### PR TITLE
Add tool permissions system with Allow/Ask/Deny patterns

### DIFF
--- a/cagent-schema.json
+++ b/cagent-schema.json
@@ -45,6 +45,10 @@
     "metadata": {
       "$ref": "#/definitions/Metadata",
       "description": "Configuration metadata"
+    },
+    "permissions": {
+      "$ref": "#/definitions/PermissionsConfig",
+      "description": "Tool permission configuration for controlling tool approval behavior"
     }
   },
   "additionalProperties": false,
@@ -331,6 +335,37 @@
         "readme": {
           "type": "string",
           "description": "README or description"
+        }
+      },
+      "additionalProperties": false
+    },
+    "PermissionsConfig": {
+      "type": "object",
+      "description": "Tool permission configuration. Controls tool call approval behavior with optional argument matching.",
+      "properties": {
+        "allow": {
+          "type": "array",
+          "description": "Tool patterns that are auto-approved without user confirmation. Supports tool names with glob patterns (e.g., 'read_*') and argument matching (e.g., 'shell:cmd=ls*' to allow shell commands starting with 'ls'). MCP tools can use qualified names (e.g., 'mcp:github:*').",
+          "items": {
+            "type": "string"
+          },
+          "examples": [
+            ["shell:cmd=ls*", "shell:cmd=git status*", "shell:cmd=go test*"],
+            ["mcp:github:get_*", "mcp:github:list_*"],
+            ["think", "create_todo*", "list_todos"]
+          ]
+        },
+        "deny": {
+          "type": "array",
+          "description": "Tool patterns that are always rejected. Takes priority over allow patterns. Supports the same pattern syntax as allow: tool names with globs and argument matching (e.g., 'shell:cmd=rm -rf*' to block dangerous rm commands).",
+          "items": {
+            "type": "string"
+          },
+          "examples": [
+            ["shell:cmd=rm -rf*", "shell:cmd=sudo*"],
+            ["shell:cmd=git push --force*", "shell:cmd=git reset --hard*"],
+            ["mcp:github:delete_*"]
+          ]
         }
       },
       "additionalProperties": false

--- a/examples/permissions.yaml
+++ b/examples/permissions.yaml
@@ -1,0 +1,63 @@
+#!/usr/bin/env cagent run
+
+metadata:
+  readme: |
+    Permissions Example
+
+    This example demonstrates how to use the permissions configuration
+    to control tool approval behavior:
+
+    - deny: Tools matching these patterns are always rejected
+    - allow: Tools matching these patterns are auto-approved
+    - (default): Tools not matching either pattern require user confirmation
+
+    Evaluation order: Deny (first) -> Allow -> Ask (default)
+
+permissions:
+  # Block dangerous commands (even with --yolo flag)
+  deny:
+    - "shell:cmd=rm *"
+    - "shell:cmd=sudo *"
+    - "shell:cmd=chmod *"
+    - "shell:cmd=sh *"
+    - "shell:cmd=bash *"
+    - "shell:cmd=zsh *"
+    - "shell:cmd=git push --force*"
+    - "shell:cmd=git reset --hard*"
+    - "shell:cmd=git clean -fd*"
+
+  # Auto-approve safe shell commands
+  allow:
+    - "shell:cmd=ls *"
+    - "shell:cmd=cat *"
+    - "shell:cmd=head *"
+    - "shell:cmd=tail *"
+    - "shell:cmd=wc *"
+    - "shell:cmd=find *"
+    - "shell:cmd=grep *"
+    - "shell:cmd=pwd"
+    - "shell:cmd=echo *"
+    - "shell:cmd=which *"
+    - "shell:cmd=type *"
+    - "shell:cmd=file *"
+    - "shell:cmd=stat *"
+    - "shell:cmd=git status*"
+    - "shell:cmd=git log*"
+    - "shell:cmd=git diff*"
+    - "shell:cmd=git show*"
+    - "shell:cmd=git branch*"
+    - "shell:cmd=git remote -v*"
+    - "shell:cmd=go test*"
+    - "shell:cmd=go build*"
+    - "shell:cmd=go fmt*"
+    - "shell:cmd=go vet*"
+    - "shell:cmd=go mod*"
+
+
+agents:
+  root:
+    model: anthropic/claude-haiku-4-5
+    description: A helpful assistant with controlled tool permissions
+    instruction: You are a helpful assistant with limited shell access.
+    toolsets:
+      - type: shell

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -13,11 +13,12 @@ const Version = "3"
 
 // Config represents the entire configuration file
 type Config struct {
-	Version  string                 `json:"version,omitempty"`
-	Agents   map[string]AgentConfig `json:"agents,omitempty"`
-	Models   map[string]ModelConfig `json:"models,omitempty"`
-	RAG      map[string]RAGConfig   `json:"rag,omitempty"`
-	Metadata Metadata               `json:"metadata,omitempty"`
+	Version     string                 `json:"version,omitempty"`
+	Agents      map[string]AgentConfig `json:"agents,omitempty"`
+	Models      map[string]ModelConfig `json:"models,omitempty"`
+	RAG         map[string]RAGConfig   `json:"rag,omitempty"`
+	Metadata    Metadata               `json:"metadata,omitempty"`
+	Permissions *PermissionsConfig     `json:"permissions,omitempty"`
 }
 
 // AgentConfig represents a single agent configuration
@@ -748,4 +749,19 @@ type RAGFusionConfig struct {
 	Strategy string             `json:"strategy,omitempty"` // Fusion strategy: "rrf" (Reciprocal Rank Fusion), "weighted", "max"
 	K        int                `json:"k,omitempty"`        // RRF parameter k (default: 60)
 	Weights  map[string]float64 `json:"weights,omitempty"`  // Strategy weights for weighted fusion
+}
+
+// PermissionsConfig represents tool permission configuration.
+// Allow/Ask/Deny model. This controls tool call approval behavior:
+// - Allow: Tools matching these patterns are auto-approved (like --yolo for specific tools)
+// - Ask: Tools matching these patterns always require user approval (default behavior)
+// - Deny: Tools matching these patterns are always rejected, even with --yolo
+//
+// Patterns support glob-style matching (e.g., "shell", "read_*", "mcp:github:*")
+// The evaluation order is: Deny (checked first), then Allow, then Ask (default)
+type PermissionsConfig struct {
+	// Allow lists tool name patterns that are auto-approved without user confirmation
+	Allow []string `json:"allow,omitempty"`
+	// Deny lists tool name patterns that are always rejected
+	Deny []string `json:"deny,omitempty"`
 }

--- a/pkg/permissions/permissions.go
+++ b/pkg/permissions/permissions.go
@@ -1,0 +1,217 @@
+// Package permissions provides tool permission checking based on configurable
+// Allow/Ask/Deny patterns.
+package permissions
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/docker/cagent/pkg/config/latest"
+)
+
+// Decision represents the permission decision for a tool call
+type Decision int
+
+const (
+	// Ask means the tool requires user approval (default behavior)
+	Ask Decision = iota
+	// Allow means the tool is auto-approved without user confirmation
+	Allow
+	// Deny means the tool is rejected and should not be executed
+	Deny
+)
+
+// String returns a human-readable representation of the decision
+func (d Decision) String() string {
+	switch d {
+	case Ask:
+		return "ask"
+	case Allow:
+		return "allow"
+	case Deny:
+		return "deny"
+	default:
+		return "unknown"
+	}
+}
+
+// Checker evaluates tool permissions based on configured patterns
+type Checker struct {
+	allowPatterns []string
+	denyPatterns  []string
+}
+
+// NewChecker creates a new permission checker from config
+func NewChecker(cfg *latest.PermissionsConfig) *Checker {
+	if cfg == nil {
+		return &Checker{}
+	}
+	return &Checker{
+		allowPatterns: cfg.Allow,
+		denyPatterns:  cfg.Deny,
+	}
+}
+
+// Check evaluates the permission for a given tool name without arguments.
+// This is a convenience method that calls CheckWithArgs with nil arguments.
+// Evaluation order: Deny (checked first), then Allow, then Ask (default)
+func (c *Checker) Check(toolName string) Decision {
+	return c.CheckWithArgs(toolName, nil)
+}
+
+// CheckWithArgs evaluates the permission for a given tool name and its arguments.
+// Evaluation order: Deny (checked first), then Allow, then Ask (default)
+//
+// The toolName can be a simple name like "shell" or a qualified name like
+// "mcp:github:create_issue".
+//
+// Patterns support:
+// - Simple tool names: "shell", "read_*"
+// - Argument matching: "shell:cmd=ls*" matches shell tool with cmd argument starting with "ls"
+// - Multiple arguments: "shell:cmd=ls*:cwd=/home/*" matches both conditions
+// - Glob patterns in both tool names and argument values
+func (c *Checker) CheckWithArgs(toolName string, args map[string]any) Decision {
+	// Deny patterns are checked first - they take priority
+	for _, pattern := range c.denyPatterns {
+		if matchToolPattern(pattern, toolName, args) {
+			return Deny
+		}
+	}
+
+	// Allow patterns are checked second
+	for _, pattern := range c.allowPatterns {
+		if matchToolPattern(pattern, toolName, args) {
+			return Allow
+		}
+	}
+
+	// Default is Ask
+	return Ask
+}
+
+// IsEmpty returns true if no permissions are configured
+func (c *Checker) IsEmpty() bool {
+	return len(c.allowPatterns) == 0 && len(c.denyPatterns) == 0
+}
+
+// parsePattern parses a permission pattern into tool name pattern and argument conditions.
+// Pattern format: "toolname" or "toolname:arg1=val1:arg2=val2"
+// Returns the tool pattern and a map of argument patterns.
+//
+// The parser looks for the first `:key=value` segment to split tool name from arguments.
+// This allows tool names with colons (like "mcp:github:create_issue") to work correctly.
+func parsePattern(pattern string) (toolPattern string, argPatterns map[string]string) {
+	argPatterns = make(map[string]string)
+
+	// Find the first occurrence of :key=value pattern
+	// We look for ":" followed by an identifier and "="
+	parts := strings.Split(pattern, ":")
+	toolParts := []string{parts[0]} // First part is always part of the tool name
+
+	for _, part := range parts[1:] {
+		// Check if this part looks like an argument pattern (contains =)
+		if key, value, found := strings.Cut(part, "="); found && key != "" {
+			// This is an argument pattern - this and all remaining parts are args
+			argPatterns[key] = value
+		} else if len(argPatterns) == 0 {
+			// No = found and we haven't started args yet, so it's part of tool name
+			toolParts = append(toolParts, part)
+		}
+		// If we've started collecting args but this part has no =, skip it
+	}
+
+	toolPattern = strings.Join(toolParts, ":")
+	return toolPattern, argPatterns
+}
+
+// matchToolPattern checks if a tool name and its arguments match a pattern.
+// The pattern can be:
+// - Simple: "shell" - matches tool name only
+// - With args: "shell:cmd=ls*" - matches tool name AND argument value
+func matchToolPattern(pattern, toolName string, args map[string]any) bool {
+	toolPattern, argPatterns := parsePattern(pattern)
+
+	// First check if the tool name matches
+	if !matchGlob(toolPattern, toolName) {
+		return false
+	}
+
+	// If no argument patterns, we're done - tool name matched
+	if len(argPatterns) == 0 {
+		return true
+	}
+
+	// If pattern has argument conditions but no args provided, no match
+	if args == nil {
+		return false
+	}
+
+	// All argument patterns must match
+	for argName, argPattern := range argPatterns {
+		argValue, exists := args[argName]
+		if !exists {
+			return false
+		}
+
+		// Convert argument value to string for matching
+		argStr := argToString(argValue)
+		if !matchGlob(argPattern, argStr) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// argToString converts an argument value to a string for pattern matching.
+func argToString(v any) string {
+	switch val := v.(type) {
+	case string:
+		return val
+	case bool:
+		return fmt.Sprintf("%t", val)
+	case float64:
+		// JSON numbers are float64 - format without trailing zeros
+		if val == float64(int64(val)) {
+			return fmt.Sprintf("%d", int64(val))
+		}
+		return fmt.Sprintf("%g", val)
+	case int, int64:
+		return fmt.Sprintf("%d", val)
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+// matchGlob checks if a value matches a glob pattern.
+// Supports glob-style patterns using filepath.Match semantics:
+// - "*" matches any sequence of characters within a path segment
+// - "?" matches any single character
+// - "[...]" matches character classes
+//
+// Matching is case-insensitive.
+//
+// Note: filepath.Match's "*" stops at path separators, but for argument
+// matching we want "*" to match any characters including spaces.
+// We handle trailing wildcards specially to support patterns like "sudo*"
+// matching "sudo rm -rf /".
+func matchGlob(pattern, value string) bool {
+	// Normalize both to lowercase for case-insensitive matching
+	pattern = strings.ToLower(pattern)
+	value = strings.ToLower(value)
+
+	// Handle trailing wildcard for prefix matching
+	// This allows "sudo*" to match "sudo rm -rf /"
+	if strings.HasSuffix(pattern, "*") && !strings.HasSuffix(pattern, "\\*") {
+		prefix := pattern[:len(pattern)-1]
+		// If prefix contains no other glob characters, do simple prefix match
+		if !strings.ContainsAny(prefix, "*?[") {
+			return strings.HasPrefix(value, prefix)
+		}
+	}
+
+	// Try glob pattern match (also handles exact matches)
+	matched, err := filepath.Match(pattern, value)
+	return err == nil && matched
+}

--- a/pkg/permissions/permissions_test.go
+++ b/pkg/permissions/permissions_test.go
@@ -1,0 +1,518 @@
+package permissions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/cagent/pkg/config/latest"
+)
+
+func TestNewChecker(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil config", func(t *testing.T) {
+		t.Parallel()
+		checker := NewChecker(nil)
+		require.NotNil(t, checker)
+		assert.True(t, checker.IsEmpty())
+	})
+
+	t.Run("empty config", func(t *testing.T) {
+		t.Parallel()
+		checker := NewChecker(&latest.PermissionsConfig{})
+		require.NotNil(t, checker)
+		assert.True(t, checker.IsEmpty())
+	})
+
+	t.Run("with patterns", func(t *testing.T) {
+		t.Parallel()
+		checker := NewChecker(&latest.PermissionsConfig{
+			Allow: []string{"read_*"},
+			Deny:  []string{"shell"},
+		})
+		require.NotNil(t, checker)
+		assert.False(t, checker.IsEmpty())
+	})
+}
+
+func TestChecker_Check(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		allow    []string
+		deny     []string
+		toolName string
+		want     Decision
+	}{
+		{
+			name:     "no patterns returns Ask",
+			toolName: "shell",
+			want:     Ask,
+		},
+		{
+			name:     "exact allow match",
+			allow:    []string{"shell"},
+			toolName: "shell",
+			want:     Allow,
+		},
+		{
+			name:     "exact deny match",
+			deny:     []string{"shell"},
+			toolName: "shell",
+			want:     Deny,
+		},
+		{
+			name:     "deny takes priority over allow",
+			allow:    []string{"shell"},
+			deny:     []string{"shell"},
+			toolName: "shell",
+			want:     Deny,
+		},
+		{
+			name:     "glob pattern allow",
+			allow:    []string{"read_*"},
+			toolName: "read_file",
+			want:     Allow,
+		},
+		{
+			name:     "glob pattern deny",
+			deny:     []string{"*_file"},
+			toolName: "write_file",
+			want:     Deny,
+		},
+		{
+			name:     "no match returns Ask",
+			allow:    []string{"read_*"},
+			deny:     []string{"shell"},
+			toolName: "write_file",
+			want:     Ask,
+		},
+		{
+			name:     "case insensitive matching",
+			allow:    []string{"Shell"},
+			toolName: "shell",
+			want:     Allow,
+		},
+		{
+			name:     "case insensitive pattern",
+			allow:    []string{"READ_*"},
+			toolName: "read_file",
+			want:     Allow,
+		},
+		{
+			name:     "question mark wildcard",
+			allow:    []string{"read_???e"},
+			toolName: "read_file",
+			want:     Allow,
+		},
+		{
+			name:     "character class",
+			allow:    []string{"[rw]*_file"},
+			toolName: "read_file",
+			want:     Allow,
+		},
+		{
+			name:     "mcp tool pattern",
+			allow:    []string{"mcp:github:*"},
+			toolName: "mcp:github:create_issue",
+			want:     Allow,
+		},
+		{
+			name:     "mcp tool exact match",
+			deny:     []string{"mcp:github:delete_repo"},
+			toolName: "mcp:github:delete_repo",
+			want:     Deny,
+		},
+		{
+			name:     "wildcard all",
+			allow:    []string{"*"},
+			toolName: "anything",
+			want:     Allow,
+		},
+		{
+			name:     "multiple patterns first match wins",
+			allow:    []string{"shell", "read_*"},
+			toolName: "read_file",
+			want:     Allow,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			checker := NewChecker(&latest.PermissionsConfig{
+				Allow: tt.allow,
+				Deny:  tt.deny,
+			})
+			got := checker.Check(tt.toolName)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestChecker_CheckWithArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		allow    []string
+		deny     []string
+		toolName string
+		args     map[string]any
+		want     Decision
+	}{
+		// Basic tool name matching (no args in pattern)
+		{
+			name:     "tool name only match with args provided",
+			allow:    []string{"shell"},
+			toolName: "shell",
+			args:     map[string]any{"cmd": "ls -la"},
+			want:     Allow,
+		},
+		{
+			name:     "tool name only match with nil args",
+			allow:    []string{"shell"},
+			toolName: "shell",
+			args:     nil,
+			want:     Allow,
+		},
+
+		// Argument matching - Allow patterns
+		{
+			name:     "allow shell with specific cmd pattern",
+			allow:    []string{"shell:cmd=ls*"},
+			toolName: "shell",
+			args:     map[string]any{"cmd": "ls -la"},
+			want:     Allow,
+		},
+		{
+			name:     "allow shell with exact cmd match",
+			allow:    []string{"shell:cmd=ls"},
+			toolName: "shell",
+			args:     map[string]any{"cmd": "ls"},
+			want:     Allow,
+		},
+		{
+			name:     "allow shell cmd pattern no match",
+			allow:    []string{"shell:cmd=ls*"},
+			toolName: "shell",
+			args:     map[string]any{"cmd": "rm -rf /"},
+			want:     Ask,
+		},
+		{
+			name:     "allow pattern with args but no args provided",
+			allow:    []string{"shell:cmd=ls*"},
+			toolName: "shell",
+			args:     nil,
+			want:     Ask,
+		},
+
+		// Argument matching - Deny patterns
+		{
+			name:     "deny shell with rm command",
+			deny:     []string{"shell:cmd=rm*"},
+			toolName: "shell",
+			args:     map[string]any{"cmd": "rm -rf /"},
+			want:     Deny,
+		},
+		{
+			name:     "deny shell with sudo",
+			deny:     []string{"shell:cmd=sudo*"},
+			toolName: "shell",
+			args:     map[string]any{"cmd": "sudo rm -rf /"},
+			want:     Deny,
+		},
+		{
+			name:     "deny pattern not matching",
+			deny:     []string{"shell:cmd=rm*"},
+			toolName: "shell",
+			args:     map[string]any{"cmd": "ls -la"},
+			want:     Ask,
+		},
+
+		// Multiple argument conditions
+		{
+			name:     "multiple args all match",
+			allow:    []string{"shell:cmd=ls*:cwd=."},
+			toolName: "shell",
+			args:     map[string]any{"cmd": "ls -la", "cwd": "."},
+			want:     Allow,
+		},
+		{
+			name:     "multiple args partial match fails",
+			allow:    []string{"shell:cmd=ls*:cwd=/home/*"},
+			toolName: "shell",
+			args:     map[string]any{"cmd": "ls -la", "cwd": "/tmp"},
+			want:     Ask,
+		},
+		{
+			name:     "multiple args missing one fails",
+			allow:    []string{"shell:cmd=ls*:cwd=."},
+			toolName: "shell",
+			args:     map[string]any{"cmd": "ls -la"},
+			want:     Ask,
+		},
+
+		// Priority: Deny > Allow
+		{
+			name:     "deny takes priority over allow with args",
+			allow:    []string{"shell:cmd=*"},
+			deny:     []string{"shell:cmd=rm*"},
+			toolName: "shell",
+			args:     map[string]any{"cmd": "rm -rf /"},
+			want:     Deny,
+		},
+		{
+			name:     "allow wins when deny pattern does not match args",
+			allow:    []string{"shell:cmd=ls*"},
+			deny:     []string{"shell:cmd=rm*"},
+			toolName: "shell",
+			args:     map[string]any{"cmd": "ls -la"},
+			want:     Allow,
+		},
+
+		// Case insensitivity
+		{
+			name:     "case insensitive arg value matching",
+			allow:    []string{"shell:cmd=LS*"},
+			toolName: "shell",
+			args:     map[string]any{"cmd": "ls -la"},
+			want:     Allow,
+		},
+		{
+			name:     "case insensitive arg name matching",
+			allow:    []string{"shell:CMD=ls*"},
+			toolName: "shell",
+			args:     map[string]any{"cmd": "ls -la"},
+			want:     Ask, // arg names are case-sensitive in Go maps
+		},
+
+		// Different argument types
+		{
+			name:     "boolean arg true",
+			allow:    []string{"tool:flag=true"},
+			toolName: "tool",
+			args:     map[string]any{"flag": true},
+			want:     Allow,
+		},
+		{
+			name:     "boolean arg false",
+			allow:    []string{"tool:flag=false"},
+			toolName: "tool",
+			args:     map[string]any{"flag": false},
+			want:     Allow,
+		},
+		{
+			name:     "numeric arg",
+			allow:    []string{"tool:count=42"},
+			toolName: "tool",
+			args:     map[string]any{"count": float64(42)}, // JSON numbers are float64
+			want:     Allow,
+		},
+
+		// Wildcard patterns in args
+		{
+			name:     "wildcard in arg value",
+			allow:    []string{"shell:cmd=*"},
+			toolName: "shell",
+			args:     map[string]any{"cmd": "anything"},
+			want:     Allow,
+		},
+		{
+			name:     "question mark wildcard in arg",
+			allow:    []string{"shell:cmd=l?"},
+			toolName: "shell",
+			args:     map[string]any{"cmd": "ls"},
+			want:     Allow,
+		},
+
+		// Complex real-world examples
+		{
+			name:     "allow safe git commands",
+			allow:    []string{"shell:cmd=git status*", "shell:cmd=git log*", "shell:cmd=git diff*"},
+			toolName: "shell",
+			args:     map[string]any{"cmd": "git status"},
+			want:     Allow,
+		},
+		{
+			name:     "deny dangerous git commands",
+			deny:     []string{"shell:cmd=git push*", "shell:cmd=git reset --hard*"},
+			toolName: "shell",
+			args:     map[string]any{"cmd": "git push origin main"},
+			want:     Deny,
+		},
+		{
+			name:     "allow read operations on specific paths",
+			allow:    []string{"read_file:path=/home/user/safe/*"},
+			toolName: "read_file",
+			args:     map[string]any{"path": "/home/user/safe/config.txt"},
+			want:     Allow,
+		},
+		{
+			name:     "deny write to sensitive paths",
+			deny:     []string{"write_file:path=/etc/*", "write_file:path=/root/*"},
+			toolName: "write_file",
+			args:     map[string]any{"path": "/etc/passwd"},
+			want:     Deny,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			checker := NewChecker(&latest.PermissionsConfig{
+				Allow: tt.allow,
+				Deny:  tt.deny,
+			})
+			got := checker.CheckWithArgs(tt.toolName, tt.args)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDecision_String(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		decision Decision
+		want     string
+	}{
+		{Ask, "ask"},
+		{Allow, "allow"},
+		{Deny, "deny"},
+		{Decision(99), "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.decision.String())
+		})
+	}
+}
+
+func TestParsePattern(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		pattern        string
+		wantTool       string
+		wantArgPattern map[string]string
+	}{
+		{
+			pattern:        "shell",
+			wantTool:       "shell",
+			wantArgPattern: map[string]string{},
+		},
+		{
+			pattern:        "shell:cmd=ls*",
+			wantTool:       "shell",
+			wantArgPattern: map[string]string{"cmd": "ls*"},
+		},
+		{
+			pattern:        "shell:cmd=ls*:cwd=/home/*",
+			wantTool:       "shell",
+			wantArgPattern: map[string]string{"cmd": "ls*", "cwd": "/home/*"},
+		},
+		{
+			// MCP tools have colons in their names - should preserve them
+			pattern:        "mcp:github:create_issue",
+			wantTool:       "mcp:github:create_issue",
+			wantArgPattern: map[string]string{},
+		},
+		{
+			// MCP tool with argument pattern
+			pattern:        "mcp:github:create_issue:repo=owner/*",
+			wantTool:       "mcp:github:create_issue",
+			wantArgPattern: map[string]string{"repo": "owner/*"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern, func(t *testing.T) {
+			t.Parallel()
+			toolPattern, argPatterns := parsePattern(tt.pattern)
+			assert.Equal(t, tt.wantTool, toolPattern)
+			assert.Equal(t, tt.wantArgPattern, argPatterns)
+		})
+	}
+}
+
+func TestMatchGlob(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		pattern string
+		value   string
+		want    bool
+	}{
+		// Exact matches
+		{"shell", "shell", true},
+		{"shell", "bash", false},
+
+		// Glob patterns
+		{"read_*", "read_file", true},
+		{"read_*", "read_directory", true},
+		{"read_*", "write_file", false},
+		{"*_file", "read_file", true},
+		{"*_file", "write_file", true},
+		{"*_file", "read_directory", false},
+
+		// Wildcards
+		{"*", "anything", true},
+		{"???", "abc", true},
+		{"???", "abcd", false},
+
+		// Character classes
+		{"[a-z]*", "shell", true},
+		{"[0-9]*", "shell", false},
+
+		// Case insensitivity
+		{"SHELL", "shell", true},
+		{"shell", "SHELL", true},
+		{"Read_*", "read_file", true},
+
+		// Qualified names (MCP tools)
+		{"mcp:*", "mcp:github:create_issue", true}, // * matches everything including :
+		{"mcp:github:*", "mcp:github:create_issue", true},
+		{"mcp:github:create_*", "mcp:github:create_issue", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern+"_"+tt.value, func(t *testing.T) {
+			t.Parallel()
+			got := matchGlob(tt.pattern, tt.value)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestArgToString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input any
+		want  string
+	}{
+		{"string", "hello", "hello"},
+		{"bool true", true, "true"},
+		{"bool false", false, "false"},
+		{"float64 integer", float64(42), "42"},
+		{"float64 decimal", float64(3.14), "3.14"},
+		{"int", 42, "42"},
+		{"int64", int64(42), "42"},
+		{"nil", nil, "<nil>"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := argToString(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/team/team.go
+++ b/pkg/team/team.go
@@ -11,12 +11,14 @@ import (
 
 	"github.com/docker/cagent/pkg/agent"
 	"github.com/docker/cagent/pkg/model/provider"
+	"github.com/docker/cagent/pkg/permissions"
 	"github.com/docker/cagent/pkg/rag"
 )
 
 type Team struct {
 	agents      map[string]*agent.Agent
 	ragManagers map[string]*rag.Manager
+	permissions *permissions.Checker
 }
 
 type Opt func(*Team)
@@ -32,6 +34,12 @@ func WithAgents(agents ...*agent.Agent) Opt {
 func WithRAGManagers(managers map[string]*rag.Manager) Opt {
 	return func(t *Team) {
 		t.ragManagers = managers
+	}
+}
+
+func WithPermissions(checker *permissions.Checker) Opt {
+	return func(t *Team) {
+		t.permissions = checker
 	}
 }
 
@@ -157,4 +165,10 @@ func (t *Team) StartRAGFileWatchers(ctx context.Context) {
 			}
 		}(mgr)
 	}
+}
+
+// Permissions returns the permission checker for this team.
+// Returns nil if no permissions are configured.
+func (t *Team) Permissions() *permissions.Checker {
+	return t.permissions
 }

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/cagent/pkg/model/provider"
 	"github.com/docker/cagent/pkg/model/provider/options"
 	"github.com/docker/cagent/pkg/modelsdev"
+	"github.com/docker/cagent/pkg/permissions"
 	"github.com/docker/cagent/pkg/rag"
 	"github.com/docker/cagent/pkg/team"
 	"github.com/docker/cagent/pkg/tools"
@@ -168,9 +169,13 @@ func Load(ctx context.Context, agentSource config.Source, runConfig *config.Runt
 		}
 	}
 
+	// Create permissions checker from config
+	permChecker := permissions.NewChecker(cfg.Permissions)
+
 	return team.New(
 		team.WithAgents(agents...),
 		team.WithRAGManagers(ragManagers),
+		team.WithPermissions(permChecker),
 	), nil
 }
 


### PR DESCRIPTION
Implement a permissions configuration that allows controlling tool approval behavior through pattern matching:

- Add permissions section to config with allow and deny string arrays
- Deny patterns are checked first and block execution (highest priority)
- Allow patterns auto-approve tools without user confirmation
- Default behavior requires user confirmation (Ask)

Pattern matching supports:
- Glob-style wildcards: * matches any sequence of characters
- ? matches any single character
- [abc] matches character classes
- Case insensitive matching
- **Argument matching**: tool:arg=pattern to match specific argument values e.g., 'shell:cmd=ls*' allows shell with cmd starting with 'ls'

Assisted-By: cagent