### PR TITLE
Add Files API support for image attachments

### DIFF
--- a/pkg/chat/chat.go
+++ b/pkg/chat/chat.go
@@ -26,9 +26,44 @@ const (
 	ImageURLDetailAuto ImageURLDetail = "auto"
 )
 
+// FileSourceType indicates how the file should be referenced in API calls
+type FileSourceType string
+
+const (
+	// FileSourceTypeNone means no file reference, use URL or base64
+	FileSourceTypeNone FileSourceType = ""
+	// FileSourceTypeFileID means the file was uploaded and should be referenced by ID
+	FileSourceTypeFileID FileSourceType = "file_id"
+	// FileSourceTypeFileURI means the file was uploaded and should be referenced by URI (Gemini)
+	FileSourceTypeFileURI FileSourceType = "file_uri"
+	// FileSourceTypeLocalPath means the file is a local path that needs to be uploaded/converted
+	FileSourceTypeLocalPath FileSourceType = "local_path"
+)
+
+// FileReference contains information about a file attachment
+type FileReference struct {
+	// SourceType indicates how this file should be referenced
+	SourceType FileSourceType `json:"source_type,omitempty"`
+	// FileID is the provider-specific file identifier (for FileSourceTypeFileID)
+	FileID string `json:"file_id,omitempty"`
+	// FileURI is the file URI (for FileSourceTypeFileURI, used by Gemini)
+	FileURI string `json:"file_uri,omitempty"`
+	// LocalPath is the path to a local file (for FileSourceTypeLocalPath)
+	LocalPath string `json:"local_path,omitempty"`
+	// MimeType is the MIME type of the file
+	MimeType string `json:"mime_type,omitempty"`
+	// Provider identifies which provider this reference is for (when uploaded)
+	Provider string `json:"provider,omitempty"`
+}
+
 type MessageImageURL struct {
+	// URL contains a data URL (base64) or a public HTTP(S) URL
 	URL    string         `json:"url,omitempty"`
 	Detail ImageURLDetail `json:"detail,omitempty"`
+
+	// FileRef contains file reference info when the image was uploaded via Files API
+	// or references a local file path that needs to be processed
+	FileRef *FileReference `json:"file_ref,omitempty"`
 }
 
 type Message struct {

--- a/pkg/cli/runner_attachment_test.go
+++ b/pkg/cli/runner_attachment_test.go
@@ -1,0 +1,214 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/cagent/pkg/chat"
+)
+
+func TestCreateUserMessageWithAttachment(t *testing.T) {
+	t.Parallel()
+
+	// Create a temporary test image file
+	tmpDir := t.TempDir()
+	jpegPath := filepath.Join(tmpDir, "test.jpg")
+	pngPath := filepath.Join(tmpDir, "test.png")
+	gifPath := filepath.Join(tmpDir, "test.gif")
+	webpPath := filepath.Join(tmpDir, "test.webp")
+	pdfPath := filepath.Join(tmpDir, "test.pdf")
+	unsupportedPath := filepath.Join(tmpDir, "test.xyz")
+
+	// Create test files
+	for _, path := range []string{jpegPath, pngPath, gifPath, webpPath, pdfPath, unsupportedPath} {
+		err := os.WriteFile(path, []byte("test data"), 0o644)
+		require.NoError(t, err)
+	}
+
+	tests := []struct {
+		name              string
+		userContent       string
+		attachmentPath    string
+		wantMultiContent  bool
+		wantFileRef       bool
+		wantMimeType      string
+		wantDefaultPrompt bool
+	}{
+		{
+			name:             "no attachment",
+			userContent:      "Hello world",
+			attachmentPath:   "",
+			wantMultiContent: false,
+		},
+		{
+			name:             "jpeg attachment",
+			userContent:      "Check this image",
+			attachmentPath:   jpegPath,
+			wantMultiContent: true,
+			wantFileRef:      true,
+			wantMimeType:     "image/jpeg",
+		},
+		{
+			name:             "png attachment",
+			userContent:      "Analyze this",
+			attachmentPath:   pngPath,
+			wantMultiContent: true,
+			wantFileRef:      true,
+			wantMimeType:     "image/png",
+		},
+		{
+			name:             "gif attachment",
+			userContent:      "What's in this gif?",
+			attachmentPath:   gifPath,
+			wantMultiContent: true,
+			wantFileRef:      true,
+			wantMimeType:     "image/gif",
+		},
+		{
+			name:             "webp attachment",
+			userContent:      "Describe this",
+			attachmentPath:   webpPath,
+			wantMultiContent: true,
+			wantFileRef:      true,
+			wantMimeType:     "image/webp",
+		},
+		{
+			name:             "pdf attachment",
+			userContent:      "Summarize this PDF",
+			attachmentPath:   pdfPath,
+			wantMultiContent: true,
+			wantFileRef:      true,
+			wantMimeType:     "application/pdf",
+		},
+		{
+			name:              "attachment with empty content gets default prompt",
+			userContent:       "",
+			attachmentPath:    jpegPath,
+			wantMultiContent:  true,
+			wantFileRef:       true,
+			wantMimeType:      "image/jpeg",
+			wantDefaultPrompt: true,
+		},
+		{
+			name:              "attachment with whitespace content gets default prompt",
+			userContent:       "   ",
+			attachmentPath:    jpegPath,
+			wantMultiContent:  true,
+			wantFileRef:       true,
+			wantMimeType:      "image/jpeg",
+			wantDefaultPrompt: true,
+		},
+		{
+			name:             "non-existent file falls back to text only",
+			userContent:      "Hello",
+			attachmentPath:   "/non/existent/file.jpg",
+			wantMultiContent: false,
+		},
+		{
+			name:             "unsupported format falls back to text only",
+			userContent:      "Hello",
+			attachmentPath:   unsupportedPath,
+			wantMultiContent: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			msg := CreateUserMessageWithAttachment(tt.userContent, tt.attachmentPath)
+
+			require.NotNil(t, msg)
+			assert.Equal(t, chat.MessageRoleUser, msg.Message.Role)
+
+			if tt.wantMultiContent {
+				assert.NotEmpty(t, msg.Message.MultiContent)
+				assert.Len(t, msg.Message.MultiContent, 2) // text + image
+
+				// Check text part
+				textPart := msg.Message.MultiContent[0]
+				assert.Equal(t, chat.MessagePartTypeText, textPart.Type)
+				if tt.wantDefaultPrompt {
+					assert.Equal(t, "Please analyze this attached file.", textPart.Text)
+				} else {
+					assert.Equal(t, tt.userContent, textPart.Text)
+				}
+
+				// Check image part
+				imagePart := msg.Message.MultiContent[1]
+				assert.Equal(t, chat.MessagePartTypeImageURL, imagePart.Type)
+				assert.NotNil(t, imagePart.ImageURL)
+
+				if tt.wantFileRef {
+					assert.NotNil(t, imagePart.ImageURL.FileRef)
+					assert.Equal(t, chat.FileSourceTypeLocalPath, imagePart.ImageURL.FileRef.SourceType)
+					assert.NotEmpty(t, imagePart.ImageURL.FileRef.LocalPath)
+					assert.Equal(t, tt.wantMimeType, imagePart.ImageURL.FileRef.MimeType)
+				}
+			} else {
+				assert.Empty(t, msg.Message.MultiContent)
+				assert.Equal(t, tt.userContent, msg.Message.Content)
+			}
+		})
+	}
+}
+
+func TestParseAttachCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		input          string
+		wantText       string
+		wantAttachPath string
+	}{
+		{
+			name:           "no attach command",
+			input:          "Hello world",
+			wantText:       "Hello world",
+			wantAttachPath: "",
+		},
+		{
+			name:           "attach at start",
+			input:          "/attach image.png describe this",
+			wantText:       "describe this",
+			wantAttachPath: "image.png",
+		},
+		{
+			name:           "attach in middle",
+			input:          "please /attach photo.jpg analyze it",
+			wantText:       "please analyze it",
+			wantAttachPath: "photo.jpg",
+		},
+		{
+			name:           "attach only",
+			input:          "/attach test.gif",
+			wantText:       "",
+			wantAttachPath: "test.gif",
+		},
+		{
+			name:           "attach with path containing spaces handled",
+			input:          "/attach my_image.png what is this?",
+			wantText:       "what is this?",
+			wantAttachPath: "my_image.png",
+		},
+		{
+			name:           "multiline with attach",
+			input:          "First line\n/attach image.jpg second part\nThird line",
+			wantText:       "First line\nsecond part\nThird line",
+			wantAttachPath: "image.jpg",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			text, path := ParseAttachCommand(tt.input)
+			assert.Equal(t, tt.wantText, text)
+			assert.Equal(t, tt.wantAttachPath, path)
+		})
+	}
+}

