### PR TITLE
Better file attachment support with `@somefile`

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -105,6 +105,23 @@ cagent run                # Runs the pirate.yaml agent
 
 ### Interface-Specific Features
 
+#### File Attachments
+
+In the TUI, you can attach file contents to your message using the `@` trigger:
+
+1. Type `@` to open the file completion menu
+2. Start typing to filter files (respects `.gitignore`)
+3. Select a file to insert the reference (e.g., `@src/main.go`)
+4. When you send your message, the file contents are automatically expanded and attached at the end of your message, while `@somefile.txt` references stay in your message so the LLM can reference the file contents in the context of your question
+
+**Example:**
+```
+Explain what the code in @pkg/agent/agent.go does
+```
+
+The agent gets the full file contents and places them in a structured `<attachments>`
+block at the end of the message, while the UI doesn't display full file contents.
+
 #### CLI Interactive Commands
 
 During CLI sessions, you can use special commands:

--- a/pkg/tui/components/completion/completion.go
+++ b/pkg/tui/components/completion/completion.go
@@ -123,14 +123,20 @@ func (c *manager) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 	case QueryMsg:
 		c.query = msg.Query
 		c.filterItems(c.query)
+		if len(c.filteredItems) == 0 {
+			c.visible = false
+		}
 		return c, nil
 
 	case OpenMsg:
-		c.visible = true
 		c.items = msg.Items
 		c.selected = 0
 		c.scrollOffset = 0
 		c.filterItems(c.query)
+		c.visible = len(c.filteredItems) > 0
+		if !c.visible {
+			return c, nil
+		}
 		return c, core.CmdHandler(OpenedMsg{})
 
 	case CloseMsg:
@@ -157,6 +163,9 @@ func (c *manager) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 
 		case key.Matches(msg, c.keyMap.Enter):
 			c.visible = false
+			if len(c.filteredItems) == 0 || c.selected >= len(c.filteredItems) {
+				return c, core.CmdHandler(ClosedMsg{})
+			}
 			return c, core.CmdHandler(SelectedMsg{Value: c.filteredItems[c.selected].Value, Execute: c.filteredItems[c.selected].Execute})
 		case key.Matches(msg, c.keyMap.Escape):
 			c.visible = false

