### PR TITLE
Use latest or tag when building image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
         with:
           images: docker/cagent
           tags: |
-            type=ref,event=branch
+            type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=tag
 
       - name: Build and push image


### PR DESCRIPTION
 1. Replaced type=ref,event=branch with
  type=raw,value=latest,enable={{is_default_branch}}
    - This will tag builds from the main branch (default
  branch) as "latest" instead of "main"
  2. Kept type=ref,event=tag
    - This ensures version tag builds (like v1.0.0) are tagged
  with their actual tag name

  Now when:
  - Building from the main branch → image will be tagged as
  latest
  - Building from a version tag like v1.0.0 → image will be
  tagged as v1.0.0