--- a/pkg/model/provider/anthropic/beta_client.go
+++ b/pkg/model/provider/anthropic/beta_client.go
@@ -38,7 +38,7 @@ func (c *Client) createBetaStream(
 		return nil, err
 	}
 
-	converted := convertBetaMessages(messages)
+	converted := convertBetaMessagesWithClient(ctx, &client, messages)
 	if err := validateAnthropicSequencingBeta(converted); err != nil {
 		slog.Warn("Invalid message sequencing for Anthropic Beta API detected, attempting self-repair", "error", err)
 		converted = repairAnthropicSequencingBeta(converted)

--- a/pkg/model/provider/anthropic/client_test.go
+++ b/pkg/model/provider/anthropic/client_test.go
@@ -22,7 +22,7 @@ func TestConvertMessages_SkipEmptySystemText(t *testing.T) {
 		Content: "   \n\t  ",
 	}}
 
-	out := convertMessages(msgs)
+	out := convertMessages(t.Context(), msgs)
 	assert.Empty(t, out)
 }
 
@@ -32,7 +32,7 @@ func TestConvertMessages_SkipEmptyUserText_NoMultiContent(t *testing.T) {
 		Content: "   \n\t  ",
 	}}
 
-	out := convertMessages(msgs)
+	out := convertMessages(t.Context(), msgs)
 	assert.Empty(t, out)
 }
 
@@ -45,7 +45,7 @@ func TestConvertMessages_UserMultiContent_SkipEmptyText_KeepImage(t *testing.T) 
 		},
 	}}
 
-	out := convertMessages(msgs)
+	out := convertMessages(t.Context(), msgs)
 	require.Len(t, out, 1)
 
 	b, err := json.Marshal(out[0])
@@ -71,7 +71,7 @@ func TestConvertMessages_SkipEmptyAssistantText_NoToolCalls(t *testing.T) {
 		Content: "  \t\n  ",
 	}}
 
-	out := convertMessages(msgs)
+	out := convertMessages(t.Context(), msgs)
 	assert.Empty(t, out)
 }
 
@@ -84,7 +84,7 @@ func TestConvertMessages_AssistantToolCalls_NoText_IncludesToolUse(t *testing.T)
 		},
 	}}
 
-	out := convertMessages(msgs)
+	out := convertMessages(t.Context(), msgs)
 	require.Len(t, out, 1)
 
 	b, err := json.Marshal(out[0])
@@ -112,7 +112,7 @@ func TestSystemMessages_AreExtractedAndNotInMessageList(t *testing.T) {
 	assert.Equal(t, "system rules here", strings.TrimSpace(sys[0].Text))
 
 	// System role messages must not appear in the anthropic messages list
-	out := convertMessages(msgs)
+	out := convertMessages(t.Context(), msgs)
 	assert.Len(t, out, 1)
 }
 
@@ -128,7 +128,7 @@ func TestSystemMessages_MultipleExtractedAndExcludedFromMessageList(t *testing.T
 	assert.Equal(t, "sys A", strings.TrimSpace(sys[0].Text))
 	assert.Equal(t, "sys B", strings.TrimSpace(sys[1].Text))
 
-	out := convertMessages(msgs)
+	out := convertMessages(t.Context(), msgs)
 	assert.Len(t, out, 1)
 }
 
