### PR TITLE
fix: cagent-action expects a prompt

### DIFF
--- a/.github/workflows/nightly-scan.yml
+++ b/.github/workflows/nightly-scan.yml
@@ -58,7 +58,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
         with:
           agent: ${{ github.workspace }}/.github/agents/nightly-scanner.yaml
-          prompt: "${{ inputs['dry-run'] && 'DRY RUN MODE: Do not create any issues. Just report what you would create.' || '' }}"
+          prompt: "${{ inputs['dry-run'] && 'DRY RUN MODE: Do not create any issues. Just report what you would create.' || 'Run the nightly scan as documented in your instructions.' }}"
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           google-api-key: ${{ secrets.GEMINI_API_KEY }}


### PR DESCRIPTION
## Summary

The `cagent-action` GitHub Action requires a non-empty `prompt` input, but the nightly scan workflow was passing an empty string (`''`) when not in dry-run mode. This fix provides a meaningful default prompt so the action always receives a valid instruction.

## Changes

- Updated the nightly scan workflow's `prompt` fallback from an empty string to `'Run the nightly scan as documented in your instructions.'`, ensuring the agent always receives an explicit prompt regardless of whether dry-run mode is enabled.

## Test plan

- Trigger the `nightly-scan` workflow without the `dry-run` input and verify the action receives the default prompt and executes successfully.
- Trigger the workflow with `dry-run` enabled and verify it still receives the dry-run prompt.