### PR TITLE
Improve sidebar layout

### DIFF
--- a/pkg/tui/components/scrollbar/scrollbar.go
+++ b/pkg/tui/components/scrollbar/scrollbar.go
@@ -9,6 +9,9 @@ import (
 	"github.com/docker/cagent/pkg/tui/styles"
 )
 
+// Width is the intrinsic width of the scrollbar component in terminal columns.
+const Width = 1
+
 type Model struct {
 	totalHeight  int
 	viewHeight   int
@@ -30,7 +33,7 @@ type Model struct {
 
 func New() *Model {
 	return &Model{
-		width:     1,
+		width:     Width,
 		trackChar: "│",
 		thumbChar: "│",
 	}

--- a/pkg/tui/components/sidebar/layout.go
+++ b/pkg/tui/components/sidebar/layout.go
@@ -1,0 +1,94 @@
+package sidebar
+
+import "github.com/docker/cagent/pkg/tui/components/scrollbar"
+
+// Layout constants for sidebar elements.
+const (
+	// treePrefixWidth is the width of tree-structure prefixes like "├ " and "└ ".
+	treePrefixWidth = 2
+
+	// starClickWidth is the clickable area width for the star indicator.
+	starClickWidth = 2
+
+	// verticalStarY is the Y position of the star in vertical mode.
+	// Line 0: tab title, Line 1: TabStyle top padding, Line 2: star + title.
+	verticalStarY = 2
+
+	// headerLines is the number of lines reserved for non-scrollable header content.
+	headerLines = 1
+)
+
+// LayoutConfig defines the spacing and sizing parameters for the sidebar.
+// All values are in terminal columns.
+//
+// Layout diagram for vertical mode:
+//
+//	|<-- outerWidth (m.width) ----------------------->|
+//	|<-PL->|<-- contentWidth -->|<-SG->|<-SW->|
+//	|      |   Tab Title────────|      |  │   |
+//	|      |   Content here     |      |  │   |
+//	|      |                    |      |  │   |
+//
+// PL = PaddingLeft, SG = ScrollbarGap, SW = scrollbar.Width
+type LayoutConfig struct {
+	// PaddingLeft is the space between the left edge of the sidebar and content.
+	// This replaces the external wrapper padding that was previously in chat.go.
+	PaddingLeft int
+	// PaddingRight is the space between the content and the right edge (when no scrollbar).
+	PaddingRight int
+	// ScrollbarGap is the space between content and the scrollbar when visible.
+	ScrollbarGap int
+}
+
+// DefaultLayoutConfig returns the default sidebar layout configuration.
+func DefaultLayoutConfig() LayoutConfig {
+	return LayoutConfig{
+		PaddingLeft:  1,
+		PaddingRight: 0,
+		ScrollbarGap: 1,
+	}
+}
+
+// Metrics holds the computed layout metrics for a given render pass.
+type Metrics struct {
+	// OuterWidth is the total width allocated to the sidebar.
+	OuterWidth int
+	// ContentWidth is the width available for actual content (tabs, text, etc.).
+	ContentWidth int
+	// ScrollbarVisible indicates whether the scrollbar will be rendered.
+	ScrollbarVisible bool
+	// config is the layout config used to compute these metrics.
+	config LayoutConfig
+}
+
+// Compute calculates the layout metrics for the given outer width and scrollbar visibility.
+func (cfg LayoutConfig) Compute(outerWidth int, scrollbarVisible bool) Metrics {
+	contentWidth := outerWidth - cfg.PaddingLeft - cfg.PaddingRight
+	if scrollbarVisible {
+		contentWidth -= scrollbar.Width + cfg.ScrollbarGap
+	}
+	if contentWidth < 1 {
+		contentWidth = 1
+	}
+	return Metrics{
+		OuterWidth:       outerWidth,
+		ContentWidth:     contentWidth,
+		ScrollbarVisible: scrollbarVisible,
+		config:           cfg,
+	}
+}
+
+// PaddingLeft returns the left padding from the config.
+func (m Metrics) PaddingLeft() int {
+	return m.config.PaddingLeft
+}
+
+// PaddingRight returns the right padding from the config.
+func (m Metrics) PaddingRight() int {
+	return m.config.PaddingRight
+}
+
+// ScrollbarGap returns the scrollbar gap from the config.
+func (m Metrics) ScrollbarGap() int {
+	return m.config.ScrollbarGap
+}

--- a/pkg/tui/components/sidebar/layout_test.go
+++ b/pkg/tui/components/sidebar/layout_test.go
@@ -1,0 +1,144 @@
+package sidebar
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/cagent/pkg/tui/components/scrollbar"
+)
+
+func TestDefaultLayoutConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultLayoutConfig()
+
+	assert.Equal(t, 1, cfg.PaddingLeft, "default PaddingLeft should be 1")
+	assert.Equal(t, 0, cfg.PaddingRight, "default PaddingRight should be 0")
+	assert.Equal(t, 1, cfg.ScrollbarGap, "default ScrollbarGap should be 1")
+}
+
+func TestScrollbarWidthConstant(t *testing.T) {
+	t.Parallel()
+
+	// Verify scrollbar.Width is the expected value
+	assert.Equal(t, 1, scrollbar.Width, "scrollbar.Width constant should be 1")
+}
+
+func TestLayoutConfigCompute(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		config           LayoutConfig
+		outerWidth       int
+		scrollbarVisible bool
+		wantContentWidth int
+	}{
+		{
+			name:             "default config without scrollbar",
+			config:           DefaultLayoutConfig(),
+			outerWidth:       40,
+			scrollbarVisible: false,
+			wantContentWidth: 39, // 40 - 1 (paddingLeft) - 0 (paddingRight)
+		},
+		{
+			name:             "default config with scrollbar",
+			config:           DefaultLayoutConfig(),
+			outerWidth:       40,
+			scrollbarVisible: true,
+			wantContentWidth: 37, // 40 - 1 (paddingLeft) - 0 (paddingRight) - 1 (scrollbarWidth) - 1 (scrollbarGap)
+		},
+		{
+			name: "custom config without scrollbar",
+			config: LayoutConfig{
+				PaddingLeft:  2,
+				PaddingRight: 1,
+				ScrollbarGap: 2,
+			},
+			outerWidth:       50,
+			scrollbarVisible: false,
+			wantContentWidth: 47, // 50 - 2 - 1
+		},
+		{
+			name: "custom config with scrollbar",
+			config: LayoutConfig{
+				PaddingLeft:  2,
+				PaddingRight: 1,
+				ScrollbarGap: 2,
+			},
+			outerWidth:       50,
+			scrollbarVisible: true,
+			wantContentWidth: 44, // 50 - 2 - 1 - 1 (scrollbarWidth constant) - 2
+		},
+		{
+			name:             "minimum content width",
+			config:           DefaultLayoutConfig(),
+			outerWidth:       2,
+			scrollbarVisible: true,
+			wantContentWidth: 1, // Should never go below 1
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			metrics := tt.config.Compute(tt.outerWidth, tt.scrollbarVisible)
+
+			assert.Equal(t, tt.outerWidth, metrics.OuterWidth)
+			assert.Equal(t, tt.wantContentWidth, metrics.ContentWidth)
+			assert.Equal(t, tt.scrollbarVisible, metrics.ScrollbarVisible)
+		})
+	}
+}
+
+func TestMetricsAccessors(t *testing.T) {
+	t.Parallel()
+
+	cfg := LayoutConfig{
+		PaddingLeft:  3,
+		PaddingRight: 2,
+		ScrollbarGap: 2,
+	}
+
+	metrics := cfg.Compute(50, true)
+
+	assert.Equal(t, 3, metrics.PaddingLeft())
+	assert.Equal(t, 2, metrics.PaddingRight())
+	assert.Equal(t, 2, metrics.ScrollbarGap())
+}
+
+func TestScrollbarGapInOutput(t *testing.T) {
+	t.Parallel()
+
+	// This test verifies that when a scrollbar is rendered,
+	// there's a visible gap between the content and the scrollbar.
+	cfg := DefaultLayoutConfig()
+	require.Equal(t, 1, cfg.ScrollbarGap, "test requires ScrollbarGap of 1")
+
+	// Simulate what verticalView does when scrollbar is visible
+	contentWidth := cfg.Compute(40, true).ContentWidth
+	gap := strings.Repeat(" ", cfg.ScrollbarGap)
+	scrollbarView := "│" // Simplified scrollbar representation
+
+	// Create a sample content line
+	contentLine := strings.Repeat("x", contentWidth)
+
+	// Join them as the sidebar does
+	combined := contentLine + gap + scrollbarView
+
+	// Verify the total width matches expected
+	expectedWidth := contentWidth + cfg.ScrollbarGap + scrollbar.Width
+	actualWidth := lipgloss.Width(combined)
+
+	assert.Equal(t, expectedWidth, actualWidth,
+		"combined line should have content + gap + scrollbar width")
+
+	// Verify there's actually a space between content and scrollbar
+	assert.Contains(t, combined, " │",
+		"there should be a space (gap) before the scrollbar")
+}

