### PR TITLE
Fix dockerized windows builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ FROM builder-$TARGETOS AS builder
 
 FROM scratch AS local
 ARG TARGETOS TARGETARCH
-COPY --from=builder /binaries/cagent-$TARGETOS-$TARGETARCH cagent
+COPY --from=builder /binaries/cagent-$TARGETOS-$TARGETARCH* cagent
 
 FROM scratch AS cross
 COPY --from=builder /binaries .

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -57,7 +57,7 @@ tasks:
 
   build-local:
     desc: Build binaries for local host platform
-    cmd: docker buildx build --target=local {{.BUILD_ARGS}} --platform local --output=./dist .
+    cmd: docker buildx build --target=local {{.BUILD_ARGS}} --platform local --output=./dist . {{if eq OS "windows"}}&& mv ./dist/cagent ./dist/cagent.exe{{end}}
 
   cross:
     desc: Build binaries for multiple platforms

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -15,6 +15,10 @@ If you're hacking on `cagent`, or just want to be on the bleeding edge, then bui
 - [Task 3.44 or higher](https://taskfile.dev/installation/)
 - [`golangci-lint`](https://golangci-lint.run/docs/welcome/install/#binaries)
 
+> Note: On windows, we currently only support building from source via docker with `task build-local`  
+>
+> See [here](#building-with-docker) for more details
+
 ##### Build commands
 
 ```bash


### PR DESCRIPTION
Enable docker builds to work on windows targets as well with `task build-local`