### PR TITLE
(feat) Add fork support for TUI

### DIFF
--- a/pkg/tui/messages/session.go
+++ b/pkg/tui/messages/session.go
@@ -50,6 +50,9 @@ type (
 	// ClearQueueMsg clears all queued messages.
 	ClearQueueMsg struct{}
 
+	// ForkSessionMsg truncates the session to fork from a specific assistant message.
+	ForkSessionMsg struct{ AssistantMessageIndex int }
+
 	// SendMsg contains the content sent to the agent.
 	SendMsg struct {
 		Content     string            // Full content sent to the agent (with file contents expanded)

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -387,6 +387,9 @@ func (a *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case messages.CompactSessionMsg:
 		return a.handleCompactSession(msg.AdditionalPrompt)
 
+	case messages.ForkSessionMsg:
+		return a.handleForkSession(msg.AssistantMessageIndex)
+
 	case messages.CopySessionToClipboardMsg:
 		return a.handleCopySessionToClipboard()
 


### PR DESCRIPTION
Summary

  - Add conversation fork feature via f keybinding when a message is selected
  - Allows users to truncate conversation history and continue from an earlier point

  Details

  When viewing a conversation, users can now:
  1. Press Tab to focus the messages panel
  2. Navigate with j/k to select an assistant message
  3. Press f to fork the session from that point

  The session is truncated to include everything up to and including the selected message, allowing the user to ask a different follow-up question.

  Test plan

  - Start a conversation with multiple exchanges
  - Press Tab to focus messages, navigate to an earlier assistant response
  - Press f to fork
  - Verify notification "Session forked." appears
  - Verify messages after the selected point are removed
  - Verify you can type a new message and continue from the fork point