### PR TITLE
Add unmanaged mode for oauth flow

### DIFF
--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -37,6 +37,7 @@ func (s *stubToolSet) Tools(context.Context) ([]tools.Tool, error) {
 func (s *stubToolSet) Instructions() string                           { return s.instructions }
 func (s *stubToolSet) SetElicitationHandler(tools.ElicitationHandler) {}
 func (s *stubToolSet) SetOAuthSuccessHandler(func())                  {}
+func (s *stubToolSet) SetManagedOAuth(bool)                           {}
 
 func TestAgentTools(t *testing.T) {
 	tests := []struct {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -155,17 +155,6 @@ type DesktopTokenResponse struct {
 	Token string `json:"token"`
 }
 
-// ResumeStartOauthRequest represents the user approval to start the OAuth flow
-type ResumeStartOauthRequest struct {
-	Confirmation bool `json:"confirmation"`
-}
-
-// ResumeCodeReceivedOauthRequest represents the response from getting the OAuth URL with code and state
-type ResumeCodeReceivedOauthRequest struct {
-	Code  string `json:"code"`
-	State string `json:"state"`
-}
-
 // ResumeElicitationRequest represents a request to resume with an elicitation response
 type ResumeElicitationRequest struct {
 	Action  string         `json:"action"`  // "accept", "decline", or "cancel"

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/docker/cagent/pkg/runtime"
 	"github.com/docker/cagent/pkg/session"
+	"github.com/docker/cagent/pkg/tools"
 )
 
 type App struct {
@@ -87,9 +88,12 @@ func (a *App) Subscribe(ctx context.Context, program *tea.Program) {
 
 // Resume resumes the runtime with the given confirmation type
 func (a *App) Resume(resumeType runtime.ResumeType) {
-	if a.runtime != nil {
-		a.runtime.Resume(context.Background(), resumeType)
-	}
+	a.runtime.Resume(context.Background(), resumeType)
+}
+
+// ResumeElicitation resumes an elicitation request with the given action and content
+func (a *App) ResumeElicitation(ctx context.Context, action tools.ElicitationAction, content map[string]any) error {
+	return a.runtime.ResumeElicitation(ctx, action, content)
 }
 
 func (a *App) NewSession() {
@@ -105,21 +109,13 @@ func (a *App) Session() *session.Session {
 }
 
 func (a *App) CompactSession() {
-	if a.runtime != nil && a.session != nil {
+	if a.session != nil {
 		events := make(chan runtime.Event, 100)
 		a.runtime.Summarize(context.Background(), a.session, events)
 		close(events)
 		for event := range events {
 			a.events <- event
 		}
-	}
-}
-
-// ResumeStartOAuth resumes the runtime with OAuth authorization confirmation
-func (a *App) ResumeStartOAuth(bool) {
-	if a.runtime != nil {
-		// TODO(rumpl): handle the error
-		_ = a.runtime.ResumeElicitation(context.Background(), "accept", nil)
 	}
 }
 

--- a/pkg/runtime/client.go
+++ b/pkg/runtime/client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/cagent/pkg/api"
 	v2 "github.com/docker/cagent/pkg/config/v2"
 	"github.com/docker/cagent/pkg/session"
+	"github.com/docker/cagent/pkg/tools"
 )
 
 // Client is an HTTP client for the cagent server API
@@ -373,17 +374,7 @@ func (c *Client) runAgentWithAgentName(ctx context.Context, sessionID, agent, ag
 	return eventChan, nil
 }
 
-func (c *Client) ResumeStartAuthorizationFlow(ctx context.Context, id string, confirmation bool) error {
-	req := api.ResumeStartOauthRequest{Confirmation: confirmation}
-	return c.doRequest(ctx, http.MethodPost, "/api/"+id+"/resumeStartOauth", req, nil)
-}
-
-func (c *Client) ResumeCodeReceived(ctx context.Context, code, state string) error {
-	req := api.ResumeCodeReceivedOauthRequest{Code: code, State: state}
-	return c.doRequest(ctx, http.MethodPost, "/api/resumeCodeReceivedOauth", req, nil)
-}
-
-func (c *Client) ResumeElicitation(ctx context.Context, action string, content map[string]any) error {
-	req := api.ResumeElicitationRequest{Action: action, Content: content}
-	return c.doRequest(ctx, http.MethodPost, "/api/resumeElicitation", req, nil)
+func (c *Client) ResumeElicitation(ctx context.Context, sessionID string, action tools.ElicitationAction, content map[string]any) error {
+	req := api.ResumeElicitationRequest{Action: string(action), Content: content}
+	return c.doRequest(ctx, http.MethodPost, "/api/sessions/"+sessionID+"/elicitation", req, nil)
 }

--- a/pkg/runtime/event.go
+++ b/pkg/runtime/event.go
@@ -293,14 +293,14 @@ func ElicitationRequest(message string, schema any, meta map[string]any, agentNa
 func (e *ElicitationRequestEvent) GetAgentName() string { return e.AgentName }
 
 type AuthorizationEvent struct {
-	Type         string `json:"type"`
-	Confirmation string `json:"confirmation"` // only "confirmed"
+	Type         string                  `json:"type"`
+	Confirmation tools.ElicitationAction `json:"confirmation"`
 	AgentContext
 }
 
 func (e *AuthorizationEvent) GetAgentName() string { return "" }
 
-func Authorization(confirmation, agentName string) Event {
+func Authorization(confirmation tools.ElicitationAction, agentName string) Event {
 	return &AuthorizationEvent{
 		Type:         "authorization_event",
 		Confirmation: confirmation,

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -2,23 +2,30 @@ package runtime
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
+	"time"
+
+	"golang.org/x/oauth2"
 
 	"github.com/docker/cagent/pkg/api"
 	"github.com/docker/cagent/pkg/chat"
 	latest "github.com/docker/cagent/pkg/config/v2"
 	"github.com/docker/cagent/pkg/session"
 	"github.com/docker/cagent/pkg/team"
+	"github.com/docker/cagent/pkg/tools"
+	"github.com/docker/cagent/pkg/tools/mcp"
 )
 
 // RemoteRuntime implements the Interface using a remote client
 type RemoteRuntime struct {
-	client        *Client
-	currentAgent  string
-	agentFilename string
-	sessionID     string
-	team          *team.Team
+	client                  *Client
+	currentAgent            string
+	agentFilename           string
+	sessionID               string
+	team                    *team.Team
+	pendingOAuthElicitation *ElicitationRequestEvent
 }
 
 // RemoteRuntimeOption is a function for configuring the RemoteRuntime
@@ -115,6 +122,10 @@ func (r *RemoteRuntime) RunStream(ctx context.Context, sess *session.Session) <-
 		}
 
 		for streamEvent := range streamChan {
+			if elicitationRequest, ok := streamEvent.(*ElicitationRequestEvent); ok {
+				// Store pending OAuth elicitation request
+				r.pendingOAuthElicitation = elicitationRequest
+			}
 			events <- streamEvent
 		}
 	}()
@@ -176,51 +187,186 @@ func (r *RemoteRuntime) convertSessionMessages(sess *session.Session) []api.Mess
 	return messages
 }
 
-// ResumeStartAuthorizationFlow allows resuming execution after user confirmation
-func (r *RemoteRuntime) ResumeStartAuthorizationFlow(ctx context.Context, confirmationType bool) {
-	slog.Debug("Resuming remote runtime", "agent", r.currentAgent, "confirmation_type", confirmationType, "session_id", r.sessionID)
+// ResumeElicitation sends an elicitation response back to a waiting elicitation request
+func (r *RemoteRuntime) ResumeElicitation(ctx context.Context, action tools.ElicitationAction, content map[string]any) error {
+	slog.Debug("Resuming remote runtime with elicitation response", "agent", r.currentAgent, "action", action, "session_id", r.sessionID)
 
-	if r.sessionID == "" {
-		slog.Error("Cannot resume: no session ID available")
-		return
+	err := r.handleOAuthElicitation(ctx, r.pendingOAuthElicitation)
+	if err != nil {
+		return err
 	}
+	// TODO: once we get here and the elicitation is the OAuth type, we need to start the managed OAuth flow
 
-	if err := r.client.ResumeStartAuthorizationFlow(ctx, r.sessionID, confirmationType); err != nil {
-		slog.Error("Failed to resume remote session", "error", err, "session_id", r.sessionID)
-	}
-}
-
-// ResumeCodeReceived allows resuming execution after user confirmation
-func (r *RemoteRuntime) ResumeCodeReceived(ctx context.Context, code, state string) error {
-	slog.Debug("Resuming remote runtime", "agent", r.currentAgent, "code", code, "state", state, "session_id", r.sessionID)
-
-	if r.sessionID == "" {
-		slog.Error("Cannot resume: no session ID available")
-		return fmt.Errorf("session ID cannot be empty")
-	}
-
-	if err := r.client.ResumeCodeReceived(ctx, code, state); err != nil {
-		slog.Error("Failed to resume remote session", "error", err, "session_id", r.sessionID)
+	if err := r.client.ResumeElicitation(ctx, r.sessionID, action, content); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-// ResumeElicitation sends an elicitation response back to a waiting elicitation request
-func (r *RemoteRuntime) ResumeElicitation(ctx context.Context, action string, content map[string]any) error {
-	slog.Debug("Resuming remote runtime with elicitation response", "agent", r.currentAgent, "action", action, "session_id", r.sessionID)
+// HandleOAuthElicitation handles OAuth elicitation requests from remote MCP servers
+func (r *RemoteRuntime) handleOAuthElicitation(ctx context.Context, req *ElicitationRequestEvent) error {
+	slog.Debug("Handling OAuth elicitation request", "server_url", req.Meta["cagent/server_url"])
 
-	if r.sessionID == "" {
-		slog.Error("Cannot resume: no session ID available")
-		return fmt.Errorf("session ID cannot be empty")
-	}
-
-	if err := r.client.ResumeElicitation(ctx, action, content); err != nil {
-		slog.Error("Failed to resume remote session with elicitation", "error", err, "session_id", r.sessionID)
+	// Extract OAuth parameters from metadata
+	serverURL, ok := req.Meta["cagent/server_url"].(string)
+	if !ok {
+		err := fmt.Errorf("server_url missing from elicitation metadata")
+		slog.Error("Failed to extract server_url", "error", err)
+		_ = r.client.ResumeElicitation(ctx, r.sessionID, "decline", nil)
 		return err
 	}
 
+	// Extract authorization server metadata
+	authServerMetadata, ok := req.Meta["auth_server_metadata"].(map[string]any)
+	if !ok {
+		err := fmt.Errorf("auth_server_metadata missing from elicitation metadata")
+		slog.Error("Failed to extract auth_server_metadata", "error", err)
+		_ = r.client.ResumeElicitation(ctx, r.sessionID, "decline", nil)
+		return err
+	}
+
+	// Unmarshal authorization server metadata
+	var authMetadata mcp.AuthorizationServerMetadata
+	metadataBytes, err := json.Marshal(authServerMetadata)
+	if err != nil {
+		slog.Error("Failed to marshal auth_server_metadata", "error", err)
+		_ = r.client.ResumeElicitation(ctx, r.sessionID, "decline", nil)
+		return fmt.Errorf("failed to marshal auth_server_metadata: %w", err)
+	}
+	if err := json.Unmarshal(metadataBytes, &authMetadata); err != nil {
+		slog.Error("Failed to unmarshal auth_server_metadata", "error", err)
+		_ = r.client.ResumeElicitation(ctx, r.sessionID, "decline", nil)
+		return fmt.Errorf("failed to unmarshal auth_server_metadata: %w", err)
+	}
+
+	slog.Debug("Authorization server metadata extracted", "issuer", authMetadata.Issuer)
+
+	// Create timeout context for OAuth flow (5 minutes)
+	oauthCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	// Create and start callback server
+	slog.Debug("Creating OAuth callback server")
+	callbackServer, err := mcp.NewCallbackServer()
+	if err != nil {
+		slog.Error("Failed to create callback server", "error", err)
+		_ = r.client.ResumeElicitation(ctx, r.sessionID, "decline", nil)
+		return fmt.Errorf("failed to create callback server: %w", err)
+	}
+	defer func() {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+		if err := callbackServer.Shutdown(shutdownCtx); err != nil {
+			slog.Error("Failed to shutdown callback server", "error", err)
+		}
+	}()
+
+	if err := callbackServer.Start(); err != nil {
+		slog.Error("Failed to start callback server", "error", err)
+		_ = r.client.ResumeElicitation(ctx, r.sessionID, "decline", nil)
+		return fmt.Errorf("failed to start callback server: %w", err)
+	}
+
+	redirectURI := callbackServer.GetRedirectURI()
+	slog.Debug("Callback server started", "redirect_uri", redirectURI)
+
+	// Register client
+	var clientID, clientSecret string
+	if authMetadata.RegistrationEndpoint != "" {
+		slog.Debug("Attempting dynamic client registration")
+		clientID, clientSecret, err = mcp.RegisterClient(oauthCtx, &authMetadata, redirectURI, nil)
+		if err != nil {
+			slog.Error("Dynamic client registration failed", "error", err)
+			_ = r.client.ResumeElicitation(ctx, r.sessionID, "decline", nil)
+			return fmt.Errorf("failed to register client: %w", err)
+		}
+		slog.Debug("Client registered successfully", "client_id", clientID)
+	} else {
+		err := fmt.Errorf("authorization server does not support dynamic client registration")
+		slog.Error("Client registration not supported", "error", err)
+		_ = r.client.ResumeElicitation(ctx, r.sessionID, "decline", nil)
+		return err
+	}
+
+	// Generate state and PKCE verifier
+	state, err := mcp.GenerateState()
+	if err != nil {
+		slog.Error("Failed to generate state", "error", err)
+		_ = r.client.ResumeElicitation(ctx, r.sessionID, "decline", nil)
+		return fmt.Errorf("failed to generate state: %w", err)
+	}
+
+	callbackServer.SetExpectedState(state)
+	verifier := mcp.GeneratePKCEVerifier()
+
+	// Build authorization URL
+	authURL := mcp.BuildAuthorizationURL(
+		authMetadata.AuthorizationEndpoint,
+		clientID,
+		redirectURI,
+		state,
+		oauth2.S256ChallengeFromVerifier(verifier),
+		serverURL,
+	)
+
+	slog.Debug("Authorization URL built", "url", authURL)
+
+	// Request authorization code (this opens the browser)
+	slog.Debug("Requesting authorization code")
+	code, receivedState, err := mcp.RequestAuthorizationCode(oauthCtx, authURL, callbackServer, state)
+	if err != nil {
+		slog.Error("Failed to get authorization code", "error", err)
+		_ = r.client.ResumeElicitation(ctx, r.sessionID, "decline", nil)
+		return fmt.Errorf("failed to get authorization code: %w", err)
+	}
+
+	if receivedState != state {
+		err := fmt.Errorf("state mismatch: expected %s, got %s", state, receivedState)
+		slog.Error("State mismatch in authorization response", "error", err)
+		_ = r.client.ResumeElicitation(ctx, r.sessionID, "decline", nil)
+		return err
+	}
+
+	slog.Debug("Authorization code received, exchanging for token")
+
+	// Exchange code for token
+	token, err := mcp.ExchangeCodeForToken(
+		oauthCtx,
+		authMetadata.TokenEndpoint,
+		code,
+		verifier,
+		clientID,
+		clientSecret,
+		redirectURI,
+	)
+	if err != nil {
+		slog.Error("Failed to exchange code for token", "error", err)
+		_ = r.client.ResumeElicitation(ctx, r.sessionID, "decline", nil)
+		return fmt.Errorf("failed to exchange code for token: %w", err)
+	}
+
+	slog.Debug("Token obtained successfully", "token_type", token.TokenType)
+
+	// Send token back to server via ResumeElicitation
+	tokenData := map[string]any{
+		"access_token": token.AccessToken,
+		"token_type":   token.TokenType,
+	}
+	if token.ExpiresIn > 0 {
+		tokenData["expires_in"] = token.ExpiresIn
+	}
+	if token.RefreshToken != "" {
+		tokenData["refresh_token"] = token.RefreshToken
+	}
+
+	slog.Debug("Sending token to server")
+	if err := r.client.ResumeElicitation(ctx, r.sessionID, tools.ElicitationActionAccept, tokenData); err != nil {
+		slog.Error("Failed to send token to server", "error", err)
+		return fmt.Errorf("failed to send token to server: %w", err)
+	}
+
+	slog.Debug("OAuth flow completed successfully")
 	return nil
 }
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -36,7 +36,7 @@ type modelStore interface {
 
 // ElicitationResult represents the result of an elicitation request
 type ElicitationResult struct {
-	Action  string         // "accept", "decline", or "cancel"
+	Action  tools.ElicitationAction
 	Content map[string]any // The submitted form data (only present when action is "accept")
 }
 
@@ -79,7 +79,7 @@ type Runtime interface {
 	// Summarize generates a summary for the session
 	Summarize(ctx context.Context, sess *session.Session, events chan Event)
 	// ResumeElicitation sends an elicitation response back to a waiting elicitation request
-	ResumeElicitation(_ context.Context, action string, content map[string]any) error
+	ResumeElicitation(_ context.Context, action tools.ElicitationAction, content map[string]any) error
 }
 
 // LocalRuntime manages the execution of agents
@@ -241,8 +241,9 @@ func (r *LocalRuntime) RunStream(ctx context.Context, sess *session.Session) <-c
 		for _, toolset := range a.ToolSets() {
 			toolset.SetElicitationHandler(r.elicitationHandler)
 			toolset.SetOAuthSuccessHandler(func() {
-				events <- Authorization("confirmed", r.currentAgent)
+				events <- Authorization(tools.ElicitationActionAccept, r.currentAgent)
 			})
+			toolset.SetManagedOAuth(r.managedOAuth)
 		}
 
 		agentTools, err := r.getTools(ctx, a, sessionSpan, events)
@@ -490,7 +491,7 @@ func (r *LocalRuntime) Resume(_ context.Context, confirmationType ResumeType) {
 }
 
 // ResumeElicitation sends an elicitation response back to a waiting elicitation request
-func (r *LocalRuntime) ResumeElicitation(ctx context.Context, action string, content map[string]any) error {
+func (r *LocalRuntime) ResumeElicitation(ctx context.Context, action tools.ElicitationAction, content map[string]any) error {
 	slog.Debug("Resuming runtime with elicitation response", "agent", r.currentAgent, "action", action)
 
 	result := ElicitationResult{

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -47,6 +47,7 @@ func (s *stubToolSet) Tools(context.Context) ([]tools.Tool, error) {
 func (s *stubToolSet) Instructions() string                           { return s.instructions }
 func (s *stubToolSet) SetElicitationHandler(tools.ElicitationHandler) {}
 func (s *stubToolSet) SetOAuthSuccessHandler(func())                  {}
+func (s *stubToolSet) SetManagedOAuth(bool)                           {}
 
 type mockStream struct {
 	responses []chat.MessageStreamResponse

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -36,6 +36,7 @@ import (
 	"github.com/docker/cagent/pkg/session"
 	"github.com/docker/cagent/pkg/team"
 	"github.com/docker/cagent/pkg/teamloader"
+	"github.com/docker/cagent/pkg/tools"
 )
 
 type Server struct {
@@ -1295,7 +1296,7 @@ func (s *Server) elicitation(c echo.Context) error {
 		return c.JSON(http.StatusNotFound, map[string]string{"error": fmt.Sprintf("runtime not found: %s", sessionID)})
 	}
 
-	if err := rt.ResumeElicitation(c.Request().Context(), req.Action, req.Content); err != nil {
+	if err := rt.ResumeElicitation(c.Request().Context(), tools.ElicitationAction(req.Action), req.Content); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to resume elicitation: %v", err))
 	}
 

--- a/pkg/tools/mcp/gateway.go
+++ b/pkg/tools/mcp/gateway.go
@@ -82,6 +82,10 @@ func (t *GatewayToolset) SetOAuthSuccessHandler(handler func()) {
 	t.cmdToolset.SetOAuthSuccessHandler(handler)
 }
 
+func (t *GatewayToolset) SetManagedOAuth(managed bool) {
+	t.cmdToolset.SetManagedOAuth(managed)
+}
+
 func (t *GatewayToolset) Stop(ctx context.Context) error {
 	return errors.Join(t.cmdToolset.Stop(ctx), t.cleanUp())
 }

--- a/pkg/tools/mcp/mcp.go
+++ b/pkg/tools/mcp/mcp.go
@@ -22,6 +22,7 @@ type mcpClient interface {
 	CallTool(ctx context.Context, request *mcp.CallToolParams) (*mcp.CallToolResult, error)
 	SetElicitationHandler(handler tools.ElicitationHandler)
 	SetOAuthSuccessHandler(handler func())
+	SetManagedOAuth(managed bool)
 	Close(ctx context.Context) error
 }
 
@@ -50,7 +51,7 @@ func NewRemoteToolset(url, transport string, headers map[string]string) *Toolset
 	slog.Debug("Creating Remote MCP toolset", "url", url, "transport", transport, "headers", headers)
 
 	return &Toolset{
-		mcpClient: newRemoteClient(url, transport, headers, NewInMemoryTokenStore()),
+		mcpClient: newRemoteClient(url, transport, headers, NewInMemoryTokenStore(), false),
 		logID:     url,
 	}
 }
@@ -240,4 +241,8 @@ func (ts *Toolset) SetElicitationHandler(handler tools.ElicitationHandler) {
 
 func (ts *Toolset) SetOAuthSuccessHandler(handler func()) {
 	ts.mcpClient.SetOAuthSuccessHandler(handler)
+}
+
+func (ts *Toolset) SetManagedOAuth(managed bool) {
+	ts.mcpClient.SetManagedOAuth(managed)
 }

--- a/pkg/tools/mcp/oauth_helpers.go
+++ b/pkg/tools/mcp/oauth_helpers.go
@@ -1,0 +1,160 @@
+package mcp
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+
+	"github.com/docker/cagent/pkg/browser"
+)
+
+// GenerateState generates a random state parameter for OAuth CSRF protection
+func GenerateState() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// BuildAuthorizationURL builds the OAuth authorization URL with PKCE
+func BuildAuthorizationURL(authEndpoint, clientID, redirectURI, state, codeChallenge, resourceURL string) string {
+	params := url.Values{}
+	params.Set("response_type", "code")
+	params.Set("client_id", clientID)
+	params.Set("redirect_uri", redirectURI)
+	params.Set("state", state)
+	params.Set("code_challenge", codeChallenge)
+	params.Set("code_challenge_method", "S256")
+	params.Set("resource", resourceURL) // RFC 8707: Resource Indicators
+	return authEndpoint + "?" + params.Encode()
+}
+
+// ExchangeCodeForToken exchanges an authorization code for an access token
+func ExchangeCodeForToken(ctx context.Context, tokenEndpoint, code, codeVerifier, clientID, clientSecret, redirectURI string) (*OAuthToken, error) {
+	data := url.Values{}
+	data.Set("grant_type", "authorization_code")
+	data.Set("code", code)
+	data.Set("redirect_uri", redirectURI)
+	data.Set("client_id", clientID)
+	data.Set("code_verifier", codeVerifier)
+	if clientSecret != "" {
+		data.Set("client_secret", clientSecret)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenEndpoint, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create token request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to exchange code for token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("token exchange failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var token OAuthToken
+	if err := json.NewDecoder(resp.Body).Decode(&token); err != nil {
+		return nil, fmt.Errorf("failed to decode token response: %w", err)
+	}
+
+	if token.ExpiresIn > 0 {
+		token.ExpiresAt = time.Now().Add(time.Duration(token.ExpiresIn) * time.Second)
+	}
+
+	return &token, nil
+}
+
+// RequestAuthorizationCode requests the user to open the authorization URL and waits for the callback
+func RequestAuthorizationCode(ctx context.Context, authURL string, callbackServer *CallbackServer, expectedState string) (string, string, error) {
+	if err := browser.Open(ctx, authURL); err != nil {
+		return "", "", err
+	}
+
+	code, state, err := callbackServer.WaitForCallback(ctx)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to receive authorization callback: %w", err)
+	}
+
+	if state != expectedState {
+		return "", "", fmt.Errorf("state mismatch: expected %s, got %s", expectedState, state)
+	}
+
+	return code, state, nil
+}
+
+// RegisterClient performs dynamic client registration
+func RegisterClient(ctx context.Context, authMetadata *AuthorizationServerMetadata, redirectURI string, scopes []string) (clientID, clientSecret string, err error) {
+	if authMetadata.RegistrationEndpoint == "" {
+		return "", "", fmt.Errorf("authorization server does not support dynamic client registration")
+	}
+
+	reqBody := map[string]any{
+		"redirect_uris": []string{redirectURI},
+		"client_name":   "cagent",
+		"grant_types":   []string{"authorization_code"},
+		"response_types": []string{
+			"code",
+		},
+	}
+	if len(scopes) > 0 {
+		reqBody["scope"] = strings.Join(scopes, " ")
+	}
+
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to marshal registration request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, authMetadata.RegistrationEndpoint, strings.NewReader(string(bodyBytes)))
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create registration request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to register client: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", "", fmt.Errorf("client registration failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var respBody struct {
+		ClientID     string `json:"client_id"`
+		ClientSecret string `json:"client_secret,omitempty"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&respBody); err != nil {
+		return "", "", fmt.Errorf("failed to decode registration response: %w", err)
+	}
+
+	if respBody.ClientID == "" {
+		return "", "", fmt.Errorf("registration response missing client_id")
+	}
+
+	return respBody.ClientID, respBody.ClientSecret, nil
+}
+
+// GeneratePKCEVerifier generates a PKCE code verifier using oauth2 library
+func GeneratePKCEVerifier() string {
+	return oauth2.GenerateVerifier()
+}

--- a/pkg/tools/mcp/stdio.go
+++ b/pkg/tools/mcp/stdio.go
@@ -81,3 +81,5 @@ func (c *stdioMCPClient) CallTool(ctx context.Context, request *mcp.CallToolPara
 func (c *stdioMCPClient) SetElicitationHandler(tools.ElicitationHandler) {}
 
 func (c *stdioMCPClient) SetOAuthSuccessHandler(func()) {}
+
+func (c *stdioMCPClient) SetManagedOAuth(bool) {}

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -39,9 +39,17 @@ type Tool struct {
 
 type ToolAnnotations mcp.ToolAnnotations
 
+type ElicitationAction string
+
+const (
+	ElicitationActionAccept  ElicitationAction = "accept"
+	ElicitationActionDecline ElicitationAction = "decline"
+	ElicitationActionCancel  ElicitationAction = "cancel"
+)
+
 type ElicitationResult struct {
-	Action  string         `json:"action"` // "accept", "decline", or "cancel"
-	Content map[string]any `json:"content,omitempty"`
+	Action  ElicitationAction `json:"action"`
+	Content map[string]any    `json:"content,omitempty"`
 }
 
 // ElicitationHandler is a function type that handles elicitation requests from the MCP server
@@ -58,6 +66,10 @@ func (t *ElicitationTool) SetOAuthSuccessHandler(func()) {
 	// No-op, this tool does not use OAuth
 }
 
+func (t *ElicitationTool) SetManagedOAuth(bool) {
+	// No-op, this tool does not use OAuth
+}
+
 type ToolSet interface {
 	Tools(ctx context.Context) ([]Tool, error)
 	Instructions() string
@@ -65,4 +77,5 @@ type ToolSet interface {
 	Stop(ctx context.Context) error
 	SetElicitationHandler(handler ElicitationHandler)
 	SetOAuthSuccessHandler(handler func())
+	SetManagedOAuth(managed bool)
 }

--- a/pkg/tui/dialog/oauth_authorization.go
+++ b/pkg/tui/dialog/oauth_authorization.go
@@ -1,6 +1,7 @@
 package dialog
 
 import (
+	"context"
 	"fmt"
 
 	"charm.land/bubbles/v2/key"
@@ -8,6 +9,7 @@ import (
 	"charm.land/lipgloss/v2"
 
 	"github.com/docker/cagent/pkg/app"
+	"github.com/docker/cagent/pkg/tools"
 	"github.com/docker/cagent/pkg/tui/core"
 	"github.com/docker/cagent/pkg/tui/core/layout"
 	"github.com/docker/cagent/pkg/tui/styles"
@@ -72,14 +74,10 @@ func (d *oauthAuthorizationDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 	case tea.KeyPressMsg:
 		switch {
 		case key.Matches(msg, d.keyMap.Yes):
-			if d.app != nil {
-				d.app.ResumeStartOAuth(true)
-			}
+			_ = d.app.ResumeElicitation(context.Background(), tools.ElicitationActionAccept, nil)
 			return d, core.CmdHandler(CloseDialogMsg{})
 		case key.Matches(msg, d.keyMap.No):
-			if d.app != nil {
-				d.app.ResumeStartOAuth(false)
-			}
+			_ = d.app.ResumeElicitation(context.Background(), tools.ElicitationActionDecline, nil)
 			return d, core.CmdHandler(CloseDialogMsg{})
 		}
 

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -305,6 +305,7 @@ func (p *chatPage) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 
 		return p, tea.Batch(spinnerCmd, dialogCmd)
 	case *runtime.ElicitationRequestEvent:
+		// TODO: handle normal elicitation requsets
 		spinnerCmd := p.setWorking(false)
 
 		serverURL := msg.Meta["cagent/server_url"].(string)
@@ -313,7 +314,6 @@ func (p *chatPage) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		})
 
 		return p, tea.Batch(spinnerCmd, dialogCmd)
-
 	}
 
 	sidebarModel, sidebarCmd := p.sidebar.Update(msg)


### PR DESCRIPTION
There are now two modes in the oauth flow

- Managed mode

In this mode, cagent handles, in process, everything oauth related: asking for user consent, starting the oauth callback server, resuming once the flow is done

- Unmanaged mode

This mode is more for the remote case in cagent, in this mode the remote cagent will _only_ ask for user consent via an elicitation, up to the client to do the oauth flow and send the token back in the elicitation response.

---

Here is what `cagent` has to say about the difference in the two modes:

Now I can explain the key differences between `handleUnmanagedOAuthFlow` and `handleManagedOAuthFlow`:

## Key Differences Between the Two OAuth Flow Functions

### **handleManagedOAuthFlow** (lines 184-285)
This function **performs the complete OAuth flow within cagent itself**:

1. **Runs a local callback server** - Creates and starts a callback server to receive the OAuth redirect
2. **Handles client registration** - Attempts dynamic client registration with the OAuth provider
3. **Generates PKCE parameters** - Creates state and PKCE verifier for secure authorization
4. **Requests user consent** - Calls `t.client.requestUserConsent()` to get approval from the user
5. **Opens authorization URL** - Calls `RequestAuthorizationCode()` which typically opens the auth URL in a browser
6. **Receives the callback** - The local callback server catches the authorization code
7. **Exchanges code for token** - Calls `ExchangeCodeForToken()` to get the access token
8. **Stores and returns** - Saves the token and notifies success

**Use case**: When cagent is running locally and can open a browser, start HTTP servers, and handle the full OAuth dance.

### **handleUnmanagedOAuthFlow** (lines 288-363)
This function **delegates the OAuth flow to the client** (typically an MCP client like Claude Desktop):

1. **Discovers OAuth metadata** - Fetches the same resource and authorization server metadata
2. **Sends elicitation request** - Calls `t.client.requestElicitation()` with OAuth metadata
3. **Waits for client response** - The client performs the OAuth flow externally
4. **Receives token from client** - Extracts the `access_token` and other fields from the elicitation response
5. **Stores and returns** - Saves the token received from the client

**Use case**: When cagent is running as an MCP server where it cannot open browsers or run callback servers. The client application handles the OAuth UI and returns the completed token.

### Summary Table

| Aspect | Managed Flow | Unmanaged Flow |
|--------|--------------|----------------|
| **Who handles OAuth UI** | cagent (opens browser) | Client application |
| **Callback server** | Yes, runs locally | No |
| **Client registration** | Yes, dynamic registration | Client handles it |
| **PKCE** | Yes, generates verifier | Client handles it |
| **Token exchange** | Yes, exchanges code for token | Client returns complete token |
| **User interaction** | Browser redirect + consent prompt | Client's own OAuth UI |
| **Typical scenario** | Standalone cagent | cagent as MCP server |

The **managed flow** is more complex but gives full control, while the **unmanaged flow** is simpler and delegates responsibility to a more capable client that has better UI capabilities for handling OAuth.