### PR TITLE
add hot-reload yaml configuration changes

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -201,3 +201,21 @@ func (a *Agent) StopToolSets(ctx context.Context) error {
 
 	return nil
 }
+
+// UpdateInstruction updates the agent's instruction prompt
+func (a *Agent) UpdateInstruction(instruction string) {
+	a.instruction = instruction
+	slog.Debug("Updated agent instruction", "agent", a.name)
+}
+
+// UpdateDescription updates the agent's description
+func (a *Agent) UpdateDescription(description string) {
+	a.description = description
+	slog.Debug("Updated agent description", "agent", a.name)
+}
+
+// UpdateCommands updates the agent's named commands
+func (a *Agent) UpdateCommands(commands map[string]string) {
+	a.commands = commands
+	slog.Debug("Updated agent commands", "agent", a.name, "command_count", len(commands))
+}

--- a/pkg/config/watcher.go
+++ b/pkg/config/watcher.go
@@ -1,0 +1,186 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// ChangeEvent represents a configuration file change event
+type ChangeEvent struct {
+	Path      string
+	Timestamp time.Time
+}
+
+// Watcher watches configuration files for changes
+type Watcher struct {
+	watcher       *fsnotify.Watcher
+	events        chan ChangeEvent
+	debounceTimer *time.Timer
+	debounceMu    sync.Mutex
+	watchedPath   string
+	closed        bool
+	closeMu       sync.RWMutex
+}
+
+const debounceDelay = 500 * time.Millisecond
+
+// NewConfigWatcher creates a new configuration file watcher
+func NewConfigWatcher() (*Watcher, error) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create file watcher: %w", err)
+	}
+
+	return &Watcher{
+		watcher: watcher,
+		events:  make(chan ChangeEvent, 16),
+	}, nil
+}
+
+// Watch starts watching the specified configuration file
+func (cw *Watcher) Watch(path string) error {
+	cw.closeMu.RLock()
+	if cw.closed {
+		cw.closeMu.RUnlock()
+		return fmt.Errorf("watcher is closed")
+	}
+	cw.closeMu.RUnlock()
+
+	// Get absolute path for consistent tracking
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("failed to get absolute path: %w", err)
+	}
+
+	// Watch the directory containing the file (more reliable than watching file directly)
+	dir := filepath.Dir(absPath)
+	if err := cw.watcher.Add(dir); err != nil {
+		return fmt.Errorf("failed to watch directory %s: %w", dir, err)
+	}
+
+	cw.watchedPath = absPath
+	slog.Debug("Started watching config file", "path", absPath)
+
+	return nil
+}
+
+// Events returns the channel for receiving configuration change events
+func (cw *Watcher) Events() <-chan ChangeEvent {
+	return cw.events
+}
+
+// Start begins processing file system events
+func (cw *Watcher) Start(ctx context.Context) {
+	go cw.processEvents(ctx)
+}
+
+// processEvents handles file system events with debouncing
+func (cw *Watcher) processEvents(ctx context.Context) {
+	defer close(cw.events)
+
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Debug("Config watcher context cancelled")
+			return
+
+		case event, ok := <-cw.watcher.Events:
+			if !ok {
+				slog.Debug("Config watcher events channel closed")
+				return
+			}
+
+			// Check if this is the file we're watching
+			eventPath, err := filepath.Abs(event.Name)
+			if err != nil {
+				slog.Warn("Failed to get absolute path for event", "path", event.Name, "error", err)
+				continue
+			}
+
+			if eventPath != cw.watchedPath {
+				continue
+			}
+
+			// Only process Write and Create events (common for file saves)
+			if event.Op&(fsnotify.Write|fsnotify.Create) == 0 {
+				continue
+			}
+
+			slog.Debug("Config file changed", "path", event.Name, "op", event.Op)
+
+			// Debounce: only emit event after delay to handle multiple rapid writes
+			cw.scheduleReload(eventPath)
+
+		case err, ok := <-cw.watcher.Errors:
+			if !ok {
+				slog.Debug("Config watcher errors channel closed")
+				return
+			}
+			slog.Error("Config watcher error", "error", err)
+		}
+	}
+}
+
+// scheduleReload schedules a reload after the debounce delay
+func (cw *Watcher) scheduleReload(path string) {
+	cw.debounceMu.Lock()
+	defer cw.debounceMu.Unlock()
+
+	// Cancel previous timer if it exists
+	if cw.debounceTimer != nil {
+		cw.debounceTimer.Stop()
+	}
+
+	// Schedule new reload
+	cw.debounceTimer = time.AfterFunc(debounceDelay, func() {
+		cw.closeMu.RLock()
+		defer cw.closeMu.RUnlock()
+
+		if cw.closed {
+			return
+		}
+
+		select {
+		case cw.events <- ChangeEvent{
+			Path:      path,
+			Timestamp: time.Now(),
+		}:
+			slog.Debug("Config reload event emitted", "path", path)
+		default:
+			slog.Warn("Config reload event channel full, skipping event")
+		}
+	})
+}
+
+// Close stops the watcher and releases resources
+func (cw *Watcher) Close() error {
+	cw.closeMu.Lock()
+	defer cw.closeMu.Unlock()
+
+	if cw.closed {
+		return nil
+	}
+
+	cw.closed = true
+
+	// Stop debounce timer
+	cw.debounceMu.Lock()
+	if cw.debounceTimer != nil {
+		cw.debounceTimer.Stop()
+	}
+	cw.debounceMu.Unlock()
+
+	// Close watcher
+	if err := cw.watcher.Close(); err != nil {
+		return fmt.Errorf("failed to close file watcher: %w", err)
+	}
+
+	slog.Debug("Config watcher closed")
+	return nil
+}

