### PR TITLE
Improve labels set on cagent build images

### DIFF
--- a/pkg/oci/Dockerfile.template
+++ b/pkg/oci/Dockerfile.template
@@ -1,12 +1,23 @@
 # syntax=docker/dockerfile:1
 
 FROM docker/cagent
-LABEL com.docker.agent.packaging.version="v0.0.1"
-LABEL com.docker.agent.runtime="cagent"
-LABEL org.opencontainers.image.description="{{ .Description }}"
-LABEL org.opencontainers.image.licenses="{{ .Licenses }}"
 LABEL com.docker.agent.mcp-servers="{{ .McpServers }}"
 LABEL com.docker.agent.models="{{ .Models }}"
+LABEL com.docker.agent.packaging.version="v0.0.1"
+LABEL com.docker.agent.runtime="cagent"
+LABEL org.opencontainers.image.author="{{ .Metadata.Author }}"
+LABEL org.opencontainers.image.created="{{ .BuildDate }}"
+LABEL org.opencontainers.image.description="{{ .Description }}"
+LABEL org.opencontainers.image.documentation="{{ .Metadata.Readme }}"
+LABEL org.opencontainers.image.licenses="{{ .Metadata.License }}"
+
+# Override labels found in docker/cagent until we know what to put there
+LABEL org.opencontainers.image.revision=""
+LABEL org.opencontainers.image.source=""
+LABEL org.opencontainers.image.title=""
+LABEL org.opencontainers.image.url=""
+LABEL org.opencontainers.image.version=""
+
 VOLUME /data
 CMD ["api", "--session-db", "/data/session.db", "/agent.yaml"]
 RUN cat <<EOF >/agent.yaml

--- a/pkg/oci/build.go
+++ b/pkg/oci/build.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/docker/cagent/pkg/config"
 )
@@ -41,9 +42,10 @@ func BuildDockerImage(ctx context.Context, agentFilePath, dockerImageName string
 	tpl := template.Must(template.New("Dockerfile").Parse(dockerfileTemplate))
 	if err := tpl.Execute(&dockerfileBuf, map[string]any{
 		"AgentConfig": string(agentYaml),
+		"BuildDate":   time.Now().UTC().Format(time.RFC3339),
 		"Description": cfg.Agents["root"].Description,
-		"Licenses":    cfg.Metadata.License,
 		"McpServers":  strings.Join(mcpServers, ","),
+		"Metadata":    cfg.Metadata,
 		"Models":      strings.Join(modelNames, ","),
 	}); err != nil {
 		return err


### PR DESCRIPTION
`cagent build ./developer.yaml`

With this yaml

```
#!/usr/bin/env cagent run
version: "2"

metadata:
  author: Docker Inc.
  license: MIT
  readme: This is an example of a developer agent.

agents:
  root:
    model: anthropic/claude-sonnet-4-0
    description: Developer
    instruction: |
      * Always use the `get_me` tool to get user info from GitHub.
      * Always use the `brave_web_search` tool to search the Web.
    toolsets:
      - type: mcp
        ref: docker:github-official
        tools:
          - get_me
      - type: mcp
        ref: docker:brave
        tools:
          - brave_web_search
```

Gives those labels

```
"com.docker.agent.mcp-servers": "docker:brave,docker:github-official",
"com.docker.agent.models": "anthropic/claude-sonnet-4-0",
"com.docker.agent.packaging.version": "v0.0.1",
"com.docker.agent.runtime": "cagent",
"org.opencontainers.image.author": "Docker Inc.",
"org.opencontainers.image.created": "2025-09-12T08:52:51Z",
"org.opencontainers.image.description": "Developer",
"org.opencontainers.image.documentation": "This is an example of a developer agent.",
"org.opencontainers.image.licenses": "MIT",
"org.opencontainers.image.revision": "",
"org.opencontainers.image.source": "",
"org.opencontainers.image.title": "",
"org.opencontainers.image.url": "",
"org.opencontainers.image.version": ""
```