### PR TITLE
`/think` toggle

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -170,6 +170,7 @@ During TUI sessions, you can use special slash commands. Type `/` to see all ava
 | `/sessions` | Browse and load past sessions                                       |
 | `/shell`    | Start a shell                                                       |
 | `/star`     | Toggle star on current session                                      |
+| `/think`    | Toggle thinking/reasoning mode                                      |
 | `/yolo`     | Toggle automatic approval of tool calls                             |
 
 #### Runtime Model Switching

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -131,6 +131,7 @@ type SessionResponse struct {
 	Messages      []session.Message          `json:"messages,omitempty"`
 	CreatedAt     time.Time                  `json:"created_at"`
 	ToolsApproved bool                       `json:"tools_approved"`
+	Thinking      bool                       `json:"thinking"`
 	InputTokens   int64                      `json:"input_tokens"`
 	OutputTokens  int64                      `json:"output_tokens"`
 	WorkingDir    string                     `json:"working_dir,omitempty"`

--- a/pkg/model/provider/bedrock/client_test.go
+++ b/pkg/model/provider/bedrock/client_test.go
@@ -770,7 +770,7 @@ func TestBuildInferenceConfig_DisablesTempTopPWhenThinkingEnabled(t *testing.T) 
 	assert.Equal(t, int32(64000), *cfg.MaxTokens)
 }
 
