### PR TITLE
Unstuck some remote MCPs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/labstack/echo/v4 v4.15.0
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mattn/go-runewidth v0.0.19
-	github.com/modelcontextprotocol/go-sdk v1.2.0
+	github.com/modelcontextprotocol/go-sdk v1.2.1-0.20260115164613-13488f7da1ed
 	github.com/natefinch/atomic v1.0.1
 	github.com/openai/openai-go/v3 v3.16.0
 	github.com/rivo/uniseg v0.4.7

--- a/go.sum
+++ b/go.sum
@@ -293,8 +293,8 @@ github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwX
 github.com/microcosm-cc/bluemonday v1.0.27/go.mod h1:jFi9vgW+H7c3V0lb6nR74Ib/DIB5OBs92Dimizgw2cA=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
-github.com/modelcontextprotocol/go-sdk v1.2.0 h1:Y23co09300CEk8iZ/tMxIX1dVmKZkzoSBZOpJwUnc/s=
-github.com/modelcontextprotocol/go-sdk v1.2.0/go.mod h1:6fM3LCm3yV7pAs8isnKLn07oKtB0MP9LHd3DfAcKw10=
+github.com/modelcontextprotocol/go-sdk v1.2.1-0.20260115164613-13488f7da1ed h1:v6U7x8QdZFPR+2klPe29iHrRTy35sQSodTxtGcOX7TU=
+github.com/modelcontextprotocol/go-sdk v1.2.1-0.20260115164613-13488f7da1ed/go.mod h1:AnQ//Qc6+4nIyyrB4cxBU7UW9VibK4iOZBeyP/rF1IE=
 github.com/mschoch/smat v0.2.0 h1:8imxQsjDm8yFEAVBe7azKmKSgzSkZXDuKkSq9374khM=
 github.com/mschoch/smat v0.2.0/go.mod h1:kc9mz7DoBKqDyiRL7VZN8KvXQMWeTaVnttLRXOlotKw=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=

--- a/pkg/tools/mcp/remote.go
+++ b/pkg/tools/mcp/remote.go
@@ -90,8 +90,9 @@ func (c *remoteMCPClient) Initialize(ctx context.Context, _ *mcp.InitializeReque
 		}
 	case "streamable", "streamable-http":
 		transport = &mcp.StreamableClientTransport{
-			Endpoint:   c.url,
-			HTTPClient: httpClient,
+			Endpoint:             c.url,
+			HTTPClient:           httpClient,
+			DisableStandaloneSSE: true,
 		}
 	default:
 		return nil, fmt.Errorf("unsupported transport type: %s", c.transportType)


### PR DESCRIPTION
Some remote MCPs get stuck when we try to connect to them because the MCP client also tries to create a persistent SSE connection.

Disable the persistent connection to make init faster for these servers. This means that we can't receive notifications from remote servers which is fine for now since we don't listen to these (yet).

More info https://github.com/modelcontextprotocol/go-sdk/issues/633