### PR TITLE
Use Oauth for remote client if needed

### DIFF
--- a/cmd/root/api.go
+++ b/cmd/root/api.go
@@ -96,6 +96,7 @@ func runHttp(cmd *cobra.Command, autoRunTools bool, args []string) error {
 		opts = append(opts, server.WithAutoRunTools(true))
 	}
 
+	runConfig.RedirectURI = redirectURI
 	s := server.New(sessionStore, runConfig, teams, opts...)
 	return s.Serve(ctx, ln)
 }

--- a/pkg/config/runtime.go
+++ b/pkg/config/runtime.go
@@ -4,4 +4,5 @@ type RuntimeConfig struct {
 	EnvFiles      []string
 	ModelsGateway string
 	ToolsGateway  string
+	RedirectURI   string
 }

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -155,7 +155,7 @@ func Load(ctx context.Context, path string, runtimeConfig config.RuntimeConfig) 
 		if !ok {
 			return nil, fmt.Errorf("agent '%s' not found in configuration", name)
 		}
-		agentTools, err := getToolsForAgent(ctx, &a, parentDir, sharedTools, models[0], env)
+		agentTools, err := getToolsForAgent(ctx, &a, parentDir, sharedTools, models[0], env, runtimeConfig)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get tools: %w", err)
 		}
@@ -209,7 +209,7 @@ func getModelsForAgent(ctx context.Context, cfg *latest.Config, a *latest.AgentC
 }
 
 // getToolsForAgent returns the tool definitions for an agent based on its configuration
