### PR TITLE
Very basic sandboxing support for the 'shell' tools

### DIFF
--- a/cagent-schema.json
+++ b/cagent-schema.json
@@ -468,6 +468,10 @@
         "name": {
           "type": "string",
           "description": "Name for the a2a tool"
+        },
+        "sandbox": {
+          "$ref": "#/definitions/SandboxConfig",
+          "description": "Sandbox configuration for running shell commands in a Docker container (shell tool only)"
         }
       },
       "additionalProperties": false,
@@ -590,6 +594,39 @@
       },
       "required": [
         "url"
+      ],
+      "additionalProperties": false
+    },
+    "SandboxConfig": {
+      "type": "object",
+      "description": "Configuration for running shell commands inside a sandboxed Docker container",
+      "properties": {
+        "image": {
+          "type": "string",
+          "description": "Docker image to use for the sandbox container. Defaults to 'alpine:latest' if not specified.",
+          "examples": [
+            "alpine:latest",
+            "ubuntu:22.04",
+            "python:3.12-alpine",
+            "node:20-alpine"
+          ]
+        },
+        "paths": {
+          "type": "array",
+          "description": "List of paths to bind-mount into the container. Each path can have an optional ':ro' suffix for read-only access (default is read-write ':rw'). Relative paths are resolved from the agent's working directory.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "examples": [
+            [".", "/tmp"],
+            ["./src", "./config:ro"],
+            ["/data:rw", "/secrets:ro"]
+          ]
+        }
+      },
+      "required": [
+        "paths"
       ],
       "additionalProperties": false
     },

--- a/examples/golibrary/builtintool/main.go
+++ b/examples/golibrary/builtintool/main.go
@@ -47,7 +47,7 @@ func run(ctx context.Context) error {
 				"root",
 				"You are an expert hacker",
 				agent.WithModel(llm),
-				agent.WithToolSets(builtin.NewShellTool(os.Environ(), &config.RuntimeConfig{Config: config.Config{WorkingDir: "/tmp"}})),
+				agent.WithToolSets(builtin.NewShellTool(os.Environ(), &config.RuntimeConfig{Config: config.Config{WorkingDir: "/tmp"}}, nil)),
 			),
 		),
 	)

--- a/examples/sandbox_agent.yaml
+++ b/examples/sandbox_agent.yaml
@@ -1,0 +1,17 @@
+#!/usr/bin/env cagent run
+
+agents:
+  root:
+    model: openai/gpt-4o
+    description: |
+      A helpful assistant that runs shell commands in a sandboxed environment.
+      All shell commands execute inside a Docker container with limited filesystem access.
+    instruction: You are a helpful assistant with access to a sandboxed shell environment.
+    toolsets:
+      - type: shell
+        sandbox:
+          image: alpine:latest
+          paths:
+            - .
+            - /tmp
+            - "${env.HOME}:ro"

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -141,6 +141,9 @@ type Toolset struct {
 	// For `shell`, `script`, `mcp` or `lsp` tools
 	Env map[string]string `json:"env,omitempty"`
 
+	// For the `shell` tool - sandbox mode
+	Sandbox *SandboxConfig `json:"sandbox,omitempty"`
+
 	// For the `todo` tool
 	Shared bool `json:"shared,omitempty"`
 
@@ -176,6 +179,21 @@ type Remote struct {
 	URL           string            `json:"url"`
 	TransportType string            `json:"transport_type,omitempty"`
 	Headers       map[string]string `json:"headers,omitempty"`
+}
+
+// SandboxConfig represents the configuration for running shell commands in a Docker container.
+// When enabled, all shell commands run inside a sandboxed Linux container with only
+// specified paths bind-mounted.
+type SandboxConfig struct {
+	// Image is the Docker image to use for the sandbox container.
+	// Defaults to "alpine:latest" if not specified.
+	Image string `json:"image,omitempty"`
+
+	// Paths is a list of paths to bind-mount into the container.
+	// Each path can optionally have a ":ro" suffix for read-only access.
+	// Default is read-write (:rw) if no suffix is specified.
+	// Example: [".", "/tmp", "/config:ro"]
+	Paths []string `json:"paths"`
 }
 
 // DeferConfig represents the deferred loading configuration for a toolset.

--- a/pkg/config/latest/validate.go
+++ b/pkg/config/latest/validate.go
@@ -45,6 +45,9 @@ func (t *Toolset) validate() error {
 	if len(t.Env) > 0 && (t.Type != "shell" && t.Type != "script" && t.Type != "mcp" && t.Type != "lsp") {
 		return errors.New("env can only be used with type 'shell', 'script', 'mcp' or 'lsp'")
 	}
+	if t.Sandbox != nil && t.Type != "shell" {
+		return errors.New("sandbox can only be used with type 'shell'")
+	}
 	if t.Shared && t.Type != "todo" {
 		return errors.New("shared can only be used with type 'todo'")
 	}
@@ -74,6 +77,10 @@ func (t *Toolset) validate() error {
 	}
 
 	switch t.Type {
+	case "shell":
+		if t.Sandbox != nil && len(t.Sandbox.Paths) == 0 {
+			return errors.New("sandbox requires at least one path to be set")
+		}
 	case "memory":
 		if t.Path == "" {
 			return errors.New("memory toolset requires a path to be set")

--- a/pkg/config/latest/validate_test.go
+++ b/pkg/config/latest/validate_test.go
@@ -88,3 +88,104 @@ agents:
 		})
 	}
 }
