### PR TITLE
Show validation errors in elicitation dialog when Enter is pressed

### DIFF
--- a/pkg/tui/dialog/elicitation_test.go
+++ b/pkg/tui/dialog/elicitation_test.go
@@ -323,7 +323,7 @@ func TestNewElicitationDialog(t *testing.T) {
 	}
 }
 
-func TestElicitationDialog_collectValues(t *testing.T) {
+func TestElicitationDialog_collectAndValidate(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -536,7 +536,8 @@ func TestElicitationDialog_collectValues(t *testing.T) {
 				tt.setupInputs(dialog)
 			}
 
-			content, valid := dialog.collectValues()
+			content, firstErrorIdx := dialog.collectAndValidate()
+			valid := firstErrorIdx < 0
 			assert.Equal(t, tt.expectedValid, valid)
 
 			if valid && tt.expectedKeys != nil {

--- a/pkg/tui/dialog/validation.go
+++ b/pkg/tui/dialog/validation.go
@@ -1,6 +1,7 @@
 package dialog
 
 import (
+	"fmt"
 	"net/mail"
 	"net/url"
 	"regexp"
@@ -28,47 +29,74 @@ func getCompiledPattern(pattern string) (*regexp.Regexp, error) {
 
 // validateStringField validates a string value against field constraints.
 func validateStringField(val string, field ElicitationField) bool {
+	return validateStringFieldWithMessage(val, field) == ""
+}
+
+// validateStringFieldWithMessage validates a string value and returns a descriptive error message.
+func validateStringFieldWithMessage(val string, field ElicitationField) string {
 	if field.MinLength > 0 && len(val) < field.MinLength {
-		return false
+		return fmt.Sprintf("Must be at least %d characters", field.MinLength)
 	}
 	if field.Pattern != "" {
 		compiled, err := getCompiledPattern(field.Pattern)
-		if err != nil || !compiled.MatchString(val) {
-			return false
+		if err != nil {
+			return "Invalid pattern in schema"
+		}
+		if !compiled.MatchString(val) {
+			return "Invalid format"
 		}
 	}
-	return validateFormat(val, field.Format)
+	return validateFormatWithMessage(val, field.Format)
 }
 
 // validateNumberField validates a numeric value against field constraints.
 func validateNumberField(val float64, field ElicitationField) bool {
+	return validateNumberFieldWithMessage(val, field) == ""
+}
+
+// validateNumberFieldWithMessage validates a numeric value and returns a descriptive error message.
+func validateNumberFieldWithMessage(val float64, field ElicitationField) string {
 	if field.HasMinimum && val < field.Minimum {
-		return false
+		return fmt.Sprintf("Must be at least %v", field.Minimum)
 	}
 	if field.HasMaximum && val > field.Maximum {
-		return false
+		return fmt.Sprintf("Must be at most %v", field.Maximum)
 	}
-	return true
+	return ""
 }
 
 // validateFormat validates a string value against a JSON Schema format.
 func validateFormat(val, format string) bool {
+	return validateFormatWithMessage(val, format) == ""
+}
+
+// validateFormatWithMessage validates a string against a JSON Schema format and returns an error message.
+func validateFormatWithMessage(val, format string) string {
 	switch format {
 	case "":
-		return true
+		return ""
 	case "email":
-		_, err := mail.ParseAddress(val)
-		return err == nil
+		if _, err := mail.ParseAddress(val); err != nil {
+			return "Must be a valid email address"
+		}
+		return ""
 	case "uri":
 		u, err := url.Parse(val)
-		return err == nil && u.Scheme != "" && u.Host != ""
+		if err != nil || u.Scheme == "" || u.Host == "" {
+			return "Must be a valid URL (http:// or https://)"
+		}
+		return ""
 	case "date":
-		_, err := time.Parse("2006-01-02", val)
-		return err == nil
+		if _, err := time.Parse("2006-01-02", val); err != nil {
+			return "Must be a valid date (YYYY-MM-DD)"
+		}
+		return ""
 	case "date-time":
-		_, err := time.Parse(time.RFC3339, val)
-		return err == nil
+		if _, err := time.Parse(time.RFC3339, val); err != nil {
+			return "Must be a valid date-time (RFC3339 format)"
+		}
+		return ""
 	default:
-		return true // Unknown format - be permissive
+		return "" // Unknown format - be permissive
 	}
 }


### PR DESCRIPTION
Previously, pressing Enter on an elicitation dialog with invalid fields would silently do nothing, making users think the Enter key wasn't working.

Now the dialog:
- Highlights invalid field labels in red
- Shows descriptive error messages below each invalid field
- Focuses the first field with an error
- Clears errors when the user modifies a field

This provides clear feedback when validation fails, such as:
- 'This field is required' for empty required fields
- 'Must be a valid number' for invalid numeric input
- 'Must be at least N' for minimum value violations
- 'Must be a valid email address' for email format errors

Assisted-By: cagent