### PR TITLE
Fix summarization provider config

### DIFF
--- a/pkg/model/provider/anthropic/client.go
+++ b/pkg/model/provider/anthropic/client.go
@@ -189,6 +189,15 @@ func (c *Client) CreateChatCompletion(
 	return response.Content[0].Text, nil
 }
 
+// Config returns a copy of the model configuration
+func (c *Client) Config() *latest.ModelConfig {
+	if c == nil || c.config == nil {
+		return nil
+	}
+	configCopy := *c.config
+	return &configCopy
+}
+
 func convertMessages(messages []chat.Message) []anthropic.MessageParam {
 	var anthropicMessages []anthropic.MessageParam
 

--- a/pkg/model/provider/dmr/client.go
+++ b/pkg/model/provider/dmr/client.go
@@ -391,6 +391,15 @@ func (c *Client) CreateChatCompletion(
 	return response.Choices[0].Message.Content, nil
 }
 
+// Config returns a copy of the model configuration
+func (c *Client) Config() *latest.ModelConfig {
+	if c == nil || c.config == nil {
+		return nil
+	}
+	configCopy := *c.config
+	return &configCopy
+}
+
 // sanitizeToolParameters ensures the tool parameter schema is safe for engines using Jinja-like templates.
 // In particular, it avoids shadowing built-in mapping methods like `keys()` by removing a literal "keys"
 // field from property schemas if present, and guarantees the outer structure is an object with a properties map.

--- a/pkg/model/provider/gemini/client.go
+++ b/pkg/model/provider/gemini/client.go
@@ -222,6 +222,15 @@ func (c *Client) buildConfig() *genai.GenerateContentConfig {
 	return config
 }
 
+// Config returns a copy of the model configuration
+func (c *Client) Config() *latest.ModelConfig {
+	if c == nil || c.config == nil {
+		return nil
+	}
+	configCopy := *c.config
+	return &configCopy
+}
+
 // convertToolsToGemini converts tools to Gemini format
 func convertToolsToGemini(requestTools []tools.Tool) []*genai.Tool {
 	if len(requestTools) == 0 {

--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -332,6 +332,15 @@ func (c *Client) CreateChatCompletion(
 	return response.Choices[0].Message.Content, nil
 }
 
+// Config returns a copy of the model configuration
+func (c *Client) Config() *latest.ModelConfig {
+	if c == nil || c.config == nil {
+		return nil
+	}
+	configCopy := *c.config
+	return &configCopy
+}
+
 // isResponsesOnlyModel returns true for newer OpenAI models that use the Responses API
 // and expect max_completion_tokens/max_output_tokens instead of max_tokens
 func isResponsesOnlyModel(model string) bool {

--- a/pkg/model/provider/provider.go
+++ b/pkg/model/provider/provider.go
@@ -52,6 +52,9 @@ type Provider interface {
 		ctx context.Context,
 		messages []chat.Message,
 	) (string, error)
+
+	// Config returns a copy of the model configuration
+	Config() *latest.ModelConfig
 }
 
 func New(ctx context.Context, cfg *latest.ModelConfig, env environment.Provider, opts ...options.Opt) (Provider, error) {


### PR DESCRIPTION
This change configures the summarization model to have a higher max token count then the original model configuration.

If a model hits the configured max_tokens limit while streaming its response to the user, when we then try to summarize the session right after we might hit the exact same limit and get no summary (especially with non-thinking models, since when they return we'll have a thread that's already at the max_tokens limit).

The issue is less noticeable with thinking models (e.g. gpt-5 family) because the API doesn't return to us all the thinking tokens that the model has consumed, so subsequent responses will have some wiggle room in the configured max_tokens

Closes #138