### PR TITLE
Cache file reads for diff rendering

### DIFF
--- a/pkg/tui/components/reasoningblock/reasoningblock.go
+++ b/pkg/tui/components/reasoningblock/reasoningblock.go
@@ -519,7 +519,13 @@ func (m *Model) renderCollapsed() string {
 	if len(visibleTools) > 0 {
 		parts = append(parts, "") // blank line before tools
 		for _, entry := range visibleTools {
-			toolView := entry.view.View()
+			// Prefer CollapsedView() for simplified rendering in collapsed state
+			var toolView string
+			if cv, ok := entry.view.(layout.CollapsedViewer); ok {
+				toolView = cv.CollapsedView()
+			} else {
+				toolView = entry.view.View()
+			}
 			if entry.fadeProgress > 0 {
 				// Strip existing ANSI codes and apply faded color based on progress
 				// (wrapping styled content doesn't override inner colors)

--- a/pkg/tui/core/layout/layout.go
+++ b/pkg/tui/core/layout/layout.go
@@ -34,3 +34,9 @@ type Model interface {
 	View() string
 	Sizeable
 }
+
+// CollapsedViewer is implemented by components that provide a simplified view
+// for use in collapsed reasoning blocks.
+type CollapsedViewer interface {
+	CollapsedView() string
+}


### PR DESCRIPTION
Also adds dedicated view for collapsed reasoning blocks (so we only show + - lines on a single line instead of the full diff), and the interface for collapsed reasoning block (or just compact) renders in general so we can differentiate how other tools render when in collapsed reasoning blocks in the future

Screencast (relevant bits at ~1:00):

https://github.com/user-attachments/assets/7e86d700-bae9-4edb-a563-0d389d2c64fd