+
+func TestToolset_Validate_Sandbox(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		config  string
+		wantErr string
+	}{
+		{
+			name: "valid shell with sandbox",
+			config: `
+version: "3"
+agents:
+  root:
+    model: "openai/gpt-4"
+    toolsets:
+      - type: shell
+        sandbox:
+          image: alpine:latest
+          paths:
+            - .
+            - /tmp
+`,
+			wantErr: "",
+		},
+		{
+			name: "shell sandbox with readonly path",
+			config: `
+version: "3"
+agents:
+  root:
+    model: "openai/gpt-4"
+    toolsets:
+      - type: shell
+        sandbox:
+          paths:
+            - ./:rw
+            - /config:ro
+`,
+			wantErr: "",
+		},
+		{
+			name: "shell sandbox without paths",
+			config: `
+version: "3"
+agents:
+  root:
+    model: "openai/gpt-4"
+    toolsets:
+      - type: shell
+        sandbox:
+          image: alpine:latest
+`,
+			wantErr: "sandbox requires at least one path to be set",
+		},
+		{
+			name: "sandbox on non-shell toolset",
+			config: `
+version: "3"
+agents:
+  root:
+    model: "openai/gpt-4"
+    toolsets:
+      - type: filesystem
+        sandbox:
+          paths:
+            - .
+`,
+			wantErr: "sandbox can only be used with type 'shell'",
+		},
+		{
+			name: "shell without sandbox is valid",
+			config: `
+version: "3"
+agents:
+  root:
+    model: "openai/gpt-4"
+    toolsets:
+      - type: shell
+`,
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var cfg Config
+			err := yaml.Unmarshal([]byte(tt.config), &cfg)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/teamloader/registry_test.go
+++ b/pkg/teamloader/registry_test.go
@@ -1,0 +1,142 @@
+package teamloader
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/cagent/pkg/config"
+	"github.com/docker/cagent/pkg/config/latest"
+	"github.com/docker/cagent/pkg/environment"
+)
+
+type mockEnvProvider struct {
+	values map[string]string
+}
+
+func (p *mockEnvProvider) Get(_ context.Context, key string) (string, bool) {
+	v, ok := p.values[key]
+	return v, ok
+}
+
+func TestExpandSandboxPaths(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		sandbox       *latest.SandboxConfig
+		envVars       map[string]string
+		expectedPaths []string
+	}{
+		{
+			name:          "nil sandbox",
+			sandbox:       nil,
+			expectedPaths: nil,
+		},
+		{
+			name: "no interpolation needed",
+			sandbox: &latest.SandboxConfig{
+				Image: "alpine:latest",
+				Paths: []string{".", "/tmp", "./config:ro"},
+			},
+			expectedPaths: []string{".", "/tmp", "./config:ro"},
+		},
+		{
+			name: "simple env var interpolation",
+			sandbox: &latest.SandboxConfig{
+				Image: "alpine:latest",
+				Paths: []string{"${env.HOME}:ro", "${env.PROJECT_DIR}"},
+			},
+			envVars: map[string]string{
+				"HOME":        "/home/user",
+				"PROJECT_DIR": "/projects/myapp",
+			},
+			expectedPaths: []string{"/home/user:ro", "/projects/myapp"},
+		},
+		{
+			name: "mixed paths with and without interpolation",
+			sandbox: &latest.SandboxConfig{
+				Image: "custom:image",
+				Paths: []string{".", "${env.HOME}:ro", "/tmp", "${env.CONFIG_PATH}:ro"},
+			},
+			envVars: map[string]string{
+				"HOME":        "/home/testuser",
+				"CONFIG_PATH": "/etc/myapp",
+			},
+			expectedPaths: []string{".", "/home/testuser:ro", "/tmp", "/etc/myapp:ro"},
+		},
+		{
+			name: "default value fallback",
+			sandbox: &latest.SandboxConfig{
+				Image: "alpine:latest",
+				Paths: []string{"${env.CUSTOM_PATH || '/default/path'}:ro"},
+			},
+			envVars:       map[string]string{},
+			expectedPaths: []string{"/default/path:ro"},
+		},
+		{
+			name: "missing env var without default",
+			sandbox: &latest.SandboxConfig{
+				Image: "alpine:latest",
+				Paths: []string{"${env.MISSING_VAR}:ro"},
+			},
+			envVars:       map[string]string{},
+			expectedPaths: []string{":ro"}, // Empty string when env var is missing
+		},
+		{
+			name: "image field preserved",
+			sandbox: &latest.SandboxConfig{
+				Image: "myregistry/myimage:v1",
+				Paths: []string{"${env.HOME}"},
+			},
+			envVars: map[string]string{
+				"HOME": "/home/user",
+			},
+			expectedPaths: []string{"/home/user"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			envProvider := &mockEnvProvider{values: tt.envVars}
+			result := expandSandboxPaths(t.Context(), tt.sandbox, envProvider)
+
+			if tt.sandbox == nil {
+				require.Nil(t, result)
+				return
+			}
+
+			require.NotNil(t, result)
+			assert.Equal(t, tt.sandbox.Image, result.Image, "Image should be preserved")
+			assert.Equal(t, tt.expectedPaths, result.Paths, "Paths should be expanded correctly")
+		})
+	}
+}
+
+func TestCreateShellToolWithSandboxExpansion(t *testing.T) {
+	t.Setenv("HOME", "/home/testuser")
+	t.Setenv("WORK_DIR", "/workspace")
+
+	toolset := latest.Toolset{
+		Type: "shell",
+		Sandbox: &latest.SandboxConfig{
+			Image: "alpine:latest",
+			Paths: []string{".", "${env.HOME}:ro", "${env.WORK_DIR}"},
+		},
+	}
+
+	registry := NewDefaultToolsetRegistry()
+
+	runConfig := &config.RuntimeConfig{
+		Config:              config.Config{WorkingDir: t.TempDir()},
+		EnvProviderForTests: environment.NewOsEnvProvider(),
+	}
+
+	tool, err := registry.CreateTool(t.Context(), toolset, ".", runConfig)
+	require.NoError(t, err)
+	require.NotNil(t, tool)
+}

