### PR TITLE
Workaround for bad endpoint returned by docker model status

### DIFF
--- a/pkg/model/provider/dmr/client.go
+++ b/pkg/model/provider/dmr/client.go
@@ -74,6 +74,9 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, opts ...options.Opt
 				},
 			},
 		}
+	// NOTE(krissetto): Workaround for a bug in the DMR CLI v0.1.44
+	case endpoint == "http://:0/engines/v1/":
+		clientConfig.BaseURL = "http://127.0.0.1:12434/engines/v1/"
 	default:
 		// Docker CE
 		clientConfig.BaseURL = endpoint


### PR DESCRIPTION
`docker model status --json` returns an invalid endpoint on linux when used with Docker CE, so lets create a workaround so that users that are not fully up to date in the future can still use cagent with DMR.

Closes #598 