### PR TITLE
feat(bedrock): add prompt caching for supported models

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -451,6 +451,19 @@ models:
 | `role_session_name` | string | Session name for assumed role | cagent-bedrock-session |
 | `external_id` | string | External ID for role assumption | (none) |
 | `endpoint_url` | string | Custom endpoint (VPC/testing) | (none) |
+| `interleaved_thinking` | bool | Enable reasoning during tool calls (requires thinking_budget) | false |
+| `disable_prompt_caching` | bool | Disable automatic prompt caching | false |
+
+#### Prompt Caching (Bedrock)
+
+Prompt caching is automatically enabled for models that support it (detected via models.dev) to reduce latency and costs. System prompts, tool definitions, and recent messages are cached with a 5-minute TTL.
+
+To disable:
+
+```yaml
+provider_opts:
+  disable_prompt_caching: true
+```
 
 **Supported models (via Converse API):**
 


### PR DESCRIPTION
Prompt caching is automatically enabled for models that support it (detected via models.dev) to reduce latency and costs. System prompts, tool definitions, and recent messages are cached with a 5-minute TTL.

To disable:

```yaml
provider_opts:
  disable_prompt_caching: true
```

P.S. Benchmarked with `examples/pr-reviewer-bedrock.yaml`: 92% cache read vs 8% cache write.

Assisted-By: cagent

