### PR TITLE
tui(edit_file): skip diff rendering on tool failure

### DIFF
--- a/pkg/tui/components/tool/editfile/editfile.go
+++ b/pkg/tui/components/tool/editfile/editfile.go
@@ -51,7 +51,7 @@ func render(
 		// - rejection/error message
 		line := fmt.Sprintf(
 			"%s%s %s",
-			styles.ToolErrorIcon.Render("✖ "),
+			toolcommon.Icon(msg, s),
 			styles.ToolNameError.Render(msg.ToolDefinition.DisplayName()),
 			styles.ToolErrorMessageStyle.Render(msg.Content),
 		)


### PR DESCRIPTION
## What I did

Adjusted the `edit_file` TUI rendering logic to **skip diff rendering when the tool execution fails**.

When an edit fails (e.g. *old text not found*), the tool does not produce a valid file state. Attempting to render a diff in this scenario led to inconsistent layout calculations and caused the editor scrollbar to go out of bounds.

This change ensures that, on failure, the TUI renders only the formatted error message and avoids invalid diff rendering.

## Related issue

Fixes #1366

## Notes

- Skips diff rendering when the `edit_file` tool returns an error  
- Prevents invalid layout and viewport calculations in the editor  
- Avoids scrollbar overflow after failed edits  
- Keeps existing behavior unchanged for successful edits  
- Purely a TUI rendering fix (no tool or API behavior changes)

## Tests

### Before

When an `edit_file` operation failed (e.g. *old text not found*):

- The TUI still attempted to render a diff  
- Diff rendering was based on an invalid file state  
- Layout calculations became inconsistent  
- The editor scrollbar could go out of bounds  
- The UI appeared broken after the failed edit  

### After

When an `edit_file` operation fails:

- Diff rendering is skipped entirely  
- Only the formatted error message is shown  
- Layout and viewport calculations remain consistent  
- The editor remains usable and visually stable  
- Successful edits continue to render diffs as before  
