### PR TITLE
/attach use file upload instead of embedding in the context

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"slices"
 	"strings"
 	"sync/atomic"
@@ -243,20 +245,91 @@ func (a *App) Run(ctx context.Context, cancel context.CancelFunc, message string
 
 	go func() {
 		if len(attachments) > 0 {
+			// Strip attachment placeholders from the message text
+			// Placeholders are in the format @/path/to/file
+			cleanMessage := message
+			for placeholder := range attachments {
+				cleanMessage = strings.ReplaceAll(cleanMessage, placeholder, "")
+			}
+			cleanMessage = strings.TrimSpace(cleanMessage)
+			if cleanMessage == "" {
+				cleanMessage = "Please analyze this attached file."
+			}
+
 			multiContent := []chat.MessagePart{
 				{
 					Type: chat.MessagePartTypeText,
-					Text: message,
+					Text: cleanMessage,
 				},
 			}
 
-			for key, dataURL := range attachments {
+			// Attachments are keyed by @filepath placeholder
+			// Extract the file path and add as file attachment for provider upload.
+			// Note: There is an inherent TOCTOU race between this validation and when
+			// the provider reads the file during upload. This validation catches common
+			// cases (deleted files, wrong paths) but files could still change before upload.
+			for placeholder := range attachments {
+				filePath := strings.TrimPrefix(placeholder, "@")
+				if filePath == "" {
+					slog.Debug("skipping attachment with empty file path", "placeholder", placeholder)
+					continue
+				}
+
+				// Convert to absolute path to ensure consistency with provider upload code
+				// and prevent issues if working directory changes between validation and upload
+				absPath, err := filepath.Abs(filePath)
+				if err != nil {
+					slog.Warn("skipping attachment: invalid path", "path", filePath, "error", err)
+					a.events <- runtime.Warning(fmt.Sprintf("Skipped attachment %s: invalid path", filePath), "")
+					continue
+				}
+
+				fi, err := os.Stat(absPath)
+				if err != nil {
+					var reason string
+					switch {
+					case os.IsNotExist(err):
+						reason = "file does not exist"
+					case os.IsPermission(err):
+						reason = "permission denied"
+					default:
+						reason = fmt.Sprintf("cannot access file: %v", err)
+					}
+					slog.Warn("skipping attachment", "path", absPath, "reason", reason)
+					a.events <- runtime.Warning(fmt.Sprintf("Skipped attachment %s: %s", filePath, reason), "")
+					continue
+				}
+
+				if !fi.Mode().IsRegular() {
+					slog.Warn("skipping attachment: not a regular file", "path", absPath, "mode", fi.Mode().String())
+					a.events <- runtime.Warning(fmt.Sprintf("Skipped attachment %s: not a regular file", filePath), "")
+					continue
+				}
+
+				const maxAttachmentSize = 100 * 1024 * 1024 // 100MB
+				if fi.Size() > maxAttachmentSize {
+					slog.Warn("skipping attachment: file too large", "path", absPath, "size", fi.Size(), "max", maxAttachmentSize)
+					a.events <- runtime.Warning(fmt.Sprintf("Skipped attachment %s: file too large (max 100MB)", filePath), "")
+					continue
+				}
+
+				mimeType := chat.DetectMimeType(absPath)
+				if !chat.IsSupportedMimeType(mimeType) {
+					slog.Warn("skipping attachment: unsupported file type", "path", absPath, "mime_type", mimeType)
+					a.events <- runtime.Warning(fmt.Sprintf("Skipped attachment %s: unsupported file type (supported: images, pdf, txt, md)", filePath), "")
+					continue
+				}
+
 				multiContent = append(multiContent, chat.MessagePart{
-					Type: chat.MessagePartTypeText,
-					Text: fmt.Sprintf("Contents of %s: %s", key, dataURL),
+					Type: chat.MessagePartTypeFile,
+					File: &chat.MessageFile{
+						Path:     absPath,
+						MimeType: mimeType,
+					},
 				})
 			}
-			a.session.AddMessage(session.UserMessage(message, multiContent...))
+
+			a.session.AddMessage(session.UserMessage(cleanMessage, multiContent...))
 		} else {
 			a.session.AddMessage(session.UserMessage(message))
 		}

--- a/pkg/chat/chat.go
+++ b/pkg/chat/chat.go
@@ -1,6 +1,11 @@
 package chat
 
-import "github.com/docker/cagent/pkg/tools"
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/docker/cagent/pkg/tools"
+)
 
 type MessageRole string
 
@@ -16,6 +21,7 @@ type MessagePartType string
 const (
 	MessagePartTypeText     MessagePartType = "text"
 	MessagePartTypeImageURL MessagePartType = "image_url"
+	MessagePartTypeFile     MessagePartType = "file"
 )
 
 type ImageURLDetail string
@@ -74,10 +80,18 @@ type Message struct {
 	CacheControl bool `json:"cache_control,omitempty"`
 }
 
+// MessageFile represents a file attachment that can be uploaded to a provider's file storage.
+type MessageFile struct {
+	Path     string `json:"path,omitempty"`      // Local file path (used for upload)
+	FileID   string `json:"file_id,omitempty"`   // Provider-specific file ID (after upload)
+	MimeType string `json:"mime_type,omitempty"` // MIME type of the file
+}
+
 type MessagePart struct {
 	Type     MessagePartType  `json:"type,omitempty"`
 	Text     string           `json:"text,omitempty"`
 	ImageURL *MessageImageURL `json:"image_url,omitempty"`
+	File     *MessageFile     `json:"file,omitempty"`
 }
 
 // FinishReason represents the reason why the model finished generating a response
@@ -144,4 +158,45 @@ type MessageStream interface {
 	Recv() (MessageStreamResponse, error)
 	// Close closes the stream
 	Close()
+}
+
+// DetectMimeType returns the MIME type for a file based on its extension.
+// This is the canonical implementation used across all packages for consistency.
+// Note: Only returns MIME types that are supported for file attachments.
+// Unsupported extensions return "application/octet-stream".
+func DetectMimeType(filePath string) string {
+	ext := strings.ToLower(filepath.Ext(filePath))
+	switch ext {
+	// Images
+	case ".jpg", ".jpeg":
+		return "image/jpeg"
+	case ".png":
+		return "image/png"
+	case ".gif":
+		return "image/gif"
+	case ".webp":
+		return "image/webp"
+	// Documents
+	case ".pdf":
+		return "application/pdf"
+	case ".txt", ".json", ".csv":
+		return "text/plain"
+	case ".md", ".markdown":
+		return "text/markdown"
+	default:
+		return "application/octet-stream"
+	}
+}
+
+// IsSupportedMimeType returns true if the MIME type is supported for file attachments.
+// Supported types include images (jpeg, png, gif, webp) and documents (pdf, text, markdown).
+func IsSupportedMimeType(mimeType string) bool {
+	switch mimeType {
+	case "image/jpeg", "image/png", "image/gif", "image/webp":
+		return true
+	case "application/pdf", "text/plain", "text/markdown":
+		return true
+	default:
+		return false
+	}
 }

--- a/pkg/model/provider/anthropic/beta_client_test.go
+++ b/pkg/model/provider/anthropic/beta_client_test.go
@@ -262,7 +262,8 @@ func TestConvertBetaMessages_UserMessage(t *testing.T) {
 		},
 	}
 
-	converted := convertBetaMessages(msgs)
+	converted, err := testClient().convertBetaMessages(t.Context(), msgs)
+	require.NoError(t, err)
 
 	require.Len(t, converted, 1)
 	assert.Equal(t, anthropic.BetaMessageParamRoleUser, converted[0].Role)
@@ -282,7 +283,8 @@ func TestConvertBetaMessages_SkipsSystemMessages(t *testing.T) {
 		},
 	}
 
