### PR TITLE
Support auto-downloading tools

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -848,6 +848,10 @@
           "items": {
             "type": "string"
           }
+        },
+        "version": {
+          "type": "string",
+          "description": "Package reference for auto-installation of MCP/LSP tool binaries. Format: 'owner/repo' or 'owner/repo@version'. Set to 'false' to disable auto-install for this toolset."
         }
       },
       "additionalProperties": false,

--- a/docs/configuration/overview/index.md
+++ b/docs/configuration/overview/index.md
@@ -146,6 +146,13 @@ API keys and secrets are read from environment variables — never stored in con
 | `XAI_API_KEY`       | xAI           |
 | `NEBIUS_API_KEY`    | Nebius        |
 
+**Tool Auto-Installation:**
+
+| Variable              | Description                                                     |
+| --------------------- | --------------------------------------------------------------- |
+| `DOCKER_AGENT_AUTO_INSTALL` | Set to `false` to disable automatic tool installation           |
+| `DOCKER_AGENT_TOOLS_DIR`    | Override the base directory for installed tools (default: `~/.cagent/tools/`) |
+
 <div class="callout callout-warning">
 <div class="callout-title">⚠️ Important
 </div>

--- a/docs/configuration/tools/index.md
+++ b/docs/configuration/tools/index.md
@@ -322,6 +322,7 @@ toolsets:
 | `tools`       | array  | Optional: only expose these tools                     |
 | `env`         | array  | Environment variables (`"KEY=value"` format)          |
 | `instruction` | string | Custom instructions injected into the agent's context |
