### PR TITLE
userconfig: protect aliases map against concurrent access

### DIFF
--- a/pkg/userconfig/userconfig.go
+++ b/pkg/userconfig/userconfig.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sync"
 
 	"github.com/goccy/go-yaml"
 	"github.com/natefinch/atomic"
@@ -38,6 +39,10 @@ const CurrentVersion = "v1"
 
 // Config represents the user-level cagent configuration
 type Config struct {
+	// mu protects concurrent access to the Aliases map.
+	// Config methods may be called from parallel tests or goroutines.
+	mu sync.Mutex
+
 	// Version is the config format version
 	Version string `yaml:"version,omitempty"`
 	// ModelsGateway is the default models gateway URL
@@ -125,6 +130,12 @@ func (c *Config) migrateFromLegacy(legacyPath string) bool {
 		return false
 	}
 
+	// Protect concurrent writes to the Aliases map while migrating
+	// legacy aliases. This avoids concurrent map write panics if
+	// the config is accessed by multiple goroutines.
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	for name, path := range legacy {
 		c.Aliases[name] = &Alias{Path: path}
 	}
@@ -159,8 +170,15 @@ func (c *Config) saveTo(path string) error {
 	return atomic.WriteFile(path, bytes.NewReader(data))
 }
 
-// GetAlias retrieves the alias configuration for a given name
+// GetAlias retrieves the alias configuration for a given name.
+//
+// This method is safe for concurrent use. Reads from the Aliases map
+// are protected by a mutex to avoid concurrent read/write panics when
+// aliases are accessed while being modified.
 func (c *Config) GetAlias(name string) (*Alias, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	alias, ok := c.Aliases[name]
 	return alias, ok
 }
@@ -186,7 +204,11 @@ func ValidateAliasName(name string) error {
 }
 
 // SetAlias creates or updates an alias.
-// Returns an error if the alias name is invalid.
+// Returns an error if the alias name or alias configuration is invalid.
+//
+// This method is safe for concurrent use. Writes to the Aliases map
+// are protected by a mutex to avoid concurrent map write panics when
+// aliases are modified from multiple goroutines.
 func (c *Config) SetAlias(name string, alias *Alias) error {
 	if err := ValidateAliasName(name); err != nil {
 		return err
@@ -194,12 +216,24 @@ func (c *Config) SetAlias(name string, alias *Alias) error {
 	if alias == nil || alias.Path == "" {
 		return errors.New("agent path cannot be empty")
 	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.Aliases[name] = alias
 	return nil
 }
 
-// DeleteAlias removes an alias. Returns true if the alias existed.
+// DeleteAlias removes an alias by name.
+// It returns true if the alias existed.
+//
+// This method is safe for concurrent use. Access to the Aliases map
+// is protected by a mutex to prevent concurrent map read/write panics
+// when called from parallel tests or goroutines.
 func (c *Config) DeleteAlias(name string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if _, exists := c.Aliases[name]; exists {
 		delete(c.Aliases, name)
 		return true


### PR DESCRIPTION
## What I did

- Protected the `Config.Aliases` map with a mutex.
- Made all reads and writes to aliases safe for concurrent use.
- Added minimal documentation explaining the concurrency guarantees.

## Related issue

Fixes #1454

## What was the bug

The `Config.Aliases` map was accessed concurrently without synchronization.

When multiple goroutines (or parallel tests) called methods like `SetAlias`, `GetAlias`, or `DeleteAlias` at the same time, this resulted in:

- `fatal error: concurrent map writes`
- flaky test failures in CI

Because Go maps are not thread-safe, even concurrent reads and writes could trigger panics.

## Description

In the previous implementation, the `Config` struct exposed methods that mutated or read from the `Aliases` map without any form of synchronization.

When these methods were invoked concurrently—most notably from tests using `t.Parallel()`—the runtime detected unsafe concurrent access and crashed.

This change introduces a mutex inside `Config` and ensures that all accesses to the `Aliases` map are properly synchronized.

## Result

- Alias operations are now safe for concurrent use.
- Flaky panics caused by concurrent map access are eliminated.
- No behavioral or API changes were introduced.

### Validation — Reproducing the original failure
The issue was originally reproducible by repeatedly running the userconfig test suite, which intermittently failed with a `concurrent map access` panic.

<img width="926" height="133" alt="image" src="https://github.com/user-attachments/assets/dc7dcf37-58e7-46d5-85a1-45b23b6493c6" />

### Validation — Race detector
The fix was also validated using the Go race detector:

<img width="870" height="90" alt="image" src="https://github.com/user-attachments/assets/e92ca5bb-9a3c-4ecb-8e29-292ed958916d" />

### Validation — Full build
After the fix, the full test suite (`go test ./...`) runs successfully without failures.