### PR TITLE
ci: switch to official go-task/setup-task action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,8 @@ jobs:
           cache: true
 
       - name: Install Task
-        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+        uses: go-task/setup-task@0ab1b2a65bc55236a3bc64cde78f80e20e8885c2 # v1.0.0
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
 
       - name: Run tests
@@ -90,9 +89,8 @@ jobs:
           cache: true
 
       - name: Install Task
-        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+        uses: go-task/setup-task@0ab1b2a65bc55236a3bc64cde78f80e20e8885c2 # v1.0.0
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
 
       - name: Build


### PR DESCRIPTION
relates to https://github.com/docker/cagent/actions/runs/17732917618/job/50387829235#step:4:6

<img width="671" height="148" alt="image" src="https://github.com/user-attachments/assets/ff7dafd9-8a93-4f9b-b16c-b9501b111091" />

switch to https://github.com/go-task/setup-task