### PR TITLE
Fix data race in telemetry package

### DIFF
--- a/pkg/telemetry/types.go
+++ b/pkg/telemetry/types.go
@@ -272,3 +272,17 @@ type Client struct {
 	// Session tracking
 	session SessionState
 }
+
+// setVersion safely sets the version with proper locking
+func (tc *Client) setVersion(version string) {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+	tc.version = version
+}
+
+// getVersion safely gets the version with proper locking
+func (tc *Client) getVersion() string {
+	tc.mu.RLock()
+	defer tc.mu.RUnlock()
+	return tc.version
+}


### PR DESCRIPTION
Add proper synchronization for global telemetry variables and Client.version field to prevent races between:
- SetGlobalTelemetryVersion writing globalTelemetryVersion
- EnsureGlobalTelemetryInitialized reading globalTelemetryVersion
- SetGlobalTelemetryVersion writing Client.version
- performHTTPRequest and createEvent reading Client.version

Changes:
- Add globalMu RWMutex to protect globalTelemetryVersion and globalTelemetryDebugMode
- Add setVersion/getVersion methods to Client for thread-safe version access
- Pass version as parameter to performHTTPRequest to avoid deadlock

Assisted-By: cagent