### PR TITLE
Auto-pull DMR models in non-interactive mode

### DIFF
--- a/pkg/model/provider/dmr/client.go
+++ b/pkg/model/provider/dmr/client.go
@@ -971,19 +971,39 @@ func parseDMRProviderOpts(cfg *latest.ModelConfig) (contextSize *int64, runtimeF
 }
 
 func pullDockerModelIfNeeded(ctx context.Context, model string) error {
-	// Check if running in interactive mode (stdin is a terminal)
-	interactive := term.IsTerminal(int(os.Stdin.Fd()))
-	if !interactive {
-		// In non-interactive mode (CI / Servers), do not attempt to pull the model
-		return nil
-	}
-
 	if modelExists(ctx, model) {
 		slog.Debug("Model already exists, skipping pull", "model", model)
 		return nil
 	}
 
-	// Prompt user for confirmation in interactive mode
+	if err := confirmModelPull(ctx, model); err != nil {
+		return err
+	}
+
+	slog.Info("Pulling DMR model", "model", model)
+	fmt.Printf("Pulling model %s...\n", model)
+
+	cmd := exec.CommandContext(ctx, "docker", "model", "pull", model)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to pull model %s: %w", model, err)
+	}
+
+	slog.Info("Model pulled successfully", "model", model)
+	fmt.Printf("Model %s pulled successfully.\n", model)
+
+	return nil
+}
+
+// confirmModelPull asks for user confirmation in interactive mode.
+// In non-interactive mode (e.g. devcontainers, CI), it proceeds automatically.
+func confirmModelPull(ctx context.Context, model string) error {
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		slog.Info("Model not found locally, pulling automatically (non-interactive mode)", "model", model)
+		return nil
+	}
+
 	fmt.Printf("\nModel %s not found locally.\n", model)
 	fmt.Printf("Do you want to pull it now? ([y]es/[n]o): ")
 
@@ -996,19 +1016,6 @@ func pullDockerModelIfNeeded(ctx context.Context, model string) error {
 	if response != "y" && response != "yes" {
 		return fmt.Errorf("model pull declined by user")
 	}
-
-	// Pull the model
-	slog.Info("Pulling DMR model", "model", model)
-	fmt.Printf("Pulling model %s...\n", model)
-	cmd := exec.CommandContext(ctx, "docker", "model", "pull", model)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to pull model %s: %w", model, err)
-	}
-
-	slog.Info("Model pulled successfully", "model", model)
-	fmt.Printf("Model %s pulled successfully.\n", model)
 
 	return nil
 }


### PR DESCRIPTION
Fixes #1856

## Problem

When running cagent with `provider: dmr` in a devcontainer (or any non-interactive environment), `pullDockerModelIfNeeded` detected a non-interactive terminal via `term.IsTerminal()` and silently returned `nil` — skipping the model pull entirely. The client was created successfully but subsequent inference calls failed because the model was never downloaded.

## Solution

- **Auto-pull in non-interactive mode**: Instead of silently skipping, automatically pull the missing model without prompting. Interactive mode still prompts for user confirmation as before.
- **Check model existence first**: Moved the `modelExists` check before the interactivity check so we skip the pull early when the model is already present, regardless of mode.
- **Extract `confirmModelPull`**: Separated the confirmation concern from the pull logic for better readability.

## Also included

- Improvements to the `user_prompt` TUI dialog: customizable title, free-form text input, updated navigation keys and tests.