### PR TITLE
fixes (#1067) : file diff width same as other messages

### DIFF
--- a/pkg/tui/components/tool/editfile/editfile.go
+++ b/pkg/tui/components/tool/editfile/editfile.go
@@ -79,7 +79,7 @@ func (c *Component) View() string {
 	}
 
 	if msg.ToolCall.Function.Arguments != "" {
-		content += "\n\n" + styles.ToolCallResult.Render(renderEditFile(msg.ToolCall, c.width-4, c.sessionState.SplitDiffView, msg.ToolStatus))
+		content += "\n\n" + styles.ToolCallResult.Render(renderEditFile(msg.ToolCall, c.width-1, c.sessionState.SplitDiffView, msg.ToolStatus))
 	}
 
 	var resultContent string


### PR DESCRIPTION
Fix for edit_file tool width issue

<img width="1409" height="418" alt="Screenshot from 2025-12-12 16-18-31" src="https://github.com/user-attachments/assets/12e0aaba-dd0a-459e-bcde-2e828b1600fa" />