+| `version`     | string | Package reference for [auto-installing](#auto-installing-tools) the command binary |
 
 ### Remote MCP (SSE / Streamable HTTP)
 
@@ -343,6 +344,81 @@ toolsets:
 | `remote.url`            | string | Base URL of the MCP server        |
 | `remote.transport_type` | string | `sse` or `streamable`             |
 | `remote.headers`        | object | HTTP headers (typically for auth) |
+
+## Auto-Installing Tools
+
+When configuring MCP or LSP tools that require a binary command, cagent can **automatically download and install** the command if it's not already available on your system. This uses the [aqua registry](https://github.com/aquaproj/aqua-registry) — a curated index of CLI tool packages.
+
+### How It Works
+
+1. When a toolset with a `command` is loaded, cagent checks if the command is available in your `PATH`
+2. If not found, it checks the cagent tools directory (`~/.cagent/tools/bin/`)
+3. If still not found, it looks up the command in the aqua registry and installs it automatically
+
+### Explicit Package Reference
+
+Use the `version` property to specify exactly which package to install:
+
+```yaml
+toolsets:
+  - type: mcp
+    command: gopls
+    version: "golang/tools@v0.25.0"
+    args: ["mcp"]
+  - type: lsp
+    command: rust-analyzer
+    version: "rust-lang/rust-analyzer@2024-01-01"
+    file_types: [".rs"]
+```
+
+The format is `owner/repo` or `owner/repo@version`. When a version is omitted, the latest release is used.
+
+### Automatic Detection
+
+If the `version` property is not set, cagent tries to auto-detect the package from the command name by searching the aqua registry:
+
+```yaml
+toolsets:
+  - type: mcp
+    command: gopls  # auto-detected as golang/tools
+    args: ["mcp"]
+```
+
+### Disabling Auto-Install
+
+You can disable auto-installation in two ways:
+
+**Per toolset** — set `version` to `"false"` or `"off"`:
+
+```yaml
+toolsets:
+  - type: mcp
+    command: my-custom-server
+    version: "false"
+```
+
+**Globally** — set the `DOCKER_AGENT_AUTO_INSTALL` environment variable:
+
+```bash
+export DOCKER_AGENT_AUTO_INSTALL=false
+```
+
+### Environment Variables
+
+| Variable              | Default                | Description                                      |
+| --------------------- | ---------------------- | ------------------------------------------------ |
+| `DOCKER_AGENT_AUTO_INSTALL` | (enabled)              | Set to `false` to disable all auto-installation  |
+| `DOCKER_AGENT_TOOLS_DIR`    | `~/.cagent/tools/`     | Base directory for installed tools               |
+| `GITHUB_TOKEN`        | —                      | GitHub token to raise API rate limits (optional) |
+
+Installed binaries are placed in `~/.cagent/tools/bin/` and cached so they are only downloaded once.
+
+<div class="callout callout-tip">
+<div class="callout-title">💡 Tip
+</div>
+  <p>Auto-install supports both Go packages (via <code>go install</code>) and GitHub release binaries (via archive download). The aqua registry metadata determines which method is used.</p>
+
+</div>
 
 ## Tool Filtering
 

--- a/docs/tools/lsp/index.md
+++ b/docs/tools/lsp/index.md
@@ -44,6 +44,7 @@ agents:
 | `args`       | array  | ✗        | Command-line arguments for the LSP server                  |
 | `env`        | object | ✗        | Environment variables for the LSP process                  |
 | `file_types` | array  | ✗        | File extensions this LSP handles (e.g., `[".go", ".mod"]`) |
+| `version`    | string | ✗        | Package reference for [auto-installing](/configuration/tools/#auto-installing-tools) the command binary (e.g., `"golang/tools@v0.25.0"`) |
 
 ## Available Tools
 
@@ -77,6 +78,7 @@ Here are configurations for popular languages:
 toolsets:
   - type: lsp
     command: gopls
+    version: "golang/tools@v0.25.0" # optional: auto-install if not in PATH
     file_types: [".go"]
 ```
 
@@ -196,9 +198,9 @@ All LSP tools use **1-based** line and character positions:
 }
 ```
 
-<div class="callout callout-warning">
-<div class="callout-title">⚠️ Server Installation
+<div class="callout callout-tip">
+<div class="callout-title">💡 Auto-Installation
 </div>
-  <p>The LSP server must be installed and available in the system PATH. docker-agent does not install LSP servers automatically. Install them using your language's package manager (e.g., <code>go install golang.org/x/tools/gopls@latest</code>).</p>
+  <p>docker-agent can automatically download and install LSP servers if they are not found in your PATH. Use the <code>version</code> property to specify a package, or let docker-agent auto-detect it from the command name. See <a href="/configuration/tools/#auto-installing-tools">Auto-Installing Tools</a> for details.</p>
 
 </div>

--- a/examples/elicitation/demo.yaml
+++ b/examples/elicitation/demo.yaml
@@ -37,5 +37,6 @@ agents:
     toolsets:
       - type: mcp
         command: uvx
+        version: "astral-sh/uv"
         args:
           ["--with", "mcp[cli]", "mcp", "run", "examples/elicitation/server.py"]

--- a/examples/finance.yaml
+++ b/examples/finance.yaml
@@ -50,6 +50,7 @@ agents:
     toolsets:
       - type: mcp
         command: uvx
+        version: "astral-sh/uv"
         args: ["yfmcp"]
 
   web_search_agent:

--- a/examples/gopher.yaml
+++ b/examples/gopher.yaml
@@ -65,6 +65,7 @@ agents:
       - type: todo
       - type: mcp
         command: gopls
+        version: "golang/tools@v0.25.0"
         args: ["mcp"]
     commands:
       fix-lint:
@@ -164,6 +165,7 @@ agents:
       - type: shell
       - type: mcp
         command: gopls
+        version: "golang/tools@v0.25.0"
         args: ["mcp"]
 
   librarian:

--- a/examples/modernize-go-tests.yaml
+++ b/examples/modernize-go-tests.yaml
@@ -87,6 +87,7 @@ agents:
       - type: todo
       - type: mcp
         command: gopls
+        version: "golang/tools@v0.25.0"
         args: ["mcp"]
         tools:
           [

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -542,6 +542,12 @@ type Toolset struct {
 	Remote  Remote   `json:"remote"`
 	Config  any      `json:"config,omitempty"`
 
+	// For `mcp` and `lsp` tools - version/package reference for auto-installation.
+	// Format: "owner/repo" or "owner/repo@version"
+	// When empty and auto-install is enabled, cagent auto-detects from the command name.
+	// Set to "false" or "off" to disable auto-install for this toolset.
+	Version string `json:"version,omitempty"`
+
 	// For the `a2a` and `openapi` tools
 	Name    string            `json:"name,omitempty"`
 	URL     string            `json:"url,omitempty"`

--- a/pkg/config/latest/validate.go
+++ b/pkg/config/latest/validate.go
@@ -85,6 +85,9 @@ func (t *Toolset) validate() error {
 	if t.Shared && t.Type != "todo" {
 		return errors.New("shared can only be used with type 'todo'")
 	}
+	if t.Version != "" && t.Type != "mcp" && t.Type != "lsp" {
+		return errors.New("version can only be used with type 'mcp' or 'lsp'")
+	}
 	if t.Command != "" && t.Type != "mcp" && t.Type != "lsp" {
 		return errors.New("command can only be used with type 'mcp' or 'lsp'")
 	}

--- a/pkg/teamloader/registry.go
+++ b/pkg/teamloader/registry.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/cagent/pkg/js"
 	"github.com/docker/cagent/pkg/memory/database/sqlite"
 	"github.com/docker/cagent/pkg/path"
+	"github.com/docker/cagent/pkg/toolinstall"
 	"github.com/docker/cagent/pkg/tools"
 	"github.com/docker/cagent/pkg/tools/a2a"
 	"github.com/docker/cagent/pkg/tools/builtin"
@@ -271,13 +272,22 @@ func createMCPTool(ctx context.Context, toolset latest.Toolset, _ string, runCon
 
 	// STDIO MCP Server from shell command
 	case toolset.Command != "":
+		// Auto-install missing command binary if needed
+		resolvedCommand, err := toolinstall.EnsureCommand(ctx, toolset.Command, toolset.Version)
+		if err != nil {
+			return nil, fmt.Errorf("resolving command %q: %w", toolset.Command, err)
+		}
+
 		env, err := environment.ExpandAll(ctx, environment.ToValues(toolset.Env), envProvider)
 		if err != nil {
 			return nil, fmt.Errorf("failed to expand the tool's environment variables: %w", err)
 		}
 		env = append(env, os.Environ()...)
 
-		return mcp.NewToolsetCommand(toolset.Name, toolset.Command, toolset.Args, env, runConfig.WorkingDir), nil
+		// Prepend tools bin dir to PATH so child processes can find installed tools
+		env = toolinstall.PrependBinDirToEnv(env)
+
+		return mcp.NewToolsetCommand(toolset.Name, resolvedCommand, toolset.Args, env, runConfig.WorkingDir), nil
 
 	// Remote MCP Server
 	case toolset.Remote.URL != "":
@@ -302,13 +312,22 @@ func createA2ATool(ctx context.Context, toolset latest.Toolset, _ string, runCon
 }
 
 func createLSPTool(ctx context.Context, toolset latest.Toolset, _ string, runConfig *config.RuntimeConfig) (tools.ToolSet, error) {
+	// Auto-install missing command binary if needed
+	resolvedCommand, err := toolinstall.EnsureCommand(ctx, toolset.Command, toolset.Version)
+	if err != nil {
+		return nil, fmt.Errorf("resolving command %q: %w", toolset.Command, err)
+	}
+
 	env, err := environment.ExpandAll(ctx, environment.ToValues(toolset.Env), runConfig.EnvProvider())
 	if err != nil {
 		return nil, fmt.Errorf("failed to expand the tool's environment variables: %w", err)
 	}
 	env = append(env, os.Environ()...)
 
-	tool := builtin.NewLSPTool(toolset.Command, toolset.Args, env, runConfig.WorkingDir)
+	// Prepend tools bin dir to PATH so child processes can find installed tools
+	env = toolinstall.PrependBinDirToEnv(env)
+
+	tool := builtin.NewLSPTool(resolvedCommand, toolset.Args, env, runConfig.WorkingDir)
 	if len(toolset.FileTypes) > 0 {
 		tool.SetFileTypes(toolset.FileTypes)
 	}

--- a/pkg/toolinstall/archive.go
+++ b/pkg/toolinstall/archive.go
@@ -1,0 +1,272 @@
+package toolinstall
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+)
+
+// templateData holds the variables available in aqua asset name templates.
+type templateData struct {
+	Version string
+	OS      string
+	Arch    string
+	Format  string
+}
+
+var templateFuncs = template.FuncMap{
+	"trimV": func(s string) string { return strings.TrimPrefix(s, "v") },
+}
+
+// renderTemplate renders a Go template string with the given data.
+func renderTemplate(tmplStr string, data templateData) (string, error) {
+	tmpl, err := template.New("asset").Funcs(templateFuncs).Parse(tmplStr)
+	if err != nil {
+		return "", fmt.Errorf("parsing template %q: %w", tmplStr, err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("executing template %q: %w", tmplStr, err)
+	}
+
+	return buf.String(), nil
+}
+
+// extractRelease extracts files from a release asset stream based on format.
+// For tar.gz, the response body is streamed directly through gzip → tar.
+// For zip, the body is spooled to a temporary file (zip requires random access).
+// Raw/single-binary formats are handled by the caller before reaching this function.
+func extractRelease(body io.ReadCloser, destDir, format string, files []PackageFile, tmplData templateData) error {
+	switch format {
+	case "tar.gz", "tgz":
+		return extractTarGz(body, destDir, files, tmplData)
+	case "zip":
+		return extractZipFromStream(body, destDir, files, tmplData)
+	default:
+		return fmt.Errorf("unsupported archive format: %s", format)
+	}
+}
+
+// writeRawBinary writes a raw (non-archived) binary stream directly to destPath
+// with executable permissions.
+func writeRawBinary(r io.Reader, destPath string) error {
+	f, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		return fmt.Errorf("creating raw binary %s: %w", destPath, err)
+	}
+
+	_, copyErr := io.Copy(f, r) //nolint:gosec // binary size bounded by GitHub release asset limits
+	closeErr := f.Close()
+
+	if copyErr != nil {
+		return fmt.Errorf("writing raw binary %s: %w", destPath, copyErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("closing raw binary %s: %w", destPath, closeErr)
+	}
+
+	return nil
+}
+
+// extractTarGz extracts files from a tar.gz archive.
+// It reads from the provided reader in a streaming fashion (gzip → tar)
+// without buffering the entire archive in memory.
+func extractTarGz(r io.Reader, destDir string, files []PackageFile, tmplData templateData) error {
+	gzReader, err := gzip.NewReader(r)
+	if err != nil {
+		return fmt.Errorf("extracting tar.gz: %w", err)
+	}
+	defer gzReader.Close()
+
+	tarReader := tar.NewReader(gzReader)
+
+	fileMap, err := buildFileMap(files, tmplData)
+	if err != nil {
+		return err
+	}
+
+	for {
+		header, err := tarReader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("extracting tar.gz: %w", err)
+		}
+
+		if header.Typeflag != tar.TypeReg {
+			continue
+		}
+
+		destName, ok := matchFile(header.Name, fileMap)
+		if !ok {
+			continue
+		}
+
+		destPath, err := safePath(destDir, destName)
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+			return err
+		}
+
+		f, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+		if err != nil {
+			return err
+		}
+
+		_, copyErr := io.Copy(f, tarReader) //nolint:gosec // archive size bounded by GitHub release asset limits
+		f.Close()
+		if copyErr != nil {
+			return copyErr
+		}
+	}
+
+	return nil
+}
+
+// extractZip extracts files from a zip archive.
+// It requires random access via io.ReaderAt; callers should provide either
+// an *os.File (spooled to a temp file) or a *bytes.Reader.
+func extractZip(ra io.ReaderAt, size int64, destDir string, files []PackageFile, tmplData templateData) error {
+	reader, err := zip.NewReader(ra, size)
+	if err != nil {
+		return fmt.Errorf("extracting zip: %w", err)
+	}
+
+	fileMap, err := buildFileMap(files, tmplData)
+	if err != nil {
+		return err
+	}
+
+	for _, f := range reader.File {
+		if f.FileInfo().IsDir() {
+			continue
+		}
+
+		destName, ok := matchFile(f.Name, fileMap)
+		if !ok {
+			continue
+		}
+
+		destPath, err := safePath(destDir, destName)
+		if err != nil {
+			return err
+		}
+
+		if err := extractZipFile(f, destPath); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func extractZipFile(f *zip.File, destPath string) error {
+	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+		return err
+	}
+
+	rc, err := f.Open()
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+
+	outFile, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		return err
+	}
+	defer outFile.Close()
+
+	_, err = io.Copy(outFile, rc) //nolint:gosec // archive size bounded by GitHub release asset limits
+	return err
+}
+
+// extractZipFromStream spools an io.Reader to a temporary file and then
+// extracts the zip archive. This avoids holding the entire archive in memory
+// while satisfying zip's requirement for random access (io.ReaderAt).
+func extractZipFromStream(r io.Reader, destDir string, files []PackageFile, tmplData templateData) error {
+	tmpFile, err := os.CreateTemp("", "cagent-zip-*.zip")
+	if err != nil {
+		return fmt.Errorf("creating temp file for zip: %w", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
+
+	size, err := io.Copy(tmpFile, r) //nolint:gosec // archive size bounded by GitHub release asset limits
+	if err != nil {
+		return fmt.Errorf("spooling zip to temp file: %w", err)
+	}
+
+	if _, err := tmpFile.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("seeking temp file: %w", err)
+	}
+
+	return extractZip(tmpFile, size, destDir, files, tmplData)
+}
+
+// buildFileMap builds a map from rendered src paths to destination binary names.
+func buildFileMap(files []PackageFile, data templateData) (map[string]string, error) {
+	m := make(map[string]string, len(files))
+	for _, f := range files {
+		src := f.Src
+		if src != "" {
+			rendered, err := renderTemplate(src, data)
+			if err != nil {
+				return nil, fmt.Errorf("rendering file src template: %w", err)
+			}
+			src = rendered
+		}
+		name := f.Name
+		if name == "" {
+			name = filepath.Base(src)
+		}
+		m[src] = name
+	}
+	return m, nil
+}
+
+// matchFile checks if an archive entry matches any expected file.
+// An empty fileMap means extract everything.
+func matchFile(entryName string, fileMap map[string]string) (string, bool) {
+	if len(fileMap) == 0 {
+		return filepath.Base(entryName), true
+	}
+
+	for src, dest := range fileMap {
+		if entryName == src || filepath.Base(entryName) == filepath.Base(src) {
+			return dest, true
+		}
+	}
+
+	return "", false
+}
+
+// errPathTraversal is returned when an archive entry attempts to write
+// outside the destination directory (Zip Slip / Tar Slip attack).
+var errPathTraversal = errors.New("archive entry attempts path traversal")
+
+// safePath validates that joining destDir with name stays within destDir.
+// Returns the cleaned absolute path or an error on path traversal.
+func safePath(destDir, name string) (string, error) {
+	destPath := filepath.Join(destDir, name)
+	cleanDest := filepath.Clean(destPath)
+	cleanDir := filepath.Clean(destDir) + string(os.PathSeparator)
+
+	if !strings.HasPrefix(cleanDest, cleanDir) {
+		return "", fmt.Errorf("%w: %q resolves to %q (outside %q)", errPathTraversal, name, cleanDest, destDir)
+	}
+
+	return cleanDest, nil
+}

--- a/pkg/toolinstall/archive_test.go
+++ b/pkg/toolinstall/archive_test.go
@@ -1,0 +1,268 @@
+package toolinstall
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderTemplate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		template string
+		data     templateData
+		expected string
+	}{
+		{
+			"basic template",
+			"tool_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}",
+			templateData{Version: "1.0.0", OS: "linux", Arch: "amd64", Format: "tar.gz"},
+			"tool_1.0.0_linux_amd64.tar.gz",
+		},
+		{
+			"with macOS replacement",
+			"gh_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}",
+			templateData{Version: "2.50.0", OS: "macOS", Arch: "arm64", Format: "tar.gz"},
+			"gh_2.50.0_macOS_arm64.tar.gz",
+		},
+		{
+			"trimV function",
+			"tool_{{trimV .Version}}_{{.OS}}.{{.Format}}",
+			templateData{Version: "v1.2.3", OS: "linux", Arch: "amd64", Format: "tar.gz"},
+			"tool_1.2.3_linux.tar.gz",
+		},
+		{
+			"no template markers",
+			"static-name.tar.gz",
+			templateData{Version: "1.0.0", OS: "linux", Arch: "amd64", Format: "tar.gz"},
+			"static-name.tar.gz",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := renderTemplate(tt.template, tt.data)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestRenderTemplate_Invalid(t *testing.T) {
+	t.Parallel()
+
+	_, err := renderTemplate("{{.Invalid", templateData{})
+	require.Error(t, err)
+}
+
+func TestWriteRawBinary(t *testing.T) {
+	t.Parallel()
+
+	destDir := t.TempDir()
+	destPath := filepath.Join(destDir, "mytool")
+	content := "#!/bin/sh\necho hello"
+
+	err := writeRawBinary(strings.NewReader(content), destPath)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(destPath)
+	require.NoError(t, err)
+	assert.Equal(t, content, string(data))
+
+	info, err := os.Stat(destPath)
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode()&0o111, "binary should be executable")
+}
+
+func TestWriteRawBinary_ErrorOnBadPath(t *testing.T) {
+	t.Parallel()
+
+	err := writeRawBinary(strings.NewReader("data"), "/nonexistent/dir/binary")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "creating raw binary")
+}
+
+func TestExtractTarGz(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	content := []byte("#!/bin/sh\necho hello")
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name: "tool_1.0.0_linux/bin/mytool",
+		Mode: 0o755,
+		Size: int64(len(content)),
+	}))
+	_, err := tw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+
+	destDir := t.TempDir()
+	files := []PackageFile{{Name: "mytool", Src: "tool_{{.Version}}_{{.OS}}/bin/mytool"}}
+	data := templateData{Version: "1.0.0", OS: "linux", Arch: "amd64"}
+
+	require.NoError(t, extractTarGz(&buf, destDir, files, data))
+
+	extracted, err := os.ReadFile(filepath.Join(destDir, "mytool"))
+	require.NoError(t, err)
+	assert.Equal(t, content, extracted)
+}
+
+func TestExtractZip(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	content := []byte("#!/bin/sh\necho hello")
+	fw, err := zw.Create("tool_1.0.0/bin/mytool")
+	require.NoError(t, err)
+	_, err = fw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+
+	destDir := t.TempDir()
+	files := []PackageFile{{Name: "mytool", Src: "tool_{{.Version}}/bin/mytool"}}
+	data := templateData{Version: "1.0.0", OS: "linux", Arch: "amd64"}
+
+	require.NoError(t, extractZip(bytes.NewReader(buf.Bytes()), int64(buf.Len()), destDir, files, data))
+
+	extracted, err := os.ReadFile(filepath.Join(destDir, "mytool"))
+	require.NoError(t, err)
+	assert.Equal(t, content, extracted)
+}
+
+func TestBuildFileMap(t *testing.T) {
+	t.Parallel()
+
+	files := []PackageFile{{Name: "gh", Src: "gh_{{.Version}}_{{.OS}}/bin/gh"}}
+	data := templateData{Version: "2.50.0", OS: "macOS", Arch: "arm64"}
+
+	m, err := buildFileMap(files, data)
+	require.NoError(t, err)
+	assert.Equal(t, "gh", m["gh_2.50.0_macOS/bin/gh"])
+}
+
+func TestMatchFile(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		entry    string
+		fileMap  map[string]string
+		wantName string
+		wantOK   bool
+	}{
+		{"exact match", "a/b/gh", map[string]string{"a/b/gh": "gh"}, "gh", true},
+		{"basename match", "other/path/gh", map[string]string{"a/b/gh": "gh"}, "gh", true},
+		{"no match", "other", map[string]string{"a/b/gh": "gh"}, "", false},
+		{"empty map extracts all", "some/binary", map[string]string{}, "binary", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			name, ok := matchFile(tt.entry, tt.fileMap)
+			assert.Equal(t, tt.wantOK, ok)
+			if ok {
+				assert.Equal(t, tt.wantName, name)
+			}
+		})
+	}
+}
+
+func TestSafePath(t *testing.T) {
+	t.Parallel()
+
+	destDir := t.TempDir()
+
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"simple name", "mytool", false},
+		{"nested path", "bin/mytool", false},
+		{"dot-dot traversal", "../../etc/passwd", true},
+		{"hidden traversal", "foo/../../etc/passwd", true},
+		{"dot prefix", "../mytool", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := safePath(destDir, tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, errPathTraversal)
+				return
+			}
+			require.NoError(t, err)
+			assert.Contains(t, result, destDir)
+		})
+	}
+}
+
+func TestExtractTarGz_PathTraversal(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	content := []byte("malicious")
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name: "evil",
+		Mode: 0o755,
+		Size: int64(len(content)),
+	}))
+	_, err := tw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+
+	destDir := t.TempDir()
+	// Map entry to a traversal dest name.
+	files := []PackageFile{{Name: "../../etc/passwd", Src: "evil"}}
+	err = extractTarGz(&buf, destDir, files, templateData{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errPathTraversal)
+}
+
+func TestExtractZip_PathTraversal(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	content := []byte("malicious")
+	fw, err := zw.Create("evil")
+	require.NoError(t, err)
+	_, err = fw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+
+	destDir := t.TempDir()
+	// Map entry to a traversal dest name.
+	files := []PackageFile{{Name: "../../etc/passwd", Src: "evil"}}
+	err = extractZip(bytes.NewReader(buf.Bytes()), int64(buf.Len()), destDir, files, templateData{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errPathTraversal)
+}

--- a/pkg/toolinstall/installer.go
+++ b/pkg/toolinstall/installer.go
@@ -1,0 +1,234 @@
+package toolinstall
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// Install downloads and installs a package at the specified version.
+// Returns the path to the installed binary.
+func (r *Registry) Install(ctx context.Context, pkg *Package, version string) (string, error) {
+	if pkg.IsGoPackage() {
+		return installGoPackage(ctx, pkg, version)
+	}
+	return r.installGitHubRelease(ctx, pkg, version)
+}
+
+// installGoPackage installs a Go package using "go install".
+func installGoPackage(ctx context.Context, pkg *Package, version string) (string, error) {
+	binaryName := pkg.BinaryName()
+	if binaryName == "" {
+		return "", fmt.Errorf("cannot determine binary name for %s/%s", pkg.RepoOwner, pkg.RepoName)
+	}
+
+	binDir := BinDir()
+	binaryPath := filepath.Join(binDir, binaryName)
+
+	// Already installed?
+	if _, err := os.Stat(binaryPath); err == nil {
+		return binaryPath, nil
+	}
+
+	// Determine the Go module path.
+	goPath := pkg.GoInstallPath
+	if goPath == "" {
+		if pkg.RepoOwner == "golang" {
+			goPath = fmt.Sprintf("golang.org/x/%s/%s", pkg.RepoName, binaryName)
+		} else {
+			goPath = fmt.Sprintf("github.com/%s/%s", pkg.RepoOwner, pkg.RepoName)
+		}
+	}
+
+	// Strip multi-module tag prefix: "gopls/v0.21.1" → "v0.21.1".
+	installVersion := version
+	if idx := strings.LastIndex(version, "/"); idx >= 0 {
+		installVersion = version[idx+1:]
+	}
+	if !strings.HasPrefix(installVersion, "v") && installVersion != "latest" {
+		installVersion = "v" + installVersion
+	}
+
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		return "", fmt.Errorf("creating bin directory: %w", err)
+	}
+
+	installArg := goPath + "@" + installVersion
+	cmd := exec.CommandContext(ctx, "go", "install", installArg)
+	cmd.Env = append(os.Environ(), "GOBIN="+binDir)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("go install %s: %w", installArg, err)
+	}
+
+	if _, err := os.Stat(binaryPath); err != nil {
+		return "", fmt.Errorf("binary %q not found after go install %s", binaryName, installArg)
+	}
+
+	return binaryPath, nil
+}
+
+// installGitHubRelease downloads and installs a package from GitHub releases.
+func (r *Registry) installGitHubRelease(ctx context.Context, pkg *Package, version string) (string, error) {
+	binaryName := pkg.BinaryName()
+	if binaryName == "" {
+		return "", fmt.Errorf("cannot determine binary name for %s/%s", pkg.RepoOwner, pkg.RepoName)
+	}
+
+	pkgDir := PackageDir(pkg.RepoOwner, pkg.RepoName, version)
+	binaryPath := filepath.Join(pkgDir, binaryName)
+
+	// Already installed?
+	if _, err := os.Stat(binaryPath); err == nil {
+		if err := ensureSymlink(binaryName, binaryPath); err != nil {
+			return "", err
+		}
+		return binaryPath, nil
+	}
+
+	pc := resolveForPlatform(pkg, version)
+
+	assetName, err := renderTemplate(pc.Asset, pc.TemplateData)
+	if err != nil {
+		return "", fmt.Errorf("rendering asset template: %w", err)
+	}
+
+	downloadURL := fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/%s",
+		pkg.RepoOwner, pkg.RepoName, version, assetName)
+
+	body, err := r.download(ctx, downloadURL)
+	if err != nil {
+		return "", fmt.Errorf("downloading %s: %w", downloadURL, err)
+	}
+	defer body.Close()
+
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		return "", fmt.Errorf("creating package directory: %w", err)
+	}
+
+	switch pc.Format {
+	case "raw", "":
+		// Single-binary download — write the body directly to binaryPath.
+		if err := writeRawBinary(body, binaryPath); err != nil {
+			return "", err
+		}
+	default:
+		if err := extractRelease(body, pkgDir, pc.Format, pc.Files, pc.TemplateData); err != nil {
+			return "", err
+		}
+	}
+
+	if err := os.Chmod(binaryPath, 0o755); err != nil {
+		return "", fmt.Errorf("setting executable permissions: %w", err)
+	}
+
+	if err := ensureSymlink(binaryName, binaryPath); err != nil {
+		return "", err
+	}
+
+	return binaryPath, nil
+}
+
+// platformConfig holds all platform-resolved package fields needed for
+// downloading and extracting a release asset.
+type platformConfig struct {
+	Format       string
+	Asset        string
+	Files        []PackageFile
+	TemplateData templateData
+}
+
+// resolveForPlatform applies platform-specific overrides from pkg.Overrides
+// in a single pass and returns a fully merged view for the current OS/arch.
+func resolveForPlatform(pkg *Package, version string) platformConfig {
+	format := pkg.Format
+	asset := pkg.Asset
+	files := pkg.Files
+	replacements := pkg.Replacements
+
+	for _, o := range pkg.Overrides {
+		if o.GOOS != "" && o.GOOS != runtime.GOOS {
+			continue
+		}
+		if o.GOArch != "" && o.GOArch != runtime.GOARCH {
+			continue
+		}
+		if o.Format != "" {
+			format = o.Format
+		}
+		if o.Asset != "" {
+			asset = o.Asset
+		}
+		if len(o.Files) > 0 {
+			files = o.Files
+		}
+		if len(o.Replacements) > 0 {
+			if replacements == nil {
+				replacements = make(map[string]string)
+			}
+			for k, v := range o.Replacements {
+				replacements[k] = v
+			}
+		}
+	}
+
+	osName := runtime.GOOS
+	archName := runtime.GOARCH
+	if r, ok := replacements[runtime.GOOS]; ok {
+		osName = r
+	}
+	if r, ok := replacements[runtime.GOARCH]; ok {
+		archName = r
+	}
+
+	templateVersion := version
+	if pkg.VersionPrefix == "" {
+		templateVersion = strings.TrimPrefix(version, "v")
+	}
+
+	return platformConfig{
+		Format: format,
+		Asset:  asset,
+		Files:  files,
+		TemplateData: templateData{
+			Version: templateVersion,
+			OS:      osName,
+			Arch:    archName,
+			Format:  format,
+		},
+	}
+}
+
+// ensureSymlink atomically creates a symlink in BinDir() pointing to the binary.
+// It uses a temporary symlink + rename to avoid TOCTOU races when multiple
+// goroutines create symlinks concurrently.
+func ensureSymlink(name, target string) error {
+	binDir := BinDir()
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		return fmt.Errorf("creating bin directory: %w", err)
+	}
+
+	link := filepath.Join(binDir, name)
+
+	// Create a temporary symlink in the same directory, then atomically
+	// rename it over the target. This avoids the Remove+Symlink TOCTOU race.
+	tmpLink := link + ".tmp." + fmt.Sprintf("%d", os.Getpid())
+	_ = os.Remove(tmpLink) // clean up any stale temp from a previous crash
+
+	if err := os.Symlink(target, tmpLink); err != nil {
+		return fmt.Errorf("creating temp symlink %s -> %s: %w", tmpLink, target, err)
+	}
+
+	if err := os.Rename(tmpLink, link); err != nil {
+		_ = os.Remove(tmpLink)
+		return fmt.Errorf("renaming symlink %s -> %s: %w", tmpLink, link, err)
+	}
+
+	return nil
+}

