### PR TITLE
Allow passing in custom tags to telemetry

### DIFF
--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -679,6 +679,233 @@ func TestHTTPRequestVerification(t *testing.T) {
 	})
 }
 
+// TestCreateEventTelemetryTags tests the TELEMETRY_TAGS environment variable support in createEvent
+func TestCreateEventTelemetryTags(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	client := newClient(logger, true, true, "test-version")
+	client.userUUID = "test-uuid"
+
+	t.Run("NoTagsSet", func(t *testing.T) {
+		t.Setenv("TELEMETRY_TAGS", "")
+
+		event := client.createEvent("test_event", map[string]any{"action": "run"})
+
+		assert.Equal(t, "run", event.Properties["action"])
+		assert.Equal(t, "test-version", event.Properties["version"])
+		assert.Equal(t, "test-uuid", event.Properties["user_uuid"])
+		// Ensure no unexpected tag keys leaked in
+		_, hasSource := event.Properties["source_system"]
+		assert.False(t, hasSource, "Expected no source_system property when TELEMETRY_TAGS is empty")
+	})
+
+	t.Run("SingleTag", func(t *testing.T) {
+		t.Setenv("TELEMETRY_TAGS", "source_system=github-actions")
+
+		event := client.createEvent("test_event", map[string]any{"action": "run"})
+
+		assert.Equal(t, "github-actions", event.Properties["source_system"])
+		assert.Equal(t, "run", event.Properties["action"])
+	})
+
+	t.Run("MultipleTags", func(t *testing.T) {
+		t.Setenv("TELEMETRY_TAGS", "source_system=github-actions,repo=docker/cagent,workflow=pr-review")
+
+		event := client.createEvent("test_event", map[string]any{"action": "run"})
+
+		assert.Equal(t, "github-actions", event.Properties["source_system"])
+		assert.Equal(t, "docker/cagent", event.Properties["repo"])
+		assert.Equal(t, "pr-review", event.Properties["workflow"])
+	})
+
+	t.Run("TagsWithWhitespace", func(t *testing.T) {
+		t.Setenv("TELEMETRY_TAGS", " source_system = github-actions , repo = docker/cagent ")
+
+		event := client.createEvent("test_event", map[string]any{"action": "run"})
+
+		assert.Equal(t, "github-actions", event.Properties["source_system"])
+		assert.Equal(t, "docker/cagent", event.Properties["repo"])
+	})
+
+	t.Run("MalformedTagsIgnored", func(t *testing.T) {
+		// Tags without "=" should be silently ignored
+		t.Setenv("TELEMETRY_TAGS", "valid_key=valid_value,malformed_no_equals,another=good")
+
+		event := client.createEvent("test_event", map[string]any{"action": "run"})
+
+		assert.Equal(t, "valid_value", event.Properties["valid_key"])
+		assert.Equal(t, "good", event.Properties["another"])
+		_, hasMalformed := event.Properties["malformed_no_equals"]
+		assert.False(t, hasMalformed, "Malformed tag without = should be ignored")
+	})
+
+	t.Run("SystemMetadataCannotBeOverwritten", func(t *testing.T) {
+		// This is the critical security test: TELEMETRY_TAGS must NOT be able to
+		// overwrite system metadata like user_uuid, version, os, os_language
+		t.Setenv("TELEMETRY_TAGS", "user_uuid=attacker,version=fake,os=spoofed,os_language=xx")
+
+		event := client.createEvent("test_event", map[string]any{"action": "run"})
+
+		// System metadata should win over tags
+		assert.Equal(t, "test-uuid", event.Properties["user_uuid"], "user_uuid must not be overwritable via TELEMETRY_TAGS")
+		assert.Equal(t, "test-version", event.Properties["version"], "version must not be overwritable via TELEMETRY_TAGS")
+		assert.NotEqual(t, "spoofed", event.Properties["os"], "os must not be overwritable via TELEMETRY_TAGS")
+		assert.NotEqual(t, "xx", event.Properties["os_language"], "os_language must not be overwritable via TELEMETRY_TAGS")
+	})
+
+	t.Run("TagsDoNotOverwriteUserProperties", func(t *testing.T) {
+		// Tags are applied after user properties, so tags CAN overwrite user-provided props.
+		// This is by design — TELEMETRY_TAGS is set by the environment operator (e.g., CI),
+		// who should have higher priority than individual event properties.
+		t.Setenv("TELEMETRY_TAGS", "action=overridden")
+
+		event := client.createEvent("test_event", map[string]any{"action": "original"})
+
+		assert.Equal(t, "overridden", event.Properties["action"],
+			"TELEMETRY_TAGS should override user-provided properties (environment operator has priority)")
+	})
+
+	t.Run("EmptyValueTag", func(t *testing.T) {
+		t.Setenv("TELEMETRY_TAGS", "empty_val=")
+
+		event := client.createEvent("test_event", map[string]any{})
+
+		assert.Empty(t, event.Properties["empty_val"], "Empty value tags should be preserved")
+	})
+
+	t.Run("TagWithEqualsInValue", func(t *testing.T) {
+		// strings.Cut splits on the first "=", so "key=val=ue" → key:"val=ue"
+		t.Setenv("TELEMETRY_TAGS", "equation=a=b")
+
+		event := client.createEvent("test_event", map[string]any{})
+
+		assert.Equal(t, "a=b", event.Properties["equation"], "Values containing = should be preserved")
+	})
+}
+
+func TestTelemetryTags(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	mockHTTP := NewMockHTTPClient()
+	client := newClient(logger, true, true, "test-version", mockHTTP.Client)
+
+	client.endpoint = "https://test-tags.com/api"
+	client.apiKey = "test-tags-key"
+	client.header = "test-header"
+
+	t.Run("TagsIncludedInEvent", func(t *testing.T) {
+		t.Setenv("TELEMETRY_TAGS", "ci=github-actions,repository=docker/cagent,workflow=PR Review")
+
+		mockHTTP = NewMockHTTPClient()
+		client.httpClient = mockHTTP
+
+		client.Track(t.Context(), &CommandEvent{Action: "test", Success: true})
+		time.Sleep(20 * time.Millisecond)
+
+		bodies := mockHTTP.GetBodies()
+		require.NotEmpty(t, bodies)
+
+		var requestBody map[string]any
+		require.NoError(t, json.Unmarshal(bodies[0], &requestBody))
+
+		records := requestBody["records"].([]any)
+		properties := records[0].(map[string]any)["properties"].(map[string]any)
+
+		assert.Equal(t, "github-actions", properties["ci"])
+		assert.Equal(t, "docker/cagent", properties["repository"])
+		assert.Equal(t, "PR Review", properties["workflow"])
+	})
+
+	t.Run("NoTagsWhenUnset", func(t *testing.T) {
+		t.Setenv("TELEMETRY_TAGS", "")
+
+		mockHTTP = NewMockHTTPClient()
+		client.httpClient = mockHTTP
+
+		client.Track(t.Context(), &CommandEvent{Action: "test", Success: true})
+		time.Sleep(20 * time.Millisecond)
+
+		bodies := mockHTTP.GetBodies()
+		require.NotEmpty(t, bodies)
+
+		var requestBody map[string]any
+		require.NoError(t, json.Unmarshal(bodies[0], &requestBody))
+
+		records := requestBody["records"].([]any)
+		properties := records[0].(map[string]any)["properties"].(map[string]any)
+
+		_, hasCi := properties["ci"]
+		assert.False(t, hasCi, "Expected no 'ci' property when TELEMETRY_TAGS is empty")
+	})
+
+	t.Run("SystemMetadataCannotBeOverwritten", func(t *testing.T) {
+		t.Setenv("TELEMETRY_TAGS", "user_uuid=fake,version=0.0.0,os=spoofed")
+
+		mockHTTP = NewMockHTTPClient()
+		client.httpClient = mockHTTP
+
+		client.Track(t.Context(), &CommandEvent{Action: "test", Success: true})
+		time.Sleep(20 * time.Millisecond)
+
+		bodies := mockHTTP.GetBodies()
+		require.NotEmpty(t, bodies)
+
+		var requestBody map[string]any
+		require.NoError(t, json.Unmarshal(bodies[0], &requestBody))
+
+		records := requestBody["records"].([]any)
+		properties := records[0].(map[string]any)["properties"].(map[string]any)
+
+		assert.NotEqual(t, "fake", properties["user_uuid"], "user_uuid should not be overwritable via tags")
+		assert.Equal(t, "test-version", properties["version"], "version should not be overwritable via tags")
+		assert.NotEqual(t, "spoofed", properties["os"], "os should not be overwritable via tags")
+	})
+
+	t.Run("MalformedTagsIgnored", func(t *testing.T) {
+		t.Setenv("TELEMETRY_TAGS", "valid=yes,no_equals_sign,=empty_key,also_valid=true")
+
+		mockHTTP = NewMockHTTPClient()
+		client.httpClient = mockHTTP
+
+		client.Track(t.Context(), &CommandEvent{Action: "test", Success: true})
+		time.Sleep(20 * time.Millisecond)
+
+		bodies := mockHTTP.GetBodies()
+		require.NotEmpty(t, bodies)
+
+		var requestBody map[string]any
+		require.NoError(t, json.Unmarshal(bodies[0], &requestBody))
+
+		records := requestBody["records"].([]any)
+		properties := records[0].(map[string]any)["properties"].(map[string]any)
+
+		assert.Equal(t, "yes", properties["valid"])
+		assert.Equal(t, "true", properties["also_valid"])
+		_, hasEmptyKey := properties[""]
+		assert.False(t, hasEmptyKey, "Empty keys should be ignored")
+	})
+
+	t.Run("WhitespaceIsTrimmed", func(t *testing.T) {
+		t.Setenv("TELEMETRY_TAGS", " key1 = value1 , key2 = value2 ")
+
+		mockHTTP = NewMockHTTPClient()
+		client.httpClient = mockHTTP
+
+		client.Track(t.Context(), &CommandEvent{Action: "test", Success: true})
+		time.Sleep(20 * time.Millisecond)
+
+		bodies := mockHTTP.GetBodies()
+		require.NotEmpty(t, bodies)
+
+		var requestBody map[string]any
+		require.NoError(t, json.Unmarshal(bodies[0], &requestBody))
+
+		records := requestBody["records"].([]any)
+		properties := records[0].(map[string]any)["properties"].(map[string]any)
+
+		assert.Equal(t, "value1", properties["key1"])
+		assert.Equal(t, "value2", properties["key2"])
+	})
+}
+
 // TestNon2xxHTTPResponseHandling ensures that 5xx responses are logged and handled gracefully
 func TestNon2xxHTTPResponseHandling(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))