-func TestBuildInferenceConfig_SetsTempTopPWhenThinkingDisabled(t *testing.T) {
+func TestBuildInferenceConfig_SetsTempTopPWhenThinkingNotConfigured(t *testing.T) {
 	t.Parallel()
 
 	temp := 0.7

--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -358,7 +358,9 @@ func (c *Client) CreateResponseStream(
 
 	// Configure reasoning for models that support it (o-series, gpt-5)
 	// Request detailed reasoning summary to get thinking traces for reasoning models
-	if isOpenAIReasoningModel(c.ModelConfig.Model) {
+	// Skip reasoning configuration entirely if thinking is explicitly disabled (via /think command)
+	thinkingEnabled := c.ModelOptions.Thinking() == nil || *c.ModelOptions.Thinking()
+	if isOpenAIReasoningModel(c.ModelConfig.Model) && thinkingEnabled {
 		params.Reasoning = shared.ReasoningParam{
 			Summary: shared.ReasoningSummaryDetailed,
 		}

--- a/pkg/model/provider/override_test.go
+++ b/pkg/model/provider/override_test.go
@@ -1,0 +1,343 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/cagent/pkg/config/latest"
+	"github.com/docker/cagent/pkg/model/provider/options"
+)
+
+// TestApplyOverrides_Thinking tests that applyOverrides correctly clears
+// thinking configuration when Thinking is set to false (disabled).
+func TestApplyOverrides_Thinking(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                      string
+		config                    *latest.ModelConfig
+		thinkingEnabled           *bool // nil means no override, true means enabled, false means disabled
+		expectThinkingBudget      *latest.ThinkingBudget
+		expectInterleavedThinking *bool // nil means key should not exist
+	}{
+		{
+			name: "clears explicit thinking_budget when disabled",
+			config: &latest.ModelConfig{
+				Provider:       "anthropic",
+				Model:          "claude-sonnet-4-0",
+				ThinkingBudget: &latest.ThinkingBudget{Tokens: 8192},
+			},
+			thinkingEnabled:      boolPtr(false),
+			expectThinkingBudget: nil,
+		},
+		{
+			name: "clears interleaved_thinking when disabled",
+			config: &latest.ModelConfig{
+				Provider:       "anthropic",
+				Model:          "claude-sonnet-4-0",
+				ThinkingBudget: &latest.ThinkingBudget{Tokens: 16384},
+				ProviderOpts:   map[string]any{"interleaved_thinking": true},
+			},
+			thinkingEnabled:           boolPtr(false),
+			expectThinkingBudget:      nil,
+			expectInterleavedThinking: nil, // key should be removed
+		},
+		{
+			name: "preserves thinking_budget when enabled",
+			config: &latest.ModelConfig{
+				Provider:       "anthropic",
+				Model:          "claude-sonnet-4-0",
+				ThinkingBudget: &latest.ThinkingBudget{Tokens: 8192},
+			},
+			thinkingEnabled:      boolPtr(true),
+			expectThinkingBudget: &latest.ThinkingBudget{Tokens: 8192},
+		},
+		{
+			name: "preserves interleaved_thinking when enabled",
+			config: &latest.ModelConfig{
+				Provider:       "anthropic",
+				Model:          "claude-sonnet-4-0",
+				ThinkingBudget: &latest.ThinkingBudget{Tokens: 8192},
+				ProviderOpts:   map[string]any{"interleaved_thinking": true},
+			},
+			thinkingEnabled:           boolPtr(true),
+			expectThinkingBudget:      &latest.ThinkingBudget{Tokens: 8192},
+			expectInterleavedThinking: boolPtr(true),
+		},
+		{
+			name: "preserves other ProviderOpts when clearing thinking",
+			config: &latest.ModelConfig{
+				Provider:       "anthropic",
+				Model:          "claude-sonnet-4-0",
+				ThinkingBudget: &latest.ThinkingBudget{Tokens: 8192},
+				ProviderOpts: map[string]any{
+					"interleaved_thinking": true,
+					"other_option":         "preserved",
+				},
+			},
+			thinkingEnabled:      boolPtr(false),
+			expectThinkingBudget: nil,
+		},
+		{
+			name: "nil options is a no-op",
+			config: &latest.ModelConfig{
+				Provider:       "anthropic",
+				Model:          "claude-sonnet-4-0",
+				ThinkingBudget: &latest.ThinkingBudget{Tokens: 8192},
+			},
+			thinkingEnabled:      nil, // Will pass nil opts
+			expectThinkingBudget: &latest.ThinkingBudget{Tokens: 8192},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Build options
+			var opts *options.ModelOptions
+			if tt.thinkingEnabled != nil {
+				mo := options.ModelOptions{}
+				options.WithThinking(*tt.thinkingEnabled)(&mo)
+				opts = &mo
+			}
+
+			// Save original other options for preservation check
+			var originalOtherOpts map[string]any
+			if tt.config.ProviderOpts != nil {
+				originalOtherOpts = make(map[string]any)
+				for k, v := range tt.config.ProviderOpts {
+					if k != "interleaved_thinking" {
+						originalOtherOpts[k] = v
+					}
+				}
+			}
+
+			// Apply overrides
+			result := applyOverrides(tt.config, opts)
+
+			// Verify thinking budget
+			if tt.expectThinkingBudget == nil {
+				assert.Nil(t, result.ThinkingBudget, "ThinkingBudget should be nil")
+			} else {
+				require.NotNil(t, result.ThinkingBudget, "ThinkingBudget should be set")
+				assert.Equal(t, tt.expectThinkingBudget.Tokens, result.ThinkingBudget.Tokens)
+				assert.Equal(t, tt.expectThinkingBudget.Effort, result.ThinkingBudget.Effort)
+			}
+
+			// Verify interleaved_thinking
+			if tt.expectInterleavedThinking == nil && tt.thinkingEnabled != nil && !*tt.thinkingEnabled {
+				// Key should be removed when thinking is disabled
+				if result.ProviderOpts != nil {
+					_, exists := result.ProviderOpts["interleaved_thinking"]
+					assert.False(t, exists, "interleaved_thinking should be removed")
+				}
+			} else if tt.expectInterleavedThinking != nil {
+				require.NotNil(t, result.ProviderOpts)
+				val, exists := result.ProviderOpts["interleaved_thinking"]
+				require.True(t, exists, "interleaved_thinking should exist")
+				assert.Equal(t, *tt.expectInterleavedThinking, val)
+			}
+
+			// Verify other ProviderOpts are preserved
+			for k, v := range originalOtherOpts {
+				require.NotNil(t, result.ProviderOpts, "ProviderOpts should exist for preserved keys")
+				assert.Equal(t, v, result.ProviderOpts[k], "other ProviderOpts key %s should be preserved", k)
+			}
+		})
+	}
+}
+
+// TestApplyOverrides_AllProviders tests that thinking override works for all providers.
+func TestApplyOverrides_AllProviders(t *testing.T) {
+	t.Parallel()
+
+	providers := []struct {
+		name     string
+		provider string
+		model    string
+	}{
+		{"OpenAI", "openai", "gpt-4o"},
+		{"Anthropic", "anthropic", "claude-sonnet-4-0"},
+		{"Google", "google", "gemini-2.5-flash"},
+		{"Bedrock Claude", "amazon-bedrock", "global.anthropic.claude-sonnet-4-5-20250929-v1:0"},
+		{"Mistral (alias)", "mistral", "mistral-large-latest"},
+		{"xAI (alias)", "xai", "grok-2"},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Create config with thinking budget
+			config := &latest.ModelConfig{
+				Provider:       p.provider,
+				Model:          p.model,
+				ThinkingBudget: &latest.ThinkingBudget{Tokens: 8192},
+			}
+
+			// Apply override with thinking disabled
+			mo := options.ModelOptions{}
+			options.WithThinking(false)(&mo)
+			result := applyOverrides(config, &mo)
+
+			// Thinking should be cleared for all providers
+			assert.Nil(t, result.ThinkingBudget,
+				"ThinkingBudget should be cleared for provider %s", p.provider)
+		})
+	}
+}
+
+// TestDefaultsThenOverrides tests the full flow: defaults applied first, then overrides.
+func TestDefaultsThenOverrides(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                 string
+		config               *latest.ModelConfig
+		thinkingEnabled      bool
+		expectThinkingBudget *latest.ThinkingBudget
+	}{
+		{
+			name: "OpenAI: defaults applied, then cleared by override",
+			config: &latest.ModelConfig{
+				Provider: "openai",
+				Model:    "gpt-4o",
+				// No ThinkingBudget set - defaults will apply
+			},
+			thinkingEnabled:      false,
+			expectThinkingBudget: nil, // Override clears the default
+		},
+		{
+			name: "OpenAI: defaults applied, preserved when enabled",
+			config: &latest.ModelConfig{
+				Provider: "openai",
+				Model:    "gpt-4o",
+			},
+			thinkingEnabled:      true,
+			expectThinkingBudget: &latest.ThinkingBudget{Effort: "medium"}, // Default preserved
+		},
+		{
+			name: "Anthropic: defaults applied, then cleared by override",
+			config: &latest.ModelConfig{
+				Provider: "anthropic",
+				Model:    "claude-sonnet-4-0",
+			},
+			thinkingEnabled:      false,
+			expectThinkingBudget: nil,
+		},
+		{
+			name: "Anthropic: defaults applied, preserved when enabled",
+			config: &latest.ModelConfig{
+				Provider: "anthropic",
+				Model:    "claude-sonnet-4-0",
+			},
+			thinkingEnabled:      true,
+			expectThinkingBudget: &latest.ThinkingBudget{Tokens: 8192},
+		},
+		{
+			name: "Google Gemini 2.5: defaults applied, then cleared by override",
+			config: &latest.ModelConfig{
+				Provider: "google",
+				Model:    "gemini-2.5-flash",
+			},
+			thinkingEnabled:      false,
+			expectThinkingBudget: nil,
+		},
+		{
+			name: "Google Gemini 3 Pro: defaults applied, then cleared by override",
+			config: &latest.ModelConfig{
+				Provider: "google",
+				Model:    "gemini-3-pro",
+			},
+			thinkingEnabled:      false,
+			expectThinkingBudget: nil,
+		},
+		{
+			name: "Bedrock Claude: defaults applied, then cleared by override",
+			config: &latest.ModelConfig{
+				Provider: "amazon-bedrock",
+				Model:    "anthropic.claude-3-sonnet",
+			},
+			thinkingEnabled:      false,
+			expectThinkingBudget: nil,
+		},
+		{
+			name: "Explicit budget cleared by override",
+			config: &latest.ModelConfig{
+				Provider:       "anthropic",
+				Model:          "claude-sonnet-4-0",
+				ThinkingBudget: &latest.ThinkingBudget{Tokens: 32000}, // Explicit
+			},
+			thinkingEnabled:      false,
+			expectThinkingBudget: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Step 1: Apply defaults (simulating createDirectProvider flow)
+			result := applyProviderDefaults(tt.config, nil)
+
+			// Step 2: Apply overrides
+			mo := options.ModelOptions{}
+			options.WithThinking(tt.thinkingEnabled)(&mo)
+			result = applyOverrides(result, &mo)
+
+			// Verify result
+			if tt.expectThinkingBudget == nil {
+				assert.Nil(t, result.ThinkingBudget, "ThinkingBudget should be nil after override")
+			} else {
+				require.NotNil(t, result.ThinkingBudget, "ThinkingBudget should be set")
+				assert.Equal(t, tt.expectThinkingBudget.Tokens, result.ThinkingBudget.Tokens)
+				assert.Equal(t, tt.expectThinkingBudget.Effort, result.ThinkingBudget.Effort)
+			}
+		})
+	}
+}
+
+// TestApplyOverrides_NilOpts tests that nil options returns config unchanged.
+func TestApplyOverrides_NilOpts(t *testing.T) {
+	t.Parallel()
+
+	config := &latest.ModelConfig{
+		Provider:       "anthropic",
+		Model:          "claude-sonnet-4-0",
+		ThinkingBudget: &latest.ThinkingBudget{Tokens: 8192},
+		ProviderOpts:   map[string]any{"interleaved_thinking": true},
+	}
+
+	result := applyOverrides(config, nil)
+
+	// Should be unchanged
+	require.NotNil(t, result.ThinkingBudget)
+	assert.Equal(t, 8192, result.ThinkingBudget.Tokens)
+	assert.Equal(t, true, result.ProviderOpts["interleaved_thinking"])
+}
+
+// TestApplyOverrides_DoesNotModifyOriginal tests that applyOverrides creates a copy.
+func TestApplyOverrides_DoesNotModifyOriginal(t *testing.T) {
+	t.Parallel()
+
+	original := &latest.ModelConfig{
+		Provider:       "anthropic",
+		Model:          "claude-sonnet-4-0",
+		ThinkingBudget: &latest.ThinkingBudget{Tokens: 8192},
+		ProviderOpts:   map[string]any{"interleaved_thinking": true},
+	}
+
+	mo := options.ModelOptions{}
+	options.WithThinking(false)(&mo)
+	result := applyOverrides(original, &mo)
+
+	// Original should be unchanged
+	require.NotNil(t, original.ThinkingBudget, "Original ThinkingBudget should be unchanged")
+	assert.Equal(t, 8192, original.ThinkingBudget.Tokens)
+
+	// Result should have changes
+	assert.Nil(t, result.ThinkingBudget, "Result ThinkingBudget should be nil")
+}

