### PR TITLE
Add 'debug auth' command to inspect Docker Desktop JWT

### DIFF
--- a/cmd/root/debug.go
+++ b/cmd/root/debug.go
@@ -54,6 +54,8 @@ func newDebugCmd() *cobra.Command {
 
 	addRuntimeConfigFlags(cmd, &flags.runConfig)
 
+	cmd.AddCommand(newDebugAuthCmd())
+
 	return cmd
 }
 

--- a/cmd/root/debug_auth.go
+++ b/cmd/root/debug_auth.go
@@ -1,0 +1,131 @@
+package root
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/spf13/cobra"
+
+	"github.com/docker/cagent/pkg/desktop"
+	"github.com/docker/cagent/pkg/telemetry"
+)
+
+// authInfo holds the parsed JWT authentication information.
+type authInfo struct {
+	Token     string    `json:"token"`
+	Subject   string    `json:"subject,omitempty"`
+	Issuer    string    `json:"issuer,omitempty"`
+	IssuedAt  time.Time `json:"issued_at,omitempty"`
+	ExpiresAt time.Time `json:"expires_at,omitempty"`
+	Expired   bool      `json:"expired"`
+	Username  string    `json:"username,omitempty"`
+	Email     string    `json:"email,omitempty"`
+}
+
+func newDebugAuthCmd() *cobra.Command {
+	var jsonOutput bool
+
+	cmd := &cobra.Command{
+		Use:   "auth",
+		Short: "Print Docker Desktop authentication information",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			telemetry.TrackCommand("debug", []string{"auth"})
+
+			ctx := cmd.Context()
+			w := cmd.OutOrStdout()
+
+			token := desktop.GetToken(ctx)
+			if token == "" {
+				if jsonOutput {
+					return json.NewEncoder(w).Encode(map[string]string{
+						"error": "no token found (is Docker Desktop running and are you logged in?)",
+					})
+				}
+				fmt.Fprintln(w, "No token found. Is Docker Desktop running and are you logged in?")
+				return nil
+			}
+
+			info, err := parseAuthInfo(token)
+			if err != nil {
+				return fmt.Errorf("failed to parse JWT: %w", err)
+			}
+
+			userInfo := desktop.GetUserInfo(ctx)
+			info.Username = userInfo.Username
+			info.Email = userInfo.Email
+
+			if jsonOutput {
+				enc := json.NewEncoder(w)
+				enc.SetIndent("", "  ")
+				return enc.Encode(info)
+			}
+
+			printAuthInfoText(w, info)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
+
+	return cmd
+}
+
+func parseAuthInfo(token string) (*authInfo, error) {
+	parsed, _, err := jwt.NewParser().ParseUnverified(token, jwt.MapClaims{})
+	if err != nil {
+		return nil, err
+	}
+
+	info := &authInfo{
+		Token: token,
+	}
+
+	if sub, err := parsed.Claims.GetSubject(); err == nil {
+		info.Subject = sub
+	}
+	if iss, err := parsed.Claims.GetIssuer(); err == nil {
+		info.Issuer = iss
+	}
+	if iat, err := parsed.Claims.GetIssuedAt(); err == nil && iat != nil {
+		info.IssuedAt = iat.Time
+	}
+	if exp, err := parsed.Claims.GetExpirationTime(); err == nil && exp != nil {
+		info.ExpiresAt = exp.Time
+		info.Expired = exp.Before(time.Now())
+	}
+
+	return info, nil
+}
+
+func printAuthInfoText(w io.Writer, info *authInfo) {
+	fmt.Fprintf(w, "Token:      %s...%s\n", info.Token[:10], info.Token[len(info.Token)-10:])
+
+	if info.Username != "" {
+		fmt.Fprintf(w, "Username:   %s\n", info.Username)
+	}
+	if info.Email != "" {
+		fmt.Fprintf(w, "Email:      %s\n", info.Email)
+	}
+	if info.Subject != "" {
+		fmt.Fprintf(w, "Subject:    %s\n", info.Subject)
+	}
+	if info.Issuer != "" {
+		fmt.Fprintf(w, "Issuer:     %s\n", info.Issuer)
+	}
+	if !info.IssuedAt.IsZero() {
+		fmt.Fprintf(w, "Issued at:  %s\n", info.IssuedAt.Local().Format(time.RFC3339))
+	}
+	if !info.ExpiresAt.IsZero() {
+		fmt.Fprintf(w, "Expires at: %s\n", info.ExpiresAt.Local().Format(time.RFC3339))
+	}
+
+	if info.Expired {
+		fmt.Fprintln(w, "Status:     ❌ Expired")
+	} else {
+		fmt.Fprintln(w, "Status:     ✅ Valid")
+	}
+}

--- a/cmd/root/debug_auth_test.go
+++ b/cmd/root/debug_auth_test.go
@@ -1,0 +1,105 @@
+package root
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func buildTestJWT(claims map[string]any) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
+	payload, _ := json.Marshal(claims)
+	payloadB64 := base64.RawURLEncoding.EncodeToString(payload)
+	sig := base64.RawURLEncoding.EncodeToString([]byte("fakesig"))
+	return fmt.Sprintf("%s.%s.%s", header, payloadB64, sig)
+}
+
+func TestParseAuthInfo_ValidToken(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	exp := now.Add(time.Hour)
+	token := buildTestJWT(map[string]any{
+		"sub": "user-123",
+		"iss": "docker",
+		"iat": now.Unix(),
+		"exp": exp.Unix(),
+	})
+
+	info, err := parseAuthInfo(token)
+	require.NoError(t, err)
+	assert.Equal(t, token, info.Token)
+	assert.Equal(t, "user-123", info.Subject)
+	assert.Equal(t, "docker", info.Issuer)
+	assert.False(t, info.Expired)
+	assert.WithinDuration(t, now, info.IssuedAt, time.Second)
+	assert.WithinDuration(t, exp, info.ExpiresAt, time.Second)
+}
+
+func TestParseAuthInfo_ExpiredToken(t *testing.T) {
+	t.Parallel()
+
+	exp := time.Now().Add(-time.Hour)
+	token := buildTestJWT(map[string]any{
+		"sub": "user-456",
+		"exp": exp.Unix(),
+	})
+
+	info, err := parseAuthInfo(token)
+	require.NoError(t, err)
+	assert.True(t, info.Expired)
+	assert.Equal(t, "user-456", info.Subject)
+}
+
+func TestParseAuthInfo_InvalidToken(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseAuthInfo("not-a-jwt")
+	require.Error(t, err)
+}
+
+func TestPrintAuthInfoText(t *testing.T) {
+	t.Parallel()
+
+	info := &authInfo{
+		Token:     "eyJhbGciOiJIUzI1NiJ9.xxxxxxxxxxxx.yyyyyyyy1234567890",
+		Username:  "testuser",
+		Email:     "test@example.com",
+		Subject:   "sub-123",
+		Issuer:    "docker",
+		IssuedAt:  time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		ExpiresAt: time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC),
+		Expired:   false,
+	}
+
+	var buf bytes.Buffer
+	printAuthInfoText(&buf, info)
+
+	output := buf.String()
+	assert.Contains(t, output, "testuser")
+	assert.Contains(t, output, "test@example.com")
+	assert.Contains(t, output, "sub-123")
+	assert.Contains(t, output, "docker")
+	assert.Contains(t, output, "✅ Valid")
+}
+
+func TestPrintAuthInfoText_Expired(t *testing.T) {
+	t.Parallel()
+
+	info := &authInfo{
+		Token:     "eyJhbGciOiJIUzI1NiJ9.xxxxxxxxxxxx.yyyyyyyy1234567890",
+		ExpiresAt: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+		Expired:   true,
+	}
+
+	var buf bytes.Buffer
+	printAuthInfoText(&buf, info)
+
+	assert.Contains(t, buf.String(), "❌ Expired")
+}


### PR DESCRIPTION
Add a new 'cagent debug auth' subcommand that fetches the JWT from Docker Desktop, parses its claims, and displays authentication status.

Supports a --json flag for machine-readable output.

Assisted-By: cagent