### PR TITLE
feat: add --prompt-file CLI flag for including file contents as system context

### DIFF
--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -32,6 +32,7 @@ type runExecFlags struct {
 	remoteAddress     string
 	connectRPC        bool
 	modelOverrides    []string
+	promptFiles       []string
 	dryRun            bool
 	runConfig         config.RuntimeConfig
 	sessionDB         string
@@ -82,6 +83,7 @@ func addRunOrExecFlags(cmd *cobra.Command, flags *runExecFlags) {
 	cmd.PersistentFlags().BoolVar(&flags.autoApprove, "yolo", false, "Automatically approve all tool calls without prompting")
 	cmd.PersistentFlags().BoolVar(&flags.hideToolResults, "hide-tool-results", false, "Hide tool call results")
 	cmd.PersistentFlags().StringVar(&flags.attachmentPath, "attach", "", "Attach an image file to the message")
+	cmd.PersistentFlags().StringArrayVar(&flags.promptFiles, "prompt-file", nil, "Append file contents to the prompt (repeatable)")
 	cmd.PersistentFlags().StringArrayVar(&flags.modelOverrides, "model", nil, "Override agent model: [agent=]provider/model (repeatable)")
 	cmd.PersistentFlags().BoolVar(&flags.dryRun, "dry-run", false, "Initialize the agent without executing anything")
 	cmd.PersistentFlags().StringVar(&flags.remoteAddress, "remote", "", "Use remote runtime with specified address")
@@ -257,7 +259,14 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 }
 
 func (f *runExecFlags) loadAgentFrom(ctx context.Context, agentSource config.Source) (*teamloader.LoadResult, error) {
-	result, err := teamloader.LoadWithConfig(ctx, agentSource, &f.runConfig, teamloader.WithModelOverrides(f.modelOverrides))
+	opts := []teamloader.Opt{
+		teamloader.WithModelOverrides(f.modelOverrides),
+	}
+	if len(f.promptFiles) > 0 {
+		opts = append(opts, teamloader.WithPromptFiles(f.promptFiles))
+	}
+
+	result, err := teamloader.LoadWithConfig(ctx, agentSource, &f.runConfig, opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Adds a new `--prompt-file` reusable flag that allows users to include additional files in the agent's system context, matching the behavior of `add_prompt_files` in agent YAML configs.

# Usage

```bash
cagent exec agent.yaml "task" --prompt-file AGENTS.md --prompt-file CLAUDE.md
cagent run agent.yaml --prompt-file guidelines.md
```

# Behavior

- Adds files as system messages (same as agent config `add_prompt_files`)
- Uses hierarchy search (finds files by traversing up directories)
- Checks home folder as fallback (`~/`)
- Merges with any `add_prompt_files` defined in agent config
- Deduplicates to avoid redundant context (saves tokens)
