### PR TITLE
fix: move registerDefaultTools to constructor to prevent concurrent map writes

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -311,6 +311,11 @@ func NewLocalRuntime(agents *team.Team, opts ...Opt) (*LocalRuntime, error) {
 
 	r.sessionCompactor = newSessionCompactor(model, r.sessionStore)
 
+	// Register runtime-managed tool handlers once during construction.
+	// This avoids concurrent map writes when multiple goroutines call
+	// RunStream on the same runtime (e.g. background agent sessions).
+	r.registerDefaultTools()
+
 	slog.Debug("Creating new runtime", "agent", r.currentAgent, "available_agents", agents.Size())
 
 	return r, nil


### PR DESCRIPTION
## Problem

`registerDefaultTools()` was called inside the `RunStream()` goroutine, which writes to the plain `map[string]ToolHandlerFunc` field `r.toolMap`. When multiple goroutines call `RunStream` on the same `LocalRuntime` concurrently (e.g. background agent sessions), this causes a `fatal error: concurrent map writes` panic.

## Fix

Move the `r.registerDefaultTools()` call from `RunStream()` to `NewLocalRuntime()`, so the map is fully populated during single-threaded construction. All subsequent accesses in `processToolCalls` are read-only, which is safe for concurrent goroutines.

## Why this is safe

- The handlers are method values on `*LocalRuntime` and never change.
- `r.bgAgents` is already initialized before `registerDefaultTools()` is called.
- No other code writes to `r.toolMap` after construction.