### PR TITLE
[experimental] Add tool-server command for remote tool invocation

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -97,6 +97,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newCatalogCmd())
 	cmd.AddCommand(newBuildCmd())
 	cmd.AddCommand(newAliasCmd())
+	cmd.AddCommand(newToolServerCmd())
 
 	// Define groups
 	cmd.AddGroup(&cobra.Group{ID: "core", Title: "Core Commands:"})

--- a/cmd/root/toolserver.go
+++ b/cmd/root/toolserver.go
@@ -1,0 +1,83 @@
+package root
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/docker/cagent/pkg/cli"
+	"github.com/docker/cagent/pkg/config"
+	"github.com/docker/cagent/pkg/server"
+	"github.com/docker/cagent/pkg/telemetry"
+	"github.com/docker/cagent/pkg/toolserver"
+)
+
+type toolserverFlags struct {
+	listenAddr string
+	runConfig  config.RuntimeConfig
+}
+
+func newToolServerCmd() *cobra.Command {
+	var flags toolserverFlags
+
+	cmd := &cobra.Command{
+		Use:   "tool-server <agent-file>|<registry-ref>",
+		Short: "Start a lightweight server exposing agent tools for remote invocation",
+		Long:  `Start a minimal HTTP server that exposes the tools defined in an agent configuration for remote invocation.`,
+		Example: `  # Start tool server on default port
+  cagent tool-server ./agent.yaml
+
+  # Start on a specific port
+  cagent tool-server ./agent.yaml --listen :9000
+
+  # Listen on a Unix socket
+  cagent tool-server ./agent.yaml --listen unix:///var/run/cagent.sock
+
+  # Call a tool using curl
+  curl -X POST http://localhost:8080/agents/root/tools/read_file \
+    -H "Content-Type: application/json" \
+    -d '{"arguments": "{\"path\": \"./README.md\"}"}'`,
+		GroupID: "server",
+		Args:    cobra.ExactArgs(1),
+		RunE:    flags.runToolServerCommand,
+		Hidden:  true,
+	}
+
+	cmd.PersistentFlags().StringVarP(&flags.listenAddr, "listen", "l", ":8080", "Address to listen on (host:port or unix:///path/to/socket)")
+	addRuntimeConfigFlags(cmd, &flags.runConfig)
+
+	return cmd
+}
+
+func (f *toolserverFlags) runToolServerCommand(cmd *cobra.Command, args []string) error {
+	telemetry.TrackCommand("tool-server", args)
+
+	ctx := cmd.Context()
+	out := cli.NewPrinter(cmd.OutOrStdout())
+	agentSource := args[0]
+
+	source, err := config.Resolve(agentSource)
+	if err != nil {
+		return fmt.Errorf("resolving agent source: %w", err)
+	}
+
+	ln, err := server.Listen(ctx, f.listenAddr)
+	if err != nil {
+		return fmt.Errorf("failed to listen on %s: %w", f.listenAddr, err)
+	}
+	go func() {
+		<-ctx.Done()
+		_ = ln.Close()
+	}()
+
+	out.Println("Starting tool server...")
+
+	s, err := toolserver.New(ctx, source, &f.runConfig)
+	if err != nil {
+		return fmt.Errorf("creating tool server: %w", err)
+	}
+
+	out.Println("Listening on " + ln.Addr().String())
+
+	return s.Serve(ctx, ln)
+}

