### PR TITLE
fix: return non-zero exit code when agent fails in one-shot mode

### DIFF
--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -394,7 +394,6 @@ func runWithoutTUI(ctx context.Context, agentFilename string, rt runtime.Runtime
 				firstLoop = false
 				lastAgent = event.GetAgentName()
 			}
-			lastErr = nil
 			switch e := event.(type) {
 			case *runtime.AgentChoiceEvent:
 				agentChanged := lastAgent != e.AgentName
@@ -504,6 +503,11 @@ func runWithoutTUI(ctx context.Context, agentFilename string, rt runtime.Runtime
 		if loopCtx.Err() != nil {
 			fmt.Println(yellow("\n⚠️  agent stopped  ⚠️"))
 		}
+
+		// Wrap runtime errors to prevent duplicate error messages and usage display
+		if lastErr != nil {
+			return RuntimeError{Err: lastErr}
+		}
 		return nil
 	}
 
@@ -547,7 +551,11 @@ func runWithoutTUI(ctx context.Context, agentFilename string, rt runtime.Runtime
 		}
 	}
 
-	return lastErr
+	// Wrap runtime errors to prevent duplicate error messages and usage display
+	if lastErr != nil {
+		return RuntimeError{Err: lastErr}
+	}
+	return nil
 }
 
 func runUserCommand(userInput string, sess *session.Session, rt runtime.Runtime, ctx context.Context) (bool, error) {


### PR DESCRIPTION
Fixes #335

This PR implements proper exit code handling for one-shot cagent runs (--tui=false), ensuring that agent failures return exit code 1 instead of 0.

## Changes
- Add RuntimeError wrapper to distinguish runtime errors from usage errors
- Update error handling to prevent duplicate error messages
- Remove error reset that was clearing failures between events

## Testing
- ✅ Failed agents now return exit code 1
- ✅ Successful agents still return exit code 0

This enables proper automation workflows, CI/CD integration, and bash scripting with cagent.