### PR TITLE
Add /cost command to show detailed session cost breakdown

### DIFF
--- a/pkg/chat/chat.go
+++ b/pkg/chat/chat.go
@@ -60,6 +60,15 @@ type Message struct {
 	ToolCallID string `json:"tool_call_id,omitempty"`
 
 	CreatedAt string `json:"created_at,omitempty"`
+
+	// Usage tracks token usage for this message (only set for assistant messages)
+	Usage *Usage `json:"usage,omitempty"`
+
+	// Model is the model that generated this message (only set for assistant messages)
+	Model string `json:"model,omitempty"`
+
+	// Cost is the cost of this message in dollars (only set for assistant messages)
+	Cost float64 `json:"cost,omitempty"`
 }
 
 type MessagePart struct {

--- a/pkg/tui/commands/commands.go
+++ b/pkg/tui/commands/commands.go
@@ -136,6 +136,16 @@ func builtInSessionCommands() []Item {
 			},
 		},
 		{
+			ID:           "session.cost",
+			Label:        "Cost",
+			SlashCommand: "/cost",
+			Description:  "Show detailed cost breakdown for this session",
+			Category:     "Session",
+			Execute: func(string) tea.Cmd {
+				return core.CmdHandler(messages.ShowCostDialogMsg{})
+			},
+		},
+		{
 			ID:           "session.attach",
 			Label:        "Attach",
 			SlashCommand: "/attach",

--- a/pkg/tui/dialog/cost.go
+++ b/pkg/tui/dialog/cost.go
@@ -1,0 +1,371 @@
+package dialog
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/atotto/clipboard"
+
+	"github.com/docker/cagent/pkg/chat"
+	"github.com/docker/cagent/pkg/session"
+	"github.com/docker/cagent/pkg/tui/components/notification"
+	"github.com/docker/cagent/pkg/tui/core"
+	"github.com/docker/cagent/pkg/tui/core/layout"
+	"github.com/docker/cagent/pkg/tui/styles"
+)
+
+// costDialog displays detailed cost breakdown for a session.
+type costDialog struct {
+	BaseDialog
+	keyMap  costDialogKeyMap
+	session *session.Session
+	offset  int
+}
+
+type costDialogKeyMap struct {
+	Close, Copy, Up, Down, PageUp, PageDown key.Binding
+}
+
+var defaultCostKeyMap = costDialogKeyMap{
+	Close:    key.NewBinding(key.WithKeys("esc", "enter", "q"), key.WithHelp("Esc", "close")),
+	Copy:     key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "copy")),
+	Up:       key.NewBinding(key.WithKeys("up", "k")),
+	Down:     key.NewBinding(key.WithKeys("down", "j")),
+	PageUp:   key.NewBinding(key.WithKeys("pgup")),
+	PageDown: key.NewBinding(key.WithKeys("pgdown")),
+}
+
+// NewCostDialog creates a new cost dialog from session data.
+func NewCostDialog(sess *session.Session) Dialog {
+	return &costDialog{keyMap: defaultCostKeyMap, session: sess}
+}
+
+func (d *costDialog) Init() tea.Cmd { return nil }
+
+func (d *costDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		cmd := d.SetSize(msg.Width, msg.Height)
+		return d, cmd
+
+	case tea.KeyPressMsg:
+		switch {
+		case key.Matches(msg, d.keyMap.Close):
+			return d, core.CmdHandler(CloseDialogMsg{})
+		case key.Matches(msg, d.keyMap.Copy):
+			_ = clipboard.WriteAll(d.renderPlainText())
+			return d, notification.SuccessCmd("Cost details copied to clipboard.")
+		case key.Matches(msg, d.keyMap.Up):
+			d.offset = max(0, d.offset-1)
+		case key.Matches(msg, d.keyMap.Down):
+			d.offset++
+		case key.Matches(msg, d.keyMap.PageUp):
+			d.offset = max(0, d.offset-d.pageSize())
+		case key.Matches(msg, d.keyMap.PageDown):
+			d.offset += d.pageSize()
+		}
+
+	case tea.MouseWheelMsg:
+		switch msg.Button.String() {
+		case "wheelup":
+			d.offset = max(0, d.offset-1)
+		case "wheeldown":
+			d.offset++
+		}
+	}
+	return d, nil
+}
+
+func (d *costDialog) dialogSize() (dialogWidth, maxHeight, contentWidth int) {
+	dialogWidth = d.ComputeDialogWidth(70, 50, 80)
+	maxHeight = min(d.Height()*70/100, 40)
+	contentWidth = d.ContentWidth(dialogWidth, 2)
+	return dialogWidth, maxHeight, contentWidth
+}
+
+func (d *costDialog) pageSize() int {
+	_, maxHeight, _ := d.dialogSize()
+	return max(1, maxHeight-10)
+}
+
+func (d *costDialog) Position() (row, col int) {
+	dialogWidth, maxHeight, _ := d.dialogSize()
+	return CenterPosition(d.Width(), d.Height(), dialogWidth, maxHeight)
+}
+
+func (d *costDialog) View() string {
+	dialogWidth, maxHeight, contentWidth := d.dialogSize()
+	content := d.renderContent(contentWidth, maxHeight)
+	return styles.DialogStyle.Padding(1, 2).Width(dialogWidth).Render(content)
+}
+
+// usageInfo holds token usage and cost for a model or message.
+type usageInfo struct {
+	label            string
+	cost             float64
+	inputTokens      int64
+	outputTokens     int64
+	cachedTokens     int64
+	cacheWriteTokens int64
+}
+
+func (u *usageInfo) totalInput() int64 {
+	return u.inputTokens + u.cachedTokens + u.cacheWriteTokens
+}
+
+// costData holds aggregated cost data for display.
+type costData struct {
+	total             usageInfo
+	models            []usageInfo
+	messages          []usageInfo
+	hasPerMessageData bool
+}
+
+func (d *costDialog) gatherCostData() costData {
+	var data costData
+	modelMap := make(map[string]*usageInfo)
+
+	for _, msg := range d.session.GetAllMessages() {
+		if msg.Message.Role != chat.MessageRoleAssistant || msg.Message.Usage == nil {
+			continue
+		}
+		data.hasPerMessageData = true
+
+		usage := msg.Message.Usage
+		model := msg.Message.Model
+		if model == "" {
+			model = "unknown"
+		}
+
+		// Update totals
+		data.total.cost += msg.Message.Cost
+		data.total.inputTokens += usage.InputTokens
+		data.total.outputTokens += usage.OutputTokens
+		data.total.cachedTokens += usage.CachedInputTokens
+		data.total.cacheWriteTokens += usage.CacheWriteTokens
+
+		// Update per-model
+		if modelMap[model] == nil {
+			modelMap[model] = &usageInfo{label: model}
+		}
+		m := modelMap[model]
+		m.cost += msg.Message.Cost
+		m.inputTokens += usage.InputTokens
+		m.outputTokens += usage.OutputTokens
+		m.cachedTokens += usage.CachedInputTokens
+		m.cacheWriteTokens += usage.CacheWriteTokens
+
+		// Track per-message
+		msgLabel := fmt.Sprintf("#%d", len(data.messages)+1)
+		if msg.AgentName != "" {
+			msgLabel = fmt.Sprintf("#%d [%s]", len(data.messages)+1, msg.AgentName)
+		}
+		data.messages = append(data.messages, usageInfo{
+			label:            msgLabel,
+			cost:             msg.Message.Cost,
+			inputTokens:      usage.InputTokens,
+			outputTokens:     usage.OutputTokens,
+			cachedTokens:     usage.CachedInputTokens,
+			cacheWriteTokens: usage.CacheWriteTokens,
+		})
+	}
+
+	// Convert model map to sorted slice (by cost descending)
+	for _, m := range modelMap {
+		data.models = append(data.models, *m)
+	}
+	sort.Slice(data.models, func(i, j int) bool {
+		return data.models[i].cost > data.models[j].cost
+	})
+
+	// Fall back to session-level totals if no per-message data
+	if !data.hasPerMessageData {
+		data.total = usageInfo{
+			cost:         d.session.Cost,
+			inputTokens:  d.session.InputTokens,
+			outputTokens: d.session.OutputTokens,
+		}
+	}
+
+	return data
+}
+
+func (d *costDialog) renderContent(contentWidth, maxHeight int) string {
+	data := d.gatherCostData()
+
+	// Build all lines
+	lines := []string{
+		RenderTitle("Session Cost Details", contentWidth, styles.DialogTitleStyle),
+		RenderSeparator(contentWidth),
+		"",
+		sectionStyle.Render("Total"),
+		"",
+		accentStyle.Render(formatCost(data.total.cost)),
+		d.renderInputLine(data.total, true),
+		fmt.Sprintf("%s %s", labelStyle.Render("output:"), valueStyle.Render(formatTokenCount(data.total.outputTokens))),
+		"",
+	}
+
+	// By Model Section
+	if len(data.models) > 0 {
+		lines = append(lines, sectionStyle.Render("By Model"), "")
+		for _, m := range data.models {
+			lines = append(lines, d.renderUsageLine(m))
+		}
+		lines = append(lines, "")
+	}
+
+	// By Message Section
+	if len(data.messages) > 0 {
+		lines = append(lines, sectionStyle.Render("By Message"), "")
+		for _, m := range data.messages {
+			lines = append(lines, d.renderUsageLine(m))
+		}
+		lines = append(lines, "")
+	} else if !data.hasPerMessageData && data.total.cost > 0 {
+		lines = append(lines, styles.MutedStyle.Render("Per-message breakdown not available for this session."), "")
+	}
+
+	// Apply scrolling
+	return d.applyScrolling(lines, contentWidth, maxHeight)
+}
+
+func (d *costDialog) renderInputLine(u usageInfo, showBreakdown bool) string {
+	line := fmt.Sprintf("%s %s", labelStyle.Render("input:"), valueStyle.Render(formatTokenCount(u.totalInput())))
+	if showBreakdown && (u.cachedTokens > 0 || u.cacheWriteTokens > 0) {
+		line += valueStyle.Render(fmt.Sprintf(" (%s new + %s cached + %s cache write)",
+			formatTokenCount(u.inputTokens),
+			formatTokenCount(u.cachedTokens),
+			formatTokenCount(u.cacheWriteTokens)))
+	}
+	return line
+}
+
+func (d *costDialog) renderUsageLine(u usageInfo) string {
+	return fmt.Sprintf("%s  %s %s  %s %s  %s",
+		accentStyle.Render(padRight(formatCostPadded(u.cost))),
+		labelStyle.Render("input:"),
+		valueStyle.Render(padRight(formatTokenCount(u.totalInput()))),
+		labelStyle.Render("output:"),
+		valueStyle.Render(padRight(formatTokenCount(u.outputTokens))),
+		accentStyle.Render(u.label))
+}
+
+func (d *costDialog) applyScrolling(allLines []string, contentWidth, maxHeight int) string {
+	const headerLines = 3 // title + separator + space
+	const footerLines = 2 // space + help
+
+	visibleLines := max(1, maxHeight-headerLines-footerLines-4)
+	contentLines := allLines[headerLines:]
+	totalContentLines := len(contentLines)
+
+	// Clamp offset
+	maxOffset := max(0, totalContentLines-visibleLines)
+	d.offset = min(d.offset, maxOffset)
+
+	// Extract visible portion
+	endIdx := min(d.offset+visibleLines, totalContentLines)
+	parts := append(allLines[:headerLines], contentLines[d.offset:endIdx]...)
+
+	// Scroll indicator
+	if totalContentLines > visibleLines {
+		scrollInfo := fmt.Sprintf("[%d-%d of %d]", d.offset+1, endIdx, totalContentLines)
+		if d.offset > 0 {
+			scrollInfo = "↑ " + scrollInfo
+		}
+		if endIdx < totalContentLines {
+			scrollInfo += " ↓"
+		}
+		parts = append(parts, styles.MutedStyle.Render(scrollInfo))
+	}
+
+	parts = append(parts, "", RenderHelpKeys(contentWidth, "↑↓", "scroll", "c", "copy", "Esc", "close"))
+	return lipgloss.JoinVertical(lipgloss.Left, parts...)
+}
+
+func (d *costDialog) renderPlainText() string {
+	data := d.gatherCostData()
+	var lines []string
+
+	// Build input line with optional breakdown
+	inputLine := fmt.Sprintf("input: %s", formatTokenCount(data.total.totalInput()))
+	if data.total.cachedTokens > 0 || data.total.cacheWriteTokens > 0 {
+		inputLine += fmt.Sprintf(" (%s new + %s cached + %s cache write)",
+			formatTokenCount(data.total.inputTokens),
+			formatTokenCount(data.total.cachedTokens),
+			formatTokenCount(data.total.cacheWriteTokens))
+	}
+
+	lines = append(lines, "Session Cost Details", "", "Total", formatCost(data.total.cost),
+		inputLine, fmt.Sprintf("output: %s", formatTokenCount(data.total.outputTokens)), "")
+
+	if len(data.models) > 0 {
+		lines = append(lines, "By Model")
+		for _, m := range data.models {
+			lines = append(lines, fmt.Sprintf("%-8s  input: %-8s  output: %-8s  %s",
+				formatCostPadded(m.cost), formatTokenCount(m.totalInput()), formatTokenCount(m.outputTokens), m.label))
+		}
+		lines = append(lines, "")
+	}
+
+	if len(data.messages) > 0 {
+		lines = append(lines, "By Message")
+		for _, m := range data.messages {
+			lines = append(lines, fmt.Sprintf("%-8s  input: %-8s  output: %-8s  %s",
+				formatCostPadded(m.cost), formatTokenCount(m.totalInput()), formatTokenCount(m.outputTokens), m.label))
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// Styles
+var (
+	sectionStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(styles.ColorTextSecondary))
+	labelStyle   = lipgloss.NewStyle().Bold(true)
+	valueStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color(styles.ColorTextSecondary))
+	accentStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color(styles.ColorHighlight))
+)
+
+func formatCost(cost float64) string {
+	if cost < 0.0001 {
+		return "$0.00"
+	}
+	if cost < 0.01 {
+		return fmt.Sprintf("$%.4f", cost)
+	}
+	return fmt.Sprintf("$%.2f", cost)
+}
+
+func formatCostPadded(cost float64) string {
+	if cost < 0.0001 {
+		return "$0.0000"
+	}
+	if cost < 1 {
+		return fmt.Sprintf("$%.4f", cost)
+	}
+	return fmt.Sprintf("$%.2f", cost)
+}
+
+func formatTokenCount(count int64) string {
+	switch {
+	case count >= 1_000_000:
+		return fmt.Sprintf("%.1fM", float64(count)/1_000_000)
+	case count >= 1_000:
+		return fmt.Sprintf("%.1fK", float64(count)/1_000)
+	default:
+		return fmt.Sprintf("%d", count)
+	}
+}
+
+func padRight(s string) string {
+	const width = 8
+	if len(s) >= width {
+		return s
+	}
+	return s + strings.Repeat(" ", width-len(s))
+}

