### PR TITLE
Session store cleanup

### DIFF
--- a/pkg/session/branch.go
+++ b/pkg/session/branch.go
@@ -9,7 +9,9 @@ import (
 	"github.com/docker/cagent/pkg/tools"
 )
 
-func buildBranchedSession(parent *Session, branchAtPosition int) (*Session, error) {
+// BranchSession creates a new session branched from the parent at the given position.
+// Messages up to (but not including) branchAtPosition are deep-cloned into the new session.
+func BranchSession(parent *Session, branchAtPosition int) (*Session, error) {
 	if parent == nil {
 		return nil, fmt.Errorf("parent session is nil")
 	}
@@ -241,16 +243,4 @@ func recalculateSessionTotals(sess *Session) {
 	sess.InputTokens = inputTokens
 	sess.OutputTokens = outputTokens
 	sess.Cost = cost
-}
-
-func collectSessionIDs(sess *Session, ids map[string]struct{}) {
-	if sess == nil || ids == nil {
-		return
-	}
-	ids[sess.ID] = struct{}{}
-	for _, item := range sess.Messages {
-		if item.SubSession != nil {
-			collectSessionIDs(item.SubSession, ids)
-		}
-	}
 }

--- a/pkg/session/branch_test.go
+++ b/pkg/session/branch_test.go
@@ -90,30 +90,30 @@ func TestCloneSessionItem(t *testing.T) {
 	})
 }
 
-func TestBuildBranchedSession(t *testing.T) {
+func TestBranchSession(t *testing.T) {
 	t.Run("nil parent returns error", func(t *testing.T) {
-		_, err := buildBranchedSession(nil, 0)
+		_, err := BranchSession(nil, 0)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "parent session is nil")
 	})
 
 	t.Run("negative position returns error", func(t *testing.T) {
 		parent := &Session{Messages: []Item{NewMessageItem(UserMessage("test"))}}
-		_, err := buildBranchedSession(parent, -1)
+		_, err := BranchSession(parent, -1)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "out of range")
 	})
 
 	t.Run("position beyond messages returns error", func(t *testing.T) {
 		parent := &Session{Messages: []Item{NewMessageItem(UserMessage("test"))}}
-		_, err := buildBranchedSession(parent, 2)
+		_, err := BranchSession(parent, 2)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "out of range")
 	})
 
 	t.Run("position equal to messages length returns error", func(t *testing.T) {
 		parent := &Session{Messages: []Item{NewMessageItem(UserMessage("test"))}}
-		_, err := buildBranchedSession(parent, 1)
+		_, err := BranchSession(parent, 1)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "out of range")
 	})
@@ -129,7 +129,7 @@ func TestBuildBranchedSession(t *testing.T) {
 			},
 		}
 
-		branched, err := buildBranchedSession(parent, 2)
+		branched, err := BranchSession(parent, 2)
 		require.NoError(t, err)
 		assert.NotNil(t, branched)
 

--- a/pkg/session/store_test.go
+++ b/pkg/session/store_test.go
@@ -244,8 +244,13 @@ func TestBranchSessionCopiesPrefix(t *testing.T) {
 
 	require.NoError(t, store.AddSession(t.Context(), parent))
 
-	branched, err := store.BranchSession(t.Context(), parent.ID, 2)
+	parentLoaded, err := store.GetSession(t.Context(), parent.ID)
 	require.NoError(t, err)
+
+	branched, err := BranchSession(parentLoaded, 2)
+	require.NoError(t, err)
+
+	require.NoError(t, store.AddSession(t.Context(), branched))
 	require.NotNil(t, branched.BranchParentPosition)
 	assert.Equal(t, parent.ID, branched.BranchParentSessionID)
 	assert.Equal(t, 2, *branched.BranchParentPosition)
@@ -289,8 +294,13 @@ func TestBranchSessionClonesSubSession(t *testing.T) {
 
 	require.NoError(t, store.AddSession(t.Context(), parent))
 
-	branched, err := store.BranchSession(t.Context(), parent.ID, 2)
+	parentLoaded, err := store.GetSession(t.Context(), parent.ID)
 	require.NoError(t, err)
+
+	branched, err := BranchSession(parentLoaded, 2)
+	require.NoError(t, err)
+
+	require.NoError(t, store.AddSession(t.Context(), branched))
 
 	loaded, err := store.GetSession(t.Context(), branched.ID)
 	require.NoError(t, err)

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/cagent/pkg/browser"
 	"github.com/docker/cagent/pkg/evaluation"
 	"github.com/docker/cagent/pkg/modelsdev"
+	"github.com/docker/cagent/pkg/session"
 	"github.com/docker/cagent/pkg/tools"
 	mcptools "github.com/docker/cagent/pkg/tools/mcp"
 	"github.com/docker/cagent/pkg/tui/components/notification"
@@ -106,9 +107,18 @@ func (a *appModel) handleBranchFromEdit(msg messages.BranchFromEditMsg) (tea.Mod
 		return a, notification.ErrorCmd("No parent session for branch")
 	}
 
-	newSess, err := store.BranchSession(context.Background(), msg.ParentSessionID, msg.BranchAtPosition)
+	parent, err := store.GetSession(context.Background(), msg.ParentSessionID)
+	if err != nil {
+		return a, notification.ErrorCmd(fmt.Sprintf("Failed to load parent session: %v", err))
+	}
+
+	newSess, err := session.BranchSession(parent, msg.BranchAtPosition)
 	if err != nil {
 		return a, notification.ErrorCmd(fmt.Sprintf("Failed to branch session: %v", err))
+	}
+
+	if err := store.AddSession(context.Background(), newSess); err != nil {
+		return a, notification.ErrorCmd(fmt.Sprintf("Failed to save branched session: %v", err))
 	}
 
 	if current := a.application.Session(); current != nil {


### PR DESCRIPTION
Remove too-specific methods from the session store

- BranchSession
- GetSessionByOffset

These are not really needed in the store interface