### PR TITLE
Auto adjust max_tokens for anthropic models

### DIFF
--- a/pkg/model/provider/anthropic/beta_client.go
+++ b/pkg/model/provider/anthropic/beta_client.go
@@ -27,6 +27,11 @@ func (c *Client) createBetaStream(
 	requestTools []tools.Tool,
 	maxTokens int64,
 ) (chat.MessageStream, error) {
+	maxTokens, err := c.adjustMaxTokensForThinking(maxTokens)
+	if err != nil {
+		return nil, err
+	}
+
 	allTools, err := convertBetaTools(requestTools)
 	if err != nil {
 		slog.Error("Failed to convert tools for Anthropic Beta request", "error", err)


### PR DESCRIPTION
Auto adjust max_tokens for anthropic models  to `thinking_budget + 8192` if the user only provides a thinking_budget

Error out if the user provides both values and thinking_budget < max_tokens

Avoids silently not applying the thinking configuration because the max_tokens value is too small