### PR TITLE
Fix main branch

### DIFF
--- a/pkg/tui/commands/commands.go
+++ b/pkg/tui/commands/commands.go
@@ -61,7 +61,7 @@ func builtInSessionCommands() []Item {
 			SlashCommand: "/sessions",
 			Description:  "Browse and load past sessions",
 			Category:     "Session",
-			Execute: func() tea.Cmd {
+			Execute: func(string) tea.Cmd {
 				return core.CmdHandler(messages.OpenSessionBrowserMsg{})
 			},
 		},


### PR DESCRIPTION
The Execute function was missing the string parameter required by the ExecuteFunc type, likely from a bad rebase.

Assisted-By: cagent