### PR TITLE
refactor(sandbox): extract Runner interface and move Docker runner to `pkg/sandbox`

### DIFF
--- a/pkg/sandbox/docker_test.go
+++ b/pkg/sandbox/docker_test.go
@@ -1,0 +1,77 @@
+package sandbox
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseSandboxPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input    string
+		wantPath string
+		wantMode string
+	}{
+		{input: ".", wantPath: ".", wantMode: "rw"},
+		{input: "/tmp", wantPath: "/tmp", wantMode: "rw"},
+		{input: "./src", wantPath: "./src", wantMode: "rw"},
+		{input: "/tmp:ro", wantPath: "/tmp", wantMode: "ro"},
+		{input: "./config:ro", wantPath: "./config", wantMode: "ro"},
+		{input: "/data:rw", wantPath: "/data", wantMode: "rw"},
+		{input: "./secrets:ro", wantPath: "./secrets", wantMode: "ro"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			path, mode := ParseSandboxPath(tt.input)
+			assert.Equal(t, tt.wantPath, path)
+			assert.Equal(t, tt.wantMode, mode)
+		})
+	}
+}
+
+func TestIsValidEnvVarName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		valid bool
+	}{
+		{"HOME", true},
+		{"USER", true},
+		{"PATH", true},
+		{"_private", true},
+		{"MY_VAR_123", true},
+		{"a", true},
+		{"A", true},
+		{"_", true},
+		{"", false},
+		{"123", false},
+		{"1VAR", false},
+		{"VAR-NAME", false},
+		{"VAR.NAME", false},
+		{"VAR NAME", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := IsValidEnvVarName(tt.name)
+			assert.Equal(t, tt.valid, result, "IsValidEnvVarName(%q)", tt.name)
+		})
+	}
+}
+
+func TestIsProcessRunning(t *testing.T) {
+	t.Parallel()
+
+	// Current process should be running
+	assert.True(t, isProcessRunning(os.Getpid()), "Current process should be running")
+
+	// Non-existent PID should not be running (using a very high PID unlikely to exist)
+	assert.False(t, isProcessRunning(999999999), "Very high PID should not be running")
+}

--- a/pkg/sandbox/runner.go
+++ b/pkg/sandbox/runner.go
@@ -1,0 +1,24 @@
+package sandbox
+
+import (
+	"context"
+	"time"
+
+	"github.com/docker/cagent/pkg/tools"
+)
+
+// Runner is a pluggable interface for sandbox execution backends.
+// Implementations handle command execution in isolated environments
+// (Docker containers, Kubernetes pods, etc.).
+type Runner interface {
+	// RunCommand executes a command synchronously and returns the result.
+	// The timeoutCtx carries the command timeout; ctx is the parent context.
+	// cwd is the working directory inside the sandbox.
+	// timeout is the original duration for formatting timeout messages.
+	RunCommand(timeoutCtx, ctx context.Context, command, cwd string, timeout time.Duration) *tools.ToolCallResult
+
+	// Start initializes the runner (e.g., discover pod, start container).
+	Start(ctx context.Context) error
+	// Stop cleans up the runner (e.g., stop container).
+	Stop(ctx context.Context) error
+}

--- a/pkg/tools/builtin/shell_test.go
+++ b/pkg/tools/builtin/shell_test.go
@@ -1,16 +1,30 @@
 package builtin
 
 import (
+	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/cagent/pkg/config"
-	"github.com/docker/cagent/pkg/config/latest"
+	"github.com/docker/cagent/pkg/sandbox"
 	"github.com/docker/cagent/pkg/tools"
 )
