### PR TITLE
Make agent name explicit for all events

### DIFF
--- a/pkg/runtime/client.go
+++ b/pkg/runtime/client.go
@@ -363,9 +363,9 @@ func (c *Client) runAgentWithAgentName(ctx context.Context, sessionID, agent, ag
 				case "stream_stopped":
 					eventChan <- StreamStopped(sessionID, event["agent_name"].(string))
 				case "authorization_required":
-					eventChan <- AuthorizationRequired(event["server_url"].(string), event["server_type"].(string), event["confirmation"].(string))
+					eventChan <- AuthorizationRequired(event["server_url"].(string), event["server_type"].(string), event["confirmation"].(string), event["agent_name"].(string))
 				case "session_compaction":
-					eventChan <- SessionCompaction(event["session_id"].(string), event["status"].(string))
+					eventChan <- SessionCompaction(event["session_id"].(string), event["status"].(string), event["agent_name"].(string))
 				case "token_usage":
 					usage := event["usage"].(map[string]any)
 					inputTokens, _ := usage["input_tokens"].(float64)
@@ -379,9 +379,9 @@ func (c *Client) runAgentWithAgentName(ctx context.Context, sessionID, agent, ag
 					maxIterations, _ := event["max_iterations"].(float64)
 					eventChan <- MaxIterationsReached(int(maxIterations))
 				case "session_title":
-					eventChan <- SessionTitle(event["session_id"].(string), event["title"].(string))
+					eventChan <- SessionTitle(event["session_id"].(string), event["title"].(string), event["agent_name"].(string))
 				case "session_summary":
-					eventChan <- SessionSummary(event["session_id"].(string), event["summary"].(string))
+					eventChan <- SessionSummary(event["session_id"].(string), event["summary"].(string), event["agent_name"].(string))
 				case "shell":
 					eventChan <- ShellOutput(event["output"].(string))
 				case "error":

--- a/pkg/runtime/event.go
+++ b/pkg/runtime/event.go
@@ -220,11 +220,14 @@ type SessionTitleEvent struct {
 	AgentContext
 }
 
-func SessionTitle(sessionID, title string) Event {
+func SessionTitle(sessionID, title, agentName string) Event {
 	return &SessionTitleEvent{
 		Type:      "session_title",
 		SessionID: sessionID,
 		Title:     title,
+		AgentContext: AgentContext{
+			AgentName: agentName,
+		},
 	}
 }
 func (e *SessionTitleEvent) isEvent() {}
@@ -236,11 +239,14 @@ type SessionSummaryEvent struct {
 	AgentContext
 }
 
-func SessionSummary(sessionID, summary string) Event {
+func SessionSummary(sessionID, summary, agentName string) Event {
 	return &SessionSummaryEvent{
 		Type:      "session_summary",
 		SessionID: sessionID,
 		Summary:   summary,
+		AgentContext: AgentContext{
+			AgentName: agentName,
+		},
 	}
 }
 func (e *SessionSummaryEvent) isEvent() {}
@@ -252,11 +258,14 @@ type SessionCompactionEvent struct {
 	AgentContext
 }
 
-func SessionCompaction(sessionID, status string) Event {
+func SessionCompaction(sessionID, status, agentName string) Event {
 	return &SessionCompactionEvent{
 		Type:      "session_compaction",
 		SessionID: sessionID,
 		Status:    status,
+		AgentContext: AgentContext{
+			AgentName: agentName,
+		},
 	}
 }
 func (e *SessionCompactionEvent) isEvent() {}
@@ -286,14 +295,16 @@ type AuthorizationRequiredEvent struct {
 	ServerURL    string `json:"server_url"`
 	ServerType   string `json:"server_type"`
 	Confirmation string `json:"confirmation"` // only  "pending" | "confirmed" | "denied"
+	AgentContext
 }
 
-func AuthorizationRequired(serverURL, serverType, confirmation string) Event {
+func AuthorizationRequired(serverURL, serverType, confirmation, agentName string) Event {
 	return &AuthorizationRequiredEvent{
 		Type:         "authorization_required",
 		ServerURL:    serverURL,
 		ServerType:   serverType,
 		Confirmation: confirmation,
+		AgentContext: AgentContext{AgentName: agentName},
 	}
 }
 

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -134,7 +134,7 @@ func (r *RemoteRuntime) Summarize(ctx context.Context, sess *session.Session, ev
 	// TODO: Implement summarization by either:
 	// 1. Adding a summarization endpoint to the remote API
 	// 2. Running a summarization agent through the remote client
-	events <- SessionSummary(sess.ID, "Summary generation not yet implemented for remote runtime")
+	events <- SessionSummary(sess.ID, "Summary generation not yet implemented for remote runtime", r.currentAgent)
 }
 
 // convertSessionMessages converts session messages to remote API message format


### PR DESCRIPTION
Make agent name explicit for all events, using `AgentContext` struct