### PR TITLE
Enable modernize and perfsprint linters, fix all findings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,10 +37,12 @@ linters:
     - loggercheck
     - misspell
     - mirror
+    - modernize
     - nakedret
     - nolintlint
     - nosprintfhostport
     - nilnesserr
+    - perfsprint
     - predeclared
     - reassign
     - recvcheck

--- a/cmd/root/alias.go
+++ b/cmd/root/alias.go
@@ -1,6 +1,7 @@
 package root
 
 import (
+	"errors"
 	"fmt"
 	"maps"
 	"path/filepath"
@@ -264,7 +265,7 @@ func expandTilde(path string) (string, error) {
 
 	homeDir := paths.GetHomeDir()
 	if homeDir == "" {
-		return "", fmt.Errorf("failed to get user home directory")
+		return "", errors.New("failed to get user home directory")
 	}
 
 	return filepath.Join(homeDir, strings.TrimPrefix(path, "~/")), nil

--- a/cmd/root/api.go
+++ b/cmd/root/api.go
@@ -1,6 +1,7 @@
 package root
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -79,7 +80,7 @@ func (f *apiFlags) runAPICommand(cmd *cobra.Command, args []string) error {
 	}()
 
 	if f.pullIntervalMins > 0 && !config.IsOCIReference(agentsPath) {
-		return fmt.Errorf("--pull-interval flag can only be used with OCI references, not local files")
+		return errors.New("--pull-interval flag can only be used with OCI references, not local files")
 	}
 
 	ln, lnCleanup, err := newListener(ctx, f.listenAddr)

--- a/cmd/root/debug_auth.go
+++ b/cmd/root/debug_auth.go
@@ -18,8 +18,8 @@ type authInfo struct {
 	Token     string    `json:"token"`
 	Subject   string    `json:"subject,omitempty"`
 	Issuer    string    `json:"issuer,omitempty"`
-	IssuedAt  time.Time `json:"issued_at,omitempty"`
-	ExpiresAt time.Time `json:"expires_at,omitempty"`
+	IssuedAt  time.Time `json:"issued_at,omitzero"`
+	ExpiresAt time.Time `json:"expires_at,omitzero"`
 	Expired   bool      `json:"expired"`
 	Username  string    `json:"username,omitempty"`
 	Email     string    `json:"email,omitempty"`

--- a/examples/golibrary/tool/main.go
+++ b/examples/golibrary/tool/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os/signal"
+	"strconv"
 	"syscall"
 
 	"github.com/docker/docker-agent/pkg/agent"
@@ -40,7 +41,7 @@ func addNumbers(_ context.Context, toolCall tools.ToolCall) (*tools.ToolCallResu
 
 	fmt.Println("Adding numbers", p.A, p.B)
 
-	return tools.ResultSuccess(fmt.Sprintf("%d", p.A+p.B)), nil
+	return tools.ResultSuccess(strconv.Itoa(p.A + p.B)), nil
 }
 
 func run(ctx context.Context) error {

--- a/pkg/a2a/adapter.go
+++ b/pkg/a2a/adapter.go
@@ -24,7 +24,7 @@ func newDockerAgentAdapter(t *team.Team, agentName string) (agent.Agent, error) 
 		return nil, fmt.Errorf("failed to get agent %s: %w", agentName, err)
 	}
 
-	desc := cmp.Or(a.Description(), fmt.Sprintf("Agent %s", agentName))
+	desc := cmp.Or(a.Description(), "Agent "+agentName)
 
 	return agent.New(agent.Config{
 		Name:        agentName,

--- a/pkg/acp/agent.go
+++ b/pkg/acp/agent.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -130,7 +131,7 @@ func (a *Agent) NewSession(ctx context.Context, params acp.NewSessionRequest) (a
 			return acp.NewSessionResponse{}, fmt.Errorf("working directory does not exist: %w", err)
 		}
 		if !info.IsDir() {
-			return acp.NewSessionResponse{}, fmt.Errorf("working directory must be a directory")
+			return acp.NewSessionResponse{}, errors.New("working directory must be a directory")
 		}
 		workingDir = absWd
 	}
@@ -190,7 +191,7 @@ func (a *Agent) Authenticate(context.Context, acp.AuthenticateRequest) (acp.Auth
 // LoadSession implements [acp.Agent] (optional, not supported)
 func (a *Agent) LoadSession(context.Context, acp.LoadSessionRequest) (acp.LoadSessionResponse, error) {
 	slog.Debug("ACP LoadSession called (not supported)")
-	return acp.LoadSessionResponse{}, fmt.Errorf("load session not supported")
+	return acp.LoadSessionResponse{}, errors.New("load session not supported")
 }
 
 // Cancel implements [acp.Agent]
@@ -490,7 +491,7 @@ func (a *Agent) handleToolCallConfirmation(ctx context.Context, acpSess *Session
 	}
 
 	if permResp.Outcome.Selected == nil {
-		return fmt.Errorf("unexpected permission outcome")
+		return errors.New("unexpected permission outcome")
 	}
 
 	switch string(permResp.Outcome.Selected.OptionId) {
@@ -708,19 +709,23 @@ func extractDiffContent(toolCall tools.ToolCall, _ string) *acp.ToolCallContent 
 		}
 
 		// Build combined diff from all edits
-		var oldText, newText string
+		var oldTextSb, newTextSb strings.Builder
 		for _, edit := range edits {
 			editMap, ok := edit.(map[string]any)
 			if !ok {
 				continue
 			}
 			if old, ok := editMap["oldText"].(string); ok {
-				oldText += old + "\n"
+				oldTextSb.WriteString(old)
+				oldTextSb.WriteByte('\n')
 			}
 			if newVal, ok := editMap["newText"].(string); ok {
-				newText += newVal + "\n"
+				newTextSb.WriteString(newVal)
+				newTextSb.WriteByte('\n')
 			}
 		}
+		oldText := oldTextSb.String()
+		newText := newTextSb.String()
 
 		if oldText != "" || newText != "" {
 			diff := acp.ToolDiffContent(path, newText, oldText)

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -627,7 +628,7 @@ func (a *App) SwitchAgent(agentName string) error {
 func (a *App) SetCurrentAgentModel(ctx context.Context, modelRef string) error {
 	modelSwitcher, ok := a.runtime.(runtime.ModelSwitcher)
 	if !ok {
-		return fmt.Errorf("model switching not supported by this runtime")
+		return errors.New("model switching not supported by this runtime")
 	}
 
 	agentName := a.runtime.CurrentAgentName()
@@ -1028,11 +1029,11 @@ func (a *App) ExportHTML(ctx context.Context, filename string) (string, error) {
 // UpdateSessionTitle updates the current session's title and persists it.
 // It works with both local and remote runtimes.
 // ErrTitleGenerating is returned when attempting to set a title while generation is in progress.
-var ErrTitleGenerating = fmt.Errorf("title generation in progress, please wait")
+var ErrTitleGenerating = errors.New("title generation in progress, please wait")
 
 func (a *App) UpdateSessionTitle(ctx context.Context, title string) error {
 	if a.session == nil {
-		return fmt.Errorf("no active session")
+		return errors.New("no active session")
 	}
 
 	// Prevent manual title edits while generation is in progress
@@ -1108,7 +1109,7 @@ func (a *App) generateTitle(ctx context.Context, userMessages []string) {
 // Returns ErrTitleGenerating if a title generation is already in progress.
 func (a *App) RegenerateSessionTitle(ctx context.Context) error {
 	if a.session == nil {
-		return fmt.Errorf("no active session")
+		return errors.New("no active session")
 	}
 
 	// Check if title generation is already in progress
@@ -1135,5 +1136,5 @@ func (a *App) RegenerateSessionTitle(ctx context.Context) error {
 	// For remote runtime, title regeneration is not yet supported
 	// (the server would need to implement this)
 	slog.Debug("Title regeneration not available for remote runtime", "session_id", a.session.ID)
-	return fmt.Errorf("title regeneration not available")
+	return errors.New("title regeneration not available")
 }

--- a/pkg/app/export/html.go
+++ b/pkg/app/export/html.go
@@ -5,10 +5,12 @@ import (
 	"bytes"
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"html/template"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -82,7 +84,7 @@ type ToolCall struct {
 // Returns the absolute path of the created file.
 func SessionToFile(sess *session.Session, agentDescription, filename string) (string, error) {
 	if sess == nil {
-		return "", fmt.Errorf("no session to export")
+		return "", errors.New("no session to export")
 	}
 	data := sessionToData(sess)
 	data.AgentDescription = agentDescription
@@ -126,7 +128,7 @@ func sessionToData(sess *session.Session) SessionData {
 // Returns the absolute path of the created file.
 func ToFile(data SessionData, filename string) (string, error) {
 	if len(data.Messages) == 0 {
-		return "", fmt.Errorf("session is empty")
+		return "", errors.New("session is empty")
 	}
 
 	// Generate filename if not provided
@@ -392,7 +394,7 @@ func formatTokens(tokens int64) string {
 	if tokens >= 1000 {
 		return fmt.Sprintf("%.1fK", float64(tokens)/1000)
 	}
-	return fmt.Sprintf("%d", tokens)
+	return strconv.FormatInt(tokens, 10)
 }
 
 func formatCost(cost float64) string {

--- a/pkg/audio/transcribe/transcribe_darwin.go
+++ b/pkg/audio/transcribe/transcribe_darwin.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"sync"
@@ -55,11 +56,11 @@ func New(apiKey string) *Transcriber {
 // connection fails. Call Stop to end transcription.
 func (t *Transcriber) Start(ctx context.Context, handler TranscriptHandler) error {
 	if t.apiKey == "" {
-		return fmt.Errorf("speech-to-text requires the OPENAI_API_KEY environment variable to be set")
+		return errors.New("speech-to-text requires the OPENAI_API_KEY environment variable to be set")
 	}
 
 	if wasRunning := t.running.Swap(true); wasRunning {
-		return fmt.Errorf("transcriber already running")
+		return errors.New("transcriber already running")
 	}
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/pkg/cli/printer.go
+++ b/pkg/cli/printer.go
@@ -322,7 +322,7 @@ func formatJSONValue(key string, value any) string {
 
 	case []any:
 		if len(v) == 0 {
-			return fmt.Sprintf("%s: []", bold(key))
+			return bold(key) + ": []"
 		}
 		// Single item arrays are rendered on a single line
 		if len(v) == 1 {

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -234,7 +235,7 @@ func Run(ctx context.Context, out *Printer, cfg Config, rt runtime.Runtime, sess
 					_ = rt.ResumeElicitation(ctx, "accept", nil)
 				case ConfirmationReject:
 					_ = rt.ResumeElicitation(ctx, "decline", nil)
-					return fmt.Errorf("OAuth authorization rejected by user")
+					return errors.New("OAuth authorization rejected by user")
 				}
 			}
 		}

--- a/pkg/config/auto.go
+++ b/pkg/config/auto.go
@@ -46,12 +46,10 @@ func (e *AutoModelFallbackError) Error() string {
 		hints = append(hints, fmt.Sprintf("    - %s: %s", p.name, p.hint))
 	}
 
-	return fmt.Sprintf(`No model providers available.
-
-To fix this, you can:
-  - Install Docker Model Runner: https://docs.docker.com/ai/model-runner/get-started/
-  - Configure an API key for a cloud provider:
-%s`, strings.Join(hints, "\n"))
+	return "No model providers available.\n\nTo fix this, you can:\n" +
+		"  - Install Docker Model Runner: https://docs.docker.com/ai/model-runner/get-started/\n" +
+		"  - Configure an API key for a cloud provider:\n" +
+		strings.Join(hints, "\n")
 }
 
 var DefaultModels = map[string]string{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -192,13 +192,13 @@ func validateProviders(cfg *latest.Config) error {
 func validateProviderName(name string) error {
 	trimmed := strings.TrimSpace(name)
 	if trimmed == "" {
-		return fmt.Errorf("name cannot be empty")
+		return errors.New("name cannot be empty")
 	}
 	if trimmed != name {
-		return fmt.Errorf("name cannot have leading or trailing whitespace")
+		return errors.New("name cannot have leading or trailing whitespace")
 	}
 	if strings.Contains(name, "/") {
-		return fmt.Errorf("name cannot contain '/'")
+		return errors.New("name cannot contain '/'")
 	}
 	return nil
 }

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -3,8 +3,10 @@ package latest
 import (
 	"cmp"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
+	"slices"
 	"strings"
 	"time"
 
@@ -61,7 +63,7 @@ func (c *Agents) UnmarshalYAML(unmarshal func(any) error) error {
 	for _, item := range items {
 		name, ok := item.Key.(string)
 		if !ok {
-			return fmt.Errorf("agent name must be a string")
+			return errors.New("agent name must be a string")
 		}
 
 		valueBytes, err := yaml.Marshal(item.Value)
@@ -162,7 +164,7 @@ type Duration struct {
 // UnmarshalYAML implements custom unmarshaling for Duration from string format
 func (d *Duration) UnmarshalYAML(unmarshal func(any) error) error {
 	if d == nil {
-		return fmt.Errorf("cannot unmarshal into nil Duration")
+		return errors.New("cannot unmarshal into nil Duration")
 	}
 
 	var s string
@@ -198,7 +200,7 @@ func (d Duration) MarshalYAML() (any, error) {
 // UnmarshalJSON implements custom unmarshaling for Duration from string format
 func (d *Duration) UnmarshalJSON(data []byte) error {
 	if d == nil {
-		return fmt.Errorf("cannot unmarshal into nil Duration")
+		return errors.New("cannot unmarshal into nil Duration")
 	}
 
 	var s string
@@ -252,7 +254,7 @@ type AgentConfig struct {
 	AddPromptFiles          []string          `json:"add_prompt_files,omitempty" yaml:"add_prompt_files,omitempty"`
 	Commands                types.Commands    `json:"commands,omitempty"`
 	StructuredOutput        *StructuredOutput `json:"structured_output,omitempty"`
-	Skills                  SkillsConfig      `json:"skills,omitempty"`
+	Skills                  SkillsConfig      `json:"skills,omitzero"`
 	Hooks                   *HooksConfig      `json:"hooks,omitempty"`
 }
 
@@ -274,12 +276,7 @@ func (s SkillsConfig) Enabled() bool {
 }
 
 func (s SkillsConfig) HasLocal() bool {
-	for _, src := range s.Sources {
-		if src == SkillSourceLocal {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(s.Sources, SkillSourceLocal)
 }
 
 func (s SkillsConfig) RemoteURLs() []string {
@@ -305,7 +302,7 @@ func (s *SkillsConfig) UnmarshalYAML(unmarshal func(any) error) error {
 
 	var sources []string
 	if err := unmarshal(&sources); err != nil {
-		return fmt.Errorf("skills must be a boolean or a list of sources")
+		return errors.New("skills must be a boolean or a list of sources")
 	}
 	s.Sources = sources
 	return nil
@@ -334,7 +331,7 @@ func (s *SkillsConfig) UnmarshalJSON(data []byte) error {
 
 	var sources []string
 	if err := json.Unmarshal(data, &sources); err != nil {
-		return fmt.Errorf("skills must be a boolean or a list of sources")
+		return errors.New("skills must be a boolean or a list of sources")
 	}
 	s.Sources = sources
 	return nil
@@ -1020,7 +1017,7 @@ func (d *RAGDatabaseConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		return nil
 	}
 
-	return fmt.Errorf("database must be a string path to a sqlite database")
+	return errors.New("database must be a string path to a sqlite database")
 }
 
 // AsString returns the database config as a connection string
@@ -1035,7 +1032,7 @@ func (d *RAGDatabaseConfig) AsString() (string, error) {
 		return str, nil
 	}
 
-	return "", fmt.Errorf("invalid database configuration: expected string path")
+	return "", errors.New("invalid database configuration: expected string path")
 }
 
 // IsEmpty returns true if no database is configured

--- a/pkg/config/overrides.go
+++ b/pkg/config/overrides.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -60,7 +61,7 @@ func applySingleOverride(cfg *latest.Config, override string) error {
 		// Global override: apply to all agents
 		modelSpec := strings.TrimSpace(override)
 		if modelSpec == "" {
-			return fmt.Errorf("empty model specification")
+			return errors.New("empty model specification")
 		}
 
 		for _, agent := range cfg.Agents {

--- a/pkg/config/types/commands.go
+++ b/pkg/config/types/commands.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"errors"
 	"fmt"
 )
 
@@ -122,7 +123,7 @@ func parseCommandValue(v any) (Command, error) {
 		inst, _ := val["instruction"].(string)
 
 		if inst == "" && desc == "" {
-			return Command{}, fmt.Errorf("command must have at least 'instruction' or 'description'")
+			return Command{}, errors.New("command must have at least 'instruction' or 'description'")
 		}
 		if inst == "" {
 			inst = desc

--- a/pkg/config/v2/types.go
+++ b/pkg/config/v2/types.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 
@@ -482,7 +483,7 @@ func (d *RAGDatabaseConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		return nil
 	}
 
-	return fmt.Errorf("database must be a string path to a sqlite database")
+	return errors.New("database must be a string path to a sqlite database")
 }
 
 // AsString returns the database config as a connection string
@@ -497,7 +498,7 @@ func (d *RAGDatabaseConfig) AsString() (string, error) {
 		return str, nil
 	}
 
-	return "", fmt.Errorf("invalid database configuration: expected string path")
+	return "", errors.New("invalid database configuration: expected string path")
 }
 
 // IsEmpty returns true if no database is configured
@@ -528,7 +529,7 @@ func (d *RAGDatabaseConfig) UnmarshalJSON(data []byte) error {
 		d.value = str
 		return nil
 	}
-	return fmt.Errorf("database must be a string path to a sqlite database")
+	return errors.New("database must be a string path to a sqlite database")
 }
 
 // RAGChunkingConfig represents text chunking configuration

--- a/pkg/config/v3/types.go
+++ b/pkg/config/v3/types.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 
@@ -619,7 +620,7 @@ func (d *RAGDatabaseConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		return nil
 	}
 
-	return fmt.Errorf("database must be a string path to a sqlite database")
+	return errors.New("database must be a string path to a sqlite database")
 }
 
 // AsString returns the database config as a connection string
@@ -634,7 +635,7 @@ func (d *RAGDatabaseConfig) AsString() (string, error) {
 		return str, nil
 	}
 
-	return "", fmt.Errorf("invalid database configuration: expected string path")
+	return "", errors.New("invalid database configuration: expected string path")
 }
 
 // IsEmpty returns true if no database is configured

--- a/pkg/config/v4/types.go
+++ b/pkg/config/v4/types.go
@@ -2,6 +2,7 @@ package v4
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"strings"
@@ -37,7 +38,7 @@ func (c *Agents) UnmarshalYAML(unmarshal func(any) error) error {
 	for _, item := range items {
 		name, ok := item.Key.(string)
 		if !ok {
-			return fmt.Errorf("agent name must be a string")
+			return errors.New("agent name must be a string")
 		}
 
 		valueBytes, err := yaml.Marshal(item.Value)
@@ -138,7 +139,7 @@ type Duration struct {
 // UnmarshalYAML implements custom unmarshaling for Duration from string format
 func (d *Duration) UnmarshalYAML(unmarshal func(any) error) error {
 	if d == nil {
-		return fmt.Errorf("cannot unmarshal into nil Duration")
+		return errors.New("cannot unmarshal into nil Duration")
 	}
 
 	var s string
@@ -174,7 +175,7 @@ func (d Duration) MarshalYAML() (any, error) {
 // UnmarshalJSON implements custom unmarshaling for Duration from string format
 func (d *Duration) UnmarshalJSON(data []byte) error {
 	if d == nil {
-		return fmt.Errorf("cannot unmarshal into nil Duration")
+		return errors.New("cannot unmarshal into nil Duration")
 	}
 
 	var s string
@@ -879,7 +880,7 @@ func (d *RAGDatabaseConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		return nil
 	}
 
-	return fmt.Errorf("database must be a string path to a sqlite database")
+	return errors.New("database must be a string path to a sqlite database")
 }
 
 // AsString returns the database config as a connection string
@@ -894,7 +895,7 @@ func (d *RAGDatabaseConfig) AsString() (string, error) {
 		return str, nil
 	}
 
-	return "", fmt.Errorf("invalid database configuration: expected string path")
+	return "", errors.New("invalid database configuration: expected string path")
 }
 
 // IsEmpty returns true if no database is configured

--- a/pkg/config/v5/types.go
+++ b/pkg/config/v5/types.go
@@ -3,8 +3,10 @@ package v5
 import (
 	"cmp"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
+	"slices"
 	"strings"
 	"time"
 
@@ -38,7 +40,7 @@ func (c *Agents) UnmarshalYAML(unmarshal func(any) error) error {
 	for _, item := range items {
 		name, ok := item.Key.(string)
 		if !ok {
-			return fmt.Errorf("agent name must be a string")
+			return errors.New("agent name must be a string")
 		}
 
 		valueBytes, err := yaml.Marshal(item.Value)
@@ -139,7 +141,7 @@ type Duration struct {
 // UnmarshalYAML implements custom unmarshaling for Duration from string format
 func (d *Duration) UnmarshalYAML(unmarshal func(any) error) error {
 	if d == nil {
-		return fmt.Errorf("cannot unmarshal into nil Duration")
+		return errors.New("cannot unmarshal into nil Duration")
 	}
 
 	var s string
@@ -175,7 +177,7 @@ func (d Duration) MarshalYAML() (any, error) {
 // UnmarshalJSON implements custom unmarshaling for Duration from string format
 func (d *Duration) UnmarshalJSON(data []byte) error {
 	if d == nil {
-		return fmt.Errorf("cannot unmarshal into nil Duration")
+		return errors.New("cannot unmarshal into nil Duration")
 	}
 
 	var s string
@@ -229,7 +231,7 @@ type AgentConfig struct {
 	AddPromptFiles          []string          `json:"add_prompt_files,omitempty" yaml:"add_prompt_files,omitempty"`
 	Commands                types.Commands    `json:"commands,omitempty"`
 	StructuredOutput        *StructuredOutput `json:"structured_output,omitempty"`
-	Skills                  SkillsConfig      `json:"skills,omitempty"`
+	Skills                  SkillsConfig      `json:"skills,omitempty"` //nolint:modernize // frozen config version
 	Hooks                   *HooksConfig      `json:"hooks,omitempty"`
 }
 
@@ -251,12 +253,7 @@ func (s SkillsConfig) Enabled() bool {
 }
 
 func (s SkillsConfig) HasLocal() bool {
-	for _, src := range s.Sources {
-		if src == SkillSourceLocal {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(s.Sources, SkillSourceLocal)
 }
 
 func (s SkillsConfig) RemoteURLs() []string {
@@ -282,7 +279,7 @@ func (s *SkillsConfig) UnmarshalYAML(unmarshal func(any) error) error {
 
 	var sources []string
 	if err := unmarshal(&sources); err != nil {
-		return fmt.Errorf("skills must be a boolean or a list of sources")
+		return errors.New("skills must be a boolean or a list of sources")
 	}
 	s.Sources = sources
 	return nil
@@ -311,7 +308,7 @@ func (s *SkillsConfig) UnmarshalJSON(data []byte) error {
 
 	var sources []string
 	if err := json.Unmarshal(data, &sources); err != nil {
-		return fmt.Errorf("skills must be a boolean or a list of sources")
+		return errors.New("skills must be a boolean or a list of sources")
 	}
 	s.Sources = sources
 	return nil
@@ -1001,7 +998,7 @@ func (d *RAGDatabaseConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		return nil
 	}
 
-	return fmt.Errorf("database must be a string path to a sqlite database")
+	return errors.New("database must be a string path to a sqlite database")
 }
 
 // AsString returns the database config as a connection string
@@ -1016,7 +1013,7 @@ func (d *RAGDatabaseConfig) AsString() (string, error) {
 		return str, nil
 	}
 
-	return "", fmt.Errorf("invalid database configuration: expected string path")
+	return "", errors.New("invalid database configuration: expected string path")
 }
 
 // IsEmpty returns true if no database is configured

--- a/pkg/environment/env_files.go
+++ b/pkg/environment/env_files.go
@@ -1,6 +1,7 @@
 package environment
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -38,7 +39,7 @@ func AbsolutePath(parentDir, relOrAbsPath string) (string, error) {
 	// For absolute paths (including tilde-expanded ones), validate against directory traversal
 	if filepath.IsAbs(p) {
 		if strings.Contains(relOrAbsPath, "..") {
-			return "", fmt.Errorf("invalid environment file path: path contains directory traversal sequences")
+			return "", errors.New("invalid environment file path: path contains directory traversal sequences")
 		}
 		return p, nil
 	}
@@ -59,7 +60,7 @@ func expandTildePath(p string) (string, error) {
 
 	homeDir := paths.GetHomeDir()
 	if homeDir == "" {
-		return "", fmt.Errorf("failed to get user home directory")
+		return "", errors.New("failed to get user home directory")
 	}
 
 	if p == "~" {

--- a/pkg/evaluation/eval.go
+++ b/pkg/evaluation/eval.go
@@ -6,6 +6,7 @@ import (
 	"cmp"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -478,7 +479,7 @@ func (r *Runner) runDockerAgentInContainer(ctx context.Context, imageID string, 
 		if stderrStr != "" {
 			return nil, fmt.Errorf("no events received from container (stderr: %s)", stderrStr)
 		}
-		return nil, fmt.Errorf("no events received from container")
+		return nil, errors.New("no events received from container")
 	}
 
 	return events, nil

--- a/pkg/evaluation/progress.go
+++ b/pkg/evaluation/progress.go
@@ -180,7 +180,7 @@ func (p *progressBar) render(final bool) {
 			name = name[:availableForName-1] + "…"
 		}
 		if runningCount == 1 {
-			status += fmt.Sprintf(" | %s", name)
+			status += " | " + name
 		} else {
 			status += fmt.Sprintf(" | %s +%d more", name, runningCount-1)
 		}

--- a/pkg/evaluation/save.go
+++ b/pkg/evaluation/save.go
@@ -366,7 +366,7 @@ func SaveRunSessionsJSON(run *EvalRun, outputDir string) (string, error) {
 func Save(sess *session.Session, filename string) (string, error) {
 	baseName := cmp.Or(filename, sess.ID)
 
-	evalFile := filepath.Join("evals", fmt.Sprintf("%s.json", baseName))
+	evalFile := filepath.Join("evals", baseName+".json")
 	for number := 1; ; number++ {
 		if _, err := os.Stat(evalFile); err != nil {
 			break

--- a/pkg/evaluation/types.go
+++ b/pkg/evaluation/types.go
@@ -43,7 +43,7 @@ func (r *Result) checkResults() (successes, failures []string) {
 	// Check size
 	if r.SizeExpected != "" {
 		if r.SizeExpected == r.Size {
-			successes = append(successes, fmt.Sprintf("size %s", r.Size))
+			successes = append(successes, "size "+r.Size)
 		} else {
 			failures = append(failures, fmt.Sprintf("size expected %s, got %s", r.SizeExpected, r.Size))
 		}
@@ -74,7 +74,7 @@ func (r *Result) checkResults() (successes, failures []string) {
 				if result.Reason != "" {
 					failures = append(failures, fmt.Sprintf("relevance: %s (reason: %s)", result.Criterion, result.Reason))
 				} else {
-					failures = append(failures, fmt.Sprintf("relevance: %s", result.Criterion))
+					failures = append(failures, "relevance: "+result.Criterion)
 				}
 			}
 		}

--- a/pkg/gateway/catalog.go
+++ b/pkg/gateway/catalog.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -178,7 +179,7 @@ func getCacheFilePath() string {
 
 func loadCatalogFromCache(cacheFile string) (Catalog, time.Duration, error) {
 	if cacheFile == "" {
-		return nil, 0, fmt.Errorf("no cache file path")
+		return nil, 0, errors.New("no cache file path")
 	}
 
 	data, err := os.ReadFile(cacheFile)

--- a/pkg/mcp/server_test.go
+++ b/pkg/mcp/server_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/docker/docker-agent/pkg/tools"
 )
 
-func boolPtr(v bool) *bool { return &v }
-
 // annot is a shorthand for building tools.ToolAnnotations in tests.
 func annot(readOnly, idempotent bool, destructive, openWorld *bool) tools.ToolAnnotations {
 	return tools.ToolAnnotations{
@@ -25,8 +23,8 @@ func annot(readOnly, idempotent bool, destructive, openWorld *bool) tools.ToolAn
 func TestAgentToolAnnotations(t *testing.T) {
 	t.Parallel()
 
-	pFalse := boolPtr(false)
-	pTrue := boolPtr(true)
+	pFalse := new(false)
+	pTrue := new(true)
 
 	tests := []struct {
 		name            string

--- a/pkg/memory/database/sqlite/sqlite.go
+++ b/pkg/memory/database/sqlite/sqlite.go
@@ -82,8 +82,8 @@ func (m *MemoryDatabase) SearchMemories(ctx context.Context, query, category str
 	var args []any
 
 	if query != "" {
-		words := strings.Fields(query)
-		for _, word := range words {
+		words := strings.FieldsSeq(query)
+		for word := range words {
 			conditions = append(conditions, "LOWER(memory) LIKE LOWER(?) ESCAPE '\\'")
 			escaped := strings.ReplaceAll(word, `\`, `\\`)
 			escaped = strings.ReplaceAll(escaped, `%`, `\%`)

--- a/pkg/model/provider/anthropic/beta_converter.go
+++ b/pkg/model/provider/anthropic/beta_converter.go
@@ -3,6 +3,7 @@ package anthropic
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -267,7 +268,7 @@ func (c *Client) convertBetaUserMultiContent(ctx context.Context, parts []chat.M
 
 			default:
 				// File part has neither path nor file ID - this is invalid
-				return nil, fmt.Errorf("invalid file attachment: neither path nor file_id provided")
+				return nil, errors.New("invalid file attachment: neither path nor file_id provided")
 			}
 		}
 	}

--- a/pkg/model/provider/dmr/client.go
+++ b/pkg/model/provider/dmr/client.go
@@ -543,7 +543,7 @@ func (c *Client) CreateEmbedding(ctx context.Context, text string) (*base.Embedd
 	}
 
 	if len(response.Data) == 0 {
-		return nil, fmt.Errorf("no embedding returned from DMR")
+		return nil, errors.New("no embedding returned from DMR")
 	}
 
 	// Convert []float32 to []float64
@@ -707,7 +707,7 @@ func (c *Client) Rerank(ctx context.Context, query string, documents []types.Doc
 	// Make HTTP request to rerank endpoint
 	// Rerank endpoint is at the base host level: http://host:port/rerank
 	// Not under /engines/v1/ like chat/embeddings
-	rerankURL := fmt.Sprintf("%s/rerank", baseURL)
+	rerankURL := baseURL + "/rerank"
 
 	slog.Debug("DMR reranking HTTP request",
 		"base_url", baseURL,
@@ -1014,7 +1014,7 @@ func confirmModelPull(ctx context.Context, model string) error {
 
 	response = strings.TrimSpace(strings.ToLower(response))
 	if response != "y" && response != "yes" {
-		return fmt.Errorf("model pull declined by user")
+		return errors.New("model pull declined by user")
 	}
 
 	return nil

--- a/pkg/model/provider/gemini/adapter.go
+++ b/pkg/model/provider/gemini/adapter.go
@@ -178,8 +178,8 @@ func (g *StreamAdapter) Recv() (chat.MessageStreamResponse, error) {
 		}
 
 		// Handle text and thoughts separately so TUI can render them distinctly
-		var textContent string
-		var reasoningText string
+		var reasoningTextSb strings.Builder
+		var textContentSb strings.Builder
 		var thoughtSignature []byte
 		for _, candidate := range res.resp.Candidates {
 			if candidate.Content != nil {
@@ -190,14 +190,16 @@ func (g *StreamAdapter) Recv() (chat.MessageStreamResponse, error) {
 
 					if part.Text != "" {
 						if part.Thought {
-							reasoningText += part.Text
+							reasoningTextSb.WriteString(part.Text)
 						} else {
-							textContent += part.Text
+							textContentSb.WriteString(part.Text)
 						}
 					}
 				}
 			}
 		}
+		reasoningText := reasoningTextSb.String()
+		textContent := textContentSb.String()
 		if reasoningText != "" {
 			resp.Choices[0].Delta.ReasoningContent = reasoningText
 		}

--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -591,7 +591,7 @@ func (c *Client) CreateEmbedding(ctx context.Context, text string) (*base.Embedd
 	}
 
 	if len(batchResult.Embeddings) == 0 {
-		return nil, fmt.Errorf("no embedding returned from OpenAI")
+		return nil, errors.New("no embedding returned from OpenAI")
 	}
 
 	embedding := batchResult.Embeddings[0]

--- a/pkg/model/provider/rulebased/client.go
+++ b/pkg/model/provider/rulebased/client.go
@@ -8,6 +8,7 @@ package rulebased
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -52,7 +53,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, models map[string]l
 	slog.Debug("Creating rule-based router", "provider", cfg.Provider, "model", cfg.Model)
 
 	if len(cfg.Routing) == 0 {
-		return nil, fmt.Errorf("no routing rules configured")
+		return nil, errors.New("no routing rules configured")
 	}
 
 	index, err := createIndex()
@@ -158,7 +159,7 @@ func (c *Client) CreateChatCompletionStream(
 ) (chat.MessageStream, error) {
 	provider := c.selectProvider(messages)
 	if provider == nil {
-		return nil, fmt.Errorf("no provider available for routing")
+		return nil, errors.New("no provider available for routing")
 	}
 
 	slog.Debug("Rule-based router selected model",

--- a/pkg/modelerrors/modelerrors.go
+++ b/pkg/modelerrors/modelerrors.go
@@ -51,7 +51,7 @@ func (e *ContextOverflowError) Error() string {
 	if e.Underlying == nil {
 		return "context window overflow"
 	}
-	return fmt.Sprintf("context window overflow: %s", e.Underlying.Error())
+	return "context window overflow: " + e.Underlying.Error()
 }
 
 func (e *ContextOverflowError) Unwrap() error {

--- a/pkg/oci/package.go
+++ b/pkg/oci/package.go
@@ -57,7 +57,7 @@ func PackageFileAsOCIToStore(ctx context.Context, agentSource config.Source, art
 		"io.docker.cagent.version":             version.Version,
 		"io.docker.agent.version":              version.Version,
 		"org.opencontainers.image.created":     time.Now().Format(time.RFC3339),
-		"org.opencontainers.image.description": fmt.Sprintf("OCI artifact containing %s", filepath.Base(agentSource.Name())),
+		"org.opencontainers.image.description": "OCI artifact containing " + filepath.Base(agentSource.Name()),
 	}
 	if author := cfg.Metadata.Author; author != "" {
 		annotations["org.opencontainers.image.authors"] = author

--- a/pkg/path/path.go
+++ b/pkg/path/path.go
@@ -1,6 +1,7 @@
 package path
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -8,25 +9,25 @@ import (
 
 func ValidatePathInDirectory(path, allowedDir string) (string, error) {
 	if path == "" {
-		return "", fmt.Errorf("empty path")
+		return "", errors.New("empty path")
 	}
 
 	cleanPath := filepath.Clean(path)
 
 	if cleanPath == "" || cleanPath == "." {
-		return "", fmt.Errorf("empty or invalid path")
+		return "", errors.New("empty or invalid path")
 	}
 
 	if filepath.IsAbs(cleanPath) && allowedDir == "" {
 		if strings.Contains(path, "..") {
-			return "", fmt.Errorf("path contains directory traversal sequences")
+			return "", errors.New("path contains directory traversal sequences")
 		}
 		return cleanPath, nil
 	}
 
 	if allowedDir == "" {
 		if strings.HasPrefix(cleanPath, "..") {
-			return "", fmt.Errorf("path contains directory traversal sequences")
+			return "", errors.New("path contains directory traversal sequences")
 		}
 		return cleanPath, nil
 	}

--- a/pkg/permissions/permissions.go
+++ b/pkg/permissions/permissions.go
@@ -5,6 +5,7 @@ package permissions
 import (
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/docker/docker-agent/pkg/config/latest"
@@ -203,11 +204,11 @@ func argToString(v any) string {
 	case string:
 		return val
 	case bool:
-		return fmt.Sprintf("%t", val)
+		return strconv.FormatBool(val)
 	case float64:
 		// JSON numbers are float64 - format without trailing zeros
 		if val == float64(int64(val)) {
-			return fmt.Sprintf("%d", int64(val))
+			return strconv.FormatInt(int64(val), 10)
 		}
 		return fmt.Sprintf("%g", val)
 	case int, int64:

--- a/pkg/rag/builder.go
+++ b/pkg/rag/builder.go
@@ -2,6 +2,7 @@ package rag
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -144,7 +145,7 @@ func buildRerankingConfig(
 
 	if rerankCfg.Model == "" {
 		slog.Error("Reranking model name is empty")
-		return nil, fmt.Errorf("reranking model is required")
+		return nil, errors.New("reranking model is required")
 	}
 
 	slog.Debug("Resolving reranking model",

--- a/pkg/rag/fusion/fusion.go
+++ b/pkg/rag/fusion/fusion.go
@@ -2,6 +2,7 @@ package fusion
 
 import (
 	"cmp"
+	"errors"
 	"fmt"
 
 	"github.com/docker/docker-agent/pkg/rag/database"
@@ -29,7 +30,7 @@ func New(config Config) (Fusion, error) {
 
 	case "weighted":
 		if len(config.Weights) == 0 {
-			return nil, fmt.Errorf("weighted fusion requires strategy weights")
+			return nil, errors.New("weighted fusion requires strategy weights")
 		}
 		return NewWeightedFusion(config.Weights), nil
 

--- a/pkg/rag/fusion/max.go
+++ b/pkg/rag/fusion/max.go
@@ -2,9 +2,9 @@ package fusion
 
 import (
 	"cmp"
-	"fmt"
 	"log/slog"
 	"slices"
+	"strconv"
 
 	"github.com/docker/docker-agent/pkg/rag/database"
 )
@@ -40,7 +40,7 @@ func (mf *MaxScoreFusion) Fuse(strategyResults map[string][]database.SearchResul
 
 	for strategyName, results := range strategyResults {
 		for rank, result := range results {
-			docID := result.Document.SourcePath + "_" + fmt.Sprint(result.Document.ChunkIndex)
+			docID := result.Document.SourcePath + "_" + strconv.Itoa(result.Document.ChunkIndex)
 
 			if _, exists := docScores[docID]; !exists {
 				docScores[docID] = &fusedDocument{

--- a/pkg/rag/fusion/rrf.go
+++ b/pkg/rag/fusion/rrf.go
@@ -2,9 +2,9 @@ package fusion
 
 import (
 	"cmp"
-	"fmt"
 	"log/slog"
 	"slices"
+	"strconv"
 
 	"github.com/docker/docker-agent/pkg/rag/database"
 )
@@ -70,7 +70,7 @@ func (rrf *ReciprocalRankFusion) Fuse(strategyResults map[string][]database.Sear
 
 	for strategyName, results := range strategyResults {
 		for rank, result := range results {
-			docID := result.Document.SourcePath + "_" + fmt.Sprint(result.Document.ChunkIndex)
+			docID := result.Document.SourcePath + "_" + strconv.Itoa(result.Document.ChunkIndex)
 
 			if _, exists := docScores[docID]; !exists {
 				docScores[docID] = &fusedDocument{

--- a/pkg/rag/fusion/weighted.go
+++ b/pkg/rag/fusion/weighted.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
+	"strconv"
 
 	"github.com/docker/docker-agent/pkg/rag/database"
 )
@@ -55,7 +56,7 @@ func (wf *WeightedFusion) Fuse(strategyResults map[string][]database.SearchResul
 		weight := wf.weights[strategyName]
 
 		for rank, result := range results {
-			docID := result.Document.SourcePath + "_" + fmt.Sprint(result.Document.ChunkIndex)
+			docID := result.Document.SourcePath + "_" + strconv.Itoa(result.Document.ChunkIndex)
 
 			if _, exists := docScores[docID]; !exists {
 				docScores[docID] = &fusedDocument{

--- a/pkg/rag/manager.go
+++ b/pkg/rag/manager.go
@@ -2,6 +2,7 @@ package rag
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -74,7 +75,7 @@ type FusionConfig struct {
 // The strategyEvents channel should be shared across all strategies for this manager.
 func New(_ context.Context, name string, config Config, strategyEvents <-chan types.Event) (*Manager, error) {
 	if len(config.StrategyConfigs) == 0 {
-		return nil, fmt.Errorf("at least one strategy required")
+		return nil, errors.New("at least one strategy required")
 	}
 
 	// Build strategies map from configs
@@ -106,7 +107,7 @@ func New(_ context.Context, name string, config Config, strategyEvents <-chan ty
 
 		// Ensure fusion was actually created
 		if fusionStrategy == nil {
-			return nil, fmt.Errorf("fusion strategy is nil after creation (this is a bug)")
+			return nil, errors.New("fusion strategy is nil after creation (this is a bug)")
 		}
 	}
 
@@ -355,7 +356,7 @@ func (m *Manager) Query(ctx context.Context, query string) ([]database.SearchRes
 
 	// Safety check: fusion should never be nil with multiple strategies
 	if m.fusion == nil {
-		return nil, fmt.Errorf("fusion strategy is nil but multiple strategies are configured (this is a bug)")
+		return nil, errors.New("fusion strategy is nil but multiple strategies are configured (this is a bug)")
 	}
 
 	fusedResults, err := m.fusion.Fuse(strategyResults)

--- a/pkg/rag/prompts/rerank.go
+++ b/pkg/rag/prompts/rerank.go
@@ -24,7 +24,7 @@ func BuildRerankDocumentsPrompt(query string, documents []types.Document) string
 			var parts []string
 
 			if doc.SourcePath != "" {
-				parts = append(parts, fmt.Sprintf("source: %s", doc.SourcePath))
+				parts = append(parts, "source: "+doc.SourcePath)
 			}
 
 			// Add relevant metadata

--- a/pkg/rag/rerank/rerank.go
+++ b/pkg/rag/rerank/rerank.go
@@ -3,6 +3,7 @@ package rerank
 import (
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -39,7 +40,7 @@ type LLMReranker struct {
 // NewLLMReranker creates a new LLM-based reranker
 func NewLLMReranker(config Config) (*LLMReranker, error) {
 	if config.Model == nil {
-		return nil, fmt.Errorf("reranking model is required")
+		return nil, errors.New("reranking model is required")
 	}
 
 	slog.Debug("[Reranker] Creating LLM-based reranker",

--- a/pkg/rag/strategy/bm25.go
+++ b/pkg/rag/strategy/bm25.go
@@ -3,6 +3,7 @@ package strategy
 import (
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math"
@@ -243,7 +244,7 @@ func (s *BM25Strategy) Query(ctx context.Context, query string, numResults int, 
 	// Tokenize query
 	queryTerms := s.tokenize(query)
 	if len(queryTerms) == 0 {
-		return nil, fmt.Errorf("query contains no valid terms")
+		return nil, errors.New("query contains no valid terms")
 	}
 
 	// For BM25, we need to retrieve all documents and score them

--- a/pkg/rag/strategy/bm25_database.go
+++ b/pkg/rag/strategy/bm25_database.go
@@ -184,7 +184,7 @@ func (d *bm25DB) SetFileMetadata(ctx context.Context, metadata database.FileMeta
 
 func (d *bm25DB) GetAllFileMetadata(ctx context.Context) ([]database.FileMetadata, error) {
 	rows, err := d.db.QueryContext(ctx,
-		fmt.Sprintf("SELECT source_path, file_hash, last_indexed, chunk_count FROM %s", d.metadataTable))
+		"SELECT source_path, file_hash, last_indexed, chunk_count FROM "+d.metadataTable)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query file metadata: %w", err)
 	}

--- a/pkg/rag/strategy/chunked_embeddings_database.go
+++ b/pkg/rag/strategy/chunked_embeddings_database.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -84,7 +85,7 @@ func (d *chunkedVectorDB) createSchema() error {
 // For chunked-embeddings, the embeddingInput parameter is ignored.
 func (d *chunkedVectorDB) AddDocumentWithEmbedding(ctx context.Context, doc database.Document, embedding []float64, _ string) error {
 	if len(embedding) == 0 {
-		return fmt.Errorf("embedding is required for vector database")
+		return errors.New("embedding is required for vector database")
 	}
 	if len(embedding) != d.vectorDimensions {
 		return fmt.Errorf("embedding dimension mismatch: got %d, expected %d", len(embedding), d.vectorDimensions)

--- a/pkg/rag/strategy/embedding.go
+++ b/pkg/rag/strategy/embedding.go
@@ -2,6 +2,7 @@ package strategy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -90,7 +91,7 @@ func createAutoEmbeddingModel(ctx context.Context, buildCtx BuildContext) (provi
 	}
 
 	if lastErr == nil {
-		return nil, fmt.Errorf("failed to create auto embedding model: no candidates configured")
+		return nil, errors.New("failed to create auto embedding model: no candidates configured")
 	}
 
 	return nil, fmt.Errorf("failed to create auto embedding model: %w", lastErr)

--- a/pkg/rag/strategy/semantic_embeddings.go
+++ b/pkg/rag/strategy/semantic_embeddings.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/docker/docker-agent/pkg/chat"
@@ -251,7 +252,7 @@ func (b *llmSemanticEmbeddingBuilder) BuildEmbeddingInput(ctx context.Context, s
 	t := b.expander.Expand(ctx, b.prompt, map[string]string{
 		"path":        sourcePath,
 		"basename":    filepath.Base(sourcePath),
-		"chunk_index": fmt.Sprintf("%d", ch.Index),
+		"chunk_index": strconv.Itoa(ch.Index),
 		"content":     ch.Content,
 		"ast_context": astContext,
 	})

--- a/pkg/rag/strategy/semantic_embeddings_database.go
+++ b/pkg/rag/strategy/semantic_embeddings_database.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -92,7 +93,7 @@ func (d *semanticVectorDB) createSchema() error {
 // For semantic-embeddings, the embeddingInput contains the LLM-generated summary.
 func (d *semanticVectorDB) AddDocumentWithEmbedding(ctx context.Context, doc database.Document, embedding []float64, embeddingInput string) error {
 	if len(embedding) == 0 {
-		return fmt.Errorf("embedding is required for vector database")
+		return errors.New("embedding is required for vector database")
 	}
 	if len(embedding) != d.vectorDimensions {
 		return fmt.Errorf("embedding dimension mismatch: got %d, expected %d", len(embedding), d.vectorDimensions)

--- a/pkg/rag/strategy/vector_store.go
+++ b/pkg/rag/strategy/vector_store.go
@@ -814,7 +814,7 @@ func (s *VectorStore) watchLoop(ctx context.Context, docPaths []string) {
 			for i, file := range filesToReindex {
 				s.emitEvent(types.Event{
 					Type:    "indexing_progress",
-					Message: fmt.Sprintf("Re-indexing: %s", filepath.Base(file)),
+					Message: "Re-indexing: " + filepath.Base(file),
 					Progress: &types.Progress{
 						Current: i + 1,
 						Total:   len(filesToReindex),
@@ -825,7 +825,7 @@ func (s *VectorStore) watchLoop(ctx context.Context, docPaths []string) {
 					slog.Error("Failed to re-index file", "path", file, "error", err)
 					s.emitEvent(types.Event{
 						Type:    "error",
-						Message: fmt.Sprintf("Failed to re-index: %s", filepath.Base(file)),
+						Message: "Failed to re-index: " + filepath.Base(file),
 						Error:   err,
 					})
 				}

--- a/pkg/runtime/model_picker.go
+++ b/pkg/runtime/model_picker.go
@@ -81,5 +81,5 @@ func (r *LocalRuntime) setModelAndEmitInfo(ctx context.Context, modelRef string,
 		return tools.ResultSuccess("Model reverted to the agent's default model"), nil
 	}
 	slog.Info("Model changed via model_picker tool", "agent", currentName, "model", modelRef)
-	return tools.ResultSuccess(fmt.Sprintf("Model changed to %s", modelRef)), nil
+	return tools.ResultSuccess("Model changed to " + modelRef), nil
 }

--- a/pkg/runtime/model_switcher.go
+++ b/pkg/runtime/model_switcher.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -67,7 +68,7 @@ type ModelSwitcherConfig struct {
 // SetAgentModel implements ModelSwitcher for LocalRuntime.
 func (r *LocalRuntime) SetAgentModel(ctx context.Context, agentName, modelRef string) error {
 	if r.modelSwitcherCfg == nil {
-		return fmt.Errorf("model switching not configured for this runtime")
+		return errors.New("model switching not configured for this runtime")
 	}
 
 	a, err := r.team.Agent(agentName)
@@ -132,7 +133,7 @@ func (r *LocalRuntime) SetAgentModel(ctx context.Context, agentName, modelRef st
 // "provider/model" spec (e.g. "openai/gpt-4o-mini").
 func (r *LocalRuntime) resolveModelRef(ctx context.Context, modelRef string) (provider.Provider, error) {
 	if r.modelSwitcherCfg == nil {
-		return nil, fmt.Errorf("model switching not configured for this runtime")
+		return nil, errors.New("model switching not configured for this runtime")
 	}
 
 	// Try named model from config first.
@@ -225,7 +226,7 @@ func (r *LocalRuntime) createProvidersFromInlineAlloy(ctx context.Context, model
 	}
 
 	if len(providers) == 0 {
-		return nil, fmt.Errorf("inline alloy spec has no valid models")
+		return nil, errors.New("inline alloy spec has no valid models")
 	}
 
 	return providers, nil
@@ -270,7 +271,7 @@ func (r *LocalRuntime) createProvidersFromAlloyConfig(ctx context.Context, alloy
 	}
 
 	if len(providers) == 0 {
-		return nil, fmt.Errorf("alloy model config has no valid models")
+		return nil, errors.New("alloy model config has no valid models")
 	}
 
 	return providers, nil

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -54,7 +55,7 @@ func WithRemoteAgentFilename(filename string) RemoteRuntimeOption {
 // It accepts any client that implements the RemoteClient interface.
 func NewRemoteRuntime(client RemoteClient, opts ...RemoteRuntimeOption) (*RemoteRuntime, error) {
 	if client == nil {
-		return nil, fmt.Errorf("client cannot be nil")
+		return nil, errors.New("client cannot be nil")
 	}
 
 	r := &RemoteRuntime{
@@ -271,7 +272,7 @@ func (r *RemoteRuntime) handleOAuthElicitation(ctx context.Context, req *Elicita
 
 	serverURL, ok := req.Meta["cagent/server_url"].(string)
 	if !ok {
-		err := fmt.Errorf("server_url missing from elicitation metadata")
+		err := errors.New("server_url missing from elicitation metadata")
 		slog.Error("Failed to extract server_url", "error", err)
 		_ = r.client.ResumeElicitation(ctx, r.sessionID, "decline", nil)
 		return err
@@ -279,7 +280,7 @@ func (r *RemoteRuntime) handleOAuthElicitation(ctx context.Context, req *Elicita
 
 	authServerMetadata, ok := req.Meta["auth_server_metadata"].(map[string]any)
 	if !ok {
-		err := fmt.Errorf("auth_server_metadata missing from elicitation metadata")
+		err := errors.New("auth_server_metadata missing from elicitation metadata")
 		slog.Error("Failed to extract auth_server_metadata", "error", err)
 		_ = r.client.ResumeElicitation(ctx, r.sessionID, "decline", nil)
 		return err
@@ -338,7 +339,7 @@ func (r *RemoteRuntime) handleOAuthElicitation(ctx context.Context, req *Elicita
 		}
 		slog.Debug("Client registered successfully", "client_id", clientID)
 	} else {
-		err := fmt.Errorf("authorization server does not support dynamic client registration")
+		err := errors.New("authorization server does not support dynamic client registration")
 		slog.Error("Client registration not supported", "error", err)
 		_ = r.client.ResumeElicitation(ctx, r.sessionID, "decline", nil)
 		return err
@@ -443,7 +444,7 @@ func (r *RemoteRuntime) CurrentAgentSkillsToolset() *builtin.SkillsToolset {
 func (r *RemoteRuntime) UpdateSessionTitle(ctx context.Context, sess *session.Session, title string) error {
 	sess.Title = title
 	if r.sessionID == "" {
-		return fmt.Errorf("cannot update session title: no session ID available")
+		return errors.New("cannot update session title: no session ID available")
 	}
 	return r.client.UpdateSessionTitle(ctx, r.sessionID, title)
 }
@@ -455,7 +456,7 @@ func (r *RemoteRuntime) CurrentMCPPrompts(context.Context) map[string]mcp.Prompt
 
 // ExecuteMCPPrompt is not supported on remote runtimes.
 func (r *RemoteRuntime) ExecuteMCPPrompt(context.Context, string, map[string]string) (string, error) {
-	return "", fmt.Errorf("MCP prompts are not supported by remote runtimes")
+	return "", errors.New("MCP prompts are not supported by remote runtimes")
 }
 
 // TitleGenerator is not supported on remote runtimes (titles are generated server-side).

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -588,7 +588,7 @@ func (r *LocalRuntime) CurrentAgentSkillsToolset() *builtin.SkillsToolset {
 func (r *LocalRuntime) ExecuteMCPPrompt(ctx context.Context, promptName string, arguments map[string]string) (string, error) {
 	currentAgent := r.CurrentAgent()
 	if currentAgent == nil {
-		return "", fmt.Errorf("no current agent available")
+		return "", errors.New("no current agent available")
 	}
 
 	for _, toolset := range currentAgent.ToolSets() {
@@ -1496,7 +1496,7 @@ func (r *LocalRuntime) ResumeElicitation(ctx context.Context, action tools.Elici
 		return nil
 	default:
 		slog.Debug("Elicitation channel not ready")
-		return fmt.Errorf("no elicitation request in progress")
+		return errors.New("no elicitation request in progress")
 	}
 }
 
@@ -2126,7 +2126,7 @@ func (r *LocalRuntime) elicitationHandler(ctx context.Context, req *mcp.ElicitPa
 	eventsChannel := r.elicitationEventsChannel
 	if eventsChannel == nil {
 		r.elicitationEventsChannelMux.RUnlock()
-		return tools.ElicitationResult{}, fmt.Errorf("no events channel available for elicitation")
+		return tools.ElicitationResult{}, errors.New("no events channel available for elicitation")
 	}
 
 	r.executeOnUserInputHooks(ctx, "", "elicitation")

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -3,7 +3,6 @@ package runtime
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"reflect"
 	"sync"
@@ -164,7 +163,7 @@ type mockProviderWithError struct {
 func (m *mockProviderWithError) ID() string { return m.id }
 
 func (m *mockProviderWithError) CreateChatCompletionStream(context.Context, []chat.Message, []tools.Tool) (chat.MessageStream, error) {
-	return nil, fmt.Errorf("simulated error creating chat completion stream")
+	return nil, errors.New("simulated error creating chat completion stream")
 }
 
 func (m *mockProviderWithError) BaseConfig() base.Config { return base.Config{} }

--- a/pkg/sandbox/sandbox.go
+++ b/pkg/sandbox/sandbox.go
@@ -5,6 +5,7 @@ package sandbox
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -26,10 +27,9 @@ func CheckAvailable(ctx context.Context) error {
 	}
 
 	if err := exec.CommandContext(ctx, "docker", "sandbox", "version").Run(); err != nil {
-		return fmt.Errorf(
-			"--sandbox requires Docker Desktop with sandbox support\n\n" +
-				"Make sure Docker Desktop is running and up to date.\n" +
-				"For more information, see https://docs.docker.com/ai/sandboxes/")
+		return errors.New("--sandbox requires Docker Desktop with sandbox support\n\n" +
+			"Make sure Docker Desktop is running and up to date.\n" +
+			"For more information, see https://docs.docker.com/ai/sandboxes/")
 	}
 
 	return nil
@@ -126,7 +126,7 @@ func Ensure(ctx context.Context, wd, extra, template, configDir string) (string,
 	// Read back the sandbox name that was just created.
 	created := ForWorkspace(ctx, wd)
 	if created == nil {
-		return "", fmt.Errorf("sandbox was created but could not be found")
+		return "", errors.New("sandbox was created but could not be found")
 	}
 
 	return created.Name, nil

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -89,7 +89,7 @@ func (sm *SessionManager) CreateSession(ctx context.Context, sessionTemplate *se
 			return nil, err
 		}
 		if !info.IsDir() {
-			return nil, fmt.Errorf("working directory must be a directory")
+			return nil, errors.New("working directory must be a directory")
 		}
 		opts = append(opts, session.WithWorkingDir(absWd))
 	}

--- a/pkg/session/branch.go
+++ b/pkg/session/branch.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -14,7 +15,7 @@ import (
 // Messages up to (but not including) branchAtPosition are deep-cloned into the new session.
 func BranchSession(parent *Session, branchAtPosition int) (*Session, error) {
 	if parent == nil {
-		return nil, fmt.Errorf("parent session is nil")
+		return nil, errors.New("parent session is nil")
 	}
 	if branchAtPosition < 0 || branchAtPosition >= len(parent.Messages) {
 		return nil, fmt.Errorf("branch position %d out of range", branchAtPosition)
@@ -55,7 +56,7 @@ func cloneSessionItem(item Item) (Item, error) {
 	case item.Summary != "":
 		return Item{Summary: item.Summary, Cost: item.Cost}, nil
 	default:
-		return Item{}, fmt.Errorf("cannot clone empty session item")
+		return Item{}, errors.New("cannot clone empty session item")
 	}
 }
 
@@ -124,10 +125,10 @@ func generateBranchTitle(parentTitle string) string {
 	const branchedSuffix = "(branched)"
 	if strings.HasSuffix(parentTitle, branchedSuffix) {
 		baseTitle := strings.TrimRight(parentTitle[:len(parentTitle)-len(branchedSuffix)], " \t")
-		return fmt.Sprintf("%s (branch 2)", baseTitle)
+		return baseTitle + " (branch 2)"
 	}
 
-	return fmt.Sprintf("%s (branched)", parentTitle)
+	return parentTitle + " (branched)"
 }
 
 func clonePermissionsConfig(src *PermissionsConfig) *PermissionsConfig {

--- a/pkg/skills/cache.go
+++ b/pkg/skills/cache.go
@@ -135,7 +135,7 @@ func parseCacheExpiry(cacheControl string) time.Time {
 		return time.Now().Add(defaultCacheTTL)
 	}
 
-	for _, directive := range strings.Split(cacheControl, ",") {
+	for directive := range strings.SplitSeq(cacheControl, ",") {
 		directive = strings.TrimSpace(directive)
 
 		if strings.EqualFold(directive, "no-store") || strings.EqualFold(directive, "no-cache") {

--- a/pkg/sqliteutil/sqlite.go
+++ b/pkg/sqliteutil/sqlite.go
@@ -23,7 +23,7 @@ func OpenDB(path string) (*sql.DB, error) {
 	// _pragma=busy_timeout(5000): Wait up to 5 seconds if database is locked
 	// _pragma=journal_mode(WAL): Enable Write-Ahead Logging for better concurrent access
 	// _pragma=foreign_keys(1): Enable foreign key constraints (critical for ON DELETE CASCADE)
-	dsn := fmt.Sprintf("%s?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=foreign_keys(1)", path)
+	dsn := path + "?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=foreign_keys(1)"
 
 	db, err := sql.Open("sqlite", dsn)
 	if err != nil {

--- a/pkg/teamloader/registry.go
+++ b/pkg/teamloader/registry.go
@@ -2,6 +2,7 @@ package teamloader
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -167,7 +168,7 @@ func createShellTool(ctx context.Context, toolset latest.Toolset, _ string, runC
 
 func createScriptTool(ctx context.Context, toolset latest.Toolset, _ string, runConfig *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
 	if len(toolset.Shell) == 0 {
-		return nil, fmt.Errorf("shell is required for script toolset")
+		return nil, errors.New("shell is required for script toolset")
 	}
 
 	env, err := environment.ExpandAll(ctx, environment.ToValues(toolset.Env), runConfig.EnvProvider())
@@ -214,7 +215,7 @@ func createFilesystemTool(_ context.Context, toolset latest.Toolset, _ string, r
 
 func createAPITool(ctx context.Context, toolset latest.Toolset, _ string, runConfig *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
 	if toolset.APIConfig.Endpoint == "" {
-		return nil, fmt.Errorf("api tool requires an endpoint in api_config")
+		return nil, errors.New("api tool requires an endpoint in api_config")
 	}
 
 	expander := js.NewJsExpander(runConfig.EnvProvider())
@@ -291,7 +292,7 @@ func createMCPTool(ctx context.Context, toolset latest.Toolset, _ string, runCon
 		return mcp.NewRemoteToolset(toolset.Name, url, toolset.Remote.TransportType, headers), nil
 
 	default:
-		return nil, fmt.Errorf("mcp toolset requires either ref, command, or remote configuration")
+		return nil, errors.New("mcp toolset requires either ref, command, or remote configuration")
 	}
 }
 
@@ -342,7 +343,7 @@ func createOpenAPITool(ctx context.Context, toolset latest.Toolset, _ string, ru
 
 func createModelPickerTool(_ context.Context, toolset latest.Toolset, _ string, _ *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
 	if len(toolset.Models) == 0 {
-		return nil, fmt.Errorf("model_picker toolset requires at least one model")
+		return nil, errors.New("model_picker toolset requires at least one model")
 	}
 	return builtin.NewModelPickerTool(toolset.Models), nil
 }

--- a/pkg/telemetry/http.go
+++ b/pkg/telemetry/http.go
@@ -25,7 +25,7 @@ func (tc *Client) createEvent(eventName string, properties map[string]any) Event
 
 	// Allow callers to attach custom metadata to telemetry events
 	if tags := os.Getenv("TELEMETRY_TAGS"); tags != "" {
-		for _, pair := range strings.Split(tags, ",") {
+		for pair := range strings.SplitSeq(tags, ",") {
 			if k, v, ok := strings.Cut(pair, "="); ok && strings.TrimSpace(k) != "" {
 				allProperties[strings.TrimSpace(k)] = strings.TrimSpace(v)
 			}
@@ -130,7 +130,7 @@ func (tc *Client) performHTTPRequest(event *EventPayload, version string) error 
 
 	// Set headers
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", fmt.Sprintf("cagent/%s", version))
+	req.Header.Set("User-Agent", "cagent/"+version)
 	if tc.apiKey != "" && tc.header != "" {
 		req.Header.Set(tc.header, tc.apiKey)
 	}

--- a/pkg/toolinstall/installer.go
+++ b/pkg/toolinstall/installer.go
@@ -3,10 +3,12 @@ package toolinstall
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 )
 
@@ -172,9 +174,7 @@ func resolveForPlatform(pkg *Package, version string) platformConfig {
 			if replacements == nil {
 				replacements = make(map[string]string)
 			}
-			for k, v := range o.Replacements {
-				replacements[k] = v
-			}
+			maps.Copy(replacements, o.Replacements)
 		}
 	}
 
@@ -218,7 +218,7 @@ func ensureSymlink(name, target string) error {
 
 	// Create a temporary symlink in the same directory, then atomically
 	// rename it over the target. This avoids the Remove+Symlink TOCTOU race.
-	tmpLink := link + ".tmp." + fmt.Sprintf("%d", os.Getpid())
+	tmpLink := link + ".tmp." + strconv.Itoa(os.Getpid())
 	_ = os.Remove(tmpLink) // clean up any stale temp from a previous crash
 
 	if err := os.Symlink(target, tmpLink); err != nil {

--- a/pkg/toolinstall/resolver.go
+++ b/pkg/toolinstall/resolver.go
@@ -155,12 +155,12 @@ func resolveVersion(ctx context.Context, registry *Registry, pkg *Package) (stri
 func extractVersionPrefix(filter string) string {
 	filter = strings.TrimSpace(filter)
 	const marker = "startsWith"
-	idx := strings.Index(filter, marker)
-	if idx < 0 {
+	_, after, ok := strings.Cut(filter, marker)
+	if !ok {
 		return ""
 	}
 
-	rest := strings.TrimSpace(filter[idx+len(marker):])
+	rest := strings.TrimSpace(after)
 	if len(rest) >= 2 && (rest[0] == '"' || rest[0] == '\'') {
 		quote := rest[0]
 		end := strings.IndexByte(rest[1:], quote)

--- a/pkg/tools/a2a/a2a.go
+++ b/pkg/tools/a2a/a2a.go
@@ -5,6 +5,7 @@ import (
 	"cmp"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -72,7 +73,7 @@ func (t *Toolset) Tools(_ context.Context) ([]tools.Tool, error) {
 	t.mu.RUnlock()
 
 	if card == nil {
-		return nil, fmt.Errorf("A2A toolset not started")
+		return nil, errors.New("A2A toolset not started")
 	}
 
 	// If skills are defined, create a tool for each skill; otherwise create one tool for the agent
@@ -162,7 +163,7 @@ func (t *Toolset) createHandler() tools.ToolHandler {
 		t.mu.RUnlock()
 
 		if client == nil {
-			return nil, fmt.Errorf("A2A client not initialized")
+			return nil, errors.New("A2A client not initialized")
 		}
 
 		params := &a2a.MessageSendParams{

--- a/pkg/tools/builtin/agent/agent.go
+++ b/pkg/tools/builtin/agent/agent.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -141,7 +142,7 @@ func NewHandler(runner Runner) *Handler {
 }
 
 func newTaskID() string {
-	return fmt.Sprintf("agent_task_%s", uuid.New().String())
+	return "agent_task_" + uuid.New().String()
 }
 
 func (h *Handler) runningTaskCount() int {
@@ -188,13 +189,7 @@ func (h *Handler) HandleRun(ctx context.Context, sess *session.Session, toolCall
 	}
 
 	subAgentNames := h.runner.CurrentAgentSubAgentNames()
-	valid := false
-	for _, name := range subAgentNames {
-		if name == params.Agent {
-			valid = true
-			break
-		}
-	}
+	valid := slices.Contains(subAgentNames, params.Agent)
 	if !valid {
 		if len(subAgentNames) > 0 {
 			return tools.ResultError(fmt.Sprintf("agent %q is not in the sub-agents list. Available: %s", params.Agent, strings.Join(subAgentNames, ", "))), nil
@@ -229,9 +224,7 @@ func (h *Handler) HandleRun(ctx context.Context, sess *session.Session, toolCall
 	t.storeStatus(taskRunning)
 	h.tasks.Store(taskID, t)
 
-	h.wg.Add(1)
-	go func() {
-		defer h.wg.Done()
+	h.wg.Go(func() {
 		defer cancel()
 
 		slog.Debug("Starting background agent task", "task_id", taskID, "agent", params.Agent)
@@ -270,7 +263,7 @@ func (h *Handler) HandleRun(ctx context.Context, sess *session.Session, toolCall
 		if t.casStatus(taskRunning, taskCompleted) {
 			slog.Debug("Background agent task completed", "task_id", taskID, "agent", params.Agent)
 		}
-	}()
+	})
 
 	return tools.ResultSuccess(fmt.Sprintf("Background agent task started with ID: %s\nAgent: %s\nTask: %s",
 		taskID, params.Agent, params.Task)), nil
@@ -310,7 +303,7 @@ func (h *Handler) HandleView(_ context.Context, _ *session.Session, toolCall too
 
 	t, exists := h.tasks.Load(params.TaskID)
 	if !exists {
-		return tools.ResultError(fmt.Sprintf("task not found: %s", params.TaskID)), nil
+		return tools.ResultError("task not found: " + params.TaskID), nil
 	}
 
 	status := t.loadStatus()
@@ -366,7 +359,7 @@ func (h *Handler) HandleStop(_ context.Context, _ *session.Session, toolCall too
 
 	t, exists := h.tasks.Load(params.TaskID)
 	if !exists {
-		return tools.ResultError(fmt.Sprintf("task not found: %s", params.TaskID)), nil
+		return tools.ResultError("task not found: " + params.TaskID), nil
 	}
 
 	if !t.casStatus(taskRunning, taskStopped) {

--- a/pkg/tools/builtin/agent/agent_test.go
+++ b/pkg/tools/builtin/agent/agent_test.go
@@ -320,13 +320,11 @@ func TestStopAll_WaitsForGoroutines(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	tk.cancel = cancel
 
-	h.wg.Add(1)
-	go func() {
-		defer h.wg.Done()
+	h.wg.Go(func() {
 		<-ctx.Done()
 		time.Sleep(10 * time.Millisecond) // simulate teardown work
 		goroutineExited.Store(true)
-	}()
+	})
 
 	h.StopAll()
 	assert.True(t, goroutineExited.Load(), "StopAll should wait for goroutine to exit")
@@ -513,11 +511,9 @@ func TestHandler_ConcurrentAccess(t *testing.T) {
 	var wg sync.WaitGroup
 
 	for range 5 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			_, _ = h.HandleList(t.Context(), nil, tools.ToolCall{})
-		}()
+		})
 	}
 
 	for i := range 5 {

--- a/pkg/tools/builtin/api.go
+++ b/pkg/tools/builtin/api.go
@@ -5,6 +5,7 @@ import (
 	"cmp"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -110,11 +111,11 @@ func (t *APITool) Tools(context.Context) ([]tools.Tool, error) {
 	}
 
 	if parsedURL.Scheme == "" || parsedURL.Host == "" {
-		return nil, fmt.Errorf("invalid URL: missing scheme or host")
+		return nil, errors.New("invalid URL: missing scheme or host")
 	}
 
 	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
-		return nil, fmt.Errorf("only HTTP and HTTPS URLs are supported")
+		return nil, errors.New("only HTTP and HTTPS URLs are supported")
 	}
 
 	outputSchema := tools.MustSchemaFor[string]()

--- a/pkg/tools/builtin/fetch.go
+++ b/pkg/tools/builtin/fetch.go
@@ -3,6 +3,7 @@ package builtin
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -44,7 +45,7 @@ type FetchToolArgs struct {
 
 func (h *fetchHandler) CallTool(ctx context.Context, params FetchToolArgs) (*tools.ToolCallResult, error) {
 	if len(params.URLs) == 0 {
-		return nil, fmt.Errorf("at least one URL is required")
+		return nil, errors.New("at least one URL is required")
 	}
 
 	// Set timeout if specified

--- a/pkg/tools/builtin/filesystem.go
+++ b/pkg/tools/builtin/filesystem.go
@@ -473,10 +473,10 @@ func (t *FilesystemTool) handleEditFile(ctx context.Context, args EditFileArgs) 
 	}
 
 	if len(changes) == 1 {
-		return tools.ResultSuccess(fmt.Sprintf("File edited successfully. %s", strings.TrimPrefix(changes[0], "Edit 1: "))), nil
+		return tools.ResultSuccess("File edited successfully. " + strings.TrimPrefix(changes[0], "Edit 1: ")), nil
 	}
 
-	return tools.ResultSuccess(fmt.Sprintf("File edited successfully. Changes:\n%s", strings.Join(changes, "\n"))), nil
+	return tools.ResultSuccess("File edited successfully. Changes:\n" + strings.Join(changes, "\n")), nil
 }
 
 func (t *FilesystemTool) handleListDirectory(_ context.Context, args ListDirectoryArgs) (*tools.ToolCallResult, error) {
@@ -817,7 +817,7 @@ func (t *FilesystemTool) handleCreateDirectory(_ context.Context, args CreateDir
 		if err := os.MkdirAll(resolvedPath, 0o755); err != nil {
 			return tools.ResultError(fmt.Sprintf("Error creating directory %s: %s", path, err)), nil
 		}
-		results = append(results, fmt.Sprintf("Directory created successfully: %s", path))
+		results = append(results, "Directory created successfully: "+path)
 	}
 
 	return tools.ResultSuccess(strings.Join(results, "\n")), nil
@@ -831,7 +831,7 @@ func (t *FilesystemTool) handleRemoveDirectory(_ context.Context, args RemoveDir
 		if err := rmdir(resolvedPath); err != nil {
 			return tools.ResultError(fmt.Sprintf("Error removing directory %s: %s", path, err)), nil
 		}
-		results = append(results, fmt.Sprintf("Directory removed successfully: %s", path))
+		results = append(results, "Directory removed successfully: "+path)
 	}
 
 	return tools.ResultSuccess(strings.Join(results, "\n")), nil

--- a/pkg/tools/builtin/lsp.go
+++ b/pkg/tools/builtin/lsp.go
@@ -916,7 +916,7 @@ func (h *lspHandler) getDiagnostics(ctx context.Context, args FileArgs) (*tools.
 	h.diagnosticsMu.RUnlock()
 
 	if !ok || len(diags) == 0 {
-		return tools.ResultSuccess(fmt.Sprintf("No diagnostics for %s", args.File)), nil
+		return tools.ResultSuccess("No diagnostics for " + args.File), nil
 	}
 
 	return tools.ResultSuccess(formatDiagnostics(args.File, diags)), nil
@@ -1022,7 +1022,7 @@ func (h *lspHandler) format(ctx context.Context, args FileArgs) (*tools.ToolCall
 	}
 
 	if len(result) == 0 || string(result) == "null" || string(result) == "[]" {
-		return tools.ResultSuccess(fmt.Sprintf("No formatting changes needed for %s", args.File)), nil
+		return tools.ResultSuccess("No formatting changes needed for " + args.File), nil
 	}
 
 	var edits []lspTextEdit
@@ -1031,7 +1031,7 @@ func (h *lspHandler) format(ctx context.Context, args FileArgs) (*tools.ToolCall
 	}
 
 	if len(edits) == 0 {
-		return tools.ResultSuccess(fmt.Sprintf("No formatting changes needed for %s", args.File)), nil
+		return tools.ResultSuccess("No formatting changes needed for " + args.File), nil
 	}
 
 	if err := applyTextEditsToFile(args.File, edits); err != nil {

--- a/pkg/tools/builtin/lsp_multiplexer.go
+++ b/pkg/tools/builtin/lsp_multiplexer.go
@@ -139,7 +139,7 @@ func routeByFile(handlers []lspRouteTarget) tools.ToolHandler {
 				return h.handler(ctx, tc)
 			}
 		}
-		return tools.ResultError(fmt.Sprintf("no LSP server configured for file: %s", args.File)), nil
+		return tools.ResultError("no LSP server configured for file: " + args.File), nil
 	}
 }
 

--- a/pkg/tools/builtin/memory.go
+++ b/pkg/tools/builtin/memory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/docker/docker-agent/pkg/memory/database"
@@ -167,7 +168,7 @@ func (t *MemoryTool) Tools(context.Context) ([]tools.Tool, error) {
 
 func (t *MemoryTool) handleAddMemory(ctx context.Context, args AddMemoryArgs) (*tools.ToolCallResult, error) {
 	memory := database.UserMemory{
-		ID:        fmt.Sprintf("%d", time.Now().UnixNano()),
+		ID:        strconv.FormatInt(time.Now().UnixNano(), 10),
 		CreatedAt: time.Now().Format(time.RFC3339),
 		Memory:    args.Memory,
 		Category:  args.Category,
@@ -177,7 +178,7 @@ func (t *MemoryTool) handleAddMemory(ctx context.Context, args AddMemoryArgs) (*
 		return nil, fmt.Errorf("failed to add memory: %w", err)
 	}
 
-	return tools.ResultSuccess(fmt.Sprintf("Memory added successfully with ID: %s", memory.ID)), nil
+	return tools.ResultSuccess("Memory added successfully with ID: " + memory.ID), nil
 }
 
 func (t *MemoryTool) handleGetMemories(ctx context.Context, _ map[string]any) (*tools.ToolCallResult, error) {

--- a/pkg/tools/builtin/openapi.go
+++ b/pkg/tools/builtin/openapi.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -87,7 +88,7 @@ func (t *OpenAPITool) fetchSpec(ctx context.Context) (*openapi3.T, error) {
 
 	// Check if the spec was truncated.
 	if len(body) >= 10<<20 {
-		return nil, fmt.Errorf("OpenAPI spec exceeds 10MB size limit")
+		return nil, errors.New("OpenAPI spec exceeds 10MB size limit")
 	}
 
 	loader := openapi3.NewLoader()
@@ -436,8 +437,8 @@ func (h *openAPIHandler) classifyParams(params openAPICallArgs) (string, url.Val
 		}
 
 		// Body parameter? (prefixed with "body_")
-		if strings.HasPrefix(key, "body_") {
-			bodyParams[strings.TrimPrefix(key, "body_")] = value
+		if after, ok := strings.CutPrefix(key, "body_"); ok {
+			bodyParams[after] = value
 			continue
 		}
 

--- a/pkg/tools/builtin/rag.go
+++ b/pkg/tools/builtin/rag.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -90,7 +91,7 @@ func (t *RAGTool) Tools(context.Context) ([]tools.Tool, error) {
 		Handler:      tools.NewHandler(t.handleQueryRAG),
 		Annotations: tools.ToolAnnotations{
 			ReadOnlyHint: true,
-			Title:        fmt.Sprintf("Query %s", t.toolName),
+			Title:        "Query " + t.toolName,
 		},
 	}
 
@@ -106,7 +107,7 @@ func (t *RAGTool) Tools(context.Context) ([]tools.Tool, error) {
 
 func (t *RAGTool) handleQueryRAG(ctx context.Context, args QueryRAGArgs) (*tools.ToolCallResult, error) {
 	if args.Query == "" {
-		return nil, fmt.Errorf("query cannot be empty")
+		return nil, errors.New("query cannot be empty")
 	}
 
 	results, err := t.manager.Query(ctx, args.Query)

--- a/pkg/tools/builtin/script_shell.go
+++ b/pkg/tools/builtin/script_shell.go
@@ -107,7 +107,7 @@ func (t *ScriptShellTool) Tools(context.Context) ([]tools.Tool, error) {
 		cfg := toolConfig
 		toolName := name
 
-		description := cmp.Or(cfg.Description, fmt.Sprintf("Execute shell command: %s", cfg.Cmd))
+		description := cmp.Or(cfg.Description, "Execute shell command: "+cfg.Cmd)
 
 		inputSchema, err := tools.SchemaToMap(map[string]any{
 			"type":       "object",

--- a/pkg/tools/builtin/shell.go
+++ b/pkg/tools/builtin/shell.go
@@ -290,7 +290,7 @@ func (h *shellHandler) ListBackgroundJobs(_ context.Context, _ map[string]any) (
 func (h *shellHandler) ViewBackgroundJob(_ context.Context, params ViewBackgroundJobArgs) (*tools.ToolCallResult, error) {
 	job, exists := h.jobs.Load(params.JobID)
 	if !exists {
-		return tools.ResultError(fmt.Sprintf("Job not found: %s", params.JobID)), nil
+		return tools.ResultError("Job not found: " + params.JobID), nil
 	}
 
 	status := job.status.Load()
@@ -324,7 +324,7 @@ func (h *shellHandler) ViewBackgroundJob(_ context.Context, params ViewBackgroun
 func (h *shellHandler) StopBackgroundJob(_ context.Context, params StopBackgroundJobArgs) (*tools.ToolCallResult, error) {
 	job, exists := h.jobs.Load(params.JobID)
 	if !exists {
-		return tools.ResultError(fmt.Sprintf("Job not found: %s", params.JobID)), nil
+		return tools.ResultError("Job not found: " + params.JobID), nil
 	}
 
 	if !job.status.CompareAndSwap(statusRunning, statusStopped) {

--- a/pkg/tools/builtin/tasks.go
+++ b/pkg/tools/builtin/tasks.go
@@ -265,7 +265,7 @@ func (t *TasksTool) createTask(_ context.Context, params CreateTaskArgs) (*tools
 	if params.Priority == "" {
 		priority = PriorityMedium
 	} else if !validPriority(params.Priority) {
-		return tools.ResultError(fmt.Sprintf("invalid priority: %s", params.Priority)), nil
+		return tools.ResultError("invalid priority: " + params.Priority), nil
 	}
 
 	t.mu.Lock()
@@ -280,7 +280,7 @@ func (t *TasksTool) createTask(_ context.Context, params CreateTaskArgs) (*tools
 	}
 	for _, depID := range deps {
 		if _, ok := store.Tasks[depID]; !ok {
-			return tools.ResultError(fmt.Sprintf("dependency task not found: %s", depID)), nil
+			return tools.ResultError("dependency task not found: " + depID), nil
 		}
 	}
 	if hasCycle(store.Tasks, id, deps) {
@@ -313,7 +313,7 @@ func (t *TasksTool) getTask(_ context.Context, params GetTaskArgs) (*tools.ToolC
 	store := t.load()
 	task, ok := store.Tasks[params.ID]
 	if !ok {
-		return tools.ResultError(fmt.Sprintf("task not found: %s", params.ID)), nil
+		return tools.ResultError("task not found: " + params.ID), nil
 	}
 
 	return taskWithEffectiveResult(task, store.Tasks), nil
@@ -326,7 +326,7 @@ func (t *TasksTool) updateTask(_ context.Context, params UpdateTaskArgs) (*tools
 	store := t.load()
 	task, ok := store.Tasks[params.ID]
 	if !ok {
-		return tools.ResultError(fmt.Sprintf("task not found: %s", params.ID)), nil
+		return tools.ResultError("task not found: " + params.ID), nil
 	}
 
 	if params.Title != "" {
@@ -341,20 +341,20 @@ func (t *TasksTool) updateTask(_ context.Context, params UpdateTaskArgs) (*tools
 	}
 	if params.Priority != "" {
 		if !validPriority(params.Priority) {
-			return tools.ResultError(fmt.Sprintf("invalid priority: %s", params.Priority)), nil
+			return tools.ResultError("invalid priority: " + params.Priority), nil
 		}
 		task.Priority = TaskPriority(params.Priority)
 	}
 	if params.Status != "" {
 		if !validStatus(params.Status) {
-			return tools.ResultError(fmt.Sprintf("invalid status: %s", params.Status)), nil
+			return tools.ResultError("invalid status: " + params.Status), nil
 		}
 		task.Status = TaskStatus(params.Status)
 	}
 	if params.Dependencies != nil {
 		for _, depID := range params.Dependencies {
 			if _, exists := store.Tasks[depID]; !exists {
-				return tools.ResultError(fmt.Sprintf("dependency task not found: %s", depID)), nil
+				return tools.ResultError("dependency task not found: " + depID), nil
 			}
 		}
 		if hasCycle(store.Tasks, params.ID, params.Dependencies) {
@@ -379,7 +379,7 @@ func (t *TasksTool) deleteTask(_ context.Context, params DeleteTaskArgs) (*tools
 
 	store := t.load()
 	if _, ok := store.Tasks[params.ID]; !ok {
-		return tools.ResultError(fmt.Sprintf("task not found: %s", params.ID)), nil
+		return tools.ResultError("task not found: " + params.ID), nil
 	}
 
 	for id, task := range store.Tasks {
@@ -483,10 +483,10 @@ func (t *TasksTool) addDependency(_ context.Context, params AddDependencyArgs) (
 	store := t.load()
 	task, ok := store.Tasks[params.TaskID]
 	if !ok {
-		return tools.ResultError(fmt.Sprintf("task not found: %s", params.TaskID)), nil
+		return tools.ResultError("task not found: " + params.TaskID), nil
 	}
 	if _, ok := store.Tasks[params.DependsOnID]; !ok {
-		return tools.ResultError(fmt.Sprintf("dependency task not found: %s", params.DependsOnID)), nil
+		return tools.ResultError("dependency task not found: " + params.DependsOnID), nil
 	}
 	if slices.Contains(task.Dependencies, params.DependsOnID) {
 		return tools.ResultError("dependency already exists"), nil
@@ -515,7 +515,7 @@ func (t *TasksTool) removeDependency(_ context.Context, params RemoveDependencyA
 	store := t.load()
 	task, ok := store.Tasks[params.TaskID]
 	if !ok {
-		return tools.ResultError(fmt.Sprintf("task not found: %s", params.TaskID)), nil
+		return tools.ResultError("task not found: " + params.TaskID), nil
 	}
 
 	filtered := make([]string, 0, len(task.Dependencies))
@@ -554,8 +554,6 @@ func taskWithEffectiveResult(task Task, tasks map[string]Task) *tools.ToolCallRe
 	}
 	return &tools.ToolCallResult{Output: string(out)}
 }
-
-func boolPtr(b bool) *bool { return &b }
 
 func (t *TasksTool) Tools(_ context.Context) ([]tools.Tool, error) {
 	return []tools.Tool{
@@ -598,7 +596,7 @@ func (t *TasksTool) Tools(_ context.Context) ([]tools.Tool, error) {
 			Handler:     tools.NewHandler(t.deleteTask),
 			Annotations: tools.ToolAnnotations{
 				Title:           "Delete Task",
-				DestructiveHint: boolPtr(true),
+				DestructiveHint: new(true),
 			},
 		},
 		{

--- a/pkg/tools/mcp/mcp.go
+++ b/pkg/tools/mcp/mcp.go
@@ -488,13 +488,13 @@ func isInitNotificationSendError(err error) bool {
 }
 
 func processMCPContent(toolResult *mcp.CallToolResult) *tools.ToolCallResult {
-	var text string
+	var text strings.Builder
 	var images, audios []tools.MediaContent
 
 	for _, c := range toolResult.Content {
 		switch c := c.(type) {
 		case *mcp.TextContent:
-			text += c.Text
+			text.WriteString(c.Text)
 		case *mcp.ImageContent:
 			images = append(images, encodeMedia(c.Data, c.MIMEType))
 		case *mcp.AudioContent:
@@ -504,15 +504,15 @@ func processMCPContent(toolResult *mcp.CallToolResult) *tools.ToolCallResult {
 				// Escape ] in name and ) in URI to prevent broken markdown links.
 				name := strings.ReplaceAll(c.Name, "]", "\\]")
 				uri := strings.ReplaceAll(c.URI, ")", "%29")
-				text += fmt.Sprintf("[%s](%s)", name, uri)
+				fmt.Fprintf(&text, "[%s](%s)", name, uri)
 			} else {
-				text += c.URI
+				text.WriteString(c.URI)
 			}
 		}
 	}
 
 	return &tools.ToolCallResult{
-		Output:            cmp.Or(text, "no output"),
+		Output:            cmp.Or(text.String(), "no output"),
 		IsError:           toolResult.IsError,
 		Images:            images,
 		Audios:            audios,

--- a/pkg/tools/mcp/oauth.go
+++ b/pkg/tools/mcp/oauth.go
@@ -181,7 +181,7 @@ func (t *oauthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	reqClone := req.Clone(req.Context())
 
 	if token, err := t.tokenStore.GetToken(t.baseURL); err == nil && !token.IsExpired() {
-		reqClone.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.AccessToken))
+		reqClone.Header.Set("Authorization", "Bearer "+token.AccessToken)
 	}
 
 	resp, err := t.base.RoundTrip(reqClone)
@@ -320,7 +320,7 @@ func (t *oauthTransport) handleManagedOAuthFlow(ctx context.Context, authServer,
 	slog.Debug("Elicitation response received", "result", result)
 
 	if result.Action != tools.ElicitationActionAccept {
-		return fmt.Errorf("user declined OAuth authorization")
+		return errors.New("user declined OAuth authorization")
 	}
 
 	slog.Debug("Requesting authorization code", "url", authURL)
@@ -331,7 +331,7 @@ func (t *oauthTransport) handleManagedOAuthFlow(ctx context.Context, authServer,
 	}
 
 	if receivedState != state {
-		return fmt.Errorf("state mismatch in authorization response")
+		return errors.New("state mismatch in authorization response")
 	}
 
 	slog.Debug("Exchanging authorization code for token")
@@ -398,7 +398,7 @@ func (t *oauthTransport) handleUnmanagedOAuthFlow(ctx context.Context, authServe
 	slog.Debug("Sending OAuth elicitation request to client")
 
 	result, err := t.client.requestElicitation(ctx, &mcpsdk.ElicitParams{
-		Message:         fmt.Sprintf("OAuth authorization required for %s", t.baseURL),
+		Message:         "OAuth authorization required for " + t.baseURL,
 		RequestedSchema: nil,
 		Meta: map[string]any{
 			"cagent/type":          "oauth_flow",
@@ -415,10 +415,10 @@ func (t *oauthTransport) handleUnmanagedOAuthFlow(ctx context.Context, authServe
 	slog.Debug("Received elicitation response from client", "action", result.Action)
 
 	if result.Action != tools.ElicitationActionAccept {
-		return fmt.Errorf("OAuth flow declined or cancelled by client")
+		return errors.New("OAuth flow declined or cancelled by client")
 	}
 	if result.Content == nil {
-		return fmt.Errorf("no token received from client")
+		return errors.New("no token received from client")
 	}
 
 	tokenData := result.Content
@@ -428,7 +428,7 @@ func (t *oauthTransport) handleUnmanagedOAuthFlow(ctx context.Context, authServe
 	if accessToken, ok := tokenData["access_token"].(string); ok {
 		token.AccessToken = accessToken
 	} else {
-		return fmt.Errorf("access_token missing or invalid in client response")
+		return errors.New("access_token missing or invalid in client response")
 	}
 
 	if tokenType, ok := tokenData["token_type"].(string); ok {

--- a/pkg/tools/mcp/oauth_helpers.go
+++ b/pkg/tools/mcp/oauth_helpers.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -102,7 +103,7 @@ func RequestAuthorizationCode(ctx context.Context, authURL string, callbackServe
 // RegisterClient performs dynamic client registration
 func RegisterClient(ctx context.Context, authMetadata *AuthorizationServerMetadata, redirectURI string, scopes []string) (clientID, clientSecret string, err error) {
 	if authMetadata.RegistrationEndpoint == "" {
-		return "", "", fmt.Errorf("authorization server does not support dynamic client registration")
+		return "", "", errors.New("authorization server does not support dynamic client registration")
 	}
 
 	reqBody := map[string]any{
@@ -148,7 +149,7 @@ func RegisterClient(ctx context.Context, authMetadata *AuthorizationServerMetada
 	}
 
 	if respBody.ClientID == "" {
-		return "", "", fmt.Errorf("registration response missing client_id")
+		return "", "", errors.New("registration response missing client_id")
 	}
 
 	return respBody.ClientID, respBody.ClientSecret, nil

--- a/pkg/tools/mcp/oauth_server.go
+++ b/pkg/tools/mcp/oauth_server.go
@@ -109,7 +109,7 @@ func (cs *CallbackServer) handleCallback(w http.ResponseWriter, r *http.Request)
 	state := query.Get("state")
 
 	if code == "" {
-		cs.errCh <- fmt.Errorf("no authorization code received")
+		cs.errCh <- errors.New("no authorization code received")
 		w.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(w, "No authorization code received")
 		return

--- a/pkg/tools/mcp/session_client.go
+++ b/pkg/tools/mcp/session_client.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"iter"
 	"log/slog"
@@ -96,7 +97,7 @@ func (c *sessionClient) ListTools(ctx context.Context, request *gomcp.ListToolsP
 		return s.Tools(ctx, request)
 	}
 	return func(yield func(*gomcp.Tool, error) bool) {
-		yield(nil, fmt.Errorf("session not initialized"))
+		yield(nil, errors.New("session not initialized"))
 	}
 }
 
@@ -104,7 +105,7 @@ func (c *sessionClient) CallTool(ctx context.Context, request *gomcp.CallToolPar
 	if s := c.getSession(); s != nil {
 		return s.CallTool(ctx, request)
 	}
-	return nil, fmt.Errorf("session not initialized")
+	return nil, errors.New("session not initialized")
 }
 
 func (c *sessionClient) ListPrompts(ctx context.Context, request *gomcp.ListPromptsParams) iter.Seq2[*gomcp.Prompt, error] {
@@ -112,7 +113,7 @@ func (c *sessionClient) ListPrompts(ctx context.Context, request *gomcp.ListProm
 		return s.Prompts(ctx, request)
 	}
 	return func(yield func(*gomcp.Prompt, error) bool) {
-		yield(nil, fmt.Errorf("session not initialized"))
+		yield(nil, errors.New("session not initialized"))
 	}
 }
 
@@ -120,7 +121,7 @@ func (c *sessionClient) GetPrompt(ctx context.Context, request *gomcp.GetPromptP
 	if s := c.getSession(); s != nil {
 		return s.GetPrompt(ctx, request)
 	}
-	return nil, fmt.Errorf("session not initialized")
+	return nil, errors.New("session not initialized")
 }
 
 // handleElicitationRequest forwards incoming elicitation requests from the MCP
@@ -134,7 +135,7 @@ func (c *sessionClient) handleElicitationRequest(ctx context.Context, req *gomcp
 	c.mu.RUnlock()
 
 	if handler == nil {
-		return nil, fmt.Errorf("no elicitation handler configured")
+		return nil, errors.New("no elicitation handler configured")
 	}
 
 	result, err := handler(ctx, req.Params)
@@ -165,7 +166,7 @@ func (c *sessionClient) requestElicitation(ctx context.Context, req *gomcp.Elici
 	c.mu.RUnlock()
 
 	if handler == nil {
-		return tools.ElicitationResult{}, fmt.Errorf("no elicitation handler configured")
+		return tools.ElicitationResult{}, errors.New("no elicitation handler configured")
 	}
 
 	return handler(ctx, req)

--- a/pkg/tui/components/editor/editor.go
+++ b/pkg/tui/components/editor/editor.go
@@ -955,11 +955,13 @@ func (e *editor) handleGraphemeBackspace() (layout.Model, tea.Cmd) {
 	textBeforeCursor := strings.Join(beforeParts, "\n")
 
 	// Build text after cursor position (after cursor on current line + remaining lines)
-	var textAfterCursor string
-	textAfterCursor = afterCursor
+	var textAfterCursorSb strings.Builder
+	textAfterCursorSb.WriteString(afterCursor)
 	for i := currentLine + 1; i < len(lines); i++ {
-		textAfterCursor += "\n" + lines[i]
+		textAfterCursorSb.WriteByte('\n')
+		textAfterCursorSb.WriteString(lines[i])
 	}
+	textAfterCursor := textAfterCursorSb.String()
 
 	// Set the text before cursor and move to end
 	e.textarea.SetValue(textBeforeCursor)

--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"os"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -478,7 +479,7 @@ func formatTokenCount(count int64) string {
 	} else if count >= 1000 {
 		return fmt.Sprintf("%.1fK", float64(count)/1000)
 	}
-	return fmt.Sprintf("%d", count)
+	return strconv.FormatInt(count, 10)
 }
 
 func formatCost(cost float64) string {
@@ -953,7 +954,7 @@ func (m *model) workingIndicator() string {
 		displayRagName := strings.ReplaceAll(ragName, "_", " ")
 
 		// RAG source header
-		header := fmt.Sprintf("Indexing %s", styles.BoldStyle.Render(displayRagName))
+		header := "Indexing " + styles.BoldStyle.Render(displayRagName)
 		indicators = append(indicators, styles.ActiveStyle.Render(header))
 
 		// Each strategy with its spinner and progress
@@ -985,7 +986,7 @@ func (m *model) workingIndicatorCollapsed() string {
 		strategies := ragGroups[ragName]
 		displayRagName := strings.ReplaceAll(ragName, "_", " ")
 
-		labels = append(labels, fmt.Sprintf("Indexing %s", styles.BoldStyle.Render(displayRagName)))
+		labels = append(labels, "Indexing "+styles.BoldStyle.Render(displayRagName))
 
 		for _, strategy := range strategies {
 			displayStratName := strings.ReplaceAll(strategy.strategyName, "-", " ")
@@ -1052,16 +1053,16 @@ func (m *model) tokenUsageSummary() string {
 
 	s := m.computeUsageStats()
 
-	parts := []string{fmt.Sprintf("Tokens: %s", formatTokenCount(s.tokens))}
+	parts := []string{"Tokens: " + formatTokenCount(s.tokens)}
 	if s.sessionCount > 1 {
 		if s.contextPct != "" {
-			parts = append(parts, fmt.Sprintf("Context: %s", s.contextPct))
+			parts = append(parts, "Context: "+s.contextPct)
 		}
-		parts = append(parts, fmt.Sprintf("Cost: $%s", formatCost(s.totalCost)), fmt.Sprintf("%d sub-sessions", s.sessionCount-1))
+		parts = append(parts, "Cost: $"+formatCost(s.totalCost), fmt.Sprintf("%d sub-sessions", s.sessionCount-1))
 	} else {
-		parts = append(parts, fmt.Sprintf("Cost: $%s", formatCost(s.totalCost)))
+		parts = append(parts, "Cost: $"+formatCost(s.totalCost))
 		if s.contextPct != "" {
-			parts = append(parts, fmt.Sprintf("Context: %s", s.contextPct))
+			parts = append(parts, "Context: "+s.contextPct)
 		}
 	}
 

--- a/pkg/tui/components/tabbar/tabbar.go
+++ b/pkg/tui/components/tabbar/tabbar.go
@@ -2,6 +2,8 @@
 package tabbar
 
 import (
+	"strings"
+
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -414,7 +416,7 @@ func (t *TabBar) View() string {
 	// Attention arrow style: warning-colored and bold so off-screen attention tabs are obvious.
 	attnArrowStyle := lipgloss.NewStyle().Foreground(styles.EnsureContrast(styles.Warning, styles.Background)).Bold(true)
 
-	var line string
+	var line strings.Builder
 	var cursor int
 
 	// Left scroll arrow — highlight if any off-screen tab to the left needs attention.
@@ -424,7 +426,7 @@ func (t *TabBar) View() string {
 			style = attnArrowStyle
 		}
 		arrow := style.Render(scrollLeftText)
-		line += arrow
+		line.WriteString(arrow)
 		t.zones = append(t.zones, clickZone{
 			startX: cursor, endX: cursor + scrollArrowWidth,
 			tabIdx: noTab, isScrollLeft: true,
@@ -475,7 +477,7 @@ func (t *TabBar) View() string {
 
 		// Insert the drop indicator before this tab if this is the visual drop position.
 		if visualDrop == i {
-			line += dropLine
+			line.WriteString(dropLine)
 			cursor += dropIndicatorWidth
 		}
 
@@ -486,14 +488,14 @@ func (t *TabBar) View() string {
 			clickZone{startX: mainEnd, endX: cursor + tabW, tabIdx: i, isClose: true},
 		)
 
-		line += tab.View()
+		line.WriteString(tab.View())
 		cursor += tabW
 		lastVisibleIdx = i
 	}
 
 	// Drop indicator after the last visible tab.
 	if visualDrop == lastVisibleIdx+1 {
-		line += dropLine
+		line.WriteString(dropLine)
 		cursor += dropIndicatorWidth
 	}
 
@@ -504,7 +506,7 @@ func (t *TabBar) View() string {
 			style = attnArrowStyle
 		}
 		arrow := style.Render(scrollRightText)
-		line += arrow
+		line.WriteString(arrow)
 		t.zones = append(t.zones, clickZone{
 			startX: cursor, endX: cursor + scrollArrowWidth,
 			tabIdx: noTab, isScrollRight: true,
@@ -514,13 +516,13 @@ func (t *TabBar) View() string {
 
 	// "+" button.
 	plus := plusStyle.Render(plusButtonText)
-	line += plus
+	line.WriteString(plus)
 	t.zones = append(t.zones, clickZone{
 		startX: cursor, endX: cursor + plusButtonWidth,
 		tabIdx: noTab, isPlus: true,
 	})
 
-	return line
+	return line.String()
 }
 
 // ensureActiveVisible adjusts scrollOffset so the active tab is visible.

--- a/pkg/tui/dialog/cost.go
+++ b/pkg/tui/dialog/cost.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 
 	"charm.land/bubbles/v2/key"
@@ -321,7 +322,7 @@ func (d *costDialog) renderPlainText() string {
 	var lines []string
 
 	// Build input line with optional breakdown
-	inputLine := fmt.Sprintf("input: %s", formatTokenCount(data.total.totalInput()))
+	inputLine := "input: " + formatTokenCount(data.total.totalInput())
 	if data.total.CachedInputTokens > 0 || data.total.CacheWriteTokens > 0 {
 		inputLine += fmt.Sprintf(" (%s new + %s cached + %s cache write)",
 			formatTokenCount(data.total.InputTokens),
@@ -330,7 +331,7 @@ func (d *costDialog) renderPlainText() string {
 	}
 
 	lines = append(lines, "Session Cost Details", "", "Total", formatCost(data.total.cost),
-		inputLine, fmt.Sprintf("output: %s", formatTokenCount(data.total.OutputTokens)), "")
+		inputLine, "output: "+formatTokenCount(data.total.OutputTokens), "")
 
 	if len(data.models) > 0 {
 		lines = append(lines, "By Model")
@@ -400,7 +401,7 @@ func formatTokenCount(count int64) string {
 	case count >= 1_000:
 		return fmt.Sprintf("%.1fK", float64(count)/1_000)
 	default:
-		return fmt.Sprintf("%d", count)
+		return strconv.FormatInt(count, 10)
 	}
 }
 

--- a/pkg/tui/dialog/model_picker.go
+++ b/pkg/tui/dialog/model_picker.go
@@ -2,6 +2,7 @@ package dialog
 
 import (
 	"cmp"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -299,7 +300,7 @@ func validateCustomModelSpec(spec string) error {
 
 		providerName, modelName, ok := strings.Cut(part, "/")
 		if !ok {
-			return fmt.Errorf("invalid format: expected 'provider/model'")
+			return errors.New("invalid format: expected 'provider/model'")
 		}
 
 		providerName = strings.TrimSpace(providerName)

--- a/pkg/tui/dialog/session_browser_test.go
+++ b/pkg/tui/dialog/session_browser_test.go
@@ -2,6 +2,7 @@ package dialog
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -164,7 +165,7 @@ func TestSessionBrowserScrolling(t *testing.T) {
 	sessions := make([]session.Summary, 20)
 	for i := range sessions {
 		sessions[i] = session.Summary{
-			ID:        fmt.Sprintf("%d", i+1),
+			ID:        strconv.Itoa(i + 1),
 			Title:     fmt.Sprintf("Session %d", i+1),
 			CreatedAt: time.Now(),
 		}

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -130,7 +130,7 @@ func (m *appModel) handleSetSessionTitle(title string) (tea.Model, tea.Cmd) {
 		}
 		return m, notification.ErrorCmd(fmt.Sprintf("Failed to set session title: %v", err))
 	}
-	return m, notification.SuccessCmd(fmt.Sprintf("Title set to: %s", title))
+	return m, notification.SuccessCmd("Title set to: " + title)
 }
 
 func (m *appModel) handleRegenerateTitle() (tea.Model, tea.Cmd) {
@@ -159,7 +159,7 @@ func isErrTitleGenerating(err error) bool {
 
 func (m *appModel) handleEvalSession(filename string) (tea.Model, tea.Cmd) {
 	evalFile, _ := evaluation.Save(m.application.Session(), filename)
-	return m, notification.SuccessCmd(fmt.Sprintf("Eval saved to file %s", evalFile))
+	return m, notification.SuccessCmd("Eval saved to file " + evalFile)
 }
 
 func (m *appModel) handleExportSession(filename string) (tea.Model, tea.Cmd) {
@@ -167,7 +167,7 @@ func (m *appModel) handleExportSession(filename string) (tea.Model, tea.Cmd) {
 	if err != nil {
 		return m, notification.ErrorCmd(fmt.Sprintf("Failed to export session: %v", err))
 	}
-	return m, notification.SuccessCmd(fmt.Sprintf("Session exported to %s", exportFile))
+	return m, notification.SuccessCmd("Session exported to " + exportFile)
 }
 
 func (m *appModel) handleCompactSession(additionalPrompt string) (tea.Model, tea.Cmd) {
@@ -391,7 +391,7 @@ func (m *appModel) handleChangeModel(modelRef string) (tea.Model, tea.Cmd) {
 	if modelRef == "" {
 		return m, notification.SuccessCmd("Model reset to default")
 	}
-	return m, notification.SuccessCmd(fmt.Sprintf("Model changed to %s", modelRef))
+	return m, notification.SuccessCmd("Model changed to " + modelRef)
 }
 
 // --- Theme picker ---
@@ -442,7 +442,7 @@ func (m *appModel) handleChangeTheme(themeRef string) (tea.Model, tea.Cmd) {
 		slog.Warn("Failed to save theme to user config", "theme", themeRef, "error", err)
 	}
 	return m, tea.Sequence(
-		notification.SuccessCmd(fmt.Sprintf("Theme changed to %s", theme.Name)),
+		notification.SuccessCmd("Theme changed to "+theme.Name),
 		core.CmdHandler(messages.ThemeChangedMsg{}),
 	)
 }
@@ -523,7 +523,7 @@ func (m *appModel) handleAttachFile(filePath string) (tea.Model, tea.Cmd) {
 			slog.Warn("failed to attach file", "path", filePath, "error", err)
 			// Attachment failed — open the file picker with an error notification
 			return m, tea.Batch(
-				notification.ErrorCmd(fmt.Sprintf("Failed to attach %s", filePath)),
+				notification.ErrorCmd("Failed to attach "+filePath),
 				core.CmdHandler(dialog.OpenDialogMsg{
 					Model: dialog.NewFilePickerDialog(filePath),
 				}),

--- a/pkg/tui/service/supervisor/supervisor.go
+++ b/pkg/tui/service/supervisor/supervisor.go
@@ -3,7 +3,7 @@ package supervisor
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"log/slog"
 	"path/filepath"
 	"sync"
@@ -101,7 +101,7 @@ func (s *Supervisor) AddSession(ctx context.Context, a *app.App, sess *session.S
 // SpawnSession creates and adds a new session.
 func (s *Supervisor) SpawnSession(ctx context.Context, workingDir string) (string, error) {
 	if s.spawner == nil {
-		return "", fmt.Errorf("session spawning is not available")
+		return "", errors.New("session spawning is not available")
 	}
 
 	a, sess, cleanup, err := s.spawner(ctx, workingDir)
@@ -387,10 +387,7 @@ func (s *Supervisor) CloseSession(sessionID string) (nextActiveID string) {
 	// first one when closing the first tab).
 	if s.activeID == sessionID {
 		if len(s.order) > 0 {
-			prevIdx := closedIdx - 1
-			if prevIdx < 0 {
-				prevIdx = 0
-			}
+			prevIdx := max(closedIdx-1, 0)
 			s.activeID = s.order[prevIdx]
 		} else {
 			s.activeID = ""

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -1471,7 +1471,7 @@ func (m *appModel) Bindings() []key.Binding {
 		bindings = append(bindings,
 			key.NewBinding(
 				key.WithKeys("ctrl+g"),
-				key.WithHelp("Ctrl+g", fmt.Sprintf("edit in %s", editorName)),
+				key.WithHelp("Ctrl+g", "edit in "+editorName),
 			),
 			key.NewBinding(
 				key.WithKeys("ctrl+r"),

--- a/pkg/userconfig/userconfig.go
+++ b/pkg/userconfig/userconfig.go
@@ -324,17 +324,13 @@ func (c *Config) DeleteAlias(name string) bool {
 	return false
 }
 
-func boolPtr(b bool) *bool {
-	return &b
-}
-
 // GetSettings returns the global settings with defaults applied.
 func (c *Config) GetSettings() *Settings {
 	if c.Settings == nil {
-		return &Settings{RestoreTabs: boolPtr(false)}
+		return &Settings{RestoreTabs: new(false)}
 	}
 	if c.Settings.RestoreTabs == nil {
-		c.Settings.RestoreTabs = boolPtr(false)
+		c.Settings.RestoreTabs = new(false)
 	}
 	return c.Settings
 }

--- a/pkg/userconfig/userconfig_test.go
+++ b/pkg/userconfig/userconfig_test.go
@@ -843,8 +843,8 @@ func TestSettings_RestoreTabs(t *testing.T) {
 	}{
 		{"nil settings", nil, false},
 		{"empty settings", &Settings{}, false},
-		{"explicitly disabled", &Settings{RestoreTabs: boolPtr(false)}, false},
-		{"explicitly enabled", &Settings{RestoreTabs: boolPtr(true)}, true},
+		{"explicitly disabled", &Settings{RestoreTabs: new(false)}, false},
+		{"explicitly enabled", &Settings{RestoreTabs: new(true)}, true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Enable two new golangci-lint linters and resolve all findings across 97 files.

## Changes

### New linters enabled in `.golangci.yml`
- **modernize** — flags code that can use newer Go idioms
- **perfsprint** — flags `fmt.Sprintf` calls replaceable with faster alternatives

### Fixes applied

**modernize:**
- `fmt.Errorf("...")" → `errors.New("...")` where no format verbs are used
- `fmt.Sprintf("%d", n)` → `strconv.Itoa(n)` / `strconv.FormatInt(n, 10)`
- Redundant `fmt.Sprintf("%s", s)` → direct string value
- `for` loops → `slices.Contains()` in `SkillsConfig.HasLocal()`
- `omitempty` → `omitzero` on struct fields where `omitempty` has no effect (`time.Time`, `SkillsConfig`)
- `boolPtr(x)` → `new(x)` and removal of now-unused helper functions
- `wg.Add(1); go func() { defer wg.Done(); ... }()` → `wg.Go(func() { ... })`

**perfsprint:**
- `fmt.Sprintf` → string concatenation or `strconv` where faster
- String concatenation in loops → `strings.Builder`
- `WriteString(fmt.Sprintf(...))` → `fmt.Fprintf`

### Notes
- Frozen config versions (v2–v5) only received safe `errors.New` / `slices.Contains` changes; the `omitzero` struct tag change was applied only to `latest`. The v5 `omitempty` is suppressed with `//nolint:modernize`.
- golangci-lint bumped locally from v2.9.0 → v2.11.2.