### PR TITLE
refactor: use errors.AsType consistently instead of errors.As with pre-declared variables

### DIFF
--- a/pkg/modelerrors/modelerrors.go
+++ b/pkg/modelerrors/modelerrors.go
@@ -100,8 +100,7 @@ func IsContextOverflowError(err error) bool {
 	}
 
 	// Already wrapped
-	var ctxErr *ContextOverflowError
-	if errors.As(err, &ctxErr) {
+	if _, ok := errors.AsType[*ContextOverflowError](err); ok {
 		return true
 	}
 
@@ -344,8 +343,7 @@ func FormatError(err error) string {
 	}
 
 	// Context overflow gets a dedicated, actionable message.
-	var ctxOverflow *ContextOverflowError
-	if errors.As(err, &ctxOverflow) {
+	if _, ok := errors.AsType[*ContextOverflowError](err); ok {
 		return "The conversation has exceeded the model's context window and automatic compaction is not enabled. " +
 			"Try running /compact to reduce the conversation size, or start a new session."
 	}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1177,8 +1177,7 @@ func (r *LocalRuntime) RunStream(ctx context.Context, sess *session.Session) <-c
 				// Auto-recovery: if the error is a context overflow and
 				// session compaction is enabled, compact the conversation
 				// and retry the request instead of surfacing raw errors.
-				var ctxOverflow *modelerrors.ContextOverflowError
-				if errors.As(err, &ctxOverflow) && r.sessionCompaction {
+				if _, ok := errors.AsType[*modelerrors.ContextOverflowError](err); ok && r.sessionCompaction {
 					slog.Warn("Context window overflow detected, attempting auto-compaction",
 						"agent", a.Name(),
 						"session_id", sess.ID,


### PR DESCRIPTION
Replace the remaining `errors.As` calls that use pre-declared target variables with the cleaner `errors.AsType[T]` generic form (available since Go 1.23).

Three call sites were updated:

- `pkg/modelerrors/modelerrors.go` – `IsContextOverflowError()`
- `pkg/modelerrors/modelerrors.go` – `FormatError()`
- `pkg/runtime/runtime.go` – context-overflow auto-compaction in `RunStream()`

All three only checked for the error type without using the unwrapped value, making `errors.AsType` a perfect fit. The rest of the codebase already uses this pattern.