### PR TITLE
fix: use session-pinned agent in RunStream instead of shared currentAgent

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -556,6 +556,19 @@ func (r *LocalRuntime) CurrentAgent() *agent.Agent {
 	return current
 }
 
+// resolveSessionAgent returns the agent for the given session. When the session
+// is pinned to a specific agent (e.g. background agent tasks), it returns that
+// agent directly instead of reading the shared currentAgent field, which may
+// point to a different agent.
+func (r *LocalRuntime) resolveSessionAgent(sess *session.Session) *agent.Agent {
+	if sess.AgentName != "" {
+		if a, err := r.team.Agent(sess.AgentName); err == nil {
+			return a
+		}
+	}
+	return r.CurrentAgent()
+}
+
 // CurrentAgentSkillsToolset returns the skills toolset for the current agent, or nil if not enabled.
 func (r *LocalRuntime) CurrentAgentSkillsToolset() *builtin.SkillsToolset {
 	a := r.CurrentAgent()
@@ -960,7 +973,7 @@ func (r *LocalRuntime) finalizeEventChannel(ctx context.Context, sess *session.S
 
 	defer close(events)
 
-	events <- StreamStopped(sess.ID, r.CurrentAgentName())
+	events <- StreamStopped(sess.ID, r.resolveSessionAgent(sess).Name())
 
 	r.executeOnUserInputHooks(ctx, sess.ID, "stream stopped")
 
@@ -990,23 +1003,14 @@ func (r *LocalRuntime) RunStream(ctx context.Context, sess *session.Session) <-c
 			r.setElicitationEventsChannel(events)
 		}
 
-		// Resolve the agent for this session. When AgentName is set on the
-		// session (e.g., background agent tasks), use it directly to avoid
-		// racing on the shared currentAgent field.
-		var a *agent.Agent
-		if sess.AgentName != "" {
-			a, _ = r.team.Agent(sess.AgentName)
-		}
-		if a == nil {
-			a = r.CurrentAgent()
-		}
+		a := r.resolveSessionAgent(sess)
 
 		// Emit agent information for sidebar display
 		// Use getEffectiveModelID to account for active fallback cooldowns
 		events <- AgentInfo(a.Name(), r.getEffectiveModelID(a), a.Description(), a.WelcomeMessage())
 
 		// Emit team information
-		events <- TeamInfo(r.agentDetailsFromTeam(), r.CurrentAgentName())
+		events <- TeamInfo(r.agentDetailsFromTeam(), a.Name())
 
 		// Initialize RAG and forward events
 		r.InitializeRAG(ctx, events)
@@ -1020,7 +1024,7 @@ func (r *LocalRuntime) RunStream(ctx context.Context, sess *session.Session) <-c
 			return
 		}
 
