### PR TITLE
Add OAuth state validation to prevent CSRF attacks

### DIFF
--- a/pkg/oauth/interfaces.go
+++ b/pkg/oauth/interfaces.go
@@ -10,8 +10,8 @@ type Manager interface {
 	// StartAuthorizationFlow signals that user confirmation has been given to start the OAuth flow
 	StartAuthorizationFlow(ctx context.Context, confirmation bool)
 
-	// SendAuthorizationCode sends the OAuth authorization code after user has completed the OAuth flow
-	SendAuthorizationCode(ctx context.Context, code string) error
+	// SendAuthorizationCode sends the OAuth authorization code and state after user has completed the OAuth flow
+	SendAuthorizationCode(ctx context.Context, code, state string) error
 
 	// Cleanup stops any owned resources like callback servers
 	Cleanup(ctx context.Context) error

--- a/pkg/runtime/client.go
+++ b/pkg/runtime/client.go
@@ -403,7 +403,7 @@ func (c *Client) ResumeStartAuthorizationFlow(ctx context.Context, id string, co
 	return c.doRequest(ctx, "POST", "/api/"+id+"/resumeStartOauth", req, nil)
 }
 
-func (c *Client) ResumeCodeReceived(ctx context.Context, code string) error {
-	req := api.ResumeCodeReceivedOauthRequest{Code: code}
+func (c *Client) ResumeCodeReceived(ctx context.Context, code, state string) error {
+	req := api.ResumeCodeReceivedOauthRequest{Code: code, State: state}
 	return c.doRequest(ctx, "POST", "/api/resumeCodeReceivedOauth", req, nil)
 }

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -170,15 +170,15 @@ func (r *RemoteRuntime) ResumeStartAuthorizationFlow(ctx context.Context, confir
 }
 
 // Resume allows resuming execution after user confirmation
-func (r *RemoteRuntime) ResumeCodeReceived(ctx context.Context, code string) error {
-	slog.Debug("Resuming remote runtime", "agent", r.currentAgent, "code", code, "session_id", r.sessionID)
+func (r *RemoteRuntime) ResumeCodeReceived(ctx context.Context, code, state string) error {
+	slog.Debug("Resuming remote runtime", "agent", r.currentAgent, "code", code, "state", state, "session_id", r.sessionID)
 
 	if r.sessionID == "" {
 		slog.Error("Cannot resume: no session ID available")
 		return fmt.Errorf("session ID cannot be empty")
 	}
 
-	if err := r.client.ResumeCodeReceived(ctx, code); err != nil {
+	if err := r.client.ResumeCodeReceived(ctx, code, state); err != nil {
 		slog.Error("Failed to resume remote session", "error", err, "session_id", r.sessionID)
 		return err
 	}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -53,8 +53,8 @@ type Runtime interface {
 	Summarize(ctx context.Context, sess *session.Session, events chan Event)
 	// ResumeStartAuthorizationFlow signals that user confirmation has been given to start the OAuth flow
 	ResumeStartAuthorizationFlow(_ context.Context, confirmation bool)
-	// ResumeCodeReceived sends the OAuth authorization code to the runtime after user has completed the OAuth flow in their browser
-	ResumeCodeReceived(_ context.Context, code string) error
+	// ResumeCodeReceived sends the OAuth authorization code and state to the runtime after user has completed the OAuth flow in their browser
+	ResumeCodeReceived(_ context.Context, code, state string) error
 }
 
 // runtime manages the execution of agents
@@ -427,11 +427,11 @@ func (r *runtime) ResumeStartAuthorizationFlow(ctx context.Context, confirmation
 	}
 }
 
-func (r *runtime) ResumeCodeReceived(ctx context.Context, code string) error {
-	slog.Debug("Sending OAuth authorization code to runtime", "agent", r.currentAgent)
+func (r *runtime) ResumeCodeReceived(ctx context.Context, code, state string) error {
+	slog.Debug("Sending OAuth authorization code and state to runtime", "agent", r.currentAgent)
 
 	if r.oauthManager != nil {
-		return r.oauthManager.SendAuthorizationCode(ctx, code)
+		return r.oauthManager.SendAuthorizationCode(ctx, code, state)
 	}
 
 	return fmt.Errorf("OAuth flow not in progress")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1060,13 +1060,14 @@ func (s *Server) resumeCodeReceivedOauth(c echo.Context) error {
 		return c.JSON(http.StatusNotFound, map[string]string{"error": fmt.Sprintf("runtime not found: %s", sessionID)})
 	}
 
-	// Send the authorization code to the runtime's OAuth channel
-	if err := rt.ResumeCodeReceived(c.Request().Context(), code); err != nil {
+	// Send the authorization code and state to the runtime's OAuth channel
+	// The state will be validated in the OAuth manager to ensure it matches the original state
+	if err := rt.ResumeCodeReceived(c.Request().Context(), code, state); err != nil {
 		slog.Error("Failed to send OAuth code to runtime", "session_id", sessionID, "error", err)
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "OAuth flow not in progress"})
 	}
 
-	slog.Debug("OAuth authorization code sent to runtime", "session_id", sessionID)
+	slog.Debug("OAuth authorization code and state sent to runtime", "session_id", sessionID)
 
 	return c.JSON(http.StatusOK, map[string]string{"message": "OAuth code received"})
 }


### PR DESCRIPTION
Implement state parameter validation in the OAuth authorization flow to ensure the state received in callbacks matches the originally generated state. 

This prevents CSRF attacks where an attacker might attempt to inject their own authorization codes into a victim's session.

This PR only affects OAuth in API Mode, TUI Mode already has this check