### PR TITLE
dockerfile: use cross-comp target to avoid emulation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,8 +98,8 @@ jobs:
           TELEMETRY_HEADER: ${{ secrets.TELEMETRY_HEADER }}
 
   build-image:
-    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
-    needs: [build]
+    needs:
+      - build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -124,8 +124,9 @@ jobs:
         with:
           images: docker/cagent
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=edge
+            type=ref,event=pr
 
       - name: Build and push image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,7 @@ FROM scratch AS cross
 COPY --from=builder /binaries .
 
 FROM alpine:3.22@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1
-COPY --from=build-agent /agent /cagent
+ARG TARGETOS TARGETARCH
+COPY --from=builder /binaries/cagent-$TARGETOS-$TARGETARCH /cagent
 RUN mkdir /data
 ENTRYPOINT ["/cagent"]


### PR DESCRIPTION
relates to https://github.com/docker/cagent/actions/runs/17650827920/job/50161382814

`build-agent` does not use cross compilation so build is done through emulation when building in GitHub Actions for `linux/arm64` architecture. Changed to use `builder` one instead.

Also update workflow to run `build` job on pull request without push to make sure there is no regression with this target.

Before it took ~19m to build:

<img width="309" height="92" alt="image" src="https://github.com/user-attachments/assets/0d19ef00-dd6c-4e4f-bca8-03ae7029856c" />

Now ~2m: https://github.com/docker/cagent/actions/runs/17671685388/job/50224866246?pr=179

<img width="293" height="93" alt="image" src="https://github.com/user-attachments/assets/899748d0-efed-4c07-831c-5afa2df912ae" />

Will open follow-ups to consolidate things in the Dockerfile.

cc @jeanlaurent