### PR TITLE
fix: use actual provider for alloy models in sidebar

### DIFF
--- a/pkg/runtime/fallback.go
+++ b/pkg/runtime/fallback.go
@@ -528,7 +528,9 @@ func (r *LocalRuntime) tryModelWithFallback(
 
 			// Stream created successfully, now handle it
 			slog.Debug("Processing stream", "agent", a.Name(), "model", modelEntry.provider.ID())
-			res, err := r.handleStream(ctx, stream, a, agentTools, sess, m, events)
+			// Extract provider name from the provider ID (e.g., "openai" from "openai/gpt-4o")
+			providerName, _, _ := strings.Cut(modelEntry.provider.ID(), "/")
+			res, err := r.handleStream(ctx, stream, a, agentTools, sess, m, events, providerName)
 			if err != nil {
 				lastErr = err
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1261,7 +1261,7 @@ func (r *LocalRuntime) Run(ctx context.Context, sess *session.Session) ([]sessio
 	return sess.GetAllMessages(), nil
 }
 
-func (r *LocalRuntime) handleStream(ctx context.Context, stream chat.MessageStream, a *agent.Agent, agentTools []tools.Tool, sess *session.Session, m *modelsdev.Model, events chan Event) (streamResult, error) {
+func (r *LocalRuntime) handleStream(ctx context.Context, stream chat.MessageStream, a *agent.Agent, agentTools []tools.Tool, sess *session.Session, m *modelsdev.Model, events chan Event, providerID string) (streamResult, error) {
 	defer stream.Close()
 
 	var fullContent strings.Builder
@@ -1332,12 +1332,11 @@ func (r *LocalRuntime) handleStream(ctx context.Context, stream chat.MessageStre
 		if actualModel == "" && response.Model != "" {
 			actualModel = response.Model
 			if !actualModelEventEmitted && actualModel != modelID {
-				// NOTE(krissetto):Prepend the provider from the configured modelID to maintain consistent format
-				// every other invocation in the code uses the provider/model format
-				formattedModel := actualModel
-				if idx := strings.Index(modelID, "/"); idx != -1 {
-					formattedModel = modelID[:idx+1] + actualModel
-				}
+				// Use the actual providerID (passed from caller) to construct the model ID.
+				// This is important for alloy models where different providers can be selected.
+				// The providerID comes from the actual provider used for this stream,
+				// not from parsing the configured model reference.
+				formattedModel := providerID + "/" + actualModel
 				slog.Debug("Detected actual model differs from configured model (streaming)", "configured", modelID, "actual", formattedModel)
 				events <- AgentInfo(a.Name(), formattedModel, a.Description(), a.WelcomeMessage())
 				actualModelEventEmitted = true


### PR DESCRIPTION
When using alloy models (multiple providers), the sidebar showed the wrong provider because formattedModel was constructed by prepending the provider from the configured modelID instead of the actual provider used.

Now passes the actual providerID to handleStream so AgentInfo events contain the correct provider/model format for sidebar display.

   Fixes #1776