### PR TITLE
Make sure the TUI doesn't know about teams

### DIFF
--- a/e2e/dependencies_test.go
+++ b/e2e/dependencies_test.go
@@ -1,0 +1,47 @@
+package e2e
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDependencies(t *testing.T) {
+	t.Run("TUI musn't know about teams", func(t *testing.T) {
+		imports := listImports(t, "../pkg/tui")
+
+		assert.True(t, imports["github.com/docker/cagent/pkg/runtime"])
+		assert.False(t, imports["github.com/docker/cagent/pkg/team"])
+	})
+}
+
+func listImports(t *testing.T, pkg string) map[string]bool {
+	t.Helper()
+
+	imports := map[string]bool{}
+
+	fileSet := token.NewFileSet()
+	err := filepath.WalkDir(pkg, func(path string, d os.DirEntry, err error) error {
+		if err != nil || !strings.HasSuffix(path, ".go") || d.IsDir() {
+			return err
+		}
+
+		ast, err := parser.ParseFile(fileSet, path, nil, parser.ImportsOnly)
+		require.NoError(t, err)
+
+		for _, i := range ast.Imports {
+			imports[strings.Trim(i.Path.Value, `"`)] = true
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	return imports
+}


### PR DESCRIPTION
When running in remote mode, the TUI can't just get the team and ask for an agent by name.
Agents are loaded remotely and their properties are not directly readable by the TUI