### PR TITLE
Split diff view by default

### DIFF
--- a/golang_developer.yaml
+++ b/golang_developer.yaml
@@ -110,7 +110,7 @@ agents:
       You are a planning agent responsible for gathering user requirements and creating a development plan.
       Always ask clarifying questions to ensure you fully understand the user's needs before creating the plan.
       Once you have a clear understanding, analyze the existing code and create a detailed development plan in a markdown file. Do not write any code yourself.
-      Once the plan is created, you will delegate tasks to the root agent. Make sure to provide the file name of the plan when delegating. Write the plan in /tmp
+      Once the plan is created, you will delegate tasks to the root agent. Make sure to provide the file name of the plan when delegating. Write the plan in the current directory.
     toolsets:
       - type: filesystem
     sub_agents:

--- a/pkg/tui/components/tool/builtins.go
+++ b/pkg/tui/components/tool/builtins.go
@@ -10,7 +10,7 @@ import (
 	"github.com/docker/cagent/pkg/tui/styles"
 )
 
-func renderEditFile(toolCall tools.ToolCall, width int) (string, string) {
+func renderEditFile(toolCall tools.ToolCall, width int, splitView bool) (string, string) {
 	var args builtin.EditFileArgs
 	if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &args); err != nil {
 		return "", ""
@@ -26,8 +26,12 @@ func renderEditFile(toolCall tools.ToolCall, width int) (string, string) {
 			output.WriteString("Edit #" + string(rune(i+1+'0')) + ":\n")
 		}
 
-		diff := computeDiff(edit.OldText, edit.NewText)
-		output.WriteString(renderDiffWithSyntaxHighlight(diff, args.Path, width))
+		diff := computeDiff(args.Path, edit.OldText, edit.NewText)
+		if splitView {
+			output.WriteString(renderSplitDiffWithSyntaxHighlight(diff, args.Path, width))
+		} else {
+			output.WriteString(renderDiffWithSyntaxHighlight(diff, args.Path, width))
+		}
 	}
 
 	return output.String(), args.Path

--- a/pkg/tui/components/tool/diff.go
+++ b/pkg/tui/components/tool/diff.go
@@ -1,13 +1,26 @@
 package tool
 
 import (
+	"os"
+	"strings"
+
 	"github.com/aymanbagabas/go-udiff"
 )
 
-func computeDiff(oldText, newText string) []*udiff.Hunk {
-	edits := udiff.Strings(oldText, newText)
+func computeDiff(path, oldText, newText string) []*udiff.Hunk {
+	currentContent, err := os.ReadFile(path)
+	if err != nil {
+		return []*udiff.Hunk{}
+	}
 
-	diff, err := udiff.ToUnifiedDiff("old", "new", oldText, edits, 3)
+	// Generate the old contents by applying inverse diff, the current file has
+	// newText applied, so we need to reverse it
+	oldContent := strings.Replace(string(currentContent), newText, oldText, 1)
+
+	// Now compute diff between old (reconstructed) and new (complete file)
+	edits := udiff.Strings(oldContent, string(currentContent))
+
+	diff, err := udiff.ToUnifiedDiff("old", "new", oldContent, edits, 3)
 	if err != nil {
 		return []*udiff.Hunk{}
 	}

--- a/pkg/tui/components/tool/syntax.go
+++ b/pkg/tui/components/tool/syntax.go
@@ -1,16 +1,36 @@
 package tool
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/alecthomas/chroma/v2"
 	"github.com/alecthomas/chroma/v2/lexers"
 	"github.com/aymanbagabas/go-udiff"
 	"github.com/charmbracelet/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/mattn/go-runewidth"
 
 	"github.com/docker/cagent/pkg/tui/styles"
 )
+
+const (
+	tabWidth     = 4
+	lineNumWidth = 5
+	minWidth     = 80
+)
+
+type chromaToken struct {
+	Text  string
+	Style lipgloss.Style
+}
+
+type linePair struct {
+	old        *udiff.Line
+	new        *udiff.Line
+	oldLineNum int
+	newLineNum int
+}
 
 // syntaxHighlight applies syntax highlighting to code and returns styled text
 func syntaxHighlight(code, filePath string) []chromaToken {
@@ -31,20 +51,13 @@ func syntaxHighlight(code, filePath string) []chromaToken {
 		if token.Value == "" {
 			continue
 		}
-
-		lipStyle := chromaToLipgloss(token.Type, style)
 		tokens = append(tokens, chromaToken{
 			Text:  token.Value,
-			Style: lipStyle,
+			Style: chromaToLipgloss(token.Type, style),
 		})
 	}
 
 	return tokens
-}
-
-type chromaToken struct {
-	Text  string
-	Style lipgloss.Style
 }
 
 func chromaToLipgloss(tokenType chroma.TokenType, style *chroma.Style) lipgloss.Style {
@@ -54,19 +67,12 @@ func chromaToLipgloss(tokenType chroma.TokenType, style *chroma.Style) lipgloss.
 	if entry.Colour.IsSet() {
 		lipStyle = lipStyle.Foreground(lipgloss.Color(entry.Colour.String()))
 	}
-
-	if entry.Background.IsSet() {
-		lipStyle = lipStyle.Background(lipgloss.Color(entry.Background.String()))
-	}
-
 	if entry.Bold == chroma.Yes {
 		lipStyle = lipStyle.Bold(true)
 	}
-
 	if entry.Italic == chroma.Yes {
 		lipStyle = lipStyle.Italic(true)
 	}
-
 	if entry.Underline == chroma.Yes {
 		lipStyle = lipStyle.Underline(true)
 	}
@@ -74,73 +80,213 @@ func chromaToLipgloss(tokenType chroma.TokenType, style *chroma.Style) lipgloss.
 	return lipStyle
 }
 
+// renderDiffWithSyntaxHighlight renders a unified diff view
 func renderDiffWithSyntaxHighlight(diff []*udiff.Hunk, filePath string, width int) string {
-	fullWidth := min(120, width)
-	const tabWidth = 4
 	var output strings.Builder
+	contentWidth := width - lineNumWidth
 
 	for _, hunk := range diff {
+		oldLineNum := hunk.FromLine
+		newLineNum := hunk.ToLine
+
 		for _, line := range hunk.Lines {
-			var lineStyle lipgloss.Style
+			lineNum := getDisplayLineNumber(&line, &oldLineNum, &newLineNum)
+			content := prepareContent(line.Content, contentWidth)
 
-			switch line.Kind {
-			case udiff.Delete:
-				lineStyle = styles.DiffRemoveStyle
-			case udiff.Insert:
-				lineStyle = styles.DiffAddStyle
-			case udiff.Equal:
-				lineStyle = styles.DiffUnchangedStyle
-			}
+			lineNumStr := styles.LineNumberStyle.Render(fmt.Sprintf("%4d ", lineNum))
+			styledLine := renderLine(content, line.Kind, filePath, contentWidth)
 
-			expandedContent := strings.ReplaceAll(line.Content, "\t", strings.Repeat(" ", tabWidth))
-			expandedContent = strings.TrimRight(expandedContent, "\n")
-
-			contentWidth := runewidth.StringWidth(expandedContent)
-			if contentWidth > fullWidth {
-				expandedContent = runewidth.Truncate(expandedContent, fullWidth-3, "...")
-			}
-
-			tokens := syntaxHighlight(expandedContent, filePath)
-
-			var lineBuilder strings.Builder
-
-			contentLength := 0
-			for i := range tokens {
-				contentLength += runewidth.StringWidth(tokens[i].Text)
-			}
-
-			paddingNeeded := 0
-			if contentLength < fullWidth {
-				paddingNeeded = fullWidth - contentLength
-			}
-
-			if line.Kind != udiff.Equal {
-				var contentBuilder strings.Builder
-				for i := range tokens {
-					token := &tokens[i]
-					styledToken := token.Style.Background(lineStyle.GetBackground())
-					contentBuilder.WriteString(styledToken.Render(token.Text))
-				}
-
-				if paddingNeeded > 0 {
-					contentBuilder.WriteString(lineStyle.Render(strings.Repeat(" ", paddingNeeded)))
-				}
-
-				lineBuilder.WriteString(contentBuilder.String())
-			} else {
-				for i := range tokens {
-					token := &tokens[i]
-					lineBuilder.WriteString(token.Style.Render(token.Text))
-				}
-				if paddingNeeded > 0 {
-					lineBuilder.WriteString(strings.Repeat(" ", paddingNeeded))
-				}
-			}
-
-			output.WriteString(lineBuilder.String())
-			output.WriteString("\n")
+			output.WriteString(lineNumStr + styledLine + "\n")
 		}
 	}
 
 	return strings.TrimSuffix(output.String(), "\n")
+}
+
+// renderSplitDiffWithSyntaxHighlight renders a split diff view with old/new side-by-side
+func renderSplitDiffWithSyntaxHighlight(diff []*udiff.Hunk, filePath string, width int) string {
+	// Fall back to unified diff if terminal is too narrow
+	separator := styles.SeparatorStyle.Render(" │ ")
+	separatorWidth := ansi.StringWidth(separator)
+	contentWidth := (width - separatorWidth - (lineNumWidth * 2)) / 2
+
+	if width < minWidth || contentWidth < 10 {
+		return renderDiffWithSyntaxHighlight(diff, filePath, width)
+	}
+
+	var output strings.Builder
+
+	for _, hunk := range diff {
+		for _, pair := range pairDiffLines(hunk.Lines, hunk.FromLine, hunk.ToLine) {
+			leftSide := renderSplitSide(pair.old, pair.oldLineNum, filePath, contentWidth)
+			rightSide := renderSplitSide(pair.new, pair.newLineNum, filePath, contentWidth)
+
+			line := leftSide + separator + rightSide
+			line = ensureWidth(line, width)
+
+			output.WriteString(line + "\n")
+		}
+	}
+
+	return strings.TrimSuffix(output.String(), "\n")
+}
+
+// getDisplayLineNumber returns the appropriate line number and updates counters
+func getDisplayLineNumber(line *udiff.Line, oldLineNum, newLineNum *int) int {
+	switch line.Kind {
+	case udiff.Delete:
+		num := *oldLineNum
+		*oldLineNum++
+		return num
+	case udiff.Insert:
+		num := *newLineNum
+		*newLineNum++
+		return num
+	case udiff.Equal:
+		num := *oldLineNum
+		*oldLineNum++
+		*newLineNum++
+		return num
+	}
+	return 0
+}
+
+// prepareContent normalizes content for display
+func prepareContent(content string, maxWidth int) string {
+	content = strings.ReplaceAll(content, "\t", strings.Repeat(" ", tabWidth))
+	content = strings.TrimRight(content, "\n")
+	if runewidth.StringWidth(content) > maxWidth {
+		content = runewidth.Truncate(content, maxWidth-3, "...")
+	}
+	return content
+}
+
+// renderLine renders a line with syntax highlighting and appropriate styling
+func renderLine(content string, kind udiff.OpKind, filePath string, width int) string {
+	tokens := syntaxHighlight(content, filePath)
+	lineStyle := getLineStyle(kind)
+
+	rendered := renderTokensWithStyle(tokens, lineStyle, kind)
+
+	return padToWidth(rendered, width, lineStyle, kind)
+}
+
+// renderSplitSide renders one side of a split diff
+func renderSplitSide(line *udiff.Line, lineNum int, filePath string, width int) string {
+	lineNumStr := formatLineNum(line, lineNum)
+
+	if line == nil {
+		return styles.LineNumberStyle.Render(lineNumStr) + strings.Repeat(" ", width)
+	}
+
+	content := prepareContent(line.Content, width)
+	styledContent := renderLine(content, line.Kind, filePath, width)
+
+	return styles.LineNumberStyle.Render(lineNumStr) + styledContent
+}
+
+// renderTokensWithStyle applies consistent styling to tokens
+func renderTokensWithStyle(tokens []chromaToken, lineStyle lipgloss.Style, kind udiff.OpKind) string {
+	var output strings.Builder
+
+	for _, token := range tokens {
+		if kind != udiff.Equal {
+			styledToken := token.Style.Background(lineStyle.GetBackground())
+			output.WriteString(styledToken.Render(token.Text))
+		} else {
+			output.WriteString(token.Style.Render(token.Text))
+		}
+	}
+
+	return output.String()
+}
+
+// padToWidth adds padding to reach the desired width
+func padToWidth(content string, width int, style lipgloss.Style, kind udiff.OpKind) string {
+	currentWidth := ansi.StringWidth(content)
+	if paddingNeeded := width - currentWidth; paddingNeeded > 0 {
+		padding := strings.Repeat(" ", paddingNeeded)
+		if kind != udiff.Equal {
+			return content + style.Render(padding)
+		}
+		return content + padding
+	}
+	return content
+}
+
+// ensureWidth ensures a line has consistent width
+func ensureWidth(line string, width int) string {
+	if lineWidth := ansi.StringWidth(line); lineWidth < width {
+		return line + strings.Repeat(" ", width-lineWidth)
+	}
+	return line
+}
+
+// getLineStyle returns the style for a diff line type
+func getLineStyle(kind udiff.OpKind) lipgloss.Style {
+	switch kind {
+	case udiff.Delete:
+		return styles.DiffRemoveStyle
+	case udiff.Insert:
+		return styles.DiffAddStyle
+	default:
+		return styles.DiffUnchangedStyle
+	}
+}
+
+// formatLineNum formats a line number or returns empty space
+func formatLineNum(line *udiff.Line, lineNum int) string {
+	if line == nil {
+		return strings.Repeat(" ", lineNumWidth)
+	}
+	return fmt.Sprintf("%4d ", lineNum)
+}
+
+// pairDiffLines pairs old and new lines for split view rendering
+func pairDiffLines(lines []udiff.Line, fromLine, toLine int) []linePair {
+	var pairs []linePair
+	oldLineNum, newLineNum := fromLine, toLine
+
+	for i := 0; i < len(lines); i++ {
+		line := &lines[i]
+
+		switch line.Kind {
+		case udiff.Equal:
+			pairs = append(pairs, linePair{
+				old: line, new: line,
+				oldLineNum: oldLineNum, newLineNum: newLineNum,
+			})
+			oldLineNum++
+			newLineNum++
+
+		case udiff.Delete:
+			// Check if next line is an insert to pair them
+			if i+1 < len(lines) && lines[i+1].Kind == udiff.Insert {
+				pairs = append(pairs, linePair{
+					old: line, new: &lines[i+1],
+					oldLineNum: oldLineNum, newLineNum: newLineNum,
+				})
+				oldLineNum++
+				newLineNum++
+				i++ // Skip the paired insert
+			} else {
+				// Unpaired delete
+				pairs = append(pairs, linePair{
+					old: line, new: nil,
+					oldLineNum: oldLineNum,
+				})
+				oldLineNum++
+			}
+
+		case udiff.Insert:
+			// Unpaired insert (paired inserts are handled above)
+			pairs = append(pairs, linePair{
+				old: nil, new: line,
+				newLineNum: newLineNum,
+			})
+			newLineNum++
+		}
+	}
+
+	return pairs
 }

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/cagent/pkg/tui/components/messages"
 	"github.com/docker/cagent/pkg/tui/components/notification"
 	"github.com/docker/cagent/pkg/tui/components/sidebar"
+	"github.com/docker/cagent/pkg/tui/components/tool"
 	"github.com/docker/cagent/pkg/tui/core"
 	"github.com/docker/cagent/pkg/tui/core/layout"
 	"github.com/docker/cagent/pkg/tui/dialog"
@@ -147,6 +148,12 @@ func (p *chatPage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return p, tea.Batch(cmds...)
 
 	case tea.KeyPressMsg:
+		if msg.String() == "ctrl+t" {
+			model, cmd := p.messages.Update(tool.ToggleDiffViewMsg{})
+			p.messages = model.(messages.Model)
+			return p, cmd
+		}
+
 		switch {
 		case key.Matches(msg, p.keyMap.Tab):
 			p.switchFocus()

--- a/pkg/tui/styles/styles.go
+++ b/pkg/tui/styles/styles.go
@@ -37,6 +37,14 @@ const (
 	ColorDiffAddBg    = "#20303B" // Dark blue-green
 	ColorDiffRemoveBg = "#3C2A2A" // Dark red-brown
 
+	// Line number and UI element colors
+	ColorLineNumber = "#565F89" // Muted blue-grey (same as ColorMutedBlue)
+	ColorSeparator  = "#414868" // Dark blue-grey (same as ColorBorderSecondary)
+
+	// Word-level diff highlight colors (visible but not harsh)
+	ColorDiffWordAddBg    = "#2D4F3F" // Medium dark teal with green tint
+	ColorDiffWordRemoveBg = "#4F2D3A" // Medium dark burgundy with red tint
+
 	// Interactive element colors
 	ColorSelected = "#364A82" // Dark blue for selected items
 	ColorHover    = "#2D3F5F" // Slightly lighter than selected
@@ -112,6 +120,10 @@ var (
 	DiffRemoveBg = lipgloss.Color(ColorDiffRemoveBg)
 	DiffAddFg    = lipgloss.Color(ColorSuccessGreen)
 	DiffRemoveFg = lipgloss.Color(ColorErrorRed)
+
+	// UI element colors
+	LineNumber = lipgloss.Color(ColorLineNumber)
+	Separator  = lipgloss.Color(ColorSeparator)
 
 	// Interactive element colors
 	Selected         = lipgloss.Color(ColorSelected)
@@ -269,6 +281,12 @@ var (
 	DiffUnchangedStyle = lipgloss.NewStyle()
 
 	DiffContextStyle = BaseStyle
+)
+
+// Syntax highlighting UI element styles
+var (
+	LineNumberStyle = BaseStyle.Foreground(LineNumber)
+	SeparatorStyle  = BaseStyle.Foreground(Separator)
 )
 
 // Tool Call Styles


### PR DESCRIPTION
This implements different things:

- a split diff view
- toggle between the unified or split view with ctrl+t
- add line numbers in the diff
- the split view is the default view
<img width="2102" height="1331" alt="Screenshot 2025-11-04 at 23 56 42" src="https://github.com/user-attachments/assets/9891df52-e7c6-4dec-a19c-dbaaead8830e" />
<img width="2102" height="1331" alt="Screenshot 2025-11-04 at 23 56 50" src="https://github.com/user-attachments/assets/e7aa4cde-a3dc-432d-9e22-0aeaa549234e" />
