### PR TITLE
Add MiniMax as a built-in provider alias

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -93,6 +93,8 @@
       url: /providers/xai/
     - title: Nebius
       url: /providers/nebius/
+    - title: MiniMax
+      url: /providers/minimax/
     - title: Local Models
       url: /providers/local/
     - title: Custom Providers

--- a/docs/providers/minimax/index.md
+++ b/docs/providers/minimax/index.md
@@ -1,0 +1,92 @@
+---
+title: "MiniMax"
+description: "Use MiniMax AI models with docker-agent."
+permalink: /providers/minimax/
+---
+
+# MiniMax
+
+_Use MiniMax AI models with docker-agent._
+
+## Overview
+
+MiniMax provides AI models through an OpenAI-compatible API. docker-agent includes built-in support for MiniMax as an alias provider.
+
+## Setup
+
+1. Get an API key from [MiniMax](https://www.minimaxi.com/)
+2. Set the environment variable:
+
+   ```bash
+   export MINIMAX_API_KEY=your-api-key
+   ```
+
+## Usage
+
+### Inline Syntax
+
+The simplest way to use MiniMax:
+
+```yaml
+agents:
+  root:
+    model: minimax/MiniMax-M2.5
+    description: Assistant using MiniMax
+    instruction: You are a helpful assistant.
+```
+
+### Named Model
+
+For more control over parameters:
+
+```yaml
+models:
+  minimax_model:
+    provider: minimax
+    model: MiniMax-M2.5
+    temperature: 0.7
+    max_tokens: 8192
+
+agents:
+  root:
+    model: minimax_model
+    description: Assistant using MiniMax
+    instruction: You are a helpful assistant.
+```
+
+## Available Models
+
+Check the [MiniMax documentation](https://www.minimaxi.com/document/introduction) for the current model catalog.
+
+| Model                    | Description                                     |
+| ------------------------ | ----------------------------------------------- |
+| `MiniMax-M2.5`           | Peak performance, 204K context                  |
+| `MiniMax-M2.5-highspeed` | Same as M2.5 but faster (~100 tps)              |
+| `MiniMax-M2.1`           | Multi-language programming capabilities         |
+| `MiniMax-M2.1-highspeed` | Faster variant of M2.1 (~100 tps)               |
+| `MiniMax-M2`             | Agentic capabilities, advanced reasoning        |
+
+## How It Works
+
+MiniMax is implemented as a built-in alias in docker-agent:
+
+- **API Type:** OpenAI-compatible (`openai`)
+- **Base URL:** `https://api.minimax.io/v1`
+- **Token Variable:** `MINIMAX_API_KEY`
+
+## Example: Code Assistant
+
+```yaml
+agents:
+  coder:
+    model: minimax/MiniMax-M2.5
+    description: Code assistant using MiniMax
+    instruction: |
+      You are an expert programmer using MiniMax M2.5.
+      Write clean, well-documented code.
+      Follow best practices for the language being used.
+    toolsets:
+      - type: filesystem
+      - type: shell
+      - type: think
+```

--- a/docs/providers/overview/index.md
+++ b/docs/providers/overview/index.md
@@ -62,6 +62,7 @@ docker-agent also includes built-in aliases for these providers:
 | Mistral    | `MISTRAL_API_KEY` |
 | xAI (Grok) | `XAI_API_KEY`     |
 | Nebius     | `NEBIUS_API_KEY`  |
+| MiniMax    | `MINIMAX_API_KEY` |
 
 ```bash
 # Use built-in providers inline

--- a/pkg/config/gather.go
+++ b/pkg/config/gather.go
@@ -103,7 +103,7 @@ func addEnvVarsForModelConfig(model *latest.ModelConfig, customProviders map[str
 			requiredEnv[alias.TokenEnvVar] = true
 		}
 	} else {
-		// Fallback to hardcoded mappings for unknown providers
+		// Fallback to hardcoded mappings for core providers
 		switch model.Provider {
 		case "openai":
 			requiredEnv["OPENAI_API_KEY"] = true
@@ -118,8 +118,6 @@ func addEnvVarsForModelConfig(model *latest.ModelConfig, customProviders map[str
 					requiredEnv["GOOGLE_API_KEY"] = true
 				}
 			}
-		case "mistral":
-			requiredEnv["MISTRAL_API_KEY"] = true
 		}
 	}
 }

--- a/pkg/model/provider/provider.go
+++ b/pkg/model/provider/provider.go
@@ -40,6 +40,27 @@ var CoreProviders = []string{
 	"amazon-bedrock",
 }
 
+// AllProviders returns all known provider names (core providers + aliases),
+// sorted for deterministic output.
+func AllProviders() []string {
+	providers := make([]string, 0, len(CoreProviders)+len(Aliases))
+	providers = append(providers, CoreProviders...)
+	for name := range Aliases {
+		providers = append(providers, name)
+	}
+	slices.Sort(providers)
+	return providers
+}
+
+// IsKnownProvider returns true if the provider name is a core provider or an alias.
+func IsKnownProvider(name string) bool {
+	if slices.Contains(CoreProviders, strings.ToLower(name)) {
+		return true
+	}
+	_, exists := Aliases[strings.ToLower(name)]
+	return exists
+}
+
 // CatalogProviders returns the list of provider names that should be shown in the model catalog.
 // This includes core providers and aliases that have a defined BaseURL (self-contained endpoints).
 // Aliases without a BaseURL (like azure) require user configuration and are excluded.
@@ -101,6 +122,11 @@ var Aliases = map[string]Alias{
 	"ollama": {
 		APIType: "openai",
 		BaseURL: "http://localhost:11434/v1",
+	},
+	"minimax": {
+		APIType:     "openai",
+		BaseURL:     "https://api.minimax.io/v1",
+		TokenEnvVar: "MINIMAX_API_KEY",
 	},
 }
 

--- a/pkg/model/provider/provider_test.go
+++ b/pkg/model/provider/provider_test.go
@@ -47,6 +47,7 @@ func TestIsCatalogProvider(t *testing.T) {
 		{"nebius has BaseURL", "nebius", true},
 		{"requesty has BaseURL", "requesty", true},
 		{"ollama has BaseURL", "ollama", true},
+		{"minimax has BaseURL", "minimax", true},
 
 		// Aliases without BaseURL (should be excluded)
 		{"azure has no BaseURL", "azure", false},
@@ -63,4 +64,45 @@ func TestIsCatalogProvider(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestAllProviders(t *testing.T) {
+	t.Parallel()
+
+	all := AllProviders()
+
+	// Should include all core providers
+	for _, core := range CoreProviders {
+		assert.Contains(t, all, core, "should include core provider %s", core)
+	}
+
+	// Should include all aliases
+	for name := range Aliases {
+		assert.Contains(t, all, name, "should include alias %s", name)
+	}
+
+	// Total count should be core + aliases
+	assert.Len(t, all, len(CoreProviders)+len(Aliases))
+}
+
+func TestIsKnownProvider(t *testing.T) {
+	t.Parallel()
+
+	// All core providers should be known
+	for _, core := range CoreProviders {
+		assert.True(t, IsKnownProvider(core), "core provider %s should be known", core)
+	}
+
+	// All aliases should be known
+	for name := range Aliases {
+		assert.True(t, IsKnownProvider(name), "alias %s should be known", name)
+	}
+
+	// Case-insensitive
+	assert.True(t, IsKnownProvider("OpenAI"))
+	assert.True(t, IsKnownProvider("ANTHROPIC"))
+
+	// Unknown providers
+	assert.False(t, IsKnownProvider("unknown"))
+	assert.False(t, IsKnownProvider(""))
 }

--- a/pkg/runtime/model_switcher.go
+++ b/pkg/runtime/model_switcher.go
@@ -389,22 +389,25 @@ func (r *LocalRuntime) getAvailableProviders(ctx context.Context) map[string]boo
 		return available
 	}
 
-	// Check credentials for each provider
-	providerEnvVars := map[string]string{
-		"openai":    "OPENAI_API_KEY",
-		"anthropic": "ANTHROPIC_API_KEY",
-		"google":    "GOOGLE_API_KEY",
-		"mistral":   "MISTRAL_API_KEY",
-		"xai":       "XAI_API_KEY",
-		"nebius":    "NEBIUS_API_KEY",
-		"requesty":  "REQUESTY_API_KEY",
-		"azure":     "AZURE_API_KEY",
+	// Check credentials for each alias provider
+	for name, alias := range provider.Aliases {
+		if alias.TokenEnvVar == "" {
+			continue
+		}
+		if key, _ := env.Get(ctx, alias.TokenEnvVar); key != "" {
+			available[name] = true
+		}
 	}
 
-	for providerName, envVar := range providerEnvVars {
-		if key, _ := env.Get(ctx, envVar); key != "" {
-			available[providerName] = true
-		}
+	// Check core providers with well-known env vars
+	if key, _ := env.Get(ctx, "OPENAI_API_KEY"); key != "" {
+		available["openai"] = true
+	}
+	if key, _ := env.Get(ctx, "ANTHROPIC_API_KEY"); key != "" {
+		available["anthropic"] = true
+	}
+	if key, _ := env.Get(ctx, "GOOGLE_API_KEY"); key != "" {
+		available["google"] = true
 	}
 
 	// DMR and ollama don't require credentials (local models)

--- a/pkg/tui/dialog/model_picker.go
+++ b/pkg/tui/dialog/model_picker.go
@@ -11,6 +11,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
+	"github.com/docker/cagent/pkg/model/provider"
 	"github.com/docker/cagent/pkg/runtime"
 	"github.com/docker/cagent/pkg/tui/components/scrollview"
 	"github.com/docker/cagent/pkg/tui/components/toolcommon"
@@ -19,15 +20,6 @@ import (
 	"github.com/docker/cagent/pkg/tui/messages"
 	"github.com/docker/cagent/pkg/tui/styles"
 )
-
-// SupportedProviders lists the valid provider names that can be used in custom model specs.
-// This includes both core providers and aliases.
-var SupportedProviders = []string{
-	// Core providers
-	"openai", "anthropic", "google", "dmr",
-	// Aliases (these map to core providers with different defaults)
-	"requesty", "azure", "xai", "nebius", "mistral", "ollama",
-}
 
 // modelPickerDialog is a dialog for selecting a model for the current agent.
 type modelPickerDialog struct {
@@ -313,23 +305,13 @@ func validateCustomModelSpec(spec string) error {
 			return fmt.Errorf("model name cannot be empty (got '%s/')", providerName)
 		}
 
-		if !isValidProvider(providerName) {
+		if !provider.IsKnownProvider(providerName) {
 			return fmt.Errorf("unknown provider '%s'. Supported: %s",
-				providerName, strings.Join(SupportedProviders, ", "))
+				providerName, strings.Join(provider.AllProviders(), ", "))
 		}
 	}
 
 	return nil
-}
-
-// isValidProvider checks if the provider name is in the list of supported providers.
-func isValidProvider(name string) bool {
-	for _, p := range SupportedProviders {
-		if strings.EqualFold(p, name) {
-			return true
-		}
-	}
-	return false
 }
 
 func (d *modelPickerDialog) filterModels() {

--- a/pkg/tui/dialog/model_picker_test.go
+++ b/pkg/tui/dialog/model_picker_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/docker/cagent/pkg/model/provider"
 	"github.com/docker/cagent/pkg/runtime"
 )
 
@@ -361,6 +362,7 @@ func TestIsValidProvider(t *testing.T) {
 		{"ollama", true},
 		{"azure", true},
 		{"requesty", true},
+		{"minimax", true},
 		{"OPENAI", true}, // case insensitive
 		{"OpenAI", true}, // case insensitive
 		{"unknown", false},
@@ -371,7 +373,7 @@ func TestIsValidProvider(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.provider, func(t *testing.T) {
 			t.Parallel()
-			got := isValidProvider(tt.provider)
+			got := provider.IsKnownProvider(tt.provider)
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
## Summary

Add [MiniMax](https://www.minimaxi.com/) (`api.minimax.io`) as a built-in OpenAI-compatible provider alias with `MINIMAX_API_KEY` support.

## Changes

**New provider:**
- Add `minimax` alias in `provider.go` targeting `https://api.minimax.io/v1`

**Refactor — single source of truth for providers:**
- Add `AllProviders()` and `IsKnownProvider()` helpers to `provider` package
- Derive supported providers in `model_picker.go` from provider package (removes hardcoded `SupportedProviders` list)
- Derive credential checks in `model_switcher.go` from `provider.Aliases` (removes parallel `providerEnvVars` map)
- Remove dead `case "mistral"` in `gather.go` (already handled by alias lookup)
- Sort `AllProviders()` output for deterministic error messages

**Docs:**
- Add `docs/providers/minimax/index.md` provider page
- Update docs navigation and providers overview

## Testing

All existing tests pass. New tests added for `AllProviders()` and `IsKnownProvider()`.

Closes #1887