### PR TITLE
Use ResultSuccess/ResultError helpers in tasks and user_prompt tools

### DIFF
--- a/pkg/tools/builtin/tasks.go
+++ b/pkg/tools/builtin/tasks.go
@@ -459,9 +459,7 @@ func (t *TasksTool) nextTask(_ context.Context, _ tools.ToolCall) (*tools.ToolCa
 		}
 	}
 
-	return &tools.ToolCallResult{
-		Output: "No actionable tasks. Everything is either done or blocked.",
-	}, nil
+	return tools.ResultSuccess("No actionable tasks. Everything is either done or blocked."), nil
 }
 
 func (t *TasksTool) addDependency(_ context.Context, params AddDependencyArgs) (*tools.ToolCallResult, error) {

--- a/pkg/tools/builtin/user_prompt.go
+++ b/pkg/tools/builtin/user_prompt.go
@@ -74,10 +74,7 @@ func (t *UserPromptTool) userPrompt(ctx context.Context, params UserPromptArgs) 
 	}
 
 	if result.Action != tools.ElicitationActionAccept {
-		return &tools.ToolCallResult{
-			Output:  string(responseJSON),
-			IsError: true,
-		}, nil
+		return tools.ResultError(string(responseJSON)), nil
 	}
 
 	return tools.ResultSuccess(string(responseJSON)), nil


### PR DESCRIPTION
Replace raw `ToolCallResult` struct literals with the `ResultSuccess` and `ResultError` helper functions in `nextTask` (tasks.go) and `userPrompt` (user_prompt.go) for consistency with the rest of the codebase.

- **tasks.go**: `nextTask` now returns `tools.ResultSuccess(...)` instead of a bare `&tools.ToolCallResult{Output: ...}`
- **user_prompt.go**: The decline/cancel path now returns `tools.ResultError(...)` instead of `&tools.ToolCallResult{Output: ..., IsError: true}`

No behavioral change — linter and tests pass.