### PR TITLE
fix(#1743): retry primary model on transient errors even without fallback models

### DIFF
--- a/pkg/runtime/fallback.go
+++ b/pkg/runtime/fallback.go
@@ -369,9 +369,10 @@ func getEffectiveCooldown(a *agent.Agent) time.Duration {
 }
 
 // getEffectiveRetries returns the number of retries to use for the agent.
-// If no retries are explicitly configured (retries == 0) and fallback models
-// are configured, returns DefaultFallbackRetries to provide sensible retry
-// behavior out of the box.
+// If no retries are explicitly configured (retries == 0), returns
+// DefaultFallbackRetries to provide sensible retry behavior out of the box.
+// Retries apply to retryable errors (5xx, timeouts) on the same model,
+// regardless of whether fallback models are configured.
 //
 // Note: Users who explicitly want 0 retries can set retries: -1 in their config
 // (though this is an edge case - most users want some retries for resilience).
@@ -381,8 +382,7 @@ func getEffectiveRetries(a *agent.Agent) int {
 	if retries < 0 {
 		return 0
 	}
-	// 0 means "use default" when fallback models are configured
-	if retries == 0 && len(a.FallbackModels()) > 0 {
+	if retries == 0 {
 		return DefaultFallbackRetries
 	}
 	return retries


### PR DESCRIPTION
## Summary

Fixes #1743

`getEffectiveRetries` returned 0 when no fallback models were configured, meaning retryable errors (5xx, timeouts) got zero retries. This caused Anthropic streaming `Internal server error` to immediately surface as `"all models failed"` instead of being retried with backoff.

## Root Cause

The `getEffectiveRetries` function conflated "no fallback models to fall back to" with "no need to retry the same model":

```go
// Before: returns 0 when no fallback models configured
if retries == 0 && len(a.FallbackModels()) > 0 {
    return DefaultFallbackRetries
}
return retries // returns 0
```

With `maxAttempts = 1 + 0 = 1`, even correctly-classified retryable errors got exactly one shot.

## Fix

Changed `getEffectiveRetries` to always return `DefaultFallbackRetries` (2 retries = 3 total attempts) when no explicit retry count is configured, regardless of whether fallback models exist:

```go
// After: always returns DefaultFallbackRetries when not explicitly configured
if retries == 0 {
    return DefaultFallbackRetries
}
return retries
```

## Tests

- Updated `TestGetEffectiveRetries` to expect `DefaultFallbackRetries` for agents without fallback models
- Added `TestPrimaryRetriesWithoutFallbackModels` — regression test reproducing the exact scenario (Anthropic streaming `Internal server error`, no fallback models, verifies retry and recovery)
- Added `isRetryableModelError` test case for the Anthropic streaming error format