### PR TITLE
Add deferred tools

### DIFF
--- a/cagent-schema.json
+++ b/cagent-schema.json
@@ -432,6 +432,31 @@
           "type": "boolean",
           "description": "Whether to ignore VCS files (.git directories and .gitignore patterns) in filesystem operations. Default: true",
           "default": true
+        },
+        "defer": {
+          "description": "Enable deferred loading for tools in this toolset. Set to true to defer all tools, or an array of tool names to defer only those tools. Deferred tools are not loaded into the agent's context immediately, but can be discovered and loaded on-demand using search_tool and add_tool.",
+          "oneOf": [
+            {
+              "type": "boolean",
+              "description": "Set to true to defer all tools"
+            },
+            {
+              "type": "array",
+              "description": "Array of tool names to defer",
+              "items": {
+                "type": "string"
+              }
+            }
+          ],
+          "examples": [
+            true,
+            ["read_file", "write_file"]
+          ]
+        },
+        "timeout": {
+          "type": "integer",
+          "description": "Timeout in seconds for the fetch tool",
+          "minimum": 1
         }
       },
       "additionalProperties": false,

--- a/examples/deferred.yaml
+++ b/examples/deferred.yaml
@@ -1,0 +1,12 @@
+#!/usr/bin/env cagent run
+
+agents:
+  root:
+    model: openai/gpt-4o
+    description: Simple agent with filesystem access
+    instruction: Use the tools to help the user with filesystem operations.
+    toolsets:
+      - type: filesystem
+        defer: true
+      - type: shell
+        defer: true

