### PR TITLE
Fix the redirect uri being empty

### DIFF
--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -181,6 +181,10 @@ func doRunCommand(ctx context.Context, args []string, exec bool) error {
 			agentFilename = tmpFile.Name()
 		}
 
+		if runConfig.RedirectURI == "" {
+			runConfig.RedirectURI = "http://localhost:8083/oauth-callback"
+		}
+
 		agents, err = teamloader.Load(ctx, agentFilename, runConfig)
 		if err != nil {
 			return err


### PR DESCRIPTION
The default value for the redirect uri was set in the oauth manager, but that was already too late, we already created the remote mcp client