### PR TITLE
Basic multi-choice selection dialog for the TUI

### DIFF
--- a/pkg/tui/dialog/multi_choice.go
+++ b/pkg/tui/dialog/multi_choice.go
@@ -1,0 +1,848 @@
+package dialog
+
+import (
+	"strconv"
+	"strings"
+
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/docker/cagent/pkg/tui/core"
+	"github.com/docker/cagent/pkg/tui/core/layout"
+	"github.com/docker/cagent/pkg/tui/styles"
+)
+
+// MultiChoiceOption represents a single selectable option in the dialog.
+type MultiChoiceOption struct {
+	ID    string // Stable identifier for the option
+	Label string // Display label shown to user
+	Value string // Value returned when selected (e.g., model-friendly sentence)
+}
+
+// MultiChoiceResult holds the result of user selection.
+type MultiChoiceResult struct {
+	OptionID    string // ID of the selected option ("custom" for custom input, "skip" for no reason)
+	Value       string // The value text (option's Value or custom text)
+	IsCustom    bool   // True if user provided custom input
+	IsSkipped   bool   // True if user chose to skip (no reason)
+	IsCancelled bool   // True if user cancelled/escaped
+}
+
+// MultiChoiceResultMsg is the tea.Msg sent when the user makes a selection.
+type MultiChoiceResultMsg struct {
+	DialogID string
+	Result   MultiChoiceResult
+}
+
+// MultiChoiceConfig configures the multi-choice dialog.
+type MultiChoiceConfig struct {
+	DialogID          string              // Unique identifier for this dialog instance
+	Title             string              // Dialog title (used as the main header)
+	Options           []MultiChoiceOption // List of options (max 10 for number selection 0-9)
+	AllowCustom       bool                // Whether to allow custom text input
+	AllowSecondary    bool                // Whether to allow secondary action (e.g., skip)
+	SecondaryLabel    string              // Label for secondary button (default: "Skip")
+	PrimaryLabel      string              // Label for primary button (default: "Continue")
+	CustomPlaceholder string              // Placeholder for custom input
+}
+
+// selection represents which item is currently selected.
+type selection int
+
+const (
+	selectionNone   selection = -1 // Nothing selected
+	selectionCustom selection = -2 // Custom text input selected
+	// Values >= 0 represent option indices
+)
+
+// Layout constants for multi-choice dialog.
+const (
+	multiChoiceMinDialogWidth    = 70 // Minimum dialog width (enough for help + buttons)
+	multiChoiceMaxDialogWidth    = 85 // Maximum dialog width
+	multiChoiceScreenWidthFactor = 90 // Max percentage of screen width (90%)
+	multiChoiceMinLabelWidth     = 10 // Minimum width for option labels
+	multiChoiceButtonSpacing     = 2  // Spacing between buttons
+	multiChoiceMinHelpSpacing    = 2  // Minimum spacing between help text and buttons
+)
+
+// indexToDisplayNum converts a 0-based option index to a display number.
+// Options 0-8 display as 1-9, option 9 displays as 0.
+func indexToDisplayNum(idx int) int {
+	if idx == 9 {
+		return 0
+	}
+	return idx + 1
+}
+
+// formatKeyRange returns the key range string for help text.
+// For 1-9 options: "1-N", for 10 options: "0-9".
+func formatKeyRange(numOptions int) string {
+	if numOptions >= 10 {
+		return "0-9"
+	}
+	if numOptions == 1 {
+		return "1"
+	}
+	return "1-" + strconv.Itoa(numOptions)
+}
+
+// clickableRange stores row range for mouse click detection.
+type clickableRange struct {
+	startRow  int       // First row (relative to content area start)
+	endRow    int       // Last row (inclusive)
+	selection selection // What this area selects
+}
+
+// multiChoiceDialog implements a reusable multi-choice selection dialog.
+type multiChoiceDialog struct {
+	BaseDialog
+	config            MultiChoiceConfig
+	selected          selection       // Currently selected item (-1 = none)
+	customInput       textinput.Model // Text input for custom response
+	keyMap            multiChoiceKeyMap
+	clickables        []clickableRange // Clickable areas for mouse handling (supports multi-row)
+	contentAbsRow     int              // Absolute screen row where content starts
+	contentAbsCol     int              // Absolute screen column where content starts
+	secondaryBtnCol   int              // Column where secondary button starts (relative to content)
+	secondaryBtnWidth int              // Width of secondary button
+	primaryBtnCol     int              // Column where primary button starts (relative to content)
+	primaryBtnWidth   int              // Width of primary button
+	btnRow            int              // Row of the buttons (relative to content)
+	tabOverride       bool             // When true, inverts the default action (Skip <-> Continue)
+}
+
+type multiChoiceKeyMap struct {
+	Enter  key.Binding
+	Escape key.Binding
+	Up     key.Binding
+	Down   key.Binding
+	Tab    key.Binding
+}
+
+func defaultMultiChoiceKeyMap() multiChoiceKeyMap {
+	return multiChoiceKeyMap{
+		Enter:  key.NewBinding(key.WithKeys("enter")),
+		Escape: key.NewBinding(key.WithKeys("esc")),
+		Up:     key.NewBinding(key.WithKeys("up")),
+		Down:   key.NewBinding(key.WithKeys("down")),
+		Tab:    key.NewBinding(key.WithKeys("tab")),
+	}
+}
+
+// NewMultiChoiceDialog creates a new multi-choice dialog.
+func NewMultiChoiceDialog(config MultiChoiceConfig) Dialog {
+	// Set defaults
+	if config.SecondaryLabel == "" {
+		config.SecondaryLabel = "Skip"
+	}
+	if config.PrimaryLabel == "" {
+		config.PrimaryLabel = "Continue"
+	}
+	if config.CustomPlaceholder == "" {
+		config.CustomPlaceholder = "Other..."
+	}
+
+	// Create text input
+	ti := textinput.New()
+	ti.SetStyles(styles.DialogInputStyle)
+	ti.Placeholder = config.CustomPlaceholder
+	ti.CharLimit = 500
+	ti.SetWidth(50)
+	ti.Prompt = ""
+
+	return &multiChoiceDialog{
+		config:      config,
+		selected:    selectionNone, // Nothing selected by default
+		customInput: ti,
+		keyMap:      defaultMultiChoiceKeyMap(),
+	}
+}
+
+// hasSelection returns true if user has made a selection or typed something.
+func (d *multiChoiceDialog) hasSelection() bool {
+	if d.selected >= 0 {
+		return true // Option selected
+	}
+	if d.selected == selectionCustom && strings.TrimSpace(d.customInput.Value()) != "" {
+		return true // Custom text entered
+	}
+	return false
+}
+
+// isSecondaryDefault returns true if secondary button should be the default action.
+// This takes into account the natural default (based on selection) and the tabOverride.
+func (d *multiChoiceDialog) isSecondaryDefault() bool {
+	naturalDefault := !d.hasSelection() // Secondary is natural default when nothing selected
+	if d.tabOverride {
+		return !naturalDefault // Invert when tab override is active
+	}
+	return naturalDefault
+}
+
+// renderNumberBox renders a number box and returns its width.
+func (d *multiChoiceDialog) renderNumberBox(num int) (rendered string, width int) {
+	numStyle := styles.DialogContentStyle.Foreground(styles.TextMuted)
+	numStr := strconv.Itoa(num)
+	rendered = numStyle.Padding(0, 1).Render(numStr)
+	return rendered, lipgloss.Width(rendered)
+}
+
+// computeHelpAndButtonsWidth calculates the actual width of help text and buttons.
+func (d *multiChoiceDialog) computeHelpAndButtonsWidth() int {
+	// Build the actual help text
+	helpStyle := styles.DialogHelpStyle
+	keyStyle := helpStyle.Foreground(styles.TextSecondary)
+
+	numOptions := len(d.config.Options)
+	if d.config.AllowCustom {
+		numOptions++
+	}
+
+	helpParts := []string{
+		keyStyle.Render("Esc") + " " + helpStyle.Render("cancel"),
+	}
+	if numOptions > 0 {
+		helpParts = append(helpParts, keyStyle.Render("↑/↓ "+formatKeyRange(numOptions))+" "+helpStyle.Render("select"))
+	} else {
+		helpParts = append(helpParts, keyStyle.Render("↑/↓")+" "+helpStyle.Render("navigate"))
+	}
+	helpText := strings.Join(helpParts, "  ")
+	helpWidth := lipgloss.Width(helpText)
+
+	// Build the actual buttons (use longer variant with ↵ for measurement)
+	btnStyle := lipgloss.NewStyle().Padding(0, 2)
+	secondaryBtn := btnStyle.Render(d.config.SecondaryLabel + " ↵")
+	primaryBtn := btnStyle.Render(d.config.PrimaryLabel + " ↵")
+	btnWidth := lipgloss.Width(secondaryBtn) + multiChoiceButtonSpacing + lipgloss.Width(primaryBtn)
+
+	return helpWidth + multiChoiceMinHelpSpacing + btnWidth
+}
+
+// computeDialogWidth calculates optimal dialog width based on content.
+func (d *multiChoiceDialog) computeDialogWidth() int {
+	frameWidth := styles.DialogStyle.GetHorizontalFrameSize()
+
+	// Compute number box width from actual rendering (use highest display number)
+	// Display numbers are 1-9, then 0 for the 10th option
+	_, numBoxWidth := d.renderNumberBox(9) // max single digit is 9
+
+	maxContentWidth := 0
+
+	// Check title width
+	titleWidth := lipgloss.Width(d.config.Title)
+	if titleWidth > maxContentWidth {
+		maxContentWidth = titleWidth
+	}
+
+	// Check each option width (number box + space + label)
+	for _, opt := range d.config.Options {
+		optWidth := numBoxWidth + 1 + lipgloss.Width(opt.Label) // +1 for space
+		if optWidth > maxContentWidth {
+			maxContentWidth = optWidth
+		}
+	}
+
+	// Check custom placeholder width
+	if d.config.AllowCustom {
+		// +1 for space, +1 for cursor space
+		customWidth := numBoxWidth + 1 + lipgloss.Width(d.config.CustomPlaceholder) + 1
+		if customWidth > maxContentWidth {
+			maxContentWidth = customWidth
+		}
+	}
+
+	// Calculate help + buttons width from actual rendering
+	helpAndBtnWidth := d.computeHelpAndButtonsWidth()
+	if helpAndBtnWidth > maxContentWidth {
+		maxContentWidth = helpAndBtnWidth
+	}
+
+	// Calculate total dialog width
+	dialogWidth := maxContentWidth + frameWidth
+
+	// Apply bounds
+	if dialogWidth < multiChoiceMinDialogWidth {
+		dialogWidth = multiChoiceMinDialogWidth
+	}
+	if dialogWidth > multiChoiceMaxDialogWidth {
+		dialogWidth = multiChoiceMaxDialogWidth
+	}
+
+	// Don't exceed screen width
+	screenLimit := d.Width() * multiChoiceScreenWidthFactor / 100
+	if dialogWidth > screenLimit && screenLimit > multiChoiceMinDialogWidth {
+		dialogWidth = screenLimit
+	}
+
+	return dialogWidth
+}
+
+// Init initializes the dialog.
+func (d *multiChoiceDialog) Init() tea.Cmd {
+	return textinput.Blink
+}
+
+// Update handles messages.
+func (d *multiChoiceDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		cmd := d.SetSize(msg.Width, msg.Height)
+		return d, cmd
+
+	case tea.KeyPressMsg:
+		if cmd := HandleQuit(msg); cmd != nil {
+			return d, cmd
+		}
+		return d.handleKeyPress(msg)
+
+	case tea.MouseClickMsg:
+		if msg.Button == tea.MouseLeft {
+			return d.handleMouseClick(msg.X, msg.Y)
+		}
+	}
+
+	return d, nil
+}
+
+// handleKeyPress handles key presses.
+func (d *multiChoiceDialog) handleKeyPress(msg tea.KeyPressMsg) (layout.Model, tea.Cmd) {
+	keyStr := msg.String()
+
+	// If custom is selected, forward most keys to the text input (including numbers)
+	if d.selected == selectionCustom {
+		switch {
+		case key.Matches(msg, d.keyMap.Escape):
+			cmd := d.sendResult(MultiChoiceResult{IsCancelled: true})
+			return d, cmd
+		case key.Matches(msg, d.keyMap.Enter):
+			return d.submitDefault()
+		case key.Matches(msg, d.keyMap.Up):
+			d.selectPrevious()
+			return d, nil
+		case key.Matches(msg, d.keyMap.Down):
+			d.selectNext()
+			return d, nil
+		case key.Matches(msg, d.keyMap.Tab):
+			d.tabOverride = !d.tabOverride
+			return d, nil
+		default:
+			// Forward to text input (including number keys)
+			var cmd tea.Cmd
+			d.customInput, cmd = d.customInput.Update(msg)
+			return d, cmd
+		}
+	}
+
+	// Check for number shortcuts (1-9, 0 for 10th) - select that option or custom
+	// Only when NOT in custom mode
+	// Keys 1-9 select options at indices 0-8, key 0 selects option at index 9
+	if len(keyStr) == 1 && keyStr[0] >= '0' && keyStr[0] <= '9' {
+		var optIdx int
+		if keyStr[0] == '0' {
+			optIdx = 9 // '0' is the 10th option
+		} else {
+			optIdx = int(keyStr[0] - '1') // '1' -> 0, '2' -> 1, etc.
+		}
+		if optIdx < len(d.config.Options) {
+			d.selected = selection(optIdx)
+			d.customInput.Blur()
+			return d, nil
+		}
+		// Check if this is the custom option number
+		if d.config.AllowCustom && optIdx == len(d.config.Options) {
+			d.selected = selectionCustom
+			d.customInput.Focus()
+			return d, nil
+		}
+	}
+
+	switch {
+	case key.Matches(msg, d.keyMap.Escape):
+		cmd := d.sendResult(MultiChoiceResult{IsCancelled: true})
+		return d, cmd
+
+	case key.Matches(msg, d.keyMap.Enter):
+		return d.submitDefault()
+
+	case key.Matches(msg, d.keyMap.Up):
+		d.selectPrevious()
+		return d, nil
+
+	case key.Matches(msg, d.keyMap.Down):
+		d.selectNext()
+		return d, nil
+
+	case key.Matches(msg, d.keyMap.Tab):
+		d.tabOverride = !d.tabOverride
+		return d, nil
+
+	default:
+		// If custom is allowed and user types, auto-select custom
+		if d.config.AllowCustom {
+			if len(keyStr) == 1 || keyStr == "backspace" || keyStr == "delete" {
+				d.selected = selectionCustom
+				d.customInput.Focus()
+				var cmd tea.Cmd
+				d.customInput, cmd = d.customInput.Update(msg)
+				return d, cmd
+			}
+		}
+		return d, nil
+	}
+}
+
+// selectPrevious moves selection up.
+func (d *multiChoiceDialog) selectPrevious() {
+	switch d.selected {
+	case selectionNone:
+		// From none, go to custom if allowed, otherwise last option
+		if d.config.AllowCustom {
+			d.selected = selectionCustom
+		} else if len(d.config.Options) > 0 {
+			d.selected = selection(len(d.config.Options) - 1)
+		}
+	case selectionCustom:
+		if len(d.config.Options) > 0 {
+			d.selected = selection(len(d.config.Options) - 1)
+		} else {
+			d.selected = selectionNone
+		}
+	default:
+		if int(d.selected) > 0 {
+			d.selected--
+		} else {
+			d.selected = selectionNone
+		}
+	}
+	d.updateFocus()
+}
+
+// selectNext moves selection down.
+func (d *multiChoiceDialog) selectNext() {
+	maxOpt := len(d.config.Options) - 1
+
+	switch d.selected {
+	case selectionNone:
+		if len(d.config.Options) > 0 {
+			d.selected = 0
+		} else if d.config.AllowCustom {
+			d.selected = selectionCustom
+		}
+	case selectionCustom:
+		d.selected = selectionNone
+	default:
+		switch {
+		case int(d.selected) < maxOpt:
+			d.selected++
+		case d.config.AllowCustom:
+			d.selected = selectionCustom
+		default:
+			d.selected = selectionNone
+		}
+	}
+	d.updateFocus()
+}
+
+// updateFocus manages text input focus based on selection.
+func (d *multiChoiceDialog) updateFocus() {
+	if d.selected == selectionCustom {
+		d.customInput.Focus()
+	} else {
+		d.customInput.Blur()
+	}
+}
+
+// submitDefault submits based on current state and tab override.
+// Secondary is default when nothing selected (unless tab toggled).
+// Primary is default when selection exists (unless tab toggled).
+func (d *multiChoiceDialog) submitDefault() (layout.Model, tea.Cmd) {
+	if d.isSecondaryDefault() {
+		return d.submitSecondary()
+	}
+	return d.submitPrimary()
+}
+
+// submitSecondary sends a secondary (skip) result.
+func (d *multiChoiceDialog) submitSecondary() (layout.Model, tea.Cmd) {
+	if !d.config.AllowSecondary {
+		return d, nil
+	}
+	cmd := d.sendResult(MultiChoiceResult{
+		OptionID:  "skip",
+		IsSkipped: true,
+	})
+	return d, cmd
+}
+
+// submitPrimary sends the current selection.
+func (d *multiChoiceDialog) submitPrimary() (layout.Model, tea.Cmd) {
+	switch d.selected {
+	case selectionNone:
+		// Nothing selected - if secondary allowed, use it; otherwise do nothing
+		if d.config.AllowSecondary {
+			return d.submitSecondary()
+		}
+		return d, nil
+	case selectionCustom:
+		value := strings.TrimSpace(d.customInput.Value())
+		if value == "" {
+			// Empty custom = secondary if allowed
+			if d.config.AllowSecondary {
+				return d.submitSecondary()
+			}
+			return d, nil
+		}
+		cmd := d.sendResult(MultiChoiceResult{
+			OptionID: "custom",
+			Value:    value,
+			IsCustom: true,
+		})
+		return d, cmd
+	default:
+		if int(d.selected) >= 0 && int(d.selected) < len(d.config.Options) {
+			opt := d.config.Options[d.selected]
+			cmd := d.sendResult(MultiChoiceResult{
+				OptionID: opt.ID,
+				Value:    opt.Value,
+			})
+			return d, cmd
+		}
+	}
+	return d, nil
+}
+
+// handleMouseClick handles mouse clicks.
+func (d *multiChoiceDialog) handleMouseClick(x, y int) (layout.Model, tea.Cmd) {
+	relY := y - d.contentAbsRow
+	relX := x - d.contentAbsCol
+
+	// Check buttons
+	if relY == d.btnRow {
+		// Skip button
+		if relX >= d.secondaryBtnCol && relX < d.secondaryBtnCol+d.secondaryBtnWidth {
+			return d.submitSecondary()
+		}
+		// Primary button
+		if relX >= d.primaryBtnCol && relX < d.primaryBtnCol+d.primaryBtnWidth {
+			return d.submitPrimary()
+		}
+	}
+
+	// Check clickable areas (options) - now supports row ranges for word wrap
+	for _, area := range d.clickables {
+		if relY >= area.startRow && relY <= area.endRow {
+			if d.selected == area.selection {
+				// Already selected - deselect
+				d.selected = selectionNone
+			} else {
+				d.selected = area.selection
+			}
+			d.updateFocus()
+			return d, nil
+		}
+	}
+
+	return d, nil
+}
+
+// sendResult creates the command to close dialog and send result.
+func (d *multiChoiceDialog) sendResult(result MultiChoiceResult) tea.Cmd {
+	return tea.Sequence(
+		core.CmdHandler(CloseDialogMsg{}),
+		core.CmdHandler(MultiChoiceResultMsg{
+			DialogID: d.config.DialogID,
+			Result:   result,
+		}),
+	)
+}
+
+// View renders the dialog.
+func (d *multiChoiceDialog) View() string {
+	dialogWidth := d.computeDialogWidth()
+	contentWidth := d.ContentWidth(dialogWidth, 2)
+
+	content := NewContent(contentWidth)
+	content.AddTitle(d.config.Title)
+	content.AddSeparator()
+
+	// Reset clickables
+	d.clickables = nil
+	rowIdx := 0
+
+	// Render options with number keys (1-indexed, 0 for 10th)
+	for i, opt := range d.config.Options {
+		isSelected := d.selected == selection(i)
+		displayNum := indexToDisplayNum(i)
+		line := d.renderOption(displayNum, opt.Label, isSelected, contentWidth)
+		content.AddContent(line)
+
+		// Calculate how many rows this option takes
+		lineHeight := lipgloss.Height(line)
+		d.clickables = append(d.clickables, clickableRange{
+			startRow:  rowIdx,
+			endRow:    rowIdx + lineHeight - 1,
+			selection: selection(i),
+		})
+		rowIdx += lineHeight
+	}
+
+	// Render custom input if allowed (as another option)
+	if d.config.AllowCustom {
+		isSelected := d.selected == selectionCustom
+		customLine := d.renderCustomOption(isSelected, contentWidth)
+		content.AddContent(customLine)
+
+		lineHeight := lipgloss.Height(customLine)
+		d.clickables = append(d.clickables, clickableRange{
+			startRow:  rowIdx,
+			endRow:    rowIdx + lineHeight - 1,
+			selection: selectionCustom,
+		})
+		rowIdx += lineHeight
+	}
+
+	// Spacing before help/buttons
+	content.AddSpace()
+	rowIdx++
+	content.AddSpace()
+	rowIdx++
+
+	// Help text and buttons on same row
+	helpAndButtons := d.renderHelpAndButtons(contentWidth)
+	content.AddContent(helpAndButtons)
+	d.btnRow = rowIdx
+
+	return styles.DialogStyle.Width(dialogWidth).Render(content.Build())
+}
+
+// renderOption renders a numbered option with selection indicator, with word wrap support.
+func (d *multiChoiceDialog) renderOption(num int, label string, isSelected bool, contentWidth int) string {
+	// Determine if we should fade this option (another option is selected)
+	hasAnySelection := d.hasSelection()
+	isFaded := hasAnySelection && !isSelected
+
+	numStyle := styles.DialogContentStyle.Foreground(styles.TextMuted)
+	labelStyle := styles.DialogContentStyle.Foreground(styles.TextPrimary)
+	selectedNumStyle := styles.DialogContentStyle.Foreground(styles.Background).Background(styles.Accent).Bold(true)
+	selectedLabelStyle := styles.DialogContentStyle.Foreground(styles.TextPrimary)
+	fadedNumStyle := styles.DialogContentStyle.Foreground(styles.TextMutedGray)
+	fadedLabelStyle := styles.DialogContentStyle.Foreground(styles.TextSecondary)
+
+	numStr := strconv.Itoa(num)
+	var numBox string
+	switch {
+	case isSelected:
+		numBox = selectedNumStyle.Padding(0, 1).Render(numStr)
+	case isFaded:
+		numBox = fadedNumStyle.Padding(0, 1).Render(numStr)
+	default:
+		numBox = numStyle.Padding(0, 1).Render(numStr)
+	}
+	numBoxWidth := lipgloss.Width(numBox)
+
+	// Calculate available width for label (allow word wrap)
+	labelWidth := contentWidth - numBoxWidth - 1 // -1 for space between number box and label
+	if labelWidth < multiChoiceMinLabelWidth {
+		labelWidth = multiChoiceMinLabelWidth
+	}
+
+	// Apply width constraint for word wrapping
+	var labelRendered string
+	switch {
+	case isSelected:
+		labelRendered = selectedLabelStyle.Width(labelWidth).Render(label)
+	case isFaded:
+		labelRendered = fadedLabelStyle.Width(labelWidth).Render(label)
+	default:
+		labelRendered = labelStyle.Width(labelWidth).Render(label)
+	}
+
+	return numBox + " " + labelRendered
+}
+
+// renderCustomOption renders the custom text input as an option.
+// contentWidth should be passed from the caller to avoid recomputing dialog dimensions.
+func (d *multiChoiceDialog) renderCustomOption(isSelected bool, contentWidth int) string {
+	// Determine if we should fade this option (another option is selected)
+	hasAnySelection := d.hasSelection()
+	isFaded := hasAnySelection && !isSelected
+
+	numStyle := styles.DialogContentStyle.Foreground(styles.TextMuted)
+	selectedNumStyle := styles.DialogContentStyle.Foreground(styles.Background).Background(styles.Accent).Bold(true)
+	fadedNumStyle := styles.DialogContentStyle.Foreground(styles.TextMutedGray)
+
+	// Custom option is numbered after all regular options (1-indexed, 0 for 10th)
+	displayNum := indexToDisplayNum(len(d.config.Options))
+	numStr := strconv.Itoa(displayNum)
+	var numBox string
+	switch {
+	case isSelected:
+		numBox = selectedNumStyle.Padding(0, 1).Render(numStr)
+	case isFaded:
+		numBox = fadedNumStyle.Padding(0, 1).Render(numStr)
+	default:
+		numBox = numStyle.Padding(0, 1).Render(numStr)
+	}
+	numBoxWidth := lipgloss.Width(numBox)
+
+	// Calculate available width for text display
+	// -1 for space between number box and input, -1 for cursor space
+	availableWidth := contentWidth - numBoxWidth - 2
+	if availableWidth < multiChoiceMinLabelWidth {
+		availableWidth = multiChoiceMinLabelWidth
+	}
+
+	value := d.customInput.Value()
+
+	if isSelected {
+		// Set width and let textinput handle its own scrolling/viewport
+		d.customInput.SetWidth(availableWidth)
+		return numBox + " " + d.customInput.View()
+	}
+
+	// When not selected, show truncated text with ellipsis if too long
+	if value == "" {
+		placeholderStyle := styles.DialogContentStyle.Foreground(styles.TextMuted).Italic(true)
+		if isFaded {
+			placeholderStyle = styles.DialogContentStyle.Foreground(styles.TextMutedGray).Italic(true)
+		}
+		return numBox + " " + placeholderStyle.Render(d.config.CustomPlaceholder)
+	}
+
+	// Truncate with ellipsis at end (showing beginning of text when not selected)
+	textStyle := styles.DialogContentStyle.Foreground(styles.TextPrimary)
+	if isFaded {
+		textStyle = styles.DialogContentStyle.Foreground(styles.TextSecondary)
+	}
+	displayText := truncateWithEllipsisEnd(value, availableWidth)
+	return numBox + " " + textStyle.Render(displayText)
+}
+
+// truncateWithEllipsisEnd truncates text to fit within maxWidth, adding "..." at the end.
+func truncateWithEllipsisEnd(text string, maxWidth int) string {
+	textWidth := lipgloss.Width(text)
+	if textWidth <= maxWidth {
+		return text
+	}
+
+	// Need to truncate - show beginning of text with "..." suffix
+	const ellipsis = "..."
+	ellipsisWidth := lipgloss.Width(ellipsis)
+	availableForText := maxWidth - ellipsisWidth
+	if availableForText < 1 {
+		return ellipsis
+	}
+
+	// Take characters from the beginning
+	result := ""
+	for _, r := range text {
+		candidate := result + string(r)
+		if lipgloss.Width(candidate) > availableForText {
+			break
+		}
+		result = candidate
+	}
+
+	return result + ellipsis
+}
+
+// renderHelpAndButtons renders help text on left and buttons on right.
+func (d *multiChoiceDialog) renderHelpAndButtons(contentWidth int) string {
+	secondaryIsDefault := d.isSecondaryDefault()
+
+	// Help text
+	helpStyle := styles.DialogHelpStyle
+	keyStyle := helpStyle.Foreground(styles.TextSecondary)
+
+	numOptions := len(d.config.Options)
+	if d.config.AllowCustom {
+		numOptions++
+	}
+
+	helpParts := []string{
+		keyStyle.Render("Esc") + " " + helpStyle.Render("cancel"),
+	}
+	if numOptions > 0 {
+		helpParts = append(helpParts, keyStyle.Render("↑/↓ "+formatKeyRange(numOptions))+" "+helpStyle.Render("select"))
+	} else {
+		helpParts = append(helpParts, keyStyle.Render("↑/↓")+" "+helpStyle.Render("navigate"))
+	}
+	helpText := strings.Join(helpParts, "  ")
+
+	// Button styles
+	defaultBtnStyle := lipgloss.NewStyle().
+		Foreground(styles.Background).
+		Background(styles.Accent).
+		Padding(0, 2).
+		Bold(true)
+
+	normalBtnStyle := lipgloss.NewStyle().
+		Foreground(styles.TextMuted).
+		Padding(0, 2)
+
+	var secondaryBtn, primaryBtn string
+
+	if secondaryIsDefault {
+		// Secondary is default
+		secondaryBtn = defaultBtnStyle.Render(d.config.SecondaryLabel + " ↵")
+		primaryBtn = normalBtnStyle.Render(d.config.PrimaryLabel)
+	} else {
+		// Primary is default
+		secondaryBtn = normalBtnStyle.Render(d.config.SecondaryLabel)
+		primaryBtn = defaultBtnStyle.Render(d.config.PrimaryLabel + " ↵")
+	}
+
+	// Calculate widths
+	helpWidth := lipgloss.Width(helpText)
+	secondaryWidth := lipgloss.Width(secondaryBtn)
+	primaryWidth := lipgloss.Width(primaryBtn)
+	totalBtnWidth := secondaryWidth + multiChoiceButtonSpacing + primaryWidth
+
+	// Calculate spacing between help and buttons
+	spacing := contentWidth - helpWidth - totalBtnWidth
+	if spacing < multiChoiceMinHelpSpacing {
+		spacing = multiChoiceMinHelpSpacing
+	}
+
+	// Store button positions for click detection (relative to content area)
+	d.secondaryBtnCol = helpWidth + spacing
+	d.secondaryBtnWidth = secondaryWidth
+	d.primaryBtnCol = d.secondaryBtnCol + secondaryWidth + multiChoiceButtonSpacing
+	d.primaryBtnWidth = primaryWidth
+
+	return helpText + strings.Repeat(" ", spacing) + secondaryBtn + strings.Repeat(" ", multiChoiceButtonSpacing) + primaryBtn
+}
+
+// Position returns the dialog position (centered).
+func (d *multiChoiceDialog) Position() (row, col int) {
+	dialogWidth := d.computeDialogWidth()
+	contentWidth := d.ContentWidth(dialogWidth, 2)
+	renderedDialog := d.View()
+	dialogHeight := lipgloss.Height(renderedDialog)
+	row, col = CenterPosition(d.Width(), d.Height(), dialogWidth, dialogHeight)
+
+	// Calculate absolute position of content area using style getters
+	borderTop := styles.DialogStyle.GetBorderTopSize()
+	borderLeft := styles.DialogStyle.GetBorderLeftSize()
+	paddingTop := styles.DialogStyle.GetPaddingTop()
+	paddingLeft := styles.DialogStyle.GetPaddingLeft()
+
+	contentRow := row + borderTop + paddingTop
+	contentCol := col + borderLeft + paddingLeft
+
+	// Title
+	titleStyle := styles.DialogTitleStyle.Width(contentWidth)
+	title := titleStyle.Render(d.config.Title)
+	contentRow += lipgloss.Height(title)
+
+	// Separator
+	separatorHeight := lipgloss.Height(RenderSeparator(contentWidth))
+	contentRow += separatorHeight
+
+	d.contentAbsRow = contentRow
+	d.contentAbsCol = contentCol
+
+	return row, col
+}

