### PR TITLE
Fix Oauth flow for sub session after task_transfer

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -62,6 +62,7 @@ type runtime struct {
 	toolMap           map[string]ToolHandler
 	team              *team.Team
 	currentAgent      string
+	rootSessionID     string // Root session ID for OAuth state encoding (preserved across sub-sessions)
 	resumeChan        chan ResumeType
 	oauthManager      oauth.Manager
 	tracer            trace.Tracer
@@ -81,6 +82,12 @@ func WithCurrentAgent(agentName string) Opt {
 func WithManagedOAuth(managed bool) Opt {
 	return func(r *runtime) {
 		r.managedOAuth = managed
+	}
+}
+
+func WithRootSessionID(sessionID string) Opt {
+	return func(r *runtime) {
+		r.rootSessionID = sessionID
 	}
 }
 
@@ -167,7 +174,16 @@ func (r *runtime) handleOAuthAuthorizationFlow(ctx context.Context, sess *sessio
 		}()
 	}
 
-	return r.oauthManager.HandleAuthorizationFlow(ctx, sess.ID, oauthRequiredErr)
+	// Use rootSessionID for OAuth state encoding to ensure callback can find the runtime
+	// This is important when OAuth is triggered from a sub-session during task transfer
+	sessionIDForOAuth := r.rootSessionID
+	if sessionIDForOAuth == "" {
+		// Fallback to current session ID if rootSessionID wasn't set (backward compatibility)
+		sessionIDForOAuth = sess.ID
+		slog.Warn("rootSessionID not set, using current session ID for OAuth", "session_id", sess.ID)
+	}
+
+	return r.oauthManager.HandleAuthorizationFlow(ctx, sessionIDForOAuth, oauthRequiredErr)
 }
 
 func (r *runtime) finalizeEventChannel(ctx context.Context, sess *session.Session, events chan Event) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -924,6 +924,7 @@ func (s *Server) runAgent(c echo.Context) error {
 		var opts []runtime.Opt = []runtime.Opt{
 			runtime.WithCurrentAgent(currentAgent),
 			runtime.WithManagedOAuth(false),
+			runtime.WithRootSessionID(sess.ID),
 		}
 		rt, err = runtime.New(t, opts...)
 		if err != nil {
@@ -931,6 +932,7 @@ func (s *Server) runAgent(c echo.Context) error {
 			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to create runtime"})
 		}
 		s.runtimes[sess.ID] = rt
+		slog.Debug("Runtime created for session", "session_id", sess.ID)
 	}
 
 	var messages []api.Message


### PR DESCRIPTION
Issue: When the Oauth is required in sub agent, the Oauth doesn't finish

Root Cause:
  - When `OAuth` is triggered in a sub-session (during task transfer), `GenerateStateWithSessionID(sess.ID)` was
  called with the sub-session ID
  - But `DecodeSessionIDFromState()` in `resumeCodeReceivedOauth` returned that sub-session ID
  - The runtime was only stored in `s.runtimes[parent_session_ID]`, not the sub-session ID
  - Result: Runtime not found

This PR stores the root/parent session ID in the runtime and use that for OAuth encoding.