--- a/pkg/tools/builtin/sandbox.go
+++ b/pkg/tools/builtin/sandbox.go
@@ -1,0 +1,266 @@
+package builtin
+
+import (
+	"bytes"
+	"cmp"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/docker/cagent/pkg/config/latest"
+	"github.com/docker/cagent/pkg/tools"
+)
+
+const (
+	// sandboxLabelKey is the label used to identify cagent sandbox containers.
+	sandboxLabelKey = "com.docker.cagent.sandbox"
+	// sandboxLabelPID stores the PID of the cagent process that created the container.
+	sandboxLabelPID = "com.docker.cagent.sandbox.pid"
+)
+
+// sandboxRunner handles command execution in a Docker container sandbox.
+type sandboxRunner struct {
+	config      *latest.SandboxConfig
+	workingDir  string
+	env         []string
+	containerID string
+	mu          sync.Mutex
+}
+
+func newSandboxRunner(config *latest.SandboxConfig, workingDir string, env []string) *sandboxRunner {
+	// Clean up any orphaned containers from previous cagent runs
+	cleanupOrphanedSandboxContainers()
+
+	return &sandboxRunner{
+		config:     config,
+		workingDir: workingDir,
+		env:        env,
+	}
+}
+
+// cleanupOrphanedSandboxContainers removes sandbox containers from previous cagent processes
+// that are no longer running. This handles cases where cagent was killed or crashed.
+func cleanupOrphanedSandboxContainers() {
+	cmd := exec.Command("docker", "ps", "-q", "--filter", "label="+sandboxLabelKey)
+	output, err := cmd.Output()
+	if err != nil {
+		return // Docker not available or no containers
+	}
+
+	containerIDs := strings.Fields(string(output))
+	currentPID := os.Getpid()
+
+	for _, containerID := range containerIDs {
+		pid := getContainerOwnerPID(containerID)
+		if pid == 0 || pid == currentPID || isProcessRunning(pid) {
+			continue
+		}
+
+		slog.Debug("Cleaning up orphaned sandbox container", "container", containerID, "pid", pid)
+		stopCmd := exec.Command("docker", "stop", "-t", "1", containerID)
+		_ = stopCmd.Run()
+	}
+}
+
+// getContainerOwnerPID returns the PID that created the container, or 0 if unknown.
+func getContainerOwnerPID(containerID string) int {
+	cmd := exec.Command("docker", "inspect", "-f",
+		"{{index .Config.Labels \""+sandboxLabelPID+"\"}}", containerID)
+	output, err := cmd.Output()
+	if err != nil {
+		return 0
+	}
+	pid, _ := strconv.Atoi(strings.TrimSpace(string(output)))
+	return pid
+}
+
+// isProcessRunning checks if a process with the given PID is still running.
+func isProcessRunning(pid int) bool {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	// On Unix, FindProcess always succeeds, so we need to send signal 0
+	// to check if the process actually exists
+	err = process.Signal(syscall.Signal(0))
+	return err == nil
+}
+
+// runCommand executes a command inside the sandbox container.
+func (s *sandboxRunner) runCommand(timeoutCtx, ctx context.Context, command, cwd string, timeout time.Duration) *tools.ToolCallResult {
+	containerID, err := s.ensureContainer(ctx)
+	if err != nil {
+		return tools.ResultError(fmt.Sprintf("Failed to start sandbox container: %s", err))
+	}
+
+	args := []string{"exec", "-w", cwd}
+	args = append(args, s.buildEnvVars()...)
+	args = append(args, containerID, "/bin/sh", "-c", command)
+
+	cmd := exec.CommandContext(timeoutCtx, "docker", args...)
+	var outBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &outBuf
+
+	err = cmd.Run()
+
+	output := formatCommandOutput(timeoutCtx, ctx, err, outBuf.String(), timeout)
+	return tools.ResultSuccess(limitOutput(output))
+}
+
+// stop stops and removes the sandbox container.
+func (s *sandboxRunner) stop() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.containerID == "" {
+		return
+	}
+
+	stopCmd := exec.Command("docker", "stop", "-t", "1", s.containerID)
+	_ = stopCmd.Run()
+
+	s.containerID = ""
+}
+
+// ensureContainer ensures the sandbox container is running, starting it if necessary.
+func (s *sandboxRunner) ensureContainer(ctx context.Context) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.containerID != "" && s.isContainerRunning(ctx) {
+		return s.containerID, nil
+	}
+	s.containerID = ""
+
+	return s.startContainer(ctx)
+}
+
+func (s *sandboxRunner) isContainerRunning(ctx context.Context) bool {
+	cmd := exec.CommandContext(ctx, "docker", "container", "inspect", "-f", "{{.State.Running}}", s.containerID)
+	output, err := cmd.Output()
+	return err == nil && strings.TrimSpace(string(output)) == "true"
+}
+
+func (s *sandboxRunner) startContainer(ctx context.Context) (string, error) {
+	containerName := s.generateContainerName()
+	image := cmp.Or(s.config.Image, "alpine:latest")
+
+	args := []string{
+		"run", "-d",
+		"--name", containerName,
+		"--rm", "--init", "--network", "host",
+		"--label", sandboxLabelKey + "=true",
+		"--label", fmt.Sprintf("%s=%d", sandboxLabelPID, os.Getpid()),
+	}
+	args = append(args, s.buildVolumeMounts()...)
+	args = append(args, s.buildEnvVars()...)
+	args = append(args, "-w", s.workingDir, image, "tail", "-f", "/dev/null")
+
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to start sandbox container: %w\nstderr: %s", err, stderr.String())
+	}
+
+	s.containerID = strings.TrimSpace(string(output))
+	return s.containerID, nil
+}
+
+func (s *sandboxRunner) generateContainerName() string {
+	randomBytes := make([]byte, 4)
+	_, _ = rand.Read(randomBytes)
+	return fmt.Sprintf("cagent-sandbox-%s", hex.EncodeToString(randomBytes))
+}
+
+func (s *sandboxRunner) buildVolumeMounts() []string {
+	var args []string
+	for _, pathSpec := range s.config.Paths {
+		hostPath, mode := parseSandboxPath(pathSpec)
+
+		// Resolve to absolute path
+		if !filepath.IsAbs(hostPath) {
+			if s.workingDir != "" {
+				hostPath = filepath.Join(s.workingDir, hostPath)
+			} else {
+				// If workingDir is empty, resolve relative to current directory
+				var err error
+				hostPath, err = filepath.Abs(hostPath)
+				if err != nil {
+					// Skip invalid paths
+					continue
+				}
+			}
+		}
+		hostPath = filepath.Clean(hostPath)
+
+		// Container path mirrors host path for simplicity
+		mountSpec := fmt.Sprintf("%s:%s:%s", hostPath, hostPath, mode)
+		args = append(args, "-v", mountSpec)
+	}
+	return args
+}
+
+// buildEnvVars creates Docker -e flags for environment variables.
+// This forwards the host environment to the sandbox container.
+// Only variables with valid POSIX names are forwarded.
+func (s *sandboxRunner) buildEnvVars() []string {
+	var args []string
+	for _, envVar := range s.env {
+		// Each env var is in KEY=VALUE format
+		// Only forward variables with valid names to avoid Docker issues
+		if idx := strings.Index(envVar, "="); idx > 0 {
+			key := envVar[:idx]
+			if isValidEnvVarName(key) {
+				args = append(args, "-e", envVar)
+			}
+		}
+	}
+	return args
+}
+
+// isValidEnvVarName checks if an environment variable name is valid for POSIX.
+// Valid names start with a letter or underscore and contain only alphanumerics and underscores.
+func isValidEnvVarName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, c := range name {
+		isValid := (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_' || (i > 0 && c >= '0' && c <= '9')
+		if !isValid {
+			return false
+		}
+	}
+	return true
+}
+
+// parseSandboxPath parses a path specification like "./path" or "/path:ro" into path and mode.
+func parseSandboxPath(pathSpec string) (path, mode string) {
+	mode = "rw" // Default to read-write
+
+	switch {
+	case strings.HasSuffix(pathSpec, ":ro"):
+		path = strings.TrimSuffix(pathSpec, ":ro")
+		mode = "ro"
+	case strings.HasSuffix(pathSpec, ":rw"):
+		path = strings.TrimSuffix(pathSpec, ":rw")
+		mode = "rw"
+	default:
+		path = pathSpec
+	}
+
+	return path, mode
+}

