### PR TITLE
cli: prevent panic when elicitation is requested in non-interactive s…

### DIFF
--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -164,27 +164,23 @@ func Run(ctx context.Context, out *Printer, cfg Config, rt runtime.Runtime, sess
 					return nil
 				}
 			case *runtime.ElicitationRequestEvent:
-				rawURL, ok := e.Meta["cagent/server_url"]
-				if !ok || rawURL == nil {
-					slog.Warn("Skipping elicitation: missing server_url (non-interactive session?)")
-					_ = rt.ResumeElicitation(ctx, "decline", nil)
-					return nil
-				}
-
-				serverURL, ok := rawURL.(string)
+				serverURL, ok := e.Meta["cagent/server_url"].(string)
 				if !ok || serverURL == "" {
-					slog.Warn("Skipping elicitation: invalid server_url type")
+					slog.Warn("Skipping elicitation: missing or invalid server_url (non-interactive session?)")
 					_ = rt.ResumeElicitation(ctx, "decline", nil)
 					return nil
 				}
 
 				result := out.PromptOAuthAuthorization(ctx, serverURL)
-				switch {
-				case ctx.Err() != nil:
+
+				if ctx.Err() != nil {
 					return ctx.Err()
-				case result == ConfirmationApprove:
+				}
+
+				switch result {
+				case ConfirmationApprove:
 					_ = rt.ResumeElicitation(ctx, "accept", nil)
-				case result == ConfirmationReject:
+				case ConfirmationReject:
 					_ = rt.ResumeElicitation(ctx, "decline", nil)
 					return fmt.Errorf("OAuth authorization rejected by user")
 				}


### PR DESCRIPTION
## What I did

- Prevented a panic when elicitation (e.g. `user_prompt` / OAuth authorization) is triggered during non-interactive `cagent exec` sessions
- Added defensive checks for elicitation metadata to avoid unsafe type assertions
- Gracefully skipped elicitation when user interaction is not possible, resuming the runtime with a declined response
- Ensured non-interactive executions fail safely instead of crashing

## Related issue

- Fixes #1554 (panic when `user_prompt` is invoked in non-interactive session)

## Before

- `cagent exec` could invoke elicitation tools in non-interactive sessions
- The CLI assumed `cagent/server_url` was always present and a valid string
- Missing or nil metadata caused a panic:
  - `interface conversion: interface {} is nil, not string`
- The process crashed instead of exiting cleanly

## After

- Elicitation metadata is validated before use
- Non-interactive sessions no longer trigger unsafe type assertions
- Elicitation is safely skipped when user input is not possible
- `cagent exec` exits cleanly without panicking

## Test

### Screenshot Yaml (test) 

<img width="944" height="276" alt="dgbsbs" src="https://github.com/user-attachments/assets/492780f8-698d-40f7-96f1-605309746237" />

### Commands 

- `go test ./...`
- `cagent exec ./agent.yml "it's not working"`
- `echo "it's not working" | cagent exec ./agent.yml -`

### Result
- Verified no panic occurs when using a YAML config with a non-existent model (`model: fake`)
- Verified the command exits gracefully and prints a controlled error message

#### Screenshot Result (test) 

<img width="1054" height="455" alt="image" src="https://github.com/user-attachments/assets/200ab564-dd80-41ca-accf-ad0d18545c11" />
