### PR TITLE
Allow to provide a eval file name

### DIFF
--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -232,16 +232,23 @@ func Run(ctx context.Context, out *Printer, cfg Config, rt runtime.Runtime, sess
 // runUserCommand handles built-in session commands
 // TODO: This is a duplication of builtInSessionCommands() in pkg/tui/tui.go
 func runUserCommand(out *Printer, userInput string, sess *session.Session, rt runtime.Runtime, ctx context.Context) (bool, error) {
-	switch userInput {
-	case "/exit":
-		os.Exit(0)
-	case "/eval":
-		evalFile, err := evaluation.Save(sess)
+	// Handle /eval with optional filename
+	if userInput == "/eval" || strings.HasPrefix(userInput, "/eval ") {
+		var filename string
+		if strings.HasPrefix(userInput, "/eval ") {
+			filename = strings.TrimSpace(strings.TrimPrefix(userInput, "/eval "))
+		}
+		evalFile, err := evaluation.Save(sess, filename)
 		if err == nil {
 			out.Println("Evaluation saved to file:", evalFile)
 			return true, err
 		}
 		return true, nil
+	}
+
+	switch userInput {
+	case "/exit":
+		os.Exit(0)
 	case "/usage":
 		out.Println("Input tokens:", sess.InputTokens)
 		out.Println("Output tokens:", sess.OutputTokens)

--- a/pkg/evaluation/save.go
+++ b/pkg/evaluation/save.go
@@ -5,22 +5,38 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/docker/cagent/pkg/session"
 )
 
-func Save(sess *session.Session) (string, error) {
+func Save(sess *session.Session, filename ...string) (string, error) {
 	if err := os.MkdirAll("evals", 0o755); err != nil {
 		return "", err
 	}
 
-	evalFile := filepath.Join("evals", fmt.Sprintf("%s.json", sess.ID))
+	var baseFilename string
+	if len(filename) > 0 && filename[0] != "" {
+		// Use the provided filename
+		baseFilename = filename[0]
+		// Ensure .json extension
+		if !strings.HasSuffix(baseFilename, ".json") {
+			baseFilename += ".json"
+		}
+	} else {
+		// Default to session ID
+		baseFilename = fmt.Sprintf("%s.json", sess.ID)
+	}
+
+	evalFile := filepath.Join("evals", baseFilename)
 	for number := 1; ; number++ {
 		if _, err := os.Stat(evalFile); err != nil {
 			break
 		}
 
-		evalFile = filepath.Join("evals", fmt.Sprintf("%s_%d.json", sess.ID, number))
+		// Add suffix before .json extension
+		nameWithoutExt := strings.TrimSuffix(baseFilename, ".json")
+		evalFile = filepath.Join("evals", fmt.Sprintf("%s_%d.json", nameWithoutExt, number))
 	}
 
 	file, err := os.Create(evalFile)

--- a/pkg/tui/messages/messages.go
+++ b/pkg/tui/messages/messages.go
@@ -2,8 +2,10 @@ package messages
 
 // Session command messages
 type (
-	NewSessionMsg             struct{}
-	EvalSessionMsg            struct{}
+	NewSessionMsg  struct{}
+	EvalSessionMsg struct {
+		Filename string
+	}
 	CompactSessionMsg         struct{}
 	CopySessionToClipboardMsg struct{}
 	ToggleYoloMsg             struct{}

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/cagent/pkg/tui/components/notification"
 	"github.com/docker/cagent/pkg/tui/components/sidebar"
 	"github.com/docker/cagent/pkg/tui/components/tool/editfile"
+	tcommands "github.com/docker/cagent/pkg/tui/commands"
 	"github.com/docker/cagent/pkg/tui/core"
 	"github.com/docker/cagent/pkg/tui/core/layout"
 	"github.com/docker/cagent/pkg/tui/dialog"
@@ -613,6 +614,15 @@ func (p *chatPage) processMessage(content string) tea.Cmd {
 	if strings.HasPrefix(content, "!") {
 		p.app.RunBangCommand(ctx, content[1:])
 		return p.messages.ScrollToBottom()
+	}
+
+	// Handle /eval command with optional filename
+	if content == "/eval" || strings.HasPrefix(content, "/eval ") {
+		var filename string
+		if strings.HasPrefix(content, "/eval ") {
+			filename = strings.TrimSpace(strings.TrimPrefix(content, "/eval "))
+		}
+		return core.CmdHandler(tcommands.EvalSessionMsg{Filename: filename})
 	}
 
 	// Persist to history

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -209,7 +209,7 @@ func (a *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a, tea.Batch(a.Init(), a.handleWindowResize(a.wWidth, a.wHeight))
 
 	case messages.EvalSessionMsg:
-		evalFile, _ := evaluation.Save(a.application.Session())
+		evalFile, _ := evaluation.Save(a.application.Session(), msg.Filename)
 		return a, core.CmdHandler(notification.ShowMsg{Text: fmt.Sprintf("Eval saved to file %s", evalFile)})
 
 	case messages.CompactSessionMsg:


### PR DESCRIPTION
This allows the `/eval` command to accept an optional file name.

`/eval` works as usual

`/eval foobar` will save the file as `foobar.json`