--- a/pkg/tui/dialog/multi_choice_test.go
+++ b/pkg/tui/dialog/multi_choice_test.go
@@ -1,0 +1,1405 @@
+package dialog
+
+import (
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/cagent/pkg/tui/core/layout"
+)
+
+// collectMsgs executes a command (or batch/sequence of commands) and collects all returned messages.
+// It handles tea.BatchMsg and tea.Sequence (which uses an unexported slice type).
+func collectMsgs(cmd tea.Cmd) []tea.Msg {
+	if cmd == nil {
+		return nil
+	}
+
+	msg := cmd()
+	if msg == nil {
+		return nil
+	}
+
+	// Handle BatchMsg
+	if batchMsg, ok := msg.(tea.BatchMsg); ok {
+		var msgs []tea.Msg
+		for _, innerCmd := range batchMsg {
+			if innerCmd != nil {
+				msgs = append(msgs, collectMsgs(innerCmd)...)
+			}
+		}
+		return msgs
+	}
+
+	// Handle Sequence (unexported type, use reflection)
+	// tea.Sequence returns a func that returns a sequenceMsg which is []tea.Cmd
+	msgValue := reflect.ValueOf(msg)
+	if msgValue.Kind() == reflect.Slice {
+		var msgs []tea.Msg
+		for i := range msgValue.Len() {
+			elem := msgValue.Index(i)
+			if elem.CanInterface() {
+				if innerCmd, ok := elem.Interface().(tea.Cmd); ok && innerCmd != nil {
+					msgs = append(msgs, collectMsgs(innerCmd)...)
+				}
+			}
+		}
+		if len(msgs) > 0 {
+			return msgs
+		}
+	}
+
+	return []tea.Msg{msg}
+}
+
+// findMsg searches for a message of the specified type in the collected messages.
+func findMsg[T any](msgs []tea.Msg) (T, bool) {
+	var zero T
+	for _, msg := range msgs {
+		if typed, ok := msg.(T); ok {
+			return typed, true
+		}
+	}
+	return zero, false
+}
+
+// hasMsg checks if a message of the specified type exists in the collected messages.
+func hasMsg[T any](msgs []tea.Msg) bool {
+	_, found := findMsg[T](msgs)
+	return found
+}
+
+func TestNewMultiChoiceDialog(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID: "test-dialog",
+		Title:    "Test Title",
+		Options: []MultiChoiceOption{
+			{ID: "opt1", Label: "Option 1", Value: "value1"},
+			{ID: "opt2", Label: "Option 2", Value: "value2"},
+		},
+		AllowCustom:    true,
+		AllowSecondary: true,
+	}
+
+	dialog := NewMultiChoiceDialog(config)
+	require.NotNil(t, dialog)
+
+	d, ok := dialog.(*multiChoiceDialog)
+	require.True(t, ok)
+
+	assert.Equal(t, "test-dialog", d.config.DialogID)
+	assert.Equal(t, "Test Title", d.config.Title)
+	assert.Len(t, d.config.Options, 2)
+	assert.True(t, d.config.AllowCustom)
+	assert.True(t, d.config.AllowSecondary)
+	assert.Equal(t, "Skip", d.config.SecondaryLabel)
+	assert.Equal(t, "Continue", d.config.PrimaryLabel)
+	// Default selection should be none
+	assert.Equal(t, selectionNone, d.selected)
+}
+
+func TestMultiChoiceDialog_DefaultValues(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID: "test-defaults",
+		Title:    "Defaults Test",
+		Options:  []MultiChoiceOption{{ID: "opt1", Label: "Option 1", Value: "value1"}},
+	}
+
+	dialog := NewMultiChoiceDialog(config)
+	d := dialog.(*multiChoiceDialog)
+
+	assert.Equal(t, "Skip", d.config.SecondaryLabel)
+	assert.Equal(t, "Continue", d.config.PrimaryLabel)
+	assert.Equal(t, "Other...", d.config.CustomPlaceholder)
+}
+
+func TestMultiChoiceDialog_HasSelection(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID:    "test-has-selection",
+		Title:       "Has Selection Test",
+		Options:     []MultiChoiceOption{{ID: "opt1", Label: "Option 1", Value: "value1"}},
+		AllowCustom: true,
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+
+	// No selection initially
+	assert.False(t, d.hasSelection())
+
+	// Select an option
+	d.selected = selection(0)
+	assert.True(t, d.hasSelection())
+
+	// Select custom but empty
+	d.selected = selectionCustom
+	d.customInput.SetValue("")
+	assert.False(t, d.hasSelection())
+
+	// Select custom with text
+	d.customInput.SetValue("something")
+	assert.True(t, d.hasSelection())
+}
+
+func TestMultiChoiceDialog_Selection(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID: "test-selection",
+		Title:    "Selection Test",
+		Options: []MultiChoiceOption{
+			{ID: "opt1", Label: "Option 1", Value: "value1"},
+			{ID: "opt2", Label: "Option 2", Value: "value2"},
+			{ID: "opt3", Label: "Option 3", Value: "value3"},
+		},
+		AllowCustom: true,
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+
+	// Should start with no selection
+	assert.Equal(t, selectionNone, d.selected)
+
+	// Move down to first option
+	d.selectNext()
+	assert.Equal(t, selection(0), d.selected)
+
+	// Move through options
+	d.selectNext()
+	assert.Equal(t, selection(1), d.selected)
+	d.selectNext()
+	assert.Equal(t, selection(2), d.selected)
+
+	// Move to custom
+	d.selectNext()
+	assert.Equal(t, selectionCustom, d.selected)
+
+	// Wrap to none
+	d.selectNext()
+	assert.Equal(t, selectionNone, d.selected)
+
+	// Move up from none goes to custom
+	d.selectPrevious()
+	assert.Equal(t, selectionCustom, d.selected)
+
+	// Move up from custom goes to last option
+	d.selectPrevious()
+	assert.Equal(t, selection(2), d.selected)
+}
+
+func TestMultiChoiceDialog_SubmitDefault_NoSelection(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID:       "test-default-skip",
+		Title:          "Default Skip Test",
+		Options:        []MultiChoiceOption{{ID: "opt1", Label: "Option 1", Value: "value1"}},
+		AllowSecondary: true,
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+	// No selection
+
+	_, cmd := d.submitDefault()
+	// Should submit skip
+	require.NotNil(t, cmd)
+}
+
+func TestMultiChoiceDialog_SubmitDefault_WithSelection(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID:       "test-default-continue",
+		Title:          "Default Continue Test",
+		Options:        []MultiChoiceOption{{ID: "opt1", Label: "Option 1", Value: "value1"}},
+		AllowSecondary: true,
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+	d.selected = selection(0) // Select first option
+
+	_, cmd := d.submitDefault()
+	// Should submit continue (the selected option)
+	require.NotNil(t, cmd)
+}
+
+func TestMultiChoiceDialog_SubmitSkip(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID:       "test-skip",
+		Title:          "Skip Test",
+		Options:        []MultiChoiceOption{{ID: "opt1", Label: "Option 1", Value: "value1"}},
+		AllowSecondary: true,
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+
+	_, cmd := d.submitSecondary()
+	require.NotNil(t, cmd)
+}
+
+func TestMultiChoiceDialog_SubmitSkip_NotAllowed(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID:       "test-skip-not-allowed",
+		Title:          "Skip Not Allowed Test",
+		Options:        []MultiChoiceOption{{ID: "opt1", Label: "Option 1", Value: "value1"}},
+		AllowSecondary: false,
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+
+	_, cmd := d.submitSecondary()
+	assert.Nil(t, cmd)
+}
+
+func TestMultiChoiceDialog_SubmitContinue_Option(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID: "test-continue-option",
+		Title:    "Continue Option Test",
+		Options: []MultiChoiceOption{
+			{ID: "opt1", Label: "Option 1", Value: "First option value"},
+		},
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+	d.selected = selection(0)
+
+	_, cmd := d.submitPrimary()
+	require.NotNil(t, cmd)
+}
+
+func TestMultiChoiceDialog_SubmitContinue_Custom(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID:    "test-continue-custom",
+		Title:       "Continue Custom Test",
+		Options:     []MultiChoiceOption{{ID: "opt1", Label: "Option 1", Value: "value1"}},
+		AllowCustom: true,
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+	d.selected = selectionCustom
+	d.customInput.SetValue("My custom reason")
+
+	_, cmd := d.submitPrimary()
+	require.NotNil(t, cmd)
+}
+
+func TestMultiChoiceDialog_SubmitContinue_EmptyCustom(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID:       "test-continue-empty-custom",
+		Title:          "Continue Empty Custom Test",
+		Options:        []MultiChoiceOption{{ID: "opt1", Label: "Option 1", Value: "value1"}},
+		AllowCustom:    true,
+		AllowSecondary: true,
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+	d.selected = selectionCustom
+	d.customInput.SetValue("") // Empty
+
+	// Should submit as skip
+	_, cmd := d.submitPrimary()
+	require.NotNil(t, cmd)
+}
+
+func TestMultiChoiceDialog_View(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID: "test-view",
+		Title:    "Choose an option:",
+		Options: []MultiChoiceOption{
+			{ID: "opt1", Label: "First", Value: "first"},
+			{ID: "opt2", Label: "Second", Value: "second"},
+		},
+		AllowCustom:    true,
+		AllowSecondary: true,
+	}
+
+	dialog := NewMultiChoiceDialog(config)
+	d := dialog.(*multiChoiceDialog)
+	d.SetSize(100, 40)
+
+	view := d.View()
+
+	// Should contain title and options with numbers (1-indexed)
+	assert.Contains(t, view, "Choose an option:")
+	assert.Contains(t, view, "1")
+	assert.Contains(t, view, "First")
+	assert.Contains(t, view, "2")
+	assert.Contains(t, view, "Second")
+	assert.Contains(t, view, "Skip")
+	assert.Contains(t, view, "Continue")
+}
+
+func TestMultiChoiceDialog_View_DefaultButton(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID:       "test-view-default",
+		Title:          "Default Button Test",
+		Options:        []MultiChoiceOption{{ID: "opt1", Label: "Option 1", Value: "value1"}},
+		AllowSecondary: true,
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+	d.SetSize(100, 40)
+
+	// No selection - Skip should be default (show ↵)
+	view1 := d.View()
+	assert.Contains(t, view1, "Skip ↵")
+
+	// With selection - Continue should be default
+	d.selected = selection(0)
+	view2 := d.View()
+	assert.Contains(t, view2, "Continue ↵")
+}
+
+func TestMultiChoiceDialog_Clickables(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID: "test-clickables",
+		Title:    "Clickables Test",
+		Options: []MultiChoiceOption{
+			{ID: "opt1", Label: "Option 1", Value: "value1"},
+			{ID: "opt2", Label: "Option 2", Value: "value2"},
+		},
+		AllowCustom: true,
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+	d.SetSize(100, 40)
+
+	// Render to populate clickables
+	_ = d.View()
+
+	// Should have 3 clickable areas: 2 options + custom
+	assert.Len(t, d.clickables, 3)
+
+	// Verify selections
+	assert.Equal(t, selection(0), d.clickables[0].selection)
+	assert.Equal(t, selection(1), d.clickables[1].selection)
+	assert.Equal(t, selectionCustom, d.clickables[2].selection)
+
+	// Verify row ranges (single-line options should have startRow == endRow)
+	assert.Equal(t, d.clickables[0].startRow, d.clickables[0].endRow)
+	assert.Equal(t, d.clickables[1].startRow, d.clickables[1].endRow)
+}
+
+func TestMultiChoiceDialog_ClickToggle(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID: "test-click-toggle",
+		Title:    "Click Toggle Test",
+		Options:  []MultiChoiceOption{{ID: "opt1", Label: "Option 1", Value: "value1"}},
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+	d.SetSize(100, 40)
+
+	// Render and position
+	_ = d.View()
+	_, _ = d.Position()
+
+	// Simulate click to select
+	d.selected = selectionNone
+	clickY := d.contentAbsRow + 0 // First option
+	d.handleMouseClick(10, clickY)
+	assert.Equal(t, selection(0), d.selected)
+
+	// Click again to deselect
+	d.handleMouseClick(10, clickY)
+	assert.Equal(t, selectionNone, d.selected)
+}
+
+// Test that dialog implements layout.Model interface
+func TestMultiChoiceDialog_ImplementsLayoutModel(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID: "test-interface",
+		Title:    "Interface Test",
+		Options:  []MultiChoiceOption{{ID: "opt1", Label: "Option 1", Value: "value1"}},
+	}
+
+	dialog := NewMultiChoiceDialog(config)
+
+	// Verify it implements layout.Model
+	var _ layout.Model = dialog
+}
+
+// ============================================================================
+// Window Sizing Tests
+// ============================================================================
+
+func TestMultiChoiceDialog_WindowSizeMsg(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID: "test-window-size",
+		Title:    "Window Size Test",
+		Options:  []MultiChoiceOption{{ID: "opt1", Label: "Option 1", Value: "value1"}},
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+
+	// Initial size should be 0
+	assert.Equal(t, 0, d.Width())
+	assert.Equal(t, 0, d.Height())
+
+	// Update via WindowSizeMsg
+	updated, _ := d.Update(tea.WindowSizeMsg{Width: 120, Height: 50})
+	d = updated.(*multiChoiceDialog)
+
+	assert.Equal(t, 120, d.Width())
+	assert.Equal(t, 50, d.Height())
+}
+
+// ============================================================================
+// Keyboard Navigation Tests
+// ============================================================================
+
+func TestMultiChoiceDialog_KeyboardNavigation_UpDown(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID: "test-keyboard-nav",
+		Title:    "Keyboard Navigation Test",
+		Options: []MultiChoiceOption{
+			{ID: "opt1", Label: "Option 1", Value: "value1"},
+			{ID: "opt2", Label: "Option 2", Value: "value2"},
+		},
+		AllowCustom: true,
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+	d.SetSize(100, 40)
+
+	downKey := tea.KeyPressMsg{Code: tea.KeyDown}
+	upKey := tea.KeyPressMsg{Code: tea.KeyUp}
+
+	// Start at none
+	assert.Equal(t, selectionNone, d.selected)
+
+	// Down -> first option
+	updated, _ := d.Update(downKey)
+	d = updated.(*multiChoiceDialog)
+	assert.Equal(t, selection(0), d.selected)
+
+	// Down -> second option
+	updated, _ = d.Update(downKey)
+	d = updated.(*multiChoiceDialog)
+	assert.Equal(t, selection(1), d.selected)
+
+	// Down -> custom
+	updated, _ = d.Update(downKey)
+	d = updated.(*multiChoiceDialog)
+	assert.Equal(t, selectionCustom, d.selected)
+
+	// Down -> wrap to none
+	updated, _ = d.Update(downKey)
+	d = updated.(*multiChoiceDialog)
+	assert.Equal(t, selectionNone, d.selected)
+
+	// Up from none -> custom
+	updated, _ = d.Update(upKey)
+	d = updated.(*multiChoiceDialog)
+	assert.Equal(t, selectionCustom, d.selected)
+
+	// Up -> last option
+	updated, _ = d.Update(upKey)
+	d = updated.(*multiChoiceDialog)
+	assert.Equal(t, selection(1), d.selected)
+}
+
+func TestMultiChoiceDialog_NumberShortcuts(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID: "test-number-shortcuts",
+		Title:    "Number Shortcuts Test",
+		Options: []MultiChoiceOption{
+			{ID: "opt1", Label: "Option 1", Value: "value1"},
+			{ID: "opt2", Label: "Option 2", Value: "value2"},
+			{ID: "opt3", Label: "Option 3", Value: "value3"},
+		},
+		AllowCustom: true,
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+	d.SetSize(100, 40)
+
+	// Press "1" to select first option (1-indexed)
+	updated, _ := d.Update(tea.KeyPressMsg{Text: "1"})
+	d = updated.(*multiChoiceDialog)
+	assert.Equal(t, selection(0), d.selected)
+
+	// Press "3" to select third option
+	updated, _ = d.Update(tea.KeyPressMsg{Text: "3"})
+	d = updated.(*multiChoiceDialog)
+	assert.Equal(t, selection(2), d.selected)
+
+	// Press "4" to select custom (4th item when AllowCustom=true)
+	updated, _ = d.Update(tea.KeyPressMsg{Text: "4"})
+	d = updated.(*multiChoiceDialog)
+	assert.Equal(t, selectionCustom, d.selected)
+
+	// Press "9" - out of range, should not change
+	updated, _ = d.Update(tea.KeyPressMsg{Text: "9"})
+	d = updated.(*multiChoiceDialog)
+	assert.Equal(t, selectionCustom, d.selected)
+}
+
+func TestMultiChoiceDialog_NumberShortcuts_NoCustom(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID:    "test-number-shortcuts-no-custom",
+		Title:       "Number Shortcuts No Custom Test",
+		Options:     []MultiChoiceOption{{ID: "opt1", Label: "Option 1", Value: "value1"}},
+		AllowCustom: false,
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+	d.SetSize(100, 40)
+
+	// Press "1" to select first option (1-indexed)
+	updated, _ := d.Update(tea.KeyPressMsg{Text: "1"})
+	d = updated.(*multiChoiceDialog)
+	assert.Equal(t, selection(0), d.selected)
+
+	// Press "2" - out of range (no custom), should not change
+	updated, _ = d.Update(tea.KeyPressMsg{Text: "2"})
+	d = updated.(*multiChoiceDialog)
+	assert.Equal(t, selection(0), d.selected)
+}
+
+func TestMultiChoiceDialog_TypingAutoSelectsCustom(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID:    "test-typing-custom",
+		Title:       "Typing Custom Test",
+		Options:     []MultiChoiceOption{{ID: "opt1", Label: "Option 1", Value: "value1"}},
+		AllowCustom: true,
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+	d.SetSize(100, 40)
+
+	// Start at option
+	d.selected = selection(0)
+
+	// Type a letter - should auto-select custom and forward to input
+	updated, _ := d.Update(tea.KeyPressMsg{Text: "h"})
+	d = updated.(*multiChoiceDialog)
+	assert.Equal(t, selectionCustom, d.selected)
+	assert.Contains(t, d.customInput.Value(), "h")
+}
+
+func TestMultiChoiceDialog_TypingInCustomMode_NumbersForwarded(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID:    "test-typing-numbers-custom",
+		Title:       "Typing Numbers in Custom Test",
+		Options:     []MultiChoiceOption{{ID: "opt1", Label: "Option 1", Value: "value1"}},
+		AllowCustom: true,
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+	d.SetSize(100, 40)
+
+	// Start in custom mode
+	d.selected = selectionCustom
+	d.customInput.Focus()
+
+	// Type "123" - should go to input, not trigger number shortcuts
+	for _, ch := range "123" {
+		updated, _ := d.Update(tea.KeyPressMsg{Text: string(ch)})
+		d = updated.(*multiChoiceDialog)
+	}
+
+	assert.Equal(t, selectionCustom, d.selected, "should still be in custom mode")
+	assert.Contains(t, d.customInput.Value(), "123")
+}
+
+func TestMultiChoiceDialog_TabOverride(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID:       "test-tab-override",
+		Title:          "Tab Override Test",
+		Options:        []MultiChoiceOption{{ID: "opt1", Label: "Option 1", Value: "value1"}},
+		AllowSecondary: true,
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+	d.SetSize(100, 40)
+
+	tabKey := tea.KeyPressMsg{Code: tea.KeyTab}
+
+	// No selection, secondary is default
+	assert.True(t, d.isSecondaryDefault())
+	view1 := d.View()
+	assert.Contains(t, view1, "Skip ↵")
+
+	// Press Tab to toggle
+	updated, _ := d.Update(tabKey)
+	d = updated.(*multiChoiceDialog)
+	assert.False(t, d.isSecondaryDefault())
+	view2 := d.View()
+	assert.Contains(t, view2, "Continue ↵")
+
+	// Press Tab again to toggle back
+	updated, _ = d.Update(tabKey)
+	d = updated.(*multiChoiceDialog)
+	assert.True(t, d.isSecondaryDefault())
+}
+
+func TestMultiChoiceDialog_TabOverride_WithSelection(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID:       "test-tab-override-selection",
+		Title:          "Tab Override With Selection Test",
+		Options:        []MultiChoiceOption{{ID: "opt1", Label: "Option 1", Value: "value1"}},
+		AllowSecondary: true,
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+	d.SetSize(100, 40)
+	d.selected = selection(0) // Has selection
+
+	tabKey := tea.KeyPressMsg{Code: tea.KeyTab}
+
+	// With selection, primary is default
+	assert.False(t, d.isSecondaryDefault())
+	view1 := d.View()
+	assert.Contains(t, view1, "Continue ↵")
+
+	// Press Tab to toggle - skip becomes default
+	updated, _ := d.Update(tabKey)
+	d = updated.(*multiChoiceDialog)
+	assert.True(t, d.isSecondaryDefault())
+	view2 := d.View()
+	assert.Contains(t, view2, "Skip ↵")
+}
+
+func TestMultiChoiceDialog_EscapeCancels(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID: "test-escape",
+		Title:    "Escape Test",
+		Options:  []MultiChoiceOption{{ID: "opt1", Label: "Option 1", Value: "value1"}},
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+	d.SetSize(100, 40)
+
+	escKey := tea.KeyPressMsg{Code: tea.KeyEscape}
+
+	_, cmd := d.Update(escKey)
+	require.NotNil(t, cmd)
+
+	msgs := collectMsgs(cmd)
+	require.NotEmpty(t, msgs)
+
+	// Should have a CloseDialogMsg
+	assert.True(t, hasMsg[CloseDialogMsg](msgs), "should emit CloseDialogMsg")
+
+	// Should have a MultiChoiceResultMsg with IsCancelled=true
+	resultMsg, found := findMsg[MultiChoiceResultMsg](msgs)
+	require.True(t, found, "should emit MultiChoiceResultMsg")
+	assert.True(t, resultMsg.Result.IsCancelled)
+	assert.Equal(t, "test-escape", resultMsg.DialogID)
+}
+
+func TestMultiChoiceDialog_EscapeCancels_InCustomMode(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID:    "test-escape-custom",
+		Title:       "Escape in Custom Mode Test",
+		Options:     []MultiChoiceOption{{ID: "opt1", Label: "Option 1", Value: "value1"}},
+		AllowCustom: true,
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+	d.SetSize(100, 40)
+	d.selected = selectionCustom
+	d.customInput.Focus()
+	d.customInput.SetValue("some text")
+
+	escKey := tea.KeyPressMsg{Code: tea.KeyEscape}
+
+	_, cmd := d.Update(escKey)
+	require.NotNil(t, cmd)
+
+	msgs := collectMsgs(cmd)
+	resultMsg, found := findMsg[MultiChoiceResultMsg](msgs)
+	require.True(t, found)
+	assert.True(t, resultMsg.Result.IsCancelled, "should cancel even with custom text")
+}
+
+// ============================================================================
+// Submit Message Content Tests
+// ============================================================================
+
+func TestMultiChoiceDialog_SubmitOption_MessageContent(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID: "test-submit-option-msg",
+		Title:    "Submit Option Message Test",
+		Options: []MultiChoiceOption{
+			{ID: "bad_args", Label: "Bad Arguments", Value: "The arguments are incorrect."},
+		},
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+	d.SetSize(100, 40)
+	d.selected = selection(0)
+
+	_, cmd := d.submitPrimary()
+	require.NotNil(t, cmd)
+
+	msgs := collectMsgs(cmd)
+
+	// Should have CloseDialogMsg
+	assert.True(t, hasMsg[CloseDialogMsg](msgs))
+
+	// Should have MultiChoiceResultMsg with correct content
+	resultMsg, found := findMsg[MultiChoiceResultMsg](msgs)
+	require.True(t, found)
+	assert.Equal(t, "test-submit-option-msg", resultMsg.DialogID)
+	assert.Equal(t, "bad_args", resultMsg.Result.OptionID)
+	assert.Equal(t, "The arguments are incorrect.", resultMsg.Result.Value)
+	assert.False(t, resultMsg.Result.IsCustom)
+	assert.False(t, resultMsg.Result.IsSkipped)
+	assert.False(t, resultMsg.Result.IsCancelled)
+}
+
+func TestMultiChoiceDialog_SubmitCustom_MessageContent(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID:    "test-submit-custom-msg",
+		Title:       "Submit Custom Message Test",
+		Options:     []MultiChoiceOption{{ID: "opt1", Label: "Option 1", Value: "value1"}},
+		AllowCustom: true,
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+	d.SetSize(100, 40)
+	d.selected = selectionCustom
+	d.customInput.SetValue("My custom rejection reason")
+
+	_, cmd := d.submitPrimary()
+	require.NotNil(t, cmd)
+
+	msgs := collectMsgs(cmd)
+
+	resultMsg, found := findMsg[MultiChoiceResultMsg](msgs)
+	require.True(t, found)
+	assert.Equal(t, "custom", resultMsg.Result.OptionID)
+	assert.Equal(t, "My custom rejection reason", resultMsg.Result.Value)
+	assert.True(t, resultMsg.Result.IsCustom)
+	assert.False(t, resultMsg.Result.IsSkipped)
+}
+
+func TestMultiChoiceDialog_SubmitSkip_MessageContent(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID:       "test-submit-skip-msg",
+		Title:          "Submit Skip Message Test",
+		Options:        []MultiChoiceOption{{ID: "opt1", Label: "Option 1", Value: "value1"}},
+		AllowSecondary: true,
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+	d.SetSize(100, 40)
+
+	_, cmd := d.submitSecondary()
+	require.NotNil(t, cmd)
+
+	msgs := collectMsgs(cmd)
+
+	resultMsg, found := findMsg[MultiChoiceResultMsg](msgs)
+	require.True(t, found)
+	assert.Equal(t, "skip", resultMsg.Result.OptionID)
+	assert.True(t, resultMsg.Result.IsSkipped)
+	assert.Empty(t, resultMsg.Result.Value)
+}
+
+func TestMultiChoiceDialog_EnterKey_SubmitsDefault(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID:       "test-enter-default",
+		Title:          "Enter Default Test",
+		Options:        []MultiChoiceOption{{ID: "opt1", Label: "Option 1", Value: "value1"}},
+		AllowSecondary: true,
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+	d.SetSize(100, 40)
+
+	enterKey := tea.KeyPressMsg{Code: tea.KeyEnter}
+
+	// No selection - enter should submit skip
+	_, cmd := d.Update(enterKey)
+	require.NotNil(t, cmd)
+	msgs := collectMsgs(cmd)
+	resultMsg, found := findMsg[MultiChoiceResultMsg](msgs)
+	require.True(t, found)
+	assert.True(t, resultMsg.Result.IsSkipped)
+}
+
+func TestMultiChoiceDialog_EnterKey_WithSelection(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID:       "test-enter-selection",
+		Title:          "Enter With Selection Test",
+		Options:        []MultiChoiceOption{{ID: "opt1", Label: "Option 1", Value: "value1"}},
+		AllowSecondary: true,
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+	d.SetSize(100, 40)
+	d.selected = selection(0)
+
+	enterKey := tea.KeyPressMsg{Code: tea.KeyEnter}
+
+	_, cmd := d.Update(enterKey)
+	require.NotNil(t, cmd)
+	msgs := collectMsgs(cmd)
+	resultMsg, found := findMsg[MultiChoiceResultMsg](msgs)
+	require.True(t, found)
+	assert.Equal(t, "opt1", resultMsg.Result.OptionID)
+	assert.False(t, resultMsg.Result.IsSkipped)
+}
+
+// ============================================================================
+// Mouse Interaction Tests
+// ============================================================================
+
+func TestMultiChoiceDialog_MouseClick_SelectsOption(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID: "test-mouse-select",
+		Title:    "Mouse Select Test",
+		Options: []MultiChoiceOption{
+			{ID: "opt1", Label: "Option 1", Value: "value1"},
+			{ID: "opt2", Label: "Option 2", Value: "value2"},
+		},
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+	d.SetSize(100, 40)
+
+	// Render to populate clickables and positions
+	_ = d.View()
+	_, _ = d.Position()
+
+	// Click on first option
+	d.selected = selectionNone
+	clickY := d.contentAbsRow + d.clickables[0].startRow
+	updated, _ := d.handleMouseClick(d.contentAbsCol+5, clickY)
+	d = updated.(*multiChoiceDialog)
+	assert.Equal(t, selection(0), d.selected)
+
+	// Click on second option
+	clickY = d.contentAbsRow + d.clickables[1].startRow
+	updated, _ = d.handleMouseClick(d.contentAbsCol+5, clickY)
+	d = updated.(*multiChoiceDialog)
+	assert.Equal(t, selection(1), d.selected)
+}
+
+func TestMultiChoiceDialog_MouseClick_SkipButton(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID:       "test-mouse-skip",
+		Title:          "Mouse Skip Button Test",
+		Options:        []MultiChoiceOption{{ID: "opt1", Label: "Option 1", Value: "value1"}},
+		AllowSecondary: true,
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+	d.SetSize(100, 40)
+
+	// Render to populate button positions
+	_ = d.View()
+	_, _ = d.Position()
+
+	// Click on skip button
+	clickX := d.contentAbsCol + d.secondaryBtnCol + 1
+	clickY := d.contentAbsRow + d.btnRow
+	_, cmd := d.handleMouseClick(clickX, clickY)
+	require.NotNil(t, cmd)
+
+	msgs := collectMsgs(cmd)
+	resultMsg, found := findMsg[MultiChoiceResultMsg](msgs)
+	require.True(t, found)
+	assert.True(t, resultMsg.Result.IsSkipped)
+}
+
+func TestMultiChoiceDialog_MouseClick_ContinueButton(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID: "test-mouse-continue",
+		Title:    "Mouse Continue Button Test",
+		Options:  []MultiChoiceOption{{ID: "opt1", Label: "Option 1", Value: "value1"}},
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+	d.SetSize(100, 40)
+	d.selected = selection(0)
+
+	// Render to populate button positions
+	_ = d.View()
+	_, _ = d.Position()
+
+	// Click on continue button
+	clickX := d.contentAbsCol + d.primaryBtnCol + 1
+	clickY := d.contentAbsRow + d.btnRow
+	_, cmd := d.handleMouseClick(clickX, clickY)
+	require.NotNil(t, cmd)
+
+	msgs := collectMsgs(cmd)
+	resultMsg, found := findMsg[MultiChoiceResultMsg](msgs)
+	require.True(t, found)
+	assert.Equal(t, "opt1", resultMsg.Result.OptionID)
+}
+
+func TestMultiChoiceDialog_MouseClick_MultiRowOption(t *testing.T) {
+	t.Parallel()
+
+	// Create an option with a very long label that will wrap
+	longLabel := strings.Repeat("This is a very long option label that should wrap to multiple lines. ", 3)
+
+	config := MultiChoiceConfig{
+		DialogID: "test-mouse-multirow",
+		Title:    "Multi-Row Option Test",
+		Options: []MultiChoiceOption{
+			{ID: "long", Label: longLabel, Value: "long-value"},
+			{ID: "short", Label: "Short", Value: "short-value"},
+		},
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+	d.SetSize(80, 40) // Smaller width to force wrapping
+
+	// Render to populate clickables
+	_ = d.View()
+	_, _ = d.Position()
+
+	// First option should span multiple rows
+	if len(d.clickables) > 0 && d.clickables[0].endRow > d.clickables[0].startRow {
+		// Click on the second row of the first option
+		clickY := d.contentAbsRow + d.clickables[0].startRow + 1
+		updated, _ := d.handleMouseClick(d.contentAbsCol+5, clickY)
+		d = updated.(*multiChoiceDialog)
+		assert.Equal(t, selection(0), d.selected, "clicking on wrapped row should select the option")
+	}
+	// If wrapping didn't happen, the test still passes (depends on label length and dialog width)
+}
+
+// ============================================================================
+// Edge Cases and Helper Function Tests
+// ============================================================================
+
+func TestMultiChoiceDialog_TruncateWithEllipsisEnd(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		text     string
+		maxWidth int
+		expected string
+	}{
+		{
+			name:     "text fits exactly",
+			text:     "Hello",
+			maxWidth: 5,
+			expected: "Hello",
+		},
+		{
+			name:     "text fits with room",
+			text:     "Hi",
+			maxWidth: 10,
+			expected: "Hi",
+		},
+		{
+			name:     "text needs truncation",
+			text:     "Hello World",
+			maxWidth: 8,
+			expected: "Hello...",
+		},
+		{
+			name:     "very short max width",
+			text:     "Hello",
+			maxWidth: 3,
+			expected: "...",
+		},
+		{
+			name:     "max width too small for ellipsis",
+			text:     "Hello",
+			maxWidth: 2,
+			expected: "...",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := truncateWithEllipsisEnd(tt.text, tt.maxWidth)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestMultiChoiceDialog_CustomLabelsNotOverwritten(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID:          "test-custom-labels",
+		Title:             "Custom Labels Test",
+		Options:           []MultiChoiceOption{{ID: "opt1", Label: "Option 1", Value: "value1"}},
+		SecondaryLabel:    "No Thanks",
+		PrimaryLabel:      "Proceed",
+		CustomPlaceholder: "Enter your own...",
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+
+	assert.Equal(t, "No Thanks", d.config.SecondaryLabel)
+	assert.Equal(t, "Proceed", d.config.PrimaryLabel)
+	assert.Equal(t, "Enter your own...", d.config.CustomPlaceholder)
+}
+
+func TestMultiChoiceDialog_HelpText_WithOptions(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID: "test-help-options",
+		Title:    "Help Text Test",
+		Options: []MultiChoiceOption{
+			{ID: "opt1", Label: "Option 1", Value: "value1"},
+			{ID: "opt2", Label: "Option 2", Value: "value2"},
+		},
+		AllowCustom: true,
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+	d.SetSize(100, 40)
+
+	view := d.View()
+	// Should show "1-3" for 2 options + custom (1-indexed)
+	assert.Contains(t, view, "1-3")
+	assert.Contains(t, view, "select")
+}
+
+func TestMultiChoiceDialog_HelpText_NoOptions(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID:    "test-help-no-options",
+		Title:       "Help Text No Options Test",
+		Options:     []MultiChoiceOption{},
+		AllowCustom: false,
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+	d.SetSize(100, 40)
+
+	view := d.View()
+	// Should show "navigate" instead of "select"
+	assert.Contains(t, view, "navigate")
+}
+
+func TestMultiChoiceDialog_EmptyCustom_FallsBackToSkip(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID:       "test-empty-custom-skip",
+		Title:          "Empty Custom Fallback Test",
+		Options:        []MultiChoiceOption{{ID: "opt1", Label: "Option 1", Value: "value1"}},
+		AllowCustom:    true,
+		AllowSecondary: true,
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+	d.SetSize(100, 40)
+	d.selected = selectionCustom
+	d.customInput.SetValue("   ") // Whitespace only
+
+	_, cmd := d.submitPrimary()
+	require.NotNil(t, cmd)
+
+	msgs := collectMsgs(cmd)
+	resultMsg, found := findMsg[MultiChoiceResultMsg](msgs)
+	require.True(t, found)
+	assert.True(t, resultMsg.Result.IsSkipped, "whitespace-only custom should fall back to skip")
+}
+
+func TestMultiChoiceDialog_EmptyCustom_NoSkip_NoOp(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID:       "test-empty-custom-no-skip",
+		Title:          "Empty Custom No Skip Test",
+		Options:        []MultiChoiceOption{{ID: "opt1", Label: "Option 1", Value: "value1"}},
+		AllowCustom:    true,
+		AllowSecondary: false,
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+	d.SetSize(100, 40)
+	d.selected = selectionCustom
+	d.customInput.SetValue("") // Empty
+
+	_, cmd := d.submitPrimary()
+	assert.Nil(t, cmd, "empty custom with no skip allowed should be no-op")
+}
+
+func TestMultiChoiceDialog_NoSelection_NoSkip_NoOp(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID:       "test-no-selection-no-skip",
+		Title:          "No Selection No Skip Test",
+		Options:        []MultiChoiceOption{{ID: "opt1", Label: "Option 1", Value: "value1"}},
+		AllowSecondary: false,
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+	d.SetSize(100, 40)
+	d.selected = selectionNone
+
+	_, cmd := d.submitPrimary()
+	assert.Nil(t, cmd, "no selection with no skip allowed should be no-op")
+}
+
+func TestMultiChoiceDialog_CustomInputFocus(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID:    "test-custom-focus",
+		Title:       "Custom Focus Test",
+		Options:     []MultiChoiceOption{{ID: "opt1", Label: "Option 1", Value: "value1"}},
+		AllowCustom: true,
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+	d.SetSize(100, 40)
+
+	// Initially not focused
+	d.selected = selection(0)
+	d.updateFocus()
+	// Note: bubbles textinput Focused() might not be directly testable without
+	// checking internal state, but we can verify the selection-based logic
+
+	// Select custom - should focus
+	d.selected = selectionCustom
+	d.updateFocus()
+	// The input should be focused (verified by the fact that typing works)
+
+	// Select option - should blur
+	d.selected = selection(0)
+	d.updateFocus()
+}
+
+func TestMultiChoiceDialog_NavigationWithoutCustom(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID:    "test-nav-no-custom",
+		Title:       "Navigation Without Custom Test",
+		Options:     []MultiChoiceOption{{ID: "opt1", Label: "Option 1", Value: "value1"}},
+		AllowCustom: false,
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+
+	// Start at none
+	assert.Equal(t, selectionNone, d.selected)
+
+	// Down -> option
+	d.selectNext()
+	assert.Equal(t, selection(0), d.selected)
+
+	// Down -> wrap to none (no custom)
+	d.selectNext()
+	assert.Equal(t, selectionNone, d.selected)
+
+	// Up from none -> last option (no custom)
+	d.selectPrevious()
+	assert.Equal(t, selection(0), d.selected)
+}
+
+func TestMultiChoiceDialog_NavigationOnlyCustom(t *testing.T) {
+	t.Parallel()
+
+	config := MultiChoiceConfig{
+		DialogID:    "test-nav-only-custom",
+		Title:       "Navigation Only Custom Test",
+		Options:     []MultiChoiceOption{}, // No options
+		AllowCustom: true,
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+
+	// Start at none
+	assert.Equal(t, selectionNone, d.selected)
+
+	// Down -> custom (no options)
+	d.selectNext()
+	assert.Equal(t, selectionCustom, d.selected)
+
+	// Down -> wrap to none
+	d.selectNext()
+	assert.Equal(t, selectionNone, d.selected)
+
+	// Up from none -> custom
+	d.selectPrevious()
+	assert.Equal(t, selectionCustom, d.selected)
+}
+
+// ============================================================================
+// Helper Function Tests
+// ============================================================================
+
+func TestIndexToDisplayNum(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		idx      int
+		expected int
+	}{
+		{0, 1},   // First option displays as 1
+		{1, 2},   // Second option displays as 2
+		{8, 9},   // 9th option displays as 9
+		{9, 0},   // 10th option displays as 0
+		{10, 11}, // Beyond 10 (edge case, shouldn't happen with max 10 options)
+	}
+
+	for _, tt := range tests {
+		result := indexToDisplayNum(tt.idx)
+		assert.Equal(t, tt.expected, result, "indexToDisplayNum(%d) should be %d", tt.idx, tt.expected)
+	}
+}
+
+func TestFormatKeyRange(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		numOptions int
+		expected   string
+	}{
+		{1, "1"},    // Single option
+		{2, "1-2"},  // Two options
+		{5, "1-5"},  // Five options
+		{9, "1-9"},  // Nine options
+		{10, "0-9"}, // Ten options (0 is 10th)
+		{11, "0-9"}, // More than 10 still shows 0-9
+	}
+
+	for _, tt := range tests {
+		result := formatKeyRange(tt.numOptions)
+		assert.Equal(t, tt.expected, result, "formatKeyRange(%d) should be %q", tt.numOptions, tt.expected)
+	}
+}
+
+func TestMultiChoiceDialog_NumberShortcuts_TenthOption(t *testing.T) {
+	t.Parallel()
+
+	// Create dialog with 10 options
+	options := make([]MultiChoiceOption, 10)
+	for i := range 10 {
+		options[i] = MultiChoiceOption{
+			ID:    "opt" + strconv.Itoa(i+1),
+			Label: "Option " + strconv.Itoa(i+1),
+			Value: "value" + strconv.Itoa(i+1),
+		}
+	}
+
+	config := MultiChoiceConfig{
+		DialogID: "test-tenth-option",
+		Title:    "Tenth Option Test",
+		Options:  options,
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+	d.SetSize(100, 40)
+
+	// Press "1" to select first option
+	updated, _ := d.Update(tea.KeyPressMsg{Text: "1"})
+	d = updated.(*multiChoiceDialog)
+	assert.Equal(t, selection(0), d.selected)
+
+	// Press "9" to select ninth option
+	updated, _ = d.Update(tea.KeyPressMsg{Text: "9"})
+	d = updated.(*multiChoiceDialog)
+	assert.Equal(t, selection(8), d.selected)
+
+	// Press "0" to select tenth option
+	updated, _ = d.Update(tea.KeyPressMsg{Text: "0"})
+	d = updated.(*multiChoiceDialog)
+	assert.Equal(t, selection(9), d.selected)
+}
+
+func TestMultiChoiceDialog_HelpText_TenOptions(t *testing.T) {
+	t.Parallel()
+
+	// Create dialog with 10 options
+	options := make([]MultiChoiceOption, 10)
+	for i := range 10 {
+		options[i] = MultiChoiceOption{
+			ID:    "opt" + strconv.Itoa(i+1),
+			Label: "Option " + strconv.Itoa(i+1),
+			Value: "value" + strconv.Itoa(i+1),
+		}
+	}
+
+	config := MultiChoiceConfig{
+		DialogID: "test-help-ten-options",
+		Title:    "Ten Options Help Test",
+		Options:  options,
+	}
+
+	d := NewMultiChoiceDialog(config).(*multiChoiceDialog)
+	d.SetSize(100, 50)
+
+	view := d.View()
+	// Should show "0-9" for 10 options
+	assert.Contains(t, view, "0-9")
+	assert.Contains(t, view, "select")
+}


### PR DESCRIPTION
Initial version of a multi-choice dialog box.  

The idea was to use it to allow for a "reason" dialog box when rejecting tool calls, or to allow the model to prompt users with options via a tool call (not included in this PR).

What does it include?
- Allows defining up to 10 options to choose from
- Choosing if "secondary" button (in the img "skip") is shown along with the primary button, and ability to give them custom labels
- Tab selection between primary/secondary buttons
- If present, secondary button is focused by default, primary gets focused when an option is chosen (e.g. "skip/send")
- Options can be chosen with numbers or by mouse click
- Optional custom input field. If present, typing any non-number will auto select this option and insert the input

---

Demo usage screenshot

<img width="726" height="302" alt="image" src="https://github.com/user-attachments/assets/5f78045b-4d04-428c-ac71-d5542f942e06" />
