### PR TITLE
Fix help for docker-agent standalone binary exec

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -110,12 +110,19 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddGroup(&cobra.Group{ID: "core", Title: "Core Commands:"})
 	cmd.AddGroup(&cobra.Group{ID: "advanced", Title: "Advanced Commands:"})
 
-	if isDockerAgent() {
+	if isDockerAgent() && !plugin.RunningStandalone() {
 		cmd.Use = "agent"
 		cmd.Short = "create or run AI agents"
 		cmd.Long = "create or run AI agents"
 		cmd.Example = `  docker agent run ./agent.yaml
   docker agent run agentcatalog/pirate`
+	}
+	if isDockerAgent() && plugin.RunningStandalone() {
+		cmd.Use = "docker-agent"
+		cmd.Short = "create or run AI agents"
+		cmd.Long = "create or run AI agents"
+		cmd.Example = `  docker-agent run ./agent.yaml
+  docker-agent run agentcatalog/pirate`
 	}
 
 	return cmd


### PR DESCRIPTION
```
🐠 ./bin/docker-agent --help
create or run AI agents

Usage:
  docker-agent [flags]
  docker-agent [command]

Examples:
  docker-agent run ./agent.yaml
  docker-agent run agentcatalog/pirate
```

(was previously displaying help for `docker agent` )