### PR TITLE
Nightly scanner should be less nit-picky about docs

### DIFF
--- a/.github/agents/nightly-scanner.yaml
+++ b/.github/agents/nightly-scanner.yaml
@@ -272,7 +272,13 @@ agents:
     model: claude-haiku
     description: Documentation gaps and improvements
     instruction: |
-      You analyze code for documentation issues. Only report significant gaps.
+      You analyze markdown documentation files for issues. Only report significant gaps.
+
+      ## ⚠️ SCOPE: Markdown files only
+
+      You MUST only report issues about `.md` files (README.md, CONTRIBUTING.md, etc.).
+      Do NOT report issues about source code files (.go, .py, .js, etc.) — missing
+      doc comments, package docs, or inline comments are out of scope.
 
       ## First: Read existing documentation
 
@@ -286,8 +292,8 @@ agents:
 
       ## ⛔ GROUNDING RULES ⛔
 
-      - **ONLY report issues in files you have actually read**
-      - **Focus on public APIs and exported functions**
+      - **ONLY report issues in `.md` files you have actually read**
+      - **NEVER report issues about source code files**
 
       ## Important: No findings is a valid outcome
 
@@ -295,20 +301,24 @@ agents:
       Do NOT manufacture issues just to have something to report. Quality over quantity.
       Many codebases are well-documented - finding nothing wrong is a positive outcome.
 
-      ## What to look for
+      **Default to `NO_ISSUES`.** Only report something if it would genuinely confuse
+      or block a new contributor trying to set up, build, or use the project.
 
-      - Exported functions/types with no documentation
-      - Complex algorithms without explanations
-      - Missing package-level documentation
-      - Outdated comments that don't match code
-      - Missing README sections for key features
+      ## What to look for (ONLY high-impact issues)
+
+      - Factually incorrect or dangerously outdated information (e.g., wrong commands, deprecated APIs)
+      - Missing setup/install/build instructions that would block a new contributor
+      - Broken links to critical resources
 
       ## What to IGNORE
 
-      - Internal/private functions
-      - Simple getter/setter methods
+      - Source code files (Go, Python, JS, etc.) — no doc comment issues
       - Test files
       - Generated code
+      - Minor wording improvements, typos, or style nits
+      - "Nice to have" sections that aren't blocking anyone
+      - Missing docs for internal or advanced features
+      - Incomplete CONTRIBUTING guidelines (unless setup steps are wrong/missing)
 
       ## Output format
 

--- a/.github/workflows/auto-issue-triage.yml
+++ b/.github/workflows/auto-issue-triage.yml
@@ -110,7 +110,8 @@ jobs:
           echo "--------------------"
 
           # Search for the result marker anywhere in the output (LLMs often add trailing empty lines)
-          RESULT=$(grep -oE 'RESULT:(NEEDS_INFO|FIXED|NO_CHANGES)' "$OUTPUT_FILE" | tail -n 1)
+          # Use || true to prevent grep exit code 1 (no match) from failing the step under pipefail
+          RESULT=$(grep -oE 'RESULT:(NEEDS_INFO|FIXED|NO_CHANGES)' "$OUTPUT_FILE" | tail -n 1 || true)
           if [[ "$RESULT" == "RESULT:NEEDS_INFO" ]]; then
             echo "action=needs_info" >> "$GITHUB_OUTPUT"
           elif [[ "$RESULT" == "RESULT:FIXED" ]]; then


### PR DESCRIPTION
## Summary

The nightly codebase scanner's documentation agent was filing issues about missing doc comments in Go source files (e.g., #1912). This PR scopes the documentation agent to only analyze `.md` files, raises the bar so it only reports high-impact issues, and fixes a `pipefail` crash in the auto-issue-triage workflow.

## Changes

**Nightly scanner documentation agent** (`nightly-scanner.yaml`):
- Restricted scope to `.md` files only — source code doc comments are no longer in scope
- Replaced the "what to look for" list with high-impact-only criteria: factually incorrect info, missing setup/build steps, broken critical links
- Expanded the "what to ignore" list to explicitly exclude style nits, typos, nice-to-have sections, and internal feature docs
- Added a default-to-`NO_ISSUES` directive so findings only get reported if they would genuinely block or mislead a contributor

**Auto-issue-triage workflow** (`auto-issue-triage.yml`):
- Fixed `grep` exit code 1 causing the "Parse agent result" step to fail under bash `pipefail` when the agent output contains no `RESULT:` marker (e.g., [this run](https://github.com/docker/cagent/actions/runs/22653191673))

## Test plan

- [ ] Trigger a dry-run of the nightly scan (`workflow_dispatch` with dry-run=true) and verify the documentation agent only analyzes `.md` files
- [ ] Verify the auto-issue-triage workflow no longer fails at the "Parse agent result" step when the agent doesn't output a result marker