### PR TITLE
Add --config-dir and --data-dir global CLI flags to override default paths

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -30,6 +30,9 @@ type rootFlags struct {
 	debugMode   bool
 	logFilePath string
 	logFile     io.Closer
+	cacheDir    string
+	configDir   string
+	dataDir     string
 }
 
 func isDockerAgent() bool {
@@ -51,6 +54,18 @@ func NewRootCmd() *cobra.Command {
   cagent run ./agent.yaml
   cagent run agentcatalog/pirate`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// Apply directory overrides before anything else so that
+			// logging, telemetry, and config loading honour them.
+			if flags.cacheDir != "" {
+				paths.SetCacheDir(flags.cacheDir)
+			}
+			if flags.configDir != "" {
+				paths.SetConfigDir(flags.configDir)
+			}
+			if flags.dataDir != "" {
+				paths.SetDataDir(flags.dataDir)
+			}
+
 			// Initialize logging before anything else so logs don't break TUI
 			if err := flags.setupLogging(); err != nil {
 				// If logging setup fails, fall back to stderr so we still get logs
@@ -96,6 +111,9 @@ func NewRootCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVarP(&flags.debugMode, "debug", "d", false, "Enable debug logging")
 	cmd.PersistentFlags().BoolVarP(&flags.enableOtel, "otel", "o", false, "Enable OpenTelemetry tracing")
 	cmd.PersistentFlags().StringVar(&flags.logFilePath, "log-file", "", "Path to debug log file (default: ~/.cagent/cagent.debug.log; only used with --debug)")
+	cmd.PersistentFlags().StringVar(&flags.cacheDir, "cache-dir", "", "Override the cache directory (default: ~/Library/Caches/cagent on macOS)")
+	cmd.PersistentFlags().StringVar(&flags.configDir, "config-dir", "", "Override the config directory (default: ~/.config/cagent)")
+	cmd.PersistentFlags().StringVar(&flags.dataDir, "data-dir", "", "Override the data directory (default: ~/.cagent)")
 
 	cmd.AddCommand(newVersionCmd())
 	cmd.AddCommand(newRunCmd())

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -3,9 +3,53 @@ package paths
 import (
 	"os"
 	"path/filepath"
+	"sync/atomic"
 )
 
+// overridable holds an optional directory override backed by an atomic pointer.
+// A nil pointer (the zero value) means "use the default".
+type overridable struct{ p atomic.Pointer[string] }
+
+// Set stores an override directory. An empty value clears the override.
+func (o *overridable) Set(dir string) {
+	if dir == "" {
+		o.p.Store(nil)
+	} else {
+		o.p.Store(&dir)
+	}
+}
+
+// get returns the override if set, or falls back to the result of defaultFn.
+func (o *overridable) get(defaultFn func() string) string {
+	if p := o.p.Load(); p != nil {
+		return filepath.Clean(*p)
+	}
+	return defaultFn()
+}
+
+var (
+	cacheDirOverride  overridable
+	configDirOverride overridable
+	dataDirOverride   overridable
+)
+
+// SetCacheDir overrides the default cache directory returned by [GetCacheDir].
+// An empty value restores the default behaviour.
+// This should be called early (e.g. during CLI flag processing) before any
+// goroutine calls the corresponding getter.
+func SetCacheDir(dir string) { cacheDirOverride.Set(dir) }
+
+// SetConfigDir overrides the default config directory returned by [GetConfigDir].
+// An empty value restores the default behaviour.
+func SetConfigDir(dir string) { configDirOverride.Set(dir) }
+
+// SetDataDir overrides the default data directory returned by [GetDataDir].
+// An empty value restores the default behaviour.
+func SetDataDir(dir string) { dataDirOverride.Set(dir) }
+
 // GetCacheDir returns the user's cache directory for cagent.
+//
+// If an override has been set via [SetCacheDir] it is returned instead.
 //
 // On Linux this follows XDG: $XDG_CACHE_HOME/cagent (default ~/.cache/cagent).
 // On macOS this uses ~/Library/Caches/cagent.
@@ -14,37 +58,46 @@ import (
 // If the cache directory cannot be determined, it falls back to a directory
 // under the system temporary directory.
 func GetCacheDir() string {
-	cacheDir, err := os.UserCacheDir()
-	if err != nil {
-		return filepath.Clean(filepath.Join(os.TempDir(), ".cagent-cache"))
-	}
-	return filepath.Clean(filepath.Join(cacheDir, "cagent"))
+	return cacheDirOverride.get(func() string {
+		cacheDir, err := os.UserCacheDir()
+		if err != nil {
+			return filepath.Clean(filepath.Join(os.TempDir(), ".cagent-cache"))
+		}
+		return filepath.Clean(filepath.Join(cacheDir, "cagent"))
+	})
 }
 
 // GetConfigDir returns the user's config directory for cagent.
+//
+// If an override has been set via [SetConfigDir] it is returned instead.
 //
 // If the home directory cannot be determined, it falls back to a directory
 // under the system temporary directory. This is a best-effort fallback and
 // not intended to be a security boundary.
 func GetConfigDir() string {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		// Fallback to temp directory
-		return filepath.Clean(filepath.Join(os.TempDir(), ".cagent-config"))
-	}
-	return filepath.Clean(filepath.Join(homeDir, ".config", "cagent"))
+	return configDirOverride.get(func() string {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return filepath.Clean(filepath.Join(os.TempDir(), ".cagent-config"))
+		}
+		return filepath.Clean(filepath.Join(homeDir, ".config", "cagent"))
+	})
 }
 
 // GetDataDir returns the user's data directory for cagent (caches, content, logs).
 //
+// If an override has been set via [SetDataDir] it is returned instead.
+//
 // If the home directory cannot be determined, it falls back to a directory
 // under the system temporary directory.
 func GetDataDir() string {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return filepath.Clean(filepath.Join(os.TempDir(), ".cagent"))
-	}
-	return filepath.Clean(filepath.Join(homeDir, ".cagent"))
+	return dataDirOverride.get(func() string {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return filepath.Clean(filepath.Join(os.TempDir(), ".cagent"))
+		}
+		return filepath.Clean(filepath.Join(homeDir, ".cagent"))
+	})
 }
 
 // GetHomeDir returns the user's home directory.

--- a/pkg/paths/paths_test.go
+++ b/pkg/paths/paths_test.go
@@ -1,0 +1,49 @@
+package paths_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/docker/cagent/pkg/paths"
+)
+
+func TestOverrides(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		set    func(string)
+		get    func() string
+		custom string
+	}{
+		{"CacheDir", paths.SetCacheDir, paths.GetCacheDir, "/custom/cache"},
+		{"ConfigDir", paths.SetConfigDir, paths.GetConfigDir, "/custom/config"},
+		{"DataDir", paths.SetDataDir, paths.GetDataDir, "/custom/data"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Restore default after the test.
+			t.Cleanup(func() { tt.set("") })
+
+			original := tt.get()
+			assert.NotEmpty(t, original)
+
+			tt.set(tt.custom)
+			assert.Equal(t, tt.custom, tt.get())
+
+			// Empty string restores the default.
+			tt.set("")
+			assert.Equal(t, original, tt.get())
+		})
+	}
+}
+
+func TestGetHomeDir(t *testing.T) {
+	t.Parallel()
+
+	assert.NotEmpty(t, paths.GetHomeDir())
+}


### PR DESCRIPTION
Add `SetCacheDir`, `SetConfigDir`, and `SetDataDir` to the paths package, allowing callers to override the default `~/.cache/cagent`, `~/.config/cagent` and `~/.cagent` directories at runtime. 

Three new persistent flags are wired in the root command:
  --cache-dir  overrides ~/.cache/cagent
  --config-dir  overrides ~/.config/cagent
  --data-dir    overrides ~/.cagent

Assisted-By: cagent