### PR TITLE
Slash commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ cagent is a multi-agent AI system with hierarchical agent structure and pluggabl
 #### Command Layer (`cmd/root/`)
 
 - **Multiple interfaces**: CLI (`run.go`), TUI (default for `run` command), API (`api.go`)
-- **Interactive commands**: `/exit`, `/reset`, `/eval`, `/usage`, `/compact` during sessions
+- **Interactive commands**: `/exit`, `/reset`, `/eval`, `/usage`, `/compact`, `/copy` during sessions
 - **Debug support**: `--debug` flag for detailed logging
 - **Gateway mode**: SSE-based transport for external MCP clients like Claude Code
 
@@ -290,6 +290,7 @@ agents:
 - `/reset` - Clear session history
 - `/usage` - Show token usage statistics
 - `/compact` - Generate summary and compact session history
+- `/copy` - Copy the current conversation to clipboard
 - `/eval` - Save evaluation data
 
 ## File Locations and Patterns

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -77,6 +77,7 @@ During CLI sessions, you can use special commands:
 | `/reset`   | Clear conversation history                  |
 | `/eval`    | Save current conversation for evaluation    |
 | `/compact` | Compact conversation to lower context usage |
+| `/copy`    | Copy the current conversation to clipboard  |
 
 ## 🔧 Configuration Reference
 

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -112,6 +112,13 @@ func (a *App) CompactSession() {
 	}
 }
 
+// ResetSession clears the conversation history
+func (a *App) ResetSession() {
+	if a.session != nil {
+		a.session.Messages = []session.Item{}
+	}
+}
+
 // ResumeStartOAuth resumes the runtime with OAuth authorization confirmation
 func (a *App) ResumeStartOAuth(bool) {
 	if a.runtime != nil {


### PR DESCRIPTION
The only way to copy from the clipboard is through CMD-P then select copy.
This adds `/copy`, `/reset and `/compact` commands in all modes (including --tui=false).

Fixes #517