### PR TITLE
Fix: Handle empty tool messages

### DIFF
--- a/pkg/tools/mcp/client.go
+++ b/pkg/tools/mcp/client.go
@@ -204,6 +204,11 @@ func processMCPContent(toolResult *mcp.CallToolResult) *tools.ToolCallResult {
 		}
 	}
 
+	// Handle an empty response. This can happen if the MCP tool does not return any content.
+	if finalContent == "" {
+		finalContent = "no output"
+	}
+
 	return &tools.ToolCallResult{
 		Output: finalContent,
 	}


### PR DESCRIPTION
Include a default output if tool call returns an empty response!

Fixes: https://github.com/docker/cagent/issues/220

## Testing Done

### Before

<img width="2828" height="449" alt="image" src="https://github.com/user-attachments/assets/f71e0b74-109c-438d-994b-19c1a30ce490" />


### After

<img width="1448" height="573" alt="Screenshot from 2025-09-17 16-23-00" src="https://github.com/user-attachments/assets/93860012-8515-43e3-81ef-b567dd0bf8fc" />

