### PR TITLE
feat: support skill arguments in command palette and inline completion

### DIFF
--- a/pkg/skills/skills.go
+++ b/pkg/skills/skills.go
@@ -16,15 +16,22 @@ const skillFile = "SKILL.md"
 
 // Skill represents a loaded skill with its metadata and content location.
 type Skill struct {
-	Name          string            `yaml:"name"`
-	Description   string            `yaml:"description"`
-	FilePath      string            `yaml:"-"`
-	BaseDir       string            `yaml:"-"`
-	Files         []string          `yaml:"-"`
-	License       string            `yaml:"license"`
-	Compatibility string            `yaml:"compatibility"`
-	Metadata      map[string]string `yaml:"metadata"`
-	AllowedTools  []string          `yaml:"allowed-tools"`
+	Name            string            `yaml:"name"`
+	Description     string            `yaml:"description"`
+	ArgsDescription string            `yaml:"args"`
+	FilePath        string            `yaml:"-"`
+	BaseDir         string            `yaml:"-"`
+	Files           []string          `yaml:"-"`
+	License         string            `yaml:"license"`
+	Compatibility   string            `yaml:"compatibility"`
+	Metadata        map[string]string `yaml:"metadata"`
+	AllowedTools    []string          `yaml:"allowed-tools"`
+}
+
+// HasArgs returns true if the skill declares an args description,
+// indicating it accepts arguments when invoked as a slash command.
+func (s Skill) HasArgs() bool {
+	return s.ArgsDescription != ""
 }
 
 // Load discovers and loads skills from the given sources.

--- a/pkg/tui/commands/commands.go
+++ b/pkg/tui/commands/commands.go
@@ -404,7 +404,11 @@ func BuildCommandCategories(ctx context.Context, application *app.App) []Categor
 		skillCommands := make([]Item, 0, len(skillsList))
 		for _, skill := range skillsList {
 			skillName := skill.Name
-			description := toolcommon.TruncateText(skill.Description, 55)
+			description := skill.Description
+			if skill.HasArgs() {
+				description += " (args: " + skill.ArgsDescription + ")"
+			}
+			description = toolcommon.TruncateText(description, 55)
 
 			skillCommands = append(skillCommands, Item{
 				ID:           "skill." + skillName,

--- a/pkg/tui/components/editor/editor.go
+++ b/pkg/tui/components/editor/editor.go
@@ -655,6 +655,15 @@ func (e *editor) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 			return e, msg.Execute()
 		}
 		if e.currentCompletion.AutoSubmit() {
+			if msg.Tab {
+				// Tab inserts the value without submitting, allowing the user
+				// to continue typing (e.g., adding arguments to a skill).
+				e.textarea.SetValue(msg.Value + " ")
+				e.textarea.MoveToEnd()
+				e.userTyped = true
+				e.clearSuggestion()
+				return e, nil
+			}
 			// For auto-submit completions (like commands), use the selected
 			// command value (e.g., "/exit") instead of what the user typed
 			// (e.g., "/e"). Append any extra text after the trigger word

--- a/pkg/tui/dialog/file_picker.go
+++ b/pkg/tui/dialog/file_picker.go
@@ -214,7 +214,7 @@ func (d *filePickerDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 			}
 			return d, nil
 
-		case key.Matches(msg, d.keyMap.Enter):
+		case key.Matches(msg, d.keyMap.Enter) || key.Matches(msg, d.keyMap.Tab):
 			if d.selected >= 0 && d.selected < len(d.filtered) {
 				entry := d.filtered[d.selected]
 				if entry.isDir {

--- a/pkg/tui/dialog/model_picker.go
+++ b/pkg/tui/dialog/model_picker.go
@@ -156,7 +156,7 @@ func (d *modelPickerDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 			}
 			return d, nil
 
-		case key.Matches(msg, d.keyMap.Enter):
+		case key.Matches(msg, d.keyMap.Enter) || key.Matches(msg, d.keyMap.Tab):
 			cmd := d.handleSelection()
 			return d, cmd
 

--- a/pkg/tui/dialog/theme_picker.go
+++ b/pkg/tui/dialog/theme_picker.go
@@ -198,7 +198,7 @@ func (d *themePickerDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 			}
 			return d, nil
 
-		case key.Matches(msg, d.keyMap.Enter):
+		case key.Matches(msg, d.keyMap.Enter) || key.Matches(msg, d.keyMap.Tab):
 			cmd := d.handleSelection()
 			return d, cmd
 

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -581,6 +581,14 @@ func (m *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.cleanupAll()
 		return m, tea.Quit
 
+	case dialog.CommandAutoCompleteMsg:
+		// Tab was pressed in the command palette: insert the slash command into the editor
+		// so the user can continue typing (e.g., adding arguments).
+		if msg.Command.SlashCommand != "" {
+			m.editor.SetValue(msg.Command.SlashCommand + " ")
+		}
+		return m, m.editor.Focus()
+
 	case dialog.RuntimeResumeMsg:
 		m.application.Resume(msg.Request)
 		return m, nil


### PR DESCRIPTION
Add an ArgsDescription field to skills (via 'args' YAML frontmatter) so skills can declare that they accept arguments. When present:

- Command palette and inline / completion show the args hint in the skill description (e.g., '(args: <module-name>)').
- Tab auto-completes the skill name into the editor without submitting, leaving the cursor for the user to type arguments before pressing Enter.
- Enter continues to execute the command immediately.

Split the combined enter/tab key binding in the completion component into separate bindings so each key can trigger distinct behavior. Preserve tab-to-select in file picker, model picker, and theme picker dialogs by matching both keys in their handlers.

Assisted-By: cagent