### PR TITLE
Add a hidden dry run to `cagent run`

### DIFF
--- a/cmd/root/exec.go
+++ b/cmd/root/exec.go
@@ -15,6 +15,10 @@ func NewExecCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&workingDir, "working-dir", "", "Set the working directory for the session (applies to tools and relative paths)")
 	cmd.PersistentFlags().BoolVar(&autoApprove, "yolo", false, "Automatically approve all tool calls without prompting")
 	cmd.PersistentFlags().StringVar(&attachmentPath, "attach", "", "Attach an image file to the message")
+
+	cmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "Initialize the agent without executing anything")
+	_ = cmd.PersistentFlags().MarkHidden("dry-run")
+
 	addGatewayFlags(cmd)
 
 	return cmd

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -39,6 +39,7 @@ var (
 	workingDir     string
 	useTUI         bool
 	remoteAddress  string
+	dryRun         bool
 )
 
 // NewRunCmd creates a new run command
@@ -250,6 +251,11 @@ func doRunCommand(ctx context.Context, args []string, exec bool) error {
 			execArgs = append(execArgs, args[1])
 		} else {
 			execArgs = append(execArgs, "Follow the default instructions")
+		}
+
+		if dryRun {
+			fmt.Println("Dry run mode enabled. Agent initialized but will not execute.")
+			return nil
 		}
 		return runWithoutTUI(ctx, agentFilename, rt, sess, execArgs)
 	}


### PR DESCRIPTION
Allows investigating startup issues or slowness