### PR TITLE
feat(tools): prevent tool calls from returning empty string

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -711,9 +711,16 @@ func (r *runtime) runTool(ctx context.Context, tool tools.Tool, toolCall tools.T
 	}
 
 	events <- ToolCallResponse(toolCall, res.Output, a.Name())
+
+	// Ensure tool response content is not empty for API compatibility
+	content := res.Output
+	if strings.TrimSpace(content) == "" {
+		content = "(no output)"
+	}
+
 	toolResponseMsg := chat.Message{
 		Role:       chat.MessageRoleTool,
-		Content:    res.Output,
+		Content:    content,
 		ToolCallID: toolCall.ID,
 		CreatedAt:  time.Now().Format(time.RFC3339),
 	}
@@ -760,9 +767,16 @@ func (r *runtime) runAgentTool(ctx context.Context, handler ToolHandler, sess *s
 	}
 
 	events <- ToolCallResponse(toolCall, output, a.Name())
+
+	// Ensure tool response content is not empty for API compatibility
+	content := output
+	if strings.TrimSpace(content) == "" {
+		content = "(no output)"
+	}
+
 	toolResponseMsg := chat.Message{
 		Role:       chat.MessageRoleTool,
-		Content:    output,
+		Content:    content,
 		ToolCallID: toolCall.ID,
 		CreatedAt:  time.Now().Format(time.RFC3339),
 	}


### PR DESCRIPTION
When a tool call returns an empty string, a chat completion error will occur, causing the agent to be unable to respond to the user.

By putting replacing any empty string outputs from tools calls with "(no output)", we can ensure that the agent is able to respond to the user, even if the tool call returns an empty string.

Fixes: #333