### PR TITLE
Remove redundant stdin nil check in api command

### DIFF
--- a/cmd/root/api.go
+++ b/cmd/root/api.go
@@ -94,7 +94,7 @@ func (f *apiFlags) runAPICommand(cmd *cobra.Command, args []string) error {
 	// Monitor stdin for EOF to detect parent process death.
 	// Only enabled when --exit-on-stdin-eof flag is passed.
 	// When spawned with piped stdio, stdin closes when the parent process dies.
-	if f.exitOnStdinEOF && stdin != nil {
+	if f.exitOnStdinEOF {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithCancel(ctx)
 		defer cancel()


### PR DESCRIPTION
The stdin variable is a copy of os.Stdin captured before it's set to nil, and os.Stdin is virtually always non-nil. The check provided no real protection and could confuse maintainers.

Fixes #1665