### PR TITLE
fade out competed tool calls in collapsed reasoning blocks

### DIFF
--- a/pkg/tui/components/messages/messages.go
+++ b/pkg/tui/components/messages/messages.go
@@ -81,6 +81,7 @@ type model struct {
 
 	// Height tracking system fields
 	scrollOffset  int                  // Current scroll position in lines
+	bottomSlack   int                  // Extra blank lines added after content shrinks
 	rendered      string               // Complete rendered content string
 	renderedItems map[int]renderedItem // Cache of rendered items with positions
 	totalHeight   int                  // Total height of all content in lines
@@ -185,6 +186,9 @@ func (m *model) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		m.invalidateAllItems()
 		return m, nil
 
+	case reasoningblock.BlockMsg:
+		return m.forwardToReasoningBlock(msg.GetBlockID(), msg)
+
 	case tea.KeyPressMsg:
 		return m.handleKeyPress(msg)
 	}
@@ -216,6 +220,7 @@ func (m *model) handleMouseClick(msg tea.MouseClickMsg) (layout.Model, tea.Cmd) 
 			if block.IsToggleLine(localLine) {
 				block.Toggle()
 				m.userHasScrolled = true // Prevent auto-scroll jump
+				m.bottomSlack = 0
 				m.invalidateItem(msgIdx)
 				return m, nil
 			}
@@ -306,12 +311,14 @@ func (m *model) handleMouseWheel(msg tea.MouseWheelMsg) (layout.Model, tea.Cmd) 
 	case "wheelup":
 		if m.scrollOffset > 0 {
 			m.userHasScrolled = true
+			m.bottomSlack = 0
 			for range mouseScrollAmount {
 				m.setScrollOffset(m.scrollOffset - defaultScrollAmount)
 			}
 		}
 	case "wheeldown":
 		m.userHasScrolled = true
+		m.bottomSlack = 0
 		for range mouseScrollAmount {
 			m.setScrollOffset(m.scrollOffset + defaultScrollAmount)
 		}
@@ -370,23 +377,39 @@ func (m *model) View() string {
 	}
 
 	prevTotalHeight := m.totalHeight
+	prevScrollableHeight := m.totalHeight + m.bottomSlack
 	m.ensureAllItemsRendered()
 
 	if m.totalHeight == 0 {
 		return ""
 	}
 
-	// Calculate viewport bounds
-	maxScrollOffset := max(0, m.totalHeight-m.height)
+	if m.userHasScrolled {
+		m.bottomSlack = 0
+	} else {
+		delta := m.totalHeight - prevTotalHeight
+		if delta < 0 {
+			m.bottomSlack += -delta
+		} else if delta > 0 && m.bottomSlack > 0 {
+			consume := min(delta, m.bottomSlack)
+			m.bottomSlack -= consume
+		}
+	}
 
