### PR TITLE
tools/script_shell: Fix implicit all required parameters

### DIFF
--- a/pkg/tools/builtin/script_shell.go
+++ b/pkg/tools/builtin/script_shell.go
@@ -37,7 +37,7 @@ func NewScriptShellTool(shellTools map[string]latest.ScriptShellToolConfig, env 
 func validateConfig(toolName string, tool latest.ScriptShellToolConfig) error {
 	// If no required array was set, all arguments are required
 	if tool.Required == nil {
-		tool.Required = make([]string, len(tool.Args))
+		tool.Required = make([]string, 0, len(tool.Args))
 		for argName := range tool.Args {
 			tool.Required = append(tool.Required, argName)
 		}


### PR DESCRIPTION
When no required array was explicitly set in the shell tool configuration, the system was intended to default all arguments as required.

However, the implementation was incorrectly creating a slice with length equal to the number of arguments but zero capacity, resulting in an empty required list.