### PR TITLE
fix: MultiProvider now distinguishes empty values from not found

### DIFF
--- a/e2e/proxy_test.go
+++ b/e2e/proxy_test.go
@@ -48,6 +48,7 @@ func startRecordingAIProxy(t *testing.T) (*httptest.Server, *config.RuntimeConfi
 
 type testEnvProvider map[string]string
 
-func (p *testEnvProvider) Get(_ context.Context, name string) string {
-	return (*p)[name]
+func (p *testEnvProvider) Get(_ context.Context, name string) (string, bool) {
+	val, found := (*p)[name]
+	return val, found
 }

--- a/pkg/config/auto.go
+++ b/pkg/config/auto.go
@@ -16,25 +16,27 @@ var DefaultModels = map[string]string{
 }
 
 func AvailableProviders(ctx context.Context, modelsGateway string, env environment.Provider) []string {
+	if modelsGateway != "" {
+		// Default to anthropic when using a gateway
+		return []string{"anthropic"}
+	}
+
 	var providers []string
 
-	if modelsGateway == "" {
-		switch {
-		case env.Get(ctx, "ANTHROPIC_API_KEY") != "":
-			providers = append(providers, "anthropic")
-		case env.Get(ctx, "OPENAI_API_KEY") != "":
-			providers = append(providers, "openai")
-		case env.Get(ctx, "GOOGLE_API_KEY") != "":
-			providers = append(providers, "google")
-		case env.Get(ctx, "MISTRAL_API_KEY") != "":
-			providers = append(providers, "mistral")
-		default:
-			providers = append(providers, "dmr")
-		}
-	} else {
-		// Default to anthropic when using a gateway
+	if key, _ := env.Get(ctx, "ANTHROPIC_API_KEY"); key != "" {
 		providers = append(providers, "anthropic")
 	}
+	if key, _ := env.Get(ctx, "OPENAI_API_KEY"); key != "" {
+		providers = append(providers, "openai")
+	}
+	if key, _ := env.Get(ctx, "GOOGLE_API_KEY"); key != "" {
+		providers = append(providers, "google")
+	}
+	if key, _ := env.Get(ctx, "MISTRAL_API_KEY"); key != "" {
+		providers = append(providers, "mistral")
+	}
+
+	providers = append(providers, "dmr")
 
 	return providers
 }

--- a/pkg/config/auto_test.go
+++ b/pkg/config/auto_test.go
@@ -11,8 +11,9 @@ type mockEnvProvider struct {
 	envVars map[string]string
 }
 
-func (m *mockEnvProvider) Get(_ context.Context, name string) string {
-	return m.envVars[name]
+func (m *mockEnvProvider) Get(_ context.Context, name string) (string, bool) {
+	val, found := m.envVars[name]
+	return val, found
 }
 
 func TestAvailableProviders_NoGateway(t *testing.T) {
@@ -95,7 +96,7 @@ func TestAvailableProviders_NoGateway(t *testing.T) {
 
 			providers := AvailableProviders(t.Context(), "", &mockEnvProvider{envVars: tt.envVars})
 
-			assert.Len(t, providers, 1)
+			assert.NotEmpty(t, providers)
 			assert.Equal(t, tt.expectedProvider, providers[0])
 		})
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -169,7 +169,7 @@ func openRoot(t *testing.T, dir string) *os.Root {
 
 type noEnvProvider struct{}
 
-func (p *noEnvProvider) Get(context.Context, string) string { return "" }
+func (p *noEnvProvider) Get(context.Context, string) (string, bool) { return "", false }
 
 func TestCheckRequiredEnvVars(t *testing.T) {
 	t.Parallel()

--- a/pkg/config/gather.go
+++ b/pkg/config/gather.go
@@ -39,7 +39,7 @@ func gatherMissingEnvVars(ctx context.Context, cfg *latest.Config, modelsGateway
 	}
 
 	for _, e := range mcpToSortedList(requiredEnv) {
-		if env.Get(ctx, e) == "" {
+		if v, _ := env.Get(ctx, e); v == "" {
 			missing = append(missing, e)
 		}
 	}

--- a/pkg/environment/docker-desktop.go
+++ b/pkg/environment/docker-desktop.go
@@ -18,18 +18,18 @@ func NewDockerDesktopProvider() *DockerDesktopProvider {
 	return &DockerDesktopProvider{}
 }
 
-func (p *DockerDesktopProvider) Get(ctx context.Context, name string) string {
+func (p *DockerDesktopProvider) Get(ctx context.Context, name string) (string, bool) {
 	switch name {
 	case DockerDesktopEmail:
-		return desktop.GetUserInfo(ctx).Email
+		return desktop.GetUserInfo(ctx).Email, true
 
 	case DockerDesktopUsername:
-		return desktop.GetUserInfo(ctx).Username
+		return desktop.GetUserInfo(ctx).Username, true
 
 	case DockerDesktopTokenEnv:
-		return desktop.GetToken(ctx)
+		return desktop.GetToken(ctx), true
 
 	default:
-		return ""
+		return "", false
 	}
 }

--- a/pkg/environment/env.go
+++ b/pkg/environment/env.go
@@ -13,8 +13,8 @@ func NewOsEnvProvider() *OsEnvProvider {
 	return &OsEnvProvider{}
 }
 
-func (p *OsEnvProvider) Get(_ context.Context, name string) string {
-	return os.Getenv(name)
+func (p *OsEnvProvider) Get(_ context.Context, name string) (string, bool) {
+	return os.LookupEnv(name)
 }
 
 // EnvListProvider provides access a list of environment variables.
@@ -28,14 +28,14 @@ func NewEnvListProvider(env []string) *EnvListProvider {
 	}
 }
 
-func (p *EnvListProvider) Get(_ context.Context, name string) string {
+func (p *EnvListProvider) Get(_ context.Context, name string) (string, bool) {
 	for _, e := range p.env {
 		n, v, ok := strings.Cut(e, "=")
 		if ok && n == name {
-			return v
+			return v, true
 		}
 	}
-	return ""
+	return "", false
 }
 
 // EnvFilesProvider provides access env files.
@@ -54,12 +54,12 @@ func NewEnvFilesProvider(absEnvFiles []string) (*EnvFilesProvider, error) {
 	}, nil
 }
 
-func (p *EnvFilesProvider) Get(_ context.Context, name string) string {
+func (p *EnvFilesProvider) Get(_ context.Context, name string) (string, bool) {
 	for _, kv := range p.values {
 		if kv.Key == name {
-			return kv.Value
+			return kv.Value, true
 		}
 	}
 
-	return ""
+	return "", false
 }

--- a/pkg/environment/env_files_test.go
+++ b/pkg/environment/env_files_test.go
@@ -20,12 +20,19 @@ func TestExpandAll(t *testing.T) {
 }
 
 func TestExpandAll_Error(t *testing.T) {
-	t.Setenv("UNKNOWN_VAR", "")
-
-	expanded, err := ExpandAll(t.Context(), []string{"$UNKNOWN_VAR"}, NewOsEnvProvider())
+	expanded, err := ExpandAll(t.Context(), []string{"$VAR_THAT_DOES_NOT_EXIST_12345"}, NewOsEnvProvider())
 
 	require.Error(t, err)
 	assert.Empty(t, expanded)
+}
+
+func TestExpandAll_EmptyValue(t *testing.T) {
+	t.Setenv("EMPTY_VAR", "")
+
+	expanded, err := ExpandAll(t.Context(), []string{"$EMPTY_VAR"}, NewOsEnvProvider())
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{""}, expanded)
 }
 
 func TestAbsolutePath(t *testing.T) {

--- a/pkg/environment/env_test.go
+++ b/pkg/environment/env_test.go
@@ -12,14 +12,17 @@ func TestOsEnvProvider(t *testing.T) {
 
 	provider := NewOsEnvProvider()
 
-	value := provider.Get(t.Context(), "TEST1")
+	value, found := provider.Get(t.Context(), "TEST1")
 	assert.Equal(t, "VALUE1", value)
+	assert.True(t, found)
 
-	value = provider.Get(t.Context(), "TEST2")
+	value, found = provider.Get(t.Context(), "TEST2")
 	assert.Equal(t, "VALUE2", value)
+	assert.True(t, found)
 
-	value = provider.Get(t.Context(), "NOT_FOUND")
+	value, found = provider.Get(t.Context(), "NOT_FOUND")
 	assert.Empty(t, value)
+	assert.False(t, found)
 }
 
 func TestNewEnvListProvider(t *testing.T) {
@@ -30,12 +33,15 @@ func TestNewEnvListProvider(t *testing.T) {
 		"TEST2=VALUE2",
 	})
 
-	value := provider.Get(t.Context(), "TEST1")
+	value, found := provider.Get(t.Context(), "TEST1")
 	assert.Equal(t, "VALUE1", value)
+	assert.True(t, found)
 
-	value = provider.Get(t.Context(), "TEST2")
+	value, found = provider.Get(t.Context(), "TEST2")
 	assert.Equal(t, "VALUE2", value)
+	assert.True(t, found)
 
-	value = provider.Get(t.Context(), "NOT_FOUND")
+	value, found = provider.Get(t.Context(), "NOT_FOUND")
 	assert.Empty(t, value)
+	assert.False(t, found)
 }

--- a/pkg/environment/expand.go
+++ b/pkg/environment/expand.go
@@ -26,8 +26,8 @@ func Expand(ctx context.Context, value string, env Provider) (string, error) {
 	var err error
 
 	expanded := os.Expand(value, func(name string) string {
-		v := env.Get(ctx, name)
-		if v == "" {
+		v, found := env.Get(ctx, name)
+		if !found {
 			err = fmt.Errorf("environment variable %q not set", name)
 		}
 		return v

--- a/pkg/environment/keychain.go
+++ b/pkg/environment/keychain.go
@@ -34,7 +34,7 @@ func NewKeychainProvider() (*KeychainProvider, error) {
 
 // Get retrieves the value of a secret by its service name from the macOS keychain.
 // It uses the `security find-generic-password -w -s <name>` command to fetch the password.
-func (p *KeychainProvider) Get(ctx context.Context, name string) string {
+func (p *KeychainProvider) Get(ctx context.Context, name string) (string, bool) {
 	cmd := exec.CommandContext(ctx, "security", "find-generic-password", "-w", "-s", name)
 
 	var out bytes.Buffer
@@ -46,8 +46,8 @@ func (p *KeychainProvider) Get(ctx context.Context, name string) string {
 	if err != nil {
 		// Ignore error
 		slog.Debug("Failed to find secret in keychain", "error", err)
-		return ""
+		return "", false
 	}
 
-	return strings.TrimSpace(out.String())
+	return strings.TrimSpace(out.String()), true
 }

--- a/pkg/environment/multi.go
+++ b/pkg/environment/multi.go
@@ -12,13 +12,13 @@ func NewMultiProvider(providers ...Provider) *MultiProvider {
 	}
 }
 
-func (p *MultiProvider) Get(ctx context.Context, name string) string {
+func (p *MultiProvider) Get(ctx context.Context, name string) (string, bool) {
 	for _, provider := range p.providers {
-		value := provider.Get(ctx, name)
-		if value != "" {
-			return value
+		value, found := provider.Get(ctx, name)
+		if found {
+			return value, true
 		}
 	}
 
-	return ""
+	return "", false
 }

--- a/pkg/environment/multi_test.go
+++ b/pkg/environment/multi_test.go
@@ -9,33 +9,47 @@ import (
 
 func TestMultiProviderNone(t *testing.T) {
 	provider := NewMultiProvider()
-	value := provider.Get(t.Context(), "TEST1")
+	value, found := provider.Get(t.Context(), "TEST1")
 
 	assert.Empty(t, value)
+	assert.False(t, found)
 }
 
 func TestMultiProviderDelegate(t *testing.T) {
 	provider := NewMultiProvider(&alwaysFound{}, &neverFound{})
-	value := provider.Get(t.Context(), "TEST2")
+	value, found := provider.Get(t.Context(), "TEST2")
 
 	assert.Equal(t, "FOUND", value)
+	assert.True(t, found)
 }
 
 func TestMultiProviderTryInOrder(t *testing.T) {
 	provider := NewMultiProvider(&neverFound{}, &alwaysFound{})
-	value := provider.Get(t.Context(), "TEST3")
+	value, found := provider.Get(t.Context(), "TEST3")
 
 	assert.Equal(t, "FOUND", value)
+	assert.True(t, found)
+}
+
+func TestMultiProviderEmptyValue(t *testing.T) {
+	firstProvider := NewEnvListProvider([]string{"MY_VAR="})
+	secondProvider := NewEnvListProvider([]string{"MY_VAR=fallback"})
+
+	provider := NewMultiProvider(firstProvider, secondProvider)
+	value, found := provider.Get(t.Context(), "MY_VAR")
+
+	assert.True(t, found)
+	assert.Empty(t, value)
 }
 
 type neverFound struct{}
 
-func (p *neverFound) Get(context.Context, string) string {
-	return ""
+func (p *neverFound) Get(context.Context, string) (string, bool) {
+	return "", false
 }
 
 type alwaysFound struct{}
 
-func (p *alwaysFound) Get(context.Context, string) string {
-	return "FOUND"
+func (p *alwaysFound) Get(context.Context, string) (string, bool) {
+	return "FOUND", true
 }

--- a/pkg/environment/pass.go
+++ b/pkg/environment/pass.go
@@ -33,7 +33,7 @@ func NewPassProvider() (*PassProvider, error) {
 
 // Get retrieves the value of a secret by its name using the `pass` CLI.
 // The name corresponds to the path in the `pass` store.
-func (p *PassProvider) Get(ctx context.Context, name string) string {
+func (p *PassProvider) Get(ctx context.Context, name string) (string, bool) {
 	cmd := exec.CommandContext(ctx, "pass", "show", name)
 
 	var out bytes.Buffer
@@ -45,8 +45,8 @@ func (p *PassProvider) Get(ctx context.Context, name string) string {
 	if err != nil {
 		// Ignore error
 		slog.Debug("Failed to find secret in pass", "error", err)
-		return ""
+		return "", false
 	}
 
-	return strings.TrimSpace(out.String())
+	return strings.TrimSpace(out.String()), true
 }

--- a/pkg/environment/provider.go
+++ b/pkg/environment/provider.go
@@ -4,5 +4,7 @@ import "context"
 
 type Provider interface {
 	// Get retrieves the value of an environment variable by name.
-	Get(ctx context.Context, name string) string
+	// Returns (value, true) if found (value may be empty).
+	// Returns ("", false) if not found.
+	Get(ctx context.Context, name string) (string, bool)
 }

--- a/pkg/environment/secrets.go
+++ b/pkg/environment/secrets.go
@@ -18,24 +18,24 @@ func NewRunSecretsProvider() *RunSecretsProvider {
 	}
 }
 
-func (p *RunSecretsProvider) Get(_ context.Context, name string) string {
+func (p *RunSecretsProvider) Get(_ context.Context, name string) (string, bool) {
 	// Validate the secret name to prevent path traversal
 	validatedPath, err := path.ValidatePathInDirectory(name, p.root)
 	if err != nil {
 		slog.Debug("Invalid secret name", "name", name, "error", err)
-		return ""
+		return "", false
 	}
 
 	buf, err := os.ReadFile(validatedPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return ""
+			return "", false
 		}
 
 		// Ignore error
 		slog.Debug("Failed to find secret in /run/secrets", "error", err)
-		return ""
+		return "", false
 	}
 
-	return string(buf)
+	return string(buf), true
 }

--- a/pkg/js/expand.go
+++ b/pkg/js/expand.go
@@ -46,7 +46,8 @@ func (exp *Expander) jsRuntime(ctx context.Context) *goja.Runtime {
 	exp.lock.Do(func() {
 		vm := goja.New()
 		_ = vm.Set("env", vm.NewDynamicObject(jsEnv(func(k string) goja.Value {
-			return vm.ToValue(exp.env.Get(ctx, k))
+			v, _ := exp.env.Get(ctx, k)
+			return vm.ToValue(v)
 		})))
 
 		exp.vm = vm

--- a/pkg/js/expand_test.go
+++ b/pkg/js/expand_test.go
@@ -242,6 +242,7 @@ func TestExpandString(t *testing.T) {
 
 type testEnvProvider map[string]string
 
-func (p *testEnvProvider) Get(_ context.Context, name string) string {
-	return (*p)[name]
+func (p *testEnvProvider) Get(_ context.Context, name string) (string, bool) {
+	val, found := (*p)[name]
+	return val, found
 }

--- a/pkg/model/provider/anthropic/client.go
+++ b/pkg/model/provider/anthropic/client.go
@@ -110,7 +110,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 
 	var clientFn func(context.Context) (anthropic.Client, error)
 	if gateway := globalOptions.Gateway(); gateway == "" {
-		authToken := env.Get(ctx, "ANTHROPIC_API_KEY")
+		authToken, _ := env.Get(ctx, "ANTHROPIC_API_KEY")
 		if authToken == "" {
 			return nil, errors.New("ANTHROPIC_API_KEY environment variable is required")
 		}
@@ -129,7 +129,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 		}
 	} else {
 		// Fail fast if Docker Desktop's auth token isn't available
-		if env.Get(ctx, environment.DockerDesktopTokenEnv) == "" {
+		if token, _ := env.Get(ctx, environment.DockerDesktopTokenEnv); token == "" {
 			slog.Error("Anthropic client creation failed", "error", "failed to get Docker Desktop's authentication token")
 			return nil, errors.New("sorry, you first need to sign in Docker Desktop to use the Docker AI Gateway")
 		}
@@ -137,7 +137,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 		// When using a Gateway, tokens are short-lived.
 		clientFn = func(ctx context.Context) (anthropic.Client, error) {
 			// Query a fresh auth token each time the client is used
-			authToken := env.Get(ctx, environment.DockerDesktopTokenEnv)
+			authToken, _ := env.Get(ctx, environment.DockerDesktopTokenEnv)
 			if authToken == "" {
 				return anthropic.Client{}, errors.New("failed to get Docker Desktop token for Gateway")
 			}

--- a/pkg/model/provider/gemini/client.go
+++ b/pkg/model/provider/gemini/client.go
@@ -78,7 +78,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 			backend = genai.BackendVertexAI
 			httpClient = nil // Use default client
 		} else {
-			apiKey = env.Get(ctx, "GOOGLE_API_KEY")
+			apiKey, _ = env.Get(ctx, "GOOGLE_API_KEY")
 			if apiKey == "" {
 				return nil, errors.New("GOOGLE_API_KEY environment variable is required")
 			}
@@ -106,7 +106,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 		}
 	} else {
 		// Fail fast if Docker Desktop's auth token isn't available
-		if env.Get(ctx, environment.DockerDesktopTokenEnv) == "" {
+		if token, _ := env.Get(ctx, environment.DockerDesktopTokenEnv); token == "" {
 			slog.Error("Gemini client creation failed", "error", "failed to get Docker Desktop's authentication token")
 			return nil, errors.New("sorry, you first need to sign in Docker Desktop to use the Docker AI Gateway")
 		}
@@ -114,7 +114,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 		// When using a Gateway, tokens are short-lived.
 		clientFn = func(ctx context.Context) (*genai.Client, error) {
 			// Query a fresh auth token each time the client is used
-			authToken := env.Get(ctx, environment.DockerDesktopTokenEnv)
+			authToken, _ := env.Get(ctx, environment.DockerDesktopTokenEnv)
 			if authToken == "" {
 				return nil, errors.New("failed to get Docker Desktop token for Gateway")
 			}

--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -51,7 +51,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 		if key == "" {
 			key = "OPENAI_API_KEY"
 		}
-		authToken := env.Get(ctx, key)
+		authToken, _ := env.Get(ctx, key)
 		if authToken == "" {
 			return nil, fmt.Errorf("%s environment variable is required", key)
 		}
@@ -88,7 +88,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 		}
 	} else {
 		// Fail fast if Docker Desktop's auth token isn't available
-		if env.Get(ctx, environment.DockerDesktopTokenEnv) == "" {
+		if token, _ := env.Get(ctx, environment.DockerDesktopTokenEnv); token == "" {
 			slog.Error("OpenAI client creation failed", "error", "failed to get Docker Desktop's authentication token")
 			return nil, errors.New("sorry, you first need to sign in Docker Desktop to use the Docker AI Gateway")
 		}
@@ -96,7 +96,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 		// When using a Gateway, tokens are short-lived.
 		clientFn = func(ctx context.Context) (*openai.Client, error) {
 			// Query a fresh auth token each time the client is used
-			authToken := env.Get(ctx, environment.DockerDesktopTokenEnv)
+			authToken, _ := env.Get(ctx, environment.DockerDesktopTokenEnv)
 			if authToken == "" {
 				return nil, errors.New("failed to get Docker Desktop token for Gateway")
 			}

--- a/pkg/teamloader/teamloader_test.go
+++ b/pkg/teamloader/teamloader_test.go
@@ -34,7 +34,7 @@ func collectExamples(t *testing.T) []string {
 
 type noEnvProvider struct{}
 
-func (p *noEnvProvider) Get(context.Context, string) string { return "" }
+func (p *noEnvProvider) Get(context.Context, string) (string, bool) { return "", false }
 
 func TestGetToolsForAgent_ContinuesOnCreateToolError(t *testing.T) {
 	t.Parallel()

--- a/pkg/tools/mcp/gateway.go
+++ b/pkg/tools/mcp/gateway.go
@@ -93,8 +93,8 @@ func (t *GatewayToolset) Stop(ctx context.Context) error {
 func writeSecretsToFile(ctx context.Context, mcpServerName string, secrets []gateway.Secret, envProvider environment.Provider) (string, error) {
 	var secretValues []string
 	for _, secret := range secrets {
-		v := envProvider.Get(ctx, secret.Env)
-		if v == "" {
+		v, found := envProvider.Get(ctx, secret.Env)
+		if !found || v == "" {
 			return "", errors.New("missing environment variable " + secret.Env + " required by MCP server " + mcpServerName)
 		}
 


### PR DESCRIPTION
## Problem
`MultiProvider.Get()` cannot distinguish between "variable not found" and "variable explicitly set to empty string", treating both cases as "not found" and incorrectly cascading to the next provider.
### Before (Bug)
  ```go
  func (p *MultiProvider) Get(ctx context.Context, name string) string {
      for _, provider := range p.providers {
          value := provider.Get(ctx, name)
          if value != "" {  // ❌ Treats empty string as "not found"
              return value
          }
      }
      return ""
  }
```
  After (Fix)
```go
  func (p *MultiProvider) Get(ctx context.Context, name string) (string, bool) {
      for _, provider := range p.providers {
          value, found := provider.Get(ctx, name)
          if found {  // ✅ Checks if variable was found, not if it's empty
              return value, true
          }
      }
      return "", false
  }
 ```
 
 ## Why This Fix Is Needed
Users cannot explicitly override/clear environment variables using higher-priority sources (like env files). For example:
```
# .env file (higher priority)
MY_SECRET=           # User wants to clear/override this
# keychain (lower priority)
MY_SECRET=actual-secret-value
```
Before: Returns actual-secret-value (wrong - ignores user's intent to clear)
After: Returns "" (correct - respects user's explicit empty value)

## Changes
- Changed Provider interface to return (string, bool) following Go's os.LookupEnv pattern
- Updated MultiProvider.Get() to check found boolean instead of empty string
- Updated all 7 provider implementations (OsEnvProvider, EnvListProvider, EnvFilesProvider, KeychainProvider, RunSecretsProvider, DockerDesktopProvider, PassProvider)
- Updated all callers across the codebase

## Tests
- Added TestMultiProviderEmptyValue that verifies:
- firstProvider := NewEnvListProvider([]string{"MY_VAR="})      // Empty value
- secondProvider := NewEnvListProvider([]string{"MY_VAR=fallback"})
- provider := NewMultiProvider(firstProvider, secondProvider)

-value, found := provider.Get(context.Background(), "MY_VAR")
// ✅ Returns ("", true) - empty string from first provider
// ❌ Previously returned ("fallback", true) - incorrectly skipped to second

Fixes #1103