### PR TITLE
Leverage latest MCP spec features from go-sdk v1.4.0

### DIFF
--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -126,18 +126,18 @@ func createMCPServer(ctx context.Context, agentFilename, agentName string, runCo
 
 		slog.Debug("Adding MCP tool", "agent", agentName, "description", description)
 
-		readOnly, err := isReadOnlyAgent(ctx, ag)
+		annotations, err := agentToolAnnotations(ctx, ag)
 		if err != nil {
 			cleanup()
-			return nil, nil, fmt.Errorf("failed to determine if agent %s is read-only: %w", agentName, err)
+			return nil, nil, fmt.Errorf("failed to compute annotations for agent %s: %w", agentName, err)
 		}
 
+		annotations.Title = description
+
 		toolDef := &mcp.Tool{
-			Name:        agentName,
-			Description: description,
-			Annotations: &mcp.ToolAnnotations{
-				ReadOnlyHint: readOnly,
-			},
+			Name:         agentName,
+			Description:  description,
+			Annotations:  annotations,
 			InputSchema:  tools.MustSchemaFor[ToolInput](),
 			OutputSchema: tools.MustSchemaFor[ToolOutput](),
 		}
@@ -185,17 +185,61 @@ func CreateToolHandler(t *team.Team, agentName string) func(context.Context, *mc
 	}
 }
 
