### PR TITLE
docs: fix hallucinated CLI flags, commands, and config formats

### DIFF
--- a/docs/community/contributing/index.md
+++ b/docs/community/contributing/index.md
@@ -12,7 +12,7 @@ _docker-agent is open source. Here's how to set up your development environment 
 
 ### Prerequisites
 
-- [Go 1.25](https://go.dev/dl/) or higher
+- [Go 1.26](https://go.dev/dl/) or higher
 - API key(s) for your chosen AI provider
 - [Task 3.44](https://taskfile.dev/installation/) or higher
 - [golangci-lint](https://golangci-lint.run/docs/welcome/install/#binaries)

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -32,7 +32,6 @@ $ docker agent run [config] [message...] [flags]
 | `--model &lt;ref&gt;`        | Override model(s). Use `provider/model` for all agents, or `agent=provider/model` for specific agents. Comma-separate multiple overrides. |
 | `--session &lt;id&gt;`       | Resume a previous session. Supports relative refs (`-1` = last, `-2` = second to last)                                                    |
 | `--prompt-file &lt;path&gt;` | Include file contents as additional system context (repeatable)                                                                           |
-| `-c &lt;name&gt;`            | Run a named command from the YAML config                                                                                                  |
 | `-d, --debug`                | Enable debug logging                                                                                                                      |
 | `--log-file &lt;path&gt;`    | Custom debug log location                                                                                                                 |
 | `-o, --otel`                 | Enable OpenTelemetry tracing                                                                                                              |
@@ -45,7 +44,6 @@ $ docker agent run agent.yaml -a developer --yolo
 $ docker agent run agent.yaml --model anthropic/claude-sonnet-4-0
 $ docker agent run agent.yaml --model "dev=openai/gpt-4o,reviewer=anthropic/claude-sonnet-4-0"
 $ docker agent run agent.yaml --session -1  # resume last session
-$ docker agent run agent.yaml -c df         # run named command
 $ docker agent run agent.yaml --prompt-file ./context.md  # include file as context
 
 # Queue multiple messages (processed in sequence)
@@ -80,7 +78,7 @@ $ docker agent new [flags]
 
 # Examples
 $ docker agent new
-$ docker agent new --model openai/gpt-5-mini --max-tokens 32000
+$ docker agent new --model openai/gpt-5-mini
 $ docker agent new --model dmr/ai/gemma3-qat:12B --max-iterations 15
 ```
 

--- a/docs/getting-started/quickstart/index.md
+++ b/docs/getting-started/quickstart/index.md
@@ -42,8 +42,8 @@ $ docker agent new
 # Or specify options directly
 $ docker agent new --model openai/gpt-4o
 
-# Override context size and iteration limits
-$ docker agent new --model dmr/ai/gemma3-qat:12B --max-tokens 32000 --max-iterations 15
+# Override iteration limits
+$ docker agent new --model dmr/ai/gemma3-qat:12B --max-iterations 15
 ```
 
 This generates an `agent.yaml` in the current directory. Then run it:

--- a/docs/guides/tips/index.md
+++ b/docs/guides/tips/index.md
@@ -266,8 +266,8 @@ Understand the difference between `sub_agents` and `handoffs`:
     <h3>handoffs (A2A)</h3>
     <p>Transfers control entirely to another agent (possibly remote). One-way handoff.</p>
     <pre style="margin-top:12px"><code class="language-yaml">handoffs:
-  - name: specialist
-    url: http://...</code></pre>
+  - specialist
+  - namespace/remote-agent</code></pre>
   </div>
 </div>
 
@@ -320,10 +320,10 @@ $ docker agent run agent.yaml --debug --log-file ./debug.log
 
 ### Check Token Usage
 
-Use the `/usage` command during a session to see token consumption:
+Use the `/cost` command during a session to see token consumption:
 
 ```text
-/usage
+/cost
 
 Token Usage:
   Input:  12,456 tokens


### PR DESCRIPTION
## Summary

Fix several documentation inaccuracies where content didn't match the actual codebase.

## Changes

- **contributing/index.md**: Fix Go version prerequisite (1.25 → 1.26, matching `go.mod`)
- **features/cli/index.md**: Remove nonexistent `-c <name>` flag and `--max-tokens` flag
- **getting-started/quickstart/index.md**: Remove nonexistent `--max-tokens` flag from example
- **guides/tips/index.md**: Fix `handoffs` YAML example to use string array (matching schema); replace `/usage` with `/cost` (the actual TUI command)

All changes verified against `go.mod`, `agent-schema.json`, and CLI flag definitions in `cmd/root/`.