### PR TITLE
tui: improve tmux experience and simplify keyboard enhancements

### DIFF
--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -116,11 +116,10 @@ type appModel struct {
 	// Focus state
 	focusedPanel FocusedPanel
 
-	// keyboardEnhancements stores the last keyboard enhancements message
+	// keyboardEnhancements stores the last keyboard enhancements message.
+	// When non-nil with Flags != 0, the terminal supports key disambiguation
+	// (shift+enter, ctrl+i vs tab, etc.).
 	keyboardEnhancements *tea.KeyboardEnhancementsMsg
-
-	// keyboardEnhancementsSupported tracks whether the terminal supports keyboard enhancements
-	keyboardEnhancementsSupported bool
 
 	// pendingRestores maps runtime tab IDs (supervisor routing keys) to
 	// persisted session-store IDs. When a tab with a pending restore is first
@@ -230,15 +229,20 @@ func (m *appModel) SetProgram(p *tea.Program) {
 	m.supervisor.SetProgram(p)
 }
 
+// hasKeyboardEnhancements reports whether the terminal supports keyboard
+// enhancements (Kitty keyboard protocol). When true, keybindings like
+// shift+enter become available.
+func (m *appModel) hasKeyboardEnhancements() bool {
+	return m.keyboardEnhancements != nil && m.keyboardEnhancements.Flags != 0
+}
+
 // reapplyKeyboardEnhancements forwards the cached keyboard enhancements message
-// to the active chat page and editor so new/replaced instances pick up the
-// terminal's key disambiguation support.
+// to the active editor so new/replaced instances pick up the terminal's key
+// disambiguation support.
 func (m *appModel) reapplyKeyboardEnhancements() {
 	if m.keyboardEnhancements == nil {
 		return
 	}
-	updated, _ := m.chatPage.Update(*m.keyboardEnhancements)
-	m.chatPage = updated.(chat.Page)
 	editorModel, _ := m.editor.Update(*m.keyboardEnhancements)
 	m.editor = editorModel.(editor.Editor)
 }
@@ -543,14 +547,10 @@ func (m *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyboardEnhancementsMsg:
 		m.keyboardEnhancements = &msg
-		m.keyboardEnhancementsSupported = msg.Flags != 0
-		// Forward to content view
-		updated, cmd := m.chatPage.Update(msg)
-		m.chatPage = updated.(chat.Page)
-		// Forward to editor
-		editorModel, editorCmd := m.editor.Update(msg)
+		// Forward to editor (only component that uses it for keybinding config)
+		editorModel, cmd := m.editor.Update(msg)
 		m.editor = editorModel.(editor.Editor)
-		return m, tea.Batch(cmd, editorCmd)
+		return m, cmd
 
 	// --- Keyboard input ---
 
@@ -1452,7 +1452,7 @@ func (m *appModel) Bindings() []key.Binding {
 	))
 
 	// Show newline help based on keyboard enhancement support
-	if m.keyboardEnhancementsSupported {
+	if m.hasKeyboardEnhancements() {
 		bindings = append(bindings, key.NewBinding(
 			key.WithKeys("shift+enter"),
 			key.WithHelp("Shift+Enter", "newline"),
@@ -2187,6 +2187,8 @@ func toFullscreenView(content, windowTitle string, working bool) tea.View {
 	view.MouseMode = tea.MouseModeCellMotion
 	view.BackgroundColor = styles.Background
 	view.WindowTitle = windowTitle
+	view.ReportFocus = true
+	view.KeyboardEnhancements.ReportEventTypes = true
 	if working {
 		view.ProgressBar = tea.NewProgressBar(tea.ProgressBarIndeterminate, 0)
 	}


### PR DESCRIPTION
Enable **ReportFocus** and **KeyboardEnhancements.ReportEventTypes** in the fullscreen view so that tmux pane focus events and Kitty keyboard protocol features (shift+enter, key disambiguation) are requested from supporting terminals.

Simplify keyboard enhancement tracking:
- Remove redundant `keyboardEnhancementsSupported` bool field; derive it via `hasKeyboardEnhancements()` from the cached message instead.
- Stop forwarding `KeyboardEnhancementsMsg` to `chatPage`, which has no handler for it. Only the editor uses it for keybinding config.