### PR TITLE
winget: automatically publish releases

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,24 @@
+name: winget
+
+on:
+  release:
+    types: [published]
+
+env:
+  WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_TOKEN }}
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - name: publish
+        run: |
+          $Release = '${{ toJSON(github.event.release) }}' | ConvertFrom-Json
+          $Version = $Release.tag_name
+          $PackageId = "Docker.Cagent"
+          $Urls = @(
+            "https://github.com/docker/cagent/releases/download/$Version/cagent-windows-amd64.exe|amd64",
+            "https://github.com/docker/cagent/releases/download/$Version/cagent-windows-arm64.exe|arm64"
+          )
+          & curl.exe -JLO https://aka.ms/wingetcreate/latest
+          & .\wingetcreate.exe update $PackageId -s -v $Version -u $Urls


### PR DESCRIPTION
Adds a new GitHub action that automates the publishing of new winget manifests.

The workflow is triggered when a release is published and requires a repository secret to be set that has public repo access.

Info on requirements for the token can be found [here](https://github.com/microsoft/winget-pkgs/pull/306270).

I made the assumption that your tags will always be your release version (that seems to be the case so far).