### PR TITLE
build: upgrade acp-go-sdk from v0.4.9 to v0.6.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/charmbracelet/glamour/v2 v2.0.0-20250811143442-a27abb32f018
 	github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.3.0.20250917201909-41ff0bf215ea
 	github.com/charmbracelet/x/ansi v0.10.2
-	github.com/coder/acp-go-sdk v0.4.9
+	github.com/coder/acp-go-sdk v0.6.3
 	github.com/dop251/goja v0.0.0-20251008123653-cf18d89f3cf6
 	github.com/fatih/color v1.18.0
 	github.com/goccy/go-yaml v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/charmbracelet/x/windows v0.2.2 h1:IofanmuvaxnKHuV04sC0eBy/smG6kIKrWG2
 github.com/charmbracelet/x/windows v0.2.2/go.mod h1:/8XtdKZzedat74NQFn0NGlGL4soHB0YQZrETF96h75k=
 github.com/clipperhouse/uax29/v2 v2.2.0 h1:ChwIKnQN3kcZteTXMgb1wztSgaU+ZemkgWdohwgs8tY=
 github.com/clipperhouse/uax29/v2 v2.2.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
-github.com/coder/acp-go-sdk v0.4.9 h1:F4sKT2up4sMqNYt6yt2L9g4MaE09VPgt3eRqDFnoY5k=
-github.com/coder/acp-go-sdk v0.4.9/go.mod h1:yKzM/3R9uELp4+nBAwwtkS0aN1FOFjo11CNPy37yFko=
+github.com/coder/acp-go-sdk v0.6.3 h1:LsXQytehdjKIYJnoVWON/nf7mqbiarnyuyE3rrjBsXQ=
+github.com/coder/acp-go-sdk v0.6.3/go.mod h1:yKzM/3R9uELp4+nBAwwtkS0aN1FOFjo11CNPy37yFko=
 github.com/containerd/stargz-snapshotter/estargz v0.17.0 h1:+TyQIsR/zSFI1Rm31EQBwpAA1ovYgIKHy7kctL3sLcE=
 github.com/containerd/stargz-snapshotter/estargz v0.17.0/go.mod h1:s06tWAiJcXQo9/8AReBCIo/QxcXFZ2n4qfsRnpl71SM=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/pkg/acp/agent.go
+++ b/pkg/acp/agent.go
@@ -59,7 +59,7 @@ func (a *Agent) Stop(ctx context.Context) {
 	}
 }
 
-// SetConnection sets the ACP connection
+// SetAgentConnection sets the ACP connection
 func (a *Agent) SetAgentConnection(conn *acp.AgentSideConnection) {
 	a.conn = conn
 }
@@ -325,7 +325,7 @@ func (a *Agent) handleToolCallConfirmation(ctx context.Context, acpSess *Session
 func (a *Agent) handleMaxIterationsReached(ctx context.Context, acpSess *Session, e *runtime.MaxIterationsReachedEvent) error {
 	permResp, err := a.conn.RequestPermission(ctx, acp.RequestPermissionRequest{
 		SessionId: acp.SessionId(acpSess.id),
-		ToolCall: acp.ToolCallUpdate{
+		ToolCall: acp.RequestPermissionToolCall{
 			ToolCallId: acp.ToolCallId("max_iterations"),
 			Title:      acp.Ptr(fmt.Sprintf("Maximum iterations (%d) reached", e.MaxIterations)),
 			Kind:       acp.Ptr(acp.ToolKindExecute),
@@ -391,7 +391,7 @@ func buildToolCallComplete(toolCall tools.ToolCall, output string) acp.SessionUp
 }
 
 // buildToolCallUpdate creates a tool call update for permission requests
-func buildToolCallUpdate(toolCall tools.ToolCall, tool tools.Tool, status acp.ToolCallStatus) acp.ToolCallUpdate {
+func buildToolCallUpdate(toolCall tools.ToolCall, tool tools.Tool, status acp.ToolCallStatus) acp.RequestPermissionToolCall {
 	kind := acp.ToolKindExecute
 	title := tool.Annotations.Title
 	if title == "" {
@@ -402,7 +402,7 @@ func buildToolCallUpdate(toolCall tools.ToolCall, tool tools.Tool, status acp.To
 		kind = acp.ToolKindRead
 	}
 
-	return acp.ToolCallUpdate{
+	return acp.RequestPermissionToolCall{
 		ToolCallId: acp.ToolCallId(toolCall.ID),
 		Title:      acp.Ptr(title),
 		Kind:       acp.Ptr(kind),


### PR DESCRIPTION
Update to the latest ACP SDK version, which renames ToolCallUpdate to RequestPermissionToolCall. 
Adapt all usages in permission request handling to use the new type name.

Also fixes the function comment to match the actual function name (SetAgentConnection).