### PR TITLE
Handle relative session references in --session flag

### DIFF
--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -87,7 +87,7 @@ func addRunOrExecFlags(cmd *cobra.Command, flags *runExecFlags) {
 	cmd.PersistentFlags().StringVar(&flags.remoteAddress, "remote", "", "Use remote runtime with specified address")
 	cmd.PersistentFlags().BoolVar(&flags.connectRPC, "connect-rpc", false, "Use Connect-RPC protocol for remote communication (requires --remote)")
 	cmd.PersistentFlags().StringVarP(&flags.sessionDB, "session-db", "s", filepath.Join(paths.GetHomeDir(), ".cagent", "session.db"), "Path to the session database")
-	cmd.PersistentFlags().StringVar(&flags.sessionID, "session", "", "Continue from a previous session by ID")
+	cmd.PersistentFlags().StringVar(&flags.sessionID, "session", "", "Continue from a previous session by ID or relative offset (e.g., -1 for last session)")
 	cmd.PersistentFlags().StringVar(&flags.fakeResponses, "fake", "", "Replay AI responses from cassette file (for testing)")
 	cmd.PersistentFlags().IntVar(&flags.fakeStreamDelay, "fake-stream", 0, "Simulate streaming with delay in ms between chunks (default 15ms if no value given)")
 	cmd.Flag("fake-stream").NoOptDefVal = "15" // --fake-stream without value uses 15ms
@@ -356,10 +356,16 @@ func (f *runExecFlags) createLocalRuntimeAndSession(ctx context.Context, loadRes
 
 	var sess *session.Session
 	if f.sessionID != "" {
-		// Load existing session
-		sess, err = sessStore.GetSession(ctx, f.sessionID)
+		// Resolve relative session references (e.g., "-1" for last session)
+		resolvedID, err := session.ResolveSessionID(ctx, sessStore, f.sessionID)
 		if err != nil {
-			return nil, nil, fmt.Errorf("loading session %q: %w", f.sessionID, err)
+			return nil, nil, fmt.Errorf("resolving session %q: %w", f.sessionID, err)
+		}
+
+		// Load existing session
+		sess, err = sessStore.GetSession(ctx, resolvedID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("loading session %q: %w", resolvedID, err)
 		}
 		sess.ToolsApproved = f.autoApprove
 		sess.HideToolResults = f.hideToolResults
@@ -375,7 +381,7 @@ func (f *runExecFlags) createLocalRuntimeAndSession(ctx context.Context, loadRes
 			}
 		}
 
-		slog.Debug("Loaded existing session", "session_id", f.sessionID, "agent", f.agentName)
+		slog.Debug("Loaded existing session", "session_id", resolvedID, "session_ref", f.sessionID, "agent", f.agentName)
 	} else {
 		sess = session.New(
 			session.WithMaxIterations(agent.MaxIterations()),

--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/docker/cagent/pkg/chat"
@@ -20,6 +22,35 @@ var (
 	ErrEmptyID  = errors.New("session ID cannot be empty")
 	ErrNotFound = errors.New("session not found")
 )
+
+// parseRelativeSessionRef checks if ref is a relative session reference (e.g., "-1", "-2")
+// and returns the offset and whether it's a relative reference.
+// Returns (1, true) for "-1", (2, true) for "-2", etc.
+// Returns (0, false) if not a relative reference.
+func parseRelativeSessionRef(ref string) (offset int, isRelative bool) {
+	if !strings.HasPrefix(ref, "-") {
+		return 0, false
+	}
+
+	// Try to parse as negative integer
+	n, err := strconv.Atoi(ref)
+	if err != nil || n >= 0 {
+		return 0, false
+	}
+
+	return -n, true
+}
+
+// ResolveSessionID resolves a session reference to an actual session ID.
+// Supports relative references like "-1" (last session), "-2" (second to last), etc.
+// If the reference is not relative, it returns the input unchanged.
+func ResolveSessionID(ctx context.Context, store Store, ref string) (string, error) {
+	offset, isRelative := parseRelativeSessionRef(ref)
+	if !isRelative {
+		return ref, nil
+	}
+	return store.GetSessionByOffset(ctx, offset)
+}
 
 // Summary contains lightweight session metadata for listing purposes.
 // This is used instead of loading full Session objects with all messages.
@@ -40,6 +71,11 @@ type Store interface {
 	DeleteSession(ctx context.Context, id string) error
 	UpdateSession(ctx context.Context, session *Session) error // Updates metadata only (not messages/items)
 	SetSessionStarred(ctx context.Context, id string, starred bool) error
+
+	// GetSessionByOffset returns the session ID at the given offset from the most recent.
+	// Offset 1 returns the most recent session, 2 returns the second most recent, etc.
+	// Only root sessions are considered (sub-sessions are excluded).
+	GetSessionByOffset(ctx context.Context, offset int) (string, error)
 
 	// === Granular item operations ===
 
@@ -298,6 +334,34 @@ func (s *InMemorySessionStore) UpdateSessionTitle(_ context.Context, sessionID, 
 	}
 	session.Title = title
 	return nil
+}
+
+// GetSessionByOffset returns the session ID at the given offset from the most recent.
+func (s *InMemorySessionStore) GetSessionByOffset(_ context.Context, offset int) (string, error) {
+	if offset < 1 {
+		return "", fmt.Errorf("offset must be >= 1, got %d", offset)
+	}
+
+	// Collect and sort sessions by creation time (newest first)
+	var sessions []*Session
+	s.sessions.Range(func(_ string, value *Session) bool {
+		// Only include root sessions (not sub-sessions)
+		if value.ParentID == "" {
+			sessions = append(sessions, value)
+		}
+		return true
+	})
+
+	sort.Slice(sessions, func(i, j int) bool {
+		return sessions[i].CreatedAt.After(sessions[j].CreatedAt)
+	})
+
+	index := offset - 1 // offset 1 means index 0 (most recent session)
+	if index >= len(sessions) {
+		return "", fmt.Errorf("session offset %d out of range (have %d sessions)", offset, len(sessions))
+	}
+
+	return sessions[index].ID, nil
 }
 
 // NewSQLiteSessionStore creates a new SQLite session store
@@ -1178,4 +1242,29 @@ func (s *SQLiteSessionStore) UpdateSessionTitle(ctx context.Context, sessionID, 
 		"UPDATE sessions SET title = ? WHERE id = ?",
 		title, sessionID)
 	return err
+}
+
+// GetSessionByOffset returns the session ID at the given offset from the most recent.
+func (s *SQLiteSessionStore) GetSessionByOffset(ctx context.Context, offset int) (string, error) {
+	if offset < 1 {
+		return "", fmt.Errorf("offset must be >= 1, got %d", offset)
+	}
+
+	// Query sessions ordered by creation time (newest first), limited to offset
+	// Only include root sessions (not sub-sessions)
+	var sessionID string
+	err := s.db.QueryRowContext(ctx,
+		`SELECT id FROM sessions 
+		 WHERE parent_id IS NULL OR parent_id = '' 
+		 ORDER BY created_at DESC 
+		 LIMIT 1 OFFSET ?`,
+		offset-1).Scan(&sessionID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", fmt.Errorf("session offset %d out of range", offset)
+		}
+		return "", err
+	}
+
+	return sessionID, nil
 }

--- a/pkg/session/store_test.go
+++ b/pkg/session/store_test.go
@@ -954,3 +954,283 @@ func TestMigration_ExistingMessagesToSessionItems(t *testing.T) {
 	assert.Equal(t, "Legacy message 1", retrieved.Messages[0].Message.Message.Content)
 	assert.Equal(t, "legacy-agent", retrieved.Messages[1].Message.AgentName)
 }
+
+func TestParseRelativeSessionRef(t *testing.T) {
+	tests := []struct {
+		name       string
+		ref        string
+		wantOffset int
+		wantIsRel  bool
+	}{
+		{"last session", "-1", 1, true},
+		{"second to last", "-2", 2, true},
+		{"tenth session", "-10", 10, true},
+		{"regular ID", "abc123", 0, false},
+		{"UUID-like", "550e8400-e29b-41d4-a716-446655440000", 0, false},
+		{"positive number", "1", 0, false},
+		{"zero", "0", 0, false},
+		{"negative zero", "-0", 0, false},
+		{"not a number", "-abc", 0, false},
+		{"empty string", "", 0, false},
+		{"just dash", "-", 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			offset, isRel := parseRelativeSessionRef(tt.ref)
+			assert.Equal(t, tt.wantOffset, offset)
+			assert.Equal(t, tt.wantIsRel, isRel)
+		})
+	}
+}
+
+func TestResolveSessionID_SQLite(t *testing.T) {
+	tempDB := filepath.Join(t.TempDir(), "test_resolve.db")
+
+	store, err := NewSQLiteSessionStore(tempDB)
+	require.NoError(t, err)
+	defer store.(*SQLiteSessionStore).Close()
+
+	// Create sessions with known timestamps
+	baseTime := time.Now()
+	sessions := []struct {
+		id        string
+		createdAt time.Time
+	}{
+		{"oldest", baseTime.Add(-3 * time.Hour)},
+		{"middle", baseTime.Add(-2 * time.Hour)},
+		{"newest", baseTime.Add(-1 * time.Hour)},
+	}
+
+	for _, s := range sessions {
+		err := store.AddSession(t.Context(), &Session{
+			ID:        s.id,
+			CreatedAt: s.createdAt,
+		})
+		require.NoError(t, err)
+	}
+
+	t.Run("resolves -1 to newest session", func(t *testing.T) {
+		id, err := ResolveSessionID(t.Context(), store, "-1")
+		require.NoError(t, err)
+		assert.Equal(t, "newest", id)
+	})
+
+	t.Run("resolves -2 to middle session", func(t *testing.T) {
+		id, err := ResolveSessionID(t.Context(), store, "-2")
+		require.NoError(t, err)
+		assert.Equal(t, "middle", id)
+	})
+
+	t.Run("resolves -3 to oldest session", func(t *testing.T) {
+		id, err := ResolveSessionID(t.Context(), store, "-3")
+		require.NoError(t, err)
+		assert.Equal(t, "oldest", id)
+	})
+
+	t.Run("returns error for out of range offset", func(t *testing.T) {
+		_, err := ResolveSessionID(t.Context(), store, "-4")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "out of range")
+	})
+
+	t.Run("returns non-relative ID unchanged", func(t *testing.T) {
+		id, err := ResolveSessionID(t.Context(), store, "some-uuid")
+		require.NoError(t, err)
+		assert.Equal(t, "some-uuid", id)
+	})
+}
+
+func TestResolveSessionID_ExcludesSubSessions(t *testing.T) {
+	tempDB := filepath.Join(t.TempDir(), "test_resolve_subsessions.db")
+
+	store, err := NewSQLiteSessionStore(tempDB)
+	require.NoError(t, err)
+	defer store.(*SQLiteSessionStore).Close()
+
+	sqliteStore := store.(*SQLiteSessionStore)
+
+	// Create a parent session
+	parent := &Session{
+		ID:        "parent",
+		CreatedAt: time.Now().Add(-2 * time.Hour),
+	}
+	err = store.AddSession(t.Context(), parent)
+	require.NoError(t, err)
+
+	// Create a sub-session directly in the database to avoid the AddSubSession complexity
+	// This simulates an existing sub-session without going through the full API
+	subSessionTime := time.Now().Add(-1 * time.Hour)
+	_, err = sqliteStore.db.ExecContext(t.Context(),
+		`INSERT INTO sessions (id, tools_approved, input_tokens, output_tokens, title, cost, send_user_message, max_iterations, working_dir, created_at, starred, permissions, agent_model_overrides, custom_models_used, thinking, parent_id)
+		 VALUES (?, 0, 0, 0, '', 0, 1, 0, '', ?, 0, '', '{}', '[]', 1, ?)`,
+		"subsession", subSessionTime.Format(time.RFC3339), "parent")
+	require.NoError(t, err)
+
+	// Create another root session (most recent root)
+	root2 := &Session{
+		ID:        "root2",
+		CreatedAt: time.Now(),
+	}
+	err = store.AddSession(t.Context(), root2)
+	require.NoError(t, err)
+
+	// -1 should resolve to root2, not the subsession
+	id, err := ResolveSessionID(t.Context(), store, "-1")
+	require.NoError(t, err)
+	assert.Equal(t, "root2", id)
+
+	// -2 should resolve to parent
+	id, err = ResolveSessionID(t.Context(), store, "-2")
+	require.NoError(t, err)
+	assert.Equal(t, "parent", id)
+}
+
+func TestResolveSessionID_InMemory(t *testing.T) {
+	store := NewInMemorySessionStore()
+
+	// Create sessions with known timestamps
+	baseTime := time.Now()
+	sessions := []struct {
+		id        string
+		createdAt time.Time
+	}{
+		{"oldest", baseTime.Add(-3 * time.Hour)},
+		{"middle", baseTime.Add(-2 * time.Hour)},
+		{"newest", baseTime.Add(-1 * time.Hour)},
+	}
+
+	for _, s := range sessions {
+		err := store.AddSession(t.Context(), &Session{
+			ID:        s.id,
+			CreatedAt: s.createdAt,
+		})
+		require.NoError(t, err)
+	}
+
+	t.Run("resolves -1 to newest session", func(t *testing.T) {
+		id, err := ResolveSessionID(t.Context(), store, "-1")
+		require.NoError(t, err)
+		assert.Equal(t, "newest", id)
+	})
+
+	t.Run("resolves -2 to middle session", func(t *testing.T) {
+		id, err := ResolveSessionID(t.Context(), store, "-2")
+		require.NoError(t, err)
+		assert.Equal(t, "middle", id)
+	})
+
+	t.Run("returns error for out of range offset", func(t *testing.T) {
+		_, err := ResolveSessionID(t.Context(), store, "-4")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "out of range")
+	})
+
+	t.Run("returns non-relative ID unchanged", func(t *testing.T) {
+		id, err := ResolveSessionID(t.Context(), store, "some-uuid")
+		require.NoError(t, err)
+		assert.Equal(t, "some-uuid", id)
+	})
+}
+
+func TestGetSessionByOffset_SQLite(t *testing.T) {
+	tempDB := filepath.Join(t.TempDir(), "test_offset.db")
+
+	store, err := NewSQLiteSessionStore(tempDB)
+	require.NoError(t, err)
+	defer store.(*SQLiteSessionStore).Close()
+
+	// Create sessions with known timestamps
+	baseTime := time.Now()
+	sessions := []struct {
+		id        string
+		createdAt time.Time
+	}{
+		{"oldest", baseTime.Add(-3 * time.Hour)},
+		{"middle", baseTime.Add(-2 * time.Hour)},
+		{"newest", baseTime.Add(-1 * time.Hour)},
+	}
+
+	for _, s := range sessions {
+		err := store.AddSession(t.Context(), &Session{
+			ID:        s.id,
+			CreatedAt: s.createdAt,
+		})
+		require.NoError(t, err)
+	}
+
+	t.Run("offset 1 returns newest", func(t *testing.T) {
+		id, err := store.GetSessionByOffset(t.Context(), 1)
+		require.NoError(t, err)
+		assert.Equal(t, "newest", id)
+	})
+
+	t.Run("offset 2 returns middle", func(t *testing.T) {
+		id, err := store.GetSessionByOffset(t.Context(), 2)
+		require.NoError(t, err)
+		assert.Equal(t, "middle", id)
+	})
+
+	t.Run("offset 3 returns oldest", func(t *testing.T) {
+		id, err := store.GetSessionByOffset(t.Context(), 3)
+		require.NoError(t, err)
+		assert.Equal(t, "oldest", id)
+	})
+
+	t.Run("offset 0 returns error", func(t *testing.T) {
+		_, err := store.GetSessionByOffset(t.Context(), 0)
+		require.Error(t, err)
+	})
+
+	t.Run("out of range offset returns error", func(t *testing.T) {
+		_, err := store.GetSessionByOffset(t.Context(), 4)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "out of range")
+	})
+}
+
+func TestGetSessionByOffset_InMemory(t *testing.T) {
+	store := NewInMemorySessionStore()
+
+	// Create sessions with known timestamps
+	baseTime := time.Now()
+	sessions := []struct {
+		id        string
+		createdAt time.Time
+	}{
+		{"oldest", baseTime.Add(-3 * time.Hour)},
+		{"middle", baseTime.Add(-2 * time.Hour)},
+		{"newest", baseTime.Add(-1 * time.Hour)},
+	}
+
+	for _, s := range sessions {
+		err := store.AddSession(t.Context(), &Session{
+			ID:        s.id,
+			CreatedAt: s.createdAt,
+		})
+		require.NoError(t, err)
+	}
+
+	t.Run("offset 1 returns newest", func(t *testing.T) {
+		id, err := store.GetSessionByOffset(t.Context(), 1)
+		require.NoError(t, err)
+		assert.Equal(t, "newest", id)
+	})
+
+	t.Run("offset 2 returns middle", func(t *testing.T) {
+		id, err := store.GetSessionByOffset(t.Context(), 2)
+		require.NoError(t, err)
+		assert.Equal(t, "middle", id)
+	})
+
+	t.Run("offset 0 returns error", func(t *testing.T) {
+		_, err := store.GetSessionByOffset(t.Context(), 0)
+		require.Error(t, err)
+	})
+
+	t.Run("out of range offset returns error", func(t *testing.T) {
+		_, err := store.GetSessionByOffset(t.Context(), 4)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "out of range")
+	})
+}


### PR DESCRIPTION
Add support for relative session offsets like "-1" (last session) or "-2" (second to last) in the --session flag, making it easier to resume recent sessions without looking up session IDs.

For example:

`cagent run ... --session -1`