--- a/pkg/tools/builtin/shell_instructions.go
+++ b/pkg/tools/builtin/shell_instructions.go
@@ -1,0 +1,168 @@
+package builtin
+
+// nativeInstructions contains the usage guide for native shell mode.
+const nativeInstructions = `# Shell Tool Usage Guide
+
+Execute shell commands in the user's environment with full control over working directories and command parameters.
+
+## Core Concepts
+
+**Execution Context**: Commands run in the user's default shell with access to all environment variables and the current workspace.
+On Windows, PowerShell (pwsh/powershell) is used when available; otherwise, cmd.exe is used.
+On Unix-like systems, ${SHELL} is used or /bin/sh as fallback.
+
+**Working Directory Management**:
+- Default execution location: working directory of the agent
+- Override with "cwd" parameter for targeted command execution
+- Supports both absolute and relative paths
+
+**Command Isolation**: Each tool call creates a fresh shell session - no state persists between executions.
+
+**Timeout Protection**: Commands have a default 30-second timeout to prevent hanging. For longer operations, specify a custom timeout.
+
+## Parameter Reference
+
+| Parameter | Type   | Required | Description |
+|-----------|--------|----------|-------------|
+| cmd       | string | Yes      | Shell command to execute |
+| cwd       | string | Yes      | Working directory (use "." for current) |
+| timeout   | int    | No       | Timeout in seconds (default: 30) |
+
+## Best Practices
+
+### ✅ DO
+- Leverage the "cwd" parameter for directory-specific commands, rather than cding within commands
+- Quote arguments containing spaces or special characters
+- Use pipes and redirections
+- Write advanced scripts with heredocs, that replace a lot of simple commands or tool calls
+- This tool is great at reading and writing multiple files at once
+- Avoid writing shell scripts to the disk. Instead, use heredocs to pipe the script to the SHELL
+- Use the timeout parameter for long-running operations (e.g., builds, tests)
+
+### Git Commits
+
+When user asks to create git commit
+
+- Add "Assisted-By: cagent" as a trailer line in the commit message
+- Use the format: git commit -m "Your commit message" -m "" -m "Assisted-By: cagent"
+
+## Usage Examples
+
+**Basic command execution:**
+{ "cmd": "ls -la", "cwd": "." }
+
+**Long-running command with custom timeout:**
+{ "cmd": "npm run build", "cwd": ".", "timeout": 120 }
+
+**Language-specific operations:**
+{ "cmd": "go test ./...", "cwd": ".", "timeout": 180 }
+{ "cmd": "npm install", "cwd": "frontend" }
+{ "cmd": "python -m pytest tests/", "cwd": "backend", "timeout": 90 }
+
+**File operations:**
+{ "cmd": "find . -name '*.go' -type f", "cwd": "." }
+{ "cmd": "grep -r 'TODO' src/", "cwd": "." }
+
+**Process management:**
+{ "cmd": "ps aux | grep node", "cwd": "." }
+{ "cmd": "docker ps --format 'table {{.Names}}\t{{.Status}}'", "cwd": "." }
+
+**Complex pipelines:**
+{ "cmd": "cat package.json | jq '.dependencies'", "cwd": "frontend" }
+
+**Bash scripts:**
+{ "cmd": "cat << 'EOF' | ${SHELL}
+echo Hello
+EOF" }
+
+## Error Handling
+
+Commands that exit with non-zero status codes will return error information along with any output produced before failure.
+Commands that exceed their timeout will be terminated automatically.
+
+---
+
+# Background Jobs
+
+Run long-running processes in the background while continuing with other tasks. Perfect for starting servers, watching files, or any process that needs to run alongside other operations.
+
+## When to Use Background Jobs
+
+**Use background jobs for:**
+- Starting web servers, databases, or other services
+- Running file watchers or live reload tools
+- Long-running processes that other tasks depend on
+- Commands that produce continuous output over time
+
+**Don't use background jobs for:**
+- Quick commands that complete in seconds
+- Commands where you need immediate results
+- One-time operations (use regular shell tool instead)
+
+## Background Job Tools
+
+**run_background_job**: Start a command in the background
+- Parameters: cmd (required), cwd (optional, defaults to ".")
+- Returns: Job ID for tracking
+
+**list_background_jobs**: List all background jobs
+- No parameters required
+- Returns: Status, runtime, and command for each job
+
+**view_background_job**: View output of a specific job
+- Parameters: job_id (required)
+- Returns: Current output and job status
+
+**stop_background_job**: Stop a running job
+- Parameters: job_id (required)
+- Terminates the process and all child processes
+
+## Background Job Workflow
+
+**1. Start a background job:**
+{ "cmd": "npm start", "cwd": "frontend" }
+→ Returns job ID (e.g., "job_1731772800_1")
+
+**2. Check running jobs:**
+Use list_background_jobs to see all jobs with their status
+
+**3. View job output:**
+{ "job_id": "job_1731772800_1" }
+→ Shows current output and status
+
+**4. Stop job when done:**
+{ "job_id": "job_1731772800_1" }
+→ Terminates the process and all child processes
+
+## Important Characteristics
+
+**Output Buffering**: Each job captures up to 10MB of output. Beyond this limit, new output is discarded to prevent memory issues.
+
+**Process Groups**: Background jobs and all their child processes are managed as a group. Stopping a job terminates the entire process tree.
+
+**Environment Inheritance**: Jobs inherit environment variables from when they are started. Changes after job start don't affect running jobs.
+
+**Automatic Cleanup**: All background jobs are automatically terminated when the agent stops.
+
+**Job Persistence**: Job history is kept in memory until agent stops. Completed jobs remain queryable.
+
+## Background Job Examples
+
+**Start a web server:**
+{ "cmd": "python -m http.server 8000", "cwd": "." }
+
+**Start a development server:**
+{ "cmd": "npm run dev", "cwd": "frontend" }
+
+**Run a file watcher:**
+{ "cmd": "go run . watch", "cwd": "." }
+
+**Start a database:**
+{ "cmd": "docker run --rm -p 5432:5432 postgres:latest", "cwd": "." }
+
+**Multiple services pattern:**
+1. Start backend: run_background_job with server command
+2. Start frontend: run_background_job with dev server
+3. Perform tasks: use other tools while services run
+4. Check logs: view_background_job to see service output
+5. Cleanup: stop_background_job for each service (or let agent cleanup automatically)`

