### PR TITLE
Fix stream cancellation in the TUI

### DIFF
--- a/pkg/tui/components/message/message.go
+++ b/pkg/tui/components/message/message.go
@@ -117,6 +117,8 @@ func (mv *messageModel) Render(width int) string {
 		return msg.Content
 	case types.MessageTypeSeparator:
 		return styles.MutedStyle.Render("•" + strings.Repeat("─", mv.width-3) + "•")
+	case types.MessageTypeCancelled:
+		return styles.WarningStyle.Render("⚠ stream cancelled ⚠")
 	case types.MessageTypeError:
 		return styles.ErrorStyle.Render("│ " + msg.Content)
 	case types.MessageTypeSystem:

--- a/pkg/tui/types/types.go
+++ b/pkg/tui/types/types.go
@@ -13,6 +13,7 @@ const (
 	MessageTypeError
 	MessageTypeShellOutput
 	MessageTypeSeparator
+	MessageTypeCancelled
 	MessageTypeToolCall
 	MessageTypeToolResult
 	MessageTypeSystem


### PR DESCRIPTION
Fixes stream cancellation logic in the TUI by stopping and removing all spinners, allowing the user to send followup messages, and adds a message indicating to the user that the stream has been canceled

---

Screenshot

<img width="1413" height="776" alt="Screenshot From 2025-10-24 13-49-30" src="https://github.com/user-attachments/assets/63d8f335-19e8-4306-b8ad-24ea1e8e136d" />

---

Closes #597 