### PR TITLE
Use multi-content when attaching files

### DIFF
--- a/pkg/chat/chat.go
+++ b/pkg/chat/chat.go
@@ -34,14 +34,7 @@ type MessageImageURL struct {
 type Message struct {
 	Role         MessageRole   `json:"role"`
 	Content      string        `json:"content"`
-	Refusal      string        `json:"refusal,omitempty"`
 	MultiContent []MessagePart `json:"multi_content,omitempty"`
-
-	// This property isn't in the official documentation, but it's in
-	// the documentation for the official library for python:
-	// - https://github.com/openai/openai-python/blob/main/chatml.md
-	// - https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb
-	Name string `json:"name,omitempty"`
 
 	// This property is used for the "reasoning" feature supported by deepseek-reasoner
 	// which is not in the official documentation.

--- a/pkg/model/provider/dmr/client.go
+++ b/pkg/model/provider/dmr/client.go
@@ -367,10 +367,6 @@ func convertMessages(messages []chat.Message) []openai.ChatCompletionMessagePara
 				}
 			}
 
-			if msg.Name != "" {
-				assistantParam.Name = param.NewOpt(msg.Name)
-			}
-
 			if msg.FunctionCall != nil {
 				assistantParam.FunctionCall.Name = msg.FunctionCall.Name           //nolint:staticcheck // deprecated but still needed for compatibility
 				assistantParam.FunctionCall.Arguments = msg.FunctionCall.Arguments //nolint:staticcheck // deprecated but still needed for compatibility

--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -219,10 +219,6 @@ func convertMessages(messages []chat.Message) []openai.ChatCompletionMessagePara
 				}
 			}
 
-			if msg.Name != "" {
-				assistantParam.Name = param.NewOpt(msg.Name)
-			}
-
 			if msg.FunctionCall != nil {
 				assistantParam.FunctionCall.Name = msg.FunctionCall.Name           //nolint:staticcheck // deprecated but still needed for compatibility
 				assistantParam.FunctionCall.Arguments = msg.FunctionCall.Arguments //nolint:staticcheck // deprecated but still needed for compatibility

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -98,7 +98,7 @@ func UserMessage(content string, multiContent ...chat.MessagePart) *Message {
 	if len(multiContent) > 0 {
 		msg = chat.Message{
 			Role:         chat.MessageRoleUser,
-			Content:      "",
+			Content:      content,
 			MultiContent: multiContent,
 			CreatedAt:    time.Now().Format(time.RFC3339),
 		}


### PR DESCRIPTION
- brings back showing the user message when the runtime tells us to
- uses multi-content for file attachments
- removes the `DisplayContent` and replaces it with `Attachments`

So if a user types `Summarize the @README.md file` we sent this to the LLM:

```json
{
  "role": "user",
  "content": [
    {
      "type": "text",
      "text": "Summarize the @README.md file"
    },
    {
      "type": "text",
      "text": "Contents of @README.md: <contents>"
    }
  ]
}
```

This can be made better, we could change our `chat.Message` struct a bit to add some more metadata. We can do this later.