### PR TITLE
Support lauching the api command with an oci artifact

### DIFF
--- a/cmd/root/api_test.go
+++ b/cmd/root/api_test.go
@@ -1,0 +1,106 @@
+package root
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsOCIReference(t *testing.T) {
+	// Create a temporary directory to test existing paths
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		// Valid OCI references
+		{
+			name:     "simple repository with tag",
+			input:    "myregistry/myrepo:latest",
+			expected: true,
+		},
+		{
+			name:     "repository with digest",
+			input:    "myregistry/myrepo@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			expected: true,
+		},
+		{
+			name:     "docker hub image",
+			input:    "nginx:latest",
+			expected: true,
+		},
+		{
+			name:     "fully qualified registry",
+			input:    "ghcr.io/docker/cagent:v1.0.0",
+			expected: true,
+		},
+		{
+			name:     "registry with port",
+			input:    "localhost:5000/myimage:tag",
+			expected: true,
+		},
+
+		// Local files - NOT OCI references
+		{
+			name:     "yaml file",
+			input:    "agent.yaml",
+			expected: false,
+		},
+		{
+			name:     "yml file",
+			input:    "config.yml",
+			expected: false,
+		},
+		{
+			name:     "yaml file with path",
+			input:    "/path/to/agent.yaml",
+			expected: false,
+		},
+		{
+			name:     "file descriptor",
+			input:    "/dev/fd/3",
+			expected: false,
+		},
+
+		// Invalid inputs - NOT valid OCI references
+		{
+			name:     "empty string",
+			input:    "",
+			expected: false,
+		},
+		{
+			name:     "typo in yaml filename",
+			input:    "my-agnt.yaml",
+			expected: false,
+		},
+		{
+			name:     "invalid OCI reference with too many colons",
+			input:    "invalid:reference:with:too:many:colons",
+			expected: false,
+		},
+		{
+			name:     "random string",
+			input:    "not-a-valid-reference!!!",
+			expected: false,
+		},
+		{
+			name:     "non-existent directory path that looks like OCI ref",
+			input:    "/path/to/agents",
+			expected: true, // Parses as valid OCI ref if path doesn't exist
+		},
+		{
+			name:     "existing directory",
+			input:    tmpDir,
+			expected: false, // Existing paths are NOT OCI references
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isOCIReference(tt.input)
+			assert.Equal(t, tt.expected, result, "isOCIReference(%q) = %v, want %v", tt.input, result, tt.expected)
+		})
+	}
+}

--- a/cmd/root/pull.go
+++ b/cmd/root/pull.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/spf13/cobra"
 
+	"github.com/docker/cagent/pkg/agentfile"
 	"github.com/docker/cagent/pkg/cli"
 	"github.com/docker/cagent/pkg/remote"
 	"github.com/docker/cagent/pkg/telemetry"
@@ -39,7 +40,7 @@ func runPullCommand(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to pull artifact: %w", err)
 	}
 
-	yamlFile, err := fromStore(registryRef)
+	yamlFile, err := agentfile.FromStore(registryRef)
 	if err != nil {
 		return fmt.Errorf("failed to get agent yaml: %w", err)
 	}

