### PR TITLE
Revert "refactor(content): make CreateReferenceLink method public"

### DIFF
--- a/pkg/content/store.go
+++ b/pkg/content/store.go
@@ -102,7 +102,7 @@ func (s *Store) StoreArtifact(img v1.Image, reference string) (string, error) {
 		return "", fmt.Errorf("saving metadata: %w", err)
 	}
 
-	if err := s.CreateReferenceLink(reference, digestStr); err != nil {
+	if err := s.createReferenceLink(reference, digestStr); err != nil {
 		return "", fmt.Errorf("creating reference link: %w", err)
 	}
 
@@ -261,8 +261,8 @@ func (s *Store) resolveReference(reference string) (string, error) {
 	return strings.TrimSpace(string(data)), nil
 }
 
-// CreateReferenceLink creates a link from reference to digest.
-func (s *Store) CreateReferenceLink(reference, digest string) error {
+// createReferenceLink creates a link from reference to digest
+func (s *Store) createReferenceLink(reference, digest string) error {
 	refsDir := filepath.Join(s.baseDir, "refs")
 	if err := os.MkdirAll(refsDir, 0o755); err != nil {
 		return fmt.Errorf("creating refs directory: %w", err)

--- a/pkg/content/store_test.go
+++ b/pkg/content/store_test.go
@@ -109,29 +109,3 @@ func TestStoreResolution(t *testing.T) {
 		assert.NotNil(t, img)
 	}
 }
-
-func TestCreateReferenceLink(t *testing.T) {
-	store, err := NewStore(WithBaseDir(t.TempDir()))
-	require.NoError(t, err)
-
-	testData := []byte("Test artifact")
-	layer := static.NewLayer(testData, types.OCIUncompressedLayer)
-	img := empty.Image
-	img, err = mutate.AppendLayers(img, layer)
-	require.NoError(t, err)
-
-	localRef := "org/repo:latest"
-	digest, err := store.StoreArtifact(img, localRef)
-	require.NoError(t, err)
-
-	// Create an additional reference link (simulates non-Docker Hub registry)
-	fullRef := "ghcr.io/org/repo:latest"
-	err = store.CreateReferenceLink(fullRef, digest)
-	require.NoError(t, err)
-
-	// Verify both references resolve to the same artifact
-	_, err = store.GetArtifactImage(localRef)
-	require.NoError(t, err)
-	_, err = store.GetArtifactImage(fullRef)
-	require.NoError(t, err)
-}

--- a/pkg/remote/pull.go
+++ b/pkg/remote/pull.go
@@ -19,10 +19,7 @@ func Pull(ctx context.Context, registryRef string, force bool, opts ...crane.Opt
 		return "", fmt.Errorf("parsing registry reference %s: %w", registryRef, err)
 	}
 
-	// Use the full reference string to preserve registry information
-	fullRef := ref.String()
-
-	remoteDigest, err := crane.Digest(fullRef, opts...)
+	remoteDigest, err := crane.Digest(ref.String(), opts...)
 	if err != nil {
 		return "", fmt.Errorf("resolving remote digest for %s: %w", registryRef, err)
 	}
@@ -32,18 +29,19 @@ func Pull(ctx context.Context, registryRef string, force bool, opts ...crane.Opt
 		return "", fmt.Errorf("creating content store: %w", err)
 	}
 
+	localRef := ref.Context().RepositoryStr() + separator(ref) + ref.Identifier()
 	if !force {
-		if meta, metaErr := store.GetArtifactMetadata(fullRef); metaErr == nil {
+		if meta, metaErr := store.GetArtifactMetadata(localRef); metaErr == nil {
 			if meta.Digest == remoteDigest {
 				if !hasCagentAnnotation(meta.Annotations) {
-					return "", fmt.Errorf("artifact %s found in store wasn't created by `cagent push`\nTry to push again with `cagent push` (cagent >= v1.10.0)", fullRef)
+					return "", fmt.Errorf("artifact %s found in store wasn't created by `cagent push`\nTry to push again with `cagent push` (cagent >= v1.10.0)", localRef)
 				}
 				return meta.Digest, nil
 			}
 		}
 	}
 
-	img, err := crane.Pull(fullRef, opts...)
+	img, err := crane.Pull(ref.String(), opts...)
 	if err != nil {
 		return "", fmt.Errorf("pulling image from registry %s: %w", registryRef, err)
 	}
@@ -53,10 +51,10 @@ func Pull(ctx context.Context, registryRef string, force bool, opts ...crane.Opt
 		return "", fmt.Errorf("getting manifest from pulled image: %w", err)
 	}
 	if !hasCagentAnnotation(manifest.Annotations) {
-		return "", fmt.Errorf("artifact %s wasn't created by `cagent push`\nTry to push again with `cagent push` (cagent >= v1.10.0)", fullRef)
+		return "", fmt.Errorf("artifact %s wasn't created by `cagent push`\nTry to push again with `cagent push` (cagent >= v1.10.0)", localRef)
 	}
 
-	digest, err := store.StoreArtifact(img, fullRef)
+	digest, err := store.StoreArtifact(img, localRef)
 	if err != nil {
 		return "", fmt.Errorf("storing artifact in content store: %w", err)
 	}
@@ -67,4 +65,13 @@ func Pull(ctx context.Context, registryRef string, force bool, opts ...crane.Opt
 func hasCagentAnnotation(annotations map[string]string) bool {
 	_, exists := annotations["io.docker.cagent.version"]
 	return exists
+}
+
+// separator returns the separator used between repository and identifier.
+// For digests it returns "@", for tags it returns ":".
+func separator(ref name.Reference) string {
+	if _, ok := ref.(name.Digest); ok {
+		return "@"
+	}
+	return ":"
 }

--- a/pkg/remote/pull_test.go
+++ b/pkg/remote/pull_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/static"
@@ -69,4 +70,43 @@ func TestPullIntegration(t *testing.T) {
 
 	err = Push("invalid:reference:with:too:many:colons")
 	require.Error(t, err)
+}
+
+func TestSeparator(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		ref      string
+		expected string
+	}{
+		{
+			name:     "tag reference uses colon",
+			ref:      "docker.io/library/alpine:latest",
+			expected: ":",
+		},
+		{
+			name:     "digest reference uses at sign",
+			ref:      "docker.io/library/alpine@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+			expected: "@",
+		},
+		{
+			name:     "short tag reference uses colon",
+			ref:      "alpine:v1.0",
+			expected: ":",
+		},
+		{
+			name:     "short digest reference uses at sign",
+			ref:      "alpine@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+			expected: "@",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ref, err := name.ParseReference(tt.ref)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, separator(ref))
+		})
+	}
 }


### PR DESCRIPTION
This reverts commit 1099753243dca8ff5b358a6206d1f940769815d7.

Something's wrong with this, when I try to run an agent I get

> failed to load agent from store: reference .....:latest not found: open /Users/rumpl/.cagent/store/refs/305d11e9bbf36d87132508a60da1f59d750bd9a10c495d7df6cf11bb9bdc9acc: no such file or directory

Revert for now, we'll fix it later