@@ -148,7 +148,7 @@ func TestSystemMessages_InterspersedExtractedAndExcluded(t *testing.T) {
 	assert.Equal(t, "S2", strings.TrimSpace(sys[1].Text))
 
 	// Converted messages must exclude system roles and preserve order of others
-	out := convertMessages(msgs)
+	out := convertMessages(t.Context(), msgs)
 	require.Len(t, out, 3)
 	expectedRoles := []string{"user", "assistant", "user"}
 	for i, expected := range expectedRoles {
@@ -173,7 +173,7 @@ func TestSequencingRepair_Standard(t *testing.T) {
 		{Role: chat.MessageRoleUser, Content: "continue"},
 	}
 
-	converted := convertMessages(msgs)
+	converted := convertMessages(t.Context(), msgs)
 	err := validateAnthropicSequencing(converted)
 	require.Error(t, err)
 
@@ -212,7 +212,7 @@ func TestConvertMessages_DropOrphanToolResults_NoPrecedingToolUse(t *testing.T) 
 		{Role: chat.MessageRoleUser, Content: "continue"},
 	}
 
-	converted := convertMessages(msgs)
+	converted := convertMessages(t.Context(), msgs)
 	// Expect only the two user text messages to appear
 	require.Len(t, converted, 2)
 
@@ -246,7 +246,7 @@ func TestConvertMessages_GroupToolResults_AfterAssistantToolUse(t *testing.T) {
 		{Role: chat.MessageRoleUser, Content: "ok"},
 	}
 
-	converted := convertMessages(msgs)
+	converted := convertMessages(t.Context(), msgs)
 	// Expect: user(start), assistant(tool_use), user(grouped tool_result), user(ok)
 	require.Len(t, converted, 4)
 

--- a/pkg/model/provider/anthropic/image_converter.go
+++ b/pkg/model/provider/anthropic/image_converter.go
@@ -1,0 +1,362 @@
+package anthropic
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/anthropics/anthropic-sdk-go"
+
+	"github.com/docker/cagent/pkg/chat"
+)
+
+// Anthropic files persist indefinitely server-side until explicitly deleted.
+// We use a 2h cache TTL to limit memory usage and handle external deletions.
+const cacheExpiration = 2 * time.Hour
+
+type cacheEntry struct {
+	fileID     string
+	uploadedAt time.Time
+}
+
+var fileUploadCache = struct {
+	sync.RWMutex
+	cache map[string]cacheEntry
+}{cache: make(map[string]cacheEntry)}
+
+// convertImagePart converts a MessageImageURL to an Anthropic image block.
+// It handles file references (uploading via Files API if possible),
+// base64 data URLs, and HTTP(S) URLs.
+func convertImagePart(ctx context.Context, client *anthropic.Client, imageURL *chat.MessageImageURL) *anthropic.ContentBlockParamUnion {
+	if imageURL == nil {
+		return nil
+	}
+
+	// Handle file reference (from /attach command)
+	if imageURL.FileRef != nil {
+		return convertFileRefToImageBlock(ctx, client, imageURL.FileRef)
+	}
+
+	// Handle data URL (base64)
+	if strings.HasPrefix(imageURL.URL, "data:") {
+		return convertDataURLToImageBlock(imageURL.URL)
+	}
+
+	// Handle HTTP(S) URL
+	if strings.HasPrefix(imageURL.URL, "http://") || strings.HasPrefix(imageURL.URL, "https://") {
+		return &anthropic.ContentBlockParamUnion{
+			OfImage: &anthropic.ImageBlockParam{
+				Source: anthropic.ImageBlockParamSourceUnion{
+					OfURL: &anthropic.URLImageSourceParam{
+						URL: imageURL.URL,
+					},
+				},
+			},
+		}
+	}
+
+	return nil
+}
+
+// convertFileRefToImageBlock handles file references, uploading via Files API if available
+func convertFileRefToImageBlock(ctx context.Context, client *anthropic.Client, fileRef *chat.FileReference) *anthropic.ContentBlockParamUnion {
+	if fileRef == nil {
+		return nil
+	}
+
+	switch fileRef.SourceType {
+	case chat.FileSourceTypeFileID:
+		// Standard API doesn't support file IDs, fall back to local path if available
+		if fileRef.LocalPath != "" {
+			slog.Debug("File ID not supported in standard API, falling back to local path", "file_id", fileRef.FileID, "path", fileRef.LocalPath)
+			return convertLocalFileToBase64Block(fileRef.LocalPath, fileRef.MimeType)
+		}
+		slog.Warn("File ID references not supported in standard Anthropic API and no local path available", "file_id", fileRef.FileID)
+		return nil
+
+	case chat.FileSourceTypeLocalPath:
+		return uploadOrConvertLocalFile(ctx, client, fileRef.LocalPath, fileRef.MimeType)
+
+	default:
+		slog.Warn("Unknown file source type", "type", fileRef.SourceType)
+		return nil
+	}
+}
+
+// uploadOrConvertLocalFile attempts to upload a local file via Files API.
+// If that fails or no client is provided, falls back to base64 encoding.
+func uploadOrConvertLocalFile(_ context.Context, _ *anthropic.Client, localPath, mimeType string) *anthropic.ContentBlockParamUnion {
+	// For standard API, we always use base64 since it doesn't support file IDs
+	// The Files API upload would be wasted since we can't reference it
+	return convertLocalFileToBase64Block(localPath, mimeType)
+}
+
+// convertLocalFileToBase64Block reads a local file and converts it to a base64 image block
+func convertLocalFileToBase64Block(localPath, mimeType string) *anthropic.ContentBlockParamUnion {
+	data, err := os.ReadFile(localPath)
+	if err != nil {
+		slog.Warn("Failed to read local file", "path", localPath, "error", err)
+		return nil
+	}
+
+	encoded := base64.StdEncoding.EncodeToString(data)
+
+	if mimeType == "" {
+		mimeType = "image/jpeg" // Default
+	}
+
+	slog.Debug("Converted local file to base64", "path", localPath, "size", len(data))
+
+	return &anthropic.ContentBlockParamUnion{
+		OfImage: &anthropic.ImageBlockParam{
+			Source: anthropic.ImageBlockParamSourceUnion{
+				OfBase64: &anthropic.Base64ImageSourceParam{
+					Data:      encoded,
+					MediaType: anthropic.Base64ImageSourceMediaType(mimeType),
+				},
+			},
+		},
+	}
+}
+
+// convertDataURLToImageBlock parses a data URL and converts it to an image block
+func convertDataURLToImageBlock(dataURL string) *anthropic.ContentBlockParamUnion {
+	parts := strings.SplitN(dataURL, ",", 2)
+	if len(parts) != 2 {
+		return nil
+	}
+
+	mediaTypePart := parts[0]
+	base64Data := parts[1]
+
+	var mediaType string
+	switch {
+	case strings.Contains(mediaTypePart, "image/jpeg"):
+		mediaType = "image/jpeg"
+	case strings.Contains(mediaTypePart, "image/png"):
+		mediaType = "image/png"
+	case strings.Contains(mediaTypePart, "image/gif"):
+		mediaType = "image/gif"
+	case strings.Contains(mediaTypePart, "image/webp"):
+		mediaType = "image/webp"
+	default:
+		mediaType = "image/jpeg"
+	}
+
+	return &anthropic.ContentBlockParamUnion{
+		OfImage: &anthropic.ImageBlockParam{
+			Source: anthropic.ImageBlockParamSourceUnion{
+				OfBase64: &anthropic.Base64ImageSourceParam{
+					Data:      base64Data,
+					MediaType: anthropic.Base64ImageSourceMediaType(mediaType),
+				},
+			},
+		},
+	}
+}
+
+// Beta API versions that support file references
+
+// convertBetaImagePart converts a MessageImageURL to a Beta API image block.
+// It handles file references (uploading via Files API), base64 data URLs, and HTTP(S) URLs.
+func convertBetaImagePart(ctx context.Context, client *anthropic.Client, imageURL *chat.MessageImageURL) *anthropic.BetaContentBlockParamUnion {
+	if imageURL == nil {
+		return nil
+	}
+
+	// Handle file reference (from /attach command)
+	if imageURL.FileRef != nil {
+		return convertBetaFileRefToImageBlock(ctx, client, imageURL.FileRef)
+	}
+
+	// Handle data URL (base64)
+	if strings.HasPrefix(imageURL.URL, "data:") {
+		return convertBetaDataURLToImageBlock(imageURL.URL)
+	}
+
+	// Handle HTTP(S) URL
+	if strings.HasPrefix(imageURL.URL, "http://") || strings.HasPrefix(imageURL.URL, "https://") {
+		return &anthropic.BetaContentBlockParamUnion{
+			OfImage: &anthropic.BetaImageBlockParam{
+				Source: anthropic.BetaImageBlockParamSourceUnion{
+					OfURL: &anthropic.BetaURLImageSourceParam{
+						URL: imageURL.URL,
+					},
+				},
+			},
+		}
+	}
+
+	return nil
+}
+
+// convertBetaFileRefToImageBlock handles file references for the Beta API
+func convertBetaFileRefToImageBlock(ctx context.Context, client *anthropic.Client, fileRef *chat.FileReference) *anthropic.BetaContentBlockParamUnion {
+	if fileRef == nil {
+		return nil
+	}
+
+	switch fileRef.SourceType {
+	case chat.FileSourceTypeFileID:
+		// Already uploaded, use file ID directly
+		slog.Debug("Using existing file ID for Beta API", "file_id", fileRef.FileID)
+		return &anthropic.BetaContentBlockParamUnion{
+			OfImage: &anthropic.BetaImageBlockParam{
+				Source: anthropic.BetaImageBlockParamSourceUnion{
+					OfFile: &anthropic.BetaFileImageSourceParam{
+						FileID: fileRef.FileID,
+					},
+				},
+			},
+		}
+
+	case chat.FileSourceTypeLocalPath:
+		// Try to upload via Files API, fall back to base64
+		return uploadOrConvertBetaLocalFile(ctx, client, fileRef.LocalPath, fileRef.MimeType)
+
+	default:
+		slog.Warn("Unknown file source type", "type", fileRef.SourceType)
+		return nil
+	}
+}
+
+// uploadOrConvertBetaLocalFile attempts to upload a local file via Files API for Beta API.
+// If that fails, falls back to base64 encoding.
+func uploadOrConvertBetaLocalFile(ctx context.Context, client *anthropic.Client, localPath, mimeType string) *anthropic.BetaContentBlockParamUnion {
+	// Check cache first
+	fileUploadCache.RLock()
+	if entry, ok := fileUploadCache.cache[localPath]; ok && time.Since(entry.uploadedAt) < cacheExpiration {
+		fileUploadCache.RUnlock()
+		slog.Debug("Using cached file ID", "path", localPath, "file_id", entry.fileID)
+		return &anthropic.BetaContentBlockParamUnion{
+			OfImage: &anthropic.BetaImageBlockParam{
+				Source: anthropic.BetaImageBlockParamSourceUnion{
+					OfFile: &anthropic.BetaFileImageSourceParam{
+						FileID: entry.fileID,
+					},
+				},
+			},
+		}
+	}
+	fileUploadCache.RUnlock()
+
+	// Try to upload via Files API
+	if client != nil {
+		fileID, err := uploadFileToAnthropic(ctx, client, localPath)
+		if err == nil {
+			fileUploadCache.Lock()
+			fileUploadCache.cache[localPath] = cacheEntry{fileID: fileID, uploadedAt: time.Now()}
+			fileUploadCache.Unlock()
+
+			if ctx.Err() != nil {
+				slog.Debug("Context canceled after file upload, file was cached for future use", "path", localPath, "file_id", fileID)
+				return nil
+			}
+
+			slog.Debug("Uploaded file to Anthropic Files API", "path", localPath, "file_id", fileID)
+			return &anthropic.BetaContentBlockParamUnion{
+				OfImage: &anthropic.BetaImageBlockParam{
+					Source: anthropic.BetaImageBlockParamSourceUnion{
+						OfFile: &anthropic.BetaFileImageSourceParam{
+							FileID: fileID,
+						},
+					},
+				},
+			}
+		}
+		slog.Warn("Failed to upload file to Anthropic, falling back to base64", "path", localPath, "error", err)
+	}
+
+	// Fall back to base64
+	return convertBetaLocalFileToBase64Block(localPath, mimeType)
+}
+
+// uploadFileToAnthropic uploads a file to Anthropic's Files API and returns the file ID
+func uploadFileToAnthropic(ctx context.Context, client *anthropic.Client, localPath string) (string, error) {
+	file, err := os.Open(localPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to open file: %w", err)
+	}
+	defer file.Close()
+
+	params := anthropic.BetaFileUploadParams{
+		File:  file,
+		Betas: []anthropic.AnthropicBeta{anthropic.AnthropicBetaFilesAPI2025_04_14},
+	}
+
+	result, err := client.Beta.Files.Upload(ctx, params)
+	if err != nil {
+		return "", fmt.Errorf("failed to upload file: %w", err)
+	}
+
+	return result.ID, nil
+}
+
+// convertBetaLocalFileToBase64Block reads a local file and converts it to a Beta API base64 image block
+func convertBetaLocalFileToBase64Block(localPath, mimeType string) *anthropic.BetaContentBlockParamUnion {
+	data, err := os.ReadFile(localPath)
+	if err != nil {
+		slog.Warn("Failed to read local file", "path", localPath, "error", err)
+		return nil
+	}
+
+	encoded := base64.StdEncoding.EncodeToString(data)
+
+	if mimeType == "" {
+		mimeType = "image/jpeg" // Default
+	}
+
+	slog.Debug("Converted local file to base64 (Beta API)", "path", localPath, "size", len(data))
+
+	return &anthropic.BetaContentBlockParamUnion{
+		OfImage: &anthropic.BetaImageBlockParam{
+			Source: anthropic.BetaImageBlockParamSourceUnion{
+				OfBase64: &anthropic.BetaBase64ImageSourceParam{
+					Data:      encoded,
+					MediaType: anthropic.BetaBase64ImageSourceMediaType(mimeType),
+				},
+			},
+		},
+	}
+}
+
+// convertBetaDataURLToImageBlock parses a data URL and converts it to a Beta API image block
+func convertBetaDataURLToImageBlock(dataURL string) *anthropic.BetaContentBlockParamUnion {
+	parts := strings.SplitN(dataURL, ",", 2)
+	if len(parts) != 2 {
+		return nil
+	}
+
+	mediaTypePart := parts[0]
+	base64Data := parts[1]
+
+	var mediaType string
+	switch {
+	case strings.Contains(mediaTypePart, "image/jpeg"):
+		mediaType = "image/jpeg"
+	case strings.Contains(mediaTypePart, "image/png"):
+		mediaType = "image/png"
+	case strings.Contains(mediaTypePart, "image/gif"):
+		mediaType = "image/gif"
+	case strings.Contains(mediaTypePart, "image/webp"):
+		mediaType = "image/webp"
+	default:
+		mediaType = "image/jpeg"
+	}
+
+	return &anthropic.BetaContentBlockParamUnion{
+		OfImage: &anthropic.BetaImageBlockParam{
+			Source: anthropic.BetaImageBlockParamSourceUnion{
+				OfBase64: &anthropic.BetaBase64ImageSourceParam{
+					Data:      base64Data,
+					MediaType: anthropic.BetaBase64ImageSourceMediaType(mediaType),
+				},
+			},
+		},
+	}
+}

