### PR TITLE
Add background job support to shell

### DIFF
--- a/pkg/tools/builtin/shell.go
+++ b/pkg/tools/builtin/shell.go
@@ -320,11 +320,11 @@ func (h *shellHandler) ListBackgroundJobs(_ context.Context, _ tools.ToolCall) (
 		status := job.status.Load()
 		statusStr := statusToString(status)
 
-		runtime := time.Since(job.startTime).Round(time.Second)
+		elapsed := time.Since(job.startTime).Round(time.Second)
 		output.WriteString(fmt.Sprintf("ID: %s\n", jobID))
 		output.WriteString(fmt.Sprintf("  Command: %s\n", job.cmd))
 		output.WriteString(fmt.Sprintf("  Status: %s\n", statusStr))
-		output.WriteString(fmt.Sprintf("  Runtime: %s\n", runtime))
+		output.WriteString(fmt.Sprintf("  Runtime: %s\n", elapsed))
 		if status != statusRunning {
 			job.outputMu.RLock()
 			output.WriteString(fmt.Sprintf("  Exit Code: %d\n", job.exitCode))

--- a/pkg/tools/builtin/shell_test.go
+++ b/pkg/tools/builtin/shell_test.go
@@ -237,7 +237,7 @@ func TestShellTool_RunBackgroundJob(t *testing.T) {
 	tool := NewShellTool(nil)
 	err := tool.Start(t.Context())
 	require.NoError(t, err)
-	defer tool.Stop(t.Context())
+	defer func() { _ = tool.Stop(t.Context()) }()
 
 	tls, err := tool.Tools(t.Context())
 	require.NoError(t, err)
@@ -277,7 +277,7 @@ func TestShellTool_ListBackgroundJobs(t *testing.T) {
 	tool := NewShellTool(nil)
 	err := tool.Start(t.Context())
 	require.NoError(t, err)
-	defer tool.Stop(t.Context())
+	defer func() { _ = tool.Stop(t.Context()) }()
 
 	tls, err := tool.Tools(t.Context())
 	require.NoError(t, err)


### PR DESCRIPTION
closes #811 
Adds background job management to the shell toolset.

**New Tools:**
- `run_shell_background` - Start long-running commands
- `list_background_jobs` - View all jobs and their status
- `view_background_job` - Check job output
- `stop_background_job` - Terminate running jobs
