### PR TITLE
temp home dir to avoid issues in some environments

### DIFF
--- a/pkg/teamloader/teamloader_test.go
+++ b/pkg/teamloader/teamloader_test.go
@@ -137,7 +137,7 @@ func TestLoadExamples(t *testing.T) {
 }
 
 func TestLoadDefaultAgent(t *testing.T) {
-	t.Parallel()
+	t.Setenv("HOME", t.TempDir())
 
 	agentSource, err := config.Resolve("default", nil)
 	require.NoError(t, err)


### PR DESCRIPTION
fixes issues running the test locally when having a default agent alias