### PR TITLE
Fix inconsistent decimal formatting in cost dialog

### DIFF
--- a/pkg/tui/dialog/cost.go
+++ b/pkg/tui/dialog/cost.go
@@ -345,10 +345,10 @@ func formatCostPadded(cost float64) string {
 	if cost < 0.0001 {
 		return "$0.0000"
 	}
-	if cost < 1 {
+	if cost < 0.01 {
 		return fmt.Sprintf("$%.4f", cost)
 	}
-	return fmt.Sprintf("$%.2f", cost)
+	return fmt.Sprintf("$%.2f  ", cost)
 }
 
 func formatTokenCount(count int64) string {


### PR DESCRIPTION
Align formatCostPadded threshold with formatCost so both use 4 decimals for costs < $0.01 and 2 decimals otherwise. This ensures total cost and per-model/per-message costs display with matching precision.

Assisted-By: cagent