### PR TITLE
Implement /commands everywhere

### DIFF
--- a/cagent-schema.json
+++ b/cagent-schema.json
@@ -109,7 +109,7 @@
           }
         },
         "commands": {
-          "description": "Named prompts for quick-start commands used with --command/-c",
+          "description": "Named prompts for /commands",
           "oneOf": [
             {
               "type": "object",

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -9,7 +9,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"time"
 
@@ -21,7 +20,6 @@ import (
 	"github.com/docker/cagent/pkg/aliases"
 	"github.com/docker/cagent/pkg/app"
 	"github.com/docker/cagent/pkg/chat"
-	"github.com/docker/cagent/pkg/config"
 	"github.com/docker/cagent/pkg/content"
 	"github.com/docker/cagent/pkg/evaluation"
 	"github.com/docker/cagent/pkg/input"
@@ -42,11 +40,8 @@ var (
 	useTUI         bool
 	remoteAddress  string
 	dryRun         bool
-	commandName    string
 	modelOverrides []string
 )
-
-const commandListSentinel = "__LIST__"
 
 // NewRunCmd creates a new run command
 func NewRunCmd() *cobra.Command {
@@ -68,12 +63,7 @@ func NewRunCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&attachmentPath, "attach", "", "Attach an image file to the message")
 	cmd.PersistentFlags().BoolVar(&useTUI, "tui", true, "Run the agent with a Terminal User Interface (TUI)")
 	cmd.PersistentFlags().StringVar(&remoteAddress, "remote", "", "Use remote runtime with specified address (only supported with TUI)")
-	cmd.PersistentFlags().StringVarP(&commandName, "command", "c", "", "Run a named command from the agent's commands section")
 	cmd.PersistentFlags().StringArrayVar(&modelOverrides, "model", nil, "Override agent model: [agent=]provider/model (repeatable)")
-	if f := cmd.PersistentFlags().Lookup("command"); f != nil {
-		// Allow `-c` without value to list available commands
-		f.NoOptDefVal = commandListSentinel
-	}
 	addGatewayFlags(cmd)
 	addRuntimeConfigFlags(cmd)
 
@@ -208,52 +198,6 @@ func doRunCommand(ctx context.Context, args []string, exec bool) error {
 		slog.Debug("Skipping local agent file loading for remote runtime", "filename", agentFilename)
 	}
 
-	// Resolve --command/-c into a first message if provided
-	var commandFirstMessage *string
-	if trimmed := strings.TrimSpace(commandName); trimmed != "" {
-		// Handle listing commands when -c is provided without a value
-		if trimmed == commandListSentinel {
-			// If the next positional arg looks like a value (not a flag), treat it as the command value.
-			if len(args) == 2 && !strings.HasPrefix(args[1], "-") {
-				trimmed = args[1]
-				// consume the positional so it won't be treated as a message later
-				args = args[:1]
-			} else {
-				cmds, err := getCommandsForAgent(agentFilename, remoteAddress != "", agents, agentName)
-				if err != nil {
-					return err
-				}
-				if len(cmds) == 0 {
-					return fmt.Errorf("no commands defined for agent '%s'", agentName)
-				}
-				printAvailableCommands(agentName, cmds)
-				fmt.Println()
-				return nil
-			}
-		}
-
-		if len(args) == 2 {
-			return fmt.Errorf("cannot use --command (-c) together with a message argument")
-		}
-
-		cmds, err := getCommandsForAgent(agentFilename, remoteAddress != "", agents, agentName)
-		if err != nil {
-			return err
-		}
-		if len(cmds) == 0 {
-			return fmt.Errorf("agent '%s' has no commands", agentName)
-		}
-		if msg, ok := cmds[trimmed]; ok {
-			commandFirstMessage = &msg
-		} else {
-			var names []string
-			for k := range cmds {
-				names = append(names, k)
-			}
-			return fmt.Errorf("'%s' is an unknown command.\n\nAvailable: %s", trimmed, strings.Join(names, ", "))
-		}
-	}
-
 	// Validate remote flag usage
 	if remoteAddress != "" && (!useTUI || exec) {
 		return fmt.Errorf("--remote flag can only be used with TUI mode")
@@ -329,10 +273,6 @@ func doRunCommand(ctx context.Context, args []string, exec bool) error {
 
 	// For `cagent run --tui=false`
 	if !useTUI {
-		// Inject first message for non-TUI if --command was used
-		if commandFirstMessage != nil {
-			args = []string{args[0], *commandFirstMessage}
-		}
 		return runWithoutTUI(ctx, agentFilename, rt, sess, args)
 	}
 
@@ -350,11 +290,6 @@ func doRunCommand(ctx context.Context, args []string, exec bool) error {
 		} else {
 			firstMessage = &args[1]
 		}
-	}
-
-	// Override firstMessage if --command was provided (cannot be combined with a message arg)
-	if commandFirstMessage != nil {
-		firstMessage = commandFirstMessage
 	}
 
 	a := app.New("cagent", agentFilename, rt, agents, sess, firstMessage)
@@ -397,11 +332,12 @@ func runWithoutTUI(ctx context.Context, agentFilename string, rt runtime.Runtime
 			return nil
 		}
 
+		userInput = runtime.ResolveCommand(ctx, rt, userInput)
+
 		handled, err := runUserCommand(userInput, sess, rt, ctx)
 		if err != nil {
 			return err
 		}
-
 		if handled {
 			return nil
 		}
@@ -833,53 +769,4 @@ func fileToDataURL(filePath string) (string, error) {
 	dataURL := fmt.Sprintf("data:%s;base64,%s", mimeType, encoded)
 
 	return dataURL, nil
-}
-
-// getCommandsForAgent returns the commands map for the selected agent,
-// loading from the in-memory team for local runs or from the YAML file for remote runs.
-func getCommandsForAgent(agentFilename string, isRemote bool, agents *team.Team, agentName string) (map[string]string, error) {
-	if !isRemote {
-		if agents == nil {
-			return nil, fmt.Errorf("failed to load agent team")
-		}
-
-		ag, err := agents.Agent(agentName)
-		if err != nil {
-			return nil, err
-		}
-
-		return ag.Commands(), nil
-	}
-
-	parentDir := filepath.Dir(agentFilename)
-	fileName := filepath.Base(agentFilename)
-	root, err := os.OpenRoot(parentDir)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open root: %w", err)
-	}
-	defer func() {
-		if err := root.Close(); err != nil {
-			slog.Error("Failed to close root", "error", err)
-		}
-	}()
-
-	cfg, err := config.LoadConfig(fileName, root)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load agent config: %w", err)
-	}
-
-	return cfg.Agents[agentName].Commands, nil
-}
-
-// printAvailableCommands pretty-prints the agent's commands sorted by name.
-func printAvailableCommands(agentName string, cmds map[string]string) {
-	fmt.Printf("Available commands for agent '%s':\n", agentName)
-	var names []string
-	for k := range cmds {
-		names = append(names, k)
-	}
-	sort.Strings(names)
-	for _, n := range names {
-		fmt.Printf(" - %s: %s\n", n, cmds[n])
-	}
 }

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -96,7 +96,7 @@ During CLI sessions, you can use special commands:
 | `add_date`             | boolean      | Add current date to context                                     | ✗        |
 | `add_environment_info` | boolean      | Add information about the environment (working dir, OS, git...) | ✗        |
 | `max_iterations`       | int          | Specifies how many times the agent can loop when using tools    | ✗        |
-| `commands`             | object/array | Named prompts for quick-start commands (used with `--command`)  | ✗        |
+| `commands`             | object/array | Named prompts for /commands                                     | ✗        |
 
 #### Example
 
@@ -118,7 +118,6 @@ agents:
 
 ### Running with named commands
 
-- Use `--command` (or `-c`) to send a predefined prompt from the agent config as the first message.
 - Example YAML forms supported:
 
 ```yaml
@@ -136,8 +135,8 @@ commands:
 Run:
 
 ```bash
-cagent run ./agent.yaml -c df
-cagent run ./agent.yaml --command ls
+cagent run ./agent.yaml /df
+cagent run ./agent.yaml /ls
 ```
 
 ### Model Properties

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -3,7 +3,6 @@ package app
 import (
 	"context"
 	"os/exec"
-	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea/v2"
@@ -51,45 +50,13 @@ func (a *App) Title() string {
 }
 
 // CurrentAgentCommands returns the commands for the active agent
-func (a *App) CurrentAgentCommands() map[string]string {
-	if localRuntime, ok := a.runtime.(*runtime.LocalRuntime); ok {
-		agent := localRuntime.CurrentAgent()
-		if agent == nil {
-			return nil
-		}
-
-		return agent.Commands()
-	}
-
-	// TODO(dga): not properly implemented for remote agents
-	return map[string]string{}
+func (a *App) CurrentAgentCommands(ctx context.Context) map[string]string {
+	return a.runtime.CurrentAgentCommands(ctx)
 }
 
 // ResolveCommand converts /command to its prompt text
-func (a *App) ResolveCommand(input string) string {
-	if !strings.HasPrefix(input, "/") {
-		return input
-	}
-
-	trimmed := strings.TrimSpace(input)
-	parts := strings.Fields(trimmed)
-	if len(parts) == 0 {
-		return input
-	}
-
-	cmdName := strings.TrimPrefix(parts[0], "/")
-	commands := a.CurrentAgentCommands()
-
-	if prompt, ok := commands[cmdName]; ok {
-		// If there are additional arguments, append them to the prompt
-		if len(parts) > 1 {
-			args := strings.Join(parts[1:], " ")
-			return prompt + " " + args
-		}
-		return prompt
-	}
-
-	return input
+func (a *App) ResolveCommand(ctx context.Context, userInput string) string {
+	return runtime.ResolveCommand(ctx, a.runtime, userInput)
 }
 
 // Run one agent loop

--- a/pkg/runtime/commands.go
+++ b/pkg/runtime/commands.go
@@ -1,0 +1,23 @@
+package runtime
+
+import (
+	"context"
+	"strings"
+)
+
+func ResolveCommand(ctx context.Context, rt Runtime, userInput string) string {
+	if !strings.HasPrefix(userInput, "/") {
+		return userInput
+	}
+
+	cmd, rest, _ := strings.Cut(userInput, " ")
+	prompt, found := rt.CurrentAgentCommands(ctx)[cmd[1:]]
+	if found {
+		userInput = prompt
+		if rest != "" {
+			userInput += " " + rest
+		}
+	}
+
+	return userInput
+}

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -62,6 +62,21 @@ func (r *RemoteRuntime) CurrentAgentName() string {
 	return r.currentAgent
 }
 
+func (r *RemoteRuntime) CurrentAgentCommands(ctx context.Context) map[string]string {
+	cfg, err := r.client.GetAgent(ctx, r.agentFilename)
+	if err != nil {
+		return map[string]string{}
+	}
+
+	for agentName, agent := range cfg.Agents {
+		if agentName == r.currentAgent {
+			return agent.Commands
+		}
+	}
+
+	return map[string]string{}
+}
+
 // RunStream starts the agent's interaction loop and returns a channel of events
 func (r *RemoteRuntime) RunStream(ctx context.Context, sess *session.Session) <-chan Event {
 	slog.Debug("Starting remote runtime stream", "agent", r.currentAgent, "session_id", r.sessionID)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -65,6 +65,8 @@ type ElicitationRequestHandler func(ctx context.Context, message string, schema 
 type Runtime interface {
 	// CurrentAgentName returns the name of the currently active agent
 	CurrentAgentName() string
+	// CurrentAgentCommands returns the commands for the active agent
+	CurrentAgentCommands(ctx context.Context) map[string]string
 	// RunStream starts the agent's interaction loop and returns a channel of events
 	RunStream(ctx context.Context, sess *session.Session) <-chan Event
 	// Run starts the agent's interaction loop and returns the final messages
@@ -174,6 +176,10 @@ func New(agents *team.Team, opts ...Opt) (*LocalRuntime, error) {
 
 func (r *LocalRuntime) CurrentAgentName() string {
 	return r.currentAgent
+}
+
+func (r *LocalRuntime) CurrentAgentCommands(context.Context) map[string]string {
+	return r.CurrentAgent().Commands()
 }
 
 // CurrentAgent returns the current agent

--- a/pkg/tui/components/editor/editor.go
+++ b/pkg/tui/components/editor/editor.go
@@ -28,14 +28,13 @@ type Editor interface {
 // editor implements Editor
 type editor struct {
 	textarea *textarea.Model
-	resolver func(string) string
 	width    int
 	height   int
 	working  bool
 }
 
 // New creates a new editor component
-func New(resolver func(string) string) Editor {
+func New() Editor {
 	ta := textarea.New()
 	ta.SetStyles(styles.InputStyle)
 	ta.Placeholder = "Type your message here..."
@@ -49,7 +48,6 @@ func New(resolver func(string) string) Editor {
 
 	return &editor{
 		textarea: ta,
-		resolver: resolver,
 	}
 }
 
@@ -73,11 +71,9 @@ func (e *editor) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			value := e.textarea.Value()
 			if value != "" && !e.working {
 				e.textarea.Reset()
-				// Resolve command before sending
-				if e.resolver != nil {
-					value = e.resolver(value)
-				}
-				return e, core.CmdHandler(SendMsg{Content: value})
+				return e, core.CmdHandler(SendMsg{
+					Content: value,
+				})
 			}
 			return e, nil
 		case "ctrl+c":

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -96,7 +96,7 @@ func New(a *app.App) Page {
 		title:        a.Title(),
 		sidebar:      sidebar.New(),
 		messages:     messages.New(a),
-		editor:       editor.New(a.ResolveCommand),
+		editor:       editor.New(),
 		focusedPanel: PanelEditor,
 		app:          a,
 		keyMap:       defaultKeyMap(),
@@ -477,9 +477,12 @@ func (p *chatPage) processMessage(content string) tea.Cmd {
 	var ctx context.Context
 	ctx, p.msgCancel = context.WithCancel(context.Background())
 
-	if strings.HasPrefix(content, "!") {
+	switch {
+	case strings.HasPrefix(content, "!"):
 		p.app.RunBangCommand(ctx, content[1:])
-	} else {
+	case strings.HasPrefix(content, "/"):
+		p.app.Run(ctx, p.msgCancel, p.app.ResolveCommand(ctx, content))
+	default:
 		p.app.Run(ctx, p.msgCancel, content)
 	}
 

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"context"
 	"time"
 
 	"github.com/charmbracelet/bubbles/v2/help"
@@ -226,7 +227,7 @@ func (a *appModel) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 		return tea.Quit
 	case key.Matches(msg, a.keyMap.CommandPalette):
 		// Open command palette
-		categories := a.buildCommandCategories()
+		categories := a.buildCommandCategories(context.Background())
 		return core.CmdHandler(dialog.OpenDialogMsg{
 			Model: dialog.NewCommandPaletteDialog(categories),
 		})
@@ -320,7 +321,7 @@ func toFullscreenView(content string) tea.View {
 }
 
 // buildCommandCategories builds the list of command categories for the command palette
-func (a *appModel) buildCommandCategories() []dialog.CommandCategory {
+func (a *appModel) buildCommandCategories(ctx context.Context) []dialog.CommandCategory {
 	categories := []dialog.CommandCategory{
 		{
 			Name: "Session",
@@ -372,7 +373,7 @@ func (a *appModel) buildCommandCategories() []dialog.CommandCategory {
 	}
 
 	// Add agent commands if available
-	agentCommands := a.application.CurrentAgentCommands()
+	agentCommands := a.application.CurrentAgentCommands(ctx)
 	if len(agentCommands) > 0 {
 		commands := make([]dialog.Command, 0, len(agentCommands))
 		for name, prompt := range agentCommands {


### PR DESCRIPTION
+ Plug /commands into `cagent exec`
+ Plug /commands into `cagent run --remote`
+ Remove `cagent run --command=cmd`. Now, we can just run `cagent run /cmd`
+ Implement command resolution in a single place
