### PR TITLE
Disable thinking for title generation

### DIFF
--- a/pkg/model/provider/clone.go
+++ b/pkg/model/provider/clone.go
@@ -25,6 +25,9 @@ func CloneWithOptions(ctx context.Context, base Provider, opts ...options.Opt) P
 		opt(tempOpts)
 		mt := tempOpts.MaxTokens()
 		modelConfig.MaxTokens = &mt
+		if t := tempOpts.Thinking(); t != nil && !*t {
+			modelConfig.ThinkingBudget = nil
+		}
 	}
 
 	clone, err := New(ctx, &modelConfig, config.Env, mergedOpts...)

--- a/pkg/model/provider/options/options.go
+++ b/pkg/model/provider/options/options.go
@@ -10,6 +10,7 @@ type ModelOptions struct {
 	generatingTitle  bool
 	maxTokens        int64
 	providers        map[string]latest.ProviderConfig
+	thinking         *bool
 }
 
 func (c *ModelOptions) Gateway() string {
@@ -30,6 +31,10 @@ func (c *ModelOptions) MaxTokens() int64 {
 
 func (c *ModelOptions) Providers() map[string]latest.ProviderConfig {
 	return c.providers
+}
+
+func (c *ModelOptions) Thinking() *bool {
+	return c.thinking
 }
 
 type Opt func(*ModelOptions)
@@ -61,6 +66,12 @@ func WithMaxTokens(maxTokens int64) Opt {
 func WithProviders(providers map[string]latest.ProviderConfig) Opt {
 	return func(cfg *ModelOptions) {
 		cfg.providers = providers
+	}
+}
+
+func WithThinking(enabled bool) Opt {
+	return func(cfg *ModelOptions) {
+		cfg.thinking = &enabled
 	}
 }
 

--- a/pkg/runtime/title_generator.go
+++ b/pkg/runtime/title_generator.go
@@ -55,6 +55,7 @@ func (t *titleGenerator) generate(ctx context.Context, sess *session.Session, ev
 		options.WithStructuredOutput(nil),
 		options.WithMaxTokens(20),
 		options.WithGeneratingTitle(),
+		options.WithThinking(false),
 	)
 
 	newTeam := team.New(


### PR DESCRIPTION
Make sure we disable thinking when generating the session title if the user had enabled thinking in their model config.

The amount of tokens required for thinking conflicts with `WithMaxTokens(20)` and causes the generation to fail