### PR TITLE
Retry starting MCP servers if ther had errors

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -164,8 +164,6 @@ func (a *Agent) ToolSets() []tools.ToolSet {
 
 func (a *Agent) ensureToolSetsAreStarted(ctx context.Context) {
 	for _, toolSet := range a.toolsets {
-		// Start() uses sync.Once internally, so concurrent calls are safe
-		// and will block until the first call completes.
 		if err := toolSet.Start(ctx); err != nil {
 			slog.Warn("Toolset start failed; skipping", "agent", a.Name(), "toolset", fmt.Sprintf("%T", toolSet.ToolSet), "error", err)
 			a.addToolWarning(fmt.Sprintf("%T start failed: %v", toolSet.ToolSet, err))

--- a/pkg/agent/opts_test.go
+++ b/pkg/agent/opts_test.go
@@ -1,0 +1,45 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/cagent/pkg/tools"
+)
+
+type flakyStartToolset struct {
+	tools.BaseToolSet
+	calls atomic.Int64
+}
+
+func (f *flakyStartToolset) Start(context.Context) error {
+	if f.calls.Add(1) == 1 {
+		return errors.New("no events channel available for elicitation")
+	}
+	return nil
+}
+
+func (f *flakyStartToolset) Tools(context.Context) ([]tools.Tool, error) { return nil, nil }
+
+func TestStartableToolSet_RetriesAfterFailure(t *testing.T) {
+	ctx := t.Context()
+	inner := &flakyStartToolset{}
+	ts := &StartableToolSet{ToolSet: inner}
+
+	err := ts.Start(ctx)
+	require.Error(t, err)
+	require.False(t, ts.IsStarted())
+
+	err = ts.Start(ctx)
+	require.NoError(t, err)
+	require.True(t, ts.IsStarted())
+
+	// Once started, subsequent calls should not call inner.Start again.
+	err = ts.Start(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), inner.calls.Load())
+}


### PR DESCRIPTION
Handling remote OAuth MCP servers is very tricky. On the one hand we are trying to show the user how many tools they had as soon as possible, on the other hand remote MCP servers with OAuth all send a 401 on init.

With the sync.Once that was in place we would:

- emit startup info, which looks at the tools
- oauth would fail
- then when the user asks a question the remote MCP server is broken

To work around this, we no longer sync.Once starting mcp servers but only serialize them _but_ retry if there was an error.

This is not ideal but it works for now, it's hard to know when we really want to start MCP servers...

Fixes #1311 