### PR TITLE
Reject tools with a reason

### DIFF
--- a/examples/golibrary/stream/main.go
+++ b/examples/golibrary/stream/main.go
@@ -63,7 +63,7 @@ func run(ctx context.Context) error {
 		case *runtime.StreamStoppedEvent:
 			log.Println("Stream stopped for session")
 		case *runtime.ToolCallConfirmationEvent:
-			rt.Resume(ctx, "approve-session")
+			rt.Resume(ctx, runtime.ResumeRequest{Type: runtime.ResumeTypeApproveSession})
 		case *runtime.ToolCallEvent:
 			log.Printf("Tool call: %s\n", e.ToolCall.Function.Name)
 		case *runtime.ToolCallResponseEvent:

--- a/gen/proto/cagent/v1/cagent.pb.go
+++ b/gen/proto/cagent/v1/cagent.pb.go
@@ -1021,6 +1021,7 @@ type ResumeSessionRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	Confirmation  string                 `protobuf:"bytes,2,opt,name=confirmation,proto3" json:"confirmation,omitempty"` // "approve", "approve-session", or "reject"
+	Reason        string                 `protobuf:"bytes,3,opt,name=reason,proto3" json:"reason,omitempty"`             // Optional rejection reason (used when confirmation is "reject")
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1065,6 +1066,13 @@ func (x *ResumeSessionRequest) GetId() string {
 func (x *ResumeSessionRequest) GetConfirmation() string {
 	if x != nil {
 		return x.Confirmation
+	}
+	return ""
+}
+
+func (x *ResumeSessionRequest) GetReason() string {
+	if x != nil {
+		return x.Reason
 	}
 	return ""
 }
@@ -4307,10 +4315,11 @@ const file_cagent_v1_cagent_proto_rawDesc = "" +
 	"\asession\x18\x01 \x01(\v2\x12.cagent.v1.SessionR\asession\"&\n" +
 	"\x14DeleteSessionRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\"\x17\n" +
-	"\x15DeleteSessionResponse\"J\n" +
+	"\x15DeleteSessionResponse\"b\n" +
 	"\x14ResumeSessionRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\"\n" +
-	"\fconfirmation\x18\x02 \x01(\tR\fconfirmation\"\x17\n" +
+	"\fconfirmation\x18\x02 \x01(\tR\fconfirmation\x12\x16\n" +
+	"\x06reason\x18\x03 \x01(\tR\x06reason\"\x17\n" +
 	"\x15ResumeSessionResponse\":\n" +
 	"\x19ToggleToolApprovalRequest\x12\x1d\n" +
 	"\n" +

--- a/pkg/acp/agent.go
+++ b/pkg/acp/agent.go
@@ -411,7 +411,7 @@ func (a *Agent) handleToolCallConfirmation(ctx context.Context, acpSess *Session
 
 	// Handle permission outcome
 	if permResp.Outcome.Cancelled != nil {
-		acpSess.rt.Resume(ctx, runtime.ResumeTypeReject)
+		acpSess.rt.Resume(ctx, runtime.ResumeRequest{Type: runtime.ResumeTypeReject})
 		return nil
 	}
 
@@ -421,11 +421,11 @@ func (a *Agent) handleToolCallConfirmation(ctx context.Context, acpSess *Session
 
 	switch string(permResp.Outcome.Selected.OptionId) {
 	case "allow":
-		acpSess.rt.Resume(ctx, runtime.ResumeTypeApprove)
+		acpSess.rt.Resume(ctx, runtime.ResumeRequest{Type: runtime.ResumeTypeApprove})
 	case "allow-always":
-		acpSess.rt.Resume(ctx, runtime.ResumeTypeApproveSession)
+		acpSess.rt.Resume(ctx, runtime.ResumeRequest{Type: runtime.ResumeTypeApproveSession})
 	case "reject":
-		acpSess.rt.Resume(ctx, runtime.ResumeTypeReject)
+		acpSess.rt.Resume(ctx, runtime.ResumeRequest{Type: runtime.ResumeTypeReject})
 	default:
 		return fmt.Errorf("unexpected permission option: %s", permResp.Outcome.Selected.OptionId)
 	}
@@ -462,9 +462,9 @@ func (a *Agent) handleMaxIterationsReached(ctx context.Context, acpSess *Session
 
 	if permResp.Outcome.Cancelled != nil || permResp.Outcome.Selected == nil ||
 		string(permResp.Outcome.Selected.OptionId) == "stop" {
-		acpSess.rt.Resume(ctx, runtime.ResumeTypeReject)
+		acpSess.rt.Resume(ctx, runtime.ResumeRequest{Type: runtime.ResumeTypeReject})
 	} else {
-		acpSess.rt.Resume(ctx, runtime.ResumeTypeApprove)
+		acpSess.rt.Resume(ctx, runtime.ResumeRequest{Type: runtime.ResumeTypeApprove})
 	}
 
 	return nil

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -146,6 +146,7 @@ type UpdateSessionPermissionsRequest struct {
 // ResumeSessionRequest represents a request to resume a session
 type ResumeSessionRequest struct {
 	Confirmation string `json:"confirmation"`
+	Reason       string `json:"reason,omitempty"` // e.g reason for tool call rejection
 }
 
 // DesktopTokenResponse represents the response from getting a desktop token

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -274,9 +274,9 @@ func (a *App) Subscribe(ctx context.Context, program *tea.Program) {
 	}
 }
 
-// Resume resumes the runtime with the given confirmation type
-func (a *App) Resume(resumeType runtime.ResumeType) {
-	a.runtime.Resume(context.Background(), resumeType)
+// Resume resumes the runtime with the given confirmation request
+func (a *App) Resume(req runtime.ResumeRequest) {
+	a.runtime.Resume(context.Background(), req)
 }
 
 // ResumeElicitation resumes an elicitation request with the given action and content

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -34,7 +34,7 @@ func (m *mockRuntime) RunStream(ctx context.Context, sess *session.Session) <-ch
 func (m *mockRuntime) Run(ctx context.Context, sess *session.Session) ([]session.Message, error) {
 	return nil, nil
 }
-func (m *mockRuntime) Resume(ctx context.Context, t runtime.ResumeType) {}
+func (m *mockRuntime) Resume(ctx context.Context, req runtime.ResumeRequest) {}
 func (m *mockRuntime) ResumeElicitation(ctx context.Context, action tools.ElicitationAction, content map[string]any) error {
 	return nil
 }

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -71,7 +71,7 @@ func Run(ctx context.Context, out *Printer, cfg Config, rt runtime.Runtime, sess
 				switch e := event.(type) {
 				case *runtime.ToolCallConfirmationEvent:
 					if !cfg.AutoApprove {
-						rt.Resume(ctx, runtime.ResumeTypeReject)
+						rt.Resume(ctx, runtime.ResumeReject(""))
 					}
 				case *runtime.ErrorEvent:
 					return fmt.Errorf("%s", e.Error)
@@ -114,12 +114,12 @@ func Run(ctx context.Context, out *Printer, cfg Config, rt runtime.Runtime, sess
 				lastConfirmedToolCallID = e.ToolCall.ID // Store the ID to avoid duplicate printing
 				switch result {
 				case ConfirmationApprove:
-					rt.Resume(ctx, runtime.ResumeTypeApprove)
+					rt.Resume(ctx, runtime.ResumeApprove())
 				case ConfirmationApproveSession:
 					sess.ToolsApproved = true
-					rt.Resume(ctx, runtime.ResumeTypeApproveSession)
+					rt.Resume(ctx, runtime.ResumeApproveSession())
 				case ConfirmationReject:
-					rt.Resume(ctx, runtime.ResumeTypeReject)
+					rt.Resume(ctx, runtime.ResumeReject(""))
 					lastConfirmedToolCallID = "" // Clear on reject since tool won't execute
 				case ConfirmationAbort:
 					// Stop the agent loop immediately
@@ -155,12 +155,12 @@ func Run(ctx context.Context, out *Printer, cfg Config, rt runtime.Runtime, sess
 				result := out.PromptMaxIterationsContinue(ctx, e.MaxIterations)
 				switch result {
 				case ConfirmationApprove:
-					rt.Resume(ctx, runtime.ResumeTypeApprove)
+					rt.Resume(ctx, runtime.ResumeApprove())
 				case ConfirmationReject:
-					rt.Resume(ctx, runtime.ResumeTypeReject)
+					rt.Resume(ctx, runtime.ResumeReject(""))
 					return nil
 				case ConfirmationAbort:
-					rt.Resume(ctx, runtime.ResumeTypeReject)
+					rt.Resume(ctx, runtime.ResumeReject(""))
 					return nil
 				}
 			case *runtime.ElicitationRequestEvent:

--- a/pkg/config/sources_test.go
+++ b/pkg/config/sources_test.go
@@ -50,6 +50,14 @@ func TestURLSource_Read_HTTPError(t *testing.T) {
 			}))
 			t.Cleanup(server.Close)
 
+			// Clean up any cached data for this URL to ensure we test the error path
+			urlCacheDir := getURLCacheDir()
+			urlHash := hashURL(server.URL)
+			cachePath := filepath.Join(urlCacheDir, urlHash)
+			etagPath := cachePath + ".etag"
+			_ = os.Remove(cachePath)
+			_ = os.Remove(etagPath)
+
 			_, err := NewURLSource(server.URL).Read(t.Context())
 			require.Error(t, err)
 		})

--- a/pkg/connectrpc/server.go
+++ b/pkg/connectrpc/server.go
@@ -225,7 +225,7 @@ func (s *Server) DeleteSession(ctx context.Context, req *connect.Request[cagentv
 
 // ResumeSession resumes a paused session.
 func (s *Server) ResumeSession(ctx context.Context, req *connect.Request[cagentv1.ResumeSessionRequest]) (*connect.Response[cagentv1.ResumeSessionResponse], error) {
-	if err := s.sm.ResumeSession(ctx, req.Msg.Id, req.Msg.Confirmation); err != nil {
+	if err := s.sm.ResumeSession(ctx, req.Msg.Id, req.Msg.Confirmation, req.Msg.Reason); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to resume session: %w", err))
 	}
 	return connect.NewResponse(&cagentv1.ResumeSessionResponse{}), nil

--- a/pkg/runtime/client.go
+++ b/pkg/runtime/client.go
@@ -251,9 +251,9 @@ func (c *Client) CreateSession(ctx context.Context, sessTemplate *session.Sessio
 	return &sess, err
 }
 
-// ResumeSession resumes a session by ID
-func (c *Client) ResumeSession(ctx context.Context, id, confirmation string) error {
-	req := api.ResumeSessionRequest{Confirmation: confirmation}
+// ResumeSession resumes a session by ID with an optional rejection reason
+func (c *Client) ResumeSession(ctx context.Context, id, confirmation, reason string) error {
+	req := api.ResumeSessionRequest{Confirmation: confirmation, Reason: reason}
 	return c.doRequest(ctx, http.MethodPost, "/api/sessions/"+id+"/resume", req, nil)
 }
 

--- a/pkg/runtime/commands_test.go
+++ b/pkg/runtime/commands_test.go
@@ -41,7 +41,7 @@ func (m *mockRuntime) RunStream(context.Context, *session.Session) <-chan Event 
 func (m *mockRuntime) Run(context.Context, *session.Session) ([]session.Message, error) {
 	return nil, nil
 }
-func (m *mockRuntime) Resume(context.Context, ResumeType) {}
+func (m *mockRuntime) Resume(context.Context, ResumeRequest) {}
 func (m *mockRuntime) ResumeElicitation(context.Context, tools.ElicitationAction, map[string]any) error {
 	return nil
 }

--- a/pkg/runtime/connectrpc_client.go
+++ b/pkg/runtime/connectrpc_client.go
@@ -154,11 +154,12 @@ func (c *ConnectRPCClient) DeleteSession(ctx context.Context, id string) error {
 	return err
 }
 
-// ResumeSession resumes a session by ID
-func (c *ConnectRPCClient) ResumeSession(ctx context.Context, id, confirmation string) error {
+// ResumeSession resumes a session by ID with an optional rejection reason
+func (c *ConnectRPCClient) ResumeSession(ctx context.Context, id, confirmation, reason string) error {
 	_, err := c.client.ResumeSession(ctx, connect.NewRequest(&cagentv1.ResumeSessionRequest{
 		Id:           id,
 		Confirmation: confirmation,
+		Reason:       reason,
 	}))
 	return err
 }

--- a/pkg/runtime/remote_client.go
+++ b/pkg/runtime/remote_client.go
@@ -18,8 +18,8 @@ type RemoteClient interface {
 	// CreateSession creates a new session
 	CreateSession(ctx context.Context, sessTemplate *session.Session) (*session.Session, error)
 
-	// ResumeSession resumes a paused session
-	ResumeSession(ctx context.Context, id, confirmation string) error
+	// ResumeSession resumes a paused session with an optional rejection reason
+	ResumeSession(ctx context.Context, id, confirmation, reason string) error
 
 	// ResumeElicitation sends an elicitation response
 	ResumeElicitation(ctx context.Context, sessionID string, action tools.ElicitationAction, content map[string]any) error

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -197,15 +197,15 @@ func (r *RemoteRuntime) Run(ctx context.Context, sess *session.Session) ([]sessi
 }
 
 // Resume allows resuming execution after user confirmation
-func (r *RemoteRuntime) Resume(ctx context.Context, confirmationType ResumeType) {
-	slog.Debug("Resuming remote runtime", "agent", r.currentAgent, "confirmation_type", confirmationType, "session_id", r.sessionID)
+func (r *RemoteRuntime) Resume(ctx context.Context, req ResumeRequest) {
+	slog.Debug("Resuming remote runtime", "agent", r.currentAgent, "type", req.Type, "reason", req.Reason, "session_id", r.sessionID)
 
 	if r.sessionID == "" {
 		slog.Error("Cannot resume: no session ID available")
 		return
 	}
 
-	if err := r.client.ResumeSession(ctx, r.sessionID, string(confirmationType)); err != nil {
+	if err := r.client.ResumeSession(ctx, r.sessionID, string(req.Type), req.Reason); err != nil {
 		slog.Error("Failed to resume remote session", "error", err, "session_id", r.sessionID)
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -204,7 +204,7 @@ func (s *Server) resumeSession(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid request body: %v", err))
 	}
 
-	if err := s.sm.ResumeSession(c.Request().Context(), c.Param("id"), req.Confirmation); err != nil {
+	if err := s.sm.ResumeSession(c.Request().Context(), c.Param("id"), req.Confirmation, req.Reason); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to resume session: %v", err))
 	}
 

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -184,8 +184,8 @@ func (sm *SessionManager) RunSession(ctx context.Context, sessionID, agentFilena
 	return streamChan, nil
 }
 
-// ResumeSession resumes a paused session.
-func (sm *SessionManager) ResumeSession(ctx context.Context, sessionID, confirmation string) error {
+// ResumeSession resumes a paused session with an optional rejection reason.
+func (sm *SessionManager) ResumeSession(ctx context.Context, sessionID, confirmation, reason string) error {
 	sm.mux.Lock()
 	defer sm.mux.Unlock()
 	rt, exists := sm.runtimeSessions.Load(sessionID)
@@ -193,7 +193,10 @@ func (sm *SessionManager) ResumeSession(ctx context.Context, sessionID, confirma
 		return errors.New("session not found")
 	}
 
-	rt.runtime.Resume(ctx, runtime.ResumeType(confirmation))
+	rt.runtime.Resume(ctx, runtime.ResumeRequest{
+		Type:   runtime.ResumeType(confirmation),
+		Reason: reason,
+	})
 	return nil
 }
 

--- a/pkg/tui/dialog/max_iterations.go
+++ b/pkg/tui/dialog/max_iterations.go
@@ -14,6 +14,13 @@ import (
 	"github.com/docker/cagent/pkg/tui/styles"
 )
 
+// Layout constants for max iterations dialog.
+const (
+	maxIterDialogWidthPercent = 60 // Dialog width as percentage of screen
+	maxIterDialogMinWidth     = 36 // Minimum dialog width
+	maxIterDialogMaxWidth     = 84 // Maximum dialog width
+)
+
 type maxIterationsDialog struct {
 	BaseDialog
 	maxIterations int
@@ -51,13 +58,13 @@ func (d *maxIterationsDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 			func() (layout.Model, tea.Cmd) {
 				return d, tea.Sequence(
 					core.CmdHandler(CloseDialogMsg{}),
-					core.CmdHandler(RuntimeResumeMsg{Response: runtime.ResumeTypeApprove}),
+					core.CmdHandler(RuntimeResumeMsg{Request: runtime.ResumeApprove()}),
 				)
 			},
 			func() (layout.Model, tea.Cmd) {
 				return d, tea.Sequence(
 					core.CmdHandler(CloseDialogMsg{}),
-					core.CmdHandler(RuntimeResumeMsg{Response: runtime.ResumeTypeReject}),
+					core.CmdHandler(RuntimeResumeMsg{Request: runtime.ResumeReject("")}),
 				)
 			},
 		)
@@ -76,8 +83,8 @@ func (d *maxIterationsDialog) Position() (row, col int) {
 
 // View renders the max iterations confirmation dialog
 func (d *maxIterationsDialog) View() string {
-	dialogWidth := d.ComputeDialogWidth(60, 36, 84)
-	contentWidth := d.ContentWidth(dialogWidth, 2)
+	dialogWidth := d.ComputeDialogWidth(maxIterDialogWidthPercent, maxIterDialogMinWidth, maxIterDialogMaxWidth)
+	contentWidth := dialogWidth - styles.DialogWarningStyle.GetHorizontalFrameSize()
 
 	infoText := fmt.Sprintf("Max Iterations: %d", d.maxIterations)
 	messageText := "The agent may be stuck in a loop. This can happen with smaller or less capable models."
@@ -95,8 +102,8 @@ func (d *maxIterationsDialog) View() string {
 		AddHelpKeys("Y", "yes", "N", "no").
 		Build()
 
+	// DialogWarningStyle already includes Padding(1, 2)
 	return styles.DialogWarningStyle.
-		Padding(1, 2).
 		Width(dialogWidth).
 		Render(content)
 }

--- a/pkg/tui/dialog/tool_confirmation.go
+++ b/pkg/tui/dialog/tool_confirmation.go
@@ -1,8 +1,6 @@
 package dialog
 
 import (
-	"strings"
-
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -16,9 +14,18 @@ import (
 	"github.com/docker/cagent/pkg/tui/types"
 )
 
+// Layout constants for tool confirmation dialog.
+const (
+	toolConfirmDialogWidthPercent  = 70 // Dialog width as percentage of screen
+	toolConfirmDialogHeightPercent = 80 // Max dialog height as percentage of screen
+	toolConfirmMinScrollHeight     = 5  // Minimum height for the scroll view
+	toolConfirmEmptyLinesBefore    = 2  // Empty lines before question
+	toolConfirmEmptyLinesAfter     = 1  // Empty lines after question
+)
+
 type (
 	RuntimeResumeMsg struct {
-		Response runtime.ResumeType
+		Request runtime.ResumeRequest
 	}
 )
 
@@ -35,24 +42,27 @@ type toolConfirmationDialog struct {
 	scrollView   messages.Model
 }
 
+// dialogDimensions returns computed dialog width and content width.
+func (d *toolConfirmationDialog) dialogDimensions() (dialogWidth, contentWidth int) {
+	dialogWidth = d.Width() * toolConfirmDialogWidthPercent / 100
+	contentWidth = dialogWidth - styles.DialogStyle.GetHorizontalFrameSize()
+	return dialogWidth, contentWidth
+}
+
 // SetSize implements [Dialog].
 func (d *toolConfirmationDialog) SetSize(width, height int) tea.Cmd {
 	d.BaseDialog.SetSize(width, height)
 
-	// Calculate dialog dimensions
-	dialogWidth := width * 70 / 100
-	contentWidth := dialogWidth - 6
-	maxDialogHeight := (height * 80) / 100
+	// Calculate dialog dimensions using helper
+	_, contentWidth := d.dialogDimensions()
+	maxDialogHeight := height * toolConfirmDialogHeightPercent / 100
 
+	// Measure fixed UI elements using the same rendering as View()
 	titleStyle := styles.DialogTitleStyle.Width(contentWidth)
 	title := titleStyle.Render("Tool Confirmation")
 	titleHeight := lipgloss.Height(title)
 
-	separatorWidth := max(contentWidth-10, 20)
-	separator := styles.DialogSeparatorStyle.
-		Align(lipgloss.Center).
-		Width(contentWidth).
-		Render(strings.Repeat("─", separatorWidth))
+	separator := d.renderSeparator(contentWidth)
 	separatorHeight := lipgloss.Height(separator)
 
 	question := styles.DialogQuestionStyle.Width(contentWidth).Render("Do you want to allow this tool call?")
@@ -62,11 +72,17 @@ func (d *toolConfirmationDialog) SetSize(width, height int) tea.Cmd {
 	optionsHeight := lipgloss.Height(options)
 
 	// Calculate available height for scroll view
-	// Total = maxDialogHeight - title - separator - 2 empty lines - question - empty line - options - 4 (dialog padding/border)
-	availableHeight := max(maxDialogHeight-titleHeight-separatorHeight-2-questionHeight-1-optionsHeight-4, 5)
+	frameHeight := styles.DialogStyle.GetVerticalFrameSize()
+	fixedContentHeight := titleHeight + separatorHeight + toolConfirmEmptyLinesBefore + questionHeight + toolConfirmEmptyLinesAfter + optionsHeight
+	availableHeight := max(maxDialogHeight-frameHeight-fixedContentHeight, toolConfirmMinScrollHeight)
 	d.scrollView.SetSize(contentWidth, availableHeight)
 
 	return nil
+}
+
+// renderSeparator renders the separator line consistently.
+func (d *toolConfirmationDialog) renderSeparator(contentWidth int) string {
+	return RenderSeparator(contentWidth)
 }
 
 // toolConfirmationKeyMap defines key bindings for tool confirmation dialog
@@ -96,8 +112,8 @@ func defaultToolConfirmationKeyMap() toolConfirmationKeyMap {
 
 // NewToolConfirmationDialog creates a new tool confirmation dialog
 func NewToolConfirmationDialog(msg *runtime.ToolCallConfirmationEvent, sessionState *service.SessionState) Dialog {
-	// Create scrollable view with initial size (will be updated in SetSize)
-	scrollView := messages.NewScrollableView(100, 20, sessionState)
+	// Create scrollable view with minimal initial size (will be updated in SetSize)
+	scrollView := messages.NewScrollableView(1, 1, sessionState)
 
 	// Add the tool call message to the view
 	scrollView.AddOrUpdateToolCall(
@@ -128,27 +144,27 @@ func (d *toolConfirmationDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		return d, cmd
 
 	case tea.KeyPressMsg:
+		if cmd := HandleQuit(msg); cmd != nil {
+			return d, cmd
+		}
+
 		switch {
 		case key.Matches(msg, d.keyMap.Yes):
 			return d, tea.Sequence(
 				core.CmdHandler(CloseDialogMsg{}),
-				core.CmdHandler(RuntimeResumeMsg{Response: runtime.ResumeTypeApprove}),
+				core.CmdHandler(RuntimeResumeMsg{Request: runtime.ResumeApprove()}),
 			)
 		case key.Matches(msg, d.keyMap.No):
-			return d, tea.Sequence(
-				core.CmdHandler(CloseDialogMsg{}),
-				core.CmdHandler(RuntimeResumeMsg{Response: runtime.ResumeTypeReject}),
-			)
+			// Open the rejection reason dialog on top of this dialog
+			return d, core.CmdHandler(OpenDialogMsg{
+				Model: NewToolRejectionReasonDialog(),
+			})
 		case key.Matches(msg, d.keyMap.All):
 			d.sessionState.SetYoloMode(true)
 			return d, tea.Sequence(
 				core.CmdHandler(CloseDialogMsg{}),
-				core.CmdHandler(RuntimeResumeMsg{Response: runtime.ResumeTypeApproveSession}),
+				core.CmdHandler(RuntimeResumeMsg{Request: runtime.ResumeApproveSession()}),
 			)
-		}
-
-		if cmd := HandleQuit(msg); cmd != nil {
-			return d, cmd
 		}
 
 		// Forward scrolling keys to the scroll view
@@ -170,29 +186,18 @@ func (d *toolConfirmationDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 
 // View renders the tool confirmation dialog
 func (d *toolConfirmationDialog) View() string {
-	dialogWidth := d.Width() * 70 / 100
-
-	// Content width (accounting for padding and borders)
-	contentWidth := dialogWidth - 6
+	dialogWidth, contentWidth := d.dialogDimensions()
 
 	dialogStyle := styles.DialogStyle.Width(dialogWidth)
 
-	// Title
 	titleStyle := styles.DialogTitleStyle.Width(contentWidth)
 	title := titleStyle.Render("Tool Confirmation")
 
 	// Separator
-	separatorWidth := max(contentWidth-10, 20)
-	separator := styles.DialogSeparatorStyle.
-		Align(lipgloss.Center).
-		Width(contentWidth).
-		Render(strings.Repeat("─", separatorWidth))
+	separator := d.renderSeparator(contentWidth)
 
 	// Get scrollable tool call view
 	argumentsSection := d.scrollView.View()
-
-	question := styles.DialogQuestionStyle.Width(contentWidth).Render("Do you want to allow this tool call?")
-	options := RenderHelpKeys(contentWidth, "Y", "yes", "N", "no", "A", "all (approve all tools this session)")
 
 	// Combine all parts with proper spacing
 	parts := []string{title, separator}
@@ -200,6 +205,10 @@ func (d *toolConfirmationDialog) View() string {
 	if argumentsSection != "" {
 		parts = append(parts, "", argumentsSection)
 	}
+
+	// Confirmation prompt
+	question := styles.DialogQuestionStyle.Width(contentWidth).Render("Do you want to allow this tool call?")
+	options := RenderHelpKeys(contentWidth, "Y", "yes", "N", "no", "A", "all (approve all tools this session)")
 
 	parts = append(parts, "", question, "", options)
 
@@ -210,7 +219,8 @@ func (d *toolConfirmationDialog) View() string {
 
 // Position calculates the position to center the dialog
 func (d *toolConfirmationDialog) Position() (row, col int) {
-	dialogWidth := d.Width() * 70 / 100
+	dialogWidth, _ := d.dialogDimensions()
 	renderedDialog := d.View()
-	return CenterPosition(d.Width(), d.Height(), dialogWidth, lipgloss.Height(renderedDialog))
+	dialogHeight := lipgloss.Height(renderedDialog)
+	return CenterPosition(d.Width(), d.Height(), dialogWidth, dialogHeight)
 }

--- a/pkg/tui/dialog/tool_rejection_reason.go
+++ b/pkg/tui/dialog/tool_rejection_reason.go
@@ -1,0 +1,68 @@
+package dialog
+
+import (
+	"github.com/docker/cagent/pkg/runtime"
+)
+
+// ToolRejectionDialogID is the unique identifier for the tool rejection reason dialog.
+const ToolRejectionDialogID = "tool-rejection-reason"
+
+// toolRejectionOptions defines the preset rejection reasons.
+// These match the original presets from tool_confirmation.go.
+var toolRejectionOptions = []MultiChoiceOption{
+	{
+		ID:    "bad_args",
+		Label: "Bad arguments",
+		Value: "The arguments provided are incorrect or invalid.",
+	},
+	{
+		ID:    "wrong_tool",
+		Label: "Wrong tool",
+		Value: "This is the wrong tool for this task.",
+	},
+	{
+		ID:    "unsafe",
+		Label: "Unsafe",
+		Value: "This action could be unsafe or destructive.",
+	},
+	{
+		ID:    "clarify",
+		Label: "Clarify first",
+		Value: "Please clarify what you're trying to accomplish.",
+	},
+}
+
+// NewToolRejectionReasonDialog creates a multi-choice dialog for selecting
+// the reason for rejecting a tool call.
+func NewToolRejectionReasonDialog() Dialog {
+	return NewMultiChoiceDialog(MultiChoiceConfig{
+		DialogID:          ToolRejectionDialogID,
+		Title:             "Why reject this tool call?",
+		Options:           toolRejectionOptions,
+		AllowCustom:       true,
+		AllowSecondary:    true,
+		SecondaryLabel:    "Skip",
+		PrimaryLabel:      "Reject",
+		CustomPlaceholder: "Other reason...",
+	})
+}
+
+// HandleToolRejectionResult processes the result from the tool rejection dialog
+// and returns the appropriate RuntimeResumeMsg.
+// Returns nil if the result was cancelled (user should stay in confirmation dialog).
+func HandleToolRejectionResult(result MultiChoiceResult) *RuntimeResumeMsg {
+	if result.IsCancelled {
+		// User pressed Esc - don't send resume, let them stay in confirmation dialog
+		return nil
+	}
+
+	// Build the reason string
+	reason := result.Value
+	if result.IsSkipped {
+		reason = "" // No reason provided
+	}
+
+	return &RuntimeResumeMsg{
+		Request: runtime.ResumeReject(reason),
+	}
+}


### PR DESCRIPTION
Draft because it depends on #1443

Allow users to give a reason when rejecting a tool call. This can help steer the model towards the right solutions and avoid some logical loops models can sometimes gets into

---

**Screencast**


https://github.com/user-attachments/assets/e3ab032a-b33e-40ad-94ee-600a59e596d5