--- a/pkg/tui/components/tool/todotool/sidebar.go
+++ b/pkg/tui/components/tool/todotool/sidebar.go
@@ -3,6 +3,8 @@ package todotool
 import (
 	"strings"
 
+	"charm.land/lipgloss/v2"
+
 	"github.com/docker/cagent/pkg/tools"
 	"github.com/docker/cagent/pkg/tools/builtin"
 	"github.com/docker/cagent/pkg/tui/components/tab"
@@ -56,12 +58,14 @@ func (c *SidebarComponent) Render() string {
 func (c *SidebarComponent) renderTodoLine(todo builtin.Todo) string {
 	icon, style := renderTodoIcon(todo.Status)
 
-	maxDescWidth := c.width - 4
+	// Compute prefix width dynamically (icon + space separator)
+	prefix := icon + " "
+	maxDescWidth := c.width - lipgloss.Width(prefix)
 	description := toolcommon.TruncateText(todo.Description, maxDescWidth)
 
-	return styles.TabPrimaryStyle.Render(style.Render(icon + " " + description))
+	return styles.TabPrimaryStyle.Render(style.Render(prefix + description))
 }
 
 func (c *SidebarComponent) renderTab(title, content string) string {
-	return tab.Render(title, content, c.width-2)
+	return tab.Render(title, content, c.width)
 }

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -396,7 +396,6 @@ func (p *chatPage) View() string {
 		sidebarView := lipgloss.NewStyle().
 			Width(sidebarWidth).
 			Height(p.chatHeight).
-			PaddingLeft(1).
 			Align(lipgloss.Left, lipgloss.Top).
 			Render(p.sidebar.View())
 
@@ -673,10 +672,10 @@ func (p *chatPage) handleSidebarClick(x, y int) bool {
 	chatWidth := max(1, innerWidth-sidebarWidth)
 
 	// Check if click is in the sidebar area (right side)
-	// sidebarView has PaddingLeft(1), so we need to account for that
+	// Sidebar now owns its own left padding via layoutCfg
 	if adjustedX >= chatWidth {
-		// Calculate x relative to sidebar content (after the 1-char padding)
-		sidebarX := adjustedX - chatWidth - 1 // -1 for sidebarView's PaddingLeft(1)
+		// Calculate x relative to sidebar's outer boundary
+		sidebarX := adjustedX - chatWidth
 		return p.sidebar.HandleClick(sidebarX, y)
 	}
 	return false


### PR DESCRIPTION
Refactor sidebar with misc layout improvements to make it less fragile and easier to maintain

- Give scrollbar component its own width
- Give sidebar configurable layout settings
- Get rid of many magic numbers in layout calculations so things are easier to maintain
- Dynamic sidebar padding based on scrollbar presence

---

### Videos

Before:

https://github.com/user-attachments/assets/4dc75410-0f34-479c-a7c6-11a99ec70135

---

After:

https://github.com/user-attachments/assets/7141a40b-c52d-419c-8c77-f86e8f7f268d


