### PR TITLE
winget: fix unexpected token error

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: publish
         run: |
-          $Release = '${{ toJSON(github.event.release) }}' | ConvertFrom-Json
+          $Release = $ENV:RELEASE | ConvertFrom-Json
           $Version = $Release.tag_name
           $PackageId = "Docker.Cagent"
           $Urls = @(
@@ -22,3 +22,5 @@ jobs:
           )
           & curl.exe -JLO https://aka.ms/wingetcreate/latest
           & .\wingetcreate.exe update $PackageId -s -v $Version -u $Urls
+        env:
+          RELEASE: ${{ toJSON(github.event.release) }}


### PR DESCRIPTION
Prior to this change the winget publish workflow would fail when trying to parse the release payload.

This was happening because the release notes contain single quotes cusing the string to be escaped.

This change stores the payload in an environment variable then references it in the run step.

According to the issue linked below, this is the way to fix it. https://github.com/actions/runner/issues/1656