### PR TITLE
Improve handling of ctrl-c

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ cagent new --model dmr/ai/gemma3n:2B-F16 --max-iterations 15
 $ cagent new
 
 ------- Welcome to cagent! -------
-(Ctrl+C to stop the agent or exit)
+(Ctrl+C to stop the agent and exit)
 
 What should your agent/agent team do? (describe its purpose):
 

--- a/cmd/root/api.go
+++ b/cmd/root/api.go
@@ -80,7 +80,7 @@ func runHTTP(cmd *cobra.Command, args []string) error {
 	}
 	defer func() {
 		for _, team := range teams {
-			if err := team.StopToolSets(); err != nil {
+			if err := team.StopToolSets(ctx); err != nil {
 				slog.Error("Failed to stop tool sets", "error", err)
 			}
 		}

--- a/cmd/root/debug.go
+++ b/cmd/root/debug.go
@@ -50,7 +50,7 @@ func debugToolsetsCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	slog.Info("Stopping toolsets", "agent", agentFilename)
-	if err := team.StopToolSets(); err != nil {
+	if err := team.StopToolSets(ctx); err != nil {
 		slog.Error("Failed to stop tool sets", "error", err)
 	}
 

--- a/cmd/root/new.go
+++ b/cmd/root/new.go
@@ -83,7 +83,7 @@ func NewNewCmd() *cobra.Command {
 				fmt.Print(blue("> "))
 
 				var err error
-				prompt, err = readLine(ctx)
+				prompt, err = readLine(ctx, os.Stdin)
 				if err != nil {
 					return fmt.Errorf("failed to read purpose: %w", err)
 				}

--- a/pkg/codemode/codemode.go
+++ b/pkg/codemode/codemode.go
@@ -117,11 +117,11 @@ func (c *codeModeTool) Start(ctx context.Context) error {
 	return nil
 }
 
-func (c *codeModeTool) Stop() error {
+func (c *codeModeTool) Stop(ctx context.Context) error {
 	var errs []error
 
 	for _, t := range c.toolsets {
-		if err := t.Stop(); err != nil {
+		if err := t.Stop(ctx); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/pkg/codemode/codemode_test.go
+++ b/pkg/codemode/codemode_test.go
@@ -79,6 +79,6 @@ func TestCodeModeTool_StartStop(t *testing.T) {
 	err := tool.Start(t.Context())
 	require.NoError(t, err)
 
-	err = tool.Stop()
+	err = tool.Stop(t.Context())
 	require.NoError(t, err)
 }

--- a/pkg/creator/agent.go
+++ b/pkg/creator/agent.go
@@ -40,8 +40,8 @@ func (f *fsToolset) Start(ctx context.Context) error {
 	return f.inner.Start(ctx)
 }
 
-func (f *fsToolset) Stop() error {
-	return f.inner.Stop()
+func (f *fsToolset) Stop(ctx context.Context) error {
+	return f.inner.Stop(ctx)
 }
 
 func (f *fsToolset) SetElicitationHandler(tools.ElicitationHandler) {

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -66,10 +66,10 @@ func (r *RemoteRuntime) CurrentAgent() *agent.Agent {
 }
 
 // StopPendingProcesses stops all pending tool operations for the remote runtime
-func (r *RemoteRuntime) StopPendingProcesses() error {
+func (r *RemoteRuntime) StopPendingProcesses(ctx context.Context) error {
 	// For remote runtime, stop the team's toolsets
 	// This will kill any spawned processes from shell tools
-	return r.team.StopToolSets()
+	return r.team.StopToolSets(ctx)
 }
 
 // RunStream starts the agent's interaction loop and returns a channel of events

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -66,7 +66,7 @@ type Runtime interface {
 	// CurrentAgent returns the currently active agent
 	CurrentAgent() *agent.Agent
 	// StopPendingProcesses stops all pending tool operations (e.g., running shell commands)
-	StopPendingProcesses() error
+	StopPendingProcesses(ctx context.Context) error
 	// RunStream starts the agent's interaction loop and returns a channel of events
 	RunStream(ctx context.Context, sess *session.Session) <-chan Event
 	// Run starts the agent's interaction loop and returns the final messages
@@ -185,8 +185,8 @@ func (r *runtime) CurrentAgent() *agent.Agent {
 	return r.team.Agent(r.currentAgent)
 }
 
-func (r *runtime) StopPendingProcesses() error {
-	return r.team.StopToolSets()
+func (r *runtime) StopPendingProcesses(ctx context.Context) error {
+	return r.team.StopToolSets(ctx)
 }
 
 // registerDefaultTools registers the default tool handlers

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -241,7 +241,7 @@ func (s *Server) editAgentConfigYAML(c echo.Context) error {
 	agentKey := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
 	if oldTeam, exists := s.teams[agentKey]; exists {
 		// Stop old team's toolsets before replacing
-		if err := oldTeam.StopToolSets(); err != nil {
+		if err := oldTeam.StopToolSets(c.Request().Context()); err != nil {
 			slog.Error("Failed to stop old team toolsets", "agentKey", agentKey, "error", err)
 		}
 	}
@@ -327,7 +327,7 @@ func (s *Server) editAgentConfig(c echo.Context) error {
 	agentKey := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
 	if oldTeam, exists := s.teams[agentKey]; exists {
 		// Stop old team's toolsets before replacing
-		if err := oldTeam.StopToolSets(); err != nil {
+		if err := oldTeam.StopToolSets(c.Request().Context()); err != nil {
 			slog.Error("Failed to stop old team toolsets", "agentKey", agentKey, "error", err)
 		}
 	}
@@ -754,7 +754,7 @@ func (s *Server) deleteAgent(c echo.Context) error {
 	// Remove from teams map and stop toolsets if active
 	if t, exists := s.teams[agentKey]; exists {
 		slog.Info("Stopping toolsets for agent", "agentKey", agentKey)
-		if err := t.StopToolSets(); err != nil {
+		if err := t.StopToolSets(c.Request().Context()); err != nil {
 			slog.Error("Failed to stop tool sets for agent", "agentKey", agentKey, "error", err)
 			// Continue with deletion even if stopping toolsets fails
 		}
@@ -816,7 +816,7 @@ func (s *Server) refreshAgentsFromDisk(ctx context.Context) error {
 	for id, oldTeam := range s.teams {
 		if _, exists := newTeams[id]; !exists {
 			// Team no longer exists on disk, stop its tool sets
-			if err := oldTeam.StopToolSets(); err != nil {
+			if err := oldTeam.StopToolSets(ctx); err != nil {
 				slog.Error("Failed to stop tool sets for removed team", "team", id, "error", err)
 			}
 		}
@@ -966,7 +966,7 @@ func (s *Server) stopSession(c echo.Context) error {
 
 		// Stop all pending tool operations (including killing shell-spawned processes)
 		if rtExists {
-			if err := rt.StopPendingProcesses(); err != nil {
+			if err := rt.StopPendingProcesses(c.Request().Context()); err != nil {
 				slog.Error("Failed to stop pending tools for session", "session_id", sessionID, "error", err)
 				// Don't return error here, as we still want to report success for stopping the session
 			}

--- a/pkg/team/team.go
+++ b/pkg/team/team.go
@@ -1,6 +1,7 @@
 package team
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/docker/cagent/pkg/agent"
@@ -57,9 +58,9 @@ func (t *Team) Size() int {
 	return len(t.agents)
 }
 
-func (t *Team) StopToolSets() error {
+func (t *Team) StopToolSets(ctx context.Context) error {
 	for _, agent := range t.agents {
-		if err := agent.StopToolSets(); err != nil {
+		if err := agent.StopToolSets(ctx); err != nil {
 			return fmt.Errorf("failed to stop tool sets: %w", err)
 		}
 	}

--- a/pkg/tools/builtin/fetch.go
+++ b/pkg/tools/builtin/fetch.go
@@ -350,6 +350,6 @@ func (t *FetchTool) Start(context.Context) error {
 	return nil
 }
 
-func (t *FetchTool) Stop() error {
+func (t *FetchTool) Stop(context.Context) error {
 	return nil
 }

--- a/pkg/tools/builtin/fetch_test.go
+++ b/pkg/tools/builtin/fetch_test.go
@@ -86,7 +86,7 @@ func TestFetchTool_StartStop(t *testing.T) {
 	err := tool.Start(t.Context())
 	require.NoError(t, err)
 
-	err = tool.Stop()
+	err = tool.Stop(t.Context())
 	require.NoError(t, err)
 }
 

--- a/pkg/tools/builtin/filesystem.go
+++ b/pkg/tools/builtin/filesystem.go
@@ -1013,7 +1013,7 @@ func (t *FilesystemTool) Start(context.Context) error {
 	return nil
 }
 
-func (t *FilesystemTool) Stop() error {
+func (t *FilesystemTool) Stop(context.Context) error {
 	return nil
 }
 

--- a/pkg/tools/builtin/filesystem_test.go
+++ b/pkg/tools/builtin/filesystem_test.go
@@ -905,7 +905,7 @@ func TestFilesystemTool_StartStop(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test Stop method
-	err = tool.Stop()
+	err = tool.Stop(t.Context())
 	require.NoError(t, err)
 }
 

--- a/pkg/tools/builtin/memory.go
+++ b/pkg/tools/builtin/memory.go
@@ -141,6 +141,6 @@ func (t *MemoryTool) Start(context.Context) error {
 	return nil
 }
 
-func (t *MemoryTool) Stop() error {
+func (t *MemoryTool) Stop(context.Context) error {
 	return nil
 }

--- a/pkg/tools/builtin/memory_test.go
+++ b/pkg/tools/builtin/memory_test.go
@@ -262,7 +262,7 @@ func TestMemoryTool_StartStop(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test Stop method
-	err = tool.Stop()
+	err = tool.Stop(t.Context())
 	require.NoError(t, err)
 }
 

--- a/pkg/tools/builtin/script_shell.go
+++ b/pkg/tools/builtin/script_shell.go
@@ -133,6 +133,6 @@ func (t *ScriptShellTool) Start(context.Context) error {
 	return nil
 }
 
-func (t *ScriptShellTool) Stop() error {
+func (t *ScriptShellTool) Stop(context.Context) error {
 	return nil
 }

--- a/pkg/tools/builtin/shell.go
+++ b/pkg/tools/builtin/shell.go
@@ -239,7 +239,7 @@ func (t *ShellTool) Start(context.Context) error {
 	return nil
 }
 
-func (t *ShellTool) Stop() error {
+func (t *ShellTool) Stop(context.Context) error {
 	t.handler.mu.Lock()
 	defer t.handler.mu.Unlock()
 

--- a/pkg/tools/builtin/shell_test.go
+++ b/pkg/tools/builtin/shell_test.go
@@ -214,7 +214,7 @@ func TestShellTool_StartStop(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test Stop method
-	err = tool.Stop()
+	err = tool.Stop(t.Context())
 	require.NoError(t, err)
 }
 

--- a/pkg/tools/builtin/think.go
+++ b/pkg/tools/builtin/think.go
@@ -77,6 +77,6 @@ func (t *ThinkTool) Start(context.Context) error {
 	return nil
 }
 
-func (t *ThinkTool) Stop() error {
+func (t *ThinkTool) Stop(context.Context) error {
 	return nil
 }

--- a/pkg/tools/builtin/think_test.go
+++ b/pkg/tools/builtin/think_test.go
@@ -149,7 +149,7 @@ func TestThinkTool_StartStop(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test Stop method
-	err = tool.Stop()
+	err = tool.Stop(t.Context())
 	require.NoError(t, err)
 }
 

--- a/pkg/tools/builtin/todo.go
+++ b/pkg/tools/builtin/todo.go
@@ -214,6 +214,6 @@ func (t *TodoTool) Start(context.Context) error {
 	return nil
 }
 
-func (t *TodoTool) Stop() error {
+func (t *TodoTool) Stop(context.Context) error {
 	return nil
 }

--- a/pkg/tools/builtin/todo_test.go
+++ b/pkg/tools/builtin/todo_test.go
@@ -411,7 +411,7 @@ func TestTodoTool_StartStop(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test Stop method
-	err = tool.Stop()
+	err = tool.Stop(t.Context())
 	require.NoError(t, err)
 }
 

--- a/pkg/tools/builtin/transfertask.go
+++ b/pkg/tools/builtin/transfertask.go
@@ -47,6 +47,6 @@ func (t *TransferTaskTool) Start(context.Context) error {
 	return nil
 }
 
-func (t *TransferTaskTool) Stop() error {
+func (t *TransferTaskTool) Stop(context.Context) error {
 	return nil
 }

--- a/pkg/tools/builtin/transfertask_test.go
+++ b/pkg/tools/builtin/transfertask_test.go
@@ -84,6 +84,6 @@ func TestTaskTool_StartStop(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test Stop method
-	err = tool.Stop()
+	err = tool.Stop(t.Context())
 	require.NoError(t, err)
 }

--- a/pkg/tools/mcp/gateway.go
+++ b/pkg/tools/mcp/gateway.go
@@ -105,8 +105,8 @@ func (t *GatewayToolset) Start(ctx context.Context) error {
 	return t.cmdToolset.Start(ctx)
 }
 
-func (t *GatewayToolset) Stop() error {
-	stopErr := t.cmdToolset.Stop()
+func (t *GatewayToolset) Stop(ctx context.Context) error {
+	stopErr := t.cmdToolset.Stop(ctx)
 	cleanUpSecretsErr := t.cleanUpSecrets()
 	cleanUpConfigErr := t.cleanUpConfig()
 

--- a/pkg/tools/mcp/remote.go
+++ b/pkg/tools/mcp/remote.go
@@ -170,7 +170,7 @@ func (c *remoteMCPClient) createHTTPClient() *http.Client {
 	}
 }
 
-func (c *remoteMCPClient) Close() error {
+func (c *remoteMCPClient) Close(context.Context) error {
 	c.mu.RLock()
 	session := c.session
 	c.mu.RUnlock()

--- a/pkg/tools/mcp/stdio.go
+++ b/pkg/tools/mcp/stdio.go
@@ -47,11 +47,12 @@ func (c *stdioMCPClient) Initialize(ctx context.Context, _ *mcp.InitializeReques
 	return c.session.InitializeResult(), nil
 }
 
-func (c *stdioMCPClient) Close() error {
-	if c.session != nil {
-		return c.session.Close()
+func (c *stdioMCPClient) Close(context.Context) error {
+	if c.session == nil {
+		return nil
 	}
-	return nil
+
+	return c.session.Close()
 }
 
 func (c *stdioMCPClient) ListTools(ctx context.Context, request *mcp.ListToolsParams) iter.Seq2[*mcp.Tool, error] {

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -52,7 +52,7 @@ type ToolSet interface {
 	Tools(ctx context.Context) ([]Tool, error)
 	Instructions() string
 	Start(ctx context.Context) error
-	Stop() error
+	Stop(ctx context.Context) error
 	SetElicitationHandler(handler ElicitationHandler)
 	SetOAuthSuccessHandler(handler func())
 }


### PR DESCRIPTION
+ Don't let MCP tools error out if the context was cancelled
+ Let the user exit cagent exec with ctrl-c

Fixes https://github.com/docker/cagent/issues/535