### PR TITLE
Hide empty sessions in session browser

### DIFF
--- a/pkg/tui/dialog/session_browser.go
+++ b/pkg/tui/dialog/session_browser.go
@@ -36,10 +36,18 @@ func NewSessionBrowserDialog(sessions []session.Summary) Dialog {
 	ti.CharLimit = 100
 	ti.SetWidth(50)
 
+	// Filter out empty sessions (sessions without a title)
+	nonEmptySessions := make([]session.Summary, 0, len(sessions))
+	for _, s := range sessions {
+		if s.Title != "" {
+			nonEmptySessions = append(nonEmptySessions, s)
+		}
+	}
+
 	return &sessionBrowserDialog{
 		textInput: ti,
-		sessions:  sessions,
-		filtered:  sessions,
+		sessions:  nonEmptySessions,
+		filtered:  nonEmptySessions,
 		keyMap:    defaultCommandPaletteKeyMap(),
 		openedAt:  time.Now(),
 	}

--- a/pkg/tui/dialog/session_browser_test.go
+++ b/pkg/tui/dialog/session_browser_test.go
@@ -117,6 +117,42 @@ func TestSessionBrowserViewShowsSelection(t *testing.T) {
 	require.NotEqual(t, view1, view2, "view should change after navigation")
 }
 
+func TestSessionBrowserFiltersEmptySessions(t *testing.T) {
+	sessions := []session.Summary{
+		{ID: "1", Title: "Session 1", CreatedAt: time.Now()},
+		{ID: "2", Title: "", CreatedAt: time.Now()},
+		{ID: "3", Title: "Session 3", CreatedAt: time.Now()},
+		{ID: "4", Title: "", CreatedAt: time.Now()},
+		{ID: "5", Title: "Session 5", CreatedAt: time.Now()},
+	}
+
+	dialog := NewSessionBrowserDialog(sessions)
+	d := dialog.(*sessionBrowserDialog)
+
+	// Should only have non-empty sessions
+	require.Len(t, d.sessions, 3, "should have 3 non-empty sessions")
+	require.Len(t, d.filtered, 3, "filtered should also have 3 sessions")
+
+	// Verify the correct sessions are kept
+	require.Equal(t, "1", d.sessions[0].ID)
+	require.Equal(t, "3", d.sessions[1].ID)
+	require.Equal(t, "5", d.sessions[2].ID)
+}
+
+func TestSessionBrowserAllEmptySessions(t *testing.T) {
+	sessions := []session.Summary{
+		{ID: "1", Title: "", CreatedAt: time.Now()},
+		{ID: "2", Title: "", CreatedAt: time.Now()},
+	}
+
+	dialog := NewSessionBrowserDialog(sessions)
+	d := dialog.(*sessionBrowserDialog)
+
+	// Should have no sessions
+	require.Empty(t, d.sessions, "should have 0 sessions")
+	require.Empty(t, d.filtered, "filtered should also have 0 sessions")
+}
+
 func TestSessionBrowserScrolling(t *testing.T) {
 	// Create more sessions than can fit in view
 	sessions := make([]session.Summary, 20)


### PR DESCRIPTION
Filter out sessions without a title from the session browser dialog. Sessions without titles are those that were created but never had meaningful content (the runtime sets the title when content is added).

Assisted-By: cagent