--- a/pkg/toolinstall/installer_test.go
+++ b/pkg/toolinstall/installer_test.go
@@ -1,0 +1,382 @@
+package toolinstall
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveForPlatform_Replacements(t *testing.T) {
+	t.Parallel()
+
+	pkg := &Package{
+		Replacements: map[string]string{
+			"darwin": "macOS",
+			"linux":  "linux",
+			"amd64":  "x86_64",
+		},
+	}
+
+	pc := resolveForPlatform(pkg, "v2.50.0")
+	assert.Equal(t, "2.50.0", pc.TemplateData.Version)
+	assert.NotEmpty(t, pc.TemplateData.OS)
+	assert.NotEmpty(t, pc.TemplateData.Arch)
+}
+
+func TestResolveForPlatform_VersionPrefixPreservesV(t *testing.T) {
+	t.Parallel()
+
+	pc := resolveForPlatform(&Package{VersionPrefix: "v"}, "v2.50.0")
+	assert.Equal(t, "v2.50.0", pc.TemplateData.Version)
+}
+
+func TestResolveForPlatform_Defaults(t *testing.T) {
+	t.Parallel()
+
+	pkg := &Package{
+		Format: "tar.gz",
+		Asset:  "tool_{{.Version}}.tar.gz",
+		Files:  []PackageFile{{Name: "tool", Src: "tool"}},
+	}
+
+	pc := resolveForPlatform(pkg, "v1.0.0")
+	assert.Equal(t, "tar.gz", pc.Format)
+	assert.Equal(t, "tool_{{.Version}}.tar.gz", pc.Asset)
+	require.Len(t, pc.Files, 1)
+	assert.Equal(t, "1.0.0", pc.TemplateData.Version)
+	assert.Equal(t, "tar.gz", pc.TemplateData.Format)
+	assert.NotEmpty(t, pc.TemplateData.OS)
+	assert.NotEmpty(t, pc.TemplateData.Arch)
+}
+
+func TestEnsureSymlink(t *testing.T) {
+	t.Setenv("DOCKER_AGENT_TOOLS_DIR", t.TempDir())
+
+	binaryPath := filepath.Join(ToolsDir(), "packages", "cli", "cli", "v1", "gh")
+	require.NoError(t, os.MkdirAll(filepath.Dir(binaryPath), 0o755))
+	require.NoError(t, os.WriteFile(binaryPath, []byte("#!/bin/sh\necho test"), 0o755))
+
+	require.NoError(t, ensureSymlink("gh", binaryPath))
+
+	target, err := os.Readlink(filepath.Join(BinDir(), "gh"))
+	require.NoError(t, err)
+	assert.Equal(t, binaryPath, target)
+
+	// Idempotent.
+	require.NoError(t, ensureSymlink("gh", binaryPath))
+}
+
+func TestInstall_AlreadyInstalled_GitHubRelease(t *testing.T) {
+	t.Setenv("DOCKER_AGENT_TOOLS_DIR", t.TempDir())
+
+	pkg := &Package{
+		RepoOwner: "cli",
+		RepoName:  "cli",
+		Files:     []PackageFile{{Name: "gh"}},
+	}
+
+	pkgDir := PackageDir("cli", "cli", "v2.50.0")
+	require.NoError(t, os.MkdirAll(pkgDir, 0o755))
+	binaryPath := filepath.Join(pkgDir, "gh")
+	require.NoError(t, os.WriteFile(binaryPath, []byte("binary"), 0o755))
+
+	result, err := (&Registry{httpClient: http.DefaultClient}).Install(t.Context(), pkg, "v2.50.0")
+	require.NoError(t, err)
+	assert.Equal(t, binaryPath, result)
+}
+
+func TestInstall_AlreadyInstalled_GoPackage(t *testing.T) {
+	t.Setenv("DOCKER_AGENT_TOOLS_DIR", t.TempDir())
+
+	pkg := &Package{
+		Type:          "go_install",
+		RepoOwner:     "golang",
+		RepoName:      "tools",
+		GoInstallPath: "golang.org/x/tools/gopls",
+		Files:         []PackageFile{{Name: "gopls"}},
+	}
+
+	require.NoError(t, os.MkdirAll(BinDir(), 0o755))
+	binaryPath := filepath.Join(BinDir(), "gopls")
+	require.NoError(t, os.WriteFile(binaryPath, []byte("binary"), 0o755))
+
+	result, err := (&Registry{httpClient: http.DefaultClient}).Install(t.Context(), pkg, "v0.21.1")
+	require.NoError(t, err)
+	assert.Equal(t, binaryPath, result)
+}
+
+func TestInstall_RawFormat(t *testing.T) {
+	t.Setenv("DOCKER_AGENT_TOOLS_DIR", t.TempDir())
+
+	binaryContent := "#!/bin/sh\necho hello"
+
+	pkg := &Package{
+		RepoOwner: "test",
+		RepoName:  "raw-tool",
+		Format:    "raw",
+		Asset:     "raw-tool",
+		Files:     []PackageFile{{Name: "raw-tool"}},
+	}
+
+	registry := &Registry{
+		httpClient: &http.Client{
+			Transport: roundTripFunc(func(_ *http.Request) *http.Response {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(binaryContent)),
+				}
+			}),
+		},
+	}
+
+	result, err := registry.Install(t.Context(), pkg, "v1.0.0")
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(result)
+	require.NoError(t, err)
+	assert.Equal(t, binaryContent, string(data))
+
+	info, err := os.Stat(result)
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode()&0o111, "binary should be executable")
+
+	// Verify symlink was created.
+	link := filepath.Join(BinDir(), "raw-tool")
+	target, err := os.Readlink(link)
+	require.NoError(t, err)
+	assert.Equal(t, result, target)
+}
+
+// roundTripFunc adapts a function to http.RoundTripper for test HTTP mocking.
+type roundTripFunc func(*http.Request) *http.Response
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req), nil
+}
+
+// mockRegistry creates a Registry whose HTTP client returns the given body for every request.
+func mockRegistry(body []byte) *Registry {
+	return &Registry{
+		httpClient: &http.Client{
+			Transport: roundTripFunc(func(_ *http.Request) *http.Response {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader(body)),
+				}
+			}),
+		},
+	}
+}
+
+// assertInstalledBinary checks that a binary exists at path with the expected
+// content, is executable, and has a symlink in BinDir().
+func assertInstalledBinary(t *testing.T, binaryPath, expectedContent, binaryName string) {
+	t.Helper()
+
+	// Verify binary content.
+	data, err := os.ReadFile(binaryPath)
+	require.NoError(t, err)
+	assert.Equal(t, expectedContent, string(data))
+
+	// Verify executable permissions.
+	info, err := os.Stat(binaryPath)
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode()&0o111, "binary should be executable")
+
+	// Verify symlink in BinDir.
+	link := filepath.Join(BinDir(), binaryName)
+	target, err := os.Readlink(link)
+	require.NoError(t, err)
+	assert.Equal(t, binaryPath, target)
+}
+
+// --- End-to-end Install tests: full download → extract → symlink flow ---
+
+func TestInstallE2E_TarGz(t *testing.T) {
+	t.Setenv("DOCKER_AGENT_TOOLS_DIR", t.TempDir())
+
+	binaryContent := "#!/bin/sh\necho hello from mytool"
+
+	// Build a real tar.gz archive containing the binary at the expected path.
+	// The asset template is "mytool_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz"
+	// and the src template is "mytool_{{.Version}}_{{.OS}}_{{.Arch}}/mytool".
+	entryName := "mytool_1.0.0_" + runtime.GOOS + "_" + runtime.GOARCH + "/mytool"
+	archive := buildTarGz(t, entryName, []byte(binaryContent))
+
+	pkg := &Package{
+		RepoOwner: "acme",
+		RepoName:  "mytool",
+		Format:    "tar.gz",
+		Asset:     "mytool_{{.Version}}_{{.OS}}_{{.Arch}}.tar.gz",
+		Files: []PackageFile{{
+			Name: "mytool",
+			Src:  "mytool_{{.Version}}_{{.OS}}_{{.Arch}}/mytool",
+		}},
+	}
+
+	result, err := mockRegistry(archive).Install(t.Context(), pkg, "v1.0.0")
+	require.NoError(t, err)
+	assertInstalledBinary(t, result, binaryContent, "mytool")
+}
+
+func TestInstallE2E_Zip(t *testing.T) {
+	t.Setenv("DOCKER_AGENT_TOOLS_DIR", t.TempDir())
+
+	binaryContent := "#!/bin/sh\necho hello from ziptool"
+
+	entryName := "ziptool_1.0.0/ziptool"
+	archive := buildZip(t, entryName, []byte(binaryContent))
+
+	pkg := &Package{
+		RepoOwner: "acme",
+		RepoName:  "ziptool",
+		Format:    "zip",
+		Asset:     "ziptool_{{.Version}}.zip",
+		Files: []PackageFile{{
+			Name: "ziptool",
+			Src:  "ziptool_{{.Version}}/ziptool",
+		}},
+	}
+
+	result, err := mockRegistry(archive).Install(t.Context(), pkg, "v1.0.0")
+	require.NoError(t, err)
+	assertInstalledBinary(t, result, binaryContent, "ziptool")
+}
+
+func TestInstallE2E_Raw(t *testing.T) {
+	t.Setenv("DOCKER_AGENT_TOOLS_DIR", t.TempDir())
+
+	binaryContent := "#!/bin/sh\necho hello from rawtool"
+
+	pkg := &Package{
+		RepoOwner: "acme",
+		RepoName:  "rawtool",
+		Format:    "raw",
+		Asset:     "rawtool",
+		Files:     []PackageFile{{Name: "rawtool"}},
+	}
+
+	result, err := mockRegistry([]byte(binaryContent)).Install(t.Context(), pkg, "v1.0.0")
+	require.NoError(t, err)
+	assertInstalledBinary(t, result, binaryContent, "rawtool")
+}
+
+func TestInstallE2E_TarGz_NoFilesList(t *testing.T) {
+	// When Files is empty, extractTarGz extracts all entries by basename.
+	t.Setenv("DOCKER_AGENT_TOOLS_DIR", t.TempDir())
+
+	binaryContent := "#!/bin/sh\necho hello from notool"
+	archive := buildTarGz(t, "anytool", []byte(binaryContent))
+
+	pkg := &Package{
+		RepoOwner: "acme",
+		RepoName:  "anytool",
+		Format:    "tar.gz",
+		Asset:     "anytool.tar.gz",
+		// No Files — the repo name is used as binary name.
+	}
+
+	result, err := mockRegistry(archive).Install(t.Context(), pkg, "v1.0.0")
+	require.NoError(t, err)
+	assertInstalledBinary(t, result, binaryContent, "anytool")
+}
+
+func TestInstallE2E_DownloadFailure(t *testing.T) {
+	t.Setenv("DOCKER_AGENT_TOOLS_DIR", t.TempDir())
+
+	pkg := &Package{
+		RepoOwner: "acme",
+		RepoName:  "badtool",
+		Format:    "tar.gz",
+		Asset:     "badtool.tar.gz",
+		Files:     []PackageFile{{Name: "badtool"}},
+	}
+
+	registry := &Registry{
+		httpClient: &http.Client{
+			Transport: roundTripFunc(func(_ *http.Request) *http.Response {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader("not found")),
+				}
+			}),
+		},
+	}
+
+	_, err := registry.Install(t.Context(), pkg, "v1.0.0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP 404")
+}
+
+func TestInstallE2E_IdempotentReinstall(t *testing.T) {
+	// Verify that calling Install twice returns the same path without error.
+	t.Setenv("DOCKER_AGENT_TOOLS_DIR", t.TempDir())
+
+	binaryContent := "#!/bin/sh\necho idempotent"
+	archive := buildTarGz(t, "idem", []byte(binaryContent))
+
+	pkg := &Package{
+		RepoOwner: "acme",
+		RepoName:  "idem",
+		Format:    "tar.gz",
+		Asset:     "idem.tar.gz",
+	}
+
+	registry := mockRegistry(archive)
+
+	result1, err := registry.Install(t.Context(), pkg, "v1.0.0")
+	require.NoError(t, err)
+
+	// Second install should hit the "already installed" path.
+	result2, err := registry.Install(t.Context(), pkg, "v1.0.0")
+	require.NoError(t, err)
+	assert.Equal(t, result1, result2)
+}
+
+// --- Test archive builders ---
+
+func buildTarGz(t *testing.T, entryName string, content []byte) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name: entryName,
+		Mode: 0o755,
+		Size: int64(len(content)),
+	}))
+	_, err := tw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+
+	return buf.Bytes()
+}
+
+func buildZip(t *testing.T, entryName string, content []byte) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	fw, err := zw.Create(entryName)
+	require.NoError(t, err)
+	_, err = fw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+
+	return buf.Bytes()
+}

