### PR TITLE
Migrate tests to use t.Chdir() and add linter rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,6 +38,8 @@ linters:
           msg: "do not use os.MkdirTemp() in tests, use t.TempDir()"
         - pattern: os\.Setenv()
           msg: "do not use os.Setenv() in tests, use t.Setenv()"
+        - pattern: os\.Chdir()
+          msg: "do not use os.Chdir() in tests, use t.Chdir()"
         - pattern: fmt\.Print.*()
           msg: "do not use fmt.Print() or fmt.Println() in tests"
     depguard:

--- a/cmd/root/completion_test.go
+++ b/cmd/root/completion_test.go
@@ -190,12 +190,7 @@ func TestCompleteAgentFilename(t *testing.T) {
 			tt.setup(t, tmpDir)
 
 			// Change working directory
-			origDir, err := os.Getwd()
-			require.NoError(t, err)
-			require.NoError(t, os.Chdir(tmpDir))
-			t.Cleanup(func() {
-				require.NoError(t, os.Chdir(origDir))
-			})
+			t.Chdir(tmpDir)
 
 			completions, directive := completeAgentFilename(tt.toComplete)
 
@@ -272,12 +267,7 @@ func TestCompleteAliasIncludesYAMLFiles(t *testing.T) {
 	writeFile(t, tmpDir, "readme.md") // not a yaml file
 
 	// Change working directory
-	origDir, err := os.Getwd()
-	require.NoError(t, err)
-	require.NoError(t, os.Chdir(tmpDir))
-	t.Cleanup(func() {
-		require.NoError(t, os.Chdir(origDir))
-	})
+	t.Chdir(tmpDir)
 
 	// Test that completeAlias includes YAML files starting with "go"
 	completions, directive := completeAlias("go")

--- a/cmd/root/record_test.go
+++ b/cmd/root/record_test.go
@@ -1,7 +1,6 @@
 package root
 
 import (
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -26,11 +25,7 @@ func TestSetupRecordingProxy_EmptyPath(t *testing.T) {
 }
 
 func TestSetupRecordingProxy_AutoGeneratesFilename(t *testing.T) {
-	tmpDir := t.TempDir()
-	originalWd, err := os.Getwd()
-	require.NoError(t, err)
-	require.NoError(t, os.Chdir(tmpDir))
-	t.Cleanup(func() { _ = os.Chdir(originalWd) })
+	t.Chdir(t.TempDir())
 
 	var runConfig config.RuntimeConfig
 

--- a/pkg/evaluation/save_test.go
+++ b/pkg/evaluation/save_test.go
@@ -1,31 +1,17 @@
 package evaluation
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/docker/cagent/pkg/session"
 )
 
 func TestSaveWithCustomFilename(t *testing.T) {
-	// Create a temporary directory for tests
-	tmpDir := t.TempDir()
-
-	// Change to temp directory
-	oldWd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Failed to get working directory: %v", err)
-	}
-	defer func() {
-		if err := os.Chdir(oldWd); err != nil {
-			t.Errorf("Failed to restore working directory: %v", err)
-		}
-	}()
-
-	if err := os.Chdir(tmpDir); err != nil {
-		t.Fatalf("Failed to change to temp dir: %v", err)
-	}
+	// Create a temporary directory and change to it
+	t.Chdir(t.TempDir())
 
 	// Create a test session
 	sess := session.New()
@@ -33,46 +19,19 @@ func TestSaveWithCustomFilename(t *testing.T) {
 
 	// Test 1: Save with custom filename
 	evalFile, err := Save(sess, "my-custom-eval")
-	if err != nil {
-		t.Fatalf("Failed to save eval: %v", err)
-	}
-
-	expectedPath := filepath.Join("evals", "my-custom-eval.json")
-	if evalFile != expectedPath {
-		t.Errorf("Expected file path %q, got %q", expectedPath, evalFile)
-	}
-
-	if _, err := os.Stat(evalFile); os.IsNotExist(err) {
-		t.Errorf("Expected file %q to exist", evalFile)
-	}
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join("evals", "my-custom-eval.json"), evalFile)
+	require.FileExists(t, evalFile)
 
 	// Test 2: Save without filename (should use session ID)
 	evalFile2, err := Save(sess, "")
-	if err != nil {
-		t.Fatalf("Failed to save eval: %v", err)
-	}
-
-	expectedPath2 := filepath.Join("evals", sess.ID+".json")
-	if evalFile2 != expectedPath2 {
-		t.Errorf("Expected file path %q, got %q", expectedPath2, evalFile2)
-	}
-
-	if _, err := os.Stat(evalFile2); os.IsNotExist(err) {
-		t.Errorf("Expected file %q to exist", evalFile2)
-	}
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join("evals", sess.ID+".json"), evalFile2)
+	require.FileExists(t, evalFile2)
 
 	// Test 3: Save with same filename (should add _1 suffix)
 	evalFile3, err := Save(sess, "my-custom-eval")
-	if err != nil {
-		t.Fatalf("Failed to save eval: %v", err)
-	}
-
-	expectedPath3 := filepath.Join("evals", "my-custom-eval_1.json")
-	if evalFile3 != expectedPath3 {
-		t.Errorf("Expected file path %q, got %q", expectedPath3, evalFile3)
-	}
-
-	if _, err := os.Stat(evalFile3); os.IsNotExist(err) {
-		t.Errorf("Expected file %q to exist", evalFile3)
-	}
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join("evals", "my-custom-eval_1.json"), evalFile3)
+	require.FileExists(t, evalFile3)
 }

--- a/pkg/skills/skills_test.go
+++ b/pkg/skills/skills_test.go
@@ -274,12 +274,8 @@ func TestBuildSkillsPrompt_Empty(t *testing.T) {
 }
 
 func TestLoad_Integration(t *testing.T) {
-	originalWd, err := os.Getwd()
-	require.NoError(t, err)
-	defer func() { _ = os.Chdir(originalWd) }()
-
 	tmpDir := t.TempDir()
-	require.NoError(t, os.Chdir(tmpDir))
+	t.Chdir(tmpDir)
 
 	claudeProjectDir := filepath.Join(tmpDir, ".claude", "skills", "test-skill")
 	require.NoError(t, os.MkdirAll(claudeProjectDir, 0o755))


### PR DESCRIPTION
Replace manual os.Getwd()/os.Chdir()/cleanup patterns with t.Chdir() in 4 test files:
- cmd/root/completion_test.go
- cmd/root/record_test.go
- pkg/evaluation/save_test.go
- pkg/skills/skills_test.go

Add forbidigo linter rule to prevent future use of os.Chdir() in tests.

Assisted-By: cagent