### PR TITLE
gitignore cagent-* binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ vendor
 # Local environment files
 .env.local
 .claude/settings.local.json
+
+# CI-downloaded binaries (cagent-action places these in the workspace root)
+/cagent
+/cagent-*
+/docker-mcp-*


### PR DESCRIPTION
## Summary

The `auto-issue-triage` workflow's `git add -A` step was picking up the `cagent` binary (~89 MB) downloaded by `cagent-action` into the workspace root, committing it to fix branches. This adds `.gitignore` entries for CI-downloaded binaries so they are never staged.

Closes: https://github.com/docker/gordon/issues/202

## Changes

- Add `/cagent` and `/cagent-*` to `.gitignore` to exclude the main agent binary and its platform-specific variants (e.g., `cagent-linux-amd64`)
- Add `/docker-mcp-*` to exclude MCP Gateway binaries downloaded during CI runs
- Patterns are root-anchored (`/`) to avoid matching source files in subdirectories

## Test plan

- [ ] Verify `git status` no longer shows the `cagent` binary after running `cagent-action` locally
- [ ] Trigger the `auto-issue-triage` workflow on a test issue with `kind/bug` label and confirm the fix commit does not include any binaries