### PR TITLE
refactor: use slices and maps stdlib functions instead of manual implementations

### DIFF
--- a/cmd/root/alias.go
+++ b/cmd/root/alias.go
@@ -2,8 +2,9 @@ package root
 
 import (
 	"fmt"
+	"maps"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/mattn/go-runewidth"
@@ -196,11 +197,7 @@ func runAliasListCommand(cmd *cobra.Command, args []string) error {
 	out.Printf("Registered aliases (%d):\n\n", len(allAliases))
 
 	// Sort aliases by name for consistent output
-	names := make([]string, 0, len(allAliases))
-	for name := range allAliases {
-		names = append(names, name)
-	}
-	sort.Strings(names)
+	names := slices.Sorted(maps.Keys(allAliases))
 
 	// Find max name width for alignment (using display width for proper Unicode handling)
 	maxLen := 0

--- a/pkg/concurrent/slice.go
+++ b/pkg/concurrent/slice.go
@@ -1,6 +1,9 @@
 package concurrent
 
-import "sync"
+import (
+	"slices"
+	"sync"
+)
 
 type Slice[V any] struct {
 	mu     sync.RWMutex
@@ -51,7 +54,7 @@ func (s *Slice[V]) All() []V {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	return append([]V(nil), s.values...)
+	return slices.Clone(s.values)
 }
 
 func (s *Slice[V]) Range(f func(index int, value V) bool) {

--- a/pkg/model/provider/provider.go
+++ b/pkg/model/provider/provider.go
@@ -43,11 +43,7 @@ var CoreProviders = []string{
 // AllProviders returns all known provider names (core providers + aliases),
 // sorted for deterministic output.
 func AllProviders() []string {
-	providers := make([]string, 0, len(CoreProviders)+len(Aliases))
-	providers = append(providers, CoreProviders...)
-	for name := range Aliases {
-		providers = append(providers, name)
-	}
+	providers := slices.Concat(CoreProviders, slices.Collect(maps.Keys(Aliases)))
 	slices.Sort(providers)
 	return providers
 }

--- a/pkg/rag/builder.go
+++ b/pkg/rag/builder.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"maps"
+	"slices"
 
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/environment"
@@ -244,11 +246,7 @@ func resolveModelConfig(modelName string, buildCfg ManagersBuildConfig) (*latest
 
 // getModelNames extracts model names from the models map for logging
 func getModelNames(models map[string]latest.ModelConfig) []string {
-	names := make([]string, 0, len(models))
-	for name := range models {
-		names = append(names, name)
-	}
-	return names
+	return slices.Collect(maps.Keys(models))
 }
 
 // splitModelRef splits a model reference into provider and model parts

--- a/pkg/rag/manager.go
+++ b/pkg/rag/manager.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"time"
 
 	"github.com/docker/docker-agent/pkg/rag/database"
@@ -424,11 +426,7 @@ func (m *Manager) Query(ctx context.Context, query string) ([]database.SearchRes
 
 // Helper to get strategy names for logging
 func getStrategyNames(stratMap map[string]strategy.Strategy) []string {
-	names := make([]string, 0, len(stratMap))
-	for name := range stratMap {
-		names = append(names, name)
-	}
-	return names
+	return slices.Collect(maps.Keys(stratMap))
 }
 
 // CheckAndReindexChangedFiles checks for file changes and re-indexes if needed

--- a/pkg/session/branch.go
+++ b/pkg/session/branch.go
@@ -3,11 +3,11 @@ package session
 import (
 	"fmt"
 	"maps"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/docker/docker-agent/pkg/chat"
-	"github.com/docker/docker-agent/pkg/tools"
 )
 
 // BranchSession creates a new session branched from the parent at the given position.
@@ -144,16 +144,14 @@ func cloneStringMap(src map[string]string) map[string]string {
 	if len(src) == 0 {
 		return nil
 	}
-	dst := make(map[string]string, len(src))
-	maps.Copy(dst, src)
-	return dst
+	return maps.Clone(src)
 }
 
 func cloneStringSlice(src []string) []string {
 	if src == nil {
 		return nil
 	}
-	return append([]string(nil), src...)
+	return slices.Clone(src)
 }
 
 func cloneMessage(src *Message) *Message {
@@ -187,11 +185,11 @@ func cloneChatMessage(src chat.Message) chat.Message {
 	}
 
 	if src.ToolCalls != nil {
-		dst.ToolCalls = append([]tools.ToolCall(nil), src.ToolCalls...)
+		dst.ToolCalls = slices.Clone(src.ToolCalls)
 	}
 
 	if src.ToolDefinitions != nil {
-		dst.ToolDefinitions = append([]tools.Tool(nil), src.ToolDefinitions...)
+		dst.ToolDefinitions = slices.Clone(src.ToolDefinitions)
 	}
 
 	if src.Usage != nil {
@@ -200,7 +198,7 @@ func cloneChatMessage(src chat.Message) chat.Message {
 	}
 
 	if src.ThoughtSignature != nil {
-		dst.ThoughtSignature = append([]byte(nil), src.ThoughtSignature...)
+		dst.ThoughtSignature = slices.Clone(src.ThoughtSignature)
 	}
 
 	return dst

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -3,6 +3,7 @@ package session
 import (
 	"log/slog"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -258,17 +259,17 @@ func deepCopyChatMessage(m chat.Message) chat.Message {
 		m.FunctionCall = &fcCopy
 	}
 	if m.ToolCalls != nil {
-		m.ToolCalls = append([]tools.ToolCall(nil), m.ToolCalls...)
+		m.ToolCalls = slices.Clone(m.ToolCalls)
 	}
 	if m.ToolDefinitions != nil {
-		m.ToolDefinitions = append([]tools.Tool(nil), m.ToolDefinitions...)
+		m.ToolDefinitions = slices.Clone(m.ToolDefinitions)
 	}
 	if m.Usage != nil {
 		usageCopy := *m.Usage
 		m.Usage = &usageCopy
 	}
 	if m.ThoughtSignature != nil {
-		m.ThoughtSignature = append([]byte(nil), m.ThoughtSignature...)
+		m.ThoughtSignature = slices.Clone(m.ThoughtSignature)
 	}
 	return m
 }

--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -169,8 +169,8 @@ func (s *InMemorySessionStore) GetSessionSummaries(_ context.Context) ([]Summary
 		})
 		return true
 	})
-	sort.Slice(summaries, func(i, j int) bool {
-		return summaries[i].CreatedAt.After(summaries[j].CreatedAt)
+	slices.SortFunc(summaries, func(a, b Summary) int {
+		return b.CreatedAt.Compare(a.CreatedAt)
 	})
 	return summaries, nil
 }

--- a/pkg/skills/skills.go
+++ b/pkg/skills/skills.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/goccy/go-yaml"
@@ -168,9 +169,7 @@ func projectSearchDirs(cwd string) []string {
 	}
 
 	// Reverse so we go from root to cwd (earlier entries get overridden by later)
-	for i, j := 0, len(dirs)-1; i < j; i, j = i+1, j-1 {
-		dirs[i], dirs[j] = dirs[j], dirs[i]
-	}
+	slices.Reverse(dirs)
 
 	return dirs
 }

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 
@@ -161,11 +162,10 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 
 	for _, agentConfig := range cfg.Agents {
 		// Merge CLI prompt files with agent config prompt files, deduplicating
-		promptFiles := append([]string{}, agentConfig.AddPromptFiles...)
-		promptFiles = append(promptFiles, loadOpts.promptFiles...)
+		promptFiles := slices.Concat(agentConfig.AddPromptFiles, loadOpts.promptFiles)
 
 		seen := make(map[string]bool)
-		unique := promptFiles[:0]
+		unique := make([]string, 0, len(promptFiles))
 		for _, f := range promptFiles {
 			if !seen[f] {
 				seen[f] = true

--- a/pkg/tools/builtin/lsp.go
+++ b/pkg/tools/builtin/lsp.go
@@ -13,7 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -1287,11 +1287,11 @@ func applyTextEditsToFile(filePath string, edits []lspTextEdit) error {
 
 	sortedEdits := make([]lspTextEdit, len(edits))
 	copy(sortedEdits, edits)
-	sort.Slice(sortedEdits, func(i, j int) bool {
-		if sortedEdits[i].Range.Start.Line != sortedEdits[j].Range.Start.Line {
-			return sortedEdits[i].Range.Start.Line > sortedEdits[j].Range.Start.Line
+	slices.SortFunc(sortedEdits, func(a, b lspTextEdit) int {
+		if a.Range.Start.Line != b.Range.Start.Line {
+			return cmp.Compare(b.Range.Start.Line, a.Range.Start.Line)
 		}
-		return sortedEdits[i].Range.Start.Character > sortedEdits[j].Range.Start.Character
+		return cmp.Compare(b.Range.Start.Character, a.Range.Start.Character)
 	})
 
 	for _, edit := range sortedEdits {

--- a/pkg/tools/builtin/lsp_multiplexer.go
+++ b/pkg/tools/builtin/lsp_multiplexer.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/docker/docker-agent/pkg/tools"
@@ -41,7 +42,7 @@ var (
 // NewLSPMultiplexer creates a multiplexer that routes LSP tool calls
 // to the appropriate backend based on file type.
 func NewLSPMultiplexer(backends []LSPBackend) *LSPMultiplexer {
-	return &LSPMultiplexer{backends: append([]LSPBackend{}, backends...)}
+	return &LSPMultiplexer{backends: slices.Clone(backends)}
 }
 
 func (m *LSPMultiplexer) Start(ctx context.Context) error {

--- a/pkg/tools/builtin/tasks.go
+++ b/pkg/tools/builtin/tasks.go
@@ -1,13 +1,13 @@
 package builtin
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -195,16 +195,18 @@ func (t *TasksTool) resolveDescription(description, filePath string) (string, er
 }
 
 func sortTasks(tasks []taskWithEffective) {
-	sort.SliceStable(tasks, func(i, j int) bool {
-		a, b := tasks[i], tasks[j]
+	slices.SortStableFunc(tasks, func(a, b taskWithEffective) int {
 		if (a.EffectiveStatus == StatusBlocked) != (b.EffectiveStatus == StatusBlocked) {
-			return a.EffectiveStatus != StatusBlocked
+			if a.EffectiveStatus != StatusBlocked {
+				return -1
+			}
+			return 1
 		}
 		pa, pb := priorityOrder[a.Priority], priorityOrder[b.Priority]
 		if pa != pb {
-			return pa < pb
+			return cmp.Compare(pa, pb)
 		}
-		return a.CreatedAt < b.CreatedAt
+		return cmp.Compare(a.CreatedAt, b.CreatedAt)
 	})
 }
 

--- a/pkg/tui/components/editor/completions/file.go
+++ b/pkg/tui/components/editor/completions/file.go
@@ -2,7 +2,7 @@ package completions
 
 import (
 	"context"
-	"sort"
+	"slices"
 	"sync"
 
 	"github.com/docker/docker-agent/pkg/fsx"
@@ -65,7 +65,7 @@ func (c *fileCompletion) Items() []completion.Item {
 	}
 
 	// Sort files by name
-	sort.Strings(files)
+	slices.Sort(files)
 
 	items := make([]completion.Item, len(files))
 	for i, f := range files {
@@ -125,7 +125,7 @@ func (c *fileCompletion) LoadInitialItemsAsync(ctx context.Context) <-chan []com
 		}
 
 		// Sort files by name
-		sort.Strings(files)
+		slices.Sort(files)
 
 		items := make([]completion.Item, len(files))
 		for i, f := range files {
@@ -189,7 +189,7 @@ func (c *fileCompletion) LoadItemsAsync(ctx context.Context) <-chan []completion
 		}
 
 		// Sort files by name
-		sort.Strings(files)
+		slices.Sort(files)
 
 		items := make([]completion.Item, len(files))
 		for i, f := range files {

--- a/pkg/tui/dialog/cost.go
+++ b/pkg/tui/dialog/cost.go
@@ -3,7 +3,7 @@ package dialog
 import (
 	"cmp"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 
 	"charm.land/bubbles/v2/key"
@@ -210,8 +210,8 @@ func (d *costDialog) gatherCostData() costData {
 	for _, m := range modelMap {
 		data.models = append(data.models, *m)
 	}
-	sort.Slice(data.models, func(i, j int) bool {
-		return data.models[i].cost > data.models[j].cost
+	slices.SortFunc(data.models, func(a, b totalUsage) int {
+		return cmp.Compare(b.cost, a.cost)
 	})
 
 	// Fall back to session-level totals if no per-message data (e.g., past sessions)

--- a/pkg/tui/dialog/model_picker.go
+++ b/pkg/tui/dialog/model_picker.go
@@ -1,8 +1,9 @@
 package dialog
 
 import (
+	"cmp"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -48,7 +49,7 @@ func NewModelPickerDialog(models []runtime.ModelChoice) Dialog {
 	// Sort models: config first, then catalog, then custom. Within each section: current first, then default, then alphabetically
 	sortedModels := make([]runtime.ModelChoice, len(models))
 	copy(sortedModels, models)
-	sort.Slice(sortedModels, func(i, j int) bool {
+	slices.SortFunc(sortedModels, func(a, b runtime.ModelChoice) int {
 		// Get section priority: config (0) < catalog (1) < custom (2)
 		getPriority := func(m runtime.ModelChoice) int {
 			if m.IsCustom {
@@ -59,20 +60,26 @@ func NewModelPickerDialog(models []runtime.ModelChoice) Dialog {
 			}
 			return 0
 		}
-		pi, pj := getPriority(sortedModels[i]), getPriority(sortedModels[j])
-		if pi != pj {
-			return pi < pj
+		pa, pb := getPriority(a), getPriority(b)
+		if pa != pb {
+			return cmp.Compare(pa, pb)
 		}
 		// Within each section: current model first
-		if sortedModels[i].IsCurrent != sortedModels[j].IsCurrent {
-			return sortedModels[i].IsCurrent
+		if a.IsCurrent != b.IsCurrent {
+			if a.IsCurrent {
+				return -1
+			}
+			return 1
 		}
 		// Then default model
-		if sortedModels[i].IsDefault != sortedModels[j].IsDefault {
-			return sortedModels[i].IsDefault
+		if a.IsDefault != b.IsDefault {
+			if a.IsDefault {
+				return -1
+			}
+			return 1
 		}
 		// Then alphabetically by name
-		return sortedModels[i].Name < sortedModels[j].Name
+		return cmp.Compare(a.Name, b.Name)
 	})
 
 	d := &modelPickerDialog{

--- a/pkg/tui/dialog/schema.go
+++ b/pkg/tui/dialog/schema.go
@@ -1,8 +1,9 @@
 package dialog
 
 import (
+	"cmp"
 	"encoding/json"
-	"sort"
+	"slices"
 )
 
 // parseElicitationSchema extracts fields from a JSON schema.
@@ -30,11 +31,14 @@ func parseObjectSchema(schemaMap, properties map[string]any) []ElicitationField 
 	}
 
 	// Sort: required first, then alphabetically
-	sort.Slice(fields, func(i, j int) bool {
-		if fields[i].Required != fields[j].Required {
-			return fields[i].Required
+	slices.SortFunc(fields, func(a, b ElicitationField) int {
+		if a.Required != b.Required {
+			if a.Required {
+				return -1
+			}
+			return 1
 		}
-		return fields[i].Name < fields[j].Name
+		return cmp.Compare(a.Name, b.Name)
 	})
 
 	return fields

--- a/pkg/tui/dialog/theme_picker.go
+++ b/pkg/tui/dialog/theme_picker.go
@@ -1,7 +1,8 @@
 package dialog
 
 import (
-	"sort"
+	"cmp"
+	"slices"
 	"strings"
 	"time"
 
@@ -62,29 +63,35 @@ func NewThemePickerDialog(themes []ThemeChoice, originalThemeRef string) Dialog 
 	// current first, then default, then alphabetically.
 	sortedThemes := make([]ThemeChoice, len(themes))
 	copy(sortedThemes, themes)
-	sort.Slice(sortedThemes, func(i, j int) bool {
+	slices.SortFunc(sortedThemes, func(a, b ThemeChoice) int {
 		getPriority := func(t ThemeChoice) int {
 			if t.IsBuiltin {
 				return 0
 			}
 			return 1
 		}
-		pi, pj := getPriority(sortedThemes[i]), getPriority(sortedThemes[j])
-		if pi != pj {
-			return pi < pj
+		pa, pb := getPriority(a), getPriority(b)
+		if pa != pb {
+			return cmp.Compare(pa, pb)
 		}
-		if sortedThemes[i].IsCurrent != sortedThemes[j].IsCurrent {
-			return sortedThemes[i].IsCurrent
+		if a.IsCurrent != b.IsCurrent {
+			if a.IsCurrent {
+				return -1
+			}
+			return 1
 		}
-		if sortedThemes[i].IsDefault != sortedThemes[j].IsDefault {
-			return sortedThemes[i].IsDefault
+		if a.IsDefault != b.IsDefault {
+			if a.IsDefault {
+				return -1
+			}
+			return 1
 		}
-		ni := strings.ToLower(sortedThemes[i].Name)
-		nj := strings.ToLower(sortedThemes[j].Name)
-		if ni != nj {
-			return ni < nj
+		na := strings.ToLower(a.Name)
+		nb := strings.ToLower(b.Name)
+		if na != nb {
+			return cmp.Compare(na, nb)
 		}
-		return sortedThemes[i].Ref < sortedThemes[j].Ref
+		return cmp.Compare(a.Ref, b.Ref)
 	})
 
 	d := &themePickerDialog{


### PR DESCRIPTION
Replace manual loops and `sort` package usage with idiomatic Go stdlib functions from the `slices` and `maps` packages across 18 files:

- `sort.Strings` → `slices.Sort`
- `sort.Slice` → `slices.SortFunc`
- `sort.SliceStable` → `slices.SortStableFunc`
- `append([]T(nil), src...)` → `slices.Clone`
- Manual map-key collection → `slices.Collect(maps.Keys(...))`
- Manual map clone → `maps.Clone`
- Manual reverse loop → `slices.Reverse`
- Manual slice concat → `slices.Concat`
- Collect keys + sort → `slices.Sorted(maps.Keys(...))`

All changes are semantically equivalent to the original code. Linter passes, all unit tests pass.