### PR TITLE
doc: document {ORIGINAL_INSTRUCTIONS} placeholder for toolset instructions

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -739,7 +739,7 @@
         },
         "instruction": {
           "type": "string",
-          "description": "Optional instruction for the tools"
+          "description": "Custom instruction for this MCP server's tools. By default, setting this field replaces the toolset's built-in instructions entirely. To enrich (rather than replace) the original instructions, include the placeholder {ORIGINAL_INSTRUCTIONS} in your text — it will be substituted with the toolset's built-in instructions at runtime. For example: '{ORIGINAL_INSTRUCTIONS}\nAlways prefer JSON output.' will prepend the original instructions and append your extra guidance."
         },
         "name": {
           "type": "string",
@@ -809,7 +809,7 @@
         },
         "instruction": {
           "type": "string",
-          "description": "Additional instruction on how to use this toolset"
+          "description": "Custom instruction for this toolset. By default, setting this field replaces the toolset's built-in instructions entirely. To enrich (rather than replace) the original instructions, include the placeholder {ORIGINAL_INSTRUCTIONS} in your text — it will be substituted with the toolset's built-in instructions at runtime. For example: '{ORIGINAL_INSTRUCTIONS}\nAlways prefer JSON output.' will prepend the original instructions and append your extra guidance."
         },
         "toon": {
           "type": "string",

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,6 +18,7 @@ Some of these agents use [built-in tools](../docs/index.html#configuration/tools
 | [mem.yaml](mem.yaml)                   | Humorous AI with persistent memory     | ✓          |       |      |       | ✓      |             |            |
 | [diag.yaml](diag.yaml)                 | Log analysis and diagnostics           | ✓          | ✓     |      | ✓     |        |             |            |
 | [todo.yaml](todo.yaml)                 | Task manager example                   |            |       | ✓    |       |        |             |            |
+| [toolset_instructions.yaml](toolset_instructions.yaml) | Enriching toolset instructions with `{ORIGINAL_INSTRUCTIONS}` | ✓ | ✓ |      |       |        |             |            |
 | [pythonista.yaml](pythonista.yaml)     | Python programming assistant           | ✓          | ✓     |      |       |        |             |            |
 | [fetch_docker.yaml](fetch_docker.yaml) | Web content fetcher and summarizer     |            |       |      |       |        | fetch (builtin) |        |
 | [alloy.yaml](alloy.yaml)               | Learning assistant                     |            |       |      |       |        |             |            |

--- a/examples/toolset_instructions.yaml
+++ b/examples/toolset_instructions.yaml
@@ -1,0 +1,57 @@
+#!/usr/bin/env docker agent run
+
+# This example demonstrates how to use {ORIGINAL_INSTRUCTIONS} in a
+# toolset instruction to *enrich* the built-in instructions instead of
+# replacing them.
+#
+# Every toolset ships with default instructions that guide the agent on
+# how to use its tools effectively (e.g., the filesystem toolset
+# explains security restrictions and performance tips). When you set
+# the `instruction` field on a toolset, by default that text *replaces*
+# the built-in instructions entirely.
+#
+# If you want to keep the original guidance and just add your own rules
+# on top, include the placeholder {ORIGINAL_INSTRUCTIONS} anywhere in
+# your instruction text. At runtime it will be substituted with the
+# toolset's built-in instructions, so the agent sees both.
+#
+# Three patterns:
+#
+#   1. Enrich (prepend originals, append yours):
+#        instruction: |
+#          {ORIGINAL_INSTRUCTIONS}
+#          Never delete files without asking.
+#
+#   2. Enrich (prepend yours, append originals):
+#        instruction: |
+#          Important: only touch files under ./src.
+#          {ORIGINAL_INSTRUCTIONS}
+#
+#   3. Replace (omit the placeholder entirely):
+#        instruction: |
+#          Only read Markdown files.
+
+agents:
+  root:
+    model: openai/gpt-4o
+    description: A coding assistant with enriched toolset instructions
+    instruction: |
+      You are a helpful coding assistant.
+    toolsets:
+      # ── Filesystem: enrich the built-in instructions ──────────
+      - type: filesystem
+        instruction: |
+          {ORIGINAL_INSTRUCTIONS}
+
+          ## Project-specific rules
+          - Never modify files outside the `src/` directory.
+          - Always create a backup before overwriting a file.
+
+      # ── Shell: enrich the built-in instructions ───────────────
+      - type: shell
+        instruction: |
+          {ORIGINAL_INSTRUCTIONS}
+
+          ## Extra safety rules
+          - Never run `rm -rf` commands.
+          - Always use `--dry-run` when available.


### PR DESCRIPTION
## Summary

Document how to use `{ORIGINAL_INSTRUCTIONS}` in a toolset `instruction` field to **enrich** the built-in instructions rather than replacing them.

## Changes

- **agent-schema.json**: Updated the `instruction` field description for both `Toolset` and `MCPToolset` to explain the `{ORIGINAL_INSTRUCTIONS}` placeholder and its behavior.
- **examples/toolset_instructions.yaml**: New example demonstrating the three usage patterns:
  1. Enrich by appending custom rules after the originals
  2. Enrich by prepending custom rules before the originals
  3. Full replacement (omit the placeholder)
- **examples/README.md**: Added the new example to the Basic Configurations table.