### PR TITLE
Improve sub-sessions usage

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -2002,25 +2002,29 @@ func (r *LocalRuntime) handleTaskTransfer(ctx context.Context, sess *session.Ses
 		session.WithParentID(sess.ID),
 	)
 
-	for event := range r.RunStream(ctx, s) {
+	return r.runSubSession(ctx, sess, s, span, evts, a.Name())
+}
+
+// runSubSession runs a child session within the parent, forwarding events and
+// propagating state (tool approvals, thinking) back to the parent when done.
+func (r *LocalRuntime) runSubSession(ctx context.Context, parent, child *session.Session, span trace.Span, evts chan Event, agentName string) (*tools.ToolCallResult, error) {
+	for event := range r.RunStream(ctx, child) {
 		evts <- event
 		if errEvent, ok := event.(*ErrorEvent); ok {
 			span.RecordError(fmt.Errorf("%s", errEvent.Error))
-			span.SetStatus(codes.Error, "error in transferred session")
+			span.SetStatus(codes.Error, "sub-session error")
 			return nil, fmt.Errorf("%s", errEvent.Error)
 		}
 	}
 
-	sess.ToolsApproved = s.ToolsApproved
-	sess.Thinking = s.Thinking
+	parent.ToolsApproved = child.ToolsApproved
+	parent.Thinking = child.Thinking
 
-	sess.AddSubSession(s)
-	evts <- SubSessionCompleted(sess.ID, s, a.Name())
+	parent.AddSubSession(child)
+	evts <- SubSessionCompleted(parent.ID, child, agentName)
 
-	slog.Debug("Task transfer completed", "agent", params.Agent, "task", params.Task)
-
-	span.SetStatus(codes.Ok, "task transfer completed")
-	return tools.ResultSuccess(s.GetLastAssistantMessageContent()), nil
+	span.SetStatus(codes.Ok, "sub-session completed")
+	return tools.ResultSuccess(child.GetLastAssistantMessageContent()), nil
 }
 
 func (r *LocalRuntime) handleHandoff(_ context.Context, _ *session.Session, toolCall tools.ToolCall, _ chan Event) (*tools.ToolCallResult, error) {

--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -130,6 +130,7 @@ type model struct {
 	toolsLoading       bool // true when more tools may still be loading
 	sessionState       *service.SessionState
 	workingAgent       string // Name of the agent currently working (empty if none)
+	currentSessionID   string // Session ID of the currently active stream
 	scrollview         *scrollview.Model
 	workingDirectory   string
 	queuedMessages     []string // Truncated preview of queued messages
@@ -484,17 +485,22 @@ func formatCost(cost float64) string {
 	return fmt.Sprintf("%.2f", cost)
 }
 
-// contextPercent returns a context usage percentage string for the current agent's session.
-// It looks up the session belonging to the current agent; if none is found, it falls back
-// to returning the percentage when there is exactly one session.
-func (m *model) contextPercent() string {
-	// Try to find the session belonging to the current agent.
+// currentSessionUsage returns the usage snapshot for the current agent's session.
+// It uses a 3-tier lookup: session ID (most reliable) → agent name → single-session fallback.
+func (m *model) currentSessionUsage() (*runtime.Usage, bool) {
+	// Direct lookup by current session ID (most reliable, no map iteration ambiguity).
+	if m.currentSessionID != "" {
+		if usage, ok := m.sessionUsage[m.currentSessionID]; ok {
+			return usage, true
+		}
+	}
+
+	// Fallback: search by current agent name.
 	if m.currentAgent != "" {
 		for sessionID, agentName := range m.sessionAgent {
 			if agentName == m.currentAgent {
-				if usage, ok := m.sessionUsage[sessionID]; ok && usage.ContextLimit > 0 {
-					percent := (float64(usage.ContextLength) / float64(usage.ContextLimit)) * 100
-					return fmt.Sprintf("%.0f%%", percent)
+				if usage, ok := m.sessionUsage[sessionID]; ok {
+					return usage, true
 				}
 			}
 		}
@@ -503,11 +509,25 @@ func (m *model) contextPercent() string {
 	// Fallback: if there's exactly one session, use it.
 	if len(m.sessionUsage) == 1 {
 		for _, usage := range m.sessionUsage {
-			if usage.ContextLimit > 0 {
-				percent := (float64(usage.ContextLength) / float64(usage.ContextLimit)) * 100
-				return fmt.Sprintf("%.0f%%", percent)
-			}
+			return usage, true
 		}
+	}
+	return nil, false
+}
+
+// currentSessionTokens returns the token count for the current agent's session.
+func (m *model) currentSessionTokens() (tokens int64, found bool) {
+	if usage, ok := m.currentSessionUsage(); ok {
+		return usage.InputTokens + usage.OutputTokens, true
+	}
+	return 0, false
+}
+
+// contextPercent returns a context usage percentage string for the current agent's session.
+func (m *model) contextPercent() string {
+	if usage, ok := m.currentSessionUsage(); ok && usage.ContextLimit > 0 {
+		percent := (float64(usage.ContextLength) / float64(usage.ContextLimit)) * 100
+		return fmt.Sprintf("%.0f%%", percent)
 	}
 	return ""
 }
@@ -626,6 +646,7 @@ func (m *model) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		// New stream starting - reset cancelled flag and enable spinner
 		m.streamCancelled = false
 		m.workingAgent = msg.AgentName
+		m.currentSessionID = msg.SessionID
 		// If title hasn't been generated yet, show the title generation spinner
 		if !m.titleGenerated {
 			m.titleRegenerating = true
@@ -987,22 +1008,40 @@ func (m *model) formatProgress(state *ragIndexingState) string {
 	return ""
 }
 
-func (m *model) tokenUsage(contentWidth int) string {
-	var totalTokens int64
-	var totalCost float64
+// usageStats holds aggregated usage statistics across all sessions, computed
+// once so both tokenUsage (vertical) and tokenUsageSummary (collapsed) can
+// reuse the values without duplicating the computation logic.
+type usageStats struct {
+	tokens       int64
+	contextPct   string
+	totalCost    float64
+	sessionCount int
+}
+
+func (m *model) computeUsageStats() usageStats {
+	var s usageStats
 	for _, usage := range m.sessionUsage {
-		totalTokens += usage.InputTokens + usage.OutputTokens
-		totalCost += usage.Cost
+		s.totalCost += usage.Cost
+		s.sessionCount++
+	}
+	s.tokens, _ = m.currentSessionTokens()
+	s.contextPct = m.contextPercent()
+	return s
+}
+
+func (m *model) tokenUsage(contentWidth int) string {
+	s := m.computeUsageStats()
+
+	line := formatTokenCount(s.tokens)
+	if s.contextPct != "" {
+		line += " (" + s.contextPct + ")"
+	}
+	line += " " + styles.TabAccentStyle.Render("$"+formatCost(s.totalCost))
+	if s.sessionCount > 1 {
+		line += " " + styles.MutedStyle.Render(fmt.Sprintf("(%d sub-sessions)", s.sessionCount-1))
 	}
 
-	var tokenUsage strings.Builder
-	fmt.Fprintf(&tokenUsage, "%s", formatTokenCount(totalTokens))
-	if ctxText := m.contextPercent(); ctxText != "" {
-		fmt.Fprintf(&tokenUsage, " (%s)", ctxText)
-	}
-	fmt.Fprintf(&tokenUsage, " %s", styles.TabAccentStyle.Render("$"+formatCost(totalCost)))
-
-	return m.renderTab("Token Usage", tokenUsage.String(), contentWidth)
+	return m.renderTab("Token Usage", line, contentWidth)
 }
 
 // tokenUsageSummary returns a single-line summary for horizontal layout.
@@ -1011,18 +1050,22 @@ func (m *model) tokenUsageSummary() string {
 		return ""
 	}
 
-	var totalTokens int64
-	var totalCost float64
-	for _, usage := range m.sessionUsage {
-		totalTokens += usage.InputTokens + usage.OutputTokens
-		totalCost += usage.Cost
+	s := m.computeUsageStats()
+
+	parts := []string{fmt.Sprintf("Tokens: %s", formatTokenCount(s.tokens))}
+	if s.sessionCount > 1 {
+		if s.contextPct != "" {
+			parts = append(parts, fmt.Sprintf("Context: %s", s.contextPct))
+		}
+		parts = append(parts, fmt.Sprintf("Cost: $%s", formatCost(s.totalCost)), fmt.Sprintf("%d sub-sessions", s.sessionCount-1))
+	} else {
+		parts = append(parts, fmt.Sprintf("Cost: $%s", formatCost(s.totalCost)))
+		if s.contextPct != "" {
+			parts = append(parts, fmt.Sprintf("Context: %s", s.contextPct))
+		}
 	}
 
-	if ctxText := m.contextPercent(); ctxText != "" {
-		return fmt.Sprintf("Tokens: %s | Cost: $%s | Context: %s", formatTokenCount(totalTokens), formatCost(totalCost), ctxText)
-	}
-
-	return fmt.Sprintf("Tokens: %s | Cost: $%s", formatTokenCount(totalTokens), formatCost(totalCost))
+	return strings.Join(parts, " | ")
 }
 
 func (m *model) sessionInfo(contentWidth int) string {

--- a/pkg/tui/components/sidebar/token_usage_test.go
+++ b/pkg/tui/components/sidebar/token_usage_test.go
@@ -1,0 +1,278 @@
+package sidebar
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/docker/cagent/pkg/runtime"
+	"github.com/docker/cagent/pkg/session"
+	"github.com/docker/cagent/pkg/tui/service"
+)
+
+func TestCurrentSessionTokens_SingleSession(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	sessionState := service.NewSessionState(sess)
+	m := New(sessionState).(*model)
+
+	m.SetTokenUsage(&runtime.TokenUsageEvent{
+		SessionID:    "session-1",
+		AgentContext: runtime.AgentContext{AgentName: "root"},
+		Usage: &runtime.Usage{
+			InputTokens:  5000,
+			OutputTokens: 3000,
+		},
+	})
+
+	m.currentAgent = "root"
+	tokens, found := m.currentSessionTokens()
+	assert.True(t, found)
+	assert.Equal(t, int64(8000), tokens)
+}
+
+func TestCurrentSessionTokens_MultipleSessions(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	sessionState := service.NewSessionState(sess)
+	m := New(sessionState).(*model)
+
+	m.SetTokenUsage(&runtime.TokenUsageEvent{
+		SessionID:    "session-root",
+		AgentContext: runtime.AgentContext{AgentName: "root"},
+		Usage: &runtime.Usage{
+			InputTokens:  20000,
+			OutputTokens: 10000,
+		},
+	})
+
+	m.SetTokenUsage(&runtime.TokenUsageEvent{
+		SessionID:    "session-child",
+		AgentContext: runtime.AgentContext{AgentName: "developer"},
+		Usage: &runtime.Usage{
+			InputTokens:  8000,
+			OutputTokens: 2000,
+		},
+	})
+
+	// Current agent is developer — should return developer's tokens
+	m.currentAgent = "developer"
+	m.currentSessionID = "session-child"
+	tokens, found := m.currentSessionTokens()
+	assert.True(t, found)
+	assert.Equal(t, int64(10000), tokens)
+
+	// Switch to root — should return root's tokens
+	m.currentAgent = "root"
+	m.currentSessionID = "session-root"
+	tokens, found = m.currentSessionTokens()
+	assert.True(t, found)
+	assert.Equal(t, int64(30000), tokens)
+}
+
+func TestCurrentSessionTokens_FallbackToSingleSession(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	sessionState := service.NewSessionState(sess)
+	m := New(sessionState).(*model)
+
+	m.sessionUsage["session-1"] = &runtime.Usage{
+		InputTokens:  5000,
+		OutputTokens: 5000,
+	}
+
+	tokens, found := m.currentSessionTokens()
+	assert.True(t, found)
+	assert.Equal(t, int64(10000), tokens)
+}
+
+func TestCurrentSessionTokens_Empty(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	sessionState := service.NewSessionState(sess)
+	m := New(sessionState).(*model)
+
+	tokens, found := m.currentSessionTokens()
+	assert.False(t, found)
+	assert.Equal(t, int64(0), tokens)
+}
+
+func TestCurrentSessionTokens_SessionIDTakesPrecedence(t *testing.T) {
+	t.Parallel()
+
+	// This test verifies the fix for the flickering bug.
+	// When the same agent runs multiple sessions (e.g., transfer_task called
+	// twice to the same sub-agent, or new_session for the same agent), the
+	// agent name lookup in sessionAgent is ambiguous because Go map iteration
+	// order is non-deterministic. Using currentSessionID for direct lookup
+	// eliminates this ambiguity.
+
+	sess := session.New()
+	sessionState := service.NewSessionState(sess)
+	m := New(sessionState).(*model)
+
+	// Same agent "developer" has two sessions (e.g., transfer_task called twice)
+	m.SetTokenUsage(&runtime.TokenUsageEvent{
+		SessionID:    "child-session-1",
+		AgentContext: runtime.AgentContext{AgentName: "developer"},
+		Usage: &runtime.Usage{
+			InputTokens:  5000,
+			OutputTokens: 5000,
+		},
+	})
+
+	m.SetTokenUsage(&runtime.TokenUsageEvent{
+		SessionID:    "child-session-2",
+		AgentContext: runtime.AgentContext{AgentName: "developer"},
+		Usage: &runtime.Usage{
+			InputTokens:  20000,
+			OutputTokens: 10000,
+		},
+	})
+
+	m.currentAgent = "developer"
+	m.currentSessionID = "child-session-2"
+
+	// Must consistently return session-2's tokens, not randomly pick between them
+	for range 100 {
+		tokens, found := m.currentSessionTokens()
+		assert.True(t, found)
+		assert.Equal(t, int64(30000), tokens, "currentSessionTokens() returned inconsistent value — the flickering bug is back")
+	}
+}
+
+func TestTokenUsageSummary_SingleSession(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	sessionState := service.NewSessionState(sess)
+	m := New(sessionState).(*model)
+
+	m.SetTokenUsage(&runtime.TokenUsageEvent{
+		SessionID:    "session-1",
+		AgentContext: runtime.AgentContext{AgentName: "root"},
+		Usage: &runtime.Usage{
+			InputTokens:   5000,
+			OutputTokens:  3000,
+			ContextLength: 8000,
+			ContextLimit:  100000,
+			Cost:          0.05,
+		},
+	})
+
+	m.currentAgent = "root"
+	m.currentSessionID = "session-1"
+	summary := m.tokenUsageSummary()
+	// Single session: shows total tokens, cost, and context
+	assert.Contains(t, summary, "Tokens: 8.0K")
+	assert.Contains(t, summary, "Cost: $0.05")
+	assert.Contains(t, summary, "Context: 8%")
+	assert.NotContains(t, summary, "sub-sessions")
+}
+
+func TestTokenUsageSummary_MultipleSessions_ShowsCurrentSessionTokens(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	sessionState := service.NewSessionState(sess)
+	m := New(sessionState).(*model)
+
+	// Root agent session: 30K tokens, $0.10
+	m.SetTokenUsage(&runtime.TokenUsageEvent{
+		SessionID:    "session-root",
+		AgentContext: runtime.AgentContext{AgentName: "root"},
+		Usage: &runtime.Usage{
+			InputTokens:   20000,
+			OutputTokens:  10000,
+			ContextLength: 30000,
+			ContextLimit:  100000,
+			Cost:          0.10,
+		},
+	})
+
+	// Child agent session: 10K tokens, $0.05
+	m.SetTokenUsage(&runtime.TokenUsageEvent{
+		SessionID:    "session-child",
+		AgentContext: runtime.AgentContext{AgentName: "developer"},
+		Usage: &runtime.Usage{
+			InputTokens:   8000,
+			OutputTokens:  2000,
+			ContextLength: 10000,
+			ContextLimit:  200000,
+			Cost:          0.05,
+		},
+	})
+
+	m.currentAgent = "root"
+	m.currentSessionID = "session-root"
+	summary := m.tokenUsageSummary()
+	// Should show current session (root) tokens, not total
+	assert.Contains(t, summary, "Tokens: 30.0K")
+	// Should show total cost ($0.10 + $0.05)
+	assert.Contains(t, summary, "Cost: $0.15")
+	// Should show context % for root session
+	assert.Contains(t, summary, "Context: 30%")
+	// Should show sub-session count
+	assert.Contains(t, summary, "1 sub-sessions")
+
+	// Switch to developer
+	m.currentAgent = "developer"
+	m.currentSessionID = "session-child"
+	summary = m.tokenUsageSummary()
+	// Should show current session (developer) tokens
+	assert.Contains(t, summary, "Tokens: 10.0K")
+	// Should still show total cost
+	assert.Contains(t, summary, "Cost: $0.15")
+	// Should show context % for developer session
+	assert.Contains(t, summary, "Context: 5%")
+}
+
+func TestTokenUsageSummary_Empty(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	sessionState := service.NewSessionState(sess)
+	m := New(sessionState).(*model)
+
+	assert.Empty(t, m.tokenUsageSummary())
+}
+
+func TestContextPercent_SessionIDTakesPrecedence(t *testing.T) {
+	t.Parallel()
+
+	// Same flickering bug applies to contextPercent — verify session ID lookup
+	// takes precedence over non-deterministic agent name map iteration.
+
+	sess := session.New()
+	sessionState := service.NewSessionState(sess)
+	m := New(sessionState).(*model)
+
+	m.SetTokenUsage(&runtime.TokenUsageEvent{
+		SessionID:    "child-session-1",
+		AgentContext: runtime.AgentContext{AgentName: "developer"},
+		Usage: &runtime.Usage{
+			ContextLength: 10000,
+			ContextLimit:  100000,
+		},
+	})
+
+	m.SetTokenUsage(&runtime.TokenUsageEvent{
+		SessionID:    "child-session-2",
+		AgentContext: runtime.AgentContext{AgentName: "developer"},
+		Usage: &runtime.Usage{
+			ContextLength: 50000,
+			ContextLimit:  100000,
+		},
+	})
+
+	m.currentAgent = "developer"
+	m.currentSessionID = "child-session-2"
+
+	for range 100 {
+		assert.Equal(t, "50%", m.contextPercent(), "contextPercent() returned inconsistent value — the flickering bug is back")
+	}
+}

--- a/pkg/tui/dialog/cost.go
+++ b/pkg/tui/dialog/cost.go
@@ -92,8 +92,9 @@ func (d *costDialog) View() string {
 
 type totalUsage struct {
 	chat.Usage
-	label string
-	cost  float64
+	label  string
+	cost   float64
+	marker bool // true for visual separators (sub-session boundaries)
 }
 
 func (u *totalUsage) add(cost float64, usage *chat.Usage) {
@@ -108,6 +109,12 @@ func (u *totalUsage) totalInput() int64 {
 	return u.InputTokens + u.CachedInputTokens + u.CacheWriteTokens
 }
 
+// isSubSessionMarker returns true if this entry is a visual separator rather
+// than an actual usage record (e.g. "── sub-session start ──").
+func (u *totalUsage) isSubSessionMarker() bool {
+	return u.marker
+}
+
 // costData holds aggregated cost data for display.
 type costData struct {
 	total             totalUsage
@@ -119,6 +126,7 @@ type costData struct {
 func (d *costDialog) gatherCostData() costData {
 	var data costData
 	modelMap := make(map[string]*totalUsage)
+	msgCounter := 0 // sequential counter across parent and sub-sessions
 
 	// Helper to add a usage record to the aggregated data
 	addRecord := func(agentName, model string, cost float64, usage *chat.Usage) {
@@ -133,9 +141,10 @@ func (d *costDialog) gatherCostData() costData {
 		modelMap[model].add(cost, usage)
 
 		// Per-message usage
-		msgLabel := fmt.Sprintf("#%d", len(data.messages)+1)
+		msgCounter++
+		msgLabel := fmt.Sprintf("#%d", msgCounter)
 		if agentName != "" {
-			msgLabel = fmt.Sprintf("#%d [%s]", len(data.messages)+1, agentName)
+			msgLabel = fmt.Sprintf("#%d [%s]", msgCounter, agentName)
 		}
 		data.messages = append(data.messages, totalUsage{
 			label: msgLabel,
@@ -155,24 +164,45 @@ func (d *costDialog) gatherCostData() costData {
 		})
 	}
 
-	// Try session messages first (local mode), then MessageUsageHistory (remote mode)
-	for _, msg := range d.session.GetAllMessages() {
-		if msg.Message.Usage != nil {
-			addRecord(msg.AgentName, msg.Message.Model, msg.Message.Cost, msg.Message.Usage)
-		}
+	// addSubSessionMarker adds a visual separator for a sub-session boundary.
+	addSubSessionMarker := func(label string) {
+		data.messages = append(data.messages, totalUsage{label: label, marker: true})
 	}
-	if !data.hasPerMessageData {
-		for _, record := range d.session.MessageUsageHistory {
-			addRecord(record.AgentName, record.Model, record.Cost, &record.Usage)
+
+	// walkSession recursively walks session items, inserting sub-session
+	// boundary markers so the "By Message" section shows clear grouping.
+	var walkSession func(sess *session.Session)
+	walkSession = func(sess *session.Session) {
+		for _, item := range sess.Messages {
+			switch {
+			case item.IsMessage():
+				msg := item.Message
+				if msg.Message.Role != chat.MessageRoleSystem && msg.Message.Usage != nil {
+					addRecord(msg.AgentName, msg.Message.Model, msg.Message.Cost, msg.Message.Usage)
+				}
+			case item.IsSubSession():
+				addSubSessionMarker("── sub-session start ──")
+				walkSession(item.SubSession)
+				subCost := item.SubSession.TotalCost()
+				if subCost > 0 {
+					addSubSessionMarker(fmt.Sprintf("── sub-session end (%s) ──", formatCost(subCost)))
+				} else {
+					addSubSessionMarker("── sub-session end ──")
+				}
+			}
+			if item.Summary != "" && item.Cost > 0 {
+				addCompactionCost(item.Cost)
+			}
 		}
 	}
 
-	// Include compaction costs from summary items. These are stored on
-	// session items that have a Summary but no Message, so they are not
-	// returned by GetAllMessages().
-	for _, item := range d.session.Messages {
-		if item.Summary != "" && item.Cost > 0 {
-			addCompactionCost(item.Cost)
+	// Walk session items (local mode) to preserve sub-session structure.
+	walkSession(d.session)
+
+	// Fall back to remote mode if no per-message data was found.
+	if !data.hasPerMessageData {
+		for _, record := range d.session.MessageUsageHistory {
+			addRecord(record.AgentName, record.Model, record.Cost, &record.Usage)
 		}
 	}
 
@@ -227,7 +257,11 @@ func (d *costDialog) renderContent(contentWidth, maxHeight int) string {
 	if len(data.messages) > 0 {
 		lines = append(lines, sectionStyle().Render("By Message"), "")
 		for _, m := range data.messages {
-			lines = append(lines, d.renderUsageLine(m))
+			if m.isSubSessionMarker() {
+				lines = append(lines, styles.MutedStyle.Render(m.label))
+			} else {
+				lines = append(lines, d.renderUsageLine(m))
+			}
 		}
 		lines = append(lines, "")
 	} else if !data.hasPerMessageData && data.total.cost > 0 {
@@ -310,8 +344,12 @@ func (d *costDialog) renderPlainText() string {
 	if len(data.messages) > 0 {
 		lines = append(lines, "By Message")
 		for _, m := range data.messages {
-			lines = append(lines, fmt.Sprintf("%-8s  input: %-8s  output: %-8s  %s",
-				formatCostPadded(m.cost), formatTokenCount(m.totalInput()), formatTokenCount(m.OutputTokens), m.label))
+			if m.isSubSessionMarker() {
+				lines = append(lines, m.label)
+			} else {
+				lines = append(lines, fmt.Sprintf("%-8s  input: %-8s  output: %-8s  %s",
+					formatCostPadded(m.cost), formatTokenCount(m.totalInput()), formatTokenCount(m.OutputTokens), m.label))
+			}
 		}
 	}
 

--- a/pkg/tui/dialog/cost_test.go
+++ b/pkg/tui/dialog/cost_test.go
@@ -189,6 +189,119 @@ func TestCostDialogCompactionCostRendersInView(t *testing.T) {
 	assert.Contains(t, view, "$0.0070") // total: 0.005 + 0.002
 }
 
+func TestCostDialogWithSubSessions(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+
+	// Add a parent message with usage
+	sess.AddMessage(&session.Message{
+		AgentName: "root",
+		Message: chat.Message{
+			Role:    chat.MessageRoleAssistant,
+			Content: "Let me create a sub-session",
+			Model:   "gpt-4o",
+			Usage: &chat.Usage{
+				InputTokens:  1000,
+				OutputTokens: 200,
+			},
+			Cost: 0.005,
+		},
+	})
+
+	// Create a sub-session with its own messages
+	subSess := session.New()
+	subSess.AddMessage(&session.Message{
+		AgentName: "sub-agent",
+		Message: chat.Message{
+			Role:    chat.MessageRoleAssistant,
+			Content: "Working on it",
+			Model:   "gpt-4o-mini",
+			Usage: &chat.Usage{
+				InputTokens:  500,
+				OutputTokens: 100,
+			},
+			Cost: 0.001,
+		},
+	})
+	subSess.AddMessage(&session.Message{
+		AgentName: "sub-agent",
+		Message: chat.Message{
+			Role:    chat.MessageRoleAssistant,
+			Content: "Done!",
+			Model:   "gpt-4o-mini",
+			Usage: &chat.Usage{
+				InputTokens:  600,
+				OutputTokens: 150,
+			},
+			Cost: 0.002,
+		},
+	})
+
+	sess.AddSubSession(subSess)
+
+	// Gather cost data
+	data := (&costDialog{session: sess}).gatherCostData()
+
+	// Total cost should include parent + sub-session messages
+	assert.InDelta(t, 0.008, data.total.cost, 0.0001)
+
+	// Messages should include: parent msg, sub-session start marker, 2 sub-session msgs, sub-session end marker
+	require.Len(t, data.messages, 5)
+	assert.Equal(t, "#1 [root]", data.messages[0].label)
+	assert.True(t, data.messages[1].isSubSessionMarker(), "expected sub-session start marker")
+	assert.Contains(t, data.messages[1].label, "sub-session start")
+	assert.Equal(t, "#2 [sub-agent]", data.messages[2].label)
+	assert.Equal(t, "#3 [sub-agent]", data.messages[3].label)
+	assert.True(t, data.messages[4].isSubSessionMarker(), "expected sub-session end marker")
+	assert.Contains(t, data.messages[4].label, "sub-session end")
+	assert.Contains(t, data.messages[4].label, "$0.0030") // sub-session total cost
+}
+
+func TestCostDialogSubSessionRendersInView(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+
+	sess.AddMessage(&session.Message{
+		AgentName: "root",
+		Message: chat.Message{
+			Role:    chat.MessageRoleAssistant,
+			Content: "Creating sub-session",
+			Model:   "gpt-4o",
+			Usage: &chat.Usage{
+				InputTokens:  1000,
+				OutputTokens: 200,
+			},
+			Cost: 0.005,
+		},
+	})
+
+	subSess := session.New()
+	subSess.AddMessage(&session.Message{
+		AgentName: "sub-agent",
+		Message: chat.Message{
+			Role:    chat.MessageRoleAssistant,
+			Content: "Sub result",
+			Model:   "gpt-4o-mini",
+			Usage: &chat.Usage{
+				InputTokens:  400,
+				OutputTokens: 80,
+			},
+			Cost: 0.001,
+		},
+	})
+	sess.AddSubSession(subSess)
+
+	dialog := NewCostDialog(sess)
+	dialog.SetSize(100, 50)
+	view := dialog.View()
+
+	assert.Contains(t, view, "sub-session start")
+	assert.Contains(t, view, "sub-session end")
+	assert.Contains(t, view, "sub-agent")
+}
+
 func TestFormatCost(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tui/page/chat/runtime_events.go
+++ b/pkg/tui/page/chat/runtime_events.go
@@ -164,9 +164,15 @@ func (p *chatPage) handleTokenUsage(msg *runtime.TokenUsageEvent) {
 	p.sidebar.SetTokenUsage(msg)
 	if msg.Usage != nil {
 		if sess := p.app.Session(); sess != nil {
-			// Update session-level token counts (used for context % tracking)
-			sess.InputTokens = msg.Usage.InputTokens
-			sess.OutputTokens = msg.Usage.OutputTokens
+			// Only update the parent session's token counts when the event
+			// belongs to this session. Sub-sessions emit their own
+			// TokenUsageEvents with a different SessionID; writing those
+			// values into the parent would overwrite the parent's own
+			// context-tracking counters.
+			if msg.SessionID == "" || msg.SessionID == sess.ID {
+				sess.InputTokens = msg.Usage.InputTokens
+				sess.OutputTokens = msg.Usage.OutputTokens
+			}
 
 			// Track per-message usage for /cost dialog
 			if msg.Usage.LastMessage != nil {


### PR DESCRIPTION
Tries to fix the usage tracking of sub-sessions vs current session.
Should print the grand total price but the tokens and % only from the current session.

Assisted-By: cagent