### PR TITLE
Make rag tool configurable

### DIFF
--- a/cagent-schema.json
+++ b/cagent-schema.json
@@ -683,9 +683,24 @@
       "type": "object",
       "description": "RAG (Retrieval-Augmented Generation) configuration for document search and retrieval with pluggable strategies. Multiple strategies enable hybrid retrieval and reranking.",
       "properties": {
-        "description": {
-          "type": "string",
-          "description": "Description of the RAG source"
+        "tool": {
+          "type": "object",
+          "description": "Tool configuration for the RAG source",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Custom name for the tool (defaults to RAG source name if not specified)"
+            },
+            "description": {
+              "type": "string",
+              "description": "Description of what the tool does (shown to the LLM when selecting tools)"
+            },
+            "instruction": {
+              "type": "string",
+              "description": "Instruction on how the RAG tool should be used effectively (shown in system prompt)"
+            }
+          },
+          "additionalProperties": false
         },
         "docs": {
           "type": "array",
@@ -709,8 +724,8 @@
                 "type": "string",
                 "description": "Retrieval strategy type",
                 "enum": [
-                  "chunked-embeddings",
-                  "bm25"
+                  "bm25",
+                  "chunked-embeddings"
                 ]
               },
               "model": {

--- a/examples/rag.yaml
+++ b/examples/rag.yaml
@@ -18,7 +18,8 @@ models:
 
 rag:
   blork_knowledge_base:
-    description: documents about the blorks
+    tool:
+      description: documents about the blorks
     docs:
       - ./rag/docs
       - ./rag/blork_field_guide.txt

--- a/examples/rag/bm25.yaml
+++ b/examples/rag/bm25.yaml
@@ -10,7 +10,8 @@ agents:
 
 rag:
   blork_knowledge_base:
-    description: keyword-based search for blork documents
+    tool:
+      description: keyword-based search for blork documents
     docs:
       - ./docs
       - ./blork_field_guide.txt

--- a/examples/rag/hybrid.yaml
+++ b/examples/rag/hybrid.yaml
@@ -18,10 +18,10 @@ agents:
 
 rag:
   knowledge_base:
-    description: to be used to search for information about blorks
+    tool: 
+      description: to be used to search for information about blorks
     docs:
       - ./blork_field_guide.txt   # Shared across both strategies
-
     strategies:
       # Chunked embeddings strategy for semantic search
       - type: chunked-embeddings
@@ -39,7 +39,6 @@ rag:
           size: 1000
           overlap: 100
           respect_word_boundaries: true
-      
       # BM25 strategy for keyword matching
       - type: bm25
         docs:
@@ -53,7 +52,6 @@ rag:
           size: 1000
           overlap: 100
           respect_word_boundaries: true
-
     # Results fusion and limiting
     results:
       fusion:                          # Configures how to combine the results from the different strategies

--- a/examples/rag/reranking.yaml
+++ b/examples/rag/reranking.yaml
@@ -23,7 +23,8 @@ agents:
 
 rag:
   knowledge_base:
-    description: to be used to search for information about blorks
+    tool:
+      description: to be used to search for information about blorks
     docs:
       - ./docs
       - ./blork_field_guide.txt

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -299,13 +299,20 @@ type StructuredOutput struct {
 	Strict bool `json:"strict,omitempty"`
 }
 
+// RAGToolConfig represents tool-specific configuration for a RAG source
+type RAGToolConfig struct {
+	Name        string `json:"name,omitempty"`        // Custom name for the tool (defaults to RAG source name if empty)
+	Description string `json:"description,omitempty"` // Tool description (what the tool does)
+	Instruction string `json:"instruction,omitempty"` // Tool instruction (how to use the tool effectively)
+}
+
 // RAGConfig represents a RAG (Retrieval-Augmented Generation) configuration
 // Uses a unified strategies array for flexible, extensible configuration
 type RAGConfig struct {
-	Description string              `json:"description,omitempty"`
-	Docs        []string            `json:"docs,omitempty"`       // Shared documents across all strategies
-	Strategies  []RAGStrategyConfig `json:"strategies,omitempty"` // Array of strategy configurations
-	Results     RAGResultsConfig    `json:"results,omitempty"`
+	Tool       RAGToolConfig       `json:"tool,omitempty"`       // Tool configuration
+	Docs       []string            `json:"docs,omitempty"`       // Shared documents across all strategies
+	Strategies []RAGStrategyConfig `json:"strategies,omitempty"` // Array of strategy configurations
+	Results    RAGResultsConfig    `json:"results,omitempty"`
 }
 
 // RAGStrategyConfig represents a single retrieval strategy configuration

--- a/pkg/rag/builder.go
+++ b/pkg/rag/builder.go
@@ -116,7 +116,11 @@ func buildManagerConfig(
 	fusionCfg := buildManagerFusionConfig(ragCfg, strategyConfigs)
 
 	return Config{
-		Description:     ragCfg.Description,
+		Tool: ToolConfig{
+			Name:        ragCfg.Tool.Name,
+			Description: ragCfg.Tool.Description,
+			Instruction: ragCfg.Tool.Instruction,
+		},
 		Docs:            GetAbsolutePaths(buildCfg.ParentDir, ragCfg.Docs),
 		Results:         results,
 		FusionConfig:    fusionCfg,


### PR DESCRIPTION
This allows users to define tool name, description and the instructions to inject into the system prompt on their rag source configuration