### PR TITLE
better file attachments

### DIFF
--- a/pkg/chat/chat_test.go
+++ b/pkg/chat/chat_test.go
@@ -1,0 +1,171 @@
+package chat
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectMimeType(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		path     string
+		expected string
+	}{
+		// Images
+		{"photo.jpg", "image/jpeg"},
+		{"photo.jpeg", "image/jpeg"},
+		{"photo.png", "image/png"},
+		{"photo.gif", "image/gif"},
+		{"photo.webp", "image/webp"},
+		// PDF
+		{"document.pdf", "application/pdf"},
+		// Text files - all map to text/plain
+		{"readme.txt", "text/plain"},
+		{"readme.md", "text/plain"},
+		{"readme.markdown", "text/plain"},
+		{"data.json", "text/plain"},
+		{"data.csv", "text/plain"},
+		{"main.go", "text/plain"},
+		{"script.py", "text/plain"},
+		{"config.yaml", "text/plain"},
+		{"Makefile.mk", "text/plain"},
+		{"page.html", "text/plain"},
+		{"style.css", "text/plain"},
+		{"app.ts", "text/plain"},
+		{"app.tsx", "text/plain"},
+		{"lib.rs", "text/plain"},
+		{"Main.java", "text/plain"},
+		{"script.sh", "text/plain"},
+		{"config.toml", "text/plain"},
+		{"schema.sql", "text/plain"},
+		{"Dockerfile.dockerfile", "text/plain"},
+		{"query.graphql", "text/plain"},
+		{"icon.svg", "text/plain"},
+		{"changes.diff", "text/plain"},
+		// Unknown binary
+		{"archive.tar.gz", "application/octet-stream"},
+		{"program.exe", "application/octet-stream"},
+		{"movie.mp4", "application/octet-stream"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			t.Parallel()
+			result := DetectMimeType(tt.path)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsSupportedMimeType(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		mimeType string
+		expected bool
+	}{
+		{"image/jpeg", true},
+		{"image/png", true},
+		{"image/gif", true},
+		{"image/webp", true},
+		{"application/pdf", true},
+		{"text/plain", true},
+		{"text/markdown", false},
+		{"application/octet-stream", false},
+		{"video/mp4", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.mimeType, func(t *testing.T) {
+			t.Parallel()
+			result := IsSupportedMimeType(tt.mimeType)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsTextFile_KnownExtensions(t *testing.T) {
+	t.Parallel()
+	textFiles := []string{
+		"main.go", "script.py", "app.ts", "lib.rs", "Main.java",
+		"readme.md", "doc.txt", "data.json", "config.yaml",
+		"style.css", "page.html", "query.sql", "script.sh",
+		"config.toml", "schema.xml", "data.csv", "notes.org",
+		"code.cpp", "header.h", "module.ex", "func.hs",
+		"app.swift", "code.kt", "app.dart", "code.zig",
+		".gitignore", "Makefile.mk", "query.graphql",
+	}
+
+	for _, f := range textFiles {
+		t.Run(f, func(t *testing.T) {
+			t.Parallel()
+			assert.True(t, IsTextFile(f), "expected %s to be detected as text", f)
+		})
+	}
+}
+
+func TestIsTextFile_KnownBinaryExtensions(t *testing.T) {
+	t.Parallel()
+	// Binary extensions are not in the text allowlist and won't match byte-sniffing
+	// if the file doesn't exist (IsTextFile returns false for unreadable files)
+	binaryFiles := []string{
+		"archive.tar.gz", "program.exe", "movie.mp4", "image.png",
+	}
+
+	for _, f := range binaryFiles {
+		t.Run(f, func(t *testing.T) {
+			t.Parallel()
+			// These files don't exist, so byte-sniffing can't run either
+			assert.False(t, IsTextFile(f), "expected %s to not be detected as text", f)
+		})
+	}
+}
+
+func TestIsTextFile_ByteSniffing(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+
+	// File with unknown extension but text content
+	textFile := filepath.Join(tmpDir, "data.custom")
+	err := os.WriteFile(textFile, []byte("This is plain text content\nwith multiple lines\n"), 0o644)
+	require.NoError(t, err)
+	assert.True(t, IsTextFile(textFile), "text content with unknown extension should be detected as text")
+
+	// File with unknown extension and binary content (null bytes)
+	binFile := filepath.Join(tmpDir, "data.custom2")
+	err = os.WriteFile(binFile, []byte{0x00, 0x01, 0x02, 0x03, 0xFF}, 0o644)
+	require.NoError(t, err)
+	assert.False(t, IsTextFile(binFile), "binary content should not be detected as text")
+
+	// Empty file should be treated as text
+	emptyFile := filepath.Join(tmpDir, "empty.custom")
+	err = os.WriteFile(emptyFile, []byte{}, 0o644)
+	require.NoError(t, err)
+	assert.True(t, IsTextFile(emptyFile), "empty file should be treated as text")
+}
+
+func TestReadFileForInline(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+
+	testFile := filepath.Join(tmpDir, "example.go")
+	content := "package main\n\nfunc main() {}\n"
+	err := os.WriteFile(testFile, []byte(content), 0o644)
+	require.NoError(t, err)
+
+	result, err := ReadFileForInline(testFile)
+	require.NoError(t, err)
+
+	assert.Contains(t, result, `<attached_file path="`+testFile+`">`)
+	assert.Contains(t, result, content)
+	assert.Contains(t, result, `</attached_file>`)
+}
+
+func TestReadFileForInline_NotFound(t *testing.T) {
+	t.Parallel()
+	_, err := ReadFileForInline("/nonexistent/file.txt")
+	assert.Error(t, err)
+}

--- a/pkg/model/provider/anthropic/beta_converter.go
+++ b/pkg/model/provider/anthropic/beta_converter.go
@@ -263,7 +263,7 @@ func createBetaFileContentBlock(fileID, mimeType string) (anthropic.BetaContentB
 		}, nil
 	}
 
-	if IsDocumentMime(mimeType) {
+	if IsAnthropicDocumentMime(mimeType) {
 		return anthropic.BetaContentBlockParamUnion{
 			OfDocument: &anthropic.BetaRequestDocumentBlockParam{
 				Source: anthropic.BetaRequestDocumentBlockSourceUnionParam{

--- a/pkg/model/provider/anthropic/files.go
+++ b/pkg/model/provider/anthropic/files.go
@@ -398,10 +398,10 @@ func IsImageMime(mimeType string) bool {
 	}
 }
 
-// IsDocumentMime returns true if the MIME type is a document type supported by Anthropic.
-func IsDocumentMime(mimeType string) bool {
+// IsAnthropicDocumentMime returns true if the MIME type is a document type supported by Anthropic.
+func IsAnthropicDocumentMime(mimeType string) bool {
 	switch mimeType {
-	case "application/pdf", "text/plain", "text/markdown":
+	case "application/pdf", "text/plain":
 		return true
 	default:
 		return false

--- a/pkg/model/provider/anthropic/files_test.go
+++ b/pkg/model/provider/anthropic/files_test.go
@@ -24,8 +24,8 @@ func TestDetectMimeType(t *testing.T) {
 		{"image.webp", "image/webp"},
 		{"document.pdf", "application/pdf"},
 		{"readme.txt", "text/plain"},
-		{"readme.md", "text/markdown"},
-		{"readme.markdown", "text/markdown"},
+		{"readme.md", "text/plain"},
+		{"readme.markdown", "text/plain"},
 		// json and csv are treated as text/plain for provider compatibility
 		{"data.json", "text/plain"},
 		{"data.csv", "text/plain"},
@@ -69,7 +69,7 @@ func TestIsDocumentMime(t *testing.T) {
 	}{
 		{"application/pdf", true},
 		{"text/plain", true},
-		{"text/markdown", true},
+		{"text/markdown", false},
 		{"image/jpeg", false},
 		{"image/png", false},
 		{"application/octet-stream", false},
@@ -77,7 +77,7 @@ func TestIsDocumentMime(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.mimeType, func(t *testing.T) {
-			result := IsDocumentMime(tt.mimeType)
+			result := IsAnthropicDocumentMime(tt.mimeType)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -94,7 +94,7 @@ func TestIsSupportedMime(t *testing.T) {
 		{"image/webp", true},
 		{"application/pdf", true},
 		{"text/plain", true},
-		{"text/markdown", true},
+		{"text/markdown", false},
 		{"application/json", false},
 		{"application/octet-stream", false},
 	}


### PR DESCRIPTION
- Inline text based files instead of using dedicated file api for now (can be improved to detect text files and send the standard plaintext content type instead, but this is at least standard and will work the same for all providers right now)
- Don't strip placeholders in msg text, they can be useul when referencing multiple files
- Fix double @@ when using the file picker for an @ attachment

Fixes these issues seen in the screenshots below:
- text files not ending in .txt were being skipped;
- .md files were being rejected by anthropic's file api
- placeholders for the attachments were no longer showing in the TUI after sending the message



<img width="2764" height="1748" alt="Screenshot 2026-02-08 at 13 17 49" src="https://github.com/user-attachments/assets/c4c24d57-fb1e-464e-9de0-6c4667515f0b" />
<img width="4336" height="2804" alt="Screenshot 2026-02-08 at 13 20 34" src="https://github.com/user-attachments/assets/bd02107d-d5f1-477c-b23c-546c27e50424" />
