### PR TITLE
Add follow-up suggestions feature

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -6,30 +6,32 @@ import (
 	"log/slog"
 	"math/rand"
 
+	"github.com/docker/cagent/pkg/config/latest"
 	"github.com/docker/cagent/pkg/model/provider"
 	"github.com/docker/cagent/pkg/tools"
 )
 
 // Agent represents an AI agent
 type Agent struct {
-	name               string
-	description        string
-	welcomeMessage     string
-	instruction        string
-	toolsets           []*StartableToolSet
-	models             []provider.Provider
-	subAgents          []*Agent
-	handoffs           []*Agent
-	parents            []*Agent
-	addDate            bool
-	addEnvironmentInfo bool
-	maxIterations      int
-	numHistoryItems    int
-	addPromptFiles     []string
-	tools              []tools.Tool
-	commands           map[string]string
-	pendingWarnings    []string
-	skillsEnabled      bool
+	name                    string
+	description             string
+	welcomeMessage          string
+	instruction             string
+	toolsets                []*StartableToolSet
+	models                  []provider.Provider
+	subAgents               []*Agent
+	handoffs                []*Agent
+	parents                 []*Agent
+	addDate                 bool
+	addEnvironmentInfo      bool
+	maxIterations           int
+	numHistoryItems         int
+	addPromptFiles          []string
+	tools                   []tools.Tool
+	commands                map[string]string
+	pendingWarnings         []string
+	skillsEnabled           bool
+	followUpSuggestionsConf *latest.FollowUpSuggestionsConfig
 }
 
 // New creates a new agent
@@ -118,6 +120,11 @@ func (a *Agent) Commands() map[string]string {
 // SkillsEnabled returns whether skills discovery is enabled for this agent.
 func (a *Agent) SkillsEnabled() bool {
 	return a.skillsEnabled
+}
+
+// FollowUpSuggestionsConfig returns the follow-up suggestions configuration for this agent.
+func (a *Agent) FollowUpSuggestionsConfig() *latest.FollowUpSuggestionsConfig {
+	return a.followUpSuggestionsConf
 }
 
 // Tools returns the tools available to this agent

--- a/pkg/agent/opts.go
+++ b/pkg/agent/opts.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"sync/atomic"
 
+	"github.com/docker/cagent/pkg/config/latest"
 	"github.com/docker/cagent/pkg/model/provider"
 	"github.com/docker/cagent/pkg/tools"
 )
