### PR TITLE
This is broken

### DIFF
--- a/pkg/tui/components/markdown/renderer.go
+++ b/pkg/tui/components/markdown/renderer.go
@@ -14,6 +14,9 @@ func NewRenderer(width int) *glamour.TermRenderer {
 	customDarkStyle.Document.BlockPrefix = ""
 	customDarkStyle.Document.BlockSuffix = ""
 
+	// The default indent token is buggy. It breaks line splitting.
+	customDarkStyle.BlockQuote.IndentToken = nil
+
 	r, _ := glamour.NewTermRenderer(
 		glamour.WithWordWrap(min(width, 120)),
 		glamour.WithStyles(customDarkStyle),


### PR DESCRIPTION
Rendering this:

```
 > Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
```

is broken on many different widths.

e.g:

```
│ Lorem ipsum dolor sit
│ amet, consectetur
│ adipiscing elit, sed do
│ eiusmod tempor
incididunt
│ ut labore et dolore
magna
│ aliqua. Ut enim ad minim
│ veniam, quis nostrud
│ exercitation ullamco
│ laboris nisi ut aliquip
│ ex ea commodo consequat.
│ Duis aute irure dolor in
│ reprehenderit in
│ voluptate velit esse
│ cillum dolore eu fugiat
│ nulla pariatur.
Excepteur
│ sint occaecat cupidatat
│ non proident, sunt in
│ culpa qui officia
│ deserunt mollit anim id
│ est laborum.
```

Removing the indent prefix fixes it.