### PR TITLE
get_memories errors on new memories

### DIFF
--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -17,7 +17,11 @@ type ToolSet interface {
 func NewHandler[T any](fn func(context.Context, T) (*ToolCallResult, error)) ToolHandler {
 	return func(ctx context.Context, toolCall ToolCall) (*ToolCallResult, error) {
 		var params T
-		if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &params); err != nil {
+		args := toolCall.Function.Arguments
+		if args == "" {
+			args = "{}"
+		}
+		if err := json.Unmarshal([]byte(args), &params); err != nil {
 			return nil, err
 		}
 		return fn(ctx, params)

--- a/pkg/tools/tools_test.go
+++ b/pkg/tools/tools_test.go
@@ -1,0 +1,80 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewHandler_WithArguments(t *testing.T) {
+	type Args struct {
+		Name string `json:"name"`
+	}
+
+	handler := NewHandler(func(_ context.Context, args Args) (*ToolCallResult, error) {
+		return ResultSuccess("hello " + args.Name), nil
+	})
+
+	result, err := handler(t.Context(), ToolCall{
+		ID:   "call_1",
+		Type: "function",
+		Function: FunctionCall{
+			Name:      "greet",
+			Arguments: `{"name":"world"}`,
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "hello world", result.Output)
+}
+
+func TestNewHandler_EmptyArguments(t *testing.T) {
+	handler := NewHandler(func(_ context.Context, _ map[string]any) (*ToolCallResult, error) {
+		return ResultSuccess("ok"), nil
+	})
+
+	result, err := handler(t.Context(), ToolCall{
+		ID:   "call_1",
+		Type: "function",
+		Function: FunctionCall{
+			Name:      "get_memories",
+			Arguments: "",
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "ok", result.Output)
+}
+
+func TestNewHandler_EmptyObjectArguments(t *testing.T) {
+	handler := NewHandler(func(_ context.Context, _ map[string]any) (*ToolCallResult, error) {
+		return ResultSuccess("ok"), nil
+	})
+
+	result, err := handler(t.Context(), ToolCall{
+		ID:   "call_1",
+		Type: "function",
+		Function: FunctionCall{
+			Name:      "list_things",
+			Arguments: "{}",
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "ok", result.Output)
+}
+
+func TestNewHandler_InvalidArguments(t *testing.T) {
+	handler := NewHandler(func(_ context.Context, _ map[string]any) (*ToolCallResult, error) {
+		return ResultSuccess("ok"), nil
+	})
+
+	_, err := handler(t.Context(), ToolCall{
+		ID:   "call_1",
+		Type: "function",
+		Function: FunctionCall{
+			Name:      "broken",
+			Arguments: `{"unterminated`,
+		},
+	})
+	require.Error(t, err)
+}


### PR DESCRIPTION
I noticed this a bunch when testing the PR reviewer locally:
<img width="200" height="65" alt="Screenshot 2026-02-23 at 11 01 40 AM" src="https://github.com/user-attachments/assets/a07d8de9-9595-44ee-86ab-9c594da4c382" />

The agent seems to work just fine, but never seems to be able to save memories if the initial get memories fails.

- Fix `NewHandler` panic when a model calls a tool with no parameters (e.g. `get_memories`) and the streaming API delivers an empty string for `Function.Arguments`
- Default empty arguments to "{}" before passing to `json.Unmarshal`, matching the existing guard in `script_shell` tools (#585)
- Add unit tests covering normal arguments, empty arguments, empty object arguments, and invalid JSON arguments

## Details

When a model invokes a tool that takes no parameters, the streaming API may deliver an empty string for `Function.Arguments`. The generic `NewHandler[T]` function passed this directly to `json.Unmarshal`, which fails with "unexpected end of JSON input".

This was previously fixed for script_shell tools in #585 by guarding with `if Arguments != ""`, but `NewHandler` (used by memory, think, and any typed handler) was missed.

## Test plan

- Added `TestNewHandler_EmptyArguments` — verifies empty string arguments no longer cause an error
- Added `TestNewHandler_WithArguments` — verifies normal JSON arguments still parse correctly
- Added `TestNewHandler_EmptyObjectArguments` — verifies "{}" arguments work
- Added `TestNewHandler_InvalidArguments` — verifies malformed JSON still returns an error