--- a/pkg/tui/components/editor/completions/file.go
+++ b/pkg/tui/components/editor/completions/file.go
@@ -44,7 +44,7 @@ func (c *fileCompletion) Items() []completion.Item {
 	for i, f := range files {
 		items[i] = completion.Item{
 			Label: f,
-			Value: f,
+			Value: "@" + f, // Include @ prefix since completion handler removes trigger
 		}
 	}
 

--- a/pkg/tui/components/editor/editor_test.go
+++ b/pkg/tui/components/editor/editor_test.go
@@ -1,0 +1,234 @@
+package editor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppendFileAttachments(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no file refs returns content unchanged", func(t *testing.T) {
+		t.Parallel()
+		e := &editor{fileRefs: nil}
+		content := "hello world"
+
+		result := e.appendFileAttachments(content)
+
+		assert.Equal(t, content, result)
+	})
+
+	t.Run("empty file refs returns content unchanged", func(t *testing.T) {
+		t.Parallel()
+		e := &editor{fileRefs: []string{}}
+		content := "hello world"
+
+		result := e.appendFileAttachments(content)
+
+		assert.Equal(t, content, result)
+	})
+
+	t.Run("appends file content as attachment", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a temp file
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "test.txt")
+		require.NoError(t, os.WriteFile(tmpFile, []byte("file content here"), 0o644))
+
+		ref := "@" + tmpFile
+		e := &editor{fileRefs: []string{ref}}
+		content := "analyze " + ref
+
+		result := e.appendFileAttachments(content)
+
+		assert.Contains(t, result, "analyze "+ref)
+		assert.Contains(t, result, "<attachments>")
+		assert.Contains(t, result, "</attachments>")
+		assert.Contains(t, result, ref+":")
+		assert.Contains(t, result, "file content here")
+		assert.Nil(t, e.fileRefs, "fileRefs should be cleared after expansion")
+	})
+
+	t.Run("multiple file attachments", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		file1 := filepath.Join(tmpDir, "first.go")
+		file2 := filepath.Join(tmpDir, "second.go")
+		require.NoError(t, os.WriteFile(file1, []byte("package first"), 0o644))
+		require.NoError(t, os.WriteFile(file2, []byte("package second"), 0o644))
+
+		ref1 := "@" + file1
+		ref2 := "@" + file2
+		e := &editor{fileRefs: []string{ref1, ref2}}
+		content := "compare " + ref1 + " with " + ref2
+
+		result := e.appendFileAttachments(content)
+
+		assert.Contains(t, result, "compare "+ref1+" with "+ref2)
+		assert.Contains(t, result, ref1+":")
+		assert.Contains(t, result, "package first")
+		assert.Contains(t, result, ref2+":")
+		assert.Contains(t, result, "package second")
+		assert.Equal(t, 1, strings.Count(result, "<attachments>"))
+		assert.Equal(t, 1, strings.Count(result, "</attachments>"))
+	})
+
+	t.Run("skips refs not in content", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "test.txt")
+		require.NoError(t, os.WriteFile(tmpFile, []byte("content"), 0o644))
+
+		ref := "@" + tmpFile
+		e := &editor{fileRefs: []string{ref}}
+		content := "message without the reference"
+
+		result := e.appendFileAttachments(content)
+
+		assert.Equal(t, content, result, "should return unchanged when ref not in content")
+		assert.Nil(t, e.fileRefs, "fileRefs should be cleared after expansion")
+	})
+
+	t.Run("skips nonexistent files", func(t *testing.T) {
+		t.Parallel()
+
+		ref := "@/nonexistent/path/file.txt"
+		e := &editor{fileRefs: []string{ref}}
+		content := "analyze " + ref
+
+		result := e.appendFileAttachments(content)
+
+		assert.Equal(t, content, result, "should return unchanged when file doesn't exist")
+		assert.Nil(t, e.fileRefs, "fileRefs should still be cleared")
+	})
+
+	t.Run("skips directories", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		ref := "@" + tmpDir
+		e := &editor{fileRefs: []string{ref}}
+		content := "analyze " + ref
+
+		result := e.appendFileAttachments(content)
+
+		assert.Equal(t, content, result, "should return unchanged for directories")
+		assert.Nil(t, e.fileRefs, "fileRefs should be cleared after expansion")
+	})
+
+	t.Run("mixed valid and invalid refs", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		validFile := filepath.Join(tmpDir, "valid.txt")
+		require.NoError(t, os.WriteFile(validFile, []byte("valid content"), 0o644))
+
+		validRef := "@" + validFile
+		invalidRef := "@/nonexistent/file.txt"
+		e := &editor{fileRefs: []string{validRef, invalidRef}}
+		content := "check " + validRef + " and " + invalidRef
+
+		result := e.appendFileAttachments(content)
+
+		assert.Contains(t, result, "<attachments>")
+		assert.Contains(t, result, validRef+":")
+		assert.Contains(t, result, "valid content")
+		assert.NotContains(t, result, invalidRef+":")
+		assert.Nil(t, e.fileRefs, "fileRefs should be cleared after expansion")
+	})
+}
+
+func TestTryAddFileRef(t *testing.T) {
+	t.Parallel()
+
+	t.Run("adds valid file path", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "manual.txt")
+		require.NoError(t, os.WriteFile(tmpFile, []byte("content"), 0o644))
+
+		e := &editor{fileRefs: nil}
+		e.tryAddFileRef("@" + tmpFile)
+
+		require.Len(t, e.fileRefs, 1)
+		assert.Equal(t, "@"+tmpFile, e.fileRefs[0])
+	})
+
+	t.Run("ignores @mentions without path characters", func(t *testing.T) {
+		t.Parallel()
+
+		e := &editor{fileRefs: nil}
+		e.tryAddFileRef("@username")
+
+		assert.Nil(t, e.fileRefs, "@mentions without / or . should be ignored")
+	})
+
+	t.Run("ignores nonexistent files", func(t *testing.T) {
+		t.Parallel()
+
+		e := &editor{fileRefs: nil}
+		e.tryAddFileRef("@/nonexistent/file.txt")
+
+		assert.Nil(t, e.fileRefs, "nonexistent files should be ignored")
+	})
+
+	t.Run("ignores directories", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		e := &editor{fileRefs: nil}
+		e.tryAddFileRef("@" + tmpDir)
+
+		assert.Nil(t, e.fileRefs, "directories should be ignored")
+	})
+
+	t.Run("avoids duplicates", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "file.go")
+		require.NoError(t, os.WriteFile(tmpFile, []byte("content"), 0o644))
+
+		ref := "@" + tmpFile
+		e := &editor{fileRefs: []string{ref}}
+		e.tryAddFileRef(ref)
+
+		assert.Len(t, e.fileRefs, 1, "should not add duplicate")
+	})
+
+	t.Run("combines with completion refs", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		completedFile := filepath.Join(tmpDir, "completed.go")
+		manualFile := filepath.Join(tmpDir, "manual.go")
+		require.NoError(t, os.WriteFile(completedFile, []byte("package completed"), 0o644))
+		require.NoError(t, os.WriteFile(manualFile, []byte("package manual"), 0o644))
+
+		// completedFile was selected via completion
+		e := &editor{fileRefs: []string{"@" + completedFile}}
+		// User typed manualFile and cursor left the word
+		e.tryAddFileRef("@" + manualFile)
+
+		require.Len(t, e.fileRefs, 2)
+		assert.Contains(t, e.fileRefs, "@"+completedFile)
+		assert.Contains(t, e.fileRefs, "@"+manualFile)
+
+		// Verify both get attached
+		content := "compare @" + completedFile + " with @" + manualFile
+		result := e.appendFileAttachments(content)
+
+		assert.Contains(t, result, "package completed")
+		assert.Contains(t, result, "package manual")
+		assert.Equal(t, 1, strings.Count(result, "<attachments>"))
+	})
+}


### PR DESCRIPTION
Makes @ references for files actually send the file contents along with the message to the LLM, so the agent doesn't have to round-trip to then get the files contents (_if it has access to a tool with which to do that_). 

Files references via @somefile get attached to a structured <attachments> section at the end of the user message, while the @somefile references remain in the message where the user typed them so the LLM has a better idea of the context and where the file contents are referenced by the user

Full attachment contents are not shown in the TUI to keep things easier to read

Also fixes a visual bug where historical completions were showing alongside @ file completions

#### Example

What the user sees:

<img width="1816" height="1314" alt="image" src="https://github.com/user-attachments/assets/445cd0ad-3783-4097-b841-f182528f54d1" />

What actually gets sent as the contents of the user message:

~~~
hey whats in here? @minimal.yaml

<attachments>
@minimal.yaml:
```
agents:
    root:
        model: openai/gpt-5-mini
        description: Writes a nice story about a subject
        instruction: You are helpful assistant
```
</attachments>
~~~
