### PR TITLE
Don't cache messages

### DIFF
--- a/pkg/tui/components/messages/messages.go
+++ b/pkg/tui/components/messages/messages.go
@@ -46,7 +46,6 @@ type renderedItem struct {
 	id     int    // Message ID or index as int
 	view   string // Cached rendered content
 	height int    // Height in lines
-	start  int    // Starting line position in complete content
 	end    int    // Ending line position in complete content
 }
 
@@ -351,7 +350,6 @@ func (m *model) ensureAllItemsRendered() {
 		item := m.renderItem(i, view)
 
 		// Update position information
-		item.start = currentPosition
 		if item.height > 0 {
 			item.end = currentPosition + item.height - 1
 		} else {


### PR DESCRIPTION
renderItem already caches what needs to be cached

Fixes #441

Signed-off-by: Djordje Lukic <djordje.lukic@docker.com>