### PR TITLE
Add JWT expiration check in GetToken

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-git/go-git/v5 v5.16.4
 	github.com/goccy/go-yaml v1.19.1
+	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/google/go-containerregistry v0.20.7
 	github.com/google/jsonschema-go v0.3.0
 	github.com/google/uuid v1.6.0

--- a/pkg/desktop/login.go
+++ b/pkg/desktop/login.go
@@ -2,6 +2,10 @@ package desktop
 
 import (
 	"context"
+	"log/slog"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
 )
 
 type DockerHubInfo struct {
@@ -12,7 +16,35 @@ type DockerHubInfo struct {
 func GetToken(ctx context.Context) string {
 	var token string
 	_ = ClientBackend.Get(ctx, "/registry/token", &token)
+
+	if token != "" {
+		checkTokenExpiration(token)
+	}
+
 	return token
+}
+
+func checkTokenExpiration(token string) {
+	// Parse the JWT without validation (we just need the claims)
+	parsed, _, err := jwt.NewParser().ParseUnverified(token, jwt.MapClaims{})
+	if err != nil {
+		slog.Debug("Failed to parse JWT", "error", err)
+		return
+	}
+
+	exp, err := parsed.Claims.GetExpirationTime()
+	if err != nil {
+		slog.Debug("Failed to get expiration time from JWT", "error", err)
+		return
+	}
+
+	if exp == nil {
+		slog.Debug("JWT has no expiration time")
+		return
+	}
+
+	isExpired := exp.Before(time.Now())
+	slog.Debug("JWT expiration check", "expiration", exp.Time, "expired", isExpired)
 }
 
 func GetUserInfo(ctx context.Context) DockerHubInfo {


### PR DESCRIPTION
Parse the JWT token (without validation) to extract the expiration claim and log at debug level whether the token is expired.

Assisted-By: cagent