### PR TITLE
Remove unused CreateTodoItem struct

### DIFF
--- a/pkg/tools/builtin/todo.go
+++ b/pkg/tools/builtin/todo.go
@@ -24,10 +24,6 @@ type Todo struct {
 	Status      string `json:"status" jsonschema:"New status (pending, in-progress,completed)"`
 }
 
-type CreateTodoItem struct {
-	Description string `json:"description" jsonschema:"Description of the todo item"`
-}
-
 type CreateTodoArgs struct {
 	Description string `json:"description" jsonschema:"Description of the todo item"`
 }


### PR DESCRIPTION
After https://github.com/docker/cagent/pull/480, `CreateTodoItem` became redundant