-func isReadOnlyAgent(ctx context.Context, ag *agent.Agent) (bool, error) {
+// agentToolAnnotations inspects the agent's tools and derives
+// [mcp.ToolAnnotations] that describe the aggregate behaviour of the agent.
+//
+//   - ReadOnlyHint is true when every tool is read-only.
+//   - DestructiveHint is explicitly false when no tool is destructive.
+//   - IdempotentHint is true when every tool is idempotent.
+//   - OpenWorldHint is explicitly false when no tool interacts with an open world.
+func agentToolAnnotations(ctx context.Context, ag *agent.Agent) (*mcp.ToolAnnotations, error) {
 	allTools, err := ag.Tools(ctx)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 
+	readOnly := true
+	destructive := false
+	idempotent := true
+	openWorld := false
+
 	for _, tool := range allTools {
-		if !tool.Annotations.ReadOnlyHint {
-			return false, nil
+		a := tool.Annotations
+		if !a.ReadOnlyHint {
+			readOnly = false
+		}
+		if !a.IdempotentHint {
+			idempotent = false
+		}
+		// *bool hints default to true per the MCP spec; nil means "assumed true".
+		if optionalBool(a.DestructiveHint, true) {
+			destructive = true
+		}
+		if optionalBool(a.OpenWorldHint, true) {
+			openWorld = true
 		}
 	}
 
-	return true, nil
+	annotations := &mcp.ToolAnnotations{
+		ReadOnlyHint:   readOnly,
+		IdempotentHint: idempotent,
+	}
+	// Only set *bool fields explicitly when they differ from the spec default
+	// (true), so that nil keeps its "default" semantics on the wire.
+	if !destructive {
+		annotations.DestructiveHint = new(bool)
+	}
+	if !openWorld {
+		annotations.OpenWorldHint = new(bool)
+	}
+
+	return annotations, nil
+}
+
+// optionalBool returns the value of p, or fallback when p is nil.
+func optionalBool(p *bool, fallback bool) bool {
+	if p != nil {
+		return *p
+	}
+	return fallback
 }

--- a/pkg/mcp/server_test.go
+++ b/pkg/mcp/server_test.go
@@ -1,0 +1,120 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/cagent/pkg/agent"
+	"github.com/docker/cagent/pkg/tools"
+)
+
+func boolPtr(v bool) *bool { return &v }
+
+// annot is a shorthand for building tools.ToolAnnotations in tests.
+func annot(readOnly, idempotent bool, destructive, openWorld *bool) tools.ToolAnnotations {
+	return tools.ToolAnnotations{
+		ReadOnlyHint:    readOnly,
+		IdempotentHint:  idempotent,
+		DestructiveHint: destructive,
+		OpenWorldHint:   openWorld,
+	}
+}
+
+func TestAgentToolAnnotations(t *testing.T) {
+	t.Parallel()
+
+	pFalse := boolPtr(false)
+	pTrue := boolPtr(true)
+
+	tests := []struct {
+		name            string
+		tools           []tools.Tool
+		wantReadOnly    bool
+		wantDestructive *bool // nil means default (true)
+		wantIdempotent  bool
+		wantOpenWorld   *bool // nil means default (true)
+	}{
+		{
+			name:            "no tools yields most conservative defaults",
+			wantReadOnly:    true,
+			wantDestructive: pFalse,
+			wantIdempotent:  true,
+			wantOpenWorld:   pFalse,
+		},
+		{
+			name: "all read-only tools",
+			tools: []tools.Tool{
+				{Name: "a", Annotations: annot(true, true, pFalse, pFalse)},
+				{Name: "b", Annotations: annot(true, true, pFalse, pFalse)},
+			},
+			wantReadOnly:    true,
+			wantDestructive: pFalse,
+			wantIdempotent:  true,
+			wantOpenWorld:   pFalse,
+		},
+		{
+			name: "mixed read-only",
+			tools: []tools.Tool{
+				{Name: "reader", Annotations: annot(true, false, pFalse, pFalse)},
+				{Name: "writer", Annotations: annot(false, false, pTrue, pFalse)},
+			},
+			wantReadOnly:   false,
+			wantIdempotent: false,
+			wantOpenWorld:  pFalse,
+			// wantDestructive nil → at least one destructive tool
+		},
+		{
+			name: "nil destructive hint treated as destructive",
+			tools: []tools.Tool{
+				{Name: "tool", Annotations: annot(false, false, nil, pFalse)},
+			},
+			wantOpenWorld: pFalse,
+			// wantDestructive nil → nil DestructiveHint defaults to true
+		},
+		{
+			name: "nil open world hint treated as open world",
+			tools: []tools.Tool{
+				{Name: "tool", Annotations: annot(false, false, pFalse, nil)},
+			},
+			wantDestructive: pFalse,
+			// wantOpenWorld nil → nil OpenWorldHint defaults to true
+		},
+		{
+			name: "open world tool makes agent open world",
+			tools: []tools.Tool{
+				{Name: "closed", Annotations: annot(true, false, pFalse, pFalse)},
+				{Name: "web", Annotations: annot(true, false, pFalse, pTrue)},
+			},
+			wantReadOnly:    true,
+			wantDestructive: pFalse,
+			// wantOpenWorld nil → open world
+		},
+		{
+			name: "all idempotent",
+			tools: []tools.Tool{
+				{Name: "a", Annotations: annot(false, true, pFalse, pFalse)},
+				{Name: "b", Annotations: annot(false, true, pFalse, pFalse)},
+			},
+			wantDestructive: pFalse,
+			wantIdempotent:  true,
+			wantOpenWorld:   pFalse,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ag := agent.New("test", "test agent", agent.WithTools(tt.tools...))
+			got, err := agentToolAnnotations(t.Context(), ag)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantReadOnly, got.ReadOnlyHint, "ReadOnlyHint")
+			assert.Equal(t, tt.wantDestructive, got.DestructiveHint, "DestructiveHint")
+			assert.Equal(t, tt.wantIdempotent, got.IdempotentHint, "IdempotentHint")
+			assert.Equal(t, tt.wantOpenWorld, got.OpenWorldHint, "OpenWorldHint")
+		})
+	}
+}

