### PR TITLE
eval: add optional setup script support for eval sessions

### DIFF
--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -207,6 +207,7 @@ type EvalCriteria struct {
 	Relevance  []string `json:"relevance"`             // Statements that should be true about the response
 	WorkingDir string   `json:"working_dir,omitempty"` // Subdirectory under evals/working_dirs/
 	Size       string   `json:"size,omitempty"`        // Expected response size: S, M, L, XL
+	Setup      string   `json:"setup,omitempty"`       // Optional sh script to run in the container before cagent exec
 }
 
 // Session helper methods


### PR DESCRIPTION
Add a 'setup' property to EvalCriteria that allows defining a sh script to run inside the eval container before cagent exec. The script is written to a temp file, bind-mounted into the container, and executed as part of the entrypoint chain. This is useful for preparing the container environment (e.g., installing packages, initializing repos) before the agent runs.

Assisted-By: cagent