### PR TITLE
Add allowed_directories to the filesystem config

### DIFF
--- a/cagent-schema.json
+++ b/cagent-schema.json
@@ -397,6 +397,13 @@
           "items": {
             "$ref": "#/definitions/PostEditConfig"
           }
+        },
+        "allowed_directories": {
+          "type": "array",
+          "description": "List of allowed directories for filesystem tool",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false,

--- a/examples/filesystem.yaml
+++ b/examples/filesystem.yaml
@@ -5,5 +5,9 @@ agents:
     model: openai/gpt-4o
     description: Simple agent with filesystem access
     instruction: Use the tools to help the user with filesystem operations.
+    commands:
+      list-tmp: List all the files in the /tmp directory.
     toolsets:
       - type: filesystem
+        allowed_directories:
+          - /tmp

--- a/pkg/acp/filesystem.go
+++ b/pkg/acp/filesystem.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	"github.com/coder/acp-go-sdk"
@@ -32,18 +31,16 @@ func getSessionID(ctx context.Context) (string, bool) {
 // and edit_file to use the ACP connection for file operations
 type FilesystemToolset struct {
 	*builtin.FilesystemTool
-	agent       *Agent
-	workindgDir string
+	agent *Agent
 }
 
 var _ tools.ToolSet = (*FilesystemToolset)(nil)
 
 // NewFilesystemToolset creates a new ACP-specific filesystem toolset
-func NewFilesystemToolset(agent *Agent, workingDir string, opts ...builtin.FileSystemOpt) *FilesystemToolset {
+func NewFilesystemToolset(agent *Agent, opts ...builtin.FileSystemOpt) *FilesystemToolset {
 	return &FilesystemToolset{
-		FilesystemTool: builtin.NewFilesystemTool([]string{workingDir}, opts...),
+		FilesystemTool: builtin.NewFilesystemTool(opts...),
 		agent:          agent,
-		workindgDir:    workingDir,
 	}
 }
 
@@ -81,7 +78,7 @@ func (t *FilesystemToolset) handleReadFile(ctx context.Context, toolCall tools.T
 
 	resp, err := t.agent.conn.ReadTextFile(ctx, acp.ReadTextFileRequest{
 		SessionId: acp.SessionId(sessionID),
-		Path:      filepath.Join(t.workindgDir, args.Path),
+		Path:      args.Path,
 	})
 	if err != nil {
 		return &tools.ToolCallResult{Output: fmt.Sprintf("Error reading file: %s", err)}, nil
@@ -126,7 +123,7 @@ func (t *FilesystemToolset) handleEditFile(ctx context.Context, toolCall tools.T
 
 	resp, err := t.agent.conn.ReadTextFile(ctx, acp.ReadTextFileRequest{
 		SessionId: acp.SessionId(sessionID),
-		Path:      filepath.Join(t.workindgDir, args.Path),
+		Path:      args.Path,
 	})
 	if err != nil {
 		return &tools.ToolCallResult{Output: fmt.Sprintf("Error reading file: %s", err)}, nil
@@ -143,7 +140,7 @@ func (t *FilesystemToolset) handleEditFile(ctx context.Context, toolCall tools.T
 
 	_, err = t.agent.conn.WriteTextFile(ctx, acp.WriteTextFileRequest{
 		SessionId: acp.SessionId(sessionID),
-		Path:      filepath.Join(t.workindgDir, args.Path),
+		Path:      args.Path,
 		Content:   modifiedContent,
 	})
 	if err != nil {

--- a/pkg/acp/registry.go
+++ b/pkg/acp/registry.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/cagent/pkg/environment"
 	"github.com/docker/cagent/pkg/teamloader"
 	"github.com/docker/cagent/pkg/tools"
+	"github.com/docker/cagent/pkg/tools/builtin"
 )
 
 // createToolsetRegistry creates a custom toolset registry with ACP-specific filesystem toolset
@@ -25,7 +26,13 @@ func createToolsetRegistry(agent *Agent) *teamloader.ToolsetRegistry {
 			}
 		}
 
-		return NewFilesystemToolset(agent, wd), nil
+		var opts []builtin.FileSystemOpt
+		allowedDirectories := []string{wd}
+		if len(toolset.AllowedDirectories) > 0 {
+			opts = append(opts, builtin.WithAllowedDirectories(append(allowedDirectories, toolset.AllowedDirectories...)))
+		}
+
+		return NewFilesystemToolset(agent, opts...), nil
 	})
 
 	return registry

--- a/pkg/config/v2/types.go
+++ b/pkg/config/v2/types.go
@@ -120,7 +120,8 @@ type Toolset struct {
 	Shell map[string]ScriptShellToolConfig `json:"shell,omitempty"`
 
 	// For the `filesystem` tool - post-edit commands
-	PostEdit []PostEditConfig `json:"post_edit,omitempty"`
+	PostEdit           []PostEditConfig `json:"post_edit,omitempty"`
+	AllowedDirectories []string         `json:"allowed_directories,omitempty"`
 
 	// For the `fetch` tool
 	Timeout int `json:"timeout,omitempty"`

--- a/pkg/creator/agent.go
+++ b/pkg/creator/agent.go
@@ -93,7 +93,7 @@ func CreateAgent(ctx context.Context, baseDir, prompt string, runConfig config.R
 
 	fmt.Println("Generating agent configuration....")
 
-	fsToolset := fsToolset{inner: builtin.NewFilesystemTool([]string{baseDir})}
+	fsToolset := fsToolset{inner: builtin.NewFilesystemTool(builtin.WithAllowedDirectories([]string{baseDir}))}
 	fileName := filepath.Base(fsToolset.path)
 	newTeam := team.New(
 		team.WithID(fileName),
@@ -198,7 +198,7 @@ func StreamCreateAgent(ctx context.Context, baseDir, prompt string, runConfig co
 
 	fmt.Println("Generating agent configuration....")
 
-	fsToolset := fsToolset{inner: builtin.NewFilesystemTool([]string{baseDir})}
+	fsToolset := fsToolset{inner: builtin.NewFilesystemTool(builtin.WithAllowedDirectories([]string{baseDir}))}
 	fileName := filepath.Base(fsToolset.path)
 
 	// Provide soft guidance to prefer the selected providers

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -156,7 +156,8 @@ func createFilesystemTool(ctx context.Context, toolset latest.Toolset, parentDir
 		opts = append(opts, builtin.WithPostEditCommands(postEditConfigs))
 	}
 
-	return builtin.NewFilesystemTool([]string{wd}, opts...), nil
+	opts = append(opts, builtin.WithAllowedDirectories(append(toolset.AllowedDirectories, wd)))
+	return builtin.NewFilesystemTool(opts...), nil
 }
 
 func createFetchTool(ctx context.Context, toolset latest.Toolset, parentDir string, envProvider environment.Provider, runtimeConfig config.RuntimeConfig) (tools.ToolSet, error) {

--- a/pkg/tools/builtin/filesystem.go
+++ b/pkg/tools/builtin/filesystem.go
@@ -57,10 +57,15 @@ func WithPostEditCommands(postEditCommands []PostEditConfig) FileSystemOpt {
 	}
 }
 
-func NewFilesystemTool(allowedDirectories []string, opts ...FileSystemOpt) *FilesystemTool {
-	t := &FilesystemTool{
-		allowedDirectories: allowedDirectories,
+func WithAllowedDirectories(directories []string) FileSystemOpt {
+	return func(t *FilesystemTool) {
+		t.allowedDirectories = append(t.allowedDirectories, directories...)
 	}
+}
+
+func NewFilesystemTool(opts ...FileSystemOpt) *FilesystemTool {
+	t := &FilesystemTool{}
+
 	for _, opt := range opts {
 		opt(t)
 	}

--- a/pkg/tools/builtin/filesystem_test.go
+++ b/pkg/tools/builtin/filesystem_test.go
@@ -14,15 +14,16 @@ import (
 )
 
 func TestNewFilesystemTool(t *testing.T) {
-	allowedDirs := []string{"/tmp", "/var/tmp"}
-	tool := NewFilesystemTool(allowedDirs)
+	tmpDir := t.TempDir()
+	tool := NewFilesystemTool(WithAllowedDirectories([]string{tmpDir}))
 
 	assert.NotNil(t, tool)
-	assert.Equal(t, allowedDirs, tool.allowedDirectories)
+	assert.Equal(t, []string{tmpDir}, tool.allowedDirectories)
 }
 
 func TestFilesystemTool_Instructions(t *testing.T) {
-	tool := NewFilesystemTool([]string{"/tmp"})
+	tmpDir := t.TempDir()
+	tool := NewFilesystemTool(WithAllowedDirectories([]string{tmpDir}))
 	instructions := tool.Instructions()
 
 	assert.Contains(t, instructions, "Filesystem Tool Instructions")
@@ -31,7 +32,8 @@ func TestFilesystemTool_Instructions(t *testing.T) {
 }
 
 func TestFilesystemTool_Tools(t *testing.T) {
-	tool := NewFilesystemTool([]string{"/tmp"})
+	tmpDir := t.TempDir()
+	tool := NewFilesystemTool(WithAllowedDirectories([]string{tmpDir}))
 	allTools, err := tool.Tools(t.Context())
 
 	require.NoError(t, err)
@@ -372,7 +374,7 @@ func TestFilesystemTool_Tools(t *testing.T) {
 }
 
 func TestFilesystemTool_DisplayNames(t *testing.T) {
-	tool := NewFilesystemTool([]string{"/tmp"})
+	tool := NewFilesystemTool()
 
 	all, err := tool.Tools(t.Context())
 	require.NoError(t, err)
@@ -385,7 +387,7 @@ func TestFilesystemTool_DisplayNames(t *testing.T) {
 
 func TestFilesystemTool_IsPathAllowed(t *testing.T) {
 	tmpDir := t.TempDir()
-	tool := NewFilesystemTool([]string{tmpDir})
+	tool := NewFilesystemTool(WithAllowedDirectories([]string{tmpDir}))
 
 	// Test allowed path
 	allowedPath := filepath.Join(tmpDir, "subdir", "file.txt")
@@ -401,7 +403,7 @@ func TestFilesystemTool_IsPathAllowed(t *testing.T) {
 
 func TestFilesystemTool_CreateDirectory(t *testing.T) {
 	tmpDir := t.TempDir()
-	tool := NewFilesystemTool([]string{tmpDir})
+	tool := NewFilesystemTool(WithAllowedDirectories([]string{tmpDir}))
 
 	handler := getToolHandler(t, tool, "create_directory")
 
@@ -424,7 +426,7 @@ func TestFilesystemTool_CreateDirectory(t *testing.T) {
 
 func TestFilesystemTool_WriteFile(t *testing.T) {
 	tmpDir := t.TempDir()
-	tool := NewFilesystemTool([]string{tmpDir})
+	tool := NewFilesystemTool(WithAllowedDirectories([]string{tmpDir}))
 
 	handler := getToolHandler(t, tool, "write_file")
 
@@ -459,7 +461,7 @@ func TestFilesystemTool_WriteFile(t *testing.T) {
 
 func TestFilesystemTool_WriteFile_NestedDirectory(t *testing.T) {
 	tmpDir := t.TempDir()
-	tool := NewFilesystemTool([]string{tmpDir})
+	tool := NewFilesystemTool(WithAllowedDirectories([]string{tmpDir}))
 
 	handler := getToolHandler(t, tool, "write_file")
 
@@ -490,7 +492,7 @@ func TestFilesystemTool_WriteFile_NestedDirectory(t *testing.T) {
 
 func TestFilesystemTool_ReadFile(t *testing.T) {
 	tmpDir := t.TempDir()
-	tool := NewFilesystemTool([]string{tmpDir})
+	tool := NewFilesystemTool(WithAllowedDirectories([]string{tmpDir}))
 
 	// Create test file
 	testFile := filepath.Join(tmpDir, "test.txt")
@@ -523,7 +525,7 @@ func TestFilesystemTool_ReadFile(t *testing.T) {
 
 func TestFilesystemTool_ReadMultipleFiles(t *testing.T) {
 	tmpDir := t.TempDir()
-	tool := NewFilesystemTool([]string{tmpDir})
+	tool := NewFilesystemTool(WithAllowedDirectories([]string{tmpDir}))
 
 	// Create test files
 	file1 := filepath.Join(tmpDir, "file1.txt")
@@ -556,7 +558,7 @@ func TestFilesystemTool_ReadMultipleFiles(t *testing.T) {
 
 func TestFilesystemTool_ListDirectory(t *testing.T) {
 	tmpDir := t.TempDir()
-	tool := NewFilesystemTool([]string{tmpDir})
+	tool := NewFilesystemTool(WithAllowedDirectories([]string{tmpDir}))
 
 	// Create test files and directories
 	testFile := filepath.Join(tmpDir, "test.txt")
@@ -584,7 +586,7 @@ func TestFilesystemTool_ListDirectory(t *testing.T) {
 
 func TestFilesystemTool_ListDirectoryWithSizes(t *testing.T) {
 	tmpDir := t.TempDir()
-	tool := NewFilesystemTool([]string{tmpDir})
+	tool := NewFilesystemTool(WithAllowedDirectories([]string{tmpDir}))
 
 	// Create test files and directories
 	testFile := filepath.Join(tmpDir, "test.txt")
@@ -606,7 +608,7 @@ func TestFilesystemTool_ListDirectoryWithSizes(t *testing.T) {
 
 func TestFilesystemTool_GetFileInfo(t *testing.T) {
 	tmpDir := t.TempDir()
-	tool := NewFilesystemTool([]string{tmpDir})
+	tool := NewFilesystemTool(WithAllowedDirectories([]string{tmpDir}))
 
 	// Create test file
 	testFile := filepath.Join(tmpDir, "test.txt")
@@ -636,7 +638,7 @@ func TestFilesystemTool_GetFileInfo(t *testing.T) {
 
 func TestFilesystemTool_MoveFile(t *testing.T) {
 	tmpDir := t.TempDir()
-	tool := NewFilesystemTool([]string{tmpDir})
+	tool := NewFilesystemTool(WithAllowedDirectories([]string{tmpDir}))
 
 	// Create test file
 	sourceFile := filepath.Join(tmpDir, "source.txt")
@@ -677,7 +679,7 @@ func TestFilesystemTool_MoveFile(t *testing.T) {
 
 func TestFilesystemTool_EditFile(t *testing.T) {
 	tmpDir := t.TempDir()
-	tool := NewFilesystemTool([]string{tmpDir})
+	tool := NewFilesystemTool(WithAllowedDirectories([]string{tmpDir}))
 
 	// Create test file
 	testFile := filepath.Join(tmpDir, "test.txt")
@@ -737,7 +739,7 @@ func TestFilesystemTool_SearchFiles(t *testing.T) {
 	require.NoError(t, os.Mkdir(subDir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(subDir, "test_sub.txt"), []byte("sub"), 0o644))
 
-	tool := NewFilesystemTool([]string{tmpDir})
+	tool := NewFilesystemTool(WithAllowedDirectories([]string{tmpDir}))
 	handler := getToolHandler(t, tool, "search_files")
 
 	// Test search for files containing "asdf"
@@ -776,7 +778,7 @@ func TestFilesystemTool_SearchFiles(t *testing.T) {
 
 func TestFilesystemTool_SearchFilesContent(t *testing.T) {
 	tmpDir := t.TempDir()
-	tool := NewFilesystemTool([]string{tmpDir})
+	tool := NewFilesystemTool(WithAllowedDirectories([]string{tmpDir}))
 
 	// Create test files with different content
 	file1Content := "This is a test file\nwith multiple lines\ncontaining test data"
@@ -838,7 +840,7 @@ func TestFilesystemTool_SearchFiles_RecursivePattern(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "child", "third.txt"), []byte("third"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "child", "ignored"), []byte("ignored"), 0o644))
 
-	tool := NewFilesystemTool([]string{tmpDir})
+	tool := NewFilesystemTool(WithAllowedDirectories([]string{tmpDir}))
 	handler := getToolHandler(t, tool, "search_files")
 
 	// Test search for files containing ".txt" files
@@ -855,7 +857,7 @@ func TestFilesystemTool_SearchFiles_RecursivePattern(t *testing.T) {
 
 func TestFilesystemTool_ListAllowedDirectories(t *testing.T) {
 	allowedDirs := []string{"/tmp", "/var/tmp", "/home/user"}
-	tool := NewFilesystemTool(allowedDirs)
+	tool := NewFilesystemTool(WithAllowedDirectories(allowedDirs))
 
 	handler := getToolHandler(t, tool, "list_allowed_directories")
 
@@ -871,7 +873,7 @@ func TestFilesystemTool_ListAllowedDirectories(t *testing.T) {
 
 func TestFilesystemTool_InvalidArguments(t *testing.T) {
 	tmpDir := t.TempDir()
-	tool := NewFilesystemTool([]string{tmpDir})
+	tool := NewFilesystemTool(WithAllowedDirectories([]string{tmpDir}))
 
 	handler := getToolHandler(t, tool, "write_file")
 
@@ -889,7 +891,9 @@ func TestFilesystemTool_InvalidArguments(t *testing.T) {
 }
 
 func TestFilesystemTool_StartStop(t *testing.T) {
-	tool := NewFilesystemTool([]string{"/tmp"})
+	tmpDir := t.TempDir()
+
+	tool := NewFilesystemTool(WithAllowedDirectories([]string{tmpDir}))
 
 	// Test Start method
 	err := tool.Start(t.Context())
@@ -916,7 +920,7 @@ func main() {
 			Cmd:  "touch $path.formatted",
 		},
 	}
-	tool := NewFilesystemTool([]string{tmpDir}, WithPostEditCommands(postEditConfigs))
+	tool := NewFilesystemTool(WithAllowedDirectories([]string{tmpDir}), WithPostEditCommands(postEditConfigs))
 
 	formattedFile := testFile + ".formatted"
 	t.Run("write_file", func(t *testing.T) {
@@ -1015,7 +1019,7 @@ func TestFilesystemTool_AddAllowedDirectory(t *testing.T) {
 	tmpDir2 := t.TempDir()
 
 	// Create filesystem tool with only tmpDir1 initially allowed
-	tool := NewFilesystemTool([]string{tmpDir1})
+	tool := NewFilesystemTool(WithAllowedDirectories([]string{tmpDir1}))
 	handler := getToolHandler(t, tool, "add_allowed_directory")
 
 	t.Run("request consent for new directory", func(t *testing.T) {
@@ -1210,7 +1214,8 @@ func TestMatchExcludePattern(t *testing.T) {
 }
 
 func TestFilesystemTool_OutputSchema(t *testing.T) {
-	tool := NewFilesystemTool(nil)
+	tmpDir := t.TempDir()
+	tool := NewFilesystemTool(WithAllowedDirectories([]string{tmpDir}))
 
 	allTools, err := tool.Tools(t.Context())
 	require.NoError(t, err)
@@ -1222,7 +1227,8 @@ func TestFilesystemTool_OutputSchema(t *testing.T) {
 }
 
 func TestFilesystemTool_ParametersAreObjects(t *testing.T) {
-	tool := NewFilesystemTool(nil)
+	tmpDir := t.TempDir()
+	tool := NewFilesystemTool(WithAllowedDirectories([]string{tmpDir}))
 
 	allTools, err := tool.Tools(t.Context())
 	require.NoError(t, err)


### PR DESCRIPTION
By default cagent adds the current working directory.

Note: The "add current working directory by default" is not great IMO, so please hold on merging this one. What I think would be best is:

- if no `allowed_directories` defined, we add the current working directory
- if `allowed_directories` is defined, we use that and don't add the CWD.

This would mean that we need to give a way for the user to **also** add the CWD to the list of allowed directories, so we need to use our scripiting engine for the user to be able to add `${env.PWD}` for example. 