### PR TITLE
Remove per-chunk UpdateMessage debug log

### DIFF
--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -1144,7 +1144,6 @@ func (s *SQLiteSessionStore) UpdateMessage(ctx context.Context, messageID int64,
 		}
 	}
 
-	slog.Debug("[STORE] UpdateMessage", "message_id", messageID, "role", msg.Message.Role, "agent", msg.AgentName)
 	return nil
 }
 


### PR DESCRIPTION
## Problem

During LLM streaming, `persistStreamingContent` is called on every chunk received from the model. Each call invokes `SQLiteSessionStore.UpdateMessage`, which contained a `slog.Debug` that fired once per chunk.

For a single short response (~1500 characters, ~5 seconds of streaming), this produced **123 identical log lines**:

```
level=DEBUG msg="[STORE] UpdateMessage" message_id=9450 role=assistant agent=root
level=DEBUG msg="[STORE] UpdateMessage" message_id=9450 role=assistant agent=root
level=DEBUG msg="[STORE] UpdateMessage" message_id=9450 role=assistant agent=root
... (120 more)
```

The same `message_id`, `role`, and `agent` on every line — no new information per call. This single pattern accounted for ~30% of all log output in `cagent.debug.log` in some specific situation. 30% might be optimistic.

## Fix

This PR suggests removing the `slog.Debug` call from `SQLiteSessionStore.UpdateMessage`.

The first message creation is already logged once in `persistStreamingContent` via `[PERSIST] Created streaming message`, which captures the `message_id` for correlation. Errors in `UpdateMessage` (sync failures, `ErrNotFound`) are still surfaced via `slog.Warn` — so we can have enough info for a diagnostic if needed