### PR TITLE
Fix MCP env var check skipped when any gateway preflight errors

### DIFF
--- a/pkg/config/gather.go
+++ b/pkg/config/gather.go
@@ -33,10 +33,12 @@ func gatherMissingEnvVars(ctx context.Context, cfg *latest.Config, modelsGateway
 	if err != nil {
 		// Store tool preflight error but continue checking models
 		toolErr = err
-	} else {
-		for _, e := range names {
-			requiredEnv[e] = true
-		}
+	}
+	// Always add tool env vars, even when some toolsets had preflight errors.
+	// Previously, a preflight error from one toolset would cause all tool
+	// env vars to be silently skipped.
+	for _, e := range names {
+		requiredEnv[e] = true
 	}
 
 	for _, e := range sortedKeys(requiredEnv) {


### PR DESCRIPTION
When GatherEnvVarsForTools returned a preflight error for any MCP toolset, the successfully-gathered env var names from other toolsets were silently discarded because they were only processed in the else branch. This meant configs with multiple MCP refs (where at least one gateway call failed) would bypass all tool env var validation.

Assisted-By: docker-agent