### PR TITLE
fix: Legacy session parsing regression: inverted compatibility logic returns empty messages

### DIFF
--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -165,18 +165,26 @@ func scanSession(scanner interface {
 		return nil, err
 	}
 
-	// Handle both old message format and new items format
+	// Ok listen up, we used to only store messages in the database, but now we
+	// store messages and sub-sessions. So we need to handle both cases.
+	// Legacy format has Message structs directly, new format has Item wrappers.
+	// When unmarshaling new format into []Message, we get empty structs.
+	// We detect legacy format by checking if the first message has actual content.
 	var items []Item
 	var messages []Message
 	if err := json.Unmarshal([]byte(messagesJSON), &messages); err != nil {
 		return nil, err
 	}
-	if len(messages) > 0 {
+	// Check if this is legacy format by seeing if we got actual message content
+	isLegacyFormat := len(messages) > 0 && (messages[0].AgentName != "" || messages[0].Message.Content != "" || messages[0].Message.Role != "")
+	if isLegacyFormat {
+		// Legacy format: messages were successfully parsed, convert them to items
+		items = convertMessagesToItems(messages)
+	} else {
+		// New format: unmarshal directly as items
 		if err := json.Unmarshal([]byte(messagesJSON), &items); err != nil {
 			return nil, err
 		}
-	} else {
-		items = convertMessagesToItems(messages)
 	}
 
 	toolsApproved, err := strconv.ParseBool(toolsApprovedStr)


### PR DESCRIPTION
## Summary
This PR fixes #1086

## Changes
- Fixed inverted condition logic in `GetSession` and `GetSessions` methods in `pkg/session/store.go`
- The backward compatibility code for parsing legacy session data was incorrectly checking only `len(messages) > 0` to determine format type
- Now properly detects legacy format by checking if the first message has actual content (AgentName, Message.Content, or Message.Role)
- Legacy format: Messages with content are converted to Items using `convertMessagesToItems`
- New format: Data is unmarshaled directly as Items

## Test plan
- [x] All existing session tests pass (`go test ./pkg/session/...`)
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)