### PR TITLE
fix: default sound notifications to off (opt-in)

### DIFF
--- a/pkg/userconfig/userconfig.go
+++ b/pkg/userconfig/userconfig.go
@@ -56,8 +56,8 @@ type Settings struct {
 	// Defaults to false when not set (user must explicitly opt-in).
 	RestoreTabs *bool `yaml:"restore_tabs,omitempty"`
 	// Sound enables playing notification sounds on task success or failure.
-	// Defaults to false when not set (user must explicitly opt-in).
-	Sound *bool `yaml:"sound,omitempty"`
+	// Defaults to false (user must explicitly opt-in).
+	Sound bool `yaml:"sound,omitempty"`
 	// SoundThreshold is the minimum duration in seconds a task must run
 	// before a success sound is played. Defaults to 5 seconds.
 	SoundThreshold int `yaml:"sound_threshold,omitempty"`
@@ -77,15 +77,15 @@ func (s *Settings) GetTabTitleMaxLength() int {
 	return s.TabTitleMaxLength
 }
 
-// GetSound returns whether sound notifications are enabled, defaulting to true.
+// GetSound returns whether sound notifications are enabled, defaulting to false.
 func (s *Settings) GetSound() bool {
-	if s == nil || s.Sound == nil {
-		return true
+	if s == nil {
+		return false
 	}
-	return *s.Sound
+	return s.Sound
 }
 
-// GetSoundThreshold returns the minimum duration for sound notifications, defaulting to 5s.
+// GetSoundThreshold returns the minimum duration for sound notifications, defaulting to 10s.
 func (s *Settings) GetSoundThreshold() int {
 	if s == nil || s.SoundThreshold <= 0 {
 		return DefaultSoundThreshold

--- a/pkg/userconfig/userconfig_test.go
+++ b/pkg/userconfig/userconfig_test.go
@@ -811,6 +811,28 @@ func TestGet_WithHideToolResults(t *testing.T) {
 	assert.True(t, settings.HideToolResults)
 }
 
+func TestSettings_GetSound(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		settings *Settings
+		expected bool
+	}{
+		{"nil settings", nil, false},
+		{"empty settings", &Settings{}, false},
+		{"explicitly enabled", &Settings{Sound: true}, true},
+		{"explicitly disabled", &Settings{Sound: false}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, tt.settings.GetSound())
+		})
+	}
+}
+
 func TestSettings_RestoreTabs(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Sound notifications were defaulting to enabled (`true`), but the design intent is for them to be off by default, requiring users to explicitly opt in.

## Changes

- Change `Sound` field from `*bool` to `bool` since the zero value (`false`) now matches the desired default, removing unnecessary pointer indirection
- Simplify `GetSound()` by removing nil pointer check and dereference
- Fix `GetSoundThreshold()` doc comment (said 5s, actual default is 10s)
- Add `TestSettings_GetSound` covering nil, empty, enabled, and disabled cases