### PR TITLE
Fix tool filtering in the filesystem

### DIFF
--- a/pkg/tools/builtin/filesystem.go
+++ b/pkg/tools/builtin/filesystem.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -443,14 +444,12 @@ func (t *FilesystemTool) Tools(context.Context) ([]tools.Tool, error) {
 	}
 
 	var allowedTools []tools.Tool
-	for _, tool := range t.allowedTools {
-		allowedTools = append(allowedTools, tools.Tool{
-			Function: &tools.FunctionDefinition{
-				Name:        tool,
-				Description: tool,
-			},
-		})
+	for _, tool := range tls {
+		if slices.Contains(t.allowedTools, tool.Function.Name) {
+			allowedTools = append(allowedTools, tool)
+		}
 	}
+
 	return allowedTools, nil
 }
 

--- a/pkg/tools/builtin/filesystem_test.go
+++ b/pkg/tools/builtin/filesystem_test.go
@@ -852,3 +852,14 @@ func TestFilesystemTool_AddAllowedDirectory(t *testing.T) {
 		assert.Len(t, tool.allowedDirectories, 2)
 	})
 }
+
+func TestFilesystemTool_FilterTools(t *testing.T) {
+	allowedDirs := []string{"/tmp"}
+	tool := NewFilesystemTool(allowedDirs, WithAllowedTools([]string{"list_allowed_directories"}))
+
+	tools, err := tool.Tools(t.Context())
+	require.NoError(t, err)
+	require.Len(t, tools, 1)
+	require.Equal(t, "list_allowed_directories", tools[0].Function.Name)
+	require.NotNil(t, tools[0].Handler)
+}


### PR DESCRIPTION
When the tools were filtered we would create a new slice of tools that doesn't contain the tool handlers. Fix this by using the original tool struct that was created and not a new struct that was lacking the tool handler.

Fixes #245