### PR TITLE
Fix agent lookup for local file sources

### DIFF
--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -276,6 +276,11 @@ func (sm *SessionManager) runtimeForSession(ctx context.Context, sess *session.S
 func (sm *SessionManager) loadTeam(ctx context.Context, agentFilename string, runConfig *config.RuntimeConfig) (*team.Team, error) {
 	agentSource, found := sm.Sources[agentFilename]
 	if !found {
+		// Fallback: try without extension (for local files keyed without .yaml)
+		nameWithoutExt := strings.TrimSuffix(agentFilename, filepath.Ext(agentFilename))
+		agentSource, found = sm.Sources[nameWithoutExt]
+	}
+	if !found {
 		return nil, fmt.Errorf("agent not found: %s", agentFilename)
 	}
 


### PR DESCRIPTION
When using a local file as an agent source (e.g., `~/<some_path>/<agent_name>.yaml`), the API endpoint for `runAgent` lookup would fail because it couldn't fine the agent.

Root cause: `ResolveSources()` stores local file sources with keys stripped of the .yaml extension (via `fileNameWithoutExt`), but OCI references are stored with .yaml extension (via `OciRefToFilename`). When the API receives a request with the .yaml extension in the path, the lookup fails for local files.

This PR creates a fallback lookup to ensure it works.