### PR TITLE
Split run

### DIFF
--- a/cmd/root/exec.go
+++ b/cmd/root/exec.go
@@ -3,8 +3,9 @@ package root
 import (
 	"context"
 
-	"github.com/docker/cagent/pkg/telemetry"
 	"github.com/spf13/cobra"
+
+	"github.com/docker/cagent/pkg/telemetry"
 )
 
 func NewExecCmd() *cobra.Command {

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	tea "github.com/charmbracelet/bubbletea/v2"
 	"github.com/spf13/cobra"
@@ -74,36 +73,11 @@ func runCommand(ctx context.Context, args []string) error {
 	return doRunCommand(ctx, args, false)
 }
 
-func agentFile(agentFilename string) string {
-	// Try to resolve as an alias first
-	if aliasStore, err := aliases.Load(); err == nil {
-		if resolvedPath, ok := aliasStore.Get(agentFilename); ok {
-			slog.Debug("Resolved alias", "alias", agentFilename, "path", resolvedPath)
-			agentFilename = resolvedPath
-		}
-	}
-
-	if strings.Contains(agentFilename, ".yaml") || strings.Contains(agentFilename, ".yml") {
-		if abs, err := filepath.Abs(agentFilename); err == nil {
-			agentFilename = abs
-		}
-	}
-	return agentFilename
-}
-
 func setupOtel(ctx context.Context) {
 	if enableOtel {
-		shutdown, err := initOTelSDK(ctx)
-		if err != nil {
+		if err := initOTelSDK(ctx); err != nil {
 			slog.Warn("Failed to initialize OpenTelemetry SDK", "error", err)
-		} else if shutdown != nil {
-			defer func() {
-				shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-				defer cancel()
-				if err := shutdown(shutdownCtx); err != nil {
-					slog.Warn("Failed to shutdown OpenTelemetry SDK", "error", err)
-				}
-			}()
+		} else {
 			slog.Debug("OpenTelemetry SDK initialized successfully")
 		}
 	}
@@ -112,200 +86,271 @@ func setupOtel(ctx context.Context) {
 func doRunCommand(ctx context.Context, args []string, exec bool) error {
 	slog.Debug("Starting agent", "agent", agentName, "debug_mode", debugMode)
 
-	agentFilename := agentFile(args[0])
-
-	// If working-dir was provided, validate and change process working directory
-	if workingDir != "" {
-		absWd, err := filepath.Abs(workingDir)
-		if err != nil {
-			return fmt.Errorf("invalid working directory: %w", err)
-		}
-		info, err := os.Stat(absWd)
-		if err != nil || !info.IsDir() {
-			return fmt.Errorf("working directory does not exist or is not a directory: %s", absWd)
-		}
-		if err := os.Chdir(absWd); err != nil {
-			return fmt.Errorf("failed to change working directory: %w", err)
-		}
-		_ = os.Setenv("PWD", absWd)
-		slog.Debug("Working directory set", "dir", absWd)
+	if err := validateRemoteFlag(exec); err != nil {
+		return err
 	}
 
-	// Skip agent file loading when using remote runtime
-	var agents *team.Team
-	var err error
-	if remoteAddress == "" {
-		// Determine how to obtain the agent definition
-		ext := strings.ToLower(filepath.Ext(agentFilename))
-		if ext == ".yaml" || ext == ".yml" || strings.HasPrefix(agentFilename, "/dev/fd/") {
-			// Treat as local YAML file: resolve to absolute path so later chdir doesn't break it
-			if !strings.Contains(agentFilename, "\n") {
-				if abs, err := filepath.Abs(agentFilename); err == nil {
-					agentFilename = abs
-				}
-			}
-			if !fileExists(agentFilename) {
-				return fmt.Errorf("agent file not found: %s", agentFilename)
-			}
-		} else {
-			// Treat as an OCI image reference. Try local store first, otherwise pull then load.
-			a, err := fromStore(agentFilename)
-			if err != nil {
-				fmt.Println("Pulling agent", agentFilename)
-				if _, pullErr := remote.Pull(agentFilename); pullErr != nil {
-					return fmt.Errorf("failed to pull OCI image %s: %w", agentFilename, pullErr)
-				}
-				// Retry after pull
-				a, err = fromStore(agentFilename)
-				if err != nil {
-					return fmt.Errorf("failed to load agent from store after pull: %w", err)
-				}
-			}
+	if err := setupWorkingDirectory(); err != nil {
+		return err
+	}
 
-			// Write the fetched content to a temporary YAML file
-			tmpFile, err := os.CreateTemp("", "agentfile-*.yaml")
-			if err != nil {
-				return err
-			}
-			defer os.Remove(tmpFile.Name())
-			if _, err := tmpFile.WriteString(a); err != nil {
-				tmpFile.Close()
-				return err
-			}
-			if err := tmpFile.Close(); err != nil {
-				return err
-			}
-			agentFilename = tmpFile.Name()
-		}
+	agentFileName, err := resolveAgentFile(ctx, args[0])
+	if err != nil {
+		return err
+	}
 
-		if runConfig.RedirectURI == "" {
-			runConfig.RedirectURI = "http://localhost:8083/oauth-callback"
-		}
+	t, err := loadAgents(ctx, agentFileName)
+	if err != nil {
+		return err
+	}
 
-		agents, err = teamloader.Load(ctx, agentFilename, runConfig, teamloader.WithModelOverrides(modelOverrides))
+	var rt runtime.Runtime
+	var sess *session.Session
+	if remoteAddress != "" {
+		rt, sess, err = createRemoteRuntimeAndSession(ctx, args[0])
 		if err != nil {
 			return err
 		}
-		defer func() {
-			if err := agents.StopToolSets(ctx); err != nil {
-				slog.Error("Failed to stop tool sets", "error", err)
-			}
-		}()
 	} else {
-		// For remote runtime, just store the original agent filename
-		// The remote server will handle agent loading
-		slog.Debug("Skipping local agent file loading for remote runtime", "filename", agentFilename)
+		rt, sess, err = createLocalRuntimeAndSession(t)
+		if err != nil {
+			return err
+		}
 	}
 
-	// Validate remote flag usage
+	if exec {
+		return handleExecMode(ctx, agentFileName, rt, sess, args)
+	}
+
+	if !useTUI {
+		return handleCLIMode(ctx, agentFileName, rt, sess, args)
+	}
+
+	return handleTUIMode(ctx, agentFileName, rt, t, sess, args)
+}
+
+func setupWorkingDirectory() error {
+	if workingDir == "" {
+		return nil
+	}
+
+	absWd, err := filepath.Abs(workingDir)
+	if err != nil {
+		return fmt.Errorf("invalid working directory: %w", err)
+	}
+
+	info, err := os.Stat(absWd)
+	if err != nil || !info.IsDir() {
+		return fmt.Errorf("working directory does not exist or is not a directory: %s", absWd)
+	}
+
+	if err := os.Chdir(absWd); err != nil {
+		return fmt.Errorf("failed to change working directory: %w", err)
+	}
+
+	_ = os.Setenv("PWD", absWd)
+	slog.Debug("Working directory set", "dir", absWd)
+	return nil
+}
+
+// resolveAgentFile resolves an agent file reference (local file or OCI image) to a local file path
+func resolveAgentFile(ctx context.Context, agentFilename string) (string, error) {
+	if remoteAddress != "" {
+		return agentFilename, nil
+	}
+	// Try to resolve as an alias first
+	if aliasStore, err := aliases.Load(); err == nil {
+		if resolvedPath, ok := aliasStore.Get(agentFilename); ok {
+			slog.Debug("Resolved alias", "alias", agentFilename, "path", resolvedPath)
+			agentFilename = resolvedPath
+		}
+	}
+
+	ext := strings.ToLower(filepath.Ext(agentFilename))
+	if ext == ".yaml" || ext == ".yml" || strings.HasPrefix(agentFilename, "/dev/fd/") {
+		// Treat as local YAML file: resolve to absolute path so later chdir doesn't break it
+		// TODO(rumpl): Why are we checking for newlines here?
+		if !strings.Contains(agentFilename, "\n") {
+			if abs, err := filepath.Abs(agentFilename); err == nil {
+				agentFilename = abs
+			}
+		}
+		if !fileExists(agentFilename) {
+			return "", fmt.Errorf("agent file not found: %s", agentFilename)
+		}
+		return agentFilename, nil
+	}
+
+	// Treat as an OCI image reference. Try local store first, otherwise pull then load.
+	a, err := fromStore(agentFilename)
+	if err != nil {
+		fmt.Println("Pulling agent", agentFilename)
+		if _, pullErr := remote.Pull(agentFilename); pullErr != nil {
+			return "", fmt.Errorf("failed to pull OCI image %s: %w", agentFilename, pullErr)
+		}
+		// Retry after pull
+		a, err = fromStore(agentFilename)
+		if err != nil {
+			return "", fmt.Errorf("failed to load agent from store after pull: %w", err)
+		}
+	}
+
+	// Write the fetched content to a temporary YAML file
+	tmpFile, err := os.CreateTemp("", "agentfile-*.yaml")
+	if err != nil {
+		return "", err
+	}
+	tmpFilename := tmpFile.Name()
+	if _, err := tmpFile.WriteString(a); err != nil {
+		tmpFile.Close()
+		os.Remove(tmpFilename)
+		return "", err
+	}
+	if err := tmpFile.Close(); err != nil {
+		os.Remove(tmpFilename)
+		return "", err
+	}
+	go func() {
+		<-ctx.Done()
+		os.Remove(tmpFilename)
+	}()
+	return tmpFilename, nil
+}
+
+func loadAgents(ctx context.Context, agentFilename string) (*team.Team, error) {
+	if runConfig.RedirectURI == "" {
+		runConfig.RedirectURI = "http://localhost:8083/oauth-callback"
+	}
+
+	t, err := teamloader.Load(ctx, agentFilename, runConfig, teamloader.WithModelOverrides(modelOverrides))
+	if err != nil {
+		return nil, err
+	}
+
+	go func() {
+		<-ctx.Done()
+		if err := t.StopToolSets(ctx); err != nil {
+			slog.Error("Failed to stop tool sets", "error", err)
+		}
+	}()
+
+	return t, nil
+}
+
+func validateRemoteFlag(exec bool) error {
 	if remoteAddress != "" && (!useTUI || exec) {
 		return fmt.Errorf("--remote flag can only be used with TUI mode")
 	}
+	return nil
+}
+
+func createRemoteRuntimeAndSession(ctx context.Context, originalFilename string) (runtime.Runtime, *session.Session, error) {
+	remoteClient, err := runtime.NewClient(remoteAddress)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create remote client: %w", err)
+	}
+
+	sessTemplate := session.New()
+	sessTemplate.ToolsApproved = autoApprove
+	sess, err := remoteClient.CreateSession(ctx, sessTemplate)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	remoteRt, err := runtime.NewRemoteRuntime(remoteClient,
+		runtime.WithRemoteCurrentAgent(agentName),
+		runtime.WithRemoteAgentFilename(originalFilename),
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create remote runtime: %w", err)
+	}
+
+	slog.Debug("Using remote runtime", "address", remoteAddress, "agent", agentName)
+	return remoteRt, sess, nil
+}
+
+func createLocalRuntimeAndSession(t *team.Team) (runtime.Runtime, *session.Session, error) {
+	agent, err := t.Agent(agentName)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sess := session.New(session.WithMaxIterations(agent.MaxIterations()))
+	sess.ToolsApproved = autoApprove
 
 	tracer := otel.Tracer(AppName)
 
-	var sess *session.Session
-
-	// Create runtime based on whether remote flag is specified
-	var rt runtime.Runtime
-	if remoteAddress != "" && useTUI && !exec {
-		// Create remote runtime for TUI mode
-		remoteClient, err := runtime.NewClient(remoteAddress)
-		if err != nil {
-			return fmt.Errorf("failed to create remote client: %w", err)
-		}
-
-		sessTemplate := session.New()
-		sessTemplate.ToolsApproved = autoApprove
-		sess, err = remoteClient.CreateSession(ctx, sessTemplate)
-		if err != nil {
-			return err
-		}
-
-		remoteRt, err := runtime.NewRemoteRuntime(remoteClient,
-			runtime.WithRemoteCurrentAgent(agentName),
-			runtime.WithRemoteAgentFilename(args[0]),
-		)
-		if err != nil {
-			return fmt.Errorf("failed to create remote runtime: %w", err)
-		}
-		rt = remoteRt
-		slog.Debug("Using remote runtime", "address", remoteAddress, "agent", agentName)
-	} else {
-		agent, err := agents.Agent(agentName)
-		if err != nil {
-			return err
-		}
-
-		// Create session first to get its ID for OAuth state encoding
-		sess = session.New(session.WithMaxIterations(agent.MaxIterations()))
-		sess.ToolsApproved = autoApprove
-
-		// Create local runtime with root session ID for OAuth state encoding
-		localRt, err := runtime.New(agents,
-			runtime.WithCurrentAgent(agentName),
-			runtime.WithTracer(tracer),
-			runtime.WithRootSessionID(sess.ID),
-		)
-		if err != nil {
-			return fmt.Errorf("failed to create runtime: %w", err)
-		}
-		rt = localRt
-		slog.Debug("Using local runtime", "agent", agentName)
+	localRt, err := runtime.New(t,
+		runtime.WithCurrentAgent(agentName),
+		runtime.WithTracer(tracer),
+		runtime.WithRootSessionID(sess.ID),
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create runtime: %w", err)
 	}
 
-	// For `cagent exec`
-	if exec {
-		execArgs := []string{"exec"}
-		if len(args) == 2 {
-			execArgs = append(execArgs, args[1])
-		} else {
-			execArgs = append(execArgs, "Follow the default instructions")
-		}
+	slog.Debug("Using local runtime", "agent", agentName)
+	return localRt, sess, nil
+}
 
-		if dryRun {
-			fmt.Println("Dry run mode enabled. Agent initialized but will not execute.")
-			return nil
-		}
-		err := cli.Run(ctx, cli.Config{
-			AppName:        AppName,
-			AttachmentPath: attachmentPath,
-		}, agentFilename, rt, sess, execArgs)
-		if cliErr, ok := err.(cli.RuntimeError); ok {
-			return RuntimeError{Err: cliErr.Err}
-		}
-		return err
-	}
-
-	// For `cagent run --tui=false`
-	if !useTUI {
-		err := cli.Run(ctx, cli.Config{
-			AppName:        AppName,
-			AttachmentPath: attachmentPath,
-		}, agentFilename, rt, sess, args)
-		if cliErr, ok := err.(cli.RuntimeError); ok {
-			return RuntimeError{Err: cliErr.Err}
-		}
-		return err
-	}
-
-	// The default is to use the TUI
-	var firstMessage *string
+func handleExecMode(ctx context.Context, agentFilename string, rt runtime.Runtime, sess *session.Session, args []string) error {
+	execArgs := []string{"exec"}
 	if len(args) == 2 {
-		// TODO: attachments
-		if args[1] == "-" {
-			buf, err := io.ReadAll(os.Stdin)
-			if err != nil {
-				return fmt.Errorf("failed to read from stdin: %w", err)
-			}
-			text := string(buf)
-			firstMessage = &text
-		} else {
-			firstMessage = &args[1]
-		}
+		execArgs = append(execArgs, args[1])
+	} else {
+		execArgs = append(execArgs, "Follow the default instructions")
 	}
 
-	a := app.New("cagent", agentFilename, rt, agents, sess, firstMessage)
+	if dryRun {
+		fmt.Println("Dry run mode enabled. Agent initialized but will not execute.")
+		return nil
+	}
+
+	err := cli.Run(ctx, cli.Config{
+		AppName:        AppName,
+		AttachmentPath: attachmentPath,
+	}, agentFilename, rt, sess, execArgs)
+	if cliErr, ok := err.(cli.RuntimeError); ok {
+		return RuntimeError{Err: cliErr.Err}
+	}
+	return err
+}
+
+func handleCLIMode(ctx context.Context, agentFilename string, rt runtime.Runtime, sess *session.Session, args []string) error {
+	err := cli.Run(ctx, cli.Config{
+		AppName:        AppName,
+		AttachmentPath: attachmentPath,
+	}, agentFilename, rt, sess, args)
+	if cliErr, ok := err.(cli.RuntimeError); ok {
+		return RuntimeError{Err: cliErr.Err}
+	}
+	return err
+}
+
+func readInitialMessage(args []string) (*string, error) {
+	if len(args) < 2 {
+		return nil, nil
+	}
+
+	if args[1] == "-" {
+		buf, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read from stdin: %w", err)
+		}
+		text := string(buf)
+		return &text, nil
+	}
+
+	return &args[1], nil
+}
+
+func handleTUIMode(ctx context.Context, agentFilename string, rt runtime.Runtime, t *team.Team, sess *session.Session, args []string) error {
+	firstMessage, err := readInitialMessage(args)
+	if err != nil {
+		return err
+	}
+
+	a := app.New("cagent", agentFilename, rt, t, sess, firstMessage)
 	m := tui.New(a)
 
 	progOpts := []tea.ProgramOption{


### PR DESCRIPTION
Completely split the ~300 lines run function into something that kinda makes more sense, this `cagent run` api has a life of its own