### PR TITLE
Restore ctrl-r binding for searching prompt history

### DIFF
--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -216,7 +216,6 @@ type KeyMap struct {
 	Cancel          key.Binding
 	ToggleSplitDiff key.Binding
 	ToggleSidebar   key.Binding
-	HistorySearch   key.Binding
 }
 
 // defaultKeyMap returns the default key bindings.


### PR DESCRIPTION
fixes an oopsie

closes #1758
