### PR TITLE
Skills

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -29,6 +29,7 @@ type Agent struct {
 	tools              []tools.Tool
 	commands           map[string]string
 	pendingWarnings    []string
+	skillsEnabled      bool
 }
 
 // New creates a new agent
@@ -112,6 +113,11 @@ func (a *Agent) Model() provider.Provider {
 // Commands returns the named commands configured for this agent.
 func (a *Agent) Commands() map[string]string {
 	return a.commands
+}
+
+// SkillsEnabled returns whether skills discovery is enabled for this agent.
+func (a *Agent) SkillsEnabled() bool {
+	return a.skillsEnabled
 }
 
 // Tools returns the tools available to this agent

--- a/pkg/agent/opts.go
+++ b/pkg/agent/opts.go
@@ -117,6 +117,12 @@ func WithLoadTimeWarnings(warnings []string) Opt {
 	}
 }
 
+func WithSkillsEnabled(enabled bool) Opt {
+	return func(a *Agent) {
+		a.skillsEnabled = enabled
+	}
+}
+
 type StartableToolSet struct {
 	tools.ToolSet
 	started atomic.Bool

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -38,6 +38,7 @@ type AgentConfig struct {
 	AddPromptFiles     []string          `json:"add_prompt_files,omitempty" yaml:"add_prompt_files,omitempty"`
 	Commands           types.Commands    `json:"commands,omitempty"`
 	StructuredOutput   *StructuredOutput `json:"structured_output,omitempty"`
+	Skills             *bool             `json:"skills,omitempty"`
 }
 
 // ModelConfig represents the configuration for a model

--- a/pkg/config/testdata/skills_disabled.yaml
+++ b/pkg/config/testdata/skills_disabled.yaml
@@ -1,0 +1,8 @@
+version: "3"
+
+agents:
+  root:
+    model: openai/gpt-4o
+    skills: false
+    toolsets:
+      - type: shell

--- a/pkg/config/testdata/skills_missing_filesystem.yaml
+++ b/pkg/config/testdata/skills_missing_filesystem.yaml
@@ -1,0 +1,8 @@
+version: "3"
+
+agents:
+  root:
+    model: openai/gpt-4o
+    skills: true
+    toolsets:
+      - type: shell

--- a/pkg/config/testdata/skills_missing_read_file.yaml
+++ b/pkg/config/testdata/skills_missing_read_file.yaml
@@ -1,0 +1,9 @@
+version: "3"
+
+agents:
+  root:
+    model: openai/gpt-4o
+    skills: true
+    toolsets:
+      - type: filesystem
+        tools: ["write_file", "edit_file"]

--- a/pkg/config/testdata/skills_valid_all_tools.yaml
+++ b/pkg/config/testdata/skills_valid_all_tools.yaml
@@ -1,0 +1,8 @@
+version: "3"
+
+agents:
+  root:
+    model: openai/gpt-4o
+    skills: true
+    toolsets:
+      - type: filesystem

--- a/pkg/config/testdata/skills_valid_explicit_tools.yaml
+++ b/pkg/config/testdata/skills_valid_explicit_tools.yaml
@@ -1,0 +1,9 @@
+version: "3"
+
+agents:
+  root:
+    model: openai/gpt-4o
+    skills: true
+    toolsets:
+      - type: filesystem
+        tools: ["read_file", "write_file"]

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -47,6 +47,14 @@ func TestValidationErrors(t *testing.T) {
 			name: "post_edit in non filesystem toolset",
 			path: "invalid_post_edit_v2.yaml",
 		},
+		{
+			name: "skills enabled without filesystem toolset",
+			path: "skills_missing_filesystem.yaml",
+		},
+		{
+			name: "skills enabled without read_file tool",
+			path: "skills_missing_read_file.yaml",
+		},
 	}
 
 	for _, tt := range tests {
@@ -55,6 +63,38 @@ func TestValidationErrors(t *testing.T) {
 
 			_, err := Load(t.Context(), testfileSource(filepath.Join("testdata", tt.path)))
 			require.Error(t, err)
+		})
+	}
+}
+
+func TestValidSkillsConfiguration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{
+			name: "skills with all filesystem tools",
+			path: "skills_valid_all_tools.yaml",
+		},
+		{
+			name: "skills with explicit read_file tool",
+			path: "skills_valid_explicit_tools.yaml",
+		},
+		{
+			name: "skills disabled",
+			path: "skills_disabled.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg, err := Load(t.Context(), testfileSource(filepath.Join("testdata", tt.path)))
+			require.NoError(t, err)
+			require.NotNil(t, cfg)
 		})
 	}
 }

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/docker/cagent/pkg/agent"
 	"github.com/docker/cagent/pkg/chat"
