### PR TITLE
fix: support Gemini 3.x versioned models (e.g., gemini-3.1-pro-preview)

### DIFF
--- a/pkg/model/provider/gemini/client.go
+++ b/pkg/model/provider/gemini/client.go
@@ -359,7 +359,7 @@ func (c *Client) buildConfig() *genai.GenerateContentConfig {
 	// is returned.
 	if thinking := c.ModelOptions.Thinking(); thinking != nil && !*thinking {
 		model := strings.ToLower(c.ModelConfig.Model)
-		if strings.HasPrefix(model, "gemini-3-") {
+		if isGemini3PlusModel(model) {
 			// Gemini 3 models require thinking — they reject ThinkingBudget=0.
 			// Use the lowest level instead and bump MaxOutputTokens so that
 			// even a tiny caller budget (e.g. 20 for title generation) leaves
@@ -414,8 +414,8 @@ func (c *Client) applyThinkingConfig(config *genai.GenerateContentConfig) {
 
 	model := strings.ToLower(c.ModelConfig.Model)
 
-	// Gemini 3 models use ThinkingLevel (effort-based)
-	if strings.HasPrefix(model, "gemini-3-") {
+	// Gemini 3+ models use ThinkingLevel (effort-based)
+	if isGemini3PlusModel(model) {
 		c.applyGemini3ThinkingLevel(config)
 		return
 	}
@@ -773,4 +773,17 @@ func providerOption(cfg *latest.ModelConfig, name string) string {
 		return v
 	}
 	return ""
+}
+
+// isGemini3PlusModel returns true if the lowercased model name is a Gemini 3+
+// model. It matches both "gemini-3-<family>" and "gemini-3.X-<family>" patterns.
+// NOTE: keep in sync with gemini3Family in pkg/model/provider/provider.go.
+func isGemini3PlusModel(model string) bool {
+	if !strings.HasPrefix(model, "gemini-3") {
+		return false
+	}
+	rest := model[len("gemini-3"):]
+	// "gemini-3-pro" → rest = "-pro"
+	// "gemini-3.1-flash" → rest = ".1-flash"
+	return rest != "" && (rest[0] == '-' || (rest[0] == '.' && strings.Contains(rest, "-")))
 }

--- a/pkg/model/provider/gemini/client_test.go
+++ b/pkg/model/provider/gemini/client_test.go
@@ -139,6 +139,18 @@ func TestBuildConfig_Gemini3_ThinkingLevel(t *testing.T) {
 			thinkingBudget:      &latest.ThinkingBudget{Effort: "medium"},
 			expectThinkingLevel: genai.ThinkingLevelMedium,
 		},
+		{
+			name:                "gemini-3.1-pro-preview with high thinking level",
+			model:               "gemini-3.1-pro-preview",
+			thinkingBudget:      &latest.ThinkingBudget{Effort: "high"},
+			expectThinkingLevel: genai.ThinkingLevelHigh,
+		},
+		{
+			name:                "gemini-3.1-flash-preview with medium thinking level",
+			model:               "gemini-3.1-flash-preview",
+			thinkingBudget:      &latest.ThinkingBudget{Effort: "medium"},
+			expectThinkingLevel: genai.ThinkingLevelMedium,
+		},
 	}
 
 	for _, tt := range tests {
@@ -310,6 +322,20 @@ func TestBuildConfig_ThinkingExplicitlyDisabled(t *testing.T) {
 			name:               "gemini-3-pro with nil thinking budget but disabled via options",
 			model:              "gemini-3-pro",
 			thinkingBudget:     nil, // Even without explicit budget, Gemini 3 may use thinking by default
+			expectLevelLow:     true,
+			expectMinMaxTokens: 200,
+		},
+		{
+			name:               "gemini-3.1-pro-preview with thinking budget but disabled via options",
+			model:              "gemini-3.1-pro-preview",
+			thinkingBudget:     &latest.ThinkingBudget{Effort: "high"},
+			expectLevelLow:     true,
+			expectMinMaxTokens: 200,
+		},
+		{
+			name:               "gemini-3.1-flash-preview with thinking budget but disabled via options",
+			model:              "gemini-3.1-flash-preview",
+			thinkingBudget:     &latest.ThinkingBudget{Effort: "medium"},
 			expectLevelLow:     true,
 			expectMinMaxTokens: 200,
 		},

--- a/pkg/model/provider/gemini/model_helpers_test.go
+++ b/pkg/model/provider/gemini/model_helpers_test.go
@@ -1,0 +1,33 @@
+package gemini
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsGemini3PlusModel(t *testing.T) {
+	t.Parallel()
+
+	match := []string{
+		"gemini-3-pro", "gemini-3-pro-preview",
+		"gemini-3-flash", "gemini-3-flash-preview",
+		"gemini-3.1-pro-preview", "gemini-3.1-flash-preview",
+		"gemini-3.5-pro", "gemini-3.5-flash",
+	}
+	noMatch := []string{
+		"gemini-2.5-flash", "gemini-2.5-pro", "gemini-2.0-flash",
+		"gemini-1.5-pro", "gpt-4o", "claude-sonnet-4-0",
+		"gemini-3",      // no trailing separator
+		"gemini-30-pro", // "0" ≠ '-' or '.'
+		"gemini-3.",     // dot with no version digit or dash
+		"gemini-3.1",    // dot-version but no trailing dash
+	}
+
+	for _, m := range match {
+		assert.True(t, isGemini3PlusModel(m), "%q should match", m)
+	}
+	for _, m := range noMatch {
+		assert.False(t, isGemini3PlusModel(m), "%q should not match", m)
+	}
+}

--- a/pkg/model/provider/model_defaults_test.go
+++ b/pkg/model/provider/model_defaults_test.go
@@ -260,6 +260,14 @@ func TestApplyModelDefaults_Google(t *testing.T) {
 			expectThinkingBudget: &latest.ThinkingBudget{Effort: "high"},
 		},
 		{
+			name: "gemini-3.1-pro-preview gets high thinking level default",
+			config: &latest.ModelConfig{
+				Provider: "google",
+				Model:    "gemini-3.1-pro-preview",
+			},
+			expectThinkingBudget: &latest.ThinkingBudget{Effort: "high"},
+		},
+		{
 			name: "gemini-3-flash gets medium thinking level default",
 			config: &latest.ModelConfig{
 				Provider: "google",
@@ -272,6 +280,14 @@ func TestApplyModelDefaults_Google(t *testing.T) {
 			config: &latest.ModelConfig{
 				Provider: "google",
 				Model:    "gemini-3-flash-preview",
+			},
+			expectThinkingBudget: &latest.ThinkingBudget{Effort: "medium"},
+		},
+		{
+			name: "gemini-3.1-flash-preview gets medium thinking level default",
+			config: &latest.ModelConfig{
+				Provider: "google",
+				Model:    "gemini-3.1-flash-preview",
 			},
 			expectThinkingBudget: &latest.ThinkingBudget{Effort: "medium"},
 		},

--- a/pkg/model/provider/model_helpers_test.go
+++ b/pkg/model/provider/model_helpers_test.go
@@ -1,0 +1,74 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGemini3Family(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		model  string
+		family string
+	}{
+		// Gemini 3 models
+		{"gemini-3-pro", "pro"},
+		{"gemini-3-pro-preview", "pro-preview"},
+		{"gemini-3-flash", "flash"},
+		{"gemini-3-flash-preview", "flash-preview"},
+
+		// Gemini 3.x models
+		{"gemini-3.1-pro-preview", "pro-preview"},
+		{"gemini-3.1-flash-preview", "flash-preview"},
+		{"gemini-3.5-pro", "pro"},
+		{"gemini-3.5-flash", "flash"},
+
+		// Non-matching models → empty family
+		{"gemini-2.5-flash", ""},
+		{"gemini-2.5-pro", ""},
+		{"gemini-2.0-flash", ""},
+		{"gemini-1.5-pro", ""},
+		{"gpt-4o", ""},
+		{"gemini-3", ""},      // No trailing separator
+		{"gemini-30-pro", ""}, // "0" is not '.' or '-'
+		{"gemini-3.", ""},     // dot with no version digit or dash
+		{"gemini-3.1", ""},    // dot-version but no trailing dash
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.family, gemini3Family(tt.model))
+		})
+	}
+}
+
+func TestIsGeminiProModel(t *testing.T) {
+	t.Parallel()
+
+	pro := []string{"gemini-3-pro", "gemini-3-pro-preview", "gemini-3.1-pro-preview", "gemini-3.5-pro"}
+	notPro := []string{"gemini-3-flash", "gemini-3.1-flash-preview", "gemini-2.5-pro", "gpt-4o"}
+
+	for _, m := range pro {
+		assert.True(t, isGeminiProModel(m), "%q should be pro", m)
+	}
+	for _, m := range notPro {
+		assert.False(t, isGeminiProModel(m), "%q should not be pro", m)
+	}
+}
+
+func TestIsGeminiFlashModel(t *testing.T) {
+	t.Parallel()
+
+	flash := []string{"gemini-3-flash", "gemini-3-flash-preview", "gemini-3.1-flash-preview", "gemini-3.5-flash"}
+	notFlash := []string{"gemini-3-pro", "gemini-3.1-pro-preview", "gemini-2.5-flash", "gpt-4o"}
+
+	for _, m := range flash {
+		assert.True(t, isGeminiFlashModel(m), "%q should be flash", m)
+	}
+	for _, m := range notFlash {
+		assert.False(t, isGeminiFlashModel(m), "%q should not be flash", m)
+	}
+}

--- a/pkg/model/provider/provider.go
+++ b/pkg/model/provider/provider.go
@@ -494,8 +494,8 @@ func applyAnthropicDefaults(cfg *latest.ModelConfig) {
 
 // applyGoogleDefaults applies default configuration for Google Gemini models.
 // - Gemini 2.5 models: thinking_budget = -1 (dynamic thinking)
-// - Gemini 3 Pro models: thinking_budget effort = "high"
-// - Gemini 3 Flash models: thinking_budget effort = "medium"
+// - Gemini 3+ Pro models: thinking_budget effort = "high"
+// - Gemini 3+ Flash models: thinking_budget effort = "medium"
 func applyGoogleDefaults(cfg *latest.ModelConfig) {
 	if cfg.ThinkingBudget != nil {
 		return // User explicitly set thinking_budget
@@ -512,24 +512,61 @@ func applyGoogleDefaults(cfg *latest.ModelConfig) {
 			"model", cfg.Model,
 			"thinking_budget", -1,
 		)
-	case strings.HasPrefix(model, "gemini-3-pro"):
-		// Gemini 3 Pro models use level-based thinking (high)
+	case isGeminiProModel(model):
+		// Gemini 3+ Pro models use level-based thinking (high)
 		cfg.ThinkingBudget = &latest.ThinkingBudget{Effort: "high"}
-		slog.Debug("Applied default thinking_budget for Google Gemini 3 Pro",
+		slog.Debug("Applied default thinking_budget for Google Gemini 3+ Pro",
 			"provider", cfg.Provider,
 			"model", cfg.Model,
 			"thinking_budget", "high",
 		)
-	case strings.HasPrefix(model, "gemini-3-flash"):
-		// Gemini 3 Flash models use level-based thinking (medium)
+	case isGeminiFlashModel(model):
+		// Gemini 3+ Flash models use level-based thinking (medium)
 		cfg.ThinkingBudget = &latest.ThinkingBudget{Effort: "medium"}
-		slog.Debug("Applied default thinking_budget for Google Gemini 3 Flash",
+		slog.Debug("Applied default thinking_budget for Google Gemini 3+ Flash",
 			"provider", cfg.Provider,
 			"model", cfg.Model,
 			"thinking_budget", "medium",
 		)
 	}
 	// For other Gemini models (e.g., gemini-2.0-*), leave unchanged
+}
+
+// gemini3Family extracts the model family (e.g. "pro", "flash") from a
+// Gemini 3+ model name, or returns "" if the model is not Gemini 3+.
+// It handles both "gemini-3-<family>" and "gemini-3.X-<family>" patterns.
+//
+// Examples:
+//
+//	gemini3Family("gemini-3-pro")              → "pro"
+//	gemini3Family("gemini-3.1-flash-preview")  → "flash-preview"
+//	gemini3Family("gemini-2.5-flash")          → ""
+func gemini3Family(model string) string {
+	if !strings.HasPrefix(model, "gemini-3") {
+		return ""
+	}
+	rest := model[len("gemini-3"):]
+	if rest == "" {
+		return ""
+	}
+	// Accept "gemini-3-..." or "gemini-3.X-..." (e.g. gemini-3.1-pro-preview)
+	switch rest[0] {
+	case '-':
+		return rest[1:] // "gemini-3-pro" → "pro"
+	case '.':
+		if _, family, ok := strings.Cut(rest, "-"); ok {
+			return family // "gemini-3.1-pro-preview" → "pro-preview"
+		}
+	}
+	return ""
+}
+
+func isGeminiProModel(model string) bool {
+	return strings.HasPrefix(gemini3Family(model), "pro")
+}
+
+func isGeminiFlashModel(model string) bool {
+	return strings.HasPrefix(gemini3Family(model), "flash")
 }
 
 // applyBedrockDefaults applies default configuration for Amazon Bedrock models.


### PR DESCRIPTION
## Problem

Gemini 3.x versioned models (e.g., `gemini-3.1-pro-preview`, `gemini-3.1-flash-preview`) were not recognized by the model prefix matching logic, which only checked for the `gemini-3-` prefix. This caused:

1. **No default thinking budget** applied for these models
2. **Wrong thinking config type** (token-based instead of level-based)
3. **Thinking couldn't be properly reduced** when explicitly disabled

## Solution

Replace hardcoded `strings.HasPrefix(model, "gemini-3-")` checks with flexible helper functions that match both `gemini-3-*` and `gemini-3.X-*` patterns:

- **`gemini3Family(model)`** in the provider package — parses the model family (`"pro"`, `"flash"`, etc.) from Gemini 3+ model names
- **`isGeminiProModel()`** / **`isGeminiFlashModel()`** — one-liner predicates for default selection
- **`isGemini3PlusModel()`** in the gemini package — predicate for thinking config routing

## Changes

- `pkg/model/provider/provider.go` — added `gemini3Family()`, `isGeminiProModel()`, `isGeminiFlashModel()`; updated `applyGoogleDefaults()`
- `pkg/model/provider/gemini/client.go` — added `isGemini3PlusModel()`; updated `buildConfig()` and `applyThinkingConfig()`
- New unit tests for all helpers and integration tests for `gemini-3.1-*` models

Fixes #2051