@@ -120,6 +121,12 @@ func WithLoadTimeWarnings(warnings []string) Opt {
 func WithSkillsEnabled(enabled bool) Opt {
 	return func(a *Agent) {
 		a.skillsEnabled = enabled
+	}
+}
+
+func WithFollowUpSuggestions(config *latest.FollowUpSuggestionsConfig) Opt {
+	return func(a *Agent) {
+		a.followUpSuggestionsConf = config
 	}
 }
 

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -22,23 +22,31 @@ type Config struct {
 
 // AgentConfig represents a single agent configuration
 type AgentConfig struct {
-	Model              string            `json:"model,omitempty"`
-	Description        string            `json:"description,omitempty"`
-	WelcomeMessage     string            `json:"welcome_message,omitempty"`
-	Toolsets           []Toolset         `json:"toolsets,omitempty"`
-	Instruction        string            `json:"instruction,omitempty"`
-	SubAgents          []string          `json:"sub_agents,omitempty"`
-	Handoffs           []string          `json:"handoffs,omitempty"`
-	RAG                []string          `json:"rag,omitempty"`
-	AddDate            bool              `json:"add_date,omitempty"`
-	AddEnvironmentInfo bool              `json:"add_environment_info,omitempty"`
-	CodeModeTools      bool              `json:"code_mode_tools,omitempty"`
-	MaxIterations      int               `json:"max_iterations,omitempty"`
-	NumHistoryItems    int               `json:"num_history_items,omitempty"`
-	AddPromptFiles     []string          `json:"add_prompt_files,omitempty" yaml:"add_prompt_files,omitempty"`
-	Commands           types.Commands    `json:"commands,omitempty"`
-	StructuredOutput   *StructuredOutput `json:"structured_output,omitempty"`
-	Skills             *bool             `json:"skills,omitempty"`
+	Model               string                     `json:"model,omitempty"`
+	Description         string                     `json:"description,omitempty"`
+	WelcomeMessage      string                     `json:"welcome_message,omitempty"`
+	Toolsets            []Toolset                  `json:"toolsets,omitempty"`
+	Instruction         string                     `json:"instruction,omitempty"`
+	SubAgents           []string                   `json:"sub_agents,omitempty"`
+	Handoffs            []string                   `json:"handoffs,omitempty"`
+	RAG                 []string                   `json:"rag,omitempty"`
+	AddDate             bool                       `json:"add_date,omitempty"`
+	AddEnvironmentInfo  bool                       `json:"add_environment_info,omitempty"`
+	CodeModeTools       bool                       `json:"code_mode_tools,omitempty"`
+	MaxIterations       int                        `json:"max_iterations,omitempty"`
+	NumHistoryItems     int                        `json:"num_history_items,omitempty"`
+	AddPromptFiles      []string                   `json:"add_prompt_files,omitempty" yaml:"add_prompt_files,omitempty"`
+	Commands            types.Commands             `json:"commands,omitempty"`
+	StructuredOutput    *StructuredOutput          `json:"structured_output,omitempty"`
+	Skills              *bool                      `json:"skills,omitempty"`
+	FollowUpSuggestions *FollowUpSuggestionsConfig `json:"follow_up_suggestions,omitempty"`
+}
+
+// FollowUpSuggestionsConfig represents configuration for follow-up suggestions
+type FollowUpSuggestionsConfig struct {
+	Enabled   bool `json:"enabled"`
+	MaxCount  int  `json:"max_count,omitempty"`  // Default: 3
+	TimeoutMs int  `json:"timeout_ms,omitempty"` // Default: 5000
 }
 
 // ModelConfig represents the configuration for a model

--- a/pkg/runtime/event.go
+++ b/pkg/runtime/event.go
@@ -478,3 +478,18 @@ func RAGIndexingCompleted(ragName, strategyName, agentName string) Event {
 		AgentContext: AgentContext{AgentName: agentName},
 	}
 }
+
+// FollowUpSuggestionsEvent is sent when follow-up suggestions are available
+type FollowUpSuggestionsEvent struct {
+	Type        string   `json:"type"`
+	Suggestions []string `json:"suggestions"`
+	AgentContext
+}
+
+func FollowUpSuggestions(suggestions []string, agentName string) Event {
+	return &FollowUpSuggestionsEvent{
+		Type:         "follow_up_suggestions",
+		Suggestions:  suggestions,
+		AgentContext: AgentContext{AgentName: agentName},
+	}
+}

--- a/pkg/runtime/suggestions_generator.go
+++ b/pkg/runtime/suggestions_generator.go
@@ -1,0 +1,166 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/docker/cagent/pkg/agent"
+	"github.com/docker/cagent/pkg/config/latest"
+	"github.com/docker/cagent/pkg/model/provider"
+	"github.com/docker/cagent/pkg/model/provider/options"
+	"github.com/docker/cagent/pkg/session"
+	"github.com/docker/cagent/pkg/team"
+)
+
+const (
+	suggestionsSystemPrompt = `You are a helpful AI assistant. Based on the conversation, suggest follow-up actions or questions the user might want to explore next.
+
+Rules:
+- Keep each suggestion very concise (under 8 words)
+- Use action verbs or short questions
+- No explanations, just the suggestion text
+
+Return suggestions as a JSON array of strings:
+["suggestion 1", "suggestion 2", "suggestion 3"]
+
+Return ONLY the JSON array, nothing else. Order suggestions by relevance (most relevant first).`
+
+	suggestionsUserPromptFormat = `Based on this conversation, suggest %d follow-up options:
+
+Last user message: %s
+
+Last assistant response: %s
+
+Provide exactly %d suggestions as a JSON array.`
+
+	defaultMaxCount   = 3
+	defaultTimeoutMs  = 5000
+	maxResponseTokens = 300
+)
+
+type suggestionsGenerator struct {
+	wg      sync.WaitGroup
+	model   provider.Provider
+	config  *latest.FollowUpSuggestionsConfig
+	enabled bool
+}
+
+func newSuggestionsGenerator(model provider.Provider, config *latest.FollowUpSuggestionsConfig) *suggestionsGenerator {
+	enabled := config != nil && config.Enabled
+	return &suggestionsGenerator{
+		model:   model,
+		config:  config,
+		enabled: enabled,
+	}
+}
+
+func (s *suggestionsGenerator) Generate(ctx context.Context, sess *session.Session, events chan<- Event, agentName string) {
+	if !s.enabled {
+		return
+	}
+
+	s.wg.Go(func() {
+		s.generate(ctx, sess, events, agentName)
+	})
+}
+
+func (s *suggestionsGenerator) Wait() {
+	s.wg.Wait()
+}
+
+func (s *suggestionsGenerator) generate(ctx context.Context, sess *session.Session, events chan<- Event, agentName string) {
+	// Apply timeout
+	timeout := time.Duration(defaultTimeoutMs) * time.Millisecond
+	if s.config != nil && s.config.TimeoutMs > 0 {
+		timeout = time.Duration(s.config.TimeoutMs) * time.Millisecond
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	slog.Debug("Generating follow-up suggestions", "session_id", sess.ID)
+
+	lastUserMsg := sess.GetLastUserMessageContent()
+	lastAssistantMsg := sess.GetLastAssistantMessageContent()
+
+	if lastUserMsg == "" || lastAssistantMsg == "" {
+		slog.Debug("Skipping suggestions generation: missing user or assistant message")
+		return
+	}
+
+	maxCount := defaultMaxCount
+	if s.config != nil && s.config.MaxCount > 0 {
+		maxCount = s.config.MaxCount
+	}
+
+	userPrompt := fmt.Sprintf(suggestionsUserPromptFormat, maxCount, lastUserMsg, lastAssistantMsg, maxCount)
+
+	suggestionsModel := provider.CloneWithOptions(
+		ctx,
+		s.model,
+		options.WithStructuredOutput(nil),
+		options.WithMaxTokens(maxResponseTokens),
+	)
+
+	newTeam := team.New(
+		team.WithAgents(agent.New("root", suggestionsSystemPrompt, agent.WithModel(suggestionsModel))),
+	)
+
+	suggestionsSession := session.New(
+		session.WithUserMessage(userPrompt),
+	)
+
+	suggestionsRuntime, err := New(newTeam, WithSessionCompaction(false))
+	if err != nil {
+		slog.Error("Failed to create suggestions generator runtime", "error", err)
+		return
+	}
+
+	_, err = suggestionsRuntime.Run(ctx, suggestionsSession)
+	if err != nil {
+		slog.Error("Failed to generate suggestions", "session_id", sess.ID, "error", err)
+		return
+	}
+
+	response := suggestionsSession.GetLastAssistantMessageContent()
+	suggestions := parseSuggestions(response, maxCount)
+
+	if len(suggestions) > 0 {
+		events <- FollowUpSuggestions(suggestions, agentName)
+	}
+}
+
+func parseSuggestions(response string, maxCount int) []string {
+	var suggestions []string
+
+	// Clean up response - models often wrap JSON in markdown code blocks
+	cleanResponse := response
+	if idx := strings.Index(response, "["); idx != -1 {
+		if endIdx := strings.LastIndex(response, "]"); endIdx > idx {
+			cleanResponse = response[idx : endIdx+1]
+		}
+	}
+
+	if err := json.Unmarshal([]byte(cleanResponse), &suggestions); err != nil {
+		return nil
+	}
+
+	// Validate and limit suggestions
+	var valid []string
+	for _, s := range suggestions {
+		if s == "" {
+			continue
+		}
+		valid = append(valid, s)
+		if len(valid) >= maxCount {
+			break
+		}
+	}
+
+	return valid
+}

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -112,6 +112,7 @@ func Load(ctx context.Context, agentSource config.Source, runConfig *config.Runt
 			agent.WithNumHistoryItems(agentConfig.NumHistoryItems),
 			agent.WithCommands(expander.ExpandMap(ctx, agentConfig.Commands)),
 			agent.WithSkillsEnabled(skillsEnabled),
+			agent.WithFollowUpSuggestions(agentConfig.FollowUpSuggestions),
 		}
 
 		models, err := getModelsForAgent(ctx, cfg, &agentConfig, autoModel, runConfig)


### PR DESCRIPTION
Generate LLM-based follow-up suggestions when an agent completes a response. Configurable per-agent via `follow_up_suggestions` config block.