### PR TITLE
Fix space key not working in elicitation text input fields

### DIFF
--- a/pkg/tui/dialog/elicitation.go
+++ b/pkg/tui/dialog/elicitation.go
@@ -104,7 +104,8 @@ func (d *ElicitationDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 
 func (d *ElicitationDialog) handleKeyPress(msg tea.KeyPressMsg) (layout.Model, tea.Cmd) {
 	switch {
-	case key.Matches(msg, d.keyMap.Space):
+	case key.Matches(msg, d.keyMap.Space) && !d.isTextInputField():
+		// Only handle space for boolean/enum fields; let it pass through to text input otherwise
 		d.toggleCurrentSelection()
 		return d, nil
 	case key.Matches(msg, d.keyMap.Escape):


### PR DESCRIPTION
The space key was being unconditionally caught by handleKeyPress and routed to toggleCurrentSelection(), which only handles boolean/enum fields. For text input fields (string, number, integer), the space key was swallowed without being forwarded to the text input component.

Assisted-By: cagent