### PR TITLE
Add mouse click support to elicitation, prompt input, and tool confirmation dialogs

### DIFF
--- a/pkg/tui/dialog/base.go
+++ b/pkg/tui/dialog/base.go
@@ -83,6 +83,23 @@ func (b *BaseDialog) CenterDialog(renderedDialog string) (row, col int) {
 	return CenterPosition(b.width, b.height, dialogWidth, dialogHeight)
 }
 
+// ContentStartRow returns the absolute Y row where content begins inside a dialog.
+// dialogRow is the top-left row of the dialog, and headerContent is the rendered
+// header text above the target content area. The dialog frame (border + padding)
+// is accounted for automatically using DialogStyle.
+func ContentStartRow(dialogRow int, headerContent string) int {
+	frameTop := styles.DialogStyle.GetBorderTopSize() + styles.DialogStyle.GetPaddingTop()
+	return dialogRow + frameTop + lipgloss.Height(headerContent)
+}
+
+// ContentEndRow returns the absolute Y row of the last content line inside a dialog.
+// dialogRow is the top-left row and dialogHeight is the total rendered height.
+// The dialog frame (border + padding) is accounted for automatically using DialogStyle.
+func ContentEndRow(dialogRow, dialogHeight int) int {
+	frameBottom := styles.DialogStyle.GetBorderBottomSize() + styles.DialogStyle.GetPaddingBottom()
+	return dialogRow + dialogHeight - 1 - frameBottom
+}
+
 // CloseWithElicitationResponse returns a command that closes the dialog and sends an elicitation response.
 func CloseWithElicitationResponse(action tools.ElicitationAction, content map[string]any) tea.Cmd {
 	return tea.Sequence(


### PR DESCRIPTION
Enable mouse interactions for TUI dialogs so users can click to focus fields, select enum/boolean options, and trigger confirmation actions instead of relying solely on keyboard navigation.

- ElicitationDialog: click field labels to focus, click boolean/enum options to select them directly
- MCPPromptInputDialog: click field labels or inputs to focus them
- ToolConfirmationDialog: click Y/N/T/A help key regions to trigger the corresponding approve/reject/allow actions

Assisted-By: cagent