### PR TITLE
Works better with git worktrees

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,9 @@ jobs:
         with:
           version: 3.x
 
+      - name: Create bin directory
+        run: mkdir -p $HOME/bin
+
       - name: Build
         run: task build
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -23,6 +23,7 @@ tasks:
     desc: Build the application binary
     cmds:
       - go build -ldflags "{{.LDFLAGS}}" -o {{.BUILD_DIR}}/{{.BINARY_NAME}} {{.MAIN_PKG}}
+      - ln -sf {{.USER_WORKING_DIR}}/{{.BUILD_DIR}}/{{.BINARY_NAME}} {{.HOME}}/bin/{{.BINARY_NAME}}
     sources:
       - "{{.GO_SOURCES}}"
       - "**/*.template"
@@ -31,10 +32,6 @@ tasks:
       - "go.sum"
     generates:
       - "{{.BUILD_DIR}}/{{.BINARY_NAME}}"
-
-  link:
-    desc: Creates a symlink to ~/bin
-    cmd: ln -sf {{.USER_WORKING_DIR}}/{{.BUILD_DIR}}/{{.BINARY_NAME}} {{.HOME}}/bin/{{.BINARY_NAME}}
 
   lint:
     desc: Run golangci-lint


### PR DESCRIPTION
The path to cagent keeps on changing when using git worktrees