### PR TITLE
Implement remote skills discovery with disk cache and dedicated tools

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -38,7 +38,6 @@ type Agent struct {
 	tools                   []tools.Tool
 	commands                types.Commands
 	pendingWarnings         []string
-	skillsEnabled           bool
 	hooks                   *latest.HooksConfig
 	thinkingConfigured      bool // true if thinking_budget was explicitly set in config
 }
@@ -191,11 +190,6 @@ func (a *Agent) FallbackCooldown() time.Duration {
 // Commands returns the named commands configured for this agent.
 func (a *Agent) Commands() types.Commands {
 	return a.commands
-}
-
-// SkillsEnabled returns whether skills discovery is enabled for this agent.
-func (a *Agent) SkillsEnabled() bool {
-	return a.skillsEnabled
 }
 
 // Hooks returns the hooks configuration for this agent.

--- a/pkg/agent/opts.go
+++ b/pkg/agent/opts.go
@@ -147,12 +147,6 @@ func WithLoadTimeWarnings(warnings []string) Opt {
 	}
 }
 
-func WithSkillsEnabled(enabled bool) Opt {
-	return func(a *Agent) {
-		a.skillsEnabled = enabled
-	}
-}
-
 func WithHooks(hooks *latest.HooksConfig) Opt {
 	return func(a *Agent) {
 		a.hooks = hooks

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/cagent/pkg/session"
 	"github.com/docker/cagent/pkg/sessiontitle"
 	"github.com/docker/cagent/pkg/tools"
+	"github.com/docker/cagent/pkg/tools/builtin"
 	mcptools "github.com/docker/cagent/pkg/tools/mcp"
 )
 
@@ -47,7 +48,10 @@ func (m *mockRuntime) SessionStore() session.Store { return nil }
 func (m *mockRuntime) Summarize(ctx context.Context, sess *session.Session, additionalPrompt string, events chan runtime.Event) {
 }
 func (m *mockRuntime) PermissionsInfo() *runtime.PermissionsInfo { return nil }
-func (m *mockRuntime) CurrentAgentSkillsEnabled() bool           { return false }
+func (m *mockRuntime) CurrentAgentSkillsToolset() *builtin.SkillsToolset {
+	return nil
+}
+
 func (m *mockRuntime) CurrentMCPPrompts(context.Context) map[string]mcptools.PromptInfo {
 	return make(map[string]mcptools.PromptInfo)
 }

--- a/pkg/config/latest/skills_config_test.go
+++ b/pkg/config/latest/skills_config_test.go
@@ -1,0 +1,270 @@
+package latest
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/goccy/go-yaml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSkillsConfig_UnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected SkillsConfig
+	}{
+		{
+			name:     "boolean true",
+			input:    "true",
+			expected: SkillsConfig{Sources: []string{"local"}},
+		},
+		{
+			name:     "boolean false",
+			input:    "false",
+			expected: SkillsConfig{Sources: nil},
+		},
+		{
+			name:     "list with local only",
+			input:    "[local]",
+			expected: SkillsConfig{Sources: []string{"local"}},
+		},
+		{
+			name:     "list with remote URL",
+			input:    "[\"http://example.com\"]",
+			expected: SkillsConfig{Sources: []string{"http://example.com"}},
+		},
+		{
+			name:  "list with local and remote",
+			input: "[local, \"https://skills.example.com\"]",
+			expected: SkillsConfig{Sources: []string{
+				"local",
+				"https://skills.example.com",
+			}},
+		},
+		{
+			name: "multiline list",
+			input: `- local
+- https://example.com
+- http://internal.corp`,
+			expected: SkillsConfig{Sources: []string{
+				"local",
+				"https://example.com",
+				"http://internal.corp",
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg SkillsConfig
+			err := yaml.Unmarshal([]byte(tt.input), &cfg)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, cfg)
+		})
+	}
+}
+
+func TestSkillsConfig_MarshalYAML(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    SkillsConfig
+		expected string
+	}{
+		{
+			name:     "disabled",
+			input:    SkillsConfig{},
+			expected: "false\n",
+		},
+		{
+			name:     "local only marshals as true",
+			input:    SkillsConfig{Sources: []string{"local"}},
+			expected: "true\n",
+		},
+		{
+			name:     "list with remote",
+			input:    SkillsConfig{Sources: []string{"local", "https://example.com"}},
+			expected: "- local\n- https://example.com\n",
+		},
+		{
+			name:     "remote only",
+			input:    SkillsConfig{Sources: []string{"https://example.com"}},
+			expected: "- https://example.com\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := yaml.Marshal(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, string(out))
+		})
+	}
+}
+
+func TestSkillsConfig_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected SkillsConfig
+	}{
+		{
+			name:     "boolean true",
+			input:    "true",
+			expected: SkillsConfig{Sources: []string{"local"}},
+		},
+		{
+			name:     "boolean false",
+			input:    "false",
+			expected: SkillsConfig{Sources: nil},
+		},
+		{
+			name:     "list with local",
+			input:    `["local"]`,
+			expected: SkillsConfig{Sources: []string{"local"}},
+		},
+		{
+			name:     "list with remote URLs",
+			input:    `["local", "https://skills.example.com"]`,
+			expected: SkillsConfig{Sources: []string{"local", "https://skills.example.com"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg SkillsConfig
+			err := json.Unmarshal([]byte(tt.input), &cfg)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, cfg)
+		})
+	}
+}
+
+func TestSkillsConfig_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    SkillsConfig
+		expected string
+	}{
+		{
+			name:     "disabled",
+			input:    SkillsConfig{},
+			expected: "false",
+		},
+		{
+			name:     "local only as true",
+			input:    SkillsConfig{Sources: []string{"local"}},
+			expected: "true",
+		},
+		{
+			name:     "list with remote",
+			input:    SkillsConfig{Sources: []string{"local", "https://example.com"}},
+			expected: `["local","https://example.com"]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := json.Marshal(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, string(out))
+		})
+	}
+}
+
+func TestSkillsConfig_Enabled(t *testing.T) {
+	assert.False(t, SkillsConfig{}.Enabled())
+	assert.False(t, SkillsConfig{Sources: nil}.Enabled())
+	assert.False(t, SkillsConfig{Sources: []string{}}.Enabled())
+	assert.True(t, SkillsConfig{Sources: []string{"local"}}.Enabled())
+	assert.True(t, SkillsConfig{Sources: []string{"https://example.com"}}.Enabled())
+}
+
+func TestSkillsConfig_HasLocal(t *testing.T) {
+	assert.False(t, SkillsConfig{}.HasLocal())
+	assert.False(t, SkillsConfig{Sources: []string{"https://example.com"}}.HasLocal())
+	assert.True(t, SkillsConfig{Sources: []string{"local"}}.HasLocal())
+	assert.True(t, SkillsConfig{Sources: []string{"local", "https://example.com"}}.HasLocal())
+}
+
+func TestSkillsConfig_RemoteURLs(t *testing.T) {
+	assert.Empty(t, SkillsConfig{}.RemoteURLs())
+	assert.Empty(t, SkillsConfig{Sources: []string{"local"}}.RemoteURLs())
+	assert.Equal(t,
+		[]string{"https://example.com", "http://internal.corp"},
+		SkillsConfig{Sources: []string{"local", "https://example.com", "http://internal.corp"}}.RemoteURLs(),
+	)
+}
+
+func TestSkillsConfig_JSONRoundTrip(t *testing.T) {
+	// This tests the upgrade path from v4 (bool) to v5 (SkillsConfig) via CloneThroughJSON
+	t.Run("bool true round trips through JSON", func(t *testing.T) {
+		jsonData := []byte("true")
+		var cfg SkillsConfig
+		require.NoError(t, json.Unmarshal(jsonData, &cfg))
+		assert.True(t, cfg.Enabled())
+		assert.True(t, cfg.HasLocal())
+		assert.Equal(t, []string{"local"}, cfg.Sources)
+
+		out, err := json.Marshal(cfg)
+		require.NoError(t, err)
+		assert.Equal(t, "true", string(out))
+	})
+
+	t.Run("bool false round trips through JSON", func(t *testing.T) {
+		jsonData := []byte("false")
+		var cfg SkillsConfig
+		require.NoError(t, json.Unmarshal(jsonData, &cfg))
+		assert.False(t, cfg.Enabled())
+		assert.Nil(t, cfg.Sources)
+
+		out, err := json.Marshal(cfg)
+		require.NoError(t, err)
+		assert.Equal(t, "false", string(out))
+	})
+
+	t.Run("list round trips through JSON", func(t *testing.T) {
+		jsonData := []byte(`["local","https://example.com"]`)
+		var cfg SkillsConfig
+		require.NoError(t, json.Unmarshal(jsonData, &cfg))
+		assert.True(t, cfg.Enabled())
+		assert.Equal(t, []string{"local", "https://example.com"}, cfg.Sources)
+
+		out, err := json.Marshal(cfg)
+		require.NoError(t, err)
+		assert.Equal(t, `["local","https://example.com"]`, string(out))
+	})
+}
+
+func TestSkillsConfig_InAgentConfig(t *testing.T) {
+	yamlInput := `
+model: openai/gpt-4
+skills:
+  - local
+  - https://skills.example.com
+toolsets:
+  - type: filesystem
+`
+	var agent AgentConfig
+	err := yaml.Unmarshal([]byte(yamlInput), &agent)
+	require.NoError(t, err)
+	assert.True(t, agent.Skills.Enabled())
+	assert.True(t, agent.Skills.HasLocal())
+	assert.Equal(t, []string{"https://skills.example.com"}, agent.Skills.RemoteURLs())
+}
+
+func TestSkillsConfig_InAgentConfigBool(t *testing.T) {
+	yamlInput := `
+model: openai/gpt-4
+skills: true
+toolsets:
+  - type: filesystem
+`
+	var agent AgentConfig
+	err := yaml.Unmarshal([]byte(yamlInput), &agent)
+	require.NoError(t, err)
+	assert.True(t, agent.Skills.Enabled())
+	assert.True(t, agent.Skills.HasLocal())
+	assert.Empty(t, agent.Skills.RemoteURLs())
+}

--- a/pkg/config/testdata/skills_with_remote.yaml
+++ b/pkg/config/testdata/skills_with_remote.yaml
@@ -1,0 +1,10 @@
+version: "5"
+
+agents:
+  root:
+    model: openai/gpt-4o
+    skills:
+      - local
+      - https://skills.example.com
+    toolsets:
+      - type: filesystem

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -49,14 +49,6 @@ func TestValidationErrors(t *testing.T) {
 			path: "invalid_post_edit_v2.yaml",
 		},
 		{
-			name: "skills enabled without filesystem toolset",
-			path: "skills_missing_filesystem.yaml",
-		},
-		{
-			name: "skills enabled without read_file tool",
-			path: "skills_missing_read_file.yaml",
-		},
-		{
 			name: "lsp toolset missing command",
 			path: "invalid_lsp_missing_command.yaml",
 		},
@@ -108,6 +100,14 @@ func TestValidSkillsConfiguration(t *testing.T) {
 			name: "skills disabled",
 			path: "skills_disabled.yaml",
 		},
+		{
+			name: "skills with remote sources",
+			path: "skills_with_remote.yaml",
+		},
+		{
+			name: "skills enabled without filesystem toolset is fine",
+			path: "skills_missing_filesystem.yaml",
+		},
 	}
 
 	for _, tt := range tests {
@@ -119,4 +119,21 @@ func TestValidSkillsConfiguration(t *testing.T) {
 			require.NotNil(t, cfg)
 		})
 	}
+}
+
+func TestInvalidSkillsSources(t *testing.T) {
+	t.Parallel()
+
+	cfgStr := `version: "5"
+agents:
+  root:
+    model: openai/gpt-4o
+    skills:
+      - invalid_source
+    toolsets:
+      - type: filesystem
+`
+	_, err := Load(t.Context(), NewBytesSource("test", []byte(cfgStr)))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown skills source")
 }

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -5,6 +5,22 @@ import (
 	"path/filepath"
 )
 
+// GetCacheDir returns the user's cache directory for cagent.
+//
+// On Linux this follows XDG: $XDG_CACHE_HOME/cagent (default ~/.cache/cagent).
+// On macOS this uses ~/Library/Caches/cagent.
+// On Windows this uses %LocalAppData%/cagent.
+//
+// If the cache directory cannot be determined, it falls back to a directory
+// under the system temporary directory.
+func GetCacheDir() string {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return filepath.Clean(filepath.Join(os.TempDir(), ".cagent-cache"))
+	}
+	return filepath.Clean(filepath.Join(cacheDir, "cagent"))
+}
+
 // GetConfigDir returns the user's config directory for cagent.
 //
 // If the home directory cannot be determined, it falls back to a directory

--- a/pkg/runtime/commands_test.go
+++ b/pkg/runtime/commands_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/cagent/pkg/session"
 	"github.com/docker/cagent/pkg/sessiontitle"
 	"github.com/docker/cagent/pkg/tools"
+	"github.com/docker/cagent/pkg/tools/builtin"
 	mcptools "github.com/docker/cagent/pkg/tools/mcp"
 )
 
@@ -51,7 +52,10 @@ func (m *mockRuntime) SessionStore() session.Store { return nil }
 func (m *mockRuntime) Summarize(context.Context, *session.Session, string, chan Event) {
 }
 func (m *mockRuntime) PermissionsInfo() *PermissionsInfo { return nil }
-func (m *mockRuntime) CurrentAgentSkillsEnabled() bool   { return false }
+func (m *mockRuntime) CurrentAgentSkillsToolset() *builtin.SkillsToolset {
+	return nil
+}
+
 func (m *mockRuntime) CurrentMCPPrompts(context.Context) map[string]mcptools.PromptInfo {
 	return make(map[string]mcptools.PromptInfo)
 }

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/cagent/pkg/sessiontitle"
 	"github.com/docker/cagent/pkg/team"
 	"github.com/docker/cagent/pkg/tools"
+	"github.com/docker/cagent/pkg/tools/builtin"
 	"github.com/docker/cagent/pkg/tools/mcp"
 )
 
@@ -433,11 +434,9 @@ func (r *RemoteRuntime) PermissionsInfo() *PermissionsInfo {
 func (r *RemoteRuntime) ResetStartupInfo() {
 }
 
-// CurrentAgentSkillsEnabled returns whether skills are enabled for the current agent.
-// It reads the agent config from the remote API to determine the skills setting.
-func (r *RemoteRuntime) CurrentAgentSkillsEnabled() bool {
-	cfg := r.readCurrentAgentConfig(context.Background())
-	return cfg.Skills != nil && *cfg.Skills
+// CurrentAgentSkillsToolset returns nil for remote runtimes since skills are managed server-side.
+func (r *RemoteRuntime) CurrentAgentSkillsToolset() *builtin.SkillsToolset {
+	return nil
 }
 
 // UpdateSessionTitle updates the title of the current session on the remote server.

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -139,8 +139,8 @@ type Runtime interface {
 	// Returns nil if no permissions are configured.
 	PermissionsInfo() *PermissionsInfo
 
-	// CurrentAgentSkillsEnabled returns whether skills are enabled for the current agent.
-	CurrentAgentSkillsEnabled() bool
+	// CurrentAgentSkillsToolset returns the skills toolset for the current agent, or nil if skills are not enabled.
+	CurrentAgentSkillsToolset() *builtin.SkillsToolset
 
 	// CurrentMCPPrompts returns MCP prompts available from the current agent's toolsets.
 	// Returns an empty map if no MCP prompts are available.
@@ -534,10 +534,18 @@ func (r *LocalRuntime) CurrentAgent() *agent.Agent {
 	return current
 }
 
-// CurrentAgentSkillsEnabled returns whether skills are enabled for the current agent.
-func (r *LocalRuntime) CurrentAgentSkillsEnabled() bool {
+// CurrentAgentSkillsToolset returns the skills toolset for the current agent, or nil if not enabled.
+func (r *LocalRuntime) CurrentAgentSkillsToolset() *builtin.SkillsToolset {
 	a := r.CurrentAgent()
-	return a != nil && a.SkillsEnabled()
+	if a == nil {
+		return nil
+	}
+	for _, ts := range a.ToolSets() {
+		if st, ok := tools.As[*builtin.SkillsToolset](ts); ok {
+			return st
+		}
+	}
+	return nil
 }
 
 // ExecuteMCPPrompt executes an MCP prompt with provided arguments and returns the content.

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/docker/cagent/pkg/agent"
 	"github.com/docker/cagent/pkg/chat"
-	"github.com/docker/cagent/pkg/skills"
 	"github.com/docker/cagent/pkg/tools"
 )
 
@@ -600,16 +599,6 @@ func buildContextSpecificSystemMessages(a *agent.Agent, s *Session) []chat.Messa
 					Content: additionalPrompt,
 				})
 			}
-		}
-	}
-
-	// Add skills section if enabled
-	if a.SkillsEnabled() {
-		if loadedSkills := skills.Load(); len(loadedSkills) > 0 {
-			messages = append(messages, chat.Message{
-				Role:    chat.MessageRoleSystem,
-				Content: skills.BuildSkillsPrompt(loadedSkills),
-			})
 		}
 	}
 

--- a/pkg/skills/cache.go
+++ b/pkg/skills/cache.go
@@ -1,0 +1,155 @@
+package skills
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type diskCache struct {
+	baseDir    string
+	httpClient *http.Client
+}
+
+type cacheMetadata struct {
+	URL       string    `json:"url"`
+	CachedAt  time.Time `json:"cached_at"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+func newDiskCache(baseDir string) *diskCache {
+	return &diskCache{
+		baseDir: baseDir,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// cacheDir returns the on-disk directory for a given base URL and skill name.
+// Structure: {baseDir}/{urlHash}/{skillName}/
+func (c *diskCache) cacheDir(baseURL, skillName string) string {
+	h := sha256.Sum256([]byte(baseURL))
+	urlHash := hex.EncodeToString(h[:8])
+	return filepath.Join(c.baseDir, urlHash, skillName)
+}
+
+// Get returns the cached content for a file if it exists and is not expired.
+func (c *diskCache) Get(baseURL, skillName, filePath string) (string, bool) {
+	dir := c.cacheDir(baseURL, skillName)
+	contentPath := filepath.Join(dir, filePath)
+	metaPath := contentPath + ".meta"
+
+	meta, err := c.readMetadata(metaPath)
+	if err != nil {
+		return "", false
+	}
+
+	if time.Now().After(meta.ExpiresAt) {
+		return "", false
+	}
+
+	data, err := os.ReadFile(contentPath)
+	if err != nil {
+		return "", false
+	}
+
+	return string(data), true
+}
+
+// FetchAndStore downloads a file from the given URL and stores it in the cache.
+// It respects Cache-Control headers to determine expiry.
+func (c *diskCache) FetchAndStore(baseURL, skillName, filePath, fileURL string) (string, error) {
+	slog.Debug("Fetching remote skill file", "url", fileURL)
+
+	resp, err := c.httpClient.Get(fileURL)
+	if err != nil {
+		return "", fmt.Errorf("fetching %s: %w", fileURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("fetching %s: HTTP %d", fileURL, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1MB per file
+	if err != nil {
+		return "", fmt.Errorf("reading %s: %w", fileURL, err)
+	}
+
+	expiresAt := parseCacheExpiry(resp.Header.Get("Cache-Control"))
+
+	dir := c.cacheDir(baseURL, skillName)
+	contentPath := filepath.Join(dir, filePath)
+	metaPath := contentPath + ".meta"
+
+	if err := os.MkdirAll(filepath.Dir(contentPath), 0o755); err != nil {
+		return "", fmt.Errorf("creating cache directory: %w", err)
+	}
+
+	if err := os.WriteFile(contentPath, body, 0o644); err != nil {
+		return "", fmt.Errorf("writing cache file: %w", err)
+	}
+
+	meta := cacheMetadata{
+		URL:       fileURL,
+		CachedAt:  time.Now(),
+		ExpiresAt: expiresAt,
+	}
+	metaJSON, _ := json.Marshal(meta)
+	if err := os.WriteFile(metaPath, metaJSON, 0o644); err != nil {
+		// Non-fatal: the content is cached, just the metadata isn't
+		slog.Debug("Failed to write cache metadata", "path", metaPath, "error", err)
+	}
+
+	return string(body), nil
+}
+
+func (c *diskCache) readMetadata(metaPath string) (cacheMetadata, error) {
+	data, err := os.ReadFile(metaPath)
+	if err != nil {
+		return cacheMetadata{}, err
+	}
+	var meta cacheMetadata
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return cacheMetadata{}, err
+	}
+	return meta, nil
+}
+
+const defaultCacheTTL = 1 * time.Hour
+
+// parseCacheExpiry extracts the expiry time from a Cache-Control header value.
+// Falls back to defaultCacheTTL if the header is missing or unparseable.
+func parseCacheExpiry(cacheControl string) time.Time {
+	if cacheControl == "" {
+		return time.Now().Add(defaultCacheTTL)
+	}
+
+	for _, directive := range strings.Split(cacheControl, ",") {
+		directive = strings.TrimSpace(directive)
+
+		if strings.EqualFold(directive, "no-store") || strings.EqualFold(directive, "no-cache") {
+			// Still cache, but with zero TTL so it's refetched next time
+			return time.Now()
+		}
+
+		if strings.HasPrefix(strings.ToLower(directive), "max-age=") {
+			ageStr := directive[len("max-age="):]
+			if seconds, err := strconv.ParseInt(ageStr, 10, 64); err == nil && seconds >= 0 {
+				return time.Now().Add(time.Duration(seconds) * time.Second)
+			}
+		}
+	}
+
+	return time.Now().Add(defaultCacheTTL)
+}

--- a/pkg/skills/cache_test.go
+++ b/pkg/skills/cache_test.go
@@ -1,0 +1,158 @@
+package skills
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiskCache_FetchAndStore(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Cache-Control", "max-age=3600")
+		fmt.Fprint(w, "file content")
+	}))
+	defer srv.Close()
+
+	cache := newDiskCache(t.TempDir())
+
+	content, err := cache.FetchAndStore("https://example.com", "my-skill", "SKILL.md", srv.URL+"/SKILL.md")
+	require.NoError(t, err)
+	assert.Equal(t, "file content", content)
+
+	// Verify it was written to disk
+	filePath := filepath.Join(cache.cacheDir("https://example.com", "my-skill"), "SKILL.md")
+	data, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+	assert.Equal(t, "file content", string(data))
+
+	// Verify metadata was written
+	metaPath := filePath + ".meta"
+	_, err = os.Stat(metaPath)
+	require.NoError(t, err)
+}
+
+func TestDiskCache_Get_NotCached(t *testing.T) {
+	cache := newDiskCache(t.TempDir())
+
+	_, ok := cache.Get("https://example.com", "nonexistent", "SKILL.md")
+	assert.False(t, ok)
+}
+
+func TestDiskCache_Get_Cached(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Cache-Control", "max-age=3600")
+		fmt.Fprint(w, "cached content")
+	}))
+	defer srv.Close()
+
+	cache := newDiskCache(t.TempDir())
+
+	_, err := cache.FetchAndStore("https://example.com", "skill", "SKILL.md", srv.URL+"/SKILL.md")
+	require.NoError(t, err)
+
+	content, ok := cache.Get("https://example.com", "skill", "SKILL.md")
+	assert.True(t, ok)
+	assert.Equal(t, "cached content", content)
+}
+
+func TestDiskCache_Get_Expired(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Cache-Control", "max-age=0")
+		fmt.Fprint(w, "expired content")
+	}))
+	defer srv.Close()
+
+	cache := newDiskCache(t.TempDir())
+
+	_, err := cache.FetchAndStore("https://example.com", "skill", "SKILL.md", srv.URL+"/SKILL.md")
+	require.NoError(t, err)
+
+	// The max-age=0 should make it immediately expired
+	_, ok := cache.Get("https://example.com", "skill", "SKILL.md")
+	assert.False(t, ok)
+}
+
+func TestDiskCache_NestedFiles(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, "nested file content")
+	}))
+	defer srv.Close()
+
+	cache := newDiskCache(t.TempDir())
+
+	content, err := cache.FetchAndStore("https://example.com", "my-skill", "references/FORMS.md", srv.URL+"/file")
+	require.NoError(t, err)
+	assert.Equal(t, "nested file content", content)
+
+	// Verify the nested directory was created
+	filePath := filepath.Join(cache.cacheDir("https://example.com", "my-skill"), "references", "FORMS.md")
+	data, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+	assert.Equal(t, "nested file content", string(data))
+}
+
+func TestDiskCache_DifferentURLsGetDifferentDirs(t *testing.T) {
+	cache := newDiskCache(t.TempDir())
+
+	dir1 := cache.cacheDir("https://example.com", "skill")
+	dir2 := cache.cacheDir("https://other.com", "skill")
+
+	assert.NotEqual(t, dir1, dir2)
+}
+
+func TestParseCacheExpiry(t *testing.T) {
+	now := time.Now()
+
+	t.Run("empty header uses default", func(t *testing.T) {
+		expiry := parseCacheExpiry("")
+		assert.WithinDuration(t, now.Add(1*time.Hour), expiry, 2*time.Second)
+	})
+
+	t.Run("max-age=3600", func(t *testing.T) {
+		expiry := parseCacheExpiry("max-age=3600")
+		assert.WithinDuration(t, now.Add(3600*time.Second), expiry, 2*time.Second)
+	})
+
+	t.Run("max-age=0", func(t *testing.T) {
+		expiry := parseCacheExpiry("max-age=0")
+		assert.WithinDuration(t, now, expiry, 2*time.Second)
+	})
+
+	t.Run("no-store", func(t *testing.T) {
+		expiry := parseCacheExpiry("no-store")
+		assert.WithinDuration(t, now, expiry, 2*time.Second)
+	})
+
+	t.Run("no-cache", func(t *testing.T) {
+		expiry := parseCacheExpiry("no-cache")
+		assert.WithinDuration(t, now, expiry, 2*time.Second)
+	})
+
+	t.Run("multiple directives with max-age", func(t *testing.T) {
+		expiry := parseCacheExpiry("public, max-age=7200")
+		assert.WithinDuration(t, now.Add(7200*time.Second), expiry, 2*time.Second)
+	})
+
+	t.Run("unknown directives use default", func(t *testing.T) {
+		expiry := parseCacheExpiry("public")
+		assert.WithinDuration(t, now.Add(1*time.Hour), expiry, 2*time.Second)
+	})
+}
+
+func TestDiskCache_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.NotFoundHandler())
+	defer srv.Close()
+
+	cache := newDiskCache(t.TempDir())
+
+	_, err := cache.FetchAndStore("https://example.com", "skill", "SKILL.md", srv.URL+"/notfound")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP 404")
+}

