### PR TITLE
Thread context.Context through modelsdev store API

### DIFF
--- a/pkg/config/examples_test.go
+++ b/pkg/config/examples_test.go
@@ -70,7 +70,7 @@ func TestParseExamples(t *testing.T) {
 					continue
 				}
 
-				model, err := modelsStore.GetModel(model.Provider + "/" + model.Model)
+				model, err := modelsStore.GetModel(t.Context(), model.Provider+"/"+model.Model)
 				require.NoError(t, err)
 				require.NotNil(t, model)
 			}

--- a/pkg/config/model_alias_test.go
+++ b/pkg/config/model_alias_test.go
@@ -237,7 +237,7 @@ func TestResolveModelAliases(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ResolveModelAliases(tt.cfg, store)
+			ResolveModelAliases(t.Context(), tt.cfg, store)
 			assert.Equal(t, tt.expected, tt.cfg)
 		})
 	}

--- a/pkg/model/provider/bedrock/client.go
+++ b/pkg/model/provider/bedrock/client.go
@@ -112,7 +112,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 
 	// Detect prompt caching capability at init time for efficiency.
 	// Uses models.dev cache pricing as proxy for capability detection.
-	cachingSupported := detectCachingSupport(cfg.Model)
+	cachingSupported := detectCachingSupport(ctx, cfg.Model)
 
 	slog.Debug("Bedrock client created successfully",
 		"model", cfg.Model,
@@ -133,7 +133,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 // detectCachingSupport checks if a model supports prompt caching using models.dev data.
 // Models with non-zero CacheRead/CacheWrite costs support prompt caching.
 // Returns false on lookup failure (safe default for unsupported models).
-func detectCachingSupport(model string) bool {
+func detectCachingSupport(ctx context.Context, model string) bool {
 	store, err := modelsdev.NewStore()
 	if err != nil {
 		slog.Debug("Bedrock models store unavailable, prompt caching disabled", "error", err)
@@ -141,7 +141,7 @@ func detectCachingSupport(model string) bool {
 	}
 
 	modelID := "amazon-bedrock/" + model
-	m, err := store.GetModel(modelID)
+	m, err := store.GetModel(ctx, modelID)
 	if err != nil {
 		slog.Debug("Bedrock prompt caching disabled: model not found in models.dev",
 			"model_id", modelID, "error", err)

--- a/pkg/model/provider/bedrock/client_test.go
+++ b/pkg/model/provider/bedrock/client_test.go
@@ -1249,7 +1249,7 @@ func TestDetectCachingSupport_SupportedModel(t *testing.T) {
 	t.Parallel()
 
 	// Uses real models.dev lookup to verify Claude models support caching
-	supported := detectCachingSupport("anthropic.claude-3-5-sonnet-20241022-v2:0")
+	supported := detectCachingSupport(t.Context(), "anthropic.claude-3-5-sonnet-20241022-v2:0")
 	assert.True(t, supported)
 }
 
@@ -1257,7 +1257,7 @@ func TestDetectCachingSupport_UnsupportedModel(t *testing.T) {
 	t.Parallel()
 
 	// Llama doesn't have cache pricing in models.dev
-	supported := detectCachingSupport("meta.llama3-8b-instruct-v1:0")
+	supported := detectCachingSupport(t.Context(), "meta.llama3-8b-instruct-v1:0")
 	assert.False(t, supported)
 }
 
@@ -1265,7 +1265,7 @@ func TestDetectCachingSupport_UnknownModel(t *testing.T) {
 	t.Parallel()
 
 	// Unknown model should gracefully return false, not panic
-	supported := detectCachingSupport("nonexistent.model.that.does.not.exist:v1")
+	supported := detectCachingSupport(t.Context(), "nonexistent.model.that.does.not.exist:v1")
 	assert.False(t, supported)
 }
 

--- a/pkg/modelsdev/store_test.go
+++ b/pkg/modelsdev/store_test.go
@@ -57,7 +57,7 @@ func TestResolveModelAlias(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := store.ResolveModelAlias(tt.provider, tt.model)
+			result := store.ResolveModelAlias(t.Context(), tt.provider, tt.model)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/pkg/rag/strategy/semantic_embeddings.go
+++ b/pkg/rag/strategy/semantic_embeddings.go
@@ -506,7 +506,7 @@ func calculateSemanticUsageCost(modelsStore modelStore, modelID string, usage *c
 		return 0
 	}
 
-	model, err := modelsStore.GetModel(modelID)
+	model, err := modelsStore.GetModel(context.Background(), modelID)
 	if err != nil {
 		slog.Debug("Failed to get semantic model pricing from models.dev, cost will be 0",
 			"model_id", modelID,

--- a/pkg/rag/strategy/vector_store.go
+++ b/pkg/rag/strategy/vector_store.go
@@ -87,7 +87,7 @@ type VectorStore struct {
 }
 
 type modelStore interface {
-	GetModel(modelID string) (*modelsdev.Model, error)
+	GetModel(ctx context.Context, modelID string) (*modelsdev.Model, error)
 }
 
 // EmbeddingInputBuilder builds the string that will be sent to the embedding model
@@ -174,7 +174,7 @@ func (s *VectorStore) calculateCost(tokens int64) float64 {
 		return 0
 	}
 
-	model, err := s.modelsStore.GetModel(s.modelID)
+	model, err := s.modelsStore.GetModel(context.Background(), s.modelID)
 	if err != nil {
 		slog.Debug("Failed to get model pricing from models.dev, cost will be 0",
 			"model_id", s.modelID,

--- a/pkg/runtime/model_switcher.go
+++ b/pkg/runtime/model_switcher.go
@@ -286,7 +286,7 @@ func (r *LocalRuntime) AvailableModels(ctx context.Context) []ModelChoice {
 // buildCatalogChoices builds ModelChoice entries from the models.dev catalog,
 // filtered by supported providers and available credentials.
 func (r *LocalRuntime) buildCatalogChoices(ctx context.Context) []ModelChoice {
-	db, err := r.modelsStore.GetDatabase()
+	db, err := r.modelsStore.GetDatabase(ctx)
 	if err != nil {
 		slog.Debug("Failed to get models.dev database for catalog", "error", err)
 		return nil
@@ -446,7 +446,7 @@ func (r *LocalRuntime) createProviderFromConfig(ctx context.Context, cfg *latest
 	if cfg.MaxTokens != nil {
 		opts = append(opts, options.WithMaxTokens(*cfg.MaxTokens))
 	} else if r.modelsStore != nil {
-		m, err := r.modelsStore.GetModel(cfg.Provider + "/" + cfg.Model)
+		m, err := r.modelsStore.GetModel(ctx, cfg.Provider+"/"+cfg.Model)
 		if err == nil && m != nil {
 			opts = append(opts, options.WithMaxTokens(m.Limit.Output))
 		}

--- a/pkg/runtime/model_switcher_test.go
+++ b/pkg/runtime/model_switcher_test.go
@@ -27,7 +27,7 @@ type mockCatalogStore struct {
 	db *modelsdev.Database
 }
 
-func (m *mockCatalogStore) GetDatabase() (*modelsdev.Database, error) {
+func (m *mockCatalogStore) GetDatabase(_ context.Context) (*modelsdev.Database, error) {
 	return m.db, nil
 }
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -171,8 +171,8 @@ type CurrentAgentInfo struct {
 }
 
 type ModelStore interface {
-	GetModel(modelID string) (*modelsdev.Model, error)
-	GetDatabase() (*modelsdev.Database, error)
+	GetModel(ctx context.Context, modelID string) (*modelsdev.Model, error)
+	GetDatabase(ctx context.Context) (*modelsdev.Database, error)
 }
 
 // RAGInitializer is implemented by runtimes that support background RAG initialization.
@@ -988,7 +988,7 @@ func (r *LocalRuntime) RunStream(ctx context.Context, sess *session.Session) <-c
 			modelID := model.ID()
 			slog.Debug("Using agent", "agent", a.Name(), "model", modelID)
 			slog.Debug("Getting model definition", "model_id", modelID)
-			m, err := r.modelsStore.GetModel(modelID)
+			m, err := r.modelsStore.GetModel(ctx, modelID)
 			if err != nil {
 				slog.Debug("Failed to get model definition", "error", err)
 			}

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -175,7 +175,7 @@ type mockModelStore struct {
 	ModelStore
 }
 
-func (m mockModelStore) GetModel(string) (*modelsdev.Model, error) {
+func (m mockModelStore) GetModel(_ context.Context, _ string) (*modelsdev.Model, error) {
 	return nil, nil
 }
 
@@ -681,7 +681,7 @@ type mockModelStoreWithLimit struct {
 	limit int
 }
 
-func (m mockModelStoreWithLimit) GetModel(string) (*modelsdev.Model, error) {
+func (m mockModelStoreWithLimit) GetModel(_ context.Context, _ string) (*modelsdev.Model, error) {
 	return &modelsdev.Model{Limit: modelsdev.Limit{Context: m.limit}, Cost: &modelsdev.Cost{}}, nil
 }
 

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -116,7 +116,7 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 	if err != nil {
 		slog.Debug("Failed to create modelsdev store for alias resolution", "error", err)
 	} else {
-		config.ResolveModelAliases(cfg, modelsStore)
+		config.ResolveModelAliases(ctx, cfg, modelsStore)
 	}
 
 	// Apply model overrides from CLI flags before checking required env vars
@@ -318,7 +318,7 @@ func getModelsForAgent(ctx context.Context, cfg *latest.Config, a *latest.AgentC
 			if err != nil {
 				return nil, false, err
 			}
-			m, err := modelsStore.GetModel(modelCfg.Provider + "/" + modelCfg.Model)
+			m, err := modelsStore.GetModel(ctx, modelCfg.Provider+"/"+modelCfg.Model)
 			if err == nil {
 				maxTokens = &m.Limit.Output
 			}
@@ -381,7 +381,7 @@ func getFallbackModelsForAgent(ctx context.Context, cfg *latest.Config, a *lates
 			if err != nil {
 				return nil, err
 			}
-			m, err := modelsStore.GetModel(modelCfg.Provider + "/" + modelCfg.Model)
+			m, err := modelsStore.GetModel(ctx, modelCfg.Provider+"/"+modelCfg.Model)
 			if err == nil {
 				maxTokens = &m.Limit.Output
 			}

--- a/pkg/tui/commands/commands.go
+++ b/pkg/tui/commands/commands.go
@@ -262,7 +262,7 @@ func BuildCommandCategories(ctx context.Context, application *app.App) []Categor
 
 	// Check if the current model supports reasoning; hide /think if not
 	currentModel := application.CurrentAgentModel()
-	if !modelsdev.ModelSupportsReasoning(currentModel) {
+	if !modelsdev.ModelSupportsReasoning(ctx, currentModel) {
 		filtered := make([]Item, 0, len(sessionCommands))
 		for _, cmd := range sessionCommands {
 			if cmd.ID != "session.think" {

--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -1,6 +1,7 @@
 package sidebar
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -252,7 +253,9 @@ func (m *model) SetAgentInfo(agentName, modelID, description string) {
 	m.currentAgent = agentName
 	m.agentModel = modelID
 	m.agentDescription = description
-	m.reasoningSupported = modelsdev.ModelSupportsReasoning(modelID)
+	// TODO: this can block for up to 30s on the first call if the cache is cold,
+	// which freezes the TUI. Move to an async command.
+	m.reasoningSupported = modelsdev.ModelSupportsReasoning(context.TODO(), modelID)
 
 	// Update the provider and model in availableAgents for the current agent.
 	// This is important when fallback models from different providers are used.

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -330,7 +330,9 @@ func (a *appModel) handleToggleYolo() (tea.Model, tea.Cmd) {
 func (a *appModel) handleToggleThinking() (tea.Model, tea.Cmd) {
 	// Check if the current model supports reasoning
 	currentModel := a.application.CurrentAgentModel()
-	if !modelsdev.ModelSupportsReasoning(currentModel) {
+	// TODO: this can block for up to 30s on the first call if the cache is cold,
+	// which freezes the TUI. Move to an async command.
+	if !modelsdev.ModelSupportsReasoning(context.TODO(), currentModel) {
 		return a, notification.InfoCmd("Thinking/reasoning is not supported for the current model")
 	}
 


### PR DESCRIPTION
Pass caller-provided context to the HTTP request in fetchFromAPI instead of using context.Background(). This allows cancellation and deadline propagation when fetching from the models.dev API.

Updated all public Store methods (GetDatabase, GetProvider, GetModel, ResolveModelAlias) and ModelSupportsReasoning to accept context. Changed the lazy loading from sync.OnceValues to sync.Once to support the context parameter. Updated all callsites across the codebase, using context.Background() only in TUI callbacks and pricing calculation callbacks where no caller context is available.

Assisted-By: cagent