### PR TITLE
eval: don't add cost, it's already added in the runtime

### DIFF
--- a/pkg/evaluation/eval.go
+++ b/pkg/evaluation/eval.go
@@ -442,7 +442,7 @@ func parseContainerEvents(events []map[string]any) (response string, cost float6
 		case "token_usage":
 			if usage, ok := event["usage"].(map[string]any); ok {
 				if c, ok := usage["cost"].(float64); ok {
-					cost += c
+					cost = c
 				}
 				if tokens, ok := usage["output_tokens"].(float64); ok {
 					outputTokens += int64(tokens)

--- a/pkg/evaluation/eval_test.go
+++ b/pkg/evaluation/eval_test.go
@@ -484,7 +484,7 @@ func TestParseContainerEvents(t *testing.T) {
 				{
 					"type": "token_usage",
 					"usage": map[string]any{
-						"cost":          0.003,
+						"cost":          0.008,
 						"output_tokens": float64(50),
 					},
 				},


### PR DESCRIPTION
The runtime sends the _current_ sesion cost, it's already added with the already present cost, so we shouldn't add twice