--- a/pkg/toolinstall/paths.go
+++ b/pkg/toolinstall/paths.go
@@ -1,0 +1,59 @@
+package toolinstall
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/docker/cagent/pkg/paths"
+)
+
+// ToolsDir returns the base directory for installed tools.
+// Checks DOCKER_AGENT_TOOLS_DIR env var, defaults to ~/.cagent/tools/
+func ToolsDir() string {
+	if dir := os.Getenv("DOCKER_AGENT_TOOLS_DIR"); dir != "" {
+		return filepath.Clean(dir)
+	}
+	return filepath.Join(paths.GetDataDir(), "tools")
+}
+
+// BinDir returns the directory where tool binaries/symlinks are placed.
+// This is ToolsDir()/bin/
+func BinDir() string {
+	return filepath.Join(ToolsDir(), "bin")
+}
+
+// PackageDir returns the directory for a specific package version.
+// This is ToolsDir()/packages/<owner>/<repo>/<version>/
+func PackageDir(owner, repo, version string) string {
+	return filepath.Join(ToolsDir(), "packages", owner, repo, version)
+}
+
+// RegistryDir returns the directory for cached registry data.
+func RegistryDir() string {
+	return filepath.Join(ToolsDir(), "registry")
+}
+
+// PrependBinDirToEnv takes an env slice and ensures the tools bin directory
+// is prepended to the PATH entry. This allows installed tools to find
+// other installed tools (e.g., npx finding node).
+func PrependBinDirToEnv(env []string) []string {
+	binDir := BinDir()
+	result := make([]string, 0, len(env))
+	found := false
+
+	for _, e := range env {
+		if existing, ok := strings.CutPrefix(e, "PATH="); ok {
+			result = append(result, "PATH="+binDir+string(os.PathListSeparator)+existing)
+			found = true
+		} else {
+			result = append(result, e)
+		}
+	}
+
+	if !found {
+		result = append(result, "PATH="+binDir)
+	}
+
+	return result
+}