--- a/pkg/toolserver/server.go
+++ b/pkg/toolserver/server.go
@@ -1,0 +1,167 @@
+// Package toolserver provides a lightweight HTTP server that exposes agent tools remotely.
+// This is useful for running cagent tools inside containers while allowing external
+// callers to invoke them.
+package toolserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+
+	"github.com/docker/cagent/pkg/agent"
+	"github.com/docker/cagent/pkg/config"
+	"github.com/docker/cagent/pkg/teamloader"
+	"github.com/docker/cagent/pkg/tools"
+)
+
+// Server is a lightweight HTTP server that exposes agent tools for remote invocation.
+type Server struct {
+	agents map[string]*agent.Agent
+}
+
+// CallToolRequest is the request body for calling a tool.
+type CallToolRequest struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"` // JSON-encoded arguments
+}
+
+// CallToolResponse is the response from calling a tool.
+type CallToolResponse struct {
+	Output  string `json:"output"`
+	IsError bool   `json:"isError,omitempty"`
+}
+
+// ErrorResponse represents an error response from the server.
+type ErrorResponse struct {
+	Error string `json:"error"`
+}
+
+// New creates a new tool server from the given agent configuration source.
+func New(ctx context.Context, agentSource config.Source, runConfig *config.RuntimeConfig) (*Server, error) {
+	// Load the team using teamloader
+	team, err := teamloader.Load(ctx, agentSource, runConfig)
+	if err != nil {
+		return nil, fmt.Errorf("loading agent configuration: %w", err)
+	}
+
+	// Build a map of all agents
+	agents := make(map[string]*agent.Agent)
+	for _, name := range team.AgentNames() {
+		a, _ := team.Agent(name)
+		agents[name] = a
+	}
+
+	return &Server{
+		agents: agents,
+	}, nil
+}
+
+// Serve starts the HTTP server on the given listener.
+func (s *Server) Serve(ctx context.Context, ln net.Listener) error {
+	mux := http.NewServeMux()
+
+	// Health check endpoint
+	mux.HandleFunc("GET /health", s.handleHealth)
+
+	// Call a tool for a specific agent
+	mux.HandleFunc("POST /agents/{agent}/tools/{tool}", s.handleCallAgentTool)
+
+	server := &http.Server{
+		Handler: mux,
+	}
+
+	go func() {
+		<-ctx.Done()
+		_ = server.Shutdown(context.Background())
+	}()
+
+	slog.Info("Tool server listening", "addr", ln.Addr().String())
+	return server.Serve(ln)
+}
+
+func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+func (s *Server) handleCallAgentTool(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	agentName := r.PathValue("agent")
+	toolName := r.PathValue("tool")
+
+	a, ok := s.agents[agentName]
+	if !ok {
+		s.writeError(w, http.StatusNotFound, fmt.Sprintf("agent %q not found", agentName))
+		return
+	}
+
+	var req CallToolRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid request body: %v", err))
+		return
+	}
+
+	result, found, err := s.callToolOnAgent(ctx, a, toolName, req.Arguments)
+	if err != nil {
+		s.writeError(w, http.StatusInternalServerError, fmt.Sprintf("tool execution failed: %v", err))
+		return
+	}
+	if !found {
+		s.writeError(w, http.StatusNotFound, fmt.Sprintf("tool %q not found on agent %q", toolName, agentName))
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(CallToolResponse{
+		Output:  result.Output,
+		IsError: result.IsError,
+	})
+}
+
+func (s *Server) callToolOnAgent(ctx context.Context, a *agent.Agent, toolName, arguments string) (*tools.ToolCallResult, bool, error) {
+	agentTools, err := a.Tools(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+
+	tool := findTool(agentTools, toolName)
+	if tool == nil {
+		return nil, false, nil
+	}
+
+	if tool.Handler == nil {
+		return nil, true, fmt.Errorf("tool %q has no handler", toolName)
+	}
+
+	result, err := tool.Handler(ctx, tools.ToolCall{
+		ID:   "toolserver-call",
+		Type: "function",
+		Function: tools.FunctionCall{
+			Name:      toolName,
+			Arguments: arguments,
+		},
+	})
+	if err != nil {
+		return nil, true, err
+	}
+
+	return result, true, nil
+}
+
+func findTool(agentTools []tools.Tool, name string) *tools.Tool {
+	for i := range agentTools {
+		if agentTools[i].Name == name {
+			return &agentTools[i]
+		}
+	}
+	return nil
+}
+
+func (s *Server) writeError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(ErrorResponse{Error: msg})
+}