-	converted := convertBetaMessages(msgs)
+	converted, err := testClient().convertBetaMessages(t.Context(), msgs)
+	require.NoError(t, err)
 
 	require.Len(t, converted, 1)
 	assert.Equal(t, anthropic.BetaMessageParamRoleUser, converted[0].Role)
@@ -297,7 +299,8 @@ func TestConvertBetaMessages_AssistantMessage(t *testing.T) {
 		},
 	}
 
-	converted := convertBetaMessages(msgs)
+	converted, err := testClient().convertBetaMessages(t.Context(), msgs)
+	require.NoError(t, err)
 
 	require.Len(t, converted, 1)
 	assert.Equal(t, anthropic.BetaMessageParamRoleAssistant, converted[0].Role)

--- a/pkg/model/provider/anthropic/beta_converter_test.go
+++ b/pkg/model/provider/anthropic/beta_converter_test.go
@@ -60,7 +60,8 @@ func TestConvertBetaMessages_MergesConsecutiveToolMessages(t *testing.T) {
 	}
 
 	// Convert to Beta format
-	betaMessages := convertBetaMessages(messages)
+	betaMessages, err := testClient().convertBetaMessages(t.Context(), messages)
+	require.NoError(t, err)
 
 	require.Len(t, betaMessages, 4, "Should have 4 messages after conversion")
 
