### PR TITLE
Telemetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,11 @@ jobs:
 
       - name: Run tests
         run: task test
+        env:
+          TELEMETRY_ENABLED: true
+          TELEMETRY_API_KEY: ${{ secrets.TELEMETRY_API_KEY }}
+          TELEMETRY_ENDPOINT: ${{ secrets.TELEMETRY_ENDPOINT }}
+          TELEMETRY_HEADER: ${{ secrets.TELEMETRY_HEADER }}
 
   license-check:
     runs-on: ubuntu-latest
@@ -87,3 +92,8 @@ jobs:
 
       - name: Build
         run: task build
+        env:
+          TELEMETRY_ENABLED: true
+          TELEMETRY_API_KEY: ${{ secrets.TELEMETRY_API_KEY }}
+          TELEMETRY_ENDPOINT: ${{ secrets.TELEMETRY_ENDPOINT }}
+          TELEMETRY_HEADER: ${{ secrets.TELEMETRY_HEADER }}

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Many examples can be found [here](/examples/README.md)!
 
 [Prebuilt binaries](https://github.com/docker/cagent/releases) for Windows, macOS and Linux can be found on the releases page of the [project's GitHub repository](https://github.com/docker/cagent/releases)
 
-Once you've downloaded the appropriate binary for your platform, you may need to give it executable permissions.  
+Once you've downloaded the appropriate binary for your platform, you may need to give it executable permissions.
 On macOS and Linux, this is done with the following command:
 
 ```sh
@@ -78,7 +78,7 @@ export ANTHROPIC_API_KEY=your_api_key_here
 export GOOGLE_API_KEY=your_api_key_here
 ```
 
-###  Run Agents!
+### Run Agents!
 
 ```bash
 # Run an agent!
@@ -188,11 +188,13 @@ cagent pull agentcatalog/pirate
 
 `cagent run agentcatalog_pirate.yaml` will run your newly pulled agent
 
-
 ## Usage
 
 More details on the usage and configuration of `cagent` can be found in [USAGE.md](/docs/USAGE.md)
 
+## Telemetry
+
+We track anonymous usage data to improve the tool. See [TELEMETRY.md](/docs/TELEMETRY.md) for details.
 
 ## Contributing
 

--- a/cmd/root/api.go
+++ b/cmd/root/api.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/docker/cagent/internal/telemetry"
 	latest "github.com/docker/cagent/pkg/config/v1"
 	"github.com/docker/cagent/pkg/server"
 	"github.com/docker/cagent/pkg/session"
@@ -28,6 +29,7 @@ func NewApiCmd() *cobra.Command {
 		Long:  `Start the API server that exposes the agent via an HTTP API`,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			telemetry.TrackCommand("api", args)
 			return runHttp(cmd, false, args)
 		},
 	}

--- a/cmd/root/catalog.go
+++ b/cmd/root/catalog.go
@@ -10,6 +10,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/docker/cagent/internal/telemetry"
 	"github.com/spf13/cobra"
 )
 
@@ -34,6 +35,10 @@ func newCatalogListCmd() *cobra.Command {
 		Short: "List catalog entries",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Track catalog list with "list" as the first argument for telemetry
+			telemetryArgs := append([]string{"list"}, args...)
+			telemetry.TrackCommand("catalog", telemetryArgs)
+
 			var org string
 			if len(args) == 0 {
 				org = "agentcatalog"

--- a/cmd/root/eval.go
+++ b/cmd/root/eval.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/docker/cagent/internal/telemetry"
 	"github.com/docker/cagent/pkg/evaluation"
 	"github.com/docker/cagent/pkg/teamloader"
 )
@@ -23,6 +24,8 @@ func NewEvalCmd() *cobra.Command {
 }
 
 func runEvalCommand(cmd *cobra.Command, args []string) error {
+	telemetry.TrackCommand("eval", args)
+
 	agents, err := teamloader.Load(cmd.Context(), args[0], runConfig)
 	if err != nil {
 		return err

--- a/cmd/root/feedback.go
+++ b/cmd/root/feedback.go
@@ -3,6 +3,7 @@ package root
 import (
 	"fmt"
 
+	"github.com/docker/cagent/internal/telemetry"
 	"github.com/spf13/cobra"
 )
 
@@ -15,6 +16,7 @@ func NewFeedbackCmd() *cobra.Command {
 		Short: "Send feedback about cagent",
 		Long:  `Submit feedback or report issues with cagent`,
 		Run: func(cmd *cobra.Command, args []string) {
+			telemetry.TrackCommand("feedback", args)
 			fmt.Println("Feel free to give feedback:\n", FeedbackLink)
 		},
 	}

--- a/cmd/root/mcp.go
+++ b/cmd/root/mcp.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/docker/cagent/internal/telemetry"
 	"github.com/docker/cagent/pkg/mcpserver"
 	"github.com/docker/cagent/pkg/servicecore"
 	"github.com/spf13/cobra"
@@ -42,7 +43,9 @@ and maintain conversational sessions.`,
 	return cmd
 }
 