--- a/pkg/model/provider/anthropic/image_converter_test.go
+++ b/pkg/model/provider/anthropic/image_converter_test.go
@@ -1,0 +1,273 @@
+package anthropic
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/cagent/pkg/chat"
+)
+
+func TestConvertImagePart(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		imageURL *chat.MessageImageURL
+		wantNil  bool
+	}{
+		{
+			name:     "nil imageURL",
+			imageURL: nil,
+			wantNil:  true,
+		},
+		{
+			name: "data URL jpeg",
+			imageURL: &chat.MessageImageURL{
+				URL: "data:image/jpeg;base64,/9j/4AAQSkZJRg==",
+			},
+			wantNil: false,
+		},
+		{
+			name: "data URL png",
+			imageURL: &chat.MessageImageURL{
+				URL: "data:image/png;base64,iVBORw0KGgo=",
+			},
+			wantNil: false,
+		},
+		{
+			name: "http URL",
+			imageURL: &chat.MessageImageURL{
+				URL: "http://example.com/image.png",
+			},
+			wantNil: false,
+		},
+		{
+			name: "https URL",
+			imageURL: &chat.MessageImageURL{
+				URL: "https://example.com/image.jpg",
+			},
+			wantNil: false,
+		},
+		{
+			name: "invalid data URL format",
+			imageURL: &chat.MessageImageURL{
+				URL: "data:image/jpeg", // missing comma and data
+			},
+			wantNil: true,
+		},
+		{
+			name: "empty URL",
+			imageURL: &chat.MessageImageURL{
+				URL: "",
+			},
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := convertImagePart(t.Context(), nil, tt.imageURL)
+			if tt.wantNil {
+				assert.Nil(t, result)
+			} else {
+				assert.NotNil(t, result)
+			}
+		})
+	}
+}
+
+func TestConvertImagePartWithFileRef(t *testing.T) {
+	t.Parallel()
+
+	// Create a temporary test image file
+	tmpDir := t.TempDir()
+	testImagePath := filepath.Join(tmpDir, "test.jpg")
+	testImageData := []byte{0xFF, 0xD8, 0xFF, 0xE0} // Minimal JPEG header
+	err := os.WriteFile(testImagePath, testImageData, 0o644)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		imageURL *chat.MessageImageURL
+		wantNil  bool
+	}{
+		{
+			name: "local file path",
+			imageURL: &chat.MessageImageURL{
+				FileRef: &chat.FileReference{
+					SourceType: chat.FileSourceTypeLocalPath,
+					LocalPath:  testImagePath,
+					MimeType:   "image/jpeg",
+				},
+			},
+			wantNil: false,
+		},
+		{
+			name: "non-existent local file",
+			imageURL: &chat.MessageImageURL{
+				FileRef: &chat.FileReference{
+					SourceType: chat.FileSourceTypeLocalPath,
+					LocalPath:  "/non/existent/path.jpg",
+					MimeType:   "image/jpeg",
+				},
+			},
+			wantNil: true,
+		},
+		{
+			name: "file ID (standard API doesn't support)",
+			imageURL: &chat.MessageImageURL{
+				FileRef: &chat.FileReference{
+					SourceType: chat.FileSourceTypeFileID,
+					FileID:     "file-abc123",
+					MimeType:   "image/jpeg",
+				},
+			},
+			wantNil: true, // Standard API doesn't support file IDs
+		},
+		{
+			name: "unknown source type",
+			imageURL: &chat.MessageImageURL{
+				FileRef: &chat.FileReference{
+					SourceType: "unknown",
+				},
+			},
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := convertImagePart(t.Context(), nil, tt.imageURL)
+			if tt.wantNil {
+				assert.Nil(t, result)
+			} else {
+				assert.NotNil(t, result)
+			}
+		})
+	}
+}
+
+func TestConvertBetaImagePartWithFileRef(t *testing.T) {
+	t.Parallel()
+
+	// Create a temporary test image file
+	tmpDir := t.TempDir()
+	testImagePath := filepath.Join(tmpDir, "test.png")
+	testImageData := []byte{0x89, 0x50, 0x4E, 0x47} // PNG header
+	err := os.WriteFile(testImagePath, testImageData, 0o644)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		imageURL *chat.MessageImageURL
+		wantNil  bool
+	}{
+		{
+			name: "local file path",
+			imageURL: &chat.MessageImageURL{
+				FileRef: &chat.FileReference{
+					SourceType: chat.FileSourceTypeLocalPath,
+					LocalPath:  testImagePath,
+					MimeType:   "image/png",
+				},
+			},
+			wantNil: false,
+		},
+		{
+			name: "file ID reference",
+			imageURL: &chat.MessageImageURL{
+				FileRef: &chat.FileReference{
+					SourceType: chat.FileSourceTypeFileID,
+					FileID:     "file-abc123",
+					MimeType:   "image/jpeg",
+				},
+			},
+			wantNil: false, // Beta API supports file IDs
+		},
+		{
+			name: "data URL",
+			imageURL: &chat.MessageImageURL{
+				URL: "data:image/png;base64,iVBORw0KGgo=",
+			},
+			wantNil: false,
+		},
+		{
+			name: "https URL",
+			imageURL: &chat.MessageImageURL{
+				URL: "https://example.com/image.png",
+			},
+			wantNil: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := convertBetaImagePart(t.Context(), nil, tt.imageURL)
+			if tt.wantNil {
+				assert.Nil(t, result)
+			} else {
+				assert.NotNil(t, result)
+			}
+		})
+	}
+}
+
+func TestConvertDataURLToImageBlock(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		dataURL string
+		wantNil bool
+	}{
+		{
+			name:    "valid jpeg",
+			dataURL: "data:image/jpeg;base64,/9j/4AAQSkZJRg==",
+			wantNil: false,
+		},
+		{
+			name:    "valid png",
+			dataURL: "data:image/png;base64,iVBORw0KGgo=",
+			wantNil: false,
+		},
+		{
+			name:    "valid gif",
+			dataURL: "data:image/gif;base64,R0lGODlh",
+			wantNil: false,
+		},
+		{
+			name:    "valid webp",
+			dataURL: "data:image/webp;base64,UklGR",
+			wantNil: false,
+		},
+		{
+			name:    "missing comma",
+			dataURL: "data:image/jpeg;base64",
+			wantNil: true,
+		},
+		{
+			name:    "empty data",
+			dataURL: "data:image/jpeg;base64,",
+			wantNil: false, // Empty base64 is technically valid
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := convertDataURLToImageBlock(tt.dataURL)
+			if tt.wantNil {
+				assert.Nil(t, result)
+			} else {
+				assert.NotNil(t, result)
+			}
+		})
+	}
+}

