### PR TITLE
Remove interleaved thinking if thinking is explicitly disabled

### DIFF
--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -143,7 +143,7 @@ type ModelConfig struct {
 	BaseURL           string   `json:"base_url,omitempty"`
 	ParallelToolCalls *bool    `json:"parallel_tool_calls,omitempty"`
 	TokenKey          string   `json:"token_key,omitempty"`
-	// ProviderOpts allows provider-specific options. Currently used for "dmr" provider only.
+	// ProviderOpts allows provider-specific options.
 	ProviderOpts map[string]any `json:"provider_opts,omitempty"`
 	TrackUsage   *bool          `json:"track_usage,omitempty"`
 	// ThinkingBudget controls reasoning effort/budget:

--- a/pkg/model/provider/clone.go
+++ b/pkg/model/provider/clone.go
@@ -25,9 +25,6 @@ func CloneWithOptions(ctx context.Context, base Provider, opts ...options.Opt) P
 		opt(tempOpts)
 		mt := tempOpts.MaxTokens()
 		modelConfig.MaxTokens = &mt
-		if t := tempOpts.Thinking(); t != nil && !*t {
-			modelConfig.ThinkingBudget = nil
-		}
 	}
 
 	clone, err := New(ctx, &modelConfig, config.Env, mergedOpts...)

--- a/pkg/model/provider/provider.go
+++ b/pkg/model/provider/provider.go
@@ -211,6 +211,20 @@ func createDirectProvider(ctx context.Context, cfg *latest.ModelConfig, env envi
 
 	// Apply defaults from custom providers (from config) or built-in aliases
 	enhancedCfg := applyProviderDefaults(cfg, globalOptions.Providers())
+	if thinking := globalOptions.Thinking(); thinking != nil && !*thinking {
+		enhancedCfg.ThinkingBudget = nil
+
+		// with thinking explicitly disabled, also remove the interleaved_thinking provider option
+		if enhancedCfg.ProviderOpts != nil {
+			// Copy to avoid mutating shared ProviderOpts in the original config
+			optsCopy := make(map[string]any, len(enhancedCfg.ProviderOpts))
+			for key, value := range enhancedCfg.ProviderOpts {
+				optsCopy[key] = value
+			}
+			delete(optsCopy, "interleaved_thinking")
+			enhancedCfg.ProviderOpts = optsCopy
+		}
+	}
 
 	// Apply overrides (e.g., disable thinking if requested by session)
 	enhancedCfg = applyOverrides(enhancedCfg, &globalOptions)


### PR DESCRIPTION
and move to `createDirectProvider` so all code paths are covered, not just `Clone`