### PR TITLE
runtime: support dynamic (session-scoped) toolset injection

### DIFF
--- a/pkg/acp/agent.go
+++ b/pkg/acp/agent.go
@@ -185,7 +185,6 @@ func (a *Agent) NewSession(
 	_ context.Context,
 	params acp.NewSessionRequest,
 ) (acp.NewSessionResponse, error) {
-
 	// Generate a new session ID
 	sid := uuid.New().String()
 

--- a/pkg/acp/registry.go
+++ b/pkg/acp/registry.go
@@ -40,7 +40,6 @@ func createToolsetRegistry(agent *Agent) *teamloader.ToolsetRegistry {
 			parentDir string,
 			runConfig *config.RuntimeConfig,
 		) (tools.ToolSet, error) {
-
 			// Determine working directory:
 			// 1. runtime config working dir
 			// 2. fallback to process working directory


### PR DESCRIPTION
## Context

ACP allows clients to provide MCP servers dynamically during the session
handshake. These MCP servers are **session-scoped** and must be injected
into the runtime without mutating agent-level (YAML-defined) configuration.

Before this change, the runtime assumed that all toolsets were statically
defined on the agent, which made it impossible to correctly support
ACP-negotiated MCP servers.

This PR introduces proper support for **dynamic, session-scoped toolset
injection** in the runtime.

## References

- Fixes part of: https://github.com/docker/cagent/issues/1435

## What I did

- Added support for **injecting toolsets at runtime creation time** via a
  new `WithToolSets(...)` runtime option.
- Extended `LocalRuntime` to maintain `extraToolsets`, separate from
  agent/YAML-defined toolsets.
- Introduced `allToolSets()` to safely merge:
  - agent-defined toolsets (from YAML)
  - runtime-injected toolsets (e.g. MCP servers from ACP)
- Updated tool discovery and startup flow (`getTools`, startup events,
  handlers) to operate on the **combined toolset list**.
- Clarified and documented toolset lifecycle and responsibilities across:
  - `acp/agent.go`
  - `acp/registry.go`
  - `runtime/runtime.go`
- Ensured MCP toolsets remain **session-scoped**, avoiding global or agent-level
  side effects.

## What is still missing (out of scope for this PR)

- Wiring ACP-provided MCP servers into `NewSession` once the ACP SDK exposes
  them in `NewSessionRequest`.
- Support for non-HTTP MCP transports (e.g. SSE).
- Persisting or rehydrating MCP toolsets on session resume.

These will be addressed in follow-up PRs once ACP interfaces stabilize.

---

## Before / After

### Before
- Runtime could only see toolsets statically defined on the agent.
- No safe mechanism to inject MCP toolsets dynamically.
- Toolset lifecycle implicitly assumed YAML ownership.

### After
- Runtime explicitly supports **dynamic toolset injection**.
- MCP (and other external) toolsets can be attached per session.
- Clear separation between:
  - agent configuration
  - runtime/session concerns

---
