### PR TITLE
fix: Semantic-embeddings stream errors treated as EOF, indexing partial summaries silently

### DIFF
--- a/pkg/rag/strategy/semantic_embeddings.go
+++ b/pkg/rag/strategy/semantic_embeddings.go
@@ -3,7 +3,9 @@ package strategy
 import (
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"path/filepath"
 	"sort"
@@ -274,8 +276,11 @@ func (b *llmSemanticEmbeddingBuilder) BuildEmbeddingInput(ctx context.Context, s
 
 	for {
 		resp, err := stream.Recv()
-		if err != nil {
+		if errors.Is(err, io.EOF) {
 			break
+		}
+		if err != nil {
+			return "", fmt.Errorf("error receiving from semantic generation stream: %w", err)
 		}
 
 		if resp.Usage != nil {


### PR DESCRIPTION
## Summary
This PR fixes #1105

## Problem
The `stream.Recv()` loop in `BuildEmbeddingInput` was breaking on **any** error, treating real stream errors (network failures, context cancellations, API errors) the same as `io.EOF`. This caused partial/incomplete summaries to be silently indexed when stream errors occurred, degrading RAG retrieval quality.

## Changes
- Added proper `io.EOF` check using `errors.Is(err, io.EOF)` to distinguish normal end-of-stream from real errors
- Return the error to caller on non-EOF errors instead of silently continuing with partial data
- Added necessary imports (`errors`, `io`)

## Fix Pattern
The fix follows the established pattern used elsewhere in the codebase (e.g., `pkg/runtime/runtime.go`):

```go
for {
    resp, err := stream.Recv()
    if errors.Is(err, io.EOF) {
        break
    }
    if err != nil {
        return "", fmt.Errorf("error receiving from semantic generation stream: %w", err)
    }
    // ... process response
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)