### PR TITLE
Rename cagent OCI annotation, keep old one

### DIFF
--- a/pkg/oci/package.go
+++ b/pkg/oci/package.go
@@ -55,6 +55,7 @@ func PackageFileAsOCIToStore(ctx context.Context, agentSource config.Source, art
 	// Prepare OCI annotations
 	annotations := map[string]string{
 		"io.docker.cagent.version":             version.Version,
+		"io.docker.agent.version":              version.Version,
 		"org.opencontainers.image.created":     time.Now().Format(time.RFC3339),
 		"org.opencontainers.image.description": fmt.Sprintf("OCI artifact containing %s", filepath.Base(agentSource.Name())),
 	}
@@ -76,7 +77,7 @@ func PackageFileAsOCIToStore(ctx context.Context, agentSource config.Source, art
 
 	// Convert to OCI manifest format to support annotations
 	img = mutate.MediaType(img, types.OCIManifestSchema1)
-	img = mutate.ConfigMediaType(img, "application/vnd.docker.cagent.config.v1+json")
+	img = mutate.ConfigMediaType(img, "application/vnd.docker.agent.config.v1+json")
 	img = mutate.Annotations(img, annotations).(v1.Image)
 
 	digest, err := store.StoreArtifact(img, artifactRef)

--- a/pkg/remote/pull.go
+++ b/pkg/remote/pull.go
@@ -63,7 +63,10 @@ func Pull(ctx context.Context, registryRef string, force bool, opts ...crane.Opt
 }
 
 func hasCagentAnnotation(annotations map[string]string) bool {
-	_, exists := annotations["io.docker.cagent.version"]
+	_, exists := annotations["io.docker.agent.version"]
+	if !exists {
+		_, exists = annotations["io.docker.cagent.version"]
+	}
 	return exists
 }
 

--- a/pkg/remote/push.go
+++ b/pkg/remote/push.go
@@ -38,7 +38,7 @@ func Push(reference string) error {
 
 	// Wrap as a spec-compliant OCI artifact so the pushed manifest includes
 	// artifactType and an empty config descriptor.
-	img = content.NewArtifactImage(img, "application/vnd.docker.cagent.config.v1+json")
+	img = content.NewArtifactImage(img, "application/vnd.docker.agent.config.v1+json")
 
 	ref, err := name.ParseReference(reference)
 	if err != nil {


### PR DESCRIPTION
Support annotation `io.docker.agent.version` in addition to the cagent one
Updated config media type with `docker.agent`