### PR TITLE
Add event for mcp init started/finished + basic TUI support

### DIFF
--- a/pkg/runtime/client.go
+++ b/pkg/runtime/client.go
@@ -76,6 +76,8 @@ func NewClient(baseURL string, opts ...ClientOption) (*Client, error) {
 			"authorization_event":    func() Event { return &AuthorizationEvent{} },
 			"agent_choice":           func() Event { return &AgentChoiceEvent{} },
 			"agent_choice_reasoning": func() Event { return &AgentChoiceReasoningEvent{} },
+			"mcp_init_started":       func() Event { return &MCPInitStartedEvent{} },
+			"mcp_init_finished":      func() Event { return &MCPInitFinishedEvent{} },
 		},
 	}
 

--- a/pkg/runtime/event.go
+++ b/pkg/runtime/event.go
@@ -307,3 +307,28 @@ func MaxIterationsReached(maxIterations int) Event {
 func (e *MaxIterationsReachedEvent) GetAgentName() string {
 	return e.AgentName
 }
+
+// MCP initialization lifecycle events
+type MCPInitStartedEvent struct {
+	Type string `json:"type"`
+	AgentContext
+}
+
+func MCPInitStarted(agentName string) Event {
+	return &MCPInitStartedEvent{
+		Type:         "mcp_init_started",
+		AgentContext: AgentContext{AgentName: agentName},
+	}
+}
+
+type MCPInitFinishedEvent struct {
+	Type string `json:"type"`
+	AgentContext
+}
+
+func MCPInitFinished(agentName string) Event {
+	return &MCPInitFinishedEvent{
+		Type:         "mcp_init_finished",
+		AgentContext: AgentContext{AgentName: agentName},
+	}
+}

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -189,6 +189,12 @@ func (p *chatPage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case *runtime.ErrorEvent:
 		cmd := p.messages.AddErrorMessage(msg.Error)
 		return p, tea.Batch(cmd, p.messages.ScrollToBottom())
+	case *runtime.MCPInitStartedEvent:
+		spinnerCmd := p.sidebar.SetMCPInitializing(true)
+		return p, spinnerCmd
+	case *runtime.MCPInitFinishedEvent:
+		spinnerCmd := p.sidebar.SetMCPInitializing(false)
+		return p, spinnerCmd
 	case *runtime.ShellOutputEvent:
 		cmd := p.messages.AddShellOutputMessage(msg.Output)
 		return p, tea.Batch(cmd, p.messages.ScrollToBottom())


### PR DESCRIPTION
Adds 2 events for signaling the start and end of mcp server initialization.

Includes initial basic TUI support so we show a spinner when mcp server init is ongoing

--- 

**Demo**

https://github.com/user-attachments/assets/2018eeef-b3b9-4f21-bfec-ff61c1d134f8

---

closes #503