### PR TITLE
Attempt to fix SQLite database locking issues with concurrent access

### DIFF
--- a/pkg/memory/database/sqlite/sqlite.go
+++ b/pkg/memory/database/sqlite/sqlite.go
@@ -14,10 +14,19 @@ type MemoryDatabase struct {
 }
 
 func NewMemoryDatabase(path string) (database.Database, error) {
-	db, err := sql.Open("sqlite", path)
+	// Add query parameters for better concurrency handling
+	// _busy_timeout: Wait up to 5 seconds if database is locked
+	// _journal_mode=WAL: Enable Write-Ahead Logging for better concurrent access
+	db, err := sql.Open("sqlite", path+"?_busy_timeout=5000&_journal_mode=WAL")
 	if err != nil {
 		return nil, err
 	}
+
+	// Configure connection pool to serialize writes (SQLite limitation)
+	// This prevents "database is locked" errors from concurrent writes
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	db.SetConnMaxLifetime(0)
 
 	_, err = db.ExecContext(context.Background(), "CREATE TABLE IF NOT EXISTS memories (id TEXT PRIMARY KEY, created_at TEXT, memory TEXT)")
 	if err != nil {

--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -42,10 +42,19 @@ type SQLiteSessionStore struct {
 
 // NewSQLiteSessionStore creates a new SQLite session store
 func NewSQLiteSessionStore(path string) (Store, error) {
-	db, err := sql.Open("sqlite", path)
+	// Add query parameters for better concurrency handling
+	// _busy_timeout: Wait up to 5 seconds if database is locked
+	// _journal_mode=WAL: Enable Write-Ahead Logging for better concurrent access
+	db, err := sql.Open("sqlite", path+"?_busy_timeout=5000&_journal_mode=WAL")
 	if err != nil {
 		return nil, err
 	}
+
+	// Configure connection pool to serialize writes (SQLite limitation)
+	// This prevents "database is locked" errors from concurrent writes
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	db.SetConnMaxLifetime(0)
 
 	_, err = db.ExecContext(context.Background(), `
 		CREATE TABLE IF NOT EXISTS sessions (


### PR DESCRIPTION
Fixes https://github.com/docker/cagent/issues/544.

This PR configures SQLite connections with proper concurrency handling to prevent "database is locked" errors when multiple operations access the database simultaneously.

Details:
- Add busy_timeout (5s) to wait for locks instead of failing immediately
- Enable WAL mode for better concurrent read/write performance
- Configure connection pool to serialize writes (SQLite best practice)

Fixes session store and memory database SQLite implementations.