--- a/cmd/root/run_test.go
+++ b/cmd/root/run_test.go
@@ -1,0 +1,278 @@
+package root
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/cagent/pkg/agentfile"
+	"github.com/docker/cagent/pkg/content"
+	"github.com/docker/cagent/pkg/oci"
+)
+
+func TestOciRefToFilename(t *testing.T) {
+	tests := []struct {
+		name     string
+		ociRef   string
+		expected string
+	}{
+		{
+			name:     "simple reference",
+			ociRef:   "myagent",
+			expected: "myagent.yaml",
+		},
+		{
+			name:     "reference with registry and tag",
+			ociRef:   "docker.io/myorg/agent:v1",
+			expected: "docker.io_myorg_agent_v1.yaml",
+		},
+		{
+			name:     "localhost with port",
+			ociRef:   "localhost:5000/test",
+			expected: "localhost_5000_test.yaml",
+		},
+		{
+			name:     "reference with digest",
+			ociRef:   "myregistry.io/org/app@sha256:abc123",
+			expected: "myregistry.io_org_app_sha256_abc123.yaml",
+		},
+		{
+			name:     "already has .yaml extension",
+			ociRef:   "myagent.yaml",
+			expected: "myagent.yaml",
+		},
+		{
+			name:     "complex path",
+			ociRef:   "registry.example.com:443/project/subproject/agent:latest",
+			expected: "registry.example.com_443_project_subproject_agent_latest.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := agentfile.OciRefToFilename(tt.ociRef)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestResolveAgentFile_LocalFile(t *testing.T) {
+	// Create a temporary YAML file
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "test-agent.yaml")
+	yamlContent := `version: "1"
+agents:
+  root:
+    model: openai/gpt-4o
+    description: Test agent
+    instruction: You are a test agent
+`
+	require.NoError(t, os.WriteFile(yamlFile, []byte(yamlContent), 0o644))
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	// Test resolving a local file
+	resolved, err := agentfile.Resolve(ctx, yamlFile)
+	require.NoError(t, err)
+
+	// Should return absolute path
+	absPath, err := filepath.Abs(yamlFile)
+	require.NoError(t, err)
+	assert.Equal(t, absPath, resolved)
+}
+
+func TestResolveAgentFile_OCIRef_ConsistentFilename(t *testing.T) {
+	// Set up a test OCI store in the default location
+	storeDir := t.TempDir()
+	t.Setenv("CAGENT_CONTENT_STORE", storeDir)
+
+	store, err := content.NewStore()
+	require.NoError(t, err)
+
+	// Create a test agent YAML file
+	agentContent := `version: "1"
+agents:
+  root:
+    model: openai/gpt-4o
+    description: Test OCI agent
+    instruction: You are a test OCI agent
+`
+	agentFile := filepath.Join(t.TempDir(), "oci-agent.yaml")
+	require.NoError(t, os.WriteFile(agentFile, []byte(agentContent), 0o644))
+
+	// Package as OCI artifact
+	ociRef := "test.registry.io/myorg/testagent:v1"
+	_, err = oci.PackageFileAsOCIToStore(agentFile, ociRef, store)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	// First resolution
+	resolved1, err := agentfile.Resolve(ctx, ociRef)
+	require.NoError(t, err)
+	assert.NotEmpty(t, resolved1)
+
+	// Verify the file exists and has correct content
+	content1, err := os.ReadFile(resolved1)
+	require.NoError(t, err)
+	assert.Equal(t, agentContent, string(content1))
+
+	// Expected filename based on OCI ref
+	expectedFilename := agentfile.OciRefToFilename(ociRef)
+	assert.Equal(t, expectedFilename, filepath.Base(resolved1))
+
+	// Store the first resolved path
+	firstResolvedPath := resolved1
+
+	// Second resolution (simulating a reload)
+	resolved2, err := agentfile.Resolve(ctx, ociRef)
+	require.NoError(t, err)
+
+	// Should return the SAME filename
+	assert.Equal(t, resolved1, resolved2, "Subsequent resolutions should return the same file path")
+	assert.Equal(t, filepath.Base(resolved1), filepath.Base(resolved2), "Filenames should be identical")
+
+	// Verify the content is still correct
+	content2, err := os.ReadFile(resolved2)
+	require.NoError(t, err)
+	assert.Equal(t, agentContent, string(content2))
+
+	// Update the agent content in the OCI store
+	updatedContent := `version: "1"
+agents:
+  root:
+    model: openai/gpt-4o-mini
+    description: Updated test OCI agent
+    instruction: You are an updated test OCI agent
+`
+	updatedFile := filepath.Join(t.TempDir(), "updated-agent.yaml")
+	require.NoError(t, os.WriteFile(updatedFile, []byte(updatedContent), 0o644))
+	_, err = oci.PackageFileAsOCIToStore(updatedFile, ociRef, store)
+	require.NoError(t, err)
+
+	// Third resolution (simulating reload after update)
+	resolved3, err := agentfile.Resolve(ctx, ociRef)
+	require.NoError(t, err)
+
+	// Should STILL use the same filename
+	assert.Equal(t, firstResolvedPath, resolved3, "Even after OCI update, should use same file path")
+
+	// But content should be updated
+	content3, err := os.ReadFile(resolved3)
+	require.NoError(t, err)
+	assert.Equal(t, updatedContent, string(content3), "Content should be updated from OCI store")
+}
+
+func TestResolveAgentFile_MultipleOCIRefs_DifferentFilenames(t *testing.T) {
+	// Set up a test OCI store in the default location
+	storeDir := t.TempDir()
+	t.Setenv("CAGENT_CONTENT_STORE", storeDir)
+
+	store, err := content.NewStore()
+	require.NoError(t, err)
+
+	// Create two different agent YAML files
+	agent1Content := `version: "1"
+agents:
+  root:
+    model: openai/gpt-4o
+    description: Agent 1
+    instruction: You are agent 1
+`
+	agent2Content := `version: "1"
+agents:
+  root:
+    model: anthropic/claude-sonnet-4-0
+    description: Agent 2
+    instruction: You are agent 2
+`
+
+	agent1File := filepath.Join(t.TempDir(), "agent1.yaml")
+	agent2File := filepath.Join(t.TempDir(), "agent2.yaml")
+	require.NoError(t, os.WriteFile(agent1File, []byte(agent1Content), 0o644))
+	require.NoError(t, os.WriteFile(agent2File, []byte(agent2Content), 0o644))
+
+	// Package as different OCI artifacts
+	ociRef1 := "test.io/org/agent1:v1"
+	ociRef2 := "test.io/org/agent2:v1"
+	_, err = oci.PackageFileAsOCIToStore(agent1File, ociRef1, store)
+	require.NoError(t, err)
+	_, err = oci.PackageFileAsOCIToStore(agent2File, ociRef2, store)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	// Resolve both OCI refs
+	resolved1, err := agentfile.Resolve(ctx, ociRef1)
+	require.NoError(t, err)
+
+	resolved2, err := agentfile.Resolve(ctx, ociRef2)
+	require.NoError(t, err)
+
+	// Should have DIFFERENT filenames
+	assert.NotEqual(t, resolved1, resolved2, "Different OCI refs should produce different file paths")
+	assert.NotEqual(t, filepath.Base(resolved1), filepath.Base(resolved2), "Different OCI refs should produce different filenames")
+
+	// Verify each has correct content
+	content1, err := os.ReadFile(resolved1)
+	require.NoError(t, err)
+	assert.Equal(t, agent1Content, string(content1))
+
+	content2, err := os.ReadFile(resolved2)
+	require.NoError(t, err)
+	assert.Equal(t, agent2Content, string(content2))
+
+	// Verify filenames match expected pattern
+	assert.Equal(t, agentfile.OciRefToFilename(ociRef1), filepath.Base(resolved1))
+	assert.Equal(t, agentfile.OciRefToFilename(ociRef2), filepath.Base(resolved2))
+}
+
+func TestResolveAgentFile_ContextCancellation(t *testing.T) {
+	// Set up a test OCI store in the default location
+	storeDir := t.TempDir()
+	t.Setenv("CAGENT_CONTENT_STORE", storeDir)
+
+	store, err := content.NewStore()
+	require.NoError(t, err)
+
+	// Create a test agent YAML file
+	agentContent := `version: "1"
+agents:
+  root:
+    model: openai/gpt-4o
+    description: Test agent
+    instruction: You are a test agent
+`
+	agentFile := filepath.Join(t.TempDir(), "agent.yaml")
+	require.NoError(t, os.WriteFile(agentFile, []byte(agentContent), 0o644))
+
+	// Package as OCI artifact
+	ociRef := "test.io/cleanup/agent:v1"
+	_, err = oci.PackageFileAsOCIToStore(agentFile, ociRef, store)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	// Resolve the OCI ref
+	resolved, err := agentfile.Resolve(ctx, ociRef)
+	require.NoError(t, err)
+	assert.FileExists(t, resolved)
+
+	// Cancel the context to trigger cleanup
+	cancel()
+
+	// Give the cleanup goroutine time to execute
+	time.Sleep(100 * time.Millisecond)
+
+	// File should be deleted
+	_, err = os.Stat(resolved)
+	assert.True(t, os.IsNotExist(err), "File should be cleaned up after context cancellation")
+}

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -56,6 +56,9 @@ $ cagent exec config.yaml --yolo          # Run the agent once and auto-accept a
 # API Server (HTTP REST API)
 $ cagent api config.yaml
 $ cagent api config.yaml --listen :8080
+$ cagent api ociReference # start API from oci reference 
+## start API from oci reference, auto-pull every 10 mins and reload if a new team was pulled
+$ cagent api ociReference --pull-interval 10
 
 # ACP Server (Agent Client Protocol via stdio)
 $ cagent acp config.yaml                 # Start ACP server on stdio

--- a/pkg/agentfile/resolver.go
+++ b/pkg/agentfile/resolver.go
@@ -1,0 +1,153 @@
+package agentfile
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/docker/cagent/pkg/aliases"
+	"github.com/docker/cagent/pkg/content"
+	"github.com/docker/cagent/pkg/remote"
+)
+
+// IsLocalFile checks if the input is a local file
+func IsLocalFile(input string) bool {
+	ext := strings.ToLower(filepath.Ext(input))
+	// Check for YAML file extensions or file descriptors
+	if ext == ".yaml" || ext == ".yml" || strings.HasPrefix(input, "/dev/fd/") {
+		return true
+	}
+	// Check if it exists as a file on disk
+	return fileExists(input)
+}
+
+// OciRefToFilename converts an OCI reference to a safe, consistent filename
+// Examples:
+//   - "docker.io/myorg/agent:v1" -> "docker.io_myorg_agent_v1.yaml"
+//   - "localhost:5000/test" -> "localhost_5000_test.yaml"
+func OciRefToFilename(ociRef string) string {
+	// Replace characters that are invalid in filenames with underscores
+	// Keep the structure recognizable but filesystem-safe
+	safe := strings.NewReplacer(
+		"/", "_",
+		":", "_",
+		"@", "_",
+		"\\", "_",
+		"*", "_",
+		"?", "_",
+		"\"", "_",
+		"<", "_",
+		">", "_",
+		"|", "_",
+	).Replace(ociRef)
+
+	// Ensure it has .yaml extension
+	if !strings.HasSuffix(safe, ".yaml") {
+		safe += ".yaml"
+	}
+
+	return safe
+}
+
+// Resolve resolves an agent file reference (local file or OCI image) to a local file path
+func Resolve(ctx context.Context, agentFilename string) (string, error) {
+	originalOCIRef := agentFilename // Store the original for OCI ref tracking
+
+	// Try to resolve as an alias first
+	if aliasStore, err := aliases.Load(); err == nil {
+		if resolvedPath, ok := aliasStore.Get(agentFilename); ok {
+			slog.Debug("Resolved alias", "alias", agentFilename, "path", resolvedPath)
+			agentFilename = resolvedPath
+		}
+	}
+
+	if IsLocalFile(agentFilename) {
+		// Treat as local YAML file: resolve to absolute path so later chdir doesn't break it
+		// TODO(rumpl): Why are we checking for newlines here?
+		if !strings.Contains(agentFilename, "\n") {
+			if abs, err := filepath.Abs(agentFilename); err == nil {
+				agentFilename = abs
+			}
+		}
+		if !fileExists(agentFilename) {
+			return "", fmt.Errorf("agent file not found: %s", agentFilename)
+		}
+		return agentFilename, nil
+	}
+
+	// Treat as an OCI image reference. Try local store first, otherwise pull then load.
+	a, err := FromStore(agentFilename)
+	if err != nil {
+		fmt.Println("Pulling agent", agentFilename)
+		if _, pullErr := remote.Pull(agentFilename); pullErr != nil {
+			return "", fmt.Errorf("failed to pull OCI image %s: %w", agentFilename, pullErr)
+		}
+		// Retry after pull
+		a, err = FromStore(agentFilename)
+		if err != nil {
+			return "", fmt.Errorf("failed to load agent from store after pull: %w", err)
+		}
+	}
+
+	filename := OciRefToFilename(originalOCIRef)
+	tmpFilename := filepath.Join(os.TempDir(), filename)
+
+	if err := os.WriteFile(tmpFilename, []byte(a), 0o644); err != nil {
+		return "", fmt.Errorf("failed to write agent file: %w", err)
+	}
+
+	slog.Debug("Resolved OCI reference to file", "oci_ref", originalOCIRef, "file", tmpFilename)
+
+	go func() {
+		<-ctx.Done()
+		os.Remove(tmpFilename)
+		slog.Debug("Cleaned up OCI reference file", "file", tmpFilename)
+	}()
+
+	return tmpFilename, nil
+}
+
+// fileExists checks if a file exists at the given path
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	exists := err == nil
+	return exists
+}
+
+// FromStore loads an agent configuration from the OCI content store
+func FromStore(reference string) (string, error) {
+	store, err := content.NewStore()
+	if err != nil {
+		return "", err
+	}
+
+	img, err := store.GetArtifactImage(reference)
+	if err != nil {
+		return "", err
+	}
+
+	layers, err := img.Layers()
+	if err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	layer := layers[0]
+	b, err := layer.Uncompressed()
+	if err != nil {
+		return "", err
+	}
+
+	_, err = io.Copy(&buf, b)
+	if err != nil {
+		return "", err
+	}
+	b.Close()
+
+	return buf.String(), nil
+}

