### PR TITLE
api: fix file source

### DIFF
--- a/pkg/config/resolve.go
+++ b/pkg/config/resolve.go
@@ -45,7 +45,7 @@ func ResolveSources(agentsPath string) (Sources, error) {
 
 	if isLocalFile(resolvedPath) {
 		return map[string]Source{
-			resolvedPath: NewFileSource(resolvedPath),
+			filepath.Base(resolvedPath): NewFileSource(resolvedPath),
 		}, nil
 	}
 

--- a/pkg/config/resolve_test.go
+++ b/pkg/config/resolve_test.go
@@ -267,3 +267,13 @@ func TestResolveAgentFile_EmptyDirectory(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, absPath, resolved)
 }
+
+func TestResolveSources(t *testing.T) {
+	t.Parallel()
+
+	sources, err := ResolveSources("./testdata/v1.yaml")
+	require.NoError(t, err)
+
+	assert.Len(t, sources, 1)
+	require.Contains(t, sources, "v1.yaml")
+}


### PR DESCRIPTION
Use the base name as the key, not the resolved absolute path