### PR TITLE
fix: honor --yolo flag in non-TUI mode

### DIFF
--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -251,12 +251,12 @@ func doRunCommand(ctx context.Context, args []string, exec bool) error {
 		} else {
 			execArgs = append(execArgs, "Follow the default instructions")
 		}
-		return runWithoutTUI(ctx, agentFilename, rt, session.New(), execArgs)
+		return runWithoutTUI(ctx, agentFilename, rt, sess, execArgs)
 	}
 
 	// For `cagent run --tui=false`
 	if !useTUI {
-		return runWithoutTUI(ctx, agentFilename, rt, session.New(), args)
+		return runWithoutTUI(ctx, agentFilename, rt, sess, args)
 	}
 
 	// The default is to use the TUI


### PR DESCRIPTION
## Fix --yolo flag not working in non-TUI mode

### Problem
The `--yolo` flag was being ignored when running `cagent run --tui=false` or `cagent exec`, causing tool calls to prompt for confirmation even when auto-approval was requested.

### Root Cause  
Lines 254 and 259 in `cmd/root/run.go` were passing `session.New()` (fresh session) to `runWithoutTUI` instead of the configured `sess` variable that had `ToolsApproved = autoApprove` set.

### Solution
Pass the configured session object (`sess`) instead of creating a new one.

### Testing
- ✅ `cagent run --yolo --tui=false` now auto-approves tools
- ✅ `cagent exec --yolo` now auto-approves tools  
- ✅ No side effects on session state or functionality