### PR TITLE
Configure cache to be used for incremental go build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,8 @@ FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS b
 COPY --from=xx / /
 RUN apk add --no-cache clang zig
 WORKDIR /src
+COPY go.mod go.sum ./
 RUN --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=bind,source=go.mod,target=go.mod \
-    --mount=type=bind,source=go.sum,target=go.sum \
     go mod download
 ENV CGO_ENABLED=1
 
@@ -26,6 +25,7 @@ ARG TARGETOS
 ARG TARGETARCH
 RUN --mount=type=cache,target=/var/cache/apk,id=apk-$TARGETPLATFORM,sharing=locked \
     xx-apk add musl-dev
+
 COPY . ./
 ARG GIT_TAG
 ARG GIT_COMMIT


### PR DESCRIPTION
Could not get cache mount to work for go build, cf https://github.com/moby/buildkit/issues/1512
Also tried https://github.com/reproducible-containers/buildkit-cache-dance/tree/v3.3.2/ with action/cache with no results (+ exporting cache was adding 1 min to build)

Finally simply adds Docker layers for go mod download