### PR TITLE
Don't force max width on the markdown renderer

### DIFF
--- a/pkg/tui/components/markdown/renderer.go
+++ b/pkg/tui/components/markdown/renderer.go
@@ -10,7 +10,7 @@ func NewRenderer(width int) *glamour.TermRenderer {
 	style := styles.MarkdownStyle()
 
 	r, _ := glamour.NewTermRenderer(
-		glamour.WithWordWrap(min(width, 120)),
+		glamour.WithWordWrap(width),
 		glamour.WithStyles(style),
 	)
 	return r


### PR DESCRIPTION
Let the user choose the size of the window and use up all the space