-	// Auto-scroll if content grew and user hasn't manually scrolled
-	if !m.userHasScrolled && m.totalHeight > prevTotalHeight {
+	scrollableHeight := m.totalHeight + m.bottomSlack
+	maxScrollOffset := max(0, scrollableHeight-m.height)
+
+	// Auto-scroll when content grows beyond any slack.
+	if !m.userHasScrolled && scrollableHeight > prevScrollableHeight {
 		m.scrollOffset = maxScrollOffset
 	} else {
 		m.scrollOffset = max(0, min(m.scrollOffset, maxScrollOffset))
 	}
 
 	lines := strings.Split(m.rendered, "\n")
+	if m.bottomSlack > 0 {
+		lines = append(lines, make([]string, m.bottomSlack)...)
+	}
 	if len(lines) == 0 {
 		return ""
 	}
@@ -515,12 +538,14 @@ const defaultScrollAmount = 1
 func (m *model) scrollUp() {
 	if m.scrollOffset > 0 {
 		m.userHasScrolled = true
+		m.bottomSlack = 0
 		m.setScrollOffset(max(0, m.scrollOffset-defaultScrollAmount))
 	}
 }
 
 func (m *model) scrollDown() {
 	m.userHasScrolled = true
+	m.bottomSlack = 0
 	m.setScrollOffset(m.scrollOffset + defaultScrollAmount)
 	if m.isAtBottom() {
 		m.userHasScrolled = false
@@ -529,11 +554,13 @@ func (m *model) scrollDown() {
 
 func (m *model) scrollPageUp() {
 	m.userHasScrolled = true
+	m.bottomSlack = 0
 	m.setScrollOffset(max(0, m.scrollOffset-m.height))
 }
 
 func (m *model) scrollPageDown() {
 	m.userHasScrolled = true
+	m.bottomSlack = 0
 	m.setScrollOffset(m.scrollOffset + m.height)
 	if m.isAtBottom() {
 		m.userHasScrolled = false
@@ -542,6 +569,7 @@ func (m *model) scrollPageDown() {
 
 func (m *model) scrollToTop() {
 	m.userHasScrolled = true
+	m.bottomSlack = 0
 	m.setScrollOffset(0)
 }
 
@@ -551,7 +579,7 @@ func (m *model) scrollToBottom() {
 }
 
 func (m *model) setScrollOffset(offset int) {
-	maxOffset := max(0, m.totalHeight-m.height)
+	maxOffset := max(0, m.totalScrollableHeight()-m.height)
 	m.scrollOffset = max(0, min(offset, maxOffset))
 	m.scrollbar.SetScrollOffset(m.scrollOffset)
 }
@@ -560,7 +588,7 @@ func (m *model) isAtBottom() bool {
 	if len(m.messages) == 0 {
 		return true
 	}
-	maxScrollOffset := max(0, m.totalHeight-m.height)
+	maxScrollOffset := max(0, m.totalScrollableHeight()-m.height)
 	return m.scrollOffset >= maxScrollOffset
 }
 
@@ -653,9 +681,11 @@ func (m *model) scrollToSelectedMessage() {
 	// Scroll to make the selected message visible
 	if startLine < m.scrollOffset {
 		m.userHasScrolled = true
+		m.bottomSlack = 0
 		m.setScrollOffset(startLine)
 	} else if endLine > m.scrollOffset+m.height {
 		m.userHasScrolled = true
+		m.bottomSlack = 0
 		m.setScrollOffset(endLine - m.height)
 	}
 }
@@ -776,6 +806,21 @@ func (m *model) invalidateAllItems() {
 	m.rendered = ""
 	m.totalHeight = 0
 	m.renderDirty = true
+}
+
+// forwardToReasoningBlock finds the reasoning block with the given ID and forwards the message to it.
+func (m *model) forwardToReasoningBlock(blockID string, msg tea.Msg) (layout.Model, tea.Cmd) {
+	for i, tuiMsg := range m.messages {
+		if tuiMsg.Type == types.MessageTypeAssistantReasoningBlock {
+			if block, ok := m.views[i].(*reasoningblock.Model); ok && block.ID() == blockID {
+				updatedView, cmd := m.views[i].Update(msg)
+				m.views[i] = updatedView
+				m.invalidateItem(i)
+				return m, cmd
+			}
+		}
+	}
+	return m, nil
 }
 
 // Message management methods
@@ -909,6 +954,7 @@ func (m *model) LoadFromSession(sess *session.Session) tea.Cmd {
 	m.rendered = ""
 	m.scrollOffset = 0
 	m.totalHeight = 0
+	m.bottomSlack = 0
 	m.selectedMessageIndex = -1
 
 	var cmds []tea.Cmd
@@ -1185,6 +1231,10 @@ func (m *model) contentWidth() int {
 	return m.width - 2
 }
 
+func (m *model) totalScrollableHeight() int {
+	return m.totalHeight + m.bottomSlack
+}
+
 // Helper methods
 func (m *model) createToolCallView(msg *types.Message) layout.Model {
 	view := tool.New(msg, m.sessionState)
@@ -1254,6 +1304,8 @@ func (m *model) isMouseOnScrollbar(x, y int) bool {
 func (m *model) handleScrollbarUpdate(msg tea.Msg) (layout.Model, tea.Cmd) {
 	sb, cmd := m.scrollbar.Update(msg)
 	m.scrollbar = sb
+	m.userHasScrolled = true
+	m.bottomSlack = 0
 	m.scrollOffset = m.scrollbar.GetScrollOffset()
 	return m, cmd
 }

--- a/pkg/tui/components/reasoningblock/reasoningblock.go
+++ b/pkg/tui/components/reasoningblock/reasoningblock.go
@@ -1,8 +1,11 @@
 package reasoningblock
 
 import (
+	"fmt"
+	"image/color"
 	"strconv"
 	"strings"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -20,17 +23,64 @@ import (
 const (
 	// previewLines is the number of reasoning lines to show when collapsed.
 	previewLines = 3
+	// completedToolVisibleDuration is how long a completed tool remains fully visible before fading.
+	completedToolVisibleDuration = 1500 * time.Millisecond
+	// completedToolFadeSteps is the number of fade animation steps.
+	completedToolFadeSteps = 16
+	// completedToolFadeDuration is how long the fade-out effect lasts before hiding.
+	completedToolFadeDuration = 1000 * time.Millisecond
+	// completedToolFadeInterval is the time between each fade step.
+	completedToolFadeInterval = completedToolFadeDuration / completedToolFadeSteps
 )
 
-// ToggleMsg is sent when the block should toggle expanded/collapsed state.
-type ToggleMsg struct {
+// fadeColor returns an interpolated color for the given fade level (1-8).
+// Level 1 is slightly faded, level 8 is very faded (close to background).
+func fadeColor(level int) color.Color {
+	// Interpolate from #808080 (normal muted) to #303038 (very faded)
+	// RGB: (128,128,128) -> (48,48,56)
+	startR, startG, startB := 128, 128, 128
+	endR, endG, endB := 48, 48, 56
+	t := float64(level) / float64(completedToolFadeSteps)
+	r := int(float64(startR) + t*float64(endR-startR))
+	g := int(float64(startG) + t*float64(endG-startG))
+	b := int(float64(startB) + t*float64(endB-startB))
+	return lipgloss.Color(fmt.Sprintf("#%02X%02X%02X", r, g, b))
+}
+
+// nowFunc is the time function used to get the current time.
+// Tests can override this for deterministic behavior.
+var nowFunc = time.Now
+
+// BlockMsg is implemented by messages that target a specific reasoning block.
+type BlockMsg interface {
+	GetBlockID() string
+}
+
+// blockMsgBase is embedded in messages that target a specific reasoning block.
+type blockMsgBase struct {
 	BlockID string
 }
 
+func (m blockMsgBase) GetBlockID() string { return m.BlockID }
+
+// ToggleMsg is sent when the block should toggle expanded/collapsed state.
+type ToggleMsg struct{ blockMsgBase }
+
+// FadeTickMsg is sent to advance a tool's fade animation by one step.
+type FadeTickMsg struct {
+	blockMsgBase
+	ToolCallID string
+}
+
+// GraceExpiredMsg is sent when a tool's grace period has expired and it should be hidden.
+type GraceExpiredMsg struct{ blockMsgBase }
+
 // toolEntry holds a tool call message and its view.
 type toolEntry struct {
-	msg  *types.Message
-	view layout.Model
+	msg                   *types.Message
+	view                  layout.Model
+	collapsedVisibleUntil time.Time // Zero means no grace period (hide immediately when completed)
+	fadeLevel             int       // 0 = not fading, 1-8 = fading (higher = more faded)
 }
 
 // contentItemKind identifies the type of content item.
@@ -178,14 +228,41 @@ func (m *Model) UpdateToolResult(toolCallID, content string, status types.ToolSt
 		if entry.msg.ToolCall.ID != toolCallID {
 			continue
 		}
+		// Check if this is a transition from in-progress to completed/error
+		wasInProgress := entry.msg.ToolStatus == types.ToolStatusPending ||
+			entry.msg.ToolStatus == types.ToolStatusRunning
+		isCompleted := status == types.ToolStatusCompleted || status == types.ToolStatusError
+
 		entry.msg.Content = strings.ReplaceAll(content, "\t", "    ")
 		entry.msg.ToolStatus = status
 		entry.msg.ToolResult = result
+
+		// Set grace period if transitioning from in-progress to completed
+		// Total visible time = completedToolVisibleDuration + completedToolFadeDuration
+		var fadeCmd tea.Cmd
+		if wasInProgress && isCompleted {
+			totalDuration := completedToolVisibleDuration + completedToolFadeDuration
+			entry.collapsedVisibleUntil = nowFunc().Add(totalDuration)
+			entry.fadeLevel = 0
+			blockID := m.id
+			tcID := toolCallID
+			// Schedule first fade tick after the visible duration
+			fadeCmd = tea.Tick(completedToolVisibleDuration, func(time.Time) tea.Msg {
+				return FadeTickMsg{blockMsgBase{blockID}, tcID}
+			})
+		}
+
 		// Recreate view to pick up new state
 		view := tool.New(entry.msg, m.sessionState)
 		view.SetSize(m.contentWidth(), 0)
+		m.toolEntries[i] = entry
 		m.toolEntries[i].view = view
-		return view.Init()
+
+		initCmd := view.Init()
+		if fadeCmd != nil {
+			return tea.Batch(initCmd, fadeCmd)
+		}
+		return initCmd
 	}
 	return nil
 }
@@ -198,6 +275,41 @@ func (m *Model) HasToolCall(toolCallID string) bool {
 		}
 	}
 	return false
+}
+
+// AdvanceFade increments a tool's fade level and returns a command for the next step.
+// Returns nil if the tool is not found or already fully faded.
+func (m *Model) AdvanceFade(toolCallID string) tea.Cmd {
+	for i, entry := range m.toolEntries {
+		if entry.msg.ToolCall.ID != toolCallID {
+			continue
+		}
+		m.toolEntries[i].fadeLevel++
+		level := m.toolEntries[i].fadeLevel
+
+		blockID := m.id
+		if level >= completedToolFadeSteps {
+			// Final step - schedule hide
+			return tea.Tick(completedToolFadeInterval, func(time.Time) tea.Msg {
+				return GraceExpiredMsg{blockMsgBase{blockID}}
+			})
+		}
+		// Schedule next fade step
+		return tea.Tick(completedToolFadeInterval, func(time.Time) tea.Msg {
+			return FadeTickMsg{blockMsgBase{blockID}, toolCallID}
+		})
+	}
+	return nil
+}
+
+// GetToolFadeLevel returns the fade level for a tool (0 = not fading, 1-8 = fading).
+func (m *Model) GetToolFadeLevel(toolCallID string) int {
+	for _, entry := range m.toolEntries {
+		if entry.msg.ToolCall.ID == toolCallID {
+			return entry.fadeLevel
+		}
+	}
+	return 0
 }
 
 // ToolCount returns the number of tool calls in this block.
@@ -233,6 +345,20 @@ func (m *Model) Init() tea.Cmd {
 
 // Update handles messages.
 func (m *Model) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case FadeTickMsg:
+		if msg.BlockID != m.id {
+			return m, nil
+		}
+		cmd := m.AdvanceFade(msg.ToolCallID)
+		return m, cmd
+	case GraceExpiredMsg:
+		if msg.BlockID != m.id {
+			return m, nil
+		}
+		return m, nil
+	}
+
 	// Forward updates to all tool views (for spinners, etc.)
 	var cmds []tea.Cmd
 	for i, entry := range m.toolEntries {
@@ -367,29 +493,44 @@ func (m *Model) renderCollapsed() string {
 		}
 	}
 
-	// Only show in-progress tool calls (pending/running) in collapsed view
-	// Completed tools are hidden to keep the view clean
-	inProgressTools := m.getInProgressTools()
-	if len(inProgressTools) > 0 {
+	// Show in-progress tools and recently completed tools (within grace period)
+	visibleTools := m.getVisibleToolsCollapsed()
+	if len(visibleTools) > 0 {
 		parts = append(parts, "") // blank line before tools
-		for _, entry := range inProgressTools {
-			parts = append(parts, entry.view.View())
+		for _, entry := range visibleTools {
+			toolView := entry.view.View()
+			if entry.fadeLevel > 0 {
+				// Strip existing ANSI codes and apply faded color based on level
+				// (wrapping styled content doesn't override inner colors)
+				stripped := ansi.Strip(toolView)
+				fadeStyle := lipgloss.NewStyle().Foreground(fadeColor(entry.fadeLevel))
+				toolView = fadeStyle.Render(stripped)
+			}
+			parts = append(parts, toolView)
 		}
 	}
 
 	return strings.Join(parts, "\n")
 }
 
-// getInProgressTools returns tool entries that are still in progress (pending or running).
-func (m *Model) getInProgressTools() []toolEntry {
-	var inProgress []toolEntry
+// getVisibleToolsCollapsed returns tool entries that should be visible in collapsed view.
+// This includes in-progress tools (pending/running) and recently completed tools within their grace period.
+func (m *Model) getVisibleToolsCollapsed() []toolEntry {
+	now := nowFunc()
+	var visible []toolEntry
 	for _, entry := range m.toolEntries {
+		// Show in-progress tools
 		if entry.msg.ToolStatus == types.ToolStatusPending ||
 			entry.msg.ToolStatus == types.ToolStatusRunning {
-			inProgress = append(inProgress, entry)
+			visible = append(visible, entry)
+			continue
+		}
+		// Show completed/error tools within grace period
+		if !entry.collapsedVisibleUntil.IsZero() && now.Before(entry.collapsedVisibleUntil) {
+			visible = append(visible, entry)
 		}
 	}
-	return inProgress
+	return visible
 }
 
 // hasExtraContent returns true if there's content that would be shown when expanded

--- a/pkg/tui/styles/styles.go
+++ b/pkg/tui/styles/styles.go
@@ -22,6 +22,7 @@ const (
 	ColorAccentBlue      = "#7AA2F7"
 	ColorMutedBlue       = "#8B95C1"
 	ColorMutedGray       = "#808080"
+	ColorFadedGray       = "#404550" // Very dim, close to background - for fade-out effects
 	ColorBackgroundAlt   = "#24283B"
 	ColorBorderSecondary = "#6B75A8"
 	ColorTextPrimary     = "#C0C0C0"
@@ -169,6 +170,7 @@ var (
 	MutedStyle          = BaseStyle.Foreground(TextMutedGray)
 	SecondaryStyle      = BaseStyle.Foreground(TextSecondary)
 	BoldStyle           = BaseStyle.Bold(true)
+	FadingStyle         = NoStyle.Foreground(lipgloss.Color(ColorFadedGray)) // Very dim for fade-out animations
 )
 
 // Status Styles


### PR DESCRIPTION
Proposal for improving how collapsed reasoning blocks render their tool calls

In progress tool calls are currently shown right below the collapsed reasoning block.  
Once the tool has finished executing, it used to disappear immediately from the collapsed view.  

Now, **finished tool calls will remain visible for 2.5 seconds, while fading out for the last 1.5 seconds** to indicate it's about to be removed from the collapsed view

Also adds some "bottom slack" to the scrolling of messages so the UI doesn't jump up and down if tool calls in reasoning blocks appear and then get removed at the very bottom of the viewport.

### Screencasts

> The interesting bits are at the start/end of each video

---

**before**

https://github.com/user-attachments/assets/a06d736a-733f-4a34-998f-1b496790fa6e

---

**after**

https://github.com/user-attachments/assets/ede84f33-28bb-43a9-a4ec-b9bbb028244c