--- a/pkg/model/provider/bedrock/convert_test.go
+++ b/pkg/model/provider/bedrock/convert_test.go
@@ -1,0 +1,241 @@
+package bedrock
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/cagent/pkg/chat"
+)
+
+func TestConvertImageURL(t *testing.T) {
+	t.Parallel()
+
+	// Create a temporary test image file
+	tmpDir := t.TempDir()
+	testImagePath := filepath.Join(tmpDir, "test.jpg")
+	testImageData := []byte{0xFF, 0xD8, 0xFF, 0xE0} // Minimal JPEG header
+	err := os.WriteFile(testImagePath, testImageData, 0o644)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		imageURL *chat.MessageImageURL
+		wantNil  bool
+	}{
+		{
+			name:     "nil imageURL",
+			imageURL: nil,
+			wantNil:  true,
+		},
+		{
+			name: "data URL jpeg",
+			imageURL: &chat.MessageImageURL{
+				URL: "data:image/jpeg;base64,/9j/4AAQSkZJRg==",
+			},
+			wantNil: false,
+		},
+		{
+			name: "data URL png",
+			imageURL: &chat.MessageImageURL{
+				URL: "data:image/png;base64,iVBORw0KGgo=",
+			},
+			wantNil: false,
+		},
+		{
+			name: "data URL gif",
+			imageURL: &chat.MessageImageURL{
+				URL: "data:image/gif;base64,R0lGODlh",
+			},
+			wantNil: false,
+		},
+		{
+			name: "data URL webp",
+			imageURL: &chat.MessageImageURL{
+				URL: "data:image/webp;base64,UklGRlYAAABXRUJQ",
+			},
+			wantNil: false,
+		},
+		{
+			name: "http URL not supported",
+			imageURL: &chat.MessageImageURL{
+				URL: "http://example.com/image.png",
+			},
+			wantNil: true, // Bedrock doesn't support URL-based images
+		},
+		{
+			name: "https URL not supported",
+			imageURL: &chat.MessageImageURL{
+				URL: "https://example.com/image.jpg",
+			},
+			wantNil: true, // Bedrock doesn't support URL-based images
+		},
+		{
+			name: "local file path",
+			imageURL: &chat.MessageImageURL{
+				FileRef: &chat.FileReference{
+					SourceType: chat.FileSourceTypeLocalPath,
+					LocalPath:  testImagePath,
+					MimeType:   "image/jpeg",
+				},
+			},
+			wantNil: false,
+		},
+		{
+			name: "non-existent local file",
+			imageURL: &chat.MessageImageURL{
+				FileRef: &chat.FileReference{
+					SourceType: chat.FileSourceTypeLocalPath,
+					LocalPath:  "/non/existent/path.jpg",
+					MimeType:   "image/jpeg",
+				},
+			},
+			wantNil: true,
+		},
+		{
+			name: "file ID not supported",
+			imageURL: &chat.MessageImageURL{
+				FileRef: &chat.FileReference{
+					SourceType: chat.FileSourceTypeFileID,
+					FileID:     "file-abc123",
+					MimeType:   "image/jpeg",
+				},
+			},
+			wantNil: true,
+		},
+		{
+			name: "file URI not supported",
+			imageURL: &chat.MessageImageURL{
+				FileRef: &chat.FileReference{
+					SourceType: chat.FileSourceTypeFileURI,
+					FileURI:    "https://example.com/file",
+					MimeType:   "image/jpeg",
+				},
+			},
+			wantNil: true,
+		},
+		{
+			name: "invalid data URL format",
+			imageURL: &chat.MessageImageURL{
+				URL: "data:image/jpeg", // missing comma and data
+			},
+			wantNil: true,
+		},
+		{
+			name: "empty URL",
+			imageURL: &chat.MessageImageURL{
+				URL: "",
+			},
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := convertImageURL(tt.imageURL)
+			if tt.wantNil {
+				assert.Nil(t, result)
+			} else {
+				assert.NotNil(t, result)
+			}
+		})
+	}
+}
+
+func TestConvertUserContent(t *testing.T) {
+	t.Parallel()
+
+	// Create a temporary test image file
+	tmpDir := t.TempDir()
+	testImagePath := filepath.Join(tmpDir, "test.png")
+	testImageData := []byte{0x89, 0x50, 0x4E, 0x47} // PNG header
+	err := os.WriteFile(testImagePath, testImageData, 0o644)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		msg       *chat.Message
+		wantCount int
+	}{
+		{
+			name: "text only",
+			msg: &chat.Message{
+				Content: "Hello world",
+			},
+			wantCount: 1,
+		},
+		{
+			name: "empty content",
+			msg: &chat.Message{
+				Content: "   ",
+			},
+			wantCount: 0,
+		},
+		{
+			name: "multi-content text only",
+			msg: &chat.Message{
+				MultiContent: []chat.MessagePart{
+					{Type: chat.MessagePartTypeText, Text: "Hello"},
+					{Type: chat.MessagePartTypeText, Text: "World"},
+				},
+			},
+			wantCount: 2,
+		},
+		{
+			name: "multi-content with image",
+			msg: &chat.Message{
+				MultiContent: []chat.MessagePart{
+					{Type: chat.MessagePartTypeText, Text: "Check this"},
+					{
+						Type: chat.MessagePartTypeImageURL,
+						ImageURL: &chat.MessageImageURL{
+							URL: "data:image/jpeg;base64,/9j/4AAQSkZJRg==",
+						},
+					},
+				},
+			},
+			wantCount: 2,
+		},
+		{
+			name: "multi-content with local file",
+			msg: &chat.Message{
+				MultiContent: []chat.MessagePart{
+					{Type: chat.MessagePartTypeText, Text: "Check this"},
+					{
+						Type: chat.MessagePartTypeImageURL,
+						ImageURL: &chat.MessageImageURL{
+							FileRef: &chat.FileReference{
+								SourceType: chat.FileSourceTypeLocalPath,
+								LocalPath:  testImagePath,
+								MimeType:   "image/png",
+							},
+						},
+					},
+				},
+			},
+			wantCount: 2,
+		},
+		{
+			name: "skip nil imageURL",
+			msg: &chat.Message{
+				MultiContent: []chat.MessagePart{
+					{Type: chat.MessagePartTypeText, Text: "Hello"},
+					{Type: chat.MessagePartTypeImageURL, ImageURL: nil},
+				},
+			},
+			wantCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := convertUserContent(tt.msg)
+			assert.Len(t, result, tt.wantCount)
+		})
+	}
+}

