### PR TITLE
Removed unnecessary thinking and force agent to post a comment, even if no issues were found

### DIFF
--- a/.github/workflows/agents/pr-review.yaml
+++ b/.github/workflows/agents/pr-review.yaml
@@ -28,6 +28,14 @@ agents:
 
       Find **real bugs in the changed code**, not style issues. If the changed code works correctly, approve it.
 
+      ## ALWAYS Post a Review
+
+      You MUST always post a review via the GitHub API, even if no issues were found.
+      - If no issues: Post an APPROVE with a brief positive message (e.g., "Looks good! No issues found.")
+      - If issues found: Post COMMENT or REQUEST_CHANGES with inline comments
+
+      Users find it confusing when no review comment is posted - they don't know if the review ran.
+
       ## Posting Reviews with Inline Comments
 
       The drafter returns issues in this format:
@@ -69,7 +77,6 @@ agents:
       - type: shell
       - type: memory
         path: .github/pr-review-memory.db
-      - type: think
 
   drafter:
     model: sonnet
@@ -143,7 +150,7 @@ agents:
     toolsets:
       - type: filesystem
         tools: [read_file, read_multiple_files, list_directory, directory_tree]
-      - type: think
+      - type: think  # Keep thinking for bug hypothesis generation
 
   verifier:
     model: sonnet
@@ -181,7 +188,6 @@ agents:
     toolsets:
       - type: filesystem
         tools: [read_file, read_multiple_files, list_directory, directory_tree]
-      - type: think
 
 permissions:
   allow:

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Process feedback and update memory
         if: steps.check.outputs.is_agent_comment == 'true'
-        uses: docker/cagent-action@7992ea47ed2446b5a80b01c46b00037c680e35ea
+        uses: docker/cagent-action@latest
         with:
           agent: ${{ github.workspace }}/.github/workflows/agents/pr-review-feedback.yaml
           prompt: |
@@ -192,7 +192,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Run PR Review Team
-        uses: docker/cagent-action@7992ea47ed2446b5a80b01c46b00037c680e35ea
+        uses: docker/cagent-action@latest
         with:
           agent: ${{ github.workspace }}/.github/workflows/agents/pr-review.yaml
           prompt: ${{ steps.read-context.outputs.prompt }}


### PR DESCRIPTION
Improve PR review agent output and reliability:

- Update `cagent-action` to `@latest` which includes proper GitHub token handling
- Reduce verbose output by removing `think` toolset from orchestrator and verifier agents (kept on drafter where reasoning helps with bug hypothesis generation)
- Always post a review comment, even when no issues are found (users found the rocket emoji confusing without context)