--- a/pkg/tui/dialog/cost_test.go
+++ b/pkg/tui/dialog/cost_test.go
@@ -1,0 +1,167 @@
+package dialog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/cagent/pkg/chat"
+	"github.com/docker/cagent/pkg/session"
+	"github.com/docker/cagent/pkg/tools"
+)
+
+func TestNewCostDialog(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+
+	dialog := NewCostDialog(sess)
+
+	require.NotNil(t, dialog)
+}
+
+func TestCostDialogView(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+
+	// Add some messages with usage info
+	sess.AddMessage(&session.Message{
+		AgentName: "root",
+		Message: chat.Message{
+			Role:    chat.MessageRoleAssistant,
+			Content: "Hello",
+			Model:   "gpt-4o",
+			Usage: &chat.Usage{
+				InputTokens:  1000,
+				OutputTokens: 500,
+			},
+			Cost: 0.005,
+		},
+	})
+
+	sess.AddMessage(&session.Message{
+		AgentName: "root",
+		Message: chat.Message{
+			Role:    chat.MessageRoleAssistant,
+			Content: "World",
+			Model:   "gpt-4o",
+			Usage: &chat.Usage{
+				InputTokens:       800,
+				OutputTokens:      300,
+				CachedInputTokens: 200,
+			},
+			Cost: 0.003,
+		},
+	})
+
+	dialog := NewCostDialog(sess)
+	// Set a large enough window size
+	dialog.SetSize(100, 50)
+	view := dialog.View()
+
+	// Check that the view contains expected content
+	// The title may be split across lines due to narrow width
+	assert.Contains(t, view, "Session Cost")
+	assert.Contains(t, view, "Total")
+	assert.Contains(t, view, "By Model")
+	assert.Contains(t, view, "gpt-4o")
+}
+
+func TestCostDialogWithToolCalls(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+
+	// Add message with tool calls
+	sess.AddMessage(&session.Message{
+		AgentName: "root",
+		Message: chat.Message{
+			Role:    chat.MessageRoleAssistant,
+			Content: "Let me help you",
+			Model:   "claude-sonnet-4-0",
+			ToolCalls: []tools.ToolCall{
+				{ID: "call_1", Function: tools.FunctionCall{Name: "shell", Arguments: `{"cmd":"ls"}`}},
+			},
+			Usage: &chat.Usage{
+				InputTokens:  2000,
+				OutputTokens: 100,
+			},
+			Cost: 0.01,
+		},
+	})
+
+	dialog := NewCostDialog(sess)
+	// Set a large enough window size
+	dialog.SetSize(100, 50)
+	view := dialog.View()
+
+	// Model name may be split across lines
+	assert.Contains(t, view, "claude")
+	assert.Contains(t, view, "$0.01")
+}
+
+func TestCostDialogEmptySession(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+
+	dialog := NewCostDialog(sess)
+	// Set a large enough window size
+	dialog.SetSize(100, 50)
+	view := dialog.View()
+
+	// Should still render without errors
+	assert.Contains(t, view, "Session Cost")
+	assert.Contains(t, view, "Total")
+	assert.Contains(t, view, "$0.00") // Zero cost
+}
+
+func TestFormatCost(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		cost     float64
+		expected string
+	}{
+		{0.0, "$0.00"},
+		{0.00001, "$0.00"},
+		{0.0001, "$0.0001"},
+		{0.001, "$0.0010"},
+		{0.01, "$0.01"},
+		{0.1, "$0.10"},
+		{1.0, "$1.00"},
+		{10.5, "$10.50"},
+	}
+
+	for _, tt := range tests {
+		result := formatCost(tt.cost)
+		assert.Equal(t, tt.expected, result, "formatCost(%f)", tt.cost)
+	}
+}
+
+func TestFormatTokenCount(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		count    int64
+		expected string
+	}{
+		{0, "0"},
+		{100, "100"},
+		{999, "999"},
+		{1000, "1.0K"},
+		{1500, "1.5K"},
+		{10000, "10.0K"},
+		{999999, "1000.0K"},
+		{1000000, "1.0M"},
+		{1500000, "1.5M"},
+		{10000000, "10.0M"},
+	}
+
+	for _, tt := range tests {
+		result := formatTokenCount(tt.count)
+		assert.Equal(t, tt.expected, result, "formatTokenCount(%d)", tt.count)
+	}
+}

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -172,6 +172,13 @@ func (a *appModel) handleToggleHideToolResults() (tea.Model, tea.Cmd) {
 	return a, cmd
 }
 
