### PR TITLE
double click to edit title

### DIFF
--- a/pkg/tui/page/chat/input_handlers.go
+++ b/pkg/tui/page/chat/input_handlers.go
@@ -130,8 +130,11 @@ func (p *chatPage) handleMouseClick(msg tea.MouseClickMsg) (layout.Model, tea.Cm
 				return p, core.CmdHandler(msgtypes.ToggleSessionStarMsg{SessionID: sess.ID})
 			}
 			return p, nil
-		case sidebar.ClickPencil:
-			p.sidebar.BeginTitleEdit()
+		case sidebar.ClickTitle:
+			// Double-click on title to edit
+			if p.sidebar.HandleTitleClick() {
+				p.sidebar.BeginTitleEdit()
+			}
 			return p, nil
 		}
 	}


### PR DESCRIPTION
fixes not being able to click on the title edit icon when the title wraps to a newline

double clicking anywhere on the title is more reliable than calculating where the edit icon should be and its hitbox, and potentially easier for the user as well

also fixes the title editor input area size calculation and moves some title specific code to the sidebar component