### PR TITLE
Enable fine grained tool streaming with anthropic

### DIFF
--- a/pkg/model/provider/anthropic/beta_client.go
+++ b/pkg/model/provider/anthropic/beta_client.go
@@ -55,7 +55,7 @@ func (c *Client) createBetaStream(
 		MaxTokens: maxTokens,
 		Messages:  converted,
 		Tools:     allTools,
-		Betas:     []anthropic.AnthropicBeta{anthropic.AnthropicBetaInterleavedThinking2025_05_14},
+		Betas:     []anthropic.AnthropicBeta{anthropic.AnthropicBetaInterleavedThinking2025_05_14, "fine-grained-tool-streaming-2025-05-14"},
 	}
 
 	// Populate proper Anthropic system prompt from input messages

--- a/pkg/model/provider/anthropic/client.go
+++ b/pkg/model/provider/anthropic/client.go
@@ -294,7 +294,10 @@ func (c *Client) CreateChatCompletionStream(
 		slog.Debug("Request", "request", string(b))
 	}
 
-	stream := client.Messages.NewStreaming(ctx, params)
+	// Add fine-grained tool streaming beta header
+	betaHeader := option.WithHeader("anthropic-beta", "fine-grained-tool-streaming-2025-05-14")
+
+	stream := client.Messages.NewStreaming(ctx, params, betaHeader)
 	trackUsage := c.ModelConfig.TrackUsage == nil || *c.ModelConfig.TrackUsage
 	ad := newStreamAdapter(stream, trackUsage)
 
@@ -313,7 +316,7 @@ func (c *Client) CreateChatCompletionStream(
 		slog.Warn("Retrying with clamped max_tokens after context length error", "original max_tokens", maxTokens, "clamped max_tokens", newMaxTokens, "used tokens", used)
 		retryParams := params
 		retryParams.MaxTokens = newMaxTokens
-		return newStreamAdapter(client.Messages.NewStreaming(ctx, retryParams), trackUsage)
+		return newStreamAdapter(client.Messages.NewStreaming(ctx, retryParams, betaHeader), trackUsage)
 	}
 
 	slog.Debug("Anthropic chat completion stream created successfully", "model", c.ModelConfig.Model)


### PR DESCRIPTION
```
cagent exec --json --model=anthropic/claude-sonnet-4-5 ./examples/filesystem.yaml 'write a 750 word poem in a /tmp/poem.md file'
```

Should now start streaming partial tool calls as soon as the first characters of the poem arrive.