### PR TITLE
Fix subagent logic

### DIFF
--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -449,7 +449,7 @@ func buildInvariantSystemMessages(a *agent.Agent) []chat.Message {
 	var messages []chat.Message
 
 	if a.HasSubAgents() {
-		subAgents := append(a.SubAgents(), a.Parents()...)
+		subAgents := a.SubAgents()
 
 		var text strings.Builder
 		var validAgentIDs []string


### PR DESCRIPTION
Fixes subagent delegation and validates model outputs to be valid subagents when `transfer_task` is called

This fixes an agent being able to delegate to another agent which is not explicitly configured in its `sub_agents` list