-func getToolsForAgent(ctx context.Context, a *latest.AgentConfig, parentDir string, sharedTools map[string]tools.ToolSet, model provider.Provider, envProvider environment.Provider) ([]tools.ToolSet, error) {
+func getToolsForAgent(ctx context.Context, a *latest.AgentConfig, parentDir string, sharedTools map[string]tools.ToolSet, model provider.Provider, envProvider environment.Provider, runtimeConfig config.RuntimeConfig) ([]tools.ToolSet, error) {
 	var t []tools.ToolSet
 
 	if len(a.SubAgents) > 0 {
@@ -307,7 +307,7 @@ func getToolsForAgent(ctx context.Context, a *latest.AgentConfig, parentDir stri
 				headers[k] = expanded
 			}
 
-			mcpc, err := mcp.NewToolsetRemote(toolset.Remote.URL, toolset.Remote.TransportType, headers, toolset.Tools)
+			mcpc, err := mcp.NewToolsetRemote(toolset.Remote.URL, toolset.Remote.TransportType, headers, toolset.Tools, runtimeConfig.RedirectURI)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create remote mcp client: %w", err)
 			}

--- a/pkg/tools/mcp/gateway.go
+++ b/pkg/tools/mcp/gateway.go
@@ -51,7 +51,7 @@ func (t *GatewayToolset) configureOnce(ctx context.Context) error {
 	if environment.IsInContainer() {
 		var err error
 		// TODO(dga): This is very temporary. Make the URL configurable.
-		t.cmdToolset, err = NewToolsetRemote("http://gateway:8811", "streaming", nil, t.toolFilter)
+		t.cmdToolset, err = NewToolsetRemote("http://gateway:8811", "streaming", nil, t.toolFilter, "")
 		if err != nil {
 			return fmt.Errorf("creating remote MCP toolset: %w", err)
 		}

--- a/pkg/tools/mcp/remote.go
+++ b/pkg/tools/mcp/remote.go
@@ -3,29 +3,86 @@ package mcp
 import (
 	"fmt"
 	"log/slog"
+	"net/http"
+	"strings"
 
 	"github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/client/transport"
 )
 
+// detectOAuthRequirement checks if the server requires OAuth authentication
+// by making a test request and checking for WWW-Authenticate header.
+// See https://modelcontextprotocol.io/specification/draft/basic/authorization#authorization-server-location.
+func detectOAuthRequirement(url string) bool {
+	req, err := http.NewRequest(http.MethodGet, url, http.NoBody)
+	if err != nil {
+		slog.Debug("Failed to create test request for OAuth detection", "error", err)
+		return false
+	}
+
+	httpClient := &http.Client{}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		slog.Debug("Failed to make test request for OAuth detection", "error", err)
+		return false
+	}
+	defer resp.Body.Close()
+
+	wwwAuth := resp.Header.Get("WWW-Authenticate")
+	if wwwAuth != "" {
+		slog.Debug("Detected OAuth requirement", "www-authenticate", wwwAuth)
+		return strings.Contains(strings.ToLower(wwwAuth), "bearer") ||
+			strings.Contains(strings.ToLower(wwwAuth), "oauth")
+	}
+
+	return false
+}
+
 // NewRemoteClient creates a new MCP client that can connect to a remote MCP server
-func NewRemoteClient(url, transportType string, headers map[string]string) (*Client, error) {
-	slog.Debug("Creating remote MCP client", "url", url, "transport", transportType, "headers", headers)
+func NewRemoteClient(url, transportType string, headers map[string]string, redirectURI string) (*Client, error) {
+	slog.Debug("Creating remote MCP client", "url", url, "transport", transportType, "headers", headers, "redirectURI", redirectURI)
+
+	// Detect if the server requires OAuth authentication
+	requiresOAuth := detectOAuthRequirement(url)
 
 	var c *client.Client
-	if transportType == "sse" {
-		var err error
-		c, err = client.NewSSEMCPClient(url, client.WithHeaders(headers))
-		if err != nil {
-			slog.Error("Failed to create sse remote MCP client", "error", err)
-			return nil, fmt.Errorf("failed to create sse remote MCP client: %w", err)
+	var err error
+
+	if requiresOAuth {
+		tokenStore := client.NewMemoryTokenStore()
+
+		oauthConfig := client.OAuthConfig{
+			RedirectURI: redirectURI,
+			TokenStore:  tokenStore,
+			PKCEEnabled: true,
+		}
+
+		if transportType == "sse" {
+			c, err = client.NewOAuthSSEClient(url, oauthConfig)
+			if err != nil {
+				slog.Error("Failed to create OAuth SSE remote MCP client", "error", err)
+				return nil, fmt.Errorf("failed to create OAuth SSE remote MCP client: %w", err)
+			}
+		} else {
+			c, err = client.NewOAuthStreamableHttpClient(url, oauthConfig)
+			if err != nil {
+				slog.Error("Failed to create OAuth streamable remote MCP client", "error", err)
+				return nil, fmt.Errorf("failed to create OAuth streamable remote MCP client: %w", err)
+			}
 		}
 	} else {
-		var err error
-		c, err = client.NewStreamableHttpClient(url, transport.WithHTTPHeaders(headers))
-		if err != nil {
-			slog.Error("Failed to create streamable remote MCP client", "error", err)
-			return nil, fmt.Errorf("failed to create streamable remote MCP client: %w", err)
+		if transportType == "sse" {
+			c, err = client.NewSSEMCPClient(url, client.WithHeaders(headers))
+			if err != nil {
+				slog.Error("Failed to create sse remote MCP client", "error", err)
+				return nil, fmt.Errorf("failed to create sse remote MCP client: %w", err)
+			}
+		} else {
+			c, err = client.NewStreamableHttpClient(url, transport.WithHTTPHeaders(headers))
+			if err != nil {
+				slog.Error("Failed to create streamable remote MCP client", "error", err)
+				return nil, fmt.Errorf("failed to create streamable remote MCP client: %w", err)
+			}
 		}
 	}
 

--- a/pkg/tools/mcp/toolset.go
+++ b/pkg/tools/mcp/toolset.go
@@ -29,10 +29,10 @@ func NewToolsetCommand(command string, args, env, toolFilter []string) *Toolset 
 }
 
 // NewToolsetRemote creates a new MCP toolset from a remote MCP Server.
-func NewToolsetRemote(url, transport string, headers map[string]string, toolFilter []string) (*Toolset, error) {
-	slog.Debug("Creating Remote MCP toolset", "url", url, "transport", transport, "headers", headers, "toolFilter", toolFilter)
+func NewToolsetRemote(url, transport string, headers map[string]string, toolFilter []string, redirectURI string) (*Toolset, error) {
+	slog.Debug("Creating Remote MCP toolset", "url", url, "transport", transport, "headers", headers, "toolFilter", toolFilter, "redirectURI", redirectURI)
 
-	mcpc, err := NewRemoteClient(url, transport, headers)
+	mcpc, err := NewRemoteClient(url, transport, headers, redirectURI)
 	if err != nil {
 		slog.Error("Failed to create remote MCP client", "error", err)
 		return nil, fmt.Errorf("failed to create remote mcp client: %w", err)


### PR DESCRIPTION
Automatically detects OAuth requirement via WWW-Authenticate header and uses PKCE flow with configurable redirect URI for secure authentication.