### PR TITLE
Add timeouts to shutdown contexts to prevent goroutine leaks

### DIFF
--- a/cmd/root/debug.go
+++ b/cmd/root/debug.go
@@ -59,24 +59,20 @@ func newDebugCmd() *cobra.Command {
 	return cmd
 }
 
-// loadTeam loads an agent team from the given agent file and returns
-// a cleanup function that must be deferred by the caller.
-func (f *debugFlags) loadTeam(ctx context.Context, agentFilename string, opts ...teamloader.Opt) (*team.Team, func() error, error) {
+// loadTeam loads an agent team from the given agent file.
+// Callers should defer stopToolSets(t) to clean up.
+func (f *debugFlags) loadTeam(ctx context.Context, agentFilename string, opts ...teamloader.Opt) (*team.Team, error) {
 	agentSource, err := config.Resolve(agentFilename, f.runConfig.EnvProvider())
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	t, err := teamloader.Load(ctx, agentSource, &f.runConfig, opts...)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	cleanup := func() error {
-		return t.StopToolSets(ctx)
-	}
-
-	return t, cleanup, nil
+	return t, nil
 }
 
 func (f *debugFlags) runDebugConfigCommand(cmd *cobra.Command, args []string) error {
@@ -100,15 +96,11 @@ func (f *debugFlags) runDebugToolsetsCommand(cmd *cobra.Command, args []string) 
 
 	ctx := cmd.Context()
 
-	t, cleanup, err := f.loadTeam(ctx, args[0])
+	t, err := f.loadTeam(ctx, args[0])
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if err := cleanup(); err != nil {
-			slog.Error("Failed to stop tool sets", "error", err)
-		}
-	}()
+	defer stopToolSets(t)
 
 	out := cli.NewPrinter(cmd.OutOrStdout())
 
@@ -144,15 +136,11 @@ func (f *debugFlags) runDebugTitleCommand(cmd *cobra.Command, args []string) err
 
 	ctx := cmd.Context()
 
-	t, cleanup, err := f.loadTeam(ctx, args[0], teamloader.WithModelOverrides(f.modelOverrides))
+	t, err := f.loadTeam(ctx, args[0], teamloader.WithModelOverrides(f.modelOverrides))
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if err := cleanup(); err != nil {
-			slog.Error("Failed to stop tool sets", "error", err)
-		}
-	}()
+	defer stopToolSets(t)
 
 	agent, err := t.DefaultAgent()
 	if err != nil {

--- a/cmd/root/new.go
+++ b/cmd/root/new.go
@@ -59,11 +59,7 @@ func (f *newFlags) runNewCommand(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer func() {
-		// Use a fresh context for cleanup since the original may be canceled
-		cleanupCtx := context.WithoutCancel(ctx)
-		_ = t.StopToolSets(cleanupCtx)
-	}()
+	defer stopToolSets(t)
 
 	rt, err := runtime.New(t)
 	if err != nil {

--- a/cmd/root/otel.go
+++ b/cmd/root/otel.go
@@ -67,7 +67,9 @@ func initOTelSDK(ctx context.Context) (err error) {
 
 	go func() {
 		<-ctx.Done()
-		_ = tp.Shutdown(context.Background())
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = tp.Shutdown(shutdownCtx)
 	}()
 
 	return nil

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -11,6 +11,7 @@ import (
 	goruntime "runtime"
 	"runtime/pprof"
 	"sync"
+	"time"
 
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
@@ -266,10 +267,7 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 	var initialTeamCleanupOnce sync.Once
 	initialTeamCleanup := func() {
 		initialTeamCleanupOnce.Do(func() {
-			cleanupCtx := context.WithoutCancel(ctx)
-			if err := loadResult.Team.StopToolSets(cleanupCtx); err != nil {
-				slog.Error("Failed to stop tool sets", "error", err)
-			}
+			stopToolSets(loadResult.Team)
 		})
 	}
 	defer initialTeamCleanup()
@@ -560,8 +558,7 @@ func (f *runExecFlags) createSessionSpawner(agentSource config.Source, sessStore
 
 		// Create cleanup function
 		cleanup := func() {
-			cleanupCtx := context.WithoutCancel(spawnCtx)
-			_ = team.StopToolSets(cleanupCtx)
+			stopToolSets(team)
 		}
 
 		// Create the app
@@ -575,6 +572,21 @@ func (f *runExecFlags) createSessionSpawner(agentSource config.Source, sessStore
 		a := app.New(spawnCtx, localRt, newSess, appOpts...)
 
 		return a, newSess, cleanup, nil
+	}
+}
+
+// toolStopper is the subset of *team.Team needed by stopToolSets.
+type toolStopper interface {
+	StopToolSets(ctx context.Context) error
+}
+
+// stopToolSets gracefully stops all tool sets with a bounded timeout so
+// that cleanup cannot block indefinitely.
+func stopToolSets(t toolStopper) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := t.StopToolSets(ctx); err != nil {
+		slog.Error("Failed to stop tool sets", "error", err)
 	}
 }
 


### PR DESCRIPTION
Replace unbounded contexts in cleanup paths with timeout-guarded ones so that shutdown cannot block indefinitely:

- **otel.go**: use a 5s timeout for `TracerProvider.Shutdown` instead of `context.Background()`.
- **run.go, new.go, debug.go**: extract a `stopToolSets` helper that wraps `StopToolSets` with a 30s timeout, replacing `context.WithoutCancel` (which never expires) and a captured parent context in `debug.go` (which could already be cancelled).

Fixes #1951
Fixes #1952