### PR TITLE
Fix wrapping toolsets with instructions

### DIFF
--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -437,7 +437,7 @@ func getToolsForAgent(ctx context.Context, a *latest.AgentConfig, parentDir stri
 		}
 
 		wrapped := WithToolsFilter(tool, toolset.Tools...)
-		wrapped = WithInstructions(wrapped, a.Instruction)
+		wrapped = WithInstructions(wrapped, toolset.Instruction)
 
 		toolSets = append(toolSets, wrapped)
 	}

--- a/pkg/teamloader/teamloader_test.go
+++ b/pkg/teamloader/teamloader_test.go
@@ -128,3 +128,18 @@ func TestOverrideModel(t *testing.T) {
 		})
 	}
 }
+
+func TestToolsetInstructions(t *testing.T) {
+	team, err := Load(t.Context(), "testdata/tool-instruction.yaml", config.RuntimeConfig{})
+	require.NoError(t, err)
+
+	agent, err := team.Agent("root")
+	require.NoError(t, err)
+
+	toolsets := agent.ToolSets()
+	require.Len(t, toolsets, 1)
+
+	instructions := toolsets[0].Instructions()
+	expected := "Dummy fetch tool instruction"
+	require.Equal(t, expected, instructions)
+}

--- a/pkg/teamloader/testdata/tool-instruction.yaml
+++ b/pkg/teamloader/testdata/tool-instruction.yaml
@@ -1,0 +1,9 @@
+version: "2"
+
+agents:
+  root:
+    model: dmr/agi:1.0
+    instruction: Be good
+    toolsets:
+      - type: fetch
+        instruction: Dummy fetch tool instruction


### PR DESCRIPTION
The wrapping toolset was given the agent instructions instead of the ones from the toolset, making all the builtin system instructions the same as the agent one. Basically we would get _n_ times (as much as builtin toolsets defined in the agent) the same system prompt from the agent.