### PR TITLE
More complete DMR support

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,22 @@ models:
 
 You'll find a curated list of agents examples, spread into 3 categories, [Basic](https://github.com/docker/cagent/tree/main/examples#basic-configurations), [Advanced](https://github.com/docker/cagent/tree/main/examples#advanced-configurations) and [multi-agents](https://github.com/docker/cagent/tree/main/examples#multi-agent-configurations) in the `/examples/` directory.
 
+### DMR provider options
+
+When using the `dmr` provider, you can use the `provider_opts` key for DMR runtime-specific (e.g. llama.cpp) options:
+
+```yaml
+models:
+  local-qwen:
+    provider: dmr
+    model: ai/qwen3
+    max_tokens: 8192
+    provider_opts:
+      runtime_flags: ["--ngl=33", "--repeat-penalty=1.2", ...]  # or comma/space-separated string
+```
+
+The default base_url `cagent` will use for dmr providers is `http://localhost:12434/engines/llama.cpp/v1`. DMR itself might need to be enabled via [Docker Desktop's settings](https://docs.docker.com/ai/model-runner/get-started/#enable-dmr-in-docker-desktop) on MacOS and Windows, and via command line on [Docker CE on Linux](https://docs.docker.com/ai/model-runner/get-started/#enable-dmr-in-docker-engine).
+
 ## Quickly generate agents and agent teams with `cagent new`
 
 Using the command `cagent new` you can quickly generate agents or multi-agent teams using a single prompt!  

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -130,9 +130,11 @@ func migrateToLatestConfig(c any) v1.Config {
 }
 
 func validateConfig(cfg *v1.Config) error {
-	for _, model := range cfg.Models {
-		if model.ParallelToolCalls == nil {
-			model.ParallelToolCalls = boolPtr(true)
+	for name := range cfg.Models {
+		if cfg.Models[name].ParallelToolCalls == nil {
+			m := cfg.Models[name]
+			m.ParallelToolCalls = boolPtr(true)
+			cfg.Models[name] = m
 		}
 	}
 

--- a/pkg/config/v1/types.go
+++ b/pkg/config/v1/types.go
@@ -114,6 +114,8 @@ type ModelConfig struct {
 	ParallelToolCalls *bool             `json:"parallel_tool_calls,omitempty" yaml:"parallel_tool_calls,omitempty"`
 	Env               map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
 	TokenKey          string            `json:"token_key,omitempty" yaml:"token_key,omitempty"`
+	// ProviderOpts allows provider-specific options. Currently used for "dmr" provider only.
+	ProviderOpts map[string]any `json:"provider_opts,omitempty" yaml:"provider_opts,omitempty"`
 }
 
 // Config represents the entire configuration file

--- a/pkg/model/provider/dmr/client_test.go
+++ b/pkg/model/provider/dmr/client_test.go
@@ -1,13 +1,14 @@
 package dmr
 
 import (
+	"reflect"
 	"testing"
 
 	latest "github.com/docker/cagent/pkg/config/v1"
 )
 
 func TestNewClientWithDefaultBaseURL(t *testing.T) {
-	// Test case 1: No base_url provided, should use default
+	// No base_url provided, should use default
 	cfg := &latest.ModelConfig{
 		Provider: "dmr",
 		Model:    "ai/qwen3",
@@ -25,7 +26,7 @@ func TestNewClientWithDefaultBaseURL(t *testing.T) {
 }
 
 func TestNewClientWithExplicitBaseURL(t *testing.T) {
-	// Test case 2: Explicit base_url provided, should use that
+	// Explicit base_url provided, should use that
 	customURL := "https://custom.example.com:8080/api/v1"
 	cfg := &latest.ModelConfig{
 		Provider: "dmr",
@@ -44,7 +45,7 @@ func TestNewClientWithExplicitBaseURL(t *testing.T) {
 }
 
 func TestNewClientWithWrongType(t *testing.T) {
-	// Test case 3: Wrong model type, should return error
+	// Wrong model type, should return error
 	cfg := &latest.ModelConfig{
 		Provider: "openai", // Wrong type
 		Model:    "gpt-4",
@@ -53,5 +54,69 @@ func TestNewClientWithWrongType(t *testing.T) {
 	_, err := NewClient(t.Context(), cfg)
 	if err == nil {
 		t.Fatal("Expected error for wrong model type, got nil")
+	}
+}
+
+func TestBuildDockerConfigureArgs(t *testing.T) {
+	args := buildDockerModelConfigureArgs("ai/qwen3:14B-Q6_K", 8192, []string{"--temp", "0.7", "--top-p", "0.9"})
+	expected := []string{"model", "configure", "--context-size=8192", "ai/qwen3:14B-Q6_K", "--", "--temp", "0.7", "--top-p", "0.9"}
+	if !reflect.DeepEqual(args, expected) {
+		t.Fatalf("unexpected args.\nexpected: %#v\nactual:   %#v", expected, args)
+	}
+}
+
+func TestBuildRuntimeFlagsFromModelConfig_LlamaCpp(t *testing.T) {
+	cfg := &latest.ModelConfig{
+		Temperature:      0.6,
+		TopP:             0.95,
+		FrequencyPenalty: 0.2,
+		PresencePenalty:  0.1,
+	}
+
+	flags := buildRuntimeFlagsFromModelConfig("llama.cpp", cfg)
+
+	// Order matters based on implementation
+	expected := []string{"--temp", "0.6", "--top-p", "0.95", "--frequency-penalty", "0.2", "--presence-penalty", "0.1"}
+	if !reflect.DeepEqual(flags, expected) {
+		t.Fatalf("unexpected runtime flags.\nexpected: %#v\nactual:   %#v", expected, flags)
+	}
+}
+
+func TestIntegrateFlagsWithProviderOptsOrder(t *testing.T) {
+	cfg := &latest.ModelConfig{
+		Temperature: 0.6,
+		TopP:        0.9,
+		MaxTokens:   4096,
+		ProviderOpts: map[string]any{
+			"runtime_flags": []string{"--threads", "6"},
+		},
+	}
+	// derive config flags first, then merge provider opts (simulating NewClient path)
+	derived := buildRuntimeFlagsFromModelConfig("llama.cpp", cfg)
+	// provider opts should be appended after derived flags so they can override by order
+	merged := append(derived, []string{"--threads", "6"}...)
+
+	args := buildDockerModelConfigureArgs("ai/qwen3:14B-Q6_K", cfg.MaxTokens, merged)
+	expected := []string{"model", "configure", "--context-size=4096", "ai/qwen3:14B-Q6_K", "--", "--temp", "0.6", "--top-p", "0.9", "--threads", "6"}
+	if !reflect.DeepEqual(args, expected) {
+		t.Fatalf("unexpected configure args.\nexpected: %#v\nactual:   %#v", expected, args)
+	}
+}
+
+func TestMergeRuntimeFlagsPreferUser_WarnsAndPrefersUser(t *testing.T) {
+	// Derived suggests temp/top-p, user overrides both and adds threads
+	derived := []string{"--temp", "0.5", "--top-p", "0.8"}
+	user := []string{"--temp", "0.7", "--threads", "8"}
+
+	merged, warnings := mergeRuntimeFlagsPreferUser(derived, user)
+
+	// Expect 1 warnings for --temp overriding
+	if len(warnings) != 1 {
+		t.Fatalf("expected 1 warning1, got %d: %#v", len(warnings), warnings)
+	}
+	// Derived conflicting flags should be dropped, user ones kept and appended
+	expected := []string{"--top-p", "0.8", "--temp", "0.7", "--threads", "8"}
+	if !reflect.DeepEqual(merged, expected) {
+		t.Fatalf("unexpected merged flags.\nexpected: %#v\nactual:   %#v", expected, merged)
 	}
 }


### PR DESCRIPTION
With this PR the `dmr` provider can now support:

- Proper context length setup using `max_tokens`
- `temperature`, `top_p`, `frequency_penalty`, `presence_penalty` all get mapped into the proper runtime flags based on the engine in use (for now only `llama.cpp` mappings);
-  Raw runtime flags to pass to the inference engine in use, via `provider_opts:runtime_flags`

Configuration example supported with these changes:

```yaml
models:
  root:
    provider: dmr
    model: ai/qwen3:14B-Q6_K
    max_tokens: 32768
    temperature: 0.7
    top_p: 0.95
    frequency_penalty: 0.2
    presence_penalty: 0.1
    provider_opts:
      runtime_flags: |
        --batch-size 1024
        --ubatch-size 512
```

closes #71 