--- a/pkg/model/provider/gemini/image_converter.go
+++ b/pkg/model/provider/gemini/image_converter.go
@@ -1,0 +1,176 @@
+package gemini
+
+import (
+	"context"
+	"encoding/base64"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"google.golang.org/genai"
+
+	"github.com/docker/cagent/pkg/chat"
+)
+
+const cacheExpiration = 2 * time.Hour // Gemini files expire after 48h server-side
+
+type cacheEntry struct {
+	fileURI    string
+	uploadedAt time.Time
+}
+
+// fileUploadCache caches file URIs to avoid re-uploading the same file.
+// Entries expire after 24 hours since Gemini auto-deletes files after 48 hours.
+var fileUploadCache = struct {
+	sync.RWMutex
+	cache map[string]cacheEntry
+}{cache: make(map[string]cacheEntry)}
+
+// convertImageURLToPart converts an image URL to a Gemini Part.
+// It handles file references (uploading via Files API if possible),
+// base64 data URLs, and local files.
+func convertImageURLToPartWithClient(ctx context.Context, client *genai.Client, imageURL *chat.MessageImageURL) *genai.Part {
+	if imageURL == nil {
+		return nil
+	}
+
+	// Handle file reference (from /attach command)
+	if imageURL.FileRef != nil {
+		return convertFileRefToPart(ctx, client, imageURL.FileRef)
+	}
+
+	// Handle data URL (base64)
+	if strings.HasPrefix(imageURL.URL, "data:") {
+		return convertDataURLToPart(imageURL.URL)
+	}
+
+	// Handle HTTP(S) URL - Gemini can fetch from URLs
+	if strings.HasPrefix(imageURL.URL, "http://") || strings.HasPrefix(imageURL.URL, "https://") {
+		return genai.NewPartFromURI(imageURL.URL, extractMimeTypeFromURL(imageURL.URL))
+	}
+
+	return nil
+}
+
+// convertFileRefToPart handles file references, uploading via Files API if available
+func convertFileRefToPart(ctx context.Context, client *genai.Client, fileRef *chat.FileReference) *genai.Part {
+	if fileRef == nil {
+		return nil
+	}
+
+	switch fileRef.SourceType {
+	case chat.FileSourceTypeFileURI:
+		// Already uploaded to Gemini, use URI directly
+		slog.Debug("Using existing file URI", "uri", fileRef.FileURI)
+		return genai.NewPartFromURI(fileRef.FileURI, fileRef.MimeType)
+
+	case chat.FileSourceTypeFileID:
+		// File ID from another provider - need to upload to Gemini
+		slog.Warn("File ID from another provider not supported for Gemini, skipping", "file_id", fileRef.FileID)
+		return nil
+
+	case chat.FileSourceTypeLocalPath:
+		// Try to upload via Files API, fall back to base64
+		return uploadOrConvertLocalFile(ctx, client, fileRef.LocalPath, fileRef.MimeType)
+
+	default:
+		slog.Warn("Unknown file source type", "type", fileRef.SourceType)
+		return nil
+	}
+}
+
+// uploadOrConvertLocalFile attempts to upload a local file via Gemini Files API.
+// If that fails, falls back to reading the file and sending as bytes.
+func uploadOrConvertLocalFile(ctx context.Context, client *genai.Client, localPath, mimeType string) *genai.Part {
+	// Check cache first
+	fileUploadCache.RLock()
+	if entry, ok := fileUploadCache.cache[localPath]; ok && time.Since(entry.uploadedAt) < cacheExpiration {
+		fileUploadCache.RUnlock()
+		slog.Debug("Using cached file URI", "path", localPath, "uri", entry.fileURI)
+		return genai.NewPartFromURI(entry.fileURI, mimeType)
+	}
+	fileUploadCache.RUnlock()
+
+	// Try to upload via Files API
+	if client != nil {
+		fileURI, err := uploadFileToGemini(ctx, client, localPath, mimeType)
+		if err == nil {
+			fileUploadCache.Lock()
+			fileUploadCache.cache[localPath] = cacheEntry{fileURI: fileURI, uploadedAt: time.Now()}
+			fileUploadCache.Unlock()
+
+			slog.Debug("Uploaded file to Gemini Files API", "path", localPath, "uri", fileURI)
+			return genai.NewPartFromURI(fileURI, mimeType)
+		}
+		slog.Warn("Failed to upload file to Gemini, falling back to bytes", "path", localPath, "error", err)
+	}
+
+	// Fall back to reading file and sending as bytes
+	return convertLocalFileToBytesPart(localPath, mimeType)
+}
+
+// uploadFileToGemini uploads a file to Gemini's Files API and returns the file URI
+func uploadFileToGemini(ctx context.Context, client *genai.Client, localPath, mimeType string) (string, error) {
+	config := &genai.UploadFileConfig{
+		MIMEType: mimeType,
+	}
+
+	file, err := client.Files.UploadFromPath(ctx, localPath, config)
+	if err != nil {
+		return "", err
+	}
+
+	return file.URI, nil
+}
+
+// convertLocalFileToBytesPart reads a local file and converts it to a bytes Part
+func convertLocalFileToBytesPart(localPath, mimeType string) *genai.Part {
+	data, err := os.ReadFile(localPath)
+	if err != nil {
+		slog.Warn("Failed to read local file", "path", localPath, "error", err)
+		return nil
+	}
+
+	if mimeType == "" {
+		mimeType = "image/jpeg" // Default
+	}
+
+	slog.Debug("Converted local file to bytes", "path", localPath, "size", len(data))
+	return genai.NewPartFromBytes(data, mimeType)
+}
+
+// convertDataURLToPart parses a data URL and converts it to a Gemini Part
+func convertDataURLToPart(dataURL string) *genai.Part {
+	// Parse data URL format: data:[<mediatype>][;base64],<data>
+	urlParts := strings.SplitN(dataURL, ",", 2)
+	if len(urlParts) != 2 {
+		return nil
+	}
+
+	imageData, err := base64.StdEncoding.DecodeString(urlParts[1])
+	if err != nil {
+		return nil
+	}
+
+	mimeType := extractMimeType(urlParts[0])
+	return genai.NewPartFromBytes(imageData, mimeType)
+}
+
+// extractMimeTypeFromURL tries to determine MIME type from a URL
+func extractMimeTypeFromURL(url string) string {
+	lowerURL := strings.ToLower(url)
+	switch {
+	case strings.HasSuffix(lowerURL, ".jpg"), strings.HasSuffix(lowerURL, ".jpeg"):
+		return "image/jpeg"
+	case strings.HasSuffix(lowerURL, ".png"):
+		return "image/png"
+	case strings.HasSuffix(lowerURL, ".gif"):
+		return "image/gif"
+	case strings.HasSuffix(lowerURL, ".webp"):
+		return "image/webp"
+	default:
+		return "image/jpeg" // Default
+	}
+}

