### PR TITLE
add optional Bearer token authorization for SSE endpoints

### DIFF
--- a/cmd/root/api.go
+++ b/cmd/root/api.go
@@ -49,6 +49,8 @@ func newAPICmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&flags.exitOnStdinEOF, "exit-on-stdin-eof", false, "Exit when stdin is closed (for integration with parent processes)")
 	_ = cmd.PersistentFlags().MarkHidden("exit-on-stdin-eof")
 	cmd.MarkFlagsMutuallyExclusive("fake", "record")
+	cmd.PersistentFlags().StringVar(&flags.runConfig.APIToken, "token", "", "Bearer token required to access SSE endpoints")
+
 	addRuntimeConfigFlags(cmd, &flags.runConfig)
 
 	return cmd
@@ -154,7 +156,7 @@ func (f *apiFlags) runAPICommand(cmd *cobra.Command, args []string) error {
 		return s.Serve(ctx, ln)
 	}
 
-	s, err := server.New(ctx, sessionStore, &f.runConfig, time.Duration(f.pullIntervalMins)*time.Minute, sources)
+	s, err := server.New(ctx, sessionStore, &f.runConfig, time.Duration(f.pullIntervalMins)*time.Minute, sources, f.runConfig.APIToken)
 	if err != nil {
 		return fmt.Errorf("creating server: %w", err)
 	}

--- a/pkg/config/runtime.go
+++ b/pkg/config/runtime.go
@@ -20,6 +20,7 @@ type Config struct {
 	ModelsGateway  string
 	GlobalCodeMode bool
 	WorkingDir     string
+	APIToken       string
 }
 
 func (runConfig *RuntimeConfig) Clone() *RuntimeConfig {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -95,7 +96,7 @@ func startServer(t *testing.T, ctx context.Context, agentsDir string) string {
 
 	sources, err := config.ResolveSources(agentsDir)
 	require.NoError(t, err)
-	srv, err := New(ctx, store, &runConfig, 0, sources)
+	srv, err := New(ctx, store, &runConfig, time.Duration(0), sources, "")
 	require.NoError(t, err)
 
 	socketPath := "unix://" + filepath.Join(t.TempDir(), "sock")
@@ -206,7 +207,7 @@ func startServerWithStore(t *testing.T, ctx context.Context, agentsDir string, s
 
 	sources, err := config.ResolveSources(agentsDir)
 	require.NoError(t, err)
-	srv, err := New(ctx, store, &runConfig, 0, sources)
+	srv, err := New(ctx, store, &runConfig, time.Duration(0), sources, "")
 	require.NoError(t, err)
 
 	socketPath := "unix://" + filepath.Join(t.TempDir(), "sock")


### PR DESCRIPTION
## What I did

- Added **optional Bearer token authorization** to SSE endpoints.
- Introduced a server-side check for the `Authorization: Bearer <token>` header.
- The authorization layer is **disabled by default** and only enforced when a token is configured.
- Requests without a valid token are rejected before any SSE data or tool execution is exposed.

## Before

- SSE endpoints were **fully open**.
- Any client that could reach the network port could:
  - Connect to the SSE stream
  - Receive tool definitions
  - Trigger command execution
- The security model implicitly assumed a **trusted local environment**.

## After

- SSE endpoints can be protected with a **simple Bearer token**.
- The server validates the token **before**:
  - Establishing the SSE connection
  - Exposing tool definitions
  - Executing any command
- Default behavior remains unchanged when no token is configured.
- This provides a basic but effective security layer for:
  - Shared servers
  - Cloud deployments
  - Internal team usage
