### PR TITLE
searchfile custom description

### DIFF
--- a/pkg/tui/components/tool/factory.go
+++ b/pkg/tui/components/tool/factory.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/cagent/pkg/tui/components/tool/listdirectory"
 	"github.com/docker/cagent/pkg/tui/components/tool/readfile"
 	"github.com/docker/cagent/pkg/tui/components/tool/readmultiplefiles"
+	"github.com/docker/cagent/pkg/tui/components/tool/searchfiles"
 	"github.com/docker/cagent/pkg/tui/components/tool/shell"
 	"github.com/docker/cagent/pkg/tui/components/tool/todotool"
 	"github.com/docker/cagent/pkg/tui/components/tool/transfertask"
@@ -64,6 +65,7 @@ func newDefaultRegistry() *Registry {
 	registry.Register(builtin.ToolNameReadFile, readfile.New)
 	registry.Register(builtin.ToolNameReadMultipleFiles, readmultiplefiles.New)
 	registry.Register(builtin.ToolNameListDirectory, listdirectory.New)
+	registry.Register(builtin.ToolNameSearchFiles, searchfiles.New)
 	registry.Register(builtin.ToolNameCreateTodo, todotool.New)
 	registry.Register(builtin.ToolNameCreateTodos, todotool.New)
 	registry.Register(builtin.ToolNameUpdateTodo, todotool.New)

--- a/pkg/tui/components/tool/searchfiles/searchfiles.go
+++ b/pkg/tui/components/tool/searchfiles/searchfiles.go
@@ -1,0 +1,123 @@
+package searchfiles
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/docker/cagent/pkg/tools/builtin"
+	"github.com/docker/cagent/pkg/tui/components/spinner"
+	"github.com/docker/cagent/pkg/tui/components/toolcommon"
+	"github.com/docker/cagent/pkg/tui/core/layout"
+	"github.com/docker/cagent/pkg/tui/service"
+	"github.com/docker/cagent/pkg/tui/types"
+)
+
+// Component is a specialized component for rendering search_files tool calls.
+type Component struct {
+	message *types.Message
+	spinner spinner.Spinner
+	width   int
+	height  int
+}
+
+// New creates a new search files component.
+func New(
+	msg *types.Message,
+	_ *service.SessionState,
+) layout.Model {
+	return &Component{
+		message: msg,
+		spinner: spinner.New(spinner.ModeSpinnerOnly),
+		width:   80,
+		height:  1,
+	}
+}
+
+func (c *Component) SetSize(width, height int) tea.Cmd {
+	c.width = width
+	c.height = height
+	return nil
+}
+
+func (c *Component) Init() tea.Cmd {
+	if c.message.ToolStatus == types.ToolStatusPending || c.message.ToolStatus == types.ToolStatusRunning {
+		return c.spinner.Init()
+	}
+	return nil
+}
+
+func (c *Component) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
+	if c.message.ToolStatus == types.ToolStatusPending || c.message.ToolStatus == types.ToolStatusRunning {
+		var cmd tea.Cmd
+		var model layout.Model
+		model, cmd = c.spinner.Update(msg)
+		c.spinner = model.(spinner.Spinner)
+		return c, cmd
+	}
+
+	return c, nil
+}
+
+func (c *Component) View() string {
+	msg := c.message
+
+	// Parse arguments
+	var args builtin.SearchFilesArgs
+	if err := json.Unmarshal([]byte(msg.ToolCall.Function.Arguments), &args); err != nil {
+		return toolcommon.RenderTool(toolcommon.Icon(msg.ToolStatus), msg.ToolDefinition.DisplayName(), c.spinner.View(), "", c.width)
+	}
+
+	// Format display name with pattern
+	displayName := fmt.Sprintf("%s(%q)", msg.ToolDefinition.DisplayName(), args.Pattern)
+
+	// For pending/running state, show spinner
+	if msg.ToolStatus == types.ToolStatusPending || msg.ToolStatus == types.ToolStatusRunning {
+		return toolcommon.RenderTool(toolcommon.Icon(msg.ToolStatus), displayName, c.spinner.View(), "", c.width)
+	}
+
+	// For completed/error state, show concise summary
+	summary := formatSummary(msg.Content)
+	params := fmt.Sprintf(": %s", summary)
+
+	return toolcommon.RenderTool(toolcommon.Icon(msg.ToolStatus), displayName, params, "", c.width)
+}
+
+// formatSummary creates a concise summary of the search results
+func formatSummary(content string) string {
+	if content == "" {
+		return "no result"
+	}
+
+	// Handle "No files found" case
+	if strings.HasPrefix(content, "No files found") {
+		return "no file found"
+	}
+
+	// Handle error cases
+	if strings.HasPrefix(content, "Error") {
+		return content
+	}
+
+	// Parse "X files found:\n..." format
+	lines := strings.Split(content, "\n")
+	if len(lines) > 0 {
+		firstLine := lines[0]
+		// Extract count from "X files found:" or "X file found:"
+		if strings.Contains(firstLine, "file found:") || strings.Contains(firstLine, "files found:") {
+			// Check if it's a single file
+			if strings.HasPrefix(firstLine, "1 file found:") && len(lines) > 1 {
+				// Return "one file found: filename"
+				fileName := strings.TrimSpace(lines[1])
+				return fmt.Sprintf("one file found: %s", fileName)
+			}
+			// Multiple files
+			return strings.TrimSuffix(firstLine, ":") + "."
+		}
+	}
+
+	// Fallback
+	return content
+}

--- a/pkg/tui/components/tool/searchfiles/searchfiles_test.go
+++ b/pkg/tui/components/tool/searchfiles/searchfiles_test.go
@@ -1,0 +1,58 @@
+package searchfiles
+
+import (
+	"testing"
+)
+
+func TestFormatSummary(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "single file found",
+			content: "1 file found:\ntest.txt",
+			want:    "one file found: test.txt",
+		},
+		{
+			name:    "single file found with path",
+			content: "1 file found:\n/path/to/file.go",
+			want:    "one file found: /path/to/file.go",
+		},
+		{
+			name:    "two files found",
+			content: "2 files found:\nfile1.txt\nfile2.txt",
+			want:    "2 files found.",
+		},
+		{
+			name:    "multiple files found",
+			content: "7 files found:\ngordon.yaml\ngordon_dev.yaml\ngordon_workspace/gordon_dev_modular.yaml\nold/gordon-handoff.yaml\nold/gordon_dev_bu.yaml\nold/gordon_dev_test.yaml\nold/v2/gordon_dev_modular.yaml",
+			want:    "7 files found.",
+		},
+		{
+			name:    "no files found",
+			content: "No files found",
+			want:    "no file found",
+		},
+		{
+			name:    "empty content",
+			content: "",
+			want:    "no result",
+		},
+		{
+			name:    "error case",
+			content: "Error: permission denied",
+			want:    "Error: permission denied",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatSummary(tt.content)
+			if got != tt.want {
+				t.Errorf("formatSummary() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Improve search_files tool output in TUI

Changes the search_files tool output from verbose multi-line format to a concise one-liner.

**Before:**
```
 ✓ Search Files
 path:
 .
 pattern:
 gordon*.yaml
 -> output:
 7 files found:
 gordon.yaml
 gordon_dev.yaml
 ...
 ```

 **After:**
 ```
  ┃ ✓ Search Files("gordon*.yaml"): 7 files found.
  ```
