### PR TITLE
fix(editor): prevent thread block when attachment file is deleted

### DIFF
--- a/pkg/tui/components/editor/editor.go
+++ b/pkg/tui/components/editor/editor.go
@@ -1273,8 +1273,19 @@ func (e *editor) InsertText(text string) {
 	e.refreshSuggestion()
 }
 
-// AttachFile adds a file as an attachment and inserts @filepath into the editor
+// AttachFile safely adds a file as an attachment and inserts @filepath into the editor.
+// If the file does not exist or is not accessible, the reference is ignored gracefully.
 func (e *editor) AttachFile(filePath string) {
+	info, err := os.Stat(filePath)
+	if err != nil {
+		slog.Warn("AttachFile skipped: cannot access file", "path", filePath, "error", err)
+		return
+	}
+	if info.IsDir() {
+		slog.Warn("AttachFile skipped: path is a directory", "path", filePath)
+		return
+	}
+
 	placeholder := "@" + filePath
 	e.addFileAttachment(placeholder)
 	currentValue := e.textarea.Value()


### PR DESCRIPTION
## What I did

- Prevented thread blocking when an attachment file is deleted.
- Updated collectAttachments to log and skip missing files instead of breaking the render flow.
- Ensured temporary files are cleaned safely.
- Preserved non-temporary attachments when appropriate.

## Releated Issue

- Fixes #1735