### PR TITLE
Faster tests

### DIFF
--- a/pkg/model/provider/anthropic/beta_client_test.go
+++ b/pkg/model/provider/anthropic/beta_client_test.go
@@ -59,12 +59,20 @@ func TestCountAnthropicTokensBeta_Success(t *testing.T) {
 
 // TestCountAnthropicTokensBeta_NoAPIKey tests error when API key is missing
 func TestCountAnthropicTokensBeta_NoAPIKey(t *testing.T) {
+	// Use a test server that returns 401 Unauthorized
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error": {"message": "invalid api key"}}`))
+	}))
+	defer server.Close()
+
 	var messages []anthropic.BetaMessageParam
 	var system []anthropic.BetaTextBlockParam
 
 	client := anthropic.NewClient(
-		option.WithAPIKey("test-key"),
-		// No base URL set
+		option.WithAPIKey("invalid-key"),
+		option.WithBaseURL(server.URL),
+		option.WithMaxRetries(0), // Disable retries to speed up test
 	)
 
 	tokens, err := countAnthropicTokensBeta(t.Context(), client, "claude-3-5-sonnet-20241022", messages, system, nil)
@@ -86,6 +94,7 @@ func TestCountAnthropicTokensBeta_ServerError(t *testing.T) {
 	client := anthropic.NewClient(
 		option.WithAPIKey("test-key"),
 		option.WithBaseURL(server.URL),
+		option.WithMaxRetries(0), // Disable retries to speed up test
 	)
 
 	tokens, err := countAnthropicTokensBeta(t.Context(), client, "claude-3-5-sonnet-20241022", messages, system, nil)

--- a/pkg/model/provider/anthropic/client_test.go
+++ b/pkg/model/provider/anthropic/client_test.go
@@ -321,12 +321,20 @@ func TestCountAnthropicTokens_Success(t *testing.T) {
 
 // TestCountAnthropicTokens_NoAPIKey tests error when API key is missing
 func TestCountAnthropicTokens_NoAPIKey(t *testing.T) {
+	// Use a test server that returns 401 Unauthorized
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error": {"message": "invalid api key"}}`))
+	}))
+	defer server.Close()
+
 	var messages []anthropic.MessageParam
 	var system []anthropic.TextBlockParam
 
 	client := anthropic.NewClient(
-		option.WithAPIKey("test-key"),
-		// No base URL set
+		option.WithAPIKey("invalid-key"),
+		option.WithBaseURL(server.URL),
+		option.WithMaxRetries(0), // Disable retries to speed up test
 	)
 
 	tokens, err := countAnthropicTokens(t.Context(), client, "claude-3-5-sonnet-20241022", messages, system, nil)
