### PR TITLE
Fix models defaults when using the "router" provider

### DIFF
--- a/pkg/model/provider/base/base.go
+++ b/pkg/model/provider/base/base.go
@@ -12,6 +12,9 @@ type Config struct {
 	ModelConfig  latest.ModelConfig
 	ModelOptions options.ModelOptions
 	Env          environment.Provider
+	// Models stores the full models map for providers that need it (e.g., routers).
+	// This enables proper cloning of providers that reference other models.
+	Models map[string]latest.ModelConfig
 }
 
 // ID returns the provider and model ID in the format "provider/model"

--- a/pkg/model/provider/clone.go
+++ b/pkg/model/provider/clone.go
@@ -27,7 +27,9 @@ func CloneWithOptions(ctx context.Context, base Provider, opts ...options.Opt) P
 		modelConfig.MaxTokens = &mt
 	}
 
-	clone, err := New(ctx, &modelConfig, config.Env, mergedOpts...)
+	// Use NewWithModels to support cloning routers that reference other models.
+	// config.Models is populated by routers; for other providers it's nil (which is fine).
+	clone, err := NewWithModels(ctx, &modelConfig, config.Models, config.Env, mergedOpts...)
 	if err != nil {
 		slog.Debug("Failed to clone provider; using base provider", "error", err, "id", base.ID())
 		return base

--- a/pkg/model/provider/clone_test.go
+++ b/pkg/model/provider/clone_test.go
@@ -1,0 +1,139 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/cagent/pkg/config/latest"
+	"github.com/docker/cagent/pkg/environment"
+	"github.com/docker/cagent/pkg/model/provider/options"
+)
+
+type cloneTestEnvProvider struct {
+	values map[string]string
+}
+
+func (m *cloneTestEnvProvider) Get(_ context.Context, name string) (string, bool) {
+	v, ok := m.values[name]
+	return v, ok
+}
+
+func newCloneTestEnv(values map[string]string) environment.Provider {
+	return &cloneTestEnvProvider{values: values}
+}
+
+func TestCloneWithOptions_RouterWithModelReferences(t *testing.T) {
+	t.Parallel()
+
+	// This test verifies that cloning a router with model references works correctly.
+	// Previously, CloneWithOptions would fail silently because it called New() instead
+	// of NewWithModels(), which meant the models map was nil and model references
+	// like "fast" couldn't be resolved. The clone would fail and return the original
+	// provider, causing options like WithThinking(false) to have no effect.
+
+	// Create a mock server that returns a minimal valid response
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer server.Close()
+
+	models := map[string]latest.ModelConfig{
+		"fast": {
+			Provider: "openai",
+			Model:    "gpt-4o-mini",
+			BaseURL:  server.URL,
+		},
+		"capable": {
+			Provider: "openai",
+			Model:    "gpt-4o",
+			BaseURL:  server.URL,
+		},
+	}
+
+	routerCfg := &latest.ModelConfig{
+		Provider: "openai",
+		Model:    "gpt-4o-mini", // fallback
+		BaseURL:  server.URL,
+		Routing: []latest.RoutingRule{
+			{
+				Model:    "fast",
+				Examples: []string{"hello", "hi"},
+			},
+			{
+				Model:    "capable",
+				Examples: []string{"explain", "analyze"},
+			},
+		},
+	}
+
+	env := newCloneTestEnv(map[string]string{
+		"OPENAI_API_KEY": "test-key",
+	})
+
+	// Create the router with the models map
+	router, err := NewWithModels(t.Context(), routerCfg, models, env)
+	require.NoError(t, err)
+
+	// Verify the original router has the models map stored
+	baseConfig := router.BaseConfig()
+	require.NotNil(t, baseConfig.Models, "Router should store models map in base config")
+
+	// Clone with thinking disabled - this should succeed and not fall back to original
+	cloned := CloneWithOptions(t.Context(), router, options.WithThinking(false))
+
+	// The clone should have the thinking option applied
+	// We verify this by checking that the clone's base config has nil ThinkingBudget
+	// (since WithThinking(false) clears thinking configuration)
+	clonedConfig := cloned.BaseConfig()
+
+	// The key assertion: ThinkingBudget should be nil because WithThinking(false) was applied
+	// If the clone failed silently, this would still have the default "medium" from applyOpenAIDefaults
+	assert.Nil(t, clonedConfig.ModelConfig.ThinkingBudget,
+		"ThinkingBudget should be nil after cloning with WithThinking(false); "+
+			"if it's not nil, the clone may have failed silently and returned the original provider")
+
+	// Also verify the models map is preserved in the clone
+	assert.NotNil(t, clonedConfig.Models, "Cloned router should preserve models map")
+	assert.Equal(t, models, clonedConfig.Models, "Models map should be identical after cloning")
+}
+
+func TestCloneWithOptions_DirectProvider(t *testing.T) {
+	t.Parallel()
+
+	// Create a mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer server.Close()
+
+	// Test that cloning a non-router provider still works correctly
+	cfg := &latest.ModelConfig{
+		Provider:       "openai",
+		Model:          "gpt-4o",
+		BaseURL:        server.URL,
+		ThinkingBudget: &latest.ThinkingBudget{Effort: "medium"},
+	}
+
+	env := newCloneTestEnv(map[string]string{
+		"OPENAI_API_KEY": "test-key",
+	})
+
+	provider, err := New(t.Context(), cfg, env)
+	require.NoError(t, err)
+
+	// Clone with thinking disabled
+	cloned := CloneWithOptions(t.Context(), provider, options.WithThinking(false))
+
+	clonedConfig := cloned.BaseConfig()
+	assert.Nil(t, clonedConfig.ModelConfig.ThinkingBudget,
+		"ThinkingBudget should be nil after cloning with WithThinking(false)")
+}

--- a/pkg/model/provider/rulebased/client.go
+++ b/pkg/model/provider/rulebased/client.go
@@ -78,7 +78,11 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, models map[string]l
 	}
 
 	client := &Client{
-		Config:   base.Config{ModelConfig: *cfg},
+		Config: base.Config{
+			ModelConfig: *cfg,
+			Models:      models,
+			Env:         env,
+		},
 		index:    index,
 		fallback: fallback,
 	}


### PR DESCRIPTION
Make sure the router uses the same models with the same defaults as the rest of the app.  
Thinking was being enabled erroneously

This is a quick fix to get things working, a cleanup of how models are provided throughout the app (agents, routing, rag etc) is due in the near future :)