### PR TITLE
Send the client name during DCR

### DIFF
--- a/pkg/tools/mcp/oauth.go
+++ b/pkg/tools/mcp/oauth.go
@@ -271,6 +271,7 @@ func registerClient(ctx context.Context, authMetadata *authorizationServerMetada
 
 	reqBody := map[string]any{
 		"redirect_uris": []string{redirectURI},
+		"client_name":   "cagent",
 		"grant_types":   []string{"authorization_code"},
 		"response_types": []string{
 			"code",


### PR DESCRIPTION
The Jam server needs this, it returns an error otherwise.