### PR TITLE
Add --fake flag for e2e test session replay

### DIFF
--- a/e2e/proxy_test.go
+++ b/e2e/proxy_test.go
@@ -1,207 +1,67 @@
 package e2e_test
 
 import (
-	"bytes"
 	"context"
-	"io"
-	"log/slog"
-	"maps"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"regexp"
-	"strings"
 	"testing"
 
-	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/dnaeon/go-vcr.v4/pkg/cassette"
 	"gopkg.in/dnaeon/go-vcr.v4/pkg/recorder"
 
 	"github.com/docker/cagent/pkg/config"
 	"github.com/docker/cagent/pkg/environment"
+	"github.com/docker/cagent/pkg/fake"
 )
-
-func removeHeadersHook(i *cassette.Interaction) error {
-	i.Request.Headers = map[string][]string{}
-	i.Response.Headers = map[string][]string{}
-	return nil
-}
-
-func customMatcher(t *testing.T) recorder.MatcherFunc {
-	t.Helper()
-
-	callIDRegex := regexp.MustCompile(`call_[a-z0-9\-]+`)
-
-	return func(r *http.Request, i cassette.Request) bool {
-		if r.Body == nil || r.Body == http.NoBody {
-			return cassette.DefaultMatcher(r, i)
-		}
-		if r.Method != i.Method {
-			return false
-		}
-		if r.URL.String() != i.URL {
-			return false
-		}
-
-		reqBody, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
-		r.Body.Close()
-		r.Body = io.NopCloser(bytes.NewBuffer(reqBody))
-
-		// Ignore Gemini's functionResponse's names
-		return callIDRegex.ReplaceAllString(string(reqBody), "call_ID") == callIDRegex.ReplaceAllString(i.Body, "call_ID")
-	}
-}
 
 func startRecordingAIProxy(t *testing.T) (*httptest.Server, *config.RuntimeConfig) {
 	t.Helper()
 
-	transport, err := recorder.New(filepath.Join("testdata", "cassettes", t.Name()),
-		recorder.WithMode(recorder.ModeRecordOnce),
-		recorder.WithMatcher(customMatcher(t)),
-		recorder.WithSkipRequestLatency(true),
-		recorder.WithHook(removeHeadersHook, recorder.AfterCaptureHook),
+	cassettePath := filepath.Join("testdata", "cassettes", t.Name())
+
+	// Create a matcher that fails the test on error
+	matcher := fake.CustomMatcher(func(err error) {
+		require.NoError(t, err)
+	})
+
+	// Header updater that adds real API keys for recording
+	headerUpdater := func(host string, req *http.Request) {
+		switch host {
+		case "https://api.openai.com/v1":
+			req.Header.Set("Authorization", "Bearer "+os.Getenv("OPENAI_API_KEY"))
+		case "https://api.anthropic.com":
+			req.Header.Del("Authorization")
+			req.Header.Set("X-Api-Key", os.Getenv("ANTHROPIC_API_KEY"))
+		case "https://generativelanguage.googleapis.com":
+			req.Header.Del("Authorization")
+			req.Header.Set("X-Goog-Api-Key", os.Getenv("GOOGLE_API_KEY"))
+		case "https://api.mistral.ai/v1":
+			req.Header.Set("Authorization", "Bearer "+os.Getenv("MISTRAL_API_KEY"))
+		}
+	}
+
+	proxyURL, cleanup, err := fake.StartProxyWithOptions(
+		cassettePath,
+		recorder.ModeRecordOnce,
+		matcher,
+		headerUpdater,
 	)
 	require.NoError(t, err)
 
-	t.Cleanup(func() { require.NoError(t, transport.Stop()) })
+	t.Cleanup(func() {
+		require.NoError(t, cleanup())
+	})
 
-	e := echo.New()
-	e.Any("/*", handle(transport))
-
-	httpServer := httptest.NewServer(e)
-	t.Cleanup(httpServer.Close)
-
-	return httpServer, &config.RuntimeConfig{
+	return &httptest.Server{URL: proxyURL}, &config.RuntimeConfig{
 		Config: config.Config{
-			ModelsGateway: httpServer.URL,
+			ModelsGateway: proxyURL,
 		},
 		EnvProviderForTests: &testEnvProvider{
 			environment.DockerDesktopTokenEnv: "DUMMY",
 		},
 	}
-}
-
-func handle(transport http.RoundTripper) echo.HandlerFunc {
-	return func(c echo.Context) error {
-		ctx := c.Request().Context()
-
-		host := c.Request().Header.Get("X-Cagent-Forward")
-		host = strings.TrimSuffix(host, "/")
-
-		var toTargetURL func(req *http.Request) string
-		var updateHeaders func(req *http.Request)
-		switch host {
-		case "https://api.openai.com/v1":
-			toTargetURL = func(req *http.Request) string {
-				return "https://api.openai.com" + req.URL.Redacted()
-			}
-			updateHeaders = func(req *http.Request) {
-				req.Header.Set("Authorization", "Bearer "+os.Getenv("OPENAI_API_KEY"))
-			}
-		case "https://api.anthropic.com":
-			toTargetURL = func(req *http.Request) string {
-				return "https://api.anthropic.com" + req.URL.Redacted()
-			}
-			updateHeaders = func(req *http.Request) {
-				req.Header.Del("Authorization")
-				req.Header.Set("X-Api-Key", os.Getenv("ANTHROPIC_API_KEY"))
-			}
-		case "https://generativelanguage.googleapis.com":
-			toTargetURL = func(req *http.Request) string {
-				return "https://generativelanguage.googleapis.com" + req.URL.Redacted()
-			}
-			updateHeaders = func(req *http.Request) {
-				req.Header.Del("Authorization")
-				req.Header.Set("X-Goog-Api-Key", os.Getenv("GOOGLE_API_KEY"))
-			}
-		case "https://api.mistral.ai/v1":
-			toTargetURL = func(req *http.Request) string {
-				return "https://api.mistral.ai" + req.URL.Redacted()
-			}
-			updateHeaders = func(req *http.Request) {
-				req.Header.Set("Authorization", "Bearer "+os.Getenv("MISTRAL_API_KEY"))
-			}
-		default:
-			return echo.NewHTTPError(http.StatusBadRequest, "unknown service host "+host)
-		}
-
-		targetURL := toTargetURL(c.Request())
-
-		req, err := http.NewRequestWithContext(ctx, c.Request().Method, targetURL, c.Request().Body)
-		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to create new request")
-		}
-
-		maps.Copy(req.Header, c.Request().Header)
-		updateHeaders(req)
-
-		client := &http.Client{
-			Timeout:   0, // no timeout, let ctx control it
-			Transport: transport,
-		}
-
-		resp, err := client.Do(req)
-		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to run request"+err.Error())
-		}
-		defer resp.Body.Close()
-
-		maps.Copy(c.Response().Header(), resp.Header)
-
-		c.Response().WriteHeader(resp.StatusCode)
-
-		if isStreamResponse(resp) {
-			return streamCopy(c, resp)
-		}
-
-		_, err = io.Copy(c.Response().Writer, resp.Body)
-		return err
-	}
-}
-
-func streamCopy(c echo.Context, resp *http.Response) error {
-	ctx := c.Request().Context()
-
-	writer := c.Response().Writer.(io.ReaderFrom)
-
-	for {
-		select {
-		case <-ctx.Done():
-			slog.WarnContext(ctx, "client disconnected, stop streaming")
-			return nil
-		default:
-			n, err := writer.ReadFrom(io.LimitReader(resp.Body, 256))
-			if n > 0 {
-				c.Response().Flush() // keep flushing to client
-			}
-			if err != nil {
-				if err == io.EOF || ctx.Err() != nil {
-					return nil
-				}
-				slog.ErrorContext(ctx, "stream read error", "error", err)
-				return err
-			}
-		}
-	}
-}
-
-func isStreamResponse(resp *http.Response) bool {
-	ct := strings.ToLower(resp.Header.Get("Content-Type"))
-	if strings.Contains(ct, "text/event-stream") {
-		return true
-	}
-
-	te := strings.ToLower(resp.Header.Get("Transfer-Encoding"))
-	if strings.Contains(te, "chunked") && !strings.Contains(ct, "application/json") {
-		return true
-	}
-
-	return strings.Contains(ct, "application/octet-stream") ||
-		strings.Contains(ct, "application/x-ndjson") ||
-		strings.Contains(ct, "application/stream+json")
 }
 
 type testEnvProvider map[string]string

