### PR TITLE
Add commands toolset to expose agent commands as tools

### DIFF
--- a/examples/commands_toolset.yaml
+++ b/examples/commands_toolset.yaml
@@ -1,0 +1,21 @@
+#!/usr/bin/env cagent run
+
+# Demonstrates the `commands` toolset which exposes agent commands as tools.
+
+agents:
+  root:
+    model: openai/gpt-5-mini
+    description: A helpful AI assistant with quick commands
+    instruction: |
+      You are a helpful assistant with predefined commands.
+      Use the command tools when the user's request matches one of them.
+
+    commands:
+      check-disk: "Check the disk space usage on the system"
+      list-files: "List all files in the current directory"
+      git-status: "Show the current git repository status"
+
+    toolsets:
+      - type: commands
+      - type: shell
+      - type: filesystem

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -160,6 +160,9 @@ type Toolset struct {
 
 	// For the `fetch` tool
 	Timeout int `json:"timeout,omitempty"`
+
+	// For the `commands` tool (populated from agent config at load time)
+	Commands map[string]string `json:"-" yaml:"-"`
 }
 
 func (t *Toolset) UnmarshalYAML(unmarshal func(any) error) error {

--- a/pkg/config/latest/validate.go
+++ b/pkg/config/latest/validate.go
@@ -107,6 +107,9 @@ func (t *Toolset) validate() error {
 		if t.Command == "" {
 			return errors.New("lsp toolset requires a command to be set")
 		}
+	case "commands":
+		// The commands field is populated from the agent's commands at load time.
+		// Validation happens in the teamloader when creating the toolset.
 	}
 
 	return nil

--- a/pkg/teamloader/registry.go
+++ b/pkg/teamloader/registry.go
@@ -69,6 +69,7 @@ func NewDefaultToolsetRegistry() *ToolsetRegistry {
 	r.Register("api", createAPITool)
 	r.Register("a2a", createA2ATool)
 	r.Register("lsp", createLSPTool)
+	r.Register("commands", createCommandsTool)
 	return r
 }
 
@@ -254,4 +255,11 @@ func createLSPTool(ctx context.Context, toolset latest.Toolset, _ string, runCon
 	}
 	env = append(env, os.Environ()...)
 	return builtin.NewLSPTool(toolset.Command, toolset.Args, env, runConfig.WorkingDir), nil
+}
+
+func createCommandsTool(_ context.Context, toolset latest.Toolset, _ string, _ *config.RuntimeConfig) (tools.ToolSet, error) {
+	if len(toolset.Commands) == 0 {
+		return nil, fmt.Errorf("commands toolset requires commands to be configured on the agent")
+	}
+	return builtin.NewCommandsTool(toolset.Commands), nil
 }

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -237,6 +237,11 @@ func getToolsForAgent(ctx context.Context, a *latest.AgentConfig, parentDir stri
 	for i := range a.Toolsets {
 		toolset := a.Toolsets[i]
 
+		// For "commands" toolset, populate the Commands field from the agent's commands
+		if toolset.Type == "commands" {
+			toolset.Commands = a.Commands
+		}
+
 		tool, err := registry.CreateTool(ctx, toolset, parentDir, runConfig)
 		if err != nil {
 			// Collect error but continue loading other toolsets

--- a/pkg/tools/builtin/commands.go
+++ b/pkg/tools/builtin/commands.go
@@ -1,0 +1,74 @@
+package builtin
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/docker/cagent/pkg/tools"
+)
+
+// CommandsTool exposes agent commands as callable tools.
+type CommandsTool struct {
+	tools.BaseToolSet
+	commands map[string]string
+}
+
+var _ tools.ToolSet = (*CommandsTool)(nil)
+
+func NewCommandsTool(commands map[string]string) *CommandsTool {
+	return &CommandsTool{commands: commands}
+}
+
+func (c *CommandsTool) Instructions() string {
+	if len(c.commands) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("## Agent Commands\n\n")
+
+	for _, name := range c.sortedNames() {
+		fmt.Fprintf(&b, "- **%s**: %s\n", name, truncate(c.commands[name], 80))
+	}
+
+	return b.String()
+}
+
+func (c *CommandsTool) Tools(_ context.Context) ([]tools.Tool, error) {
+	if len(c.commands) == 0 {
+		return nil, nil
+	}
+
+	result := make([]tools.Tool, 0, len(c.commands))
+	for _, name := range c.sortedNames() {
+		prompt := c.commands[name]
+		result = append(result, tools.Tool{
+			Name:        "command_" + name,
+			Category:    "commands",
+			Description: fmt.Sprintf("Execute '%s' command: %s", name, truncate(prompt, 100)),
+			Parameters:  map[string]any{"type": "object", "properties": map[string]any{}},
+			Handler: func(_ context.Context, _ tools.ToolCall) (*tools.ToolCallResult, error) {
+				return &tools.ToolCallResult{
+					Output: fmt.Sprintf("Execute: %s", prompt),
+				}, nil
+			},
+			Annotations: tools.ToolAnnotations{ReadOnlyHint: true},
+		})
+	}
+
+	return result, nil
+}
+
+func (c *CommandsTool) sortedNames() []string {
+	return slices.Sorted(maps.Keys(c.commands))
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}

--- a/pkg/tools/builtin/commands_test.go
+++ b/pkg/tools/builtin/commands_test.go
@@ -1,0 +1,80 @@
+package builtin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/cagent/pkg/tools"
+)
+
+func TestCommandsTool_Empty(t *testing.T) {
+	t.Parallel()
+
+	tool := NewCommandsTool(nil)
+
+	toolList, err := tool.Tools(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, toolList)
+	assert.Empty(t, tool.Instructions())
+}
+
+func TestCommandsTool_Tools(t *testing.T) {
+	t.Parallel()
+
+	tool := NewCommandsTool(map[string]string{
+		"df": "check disk space",
+		"ls": "list files",
+	})
+
+	toolList, err := tool.Tools(t.Context())
+	require.NoError(t, err)
+	require.Len(t, toolList, 2)
+
+	// Sorted alphabetically
+	assert.Equal(t, "command_df", toolList[0].Name)
+	assert.Equal(t, "command_ls", toolList[1].Name)
+
+	for _, tl := range toolList {
+		assert.Equal(t, "commands", tl.Category)
+		assert.True(t, tl.Annotations.ReadOnlyHint)
+	}
+}
+
+func TestCommandsTool_Handler(t *testing.T) {
+	t.Parallel()
+
+	tool := NewCommandsTool(map[string]string{"df": "check disk space"})
+
+	toolList, err := tool.Tools(t.Context())
+	require.NoError(t, err)
+	require.Len(t, toolList, 1)
+
+	result, err := toolList[0].Handler(t.Context(), tools.ToolCall{})
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, "check disk space")
+}
+
+func TestCommandsTool_Instructions(t *testing.T) {
+	t.Parallel()
+
+	tool := NewCommandsTool(map[string]string{
+		"df": "check disk space",
+		"ls": "list files",
+	})
+
+	instructions := tool.Instructions()
+	assert.Contains(t, instructions, "Agent Commands")
+	assert.Contains(t, instructions, "df")
+	assert.Contains(t, instructions, "ls")
+}
+
+func TestTruncate(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "hello", truncate("hello", 10))
+	assert.Equal(t, "hello", truncate("hello", 5))
+	assert.Equal(t, "hello...", truncate("hello world", 8))
+	assert.Empty(t, truncate("", 10))
+}


### PR DESCRIPTION
This adds a new 'commands' toolset type that exposes an agent's slash commands as callable tools. This allows agents to programmatically execute the same commands that users can invoke via slash commands.

This is still draft because it's currently pretty much useless. Needs some more work on it