### PR TITLE
adding a --work-dir to mcp mode

### DIFF
--- a/cmd/root/common.go
+++ b/cmd/root/common.go
@@ -1,0 +1,33 @@
+package root
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+)
+
+func setupWorkingDirectory(workingDir string) error {
+	if workingDir == "" {
+		return nil
+	}
+
+	absWd, err := filepath.Abs(workingDir)
+	if err != nil {
+		return fmt.Errorf("invalid working directory: %w", err)
+	}
+
+	info, err := os.Stat(absWd)
+	if err != nil || !info.IsDir() {
+		return fmt.Errorf("working directory does not exist or is not a directory: %s", absWd)
+	}
+
+	if err := os.Chdir(absWd); err != nil {
+		return fmt.Errorf("failed to change working directory: %w", err)
+	}
+
+	_ = os.Setenv("PWD", absWd)
+	slog.Debug("Working directory set", "path", absWd)
+
+	return nil
+}

--- a/cmd/root/mcp.go
+++ b/cmd/root/mcp.go
@@ -9,7 +9,8 @@ import (
 )
 
 type mcpFlags struct {
-	runConfig config.RuntimeConfig
+	workingDir string
+	runConfig  config.RuntimeConfig
 }
 
 func newMCPCmd() *cobra.Command {
@@ -26,6 +27,7 @@ func newMCPCmd() *cobra.Command {
 		RunE: flags.runMCPCommand,
 	}
 
+	cmd.PersistentFlags().StringVar(&flags.workingDir, "working-dir", "", "Set the working directory for the session (applies to tools and relative paths)")
 	addRuntimeConfigFlags(cmd, &flags.runConfig)
 
 	return cmd
@@ -34,6 +36,10 @@ func newMCPCmd() *cobra.Command {
 func (f *mcpFlags) runMCPCommand(cmd *cobra.Command, args []string) error {
 	telemetry.TrackCommand("mcp", args)
 	ctx := cmd.Context()
+
+	if err := setupWorkingDirectory(f.workingDir); err != nil {
+		return err
+	}
 
 	return mcp.StartMCPServer(ctx, args[0], f.runConfig)
 }

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"path/filepath"
 
 	tea "github.com/charmbracelet/bubbletea/v2"
 	"github.com/spf13/cobra"
@@ -120,27 +119,7 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 }
 
 func (f *runExecFlags) setupWorkingDirectory() error {
-	if f.workingDir == "" {
-		return nil
-	}
-
-	absWd, err := filepath.Abs(f.workingDir)
-	if err != nil {
-		return fmt.Errorf("invalid working directory: %w", err)
-	}
-
-	info, err := os.Stat(absWd)
-	if err != nil || !info.IsDir() {
-		return fmt.Errorf("working directory does not exist or is not a directory: %s", absWd)
-	}
-
-	if err := os.Chdir(absWd); err != nil {
-		return fmt.Errorf("failed to change working directory: %w", err)
-	}
-
-	_ = os.Setenv("PWD", absWd)
-	slog.Debug("Working directory set", "dir", absWd)
-	return nil
+	return setupWorkingDirectory(f.workingDir)
 }
 
 // resolveAgentFile is a wrapper method that calls the agentfile.Resolve function


### PR DESCRIPTION
This allow to configuren in claude desktop like so


```
{
  "mcpServers": {
    "gordon": {
      "command": "/Users/dockereng/bin/cagent",
      "args": ["mcp", "dockereng/myagent","--working-dir", "/Users/dockereng/src"],
        "env": {
            "PATH": "/Applications/Docker.app/Contents/Resources/bin:${PATH}",
            "ANTHROPIC_API_KEY": "YYYYY,
            "OPENAI_API_KEY": "XXXXX
        }
    }
  }
}
```