### PR TITLE
Improve Oauth error management

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -12,17 +12,17 @@ import (
 	"github.com/docker/cagent/pkg/tools"
 )
 
-// ToolSetStartupError wraps toolset startup failures with context
-type ToolSetStartupError struct {
-	Err   error
-	Index int
+// ToolSetError wraps toolset startup failures with context
+type ToolSetError struct {
+	Err     error
+	Toolset tools.ToolSet
 }
 
-func (e *ToolSetStartupError) Error() string {
+func (e *ToolSetError) Error() string {
 	return fmt.Sprintf("failed to start toolset: %v", e.Err)
 }
 
-func (e *ToolSetStartupError) Unwrap() error {
+func (e *ToolSetError) Unwrap() error {
 	return e.Err
 }
 
@@ -148,16 +148,16 @@ func (a *Agent) ensureToolSetsAreStarted(ctx context.Context) error {
 	a.toolsetsMutex.Lock()
 	defer a.toolsetsMutex.Unlock()
 
-	for i, toolSet := range a.toolsets {
+	for _, toolSet := range a.toolsets {
 		// Skip if toolset is already started
 		if a.startedToolsets[toolSet] {
 			continue
 		}
 
 		if err := toolSet.Start(ctx); err != nil {
-			return &ToolSetStartupError{
-				Err:   err,
-				Index: i,
+			return &ToolSetError{
+				Err:     err,
+				Toolset: toolSet,
 			}
 		}
 

--- a/pkg/oauth/errors.go
+++ b/pkg/oauth/errors.go
@@ -1,6 +1,12 @@
 package oauth
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+
+	"github.com/docker/cagent/pkg/agent"
+	"github.com/mark3labs/mcp-go/client"
+)
 
 // AuthorizationRequiredError wraps an OAuth authorization error with server information
 type AuthorizationRequiredError struct {
@@ -15,4 +21,38 @@ func (e *AuthorizationRequiredError) Error() string {
 
 func (e *AuthorizationRequiredError) Unwrap() error {
 	return e.Err
+}
+
+// MayBeOAuthError checks if the given error is an OAuth authorization error and wraps it
+// with server information if available.
+//
+// This function examines error chains to identify OAuth authorization errors wrapped within
+// agent ToolSetError (or any other future error that might contain a possible OAuth error).
+// When found, it extracts server information and returns a properly wrapped AuthorizationRequiredError.
+//
+// Returns:
+// - wrapped error and true if this is an OAuth authorization error
+// - original error and false otherwise
+func MayBeOAuthError(err error) (error, bool) {
+	if err != nil {
+		// Check if this is a ToolSetError
+		var toolSetErr *agent.ToolSetError
+		if errors.As(err, &toolSetErr) {
+			toolSet := toolSetErr.Toolset
+			// Check if the inner error is an OAuth authorization error
+			if client.IsOAuthAuthorizationRequiredError(toolSetErr.Err) {
+				// Only remote MCP toolsets support OAuth. Remote MCP toolsets implement ServerInfoProvider.
+				if serverInfoProvider, ok := toolSet.(ServerInfoProvider); ok {
+					serverURL, serverType := serverInfoProvider.GetServerInfo()
+					return &AuthorizationRequiredError{
+						Err:        toolSetErr.Err,
+						ServerURL:  serverURL,
+						ServerType: serverType,
+					}, true
+				}
+			}
+		}
+	}
+
+	return err, false
 }

--- a/pkg/oauth/manager.go
+++ b/pkg/oauth/manager.go
@@ -2,7 +2,6 @@ package oauth
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 
@@ -140,23 +139,4 @@ func (m *manager) performOAuthAuthorization(ctx context.Context, sessionID strin
 
 	slog.Info("OAuth authorization completed successfully")
 	return nil
-}
-
-// WrapOAuthError wraps an OAuth authorization error with server information from a toolset
-func WrapOAuthError(err error, serverInfoProvider ServerInfoProvider) error {
-	if client.IsOAuthAuthorizationRequiredError(err) {
-		serverURL, serverType := serverInfoProvider.GetServerInfo()
-		return &AuthorizationRequiredError{
-			Err:        err,
-			ServerURL:  serverURL,
-			ServerType: serverType,
-		}
-	}
-	return err
-}
-
-// IsAuthorizationRequiredError checks if an error is an OAuth authorization required error
-func IsAuthorizationRequiredError(err error) bool {
-	var oauthErr *AuthorizationRequiredError
-	return errors.As(err, &oauthErr)
 }


### PR DESCRIPTION
At the moment, most of remote MCP servers fail at tools discovery (but they might also fail at tool execution in the future).

This PR creates `MayBeOAuthError` function that examines if an error is related to OAuth, then decorates the error with necessary metadata (like `serverURL`). This function can be used in any place where a failure related to OAuth can happen. It only handles ToolsetError at tool discovery for now, we can add other types of error if needed. The most important thing is always give context to an Oauth error (which `serverURL` for example).

This also moves more things to `oauth` package and simplify logic in `runtime.go`.