### PR TITLE
RAG: Semantic embeddings strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ See [MCP Mode documentation](./docs/MCP-MODE.md) for detailed instructions on ex
 - **💭 Advanced reasoning** - Built-in "think", "todo" and "memory" tools for
   complex problem-solving.
 - **🔍 RAG (Retrieval-Augmented Generation)** - Pluggable retrieval strategies
-  (chunked_embeddings, BM25, more to come..) with hybrid retrieval, fusion, and result reranking support.
+  (BM25, chunked-embeddings, semantic-embeddings) with hybrid retrieval, result fusion and reranking support.
 - **🌐 Multiple AI providers** - Support for OpenAI, Anthropic, Gemini, xAI,
   Mistral, Nebius and [Docker Model
   Runner](https://docs.docker.com/ai/model-runner/).
@@ -369,7 +369,7 @@ agents:
 ```
 
 **Features:**
-- **Multiple strategies**: Vector (semantic), BM25 (keyword), or both
+- **Multiple strategies**: Vector embeddings, semantic embeddings, BM25 (keyword), or combinations
 - **Parallel execution**: Strategies run concurrently for fast results
 - **Pluggable fusion**: RRF, weighted, or max score combining
 - **Result reranking**: Re-score results with specialized models for improved relevance

--- a/cagent-schema.json
+++ b/cagent-schema.json
@@ -725,12 +725,13 @@
                 "description": "Retrieval strategy type",
                 "enum": [
                   "bm25",
-                  "chunked-embeddings"
+                  "chunked-embeddings",
+                  "semantic-embeddings"
                 ]
               },
               "embedding_model": {
                 "type": "string",
-                "description": "Embedding model reference for chunked-embeddings strategies (looked up in models map, or 'auto' for automatic selection)",
+                "description": "Embedding model reference for chunked-embeddings and semantic-embeddings strategies (looked up in models map, or 'auto' for automatic selection)",
                 "examples": [
                   "openai/text-embedding-3-small",
                   "dmr/embeddinggemma",
@@ -811,6 +812,41 @@
                   }
                 },
                 "additionalProperties": false
+              },
+              "embedding_batch_size": {
+                "type": "integer",
+                "description": "Number of text chunks to send to the embedding API in a single request (chunked-embeddings/semantic-embeddings only)",
+                "minimum": 1,
+                "default": 50
+              },
+              "max_embedding_concurrency": {
+                "type": "integer",
+                "description": "Maximum concurrent embedding batch API requests. For semantic-embeddings, also controls parallel LLM calls for generating chunk summaries.",
+                "minimum": 1,
+                "default": 3
+              },
+              "max_indexing_concurrency": {
+                "type": "integer",
+                "description": "Maximum number of files to index in parallel during initialization",
+                "minimum": 1,
+                "default": 3
+              },
+              "chat_model": {
+                "type": "string",
+                "description": "Chat model used to generate semantic representations for each chunk (semantic-embeddings only, required)",
+                "examples": [
+                  "anthropic/claude-sonnet-4-5",
+                  "openai/gpt-4o-mini"
+                ]
+              },
+              "semantic_prompt": {
+                "type": "string",
+                "description": "Custom prompt template for semantic LLM. Uses JavaScript template literal syntax with the following placeholders: ${path} (full source file path), ${basename} (base name of file), ${chunk_index} (numeric chunk index), ${content} (raw chunk content), ${ast_context} (AST metadata when ast_context is enabled). Only applicable to semantic-embeddings strategy."
+              },
+              "ast_context": {
+                "type": "boolean",
+                "description": "Include TreeSitter-derived AST metadata in the semantic prompt (semantic-embeddings only, requires chunking.code_aware for best results)",
+                "default": false
               }
             },
             "additionalProperties": true

--- a/examples/rag/semantic_embeddings.yaml
+++ b/examples/rag/semantic_embeddings.yaml
@@ -1,0 +1,97 @@
+# This example demonstrates the semantic-embeddings RAG strategy.
+#
+# Unlike chunked-embeddings which embeds raw text chunks directly,
+# semantic-embeddings uses an LLM to generate semantic summaries of each
+# chunk before embedding. This captures the meaning/purpose of code,
+# making retrieval more semantic than direct chunk embedding.
+#
+# Trade-offs:
+# - Higher quality retrieval for code and structured content
+# - Slower indexing (requires LLM call per chunk)
+# - Additional cost from semantic model API calls
+
+agents:
+  root:
+    model: openai/gpt-4o
+    description: assistant with semantic code search
+    instruction: |
+      You are a helpful coding assistant with access to semantic code search.
+      Use the search tool to find relevant code based on meaning, not just keywords.
+    rag:
+      - codebase
+
+rag:
+  codebase:
+    tool:
+      description: Search the codebase for relevant code snippets by semantic meaning
+    docs:
+      - ../../pkg/**/*.go
+      - ../../cmd/**/*.go
+    strategies:
+      - type: semantic-embeddings
+        # Required: embedding model for vector similarity
+        embedding_model: openai/text-embedding-3-small
+        vector_dimensions: 1536
+
+        # Required: chat model to generate semantic summaries of each chunk
+        chat_model: openai/gpt-4o-mini
+        
+        # Custom prompt template for generating semantic summaries during indexing.
+        # Uses JS template literal syntax with these placeholders:
+        #   ${path}        - full source file path
+        #   ${basename}    - base name of the source file
+        #   ${chunk_index} - numeric index of the chunk
+        #   ${content}     - raw chunk content
+        #   ${ast_context} - formatted AST metadata (when ast_context: true)
+        semantic_prompt: |
+          You are summarizing source code for semantic search.
+
+          File: ${basename}
+          ${ast_context}
+
+          ```
+          ${content}
+          ```
+
+          In 2-4 sentences, explain what this code does. Be specific:
+          - Name exact functions, types, and methods
+          - Mention key dependencies or libraries used
+          - Describe inputs, outputs, and notable behavior
+
+        # Optional: database path (defaults to auto-generated name)
+        database: ./semantic_embeddings.db
+
+        # Optional: similarity settings
+        similarity_metric: cosine_similarity
+        threshold: 0.3
+        limit: 10
+
+        # Optional: performance tuning
+        embedding_batch_size: 50        # chunks per embedding API call
+        max_embedding_concurrency: 3    # parallel embedding/LLM requests
+        max_indexing_concurrency: 3     # parallel file indexing
+
+        # Optional: include AST metadata in semantic prompt (best with code_aware chunking)
+        ast_context: true
+
+        # Optional: chunking configuration
+        chunking:
+          size: 1000
+          respect_word_boundaries: true
+          code_aware: true  # Use tree-sitter for AST-aware chunking
+
+    results:
+      # Optional: rerank results using an LLM for better relevance
+      reranking:
+        model: openai/gpt-4o-mini
+        threshold: 0.3
+        # Custom criteria to guide the reranking model's relevance scoring
+        criteria: |
+          When scoring relevance, prioritize:
+          - Code that directly implements the queried functionality
+          - Functions and methods over comments or documentation
+          - Complete implementations over partial snippets
+      deduplicate: true
+      return_full_content: false # return full document content instead of just the matched chunks
+      limit: 5
+

--- a/pkg/rag/strategy/semantic_embeddings.go
+++ b/pkg/rag/strategy/semantic_embeddings.go
@@ -1,0 +1,523 @@
+package strategy
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/docker/cagent/pkg/chat"
+	"github.com/docker/cagent/pkg/config/latest"
+	"github.com/docker/cagent/pkg/js"
+	"github.com/docker/cagent/pkg/model/provider"
+	"github.com/docker/cagent/pkg/model/provider/options"
+	"github.com/docker/cagent/pkg/rag/chunk"
+	"github.com/docker/cagent/pkg/rag/types"
+	"github.com/docker/cagent/pkg/tools"
+)
+
+// NewSemanticEmbeddingsFromConfig creates a semantic-embeddings strategy from configuration.
+//
+// This strategy uses an LLM to generate semantic summaries of each chunk before embedding.
+// The summaries capture the meaning/purpose of the code, making retrieval more semantic
+// than direct chunk embedding.
+//
+// Configuration (in RAGStrategyConfig.Params):
+//
+//   - embedding_model (string, required): embedding model name (same as chunked-embeddings)
+//   - chat_model (string, required): chat model used to generate semantic
+//     representations for each chunk (e.g., "anthropic/claude-sonnet-4-5")
+//   - vector_dimensions (int, required): embedding vector dimensions
+//   - semantic_prompt (string, optional): prompt template for the semantic LLM
+//   - ast_context (bool, optional): when true, include TreeSitter-derived AST
+//     metadata in the semantic prompt (requires chunking.code_aware for best results)
+//   - similarity_metric (string, optional): "cosine_similarity" (default) or "euclidean"
+//   - threshold (float, optional): minimum similarity score (default: 0.5)
+//   - embedding_batch_size (int, optional): batch size for embedding calls (default: 50)
+//   - max_embedding_concurrency (int, optional): parallel embedding/LLM calls (default: 3)
+//   - max_indexing_concurrency (int, optional): parallel file indexing (default: 3)
+//
+// # Template Placeholders
+//
+// Templates use JavaScript template literal syntax (${variable}). The following
+// placeholders are available:
+//
+//   - ${path}         - full source file path
+//   - ${basename}     - base name of the source file
+//   - ${chunk_index}  - numeric index of the chunk
+//   - ${content}      - raw chunk content
+//   - ${ast_context}  - formatted AST metadata (empty when unavailable)
+//
+// If semantic_prompt is omitted, a sensible default is used.
+func NewSemanticEmbeddingsFromConfig(ctx context.Context, cfg latest.RAGStrategyConfig, buildCtx BuildContext, events chan<- types.Event) (*Config, error) {
+	const strategyName = "semantic-embeddings"
+
+	// Extract required embedding model parameter
+	embeddingModelName := GetParam(cfg.Params, "embedding_model", "")
+	if embeddingModelName == "" {
+		return nil, fmt.Errorf("'embedding_model' parameter required for %s strategy", strategyName)
+	}
+
+	// Extract required chat model parameter
+	chatModelName := GetParam(cfg.Params, "chat_model", "")
+	if strings.TrimSpace(chatModelName) == "" {
+		return nil, fmt.Errorf("'chat_model' parameter required for %s strategy", strategyName)
+	}
+
+	// vector_dimensions is required
+	vectorDimensionsPtr := GetParamPtr[int](cfg.Params, "vector_dimensions")
+	if vectorDimensionsPtr == nil {
+		return nil, fmt.Errorf("'vector_dimensions' parameter required for %s strategy", strategyName)
+	}
+	vectorDimensions := *vectorDimensionsPtr
+
+	// Create embedding provider
+	embeddingCfg, err := CreateEmbeddingProvider(ctx, embeddingModelName, buildCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create chat model provider
+	chatModelCfg, err := ResolveModelConfig(chatModelName, buildCtx.Models)
+	if err != nil {
+		return nil, fmt.Errorf("invalid chat_model %q: %w", chatModelName, err)
+	}
+
+	chatProvider, err := provider.New(ctx, &chatModelCfg, buildCtx.Env,
+		options.WithGateway(buildCtx.ModelsGateway))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create chat model provider: %w", err)
+	}
+
+	chatModelID := chatProvider.ID()
+	if chatModelID == "" && chatModelCfg.Provider != "" && chatModelCfg.Model != "" {
+		chatModelID = fmt.Sprintf("%s/%s", chatModelCfg.Provider, chatModelCfg.Model)
+	}
+
+	// Get optional parameters with defaults
+	similarityMetric := GetParam(cfg.Params, "similarity_metric", "cosine_similarity")
+	threshold := GetParam(cfg.Params, "threshold", 0.5)
+	if thresholdPtr := GetParamPtr[float64](cfg.Params, "threshold"); thresholdPtr != nil {
+		threshold = *thresholdPtr
+	}
+
+	batchSize := GetParam(cfg.Params, "embedding_batch_size", 50)
+	maxConcurrency := GetParam(cfg.Params, "max_embedding_concurrency", 3)
+	fileIndexConcurrency := GetParam(cfg.Params, "max_indexing_concurrency", 3)
+
+	// Read optional semantic_prompt and ast_context parameters
+	semanticPrompt := GetParam(cfg.Params, "semantic_prompt", defaultSemanticPrompt())
+	useASTContext := GetParam(cfg.Params, "ast_context", false)
+	if useASTContext && !cfg.Chunking.CodeAware {
+		slog.Warn("semantic-embeddings ast_context is enabled but chunking.code_aware is false; AST metadata may be unavailable",
+			"rag", buildCtx.RAGName)
+	}
+
+	// Merge document paths
+	docs := MergeDocPaths(buildCtx.SharedDocs, cfg.Docs, buildCtx.ParentDir)
+
+	// Resolve database path
+	dbPath, err := ResolveDatabasePath(cfg.Database, buildCtx.ParentDir,
+		fmt.Sprintf("rag_%s_semantic_embeddings.db", buildCtx.RAGName))
+	if err != nil {
+		return nil, fmt.Errorf("invalid database config: %w", err)
+	}
+
+	// Create semantic vector database (includes embedding_input column for debugging)
+	db, err := newSemanticVectorDB(dbPath, vectorDimensions, strategyName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create database: %w", err)
+	}
+
+	// Create embedder
+	embedder := CreateEmbedder(embeddingCfg.Provider, batchSize, maxConcurrency)
+
+	// Set default limit if not provided
+	limit := cfg.Limit
+	if limit == 0 {
+		limit = 5
+	}
+
+	// Parse chunking configuration
+	chunkingCfg := ParseChunkingConfig(cfg)
+
+	// Create vector store
+	store := NewVectorStore(VectorStoreConfig{
+		Name:                 strategyName,
+		Database:             db,
+		Embedder:             embedder,
+		Events:               events,
+		SimilarityMetric:     similarityMetric,
+		ModelID:              embeddingCfg.ModelID,
+		ModelsStore:          embeddingCfg.ModelsStore,
+		EmbeddingConcurrency: maxConcurrency,
+		FileIndexConcurrency: fileIndexConcurrency,
+		Chunking:             chunkingCfg,
+	})
+
+	// Create usage tracker for chat LLM calls
+	usageTracker := func(ctx context.Context, usage *chat.Usage) {
+		if usage == nil {
+			return
+		}
+
+		totalTokens := usage.InputTokens +
+			usage.OutputTokens +
+			usage.ReasoningTokens +
+			usage.CachedInputTokens +
+			usage.CacheWriteTokens
+		if totalTokens == 0 {
+			return
+		}
+
+		cost := calculateSemanticUsageCost(ctx, embeddingCfg.ModelsStore, chatModelID, usage)
+		store.RecordUsage(totalTokens, cost)
+	}
+
+	// Configure the embedding input builder to use the chat LLM
+	store.SetEmbeddingInputBuilder(newLLMSemanticEmbeddingBuilder(
+		chatProvider, semanticPrompt, usageTracker, useASTContext))
+
+	return &Config{
+		Name:      strategyName,
+		Strategy:  store,
+		Docs:      docs,
+		Limit:     limit,
+		Threshold: threshold,
+		Chunking:  chunkingCfg,
+	}, nil
+}
+
+// defaultSemanticPrompt returns the default prompt template used to generate
+// semantic summaries for code chunks.
+func defaultSemanticPrompt() string {
+	return `You are summarizing source code for semantic search and RAG.
+
+File path: ${path}
+Chunk index: ${chunk_index}
+${ast_context}
+
+` + "```" + `
+${content}
+` + "```" + `
+
+In 2-4 sentences, explain what this code does. Be specific about identifiers:
+- Name the exact functions, types, and methods involved
+- Mention key dependencies or libraries used (e.g., "uses yaml.Strict()", "calls http.Get()")
+- Describe inputs, outputs, and notable behavior
+
+Don't paraphrase - say "Parse() unmarshals YAML into Config" not "parses data into a struct".
+Include error handling patterns and edge cases if present.`
+}
+
+// llmSemanticEmbeddingBuilder uses a chat model to generate a semantic summary
+// for each chunk before it is embedded.
+type llmSemanticEmbeddingBuilder struct {
+	provider     provider.Provider
+	prompt       string
+	usageTracker func(ctx context.Context, usage *chat.Usage)
+	astContext   bool
+}
+
+// newLLMSemanticEmbeddingBuilder creates a new embedding input builder that
+// calls the given provider with the configured prompt template.
+func newLLMSemanticEmbeddingBuilder(
+	p provider.Provider,
+	prompt string,
+	usageTracker func(ctx context.Context, usage *chat.Usage),
+	astContext bool,
+) EmbeddingInputBuilder {
+	return &llmSemanticEmbeddingBuilder{
+		provider:     p,
+		prompt:       prompt,
+		usageTracker: usageTracker,
+		astContext:   astContext,
+	}
+}
+
+func (b *llmSemanticEmbeddingBuilder) BuildEmbeddingInput(ctx context.Context, sourcePath string, ch chunk.Chunk) (string, error) {
+	// Fill in the prompt template with code-specific context
+	astContext := ""
+	if b.astContext {
+		astContext = formatASTContext(ch.Metadata)
+	}
+
+	t, err := js.ExpandString(ctx, b.prompt, map[string]string{
+		"path":        sourcePath,
+		"basename":    filepath.Base(sourcePath),
+		"chunk_index": fmt.Sprintf("%d", ch.Index),
+		"content":     ch.Content,
+		"ast_context": astContext,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to expand prompt template: %w", err)
+	}
+
+	messages := []chat.Message{
+		{
+			Role:    chat.MessageRoleUser,
+			Content: t,
+		},
+	}
+
+	stream, err := b.provider.CreateChatCompletionStream(ctx, messages, []tools.Tool{})
+	if err != nil {
+		return "", fmt.Errorf("failed to start semantic generation: %w", err)
+	}
+	defer stream.Close()
+
+	var (
+		sb    strings.Builder
+		usage *chat.Usage
+	)
+
+	for {
+		resp, err := stream.Recv()
+		if err != nil {
+			break
+		}
+
+		if resp.Usage != nil {
+			usage = resp.Usage
+		}
+
+		for _, choice := range resp.Choices {
+			if choice.Delta.Content != "" {
+				sb.WriteString(choice.Delta.Content)
+			}
+		}
+	}
+
+	summary := strings.TrimSpace(sb.String())
+
+	if usage != nil && b.usageTracker != nil {
+		b.usageTracker(ctx, usage)
+	}
+
+	// Maximum length for embedding input to stay within model limits.
+	const maxEmbeddingInputLength = 2000
+
+	if summary == "" {
+		// If the semantic model returns no content, fall back to truncated chunk
+		slog.Warn("Semantic model returned empty summary; falling back to truncated chunk content",
+			"path", sourcePath,
+			"chunk_index", ch.Index,
+			"original_length", len(ch.Content))
+
+		fallback := ch.Content
+		if len(fallback) > maxEmbeddingInputLength {
+			fallback = fallback[:maxEmbeddingInputLength] + "..."
+			slog.Debug("Truncated fallback content to fit embedding model limits",
+				"original_length", len(ch.Content),
+				"truncated_length", len(fallback))
+		}
+		return fallback, nil
+	}
+
+	// Build the final embedding input by prepending structured metadata to the summary.
+	// This ensures that key identifiers (function names, packages, signatures) are present
+	// in the embedding, improving retrieval for queries that use code identifiers.
+	embeddingInput := buildEmbeddingInputWithMetadata(sourcePath, ch.Metadata, summary)
+
+	// Truncate if embedding input is unexpectedly long
+	if len(embeddingInput) > maxEmbeddingInputLength {
+		slog.Warn("Semantic embedding input exceeds model limits; truncating",
+			"path", sourcePath,
+			"chunk_index", ch.Index,
+			"original_length", len(embeddingInput),
+			"truncated_length", maxEmbeddingInputLength)
+		embeddingInput = embeddingInput[:maxEmbeddingInputLength] + "..."
+	}
+
+	slog.Debug("Generated semantic embedding input for chunk",
+		"path", sourcePath,
+		"chunk_index", ch.Index,
+		"embedding_input", embeddingInput)
+
+	return embeddingInput, nil
+}
+
+// buildEmbeddingInputWithMetadata constructs the final text to be embedded by
+// prepending structured metadata to the LLM-generated summary. This hybrid approach
+// ensures that:
+//  1. Key identifiers (function names, packages, signatures) are present verbatim
+//     for better keyword matching
+//  2. The semantic summary provides conceptual understanding for similarity search
+//
+// Example output:
+//
+//	File: pkg/config/parser.go
+//	Function: Parse (function)
+//	Package: config
+//	Signature: func Parse(data []byte) (*Config, error)
+//
+//	This function parses YAML-formatted byte data into a Config struct...
+func buildEmbeddingInputWithMetadata(sourcePath string, metadata map[string]string, summary string) string {
+	var sb strings.Builder
+
+	// Always include the file path for context
+	sb.WriteString("File: ")
+	sb.WriteString(sourcePath)
+	sb.WriteString("\n")
+
+	// Add symbol name and kind if available
+	if name := metadata["symbol_name"]; name != "" {
+		sb.WriteString("Function: ")
+		sb.WriteString(name)
+		if kind := metadata["symbol_kind"]; kind != "" {
+			sb.WriteString(" (")
+			sb.WriteString(kind)
+			sb.WriteString(")")
+		}
+		sb.WriteString("\n")
+	}
+
+	// Add receiver for methods
+	if receiver := metadata["receiver"]; receiver != "" {
+		sb.WriteString("Receiver: ")
+		sb.WriteString(receiver)
+		sb.WriteString("\n")
+	}
+
+	// Add package name
+	if pkg := metadata["package"]; pkg != "" {
+		sb.WriteString("Package: ")
+		sb.WriteString(pkg)
+		sb.WriteString("\n")
+	}
+
+	// Add signature - this is crucial for matching function signatures
+	if sig := metadata["signature"]; sig != "" {
+		sb.WriteString("Signature: ")
+		sb.WriteString(sig)
+		sb.WriteString("\n")
+	}
+
+	// Add any additional symbols in the chunk
+	if additional := metadata["additional_symbols"]; additional != "" {
+		sb.WriteString("Also contains: ")
+		sb.WriteString(additional)
+		sb.WriteString("\n")
+	}
+
+	// Add blank line before summary
+	sb.WriteString("\n")
+	sb.WriteString(summary)
+
+	return sb.String()
+}
+
+// formatASTContext formats chunk metadata as human-readable AST context.
+func formatASTContext(metadata map[string]string) string {
+	if len(metadata) == 0 {
+		return ""
+	}
+
+	type keyLabel struct {
+		key   string
+		label string
+	}
+
+	keyOrder := []keyLabel{
+		{key: "symbol_name", label: "Symbol"},
+		{key: "symbol_kind", label: "Kind"},
+		{key: "receiver", label: "Receiver"},
+		{key: "signature", label: "Signature"},
+		{key: "doc", label: "Doc"},
+		{key: "package", label: "Package"},
+		{key: "start_line", label: "Start line"},
+		{key: "end_line", label: "End line"},
+		{key: "additional_symbols", label: "Additional symbols"},
+		{key: "symbol_count", label: "Symbol count"},
+	}
+
+	const maxLines = 8
+	lines := make([]string, 0, maxLines)
+	used := make(map[string]bool, len(keyOrder))
+
+	for _, entry := range keyOrder {
+		value := strings.TrimSpace(metadata[entry.key])
+		if value == "" {
+			continue
+		}
+		lines = append(lines, fmt.Sprintf("- %s: %s", entry.label, value))
+		used[entry.key] = true
+		if len(lines) >= maxLines {
+			break
+		}
+	}
+
+	if len(lines) < maxLines {
+		extraKeys := make([]string, 0, len(metadata))
+		for key := range metadata {
+			if used[key] {
+				continue
+			}
+			extraKeys = append(extraKeys, key)
+		}
+
+		sort.Strings(extraKeys)
+		for _, key := range extraKeys {
+			value := strings.TrimSpace(metadata[key])
+			if value == "" {
+				continue
+			}
+			lines = append(lines, fmt.Sprintf("- %s: %s", humanizeMetadataKey(key), value))
+			if len(lines) >= maxLines {
+				break
+			}
+		}
+	}
+
+	if len(lines) == 0 {
+		return ""
+	}
+
+	return "AST context:\n" + strings.Join(lines, "\n")
+}
+
+// humanizeMetadataKey converts snake_case keys to Title Case.
+func humanizeMetadataKey(key string) string {
+	parts := strings.Split(key, "_")
+	for i, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		lower := strings.ToLower(part)
+		if len(lower) == 1 {
+			parts[i] = strings.ToUpper(lower)
+			continue
+		}
+		parts[i] = strings.ToUpper(lower[:1]) + lower[1:]
+	}
+	return strings.Join(parts, " ")
+}
+
+// calculateSemanticUsageCost calculates cost for semantic LLM usage.
+func calculateSemanticUsageCost(ctx context.Context, modelsStore modelStore, modelID string, usage *chat.Usage) float64 {
+	if usage == nil || modelsStore == nil || modelID == "" || strings.HasPrefix(modelID, "dmr/") {
+		return 0
+	}
+
+	model, err := modelsStore.GetModel(ctx, modelID)
+	if err != nil {
+		slog.Debug("Failed to get semantic model pricing from models.dev, cost will be 0",
+			"model_id", modelID,
+			"error", err)
+		return 0
+	}
+
+	if model.Cost == nil {
+		return 0
+	}
+
+	inputCost := float64(usage.InputTokens) * model.Cost.Input
+	outputCost := float64(usage.OutputTokens+usage.ReasoningTokens) * model.Cost.Output
+	cacheReadCost := float64(usage.CachedInputTokens) * model.Cost.CacheRead
+	cacheWriteCost := float64(usage.CacheWriteTokens) * model.Cost.CacheWrite
+
+	return (inputCost + outputCost + cacheReadCost + cacheWriteCost) / 1e6
+}

--- a/pkg/rag/strategy/semantic_embeddings_test.go
+++ b/pkg/rag/strategy/semantic_embeddings_test.go
@@ -1,0 +1,39 @@
+package strategy
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatASTContext(t *testing.T) {
+	metadata := map[string]string{
+		"symbol_name":        "Init",
+		"symbol_kind":        "method",
+		"signature":          "func (p *chatPage) Init() tea.Cmd",
+		"doc":                "Init prepares the chat page.",
+		"package":            "chat",
+		"additional_symbols": "InitSidebar",
+		"custom_note":        "requires session state",
+	}
+
+	formatted := formatASTContext(metadata)
+	if formatted == "" {
+		t.Fatalf("expected formatted AST context but got empty string")
+	}
+
+	if !strings.Contains(formatted, "AST context:") {
+		t.Fatalf("expected prefix 'AST context:' in %q", formatted)
+	}
+
+	if !strings.Contains(formatted, "- Symbol: Init") {
+		t.Fatalf("expected symbol line in %q", formatted)
+	}
+
+	if !strings.Contains(formatted, "- Custom Note: requires session state") {
+		t.Fatalf("expected custom key to be humanized in %q", formatted)
+	}
+
+	if got := formatASTContext(nil); got != "" {
+		t.Fatalf("expected empty string for nil metadata, got %q", got)
+	}
+}

--- a/pkg/rag/strategy/strategy.go
+++ b/pkg/rag/strategy/strategy.go
@@ -25,9 +25,11 @@ func BuildStrategy(ctx context.Context, cfg latest.RAGStrategyConfig, buildCtx B
 	switch cfg.Type {
 	case "chunked-embeddings":
 		return NewChunkedEmbeddingsFromConfig(ctx, cfg, buildCtx, events)
+	case "semantic-embeddings":
+		return NewSemanticEmbeddingsFromConfig(ctx, cfg, buildCtx, events)
 	case "bm25":
 		return NewBM25FromConfig(ctx, cfg, buildCtx, events)
 	default:
-		return nil, fmt.Errorf("unknown strategy type: %s (available: chunked-embeddings, bm25)", cfg.Type)
+		return nil, fmt.Errorf("unknown strategy type: %s (available: chunked-embeddings, semantic-embeddings, bm25)", cfg.Type)
 	}
 }


### PR DESCRIPTION
### Semantic embeddings

The concept around this RAG strategy is to create embeddings for a semantic summary of a document (or chunk) instead of just its contents, using a chat model to generate that semantic summary. 

The prompt used for generating this semantic summary can be user defined and includes js template support.

When using code, you can configure the strategy to extract AST information that you can then include in the semantic_prompt. Particularly useful when using `code_aware: true` in the chunking configuration.

The cost to using this is indexing speed and LLM costs, since for each document chunk the system will make a call to the defined chat model 

When used together with the other strategies and re-ranking in a hybrid RAG setup, giving the appropriate docs to each strategy, can greatly improve the quality of the RAG output.

