### PR TITLE
Fix the oauth callback server

### DIFF
--- a/pkg/oauth/manager.go
+++ b/pkg/oauth/manager.go
@@ -183,12 +183,16 @@ func (m *manager) performOAuthAuthorization(ctx context.Context, sessionID strin
 	slog.Debug("Waiting for OAuth authorization code")
 	var code string
 
-	// Ensure callback server is started if needed
-	if err := m.ensureCallbackServer(ctx); err != nil {
-		slog.Warn("Failed to start callback server, falling back to manual input", "error", err)
-	}
-
 	if m.managedServer {
+		// Ensure callback server is started if needed
+		if err := m.ensureCallbackServer(ctx); err != nil {
+			slog.Warn("Failed to start callback server, falling back to manual input", "error", err)
+		}
+
+		defer func() {
+			SetGlobalCallbackServer(nil)
+		}()
+
 		// Check if we have a callback server running (either global or our own)
 		if callbackServer := m.getCallbackServer(); callbackServer != nil {
 			slog.Debug("Using callback server for OAuth authorization")


### PR DESCRIPTION
- make sure to remove the server when we don't need it any more
- only start the server if really needed (managed mode)