### PR TITLE
Make /compact non-blocking with spinner feedback

### DIFF
--- a/pkg/tui/page/chat/runtime_events.go
+++ b/pkg/tui/page/chat/runtime_events.go
@@ -124,7 +124,12 @@ func (p *chatPage) handleRuntimeEvent(msg tea.Msg) (bool, tea.Cmd) {
 
 	case *runtime.SessionCompactionEvent:
 		if msg.Status == "completed" {
-			return true, notification.SuccessCmd("Session compacted successfully.")
+			return true, tea.Batch(
+				p.setWorking(false),
+				p.setPendingResponse(false),
+				notification.SuccessCmd("Session compacted successfully."),
+				p.messages.ScrollToBottom(),
+			)
 		}
 		return true, nil
 


### PR DESCRIPTION
Run session compaction asynchronously in a background goroutine instead of blocking the TUI render thread. Show the working spinner and pending response indicator while the LLM generates the summary, and clear them when the compaction completes. The compaction context is cancellable via Esc, matching the behavior of regular agent streams.

Fixes #1678

Assisted-By: cagent