### PR TITLE
Replace the brittle tail -n 1 parsing with something that searches for the marker

### DIFF
--- a/.github/workflows/auto-issue-triage.yml
+++ b/.github/workflows/auto-issue-triage.yml
@@ -109,16 +109,16 @@ jobs:
           cat "$OUTPUT_FILE"
           echo "--------------------"
 
-          # The agent contract requires the result marker on the last line
-          LAST_LINE=$(tail -n 1 "$OUTPUT_FILE" | tr -d '[:space:]')
-          if [[ "$LAST_LINE" == "RESULT:NEEDS_INFO" ]]; then
+          # Search for the result marker anywhere in the output (LLMs often add trailing empty lines)
+          RESULT=$(grep -oE 'RESULT:(NEEDS_INFO|FIXED|NO_CHANGES)' "$OUTPUT_FILE" | tail -n 1)
+          if [[ "$RESULT" == "RESULT:NEEDS_INFO" ]]; then
             echo "action=needs_info" >> "$GITHUB_OUTPUT"
-          elif [[ "$LAST_LINE" == "RESULT:FIXED" ]]; then
+          elif [[ "$RESULT" == "RESULT:FIXED" ]]; then
             echo "action=fixed" >> "$GITHUB_OUTPUT"
-          elif [[ "$LAST_LINE" == "RESULT:NO_CHANGES" ]]; then
+          elif [[ "$RESULT" == "RESULT:NO_CHANGES" ]]; then
             echo "action=none" >> "$GITHUB_OUTPUT"
           else
-            echo "::warning::No recognized result marker on last line: $LAST_LINE"
+            echo "::warning::No recognized result marker found in agent output"
             echo "action=none" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
## Summary

Fix result marker parsing in the auto-issue-triage workflow. The previous `tail -n 1` approach silently discarded valid agent results when LLM output contained trailing empty lines — which happened on the very first production run ([actions/runs/22631502933](https://github.com/docker/cagent/actions/runs/22631502933)), where the agent successfully diagnosed and fixed issue #1651 but the result was dropped.

## Changes

- Replace `tail -n 1 | tr -d '[:space:]'` with `grep -oE 'RESULT:(NEEDS_INFO|FIXED|NO_CHANGES)' | tail -n 1` to search the entire output for the result marker instead of relying on it being the literal last line
- Update the warning message to reflect the new search-based approach

## Test plan

- [ ] Re-run the triage workflow on an issue with `kind/bug` label — verify the result marker is correctly parsed even with trailing empty lines in agent output
- [ ] Verify `RESULT:NEEDS_INFO`, `RESULT:FIXED`, and `RESULT:NO_CHANGES` paths still work correctly
- [ ] Verify that when no marker is present, the fallback `action=none` is still set