### PR TITLE
Support for OpenRouter via a new provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ See [the USAGE docs](./docs/USAGE.md#tool-configuration) for more detailed infor
 - **🔄 Smart delegation** - Agents can automatically route tasks to the most suitable specialist.
 - **📝 YAML configuration** - Declarative model and agent configuration.
 - **💭 Advanced reasoning** - Built-in "think", "todo" and "memory" tools for complex problem-solving.
-- **🌐 Multiple AI providers** - Support for OpenAI, Anthropic, Gemini and [Docker Model Runner](https://docs.docker.com/ai/model-runner/).
+- **🌐 Multiple AI providers** - Support for OpenAI, Anthropic, OpenRouter, Gemini and [Docker Model Runner](https://docs.docker.com/ai/model-runner/).
 
 ## 🚀 Quick Start 🚀
 
@@ -128,6 +128,9 @@ export ANTHROPIC_API_KEY=your_api_key_here
 
 # For Gemini models
 export GOOGLE_API_KEY=your_api_key_here
+
+# For OpenRouter models
+export OPENROUTER_API_KEY=your_api_key_here
 ```
 
 ### Run Agents!
@@ -208,12 +211,13 @@ To use the feature, you must have an Anthropic, OpenAI or Google API key availab
 
 You can choose what provider and model gets used by passing the `--model provider/modelname` flag to `cagent new`
 
-If `--model` is unspecified, `cagent new` will automatically choose between these 3 providers in order based on the first api key it finds in your environment.
+If `--model` is unspecified, `cagent new` will automatically choose between these providers in order based on the first api key it finds in your environment.
 
 ```sh
-export ANTHROPIC_API_KEY=your_api_key_here  # first choice. default model claude-sonnet-4-0
-export OPENAI_API_KEY=your_api_key_here     # if anthropic key not set. default model gpt-5-mini
-export GOOGLE_API_KEY=your_api_key_here     # if anthropic and openai keys are not set. default model gemini-2.5-flash
+export ANTHROPIC_API_KEY=your_api_key_here   # default model claude-sonnet-4-0
+export OPENAI_API_KEY=your_api_key_here      # default model gpt-5-mini
+export GOOGLE_API_KEY=your_api_key_here      # default model gemini-2.5-flash
+export OPENROUTER_API_KEY=your_api_key_here  # default model depends on your OpenRouter route
 ```
 
 `--max-tokens` can be specified to override the context limit used.  

--- a/cmd/root/new.go
+++ b/cmd/root/new.go
@@ -37,7 +37,7 @@ func NewNewCmd() *cobra.Command {
 			if idx := strings.Index(modelParam, "/"); idx > 0 {
 				candidate := strings.ToLower(modelParam[:idx])
 				switch candidate {
-				case "anthropic", "openai", "google", "dmr":
+				case "anthropic", "openai", "openrouter", "google", "dmr":
 					derivedProvider = candidate
 					model = modelParam[idx+1:]
 				}
@@ -48,7 +48,7 @@ func NewNewCmd() *cobra.Command {
 				modelProvider = derivedProvider
 			} else {
 				if runConfig.ModelsGateway == "" {
-					// Prefer Anthropic, then OpenAI, then Google based on available API keys
+					// Prefer Anthropic, then OpenAI, then Google, then OpenRouter based on available API keys
 					// default to DMR if no provider credentials are found
 					switch {
 					case os.Getenv("ANTHROPIC_API_KEY") != "":
@@ -60,6 +60,9 @@ func NewNewCmd() *cobra.Command {
 					case os.Getenv("GOOGLE_API_KEY") != "":
 						modelProvider = "google"
 						fmt.Printf("%s\n\n", gray("GOOGLE_API_KEY found, using Google"))
+					case os.Getenv("OPENROUTER_API_KEY") != "":
+						modelProvider = "openrouter"
+						fmt.Printf("%s\n\n", gray("OPENROUTER_API_KEY found, using OpenRouter"))
 					default:
 						modelProvider = "dmr"
 						fmt.Printf("%s\n\n", yellow("⚠️ No provider credentials found, defaulting to Docker Model Runner (DMR)"))
@@ -133,7 +136,7 @@ func NewNewCmd() *cobra.Command {
 		},
 	}
 	addGatewayFlags(cmd)
-	cmd.PersistentFlags().StringVar(&modelParam, "model", "", "Model to use, optionally as provider/model where provider is one of: anthropic, openai, google, dmr. If omitted, provider is auto-selected based on available credentials or gateway")
+	cmd.PersistentFlags().StringVar(&modelParam, "model", "", "Model to use, optionally as provider/model where provider is one of: anthropic, openai, openrouter, google, dmr. If omitted, provider is auto-selected based on available credentials or gateway")
 	cmd.PersistentFlags().IntVar(&maxTokensParam, "max-tokens", 0, "Override max_tokens for the selected model (0 = default)")
 
 	return cmd

--- a/internal/creator/agent.go
+++ b/internal/creator/agent.go
@@ -123,10 +123,11 @@ func CreateAgent(ctx context.Context, baseDir, prompt string, runConfig config.R
 
 func StreamCreateAgent(ctx context.Context, baseDir, prompt string, runConfig config.RuntimeConfig, providerName, modelNameOverride string, maxTokensOverride int) (<-chan runtime.Event, error) {
 	defaultModels := map[string]string{
-		"openai":    "gpt-5-mini",
-		"anthropic": "claude-sonnet-4-0",
-		"google":    "gemini-2.5-flash",
-		"dmr":       "ai/qwen3:latest",
+		"openai":     "gpt-5-mini",
+		"anthropic":  "claude-sonnet-4-0",
+		"google":     "gemini-2.5-flash",
+		"dmr":        "ai/qwen3:latest",
+		"openrouter": "anthropic/claude-sonnet-4",
 	}
 
 	var modelName string
@@ -159,6 +160,9 @@ func StreamCreateAgent(ctx context.Context, baseDir, prompt string, runConfig co
 		}
 		if os.Getenv("GOOGLE_API_KEY") != "" {
 			usableProviders = append(usableProviders, "google")
+		}
+		if os.Getenv("OPENROUTER_API_KEY") != "" {
+			usableProviders = append(usableProviders, "openrouter")
 		}
 		// DMR runs locally by default; include it when not using a gateway
 		usableProviders = append(usableProviders, "dmr")

--- a/pkg/model/provider/openrouter/adapter.go
+++ b/pkg/model/provider/openrouter/adapter.go
@@ -1,0 +1,12 @@
+package openrouter
+
+import (
+	"github.com/sashabaranov/go-openai"
+
+	"github.com/docker/cagent/pkg/chat"
+	"github.com/docker/cagent/pkg/model/provider/oaistream"
+)
+
+func newStreamAdapter(stream *openai.ChatCompletionStream) chat.MessageStream {
+	return oaistream.NewStreamAdapter(stream)
+}

--- a/pkg/model/provider/openrouter/client.go
+++ b/pkg/model/provider/openrouter/client.go
@@ -1,0 +1,200 @@
+package openrouter
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	openai "github.com/sashabaranov/go-openai"
+
+	"github.com/docker/cagent/pkg/chat"
+	latest "github.com/docker/cagent/pkg/config/v2"
+	"github.com/docker/cagent/pkg/environment"
+	"github.com/docker/cagent/pkg/model/provider/options"
+	"github.com/docker/cagent/pkg/tools"
+)
+
+// Client implements the provider for OpenRouter using the OpenAI-compatible SDK.
+// OpenRouter speaks the OpenAI Chat Completions API with a different base URL
+// and requires the OPENROUTER_API_KEY header.
+// Docs: https://openrouter.ai/docs#chat-completions
+
+type Client struct {
+	client *openai.Client
+	config *latest.ModelConfig
+}
+
+func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Provider, opts ...options.Opt) (*Client, error) {
+	if cfg == nil {
+		return nil, errors.New("model configuration is required")
+	}
+	if cfg.Provider != "openrouter" {
+		return nil, errors.New("model type must be 'openrouter'")
+	}
+
+	apiKey := env.Get(ctx, "OPENROUTER_API_KEY")
+	if apiKey == "" {
+		return nil, errors.New("OPENROUTER_API_KEY environment variable is required")
+	}
+
+	// OpenRouter is OpenAI-compatible at base URL https://openrouter.ai/api/v1
+	cfgURL := cfg.BaseURL
+	if strings.TrimSpace(cfgURL) == "" {
+		cfgURL = "https://openrouter.ai/api/v1"
+	}
+
+	oc := openai.DefaultConfig(apiKey)
+	oc.BaseURL = cfgURL
+	// OpenRouter requires HTTP header: HTTP-Referer (optional) and X-Title (optional).
+	// The go-openai client allows custom headers via a custom http.Client Transport.
+	// We'll attach X-Title if provided via cfg.ProviderOpts["x_title"].
+	if cfg.ProviderOpts != nil {
+		if v, ok := cfg.ProviderOpts["x_title"].(string); ok && v != "" {
+			oc.HTTPClient = withHeader(oc.HTTPClient, map[string]string{"X-Title": v})
+		}
+		if v, ok := cfg.ProviderOpts["http_referer"].(string); ok && v != "" {
+			oc.HTTPClient = withHeader(oc.HTTPClient, map[string]string{"HTTP-Referer": v})
+		}
+	}
+
+	client := openai.NewClientWithConfig(oc)
+	return &Client{client: client, config: cfg}, nil
+}
+
+func withHeader(base openai.HTTPDoer, add map[string]string) openai.HTTPDoer {
+	if base == nil {
+		base = http.DefaultClient
+	}
+	return headerDoer{base: base, add: add}
+}
+
+type headerDoer struct {
+	base openai.HTTPDoer
+	add  map[string]string
+}
+
+func (h headerDoer) Do(req *http.Request) (*http.Response, error) {
+	for k, v := range h.add {
+		if req.Header.Get(k) == "" {
+			req.Header.Set(k, v)
+		}
+	}
+	return h.base.Do(req)
+}
+
+func (c *Client) CreateChatCompletionStream(
+	ctx context.Context,
+	messages []chat.Message,
+	requestTools []tools.Tool,
+) (chat.MessageStream, error) {
+	slog.Debug("Creating OpenRouter chat completion stream",
+		"model", c.config.Model,
+		"message_count", len(messages),
+		"tool_count", len(requestTools))
+
+	if len(messages) == 0 {
+		return nil, errors.New("at least one message is required")
+	}
+
+	req := openai.ChatCompletionRequest{
+		Model:            c.config.Model,
+		Messages:         convertMessages(messages),
+		Temperature:      float32(c.config.Temperature),
+		TopP:             float32(c.config.TopP),
+		FrequencyPenalty: float32(c.config.FrequencyPenalty),
+		PresencePenalty:  float32(c.config.PresencePenalty),
+		Stream:           true,
+		StreamOptions:    &openai.StreamOptions{IncludeUsage: true},
+	}
+	if c.config.MaxTokens > 0 {
+		req.MaxTokens = c.config.MaxTokens
+	}
+	if len(requestTools) > 0 {
+		req.Tools = make([]openai.Tool, len(requestTools))
+		for i, tool := range requestTools {
+			req.Tools[i] = openai.Tool{
+				Type: openai.ToolTypeFunction,
+				Function: &openai.FunctionDefinition{
+					Name:        tool.Function.Name,
+					Description: tool.Function.Description,
+					Strict:      tool.Function.Strict,
+					Parameters:  tool.Function.Parameters,
+				},
+			}
+			if len(tool.Function.Parameters.Properties) == 0 {
+				req.Tools[i].Function.Parameters = json.RawMessage("{}")
+			}
+		}
+		if c.config.ParallelToolCalls != nil {
+			req.ParallelToolCalls = *c.config.ParallelToolCalls
+		}
+	}
+
+	stream, err := c.client.CreateChatCompletionStream(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return newStreamAdapter(stream), nil
+}
+
+func (c *Client) CreateChatCompletion(
+	ctx context.Context,
+	messages []chat.Message,
+) (string, error) {
+	req := openai.ChatCompletionRequest{
+		Model:    c.config.Model,
+		Messages: convertMessages(messages),
+	}
+	if c.config.MaxTokens > 0 {
+		req.MaxTokens = c.config.MaxTokens
+	}
+	resp, err := c.client.CreateChatCompletion(ctx, req)
+	if err != nil {
+		return "", err
+	}
+	return resp.Choices[0].Message.Content, nil
+}
+
+func (c *Client) ID() string { return c.config.Provider + "/" + c.config.Model }
+
+func convertMessages(messages []chat.Message) []openai.ChatCompletionMessage {
+	openaiMessages := make([]openai.ChatCompletionMessage, len(messages))
+	for i := range messages {
+		msg := &messages[i]
+		m := openai.ChatCompletionMessage{Role: string(msg.Role), Name: msg.Name}
+		if len(msg.MultiContent) == 0 {
+			m.Content = msg.Content
+		} else {
+			m.MultiContent = convertMultiContent(msg.MultiContent)
+		}
+		if msg.FunctionCall != nil {
+			m.FunctionCall = &openai.FunctionCall{Name: msg.FunctionCall.Name, Arguments: msg.FunctionCall.Arguments}
+		}
+		if len(msg.ToolCalls) > 0 {
+			m.ToolCalls = make([]openai.ToolCall, len(msg.ToolCalls))
+			for j, tc := range msg.ToolCalls {
+				m.ToolCalls[j] = openai.ToolCall{ID: tc.ID, Type: openai.ToolType(tc.Type), Function: openai.FunctionCall{Name: tc.Function.Name, Arguments: tc.Function.Arguments}}
+			}
+		}
+		if msg.ToolCallID != "" {
+			m.ToolCallID = msg.ToolCallID
+		}
+		openaiMessages[i] = m
+	}
+	return openaiMessages
+}
+
+func convertMultiContent(multiContent []chat.MessagePart) []openai.ChatMessagePart {
+	out := make([]openai.ChatMessagePart, len(multiContent))
+	for i, part := range multiContent {
+		p := openai.ChatMessagePart{Type: openai.ChatMessagePartType(part.Type), Text: part.Text}
+		if part.Type == chat.MessagePartTypeImageURL && part.ImageURL != nil {
+			p.ImageURL = &openai.ChatMessageImageURL{URL: part.ImageURL.URL, Detail: openai.ImageURLDetail(part.ImageURL.Detail)}
+		}
+		out[i] = p
+	}
+	return out
+}

--- a/pkg/model/provider/openrouter/client_test.go
+++ b/pkg/model/provider/openrouter/client_test.go
@@ -1,0 +1,35 @@
+package openrouter
+
+import (
+	"testing"
+
+	"github.com/docker/cagent/pkg/chat"
+)
+
+func TestConvertMessages_Basic(t *testing.T) {
+	msgs := []chat.Message{{Role: chat.MessageRoleUser, Content: "hi"}}
+	out := convertMessages(msgs)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(out))
+	}
+	if out[0].Role != "user" || out[0].Content != "hi" {
+		t.Fatalf("unexpected conversion: %+v", out[0])
+	}
+}
+
+func TestConvertMultiContent_ImageURL(t *testing.T) {
+	msgs := []chat.Message{{
+		Role: chat.MessageRoleUser,
+		MultiContent: []chat.MessagePart{
+			{Type: chat.MessagePartTypeText, Text: "hello"},
+			{Type: chat.MessagePartTypeImageURL, ImageURL: &chat.MessageImageURL{URL: "http://example.com/img.png", Detail: "high"}},
+		},
+	}} 
+	out := convertMessages(msgs)
+	if len(out) != 1 {
+		t.Fatalf("expected 1, got %d", len(out))
+	}
+	if len(out[0].MultiContent) != 2 {
+		t.Fatalf("expected 2 parts, got %d", len(out[0].MultiContent))
+	}
+}

--- a/pkg/model/provider/provider.go
+++ b/pkg/model/provider/provider.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/cagent/pkg/model/provider/dmr"
 	"github.com/docker/cagent/pkg/model/provider/gemini"
 	"github.com/docker/cagent/pkg/model/provider/openai"
+	"github.com/docker/cagent/pkg/model/provider/openrouter"
 	"github.com/docker/cagent/pkg/model/provider/options"
 	"github.com/docker/cagent/pkg/tools"
 )
@@ -40,6 +41,9 @@ func New(ctx context.Context, cfg *latest.ModelConfig, env environment.Provider,
 	switch cfg.Provider {
 	case "openai":
 		return openai.NewClient(ctx, cfg, env, opts...)
+
+	case "openrouter":
+		return openrouter.NewClient(ctx, cfg, env, opts...)
 
 	case "anthropic":
 		return anthropic.NewClient(ctx, cfg, env, opts...)


### PR DESCRIPTION
Summary
- Add OpenRouter provider and integrate with agent/CLI.

Details
- Add OpenRouter provider:
  - pkg/model/provider/openrouter/adapter.go
  - pkg/model/provider/openrouter/client.go
  - pkg/model/provider/openrouter/client_test.go
- Register OpenRouter in provider registry (pkg/model/provider/provider.go)
- Update agent creation (internal/creator/agent.go)
- Update CLI `new` command (cmd/root/new.go)
- Update documentation (README.md)
