### PR TITLE
Remove --gateway command line flag

### DIFF
--- a/cmd/root/gateway.go
+++ b/cmd/root/gateway.go
@@ -11,18 +11,12 @@ import (
 )
 
 const (
-	flagGateway       = "gateway"
 	flagModelsGateway = "models-gateway"
-	envGateway        = "CAGENT_GATEWAY"
 	envModelsGateway  = "CAGENT_MODELS_GATEWAY"
 )
 
-type gatewayConfig struct {
-	mainGateway string
-}
-
 func canonize(endpoint string) string {
-	return strings.TrimSpace(strings.TrimSuffix(endpoint, "/"))
+	return strings.TrimSuffix(strings.TrimSpace(endpoint), "/")
 }
 
 func logEnvvarShadowing(flagValue, varName, flagName string) {
@@ -32,38 +26,13 @@ func logEnvvarShadowing(flagValue, varName, flagName string) {
 }
 
 func addGatewayFlags(cmd *cobra.Command, runConfig *config.RuntimeConfig) {
-	var gwConfig gatewayConfig
-
-	cmd.PersistentFlags().StringVar(&gwConfig.mainGateway, flagGateway, "", "Set the gateway address to use for models and tool calls")
 	cmd.PersistentFlags().StringVar(&runConfig.ModelsGateway, flagModelsGateway, "", "Set the models gateway address")
-
-	// Don't allow gateway to be specified if a qualified gateway flag is provided
-	cmd.MarkFlagsMutuallyExclusive(flagGateway, flagModelsGateway)
 
 	persistentPreRunE := cmd.PersistentPreRunE
 	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
-		// verify mutual exclusion for environment variables
-		if os.Getenv(envGateway) != "" && os.Getenv(envModelsGateway) != "" {
-			return fmt.Errorf("environment variables %s and %s cannot be set at the same time", envGateway, envModelsGateway)
-		}
-
-		// Get gateway value from the environment.
-		// This behavior sets both the models and tools gateway
-		mainGateway := os.Getenv(envGateway)
-		if mainGateway != "" {
-			logEnvvarShadowing(gwConfig.mainGateway, envGateway, flagGateway)
-			gwConfig.mainGateway = mainGateway
-			runConfig.ModelsGateway = mainGateway
-		}
-
 		if gateway := os.Getenv(envModelsGateway); gateway != "" {
 			logEnvvarShadowing(runConfig.ModelsGateway, envModelsGateway, flagModelsGateway)
 			runConfig.ModelsGateway = gateway
-		}
-
-		// Set the qualified gateways to the main gateway if they haven't been set explicitly
-		if runConfig.ModelsGateway == "" {
-			runConfig.ModelsGateway = gwConfig.mainGateway
 		}
 
 		// Ensure the gateway url is canonical.

--- a/cmd/root/gateway_test.go
+++ b/cmd/root/gateway_test.go
@@ -12,136 +12,53 @@ import (
 
 func TestGatewayLogic(t *testing.T) {
 	tests := []struct {
-		name                  string
-		envVars               map[string]string
-		args                  []string
-		expectedModelsGateway string
-		expectError           bool
-		errorContains         string
+		name     string
+		env      string
+		args     []string
+		expected string
 	}{
 		{
-			name:                  "env_var_models_gateway",
-			envVars:               map[string]string{"CAGENT_MODELS_GATEWAY": "https://models.example.com"},
-			expectedModelsGateway: "https://models.example.com",
+			name:     "env",
+			env:      "https://models.example.com",
+			expected: "https://models.example.com",
 		},
 		{
-			name:                  "env_var_gateway",
-			envVars:               map[string]string{"CAGENT_GATEWAY": "https://gateway.example.com"},
-			expectedModelsGateway: "https://gateway.example.com",
+			name:     "cli",
+			args:     []string{"--models-gateway", "https://cli-models.example.com"},
+			expected: "https://cli-models.example.com",
 		},
 		{
-			name:                  "cli_flag_models_gateway",
-			args:                  []string{"--models-gateway", "https://cli-models.example.com"},
-			expectedModelsGateway: "https://cli-models.example.com",
-		},
-		{
-			name:          "cli_flag_gateway_mutually_exclusive_with_models_gateway",
-			args:          []string{"--gateway", "https://gateway.example.com", "--models-gateway", "https://models.example.com"},
-			expectError:   true,
-			errorContains: "if any flags in the group [gateway models-gateway] are set none of the others can be",
-		},
-		{
-			name: "gateway_url_canonicalization_with_main_gateway",
-			envVars: map[string]string{
-				"CAGENT_GATEWAY": "https://gateway.example.com/", // Main gateway with trailing slash
-			},
-			args:                  []string{},
-			expectedModelsGateway: "https://gateway.example.com",
-		},
-		// Tests for combinations of environment variables and CLI arguments
-		{
-			name: "env_var_overrides_same_cli_flag",
-			envVars: map[string]string{
-				"CAGENT_MODELS_GATEWAY": "https://env-models.example.com",
-			},
-			args:                  []string{"--models-gateway", "https://cli-models.example.com"},
-			expectedModelsGateway: "https://env-models.example.com",
-		},
-		{
-			name: "env_var_main_gateway_overrides_cli_flags",
-			envVars: map[string]string{
-				"CAGENT_GATEWAY": "https://env-gateway.example.com",
-			},
-			args:                  []string{"--models-gateway", "https://cli-gateway.example.com"},
-			expectedModelsGateway: "https://env-gateway.example.com",
-		},
-		{
-			name:                  "cli_flag_gateway_sets_both_gateways",
-			args:                  []string{"--gateway", "https://cli-gateway.example.com"},
-			expectedModelsGateway: "https://cli-gateway.example.com",
-		},
-		{
-			name: "env_vars_both_gateways_override_cli_gateway_flag",
-			envVars: map[string]string{
-				"CAGENT_MODELS_GATEWAY": "https://env-models.example.com",
-			},
-			args:                  []string{"--gateway", "https://cli-gateway.example.com"},
-			expectedModelsGateway: "https://env-models.example.com",
-		},
-		{
-			name: "env_var_main_gateway_mutually_exclusive_with_models_gateway",
-			envVars: map[string]string{
-				"CAGENT_GATEWAY":        "https://gateway.example.com",
-				"CAGENT_MODELS_GATEWAY": "https://models.example.com",
-			},
-			args:          []string{},
-			expectError:   true,
-			errorContains: "environment variables CAGENT_GATEWAY and CAGENT_MODELS_GATEWAY cannot be set at the same time",
-		},
-		{
-			name: "env_var_main_gateway_mutually_exclusive_with_both_specific_gateways",
-			envVars: map[string]string{
-				"CAGENT_GATEWAY":        "https://gateway.example.com",
-				"CAGENT_MODELS_GATEWAY": "https://models.example.com",
-			},
-			args:          []string{},
-			expectError:   true,
-			errorContains: "environment variables CAGENT_GATEWAY and CAGENT_MODELS_GATEWAY cannot be set at the same time",
+			name:     "env_overrides_cli",
+			env:      "https://env-models.example.com",
+			args:     []string{"--models-gateway", "https://cli-models.example.com"},
+			expected: "https://env-models.example.com",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Set test environment variables using t.Setenv (automatically handles cleanup)
-			for key, value := range tt.envVars {
-				t.Setenv(key, value)
-			}
+			t.Setenv("CAGENT_MODELS_GATEWAY", tt.env)
 
-			// Create a test command with gateway flags
 			cmd := &cobra.Command{
-				Use: "test",
-				RunE: func(cmd *cobra.Command, args []string) error {
-					// Command logic here - for testing, we just return nil
+				RunE: func(*cobra.Command, []string) error {
 					return nil
 				},
 			}
-
-			// Add gateway flags (this is the actual function being tested)
 			runConfig := config.RuntimeConfig{}
 			addGatewayFlags(cmd, &runConfig)
 
-			// Set command arguments and execute
 			cmd.SetArgs(tt.args)
+			err := cmd.Execute()
 
-			// Execute the command - this triggers flag parsing and PersistentPreRunE
-			_, err := cmd.ExecuteC()
-
-			if tt.expectError {
-				require.Error(t, err)
-				if tt.errorContains != "" {
-					assert.Contains(t, err.Error(), tt.errorContains)
-				}
-			} else {
-				require.NoError(t, err)
-
-				// Verify expected gateway configuration
-				assert.Equal(t, tt.expectedModelsGateway, runConfig.ModelsGateway, "Models gateway mismatch")
-			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, runConfig.ModelsGateway)
 		})
 	}
 }
 
 func TestCanonize(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		input    string
@@ -160,7 +77,7 @@ func TestCanonize(t *testing.T) {
 		{
 			name:     "trailing_slash_and_whitespace",
 			input:    " https://example.com/ ",
-			expected: "https://example.com/", // TrimSuffix doesn't work because string ends with " ", not "/"
+			expected: "https://example.com",
 		},
 		{
 			name:     "no_trailing_slash",
@@ -186,7 +103,10 @@ func TestCanonize(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			result := canonize(tt.input)
+
 			assert.Equal(t, tt.expected, result)
 		})
 	}


### PR DESCRIPTION
This is a duplicate of `--models-gateway` and adds a lot of complexity.