--- a/pkg/runtime/title_generator.go
+++ b/pkg/runtime/title_generator.go
@@ -55,7 +55,7 @@ func (t *titleGenerator) generate(ctx context.Context, sess *session.Session, ev
 		options.WithStructuredOutput(nil),
 		options.WithMaxTokens(20),
 		options.WithGeneratingTitle(),
-		options.WithThinking(false),
+		options.WithThinking(false), // Disable thinking to avoid max_tokens < thinking_budget errors
 	)
 
 	newTeam := team.New(

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -49,6 +49,8 @@ func New(ctx context.Context, sessionStore session.Store, runConfig *config.Runt
 	group.POST("/sessions/:id/resume", s.resumeSession)
 	// Toggle YOLO mode for a session
 	group.POST("/sessions/:id/tools/toggle", s.toggleSessionYolo)
+	// Toggle thinking mode for a session
+	group.POST("/sessions/:id/thinking/toggle", s.toggleSessionThinking)
 	// Update session permissions
 	group.PATCH("/sessions/:id/permissions", s.updateSessionPermissions)
 	// Create a new session
@@ -188,6 +190,7 @@ func (s *Server) getSession(c echo.Context) error {
 		CreatedAt:     sess.CreatedAt,
 		Messages:      sess.GetAllMessages(),
 		ToolsApproved: sess.ToolsApproved,
+		Thinking:      sess.Thinking,
 		InputTokens:   sess.InputTokens,
 		OutputTokens:  sess.OutputTokens,
 		WorkingDir:    sess.WorkingDir,
@@ -211,6 +214,13 @@ func (s *Server) resumeSession(c echo.Context) error {
 func (s *Server) toggleSessionYolo(c echo.Context) error {
 	if err := s.sm.ToggleToolApproval(c.Request().Context(), c.Param("id")); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to toggle session tool approval mode: %v", err))
+	}
+	return c.JSON(http.StatusOK, nil)
+}
+
+func (s *Server) toggleSessionThinking(c echo.Context) error {
+	if err := s.sm.ToggleThinking(c.Request().Context(), c.Param("id")); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to toggle session thinking mode: %v", err))
 	}
 	return c.JSON(http.StatusOK, nil)
 }

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -223,6 +223,20 @@ func (sm *SessionManager) ToggleToolApproval(ctx context.Context, sessionID stri
 	return sm.sessionStore.UpdateSession(ctx, sess)
 }
 
+// ToggleThinking toggles the thinking mode for a session.
+func (sm *SessionManager) ToggleThinking(ctx context.Context, sessionID string) error {
+	sm.mux.Lock()
+	defer sm.mux.Unlock()
+	sess, err := sm.sessionStore.GetSession(ctx, sessionID)
+	if err != nil {
+		return err
+	}
+
+	sess.Thinking = !sess.Thinking
+
+	return sm.sessionStore.UpdateSession(ctx, sess)
+}
+
 // UpdateSessionPermissions updates the permissions for a session.
 func (sm *SessionManager) UpdateSessionPermissions(ctx context.Context, sessionID string, perms *session.PermissionsConfig) error {
 	sm.mux.Lock()

--- a/pkg/session/migrations.go
+++ b/pkg/session/migrations.go
@@ -235,5 +235,12 @@ func getAllMigrations() []Migration {
 			UpSQL:       `ALTER TABLE sessions ADD COLUMN custom_models_used TEXT DEFAULT '[]'`,
 			DownSQL:     `ALTER TABLE sessions DROP COLUMN custom_models_used`,
 		},
+		{
+			ID:          13,
+			Name:        "013_add_thinking_column",
+			Description: "Add thinking column to sessions table for session-level thinking toggle (default enabled)",
+			UpSQL:       `ALTER TABLE sessions ADD COLUMN thinking BOOLEAN DEFAULT 1`,
+			DownSQL:     `ALTER TABLE sessions DROP COLUMN thinking`,
+		},
 	}
 }

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -62,6 +62,12 @@ type Session struct {
 	// ToolsApproved is a flag to indicate if the tools have been approved
 	ToolsApproved bool `json:"tools_approved"`
 
+	// Thinking is a session-level flag to enable thinking/interleaved thinking
+	// defaults for all providers. When false, providers will not apply auto-thinking budgets
+	// or interleaved thinking, regardless of model config. This is controlled by the /think
+	// command in the TUI. Defaults to true (thinking enabled).
+	Thinking bool `json:"thinking"`
+
 	// HideToolResults is a flag to indicate if tool results should be hidden
 	HideToolResults bool `json:"hide_tool_results"`
 
@@ -387,6 +393,12 @@ func WithToolsApproved(toolsApproved bool) Opt {
 	}
 }
 
+func WithThinking(thinking bool) Opt {
+	return func(s *Session) {
+		s.Thinking = thinking
+	}
+}
+
 func WithHideToolResults(hideToolResults bool) Opt {
 	return func(s *Session) {
 		s.HideToolResults = hideToolResults
@@ -427,6 +439,7 @@ func New(opts ...Opt) *Session {
 		ID:              sessionID,
 		CreatedAt:       time.Now(),
 		SendUserMessage: true,
+		Thinking:        true, // Default to thinking enabled
 	}
 
 	for _, opt := range opts {

--- a/pkg/tui/commands/commands.go
+++ b/pkg/tui/commands/commands.go
@@ -146,6 +146,16 @@ func builtInSessionCommands() []Item {
 			},
 		},
 		{
+			ID:           "session.think",
+			Label:        "Think",
+			SlashCommand: "/think",
+			Description:  "Toggle thinking/reasoning mode",
+			Category:     "Session",
+			Execute: func(string) tea.Cmd {
+				return core.CmdHandler(messages.ToggleThinkingMsg{})
+			},
+		},
+		{
 			ID:           "session.shell",
 			Label:        "Shell",
 			SlashCommand: "/shell",

--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -755,6 +755,7 @@ func (m *model) toolsetInfo(contentWidth int) string {
 		shortcut string
 	}{
 		{m.sessionState.YoloMode, "YOLO mode enabled", "^y"},
+		{m.sessionState.Thinking, "Thinking enabled", "/think"},
 		{m.sessionState.HideToolResults, "Tool output hidden", "^o"},
 		{m.sessionState.SplitDiffView, "Split Diff View enabled", "^t"},
 	}

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -190,6 +190,27 @@ func (a *appModel) handleToggleYolo() (tea.Model, tea.Cmd) {
 	return a, nil
 }
 
+func (a *appModel) handleToggleThinking() (tea.Model, tea.Cmd) {
+	sess := a.application.Session()
+	sess.Thinking = !sess.Thinking
+	a.sessionState.SetThinking(sess.Thinking)
+
+	// Persist the change to the database immediately
+	if store := a.application.SessionStore(); store != nil {
+		if err := store.UpdateSession(context.Background(), sess); err != nil {
+			return a, notification.ErrorCmd(fmt.Sprintf("Failed to save session: %v", err))
+		}
+	}
+
+	var msg string
+	if sess.Thinking {
+		msg = "Thinking/reasoning enabled for this session"
+	} else {
+		msg = "Thinking/reasoning disabled for this session"
+	}
+	return a, notification.InfoCmd(msg)
+}
+
 func (a *appModel) handleToggleHideToolResults() (tea.Model, tea.Cmd) {
 	updated, cmd := a.chatPage.Update(messages.ToggleHideToolResultsMsg{})
 	a.chatPage = updated.(chat.Page)

--- a/pkg/tui/messages/messages.go
+++ b/pkg/tui/messages/messages.go
@@ -11,6 +11,7 @@ type (
 	ExportSessionMsg               struct{ Filename string }
 	ShowCostDialogMsg              struct{}
 	ToggleYoloMsg                  struct{}
+	ToggleThinkingMsg              struct{}
 	ToggleHideToolResultsMsg       struct{}
 	StartShellMsg                  struct{}
 	SwitchAgentMsg                 struct{ AgentName string }

--- a/pkg/tui/service/sessionstate.go
+++ b/pkg/tui/service/sessionstate.go
@@ -13,6 +13,7 @@ type SessionState struct {
 	// or unified (false)
 	SplitDiffView   bool
 	YoloMode        bool
+	Thinking        bool // true = enabled (default), false = disabled
 	HideToolResults bool
 	PreviousMessage *types.Message
 	// CurrentAgent is the name of the currently active agent for user messages
@@ -24,6 +25,7 @@ func NewSessionState(sessionState *session.Session) *SessionState {
 	return &SessionState{
 		SplitDiffView:   true, // Default to split view
 		YoloMode:        sessionState.ToolsApproved,
+		Thinking:        sessionState.Thinking,
 		HideToolResults: sessionState.HideToolResults,
 	}
 }
@@ -47,4 +49,8 @@ func (s *SessionState) ToggleHideToolResults() {
 
 func (s *SessionState) SetCurrentAgent(agentName string) {
 	s.CurrentAgent = agentName
+}
+
+func (s *SessionState) SetThinking(enabled bool) {
+	s.Thinking = enabled
 }

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -299,6 +299,9 @@ func (a *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case messages.ToggleYoloMsg:
 		return a.handleToggleYolo()
 
+	case messages.ToggleThinkingMsg:
+		return a.handleToggleThinking()
+
 	case messages.ToggleHideToolResultsMsg:
 		return a.handleToggleHideToolResults()
 


### PR DESCRIPTION
Includes:
- `/think` command to quickly enable or disable thinking, session-wide, at any point in the conversation.
- API support for the think toggle
- Sidebar view
- Notification popup on toggle
- DB persistence w/ migration 

---

Screenshots:

<img width="1269" height="990" alt="Screenshot From 2026-01-17 18-42-45" src="https://github.com/user-attachments/assets/463b311b-da62-4aa0-8e8d-e68a200b25ce" />
<img width="1269" height="990" alt="Screenshot From 2026-01-17 18-48-10" src="https://github.com/user-attachments/assets/5547e056-ca84-4cd4-b945-228978d55810" />