### PR TITLE
Hardcode telemetry credentials for open source distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,6 @@ jobs:
 
       - name: Run tests
         run: task test
-        env:
-          TELEMETRY_API_KEY: ${{ secrets.TELEMETRY_API_KEY }}
-          TELEMETRY_ENDPOINT: ${{ secrets.TELEMETRY_ENDPOINT }}
-          TELEMETRY_HEADER: ${{ secrets.TELEMETRY_HEADER }}
 
   license-check:
     runs-on: ubuntu-latest
@@ -95,10 +91,6 @@ jobs:
 
       - name: Build
         run: task build
-        env:
-          TELEMETRY_API_KEY: ${{ secrets.TELEMETRY_API_KEY }}
-          TELEMETRY_ENDPOINT: ${{ secrets.TELEMETRY_ENDPOINT }}
-          TELEMETRY_HEADER: ${{ secrets.TELEMETRY_HEADER }}
 
   build-image:
     needs: [lint, test, license-check]
@@ -141,11 +133,3 @@ jobs:
             GIT_TAG=${{ github.ref_name }}
             GIT_COMMIT=${{ github.sha }}
             BUILD_DATE=${{ steps.meta.outputs.created || github.event.repository.updated_at || format('YYYY-MM-DD') }}
-          secret-envs: |
-            telemetry_api_key=TELEMETRY_API_KEY
-            telemetry_endpoint=TELEMETRY_ENDPOINT
-            telemetry_header=TELEMETRY_HEADER
-        env:
-          TELEMETRY_API_KEY: ${{ secrets.TELEMETRY_API_KEY }}
-          TELEMETRY_ENDPOINT: ${{ secrets.TELEMETRY_ENDPOINT }}
-          TELEMETRY_HEADER: ${{ secrets.TELEMETRY_HEADER }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,12 +20,9 @@ ARG TARGETPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
 RUN --mount=type=cache,target=/root/.cache,id=docker-ai-$TARGETPLATFORM \
-    --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=secret,id=telemetry_api_key,env=TELEMETRY_API_KEY \
-    --mount=type=secret,id=telemetry_endpoint,env=TELEMETRY_ENDPOINT \
-    --mount=type=secret,id=telemetry_header,env=TELEMETRY_HEADER <<EOT
+    --mount=type=cache,target=/go/pkg/mod <<EOT
     set -ex
-    xx-go build -trimpath -ldflags "-s -w -X 'github.com/docker/cagent/pkg/version.Version=$GIT_TAG' -X 'github.com/docker/cagent/pkg/version.Commit=$GIT_COMMIT' -X 'github.com/docker/cagent/pkg/telemetry.TelemetryEndpoint=$TELEMETRY_ENDPOINT' -X 'github.com/docker/cagent/pkg/telemetry.TelemetryAPIKey=$TELEMETRY_API_KEY' -X 'github.com/docker/cagent/pkg/telemetry.TelemetryHeader=$TELEMETRY_HEADER'" -o /binaries/cagent-$TARGETOS-$TARGETARCH .
+    xx-go build -trimpath -ldflags "-s -w -X 'github.com/docker/cagent/pkg/version.Version=$GIT_TAG' -X 'github.com/docker/cagent/pkg/version.Commit=$GIT_COMMIT'" -o /binaries/cagent-$TARGETOS-$TARGETARCH .
     xx-verify --static /binaries/cagent-$TARGETOS-$TARGETARCH
     if [ "$TARGETOS" = "windows" ]; then
       mv /binaries/cagent-$TARGETOS-$TARGETARCH /binaries/cagent-$TARGETOS-$TARGETARCH.exe

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,8 +9,8 @@ vars:
   GIT_COMMIT:
     sh: git rev-parse HEAD
   GO_SOURCES: "**/*.go"
-  BUILD_ARGS: '--build-arg GIT_TAG="{{.GIT_TAG}}" --build-arg GIT_COMMIT="{{.GIT_COMMIT}}" --build-arg BUILD_DATE="{{.BUILD_DATE}}" --secret id=telemetry_api_key,env=TELEMETRY_API_KEY --secret id=telemetry_endpoint,env=TELEMETRY_ENDPOINT --secret id=telemetry_header,env=TELEMETRY_HEADER'
-  LDFLAGS: '-X "github.com/docker/cagent/pkg/version.Version={{.GIT_TAG}}" -X "github.com/docker/cagent/pkg/version.Commit={{.GIT_COMMIT}}" -X "github.com/docker/cagent/pkg/telemetry.TelemetryEndpoint={{.TELEMETRY_ENDPOINT}}" -X "github.com/docker/cagent/pkg/telemetry.TelemetryAPIKey={{.TELEMETRY_API_KEY}}" -X "github.com/docker/cagent/pkg/telemetry.TelemetryHeader={{.TELEMETRY_HEADER}}"'
+  BUILD_ARGS: '--build-arg GIT_TAG="{{.GIT_TAG}}" --build-arg GIT_COMMIT="{{.GIT_COMMIT}}" --build-arg BUILD_DATE="{{.BUILD_DATE}}"'
+  LDFLAGS: '-X "github.com/docker/cagent/pkg/version.Version={{.GIT_TAG}}" -X "github.com/docker/cagent/pkg/version.Commit={{.GIT_COMMIT}}"'
 
 tasks:
   default:

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -72,11 +72,6 @@ Events are processed synchronously when `Track()` is called, sending HTTP reques
 
 ### Configuration
 
-The system respects these environment variables:
+Telemetry is enabled by default. To disable it, set:
 
-- `TELEMETRY_ENABLED=false` - Disable telemetry collection (default: enabled)
-- `TELEMETRY_ENDPOINT=<url>` - Remote telemetry endpoint (optional)
-- `TELEMETRY_API_KEY=<key>` - API key for remote telemetry (optional)
-- `TELEMETRY_HEADER=<header>` - Authorization header for remote telemetry (optional)
-
-The `--debug` flag enables local event logging without affecting HTTP transmission.
+- `TELEMETRY_ENABLED=false`

--- a/pkg/telemetry/client.go
+++ b/pkg/telemetry/client.go
@@ -53,9 +53,16 @@ func NewClient(logger *slog.Logger, enabled, debugMode bool, version string, cus
 		}, nil
 	}
 
