### PR TITLE
Fix broken links in docs pages, were not using relative urls

### DIFF
--- a/docs/community/contributing/index.md
+++ b/docs/community/contributing/index.md
@@ -89,7 +89,7 @@ File issues on the [GitHub issue tracker](https://github.com/docker/cagent/issue
 <div class="callout callout-info">
 <div class="callout-title">ℹ️ See also
 </div>
-  <a href="/community/troubleshooting/">Troubleshooting</a> — Common issues and debug mode. <a href="/community/telemetry/">Telemetry</a> — What data is collected and how to opt out.
+  <a href="{{ '/community/troubleshooting/' | relative_url }}">Troubleshooting</a> — Common issues and debug mode. <a href="{{ '/community/telemetry/' | relative_url }}">Telemetry</a> — What data is collected and how to opt out.
 
 </div>
 

--- a/docs/concepts/agents/index.md
+++ b/docs/concepts/agents/index.md
@@ -113,6 +113,6 @@ $ docker agent run  # now runs your custom agent
 <div class="callout callout-tip">
 <div class="callout-title">💡 See also
 </div>
-  <p>For reusable task-specific instructions, see <a href="/features/skills/">Skills</a>. For multi-agent patterns, see <a href="/concepts/multi-agent/">Multi-Agent</a>. For full config reference, see <a href="/configuration/agents/">Agent Config</a>.</p>
+  <p>For reusable task-specific instructions, see <a href="{{ '/features/skills/' | relative_url }}">Skills</a>. For multi-agent patterns, see <a href="{{ '/concepts/multi-agent/' | relative_url }}">Multi-Agent</a>. For full config reference, see <a href="{{ '/configuration/agents/' | relative_url }}">Agent Config</a>.</p>
 
 </div>

--- a/docs/concepts/distribution/index.md
+++ b/docs/concepts/distribution/index.md
@@ -15,7 +15,7 @@ docker-agent agents can be pushed to any OCI-compatible registry (Docker Hub, Gi
 <div class="callout callout-tip">
 <div class="callout-title">💡 Tip
 </div>
-  <p>For CLI commands related to distribution, see <a href="/features/cli/">CLI Reference</a> (<code>docker agent share push</code>, <code>docker agent share pull</code>, <code>docker agent alias</code>).</p>
+  <p>For CLI commands related to distribution, see <a href="{{ '/features/cli/' | relative_url }}">CLI Reference</a> (<code>docker agent share push</code>, <code>docker agent share pull</code>, <code>docker agent alias</code>).</p>
 
 </div>
 
@@ -103,6 +103,6 @@ $ docker agent run docker.io/myorg/private-agent:latest
 <div class="callout callout-info">
 <div class="callout-title">ℹ️ Troubleshooting
 </div>
-  <p>Having issues with push/pull? See <a href="/community/troubleshooting/">Troubleshooting</a> for common registry issues.</p>
+  <p>Having issues with push/pull? See <a href="{{ '/community/troubleshooting/' | relative_url }}">Troubleshooting</a> for common registry issues.</p>
 
 </div>

--- a/docs/concepts/models/index.md
+++ b/docs/concepts/models/index.md
@@ -100,7 +100,7 @@ models:
 <div class="callout callout-info">
 <div class="callout-title">ℹ️ Multi-provider teams
 </div>
-  <p>Different agents can use different providers in the same config. See <a href="/concepts/multi-agent/">Multi-Agent</a> for patterns.</p>
+  <p>Different agents can use different providers in the same config. See <a href="{{ '/concepts/multi-agent/' | relative_url }}">Multi-Agent</a> for patterns.</p>
 
 </div>
 

--- a/docs/concepts/multi-agent/index.md
+++ b/docs/concepts/multi-agent/index.md
@@ -173,6 +173,6 @@ toolsets:
 <div class="callout callout-info">
 <div class="callout-title">ℹ️ Beyond docker-agent
 </div>
-  <p>For interoperability with other agent frameworks, docker-agent supports the <a href="/features/a2a/">A2A protocol</a> and can expose agents via <a href="/features/mcp-mode/">MCP Mode</a>.</p>
+  <p>For interoperability with other agent frameworks, docker-agent supports the <a href="{{ '/features/a2a/' | relative_url }}">A2A protocol</a> and can expose agents via <a href="{{ '/features/mcp-mode/' | relative_url }}">MCP Mode</a>.</p>
 
 </div>

--- a/docs/concepts/tools/index.md
+++ b/docs/concepts/tools/index.md
@@ -190,6 +190,6 @@ toolsets:
 <div class="callout callout-tip">
 <div class="callout-title">💡 See also
 </div>
-  <p>For connecting to 50+ cloud services via remote MCP with OAuth, see <a href="/features/remote-mcp/">Remote MCP Servers</a>. For RAG (document retrieval), see <a href="/features/rag/">RAG</a>. For full tool config reference, see <a href="/configuration/tools/">Tool Config</a>.</p>
+  <p>For connecting to 50+ cloud services via remote MCP with OAuth, see <a href="{{ '/features/remote-mcp/' | relative_url }}">Remote MCP Servers</a>. For RAG (document retrieval), see <a href="{{ '/features/rag/' | relative_url }}">RAG</a>. For full tool config reference, see <a href="{{ '/configuration/tools/' | relative_url }}">Tool Config</a>.</p>
 
 </div>

--- a/docs/configuration/agents/index.md
+++ b/docs/configuration/agents/index.md
@@ -50,7 +50,7 @@ agents:
 <div class="callout callout-tip">
 <div class="callout-title">💡 See also
 </div>
-  <p>For model parameters, see <a href="/configuration/models/">Model Config</a>. For tool details, see <a href="/configuration/tools/">Tool Config</a>. For multi-agent patterns, see <a href="/concepts/multi-agent/">Multi-Agent</a>.</p>
+  <p>For model parameters, see <a href="{{ '/configuration/models/' | relative_url }}">Model Config</a>. For tool details, see <a href="{{ '/configuration/tools/' | relative_url }}">Tool Config</a>. For multi-agent patterns, see <a href="{{ '/concepts/multi-agent/' | relative_url }}">Multi-Agent</a>.</p>
 
 </div>
 

--- a/docs/configuration/overview/index.md
+++ b/docs/configuration/overview/index.md
@@ -91,17 +91,17 @@ Models can be referenced inline or defined in the `models` section:
 ## Config Sections
 
 <div class="cards">
-  <a class="card" href="/configuration/agents/">
+  <a class="card" href="{{ '/configuration/agents/' | relative_url }}">
     <div class="card-icon">🤖</div>
     <h3>Agent Config</h3>
     <p>All agent properties: model, instruction, tools, sub-agents, hooks, and more.</p>
   </a>
-  <a class="card" href="/configuration/models/">
+  <a class="card" href="{{ '/configuration/models/' | relative_url }}">
     <div class="card-icon">🧠</div>
     <h3>Model Config</h3>
     <p>Provider setup, parameters, thinking budget, and provider-specific options.</p>
   </a>
-  <a class="card" href="/configuration/tools/">
+  <a class="card" href="{{ '/configuration/tools/' | relative_url }}">
     <div class="card-icon">🔧</div>
     <h3>Tool Config</h3>
     <p>Built-in tools, MCP tools, Docker MCP, LSP, API tools, and tool filtering.</p>
@@ -111,22 +111,22 @@ Models can be referenced inline or defined in the `models` section:
 ## Advanced Configuration
 
 <div class="cards">
-  <a class="card" href="/configuration/hooks/">
+  <a class="card" href="{{ '/configuration/hooks/' | relative_url }}">
     <div class="card-icon">⚡</div>
     <h3>Hooks</h3>
     <p>Run shell commands at lifecycle events like tool calls and session start/end.</p>
   </a>
-  <a class="card" href="/configuration/permissions/">
+  <a class="card" href="{{ '/configuration/permissions/' | relative_url }}">
     <div class="card-icon">🔐</div>
     <h3>Permissions</h3>
     <p>Control which tools auto-approve, require confirmation, or are blocked.</p>
   </a>
-  <a class="card" href="/configuration/sandbox/">
+  <a class="card" href="{{ '/configuration/sandbox/' | relative_url }}">
     <div class="card-icon">📦</div>
     <h3>Sandbox Mode</h3>
     <p>Run shell commands in an isolated Docker container for security.</p>
   </a>
-  <a class="card" href="/configuration/structured-output/">
+  <a class="card" href="{{ '/configuration/structured-output/' | relative_url }}">
     <div class="card-icon">📋</div>
     <h3>Structured Output</h3>
     <p>Constrain agent responses to match a specific JSON schema.</p>

--- a/docs/configuration/permissions/index.md
+++ b/docs/configuration/permissions/index.md
@@ -192,6 +192,6 @@ Hooks can override allow decisions but cannot override deny decisions.
 <div class="callout callout-warning">
 <div class="callout-title">⚠️ Security Note
 </div>
-  <p>Permissions are enforced client-side. They help prevent accidental operations but should not be relied upon as a security boundary for untrusted agents. For stronger isolation, use <a href="/configuration/sandbox/">sandbox mode</a>.</p>
+  <p>Permissions are enforced client-side. They help prevent accidental operations but should not be relied upon as a security boundary for untrusted agents. For stronger isolation, use <a href="{{ '/configuration/sandbox/' | relative_url }}">sandbox mode</a>.</p>
 
 </div>

--- a/docs/features/a2a/index.md
+++ b/docs/features/a2a/index.md
@@ -42,7 +42,7 @@ $ docker agent serve a2a agentcatalog/pirate
 <div class="callout callout-tip">
 <div class="callout-title">💡 See also
 </div>
-  <p>For exposing agents via MCP instead, see <a href="/features/mcp-mode/">MCP Mode</a>. For stdio-based integration, see <a href="/features/acp/">ACP</a>. For the HTTP API, see <a href="/features/api-server/">API Server</a>.</p>
+  <p>For exposing agents via MCP instead, see <a href="{{ '/features/mcp-mode/' | relative_url }}">MCP Mode</a>. For stdio-based integration, see <a href="{{ '/features/acp/' | relative_url }}">ACP</a>. For the HTTP API, see <a href="{{ '/features/api-server/' | relative_url }}">API Server</a>.</p>
 
 </div>
 

--- a/docs/features/acp/index.md
+++ b/docs/features/acp/index.md
@@ -98,13 +98,13 @@ child.stdout.on("data", (data) => {
 <div class="callout callout-tip">
 <div class="callout-title">💡 When to use ACP
 </div>
-  <p>Use ACP when building **IDE integrations**, **editor plugins**, or any tool that wants to embed a docker-agent agent as a subprocess. For HTTP-based integrations, use the <a href="/features/api-server/">API Server</a> instead.</p>
+  <p>Use ACP when building **IDE integrations**, **editor plugins**, or any tool that wants to embed a docker-agent agent as a subprocess. For HTTP-based integrations, use the <a href="{{ '/features/api-server/' | relative_url }}">API Server</a> instead.</p>
 
 </div>
 
 <div class="callout callout-info">
 <div class="callout-title">ℹ️ See also
 </div>
-  <p>For HTTP-based agent access, see the <a href="/features/api-server/">API Server</a>. For agent-to-agent communication, see <a href="/features/a2a/">A2A Protocol</a>. For exposing agents as MCP tools, see <a href="/features/mcp-mode/">MCP Mode</a>.</p>
+  <p>For HTTP-based agent access, see the <a href="{{ '/features/api-server/' | relative_url }}">API Server</a>. For agent-to-agent communication, see <a href="{{ '/features/a2a/' | relative_url }}">A2A Protocol</a>. For exposing agents as MCP tools, see <a href="{{ '/features/mcp-mode/' | relative_url }}">MCP Mode</a>.</p>
 
 </div>

--- a/docs/features/api-server/index.md
+++ b/docs/features/api-server/index.md
@@ -160,6 +160,6 @@ Toggle auto-approve with `POST /api/sessions/:id/tools/toggle` for automated wor
 <div class="callout callout-info">
 <div class="callout-title">ℹ️ See also
 </div>
-  <p>For interactive use, see the <a href="/features/tui/">Terminal UI</a>. For agent-to-agent communication, see <a href="/features/a2a/">A2A Protocol</a> and <a href="/features/acp/">ACP</a>. For MCP integration, see <a href="/features/mcp-mode/">MCP Mode</a>.</p>
+  <p>For interactive use, see the <a href="{{ '/features/tui/' | relative_url }}">Terminal UI</a>. For agent-to-agent communication, see <a href="{{ '/features/a2a/' | relative_url }}">A2A Protocol</a> and <a href="{{ '/features/acp/' | relative_url }}">ACP</a>. For MCP integration, see <a href="{{ '/features/mcp-mode/' | relative_url }}">MCP Mode</a>.</p>
 
 </div>

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -244,6 +244,6 @@ Commands that accept a config support multiple reference types:
 <div class="callout callout-info">
 <div class="callout-title">ℹ️ Debugging
 </div>
-  <p>Having issues? See <a href="/community/troubleshooting/">Troubleshooting</a> for debug mode, log analysis, and common solutions.</p>
+  <p>Having issues? See <a href="{{ '/community/troubleshooting/' | relative_url }}">Troubleshooting</a> for debug mode, log analysis, and common solutions.</p>
 
 </div>

--- a/docs/features/evaluation/index.md
+++ b/docs/features/evaluation/index.md
@@ -227,6 +227,6 @@ $ docker agent eval agent.yaml ./evals
 <div class="callout callout-info">
 <div class="callout-title">ℹ️ See also
 </div>
-  <p>Use <code>/eval</code> in the <a href="/features/tui/">TUI</a> to create eval sessions from conversations. See the <a href="/features/cli/">CLI Reference</a> for all <code>docker agent eval</code> flags. Example eval configs are in <a href="https://github.com/docker/cagent/tree/main/examples/eval">examples/eval</a> on GitHub.</p>
+  <p>Use <code>/eval</code> in the <a href="{{ '/features/tui/' | relative_url }}">TUI</a> to create eval sessions from conversations. See the <a href="{{ '/features/cli/' | relative_url }}">CLI Reference</a> for all <code>docker agent eval</code> flags. Example eval configs are in <a href="https://github.com/docker/cagent/tree/main/examples/eval">examples/eval</a> on GitHub.</p>
 
 </div>

--- a/docs/features/mcp-mode/index.md
+++ b/docs/features/mcp-mode/index.md
@@ -20,7 +20,7 @@ The `docker agent serve mcp` command makes your agents available to any applicat
 <div class="callout callout-info">
 <div class="callout-title">ℹ️ What is MCP?
 </div>
-  <p>The <a href="https://modelcontextprotocol.io/">Model Context Protocol</a> is an open standard for connecting AI tools. See also <a href="/features/remote-mcp/">Remote MCP Servers</a> for connecting to cloud services.</p>
+  <p>The <a href="https://modelcontextprotocol.io/">Model Context Protocol</a> is an open standard for connecting AI tools. See also <a href="{{ '/features/remote-mcp/' | relative_url }}">Remote MCP Servers</a> for connecting to cloud services.</p>
 
 </div>
 

--- a/docs/features/skills/index.md
+++ b/docs/features/skills/index.md
@@ -129,6 +129,6 @@ The skill will automatically be available to any agent with `skills: true`.
 <div class="callout callout-info">
 <div class="callout-title">ℹ️ See also
 </div>
-  <p>Skills are enabled in the <a href="/configuration/agents/">Agent Config</a> with the <code>skills: true</code> property. For tool-based capabilities, see <a href="/concepts/tools/">Tools</a>.</p>
+  <p>Skills are enabled in the <a href="{{ '/configuration/agents/' | relative_url }}">Agent Config</a> with the <code>skills: true</code> property. For tool-based capabilities, see <a href="{{ '/concepts/tools/' | relative_url }}">Tools</a>.</p>
 
 </div>

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -9,7 +9,7 @@ permalink: /features/tui/
 _docker-agent's default interface is a rich, interactive terminal UI with file attachments, themes, session management, and more._
 
 <div class="demo-container">
-  <img src="/demo.gif" alt="docker-agent TUI in action showing an interactive agent session" loading="lazy">
+  <img src="{{ '/demo.gif' | relative_url }}" alt="docker-agent TUI in action showing an interactive agent session" loading="lazy">
 </div>
 
 ## Launching the TUI

--- a/docs/getting-started/installation/index.md
+++ b/docs/getting-started/installation/index.md
@@ -129,12 +129,12 @@ $ docker agent run agentcatalog/pirate
 ## What's Next?
 
 <div class="cards">
-  <a class="card" href="/getting-started/quickstart/">
+  <a class="card" href="{{ '/getting-started/quickstart/' | relative_url }}">
     <div class="card-icon">⚡</div>
     <h3>Quick Start</h3>
     <p>Create and run your first agent in under 5 minutes.</p>
   </a>
-  <a class="card" href="/community/troubleshooting/">
+  <a class="card" href="{{ '/community/troubleshooting/' | relative_url }}">
     <div class="card-icon">🔧</div>
     <h3>Troubleshooting</h3>
     <p>Something not working? Debug mode, common issues, and solutions.</p>

--- a/docs/getting-started/introduction/index.md
+++ b/docs/getting-started/introduction/index.md
@@ -91,19 +91,19 @@ $ docker agent run agent.yaml
 <div class="callout callout-tip">
 <div class="callout-title">💡 Tip
 </div>
-  <p>Jump straight to the <a href="/getting-started/quickstart/">Quick Start</a> if you want to build your first agent right away.</p>
+  <p>Jump straight to the <a href="{{ '/getting-started/quickstart/' | relative_url }}">Quick Start</a> if you want to build your first agent right away.</p>
 
 </div>
 
 ## What's Next?
 
 <div class="cards">
-  <a class="card" href="/getting-started/installation/">
+  <a class="card" href="{{ '/getting-started/installation/' | relative_url }}">
     <div class="card-icon">📥</div>
     <h3>Installation</h3>
     <p>Install docker-agent on macOS, Linux, or Windows.</p>
   </a>
-  <a class="card" href="/getting-started/quickstart/">
+  <a class="card" href="{{ '/getting-started/quickstart/' | relative_url }}">
     <div class="card-icon">⚡</div>
     <h3>Quick Start</h3>
     <p>Build your first agent in under 5 minutes.</p>

--- a/docs/getting-started/quickstart/index.md
+++ b/docs/getting-started/quickstart/index.md
@@ -139,22 +139,22 @@ agents:
 ## What's Next?
 
 <div class="cards">
-  <a class="card" href="/concepts/agents/">
+  <a class="card" href="{{ '/concepts/agents/' | relative_url }}">
     <div class="card-icon">🤖</div>
     <h3>Understand Agents</h3>
     <p>Learn how agents work and what you can configure.</p>
   </a>
-  <a class="card" href="/concepts/multi-agent/">
+  <a class="card" href="{{ '/concepts/multi-agent/' | relative_url }}">
     <div class="card-icon">👥</div>
     <h3>Multi-Agent Systems</h3>
     <p>Build teams of collaborating agents.</p>
   </a>
-  <a class="card" href="/configuration/overview/">
+  <a class="card" href="{{ '/configuration/overview/' | relative_url }}">
     <div class="card-icon">📚</div>
     <h3>Configuration Reference</h3>
     <p>Full reference for all YAML options.</p>
   </a>
-  <a class="card" href="/community/troubleshooting/">
+  <a class="card" href="{{ '/community/troubleshooting/' | relative_url }}">
     <div class="card-icon">🔧</div>
     <h3>Troubleshooting</h3>
     <p>Something not working? Debug tips and common fixes.</p>

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ permalink: /
   <h1>docker-agent</h1>
   <p>Build, run, and share powerful AI agents with a declarative YAML config, rich tool ecosystem, and multi-agent orchestration — by Docker.</p>
   <div class="hero-buttons">
-    <a href="/getting-started/introduction/" class="btn btn-primary">Get Started</a>
+    <a href="{{ '/getting-started/introduction/' | relative_url }}" class="btn btn-primary">Get Started</a>
     <a href="https://github.com/docker/cagent" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">GitHub →</a>
   </div>
 </div>
@@ -84,33 +84,33 @@ docker agent run --exec agent.yaml "Explain the code in main.go"
 ## Explore the Docs
 
 <div class="cards">
-<a class="card" href="/getting-started/introduction/">
+<a class="card" href="{{ '/getting-started/introduction/' | relative_url }}">
     <div class="card-icon">🚀
 </div>
     <h3>Getting Started</h3>
     <p>Learn what docker agent is and get your first agent running in minutes.</p>
   </a>
-  <a class="card" href="/concepts/agents/">
+  <a class="card" href="{{ '/concepts/agents/' | relative_url }}">
     <div class="card-icon">💡</div>
     <h3>Core Concepts</h3>
     <p>Understand agents, models, tools, and multi-agent orchestration.</p>
   </a>
-  <a class="card" href="/configuration/overview/">
+  <a class="card" href="{{ '/configuration/overview/' | relative_url }}">
     <div class="card-icon">⚙️</div>
     <h3>Configuration</h3>
     <p>Complete reference for agent, model, and tool configuration.</p>
   </a>
-  <a class="card" href="/features/tui/">
+  <a class="card" href="{{ '/features/tui/' | relative_url }}">
     <div class="card-icon">✨</div>
     <h3>Features</h3>
     <p>TUI, CLI, MCP mode, RAG, Skills, and distribution.</p>
   </a>
-  <a class="card" href="/providers/overview/">
+  <a class="card" href="{{ '/providers/overview/' | relative_url }}">
     <div class="card-icon">🧠</div>
     <h3>Model Providers</h3>
     <p>OpenAI, Anthropic, Gemini, AWS Bedrock, Docker Model Runner, and custom providers.</p>
   </a>
-  <a class="card" href="/community/contributing/">
+  <a class="card" href="{{ '/community/contributing/' | relative_url }}">
     <div class="card-icon">🤝</div>
     <h3>Community</h3>
     <p>Contributing guidelines, troubleshooting, and more.</p>

--- a/docs/providers/local/index.md
+++ b/docs/providers/local/index.md
@@ -19,7 +19,7 @@ docker-agent can connect to any OpenAI-compatible local model server. This guide
 <div class="callout callout-tip">
 <div class="callout-title">💡 Docker Model Runner
 </div>
-  <p>For the easiest local model experience, consider <a href="/providers/dmr/">Docker Model Runner</a> which is built into Docker Desktop and requires no additional setup.</p>
+  <p>For the easiest local model experience, consider <a href="{{ '/providers/dmr/' | relative_url }}">Docker Model Runner</a> which is built into Docker Desktop and requires no additional setup.</p>
 
 </div>
 

--- a/docs/providers/openai/index.md
+++ b/docs/providers/openai/index.md
@@ -62,7 +62,7 @@ models:
 <div class="callout callout-tip">
 <div class="callout-title">💡 Custom endpoints
 </div>
-  <p>Use <code>base_url</code> for proxies and OpenAI-compatible services. See <a href="/providers/custom/">Custom Providers</a> for full setup.</p>
+  <p>Use <code>base_url</code> for proxies and OpenAI-compatible services. See <a href="{{ '/providers/custom/' | relative_url }}">Custom Providers</a> for full setup.</p>
 
 </div>
 

--- a/docs/providers/overview/index.md
+++ b/docs/providers/overview/index.md
@@ -11,32 +11,32 @@ _docker-agent supports multiple AI model providers. Choose the right one for you
 ## Supported Providers
 
 <div class="cards">
-  <a class="card" href="/providers/openai/">
+  <a class="card" href="{{ '/providers/openai/' | relative_url }}">
     <div class="card-icon">🟢</div>
     <h3>OpenAI</h3>
     <p>GPT-4o, GPT-5, GPT-5-mini. The most widely used AI models.</p>
   </a>
-  <a class="card" href="/providers/anthropic/">
+  <a class="card" href="{{ '/providers/anthropic/' | relative_url }}">
     <div class="card-icon">🟠</div>
     <h3>Anthropic</h3>
     <p>Claude Sonnet 4, Claude Sonnet 4.5. Excellent for coding and analysis.</p>
   </a>
-  <a class="card" href="/providers/google/">
+  <a class="card" href="{{ '/providers/google/' | relative_url }}">
     <div class="card-icon">🔵</div>
     <h3>Google Gemini</h3>
     <p>Gemini 2.5 Flash, Gemini 3 Pro. Fast and cost-effective.</p>
   </a>
-  <a class="card" href="/providers/bedrock/">
+  <a class="card" href="{{ '/providers/bedrock/' | relative_url }}">
     <div class="card-icon">🟡</div>
     <h3>AWS Bedrock</h3>
     <p>Access Claude, Nova, Llama, and more through AWS infrastructure.</p>
   </a>
-  <a class="card" href="/providers/dmr/">
+  <a class="card" href="{{ '/providers/dmr/' | relative_url }}">
     <div class="card-icon">🐳</div>
     <h3>Docker Model Runner</h3>
     <p>Run models locally with Docker. No API keys, no costs.</p>
   </a>
-  <a class="card" href="/providers/custom/">
+  <a class="card" href="{{ '/providers/custom/' | relative_url }}">
     <div class="card-icon">🔧</div>
     <h3>Custom Providers</h3>
     <p>Connect to any OpenAI-compatible API endpoint.</p>


### PR DESCRIPTION
Fixes 404 in many places in https://docker.github.io/cagent/

tested locally