### PR TITLE
## Fix: Predefined slash commands work correctly while agent is working

### DIFF
--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -611,6 +611,14 @@ func (p *chatPage) cancelStream(showCancelMessage bool) tea.Cmd {
 // handleSendMsg handles incoming messages from the editor, either processing
 // them immediately or queuing them if the agent is busy.
 func (p *chatPage) handleSendMsg(msg msgtypes.SendMsg) (layout.Model, tea.Cmd) {
+	// Predefined slash commands (e.g., /yolo, /exit, /compact) execute immediately
+	// even while the agent is working - they're UI commands that don't interrupt the stream.
+	// Custom agent commands (defined in config) should still be queued.
+	if commands.ParseSlashCommand(msg.Content) != nil {
+		cmd := p.processMessage(msg)
+		return p, cmd
+	}
+
 	// If not working, process immediately
 	if !p.working {
 		cmd := p.processMessage(msg)


### PR DESCRIPTION
### Problem

When the agent is processing a long-running prompt, sending a predefined slash command (like `/yolo`) via the completion popup would:
1. **Freeze the agent** - the stream would stop and never continue
2. **Get queued** instead of executing immediately

### Root Cause

The completion popup's auto-submit feature bypasses the editor's `working` check, allowing slash commands to be sent while the agent is busy. When `processMessage` received these commands, it would:
1. Call `msgCancel()` first, cancelling the running stream
2. Then recognize the slash command and return early without starting a new stream
3. Result: cancelled stream with nothing to replace it → freeze

### Solution

**Commit 1: Don't cancel when running commands**
- Move the slash command check (`ParseSlashCommand`) *before* the `msgCancel()` call
- Predefined slash commands now return early without touching the running stream

**Commit 2: Don't queue predefined commands**  
- In `handleSendMsg`, check for predefined slash commands first
- If it's a predefined command (`/yolo`, `/exit`, `/compact`, etc.), execute immediately
- Custom agent commands (defined in config) still get queued as expected

### Behavior After Fix

| Command Type | While Agent Working |
|-------------|---------------------|
| Predefined (`/yolo`, `/exit`, `/compact`) | Executes immediately, stream continues |
| Custom agent command (`/fix-lint`) | Queued |
| Regular message | Queued |