### PR TITLE
Improves first run marker logic to better handle concurrent launches

### DIFF
--- a/cmd/root/root_test.go
+++ b/cmd/root/root_test.go
@@ -1,0 +1,54 @@
+package root
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/docker/cagent/pkg/paths"
+)
+
+// TestIsFirstRun_AtomicMarker verifies that concurrent callers racing to
+// create the first-run marker produce exactly one winner. This test
+// overrides `paths.GetConfigDir`; do not run it in parallel with other
+// tests that rely on the real config dir.
+func TestIsFirstRun_AtomicMarker(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Override GetConfigDir for isolation
+	old := paths.GetConfigDir
+	paths.GetConfigDir = func() string { return tmp }
+	t.Cleanup(func() { paths.GetConfigDir = old })
+
+	const tries = 20
+	var wg sync.WaitGroup
+	wg.Add(tries)
+
+	var trues int32
+
+	start := make(chan struct{})
+
+	for i := 0; i < tries; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			if isFirstRun() {
+				atomic.AddInt32(&trues, 1)
+			}
+		}()
+	}
+
+	// Release all goroutines simultaneously to maximize contention.
+	close(start)
+
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&trues); got != 1 {
+		t.Fatalf("expected exactly 1 true, got %d", got)
+	}
+
+	// Subsequent call should be false
+	if isFirstRun() {
+		t.Fatalf("expected false on subsequent call after marker exists")
+	}
+}

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -10,7 +10,9 @@ import (
 // If the home directory cannot be determined, it falls back to a directory
 // under the system temporary directory. This is a best-effort fallback and
 // not intended to be a security boundary.
-func GetConfigDir() string {
+//
+// Exposed as a variable so tests can override it.
+var GetConfigDir = func() string {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		// Fallback to temp directory


### PR DESCRIPTION
# Summary

This PR improves the marker logic to better handle concurrent launches, which might prevent numerous starting messages from being displayed when numerous agents start at scale.

# Changes

- Switches to use os.OpenFile in isFirstRun()
- Adds a unit test to ensure the isFirstRun() function does better handle the concurrent launch
- Overrides the GetConfigDir function to allow easy testing, this approach has been done elsewhere in flags_test.go

Closes #1709