### PR TITLE
Fix the mouse position on selection

### DIFF
--- a/pkg/tui/components/messages/messages.go
+++ b/pkg/tui/components/messages/messages.go
@@ -41,6 +41,7 @@ type Model interface {
 	layout.Sizeable
 	layout.Focusable
 	layout.Help
+	layout.Positionable
 
 	AddUserMessage(content string) tea.Cmd
 	AddErrorMessage(content string) tea.Cmd
@@ -111,6 +112,8 @@ type model struct {
 	selection selectionState
 
 	splitDiffView bool
+
+	xPos, yPos int
 }
 
 // New creates a new message list component
@@ -327,6 +330,12 @@ func (m *model) SetSize(width, height int) tea.Cmd {
 
 	// Size changes may affect item rendering, invalidate all items
 	m.invalidateAllItems()
+	return nil
+}
+
+func (m *model) SetPosition(x, y int) tea.Cmd {
+	m.xPos = x
+	m.yPos = y
 	return nil
 }
 
@@ -746,12 +755,11 @@ func (m *model) removePendingToolCallMessages() {
 
 // mouseToLineCol converts mouse position to line/column in rendered content
 func (m *model) mouseToLineCol(x, y int) (line, col int) {
-	// Adjust for header (2 lines: text + bottom padding)
-	adjustedY := max(0, y-2)
+	adjustedY := max(0, y-m.yPos)
 	line = m.scrollOffset + adjustedY
 
 	// Adjust for left padding (1 column from AppStyle)
-	adjustedX := max(0, x-1)
+	adjustedX := max(0, x-1-m.xPos)
 	col = adjustedX
 
 	return line, col

--- a/pkg/tui/core/layout/layout.go
+++ b/pkg/tui/core/layout/layout.go
@@ -17,6 +17,10 @@ type Focusable interface {
 	Blur() tea.Cmd
 }
 
+type Positionable interface {
+	SetPosition(x, y int) tea.Cmd
+}
+
 // Help represents components that provide help information
 type Help interface {
 	Bindings() []key.Binding

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -405,13 +405,13 @@ func (p *chatPage) SetSize(width, height int) tea.Cmd {
 		mainWidth = innerWidth - sidebarWidth
 		p.chatHeight = height - p.inputHeight
 		p.sidebar.SetMode(sidebar.ModeVertical)
-		cmds = append(cmds, p.sidebar.SetSize(sidebarWidth, p.chatHeight))
+		cmds = append(cmds, p.sidebar.SetSize(sidebarWidth, p.chatHeight), p.messages.SetPosition(0, 0))
 	} else {
 		const horizontalSidebarHeight = 3
 		mainWidth = innerWidth
 		p.chatHeight = height - p.inputHeight - horizontalSidebarHeight
 		p.sidebar.SetMode(sidebar.ModeHorizontal)
-		cmds = append(cmds, p.sidebar.SetSize(width, horizontalSidebarHeight))
+		cmds = append(cmds, p.sidebar.SetSize(width, horizontalSidebarHeight), p.messages.SetPosition(0, horizontalSidebarHeight))
 	}
 
 	// Set component sizes


### PR DESCRIPTION
We used to have a title bar, but that changed and we now either only have a sidebar or the sidebar becomes the title bar depending on the window size. This means that the position of the messages component is not static any more so mouse events became wrong in certain cases (when there is no title bar). This fixes it by sending the messages component its absolute position on the screen when needed.