### PR TITLE
Make tracking usage disable-able.

### DIFF
--- a/pkg/config/v2/types.go
+++ b/pkg/config/v2/types.go
@@ -37,6 +37,7 @@ type ModelConfig struct {
 	TokenKey          string  `json:"token_key,omitempty" yaml:"token_key,omitempty"`
 	// ProviderOpts allows provider-specific options. Currently used for "dmr" provider only.
 	ProviderOpts map[string]any `json:"provider_opts,omitempty" yaml:"provider_opts,omitempty"`
+	TrackUsage   *bool          `json:"track_usage,omitempty" yaml:"track_usage,omitempty"`
 }
 
 type Metadata struct {

--- a/pkg/model/provider/dmr/adapter.go
+++ b/pkg/model/provider/dmr/adapter.go
@@ -8,6 +8,6 @@ import (
 )
 
 // newStreamAdapter returns the shared OpenAI stream adapter implementation
-func newStreamAdapter(stream *openai.ChatCompletionStream) chat.MessageStream {
-	return oaistream.NewStreamAdapter(stream)
+func newStreamAdapter(stream *openai.ChatCompletionStream, trackUsage bool) chat.MessageStream {
+	return oaistream.NewStreamAdapter(stream, trackUsage)
 }

--- a/pkg/model/provider/dmr/client.go
+++ b/pkg/model/provider/dmr/client.go
@@ -291,6 +291,11 @@ func (c *Client) CreateChatCompletionStream(
 		return nil, errors.New("at least one message is required")
 	}
 
+	trackUsage := true
+	if c.config.TrackUsage != nil && *c.config.TrackUsage == false {
+		trackUsage = false
+	}
+
 	request := openai.ChatCompletionRequest{
 		Model:            c.config.Model,
 		Messages:         convertMessages(messages),
@@ -300,7 +305,7 @@ func (c *Client) CreateChatCompletionStream(
 		PresencePenalty:  float32(c.config.PresencePenalty),
 		Stream:           true,
 		StreamOptions: &openai.StreamOptions{
-			IncludeUsage: true,
+			IncludeUsage: trackUsage,
 		},
 	}
 
@@ -356,7 +361,7 @@ func (c *Client) CreateChatCompletionStream(
 	}
 
 	slog.Debug("DMR chat completion stream created successfully", "model", c.config.Model)
-	return newStreamAdapter(stream), nil
+	return newStreamAdapter(stream, trackUsage), nil
 }
 
 func (c *Client) CreateChatCompletion(

--- a/pkg/model/provider/oaistream/adapter.go
+++ b/pkg/model/provider/oaistream/adapter.go
@@ -16,12 +16,14 @@ type StreamAdapter struct {
 	stream           *openai.ChatCompletionStream
 	lastFinishReason chat.FinishReason
 	toolCalls        map[int]string
+	trackUsage       bool
 }
 
-func NewStreamAdapter(stream *openai.ChatCompletionStream) *StreamAdapter {
+func NewStreamAdapter(stream *openai.ChatCompletionStream, trackUsage bool) *StreamAdapter {
 	return &StreamAdapter{
-		stream:    stream,
-		toolCalls: make(map[int]string),
+		stream:     stream,
+		toolCalls:  make(map[int]string),
+		trackUsage: trackUsage,
 	}
 }
 
@@ -64,7 +66,7 @@ func (a *StreamAdapter) Recv() (chat.MessageStreamResponse, error) {
 	// Convert the choices
 	for i := range openaiResponse.Choices {
 		choice := &openaiResponse.Choices[i]
-		if choice.FinishReason == openai.FinishReasonStop {
+		if a.trackUsage && choice.FinishReason == openai.FinishReasonStop {
 			choice.FinishReason = openai.FinishReasonNull
 		}
 

--- a/pkg/model/provider/openai/adapter.go
+++ b/pkg/model/provider/openai/adapter.go
@@ -8,6 +8,6 @@ import (
 )
 
 // newStreamAdapter returns the shared OpenAI stream adapter implementation
-func newStreamAdapter(stream *openai.ChatCompletionStream) chat.MessageStream {
-	return oaistream.NewStreamAdapter(stream)
+func newStreamAdapter(stream *openai.ChatCompletionStream, trackUsage bool) chat.MessageStream {
+	return oaistream.NewStreamAdapter(stream, trackUsage)
 }

--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -200,6 +200,12 @@ func (c *Client) CreateChatCompletionStream(
 		return nil, errors.New("at least one message is required")
 	}
 
+	trackUsage := true
+
+	if c.config.TrackUsage != nil && *c.config.TrackUsage == false {
+		trackUsage = false
+	}
+
 	request := openai.ChatCompletionRequest{
 		Model:            c.config.Model,
 		Messages:         convertMessages(messages),
@@ -209,7 +215,7 @@ func (c *Client) CreateChatCompletionStream(
 		PresencePenalty:  float32(c.config.PresencePenalty),
 		Stream:           true,
 		StreamOptions: &openai.StreamOptions{
-			IncludeUsage: true,
+			IncludeUsage: trackUsage,
 		},
 	}
 
@@ -273,7 +279,7 @@ func (c *Client) CreateChatCompletionStream(
 	}
 
 	slog.Debug("OpenAI chat completion stream created successfully", "model", c.config.Model)
-	return newStreamAdapter(stream), nil
+	return newStreamAdapter(stream, trackUsage), nil
 }
 
 func (c *Client) CreateChatCompletion(


### PR DESCRIPTION
Gloo's API is OpenAI compatible, except it doesn't report usage. There's a bug where cagent keeps looping when usage reporting isn't given. This offers a workaround by disabling usage tracking.

Verified OpenAI works with or without usage tracking.