### PR TITLE
Implement file autocompletion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/google/go-containerregistry v0.20.6
 	github.com/google/jsonschema-go v0.3.0
 	github.com/google/uuid v1.6.0
+	github.com/junegunn/fzf v0.66.1
 	github.com/k3a/html2text v1.2.1
 	github.com/labstack/echo/v4 v4.13.4
 	github.com/mattn/go-runewidth v0.0.19

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/junegunn/fzf v0.66.1 h1:Dw298QI+D1JeZSZLdXo5EQ0hAy4ZNxf5ONDJAIVROwA=
+github.com/junegunn/fzf v0.66.1/go.mod h1:xlXX2/rmsccKQUnr9QOXPDi5DyV9cM0UjKy/huScBeE=
 github.com/k3a/html2text v1.2.1 h1:nvnKgBvBR/myqrwfLuiqecUtaK1lB9hGziIJKatNFVY=
 github.com/k3a/html2text v1.2.1/go.mod h1:ieEXykM67iT8lTvEWBh6fhpH4B23kB9OMKPdIBmgUqA=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=

--- a/pkg/fsx/fs.go
+++ b/pkg/fsx/fs.go
@@ -1,0 +1,78 @@
+package fsx
+
+import (
+	"os"
+	"path/filepath"
+)
+
+type TreeNode struct {
+	Name     string      `json:"name"`
+	Type     string      `json:"type"`
+	Children []*TreeNode `json:"children,omitempty"`
+}
+
+func DirectoryTree(path string, isPathAllowed func(string) error, maxDepth, currentDepth int) (*TreeNode, error) {
+	if maxDepth > 0 && currentDepth >= maxDepth {
+		return nil, nil
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+
+	node := &TreeNode{
+		Name: filepath.Base(path),
+		Type: "file",
+	}
+
+	if info.IsDir() {
+		node.Type = "directory"
+		node.Children = []*TreeNode{}
+
+		entries, err := os.ReadDir(path)
+		if err != nil {
+			return node, nil // Return partial result on error
+		}
+
+		for _, entry := range entries {
+			childPath := filepath.Join(path, entry.Name())
+			if err := isPathAllowed(childPath); err != nil {
+				continue // Skip disallowed paths
+			}
+
+			childNode, err := DirectoryTree(childPath, isPathAllowed, maxDepth, currentDepth+1)
+			if err != nil || childNode == nil {
+				continue
+			}
+			node.Children = append(node.Children, childNode)
+		}
+	}
+
+	return node, nil
+}
+
+func ListDirectory(path string, maxDept int) ([]string, error) {
+	var files []string
+
+	tree, err := DirectoryTree(path, func(string) error { return nil }, maxDept, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	var traverse func(node *TreeNode, currentPath string)
+	traverse = func(node *TreeNode, currentPath string) {
+		newPath := filepath.Join(currentPath, node.Name)
+		switch node.Type {
+		case "file":
+			files = append(files, newPath)
+		case "directory":
+			for _, child := range node.Children {
+				traverse(child, newPath)
+			}
+		}
+	}
+
+	traverse(tree, "")
+	return files, nil
+}

--- a/pkg/tools/builtin/filesystem_test.go
+++ b/pkg/tools/builtin/filesystem_test.go
@@ -725,46 +725,6 @@ func TestFilesystemTool_EditFile(t *testing.T) {
 	assert.Contains(t, result.Output, "old text not found")
 }
 
-func TestFilesystemTool_DirectoryTree(t *testing.T) {
-	tmpDir := t.TempDir()
-	tool := NewFilesystemTool([]string{tmpDir})
-
-	// Create test directory structure
-	subDir1 := filepath.Join(tmpDir, "subdir1")
-	subDir2 := filepath.Join(tmpDir, "subdir1", "subdir2")
-	require.NoError(t, os.MkdirAll(subDir2, 0o755))
-
-	file1 := filepath.Join(tmpDir, "file1.txt")
-	file2 := filepath.Join(subDir1, "file2.txt")
-	file3 := filepath.Join(subDir2, "file3.txt")
-
-	require.NoError(t, os.WriteFile(file1, []byte("test1"), 0o644))
-	require.NoError(t, os.WriteFile(file2, []byte("test2"), 0o644))
-	require.NoError(t, os.WriteFile(file3, []byte("test3"), 0o644))
-
-	handler := getToolHandler(t, tool, "directory_tree")
-
-	// Test directory tree without depth limit
-	args := map[string]any{"path": tmpDir}
-	result := callHandler(t, handler, args)
-
-	var tree TreeNode
-	require.NoError(t, json.Unmarshal([]byte(result.Output), &tree))
-
-	assert.Equal(t, "directory", tree.Type)
-	assert.GreaterOrEqual(t, len(tree.Children), 2) // file1.txt and subdir1
-
-	// Test with depth limit
-	args = map[string]any{
-		"path":      tmpDir,
-		"max_depth": 2,
-	}
-	result = callHandler(t, handler, args)
-
-	require.NoError(t, json.Unmarshal([]byte(result.Output), &tree))
-	assert.Equal(t, "directory", tree.Type)
-}
-
 func TestFilesystemTool_SearchFiles(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/pkg/tui/components/completion/completion.go
+++ b/pkg/tui/components/completion/completion.go
@@ -1,0 +1,257 @@
+package completion
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/v2/key"
+	tea "github.com/charmbracelet/bubbletea/v2"
+	"github.com/charmbracelet/lipgloss/v2"
+	"github.com/junegunn/fzf/src/algo"
+	"github.com/junegunn/fzf/src/util"
+
+	"github.com/docker/cagent/pkg/tui/core"
+	"github.com/docker/cagent/pkg/tui/styles"
+)
+
+const maxItems = 10
+
+type Item struct {
+	Label       string
+	Description string
+	Value       string
+}
+
+type OpenMsg struct {
+	Items []Item
+}
+
+type OpenedMsg struct{}
+
+type CloseMsg struct{}
+
+type ClosedMsg struct{}
+
+type QueryMsg struct {
+	Query string
+}
+
+type SelectedMsg struct {
+	Value string
+}
+
+type matchResult struct {
+	item  Item
+	score int
+}
+
+type completionKeyMap struct {
+	Up     key.Binding
+	Down   key.Binding
+	Enter  key.Binding
+	Escape key.Binding
+}
+
+// defaultCompletionKeyMap returns default key bindings
+func defaultCompletionKeyMap() completionKeyMap {
+	return completionKeyMap{
+		Up: key.NewBinding(
+			key.WithKeys("up"),
+			key.WithHelp("↑", "up"),
+		),
+		Down: key.NewBinding(
+			key.WithKeys("down"),
+			key.WithHelp("↓", "down"),
+		),
+		Enter: key.NewBinding(
+			key.WithKeys("enter"),
+			key.WithHelp("enter", "select"),
+		),
+		Escape: key.NewBinding(
+			key.WithKeys("esc"),
+			key.WithHelp("esc", "cancel"),
+		),
+	}
+}
+
+// Manager manages the dialog stack and rendering
+type Manager interface {
+	tea.Model
+
+	GetLayers() []*lipgloss.Layer
+	Open() bool
+}
+
+// manager represents an item completion component that manages completion state and UI
+type manager struct {
+	keyMap        completionKeyMap
+	width         int
+	height        int
+	items         []Item
+	filteredItems []Item
+	query         string
+	selected      int
+	scrollOffset  int
+	visible       bool
+}
+
+// New creates a new  completion component
+func New() Manager {
+	return &manager{
+		keyMap: defaultCompletionKeyMap(),
+	}
+}
+
+func (c *manager) Init() tea.Cmd {
+	return nil
+}
+
+func (c *manager) Open() bool {
+	return c.visible
+}
+
+func (c *manager) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		c.width = msg.Width
+		c.height = msg.Height
+		return c, nil
+
+	case QueryMsg:
+		c.query = msg.Query
+		c.filterItems(c.query)
+		return c, nil
+
+	case OpenMsg:
+		c.visible = true
+		c.items = msg.Items
+		c.selected = 0
+		c.scrollOffset = 0
+		c.filterItems(c.query)
+		return c, core.CmdHandler(OpenedMsg{})
+
+	case CloseMsg:
+		c.visible = false
+		return c, nil
+
+	case tea.KeyPressMsg:
+		switch {
+		case key.Matches(msg, c.keyMap.Up):
+			if c.selected > 0 {
+				c.selected--
+			}
+			if c.selected < c.scrollOffset {
+				c.scrollOffset = c.selected
+			}
+
+		case key.Matches(msg, c.keyMap.Down):
+			if c.selected < len(c.filteredItems)-1 {
+				c.selected++
+			}
+			if c.selected >= c.scrollOffset+10 {
+				c.scrollOffset = c.selected - 9
+			}
+
+		case key.Matches(msg, c.keyMap.Enter):
+			c.visible = false
+			return c, core.CmdHandler(SelectedMsg{Value: c.filteredItems[c.selected].Value})
+		case key.Matches(msg, c.keyMap.Escape):
+			c.visible = false
+			return c, core.CmdHandler(ClosedMsg{})
+		}
+	}
+
+	return c, nil
+}
+
+func (c *manager) View() string {
+	if !c.visible {
+		return ""
+	}
+
+	var lines []string
+
+	if len(c.filteredItems) == 0 {
+		lines = append(lines, styles.CompletionNoResultsStyle.Render("No results found"))
+	} else {
+		visibleStart := c.scrollOffset
+		visibleEnd := min(c.scrollOffset+maxItems, len(c.filteredItems))
+
+		for i := visibleStart; i < visibleEnd; i++ {
+			item := c.filteredItems[i]
+			isSelected := i == c.selected
+
+			var itemStyle lipgloss.Style
+			if isSelected {
+				itemStyle = styles.CompletionSelectedStyle
+			} else {
+				itemStyle = styles.CompletionNormalStyle
+			}
+
+			text := item.Label
+			if item.Description != "" {
+				text += " " + styles.CompletionDescStyle.Render(item.Description)
+			}
+
+			lines = append(lines, itemStyle.Width(c.width-6).Render(text))
+		}
+	}
+
+	content := lipgloss.JoinVertical(lipgloss.Left, lines...)
+	return styles.CompletionBoxStyle.Render(content)
+}
+
+func (c *manager) GetLayers() []*lipgloss.Layer {
+	if !c.visible {
+		return nil
+	}
+
+	view := c.View()
+	viewHeight := lipgloss.Height(view)
+
+	editorHeight := 5
+	yPos := max(c.height-viewHeight-editorHeight-1, 0)
+
+	return []*lipgloss.Layer{
+		lipgloss.NewLayer(view).SetContent(view).X(1).Y(yPos),
+	}
+}
+
+func (c *manager) filterItems(query string) {
+	if query == "" {
+		c.filteredItems = c.items
+		return
+	}
+
+	pattern := []rune(strings.ToLower(query))
+	var matches []matchResult
+
+	for _, item := range c.items {
+		chars := util.ToChars([]byte(item.Label))
+		result, _ := algo.FuzzyMatchV1(
+			false, // caseSensitive
+			false, // normalize
+			true,  // forward
+			&chars,
+			pattern,
+			true, // withPos
+			nil,  // slab
+		)
+
+		if result.Start >= 0 {
+			matches = append(matches, matchResult{
+				item:  item,
+				score: result.Score,
+			})
+		}
+	}
+
+	sort.Slice(matches, func(i, j int) bool {
+		return matches[i].score > matches[j].score
+	})
+
+	c.filteredItems = make([]Item, 0, len(matches))
+	for _, match := range matches {
+		c.filteredItems = append(c.filteredItems, match.item)
+	}
+}

