### PR TITLE
:brain: :wrench: fix correct mem memory param in mem.yaml example

### DIFF
--- a/examples/mem.yaml
+++ b/examples/mem.yaml
@@ -5,8 +5,9 @@ agents:
   root:
     model: openai/gpt-4o
     description: Humorous AI with persistent memory
-    memory:
-      path: ./funny.db
+    toolsets:
+      - type: memory
+        path: "./funny.db"
     instruction: You are a funny chatter
 
 metadata:


### PR DESCRIPTION
# 🐛 Current Bug

* The current version doesn't parse the yaml file, so no linting output.

# ✅ Fixed Demo

The correct version is specified in the docs

# 💻 Screenshots 

