### PR TITLE
Allow disabling thinking via yaml with thinking_budget: 0 or none

### DIFF
--- a/cagent-schema.json
+++ b/cagent-schema.json
@@ -459,26 +459,29 @@
           "description": "Whether to track usage"
         },
         "thinking_budget": {
-          "description": "Controls reasoning effort/budget. OpenAI: string levels ('minimal','low','medium','high'), default 'medium'. Anthropic: integer token budget (1024-32768), default 8192. Amazon Bedrock (Claude): same as Anthropic. Google Gemini 2.5: integer token budget (-1 for dynamic, 0 to disable, 24576 max), default -1. Google Gemini 3: string levels ('minimal' Flash only,'low','medium','high'), default 'high' for Pro, 'medium' for Flash.",
+          "description": "Controls reasoning effort/budget. Use 'none' or 0 to disable thinking. OpenAI: string levels ('minimal','low','medium','high'), default 'medium'. Anthropic: integer token budget (1024-32768), default 8192. Amazon Bedrock (Claude): same as Anthropic. Google Gemini 2.5: integer token budget (-1 for dynamic, 0 to disable, 24576 max), default -1. Google Gemini 3: string levels ('minimal' Flash only,'low','medium','high'), default 'high' for Pro, 'medium' for Flash.",
           "oneOf": [
             {
               "type": "string",
               "enum": [
+                "none",
                 "minimal",
                 "low",
                 "medium",
                 "high"
               ],
-              "description": "Reasoning effort level (OpenAI, Gemini 3)"
+              "description": "Reasoning effort level (OpenAI, Gemini 3). Use 'none' to disable thinking."
             },
             {
               "type": "integer",
               "minimum": -1,
               "maximum": 32768,
-              "description": "Token budget for extended thinking (Anthropic, Bedrock Claude, Gemini 2.5)"
+              "description": "Token budget for extended thinking (Anthropic, Bedrock Claude, Gemini 2.5). Use 0 to disable thinking."
             }
           ],
           "examples": [
+            "none",
+            0,
             "minimal",
             "low",
             "medium",

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -310,10 +310,17 @@ func (f *runExecFlags) createLocalRuntimeAndSession(ctx context.Context, loadRes
 
 		slog.Debug("Loaded existing session", "session_id", f.sessionID, "agent", f.agentName)
 	} else {
+		thinking := true
+		if tb := agent.Model().BaseConfig().ModelConfig.ThinkingBudget; tb != nil {
+			if tb.Effort == "none" || (tb.Tokens == 0 && tb.Effort == "") {
+				thinking = false
+			}
+		}
 		sess = session.New(
 			session.WithMaxIterations(agent.MaxIterations()),
 			session.WithToolsApproved(f.autoApprove),
 			session.WithHideToolResults(f.hideToolResults),
+			session.WithThinking(thinking),
 		)
 		// Session is stored lazily on first UpdateSession call (when content is added)
 		// This avoids creating empty sessions in the database

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -284,11 +284,31 @@ models:
 
 Determine how much the model should think by setting the `thinking_budget`
 
+- **Disable thinking**: Use `none` (string) or `0` (integer) to explicitly disable thinking for any provider
 - **OpenAI**: use effort levels — `minimal`, `low`, `medium`, `high`. Default: `medium`
 - **Anthropic**: set an integer token budget. Range is 1024–32768; must be strictly less than `max_tokens`. Default: `8192` with `interleaved_thinking: true`
 - **Google (Gemini 2.5)**: set an integer token budget. `0` -> disable thinking, `-1` -> dynamic thinking (model decides). Default: `-1` (dynamic)
 - **Google (Gemini 3)**: use effort levels — `minimal` (Flash only), `low`, `medium`, `high`. Default: `high` for Pro, `medium` for Flash
 - **Amazon Bedrock (Claude models)**: set an integer token budget, same as Anthropic. Default: `8192` with `interleaved_thinking: true`
+
+**Disabling thinking:**
+
+```yaml
+models:
+  # Using string "none"
+  gpt-no-thinking:
+    provider: openai
+    model: gpt-5
+    thinking_budget: none # or 0
+
+  # Using integer 0
+  claude-no-thinking:
+    provider: anthropic
+    model: claude-sonnet-4-5
+    thinking_budget: 0 # or none
+```
+
+Note: When thinking is disabled via config, it can still be enabled during a session using the `/think` command, which will restore the provider's default thinking configuration.
 
 Examples (OpenAI):
 


### PR DESCRIPTION
Configs like this will disable thinking. If re-enabled with `/think`, default budgets will be used based on the model provider

```yaml
models:
  # Using string "none"
  gpt-no-thinking:
    provider: openai
    model: gpt-5
    thinking_budget: none # or 0

  # Using integer 0
  claude-no-thinking:
    provider: anthropic
    model: claude-sonnet-4-5
    thinking_budget: 0 # or none
```