### PR TITLE
tui: fix animated spinners inside terminal multiplexers

### DIFF
--- a/cmd/root/new.go
+++ b/cmd/root/new.go
@@ -108,7 +108,15 @@ func runTUI(ctx context.Context, rt runtime.Runtime, sess *session.Session, spaw
 	wd, _ := os.Getwd()
 	model := tui.New(ctx, spawner, a, wd, cleanup)
 
-	p := tea.NewProgram(model, tea.WithContext(ctx), tea.WithFilter(filter))
+	programOpts := []tea.ProgramOption{tea.WithContext(ctx), tea.WithFilter(filter)}
+
+	// Terminal multiplexers can drop frames at the default 60 FPS, making
+	// spinners appear static. Cap the renderer at 30 FPS when detected.
+	if inMultiplexer() {
+		programOpts = append(programOpts, tea.WithFPS(30))
+	}
+
+	p := tea.NewProgram(model, programOpts...)
 	coalescer.SetSender(p.Send)
 
 	if m, ok := model.(interface{ SetProgram(p *tea.Program) }); ok {
@@ -117,4 +125,17 @@ func runTUI(ctx context.Context, rt runtime.Runtime, sess *session.Session, spaw
 
 	_, err := p.Run()
 	return err
+}
+
+// inMultiplexer reports whether the process is running inside a terminal
+// multiplexer (tmux, screen).
+func inMultiplexer() bool {
+	if os.Getenv("TMUX") != "" {
+		return true
+	}
+	if os.Getenv("STY") != "" {
+		return true
+	}
+	term := os.Getenv("TERM")
+	return strings.HasPrefix(term, "tmux") || strings.HasPrefix(term, "screen")
 }

--- a/pkg/tui/components/spinner/spinner.go
+++ b/pkg/tui/components/spinner/spinner.go
@@ -2,6 +2,7 @@ package spinner
 
 import (
 	"math/rand/v2"
+	"os"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -69,8 +70,8 @@ var defaultMessages = []string{
 
 func New(mode Mode, dotsStyle lipgloss.Style) Spinner {
 	// Pre-render all spinner frames for fast lookup during render
-	styledFrames := make([]string, len(frames))
-	for i, char := range frames {
+	styledFrames := make([]string, len(spinnerFrames))
+	for i, char := range spinnerFrames {
 		styledFrames[i] = dotsStyle.Render(char)
 	}
 
@@ -136,12 +137,42 @@ func (s *spinner) Stop() {
 	s.animSub.Stop()
 }
 
-// frames contains the braille spinner characters used for animation.
-var frames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+// spinnerFrames holds the animation frames for the current terminal.
+// Braille characters are used by default; inside tmux they don't render
+// correctly, so we fall back to ASCII.
+var spinnerFrames = selectFrames(inMultiplexer())
+
+// inMultiplexer reports whether the process is running inside a terminal
+// multiplexer (tmux, screen). Detection checks multiple env vars because
+// some of them may be stripped in containers or sudo sessions.
+func inMultiplexer() bool {
+	if os.Getenv("TMUX") != "" {
+		return true
+	}
+	if os.Getenv("STY") != "" { // GNU screen
+		return true
+	}
+	term := os.Getenv("TERM")
+	return strings.HasPrefix(term, "tmux") || strings.HasPrefix(term, "screen")
+}
+
+var (
+	brailleFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+	asciiFrames   = []string{"|", "/", "-", "\\"}
+)
+
+// selectFrames returns ASCII spinner frames when inTmux is true,
+// braille frames otherwise.
+func selectFrames(inTmux bool) []string {
+	if inTmux {
+		return asciiFrames
+	}
+	return brailleFrames
+}
 
 // Frame returns the spinner character for the given animation frame.
 func Frame(index int) string {
-	return frames[index%len(frames)]
+	return spinnerFrames[index%len(spinnerFrames)]
 }
 
 // lightStyles maps distance from light position to style (0=brightest, 1=bright, 2=dim, 3+=dimmest).

--- a/pkg/tui/components/spinner/spinner_test.go
+++ b/pkg/tui/components/spinner/spinner_test.go
@@ -21,6 +21,45 @@ func TestSpinnerCopyDoesNotLeakAnimationSubscription(t *testing.T) {
 	require.False(t, animation.HasActive())
 }
 
+func TestFrameWrapsAround(t *testing.T) {
+	n := len(spinnerFrames)
+	require.Equal(t, spinnerFrames[0], Frame(0))
+	require.Equal(t, spinnerFrames[1], Frame(1))
+	require.Equal(t, spinnerFrames[0], Frame(n), "Frame should wrap around")
+}
+
+func TestSelectFrames(t *testing.T) {
+	require.Equal(t, brailleFrames, selectFrames(false))
+	require.Equal(t, asciiFrames, selectFrames(true))
+}
+
+func TestInMultiplexer(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want bool
+	}{
+		{"plain terminal", map[string]string{"TERM": "xterm-256color"}, false},
+		{"TMUX set", map[string]string{"TMUX": "/tmp/tmux-1000/default,123,0"}, true},
+		{"STY set", map[string]string{"STY": "12345.pts-0"}, true},
+		{"TERM=tmux-256color", map[string]string{"TERM": "tmux-256color"}, true},
+		{"TERM=screen-256color", map[string]string{"TERM": "screen-256color"}, true},
+		{"TERM=screen", map[string]string{"TERM": "screen"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clear all multiplexer env vars
+			t.Setenv("TMUX", "")
+			t.Setenv("STY", "")
+			t.Setenv("TERM", "")
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+			require.Equal(t, tt.want, inMultiplexer())
+		})
+	}
+}
+
 func BenchmarkSpinner_ModeSpinnerOnly(b *testing.B) {
 	s := New(ModeSpinnerOnly, lipgloss.NewStyle())
 	for b.Loop() {


### PR DESCRIPTION
Two changes improve spinner rendering in tmux and screen:

1. Cap the Bubble Tea renderer at 30 FPS when a multiplexer is detected. The default 60 FPS can overwhelm the multiplexer's rendering pipeline, causing dropped frames that make spinners appear static.

2. Fall back to ASCII spinner frames (|, /, -, \\) instead of braille characters, which may not render correctly in every multiplexer configuration.

Multiplexer detection checks $TMUX, $STY, and the $TERM prefix (tmux*, screen*) so it still triggers when individual env vars are stripped (containers, sudo, etc.).

Assisted-By: docker-agent