### PR TITLE
Allow toolsets to fail initialization without taking down the app

### DIFF
--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -1,0 +1,90 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/cagent/pkg/tools"
+)
+
+type stubToolSet struct {
+	startErr     error
+	tools        []tools.Tool
+	listErr      error
+	instructions string
+}
+
+func newStubToolSet(startErr error, toolsList []tools.Tool, listErr error) tools.ToolSet {
+	return &stubToolSet{
+		startErr:     startErr,
+		tools:        toolsList,
+		listErr:      listErr,
+		instructions: "stub",
+	}
+}
+
+func (s *stubToolSet) Start(context.Context) error { return s.startErr }
+func (s *stubToolSet) Stop(context.Context) error  { return nil }
+func (s *stubToolSet) Tools(context.Context) ([]tools.Tool, error) {
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+	return s.tools, nil
+}
+func (s *stubToolSet) Instructions() string                           { return s.instructions }
+func (s *stubToolSet) SetElicitationHandler(tools.ElicitationHandler) {}
+func (s *stubToolSet) SetOAuthSuccessHandler(func())                  {}
+
+func TestAgentTools(t *testing.T) {
+	tests := []struct {
+		name          string
+		toolsets      []tools.ToolSet
+		wantToolCount int
+		wantWarnings  int
+	}{
+		{
+			name:          "partial success",
+			toolsets:      []tools.ToolSet{newStubToolSet(nil, []tools.Tool{{Name: "good", Parameters: map[string]any{}}}, nil), newStubToolSet(errors.New("boom"), nil, nil)},
+			wantToolCount: 1,
+			wantWarnings:  1,
+		},
+		{
+			name:          "all fail on start",
+			toolsets:      []tools.ToolSet{newStubToolSet(errors.New("fail1"), nil, nil), newStubToolSet(errors.New("fail2"), nil, nil)},
+			wantToolCount: 0,
+			wantWarnings:  2,
+		},
+		{
+			name:          "list failure becomes warning",
+			toolsets:      []tools.ToolSet{newStubToolSet(nil, nil, errors.New("list boom"))},
+			wantToolCount: 0,
+			wantWarnings:  1,
+		},
+		{
+			name:          "no toolsets",
+			toolsets:      nil,
+			wantToolCount: 0,
+			wantWarnings:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := New("root", "test", WithToolSets(tt.toolsets...))
+			got, err := a.Tools(t.Context())
+
+			require.NoError(t, err)
+			require.Len(t, got, tt.wantToolCount)
+
+			warnings := a.DrainWarnings()
+			if tt.wantWarnings == 0 {
+				require.Nil(t, warnings)
+			} else {
+				require.Len(t, warnings, tt.wantWarnings)
+			}
+		})
+	}
+}

--- a/pkg/agent/opts.go
+++ b/pkg/agent/opts.go
@@ -97,6 +97,14 @@ func WithCommands(commands map[string]string) Opt {
 	}
 }
 
+func WithLoadTimeWarnings(warnings []string) Opt {
+	return func(a *Agent) {
+		for _, w := range warnings {
+			a.addToolWarning(w)
+		}
+	}
+}
+
 type StartableToolSet struct {
 	tools.ToolSet
 	started atomic.Bool

--- a/pkg/runtime/event.go
+++ b/pkg/runtime/event.go
@@ -168,6 +168,20 @@ func ShellOutput(output string) Event {
 	}
 }
 
