### PR TITLE
Show better errors if `dmr` not found or no providers for `model: "auto"`

### DIFF
--- a/pkg/creator/agent_test.go
+++ b/pkg/creator/agent_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/docker/cagent/pkg/config"
 	"github.com/docker/cagent/pkg/config/latest"
+	"github.com/docker/cagent/pkg/environment"
 )
 
 func TestAgentConfigYAML(t *testing.T) {
@@ -102,14 +103,17 @@ func TestAgent(t *testing.T) {
 
 	ctx := t.Context()
 
-	// Create a minimal runtime config
+	// Create a runtime config with a mock env provider that has a dummy API key
+	// so the auto model can resolve to a provider without needing real credentials
 	runConfig := &config.RuntimeConfig{
 		Config: config.Config{
 			WorkingDir: t.TempDir(),
 		},
+		EnvProviderForTests: environment.NewEnvListProvider([]string{
+			"OPENAI_API_KEY=dummy-key-for-testing",
+		}),
 	}
 
-	// Test with a mock model override to avoid needing real API keys
 	// The auto model will be resolved based on available providers
 	team, err := Agent(ctx, runConfig, "")
 	require.NoError(t, err)

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -3,6 +3,7 @@ package teamloader
 import (
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	"github.com/docker/cagent/pkg/config/latest"
 	"github.com/docker/cagent/pkg/js"
 	"github.com/docker/cagent/pkg/model/provider"
+	"github.com/docker/cagent/pkg/model/provider/dmr"
 	"github.com/docker/cagent/pkg/model/provider/options"
 	"github.com/docker/cagent/pkg/modelsdev"
 	"github.com/docker/cagent/pkg/permissions"
@@ -157,6 +159,12 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 
 		models, thinkingConfigured, err := getModelsForAgent(ctx, cfg, &agentConfig, autoModel, runConfig)
 		if err != nil {
+			// Return auto model fallback errors and DMR not installed errors directly
+			// without wrapping to provide cleaner messages
+			var autoErr *config.ErrAutoModelFallback
+			if errors.As(err, &autoErr) || errors.Is(err, dmr.ErrNotInstalled) {
+				return nil, err
+			}
 			return nil, fmt.Errorf("failed to get models: %w", err)
 		}
 		for _, model := range models {
@@ -238,9 +246,11 @@ func getModelsForAgent(ctx context.Context, cfg *latest.Config, a *latest.AgentC
 
 	for name := range strings.SplitSeq(a.Model, ",") {
 		modelCfg, exists := cfg.Models[name]
+		isAutoModel := false
 		if !exists {
 			if name == "auto" {
 				modelCfg = autoModelFn()
+				isAutoModel = true
 			} else {
 				return nil, false, fmt.Errorf("model '%s' not found in configuration", name)
 			}
@@ -286,6 +296,10 @@ func getModelsForAgent(ctx context.Context, cfg *latest.Config, a *latest.AgentC
 			opts...,
 		)
 		if err != nil {
+			// Return a cleaner error message for auto model selection failures
+			if isAutoModel {
+				return nil, false, &config.ErrAutoModelFallback{}
+			}
 			return nil, false, err
 		}
 		models = append(models, model)

--- a/pkg/teamloader/testdata/auto-model.yaml
+++ b/pkg/teamloader/testdata/auto-model.yaml
@@ -1,0 +1,4 @@
+agents:
+  root:
+    model: auto
+    instruction: Test agent with auto model selection


### PR DESCRIPTION
- if a user is explicitly trying to use `dmr` but it's not installed, point them to the getting started docs
- refactors up how we check for provider api keys
- shows an appropriate error message if all `model: "auto"` fallbacks fail

### Screenshots
<img width="1530" height="683" alt="Screenshot From 2026-02-01 13-38-10" src="https://github.com/user-attachments/assets/b34a1c87-2018-4b1d-b99f-62df7fd16835" />

<img width="1530" height="683" alt="image" src="https://github.com/user-attachments/assets/fa327816-7a9e-4ce7-a7f3-7acc7e9ac9af" />