--- a/pkg/tools/mcp/mcp.go
+++ b/pkg/tools/mcp/mcp.go
@@ -488,32 +488,45 @@ func isInitNotificationSendError(err error) bool {
 }
 
 func processMCPContent(toolResult *mcp.CallToolResult) *tools.ToolCallResult {
-	finalContent := ""
-	var images []tools.ImageContent
+	var text string
+	var images, audios []tools.MediaContent
 
-	for _, resultContent := range toolResult.Content {
-		switch c := resultContent.(type) {
+	for _, c := range toolResult.Content {
+		switch c := c.(type) {
 		case *mcp.TextContent:
-			finalContent += c.Text
+			text += c.Text
 		case *mcp.ImageContent:
-			// MCP SDK decodes the base64 wire format into raw bytes,
-			// so we need to re-encode to base64 for our ImageContent.
-			images = append(images, tools.ImageContent{
-				Data:     base64.StdEncoding.EncodeToString(c.Data),
-				MimeType: c.MIMEType,
-			})
+			images = append(images, encodeMedia(c.Data, c.MIMEType))
+		case *mcp.AudioContent:
+			audios = append(audios, encodeMedia(c.Data, c.MIMEType))
+		case *mcp.ResourceLink:
+			if c.Name != "" {
+				// Escape ] in name and ) in URI to prevent broken markdown links.
+				name := strings.ReplaceAll(c.Name, "]", "\\]")
+				uri := strings.ReplaceAll(c.URI, ")", "%29")
+				text += fmt.Sprintf("[%s](%s)", name, uri)
+			} else {
+				text += c.URI
+			}
 		}
 	}
 
-	// Handle an empty response. This can happen if the MCP tool does not return any content.
-	finalContent = cmp.Or(finalContent, "no output")
-
-	result := &tools.ToolCallResult{
-		Output:  finalContent,
-		IsError: toolResult.IsError,
-		Images:  images,
+	return &tools.ToolCallResult{
+		Output:            cmp.Or(text, "no output"),
+		IsError:           toolResult.IsError,
+		Images:            images,
+		Audios:            audios,
+		StructuredContent: toolResult.StructuredContent,
 	}
-	return result
+}
+
+// encodeMedia re-encodes raw bytes (as decoded by the MCP SDK) back to base64
+// for our internal MediaContent representation.
+func encodeMedia(data []byte, mimeType string) tools.MediaContent {
+	return tools.MediaContent{
+		Data:     base64.StdEncoding.EncodeToString(data),
+		MimeType: mimeType,
+	}
 }
 
 func (ts *Toolset) SetElicitationHandler(handler tools.ElicitationHandler) {

--- a/pkg/tools/mcp/mcp_test.go
+++ b/pkg/tools/mcp/mcp_test.go
@@ -110,70 +110,144 @@ func TestCallToolStripsNullArguments(t *testing.T) {
 	}
 }
 
-func TestProcessMCPContent_WithImages(t *testing.T) {
+func TestProcessMCPContent(t *testing.T) {
 	t.Parallel()
 
-	t.Run("text only", func(t *testing.T) {
-		t.Parallel()
-		result := processMCPContent(&mcp.CallToolResult{
-			Content: []mcp.Content{&mcp.TextContent{Text: "hello"}},
-		})
-		assert.Equal(t, "hello", result.Output)
-		assert.Empty(t, result.Images)
-		assert.False(t, result.IsError)
-	})
+	tests := []struct {
+		name           string
+		input          *mcp.CallToolResult
+		wantOutput     string
+		wantIsError    bool
+		wantImages     []tools.MediaContent
+		wantAudios     []tools.MediaContent
+		wantStructured any
+	}{
+		// --- text ---
+		{
+			name:       "text only",
+			input:      callToolResult(&mcp.TextContent{Text: "hello"}),
+			wantOutput: "hello",
+		},
+		{
+			name:       "empty response",
+			input:      &mcp.CallToolResult{},
+			wantOutput: "no output",
+		},
 
-	t.Run("image only", func(t *testing.T) {
-		t.Parallel()
-		// mcp.ImageContent.Data holds raw bytes (SDK decodes base64 from wire)
-		rawImageData := []byte("imagedata")
-		result := processMCPContent(&mcp.CallToolResult{
-			Content: []mcp.Content{
-				&mcp.ImageContent{
-					Data:     rawImageData,
-					MIMEType: "image/png",
-				},
-			},
-		})
-		assert.Equal(t, "no output", result.Output) // no text content, so default
-		require.Len(t, result.Images, 1)
-		assert.Equal(t, "image/png", result.Images[0].MimeType)
-		// Output should be base64-encoded
-		assert.Equal(t, "aW1hZ2VkYXRh", result.Images[0].Data)
-	})
+		// --- images ---
+		{
+			name:       "image only",
+			input:      callToolResult(&mcp.ImageContent{Data: []byte("imagedata"), MIMEType: "image/png"}),
+			wantOutput: "no output",
+			wantImages: []tools.MediaContent{{Data: "aW1hZ2VkYXRh", MimeType: "image/png"}},
+		},
+		{
+			name:       "text and image",
+			input:      callToolResult(&mcp.TextContent{Text: "Here is the screenshot"}, &mcp.ImageContent{Data: []byte("screenshot"), MIMEType: "image/jpeg"}),
+			wantOutput: "Here is the screenshot",
+			wantImages: []tools.MediaContent{{Data: "c2NyZWVuc2hvdA==", MimeType: "image/jpeg"}},
+		},
+		{
+			name:        "error with image",
+			input:       &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: "error occurred"}, &mcp.ImageContent{Data: []byte("error"), MIMEType: "image/png"}}},
+			wantOutput:  "error occurred",
+			wantIsError: true,
+			wantImages:  []tools.MediaContent{{Data: "ZXJyb3I=", MimeType: "image/png"}},
+		},
 
-	t.Run("text and image", func(t *testing.T) {
-		t.Parallel()
-		result := processMCPContent(&mcp.CallToolResult{
-			Content: []mcp.Content{
-				&mcp.TextContent{Text: "Here is the screenshot"},
-				&mcp.ImageContent{
-					Data:     []byte("screenshot"),
-					MIMEType: "image/jpeg",
-				},
-			},
-		})
-		assert.Equal(t, "Here is the screenshot", result.Output)
-		require.Len(t, result.Images, 1)
-		assert.Equal(t, "image/jpeg", result.Images[0].MimeType)
-		assert.Equal(t, "c2NyZWVuc2hvdA==", result.Images[0].Data)
-	})
+		// --- audio ---
+		{
+			name:       "audio only",
+			input:      callToolResult(&mcp.AudioContent{Data: []byte("audiodata"), MIMEType: "audio/wav"}),
+			wantOutput: "no output",
+			wantAudios: []tools.MediaContent{{Data: "YXVkaW9kYXRh", MimeType: "audio/wav"}},
+		},
+		{
+			name:       "text and audio",
+			input:      callToolResult(&mcp.TextContent{Text: "Here is the recording"}, &mcp.AudioContent{Data: []byte("recording"), MIMEType: "audio/mp3"}),
+			wantOutput: "Here is the recording",
+			wantAudios: []tools.MediaContent{{Data: "cmVjb3JkaW5n", MimeType: "audio/mp3"}},
+		},
+		{
+			name:       "text image and audio",
+			input:      callToolResult(&mcp.TextContent{Text: "multimedia"}, &mcp.ImageContent{Data: []byte("img"), MIMEType: "image/png"}, &mcp.AudioContent{Data: []byte("aud"), MIMEType: "audio/wav"}),
+			wantOutput: "multimedia",
+			wantImages: []tools.MediaContent{{Data: "aW1n", MimeType: "image/png"}},
+			wantAudios: []tools.MediaContent{{Data: "YXVk", MimeType: "audio/wav"}},
+		},
 
-	t.Run("error with image", func(t *testing.T) {
-		t.Parallel()
-		result := processMCPContent(&mcp.CallToolResult{
-			IsError: true,
-			Content: []mcp.Content{
-				&mcp.TextContent{Text: "error occurred"},
-				&mcp.ImageContent{
-					Data:     []byte("error"),
-					MIMEType: "image/png",
-				},
-			},
+		// --- resource links ---
+		{
+			name:       "resource link with name",
+			input:      callToolResult(&mcp.ResourceLink{Name: "my-doc", URI: "file:///path/to/doc.txt"}),
+			wantOutput: "[my-doc](file:///path/to/doc.txt)",
+		},
+		{
+			name:       "resource link without name",
+			input:      callToolResult(&mcp.ResourceLink{URI: "file:///path/to/doc.txt"}),
+			wantOutput: "file:///path/to/doc.txt",
+		},
+		{
+			name:       "text and resource link",
+			input:      callToolResult(&mcp.TextContent{Text: "See: "}, &mcp.ResourceLink{Name: "readme", URI: "file:///README.md"}),
+			wantOutput: "See: [readme](file:///README.md)",
+		},
+		{
+			name:       "resource link name with bracket is escaped",
+			input:      callToolResult(&mcp.ResourceLink{Name: "doc]name", URI: "file:///doc.txt"}),
+			wantOutput: `[doc\]name](file:///doc.txt)`,
+		},
+		{
+			name:       "resource link URI with paren is escaped",
+			input:      callToolResult(&mcp.ResourceLink{Name: "doc", URI: "file:///path(1)/doc.txt"}),
+			wantOutput: "[doc](file:///path(1%29/doc.txt)",
+		},
+
+		// --- structured content ---
+		{
+			name:           "structured content passed through",
+			input:          &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "done"}}, StructuredContent: map[string]any{"status": "ok", "count": float64(42)}},
+			wantOutput:     "done",
+			wantStructured: map[string]any{"status": "ok", "count": float64(42)},
+		},
+		{
+			name:       "nil structured content",
+			input:      callToolResult(&mcp.TextContent{Text: "hello"}),
+			wantOutput: "hello",
+		},
+		{
+			name:           "structured content without text",
+			input:          &mcp.CallToolResult{StructuredContent: map[string]any{"key": "value"}},
+			wantOutput:     "no output",
+			wantStructured: map[string]any{"key": "value"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := processMCPContent(tt.input)
+
+			assert.Equal(t, tt.wantOutput, result.Output)
+			assert.Equal(t, tt.wantIsError, result.IsError)
+
+			if tt.wantImages != nil {
+				assert.Equal(t, tt.wantImages, result.Images)
+			} else {
+				assert.Empty(t, result.Images)
+			}
+			if tt.wantAudios != nil {
+				assert.Equal(t, tt.wantAudios, result.Audios)
+			} else {
+				assert.Empty(t, result.Audios)
+			}
+			assert.Equal(t, tt.wantStructured, result.StructuredContent)
 		})
-		assert.True(t, result.IsError)
-		assert.Equal(t, "error occurred", result.Output)
-		require.Len(t, result.Images, 1)
-		assert.Equal(t, "ZXJyb3I=", result.Images[0].Data)
-	})
+	}
+}
+
+// callToolResult is a helper to build a CallToolResult from content blocks.
+func callToolResult(content ...mcp.Content) *mcp.CallToolResult {
+	return &mcp.CallToolResult{Content: content}
 }

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -41,22 +41,33 @@ type FunctionCall struct {
 	Arguments string `json:"arguments,omitempty"`
 }
 
