### PR TITLE
Text cannot be selected in the TUI

### DIFF
--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -25,7 +25,7 @@ var lastMouseEvent time.Time
 // MouseEventFilter filters mouse events to prevent spam
 func MouseEventFilter(_ tea.Model, msg tea.Msg) tea.Msg {
 	switch msg.(type) {
-	case tea.MouseWheelMsg, tea.MouseMotionMsg:
+	case tea.MouseWheelMsg, tea.MouseMotionMsg, tea.MouseMsg:
 		now := time.Now()
 		if now.Sub(lastMouseEvent) < 20*time.Millisecond {
 			return nil


### PR DESCRIPTION
I detected that I'm not able to select text inside of the TUI (MacOS / Terminal and VSCode integrated Terminal). This is bad if I want to reuse the generated text anywhere else.

> [!NOTE]
> This fix was created by using `cagent run ./golang_developer.yaml` and simply prompting `selecting text in the TUI is not possible, fix it` - I did not have to study the codebase at all.