### PR TITLE
Fix paste events going to editor when dialog is open

### DIFF
--- a/pkg/tui/dialog/command_palette.go
+++ b/pkg/tui/dialog/command_palette.go
@@ -109,6 +109,14 @@ func (d *commandPaletteDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		cmd := d.SetSize(msg.Width, msg.Height)
 		return d, cmd
 
+	case tea.PasteMsg:
+		// Forward paste to text input
+		var cmd tea.Cmd
+		d.textInput, cmd = d.textInput.Update(msg)
+		cmds = append(cmds, cmd)
+		d.filterCommands()
+		return d, tea.Batch(cmds...)
+
 	case tea.KeyPressMsg:
 		if cmd := HandleQuit(msg); cmd != nil {
 			return d, cmd

--- a/pkg/tui/dialog/elicitation.go
+++ b/pkg/tui/dialog/elicitation.go
@@ -84,6 +84,14 @@ func (d *ElicitationDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		cmd := d.SetSize(msg.Width, msg.Height)
 		return d, cmd
+	case tea.PasteMsg:
+		// Forward paste to text input if current field uses one
+		if d.isTextInputField() {
+			var cmd tea.Cmd
+			d.inputs[d.currentField], cmd = d.inputs[d.currentField].Update(msg)
+			return d, cmd
+		}
+		return d, nil
 	case tea.KeyPressMsg:
 		if msg.String() == "ctrl+c" {
 			cmd := d.close(tools.ElicitationActionDecline, nil)

--- a/pkg/tui/dialog/file_picker.go
+++ b/pkg/tui/dialog/file_picker.go
@@ -197,6 +197,13 @@ func (d *filePickerDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		cmd := d.SetSize(msg.Width, msg.Height)
 		return d, cmd
 
+	case tea.PasteMsg:
+		// Forward paste to text input
+		var cmd tea.Cmd
+		d.textInput, cmd = d.textInput.Update(msg)
+		d.filterEntries()
+		return d, cmd
+
 	case tea.KeyPressMsg:
 		if cmd := HandleQuit(msg); cmd != nil {
 			return d, cmd

--- a/pkg/tui/dialog/mcp_prompt_input.go
+++ b/pkg/tui/dialog/mcp_prompt_input.go
@@ -107,6 +107,15 @@ func (d *MCPPromptInputDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		cmd := d.SetSize(msg.Width, msg.Height)
 		return d, cmd
 
+	case tea.PasteMsg:
+		// Forward paste to current text input
+		if d.currentInput < len(d.inputs) {
+			var cmd tea.Cmd
+			d.inputs[d.currentInput], cmd = d.inputs[d.currentInput].Update(msg)
+			cmds = append(cmds, cmd)
+		}
+		return d, tea.Batch(cmds...)
+
 	case tea.KeyPressMsg:
 		if cmd := HandleQuit(msg); cmd != nil {
 			return d, cmd

--- a/pkg/tui/dialog/model_picker.go
+++ b/pkg/tui/dialog/model_picker.go
@@ -104,6 +104,14 @@ func (d *modelPickerDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		cmd := d.SetSize(msg.Width, msg.Height)
 		return d, cmd
 
+	case tea.PasteMsg:
+		// Forward paste to text input
+		var cmd tea.Cmd
+		d.textInput, cmd = d.textInput.Update(msg)
+		d.filterModels()
+		d.errMsg = "" // Clear error when user types
+		return d, cmd
+
 	case tea.MouseClickMsg:
 		return d.handleMouseClick(msg)
 

--- a/pkg/tui/dialog/multi_choice.go
+++ b/pkg/tui/dialog/multi_choice.go
@@ -291,6 +291,23 @@ func (d *multiChoiceDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		cmd := d.SetSize(msg.Width, msg.Height)
 		return d, cmd
 
+	case tea.PasteMsg:
+		// Forward paste to custom text input if custom is selected or allowed
+		if d.selected == selectionCustom {
+			var cmd tea.Cmd
+			d.customInput, cmd = d.customInput.Update(msg)
+			return d, cmd
+		}
+		// Auto-select custom mode when pasting if custom is allowed
+		if d.config.AllowCustom {
+			d.selected = selectionCustom
+			d.customInput.Focus()
+			var cmd tea.Cmd
+			d.customInput, cmd = d.customInput.Update(msg)
+			return d, cmd
+		}
+		return d, nil
+
 	case tea.KeyPressMsg:
 		if cmd := HandleQuit(msg); cmd != nil {
 			return d, cmd

--- a/pkg/tui/dialog/session_browser.go
+++ b/pkg/tui/dialog/session_browser.go
@@ -97,6 +97,13 @@ func (d *sessionBrowserDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		cmd := d.SetSize(msg.Width, msg.Height)
 		return d, cmd
 
+	case tea.PasteMsg:
+		// Forward paste to text input
+		var cmd tea.Cmd
+		d.textInput, cmd = d.textInput.Update(msg)
+		d.filterSessions()
+		return d, cmd
+
 	case tea.KeyPressMsg:
 		if cmd := HandleQuit(msg); cmd != nil {
 			return d, cmd

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -201,6 +201,19 @@ func (a *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyPressMsg:
 		return a.handleKeyPressMsg(msg)
 
+	case tea.PasteMsg:
+		// If dialogs are active, only they should receive paste events.
+		// This prevents paste content from going to both dialog and editor.
+		if a.dialog.Open() {
+			u, dialogCmd := a.dialog.Update(msg)
+			a.dialog = u.(dialog.Manager)
+			return a, dialogCmd
+		}
+		// Otherwise forward to chat page (editor)
+		updated, cmd := a.chatPage.Update(msg)
+		a.chatPage = updated.(chat.Page)
+		return a, cmd
+
 	case tea.MouseWheelMsg:
 		// If dialogs are active, they get priority for mouse events
 		if a.dialog.Open() {


### PR DESCRIPTION
Route tea.PasteMsg exclusively to the active dialog instead of both dialog and editor. Also add explicit paste handling to all dialogs with text inputs so they properly forward paste events to their textinput components.

Assisted-By: cagent