### PR TITLE
Fix the session compaction

### DIFF
--- a/pkg/runtime/prompts/compaction-system.txt
+++ b/pkg/runtime/prompts/compaction-system.txt
@@ -1,0 +1,4 @@
+You are an AI assistant that helps summarize conversations for future reference. 
+
+Your task is to generate a concise summary of the conversation that captures the key points, decisions made, and important context. 
+The summary should be clear and informative, enabling someone who was not part of the original conversation to understand what transpired.

--- a/pkg/runtime/prompts/compaction-user.txt
+++ b/pkg/runtime/prompts/compaction-user.txt
@@ -1,0 +1,3 @@
+Provide a detailed prompt for continuing our conversation above. 
+Focus on information that would be helpful for continuing the conversation, including what we did, what we're doing, 
+which files we're working on, and what we're going to do next considering new session will not have access to our conversation.

--- a/pkg/runtime/session_compaction.go
+++ b/pkg/runtime/session_compaction.go
@@ -2,31 +2,23 @@ package runtime
 
 import (
 	"context"
-	"fmt"
+	_ "embed"
 	"log/slog"
-	"strings"
+	"time"
 
 	"github.com/docker/cagent/pkg/agent"
+	"github.com/docker/cagent/pkg/chat"
 	"github.com/docker/cagent/pkg/model/provider"
 	"github.com/docker/cagent/pkg/model/provider/options"
 	"github.com/docker/cagent/pkg/session"
 	"github.com/docker/cagent/pkg/team"
 )
 
-const (
-	compactionSystemPrompt = "You are a helpful AI assistant that creates comprehensive summaries of conversations. You will be given a conversation history and asked to create a concise yet thorough summary that captures the key points, decisions made, and outcomes."
-	compactionUserPrompt   = `Based on the following conversation between a user and an AI assistant, create a comprehensive summary that captures:
-- The main topics discussed
-- Key information exchanged
-- Decisions made or conclusions reached
-- Important outcomes or results
+//go:embed prompts/compaction-system.txt
+var compactionSystemPrompt string
 
-Provide a well-structured summary (2-4 paragraphs) that someone could read to understand what happened in this conversation. Return ONLY the summary text, nothing else.
-
-Conversation history:%s
-
-Generate a summary for this conversation:`
-)
+//go:embed prompts/compaction-user.txt
+var compactionUserPrompt string
 
 type sessionCompactor struct {
 	model provider.Provider
@@ -46,16 +38,49 @@ func (c *sessionCompactor) Compact(ctx context.Context, sess *session.Session, a
 		events <- SessionCompaction(sess.ID, "completed", agentName)
 	}()
 
-	messages := sess.GetAllMessages()
-	if len(messages) == 0 {
+	summaryModel := provider.CloneWithOptions(ctx, c.model, options.WithStructuredOutput(nil))
+	root := agent.New("root", compactionSystemPrompt, agent.WithModel(summaryModel))
+	newTeam := team.New(team.WithAgents(root))
+
+	messages := sess.GetMessages(root)
+	if !hasConversationMessages(messages) {
 		events <- Warning("Session is empty. Start a conversation before compacting.", agentName)
 		return
 	}
 
-	conversationHistory := c.buildConversationHistory(messages)
-	userPrompt := c.buildUserPrompt(conversationHistory, additionalPrompt)
+	summarySession := session.New()
+	summarySession.Title = "Generating summary..."
+	for _, msg := range messages {
+		summarySession.AddMessage(&session.Message{Message: msg})
+	}
 
-	summary := c.generateSummary(ctx, userPrompt)
+	prompt := compactionUserPrompt
+	if additionalPrompt != "" {
+		prompt += "\n\nAdditional instructions from user: " + additionalPrompt
+	}
+	summarySession.AddMessage(&session.Message{
+		Message: chat.Message{
+			Role:      chat.MessageRoleUser,
+			Content:   prompt,
+			CreatedAt: time.Now().Format(time.RFC3339),
+		},
+	})
+
+	summaryRuntime, err := New(newTeam, WithSessionCompaction(false))
+	if err != nil {
+		slog.Error("Failed to create summary generator runtime", "error", err)
+		events <- Error(err.Error())
+		return
+	}
+
+	_, err = summaryRuntime.Run(ctx, summarySession)
+	if err != nil {
+		slog.Error("Failed to generate session summary", "error", err)
+		events <- Error(err.Error())
+		return
+	}
+
+	summary := summarySession.GetLastAssistantMessageContent()
 	if summary == "" {
 		return
 	}
@@ -66,52 +91,11 @@ func (c *sessionCompactor) Compact(ctx context.Context, sess *session.Session, a
 	events <- SessionSummary(sess.ID, summary, agentName)
 }
 
-func (c *sessionCompactor) buildConversationHistory(messages []session.Message) string {
-	var builder strings.Builder
-	for i := range messages {
-		role := "Unknown"
-		switch messages[i].Message.Role {
-		case "user":
-			role = "User"
-		case "assistant":
-			role = "Assistant"
-		case "system":
-			continue
+func hasConversationMessages(messages []chat.Message) bool {
+	for _, msg := range messages {
+		if msg.Role != chat.MessageRoleSystem {
+			return true
 		}
-		fmt.Fprintf(&builder, "\n%s: %s", role, messages[i].Message.Content)
 	}
-	return builder.String()
-}
-
-func (c *sessionCompactor) buildUserPrompt(conversationHistory, additionalPrompt string) string {
-	prompt := fmt.Sprintf(compactionUserPrompt, conversationHistory)
-	if additionalPrompt != "" {
-		prompt += fmt.Sprintf("\n\nAdditional instructions from user: %s", additionalPrompt)
-	}
-	return prompt
-}
-
-func (c *sessionCompactor) generateSummary(ctx context.Context, userPrompt string) string {
-	summaryModel := provider.CloneWithOptions(ctx, c.model, options.WithStructuredOutput(nil))
-	newTeam := team.New(
-		team.WithAgents(agent.New("root", compactionSystemPrompt, agent.WithModel(summaryModel))),
-	)
-
-	summarySession := session.New(session.WithSystemMessage(compactionSystemPrompt))
-	summarySession.AddMessage(session.UserMessage(userPrompt))
-	summarySession.Title = "Generating summary..."
-
-	summaryRuntime, err := New(newTeam, WithSessionCompaction(false))
-	if err != nil {
-		slog.Error("Failed to create summary generator runtime", "error", err)
-		return ""
-	}
-
-	_, err = summaryRuntime.Run(ctx, summarySession)
-	if err != nil {
-		slog.Error("Failed to generate session summary", "error", err)
-		return ""
-	}
-
-	return summarySession.GetLastAssistantMessageContent()
+	return false
 }


### PR DESCRIPTION
We were being stupid, the main session calls sess.GetMessages, which potentially trims things, either the number of messages if configured that way, or by removing old tool call results. But then we would use GetAllMessages when compacting, resulting in a compaction that doesn't work because the context that we are sending is potentially bigger than the LLMs max tokens limit.