### PR TITLE
More distinctive style for welcome messages

### DIFF
--- a/pkg/tui/components/message/message.go
+++ b/pkg/tui/components/message/message.go
@@ -111,12 +111,7 @@ func (mv *messageModel) Render(width int) string {
 	case types.MessageTypeCancelled:
 		return styles.WarningStyle.Render("⚠ stream cancelled ⚠")
 	case types.MessageTypeWelcome:
-		// Render welcome message with a distinct style
-		rendered, err := markdown.NewRenderer(width).Render(msg.Content)
-		if err != nil {
-			return styles.MutedStyle.Render(msg.Content)
-		}
-		return styles.MutedStyle.Render(strings.TrimRight(rendered, "\n\r\t "))
+		return styles.WelcomeMessageBorderStyle.Width(width - 1).Render(strings.TrimRight(msg.Content, "\n\r\t "))
 	case types.MessageTypeError:
 		return styles.ErrorStyle.Render("│ " + msg.Content)
 	default:

--- a/pkg/tui/styles/styles.go
+++ b/pkg/tui/styles/styles.go
@@ -200,6 +200,12 @@ var (
 				BorderForeground(BorderPrimary).
 				Bold(true).
 				Background(BackgroundAlt)
+
+	WelcomeMessageBorderStyle = BaseStyle.
+					Padding(1, 2).
+					BorderLeft(true).
+					BorderStyle(lipgloss.DoubleBorder()).
+					Bold(true)
 )
 
 // Dialog Styles


### PR DESCRIPTION
Before:

<img width="928" height="210" alt="Screenshot 2025-11-17 at 14 28 33" src="https://github.com/user-attachments/assets/a146bcc4-2de6-41e9-9355-1cfbe0d2dcef" />

After:

<img width="938" height="305" alt="Screenshot 2025-11-17 at 14 28 17" src="https://github.com/user-attachments/assets/ffddcca6-2a6a-49d0-a84a-a6ab564ffe1a" />
