### PR TITLE
Don't panic if toolset not started, only return empty instructions

### DIFF
--- a/pkg/tools/mcp/mcp.go
+++ b/pkg/tools/mcp/mcp.go
@@ -115,7 +115,8 @@ func (ts *Toolset) Start(ctx context.Context) error {
 
 func (ts *Toolset) Instructions() string {
 	if !ts.started.Load() {
-		panic("toolset not started")
+		// TODO: this should never happen...
+		return ""
 	}
 	return ts.instructions
 }


### PR DESCRIPTION
this doesn't fix anything but at least we won't panic, it's a quick ugly patch for now