### PR TITLE
Update default anthropic model to sonnet 4.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ agents:
 models:
   claude:
     provider: anthropic
-    model: claude-sonnet-4-0
+    model: claude-sonnet-4-5
     max_tokens: 64000
 ```
 
@@ -425,7 +425,7 @@ these three providers in order based on the first api key it finds in your
 environment.
 
 ```sh
-export ANTHROPIC_API_KEY=your_api_key_here  # first choice. default model claude-sonnet-4-0
+export ANTHROPIC_API_KEY=your_api_key_here  # first choice. default model claude-sonnet-4-5
 export OPENAI_API_KEY=your_api_key_here     # if anthropic key not set. default model gpt-5-mini
 export GOOGLE_API_KEY=your_api_key_here     # if anthropic and openai keys are not set. default model gemini-2.5-flash
 ```

--- a/pkg/config/auto.go
+++ b/pkg/config/auto.go
@@ -52,7 +52,7 @@ To fix this, you can:
 
 var DefaultModels = map[string]string{
 	"openai":         "gpt-5-mini",
-	"anthropic":      "claude-sonnet-4-0",
+	"anthropic":      "claude-sonnet-4-5",
 	"google":         "gemini-2.5-flash",
 	"dmr":            "ai/qwen3:latest",
 	"mistral":        "mistral-small-latest",
@@ -82,7 +82,16 @@ func AvailableProviders(ctx context.Context, modelsGateway string, env environme
 	return providers
 }
 
-func AutoModelConfig(ctx context.Context, modelsGateway string, env environment.Provider) latest.ModelConfig {
+func AutoModelConfig(ctx context.Context, modelsGateway string, env environment.Provider, defaultModel *latest.ModelConfig) latest.ModelConfig {
+	// If user specified a default model config, use it (with defaults for unset fields)
+	if defaultModel != nil && defaultModel.Provider != "" && defaultModel.Model != "" {
+		result := *defaultModel
+		if result.MaxTokens == nil {
+			result.MaxTokens = PreferredMaxTokens(result.Provider)
+		}
+		return result
+	}
+
 	availableProviders := AvailableProviders(ctx, modelsGateway, env)
 	firstAvailable := availableProviders[0]
 

--- a/pkg/config/runtime.go
+++ b/pkg/config/runtime.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"sync"
 
+	"github.com/docker/cagent/pkg/config/latest"
 	"github.com/docker/cagent/pkg/environment"
 )
 
@@ -18,6 +19,7 @@ type RuntimeConfig struct {
 type Config struct {
 	EnvFiles       []string
 	ModelsGateway  string
+	DefaultModel   *latest.ModelConfig
 	GlobalCodeMode bool
 	WorkingDir     string
 }

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -132,7 +132,7 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 	agentsByName := make(map[string]*agent.Agent)
 
 	autoModel := sync.OnceValue(func() latest.ModelConfig {
-		return config.AutoModelConfig(ctx, runConfig.ModelsGateway, env)
+		return config.AutoModelConfig(ctx, runConfig.ModelsGateway, env, runConfig.DefaultModel)
 	})
 
 	expander := js.NewJsExpander(env)

--- a/pkg/userconfig/userconfig.go
+++ b/pkg/userconfig/userconfig.go
@@ -16,6 +16,7 @@ import (
 	"github.com/goccy/go-yaml"
 	"github.com/natefinch/atomic"
 
+	"github.com/docker/cagent/pkg/config/latest"
 	"github.com/docker/cagent/pkg/paths"
 )
 
@@ -67,6 +68,9 @@ type Config struct {
 	Version string `yaml:"version,omitempty"`
 	// ModelsGateway is the default models gateway URL
 	ModelsGateway string `yaml:"models_gateway,omitempty"`
+	// DefaultModel is the default model to use when model is set to "auto".
+	// Supports both shorthand ("provider/model") and full model definition.
+	DefaultModel *latest.FlexibleModelConfig `yaml:"default_model,omitempty"`
 	// Aliases maps alias names to alias configurations
 	Aliases map[string]*Alias `yaml:"aliases,omitempty"`
 	// Settings contains global user settings

--- a/pkg/userconfig/userconfig_test.go
+++ b/pkg/userconfig/userconfig_test.go
@@ -5,8 +5,11 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/goccy/go-yaml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/docker/cagent/pkg/config/latest"
 )
 
 func TestConfig_Empty(t *testing.T) {
@@ -624,4 +627,158 @@ func TestConfig_CredentialHelper_Empty(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Nil(t, config.CredentialHelper)
+}
+
+func TestDefaultModelConfig_Shorthand(t *testing.T) {
+	t.Parallel()
+
+	yamlContent := `default_model: anthropic/claude-sonnet-4-5`
+
+	var config Config
+	err := yaml.Unmarshal([]byte(yamlContent), &config)
+	require.NoError(t, err)
+
+	require.NotNil(t, config.DefaultModel)
+	assert.Equal(t, "anthropic", config.DefaultModel.Provider)
+	assert.Equal(t, "claude-sonnet-4-5", config.DefaultModel.Model)
+	assert.Nil(t, config.DefaultModel.MaxTokens)
+}
+
+func TestDefaultModelConfig_FullDefinition(t *testing.T) {
+	t.Parallel()
+
+	yamlContent := `default_model:
+  provider: anthropic
+  model: claude-sonnet-4-5
+  max_tokens: 64000
+  thinking_budget: 10000`
+
+	var config Config
+	err := yaml.Unmarshal([]byte(yamlContent), &config)
+	require.NoError(t, err)
+
+	require.NotNil(t, config.DefaultModel)
+	assert.Equal(t, "anthropic", config.DefaultModel.Provider)
+	assert.Equal(t, "claude-sonnet-4-5", config.DefaultModel.Model)
+	require.NotNil(t, config.DefaultModel.MaxTokens)
+	assert.Equal(t, int64(64000), *config.DefaultModel.MaxTokens)
+	require.NotNil(t, config.DefaultModel.ThinkingBudget)
+	assert.Equal(t, 10000, config.DefaultModel.ThinkingBudget.Tokens)
+}
+
+func TestDefaultModelConfig_FullDefinitionWithEffort(t *testing.T) {
+	t.Parallel()
+
+	yamlContent := `default_model:
+  provider: openai
+  model: o1
+  thinking_budget: high`
+
+	var config Config
+	err := yaml.Unmarshal([]byte(yamlContent), &config)
+	require.NoError(t, err)
+
+	require.NotNil(t, config.DefaultModel)
+	assert.Equal(t, "openai", config.DefaultModel.Provider)
+	assert.Equal(t, "o1", config.DefaultModel.Model)
+	require.NotNil(t, config.DefaultModel.ThinkingBudget)
+	assert.Equal(t, "high", config.DefaultModel.ThinkingBudget.Effort)
+}
+
+func TestDefaultModelConfig_Marshal_ShorthandOutput(t *testing.T) {
+	t.Parallel()
+
+	config := &latest.FlexibleModelConfig{
+		ModelConfig: latest.ModelConfig{
+			Provider: "anthropic",
+			Model:    "claude-sonnet-4-5",
+		},
+	}
+
+	data, err := yaml.Marshal(config)
+	require.NoError(t, err)
+
+	// Should output shorthand format when only provider/model are set
+	assert.Equal(t, "anthropic/claude-sonnet-4-5\n", string(data))
+}
+
+func TestDefaultModelConfig_Marshal_FullOutput(t *testing.T) {
+	t.Parallel()
+
+	maxTokens := int64(64000)
+	config := &latest.FlexibleModelConfig{
+		ModelConfig: latest.ModelConfig{
+			Provider:  "anthropic",
+			Model:     "claude-sonnet-4-5",
+			MaxTokens: &maxTokens,
+		},
+	}
+
+	data, err := yaml.Marshal(config)
+	require.NoError(t, err)
+
+	// Should output full format when extra options are set
+	assert.Contains(t, string(data), "provider:")
+	assert.Contains(t, string(data), "model:")
+	assert.Contains(t, string(data), "max_tokens:")
+}
+
+func TestDefaultModelConfig_InvalidShorthand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr bool
+	}{
+		{"no slash", "default_model: anthropic", true},
+		{"empty provider", "default_model: /model", true},
+		{"empty model", "default_model: provider/", true},
+		{"valid shorthand", "default_model: anthropic/claude-sonnet-4-5", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var config Config
+			err := yaml.Unmarshal([]byte(tt.yaml), &config)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestConfig_DefaultModel_SaveAndLoad(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+
+	maxTokens := int64(64000)
+	config := &Config{
+		DefaultModel: &latest.FlexibleModelConfig{
+			ModelConfig: latest.ModelConfig{
+				Provider:       "anthropic",
+				Model:          "claude-sonnet-4-5",
+				MaxTokens:      &maxTokens,
+				ThinkingBudget: &latest.ThinkingBudget{Tokens: 10000},
+			},
+		},
+	}
+
+	require.NoError(t, config.saveTo(configFile))
+
+	loaded, err := loadFrom(configFile, "")
+	require.NoError(t, err)
+
+	require.NotNil(t, loaded.DefaultModel)
+	assert.Equal(t, "anthropic", loaded.DefaultModel.Provider)
+	assert.Equal(t, "claude-sonnet-4-5", loaded.DefaultModel.Model)
+	require.NotNil(t, loaded.DefaultModel.MaxTokens)
+	assert.Equal(t, int64(64000), *loaded.DefaultModel.MaxTokens)
+	require.NotNil(t, loaded.DefaultModel.ThinkingBudget)
+	assert.Equal(t, 10000, loaded.DefaultModel.ThinkingBudget.Tokens)
 }


### PR DESCRIPTION
And allow users to define their own default model in their global config

Both full model def and shorthand formats are supported

### Examples of global config.yaml

```yaml
version: v1
default_model:
    provider: anthropic
    model: claude-haiku-4-5
    max_tokens: 64000
    thinking_budget: 10000
    provider_opts:
        interleaved_thinking: true
```

```yaml
version: v1
default_model: anthropic/claude-opus-4-5
```