### PR TITLE
Make sure the directory exists before creating or opening the database

### DIFF
--- a/pkg/session/store_test.go
+++ b/pkg/session/store_test.go
@@ -259,16 +259,6 @@ func TestStoreAgentNameJSON(t *testing.T) {
 	assert.Equal(t, "another-agent", retrievedSession.Messages[2].Message.AgentName) // Second agent
 }
 
-func TestNewSQLiteSessionStore_DirectoryDoesNotExist(t *testing.T) {
-	nonExistentPath := "/nonexistent/path/to/session.db"
-
-	_, err := NewSQLiteSessionStore(nonExistentPath)
-	require.Error(t, err)
-
-	assert.Contains(t, err.Error(), "cannot create database")
-	assert.Contains(t, err.Error(), "does not exist")
-}
-
 func TestNewSQLiteSessionStore_DirectoryNotWritable(t *testing.T) {
 	readOnlyDir := filepath.Join(t.TempDir(), "readonly")
 	err := os.Mkdir(readOnlyDir, 0o555)

--- a/pkg/sqliteutil/sqlite.go
+++ b/pkg/sqliteutil/sqlite.go
@@ -14,6 +14,11 @@ import (
 // OpenDB opens a SQLite database with recommended pragmas for concurrency and foreign key support.
 // It configures the connection pool for serialized writes (MaxOpenConns=1).
 func OpenDB(path string) (*sql.DB, error) {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("cannot create database directory %q: %w", dir, err)
+	}
+
 	// Add query parameters for better concurrency handling and data integrity
 	// _pragma=busy_timeout(5000): Wait up to 5 seconds if database is locked
 	// _pragma=journal_mode(WAL): Enable Write-Ahead Logging for better concurrent access


### PR DESCRIPTION
Running `docker run docker/cagent:1.18.7 run` fails with the error saying it can't create the database.

This error goes all the way back to v1.16.0, the weird thing is that 1.18.8 doesn't have this error, I'm not sure what is going on, looking at the diff of the 1.18.8 version there is nothing that I can see that would fix this...

In desperation let's just make sure that the directory where we want to store the database exists.

Fixes #1305 