@@ -348,6 +356,7 @@ func TestCountAnthropicTokens_ServerError(t *testing.T) {
 	client := anthropic.NewClient(
 		option.WithAPIKey("test-key"),
 		option.WithBaseURL(server.URL),
+		option.WithMaxRetries(0), // Disable retries to speed up test
 	)
 
 	tokens, err := countAnthropicTokens(t.Context(), client, "claude-3-5-sonnet-20241022", messages, system, nil)

--- a/pkg/remote/pull_test.go
+++ b/pkg/remote/pull_test.go
@@ -1,6 +1,9 @@
 package remote
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/crane"
@@ -15,12 +18,28 @@ import (
 )
 
 func TestPullNonExistentRegistry(t *testing.T) {
-	_, err := Pull(t.Context(), "registry.example.com/non-existent:latest", false)
+	// Use a test server that returns 404 for fast failure
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	// Extract host:port from server URL (remove http://)
+	registry := strings.TrimPrefix(server.URL, "http://")
+	_, err := Pull(t.Context(), registry+"/non-existent:latest", false, crane.Insecure)
 	require.Error(t, err)
 }
 
 func TestPullWithOptions(t *testing.T) {
-	_, err := Pull(t.Context(), "registry.example.com/test:latest", false, crane.Insecure)
+	// Use a test server that returns 404 for fast failure
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	// Extract host:port from server URL (remove http://)
+	registry := strings.TrimPrefix(server.URL, "http://")
+	_, err := Pull(t.Context(), registry+"/test:latest", false, crane.Insecure)
 	require.Error(t, err)
 }
 

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -478,7 +478,7 @@ func TestStartBackgroundRAGInit_StopsForwardingAfterContextCancel(t *testing.T) 
 	select {
 	case <-eventsCh:
 		// ok: at least one event forwarded
-	case <-time.After(2 * time.Second):
+	case <-time.After(100 * time.Millisecond):
 		t.Fatalf("expected RAG event to be forwarded before cancellation")
 	}
 
@@ -486,7 +486,7 @@ func TestStartBackgroundRAGInit_StopsForwardingAfterContextCancel(t *testing.T) 
 	cancel()
 
 	// Give the forwarder time to observe cancellation.
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 
 	// Emit another event; it should NOT be forwarded.
 	strategyEvents <- ragtypes.Event{
@@ -497,7 +497,7 @@ func TestStartBackgroundRAGInit_StopsForwardingAfterContextCancel(t *testing.T) 
 	select {
 	case ev := <-eventsCh:
 		t.Fatalf("expected no events after cancellation, got %T", ev)
-	case <-time.After(200 * time.Millisecond):
+	case <-time.After(20 * time.Millisecond):
 		// success: no events forwarded
 	}
 }

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -129,7 +129,7 @@ func TestSessionTracking(t *testing.T) {
 	client.RecordSessionEnd(ctx)
 
 	// Wait for events to be processed
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 
 	requestCount := mockHTTP.GetRequestCount()
 	assert.Positive(t, requestCount, "Expected HTTP requests to be made for session tracking events")
@@ -160,14 +160,13 @@ func TestCommandTracking(t *testing.T) {
 	}
 	err := client.TrackCommand(t.Context(), cmdInfo, func(ctx context.Context) error {
 		executed = true
-		time.Sleep(10 * time.Millisecond)
 		return nil
 	})
 	require.NoError(t, err)
 	assert.True(t, executed)
 
 	// Wait for events to be processed
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 
 	requestCount := mockHTTP.GetRequestCount()
 	assert.Positive(t, requestCount, "Expected HTTP requests to be made for command tracking")
@@ -202,7 +201,7 @@ func TestCommandTrackingWithError(t *testing.T) {
 	assert.Equal(t, testErr, err)
 
 	// Wait for events to be processed
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 
 	requestCount := mockHTTP.GetRequestCount()
 	assert.Positive(t, requestCount, "Expected HTTP requests to be made for command error tracking")
@@ -479,9 +478,7 @@ func TestAllEventTypes(t *testing.T) {
 	client.RecordSessionEnd(ctx)
 
 	// Wait for events to be processed
-
-	// Give additional time for background processing
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 
 	requestCount := mockHTTP.GetRequestCount()
 	assert.Positive(t, requestCount, "Expected HTTP requests to be made for telemetry events")
@@ -530,8 +527,6 @@ func TestTrackServerStart(t *testing.T) {
 	}
 	err := client.TrackServerStart(t.Context(), cmdInfo, func(ctx context.Context) error {
 		executed = true
-		// Simulate server running briefly
-		time.Sleep(10 * time.Millisecond)
 		return nil
 	})
 	require.NoError(t, err)
@@ -598,8 +593,8 @@ func TestHTTPRequestVerification(t *testing.T) {
 
 		client.Track(ctx, event)
 
-		// Give additional time for background processing (race condition fix)
-		time.Sleep(100 * time.Millisecond)
+		// Give time for background processing
+		time.Sleep(20 * time.Millisecond)
 
 		// Debug output
 		t.Logf("HTTP requests captured: %d", mockHTTP.GetRequestCount())
@@ -688,8 +683,8 @@ func TestNon2xxHTTPResponseHandling(t *testing.T) {
 
 	client.Track(t.Context(), &CommandEvent{Action: "error-test", Success: true})
 
-	// Give more time for background processing
-	time.Sleep(100 * time.Millisecond)
+	// Give time for background processing
+	time.Sleep(20 * time.Millisecond)
 
 	requestCount := mockHTTP.GetRequestCount()
 	assert.Positive(t, requestCount, "Expected HTTP request to be made despite error response")
@@ -703,7 +698,7 @@ func TestNon2xxHTTPResponseHandling(t *testing.T) {
 
 	client.Track(t.Context(), &CommandEvent{Action: "not-found-test", Success: true})
 
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 
 	finalRequestCount := mockHTTP.GetRequestCount()
 	assert.GreaterOrEqual(t, finalRequestCount, 2, "Expected at least 2 HTTP requests (500 + 404)")

--- a/pkg/tools/builtin/shell_test.go
+++ b/pkg/tools/builtin/shell_test.go
@@ -2,7 +2,6 @@ package builtin
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -115,9 +114,7 @@ func TestShellTool_ListBackgroundJobs(t *testing.T) {
 	_, err = tool.handler.RunShellBackground(t.Context(), RunShellBackgroundArgs{Cmd: "echo test"})
 	require.NoError(t, err)
 
-	// Wait for job to complete
-	time.Sleep(500 * time.Millisecond)
-
+	// No need to wait - ListBackgroundJobs shows jobs regardless of status
 	listResult, err := tool.handler.ListBackgroundJobs(t.Context(), nil)
 
 	require.NoError(t, err)


### PR DESCRIPTION
Used `cagent run ./examples/gopher.yaml` to optimize our slowest tests