### PR TITLE
docs(paths): add clarifying comments for config and data dirs

### DIFF
--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -5,33 +5,39 @@ import (
 	"path/filepath"
 )
 
-// GetConfigDir returns the user's config directory for cagent
-// Falls back to temp directory if home directory cannot be determined
+// GetConfigDir returns the user's config directory for cagent.
+//
+// If the home directory cannot be determined, it falls back to a directory
+// under the system temporary directory. This is a best-effort fallback and
+// not intended to be a security boundary.
 func GetConfigDir() string {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		// Fallback to temp directory
-		return filepath.Join(os.TempDir(), ".cagent-config")
+		return filepath.Clean(filepath.Join(os.TempDir(), ".cagent-config"))
 	}
-	return filepath.Join(homeDir, ".config", "cagent")
+	return filepath.Clean(filepath.Join(homeDir, ".config", "cagent"))
 }
 
-// GetDataDir returns the user's data directory for cagent (caches, content, logs)
-// Falls back to temp directory if home directory cannot be determined
+// GetDataDir returns the user's data directory for cagent (caches, content, logs).
+//
+// If the home directory cannot be determined, it falls back to a directory
+// under the system temporary directory.
 func GetDataDir() string {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		return filepath.Join(os.TempDir(), ".cagent")
+		return filepath.Clean(filepath.Join(os.TempDir(), ".cagent"))
 	}
-	return filepath.Join(homeDir, ".cagent")
+	return filepath.Clean(filepath.Join(homeDir, ".cagent"))
 }
 
-// GetHomeDir returns the user's home directory
-// Returns empty string if the home directory cannot be determined
+// GetHomeDir returns the user's home directory.
+//
+// Returns an empty string if the home directory cannot be determined.
 func GetHomeDir() string {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return ""
 	}
-	return homeDir
+	return filepath.Clean(homeDir)
 }


### PR DESCRIPTION
## What I did

- Added a small defensive improvement to path handling in the `paths` package.
- Normalized directory paths using `filepath.Clean` to ensure consistent canonical paths.
- Clarified fallback behavior in comments for cases where the home directory cannot be determined.

## Reference

This PR is a follow-up to earlier work on concurrency and hardening:

- See PR #1458  — fixed flaky tests caused by concurrent map access.
- The change here was not included in that PR because that one involved a larger diff and unrelated logic, and including this would have unnecessarily mixed concerns.

## Why

While the concrete behavior of these helpers does not change, normalizing and documenting paths improves readability, predictability, and long-term maintainability. This is a lightweight, defensive improvement that aligns with prior hardening efforts.

## Result

- No functional or API changes.
- Path helpers use canonical path normalization.
- Better inline documentation for future maintainers.
