### PR TITLE
tui/tabbar: Prevent closing the last remaining tab

### DIFF
--- a/pkg/tui/components/tabbar/tabbar.go
+++ b/pkg/tui/components/tabbar/tabbar.go
@@ -219,7 +219,7 @@ func (t *TabBar) Update(msg tea.Msg) tea.Cmd {
 			return core.CmdHandler(messages.SwitchTabMsg{SessionID: t.tabs[prevIdx].SessionID})
 
 		case key.Matches(msg, t.keyMap.CloseTab):
-			if len(t.tabs) == 0 {
+			if len(t.tabs) <= 1 {
 				return nil
 			}
 			return core.CmdHandler(messages.CloseTabMsg{SessionID: t.tabs[t.activeIdx].SessionID})


### PR DESCRIPTION
- partially addresses: https://github.com/docker/cagent/issues/1771

Ignore close tab key (Ctrl+W) when only one tab remains open.

This prevents accidentally clearing the current session and preserves muscle memory for users who expect Ctrl+W to delete the last word in single-tab scenarios.