-	endpoint := getTelemetryEndpoint()
-	apiKey := getTelemetryAPIKey()
-	header := getTelemetryHeader()
+	header := "x-api-key"
+
+	endpoint := "https://api.docker.com/events/v1/track"
+	apiKey := "Gxw1IjiDEP29dWm9DanuE2XhIKKzqDEY4iGlW1P0"
+
+	// Use staging configuration in debug mode
+	if debugMode {
+		endpoint = "https://api-stage.docker.com/events/v1/track"
+		apiKey = "z4sTQ8eDid2nJ53md8ptCaZlVxvIlhvf4AGR7oi5"
+	}
 
 	var httpClient *http.Client
 	if len(customHttpClient) > 0 && customHttpClient[0] != nil {
@@ -77,16 +84,7 @@ func NewClient(logger *slog.Logger, enabled, debugMode bool, version string, cus
 	}
 
 	if debugMode {
-		hasEndpoint := endpoint != ""
-		hasAPIKey := apiKey != ""
-		hasHeader := header != ""
-		telemetryLogger.Debug("Telemetry configuration",
-			"enabled", enabled,
-			"has_endpoint", hasEndpoint,
-			"has_api_key", hasAPIKey,
-			"has_header", hasHeader,
-			"http_enabled", hasEndpoint && hasAPIKey && hasHeader,
-		)
+		telemetryLogger.Debug("Enabled:", enabled)
 	}
 
 	return client, nil

--- a/pkg/telemetry/utils.go
+++ b/pkg/telemetry/utils.go
@@ -14,14 +14,6 @@ import (
 	"github.com/docker/cagent/pkg/paths"
 )
 
-// Build-time telemetry configuration (set via -ldflags)
-var (
-	TelemetryEnabled  = "true" // Default enabled
-	TelemetryEndpoint = ""     // Set at build time
-	TelemetryAPIKey   = ""     // Set at build time
-	TelemetryHeader   = ""     // Set at build time
-)
-
 // getSystemInfo collects system information for events
 func getSystemInfo() (osName, osVersion, osLanguage string) {
 	osInfo := runtime.GOOS
@@ -39,27 +31,6 @@ func GetTelemetryEnabled() bool {
 	}
 	// Default to true (telemetry enabled)
 	return true
-}
-
-func getTelemetryEndpoint() string {
-	if env := os.Getenv("TELEMETRY_ENDPOINT"); env != "" {
-		return env
-	}
-	return TelemetryEndpoint
-}
-
-func getTelemetryAPIKey() string {
-	if env := os.Getenv("TELEMETRY_API_KEY"); env != "" {
-		return env
-	}
-	return TelemetryAPIKey
-}
-
-func getTelemetryHeader() string {
-	if env := os.Getenv("TELEMETRY_HEADER"); env != "" {
-		return env
-	}
-	return TelemetryHeader
 }
 
 // getUserUUIDFilePath returns the path to the user UUID file


### PR DESCRIPTION
Replace environment variable-based telemetry configuration with hardcoded production credentials to enable telemetry collection for users building cagent from source.

## Changes

  - Hardcode production telemetry endpoint, API key, and header in pkg/telemetry/client.go
  - Add staging credentials for debug mode usage
  - Remove telemetry secret mounts from Dockerfile
  - Remove telemetry environment variables from Taskfile.yml and CI workflow
  - Update telemetry documentation to reflect simplified configuration
  - Users can still disable telemetry via `TELEMETRY_ENABLED=false`

## Motivation

Previously, telemetry credentials were injected as GitHub secrets during builds, preventing source builds from reporting telemetry. Since the telemetry endpoint is public and approved for open source use, hardcoding these values ensures all builds contribute usage data.