### PR TITLE
provider/anthropic: enforce tool sequencing, remove self-repair/validation

### DIFF
--- a/pkg/model/provider/anthropic/beta_client.go
+++ b/pkg/model/provider/anthropic/beta_client.go
@@ -43,14 +43,6 @@ func (c *Client) createBetaStream(
 		slog.Error("Failed to convert messages for Anthropic Beta request", "error", err)
 		return nil, err
 	}
-	if err := validateAnthropicSequencingBeta(converted); err != nil {
-		slog.Warn("Invalid message sequencing for Anthropic Beta API detected, attempting self-repair", "error", err)
-		converted = repairAnthropicSequencingBeta(converted)
-		if err2 := validateAnthropicSequencingBeta(converted); err2 != nil {
-			slog.Error("Failed to self-repair Anthropic Beta sequencing", "error", err2)
-			return nil, err
-		}
-	}
 
 	sys := extractBetaSystemBlocks(messages)
 
@@ -145,114 +137,6 @@ func (c *Client) createBetaStream(
 	slog.Debug("Anthropic Beta API chat completion stream created successfully", "model", c.ModelConfig.Model)
 	return ad, nil
 }
-
-// validateAnthropicSequencingBeta performs the same validation as standard API but for Beta payloads
-func validateAnthropicSequencingBeta(msgs []anthropic.BetaMessageParam) error {
-	for i := range msgs {
-		m, ok := marshalToMapBeta(msgs[i])
-		if !ok || m["role"] != "assistant" {
-			continue
-		}
-
-		toolUseIDs := collectToolUseIDs(contentArrayBeta(m))
-		if len(toolUseIDs) == 0 {
-			continue
-		}
-
-		if i+1 >= len(msgs) {
-			slog.Warn("Anthropic (beta) sequencing invalid: assistant tool_use present but no next user tool_result message", "assistant_index", i)
-			return errors.New("assistant tool_use present but no subsequent user message with tool_result blocks (beta)")
-		}
-
-		next, ok := marshalToMapBeta(msgs[i+1])
-		if !ok || next["role"] != "user" {
-			slog.Warn("Anthropic (beta) sequencing invalid: next message after assistant tool_use is not user", "assistant_index", i, "next_role", next["role"])
-			return errors.New("assistant tool_use must be followed by a user message containing corresponding tool_result blocks (beta)")
-		}
-
-		toolResultIDs := collectToolResultIDs(contentArrayBeta(next))
-		missing := differenceIDs(toolUseIDs, toolResultIDs)
-		if len(missing) > 0 {
-			slog.Warn("Anthropic (beta) sequencing invalid: missing tool_result for tool_use id in next user message", "assistant_index", i, "tool_use_id", missing[0], "missing_count", len(missing))
-			return fmt.Errorf("missing tool_result for tool_use id %s in the next user message (beta)", missing[0])
-		}
-	}
-	return nil
-}
-
-// repairAnthropicSequencingBeta inserts a synthetic user message with tool_result blocks
-// for any assistant tool_use blocks that don't have corresponding tool_result blocks
-// in the immediate next user message.
-func repairAnthropicSequencingBeta(msgs []anthropic.BetaMessageParam) []anthropic.BetaMessageParam {
-	if len(msgs) == 0 {
-		return msgs
-	}
-	repaired := make([]anthropic.BetaMessageParam, 0, len(msgs)+2)
-	for i := range msgs {
-		m, ok := marshalToMapBeta(msgs[i])
-		if !ok || m["role"] != "assistant" {
-			repaired = append(repaired, msgs[i])
-			continue
-		}
-
-		toolUseIDs := collectToolUseIDs(contentArrayBeta(m))
-		if len(toolUseIDs) == 0 {
-			repaired = append(repaired, msgs[i])
-			continue
-		}
-
-		// Check if the next message is a user message with tool_results
-		needsSyntheticMessage := true
-		if i+1 < len(msgs) {
-			if next, ok := marshalToMapBeta(msgs[i+1]); ok && next["role"] == "user" {
-				toolResultIDs := collectToolResultIDs(contentArrayBeta(next))
-				// Remove tool_use IDs that have corresponding tool_results
-				for id := range toolResultIDs {
-					delete(toolUseIDs, id)
-				}
-				// If all tool_use IDs have results, no synthetic message needed
-				if len(toolUseIDs) == 0 {
-					needsSyntheticMessage = false
-				}
-			}
-		}
-
-		// Append the assistant message first
-		repaired = append(repaired, msgs[i])
-
-		// If there are missing tool_results, insert a synthetic user message immediately after
-		if needsSyntheticMessage && len(toolUseIDs) > 0 {
-			slog.Debug("Inserting synthetic user message for missing tool_results",
-				"assistant_index", i,
-				"missing_count", len(toolUseIDs))
-
-			blocks := make([]anthropic.BetaContentBlockParamUnion, 0, len(toolUseIDs))
-			for id := range toolUseIDs {
-				slog.Debug("Creating synthetic tool_result", "tool_use_id", id)
-				blocks = append(blocks, anthropic.BetaContentBlockParamUnion{
-					OfToolResult: &anthropic.BetaToolResultBlockParam{
-						ToolUseID: id,
-						Content: []anthropic.BetaToolResultBlockParamContentUnion{
-							{OfText: &anthropic.BetaTextBlockParam{Text: "(tool execution failed)"}},
-						},
-					},
-				})
-			}
-			repaired = append(repaired, anthropic.BetaMessageParam{
-				Role:    anthropic.BetaMessageParamRoleUser,
-				Content: blocks,
-			})
-		}
-	}
-	return repaired
-}
-
-// marshalToMapBeta is an alias for marshalToMap - shared with standard API.
-// Kept as separate function for clarity in Beta-specific code paths.
-var marshalToMapBeta = marshalToMap
-
-// contentArrayBeta is an alias for contentArray - shared with standard API.
-var contentArrayBeta = contentArray
 
 // countAnthropicTokensBeta calls Anthropic's Count Tokens API for the provided Beta API payload
 // and returns the number of input tokens.

