### PR TITLE
fix: Esc key not interrupting sub-agents in multi-agent sessions

### DIFF
--- a/pkg/tui/components/message/message.go
+++ b/pkg/tui/components/message/message.go
@@ -210,6 +210,14 @@ func (mv *messageModel) Message() *types.Message {
 
 // Layout.Sizeable methods
 
+// StopAnimation stops the spinner animation and unregisters from the animation coordinator.
+// This must be called when the view is removed from the UI to avoid leaked animation subscriptions.
+func (mv *messageModel) StopAnimation() {
+	if mv.message.Type == types.MessageTypeSpinner || mv.message.Type == types.MessageTypeLoading {
+		mv.spinner.Stop()
+	}
+}
+
 // SetSize sets the dimensions of the message view
 func (mv *messageModel) SetSize(width, height int) tea.Cmd {
 	mv.width = width

--- a/pkg/tui/components/messages/messages.go
+++ b/pkg/tui/components/messages/messages.go
@@ -180,6 +180,7 @@ func (m *model) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 	case messages.StreamCancelledMsg:
 		m.removeSpinner()
 		m.removePendingToolCallMessages()
+		m.stopReasoningBlockAnimations()
 		return m, nil
 
 	case tea.WindowSizeMsg:
@@ -1515,6 +1516,22 @@ func (m *model) RemoveSpinner() {
 	m.removeSpinner()
 }
 
+// animationStopper is implemented by views that register with the animation coordinator.
+// When a view is removed from the UI, StopAnimation must be called to unregister
+// its animation subscription and prevent leaked ticks.
+type animationStopper interface {
+	StopAnimation()
+}
+
+// stopViewAnimation stops animation subscriptions for a view being removed.
+// This prevents animation tick leaks when views with active spinners are
+// removed from the message list (e.g., on stream cancellation via ESC).
+func stopViewAnimation(view layout.Model) {
+	if stopper, ok := view.(animationStopper); ok {
+		stopper.StopAnimation()
+	}
+}
+
 func (m *model) removeSpinner() {
 	if len(m.messages) == 0 {
 		return
@@ -1522,10 +1539,12 @@ func (m *model) removeSpinner() {
 
 	lastIdx := len(m.messages) - 1
 	if m.messages[lastIdx].Type == types.MessageTypeSpinner {
-		m.messages = m.messages[:lastIdx]
-		if len(m.views) > lastIdx {
+		// Stop any animation subscriptions before removing the view
+		if lastIdx < len(m.views) {
+			stopViewAnimation(m.views[lastIdx])
 			m.views = m.views[:lastIdx]
 		}
+		m.messages = m.messages[:lastIdx]
 		m.invalidateAllItems()
 	}
 }
@@ -1537,6 +1556,10 @@ func (m *model) removePendingToolCallMessages() {
 	for i, msg := range m.messages {
 		if msg.Type == types.MessageTypeToolCall &&
 			(msg.ToolStatus == types.ToolStatusPending || msg.ToolStatus == types.ToolStatusRunning) {
+			// Stop any animation subscriptions before removing the view
+			if i < len(m.views) {
+				stopViewAnimation(m.views[i])
+			}
 			continue
 		}
 
@@ -1550,6 +1573,23 @@ func (m *model) removePendingToolCallMessages() {
 		m.messages = toolCallMessages
 		m.views = views
 		m.invalidateAllItems()
+	}
+}
+
+// stopReasoningBlockAnimations stops spinner animations in reasoning blocks
+// that have in-progress tool calls. Called on stream cancellation to prevent
+// spinners from running indefinitely after ESC is pressed.
+func (m *model) stopReasoningBlockAnimations() {
+	for i, msg := range m.messages {
+		if msg.Type != types.MessageTypeAssistantReasoningBlock || i >= len(m.views) {
+			continue
+		}
+		block, ok := m.views[i].(*reasoningblock.Model)
+		if !ok {
+			continue
+		}
+		block.StopAnimation()
+		m.invalidateItem(i)
 	}
 }
 

--- a/pkg/tui/components/reasoningblock/reasoningblock.go
+++ b/pkg/tui/components/reasoningblock/reasoningblock.go
@@ -667,6 +667,31 @@ func (m *Model) renderReasoningPreviewWithTruncationInfo() (string, bool) {
 	return m.messageStyle().Render(preview), reasoningTruncated
 }
 
+// StopAnimation stops all animation subscriptions for this reasoning block.
+// This must be called when the block is removed from the UI to avoid leaked animation subscriptions.
+func (m *Model) StopAnimation() {
+	// Stop the block's own fade animation registration
+	if m.animationRegistered {
+		m.animationRegistered = false
+		animation.Unregister()
+	}
+	// Stop spinners in all tool entries
+	for _, entry := range m.toolEntries {
+		stopViewAnimation(entry.view)
+	}
+}
+
+// stopViewAnimation stops animation subscriptions for a view being removed.
+type animationStopper interface {
+	StopAnimation()
+}
+
+func stopViewAnimation(view layout.Model) {
+	if stopper, ok := view.(animationStopper); ok {
+		stopper.StopAnimation()
+	}
+}
+
 // IsHeaderLine returns true if the given line index is the header (line 0).
 func (m *Model) IsHeaderLine(lineIdx int) bool {
 	return lineIdx == 0

--- a/pkg/tui/components/toolcommon/base.go
+++ b/pkg/tui/components/toolcommon/base.go
@@ -136,6 +136,15 @@ func (b *Base) CollapsedView() string {
 	return b.View()
 }
 
+// StopAnimation stops the spinner animation and unregisters from the animation coordinator.
+// This must be called when the view is removed from the UI to avoid leaked animation subscriptions.
+func (b *Base) StopAnimation() {
+	if b.spinnerRegistered {
+		b.spinnerRegistered = false
+		b.spinner.Stop()
+	}
+}
+
 func (b *Base) isSpinnerActive() bool {
 	return b.message.ToolStatus == types.ToolStatusPending ||
 		b.message.ToolStatus == types.ToolStatusRunning

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -143,6 +143,7 @@ type chatPage struct {
 
 	msgCancel       context.CancelFunc
 	streamCancelled bool
+	streamDepth     int // nesting depth of active streams (incremented on StreamStarted, decremented on StreamStopped)
 
 	// Track whether we've received content from an assistant response
 	// Used by --exit-after-response to ensure we don't exit before receiving content
@@ -609,6 +610,7 @@ func (p *chatPage) cancelStream(showCancelMessage bool) tea.Cmd {
 	p.msgCancel()
 	p.msgCancel = nil
 	p.streamCancelled = true
+	p.streamDepth = 0
 	p.setPendingResponse(false)
 	// Send StreamCancelledMsg to all components to handle cleanup
 	return tea.Batch(
@@ -838,6 +840,8 @@ func (p *chatPage) processMessage(msg msgtypes.SendMsg) tea.Cmd {
 	if p.msgCancel != nil {
 		p.msgCancel()
 	}
+
+	p.streamDepth = 0
 
 	var ctx context.Context
 	ctx, p.msgCancel = context.WithCancel(context.Background())

--- a/pkg/tui/page/chat/runtime_events.go
+++ b/pkg/tui/page/chat/runtime_events.go
@@ -184,6 +184,7 @@ func (p *chatPage) handleTokenUsage(msg *runtime.TokenUsageEvent) {
 func (p *chatPage) handleStreamStarted(msg *runtime.StreamStartedEvent) tea.Cmd {
 	slog.Debug("handleStreamStarted called", "agent", msg.AgentName, "session_id", msg.SessionID)
 	p.streamCancelled = false
+	p.streamDepth++
 	spinnerCmd := p.setWorking(true)
 	pendingCmd := p.setPendingResponse(true)
 	sidebarCmd := p.forwardToSidebar(msg)
@@ -214,20 +215,30 @@ func (p *chatPage) handleStreamStopped(msg *runtime.StreamStoppedEvent) tea.Cmd 
 		"agent", msg.AgentName,
 		"session_id", msg.SessionID,
 		"should_exit", p.app.ShouldExitAfterFirstResponse(),
-		"has_content", p.hasReceivedAssistantContent)
-	spinnerCmd := p.setWorking(false)
-	p.setPendingResponse(false)
-	if p.msgCancel != nil {
-		p.msgCancel = nil
+		"has_content", p.hasReceivedAssistantContent,
+		"stream_depth", p.streamDepth)
+
+	if p.streamDepth > 0 {
+		p.streamDepth--
 	}
-	p.streamCancelled = false
+
 	sidebarCmd := p.forwardToSidebar(msg)
 
-	// Check if there are queued messages to process
+	// Sub-agent stream stopped — the parent is still running, so only
+	// forward to the sidebar and keep the working/cancel state intact.
+	// Without this guard, pressing Esc after a sub-agent completes but
+	// while the parent continues would have no effect.
+	if p.streamDepth > 0 {
+		return tea.Batch(p.messages.ScrollToBottom(), sidebarCmd)
+	}
+
+	// Outermost stream stopped — fully clean up.
+	p.msgCancel = nil
+	p.streamCancelled = false
+	spinnerCmd := p.setWorking(false)
+	p.setPendingResponse(false)
 	queueCmd := p.processNextQueuedMessage()
 
-	// Check if we should exit after this response
-	// Only exit if we've actually received assistant content (not just on any stream stop)
 	var exitCmd tea.Cmd
 	if p.app.ShouldExitAfterFirstResponse() && p.hasReceivedAssistantContent {
 		slog.Debug("Exit after first response triggered, scheduling delayed exit")


### PR DESCRIPTION
When a sub-agent completed via transfer_task, its StreamStopped event cleared p.working and p.msgCancel, making the Esc key ineffective while the parent agent continued processing. Track nested stream depth so that working state and cancel func are only cleared when the outermost stream ends.

Fixes https://github.com/docker/cagent/issues/1898

Assisted-By: cagent