### PR TITLE
Simplify runtime telemetry and tools

### DIFF
--- a/pkg/telemetry/context.go
+++ b/pkg/telemetry/context.go
@@ -2,6 +2,7 @@ package telemetry
 
 import (
 	"context"
+	"time"
 )
 
 // contextKey is a type for context keys to avoid collisions
@@ -22,4 +23,34 @@ func FromContext(ctx context.Context) *Client {
 		return client
 	}
 	return nil
+}
+
+func RecordError(ctx context.Context, err string) {
+	if client := FromContext(ctx); client != nil {
+		client.RecordError(ctx, err)
+	}
+}
+
+func RecordToolCall(ctx context.Context, toolName, sessionID, agentName string, duration time.Duration, err error) {
+	if client := FromContext(ctx); client != nil {
+		client.RecordToolCall(ctx, toolName, sessionID, agentName, duration, err)
+	}
+}
+
+func RecordSessionEnd(ctx context.Context) {
+	if client := FromContext(ctx); client != nil {
+		client.RecordSessionEnd(ctx)
+	}
+}
+
+func RecordSessionStart(ctx context.Context, sessionID, agentName string) {
+	if client := FromContext(ctx); client != nil {
+		client.RecordSessionStart(ctx, sessionID, agentName)
+	}
+}
+
+func RecordTokenUsage(ctx context.Context, model string, inputTokens, outputTokens int64, cost float64) {
+	if client := FromContext(ctx); client != nil {
+		client.RecordTokenUsage(ctx, model, inputTokens, outputTokens, cost)
+	}
 }


### PR DESCRIPTION
- only get the tools once at the start of the stream
- create telemetry public functions that look for the context