### PR TITLE
read pdf

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/junegunn/fzf v0.67.0
 	github.com/k3a/html2text v1.3.0
 	github.com/labstack/echo/v4 v4.15.0
+	github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mattn/go-runewidth v0.0.19
 	github.com/modelcontextprotocol/go-sdk v1.2.1-0.20260115164613-13488f7da1ed

--- a/go.sum
+++ b/go.sum
@@ -279,6 +279,8 @@ github.com/labstack/echo/v4 v4.15.0 h1:hoRTKWcnR5STXZFe9BmYun9AMTNeSbjHi2vtDuADJ
 github.com/labstack/echo/v4 v4.15.0/go.mod h1:xmw1clThob0BSVRX1CRQkGQ/vjwcpOMjQZSZa9fKA/c=
 github.com/labstack/gommon v0.4.2 h1:F8qTUNXgG1+6WQmqoUWnz8WiEU60mXVVw0P4ht1WRA0=
 github.com/labstack/gommon v0.4.2/go.mod h1:QlUFxVM+SNXhDL/Z7YhocGIBYOiwB0mXm1+1bAPHPyU=
+github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728 h1:QwWKgMY28TAXaDl+ExRDqGQltzXqN/xypdKP86niVn8=
+github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728/go.mod h1:1fEHWurg7pvf5SG6XNE5Q8UZmOwex51Mkx3SLhrW5B4=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=

--- a/pkg/tools/builtin/pdf.go
+++ b/pkg/tools/builtin/pdf.go
@@ -1,0 +1,36 @@
+package builtin
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/ledongthuc/pdf"
+)
+
+// readPDFText extracts plain text content from a PDF file.
+func readPDFText(path string) (string, error) {
+	f, r, err := pdf.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to open PDF: %w", err)
+	}
+	defer f.Close()
+
+	var buf bytes.Buffer
+	b, err := r.GetPlainText()
+	if err != nil {
+		return "", fmt.Errorf("failed to extract text from PDF: %w", err)
+	}
+
+	if _, err := io.Copy(&buf, b); err != nil {
+		return "", fmt.Errorf("failed to read PDF text: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
+// isPDFFile checks if a file path has a PDF extension.
+func isPDFFile(path string) bool {
+	return strings.HasSuffix(strings.ToLower(path), ".pdf")
+}

--- a/pkg/tools/builtin/pdf_test.go
+++ b/pkg/tools/builtin/pdf_test.go
@@ -1,0 +1,104 @@
+package builtin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsPDFFile(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		path     string
+		expected bool
+	}{
+		{"document.pdf", true},
+		{"document.PDF", true},
+		{"document.Pdf", true},
+		{"path/to/document.pdf", true},
+		{"/absolute/path/to/document.pdf", true},
+		{"document.txt", false},
+		{"document.pdf.txt", false},
+		{"document", false},
+		{"", false},
+		{"pdf", false},
+		{".pdf", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.path, func(t *testing.T) {
+			t.Parallel()
+			result := isPDFFile(tc.path)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestReadPDFText_NonexistentFile(t *testing.T) {
+	t.Parallel()
+	_, err := readPDFText("/nonexistent/path/to/file.pdf")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to open PDF")
+}
+
+func TestReadPDFText_InvalidFile(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	invalidPDF := filepath.Join(tmpDir, "invalid.pdf")
+	require.NoError(t, os.WriteFile(invalidPDF, []byte("not a valid pdf content"), 0o644))
+
+	_, err := readPDFText(invalidPDF)
+	require.Error(t, err)
+}
+
+func TestFilesystemTool_ReadFile_PDF(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	tool := NewFilesystemTool(tmpDir)
+
+	invalidPDF := "test.pdf"
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, invalidPDF), []byte("not a valid pdf"), 0o644))
+
+	result, err := tool.handleReadFile(t.Context(), ReadFileArgs{
+		Path: invalidPDF,
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Output, "failed to open PDF")
+}
+
+func TestFilesystemTool_ReadFile_PDFNotFound(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	tool := NewFilesystemTool(tmpDir)
+
+	result, err := tool.handleReadFile(t.Context(), ReadFileArgs{
+		Path: "nonexistent.pdf",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Output, "failed to open PDF")
+}
+
+func TestFilesystemTool_ReadMultipleFiles_WithPDF(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	tool := NewFilesystemTool(tmpDir)
+
+	textFile := "test.txt"
+	pdfFile := "test.pdf"
+	textContent := "Hello, World!"
+
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, textFile), []byte(textContent), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, pdfFile), []byte("invalid pdf"), 0o644))
+
+	result, err := tool.handleReadMultipleFiles(t.Context(), ReadMultipleFilesArgs{
+		Paths: []string{textFile, pdfFile},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, textContent)
+	assert.Contains(t, result.Output, "failed to open PDF")
+}


### PR DESCRIPTION
## Add PDF file reading support
Adds the ability to read PDF files via the  read_file  and
read_multiple_files  tools using the  github.com/ledongthuc/pdf  library.

### Changes
• Add  ledongthuc/pdf  dependency (pure Go, zero external dependencies)
• Detect PDF files by extension and extract plain text automatically
• Handle errors gracefully for invalid or corrupted PDFs