--- a/pkg/skills/remote.go
+++ b/pkg/skills/remote.go
@@ -1,0 +1,140 @@
+package skills
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/docker/cagent/pkg/paths"
+)
+
+// remoteIndex represents the index.json served at /.well-known/skills/index.json
+type remoteIndex struct {
+	Skills []remoteSkillEntry `json:"skills"`
+}
+
+type remoteSkillEntry struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Files       []string `json:"files"`
+}
+
+var defaultHTTPClient = &http.Client{
+	Timeout: 30 * time.Second,
+}
+
+func defaultCache() *diskCache {
+	return newDiskCache(filepath.Join(paths.GetCacheDir(), "skills"))
+}
+
+// loadRemoteSkills fetches skills from a remote URL per the well-known skills discovery spec.
+// It fetches /.well-known/skills/index.json, then prefetches all listed files
+// into a disk cache so the agent can read them without network requests during
+// task execution.
+func loadRemoteSkills(baseURL string) []Skill {
+	return loadRemoteSkillsWithCache(baseURL, defaultCache())
+}
+
+func loadRemoteSkillsWithCache(baseURL string, cache *diskCache) []Skill {
+	baseURL = strings.TrimRight(baseURL, "/")
+	indexURL := baseURL + "/.well-known/skills/index.json"
+
+	slog.Debug("Fetching remote skills index", "url", indexURL)
+
+	resp, err := defaultHTTPClient.Get(indexURL)
+	if err != nil {
+		slog.Warn("Failed to fetch remote skills index", "url", indexURL, "error", err)
+		return nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		slog.Warn("Remote skills index returned non-OK status", "url", indexURL, "status", resp.StatusCode)
+		return nil
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1MB limit
+	if err != nil {
+		slog.Warn("Failed to read remote skills index", "url", indexURL, "error", err)
+		return nil
+	}
+
+	var index remoteIndex
+	if err := json.Unmarshal(body, &index); err != nil {
+		slog.Warn("Failed to parse remote skills index", "url", indexURL, "error", err)
+		return nil
+	}
+
+	var skills []Skill
+	for _, entry := range index.Skills {
+		if entry.Name == "" || entry.Description == "" {
+			continue
+		}
+
+		cacheDir := cache.cacheDir(baseURL, entry.Name)
+		prefetchFiles(cache, baseURL, entry.Name, entry.Files)
+
+		skill := Skill{
+			Name:        entry.Name,
+			Description: entry.Description,
+			FilePath:    filepath.Join(cacheDir, "SKILL.md"),
+			BaseDir:     cacheDir,
+			Files:       entry.Files,
+		}
+		skills = append(skills, skill)
+	}
+
+	slog.Debug("Loaded remote skills", "url", baseURL, "count", len(skills))
+	return skills
+}
+
+// prefetchFiles downloads all files listed in the index for a skill,
+// storing them in the disk cache. Files already in cache (and not expired)
+// are skipped.
+func prefetchFiles(cache *diskCache, baseURL, skillName string, files []string) {
+	for _, file := range files {
+		if !isValidFilePath(file) {
+			slog.Debug("Skipping invalid file path in skill", "skill", skillName, "file", file)
+			continue
+		}
+
+		if _, ok := cache.Get(baseURL, skillName, file); ok {
+			continue
+		}
+
+		fileURL := fmt.Sprintf("%s/.well-known/skills/%s/%s", baseURL, skillName, file)
+		if _, err := cache.FetchAndStore(baseURL, skillName, file, fileURL); err != nil {
+			slog.Warn("Failed to prefetch skill file", "skill", skillName, "file", file, "error", err)
+		}
+	}
+}
+
+// isValidFilePath checks a relative file path from the index for safety.
+// Rejects absolute paths, parent traversals, and invalid characters.
+func isValidFilePath(path string) bool {
+	if path == "" {
+		return false
+	}
+	if strings.HasPrefix(path, "/") {
+		return false
+	}
+	if strings.Contains(path, "..") {
+		return false
+	}
+	// Reject backslashes, query strings, fragments, brackets
+	for _, c := range path {
+		switch c {
+		case '\\', '?', '#', '[', ']':
+			return false
+		}
+		if c < 0x20 || c > 0x7E {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/skills/remote_test.go
+++ b/pkg/skills/remote_test.go
@@ -1,0 +1,314 @@
+package skills
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadRemoteSkills(t *testing.T) {
+	t.Run("valid index with skills and prefetch", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/.well-known/skills/index.json":
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, `{
+					"skills": [
+						{
+							"name": "docker-build",
+							"description": "Build Docker images",
+							"files": ["SKILL.md", "references/COMMANDS.md"]
+						},
+						{
+							"name": "k8s-deploy",
+							"description": "Deploy to Kubernetes",
+							"files": ["SKILL.md"]
+						}
+					]
+				}`)
+			case "/.well-known/skills/docker-build/SKILL.md":
+				fmt.Fprint(w, "# Docker Build")
+			case "/.well-known/skills/docker-build/references/COMMANDS.md":
+				fmt.Fprint(w, "# Docker Commands Reference")
+			case "/.well-known/skills/k8s-deploy/SKILL.md":
+				fmt.Fprint(w, "# K8s Deploy")
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer srv.Close()
+
+		cacheDir := t.TempDir()
+		cache := newDiskCache(cacheDir)
+		skills := loadRemoteSkillsWithCache(srv.URL, cache)
+
+		require.Len(t, skills, 2)
+
+		assert.Equal(t, "docker-build", skills[0].Name)
+		assert.Equal(t, "Build Docker images", skills[0].Description)
+		assert.Equal(t, []string{"SKILL.md", "references/COMMANDS.md"}, skills[0].Files)
+
+		// Verify SKILL.md was prefetched to disk
+		skillMD, err := os.ReadFile(skills[0].FilePath)
+		require.NoError(t, err)
+		assert.Equal(t, "# Docker Build", string(skillMD))
+
+		// Verify reference file was prefetched
+		refFile := filepath.Join(skills[0].BaseDir, "references", "COMMANDS.md")
+		refContent, err := os.ReadFile(refFile)
+		require.NoError(t, err)
+		assert.Equal(t, "# Docker Commands Reference", string(refContent))
+
+		assert.Equal(t, "k8s-deploy", skills[1].Name)
+	})
+
+	t.Run("trailing slash on base URL", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/.well-known/skills/index.json":
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, `{"skills": [{"name": "test", "description": "Test skill", "files": ["SKILL.md"]}]}`)
+			case "/.well-known/skills/test/SKILL.md":
+				fmt.Fprint(w, "# Test")
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer srv.Close()
+
+		cache := newDiskCache(t.TempDir())
+		skills := loadRemoteSkillsWithCache(srv.URL+"/", cache)
+		require.Len(t, skills, 1)
+
+		content, err := os.ReadFile(skills[0].FilePath)
+		require.NoError(t, err)
+		assert.Equal(t, "# Test", string(content))
+	})
+
+	t.Run("empty skills array", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"skills": []}`)
+		}))
+		defer srv.Close()
+
+		skills := loadRemoteSkillsWithCache(srv.URL, newDiskCache(t.TempDir()))
+		assert.Empty(t, skills)
+	})
+
+	t.Run("skips entries with missing name", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"skills": [{"name": "", "description": "No name", "files": ["SKILL.md"]}]}`)
+		}))
+		defer srv.Close()
+
+		skills := loadRemoteSkillsWithCache(srv.URL, newDiskCache(t.TempDir()))
+		assert.Empty(t, skills)
+	})
+
+	t.Run("skips entries with missing description", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"skills": [{"name": "test", "description": "", "files": ["SKILL.md"]}]}`)
+		}))
+		defer srv.Close()
+
+		skills := loadRemoteSkillsWithCache(srv.URL, newDiskCache(t.TempDir()))
+		assert.Empty(t, skills)
+	})
+
+	t.Run("server returns 404", func(t *testing.T) {
+		srv := httptest.NewServer(http.NotFoundHandler())
+		defer srv.Close()
+
+		skills := loadRemoteSkillsWithCache(srv.URL, newDiskCache(t.TempDir()))
+		assert.Empty(t, skills)
+	})
+
+	t.Run("server returns invalid JSON", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprint(w, `not json`)
+		}))
+		defer srv.Close()
+
+		skills := loadRemoteSkillsWithCache(srv.URL, newDiskCache(t.TempDir()))
+		assert.Empty(t, skills)
+	})
+
+	t.Run("unreachable server", func(t *testing.T) {
+		skills := loadRemoteSkillsWithCache("http://127.0.0.1:1", newDiskCache(t.TempDir()))
+		assert.Empty(t, skills)
+	})
+
+	t.Run("uses cached files instead of re-fetching", func(t *testing.T) {
+		fetchCount := 0
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fetchCount++
+			switch r.URL.Path {
+			case "/.well-known/skills/index.json":
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, `{"skills": [{"name": "cached-skill", "description": "Cached", "files": ["SKILL.md"]}]}`)
+			case "/.well-known/skills/cached-skill/SKILL.md":
+				w.Header().Set("Cache-Control", "max-age=3600")
+				fmt.Fprint(w, "# Cached Skill")
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer srv.Close()
+
+		cache := newDiskCache(t.TempDir())
+
+		// First load
+		skills1 := loadRemoteSkillsWithCache(srv.URL, cache)
+		require.Len(t, skills1, 1)
+		assert.Equal(t, 2, fetchCount) // index.json + SKILL.md
+
+		// Second load — SKILL.md should be cached
+		skills2 := loadRemoteSkillsWithCache(srv.URL, cache)
+		require.Len(t, skills2, 1)
+		assert.Equal(t, 3, fetchCount) // only index.json re-fetched, SKILL.md from cache
+	})
+
+	t.Run("skips invalid file paths", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/.well-known/skills/index.json":
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, `{"skills": [{"name": "test", "description": "Test", "files": ["SKILL.md", "../../../etc/passwd", "/absolute/path"]}]}`)
+			case "/.well-known/skills/test/SKILL.md":
+				fmt.Fprint(w, "# Test")
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer srv.Close()
+
+		cache := newDiskCache(t.TempDir())
+		skills := loadRemoteSkillsWithCache(srv.URL, cache)
+		require.Len(t, skills, 1)
+		// Only SKILL.md should have been fetched, not the malicious paths
+	})
+}
+
+func TestLoadWithRemoteSources(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/skills/index.json":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"skills": [{"name": "remote-skill", "description": "A remote skill", "files": ["SKILL.md"]}]}`)
+		case "/.well-known/skills/remote-skill/SKILL.md":
+			fmt.Fprint(w, "# Remote Skill")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	skills := Load([]string{srv.URL})
+
+	found := false
+	for _, s := range skills {
+		if s.Name != "remote-skill" {
+			continue
+		}
+		found = true
+		assert.Equal(t, "A remote skill", s.Description)
+		// FilePath should now be a local cache path
+		content, err := os.ReadFile(s.FilePath)
+		require.NoError(t, err)
+		assert.Equal(t, "# Remote Skill", string(content))
+	}
+	assert.True(t, found, "Expected to find remote-skill")
+}
+
+func TestLoadWithMixedSources(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/skills/index.json":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"skills": [{"name": "remote-skill", "description": "A remote skill", "files": ["SKILL.md"]}]}`)
+		case "/.well-known/skills/remote-skill/SKILL.md":
+			fmt.Fprint(w, "# Remote")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+	t.Setenv("HOME", t.TempDir())
+
+	skills := Load([]string{"local", srv.URL})
+
+	found := false
+	for _, s := range skills {
+		if s.Name == "remote-skill" {
+			found = true
+			assert.Equal(t, "A remote skill", s.Description)
+		}
+	}
+	assert.True(t, found, "Expected to find remote-skill from mixed sources")
+}
+
+func TestLoadWithEmptySources(t *testing.T) {
+	skills := Load(nil)
+	assert.Empty(t, skills)
+
+	skills = Load([]string{})
+	assert.Empty(t, skills)
+}
+
+func TestRemoteIndex_JSONParsing(t *testing.T) {
+	input := `{
+		"skills": [
+			{
+				"name": "test-skill",
+				"description": "A test skill",
+				"files": ["SKILL.md", "README.md", "templates/"]
+			}
+		]
+	}`
+
+	var idx remoteIndex
+	err := json.Unmarshal([]byte(input), &idx)
+	require.NoError(t, err)
+	require.Len(t, idx.Skills, 1)
+	assert.Equal(t, "test-skill", idx.Skills[0].Name)
+	assert.Equal(t, "A test skill", idx.Skills[0].Description)
+	assert.Equal(t, []string{"SKILL.md", "README.md", "templates/"}, idx.Skills[0].Files)
+}
+
+func TestIsValidFilePath(t *testing.T) {
+	tests := []struct {
+		path  string
+		valid bool
+	}{
+		{"SKILL.md", true},
+		{"references/FORMS.md", true},
+		{"scripts/extract.py", true},
+		{"assets/config.template.yaml", true},
+		{"", false},
+		{"/absolute/path", false},
+		{"../escape", false},
+		{"sub/../escape", false},
+		{"back\\slash", false},
+		{"query?param", false},
+		{"hash#fragment", false},
+		{"bracket[0]", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			assert.Equal(t, tt.valid, isValidFilePath(tt.path))
+		})
+	}
+}

