### PR TITLE
Remove the parentheses around the parameters

### DIFF
--- a/pkg/tui/components/tool/listdirectory/listdirectory.go
+++ b/pkg/tui/components/tool/listdirectory/listdirectory.go
@@ -73,7 +73,7 @@ func (c *Component) View() string {
 
 	// Shorten the path for display
 	shortPath := shortenPath(args.Path)
-	displayName := fmt.Sprintf("%s(%s)", msg.ToolDefinition.DisplayName(), shortPath)
+	displayName := fmt.Sprintf("%s %s", msg.ToolDefinition.DisplayName(), shortPath)
 
 	// For pending/running state, show spinner
 	if msg.ToolStatus == types.ToolStatusPending || msg.ToolStatus == types.ToolStatusRunning {

--- a/pkg/tui/components/tool/searchfiles/searchfiles.go
+++ b/pkg/tui/components/tool/searchfiles/searchfiles.go
@@ -71,7 +71,7 @@ func (c *Component) View() string {
 	}
 
 	// Format display name with pattern
-	displayName := fmt.Sprintf("%s(%q)", msg.ToolDefinition.DisplayName(), args.Pattern)
+	displayName := fmt.Sprintf("%s %q", msg.ToolDefinition.DisplayName(), args.Pattern)
 
 	// For pending/running state, show spinner
 	if msg.ToolStatus == types.ToolStatusPending || msg.ToolStatus == types.ToolStatusRunning {


### PR DESCRIPTION
in "list directory" and "search file" tool components

None of the other tool render components use ()