--- a/pkg/desktop/connection_other.go
+++ b/pkg/desktop/connection_other.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package desktop
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/cagent/pkg/config"
 	latest "github.com/docker/cagent/pkg/config/v2"
 	"github.com/docker/cagent/pkg/session"
+	"github.com/docker/cagent/pkg/teamloader"
 )
 
 func TestServer_ListAgents(t *testing.T) {
@@ -215,6 +216,401 @@ func TestServer_ListSessions(t *testing.T) {
 	unmarshal(t, buf, &sessions)
 
 	assert.Empty(t, sessions)
+}
+
+func TestServer_ReloadTeams(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "dummy")
+	t.Setenv("ANTHROPIC_API_KEY", "dummy")
+
+	ctx := t.Context()
+
+	// Create initial agents directory with pirate agent
+	agentsDir1 := prepareAgentsDir(t, "pirate.yaml")
+
+	var store mockStore
+	var runConfig config.RuntimeConfig
+
+	// Load initial teams
+	teams, err := teamloader.LoadTeams(ctx, agentsDir1, runConfig)
+	require.NoError(t, err)
+
+	srv, err := New(store, runConfig, teams, WithAgentsDir(agentsDir1))
+	require.NoError(t, err)
+
+	// Verify initial state - should have pirate agent
+	initialTeamsCount := srv.countTeams()
+	hasPirate := srv.hasTeam("pirate.yaml")
+
+	assert.Equal(t, 1, initialTeamsCount)
+	assert.True(t, hasPirate, "should have pirate agent initially")
+
+	// Create a new agents directory with different agents
+	agentsDir2 := prepareAgentsDir(t, "contradict.yaml", "multi_agents.yaml")
+
+	// Reload teams from the new directory
+	err = srv.ReloadTeams(ctx, agentsDir2)
+	require.NoError(t, err)
+
+	// Verify teams were reloaded
+	newTeamsCount := srv.countTeams()
+	hasPirateAfter := srv.hasTeam("pirate.yaml")
+	hasContradict := srv.hasTeam("contradict.yaml")
+	hasMulti := srv.hasTeam("multi_agents.yaml")
+
+	assert.Equal(t, 2, newTeamsCount, "should have 2 agents after reload")
+	assert.False(t, hasPirateAfter, "pirate agent should be removed")
+	assert.True(t, hasContradict, "should have contradict agent")
+	assert.True(t, hasMulti, "should have multi_agents agent")
+}
+
+func TestServer_ReloadTeams_Concurrent(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "dummy")
+	t.Setenv("ANTHROPIC_API_KEY", "dummy")
+
+	ctx := t.Context()
+
+	agentsDir := prepareAgentsDir(t, "pirate.yaml")
+
+	var store mockStore
+	var runConfig config.RuntimeConfig
+
+	// Load initial teams
+	teams, err := teamloader.LoadTeams(ctx, agentsDir, runConfig)
+	require.NoError(t, err)
+
+	srv, err := New(store, runConfig, teams, WithAgentsDir(agentsDir))
+	require.NoError(t, err)
+
+	// Create another directory for reloading
+	agentsDir2 := prepareAgentsDir(t, "contradict.yaml")
+
+	// Test concurrent access: read teams while reloading
+	done := make(chan bool)
+	go func() {
+		for range 100 {
+			_ = srv.countTeams()
+		}
+		done <- true
+	}()
+
+	err = srv.ReloadTeams(ctx, agentsDir2)
+	require.NoError(t, err)
+
+	err = srv.ReloadTeams(ctx, agentsDir)
+	require.NoError(t, err)
+
+	<-done
+
+	// Verify final state matches last reload
+	hasPirate := srv.hasTeam("pirate.yaml")
+
+	assert.True(t, hasPirate, "should have pirate agent after final reload")
+}
+
+func TestServer_ReloadTeams_InvalidPath(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "dummy")
+
+	ctx := t.Context()
+
+	agentsDir := prepareAgentsDir(t, "pirate.yaml")
+
+	var store mockStore
+	var runConfig config.RuntimeConfig
+
+	// Load initial teams
+	teams, err := teamloader.LoadTeams(ctx, agentsDir, runConfig)
+	require.NoError(t, err)
+
+	srv, err := New(store, runConfig, teams, WithAgentsDir(agentsDir))
+	require.NoError(t, err)
+
+	// Try to reload from non-existent path
+	err = srv.ReloadTeams(ctx, "/nonexistent/path")
+	require.Error(t, err)
+
+	// Verify original teams are still intact
+	teamsCount := srv.countTeams()
+	hasPirate := srv.hasTeam("pirate.yaml")
+
+	assert.Equal(t, 1, teamsCount, "should still have original team")
+	assert.True(t, hasPirate, "should still have pirate agent")
+}
+
+func TestServer_RefreshAgentsFromDisk_AddNewAgent(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "dummy")
+	t.Setenv("ANTHROPIC_API_KEY", "dummy")
+
+	ctx := t.Context()
+
+	// Start with only pirate agent
+	agentsDir := prepareAgentsDir(t, "pirate.yaml")
+
+	var store mockStore
+	var runConfig config.RuntimeConfig
+
+	teams, err := teamloader.LoadTeams(ctx, agentsDir, runConfig)
+	require.NoError(t, err)
+
+	srv, err := New(store, runConfig, teams, WithAgentsDir(agentsDir))
+	require.NoError(t, err)
+
+	// Verify initial state
+	initialCount := srv.countTeams()
+	hasPirate := srv.hasTeam("pirate.yaml")
+	hasContradict := srv.hasTeam("contradict.yaml")
+
+	assert.Equal(t, 1, initialCount)
+	assert.True(t, hasPirate)
+	assert.False(t, hasContradict)
+
+	// Add a new agent to the directory
+	buf, err := os.ReadFile(filepath.Join("testdata", "contradict.yaml"))
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(agentsDir, "contradict.yaml"), buf, 0o600)
+	require.NoError(t, err)
+
+	// Refresh agents from disk
+	err = srv.refreshAgentsFromDisk(ctx)
+	require.NoError(t, err)
+
+	// Verify new agent was added
+	newCount := srv.countTeams()
+	hasPirateAfter := srv.hasTeam("pirate.yaml")
+	hasContradictAfter := srv.hasTeam("contradict.yaml")
+
+	assert.Equal(t, 2, newCount, "should have 2 agents after refresh")
+	assert.True(t, hasPirateAfter, "pirate agent should still exist")
+	assert.True(t, hasContradictAfter, "contradict agent should be added")
+}
+
+func TestServer_RefreshAgentsFromDisk_RemoveAgent(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "dummy")
+	t.Setenv("ANTHROPIC_API_KEY", "dummy")
+
+	ctx := t.Context()
+
+	// Start with two agents
+	agentsDir := prepareAgentsDir(t, "pirate.yaml", "contradict.yaml")
+
+	var store mockStore
+	var runConfig config.RuntimeConfig
+
+	teams, err := teamloader.LoadTeams(ctx, agentsDir, runConfig)
+	require.NoError(t, err)
+
+	srv, err := New(store, runConfig, teams, WithAgentsDir(agentsDir))
+	require.NoError(t, err)
+
+	// Verify initial state
+	initialCount := srv.countTeams()
+	hasPirate := srv.hasTeam("pirate.yaml")
+	hasContradict := srv.hasTeam("contradict.yaml")
+
+	assert.Equal(t, 2, initialCount)
+	assert.True(t, hasPirate)
+	assert.True(t, hasContradict)
+
+	// Remove contradict agent from disk
+	err = os.Remove(filepath.Join(agentsDir, "contradict.yaml"))
+	require.NoError(t, err)
+
+	// Refresh agents from disk
+	err = srv.refreshAgentsFromDisk(ctx)
+	require.NoError(t, err)
+
+	// Verify agent was removed
+	newCount := srv.countTeams()
+	hasPirateAfter := srv.hasTeam("pirate.yaml")
+	hasContradictAfter := srv.hasTeam("contradict.yaml")
+
+	assert.Equal(t, 1, newCount, "should have 1 agent after refresh")
+	assert.True(t, hasPirateAfter, "pirate agent should still exist")
+	assert.False(t, hasContradictAfter, "contradict agent should be removed")
+}
+
+func TestServer_RefreshAgentsFromDisk_UpdateAgent(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "dummy")
+
+	ctx := t.Context()
+
+	// Start with pirate agent
+	agentsDir := prepareAgentsDir(t, "pirate.yaml")
+
+	var store mockStore
+	var runConfig config.RuntimeConfig
+
+	teams, err := teamloader.LoadTeams(ctx, agentsDir, runConfig)
+	require.NoError(t, err)
+
+	srv, err := New(store, runConfig, teams, WithAgentsDir(agentsDir))
+	require.NoError(t, err)
+
+	// Get initial agent
+	initialTeam, exists := srv.getTeam("pirate.yaml")
+	require.True(t, exists)
+	require.NotNil(t, initialTeam)
+
+	initialAgent, err := initialTeam.Agent("root")
+	require.NoError(t, err)
+	initialInstruction := initialAgent.Instruction()
+
+	// Modify the agent file on disk
+	modifiedConfig := `version: "2"
+agents:
+  root:
+    model: openai/gpt-4o
+    description: "Updated pirate"
+    instruction: "You are an UPDATED pirate. Talk like a pirate in all your responses."
+`
+	err = os.WriteFile(filepath.Join(agentsDir, "pirate.yaml"), []byte(modifiedConfig), 0o600)
+	require.NoError(t, err)
+
+	// Refresh agents from disk
+	err = srv.refreshAgentsFromDisk(ctx)
+	require.NoError(t, err)
+
+	// Verify agent was updated
+	updatedTeam, exists := srv.getTeam("pirate.yaml")
+	require.True(t, exists)
+	require.NotNil(t, updatedTeam)
+
+	updatedAgent, err := updatedTeam.Agent("root")
+	require.NoError(t, err)
+	updatedInstruction := updatedAgent.Instruction()
+
+	assert.NotEqual(t, initialInstruction, updatedInstruction, "instruction should be updated")
+	assert.Contains(t, updatedInstruction, "UPDATED", "should have updated instruction")
+}
+
+func TestServer_RefreshAgentsFromDisk_MultipleChanges(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "dummy")
+	t.Setenv("ANTHROPIC_API_KEY", "dummy")
+
+	ctx := t.Context()
+
+	// Start with pirate and contradict agents
+	agentsDir := prepareAgentsDir(t, "pirate.yaml", "contradict.yaml")
+
+	var store mockStore
+	var runConfig config.RuntimeConfig
+
+	teams, err := teamloader.LoadTeams(ctx, agentsDir, runConfig)
+	require.NoError(t, err)
+
+	srv, err := New(store, runConfig, teams, WithAgentsDir(agentsDir))
+	require.NoError(t, err)
+
+	// Verify initial state
+	initialCount := srv.countTeams()
+	assert.Equal(t, 2, initialCount)
+
+	// Remove contradict, add multi_agents
+	err = os.Remove(filepath.Join(agentsDir, "contradict.yaml"))
+	require.NoError(t, err)
+
+	buf, err := os.ReadFile(filepath.Join("testdata", "multi_agents.yaml"))
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(agentsDir, "multi_agents.yaml"), buf, 0o600)
+	require.NoError(t, err)
+
+	// Refresh agents from disk
+	err = srv.refreshAgentsFromDisk(ctx)
+	require.NoError(t, err)
+
+	// Verify changes
+	newCount := srv.countTeams()
+	hasPirate := srv.hasTeam("pirate.yaml")
+	hasContradict := srv.hasTeam("contradict.yaml")
+	hasMulti := srv.hasTeam("multi_agents.yaml")
+
+	assert.Equal(t, 2, newCount, "should have 2 agents")
+	assert.True(t, hasPirate, "pirate agent should still exist")
+	assert.False(t, hasContradict, "contradict agent should be removed")
+	assert.True(t, hasMulti, "multi_agents should be added")
+}
+
+func TestServer_RefreshAgentsFromDisk_NoChanges(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "dummy")
+
+	ctx := t.Context()
+
+	agentsDir := prepareAgentsDir(t, "pirate.yaml")
+
+	var store mockStore
+	var runConfig config.RuntimeConfig
+
+	teams, err := teamloader.LoadTeams(ctx, agentsDir, runConfig)
+	require.NoError(t, err)
+
+	srv, err := New(store, runConfig, teams, WithAgentsDir(agentsDir))
+	require.NoError(t, err)
+
+	// Get initial state
+	initialCount := srv.countTeams()
+
+	// Refresh without any changes
+	err = srv.refreshAgentsFromDisk(ctx)
+	require.NoError(t, err)
+
+	// Verify state unchanged
+	newCount := srv.countTeams()
+	exists := srv.hasTeam("pirate.yaml")
+
+	assert.Equal(t, initialCount, newCount, "count should be unchanged")
+	assert.True(t, exists, "team should still exist")
+	// Note: team will be a different instance due to reload, but that's expected
+}
+
+func TestServer_RefreshAgentsFromDisk_EmptyDir(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "dummy")
+
+	ctx := t.Context()
+
+	// Start with one agent
+	agentsDir := prepareAgentsDir(t, "pirate.yaml")
+
+	var store mockStore
+	var runConfig config.RuntimeConfig
+
+	teams, err := teamloader.LoadTeams(ctx, agentsDir, runConfig)
+	require.NoError(t, err)
+
+	srv, err := New(store, runConfig, teams, WithAgentsDir(agentsDir))
+	require.NoError(t, err)
+
+	// Remove all agents
+	err = os.Remove(filepath.Join(agentsDir, "pirate.yaml"))
+	require.NoError(t, err)
+
+	// Refresh with empty directory
+	err = srv.refreshAgentsFromDisk(ctx)
+	require.NoError(t, err)
+
+	// Verify all agents removed
+	count := srv.countTeams()
+
+	assert.Equal(t, 0, count, "should have no agents")
+}
+
+func TestServer_RefreshAgentsFromDisk_NoAgentsDir(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "dummy")
+
+	ctx := t.Context()
+
+	var store mockStore
+	var runConfig config.RuntimeConfig
+
+	// Create server without agentsDir
+	srv, err := New(store, runConfig, nil)
+	require.NoError(t, err)
+
+	// Refresh should be no-op
+	err = srv.refreshAgentsFromDisk(ctx)
+	require.NoError(t, err)
+
+	count := srv.countTeams()
+
+	assert.Equal(t, 0, count)
 }
 
 func prepareAgentsDir(t *testing.T, testFiles ...string) string {


### PR DESCRIPTION
Enables running the api server for agent teams in an oci artifact (e.g. pushed with `cagent push agent.yaml namespace/repo`)

Example to run from an oci artifact and auto-pull new versions every 10 mins:

```sh
cagent api namespace/repo --pull-interval 10
```

Also adds --pull-interval to allow for auto-pulling and reloading of an agent team from an oci reference

Closes #689