### PR TITLE
Fix Title Length

### DIFF
--- a/e2e/testdata/cassettes/TestRuntime_Mistral_Basic.yaml
+++ b/e2e/testdata/cassettes/TestRuntime_Mistral_Basic.yaml
@@ -28,7 +28,7 @@ interactions:
     proto_minor: 1
     content_length: 0
     host: api.mistral.ai
-    body: "{\"messages\":[{\"content\":\"You are a helpful AI assistant that generates concise, descriptive titles for conversations. You will be given a conversation history and asked to create a title that captures the main topic.\",\"role\":\"system\"},{\"content\":\"Based on the following message a user sent to an AI assistant, generate a short, descriptive title (maximum 50 characters) that captures the main topic or purpose of the conversation. Return ONLY the title text, nothing else.\\n\\nUser message: What's 2+2?\\n\\n\",\"role\":\"user\"}],\"model\":\"mistral-small\",\"stream_options\":{\"include_usage\":true},\"stream\":true}"
+    body: "{\"messages\":[{\"content\":\"You are a helpful AI assistant that generates concise, descriptive titles for conversations. You will be given a conversation history and asked to create a title that captures the main topic.\",\"role\":\"system\"},{\"content\":\"Based on the following message a user sent to an AI assistant, generate a short, descriptive title (maximum 50 characters) that captures the main topic or purpose of the conversation. Return ONLY the title text, nothing else.\\n\\nUser message: What's 2+2?\\n\\n\",\"role\":\"user\"}],\"model\":\"mistral-small\",\"max_tokens\":100,\"stream_options\":{\"include_usage\":true},\"stream\":true}"
     url: https://api.mistral.ai/v1/chat/completions
     method: POST
   response:

--- a/e2e/testdata/cassettes/TestRuntime_OpenAI_Basic.yaml
+++ b/e2e/testdata/cassettes/TestRuntime_OpenAI_Basic.yaml
@@ -8,7 +8,7 @@ interactions:
     proto_minor: 1
     content_length: 0
     host: api.openai.com
-    body: "{\"messages\":[{\"content\":\"You are a helpful AI assistant that generates concise, descriptive titles for conversations. You will be given a conversation history and asked to create a title that captures the main topic.\",\"role\":\"system\"},{\"content\":\"Based on the following message a user sent to an AI assistant, generate a short, descriptive title (maximum 50 characters) that captures the main topic or purpose of the conversation. Return ONLY the title text, nothing else.\\n\\nUser message: What's 2+2?\\n\\n\",\"role\":\"user\"}],\"model\":\"gpt-3.5-turbo\",\"stream_options\":{\"include_usage\":true},\"stream\":true}"
+    body: "{\"messages\":[{\"content\":\"You are a helpful AI assistant that generates concise, descriptive titles for conversations. You will be given a conversation history and asked to create a title that captures the main topic.\",\"role\":\"system\"},{\"content\":\"Based on the following message a user sent to an AI assistant, generate a short, descriptive title (maximum 50 characters) that captures the main topic or purpose of the conversation. Return ONLY the title text, nothing else.\\n\\nUser message: What's 2+2?\\n\\n\",\"role\":\"user\"}],\"model\":\"gpt-3.5-turbo\",\"max_tokens\":100,\"stream_options\":{\"include_usage\":true},\"stream\":true}"
     url: https://api.openai.com/v1/chat/completions
     method: POST
   response:

--- a/pkg/model/provider/clone.go
+++ b/pkg/model/provider/clone.go
@@ -18,7 +18,18 @@ func CloneWithOptions(ctx context.Context, base Provider, opts ...options.Opt) P
 	mergedOpts := append(baseOpts, opts...)
 	mergedOpts = append(mergedOpts, options.WithGeneratingTitle())
 
-	clone, err := New(ctx, &config.ModelConfig, config.Env, mergedOpts...)
+	// Apply max_tokens override if present in options
+	// We need to apply it to the ModelConfig itself since that's what providers use
+	modelConfig := config.ModelConfig
+	for _, opt := range mergedOpts {
+		tempOpts := &options.ModelOptions{}
+		opt(tempOpts)
+		if maxTokens := tempOpts.MaxTokens(); maxTokens != nil {
+			modelConfig.MaxTokens = *maxTokens
+		}
+	}
+
+	clone, err := New(ctx, &modelConfig, config.Env, mergedOpts...)
 	if err != nil {
 		slog.Debug("Failed to clone provider; using base provider", "error", err, "id", base.ID())
 		return base

--- a/pkg/model/provider/options/options.go
+++ b/pkg/model/provider/options/options.go
@@ -8,6 +8,7 @@ type ModelOptions struct {
 	gateway          string
 	structuredOutput *latest.StructuredOutput
 	generatingTitle  bool
+	maxTokens        *int
 }
 
 func (c *ModelOptions) Gateway() string {
@@ -20,6 +21,10 @@ func (c *ModelOptions) StructuredOutput() *latest.StructuredOutput {
 
 func (c *ModelOptions) GeneratingTitle() bool {
 	return c.generatingTitle
+}
+
+func (c *ModelOptions) MaxTokens() *int {
+	return c.maxTokens
 }
 
 type Opt func(*ModelOptions)
@@ -42,6 +47,12 @@ func WithGeneratingTitle() Opt {
 	}
 }
 
+func WithMaxTokens(maxTokens int) Opt {
+	return func(cfg *ModelOptions) {
+		cfg.maxTokens = &maxTokens
+	}
+}
+
 // FromModelOptions converts a concrete ModelOptions value into a slice of
 // Opt configuration functions. Later Opts override earlier ones when applied.
 func FromModelOptions(m ModelOptions) []Opt {
@@ -54,6 +65,9 @@ func FromModelOptions(m ModelOptions) []Opt {
 	}
 	if m.generatingTitle {
 		out = append(out, WithGeneratingTitle())
+	}
+	if m.maxTokens != nil {
+		out = append(out, WithMaxTokens(*m.maxTokens))
 	}
 	return out
 }


### PR DESCRIPTION
## Fix Title Length

Ensures session titles are properly truncated to 50 characters maximum, sometimes the whole plan was being outputed in the title breaking the TUI completly

### Changes

• Added  MaxTokens  option to provider options (set to 100 for title generation) by @rumpl suggestion
• Implemented  truncateTitle()  function that truncates titles to 50 chars with ellipsis
• Updated title generation to apply truncation before setting session title
• Added comprehensive test coverage for title truncation edge cases

### Why

Prevents overly long session titles from breaking UI/UX constraints by enforcing a 50-character limit at the runtime level.