### PR TITLE
Make /commands searchable in the command palette

### DIFF
--- a/pkg/tui/commands/commands.go
+++ b/pkg/tui/commands/commands.go
@@ -190,7 +190,7 @@ func builtInSessionCommands() []Item {
 			ID:           "settings.theme",
 			Label:        "Theme",
 			SlashCommand: "/theme",
-			Description:  "Change the color theme (saved globally)",
+			Description:  "Change the color theme",
 			Category:     "Settings",
 			Execute: func(string) tea.Cmd {
 				return core.CmdHandler(messages.OpenThemePickerMsg{})

--- a/pkg/tui/dialog/command_palette.go
+++ b/pkg/tui/dialog/command_palette.go
@@ -182,7 +182,8 @@ func (d *commandPaletteDialog) filterCommands() {
 		for _, cmd := range cat.Commands {
 			if strings.Contains(strings.ToLower(cmd.Label), query) ||
 				strings.Contains(strings.ToLower(cmd.Description), query) ||
-				strings.Contains(strings.ToLower(cmd.Category), query) {
+				strings.Contains(strings.ToLower(cmd.Category), query) ||
+				strings.Contains(strings.ToLower(cmd.SlashCommand), query) {
 				d.filtered = append(d.filtered, cmd)
 			}
 		}

--- a/pkg/tui/dialog/command_palette_test.go
+++ b/pkg/tui/dialog/command_palette_test.go
@@ -14,18 +14,20 @@ var categories = []commands.Category{
 		Name: "Session",
 		Commands: []commands.Item{
 			{
-				ID:          "session.new",
-				Label:       "New Session",
-				Description: "Start a new conversation session",
-				Category:    "Session",
-				Execute:     func(string) tea.Cmd { return nil },
+				ID:           "session.new",
+				Label:        "New Session",
+				SlashCommand: "/new",
+				Description:  "Start a new conversation session",
+				Category:     "Session",
+				Execute:      func(string) tea.Cmd { return nil },
 			},
 			{
-				ID:          "session.compact",
-				Label:       "Compact Session",
-				Description: "Summarize and compact the current conversation",
-				Category:    "Session",
-				Execute:     func(string) tea.Cmd { return nil },
+				ID:           "session.compact",
+				Label:        "Compact Session",
+				SlashCommand: "/compact",
+				Description:  "Summarize and compact the current conversation",
+				Category:     "Session",
+				Execute:      func(string) tea.Cmd { return nil },
 			},
 		},
 	},
@@ -43,6 +45,11 @@ func TestCommandPaletteFiltering(t *testing.T) {
 		{
 			name:     "filter by new",
 			input:    "new",
+			expected: []string{"session.new"},
+		},
+		{
+			name:     "filter by slash command",
+			input:    "/new",
 			expected: []string{"session.new"},
 		},
 		{


### PR DESCRIPTION
If a users searches for a slash command command with the / prefix, for muscle memory of because of their expectations, lets show them what they want to see