### PR TITLE
Warn if compaction is called on an empty session

### DIFF
--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -645,15 +645,20 @@ func runUserCommand(userInput string, sess *session.Session, rt runtime.Runtime,
 		// Process events and show the summary
 		close(events)
 		summaryGenerated := false
+		hasWarning := false
 		for event := range events {
-			if summaryEvent, ok := event.(*runtime.SessionSummaryEvent); ok {
+			switch e := event.(type) {
+			case *runtime.SessionSummaryEvent:
 				fmt.Printf("%s\n", yellow("Summary generated and added to session"))
-				fmt.Printf("Summary: %s\n", summaryEvent.Summary)
+				fmt.Printf("Summary: %s\n", e.Summary)
 				summaryGenerated = true
+			case *runtime.WarningEvent:
+				fmt.Printf("%s\n", yellow("Warning: "+e.Message))
+				hasWarning = true
 			}
 		}
 
-		if !summaryGenerated {
+		if !summaryGenerated && !hasWarning {
 			fmt.Printf("%s\n", yellow("No summary generated"))
 		}
 

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -148,6 +148,7 @@ func (a *App) CompactSession() {
 	if a.runtime != nil && a.session != nil {
 		events := make(chan runtime.Event, 100)
 		a.runtime.Summarize(context.Background(), a.session, events)
+		close(events)
 		for event := range events {
 			a.events <- event
 		}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1046,6 +1046,13 @@ func (r *runtime) Summarize(ctx context.Context, sess *session.Session, events c
 	// Create conversation history for summarization
 	var conversationHistory strings.Builder
 	messages := sess.GetAllMessages()
+
+	// Check if session is empty
+	if len(messages) == 0 {
+		slog.Debug("Session is empty, nothing to summarize", "session_id", sess.ID)
+		events <- &WarningEvent{Message: "Session is empty. Start a conversation before compacting."}
+		return
+	}
 	for i := range messages {
 		role := "Unknown"
 		switch messages[i].Message.Role {


### PR DESCRIPTION
If compaction is called on an empty session in the TUI or in the CLI, warn the user.

---

Screenshots:

<img width="1160" height="726" alt="Screenshot From 2025-10-29 12-14-13" src="https://github.com/user-attachments/assets/49c51e24-58c0-471d-9720-3cbbe620806c" />
<img width="1160" height="726" alt="Screenshot From 2025-10-29 12-14-42" src="https://github.com/user-attachments/assets/9a492dee-71bf-4e4e-a144-b07ee56d903c" />

---

Fixes #618