--- a/pkg/model/provider/anthropic/client.go
+++ b/pkg/model/provider/anthropic/client.go
@@ -271,15 +271,8 @@ func (c *Client) CreateChatCompletionStream(
 		slog.Error("Failed to convert messages for Anthropic request", "error", err)
 		return nil, err
 	}
-	// Preflight validation to ensure tool_use/tool_result sequencing is valid
-	if err := validateAnthropicSequencing(converted); err != nil {
-		slog.Warn("Invalid message sequencing for Anthropic detected, attempting self-repair", "error", err)
-		converted = repairAnthropicSequencing(converted)
-		if err2 := validateAnthropicSequencing(converted); err2 != nil {
-			slog.Error("Failed to self-repair Anthropic sequencing", "error", err2)
-			return nil, err
-		}
-	}
+	// convertMessages enforces Anthropic tool sequencing strictly; if it's invalid,
+	// convertMessages returns an error.
 	sys := extractSystemBlocks(messages)
 
 	params := anthropic.MessageNewParams{
@@ -368,9 +361,10 @@ func (c *Client) CreateChatCompletionStream(
 
 func (c *Client) convertMessages(ctx context.Context, messages []chat.Message) ([]anthropic.MessageParam, error) {
 	var anthropicMessages []anthropic.MessageParam
-	// Track whether the last appended assistant message included tool_use blocks
-	// so we can ensure the immediate next message is the grouped tool_result user message.
-	pendingAssistantToolUse := false
+	// Track the set of tool_use IDs from the last appended assistant message.
+	// Anthropic requires the immediate next message to be a user message containing
+	// tool_result blocks for those IDs (and only those IDs).
+	var pendingToolUseIDs map[string]struct{}
 
 	for i := 0; i < len(messages); i++ {
 		msg := &messages[i]
@@ -379,6 +373,9 @@ func (c *Client) convertMessages(ctx context.Context, messages []chat.Message) (
 			continue
 		}
 		if msg.Role == chat.MessageRoleUser {
+			if pendingToolUseIDs != nil {
+				return nil, errors.New("assistant tool_use must be immediately followed by tool results")
+			}
 			// Handle MultiContent for user messages (including images and files)
 			if len(msg.MultiContent) > 0 {
 				contentBlocks, err := c.convertUserMultiContent(ctx, msg.MultiContent)
@@ -396,6 +393,9 @@ func (c *Client) convertMessages(ctx context.Context, messages []chat.Message) (
 			continue
 		}
 		if msg.Role == chat.MessageRoleAssistant {
+			if pendingToolUseIDs != nil {
+				return nil, errors.New("assistant tool_use must be immediately followed by tool results")
+			}
 			contentBlocks := make([]anthropic.ContentBlockParamUnion, 0)
 
 			// Include thinking blocks when present to preserve extended thinking context
@@ -406,6 +406,7 @@ func (c *Client) convertMessages(ctx context.Context, messages []chat.Message) (
 			}
 
 			if len(msg.ToolCalls) > 0 {
+				pendingToolUseIDs = make(map[string]struct{}, len(msg.ToolCalls))
 				blockLen := len(msg.ToolCalls)
 				msgContent := strings.TrimSpace(msg.Content)
 				offset := 0
@@ -426,6 +427,9 @@ func (c *Client) convertMessages(ctx context.Context, messages []chat.Message) (
 					if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &inpts); err != nil {
 						inpts = map[string]any{}
 					}
+					if toolCall.ID != "" {
+						pendingToolUseIDs[toolCall.ID] = struct{}{}
+					}
 					toolUseBlocks[len(contentBlocks)+j+offset] = anthropic.ContentBlockParamUnion{
 						OfToolUse: &anthropic.ToolUseBlockParam{
 							ID:    toolCall.ID,
@@ -435,8 +439,6 @@ func (c *Client) convertMessages(ctx context.Context, messages []chat.Message) (
 					}
 				}
 				anthropicMessages = append(anthropicMessages, anthropic.NewAssistantMessage(toolUseBlocks...))
-				// Mark that we expect the very next message to be the grouped tool_result blocks.
-				pendingAssistantToolUse = true
 			} else {
 				if txt := strings.TrimSpace(msg.Content); txt != "" {
 					contentBlocks = append(contentBlocks, anthropic.NewTextBlock(txt))
@@ -444,36 +446,56 @@ func (c *Client) convertMessages(ctx context.Context, messages []chat.Message) (
 				if len(contentBlocks) > 0 {
 					anthropicMessages = append(anthropicMessages, anthropic.NewAssistantMessage(contentBlocks...))
 				}
-				// No tool_use in this assistant message
-				pendingAssistantToolUse = false
+				pendingToolUseIDs = nil
 			}
 			continue
 		}
 		if msg.Role == chat.MessageRoleTool {
+			if pendingToolUseIDs == nil {
+				return nil, fmt.Errorf("unexpected tool result without preceding tool_use (tool_use_id=%q)", messages[i].ToolCallID)
+			}
 			// Group consecutive tool results into a single user message.
 			//
 			// This is to satisfy Anthropic's requirement that tool_use blocks are immediately followed
 			// by a single user message containing all corresponding tool_result blocks.
 			var blocks []anthropic.ContentBlockParamUnion
+			hadToolMessages := false
 			j := i
 			for j < len(messages) && messages[j].Role == chat.MessageRoleTool {
-				tr := anthropic.NewToolResultBlock(messages[j].ToolCallID, strings.TrimSpace(messages[j].Content), false)
+				hadToolMessages = true
+				id := messages[j].ToolCallID
+				if strings.TrimSpace(id) == "" {
+					return nil, errors.New("tool result is missing tool_use_id")
+				}
+				if _, ok := pendingToolUseIDs[id]; !ok {
+					return nil, fmt.Errorf("unexpected tool_result tool_use_id=%q", id)
+				}
+				tr := anthropic.NewToolResultBlock(id, strings.TrimSpace(messages[j].Content), false)
 				blocks = append(blocks, tr)
+				delete(pendingToolUseIDs, id)
 				j++
 			}
-			if len(blocks) > 0 {
-				// Only include tool_result blocks if they immediately follow an assistant
-				// message that contained tool_use. Otherwise, drop them to avoid invalid
-				// sequencing errors.
-				if pendingAssistantToolUse {
-					anthropicMessages = append(anthropicMessages, anthropic.NewUserMessage(blocks...))
-				}
-				// Whether we used them or not, we've now handled the expected tool_result slot.
-				pendingAssistantToolUse = false
+			if hadToolMessages && len(blocks) == 0 {
+				return nil, errors.New("tool_result messages present but none match pending tool_use ids")
 			}
+			if len(pendingToolUseIDs) > 0 {
+				missing := make([]string, 0, len(pendingToolUseIDs))
+				for id := range pendingToolUseIDs {
+					missing = append(missing, id)
+				}
+				return nil, fmt.Errorf("missing tool_result for tool_use id %s (and %d more)", missing[0], len(missing)-1)
+			}
+			if len(blocks) > 0 {
+				anthropicMessages = append(anthropicMessages, anthropic.NewUserMessage(blocks...))
+			}
+			pendingToolUseIDs = nil
 			i = j - 1
 			continue
 		}
+	}
+
+	if pendingToolUseIDs != nil {
+		return nil, errors.New("assistant tool_use present but no subsequent tool results")
 	}
 
 	// Add ephemeral cache to last 2 messages' last content block
@@ -668,150 +690,7 @@ func (c *Client) FileManager() *FileManager {
 	return c.fileManager
 }
 
-// validateAnthropicSequencing verifies that for every assistant message that includes
-// one or more tool_use blocks, the immediately following message is a user message
-// that includes tool_result blocks for all those tool_use IDs (grouped into that single message).
-func validateAnthropicSequencing(msgs []anthropic.MessageParam) error {
-	// Marshal-based inspection to avoid depending on SDK internals of union types
-	for i := range msgs {
-		m, ok := marshalToMap(msgs[i])
-		if !ok || m["role"] != "assistant" {
-			continue
-		}
-
-		toolUseIDs := collectToolUseIDs(contentArray(m))
-		if len(toolUseIDs) == 0 {
-			continue
-		}
-
-		if i+1 >= len(msgs) {
-			slog.Warn("Anthropic sequencing invalid: assistant tool_use present but no next user tool_result message", "assistant_index", i)
-			return errors.New("assistant tool_use present but no subsequent user message with tool_result blocks")
-		}
-
-		next, ok := marshalToMap(msgs[i+1])
-		if !ok || next["role"] != "user" {
-			slog.Warn("Anthropic sequencing invalid: next message after assistant tool_use is not user", "assistant_index", i, "next_role", next["role"])
-			return errors.New("assistant tool_use must be followed by a user message containing corresponding tool_result blocks")
-		}
-
-		toolResultIDs := collectToolResultIDs(contentArray(next))
-		missing := differenceIDs(toolUseIDs, toolResultIDs)
-		if len(missing) > 0 {
-			slog.Warn("Anthropic sequencing invalid: missing tool_result for tool_use id in next user message", "assistant_index", i, "tool_use_id", missing[0], "missing_count", len(missing))
-			return fmt.Errorf("missing tool_result for tool_use id %s in the next user message", missing[0])
-		}
-	}
-	return nil
-}
-
-// repairAnthropicSequencing inserts a synthetic user message containing tool_result blocks
-// immediately after any assistant message that has tool_use blocks missing a corresponding
-// tool_result in the next user message. This is a best-effort local repair to keep the
-// conversation valid for Anthropic while preserving original messages, to keep the agent loop running.
-func repairAnthropicSequencing(msgs []anthropic.MessageParam) []anthropic.MessageParam {
-	if len(msgs) == 0 {
-		return msgs
-	}
-	repaired := make([]anthropic.MessageParam, 0, len(msgs)+2)
-	for i := range msgs {
-		repaired = append(repaired, msgs[i])
-
-		m, ok := marshalToMap(msgs[i])
-		if !ok || m["role"] != "assistant" {
-			continue
-		}
-
-		toolUseIDs := collectToolUseIDs(contentArray(m))
-		if len(toolUseIDs) == 0 {
-			continue
-		}
-
-		// Remove any IDs that already have results in the next user message
-		if i+1 < len(msgs) {
-			if next, ok := marshalToMap(msgs[i+1]); ok && next["role"] == "user" {
-				toolResultIDs := collectToolResultIDs(contentArray(next))
-				for id := range toolResultIDs {
-					delete(toolUseIDs, id)
-				}
-			}
-		}
-
-		if len(toolUseIDs) > 0 {
-			blocks := make([]anthropic.ContentBlockParamUnion, 0, len(toolUseIDs))
-			for id := range toolUseIDs {
-				blocks = append(blocks, anthropic.NewToolResultBlock(id, "(tool execution failed)", false))
-			}
-			repaired = append(repaired, anthropic.NewUserMessage(blocks...))
-		}
-	}
-	return repaired
-}
-
-// marshalToMap is a helper that converts any value to a map[string]any via JSON marshaling.
-// This is used to inspect SDK union types without depending on their internal structure.
-// It's shared by both standard and Beta API validation/repair code.
-func marshalToMap(v any) (map[string]any, bool) {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return nil, false
-	}
-	var m map[string]any
-	if json.Unmarshal(b, &m) != nil {
-		return nil, false
-	}
-	return m, true
-}
-
-// contentArray extracts the content array from a marshaled message map.
-// Used by both standard and Beta API validation/repair code.
-func contentArray(m map[string]any) []any {
-	if a, ok := m["content"].([]any); ok {
-		return a
-	}
-	return nil
-}
-
-func collectToolUseIDs(content []any) map[string]struct{} {
-	ids := make(map[string]struct{})
-	for _, c := range content {
-		if cb, ok := c.(map[string]any); ok {
-			if t, _ := cb["type"].(string); t == "tool_use" {
-				if id, _ := cb["id"].(string); id != "" {
-					ids[id] = struct{}{}
-				}
-			}
-		}
-	}
-	return ids
-}
-
-func collectToolResultIDs(content []any) map[string]struct{} {
-	ids := make(map[string]struct{})
-	for _, c := range content {
-		if cb, ok := c.(map[string]any); ok {
-			if t, _ := cb["type"].(string); t == "tool_result" {
-				if id, _ := cb["tool_use_id"].(string); id != "" {
-					ids[id] = struct{}{}
-				}
-			}
-		}
-	}
-	return ids
-}
-
-func differenceIDs(a, b map[string]struct{}) []string {
-	if len(a) == 0 {
-		return nil
-	}
-	var missing []string
-	for id := range a {
-		if _, ok := b[id]; !ok {
-			missing = append(missing, id)
-		}
-	}
-	return missing
-}
+// Tool sequencing validation helpers removed; conversion enforces sequencing strictly.
 
 // anthropicContextLimit returns a reasonable default context window for Anthropic models.
 // We default to 200k tokens, which is what 3.5-4.5 models support; adjust as needed over time.

--- a/pkg/model/provider/anthropic/client_test.go
+++ b/pkg/model/provider/anthropic/client_test.go
@@ -91,11 +91,15 @@ func TestConvertMessages_AssistantToolCalls_NoText_IncludesToolUse(t *testing.T)
 		ToolCalls: []tools.ToolCall{
 			{ID: "tool-1", Function: tools.FunctionCall{Name: "do_thing", Arguments: "{\"x\":1}"}},
 		},
+	}, {
+		Role:       chat.MessageRoleTool,
+		ToolCallID: "tool-1",
+		Content:    "result",
 	}}
 
 	out, err := testClient().convertMessages(t.Context(), msgs)
 	require.NoError(t, err)
-	require.Len(t, out, 1)
+	require.Len(t, out, 2)
 
 	b, err := json.Marshal(out[0])
 	require.NoError(t, err)
@@ -173,7 +177,7 @@ func TestSystemMessages_InterspersedExtractedAndExcluded(t *testing.T) {
 	}
 }
 
-func TestSequencingRepair_Standard(t *testing.T) {
+func TestConvertMessages_MissingToolResults_Fails(t *testing.T) {
 	msgs := []chat.Message{
 		{Role: chat.MessageRoleUser, Content: "start"},
 		{
@@ -182,44 +186,15 @@ func TestSequencingRepair_Standard(t *testing.T) {
 				{ID: "tool-1", Function: tools.FunctionCall{Name: "do_thing", Arguments: "{}"}},
 			},
 		},
-		// Intentionally missing the user/tool_result message here
+		// Intentionally missing the tool result message here
 		{Role: chat.MessageRoleUser, Content: "continue"},
 	}
 
-	converted, err := testClient().convertMessages(t.Context(), msgs)
-	require.NoError(t, err)
-	err = validateAnthropicSequencing(converted)
+	_, err := testClient().convertMessages(t.Context(), msgs)
 	require.Error(t, err)
-
-	repaired := repairAnthropicSequencing(converted)
-	err = validateAnthropicSequencing(repaired)
-	require.NoError(t, err)
 }
 
-func TestSequencingRepair_Beta(t *testing.T) {
-	msgs := []chat.Message{
-		{Role: chat.MessageRoleUser, Content: "start"},
-		{
-			Role: chat.MessageRoleAssistant,
-			ToolCalls: []tools.ToolCall{
-				{ID: "tool-1", Function: tools.FunctionCall{Name: "do_thing", Arguments: "{}"}},
-			},
-		},
-		// Intentionally missing the user/tool_result message here
-		{Role: chat.MessageRoleUser, Content: "continue"},
-	}
-
-	converted, err := testClient().convertBetaMessages(t.Context(), msgs)
-	require.NoError(t, err)
-	err = validateAnthropicSequencingBeta(converted)
-	require.Error(t, err)
-
-	repaired := repairAnthropicSequencingBeta(converted)
-	err = validateAnthropicSequencingBeta(repaired)
-	require.NoError(t, err)
-}
-
-func TestConvertMessages_DropOrphanToolResults_NoPrecedingToolUse(t *testing.T) {
+func TestConvertMessages_OrphanToolResults_NoPrecedingToolUse_Fails(t *testing.T) {
 	msgs := []chat.Message{
 		{Role: chat.MessageRoleUser, Content: "start"},
 		// Orphan tool result (no assistant tool_use immediately before)
@@ -227,24 +202,8 @@ func TestConvertMessages_DropOrphanToolResults_NoPrecedingToolUse(t *testing.T) 
 		{Role: chat.MessageRoleUser, Content: "continue"},
 	}
 
-	converted, err := testClient().convertMessages(t.Context(), msgs)
-	require.NoError(t, err)
-	// Expect only the two user text messages to appear
-	require.Len(t, converted, 2)
-
-	// Ensure none of the converted messages contain tool_result blocks
-	for i := range converted {
-		b, err := json.Marshal(converted[i])
-		require.NoError(t, err)
-		var m map[string]any
-		require.NoError(t, json.Unmarshal(b, &m))
-		content, _ := m["content"].([]any)
-		for _, c := range content {
-			if cb, ok := c.(map[string]any); ok {
-				assert.NotEqual(t, "tool_result", cb["type"], "unexpected orphan tool_result included in payload")
-			}
-		}
-	}
+	_, err := testClient().convertMessages(t.Context(), msgs)
+	require.Error(t, err)
 }
 
 func TestConvertMessages_GroupToolResults_AfterAssistantToolUse(t *testing.T) {
@@ -267,9 +226,6 @@ func TestConvertMessages_GroupToolResults_AfterAssistantToolUse(t *testing.T) {
 	// Expect: user(start), assistant(tool_use), user(grouped tool_result), user(ok)
 	require.Len(t, converted, 4)
 
-	// Validate sequencing is acceptable to Anthropic
-	require.NoError(t, validateAnthropicSequencing(converted))
-
 	b, err := json.Marshal(converted[2])
 	require.NoError(t, err)
 	var m map[string]any
@@ -291,6 +247,23 @@ func TestConvertMessages_GroupToolResults_AfterAssistantToolUse(t *testing.T) {
 	}
 	assert.Contains(t, ids, "tool-1")
 	assert.Contains(t, ids, "tool-2")
+}
+
+func TestConvertMessages_UnexpectedToolResultID_Fails(t *testing.T) {
+	msgs := []chat.Message{
+		{Role: chat.MessageRoleUser, Content: "start"},
+		{
+			Role: chat.MessageRoleAssistant,
+			ToolCalls: []tools.ToolCall{
+				{ID: "tool-1", Function: tools.FunctionCall{Name: "t1", Arguments: "{}"}},
+			},
+		},
+		{Role: chat.MessageRoleTool, ToolCallID: "tool-1", Content: "ok"},
+		{Role: chat.MessageRoleTool, ToolCallID: "tool-2", Content: "orphan"},
+	}
+
+	_, err := testClient().convertMessages(t.Context(), msgs)
+	require.Error(t, err)
 }
 
 // TestCountAnthropicTokens_Success tests successful token counting for standard API


### PR DESCRIPTION
We should not need to validate and self-repair things, we should instead fail fast and make really sure that we have the right tools and tool results in the session.

An attempt at fixing #1644