--- a/pkg/fake/proxy.go
+++ b/pkg/fake/proxy.go
@@ -1,0 +1,225 @@
+// Package fake provides a VCR-based proxy for replaying recorded AI API responses.
+// This is useful for E2E testing without making real API calls.
+package fake
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log/slog"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	"gopkg.in/dnaeon/go-vcr.v4/pkg/cassette"
+	"gopkg.in/dnaeon/go-vcr.v4/pkg/recorder"
+)
+
+// StartProxy starts an internal HTTP proxy that replays cassette responses.
+// It returns the proxy URL and a cleanup function that should be called when done.
+func StartProxy(cassettePath string) (string, func() error, error) {
+	return StartProxyWithOptions(cassettePath, recorder.ModeReplayOnly, nil, nil)
+}
+
+// StartProxyWithOptions starts an internal HTTP proxy with configurable options.
+// - mode: recorder mode (ModeReplayOnly, ModeRecordOnce, etc.)
+// - matcher: custom matcher function (nil uses default CustomMatcher)
+// - headerUpdater: optional function to update request headers (for recording with real API keys)
+func StartProxyWithOptions(
+	cassettePath string,
+	mode recorder.Mode,
+	matcher recorder.MatcherFunc,
+	headerUpdater func(host string, req *http.Request),
+) (string, func() error, error) {
+	if matcher == nil {
+		matcher = CustomMatcher(nil)
+	}
+
+	transport, err := recorder.New(cassettePath,
+		recorder.WithMode(mode),
+		recorder.WithMatcher(matcher),
+		recorder.WithSkipRequestLatency(true),
+		recorder.WithHook(RemoveHeadersHook, recorder.AfterCaptureHook),
+	)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to create VCR recorder: %w", err)
+	}
+
+	e := echo.New()
+	e.HideBanner = true
+	e.HidePort = true
+	e.Any("/*", Handle(transport, headerUpdater))
+
+	httpServer := httptest.NewServer(e)
+
+	cleanup := func() error {
+		httpServer.Close()
+		return transport.Stop()
+	}
+
+	return httpServer.URL, cleanup, nil
+}
+
+// RemoveHeadersHook strips headers from recorded interactions for security.
+func RemoveHeadersHook(i *cassette.Interaction) error {
+	i.Request.Headers = map[string][]string{}
+	i.Response.Headers = map[string][]string{}
+	return nil
+}
+
+// CustomMatcher creates a matcher that normalizes tool call IDs for consistent matching.
+// The onError callback is called if reading the request body fails (nil logs and returns false).
+func CustomMatcher(onError func(err error)) recorder.MatcherFunc {
+	callIDRegex := regexp.MustCompile(`call_[a-z0-9\-]+`)
+
+	return func(r *http.Request, i cassette.Request) bool {
+		if r.Body == nil || r.Body == http.NoBody {
+			return cassette.DefaultMatcher(r, i)
+		}
+		if r.Method != i.Method {
+			return false
+		}
+		if r.URL.String() != i.URL {
+			return false
+		}
+
+		reqBody, err := io.ReadAll(r.Body)
+		if err != nil {
+			if onError != nil {
+				onError(err)
+			} else {
+				slog.Error("Failed to read request body for matching", "error", err)
+			}
+			return false
+		}
+		r.Body.Close()
+		r.Body = io.NopCloser(bytes.NewBuffer(reqBody))
+
+		// Normalize tool call IDs for matching
+		return callIDRegex.ReplaceAllString(string(reqBody), "call_ID") == callIDRegex.ReplaceAllString(i.Body, "call_ID")
+	}
+}
+
+// TargetURLForHost returns the target URL builder for a given forwarding host.
+// Returns nil if the host is not recognized.
+func TargetURLForHost(host string) func(req *http.Request) string {
+	switch host {
+	case "https://api.openai.com/v1":
+		return func(req *http.Request) string {
+			return "https://api.openai.com" + req.URL.Redacted()
+		}
+	case "https://api.anthropic.com":
+		return func(req *http.Request) string {
+			return "https://api.anthropic.com" + req.URL.Redacted()
+		}
+	case "https://generativelanguage.googleapis.com":
+		return func(req *http.Request) string {
+			return "https://generativelanguage.googleapis.com" + req.URL.Redacted()
+		}
+	case "https://api.mistral.ai/v1":
+		return func(req *http.Request) string {
+			return "https://api.mistral.ai" + req.URL.Redacted()
+		}
+	default:
+		return nil
+	}
+}
+
+// Handle creates an echo handler that proxies requests through the VCR transport.
+// The headerUpdater is called with the host and request to update headers (e.g., for adding API keys).
+func Handle(transport http.RoundTripper, headerUpdater func(host string, req *http.Request)) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		ctx := c.Request().Context()
+
+		host := c.Request().Header.Get("X-Cagent-Forward")
+		host = strings.TrimSuffix(host, "/")
+
+		toTargetURL := TargetURLForHost(host)
+		if toTargetURL == nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "unknown service host "+host)
+		}
+
+		targetURL := toTargetURL(c.Request())
+
+		req, err := http.NewRequestWithContext(ctx, c.Request().Method, targetURL, c.Request().Body)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to create new request")
+		}
+
+		maps.Copy(req.Header, c.Request().Header)
+
+		if headerUpdater != nil {
+			headerUpdater(host, req)
+		}
+
+		client := &http.Client{
+			Timeout:   0, // no timeout, let ctx control it
+			Transport: transport,
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			slog.Error("VCR proxy request failed", "url", targetURL, "error", err)
+			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to run request: "+err.Error())
+		}
+		defer resp.Body.Close()
+
+		maps.Copy(c.Response().Header(), resp.Header)
+
+		c.Response().WriteHeader(resp.StatusCode)
+
+		if IsStreamResponse(resp) {
+			return StreamCopy(c, resp)
+		}
+
+		_, err = io.Copy(c.Response().Writer, resp.Body)
+		return err
+	}
+}
+
+// StreamCopy copies a streaming response to the client.
+func StreamCopy(c echo.Context, resp *http.Response) error {
+	ctx := c.Request().Context()
+
+	writer := c.Response().Writer.(io.ReaderFrom)
+
+	for {
+		select {
+		case <-ctx.Done():
+			slog.WarnContext(ctx, "client disconnected, stop streaming")
+			return nil
+		default:
+			n, err := writer.ReadFrom(io.LimitReader(resp.Body, 256))
+			if n > 0 {
+				c.Response().Flush() // keep flushing to client
+			}
+			if err != nil {
+				if err == io.EOF || ctx.Err() != nil {
+					return nil
+				}
+				slog.ErrorContext(ctx, "stream read error", "error", err)
+				return err
+			}
+		}
+	}
+}
+
+// IsStreamResponse checks if the response should be streamed.
+func IsStreamResponse(resp *http.Response) bool {
+	ct := strings.ToLower(resp.Header.Get("Content-Type"))
+	if strings.Contains(ct, "text/event-stream") {
+		return true
+	}
+
+	te := strings.ToLower(resp.Header.Get("Transfer-Encoding"))
+	if strings.Contains(te, "chunked") && !strings.Contains(ct, "application/json") {
+		return true
+	}
+
+	return strings.Contains(ct, "application/octet-stream") ||
+		strings.Contains(ct, "application/x-ndjson") ||
+		strings.Contains(ct, "application/stream+json")
+}


