### PR TITLE
Fixes #574 - "Thinking:" prefix missing in CLI mode (--tui=false)

### DIFF
--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -446,6 +446,10 @@ func runWithoutTUI(ctx context.Context, agentFilename string, rt runtime.Runtime
 					}
 					llmIsTyping = true
 				}
+				// Add newline when transitioning from reasoning to regular content
+				if reasoningStarted {
+					fmt.Println()
+				}
 				reasoningStarted = false // Reset when regular content starts
 				fmt.Printf("%s", e.Content)
 			case *runtime.AgentChoiceReasoningEvent:


### PR DESCRIPTION
## Changes
- Added state tracking (`reasoningStarted` boolean) to handle streaming reasoning events
- Print "Thinking:" prefix only once per reasoning sequence
- Include agent name for sub-agents (e.g., "Thinking: helper:")
- Reset state appropriately when switching agents or content types

## Testing
Tested with Docker Model Runner (DMR) using `ai/gpt-oss:latest`:
- [x] Reasoning prefix appears in CLI mode
- [x] TUI and CLI behavior now consistent
- [x] All existing tests pass

Signed-off-by: Sadique Azmi <sadiquemobaraka5@gmail.com>