--- a/pkg/runtime/event.go
+++ b/pkg/runtime/event.go
@@ -479,3 +479,52 @@ func RAGIndexingCompleted(ragName, strategyName, agentName string) Event {
 		AgentContext: AgentContext{AgentName: agentName},
 	}
 }
+
+// ConfigReloadStartedEvent is sent when configuration reload begins
+type ConfigReloadStartedEvent struct {
+	Type       string `json:"type"`
+	ConfigPath string `json:"config_path"`
+	AgentContext
+}
+
+func ConfigReloadStarted(configPath, agentName string) Event {
+	return &ConfigReloadStartedEvent{
+		Type:         "config_reload_started",
+		ConfigPath:   configPath,
+		AgentContext: AgentContext{AgentName: agentName},
+	}
+}
+
+// ConfigReloadedEvent is sent when configuration reload completes successfully
+type ConfigReloadedEvent struct {
+	Type           string   `json:"type"`
+	ConfigPath     string   `json:"config_path"`
+	ReloadedAgents []string `json:"reloaded_agents"`
+	AgentContext
+}
+
+func ConfigReloaded(configPath string, reloadedAgents []string, agentName string) Event {
+	return &ConfigReloadedEvent{
+		Type:           "config_reloaded",
+		ConfigPath:     configPath,
+		ReloadedAgents: reloadedAgents,
+		AgentContext:   AgentContext{AgentName: agentName},
+	}
+}
+
+// ConfigReloadFailedEvent is sent when configuration reload fails
+type ConfigReloadFailedEvent struct {
+	Type       string `json:"type"`
+	ConfigPath string `json:"config_path"`
+	Error      string `json:"error"`
+	AgentContext
+}
+
+func ConfigReloadFailed(configPath, errorMsg, agentName string) Event {
+	return &ConfigReloadFailedEvent{
+		Type:         "config_reload_failed",
+		ConfigPath:   configPath,
+		Error:        errorMsg,
+		AgentContext: AgentContext{AgentName: agentName},
+	}
+}

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -293,6 +293,18 @@ func (p *chatPage) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		model, cmd = p.sidebar.Update(msg)
 		p.sidebar = model.(sidebar.Model)
 		return p, cmd
+	case *runtime.ConfigReloadStartedEvent:
+		cmd := core.CmdHandler(notification.ShowMsg{Text: "Reloading configuration...", Type: notification.TypeInfo})
+		return p, cmd
+	case *runtime.ConfigReloadedEvent:
+		agentList := strings.Join(msg.ReloadedAgents, ", ")
+		notifText := fmt.Sprintf("✓ Configuration reloaded (%s)", agentList)
+		cmd := core.CmdHandler(notification.ShowMsg{Text: notifText, Type: notification.TypeSuccess})
+		return p, cmd
+	case *runtime.ConfigReloadFailedEvent:
+		notifText := fmt.Sprintf("✗ Config reload failed: %s", msg.Error)
+		cmd := core.CmdHandler(notification.ShowMsg{Text: notifText, Type: notification.TypeError})
+		return p, cmd
 	case *runtime.UserMessageEvent:
 		cmd := p.messages.AddUserMessage(msg.Message)
 		return p, cmd


### PR DESCRIPTION
Fixes #282

Implements automatic configuration reloading when agent YAML files change on disk.
### What's included:
- File watching with `fsnotify` and 500ms debounce for multiple rapid writes
- Validates new config before applying (falls back on error)
- Reloads `instruction`, `description`, and `commands` properties
- TUI notifications for reload events (started/success/failure)

### What's NOT included:
- reloading `Model` or `toolset` changes
