### PR TITLE
Google/Gemini thinking budget support

### DIFF
--- a/cagent-schema.json
+++ b/cagent-schema.json
@@ -182,7 +182,7 @@
           "description": "Whether to track usage"
         },
         "thinking_budget": {
-          "description": "Controls reasoning effort/budget. For OpenAI: string levels ('minimal', 'low', 'medium', 'high'). For Anthropic: integer token budget (1024-32768)",
+          "description": "Controls reasoning effort/budget. OpenAI: string levels ('minimal','low','medium','high'). Anthropic: integer token budget (1024-32768). Gemini: integer token budget (-1 for unlimited, 0 to disable, 24576 max).",
           "oneOf": [
             {
               "type": "string",
@@ -191,12 +191,12 @@
             },
             {
               "type": "integer",
-              "minimum": 1024,
+              "minimum": -1,
               "maximum": 32768,
-              "description": "Token budget for extended thinking (Anthropic)"
+              "description": "Token budget for extended thinking (Anthropic, Google)"
             }
           ],
-          "examples": ["minimal", "low", "medium", "high", 1024, 32768]
+          "examples": ["minimal", "low", "medium", "high", -1, 0, 1024, 24576, 32768]
         }
       },
       "additionalProperties": false

--- a/examples/thinking_budget.yaml
+++ b/examples/thinking_budget.yaml
@@ -9,8 +9,9 @@ agents:
   root:
     model: gpt-5-mini-min # <- try with gpt-5-mini-high
     # model: claude-4-5-sonnet-min # <- try with claude-4-5-sonnet-high
+    # model: gemini-2-5-flash-dynamic-thinking # <- try with -no-thinking, -low or -high variants
     description: a helpful assistant that thinks
-    instruction: you are a helpful assistant
+    instruction: you are a helpful assistant who can also use tools, but only if you need to
     commands:
       demo: "hey i need python code for a mandelbrot fractal"
     toolsets:
@@ -35,6 +36,26 @@ models:
   claude-4-5-sonnet-high:
     provider: anthropic
     model: claude-sonnet-4-5-20250929
-    thinking_budget: 32768 # <- tokens, 32768 is the suggested maximum without batching
+    thinking_budget: 32768 # <- tokens, 32768 is the Anthropic suggested maximum without batching
     provider_opts:
-      interleaved_thinking: true # <- enable interleaved thinking, aka tool calling during model reasoning
+      interleaved_thinking: true # <- enables interleaved thinking, aka tool calling during model reasoning
+
+  gemini-2-5-flash-dynamic-thinking:
+    provider: google
+    model: gemini-2.5-flash
+    thinking_budget: -1 # <- google only, dynamic thinking
+
+  gemini-2-5-flash-no-thinking:
+    provider: google
+    model: gemini-2.5-flash
+    thinking_budget: 0 # <- google only, no thinking
+  
+  gemini-2-5-flash-low:
+    provider: google
+    model: gemini-2.5-flash
+    thinking_budget: 1024
+  
+  gemini-2-5-flash-high:
+    provider: google
+    model: gemini-2.5-flash
+    thinking_budget: 24576 # <- google's maximum thinking budget for all models except Gemini 2.5 Pro (max 32768)

--- a/pkg/chat/chat.go
+++ b/pkg/chat/chat.go
@@ -119,6 +119,7 @@ type Usage struct {
 	OutputTokens       int `json:"output_tokens"`
 	CachedInputTokens  int `json:"cached_input_tokens"`
 	CachedOutputTokens int `json:"cached_output_tokens"`
+	ReasoningTokens    int `json:"reasoning_tokens,omitempty"`
 }
 
 // MessageStream interface represents a stream of chat completions

--- a/pkg/model/provider/oaistream/adapter.go
+++ b/pkg/model/provider/oaistream/adapter.go
@@ -49,9 +49,13 @@ func (a *StreamAdapter) Recv() (chat.MessageStreamResponse, error) {
 			OutputTokens:       openaiResponse.Usage.CompletionTokens,
 			CachedInputTokens:  0,
 			CachedOutputTokens: 0,
+			ReasoningTokens:    0,
 		}
 		if openaiResponse.Usage.PromptTokensDetails != nil {
 			response.Usage.CachedInputTokens = openaiResponse.Usage.PromptTokensDetails.CachedTokens
+		}
+		if openaiResponse.Usage.CompletionTokensDetails != nil {
+			response.Usage.ReasoningTokens = openaiResponse.Usage.CompletionTokensDetails.ReasoningTokens
 		}
 		// Use the tracked finish reason instead of hardcoding stop
 		finishReason := a.lastFinishReason

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -481,19 +481,19 @@ func (r *runtime) handleStream(ctx context.Context, stream chat.MessageStream, a
 		if response.Usage != nil {
 			if m != nil {
 				sess.Cost += (float64(response.Usage.InputTokens)*m.Cost.Input +
-					float64(response.Usage.OutputTokens)*m.Cost.Output +
+					float64(response.Usage.OutputTokens+response.Usage.ReasoningTokens)*m.Cost.Output +
 					float64(response.Usage.CachedInputTokens)*m.Cost.CacheRead +
 					float64(response.Usage.CachedOutputTokens)*m.Cost.CacheWrite) / 1e6
 			}
 
 			sess.InputTokens = response.Usage.InputTokens + response.Usage.CachedInputTokens
-			sess.OutputTokens = response.Usage.OutputTokens + response.Usage.CachedOutputTokens
+			sess.OutputTokens = response.Usage.OutputTokens + response.Usage.CachedOutputTokens + response.Usage.ReasoningTokens
 
 			modelName := "unknown"
 			if m != nil {
 				modelName = m.Name
 			}
-			telemetry.RecordTokenUsage(ctx, modelName, int64(response.Usage.InputTokens), int64(response.Usage.OutputTokens), sess.Cost)
+			telemetry.RecordTokenUsage(ctx, modelName, int64(response.Usage.InputTokens), int64(response.Usage.OutputTokens+response.Usage.ReasoningTokens), sess.Cost)
 		}
 
 		if len(response.Choices) == 0 {


### PR DESCRIPTION
Adds thinking budget support for the Google provider

Supports:
- dynamic thinking (`thinking_budget: -1`)  
- no thinking (`thinking_budget: 0`, can't disable on 2.5-pro)
- token based thinking (`thinking_budget` <= 24576 for most models, 32768 for 2.5-pro)

Reasoning tokens are also included in usage and cost reporting as well

Closes #70