### PR TITLE
fix: correct memory database cache path for pr-reviewer GHA

### DIFF
--- a/.github/workflows/agents/pr-review-feedback.yaml
+++ b/.github/workflows/agents/pr-review-feedback.yaml
@@ -18,7 +18,7 @@ agents:
 
     toolsets:
       - type: memory
-        path: .github/pr-review-memory.db
+        path: pr-review-memory.db
       - type: shell
 
 permissions:

--- a/.github/workflows/agents/pr-review.yaml
+++ b/.github/workflows/agents/pr-review.yaml
@@ -76,7 +76,7 @@ agents:
         tools: [read_file, read_multiple_files, list_directory, directory_tree]
       - type: shell
       - type: memory
-        path: .github/pr-review-memory.db
+        path: pr-review-memory.db
 
   drafter:
     model: sonnet

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -55,7 +55,7 @@ jobs:
         if: steps.check.outputs.is_agent_comment == 'true'
         uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7
         with:
-          path: .github/pr-review-memory.db
+          path: .github/workflows/agents/pr-review-memory.db
           key: pr-review-memory-${{ github.repository }}
           restore-keys: |
             pr-review-memory-${{ github.repository }}
@@ -89,7 +89,7 @@ jobs:
         if: steps.check.outputs.is_agent_comment == 'true'
         uses: actions/cache/save@v4
         with:
-          path: .github/pr-review-memory.db
+          path: .github/workflows/agents/pr-review-memory.db
           key: pr-review-memory-${{ github.repository }}
 
   # ==========================================================================
@@ -131,7 +131,7 @@ jobs:
       - name: Restore reviewer memory database
         uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7
         with:
-          path: .github/pr-review-memory.db
+          path: .github/workflows/agents/pr-review-memory.db
           key: pr-review-memory-${{ github.repository }}
           restore-keys: |
             pr-review-memory-${{ github.repository }}
@@ -203,7 +203,7 @@ jobs:
         if: always()
         uses: actions/cache/save@v4
         with:
-          path: .github/pr-review-memory.db
+          path: .github/workflows/agents/pr-review-memory.db
           key: pr-review-memory-${{ github.repository }}
 
       - name: Add completion reaction


### PR DESCRIPTION
## Summary
- Fixed cache path mismatch that caused "Path Validation Error" when saving the reviewer memory database
- Simplified the memory database path by removing nested `.github/` directory

## Problem
The workflow was attempting to cache `.github/pr-review-memory.db`, but cagent was actually creating the file at `.github/workflows/agents/.github/pr-review-memory.db`.

This happened because:
1. `cagent-action` changes directory with `cd` but doesn't pass `--working-dir` to cagent
2. cagent resolves relative paths in agent configs from the **agent config's directory**, not the workspace root
3. The agent config path `.github/pr-review-memory.db` + parent dir `.github/workflows/agents/` = `.github/workflows/agents/.github/pr-review-memory.db`

## Changes
- Updated agent configs (`pr-review.yaml`, `pr-review-feedback.yaml`) to use `pr-review-memory.db` instead of `.github/pr-review-memory.db`
- Updated all cache paths in `pr-review.yml` to `.github/workflows/agents/pr-review-memory.db`