### PR TITLE
Refactor scrollbar into more reusable `scrollview` component

### DIFF
--- a/pkg/tui/components/messages/messages_test.go
+++ b/pkg/tui/components/messages/messages_test.go
@@ -844,7 +844,7 @@ func BenchmarkMessagesView_RenderWhileScrolling(b *testing.B) {
 	for i := range b.N {
 		// Vary scroll position to simulate wheel scrolling
 		m.scrollOffset = (i % 50) * 2
-		m.scrollbar.SetScrollOffset(m.scrollOffset)
+		m.scrollview.SetScrollOffset(m.scrollOffset)
 		_ = m.View()
 	}
 }
@@ -871,7 +871,7 @@ func BenchmarkMessagesView_LargeHistory(b *testing.B) {
 
 	for i := range b.N {
 		m.scrollOffset = (i % 100) * 5
-		m.scrollbar.SetScrollOffset(m.scrollOffset)
+		m.scrollview.SetScrollOffset(m.scrollOffset)
 		_ = m.View()
 	}
 }

--- a/pkg/tui/components/scrollview/scrollview.go
+++ b/pkg/tui/components/scrollview/scrollview.go
@@ -1,0 +1,324 @@
+// Package scrollview provides a composable scrollable view that pairs content
+// with a fixed-position scrollbar. It guarantees that every rendered line is
+// exactly [Model.width] columns wide and exactly [Model.height] lines tall
+//
+// Simple path: call [Model.Update] + [Model.View].
+// Advanced path (custom scroll management): use [Model.UpdateMouse],
+// [Model.SetScrollOffset], and [Model.ViewWithLines].
+package scrollview
+
+import (
+	"strings"
+
+	"charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/docker/cagent/pkg/tui/components/scrollbar"
+)
+
+// ScrollKeyMap defines which keys trigger scroll actions.
+type ScrollKeyMap struct {
+	Up       key.Binding // optional — leave unset for list dialogs that use up/down for selection
+	Down     key.Binding
+	PageUp   key.Binding
+	PageDown key.Binding
+	Top      key.Binding // home
+	Bottom   key.Binding // end
+}
+
+// DefaultScrollKeyMap returns a key map with page-up/down and home/end.
+// Up/Down are intentionally unbound so list dialogs can use them for selection.
+func DefaultScrollKeyMap() *ScrollKeyMap {
+	return &ScrollKeyMap{
+		PageUp:   key.NewBinding(key.WithKeys("pgup")),
+		PageDown: key.NewBinding(key.WithKeys("pgdown")),
+		Top:      key.NewBinding(key.WithKeys("home")),
+		Bottom:   key.NewBinding(key.WithKeys("end")),
+	}
+}
+
+// ReadOnlyScrollKeyMap returns a key map where up/down/j/k also scroll.
+func ReadOnlyScrollKeyMap() *ScrollKeyMap {
+	return &ScrollKeyMap{
+		Up:       key.NewBinding(key.WithKeys("up", "k")),
+		Down:     key.NewBinding(key.WithKeys("down", "j")),
+		PageUp:   key.NewBinding(key.WithKeys("pgup")),
+		PageDown: key.NewBinding(key.WithKeys("pgdown")),
+		Top:      key.NewBinding(key.WithKeys("home")),
+		Bottom:   key.NewBinding(key.WithKeys("end")),
+	}
+}
+
+type Option func(*Model)
+
+// WithGapWidth sets the space columns between content and scrollbar (default 1).
+func WithGapWidth(n int) Option { return func(m *Model) { m.gapWidth = n } }
+
+// WithReserveScrollbarSpace always reserves gap+scrollbar columns, preventing layout shifts.
+func WithReserveScrollbarSpace(v bool) Option {
+	return func(m *Model) { m.reserveScrollbarSpace = v }
+}
+
+// WithWheelStep sets lines scrolled per wheel tick (default 2).
+func WithWheelStep(n int) Option { return func(m *Model) { m.wheelStep = n } }
+
+// WithKeyMap sets keyboard bindings for scroll actions. Pass nil to disable.
+func WithKeyMap(km *ScrollKeyMap) Option { return func(m *Model) { m.keyMap = km } }
+
+// Model is a composable scrollable view that owns a scrollbar and ensures
+// fixed-width rendering.
+type Model struct {
+	sb *scrollbar.Model
+
+	xPos, yPos    int
+	width, height int
+
+	gapWidth              int
+	reserveScrollbarSpace bool
+	wheelStep             int
+	keyMap                *ScrollKeyMap
+
+	lines       []string
+	totalHeight int
+
+	// scrollOffset tracks the desired scroll position independently of the
+	// scrollbar, so EnsureLineVisible works before SetContent is called.
+	scrollOffset int
+}
+
+// New creates a new scrollview with the given options.
+func New(opts ...Option) *Model {
+	m := &Model{
+		sb:        scrollbar.New(),
+		gapWidth:  1,
+		wheelStep: 2,
+		keyMap:    DefaultScrollKeyMap(),
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}
+
+// SetSize sets the total width and height of the scrollable region.
+func (m *Model) SetSize(width, height int) {
+	m.width = width
+	m.height = height
+	m.updateScrollbarPosition()
+}
+
+// SetPosition sets the absolute screen position (for mouse hit-testing).
+func (m *Model) SetPosition(x, y int) {
+	m.xPos = x
+	m.yPos = y
+	m.updateScrollbarPosition()
+}
+
+// SetContent provides the full content buffer and total height.
+// totalHeight may be >= len(lines) for virtual blank lines (e.g. bottomSlack).
+func (m *Model) SetContent(lines []string, totalHeight int) {
+	m.lines = lines
+	m.totalHeight = max(totalHeight, len(lines))
+	m.sb.SetDimensions(m.height, m.totalHeight)
+}
+
+// NeedsScrollbar returns true if content is taller than the viewport.
+func (m *Model) NeedsScrollbar() bool { return m.totalHeight > m.height }
+
+// ContentWidth returns the width available for content text.
+func (m *Model) ContentWidth() int {
+	if m.reserveScrollbarSpace || m.NeedsScrollbar() {
+		return max(1, m.width-m.gapWidth-scrollbar.Width)
+	}
+	return max(1, m.width)
+}
+
+// ReservedCols returns columns reserved for gap + scrollbar.
+func (m *Model) ReservedCols() int { return m.gapWidth + scrollbar.Width }
+
+// VisibleHeight returns the viewport height in lines.
+func (m *Model) VisibleHeight() int { return m.height }
+
+// ScrollbarX returns the absolute screen X of the scrollbar column.
+func (m *Model) ScrollbarX() int { return m.xPos + m.width - scrollbar.Width }
+
+// ScrollOffset returns the current scroll offset.
+func (m *Model) ScrollOffset() int { return m.scrollOffset }
+
+// SetScrollOffset sets the scroll offset, clamped when content dimensions are known.
+func (m *Model) SetScrollOffset(offset int) {
+	m.scrollOffset = max(0, offset)
+	if m.totalHeight > 0 && m.height > 0 {
+		m.scrollOffset = min(m.scrollOffset, max(0, m.totalHeight-m.height))
+	}
+	m.sb.SetScrollOffset(m.scrollOffset)
+}
+
+// ScrollBy adjusts the scroll offset by delta lines.
+func (m *Model) ScrollBy(delta int) { m.SetScrollOffset(m.scrollOffset + delta) }
+func (m *Model) LineUp()            { m.ScrollBy(-1) }
+func (m *Model) LineDown()          { m.ScrollBy(1) }
+func (m *Model) PageUp()            { m.ScrollBy(-m.height) }
+func (m *Model) PageDown()          { m.ScrollBy(m.height) }
+func (m *Model) ScrollToTop()       { m.SetScrollOffset(0) }
+func (m *Model) ScrollToBottom()    { m.SetScrollOffset(m.totalHeight) }
+
+// EnsureLineVisible scrolls minimally to bring a line into the viewport.
+// Works before [SetContent] — only needs [SetSize].
+func (m *Model) EnsureLineVisible(line int) {
+	m.EnsureRangeVisible(line, line)
+}
+
+// EnsureRangeVisible scrolls minimally to bring lines startLine..endLine into
+// the view. If the range is taller than the view, the start is prioritized.
+func (m *Model) EnsureRangeVisible(startLine, endLine int) {
+	startLine = max(0, startLine)
+	endLine = max(startLine, endLine)
+	if endLine >= m.scrollOffset+m.height {
+		m.SetScrollOffset(endLine - m.height + 1)
+	}
+	if startLine < m.scrollOffset {
+		m.SetScrollOffset(startLine)
+	}
+}
+
+// Update handles mouse (scrollbar click/drag/wheel) and keyboard scroll events.
+// Returns handled=true when the event was consumed.
+func (m *Model) Update(msg tea.Msg) (handled bool, cmd tea.Cmd) {
+	m.updateScrollbarPosition() // Ensure scrollbar position is fresh for hit-testing
+	switch msg := msg.(type) {
+	case tea.MouseClickMsg, tea.MouseMotionMsg, tea.MouseReleaseMsg:
+		return m.UpdateMouse(msg)
+
+	case tea.MouseWheelMsg:
+		switch msg.Button.String() {
+		case "wheelup":
+			m.ScrollBy(-m.wheelStep)
+			return true, nil
+		case "wheeldown":
+			m.ScrollBy(m.wheelStep)
+			return true, nil
+		}
+
+	case tea.KeyPressMsg:
+		if m.keyMap == nil {
+			return false, nil
+		}
+		switch {
+		case m.keyMap.Up.Enabled() && key.Matches(msg, m.keyMap.Up):
+			m.LineUp()
+			return true, nil
+		case m.keyMap.Down.Enabled() && key.Matches(msg, m.keyMap.Down):
+			m.LineDown()
+			return true, nil
+		case key.Matches(msg, m.keyMap.PageUp):
+			m.PageUp()
+			return true, nil
+		case key.Matches(msg, m.keyMap.PageDown):
+			m.PageDown()
+			return true, nil
+		case key.Matches(msg, m.keyMap.Top):
+			m.ScrollToTop()
+			return true, nil
+		case key.Matches(msg, m.keyMap.Bottom):
+			m.ScrollToBottom()
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// UpdateMouse delegates mouse events to the scrollbar. Low-level alternative to [Update].
+func (m *Model) UpdateMouse(msg tea.Msg) (handled bool, cmd tea.Cmd) {
+	prev := m.scrollOffset
+	sb, c := m.sb.Update(msg)
+	m.sb = sb
+	m.scrollOffset = m.sb.GetScrollOffset()
+	return m.scrollOffset != prev || m.sb.IsDragging(), c
+}
+
+// IsDragging returns whether the scrollbar thumb is being dragged.
+func (m *Model) IsDragging() bool { return m.sb.IsDragging() }
+
+// View renders the scrollable region with automatic content slicing.
+// Output is exactly width columns wide and height lines tall.
+func (m *Model) View() string {
+	if m.width <= 0 || m.height <= 0 {
+		return ""
+	}
+	m.syncScrollbar()
+
+	// Slice visible window from content
+	visible := make([]string, m.height)
+	for i := range m.height {
+		if idx := m.scrollOffset + i; idx < len(m.lines) {
+			visible[i] = m.lines[idx]
+		}
+	}
+	return m.compose(visible)
+}
+
+// ViewWithLines renders pre-sliced visible lines with the scrollbar.
+// The caller provides exactly the visible window; scrollview handles
+// padding, truncation, and scrollbar composition.
+func (m *Model) ViewWithLines(visibleLines []string) string {
+	if m.width <= 0 || m.height <= 0 {
+		return ""
+	}
+	m.syncScrollbar()
+
+	result := make([]string, m.height)
+	copy(result, visibleLines)
+	return m.compose(result)
+}
+
+// syncScrollbar syncs the local scroll offset to the scrollbar and reads back the clamped value.
+func (m *Model) syncScrollbar() {
+	m.sb.SetDimensions(m.height, m.totalHeight)
+	m.sb.SetScrollOffset(m.scrollOffset)
+	m.scrollOffset = m.sb.GetScrollOffset()
+}
+
+// compose pads/truncates lines to contentWidth and joins with the scrollbar column.
+// lines must have exactly m.height entries.
+func (m *Model) compose(lines []string) string {
+	contentWidth := m.ContentWidth()
+
+	// Pad or truncate each line to exact content width
+	for i, line := range lines {
+		w := ansi.StringWidth(line)
+		switch {
+		case w > contentWidth:
+			lines[i] = ansi.Truncate(line, contentWidth, "")
+		case w < contentWidth:
+			lines[i] = line + strings.Repeat(" ", contentWidth-w)
+		}
+	}
+
+	contentView := strings.Join(lines, "\n")
+
+	// Build the right-side column (scrollbar, placeholder, or nothing)
+	if m.NeedsScrollbar() {
+		return lipgloss.JoinHorizontal(lipgloss.Top, contentView, m.buildColumn(m.gapWidth), m.sb.View())
+	}
+	if m.reserveScrollbarSpace {
+		return lipgloss.JoinHorizontal(lipgloss.Top, contentView, m.buildColumn(m.gapWidth+scrollbar.Width))
+	}
+	return contentView
+}
+
+// buildColumn returns a column of spaces with the given width and m.height lines.
+func (m *Model) buildColumn(colWidth int) string {
+	col := strings.Repeat(" ", colWidth)
+	lines := make([]string, m.height)
+	for i := range lines {
+		lines[i] = col
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (m *Model) updateScrollbarPosition() {
+	m.sb.SetPosition(m.ScrollbarX(), m.yPos)
+}

--- a/pkg/tui/components/sidebar/layout_test.go
+++ b/pkg/tui/components/sidebar/layout_test.go
@@ -182,7 +182,7 @@ func BenchmarkSidebarVerticalView_Scroll(b *testing.B) {
 
 	for i := range b.N {
 		// Simulate scrolling by updating scroll offset
-		m.scrollbar.SetScrollOffset(i % 10)
+		m.scrollview.SetScrollOffset(i % 10)
 		_ = m.verticalView()
 	}
 }

--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/cagent/pkg/session"
 	"github.com/docker/cagent/pkg/tools"
 	"github.com/docker/cagent/pkg/tui/components/scrollbar"
+	"github.com/docker/cagent/pkg/tui/components/scrollview"
 	"github.com/docker/cagent/pkg/tui/components/spinner"
 	"github.com/docker/cagent/pkg/tui/components/tab"
 	"github.com/docker/cagent/pkg/tui/components/tool/todotool"
@@ -90,6 +91,8 @@ type Model interface {
 	SetTitleRegenerating(regenerating bool) tea.Cmd
 	// ScrollByWheel applies a wheel delta to the sidebar scrollbar.
 	ScrollByWheel(delta int)
+	// IsScrollbarDragging returns true when the scrollbar thumb is being dragged.
+	IsScrollbarDragging() bool
 }
 
 // ragIndexingState tracks per-strategy indexing progress
@@ -127,7 +130,7 @@ type model struct {
 	toolsLoading       bool // true when more tools may still be loading
 	sessionState       *service.SessionState
 	workingAgent       string // Name of the agent currently working (empty if none)
-	scrollbar          *scrollbar.Model
+	scrollview         *scrollview.Model
 	workingDirectory   string
 	queuedMessages     []string // Truncated preview of queued messages
 	streamCancelled    bool     // true after ESC cancel until next StreamStartedEvent
@@ -162,17 +165,20 @@ func New(sessionState *service.SessionState, opts ...Option) Model {
 	ti.Prompt = "" // No prompt to maximize usable width in collapsed sidebar
 
 	m := &model{
-		width:              20,
-		layoutCfg:          DefaultLayoutConfig(),
-		height:             24,
-		sessionUsage:       make(map[string]*runtime.Usage),
-		sessionAgent:       make(map[string]string),
-		todoComp:           todotool.NewSidebarComponent(),
-		spinner:            spinner.New(spinner.ModeSpinnerOnly, styles.SpinnerDotsHighlightStyle),
-		sessionTitle:       "New session",
-		ragIndexing:        make(map[string]*ragIndexingState),
-		sessionState:       sessionState,
-		scrollbar:          scrollbar.New(),
+		width:        20,
+		layoutCfg:    DefaultLayoutConfig(),
+		height:       24,
+		sessionUsage: make(map[string]*runtime.Usage),
+		sessionAgent: make(map[string]string),
+		todoComp:     todotool.NewSidebarComponent(),
+		spinner:      spinner.New(spinner.ModeSpinnerOnly, styles.SpinnerDotsHighlightStyle),
+		sessionTitle: "New session",
+		ragIndexing:  make(map[string]*ragIndexingState),
+		sessionState: sessionState,
+		scrollview: scrollview.New(
+			scrollview.WithWheelStep(1),
+			scrollview.WithKeyMap(nil), // Sidebar has no keyboard scroll — only mouse
+		),
 		workingDirectory:   getCurrentWorkingDirectory(),
 		reasoningSupported: true,
 		preferredWidth:     DefaultWidth,
@@ -317,11 +323,15 @@ func (m *model) SetTitleRegenerating(regenerating bool) tea.Cmd {
 	return nil
 }
 
+func (m *model) IsScrollbarDragging() bool {
+	return m.scrollview.IsDragging()
+}
+
 func (m *model) ScrollByWheel(delta int) {
 	if m.mode != ModeVertical || delta == 0 {
 		return
 	}
-	m.scrollbar.SetScrollOffset(m.scrollbar.GetScrollOffset() + delta)
+	m.scrollview.ScrollBy(delta)
 }
 
 // ClickResult indicates what was clicked in the sidebar
@@ -367,7 +377,7 @@ func (m *model) HandleClickType(x, y int) ClickResult {
 	}
 
 	// In vertical mode, the title starts at verticalStarY
-	scrollOffset := m.scrollbar.GetScrollOffset()
+	scrollOffset := m.scrollview.ScrollOffset()
 	contentY := y + scrollOffset // Convert viewport Y to content Y
 	titleLines := m.titleLineCount()
 
@@ -479,21 +489,10 @@ func (m *model) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		cmd := m.SetSize(msg.Width, msg.Height)
 		return m, cmd
-	case tea.MouseClickMsg, tea.MouseMotionMsg, tea.MouseReleaseMsg:
+	case tea.MouseClickMsg, tea.MouseMotionMsg, tea.MouseReleaseMsg, tea.MouseWheelMsg:
 		if m.mode == ModeVertical {
-			sb, cmd := m.scrollbar.Update(msg)
-			m.scrollbar = sb
+			_, cmd := m.scrollview.Update(msg)
 			return m, cmd
-		}
-		return m, nil
-	case tea.MouseWheelMsg:
-		if m.mode == ModeVertical {
-			switch msg.Button.String() {
-			case "wheelup":
-				m.ScrollByWheel(-1)
-			case "wheeldown":
-				m.ScrollByWheel(1)
-			}
 		}
 		return m, nil
 	case *runtime.TokenUsageEvent:
@@ -776,19 +775,18 @@ func (m *model) collapsedView() string {
 }
 
 func (m *model) verticalView() string {
-	visibleLines := m.height
 	contentWidthNoScroll := m.contentWidth(false)
 
 	// Use cached render if available and width hasn't changed
 	if !m.cacheDirty && len(m.cachedLines) > 0 && m.cachedWidth == contentWidthNoScroll {
-		return m.renderFromCache(visibleLines)
+		return m.renderFromCache()
 	}
 
 	// Two-pass rendering: first check if scrollbar is needed
 	// Pass 1: render without scrollbar to count lines
 	lines := m.renderSections(contentWidthNoScroll)
 	totalLines := len(lines)
-	needsScrollbar := totalLines > visibleLines
+	needsScrollbar := totalLines > m.height
 
 	// Pass 2: if scrollbar needed, re-render with narrower content width
 	if needsScrollbar {
@@ -802,43 +800,22 @@ func (m *model) verticalView() string {
 	m.cachedNeedsScrollbar = needsScrollbar
 	m.cacheDirty = false
 
-	return m.renderFromCache(visibleLines)
+	return m.renderFromCache()
 }
 
-// renderFromCache renders the sidebar from cached lines, applying scroll offset and scrollbar.
-func (m *model) renderFromCache(visibleLines int) string {
-	lines := m.cachedLines
-	totalLines := len(lines)
-	needsScrollbar := m.cachedNeedsScrollbar
-
-	// Update scrollbar dimensions
-	m.scrollbar.SetDimensions(visibleLines, totalLines)
-
-	// Get scroll offset from scrollbar
-	scrollOffset := m.scrollbar.GetScrollOffset()
-
-	// Extract visible portion - copy to avoid mutating cache
-	endIdx := min(scrollOffset+visibleLines, totalLines)
-	visibleContent := make([]string, endIdx-scrollOffset)
-	copy(visibleContent, lines[scrollOffset:endIdx])
-
-	// Pad to fill height if content is shorter
-	for len(visibleContent) < visibleLines {
-		visibleContent = append(visibleContent, "")
+// renderFromCache renders the sidebar from cached lines using the scrollview
+// component which guarantees fixed-width output and a pinned scrollbar.
+func (m *model) renderFromCache() string {
+	// Compute the scrollview region width: content + gap + scrollbar (if needed)
+	regionWidth := m.contentWidth(m.cachedNeedsScrollbar)
+	if m.cachedNeedsScrollbar {
+		regionWidth += m.layoutCfg.ScrollbarGap + scrollbar.Width
 	}
 
-	// Render with scrollbar gap if needed
-	if needsScrollbar {
-		scrollbarGap := strings.Repeat(" ", m.layoutCfg.ScrollbarGap)
-		scrollbarView := m.scrollbar.View()
-		return lipgloss.JoinHorizontal(lipgloss.Top,
-			strings.Join(visibleContent, "\n"),
-			scrollbarGap,
-			scrollbarView,
-		)
-	}
+	m.scrollview.SetSize(regionWidth, m.height)
+	m.scrollview.SetContent(m.cachedLines, len(m.cachedLines))
 
-	return strings.Join(visibleContent, "\n")
+	return m.scrollview.View()
 }
 
 // renderSections renders all sidebar sections and returns them as lines.
@@ -1196,9 +1173,12 @@ func (m *model) renderToggleIndicator(label, shortcut string, contentWidth int) 
 
 // SetSize sets the dimensions of the component
 func (m *model) SetSize(width, height int) tea.Cmd {
+	if m.width == width && m.height == height {
+		return nil // Dimensions unchanged — skip cache invalidation
+	}
 	m.width = width
 	m.height = height
-	m.updateScrollbarPosition()
+	m.updateScrollviewPosition()
 	m.updateTitleInputWidth()
 	m.invalidateCache() // Width/height change affects layout
 	return nil
@@ -1225,15 +1205,14 @@ func (m *model) updateTitleInputWidth() {
 func (m *model) SetPosition(x, y int) tea.Cmd {
 	m.xPos = x
 	m.yPos = y
-	m.updateScrollbarPosition()
+	m.updateScrollviewPosition()
 	return nil
 }
 
-// updateScrollbarPosition updates the scrollbar's position based on sidebar position and size
-func (m *model) updateScrollbarPosition() {
-	// Scrollbar is at the right edge of the sidebar content
-	// width-1 because the scrollbar is 1 char wide and at the rightmost position
-	m.scrollbar.SetPosition(m.xPos+m.width-1, m.yPos)
+// updateScrollviewPosition updates the scrollview's position based on sidebar position and layout.
+func (m *model) updateScrollviewPosition() {
+	// The scrollview region starts after left padding.
+	m.scrollview.SetPosition(m.xPos+m.layoutCfg.PaddingLeft, m.yPos)
 }
 
 // GetSize returns the current dimensions

--- a/pkg/tui/dialog/command_palette.go
+++ b/pkg/tui/dialog/command_palette.go
@@ -10,7 +10,7 @@ import (
 	"charm.land/lipgloss/v2"
 
 	"github.com/docker/cagent/pkg/tui/commands"
-	"github.com/docker/cagent/pkg/tui/components/scrollbar"
+	"github.com/docker/cagent/pkg/tui/components/scrollview"
 	"github.com/docker/cagent/pkg/tui/components/toolcommon"
 	"github.com/docker/cagent/pkg/tui/core"
 	"github.com/docker/cagent/pkg/tui/core/layout"
@@ -25,25 +25,22 @@ type CommandExecuteMsg struct {
 // commandPaletteDialog implements Dialog for the command palette
 type commandPaletteDialog struct {
 	BaseDialog
-	textInput        textinput.Model
-	categories       []commands.Category
-	filtered         []commands.Item
-	selected         int
-	keyMap           commandPaletteKeyMap
-	scrollbar        *scrollbar.Model
-	needsScrollToSel bool // true when keyboard nav requires scrolling to selection
-	lastClickTime    time.Time
-	lastClickIndex   int
+	textInput      textinput.Model
+	categories     []commands.Category
+	filtered       []commands.Item
+	selected       int
+	keyMap         commandPaletteKeyMap
+	scrollview     *scrollview.Model
+	lastClickTime  time.Time
+	lastClickIndex int
 }
 
 // commandPaletteKeyMap defines key bindings for the command palette
 type commandPaletteKeyMap struct {
-	Up       key.Binding
-	Down     key.Binding
-	PageUp   key.Binding
-	PageDown key.Binding
-	Enter    key.Binding
-	Escape   key.Binding
+	Up     key.Binding
+	Down   key.Binding
+	Enter  key.Binding
+	Escape key.Binding
 }
 
 // defaultCommandPaletteKeyMap returns default key bindings
@@ -56,14 +53,6 @@ func defaultCommandPaletteKeyMap() commandPaletteKeyMap {
 		Down: key.NewBinding(
 			key.WithKeys("down", "ctrl+j"),
 			key.WithHelp("↓/ctrl+j", "down"),
-		),
-		PageUp: key.NewBinding(
-			key.WithKeys("pgup"),
-			key.WithHelp("pgup", "page up"),
-		),
-		PageDown: key.NewBinding(
-			key.WithKeys("pgdown"),
-			key.WithHelp("pgdown", "page down"),
 		),
 		Enter: key.NewBinding(
 			key.WithKeys("enter"),
@@ -85,7 +74,6 @@ func NewCommandPaletteDialog(categories []commands.Category) Dialog {
 	ti.CharLimit = 100
 	ti.SetWidth(50)
 
-	// Build initial filtered list (all commands)
 	var allCommands []commands.Item
 	for _, cat := range categories {
 		allCommands = append(allCommands, cat.Commands...)
@@ -97,7 +85,7 @@ func NewCommandPaletteDialog(categories []commands.Category) Dialog {
 		filtered:   allCommands,
 		selected:   0,
 		keyMap:     defaultCommandPaletteKeyMap(),
-		scrollbar:  scrollbar.New(),
+		scrollview: scrollview.New(scrollview.WithReserveScrollbarSpace(true)),
 	}
 }
 
@@ -108,7 +96,10 @@ func (d *commandPaletteDialog) Init() tea.Cmd {
 
 // Update handles messages for the command palette dialog
 func (d *commandPaletteDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
-	var cmds []tea.Cmd
+	// Scrollview handles mouse scrollbar, wheel, and pgup/pgdn/home/end
+	if handled, cmd := d.scrollview.Update(msg); handled {
+		return d, cmd
+	}
 
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
@@ -116,21 +107,28 @@ func (d *commandPaletteDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		return d, cmd
 
 	case tea.PasteMsg:
-		// Forward paste to text input
 		var cmd tea.Cmd
 		d.textInput, cmd = d.textInput.Update(msg)
-		cmds = append(cmds, cmd)
 		d.filterCommands()
-		return d, tea.Batch(cmds...)
+		return d, cmd
 
 	case tea.MouseClickMsg:
-		return d.handleMouseClick(msg)
-
-	case tea.MouseMotionMsg, tea.MouseReleaseMsg:
-		return d.handleMouseDrag(msg)
-
-	case tea.MouseWheelMsg:
-		return d.handleMouseWheel(msg)
+		// Scrollbar clicks already handled above; this handles list item clicks
+		if msg.Button == tea.MouseLeft {
+			if cmdIdx := d.mouseYToCommandIndex(msg.Y); cmdIdx >= 0 {
+				now := time.Now()
+				if cmdIdx == d.lastClickIndex && now.Sub(d.lastClickTime) < styles.DoubleClickThreshold {
+					d.selected = cmdIdx
+					d.lastClickTime = time.Time{}
+					cmd := d.executeSelected()
+					return d, cmd
+				}
+				d.selected = cmdIdx
+				d.lastClickTime = now
+				d.lastClickIndex = cmdIdx
+			}
+		}
+		return d, nil
 
 	case tea.KeyPressMsg:
 		if cmd := HandleQuit(msg); cmd != nil {
@@ -144,31 +142,15 @@ func (d *commandPaletteDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		case key.Matches(msg, d.keyMap.Up):
 			if d.selected > 0 {
 				d.selected--
-				d.needsScrollToSel = true
+				d.scrollview.EnsureLineVisible(d.findSelectedLine())
 			}
 			return d, nil
 
 		case key.Matches(msg, d.keyMap.Down):
 			if d.selected < len(d.filtered)-1 {
 				d.selected++
-				d.needsScrollToSel = true
+				d.scrollview.EnsureLineVisible(d.findSelectedLine())
 			}
-			return d, nil
-
-		case key.Matches(msg, d.keyMap.PageUp):
-			d.selected -= d.visibleLines()
-			if d.selected < 0 {
-				d.selected = 0
-			}
-			d.needsScrollToSel = true
-			return d, nil
-
-		case key.Matches(msg, d.keyMap.PageDown):
-			d.selected += d.visibleLines()
-			if d.selected >= len(d.filtered) {
-				d.selected = max(0, len(d.filtered)-1)
-			}
-			d.needsScrollToSel = true
 			return d, nil
 
 		case key.Matches(msg, d.keyMap.Enter):
@@ -178,12 +160,12 @@ func (d *commandPaletteDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		default:
 			var cmd tea.Cmd
 			d.textInput, cmd = d.textInput.Update(msg)
-			cmds = append(cmds, cmd)
 			d.filterCommands()
+			return d, cmd
 		}
 	}
 
-	return d, tea.Batch(cmds...)
+	return d, nil
 }
 
 // executeSelected executes the currently selected command and closes the dialog.
@@ -199,74 +181,17 @@ func (d *commandPaletteDialog) executeSelected() tea.Cmd {
 	return tea.Sequence(cmds...)
 }
 
-// handleMouseClick handles mouse click events on the dialog
-func (d *commandPaletteDialog) handleMouseClick(msg tea.MouseClickMsg) (layout.Model, tea.Cmd) {
-	// Check if click is on the scrollbar
-	if d.isMouseOnScrollbar(msg.X, msg.Y) {
-		d.scrollbar, _ = d.scrollbar.Update(msg)
-		return d, nil
-	}
-
-	// Check if click is on a command in the list
-	if msg.Button != tea.MouseLeft {
-		return d, nil
-	}
-	cmdIdx := d.mouseYToCommandIndex(msg.Y)
-	if cmdIdx < 0 {
-		return d, nil
-	}
-
-	now := time.Now()
-	// Double-click: execute
-	if cmdIdx == d.lastClickIndex && now.Sub(d.lastClickTime) < styles.DoubleClickThreshold {
-		d.selected = cmdIdx
-		d.lastClickTime = time.Time{}
-		cmd := d.executeSelected()
-		return d, cmd
-	}
-	// Single click: select
-	d.selected = cmdIdx
-	d.lastClickTime = now
-	d.lastClickIndex = cmdIdx
-	return d, nil
-}
-
-// handleMouseDrag handles mouse drag/release for scrollbar
-func (d *commandPaletteDialog) handleMouseDrag(msg tea.Msg) (layout.Model, tea.Cmd) {
-	if d.scrollbar.IsDragging() {
-		d.scrollbar, _ = d.scrollbar.Update(msg)
-	}
-	return d, nil
-}
-
-// handleMouseWheel handles mouse wheel scrolling inside the dialog
-func (d *commandPaletteDialog) handleMouseWheel(msg tea.MouseWheelMsg) (layout.Model, tea.Cmd) {
-	if !d.isMouseInDialog(msg.X, msg.Y) {
-		return d, nil
-	}
-	switch msg.Button.String() {
-	case "wheelup":
-		d.scrollbar.ScrollUp()
-		d.scrollbar.ScrollUp()
-	case "wheeldown":
-		d.scrollbar.ScrollDown()
-		d.scrollbar.ScrollDown()
-	}
-	return d, nil
-}
-
 // filterCommands filters the command list based on search input
 func (d *commandPaletteDialog) filterCommands() {
 	query := strings.ToLower(strings.TrimSpace(d.textInput.Value()))
 
 	if query == "" {
-		// Show all commands
 		d.filtered = make([]commands.Item, 0)
 		for _, cat := range d.categories {
 			d.filtered = append(d.filtered, cat.Commands...)
 		}
 		d.selected = 0
-		d.scrollbar.SetScrollOffset(0)
+		d.scrollview.SetScrollOffset(0)
 		return
 	}
 
@@ -285,73 +210,51 @@ func (d *commandPaletteDialog) filterCommands() {
 	if d.selected >= len(d.filtered) {
 		d.selected = 0
 	}
-	d.scrollbar.SetScrollOffset(0)
+	d.scrollview.SetScrollOffset(0)
 }
 
 // Command palette dialog dimension constants
 const (
-	paletteWidthPercent    = 80
-	paletteMinWidth        = 50
-	paletteMaxWidth        = 80
-	paletteHeightPercent   = 70
-	paletteMaxHeight       = 30
-	paletteDialogPadding   = 6 // horizontal padding inside dialog border
-	paletteListOverhead    = 8 // title(1) + space(1) + input(1) + separator(1) + space(1) + help(1) + borders(2)
-	paletteListStartY      = 6 // border(1) + padding(1) + title(1) + space(1) + input(1) + separator(1)
-	paletteScrollbarXInset = 3
-	paletteScrollbarGap    = 1
+	paletteWidthPercent  = 80
+	paletteMinWidth      = 50
+	paletteMaxWidth      = 80
+	paletteHeightPercent = 70
+	paletteMaxHeight     = 30
+	paletteDialogPadding = 6 // horizontal padding inside dialog border
+	paletteListOverhead  = 8 // title(1) + space(1) + input(1) + separator(1) + space(1) + help(1) + borders(2)
+	paletteListStartY    = 6 // border(1) + padding(1) + title(1) + space(1) + input(1) + separator(1)
 )
 
 // dialogSize returns the dialog dimensions.
 func (d *commandPaletteDialog) dialogSize() (dialogWidth, maxHeight, contentWidth int) {
 	dialogWidth = max(min(d.Width()*paletteWidthPercent/100, paletteMaxWidth), paletteMinWidth)
 	maxHeight = min(d.Height()*paletteHeightPercent/100, paletteMaxHeight)
-	contentWidth = dialogWidth - paletteDialogPadding - scrollbar.Width - paletteScrollbarGap
+	contentWidth = dialogWidth - paletteDialogPadding - d.scrollview.ReservedCols()
 	return dialogWidth, maxHeight, contentWidth
 }
 
-// visibleLines returns the number of lines available for the command list.
-func (d *commandPaletteDialog) visibleLines() int {
-	_, maxHeight, _ := d.dialogSize()
-	return max(1, maxHeight-paletteListOverhead)
-}
-
-// isMouseInDialog checks if the mouse position is inside the dialog bounds
-func (d *commandPaletteDialog) isMouseInDialog(x, y int) bool {
-	dialogRow, dialogCol := d.Position()
-	dialogWidth, maxHeight, _ := d.dialogSize()
-	return x >= dialogCol && x < dialogCol+dialogWidth &&
-		y >= dialogRow && y < dialogRow+maxHeight
-}
-
-// isMouseOnScrollbar checks if the mouse position is on the scrollbar
-func (d *commandPaletteDialog) isMouseOnScrollbar(x, y int) bool {
-	lines, lineToCmd := d.buildLines(0)
-	if len(lines) <= d.visibleLines() {
-		return false
-	}
-	_ = lineToCmd // used for other purposes
-	dialogRow, dialogCol := d.Position()
-	dialogWidth, _, _ := d.dialogSize()
-	scrollbarX := dialogCol + dialogWidth - paletteScrollbarXInset - scrollbar.Width
-	scrollbarY := dialogRow + paletteListStartY
-	visLines := d.visibleLines()
-	return x >= scrollbarX && x < scrollbarX+scrollbar.Width &&
-		y >= scrollbarY && y < scrollbarY+visLines
+// SetSize sets the dialog dimensions and configures the scrollview.
+func (d *commandPaletteDialog) SetSize(width, height int) tea.Cmd {
+	cmd := d.BaseDialog.SetSize(width, height)
+	_, maxHeight, contentWidth := d.dialogSize()
+	regionWidth := contentWidth + d.scrollview.ReservedCols()
+	visLines := max(1, maxHeight-paletteListOverhead)
+	d.scrollview.SetSize(regionWidth, visLines)
+	return cmd
 }
 
 // mouseYToCommandIndex converts a mouse Y position to a command index.
 // Returns -1 if the position is not on a command.
 func (d *commandPaletteDialog) mouseYToCommandIndex(y int) int {
 	dialogRow, _ := d.Position()
-	visLines := d.visibleLines()
+	visLines := d.scrollview.VisibleHeight()
 	listStartY := dialogRow + paletteListStartY
 
 	if y < listStartY || y >= listStartY+visLines {
 		return -1
 	}
 	lineInView := y - listStartY
-	actualLine := d.scrollbar.GetScrollOffset() + lineInView
+	actualLine := d.scrollview.ScrollOffset() + lineInView
 
 	_, lineToCmd := d.buildLines(0)
 	if actualLine < 0 || actualLine >= len(lineToCmd) {
@@ -403,75 +306,32 @@ func (d *commandPaletteDialog) findSelectedLine() int {
 // View renders the command palette dialog
 func (d *commandPaletteDialog) View() string {
 	dialogWidth, _, contentWidth := d.dialogSize()
-	visLines := d.visibleLines()
 	d.textInput.SetWidth(contentWidth)
 
-	// Build all lines with command mapping
 	allLines, _ := d.buildLines(contentWidth)
-	totalLines := len(allLines)
+	regionWidth := contentWidth + d.scrollview.ReservedCols()
 
-	// Update scrollbar dimensions
-	d.scrollbar.SetDimensions(visLines, totalLines)
-
-	// Auto-scroll to selection when keyboard navigation occurred
-	if d.needsScrollToSel {
-		selectedLine := d.findSelectedLine()
-		scrollOffset := d.scrollbar.GetScrollOffset()
-		if selectedLine < scrollOffset {
-			d.scrollbar.SetScrollOffset(selectedLine)
-		} else if selectedLine >= scrollOffset+visLines {
-			d.scrollbar.SetScrollOffset(selectedLine - visLines + 1)
-		}
-		d.needsScrollToSel = false
-	}
-
-	// Slice visible lines based on scroll offset
-	scrollOffset := d.scrollbar.GetScrollOffset()
-	visibleEnd := min(scrollOffset+visLines, totalLines)
-	var visibleCommandLines []string
-	if totalLines > 0 {
-		visibleCommandLines = allLines[scrollOffset:visibleEnd]
-	}
-
-	// Pad with empty lines if content is shorter than visible area
-	for len(visibleCommandLines) < visLines {
-		visibleCommandLines = append(visibleCommandLines, "")
-	}
-
-	// Handle empty state
-	if len(d.filtered) == 0 {
-		visibleCommandLines = []string{"", styles.DialogContentStyle.
-			Italic(true).
-			Align(lipgloss.Center).
-			Width(contentWidth).
-			Render("No commands found")}
-		for len(visibleCommandLines) < visLines {
-			visibleCommandLines = append(visibleCommandLines, "")
-		}
-	}
-
-	// Build command list with fixed width
-	commandListStyle := lipgloss.NewStyle().Width(contentWidth)
-	fixedWidthLines := make([]string, len(visibleCommandLines))
-	for i, line := range visibleCommandLines {
-		fixedWidthLines[i] = commandListStyle.Render(line)
-	}
-	commandListContent := strings.Join(fixedWidthLines, "\n")
-
-	// Set scrollbar position for mouse hit testing
+	// Set scrollview position for mouse hit-testing (auto-computed from dialog position)
 	dialogRow, dialogCol := d.Position()
-	scrollbarX := dialogCol + dialogWidth - paletteScrollbarXInset - scrollbar.Width
-	d.scrollbar.SetPosition(scrollbarX, dialogRow+paletteListStartY)
+	d.scrollview.SetPosition(dialogCol+3, dialogRow+paletteListStartY)
 
-	// Combine content with scrollbar
-	gap := strings.Repeat(" ", paletteScrollbarGap)
-	scrollbarView := d.scrollbar.View()
-	if scrollbarView == "" {
-		scrollbarView = strings.Repeat(" ", scrollbar.Width)
+	d.scrollview.SetContent(allLines, len(allLines))
+
+	var scrollableContent string
+	if len(d.filtered) == 0 {
+		visLines := d.scrollview.VisibleHeight()
+		emptyLines := []string{"", styles.DialogContentStyle.
+			Italic(true).Align(lipgloss.Center).Width(contentWidth).
+			Render("No commands found")}
+		for len(emptyLines) < visLines {
+			emptyLines = append(emptyLines, "")
+		}
+		scrollableContent = d.scrollview.ViewWithLines(emptyLines)
+	} else {
+		scrollableContent = d.scrollview.View()
 	}
-	scrollableContent := lipgloss.JoinHorizontal(lipgloss.Top, commandListContent, gap, scrollbarView)
 
-	content := NewContent(contentWidth+paletteScrollbarGap+scrollbar.Width).
+	content := NewContent(regionWidth).
 		AddTitle("Commands").
 		AddSpace().
 		AddContent(d.textInput.View()).
@@ -499,7 +359,6 @@ func (d *commandPaletteDialog) renderCommand(cmd commands.Item, selected bool, c
 	var content string
 	content += actionStyle.Render(label)
 	if cmd.Description != "" {
-		// Calculate available width for description: contentWidth - label - " • " separator
 		separator := " • "
 		separatorWidth := lipgloss.Width(separator)
 		availableWidth := contentWidth - labelWidth - separatorWidth

--- a/pkg/tui/dialog/model_picker_test.go
+++ b/pkg/tui/dialog/model_picker_test.go
@@ -3,7 +3,6 @@ package dialog
 import (
 	"testing"
 
-	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -183,23 +182,18 @@ func TestModelPickerPageNavigation(t *testing.T) {
 	d.Init()
 	d.Update(tea.WindowSizeMsg{Width: 80, Height: 20})
 
-	pageSize := d.pageSize()
-
-	// Page down
+	// Page down scrolls the viewport (handled by scrollview), not the selection
 	pageDownKey := tea.KeyPressMsg{Code: tea.KeyPgDown}
-	require.True(t, key.Matches(pageDownKey, d.keyMap.PageDown), "pagedown key should match")
-
 	updated, _ := d.Update(pageDownKey)
 	d = updated.(*modelPickerDialog)
-	require.Equal(t, pageSize, d.selected, "selection should advance by page size")
+	require.Equal(t, 0, d.selected, "selection should not move on page down (scrollview scrolls viewport)")
+	require.Positive(t, d.scrollview.ScrollOffset(), "scrollview should have scrolled")
 
-	// Page up
+	// Page up scrolls back
 	pageUpKey := tea.KeyPressMsg{Code: tea.KeyPgUp}
-	require.True(t, key.Matches(pageUpKey, d.keyMap.PageUp), "pageup key should match")
-
 	updated, _ = d.Update(pageUpKey)
 	d = updated.(*modelPickerDialog)
-	require.Equal(t, 0, d.selected, "selection should return to 0")
+	require.Equal(t, 0, d.scrollview.ScrollOffset(), "scrollview should scroll back to top")
 }
 
 func TestModelPickerEscape(t *testing.T) {

--- a/pkg/tui/dialog/session_browser_test.go
+++ b/pkg/tui/dialog/session_browser_test.go
@@ -170,7 +170,7 @@ func TestSessionBrowserScrolling(t *testing.T) {
 	// Set a small window size to force scrolling
 	d.Update(tea.WindowSizeMsg{Width: 80, Height: 20})
 
-	maxVisible := d.pageSize()
+	maxVisible := d.scrollview.VisibleHeight()
 	t.Logf("Max visible items: %d", maxVisible)
 
 	// Navigate down past the visible area
@@ -185,11 +185,12 @@ func TestSessionBrowserScrolling(t *testing.T) {
 	// Call View() to trigger offset adjustment (like the TUI does)
 	view := d.View()
 
-	t.Logf("Selected: %d, Offset: %d", d.selected, d.offset)
+	scrollOffset := d.scrollview.ScrollOffset()
+	t.Logf("Selected: %d, ScrollOffset: %d", d.selected, scrollOffset)
 
-	// The offset should have adjusted so selected is visible
-	require.LessOrEqual(t, d.offset, d.selected, "offset should be <= selected")
-	require.Less(t, d.selected, d.offset+maxVisible, "selected should be within visible range")
+	// The scroll offset should have adjusted so selected is visible
+	require.LessOrEqual(t, scrollOffset, d.selected, "scroll offset should be <= selected")
+	require.Less(t, d.selected, scrollOffset+maxVisible, "selected should be within visible range")
 
 	// Verify the view shows the selected session
 	expectedTitle := fmt.Sprintf("Session %d", d.selected+1)

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -774,14 +774,14 @@ func (p *chatPage) SetSize(width, height int) tea.Cmd {
 		cmds = append(cmds,
 			p.sidebar.SetSize(sl.sidebarWidth-toggleColumnWidth, sl.chatHeight),
 			p.sidebar.SetPosition(styles.AppPaddingLeft+sl.sidebarStartX, 0),
-			p.messages.SetPosition(0, 0),
+			p.messages.SetPosition(styles.AppPaddingLeft, 0),
 		)
 	case sidebarCollapsed, sidebarCollapsedNarrow:
 		p.sidebar.SetMode(sidebar.ModeCollapsed)
 		cmds = append(cmds,
 			p.sidebar.SetSize(sl.sidebarWidth, sl.sidebarHeight),
 			p.sidebar.SetPosition(styles.AppPaddingLeft, 0),
-			p.messages.SetPosition(0, sl.sidebarHeight),
+			p.messages.SetPosition(styles.AppPaddingLeft, sl.sidebarHeight),
 		)
 	}
 

--- a/pkg/tui/page/chat/input_handlers.go
+++ b/pkg/tui/page/chat/input_handlers.go
@@ -193,6 +193,21 @@ func (p *chatPage) handleMouseMotion(msg tea.MouseMotionMsg) (layout.Model, tea.
 		return p, nil
 	}
 
+	// During a scrollbar drag, forward motion to both scrollable components
+	// so the drag continues even when the cursor drifts outside the component.
+	// The scrollbar ignores motion if it isn't the one being dragged.
+	if p.isScrollbarDragging() {
+		var cmds []tea.Cmd
+		messagesModel, messagesCmd := p.messages.Update(msg)
+		p.messages = messagesModel.(messages.Model)
+		cmds = append(cmds, messagesCmd)
+
+		sidebarModel, sidebarCmd := p.sidebar.Update(msg)
+		p.sidebar = sidebarModel.(sidebar.Model)
+		cmds = append(cmds, sidebarCmd)
+		return p, tea.Batch(cmds...)
+	}
+
 	hit := NewHitTest(p)
 	p.isHoveringHandle = hit.IsOnResizeLine(msg.Y)
 
@@ -201,6 +216,8 @@ func (p *chatPage) handleMouseMotion(msg tea.MouseMotionMsg) (layout.Model, tea.
 }
 
 // handleMouseRelease handles mouse release events.
+// Release is broadcast to all scrollable components so that a scrollbar drag
+// that ends outside the component's bounds still terminates correctly.
 func (p *chatPage) handleMouseRelease(msg tea.MouseReleaseMsg) (layout.Model, tea.Cmd) {
 	if p.isDragging {
 		p.isDragging = false
@@ -210,8 +227,25 @@ func (p *chatPage) handleMouseRelease(msg tea.MouseReleaseMsg) (layout.Model, te
 		p.isDraggingSidebar = false
 		return p, nil
 	}
-	cmd := p.routeMouseEvent(msg, msg.Y)
-	return p, cmd
+
+	var cmds []tea.Cmd
+
+	// Forward release to both messages and sidebar so any active scrollbar
+	// drag is properly ended, regardless of where the mouse was released.
+	messagesModel, messagesCmd := p.messages.Update(msg)
+	p.messages = messagesModel.(messages.Model)
+	cmds = append(cmds, messagesCmd)
+
+	sidebarModel, sidebarCmd := p.sidebar.Update(msg)
+	p.sidebar = sidebarModel.(sidebar.Model)
+	cmds = append(cmds, sidebarCmd)
+
+	return p, tea.Batch(cmds...)
+}
+
+// isScrollbarDragging returns true if any scrollable component has an active scrollbar drag.
+func (p *chatPage) isScrollbarDragging() bool {
+	return p.messages.IsScrollbarDragging() || p.sidebar.IsScrollbarDragging()
 }
 
 // handleMouseWheel handles mouse wheel events.


### PR DESCRIPTION
This PR does a few things:

- Introduces a scrollview component to be used with any components that needs scrolling and a scrollbar;
- Reduces code duplication because of that and simplifies how components interact with a scrollbar, moving most of the scroll specific logic out of components that don't have special edge cases to handle (messages being one of them for now);
- Adapts most scrollable components to use this, for more consistent styling and behavior (mouse support, common keys to scroll with, etc);
- Fixes some minor scrollbar positioning and UX bugs in certain scenarios when dragging the scrollbar with a mouse;
