### PR TITLE
Fix session title generation to handle multi-content messages

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1097,7 +1097,23 @@ func (r *LocalRuntime) generateSessionTitle(ctx context.Context, sess *session.S
 	messages := sess.GetAllMessages()
 	for i := range messages {
 		if messages[i].Message.Role == chat.MessageRoleUser {
-			conversationHistory.WriteString(fmt.Sprintf("\n%s: %s", messages[i].Message.Role, messages[i].Message.Content))
+			if len(messages[i].Message.MultiContent) > 0 {
+				hasContent := false
+				for _, part := range messages[i].Message.MultiContent {
+					if part.Type == chat.MessagePartTypeText && part.Text != "" {
+						conversationHistory.WriteString(fmt.Sprintf("\n%s: %s", messages[i].Message.Role, part.Text))
+						hasContent = true
+					} else if part.Type == chat.MessagePartTypeImageURL {
+						conversationHistory.WriteString(" [with attached image]")
+						hasContent = true
+					}
+				}
+				if !hasContent {
+					conversationHistory.WriteString(fmt.Sprintf("\n%s: [attachment]", messages[i].Message.Role))
+				}
+			} else {
+				conversationHistory.WriteString(fmt.Sprintf("\n%s: %s", messages[i].Message.Role, messages[i].Message.Content))
+			}
 			break
 		}
 	}


### PR DESCRIPTION
The session title generator was only reading the Content field, which is empty when messages contain file attachments (stored in MultiContent). This caused sessions with attachments to be titled like "I don't see a user message in your request" or even from time to to "Claude AI response features" etc.

This commit updates `generateSessionTitle` to:
- Check for and extract text from `MultiContent` parts if exist
- Include context for image attachments in the title prompt