### PR TITLE
fix: prevent title generation from hanging with Gemini 3 models

### DIFF
--- a/pkg/model/provider/options/options.go
+++ b/pkg/model/provider/options/options.go
@@ -94,5 +94,8 @@ func FromModelOptions(m ModelOptions) []Opt {
 	if len(m.providers) > 0 {
 		out = append(out, WithProviders(m.providers))
 	}
+	if m.thinking != nil {
+		out = append(out, WithThinking(*m.thinking))
+	}
 	return out
 }


### PR DESCRIPTION
When using Gemini 3 models (e.g., gemini-3-flash-preview), title generation would hang because thinking was not being properly disabled. The low max_tokens (20) used for title generation left no room for thinking tokens, causing the API to hang.

Changes:
- Set ThinkingBudget=0 in Gemini client when ModelOptions.Thinking() is false, which completely disables thinking at the API level
- Add 30-second timeout to title generation as a safety net
- Fix FromModelOptions to preserve the thinking setting when cloning providers

Assisted-By: cagent