--- a/pkg/toolinstall/paths_test.go
+++ b/pkg/toolinstall/paths_test.go
@@ -1,0 +1,87 @@
+package toolinstall
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToolsDir_Default(t *testing.T) {
+	t.Setenv("DOCKER_AGENT_TOOLS_DIR", "")
+
+	dir := ToolsDir()
+	assert.Contains(t, dir, "tools")
+}
+
+func TestToolsDir_EnvOverride(t *testing.T) {
+	t.Setenv("DOCKER_AGENT_TOOLS_DIR", "/custom/tools/dir")
+
+	dir := ToolsDir()
+	assert.Equal(t, "/custom/tools/dir", dir)
+}
+
+func TestBinDir(t *testing.T) {
+	t.Setenv("DOCKER_AGENT_TOOLS_DIR", "/custom/tools")
+
+	dir := BinDir()
+	assert.Equal(t, "/custom/tools/bin", dir)
+}
+
+func TestPackageDir(t *testing.T) {
+	t.Setenv("DOCKER_AGENT_TOOLS_DIR", "/custom/tools")
+
+	dir := PackageDir("cli", "cli", "v2.50.0")
+	expected := "/custom/tools/packages/cli/cli/v2.50.0"
+	assert.Equal(t, expected, dir)
+}
+
+func TestRegistryDir(t *testing.T) {
+	t.Setenv("DOCKER_AGENT_TOOLS_DIR", "/custom/tools")
+
+	dir := RegistryDir()
+	assert.Equal(t, "/custom/tools/registry", dir)
+}
+
+func TestPrependBinDirToEnv_WithExistingPATH(t *testing.T) {
+	t.Setenv("DOCKER_AGENT_TOOLS_DIR", "/custom/tools")
+
+	env := []string{
+		"HOME=/home/user",
+		"PATH=/usr/bin:/usr/local/bin",
+		"FOO=bar",
+	}
+
+	result := PrependBinDirToEnv(env)
+
+	require.Len(t, result, 3)
+	assert.Equal(t, "HOME=/home/user", result[0])
+	assert.Equal(t, "PATH=/custom/tools/bin"+string(os.PathListSeparator)+"/usr/bin:/usr/local/bin", result[1])
+	assert.Equal(t, "FOO=bar", result[2])
+}
+
+func TestPrependBinDirToEnv_NoPATH(t *testing.T) {
+	t.Setenv("DOCKER_AGENT_TOOLS_DIR", "/custom/tools")
+
+	env := []string{
+		"HOME=/home/user",
+		"FOO=bar",
+	}
+
+	result := PrependBinDirToEnv(env)
+
+	require.Len(t, result, 3)
+	assert.Equal(t, "HOME=/home/user", result[0])
+	assert.Equal(t, "FOO=bar", result[1])
+	assert.Equal(t, "PATH=/custom/tools/bin", result[2])
+}
+
+func TestPrependBinDirToEnv_EmptyEnv(t *testing.T) {
+	t.Setenv("DOCKER_AGENT_TOOLS_DIR", "/custom/tools")
+
+	result := PrependBinDirToEnv(nil)
+
+	require.Len(t, result, 1)
+	assert.Equal(t, "PATH=/custom/tools/bin", result[0])
+}