### PR DESCRIPTION
## Summary
- Add `--fake <cassette-path>` flag to replay recorded AI responses for E2E testing
- Extract VCR proxy logic into reusable `pkg/fake` package
- Refactor `e2e/proxy_test.go` to use shared code, removing ~110 lines of duplication

## Test plan
- [x] Build passes (`task build`)
- [x] Lint passes (`task lint`)
- [x] Manual test with curl (see below)
- [x] E2E tests pass (`task test`)

### Manual testing

**Terminal 1 - Start server with fake mode:**
```
./bin/cagent api \
  --fake ./e2e/testdata/cassettes/TestExec_OpenAI \
  --listen :8080 \
  --session-db /tmp/test-session.db \
  ./e2e/testdata/basic.yaml
```
  
**Terminal 2 - Test normal endpoints and AI replay:
```
# Create session and send message
SESSION_ID=$(curl -s -X POST http://localhost:8080/api/sessions \
  -H "Content-Type: application/json" -d '{}' | jq -r '.id')

curl -N "http://localhost:8080/api/sessions/${SESSION_ID}/agent/basic.yaml" \
  -H "Content-Type: application/json" \
  -d '[{"role": "user", "content": "What'\''s 2+2?"}]'
```

**Expected output (replayed from cassette, no real API call):
```
data: {"type":"agent_info","agent_name":"root","model":"openai/gpt-3.5-turbo","description":"A helpful AI assistant"}
data: {"type":"stream_started","session_id":"...","agent_name":"root"}
data: {"type":"agent_choice","content":"2","agent_name":"root"}
data: {"type":"agent_choice","content":" +","agent_name":"root"}
data: {"type":"agent_choice","content":" ","agent_name":"root"}
data: {"type":"agent_choice","content":"2","agent_name":"root"}
data: {"type":"agent_choice","content":" equals","agent_name":"root"}
data: {"type":"agent_choice","content":" ","agent_name":"root"}
data: {"type":"agent_choice","content":"4","agent_name":"root"}
data: {"type":"agent_choice","content":".","agent_name":"root"}
data: {"type":"stream_stopped","session_id":"...","agent_name":"root"}
```