### PR TITLE
Fix sidebar green text background to be transparent

### DIFF
--- a/pkg/tui/styles/styles.go
+++ b/pkg/tui/styles/styles.go
@@ -278,8 +278,7 @@ var (
 			Foreground(TextPrimary)
 
 	TabAccentStyle = BaseStyle.
-			Foreground(TabAccentFg).
-			Background(TabBg)
+			Foreground(TabAccentFg)
 )
 
 // Command Palette Styles


### PR DESCRIPTION
Remove background color from TabAccentStyle to make green accent text in the sidebar have transparent backgrounds instead of grayish ones.

Affects:
- Agent names
- Cost display symbols
- Directory path indicators
- Agent status indicators
- Tools available indicators
- Toggle checkmarks

The green foreground color (#99f868) is preserved while removing the gray background (#25252c).

Assisted-By: cagent