+	"github.com/docker/cagent/pkg/skills"
 )
 
 // TODO: instead of trimming, we should compact the history when it nears the
@@ -335,6 +336,14 @@ func (s *Session) GetMessages(a *agent.Agent) []chat.Message {
 			if additionalPrompt != "" {
 				content += "\n\n" + additionalPrompt
 			}
+		}
+	}
+
+	// Add skills section if enabled
+	if a.SkillsEnabled() {
+		loadedSkills := skills.Load()
+		if len(loadedSkills) > 0 {
+			content += skills.BuildSkillsPrompt(loadedSkills)
 		}
 	}
 

--- a/pkg/skills/skills.go
+++ b/pkg/skills/skills.go
@@ -1,0 +1,224 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/docker/cagent/pkg/paths"
+)
+
+type skillFormat string
+
+const (
+	formatClaude skillFormat = "claude"
+	formatCodex  skillFormat = "codex"
+
+	skillFile = "SKILL.md"
+)
+
+type Skill struct {
+	Name        string
+	Description string
+	FilePath    string
+	BaseDir     string
+}
+
+type frontmatter struct {
+	Name        string
+	Description string
+}
+
+func stripQuotes(value string) string {
+	if len(value) >= 2 {
+		if (value[0] == '"' && value[len(value)-1] == '"') ||
+			(value[0] == '\'' && value[len(value)-1] == '\'') {
+			return value[1 : len(value)-1]
+		}
+	}
+	return value
+}
+
+func parseFrontmatter(content string) (frontmatter, string) {
+	fm := frontmatter{}
+
+	normalizedContent := strings.ReplaceAll(content, "\r\n", "\n")
+	normalizedContent = strings.ReplaceAll(normalizedContent, "\r", "\n")
+
+	if !strings.HasPrefix(normalizedContent, "---") {
+		return fm, normalizedContent
+	}
+
+	endIndex := strings.Index(normalizedContent[3:], "\n---")
+	if endIndex == -1 {
+		return fm, normalizedContent
+	}
+
+	frontmatterBlock := normalizedContent[4 : endIndex+3]
+	body := strings.TrimSpace(normalizedContent[endIndex+7:])
+
+	lineRegex := regexp.MustCompile(`^(\w+):\s*(.*)$`)
+	for line := range strings.SplitSeq(frontmatterBlock, "\n") {
+		matches := lineRegex.FindStringSubmatch(line)
+		if matches != nil {
+			key := matches[1]
+			value := stripQuotes(strings.TrimSpace(matches[2]))
+			switch key {
+			case "name":
+				fm.Name = value
+			case "description":
+				fm.Description = value
+			}
+		}
+	}
+
+	return fm, body
+}
+
+func loadSkillsFromDir(dir string, format skillFormat) []Skill {
+	var skills []Skill
+
+	info, err := os.Stat(dir)
+	if err != nil || !info.IsDir() {
+		return skills
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return skills
+	}
+
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+
+		if entry.Type()&os.ModeSymlink != 0 {
+			continue
+		}
+
+		fullPath := filepath.Join(dir, entry.Name())
+
+		switch format {
+		case formatClaude:
+			if !entry.IsDir() {
+				continue
+			}
+
+			skillFile := filepath.Join(fullPath, skillFile)
+			rawContent, err := os.ReadFile(skillFile)
+			if err != nil {
+				continue
+			}
+
+			fm, _ := parseFrontmatter(string(rawContent))
+			if fm.Description == "" {
+				continue
+			}
+
+			name := fm.Name
+			if name == "" {
+				name = entry.Name()
+			}
+
+			skills = append(skills, Skill{
+				Name:        name,
+				Description: fm.Description,
+				FilePath:    skillFile,
+				BaseDir:     fullPath,
+			})
+
+		case formatCodex:
+			if entry.IsDir() {
+				skills = append(skills, loadSkillsFromDir(fullPath, format)...)
+			} else if entry.Name() == skillFile {
+				rawContent, err := os.ReadFile(fullPath)
+				if err != nil {
+					continue
+				}
+
+				fm, _ := parseFrontmatter(string(rawContent))
+				if fm.Description == "" {
+					continue
+				}
+
+				skillDir := filepath.Dir(fullPath)
+				name := fm.Name
+				if name == "" {
+					name = filepath.Base(skillDir)
+				}
+
+				skills = append(skills, Skill{
+					Name:        name,
+					Description: fm.Description,
+					FilePath:    fullPath,
+					BaseDir:     skillDir,
+				})
+			}
+		}
+	}
+
+	return skills
+}
+
+func Load() []Skill {
+	skillMap := make(map[string]Skill)
+
+	homeDir := paths.GetHomeDir()
+	if homeDir == "" {
+		return nil
+	}
+
+	codexUserDir := filepath.Join(homeDir, ".codex", "skills")
+	for _, skill := range loadSkillsFromDir(codexUserDir, formatCodex) {
+		skillMap[skill.Name] = skill
+	}
+
+	claudeUserDir := filepath.Join(homeDir, ".claude", "skills")
+	for _, skill := range loadSkillsFromDir(claudeUserDir, formatClaude) {
+		skillMap[skill.Name] = skill
+	}
+
+	cwd, err := os.Getwd()
+	if err == nil {
+		claudeProjectDir := filepath.Join(cwd, ".claude", "skills")
+		for _, skill := range loadSkillsFromDir(claudeProjectDir, formatClaude) {
+			skillMap[skill.Name] = skill
+		}
+	}
+
+	result := make([]Skill, 0, len(skillMap))
+	for _, skill := range skillMap {
+		result = append(result, skill)
+	}
+
+	return result
+}
+
+func BuildSkillsPrompt(skills []Skill) string {
+	if len(skills) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteString("\n\n<available_skills>\n")
+	sb.WriteString("The following skills provide specialized instructions for specific tasks.\n")
+	sb.WriteString("Use the read_file tool to load a skill's file when the task matches its description.\n")
+	sb.WriteString("Skills may contain {baseDir} placeholders - replace them with the skill's base directory path.\n\n")
+
+	for _, skill := range skills {
+		sb.WriteString("- ")
+		sb.WriteString(skill.Name)
+		sb.WriteString(": ")
+		sb.WriteString(skill.Description)
+		sb.WriteString("\n  File: ")
+		sb.WriteString(skill.FilePath)
+		sb.WriteString("\n  Base directory: ")
+		sb.WriteString(skill.BaseDir)
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString("</available_skills>")
+	return sb.String()
+}

--- a/pkg/skills/skills_test.go
+++ b/pkg/skills/skills_test.go
@@ -1,0 +1,253 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseFrontmatter(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		wantFM   frontmatter
+		wantBody string
+	}{
+		{
+			name: "valid frontmatter",
+			content: `---
+name: my-skill
+description: A test skill
+---
+
+# Skill Content`,
+			wantFM:   frontmatter{Name: "my-skill", Description: "A test skill"},
+			wantBody: "# Skill Content",
+		},
+		{
+			name: "quoted values",
+			content: `---
+name: "quoted-name"
+description: 'single quoted desc'
+---
+
+Body`,
+			wantFM:   frontmatter{Name: "quoted-name", Description: "single quoted desc"},
+			wantBody: "Body",
+		},
+		{
+			name:     "no frontmatter",
+			content:  "# Just content\n\nNo frontmatter here.",
+			wantFM:   frontmatter{},
+			wantBody: "# Just content\n\nNo frontmatter here.",
+		},
+		{
+			name: "only description",
+			content: `---
+description: Just a description
+---
+
+Content`,
+			wantFM:   frontmatter{Description: "Just a description"},
+			wantBody: "Content",
+		},
+		{
+			name:     "windows line endings",
+			content:  "---\r\nname: windows\r\ndescription: Windows skill\r\n---\r\n\r\nBody",
+			wantFM:   frontmatter{Name: "windows", Description: "Windows skill"},
+			wantBody: "Body",
+		},
+		{
+			name:     "unclosed frontmatter",
+			content:  "---\nname: unclosed\ndescription: No closing\n\nBody",
+			wantFM:   frontmatter{},
+			wantBody: "---\nname: unclosed\ndescription: No closing\n\nBody",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fm, body := parseFrontmatter(tt.content)
+			assert.Equal(t, tt.wantFM, fm)
+			assert.Equal(t, tt.wantBody, body)
+		})
+	}
+}
+
+func TestStripQuotes(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{`"double quoted"`, "double quoted"},
+		{`'single quoted'`, "single quoted"},
+		{`no quotes`, "no quotes"},
+		{`"mismatched'`, `"mismatched'`},
+		{`""`, ""},
+		{`''`, ""},
+		{`"`, `"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := stripQuotes(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestLoadSkillsFromDir_Claude(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	skillDir := filepath.Join(tmpDir, "pdf-extractor")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+
+	skillContent := `---
+description: Extract text from PDF files
+---
+
+# PDF Extraction
+
+Use pdftotext to extract content.
+`
+	require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(skillContent), 0o644))
+
+	skills := loadSkillsFromDir(tmpDir, formatClaude)
+
+	require.Len(t, skills, 1)
+	assert.Equal(t, "pdf-extractor", skills[0].Name)
+	assert.Equal(t, "Extract text from PDF files", skills[0].Description)
+	assert.Equal(t, filepath.Join(skillDir, "SKILL.md"), skills[0].FilePath)
+	assert.Equal(t, skillDir, skills[0].BaseDir)
+}
+
+func TestLoadSkillsFromDir_Codex(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	nestedDir := filepath.Join(tmpDir, "db", "migrate")
+	require.NoError(t, os.MkdirAll(nestedDir, 0o755))
+
+	skillContent := `---
+name: db-migrate
+description: Database migration helper
+---
+
+# DB Migration
+
+Run migrations with care.
+`
+	require.NoError(t, os.WriteFile(filepath.Join(nestedDir, "SKILL.md"), []byte(skillContent), 0o644))
+
+	skills := loadSkillsFromDir(tmpDir, formatCodex)
+
+	require.Len(t, skills, 1)
+	assert.Equal(t, "db-migrate", skills[0].Name)
+	assert.Equal(t, "Database migration helper", skills[0].Description)
+	assert.Equal(t, filepath.Join(nestedDir, "SKILL.md"), skills[0].FilePath)
+	assert.Equal(t, nestedDir, skills[0].BaseDir)
+}
+
+func TestLoadSkillsFromDir_SkipHiddenAndSymlinks(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	hiddenDir := filepath.Join(tmpDir, ".hidden-skill")
+	require.NoError(t, os.MkdirAll(hiddenDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(hiddenDir, "SKILL.md"), []byte("---\ndescription: Hidden\n---\n"), 0o644))
+
+	skills := loadSkillsFromDir(tmpDir, formatClaude)
+	assert.Empty(t, skills)
+}
+
+func TestLoadSkillsFromDir_SkipNoDescription(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	skillDir := filepath.Join(tmpDir, "no-desc")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+
+	skillContent := `---
+name: no-description
+---
+
+# No Description
+
+This skill has no description field.
+`
+	require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(skillContent), 0o644))
+
+	skills := loadSkillsFromDir(tmpDir, formatClaude)
+	assert.Empty(t, skills)
+}
+
+func TestLoadSkillsFromDir_NonExistentDir(t *testing.T) {
+	skills := loadSkillsFromDir("/nonexistent/path/12345", formatClaude)
+	assert.Empty(t, skills)
+}
+
+func TestBuildSkillsPrompt(t *testing.T) {
+	skills := []Skill{
+		{
+			Name:        "pdf-extractor",
+			Description: "Extract text from PDFs",
+			FilePath:    "/home/user/.claude/skills/pdf-extractor/SKILL.md",
+			BaseDir:     "/home/user/.claude/skills/pdf-extractor",
+		},
+		{
+			Name:        "code-review",
+			Description: "Perform code reviews",
+			FilePath:    "/project/.claude/skills/code-review/SKILL.md",
+			BaseDir:     "/project/.claude/skills/code-review",
+		},
+	}
+
+	prompt := BuildSkillsPrompt(skills)
+
+	assert.Contains(t, prompt, "<available_skills>")
+	assert.Contains(t, prompt, "</available_skills>")
+	assert.Contains(t, prompt, "pdf-extractor: Extract text from PDFs")
+	assert.Contains(t, prompt, "code-review: Perform code reviews")
+	assert.Contains(t, prompt, "File: /home/user/.claude/skills/pdf-extractor/SKILL.md")
+	assert.Contains(t, prompt, "Base directory: /project/.claude/skills/code-review")
+}
+
+func TestBuildSkillsPrompt_Empty(t *testing.T) {
+	prompt := BuildSkillsPrompt(nil)
+	assert.Empty(t, prompt)
+
+	prompt = BuildSkillsPrompt([]Skill{})
+	assert.Empty(t, prompt)
+}
+
+func TestLoad_Integration(t *testing.T) {
+	originalWd, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(originalWd) }()
+
+	tmpDir := t.TempDir()
+	require.NoError(t, os.Chdir(tmpDir))
+
+	claudeProjectDir := filepath.Join(tmpDir, ".claude", "skills", "test-skill")
+	require.NoError(t, os.MkdirAll(claudeProjectDir, 0o755))
+
+	skillContent := `---
+description: Test project skill
+---
+
+# Test Skill
+`
+	require.NoError(t, os.WriteFile(filepath.Join(claudeProjectDir, "SKILL.md"), []byte(skillContent), 0o644))
+
+	skills := Load()
+
+	found := false
+	for _, s := range skills {
+		if s.Name == "test-skill" {
+			found = true
+			assert.Equal(t, "Test project skill", s.Description)
+			break
+		}
+	}
+	assert.True(t, found, "Expected to find test-skill from project directory")
+}

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -96,6 +96,11 @@ func Load(ctx context.Context, agentSource config.Source, runConfig *config.Runt
 	expander := js.NewJsExpander(env)
 
 	for name, agentConfig := range cfg.Agents {
+		skillsEnabled := false
+		if agentConfig.Skills != nil {
+			skillsEnabled = *agentConfig.Skills
+		}
+
 		opts := []agent.Opt{
 			agent.WithName(name),
 			agent.WithDescription(expander.Expand(ctx, agentConfig.Description)),
@@ -106,6 +111,7 @@ func Load(ctx context.Context, agentSource config.Source, runConfig *config.Runt
 			agent.WithMaxIterations(agentConfig.MaxIterations),
 			agent.WithNumHistoryItems(agentConfig.NumHistoryItems),
 			agent.WithCommands(expander.ExpandMap(ctx, agentConfig.Commands)),
+			agent.WithSkillsEnabled(skillsEnabled),
 		}
 
 		models, err := getModelsForAgent(ctx, cfg, &agentConfig, autoModel, runConfig)


### PR DESCRIPTION
If an agent has skills enabled we load skills from

- `~/.codex/skills/**/SKILL.md`
- `~/.claude/skills/*/SKILL.md`
- `./.claude/skills/*/SKILL.md`

And instruct the LLM to load them on demand.

Doesn't support `allowed-tools`.

Skills require the `read_file` tool from the filesystem at least.