### PR TITLE
Implement per-URL token stores for MCP tools

### DIFF
--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -319,7 +319,7 @@ func getToolsForAgent(ctx context.Context, a *latest.AgentConfig, parentDir stri
 				headers[k] = expanded
 			}
 
-			mcpc, err := mcp.NewToolsetRemote(toolset.Remote.URL, toolset.Remote.TransportType, headers, toolset.Tools, runtimeConfig.RedirectURI, mcp.GetGlobalTokenStore())
+			mcpc, err := mcp.NewToolsetRemote(toolset.Remote.URL, toolset.Remote.TransportType, headers, toolset.Tools, runtimeConfig.RedirectURI)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create remote mcp client: %w", err)
 			}

--- a/pkg/tools/mcp/gateway.go
+++ b/pkg/tools/mcp/gateway.go
@@ -52,7 +52,7 @@ func (t *GatewayToolset) Instructions() string {
 func (t *GatewayToolset) configureOnce(ctx context.Context) error {
 	if mcpGatewayURL := os.Getenv(DOCKER_MCP_GATEWAY_URL_ENV); mcpGatewayURL != "" {
 		var err error
-		t.cmdToolset, err = NewToolsetRemote(mcpGatewayURL, "streaming", nil, t.toolFilter, "", GetGlobalTokenStore())
+		t.cmdToolset, err = NewToolsetRemote(mcpGatewayURL, "streaming", nil, t.toolFilter, "")
 		if err != nil {
 			return fmt.Errorf("connecting to remote MCP Gateway: %w", err)
 		}

--- a/pkg/tools/mcp/remote.go
+++ b/pkg/tools/mcp/remote.go
@@ -5,25 +5,10 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
-	"sync"
 
 	"github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/client/transport"
 )
-
-var (
-	globalTokenStore client.TokenStore
-	tokenStoreOnce   sync.Once
-)
-
-// GetGlobalTokenStore returns the global tokenStore instance, creating it if necessary
-func GetGlobalTokenStore() client.TokenStore {
-	tokenStoreOnce.Do(func() {
-		globalTokenStore = client.NewMemoryTokenStore()
-		slog.Debug("Created global tokenStore")
-	})
-	return globalTokenStore
-}
 
 // detectOAuthRequirement checks if the server requires OAuth authentication
 // by making a test request and checking for WWW-Authenticate header.

--- a/pkg/tools/mcp/remote_test.go
+++ b/pkg/tools/mcp/remote_test.go
@@ -1,0 +1,63 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/mark3labs/mcp-go/client"
+)
+
+func TestGlobalTokenManager(t *testing.T) {
+	// Test that different URLs get different token stores
+	url1 := "http://example1.com"
+	url2 := "http://example2.com"
+
+	store1 := GetTokenStore(url1)
+	store2 := GetTokenStore(url2)
+
+	// They should be different instances
+	if store1 == store2 {
+		t.Error("Expected different token stores for different URLs")
+	}
+
+	// Test that same URL returns same token store
+	store1Again := GetTokenStore(url1)
+	if store1 != store1Again {
+		t.Error("Expected same token store for same URL")
+	}
+
+	// Verify they are actual MemoryTokenStore instances
+	if _, ok := store1.(*client.MemoryTokenStore); !ok {
+		t.Error("Expected store1 to be a MemoryTokenStore")
+	}
+	if _, ok := store2.(*client.MemoryTokenStore); !ok {
+		t.Error("Expected store2 to be a MemoryTokenStore")
+	}
+}
+
+func TestGlobalTokenManagerConcurrency(t *testing.T) {
+	url := "http://concurrent-test.com"
+
+	// Test concurrent access
+	done := make(chan bool, 10)
+	stores := make([]client.TokenStore, 10)
+
+	for i := 0; i < 10; i++ {
+		go func(index int) {
+			stores[index] = GetTokenStore(url)
+			done <- true
+		}(i)
+	}
+
+	// Wait for all goroutines to complete
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+
+	// All stores should be the same instance
+	firstStore := stores[0]
+	for i := 1; i < 10; i++ {
+		if stores[i] != firstStore {
+			t.Errorf("Expected all stores to be the same instance, but store[%d] differs", i)
+		}
+	}
+}

--- a/pkg/tools/mcp/token.go
+++ b/pkg/tools/mcp/token.go
@@ -1,0 +1,60 @@
+package mcp
+
+import (
+	"log/slog"
+	"sync"
+
+	"github.com/mark3labs/mcp-go/client"
+)
+
+// TokenManager manages token stores per URL
+type TokenManager struct {
+	stores map[string]client.TokenStore
+	mu     sync.RWMutex
+}
+
+var (
+	tokenManager *TokenManager
+	managerOnce  sync.Once
+)
+
+// getTokenManager returns the global token manager instance, creating it if necessary
+func getTokenManager() *TokenManager {
+	managerOnce.Do(func() {
+		tokenManager = &TokenManager{
+			stores: make(map[string]client.TokenStore),
+		}
+		slog.Debug("Created global token manager")
+	})
+	return tokenManager
+}
+
+// GetTokenStoreForServer returns a token store for the given URL, creating it if necessary
+func (m *TokenManager) GetTokenStoreForServer(url string) client.TokenStore {
+	m.mu.RLock()
+	store, exists := m.stores[url]
+	m.mu.RUnlock()
+
+	if exists {
+		return store
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Double-check in case another goroutine created it while we were waiting for the lock
+	if store, exists := m.stores[url]; exists {
+		return store
+	}
+
+	store = client.NewMemoryTokenStore()
+	m.stores[url] = store
+	slog.Debug("Created token store for URL", "url", url)
+	return store
+}
+
+// GetTokenStore returns the tokenStore instance for the given URL
+func GetTokenStore(url string) client.TokenStore {
+	manager := getTokenManager()
+	return manager.GetTokenStoreForServer(url)
+}

--- a/pkg/tools/mcp/toolset.go
+++ b/pkg/tools/mcp/toolset.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 
 	"github.com/docker/cagent/pkg/tools"
-	"github.com/mark3labs/mcp-go/client"
 )
 
 // Toolset represents a set of MCP tools
@@ -30,9 +29,10 @@ func NewToolsetCommand(command string, args, env, toolFilter []string) *Toolset 
 }
 
 // NewToolsetRemote creates a new MCP toolset from a remote MCP Server.
-func NewToolsetRemote(url, transport string, headers map[string]string, toolFilter []string, redirectURI string, tokenStore client.TokenStore) (*Toolset, error) {
+func NewToolsetRemote(url, transport string, headers map[string]string, toolFilter []string, redirectURI string) (*Toolset, error) {
 	slog.Debug("Creating Remote MCP toolset", "url", url, "transport", transport, "headers", headers, "toolFilter", toolFilter, "redirectURI", redirectURI)
 
+	tokenStore := GetTokenStore(url)
 	mcpc, err := NewRemoteClient(url, transport, headers, redirectURI, tokenStore)
 	if err != nil {
 		slog.Error("Failed to create remote MCP client", "error", err)


### PR DESCRIPTION
- Add TokenManager to handle separate token stores per URL
- Simplify NewToolsetRemote API by removing tokenStore parameter
- Refactor token management into dedicated token.go file