### PR TITLE
feat: add Requesty provider with custom header support

### DIFF
--- a/pkg/config/v1/types.go
+++ b/pkg/config/v1/types.go
@@ -92,6 +92,7 @@ type ModelConfig struct {
 	PresencePenalty   float64           `json:"presence_penalty,omitempty" yaml:"presence_penalty,omitempty"`
 	BaseURL           string            `json:"base_url,omitempty" yaml:"base_url,omitempty"`
 	ParallelToolCalls *bool             `json:"parallel_tool_calls,omitempty" yaml:"parallel_tool_calls,omitempty"`
+	Headers           map[string]string `json:"headers,omitempty" yaml:"headers,omitempty"`
 	Env               map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
 	TokenKey          string            `json:"token_key,omitempty" yaml:"token_key,omitempty"`
 }

--- a/pkg/model/provider/provider.go
+++ b/pkg/model/provider/provider.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/cagent/pkg/model/provider/gemini"
 	"github.com/docker/cagent/pkg/model/provider/openai"
 	"github.com/docker/cagent/pkg/model/provider/options"
+	"github.com/docker/cagent/pkg/model/provider/requesty"
 	"github.com/docker/cagent/pkg/tools"
 )
 
@@ -40,6 +41,9 @@ func New(ctx context.Context, cfg *latest.ModelConfig, env environment.Provider,
 	switch cfg.Provider {
 	case "openai":
 		return openai.NewClient(ctx, cfg, env, opts...)
+
+	case "requesty":
+		return requesty.NewClient(ctx, cfg, env, opts...)
 
 	case "anthropic":
 		return anthropic.NewClient(ctx, cfg, env, opts...)

--- a/pkg/model/provider/requesty/adapter.go
+++ b/pkg/model/provider/requesty/adapter.go
@@ -1,0 +1,120 @@
+package requesty
+
+import (
+	"github.com/sashabaranov/go-openai"
+
+	"github.com/docker/cagent/pkg/chat"
+	"github.com/docker/cagent/pkg/tools"
+)
+
+// streamAdapter adapts the OpenAI stream to our interface for Requesty
+type streamAdapter struct {
+	stream           *openai.ChatCompletionStream
+	lastFinishReason chat.FinishReason
+	toolCalls        map[int]string
+}
+
+func newStreamAdapter(stream *openai.ChatCompletionStream) *streamAdapter {
+	return &streamAdapter{
+		stream:    stream,
+		toolCalls: make(map[int]string),
+	}
+}
+
+// Recv gets the next completion chunk
+func (a *streamAdapter) Recv() (chat.MessageStreamResponse, error) {
+	openaiResponse, err := a.stream.Recv()
+	if err != nil {
+		return chat.MessageStreamResponse{}, err
+	}
+
+	// Convert the OpenAI response to our generic format
+	response := chat.MessageStreamResponse{
+		ID:      openaiResponse.ID,
+		Object:  openaiResponse.Object,
+		Created: openaiResponse.Created,
+		Model:   openaiResponse.Model,
+		Choices: make([]chat.MessageStreamChoice, len(openaiResponse.Choices)),
+	}
+
+	if openaiResponse.Usage != nil {
+		cachedTokens := 0
+		if openaiResponse.Usage.PromptTokensDetails != nil {
+			cachedTokens = openaiResponse.Usage.PromptTokensDetails.CachedTokens
+		}
+		response.Usage = &chat.Usage{
+			InputTokens:        openaiResponse.Usage.PromptTokens,
+			OutputTokens:       openaiResponse.Usage.CompletionTokens,
+			CachedInputTokens:  cachedTokens,
+			CachedOutputTokens: 0,
+		}
+		// Use the tracked finish reason instead of hardcoding stop
+		finishReason := a.lastFinishReason
+		if finishReason == "" {
+			finishReason = chat.FinishReasonStop
+		}
+		response.Choices = append(response.Choices, chat.MessageStreamChoice{
+			FinishReason: finishReason,
+		})
+	}
+
+	// Convert the choices
+	for i := range openaiResponse.Choices {
+		choice := &openaiResponse.Choices[i]
+		if choice.FinishReason == openai.FinishReasonStop {
+			choice.FinishReason = openai.FinishReasonNull
+		}
+
+		finishReason := chat.FinishReason(choice.FinishReason)
+		// Track the finish reason for when we get usage info
+		if finishReason != chat.FinishReasonNull && finishReason != "" {
+			a.lastFinishReason = finishReason
+		}
+
+		response.Choices[i] = chat.MessageStreamChoice{
+			Index:        choice.Index,
+			FinishReason: finishReason,
+			Delta: chat.MessageDelta{
+				Role:    choice.Delta.Role,
+				Content: choice.Delta.Content,
+			},
+		}
+
+		// Convert function call if present
+		if choice.Delta.FunctionCall != nil {
+			response.Choices[i].Delta.FunctionCall = &tools.FunctionCall{
+				Name:      choice.Delta.FunctionCall.Name,
+				Arguments: choice.Delta.FunctionCall.Arguments,
+			}
+		}
+
+		// Convert tool calls if present
+		if len(choice.Delta.ToolCalls) > 0 {
+			response.Choices[i].Delta.ToolCalls = make([]tools.ToolCall, len(choice.Delta.ToolCalls))
+			for j, toolCall := range choice.Delta.ToolCalls {
+				id := toolCall.ID
+				if existing, ok := a.toolCalls[*toolCall.Index]; ok {
+					id = existing
+				} else {
+					a.toolCalls[*toolCall.Index] = id
+				}
+
+				response.Choices[i].Delta.ToolCalls[j] = tools.ToolCall{
+					ID:   id,
+					Type: tools.ToolType(toolCall.Type),
+					Function: tools.FunctionCall{
+						Name:      toolCall.Function.Name,
+						Arguments: toolCall.Function.Arguments,
+					},
+				}
+			}
+		}
+	}
+
+	return response, nil
+}
+
+// Close closes the stream
+func (a *streamAdapter) Close() {
+	a.stream.Close()
+}

--- a/pkg/model/provider/requesty/client.go
+++ b/pkg/model/provider/requesty/client.go
@@ -1,0 +1,265 @@
+package requesty
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/sashabaranov/go-openai"
+
+	"github.com/docker/cagent/pkg/chat"
+	latest "github.com/docker/cagent/pkg/config/v1"
+	"github.com/docker/cagent/pkg/environment"
+	"github.com/docker/cagent/pkg/model/provider/options"
+	"github.com/docker/cagent/pkg/tools"
+)
+
+// Client represents a Requesty client
+type Client struct {
+	client  *openai.Client
+	config  *latest.ModelConfig
+}
+
+// headerTransport wraps http.RoundTripper to add custom headers
+type headerTransport struct {
+	headers map[string]string
+	base    http.RoundTripper
+}
+
+func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Add custom headers to the request
+	for key, value := range t.headers {
+		req.Header.Set(key, value)
+	}
+	return t.base.RoundTrip(req)
+}
+
+// NewClient creates a new Requesty client
+func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Provider, opts ...options.Opt) (*Client, error) {
+	if cfg == nil {
+		slog.Error("Requesty client creation failed", "error", "model configuration is required")
+		return nil, errors.New("model configuration is required")
+	}
+
+	if cfg.Provider != "requesty" {
+		slog.Error("Requesty client creation failed", "error", "model type must be 'requesty'", "actual_type", cfg.Provider)
+		return nil, errors.New("model type must be 'requesty'")
+	}
+
+	// Set default base_url for Requesty if not provided
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = "https://router.requesty.ai/v1"
+		slog.Debug("Using default Requesty base_url", "base_url", baseURL)
+	}
+
+	// Set default headers for Requesty
+	headers := make(map[string]string)
+	if cfg.Headers != nil {
+		for k, v := range cfg.Headers {
+			headers[k] = v
+		}
+	}
+	if _, ok := headers["HTTP-Referer"]; !ok {
+		headers["HTTP-Referer"] = "https://github.com/docker/cagent"
+	}
+	if _, ok := headers["X-Title"]; !ok {
+		headers["X-Title"] = "Cagent"
+	}
+
+	// Get auth token
+	key := cfg.TokenKey
+	if key == "" {
+		key = "REQUESTY_API_KEY"
+	}
+	authToken, err := env.Get(ctx, key)
+	if err != nil || authToken == "" {
+		slog.Error("Requesty client creation failed", "error", "failed to get authentication token", "details", err)
+		return nil, errors.New("REQUESTY_API_KEY environment variable is required")
+	}
+
+	// Create OpenAI config with Requesty settings
+	openaiConfig := openai.DefaultConfig(authToken)
+	openaiConfig.BaseURL = baseURL
+
+	// Create HTTP client with custom headers
+	httpClient := &http.Client{
+		Transport: &headerTransport{
+			headers: headers,
+			base:    http.DefaultTransport,
+		},
+	}
+	openaiConfig.HTTPClient = httpClient
+
+	// Create OpenAI client with Requesty configuration
+	client := openai.NewClientWithConfig(openaiConfig)
+
+	slog.Debug("Requesty client created successfully", "model", cfg.Model, "base_url", baseURL, "headers", headers)
+
+	return &Client{
+		client: client,
+		config: cfg,
+	}, nil
+}
+
+// ID returns the provider ID
+func (c *Client) ID() string {
+	return "requesty"
+}
+
+// CreateChatCompletionStream creates a streaming chat completion
+func (c *Client) CreateChatCompletionStream(ctx context.Context, messages []chat.Message, requestTools []tools.Tool) (chat.MessageStream, error) {
+	slog.Debug("Creating Requesty chat completion stream", "model", c.config.Model, "message_count", len(messages), "tool_count", len(requestTools))
+
+	if len(messages) == 0 {
+		slog.Error("Requesty stream creation failed", "error", "at least one message is required")
+		return nil, errors.New("at least one message is required")
+	}
+
+	request := openai.ChatCompletionRequest{
+		Model:            c.config.Model,
+		Messages:         convertMessages(messages),
+		Temperature:      float32(c.config.Temperature),
+		TopP:             float32(c.config.TopP),
+		FrequencyPenalty: float32(c.config.FrequencyPenalty),
+		PresencePenalty:  float32(c.config.PresencePenalty),
+		Stream:           true,
+		StreamOptions: &openai.StreamOptions{
+			IncludeUsage: true,
+		},
+	}
+
+	if c.config.MaxTokens > 0 {
+		request.MaxTokens = c.config.MaxTokens
+	}
+
+	if c.config.ParallelToolCalls != nil {
+		request.ParallelToolCalls = *c.config.ParallelToolCalls
+	}
+
+	// Add tools if provided
+	if len(requestTools) > 0 {
+		slog.Debug("Adding tools to Requesty request", "tool_count", len(requestTools))
+		request.Tools = make([]openai.Tool, len(requestTools))
+		for i, tool := range requestTools {
+			request.Tools[i] = openai.Tool{
+				Type: openai.ToolTypeFunction,
+				Function: &openai.FunctionDefinition{
+					Name:        tool.Function.Name,
+					Description: tool.Function.Description,
+					Strict:      tool.Function.Strict,
+					Parameters:  tool.Function.Parameters,
+				},
+			}
+			if len(tool.Function.Parameters.Properties) == 0 {
+				request.Tools[i].Function.Parameters = json.RawMessage("{}")
+			}
+			slog.Debug("Added tool to Requesty request", "tool_name", tool.Function.Name)
+		}
+	}
+
+	stream, err := c.client.CreateChatCompletionStream(ctx, request)
+	if err != nil {
+		slog.Error("Requesty stream creation failed", "error", err, "model", c.config.Model)
+		return nil, err
+	}
+
+	slog.Debug("Requesty chat completion stream created successfully", "model", c.config.Model)
+	return newStreamAdapter(stream), nil
+}
+
+// CreateChatCompletion creates a non-streaming chat completion
+func (c *Client) CreateChatCompletion(ctx context.Context, messages []chat.Message) (string, error) {
+	slog.Debug("Creating Requesty chat completion", "model", c.config.Model, "message_count", len(messages))
+
+	request := openai.ChatCompletionRequest{
+		Model:    c.config.Model,
+		Messages: convertMessages(messages),
+	}
+
+	if c.config.MaxTokens > 0 {
+		request.MaxTokens = c.config.MaxTokens
+	}
+
+	if c.config.ParallelToolCalls != nil {
+		request.ParallelToolCalls = *c.config.ParallelToolCalls
+	}
+
+	response, err := c.client.CreateChatCompletion(ctx, request)
+	if err != nil {
+		slog.Error("Requesty chat completion failed", "error", err, "model", c.config.Model)
+		return "", err
+	}
+
+	slog.Debug("Requesty chat completion successful", "model", c.config.Model, "response_length", len(response.Choices[0].Message.Content))
+	return response.Choices[0].Message.Content, nil
+}
+
+// Helper functions (copied from OpenAI provider)
+func convertMultiContent(multiContent []chat.MessagePart) []openai.ChatMessagePart {
+	openaiMultiContent := make([]openai.ChatMessagePart, len(multiContent))
+	for i, part := range multiContent {
+		openaiPart := openai.ChatMessagePart{
+			Type: openai.ChatMessagePartType(part.Type),
+			Text: part.Text,
+		}
+
+		// Handle image URL conversion
+		if part.Type == chat.MessagePartTypeImageURL && part.ImageURL != nil {
+			openaiPart.ImageURL = &openai.ChatMessageImageURL{
+				URL:    part.ImageURL.URL,
+				Detail: openai.ImageURLDetail(part.ImageURL.Detail),
+			}
+		}
+
+		openaiMultiContent[i] = openaiPart
+	}
+	return openaiMultiContent
+}
+
+func convertMessages(messages []chat.Message) []openai.ChatCompletionMessage {
+	openaiMessages := make([]openai.ChatCompletionMessage, len(messages))
+	for i := range messages {
+		msg := &messages[i]
+		openaiMessage := openai.ChatCompletionMessage{
+			Role: string(msg.Role),
+			Name: msg.Name,
+		}
+
+		if len(msg.MultiContent) == 0 {
+			openaiMessage.Content = msg.Content
+		} else {
+			openaiMessage.MultiContent = convertMultiContent(msg.MultiContent)
+		}
+
+		if msg.FunctionCall != nil {
+			openaiMessage.FunctionCall = &openai.FunctionCall{
+				Name:      msg.FunctionCall.Name,
+				Arguments: msg.FunctionCall.Arguments,
+			}
+		}
+
+		if len(msg.ToolCalls) > 0 {
+			openaiMessage.ToolCalls = make([]openai.ToolCall, len(msg.ToolCalls))
+			for j, toolCall := range msg.ToolCalls {
+				openaiMessage.ToolCalls[j] = openai.ToolCall{
+					ID:   toolCall.ID,
+					Type: openai.ToolType(toolCall.Type),
+					Function: openai.FunctionCall{
+						Name:      toolCall.Function.Name,
+						Arguments: toolCall.Function.Arguments,
+					},
+				}
+			}
+		}
+
+		if msg.ToolCallID != "" {
+			openaiMessage.ToolCallID = msg.ToolCallID
+		}
+
+		openaiMessages[i] = openaiMessage
+	}
+	return openaiMessages
+}


### PR DESCRIPTION
- Add new 'requesty' model provider for enterprise LLM routing
- Support custom HTTP headers via ModelConfig.Headers field
- Default base_url to https://router.requesty.ai/v1
- Maintain full OpenAI API compatibility with now access to +300 models

Enablesintegration with Requesty's enterprise LLM gateway serving 15k+ developers while preserving existing OpenAI workflows.