### PR TITLE
ci: add concurrency check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
-name: CI
+name: ci
+
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
add concurrency check in our workflows to ensure that only a single workflow using the same concurrency group will run at a time. it allows to reduce job build queue in our pipeline.

more info: https://docs.github.com/en/actions/using-jobs/using-concurrency