### PR TITLE
feat(cli): add --hide-output-for flag to control tool output verbosity

### DIFF
--- a/cmd/root/exec.go
+++ b/cmd/root/exec.go
@@ -1,6 +1,11 @@
 package root
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
 
 func NewExecCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -15,6 +20,9 @@ func NewExecCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&workingDir, "working-dir", "", "Set the working directory for the session (applies to tools and relative paths)")
 	cmd.PersistentFlags().BoolVar(&autoApprove, "yolo", false, "Automatically approve all tool calls without prompting")
 	cmd.PersistentFlags().StringVar(&attachmentPath, "attach", "", "Attach an image file to the message")
+	allOptions := GetAllHideOutputOptions()
+	helpText := fmt.Sprintf("Hide output for specific tools (comma-separated). Available: %s", strings.Join(allOptions, ","))
+	cmd.PersistentFlags().StringVar(&hideOutputFor, "hide-output-for", "", helpText)
 	addGatewayFlags(cmd)
 
 	return cmd

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -39,6 +39,11 @@ cagent provides multiple interfaces and deployment modes:
 $ cagent run config.yaml
 $ cagent run config.yaml -a agent_name  # Run specific agent
 $ cagent run config.yaml --debug        # Enable debug logging
+$ cagent run config.yaml --hide-output-for=file-ops,shell  # Hide verbose tool output
+
+# Non-interactive execution
+$ cagent run config.yaml "message" --tui=false --yolo
+$ cagent exec config.yaml --yolo        # Execute with default instructions
 
 # API Server (HTTP REST API)
 $ cagent api config.yaml
@@ -64,6 +69,38 @@ During CLI sessions, you can use special commands:
 | `/reset`   | Clear conversation history                  |
 | `/eval`    | Save current conversation for evaluation    |
 | `/compact` | Compact conversation to lower context usage |
+
+#### Output Control
+
+Control the verbosity of tool execution output:
+
+```bash
+# Hide output from all file operations
+$ cagent run config.yaml --hide-output-for=file-ops
+
+# Hide output from shell commands (see commands but not their output)
+$ cagent run config.yaml --hide-output-for=shell
+
+# Hide output from specific tools
+$ cagent run config.yaml --hide-output-for=read_file,write_file,think
+
+# Hide output from all tools
+$ cagent run config.yaml --hide-output-for=all
+
+# Combine with other flags for clean automation
+$ cagent run config.yaml "message" --tui=false --yolo --hide-output-for=file-ops,shell
+```
+
+**Available options:**
+- `all` - Hide output from all tools
+- `file-ops` - Hide output from file operations (read_file, write_file, list_files, etc.)
+- Specific tool names: `shell`, `read_file`, `write_file`, `think`, etc.
+- Comma-separated combinations for granular control
+
+**What you see:**
+- ✅ Tool calls: `shell(cmd: "ls -la", cwd: ".")`
+- ✅ Agent responses and reasoning
+- ❌ Verbose tool output: Shows `shell response → (output hidden)` instead of full command output
 
 #### MCP Server Mode
 

--- a/pkg/environment/secrets_test.go
+++ b/pkg/environment/secrets_test.go
@@ -11,7 +11,7 @@ import (
 
 func writeSecret(value string) func(string) error {
 	return func(path string) error {
-		return os.WriteFile(path, []byte(value), 0700)
+		return os.WriteFile(path, []byte(value), 0o700)
 	}
 }
 


### PR DESCRIPTION
## 🎯 **Feature: Output Control for Tool Execution**

Adds a new `--hide-output-for` flag that allows users to selectively hide verbose tool output while maintaining visibility into tool calls and agent reasoning.

### **What's New**
- **Granular Control**: Hide output from specific tools or categories
- **Smart Categories**: Use `file-ops`, `shell`, `all` for common groupings
- **Individual Tools**: Target specific tools like `read_file`, `write_file`
- **Clean Automation**: Perfect for CI/CD and automated workflows

### **Usage Examples**
```bash
# Hide file operation output
cagent run config.yaml --hide-output-for=file-ops

# Hide shell command output  
cagent run config.yaml --hide-output-for=shell

# Hide specific tools
cagent run config.yaml --hide-output-for=read_file,write_file,think

# Perfect for automation
cagent run config.yaml "task" --tui=false --yolo --hide-output-for=file-ops,shell
```

### **Technical Details**
- **Validation**: Comprehensive validation with helpful error messages
- **Categories**: Pre-defined categories for common tool groupings
- **Individual Tools**: Support for hiding specific tool output
- **Documentation**: Updated USAGE.md with examples and options

### **Files Changed**
- `cmd/root/{exec,run}.go`: Add flag and validation
- `cmd/root/run_text_utils.go`: Core hiding logic and categories
- `docs/USAGE.md`: Documentation and usage examples