### PR TITLE
Fix api endpoint handling when using oci references

### DIFF
--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -590,6 +591,238 @@ func TestServer_RefreshAgentsFromDisk_NoAgentsDir(t *testing.T) {
 	count := srv.countTeams()
 
 	assert.Equal(t, 0, count)
+}
+
+func TestServer_RefreshAgentsFromDisk_WithAgentsPath(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "dummy")
+	t.Setenv("ANTHROPIC_API_KEY", "dummy")
+
+	ctx := t.Context()
+
+	agentsDir := prepareAgentsDir(t, "pirate.yaml", "contradict.yaml", "multi_agents.yaml")
+
+	singleAgentDir := t.TempDir()
+	pirateContent, err := os.ReadFile(filepath.Join(agentsDir, "pirate.yaml"))
+	require.NoError(t, err)
+	singleAgentPath := filepath.Join(singleAgentDir, "pirate.yaml")
+	err = os.WriteFile(singleAgentPath, pirateContent, 0o600)
+	require.NoError(t, err)
+
+	var store mockStore
+	runConfig := config.RuntimeConfig{}
+
+	teams, err := teamloader.LoadTeams(ctx, agentsDir, &runConfig)
+	require.NoError(t, err)
+
+	srv, err := New(store, &runConfig, teams,
+		WithAgentsPath(singleAgentPath),
+		WithAgentsDir(agentsDir),
+	)
+	require.NoError(t, err)
+
+	initialCount := srv.countTeams()
+	assert.Equal(t, 3, initialCount, "should start with 3 agents")
+
+	err = srv.refreshAgentsFromDisk(ctx)
+	require.NoError(t, err)
+
+	newCount := srv.countTeams()
+	hasPirate := srv.hasTeam("pirate.yaml")
+	hasContradict := srv.hasTeam("contradict.yaml")
+	hasMulti := srv.hasTeam("multi_agents.yaml")
+
+	assert.Equal(t, 1, newCount, "should only have 1 agent after refresh (from agentsPath)")
+	assert.True(t, hasPirate, "should have pirate agent from agentsPath")
+	assert.False(t, hasContradict, "should not have contradict (not in agentsPath)")
+	assert.False(t, hasMulti, "should not have multi_agents (not in agentsPath)")
+}
+
+func TestServer_RefreshAgentsFromDisk_AgentsPathPrecedence(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "dummy")
+	t.Setenv("ANTHROPIC_API_KEY", "dummy")
+
+	ctx := t.Context()
+
+	agentsDir := prepareAgentsDir(t, "pirate.yaml", "contradict.yaml", "multi_agents.yaml")
+	agentsPath := filepath.Join(agentsDir, "pirate.yaml")
+
+	var store mockStore
+	runConfig := config.RuntimeConfig{}
+
+	teams, err := teamloader.LoadTeams(ctx, agentsDir, &runConfig)
+	require.NoError(t, err)
+
+	srv, err := New(store, &runConfig, teams,
+		WithAgentsPath(agentsPath),
+		WithAgentsDir(agentsDir),
+	)
+	require.NoError(t, err)
+
+	modifiedPirate := `version: "2"
+agents:
+  root:
+    model: openai/gpt-4o
+    description: "Modified pirate"
+    instruction: "You are a MODIFIED pirate."
+`
+	err = os.WriteFile(agentsPath, []byte(modifiedPirate), 0o600)
+	require.NoError(t, err)
+
+	err = srv.refreshAgentsFromDisk(ctx)
+	require.NoError(t, err)
+
+	count := srv.countTeams()
+	assert.Equal(t, 1, count, "should only load from agentsPath")
+
+	team, exists := srv.getTeam("pirate.yaml")
+	require.True(t, exists)
+	agent, err := team.Agent("root")
+	require.NoError(t, err)
+	assert.Contains(t, agent.Instruction(), "MODIFIED", "should have loaded modified pirate from agentsPath")
+
+	_, exists = srv.getTeam("contradict.yaml")
+	assert.False(t, exists, "contradict should not be loaded (agentsPath takes precedence)")
+}
+
+// TestServer_OCIRef_NoTmpScan is a regression test for the bug where OCI references
+// would cause the server to scan /tmp for all .yaml files instead of using the
+// specific OCI-resolved agent. This test ensures:
+// 1. getAgents() doesn't refresh when using OCI refs (no /tmp scan)
+// 2. Only the OCI agent is available, not noise files from /tmp
+func TestServer_OCIRef_NoTmpScan(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "dummy")
+
+	ctx := t.Context()
+
+	// Simulate /tmp with the OCI agent and noise files
+	tmpDir := t.TempDir()
+
+	// Create noise files that should NOT be loaded
+	for i := 1; i <= 3; i++ {
+		noisePath := filepath.Join(tmpDir, "noise"+string(rune('0'+i))+".yaml")
+		noiseContent := `version: "2"
+agents:
+  root:
+    model: openai/gpt-4o
+    description: "Noise"
+    instruction: "Should not be loaded"
+`
+		err := os.WriteFile(noisePath, []byte(noiseContent), 0o600)
+		require.NoError(t, err)
+	}
+
+	// Create the OCI agent file
+	pirateContent, err := os.ReadFile(filepath.Join("testdata", "pirate.yaml"))
+	require.NoError(t, err)
+	ociFile := filepath.Join(tmpDir, "docker.io_myorg_pirate_v1.yaml")
+	err = os.WriteFile(ociFile, pirateContent, 0o600)
+	require.NoError(t, err)
+
+	var store mockStore
+	runConfig := config.RuntimeConfig{}
+
+	// Load teams from the OCI file
+	teams, err := teamloader.LoadTeams(ctx, ociFile, &runConfig)
+	require.NoError(t, err)
+
+	// Create server WITHOUT agentsDir (OCI ref mode)
+	// This is what api.go does when agentfile.IsOCIReference() returns true
+	srv, err := New(store, &runConfig, teams)
+	require.NoError(t, err)
+
+	// Verify setup: no agentsDir
+	assert.False(t, srv.hasAgentsDir(), "OCI refs should not have agentsDir")
+
+	// Simulate getAgents() behavior - should skip refresh
+	// (In production, getAgents checks hasAgentsDir and skips refresh for OCI refs)
+	err = srv.refreshAgentsFromDisk(ctx)
+	// Should be no-op since no agentsDir is set
+	require.NoError(t, err)
+
+	// Critical assertion: only the OCI agent should be loaded, not noise files
+	count := srv.countTeams()
+	assert.Equal(t, 1, count, "should only have the OCI agent, not files from /tmp")
+
+	// Verify it's the correct agent
+	team, exists := srv.getTeam("docker.io_myorg_pirate_v1.yaml")
+	require.True(t, exists, "should have the OCI agent")
+
+	agent, err := team.Agent("root")
+	require.NoError(t, err)
+	assert.Contains(t, agent.Instruction(), "pirate", "should be the pirate agent")
+
+	// Verify noise files were NOT loaded
+	_, exists = srv.getTeam("noise1.yaml")
+	assert.False(t, exists, "noise files should not be loaded")
+	_, exists = srv.getTeam("noise2.yaml")
+	assert.False(t, exists, "noise files should not be loaded")
+}
+
+// TestServer_WriteOperations_OCIRef_MethodNotAllowed verifies that write operations
+// (edit, create, delete, import, export) return 405 Method Not Allowed when the server
+// is running in OCI ref mode (no agentsDir).
+func TestServer_WriteOperations_OCIRef_MethodNotAllowed(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "dummy")
+
+	ctx := t.Context()
+
+	// Create OCI agent in temp directory
+	tmpDir := t.TempDir()
+	pirateContent, err := os.ReadFile(filepath.Join("testdata", "pirate.yaml"))
+	require.NoError(t, err)
+	ociFile := filepath.Join(tmpDir, "docker.io_myorg_pirate_v1.yaml")
+	err = os.WriteFile(ociFile, pirateContent, 0o600)
+	require.NoError(t, err)
+
+	var store mockStore
+	runConfig := config.RuntimeConfig{}
+
+	teams, err := teamloader.LoadTeams(ctx, ociFile, &runConfig)
+	require.NoError(t, err)
+
+	// Create server WITHOUT agentsDir (OCI ref mode)
+	srv, err := New(store, &runConfig, teams)
+	require.NoError(t, err)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	go func() {
+		_ = srv.Serve(ctx, ln)
+	}()
+
+	baseURL := fmt.Sprintf("http://%s", ln.Addr().String())
+
+	// Test editAgentConfig returns 405
+	t.Run("editAgentConfig", func(t *testing.T) {
+		reqBody := `{"filename":"pirate.yaml","agent_config":{"agents":{"root":{"description":"Modified"}}}}`
+		resp, err := http.Post(baseURL+"/api/agents/config", "application/json", strings.NewReader(reqBody))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode, "should return 405 for write operations on OCI refs")
+	})
+
+	// Test createAgent returns 405
+	t.Run("createAgent", func(t *testing.T) {
+		reqBody := `{"filename":"new-agent.yaml","name":"newagent","model":"openai/gpt-4o"}`
+		resp, err := http.Post(baseURL+"/api/agents", "application/json", strings.NewReader(reqBody))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode, "should return 405 for write operations on OCI refs")
+	})
+
+	// Test deleteAgent returns 405
+	t.Run("deleteAgent", func(t *testing.T) {
+		reqBody := `{"filename":"pirate.yaml"}`
+		req, err := http.NewRequest(http.MethodDelete, baseURL+"/api/agents", strings.NewReader(reqBody))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode, "should return 405 for write operations on OCI refs")
+	})
 }
 
 func prepareAgentsDir(t *testing.T, testFiles ...string) string {


### PR DESCRIPTION
When using an ociRef, there could be some issues when attempting to reload agents from the getAgents endpoint because we were not properly checking the set directory and agent path currently in use.

Solution:
- Guard api endpoints if no agent dir is available (when using ociRef, for example).
- Dont set agentsdir when using ociRefs to avoid erroneous reloading of all yaml files in a path
- Add some tests