### PR TITLE
fix: restore ctrl-1, ctrl-2... shortcuts for quick agent selection

### DIFF
--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -231,8 +231,13 @@ func (m *appModel) handleCycleAgent() (tea.Model, tea.Cmd) {
 		}
 	}
 	nextIndex := (currentIndex + 1) % len(availableAgents)
-	if nextIndex >= 0 && nextIndex < len(availableAgents) {
-		agentName := availableAgents[nextIndex].Name
+	return m.handleSwitchToAgentByIndex(nextIndex)
+}
+
+func (m *appModel) handleSwitchToAgentByIndex(index int) (tea.Model, tea.Cmd) {
+	availableAgents := m.sessionState.AvailableAgents()
+	if index >= 0 && index < len(availableAgents) {
+		agentName := availableAgents[index].Name
 		if agentName != m.sessionState.CurrentAgentName() {
 			return m, core.CmdHandler(messages.SwitchAgentMsg{AgentName: agentName})
 		}

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -1554,6 +1554,12 @@ func (m *appModel) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		updated, cmd := m.chatPage.Update(msg)
 		m.chatPage = updated.(chat.Page)
 		return m, cmd
+
+	default:
+		// Handle ctrl+1 through ctrl+9 for quick agent switching
+		if index := parseCtrlNumberKey(msg); index >= 0 {
+			return m.handleSwitchToAgentByIndex(index)
+		}
 	}
 
 	// Focus-based routing
@@ -1569,6 +1575,15 @@ func (m *appModel) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 
 	return m, nil
+}
+
+// parseCtrlNumberKey checks if msg is ctrl+1 through ctrl+9 and returns the index (0-8), or -1 if not matched
+func parseCtrlNumberKey(msg tea.KeyPressMsg) int {
+	s := msg.String()
+	if len(s) == 6 && s[:5] == "ctrl+" && s[5] >= '1' && s[5] <= '9' {
+		return int(s[5] - '1')
+	}
+	return -1
 }
 
 // switchFocus toggles between content and editor panels.


### PR DESCRIPTION
These shortcuts were accidentally dropped during the parallel session support refactoring in commit 0069cadf70eec01397a6f536447f9a4f2ef6b368.

This re-adds the `parseCtrlNumberKey` utility and intercepts `ctrl+1` through `ctrl+9` in the global key press handler, delegating to a new `handleSwitchToAgentByIndex` function.

Assisted-By: cagent