-func runMCPCommand(*cobra.Command, []string) error {
+func runMCPCommand(_ *cobra.Command, args []string) error {
+	telemetry.TrackCommand("mcp", args)
+
 	// Default agents directory to current working directory if not specified
 	resolvedAgentsDir := agentsDir
 	if resolvedAgentsDir == "" {

--- a/cmd/root/new.go
+++ b/cmd/root/new.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/docker/cagent/internal/creator"
+	"github.com/docker/cagent/internal/telemetry"
 	"github.com/docker/cagent/pkg/runtime"
 )
 
@@ -21,6 +22,8 @@ func NewNewCmd() *cobra.Command {
 		Short: "Create a new agent configuration",
 		Long:  `Create a new agent configuration by asking questions and generating a YAML file`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			telemetry.TrackCommand("new", args)
+
 			ctx := cmd.Context()
 
 			var model string         // final model name

--- a/cmd/root/pull.go
+++ b/cmd/root/pull.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/docker/cagent/internal/telemetry"
 	"github.com/docker/cagent/pkg/remote"
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/spf13/cobra"
@@ -19,6 +20,7 @@ func NewPullCmd() *cobra.Command {
 		Long:  `Pull an artifact from Docker Hub`,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			telemetry.TrackCommand("pull", args)
 			return runPullCommand(args[0])
 		},
 	}

--- a/cmd/root/push.go
+++ b/cmd/root/push.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/docker/cagent/internal/telemetry"
 	"github.com/docker/cagent/pkg/content"
 	"github.com/docker/cagent/pkg/oci"
 	"github.com/docker/cagent/pkg/remote"
@@ -21,6 +22,7 @@ The local identifier can be either a reference (tag) or a digest that was return
 from the build command.`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			telemetry.TrackCommand("push", args)
 			return runPushCommand(args[0], args[1])
 		},
 	}

--- a/cmd/root/readme.go
+++ b/cmd/root/readme.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/docker/cagent/internal/telemetry"
 	"github.com/docker/cagent/pkg/config"
 	"github.com/spf13/cobra"
 )
@@ -21,6 +22,8 @@ func NewReadmeCmd() *cobra.Command {
 }
 
 func readmeAgentCommand(_ *cobra.Command, args []string) error {
+	telemetry.TrackCommand("readme", args)
+
 	agentFilename := args[0]
 
 	// Get current working directory as the base directory for security validation

--- a/cmd/root/version.go
+++ b/cmd/root/version.go
@@ -3,6 +3,7 @@ package root
 import (
 	"fmt"
 
+	"github.com/docker/cagent/internal/telemetry"
 	"github.com/spf13/cobra"
 )
 
@@ -20,6 +21,9 @@ func NewVersionCmd() *cobra.Command {
 		Short: "Print the version information",
 		Long:  `Display the version, build time, and commit hash`,
 		Run: func(cmd *cobra.Command, args []string) {
+			// Track the version command
+			telemetry.TrackCommand("version", args)
+
 			fmt.Printf("cagent version %s\n", Version)
 			fmt.Printf("Build time: %s\n", BuildTime)
 			fmt.Printf("Commit: %s\n", Commit)

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -1,0 +1,82 @@
+# Telemetry for cagent
+
+The telemetry system in `cagent` collects **anonymous usage data** to help improve the tool. All events are processed **asynchronously** in the background and never block command execution. Telemetry can be disabled at any time.
+
+On first startup, `cagent` displays a notice about telemetry collection and how to disable it, so users are always informed.
+
+---
+
+## Quick Start
+
+### Disable telemetry
+
+```bash
+# Environment variable
+TELEMETRY_ENABLED=false cagent run agent.yaml
+
+# The application defaults to enabled when no environment variable is set
+```
+
+### Enable debug mode (see events locally)
+
+```bash
+# Use the --debug flag to see telemetry events printed locally
+cagent run agent.yaml --debug
+```
+
+---
+
+## What's Collected ✅
+
+- Command names and success/failure status
+- Agent names and model types
+- Tool names and whether calls succeed or fail
+- Token counts (input/output totals) and estimated costs
+- Session metadata (durations, error counts)
+
+## What's NOT Collected ❌
+
+- User input or prompts
+- Agent responses or generated content
+- File contents
+- API keys or credentials
+- Personally identifying information
+
+---
+
+## For Developers
+
+Telemetry is automatically wrapped around all commands. If you need to record additional events, use the context-based approach:
+
+```go
+// Recommended: Use context-based telemetry (clean, testable)
+if telemetryClient := telemetry.FromContext(ctx); telemetryClient != nil {
+    telemetryClient.RecordToolCall(ctx, "filesystem", "session-id", "agentName", time.Millisecond*500, nil)
+    telemetryClient.RecordTokenUsage(ctx, "gpt-4", 100, 50, 0.01)
+}
+
+// Or use direct telemetry calls:
+telemetry.TrackCommand("run", args)
+```
+
+### Event Types
+
+The system uses structured, type-safe events:
+
+- **Command events**: Track CLI command execution with success status
+- **Tool events**: Track agent tool calls with timing and error information
+- **Token events**: Track LLM token usage by model, session, and cost
+- **Session events**: Track agent session lifecycle with separate start/end events and aggregate metrics
+
+Events are queued in a buffered channel (1000 events) and processed asynchronously by a background goroutine. Use `client.Shutdown(ctx)` at program exit to flush remaining events.
+
+### Configuration
+
+The system respects these environment variables:
+
+- `TELEMETRY_ENABLED=false` - Disable telemetry collection (default: enabled)
+- `TELEMETRY_ENDPOINT=<url>` - Remote telemetry endpoint (optional)
+- `TELEMETRY_API_KEY=<key>` - API key for remote telemetry (optional)
+- `TELEMETRY_HEADER=<header>` - Authorization header for remote telemetry (optional)
+
+The `--debug` flag enables local event logging without affecting HTTP transmission.

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -1,0 +1,17 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// GetConfigDir returns the user's config directory for cagent
+// Falls back to temp directory if home directory cannot be determined
+func GetConfigDir() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		// Fallback to temp directory
+		return filepath.Join(os.TempDir(), ".cagent-config")
+	}
+	return filepath.Join(homeDir, ".config", "cagent")
+}

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -1,0 +1,148 @@
+package telemetry
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync/atomic"
+	"time"
+)
+
+// NewClient creates a new simplified telemetry client with explicit debug control
+func NewClient(logger *slog.Logger, enabled, debugMode bool, version string) (*Client, error) {
+	return NewClientWithHTTPClient(logger, enabled, debugMode, version, &http.Client{Timeout: 30 * time.Second})
+}
+
+// NewClientWithHTTPClient creates a new telemetry client with a custom HTTP client (useful for testing)
+func NewClientWithHTTPClient(logger *slog.Logger, enabled, debugMode bool, version string, httpClient HTTPClient) (*Client, error) {
+	// Debug mode only affects output destination, not whether telemetry is enabled
+	// Respect the user's enabled setting
+
+	if !enabled {
+		return &Client{
+			logger:  logger,
+			enabled: false,
+			version: version,
+		}, nil
+	}
+
+	endpoint := getTelemetryEndpoint()
+	apiKey := getTelemetryAPIKey()
+	header := getTelemetryHeader()
+
+	client := &Client{
+		logger:     logger,
+		enabled:    enabled,
+		debugMode:  debugMode,
+		httpClient: httpClient,
+		endpoint:   endpoint,
+		apiKey:     apiKey,
+		header:     header,
+		version:    version,
+		eventChan:  make(chan EventWithContext, 1000), // Buffer for 1000 events
+		stopChan:   make(chan struct{}),
+		done:       make(chan struct{}),
+	}
+
+	if debugMode {
+		hasEndpoint := endpoint != ""
+		hasAPIKey := apiKey != ""
+		hasHeader := header != ""
+		logger.Debug("Telemetry configuration",
+			"enabled", enabled,
+			"has_endpoint", hasEndpoint,
+			"has_api_key", hasAPIKey,
+			"has_header", hasHeader,
+			"http_enabled", hasEndpoint && hasAPIKey && hasHeader,
+		)
+	}
+
+	// Start background event processor
+	go client.processEvents()
+
+	return client, nil
+}
+
+// IsEnabled returns whether telemetry is enabled
+func (tc *Client) IsEnabled() bool {
+	tc.mu.RLock()
+	defer tc.mu.RUnlock()
+	return tc.enabled
+}
+
+// Shutdown gracefully shuts down the telemetry client
+func (tc *Client) Shutdown(ctx context.Context) error {
+	tc.RecordSessionEnd(ctx)
+
+	if !tc.enabled {
+		return nil
+	}
+
+	// Signal shutdown to background goroutine
+	close(tc.stopChan)
+
+	// Wait for background processing to complete with timeout
+	select {
+	case <-tc.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(5 * time.Second):
+		return fmt.Errorf("timeout waiting for telemetry shutdown")
+	}
+}
+
+// processEvents runs in a background goroutine to process telemetry events
+func (tc *Client) processEvents() {
+	defer close(tc.done)
+
+	if tc.debugMode {
+		tc.logger.Debug("🔄 Background event processor started")
+	}
+
+	for {
+		select {
+		case event := <-tc.eventChan:
+			if tc.debugMode {
+				tc.logger.Debug("🔄 Processing event from channel", "event_type", event.eventName)
+			}
+			tc.processEvent(event)
+		case <-tc.stopChan:
+			if tc.debugMode {
+				tc.logger.Debug("🛑 Background processor received stop signal")
+			}
+			// Drain remaining events before shutting down
+			for {
+				select {
+				case event := <-tc.eventChan:
+					if tc.debugMode {
+						tc.logger.Debug("🔄 Draining event during shutdown", "event_type", event.eventName)
+					}
+					tc.processEvent(event)
+				default:
+					if tc.debugMode {
+						tc.logger.Debug("🛑 Background processor shutting down")
+					}
+					return
+				}
+			}
+		}
+	}
+}
+
+// processEvent handles individual events in the background goroutine
+func (tc *Client) processEvent(eventCtx EventWithContext) {
+	// Track that we're processing this event
+	atomic.AddInt64(&tc.requestCount, 1)
+	defer atomic.AddInt64(&tc.requestCount, -1)
+
+	event := tc.createEvent(eventCtx.eventName, eventCtx.properties)
+
+	if tc.debugMode {
+		tc.printEvent(&event)
+	}
+
+	// Always send the event (regardless of debug mode)
+	tc.sendEvent(&event)
+}

--- a/internal/telemetry/context.go
+++ b/internal/telemetry/context.go
@@ -1,0 +1,25 @@
+package telemetry
+
+import (
+	"context"
+)
+
+// contextKey is a type for context keys to avoid collisions
+type contextKey string
+
+const (
+	clientContextKey contextKey = "telemetry_client"
+)
+
+// WithClient adds a telemetry client to the context
+func WithClient(ctx context.Context, client *Client) context.Context {
+	return context.WithValue(ctx, clientContextKey, client)
+}
+
+// FromContext retrieves the telemetry client from context
+func FromContext(ctx context.Context) *Client {
+	if client, ok := ctx.Value(clientContextKey).(*Client); ok {
+		return client
+	}
+	return nil
+}

--- a/internal/telemetry/events.go
+++ b/internal/telemetry/events.go
@@ -1,0 +1,177 @@
+package telemetry
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// Track records a structured telemetry event with type-safe properties (non-blocking)
+// This is the only method for telemetry tracking, all event-specific methods are wrappers around this one
+func (tc *Client) Track(ctx context.Context, structuredEvent StructuredEvent) {
+	eventType := structuredEvent.GetEventType()
+	structuredProps := structuredEvent.ToStructuredProperties()
+
+	// Convert structured properties to map using JSON marshaling
+	// This automatically handles all fields and respects json tags (including omitempty)
+	properties, err := structToMap(structuredProps)
+	if err != nil {
+		tc.logger.Error("Failed to convert structured properties to map", "error", err, "event_type", eventType)
+		return
+	}
+
+	// Send event to background processor (non-blocking)
+	if !tc.enabled {
+		return
+	}
+
+	// Debug logging to track event flow
+	if tc.debugMode {
+		tc.logger.Debug("📤 Queuing telemetry event", "event_type", eventType, "channel_length", len(tc.eventChan))
+	}
+
+	select {
+	case tc.eventChan <- EventWithContext{
+		eventName:  string(eventType),
+		properties: properties,
+	}:
+		// Event queued successfully
+		if tc.debugMode {
+			tc.logger.Debug("✅ Event queued successfully", "event_type", eventType, "channel_length", len(tc.eventChan))
+		}
+	default:
+		// Channel full - drop event to avoid blocking
+		if tc.debugMode {
+			fmt.Printf("⚠️  Telemetry event dropped (buffer full): %s\n", eventType)
+		}
+		// Log dropped event for visibility
+		tc.logger.Warn("Telemetry event dropped", "reason", "buffer_full", "event_name", eventType)
+	}
+}
+
+// RecordSessionStart initializes session tracking
+func (tc *Client) RecordSessionStart(ctx context.Context, agentName, sessionID string) string {
+	tc.mu.Lock()
+	tc.session = SessionState{
+		ID:           sessionID,
+		AgentName:    agentName,
+		StartTime:    time.Now(),
+		ToolCalls:    0,
+		TokenUsage:   SessionTokenUsage{},
+		ErrorCount:   0,
+		Error:        []string{},
+		SessionEnded: false,
+	}
+	tc.mu.Unlock()
+
+	if tc.enabled {
+		sessionEvent := &SessionStartEvent{
+			Action:    "start",
+			SessionID: sessionID,
+			AgentName: agentName,
+		}
+		tc.Track(ctx, sessionEvent)
+	}
+
+	return sessionID
+}
+
+// RecordError records a general session error
+func (tc *Client) RecordError(ctx context.Context, errorMsg string) {
+	tc.mu.Lock()
+
+	if tc.session.SessionEnded || tc.session.AgentName == "" || tc.session.ID == "" {
+		tc.mu.Unlock()
+		return
+	}
+
+	tc.session.ErrorCount++
+	tc.session.Error = append(tc.session.Error, errorMsg)
+
+	tc.mu.Unlock()
+}
+
+// RecordSessionEnd finalizes session tracking
+func (tc *Client) RecordSessionEnd(ctx context.Context) {
+	tc.mu.Lock()
+
+	if tc.session.SessionEnded || tc.session.AgentName == "" || tc.session.ID == "" {
+		tc.mu.Unlock()
+		return
+	}
+
+	tc.session.SessionEnded = true
+
+	// Capture session data while holding the lock
+	sessionEvent := &SessionEndEvent{
+		Action:       "end",
+		SessionID:    tc.session.ID,
+		AgentName:    tc.session.AgentName,
+		Duration:     time.Since(tc.session.StartTime).Milliseconds(),
+		ToolCalls:    tc.session.ToolCalls,
+		InputTokens:  tc.session.TokenUsage.InputTokens,
+		OutputTokens: tc.session.TokenUsage.OutputTokens,
+		TotalTokens:  tc.session.TokenUsage.InputTokens + tc.session.TokenUsage.OutputTokens,
+		IsSuccess:    tc.session.ErrorCount == 0,
+		Error:        tc.session.Error,
+	}
+
+	tc.mu.Unlock()
+
+	if tc.enabled {
+		tc.Track(ctx, sessionEvent)
+	}
+}
+
+// RecordToolCall records a tool call event
+func (tc *Client) RecordToolCall(ctx context.Context, toolName, sessionID, agentName string, duration time.Duration, err error) {
+	tc.mu.Lock()
+	tc.session.ToolCalls++
+	if err != nil {
+		tc.session.ErrorCount++
+	}
+	tc.mu.Unlock()
+
+	if tc.enabled {
+		errorMsg := ""
+		if err != nil {
+			errorMsg = err.Error()
+		}
+
+		toolEvent := &ToolEvent{
+			Action:    "call",
+			ToolName:  toolName,
+			SessionID: sessionID,
+			AgentName: agentName,
+			Duration:  duration.Milliseconds(),
+			Success:   err == nil,
+			Error:     errorMsg,
+		}
+		tc.Track(ctx, toolEvent)
+	}
+}
+
+// RecordTokenUsage records token usage metrics
+func (tc *Client) RecordTokenUsage(ctx context.Context, model string, inputTokens, outputTokens int64, cost float64) {
+	tc.mu.Lock()
+	tc.session.TokenUsage.InputTokens += inputTokens
+	tc.session.TokenUsage.OutputTokens += outputTokens
+	tc.session.TokenUsage.Cost += cost
+
+	tokenEvent := &TokenEvent{
+		Action:       "usage",
+		ModelName:    model,
+		SessionID:    tc.session.ID,
+		AgentName:    tc.session.AgentName,
+		InputTokens:  inputTokens,
+		OutputTokens: outputTokens,
+		TotalTokens:  inputTokens + outputTokens,
+		Cost:         cost,
+	}
+
+	tc.mu.Unlock()
+
+	if tc.enabled {
+		tc.Track(ctx, tokenEvent)
+	}
+}

--- a/internal/telemetry/global.go
+++ b/internal/telemetry/global.go
@@ -1,0 +1,105 @@
+package telemetry
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"sync"
+)
+
+// TrackCommand records a command event using automatic telemetry initialization
+func TrackCommand(action string, args []string) {
+	// Automatically initialize telemetry if not already done
+	ensureGlobalTelemetryInitialized()
+
+	if globalToolTelemetryClient != nil {
+		ctx := context.Background()
+		commandEvent := CommandEvent{
+			Action:  action,
+			Args:    args,
+			Success: true, // We're tracking user intent, not outcome
+		}
+		globalToolTelemetryClient.Track(ctx, &commandEvent)
+	}
+}
+
+// Global variables for simple tool telemetry
+var (
+	globalToolTelemetryClient *Client
+	globalTelemetryOnce       sync.Once
+	globalTelemetryVersion    = "unknown"
+	globalTelemetryDebugMode  = false
+)
+
+// SetGlobalToolTelemetryClient sets the global client for tool telemetry
+// This allows other packages to record tool events without context passing
+// This is now optional - if not called, automatic initialization will happen
+func SetGlobalToolTelemetryClient(client *Client, logger *slog.Logger) {
+	globalToolTelemetryClient = client
+	// Logger is now handled internally by automatic initialization
+}
+
+// GetGlobalTelemetryClient returns the global telemetry client for adding to context
+func GetGlobalTelemetryClient() *Client {
+	ensureGlobalTelemetryInitialized()
+	return globalToolTelemetryClient
+}
+
+// SetGlobalTelemetryVersion sets the version for automatic telemetry initialization
+// This should be called by the root package to provide the correct version
+func SetGlobalTelemetryVersion(version string) {
+	// If telemetry is already initialized, update the version
+	if globalToolTelemetryClient != nil {
+		globalToolTelemetryClient.version = version
+	}
+	// Store the version for future automatic initialization
+	globalTelemetryVersion = version
+}
+
+// SetGlobalTelemetryDebugMode sets the debug mode for automatic telemetry initialization
+// This should be called by the root package to pass the --debug flag state
+func SetGlobalTelemetryDebugMode(debug bool) {
+	globalTelemetryDebugMode = debug
+}
+
+// ensureGlobalTelemetryInitialized ensures telemetry is initialized exactly once
+// This handles all the setup automatically - no explicit initialization needed
+func ensureGlobalTelemetryInitialized() {
+	globalTelemetryOnce.Do(func() {
+		// Use the debug mode set by the root package via --debug flag
+		debugMode := globalTelemetryDebugMode
+
+		// Create logger with appropriate level based on debug mode
+		logLevel := slog.LevelInfo
+		if debugMode {
+			logLevel = slog.LevelDebug
+		}
+		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+			Level: logLevel,
+		}))
+
+		// Get telemetry enabled setting
+		enabled := GetTelemetryEnabled()
+
+		// Use the version set by SetGlobalTelemetryVersion or default
+		version := globalTelemetryVersion
+
+		// Try to initialize telemetry
+		client, err := NewClient(logger, enabled, debugMode, version)
+		if err != nil {
+			// If initialization fails, create a disabled client
+			client, _ = NewClient(logger, false, debugMode, version)
+		}
+
+		globalToolTelemetryClient = client
+
+		if debugMode {
+			logger.Info("Auto-initialized telemetry", "enabled", enabled, "debug", debugMode)
+		}
+	})
+}
+
+// EnsureGlobalTelemetryInitialized makes the private initialization function public
+func EnsureGlobalTelemetryInitialized() {
+	ensureGlobalTelemetryInitialized()
+}

--- a/internal/telemetry/http.go
+++ b/internal/telemetry/http.go
@@ -1,0 +1,165 @@
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// createEvent creates an EventPayload struct from eventType and properties
+func (tc *Client) createEvent(eventName string, properties map[string]interface{}) EventPayload {
+	osInfo, _, osLanguage := getSystemInfo()
+
+	// Create a new properties map that includes both user properties and system metadata
+	allProperties := make(map[string]interface{})
+
+	// Copy user-provided properties first
+	for k, v := range properties {
+		allProperties[k] = v
+	}
+
+	// Add system metadata to properties
+	allProperties["user_uuid"] = userUUID
+	allProperties["version"] = tc.version
+	allProperties["os"] = osInfo
+	allProperties["os_language"] = osLanguage
+
+	event := EventPayload{
+		Event:          EventType(eventName),
+		EventTimestamp: time.Now().UnixMilli(),
+		Source:         "cagent",
+		Properties:     allProperties,
+	}
+
+	return event
+}
+
+// printEvent prints event in debug mode
+func (tc *Client) printEvent(event *EventPayload) {
+	output, err := json.MarshalIndent(event, "", "  ")
+	if err != nil {
+		tc.logger.Error("Failed to marshal telemetry event", "error", err)
+		return
+	}
+	tc.logger.Info("🔍 TELEMETRY EVENT", "event", string(output))
+}
+
+// sendEvent sends a single event to Docker events API and handles logging
+func (tc *Client) sendEvent(event *EventPayload) {
+	// Send to Docker events API if conditions are met
+	if tc.apiKey != "" && tc.endpoint != "" && tc.enabled {
+		tc.logger.Debug("Sending telemetry event via HTTP", "event", event.Event, "endpoint", tc.endpoint)
+
+		// Perform HTTP request inline
+		if err := tc.performHTTPRequest(event); err != nil {
+			tc.logger.Debug("Failed to send telemetry event to Docker API", "error", err, "event", event.Event)
+		} else {
+			tc.logger.Debug("Successfully sent telemetry event via HTTP", "event", event.Event)
+		}
+	} else {
+		tc.logger.Debug("Skipping HTTP telemetry event - missing endpoint or API key or disabled",
+			"event", event.Event,
+			"has_endpoint", tc.endpoint != "",
+			"has_api_key", tc.apiKey != "",
+			"enabled", tc.enabled)
+	}
+
+	// Event processing (OpenTelemetry tracing handled in run.go)
+
+	// Log the event
+	logArgs := []interface{}{
+		"event", event.Event,
+		"event_timestamp", event.EventTimestamp,
+		"source", event.Source,
+	}
+
+	// Add key properties to log
+	if userUUID, ok := event.Properties["user_uuid"].(string); ok {
+		logArgs = append(logArgs, "user_uuid", userUUID)
+	}
+	if sessionID, ok := event.Properties["session_id"].(string); ok {
+		logArgs = append(logArgs, "session_id", sessionID)
+	}
+
+	tc.logger.Debug("Telemetry event recorded", logArgs...)
+
+	// Enhanced debug logging with full event structure
+	if tc.logger.Enabled(context.Background(), slog.LevelDebug) {
+		if jsonData, err := json.Marshal(event); err == nil {
+			tc.logger.Debug("Full telemetry event JSON", "json", string(jsonData))
+		}
+	}
+}
+
+// performHTTPRequest handles the actual HTTP request to the telemetry API
+func (tc *Client) performHTTPRequest(event *EventPayload) error {
+	// Wrap event in records array to match MarlinRequest format
+	requestBody := map[string]interface{}{
+		"records": []interface{}{event},
+	}
+
+	// Serialize request to JSON
+	jsonData, err := json.Marshal(requestBody)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request to JSON: %w", err)
+	}
+
+	// Create HTTP request
+	req, err := http.NewRequest(http.MethodPost, tc.endpoint, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+
+	// Set headers
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", fmt.Sprintf("cagent/%s", tc.version))
+	if tc.apiKey != "" && tc.header != "" {
+		req.Header.Set(tc.header, tc.apiKey)
+	}
+
+	// Debug: log request details
+	tc.logger.Debug("HTTP request details",
+		"method", req.Method,
+		"url", req.URL.String(),
+		"content_type", req.Header.Get("Content-Type"),
+		"user_agent", req.Header.Get("User-Agent"),
+		"has_header", req.Header.Get(tc.header) != "",
+		"header_length", len(req.Header.Get(tc.header)),
+		"payload_size", len(jsonData),
+		"payload", string(jsonData),
+	)
+
+	// Send request with timeout context
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	req = req.WithContext(ctx)
+
+	resp, err := tc.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("HTTP request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Check response status
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body := make([]byte, 1024) // Read up to 1KB of error response
+		n, _ := resp.Body.Read(body)
+
+		// Enhanced error logging with response details
+		tc.logger.Debug("HTTP error response details",
+			"status_code", resp.StatusCode,
+			"status_text", resp.Status,
+			"content_type", resp.Header.Get("Content-Type"),
+			"content_length", resp.Header.Get("Content-Length"),
+			"response_body", string(body[:n]),
+		)
+
+		return fmt.Errorf("HTTP request failed with status %d: %s", resp.StatusCode, string(body[:n]))
+	}
+
+	return nil
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -1,0 +1,28 @@
+// Package telemetry provides anonymous usage tracking for cagent.
+//
+// This package implements a comprehensive telemetry system that collects anonymous
+// usage data to help improve the tool. All events are processed asynchronously
+// and never block command execution. Telemetry can be disabled at any time.
+//
+// The system tracks:
+// - Command names and success/failure status
+// - Agent names and model types
+// - Tool names and whether calls succeed or fail
+// - Token counts (input/output totals) and estimated costs
+// - Session metadata (durations, error counts)
+//
+// The system does NOT collect:
+// - User input or prompts
+// - Agent responses or generated content
+// - File contents or paths
+// - API keys or credentials
+// - Personally identifying information
+//
+// Files in this package:
+// - client.go: Core client functionality, lifecycle management
+// - events.go: Event tracking methods for sessions, tools, tokens
+// - http.go: HTTP request handling and event transmission
+// - global.go: Global telemetry functions and initialization
+// - utils.go: Utility functions and system information collection
+// - types.go: Event types and data structures
+package telemetry

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -1,0 +1,1080 @@
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// MockHTTPClient captures HTTP requests for testing
+type MockHTTPClient struct {
+	mu       sync.Mutex
+	requests []*http.Request
+	bodies   [][]byte
+	response *http.Response
+}
+
+// NewMockHTTPClient creates a new mock HTTP client with a default success response
+func NewMockHTTPClient() *MockHTTPClient {
+	return &MockHTTPClient{
+		response: &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(bytes.NewReader([]byte(`{"success": true}`))),
+			Header:     make(http.Header),
+		},
+	}
+}
+
+// SetResponse allows updating the mock response for testing different scenarios
+func (m *MockHTTPClient) SetResponse(resp *http.Response) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.response = resp
+}
+
+// Do implements http.Client.Do and captures the request
+func (m *MockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Capture the request
+	m.requests = append(m.requests, req)
+
+	// Read and store the body for inspection
+	if req.Body != nil {
+		body, _ := io.ReadAll(req.Body)
+		m.bodies = append(m.bodies, body)
+		// Reset body for the actual request processing
+		req.Body = io.NopCloser(bytes.NewReader(body))
+	} else {
+		m.bodies = append(m.bodies, nil)
+	}
+
+	return m.response, nil
+}
+
+// GetRequests returns all captured requests
+func (m *MockHTTPClient) GetRequests() []*http.Request {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]*http.Request{}, m.requests...)
+}
+
+// GetBodies returns all captured request bodies
+func (m *MockHTTPClient) GetBodies() [][]byte {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([][]byte{}, m.bodies...)
+}
+
+// GetRequestCount returns the number of HTTP requests made
+func (m *MockHTTPClient) GetRequestCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.requests)
+}
+
+func TestNewClient(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	// Test enabled client with mock HTTP client to capture HTTP calls
+	// Note: debug mode does NOT disable HTTP calls - it only adds extra logging
+	mockHTTP := NewMockHTTPClient()
+	client, err := NewClientWithHTTPClient(logger, true, true, "test-version", mockHTTP)
+	if err != nil {
+		t.Fatalf("Failed to create enabled client: %v", err)
+	}
+	if !client.IsEnabled() {
+		t.Error("Expected client to be enabled")
+	}
+
+	// Test disabled client
+	client, err = NewClient(logger, false, false, "test-version")
+	if err != nil {
+		t.Fatalf("Failed to create disabled client: %v", err)
+	}
+	if client.IsEnabled() {
+		t.Error("Expected client to be disabled")
+	}
+}
+
+func TestDisabledClient(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	client, err := NewClient(logger, false, false, "test-version")
+	if err != nil {
+		t.Fatalf("Failed to create disabled client: %v", err)
+	}
+
+	// This should not panic
+	commandEvent := &CommandEvent{
+		Action:  "test-command",
+		Success: true,
+		Error:   "",
+	}
+	client.Track(context.Background(), commandEvent)
+	client.RecordToolCall(context.Background(), "test-tool", "session-id", "agent-name", time.Millisecond, nil)
+	client.RecordTokenUsage(context.Background(), "test-model", 100, 50, 0.5)
+}
+
+func TestSessionTracking(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	mockHTTP := NewMockHTTPClient()
+	client, err := NewClientWithHTTPClient(logger, true, true, "test-version", mockHTTP)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	// Set endpoint, apiKey, and header to verify HTTP calls are made correctly
+	client.endpoint = "https://test-session-tracking.com/api"
+	client.apiKey = "test-session-key"
+	client.header = "test-header"
+
+	ctx := context.Background()
+
+	// Test session lifecycle
+	sessionID := client.RecordSessionStart(ctx, "test-agent", "test-session-id")
+	if sessionID == "" {
+		t.Error("Expected non-empty session ID")
+	}
+
+	// Record some activity
+	client.RecordToolCall(ctx, "test-tool", "session-id", "agent-name", time.Millisecond, nil)
+	client.RecordTokenUsage(ctx, "test-model", 100, 50, 0.5)
+
+	// End session
+	client.RecordSessionEnd(ctx)
+
+	// Multiple ends should be safe
+	client.RecordSessionEnd(ctx)
+
+	// Wait for events to be processed
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify HTTP requests were made (should have session start, tool call, token usage, session end)
+	requestCount := mockHTTP.GetRequestCount()
+	if requestCount == 0 {
+		t.Fatal("Expected HTTP requests to be made for session tracking events, but none were captured")
+	}
+
+	t.Logf("Session tracking HTTP requests captured: %d", requestCount)
+
+	// Verify request structure
+	requests := mockHTTP.GetRequests()
+	for i, req := range requests {
+		if req.Method != http.MethodPost {
+			t.Errorf("Request %d: Expected POST method, got %s", i, req.Method)
+		}
+		if req.Header.Get("test-header") != "test-session-key" {
+			t.Errorf("Request %d: Expected test-header test-session-key, got %s", i, req.Header.Get("test-header"))
+		}
+	}
+}
+
+func TestCommandTracking(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	mockHTTP := NewMockHTTPClient()
+	client, err := NewClientWithHTTPClient(logger, true, true, "test-version", mockHTTP)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	// Set endpoint, apiKey, and header to verify HTTP calls are made correctly
+	client.endpoint = "https://test-command-tracking.com/api"
+	client.apiKey = "test-command-key"
+	client.header = "test-header"
+
+	executed := false
+	cmdInfo := CommandInfo{
+		Action: "test-command",
+		Args:   []string{},
+		Flags:  []string{},
+	}
+	err = client.TrackCommand(context.Background(), cmdInfo, func(ctx context.Context) error {
+		executed = true
+		time.Sleep(10 * time.Millisecond)
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("Command execution failed: %v", err)
+	}
+	if !executed {
+		t.Error("Expected command function to be executed")
+	}
+
+	// Wait for events to be processed
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify HTTP requests were made for command tracking
+	requestCount := mockHTTP.GetRequestCount()
+	if requestCount == 0 {
+		t.Fatal("Expected HTTP requests to be made for command tracking, but none were captured")
+	}
+
+	t.Logf("Command tracking HTTP requests captured: %d", requestCount)
+
+	// Verify request structure
+	requests := mockHTTP.GetRequests()
+	for i, req := range requests {
+		if req.Header.Get("test-header") != "test-command-key" {
+			t.Errorf("Request %d: Expected test-header test-command-key, got %s", i, req.Header.Get("test-header"))
+		}
+	}
+}
+
+func TestCommandTrackingWithError(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	mockHTTP := NewMockHTTPClient()
+	client, err := NewClientWithHTTPClient(logger, true, true, "test-version", mockHTTP)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	// Set endpoint, apiKey, and header to verify HTTP calls are made correctly
+	client.endpoint = "https://test-command-error.com/api"
+	client.apiKey = "test-command-error-key"
+	client.header = "test-header"
+
+	testErr := &testError{}
+	cmdInfo := CommandInfo{
+		Action: "failing-command",
+		Args:   []string{},
+		Flags:  []string{},
+	}
+	err = client.TrackCommand(context.Background(), cmdInfo, func(ctx context.Context) error {
+		return testErr
+	})
+
+	if err != testErr {
+		t.Errorf("Expected error %v, got %v", testErr, err)
+	}
+
+	// Wait for events to be processed
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify HTTP requests were made for command tracking with error
+	requestCount := mockHTTP.GetRequestCount()
+	if requestCount == 0 {
+		t.Fatal("Expected HTTP requests to be made for command error tracking, but none were captured")
+	}
+
+	t.Logf("Command error tracking HTTP requests captured: %d", requestCount)
+}
+
+func TestStructuredEvent(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	// Use debug mode to avoid HTTP calls in tests
+	client, err := NewClient(logger, true, true, "test-version")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	event := CommandEvent{
+		Action:  "test-command",
+		Success: true,
+	}
+
+	// Should not panic
+	client.Track(context.Background(), &event)
+}
+
+func TestGetTelemetryEnabled(t *testing.T) {
+	// Save original env var
+	originalEnabled := os.Getenv("TELEMETRY_ENABLED")
+	defer func() {
+		if originalEnabled != "" {
+			os.Setenv("TELEMETRY_ENABLED", originalEnabled)
+		} else {
+			os.Unsetenv("TELEMETRY_ENABLED")
+		}
+	}()
+
+	// Test default (enabled)
+	os.Unsetenv("TELEMETRY_ENABLED")
+	if !GetTelemetryEnabled() {
+		t.Error("Expected telemetry to be enabled by default")
+	}
+
+	// Test explicitly disabled
+	os.Setenv("TELEMETRY_ENABLED", "false")
+	if GetTelemetryEnabled() {
+		t.Error("Expected telemetry to be disabled when TELEMETRY_ENABLED=false")
+	}
+
+	// Test explicitly enabled
+	os.Setenv("TELEMETRY_ENABLED", "true")
+	if !GetTelemetryEnabled() {
+		t.Error("Expected telemetry to be enabled when TELEMETRY_ENABLED=true")
+	}
+}
+
+// testError is a simple error implementation for testing
+type testError struct{}
+
+func (e *testError) Error() string {
+	return "test error"
+}
+
+// Test-only methods - these wrap command execution with telemetry for testing purposes
+
+// TrackCommand wraps command execution with telemetry (test-only method)
+func (tc *Client) TrackCommand(ctx context.Context, commandInfo CommandInfo, fn func(context.Context) error) error {
+	if !tc.enabled {
+		return fn(ctx)
+	}
+
+	// Add telemetry client to context so the wrapped function can access it
+	ctx = WithClient(ctx, tc)
+
+	// Send telemetry event immediately (optimistic approach)
+	commandEvent := CommandEvent{
+		Action:  commandInfo.Action,
+		Args:    commandInfo.Args,
+		Success: true, // Assume success - we're tracking user intent, not outcome
+	}
+
+	// Send the telemetry event immediately
+	tc.Track(ctx, &commandEvent)
+
+	// Now run the command function
+	return fn(ctx)
+}
+
+// TrackServerStart immediately sends telemetry for server startup, then runs the server function (test-only method)
+// This is for long-running commands that may never exit (api, mcp, etc.)
+func (tc *Client) TrackServerStart(ctx context.Context, commandInfo CommandInfo, fn func(context.Context) error) error {
+	if !tc.enabled {
+		return fn(ctx)
+	}
+
+	// Add telemetry client to context so the wrapped function can access it
+	ctx = WithClient(ctx, tc)
+
+	// Send startup event immediately
+	startupEvent := CommandEvent{
+		Action:  commandInfo.Action,
+		Args:    commandInfo.Args,
+		Success: true, // We assume startup succeeds if we reach this point
+	}
+
+	// Send the startup telemetry event immediately
+	tc.Track(ctx, &startupEvent)
+
+	// Now run the server function (which may run indefinitely)
+	return fn(ctx)
+}
+
+// TestAllEventTypes tests all possible telemetry events with mock HTTP client
+func TestAllEventTypes(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	// Use mock HTTP client to avoid actual HTTP calls in tests
+	mockHTTP := NewMockHTTPClient()
+	client, err := NewClientWithHTTPClient(logger, true, true, "test-version", mockHTTP)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	// Set endpoint, apiKey, and header to verify HTTP calls are made correctly
+	client.endpoint = "https://test-telemetry-all-events.com/api"
+	client.apiKey = "test-all-events-key"
+	client.header = "test-header"
+
+	ctx := context.Background()
+	sessionID := "test-session-123"
+	agentName := "test-agent"
+
+	// Start session to enable session-based events
+	client.RecordSessionStart(ctx, agentName, sessionID)
+
+	t.Run("CommandEvents", func(t *testing.T) {
+		// Test all major command events based on cmd/ files
+		commands := []struct {
+			action string
+			args   []string
+		}{
+			{"run", []string{"config.yaml"}},
+			{"api", []string{}},
+			{"mcp", []string{}},
+			{"tui", []string{"config.yaml"}},
+			{"pull", []string{"user/agent:latest"}},
+			{"push", []string{"user/agent:latest"}},
+			{"catalog", []string{}},
+			{"new", []string{"my-agent"}},
+			{"version", []string{}},
+			{"feedback", []string{}},
+			{"eval", []string{"expression"}},
+			{"readme", []string{}},
+			{"gateway", []string{}},
+			{"debug", []string{}},
+		}
+
+		for _, cmd := range commands {
+			t.Run(cmd.action, func(t *testing.T) {
+				// Test successful command
+				event := &CommandEvent{
+					Action:  cmd.action,
+					Args:    cmd.args,
+					Success: true,
+				}
+				client.Track(ctx, event)
+
+				// Test command with error
+				errorEvent := &CommandEvent{
+					Action:  cmd.action,
+					Args:    cmd.args,
+					Success: false,
+					Error:   "test error",
+				}
+				client.Track(ctx, errorEvent)
+			})
+		}
+	})
+
+	t.Run("SessionEvents", func(t *testing.T) {
+		// Test session start event
+		startEvent := &SessionStartEvent{
+			Action:    "start",
+			SessionID: sessionID,
+			AgentName: agentName,
+		}
+		client.Track(ctx, startEvent)
+
+		// Test session end event
+		endEvent := &SessionEndEvent{
+			Action:       "end",
+			SessionID:    sessionID,
+			AgentName:    agentName,
+			Duration:     1000, // 1 second
+			ToolCalls:    5,
+			InputTokens:  100,
+			OutputTokens: 200,
+			TotalTokens:  300,
+			IsSuccess:    true,
+			Error:        []string{},
+		}
+		client.Track(ctx, endEvent)
+
+		// Test session with errors
+		errorSessionEvent := &SessionEndEvent{
+			Action:       "end",
+			SessionID:    sessionID + "-error",
+			AgentName:    agentName,
+			Duration:     500,
+			ToolCalls:    3,
+			InputTokens:  50,
+			OutputTokens: 25,
+			TotalTokens:  75,
+			IsSuccess:    false,
+			Error:        []string{"session failed"},
+		}
+		client.Track(ctx, errorSessionEvent)
+	})
+
+	t.Run("ToolEvents", func(t *testing.T) {
+		// Test various tool events based on the tool system
+		tools := []struct {
+			name     string
+			success  bool
+			duration int64
+			error    string
+		}{
+			{"think", true, 100, ""},
+			{"todo", true, 50, ""},
+			{"memory", true, 200, ""},
+			{"transfer_task", true, 150, ""},
+			{"filesystem", true, 75, ""},
+			{"shell", true, 300, ""},
+			{"mcp_tool", false, 500, "tool execution failed"},
+			{"custom_tool", true, 125, ""},
+		}
+
+		for _, tool := range tools {
+			t.Run(tool.name, func(t *testing.T) {
+				event := &ToolEvent{
+					Action:    "call",
+					ToolName:  tool.name,
+					SessionID: sessionID,
+					AgentName: agentName,
+					Duration:  tool.duration,
+					Success:   tool.success,
+					Error:     tool.error,
+				}
+				client.Track(ctx, event)
+
+				// Also test RecordToolCall method
+				var err error
+				if tool.error != "" {
+					err = &testError{}
+				}
+				client.RecordToolCall(ctx, tool.name, sessionID, agentName, time.Duration(tool.duration)*time.Millisecond, err)
+			})
+		}
+	})
+
+	t.Run("TokenEvents", func(t *testing.T) {
+		// Test token events for different models
+		models := []struct {
+			name         string
+			inputTokens  int64
+			outputTokens int64
+		}{
+			{"gpt-4", 150, 75},
+			{"claude-3-sonnet", 200, 100},
+			{"gemini-pro", 100, 50},
+			{"local-model", 80, 40},
+		}
+
+		for _, model := range models {
+			t.Run(model.name, func(t *testing.T) {
+				event := &TokenEvent{
+					Action:       "usage",
+					ModelName:    model.name,
+					SessionID:    sessionID,
+					AgentName:    agentName,
+					InputTokens:  model.inputTokens,
+					OutputTokens: model.outputTokens,
+					TotalTokens:  model.inputTokens + model.outputTokens,
+					Cost:         0,
+				}
+				client.Track(ctx, event)
+
+				// Also test RecordTokenUsage method
+				client.RecordTokenUsage(ctx, model.name, model.inputTokens, model.outputTokens, 0)
+			})
+		}
+
+		// Test token event with error
+		errorTokenEvent := &TokenEvent{
+			Action:       "usage",
+			ModelName:    "failing-model",
+			SessionID:    sessionID,
+			AgentName:    agentName,
+			InputTokens:  50,
+			OutputTokens: 0,
+			TotalTokens:  50,
+			Cost:         0,
+		}
+		client.Track(ctx, errorTokenEvent)
+	})
+
+	// End session
+	client.RecordSessionEnd(ctx)
+
+	// Wait for events to be processed
+
+	// Give additional time for background processing
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify that HTTP requests were made for all events
+	requestCount := mockHTTP.GetRequestCount()
+	if requestCount == 0 {
+		t.Fatal("Expected HTTP requests to be made for telemetry events, but none were captured")
+	}
+
+	t.Logf("Total HTTP requests captured: %d", requestCount)
+
+	// Verify that all requests have correct structure
+	requests := mockHTTP.GetRequests()
+	bodies := mockHTTP.GetBodies()
+
+	if len(requests) != len(bodies) {
+		t.Fatalf("Mismatch between request count (%d) and body count (%d)", len(requests), len(bodies))
+	}
+
+	// Verify each HTTP request has correct headers and endpoint
+	for i, req := range requests {
+		// Verify method and URL
+		if req.Method != http.MethodPost {
+			t.Errorf("Request %d: Expected POST method, got %s", i, req.Method)
+		}
+		if req.URL.String() != "https://test-telemetry-all-events.com/api" {
+			t.Errorf("Request %d: Expected URL https://test-telemetry-all-events.com/api, got %s", i, req.URL.String())
+		}
+
+		// Verify headers
+		if req.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("Request %d: Expected Content-Type application/json, got %s", i, req.Header.Get("Content-Type"))
+		}
+		if req.Header.Get("User-Agent") != "cagent/test-version" {
+			t.Errorf("Request %d: Expected User-Agent cagent/test-version, got %s", i, req.Header.Get("User-Agent"))
+		}
+		if req.Header.Get("test-header") != "test-all-events-key" {
+			t.Errorf("Request %d: Expected test-header test-all-events-key, got %s", i, req.Header.Get("test-header"))
+		}
+
+		// Verify request body structure
+		var requestBody map[string]interface{}
+		if err := json.Unmarshal(bodies[i], &requestBody); err != nil {
+			t.Errorf("Request %d: Failed to unmarshal request body: %v", i, err)
+			continue
+		}
+
+		// Verify it has records array structure
+		records, ok := requestBody["records"].([]interface{})
+		if !ok {
+			t.Errorf("Request %d: Expected 'records' array in request body", i)
+			continue
+		}
+		if len(records) != 1 {
+			t.Errorf("Request %d: Expected 1 record, got %d", i, len(records))
+			continue
+		}
+
+		// Verify the event structure
+		record := records[0].(map[string]interface{})
+		if eventType, ok := record["event"].(string); !ok || eventType == "" {
+			t.Errorf("Request %d: Expected non-empty event type, got %v", i, record["event"])
+		}
+
+		// Verify properties exist
+		if _, ok := record["properties"].(map[string]interface{}); !ok {
+			t.Errorf("Request %d: Expected properties object in event", i)
+		}
+	}
+}
+
+// TestTrackServerStart tests long-running server command tracking
+func TestTrackServerStart(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	client, err := NewClient(logger, true, true, "test-version")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	executed := false
+	cmdInfo := CommandInfo{
+		Action: "mcp",
+		Args:   []string{},
+		Flags:  []string{"--port", "8080"},
+	}
+	err = client.TrackServerStart(context.Background(), cmdInfo, func(ctx context.Context) error {
+		executed = true
+		// Simulate server running briefly
+		time.Sleep(10 * time.Millisecond)
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("Server execution failed: %v", err)
+	}
+	if !executed {
+		t.Error("Expected server function to be executed")
+	}
+}
+
+// TestBuildCommandInfo tests the BuildCommandInfo function with all commands
+func TestBuildCommandInfo(t *testing.T) {
+	testCases := []struct {
+		name     string
+		command  string
+		args     []string
+		expected CommandInfo
+	}{
+		{
+			name:    "run command with config",
+			command: "run",
+			args:    []string{"config.yaml", "--debug"},
+			expected: CommandInfo{
+				Action: "run",
+				Args:   []string{"config.yaml"},
+				Flags:  []string{},
+			},
+		},
+		{
+			name:    "pull command with image",
+			command: "pull",
+			args:    []string{"user/agent:latest"},
+			expected: CommandInfo{
+				Action: "pull",
+				Args:   []string{"user/agent:latest"},
+				Flags:  []string{},
+			},
+		},
+		{
+			name:    "catalog command",
+			command: "catalog",
+			args:    []string{},
+			expected: CommandInfo{
+				Action: "catalog",
+				Args:   []string{},
+				Flags:  []string{},
+			},
+		},
+		{
+			name:    "version command",
+			command: "version",
+			args:    []string{},
+			expected: CommandInfo{
+				Action: "version",
+				Args:   []string{},
+				Flags:  []string{},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: tc.command}
+			result := BuildCommandInfo(cmd, tc.args, tc.command)
+
+			if result.Action != tc.expected.Action {
+				t.Errorf("Expected Action %s, got %s", tc.expected.Action, result.Action)
+			}
+
+			if len(result.Args) != len(tc.expected.Args) {
+				t.Errorf("Expected %d args, got %d", len(tc.expected.Args), len(result.Args))
+			} else {
+				for i, arg := range tc.expected.Args {
+					if i < len(result.Args) && result.Args[i] != arg {
+						t.Errorf("Expected arg[%d] %s, got %s", i, arg, result.Args[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestGlobalTelemetryFunctions tests the global telemetry convenience functions
+func TestGlobalTelemetryFunctions(t *testing.T) {
+	// Save original global state
+	originalClient := globalToolTelemetryClient
+	originalOnce := globalTelemetryOnce
+	originalVersion := globalTelemetryVersion
+	originalDebugMode := globalTelemetryDebugMode
+	defer func() {
+		globalToolTelemetryClient = originalClient
+		globalTelemetryOnce = originalOnce
+		globalTelemetryVersion = originalVersion
+		globalTelemetryDebugMode = originalDebugMode
+	}()
+
+	// Reset global state for testing
+	globalToolTelemetryClient = nil
+	globalTelemetryOnce = sync.Once{}
+	SetGlobalTelemetryVersion("test-version")
+	SetGlobalTelemetryDebugMode(true)
+
+	// Test global command recording
+	TrackCommand("test-command", []string{"arg1"})
+
+	// Verify global client was initialized
+	if globalToolTelemetryClient == nil {
+		t.Error("Expected global telemetry client to be initialized")
+	}
+
+	// Test explicit initialization
+	EnsureGlobalTelemetryInitialized()
+	client := GetGlobalTelemetryClient()
+	if client == nil {
+		t.Error("Expected GetGlobalTelemetryClient to return non-nil client")
+	}
+}
+
+// TestHTTPRequestVerification tests that HTTP requests are made correctly when telemetry is enabled
+func TestHTTPRequestVerification(t *testing.T) {
+	// Create logger with debug level to see all debug messages
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	mockHTTP := NewMockHTTPClient()
+
+	// Create client with mock HTTP client, endpoint, and API key to trigger HTTP calls
+	client, err := NewClientWithHTTPClient(logger, true, true, "test-version", mockHTTP)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	// Set endpoint, API key, and header to ensure HTTP calls are made
+	client.endpoint = "https://test-telemetry.example.com/api/events"
+	client.apiKey = "test-api-key"
+	client.header = "test-header"
+
+	ctx := context.Background()
+
+	// Test command event HTTP request
+	t.Run("CommandEventHTTPRequest", func(t *testing.T) {
+		// Reset mock before test
+		mockHTTP = NewMockHTTPClient()
+		client.httpClient = mockHTTP
+
+		event := &CommandEvent{
+			Action:  "run",
+			Args:    []string{"config.yaml"},
+			Success: true,
+		}
+
+		// Verify the client is properly configured
+		if client.endpoint == "" {
+			t.Fatal("Client endpoint should be set for this test")
+		}
+		if client.apiKey == "" {
+			t.Fatal("Client API key should be set for this test")
+		}
+		if !client.enabled {
+			t.Fatal("Client should be enabled for this test")
+		}
+
+		t.Logf("Before Track: endpoint=%s, apiKey len=%d, enabled=%t", client.endpoint, len(client.apiKey), client.enabled)
+
+		client.Track(ctx, event)
+
+		// Give additional time for background processing (race condition fix)
+		time.Sleep(100 * time.Millisecond)
+
+		// Debug output
+		t.Logf("HTTP requests captured: %d", mockHTTP.GetRequestCount())
+
+		// Verify HTTP request was made
+		if mockHTTP.GetRequestCount() == 0 {
+			t.Fatal("Expected HTTP request to be made, but none were captured")
+		}
+
+		requests := mockHTTP.GetRequests()
+		req := requests[0]
+
+		// Verify request method and URL
+		if req.Method != http.MethodPost {
+			t.Errorf("Expected POST request, got %s", req.Method)
+		}
+		if req.URL.String() != "https://test-telemetry.example.com/api/events" {
+			t.Errorf("Expected URL https://test-telemetry.example.com/api/events, got %s", req.URL.String())
+		}
+
+		// Verify headers
+		if req.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("Expected Content-Type application/json, got %s", req.Header.Get("Content-Type"))
+		}
+		if req.Header.Get("User-Agent") != "cagent/test-version" {
+			t.Errorf("Expected User-Agent cagent/test-version, got %s", req.Header.Get("User-Agent"))
+		}
+		if req.Header.Get("test-header") != "test-api-key" {
+			t.Errorf("Expected test-header test-api-key, got %s", req.Header.Get("test-header"))
+		}
+
+		// Verify request body structure
+		bodies := mockHTTP.GetBodies()
+		if len(bodies) == 0 {
+			t.Fatal("Expected request body to be captured")
+		}
+
+		var requestBody map[string]interface{}
+		if err := json.Unmarshal(bodies[0], &requestBody); err != nil {
+			t.Fatalf("Failed to unmarshal request body: %v", err)
+		}
+
+		// Verify it has records array structure
+		records, ok := requestBody["records"].([]interface{})
+		if !ok {
+			t.Fatal("Expected 'records' array in request body")
+		}
+		if len(records) != 1 {
+			t.Fatalf("Expected 1 record, got %d", len(records))
+		}
+
+		// Verify the event structure
+		record := records[0].(map[string]interface{})
+		if record["event"] != "command" {
+			t.Errorf("Expected event type 'command', got %v", record["event"])
+		}
+
+		// Verify properties contain the command data
+		properties, ok := record["properties"].(map[string]interface{})
+		if !ok {
+			t.Fatal("Expected properties object in event")
+		}
+		if properties["action"] != "run" {
+			t.Errorf("Expected action 'run', got %v", properties["action"])
+		}
+		if properties["is_success"] != true {
+			t.Errorf("Expected is_success true, got %v", properties["is_success"])
+		}
+	})
+
+	// Test that no HTTP calls are made when endpoint/apiKey are missing
+	t.Run("NoHTTPWhenMissingCredentials", func(t *testing.T) {
+		mockHTTP2 := NewMockHTTPClient()
+		client2, err := NewClientWithHTTPClient(logger, true, true, "test-version", mockHTTP2)
+		if err != nil {
+			t.Fatalf("Failed to create client: %v", err)
+		}
+
+		// Leave endpoint and API key empty
+		client2.endpoint = ""
+		client2.apiKey = ""
+
+		event := &CommandEvent{
+			Action:  "version",
+			Success: true,
+		}
+
+		client2.Track(ctx, event)
+
+		// Verify no HTTP requests were made
+		if mockHTTP2.GetRequestCount() != 0 {
+			t.Errorf("Expected no HTTP requests when endpoint/apiKey are missing, got %d", mockHTTP2.GetRequestCount())
+		}
+	})
+
+	// Test that no HTTP calls are made when client is disabled
+	t.Run("NoHTTPWhenDisabled", func(t *testing.T) {
+		mockHTTP3 := NewMockHTTPClient()
+		client3, err := NewClientWithHTTPClient(logger, false, true, "test-version", mockHTTP3)
+		if err != nil {
+			t.Fatalf("Failed to create client: %v", err)
+		}
+
+		event := &CommandEvent{
+			Action:  "version",
+			Success: true,
+		}
+
+		client3.Track(ctx, event)
+
+		// Verify no HTTP requests were made (client disabled means Track returns early)
+		if mockHTTP3.GetRequestCount() != 0 {
+			t.Errorf("Expected no HTTP requests when client is disabled, got %d", mockHTTP3.GetRequestCount())
+		}
+	})
+}
+
+// TestShutdownFlushesEvents verifies that Shutdown drains the event queue
+func TestShutdownFlushesEvents(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	mockHTTP := NewMockHTTPClient()
+	client, err := NewClientWithHTTPClient(logger, true, true, "test-version", mockHTTP)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	client.endpoint = "https://test-shutdown.com/api"
+	client.apiKey = "shutdown-key"
+	client.header = "test-header"
+
+	ctx := context.Background()
+	client.Track(ctx, &CommandEvent{Action: "shutdown-test", Success: true})
+
+	// Shutdown should flush pending events
+	err = client.Shutdown(ctx)
+	if err != nil {
+		t.Fatalf("Shutdown failed: %v", err)
+	}
+
+	if mockHTTP.GetRequestCount() == 0 {
+		t.Error("Expected at least 1 HTTP request to be sent during Shutdown flush")
+	}
+}
+
+// SlowMockHTTPClient creates artificial backpressure by adding delays
+type SlowMockHTTPClient struct {
+	*MockHTTPClient
+	delay time.Duration
+}
+
+func NewSlowMockHTTPClient(delay time.Duration) *SlowMockHTTPClient {
+	return &SlowMockHTTPClient{
+		MockHTTPClient: NewMockHTTPClient(),
+		delay:          delay,
+	}
+}
+
+func (s *SlowMockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	time.Sleep(s.delay) // Add artificial delay
+	return s.MockHTTPClient.Do(req)
+}
+
+// TestEventBufferOverflowDropsEvents verifies that events are dropped when buffer is full
+func TestEventBufferOverflowDropsEvents(t *testing.T) {
+	// Create a slow HTTP mock to cause backpressure
+	slowMock := NewSlowMockHTTPClient(50 * time.Millisecond)
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	client, err := NewClientWithHTTPClient(logger, true, true, "test-version", slowMock)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	client.endpoint = "https://test-overflow.com/api"
+	client.apiKey = "overflow-key"
+	client.header = "test-header"
+
+	// Fill buffer completely by sending many events rapidly
+	bufferSize := cap(client.eventChan) // Use actual production buffer size (1000)
+
+	// Send events very rapidly to overwhelm the slow processor
+	for i := 0; i < bufferSize+100; i++ { // Send way more than capacity
+		client.Track(context.Background(), &CommandEvent{
+			Action:  "overflow-test",
+			Success: true,
+		})
+	}
+
+	// Give time for processing and potential overflow
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify the channel length is reasonable (either full or being processed)
+	channelLen := len(client.eventChan)
+	if channelLen > bufferSize {
+		t.Errorf("Event channel exceeded capacity: len=%d cap=%d", channelLen, bufferSize)
+	}
+
+	// The test passes if we don't exceed capacity - this verifies overflow protection works
+	t.Logf("Buffer handled overflow correctly: len=%d cap=%d", channelLen, bufferSize)
+
+	// Clean shutdown
+}
+
+// TestNon2xxHTTPResponseHandling ensures that 5xx responses are logged and handled gracefully
+func TestNon2xxHTTPResponseHandling(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	mockHTTP := NewMockHTTPClient()
+	client, err := NewClientWithHTTPClient(logger, true, true, "test-version", mockHTTP)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	client.endpoint = "https://test-error-response.com/api"
+	client.apiKey = "error-key"
+	client.header = "test-header"
+
+	// Configure mock to return 500
+	mockHTTP.SetResponse(&http.Response{
+		StatusCode: 500,
+		Status:     "500 Internal Server Error",
+		Body:       io.NopCloser(bytes.NewReader([]byte("internal error"))),
+		Header:     make(http.Header),
+	})
+
+	client.Track(context.Background(), &CommandEvent{Action: "error-test", Success: true})
+
+	// Give more time for background processing
+	time.Sleep(100 * time.Millisecond)
+
+	requestCount := mockHTTP.GetRequestCount()
+	if requestCount == 0 {
+		t.Errorf("Expected HTTP request to be made despite error response, got %d requests", requestCount)
+	}
+
+	// Test additional error codes
+	mockHTTP.SetResponse(&http.Response{
+		StatusCode: 404,
+		Status:     "404 Not Found",
+		Body:       io.NopCloser(bytes.NewReader([]byte("not found"))),
+		Header:     make(http.Header),
+	})
+
+	client.Track(context.Background(), &CommandEvent{Action: "not-found-test", Success: true})
+
+	time.Sleep(100 * time.Millisecond)
+
+	finalRequestCount := mockHTTP.GetRequestCount()
+	if finalRequestCount < 2 {
+		t.Errorf("Expected at least 2 HTTP requests (500 + 404), got %d", finalRequestCount)
+	}
+}

--- a/internal/telemetry/types.go
+++ b/internal/telemetry/types.go
@@ -1,0 +1,288 @@
+package telemetry
+
+import (
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// EVENTS BASE
+
+// StructuredEvent represents a type-safe telemetry event with structured properties
+type StructuredEvent interface {
+	GetEventType() EventType
+	ToStructuredProperties() interface{}
+}
+
+// Simplified event system - event types are now just strings in the Event.Event field
+
+// EventType represents the type of telemetry event
+type EventType string
+
+const (
+	EventTypeCommand EventType = "command"
+	EventTypeSession EventType = "session"
+	EventTypeToken   EventType = "token"
+	EventTypeTool    EventType = "tool"
+)
+
+// EventPayload represents a structured telemetry event
+type EventPayload struct {
+	Event          EventType `json:"event"`
+	EventTimestamp int64     `json:"event_timestamp"`
+	Source         string    `json:"source"`
+
+	Properties map[string]interface{} `json:"properties,omitempty"`
+}
+
+// EventWithContext wraps an event with its context for async processing
+type EventWithContext struct {
+	eventName  string
+	properties map[string]interface{}
+}
+
+// COMMAND EVENTS
+
+// CommandEvent represents command execution events
+type CommandEvent struct {
+	Action  string   `json:"action"`
+	Args    []string `json:"args,omitempty"`
+	Success bool     `json:"success"`
+	Error   string   `json:"error,omitempty"`
+}
+
+// CommandPayload represents the HTTP payload structure for command events
+type CommandPayload struct {
+	Action    string   `json:"action"`
+	Args      []string `json:"args,omitempty"`
+	IsSuccess bool     `json:"is_success"`
+	Error     string   `json:"error,omitempty"`
+}
+
+func (e *CommandEvent) GetEventType() EventType {
+	return EventTypeCommand
+}
+
+func (e *CommandEvent) ToStructuredProperties() interface{} {
+	return CommandPayload{
+		Action:    e.Action,
+		Args:      e.Args,
+		IsSuccess: e.Success,
+		Error:     e.Error,
+	}
+}
+
+// TOOL EVENTS
+
+// ToolEvent represents tool call events
+type ToolEvent struct {
+	Action    string `json:"action"`
+	ToolName  string `json:"tool_name"`
+	SessionID string `json:"session_id"`
+	AgentName string `json:"agent_name"`
+	Duration  int64  `json:"duration_ms"`
+	Success   bool   `json:"success"`
+	Error     string `json:"error,omitempty"`
+}
+
+// ToolPayload represents the HTTP payload structure for tool events
+type ToolPayload struct {
+	Action     string `json:"action"`
+	SessionID  string `json:"session_id"`
+	AgentName  string `json:"agent_name"`
+	ToolName   string `json:"tool_name"`
+	DurationMs int64  `json:"duration_ms"`
+	IsSuccess  bool   `json:"is_success"`
+	Error      string `json:"error,omitempty"`
+}
+
+func (e *ToolEvent) GetEventType() EventType {
+	return EventTypeTool
+}
+
+func (e *ToolEvent) ToStructuredProperties() interface{} {
+	return ToolPayload{
+		Action:     e.Action,
+		SessionID:  e.SessionID,
+		AgentName:  e.AgentName,
+		ToolName:   e.ToolName,
+		DurationMs: e.Duration,
+		IsSuccess:  e.Success,
+		Error:      e.Error,
+	}
+}
+
+// TOKEN EVENTS
+
+// TokenEvent represents token usage events
+type TokenEvent struct {
+	Action       string  `json:"action"`
+	ModelName    string  `json:"model_name"`
+	SessionID    string  `json:"session_id"`
+	AgentName    string  `json:"agent_name"`
+	InputTokens  int64   `json:"input_tokens"`
+	OutputTokens int64   `json:"output_tokens"`
+	TotalTokens  int64   `json:"total_tokens"`
+	Cost         float64 `json:"cost"`
+}
+
+// TokenPayload represents the HTTP payload structure for token events
+type TokenPayload struct {
+	Action       string  `json:"action"`
+	SessionID    string  `json:"session_id"`
+	AgentName    string  `json:"agent_name"`
+	ModelName    string  `json:"model_name"`
+	InputTokens  int64   `json:"input_tokens"`
+	OutputTokens int64   `json:"output_tokens"`
+	TotalTokens  int64   `json:"total_tokens"`
+	Cost         float64 `json:"cost"`
+}
+
+func (e *TokenEvent) GetEventType() EventType {
+	return EventTypeToken
+}
+
+func (e *TokenEvent) ToStructuredProperties() interface{} {
+	return TokenPayload{
+		Action:       e.Action,
+		SessionID:    e.SessionID,
+		AgentName:    e.AgentName,
+		ModelName:    e.ModelName,
+		InputTokens:  e.InputTokens,
+		OutputTokens: e.OutputTokens,
+		TotalTokens:  e.TotalTokens,
+		Cost:         e.Cost,
+	}
+}
+
+// SESSION EVENTS
+
+// SessionTokenUsage tracks token consumption
+type SessionTokenUsage struct {
+	InputTokens  int64   `json:"input_tokens"`
+	OutputTokens int64   `json:"output_tokens"`
+	Cost         float64 `json:"cost"`
+}
+
+// SessionState consolidates all session-related tracking
+type SessionState struct {
+	ID           string
+	AgentName    string
+	StartTime    time.Time
+	ToolCalls    int
+	TokenUsage   SessionTokenUsage
+	ErrorCount   int
+	Error        []string
+	SessionEnded bool
+}
+
+// SessionStartEvent represents session events
+type SessionStartEvent struct {
+	Action    string `json:"action"`
+	SessionID string `json:"session_id"`
+	AgentName string `json:"agent_name"`
+}
+
+// SessionStartPayload represents the HTTP payload structure for session events
+type SessionStartPayload struct {
+	Action    string `json:"action"`
+	SessionID string `json:"session_id"`
+	AgentName string `json:"agent_name"`
+}
+
+func (e *SessionStartEvent) GetEventType() EventType {
+	return EventTypeSession
+}
+
+func (e *SessionStartEvent) ToStructuredProperties() interface{} {
+	return SessionStartPayload{
+		Action:    "start",
+		SessionID: e.SessionID,
+		AgentName: e.AgentName,
+	}
+}
+
+// SessionEndEvent represents session events
+type SessionEndEvent struct {
+	Action       string   `json:"action"`
+	SessionID    string   `json:"session_id"`
+	AgentName    string   `json:"agent_name"`
+	Duration     int64    `json:"duration_ms"`
+	ToolCalls    int      `json:"tool_calls"`
+	InputTokens  int64    `json:"input_tokens"`
+	OutputTokens int64    `json:"output_tokens"`
+	TotalTokens  int64    `json:"total_tokens"`
+	ErrorCount   int      `json:"error_count"`
+	Cost         float64  `json:"cost"`
+	IsSuccess    bool     `json:"is_success"`
+	Error        []string `json:"error"`
+}
+
+// SessionEndPayload represents the HTTP payload structure for session events
+type SessionEndPayload struct {
+	Action       string   `json:"action"`
+	SessionID    string   `json:"session_id"`
+	AgentName    string   `json:"agent_name"`
+	DurationMs   int64    `json:"duration_ms"`
+	ToolCalls    int      `json:"tool_calls"`
+	InputTokens  int64    `json:"input_tokens"`
+	OutputTokens int64    `json:"output_tokens"`
+	TotalTokens  int64    `json:"total_tokens"`
+	Cost         float64  `json:"cost"`
+	ErrorCount   int      `json:"error_count"`
+	IsSuccess    bool     `json:"is_success"`
+	Error        []string `json:"error"`
+}
+
+func (e *SessionEndEvent) GetEventType() EventType {
+	return EventTypeSession
+}
+
+func (e *SessionEndEvent) ToStructuredProperties() interface{} {
+	return SessionEndPayload{
+		Action:       "end",
+		SessionID:    e.SessionID,
+		AgentName:    e.AgentName,
+		DurationMs:   e.Duration,
+		ToolCalls:    e.ToolCalls,
+		InputTokens:  e.InputTokens,
+		OutputTokens: e.OutputTokens,
+		TotalTokens:  e.TotalTokens,
+		Cost:         e.Cost,
+		ErrorCount:   e.ErrorCount,
+		IsSuccess:    e.IsSuccess,
+		Error:        e.Error,
+	}
+}
+
+// TELEMETRY CLIENT
+
+// HTTPClient interface for making HTTP requests (allows mocking in tests)
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// Client provides simplified telemetry functionality for cagent
+type Client struct {
+	logger     *slog.Logger
+	enabled    bool
+	debugMode  bool // Print to stdout instead of sending
+	httpClient HTTPClient
+	endpoint   string // Docker events API endpoint
+	apiKey     string // Docker events API key for authentication
+	header     string // Authorization header for remote telemetry
+	version    string // App version for User-Agent and events
+	mu         sync.RWMutex
+
+	// Session tracking (consolidated)
+	session SessionState
+
+	// Async processing
+	eventChan chan EventWithContext
+	stopChan  chan struct{}
+	done      chan struct{}
+
+	// HTTP request tracking
+	requestCount int64 // Atomic counter for active requests
+}

--- a/internal/telemetry/utils.go
+++ b/internal/telemetry/utils.go
@@ -1,0 +1,172 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/docker/cagent/internal/config"
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+)
+
+var userUUID string
+
+// getSystemInfo collects system information for events
+func getSystemInfo() (osName, osVersion, osLanguage string) {
+	osInfo := runtime.GOOS
+	osLang := os.Getenv("LANG")
+	if osLang == "" {
+		osLang = "en-US"
+	}
+	return osInfo, "", osLang
+}
+
+// GetTelemetryEnabled checks if telemetry should be enabled based on environment
+func GetTelemetryEnabled() bool {
+	if env := os.Getenv("TELEMETRY_ENABLED"); env != "" {
+		return env == "true"
+	}
+	return true // Default enabled
+}
+
+func getTelemetryEndpoint() string {
+	return os.Getenv("TELEMETRY_ENDPOINT")
+}
+
+func getTelemetryAPIKey() string {
+	return os.Getenv("TELEMETRY_API_KEY")
+}
+
+func getTelemetryHeader() string {
+	return os.Getenv("TELEMETRY_HEADER")
+}
+
+// getUserUUIDFilePath returns the path to the user UUID file
+func getUserUUIDFilePath() string {
+	configDir := config.GetConfigDir()
+	return filepath.Join(configDir, "user-uuid")
+}
+
+// getUserUUID gets or creates a persistent user UUID
+func getUserUUID() string {
+	uuidFile := getUserUUIDFilePath()
+
+	// Try to read existing UUID
+	if data, err := os.ReadFile(uuidFile); err == nil {
+		existingUUID := strings.TrimSpace(string(data))
+		if existingUUID != "" {
+			return existingUUID
+		}
+		// UUID file exists but is empty/invalid - will generate new one
+	} else {
+		// UUID file cannot be read (likely first run) - will generate new one
+	}
+
+	// Generate new UUID and save it
+	newUUID := uuid.New().String()
+	if err := saveUserUUID(newUUID); err != nil {
+		// If we can't save, still return a UUID for this session
+		// but it won't persist across runs
+		return newUUID
+	}
+
+	return newUUID
+}
+
+// saveUserUUID saves the UUID to disk
+func saveUserUUID(newUUID string) error {
+	uuidFile := getUserUUIDFilePath()
+
+	// Ensure directory exists
+	dir := filepath.Dir(uuidFile)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+
+	// Write UUID to file (readable only by user)
+	return os.WriteFile(uuidFile, []byte(newUUID), 0o600)
+}
+
+// structToMap converts a struct to map[string]interface{} using JSON marshaling
+// This automatically handles all fields and respects JSON tags (including omitempty)
+func structToMap(v interface{}) (map[string]interface{}, error) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal struct: %w", err)
+	}
+
+	var result map[string]interface{}
+	err = json.Unmarshal(data, &result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal to map: %w", err)
+	}
+
+	return result, nil
+}
+
+// CommandInfo represents the parsed command information
+type CommandInfo struct {
+	Action string
+	Args   []string
+	Flags  []string
+}
+
+// BuildCommandInfo extracts detailed command information for telemetry
+func BuildCommandInfo(cmd *cobra.Command, args []string, baseName string) CommandInfo {
+	info := CommandInfo{
+		Action: baseName,
+		Args:   []string{},
+		Flags:  []string{},
+	}
+
+	// Only capture arguments for specific commands where they provide valuable context
+	shouldCaptureArgs := baseName == "run" || baseName == "pull" || baseName == "catalog"
+
+	if shouldCaptureArgs {
+		// Add subcommands from args (first non-flag arguments)
+		for _, arg := range args {
+			if !strings.HasPrefix(arg, "-") {
+				info.Args = append(info.Args, arg)
+			} else {
+				// Stop at first flag
+				break
+			}
+		}
+	}
+
+	// Add important flags that provide context
+	if cmd.Flags() != nil {
+		// Check for help flag
+		if help, _ := cmd.Flags().GetBool("help"); help {
+			info.Flags = append(info.Flags, "--help")
+		}
+
+		// Check for version flag (if it exists)
+		if cmd.Flags().Lookup("version") != nil {
+			if version, _ := cmd.Flags().GetBool("version"); version {
+				info.Flags = append(info.Flags, "--version")
+			}
+		}
+
+		// Check for other commonly used flags (more relevant for run/pull commands)
+		if shouldCaptureArgs {
+			flagsToCheck := []string{"config", "agent", "model", "output", "format", "yolo"}
+			for _, flagName := range flagsToCheck {
+				if flag := cmd.Flags().Lookup(flagName); flag != nil && flag.Changed {
+					info.Flags = append(info.Flags, "--"+flagName)
+				}
+			}
+		}
+	}
+
+	return info
+}
+
+// init generates UUIDs once per process
+func init() {
+	userUUID = getUserUUID()
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/lipgloss/v2"
 
 	"github.com/docker/cagent/internal/app"
+	"github.com/docker/cagent/internal/telemetry"
 	"github.com/docker/cagent/internal/tui/components/statusbar"
 	"github.com/docker/cagent/internal/tui/dialog"
 	chatpage "github.com/docker/cagent/internal/tui/page/chat"
@@ -76,6 +77,7 @@ func New(a *app.App) tea.Model {
 
 // Init initializes the application
 func (a *appModel) Init() tea.Cmd {
+	telemetry.TrackCommand("tui", []string{"init"})
 	return tea.Batch(
 		// Initialize dialog system
 		a.dialog.Init(),


### PR DESCRIPTION
Resolves https://github.com/docker/new-cagent/issues/15 by adding Marlin event tracking. See [Notion](https://www.notion.so/dockerinc/Tracking-plan-cagent-events-25757a1d467380488ab9f0a25f9baa29?source=copy_link) for more context.

You can see it working by running `TELEMETRY_ENABLED=false cagent version --debug`.

example `command` events (basically any time the user types `cagent [commandName]`:
```
> cagent run
{
  "records": [
    {
      "event": "command",
      "event_timestamp": 1756510035096,
      "source": "cagent",
      "properties": {
        "action": "run",
        "args": [
          "examples/code.yaml"
        ],
        "is_success": true,
        "os": "darwin",
        "os_language": "en_US.UTF-8",
        "user_uuid": "e94abf39-bb0a-44f1-9ba6-ee84401c3d67",
        "version": "dev"
      }
    }
  ]
}

> cagent feedback
{
  "records": [
    {
      "event": "command",
      "event_timestamp": 1756490808917,
      "source": "cagent",
      "properties": {
        "action": "feedback",
        "duration_ms": 0,
        "is_success": true,
        "os": "darwin",
        "os_language": "en_US.UTF-8",
        "user_uuid": "e94abf39-bb0a-44f1-9ba6-ee84401c3d67",
        "version": "dev"
      }
    }
  ]
}

> cagent pull
{
  "records": [
    {
      "event": "command",
      "event_timestamp": 1756490898358,
      "source": "cagent",
      "properties": {
        "action": "pull",
        "args": [
          "agentcatalog/pirate"
        ],
        "duration_ms": 0,
        "is_success": true,
        "os": "darwin",
        "os_language": "en_US.UTF-8",
        "user_uuid": "e94abf39-bb0a-44f1-9ba6-ee84401c3d67",
        "version": "dev"
      }
    }
  ]
}

> cagent api
{
  "records": [
    {
      "event": "command",
      "event_timestamp": 1756566317361,
      "source": "cagent",
      "properties": {
        "action": "api",
        "flags": [
          "--port",
          "8080"
        ],
        "is_success": true,
        "os": "darwin",
        "os_language": "en_US.UTF-8",
        "user_uuid": "e94abf39-bb0a-44f1-9ba6-ee84401c3d67",
        "version": "test-version"
      }
    }
  ]
}
```

example `session` events:
```
> session start
{
  "records": [
    {
      "event": "session",
      "event_timestamp": 1756609209929,
      "source": "cagent",
      "properties": {
        "action": "start",
        "agent_name": "root",
        "os": "darwin",
        "os_language": "en_US.UTF-8",
        "session_id": "95c946e5-7e17-4456-9a20-b02f7e105109",
        "user_uuid": "e94abf39-bb0a-44f1-9ba6-ee84401c3d67",
        "version": "dev"
      }
    }
  ]
}

> session end
{
  "records": [
    {
      "event": "session",
      "event_timestamp": 1756609228338,
      "source": "cagent",
      "properties": {
        "action": "end",
        "agent_name": "root",
        "cost": 0,
        "duration_ms": 1943,
        "error": [],
        "error_count": 0,
        "input_tokens": 3839,
        "is_success": true,
        "os": "darwin",
        "os_language": "en_US.UTF-8",
        "output_tokens": 11,
        "session_id": "3fe0e42a-f9e0-41d0-814c-a0f392635ef0",
        "tool_calls": 0,
        "total_tokens": 3850,
        "user_uuid": "e94abf39-bb0a-44f1-9ba6-ee84401c3d67",
        "version": "dev"
      }
    }
  ]
}
```

example `token` event:
```
> token usage
{
  "records": [
    {
      "event": "token",
      "event_timestamp": 1756609213507,
      "source": "cagent",
      "properties": {
        "action": "usage",
        "agent_name": "root",
        "cost": 0.011964,
        "input_tokens": 3668,
        "model_name": "Claude Sonnet 4",
        "os": "darwin",
        "os_language": "en_US.UTF-8",
        "output_tokens": 64,
        "session_id": "95c946e5-7e17-4456-9a20-b02f7e105109",
        "total_tokens": 3732,
        "user_uuid": "e94abf39-bb0a-44f1-9ba6-ee84401c3d67",
        "version": "dev"
      }
    }
  ]
}
```

example `tool` event:
```
> tool call
{
  "records": [
    {
      "event": "tool",
      "event_timestamp": 1756609213890,
      "source": "cagent",
      "properties": {
        "action": "call",
        "agent_name": "root",
        "duration_ms": 0,
        "is_success": true,
        "os": "darwin",
        "os_language": "en_US.UTF-8",
        "session_id": "95c946e5-7e17-4456-9a20-b02f7e105109",
        "tool_name": "list_allowed_directories",
        "user_uuid": "e94abf39-bb0a-44f1-9ba6-ee84401c3d67",
        "version": "dev"
      }
    }
  ]
}

{
  "records": [
    {
      "event": "token",
      "event_timestamp": 1756609216969,
      "source": "cagent",
      "properties": {
        "action": "usage",
        "agent_name": "root",
        "cost": 0.025128,
        "input_tokens": 3763,
        "model_name": "Claude Sonnet 4",
        "os": "darwin",
        "os_language": "en_US.UTF-8",
        "output_tokens": 125,
        "session_id": "95c946e5-7e17-4456-9a20-b02f7e105109",
        "total_tokens": 3888,
        "user_uuid": "e94abf39-bb0a-44f1-9ba6-ee84401c3d67",
        "version": "dev"
      }
    }
  ]
}
```

Successful HTTP requests:
<img width="1378" height="1843" alt="Screenshot 2025-08-30 at 11 03 54 PM" src="https://github.com/user-attachments/assets/789d586f-1e97-4c49-afd9-e0f94b6df726" />


Here it is in Sigma:
<img width="784" height="705" alt="Screenshot 2025-08-30 at 11 05 28 PM" src="https://github.com/user-attachments/assets/eb403b0d-7925-4ed0-9832-aad58578f547" />
