### PR TITLE
improve message resizing for pending responses

### DIFF
--- a/pkg/tui/components/messages/messages.go
+++ b/pkg/tui/components/messages/messages.go
@@ -57,6 +57,7 @@ type Model interface {
 	LoadFromSession(sess *session.Session) tea.Cmd
 
 	ScrollToBottom() tea.Cmd
+	AdjustBottomSlack(delta int)
 }
 
 // renderedItem represents a cached rendered message with position information
@@ -1236,6 +1237,13 @@ func (m *model) ScrollToBottom() tea.Cmd {
 		}
 		return nil
 	}
+}
+
+func (m *model) AdjustBottomSlack(delta int) {
+	if delta == 0 {
+		return
+	}
+	m.bottomSlack = max(0, m.bottomSlack+delta)
 }
 
 // contentWidth returns the width available for content.


### PR DESCRIPTION
Avoid breaking the TUI layout when the pendingSpinner appears at the very bottom of the messages area

Screencasts:

**before**

https://github.com/user-attachments/assets/d040f04e-4040-4027-9596-7956612ddc84

---

**after**

https://github.com/user-attachments/assets/c609b535-c193-4893-9bb1-8d522f3f7223