### PR TITLE
Fix todo update failures by removing ID from create_todos schema

### DIFF
--- a/pkg/tools/builtin/todo.go
+++ b/pkg/tools/builtin/todo.go
@@ -24,12 +24,16 @@ type Todo struct {
 	Status      string `json:"status" jsonschema:"New status (pending, in-progress,completed)"`
 }
 
+type CreateTodoItem struct {
+	Description string `json:"description" jsonschema:"Description of the todo item"`
+}
+
 type CreateTodoArgs struct {
 	Description string `json:"description" jsonschema:"Description of the todo item"`
 }
 
 type CreateTodosArgs struct {
-	Todos []Todo `json:"todos" jsonschema:"List of todo items"`
+	Todos []CreateTodoItem `json:"todos" jsonschema:"List of todo items"`
 }
 
 type UpdateTodoArgs struct {

--- a/pkg/tools/builtin/todo_test.go
+++ b/pkg/tools/builtin/todo_test.go
@@ -77,22 +77,12 @@ func TestTodoTool_Tools(t *testing.T) {
 			"items": {
 				"type": "object",
 				"required": [
-					"id",
-					"description",
-					"status"
+					"description"
 				],
 				"properties": {
 					"description": {
 						"type": "string",
 						"description": "Description of the todo item"
-					},
-					"id": {
-						"type": "string",
-						"description": "ID of the todo item"
-					},
-					"status": {
-						"type": "string",
-						"description": "New status (pending, in-progress,completed)"
 					}
 				},
 				"additionalProperties": false
@@ -191,7 +181,7 @@ func TestTodoTool_CreateTodos(t *testing.T) {
 
 	// Create multiple todos
 	args := CreateTodosArgs{
-		Todos: []Todo{
+		Todos: []CreateTodoItem{
 			{Description: "First todo item"},
 			{Description: "Second todo item"},
 			{Description: "Third todo item"},
@@ -222,7 +212,7 @@ func TestTodoTool_CreateTodos(t *testing.T) {
 
 	// Create multiple todos
 	args = CreateTodosArgs{
-		Todos: []Todo{
+		Todos: []CreateTodoItem{
 			{Description: "Last todo item"},
 		},
 	}


### PR DESCRIPTION
This fixes two related issues with todo management:

1. "todo X not found" errors when updating todos
   - LLMs were providing IDs in create_todos (e.g., "id": "1") because the schema included an id field
   - Backend doesn't care about IDs generated by LLMs and auto-generates its own IDs (e.g., "todo_1") but LLMs would later try to update using the wrong ID format (that it generated primarily)
   - Solution: Created `CreateTodoItem` struct without id/status fields for the create_todos schema, preventing LLM from any confusion

2. Missing todo update events in TUI
   - TUI was updating todos on ToolCall event (before execution)
   - If a tool failed, TUI would show the update even though it never succeeded in the backend
   - Solution: Moved todo updates to ToolCallResponse event with error checking to ensure TUI only updates after successful execution
