### PR TITLE
Don't resolve model aliases when base_url is used

### DIFF
--- a/pkg/config/model_alias.go
+++ b/pkg/config/model_alias.go
@@ -12,6 +12,11 @@ import (
 // ResolveModelAliases resolves model aliases to their pinned versions in the config.
 // For example, "claude-sonnet-4-5" might resolve to "claude-sonnet-4-5-20250929".
 // This modifies the config in place.
+//
+// NOTE: Alias resolution is skipped for models with custom base_url configurations,
+// either set directly on the model or inherited from a custom provider definition.
+// This is necessary because external providers (like Azure Foundry) may use the alias
+// names directly as deployment names rather than the pinned version names.
 func ResolveModelAliases(ctx context.Context, cfg *latest.Config) {
 	store, err := modelsdev.NewStore()
 	if err != nil {
@@ -21,6 +26,14 @@ func ResolveModelAliases(ctx context.Context, cfg *latest.Config) {
 
 	// Resolve model aliases in the models section
 	for name, modelCfg := range cfg.Models {
+		// Skip alias resolution for models with custom base_url (direct or via provider)
+		// Custom endpoints like Azure Foundry use alias names as deployment names
+		if hasCustomBaseURL(&modelCfg, cfg.Providers) {
+			slog.Debug("Skipping model alias resolution for model with custom base_url",
+				"model_name", name, "provider", modelCfg.Provider, "model", modelCfg.Model)
+			continue
+		}
+
 		if resolved := store.ResolveModelAlias(ctx, modelCfg.Provider, modelCfg.Model); resolved != modelCfg.Model {
 			modelCfg.Model = resolved
 			cfg.Models[name] = modelCfg
@@ -57,4 +70,22 @@ func ResolveModelAliases(ctx context.Context, cfg *latest.Config) {
 		agentCfg.Model = strings.Join(resolvedModels, ",")
 		cfg.Agents[agentName] = agentCfg
 	}
+}
+
+// hasCustomBaseURL checks if a model config has a custom base_url, either directly
+// or through a referenced provider definition.
+func hasCustomBaseURL(modelCfg *latest.ModelConfig, providers map[string]latest.ProviderConfig) bool {
+	// Check if the model has a direct base_url
+	if modelCfg.BaseURL != "" {
+		return true
+	}
+
+	// Check if the model references a provider with a base_url
+	if providers != nil && modelCfg.Provider != "" {
+		if providerCfg, exists := providers[modelCfg.Provider]; exists {
+			return providerCfg.BaseURL != ""
+		}
+	}
+
+	return false
 }

--- a/pkg/config/model_alias_test.go
+++ b/pkg/config/model_alias_test.go
@@ -153,12 +153,190 @@ func TestResolveModelAliases(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "skips resolution for model with direct base_url",
+			cfg: &latest.Config{
+				Models: map[string]latest.ModelConfig{
+					"azure_model": {
+						Provider: "anthropic",
+						Model:    "claude-sonnet-4-5",
+						BaseURL:  "https://my-foundry.ai.azure.com/anthropic/v1",
+					},
+				},
+			},
+			expected: &latest.Config{
+				Models: map[string]latest.ModelConfig{
+					"azure_model": {
+						Provider: "anthropic",
+						Model:    "claude-sonnet-4-5", // NOT resolved - has custom base_url
+						BaseURL:  "https://my-foundry.ai.azure.com/anthropic/v1",
+					},
+				},
+			},
+		},
+		{
+			name: "skips resolution for model referencing provider with base_url",
+			cfg: &latest.Config{
+				Providers: map[string]latest.ProviderConfig{
+					"azure_foundry": {
+						BaseURL:  "https://my-foundry.ai.azure.com/anthropic/v1",
+						TokenKey: "AZURE_API_KEY",
+					},
+				},
+				Models: map[string]latest.ModelConfig{
+					"azure_model": {
+						Provider: "azure_foundry",
+						Model:    "claude-sonnet-4-5",
+					},
+				},
+			},
+			expected: &latest.Config{
+				Providers: map[string]latest.ProviderConfig{
+					"azure_foundry": {
+						BaseURL:  "https://my-foundry.ai.azure.com/anthropic/v1",
+						TokenKey: "AZURE_API_KEY",
+					},
+				},
+				Models: map[string]latest.ModelConfig{
+					"azure_model": {
+						Provider: "azure_foundry",
+						Model:    "claude-sonnet-4-5", // NOT resolved - provider has custom base_url
+					},
+				},
+			},
+		},
+		{
+			name: "does not resolve when custom provider name is used",
+			// Note: Custom provider names (not in models.dev) won't resolve because
+			// we can't determine if the underlying API supports the aliased model.
+			// This is expected behavior - only standard provider names are resolved.
+			cfg: &latest.Config{
+				Providers: map[string]latest.ProviderConfig{
+					"my_anthropic": {
+						TokenKey: "MY_ANTHROPIC_KEY",
+						// No BaseURL - but custom provider name means no resolution
+					},
+				},
+				Models: map[string]latest.ModelConfig{
+					"my_model": {
+						Provider: "my_anthropic",
+						Model:    "claude-sonnet-4-5",
+					},
+				},
+			},
+			expected: &latest.Config{
+				Providers: map[string]latest.ProviderConfig{
+					"my_anthropic": {
+						TokenKey: "MY_ANTHROPIC_KEY",
+					},
+				},
+				Models: map[string]latest.ModelConfig{
+					"my_model": {
+						Provider: "my_anthropic",
+						Model:    "claude-sonnet-4-5", // NOT resolved - custom provider name
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ResolveModelAliases(ctx, tt.cfg)
 			assert.Equal(t, tt.expected, tt.cfg)
+		})
+	}
+}
+
+func TestHasCustomBaseURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		modelCfg  *latest.ModelConfig
+		providers map[string]latest.ProviderConfig
+		expected  bool
+	}{
+		{
+			name: "no base_url anywhere",
+			modelCfg: &latest.ModelConfig{
+				Provider: "anthropic",
+				Model:    "claude-sonnet-4-5",
+			},
+			providers: nil,
+			expected:  false,
+		},
+		{
+			name: "direct base_url on model",
+			modelCfg: &latest.ModelConfig{
+				Provider: "anthropic",
+				Model:    "claude-sonnet-4-5",
+				BaseURL:  "https://custom.example.com/v1",
+			},
+			providers: nil,
+			expected:  true,
+		},
+		{
+			name: "base_url from provider",
+			modelCfg: &latest.ModelConfig{
+				Provider: "my_provider",
+				Model:    "claude-sonnet-4-5",
+			},
+			providers: map[string]latest.ProviderConfig{
+				"my_provider": {
+					BaseURL:  "https://custom.example.com/v1",
+					TokenKey: "MY_KEY",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "provider exists but no base_url",
+			modelCfg: &latest.ModelConfig{
+				Provider: "my_provider",
+				Model:    "claude-sonnet-4-5",
+			},
+			providers: map[string]latest.ProviderConfig{
+				"my_provider": {
+					TokenKey: "MY_KEY",
+					// No BaseURL
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "provider not found in providers map",
+			modelCfg: &latest.ModelConfig{
+				Provider: "nonexistent",
+				Model:    "claude-sonnet-4-5",
+			},
+			providers: map[string]latest.ProviderConfig{
+				"other_provider": {
+					BaseURL: "https://other.example.com/v1",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "empty provider name",
+			modelCfg: &latest.ModelConfig{
+				Provider: "",
+				Model:    "claude-sonnet-4-5",
+			},
+			providers: map[string]latest.ProviderConfig{
+				"my_provider": {
+					BaseURL: "https://custom.example.com/v1",
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := hasCustomBaseURL(tt.modelCfg, tt.providers)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }


### PR DESCRIPTION
When `base_url` is defined on a model configuration, we don't know exactly what the provider may be expecting, so don't resolve model aliases

Fixes #1331