### PR TITLE
Fix docker-agent version for cli plugin & standalone exec

### DIFF
--- a/cmd/root/version.go
+++ b/cmd/root/version.go
@@ -1,6 +1,7 @@
 package root
 
 import (
+	"github.com/docker/cli/cli-plugins/plugin"
 	"github.com/spf13/cobra"
 
 	"github.com/docker/cagent/pkg/cli"
@@ -22,6 +23,14 @@ func runVersionCommand(cmd *cobra.Command, args []string) {
 	telemetry.TrackCommand("version", args)
 
 	out := cli.NewPrinter(cmd.OutOrStdout())
-	out.Printf("cagent version %s\n", version.Version)
+
+	commandName := "docker-agent"
+	if cmd.Parent() != nil {
+		commandName = cmd.Parent().Name()
+	}
+	if !plugin.RunningStandalone() {
+		commandName = "docker " + commandName
+	}
+	out.Printf("%s version %s\n", commandName, version.Version)
 	out.Printf("Commit: %s\n", version.Commit)
 }


### PR DESCRIPTION
Another quick one to cleanup version output when executing docker-agent cli plugin (standalone or plugin mode)
```
🐠 ./bin/docker-agent version
docker-agent version dev
Commit: 19ac4a68d80104161bf411c9ca69c16fe929c5fa
🐠 docker agent version
docker agent version dev
Commit: 19ac4a68d80104161bf411c9ca69c16fe929c5fa
🐠 ./bin/cagent version
cagent version dev
Commit: 19ac4a68d80104161bf411c9ca69c16fe929c5fa
```