### PR TITLE
provider/openai: Allow custom token key

### DIFF
--- a/pkg/config/v1/types.go
+++ b/pkg/config/v1/types.go
@@ -93,6 +93,7 @@ type ModelConfig struct {
 	BaseURL           string            `json:"base_url,omitempty" yaml:"base_url,omitempty"`
 	ParallelToolCalls *bool             `json:"parallel_tool_calls,omitempty" yaml:"parallel_tool_calls,omitempty"`
 	Env               map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
+	TokenKey          string            `json:"token_key,omitempty" yaml:"token_key,omitempty"`
 }
 
 // Config represents the entire configuration file

--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -47,7 +47,11 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 
 	var openaiConfig openai.ClientConfig
 	if gateway := globalOptions.Gateway(); gateway == "" {
-		authToken, err := env.Get(ctx, "OPENAI_API_KEY")
+		key := cfg.TokenKey
+		if key == "" {
+			key = "OPENAI_API_KEY"
+		}
+		authToken, err := env.Get(ctx, key)
 		if err != nil || authToken == "" {
 			slog.Error("OpenAI client creation failed", "error", "failed to get authentication token", "details", err)
 			return nil, errors.New("OPENAI_API_KEY environment variable is required")


### PR DESCRIPTION
This makes it possible to use other OpenAI-compatible APIs.