### PR TITLE
Fix `mcp/notion` not working with OpenAI models

### DIFF
--- a/pkg/model/provider/openai/schema.go
+++ b/pkg/model/provider/openai/schema.go
@@ -20,7 +20,7 @@ func ConvertParametersToSchema(params any) (shared.FunctionParameters, error) {
 }
 
 // walkSchema calls fn on the given schema node, then recursively walks into
-// properties, anyOf/oneOf/allOf variants, and array items.
+// properties, anyOf/oneOf/allOf variants, array items, and additionalProperties.
 func walkSchema(schema map[string]any, fn func(map[string]any)) {
 	fn(schema)
 
@@ -44,6 +44,11 @@ func walkSchema(schema map[string]any, fn func(map[string]any)) {
 
 	if items, ok := schema["items"].(map[string]any); ok {
 		walkSchema(items, fn)
+	}
+
+	// additionalProperties can be a boolean or an object schema
+	if additionalProps, ok := schema["additionalProperties"].(map[string]any); ok {
+		walkSchema(additionalProps, fn)
 	}
 }
 


### PR DESCRIPTION
Fixes error: 'required' is required to be supplied and to be an array including every key in properties. Missing 'bulleted_list_item'.

The OpenAI Response API requires all properties in a JSON Schema to be listed in the 'required' array. The walkSchema function was not walking into 'additionalProperties' when it contained an object schema, causing properties within those schemas (like 'bulleted_list_item' in the Notion MCP tool schema) to be missing from the required array.