@@ -83,7 +84,7 @@ func TestConvertBetaMessages_MergesConsecutiveToolMessages(t *testing.T) {
 	assert.Contains(t, toolResultIDs, "tool_call_2")
 
 	// Most importantly: validate that the sequence is valid for Anthropic API
-	err := validateAnthropicSequencingBeta(betaMessages)
+	err = validateAnthropicSequencingBeta(betaMessages)
 	require.NoError(t, err, "Converted messages should pass Anthropic sequencing validation")
 }
 
@@ -119,11 +120,12 @@ func TestConvertBetaMessages_SingleToolMessage(t *testing.T) {
 		},
 	}
 
-	betaMessages := convertBetaMessages(messages)
+	betaMessages, err := testClient().convertBetaMessages(t.Context(), messages)
+	require.NoError(t, err)
 	require.Len(t, betaMessages, 4)
 
 	// Validate sequence
-	err := validateAnthropicSequencingBeta(betaMessages)
+	err = validateAnthropicSequencingBeta(betaMessages)
 	require.NoError(t, err)
 }
 
@@ -179,9 +181,10 @@ func TestConvertBetaMessages_NonConsecutiveToolMessages(t *testing.T) {
 		},
 	}
 
-	betaMessages := convertBetaMessages(messages)
+	betaMessages, err := testClient().convertBetaMessages(t.Context(), messages)
+	require.NoError(t, err)
 
 	// Validate the entire sequence
-	err := validateAnthropicSequencingBeta(betaMessages)
+	err = validateAnthropicSequencingBeta(betaMessages)
 	require.NoError(t, err, "Messages with non-consecutive tool calls should still validate")
 }

