### PR TITLE
Better DMR support

### DIFF
--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -134,6 +134,6 @@ The DMR provider supports speculative decoding for faster inference. Configure i
 - `speculative_num_tokens` (int): Number of tokens to generate speculatively
 - `speculative_acceptance_rate` (float): Acceptance rate threshold for speculative tokens
 
-All three options are passed to `docker model configure` as command-line flags.
+All three options are sent to Model Runner via its internal `POST /engines/_configure` API endpoint.
 
 You can also pass any flag of the underlying model runtime (llama.cpp or vllm) using the `runtime_flags` option

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -584,12 +584,12 @@ models:
       speculative_acceptance_rate: 0.8         # Acceptance rate threshold
 ```
 
-All three speculative decoding options are passed to `docker model configure` as flags:
-- `speculative_draft_model` → `--speculative-draft-model`
-- `speculative_num_tokens` → `--speculative-num-tokens`
-- `speculative_acceptance_rate` → `--speculative-acceptance-rate`
+All three speculative decoding options are sent to Model Runner via its internal `POST /engines/_configure` API endpoint:
+- `speculative_draft_model` → `speculative.draft_model`
+- `speculative_num_tokens` → `speculative.num_tokens`
+- `speculative_acceptance_rate` → `speculative.min_acceptance_rate`
 
-These options work alongside `max_tokens` (which sets `--context-size`) and `runtime_flags`.
+These options work alongside `max_tokens` (which sets `context-size`) and `runtime_flags`.
 
 ##### Troubleshooting:
 

--- a/pkg/model/provider/dmr/client.go
+++ b/pkg/model/provider/dmr/client.go
@@ -35,10 +35,30 @@ import (
 )
 
 const (
+	// configureTimeout is the timeout for the model configure HTTP request.
+	// This is kept short to avoid stalling client creation.
+	configureTimeout = 10 * time.Second
+
+	// connectivityTimeout is the timeout for testing DMR endpoint connectivity.
+	// This is kept short to quickly detect unreachable endpoints and try fallbacks.
+	connectivityTimeout = 2 * time.Second
+)
+
+const (
 	// dmrInferencePrefix mirrors github.com/docker/model-runner/pkg/inference.InferencePrefix.
 	dmrInferencePrefix = "/engines"
 	// dmrExperimentalEndpointsPrefix mirrors github.com/docker/model-runner/pkg/inference.ExperimentalEndpointsPrefix.
 	dmrExperimentalEndpointsPrefix = "/exp/vDD4.40"
+
+	// dmrDefaultPort is the default port for Docker Model Runner.
+	dmrDefaultPort = "12434"
+
+	// Docker Desktop internal hostnames and fallback IPs for cross-platform support.
+	// These are tried in order when the primary endpoint is unreachable.
+	dmrModelRunnerInternal = "model-runner.docker.internal" // Docker Desktop's model-runner service
+	dmrHostDockerInternal  = "host.docker.internal"         // Docker Desktop's host access (macOS/Windows/Linux Desktop)
+	dmrDockerBridgeGateway = "172.17.0.1"                   // Default Docker bridge gateway (Linux Docker CE)
+	dmrLocalhost           = "127.0.0.1"                    // Localhost fallback
 )
 
 // Client represents an DMR client wrapper
@@ -86,12 +106,45 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, opts ...options.Opt
 
 	baseURL, clientOptions, httpClient := resolveDMRBaseURL(cfg, endpoint)
 
-	clientOptions = append(clientOptions, option.WithBaseURL(baseURL), option.WithAPIKey("")) // DMR doesn't need auth
-
 	// Ensure we always have a non-nil HTTP client for both OpenAI adapter and direct HTTP calls (rerank).
 	if httpClient == nil {
 		httpClient = &http.Client{}
 	}
+
+	// Test connectivity to the resolved URL and try fallbacks if needed.
+	// Only attempt fallbacks when no explicit URL was configured (BaseURL or MODEL_RUNNER_HOST).
+	if cfg.BaseURL == "" && os.Getenv("MODEL_RUNNER_HOST") == "" {
+		if !testDMRConnectivity(ctx, httpClient, baseURL) {
+			slog.Debug("DMR primary endpoint unreachable, trying fallbacks", "primary_url", baseURL)
+
+			// Try fallback URLs in order (Docker Desktop internal hosts, bridge gateway, localhost)
+			fallbackURLs := getDMRFallbackURLs()
+			foundFallback := false
+			for _, fallbackURL := range fallbackURLs {
+				if fallbackURL == baseURL {
+					continue // Skip if same as primary
+				}
+				slog.Debug("DMR trying fallback endpoint", "url", fallbackURL)
+				if testDMRConnectivity(ctx, httpClient, fallbackURL) {
+					slog.Info("DMR using fallback endpoint", "fallback_url", fallbackURL, "original_url", baseURL)
+					baseURL = fallbackURL
+					// Reset client options since we're using a different URL (no Unix socket needed for HTTP endpoints)
+					clientOptions = nil
+					foundFallback = true
+					break
+				}
+			}
+			if !foundFallback {
+				slog.Debug("DMR all fallback endpoints unreachable, continuing with original URL", "original_url", baseURL)
+			}
+		} else {
+			slog.Debug("DMR primary endpoint reachable", "url", baseURL)
+		}
+	} else {
+		slog.Debug("DMR using explicitly configured URL", "url", baseURL)
+	}
+
+	clientOptions = append(clientOptions, option.WithBaseURL(baseURL), option.WithAPIKey("")) // DMR doesn't need auth
 
 	// Build runtime flags from ModelConfig and engine
 	contextSize, providerRuntimeFlags, specOpts := parseDMRProviderOpts(cfg)
@@ -104,8 +157,8 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, opts ...options.Opt
 	// Skip model configuration when generating titles to avoid reconfiguring the model
 	// with different settings (e.g., smaller max_tokens) that would affect the main agent.
 	if !globalOptions.GeneratingTitle() {
-		if err := configureDockerModel(ctx, cfg.Model, contextSize, finalFlags, specOpts); err != nil {
-			slog.Debug("docker model configure skipped or failed", "error", err)
+		if err := configureModel(ctx, httpClient, baseURL, cfg.Model, contextSize, finalFlags, specOpts); err != nil {
+			slog.Debug("model configure via API skipped or failed", "error", err)
 		}
 	}
 
@@ -125,6 +178,48 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, opts ...options.Opt
 func inContainer() bool {
 	finfo, err := os.Stat("/.dockerenv")
 	return err == nil && finfo.Mode().IsRegular()
+}
+
+// testDMRConnectivity performs a quick health check against a DMR endpoint.
+// It returns true if the endpoint is reachable and responds within the timeout.
+func testDMRConnectivity(ctx context.Context, httpClient *http.Client, baseURL string) bool {
+	// Build a simple health check URL - try the models endpoint which should always exist
+	healthURL := strings.TrimSuffix(baseURL, "/") + "/models"
+
+	ctx, cancel := context.WithTimeout(ctx, connectivityTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, http.NoBody)
+	if err != nil {
+		slog.Debug("DMR connectivity check: failed to create request", "url", healthURL, "error", err)
+		return false
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		slog.Debug("DMR connectivity check: request failed", "url", healthURL, "error", err)
+		return false
+	}
+	defer resp.Body.Close()
+
+	// Any response (even 4xx/5xx) means the server is reachable
+	slog.Debug("DMR connectivity check: success", "url", healthURL, "status", resp.StatusCode)
+	return true
+}
+
+// getDMRFallbackURLs returns a list of fallback URLs to try for DMR connectivity.
+// The order is chosen to maximize compatibility across platforms:
+// 1. model-runner.docker.internal - Docker Desktop's integrated model-runner
+// 2. host.docker.internal - Docker Desktop's host access (works on macOS/Windows/Linux Desktop)
+// 3. 172.17.0.1 - Default Docker bridge gateway (Linux Docker CE)
+// 4. 127.0.0.1 - Localhost (when running directly on host)
+func getDMRFallbackURLs() []string {
+	return []string{
+		fmt.Sprintf("http://%s%s/v1/", dmrModelRunnerInternal, dmrInferencePrefix),
+		fmt.Sprintf("http://%s:%s%s/v1/", dmrHostDockerInternal, dmrDefaultPort, dmrInferencePrefix),
+		fmt.Sprintf("http://%s:%s%s/v1/", dmrDockerBridgeGateway, dmrDefaultPort, dmrInferencePrefix),
+		fmt.Sprintf("http://%s:%s%s/v1/", dmrLocalhost, dmrDefaultPort, dmrInferencePrefix),
+	}
 }
 
 // resolveDMRBaseURL determines the correct base URL and HTTP options to talk to
@@ -920,45 +1015,121 @@ func modelExists(ctx context.Context, model string) bool {
 	return true
 }
 
-func configureDockerModel(ctx context.Context, model string, contextSize *int64, runtimeFlags []string, specOpts *speculativeDecodingOpts) error {
-	args := buildDockerModelConfigureArgs(model, contextSize, runtimeFlags, specOpts)
+// configureRequest mirrors the model-runner's scheduling.ConfigureRequest structure.
+// It specifies per-model runtime configuration options sent via POST /engines/_configure.
+type configureRequest struct {
+	Model        string                      `json:"model"`
+	ContextSize  *int32                      `json:"context-size,omitempty"`
+	RuntimeFlags []string                    `json:"runtime-flags,omitempty"`
+	Speculative  *speculativeDecodingRequest `json:"speculative,omitempty"`
+}
 
-	cmd := exec.CommandContext(ctx, "docker", args...)
-	slog.Debug("Running docker model configure", "model", model, "args", args)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return errors.New(strings.TrimSpace(stderr.String()))
+// speculativeDecodingRequest mirrors model-runner's inference.SpeculativeDecodingConfig.
+type speculativeDecodingRequest struct {
+	DraftModel        string  `json:"draft_model,omitempty"`
+	NumTokens         int     `json:"num_tokens,omitempty"`
+	MinAcceptanceRate float64 `json:"min_acceptance_rate,omitempty"`
+}
+
+// configureModel sends model configuration to Model Runner via POST /engines/_configure.
+// This replaces the previous approach of shelling out to `docker model configure`.
+func configureModel(ctx context.Context, httpClient *http.Client, baseURL, model string, contextSize *int64, runtimeFlags []string, specOpts *speculativeDecodingOpts) error {
+	if httpClient == nil {
+		httpClient = &http.Client{}
 	}
-	slog.Debug("docker model configure completed", "model", model)
+
+	configureURL := buildConfigureURL(baseURL)
+	reqBody := buildConfigureRequest(model, contextSize, runtimeFlags, specOpts)
+
+	reqData, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("failed to marshal configure request: %w", err)
+	}
+
+	// Use a timeout context to avoid blocking client creation indefinitely
+	ctx, cancel := context.WithTimeout(ctx, configureTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, configureURL, bytes.NewReader(reqData))
+	if err != nil {
+		return fmt.Errorf("failed to create configure request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	slog.Debug("Sending model configure request via API",
+		"model", model,
+		"url", configureURL,
+		"context_size", contextSize,
+		"runtime_flags", runtimeFlags,
+		"speculative_opts", specOpts)
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("configure request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Model Runner returns 202 Accepted on success
+	if resp.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("configure request failed with status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	slog.Debug("Model configure via API completed", "model", model)
 	return nil
 }
 
-// buildDockerModelConfigureArgs returns the argument vector passed to `docker` for model configuration.
-// It formats context size, speculative decoding options, and runtime flags consistently with the CLI contract.
-func buildDockerModelConfigureArgs(model string, contextSize *int64, runtimeFlags []string, specOpts *speculativeDecodingOpts) []string {
-	args := []string{"model", "configure"}
+// buildConfigureURL derives the /engines/_configure endpoint URL from the OpenAI base URL.
+// It handles various URL formats:
+//   - http://host:port/engines/v1/ → http://host:port/engines/_configure
+//   - http://_/exp/vDD4.40/engines/v1 → http://_/exp/vDD4.40/engines/_configure
+//   - http://host:port/engines/llama.cpp/v1/ → http://host:port/engines/llama.cpp/_configure
+func buildConfigureURL(baseURL string) string {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		// Fallback: just strip /v1/ suffix and append /_configure
+		baseURL = strings.TrimSuffix(baseURL, "/")
+		baseURL = strings.TrimSuffix(baseURL, "/v1")
+		return baseURL + "/_configure"
+	}
+
+	path := u.Path
+
+	// Remove trailing slash for consistent handling
+	path = strings.TrimSuffix(path, "/")
+
+	// Remove /v1 suffix to get to the engines path
+	path = strings.TrimSuffix(path, "/v1")
+
+	// Append /_configure
+	path += "/_configure"
+
+	u.Path = path
+	return u.String()
+}
+
+// buildConfigureRequest constructs the JSON request body for POST /engines/_configure.
+func buildConfigureRequest(model string, contextSize *int64, runtimeFlags []string, specOpts *speculativeDecodingOpts) configureRequest {
+	req := configureRequest{
+		Model:        model,
+		RuntimeFlags: runtimeFlags,
+	}
+
+	// Convert int64 context size to int32 as expected by model-runner
 	if contextSize != nil {
-		args = append(args, "--context-size="+strconv.FormatInt(*contextSize, 10))
+		cs := int32(*contextSize)
+		req.ContextSize = &cs
 	}
+
 	if specOpts != nil {
-		if specOpts.draftModel != "" {
-			args = append(args, "--speculative-draft-model="+specOpts.draftModel)
-		}
-		if specOpts.numTokens > 0 {
-			args = append(args, "--speculative-num-tokens="+strconv.Itoa(specOpts.numTokens))
-		}
-		if specOpts.acceptanceRate > 0 {
-			args = append(args, "--speculative-min-acceptance-rate="+strconv.FormatFloat(specOpts.acceptanceRate, 'f', -1, 64))
+		req.Speculative = &speculativeDecodingRequest{
+			DraftModel:        specOpts.draftModel,
+			NumTokens:         specOpts.numTokens,
+			MinAcceptanceRate: specOpts.acceptanceRate,
 		}
 	}
-	args = append(args, model)
-	if len(runtimeFlags) > 0 {
-		args = append(args, "--")
-		args = append(args, runtimeFlags...)
-	}
-	return args
+
+	return req
 }
 
 func getDockerModelEndpointAndEngine(ctx context.Context) (endpoint, engine string, err error) {
@@ -1025,7 +1196,7 @@ func buildRuntimeFlagsFromModelConfig(engine string, cfg *latest.ModelConfig) []
 		if cfg.PresencePenalty != nil {
 			flags = append(flags, "--presence-penalty", strconv.FormatFloat(*cfg.PresencePenalty, 'f', -1, 64))
 		}
-		// Note: Context size already handled via --context-size during `docker model configure`
+		// Note: Context size already handled via context-size field in the configure API request
 	default:
 		// Unknown engine: no flags
 	}

--- a/pkg/model/provider/dmr/client_test.go
+++ b/pkg/model/provider/dmr/client_test.go
@@ -1,6 +1,10 @@
 package dmr
 
 import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,6 +27,60 @@ func TestNewClientWithExplicitBaseURL(t *testing.T) {
 	assert.Equal(t, "https://custom.example.com:8080/api/v1", client.baseURL)
 }
 
+func TestGetDMRFallbackURLs(t *testing.T) {
+	t.Parallel()
+
+	urls := getDMRFallbackURLs()
+
+	// Should return 4 fallback URLs
+	require.Len(t, urls, 4)
+
+	// Verify the expected URLs in order
+	assert.Equal(t, "http://model-runner.docker.internal/engines/v1/", urls[0])
+	assert.Equal(t, "http://host.docker.internal:12434/engines/v1/", urls[1])
+	assert.Equal(t, "http://172.17.0.1:12434/engines/v1/", urls[2])
+	assert.Equal(t, "http://127.0.0.1:12434/engines/v1/", urls[3])
+}
+
+func TestDMRConnectivity(t *testing.T) {
+	t.Parallel()
+
+	t.Run("reachable endpoint", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/models", r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":[]}`))
+		}))
+		defer server.Close()
+
+		result := testDMRConnectivity(t.Context(), server.Client(), server.URL+"/")
+		assert.True(t, result)
+	})
+
+	t.Run("reachable endpoint with error response", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer server.Close()
+
+		// Should still return true because server is reachable
+		result := testDMRConnectivity(t.Context(), server.Client(), server.URL+"/")
+		assert.True(t, result)
+	})
+
+	t.Run("unreachable endpoint", func(t *testing.T) {
+		t.Parallel()
+
+		// Use a port that's unlikely to have anything listening
+		result := testDMRConnectivity(t.Context(), &http.Client{}, "http://127.0.0.1:59999/")
+		assert.False(t, result)
+	})
+}
+
 func TestNewClientWithWrongType(t *testing.T) {
 	t.Parallel()
 
@@ -35,12 +93,205 @@ func TestNewClientWithWrongType(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestBuildDockerConfigureArgs(t *testing.T) {
+func TestBuildConfigureURL(t *testing.T) {
 	t.Parallel()
 
-	args := buildDockerModelConfigureArgs("ai/qwen3:14B-Q6_K", int64Ptr(8192), []string{"--temp", "0.7", "--top-p", "0.9"}, nil)
+	tests := []struct {
+		name     string
+		baseURL  string
+		expected string
+	}{
+		{
+			name:     "standard engines path",
+			baseURL:  "http://127.0.0.1:12434/engines/v1/",
+			expected: "http://127.0.0.1:12434/engines/_configure",
+		},
+		{
+			name:     "standard engines path without trailing slash",
+			baseURL:  "http://127.0.0.1:12434/engines/v1",
+			expected: "http://127.0.0.1:12434/engines/_configure",
+		},
+		{
+			name:     "Docker Desktop experimental prefix",
+			baseURL:  "http://_/exp/vDD4.40/engines/v1",
+			expected: "http://_/exp/vDD4.40/engines/_configure",
+		},
+		{
+			name:     "Docker Desktop experimental prefix with trailing slash",
+			baseURL:  "http://_/exp/vDD4.40/engines/v1/",
+			expected: "http://_/exp/vDD4.40/engines/_configure",
+		},
+		{
+			name:     "backend-scoped path",
+			baseURL:  "http://127.0.0.1:12434/engines/llama.cpp/v1/",
+			expected: "http://127.0.0.1:12434/engines/llama.cpp/_configure",
+		},
+		{
+			name:     "container internal host",
+			baseURL:  "http://model-runner.docker.internal/engines/v1/",
+			expected: "http://model-runner.docker.internal/engines/_configure",
+		},
+		{
+			name:     "custom port",
+			baseURL:  "http://localhost:8080/engines/v1/",
+			expected: "http://localhost:8080/engines/_configure",
+		},
+	}
 
-	assert.Equal(t, []string{"model", "configure", "--context-size=8192", "ai/qwen3:14B-Q6_K", "--", "--temp", "0.7", "--top-p", "0.9"}, args)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := buildConfigureURL(tt.baseURL)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestBuildConfigureRequest(t *testing.T) {
+	t.Parallel()
+
+	t.Run("with all options", func(t *testing.T) {
+		t.Parallel()
+		specOpts := &speculativeDecodingOpts{
+			draftModel:     "ai/qwen3:1B",
+			numTokens:      5,
+			acceptanceRate: 0.8,
+		}
+		contextSize := int64(8192)
+
+		req := buildConfigureRequest("ai/qwen3:14B-Q6_K", &contextSize, []string{"--temp", "0.7", "--top-p", "0.9"}, specOpts)
+
+		assert.Equal(t, "ai/qwen3:14B-Q6_K", req.Model)
+		require.NotNil(t, req.ContextSize)
+		assert.Equal(t, int32(8192), *req.ContextSize)
+		assert.Equal(t, []string{"--temp", "0.7", "--top-p", "0.9"}, req.RuntimeFlags)
+		require.NotNil(t, req.Speculative)
+		assert.Equal(t, "ai/qwen3:1B", req.Speculative.DraftModel)
+		assert.Equal(t, 5, req.Speculative.NumTokens)
+		assert.InEpsilon(t, 0.8, req.Speculative.MinAcceptanceRate, 0.001)
+	})
+
+	t.Run("without speculative options", func(t *testing.T) {
+		t.Parallel()
+		contextSize := int64(4096)
+
+		req := buildConfigureRequest("ai/qwen3:14B-Q6_K", &contextSize, []string{"--threads", "8"}, nil)
+
+		assert.Equal(t, "ai/qwen3:14B-Q6_K", req.Model)
+		require.NotNil(t, req.ContextSize)
+		assert.Equal(t, int32(4096), *req.ContextSize)
+		assert.Equal(t, []string{"--threads", "8"}, req.RuntimeFlags)
+		assert.Nil(t, req.Speculative)
+	})
+
+	t.Run("without context size", func(t *testing.T) {
+		t.Parallel()
+		specOpts := &speculativeDecodingOpts{
+			draftModel: "ai/qwen3:1B",
+			numTokens:  5,
+		}
+
+		req := buildConfigureRequest("ai/qwen3:14B-Q6_K", nil, nil, specOpts)
+
+		assert.Equal(t, "ai/qwen3:14B-Q6_K", req.Model)
+		assert.Nil(t, req.ContextSize)
+		assert.Nil(t, req.RuntimeFlags)
+		require.NotNil(t, req.Speculative)
+		assert.Equal(t, "ai/qwen3:1B", req.Speculative.DraftModel)
+		assert.Equal(t, 5, req.Speculative.NumTokens)
+	})
+
+	t.Run("minimal config", func(t *testing.T) {
+		t.Parallel()
+		req := buildConfigureRequest("ai/qwen3:14B-Q6_K", nil, nil, nil)
+
+		assert.Equal(t, "ai/qwen3:14B-Q6_K", req.Model)
+		assert.Nil(t, req.ContextSize)
+		assert.Nil(t, req.RuntimeFlags)
+		assert.Nil(t, req.Speculative)
+	})
+}
+
+func TestConfigureModelViaAPI(t *testing.T) {
+	t.Parallel()
+
+	t.Run("successful configuration", func(t *testing.T) {
+		t.Parallel()
+
+		var receivedRequest configureRequest
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodPost, r.Method)
+			assert.Equal(t, "/engines/_configure", r.URL.Path)
+			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+			body, err := io.ReadAll(r.Body)
+			if !assert.NoError(t, err) {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			err = json.Unmarshal(body, &receivedRequest)
+			if !assert.NoError(t, err) {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+
+			w.WriteHeader(http.StatusAccepted)
+		}))
+		defer server.Close()
+
+		baseURL := server.URL + "/engines/v1/"
+		contextSize := int64(8192)
+		specOpts := &speculativeDecodingOpts{
+			draftModel:     "ai/qwen3:1B",
+			numTokens:      5,
+			acceptanceRate: 0.8,
+		}
+
+		err := configureModel(t.Context(), server.Client(), baseURL, "ai/qwen3:14B", &contextSize, []string{"--temp", "0.7"}, specOpts)
+		require.NoError(t, err)
+
+		// Verify request body
+		assert.Equal(t, "ai/qwen3:14B", receivedRequest.Model)
+		require.NotNil(t, receivedRequest.ContextSize)
+		assert.Equal(t, int32(8192), *receivedRequest.ContextSize)
+		assert.Equal(t, []string{"--temp", "0.7"}, receivedRequest.RuntimeFlags)
+		require.NotNil(t, receivedRequest.Speculative)
+		assert.Equal(t, "ai/qwen3:1B", receivedRequest.Speculative.DraftModel)
+		assert.Equal(t, 5, receivedRequest.Speculative.NumTokens)
+		assert.InEpsilon(t, 0.8, receivedRequest.Speculative.MinAcceptanceRate, 0.001)
+	})
+
+	t.Run("server returns error", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("internal error"))
+		}))
+		defer server.Close()
+
+		baseURL := server.URL + "/engines/v1/"
+		err := configureModel(t.Context(), server.Client(), baseURL, "ai/qwen3:14B", nil, nil, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "500")
+		assert.Contains(t, err.Error(), "internal error")
+	})
+
+	t.Run("server returns conflict", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write([]byte("runner already active"))
+		}))
+		defer server.Close()
+
+		baseURL := server.URL + "/engines/v1/"
+		err := configureModel(t.Context(), server.Client(), baseURL, "ai/qwen3:14B", nil, nil, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "409")
+		assert.Contains(t, err.Error(), "runner already active")
+	})
 }
 
 func TestBuildRuntimeFlagsFromModelConfig_LlamaCpp(t *testing.T) {
@@ -72,8 +323,11 @@ func TestIntegrateFlagsWithProviderOptsOrder(t *testing.T) {
 	// provider opts should be appended after derived flags so they can override by order
 	merged := append(derived, []string{"--threads", "6"}...)
 
-	args := buildDockerModelConfigureArgs("ai/qwen3:14B-Q6_K", cfg.MaxTokens, merged, nil)
-	assert.Equal(t, []string{"model", "configure", "--context-size=4096", "ai/qwen3:14B-Q6_K", "--", "--temp", "0.6", "--top-p", "0.9", "--threads", "6"}, args)
+	req := buildConfigureRequest("ai/qwen3:14B-Q6_K", cfg.MaxTokens, merged, nil)
+	assert.Equal(t, "ai/qwen3:14B-Q6_K", req.Model)
+	require.NotNil(t, req.ContextSize)
+	assert.Equal(t, int32(4096), *req.ContextSize)
+	assert.Equal(t, []string{"--temp", "0.6", "--top-p", "0.9", "--threads", "6"}, req.RuntimeFlags)
 }
 
 func TestMergeRuntimeFlagsPreferUser_WarnsAndPrefersUser(t *testing.T) {
@@ -98,46 +352,6 @@ func floatPtr(f float64) *float64 {
 
 func int64Ptr(i int64) *int64 {
 	return &i
-}
-
-func TestBuildDockerConfigureArgsWithSpeculativeDecoding(t *testing.T) {
-	t.Parallel()
-
-	specOpts := &speculativeDecodingOpts{
-		draftModel:     "ai/qwen3:1B",
-		numTokens:      5,
-		acceptanceRate: 0.8,
-	}
-	args := buildDockerModelConfigureArgs("ai/qwen3:14B-Q6_K", int64Ptr(8192), []string{"--temp", "0.7"}, specOpts)
-
-	assert.Equal(t, []string{
-		"model", "configure",
-		"--context-size=8192",
-		"--speculative-draft-model=ai/qwen3:1B",
-		"--speculative-num-tokens=5",
-		"--speculative-min-acceptance-rate=0.8",
-		"ai/qwen3:14B-Q6_K",
-		"--",
-		"--temp", "0.7",
-	}, args)
-}
-
-func TestBuildDockerConfigureArgsWithPartialSpeculativeDecoding(t *testing.T) {
-	t.Parallel()
-
-	specOpts := &speculativeDecodingOpts{
-		draftModel: "ai/qwen3:1B",
-		numTokens:  5,
-		// acceptanceRate not set (0 value)
-	}
-	args := buildDockerModelConfigureArgs("ai/qwen3:14B-Q6_K", nil, nil, specOpts)
-
-	assert.Equal(t, []string{
-		"model", "configure",
-		"--speculative-draft-model=ai/qwen3:1B",
-		"--speculative-num-tokens=5",
-		"ai/qwen3:14B-Q6_K",
-	}, args)
 }
 
 func TestParseDMRProviderOptsWithSpeculativeDecoding(t *testing.T) {
@@ -178,4 +392,62 @@ func TestParseDMRProviderOptsWithoutSpeculativeDecoding(t *testing.T) {
 	assert.Equal(t, int64(4096), *contextSize)
 	assert.Equal(t, []string{"--threads", "8"}, runtimeFlags)
 	assert.Nil(t, specOpts)
+}
+
+func TestConfigureRequestJSONSerialization(t *testing.T) {
+	t.Parallel()
+
+	t.Run("full request serializes correctly", func(t *testing.T) {
+		t.Parallel()
+		contextSize := int32(8192)
+		req := configureRequest{
+			Model:        "ai/qwen3:14B",
+			ContextSize:  &contextSize,
+			RuntimeFlags: []string{"--temp", "0.7"},
+			Speculative: &speculativeDecodingRequest{
+				DraftModel:        "ai/qwen3:1B",
+				NumTokens:         5,
+				MinAcceptanceRate: 0.8,
+			},
+		}
+
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		var parsed map[string]any
+		err = json.Unmarshal(data, &parsed)
+		require.NoError(t, err)
+
+		assert.Equal(t, "ai/qwen3:14B", parsed["model"])
+		assert.InEpsilon(t, float64(8192), parsed["context-size"].(float64), 0.001)
+		assert.Equal(t, []any{"--temp", "0.7"}, parsed["runtime-flags"])
+
+		spec, ok := parsed["speculative"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "ai/qwen3:1B", spec["draft_model"])
+		assert.InEpsilon(t, float64(5), spec["num_tokens"].(float64), 0.001)
+		assert.InEpsilon(t, 0.8, spec["min_acceptance_rate"].(float64), 0.001)
+	})
+
+	t.Run("minimal request omits nil fields", func(t *testing.T) {
+		t.Parallel()
+		req := configureRequest{
+			Model: "ai/qwen3:14B",
+		}
+
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		var parsed map[string]any
+		err = json.Unmarshal(data, &parsed)
+		require.NoError(t, err)
+
+		assert.Equal(t, "ai/qwen3:14B", parsed["model"])
+		_, hasContextSize := parsed["context-size"]
+		assert.False(t, hasContextSize, "context-size should be omitted when nil")
+		_, hasRuntimeFlags := parsed["runtime-flags"]
+		assert.False(t, hasRuntimeFlags, "runtime-flags should be omitted when nil")
+		_, hasSpeculative := parsed["speculative"]
+		assert.False(t, hasSpeculative, "speculative should be omitted when nil")
+	})
 }


### PR DESCRIPTION
Uses the /engines/_configure endpoint instead of shelling out to the CLI.

Also makes endpoint selection mor resilient. If `base_url` is not set, cagent will try multiple well-known URL to best support the environment its deployed in (local binary, container on linux, in a container on DD on mac/windows)