### PR TITLE
Make history append-only

### DIFF
--- a/pkg/history/history.go
+++ b/pkg/history/history.go
@@ -1,14 +1,12 @@
 package history
 
 import (
-	"bytes"
+	"bufio"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
-
-	"github.com/natefinch/atomic"
 )
 
 type History struct {
@@ -45,8 +43,12 @@ func New(opts ...Opt) (*History, error) {
 	}
 
 	h := &History{
-		path:    filepath.Join(homeDir, ".cagent", "history.json"),
+		path:    filepath.Join(homeDir, ".cagent", "history"),
 		current: -1,
+	}
+
+	if err := h.migrateOldHistory(homeDir); err != nil {
+		return nil, err
 	}
 
 	if err := h.load(); err != nil && !os.IsNotExist(err) {
@@ -56,15 +58,42 @@ func New(opts ...Opt) (*History, error) {
 	return h, nil
 }
 
+func (h *History) migrateOldHistory(homeDir string) error {
+	oldPath := filepath.Join(homeDir, ".cagent", "history.json")
+
+	data, err := os.ReadFile(oldPath)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	var old struct {
+		Messages []string `json:"messages"`
+	}
+	if err := json.Unmarshal(data, &old); err != nil {
+		return err
+	}
+
+	for _, msg := range old.Messages {
+		if err := h.append(msg); err != nil {
+			return err
+		}
+	}
+
+	return os.Remove(oldPath)
+}
+
 func (h *History) Add(message string) error {
-	// Add the message last but avoid duplicate messages
+	// Update in-memory list: remove duplicate and append to end
 	h.Messages = slices.DeleteFunc(h.Messages, func(m string) bool {
 		return m == message
 	})
 	h.Messages = append(h.Messages, message)
 	h.current = len(h.Messages)
 
-	return h.save()
+	return h.append(message)
 }
 
 func (h *History) Previous() string {
@@ -104,40 +133,71 @@ func (h *History) Next() string {
 // LatestMatch returns the most recent history entry that extends the provided
 // prefix, or the latest message when no prefix is supplied.
 func (h *History) LatestMatch(prefix string) string {
-	if prefix == "" {
-		if len(h.Messages) == 0 {
-			return ""
-		}
-		return h.Messages[len(h.Messages)-1]
-	}
-
 	for i := len(h.Messages) - 1; i >= 0; i-- {
-		if strings.HasPrefix(h.Messages[i], prefix) && len(h.Messages[i]) > len(prefix) {
-			return h.Messages[i]
+		msg := h.Messages[i]
+		if strings.HasPrefix(msg, prefix) && len(msg) > len(prefix) {
+			return msg
 		}
 	}
-
 	return ""
 }
 
-func (h *History) save() error {
-	data, err := json.Marshal(h)
-	if err != nil {
-		return err
-	}
-
+func (h *History) append(message string) error {
 	if err := os.MkdirAll(filepath.Dir(h.path), 0o755); err != nil {
 		return err
 	}
 
-	return atomic.WriteFile(h.path, bytes.NewReader(data))
-}
+	f, err := os.OpenFile(h.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
 
-func (h *History) load() error {
-	data, err := os.ReadFile(h.path)
+	encoded, err := json.Marshal(message)
 	if err != nil {
 		return err
 	}
 
-	return json.Unmarshal(data, h)
+	_, err = f.Write(append(encoded, '\n'))
+	return err
+}
+
+func (h *History) load() error {
+	f, err := os.Open(h.path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	var all []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+
+		var message string
+		if err := json.Unmarshal([]byte(line), &message); err != nil {
+			continue
+		}
+		all = append(all, message)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+
+	// Deduplicate keeping the latest occurrence of each message
+	seen := make(map[string]bool)
+	for i := len(all) - 1; i >= 0; i-- {
+		if seen[all[i]] {
+			continue
+		}
+		seen[all[i]] = true
+		h.Messages = append(h.Messages, all[i])
+	}
+	slices.Reverse(h.Messages)
+
+	return nil
 }

--- a/pkg/history/history_test.go
+++ b/pkg/history/history_test.go
@@ -1,6 +1,8 @@
 package history
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -119,4 +121,69 @@ func TestHistory_MoveDuplicateLast(t *testing.T) {
 	assert.Equal(t, "third", h.Previous())
 	assert.Equal(t, "second", h.Previous())
 	assert.Equal(t, "second", h.Previous())
+}
+
+func TestHistory_MultilineMessage(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	h, err := New(WithBaseDir(tmpDir))
+	require.NoError(t, err)
+
+	multiline := "line1\nline2\nline3"
+	require.NoError(t, h.Add(multiline))
+
+	h2, err := New(WithBaseDir(tmpDir))
+	require.NoError(t, err)
+
+	require.Len(t, h2.Messages, 1)
+	assert.Equal(t, multiline, h2.Messages[0])
+}
+
+func TestHistory_MigrateOldFormat(t *testing.T) {
+	tmpDir := t.TempDir()
+	err := os.MkdirAll(filepath.Join(tmpDir, ".cagent"), 0o755)
+	require.NoError(t, err)
+	oldHistFile := filepath.Join(tmpDir, ".cagent", "history.json")
+	newHistFile := filepath.Join(tmpDir, ".cagent", "history")
+
+	require.NoError(t, os.WriteFile(oldHistFile, []byte(`{"messages":["old1","old2","old3"]}`), 0o644))
+
+	h, err := New(WithBaseDir(tmpDir))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"old1", "old2", "old3"}, h.Messages)
+
+	_, err = os.Stat(oldHistFile)
+	assert.True(t, os.IsNotExist(err), "old history.json should be removed")
+
+	_, err = os.Stat(newHistFile)
+	assert.NoError(t, err, "new history file should exist")
+}
+
+func TestHistory_LatestMatch(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	h, err := New(WithBaseDir(tmpDir))
+	require.NoError(t, err)
+
+	// Empty history returns empty string
+	assert.Empty(t, h.LatestMatch(""))
+	assert.Empty(t, h.LatestMatch("prefix"))
+
+	// Add some messages
+	require.NoError(t, h.Add("hello world"))
+	require.NoError(t, h.Add("hello there"))
+	require.NoError(t, h.Add("goodbye"))
+
+	// Empty prefix returns latest message
+	assert.Equal(t, "goodbye", h.LatestMatch(""))
+
+	// Prefix matching returns latest match
+	assert.Equal(t, "hello there", h.LatestMatch("hello"))
+	assert.Equal(t, "goodbye", h.LatestMatch("good"))
+
+	// No match returns empty string
+	assert.Empty(t, h.LatestMatch("xyz"))
+
+	// Exact match doesn't count (must extend prefix)
+	assert.Empty(t, h.LatestMatch("goodbye"))
 }


### PR DESCRIPTION
Move to an NDJSON file format, old history is migrated.

The history being append-only now fixes the case where two cagent processes would erase one another's history