### PR TITLE
Fix rendering of root messages after subagents finish

### DIFF
--- a/pkg/tui/components/message/message.go
+++ b/pkg/tui/components/message/message.go
@@ -83,26 +83,26 @@ func (mv *messageModel) Render(width int) string {
 			return mv.spinner.View()
 		}
 
-		text := senderPrefix(msg.Sender) + msg.Content
-		rendered, err := markdown.NewRenderer(width).Render(text)
+		rendered, err := markdown.NewRenderer(width).Render(msg.Content)
 		if err != nil {
-			return text
+			return senderPrefix(msg.Sender) + msg.Content
 		}
 
-		return strings.TrimRight(rendered, "\n\r\t ")
+		return senderPrefix(msg.Sender) + strings.TrimRight(rendered, "\n\r\t ")
 	case types.MessageTypeAssistantReasoning:
 		if msg.Content == "" {
 			return mv.spinner.View()
 		}
-		text := "Thinking: " + senderPrefix(msg.Sender) + msg.Content
 		// Render through the markdown renderer to ensure proper wrapping to width
-		rendered, err := markdown.NewRenderer(width).Render(text)
+		rendered, err := markdown.NewRenderer(width).Render(msg.Content)
 		if err != nil {
+			text := "Thinking: " + senderPrefix(msg.Sender) + msg.Content
 			return styles.MutedStyle.Italic(true).Render(text)
 		}
 		// Strip ANSI from inner rendering so muted style fully applies
 		clean := stripANSI(strings.TrimRight(rendered, "\n\r\t "))
-		return styles.MutedStyle.Italic(true).Render(clean)
+		thinkingText := "Thinking: " + senderPrefix(msg.Sender) + clean
+		return styles.MutedStyle.Italic(true).Render(thinkingText)
 	case types.MessageTypeShellOutput:
 		if rendered, err := markdown.NewRenderer(width).Render(fmt.Sprintf("```console\n%s\n```", msg.Content)); err == nil {
 			return strings.TrimRight(rendered, "\n\r\t ")
@@ -125,10 +125,10 @@ func (mv *messageModel) Render(width int) string {
 }
 
 func senderPrefix(sender string) string {
-	if sender == "" || sender == "root" {
+	if sender == "" {
 		return ""
 	}
-	return fmt.Sprintf("%s: ", sender)
+	return styles.AgentBadgeStyle.Render("["+sender+"]") + "\n\n"
 }
 
 // Height calculates the height needed for this message view

--- a/pkg/tui/components/messages/messages.go
+++ b/pkg/tui/components/messages/messages.go
@@ -673,7 +673,7 @@ func (m *model) AppendToLastMessage(agentName string, messageType types.MessageT
 	lastIdx := len(m.messages) - 1
 	lastMsg := m.messages[lastIdx]
 
-	if lastMsg.Type == messageType {
+	if lastMsg.Type == messageType && lastMsg.Sender == agentName {
 		lastMsg.Content += content
 		m.views[lastIdx].(message.Model).SetMessage(lastMsg)
 		m.invalidateItem(lastIdx)

--- a/pkg/tui/components/tool/transfertask/transfertask.go
+++ b/pkg/tui/components/tool/transfertask/transfertask.go
@@ -48,5 +48,7 @@ func (c *Component) View() string {
 		return "" // TODO: Partial tool call
 	}
 
-	return c.message.Sender + " -> " + params.Agent + ": " + styles.MutedStyle.Render(params.Task)
+	badge := styles.TransferBadgeStyle.Render(c.message.Sender + " -> " + params.Agent + ": ")
+	content := styles.MutedStyle.PaddingLeft(2).Render(params.Task)
+	return badge + "\n" + content
 }

--- a/pkg/tui/styles/styles.go
+++ b/pkg/tui/styles/styles.go
@@ -38,6 +38,10 @@ const (
 	// Status colors
 	ColorInfoCyan = "#7DCFFF" // Soft cyan
 
+	// Badge colors
+	ColorAgentBadge    = "#BB9AF7" // Soft purple
+	ColorTransferBadge = "#7DCFFF" // Soft cyan
+
 	// Diff colors
 	ColorDiffAddBg    = "#20303B" // Dark blue-green
 	ColorDiffRemoveBg = "#3C2A2A" // Dark red-brown
@@ -135,6 +139,10 @@ var (
 	SelectedFg       = lipgloss.Color(ColorTextPrimary)
 	Hover            = lipgloss.Color(ColorHover)
 	PlaceholderColor = lipgloss.Color(ColorMutedBlue)
+
+	// Badge colors
+	AgentBadge    = lipgloss.Color(ColorAgentBadge)
+	TransferBadge = lipgloss.Color(ColorTransferBadge)
 )
 
 // Base Styles
@@ -384,6 +392,19 @@ var (
 					Foreground(TextMuted).
 					Italic(true).
 					Align(lipgloss.Center)
+)
+
+// Agent and transfer badge styles
+var (
+	AgentBadgeStyle = BaseStyle.
+			Foreground(AgentBadge).
+			Bold(true).
+			Padding(0, 1)
+
+	TransferBadgeStyle = BaseStyle.
+				Foreground(TransferBadge).
+				Bold(true).
+				Padding(0, 1)
 )
 
 // Deprecated styles (kept for backward compatibility)


### PR DESCRIPTION
Misc fixes to improve clarity in msg rendering:

- Always show the agent name as a badge to keep clarity between subagent/parent agent responses and not over complicate the code;
- Check if the agent has changed before appending content to a previous message component. Previously content was directly appended if the previous message was a normal message, without checking for the agent name, so it'd be hard to recognize when a task delegation had finished and what agent was the last to answer;
- Add some basic styling to view agent names on top of their messages;
- Adjusts task transfers styling to make it a bit easier to read

For now I think it's better to keep clarity around which agent is outputting text without complicating the code around when to show or not the root agent's badge (e.g. maybe we could avoid showing the root agent badge on the first message and other minor things, but i think it's better to keep it simpler and consistent). This can surely be revisited at some point

---

**Screenshots**:

Start of chat and task delegation:

<img width="1578" height="716" alt="Screenshot From 2025-11-14 13-26-31" src="https://github.com/user-attachments/assets/f8da36c4-0149-4ef3-991f-eb8e7eab135e" />

---

Clarity around which agent is responding after a subagent returns to a parent agent:

<img width="1578" height="716" alt="Screenshot From 2025-11-14 13-26-50" src="https://github.com/user-attachments/assets/50600c2c-3029-42d9-a6a6-85287a77a479" />

---

Closes #770 