### PR TITLE
feat(anthropic): add structured output support (#802)

### DIFF
--- a/pkg/model/provider/anthropic/beta_client.go
+++ b/pkg/model/provider/anthropic/beta_client.go
@@ -61,6 +61,17 @@ func (c *Client) createBetaStream(
 		params.System = sys
 	}
 
+	// Apply structured output configuration
+	if structuredOutput := c.ModelOptions.StructuredOutput(); structuredOutput != nil {
+		slog.Debug("Anthropic Beta API using structured output", "name", structuredOutput.Name)
+
+		// Add structured outputs beta header
+		params.Betas = append(params.Betas, "structured-outputs-2025-11-13")
+
+		// Configure output format using the SDK helper
+		params.OutputFormat = anthropic.BetaJSONSchemaOutputFormat(structuredOutput.Schema)
+	}
+
 	// For interleaved thinking to make sense, we use a default of 16384 tokens for the thinking budget
 	thinkingTokens := int64(16384)
 	if c.ModelConfig.ThinkingBudget != nil {


### PR DESCRIPTION
## Summary

Enables JSON schema-based structured outputs for Anthropic models using the `structured-outputs-2025-11-13` beta feature.

Closes #802

## Changes

- Remove blocking error when `structured_output` is configured
- Configure `OutputFormat` using `BetaJSONSchemaOutputFormat` helper

## Testing

- [x] All tests pass
- [x] Linting passes
- [x] Build succeeds
- [x] Example tested manually

## Example

```yaml
models:
  claude_structured:
    provider: anthropic
    model: claude-sonnet-4-5
    max_tokens: 1024

agents:
  root:
    model: claude_structured
    structured_output:
      name: "contact_info"
      schema:
        type: object
        properties:
          name: { type: string }
          email: { type: string }
          plan_interest: { type: string }
          demo_requested: { type: boolean }
        required: [name, email, plan_interest, demo_requested]
```