### PR TITLE
Fix: Kill shell-spawned processes when stopping sessions

### DIFF
--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -65,6 +65,13 @@ func (r *RemoteRuntime) CurrentAgent() *agent.Agent {
 	return agent.New(r.currentAgent, fmt.Sprintf("Remote agent: %s", r.currentAgent))
 }
 
+// StopPendingProcesses stops all pending tool operations for the remote runtime
+func (r *RemoteRuntime) StopPendingProcesses() error {
+	// For remote runtime, stop the team's toolsets
+	// This will kill any spawned processes from shell tools
+	return r.team.StopToolSets()
+}
+
 // RunStream starts the agent's interaction loop and returns a channel of events
 func (r *RemoteRuntime) RunStream(ctx context.Context, sess *session.Session) <-chan Event {
 	slog.Debug("Starting remote runtime stream", "agent", r.currentAgent, "session_id", r.sessionID)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -65,6 +65,8 @@ type ElicitationRequestHandler func(ctx context.Context, message string, schema 
 type Runtime interface {
 	// CurrentAgent returns the currently active agent
 	CurrentAgent() *agent.Agent
+	// StopPendingProcesses stops all pending tool operations (e.g., running shell commands)
+	StopPendingProcesses() error
 	// RunStream starts the agent's interaction loop and returns a channel of events
 	RunStream(ctx context.Context, sess *session.Session) <-chan Event
 	// Run starts the agent's interaction loop and returns the final messages
@@ -181,6 +183,10 @@ func New(agents *team.Team, opts ...Opt) (Runtime, error) {
 
 func (r *runtime) CurrentAgent() *agent.Agent {
 	return r.team.Agent(r.currentAgent)
+}
+
+func (r *runtime) StopPendingProcesses() error {
+	return r.team.StopToolSets()
 }
 
 // registerDefaultTools registers the default tool handlers


### PR DESCRIPTION
This PR creates a `stopSession` endpoint that allows to stop and clean all spawned resources by the runtime of that process.

**Context:** When `stopSession` was called, it would only cancel the runtime context, leaving child processes spawned by shell commands (like `npm install` or long-running scripts) still running. This fix ensures all spawned processes are properly terminated.