### PR TITLE
Remove the borders from the tool args and result

### DIFF
--- a/pkg/tui/styles/styles.go
+++ b/pkg/tui/styles/styles.go
@@ -321,17 +321,10 @@ var (
 				BorderForeground(BorderSecondary).
 				Background(BackgroundAlt)
 
-	ToolCallArgs = BaseStyle.
-			BorderLeft(true).
-			BorderStyle(lipgloss.RoundedBorder()).
-			BorderForeground(BorderSecondary)
+	ToolCallArgs   = BaseStyle
+	ToolCallResult = BaseStyle
 
 	ToolCallArgKey = BaseStyle.Bold(true).Foreground(TextSecondary)
-
-	ToolCallResult = BaseStyle.
-			BorderLeft(true).
-			BorderStyle(lipgloss.RoundedBorder()).
-			BorderForeground(BorderSecondary)
 
 	ToolCallResultKey = BaseStyle.
 				Bold(true).


### PR DESCRIPTION
It's not needed any more since we have one already

<img width="2168" height="1397" alt="Screenshot 2025-11-24 at 14 56 16" src="https://github.com/user-attachments/assets/38947f33-8186-4d96-8ae6-088ca99f8a7e" />

