### PR TITLE
Enable selecting models in TUI based on available credentials

### DIFF
--- a/pkg/model/provider/provider.go
+++ b/pkg/model/provider/provider.go
@@ -28,6 +28,50 @@ type Alias struct {
 	TokenEnvVar string // Environment variable name for the API token
 }
 
+// CoreProviders lists all natively implemented provider types.
+// These are the provider types that have direct implementations (not aliases).
+var CoreProviders = []string{
+	"openai",
+	"anthropic",
+	"google",
+	"dmr",
+	"amazon-bedrock",
+}
+
+// CatalogProviders returns the list of provider names that should be shown in the model catalog.
+// This includes core providers and aliases that have a defined BaseURL (self-contained endpoints).
+// Aliases without a BaseURL (like azure) require user configuration and are excluded.
+func CatalogProviders() []string {
+	providers := make([]string, 0, len(CoreProviders)+len(Aliases))
+
+	// Add all core providers
+	providers = append(providers, CoreProviders...)
+
+	// Add aliases that have a defined BaseURL (they work out of the box)
+	for name, alias := range Aliases {
+		if alias.BaseURL != "" {
+			providers = append(providers, name)
+		}
+	}
+
+	return providers
+}
+
+// IsCatalogProvider returns true if the provider name is valid for the model catalog.
+func IsCatalogProvider(name string) bool {
+	// Check core providers
+	for _, p := range CoreProviders {
+		if p == name {
+			return true
+		}
+	}
+	// Check aliases with BaseURL
+	if alias, exists := Aliases[name]; exists && alias.BaseURL != "" {
+		return true
+	}
+	return false
+}
+
 // Aliases maps provider names to their corresponding configurations
 var Aliases = map[string]Alias{
 	"requesty": {

--- a/pkg/model/provider/provider_test.go
+++ b/pkg/model/provider/provider_test.go
@@ -1,0 +1,66 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCatalogProviders(t *testing.T) {
+	t.Parallel()
+
+	providers := CatalogProviders()
+
+	// Should include all core providers
+	for _, core := range CoreProviders {
+		assert.Contains(t, providers, core, "should include core provider %s", core)
+	}
+
+	// Should include aliases with BaseURL
+	for name, alias := range Aliases {
+		if alias.BaseURL != "" {
+			assert.Contains(t, providers, name, "should include alias %s with BaseURL", name)
+		} else {
+			assert.NotContains(t, providers, name, "should NOT include alias %s without BaseURL", name)
+		}
+	}
+}
+
+func TestIsCatalogProvider(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		provider string
+		want     bool
+	}{
+		// Core providers
+		{"openai is core", "openai", true},
+		{"anthropic is core", "anthropic", true},
+		{"google is core", "google", true},
+		{"dmr is core", "dmr", true},
+		{"amazon-bedrock is core", "amazon-bedrock", true},
+
+		// Aliases with BaseURL (should be included)
+		{"mistral has BaseURL", "mistral", true},
+		{"xai has BaseURL", "xai", true},
+		{"nebius has BaseURL", "nebius", true},
+		{"requesty has BaseURL", "requesty", true},
+		{"ollama has BaseURL", "ollama", true},
+
+		// Aliases without BaseURL (should be excluded)
+		{"azure has no BaseURL", "azure", false},
+
+		// Unknown providers
+		{"unknown provider", "unknown", false},
+		{"cohere not supported", "cohere", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := IsCatalogProvider(tt.provider)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/modelsdev/types.go
+++ b/pkg/modelsdev/types.go
@@ -23,6 +23,7 @@ type Provider struct {
 type Model struct {
 	ID          string     `json:"id"`
 	Name        string     `json:"name"`
+	Family      string     `json:"family,omitempty"`
 	Attachment  bool       `json:"attachment"`
 	Reasoning   bool       `json:"reasoning"`
 	Temperature bool       `json:"temperature"`

--- a/pkg/runtime/model_switcher_test.go
+++ b/pkg/runtime/model_switcher_test.go
@@ -1,10 +1,38 @@
 package runtime
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/cagent/pkg/config/latest"
+	"github.com/docker/cagent/pkg/modelsdev"
 )
+
+// mockEnvProvider is a simple environment provider for testing
+type mockEnvProvider struct {
+	vars map[string]string
+}
+
+func (m *mockEnvProvider) Get(_ context.Context, name string) (string, bool) {
+	v, ok := m.vars[name]
+	return v, ok
+}
+
+// mockCatalogStore implements CatalogStore for testing
+type mockCatalogStore struct {
+	db *modelsdev.Database
+}
+
+func (m *mockCatalogStore) GetModel(_ context.Context, _ string) (*modelsdev.Model, error) {
+	return nil, nil
+}
+
+func (m *mockCatalogStore) GetDatabase(_ context.Context) (*modelsdev.Database, error) {
+	return m.db, nil
+}
 
 func TestIsInlineAlloySpec(t *testing.T) {
 	t.Parallel()
@@ -67,5 +95,303 @@ func TestIsInlineAlloySpec(t *testing.T) {
 			got := isInlineAlloySpec(tt.modelRef)
 			assert.Equal(t, tt.want, got)
 		})
+	}
+}
+
+func TestIsEmbeddingModel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		family string
+		model  string
+		want   bool
+	}{
+		// Family-based detection
+		{"family text-embedding", "text-embedding", "Text Embedding 3 Large", true},
+		{"family cohere-embed", "cohere-embed", "Embed v4.0", true},
+		{"family mistral-embed", "mistral-embed", "Mistral Embed", true},
+		{"family gemini-embedding", "gemini-embedding", "Gemini Embedding", true},
+		// Name-based fallback (empty family)
+		{"name fallback embed", "", "Text Embedding 3 Large", true},
+		{"name fallback mistral", "", "Mistral Embed", true},
+		// Non-embedding models
+		{"gpt family", "gpt", "GPT-4o", false},
+		{"claude family", "claude-sonnet", "Claude Sonnet 4", false},
+		{"llama family", "llama", "Llama 3.1 70B", false},
+		{"empty both", "", "GPT-4o", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := isEmbeddingModel(tt.family, tt.model)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMapModelsDevProvider(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		providerID   string
+		wantProvider string
+		wantSupport  bool
+	}{
+		{"openai", "openai", true},
+		{"anthropic", "anthropic", true},
+		{"google", "google", true},
+		{"mistral", "mistral", true},
+		{"xai", "xai", true},
+		{"amazon-bedrock", "amazon-bedrock", true},
+		{"unsupported-provider", "", false},
+		{"cohere", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.providerID, func(t *testing.T) {
+			t.Parallel()
+			gotProvider, gotSupport := mapModelsDevProvider(tt.providerID)
+			assert.Equal(t, tt.wantProvider, gotProvider)
+			assert.Equal(t, tt.wantSupport, gotSupport)
+		})
+	}
+}
+
+func TestGetAvailableProviders(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		envVars       map[string]string
+		modelsGateway string
+		wantProviders []string
+	}{
+		{
+			name: "only openai key",
+			envVars: map[string]string{
+				"OPENAI_API_KEY": "sk-test",
+			},
+			wantProviders: []string{"openai", "dmr", "ollama"},
+		},
+		{
+			name: "openai and anthropic keys",
+			envVars: map[string]string{
+				"OPENAI_API_KEY":    "sk-test",
+				"ANTHROPIC_API_KEY": "sk-ant-test",
+			},
+			wantProviders: []string{"openai", "anthropic", "dmr", "ollama"},
+		},
+		{
+			name: "with gateway - uses docker token",
+			envVars: map[string]string{
+				"DOCKER_TOKEN": "test-token",
+			},
+			modelsGateway: "https://gateway.example.com",
+			wantProviders: []string{"openai", "anthropic", "google", "mistral", "xai"},
+		},
+		{
+			name: "with gateway but no token",
+			envVars: map[string]string{
+				"OPENAI_API_KEY": "sk-test", // This is ignored when gateway is set
+			},
+			modelsGateway: "https://gateway.example.com",
+			wantProviders: []string{}, // No token means no providers via gateway
+		},
+		{
+			name: "aws access key for bedrock",
+			envVars: map[string]string{
+				"AWS_ACCESS_KEY_ID": "AKIA...",
+			},
+			wantProviders: []string{"amazon-bedrock", "dmr", "ollama"},
+		},
+		{
+			name: "aws profile for bedrock",
+			envVars: map[string]string{
+				"AWS_PROFILE": "my-profile",
+			},
+			wantProviders: []string{"amazon-bedrock", "dmr", "ollama"},
+		},
+		{
+			name: "aws web identity for bedrock (EKS/IRSA)",
+			envVars: map[string]string{
+				"AWS_WEB_IDENTITY_TOKEN_FILE": "/var/run/secrets/token",
+			},
+			wantProviders: []string{"amazon-bedrock", "dmr", "ollama"},
+		},
+		{
+			name: "aws container credentials for bedrock (ECS)",
+			envVars: map[string]string{
+				"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/v2/credentials/...",
+			},
+			wantProviders: []string{"amazon-bedrock", "dmr", "ollama"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := &LocalRuntime{
+				modelSwitcherCfg: &ModelSwitcherConfig{
+					EnvProvider:   &mockEnvProvider{vars: tt.envVars},
+					ModelsGateway: tt.modelsGateway,
+				},
+			}
+
+			got := r.getAvailableProviders(t.Context())
+
+			for _, want := range tt.wantProviders {
+				assert.True(t, got[want], "expected provider %s to be available", want)
+			}
+		})
+	}
+}
+
+func TestBuildCatalogChoices(t *testing.T) {
+	t.Parallel()
+
+	// Create a mock database with some models
+	db := &modelsdev.Database{
+		Providers: map[string]modelsdev.Provider{
+			"openai": {
+				ID:   "openai",
+				Name: "OpenAI",
+				Models: map[string]modelsdev.Model{
+					"gpt-4o": {
+						ID:   "gpt-4o",
+						Name: "GPT-4o",
+						Modalities: modelsdev.Modalities{
+							Output: []string{"text"},
+						},
+					},
+					"dall-e-3": {
+						ID:   "dall-e-3",
+						Name: "DALL-E 3",
+						Modalities: modelsdev.Modalities{
+							Output: []string{"image"}, // Not a text model
+						},
+					},
+					"text-embedding-3-large": {
+						ID:     "text-embedding-3-large",
+						Name:   "Text Embedding 3 Large",
+						Family: "text-embedding",
+						Modalities: modelsdev.Modalities{
+							Output: []string{"text"}, // Embedding model - identified by family field
+						},
+					},
+				},
+			},
+			"anthropic": {
+				ID:   "anthropic",
+				Name: "Anthropic",
+				Models: map[string]modelsdev.Model{
+					"claude-sonnet-4-0": {
+						ID:   "claude-sonnet-4-0",
+						Name: "Claude Sonnet 4",
+						Modalities: modelsdev.Modalities{
+							Output: []string{"text"},
+						},
+					},
+				},
+			},
+			"unsupported": {
+				ID:   "unsupported",
+				Name: "Unsupported Provider",
+				Models: map[string]modelsdev.Model{
+					"some-model": {
+						ID:   "some-model",
+						Name: "Some Model",
+						Modalities: modelsdev.Modalities{
+							Output: []string{"text"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	r := &LocalRuntime{
+		modelsStore: &mockCatalogStore{db: db},
+		modelSwitcherCfg: &ModelSwitcherConfig{
+			EnvProvider: &mockEnvProvider{vars: map[string]string{
+				"OPENAI_API_KEY":    "sk-test",
+				"ANTHROPIC_API_KEY": "sk-ant-test",
+			}},
+			Models: map[string]latest.ModelConfig{
+				"my_model": {Provider: "openai", Model: "gpt-4o"}, // This should be excluded from catalog (duplicate)
+			},
+		},
+	}
+
+	choices := r.buildCatalogChoices(t.Context())
+
+	// Should include Claude Sonnet (not a duplicate)
+	var foundClaude bool
+	for _, c := range choices {
+		if c.Ref == "anthropic/claude-sonnet-4-0" {
+			foundClaude = true
+			assert.True(t, c.IsCatalog)
+			assert.Equal(t, "Claude Sonnet 4", c.Name)
+		}
+	}
+	require.True(t, foundClaude, "should include Claude Sonnet from catalog")
+
+	// Should NOT include DALL-E 3 (not a text model)
+	for _, c := range choices {
+		assert.NotEqual(t, "openai/dall-e-3", c.Ref, "should not include non-text models")
+	}
+
+	// Should NOT include embedding models
+	for _, c := range choices {
+		assert.NotEqual(t, "openai/text-embedding-3-large", c.Ref, "should not include embedding models")
+	}
+
+	// Should NOT include unsupported provider
+	for _, c := range choices {
+		assert.NotEqual(t, "unsupported", c.Provider, "should not include unsupported providers")
+	}
+}
+
+func TestBuildCatalogChoicesWithDuplicates(t *testing.T) {
+	t.Parallel()
+
+	db := &modelsdev.Database{
+		Providers: map[string]modelsdev.Provider{
+			"openai": {
+				ID:   "openai",
+				Name: "OpenAI",
+				Models: map[string]modelsdev.Model{
+					"gpt-4o": {
+						ID:   "gpt-4o",
+						Name: "GPT-4o",
+						Modalities: modelsdev.Modalities{
+							Output: []string{"text"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	r := &LocalRuntime{
+		modelsStore: &mockCatalogStore{db: db},
+		modelSwitcherCfg: &ModelSwitcherConfig{
+			EnvProvider: &mockEnvProvider{vars: map[string]string{
+				"OPENAI_API_KEY": "sk-test",
+			}},
+			Models: map[string]latest.ModelConfig{
+				// This model has the same provider/model as the catalog entry
+				"my_gpt4o": {Provider: "openai", Model: "gpt-4o"},
+			},
+		},
+	}
+
+	choices := r.buildCatalogChoices(t.Context())
+
+	// Should NOT include gpt-4o since it's already in config
+	for _, c := range choices {
+		assert.NotEqual(t, "openai/gpt-4o", c.Ref, "should not include duplicates from config")
 	}
 }


### PR DESCRIPTION
The goal of this change is to show a list of models from models.dev that the user can switch to, based on the available credentials on the users machine.

Supports: mouse scrolling, grabbing the scrollbar, clicking to highlight a model, double clicking to select and confirm

Also makes the dialog dynamically resize based on screen size, given the potentially large list of models to select from

---

Demo:

https://github.com/user-attachments/assets/45e85534-7f88-4b02-83d1-13a1c9829dcf


---

Closes #1392