-		events <- ToolsetInfo(len(agentTools), false, r.CurrentAgentName())
+		events <- ToolsetInfo(len(agentTools), false, a.Name())
 
 		messages := sess.GetMessages(a)
 		if sess.SendUserMessage {
@@ -1039,8 +1043,7 @@ func (r *LocalRuntime) RunStream(ctx context.Context, sess *session.Session) <-c
 		runtimeMaxIterations := sess.MaxIterations
 
 		for {
-			// Set elicitation handler on all MCP toolsets before getting tools
-			a := r.CurrentAgent()
+			a = r.resolveSessionAgent(sess)
 
 			r.emitAgentWarnings(a, events)
 			r.configureToolsetHandlers(a, events)
@@ -1054,7 +1057,7 @@ func (r *LocalRuntime) RunStream(ctx context.Context, sess *session.Session) <-c
 			// Emit updated tool count. After a ToolListChanged MCP notification
 			// the cache is invalidated, so getTools above re-fetches from the
 			// server and may return a different count.
-			events <- ToolsetInfo(len(agentTools), false, r.CurrentAgentName())
+			events <- ToolsetInfo(len(agentTools), false, a.Name())
 
 			// Check iteration limit
 			if runtimeMaxIterations > 0 && iteration >= runtimeMaxIterations {
@@ -1184,7 +1187,7 @@ func (r *LocalRuntime) RunStream(ctx context.Context, sess *session.Session) <-c
 					)
 					events <- Warning(
 						"The conversation has exceeded the model's context window. Automatically compacting the conversation history...",
-						r.CurrentAgentName(),
+						a.Name(),
 					)
 					r.Summarize(ctx, sess, "", events)
 
@@ -1282,7 +1285,7 @@ func (r *LocalRuntime) RunStream(ctx context.Context, sess *session.Session) <-c
 
 			usage := SessionUsage(sess, contextLimit)
 			usage.LastMessage = msgUsage
-			events <- NewTokenUsageEvent(sess.ID, r.CurrentAgentName(), usage)
+			events <- NewTokenUsageEvent(sess.ID, a.Name(), usage)
 
 			// Record the message count before tool calls so we can
 			// measure how much content was added by tool results.
@@ -1357,7 +1360,7 @@ func (r *LocalRuntime) configureToolsetHandlers(a *agent.Agent, events chan Even
 	for _, toolset := range a.ToolSets() {
 		tools.ConfigureHandlers(toolset,
 			r.elicitationHandler,
-			func() { events <- Authorization(tools.ElicitationActionAccept, r.CurrentAgentName()) },
+			func() { events <- Authorization(tools.ElicitationActionAccept, a.Name()) },
 			r.managedOAuth,
 		)
 	}
@@ -1371,7 +1374,7 @@ func (r *LocalRuntime) emitAgentWarningsWithSend(a *agent.Agent, send func(Event
 	}
 
 	slog.Warn("Tool setup partially failed; continuing", "agent", a.Name(), "warnings", warnings)
-	send(Warning(formatToolWarning(a, warnings), r.CurrentAgentName()))
+	send(Warning(formatToolWarning(a, warnings), a.Name()))
 }
 
 func (r *LocalRuntime) emitAgentWarnings(a *agent.Agent, events chan Event) {
@@ -1383,7 +1386,7 @@ func (r *LocalRuntime) emitAgentWarnings(a *agent.Agent, events chan Event) {
 	slog.Warn("Tool setup partially failed; continuing", "agent", a.Name(), "warnings", warnings)
 
 	if events != nil {
-		events <- Warning(formatToolWarning(a, warnings), r.CurrentAgentName())
+		events <- Warning(formatToolWarning(a, warnings), a.Name())
 	}
 }
 
@@ -1631,7 +1634,7 @@ func (r *LocalRuntime) handleStream(ctx context.Context, stream chat.MessageStre
 
 // processToolCalls handles the execution of tool calls for an agent
 func (r *LocalRuntime) processToolCalls(ctx context.Context, sess *session.Session, calls []tools.ToolCall, agentTools []tools.Tool, events chan Event) {
-	a := r.CurrentAgent()
+	a := r.resolveSessionAgent(sess)
 	slog.Debug("Processing tool calls", "agent", a.Name(), "call_count", len(calls))
 
 	// Build a map of agent tools for quick lookup
@@ -2347,18 +2350,18 @@ func (r *LocalRuntime) setModelAndEmitInfo(ctx context.Context, modelRef string,
 // The additionalPrompt parameter allows users to provide additional instructions
 // for the summarization (e.g., "focus on code changes" or "include action items").
 func (r *LocalRuntime) Summarize(ctx context.Context, sess *session.Session, additionalPrompt string, events chan Event) {
-	r.sessionCompactor.Compact(ctx, sess, additionalPrompt, events, r.CurrentAgentName())
+	a := r.resolveSessionAgent(sess)
+	r.sessionCompactor.Compact(ctx, sess, additionalPrompt, events, a.Name())
 
 	// Emit a TokenUsageEvent so the sidebar immediately reflects the
 	// compaction: tokens drop to the summary size, context % drops, and
 	// cost increases by the summary generation cost.
-	a := r.CurrentAgent()
 	modelID := r.getEffectiveModelID(a)
 	var contextLimit int64
 	if m, err := r.modelsStore.GetModel(ctx, modelID); err == nil && m != nil {
 		contextLimit = int64(m.Limit.Context)
 	}
-	events <- NewTokenUsageEvent(sess.ID, r.CurrentAgentName(), SessionUsage(sess, contextLimit))
+	events <- NewTokenUsageEvent(sess.ID, a.Name(), SessionUsage(sess, contextLimit))
 }
 
 // setElicitationEventsChannel sets the current events channel for elicitation requests

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -1908,3 +1908,110 @@ func TestEstimateMessageTokens(t *testing.T) {
 		})
 	}
 }
+
+// TestResolveSessionAgent_PinnedAgent verifies that resolveSessionAgent returns
+// the session-pinned agent when AgentName is set, even though the runtime's
+// currentAgent points elsewhere (root). Before the fix, the shared currentAgent
+// field was always used, so background sub-agent tasks ran with root's config.
+func TestResolveSessionAgent_PinnedAgent(t *testing.T) {
+	prov := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
+	worker := agent.New("worker", "Worker agent", agent.WithModel(prov))
+	root := agent.New("root", "Root agent", agent.WithModel(prov))
+	tm := team.New(team.WithAgents(root, worker))
+
+	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+	assert.Equal(t, "root", rt.CurrentAgentName(), "default agent should be root")
+
+	// Session pinned to worker (as run_background_agent does).
+	sess := session.New(session.WithAgentName("worker"))
+
+	resolved := rt.resolveSessionAgent(sess)
+	assert.Equal(t, "worker", resolved.Name(), "resolveSessionAgent should return pinned agent")
+}
+
+// TestResolveSessionAgent_FallsBackToCurrentAgent verifies that when no
+// AgentName is set on the session, resolveSessionAgent falls back to the
+// runtime's currentAgent (the normal interactive-session path).
+func TestResolveSessionAgent_FallsBackToCurrentAgent(t *testing.T) {
+	prov := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
+	root := agent.New("root", "Root agent", agent.WithModel(prov))
+	tm := team.New(team.WithAgents(root))
+
+	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+
+	sess := session.New() // no AgentName
+	resolved := rt.resolveSessionAgent(sess)
+	assert.Equal(t, "root", resolved.Name(), "should fall back to currentAgent")
+}
+
+// TestResolveSessionAgent_InvalidNameFallsBack verifies that if the session's
+// AgentName refers to an agent that doesn't exist in the team, we gracefully
+// fall back to currentAgent instead of returning nil (which would panic).
+func TestResolveSessionAgent_InvalidNameFallsBack(t *testing.T) {
+	prov := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
+	root := agent.New("root", "Root agent", agent.WithModel(prov))
+	tm := team.New(team.WithAgents(root))
+
+	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+
+	sess := session.New(session.WithAgentName("nonexistent"))
+	resolved := rt.resolveSessionAgent(sess)
+	require.NotNil(t, resolved, "should never return nil")
+	assert.Equal(t, "root", resolved.Name(), "should fall back to currentAgent for unknown AgentName")
+}
+
+// TestProcessToolCalls_UsesPinnedAgent verifies that tool-call events emitted by
+// processToolCalls carry the pinned agent's name, not root's. Before the fix,
+// processToolCalls called r.CurrentAgent() which always returned root for
+// background sessions.
+func TestProcessToolCalls_UsesPinnedAgent(t *testing.T) {
+	var executed bool
+	workerTool := tools.Tool{
+		Name:       "worker_tool",
+		Parameters: map[string]any{},
+		Handler: func(_ context.Context, _ tools.ToolCall) (*tools.ToolCallResult, error) {
+			executed = true
+			return tools.ResultSuccess("ok"), nil
+		},
+	}
+
+	prov := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
+	worker := agent.New("worker", "Worker agent", agent.WithModel(prov))
+	root := agent.New("root", "Root agent", agent.WithModel(prov))
+	tm := team.New(team.WithAgents(root, worker))
+
+	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+	rt.registerDefaultTools()
+	assert.Equal(t, "root", rt.CurrentAgentName())
+
+	// Simulate a background session pinned to "worker".
+	sess := session.New(
+		session.WithUserMessage("go"),
+		session.WithToolsApproved(true),
+		session.WithAgentName("worker"),
+	)
+
+	calls := []tools.ToolCall{{
+		ID:       "call-1",
+		Type:     "function",
+		Function: tools.FunctionCall{Name: "worker_tool", Arguments: "{}"},
+	}}
+
+	events := make(chan Event, 32)
+	rt.processToolCalls(t.Context(), sess, calls, []tools.Tool{workerTool}, events)
+	close(events)
+
+	assert.True(t, executed, "worker_tool handler should have been called")
+
+	// Every event emitted must reference "worker", not "root".
+	for ev := range events {
+		if named, ok := ev.(interface{ GetAgentName() string }); ok {
+			assert.Equal(t, "worker", named.GetAgentName(),
+				"event %T should reference pinned agent \"worker\", not root", ev)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Sub-agents dispatched via `run_background_agent` executed with root's toolset, model, and instructions. This happened because `RunStream` resolved the agent through the shared `currentAgent` field, which is never updated for background sessions.

## Root Cause

Multiple places in the streaming loop (`RunStream`, `processToolCalls`, `finalizeEventChannel`, `Summarize`, and helper methods) independently called `r.CurrentAgent()` or `r.CurrentAgentName()`, which always returns the root agent for background sessions since `run_background_agent` never calls `setCurrentAgent`.

## Fix

Introduce `resolveSessionAgent(sess)` — a single method that checks `sess.AgentName` first (set for background agent tasks) and falls back to `CurrentAgent()` for interactive sessions. This is used consistently across all affected call sites.

### Additional fixes
- **Nil-pointer panic**: The previous inline resolution silently discarded the error from `team.Agent()` and could leave the agent nil. The new helper always falls back to `CurrentAgent()`.
- **Pre-loop event emissions**: `TeamInfo` and `ToolsetInfo` events before the loop used `r.CurrentAgentName()` instead of the resolved agent.
- **`emitAgentWarnings` / `configureToolsetHandlers`**: These methods already received the agent as a parameter but independently called `r.CurrentAgentName()` for event names.
- **`Summarize`**: Used `r.CurrentAgentName()` and `r.CurrentAgent()` instead of the session-aware resolution.

Assisted-By: docker-agent