### PR TITLE
Animate window title while working for tmux activity detection

### DIFF
--- a/pkg/tui/components/spinner/spinner.go
+++ b/pkg/tui/components/spinner/spinner.go
@@ -69,8 +69,8 @@ var defaultMessages = []string{
 
 func New(mode Mode, dotsStyle lipgloss.Style) Spinner {
 	// Pre-render all spinner frames for fast lookup during render
-	styledFrames := make([]string, len(spinnerChars))
-	for i, char := range spinnerChars {
+	styledFrames := make([]string, len(frames))
+	for i, char := range frames {
 		styledFrames[i] = dotsStyle.Render(char)
 	}
 
@@ -136,7 +136,13 @@ func (s *spinner) Stop() {
 	s.animSub.Stop()
 }
 
-var spinnerChars = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+// frames contains the braille spinner characters used for animation.
+var frames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+// Frame returns the spinner character for the given animation frame.
+func Frame(index int) string {
+	return frames[index%len(frames)]
+}
 
 // lightStyles maps distance from light position to style (0=brightest, 1=bright, 2=dim, 3+=dimmest).
 var lightStyles = []lipgloss.Style{

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -95,6 +95,10 @@ type appModel struct {
 	// Working state indicator (resize handle spinner)
 	workingSpinner spinner.Spinner
 
+	// animFrame is the current animation frame, used to rotate the window
+	// title spinner so that tmux can detect pane activity.
+	animFrame int
+
 	// Window state
 	wWidth, wHeight int
 	width, height   int
@@ -445,6 +449,8 @@ func (m *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.workingSpinner = model.(spinner.Spinner)
 			cmds = append(cmds, cmd)
 		}
+		// Track frame for window-title spinner (tmux activity detection)
+		m.animFrame = msg.Frame
 		// Forward frame to tab bar for running indicator animation
 		m.tabBar.SetAnimFrame(msg.Frame)
 		if animation.HasActive() {
@@ -1992,11 +1998,17 @@ func (m *appModel) View() tea.View {
 }
 
 // windowTitle returns the terminal window title.
+// When the agent is working, a rotating spinner character is prepended so that
+// terminal multiplexers (tmux) can detect activity in the pane.
 func (m *appModel) windowTitle() string {
+	title := "cagent"
 	if sessionTitle := m.sessionState.SessionTitle(); sessionTitle != "" {
-		return sessionTitle + " - cagent"
+		title = sessionTitle + " - cagent"
 	}
-	return "cagent"
+	if m.chatPage.IsWorking() {
+		title = spinner.Frame(m.animFrame) + " " + title
+	}
+	return title
 }
 
 // cleanupAll cleans up all sessions, editors, and resources.


### PR DESCRIPTION
When running inside tmux, the TUI's alternate screen and progress bar protocol are not visible in the tmux status bar. This makes it hard to tell whether the agent is actively working.

This PR prepends a rotating braille spinner character to the terminal window title while the agent is working. tmux detects title changes as pane activity, making the working state visible in the status bar.

### Changes

- **`pkg/tui/tui.go`**: Track animation frame in `appModel` and prepend a spinner character to the window title when working.
- **`pkg/tui/components/spinner/spinner.go`**: Add exported `Frame(index)` accessor for the spinner characters, keeping the slice unexported to prevent external mutation.
- **`pkg/tools/builtin/user_prompt.go`**, **`pkg/tui/dialog/elicitation.go`**, **`pkg/tui/dialog/elicitation_test.go`**: Improve user_prompt TUI dialog with title, free-form input, and keyboard navigation.