+type WarningEvent struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+	AgentContext
+}
+
+func Warning(message, agentName string) Event {
+	return &WarningEvent{
+		Type:         "warning",
+		Message:      message,
+		AgentContext: AgentContext{AgentName: agentName},
+	}
+}
+
 type TokenUsageEvent struct {
 	Type  string `json:"type"`
 	Usage *Usage `json:"usage"`

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -223,6 +223,9 @@ func (r *runtime) RunStream(ctx context.Context, sess *session.Session) <-chan E
 
 		// Set elicitation handler on all MCP toolsets before getting tools
 		a := r.CurrentAgent()
+
+		r.emitAgentWarnings(a, events)
+
 		for _, toolset := range a.ToolSets() {
 			toolset.SetElicitationHandler(r.elicitationHandler)
 			toolset.SetOAuthSuccessHandler(func() {
@@ -404,9 +407,8 @@ func (r *runtime) RunStream(ctx context.Context, sess *session.Session) <-chan E
 	return events
 }
 
+// getTools executes tool retrieval with automatic OAuth handling
 func (r *runtime) getTools(ctx context.Context, a *agent.Agent, sessionSpan trace.Span, events chan Event) ([]tools.Tool, error) {
-	// Execute tool retrieval with automatic OAuth handling
-	var agentTools []tools.Tool
 	shouldEmitMCPInit := events != nil && len(a.ToolSets()) > 0
 	if shouldEmitMCPInit {
 		events <- MCPInitStarted(a.Name())
@@ -417,7 +419,7 @@ func (r *runtime) getTools(ctx context.Context, a *agent.Agent, sessionSpan trac
 		}
 	}()
 
-	tls, err := a.Tools(ctx)
+	agentTools, err := a.Tools(ctx)
 	if err != nil {
 		slog.Error("Failed to get agent tools", "agent", a.Name(), "error", err)
 		sessionSpan.RecordError(err)
@@ -425,10 +427,35 @@ func (r *runtime) getTools(ctx context.Context, a *agent.Agent, sessionSpan trac
 		telemetry.RecordError(ctx, err.Error())
 		return nil, err
 	}
-	agentTools = tls
 
 	slog.Debug("Retrieved agent tools", "agent", a.Name(), "tool_count", len(agentTools))
 	return agentTools, nil
+}
+
+func (r *runtime) emitAgentWarnings(a *agent.Agent, events chan Event) {
+	warnings := a.DrainWarnings()
+	if len(warnings) == 0 {
+		return
+	}
+
+	slog.Warn("Tool setup partially failed; continuing", "agent", a.Name(), "warnings", warnings)
+
+	if events != nil {
+		events <- Warning(formatToolWarning(a, warnings), r.currentAgent)
+	}
+}
+
+func formatToolWarning(a *agent.Agent, warnings []string) string {
+	var builder strings.Builder
+	builder.WriteString(fmt.Sprintf("Some toolsets failed to initialize for agent '%s'.\n\n", a.Name()))
+	builder.WriteString("Details:\n\n")
+	for _, warning := range warnings {
+		builder.WriteString("- ")
+		builder.WriteString(warning)
+		builder.WriteByte('\n')
+	}
+
+	return strings.TrimSuffix(builder.String(), "\n")
 }
 
 func (r *runtime) Resume(_ context.Context, confirmationType string) {

--- a/pkg/tui/components/message/message.go
+++ b/pkg/tui/components/message/message.go
@@ -119,6 +119,8 @@ func (mv *messageModel) Render(width int) string {
 		return styles.MutedStyle.Render("•" + strings.Repeat("─", mv.width-3) + "•")
 	case types.MessageTypeError:
 		return styles.ErrorStyle.Render("│ " + msg.Content)
+	case types.MessageTypeWarning:
+		return styles.WarningStyle.Render(msg.Content)
 	case types.MessageTypeSystem:
 		return styles.MutedStyle.Render("ℹ " + msg.Content)
 	default:

--- a/pkg/tui/components/messages/messages.go
+++ b/pkg/tui/components/messages/messages.go
@@ -36,6 +36,7 @@ type Model interface {
 	AppendToLastMessage(agentName string, messageType types.MessageType, content string) tea.Cmd
 	ScrollToBottom() tea.Cmd
 	AddShellOutputMessage(content string) tea.Cmd
+	AddWarningMessage(content string) tea.Cmd
 	AddSystemMessage(content string) tea.Cmd
 	PlainTextTranscript() string
 	IsAtBottom() bool
@@ -428,6 +429,14 @@ func (m *model) AddErrorMessage(content string) tea.Cmd {
 func (m *model) AddShellOutputMessage(content string) tea.Cmd {
 	return m.addMessage(&types.Message{
 		Type:    types.MessageTypeShellOutput,
+		Content: content,
+	})
+}
+
+func (m *model) AddWarningMessage(content string) tea.Cmd {
+	// Create a new warning message
+	return m.addMessage(&types.Message{
+		Type:    types.MessageTypeWarning,
 		Content: content,
 	})
 }

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -199,6 +199,9 @@ func (p *chatPage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case *runtime.ShellOutputEvent:
 		cmd := p.messages.AddShellOutputMessage(msg.Output)
 		return p, tea.Batch(cmd, p.messages.ScrollToBottom())
+	case *runtime.WarningEvent:
+		cmd := p.messages.AddWarningMessage(msg.Message)
+		return p, tea.Batch(cmd, p.messages.ScrollToBottom())
 	case *runtime.UserMessageEvent:
 		cmd := p.messages.AddUserMessage(msg.Message)
 		return p, tea.Batch(cmd, p.messages.ScrollToBottom())

--- a/pkg/tui/types/types.go
+++ b/pkg/tui/types/types.go
@@ -16,6 +16,7 @@ const (
 	MessageTypeToolCall
 	MessageTypeToolResult
 	MessageTypeSystem
+	MessageTypeWarning
 )
 
 // ToolStatus represents the status of a tool call


### PR DESCRIPTION
We don't want to crash the app if a single toolset has problems, instead lets log a warning, show it to the user, and let the agent continue

---

Screenshot:

<img width="1472" height="611" alt="Screenshot 2025-10-23 at 14 35 02" src="https://github.com/user-attachments/assets/44e94272-aa79-42c9-9a21-a1a5724fa92c" />

---

Closes #33 