### PR TITLE
Replace time.Sleep in tests with deterministic synchronization

### DIFF
--- a/pkg/runtime/fallback_test.go
+++ b/pkg/runtime/fallback_test.go
@@ -243,10 +243,7 @@ func TestSleepWithContext(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())
 
 		// Cancel context after a short delay
-		go func() {
-			time.Sleep(10 * time.Millisecond)
-			cancel()
-		}()
+		time.AfterFunc(10*time.Millisecond, cancel)
 
 		start := time.Now()
 		completed := sleepWithContext(ctx, 1*time.Second)
@@ -699,11 +696,9 @@ func TestFallbackCooldownState(t *testing.T) {
 	assert.Equal(t, 0, state.fallbackIndex)
 
 	// Wait for cooldown to expire
-	time.Sleep(150 * time.Millisecond)
-
-	// Should no longer be in cooldown
-	state = rt.getCooldownState(agentName)
-	assert.Nil(t, state, "cooldown should have expired")
+	require.Eventually(t, func() bool {
+		return rt.getCooldownState(agentName) == nil
+	}, time.Second, 10*time.Millisecond, "cooldown should have expired")
 
 	// Set cooldown again and then clear it
 	rt.setCooldownState(agentName, 1, 1*time.Hour)

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -577,7 +577,8 @@ func TestStartBackgroundRAGInit_StopsForwardingAfterContextCancel(t *testing.T) 
 	// Cancel the context and ensure no further events are forwarded.
 	cancel()
 
-	// Give the forwarder time to observe cancellation.
+	// Brief yield to allow the forwarder goroutine to observe cancellation.
+	// This is a timing-based negative test: we verify no event is forwarded.
 	time.Sleep(10 * time.Millisecond)
 
 	// Emit another event; it should NOT be forwarded.


### PR DESCRIPTION
Use require.Eventually, time.AfterFunc, and channel synchronization instead of fixed time.Sleep calls to make tests faster and less flaky.

- telemetry: poll mockHTTP.GetRequestCount() with require.Eventually
- fake/proxy: use channel write and require.Eventually for sync points
- runtime/fallback: use time.AfterFunc for context cancel, require.Eventually for cooldown expiry
- tui/styles: poll atomic callback counter with require.Eventually

Assisted-By: cagent