### PR TITLE
Cleaner agent switching ux in the TUI

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -114,6 +114,17 @@ func New(ctx context.Context, rt runtime.Runtime, sess *session.Session, opts ..
 		})
 	}
 
+	// If the runtime supports background toolset loading, start it to load
+	// tools for all agents (not just the current one) and emit updated TeamInfo.
+	if toolsetLoader, ok := rt.(runtime.BackgroundToolsetLoader); ok {
+		toolsetLoader.StartBackgroundToolsetLoad(ctx, func(event runtime.Event) {
+			select {
+			case app.events <- event:
+			case <-ctx.Done():
+			}
+		})
+	}
+
 	return app
 }
 

--- a/pkg/runtime/event.go
+++ b/pkg/runtime/event.go
@@ -395,13 +395,23 @@ func AgentInfo(agentName, model, description, welcomeMessage string) Event {
 	}
 }
 
+// ToolsetSummary contains summary information about a single toolset
+type ToolsetSummary struct {
+	Name      string   `json:"name"`       // User-friendly name (e.g., "filesystem", "mcp (docker:context7)")
+	ToolCount int      `json:"tool_count"` // Number of tools in this toolset
+	ToolNames []string `json:"tool_names"` // List of individual tool names for details dialog
+}
+
 // AgentDetails contains information about an agent for display in the sidebar
 type AgentDetails struct {
-	Name        string         `json:"name"`
-	Description string         `json:"description"`
-	Provider    string         `json:"provider"`
-	Model       string         `json:"model"`
-	Commands    types.Commands `json:"commands,omitempty"`
+	Name         string           `json:"name"`
+	Description  string           `json:"description"`
+	Provider     string           `json:"provider"`
+	Model        string           `json:"model"`
+	Commands     types.Commands   `json:"commands,omitempty"`
+	TotalTools   int              `json:"total_tools"`        // Total count of all tools for this agent
+	Toolsets     []ToolsetSummary `json:"toolsets,omitempty"` // Detailed summary of each toolset
+	ToolsLoading bool             `json:"tools_loading"`      // True if tools are still being loaded for this agent
 }
 
 // TeamInfoEvent is sent when team information is available
