### PR TITLE
Fix Docker Desktop Socket Location for WSL2

### DIFF
--- a/pkg/desktop/sockets_linux.go
+++ b/pkg/desktop/sockets_linux.go
@@ -8,24 +8,35 @@ import (
 
 func getDockerDesktopPaths() (DockerDesktopPaths, error) {
 	_, err := os.Stat("/run/host-services/backend.sock")
-	if err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			return DockerDesktopPaths{}, err
-		}
-
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return DockerDesktopPaths{}, err
-		}
-
-		// On Linux
+	if err == nil {
+		// Inside LinuxKit
 		return DockerDesktopPaths{
-			BackendSocket: filepath.Join(home, ".docker", "desktop", "backend.sock"),
+			BackendSocket: "/run/host-services/backend.sock",
 		}, nil
 	}
 
-	// Inside LinuxKit
+	if !errors.Is(err, os.ErrNotExist) {
+		return DockerDesktopPaths{}, err
+	}
+
+	if _, err = os.Stat("/mnt/wsl/docker-desktop/shared-sockets/host-services/backend.sock"); err == nil {
+		// Inside WSL2
+		return DockerDesktopPaths{
+			BackendSocket: "/mnt/wsl/docker-desktop/shared-sockets/host-services/backend.sock",
+		}, nil
+	}
+
+	if !errors.Is(err, os.ErrNotExist) {
+		return DockerDesktopPaths{}, err
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return DockerDesktopPaths{}, err
+	}
+
+	// On Linux
 	return DockerDesktopPaths{
-		BackendSocket: "/run/host-services/backend.sock",
+		BackendSocket: filepath.Join(home, ".docker", "desktop", "backend.sock"),
 	}, nil
 }


### PR DESCRIPTION
Socket path detection now checks WSL2 path (`/mnt/wsl/docker-desktop/shared-sockets/host-services/backend.sock`) between LinuxKit and native Linux checks in `pkg/desktop/sockets_linux.go`.