### PR TITLE
Add top-level mcps section for reusable MCP server definitions

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -48,6 +48,13 @@
         "$ref": "#/definitions/ModelConfig"
       }
     },
+    "mcps": {
+      "type": "object",
+      "description": "Map of reusable MCP server definitions. Define MCP servers here and reference them by name from agent toolsets to avoid duplication.",
+      "additionalProperties": {
+        "$ref": "#/definitions/MCPToolset"
+      }
+    },
     "rag": {
       "type": "object",
       "description": "Map of RAG (Retrieval-Augmented Generation) configurations",
@@ -683,6 +690,95 @@
       },
       "additionalProperties": false
     },
+    "MCPToolset": {
+      "type": "object",
+      "description": "Reusable MCP server definition. Define once at the top level and reference by name from agent toolsets.",
+      "properties": {
+        "command": {
+          "type": "string",
+          "description": "Command to run the MCP server (stdio transport)"
+        },
+        "args": {
+          "type": "array",
+          "description": "Arguments to pass to the command",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ref": {
+          "type": "string",
+          "description": "Docker MCP reference (e.g., 'docker:context7')",
+          "pattern": "^docker:"
+        },
+        "remote": {
+          "$ref": "#/definitions/Remote",
+          "description": "Remote MCP server configuration (SSE/streamable-http transport)"
+        },
+        "config": {
+          "description": "MCP server configuration (for docker refs)"
+        },
+        "version": {
+          "type": "string",
+          "description": "Version/package reference for auto-installation"
+        },
+        "env": {
+          "type": "object",
+          "description": "Environment variables for the MCP server",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "tools": {
+          "type": "array",
+          "description": "Optional list of tools to expose from the MCP server",
+          "items": {
+            "type": "string"
+          }
+        },
+        "instruction": {
+          "type": "string",
+          "description": "Optional instruction for the tools"
+        },
+        "name": {
+          "type": "string",
+          "description": "Optional display name override for the MCP server"
+        },
+        "defer": {
+          "description": "Deferred loading configuration for tools from this MCP server",
+          "oneOf": [
+            {
+              "type": "boolean",
+              "description": "Set to true to defer all tools"
+            },
+            {
+              "type": "array",
+              "description": "Array of tool names to defer",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "command"
+          ]
+        },
+        {
+          "required": [
+            "remote"
+          ]
+        },
+        {
+          "required": [
+            "ref"
+          ]
+        }
+      ],
+      "additionalProperties": false
+    },
     "Toolset": {
       "type": "object",
       "description": "Tool configuration",
@@ -718,8 +814,7 @@
         },
         "ref": {
           "type": "string",
-          "description": "Reference to external tool (e.g., docker:context7)",
-          "pattern": "^docker:"
+          "description": "Reference to a Docker MCP tool (e.g., 'docker:context7') or a named MCP definition from the top-level 'mcps' section"
         },
         "config": {
           "description": "Tool-specific configuration"

--- a/examples/mcp-definitions.yaml
+++ b/examples/mcp-definitions.yaml
@@ -1,0 +1,78 @@
+#!/usr/bin/env docker agent run
+# yaml-language-server: $schema=../agent-schema.json
+
+# This example demonstrates how to use the top-level `mcps` section to define
+# MCP servers once and reference them across multiple agents, avoiding duplication.
+
+models:
+  model:
+    provider: anthropic
+    model: claude-sonnet-4-0
+    max_tokens: 64000
+
+# Define MCP servers once at the top level.
+# Each entry can use `command`, `remote`, or `ref` (just like inline MCP toolsets).
+mcps:
+  context7:
+    ref: docker:context7
+
+  github:
+    ref: docker:github
+    env:
+      GITHUB_PERSONAL_ACCESS_TOKEN: "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+    tools:
+      - create_or_update_file
+      - search_repositories
+      - create_repository
+      - get_file_contents
+      - push_files
+      - create_issue
+      - create_pull_request
+      - list_issues
+
+agents:
+  root:
+    model: model
+    description: Lead developer
+    instruction: |
+      You are the lead developer. Coordinate the team.
+    sub_agents: [frontend, backend]
+    toolsets:
+      - type: filesystem
+      - type: think
+      # Reference the MCP definition by name — no need to repeat the full config.
+      - type: mcp
+        ref: context7
+      - type: mcp
+        ref: github
+
+  frontend:
+    model: model
+    description: Frontend engineer
+    instruction: |
+      You are a frontend engineer.
+    toolsets:
+      - type: filesystem
+      - type: shell
+      # Same MCP server, referenced by name.
+      - type: mcp
+        ref: context7
+      # Reference github MCP but override the tool list for this agent.
+      - type: mcp
+        ref: github
+        tools:
+          - get_file_contents
+          - search_repositories
+
+  backend:
+    model: model
+    description: Backend engineer
+    instruction: |
+      You are a backend engineer.
+    toolsets:
+      - type: filesystem
+      - type: shell
+      - type: mcp
+        ref: context7
+      - type: mcp
+        ref: github

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -113,6 +113,10 @@ func validateConfig(cfg *latest.Config) error {
 		return err
 	}
 
+	if err := resolveMCPDefinitions(cfg); err != nil {
+		return err
+	}
+
 	allNames := map[string]bool{}
 	for _, agent := range cfg.Agents {
 		allNames[agent.Name] = true

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -21,9 +21,32 @@ type Config struct {
 	Agents      Agents                    `json:"agents,omitempty"`
 	Providers   map[string]ProviderConfig `json:"providers,omitempty"`
 	Models      map[string]ModelConfig    `json:"models,omitempty"`
+	MCPs        map[string]MCPToolset     `json:"mcps,omitempty"`
 	RAG         map[string]RAGConfig      `json:"rag,omitempty"`
 	Metadata    Metadata                  `json:"metadata"`
 	Permissions *PermissionsConfig        `json:"permissions,omitempty"`
+}
+
+// MCPToolset is a reusable MCP server definition stored in the top-level
+// "mcps" section. It is identical to a Toolset but skips the normal
+// Toolset.validate() call during YAML unmarshaling because the "type"
+// field is implicit (always "mcp") and the source (command/remote/ref)
+// is validated later during config resolution.
+type MCPToolset struct {
+	Toolset `json:",inline" yaml:",inline"`
+}
+
+func (m *MCPToolset) UnmarshalYAML(unmarshal func(any) error) error {
+	// Use a plain alias to avoid triggering Toolset.UnmarshalYAML
+	// (which calls validate and requires "type" to be set).
+	type alias Toolset
+	var tmp alias
+	if err := unmarshal(&tmp); err != nil {
+		return err
+	}
+	m.Toolset = Toolset(tmp)
+	m.Type = "mcp"
+	return m.validate()
 }
 
 type Agents []AgentConfig

--- a/pkg/config/latest/validate.go
+++ b/pkg/config/latest/validate.go
@@ -2,7 +2,6 @@ package latest
 
 import (
 	"errors"
-	"strings"
 )
 
 func (t *Config) UnmarshalYAML(unmarshal func(any) error) error {
@@ -138,10 +137,6 @@ func (t *Toolset) validate() error {
 		}
 		if count > 1 {
 			return errors.New("either command, remote or ref must be set, but only one of those")
-		}
-
-		if t.Ref != "" && !strings.Contains(t.Ref, "docker:") {
-			return errors.New("only docker refs are supported for MCP tools, e.g., 'docker:context7'")
 		}
 	case "a2a":
 		if t.URL == "" {

--- a/pkg/config/mcps.go
+++ b/pkg/config/mcps.go
@@ -1,0 +1,97 @@
+package config
+
+import (
+	"fmt"
+	"maps"
+	"strings"
+
+	"github.com/docker/cagent/pkg/config/latest"
+)
+
+// resolveMCPDefinitions resolves MCP definition references in agent toolsets.
+// When an agent toolset of type "mcp" has a ref that matches a key in the
+// top-level mcps section (rather than a "docker:" ref), the toolset is expanded
+// with the definition's properties. Any properties set directly on the toolset
+// override the corresponding definition properties.
+func resolveMCPDefinitions(cfg *latest.Config) error {
+	for name, def := range cfg.MCPs {
+		if err := validateMCPDefinition(name, &def.Toolset); err != nil {
+			return err
+		}
+	}
+
+	for i := range cfg.Agents {
+		agent := &cfg.Agents[i]
+		for j := range agent.Toolsets {
+			ts := &agent.Toolsets[j]
+			if ts.Type != "mcp" || ts.Ref == "" || strings.HasPrefix(ts.Ref, "docker:") {
+				continue
+			}
+
+			def, ok := cfg.MCPs[ts.Ref]
+			if !ok {
+				return fmt.Errorf("agent '%s' references non-existent MCP definition '%s'", agent.Name, ts.Ref)
+			}
+
+			applyMCPDefaults(ts, &def.Toolset)
+		}
+	}
+
+	return nil
+}
+
+// validateMCPDefinition validates that a definition's ref uses the docker: prefix.
+// The basic source validation (exactly one of command/remote/ref) is already handled
+// by Toolset.validate() during YAML unmarshaling.
+func validateMCPDefinition(name string, def *latest.Toolset) error {
+	if def.Ref != "" && !strings.HasPrefix(def.Ref, "docker:") {
+		return fmt.Errorf("MCP definition '%s': only docker refs are supported (e.g., 'docker:context7')", name)
+	}
+	return nil
+}
+
+// applyMCPDefaults fills empty fields in ts from def. Toolset values win.
+// Env maps are merged (toolset values take precedence on key conflicts).
+func applyMCPDefaults(ts, def *latest.Toolset) {
+	// Replace the definition-name ref with the actual source.
+	if def.Ref != "" {
+		ts.Ref = def.Ref
+	} else {
+		ts.Ref = ""
+	}
+	if ts.Command == "" {
+		ts.Command = def.Command
+	}
+	if ts.Remote.URL == "" {
+		ts.Remote = def.Remote
+	}
+	if len(ts.Args) == 0 {
+		ts.Args = def.Args
+	}
+	if ts.Version == "" {
+		ts.Version = def.Version
+	}
+	if ts.Config == nil {
+		ts.Config = def.Config
+	}
+	if ts.Name == "" {
+		ts.Name = def.Name
+	}
+	if ts.Instruction == "" {
+		ts.Instruction = def.Instruction
+	}
+	if len(ts.Tools) == 0 {
+		ts.Tools = def.Tools
+	}
+	if ts.Defer.IsEmpty() {
+		ts.Defer = def.Defer
+	}
+	if len(def.Env) > 0 {
+		merged := make(map[string]string, len(def.Env)+len(ts.Env))
+		maps.Copy(merged, def.Env)
+		if ts.Env != nil {
+			maps.Copy(merged, ts.Env)
+		}
+		ts.Env = merged
+	}
+}

--- a/pkg/config/mcps_test.go
+++ b/pkg/config/mcps_test.go
@@ -1,0 +1,138 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMCPDefinitions_BasicRef(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := Load(t.Context(), NewFileSource("testdata/mcp_definitions.yaml"))
+	require.NoError(t, err)
+
+	root, ok := cfg.Agents.Lookup("root")
+	require.True(t, ok)
+	require.Len(t, root.Toolsets, 2)
+
+	// context7 definition (docker ref) is resolved onto the toolset.
+	ts0 := root.Toolsets[0]
+	assert.Equal(t, "mcp", ts0.Type)
+	assert.Equal(t, "docker:context7", ts0.Ref)
+
+	// custom_mcp definition (command) is resolved onto the toolset.
+	ts1 := root.Toolsets[1]
+	assert.Equal(t, "mcp", ts1.Type)
+	assert.Equal(t, "my-mcp-server", ts1.Command)
+	assert.Equal(t, []string{"--port", "8080"}, ts1.Args)
+	assert.Equal(t, map[string]string{"MY_VAR": "my_value"}, ts1.Env)
+	assert.Empty(t, ts1.Ref)
+
+	// The same definition is reusable across agents.
+	other, ok := cfg.Agents.Lookup("other")
+	require.True(t, ok)
+	require.Len(t, other.Toolsets, 1)
+	assert.Equal(t, "docker:context7", other.Toolsets[0].Ref)
+}
+
+func TestMCPDefinitions_OverrideFields(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := Load(t.Context(), NewFileSource("testdata/mcp_definitions_override.yaml"))
+	require.NoError(t, err)
+
+	root, ok := cfg.Agents.Lookup("root")
+	require.True(t, ok)
+	require.Len(t, root.Toolsets, 1)
+
+	ts := root.Toolsets[0]
+	assert.Equal(t, "docker:github", ts.Ref)
+
+	// Toolset-level tools override the definition.
+	assert.Equal(t, []string{"create_issue"}, ts.Tools)
+
+	// Unset fields fall back to the definition.
+	assert.Equal(t, "Use this for GitHub operations", ts.Instruction)
+	assert.Equal(t, "GitHub MCP", ts.Name)
+
+	// Env is merged: definition + toolset, toolset wins on conflicts.
+	assert.Equal(t, "token123", ts.Env["GITHUB_TOKEN"])
+	assert.Equal(t, "extra", ts.Env["EXTRA_VAR"])
+}
+
+func TestMCPDefinitions_InvalidRef(t *testing.T) {
+	t.Parallel()
+
+	_, err := Load(t.Context(), NewFileSource("testdata/mcp_definitions_invalid_ref.yaml"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-existent MCP definition 'nonexistent'")
+}
+
+func TestMCPDefinitions_InvalidDefinition(t *testing.T) {
+	t.Parallel()
+
+	_, err := Load(t.Context(), NewFileSource("testdata/mcp_definitions_invalid_def.yaml"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "either command, remote or ref must be set")
+}
+
+func TestMCPDefinitions_Remote(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := Load(t.Context(), NewFileSource("testdata/mcp_definitions_remote.yaml"))
+	require.NoError(t, err)
+
+	root, ok := cfg.Agents.Lookup("root")
+	require.True(t, ok)
+	require.Len(t, root.Toolsets, 1)
+
+	ts := root.Toolsets[0]
+	assert.Equal(t, "https://mcp.example.com/sse", ts.Remote.URL)
+	assert.Equal(t, "Bearer token123", ts.Remote.Headers["Authorization"])
+	assert.Empty(t, ts.Ref)
+}
+
+func TestMCPDefinitions_NoMCPsSection(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := Load(t.Context(), NewFileSource("testdata/autoregister.yaml"))
+	require.NoError(t, err)
+	assert.Nil(t, cfg.MCPs)
+}
+
+func TestMCPDefinitions_RejectsNonsenseFields(t *testing.T) {
+	t.Parallel()
+
+	_, err := Load(t.Context(), NewFileSource("testdata/mcp_definitions_invalid_fields.yaml"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "shared can only be used with type 'todo'")
+}
+
+func TestMCPDefinitions_RejectsMultipleSources(t *testing.T) {
+	t.Parallel()
+
+	_, err := Load(t.Context(), NewFileSource("testdata/mcp_definitions_multiple_sources.yaml"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "either command, remote or ref must be set, but only one of those")
+}
+
+func TestMCPDefinitions_EnvMerge(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := Load(t.Context(), NewFileSource("testdata/mcp_definitions_env_merge.yaml"))
+	require.NoError(t, err)
+
+	root, ok := cfg.Agents.Lookup("root")
+	require.True(t, ok)
+	require.Len(t, root.Toolsets, 1)
+
+	ts := root.Toolsets[0]
+	// Toolset value wins on key conflict
+	assert.Equal(t, "from_toolset", ts.Env["KEY"])
+	// Definition-only key is preserved
+	assert.Equal(t, "from_definition", ts.Env["SHARED"])
+	// Toolset-only key is preserved
+	assert.Equal(t, "from_toolset", ts.Env["EXTRA"])
+}

--- a/pkg/config/testdata/mcp_definitions.yaml
+++ b/pkg/config/testdata/mcp_definitions.yaml
@@ -1,0 +1,29 @@
+models:
+  model:
+    provider: anthropic
+    model: claude-sonnet-4-0
+    max_tokens: 64000
+
+mcps:
+  context7:
+    ref: docker:context7
+
+  custom_mcp:
+    command: my-mcp-server
+    args: ["--port", "8080"]
+    env:
+      MY_VAR: "my_value"
+
+agents:
+  root:
+    model: model
+    toolsets:
+      - type: mcp
+        ref: context7
+      - type: mcp
+        ref: custom_mcp
+  other:
+    model: model
+    toolsets:
+      - type: mcp
+        ref: context7

--- a/pkg/config/testdata/mcp_definitions_env_merge.yaml
+++ b/pkg/config/testdata/mcp_definitions_env_merge.yaml
@@ -1,0 +1,21 @@
+models:
+  model:
+    provider: anthropic
+    model: claude-sonnet-4-0
+
+mcps:
+  test:
+    ref: docker:test
+    env:
+      KEY: "from_definition"
+      SHARED: "from_definition"
+
+agents:
+  root:
+    model: model
+    toolsets:
+      - type: mcp
+        ref: test
+        env:
+          KEY: "from_toolset"
+          EXTRA: "from_toolset"

--- a/pkg/config/testdata/mcp_definitions_invalid_def.yaml
+++ b/pkg/config/testdata/mcp_definitions_invalid_def.yaml
@@ -1,0 +1,15 @@
+models:
+  model:
+    provider: anthropic
+    model: claude-sonnet-4-0
+
+mcps:
+  broken:
+    command: ""
+
+agents:
+  root:
+    model: model
+    toolsets:
+      - type: mcp
+        ref: docker:context7

--- a/pkg/config/testdata/mcp_definitions_invalid_fields.yaml
+++ b/pkg/config/testdata/mcp_definitions_invalid_fields.yaml
@@ -1,0 +1,16 @@
+models:
+  model:
+    provider: anthropic
+    model: claude-sonnet-4-0
+
+mcps:
+  test:
+    ref: docker:context7
+    shared: true
+
+agents:
+  root:
+    model: model
+    toolsets:
+      - type: mcp
+        ref: test

--- a/pkg/config/testdata/mcp_definitions_invalid_ref.yaml
+++ b/pkg/config/testdata/mcp_definitions_invalid_ref.yaml
@@ -1,0 +1,11 @@
+models:
+  model:
+    provider: anthropic
+    model: claude-sonnet-4-0
+
+agents:
+  root:
+    model: model
+    toolsets:
+      - type: mcp
+        ref: nonexistent

--- a/pkg/config/testdata/mcp_definitions_multiple_sources.yaml
+++ b/pkg/config/testdata/mcp_definitions_multiple_sources.yaml
@@ -1,0 +1,16 @@
+models:
+  model:
+    provider: anthropic
+    model: claude-sonnet-4-0
+
+mcps:
+  broken:
+    command: my-server
+    ref: docker:context7
+
+agents:
+  root:
+    model: model
+    toolsets:
+      - type: mcp
+        ref: broken

--- a/pkg/config/testdata/mcp_definitions_override.yaml
+++ b/pkg/config/testdata/mcp_definitions_override.yaml
@@ -1,0 +1,26 @@
+models:
+  model:
+    provider: anthropic
+    model: claude-sonnet-4-0
+
+mcps:
+  github:
+    ref: docker:github
+    env:
+      GITHUB_TOKEN: "token123"
+    tools:
+      - create_issue
+      - list_issues
+    instruction: "Use this for GitHub operations"
+    name: "GitHub MCP"
+
+agents:
+  root:
+    model: model
+    toolsets:
+      - type: mcp
+        ref: github
+        tools:
+          - create_issue
+        env:
+          EXTRA_VAR: "extra"

--- a/pkg/config/testdata/mcp_definitions_remote.yaml
+++ b/pkg/config/testdata/mcp_definitions_remote.yaml
@@ -1,0 +1,18 @@
+models:
+  model:
+    provider: anthropic
+    model: claude-sonnet-4-0
+
+mcps:
+  my_server:
+    remote:
+      url: https://mcp.example.com/sse
+      headers:
+        Authorization: "Bearer token123"
+
+agents:
+  root:
+    model: model
+    toolsets:
+      - type: mcp
+        ref: my_server


### PR DESCRIPTION
## Summary

Adds a top-level `mcps` section to the agent config for defining MCP server configurations once and referencing them by name from agent toolsets. This eliminates duplication when multiple agents use the same MCP server.

### Before

```yaml
agents:
  root:
    toolsets:
      - type: mcp
        ref: docker:context7
  frontend:
    toolsets:
      - type: mcp
        ref: docker:context7  # duplicated
  backend:
    toolsets:
      - type: mcp
        ref: docker:context7  # duplicated
```

### After

```yaml
mcps:
  context7:
    ref: docker:context7

agents:
  root:
    toolsets:
      - type: mcp
        ref: context7
  frontend:
    toolsets:
      - type: mcp
        ref: context7
  backend:
    toolsets:
      - type: mcp
        ref: context7
```

### Override semantics

- Toolset fields take precedence over definition fields
- `env` maps are merged (toolset values win on key conflicts)
- Definitions support all MCP sources: `command`, `remote`, and `ref` (docker refs)

### Changes

- **pkg/config/latest/types.go** — `MCPToolset` type (wraps `Toolset`, validates at parse time), `MCPs` field on `Config`
- **pkg/config/latest/validate.go** — Removed `docker:` prefix restriction from `Toolset.validate()` (now checked during MCP definition validation)
- **pkg/config/mcps.go** — Resolution logic: `resolveMCPDefinitions`, `validateMCPDefinition`, `applyMCPDefaults`
- **pkg/config/config.go** — Call `resolveMCPDefinitions` in `validateConfig`
- **agent-schema.json** — `mcps` property and `MCPToolset` definition
- **examples/mcp-definitions.yaml** — Example config
- **pkg/config/mcps_test.go** — 9 test cases

Closes #1667