### PR TITLE
Persist tool call error state in session messages

### DIFF
--- a/pkg/chat/chat.go
+++ b/pkg/chat/chat.go
@@ -74,6 +74,9 @@ type Message struct {
 	// For Role=tool prompts this should be set to the ID given in the assistant's prior request to call a tool.
 	ToolCallID string `json:"tool_call_id,omitempty"`
 
+	// IsError indicates the tool call failed (only for Role=tool messages).
+	IsError bool `json:"is_error,omitempty"`
+
 	CreatedAt string `json:"created_at,omitempty"`
 
 	// Usage tracks token usage for this message (only set for assistant messages)

--- a/pkg/model/provider/anthropic/client.go
+++ b/pkg/model/provider/anthropic/client.go
@@ -457,7 +457,7 @@ func (c *Client) convertMessages(ctx context.Context, messages []chat.Message) (
 			var blocks []anthropic.ContentBlockParamUnion
 			j := i
 			for j < len(messages) && messages[j].Role == chat.MessageRoleTool {
-				tr := anthropic.NewToolResultBlock(messages[j].ToolCallID, strings.TrimSpace(messages[j].Content), false)
+				tr := anthropic.NewToolResultBlock(messages[j].ToolCallID, strings.TrimSpace(messages[j].Content), messages[j].IsError)
 				blocks = append(blocks, tr)
 				j++
 			}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1667,6 +1667,7 @@ func (r *LocalRuntime) executeToolWithHandler(
 		Role:       chat.MessageRoleTool,
 		Content:    content,
 		ToolCallID: toolCall.ID,
+		IsError:    res.IsError,
 		CreatedAt:  time.Now().Format(time.RFC3339),
 	}
 	addAgentMessage(sess, a, &toolResponseMsg, events)
@@ -1763,6 +1764,7 @@ func (r *LocalRuntime) addToolErrorResponse(_ context.Context, sess *session.Ses
 		Role:       chat.MessageRoleTool,
 		Content:    errorMsg,
 		ToolCallID: toolCall.ID,
+		IsError:    true,
 		CreatedAt:  time.Now().Format(time.RFC3339),
 	}
 	addAgentMessage(sess, a, &toolResponseMsg, events)


### PR DESCRIPTION
When a tool call fails (either from execution error or user rejection), the IsError flag was only sent in the streaming SSE event but never stored on the tool response message in the session. This means that when a session is reloaded, the error state is lost and failed tool calls appear as if they succeeded.

This PR adds an IsError field to chat.Message and populate it from the tool execution result in both executeToolWithHandler and addToolErrorResponse. Also pass the persisted value through to the Anthropic provider instead of hardcoding false, so that the model receives accurate error context on session resumption.