### PR TITLE
Improve MCP server lifecycle: caching and auto-restart

### DIFF
--- a/examples/mcp-toolkit.yaml
+++ b/examples/mcp-toolkit.yaml
@@ -41,7 +41,6 @@ agents:
       - type: mcp
         command: docker
         args: ["mcp", "gateway", "run"]
-        tools: ["mcp-activate-profile", "mcp-add", "mcp-config-set", "mcp-create-profile", "mcp-remove"]
 
 permissions:
   allow:
@@ -50,5 +49,6 @@ permissions:
      - mcp-add
      - mcp-config-set
      - mcp-create-profile
+     - mcp-find
      - mcp-remove
   

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -125,6 +125,17 @@ func New(ctx context.Context, rt runtime.Runtime, sess *session.Session, opts ..
 		})
 	}
 
+	// Subscribe to tool list changes so the sidebar updates immediately
+	// when an MCP server adds or removes tools (outside of a RunStream).
+	if tcs, ok := rt.(runtime.ToolsChangeSubscriber); ok {
+		tcs.OnToolsChanged(func(event runtime.Event) {
+			select {
+			case app.events <- event:
+			case <-ctx.Done():
+			}
+		})
+	}
+
 	return app
 }
 

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -270,8 +270,8 @@ func TestSimple(t *testing.T) {
 
 	// Extract the actual message from MessageAddedEvent to use in comparison
 	// (it contains dynamic fields like CreatedAt that we can't predict)
-	require.Len(t, events, 9)
-	msgAdded := events[6].(*MessageAddedEvent)
+	require.Len(t, events, 10)
+	msgAdded := events[7].(*MessageAddedEvent)
 	require.NotNil(t, msgAdded.Message)
 	require.Equal(t, "Hello", msgAdded.Message.Message.Content)
 	require.Equal(t, chat.MessageRoleAssistant, msgAdded.Message.Message.Role)
@@ -282,6 +282,7 @@ func TestSimple(t *testing.T) {
 		ToolsetInfo(0, false, "root"),
 		UserMessage("Hi", sess.ID, nil, 0),
 		StreamStarted(sess.ID, "root"),
+		ToolsetInfo(0, false, "root"),
 		AgentChoice("root", "Hello"),
 		MessageAdded(sess.ID, msgAdded.Message, "root"),
 		NewTokenUsageEvent(sess.ID, "root", &Usage{InputTokens: 3, OutputTokens: 2, ContextLength: 5, LastMessage: &MessageUsage{
@@ -310,8 +311,8 @@ func TestMultipleContentChunks(t *testing.T) {
 
 	// Extract the actual message from MessageAddedEvent to use in comparison
 	// (it contains dynamic fields like CreatedAt that we can't predict)
-	require.Len(t, events, 13)
-	msgAdded := events[10].(*MessageAddedEvent)
+	require.Len(t, events, 14)
+	msgAdded := events[11].(*MessageAddedEvent)
 	require.NotNil(t, msgAdded.Message)
 
 	expectedEvents := []Event{
@@ -320,6 +321,7 @@ func TestMultipleContentChunks(t *testing.T) {
 		ToolsetInfo(0, false, "root"),
 		UserMessage("Please greet me", sess.ID, nil, 0),
 		StreamStarted(sess.ID, "root"),
+		ToolsetInfo(0, false, "root"),
 		AgentChoice("root", "Hello "),
 		AgentChoice("root", "there, "),
 		AgentChoice("root", "how "),
@@ -350,8 +352,8 @@ func TestWithReasoning(t *testing.T) {
 
 	// Extract the actual message from MessageAddedEvent to use in comparison
 	// (it contains dynamic fields like CreatedAt that we can't predict)
-	require.Len(t, events, 11)
-	msgAdded := events[8].(*MessageAddedEvent)
+	require.Len(t, events, 12)
+	msgAdded := events[9].(*MessageAddedEvent)
 	require.NotNil(t, msgAdded.Message)
 
 	expectedEvents := []Event{
@@ -360,6 +362,7 @@ func TestWithReasoning(t *testing.T) {
 		ToolsetInfo(0, false, "root"),
 		UserMessage("Hi", sess.ID, nil, 0),
 		StreamStarted(sess.ID, "root"),
+		ToolsetInfo(0, false, "root"),
 		AgentChoiceReasoning("root", "Let me think about this..."),
 		AgentChoiceReasoning("root", " I should respond politely."),
 		AgentChoice("root", "Hello, how can I help you?"),
@@ -389,8 +392,8 @@ func TestMixedContentAndReasoning(t *testing.T) {
 
 	// Extract the actual message from MessageAddedEvent to use in comparison
 	// (it contains dynamic fields like CreatedAt that we can't predict)
-	require.Len(t, events, 12)
-	msgAdded := events[9].(*MessageAddedEvent)
+	require.Len(t, events, 13)
+	msgAdded := events[10].(*MessageAddedEvent)
 	require.NotNil(t, msgAdded.Message)
 
 	expectedEvents := []Event{
@@ -399,6 +402,7 @@ func TestMixedContentAndReasoning(t *testing.T) {
 		ToolsetInfo(0, false, "root"),
 		UserMessage("Hi there", sess.ID, nil, 0),
 		StreamStarted(sess.ID, "root"),
+		ToolsetInfo(0, false, "root"),
 		AgentChoiceReasoning("root", "The user wants a greeting"),
 		AgentChoice("root", "Hello!"),
 		AgentChoiceReasoning("root", " I should be friendly"),
@@ -450,16 +454,17 @@ func TestErrorEvent(t *testing.T) {
 		events = append(events, ev)
 	}
 
-	require.Len(t, events, 7)
+	require.Len(t, events, 8)
 	require.IsType(t, &AgentInfoEvent{}, events[0])
 	require.IsType(t, &TeamInfoEvent{}, events[1])
 	require.IsType(t, &ToolsetInfoEvent{}, events[2])
 	require.IsType(t, &UserMessageEvent{}, events[3])
 	require.IsType(t, &StreamStartedEvent{}, events[4])
-	require.IsType(t, &ErrorEvent{}, events[5])
-	require.IsType(t, &StreamStoppedEvent{}, events[6])
+	require.IsType(t, &ToolsetInfoEvent{}, events[5])
+	require.IsType(t, &ErrorEvent{}, events[6])
+	require.IsType(t, &StreamStoppedEvent{}, events[7])
 
-	errorEvent := events[5].(*ErrorEvent)
+	errorEvent := events[6].(*ErrorEvent)
 	require.Contains(t, errorEvent.Error, "simulated error")
 }
 

--- a/pkg/tools/capabilities.go
+++ b/pkg/tools/capabilities.go
@@ -34,6 +34,12 @@ func GetInstructions(ts ToolSet) string {
 	return ""
 }
 
+// ChangeNotifier is implemented by toolsets that can notify when their
+// tool list changes (e.g. after an MCP ToolListChanged notification).
+type ChangeNotifier interface {
+	SetToolsChangedHandler(handler func())
+}
+
 // ConfigureHandlers sets all applicable handlers on a toolset.
 // It checks for Elicitable and OAuthCapable interfaces and configures them.
 // This is a convenience function that handles the capability checking internally.

--- a/pkg/tools/mcp/mcp_test.go
+++ b/pkg/tools/mcp/mcp_test.go
@@ -43,6 +43,12 @@ func (m *mockMCPClient) SetOAuthSuccessHandler(func()) {}
 
 func (m *mockMCPClient) SetManagedOAuth(bool) {}
 
+func (m *mockMCPClient) SetToolListChangedHandler(func()) {}
+
+func (m *mockMCPClient) SetPromptListChangedHandler(func()) {}
+
+func (m *mockMCPClient) Wait() error { return nil }
+
 func (m *mockMCPClient) Close(context.Context) error { return nil }
 
 func TestCallToolStripsNullArguments(t *testing.T) {

--- a/pkg/tools/mcp/session_client.go
+++ b/pkg/tools/mcp/session_client.go
@@ -1,0 +1,194 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"log/slog"
+	"sync"
+
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/docker/cagent/pkg/tools"
+)
+
+// sessionClient provides shared session-management logic for MCP client
+// implementations. Both stdioMCPClient and remoteMCPClient embed it to avoid
+// duplicating the session-nil guards, notification handlers, and delegating
+// methods.
+type sessionClient struct {
+	session                  *gomcp.ClientSession
+	toolListChangedHandler   func()
+	promptListChangedHandler func()
+	elicitationHandler       tools.ElicitationHandler
+	oauthSuccessHandler      func()
+	mu                       sync.RWMutex
+}
+
+// setSession stores the session under the write lock.
+func (c *sessionClient) setSession(s *gomcp.ClientSession) {
+	c.mu.Lock()
+	c.session = s
+	c.mu.Unlock()
+}
+
+// getSession returns the current session under the read lock.
+func (c *sessionClient) getSession() *gomcp.ClientSession {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.session
+}
+
+// notificationHandlers returns ToolListChanged and PromptListChanged closures
+// suitable for gomcp.ClientOptions. They read the registered handler under the
+// read lock and invoke it if non-nil.
+func (c *sessionClient) notificationHandlers() (
+	toolChanged func(context.Context, *gomcp.ToolListChangedRequest),
+	promptChanged func(context.Context, *gomcp.PromptListChangedRequest),
+) {
+	toolChanged = func(_ context.Context, _ *gomcp.ToolListChangedRequest) {
+		c.mu.RLock()
+		h := c.toolListChangedHandler
+		c.mu.RUnlock()
+		if h != nil {
+			h()
+		}
+	}
+	promptChanged = func(_ context.Context, _ *gomcp.PromptListChangedRequest) {
+		c.mu.RLock()
+		h := c.promptListChangedHandler
+		c.mu.RUnlock()
+		if h != nil {
+			h()
+		}
+	}
+	return toolChanged, promptChanged
+}
+
+func (c *sessionClient) SetToolListChangedHandler(handler func()) {
+	c.mu.Lock()
+	c.toolListChangedHandler = handler
+	c.mu.Unlock()
+}
+
+func (c *sessionClient) SetPromptListChangedHandler(handler func()) {
+	c.mu.Lock()
+	c.promptListChangedHandler = handler
+	c.mu.Unlock()
+}
+
+func (c *sessionClient) Wait() error {
+	if s := c.getSession(); s != nil {
+		return s.Wait()
+	}
+	return nil
+}
+
+func (c *sessionClient) Close(context.Context) error {
+	if s := c.getSession(); s != nil {
+		return s.Close()
+	}
+	return nil
+}
+
+func (c *sessionClient) ListTools(ctx context.Context, request *gomcp.ListToolsParams) iter.Seq2[*gomcp.Tool, error] {
+	if s := c.getSession(); s != nil {
+		return s.Tools(ctx, request)
+	}
+	return func(yield func(*gomcp.Tool, error) bool) {
+		yield(nil, fmt.Errorf("session not initialized"))
+	}
+}
+
+func (c *sessionClient) CallTool(ctx context.Context, request *gomcp.CallToolParams) (*gomcp.CallToolResult, error) {
+	if s := c.getSession(); s != nil {
+		return s.CallTool(ctx, request)
+	}
+	return nil, fmt.Errorf("session not initialized")
+}
+
+func (c *sessionClient) ListPrompts(ctx context.Context, request *gomcp.ListPromptsParams) iter.Seq2[*gomcp.Prompt, error] {
+	if s := c.getSession(); s != nil {
+		return s.Prompts(ctx, request)
+	}
+	return func(yield func(*gomcp.Prompt, error) bool) {
+		yield(nil, fmt.Errorf("session not initialized"))
+	}
+}
+
+func (c *sessionClient) GetPrompt(ctx context.Context, request *gomcp.GetPromptParams) (*gomcp.GetPromptResult, error) {
+	if s := c.getSession(); s != nil {
+		return s.GetPrompt(ctx, request)
+	}
+	return nil, fmt.Errorf("session not initialized")
+}
+
+// handleElicitationRequest forwards incoming elicitation requests from the MCP
+// server to the registered handler. It is used as the gomcp ElicitationHandler
+// callback for both stdio and remote clients.
+func (c *sessionClient) handleElicitationRequest(ctx context.Context, req *gomcp.ElicitRequest) (*gomcp.ElicitResult, error) {
+	slog.Debug("Received elicitation request from MCP server", "message", req.Params.Message)
+
+	c.mu.RLock()
+	handler := c.elicitationHandler
+	c.mu.RUnlock()
+
+	if handler == nil {
+		return nil, fmt.Errorf("no elicitation handler configured")
+	}
+
+	result, err := handler(ctx, req.Params)
+	if err != nil {
+		return nil, fmt.Errorf("elicitation failed: %w", err)
+	}
+
+	return &gomcp.ElicitResult{
+		Action:  string(result.Action),
+		Content: result.Content,
+	}, nil
+}
+
+// SetElicitationHandler sets the handler that processes elicitation requests
+// from the MCP server.
+func (c *sessionClient) SetElicitationHandler(handler tools.ElicitationHandler) {
+	c.mu.Lock()
+	c.elicitationHandler = handler
+	c.mu.Unlock()
+}
+
+// requestElicitation invokes the registered elicitation handler directly.
+// This is used by the OAuth transport to trigger elicitation outside of
+// the normal MCP request flow.
+func (c *sessionClient) requestElicitation(ctx context.Context, req *gomcp.ElicitParams) (tools.ElicitationResult, error) {
+	c.mu.RLock()
+	handler := c.elicitationHandler
+	c.mu.RUnlock()
+
+	if handler == nil {
+		return tools.ElicitationResult{}, fmt.Errorf("no elicitation handler configured")
+	}
+
+	return handler(ctx, req)
+}
+
+// SetOAuthSuccessHandler sets the handler called when an OAuth flow completes.
+func (c *sessionClient) SetOAuthSuccessHandler(handler func()) {
+	c.mu.Lock()
+	c.oauthSuccessHandler = handler
+	c.mu.Unlock()
+}
+
+// oauthSuccess invokes the registered OAuth success handler, if any.
+func (c *sessionClient) oauthSuccess() {
+	c.mu.RLock()
+	handler := c.oauthSuccessHandler
+	c.mu.RUnlock()
+
+	if handler != nil {
+		handler()
+	}
+}
+
+// SetManagedOAuth is a no-op at the session level. The remoteMCPClient
+// overrides this to store the managed flag for its OAuth transport.
+func (c *sessionClient) SetManagedOAuth(bool) {}

--- a/pkg/tools/mcp/stdio.go
+++ b/pkg/tools/mcp/stdio.go
@@ -3,27 +3,20 @@ package mcp
 import (
 	"context"
 	"errors"
-	"fmt"
-	"iter"
-	"log/slog"
 	"os/exec"
 	"runtime"
-	"sync"
 
-	"github.com/modelcontextprotocol/go-sdk/mcp"
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/docker/cagent/pkg/desktop"
-	"github.com/docker/cagent/pkg/tools"
 )
 
 type stdioMCPClient struct {
-	command            string
-	args               []string
-	env                []string
-	session            *mcp.ClientSession
-	cwd                string
-	elicitationHandler tools.ElicitationHandler
-	mu                 sync.RWMutex
+	sessionClient
+	command string
+	args    []string
+	env     []string
+	cwd     string
 }
 
 func newStdioCmdClient(command string, args, env []string, cwd string) *stdioMCPClient {
@@ -35,19 +28,23 @@ func newStdioCmdClient(command string, args, env []string, cwd string) *stdioMCP
 	}
 }
 
-func (c *stdioMCPClient) Initialize(ctx context.Context, _ *mcp.InitializeRequest) (*mcp.InitializeResult, error) {
+func (c *stdioMCPClient) Initialize(ctx context.Context, _ *gomcp.InitializeRequest) (*gomcp.InitializeResult, error) {
 	// First, let's see if DD is running. This will help produce a better error message
 	// Skip this check on Linux where Docker runs natively without Docker Desktop
 	if c.command == "docker" && runtime.GOOS != "linux" && !desktop.IsDockerDesktopRunning(ctx) {
 		return nil, errors.New("Docker Desktop is not running") //nolint:staticcheck // Don't lowercase Docker Desktop
 	}
 
-	// Create client options with elicitation support
-	opts := &mcp.ClientOptions{
-		ElicitationHandler: c.handleElicitationRequest,
+	toolChanged, promptChanged := c.notificationHandlers()
+
+	// Create client options with elicitation and notification support
+	opts := &gomcp.ClientOptions{
+		ElicitationHandler:       c.handleElicitationRequest,
+		ToolListChangedHandler:   toolChanged,
+		PromptListChangedHandler: promptChanged,
 	}
 
-	client := mcp.NewClient(&mcp.Implementation{
+	client := gomcp.NewClient(&gomcp.Implementation{
 		Name:    "cagent",
 		Version: "1.0.0",
 	}, opts)
@@ -55,95 +52,14 @@ func (c *stdioMCPClient) Initialize(ctx context.Context, _ *mcp.InitializeReques
 	cmd := exec.CommandContext(ctx, c.command, c.args...)
 	cmd.Env = c.env
 	cmd.Dir = c.cwd
-	session, err := client.Connect(ctx, &mcp.CommandTransport{
+	session, err := client.Connect(ctx, &gomcp.CommandTransport{
 		Command: cmd,
 	}, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	c.session = session
-	return c.session.InitializeResult(), nil
-}
+	c.setSession(session)
 
-// handleElicitationRequest forwards incoming elicitation requests from the MCP server
-func (c *stdioMCPClient) handleElicitationRequest(ctx context.Context, req *mcp.ElicitRequest) (*mcp.ElicitResult, error) {
-	slog.Debug("Received elicitation request from stdio MCP server", "message", req.Params.Message)
-
-	c.mu.RLock()
-	handler := c.elicitationHandler
-	c.mu.RUnlock()
-
-	if handler == nil {
-		return nil, fmt.Errorf("no elicitation handler configured")
-	}
-
-	result, err := handler(ctx, req.Params)
-	if err != nil {
-		return nil, fmt.Errorf("elicitation failed: %w", err)
-	}
-
-	return &mcp.ElicitResult{
-		Action:  string(result.Action),
-		Content: result.Content,
-	}, nil
-}
-
-// SetElicitationHandler sets the elicitation handler for stdio MCP clients
-func (c *stdioMCPClient) SetElicitationHandler(handler tools.ElicitationHandler) {
-	c.mu.Lock()
-	c.elicitationHandler = handler
-	c.mu.Unlock()
-}
-
-// SetOAuthSuccessHandler is a no-op for stdio clients (OAuth not supported)
-func (c *stdioMCPClient) SetOAuthSuccessHandler(func()) {}
-
-// SetManagedOAuth is a no-op for stdio clients (OAuth not supported)
-func (c *stdioMCPClient) SetManagedOAuth(bool) {}
-
-func (c *stdioMCPClient) Close(context.Context) error {
-	if c.session == nil {
-		return nil
-	}
-
-	return c.session.Close()
-}
-
-func (c *stdioMCPClient) ListTools(ctx context.Context, request *mcp.ListToolsParams) iter.Seq2[*mcp.Tool, error] {
-	if c.session == nil {
-		return func(yield func(*mcp.Tool, error) bool) {
-			yield(nil, fmt.Errorf("session not initialized"))
-		}
-	}
-
-	return c.session.Tools(ctx, request)
-}
-
-func (c *stdioMCPClient) CallTool(ctx context.Context, request *mcp.CallToolParams) (*mcp.CallToolResult, error) {
-	if c.session == nil {
-		return nil, fmt.Errorf("session not initialized")
-	}
-
-	return c.session.CallTool(ctx, request)
-}
-
-// ListPrompts retrieves available prompts from the MCP server via stdio transport
-func (c *stdioMCPClient) ListPrompts(ctx context.Context, request *mcp.ListPromptsParams) iter.Seq2[*mcp.Prompt, error] {
-	if c.session == nil {
-		return func(yield func(*mcp.Prompt, error) bool) {
-			yield(nil, fmt.Errorf("session not initialized"))
-		}
-	}
-
-	return c.session.Prompts(ctx, request)
-}
-
-// GetPrompt retrieves a specific prompt with arguments from the MCP server via stdio transport
-func (c *stdioMCPClient) GetPrompt(ctx context.Context, request *mcp.GetPromptParams) (*mcp.GetPromptResult, error) {
-	if c.session == nil {
-		return nil, fmt.Errorf("session not initialized")
-	}
-
-	return c.session.GetPrompt(ctx, request)
+	return session.InitializeResult(), nil
 }


### PR DESCRIPTION
- Cache tool and prompt lists in MCP Toolset, invalidated via ToolListChanged/PromptListChanged **server notifications** instead of re-fetching on every agent iteration
- Auto-restart MCP servers that die unexpectedly with exponential backoff (up to 5 attempts), distinguishing crashes from intentional Stop() calls via a stopping flag

Assisted-By: cagent