### PR TITLE
fix(#2012): Return clear error when OPENAI_API_KEY is missing for speech-to-text

### DIFF
--- a/pkg/audio/transcribe/transcribe_darwin.go
+++ b/pkg/audio/transcribe/transcribe_darwin.go
@@ -54,6 +54,10 @@ func New(apiKey string) *Transcriber {
 // transcription delta received. Returns an error if already running or if
 // connection fails. Call Stop to end transcription.
 func (t *Transcriber) Start(ctx context.Context, handler TranscriptHandler) error {
+	if t.apiKey == "" {
+		return fmt.Errorf("speech-to-text requires the OPENAI_API_KEY environment variable to be set")
+	}
+
 	if wasRunning := t.running.Swap(true); wasRunning {
 		return fmt.Errorf("transcriber already running")
 	}


### PR DESCRIPTION
When /speak is invoked without OPENAI_API_KEY set, the transcriber either
shows a cryptic WebSocket error or silently enters recording mode with no
transcription. Add an early check in Transcriber.Start() that returns an
actionable error message before attempting the connection.

Fixes #2012

Assisted-By: docker-agent