### PR TITLE
Fix OAuth panic when reusing manager across sub-sessions

### DIFF
--- a/pkg/oauth/interfaces.go
+++ b/pkg/oauth/interfaces.go
@@ -13,6 +13,9 @@ type Manager interface {
 	// SendAuthorizationCode sends the OAuth authorization code and state after user has completed the OAuth flow
 	SendAuthorizationCode(ctx context.Context, code, state string) error
 
+	// UpdateEmitCallback updates the callback function for emitting auth events
+	UpdateEmitCallback(emitAuthRequired func(serverURL, serverType, status string))
+
 	// Cleanup stops any owned resources like callback servers
 	Cleanup(ctx context.Context) error
 }

--- a/pkg/oauth/manager.go
+++ b/pkg/oauth/manager.go
@@ -296,6 +296,11 @@ func (m *manager) getCallbackServer() *CallbackServer {
 	return m.callbackServer
 }
 
+// UpdateEmitCallback updates the callback function for emitting auth events
+func (m *manager) UpdateEmitCallback(emitAuthRequired func(serverURL, serverType, status string)) {
+	m.emitAuthRequired = emitAuthRequired
+}
+
 // Cleanup stops the callback server if we own it
 func (m *manager) Cleanup(ctx context.Context) error {
 	m.serverMutex.Lock()

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -154,17 +154,25 @@ func (r *runtime) registerDefaultTools() {
 
 // handleOAuthAuthorizationFlow handles a single OAuth authorization flow
 func (r *runtime) handleOAuthAuthorizationFlow(ctx context.Context, sess *session.Session, oauthRequiredErr *oauth.AuthorizationRequiredError, events chan Event) error {
-	// Create OAuth manager if it doesn't exist
+	// Create emitAuthRequired callback with current events channel
+	emitAuthRequired := func(serverURL, serverType, status string) {
+		events <- AuthorizationRequired(serverURL, serverType, status, r.currentAgent)
+	}
+
+	// Create OAuth manager if it doesn't exist, or update callback if it does
 	if r.oauthManager == nil {
-		emitAuthRequired := func(serverURL, serverType, status string) {
-			events <- AuthorizationRequired(serverURL, serverType, status, r.currentAgent)
-		}
 		r.oauthManager = oauth.NewManager(emitAuthRequired, oauth.WithManagedServer(r.managedOAuth))
 		defer func() {
 			if cleanupErr := r.oauthManager.Cleanup(ctx); cleanupErr != nil {
 				slog.Error("Failed to cleanup OAuth manager", "error", cleanupErr)
 			}
 		}()
+	} else {
+		// Update the callback to use the current events channel
+		// This is important when OAuth manager is reused across sub-sessions (e.g., during task transfer)
+		// If we don't update the callback, events may be sent to a closed channel by a previous session
+		slog.Debug("Reusing existing OAuth manager, updating callback with current events channel")
+		r.oauthManager.UpdateEmitCallback(emitAuthRequired)
 	}
 
 	return r.oauthManager.HandleAuthorizationFlow(ctx, sess.ID, oauthRequiredErr)


### PR DESCRIPTION
When runtime reuses the same OAuth manager for multiple sessions (e.g., during task transfers), the manager's callback still referenced the closed events channel from the previous session, causing a panic.

Add `UpdateEmitCallback` to allow updating the callback function with the current session's events channel when reusing the OAuth manager.