--- a/pkg/tools/builtin/skills.go
+++ b/pkg/tools/builtin/skills.go
@@ -1,0 +1,239 @@
+package builtin
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/docker/cagent/pkg/skills"
+	"github.com/docker/cagent/pkg/tools"
+)
+
+const (
+	ToolNameReadSkill     = "read_skill"
+	ToolNameReadSkillFile = "read_skill_file"
+)
+
+var (
+	_ tools.ToolSet      = (*SkillsToolset)(nil)
+	_ tools.Instructable = (*SkillsToolset)(nil)
+)
+
+// SkillsToolset provides the read_skill and read_skill_file tools that let an
+// agent load skill content and supporting resources by name. It hides whether
+// a skill is local or remote — the agent just sees a name and description.
+type SkillsToolset struct {
+	skills []skills.Skill
+}
+
+func NewSkillsToolset(loadedSkills []skills.Skill) *SkillsToolset {
+	return &SkillsToolset{
+		skills: loadedSkills,
+	}
+}
+
+// Skills returns the loaded skills (used by the app layer for slash commands).
+func (s *SkillsToolset) Skills() []skills.Skill {
+	return s.skills
+}
+
+func (s *SkillsToolset) findSkill(name string) *skills.Skill {
+	for i := range s.skills {
+		if s.skills[i].Name == name {
+			return &s.skills[i]
+		}
+	}
+	return nil
+}
+
+// ReadSkillContent returns the content of a skill's SKILL.md by name.
+func (s *SkillsToolset) ReadSkillContent(name string) (string, error) {
+	skill := s.findSkill(name)
+	if skill == nil {
+		return "", fmt.Errorf("skill %q not found", name)
+	}
+
+	content, err := readFileContent(skill.FilePath)
+	if err != nil {
+		return "", err
+	}
+
+	return content, nil
+}
+
+// ReadSkillFile returns the content of a supporting file within a skill.
+// The path is relative to the skill's base directory (e.g. "references/FORMS.md").
+func (s *SkillsToolset) ReadSkillFile(skillName, relativePath string) (string, error) {
+	skill := s.findSkill(skillName)
+	if skill == nil {
+		return "", fmt.Errorf("skill %q not found", skillName)
+	}
+
+	if !isValidRelativePath(relativePath) {
+		return "", fmt.Errorf("invalid file path %q", relativePath)
+	}
+
+	absPath := filepath.Join(skill.BaseDir, filepath.FromSlash(relativePath))
+
+	// Ensure the resolved path stays within the skill's base directory
+	cleanBase := filepath.Clean(skill.BaseDir)
+	cleanPath := filepath.Clean(absPath)
+	if !strings.HasPrefix(cleanPath, cleanBase+string(filepath.Separator)) && cleanPath != cleanBase {
+		return "", fmt.Errorf("path %q escapes skill directory", relativePath)
+	}
+
+	content, err := readFileContent(absPath)
+	if err != nil {
+		return "", err
+	}
+
+	return content, nil
+}
+
+func readFileContent(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("reading file: %w", err)
+	}
+	return string(data), nil
+}
+
+func isValidRelativePath(p string) bool {
+	if p == "" || strings.HasPrefix(p, "/") || strings.HasPrefix(p, "\\") {
+		return false
+	}
+	if strings.Contains(p, "..") {
+		return false
+	}
+	return true
+}
+
+type readSkillArgs struct {
+	Name string `json:"name" jsonschema:"The name of the skill to read"`
+}
+
+type readSkillFileArgs struct {
+	SkillName string `json:"skill_name" jsonschema:"The name of the skill that contains the file"`
+	Path      string `json:"path" jsonschema:"The relative path to the file within the skill (e.g. references/FORMS.md)"`
+}
+
+func (s *SkillsToolset) handleReadSkill(_ context.Context, args readSkillArgs) (*tools.ToolCallResult, error) {
+	content, err := s.ReadSkillContent(args.Name)
+	if err != nil {
+		return tools.ResultError(err.Error()), nil
+	}
+	return tools.ResultSuccess(content), nil
+}
+
+func (s *SkillsToolset) handleReadSkillFile(_ context.Context, args readSkillFileArgs) (*tools.ToolCallResult, error) {
+	content, err := s.ReadSkillFile(args.SkillName, args.Path)
+	if err != nil {
+		return tools.ResultError(err.Error()), nil
+	}
+	return tools.ResultSuccess(content), nil
+}
+
+func (s *SkillsToolset) Instructions() string {
+	if len(s.skills) == 0 {
+		return ""
+	}
+
+	hasFiles := false
+	for _, skill := range s.skills {
+		if len(skill.Files) > 1 {
+			hasFiles = true
+			break
+		}
+	}
+
+	var sb strings.Builder
+	sb.WriteString("The following skills provide specialized instructions for specific tasks. ")
+	sb.WriteString("Each skill's description indicates what it does and when to use it.\n\n")
+	sb.WriteString("When a user's request matches a skill's description, use the read_skill tool to load the skill's content. ")
+	sb.WriteString("The content contains detailed instructions to follow for that task.\n\n")
+
+	if hasFiles {
+		sb.WriteString("Some skills reference supporting files (scripts, documentation, templates). ")
+		sb.WriteString("When skill instructions reference a file path, use the read_skill_file tool to load it on demand. ")
+		sb.WriteString("Do not load all files upfront — only load them as needed.\n\n")
+	}
+
+	sb.WriteString("<available_skills>\n")
+	for _, skill := range s.skills {
+		sb.WriteString("  <skill>\n")
+		sb.WriteString("    <name>")
+		sb.WriteString(skill.Name)
+		sb.WriteString("</name>\n")
+		sb.WriteString("    <description>")
+		sb.WriteString(skill.Description)
+		sb.WriteString("</description>\n")
+		if len(skill.Files) > 1 {
+			sb.WriteString("    <files>")
+			// List files excluding SKILL.md itself
+			first := true
+			for _, f := range skill.Files {
+				if f == "SKILL.md" {
+					continue
+				}
+				if !first {
+					sb.WriteString(", ")
+				}
+				sb.WriteString(f)
+				first = false
+			}
+			sb.WriteString("</files>\n")
+		}
+		sb.WriteString("  </skill>\n")
+	}
+	sb.WriteString("</available_skills>")
+
+	return sb.String()
+}
+
+func (s *SkillsToolset) Tools(context.Context) ([]tools.Tool, error) {
+	if len(s.skills) == 0 {
+		return nil, nil
+	}
+
+	result := []tools.Tool{
+		{
+			Name:         ToolNameReadSkill,
+			Category:     "skills",
+			Description:  "Read the content of a skill by name. Use this when a user's request matches an available skill.",
+			Parameters:   tools.MustSchemaFor[readSkillArgs](),
+			OutputSchema: tools.MustSchemaFor[string](),
+			Handler:      tools.NewHandler(s.handleReadSkill),
+			Annotations: tools.ToolAnnotations{
+				Title:        "Read Skill",
+				ReadOnlyHint: true,
+			},
+		},
+	}
+
+	// Only expose read_skill_file if any skill has supporting files
+	hasFiles := false
+	for _, skill := range s.skills {
+		if len(skill.Files) > 1 {
+			hasFiles = true
+			break
+		}
+	}
+	if hasFiles {
+		result = append(result, tools.Tool{
+			Name:         ToolNameReadSkillFile,
+			Category:     "skills",
+			Description:  "Read a supporting file from a skill (e.g. references, scripts, assets). Use when skill instructions reference additional files.",
+			Parameters:   tools.MustSchemaFor[readSkillFileArgs](),
+			OutputSchema: tools.MustSchemaFor[string](),
+			Handler:      tools.NewHandler(s.handleReadSkillFile),
+			Annotations: tools.ToolAnnotations{
+				Title:        "Read Skill File",
+				ReadOnlyHint: true,
+			},
+		})
+	}
+
+	return result, nil
+}

