### PR TITLE
prompt-file is not yet supported by cagent-action, use prompt for now

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -184,11 +184,18 @@ jobs:
           echo "Context built:"
           wc -l review_context.md
 
+      - name: Read context file
+        id: read-context
+        run: |
+          echo "prompt<<EOF" >> $GITHUB_OUTPUT
+          cat review_context.md >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: Run PR Review Team
         uses: docker/cagent-action@7992ea47ed2446b5a80b01c46b00037c680e35ea
         with:
           agent: ${{ github.workspace }}/.github/workflows/agents/pr-review.yaml
-          prompt-file: review_context.md
+          prompt: ${{ steps.read-context.outputs.prompt }}
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
I haven't implemented `--prompt-file` support in the cagent-action yet, so this PR switches to `--prompt` for the PR reviewer agent for now until I can prioritize it.

- Added "Read context file" step after building the context
- Changed `prompt-file: review_context.md` → `prompt: ${{ steps.read-context.outputs.prompt }}`

The pattern uses GitHub's heredoc syntax for multi-line outputs:
```yaml
- name: Read context file
  id: read-context
  run: |
    echo "prompt<<EOF" >> $GITHUB_OUTPUT
    cat <file>.md >> $GITHUB_OUTPUT
    echo "EOF" >> $GITHUB_OUTPUT
```

This safely handles multi-line content with special characters, and the cagent-action already passes large prompts via stdin to avoid argument length limits.