### PR TITLE
Add podcast generation workflow to show the integration in using github models.

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -53,7 +53,7 @@ tasks:
 
   test:
     desc: Run tests
-    cmd: OPENAI_API_KEY= ANTHROPIC_API_KEY= GOOGLE_API_KEY= MISTRAL_API_KEY= go test {{.CLI_ARGS}} ./...
+    cmd: OPENAI_API_KEY= ANTHROPIC_API_KEY= GOOGLE_API_KEY= MISTRAL_API_KEY= GITHUB_TOKEN= go test {{.CLI_ARGS}} ./...
 
   build-local:
     desc: Build binaries for local host platform

--- a/examples/podcastgenerator_githubmodel.yaml
+++ b/examples/podcastgenerator_githubmodel.yaml
@@ -62,6 +62,6 @@ agents:
 models:
   github-model:
     provider: openai
-    model: openai/gpt-5
+    model: gpt-5
     base_url: https://models.github.ai/inference
-    token_Key: ${GITHUB_TOKEN} 
+    token_key: GITHUB_TOKEN

--- a/pkg/config/gather.go
+++ b/pkg/config/gather.go
@@ -55,8 +55,10 @@ func GatherEnvVarsForModels(cfg *latest.Config) []string {
 		for modelName := range modelNames {
 			model := cfg.Models[modelName]
 
-			// Use the token environment variable from the alias if available
-			if alias, exists := provider.Aliases[model.Provider]; exists {
+			if model.TokenKey != "" {
+				requiredEnv[model.TokenKey] = true
+			} else if alias, exists := provider.Aliases[model.Provider]; exists {
+				// Use the token environment variable from the alias if available
 				if alias.TokenEnvVar != "" {
 					requiredEnv[alias.TokenEnvVar] = true
 				}


### PR DESCRIPTION
This pull request introduces a new multi-agent workflow configuration for podcast generation, defined in the `examples/podcastgenerator_githubmodel.yaml` file. The configuration outlines a coordinated process involving three specialized agents—Director, Researcher, and Scriptwriter—each with clear responsibilities and toolsets, and leverages the `github-model` (OpenAI GPT-5) for all agents.

**New Podcast Generation Workflow Configuration:**

* **Overall Orchestration:**
  - Introduces a `root` agent acting as the Podcast Director, responsible for orchestrating the entire podcast creation process, delegating tasks, and ensuring quality control.
  - The Director coordinates with `researcher` and `scriptwriter` sub-agents to manage research and scriptwriting phases.

* **Agent Specialization:**
  - Adds a `researcher` agent focused on gathering comprehensive, accurate, and engaging information using web search (via DuckDuckGo).
  - Adds a `scriptwriter` agent responsible for transforming research into professional, conversational podcast scripts, with support for multiple podcast formats.

* **Toolset Integration:**
  - Configures each agent with specific toolsets: the researcher uses DuckDuckGo for web research, and the scriptwriter uses a filesystem tool for output handling.
  
  Fixes #1042 