--- a/pkg/tools/builtin/skills_test.go
+++ b/pkg/tools/builtin/skills_test.go
@@ -1,0 +1,223 @@
+package builtin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/cagent/pkg/skills"
+)
+
+func TestSkillsToolset_ReadSkillContent_Local(t *testing.T) {
+	tmpDir := t.TempDir()
+	skillFile := filepath.Join(tmpDir, "SKILL.md")
+	require.NoError(t, os.WriteFile(skillFile, []byte("# Local Skill\nDo the thing."), 0o644))
+
+	st := NewSkillsToolset([]skills.Skill{
+		{Name: "local-skill", Description: "A local skill", FilePath: skillFile, BaseDir: tmpDir},
+	})
+
+	content, err := st.ReadSkillContent("local-skill")
+	require.NoError(t, err)
+	assert.Equal(t, "# Local Skill\nDo the thing.", content)
+}
+
+func TestSkillsToolset_ReadSkillContent_NotFound(t *testing.T) {
+	st := NewSkillsToolset([]skills.Skill{
+		{Name: "exists", Description: "Exists", FilePath: "/tmp/nonexistent"},
+	})
+
+	_, err := st.ReadSkillContent("does-not-exist")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestSkillsToolset_ReadSkillFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "SKILL.md"), []byte("# Main"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "references"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "references", "FORMS.md"), []byte("# Forms Reference"), 0o644))
+
+	st := NewSkillsToolset([]skills.Skill{
+		{
+			Name: "my-skill", Description: "My skill", FilePath: filepath.Join(tmpDir, "SKILL.md"), BaseDir: tmpDir,
+			Files: []string{"SKILL.md", "references/FORMS.md"},
+		},
+	})
+
+	content, err := st.ReadSkillFile("my-skill", "references/FORMS.md")
+	require.NoError(t, err)
+	assert.Equal(t, "# Forms Reference", content)
+}
+
+func TestSkillsToolset_ReadSkillFile_PathTraversal(t *testing.T) {
+	tmpDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "SKILL.md"), []byte("# Main"), 0o644))
+
+	st := NewSkillsToolset([]skills.Skill{
+		{Name: "my-skill", Description: "My skill", FilePath: filepath.Join(tmpDir, "SKILL.md"), BaseDir: tmpDir},
+	})
+
+	_, err := st.ReadSkillFile("my-skill", "../../../etc/passwd")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid file path")
+
+	_, err = st.ReadSkillFile("my-skill", "/etc/passwd")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid file path")
+}
+
+func TestSkillsToolset_ReadSkillFile_SkillNotFound(t *testing.T) {
+	st := NewSkillsToolset([]skills.Skill{
+		{Name: "exists", Description: "Exists", FilePath: "/tmp/test"},
+	})
+
+	_, err := st.ReadSkillFile("nonexistent", "SKILL.md")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestSkillsToolset_Instructions(t *testing.T) {
+	st := NewSkillsToolset([]skills.Skill{
+		{Name: "skill-a", Description: "Does A"},
+		{Name: "skill-b", Description: "Does B", Files: []string{"SKILL.md", "references/HELP.md"}},
+	})
+
+	instructions := st.Instructions()
+
+	assert.Contains(t, instructions, "read_skill")
+	assert.Contains(t, instructions, "read_skill_file")
+	assert.Contains(t, instructions, "<available_skills>")
+	assert.Contains(t, instructions, "<name>skill-a</name>")
+	assert.Contains(t, instructions, "<description>Does A</description>")
+	assert.Contains(t, instructions, "<name>skill-b</name>")
+	assert.Contains(t, instructions, "<description>Does B</description>")
+	assert.Contains(t, instructions, "<files>references/HELP.md</files>")
+	// Should NOT contain file system paths
+	assert.NotContains(t, instructions, "FilePath")
+}
+
+func TestSkillsToolset_Instructions_NoFiles(t *testing.T) {
+	st := NewSkillsToolset([]skills.Skill{
+		{Name: "simple", Description: "Simple skill"},
+	})
+
+	instructions := st.Instructions()
+
+	assert.Contains(t, instructions, "read_skill")
+	assert.NotContains(t, instructions, "read_skill_file")
+	assert.NotContains(t, instructions, "<files>")
+}
+
+func TestSkillsToolset_Instructions_Empty(t *testing.T) {
+	st := NewSkillsToolset(nil)
+	assert.Empty(t, st.Instructions())
+
+	st = NewSkillsToolset([]skills.Skill{})
+	assert.Empty(t, st.Instructions())
+}
+
+func TestSkillsToolset_Tools_WithFiles(t *testing.T) {
+	st := NewSkillsToolset([]skills.Skill{
+		{Name: "test", Description: "Test skill", Files: []string{"SKILL.md", "references/HELP.md"}},
+	})
+
+	tools, err := st.Tools(t.Context())
+	require.NoError(t, err)
+	require.Len(t, tools, 2)
+
+	assert.Equal(t, ToolNameReadSkill, tools[0].Name)
+	assert.Equal(t, ToolNameReadSkillFile, tools[1].Name)
+}
+
+func TestSkillsToolset_Tools_WithoutFiles(t *testing.T) {
+	st := NewSkillsToolset([]skills.Skill{
+		{Name: "test", Description: "Test skill"},
+	})
+
+	tools, err := st.Tools(t.Context())
+	require.NoError(t, err)
+	require.Len(t, tools, 1)
+
+	assert.Equal(t, ToolNameReadSkill, tools[0].Name)
+}
+
+func TestSkillsToolset_Tools_Empty(t *testing.T) {
+	st := NewSkillsToolset(nil)
+
+	tools, err := st.Tools(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, tools)
+}
+
+func TestSkillsToolset_Skills(t *testing.T) {
+	input := []skills.Skill{
+		{Name: "a", Description: "A"},
+		{Name: "b", Description: "B"},
+	}
+	st := NewSkillsToolset(input)
+
+	assert.Equal(t, input, st.Skills())
+}
+
+func TestSkillsToolset_HandleReadSkill(t *testing.T) {
+	tmpDir := t.TempDir()
+	skillFile := filepath.Join(tmpDir, "SKILL.md")
+	require.NoError(t, os.WriteFile(skillFile, []byte("skill instructions"), 0o644))
+
+	st := NewSkillsToolset([]skills.Skill{
+		{Name: "test-skill", Description: "Test", FilePath: skillFile, BaseDir: tmpDir},
+	})
+
+	result, err := st.handleReadSkill(t.Context(), readSkillArgs{Name: "test-skill"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Output, "skill instructions")
+}
+
+func TestSkillsToolset_HandleReadSkill_NotFound(t *testing.T) {
+	st := NewSkillsToolset([]skills.Skill{
+		{Name: "exists", Description: "Exists", FilePath: "/tmp/test"},
+	})
+
+	result, err := st.handleReadSkill(t.Context(), readSkillArgs{Name: "missing"})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Output, "not found")
+}
+
+func TestSkillsToolset_HandleReadSkillFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "SKILL.md"), []byte("# Main"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "scripts"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "scripts", "deploy.sh"), []byte("#!/bin/bash\necho deploy"), 0o644))
+
+	st := NewSkillsToolset([]skills.Skill{
+		{
+			Name: "my-skill", Description: "My skill", FilePath: filepath.Join(tmpDir, "SKILL.md"), BaseDir: tmpDir,
+			Files: []string{"SKILL.md", "scripts/deploy.sh"},
+		},
+	})
+
+	result, err := st.handleReadSkillFile(t.Context(), readSkillFileArgs{SkillName: "my-skill", Path: "scripts/deploy.sh"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Output, "echo deploy")
+}
+
+func TestSkillsToolset_HandleReadSkillFile_PathTraversal(t *testing.T) {
+	tmpDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "SKILL.md"), []byte("# Main"), 0o644))
+
+	st := NewSkillsToolset([]skills.Skill{
+		{Name: "my-skill", Description: "My skill", FilePath: filepath.Join(tmpDir, "SKILL.md"), BaseDir: tmpDir},
+	})
+
+	result, err := st.handleReadSkillFile(t.Context(), readSkillFileArgs{SkillName: "my-skill", Path: "../../../etc/passwd"})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Output, "invalid file path")
+}


