### PR TITLE
Show message count in session browser dialog

### DIFF
--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -418,6 +418,17 @@ func (s *Session) IsSubSession() bool {
 	return s.ParentID != ""
 }
 
+// MessageCount returns the number of items that contain a message.
+func (s *Session) MessageCount() int {
+	n := 0
+	for _, item := range s.Messages {
+		if item.IsMessage() {
+			n++
+		}
+	}
+	return n
+}
+
 // New creates a new agent session
 func New(opts ...Opt) *Session {
 	sessionID := uuid.New().String()

--- a/pkg/session/store_test.go
+++ b/pkg/session/store_test.go
@@ -215,10 +215,12 @@ func TestGetSessionSummaries(t *testing.T) {
 	assert.Equal(t, "session-2", summaries[0].ID)
 	assert.Equal(t, "Second Session", summaries[0].Title)
 	assert.Equal(t, session2Time, summaries[0].CreatedAt)
+	assert.Equal(t, 1, summaries[0].NumMessages)
 
 	assert.Equal(t, "session-1", summaries[1].ID)
 	assert.Equal(t, "First Session", summaries[1].Title)
 	assert.Equal(t, session1Time, summaries[1].CreatedAt)
+	assert.Equal(t, 1, summaries[1].NumMessages)
 }
 
 func TestBranchSessionCopiesPrefix(t *testing.T) {

--- a/pkg/tui/dialog/session_browser.go
+++ b/pkg/tui/dialog/session_browser.go
@@ -317,13 +317,15 @@ func (d *sessionBrowserDialog) renderSession(sess session.Summary, selected bool
 		title = "Untitled"
 	}
 
+	suffix := fmt.Sprintf(" (%d) • %s", sess.NumMessages, d.timeAgo(sess.CreatedAt))
+
 	starWidth := 3
-	maxTitleLen := maxWidth - 25 - starWidth
+	maxTitleLen := max(1, maxWidth-len(suffix)-starWidth)
 	if len(title) > maxTitleLen {
 		title = title[:maxTitleLen-1] + "…"
 	}
 
-	return styles.StarIndicator(sess.Starred) + titleStyle.Render(title) + timeStyle.Render(" • "+d.timeAgo(sess.CreatedAt))
+	return styles.StarIndicator(sess.Starred) + titleStyle.Render(title) + timeStyle.Render(suffix)
 }
 
 func (d *sessionBrowserDialog) timeAgo(t time.Time) string {


### PR DESCRIPTION
Add NumMessages field to session.Summary and populate it from both SQLite (via LEFT JOIN on session_items) and InMemory stores. Display the count in the session browser as '(N)' next to each session title.

Assisted-By: cagent