### PR TITLE
Add session starring feature

### DIFF
--- a/pkg/session/migrations.go
+++ b/pkg/session/migrations.go
@@ -207,6 +207,13 @@ func getAllMigrations() []Migration {
 			UpSQL:       `ALTER TABLE sessions ADD COLUMN working_dir TEXT DEFAULT ''`,
 			DownSQL:     `ALTER TABLE sessions DROP COLUMN working_dir`,
 		},
+		{
+			ID:          9,
+			Name:        "009_add_starred_column",
+			Description: "Add starred column to sessions table",
+			UpSQL:       `ALTER TABLE sessions ADD COLUMN starred BOOLEAN DEFAULT 0`,
+			DownSQL:     `ALTER TABLE sessions DROP COLUMN starred`,
+		},
 		// Add more migrations here as needed
 	}
 }

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -76,6 +76,9 @@ type Session struct {
 	// If 0, there is no limit
 	MaxIterations int `json:"max_iterations"`
 
+	// Starred indicates if this session has been starred by the user
+	Starred bool `json:"starred"`
+
 	InputTokens  int64   `json:"input_tokens"`
 	OutputTokens int64   `json:"output_tokens"`
 	Cost         float64 `json:"cost"`

--- a/pkg/tui/commands/commands.go
+++ b/pkg/tui/commands/commands.go
@@ -66,6 +66,16 @@ func builtInSessionCommands() []Item {
 			},
 		},
 		{
+			ID:           "session.star",
+			Label:        "Star",
+			SlashCommand: "/star",
+			Description:  "Toggle star on current session",
+			Category:     "Session",
+			Execute: func(string) tea.Cmd {
+				return core.CmdHandler(messages.ToggleSessionStarMsg{})
+			},
+		},
+		{
 			ID:           "session.compact",
 			Label:        "Compact",
 			SlashCommand: "/compact",

--- a/pkg/tui/messages/messages.go
+++ b/pkg/tui/messages/messages.go
@@ -13,6 +13,7 @@ type (
 	SwitchAgentMsg            struct{ AgentName string }
 	OpenSessionBrowserMsg     struct{}
 	LoadSessionMsg            struct{ SessionID string }
+	ToggleSessionStarMsg      struct{ SessionID string } // Toggle star on a session; empty ID means current session
 )
 
 // AgentCommandMsg command message

--- a/pkg/tui/page/chat/input_handlers.go
+++ b/pkg/tui/page/chat/input_handlers.go
@@ -7,7 +7,9 @@ import (
 	"github.com/docker/cagent/pkg/tui/components/editor"
 	"github.com/docker/cagent/pkg/tui/components/messages"
 	"github.com/docker/cagent/pkg/tui/components/tool/editfile"
+	"github.com/docker/cagent/pkg/tui/core"
 	"github.com/docker/cagent/pkg/tui/core/layout"
+	msgtypes "github.com/docker/cagent/pkg/tui/messages"
 )
 
 // handleKeyPress handles keyboard input events for the chat page.
@@ -54,6 +56,15 @@ func (p *chatPage) handleKeyPress(msg tea.KeyPressMsg) (layout.Model, tea.Cmd, b
 func (p *chatPage) handleMouseClick(msg tea.MouseClickMsg) (layout.Model, tea.Cmd) {
 	if p.isOnResizeHandle(msg.X, msg.Y) {
 		p.isDragging = true
+		return p, nil
+	}
+	// Check if click is on the star in sidebar
+	if msg.Button == tea.MouseLeft && p.handleSidebarClick(msg.X, msg.Y) {
+		// Emit toggle message to persist the change
+		sess := p.app.Session()
+		if sess != nil {
+			return p, core.CmdHandler(msgtypes.ToggleSessionStarMsg{SessionID: sess.ID})
+		}
 		return p, nil
 	}
 	cmd := p.routeMouseEvent(msg, msg.Y)

--- a/pkg/tui/styles/styles.go
+++ b/pkg/tui/styles/styles.go
@@ -305,6 +305,20 @@ var (
 					Foreground(White)
 )
 
+// Star Styles for session browser and sidebar
+var (
+	StarredStyle   = BaseStyle.Foreground(Success)
+	UnstarredStyle = BaseStyle.Foreground(TextMuted)
+)
+
+// StarIndicator returns the styled star indicator for a given starred status
+func StarIndicator(starred bool) string {
+	if starred {
+		return StarredStyle.Render("★") + " "
+	}
+	return UnstarredStyle.Render("☆") + " "
+}
+
 // Diff Styles (matching glamour markdown theme)
 var (
 	DiffAddStyle = BaseStyle.

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -236,6 +236,18 @@ func (a *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case messages.LoadSessionMsg:
 		return a.handleLoadSession(msg.SessionID)
 
+	case messages.ToggleSessionStarMsg:
+		sessionID := msg.SessionID
+		if sessionID == "" {
+			// Empty ID means current session
+			if sess := a.application.Session(); sess != nil {
+				sessionID = sess.ID
+			} else {
+				return a, nil
+			}
+		}
+		return a.handleToggleSessionStar(sessionID)
+
 	case messages.StartShellMsg:
 		return a.startShell()
 


### PR DESCRIPTION
- Add starred column to sessions database with migration
- Add star indicator (★/☆) in sidebar next to session title
- Add star indicator in session browser dialog
- Add /star command to toggle star on current session
- Add clickable star in sidebar to toggle starred status
- Add 's' key in session browser to toggle star on selected session
- Add 'f' key in session browser to filter by starred/unstarred/all
- Add 'c' key in session browser to copy session ID to clipboard
- Show session ID in session browser footer
- Only show star icon after session has content (not on new empty sessions)
- Use UpdateSession (upsert) when starring to handle unpersisted sessions

Assisted-By: cagent