### PR TITLE
Attachment improvements - Pasted text attachments

### DIFF
--- a/pkg/tui/components/editor/banner.go
+++ b/pkg/tui/components/editor/banner.go
@@ -1,0 +1,145 @@
+package editor
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"github.com/mattn/go-runewidth"
+
+	"github.com/docker/cagent/pkg/tui/styles"
+)
+
+const (
+	bannerSeparatorText = "  •  "
+	// BorderLeft + PaddingLeft from banner style
+	bannerContentOffset = 2
+)
+
+type attachmentBanner struct {
+	items   []bannerItem
+	height  int // cached height after last render
+	regions []bannerRegion
+}
+
+type bannerItem struct {
+	label       string
+	placeholder string
+}
+
+type bannerRegion struct {
+	start int
+	end   int
+	item  bannerItem
+}
+
+func newAttachmentBanner() *attachmentBanner {
+	return &attachmentBanner{}
+}
+
+func (b *attachmentBanner) SetItems(items []bannerItem) {
+	b.items = items
+	b.updateHeight()
+}
+
+// Height returns the number of lines this banner will take when rendered.
+func (b *attachmentBanner) Height() int {
+	return b.height
+}
+
+// updateHeight recalculates the banner height based on current state.
+func (b *attachmentBanner) updateHeight() {
+	if len(b.items) == 0 {
+		b.height = 0
+		return
+	}
+	// Banner takes 1 line when visible
+	b.height = 1
+}
+
+func (b *attachmentBanner) View() string {
+	if len(b.items) == 0 {
+		return ""
+	}
+
+	// Build pill-style badges for each attachment
+	var pills []string
+	for _, item := range b.items {
+		name, size := parseLabel(item.label)
+
+		// Create a nice pill: icon + name + size
+		pill := styles.AttachmentIconStyle.Render("📎 ") +
+			styles.AttachmentBadgeStyle.Render(name)
+		if size != "" {
+			pill += " " + styles.AttachmentSizeStyle.Render(size)
+		}
+		pills = append(pills, pill)
+	}
+
+	separator := styles.MutedStyle.Render(bannerSeparatorText)
+	content := strings.Join(pills, separator)
+
+	b.buildRegions(pills, separator)
+
+	// Wrap in banner style with subtle left border
+	banner := lipgloss.NewStyle().
+		BorderLeft(true).
+		BorderStyle(lipgloss.ThickBorder()).
+		BorderForeground(styles.Info).
+		PaddingLeft(1).
+		PaddingRight(1).
+		Foreground(styles.TextSecondary).
+		Render(content)
+
+	return styles.AttachmentBannerStyle.Render(banner)
+}
+
+func (b *attachmentBanner) buildRegions(pills []string, separator string) {
+	b.regions = b.regions[:0]
+	if len(pills) == 0 {
+		return
+	}
+
+	pos := 0
+	sepWidth := runewidth.StringWidth(stripANSI(separator))
+
+	for i, pill := range pills {
+		if i > 0 {
+			pos += sepWidth
+		}
+		width := runewidth.StringWidth(stripANSI(pill))
+		b.regions = append(b.regions, bannerRegion{
+			start: pos,
+			end:   pos + width,
+			item:  b.items[i],
+		})
+		pos += width
+	}
+}
+
+func (b *attachmentBanner) HitTest(x int) (bannerItem, bool) {
+	if len(b.regions) == 0 {
+		return bannerItem{}, false
+	}
+
+	rel := x - bannerContentOffset
+	if rel < 0 {
+		return bannerItem{}, false
+	}
+
+	for _, region := range b.regions {
+		if rel >= region.start && rel < region.end {
+			return region.item, true
+		}
+	}
+	return bannerItem{}, false
+}
+
+// parseLabel splits a label like "paste-1 (21.1 KB)" into name and size parts.
+func parseLabel(label string) (name, size string) {
+	// Find the last opening parenthesis for size
+	idx := strings.LastIndex(label, " (")
+	if idx > 0 && strings.HasSuffix(label, ")") {
+		return label[:idx], label[idx+1:]
+	}
+	return label, ""
+}

--- a/pkg/tui/components/editor/editor.go
+++ b/pkg/tui/components/editor/editor.go
@@ -1,19 +1,24 @@
 package editor
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"regexp"
-	"slices"
 	"strings"
 
+	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/textarea"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/atotto/clipboard"
+	"github.com/docker/go-units"
 	"github.com/mattn/go-runewidth"
 
 	"github.com/docker/cagent/pkg/app"
 	"github.com/docker/cagent/pkg/history"
+	"github.com/docker/cagent/pkg/paths"
 	"github.com/docker/cagent/pkg/tui/components/completion"
 	"github.com/docker/cagent/pkg/tui/components/editor/completions"
 	"github.com/docker/cagent/pkg/tui/core"
