### PR TITLE
Wrap todo descriptions at word boundaries in sidebar

### DIFF
--- a/pkg/tui/components/tool/todotool/sidebar.go
+++ b/pkg/tui/components/tool/todotool/sidebar.go
@@ -58,12 +58,23 @@ func (c *SidebarComponent) Render() string {
 func (c *SidebarComponent) renderTodoLine(todo builtin.Todo) string {
 	icon, style := renderTodoIcon(todo.Status)
 
-	// Compute prefix width dynamically (icon + space separator)
 	prefix := icon + " "
-	maxDescWidth := c.width - lipgloss.Width(prefix)
-	description := toolcommon.TruncateText(todo.Description, maxDescWidth)
+	prefixWidth := lipgloss.Width(prefix)
+	maxDescWidth := max(1, c.width-prefixWidth)
 
-	return styles.TabPrimaryStyle.Render(style.Render(prefix + description))
+	wrapped := toolcommon.WrapLinesWords(todo.Description, maxDescWidth)
+	indent := strings.Repeat(" ", prefixWidth)
+
+	var b strings.Builder
+	for i, line := range wrapped {
+		if i == 0 {
+			b.WriteString(prefix + line)
+		} else {
+			b.WriteString("\n" + indent + line)
+		}
+	}
+
+	return styles.TabPrimaryStyle.Render(style.Render(b.String()))
 }
 
 func (c *SidebarComponent) renderTab(title, content string) string {

--- a/pkg/tui/components/toolcommon/common_test.go
+++ b/pkg/tui/components/toolcommon/common_test.go
@@ -378,6 +378,102 @@ func TestWrapLines(t *testing.T) {
 	}
 }
 
+func TestWrapLinesWords(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		width    int
+		expected []string
+	}{
+		{
+			name:     "fits on one line",
+			text:     "hello world",
+			width:    20,
+			expected: []string{"hello world"},
+		},
+		{
+			name:     "wraps at word boundary",
+			text:     "hello world foo",
+			width:    11,
+			expected: []string{"hello world", "foo"},
+		},
+		{
+			name:     "word exceeds width falls back to rune split",
+			text:     "supercalifragilistic",
+			width:    10,
+			expected: []string{"supercalif", "ragilistic"},
+		},
+		{
+			name:     "mixed short and long words",
+			text:     "hi supercalifragilistic ok",
+			width:    10,
+			expected: []string{"hi", "supercalif", "ragilistic", "ok"},
+		},
+		{
+			name:     "multiple lines input",
+			text:     "hello world\nfoo bar baz",
+			width:    9,
+			expected: []string{"hello", "world", "foo bar", "baz"},
+		},
+		{
+			name:     "empty string",
+			text:     "",
+			width:    10,
+			expected: []string{""},
+		},
+		{
+			name:     "zero width",
+			text:     "hello world",
+			width:    0,
+			expected: []string{"hello world"},
+		},
+		{
+			name:     "negative width",
+			text:     "hello world",
+			width:    -1,
+			expected: []string{"hello world"},
+		},
+		{
+			name:     "single word exactly at width",
+			text:     "hello",
+			width:    5,
+			expected: []string{"hello"},
+		},
+		{
+			name:     "preserves empty lines",
+			text:     "a\n\nb",
+			width:    10,
+			expected: []string{"a", "", "b"},
+		},
+		{
+			name:     "each word on its own line",
+			text:     "aa bb cc dd",
+			width:    3,
+			expected: []string{"aa", "bb", "cc", "dd"},
+		},
+		{
+			name:     "unicode words",
+			text:     "héllo wörld",
+			width:    6,
+			expected: []string{"héllo", "wörld"},
+		},
+		{
+			name:     "CJK word exceeds width",
+			text:     "你好世界 test",
+			width:    5,
+			expected: []string{"你好", "世界", "test"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := WrapLinesWords(tt.text, tt.width)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestTruncateText(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Replace truncation with word-aware wrapping so that todo items in the sidebar display their full description regardless of sidebar width.

Long descriptions wrap onto subsequent lines, indented to align with the text after the icon prefix, and line breaks prefer word boundaries over splitting mid-word.

### Changes

- **`pkg/tui/components/toolcommon/truncate.go`** — New `WrapLinesWords` function that wraps at word boundaries, falling back to rune-level splitting for words exceeding the available width.
- **`pkg/tui/components/tool/todotool/sidebar.go`** — Use `WrapLinesWords` instead of `TruncateText` so todo descriptions wrap fully with proper indentation on continuation lines.
- **`pkg/tui/components/toolcommon/common_test.go`** — Tests for `WrapLinesWords` covering normal wrapping, long words, multi-line input, edge cases, and unicode/CJK.

<img width="2168" height="1402" alt="Screenshot 2026-02-08 at 23 08 14" src="https://github.com/user-attachments/assets/5270744f-d283-4a81-9a7a-5ee793bf7307" />