--- a/pkg/model/provider/anthropic/files.go
+++ b/pkg/model/provider/anthropic/files.go
@@ -1,0 +1,420 @@
+package anthropic
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/anthropics/anthropic-sdk-go"
+
+	"github.com/docker/cagent/pkg/chat"
+)
+
+const (
+	// filesAPIBeta is the beta header value required for the Files API.
+	filesAPIBeta = "files-api-2025-04-14"
+
+	// defaultFileTTL is the default time-to-live for uploaded files.
+	defaultFileTTL = 24 * time.Hour
+)
+
+// UploadedFile represents a file that has been uploaded to Anthropic.
+type UploadedFile struct {
+	FileID      string
+	Filename    string
+	MimeType    string
+	SizeBytes   int64
+	UploadedAt  time.Time
+	LocalPath   string
+	ContentHash string
+}
+
+// inFlightUpload tracks an upload in progress to prevent duplicate concurrent uploads.
+type inFlightUpload struct {
+	done   chan struct{}
+	result *UploadedFile
+	err    error
+}
+
+// cacheKey creates a composite key for deduplication that includes both content hash and MIME type.
+// This prevents issues where identical content with different extensions would share cached uploads.
+// Uses a null byte as delimiter since it cannot appear in either SHA256 hex strings or MIME types.
+func cacheKey(contentHash, mimeType string) string {
+	return contentHash + "\x00" + mimeType
+}
+
+// FileManager manages file uploads to Anthropic's Files API.
+// It provides deduplication, caching, and TTL-based cleanup.
+// Thread-safe for concurrent use.
+type FileManager struct {
+	clientFn func(context.Context) (anthropic.Client, error)
+
+	mu       sync.RWMutex
+	uploads  map[string]*UploadedFile   // cache key (hash:mime) → uploaded file
+	paths    map[string]string          // local path → cache key
+	inFlight map[string]*inFlightUpload // cache key → in-progress upload
+}
+
+// NewFileManager creates a new FileManager with the given client factory.
+func NewFileManager(clientFn func(context.Context) (anthropic.Client, error)) *FileManager {
+	return &FileManager{
+		clientFn: clientFn,
+		uploads:  make(map[string]*UploadedFile),
+		paths:    make(map[string]string),
+		inFlight: make(map[string]*inFlightUpload),
+	}
+}
+
+// GetOrUpload returns an existing upload for the file or uploads it if not cached.
+// Files are deduplicated by content hash AND MIME type, so identical files with
+// different extensions will be uploaded separately.
+// Concurrent calls for the same file will wait for a single upload to complete.
+func (fm *FileManager) GetOrUpload(ctx context.Context, filePath string) (*UploadedFile, error) {
+	absPath, err := filepath.Abs(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get absolute path: %w", err)
+	}
+
+	// Determine MIME type early - needed for cache key
+	mimeType := chat.DetectMimeType(absPath)
+
+	// Check if we already have this path cached
+	fm.mu.RLock()
+	if key, ok := fm.paths[absPath]; ok {
+		if upload, ok := fm.uploads[key]; ok {
+			fm.mu.RUnlock()
+			return upload, nil
+		}
+	}
+	fm.mu.RUnlock()
+
+	// Open file once and compute hash while reading for upload preparation
+	// This validates the file exists and is readable
+	file, err := os.Open(absPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file: %w", err)
+	}
+	defer file.Close()
+
+	stat, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat file: %w", err)
+	}
+
+	// Compute hash by reading file content
+	h := sha256.New()
+	if _, err := io.Copy(h, file); err != nil {
+		return nil, fmt.Errorf("failed to hash file: %w", err)
+	}
+	hash := hex.EncodeToString(h.Sum(nil))
+
+	// Create cache key from hash + MIME type
+	key := cacheKey(hash, mimeType)
+
+	// Try to get from cache or join an in-flight upload
+	fm.mu.Lock()
+
+	// Double-check cache after acquiring write lock
+	if upload, ok := fm.uploads[key]; ok {
+		fm.paths[absPath] = key
+		fm.mu.Unlock()
+		return upload, nil
+	}
+
+	// Check if there's an in-flight upload for this key
+	if flight, ok := fm.inFlight[key]; ok {
+		fm.mu.Unlock()
+		// Wait for the in-flight upload to complete
+		select {
+		case <-flight.done:
+			// Check context after waking up
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			if flight.err != nil {
+				return nil, flight.err
+			}
+			// Cache the path mapping
+			fm.mu.Lock()
+			fm.paths[absPath] = key
+			fm.mu.Unlock()
+			return flight.result, nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	// Start a new upload - register it as in-flight
+	flight := &inFlightUpload{
+		done: make(chan struct{}),
+	}
+	fm.inFlight[key] = flight
+	fm.mu.Unlock()
+
+	// Perform the upload (outside the lock)
+	// File needs to be re-opened since we consumed it for hashing
+	var upload *UploadedFile
+	func() {
+		defer func() {
+			fm.mu.Lock()
+			flight.result = upload
+			flight.err = err
+			close(flight.done)
+			delete(fm.inFlight, key)
+
+			// Cache successful uploads regardless of context cancellation.
+			// The file is already on Anthropic's servers and should be reusable.
+			if err == nil && upload != nil {
+				fm.uploads[key] = upload
+				fm.paths[absPath] = key
+			}
+			fm.mu.Unlock()
+		}()
+
+		upload, err = fm.upload(ctx, absPath, hash, mimeType, stat.Size())
+	}()
+
+	// If context was cancelled but upload succeeded, still return the upload.
+	// The file is already on Anthropic's servers and cached for reuse.
+	if err == nil && upload != nil {
+		return upload, nil
+	}
+
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	return upload, err
+}
+
+// upload performs the actual file upload to Anthropic.
+func (fm *FileManager) upload(ctx context.Context, filePath, contentHash, mimeType string, fileSize int64) (*UploadedFile, error) {
+	client, err := fm.clientFn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get client: %w", err)
+	}
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file: %w", err)
+	}
+	defer file.Close()
+
+	filename := filepath.Base(filePath)
+
+	slog.Debug("Uploading file to Anthropic Files API",
+		"filename", filename,
+		"mime_type", mimeType,
+		"size", fileSize)
+
+	// Use the SDK's File helper to create the upload
+	params := anthropic.BetaFileUploadParams{
+		File:  anthropic.File(file, filename, mimeType),
+		Betas: []anthropic.AnthropicBeta{filesAPIBeta},
+	}
+
+	result, err := client.Beta.Files.Upload(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to upload file: %w", err)
+	}
+
+	upload := &UploadedFile{
+		FileID:      result.ID,
+		Filename:    result.Filename,
+		MimeType:    result.MimeType,
+		SizeBytes:   result.SizeBytes,
+		UploadedAt:  time.Now(),
+		LocalPath:   filePath,
+		ContentHash: contentHash,
+	}
+
+	slog.Info("File uploaded to Anthropic",
+		"file_id", upload.FileID,
+		"filename", upload.Filename,
+		"size", upload.SizeBytes)
+
+	return upload, nil
+}
+
+// Delete removes a file from Anthropic's storage.
+func (fm *FileManager) Delete(ctx context.Context, fileID string) error {
+	client, err := fm.clientFn(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get client: %w", err)
+	}
+
+	params := anthropic.BetaFileDeleteParams{
+		Betas: []anthropic.AnthropicBeta{filesAPIBeta},
+	}
+
+	_, err = client.Beta.Files.Delete(ctx, fileID, params)
+	if err != nil {
+		return fmt.Errorf("failed to delete file: %w", err)
+	}
+
+	slog.Debug("Deleted file from Anthropic", "file_id", fileID)
+	return nil
+}
+
+// Cleanup removes files older than the specified TTL from both Anthropic and the cache.
+func (fm *FileManager) Cleanup(ctx context.Context, ttl time.Duration) error {
+	if ttl == 0 {
+		ttl = defaultFileTTL
+	}
+
+	cutoff := time.Now().Add(-ttl)
+
+	fm.mu.Lock()
+	defer fm.mu.Unlock()
+
+	// Collect keys to delete first to avoid modifying map during iteration
+	var keysToDelete []string
+	var errs []error
+
+	for key, upload := range fm.uploads {
+		if upload.UploadedAt.Before(cutoff) {
+			if err := fm.deleteUnlocked(ctx, upload.FileID); err != nil {
+				slog.Warn("Failed to delete expired file", "file_id", upload.FileID, "error", err)
+				errs = append(errs, err)
+				continue
+			}
+			keysToDelete = append(keysToDelete, key)
+		}
+	}
+
+	// Now delete from maps
+	for _, key := range keysToDelete {
+		delete(fm.uploads, key)
+	}
+
+	// Collect paths to delete
+	var pathsToDelete []string
+	for path, k := range fm.paths {
+		for _, deletedKey := range keysToDelete {
+			if k == deletedKey {
+				pathsToDelete = append(pathsToDelete, path)
+				break
+			}
+		}
+	}
+
+	for _, path := range pathsToDelete {
+		delete(fm.paths, path)
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to delete %d files during cleanup", len(errs))
+	}
+	return nil
+}
+
+// CleanupAll removes all cached files from Anthropic.
+func (fm *FileManager) CleanupAll(ctx context.Context) error {
+	fm.mu.Lock()
+	defer fm.mu.Unlock()
+
+	// Collect keys to delete first to avoid modifying map during iteration
+	var keysToDelete []string
+	var errs []error
+
+	for key, upload := range fm.uploads {
+		if err := fm.deleteUnlocked(ctx, upload.FileID); err != nil {
+			slog.Warn("Failed to delete file during cleanup", "file_id", upload.FileID, "error", err)
+			errs = append(errs, err)
+			continue
+		}
+		keysToDelete = append(keysToDelete, key)
+	}
+
+	// Now delete from map
+	for _, key := range keysToDelete {
+		delete(fm.uploads, key)
+	}
+
+	// Clear path mappings
+	fm.paths = make(map[string]string)
+
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to delete %d files during cleanup", len(errs))
+	}
+	return nil
+}
+
+// deleteUnlocked deletes a file without acquiring the lock (caller must hold lock).
+func (fm *FileManager) deleteUnlocked(ctx context.Context, fileID string) error {
+	client, err := fm.clientFn(ctx)
+	if err != nil {
+		return err
+	}
+
+	params := anthropic.BetaFileDeleteParams{
+		Betas: []anthropic.AnthropicBeta{filesAPIBeta},
+	}
+
+	_, err = client.Beta.Files.Delete(ctx, fileID, params)
+	return err
+}
+
+// CachedCount returns the number of files currently cached.
+func (fm *FileManager) CachedCount() int {
+	fm.mu.RLock()
+	defer fm.mu.RUnlock()
+	return len(fm.uploads)
+}
+
+// hashFile computes the SHA256 hash of a file's contents.
+// Note: This function is only used for testing and legacy code paths.
+// The main GetOrUpload path computes the hash inline to avoid opening the file twice.
+func hashFile(filePath string) (string, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, file); err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// IsImageMime returns true if the MIME type is an image type supported by Anthropic.
+func IsImageMime(mimeType string) bool {
+	switch mimeType {
+	case "image/jpeg", "image/png", "image/gif", "image/webp":
+		return true
+	default:
+		return false
+	}
+}
+
+// IsDocumentMime returns true if the MIME type is a document type supported by Anthropic.
+func IsDocumentMime(mimeType string) bool {
+	switch mimeType {
+	case "application/pdf", "text/plain", "text/markdown":
+		return true
+	default:
+		return false
+	}
+}
+
+// IsSupportedMime returns true if the MIME type is supported by Anthropic's Files API.
+func IsSupportedMime(mimeType string) bool {
+	return chat.IsSupportedMimeType(mimeType)
+}
+
+// ErrUnsupportedFileType is returned when a file type is not supported by the Files API.
+var ErrUnsupportedFileType = errors.New("unsupported file type for Anthropic Files API")
+
+// ErrFileManagerNotInitialized is returned when file operations are attempted without a FileManager.
+var ErrFileManagerNotInitialized = errors.New("file manager not initialized")