--- a/pkg/tui/components/notification/notification.go
+++ b/pkg/tui/components/notification/notification.go
@@ -32,25 +32,25 @@ type notificationItem struct {
 	TimerCmd tea.Cmd
 }
 
-// Notification represents a notification manager that displays
+// Manager represents a notification manager that displays
 // multiple stacked messages in the bottom right corner of the screen
-type Notification struct {
+type Manager struct {
 	width, height int
 	items         []notificationItem
 }
 
-func New() Notification {
-	return Notification{
+func New() Manager {
+	return Manager{
 		items: make([]notificationItem, 0),
 	}
 }
 
-func (n *Notification) SetSize(width, height int) {
+func (n *Manager) SetSize(width, height int) {
 	n.width = width
 	n.height = height
 }
 
-func (n *Notification) Update(msg tea.Msg) (Notification, tea.Cmd) {
+func (n *Manager) Update(msg tea.Msg) (Manager, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		n.width = msg.Width
@@ -91,7 +91,7 @@ func (n *Notification) Update(msg tea.Msg) (Notification, tea.Cmd) {
 	return *n, nil
 }
 
-func (n *Notification) View() string {
+func (n *Manager) View() string {
 	if len(n.items) == 0 {
 		return ""
 	}
@@ -106,7 +106,7 @@ func (n *Notification) View() string {
 	return lipgloss.JoinVertical(lipgloss.Right, views...)
 }
 
-func (n *Notification) GetLayer() *lipgloss.Layer {
+func (n *Manager) GetLayer() *lipgloss.Layer {
 	if len(n.items) == 0 {
 		return nil
 	}
@@ -117,7 +117,7 @@ func (n *Notification) GetLayer() *lipgloss.Layer {
 	return lipgloss.NewLayer(view).X(col).Y(row)
 }
 
-func (n *Notification) position() (row, col int) {
+func (n *Manager) position() (row, col int) {
 	notificationView := n.View()
 	viewHeight := lipgloss.Height(notificationView)
 	viewWidth := lipgloss.Width(notificationView)
@@ -129,6 +129,6 @@ func (n *Notification) position() (row, col int) {
 	return row, col
 }
 
-func (n *Notification) IsVisible() bool {
+func (n *Manager) Open() bool {
 	return len(n.items) > 0
 }

--- a/pkg/tui/components/notification/notification_test.go
+++ b/pkg/tui/components/notification/notification_test.go
@@ -10,7 +10,7 @@ func TestNotification_InitialState(t *testing.T) {
 	n := New()
 
 	require.Empty(t, n.items)
-	require.False(t, n.IsVisible())
+	require.False(t, n.Open())
 }
 
 func TestNotification_Show(t *testing.T) {
@@ -20,7 +20,7 @@ func TestNotification_Show(t *testing.T) {
 
 	require.Len(t, updated.items, 1)
 	require.Equal(t, "Test notification", updated.items[0].Text)
-	require.True(t, updated.IsVisible())
+	require.True(t, updated.Open())
 	require.NotEmpty(t, updated.View())
 }
 
@@ -33,7 +33,7 @@ func TestNotification_Hide(t *testing.T) {
 	updated, _ = updated.Update(HideMsg{})
 
 	require.Empty(t, updated.items)
-	require.False(t, updated.IsVisible())
+	require.False(t, updated.Open())
 	require.Empty(t, updated.View())
 }
 

--- a/pkg/tui/dialog/dialog.go
+++ b/pkg/tui/dialog/dialog.go
@@ -29,7 +29,7 @@ type Manager interface {
 	tea.Model
 
 	GetLayers() []*lipgloss.Layer
-	HasDialog() bool
+	Open() bool
 }
 
 // manager implements Manager
@@ -130,8 +130,8 @@ func (d *manager) handleCloseAll() (tea.Model, tea.Cmd) {
 	return d, nil
 }
 
-// HasDialog returns true if there is at least one active dialog
-func (d *manager) HasDialog() bool {
+// Open returns true if there is at least one active dialog
+func (d *manager) Open() bool {
 	return len(d.dialogStack) > 0
 }
 

--- a/pkg/tui/styles/styles.go
+++ b/pkg/tui/styles/styles.go
@@ -321,6 +321,30 @@ var (
 				Padding(0, 1)
 )
 
+// Completion Styles
+var (
+	CompletionBoxStyle = BaseStyle.
+				Border(lipgloss.RoundedBorder()).
+				BorderForeground(BorderSecondary).
+				Padding(0, 1)
+
+	CompletionSelectedStyle = BaseStyle.
+				Foreground(TextPrimary).
+				Bold(true)
+
+	CompletionNormalStyle = BaseStyle.
+				Foreground(TextPrimary)
+
+	CompletionDescStyle = BaseStyle.
+				Foreground(TextSecondary).
+				Italic(true)
+
+	CompletionNoResultsStyle = BaseStyle.
+					Foreground(TextMuted).
+					Italic(true).
+					Align(lipgloss.Center)
+)
+
 // Deprecated styles (kept for backward compatibility)
 var (
 	StatusStyle = MutedStyle

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/cagent/pkg/app"
 	"github.com/docker/cagent/pkg/evaluation"
 	"github.com/docker/cagent/pkg/runtime"
+	"github.com/docker/cagent/pkg/tui/components/completion"
 	"github.com/docker/cagent/pkg/tui/components/notification"
 	"github.com/docker/cagent/pkg/tui/components/statusbar"
 	"github.com/docker/cagent/pkg/tui/core"
@@ -43,12 +44,12 @@ type appModel struct {
 	width, height   int
 	keyMap          KeyMap
 
-	chatPage     chatpage.Page
-	statusBar    statusbar.StatusBar
-	notification notification.Notification
+	chatPage  chatpage.Page
+	statusBar statusbar.StatusBar
 
-	// Dialog system
-	dialog dialog.Manager
+	notification notification.Manager
+	dialog       dialog.Manager
+	completions  completion.Manager
 
 	// State
 	ready bool
@@ -82,6 +83,7 @@ func New(a *app.App) tea.Model {
 		keyMap:       DefaultKeyMap(),
 		dialog:       dialog.New(),
 		notification: notification.New(),
+		completions:  completion.New(),
 		application:  a,
 	}
 
@@ -122,6 +124,7 @@ func (a *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		a.wWidth, a.wHeight = msg.Width, msg.Height
 		cmd := a.handleWindowResize(msg.Width, msg.Height)
+		a.completions.Update(msg)
 		return a, cmd
 
 	case notification.ShowMsg, notification.HideMsg:
@@ -135,7 +138,7 @@ func (a *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.MouseWheelMsg:
 		// If dialogs are active, they get priority for mouse events
-		if a.dialog.HasDialog() {
+		if a.dialog.Open() {
 			u, dialogCmd := a.dialog.Update(msg)
 			a.dialog = u.(dialog.Manager)
 			return a, dialogCmd
@@ -159,16 +162,25 @@ func (a *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// For other messages, check if dialogs should handle them first
 		// If dialogs are active, they get priority for input
-		if a.dialog.HasDialog() {
+		if a.dialog.Open() {
 			u, dialogCmd := a.dialog.Update(msg)
 			a.dialog = u.(dialog.Manager)
 			return a, dialogCmd
 		}
 
-		// Otherwise, forward to chat page
-		updated, cmd := a.chatPage.Update(msg)
+		var cmds []tea.Cmd
+		var cmd tea.Cmd
+
+		updated, cmd := a.completions.Update(msg)
+		cmds = append(cmds, cmd)
+		a.completions = updated.(completion.Manager)
+
+		updated, cmd = a.chatPage.Update(msg)
+		cmds = append(cmds, cmd)
+
 		a.chatPage = updated.(chatpage.Page)
-		return a, cmd
+
+		return a, tea.Batch(cmds...)
 	}
 }
 
@@ -212,13 +224,35 @@ func (a *appModel) handleWindowResize(width, height int) tea.Cmd {
 	return tea.Batch(cmds...)
 }
 
-// handleKeyPressMsg processes keyboard input
 func (a *appModel) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
-	// If dialogs are active, they handle key input first
-	if a.dialog.HasDialog() {
+	if a.dialog.Open() {
 		u, dialogCmd := a.dialog.Update(msg)
 		a.dialog = u.(dialog.Manager)
 		return dialogCmd
+	}
+
+	if a.completions.Open() {
+		// Check if this is a navigation key that the completion manager should handle
+		switch msg.String() {
+		case "up", "down", "enter", "esc":
+			// Let completion manager handle navigation keys
+			u, completionCmd := a.completions.Update(msg)
+			a.completions = u.(completion.Manager)
+			return completionCmd
+		default:
+			// For all other keys (typing), send to both completion (for filtering) and editor
+			var cmds []tea.Cmd
+			u, completionCmd := a.completions.Update(msg)
+			a.completions = u.(completion.Manager)
+			cmds = append(cmds, completionCmd)
+
+			// Also send to chat page/editor so user can continue typing
+			updated, cmd := a.chatPage.Update(msg)
+			a.chatPage = updated.(chatpage.Page)
+			cmds = append(cmds, cmd)
+
+			return tea.Batch(cmds...)
+		}
 	}
 
 	switch {
@@ -285,8 +319,7 @@ func (a *appModel) View() tea.View {
 
 	baseView := lipgloss.JoinVertical(lipgloss.Top, components...)
 
-	// Check if we need to render any overlays (dialogs or notifications)
-	hasOverlays := a.dialog.HasDialog() || a.notification.IsVisible()
+	hasOverlays := a.dialog.Open() || a.notification.Open() || a.completions.Open()
 
 	if hasOverlays {
 		baseLayer := lipgloss.NewLayer(baseView)
@@ -294,13 +327,18 @@ func (a *appModel) View() tea.View {
 		allLayers = append(allLayers, baseLayer)
 
 		// Add dialog layers
-		if a.dialog.HasDialog() {
+		if a.dialog.Open() {
 			dialogLayers := a.dialog.GetLayers()
 			allLayers = append(allLayers, dialogLayers...)
 		}
 
-		if a.notification.IsVisible() {
+		if a.notification.Open() {
 			allLayers = append(allLayers, a.notification.GetLayer())
+		}
+
+		if a.completions.Open() {
+			layers := a.completions.GetLayers()
+			allLayers = append(allLayers, layers...)
 		}
 
 		canvas := lipgloss.NewCanvas(allLayers...)


### PR DESCRIPTION
When the user types @ we will open an overlay showing a list with files, they can then continue typing and we filter the list (using fzf). Presing <enter> inserts the path to the editor.

The completion overlay doesn't care what it shows or filters, we will reuse this for `/` commands.

https://github.com/user-attachments/assets/18ce1916-67ba-473a-bf0f-2de556f97069