--- a/pkg/tools/builtin/shell_test.go
+++ b/pkg/tools/builtin/shell_test.go
@@ -1,25 +1,27 @@
 package builtin
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/cagent/pkg/config"
+	"github.com/docker/cagent/pkg/config/latest"
 	"github.com/docker/cagent/pkg/tools"
 )
 
 func TestNewShellTool(t *testing.T) {
 	t.Setenv("SHELL", "/bin/bash")
-	tool := NewShellTool(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
+	tool := NewShellTool(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}}, nil)
 
 	assert.NotNil(t, tool)
 	assert.NotNil(t, tool.handler)
 	assert.Equal(t, "/bin/bash", tool.handler.shell)
 
 	t.Setenv("SHELL", "")
-	tool = NewShellTool(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
+	tool = NewShellTool(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}}, nil)
 
 	assert.NotNil(t, tool)
 	assert.NotNil(t, tool.handler)
@@ -27,7 +29,7 @@ func TestNewShellTool(t *testing.T) {
 }
 
 func TestShellTool_HandlerEcho(t *testing.T) {
-	tool := NewShellTool(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
+	tool := NewShellTool(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}}, nil)
 
 	result, err := tool.handler.RunShell(t.Context(), RunShellArgs{
 		Cmd: "echo 'hello world'",
@@ -38,7 +40,7 @@ func TestShellTool_HandlerEcho(t *testing.T) {
 }
 
 func TestShellTool_HandlerWithCwd(t *testing.T) {
-	tool := NewShellTool(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
+	tool := NewShellTool(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}}, nil)
 	tmpDir := t.TempDir()
 
 	result, err := tool.handler.RunShell(t.Context(), RunShellArgs{
@@ -52,7 +54,7 @@ func TestShellTool_HandlerWithCwd(t *testing.T) {
 }
 
 func TestShellTool_HandlerError(t *testing.T) {
-	tool := NewShellTool(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
+	tool := NewShellTool(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}}, nil)
 
 	result, err := tool.handler.RunShell(t.Context(), RunShellArgs{
 		Cmd: "command_that_does_not_exist",
@@ -63,7 +65,7 @@ func TestShellTool_HandlerError(t *testing.T) {
 }
 
 func TestShellTool_OutputSchema(t *testing.T) {
-	tool := NewShellTool(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
+	tool := NewShellTool(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}}, nil)
 
 	allTools, err := tool.Tools(t.Context())
 	require.NoError(t, err)
@@ -75,7 +77,7 @@ func TestShellTool_OutputSchema(t *testing.T) {
 }
 
 func TestShellTool_ParametersAreObjects(t *testing.T) {
-	tool := NewShellTool(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
+	tool := NewShellTool(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}}, nil)
 
 	allTools, err := tool.Tools(t.Context())
 	require.NoError(t, err)
@@ -90,7 +92,7 @@ func TestShellTool_ParametersAreObjects(t *testing.T) {
 
 // Minimal tests for background job features
 func TestShellTool_RunBackgroundJob(t *testing.T) {
-	tool := NewShellTool(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
+	tool := NewShellTool(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}}, nil)
 	err := tool.Start(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -103,7 +105,7 @@ func TestShellTool_RunBackgroundJob(t *testing.T) {
 }
 
 func TestShellTool_ListBackgroundJobs(t *testing.T) {
-	tool := NewShellTool(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
+	tool := NewShellTool(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}}, nil)
 	err := tool.Start(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -120,4 +122,114 @@ func TestShellTool_ListBackgroundJobs(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, listResult.Output, "Background Jobs:")
 	assert.Contains(t, listResult.Output, "ID: job_")
+}
+
+func TestParseSandboxPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input    string
+		wantPath string
+		wantMode string
+	}{
+		{input: ".", wantPath: ".", wantMode: "rw"},
+		{input: "/tmp", wantPath: "/tmp", wantMode: "rw"},
+		{input: "./src", wantPath: "./src", wantMode: "rw"},
+		{input: "/tmp:ro", wantPath: "/tmp", wantMode: "ro"},
+		{input: "./config:ro", wantPath: "./config", wantMode: "ro"},
+		{input: "/data:rw", wantPath: "/data", wantMode: "rw"},
+		{input: "./secrets:ro", wantPath: "./secrets", wantMode: "ro"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			path, mode := parseSandboxPath(tt.input)
+			assert.Equal(t, tt.wantPath, path)
+			assert.Equal(t, tt.wantMode, mode)
+		})
+	}
+}
+
+func TestShellTool_SandboxInstructions(t *testing.T) {
+	t.Parallel()
+
+	workingDir := "/workspace/project"
+	sandboxConfig := &latest.SandboxConfig{
+		Image: "alpine:latest",
+		Paths: []string{
+			".",
+			"/tmp",
+			"/home/user:ro",
+		},
+	}
+
+	tool := NewShellTool(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: workingDir}}, sandboxConfig)
+
+	instructions := tool.Instructions()
+
+	// Check that the sandbox note is included
+	assert.Contains(t, instructions, "For sandboxing reasons, all shell commands run inside a Linux container")
+
+	// Check that the native instructions are included
+	assert.Contains(t, instructions, "Shell Tool Usage Guide")
+
+	// Verify that mounted paths section is NOT included
+	assert.NotContains(t, instructions, "## Mounted Paths")
+	assert.NotContains(t, instructions, "The following paths are accessible in the sandbox:")
+}
+
+func TestShellTool_NativeInstructions(t *testing.T) {
+	t.Parallel()
+
+	tool := NewShellTool(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}}, nil)
+
+	instructions := tool.Instructions()
+
+	// Check that native instructions are returned (not sandbox)
+	assert.Contains(t, instructions, "Shell Tool Usage Guide")
+	assert.NotContains(t, instructions, "Sandbox Mode")
+	assert.NotContains(t, instructions, "## Mounted Paths")
+}
+
+func TestIsValidEnvVarName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		valid bool
+	}{
+		{"HOME", true},
+		{"USER", true},
+		{"PATH", true},
+		{"_private", true},
+		{"MY_VAR_123", true},
+		{"a", true},
+		{"A", true},
+		{"_", true},
+		{"", false},
+		{"123", false},
+		{"1VAR", false},
+		{"VAR-NAME", false},
+		{"VAR.NAME", false},
+		{"VAR NAME", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := isValidEnvVarName(tt.name)
+			assert.Equal(t, tt.valid, result, "isValidEnvVarName(%q)", tt.name)
+		})
+	}
+}
+
+func TestIsProcessRunning(t *testing.T) {
+	t.Parallel()
+
+	// Current process should be running
+	assert.True(t, isProcessRunning(os.Getpid()), "Current process should be running")
+
+	// Non-existent PID should not be running (using a very high PID unlikely to exist)
+	assert.False(t, isProcessRunning(999999999), "Very high PID should not be running")
 }


### PR DESCRIPTION
Allow the shell toolset to run in a docker container with a user-defined list of bind mounts and permissions

This is the beginning of a sandboxing story