### PR TITLE
permissions: add Ask list to force confirmation for tools

### DIFF
--- a/cagent-schema.json
+++ b/cagent-schema.json
@@ -636,6 +636,21 @@
             ]
           ]
         },
+        "ask": {
+          "type": "array",
+          "description": "Tool patterns that always require user confirmation, even for tools that are normally auto-approved (e.g. read-only tools). Supports the same pattern syntax as allow: tool names with globs and argument matching (e.g., 'fetch' to always ask before fetching URLs).",
+          "items": {
+            "type": "string"
+          },
+          "examples": [
+            [
+              "fetch"
+            ],
+            [
+              "mcp:github:get_*"
+            ]
+          ]
+        },
         "deny": {
           "type": "array",
           "description": "Tool patterns that are always rejected. Takes priority over allow patterns. Supports the same pattern syntax as allow: tool names with globs and argument matching (e.g., 'shell:cmd=rm -rf*' to block dangerous rm commands).",

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -532,9 +532,10 @@ func (a *App) PermissionsInfo() *runtime.PermissionsInfo {
 	// Get session-level permissions
 	var sessionPerms *runtime.PermissionsInfo
 	if a.session != nil && a.session.Permissions != nil {
-		if len(a.session.Permissions.Allow) > 0 || len(a.session.Permissions.Deny) > 0 {
+		if len(a.session.Permissions.Allow) > 0 || len(a.session.Permissions.Ask) > 0 || len(a.session.Permissions.Deny) > 0 {
 			sessionPerms = &runtime.PermissionsInfo{
 				Allow: a.session.Permissions.Allow,
+				Ask:   a.session.Permissions.Ask,
 				Deny:  a.session.Permissions.Deny,
 			}
 		}
@@ -549,10 +550,12 @@ func (a *App) PermissionsInfo() *runtime.PermissionsInfo {
 	result := &runtime.PermissionsInfo{}
 	if sessionPerms != nil {
 		result.Allow = append(result.Allow, sessionPerms.Allow...)
+		result.Ask = append(result.Ask, sessionPerms.Ask...)
 		result.Deny = append(result.Deny, sessionPerms.Deny...)
 	}
 	if teamPerms != nil {
 		result.Allow = append(result.Allow, teamPerms.Allow...)
+		result.Ask = append(result.Ask, teamPerms.Ask...)
 		result.Deny = append(result.Deny, teamPerms.Deny...)
 	}
 

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -1069,14 +1069,18 @@ type RAGFusionConfig struct {
 // PermissionsConfig represents tool permission configuration.
 // Allow/Ask/Deny model. This controls tool call approval behavior:
 // - Allow: Tools matching these patterns are auto-approved (like --yolo for specific tools)
-// - Ask: Tools matching these patterns always require user approval (default behavior)
+// - Ask: Tools matching these patterns always require user approval, even if the tool is read-only
 // - Deny: Tools matching these patterns are always rejected, even with --yolo
 //
 // Patterns support glob-style matching (e.g., "shell", "read_*", "mcp:github:*")
-// The evaluation order is: Deny (checked first), then Allow, then Ask (default)
+// The evaluation order is: Deny (checked first), then Allow, then Ask (explicit), then default
+// (read-only tools auto-approved, others ask)
 type PermissionsConfig struct {
 	// Allow lists tool name patterns that are auto-approved without user confirmation
 	Allow []string `json:"allow,omitempty"`
+	// Ask lists tool name patterns that always require user confirmation,
+	// even for tools that are normally auto-approved (e.g. read-only tools)
+	Ask []string `json:"ask,omitempty"`
 	// Deny lists tool name patterns that are always rejected
 	Deny []string `json:"deny,omitempty"`
 }

--- a/pkg/config/v4/types.go
+++ b/pkg/config/v4/types.go
@@ -1056,14 +1056,18 @@ type RAGFusionConfig struct {
 // PermissionsConfig represents tool permission configuration.
 // Allow/Ask/Deny model. This controls tool call approval behavior:
 // - Allow: Tools matching these patterns are auto-approved (like --yolo for specific tools)
-// - Ask: Tools matching these patterns always require user approval (default behavior)
+// - Ask: Tools matching these patterns always require user approval, even if the tool is read-only
 // - Deny: Tools matching these patterns are always rejected, even with --yolo
 //
 // Patterns support glob-style matching (e.g., "shell", "read_*", "mcp:github:*")
-// The evaluation order is: Deny (checked first), then Allow, then Ask (default)
+// The evaluation order is: Deny (checked first), then Allow, then Ask (explicit), then default
+// (read-only tools auto-approved, others ask)
 type PermissionsConfig struct {
 	// Allow lists tool name patterns that are auto-approved without user confirmation
 	Allow []string `json:"allow,omitempty"`
+	// Ask lists tool name patterns that always require user confirmation,
+	// even for tools that are normally auto-approved (e.g. read-only tools)
+	Ask []string `json:"ask,omitempty"`
 	// Deny lists tool name patterns that are always rejected
 	Deny []string `json:"deny,omitempty"`
 }

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -136,10 +136,13 @@ type MessageUsageRecord struct {
 }
 
 // PermissionsConfig defines session-level tool permission overrides
-// using pattern-based rules (Allow/Deny arrays).
+// using pattern-based rules (Allow/Ask/Deny arrays).
 type PermissionsConfig struct {
 	// Allow lists tool name patterns that are auto-approved without user confirmation.
 	Allow []string `json:"allow,omitempty"`
+	// Ask lists tool name patterns that always require user confirmation,
+	// even for tools that are normally auto-approved (e.g. read-only tools).
+	Ask []string `json:"ask,omitempty"`
 	// Deny lists tool name patterns that are always rejected.
 	Deny []string `json:"deny,omitempty"`
 }

--- a/pkg/tui/dialog/permissions.go
+++ b/pkg/tui/dialog/permissions.go
@@ -106,8 +106,17 @@ func (d *permissionsDialog) renderContent(contentWidth, maxHeight int) string {
 			lines = append(lines, "")
 		}
 
-		// If both are empty
-		if len(d.permissions.Allow) == 0 && len(d.permissions.Deny) == 0 {
+		// Ask section
+		if len(d.permissions.Ask) > 0 {
+			lines = append(lines, d.renderSectionHeader("Ask", "Always requires confirmation, even for read-only tools"), "")
+			for _, pattern := range d.permissions.Ask {
+				lines = append(lines, d.renderAskPattern(pattern))
+			}
+			lines = append(lines, "")
+		}
+
+		// If all are empty
+		if len(d.permissions.Allow) == 0 && len(d.permissions.Ask) == 0 && len(d.permissions.Deny) == 0 {
 			lines = append(lines, styles.MutedStyle.Render("No permission patterns configured."), "")
 		}
 	}
@@ -147,6 +156,12 @@ func (d *permissionsDialog) renderPattern(pattern string, isDeny bool) string {
 		style = lipgloss.NewStyle().Foreground(styles.Success)
 	}
 
+	return style.Render(icon) + "  " + lipgloss.NewStyle().Foreground(styles.Highlight).Render(pattern)
+}
+
+func (d *permissionsDialog) renderAskPattern(pattern string) string {
+	icon := "?"
+	style := lipgloss.NewStyle().Foreground(styles.TextSecondary)
 	return style.Render(icon) + "  " + lipgloss.NewStyle().Foreground(styles.Highlight).Render(pattern)
 }
 


### PR DESCRIPTION
Read-only tools (ReadOnlyHint: true) were always auto-approved with no way to override that via permissions config. This adds an explicit Ask field to PermissionsConfig that forces user confirmation even for read-only tools.

- Add Ask []string to PermissionsConfig in config/latest, config/v4, and session packages
- Add ForceAsk Decision constant to the permissions package, returned when a tool explicitly matches an Ask pattern (distinct from the default Ask fallback)
- Update Checker.CheckWithArgs to return ForceAsk for Ask pattern matches, and update IsEmpty/AskPatterns accordingly
- Handle ForceAsk in executeWithApproval by bypassing ReadOnlyHint and ToolsApproved auto-approval, jumping directly to user confirmation
- Extract confirmation dialog into askUserForConfirmation helper to avoid duplication between session, team, and default flows
- Update cagent-schema.json with the new ask property

Example usage:
  permissions: ask:
      - fetch        # always ask before fetching URLs (read-only)
      - mcp:github:get_*

Assisted-By: cagent