### PR TITLE
Ensure generated title is a single line string

### DIFF
--- a/e2e/testdata/cassettes/TestRuntime_Mistral_Basic.yaml
+++ b/e2e/testdata/cassettes/TestRuntime_Mistral_Basic.yaml
@@ -58,7 +58,7 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: api.mistral.ai
-        body: '{"messages":[{"content":"You are a helpful AI assistant that generates concise, descriptive titles for conversations. You will be given a conversation history and asked to create a title that captures the main topic.","role":"system"},{"content":"Based on the following message a user sent to an AI assistant, generate a short, descriptive title (maximum 50 characters) that captures the main topic or purpose of the conversation. Return ONLY the title text, nothing else.\n\nUser message: What''s 2+2?\n\n","role":"user"}],"model":"mistral-small","stream_options":{"include_usage":true},"stream":true}'
+        body: '{"messages":[{"content":"You are a helpful AI assistant that generates concise, descriptive titles for conversations. You will be given a conversation history and asked to create a single-line title that captures the main topic. Never use newlines or line breaks in your response.","role":"system"},{"content":"Based on the following message a user sent to an AI assistant, generate a short, descriptive title (maximum 50 characters) that captures the main topic or purpose of the conversation. Return ONLY the title text on a single line, nothing else. Do not include any newlines, explanations, or formatting.\n\nUser message: What''s 2+2?\n\n","role":"user"}],"model":"mistral-small","stream_options":{"include_usage":true},"stream":true}'
         url: https://api.mistral.ai/v1/chat/completions
         method: POST
       response:

--- a/e2e/testdata/cassettes/TestRuntime_OpenAI_Basic.yaml
+++ b/e2e/testdata/cassettes/TestRuntime_OpenAI_Basic.yaml
@@ -52,7 +52,7 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: api.openai.com
-        body: '{"messages":[{"content":"You are a helpful AI assistant that generates concise, descriptive titles for conversations. You will be given a conversation history and asked to create a title that captures the main topic.","role":"system"},{"content":"Based on the following message a user sent to an AI assistant, generate a short, descriptive title (maximum 50 characters) that captures the main topic or purpose of the conversation. Return ONLY the title text, nothing else.\n\nUser message: What''s 2+2?\n\n","role":"user"}],"model":"gpt-3.5-turbo","stream_options":{"include_usage":true},"stream":true}'
+        body: '{"messages":[{"content":"You are a helpful AI assistant that generates concise, descriptive titles for conversations. You will be given a conversation history and asked to create a single-line title that captures the main topic. Never use newlines or line breaks in your response.","role":"system"},{"content":"Based on the following message a user sent to an AI assistant, generate a short, descriptive title (maximum 50 characters) that captures the main topic or purpose of the conversation. Return ONLY the title text on a single line, nothing else. Do not include any newlines, explanations, or formatting.\n\nUser message: What''s 2+2?\n\n","role":"user"}],"model":"gpt-3.5-turbo","stream_options":{"include_usage":true},"stream":true}'
         url: https://api.openai.com/v1/chat/completions
         method: POST
       response:

--- a/pkg/runtime/title_generator.go
+++ b/pkg/runtime/title_generator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 
 	"github.com/docker/cagent/pkg/agent"
@@ -14,8 +15,8 @@ import (
 )
 
 const (
-	titleSystemPrompt     = "You are a helpful AI assistant that generates concise, descriptive titles for conversations. You will be given a conversation history and asked to create a title that captures the main topic."
-	titleUserPromptFormat = "Based on the following message a user sent to an AI assistant, generate a short, descriptive title (maximum 50 characters) that captures the main topic or purpose of the conversation. Return ONLY the title text, nothing else.\n\nUser message: %s\n\n"
+	titleSystemPrompt     = "You are a helpful AI assistant that generates concise, descriptive titles for conversations. You will be given a conversation history and asked to create a single-line title that captures the main topic. Never use newlines or line breaks in your response."
+	titleUserPromptFormat = "Based on the following message a user sent to an AI assistant, generate a short, descriptive title (maximum 50 characters) that captures the main topic or purpose of the conversation. Return ONLY the title text on a single line, nothing else. Do not include any newlines, explanations, or formatting.\n\nUser message: %s\n\n"
 )
 
 type titleGenerator struct {
@@ -82,7 +83,29 @@ func (t *titleGenerator) generate(ctx context.Context, sess *session.Session, fi
 		return
 	}
 
+	// Sanitize the title to ensure it's a single line
+	title = sanitizeTitle(title)
+	if title == "" {
+		return
+	}
+
 	sess.Title = title
 	slog.Debug("Generated session title", "session_id", sess.ID, "title", title)
 	events <- SessionTitle(sess.ID, title)
+}
+
+// sanitizeTitle ensures the title is a single line by taking only the first
+// non-empty line and stripping any control characters that could break TUI rendering.
+func sanitizeTitle(title string) string {
+	// Split by newlines and take the first non-empty line
+	lines := strings.Split(title, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			// Remove any remaining carriage returns
+			line = strings.ReplaceAll(line, "\r", "")
+			return line
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
When a models returns a multi-line string for any reason, rendering in the TUI can break.

Prompt the LLM not to do that, and also sanitize it's output because LLMs can't be trusted