### PR TITLE
Remove no longer used focus

### DIFF
--- a/pkg/tui/components/editor/editor.go
+++ b/pkg/tui/components/editor/editor.go
@@ -120,11 +120,6 @@ func (e *editor) Blur() tea.Cmd {
 	return nil
 }
 
-// IsFocused returns whether the component is focused
-func (e *editor) IsFocused() bool {
-	return e.textarea.Focused()
-}
-
 // Bindings returns key bindings for the component
 func (e *editor) Bindings() []key.Binding {
 	return []key.Binding{

--- a/pkg/tui/components/messages/messages.go
+++ b/pkg/tui/components/messages/messages.go
@@ -53,14 +53,12 @@ type renderedItem struct {
 
 // model implements Model
 type model struct {
-	renderer    *glamour.TermRenderer
-	messages    []types.Message
-	views       []layout.Model
-	width       int
-	height      int
-	focused     bool
-	app         *app.App
-	toolFocused layout.Model
+	renderer *glamour.TermRenderer
+	messages []types.Message
+	views    []layout.Model
+	width    int
+	height   int
+	app      *app.App
 
 	// Height tracking system fields
 	scrollOffset  int                  // Current scroll position in lines
@@ -151,16 +149,6 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.scrollToBottom()
 			return m, nil
 		}
-
-		if m.focused && m.toolFocused != nil {
-			if updatedModel, cmd := m.toolFocused.Update(msg); cmd != nil {
-				m.toolFocused = updatedModel.(layout.Model)
-				return m, cmd
-			} else {
-				m.toolFocused = updatedModel.(layout.Model)
-			}
-			return m, nil
-		}
 	}
 
 	// Forward updates to all message views
@@ -248,19 +236,12 @@ func (m *model) GetSize() (width, height int) {
 
 // Focus gives focus to the component
 func (m *model) Focus() tea.Cmd {
-	m.focused = true
 	return nil
 }
 
 // Blur removes focus from the component
 func (m *model) Blur() tea.Cmd {
-	m.focused = false
 	return nil
-}
-
-// IsFocused returns whether the component is focused
-func (m *model) IsFocused() bool {
-	return m.focused
 }
 
 // Bindings returns key bindings for the component

--- a/pkg/tui/core/layout/layout.go
+++ b/pkg/tui/core/layout/layout.go
@@ -15,7 +15,6 @@ type Sizeable interface {
 type Focusable interface {
 	Focus() tea.Cmd
 	Blur() tea.Cmd
-	IsFocused() bool
 }
 
 // Help represents components that provide help information


### PR DESCRIPTION
The tool focus was used before we had dialogs, no longer needed.