--- a/pkg/toolinstall/registry.go
+++ b/pkg/toolinstall/registry.go
@@ -1,0 +1,382 @@
+package toolinstall
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/goccy/go-yaml"
+)
+
+// githubToken returns a GitHub personal access token from the environment,
+// checking GITHUB_TOKEN first, then GH_TOKEN (used by the gh CLI).
+// Returns an empty string if neither is set.
+func githubToken() string {
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		return token
+	}
+	return os.Getenv("GH_TOKEN")
+}
+
+// setGitHubAuth adds a Bearer authorization header to the request
+// if a GitHub token is available in the environment. This raises the
+// GitHub API rate limit from 60 to 5,000 requests per hour.
+func setGitHubAuth(req *http.Request) {
+	if token := githubToken(); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+}
+
+const (
+	registryBaseURL  = "https://raw.githubusercontent.com/aquaproj/aqua-registry/main"
+	registryCacheTTL = 24 * time.Hour
+)
+
+// Package represents a parsed aqua registry package definition.
+type Package struct {
+	Type          string            `yaml:"type"`
+	RepoOwner     string            `yaml:"repo_owner"`
+	RepoName      string            `yaml:"repo_name"`
+	Description   string            `yaml:"description"`
+	Asset         string            `yaml:"asset"`
+	Format        string            `yaml:"format"`
+	Files         []PackageFile     `yaml:"files"`
+	Overrides     []Override        `yaml:"overrides"`
+	Replacements  map[string]string `yaml:"replacements"`
+	SupportedEnvs []string          `yaml:"supported_envs"`
+	VersionFilter string            `yaml:"version_filter"`
+	VersionPrefix string            `yaml:"version_prefix"`
+	Name          string            `yaml:"name"`
+
+	// GoInstallPath is the Go module path for go_install/go_build packages.
+	// Example: "golang.org/x/tools/gopls"
+	GoInstallPath string `yaml:"path"`
+}
+
+// IsGoPackage returns true if this package is installed via "go install".
+func (p *Package) IsGoPackage() bool {
+	switch p.Type {
+	case "go_install", "go", "go_build":
+		return true
+	default:
+		return false
+	}
+}
+
+// BinaryName returns the primary binary name this package provides.
+func (p *Package) BinaryName() string {
+	if len(p.Files) > 0 {
+		return p.Files[0].Name
+	}
+	return p.RepoName
+}
+
+// PackageFile describes a file within a downloaded archive.
+type PackageFile struct {
+	Name string `yaml:"name"`
+	Src  string `yaml:"src"`
+}
+
+// Override represents a platform-specific override for a package.
+type Override struct {
+	GOOS         string            `yaml:"goos"`
+	GOArch       string            `yaml:"goarch"`
+	Asset        string            `yaml:"asset"`
+	Format       string            `yaml:"format"`
+	Files        []PackageFile     `yaml:"files"`
+	Replacements map[string]string `yaml:"replacements"`
+}
+
+// registryIndex represents the top-level registry.yaml containing full package definitions.
+type registryIndex struct {
+	Packages []Package `yaml:"packages"`
+}
+
+// Registry provides lookup of aqua packages.
+type Registry struct {
+	httpClient *http.Client
+	baseURL    string
+	cacheDir   string
+
+	// In-memory cache for the parsed registry index, populated once via sync.Once.
+	indexOnce   sync.Once
+	cachedIndex *registryIndex
+	indexErr    error
+}
+
+var (
+	sharedRegistry     *Registry
+	sharedRegistryOnce sync.Once
+)
+
+// NewRegistry creates a new Registry with default settings.
+func NewRegistry() *Registry {
+	return &Registry{
+		httpClient: http.DefaultClient,
+		baseURL:    registryBaseURL,
+		cacheDir:   RegistryDir(),
+	}
+}
+
+// SharedRegistry returns a package-level Registry instance that is reused
+// across all tool resolutions within a cagent session, avoiding repeated
+// YAML parsing and HTTP fetches.
+func SharedRegistry() *Registry {
+	sharedRegistryOnce.Do(func() {
+		sharedRegistry = NewRegistry()
+	})
+	return sharedRegistry
+}
+
+// LookupByName searches the registry for a package by "owner/repo" identifier.
+// Searches the full registry index first, then falls back to fetching the
+// per-package YAML from pkgs/<owner>/<repo>/registry.yaml.
+func (r *Registry) LookupByName(ctx context.Context, name string) (*Package, error) {
+	parts := strings.SplitN(name, "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid aqua package name %q: expected owner/repo format", name)
+	}
+
+	owner, repo := parts[0], parts[1]
+
+	// Try the full registry index first.
+	index, err := r.fetchIndex(ctx)
+	if err == nil {
+		for i := range index.Packages {
+			p := &index.Packages[i]
+			if strings.EqualFold(p.RepoOwner, owner) && strings.EqualFold(p.RepoName, repo) {
+				return p, nil
+			}
+		}
+	}
+
+	// Fallback: fetch the per-package YAML file.
+	data, err := r.fetchCached(ctx, fmt.Sprintf("pkgs/%s/%s/registry.yaml", owner, repo), 0)
+	if err != nil {
+		return nil, fmt.Errorf("fetching package %s: %w", name, err)
+	}
+
+	var wrapper registryIndex
+	if err := yaml.Unmarshal(data, &wrapper); err != nil {
+		return nil, fmt.Errorf("parsing package YAML for %s: %w", name, err)
+	}
+
+	if len(wrapper.Packages) == 0 {
+		return nil, fmt.Errorf("no packages found in registry for %s", name)
+	}
+
+	return &wrapper.Packages[0], nil
+}
+
+// LookupByCommand searches for a package providing a binary matching the command name.
+// First checks repo names, then files[].name across all packages.
+func (r *Registry) LookupByCommand(ctx context.Context, command string) (*Package, error) {
+	index, err := r.fetchIndex(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("fetching registry index: %w", err)
+	}
+
+	// Single pass: prefer repo name match, but track the first file-name match.
+	var fileMatch *Package
+	for i := range index.Packages {
+		p := &index.Packages[i]
+		if p.RepoName == command {
+			return p, nil
+		}
+		if fileMatch == nil && providesCommand(p, command) {
+			fileMatch = p
+		}
+	}
+
+	if fileMatch != nil {
+		return fileMatch, nil
+	}
+
+	return nil, fmt.Errorf("no aqua package found providing command %q", command)
+}
+
+// providesCommand returns true if any of the package's files entries has
+// a binary matching the given command name.
+func providesCommand(pkg *Package, command string) bool {
+	for _, f := range pkg.Files {
+		if f.Name == command {
+			return true
+		}
+	}
+	return false
+}
+
+// fetchIndex fetches and parses the full registry index, with caching.
+// The parsed result is cached in memory so that repeated calls within the
+// same Registry instance skip both the HTTP fetch and YAML deserialization.
+func (r *Registry) fetchIndex(ctx context.Context) (*registryIndex, error) {
+	r.indexOnce.Do(func() {
+		var data []byte
+		data, r.indexErr = r.fetchCached(ctx, "registry.yaml", registryCacheTTL)
+		if r.indexErr != nil {
+			return
+		}
+
+		var index registryIndex
+		if err := yaml.Unmarshal(data, &index); err != nil {
+			r.indexErr = fmt.Errorf("parsing registry index: %w", err)
+			return
+		}
+		r.cachedIndex = &index
+	})
+
+	return r.cachedIndex, r.indexErr
+}
+
+// fetchCached fetches a file from the registry, using a local file cache.
+// A ttl of 0 means the cache never expires.
+func (r *Registry) fetchCached(ctx context.Context, path string, ttl time.Duration) ([]byte, error) {
+	cachePath := filepath.Join(r.cacheDir, path)
+
+	// Return cached data if still fresh.
+	if info, err := os.Stat(cachePath); err == nil {
+		if ttl == 0 || time.Since(info.ModTime()) < ttl {
+			return os.ReadFile(cachePath)
+		}
+	}
+
+	// Fetch from remote.
+	url := r.baseURL + "/" + path
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		if data, readErr := os.ReadFile(cachePath); readErr == nil {
+			return data, nil
+		}
+		return nil, fmt.Errorf("creating request for %s: %w", url, err)
+	}
+	setGitHubAuth(req)
+
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		if data, readErr := os.ReadFile(cachePath); readErr == nil {
+			return data, nil // stale cache beats no data
+		}
+		return nil, fmt.Errorf("fetching %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		if data, readErr := os.ReadFile(cachePath); readErr == nil {
+			return data, nil
+		}
+		return nil, fmt.Errorf("fetching %s: HTTP %d", url, resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response from %s: %w", url, err)
+	}
+
+	// Write to cache atomically (best-effort): write to a temp file in the
+	// same directory, then rename. This avoids races when multiple goroutines
+	// fetch the same path concurrently.
+	if err := os.MkdirAll(filepath.Dir(cachePath), 0o755); err == nil {
+		if tmpFile, tmpErr := os.CreateTemp(filepath.Dir(cachePath), ".cache-*.tmp"); tmpErr == nil {
+			if _, writeErr := tmpFile.Write(data); writeErr == nil {
+				tmpFile.Close()
+				_ = os.Rename(tmpFile.Name(), cachePath)
+			} else {
+				tmpFile.Close()
+				_ = os.Remove(tmpFile.Name())
+			}
+		}
+	}
+
+	return data, nil
+}
+
+// githubRelease represents the relevant fields from the GitHub releases API.
+type githubRelease struct {
+	TagName string `json:"tag_name"`
+}
+
+// latestVersion fetches the latest release version for a GitHub repo.
+func (r *Registry) latestVersion(ctx context.Context, owner, repo string) (string, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases/latest", owner, repo)
+
+	var release githubRelease
+	if err := r.fetchGitHubJSON(ctx, url, &release); err != nil {
+		return "", fmt.Errorf("fetching latest release for %s/%s: %w", owner, repo, err)
+	}
+
+	if release.TagName == "" {
+		return "", fmt.Errorf("no tag_name found in latest release for %s/%s", owner, repo)
+	}
+
+	return release.TagName, nil
+}
+
+// latestVersionFiltered fetches the latest release version matching a tag prefix.
+// Needed for multi-module repos like golang/tools where tags look like "gopls/v0.21.1".
+func (r *Registry) latestVersionFiltered(ctx context.Context, owner, repo, tagPrefix string) (string, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases?per_page=50", owner, repo)
+
+	var releases []githubRelease
+	if err := r.fetchGitHubJSON(ctx, url, &releases); err != nil {
+		return "", fmt.Errorf("fetching releases for %s/%s: %w", owner, repo, err)
+	}
+
+	for _, rel := range releases {
+		if strings.HasPrefix(rel.TagName, tagPrefix) {
+			return rel.TagName, nil
+		}
+	}
+
+	return "", fmt.Errorf("no release found for %s/%s with tag prefix %q", owner, repo, tagPrefix)
+}
+
+// fetchGitHubJSON fetches a GitHub API endpoint and decodes the JSON response.
+func (r *Registry) fetchGitHubJSON(ctx context.Context, url string, target any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	setGitHubAuth(req)
+
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	return json.NewDecoder(resp.Body).Decode(target)
+}
+
+// download opens an HTTP connection to the given URL and returns the
+// response body as an io.ReadCloser. The caller is responsible for closing it.
+func (r *Registry) download(ctx context.Context, url string) (io.ReadCloser, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return nil, err
+	}
+	setGitHubAuth(req)
+
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	return resp.Body, nil
+}

