### PR TITLE
Make sidebars and the editor resize handler more sleek

### DIFF
--- a/pkg/tui/components/scrollbar/scrollbar.go
+++ b/pkg/tui/components/scrollbar/scrollbar.go
@@ -32,7 +32,7 @@ func New() *Model {
 	return &Model{
 		width:     1,
 		trackChar: "│",
-		thumbChar: "█",
+		thumbChar: "│",
 	}
 }
 
@@ -106,7 +106,11 @@ func (m *Model) View() string {
 		var char string
 
 		if i >= thumbTop && i < thumbTop+thumbHeight {
-			style = styles.ThumbStyle
+			if m.dragging {
+				style = styles.ThumbActiveStyle
+			} else {
+				style = styles.ThumbStyle
+			}
 			char = m.thumbChar
 		} else {
 			style = styles.TrackStyle

--- a/pkg/tui/styles/styles.go
+++ b/pkg/tui/styles/styles.go
@@ -446,8 +446,9 @@ var (
 
 // Scrollbar
 var (
-	TrackStyle = lipgloss.NewStyle().Foreground(BorderSecondary)
-	ThumbStyle = lipgloss.NewStyle().Foreground(Accent)
+	TrackStyle       = lipgloss.NewStyle().Foreground(BorderSecondary)
+	ThumbStyle       = lipgloss.NewStyle().Foreground(Info).Background(BackgroundAlt).Bold(true)
+	ThumbActiveStyle = lipgloss.NewStyle().Foreground(White).Background(BackgroundAlt).Bold(true)
 )
 
 // Resize Handle Style
@@ -456,10 +457,12 @@ var (
 				Foreground(BorderSecondary)
 
 	ResizeHandleHoverStyle = BaseStyle.
-				Foreground(Accent)
+				Foreground(Info).
+				Bold(true)
 
 	ResizeHandleActiveStyle = BaseStyle.
-				Foreground(lipgloss.Color(ColorTextPrimary))
+				Foreground(White).
+				Bold(true)
 )
 
 // Notification Styles


### PR DESCRIPTION
Some misc TUI visual improvements around scrollbars:

- Makes scrollbars a bit less intrusive and more sleek with a thinner bar and pseudo-glow effect + color change when clicking and dragging
- Makes sidebar scrollbar scrollable by clicking and dragging it
- Consolidates most of the styling and colors with the text input resize handler as well
- Keeps text input resize handler centered when "Working.." spinner is present

--- 

### Videos

Before:


https://github.com/user-attachments/assets/cf121544-a178-4097-b2e0-1bfd74bba3e2

---

After:


https://github.com/user-attachments/assets/f804e4cd-d8d8-41fb-b14f-23fe34b252e4