+func (a *appModel) handleShowCostDialog() (tea.Model, tea.Cmd) {
+	sess := a.application.Session()
+	return a, core.CmdHandler(dialog.OpenDialogMsg{
+		Model: dialog.NewCostDialog(sess),
+	})
+}
+
 // MCP prompt handlers
 
 func (a *appModel) handleShowMCPPromptInput(promptName string, promptInfo any) (tea.Model, tea.Cmd) {

--- a/pkg/tui/messages/messages.go
+++ b/pkg/tui/messages/messages.go
@@ -8,6 +8,7 @@ type (
 	CompactSessionMsg         struct{ AdditionalPrompt string }
 	CopySessionToClipboardMsg struct{}
 	ExportSessionMsg          struct{ Filename string }
+	ShowCostDialogMsg         struct{}
 	ToggleYoloMsg             struct{}
 	ToggleHideToolResultsMsg  struct{}
 	StartShellMsg             struct{}

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -278,6 +278,9 @@ func (a *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case messages.ToggleHideToolResultsMsg:
 		return a.handleToggleHideToolResults()
 
+	case messages.ShowCostDialogMsg:
+		return a.handleShowCostDialog()
+
 	case messages.AgentCommandMsg:
 		return a.handleAgentCommand(msg.Command)
 


### PR DESCRIPTION
Introduces a new /cost command that displays a dialog with comprehensive cost information including:

- Total: cost, input tokens (with cache breakdown), output tokens
- By Model: per-model cost and token usage breakdown
- By Message: per-message cost and token usage

Features:
- Scrollable dialog for sessions with many messages
- Copy to clipboard with 'c' key
- Per-message usage tracking stored on chat.Message
- Falls back to session-level totals for legacy sessions

The command is accessible via /cost in the editor or through the command palette (Ctrl+P).

Assisted-By: cagent