### PR TITLE
Make TUI more responsive when scrolling

### DIFF
--- a/pkg/tui/components/editor/editor.go
+++ b/pkg/tui/components/editor/editor.go
@@ -63,6 +63,7 @@ type Editor interface {
 	layout.Focusable
 	SetWorking(working bool) tea.Cmd
 	AcceptSuggestion() tea.Cmd
+	ScrollByWheel(delta int)
 	// Value returns the current editor content
 	Value() string
 	// SetValue updates the editor content
@@ -493,6 +494,25 @@ func (e *editor) AcceptSuggestion() tea.Cmd {
 
 	// Update the completion query to reflect the new editor content
 	return e.updateCompletionQuery()
+}
+
+func (e *editor) ScrollByWheel(delta int) {
+	if delta == 0 {
+		return
+	}
+
+	steps := delta
+	if steps < 0 {
+		steps = -steps
+		for range steps {
+			e.textarea.CursorUp()
+		}
+		return
+	}
+
+	for range steps {
+		e.textarea.CursorDown()
+	}
 }
 
 // resetAndSend prepares a message for sending: processes pending file refs,

--- a/pkg/tui/components/messages/clipboard.go
+++ b/pkg/tui/components/messages/clipboard.go
@@ -92,7 +92,8 @@ func (m *model) extractSelectedText() string {
 		return ""
 	}
 
-	lines := strings.Split(m.rendered, "\n")
+	m.ensureAllItemsRendered()
+	lines := m.renderedLines
 	startLine, startCol, endLine, endCol := m.selection.normalized()
 
 	if startLine < 0 || startLine >= len(lines) {

--- a/pkg/tui/components/messages/messages.go
+++ b/pkg/tui/components/messages/messages.go
@@ -58,6 +58,7 @@ type Model interface {
 
 	ScrollToBottom() tea.Cmd
 	AdjustBottomSlack(delta int)
+	ScrollByWheel(delta int)
 }
 
 // renderedItem represents a cached rendered message with position information
@@ -84,7 +85,7 @@ type model struct {
 	// Height tracking system fields
 	scrollOffset  int                  // Current scroll position in lines
 	bottomSlack   int                  // Extra blank lines added after content shrinks
-	rendered      string               // Complete rendered content string
+	renderedLines []string             // Cached rendered content as lines (avoids split/join per frame)
 	renderedItems map[int]renderedItem // Cache of rendered items with positions
 	totalHeight   int                  // Total height of all content in lines
 	renderDirty   bool                 // True when rendered content needs rebuild
@@ -333,27 +334,12 @@ func (m *model) handleMouseRelease(msg tea.MouseReleaseMsg) (layout.Model, tea.C
 }
 
 func (m *model) handleMouseWheel(msg tea.MouseWheelMsg) (layout.Model, tea.Cmd) {
-	const mouseScrollAmount = 2
 	switch msg.Button.String() {
 	case "wheelup":
-		if m.scrollOffset > 0 {
-			m.userHasScrolled = true
-			m.bottomSlack = 0
-			for range mouseScrollAmount {
-				m.setScrollOffset(m.scrollOffset - defaultScrollAmount)
-			}
-		}
+		m.scrollByWheel(-1)
 	case "wheeldown":
-		m.userHasScrolled = true
-		m.bottomSlack = 0
-		for range mouseScrollAmount {
-			m.setScrollOffset(m.scrollOffset + defaultScrollAmount)
-		}
-		if m.isAtBottom() {
-			m.userHasScrolled = false
-		}
+		m.scrollByWheel(1)
 	}
-	m.scrollbar.SetScrollOffset(m.scrollOffset)
 	return m, nil
 }
 
@@ -433,22 +419,28 @@ func (m *model) View() string {
 		m.scrollOffset = max(0, min(m.scrollOffset, maxScrollOffset))
 	}
 
-	lines := strings.Split(m.rendered, "\n")
-	if m.bottomSlack > 0 {
-		lines = append(lines, make([]string, m.bottomSlack)...)
-	}
-	if len(lines) == 0 {
+	// Use cached lines directly - O(1) instead of O(totalHeight) split
+	totalLines := len(m.renderedLines) + m.bottomSlack
+	if totalLines == 0 {
 		return ""
 	}
 
 	startLine := m.scrollOffset
-	endLine := min(startLine+m.height, len(lines))
+	endLine := min(startLine+m.height, totalLines)
 
 	if startLine >= endLine {
 		return ""
 	}
 
-	visibleLines := lines[startLine:endLine]
+	// Copy only the visible window to avoid mutating cached lines
+	// This is O(viewportHeight) instead of O(totalHeight)
+	visibleLines := make([]string, endLine-startLine)
+	for i := startLine; i < endLine; i++ {
+		if i < len(m.renderedLines) {
+			visibleLines[i-startLine] = m.renderedLines[i]
+		}
+		// Lines beyond renderedLines are bottom slack (empty strings), already zero-valued
+	}
 
 	if m.selection.active {
 		visibleLines = m.applySelectionHighlight(visibleLines, startLine)
@@ -471,22 +463,18 @@ func (m *model) View() string {
 		}
 	}
 
-	contentView := strings.Join(visibleLines, "\n")
 	scrollbarView := m.scrollbar.View()
 
 	if scrollbarView != "" {
-		// For proper horizontal layout, all components must have the same height
-		contentLines := strings.Split(contentView, "\n")
-
 		// Ensure content is exactly m.height lines by padding with empty lines if needed
-		for len(contentLines) < m.height {
-			contentLines = append(contentLines, "")
+		for len(visibleLines) < m.height {
+			visibleLines = append(visibleLines, "")
 		}
 		// Truncate if somehow longer (shouldn't happen but safety check)
-		if len(contentLines) > m.height {
-			contentLines = contentLines[:m.height]
+		if len(visibleLines) > m.height {
+			visibleLines = visibleLines[:m.height]
 		}
-		paddedContentView := strings.Join(contentLines, "\n")
+		contentView := strings.Join(visibleLines, "\n")
 
 		// Create spacer with exactly m.height lines
 		spacerLines := make([]string, m.height)
@@ -495,10 +483,10 @@ func (m *model) View() string {
 		}
 		spacer := strings.Join(spacerLines, "\n")
 
-		return lipgloss.JoinHorizontal(lipgloss.Top, paddedContentView, spacer, scrollbarView)
+		return lipgloss.JoinHorizontal(lipgloss.Top, contentView, spacer, scrollbarView)
 	}
 
-	return contentView
+	return strings.Join(visibleLines, "\n")
 }
 
 // SetSize sets the dimensions of the component
@@ -560,7 +548,10 @@ func (m *model) Help() help.KeyMap {
 }
 
 // Scrolling methods
-const defaultScrollAmount = 1
+const (
+	defaultScrollAmount = 1
+	wheelScrollAmount   = 2
+)
 
 func (m *model) scrollUp() {
 	if m.scrollOffset > 0 {
@@ -603,6 +594,28 @@ func (m *model) scrollToTop() {
 func (m *model) scrollToBottom() {
 	m.userHasScrolled = false
 	m.setScrollOffset(9_999_999) // Will be clamped in View()
+}
+
+func (m *model) ScrollByWheel(delta int) {
+	m.scrollByWheel(delta)
+}
+
+func (m *model) scrollByWheel(delta int) {
+	if delta == 0 {
+		return
+	}
+
+	prevOffset := m.scrollOffset
+	m.setScrollOffset(m.scrollOffset + (delta * wheelScrollAmount * defaultScrollAmount))
+	if m.scrollOffset == prevOffset {
+		return
+	}
+
+	m.userHasScrolled = true
+	m.bottomSlack = 0
+	if m.isAtBottom() {
+		m.userHasScrolled = false
+	}
 }
 
 func (m *model) setScrollOffset(offset int) {
@@ -788,12 +801,12 @@ func (m *model) needsSeparator(index int) bool {
 }
 
 func (m *model) ensureAllItemsRendered() {
-	if !m.renderDirty && m.rendered != "" {
+	if !m.renderDirty && len(m.renderedLines) > 0 {
 		return
 	}
 
 	if len(m.views) == 0 {
-		m.rendered = ""
+		m.renderedLines = nil
 		m.totalHeight = 0
 		m.renderDirty = false
 		return
@@ -816,7 +829,8 @@ func (m *model) ensureAllItemsRendered() {
 		}
 	}
 
-	m.rendered = strings.Join(allLines, "\n")
+	// Store lines directly - avoid join/split on every View() call
+	m.renderedLines = allLines
 	m.totalHeight = len(allLines)
 	m.renderDirty = false
 }
@@ -830,7 +844,7 @@ func (m *model) invalidateItem(index int) {
 
 func (m *model) invalidateAllItems() {
 	m.renderedItems = make(map[int]renderedItem)
-	m.rendered = ""
+	m.renderedLines = nil
 	m.totalHeight = 0
 	m.renderDirty = true
 }
@@ -978,7 +992,7 @@ func (m *model) LoadFromSession(sess *session.Session) tea.Cmd {
 	m.messages = nil
 	m.views = nil
 	m.renderedItems = make(map[int]renderedItem)
-	m.rendered = ""
+	m.renderedLines = nil
 	m.scrollOffset = 0
 	m.totalHeight = 0
 	m.bottomSlack = 0

--- a/pkg/tui/components/messages/selection.go
+++ b/pkg/tui/components/messages/selection.go
@@ -136,7 +136,8 @@ func (m *model) autoScroll() tea.Cmd {
 
 // selectWordAt selects the word at the given line and column position
 func (m *model) selectWordAt(line, col int) {
-	lines := strings.Split(m.rendered, "\n")
+	m.ensureAllItemsRendered()
+	lines := m.renderedLines
 	if line < 0 || line >= len(lines) {
 		return
 	}
@@ -184,7 +185,8 @@ func (m *model) selectWordAt(line, col int) {
 
 // selectLineAt selects the entire line at the given line position
 func (m *model) selectLineAt(line int) {
-	lines := strings.Split(m.rendered, "\n")
+	m.ensureAllItemsRendered()
+	lines := m.renderedLines
 	if line < 0 || line >= len(lines) {
 		return
 	}

--- a/pkg/tui/input/wheel_coalescer.go
+++ b/pkg/tui/input/wheel_coalescer.go
@@ -1,0 +1,83 @@
+package input
+
+import (
+	"sync"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/docker/cagent/pkg/tui/messages"
+)
+
+const wheelFlushInterval = 16 * time.Millisecond
+
+// WheelCoalescer aggregates wheel events into a single delta per flush interval.
+type WheelCoalescer struct {
+	mu        sync.Mutex
+	pending   int
+	lastX     int
+	lastY     int
+	scheduled bool
+	send      func(tea.Msg)
+}
+
+// NewWheelCoalescer creates a new wheel coalescer.
+func NewWheelCoalescer() *WheelCoalescer {
+	return &WheelCoalescer{}
+}
+
+// SetSender wires the message sender used to emit coalesced events.
+func (c *WheelCoalescer) SetSender(send func(tea.Msg)) {
+	c.mu.Lock()
+	c.send = send
+	c.mu.Unlock()
+}
+
+// Handle consumes a wheel message and returns true if it was coalesced.
+func (c *WheelCoalescer) Handle(msg tea.MouseWheelMsg) bool {
+	delta, ok := wheelDelta(msg)
+	if !ok {
+		return false
+	}
+
+	c.mu.Lock()
+	c.pending += delta
+	c.lastX = msg.X
+	c.lastY = msg.Y
+	if c.scheduled {
+		c.mu.Unlock()
+		return true
+	}
+	c.scheduled = true
+	c.mu.Unlock()
+
+	time.AfterFunc(wheelFlushInterval, c.flush)
+	return true
+}
+
+func (c *WheelCoalescer) flush() {
+	c.mu.Lock()
+	pending := c.pending
+	x := c.lastX
+	y := c.lastY
+	c.pending = 0
+	c.scheduled = false
+	send := c.send
+	c.mu.Unlock()
+
+	if pending == 0 || send == nil {
+		return
+	}
+	send(messages.WheelCoalescedMsg{Delta: pending, X: x, Y: y})
+}
+
+func wheelDelta(msg tea.MouseWheelMsg) (int, bool) {
+	switch msg.Button {
+	case tea.MouseWheelUp:
+		return -1, true
+	case tea.MouseWheelDown:
+		return 1, true
+	default:
+		return 0, false
+	}
+}

--- a/pkg/tui/messages/scroll.go
+++ b/pkg/tui/messages/scroll.go
@@ -1,0 +1,9 @@
+package messages
+
+// WheelCoalescedMsg aggregates mouse wheel deltas to reduce render storms.
+// Delta is positive for wheel down and negative for wheel up.
+type WheelCoalescedMsg struct {
+	Delta int
+	X     int
+	Y     int
+}

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -440,6 +440,9 @@ func (p *chatPage) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 	case tea.MouseWheelMsg:
 		return p.handleMouseWheel(msg)
 
+	case msgtypes.WheelCoalescedMsg:
+		return p.handleWheelCoalesced(msg)
+
 	case msgtypes.StreamCancelledMsg:
 		model, cmd := p.messages.Update(msg)
 		p.messages = model.(messages.Model)


### PR DESCRIPTION
Coalesce mouse scroll events so we don't backlog the render pipeline with a ton of events.

This improves CPU performance when scrolling with a mouse/trackpad by 8-12x, while making the TUI **much** more responsive, even on large high res screens and with many long messages in the session. Where the scroll rendering used to lag behind the mouse scroll, continuing well after the user stopped scrolling, now its way more reactive to user input

Also includes:
- caching rendered output in lines instead of a single string, avoiding split/joins on every render and reducing cpu usage by roughly 15-20% and mem usage by 25-50% for message rendering (based on number of messages etc)
- caching sidebar render to avoid needless redraws

### Screencasts

**before**
> :warning: When i wiggle the mouse, i have already stopped scrolling, but the TUI is lagging behind even on a very fast cpu

https://github.com/user-attachments/assets/b6e05313-1dff-4675-9a15-c658f6a1b692


**after**
> scroll rendering stops as soon as i stop scrolling

https://github.com/user-attachments/assets/490c437a-9c0b-4cb7-8cf3-0f6599601482

