### PR TITLE
Trim the model name, allowing spaces between models

### DIFF
--- a/pkg/config/gather.go
+++ b/pkg/config/gather.go
@@ -54,6 +54,7 @@ func GatherEnvVarsForModels(cfg *latest.Config) []string {
 	for agentName := range cfg.Agents {
 		modelNames := strings.SplitSeq(cfg.Agents[agentName].Model, ",")
 		for modelName := range modelNames {
+			modelName = strings.TrimSpace(modelName)
 			model := cfg.Models[modelName]
 
 			if model.TokenKey != "" {


### PR DESCRIPTION
So we can model1, model2

This is in line with how these are handled from the command line

Fixes #1101 