--- a/pkg/tools/builtin/deferred.go
+++ b/pkg/tools/builtin/deferred.go
@@ -1,0 +1,228 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/docker/cagent/pkg/tools"
+)
+
+const (
+	ToolNameSearchTool = "search_tool"
+	ToolNameAddTool    = "add_tool"
+)
+
+type deferredToolEntry struct {
+	tool   tools.Tool
+	source tools.ToolSet
+}
+
+type DeferredToolset struct {
+	tools.ElicitationTool
+
+	mu             sync.RWMutex
+	deferredTools  map[string]deferredToolEntry
+	activatedTools map[string]tools.Tool
+	sources        []deferredSource
+}
+
+type deferredSource struct {
+	toolset  tools.ToolSet
+	deferAll bool
+	tools    []string
+}
+
+var _ tools.ToolSet = (*DeferredToolset)(nil)
+
+func NewDeferredToolset() *DeferredToolset {
+	return &DeferredToolset{
+		deferredTools:  make(map[string]deferredToolEntry),
+		activatedTools: make(map[string]tools.Tool),
+	}
+}
+
+func (d *DeferredToolset) AddSource(toolset tools.ToolSet, deferAll bool, toolNames []string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.sources = append(d.sources, deferredSource{
+		toolset:  toolset,
+		deferAll: deferAll,
+		tools:    toolNames,
+	})
+}
+
+func (d *DeferredToolset) HasSources() bool {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return len(d.sources) > 0
+}
+
+func (d *DeferredToolset) Instructions() string {
+	return `## Deferred Tool Loading
+
+This agent has access to additional tools that can be discovered and loaded on-demand.
+
+Use the search_tool to find available tools by name or description pattern.
+When searching a tool, prefer to search by action keywords (e.g., "remote", "read", "write") rather than specific tool names.
+Use single words to maximize matching results.
+
+Use the add_tool to activate a discovered tool for use.`
+}
+
+type SearchToolArgs struct {
+	Query string `json:"query" jsonschema:"Search query to find tools by name or description (case-insensitive)"`
+}
+
+type SearchToolResult struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type AddToolArgs struct {
+	Name string `json:"name" jsonschema:"The name of the tool to activate"`
+}
+
+func (d *DeferredToolset) handleSearchTool(ctx context.Context, toolCall tools.ToolCall) (*tools.ToolCallResult, error) {
+	var args SearchToolArgs
+	if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &args); err != nil {
+		return nil, fmt.Errorf("failed to parse arguments: %w", err)
+	}
+
+	query := strings.ToLower(args.Query)
+
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	var results []SearchToolResult
+	for name, entry := range d.deferredTools {
+		// Search in name and description
+		// TODO: fuzzy search? Levenshtein distance? Semantic search?
+		if strings.Contains(strings.ToLower(name), query) ||
+			strings.Contains(strings.ToLower(entry.tool.Description), query) {
+			results = append(results, SearchToolResult{
+				Name:        name,
+				Description: entry.tool.Description,
+			})
+		}
+	}
+
+	if len(results) == 0 {
+		return &tools.ToolCallResult{
+			Output: fmt.Sprintf("No deferred tools found matching '%s'", args.Query),
+		}, nil
+	}
+
+	output, err := json.MarshalIndent(results, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal results: %w", err)
+	}
+
+	return &tools.ToolCallResult{
+		Output: fmt.Sprintf("Found %d deferred tool(s):\n%s", len(results), string(output)),
+	}, nil
+}
+
+func (d *DeferredToolset) handleAddTool(ctx context.Context, toolCall tools.ToolCall) (*tools.ToolCallResult, error) {
+	var args AddToolArgs
+	if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &args); err != nil {
+		return nil, fmt.Errorf("failed to parse arguments: %w", err)
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if _, exists := d.activatedTools[args.Name]; exists {
+		return &tools.ToolCallResult{
+			Output: fmt.Sprintf("Tool '%s' is already active", args.Name),
+		}, nil
+	}
+
+	entry, exists := d.deferredTools[args.Name]
+	if !exists {
+		return &tools.ToolCallResult{
+			Output: fmt.Sprintf("Tool '%s' not found.", args.Name),
+		}, nil
+	}
+
+	delete(d.deferredTools, args.Name)
+	d.activatedTools[args.Name] = entry.tool
+
+	return &tools.ToolCallResult{
+		Output: fmt.Sprintf("Tool '%s' has been activated and is now available for use.\n\nDescription: %s", args.Name, entry.tool.Description),
+	}, nil
+}
+
+func (d *DeferredToolset) Tools(ctx context.Context) ([]tools.Tool, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	result := []tools.Tool{
+		{
+			Name:         ToolNameSearchTool,
+			Category:     "deferred",
+			Description:  "Search for available deferred tools by name or description. Use this to discover tools that can be activated.",
+			Parameters:   tools.MustSchemaFor[SearchToolArgs](),
+			OutputSchema: tools.MustSchemaFor[string](),
+			Handler:      d.handleSearchTool,
+			Annotations: tools.ToolAnnotations{
+				Title:        "Search Tool",
+				ReadOnlyHint: true,
+			},
+		},
+		{
+			Name:         ToolNameAddTool,
+			Category:     "deferred",
+			Description:  "Activate a deferred tool by name, making it available for use. Use search_tool first to find available tools.",
+			Parameters:   tools.MustSchemaFor[AddToolArgs](),
+			OutputSchema: tools.MustSchemaFor[string](),
+			Handler:      d.handleAddTool,
+			Annotations: tools.ToolAnnotations{
+				Title:        "Add Tool",
+				ReadOnlyHint: true,
+			},
+		},
+	}
+
+	for _, tool := range d.activatedTools {
+		result = append(result, tool)
+	}
+
+	return result, nil
+}
+
+func (d *DeferredToolset) Start(ctx context.Context) error {
+	// Note: we are not responsible for starting the underlying toolsets here
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	for _, source := range d.sources {
+		allTools, err := source.toolset.Tools(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to get tools from source: %w", err)
+		}
+
+		for _, tool := range allTools {
+			if !source.deferAll && !slices.Contains(source.tools, tool.Name) {
+				continue
+			}
+
+			if _, exists := d.deferredTools[tool.Name]; !exists {
+				d.deferredTools[tool.Name] = deferredToolEntry{
+					tool:   tool,
+					source: source.toolset,
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (d *DeferredToolset) Stop(ctx context.Context) error {
+	return nil
+}


### PR DESCRIPTION
A user can define a whole toolset or a subset of tools as deferred, when this is the case, we add two tools, one for searching tools and the second one for addinf the tool to the context.