### PR DESCRIPTION
Add support for remote skill sources via the well-known skills discovery spec (https://github.com/cloudflare/agent-skills-discovery-rfc). The skills config now accepts both the existing boolean form and a list of sources:

```yaml
skills: true          # equivalent to ["local"]
skills:
  - local
  - https://example.com
```

Remote skills are fetched from /.well-known/skills/index.json, and all files listed in the index are prefetched into a disk cache under the XDG cache directory (~/.cache/cagent/skills/ on Linux). Cache-Control headers are respected for expiry.

Instead of depending on read_file/fetch tools, skills now get their own dedicated toolset (SkillsToolset) with two tools:
- read_skill: loads a skill's SKILL.md by name
- read_skill_file: loads supporting resources (references, scripts, assets) by skill name and relative path

The agent never sees whether a skill is local or remote. The toolset handles progressive disclosure per the spec: only name+description at startup, SKILL.md on activation, supporting files on demand.

Other changes:
- Replace Skills *bool config field with SkillsConfig supporting both bool and list-of-sources YAML/JSON formats
- Add paths.GetCacheDir() using os.UserCacheDir() for XDG compliance
- Remove skills system prompt injection from session.go (now handled by the toolset's Instructable interface)
- Remove filesystem/read_file validation requirement for skills
- Validate skill sources (must be "local" or HTTP/HTTPS URL)

Assisted-By: cagent