### PR TITLE
feat(bedrock): add interleaved thinking support

### DIFF
--- a/examples/pr-reviewer-bedrock.yaml
+++ b/examples/pr-reviewer-bedrock.yaml
@@ -457,6 +457,8 @@ models:
     provider: amazon-bedrock
     model: global.anthropic.claude-opus-4-5-20251101-v1:0
     max_tokens: 64000
+    thinking_budget: 32000
     provider_opts:
       region: eu-west-1
       profile: bedrock1
+      interleaved_thinking: true

--- a/pkg/model/provider/bedrock/adapter.go
+++ b/pkg/model/provider/bedrock/adapter.go
@@ -151,9 +151,16 @@ func (a *streamAdapter) Recv() (chat.MessageStreamResponse, error) {
 				}}
 
 			case *types.ContentBlockDeltaMemberReasoningContent:
-				// Handle reasoning/thinking content
-				if textDelta, ok := delta.Value.(*types.ReasoningContentBlockDeltaMemberText); ok {
-					response.Choices[0].Delta.ReasoningContent = textDelta.Value
+				// Handle reasoning content (text, signature, redacted)
+				switch reasoningDelta := delta.Value.(type) {
+				case *types.ReasoningContentBlockDeltaMemberText:
+					response.Choices[0].Delta.ReasoningContent = reasoningDelta.Value
+				case *types.ReasoningContentBlockDeltaMemberSignature:
+					response.Choices[0].Delta.ThinkingSignature = reasoningDelta.Value
+				case *types.ReasoningContentBlockDeltaMemberRedactedContent:
+					response.Choices[0].Delta.ThinkingSignature = string(reasoningDelta.Value)
+				default:
+					return chat.MessageStreamResponse{}, fmt.Errorf("unknown reasoning delta type: %T", reasoningDelta)
 				}
 			}
 		}


### PR DESCRIPTION
Add support for interleaved thinking in the Bedrock provider, enabling multi-turn extended thinking conversations with
Claude models on AWS Bedrock.

```yaml
models:
  my-model:
    provider: amazon-bedrock
    model: anthropic.claude-sonnet-4-20250514-v1:0
    max_tokens: 64000
    thinking_budget: 32000
    provider_opts:
      region: us-east-1
      interleaved_thinking: true #<----
  ```
  
Assisted-By: cagent