### PR TITLE
avoid parallel tests in the teamloader load examples test

### DIFF
--- a/pkg/teamloader/teamloader_test.go
+++ b/pkg/teamloader/teamloader_test.go
@@ -101,10 +101,10 @@ func TestLoadExamples(t *testing.T) {
 	}
 
 	// Load all the examples.
+	// Note: don't use t.Parallel() to avoid SQLite lock contention when
+	// multiple RAG examples share the same relative database paths (e.g., ./bm25.db).
 	for _, agentFilename := range examples {
 		t.Run(agentFilename, func(t *testing.T) {
-			t.Parallel()
-
 			agentSource, err := config.Resolve(agentFilename)
 			require.NoError(t, err)
 


### PR DESCRIPTION
Very occasionally, the rag example files could create sqlite db contention issues during the load examples test

An example has been spotted in the while here: https://github.com/docker/cagent/actions/runs/21455949757/job/61796708309

Since the speed difference running them sequentially is negligible, removing t.Parallel() here keeps things simple