### PR TITLE
Replace json.MarshalIndent with json.Marshal in builtin tools

### DIFF
--- a/pkg/tools/builtin/deferred.go
+++ b/pkg/tools/builtin/deferred.go
@@ -110,7 +110,7 @@ func (d *DeferredToolset) handleSearchTool(_ context.Context, args SearchToolArg
 		return tools.ResultError(fmt.Sprintf("No deferred tools found matching '%s'", args.Query)), nil
 	}
 
-	output, err := json.MarshalIndent(results, "", "  ")
+	output, err := json.Marshal(results)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal results: %w", err)
 	}

--- a/pkg/tools/builtin/fetch.go
+++ b/pkg/tools/builtin/fetch.go
@@ -2,7 +2,6 @@ package builtin
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -77,12 +76,7 @@ func (h *fetchHandler) CallTool(ctx context.Context, params FetchToolArgs) (*too
 	}
 
 	// Multiple URLs - return structured results
-	output, err := json.MarshalIndent(results, "", "  ")
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal results: %w", err)
-	}
-
-	return tools.ResultSuccess(string(output)), nil
+	return tools.ResultJSON(results), nil
 }
 
 type FetchResult struct {

--- a/pkg/tools/builtin/filesystem.go
+++ b/pkg/tools/builtin/filesystem.go
@@ -408,7 +408,7 @@ func (t *FilesystemTool) handleDirectoryTree(_ context.Context, args DirectoryTr
 		return tools.ResultError(fmt.Sprintf("Error building directory tree: %s", err)), nil
 	}
 
-	result, err := json.MarshalIndent(tree, "", "  ")
+	result, err := json.Marshal(tree)
 	if err != nil {
 		return tools.ResultError(fmt.Sprintf("Error formatting tree: %s", err)), nil
 	}
@@ -662,7 +662,7 @@ func (t *FilesystemTool) handleReadMultipleFiles(ctx context.Context, args ReadM
 
 	var output string
 	if args.JSON {
-		jsonResult, err := json.MarshalIndent(contents, "", "  ")
+		jsonResult, err := json.Marshal(contents)
 		if err != nil {
 			return tools.ResultError(fmt.Sprintf("Error formatting JSON: %s", err)), nil
 		}

--- a/pkg/tools/builtin/lsp.go
+++ b/pkg/tools/builtin/lsp.go
@@ -1741,7 +1741,7 @@ func formatHoverContents(contents any) string {
 		if value, ok := c["value"].(string); ok {
 			return value
 		}
-		data, _ := json.MarshalIndent(c, "", "  ")
+		data, _ := json.Marshal(c)
 		return string(data)
 	case []any:
 		var parts []string
@@ -1750,7 +1750,7 @@ func formatHoverContents(contents any) string {
 		}
 		return strings.Join(parts, "\n\n")
 	default:
-		data, _ := json.MarshalIndent(contents, "", "  ")
+		data, _ := json.Marshal(contents)
 		return string(data)
 	}
 }

--- a/pkg/tools/builtin/tasks.go
+++ b/pkg/tools/builtin/tasks.go
@@ -399,11 +399,7 @@ func (t *TasksTool) deleteTask(_ context.Context, params DeleteTaskArgs) (*tools
 		return tools.ResultError(err.Error()), nil
 	}
 
-	out, err := json.MarshalIndent(map[string]string{"deleted": params.ID}, "", "  ")
-	if err != nil {
-		return tools.ResultError(err.Error()), nil
-	}
-	return &tools.ToolCallResult{Output: string(out)}, nil
+	return tools.ResultJSON(map[string]string{"deleted": params.ID}), nil
 }
 
 func (t *TasksTool) listTasks(_ context.Context, params ListTasksArgs) (*tools.ToolCallResult, error) {
@@ -440,11 +436,7 @@ func (t *TasksTool) listTasks(_ context.Context, params ListTasksArgs) (*tools.T
 
 	sortTasks(tasks)
 
-	out, err := json.Marshal(tasks)
-	if err != nil {
-		return tools.ResultError(err.Error()), nil
-	}
-	return &tools.ToolCallResult{Output: string(out)}, nil
+	return tools.ResultJSON(tasks), nil
 }
 
 func (t *TasksTool) nextTask(_ context.Context, _ tools.ToolCall) (*tools.ToolCallResult, error) {
@@ -463,11 +455,7 @@ func (t *TasksTool) nextTask(_ context.Context, _ tools.ToolCall) (*tools.ToolCa
 
 	for _, task := range tasks {
 		if task.EffectiveStatus != StatusBlocked && task.EffectiveStatus != StatusDone {
-			out, err := json.Marshal(task)
-			if err != nil {
-				return tools.ResultError(err.Error()), nil
-			}
-			return &tools.ToolCallResult{Output: string(out)}, nil
+			return tools.ResultJSON(task), nil
 		}
 	}
 
@@ -536,23 +524,14 @@ func (t *TasksTool) removeDependency(_ context.Context, params RemoveDependencyA
 }
 
 func taskResult(task Task) *tools.ToolCallResult {
-	out, err := json.Marshal(task)
-	if err != nil {
-		return tools.ResultError(err.Error())
-	}
-	return &tools.ToolCallResult{Output: string(out)}
+	return tools.ResultJSON(task)
 }
 
 func taskWithEffectiveResult(task Task, tasks map[string]Task) *tools.ToolCallResult {
-	result := taskWithEffective{
+	return tools.ResultJSON(taskWithEffective{
 		Task:            task,
 		EffectiveStatus: effectiveStatus(task, tasks),
-	}
-	out, err := json.Marshal(result)
-	if err != nil {
-		return tools.ResultError(err.Error())
-	}
-	return &tools.ToolCallResult{Output: string(out)}
+	})
 }
 
 func (t *TasksTool) Tools(_ context.Context) ([]tools.Tool, error) {

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -84,6 +84,16 @@ func ResultSuccess(output string) *ToolCallResult {
 	}
 }
 
+// ResultJSON marshals v as JSON and returns it as a successful tool result.
+// If marshaling fails, it returns an error result.
+func ResultJSON(v any) *ToolCallResult {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return ResultError(err.Error())
+	}
+	return &ToolCallResult{Output: string(data)}
+}
+
 type ToolType string
 
 type Tool struct {


### PR DESCRIPTION
Tool output sent to the LLM does not benefit from pretty-printing.

## Changes

- Use `json.Marshal` instead of `json.MarshalIndent` across builtin tool response paths (`deferred`, `fetch`, `filesystem`, `lsp`, `tasks`).
- Add a `tools.ResultJSON` helper that encapsulates the repeated marshal → error-check → wrap-in-`ToolCallResult` pattern, eliminating boilerplate in `fetch.go` and `tasks.go`.

## Summary

| File | What changed |
|---|---|
| `pkg/tools/tools.go` | New `ResultJSON(v any)` helper (+10 lines) |
| `pkg/tools/builtin/deferred.go` | `MarshalIndent` → `Marshal` |
| `pkg/tools/builtin/fetch.go` | `MarshalIndent` → `ResultJSON`, removed `encoding/json` import |
| `pkg/tools/builtin/filesystem.go` | `MarshalIndent` → `Marshal` (2 sites) |
| `pkg/tools/builtin/lsp.go` | `MarshalIndent` → `Marshal` (2 sites) |
| `pkg/tools/builtin/tasks.go` | `MarshalIndent`/`Marshal` → `ResultJSON` (5 sites) |

Net: **+22 / -39 lines**