--- a/pkg/model/provider/gemini/image_converter_test.go
+++ b/pkg/model/provider/gemini/image_converter_test.go
@@ -1,0 +1,189 @@
+package gemini
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/cagent/pkg/chat"
+)
+
+func TestConvertImageURLToPartWithClient(t *testing.T) {
+	t.Parallel()
+
+	// Create a temporary test image file
+	tmpDir := t.TempDir()
+	testImagePath := filepath.Join(tmpDir, "test.jpg")
+	testImageData := []byte{0xFF, 0xD8, 0xFF, 0xE0} // Minimal JPEG header
+	err := os.WriteFile(testImagePath, testImageData, 0o644)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		imageURL *chat.MessageImageURL
+		wantNil  bool
+	}{
+		{
+			name:     "nil imageURL",
+			imageURL: nil,
+			wantNil:  true,
+		},
+		{
+			name: "data URL",
+			imageURL: &chat.MessageImageURL{
+				URL: "data:image/jpeg;base64,/9j/4AAQSkZJRg==",
+			},
+			wantNil: false,
+		},
+		{
+			name: "http URL",
+			imageURL: &chat.MessageImageURL{
+				URL: "http://example.com/image.png",
+			},
+			wantNil: false,
+		},
+		{
+			name: "https URL",
+			imageURL: &chat.MessageImageURL{
+				URL: "https://example.com/image.jpg",
+			},
+			wantNil: false,
+		},
+		{
+			name: "local file path",
+			imageURL: &chat.MessageImageURL{
+				FileRef: &chat.FileReference{
+					SourceType: chat.FileSourceTypeLocalPath,
+					LocalPath:  testImagePath,
+					MimeType:   "image/jpeg",
+				},
+			},
+			wantNil: false,
+		},
+		{
+			name: "non-existent local file",
+			imageURL: &chat.MessageImageURL{
+				FileRef: &chat.FileReference{
+					SourceType: chat.FileSourceTypeLocalPath,
+					LocalPath:  "/non/existent/path.jpg",
+					MimeType:   "image/jpeg",
+				},
+			},
+			wantNil: true,
+		},
+		{
+			name: "file URI reference",
+			imageURL: &chat.MessageImageURL{
+				FileRef: &chat.FileReference{
+					SourceType: chat.FileSourceTypeFileURI,
+					FileURI:    "https://generativelanguage.googleapis.com/v1/files/abc123",
+					MimeType:   "image/jpeg",
+				},
+			},
+			wantNil: false,
+		},
+		{
+			name: "file ID from other provider",
+			imageURL: &chat.MessageImageURL{
+				FileRef: &chat.FileReference{
+					SourceType: chat.FileSourceTypeFileID,
+					FileID:     "file-abc123",
+					MimeType:   "image/jpeg",
+				},
+			},
+			wantNil: true, // Gemini doesn't support file IDs from other providers
+		},
+		{
+			name: "invalid data URL",
+			imageURL: &chat.MessageImageURL{
+				URL: "data:image/jpeg", // missing comma and data
+			},
+			wantNil: true,
+		},
+		{
+			name: "empty URL",
+			imageURL: &chat.MessageImageURL{
+				URL: "",
+			},
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := convertImageURLToPartWithClient(t.Context(), nil, tt.imageURL)
+			if tt.wantNil {
+				assert.Nil(t, result)
+			} else {
+				assert.NotNil(t, result)
+			}
+		})
+	}
+}
+
+func TestConvertDataURLToPart(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		dataURL string
+		wantNil bool
+	}{
+		{
+			name:    "valid jpeg",
+			dataURL: "data:image/jpeg;base64,/9j/4AAQSkZJRg==",
+			wantNil: false,
+		},
+		{
+			name:    "valid png",
+			dataURL: "data:image/png;base64,iVBORw0KGgo=",
+			wantNil: false,
+		},
+		{
+			name:    "missing comma",
+			dataURL: "data:image/jpeg;base64",
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := convertDataURLToPart(tt.dataURL)
+			if tt.wantNil {
+				assert.Nil(t, result)
+			} else {
+				assert.NotNil(t, result)
+			}
+		})
+	}
+}
+
+func TestExtractMimeTypeFromURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		url      string
+		expected string
+	}{
+		{"https://example.com/image.jpg", "image/jpeg"},
+		{"https://example.com/image.jpeg", "image/jpeg"},
+		{"https://example.com/image.png", "image/png"},
+		{"https://example.com/image.gif", "image/gif"},
+		{"https://example.com/image.webp", "image/webp"},
+		{"https://example.com/image.unknown", "image/jpeg"}, // default
+		{"https://example.com/IMAGE.PNG", "image/png"},      // case insensitive
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			t.Parallel()
+			result := extractMimeTypeFromURL(tt.url)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/model/provider/oaistream/image_converter.go
+++ b/pkg/model/provider/oaistream/image_converter.go
@@ -1,0 +1,115 @@
+package oaistream
+
+import (
+	"encoding/base64"
+	"log/slog"
+	"os"
+
+	"github.com/openai/openai-go/v3"
+
+	"github.com/docker/cagent/pkg/chat"
+)
+
+// convertImageURLToOpenAI converts a MessageImageURL to an OpenAI image content part.
+// It handles file references (converting to base64), base64 data URLs, and HTTP(S) URLs.
+func convertImageURLToOpenAI(imageURL *chat.MessageImageURL) *openai.ChatCompletionContentPartUnionParam {
+	if imageURL == nil {
+		return nil
+	}
+
+	var url string
+	detail := string(imageURL.Detail)
+
+	// Handle file reference (from /attach command)
+	if imageURL.FileRef != nil {
+		url = convertFileRefToDataURL(imageURL.FileRef)
+		if url == "" {
+			return nil
+		}
+	} else {
+		url = imageURL.URL
+	}
+
+	// Empty URL means we couldn't convert
+	if url == "" {
+		return nil
+	}
+
+	result := openai.ImageContentPart(openai.ChatCompletionContentPartImageImageURLParam{
+		URL:    url,
+		Detail: detail,
+	})
+	return &result
+}
+
+// convertFileRefToDataURL handles file references, converting to base64 data URL
+func convertFileRefToDataURL(fileRef *chat.FileReference) string {
+	if fileRef == nil {
+		return ""
+	}
+
+	switch fileRef.SourceType {
+	case chat.FileSourceTypeFileID, chat.FileSourceTypeFileURI:
+		// File IDs from other providers need to be re-read from disk
+		// This shouldn't happen in normal flow since we store local paths
+		slog.Warn("File ID/URI from another provider not supported for OpenAI, skipping",
+			"file_id", fileRef.FileID,
+			"source_type", fileRef.SourceType)
+		return ""
+
+	case chat.FileSourceTypeLocalPath:
+		return convertLocalFileToDataURL(fileRef.LocalPath, fileRef.MimeType)
+
+	default:
+		slog.Warn("Unknown file source type", "type", fileRef.SourceType)
+		return ""
+	}
+}
+
+// convertLocalFileToDataURL reads a local file and converts it to a base64 data URL
+func convertLocalFileToDataURL(localPath, mimeType string) string {
+	data, err := os.ReadFile(localPath)
+	if err != nil {
+		slog.Warn("Failed to read local file", "path", localPath, "error", err)
+		return ""
+	}
+
+	if mimeType == "" {
+		mimeType = "image/jpeg" // Default
+	}
+
+	encoded := base64.StdEncoding.EncodeToString(data)
+	slog.Debug("Converted local file to base64 data URL", "path", localPath, "size", len(data))
+
+	return "data:" + mimeType + ";base64," + encoded
+}
+
+// HasFileRef checks if any message part has a file reference that needs processing
+func HasFileRef(multiContent []chat.MessagePart) bool {
+	for _, part := range multiContent {
+		if part.Type == chat.MessagePartTypeImageURL && part.ImageURL != nil && part.ImageURL.FileRef != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// ConvertMultiContentWithFileSupport converts chat.MessagePart slices to OpenAI content parts,
+// handling file references properly.
+func ConvertMultiContentWithFileSupport(multiContent []chat.MessagePart) []openai.ChatCompletionContentPartUnionParam {
+	parts := make([]openai.ChatCompletionContentPartUnionParam, 0, len(multiContent))
+	for _, part := range multiContent {
+		switch part.Type {
+		case chat.MessagePartTypeText:
+			parts = append(parts, openai.TextContentPart(part.Text))
+		case chat.MessagePartTypeImageURL:
+			if part.ImageURL != nil {
+				// Use the file-aware converter
+				if imgPart := convertImageURLToOpenAI(part.ImageURL); imgPart != nil {
+					parts = append(parts, *imgPart)
+				}
+			}
+		}
+	}
+	return parts
+}

--- a/pkg/model/provider/oaistream/image_converter_test.go
+++ b/pkg/model/provider/oaistream/image_converter_test.go
@@ -1,0 +1,283 @@
+package oaistream
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/cagent/pkg/chat"
+)
+
+func TestConvertImageURLToOpenAI(t *testing.T) {
+	t.Parallel()
+
+	// Create a temporary test image file
+	tmpDir := t.TempDir()
+	testImagePath := filepath.Join(tmpDir, "test.jpg")
+	testImageData := []byte{0xFF, 0xD8, 0xFF, 0xE0} // Minimal JPEG header
+	err := os.WriteFile(testImagePath, testImageData, 0o644)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		imageURL *chat.MessageImageURL
+		wantNil  bool
+	}{
+		{
+			name:     "nil imageURL",
+			imageURL: nil,
+			wantNil:  true,
+		},
+		{
+			name: "data URL",
+			imageURL: &chat.MessageImageURL{
+				URL:    "data:image/jpeg;base64,/9j/4AAQSkZJRg==",
+				Detail: chat.ImageURLDetailAuto,
+			},
+			wantNil: false,
+		},
+		{
+			name: "http URL",
+			imageURL: &chat.MessageImageURL{
+				URL:    "http://example.com/image.png",
+				Detail: chat.ImageURLDetailHigh,
+			},
+			wantNil: false,
+		},
+		{
+			name: "https URL",
+			imageURL: &chat.MessageImageURL{
+				URL:    "https://example.com/image.jpg",
+				Detail: chat.ImageURLDetailLow,
+			},
+			wantNil: false,
+		},
+		{
+			name: "local file path",
+			imageURL: &chat.MessageImageURL{
+				Detail: chat.ImageURLDetailAuto,
+				FileRef: &chat.FileReference{
+					SourceType: chat.FileSourceTypeLocalPath,
+					LocalPath:  testImagePath,
+					MimeType:   "image/jpeg",
+				},
+			},
+			wantNil: false,
+		},
+		{
+			name: "non-existent local file",
+			imageURL: &chat.MessageImageURL{
+				FileRef: &chat.FileReference{
+					SourceType: chat.FileSourceTypeLocalPath,
+					LocalPath:  "/non/existent/path.jpg",
+					MimeType:   "image/jpeg",
+				},
+			},
+			wantNil: true,
+		},
+		{
+			name: "file ID from other provider",
+			imageURL: &chat.MessageImageURL{
+				FileRef: &chat.FileReference{
+					SourceType: chat.FileSourceTypeFileID,
+					FileID:     "file-abc123",
+					MimeType:   "image/jpeg",
+				},
+			},
+			wantNil: true, // OpenAI doesn't support file IDs for chat completions
+		},
+		{
+			name: "empty URL no file ref",
+			imageURL: &chat.MessageImageURL{
+				URL: "",
+			},
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := convertImageURLToOpenAI(tt.imageURL)
+			if tt.wantNil {
+				assert.Nil(t, result)
+			} else {
+				assert.NotNil(t, result)
+			}
+		})
+	}
+}
+
+func TestConvertFileRefToDataURL(t *testing.T) {
+	t.Parallel()
+
+	// Create a temporary test image file
+	tmpDir := t.TempDir()
+	testImagePath := filepath.Join(tmpDir, "test.png")
+	testImageData := []byte{0x89, 0x50, 0x4E, 0x47} // PNG header
+	err := os.WriteFile(testImagePath, testImageData, 0o644)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		fileRef  *chat.FileReference
+		wantData bool
+	}{
+		{
+			name:     "nil fileRef",
+			fileRef:  nil,
+			wantData: false,
+		},
+		{
+			name: "local file path",
+			fileRef: &chat.FileReference{
+				SourceType: chat.FileSourceTypeLocalPath,
+				LocalPath:  testImagePath,
+				MimeType:   "image/png",
+			},
+			wantData: true,
+		},
+		{
+			name: "non-existent file",
+			fileRef: &chat.FileReference{
+				SourceType: chat.FileSourceTypeLocalPath,
+				LocalPath:  "/non/existent/file.png",
+				MimeType:   "image/png",
+			},
+			wantData: false,
+		},
+		{
+			name: "file ID not supported",
+			fileRef: &chat.FileReference{
+				SourceType: chat.FileSourceTypeFileID,
+				FileID:     "file-123",
+			},
+			wantData: false,
+		},
+		{
+			name: "file URI not supported",
+			fileRef: &chat.FileReference{
+				SourceType: chat.FileSourceTypeFileURI,
+				FileURI:    "https://example.com/file",
+			},
+			wantData: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := convertFileRefToDataURL(tt.fileRef)
+			if tt.wantData {
+				assert.NotEmpty(t, result)
+				assert.True(t, strings.HasPrefix(result, "data:"))
+			} else {
+				assert.Empty(t, result)
+			}
+		})
+	}
+}
+
+func TestConvertLocalFileToDataURL(t *testing.T) {
+	t.Parallel()
+
+	// Create a temporary test image file
+	tmpDir := t.TempDir()
+	testImagePath := filepath.Join(tmpDir, "test.gif")
+	testImageData := []byte{0x47, 0x49, 0x46, 0x38} // GIF header
+	err := os.WriteFile(testImagePath, testImageData, 0o644)
+	require.NoError(t, err)
+
+	t.Run("valid file", func(t *testing.T) {
+		t.Parallel()
+		result := convertLocalFileToDataURL(testImagePath, "image/gif")
+		assert.True(t, strings.HasPrefix(result, "data:image/gif;base64,"))
+	})
+
+	t.Run("default mime type", func(t *testing.T) {
+		t.Parallel()
+		result := convertLocalFileToDataURL(testImagePath, "")
+		assert.True(t, strings.HasPrefix(result, "data:image/jpeg;base64,")) // default
+	})
+
+	t.Run("non-existent file", func(t *testing.T) {
+		t.Parallel()
+		result := convertLocalFileToDataURL("/non/existent/file.jpg", "image/jpeg")
+		assert.Empty(t, result)
+	})
+}
+
+func TestConvertMultiContentWithFileSupport(t *testing.T) {
+	t.Parallel()
+
+	// Create a temporary test image file
+	tmpDir := t.TempDir()
+	testImagePath := filepath.Join(tmpDir, "test.jpg")
+	testImageData := []byte{0xFF, 0xD8, 0xFF, 0xE0}
+	err := os.WriteFile(testImagePath, testImageData, 0o644)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name         string
+		multiContent []chat.MessagePart
+		wantCount    int
+	}{
+		{
+			name:         "empty",
+			multiContent: []chat.MessagePart{},
+			wantCount:    0,
+		},
+		{
+			name: "text only",
+			multiContent: []chat.MessagePart{
+				{Type: chat.MessagePartTypeText, Text: "Hello"},
+			},
+			wantCount: 1,
+		},
+		{
+			name: "text and URL image",
+			multiContent: []chat.MessagePart{
+				{Type: chat.MessagePartTypeText, Text: "Check this"},
+				{Type: chat.MessagePartTypeImageURL, ImageURL: &chat.MessageImageURL{URL: "https://example.com/img.png"}},
+			},
+			wantCount: 2,
+		},
+		{
+			name: "text and local file image",
+			multiContent: []chat.MessagePart{
+				{Type: chat.MessagePartTypeText, Text: "Check this"},
+				{
+					Type: chat.MessagePartTypeImageURL,
+					ImageURL: &chat.MessageImageURL{
+						FileRef: &chat.FileReference{
+							SourceType: chat.FileSourceTypeLocalPath,
+							LocalPath:  testImagePath,
+							MimeType:   "image/jpeg",
+						},
+					},
+				},
+			},
+			wantCount: 2,
+		},
+		{
+			name: "skip nil imageURL",
+			multiContent: []chat.MessagePart{
+				{Type: chat.MessagePartTypeText, Text: "Hello"},
+				{Type: chat.MessagePartTypeImageURL, ImageURL: nil},
+			},
+			wantCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := ConvertMultiContentWithFileSupport(tt.multiContent)
+			assert.Len(t, result, tt.wantCount)
+		})
+	}
+}