### PR DESCRIPTION
Closes: https://github.com/docker/gordon/issues/121

Add support for a `TELEMETRY_TAGS` environment variable that allows callers to attach custom key-value metadata to every telemetry event. This enables tracking where and how the binary is invoked (e.g., GitHub Actions, specific repos, workflows) without hardcoding provider-specific logic into the binary itself.

## Changes

- **`pkg/telemetry/http.go`**: Parse `TELEMETRY_TAGS` env var (comma-separated `key=value` pairs) in `createEvent()` and merge them into event properties. System metadata (`user_uuid`, `version`, `os`, `os_language`) is written **after** tags to prevent spoofing. Empty keys and malformed entries (missing `=`) are silently ignored. Whitespace around keys and values is trimmed.
- **`pkg/telemetry/telemetry_test.go`**: Add two test suites:
  - `TestCreateEventTelemetryTags` — unit tests calling `createEvent()` directly, covering: single/multiple tags, whitespace trimming, malformed input, empty values, values containing `=`, system metadata protection, and operator-priority behavior.
  - `TestTelemetryTags` — integration tests using `MockHTTPClient` to verify tags appear in the actual HTTP request payload, including security and edge-case scenarios.

## Test plan

- `go test ./pkg/telemetry/ -run TestCreateEventTelemetryTags -v` — 9 subtests
- `go test ./pkg/telemetry/ -run TestTelemetryTags -v` — 5 subtests
- `go test ./pkg/telemetry/` — full suite passes with no regressions