### PR TITLE
feat: click to copy working directory in TUI sidebar

### DIFF
--- a/pkg/tui/components/sidebar/collapsed_view.go
+++ b/pkg/tui/components/sidebar/collapsed_view.go
@@ -27,18 +27,7 @@ type CollapsedViewModel struct {
 // LineCount returns the number of lines needed to render this layout.
 func (vm CollapsedViewModel) LineCount() int {
 	lines := 1 // divider
-
-	switch {
-	case vm.TitleAndIndicatorOnOneLine:
-		lines++
-	case vm.WorkingIndicator == "":
-		// No working indicator but title wraps
-		lines += linesNeeded(lipgloss.Width(vm.TitleWithStar), vm.ContentWidth)
-	default:
-		// Title and working indicator on separate lines, each may wrap
-		lines += linesNeeded(lipgloss.Width(vm.TitleWithStar), vm.ContentWidth)
-		lines += linesNeeded(lipgloss.Width(vm.WorkingIndicator), vm.ContentWidth)
-	}
+	lines += vm.titleSectionLines()
 
 	if vm.WdAndUsageOnOneLine {
 		lines++
@@ -50,6 +39,20 @@ func (vm CollapsedViewModel) LineCount() int {
 	}
 
 	return lines
+}
+
+// titleSectionLines returns the number of rendered lines consumed by the
+// title (and optional working indicator) section.
+func (vm CollapsedViewModel) titleSectionLines() int {
+	switch {
+	case vm.TitleAndIndicatorOnOneLine:
+		return 1
+	case vm.WorkingIndicator == "":
+		return linesNeeded(lipgloss.Width(vm.TitleWithStar), vm.ContentWidth)
+	default:
+		return linesNeeded(lipgloss.Width(vm.TitleWithStar), vm.ContentWidth) +
+			linesNeeded(lipgloss.Width(vm.WorkingIndicator), vm.ContentWidth)
+	}
 }
 
 // RenderCollapsedView renders the collapsed sidebar from a CollapsedViewModel.

--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -92,6 +92,8 @@ type Model interface {
 	SetTitleRegenerating(regenerating bool) tea.Cmd
 	// IsScrollbarDragging returns true when the scrollbar thumb is being dragged.
 	IsScrollbarDragging() bool
+	// WorkingDirectory returns the working directory path displayed in the sidebar.
+	WorkingDirectory() string
 	// Cleanup cancels any in-flight async operations.
 	Cleanup()
 }
@@ -351,13 +353,19 @@ func (m *model) IsScrollbarDragging() bool {
 	return m.scrollview.IsDragging()
 }
 
+// WorkingDirectory returns the working directory path displayed in the sidebar.
+func (m *model) WorkingDirectory() string {
+	return m.workingDirectory
+}
+
 // ClickResult indicates what was clicked in the sidebar
 type ClickResult int
 
 const (
 	ClickNone ClickResult = iota
 	ClickStar
-	ClickTitle // Click on the title area (use double-click to edit)
+	ClickTitle      // Click on the title area (use double-click to edit)
+	ClickWorkingDir // Click on the working directory line
 )
 
 // HandleClick checks if click is on the star or title and returns true if it was
@@ -367,7 +375,7 @@ func (m *model) HandleClick(x, y int) bool {
 	return m.HandleClickType(x, y) != ClickNone
 }
 
-// HandleClickType returns what was clicked (star, title, or nothing)
+// HandleClickType returns what was clicked (star, title, working dir, or nothing)
 func (m *model) HandleClickType(x, y int) ClickResult {
 	// Account for left padding
 	adjustedX := x - m.layoutCfg.PaddingLeft
@@ -390,6 +398,15 @@ func (m *model) HandleClickType(x, y int) ClickResult {
 				return ClickTitle
 			}
 		}
+
+		// In collapsed mode, working dir line follows the title section.
+		vm := m.computeCollapsedViewModel(m.contentWidth(false))
+		wdStartY := vm.titleSectionLines()
+		wdLines := linesNeeded(lipgloss.Width(vm.WorkingDir), vm.ContentWidth)
+		if m.workingDirectory != "" && y >= wdStartY && y < wdStartY+wdLines {
+			return ClickWorkingDir
+		}
+
 		return ClickNone
 	}
 
@@ -409,6 +426,12 @@ func (m *model) HandleClickType(x, y int) ClickResult {
 			return ClickTitle
 		}
 	}
+
+	// Working dir is at: verticalStarY + titleLines (title) + 1 (empty separator)
+	if m.workingDirectory != "" && contentY == verticalStarY+titleLines+1 {
+		return ClickWorkingDir
+	}
+
 	return ClickNone
 }
 

--- a/pkg/tui/components/sidebar/title_edit_test.go
+++ b/pkg/tui/components/sidebar/title_edit_test.go
@@ -255,3 +255,80 @@ func TestSidebar_HandleClickType_NoWrap(t *testing.T) {
 	result = sb.HandleClickType(paddingLeft+1, verticalStarY)
 	assert.Equal(t, ClickStar, result, "star should still be clickable")
 }