--- a/pkg/toolinstall/registry_test.go
+++ b/pkg/toolinstall/registry_test.go
@@ -1,0 +1,380 @@
+package toolinstall
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testRegistryYAML = `packages:
+  - type: github_release
+    repo_owner: cli
+    repo_name: cli
+    description: "GitHub's official CLI"
+    asset: "gh_{{.Version}}_{{.OS}}_{{.Arch}}.{{.Format}}"
+    format: tar.gz
+    files:
+      - name: gh
+        src: "gh_{{.Version}}_{{.OS}}_{{.Arch}}/bin/gh"
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: amd64
+      arm64: arm64
+      darwin: macOS
+      linux: linux
+      windows: windows
+  - type: github_release
+    repo_owner: junegunn
+    repo_name: fzf
+    description: "A command-line fuzzy finder"
+    asset: "fzf-{{.Version}}-{{.OS}}_{{.Arch}}.{{.Format}}"
+    format: tar.gz
+    files:
+      - name: fzf
+  - type: github_release
+    repo_owner: BurntSushi
+    repo_name: ripgrep
+    description: "ripgrep recursively searches directories"
+    asset: "ripgrep-{{.Version}}-{{.OS}}_{{.Arch}}.{{.Format}}"
+    format: tar.gz
+    files:
+      - name: rg
+  - type: go_build
+    repo_owner: golang
+    repo_name: tools
+    description: "Go tools including gopls"
+    version_filter: 'Version startsWith "gopls/"'
+    path: golang.org/x/tools/gopls
+    files:
+      - name: gopls
+`
+
+func newTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/registry.yaml", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(testRegistryYAML))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return server
+}
+
+func newTestRegistry(t *testing.T, server *httptest.Server) *Registry {
+	t.Helper()
+
+	return &Registry{
+		httpClient: server.Client(),
+		baseURL:    server.URL,
+		cacheDir:   filepath.Join(t.TempDir(), "registry-cache"),
+	}
+}
+
+func TestRegistry_LookupByName(t *testing.T) {
+	t.Parallel()
+
+	registry := newTestRegistry(t, newTestServer(t))
+
+	pkg, err := registry.LookupByName(t.Context(), "cli/cli")
+	require.NoError(t, err)
+	assert.Equal(t, "github_release", pkg.Type)
+	assert.Equal(t, "cli", pkg.RepoOwner)
+	assert.Equal(t, "cli", pkg.RepoName)
+	assert.Equal(t, "tar.gz", pkg.Format)
+	require.Len(t, pkg.Files, 1)
+	assert.Equal(t, "gh", pkg.Files[0].Name)
+	require.Len(t, pkg.Overrides, 1)
+	assert.Equal(t, "macOS", pkg.Replacements["darwin"])
+}
+
+func TestRegistry_LookupByName_InvalidFormat(t *testing.T) {
+	t.Parallel()
+
+	_, err := newTestRegistry(t, newTestServer(t)).LookupByName(t.Context(), "invalid")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected owner/repo format")
+}
+
+func TestRegistry_LookupByName_NotFound(t *testing.T) {
+	t.Parallel()
+
+	_, err := newTestRegistry(t, newTestServer(t)).LookupByName(t.Context(), "nonexistent/package")
+	require.Error(t, err)
+}
+
+func TestRegistry_LookupByCommand_ByRepoName(t *testing.T) {
+	t.Parallel()
+
+	registry := newTestRegistry(t, newTestServer(t))
+
+	pkg, err := registry.LookupByCommand(t.Context(), "fzf")
+	require.NoError(t, err)
+	assert.Equal(t, "junegunn", pkg.RepoOwner)
+	assert.Equal(t, "fzf", pkg.RepoName)
+}
+
+func TestRegistry_LookupByCommand_BinaryNameDiffersFromRepo(t *testing.T) {
+	t.Parallel()
+
+	registry := newTestRegistry(t, newTestServer(t))
+
+	// "gopls" binary comes from "golang/tools" — found via files[].name scan.
+	pkg, err := registry.LookupByCommand(t.Context(), "gopls")
+	require.NoError(t, err)
+	assert.Equal(t, "golang", pkg.RepoOwner)
+	assert.Equal(t, "tools", pkg.RepoName)
+	assert.Equal(t, "go_build", pkg.Type)
+	assert.Equal(t, "golang.org/x/tools/gopls", pkg.GoInstallPath)
+	require.Len(t, pkg.Files, 1)
+	assert.Equal(t, "gopls", pkg.Files[0].Name)
+}
+
+func TestRegistry_LookupByCommand_NotFound(t *testing.T) {
+	t.Parallel()
+
+	_, err := newTestRegistry(t, newTestServer(t)).LookupByCommand(t.Context(), "nonexistent-tool")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no aqua package found")
+}
+
+func TestRegistry_Caching(t *testing.T) {
+	t.Parallel()
+
+	callCount := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/registry.yaml", func(w http.ResponseWriter, _ *http.Request) {
+		callCount++
+		_, _ = w.Write([]byte(testRegistryYAML))
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	registry := &Registry{
+		httpClient: server.Client(),
+		baseURL:    server.URL,
+		cacheDir:   filepath.Join(t.TempDir(), "cache"),
+	}
+
+	_, err := registry.LookupByCommand(t.Context(), "fzf")
+	require.NoError(t, err)
+	assert.Equal(t, 1, callCount)
+
+	_, err = registry.LookupByCommand(t.Context(), "fzf")
+	require.NoError(t, err)
+	assert.Equal(t, 1, callCount) // Served from cache.
+}
+
+func TestRegistry_CacheFallback(t *testing.T) {
+	t.Parallel()
+
+	cacheDir := filepath.Join(t.TempDir(), "cache")
+	cachePath := filepath.Join(cacheDir, "registry.yaml")
+	require.NoError(t, os.MkdirAll(cacheDir, 0o755))
+	require.NoError(t, os.WriteFile(cachePath, []byte(testRegistryYAML), 0o644))
+
+	// Server always returns 500.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	registry := &Registry{
+		httpClient: server.Client(),
+		baseURL:    server.URL,
+		cacheDir:   cacheDir,
+	}
+
+	// Should fall back to stale cache.
+	pkg, err := registry.LookupByCommand(t.Context(), "fzf")
+	require.NoError(t, err)
+	assert.Equal(t, "junegunn", pkg.RepoOwner)
+}
+
+func TestRegistry_SendsAuthHeader(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "ghp_test_registry_token")
+
+	var gotAuth string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/registry.yaml", func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(testRegistryYAML))
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	registry := &Registry{
+		httpClient: server.Client(),
+		baseURL:    server.URL,
+		cacheDir:   filepath.Join(t.TempDir(), "cache"),
+	}
+
+	_, err := registry.LookupByCommand(t.Context(), "fzf")
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer ghp_test_registry_token", gotAuth)
+}
+
+func TestRegistry_NoAuthHeaderWithoutToken(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
+
+	var gotAuth string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/registry.yaml", func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(testRegistryYAML))
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	registry := &Registry{
+		httpClient: server.Client(),
+		baseURL:    server.URL,
+		cacheDir:   filepath.Join(t.TempDir(), "cache"),
+	}
+
+	_, err := registry.LookupByCommand(t.Context(), "fzf")
+	require.NoError(t, err)
+	assert.Empty(t, gotAuth)
+}
+
+func TestRegistry_InMemoryIndexCaching(t *testing.T) {
+	t.Parallel()
+
+	parseCount := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/registry.yaml", func(w http.ResponseWriter, _ *http.Request) {
+		parseCount++
+		_, _ = w.Write([]byte(testRegistryYAML))
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	registry := &Registry{
+		httpClient: server.Client(),
+		baseURL:    server.URL,
+		cacheDir:   filepath.Join(t.TempDir(), "cache"),
+	}
+
+	// First lookup: fetches + parses.
+	_, err := registry.LookupByCommand(t.Context(), "fzf")
+	require.NoError(t, err)
+	assert.Equal(t, 1, parseCount)
+
+	// Remove file cache to prove in-memory cache is used.
+	require.NoError(t, os.RemoveAll(registry.cacheDir))
+
+	// Second lookup: served from in-memory cached index (no HTTP, no re-parse).
+	pkg, err := registry.LookupByCommand(t.Context(), "fzf")
+	require.NoError(t, err)
+	assert.Equal(t, "junegunn", pkg.RepoOwner)
+	assert.Equal(t, 1, parseCount) // Still 1 — no second fetch.
+}
+
+// --- GitHub auth tests ---
+
+func TestGithubToken_FromGITHUB_TOKEN(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "ghp_test123")
+	t.Setenv("GH_TOKEN", "")
+	assert.Equal(t, "ghp_test123", githubToken())
+}
+
+func TestGithubToken_FromGH_TOKEN(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "ghp_fallback456")
+	assert.Equal(t, "ghp_fallback456", githubToken())
+}
+
+func TestGithubToken_GITHUB_TOKEN_TakesPrecedence(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "ghp_primary")
+	t.Setenv("GH_TOKEN", "ghp_secondary")
+	assert.Equal(t, "ghp_primary", githubToken())
+}
+
+func TestGithubToken_Empty(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
+	assert.Empty(t, githubToken())
+}
+
+func TestSetGitHubAuth_WithToken(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "ghp_test_token")
+
+	req, err := http.NewRequest(http.MethodGet, "https://api.github.com/repos/test/test", http.NoBody)
+	require.NoError(t, err)
+
+	setGitHubAuth(req)
+	assert.Equal(t, "Bearer ghp_test_token", req.Header.Get("Authorization"))
+}
+
+func TestSetGitHubAuth_WithoutToken(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
+
+	req, err := http.NewRequest(http.MethodGet, "https://api.github.com/repos/test/test", http.NoBody)
+	require.NoError(t, err)
+
+	setGitHubAuth(req)
+	assert.Empty(t, req.Header.Get("Authorization"))
+}
+
+// --- Package type tests ---
+
+func TestPackage_BinaryName(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "gh", (&Package{
+		RepoName: "cli",
+		Files:    []PackageFile{{Name: "gh"}},
+	}).BinaryName())
+
+	assert.Equal(t, "fzf", (&Package{
+		RepoName: "fzf",
+	}).BinaryName())
+}
+
+func TestPackage_IsGoPackage(t *testing.T) {
+	t.Parallel()
+
+	for _, typ := range []string{"go_install", "go", "go_build"} {
+		assert.True(t, (&Package{Type: typ}).IsGoPackage(), typ)
+	}
+	assert.False(t, (&Package{Type: "github_release"}).IsGoPackage())
+	assert.False(t, (&Package{}).IsGoPackage())
+}
+
+func TestProvidesCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		pkg     *Package
+		command string
+		want    bool
+	}{
+		{"match in files", &Package{Files: []PackageFile{{Name: "gopls"}}}, "gopls", true},
+		{"no match in files", &Package{Files: []PackageFile{{Name: "gopls"}}}, "other", false},
+		{"no files", &Package{RepoName: "fzf"}, "fzf", false},
+		{"second file matches", &Package{Files: []PackageFile{{Name: "gh"}, {Name: "gh-cli"}}}, "gh-cli", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, providesCommand(tt.pkg, tt.command))
+		})
+	}
+}

