### PR TITLE
Better handling of the gateway

### DIFF
--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -2,28 +2,101 @@ package httpclient
 
 import (
 	"fmt"
+	"maps"
 	"net/http"
 	"runtime"
 
 	"github.com/docker/cagent/pkg/version"
 )
 
+type HTTPOptions struct {
+	Header http.Header
+}
+
+type Opt func(*HTTPOptions)
+
+func NewHTTPClient(opts ...Opt) *http.Client {
+	httpOptions := HTTPOptions{
+		Header: make(http.Header),
+	}
+
+	for _, opt := range opts {
+		opt(&httpOptions)
+	}
+
+	// Enforce a consistent User-Agent header
+	httpOptions.Header.Set("User-Agent", fmt.Sprintf("Cagent/%s (%s; %s)", version.Version, getNormalizedOS(), getNormalizedArchitecture()))
+
+	return &http.Client{
+		Transport: &userAgentTransport{
+			httpOptions: httpOptions,
+			rt:          http.DefaultTransport,
+		},
+	}
+}
+
+func WithHeader(key, value string) Opt {
+	return func(o *HTTPOptions) {
+		o.Header.Set(key, value)
+	}
+}
+
+func WithProxiedBaseURL(value string) Opt {
+	return func(o *HTTPOptions) {
+		o.Header.Set("X-Cagent-Forward", value)
+
+		// Enforce consistent headers (Anthropic client sets similar header already)
+		o.Header.Set("X-Cagent-Lang", "go")
+		o.Header.Set("X-Cagent-OS", getNormalizedOS())
+		o.Header.Set("X-Cagent-Arch", getNormalizedArchitecture())
+		o.Header.Set("X-Cagent-Runtime", "cagent")
+		o.Header.Set("X-Cagent-Runtime-Version", version.Version)
+	}
+}
+
 type userAgentTransport struct {
-	agent string
-	rt    http.RoundTripper
+	httpOptions HTTPOptions
+	rt          http.RoundTripper
 }
 
 func (u *userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	r2 := req.Clone(req.Context())
-	r2.Header.Set("User-Agent", u.agent)
+	maps.Copy(r2.Header, u.httpOptions.Header)
 	return u.rt.RoundTrip(r2)
 }
 
-func NewHttpClient() *http.Client {
-	return &http.Client{
-		Transport: &userAgentTransport{
-			agent: fmt.Sprintf("Cagent/%s (%s; %s)", version.Version, runtime.GOOS, runtime.GOARCH),
-			rt:    http.DefaultTransport,
-		},
+func getNormalizedOS() string {
+	switch runtime.GOOS {
+	case "ios":
+		return "iOS"
+	case "android":
+		return "Android"
+	case "darwin":
+		return "MacOS"
+	case "window":
+		return "Windows"
+	case "freebsd":
+		return "FreeBSD"
+	case "openbsd":
+		return "OpenBSD"
+	case "linux":
+		return "Linux"
+	default:
+		return fmt.Sprintf("Other:%s", runtime.GOOS)
+	}
+}
+
+func getNormalizedArchitecture() string {
+	switch runtime.GOARCH {
+	case "386":
+		return "x32"
+	case "amd64":
+		return "x64"
+	case "arm":
+		return "arm"
+	case "arm64":
+		return "arm64"
+	default:
+		return fmt.Sprintf("other:%s", runtime.GOARCH)
 	}
 }

--- a/pkg/model/provider/anthropic/client.go
+++ b/pkg/model/provider/anthropic/client.go
@@ -82,7 +82,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 		slog.Debug("Anthropic API key found, creating client")
 		requestOptions := []option.RequestOption{
 			option.WithAPIKey(authToken),
-			option.WithHTTPClient(httpclient.NewHttpClient()),
+			option.WithHTTPClient(httpclient.NewHTTPClient()),
 		}
 		if cfg.BaseURL != "" {
 			requestOptions = append(requestOptions, option.WithBaseURL(cfg.BaseURL))
@@ -110,7 +110,9 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 				option.WithAuthToken(authToken),
 				option.WithAPIKey(authToken),
 				option.WithBaseURL(gateway),
-				option.WithHTTPClient(httpclient.NewHttpClient()),
+				option.WithHTTPClient(httpclient.NewHTTPClient(
+					httpclient.WithProxiedBaseURL(defaultsTo(cfg.BaseURL, "https://api.anthropic.com/")),
+				)),
 			), nil
 		}
 	}
@@ -656,4 +658,11 @@ func countAnthropicTokens(
 		return 0, err
 	}
 	return result.InputTokens, nil
+}
+
+func defaultsTo(value, defaultValue string) string {
+	if value != "" {
+		return value
+	}
+	return defaultValue
 }

--- a/pkg/model/provider/gemini/client.go
+++ b/pkg/model/provider/gemini/client.go
@@ -52,7 +52,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 		client, err := genai.NewClient(ctx, &genai.ClientConfig{
 			APIKey:     apiKey,
 			Backend:    genai.BackendGeminiAPI,
-			HTTPClient: httpclient.NewHttpClient(),
+			HTTPClient: httpclient.NewHTTPClient(),
 			HTTPOptions: genai.HTTPOptions{
 				BaseURL: cfg.BaseURL,
 			},
@@ -80,9 +80,11 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 			}
 
 			return genai.NewClient(ctx, &genai.ClientConfig{
-				APIKey:     authToken,
-				Backend:    genai.BackendGeminiAPI,
-				HTTPClient: httpclient.NewHttpClient(),
+				APIKey:  authToken,
+				Backend: genai.BackendGeminiAPI,
+				HTTPClient: httpclient.NewHTTPClient(
+					httpclient.WithProxiedBaseURL(defaultsTo(cfg.BaseURL, "https://generativelanguage.googleapis.com/")),
+				),
 				HTTPOptions: genai.HTTPOptions{
 					BaseURL: gateway,
 					Headers: http.Header{
@@ -345,4 +347,11 @@ func (c *Client) CreateChatCompletionStream(
 	// Build a fresh client per request when using the gateway
 	iter := client.Models.GenerateContentStream(ctx, c.ModelConfig.Model, contents, config)
 	return NewStreamAdapter(iter, c.ModelConfig.Model), nil
+}
+
+func defaultsTo(value, defaultValue string) string {
+	if value != "" {
+		return value
+	}
+	return defaultValue
 }

--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -72,7 +72,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 			openaiConfig.BaseURL = cfg.BaseURL
 		}
 
-		openaiConfig.HTTPClient = httpclient.NewHttpClient()
+		openaiConfig.HTTPClient = httpclient.NewHTTPClient()
 
 		// TODO: Move this logic to ProviderAliases as a config function
 		if cfg.ProviderOpts != nil {
@@ -109,7 +109,9 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 
 			openaiConfig := openai.DefaultConfig(authToken)
 			openaiConfig.BaseURL = gateway + "/v1"
-			openaiConfig.HTTPClient = httpclient.NewHttpClient()
+			openaiConfig.HTTPClient = httpclient.NewHTTPClient(
+				httpclient.WithProxiedBaseURL(defaultsTo(cfg.BaseURL, "https://api.openai.com/v1")),
+			)
 
 			return openai.NewClientWithConfig(openaiConfig), nil
 		}
@@ -392,4 +394,11 @@ type jsonSchema map[string]any
 
 func (j jsonSchema) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]any(j))
+}
+
+func defaultsTo(value, defaultValue string) string {
+	if value != "" {
+		return value
+	}
+	return defaultValue
 }


### PR DESCRIPTION
Always use a custom http client, with a custom user-agent and custom telemetry headers.