### PR TITLE
fix: use alt modifier for session browser shortcuts to avoid search conflict

### DIFF
--- a/pkg/tui/dialog/session_browser.go
+++ b/pkg/tui/dialog/session_browser.go
@@ -42,9 +42,9 @@ func defaultSessionBrowserKeyMap() sessionBrowserKeyMap {
 		PageDown:   base.PageDown,
 		Enter:      base.Enter,
 		Escape:     base.Escape,
-		Star:       key.NewBinding(key.WithKeys("s")),
-		FilterStar: key.NewBinding(key.WithKeys("f")),
-		CopyID:     key.NewBinding(key.WithKeys("c")),
+		Star:       key.NewBinding(key.WithKeys("alt+s")),
+		FilterStar: key.NewBinding(key.WithKeys("alt+f")),
+		CopyID:     key.NewBinding(key.WithKeys("alt+c")),
 	}
 }
 
@@ -306,7 +306,7 @@ func (d *sessionBrowserDialog) View() string {
 		AddSeparator().
 		AddContent(idFooter).
 		AddSpace().
-		AddHelpKeys("↑/↓", "navigate", "s", "star", "f", filterDesc, "c", "copy id", "enter", "load", "esc", "close").
+		AddHelpKeys("↑/↓", "navigate", "alt+s", "star", "alt+f", filterDesc, "alt+c", "copy id", "enter", "load", "esc", "close").
 		Build()
 
 	return styles.DialogStyle.Width(dialogWidth).Render(content)


### PR DESCRIPTION
Plain `s`, `f`, and `c` keys were intercepted by the star, filter, and copy-id actions before reaching the search text input, making it impossible to search for sessions containing those characters.

Change the key bindings to `alt+s`, `alt+f`, and `alt+c` so that unmodified key presses are forwarded to the search input as expected.

Fixes #1642