### PR TITLE
feat: enhance commands with description, positional args, and shell e…

### DIFF
--- a/cagent-schema.json
+++ b/cagent-schema.json
@@ -131,12 +131,20 @@
           }
         },
         "commands": {
-          "description": "Named prompts for /commands",
+          "description": "Named prompts for /commands. Supports simple string format or advanced object format with description and instruction.",
           "oneOf": [
             {
               "type": "object",
               "additionalProperties": {
-                "type": "string"
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "description": "Simple command format: the string becomes the instruction"
+                  },
+                  {
+                    "$ref": "#/definitions/CommandConfig"
+                  }
+                ]
               }
             },
             {
@@ -144,7 +152,15 @@
               "items": {
                 "type": "object",
                 "additionalProperties": {
-                  "type": "string"
+                  "oneOf": [
+                    {
+                      "type": "string",
+                      "description": "Simple command format: the string becomes the instruction"
+                    },
+                    {
+                      "$ref": "#/definitions/CommandConfig"
+                    }
+                  ]
                 }
               }
             }
@@ -219,6 +235,21 @@
         "hooks": {
           "$ref": "#/definitions/HooksConfig",
           "description": "Lifecycle hooks for executing shell commands at various points in the agent's execution"
+        }
+      },
+      "additionalProperties": false
+    },
+    "CommandConfig": {
+      "type": "object",
+      "description": "Advanced command configuration with description and instruction",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Description shown in completion dialogs and help text"
+        },
+        "instruction": {
+          "type": "string",
+          "description": "The prompt sent to the agent. Supports bang commands (!`command`) and positional arguments ($1, $2, etc.)"
         }
       },
       "additionalProperties": false

--- a/cmd/root/completion.go
+++ b/cmd/root/completion.go
@@ -66,7 +66,7 @@ func completeMessage(cmd *cobra.Command, args []string, toComplete string) ([]st
 	var candidates []string
 	for k, v := range cfg.Agents[agent].Commands {
 		if strings.HasPrefix("/"+k, toComplete) {
-			candidates = append(candidates, "/"+k+"\t"+v)
+			candidates = append(candidates, "/"+k+"\t"+v.DisplayText())
 		}
 	}
 

--- a/examples/gopher.yaml
+++ b/examples/gopher.yaml
@@ -63,7 +63,20 @@ agents:
         command: gopls
         args: ["mcp"]
     commands:
-      fix-lint: "Fix the lint issues"
+      fix-lint:
+        description: "Fix the lint issues"
+        instruction: |
+          Fix the lint issues (if any).
+
+          Here the result of the linting command:
+          $ task lint
+          !shell(cmd="task lint")
+
+          $go_diagnostics
+          !go_diagnostics()
+
+          $go_vulncheck
+          !go_vulncheck()
       remove-comments-tests: "Remove useless comments in test files (*_test.go)"
       commit: "Git commit the changes with a meaningful message"
       simplify: "Look at the local changes and try to simplify the code and architecture but don't remove any feature. I just want the code to be easier to read and maintain."

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 
 	"github.com/docker/cagent/pkg/config/latest"
+	"github.com/docker/cagent/pkg/config/types"
 	"github.com/docker/cagent/pkg/model/provider"
 	"github.com/docker/cagent/pkg/tools"
 )