--- a/pkg/model/provider/anthropic/files_test.go
+++ b/pkg/model/provider/anthropic/files_test.go
@@ -1,0 +1,239 @@
+package anthropic
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/cagent/pkg/chat"
+)
+
+func TestDetectMimeType(t *testing.T) {
+	tests := []struct {
+		path     string
+		expected string
+	}{
+		{"image.jpg", "image/jpeg"},
+		{"image.jpeg", "image/jpeg"},
+		{"image.png", "image/png"},
+		{"image.gif", "image/gif"},
+		{"image.webp", "image/webp"},
+		{"document.pdf", "application/pdf"},
+		{"readme.txt", "text/plain"},
+		{"readme.md", "text/markdown"},
+		{"readme.markdown", "text/markdown"},
+		// json and csv are treated as text/plain for provider compatibility
+		{"data.json", "text/plain"},
+		{"data.csv", "text/plain"},
+		{"unknown.xyz", "application/octet-stream"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			result := chat.DetectMimeType(tt.path)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsImageMime(t *testing.T) {
+	tests := []struct {
+		mimeType string
+		expected bool
+	}{
+		{"image/jpeg", true},
+		{"image/png", true},
+		{"image/gif", true},
+		{"image/webp", true},
+		{"application/pdf", false},
+		{"text/plain", false},
+		{"application/octet-stream", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.mimeType, func(t *testing.T) {
+			result := IsImageMime(tt.mimeType)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsDocumentMime(t *testing.T) {
+	tests := []struct {
+		mimeType string
+		expected bool
+	}{
+		{"application/pdf", true},
+		{"text/plain", true},
+		{"text/markdown", true},
+		{"image/jpeg", false},
+		{"image/png", false},
+		{"application/octet-stream", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.mimeType, func(t *testing.T) {
+			result := IsDocumentMime(tt.mimeType)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsSupportedMime(t *testing.T) {
+	tests := []struct {
+		mimeType string
+		expected bool
+	}{
+		{"image/jpeg", true},
+		{"image/png", true},
+		{"image/gif", true},
+		{"image/webp", true},
+		{"application/pdf", true},
+		{"text/plain", true},
+		{"text/markdown", true},
+		{"application/json", false},
+		{"application/octet-stream", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.mimeType, func(t *testing.T) {
+			result := IsSupportedMime(tt.mimeType)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestHashFile(t *testing.T) {
+	// Create a temporary file
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.txt")
+	content := []byte("test content for hashing")
+	err := os.WriteFile(testFile, content, 0o644)
+	require.NoError(t, err)
+
+	// Hash should be consistent for same content
+	hash1, err := hashFile(testFile)
+	require.NoError(t, err)
+	assert.NotEmpty(t, hash1)
+
+	hash2, err := hashFile(testFile)
+	require.NoError(t, err)
+	assert.Equal(t, hash1, hash2)
+
+	// Different content should produce different hash
+	testFile2 := filepath.Join(tmpDir, "test2.txt")
+	err = os.WriteFile(testFile2, []byte("different content"), 0o644)
+	require.NoError(t, err)
+
+	hash3, err := hashFile(testFile2)
+	require.NoError(t, err)
+	assert.NotEqual(t, hash1, hash3)
+}
+
+func TestHashFile_NotFound(t *testing.T) {
+	_, err := hashFile("/nonexistent/path/to/file.txt")
+	assert.Error(t, err)
+}
+
+func TestNewFileManager(t *testing.T) {
+	fm := NewFileManager(nil)
+	require.NotNil(t, fm)
+	assert.Equal(t, 0, fm.CachedCount())
+}
+
+func TestUploadedFile_TTL(t *testing.T) {
+	old := &UploadedFile{
+		FileID:     "file_old",
+		UploadedAt: time.Now().Add(-25 * time.Hour),
+	}
+	recent := &UploadedFile{
+		FileID:     "file_recent",
+		UploadedAt: time.Now().Add(-1 * time.Hour),
+	}
+
+	cutoff := time.Now().Add(-24 * time.Hour)
+
+	assert.True(t, old.UploadedAt.Before(cutoff), "old file should be before cutoff")
+	assert.False(t, recent.UploadedAt.Before(cutoff), "recent file should not be before cutoff")
+}
+
+func TestFileManager_Deduplication(t *testing.T) {
+	// This test verifies the deduplication logic structure
+	// Actual upload testing would require mocking the Anthropic client
+
+	fm := NewFileManager(nil)
+	require.NotNil(t, fm)
+
+	// Manually populate the cache to test deduplication logic
+	testHash := "abc123"
+	testFile := &UploadedFile{
+		FileID:      "file_test",
+		Filename:    "test.png",
+		MimeType:    "image/png",
+		ContentHash: testHash,
+		UploadedAt:  time.Now(),
+		LocalPath:   "/path/to/test.png",
+	}
+
+	fm.mu.Lock()
+	fm.uploads[testHash] = testFile
+	fm.paths["/path/to/test.png"] = testHash
+	fm.mu.Unlock()
+
+	// Check that the file is cached
+	assert.Equal(t, 1, fm.CachedCount())
+
+	// Verify the path mapping exists
+	fm.mu.RLock()
+	hash, ok := fm.paths["/path/to/test.png"]
+	fm.mu.RUnlock()
+	assert.True(t, ok)
+	assert.Equal(t, testHash, hash)
+
+	// Verify the upload exists
+	fm.mu.RLock()
+	upload, ok := fm.uploads[testHash]
+	fm.mu.RUnlock()
+	assert.True(t, ok)
+	assert.Equal(t, "file_test", upload.FileID)
+}
+
+func TestCreateFileContentBlock_NotSupported(t *testing.T) {
+	// Standard API doesn't support file references - Files API is Beta-only
+	_, err := createFileContentBlock("file_123", "image/png")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Beta API")
+}
+
+func TestCreateBetaFileContentBlock_Image(t *testing.T) {
+	block, err := createBetaFileContentBlock("file_beta_123", "image/jpeg")
+	require.NoError(t, err)
+	assert.NotNil(t, block.OfImage)
+	assert.Nil(t, block.OfDocument)
+	assert.Equal(t, "file_beta_123", block.OfImage.Source.OfFile.FileID)
+}
+
+func TestCreateBetaFileContentBlock_Document(t *testing.T) {
+	block, err := createBetaFileContentBlock("file_beta_456", "application/pdf")
+	require.NoError(t, err)
+	assert.NotNil(t, block.OfDocument)
+	assert.Nil(t, block.OfImage)
+	assert.Equal(t, "file_beta_456", block.OfDocument.Source.OfFile.FileID)
+}
+
+func TestCreateBetaFileContentBlock_Unsupported(t *testing.T) {
+	_, err := createBetaFileContentBlock("file_beta_000", "video/mp4")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnsupportedFileType)
+}
+
+func TestFileManager_CleanupAll_Empty(t *testing.T) {
+	fm := NewFileManager(nil)
+	err := fm.CleanupAll(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 0, fm.CachedCount())
+}


### PR DESCRIPTION
## PR: Anthropic Files API Integration

### What it does

Attachments are now uploaded once to Anthropic's Files API and referenced by ID, instead of being base64-
encoded inline in every request. This dramatically reduces context window usage for image and document
attachments.

### Benefits

• Massive token savings: A 1MB image that previously consumed ~200k tokens now uses just a file reference
• Deduplication: Same file attached multiple times shares a single upload (content-hash based)
• Supports more file types: Images (jpeg, png, gif, webp) and documents (pdf, txt)
• Backward compatible: Existing sessions with base64 attachments continue to work

### Supported file types

Type
Images: image/jpeg ,  image/png ,  image/gif ,  image/webp
Documents: application/pdf ,  text/plain ,  text/markdown