### PR TITLE
Better support copying emojis

### DIFF
--- a/pkg/tui/components/messages/clipboard.go
+++ b/pkg/tui/components/messages/clipboard.go
@@ -186,11 +186,11 @@ func (m *model) copySelectedMessageToClipboard() tea.Cmd {
 // copyTextToClipboard copies text to the system clipboard
 func copyTextToClipboard(text string) tea.Cmd {
 	return tea.Sequence(
-		tea.SetClipboard(text),
 		func() tea.Msg {
 			_ = clipboard.WriteAll(text)
 			return nil
 		},
+		tea.SetClipboard(text),
 		notification.SuccessCmd("Text copied to clipboard."),
 	)
 }


### PR DESCRIPTION
Instead of copying to the clipboard with `pbcopy` (and friends) then OSC52, we do it the reverse order.
That makes sure that terminals that support OSC52 get a chance to copy emojis and stuff to the clipboard.
Those that don't support will fallback on what was copied by `pbcopy`.