### PR TITLE
Keep messages column for backward/forward compatibility

### DIFF
--- a/pkg/session/migrations.go
+++ b/pkg/session/migrations.go
@@ -300,12 +300,9 @@ func getAllMigrations() []Migration {
 			Description: "Migrate existing messages JSON data to session_items table",
 			UpFunc:      migrateMessagesToSessionItems,
 		},
-		{
-			ID:          16,
-			Name:        "016_drop_messages_column",
-			Description: "Remove the legacy messages JSON column from sessions table",
-			UpSQL:       `ALTER TABLE sessions DROP COLUMN messages`,
-		},
+		// Note: We intentionally keep the messages column for backward compatibility.
+		// Old versions of cagent can still read sessions via the messages column,
+		// while new versions read from session_items but also write to messages.
 	}
 }
 


### PR DESCRIPTION
Ensure sessions created by new cagent versions can be read by older versions, and sessions created by older versions can be read by new versions.

Changes:
- Remove migration 016 that dropped the messages column
- Sync messages JSON column after every write operation (AddMessage, UpdateMessage, AddSubSession, AddSummary)
- Fall back to reading from messages column when session_items is empty
- Add querier interface to unify db/tx operations and reduce code duplication
- Add comprehensive compatibility tests

Compatibility matrix:
- Old writer -> Old reader: works (messages column)
- Old writer -> New reader: works (falls back to messages column)
- New writer -> Old reader: works (messages column populated)
- New writer -> New reader: works (session_items table)

Assisted-By: cagent