### PR TITLE
max iteration support for cagent new

### DIFF
--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -349,7 +349,7 @@ func runWithoutTUI(ctx context.Context, agentFilename string, rt runtime.Runtime
 		lastAgent := rt.CurrentAgent().Name()
 		llmIsTyping := false
 		var lastConfirmedToolCallID string
-		for event := range rt.RunStream(loopCtx, sess) {
+		for event := range rt.RunStream(loopCtx, sess, 0) {
 			if event.GetAgentName() != "" && (firstLoop || lastAgent != event.GetAgentName()) {
 				if !firstLoop {
 					if llmIsTyping {

--- a/cmd/root/run_text_utils.go
+++ b/cmd/root/run_text_utils.go
@@ -18,6 +18,7 @@ var (
 	yellow = color.New(color.FgYellow).SprintfFunc()
 	red    = color.New(color.FgRed).SprintfFunc()
 	gray   = color.New(color.FgHiBlack).SprintfFunc()
+	green  = color.New(color.FgGreen).SprintfFunc()
 )
 
 // text styles
@@ -113,6 +114,28 @@ func printToolCallWithConfirmation(toolCall tools.ToolCall, scanner *bufio.Scann
 
 func printToolCallResponse(toolCall tools.ToolCall, response string) {
 	fmt.Printf("\n%s\n", gray("%s response%s", bold(toolCall.Function.Name), formatToolCallResponse(response)))
+}
+
+func promptMaxIterationsContinue(maxIterations int) ConfirmationResult {
+	fmt.Printf("\n%s\n", yellow("⚠️  Maximum iterations (%d) reached. The agent may be stuck in a loop.", maxIterations))
+	fmt.Printf("%s\n", gray("This can happen with smaller or less capable models."))
+	fmt.Printf("\n%s (y/n): ", blue("Do you want to continue for 10 more iterations?"))
+
+	reader := bufio.NewReader(os.Stdin)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		fmt.Printf("\n%s\n", red("Failed to read input, exiting..."))
+		return ConfirmationAbort
+	}
+
+	response = strings.TrimSpace(strings.ToLower(response))
+	if response == "y" || response == "yes" {
+		fmt.Printf("%s\n\n", green("✓ Continuing..."))
+		return ConfirmationApprove
+	} else {
+		fmt.Printf("%s\n\n", gray("Exiting..."))
+		return ConfirmationReject
+	}
 }
 
 func formatToolCallArguments(arguments string) string {

--- a/examples/golibrary/stream/main.go
+++ b/examples/golibrary/stream/main.go
@@ -44,7 +44,7 @@ func main() {
 
 	sess := session.New(session.WithUserMessage("", "How are you doing?"))
 
-	events := rt.RunStream(ctx, sess)
+	events := rt.RunStream(ctx, sess, 0)
 	for event := range events {
 		switch e := event.(type) {
 		case *runtime.AgentChoiceEvent:

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -58,7 +58,7 @@ func (a *App) Run(ctx context.Context, message string) {
 
 		// User message
 		a.session.AddMessage(session.UserMessage(a.agentFilename, message))
-		for event := range a.runtime.RunStream(ctx, a.session) {
+		for event := range a.runtime.RunStream(ctx, a.session, 0) {
 			a.events <- event
 		}
 	}()

--- a/pkg/runtime/event.go
+++ b/pkg/runtime/event.go
@@ -289,3 +289,22 @@ func (e *AuthorizationRequiredEvent) isEvent() {}
 func (e *AuthorizationRequiredEvent) GetAgentName() string {
 	return ""
 }
+
+type MaxIterationsReachedEvent struct {
+	Type          string `json:"type"`
+	MaxIterations int    `json:"max_iterations"`
+	AgentContext
+}
+
+func MaxIterationsReached(maxIterations int) Event {
+	return &MaxIterationsReachedEvent{
+		Type:          "max_iterations_reached",
+		MaxIterations: maxIterations,
+	}
+}
+
+func (e *MaxIterationsReachedEvent) isEvent() {}
+
+func (e *MaxIterationsReachedEvent) GetAgentName() string {
+	return e.AgentName
+}

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -72,8 +72,9 @@ func (r *RemoteRuntime) CurrentAgent() *agent.Agent {
 	return agent.New(r.currentAgent, fmt.Sprintf("Remote agent: %s", r.currentAgent))
 }
 
-// RunStream starts the agent's interaction loop and returns a channel of events
-func (r *RemoteRuntime) RunStream(ctx context.Context, sess *session.Session) <-chan Event {
+// RunStream starts the agent's interaction loop with an optional iteration limit
+// If maxIterations is 0, there is no limit
+func (r *RemoteRuntime) RunStream(ctx context.Context, sess *session.Session, maxIterations int) <-chan Event {
 	slog.Debug("Starting remote runtime stream", "agent", r.currentAgent, "session_id", r.sessionID)
 	events := make(chan Event, 128)
 
@@ -125,7 +126,7 @@ func (r *RemoteRuntime) RunStream(ctx context.Context, sess *session.Session) <-
 
 // Run starts the agent's interaction loop and returns the final messages
 func (r *RemoteRuntime) Run(ctx context.Context, sess *session.Session) ([]session.Message, error) {
-	eventsChan := r.RunStream(ctx, sess)
+	eventsChan := r.RunStream(ctx, sess, 0)
 
 	for event := range eventsChan {
 		if errEvent, ok := event.(*ErrorEvent); ok {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -883,7 +883,7 @@ func (s *Server) runAgent(c echo.Context) error {
 	c.Response().Header().Set("Connection", "keep-alive")
 	c.Response().WriteHeader(http.StatusOK)
 
-	streamChan := rt.RunStream(c.Request().Context(), sess)
+	streamChan := rt.RunStream(c.Request().Context(), sess, 0)
 	for event := range streamChan {
 		data, err := json.Marshal(event)
 		if err != nil {


### PR DESCRIPTION
Allow defining `--max-iterations` parameter on the `cagent new` command.

The rest of the cagent commands (run, api, ..) maintain the current behavior by calling `rt.RunStream` with `maxIterations` set to 0 (unlimited)

When using a model via dmr, the default max_iterations is set to 20.  
For all other providers, there is no set default (so iterations are unlimited).

When the max iteration count is reached, the user will be prompted if they want to continue for 10 more iterations or stop the execution of the agent.

**Screenshots**

Examples using `--max-iterations 2`:

<img width="1022" height="684" alt="Screenshot 2025-09-17 at 13 02 14" src="https://github.com/user-attachments/assets/63c60041-a6b6-4053-a366-ddc3e4977262" />

---

<img width="1022" height="684" alt="Screenshot 2025-09-17 at 13 01 45" src="https://github.com/user-attachments/assets/e78e518a-b432-4e7f-b088-4d3cd824d6ed" />

---

references #227