### PR TITLE
Improve autocomplete ghost text visibility on dark theme (#870)

### DIFF
--- a/pkg/tui/styles/styles.go
+++ b/pkg/tui/styles/styles.go
@@ -57,6 +57,9 @@ const (
 	// Interactive element colors
 	ColorSelected = "#364A82" // Dark blue for selected items
 	ColorHover    = "#2D3F5F" // Slightly lighter than selected
+
+	// AutoCompleteGhost colors
+	ColorSuggestionGhost = "#6B6B6B"
 )
 
 // Chroma syntax highlighting colors (Monokai theme)
@@ -349,7 +352,8 @@ var (
 	}
 	EditorStyle = BaseStyle.Padding(2, 0, 0, 0)
 	// SuggestionGhostStyle renders inline auto-complete hints in a muted tone.
-	SuggestionGhostStyle = BaseStyle.Foreground(TextMuted)
+	// Use a distinct grey so suggestion text is visually separate from the user's input.
+	SuggestionGhostStyle = BaseStyle.Foreground(lipgloss.Color(ColorSuggestionGhost))
 )
 
 // Scrollbar


### PR DESCRIPTION
The current inline autocomplete “ghost text” is a bit hard to distinguish from the user’s actual input in the dark theme. This PR adjusts the ghost text color to a lighter grey so suggestions are easier to spot without changing the behavior.

What I changed

Updated SuggestionGhostStyle in pkg/tui/styles/styles.go

New color makes autocomplete hints clearer and more readable on dark backgrounds

No functional or behavioral changes — purely visual/UX

Testing

Ubuntu Terminal: suggestions appear with the updated lighter tone

WSL / Windows Terminal: ghost text displays correctly and stands out more clearly

Tested alongside the new newline-handling logic (#871) to make sure both features feel consistent

This should make autocomplete easier and more intuitive while keeping the overall theme intact.

Closes: #870

Signed-off-by: Rakesh S. <rakesh.s552004@gmail.com>