### PR TITLE
Speculative decoding support for DMR provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ in the `/examples/` directory.
 ### DMR (Docker Model Runner) provider options
 
 When using the `dmr` provider, you can use the `provider_opts` key for DMR
-runtime-specific (e.g. llama.cpp) options:
+runtime-specific (e.g. llama.cpp/vllm) options and speculative decoding:
 
 ```yaml
 models:
@@ -273,7 +273,12 @@ models:
     model: ai/qwen3
     max_tokens: 8192
     provider_opts:
+      # general flags passed to the underlying model runtime
       runtime_flags: ["--ngl=33", "--repeat-penalty=1.2", ...] # or comma/space-separated string
+      # speculative decoding for faster inference
+      speculative_draft_model: ai/qwen3:1B
+      speculative_num_tokens: 5
+      speculative_acceptance_rate: 0.8
 ```
 
 The default base_url `cagent` will use for DMR providers is
@@ -282,6 +287,8 @@ enabled via [Docker Desktop's
 settings](https://docs.docker.com/ai/model-runner/get-started/#enable-dmr-in-docker-desktop)
 on MacOS and Windows, and via command line on [Docker CE on
 Linux](https://docs.docker.com/ai/model-runner/get-started/#enable-dmr-in-docker-engine).
+
+See the [DMR Provider documentation](docs/USAGE.md#dmr-docker-model-runner-provider-usage) for more details on runtime flags and speculative decoding options.
 
 ## Quickly generate agents and agent teams with `cagent new`
 

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -25,7 +25,7 @@ var ProviderAliases = map[string]Alias{
 
 ## Add custom config if needed (optional)
 
-If your provider requires custom config, like Azure's `api_version`
+If your provider requires custom config, like Azure's `api_version` or DMR's speculative decoding options
 
 ```yaml
 models:
@@ -41,6 +41,14 @@ models:
     model: gpt-4o
     provider_opts:
       your_custom_option: your_custom_value
+  # DMR with speculative decoding
+  dmr_model:
+    provider: dmr
+    model: ai/qwen3:14B
+    provider_opts:
+      speculative_draft_model: ai/qwen3:1B
+      speculative_num_tokens: 5
+      speculative_acceptance_rate: 0.8
 ```
 
 edit [`pkg/model/provider/openai/client.go`](https://github.com/docker/cagent/blob/main/pkg/model/provider/openai/client.go)
@@ -63,3 +71,15 @@ switch cfg.Provider { //nolint:gocritic
       }
    }
 ```
+
+## DMR Provider Specific Options
+
+The DMR provider supports speculative decoding for faster inference. Configure it using `provider_opts`:
+
+- `speculative_draft_model` (string): Model to use for draft predictions
+- `speculative_num_tokens` (int): Number of tokens to generate speculatively
+- `speculative_acceptance_rate` (float): Acceptance rate threshold for speculative tokens
+
+All three options are passed to `docker model configure` as command-line flags.
+
+You can also pass any flag of the underlying model runtime (llama.cpp or vllm) using the `runtime_flags` option

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -382,7 +382,30 @@ models:
       runtime_flags: "--ngl=33 --repeat-penalty=1.2"  # string accepted as well
 ```
 
-Troubleshooting:
+##### Speculative Decoding
+
+DMR supports speculative decoding for faster inference by using a smaller draft model to predict tokens ahead. Configure speculative decoding using `provider_opts`:
+
+```yaml
+models:
+  qwen-with-speculative:
+    provider: dmr
+    model: ai/qwen3:14B
+    max_tokens: 8192
+    provider_opts:
+      speculative_draft_model: ai/qwen3:0.6B-F16     # Draft model for predictions
+      speculative_num_tokens: 16                # Number of tokens to generate speculatively
+      speculative_acceptance_rate: 0.8         # Acceptance rate threshold
+```
+
+All three speculative decoding options are passed to `docker model configure` as flags:
+- `speculative_draft_model` → `--speculative-draft-model`
+- `speculative_num_tokens` → `--speculative-num-tokens`
+- `speculative_acceptance_rate` → `--speculative-acceptance-rate`
+
+These options work alongside `max_tokens` (which sets `--context-size`) and `runtime_flags`.
+
+##### Troubleshooting:
 
 - Plugin not found: cagent will log a debug message and use the default base URL
 - Endpoint empty in status: ensure the Model Runner is running, or set `base_url` manually

--- a/examples/dmr.yaml
+++ b/examples/dmr.yaml
@@ -3,8 +3,11 @@
 agents:
   root:
     model: qwen
+    # model: qwen_speculative
     description: "Pirate-themed AI assistant"
     instruction: Talk like a pirate
+    commands:
+      demo: "Hey tell me a story about docker containers"
 
 models:
   qwen:
@@ -12,3 +15,13 @@ models:
     model: ai/qwen3
     # base_url defaults to http://localhost:12434/engines/llama.cpp/v1
     # use http://model-runner.docker.internal/engines/v1 if you run cagent from a container
+  
+  # try this model for faster inference if you have enough memory
+  qwen_speculative:
+    provider: dmr
+    model: ai/qwen3
+    # The draft model should be a smaller, faster variant of the main model with low latency
+    provider_opts:
+      speculative_draft_model: ai/qwen3:0.6B-Q4_K_M
+      speculative_num_tokens: 16 # (this is the llama.cpp default if omitted)
+      speculative_acceptance_rate: 0.8 # (this is the llama.cpp default if omitted)


### PR DESCRIPTION
With the next release of DMR's inference server and CLI, they'll have [support for speculative decoding](https://github.com/docker/model-runner/pull/327).

This PR prepares `cagent` to be able to support this new feature on day 1. We can hold off merging until then