### PR TITLE
The api should not start an oauth callback server

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -882,6 +882,7 @@ func (s *Server) runAgent(c echo.Context) error {
 	if !exists {
 		var opts []runtime.Opt = []runtime.Opt{
 			runtime.WithCurrentAgent(currentAgent),
+			runtime.WithManagedOAuth(false),
 		}
 		rt, err = runtime.New(t, opts...)
 		if err != nil {


### PR DESCRIPTION
In api mode we are not the ones who manage the callback server, up to the caller to do it for us and tell us when the auth is granted