--- a/pkg/toolserver/server_test.go
+++ b/pkg/toolserver/server_test.go
@@ -1,0 +1,208 @@
+package toolserver
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/cagent/pkg/agent"
+	"github.com/docker/cagent/pkg/tools"
+)
+
+// mockToolSet is a simple toolset for testing.
+type mockToolSet struct {
+	tools.BaseToolSet
+	toolList []tools.Tool
+}
+
+func (m *mockToolSet) Tools(context.Context) ([]tools.Tool, error) {
+	return m.toolList, nil
+}
+
+func TestServer_HandleHealth(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{
+		agents: make(map[string]*agent.Agent),
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/health", http.NoBody)
+	w := httptest.NewRecorder()
+
+	s.handleHealth(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "ok")
+}
+
+func TestServer_HandleCallAgentTool(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	mockTools := []tools.Tool{
+		{
+			Name:        "greet",
+			Description: "Greet tool",
+			Handler: func(_ context.Context, tc tools.ToolCall) (*tools.ToolCallResult, error) {
+				var args struct {
+					Name string `json:"name"`
+				}
+				_ = json.Unmarshal([]byte(tc.Function.Arguments), &args)
+				return tools.ResultSuccess("Hello, " + args.Name), nil
+			},
+		},
+	}
+
+	testAgent := agent.New("greeter", "Greeter agent",
+		agent.WithToolSets(&mockToolSet{toolList: mockTools}),
+	)
+
+	s := &Server{
+		agents: map[string]*agent.Agent{
+			"greeter": testAgent,
+		},
+	}
+
+	body := `{"arguments": "{\"name\": \"World\"}"}`
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/agents/greeter/tools/greet", strings.NewReader(body))
+	req.SetPathValue("agent", "greeter")
+	req.SetPathValue("tool", "greet")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	s.handleCallAgentTool(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp CallToolResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, "Hello, World", resp.Output)
+}
+
+func TestServer_HandleCallAgentTool_AgentNotFound(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	s := &Server{
+		agents: make(map[string]*agent.Agent),
+	}
+
+	body := `{"arguments": "{}"}`
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/agents/nonexistent/tools/greet", strings.NewReader(body))
+	req.SetPathValue("agent", "nonexistent")
+	req.SetPathValue("tool", "greet")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	s.handleCallAgentTool(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	var resp ErrorResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Contains(t, resp.Error, "not found")
+}
+
+func TestServer_HandleCallAgentTool_ToolNotFound(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	testAgent := agent.New("test", "Test agent",
+		agent.WithToolSets(&mockToolSet{toolList: []tools.Tool{}}),
+	)
+
+	s := &Server{
+		agents: map[string]*agent.Agent{
+			"test": testAgent,
+		},
+	}
+
+	body := `{"arguments": "{}"}`
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/agents/test/tools/nonexistent", strings.NewReader(body))
+	req.SetPathValue("agent", "test")
+	req.SetPathValue("tool", "nonexistent")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	s.handleCallAgentTool(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	var resp ErrorResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Contains(t, resp.Error, "not found")
+}
+
+func TestServer_HandleCallAgentTool_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	testAgent := agent.New("test", "Test agent")
+
+	s := &Server{
+		agents: map[string]*agent.Agent{
+			"test": testAgent,
+		},
+	}
+
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/agents/test/tools/foo", strings.NewReader("not json"))
+	req.SetPathValue("agent", "test")
+	req.SetPathValue("tool", "foo")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	s.handleCallAgentTool(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestServer_HandleCallAgentTool_ToolError(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	mockTools := []tools.Tool{
+		{
+			Name:        "failing",
+			Description: "A failing tool",
+			Handler: func(_ context.Context, _ tools.ToolCall) (*tools.ToolCallResult, error) {
+				return tools.ResultError("something went wrong"), nil
+			},
+		},
+	}
+
+	testAgent := agent.New("test", "Test agent",
+		agent.WithToolSets(&mockToolSet{toolList: mockTools}),
+	)
+
+	s := &Server{
+		agents: map[string]*agent.Agent{
+			"test": testAgent,
+		},
+	}
+
+	body := `{"arguments": "{}"}`
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/agents/test/tools/failing", strings.NewReader(body))
+	req.SetPathValue("agent", "test")
+	req.SetPathValue("tool", "failing")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	s.handleCallAgentTool(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp CallToolResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, "something went wrong", resp.Output)
+	assert.True(t, resp.IsError)
+}


### PR DESCRIPTION
Adds a lightweight HTTP server that exposes agent tools for remote invocation, useful for running cagent tools inside containers.

Endpoints:
- GET /health - Health check
- POST /agents/{agent}/tools/{tool} - Call a tool on a specific agent

Assisted-By: cagent