### PR TITLE
agent: Improve toolset error reporting

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -209,8 +209,9 @@ func (a *Agent) Tools(ctx context.Context) ([]tools.Tool, error) {
 		}
 		ta, err := toolSet.Tools(ctx)
 		if err != nil {
-			slog.Warn("Toolset listing failed; skipping", "agent", a.Name(), "toolset", fmt.Sprintf("%T", toolSet.ToolSet), "error", err)
-			a.addToolWarning(fmt.Sprintf("%T list failed: %v", toolSet.ToolSet, err))
+			desc := tools.DescribeToolSet(toolSet)
+			slog.Warn("Toolset listing failed; skipping", "agent", a.Name(), "toolset", desc, "error", err)
+			a.addToolWarning(fmt.Sprintf("%s list failed: %v", desc, err))
 			continue
 		}
 		agentTools = append(agentTools, ta...)
@@ -238,8 +239,9 @@ func (a *Agent) ToolSets() []tools.ToolSet {
 func (a *Agent) ensureToolSetsAreStarted(ctx context.Context) {
 	for _, toolSet := range a.toolsets {
 		if err := toolSet.Start(ctx); err != nil {
-			slog.Warn("Toolset start failed; skipping", "agent", a.Name(), "toolset", fmt.Sprintf("%T", toolSet.ToolSet), "error", err)
-			a.addToolWarning(fmt.Sprintf("%T start failed: %v", toolSet.ToolSet, err))
+			desc := tools.DescribeToolSet(toolSet)
+			slog.Warn("Toolset start failed; skipping", "agent", a.Name(), "toolset", desc, "error", err)
+			a.addToolWarning(fmt.Sprintf("%s start failed: %v", desc, err))
 			continue
 		}
 	}

--- a/pkg/teamloader/registry.go
+++ b/pkg/teamloader/registry.go
@@ -131,7 +131,7 @@ func createMemoryTool(_ context.Context, toolset latest.Toolset, parentDir strin
 		return nil, fmt.Errorf("failed to create memory database: %w", err)
 	}
 
-	return builtin.NewMemoryTool(db), nil
+	return builtin.NewMemoryToolWithPath(db, validatedMemoryPath), nil
 }
 
 func createThinkTool(_ context.Context, _ latest.Toolset, _ string, _ *config.RuntimeConfig) (tools.ToolSet, error) {

--- a/pkg/tools/builtin/memory.go
+++ b/pkg/tools/builtin/memory.go
@@ -23,12 +23,14 @@ type DB interface {
 }
 
 type MemoryTool struct {
-	db DB
+	db   DB
+	path string
 }
 
 // Verify interface compliance
 var (
 	_ tools.ToolSet      = (*MemoryTool)(nil)
+	_ tools.Describer    = (*MemoryTool)(nil)
 	_ tools.Instructable = (*MemoryTool)(nil)
 )
 
@@ -36,6 +38,23 @@ func NewMemoryTool(manager DB) *MemoryTool {
 	return &MemoryTool{
 		db: manager,
 	}
+}
+
+// NewMemoryToolWithPath creates a MemoryTool and records the database path for
+// user-visible identification in warnings and error messages.
+func NewMemoryToolWithPath(manager DB, dbPath string) *MemoryTool {
+	return &MemoryTool{
+		db:   manager,
+		path: dbPath,
+	}
+}
+
+// Describe returns a short, user-visible description of this toolset instance.
+func (t *MemoryTool) Describe() string {
+	if t.path != "" {
+		return "memory(path=" + t.path + ")"
+	}
+	return "memory"
 }
 
 type AddMemoryArgs struct {

--- a/pkg/tools/mcp/describe_test.go
+++ b/pkg/tools/mcp/describe_test.go
@@ -1,0 +1,53 @@
+package mcp
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestToolsetDescribe_Stdio(t *testing.T) {
+	t.Parallel()
+
+	ts := NewToolsetCommand("", "python", []string{"-m", "mcp_server"}, nil, "")
+	assert.Check(t, is.Equal(ts.Describe(), "mcp(stdio cmd=python args_len=2)"))
+}
+
+func TestToolsetDescribe_StdioNoArgs(t *testing.T) {
+	t.Parallel()
+
+	ts := NewToolsetCommand("", "my-server", nil, nil, "")
+	assert.Check(t, is.Equal(ts.Describe(), "mcp(stdio cmd=my-server)"))
+}
+
+func TestToolsetDescribe_RemoteHostAndPort(t *testing.T) {
+	t.Parallel()
+
+	ts := NewRemoteToolset("", "http://example.com:8443/mcp/v1?key=secret", "sse", nil)
+	assert.Check(t, is.Equal(ts.Describe(), "mcp(remote host=example.com:8443 transport=sse)"))
+}
+
+func TestToolsetDescribe_RemoteDefaultPort(t *testing.T) {
+	t.Parallel()
+
+	ts := NewRemoteToolset("", "https://api.example.com/mcp", "streamable", nil)
+	assert.Check(t, is.Equal(ts.Describe(), "mcp(remote host=api.example.com transport=streamable)"))
+}
+
+func TestToolsetDescribe_RemoteInvalidURL(t *testing.T) {
+	t.Parallel()
+
+	ts := NewRemoteToolset("", "://bad-url", "sse", nil)
+	assert.Check(t, is.Equal(ts.Describe(), "mcp(remote transport=sse)"))
+}
+
+func TestToolsetDescribe_GatewayRef(t *testing.T) {
+	t.Parallel()
+
+	// Build a GatewayToolset manually to avoid needing Docker or a live registry.
+	inner := NewToolsetCommand("", "docker", []string{"mcp", "gateway", "run"}, nil, "")
+	inner.description = "mcp(ref=github-official)"
+	gt := &GatewayToolset{Toolset: inner, cleanUp: func() error { return nil }}
+	assert.Check(t, is.Equal(gt.Describe(), "mcp(ref=github-official)"))
+}

--- a/pkg/tools/mcp/gateway.go
+++ b/pkg/tools/mcp/gateway.go
@@ -54,8 +54,11 @@ func NewGatewayToolset(ctx context.Context, name, mcpServerName string, config a
 		"--config", fileConfig,
 	}
 
+	inner := NewToolsetCommand(name, "docker", args, nil, cwd)
+	inner.description = "mcp(ref=" + mcpServerName + ")"
+
 	return &GatewayToolset{
-		Toolset: NewToolsetCommand(name, "docker", args, nil, cwd),
+		Toolset: inner,
 		cleanUp: func() error {
 			return errors.Join(os.Remove(fileSecrets), os.Remove(fileConfig))
 		},

--- a/pkg/tools/mcp/mcp.go
+++ b/pkg/tools/mcp/mcp.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"iter"
 	"log/slog"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -41,6 +42,7 @@ type Toolset struct {
 	name         string
 	mcpClient    mcpClient
 	logID        string
+	description  string // user-visible description, set by constructors
 	instructions string
 	mu           sync.Mutex
 	started      bool
@@ -66,7 +68,10 @@ func (ts *Toolset) invalidateCache() {
 	ts.cacheGen++
 }
 
-var _ tools.ToolSet = (*Toolset)(nil)
+var (
+	_ tools.ToolSet   = (*Toolset)(nil)
+	_ tools.Describer = (*Toolset)(nil)
+)
 
 // Verify that Toolset implements optional capability interfaces
 var (
@@ -80,21 +85,25 @@ var (
 func NewToolsetCommand(name, command string, args, env []string, cwd string) *Toolset {
 	slog.Debug("Creating Stdio MCP toolset", "command", command, "args", args)
 
+	desc := buildStdioDescription(command, args)
 	return &Toolset{
-		name:      name,
-		mcpClient: newStdioCmdClient(command, args, env, cwd),
-		logID:     command,
+		name:        name,
+		mcpClient:   newStdioCmdClient(command, args, env, cwd),
+		logID:       command,
+		description: desc,
 	}
 }
 
 // NewRemoteToolset creates a new MCP toolset from a remote MCP Server.
-func NewRemoteToolset(name, url, transport string, headers map[string]string) *Toolset {
-	slog.Debug("Creating Remote MCP toolset", "url", url, "transport", transport, "headers", headers)
+func NewRemoteToolset(name, urlString, transport string, headers map[string]string) *Toolset {
+	slog.Debug("Creating Remote MCP toolset", "url", urlString, "transport", transport, "headers", headers)
 
+	desc := buildRemoteDescription(urlString, transport)
 	return &Toolset{
-		name:      name,
-		mcpClient: newRemoteClient(url, transport, headers, NewInMemoryTokenStore()),
-		logID:     url,
+		name:        name,
+		mcpClient:   newRemoteClient(urlString, transport, headers, NewInMemoryTokenStore()),
+		logID:       urlString,
+		description: desc,
 	}
 }
 
@@ -103,6 +112,30 @@ func NewRemoteToolset(name, url, transport string, headers map[string]string) *T
 // "started" so the agent can proceed, but watchConnection must not be spawned
 // because there is no live connection to monitor.
 var errServerUnavailable = errors.New("MCP server unavailable")
+
+// Describe returns a short, user-visible description of this toolset instance.
+// It never includes secrets.
+func (ts *Toolset) Describe() string {
+	return ts.description
+}
+
+// buildStdioDescription produces a user-visible description for a stdio MCP toolset.
+func buildStdioDescription(command string, args []string) string {
+	if len(args) == 0 {
+		return "mcp(stdio cmd=" + command + ")"
+	}
+	return fmt.Sprintf("mcp(stdio cmd=%s args_len=%d)", command, len(args))
+}
+
+// buildRemoteDescription produces a user-visible description for a remote MCP toolset,
+// exposing only the host (and port when present) from the URL.
+func buildRemoteDescription(rawURL, transport string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return "mcp(remote transport=" + transport + ")"
+	}
+	return "mcp(remote host=" + u.Host + " transport=" + transport + ")"
+}
 
 func (ts *Toolset) Start(ctx context.Context) error {
 	ts.mu.Lock()

--- a/pkg/tools/metadata.go
+++ b/pkg/tools/metadata.go
@@ -1,0 +1,25 @@
+package tools
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ToolsetMetadata exposes optional details for toolset identification.
+// Implemented by toolsets that can provide additional context for warnings.
+type ToolsetMetadata interface {
+	ToolsetID() string
+}
+
+// ToolsetIdentifier returns a human-readable identifier for a toolset.
+// It falls back to the toolset type when no metadata is available.
+func ToolsetIdentifier(ts ToolSet) string {
+	if meta, ok := As[ToolsetMetadata](ts); ok {
+		label := strings.TrimSpace(meta.ToolsetID())
+		if label != "" {
+			return label
+		}
+	}
+
+	return fmt.Sprintf("%T", ts)
+}

--- a/pkg/tools/startable.go
+++ b/pkg/tools/startable.go
@@ -2,8 +2,31 @@ package tools
 
 import (
 	"context"
+	"fmt"
 	"sync"
 )
+
+// Describer can be implemented by a ToolSet to provide a short, user-visible
+// description that uniquely identifies the toolset instance (e.g. for use in
+// error messages and warnings). The string must never contain secrets.
+type Describer interface {
+	Describe() string
+}
+
+// DescribeToolSet returns a short description for ts suitable for user-visible
+// messages. It unwraps a StartableToolSet, then delegates to Describer if
+// implemented. Falls back to the Go type name when not.
+func DescribeToolSet(ts ToolSet) string {
+	if s, ok := ts.(*StartableToolSet); ok {
+		ts = s.ToolSet
+	}
+	if d, ok := ts.(Describer); ok {
+		if desc := d.Describe(); desc != "" {
+			return desc
+		}
+	}
+	return fmt.Sprintf("%T", ts)
+}
 
 // StartableToolSet wraps a ToolSet with lazy, single-flight start semantics.
 // This is the canonical way to manage toolset lifecycle.

--- a/pkg/tools/startable_test.go
+++ b/pkg/tools/startable_test.go
@@ -1,0 +1,59 @@
+package tools_test
+
+import (
+	"context"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+
+	"github.com/docker/cagent/pkg/tools"
+)
+
+// stubDescriber implements ToolSet and Describer.
+type stubDescriber struct{ desc string }
+
+func (s *stubDescriber) Tools(context.Context) ([]tools.Tool, error) { return nil, nil }
+func (s *stubDescriber) Describe() string                            { return s.desc }
+
+// stubToolSet implements ToolSet only (no Describer).
+type stubToolSet struct{}
+
+func (s *stubToolSet) Tools(context.Context) ([]tools.Tool, error) { return nil, nil }
+
+func TestDescribeToolSet_UsesDescriber(t *testing.T) {
+	t.Parallel()
+
+	ts := &stubDescriber{desc: "mcp(ref=docker:github-official)"}
+	assert.Check(t, is.Equal(tools.DescribeToolSet(ts), "mcp(ref=docker:github-official)"))
+}
+
+func TestDescribeToolSet_UnwrapsStartableAndUsesDescriber(t *testing.T) {
+	t.Parallel()
+
+	inner := &stubDescriber{desc: "mcp(stdio cmd=python args=-m,srv)"}
+	wrapped := tools.NewStartable(inner)
+	assert.Check(t, is.Equal(tools.DescribeToolSet(wrapped), "mcp(stdio cmd=python args=-m,srv)"))
+}
+
+func TestDescribeToolSet_FallsBackToTypeName(t *testing.T) {
+	t.Parallel()
+
+	ts := &stubToolSet{}
+	assert.Check(t, is.Equal(tools.DescribeToolSet(ts), "*tools_test.stubToolSet"))
+}
+
+func TestDescribeToolSet_FallsBackToTypeNameWhenDescribeEmpty(t *testing.T) {
+	t.Parallel()
+
+	ts := &stubDescriber{desc: ""}
+	assert.Check(t, is.Equal(tools.DescribeToolSet(ts), "*tools_test.stubDescriber"))
+}
+
+func TestDescribeToolSet_UnwrapsStartableAndFallsBackToTypeName(t *testing.T) {
+	t.Parallel()
+
+	inner := &stubToolSet{}
+	wrapped := tools.NewStartable(inner)
+	assert.Check(t, is.Equal(tools.DescribeToolSet(wrapped), "*tools_test.stubToolSet"))
+}


### PR DESCRIPTION
Error messages now display `mcp(stdio cmd=python) ... failed` instead of `*mcp.Toolset .. failed`, helping users identify which specific toolset failed.

This commit adds a Describer interface that toolsets can implement to provide short, user-visible descriptions (never containing secrets).

Implementations:
- MCP stdio toolsets show command and args: "mcp(stdio cmd=python args_len=2)"
- MCP remote toolsets show host and transport: "mcp(remote host=api.com transport=sse)"
- MCP gateway toolsets show the server reference: "mcp(ref=github-official)"
- Memory tools show database path when available: "memory(path=/tmp/agent.db)"

<img width="638" height="153" alt="image" src="https://github.com/user-attachments/assets/0ad36d2a-5eea-4e6d-8c44-6f0ed932a893" />
