### PR TITLE
Fix docker ai shellout to cagent

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -159,7 +159,9 @@ We collect anonymous usage data to help improve cagent. To disable:
 	rootCmd.SetErr(stderr)
 	setContextRecursive(ctx, rootCmd)
 
-	if plugin.RunningStandalone() {
+	// when running 'docker ai', env vars are set for cli plugin and RunningStandalone is false, but ai shells out to cagent
+	// if the command is 'cagent' we want to run cagent standalone (there's no 'docker cagent')
+	if plugin.RunningStandalone() || rootCmd.Name() == "cagent" {
 		// When no subcommand is given, default to "run".
 		rootCmd.SetArgs(defaultToRun(rootCmd, args))
 


### PR DESCRIPTION
detect when `cagent` (standalone invocation) is invoked by a cli plugin, and run cagent standalone, not as a cli plugin