### PR TITLE
updated GHA with new checks:write permission

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -10,10 +10,13 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
-  issues: write
 
 jobs:
   review:
     uses: docker/cagent-action/.github/workflows/review-pr.yml@latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      checks: write
     secrets: inherit


### PR DESCRIPTION
adds `checks: write` so the review agent can create a "PR Review" check run on PRs