### PR TITLE
Expand $EDITOR in the TUI

### DIFF
--- a/pkg/tui/page/chat/chat_test.go
+++ b/pkg/tui/page/chat/chat_test.go
@@ -1,0 +1,112 @@
+package chat
+
+import (
+	"testing"
+)
+
+func TestGetEditorDisplayNameFromEnv(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		visual    string
+		editorEnv string
+		want      string
+	}{
+		{
+			name:      "VSCode",
+			visual:    "",
+			editorEnv: "code",
+			want:      "VSCode",
+		},
+		{
+			name:      "VSCode with args",
+			visual:    "",
+			editorEnv: "code --wait",
+			want:      "VSCode",
+		},
+		{
+			name:      "VSCode with full path",
+			visual:    "",
+			editorEnv: "/usr/local/bin/code --wait",
+			want:      "VSCode",
+		},
+		{
+			name:      "Vim",
+			visual:    "",
+			editorEnv: "vim",
+			want:      "Vim",
+		},
+		{
+			name:      "Neovim",
+			visual:    "",
+			editorEnv: "nvim",
+			want:      "Neovim",
+		},
+		{
+			name:      "Cursor",
+			visual:    "",
+			editorEnv: "cursor",
+			want:      "Cursor",
+		},
+		{
+			name:      "Unknown editor",
+			visual:    "",
+			editorEnv: "myeditor",
+			want:      "Myeditor",
+		},
+		{
+			name:      "Unknown editor with full path",
+			visual:    "",
+			editorEnv: "/opt/bin/myeditor",
+			want:      "Myeditor",
+		},
+		{
+			name:      "Empty (uses platform default)",
+			visual:    "",
+			editorEnv: "",
+			want:      "Vi", // On non-Windows platforms, falls back to vi
+		},
+		{
+			name:      "VSCode Insiders",
+			visual:    "",
+			editorEnv: "code-insiders",
+			want:      "VSCode",
+		},
+		{
+			name:      "Neovim Qt",
+			visual:    "",
+			editorEnv: "nvim-qt",
+			want:      "Neovim",
+		},
+		{
+			name:      "Vim GTK",
+			visual:    "",
+			editorEnv: "vim-gtk3",
+			want:      "Vim",
+		},
+		{
+			name:      "VISUAL takes precedence over EDITOR",
+			visual:    "code",
+			editorEnv: "vim",
+			want:      "VSCode",
+		},
+		{
+			name:      "VISUAL with args takes precedence",
+			visual:    "code --wait",
+			editorEnv: "vim",
+			want:      "VSCode",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := getEditorDisplayNameFromEnv(tt.visual, tt.editorEnv)
+			if got != tt.want {
+				t.Errorf("getEditorDisplayNameFromEnv(%q, %q) = %v, want %v", tt.visual, tt.editorEnv, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/tui/page/chat/editor.go
+++ b/pkg/tui/page/chat/editor.go
@@ -41,7 +41,7 @@ func (p *chatPage) openExternalEditor() tea.Cmd {
 		if runtime.GOOS == "windows" {
 			editorCmd = "notepad"
 		} else {
-			editorCmd = "vim"
+			editorCmd = "vi"
 		}
 	}
 


### PR DESCRIPTION
Expand $EDITOR to actual editor name in TUI help text

  The TUI help footer now displays the actual configured editor name instead of the literal
  string "$EDITOR".

  Before: Ctrl+g edit in $EDITOR
  After: Ctrl+g edit in VSCode (or Vim, Neovim, Cursor, etc.)

  The implementation:
  - Reads VISUAL or EDITOR environment variables
  - Extracts base command name from paths and arguments
  - Maps common editors (code, vim, nvim, cursor, etc.) to friendly display names
  - Falls back to capitalized base name for unknown editors
  - Returns "$EDITOR" if not configured

so moving from
<img width="314" height="66" alt="Screenshot 2026-01-07 at 19 33 50" src="https://github.com/user-attachments/assets/cb50d72b-b347-4800-8dd0-4e3ddbc28b36" />
to
<img width="230" height="40" alt="Screenshot 2026-01-07 at 19 34 22" src="https://github.com/user-attachments/assets/7472e739-2fae-4827-8851-f2d9f6f0d662" />

