### PR TITLE
fix(tui): use innerWidth for horizontal sidebar

### DIFF
--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -555,7 +555,7 @@ func (p *chatPage) SetSize(width, height int) tea.Cmd {
 		p.chatHeight = max(1, height-actualEditorHeight-horizontalSidebarHeight-2) // -1 for resize handle, -1 for empty line before status bar
 		p.sidebar.SetMode(sidebar.ModeHorizontal)
 		cmds = append(cmds,
-			p.sidebar.SetSize(width, horizontalSidebarHeight),
+			p.sidebar.SetSize(innerWidth, horizontalSidebarHeight),
 			p.sidebar.SetPosition(styles.AppPaddingLeft, 0),
 			p.messages.SetPosition(0, horizontalSidebarHeight),
 		)


### PR DESCRIPTION
The horizontal sidebar received the full terminal width instead of innerWidth (minus app padding), causing content overflow on narrow terminals where the Context percentage would get truncated.

Assisted-By: cagent