### PR TITLE
fix: show correct tool count in TUI when running in --remote mode

### DIFF
--- a/gen/cagent/v1/cagent.pb.go
+++ b/gen/cagent/v1/cagent.pb.go
@@ -4274,6 +4274,104 @@ func (x *ShellOutputEvent) GetOutput() string {
 	return ""
 }
 
+// GetAgentToolCountRequest is the request for GetAgentToolCount.
+type GetAgentToolCountRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	AgentName     string                 `protobuf:"bytes,2,opt,name=agent_name,json=agentName,proto3" json:"agent_name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetAgentToolCountRequest) Reset() {
+	*x = GetAgentToolCountRequest{}
+	mi := &file_cagent_v1_cagent_proto_msgTypes[65]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetAgentToolCountRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetAgentToolCountRequest) ProtoMessage() {}
+
+func (x *GetAgentToolCountRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cagent_v1_cagent_proto_msgTypes[65]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetAgentToolCountRequest.ProtoReflect.Descriptor instead.
+func (*GetAgentToolCountRequest) Descriptor() ([]byte, []int) {
+	return file_cagent_v1_cagent_proto_rawDescGZIP(), []int{65}
+}
+
+func (x *GetAgentToolCountRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *GetAgentToolCountRequest) GetAgentName() string {
+	if x != nil {
+		return x.AgentName
+	}
+	return ""
+}
+
+// GetAgentToolCountResponse is the response for GetAgentToolCount.
+type GetAgentToolCountResponse struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	AvailableTools int32                  `protobuf:"varint,1,opt,name=available_tools,json=availableTools,proto3" json:"available_tools,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *GetAgentToolCountResponse) Reset() {
+	*x = GetAgentToolCountResponse{}
+	mi := &file_cagent_v1_cagent_proto_msgTypes[66]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetAgentToolCountResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetAgentToolCountResponse) ProtoMessage() {}
+
+func (x *GetAgentToolCountResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cagent_v1_cagent_proto_msgTypes[66]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetAgentToolCountResponse.ProtoReflect.Descriptor instead.
+func (*GetAgentToolCountResponse) Descriptor() ([]byte, []int) {
+	return file_cagent_v1_cagent_proto_rawDescGZIP(), []int{66}
+}
+
+func (x *GetAgentToolCountResponse) GetAvailableTools() int32 {
+	if x != nil {
+		return x.AvailableTools
+	}
+	return 0
+}
+
 // PingRequest is the request for Ping.
 type PingRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -4283,7 +4381,7 @@ type PingRequest struct {
 
 func (x *PingRequest) Reset() {
 	*x = PingRequest{}
-	mi := &file_cagent_v1_cagent_proto_msgTypes[65]
+	mi := &file_cagent_v1_cagent_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4295,7 +4393,7 @@ func (x *PingRequest) String() string {
 func (*PingRequest) ProtoMessage() {}
 
 func (x *PingRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cagent_v1_cagent_proto_msgTypes[65]
+	mi := &file_cagent_v1_cagent_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4308,7 +4406,7 @@ func (x *PingRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PingRequest.ProtoReflect.Descriptor instead.
 func (*PingRequest) Descriptor() ([]byte, []int) {
-	return file_cagent_v1_cagent_proto_rawDescGZIP(), []int{65}
+	return file_cagent_v1_cagent_proto_rawDescGZIP(), []int{67}
 }
 
 // PingResponse is the response for Ping.
@@ -4321,7 +4419,7 @@ type PingResponse struct {
 
 func (x *PingResponse) Reset() {
 	*x = PingResponse{}
-	mi := &file_cagent_v1_cagent_proto_msgTypes[66]
+	mi := &file_cagent_v1_cagent_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4333,7 +4431,7 @@ func (x *PingResponse) String() string {
 func (*PingResponse) ProtoMessage() {}
 
 func (x *PingResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cagent_v1_cagent_proto_msgTypes[66]
+	mi := &file_cagent_v1_cagent_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4346,7 +4444,7 @@ func (x *PingResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PingResponse.ProtoReflect.Descriptor instead.
 func (*PingResponse) Descriptor() ([]byte, []int) {
-	return file_cagent_v1_cagent_proto_rawDescGZIP(), []int{66}
+	return file_cagent_v1_cagent_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *PingResponse) GetStatus() string {
@@ -4681,10 +4779,16 @@ const file_cagent_v1_cagent_proto_rawDesc = "" +
 	"\n" +
 	"agent_name\x18\x04 \x01(\tR\tagentName\"*\n" +
 	"\x10ShellOutputEvent\x12\x16\n" +
-	"\x06output\x18\x01 \x01(\tR\x06output\"\r\n" +
+	"\x06output\x18\x01 \x01(\tR\x06output\"I\n" +
+	"\x18GetAgentToolCountRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1d\n" +
+	"\n" +
+	"agent_name\x18\x02 \x01(\tR\tagentName\"D\n" +
+	"\x19GetAgentToolCountResponse\x12'\n" +
+	"\x0favailable_tools\x18\x01 \x01(\x05R\x0eavailableTools\"\r\n" +
 	"\vPingRequest\"&\n" +
 	"\fPingResponse\x12\x16\n" +
-	"\x06status\x18\x01 \x01(\tR\x06status2\xd1\a\n" +
+	"\x06status\x18\x01 \x01(\tR\x06status2\xb1\b\n" +
 	"\fAgentService\x12I\n" +
 	"\n" +
 	"ListAgents\x12\x1c.cagent.v1.ListAgentsRequest\x1a\x1d.cagent.v1.ListAgentsResponse\x12C\n" +
@@ -4698,7 +4802,8 @@ const file_cagent_v1_cagent_proto_rawDesc = "" +
 	"\x12ToggleToolApproval\x12$.cagent.v1.ToggleToolApprovalRequest\x1a%.cagent.v1.ToggleToolApprovalResponse\x12a\n" +
 	"\x12UpdateSessionTitle\x12$.cagent.v1.UpdateSessionTitleRequest\x1a%.cagent.v1.UpdateSessionTitleResponse\x12^\n" +
 	"\x11ResumeElicitation\x12#.cagent.v1.ResumeElicitationRequest\x1a$.cagent.v1.ResumeElicitationResponse\x12:\n" +
-	"\bRunAgent\x12\x1a.cagent.v1.RunAgentRequest\x1a\x10.cagent.v1.Event0\x01\x127\n" +
+	"\bRunAgent\x12\x1a.cagent.v1.RunAgentRequest\x1a\x10.cagent.v1.Event0\x01\x12^\n" +
+	"\x11GetAgentToolCount\x12#.cagent.v1.GetAgentToolCountRequest\x1a$.cagent.v1.GetAgentToolCountResponse\x127\n" +
 	"\x04Ping\x12\x16.cagent.v1.PingRequest\x1a\x17.cagent.v1.PingResponseB\x98\x01\n" +
 	"\rcom.cagent.v1B\vCagentProtoP\x01Z5github.com/docker/cagent/gen/proto/cagent/v1;cagentv1\xa2\x02\x03CXX\xaa\x02\tCagent.V1\xca\x02\tCagent\\V1\xe2\x02\x15Cagent\\V1\\GPBMetadata\xea\x02\n" +
 	"Cagent::V1b\x06proto3"
@@ -4715,7 +4820,7 @@ func file_cagent_v1_cagent_proto_rawDescGZIP() []byte {
 	return file_cagent_v1_cagent_proto_rawDescData
 }
 
-var file_cagent_v1_cagent_proto_msgTypes = make([]protoimpl.MessageInfo, 67)
+var file_cagent_v1_cagent_proto_msgTypes = make([]protoimpl.MessageInfo, 69)
 var file_cagent_v1_cagent_proto_goTypes = []any{
 	(*Agent)(nil),                      // 0: cagent.v1.Agent
 	(*ListAgentsRequest)(nil),          // 1: cagent.v1.ListAgentsRequest
@@ -4782,8 +4887,10 @@ var file_cagent_v1_cagent_proto_goTypes = []any{
 	(*RAGIndexingCompletedEvent)(nil),  // 62: cagent.v1.RAGIndexingCompletedEvent
 	(*HookBlockedEvent)(nil),           // 63: cagent.v1.HookBlockedEvent
 	(*ShellOutputEvent)(nil),           // 64: cagent.v1.ShellOutputEvent
-	(*PingRequest)(nil),                // 65: cagent.v1.PingRequest
-	(*PingResponse)(nil),               // 66: cagent.v1.PingResponse
+	(*GetAgentToolCountRequest)(nil),   // 65: cagent.v1.GetAgentToolCountRequest
+	(*GetAgentToolCountResponse)(nil),  // 66: cagent.v1.GetAgentToolCountResponse
+	(*PingRequest)(nil),                // 67: cagent.v1.PingRequest
+	(*PingResponse)(nil),               // 68: cagent.v1.PingResponse
 }
 var file_cagent_v1_cagent_proto_depIdxs = []int32{
 	0,  // 0: cagent.v1.ListAgentsResponse.agents:type_name -> cagent.v1.Agent
@@ -4850,21 +4957,23 @@ var file_cagent_v1_cagent_proto_depIdxs = []int32{
 	22, // 61: cagent.v1.AgentService.UpdateSessionTitle:input_type -> cagent.v1.UpdateSessionTitleRequest
 	24, // 62: cagent.v1.AgentService.ResumeElicitation:input_type -> cagent.v1.ResumeElicitationRequest
 	28, // 63: cagent.v1.AgentService.RunAgent:input_type -> cagent.v1.RunAgentRequest
-	65, // 64: cagent.v1.AgentService.Ping:input_type -> cagent.v1.PingRequest
-	2,  // 65: cagent.v1.AgentService.ListAgents:output_type -> cagent.v1.ListAgentsResponse
-	4,  // 66: cagent.v1.AgentService.GetAgent:output_type -> cagent.v1.GetAgentResponse
-	7,  // 67: cagent.v1.AgentService.ListSessions:output_type -> cagent.v1.ListSessionsResponse
-	13, // 68: cagent.v1.AgentService.GetSession:output_type -> cagent.v1.GetSessionResponse
-	15, // 69: cagent.v1.AgentService.CreateSession:output_type -> cagent.v1.CreateSessionResponse
-	17, // 70: cagent.v1.AgentService.DeleteSession:output_type -> cagent.v1.DeleteSessionResponse
-	19, // 71: cagent.v1.AgentService.ResumeSession:output_type -> cagent.v1.ResumeSessionResponse
-	21, // 72: cagent.v1.AgentService.ToggleToolApproval:output_type -> cagent.v1.ToggleToolApprovalResponse
-	23, // 73: cagent.v1.AgentService.UpdateSessionTitle:output_type -> cagent.v1.UpdateSessionTitleResponse
-	25, // 74: cagent.v1.AgentService.ResumeElicitation:output_type -> cagent.v1.ResumeElicitationResponse
-	29, // 75: cagent.v1.AgentService.RunAgent:output_type -> cagent.v1.Event
-	66, // 76: cagent.v1.AgentService.Ping:output_type -> cagent.v1.PingResponse
-	65, // [65:77] is the sub-list for method output_type
-	53, // [53:65] is the sub-list for method input_type
+	65, // 64: cagent.v1.AgentService.GetAgentToolCount:input_type -> cagent.v1.GetAgentToolCountRequest
+	67, // 65: cagent.v1.AgentService.Ping:input_type -> cagent.v1.PingRequest
+	2,  // 66: cagent.v1.AgentService.ListAgents:output_type -> cagent.v1.ListAgentsResponse
+	4,  // 67: cagent.v1.AgentService.GetAgent:output_type -> cagent.v1.GetAgentResponse
+	7,  // 68: cagent.v1.AgentService.ListSessions:output_type -> cagent.v1.ListSessionsResponse
+	13, // 69: cagent.v1.AgentService.GetSession:output_type -> cagent.v1.GetSessionResponse
+	15, // 70: cagent.v1.AgentService.CreateSession:output_type -> cagent.v1.CreateSessionResponse
+	17, // 71: cagent.v1.AgentService.DeleteSession:output_type -> cagent.v1.DeleteSessionResponse
+	19, // 72: cagent.v1.AgentService.ResumeSession:output_type -> cagent.v1.ResumeSessionResponse
+	21, // 73: cagent.v1.AgentService.ToggleToolApproval:output_type -> cagent.v1.ToggleToolApprovalResponse
+	23, // 74: cagent.v1.AgentService.UpdateSessionTitle:output_type -> cagent.v1.UpdateSessionTitleResponse
+	25, // 75: cagent.v1.AgentService.ResumeElicitation:output_type -> cagent.v1.ResumeElicitationResponse
+	29, // 76: cagent.v1.AgentService.RunAgent:output_type -> cagent.v1.Event
+	66, // 77: cagent.v1.AgentService.GetAgentToolCount:output_type -> cagent.v1.GetAgentToolCountResponse
+	68, // 78: cagent.v1.AgentService.Ping:output_type -> cagent.v1.PingResponse
+	66, // [66:79] is the sub-list for method output_type
+	53, // [53:66] is the sub-list for method input_type
 	53, // [53:53] is the sub-list for extension type_name
 	53, // [53:53] is the sub-list for extension extendee
 	0,  // [0:53] is the sub-list for field type_name
@@ -4912,7 +5021,7 @@ func file_cagent_v1_cagent_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_cagent_v1_cagent_proto_rawDesc), len(file_cagent_v1_cagent_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   67,
+			NumMessages:   69,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/proto/cagent/v1/cagent.pb.go
+++ b/gen/proto/cagent/v1/cagent.pb.go
@@ -4274,6 +4274,104 @@ func (x *ShellOutputEvent) GetOutput() string {
 	return ""
 }
 
+// GetAgentToolCountRequest is the request for GetAgentToolCount.
+type GetAgentToolCountRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	AgentName     string                 `protobuf:"bytes,2,opt,name=agent_name,json=agentName,proto3" json:"agent_name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetAgentToolCountRequest) Reset() {
+	*x = GetAgentToolCountRequest{}
+	mi := &file_cagent_v1_cagent_proto_msgTypes[65]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetAgentToolCountRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetAgentToolCountRequest) ProtoMessage() {}
+
+func (x *GetAgentToolCountRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cagent_v1_cagent_proto_msgTypes[65]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetAgentToolCountRequest.ProtoReflect.Descriptor instead.
+func (*GetAgentToolCountRequest) Descriptor() ([]byte, []int) {
+	return file_cagent_v1_cagent_proto_rawDescGZIP(), []int{65}
+}
+
+func (x *GetAgentToolCountRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *GetAgentToolCountRequest) GetAgentName() string {
+	if x != nil {
+		return x.AgentName
+	}
+	return ""
+}
+
+// GetAgentToolCountResponse is the response for GetAgentToolCount.
+type GetAgentToolCountResponse struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	AvailableTools int32                  `protobuf:"varint,1,opt,name=available_tools,json=availableTools,proto3" json:"available_tools,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *GetAgentToolCountResponse) Reset() {
+	*x = GetAgentToolCountResponse{}
+	mi := &file_cagent_v1_cagent_proto_msgTypes[66]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetAgentToolCountResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetAgentToolCountResponse) ProtoMessage() {}
+
+func (x *GetAgentToolCountResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cagent_v1_cagent_proto_msgTypes[66]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetAgentToolCountResponse.ProtoReflect.Descriptor instead.
+func (*GetAgentToolCountResponse) Descriptor() ([]byte, []int) {
+	return file_cagent_v1_cagent_proto_rawDescGZIP(), []int{66}
+}
+
+func (x *GetAgentToolCountResponse) GetAvailableTools() int32 {
+	if x != nil {
+		return x.AvailableTools
+	}
+	return 0
+}
+
 // PingRequest is the request for Ping.
 type PingRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -4283,7 +4381,7 @@ type PingRequest struct {
 
 func (x *PingRequest) Reset() {
 	*x = PingRequest{}
-	mi := &file_cagent_v1_cagent_proto_msgTypes[65]
+	mi := &file_cagent_v1_cagent_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4295,7 +4393,7 @@ func (x *PingRequest) String() string {
 func (*PingRequest) ProtoMessage() {}
 
 func (x *PingRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cagent_v1_cagent_proto_msgTypes[65]
+	mi := &file_cagent_v1_cagent_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4308,7 +4406,7 @@ func (x *PingRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PingRequest.ProtoReflect.Descriptor instead.
 func (*PingRequest) Descriptor() ([]byte, []int) {
-	return file_cagent_v1_cagent_proto_rawDescGZIP(), []int{65}
+	return file_cagent_v1_cagent_proto_rawDescGZIP(), []int{67}
 }
 
 // PingResponse is the response for Ping.
@@ -4321,7 +4419,7 @@ type PingResponse struct {
 
 func (x *PingResponse) Reset() {
 	*x = PingResponse{}
-	mi := &file_cagent_v1_cagent_proto_msgTypes[66]
+	mi := &file_cagent_v1_cagent_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4333,7 +4431,7 @@ func (x *PingResponse) String() string {
 func (*PingResponse) ProtoMessage() {}
 
 func (x *PingResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cagent_v1_cagent_proto_msgTypes[66]
+	mi := &file_cagent_v1_cagent_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4346,7 +4444,7 @@ func (x *PingResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PingResponse.ProtoReflect.Descriptor instead.
 func (*PingResponse) Descriptor() ([]byte, []int) {
-	return file_cagent_v1_cagent_proto_rawDescGZIP(), []int{66}
+	return file_cagent_v1_cagent_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *PingResponse) GetStatus() string {
@@ -4681,10 +4779,16 @@ const file_cagent_v1_cagent_proto_rawDesc = "" +
 	"\n" +
 	"agent_name\x18\x04 \x01(\tR\tagentName\"*\n" +
 	"\x10ShellOutputEvent\x12\x16\n" +
-	"\x06output\x18\x01 \x01(\tR\x06output\"\r\n" +
+	"\x06output\x18\x01 \x01(\tR\x06output\"I\n" +
+	"\x18GetAgentToolCountRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1d\n" +
+	"\n" +
+	"agent_name\x18\x02 \x01(\tR\tagentName\"D\n" +
+	"\x19GetAgentToolCountResponse\x12'\n" +
+	"\x0favailable_tools\x18\x01 \x01(\x05R\x0eavailableTools\"\r\n" +
 	"\vPingRequest\"&\n" +
 	"\fPingResponse\x12\x16\n" +
-	"\x06status\x18\x01 \x01(\tR\x06status2\xd1\a\n" +
+	"\x06status\x18\x01 \x01(\tR\x06status2\xb1\b\n" +
 	"\fAgentService\x12I\n" +
 	"\n" +
 	"ListAgents\x12\x1c.cagent.v1.ListAgentsRequest\x1a\x1d.cagent.v1.ListAgentsResponse\x12C\n" +
@@ -4698,7 +4802,8 @@ const file_cagent_v1_cagent_proto_rawDesc = "" +
 	"\x12ToggleToolApproval\x12$.cagent.v1.ToggleToolApprovalRequest\x1a%.cagent.v1.ToggleToolApprovalResponse\x12a\n" +
 	"\x12UpdateSessionTitle\x12$.cagent.v1.UpdateSessionTitleRequest\x1a%.cagent.v1.UpdateSessionTitleResponse\x12^\n" +
 	"\x11ResumeElicitation\x12#.cagent.v1.ResumeElicitationRequest\x1a$.cagent.v1.ResumeElicitationResponse\x12:\n" +
-	"\bRunAgent\x12\x1a.cagent.v1.RunAgentRequest\x1a\x10.cagent.v1.Event0\x01\x127\n" +
+	"\bRunAgent\x12\x1a.cagent.v1.RunAgentRequest\x1a\x10.cagent.v1.Event0\x01\x12^\n" +
+	"\x11GetAgentToolCount\x12#.cagent.v1.GetAgentToolCountRequest\x1a$.cagent.v1.GetAgentToolCountResponse\x127\n" +
 	"\x04Ping\x12\x16.cagent.v1.PingRequest\x1a\x17.cagent.v1.PingResponseB\x98\x01\n" +
 	"\rcom.cagent.v1B\vCagentProtoP\x01Z5github.com/docker/cagent/gen/proto/cagent/v1;cagentv1\xa2\x02\x03CXX\xaa\x02\tCagent.V1\xca\x02\tCagent\\V1\xe2\x02\x15Cagent\\V1\\GPBMetadata\xea\x02\n" +
 	"Cagent::V1b\x06proto3"
@@ -4715,7 +4820,7 @@ func file_cagent_v1_cagent_proto_rawDescGZIP() []byte {
 	return file_cagent_v1_cagent_proto_rawDescData
 }
 
-var file_cagent_v1_cagent_proto_msgTypes = make([]protoimpl.MessageInfo, 67)
+var file_cagent_v1_cagent_proto_msgTypes = make([]protoimpl.MessageInfo, 69)
 var file_cagent_v1_cagent_proto_goTypes = []any{
 	(*Agent)(nil),                      // 0: cagent.v1.Agent
 	(*ListAgentsRequest)(nil),          // 1: cagent.v1.ListAgentsRequest
@@ -4782,8 +4887,10 @@ var file_cagent_v1_cagent_proto_goTypes = []any{
 	(*RAGIndexingCompletedEvent)(nil),  // 62: cagent.v1.RAGIndexingCompletedEvent
 	(*HookBlockedEvent)(nil),           // 63: cagent.v1.HookBlockedEvent
 	(*ShellOutputEvent)(nil),           // 64: cagent.v1.ShellOutputEvent
-	(*PingRequest)(nil),                // 65: cagent.v1.PingRequest
-	(*PingResponse)(nil),               // 66: cagent.v1.PingResponse
+	(*GetAgentToolCountRequest)(nil),   // 65: cagent.v1.GetAgentToolCountRequest
+	(*GetAgentToolCountResponse)(nil),  // 66: cagent.v1.GetAgentToolCountResponse
+	(*PingRequest)(nil),                // 67: cagent.v1.PingRequest
+	(*PingResponse)(nil),               // 68: cagent.v1.PingResponse
 }
 var file_cagent_v1_cagent_proto_depIdxs = []int32{
 	0,  // 0: cagent.v1.ListAgentsResponse.agents:type_name -> cagent.v1.Agent
@@ -4850,21 +4957,23 @@ var file_cagent_v1_cagent_proto_depIdxs = []int32{
 	22, // 61: cagent.v1.AgentService.UpdateSessionTitle:input_type -> cagent.v1.UpdateSessionTitleRequest
 	24, // 62: cagent.v1.AgentService.ResumeElicitation:input_type -> cagent.v1.ResumeElicitationRequest
 	28, // 63: cagent.v1.AgentService.RunAgent:input_type -> cagent.v1.RunAgentRequest
-	65, // 64: cagent.v1.AgentService.Ping:input_type -> cagent.v1.PingRequest
-	2,  // 65: cagent.v1.AgentService.ListAgents:output_type -> cagent.v1.ListAgentsResponse
-	4,  // 66: cagent.v1.AgentService.GetAgent:output_type -> cagent.v1.GetAgentResponse
-	7,  // 67: cagent.v1.AgentService.ListSessions:output_type -> cagent.v1.ListSessionsResponse
-	13, // 68: cagent.v1.AgentService.GetSession:output_type -> cagent.v1.GetSessionResponse
-	15, // 69: cagent.v1.AgentService.CreateSession:output_type -> cagent.v1.CreateSessionResponse
-	17, // 70: cagent.v1.AgentService.DeleteSession:output_type -> cagent.v1.DeleteSessionResponse
-	19, // 71: cagent.v1.AgentService.ResumeSession:output_type -> cagent.v1.ResumeSessionResponse
-	21, // 72: cagent.v1.AgentService.ToggleToolApproval:output_type -> cagent.v1.ToggleToolApprovalResponse
-	23, // 73: cagent.v1.AgentService.UpdateSessionTitle:output_type -> cagent.v1.UpdateSessionTitleResponse
-	25, // 74: cagent.v1.AgentService.ResumeElicitation:output_type -> cagent.v1.ResumeElicitationResponse
-	29, // 75: cagent.v1.AgentService.RunAgent:output_type -> cagent.v1.Event
-	66, // 76: cagent.v1.AgentService.Ping:output_type -> cagent.v1.PingResponse
-	65, // [65:77] is the sub-list for method output_type
-	53, // [53:65] is the sub-list for method input_type
+	65, // 64: cagent.v1.AgentService.GetAgentToolCount:input_type -> cagent.v1.GetAgentToolCountRequest
+	67, // 65: cagent.v1.AgentService.Ping:input_type -> cagent.v1.PingRequest
+	2,  // 66: cagent.v1.AgentService.ListAgents:output_type -> cagent.v1.ListAgentsResponse
+	4,  // 67: cagent.v1.AgentService.GetAgent:output_type -> cagent.v1.GetAgentResponse
+	7,  // 68: cagent.v1.AgentService.ListSessions:output_type -> cagent.v1.ListSessionsResponse
+	13, // 69: cagent.v1.AgentService.GetSession:output_type -> cagent.v1.GetSessionResponse
+	15, // 70: cagent.v1.AgentService.CreateSession:output_type -> cagent.v1.CreateSessionResponse
+	17, // 71: cagent.v1.AgentService.DeleteSession:output_type -> cagent.v1.DeleteSessionResponse
+	19, // 72: cagent.v1.AgentService.ResumeSession:output_type -> cagent.v1.ResumeSessionResponse
+	21, // 73: cagent.v1.AgentService.ToggleToolApproval:output_type -> cagent.v1.ToggleToolApprovalResponse
+	23, // 74: cagent.v1.AgentService.UpdateSessionTitle:output_type -> cagent.v1.UpdateSessionTitleResponse
+	25, // 75: cagent.v1.AgentService.ResumeElicitation:output_type -> cagent.v1.ResumeElicitationResponse
+	29, // 76: cagent.v1.AgentService.RunAgent:output_type -> cagent.v1.Event
+	66, // 77: cagent.v1.AgentService.GetAgentToolCount:output_type -> cagent.v1.GetAgentToolCountResponse
+	68, // 78: cagent.v1.AgentService.Ping:output_type -> cagent.v1.PingResponse
+	66, // [66:79] is the sub-list for method output_type
+	53, // [53:66] is the sub-list for method input_type
 	53, // [53:53] is the sub-list for extension type_name
 	53, // [53:53] is the sub-list for extension extendee
 	0,  // [0:53] is the sub-list for field type_name
@@ -4912,7 +5021,7 @@ func file_cagent_v1_cagent_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_cagent_v1_cagent_proto_rawDesc), len(file_cagent_v1_cagent_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   67,
+			NumMessages:   69,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/connectrpc/server.go
+++ b/pkg/connectrpc/server.go
@@ -306,6 +306,23 @@ func (s *Server) Ping(_ context.Context, _ *connect.Request[cagentv1.PingRequest
 	}), nil
 }
 
+// GetAgentToolCount returns the number of tools available for an agent.
+func (s *Server) GetAgentToolCount(ctx context.Context, req *connect.Request[cagentv1.GetAgentToolCountRequest]) (*connect.Response[cagentv1.GetAgentToolCountResponse], error) {
+	agentName := req.Msg.AgentName
+	if agentName == "" {
+		agentName = "root"
+	}
+
+	count, err := s.sm.GetAgentToolCount(ctx, req.Msg.Id, agentName)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to get agent tool count: %w", err))
+	}
+
+	return connect.NewResponse(&cagentv1.GetAgentToolCountResponse{
+		AvailableTools: int32(count),
+	}), nil
+}
+
 // Helper functions for converting between types
 
 func sessionMessageToProto(msg session.Message) *cagentv1.Message {

--- a/pkg/runtime/client.go
+++ b/pkg/runtime/client.go
@@ -79,6 +79,15 @@ func NewClient(baseURL string, opts ...ClientOption) (*Client, error) {
 			"agent_choice_reasoning": func() Event { return &AgentChoiceReasoningEvent{} },
 			"mcp_init_started":       func() Event { return &MCPInitStartedEvent{} },
 			"mcp_init_finished":      func() Event { return &MCPInitFinishedEvent{} },
+			"agent_info":             func() Event { return &AgentInfoEvent{} },
+			"team_info":              func() Event { return &TeamInfoEvent{} },
+			"toolset_info":           func() Event { return &ToolsetInfoEvent{} },
+			"agent_switching":        func() Event { return &AgentSwitchingEvent{} },
+			"warning":                func() Event { return &WarningEvent{} },
+			"hook_blocked":           func() Event { return &HookBlockedEvent{} },
+			"rag_indexing_started":   func() Event { return &RAGIndexingStartedEvent{} },
+			"rag_indexing_progress":  func() Event { return &RAGIndexingProgressEvent{} },
+			"rag_indexing_completed": func() Event { return &RAGIndexingCompletedEvent{} },
 		},
 	}
 
@@ -383,4 +392,18 @@ func (c *Client) ResumeElicitation(ctx context.Context, sessionID string, action
 func (c *Client) UpdateSessionTitle(ctx context.Context, sessionID, title string) error {
 	req := api.UpdateSessionTitleRequest{Title: title}
 	return c.doRequest(ctx, http.MethodPatch, "/api/sessions/"+sessionID+"/title", req, nil)
+}
+
+// GetAgentToolCount returns the number of tools available for an agent.
+func (c *Client) GetAgentToolCount(ctx context.Context, agentFilename, agentName string) (int, error) {
+	var resp struct {
+		AvailableTools int `json:"available_tools"`
+	}
+	endpoint := fmt.Sprintf("/api/agents/%s/%s/tools/count", url.PathEscape(agentFilename), url.PathEscape(agentName))
+	err := c.doRequest(ctx, http.MethodGet, endpoint, nil, &resp)
+	if err != nil {
+		return 0, err
+	}
+
+	return resp.AvailableTools, nil
 }

--- a/pkg/runtime/connectrpc_client.go
+++ b/pkg/runtime/connectrpc_client.go
@@ -183,6 +183,19 @@ func (c *ConnectRPCClient) UpdateSessionTitle(ctx context.Context, sessionID, ti
 	return err
 }
 
+// GetAgentToolCount returns the number of tools available for an agent.
+func (c *ConnectRPCClient) GetAgentToolCount(ctx context.Context, agentFilename, agentName string) (int, error) {
+	resp, err := c.client.GetAgentToolCount(ctx, connect.NewRequest(&cagentv1.GetAgentToolCountRequest{
+		Id:        agentFilename,
+		AgentName: agentName,
+	}))
+	if err != nil {
+		return 0, err
+	}
+
+	return int(resp.Msg.AvailableTools), nil
+}
+
 // ResumeElicitation sends an elicitation response
 func (c *ConnectRPCClient) ResumeElicitation(ctx context.Context, sessionID string, action tools.ElicitationAction, content map[string]any) error {
 	contentJSON, err := json.Marshal(content)

--- a/pkg/runtime/remote_client.go
+++ b/pkg/runtime/remote_client.go
@@ -32,6 +32,9 @@ type RemoteClient interface {
 
 	// UpdateSessionTitle updates the title of a session
 	UpdateSessionTitle(ctx context.Context, sessionID, title string) error
+
+	// GetAgentToolCount returns the number of tools available for an agent
+	GetAgentToolCount(ctx context.Context, agentFilename, agentName string) (int, error)
 }
 
 // Verify that both clients implement RemoteClient

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -64,6 +64,9 @@ func New(ctx context.Context, sessionStore session.Store, runConfig *config.Runt
 	group.POST("/sessions/:id/agent/:agent/:agent_name", s.runAgent)
 	group.POST("/sessions/:id/elicitation", s.elicitation)
 
+	// Agent tool count
+	group.GET("/agents/:id/:agent_name/tools/count", s.getAgentToolCount)
+
 	// Health check endpoint
 	group.GET("/ping", func(c echo.Context) error {
 		return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
@@ -218,6 +221,15 @@ func (s *Server) toggleSessionYolo(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to toggle session tool approval mode: %v", err))
 	}
 	return c.JSON(http.StatusOK, nil)
+}
+
+func (s *Server) getAgentToolCount(c echo.Context) error {
+	count, err := s.sm.GetAgentToolCount(c.Request().Context(), c.Param("id"), c.Param("agent_name"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to get agent tool count: %v", err))
+	}
+
+	return c.JSON(http.StatusOK, map[string]int{"available_tools": count})
 }
 
 func (s *Server) toggleSessionThinking(c echo.Context) error {

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -394,3 +394,24 @@ func (sm *SessionManager) loadTeam(ctx context.Context, agentFilename string, ru
 
 	return teamloader.Load(ctx, agentSource, runConfig)
 }
+
+// GetAgentToolCount loads the agent's team and returns the number of
+// tools available to the given agent.
+func (sm *SessionManager) GetAgentToolCount(ctx context.Context, agentFilename, agentName string) (int, error) {
+	t, err := sm.loadTeam(ctx, agentFilename, sm.runConfig)
+	if err != nil {
+		return 0, err
+	}
+
+	a, err := t.Agent(agentName)
+	if err != nil {
+		return 0, err
+	}
+
+	agentTools, err := a.Tools(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get tools: %w", err)
+	}
+
+	return len(agentTools), nil
+}

--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -1131,7 +1131,9 @@ func (m *model) toolsetInfo(contentWidth int) string {
 	var lines []string
 
 	// Tools status line
-	lines = append(lines, m.renderToolsStatus())
+	if toolsStatus := m.renderToolsStatus(); toolsStatus != "" {
+		lines = append(lines, toolsStatus)
+	}
 
 	// Skills status line
 	if m.availableSkills > 0 {

--- a/proto/cagent/v1/cagent.proto
+++ b/proto/cagent/v1/cagent.proto
@@ -39,6 +39,11 @@ service AgentService {
   // RunAgent runs an agent loop and streams events.
   rpc RunAgent(RunAgentRequest) returns (stream Event);
 
+  // GetAgentToolCount returns the number of tools available for an agent.
+  // This is used by the remote TUI to display the tool count at startup
+  // without waiting for the first RunAgent call.
+  rpc GetAgentToolCount(GetAgentToolCountRequest) returns (GetAgentToolCountResponse);
+
   // Ping is a health check endpoint.
   rpc Ping(PingRequest) returns (PingResponse);
 }
@@ -499,6 +504,17 @@ message HookBlockedEvent {
 // ShellOutputEvent is sent for shell output.
 message ShellOutputEvent {
   string output = 1;
+}
+
+// GetAgentToolCountRequest is the request for GetAgentToolCount.
+message GetAgentToolCountRequest {
+  string id = 1;
+  string agent_name = 2;
+}
+
+// GetAgentToolCountResponse is the response for GetAgentToolCount.
+message GetAgentToolCountResponse {
+  int32 available_tools = 1;
 }
 
 // PingRequest is the request for Ping.


### PR DESCRIPTION
The remote TUI sidebar displayed an incorrect tool count because of two issues:

1. The HTTP SSE client was missing event type registrations for toolset_info, agent_info, team_info, agent_switching, and several other event types added after the initial implementation. These events were silently dropped, so the TUI never received the real tool count streamed by the server during RunStream.

2. RemoteRuntime.EmitStartupInfo used len(cfg.Toolsets) — the number of toolset configurations (e.g. mcp, shell, filesystem) — instead of the actual number of individual tools. There was no server-side API to query the real count at startup.

This commit:
- Adds missing event types to the HTTP SSE client registry
- Adds a GetAgentToolCount RPC (proto + ConnectRPC + HTTP) that loads the agent's team and counts its tools server-side
- Updates RemoteRuntime.EmitStartupInfo to call GetAgentToolCount, showing a loading indicator while the count is fetched
- Fixes the sidebar to skip empty tool status lines

Assisted-By: cagent