### PR TITLE
Auto create directories in write_file

### DIFF
--- a/pkg/tools/builtin/filesystem.go
+++ b/pkg/tools/builtin/filesystem.go
@@ -976,6 +976,12 @@ func (t *FilesystemTool) handleWriteFile(ctx context.Context, toolCall tools.Too
 		return &tools.ToolCallResult{Output: fmt.Sprintf("Error: %s", err)}, nil
 	}
 
+	// Create parent directory structure if it doesn't exist
+	dir := filepath.Dir(args.Path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return &tools.ToolCallResult{Output: fmt.Sprintf("Error creating directory structure: %s", err)}, nil
+	}
+
 	if err := os.WriteFile(args.Path, []byte(args.Content), 0o644); err != nil {
 		return &tools.ToolCallResult{Output: fmt.Sprintf("Error writing file: %s", err)}, nil
 	}

--- a/pkg/tools/builtin/filesystem_test.go
+++ b/pkg/tools/builtin/filesystem_test.go
@@ -457,6 +457,37 @@ func TestFilesystemTool_WriteFile(t *testing.T) {
 	assert.Contains(t, result.Output, "not within allowed directories")
 }
 
+func TestFilesystemTool_WriteFile_NestedDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	tool := NewFilesystemTool([]string{tmpDir})
+
+	handler := getToolHandler(t, tool, "write_file")
+
+	// Write to a nested path that doesn't exist
+	nestedFile := filepath.Join(tmpDir, "a", "b", "c", "test.txt")
+	content := "Hello, nested world!"
+
+	args := map[string]any{
+		"path":    nestedFile,
+		"content": content,
+	}
+	result := callHandler(t, handler, args)
+
+	// Verify success
+	assert.Contains(t, result.Output, "File written successfully")
+	assert.FileExists(t, nestedFile)
+
+	// Verify content
+	writtenContent, err := os.ReadFile(nestedFile)
+	require.NoError(t, err)
+	assert.Equal(t, content, string(writtenContent))
+
+	// Verify directories were created
+	assert.DirExists(t, filepath.Join(tmpDir, "a"))
+	assert.DirExists(t, filepath.Join(tmpDir, "a", "b"))
+	assert.DirExists(t, filepath.Join(tmpDir, "a", "b", "c"))
+}
+
 func TestFilesystemTool_ReadFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	tool := NewFilesystemTool([]string{tmpDir})


### PR DESCRIPTION
closes #621

The `write_file` builtin tool now automatically creates parent directory structures when writing files to nested paths that don't exist.