@@ -24,6 +29,29 @@ import (
 // ansiRegexp matches ANSI escape sequences so they can be removed when
 // computing layout measurements.
 var ansiRegexp = regexp.MustCompile(`\x1b\[[0-9;]*[A-Za-z]`)
+
+const (
+	// maxInlinePasteLines is the maximum number of lines for inline paste.
+	// Pastes exceeding this are buffered to a temp file attachment.
+	maxInlinePasteLines = 5
+	// maxInlinePasteChars is the character limit for inline pastes.
+	// This catches very long single-line pastes that would clutter the editor.
+	maxInlinePasteChars = 500
+)
+
+type attachment struct {
+	path        string // Path to file (temp for pastes, real for file refs)
+	placeholder string // @paste-1 or @filename
+	label       string // Display label like "paste-1 (21.1 KB)"
+	sizeBytes   int
+	isTemp      bool // True for paste temp files that need cleanup
+}
+
+// AttachmentPreview describes an attachment and its contents for dialog display.
+type AttachmentPreview struct {
+	Title   string
+	Content string
+}
 
 // SendMsg represents a message to send
 type SendMsg struct {
@@ -42,6 +70,10 @@ type Editor interface {
 	Value() string
 	// SetValue updates the editor content
 	SetValue(content string)
+	Cleanup()
+	GetSize() (width, height int)
+	BannerHeight() int
+	AttachmentAt(x int) (AttachmentPreview, bool)
 }
 
 // editor implements [Editor]
@@ -65,11 +97,15 @@ type editor struct {
 	userTyped bool
 	// keyboardEnhancementsSupported tracks whether the terminal supports keyboard enhancements
 	keyboardEnhancementsSupported bool
-	// fileRefs tracks @filename placeholders inserted via completion (handles spaces in filenames).
-	fileRefs []string
 	// pendingFileRef tracks the current @word being typed (for manual file ref detection).
 	// Only set when cursor is in a word starting with @, cleared when cursor leaves.
 	pendingFileRef string
+	// banner renders pending attachments so the user can see what's queued.
+	banner *attachmentBanner
+	// attachments tracks all file attachments (pastes and file refs).
+	attachments []attachment
+	// pasteCounter tracks the next paste number for display purposes.
+	pasteCounter int
 }
 
 // New creates a new editor component
@@ -90,6 +126,7 @@ func New(a *app.App, hist *history.History) Editor {
 		completions: completions.Completions(a),
 		// Default to no keyboard enhancements; ctrl+j will be used until we know otherwise
 		keyboardEnhancementsSupported: false,
+		banner:                        newAttachmentBanner(),
 	}
 
 	// Configure initial keybinding (ctrl+j for legacy terminals)
@@ -245,8 +282,14 @@ func (e *editor) configureNewlineKeybinding() {
 
 // Update handles messages and updates the component state
 func (e *editor) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
+	defer e.updateAttachmentBanner()
+
 	var cmds []tea.Cmd
 	switch msg := msg.(type) {
+	case tea.PasteMsg:
+		if e.handlePaste(msg.Content) {
+			return e, nil
+		}
 	case tea.KeyboardEnhancementsMsg:
 		// Track keyboard enhancement support and configure newline keybinding accordingly
 		e.keyboardEnhancementsSupported = msg.Flags != 0
@@ -297,10 +340,9 @@ func (e *editor) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 				e.textarea.SetValue(newValue)
 				e.textarea.MoveToEnd()
 			}
-			// Track file references when using @ completion, so we can distinguish from
-			// normal user input that may contain @smth as literal text to send (not a file reference)
-			if e.currentCompletion != nil && e.currentCompletion.Trigger() == "@" {
-				e.fileRefs = append(e.fileRefs, msg.Value)
+			// Track file references when using @ completion (but not paste placeholders)
+			if e.currentCompletion != nil && e.currentCompletion.Trigger() == "@" && !strings.HasPrefix(msg.Value, "@paste-") {
+				e.addFileAttachment(msg.Value)
 			}
 			// Clear history suggestion after selecting a completion
 			e.clearSuggestion()
@@ -311,6 +353,10 @@ func (e *editor) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		e.completionWord = ""
 		return e, nil
 	case tea.KeyPressMsg:
+		if key.Matches(msg, e.textarea.KeyMap.Paste) {
+			return e.handleClipboardPaste()
+		}
+
 		switch msg.String() {
 		// Handle send/newline keys:
 		// - Enter: submit current input (if textarea inserted a newline, submit previous buffer).
@@ -338,7 +384,7 @@ func (e *editor) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 				if prev != "" && !e.working {
 					e.tryAddFileRef(e.pendingFileRef) // Add any pending @filepath before send
 					e.pendingFileRef = ""
-					attachments := e.fileParts(prev)
+					attachments := e.collectAttachments(prev)
 					e.textarea.SetValue(prev)
 					e.textarea.MoveToEnd()
 					e.textarea.Reset()
@@ -354,7 +400,7 @@ func (e *editor) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 				slog.Debug(value)
 				e.tryAddFileRef(e.pendingFileRef) // Add any pending @filepath before send
 				e.pendingFileRef = ""
-				attachments := e.fileParts(value)
+				attachments := e.collectAttachments(value)
 				e.textarea.Reset()
 				e.userTyped = false
 				e.refreshSuggestion()
@@ -447,11 +493,54 @@ func (e *editor) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 	return e, tea.Batch(cmds...)
 }
 
+func (e *editor) handleClipboardPaste() (layout.Model, tea.Cmd) {
+	content, err := clipboard.ReadAll()
+	if err != nil {
+		slog.Warn("failed to read clipboard", "error", err)
+		return e, nil
+	}
+
+	// handlePaste returns true if content was buffered to disk (large paste),
+	// false if it's small enough for inline insertion.
+	if !e.handlePaste(content) {
+		e.textarea.InsertString(content)
+	}
+	return e, textarea.Blink
+}
+
 func (e *editor) startCompletion(c completions.Completion) tea.Cmd {
 	e.currentCompletion = c
+	items := c.Items()
+
+	// Prepend paste placeholders for @ trigger so users can easily reference them
+	if c.Trigger() == "@" {
+		pasteItems := e.getPasteCompletionItems()
+		if len(pasteItems) > 0 {
+			items = append(pasteItems, items...)
+		}
+	}
+
 	return core.CmdHandler(completion.OpenMsg{
-		Items: c.Items(),
+		Items: items,
 	})
+}
+
+// getPasteCompletionItems returns completion items for paste attachments only.
+func (e *editor) getPasteCompletionItems() []completion.Item {
+	var items []completion.Item
+	for _, att := range e.attachments {
+		if !att.isTemp {
+			continue // Only show pastes, not file refs
+		}
+		name := strings.TrimPrefix(att.placeholder, "@")
+		items = append(items, completion.Item{
+			Label:       name,
+			Description: units.HumanSize(float64(att.sizeBytes)),
+			Value:       att.placeholder,
+			Pinned:      true,
+		})
+	}
+	return items
 }
 
 // View renders the component
@@ -462,27 +551,82 @@ func (e *editor) View() string {
 		view = e.applySuggestionOverlay(view)
 	}
 
+	bannerView := e.banner.View()
+	if bannerView != "" {
+		// Banner is shown - no extra top padding needed
+		view = lipgloss.JoinVertical(lipgloss.Left, bannerView, view)
+	}
+
 	return styles.EditorStyle.Render(view)
 }
 
 // SetSize sets the dimensions of the component
 func (e *editor) SetSize(width, height int) tea.Cmd {
 	e.width = width
-	e.height = height
+	e.height = max(height, 1)
 
-	// Account for border and padding
-	contentWidth := max(width, 10)
-	contentHeight := max(height, 3) // Minimum 3 lines, but respect height parameter
-
-	e.textarea.SetWidth(contentWidth)
-	e.textarea.SetHeight(contentHeight)
+	e.textarea.SetWidth(max(width, 10))
+	e.updateTextareaHeight()
 
 	return nil
 }
 
-// GetSize returns the current dimensions
+func (e *editor) updateTextareaHeight() {
+	available := e.height
+	if e.banner != nil {
+		available -= e.banner.Height()
+	}
+
+	if available < 1 {
+		available = 1
+	}
+
+	e.textarea.SetHeight(available)
+}
+
+// BannerHeight returns the current height of the attachment banner (0 if hidden)
+func (e *editor) BannerHeight() int {
+	if e.banner == nil {
+		return 0
+	}
+	return e.banner.Height()
+}
+
+// GetSize returns the rendered dimensions including EditorStyle padding.
 func (e *editor) GetSize() (width, height int) {
-	return e.width, e.height
+	return e.width + styles.EditorStyle.GetHorizontalFrameSize(),
+		e.height + styles.EditorStyle.GetVerticalFrameSize()
+}
+
+// AttachmentAt returns preview information for the attachment rendered at the given X position.
+func (e *editor) AttachmentAt(x int) (AttachmentPreview, bool) {
+	if e.banner == nil || e.banner.Height() == 0 {
+		return AttachmentPreview{}, false
+	}
+
+	item, ok := e.banner.HitTest(x)
+	if !ok {
+		return AttachmentPreview{}, false
+	}
+
+	for _, att := range e.attachments {
+		if att.placeholder != item.placeholder {
+			continue
+		}
+
+		data, err := os.ReadFile(att.path)
+		if err != nil {
+			slog.Warn("failed to read attachment preview", "path", att.path, "error", err)
+			return AttachmentPreview{}, false
+		}
+
+		return AttachmentPreview{
+			Title:   item.label,
+			Content: string(data),
+		}, true
+	}
+
+	return AttachmentPreview{}, false
 }
 
 // Focus gives focus to the component
@@ -514,11 +658,16 @@ func (e *editor) SetValue(content string) {
 	e.refreshSuggestion()
 }
 
-// tryAddFileRef checks if word is a valid @filepath and adds it to fileRefs.
+// tryAddFileRef checks if word is a valid @filepath and adds it as attachment.
 // Called when cursor leaves a word to detect manually-typed file references.
 func (e *editor) tryAddFileRef(word string) {
 	// Must start with @ and look like a path (contains / or .)
 	if !strings.HasPrefix(word, "@") || len(word) < 2 {
+		return
+	}
+
+	// Don't track paste placeholders as file refs
+	if strings.HasPrefix(word, "@paste-") {
 		return
 	}
 
@@ -527,6 +676,13 @@ func (e *editor) tryAddFileRef(word string) {
 		return // not a path-like reference (e.g., @username)
 	}
 
+	e.addFileAttachment(word)
+}
+
+// addFileAttachment adds a file reference as an attachment if valid.
+func (e *editor) addFileAttachment(placeholder string) {
+	path := strings.TrimPrefix(placeholder, "@")
+
 	// Check if it's an existing file (not directory)
 	info, err := os.Stat(path)
 	if err != nil || info.IsDir() {
@@ -534,41 +690,137 @@ func (e *editor) tryAddFileRef(word string) {
 	}
 
 	// Avoid duplicates
-	if slices.Contains(e.fileRefs, word) {
-		return
+	for _, att := range e.attachments {
+		if att.placeholder == placeholder {
+			return
+		}
 	}
 
-	e.fileRefs = append(e.fileRefs, word)
+	e.attachments = append(e.attachments, attachment{
+		path:        path,
+		placeholder: placeholder,
+		label:       fmt.Sprintf("%s (%s)", filepath.Base(path), units.HumanSize(float64(info.Size()))),
+		sizeBytes:   int(info.Size()),
+		isTemp:      false,
+	})
 }
 
-// appendFileAttachments appends file contents as a structured attachments section.
-// Returns the original content unchanged if no valid file references exist.
-func (e *editor) fileParts(content string) map[string]string {
-	if len(e.fileRefs) == 0 {
+// collectAttachments returns a map of placeholder to file content for all attachments
+// referenced in content. Unreferenced attachments are cleaned up.
+func (e *editor) collectAttachments(content string) map[string]string {
+	if len(e.attachments) == 0 {
 		return nil
 	}
 
 	attachments := make(map[string]string)
-	for _, ref := range e.fileRefs {
-		if !strings.Contains(content, ref) {
+	for _, att := range e.attachments {
+		if !strings.Contains(content, att.placeholder) {
+			if att.isTemp {
+				_ = os.Remove(att.path)
+			}
 			continue
 		}
 
-		filename := strings.TrimPrefix(ref, "@")
-		info, err := os.Stat(filename)
-		if err != nil || info.IsDir() {
-			continue
-		}
-
-		data, err := os.ReadFile(filename)
+		data, err := os.ReadFile(att.path)
 		if err != nil {
-			slog.Warn("failed to read file attachment", "path", filename, "error", err)
+			slog.Warn("failed to read attachment", "path", att.path, "error", err)
+			if att.isTemp {
+				_ = os.Remove(att.path)
+			}
 			continue
 		}
-		attachments[ref] = string(data)
-	}
 
-	e.fileRefs = nil
+		attachments[att.placeholder] = string(data)
+
+		if att.isTemp {
+			_ = os.Remove(att.path)
+		}
+	}
+	e.attachments = nil
 
 	return attachments
+}
+
+// Cleanup removes any temporary paste files that haven't been sent yet.
+func (e *editor) Cleanup() {
+	for _, att := range e.attachments {
+		if att.isTemp {
+			_ = os.Remove(att.path)
+		}
+	}
+	e.attachments = nil
+}
+
+func (e *editor) handlePaste(content string) bool {
+	// Count lines (newlines + 1 for content without trailing newline)
+	lines := strings.Count(content, "\n") + 1
+	if strings.HasSuffix(content, "\n") {
+		lines-- // Don't count trailing newline as extra line
+	}
+
+	// Allow inline if within both limits
+	if lines <= maxInlinePasteLines && len(content) <= maxInlinePasteChars {
+		return false
+	}
+
+	e.pasteCounter++
+	att, err := createPasteAttachment(content, e.pasteCounter)
+	if err != nil {
+		slog.Warn("failed to buffer paste", "error", err)
+		// Still return true to prevent the large paste from falling through
+		// to textarea.Update(), which would block the UI for seconds.
+		return true
+	}
+
+	e.textarea.InsertString(att.placeholder)
+	e.attachments = append(e.attachments, att)
+
+	return true
+}
+
+func (e *editor) updateAttachmentBanner() {
+	if e.banner == nil {
+		return
+	}
+
+	value := e.textarea.Value()
+	var items []bannerItem
+
+	for _, att := range e.attachments {
+		if strings.Contains(value, att.placeholder) {
+			items = append(items, bannerItem{
+				label:       att.label,
+				placeholder: att.placeholder,
+			})
+		}
+	}
+
+	e.banner.SetItems(items)
+	e.updateTextareaHeight()
+}
+
+func createPasteAttachment(content string, num int) (attachment, error) {
+	pasteDir := filepath.Join(paths.GetDataDir(), "pastes")
+	if err := os.MkdirAll(pasteDir, 0o700); err != nil {
+		return attachment{}, fmt.Errorf("create paste dir: %w", err)
+	}
+
+	file, err := os.CreateTemp(pasteDir, "paste-*.txt")
+	if err != nil {
+		return attachment{}, fmt.Errorf("create paste file: %w", err)
+	}
+	defer file.Close()
+
+	if _, err := file.WriteString(content); err != nil {
+		return attachment{}, fmt.Errorf("write paste file: %w", err)
+	}
+
+	displayName := fmt.Sprintf("paste-%d", num)
+	return attachment{
+		path:        file.Name(),
+		placeholder: "@" + displayName,
+		label:       fmt.Sprintf("%s (%s)", displayName, units.HumanSize(float64(len(content)))),
+		sizeBytes:   len(content),
+		isTemp:      true,
+	}, nil
 }

--- a/pkg/tui/components/editor/paste_test.go
+++ b/pkg/tui/components/editor/paste_test.go
@@ -1,0 +1,217 @@
+package editor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/docker/go-units"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandlePaste_SmallContent(t *testing.T) {
+	t.Parallel()
+
+	e := &editor{}
+	// Content that's under both limits: few lines and few chars
+	smallContent := "line1\nline2\nline3"
+
+	handled := e.handlePaste(smallContent)
+
+	assert.False(t, handled, "small content should not be handled (return false)")
+	assert.Empty(t, e.attachments, "no attachments should be created for small content")
+}
+
+func TestHandlePaste_AtLineLimitIsInline(t *testing.T) {
+	t.Parallel()
+
+	e := &editor{}
+	// Exactly at line limit (10 lines) and under char limit should be inline
+	lines := make([]string, maxInlinePasteLines)
+	for i := range lines {
+		lines[i] = "short"
+	}
+	content := strings.Join(lines, "\n")
+
+	handled := e.handlePaste(content)
+
+	assert.False(t, handled, "content at line limit should be inline")
+}
+
+func TestHandlePaste_AtCharLimitIsInline(t *testing.T) {
+	t.Parallel()
+
+	e := &editor{}
+	// Exactly at char limit and under line limit should be inline
+	content := strings.Repeat("x", maxInlinePasteChars)
+
+	handled := e.handlePaste(content)
+
+	assert.False(t, handled, "content at char limit should be inline")
+}
+
+func TestHandlePaste_ExceedsLineLimit(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	pastesDir := filepath.Join(tmpDir, "pastes")
+
+	e := &editor{}
+	// Content exceeding line limit (11 lines)
+	lines := make([]string, maxInlinePasteLines+1)
+	for i := range lines {
+		lines[i] = "short"
+	}
+	largeContent := strings.Join(lines, "\n")
+
+	// Create paste buffer directly to test without textarea
+	att, err := createPasteAttachmentInDir(pastesDir, largeContent)
+	require.NoError(t, err)
+
+	e.attachments = append(e.attachments, att)
+
+	// Verify file was created
+	assert.FileExists(t, att.path)
+
+	// Verify attachment struct is correct
+	assert.NotEmpty(t, att.path)
+	assert.True(t, strings.HasPrefix(att.placeholder, "@"))
+	assert.True(t, att.isTemp, "paste attachments should be marked as temp")
+}
+
+func TestHandlePaste_ExceedsCharLimit(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	pastesDir := filepath.Join(tmpDir, "pastes")
+
+	e := &editor{}
+	// Single line exceeding char limit
+	largeContent := strings.Repeat("x", maxInlinePasteChars+1)
+
+	// Create paste buffer directly to test without textarea
+	att, err := createPasteAttachmentInDir(pastesDir, largeContent)
+	require.NoError(t, err)
+
+	e.attachments = append(e.attachments, att)
+
+	// Verify file was created
+	assert.FileExists(t, att.path)
+
+	// Verify attachment struct is correct
+	assert.NotEmpty(t, att.path)
+	assert.True(t, strings.HasPrefix(att.placeholder, "@"))
+	assert.NotEmpty(t, att.label, "label should show size")
+	assert.True(t, att.isTemp, "paste attachments should be marked as temp")
+}
+
+func TestCollectAttachments_WithPastes(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	pastesDir := filepath.Join(tmpDir, "pastes")
+
+	content := "This is the pasted content"
+	att, err := createPasteAttachmentInDir(pastesDir, content)
+	require.NoError(t, err)
+
+	e := &editor{
+		attachments: []attachment{att},
+	}
+
+	input := "Hello " + att.placeholder + " world"
+	result := e.collectAttachments(input)
+
+	// Content should be in the attachments map keyed by placeholder
+	require.NotNil(t, result)
+	assert.Equal(t, content, result[att.placeholder])
+	assert.NoFileExists(t, att.path, "paste file should be removed after collection")
+	assert.Empty(t, e.attachments, "attachments should be cleared")
+}
+
+func TestCollectAttachments_RemovesUnusedFiles(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	pastesDir := filepath.Join(tmpDir, "pastes")
+
+	att, err := createPasteAttachmentInDir(pastesDir, "unused content")
+	require.NoError(t, err)
+
+	e := &editor{
+		attachments: []attachment{att},
+	}
+
+	// Collect with content that doesn't include the placeholder
+	result := e.collectAttachments("no placeholder here")
+
+	assert.Empty(t, result)
+	assert.NoFileExists(t, att.path, "unused paste file should be removed")
+	assert.Empty(t, e.attachments)
+}
+
+func TestCleanup_RemovesAllPasteFiles(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	pastesDir := filepath.Join(tmpDir, "pastes")
+
+	att1, err := createPasteAttachmentInDir(pastesDir, "content 1")
+	require.NoError(t, err)
+
+	att2, err := createPasteAttachmentInDir(pastesDir, "content 2")
+	require.NoError(t, err)
+
+	e := &editor{
+		attachments: []attachment{att1, att2},
+	}
+
+	// Verify files exist before cleanup
+	assert.FileExists(t, att1.path)
+	assert.FileExists(t, att2.path)
+
+	e.Cleanup()
+
+	// Verify files are removed after cleanup
+	assert.NoFileExists(t, att1.path, "att1 should be removed")
+	assert.NoFileExists(t, att2.path, "att2 should be removed")
+	assert.Empty(t, e.attachments, "attachments should be cleared")
+}
+
+func TestCleanup_HandlesEmptyPastes(t *testing.T) {
+	t.Parallel()
+
+	e := &editor{}
+
+	// Should not panic
+	e.Cleanup()
+
+	assert.Empty(t, e.attachments)
+}
+
+// createPasteAttachmentInDir is a test helper that creates a paste attachment in a specific directory.
+func createPasteAttachmentInDir(dir, content string) (attachment, error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return attachment{}, err
+	}
+
+	file, err := os.CreateTemp(dir, "paste-*.txt")
+	if err != nil {
+		return attachment{}, err
+	}
+	defer file.Close()
+
+	if _, err := file.WriteString(content); err != nil {
+		return attachment{}, err
+	}
+
+	path := file.Name()
+	return attachment{
+		path:        path,
+		placeholder: "@" + path,
+		label:       filepath.Base(path) + " (" + units.HumanSize(float64(len(content))) + ")",
+		isTemp:      true,
+	}, nil
+}

--- a/pkg/tui/dialog/attachment_preview.go
+++ b/pkg/tui/dialog/attachment_preview.go
@@ -1,0 +1,186 @@
+package dialog
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/bubbles/v2/viewport"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/docker/cagent/pkg/tui/components/editor"
+	"github.com/docker/cagent/pkg/tui/core"
+	"github.com/docker/cagent/pkg/tui/core/layout"
+	"github.com/docker/cagent/pkg/tui/styles"
+)
+
+// Dialog sizing constants
+const (
+	dialogSizePercent  = 70 // dialog uses 70% of terminal dimensions
+	dialogFramePadding = 6  // border (2) + internal padding (4)
+	dialogMinWidth     = 20
+	dialogChromeRows   = 4 // title + separator + blank line + help
+	dialogFrameHeight  = 4 // top/bottom border + padding
+	minViewportHeight  = 5
+	tabWidth           = 4
+)
+
+type attachmentPreviewDialog struct {
+	width, height int
+	preview       editor.AttachmentPreview
+	viewport      viewport.Model
+
+	titleView     string
+	separatorView string
+	helpView      string
+	dialogWidth   int
+	dialogHeight  int
+	innerWidth    int
+}
+
+// NewAttachmentPreviewDialog returns a dialog that shows attachment content in a scrollable view.
+func NewAttachmentPreviewDialog(preview editor.AttachmentPreview) Dialog {
+	vp := viewport.New(
+		viewport.WithWidth(80),
+		viewport.WithHeight(20),
+	)
+	vp.SoftWrap = true
+	vp.FillHeight = true
+	vp.LeftGutterFunc = func(ctx viewport.GutterContext) string {
+		str := fmt.Sprintf("%4d ", ctx.Index+1)
+		if ctx.Soft {
+			return styles.LineNumberStyle.Render(strings.Repeat(" ", len(str)))
+		}
+		return styles.LineNumberStyle.Render(str)
+	}
+
+	vp.SetContent(sanitizeContent(preview.Content))
+
+	return &attachmentPreviewDialog{
+		preview:  preview,
+		viewport: vp,
+	}
+}
+
+func (d *attachmentPreviewDialog) Init() tea.Cmd {
+	return nil
+}
+
+func (d *attachmentPreviewDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		cmd := d.SetSize(msg.Width, msg.Height)
+		return d, cmd
+
+	case tea.KeyPressMsg:
+		switch msg.String() {
+		case "esc", "q":
+			return d, core.CmdHandler(CloseDialogMsg{})
+		}
+	}
+
+	var cmd tea.Cmd
+	d.viewport, cmd = d.viewport.Update(msg)
+	return d, cmd
+}
+
+func (d *attachmentPreviewDialog) View() string {
+	// Constrain viewport output to fixed dimensions to prevent layout shifts
+	viewportView := lipgloss.NewStyle().
+		Height(d.viewport.Height()).
+		MaxHeight(d.viewport.Height()).
+		Render(d.viewport.View())
+
+	content := lipgloss.JoinVertical(
+		lipgloss.Left,
+		d.titleView,
+		d.separatorView,
+		viewportView,
+		"",
+		d.helpView,
+	)
+
+	return styles.DialogStyle.
+		Width(d.dialogWidth).
+		Height(d.dialogHeight).
+		Render(content)
+}
+
+func (d *attachmentPreviewDialog) Position() (row, col int) {
+	// Use pre-computed dimensions for stable positioning
+	dialogHeight := d.dialogHeight
+	if dialogHeight == 0 {
+		dialogHeight = 20 // fallback before SetSize is called
+	}
+	dialogWidth := d.dialogWidth
+	if dialogWidth == 0 {
+		dialogWidth = dialogMinWidth
+	}
+
+	row = max(0, (d.height-dialogHeight)/2)
+	col = max(0, (d.width-dialogWidth)/2)
+	return row, col
+}
+
+func (d *attachmentPreviewDialog) SetSize(width, height int) tea.Cmd {
+	d.width = width
+	d.height = height
+
+	// Cache computed dimensions
+	d.dialogWidth = d.computeDialogWidth()
+	// Reduce innerWidth by extra margin (2) to prevent softwrap/border overlap issues
+	// and ensure there's a safe gap between content and dialog border
+	d.innerWidth = max(dialogMinWidth, d.dialogWidth-dialogFramePadding-2)
+
+	maxDialogHeight := max(10, (height*dialogSizePercent)/100)
+	chromeHeight := dialogChromeRows + dialogFrameHeight
+	viewportHeight := max(minViewportHeight, maxDialogHeight-chromeHeight)
+	d.dialogHeight = chromeHeight + viewportHeight
+
+	// Pre-render chrome elements
+	d.titleView = renderSingleLine(styles.DialogTitleInfoStyle, d.preview.Title, d.innerWidth)
+	d.separatorView = styles.DialogSeparatorStyle.
+		Width(d.innerWidth).
+		Align(lipgloss.Center).
+		Render(strings.Repeat("─", d.innerWidth))
+
+	helpText := "[esc/q] close | scroll: ↑↓ / wheel"
+	d.helpView = renderSingleLine(styles.DialogHelpStyle, helpText, d.innerWidth)
+
+	d.viewport.SetWidth(d.innerWidth)
+	d.viewport.SetHeight(viewportHeight)
+
+	d.viewport.SetContent(sanitizeContent(d.preview.Content))
+
+	return nil
+}
+
+// sanitizeContent normalizes line endings and expands tabs to spaces to prevent layout issues
+// This ensures more consistent width calculations
+// e.g. '/t' is counted as one char but rendered as multiple, which can cause layout issues
+func sanitizeContent(content string) string {
+	// Normalize line endings to \n to prevent layout issues
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	content = strings.ReplaceAll(content, "\r", "\n")
+	// Expand tabs to spaces to ensure soft wrap calculations match visual width
+	content = strings.ReplaceAll(content, "\t", strings.Repeat(" ", tabWidth))
+	return content
+}
+
+func (d *attachmentPreviewDialog) computeDialogWidth() int {
+	width := d.width * dialogSizePercent / 100
+	if width < 40 {
+		width = d.width - 4
+	}
+	return max(dialogMinWidth, width)
+}
+
+func renderSingleLine(style lipgloss.Style, text string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	trimmed := ansi.Truncate(text, width, "…")
+	padded := trimmed + strings.Repeat(" ", max(0, width-lipgloss.Width(trimmed)))
+	return style.Width(width).Render(padded)
+}

--- a/pkg/tui/styles/styles.go
+++ b/pkg/tui/styles/styles.go
@@ -145,9 +145,11 @@ var (
 )
 
 // Base Styles
+const AppPaddingLeft = 1 // Keep in sync with AppStyle padding
+
 var (
 	BaseStyle = lipgloss.NewStyle().Foreground(TextPrimary)
-	AppStyle  = BaseStyle.Padding(0, 1, 0, 1)
+	AppStyle  = BaseStyle.Padding(0, 1, 0, AppPaddingLeft)
 )
 
 // Text Styles
@@ -346,10 +348,25 @@ var (
 			Color: Accent,
 		},
 	}
-	EditorStyle = BaseStyle.Padding(2, 0, 0, 0)
+	EditorStyle = BaseStyle.Padding(1, 0, 1, 0)
 	// SuggestionGhostStyle renders inline auto-complete hints in a muted tone.
 	// Use a distinct grey so suggestion text is visually separate from the user's input.
 	SuggestionGhostStyle = BaseStyle.Foreground(lipgloss.Color(ColorSuggestionGhost))
+
+	// Attachment banner styles - polished look with subtle border
+	AttachmentBannerStyle = BaseStyle.
+				Foreground(TextSecondary)
+
+	AttachmentBadgeStyle = BaseStyle.
+				Foreground(lipgloss.Color(ColorInfoCyan)).
+				Bold(true)
+
+	AttachmentSizeStyle = BaseStyle.
+				Foreground(TextMuted).
+				Italic(true)
+
+	AttachmentIconStyle = BaseStyle.
+				Foreground(lipgloss.Color(ColorInfoCyan))
 )
 
 // Scrollbar
@@ -361,8 +378,13 @@ var (
 // Resize Handle Style
 var (
 	ResizeHandleStyle = BaseStyle.
-		Foreground(BorderSecondary).
-		Background(BackgroundAlt)
+				Foreground(BorderSecondary)
+
+	ResizeHandleHoverStyle = BaseStyle.
+				Foreground(Accent)
+
+	ResizeHandleActiveStyle = BaseStyle.
+				Foreground(lipgloss.Color(ColorTextPrimary))
 )
 
 // Notification Styles

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -270,6 +270,10 @@ func (a *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.application.Resume(msg.Response)
 		return a, nil
 
+	case chat.EditorHeightChangedMsg:
+		a.completions.SetEditorBottom(msg.Height)
+		return a, nil
+
 	case error:
 		a.err = msg
 		return a, nil
@@ -323,6 +327,9 @@ func (a *appModel) handleWindowResize(width, height int) tea.Cmd {
 
 	cmd = a.chatPage.SetSize(a.width, a.height)
 	cmds = append(cmds, cmd)
+
+	// Update completion manager with actual editor height for popup positioning
+	a.completions.SetEditorBottom(a.chatPage.GetInputHeight())
 
 	// Update status bar width
 	a.statusBar.SetWidth(a.width)


### PR DESCRIPTION
Includes a simple banner on top of the text area to show what files have been attached to the message. 
If a user clicks on an attachment in the banner, they can see a preview of the file.

If the user pastes more than 10 lines or 500 chars, create a temp file and attach it instead
This pasted content will then behave the same as normal attachments

Since this is already more than big enough, a subsequent PR will bring more improvements like showing attachments on the messages too

Screenshots:
<img width="1770" height="1045" alt="Screenshot From 2025-12-09 15-35-38" src="https://github.com/user-attachments/assets/f5fba2fb-6f63-4759-a2fe-d848fa984bdf" />
<img width="1770" height="1045" alt="Screenshot From 2025-12-09 15-35-43" src="https://github.com/user-attachments/assets/d629bf7a-f12e-4c81-a65a-5c810d71b1fd" />