--- a/pkg/toolinstall/resolver.go
+++ b/pkg/toolinstall/resolver.go
@@ -1,0 +1,192 @@
+package toolinstall
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sync/singleflight"
+)
+
+// EnsureCommand makes sure a command binary is available.
+// It checks PATH first, then the cagent tools directory, then
+// attempts to install from the aqua registry if auto-install is enabled.
+//
+// Returns the resolved command (may be the same string if found in PATH,
+// or a full path to the installed binary) and any error encountered.
+// When auto-install is disabled (globally or per-toolset), the original
+// command is returned with no error.
+func EnsureCommand(ctx context.Context, command, version string) (string, error) {
+	if strings.EqualFold(os.Getenv("DOCKER_AGENT_AUTO_INSTALL"), "false") {
+		return command, nil
+	}
+
+	lower := strings.ToLower(strings.TrimSpace(version))
+	if lower == "false" || lower == "off" {
+		return command, nil
+	}
+
+	resolvedPath, err := resolve(ctx, command, version)
+	if err != nil {
+		return "", fmt.Errorf("auto-installing command %q: %w", command, err)
+	}
+
+	return resolvedPath, nil
+}
+
+// installGroup deduplicates concurrent installations of the same command.
+// If two goroutines call resolve("fzf") simultaneously, only one performs
+// the actual download and install; the other waits and receives the same result.
+var installGroup singleflight.Group
+
+// resolve checks if a command is available and installs it if needed.
+// Returns the path to the usable binary.
+func resolve(ctx context.Context, command, version string) (string, error) {
+	// Check system PATH first — return original command name (not full path)
+	// so the caller uses it as-is via exec.Command.
+	if _, err := exec.LookPath(command); err == nil {
+		return command, nil
+	}
+
+	// Check if already installed in our bin dir.
+	binPath := filepath.Join(BinDir(), command)
+	if info, err := os.Stat(binPath); err == nil && info.Mode()&0o111 != 0 {
+		return binPath, nil
+	}
+
+	// Use singleflight to deduplicate concurrent installs of the same command.
+	result, err, _ := installGroup.Do(command, func() (any, error) {
+		return doInstall(ctx, command, version)
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return result.(string), nil
+}
+
+// doInstall performs the actual package resolution and installation.
+func doInstall(ctx context.Context, command, versionRef string) (string, error) {
+	// Re-check bin dir under singleflight — another goroutine may have
+	// just finished installing while we were waiting.
+	binPath := filepath.Join(BinDir(), command)
+	if info, err := os.Stat(binPath); err == nil && info.Mode()&0o111 != 0 {
+		return binPath, nil
+	}
+
+	slog.Info("Auto-installing missing command via aqua registry", "command", command)
+
+	registry := SharedRegistry()
+
+	pkg, version, err := lookupPackage(ctx, registry, command, versionRef)
+	if err != nil {
+		return "", err
+	}
+
+	if version == "" {
+		version, err = resolveVersion(ctx, registry, pkg)
+		if err != nil {
+			return "", fmt.Errorf("resolving latest version for %s/%s: %w", pkg.RepoOwner, pkg.RepoName, err)
+		}
+	}
+
+	pkgName := pkg.RepoOwner + "/" + pkg.RepoName
+	slog.Info("Installing tool", "command", command, "package", pkgName, "version", version)
+
+	binaryPath, err := registry.Install(ctx, pkg, version)
+	if err != nil {
+		return "", fmt.Errorf("installing %s@%s: %w", pkgName, version, err)
+	}
+
+	slog.Info("Successfully installed command",
+		"command", command, "package", fmt.Sprintf("%s@%s", pkgName, version), "path", binaryPath)
+
+	return binaryPath, nil
+}
+
+// lookupPackage resolves the aqua package for a command.
+// If versionRef is provided (e.g. "owner/repo@v1.0"), it parses the reference
+// and looks up by name. Otherwise, it searches by command name.
+// Returns the package, the explicit version (if any), and any error.
+func lookupPackage(ctx context.Context, registry *Registry, command, versionRef string) (*Package, string, error) {
+	if versionRef == "" {
+		pkg, err := registry.LookupByCommand(ctx, command)
+		if err != nil {
+			return nil, "", fmt.Errorf("looking up command %q in aqua registry: %w", command, err)
+		}
+		return pkg, "", nil
+	}
+
+	owner, repo, version, err := parseAquaRef(versionRef)
+	if err != nil {
+		return nil, "", fmt.Errorf("parsing aqua reference: %w", err)
+	}
+
+	pkg, err := registry.LookupByName(ctx, owner+"/"+repo)
+	if err != nil {
+		return nil, "", fmt.Errorf("looking up aqua package %s/%s: %w", owner, repo, err)
+	}
+
+	return pkg, version, nil
+}
+
+// resolveVersion determines the latest version for a package.
+func resolveVersion(ctx context.Context, registry *Registry, pkg *Package) (string, error) {
+	// Check for a version_filter with a "startsWith" prefix (multi-module repos).
+	if prefix := extractVersionPrefix(pkg.VersionFilter); prefix != "" {
+		return registry.latestVersionFiltered(ctx, pkg.RepoOwner, pkg.RepoName, prefix)
+	}
+
+	// For go types, use "latest" and let go install resolve it.
+	if pkg.IsGoPackage() {
+		return "latest", nil
+	}
+
+	return registry.latestVersion(ctx, pkg.RepoOwner, pkg.RepoName)
+}
+
+// extractVersionPrefix parses an aqua version_filter expression like
+// 'Version startsWith "gopls/"' and returns the prefix string.
+// Returns "" if the filter doesn't match this pattern.
+func extractVersionPrefix(filter string) string {
+	filter = strings.TrimSpace(filter)
+	const marker = "startsWith"
+	idx := strings.Index(filter, marker)
+	if idx < 0 {
+		return ""
+	}
+
+	rest := strings.TrimSpace(filter[idx+len(marker):])
+	if len(rest) >= 2 && (rest[0] == '"' || rest[0] == '\'') {
+		quote := rest[0]
+		end := strings.IndexByte(rest[1:], quote)
+		if end >= 0 {
+			return rest[1 : end+1]
+		}
+	}
+
+	return ""
+}
+
+// parseAquaRef parses an aqua reference string into owner, repo, and version.
+// Format: "owner/repo" or "owner/repo@version"
+func parseAquaRef(ref string) (owner, repo, version string, err error) {
+	ref = strings.TrimSpace(ref)
+
+	atParts := strings.SplitN(ref, "@", 2)
+	namePart := atParts[0]
+	if len(atParts) == 2 {
+		version = atParts[1]
+	}
+
+	parts := strings.SplitN(namePart, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", "", fmt.Errorf("invalid aqua reference %q: expected owner/repo[@version] format", ref)
+	}
+
+	return parts[0], parts[1], version, nil
+}

--- a/pkg/toolinstall/resolver_test.go
+++ b/pkg/toolinstall/resolver_test.go
@@ -1,0 +1,196 @@
+package toolinstall
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- EnsureCommand tests ---
+
+func TestEnsureCommand_FoundInPath(t *testing.T) {
+	command := "ls"
+	if _, err := exec.LookPath(command); err != nil {
+		t.Skipf("skipping: %q not in PATH", command)
+	}
+
+	result, err := EnsureCommand(t.Context(), command, "")
+	require.NoError(t, err)
+	assert.Equal(t, command, result)
+}
+
+func TestEnsureCommand_DisabledGlobally(t *testing.T) {
+	t.Setenv("DOCKER_AGENT_AUTO_INSTALL", "false")
+	result, err := EnsureCommand(t.Context(), "nonexistent-command", "")
+	require.NoError(t, err)
+	assert.Equal(t, "nonexistent-command", result)
+}
+
+func TestEnsureCommand_DisabledGlobally_CaseInsensitive(t *testing.T) {
+	t.Setenv("DOCKER_AGENT_AUTO_INSTALL", "False")
+	result, err := EnsureCommand(t.Context(), "nonexistent-command", "")
+	require.NoError(t, err)
+	assert.Equal(t, "nonexistent-command", result)
+}
+
+func TestEnsureCommand_DisabledPerToolset(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []string{"false", "False", "off", "OFF", " off "} {
+		t.Run(value, func(t *testing.T) {
+			t.Parallel()
+			result, err := EnsureCommand(t.Context(), "nonexistent-command", value)
+			require.NoError(t, err)
+			assert.Equal(t, "nonexistent-command", result)
+		})
+	}
+}
+
+func TestEnsureCommand_SoftFail(t *testing.T) {
+	t.Setenv("DOCKER_AGENT_TOOLS_DIR", t.TempDir())
+	t.Setenv("DOCKER_AGENT_AUTO_INSTALL", "")
+
+	_, err := EnsureCommand(t.Context(), "nonexistent-tool", "invalid-ref")
+	require.Error(t, err)
+}
+
+func TestEnsureCommand_FoundInBinDir(t *testing.T) {
+	toolsDir := t.TempDir()
+	t.Setenv("DOCKER_AGENT_TOOLS_DIR", toolsDir)
+	t.Setenv("DOCKER_AGENT_AUTO_INSTALL", "")
+
+	binDir := filepath.Join(toolsDir, "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	fakeBin := filepath.Join(binDir, "my-tool")
+	require.NoError(t, os.WriteFile(fakeBin, []byte("#!/bin/sh\necho test"), 0o755))
+
+	result, err := EnsureCommand(t.Context(), "my-tool", "")
+	require.NoError(t, err)
+	assert.Equal(t, fakeBin, result)
+}
+
+func TestEnsureCommand_NonExecutableInBinDirIsSkipped(t *testing.T) {
+	toolsDir := t.TempDir()
+	t.Setenv("DOCKER_AGENT_TOOLS_DIR", toolsDir)
+	t.Setenv("DOCKER_AGENT_AUTO_INSTALL", "")
+
+	binDir := filepath.Join(toolsDir, "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, "not-executable"), []byte("data"), 0o644))
+
+	// Falls through to auto-install → fails → returns error.
+	_, err := EnsureCommand(t.Context(), "not-executable", "")
+	require.Error(t, err)
+}
+
+// --- resolve tests ---
+
+func TestResolve_FoundInPath(t *testing.T) {
+	t.Parallel()
+
+	command := "ls"
+	if _, err := exec.LookPath(command); err != nil {
+		t.Skipf("skipping: %q not in PATH", command)
+	}
+
+	path, err := resolve(t.Context(), command, "")
+	require.NoError(t, err)
+	assert.NotEmpty(t, path)
+}
+
+func TestResolve_FoundInBinDir(t *testing.T) {
+	toolsDir := t.TempDir()
+	t.Setenv("DOCKER_AGENT_TOOLS_DIR", toolsDir)
+
+	binDir := filepath.Join(toolsDir, "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	fakeBin := filepath.Join(binDir, "my-custom-tool")
+	require.NoError(t, os.WriteFile(fakeBin, []byte("#!/bin/sh\necho ok"), 0o755))
+
+	path, err := resolve(t.Context(), "my-custom-tool", "")
+	require.NoError(t, err)
+	assert.Equal(t, fakeBin, path)
+}
+
+func TestResolve_NotFoundAnywhere(t *testing.T) {
+	t.Setenv("DOCKER_AGENT_TOOLS_DIR", t.TempDir())
+
+	_, err := resolve(t.Context(), "definitely-nonexistent-tool-xyz123", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "looking up command")
+}
+
+func TestResolve_InvalidAquaRef(t *testing.T) {
+	t.Setenv("DOCKER_AGENT_TOOLS_DIR", t.TempDir())
+
+	_, err := resolve(t.Context(), "sometool", "invalid-ref")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parsing aqua reference")
+}
+
+// --- parseAquaRef tests ---
+
+func TestParseAquaRef(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		ref         string
+		wantOwner   string
+		wantRepo    string
+		wantVersion string
+		wantErr     bool
+	}{
+		{"owner/repo only", "cli/cli", "cli", "cli", "", false},
+		{"owner/repo@version", "cli/cli@v2.50.0", "cli", "cli", "v2.50.0", false},
+		{"with spaces", "  junegunn/fzf@0.50.0  ", "junegunn", "fzf", "0.50.0", false},
+		{"no slash", "justarepo", "", "", "", true},
+		{"empty owner", "/repo", "", "", "", true},
+		{"empty repo", "owner/", "", "", "", true},
+		{"empty string", "", "", "", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			owner, repo, version, err := parseAquaRef(tt.ref)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantOwner, owner)
+			assert.Equal(t, tt.wantRepo, repo)
+			assert.Equal(t, tt.wantVersion, version)
+		})
+	}
+}
+
+// --- extractVersionPrefix tests ---
+
+func TestExtractVersionPrefix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		filter string
+		want   string
+	}{
+		{`Version startsWith "gopls/"`, "gopls/"},
+		{`Version startsWith 'cmd/'`, "cmd/"},
+		{"", ""},
+		{`Version contains "v1"`, ""},
+		{`  Version startsWith  "tools/"  `, "tools/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.filter, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, extractVersionPrefix(tt.filter))
+		})
+	}
+}


### PR DESCRIPTION
Make it possible to auto-install mcp servers and other command line tools.

Tools can be referenced from [aqua](https://aquaproj.github.io)'s registry and will be installed for cagent only.