+
+// noopRunner is a minimal sandbox.Runner for testing sandbox-mode behavior
+// without needing Docker.
+type noopRunner struct{}
+
+var _ sandbox.Runner = (*noopRunner)(nil)
+
+func (*noopRunner) RunCommand(_, _ context.Context, _, _ string, _ time.Duration) *tools.ToolCallResult {
+	return tools.ResultSuccess("<noop>")
+}
+func (*noopRunner) Start(context.Context) error { return nil }
+func (*noopRunner) Stop(context.Context) error  { return nil }
 
 func TestNewShellTool(t *testing.T) {
 	t.Setenv("SHELL", "/bin/bash")
@@ -124,47 +138,11 @@ func TestShellTool_ListBackgroundJobs(t *testing.T) {
 	assert.Contains(t, listResult.Output, "ID: job_")
 }
 
-func TestParseSandboxPath(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		input    string
-		wantPath string
-		wantMode string
-	}{
-		{input: ".", wantPath: ".", wantMode: "rw"},
-		{input: "/tmp", wantPath: "/tmp", wantMode: "rw"},
-		{input: "./src", wantPath: "./src", wantMode: "rw"},
-		{input: "/tmp:ro", wantPath: "/tmp", wantMode: "ro"},
-		{input: "./config:ro", wantPath: "./config", wantMode: "ro"},
-		{input: "/data:rw", wantPath: "/data", wantMode: "rw"},
-		{input: "./secrets:ro", wantPath: "./secrets", wantMode: "ro"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			t.Parallel()
-			path, mode := parseSandboxPath(tt.input)
-			assert.Equal(t, tt.wantPath, path)
-			assert.Equal(t, tt.wantMode, mode)
-		})
-	}
-}
-
 func TestShellTool_SandboxInstructions(t *testing.T) {
 	t.Parallel()
 
-	workingDir := "/workspace/project"
-	sandboxConfig := &latest.SandboxConfig{
-		Image: "alpine:latest",
-		Paths: []string{
-			".",
-			"/tmp",
-			"/home/user:ro",
-		},
-	}
-
-	tool := NewShellTool(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: workingDir}}, sandboxConfig)
+	runner := &noopRunner{}
+	tool := NewShellTool(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: "/workspace/project"}}, runner)
 
 	instructions := tool.Instructions()
 
@@ -190,48 +168,6 @@ func TestShellTool_NativeInstructions(t *testing.T) {
 	assert.Contains(t, instructions, "Shell Tool Usage Guide")
 	assert.NotContains(t, instructions, "Sandbox Mode")
 	assert.NotContains(t, instructions, "## Mounted Paths")
-}
-
-func TestIsValidEnvVarName(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name  string
-		valid bool
-	}{
-		{"HOME", true},
-		{"USER", true},
-		{"PATH", true},
-		{"_private", true},
-		{"MY_VAR_123", true},
-		{"a", true},
-		{"A", true},
-		{"_", true},
-		{"", false},
-		{"123", false},
-		{"1VAR", false},
-		{"VAR-NAME", false},
-		{"VAR.NAME", false},
-		{"VAR NAME", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			result := isValidEnvVarName(tt.name)
-			assert.Equal(t, tt.valid, result, "isValidEnvVarName(%q)", tt.name)
-		})
-	}
-}
-
-func TestIsProcessRunning(t *testing.T) {
-	t.Parallel()
-
-	// Current process should be running
-	assert.True(t, isProcessRunning(os.Getpid()), "Current process should be running")
-
-	// Non-existent PID should not be running (using a very high PID unlikely to exist)
-	assert.False(t, isProcessRunning(999999999), "Very high PID should not be running")
 }
 
 func TestResolveWorkDir(t *testing.T) {


### PR DESCRIPTION
Introduce a pluggable `sandbox.Runner` interface to decouple shell tool execution from the Docker sandbox implementation. This enables adding alternative sandbox backends without modifying the shell tool itself.

Changes:
- Add sandbox.Runner interface in `pkg/sandbox/runner.go`
- Move and refactor Docker sandbox from `pkg/tools/builtin/sandbox.go` to `pkg/sandbox/docker.go`, implementing the Runner interface
- Update `ShellTool` to accept `sandbox.Runner` instead of the concrete `*sandboxRunner` type
- Update registry to create `sandbox.DockerRunner` and pass it to `ShellTool`

@dgageot, FYI (I see you added the initial support for Sandbox under #1209).