-// ImageContent represents a base64-encoded image returned by a tool.
-type ImageContent struct {
-	// Data is the base64-encoded image data.
+// MediaContent represents base64-encoded binary data (image, audio, etc.)
+// returned by a tool.
+type MediaContent struct {
+	// Data is the base64-encoded payload.
 	Data string `json:"data"`
-	// MimeType is the MIME type of the image (e.g. "image/png", "image/jpeg").
+	// MimeType identifies the content type (e.g. "image/png", "audio/wav").
 	MimeType string `json:"mimeType"`
 }
+
+// ImageContent is an alias kept for readability at call sites.
+type ImageContent = MediaContent
+
+// AudioContent is an alias kept for readability at call sites.
+type AudioContent = MediaContent
 
 type ToolCallResult struct {
 	Output  string `json:"output"`
 	IsError bool   `json:"isError,omitempty"`
 	Meta    any    `json:"meta,omitempty"`
 	// Images contains optional image attachments returned by the tool.
-	// When present, these are forwarded to the LLM as image content alongside
-	// the text output.
-	Images []ImageContent `json:"images,omitempty"`
+	Images []MediaContent `json:"images,omitempty"`
+	// Audios contains optional audio attachments returned by the tool.
+	Audios []MediaContent `json:"audios,omitempty"`
+	// StructuredContent holds optional structured output returned by an MCP
+	// tool whose definition includes an OutputSchema. When non-nil it is the
+	// JSON-decoded structured result from the server.
+	StructuredContent any `json:"structuredContent,omitempty"`
 }
 
 func ResultError(output string) *ToolCallResult {


### PR DESCRIPTION
## Summary

Handle additional MCP content types and set richer tool annotations when exposing agents as MCP servers, leveraging features available in go-sdk v1.4.0.

## Changes

### New MCP content types in `processMCPContent`
- **AudioContent**: Re-encode raw bytes to base64 and collect in `ToolCallResult.Audios`, matching the existing ImageContent pattern.
- **ResourceLink**: Render as markdown links (`[name](uri)`) with proper escaping of `]` in names and `)` in URIs to prevent broken output.
- **StructuredContent**: Pass through `CallToolResult.StructuredContent` for tools that define an `OutputSchema`.

### Richer ToolAnnotations on MCP server
- Replace the single `ReadOnlyHint` computation with `agentToolAnnotations()` that inspects all agent tools to derive `DestructiveHint`, `IdempotentHint`, `OpenWorldHint`, and `Title`.
- Follows MCP spec defaults: `*bool` fields left nil when they match the spec default (true), explicitly set to false otherwise.

### Code quality
- Introduce `MediaContent` base type with `ImageContent`/`AudioContent` as type aliases (no breaking changes at call sites).
- Extract `encodeMedia` and `optionalBool` helpers to reduce duplication.
- Consolidate four separate `processMCPContent` test functions into one table-driven test.
- Add new `server_test.go` with table-driven tests for `agentToolAnnotations`.