### PR TITLE
Remove the dryRun property for editing files

### DIFF
--- a/pkg/tools/builtin/filesystem.go
+++ b/pkg/tools/builtin/filesystem.go
@@ -160,10 +160,6 @@ func (t *FilesystemTool) Tools(context.Context) ([]tools.Tool, error) {
 							},
 							"description": "Array of edit operations",
 						},
-						"dryRun": map[string]any{
-							"type":        "boolean",
-							"description": "If true, preview changes without applying them",
-						},
 					},
 					Required: []string{"path", "edits"},
 				},
@@ -599,7 +595,6 @@ func (t *FilesystemTool) handleEditFile(ctx context.Context, toolCall tools.Tool
 			OldText string `json:"oldText"`
 			NewText string `json:"newText"`
 		} `json:"edits"`
-		DryRun bool `json:"dryRun"`
 	}
 	if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &args); err != nil {
 		return nil, fmt.Errorf("failed to parse arguments: %w", err)
@@ -624,10 +619,6 @@ func (t *FilesystemTool) handleEditFile(ctx context.Context, toolCall tools.Tool
 		}
 		modifiedContent = strings.Replace(modifiedContent, edit.OldText, edit.NewText, 1)
 		changes = append(changes, fmt.Sprintf("Edit %d: Replaced %d characters", i+1, len(edit.OldText)))
-	}
-
-	if args.DryRun {
-		return &tools.ToolCallResult{Output: fmt.Sprintf("Dry run completed. Changes:\n%s", strings.Join(changes, "\n"))}, nil
 	}
 
 	if err := os.WriteFile(args.Path, []byte(modifiedContent), 0o644); err != nil {

--- a/pkg/tools/builtin/filesystem_test.go
+++ b/pkg/tools/builtin/filesystem_test.go
@@ -362,7 +362,6 @@ func TestFilesystemTool_EditFile(t *testing.T) {
 				"newText": "See you later",
 			},
 		},
-		"dryRun": false,
 	}
 	result := callHandler(t, handler, args)
 
@@ -374,26 +373,6 @@ func TestFilesystemTool_EditFile(t *testing.T) {
 	expected := "Hi Universe\nThis is a test\nSee you later"
 	assert.Equal(t, expected, string(editedContent))
 
-	// Test dry run
-	args = map[string]any{
-		"path": testFile,
-		"edits": []map[string]any{
-			{
-				"oldText": "Hi Universe",
-				"newText": "Hello Again",
-			},
-		},
-		"dryRun": true,
-	}
-	result = callHandler(t, handler, args)
-
-	assert.Contains(t, result.Output, "Dry run completed")
-
-	// Verify file unchanged
-	unchangedContent, err := os.ReadFile(testFile)
-	require.NoError(t, err)
-	assert.Equal(t, expected, string(unchangedContent))
-
 	// Test edit with non-existent text
 	args = map[string]any{
 		"path": testFile,
@@ -403,7 +382,6 @@ func TestFilesystemTool_EditFile(t *testing.T) {
 				"newText": "Replacement",
 			},
 		},
-		"dryRun": false,
 	}
 	result = callHandler(t, handler, args)
 


### PR DESCRIPTION
I've never seen any LLMs use this, also not sure it's really helpful.