@@ -443,16 +453,18 @@ func AgentSwitching(switching bool, fromAgent, toAgent string) Event {
 // ToolsetInfoEvent is sent when toolset information is available
 // When Loading is true, more tools may still be loading (e.g., MCP servers starting)
 type ToolsetInfoEvent struct {
-	Type           string `json:"type"`
-	AvailableTools int    `json:"available_tools"`
-	Loading        bool   `json:"loading"`
+	Type           string           `json:"type"`
+	AvailableTools int              `json:"available_tools"`
+	Toolsets       []ToolsetSummary `json:"toolsets,omitempty"` // Detailed summary of each toolset
+	Loading        bool             `json:"loading"`
 	AgentContext
 }
 
-func ToolsetInfo(availableTools int, loading bool, agentName string) Event {
+func ToolsetInfo(availableTools int, toolsets []ToolsetSummary, loading bool, agentName string) Event {
 	return &ToolsetInfoEvent{
 		Type:           "toolset_info",
 		AvailableTools: availableTools,
+		Toolsets:       toolsets,
 		Loading:        loading,
 		AgentContext:   AgentContext{AgentName: agentName},
 	}

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -102,7 +102,7 @@ func (r *RemoteRuntime) EmitStartupInfo(ctx context.Context, events chan Event) 
 
 	events <- AgentInfo(r.currentAgent, cfg.Model, cfg.Description, cfg.WelcomeMessage)
 	events <- TeamInfo(r.agentDetailsFromConfig(ctx), r.currentAgent)
-	events <- ToolsetInfo(len(cfg.Toolsets), false, r.currentAgent)
+	events <- ToolsetInfo(len(cfg.Toolsets), nil, false, r.currentAgent)
 }
 
 func (r *RemoteRuntime) agentDetailsFromConfig(ctx context.Context) []AgentDetails {

--- a/pkg/teamloader/filter.go
+++ b/pkg/teamloader/filter.go
@@ -50,6 +50,11 @@ func (f *filterTools) Instructions() string {
 	return tools.GetInstructions(f.ToolSet)
 }
 
+// Unwrap returns the inner toolset for unwrapping during display name computation.
+func (f *filterTools) Unwrap() tools.ToolSet {
+	return f.ToolSet
+}
+
 func (f *filterTools) Tools(ctx context.Context) ([]tools.Tool, error) {
 	allTools, err := f.ToolSet.Tools(ctx)
 	if err != nil {

--- a/pkg/teamloader/instructions.go
+++ b/pkg/teamloader/instructions.go
@@ -29,3 +29,8 @@ func (a replaceInstruction) Instructions() string {
 	original := tools.GetInstructions(a.ToolSet)
 	return strings.Replace(a.instruction, "{ORIGINAL_INSTRUCTIONS}", original, 1)
 }
+
+// Unwrap returns the inner toolset for unwrapping during display name computation.
+func (a replaceInstruction) Unwrap() tools.ToolSet {
+	return a.ToolSet
+}

--- a/pkg/teamloader/toon.go
+++ b/pkg/teamloader/toon.go
@@ -16,6 +16,11 @@ type toonTools struct {
 	toolRegexps []*regexp.Regexp
 }
 
+// Unwrap returns the inner toolset for unwrapping during display name computation.
+func (f *toonTools) Unwrap() tools.ToolSet {
+	return f.ToolSet
+}
+
 func (f *toonTools) Tools(ctx context.Context) ([]tools.Tool, error) {
 	allTools, err := f.ToolSet.Tools(ctx)
 	if err != nil {

--- a/pkg/tools/mcp/mcp.go
+++ b/pkg/tools/mcp/mcp.go
@@ -49,6 +49,11 @@ var (
 	_ tools.OAuthCapable = (*Toolset)(nil)
 )
 
+// Name returns the name of the MCP toolset (e.g., the ref or command).
+func (ts *Toolset) Name() string {
+	return ts.name
+}
+
 // NewToolsetCommand creates a new MCP toolset from a command.
 func NewToolsetCommand(name, command string, args, env []string, cwd string) *Toolset {
 	slog.Debug("Creating Stdio MCP toolset", "command", command, "args", args)

--- a/pkg/tui/components/scrollbar/scrollbar.go
+++ b/pkg/tui/components/scrollbar/scrollbar.go
@@ -131,6 +131,7 @@ func (m *Model) calculateThumbPosition() (top, height int) {
 		return 0, 0
 	}
 
+	// Thumb height is proportional to visible/total content, minimum 1
 	thumbHeight := max(1, (m.viewHeight*m.height)/m.totalHeight)
 
 	maxScroll := m.maxScrollOffset()
@@ -138,8 +139,15 @@ func (m *Model) calculateThumbPosition() (top, height int) {
 		return 0, thumbHeight
 	}
 
+	// Scrollable track height is track minus thumb
 	scrollableTrackHeight := m.height - thumbHeight
-	thumbTop := (m.scrollOffset * scrollableTrackHeight) / maxScroll
+
+	// Use rounding (add half divisor) for smoother thumb movement
+	// This prevents the thumb staying at 0 for multiple scroll steps
+	thumbTop := (m.scrollOffset*scrollableTrackHeight + maxScroll/2) / maxScroll
+
+	// Clamp to valid range
+	thumbTop = min(thumbTop, scrollableTrackHeight)
 
 	return thumbTop, thumbHeight
 }

--- a/pkg/tui/components/sidebar/layout_test.go
+++ b/pkg/tui/components/sidebar/layout_test.go
@@ -172,7 +172,7 @@ func BenchmarkSidebarVerticalView_Scroll(b *testing.B) {
 	})
 
 	// Add some tools
-	m.SetToolsetInfo(25, false)
+	m.SetToolsetInfo("agent1", 25, nil, false)
 
 	// Initial render to populate cache
 	_ = m.verticalView()
@@ -214,7 +214,7 @@ func BenchmarkSidebarVerticalView_NoCache(b *testing.B) {
 	})
 
 	// Add some tools
-	m.SetToolsetInfo(25, false)
+	m.SetToolsetInfo("agent1", 25, nil, false)
 
 	b.ResetTimer()
 	b.ReportAllocs()

--- a/pkg/tui/components/sidebar/section.go
+++ b/pkg/tui/components/sidebar/section.go
@@ -1,0 +1,78 @@
+package sidebar
+
+import "strings"
+
+// Section represents a self-contained sidebar section that can render itself
+// and handle click detection within its bounds.
+type Section interface {
+	// Render returns the rendered content and the number of lines it occupies.
+	Render(contentWidth int) (content string, lineCount int)
+
+	// HandleClick checks if a click at the given line (relative to section start)
+	// should be handled. Returns a ClickResult if handled, nil otherwise.
+	HandleClick(lineInSection int) *ClickResult
+}
+
+// SectionRenderer helps render multiple sections and track their positions.
+type SectionRenderer struct {
+	lines       []string
+	sections    []sectionInfo
+	currentLine int
+}
+
+type sectionInfo struct {
+	section   Section
+	startLine int
+	lineCount int
+}
+
+// NewSectionRenderer creates a new section renderer.
+func NewSectionRenderer() *SectionRenderer {
+	return &SectionRenderer{}
+}
+
+// AddSection renders a section and tracks its position.
+func (r *SectionRenderer) AddSection(section Section, contentWidth int) {
+	content, lineCount := section.Render(contentWidth)
+	if lineCount == 0 {
+		return
+	}
+
+	r.sections = append(r.sections, sectionInfo{
+		section:   section,
+		startLine: r.currentLine,
+		lineCount: lineCount,
+	})
+
+	// Split content into lines and append
+	if content != "" {
+		r.lines = append(r.lines, strings.Split(content, "\n")...)
+	}
+	r.currentLine += lineCount
+}
+
+// AddContent adds raw content without section tracking (for legacy sections).
+func (r *SectionRenderer) AddContent(content string) {
+	if content == "" {
+		return
+	}
+	lines := strings.Split(content, "\n")
+	r.lines = append(r.lines, lines...)
+	r.currentLine += len(lines)
+}
+
+// GetLines returns all rendered lines.
+func (r *SectionRenderer) GetLines() []string {
+	return r.lines
+}
+
+// HandleClick finds which section was clicked and delegates to it.
+func (r *SectionRenderer) HandleClick(contentY int) *ClickResult {
+	for _, info := range r.sections {
+		if contentY >= info.startLine && contentY < info.startLine+info.lineCount {
+			lineInSection := contentY - info.startLine
+			return info.section.HandleClick(lineInSection)
+		}
+	}
+	return nil
+}

--- a/pkg/tui/components/sidebar/section_agents.go
+++ b/pkg/tui/components/sidebar/section_agents.go
@@ -1,0 +1,239 @@
+package sidebar
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/docker/cagent/pkg/runtime"
+	"github.com/docker/cagent/pkg/tui/styles"
+)
+
+// AgentsSection renders the agents list in the sidebar.
+type AgentsSection struct {
+	agents         []runtime.AgentDetails
+	currentAgent   string
+	agentSwitching bool
+
+	// Computed during Render for click handling
+	agentLines []agentLineInfo
+}
+
+// agentLineInfo tracks where an agent is rendered within this section.
+type agentLineInfo struct {
+	name      string
+	startLine int // relative to section start
+	lineCount int
+}
+
+// NewAgentsSection creates a new agents section.
+func NewAgentsSection(agents []runtime.AgentDetails, currentAgent string, switching bool) *AgentsSection {
+	return &AgentsSection{
+		agents:         agents,
+		currentAgent:   currentAgent,
+		agentSwitching: switching,
+	}
+}
+
+// Update updates the section state.
+func (s *AgentsSection) Update(agents []runtime.AgentDetails, currentAgent string, switching bool) {
+	s.agents = agents
+	s.currentAgent = currentAgent
+	s.agentSwitching = switching
+}
+
+// Render renders the agents section and returns content + line count.
+func (s *AgentsSection) Render(contentWidth int) (string, int) {
+	if len(s.agents) == 0 {
+		return "", 0
+	}
+
+	// Reset agent line tracking
+	s.agentLines = nil
+
+	// Build header (title line + tab body top padding)
+	suffix := ""
+	if len(s.agents) > 1 {
+		suffix = "^s"
+	}
+	header := s.renderHeader(suffix, contentWidth)
+	headerLines := strings.Split(header, "\n")
+
+	var allLines []string
+	allLines = append(allLines, headerLines...)
+
+	// Track where each agent starts (relative to section start)
+	currentLine := len(headerLines)
+
+	// Find current agent for model display
+	var currentAgentDetails runtime.AgentDetails
+	for _, agent := range s.agents {
+		if agent.Name == s.currentAgent {
+			currentAgentDetails = agent
+			break
+		}
+	}
+
+	// Render agent list (simple list, current agent highlighted)
+	for i, agent := range s.agents {
+		isCurrent := agent.Name == s.currentAgent
+		content := s.renderAgentLine(agent, isCurrent, i, contentWidth)
+
+		s.agentLines = append(s.agentLines, agentLineInfo{
+			name:      agent.Name,
+			startLine: currentLine,
+			lineCount: 1, // Each agent is now just one line
+		})
+
+		allLines = append(allLines, content)
+		currentLine++
+	}
+
+	// Add model info separately below the list
+	if currentAgentDetails.Model != "" {
+		allLines = append(allLines, "") // blank line separator
+		modelLines := s.renderModelInfo(currentAgentDetails.Model, contentWidth)
+		allLines = append(allLines, modelLines...)
+	}
+
+	// Add bottom padding
+	allLines = append(allLines, "")
+
+	return strings.Join(allLines, "\n"), len(allLines)
+}
+
+// HandleClick handles a click within this section.
+func (s *AgentsSection) HandleClick(lineInSection int) *ClickResult {
+	for _, info := range s.agentLines {
+		if lineInSection >= info.startLine && lineInSection < info.startLine+info.lineCount {
+			return &ClickResult{Type: ClickAgentSwitch, AgentName: info.name}
+		}
+	}
+	return nil
+}
+
+// renderHeader renders the section header with optional suffix.
+func (s *AgentsSection) renderHeader(suffix string, contentWidth int) string {
+	styleTitle := styles.TabTitleStyle
+
+	var titleLine string
+	if suffix != "" {
+		titleRendered := styleTitle.PaddingRight(1).Render("Agents")
+		suffixRendered := styles.MutedStyle.PaddingLeft(1).Render(suffix)
+		titleWidth := lipgloss.Width(titleRendered)
+		suffixWidth := lipgloss.Width(suffixRendered)
+		dashWidth := contentWidth - titleWidth - suffixWidth
+		if dashWidth < 1 {
+			dashWidth = 1
+		}
+		dashes := styleTitle.Render(strings.Repeat("─", dashWidth))
+		titleLine = titleRendered + dashes + suffixRendered
+	} else {
+		titleLine = lipgloss.PlaceHorizontal(contentWidth, lipgloss.Left,
+			styleTitle.PaddingRight(1).Render("Agents"),
+			lipgloss.WithWhitespaceChars("─"),
+			lipgloss.WithWhitespaceStyle(styleTitle),
+		)
+	}
+
+	// Add tab body top padding (1 blank line)
+	return titleLine + "\n"
+}
+
+// renderAgentLine renders a single agent line in the list with right-aligned shortcut.
+func (s *AgentsSection) renderAgentLine(agent runtime.AgentDetails, isCurrent bool, index, contentWidth int) string {
+	var left string
+	if isCurrent {
+		icon := "●"
+		if s.agentSwitching {
+			icon = "↔"
+		}
+		iconStyled := styles.RadioSelectedStyle.Render(icon)
+		nameStyled := styles.AgentNameSelectedStyle.Render(agent.Name)
+		left = iconStyled + " " + nameStyled
+	} else {
+		// Non-current agents: muted radio button and name
+		radio := styles.RadioUnselectedStyle.Render("○")
+		name := styles.MutedStyle.Render(agent.Name)
+		left = radio + " " + name
+	}
+
+	// Add right-aligned shortcut for agents 1-9 (index 0-8)
+	if index < 9 {
+		shortcut := styles.MutedStyle.Render("^" + string('1'+rune(index)))
+		leftWidth := lipgloss.Width(left)
+		shortcutWidth := lipgloss.Width(shortcut)
+		gap := contentWidth - leftWidth - shortcutWidth
+		if gap > 0 {
+			return left + strings.Repeat(" ", gap) + shortcut
+		}
+	}
+
+	return left
+}
+
+// renderModelInfo renders the model information with word-wrapping.
+func (s *AgentsSection) renderModelInfo(model string, contentWidth int) []string {
+	label := styles.MutedStyle.Render("Model ")
+	labelWidth := lipgloss.Width(label)
+
+	// Calculate available width for model text
+	availableWidth := contentWidth - labelWidth
+	if availableWidth < 10 {
+		availableWidth = 10
+	}
+
+	// Wrap the model text
+	wrappedLines := wrapText(model, availableWidth)
+	if len(wrappedLines) == 0 {
+		return nil
+	}
+
+	var result []string
+	// First line: label + first part of model (SecondaryStyle to stand out more)
+	result = append(result, label+styles.SecondaryStyle.Render(wrappedLines[0]))
+
+	// Subsequent lines: indent to align with model text
+	indent := strings.Repeat(" ", labelWidth)
+	for i := 1; i < len(wrappedLines); i++ {
+		result = append(result, indent+styles.SecondaryStyle.Render(wrappedLines[i]))
+	}
+
+	return result
+}
+
+// wrapText wraps text to fit within maxWidth, breaking on reasonable boundaries.
+func wrapText(text string, maxWidth int) []string {
+	if maxWidth <= 0 || text == "" {
+		return nil
+	}
+
+	// If it fits, return as-is
+	if len(text) <= maxWidth {
+		return []string{text}
+	}
+
+	var lines []string
+	remaining := text
+
+	for remaining != "" {
+		if len(remaining) <= maxWidth {
+			lines = append(lines, remaining)
+			break
+		}
+
+		// Find a good break point (prefer breaking at / or -)
+		breakAt := maxWidth
+		for i := maxWidth; i > maxWidth/2; i-- {
+			if remaining[i] == '/' || remaining[i] == '-' {
+				breakAt = i + 1 // Include the delimiter
+				break
+			}
+		}
+
+		lines = append(lines, remaining[:breakAt])
+		remaining = remaining[breakAt:]
+	}
+
+	return lines
+}

--- a/pkg/tui/components/sidebar/title_edit_test.go
+++ b/pkg/tui/components/sidebar/title_edit_test.go
@@ -98,7 +98,7 @@ func TestSidebar_HandleClickType(t *testing.T) {
 	// In vertical mode, the title line is at verticalStarY
 	// Click on the star area (adjusted x = 0-2, so raw x = 1-3)
 	result := sb.HandleClickType(paddingLeft+1, verticalStarY)
-	assert.Equal(t, ClickStar, result, "click on star area should return ClickStar")
+	assert.Equal(t, ClickStar, result.Type, "click on star area should return ClickStar")
 
 	// Set up a title with titleGenerated=true so ClickTitle can be returned
 	m.sessionTitle = "Hi"
@@ -108,16 +108,16 @@ func TestSidebar_HandleClickType(t *testing.T) {
 	// Star "☆ " = 2 chars, so title area starts at position 2
 	titleX := paddingLeft + 3 // middle of title
 	result = sb.HandleClickType(titleX, verticalStarY)
-	assert.Equal(t, ClickTitle, result, "click on title area should return ClickTitle")
+	assert.Equal(t, ClickTitle, result.Type, "click on title area should return ClickTitle")
 
 	// Click at the end (where pencil icon is) should also return ClickTitle
 	pencilX := paddingLeft + 4
 	result = sb.HandleClickType(pencilX, verticalStarY)
-	assert.Equal(t, ClickTitle, result, "click on pencil icon area should return ClickTitle")
+	assert.Equal(t, ClickTitle, result.Type, "click on pencil icon area should return ClickTitle")
 
 	// Click elsewhere (wrong y)
 	result = sb.HandleClickType(10, 0)
-	assert.Equal(t, ClickNone, result, "click elsewhere should return ClickNone")
+	assert.Equal(t, ClickNone, result.Type, "click elsewhere should return ClickNone")
 }
 
 func TestSidebar_TitleRegenerating(t *testing.T) {
@@ -174,15 +174,15 @@ func TestSidebar_HandleClickType_WrappedTitle_Collapsed(t *testing.T) {
 
 	// Click on line 0 (first title line) after star should return ClickTitle
 	result := sb.HandleClickType(paddingLeft+3, 0)
-	assert.Equal(t, ClickTitle, result, "click on first title line should return ClickTitle")
+	assert.Equal(t, ClickTitle, result.Type, "click on first title line should return ClickTitle")
 
 	// Click on line 1 (wrapped title line) should also return ClickTitle
 	result = sb.HandleClickType(paddingLeft+1, 1)
-	assert.Equal(t, ClickTitle, result, "click on wrapped title line should return ClickTitle")
+	assert.Equal(t, ClickTitle, result.Type, "click on wrapped title line should return ClickTitle")
 
 	// Star should still be clickable on line 0
 	result = sb.HandleClickType(paddingLeft+1, 0)
-	assert.Equal(t, ClickStar, result, "star should still be clickable on line 0")
+	assert.Equal(t, ClickStar, result.Type, "star should still be clickable on line 0")
 }
 
 func TestSidebar_HandleClickType_WrappedTitle_Vertical(t *testing.T) {
@@ -212,15 +212,15 @@ func TestSidebar_HandleClickType_WrappedTitle_Vertical(t *testing.T) {
 	// In vertical mode, title starts at verticalStarY
 	// Click on verticalStarY (first title line) after star should return ClickTitle
 	result := sb.HandleClickType(paddingLeft+3, verticalStarY)
-	assert.Equal(t, ClickTitle, result, "click on first title line should return ClickTitle")
+	assert.Equal(t, ClickTitle, result.Type, "click on first title line should return ClickTitle")
 
 	// Click on verticalStarY+1 (wrapped title line) should also return ClickTitle
 	result = sb.HandleClickType(paddingLeft+1, verticalStarY+1)
-	assert.Equal(t, ClickTitle, result, "click on wrapped title line should return ClickTitle")
+	assert.Equal(t, ClickTitle, result.Type, "click on wrapped title line should return ClickTitle")
 
 	// Star should still be clickable on verticalStarY
 	result = sb.HandleClickType(paddingLeft+1, verticalStarY)
-	assert.Equal(t, ClickStar, result, "star should still be clickable on verticalStarY")
+	assert.Equal(t, ClickStar, result.Type, "star should still be clickable on verticalStarY")
 }
 
 func TestSidebar_HandleClickType_NoWrap(t *testing.T) {
@@ -249,9 +249,9 @@ func TestSidebar_HandleClickType_NoWrap(t *testing.T) {
 
 	// Click on the title area should return ClickTitle
 	result := sb.HandleClickType(paddingLeft+3, verticalStarY)
-	assert.Equal(t, ClickTitle, result, "click on title should return ClickTitle")
+	assert.Equal(t, ClickTitle, result.Type, "click on title should return ClickTitle")
 
 	// Star should still be clickable
 	result = sb.HandleClickType(paddingLeft+1, verticalStarY)
-	assert.Equal(t, ClickStar, result, "star should still be clickable")
+	assert.Equal(t, ClickStar, result.Type, "star should still be clickable")
 }

--- a/pkg/tui/components/tab/tab.go
+++ b/pkg/tui/components/tab/tab.go
@@ -1,22 +1,47 @@
 package tab
 
 import (
+	"strings"
+
 	"charm.land/lipgloss/v2"
 
 	"github.com/docker/cagent/pkg/tui/styles"
 )
 
 func Render(title, content string, width int) string {
+	return RenderWithSuffix(title, "", content, width)
+}
+
+// RenderWithSuffix renders a tab with an optional right-aligned suffix on the title line.
+func RenderWithSuffix(title, suffix, content string, width int) string {
 	styleTitle := styles.TabTitleStyle
 	styleBody := styles.TabStyle
 
+	// Build the title line with optional suffix
+	var titleLine string
+	if suffix != "" {
+		// Calculate available space for the dash fill between title and suffix
+		titleRendered := styleTitle.PaddingRight(1).Render(title)
+		suffixRendered := styles.MutedStyle.PaddingLeft(1).Render(suffix)
+		titleWidth := lipgloss.Width(titleRendered)
+		suffixWidth := lipgloss.Width(suffixRendered)
+		dashWidth := width - titleWidth - suffixWidth
+		if dashWidth < 1 {
+			dashWidth = 1
+		}
+		dashes := styleTitle.Render(strings.Repeat("─", dashWidth))
+		titleLine = titleRendered + dashes + suffixRendered
+	} else {
+		titleLine = lipgloss.PlaceHorizontal(width, lipgloss.Left,
+			styleTitle.PaddingRight(1).Render(title),
+			lipgloss.WithWhitespaceChars("─"),
+			lipgloss.WithWhitespaceStyle(styleTitle),
+		)
+	}
+
 	return styles.NoStyle.PaddingBottom(1).Render(
 		lipgloss.JoinVertical(lipgloss.Top,
-			lipgloss.PlaceHorizontal(width, lipgloss.Left,
-				styleTitle.PaddingRight(1).Render(title),
-				lipgloss.WithWhitespaceChars("─"),
-				lipgloss.WithWhitespaceStyle(styleTitle),
-			),
+			titleLine,
 			styles.RenderComposite(styleBody.Width(width), content),
 		),
 	)

--- a/pkg/tui/dialog/agent_picker.go
+++ b/pkg/tui/dialog/agent_picker.go
@@ -1,0 +1,802 @@
+package dialog
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/docker/cagent/pkg/runtime"
+	"github.com/docker/cagent/pkg/tui/components/scrollbar"
+	"github.com/docker/cagent/pkg/tui/core"
+	"github.com/docker/cagent/pkg/tui/core/layout"
+	"github.com/docker/cagent/pkg/tui/messages"
+	"github.com/docker/cagent/pkg/tui/styles"
+)
+
+const (
+	agentPickerMinWidth   = 60
+	agentPickerMaxWidth   = 130
+	agentDoubleClickDelay = 400 * time.Millisecond
+
+	agentPickerHeightPercent = 70
+	agentPickerMaxHeight     = 200
+
+	// agentPickerListOverhead is the number of rows used by dialog chrome:
+	// title(1) + separator(1) + space(1) + help(1) + borders/padding(4) = 8
+	agentPickerListOverhead = 8
+
+	// agentPickerListStartOffset is the Y offset from dialog top to where the agent list starts:
+	// border(1) + padding(1) + title(1) + separator(1) = 4
+	agentPickerListStartOffset = 4
+
+	// agentPickerScrollbarXInset is the inset from dialog right edge for the scrollbar.
+	// This matches border(1) + horizontal padding(2) = 3.
+	agentPickerScrollbarXInset = 3
+
+	agentPickerScrollbarGap = 1
+
+	// minLengthForEllipsis is the minimum string length required before truncating with ellipsis.
+	minLengthForEllipsis = 3
+
+	// pageJumpSize is the number of items to skip when using PgUp/PgDown.
+	pageJumpSize = 5
+
+	// minCardWidth is the minimum width for agent cards to prevent overly narrow rendering.
+	minCardWidth = 10
+
+	// descPreviewLength is the maximum description length used for dialog width calculation.
+	descPreviewLength = 60
+
+	// Layout constants for agent card rendering
+	cardPrefixWidth    = 4 // Radio selector + spaces
+	cardNameModelGap   = 2 // Space between name and model
+	cardShortcutWidth  = 6 // Shortcut display width + padding
+	cardIndent         = 4 // Indent for description, model, tools lines
+	cardToolsetIndent  = 2 // Additional indent for toolset names
+	cardToolNameIndent = 4 // Additional indent for individual tool names
+
+	// screenMargin is the margin to keep from screen edges when sizing dialog.
+	screenMargin = 8
+
+	// scrollAdjustment is the offset adjustment when scrolling to keep selection visible.
+	scrollAdjustment = 1
+
+	// contentWidthPadding is the padding parameter for content width calculation.
+	contentWidthPadding = 2
+
+	// maxKeyboardShortcuts is the maximum number of Ctrl+N shortcuts (Ctrl+1 through Ctrl+9).
+	maxKeyboardShortcuts = 9
+
+	// indexDisplayOffset converts 0-based index to 1-based display number.
+	indexDisplayOffset = 1
+
+	// minVisibleLines is the minimum number of lines to display in the agent list.
+	minVisibleLines = 1
+
+	// minGapBetweenNameAndShortcut is the minimum space between agent name and shortcut.
+	minGapBetweenNameAndShortcut = 1
+
+	// maxDescriptionLines is the maximum number of lines to show for wrapped descriptions.
+	maxDescriptionLines = 2
+
+	// ellipsisReservedSpace is the number of characters to reserve for ellipsis when truncating.
+	ellipsisReservedSpace = 1
+)
+
+type agentPickerDialog struct {
+	BaseDialog
+	agents        []runtime.AgentDetails
+	currentAgent  string
+	selected      int
+	keyMap        agentPickerKeyMap
+	lastClickTime time.Time
+	lastClickIdx  int
+
+	scrollbar        *scrollbar.Model
+	needsScrollToSel bool
+	lineToAgent      []int // maps rendered line index -> agent index (-1 for separators)
+
+	expandedTools map[int]bool // tracks which agents have their tools section expanded
+	toolsLineY    map[int]int  // maps agent index -> Y offset of "Tools:" line within card (for click detection)
+}
+
+type agentPickerKeyMap struct {
+	Enter  key.Binding
+	Escape key.Binding
+	Up     key.Binding
+	Down   key.Binding
+	PgUp   key.Binding
+	PgDown key.Binding
+	Home   key.Binding
+	End    key.Binding
+}
+
+func defaultAgentPickerKeyMap() agentPickerKeyMap {
+	return agentPickerKeyMap{
+		Enter:  key.NewBinding(key.WithKeys("enter")),
+		Escape: key.NewBinding(key.WithKeys("esc")),
+		Up:     key.NewBinding(key.WithKeys("up", "k")),
+		Down:   key.NewBinding(key.WithKeys("down", "j")),
+		PgUp:   key.NewBinding(key.WithKeys("pgup")),
+		PgDown: key.NewBinding(key.WithKeys("pgdown")),
+		Home:   key.NewBinding(key.WithKeys("home")),
+		End:    key.NewBinding(key.WithKeys("end")),
+	}
+}
+
+// NewAgentPickerDialog creates a dialog for selecting an agent.
+func NewAgentPickerDialog(agents []runtime.AgentDetails, currentAgent string) Dialog {
+	d := &agentPickerDialog{
+		agents:        agents,
+		currentAgent:  currentAgent,
+		selected:      0,
+		keyMap:        defaultAgentPickerKeyMap(),
+		lastClickIdx:  -1,
+		scrollbar:     scrollbar.New(),
+		expandedTools: make(map[int]bool),
+		toolsLineY:    make(map[int]int),
+	}
+	// Pre-select the current agent if found
+	for i, agent := range agents {
+		if agent.Name == currentAgent {
+			d.selected = i
+			d.needsScrollToSel = true // Ensure current agent is visible on open
+			break
+		}
+	}
+	return d
+}
+
+func (d *agentPickerDialog) Init() tea.Cmd {
+	return nil
+}
+
+func (d *agentPickerDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		cmd := d.SetSize(msg.Width, msg.Height)
+		return d, cmd
+
+	case *runtime.TeamInfoEvent:
+		// Update agent list with new data (including updated tool loading status)
+		d.updateAgents(msg.AvailableAgents)
+		return d, nil
+
+	case tea.KeyPressMsg:
+		if cmd := HandleQuit(msg); cmd != nil {
+			return d, cmd
+		}
+		return d.handleKeyPress(msg)
+
+	case tea.MouseClickMsg:
+		return d.handleMouseClick(msg)
+
+	case tea.MouseMotionMsg:
+		return d.handleMouseMotion(msg)
+
+	case tea.MouseReleaseMsg:
+		return d.handleMouseRelease(msg)
+
+	case tea.MouseWheelMsg:
+		return d.handleMouseWheel(msg)
+	}
+
+	return d, nil
+}
+
+// updateAgents updates the agent list while preserving UI state (selection, expanded tools, etc.)
+func (d *agentPickerDialog) updateAgents(agents []runtime.AgentDetails) {
+	// Preserve the selected agent name to re-select after update
+	var selectedAgentName string
+	if d.selected >= 0 && d.selected < len(d.agents) {
+		selectedAgentName = d.agents[d.selected].Name
+	}
+
+	// Update agents
+	d.agents = agents
+
+	// Restore selection by name
+	d.selected = 0
+	for i, agent := range d.agents {
+		if agent.Name == selectedAgentName {
+			d.selected = i
+			break
+		}
+	}
+
+	// Clear line mapping so it gets rebuilt on next render
+	d.lineToAgent = nil
+}
+
+func (d *agentPickerDialog) handleKeyPress(msg tea.KeyPressMsg) (layout.Model, tea.Cmd) {
+	// Check for Ctrl+number shortcuts
+	if msg.Mod == tea.ModCtrl && msg.Code >= '1' && msg.Code <= '9' {
+		index := int(msg.Code - '1')
+		if index >= 0 && index < len(d.agents) {
+			return d.selectAgent(index)
+		}
+		return d, nil
+	}
+
+	switch {
+	case key.Matches(msg, d.keyMap.Escape):
+		return d, core.CmdHandler(CloseDialogMsg{})
+
+	case key.Matches(msg, d.keyMap.Enter):
+		if d.selected >= 0 && d.selected < len(d.agents) {
+			return d.selectAgent(d.selected)
+		}
+		return d, nil
+
+	case key.Matches(msg, d.keyMap.Up):
+		if d.selected > 0 {
+			d.selected--
+			d.needsScrollToSel = true
+		}
+		return d, nil
+
+	case key.Matches(msg, d.keyMap.Down):
+		if d.selected < len(d.agents)-1 {
+			d.selected++
+			d.needsScrollToSel = true
+		}
+		return d, nil
+
+	case key.Matches(msg, d.keyMap.PgUp):
+		d.selected = max(0, d.selected-pageJumpSize)
+		d.needsScrollToSel = true
+		return d, nil
+
+	case key.Matches(msg, d.keyMap.PgDown):
+		d.selected = min(len(d.agents)-1, d.selected+pageJumpSize)
+		d.needsScrollToSel = true
+		return d, nil
+
+	case key.Matches(msg, d.keyMap.Home):
+		d.selected = 0
+		d.needsScrollToSel = true
+		return d, nil
+
+	case key.Matches(msg, d.keyMap.End):
+		d.selected = len(d.agents) - 1
+		d.needsScrollToSel = true
+		return d, nil
+	}
+
+	return d, nil
+}
+
+func (d *agentPickerDialog) selectAgent(index int) (layout.Model, tea.Cmd) {
+	if index < 0 || index >= len(d.agents) {
+		return d, nil
+	}
+
+	agentName := d.agents[index].Name
+	if agentName == d.currentAgent {
+		// Already selected, just close
+		return d, core.CmdHandler(CloseDialogMsg{})
+	}
+
+	return d, tea.Sequence(
+		core.CmdHandler(CloseDialogMsg{}),
+		core.CmdHandler(messages.SwitchAgentMsg{AgentName: agentName}),
+	)
+}
+
+func (d *agentPickerDialog) handleMouseClick(msg tea.MouseClickMsg) (layout.Model, tea.Cmd) {
+	// Check if click is on the scrollbar
+	if d.isMouseOnScrollbar(msg.X, msg.Y) {
+		sb, cmd := d.scrollbar.Update(msg)
+		d.scrollbar = sb
+		return d, cmd
+	}
+
+	// Only respond to left clicks inside the dialog
+	if msg.Button != tea.MouseLeft || !d.isMouseInDialog(msg.X, msg.Y) {
+		return d, nil
+	}
+
+	agentIdx := d.mouseYToAgentIndex(msg.Y)
+	if agentIdx < 0 || agentIdx >= len(d.agents) {
+		return d, nil
+	}
+
+	// Check if click is on the "Tools:" line to toggle expansion
+	if d.isClickOnToolsLine(msg.Y, agentIdx) {
+		d.expandedTools[agentIdx] = !d.expandedTools[agentIdx]
+		return d, nil
+	}
+
+	now := time.Now()
+	if agentIdx == d.lastClickIdx && now.Sub(d.lastClickTime) < agentDoubleClickDelay {
+		// Double-click - select immediately
+		d.lastClickTime = time.Time{}
+		d.lastClickIdx = -1
+		return d.selectAgent(agentIdx)
+	}
+
+	// Single click - highlight
+	d.selected = agentIdx
+	d.needsScrollToSel = true
+	d.lastClickTime = now
+	d.lastClickIdx = agentIdx
+
+	return d, nil
+}
+
+func (d *agentPickerDialog) handleMouseMotion(msg tea.MouseMotionMsg) (layout.Model, tea.Cmd) {
+	if d.scrollbar.IsDragging() {
+		sb, cmd := d.scrollbar.Update(msg)
+		d.scrollbar = sb
+		return d, cmd
+	}
+	return d, nil
+}
+
+func (d *agentPickerDialog) handleMouseRelease(msg tea.MouseReleaseMsg) (layout.Model, tea.Cmd) {
+	if d.scrollbar.IsDragging() {
+		sb, cmd := d.scrollbar.Update(msg)
+		d.scrollbar = sb
+		return d, cmd
+	}
+	return d, nil
+}
+
+func (d *agentPickerDialog) handleMouseWheel(msg tea.MouseWheelMsg) (layout.Model, tea.Cmd) {
+	// Only scroll if mouse is inside the dialog
+	if !d.isMouseInDialog(msg.X, msg.Y) {
+		return d, nil
+	}
+
+	switch msg.Button.String() {
+	case "wheelup":
+		d.scrollbar.ScrollUp()
+		d.scrollbar.ScrollUp()
+	case "wheeldown":
+		d.scrollbar.ScrollDown()
+		d.scrollbar.ScrollDown()
+	}
+	return d, nil
+}
+
+func (d *agentPickerDialog) isMouseInDialog(x, y int) bool {
+	dialogRow, dialogCol := d.Position()
+	dialogWidth, maxHeight, _ := d.dialogSize()
+	return x >= dialogCol && x < dialogCol+dialogWidth &&
+		y >= dialogRow && y < dialogRow+maxHeight
+}
+
+func (d *agentPickerDialog) isMouseOnScrollbar(x, y int) bool {
+	dialogWidth, maxHeight, contentWidth := d.dialogSize()
+	visibleLines := d.visibleLines(maxHeight)
+	cardWidth := max(minCardWidth, contentWidth-agentPickerScrollbarGap-scrollbar.Width)
+
+	// Ensure we have up-to-date line mapping for correct total line count
+	if d.lineToAgent == nil {
+		_, d.lineToAgent = d.buildLines(cardWidth)
+	}
+	if len(d.lineToAgent) <= visibleLines {
+		return false // No scrollbar when content fits
+	}
+
+	dialogRow, dialogCol := d.Position()
+	scrollbarX := dialogCol + dialogWidth - agentPickerScrollbarXInset - scrollbar.Width
+	scrollbarY := dialogRow + agentPickerListStartOffset
+
+	return x >= scrollbarX && x < scrollbarX+scrollbar.Width &&
+		y >= scrollbarY && y < scrollbarY+visibleLines
+}
+
+// mouseYToAgentIndex converts a mouse Y position to an agent index.
+// Returns -1 if the position is outside the list.
+func (d *agentPickerDialog) mouseYToAgentIndex(y int) int {
+	dialogRow, _ := d.Position()
+	_, maxHeight, contentWidth := d.dialogSize()
+	visibleLines := d.visibleLines(maxHeight)
+
+	listStartY := dialogRow + agentPickerListStartOffset
+	if y < listStartY || y >= listStartY+visibleLines {
+		return -1
+	}
+
+	// Ensure lineToAgent is initialized (may be nil before first View call)
+	if d.lineToAgent == nil {
+		cardWidth := max(minCardWidth, contentWidth-agentPickerScrollbarGap-scrollbar.Width)
+		_, d.lineToAgent = d.buildLines(cardWidth)
+	}
+
+	lineInView := y - listStartY
+	actualLine := d.scrollbar.GetScrollOffset() + lineInView
+	if actualLine < 0 || actualLine >= len(d.lineToAgent) {
+		return -1
+	}
+
+	return d.lineToAgent[actualLine]
+}
+
+// isClickOnToolsLine checks if the click is on the "Tools:" line for the given agent.
+func (d *agentPickerDialog) isClickOnToolsLine(y, agentIdx int) bool {
+	dialogRow, _ := d.Position()
+	listStartY := dialogRow + agentPickerListStartOffset
+	scrollOffset := d.scrollbar.GetScrollOffset()
+
+	// Get the line index within the full content
+	lineInView := y - listStartY
+	actualLine := scrollOffset + lineInView
+
+	// Check if this agent has a toolsLineY entry and if it matches
+	if toolsLine, ok := d.toolsLineY[agentIdx]; ok {
+		// toolsLineY stores the absolute line index within the content
+		return actualLine == toolsLine
+	}
+	return false
+}
+
+func (d *agentPickerDialog) computeDialogWidthInternal() int {
+	// Calculate width needed to fit content without truncation
+	maxNameLen := 0
+	maxModelLen := 0
+	maxDescLen := 0
+
+	for _, agent := range d.agents {
+		if len(agent.Name) > maxNameLen {
+			maxNameLen = len(agent.Name)
+		}
+		if len(agent.Model) > maxModelLen {
+			maxModelLen = len(agent.Model)
+		}
+		// Take first descPreviewLength chars of description for width calculation
+		desc := agent.Description
+		if len(desc) > descPreviewLength {
+			desc = desc[:descPreviewLength]
+		}
+		if len(desc) > maxDescLen {
+			maxDescLen = len(desc)
+		}
+	}
+
+	// Calculate required width: prefix + name + gap + model + shortcut width
+	contentWidth := cardPrefixWidth + maxNameLen + cardNameModelGap + maxModelLen + cardShortcutWidth
+	// Also consider description width
+	descWidth := cardIndent + maxDescLen
+
+	neededWidth := max(contentWidth, descWidth)
+
+	// Add dialog frame size
+	frameWidth := styles.DialogStyle.GetHorizontalFrameSize()
+	dialogWidth := neededWidth + frameWidth + agentPickerScrollbarGap + scrollbar.Width
+
+	// Apply bounds
+	dialogWidth = max(agentPickerMinWidth, dialogWidth)
+
+	// Don't exceed screen or max width
+	maxWidth := min(agentPickerMaxWidth, d.Width()-screenMargin)
+	dialogWidth = min(dialogWidth, maxWidth)
+
+	return dialogWidth
+}
+
+func (d *agentPickerDialog) View() string {
+	dialogWidth, maxHeight, contentWidth := d.dialogSize()
+	visibleLines := d.visibleLines(maxHeight)
+
+	cardWidth := max(minCardWidth, contentWidth-agentPickerScrollbarGap-scrollbar.Width)
+
+	// Build all rendered lines and mapping
+	allLines, lineToAgent := d.buildLines(cardWidth)
+	d.lineToAgent = lineToAgent
+
+	totalLines := len(allLines)
+	d.scrollbar.SetDimensions(visibleLines, totalLines)
+
+	// Auto-scroll to selection when keyboard navigation occurred
+	if d.needsScrollToSel {
+		selectedLine := d.findSelectedLine(lineToAgent)
+		scrollOffset := d.scrollbar.GetScrollOffset()
+		if selectedLine < scrollOffset {
+			d.scrollbar.SetScrollOffset(selectedLine)
+		} else if selectedLine >= scrollOffset+visibleLines {
+			d.scrollbar.SetScrollOffset(selectedLine - visibleLines + scrollAdjustment)
+		}
+		d.needsScrollToSel = false
+	}
+
+	// Slice visible lines based on scroll offset
+	scrollOffset := d.scrollbar.GetScrollOffset()
+	visibleEnd := min(scrollOffset+visibleLines, totalLines)
+	var visibleAgentLines []string
+	if totalLines > 0 {
+		visibleAgentLines = allLines[scrollOffset:visibleEnd]
+	}
+
+	// Pad with empty lines if content is shorter than visible area
+	for len(visibleAgentLines) < visibleLines {
+		visibleAgentLines = append(visibleAgentLines, "")
+	}
+
+	// Handle empty state
+	if len(d.agents) == 0 {
+		visibleAgentLines = []string{"", styles.DialogContentStyle.
+			Italic(true).
+			Align(lipgloss.Center).
+			Width(cardWidth).
+			Render("No agents found")}
+		for len(visibleAgentLines) < visibleLines {
+			visibleAgentLines = append(visibleAgentLines, "")
+		}
+	}
+
+	// Build list with fixed width to keep scrollbar position stable
+	listLineStyle := lipgloss.NewStyle().Width(cardWidth)
+	fixedWidthLines := make([]string, len(visibleAgentLines))
+	for i, line := range visibleAgentLines {
+		fixedWidthLines[i] = listLineStyle.Render(line)
+	}
+	listContent := strings.Join(fixedWidthLines, "\n")
+
+	// Set scrollbar position for mouse hit testing
+	dialogRow, dialogCol := d.Position()
+	scrollbarX := dialogCol + dialogWidth - agentPickerScrollbarXInset - scrollbar.Width
+	scrollbarY := dialogRow + agentPickerListStartOffset
+	d.scrollbar.SetPosition(scrollbarX, scrollbarY)
+
+	// Get scrollbar view (or placeholder for consistent layout)
+	scrollbarView := d.scrollbar.View()
+	if scrollbarView == "" {
+		scrollbarView = strings.Repeat(" ", scrollbar.Width)
+	}
+
+	scrollableContent := lipgloss.JoinHorizontal(
+		lipgloss.Top,
+		listContent,
+		strings.Repeat(" ", agentPickerScrollbarGap),
+		scrollbarView,
+	)
+
+	content := NewContent(cardWidth+agentPickerScrollbarGap+scrollbar.Width).
+		AddTitle("Agents").
+		AddSeparator().
+		AddContent(scrollableContent).
+		AddSpace().
+		AddHelpKeys("↑/↓", "navigate", "enter", "switch", "esc", "cancel").
+		Build()
+
+	return styles.DialogStyle.Width(dialogWidth).Render(content)
+}
+
+func (d *agentPickerDialog) dialogSize() (dialogWidth, maxHeight, contentWidth int) {
+	dialogWidth = d.computeDialogWidthInternal()
+	maxHeight = min(d.Height()*agentPickerHeightPercent/100, agentPickerMaxHeight)
+	contentWidth = d.ContentWidth(dialogWidth, contentWidthPadding)
+	return dialogWidth, maxHeight, contentWidth
+}
+
+func (d *agentPickerDialog) visibleLines(maxHeight int) int {
+	return max(minVisibleLines, maxHeight-agentPickerListOverhead)
+}
+
+func (d *agentPickerDialog) buildLines(cardWidth int) (lines []string, lineToAgent []int) {
+	d.toolsLineY = make(map[int]int)
+
+	lastIdx := len(d.agents) - 1
+	for i, agent := range d.agents {
+		cardStartLine := len(lines)
+		card, toolsLineOffset := d.renderAgentCard(agent, i, cardWidth)
+		cardLines := strings.Split(card, "\n")
+
+		// for click detection
+		if toolsLineOffset >= 0 {
+			d.toolsLineY[i] = cardStartLine + toolsLineOffset
+		}
+
+		for _, l := range cardLines {
+			lines = append(lines, l)
+			lineToAgent = append(lineToAgent, i)
+		}
+		// Add separator between cards, or trailing blank for last card
+		// Map separator lines so clicking near an agent selects it:
+		// - blank line after card → belongs to card above
+		// - separator line → belongs to card above
+		// - blank line before next card → belongs to card below
+		if i < lastIdx {
+			// Blank line, subtle separator, blank line
+			separator := styles.MutedStyle.Render(strings.Repeat("─", cardWidth))
+			lines = append(lines, "", separator, "")
+			lineToAgent = append(lineToAgent, i, i, i+1)
+		} else {
+			// Trailing blank line for last card so clicking below it still selects it
+			lines = append(lines, "")
+			lineToAgent = append(lineToAgent, i)
+		}
+	}
+	return lines, lineToAgent
+}
+
+func (d *agentPickerDialog) findSelectedLine(lineToAgent []int) int {
+	if d.selected < 0 || d.selected >= len(d.agents) {
+		return 0
+	}
+	for i, idx := range lineToAgent {
+		if idx == d.selected {
+			return i
+		}
+	}
+	return 0
+}
+
+func (d *agentPickerDialog) renderAgentCard(agent runtime.AgentDetails, index, contentWidth int) (string, int) {
+	isSelected := index == d.selected
+	indent := strings.Repeat(" ", cardIndent)
+
+	// Build shortcut hint
+	shortcut := ""
+	if index < maxKeyboardShortcuts {
+		shortcut = fmt.Sprintf("^%d", index+indexDisplayOffset)
+	}
+
+	// Line 1: Radio selector + Name + Shortcut (right-aligned)
+	var selector string
+	var nameStyle lipgloss.Style
+
+	if isSelected {
+		selector = styles.RadioSelectedStyle.Render("●") + " "
+		nameStyle = styles.AgentNameSelectedStyle
+	} else {
+		selector = styles.RadioUnselectedStyle.Render("○") + " "
+		nameStyle = styles.AgentNameUnselectedStyle
+	}
+
+	namePart := selector + nameStyle.Render(agent.Name)
+	nameWidth := lipgloss.Width(namePart)
+	shortcutWidth := lipgloss.Width(shortcut)
+
+	gap := contentWidth - nameWidth - shortcutWidth
+	if gap < minGapBetweenNameAndShortcut {
+		gap = minGapBetweenNameAndShortcut
+	}
+	line1 := namePart + strings.Repeat(" ", gap) + styles.MutedStyle.Render(shortcut)
+
+	var lines []string
+	lines = append(lines, line1)
+
+	// Desc: line (if description present)
+	if agent.Description != "" {
+		descLabel := "Desc:  "
+		descLabelWidth := len(descLabel)
+		maxDescWidth := contentWidth - cardIndent - descLabelWidth
+		descLines := wrapText(agent.Description, maxDescWidth, maxDescriptionLines)
+		for i, dl := range descLines {
+			if i == 0 {
+				lines = append(lines, indent+styles.AgentDescLabelStyle.Render(descLabel)+styles.AgentDescValueStyle.Render(dl))
+			} else {
+				// Indent continuation lines by label width
+				lines = append(lines, indent+strings.Repeat(" ", descLabelWidth)+styles.AgentDescValueStyle.Render(dl))
+			}
+		}
+	}
+
+	// Model: line
+	var modelValue string
+	switch {
+	case agent.Provider != "" && agent.Model != "":
+		modelValue = agent.Provider + "/" + agent.Model
+	case agent.Model != "":
+		modelValue = agent.Model
+	case agent.Provider != "":
+		modelValue = agent.Provider
+	}
+	if modelValue != "" {
+		modelLabel := "Model: "
+		lines = append(lines, indent+styles.AgentModelLabelStyle.Render(modelLabel)+styles.AgentModelValueStyle.Render(modelValue))
+	}
+
+	// Tools: line with expand indicator or loading indicator
+	toolsLineOffset := -1
+	if agent.ToolsLoading {
+		// Tools are still being loaded - show loading indicator
+		toolsLabel := "Tools: "
+		lines = append(lines, indent+styles.AgentToolsLabelStyle.Render(toolsLabel)+styles.MutedStyle.Italic(true).Render("loading..."))
+	} else if agent.TotalTools > 0 || len(agent.Toolsets) > 0 {
+		toolsLabel := "Tools: "
+		toolsValue := fmt.Sprintf("%d", agent.TotalTools)
+
+		expandIndicator := ""
+		if d.expandedTools[index] {
+			expandIndicator = " " + styles.AgentToolsExpanderStyle.Render("[-]")
+		} else {
+			expandIndicator = " " + styles.AgentToolsExpanderStyle.Render("[+]")
+		}
+
+		toolsLineOffset = len(lines)
+		lines = append(lines, indent+styles.AgentToolsLabelStyle.Render(toolsLabel)+styles.AgentToolsValueStyle.Render(toolsValue)+expandIndicator)
+
+		// If expanded, show toolsets and their tools directly under Tools:
+		if d.expandedTools[index] {
+			if len(agent.Toolsets) > 0 {
+				for _, ts := range agent.Toolsets {
+					// Toolset name with count
+					tsHeader := fmt.Sprintf("%s [%d]:", ts.Name, ts.ToolCount)
+					lines = append(lines, indent+strings.Repeat(" ", cardToolsetIndent)+styles.AgentToolsetNameStyle.Render(tsHeader))
+					// Individual tool names
+					for _, toolName := range ts.ToolNames {
+						lines = append(lines, indent+strings.Repeat(" ", cardToolNameIndent)+styles.AgentToolNameStyle.Render("- "+toolName))
+					}
+				}
+			} else {
+				lines = append(lines, indent+styles.MutedStyle.Render(strings.Repeat(" ", cardToolsetIndent)+"(toolset details loading...)"))
+			}
+		}
+	}
+
+	return strings.Join(lines, "\n"), toolsLineOffset
+}
+
+// wrapText wraps text to fit within maxWidth, returning at most maxLines lines.
+func wrapText(text string, maxWidth, maxLines int) []string {
+	if maxWidth <= 0 || text == "" {
+		return nil
+	}
+
+	words := strings.Fields(text)
+	if len(words) == 0 {
+		return nil
+	}
+
+	var lines []string
+	var currentLine strings.Builder
+
+	for _, word := range words {
+		switch {
+		case currentLine.Len() == 0:
+			if len(word) > maxWidth {
+				// Word too long, truncate it
+				lines = append(lines, word[:maxWidth-ellipsisReservedSpace]+"…")
+				if len(lines) >= maxLines {
+					return lines
+				}
+				continue
+			}
+			currentLine.WriteString(word)
+		case currentLine.Len()+1+len(word) <= maxWidth:
+			// Word fits on current line
+			currentLine.WriteString(" ")
+			currentLine.WriteString(word)
+		default:
+			// Word doesn't fit, start new line
+			lines = append(lines, currentLine.String())
+			if len(lines) >= maxLines {
+				// We're at max lines, add ellipsis to last line if there's more content
+				last := lines[len(lines)-1]
+				if len(last) > minLengthForEllipsis {
+					lines[len(lines)-1] = last[:len(last)-ellipsisReservedSpace] + "…"
+				}
+				return lines
+			}
+			currentLine.Reset()
+			if len(word) > maxWidth {
+				lines = append(lines, word[:maxWidth-ellipsisReservedSpace]+"…")
+				if len(lines) >= maxLines {
+					return lines
+				}
+			} else {
+				currentLine.WriteString(word)
+			}
+		}
+	}
+
+	// Don't forget the last line
+	if currentLine.Len() > 0 && len(lines) < maxLines {
+		lines = append(lines, currentLine.String())
+	}
+
+	return lines
+}
+
+func (d *agentPickerDialog) Position() (row, col int) {
+	dialogWidth, maxHeight, _ := d.dialogSize()
+	return CenterPosition(d.Width(), d.Height(), dialogWidth, maxHeight)
+}

--- a/pkg/tui/dialog/agent_picker_test.go
+++ b/pkg/tui/dialog/agent_picker_test.go
@@ -1,0 +1,63 @@
+package dialog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWrapText(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		text     string
+		maxWidth int
+		maxLines int
+		expected []string
+	}{
+		{
+			name:     "empty text",
+			text:     "",
+			maxWidth: 50,
+			maxLines: 3,
+			expected: nil,
+		},
+		{
+			name:     "single word fits",
+			text:     "hello",
+			maxWidth: 50,
+			maxLines: 3,
+			expected: []string{"hello"},
+		},
+		{
+			name:     "multiple words on one line",
+			text:     "hello world",
+			maxWidth: 50,
+			maxLines: 3,
+			expected: []string{"hello world"},
+		},
+		{
+			name:     "words wrap to multiple lines",
+			text:     "hello world this is a test",
+			maxWidth: 12,
+			maxLines: 3,
+			expected: []string{"hello world", "this is a", "test"},
+		},
+		{
+			name:     "max lines truncation",
+			text:     "one two three four five six seven",
+			maxWidth: 10,
+			maxLines: 2,
+			expected: []string{"one two", "three fou…"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := wrapText(tt.text, tt.maxWidth, tt.maxLines)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -233,27 +233,10 @@ func (a *appModel) handleSwitchAgent(agentName string) (tea.Model, tea.Cmd) {
 	}
 
 	a.sessionState.SetCurrentAgentName(agentName)
-	return a, notification.SuccessCmd(fmt.Sprintf("Switched to agent '%s'", agentName))
-}
-
-func (a *appModel) handleCycleAgent() (tea.Model, tea.Cmd) {
-	availableAgents := a.sessionState.AvailableAgents()
-	if len(availableAgents) <= 1 {
-		return a, notification.InfoCmd("No other agents available")
-	}
-
-	// Find the current agent index
-	currentIndex := -1
-	for i, agent := range availableAgents {
-		if agent.Name == a.sessionState.CurrentAgentName() {
-			currentIndex = i
-			break
-		}
-	}
-
-	// Cycle to the next agent (wrap around to 0 if at the end)
-	nextIndex := (currentIndex + 1) % len(availableAgents)
-	return a.handleSwitchToAgentByIndex(nextIndex)
+	return a, tea.Batch(
+		notification.SuccessCmd(fmt.Sprintf("Switched to agent '%s'", agentName)),
+		func() tea.Msg { return messages.AgentSwitchedMsg{AgentName: agentName} },
+	)
 }
 
 func (a *appModel) handleSwitchToAgentByIndex(index int) (tea.Model, tea.Cmd) {

--- a/pkg/tui/messages/agent.go
+++ b/pkg/tui/messages/agent.go
@@ -5,6 +5,9 @@ type (
 	// SwitchAgentMsg switches to a different agent.
 	SwitchAgentMsg struct{ AgentName string }
 
+	// AgentSwitchedMsg notifies that an agent switch has completed.
+	AgentSwitchedMsg struct{ AgentName string }
+
 	// AgentCommandMsg sends a command to the agent.
 	AgentCommandMsg struct{ Command string }
 
@@ -13,4 +16,10 @@ type (
 
 	// ChangeModelMsg changes the model for the current agent.
 	ChangeModelMsg struct{ ModelRef string }
+
+	// ToggleAgentDropdownMsg toggles the agent dropdown in the sidebar.
+	ToggleAgentDropdownMsg struct{}
+
+	// OpenAgentPickerDialogMsg opens the agent picker dialog.
+	OpenAgentPickerDialogMsg struct{}
 )

--- a/pkg/tui/page/chat/hittest.go
+++ b/pkg/tui/page/chat/hittest.go
@@ -162,7 +162,7 @@ func ExtractCoords(msg tea.Msg) (x, y int, ok bool) {
 // sidebarClickTarget determines the specific target within the sidebar area.
 func (h *HitTest) sidebarClickTarget(x, y int) MouseTarget {
 	clickResult := h.page.handleSidebarClickType(x, y)
-	switch clickResult {
+	switch clickResult.Type {
 	case sidebar.ClickStar:
 		return TargetSidebarStar
 	case sidebar.ClickTitle:

--- a/pkg/tui/page/chat/input_handlers.go
+++ b/pkg/tui/page/chat/input_handlers.go
@@ -141,6 +141,24 @@ func (p *chatPage) handleMouseClick(msg tea.MouseClickMsg) (layout.Model, tea.Cm
 			return p, nil
 		}
 
+	case TargetSidebarContent:
+		// Handle agent-related clicks within sidebar content area
+		if msg.Button == tea.MouseLeft {
+			clickResult := p.handleSidebarClickType(msg.X, msg.Y)
+			switch clickResult.Type {
+			case sidebar.ClickAgentDropdown:
+				// Only in collapsed mode - open the picker dialog
+				cmd := p.toggleAgentDropdown()
+				return p, cmd
+			case sidebar.ClickAgentSwitch:
+				// Direct click on agent in expanded sidebar - switch directly
+				if clickResult.AgentName != "" && clickResult.AgentName != p.sidebar.GetCurrentAgentName() {
+					return p, core.CmdHandler(msgtypes.SwitchAgentMsg{AgentName: clickResult.AgentName})
+				}
+				return p, nil
+			}
+		}
+
 	case TargetEditorBanner:
 		if msg.Button == tea.MouseLeft {
 			localX := max(0, msg.X-styles.AppPaddingLeft)

--- a/pkg/tui/page/chat/runtime_events.go
+++ b/pkg/tui/page/chat/runtime_events.go
@@ -108,7 +108,7 @@ func (p *chatPage) handleRuntimeEvent(msg tea.Msg) (bool, tea.Cmd) {
 		return true, nil
 
 	case *runtime.ToolsetInfoEvent:
-		p.sidebar.SetToolsetInfo(msg.AvailableTools, msg.Loading)
+		p.sidebar.SetToolsetInfo(msg.AgentName, msg.AvailableTools, msg.Toolsets, msg.Loading)
 		return true, nil
 
 	case *runtime.SessionTitleEvent:

--- a/pkg/tui/styles/styles.go
+++ b/pkg/tui/styles/styles.go
@@ -81,6 +81,24 @@ var (
 	TabBg        color.Color
 	TabPrimaryFg color.Color
 	TabAccentFg  color.Color
+
+	// Agent picker colors
+	RadioSelectedColor       color.Color
+	RadioUnselectedColor     color.Color
+	AgentNameSelectedColor   color.Color
+	AgentNameUnselectedColor color.Color
+
+	// Agent picker line-specific colors (label + value for each line type)
+	AgentDescLabelColor     color.Color
+	AgentDescValueColor     color.Color
+	AgentModelLabelColor    color.Color
+	AgentModelValueColor    color.Color
+	AgentToolsLabelColor    color.Color
+	AgentToolsValueColor    color.Color
+	AgentToolsExpanderColor color.Color
+	AgentToolsetsLabelColor color.Color
+	AgentToolsetNameColor   color.Color
+	AgentToolNameColor      color.Color
 )
 
 // Base Styles
@@ -475,6 +493,33 @@ var (
 	SelectionStyle = BaseStyle.
 		Background(Selected).
 		Foreground(SelectedFg)
+)
+
+// Radio Button Styles - for agent picker and similar selectable lists
+var (
+	// RadioSelectedStyle is for the filled radio button (●) when an item is selected/focused
+	RadioSelectedStyle = BaseStyle.Foreground(RadioSelectedColor)
+	// RadioUnselectedStyle is for the empty radio button (○) when an item is not selected
+	RadioUnselectedStyle = BaseStyle.Foreground(RadioUnselectedColor)
+)
+
+// Agent Picker Styles - for the agent selection dialog and sidebar agent list
+var (
+	// AgentNameSelectedStyle is for the agent name when selected/focused
+	AgentNameSelectedStyle = BaseStyle.Foreground(AgentNameSelectedColor).Bold(true)
+	// AgentNameUnselectedStyle is for the agent name when not selected
+	AgentNameUnselectedStyle = BaseStyle.Foreground(AgentNameUnselectedColor)
+	// Agent picker line-specific styles (label + value for each line type)
+	AgentDescLabelStyle     = BaseStyle.Foreground(AgentDescLabelColor)
+	AgentDescValueStyle     = BaseStyle.Foreground(AgentDescValueColor)
+	AgentModelLabelStyle    = BaseStyle.Foreground(AgentModelLabelColor)
+	AgentModelValueStyle    = BaseStyle.Foreground(AgentModelValueColor)
+	AgentToolsLabelStyle    = BaseStyle.Foreground(AgentToolsLabelColor)
+	AgentToolsValueStyle    = BaseStyle.Foreground(AgentToolsValueColor)
+	AgentToolsExpanderStyle = BaseStyle.Foreground(AgentToolsExpanderColor)
+	AgentToolsetsLabelStyle = BaseStyle.Foreground(AgentToolsetsLabelColor)
+	AgentToolsetNameStyle   = BaseStyle.Foreground(AgentToolsetNameColor).Italic(true)
+	AgentToolNameStyle      = BaseStyle.Foreground(AgentToolNameColor)
 )
 
 // Spinner Styles - rebuilt by ApplyTheme() with actual spinner colors from theme

--- a/pkg/tui/styles/theme.go
+++ b/pkg/tui/styles/theme.go
@@ -130,6 +130,24 @@ type ThemeColors struct {
 	BadgeAccent  string `yaml:"badge_accent,omitempty"`  // Accent badge (e.g., purple highlights)
 	BadgeInfo    string `yaml:"badge_info,omitempty"`    // Info badge (e.g., cyan)
 	BadgeSuccess string `yaml:"badge_success,omitempty"` // Success badge (e.g., green)
+
+	// Agent picker colors
+	RadioSelected       string `yaml:"radio_selected,omitempty"`        // Radio button when selected
+	RadioUnselected     string `yaml:"radio_unselected,omitempty"`      // Radio button when not selected
+	AgentNameSelected   string `yaml:"agent_name_selected,omitempty"`   // Agent name when selected
+	AgentNameUnselected string `yaml:"agent_name_unselected,omitempty"` // Agent name when not selected
+
+	// Agent picker line-specific colors (label + value for each line type)
+	AgentDescLabel     string `yaml:"agent_desc_label,omitempty"`     // "Desc:" label
+	AgentDescValue     string `yaml:"agent_desc_value,omitempty"`     // Description value text
+	AgentModelLabel    string `yaml:"agent_model_label,omitempty"`    // "Model:" label
+	AgentModelValue    string `yaml:"agent_model_value,omitempty"`    // Model value text
+	AgentToolsLabel    string `yaml:"agent_tools_label,omitempty"`    // "Tools:" label
+	AgentToolsValue    string `yaml:"agent_tools_value,omitempty"`    // Tools count value
+	AgentToolsExpander string `yaml:"agent_tools_expander,omitempty"` // Tools expander indicator (▶/▼)
+	AgentToolsetsLabel string `yaml:"agent_toolsets_label,omitempty"` // "Toolsets:" label in expanded view
+	AgentToolsetName   string `yaml:"agent_toolset_name,omitempty"`   // Toolset name in expanded view
+	AgentToolName      string `yaml:"agent_tool_name,omitempty"`      // Individual tool name in expanded view
 }
 
 // ChromaColors contains syntax highlighting colors (for code blocks).
@@ -746,6 +764,49 @@ func mergeColors(base, override ThemeColors) ThemeColors {
 	if override.BadgeSuccess != "" {
 		result.BadgeSuccess = override.BadgeSuccess
 	}
+	// Agent picker colors
+	if override.RadioSelected != "" {
+		result.RadioSelected = override.RadioSelected
+	}
+	if override.RadioUnselected != "" {
+		result.RadioUnselected = override.RadioUnselected
+	}
+	if override.AgentNameSelected != "" {
+		result.AgentNameSelected = override.AgentNameSelected
+	}
+	if override.AgentNameUnselected != "" {
+		result.AgentNameUnselected = override.AgentNameUnselected
+	}
+	if override.AgentDescLabel != "" {
+		result.AgentDescLabel = override.AgentDescLabel
+	}
+	if override.AgentDescValue != "" {
+		result.AgentDescValue = override.AgentDescValue
+	}
+	if override.AgentModelLabel != "" {
+		result.AgentModelLabel = override.AgentModelLabel
+	}
+	if override.AgentModelValue != "" {
+		result.AgentModelValue = override.AgentModelValue
+	}
+	if override.AgentToolsLabel != "" {
+		result.AgentToolsLabel = override.AgentToolsLabel
+	}
+	if override.AgentToolsValue != "" {
+		result.AgentToolsValue = override.AgentToolsValue
+	}
+	if override.AgentToolsExpander != "" {
+		result.AgentToolsExpander = override.AgentToolsExpander
+	}
+	if override.AgentToolsetsLabel != "" {
+		result.AgentToolsetsLabel = override.AgentToolsetsLabel
+	}
+	if override.AgentToolsetName != "" {
+		result.AgentToolsetName = override.AgentToolsetName
+	}
+	if override.AgentToolName != "" {
+		result.AgentToolName = override.AgentToolName
+	}
 	return result
 }
 
@@ -925,6 +986,23 @@ func ApplyTheme(theme *Theme) {
 	TabBg = lipgloss.Color(c.TabBg)
 	TabPrimaryFg = lipgloss.Color(c.TextMuted)
 	TabAccentFg = lipgloss.Color(c.Highlight)
+
+	// Agent picker colors - use theme values with fallbacks
+	RadioSelectedColor = lipgloss.Color(fallback(c.RadioSelected, c.Highlight))
+	RadioUnselectedColor = lipgloss.Color(fallback(c.RadioUnselected, c.TextMuted))
+	AgentNameSelectedColor = lipgloss.Color(fallback(c.AgentNameSelected, c.Highlight))
+	AgentNameUnselectedColor = lipgloss.Color(fallback(c.AgentNameUnselected, c.TextPrimary))
+	// Agent picker line-specific colors (label + value for each line type)
+	AgentDescLabelColor = lipgloss.Color(fallback(c.AgentDescLabel, c.TextMuted))
+	AgentDescValueColor = lipgloss.Color(fallback(c.AgentDescValue, c.TextSecondary))
+	AgentModelLabelColor = lipgloss.Color(fallback(c.AgentModelLabel, c.TextMuted))
+	AgentModelValueColor = lipgloss.Color(fallback(c.AgentModelValue, c.Info))
+	AgentToolsLabelColor = lipgloss.Color(fallback(c.AgentToolsLabel, c.TextMuted))
+	AgentToolsValueColor = lipgloss.Color(fallback(c.AgentToolsValue, c.TextSecondary))
+	AgentToolsExpanderColor = lipgloss.Color(fallback(c.AgentToolsExpander, c.Accent))
+	AgentToolsetsLabelColor = lipgloss.Color(fallback(c.AgentToolsetsLabel, c.TextMuted))
+	AgentToolsetNameColor = lipgloss.Color(fallback(c.AgentToolsetName, c.Info))
+	AgentToolNameColor = lipgloss.Color(fallback(c.AgentToolName, c.TextMuted))
 
 	// Rebuild all derived styles
 	rebuildStyles()
@@ -1188,6 +1266,24 @@ func rebuildStyles() {
 	// Selection styles
 	SelectionStyle = BaseStyle.Background(Selected).Foreground(SelectedFg)
 
+	// Radio button and agent picker styles
+	RadioSelectedStyle = BaseStyle.Foreground(RadioSelectedColor)
+	RadioUnselectedStyle = BaseStyle.Foreground(RadioUnselectedColor)
+	AgentNameSelectedStyle = BaseStyle.Foreground(AgentNameSelectedColor).Bold(true)
+	AgentNameUnselectedStyle = BaseStyle.Foreground(AgentNameUnselectedColor)
+
+	// Agent picker line-specific styles (label + value for each line type)
+	AgentDescLabelStyle = BaseStyle.Foreground(AgentDescLabelColor)
+	AgentDescValueStyle = BaseStyle.Foreground(AgentDescValueColor)
+	AgentModelLabelStyle = BaseStyle.Foreground(AgentModelLabelColor)
+	AgentModelValueStyle = BaseStyle.Foreground(AgentModelValueColor)
+	AgentToolsLabelStyle = BaseStyle.Foreground(AgentToolsLabelColor)
+	AgentToolsValueStyle = BaseStyle.Foreground(AgentToolsValueColor)
+	AgentToolsExpanderStyle = BaseStyle.Foreground(AgentToolsExpanderColor)
+	AgentToolsetsLabelStyle = BaseStyle.Foreground(AgentToolsetsLabelColor)
+	AgentToolsetNameStyle = BaseStyle.Foreground(AgentToolsetNameColor).Italic(true)
+	AgentToolNameStyle = BaseStyle.Foreground(AgentToolNameColor)
+
 	// Spinner styles
 	SpinnerDotsAccentStyle = BaseStyle.Foreground(Accent)
 	SpinnerDotsHighlightStyle = BaseStyle.Foreground(TabAccentFg)
@@ -1195,6 +1291,16 @@ func rebuildStyles() {
 	SpinnerTextBrightStyle = BaseStyle.Foreground(lipgloss.Color(CurrentTheme().Colors.SpinnerBright))
 	SpinnerTextDimStyle = BaseStyle.Foreground(lipgloss.Color(CurrentTheme().Colors.SpinnerDim))
 	SpinnerTextDimmestStyle = BaseStyle.Foreground(Accent)
+}
+
+// fallback returns the first non-empty string, or empty if all are empty.
+func fallback(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 func bestForegroundHex(bgHex string, candidates ...string) string {

--- a/pkg/tui/styles/themes/catppuccin-latte.yaml
+++ b/pkg/tui/styles/themes/catppuccin-latte.yaml
@@ -58,6 +58,25 @@ colors:
   badge_info: "#04a5e5"
   badge_success: "#40a02b"
 
+  # Agent picker colors
+  radio_selected: "#ea76cb"
+  radio_unselected: "#7c7f93"
+  agent_name_selected: "#ea76cb"
+  agent_name_unselected: "#4c4f69"
+
+  # Agent picker line-specific colors (label + value for each line type)
+  # Labels slightly muted, values bright/primary for readability
+  agent_desc_label: "#7c7f93"
+  agent_desc_value: "#4c4f69"
+  agent_model_label: "#7c7f93"
+  agent_model_value: "#4c4f69"
+  agent_tools_label: "#7c7f93"
+  agent_tools_value: "#4c4f69"
+  agent_tools_expander: "#1e66f5"
+  agent_toolsets_label: "#7c7f93"
+  agent_toolset_name: "#5c5f77"
+  agent_tool_name: "#5c5f77"
+
 chroma:
   # Syntax highlighting colors - Catppuccin Latte style
   comment: "#8c8fa1"

--- a/pkg/tui/styles/themes/catppuccin-mocha.yaml
+++ b/pkg/tui/styles/themes/catppuccin-mocha.yaml
@@ -58,6 +58,25 @@ colors:
   badge_info: "#89dceb"
   badge_success: "#a6e3a1"
 
+  # Agent picker colors
+  radio_selected: "#f5c2e7"
+  radio_unselected: "#7f849c"
+  agent_name_selected: "#f5c2e7"
+  agent_name_unselected: "#cdd6f4"
+
+  # Agent picker line-specific colors (label + value for each line type)
+  # Labels slightly muted, values bright/primary for readability
+  agent_desc_label: "#9399b2"
+  agent_desc_value: "#cdd6f4"
+  agent_model_label: "#9399b2"
+  agent_model_value: "#cdd6f4"
+  agent_tools_label: "#9399b2"
+  agent_tools_value: "#cdd6f4"
+  agent_tools_expander: "#89b4fa"
+  agent_toolsets_label: "#9399b2"
+  agent_toolset_name: "#bac2de"
+  agent_tool_name: "#bac2de"
+
 chroma:
   # Syntax highlighting colors - Catppuccin style
   comment: "#7f849c"

--- a/pkg/tui/styles/themes/default.yaml
+++ b/pkg/tui/styles/themes/default.yaml
@@ -57,6 +57,25 @@ colors:
   badge_info: "#7DCFFF"
   badge_success: "#9ECE6A"
 
+  # Agent picker colors
+  radio_selected: "#98C379"
+  radio_unselected: "#808080"
+  agent_name_selected: "#98C379"
+  agent_name_unselected: "#C0C0C0"
+
+  # Agent picker line-specific colors (label + value for each line type)
+  # Labels slightly muted, values bright/primary for readability
+  agent_desc_label: "#909090"
+  agent_desc_value: "#C0C0C0"
+  agent_model_label: "#909090"
+  agent_model_value: "#C0C0C0"
+  agent_tools_label: "#909090"
+  agent_tools_value: "#C0C0C0"
+  agent_tools_expander: "#7AA2F7"
+  agent_toolsets_label: "#909090"
+  agent_toolset_name: "#A8A8A8"
+  agent_tool_name: "#A8A8A8"
+
 chroma:
   # Syntax highlighting colors (Monokai-inspired)
   error_fg: "#F1F1F1"

--- a/pkg/tui/styles/themes/dracula.yaml
+++ b/pkg/tui/styles/themes/dracula.yaml
@@ -58,6 +58,25 @@ colors:
   badge_info: "#8be9fd"
   badge_success: "#50fa7b"
 
+  # Agent picker colors
+  radio_selected: "#ff79c6"
+  radio_unselected: "#6272a4"
+  agent_name_selected: "#ff79c6"
+  agent_name_unselected: "#f8f8f2"
+
+  # Agent picker line-specific colors (label + value for each line type)
+  # Labels slightly muted, values bright/primary for readability
+  agent_desc_label: "#6272a4"
+  agent_desc_value: "#f8f8f2"
+  agent_model_label: "#6272a4"
+  agent_model_value: "#f8f8f2"
+  agent_tools_label: "#6272a4"
+  agent_tools_value: "#f8f8f2"
+  agent_tools_expander: "#8be9fd"
+  agent_toolsets_label: "#6272a4"
+  agent_toolset_name: "#d0d0d0"
+  agent_tool_name: "#d0d0d0"
+
 chroma:
   # Syntax highlighting colors - Dracula style
   comment: "#6272a4"

--- a/pkg/tui/styles/themes/gruvbox-dark.yaml
+++ b/pkg/tui/styles/themes/gruvbox-dark.yaml
@@ -58,6 +58,25 @@ colors:
   badge_info: "#8ec07c"
   badge_success: "#b8bb26"
 
+  # Agent picker colors
+  radio_selected: "#d3869b"
+  radio_unselected: "#7c6f64"
+  agent_name_selected: "#d3869b"
+  agent_name_unselected: "#ebdbb2"
+
+  # Agent picker line-specific colors (label + value for each line type)
+  # Labels slightly muted, values bright/primary for readability
+  agent_desc_label: "#928374"
+  agent_desc_value: "#ebdbb2"
+  agent_model_label: "#928374"
+  agent_model_value: "#ebdbb2"
+  agent_tools_label: "#928374"
+  agent_tools_value: "#ebdbb2"
+  agent_tools_expander: "#83a598"
+  agent_toolsets_label: "#928374"
+  agent_toolset_name: "#bdae93"
+  agent_tool_name: "#bdae93"
+
 chroma:
   # Syntax highlighting colors - Gruvbox style
   comment: "#928374"

--- a/pkg/tui/styles/themes/gruvbox-light.yaml
+++ b/pkg/tui/styles/themes/gruvbox-light.yaml
@@ -58,6 +58,25 @@ colors:
   badge_info: "#076678"
   badge_success: "#79740e"
 
+  # Agent picker colors
+  radio_selected: "#8f3f71"
+  radio_unselected: "#7c6f64"
+  agent_name_selected: "#8f3f71"
+  agent_name_unselected: "#282828"
+
+  # Agent picker line-specific colors (label + value for each line type)
+  # Labels slightly muted, values bright/primary for readability
+  agent_desc_label: "#7c6f64"
+  agent_desc_value: "#282828"
+  agent_model_label: "#7c6f64"
+  agent_model_value: "#282828"
+  agent_tools_label: "#7c6f64"
+  agent_tools_value: "#282828"
+  agent_tools_expander: "#076678"
+  agent_toolsets_label: "#7c6f64"
+  agent_toolset_name: "#3c3836"
+  agent_tool_name: "#3c3836"
+
 chroma:
   # Syntax highlighting colors - Gruvbox Light style
   comment: "#928374"

--- a/pkg/tui/styles/themes/nord.yaml
+++ b/pkg/tui/styles/themes/nord.yaml
@@ -58,6 +58,25 @@ colors:
   badge_info: "#88c0d0"
   badge_success: "#a3be8c"
 
+  # Agent picker colors
+  radio_selected: "#b48ead"
+  radio_unselected: "#616e88"
+  agent_name_selected: "#b48ead"
+  agent_name_unselected: "#d8dee9"
+
+  # Agent picker line-specific colors (label + value for each line type)
+  # Labels slightly muted, values bright/primary for readability
+  agent_desc_label: "#616e88"
+  agent_desc_value: "#d8dee9"
+  agent_model_label: "#616e88"
+  agent_model_value: "#d8dee9"
+  agent_tools_label: "#616e88"
+  agent_tools_value: "#d8dee9"
+  agent_tools_expander: "#81a1c1"
+  agent_toolsets_label: "#616e88"
+  agent_toolset_name: "#b8c5d9"
+  agent_tool_name: "#b8c5d9"
+
 chroma:
   # Syntax highlighting colors - Nord style
   comment: "#616e88"

--- a/pkg/tui/styles/themes/one-dark.yaml
+++ b/pkg/tui/styles/themes/one-dark.yaml
@@ -58,6 +58,25 @@ colors:
   badge_info: "#56b6c2"
   badge_success: "#98c379"
 
+  # Agent picker colors
+  radio_selected: "#c678dd"
+  radio_unselected: "#5c6370"
+  agent_name_selected: "#c678dd"
+  agent_name_unselected: "#abb2bf"
+
+  # Agent picker line-specific colors (label + value for each line type)
+  # Labels slightly muted, values bright/primary for readability
+  agent_desc_label: "#5c6370"
+  agent_desc_value: "#abb2bf"
+  agent_model_label: "#5c6370"
+  agent_model_value: "#abb2bf"
+  agent_tools_label: "#5c6370"
+  agent_tools_value: "#abb2bf"
+  agent_tools_expander: "#61afef"
+  agent_toolsets_label: "#5c6370"
+  agent_toolset_name: "#9098a8"
+  agent_tool_name: "#9098a8"
+
 chroma:
   # Syntax highlighting colors - One Dark style
   comment: "#5c6370"

--- a/pkg/tui/styles/themes/solarized-dark.yaml
+++ b/pkg/tui/styles/themes/solarized-dark.yaml
@@ -58,6 +58,25 @@ colors:
   badge_info: "#2aa198"
   badge_success: "#859900"
 
+  # Agent picker colors
+  radio_selected: "#d33682"
+  radio_unselected: "#657b83"
+  agent_name_selected: "#d33682"
+  agent_name_unselected: "#93a1a1"
+
+  # Agent picker line-specific colors (label + value for each line type)
+  # Labels slightly muted, values bright/primary for readability
+  agent_desc_label: "#657b83"
+  agent_desc_value: "#93a1a1"
+  agent_model_label: "#657b83"
+  agent_model_value: "#93a1a1"
+  agent_tools_label: "#657b83"
+  agent_tools_value: "#93a1a1"
+  agent_tools_expander: "#268bd2"
+  agent_toolsets_label: "#657b83"
+  agent_toolset_name: "#839496"
+  agent_tool_name: "#839496"
+
 chroma:
   # Syntax highlighting colors - Solarized style
   comment: "#586e75"

--- a/pkg/tui/styles/themes/tokyo-night.yaml
+++ b/pkg/tui/styles/themes/tokyo-night.yaml
@@ -58,6 +58,25 @@ colors:
   badge_info: "#7dcfff"
   badge_success: "#9ece6a"
 
+  # Agent picker colors
+  radio_selected: "#bb9af7"
+  radio_unselected: "#565f89"
+  agent_name_selected: "#bb9af7"
+  agent_name_unselected: "#c0caf5"
+
+  # Agent picker line-specific colors (label + value for each line type)
+  # Labels slightly muted, values bright/primary for readability
+  agent_desc_label: "#565f89"
+  agent_desc_value: "#c0caf5"
+  agent_model_label: "#565f89"
+  agent_model_value: "#c0caf5"
+  agent_tools_label: "#565f89"
+  agent_tools_value: "#c0caf5"
+  agent_tools_expander: "#7aa2f7"
+  agent_toolsets_label: "#565f89"
+  agent_toolset_name: "#a9b1d6"
+  agent_tool_name: "#a9b1d6"
+
 chroma:
   # Syntax highlighting colors - Tokyo Night style
   comment: "#565f89"


### PR DESCRIPTION
Give it a try and let me know if this is worth a cleanup pass

:warning: Ignore the code for now, plenty of vibes and it has not been thoroughly looked into.

- Makes the sidebar agents section its own component (as an example for future refactoring of all sections)
- Cleans up agent view in the sidebar to only show essential agent info (name and model)
- Allows switching by clicking on the agent in the sidebar
- Adds proper agent selection dialog with more info per agent and easier to read descriptions, including expandable toolset/tool list

### Screencast

https://github.com/user-attachments/assets/c4c1d5ab-d2d8-454a-9f77-f0e652b0f0b9
