### PR TITLE
Don't reconfigure dmr model when generating a title

### DIFF
--- a/pkg/model/provider/clone.go
+++ b/pkg/model/provider/clone.go
@@ -16,7 +16,6 @@ func CloneWithOptions(ctx context.Context, base Provider, opts ...options.Opt) P
 	// Preserve existing options, then apply overrides. Later opts take precedence.
 	baseOpts := options.FromModelOptions(config.ModelOptions)
 	mergedOpts := append(baseOpts, opts...)
-	mergedOpts = append(mergedOpts, options.WithGeneratingTitle())
 
 	// Apply max_tokens override if present in options
 	// We need to apply it to the ModelConfig itself since that's what providers use

--- a/pkg/model/provider/dmr/client.go
+++ b/pkg/model/provider/dmr/client.go
@@ -94,8 +94,12 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, opts ...options.Opt
 		slog.Warn(w)
 	}
 	slog.Debug("DMR provider_opts parsed", "model", cfg.Model, "context_size", contextSize, "runtime_flags", finalFlags, "speculative_opts", specOpts, "engine", engine)
-	if err := configureDockerModel(ctx, cfg.Model, contextSize, finalFlags, specOpts); err != nil {
-		slog.Debug("docker model configure skipped or failed", "error", err)
+	// Skip model configuration when generating titles to avoid reconfiguring the model
+	// with different settings (e.g., smaller max_tokens) that would affect the main agent.
+	if !globalOptions.GeneratingTitle() {
+		if err := configureDockerModel(ctx, cfg.Model, contextSize, finalFlags, specOpts); err != nil {
+			slog.Debug("docker model configure skipped or failed", "error", err)
+		}
 	}
 
 	slog.Debug("DMR client created successfully", "model", cfg.Model, "base_url", baseURL)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1418,7 +1418,13 @@ func (r *LocalRuntime) generateSessionTitle(ctx context.Context, sess *session.S
 	systemPrompt := "You are a helpful AI assistant that generates concise, descriptive titles for conversations. You will be given a conversation history and asked to create a title that captures the main topic."
 	userPrompt := fmt.Sprintf("Based on the following message a user sent to an AI assistant, generate a short, descriptive title (maximum 50 characters) that captures the main topic or purpose of the conversation. Return ONLY the title text, nothing else.\n\nUser message: %s\n\n", firstUserMessage)
 
-	titleModel := provider.CloneWithOptions(ctx, r.CurrentAgent().Model(), options.WithStructuredOutput(nil), options.WithMaxTokens(100))
+	titleModel := provider.CloneWithOptions(
+		ctx,
+		r.CurrentAgent().Model(),
+		options.WithStructuredOutput(nil),
+		options.WithMaxTokens(100),
+		options.WithGeneratingTitle(),
+	)
 	newTeam := team.New(
 		team.WithID("title-generator"),
 		team.WithAgents(agent.New("root", systemPrompt, agent.WithModel(titleModel))),


### PR DESCRIPTION
This is mainly because we currently have to call `docker model configure ...` before calling the inference endpoint to make sure a model has been configured correctly on the DMR side of things. The generated title gets truncated anyway so this shouldn't have major side-effects for DMR users