--- a/pkg/model/provider/oaistream/messages.go
+++ b/pkg/model/provider/oaistream/messages.go
@@ -24,22 +24,9 @@ func (j JSONSchema) MarshalJSON() ([]byte, error) {
 }
 
 // ConvertMultiContent converts chat.MessagePart slices to OpenAI content parts.
+// This now handles file references properly by using the file-aware converter.
 func ConvertMultiContent(multiContent []chat.MessagePart) []openai.ChatCompletionContentPartUnionParam {
-	parts := make([]openai.ChatCompletionContentPartUnionParam, len(multiContent))
-	for i, part := range multiContent {
-		switch part.Type {
-		case chat.MessagePartTypeText:
-			parts[i] = openai.TextContentPart(part.Text)
-		case chat.MessagePartTypeImageURL:
-			if part.ImageURL != nil {
-				parts[i] = openai.ImageContentPart(openai.ChatCompletionContentPartImageImageURLParam{
-					URL:    part.ImageURL.URL,
-					Detail: string(part.ImageURL.Detail),
-				})
-			}
-		}
-	}
-	return parts
+	return ConvertMultiContentWithFileSupport(multiContent)
 }
 
 // ConvertMessages converts chat.Message slices to OpenAI message params.

--- a/pkg/model/provider/oaistream/messages_test.go
+++ b/pkg/model/provider/oaistream/messages_test.go
@@ -41,11 +41,11 @@ func TestConvertMultiContent(t *testing.T) {
 			wantCount: 2,
 		},
 		{
-			name: "image without URL",
+			name: "image without URL skipped",
 			multiContent: []chat.MessagePart{
 				{Type: chat.MessagePartTypeImageURL, ImageURL: nil},
 			},
-			wantCount: 1,
+			wantCount: 0, // nil ImageURL is now properly skipped
 		},
 	}
 


### PR DESCRIPTION
Add Files API support for image attachments

Images attached via  /attach  now use provider-specific Files APIs instead of
embedding base64 data in every message.

Changes:

• Store local file paths in messages instead of immediate base64 conversion
• Anthropic: Upload via Files API (beta), reference by  file_id , with caching to
avoid re-uploads
• Gemini: Upload via Files API, reference by URI, with caching
• OpenAI/Bedrock: Convert to base64 at send time (no Files API for chat vision)

Benefits:

• Significantly reduces token usage for Anthropic (file IDs vs ~3000+ tokens per
image)
• Fixes "prompt too long" errors when attaching large images
• Each provider handles images optimally for its API