### PR TITLE
Improve TUI rendering with thinking blocks and interleaved thinking

### DIFF
--- a/pkg/tui/styles/styles.go
+++ b/pkg/tui/styles/styles.go
@@ -516,9 +516,14 @@ var (
 // Agent and transfer badge styles
 var (
 	AgentBadgeStyle = BaseStyle.
-		Foreground(AgentBadgeFg).
-		Background(AgentBadgeBg).
-		Padding(0, 1)
+			Foreground(AgentBadgeFg).
+			Background(AgentBadgeBg).
+			Padding(0, 1)
+
+	ThinkingBadgeStyle = BaseStyle.
+				Foreground(TextMuted). // Muted blue, distinct from gray italic content
+				Bold(true).
+				Italic(true)
 )
 
 // Deprecated styles (kept for backward compatibility)


### PR DESCRIPTION
Misc rendering improvements related to thinking and interleaved thinking:
- Show agent name only when the agent actually changes, not when passing between thinking/regular content/tool calls
- Keep thinking indentation consistent with content and tool calls
- Make `Thinking: ` a proper badge with its own styling to differentiate from the thinking content
- Show thinking badge only when its the first thinking block, or when passing from normal content to a thought. Don't show it when going between thoughts and tool calls when interleaved thinking is enabled
- Remove double newlines after thinking content

---

### Screenshots 

Before:

<img width="1389" height="1152" alt="Screenshot 2026-01-08 at 17 09 50" src="https://github.com/user-attachments/assets/b140b8d1-42c9-48ea-bead-82ab3f7fdf18" />

---

After:

<img width="1389" height="1152" alt="Screenshot 2026-01-08 at 17 07 42" src="https://github.com/user-attachments/assets/2b829c4c-c428-4c84-95ce-020b7e06fada" />
