### PR TITLE
Fix tick leak

### DIFF
--- a/pkg/tui/components/spinner/spinner_test.go
+++ b/pkg/tui/components/spinner/spinner_test.go
@@ -4,7 +4,22 @@ import (
 	"testing"
 
 	"charm.land/lipgloss/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/cagent/pkg/tui/animation"
 )
+
+func TestSpinnerCopyDoesNotLeakAnimationSubscription(t *testing.T) {
+	s1 := New(ModeSpinnerOnly, lipgloss.NewStyle())
+	cmd := s1.Init()
+	require.NotNil(t, cmd)
+	require.True(t, animation.HasActive())
+
+	// Copy the spinner value and stop via the copy; should still stop the shared subscription.
+	s2 := s1
+	s2.Stop()
+	require.False(t, animation.HasActive())
+}
 
 func BenchmarkSpinner_ModeSpinnerOnly(b *testing.B) {
 	s := New(ModeSpinnerOnly, lipgloss.NewStyle())


### PR DESCRIPTION
The animation subscription was a value, that got copied so Stop()ing would stop a copied subscription resulting in ~10% CPU usage once the assistant finished answering and nothing was moving on the screen.

Make sure that all the spinners share the same animation subscription