### PR TITLE
The command palette should not move

### DIFF
--- a/pkg/tui/dialog/command_palette.go
+++ b/pkg/tui/dialog/command_palette.go
@@ -283,11 +283,8 @@ func (d *commandPaletteDialog) Position() (row, col int) {
 
 	maxHeight := min(d.height*70/100, 30)
 
-	// Estimate dialog height
-	dialogHeight := min(8+len(d.filtered), maxHeight)
-
 	// Center the dialog
-	row = max(0, (d.height-dialogHeight)/2)
+	row = max(0, (d.height-maxHeight)/2)
 	col = max(0, (d.width-dialogWidth)/2)
 	return row, col
 }
@@ -297,11 +294,4 @@ func (d *commandPaletteDialog) SetSize(width, height int) tea.Cmd {
 	d.width = width
 	d.height = height
 	return nil
-}
-
-// OpenCommandPalette returns a command to open the command palette
-func OpenCommandPalette(categories []CommandCategory) tea.Cmd {
-	return core.CmdHandler(OpenDialogMsg{
-		Model: NewCommandPaletteDialog(categories),
-	})
 }

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -227,7 +227,9 @@ func (a *appModel) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 	case key.Matches(msg, a.keyMap.CommandPalette):
 		// Open command palette
 		categories := a.buildCommandCategories()
-		return dialog.OpenCommandPalette(categories)
+		return core.CmdHandler(dialog.OpenDialogMsg{
+			Model: dialog.NewCommandPaletteDialog(categories),
+		})
 	default:
 		updated, cmd := a.chatPage.Update(msg)
 		a.chatPage = updated.(chatpage.Page)


### PR DESCRIPTION
The command palette tries to stay centered vertically and horizontally in the window, but it would jump around if the inner model changes size.

We want to only keep the initial position calculated on window resize, this keeps the command palette nicely in the same spot all the time