@@ -28,7 +29,7 @@ type Agent struct {
 	numHistoryItems    int
 	addPromptFiles     []string
 	tools              []tools.Tool
-	commands           map[string]string
+	commands           types.Commands
 	pendingWarnings    []string
 	skillsEnabled      bool
 	hooks              *latest.HooksConfig
@@ -113,7 +114,7 @@ func (a *Agent) Model() provider.Provider {
 }
 
 // Commands returns the named commands configured for this agent.
-func (a *Agent) Commands() map[string]string {
+func (a *Agent) Commands() types.Commands {
 	return a.commands
 }
 

--- a/pkg/agent/opts.go
+++ b/pkg/agent/opts.go
@@ -4,6 +4,7 @@ import (
 	"sync/atomic"
 
 	"github.com/docker/cagent/pkg/config/latest"
+	"github.com/docker/cagent/pkg/config/types"
 	"github.com/docker/cagent/pkg/model/provider"
 	"github.com/docker/cagent/pkg/tools"
 )
@@ -104,7 +105,7 @@ func WithNumHistoryItems(numHistoryItems int) Opt {
 	}
 }
 
-func WithCommands(commands map[string]string) Opt {
+func WithCommands(commands types.Commands) Opt {
 	return func(a *Agent) {
 		a.commands = commands
 	}

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -10,6 +10,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/docker/cagent/pkg/chat"
+	"github.com/docker/cagent/pkg/config/types"
 	"github.com/docker/cagent/pkg/runtime"
 	"github.com/docker/cagent/pkg/session"
 	"github.com/docker/cagent/pkg/tools"
@@ -96,7 +97,7 @@ func (a *App) Runtime() runtime.Runtime {
 }
 
 // CurrentAgentCommands returns the commands for the active agent
-func (a *App) CurrentAgentCommands(ctx context.Context) map[string]string {
+func (a *App) CurrentAgentCommands(ctx context.Context) types.Commands {
 	return a.runtime.CurrentAgentCommands(ctx)
 }
 

--- a/pkg/config/commands_test.go
+++ b/pkg/config/commands_test.go
@@ -12,15 +12,40 @@ func TestV2Commands_AllForms(t *testing.T) {
 	cfg, err := Load(t.Context(), testfileSource("testdata/commands_v2.yaml"))
 	require.NoError(t, err)
 
+	// Test simple map format
 	cmdsMap := cfg.Agents["root"].Commands
-	require.Equal(t, "check disk", cmdsMap["df"])
-	require.Equal(t, "list files", cmdsMap["ls"])
+	require.Equal(t, "check disk", cmdsMap["df"].Instruction)
+	require.Equal(t, "list files", cmdsMap["ls"].Instruction)
+	require.Empty(t, cmdsMap["df"].Description) // Simple format has no description
 
+	// Test list format
 	cmdsList := cfg.Agents["another_agent"].Commands
-	require.Equal(t, "check disk", cmdsList["df"])
-	require.Equal(t, "list files", cmdsList["ls"])
+	require.Equal(t, "check disk", cmdsList["df"].Instruction)
+	require.Equal(t, "list files", cmdsList["ls"].Instruction)
 
+	// Test advanced format with description and instruction
+	cmdsAdvanced := cfg.Agents["advanced_agent"].Commands
+	require.Equal(t, "Fix linting errors in the codebase", cmdsAdvanced["fix-lint"].Description)
+	require.Equal(t, "Fix the lint issues", cmdsAdvanced["fix-lint"].Instruction)
+	require.Equal(t, "Analyze the code", cmdsAdvanced["analyze"].Description)
+	require.Contains(t, cmdsAdvanced["analyze"].Instruction, "$1")
+	require.Contains(t, cmdsAdvanced["analyze"].Instruction, "$2")
+
+	// Test empty commands
 	require.Empty(t, cfg.Agents["none_agent"].Commands)
+}
+
+func TestV2Commands_DisplayText(t *testing.T) {
+	cfg, err := Load(t.Context(), testfileSource("testdata/commands_v2.yaml"))
+	require.NoError(t, err)
+
+	// Simple format: DisplayText returns the instruction
+	simpleCmd := cfg.Agents["root"].Commands["df"]
+	require.Equal(t, "check disk", simpleCmd.DisplayText())
+
+	// Advanced format: DisplayText returns description if available
+	advancedCmd := cfg.Agents["advanced_agent"].Commands["fix-lint"]
+	require.Equal(t, "Fix linting errors in the codebase", advancedCmd.DisplayText())
 }
 
 func TestMigrate_v1_Commands_AllForms(t *testing.T) {
@@ -28,12 +53,12 @@ func TestMigrate_v1_Commands_AllForms(t *testing.T) {
 	require.NoError(t, err)
 
 	cmdsMap := cfg.Agents["root"].Commands
-	require.Equal(t, "check disk", cmdsMap["df"])
-	require.Equal(t, "list files", cmdsMap["ls"])
+	require.Equal(t, "check disk", cmdsMap["df"].Instruction)
+	require.Equal(t, "list files", cmdsMap["ls"].Instruction)
 
 	cmdsList := cfg.Agents["another_agent"].Commands
-	require.Equal(t, "check disk", cmdsList["df"])
-	require.Equal(t, "list files", cmdsList["ls"])
+	require.Equal(t, "check disk", cmdsList["df"].Instruction)
+	require.Equal(t, "list files", cmdsList["ls"].Instruction)
 
 	require.Empty(t, cfg.Agents["yet_another_agent"].Commands)
 }
@@ -43,12 +68,12 @@ func TestMigrate_v0_Commands_AllForms(t *testing.T) {
 	require.NoError(t, err)
 
 	cmdsMap := cfg.Agents["root"].Commands
-	require.Equal(t, "check disk", cmdsMap["df"])
-	require.Equal(t, "list files", cmdsMap["ls"])
+	require.Equal(t, "check disk", cmdsMap["df"].Instruction)
+	require.Equal(t, "list files", cmdsMap["ls"].Instruction)
 
 	cmdsList := cfg.Agents["another_agent"].Commands
-	require.Equal(t, "check disk", cmdsList["df"])
-	require.Equal(t, "list files", cmdsList["ls"])
+	require.Equal(t, "check disk", cmdsList["df"].Instruction)
+	require.Equal(t, "list files", cmdsList["ls"].Instruction)
 
 	require.Empty(t, cfg.Agents["yet_another_agent"].Commands)
 }

--- a/pkg/config/latest/types_test.go
+++ b/pkg/config/latest/types_test.go
@@ -17,8 +17,8 @@ ls: "list files"
 `)
 	err := yaml.Unmarshal(input, &c)
 	require.NoError(t, err)
-	require.Equal(t, "check disk", c["df"])
-	require.Equal(t, "list files", c["ls"])
+	require.Equal(t, "check disk", c["df"].Instruction)
+	require.Equal(t, "list files", c["ls"].Instruction)
 }
 
 func TestCommandsUnmarshal_List(t *testing.T) {
@@ -29,8 +29,8 @@ func TestCommandsUnmarshal_List(t *testing.T) {
 `)
 	err := yaml.Unmarshal(input, &c)
 	require.NoError(t, err)
-	require.Equal(t, "check disk", c["df"])
-	require.Equal(t, "list files", c["ls"])
+	require.Equal(t, "check disk", c["df"].Instruction)
+	require.Equal(t, "list files", c["ls"].Instruction)
 }
 
 func TestThinkingBudget_MarshalUnmarshal_String(t *testing.T) {

--- a/pkg/config/testdata/commands_v2.yaml
+++ b/pkg/config/testdata/commands_v2.yaml
@@ -16,6 +16,19 @@ agents:
       - df: "check disk"
       - ls: "list files"
 
-  yet_another_agent:
+  advanced_agent:
+    model: openai/gpt-4o
+    instruction: you are a helpful computer assistant
+    commands:
+      fix-lint:
+        description: "Fix linting errors in the codebase"
+        instruction: "Fix the lint issues"
+      analyze:
+        description: "Analyze the code"
+        instruction: |
+          Analyze the following files: $1
+          Focus on: $2
+
+  none_agent:
     model: openai/gpt-4o
     instruction: you are a helpful computer assistant

--- a/pkg/config/types/commands.go
+++ b/pkg/config/types/commands.go
@@ -1,36 +1,104 @@
 package types
 
-// Commands represents a set of named prompts for quick-starting conversations.
+import (
+	"fmt"
+)
+
+// Command represents an agent command with optional metadata.
 // It supports two YAML formats:
 //
-// commands:
+// Simple format (string value):
 //
-//	df: "check disk space"
-//	ls: "list files"
+//	fix-lint: "Fix the lint issues"
 //
-// or
+// Advanced format (object value):
 //
-// commands:
-//   - df: "check disk space"
-//   - ls: "list files"
-type Commands map[string]string
+//	fix-lint:
+//	  description: "Fix linting errors in the codebase"
+//	  instruction: |
+//	    Fix the lint issues reported by: !`golangci-lint run`
+//	    Focus on files: $1
+type Command struct {
+	// Description is shown in completion dialogs and help text.
+	// For simple format commands, this is empty and the instruction is used for display.
+	Description string `json:"description,omitempty"`
 
-// UnmarshalYAML supports both map and list-of-singleton-maps syntaxes.
+	// Instruction is the prompt sent to the agent.
+	// Supports:
+	// - Bang commands: !`command` (executed and output inserted)
+	// - Positional arguments: $1, $2, etc.
+	Instruction string `json:"instruction,omitempty"`
+}
+
+// DisplayText returns the text to show in completion dialogs.
+// Returns Description if available, otherwise truncates the Instruction.
+func (c Command) DisplayText() string {
+	if c.Description != "" {
+		return c.Description
+	}
+	return c.Instruction
+}
+
+// Commands represents a set of named prompts for quick-starting conversations.
+// It supports multiple YAML formats:
+//
+// Map of simple strings:
+//
+//	commands:
+//	  df: "check disk space"
+//	  ls: "list files"
+//
+// List of singleton maps (simple strings):
+//
+//	commands:
+//	  - df: "check disk space"
+//	  - ls: "list files"
+//
+// Map of advanced objects:
+//
+//	commands:
+//	  fix-lint:
+//	    description: "Fix linting errors"
+//	    instruction: "Fix the lint issues"
+//
+// Mixed format (simple and advanced):
+//
+//	commands:
+//	  simple: "A simple command"
+//	  advanced:
+//	    description: "An advanced command"
+//	    instruction: "Do something complex"
+type Commands map[string]Command
+
+// UnmarshalYAML supports both map and list-of-singleton-maps syntaxes,
+// with values being either simple strings or Command objects.
 func (c *Commands) UnmarshalYAML(unmarshal func(any) error) error {
-	// Try direct map first
-	var m map[string]string
+	// Try direct map first (handles both simple and advanced formats)
+	var m map[string]any
 	if err := unmarshal(&m); err == nil && m != nil {
-		*c = m
+		result := make(map[string]Command)
+		for k, v := range m {
+			cmd, err := parseCommandValue(v)
+			if err != nil {
+				return fmt.Errorf("command %q: %w", k, err)
+			}
+			result[k] = cmd
+		}
+		*c = result
 		return nil
 	}
 
 	// Try list of maps [{k:v}, {k:v}]
-	var list []map[string]string
+	var list []map[string]any
 	if err := unmarshal(&list); err == nil && list != nil {
-		result := make(map[string]string)
+		result := make(map[string]Command)
 		for _, item := range list {
 			for k, v := range item {
-				result[k] = v
+				cmd, err := parseCommandValue(v)
+				if err != nil {
+					return fmt.Errorf("command %q: %w", k, err)
+				}
+				result[k] = cmd
 			}
 		}
 		*c = result
@@ -38,6 +106,30 @@ func (c *Commands) UnmarshalYAML(unmarshal func(any) error) error {
 	}
 
 	// If none matched, treat as empty
-	*c = map[string]string{}
+	*c = map[string]Command{}
 	return nil
+}
+
+// parseCommandValue parses a command value which can be either:
+// - a simple string (becomes the instruction)
+// - a map with description/instruction fields
+func parseCommandValue(v any) (Command, error) {
+	switch val := v.(type) {
+	case string:
+		return Command{Instruction: val}, nil
+	case map[string]any:
+		desc, _ := val["description"].(string)
+		inst, _ := val["instruction"].(string)
+
+		if inst == "" && desc == "" {
+			return Command{}, fmt.Errorf("command must have at least 'instruction' or 'description'")
+		}
+		if inst == "" {
+			inst = desc
+		}
+
+		return Command{Description: desc, Instruction: inst}, nil
+	default:
+		return Command{}, fmt.Errorf("invalid command value type: %T", v)
+	}
 }

--- a/pkg/config/v2/types_test.go
+++ b/pkg/config/v2/types_test.go
@@ -17,8 +17,8 @@ ls: "list files"
 `)
 	err := yaml.Unmarshal(input, &c)
 	require.NoError(t, err)
-	require.Equal(t, "check disk", c["df"])
-	require.Equal(t, "list files", c["ls"])
+	require.Equal(t, "check disk", c["df"].Instruction)
+	require.Equal(t, "list files", c["ls"].Instruction)
 }
 
 func TestCommandsUnmarshal_List(t *testing.T) {
@@ -29,6 +29,30 @@ func TestCommandsUnmarshal_List(t *testing.T) {
 `)
 	err := yaml.Unmarshal(input, &c)
 	require.NoError(t, err)
-	require.Equal(t, "check disk", c["df"])
-	require.Equal(t, "list files", c["ls"])
+	require.Equal(t, "check disk", c["df"].Instruction)
+	require.Equal(t, "list files", c["ls"].Instruction)
+}
+
+func TestCommandsUnmarshal_Advanced(t *testing.T) {
+	var c types.Commands
+	input := []byte(`
+fix-lint:
+  description: "Fix linting errors"
+  instruction: "Fix the lint issues"
+simple: "A simple command"
+`)
+	err := yaml.Unmarshal(input, &c)
+	require.NoError(t, err)
+	require.Equal(t, "Fix linting errors", c["fix-lint"].Description)
+	require.Equal(t, "Fix the lint issues", c["fix-lint"].Instruction)
+	require.Equal(t, "A simple command", c["simple"].Instruction)
+	require.Empty(t, c["simple"].Description)
+}
+
+func TestCommandsDisplayText(t *testing.T) {
+	simple := types.Command{Instruction: "simple instruction"}
+	require.Equal(t, "simple instruction", simple.DisplayText())
+
+	advanced := types.Command{Description: "my description", Instruction: "instruction"}
+	require.Equal(t, "my description", advanced.DisplayText())
 }

--- a/pkg/js/expand.go
+++ b/pkg/js/expand.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/dop251/goja"
 
+	"github.com/docker/cagent/pkg/config/types"
 	"github.com/docker/cagent/pkg/environment"
 )
 
@@ -98,4 +99,22 @@ func ExpandString(_ context.Context, str string, values map[string]string) (stri
 	}
 
 	return fmt.Sprintf("%v", expanded.Export()), nil
+}
+
+// ExpandCommands expands JS template literals in all command fields
+func (exp *Expander) ExpandCommands(ctx context.Context, cmds types.Commands) types.Commands {
+	if cmds == nil {
+		return nil
+	}
+
+	expanded := make(types.Commands, len(cmds))
+
+	for k, cmd := range cmds {
+		expanded[k] = types.Command{
+			Description: exp.Expand(ctx, cmd.Description),
+			Instruction: exp.Expand(ctx, cmd.Instruction),
+		}
+	}
+
+	return expanded
 }

--- a/pkg/runtime/commands.go
+++ b/pkg/runtime/commands.go
@@ -2,22 +2,320 @@ package runtime
 
 import (
 	"context"
+	"encoding/json"
+	"log/slog"
+	"regexp"
+	"strconv"
 	"strings"
+	"time"
+
+	"github.com/docker/cagent/pkg/tools"
 )
 
+var (
+	// positionalArgRegex matches $1, $2, etc. for argument substitution
+	positionalArgRegex = regexp.MustCompile(`\$(\d+)`)
+
+	// argumentsPlaceholder is the literal string for all arguments substitution
+	argumentsPlaceholder = "$ARGUMENTS"
+)
+
+// ResolveCommand transforms a /command into its expanded instruction text.
+// It processes:
+// 1. Command lookup from agent commands
+// 2. Positional argument substitution ($1, $2, etc.)
+// 3. Tool command execution (!tool_name(arg=value)) - tools executed and output inserted
 func ResolveCommand(ctx context.Context, rt Runtime, userInput string) string {
 	if !strings.HasPrefix(userInput, "/") {
 		return userInput
 	}
 
 	cmd, rest, _ := strings.Cut(userInput, " ")
-	prompt, found := rt.CurrentAgentCommands(ctx)[cmd[1:]]
-	if found {
-		userInput = prompt
-		if rest != "" {
-			userInput += " " + rest
+	commandName := cmd[1:] // Remove leading "/"
+
+	command, found := rt.CurrentAgentCommands(ctx)[commandName]
+	if !found {
+		return userInput
+	}
+
+	instruction := command.Instruction
+	args := tokenize(rest)
+
+	// Substitute positional arguments ($1, $2, etc.)
+	instruction = substitutePositionalArgs(instruction, args)
+
+	// Execute tool commands and substitute their output
+	instruction = executeToolCommands(ctx, rt, instruction)
+
+	// Append remaining text if no placeholders were used
+	if rest != "" && !positionalArgRegex.MatchString(command.Instruction) && !strings.Contains(command.Instruction, argumentsPlaceholder) {
+		instruction += " " + rest
+	}
+
+	return instruction
+}
+
+// tokenize splits input into tokens, respecting quoted strings.
+// Quotes are stripped from the tokens.
+func tokenize(input string) []string {
+	if input == "" {
+		return nil
+	}
+
+	var tokens []string
+	var current strings.Builder
+	var quoteChar rune
+
+	for _, r := range input {
+		switch {
+		case quoteChar == 0 && (r == '"' || r == '\''):
+			quoteChar = r
+		case r == quoteChar:
+			quoteChar = 0
+		case r == ' ' && quoteChar == 0:
+			if current.Len() > 0 {
+				tokens = append(tokens, current.String())
+				current.Reset()
+			}
+		default:
+			current.WriteRune(r)
 		}
 	}
 
-	return userInput
+	if current.Len() > 0 {
+		tokens = append(tokens, current.String())
+	}
+
+	return tokens
+}
+
+// substitutePositionalArgs replaces $1, $2, etc. with the corresponding arguments.
+// $0 and $ARGUMENTS are replaced with all arguments joined by space.
+func substitutePositionalArgs(instruction string, args []string) string {
+	allArgs := strings.Join(args, " ")
+	instruction = strings.ReplaceAll(instruction, argumentsPlaceholder, allArgs)
+
+	return positionalArgRegex.ReplaceAllStringFunc(instruction, func(match string) string {
+		num, _ := strconv.Atoi(match[1:])
+		if num == 0 {
+			return allArgs
+		}
+		if idx := num - 1; idx < len(args) {
+			return args[idx]
+		}
+		return ""
+	})
+}
+
+// toolCommand represents a parsed tool command from the instruction.
+type toolCommand struct {
+	start    int
+	end      int
+	toolName string
+	argsStr  string
+}
+
+// parseToolCommands finds all !tool_name(...) patterns in the instruction.
+func parseToolCommands(instruction string) []toolCommand {
+	var commands []toolCommand
+
+	for i := 0; i < len(instruction); i++ {
+		if instruction[i] != '!' {
+			continue
+		}
+
+		start := i
+		i++
+
+		// Parse tool name
+		nameStart := i
+		for i < len(instruction) && isWordChar(instruction[i]) {
+			i++
+		}
+		if i == nameStart || i >= len(instruction) || instruction[i] != '(' {
+			continue
+		}
+		toolName := instruction[nameStart:i]
+
+		// Find matching ')'
+		argsStart := i + 1
+		end, ok := findMatchingParen(instruction, i)
+		if !ok {
+			continue
+		}
+
+		commands = append(commands, toolCommand{
+			start:    start,
+			end:      end,
+			toolName: toolName,
+			argsStr:  instruction[argsStart : end-1],
+		})
+		i = end - 1 // -1 because loop will increment
+	}
+
+	return commands
+}
+
+// findMatchingParen finds the index after the matching closing parenthesis.
+// It handles nested parentheses and quoted strings.
+func findMatchingParen(s string, openIdx int) (int, bool) {
+	depth := 1
+	var quoteChar byte
+
+	for i := openIdx + 1; i < len(s) && depth > 0; i++ {
+		ch := s[i]
+		if quoteChar != 0 {
+			if ch == quoteChar {
+				quoteChar = 0
+			} else if ch == '\\' && i+1 < len(s) {
+				i++ // skip escaped char
+			}
+			continue
+		}
+		switch ch {
+		case '"', '\'':
+			quoteChar = ch
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i + 1, true
+			}
+		}
+	}
+	return 0, false
+}
+
+// isWordChar returns true if the byte is a valid word character.
+func isWordChar(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_'
+}
+
+// executeToolCommands executes !tool_name(arg=value) patterns and replaces them with output.
+func executeToolCommands(ctx context.Context, rt Runtime, instruction string) string {
+	commands := parseToolCommands(instruction)
+	if len(commands) == 0 {
+		return instruction
+	}
+
+	agentTools, err := rt.CurrentAgentTools(ctx)
+	if err != nil {
+		slog.Warn("Failed to get agent tools for command execution", "error", err)
+		return instruction
+	}
+
+	toolMap := make(map[string]tools.Tool, len(agentTools))
+	for _, t := range agentTools {
+		toolMap[t.Name] = t
+	}
+
+	// Process in reverse order to maintain correct indices
+	result := instruction
+	for i := len(commands) - 1; i >= 0; i-- {
+		cmd := commands[i]
+		replacement := executeSingleToolCommand(ctx, toolMap, cmd.toolName, cmd.argsStr)
+		result = result[:cmd.start] + replacement + result[cmd.end:]
+	}
+
+	return result
+}
+
+// executeSingleToolCommand executes a single tool command and returns the output.
+func executeSingleToolCommand(ctx context.Context, toolMap map[string]tools.Tool, toolName, argsStr string) string {
+	slog.Debug("Executing tool command", "tool", toolName, "args", argsStr)
+
+	tool, exists := toolMap[toolName]
+	if !exists {
+		slog.Warn("Tool not found for command execution", "tool", toolName)
+		return "Error: tool '" + toolName + "' not found"
+	}
+	if tool.Handler == nil {
+		slog.Warn("Tool has no handler", "tool", toolName)
+		return "Error: tool '" + toolName + "' has no handler"
+	}
+
+	argsJSON, err := json.Marshal(parseToolArgs(argsStr))
+	if err != nil {
+		slog.Warn("Failed to marshal tool arguments", "tool", toolName, "error", err)
+		return "Error: failed to marshal arguments for '" + toolName + "'"
+	}
+
+	toolCall := tools.ToolCall{
+		ID:   "cmd_" + toolName,
+		Type: "function",
+		Function: tools.FunctionCall{
+			Name:      toolName,
+			Arguments: string(argsJSON),
+		},
+	}
+
+	toolCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	result, err := tool.Handler(toolCtx, toolCall)
+	if err != nil {
+		slog.Warn("Tool execution failed", "tool", toolName, "error", err)
+		return "Error executing '" + toolName + "': " + err.Error()
+	}
+
+	output := strings.TrimSpace(result.Output)
+	slog.Debug("Tool command output", "tool", toolName, "output_length", len(output))
+	return output
+}
+
+// parseToolArgs parses key=value pairs from a tool command argument string.
+func parseToolArgs(argsStr string) map[string]any {
+	result := make(map[string]any)
+	if strings.TrimSpace(argsStr) == "" {
+		return result
+	}
+
+	var key, value strings.Builder
+	var quoteChar rune
+	inValue := false
+
+	flush := func() {
+		k := strings.TrimSpace(key.String())
+		if k != "" {
+			result[k] = parseValue(strings.TrimSpace(value.String()))
+		}
+		key.Reset()
+		value.Reset()
+		inValue = false
+	}
+
+	for _, r := range argsStr {
+		switch {
+		case quoteChar == 0 && (r == '"' || r == '\''):
+			quoteChar = r
+		case r == quoteChar:
+			quoteChar = 0
+		case r == '=' && !inValue && quoteChar == 0:
+			inValue = true
+		case r == ' ' && quoteChar == 0 && inValue:
+			flush()
+		case inValue:
+			value.WriteRune(r)
+		default:
+			key.WriteRune(r)
+		}
+	}
+	flush()
+
+	return result
+}
+
+// parseValue converts a string to a typed value (bool, int, float, or string).
+func parseValue(s string) any {
+	if b, err := strconv.ParseBool(s); err == nil {
+		return b
+	}
+	if i, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return i
+	}
+	if f, err := strconv.ParseFloat(s, 64); err == nil {
+		return f
+	}
+	return s
 }

--- a/pkg/runtime/commands_test.go
+++ b/pkg/runtime/commands_test.go
@@ -1,0 +1,621 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/cagent/pkg/config/types"
+	"github.com/docker/cagent/pkg/session"
+	"github.com/docker/cagent/pkg/tools"
+)
+
+// mockRuntime implements Runtime interface for testing
+type mockRuntime struct {
+	commands types.Commands
+	tools    []tools.Tool
+}
+
+func (m *mockRuntime) CurrentAgentCommands(context.Context) types.Commands {
+	return m.commands
+}
+
+func (m *mockRuntime) CurrentAgentTools(context.Context) ([]tools.Tool, error) {
+	return m.tools, nil
+}
+func (m *mockRuntime) CurrentAgentName() string { return "test" }
+func (m *mockRuntime) SetCurrentAgent(string) error {
+	return nil
+}
+func (m *mockRuntime) EmitStartupInfo(context.Context, chan Event) {}
+func (m *mockRuntime) ResetStartupInfo()                           {}
+func (m *mockRuntime) RunStream(context.Context, *session.Session) <-chan Event {
+	return nil
+}
+
+func (m *mockRuntime) Run(context.Context, *session.Session) ([]session.Message, error) {
+	return nil, nil
+}
+func (m *mockRuntime) Resume(context.Context, ResumeType) {}
+func (m *mockRuntime) ResumeElicitation(context.Context, tools.ElicitationAction, map[string]any) error {
+	return nil
+}
+func (m *mockRuntime) SessionStore() session.Store { return nil }
+func (m *mockRuntime) Summarize(context.Context, *session.Session, string, chan Event) {
+}
+
+func TestResolveCommand_SimpleCommand(t *testing.T) {
+	t.Parallel()
+
+	rt := &mockRuntime{
+		commands: types.Commands{
+			"test": types.Command{Instruction: "This is the test instruction"},
+		},
+	}
+
+	result := ResolveCommand(t.Context(), rt, "/test")
+	assert.Equal(t, "This is the test instruction", result)
+}
+
+func TestResolveCommand_CommandNotFound(t *testing.T) {
+	t.Parallel()
+
+	rt := &mockRuntime{
+		commands: types.Commands{},
+	}
+
+	result := ResolveCommand(t.Context(), rt, "/unknown")
+	assert.Equal(t, "/unknown", result)
+}
+
+func TestResolveCommand_NotACommand(t *testing.T) {
+	t.Parallel()
+
+	rt := &mockRuntime{
+		commands: types.Commands{
+			"test": types.Command{Instruction: "instruction"},
+		},
+	}
+
+	result := ResolveCommand(t.Context(), rt, "regular message")
+	assert.Equal(t, "regular message", result)
+}
+
+func TestResolveCommand_PositionalArgs(t *testing.T) {
+	t.Parallel()
+
+	rt := &mockRuntime{
+		commands: types.Commands{
+			"fix": types.Command{Instruction: "Fix the file $1 with options $2"},
+		},
+	}
+
+	result := ResolveCommand(t.Context(), rt, "/fix main.go --verbose")
+	assert.Equal(t, "Fix the file main.go with options --verbose", result)
+}
+
+func TestResolveCommand_PositionalArgsWithQuotes(t *testing.T) {
+	t.Parallel()
+
+	rt := &mockRuntime{
+		commands: types.Commands{
+			"search": types.Command{Instruction: "Search for $1 in $2"},
+		},
+	}
+
+	result := ResolveCommand(t.Context(), rt, `/search "hello world" ./src`)
+	assert.Equal(t, "Search for hello world in ./src", result)
+}
+
+func TestResolveCommand_AllArgs(t *testing.T) {
+	t.Parallel()
+
+	rt := &mockRuntime{
+		commands: types.Commands{
+			"run": types.Command{Instruction: "Run command with args: $0"},
+		},
+	}
+
+	result := ResolveCommand(t.Context(), rt, "/run arg1 arg2 arg3")
+	assert.Equal(t, "Run command with args: arg1 arg2 arg3", result)
+}
+
+func TestResolveCommand_ArgumentsPlaceholder(t *testing.T) {
+	t.Parallel()
+
+	rt := &mockRuntime{
+		commands: types.Commands{
+			"run": types.Command{Instruction: "Run command with args: $ARGUMENTS"},
+		},
+	}
+
+	result := ResolveCommand(t.Context(), rt, "/run arg1 arg2 arg3")
+	assert.Equal(t, "Run command with args: arg1 arg2 arg3", result)
+}
+
+func TestResolveCommand_ArgumentsPlaceholderEmpty(t *testing.T) {
+	t.Parallel()
+
+	rt := &mockRuntime{
+		commands: types.Commands{
+			"run": types.Command{Instruction: "Run command with args: $ARGUMENTS"},
+		},
+	}
+
+	result := ResolveCommand(t.Context(), rt, "/run")
+	assert.Equal(t, "Run command with args: ", result)
+}
+
+func TestResolveCommand_ArgumentsPlaceholderWithPositional(t *testing.T) {
+	t.Parallel()
+
+	rt := &mockRuntime{
+		commands: types.Commands{
+			"run": types.Command{Instruction: "First: $1, All: $ARGUMENTS"},
+		},
+	}
+
+	result := ResolveCommand(t.Context(), rt, "/run arg1 arg2 arg3")
+	assert.Equal(t, "First: arg1, All: arg1 arg2 arg3", result)
+}
+
+func TestResolveCommand_MissingArgs(t *testing.T) {
+	t.Parallel()
+
+	rt := &mockRuntime{
+		commands: types.Commands{
+			"fix": types.Command{Instruction: "Fix $1 and $2 and $3"},
+		},
+	}
+
+	result := ResolveCommand(t.Context(), rt, "/fix file1")
+	// $2 and $3 should be replaced with empty strings
+	assert.Equal(t, "Fix file1 and  and ", result)
+}
+
+func TestResolveCommand_ToolCommand(t *testing.T) {
+	t.Parallel()
+
+	rt := &mockRuntime{
+		commands: types.Commands{
+			"info": types.Command{Instruction: "Result: !echo_tool()"},
+		},
+		tools: []tools.Tool{
+			{
+				Name: "echo_tool",
+				Handler: func(_ context.Context, _ tools.ToolCall) (*tools.ToolCallResult, error) {
+					return tools.ResultSuccess("hello from tool"), nil
+				},
+			},
+		},
+	}
+
+	result := ResolveCommand(t.Context(), rt, "/info")
+	assert.Equal(t, "Result: hello from tool", result)
+}
+
+func TestResolveCommand_ToolCommandWithArgs(t *testing.T) {
+	t.Parallel()
+
+	rt := &mockRuntime{
+		commands: types.Commands{
+			"greet": types.Command{Instruction: "Greeting: !greet_tool(name=World)"},
+		},
+		tools: []tools.Tool{
+			{
+				Name: "greet_tool",
+				Handler: func(_ context.Context, tc tools.ToolCall) (*tools.ToolCallResult, error) {
+					// Parse the args to verify they're passed correctly
+					return tools.ResultSuccess("Hello, " + tc.Function.Arguments), nil
+				},
+			},
+		},
+	}
+
+	result := ResolveCommand(t.Context(), rt, "/greet")
+	assert.Contains(t, result, "Greeting:")
+	assert.Contains(t, result, "World")
+}
+
+func TestResolveCommand_ToolCommandWithQuotedArgs(t *testing.T) {
+	t.Parallel()
+
+	rt := &mockRuntime{
+		commands: types.Commands{
+			"search": types.Command{Instruction: `Files: !search_tool(query="hello world" path=/tmp)`},
+		},
+		tools: []tools.Tool{
+			{
+				Name: "search_tool",
+				Handler: func(_ context.Context, tc tools.ToolCall) (*tools.ToolCallResult, error) {
+					return tools.ResultSuccess("searched: " + tc.Function.Arguments), nil
+				},
+			},
+		},
+	}
+
+	result := ResolveCommand(t.Context(), rt, "/search")
+	assert.Contains(t, result, "Files:")
+	assert.Contains(t, result, "hello world")
+}
+
+func TestResolveCommand_ToolCommandNotFound(t *testing.T) {
+	t.Parallel()
+
+	rt := &mockRuntime{
+		commands: types.Commands{
+			"fail": types.Command{Instruction: "Result: !nonexistent_tool()"},
+		},
+		tools: []tools.Tool{},
+	}
+
+	result := ResolveCommand(t.Context(), rt, "/fail")
+	assert.Contains(t, result, "Error")
+	assert.Contains(t, result, "not found")
+}
+
+func TestResolveCommand_CombinedPositionalAndTool(t *testing.T) {
+	t.Parallel()
+
+	rt := &mockRuntime{
+		commands: types.Commands{
+			"check": types.Command{
+				Instruction: "Check $1 with result: !check_tool()",
+			},
+		},
+		tools: []tools.Tool{
+			{
+				Name: "check_tool",
+				Handler: func(_ context.Context, _ tools.ToolCall) (*tools.ToolCallResult, error) {
+					return tools.ResultSuccess("check_output"), nil
+				},
+			},
+		},
+	}
+
+	result := ResolveCommand(t.Context(), rt, "/check myfile.go")
+	assert.Equal(t, "Check myfile.go with result: check_output", result)
+}
+
+func TestResolveCommand_ExtraArgsAppended(t *testing.T) {
+	t.Parallel()
+
+	rt := &mockRuntime{
+		commands: types.Commands{
+			"simple": types.Command{Instruction: "Do the thing"},
+		},
+	}
+
+	// Commands without positional args get extra text appended
+	result := ResolveCommand(t.Context(), rt, "/simple with extra text")
+	assert.Equal(t, "Do the thing with extra text", result)
+}
+
+func TestTokenize(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{"empty", "", nil},
+		{"single", "arg1", []string{"arg1"}},
+		{"multiple", "arg1 arg2 arg3", []string{"arg1", "arg2", "arg3"}},
+		{"quoted", `"hello world" arg2`, []string{"hello world", "arg2"}},
+		{"single quoted", `'hello world' arg2`, []string{"hello world", "arg2"}},
+		{"mixed", `arg1 "quoted arg" arg3`, []string{"arg1", "quoted arg", "arg3"}},
+		{"extra spaces", "arg1  arg2   arg3", []string{"arg1", "arg2", "arg3"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := tokenize(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSubstitutePositionalArgs(t *testing.T) {
+	tests := []struct {
+		name        string
+		instruction string
+		args        []string
+		expected    string
+	}{
+		{
+			name:        "basic substitution",
+			instruction: "Fix $1",
+			args:        []string{"file.go"},
+			expected:    "Fix file.go",
+		},
+		{
+			name:        "multiple args",
+			instruction: "$1 and $2",
+			args:        []string{"first", "second"},
+			expected:    "first and second",
+		},
+		{
+			name:        "all args with $0",
+			instruction: "Run: $0",
+			args:        []string{"a", "b", "c"},
+			expected:    "Run: a b c",
+		},
+		{
+			name:        "all args with $ARGUMENTS",
+			instruction: "Run: $ARGUMENTS",
+			args:        []string{"a", "b", "c"},
+			expected:    "Run: a b c",
+		},
+		{
+			name:        "$ARGUMENTS with positional",
+			instruction: "First: $1, All: $ARGUMENTS",
+			args:        []string{"a", "b", "c"},
+			expected:    "First: a, All: a b c",
+		},
+		{
+			name:        "$ARGUMENTS empty",
+			instruction: "Args: $ARGUMENTS",
+			args:        nil,
+			expected:    "Args: ",
+		},
+		{
+			name:        "missing arg",
+			instruction: "Use $1 and $2",
+			args:        []string{"only_one"},
+			expected:    "Use only_one and ",
+		},
+		{
+			name:        "no args provided",
+			instruction: "Fix $1",
+			args:        nil,
+			expected:    "Fix ",
+		},
+		{
+			name:        "no placeholders",
+			instruction: "Just text",
+			args:        []string{"unused"},
+			expected:    "Just text",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := substitutePositionalArgs(tt.instruction, tt.args)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestParseToolArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected map[string]any
+	}{
+		{
+			name:     "empty",
+			input:    "",
+			expected: map[string]any{},
+		},
+		{
+			name:     "single arg",
+			input:    "key=value",
+			expected: map[string]any{"key": "value"},
+		},
+		{
+			name:     "multiple args",
+			input:    "key1=value1 key2=value2",
+			expected: map[string]any{"key1": "value1", "key2": "value2"},
+		},
+		{
+			name:     "quoted value",
+			input:    `key="hello world"`,
+			expected: map[string]any{"key": "hello world"},
+		},
+		{
+			name:     "single quoted value",
+			input:    `key='hello world'`,
+			expected: map[string]any{"key": "hello world"},
+		},
+		{
+			name:     "mixed quotes and unquoted",
+			input:    `name="John Doe" age=30`,
+			expected: map[string]any{"name": "John Doe", "age": int64(30)},
+		},
+		{
+			name:     "boolean true",
+			input:    "flag=true",
+			expected: map[string]any{"flag": true},
+		},
+		{
+			name:     "boolean false",
+			input:    "flag=false",
+			expected: map[string]any{"flag": false},
+		},
+		{
+			name:     "integer",
+			input:    "count=42",
+			expected: map[string]any{"count": int64(42)},
+		},
+		{
+			name:     "float",
+			input:    "ratio=3.14",
+			expected: map[string]any{"ratio": 3.14},
+		},
+		{
+			name:     "path value",
+			input:    "path=/tmp/file.txt",
+			expected: map[string]any{"path": "/tmp/file.txt"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := parseToolArgs(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestParseValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected any
+	}{
+		{"string", "hello", "hello"},
+		{"true", "true", true},
+		{"false", "false", false},
+		{"integer", "42", int64(42)},
+		{"negative integer", "-10", int64(-10)},
+		{"float", "3.14", 3.14},
+		{"negative float", "-2.5", -2.5},
+		{"path", "/tmp/file", "/tmp/file"},
+		{"url-like", "http://example.com", "http://example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := parseValue(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestParseToolCommands(t *testing.T) {
+	tests := []struct {
+		name        string
+		instruction string
+		expected    []toolCommand
+	}{
+		{
+			name:        "empty",
+			instruction: "",
+			expected:    nil,
+		},
+		{
+			name:        "no commands",
+			instruction: "Just some text",
+			expected:    nil,
+		},
+		{
+			name:        "simple command",
+			instruction: "!tool()",
+			expected:    []toolCommand{{start: 0, end: 7, toolName: "tool", argsStr: ""}},
+		},
+		{
+			name:        "command with args",
+			instruction: "!tool(arg=value)",
+			expected:    []toolCommand{{start: 0, end: 16, toolName: "tool", argsStr: "arg=value"}},
+		},
+		{
+			name:        "command in text",
+			instruction: "Before !tool(arg=value) After",
+			expected:    []toolCommand{{start: 7, end: 23, toolName: "tool", argsStr: "arg=value"}},
+		},
+		{
+			name:        "nested parentheses",
+			instruction: `!shell(cmd="echo $((2+2))")`,
+			expected:    []toolCommand{{start: 0, end: 27, toolName: "shell", argsStr: `cmd="echo $((2+2))"`}},
+		},
+		{
+			name:        "deeply nested parentheses",
+			instruction: `!shell(cmd="sh -c 'echo $((1+2+3))'")`,
+			expected:    []toolCommand{{start: 0, end: 37, toolName: "shell", argsStr: `cmd="sh -c 'echo $((1+2+3))'"`}},
+		},
+		{
+			name:        "multiple commands",
+			instruction: "!tool1() and !tool2(arg=val)",
+			expected: []toolCommand{
+				{start: 0, end: 8, toolName: "tool1", argsStr: ""},
+				{start: 13, end: 28, toolName: "tool2", argsStr: "arg=val"},
+			},
+		},
+		{
+			name:        "quoted string with parens",
+			instruction: `!tool(msg="hello (world)")`,
+			expected:    []toolCommand{{start: 0, end: 26, toolName: "tool", argsStr: `msg="hello (world)"`}},
+		},
+		{
+			name:        "single quoted string with parens",
+			instruction: `!tool(msg='hello (world)')`,
+			expected:    []toolCommand{{start: 0, end: 26, toolName: "tool", argsStr: `msg='hello (world)'`}},
+		},
+		{
+			name:        "exclamation without tool",
+			instruction: "Hello! World",
+			expected:    nil,
+		},
+		{
+			name:        "unbalanced parens",
+			instruction: "!tool(arg=value",
+			expected:    nil,
+		},
+		{
+			name:        "tool name with underscore",
+			instruction: "!my_tool()",
+			expected:    []toolCommand{{start: 0, end: 10, toolName: "my_tool", argsStr: ""}},
+		},
+		{
+			name:        "tool name with numbers",
+			instruction: "!tool123()",
+			expected:    []toolCommand{{start: 0, end: 10, toolName: "tool123", argsStr: ""}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := parseToolCommands(tt.instruction)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestResolveCommand_NestedParentheses(t *testing.T) {
+	t.Parallel()
+
+	rt := &mockRuntime{
+		commands: types.Commands{
+			"calc": types.Command{Instruction: `!shell(cmd="sh -c 'echo $(($ARGUMENTS))'")`},
+		},
+		tools: []tools.Tool{
+			{
+				Name: "shell",
+				Handler: func(_ context.Context, tc tools.ToolCall) (*tools.ToolCallResult, error) {
+					// Return the arguments to verify they're parsed correctly
+					return tools.ResultSuccess("args: " + tc.Function.Arguments), nil
+				},
+			},
+		},
+	}
+
+	result := ResolveCommand(t.Context(), rt, "/calc 2+2")
+	assert.Contains(t, result, `sh -c 'echo $((2+2))'`)
+}
+
+func TestResolveCommand_MultipleNestedParens(t *testing.T) {
+	t.Parallel()
+
+	rt := &mockRuntime{
+		commands: types.Commands{
+			"test": types.Command{Instruction: `Result: !tool(cmd="func(a(b(c)))")`},
+		},
+		tools: []tools.Tool{
+			{
+				Name: "tool",
+				Handler: func(_ context.Context, tc tools.ToolCall) (*tools.ToolCallResult, error) {
+					return tools.ResultSuccess(tc.Function.Arguments), nil
+				},
+			},
+		},
+	}
+
+	result := ResolveCommand(t.Context(), rt, "/test")
+	assert.Contains(t, result, `func(a(b(c)))`)
+}

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/cagent/pkg/api"
 	"github.com/docker/cagent/pkg/chat"
 	"github.com/docker/cagent/pkg/config/latest"
+	"github.com/docker/cagent/pkg/config/types"
 	"github.com/docker/cagent/pkg/session"
 	"github.com/docker/cagent/pkg/team"
 	"github.com/docker/cagent/pkg/tools"
@@ -80,8 +81,16 @@ func (r *RemoteRuntime) SetCurrentAgent(agentName string) error {
 	return nil
 }
 
-func (r *RemoteRuntime) CurrentAgentCommands(ctx context.Context) map[string]string {
+func (r *RemoteRuntime) CurrentAgentCommands(ctx context.Context) types.Commands {
 	return r.readCurrentAgentConfig(ctx).Commands
+}
+
+// CurrentAgentTools returns the tools for the current agent.
+// For remote runtime, this returns an empty list as tools are managed server-side.
+func (r *RemoteRuntime) CurrentAgentTools(_ context.Context) ([]tools.Tool, error) {
+	// Remote runtime doesn't have direct access to tools
+	// Tool execution happens on the server side
+	return nil, nil
 }
 
 // EmitStartupInfo emits initial agent, team, and toolset information for immediate sidebar display

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/docker/cagent/pkg/agent"
 	"github.com/docker/cagent/pkg/chat"
+	"github.com/docker/cagent/pkg/config/types"
 	"github.com/docker/cagent/pkg/hooks"
 	"github.com/docker/cagent/pkg/model/provider"
 	"github.com/docker/cagent/pkg/model/provider/options"
@@ -95,7 +96,9 @@ type Runtime interface {
 	// SetCurrentAgent sets the currently active agent for subsequent user messages
 	SetCurrentAgent(agentName string) error
 	// CurrentAgentCommands returns the commands for the active agent
-	CurrentAgentCommands(ctx context.Context) map[string]string
+	CurrentAgentCommands(ctx context.Context) types.Commands
+	// CurrentAgentTools returns the tools for the active agent
+	CurrentAgentTools(ctx context.Context) ([]tools.Tool, error)
 	// EmitStartupInfo emits initial agent, team, and toolset information for immediate display
 	EmitStartupInfo(ctx context.Context, events chan Event)
 	// ResetStartupInfo resets the startup info emission flag, allowing re-emission
@@ -369,8 +372,15 @@ func (r *LocalRuntime) SetCurrentAgent(agentName string) error {
 	return nil
 }
 
-func (r *LocalRuntime) CurrentAgentCommands(context.Context) map[string]string {
+func (r *LocalRuntime) CurrentAgentCommands(context.Context) types.Commands {
 	return r.CurrentAgent().Commands()
+}
+
+// CurrentAgentTools returns the tools available to the current agent.
+// This starts the toolsets if needed and returns all available tools.
+func (r *LocalRuntime) CurrentAgentTools(ctx context.Context) ([]tools.Tool, error) {
+	a := r.CurrentAgent()
+	return a.Tools(ctx)
 }
 
 // CurrentMCPPrompts returns the available MCP prompts from all active MCP toolsets

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -112,7 +112,7 @@ func Load(ctx context.Context, agentSource config.Source, runConfig *config.Runt
 			agent.WithAddPromptFiles(agentConfig.AddPromptFiles),
 			agent.WithMaxIterations(agentConfig.MaxIterations),
 			agent.WithNumHistoryItems(agentConfig.NumHistoryItems),
-			agent.WithCommands(expander.ExpandMap(ctx, agentConfig.Commands)),
+			agent.WithCommands(expander.ExpandCommands(ctx, agentConfig.Commands)),
 			agent.WithSkillsEnabled(skillsEnabled),
 			agent.WithHooks(agentConfig.Hooks),
 		}

--- a/pkg/tui/commands/commands.go
+++ b/pkg/tui/commands/commands.go
@@ -157,11 +157,11 @@ func BuildCommandCategories(ctx context.Context, application *app.App) []Categor
 	agentCommands := application.CurrentAgentCommands(ctx)
 	if len(agentCommands) > 0 {
 		var commands []Item
-		for name, prompt := range agentCommands {
+		for name, cmd := range agentCommands {
 			commands = append(commands, Item{
 				ID:           "agent.command." + name,
 				Label:        name,
-				Description:  toolcommon.TruncateText(prompt, 60),
+				Description:  toolcommon.TruncateText(cmd.DisplayText(), 60),
 				Category:     "Agent Commands",
 				SlashCommand: "/" + name,
 				Execute: func(string) tea.Cmd {

--- a/pkg/tui/components/message/message.go
+++ b/pkg/tui/components/message/message.go
@@ -50,7 +50,7 @@ func New(msg, previous *types.Message) *messageModel {
 
 // Init initializes the message view
 func (mv *messageModel) Init() tea.Cmd {
-	if mv.message.Type == types.MessageTypeSpinner {
+	if mv.message.Type == types.MessageTypeSpinner || mv.message.Type == types.MessageTypeLoading {
 		return mv.spinner.Tick()
 	}
 	return nil
@@ -66,7 +66,7 @@ func (mv *messageModel) SetSelected(selected bool) {
 
 // Update handles messages and updates the message view state
 func (mv *messageModel) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
-	if mv.message.Type == types.MessageTypeSpinner {
+	if mv.message.Type == types.MessageTypeSpinner || mv.message.Type == types.MessageTypeLoading {
 		s, cmd := mv.spinner.Update(msg)
 		mv.spinner = s.(spinner.Spinner)
 		return mv, cmd
@@ -136,6 +136,9 @@ func (mv *messageModel) Render(width int) string {
 		return styles.WelcomeMessageStyle.Width(width - 1).Render(strings.TrimRight(msg.Content, "\n\r\t "))
 	case types.MessageTypeError:
 		return styles.ErrorMessageStyle.Width(width - 1).Render(msg.Content)
+	case types.MessageTypeLoading:
+		// Show spinner with the loading description
+		return mv.spinner.View() + " " + styles.MutedStyle.Render(msg.Content)
 	default:
 		return msg.Content
 	}

--- a/pkg/tui/components/messages/messages.go
+++ b/pkg/tui/components/messages/messages.go
@@ -50,6 +50,8 @@ type Model interface {
 	layout.Positionable
 
 	AddUserMessage(content string) tea.Cmd
+	AddLoadingMessage(description string) tea.Cmd
+	ReplaceLoadingWithUser(content string) tea.Cmd
 	AddErrorMessage(content string) tea.Cmd
 	AddAssistantMessage() tea.Cmd
 	AddCancelledMessage() tea.Cmd
@@ -785,6 +787,29 @@ func (m *model) isAtBottom() bool {
 
 // AddUserMessage adds a user message to the chat
 func (m *model) AddUserMessage(content string) tea.Cmd {
+	return m.addMessage(types.User(content))
+}
+
+// AddLoadingMessage adds a temporary loading message with a spinner and description
+func (m *model) AddLoadingMessage(description string) tea.Cmd {
+	return m.addMessage(types.Loading(description))
+}
+
+// ReplaceLoadingWithUser replaces the last loading message with a user message
+func (m *model) ReplaceLoadingWithUser(content string) tea.Cmd {
+	// Find and remove the last loading message
+	for i := len(m.messages) - 1; i >= 0; i-- {
+		if m.messages[i].Type == types.MessageTypeLoading {
+			m.messages = append(m.messages[:i], m.messages[i+1:]...)
+			if i < len(m.views) {
+				m.views = append(m.views[:i], m.views[i+1:]...)
+			}
+			m.invalidateAllItems()
+			break
+		}
+	}
+
+	// Add the actual user message
 	return m.addMessage(types.User(content))
 }
 

--- a/pkg/tui/types/types.go
+++ b/pkg/tui/types/types.go
@@ -20,6 +20,7 @@ const (
 	MessageTypeToolCall
 	MessageTypeToolResult
 	MessageTypeWelcome
+	MessageTypeLoading
 )
 
 // ToolStatus represents the status of a tool call
@@ -99,5 +100,12 @@ func ToolCallMessage(agentName string, toolCall tools.ToolCall, toolDef tools.To
 		ToolCall:       toolCall,
 		ToolDefinition: toolDef,
 		ToolStatus:     status,
+	}
+}
+
+func Loading(description string) *Message {
+	return &Message{
+		Type:    MessageTypeLoading,
+		Content: strings.ReplaceAll(description, "\t", "    "),
 	}
 }


### PR DESCRIPTION
Add a new Command type that supports:
- Description field for human-readable command descriptions
- Instruction field for the actual command text
- Three YAML formats: simple string, list, and advanced object format
- Positional arguments ($1, $2, $0 for all args) in instructions
- Bang commands (!command) to execute tools