+
+func TestSidebar_HandleClickType_WorkingDir_Vertical(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	sessionState := service.NewSessionState(sess)
+	sb := New(sessionState)
+
+	m := sb.(*model)
+	m.sessionHasContent = true
+	m.titleGenerated = true
+	m.mode = ModeVertical
+	m.width = 50
+	m.sessionTitle = "Hi"
+	m.workingDirectory = "~/projects/myapp"
+
+	paddingLeft := m.layoutCfg.PaddingLeft
+
+	// In vertical mode, working dir is at verticalStarY + titleLineCount + 1 (empty separator)
+	titleLines := m.titleLineCount()
+	wdY := verticalStarY + titleLines + 1
+
+	// Click on the working directory line
+	result := sb.HandleClickType(paddingLeft+3, wdY)
+	assert.Equal(t, ClickWorkingDir, result, "click on working dir line should return ClickWorkingDir")
+
+	// Click on the title line should still return ClickTitle
+	result = sb.HandleClickType(paddingLeft+3, verticalStarY)
+	assert.Equal(t, ClickTitle, result, "click on title should still return ClickTitle")
+
+	// Click on the empty separator line should return ClickNone
+	result = sb.HandleClickType(paddingLeft+3, verticalStarY+titleLines)
+	assert.Equal(t, ClickNone, result, "click on separator line should return ClickNone")
+}
+
+func TestSidebar_HandleClickType_WorkingDir_Collapsed(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	sessionState := service.NewSessionState(sess)
+	sb := New(sessionState)
+
+	m := sb.(*model)
+	m.sessionHasContent = true
+	m.titleGenerated = true
+	m.mode = ModeCollapsed
+	m.width = 50
+	m.sessionTitle = "Hi"
+	m.workingDirectory = "~/projects/myapp"
+
+	paddingLeft := m.layoutCfg.PaddingLeft
+
+	// In collapsed mode, title occupies 1 line, then working dir
+	titleLines := m.titleLineCount()
+	assert.Equal(t, 1, titleLines, "title should be on single line")
+
+	// Click on the working directory line (right after title)
+	result := sb.HandleClickType(paddingLeft+3, titleLines)
+	assert.Equal(t, ClickWorkingDir, result, "click on working dir line should return ClickWorkingDir")
+
+	// Click on the title should still return ClickTitle
+	result = sb.HandleClickType(paddingLeft+3, 0)
+	assert.Equal(t, ClickTitle, result, "click on title should still return ClickTitle")
+}
+
+func TestSidebar_WorkingDirectory(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	sessionState := service.NewSessionState(sess)
+	sb := New(sessionState)
+
+	m := sb.(*model)
+	m.workingDirectory = "~/projects/myapp"
+
+	assert.Equal(t, "~/projects/myapp", sb.WorkingDirectory())
+}

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -920,7 +920,7 @@ func (p *chatPage) SetSidebarSettings(settings SidebarSettings) {
 }
 
 // handleSidebarClickType checks what was clicked in the sidebar area.
-// Returns the type of click (star, title, or none).
+// Returns the type of click (star, title, working dir, or none).
 func (p *chatPage) handleSidebarClickType(x, y int) sidebar.ClickResult {
 	adjustedX := x - styles.AppPadding
 	sl := p.computeSidebarLayout()

--- a/pkg/tui/page/chat/hittest.go
+++ b/pkg/tui/page/chat/hittest.go
@@ -16,6 +16,7 @@ const (
 	TargetSidebarResizeHandle
 	TargetSidebarStar
 	TargetSidebarTitle
+	TargetSidebarWorkingDir
 	TargetSidebarContent
 	TargetMessages
 )
@@ -124,6 +125,8 @@ func (h *HitTest) sidebarClickTarget(x, y int) MouseTarget {
 		return TargetSidebarStar
 	case sidebar.ClickTitle:
 		return TargetSidebarTitle
+	case sidebar.ClickWorkingDir:
+		return TargetSidebarWorkingDir
 	default:
 		return TargetSidebarContent
 	}

--- a/pkg/tui/page/chat/input_handlers.go
+++ b/pkg/tui/page/chat/input_handlers.go
@@ -7,6 +7,7 @@ import (
 
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
+	"github.com/atotto/clipboard"
 
 	"github.com/docker/docker-agent/pkg/app"
 	"github.com/docker/docker-agent/pkg/tui/components/messages"
@@ -89,6 +90,18 @@ func (p *chatPage) persistSessionTitle(newTitle string) tea.Cmd {
 	}
 }
 
+// copyWorkingDirToClipboard copies the working directory path to the system clipboard.
+func copyWorkingDirToClipboard(wd string) tea.Cmd {
+	return tea.Sequence(
+		func() tea.Msg {
+			_ = clipboard.WriteAll(wd)
+			return nil
+		},
+		tea.SetClipboard(wd),
+		notification.SuccessCmd("Working directory copied to clipboard."),
+	)
+}
+
 // handleMouseClick handles mouse click events.
 func (p *chatPage) handleMouseClick(msg tea.MouseClickMsg) (layout.Model, tea.Cmd) {
 	hit := NewHitTest(p)
@@ -128,6 +141,11 @@ func (p *chatPage) handleMouseClick(msg tea.MouseClickMsg) (layout.Model, tea.Cm
 				return p, core.CmdHandler(msgtypes.RequestFocusMsg{Target: msgtypes.PanelSidebarTitle})
 			}
 			return p, nil
+		}
+
+	case TargetSidebarWorkingDir:
+		if msg.Button == tea.MouseLeft {
+			return p, copyWorkingDirToClipboard(p.sidebar.WorkingDirectory())
 		}
 
 	case TargetMessages:


### PR DESCRIPTION
## Summary

Add click-to-copy for the working directory shown in the TUI sidebar. Clicking the path copies it to the system clipboard and shows a notification. Works in both vertical and collapsed sidebar modes.

## Changes

- **sidebar.go**: Add `ClickWorkingDir` result to `HandleClickType`, add `WorkingDirectory()` getter to `Model` interface
- **collapsed_view.go**: Extract `titleSectionLines()` to share layout logic between `LineCount()` and click detection
- **hittest.go**: Add `TargetSidebarWorkingDir` mouse target
- **input_handlers.go**: Handle working dir click by copying to clipboard with notification
- **title_edit_test.go**: Add tests for working dir click detection in both vertical and collapsed modes