### PR TITLE
Only send the delta on the partial tool call

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"cmp"
 	"context"
 	"encoding/base64"
 	"errors"
@@ -997,12 +998,24 @@ func (a *App) mergeEvents(events []tea.Msg) []tea.Msg {
 			result = append(result, merged)
 
 		case *runtime.PartialToolCallEvent:
-			// For PartialToolCallEvent, keep only the latest one per tool call ID
-			// Only merge consecutive events with the same ID
+			// For PartialToolCallEvent, merge consecutive events with the same tool call ID
+			// by concatenating argument deltas
 			latest := ev
 			for i+1 < len(events) {
 				if next, ok := events[i+1].(*runtime.PartialToolCallEvent); ok && next.ToolCall.ID == ev.ToolCall.ID {
-					latest = next
+					latest = &runtime.PartialToolCallEvent{
+						Type: ev.Type,
+						ToolCall: tools.ToolCall{
+							ID:   ev.ToolCall.ID,
+							Type: ev.ToolCall.Type,
+							Function: tools.FunctionCall{
+								Name:      cmp.Or(next.ToolCall.Function.Name, latest.ToolCall.Function.Name),
+								Arguments: latest.ToolCall.Function.Arguments + next.ToolCall.Function.Arguments,
+							},
+						},
+						ToolDefinition: cmp.Or(latest.ToolDefinition, next.ToolDefinition),
+						AgentContext:   ev.AgentContext,
+					}
 					i++
 				} else {
 					break

--- a/pkg/runtime/event.go
+++ b/pkg/runtime/event.go
@@ -64,15 +64,20 @@ func UserMessage(message, sessionID string, multiContent []chat.MessagePart, ses
 type PartialToolCallEvent struct {
 	Type           string         `json:"type"`
 	ToolCall       tools.ToolCall `json:"tool_call"`
-	ToolDefinition tools.Tool     `json:"tool_definition"`
+	ToolDefinition *tools.Tool    `json:"tool_definition,omitempty"`
 	AgentContext
 }
 
 func PartialToolCall(toolCall tools.ToolCall, toolDefinition tools.Tool, agentName string) Event {
+	var toolDef *tools.Tool
+	if toolDefinition.Name != "" {
+		def := toolDefinition
+		toolDef = &def
+	}
 	return &PartialToolCallEvent{
 		Type:           "partial_tool_call",
 		ToolCall:       toolCall,
-		ToolDefinition: toolDefinition,
+		ToolDefinition: toolDef,
 		AgentContext:   newAgentContext(agentName),
 	}
 }

--- a/pkg/runtime/runtime_response_api_test.go
+++ b/pkg/runtime/runtime_response_api_test.go
@@ -1,11 +1,13 @@
 package runtime
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/tools"
 )
 
 // TestResponseAPIToolCallHandling verifies that tool calls from the Response API
@@ -73,4 +75,58 @@ func TestResponseAPIMultipleToolCalls(t *testing.T) {
 		}
 	}
 	require.ElementsMatch(t, []string{"search", "calculate"}, toolCalls, "Expected both tool calls")
+}
+
+func TestPartialToolCallEventsContainOnlyNewArgumentBytes(t *testing.T) {
+	stream := newStreamBuilder().
+		AddToolCallName("call_abc", "write_file").
+		AddToolCallArguments("call_abc", `{"path":"story.md"`).
+		AddToolCallArguments("call_abc", `,"content":"Once upon a time"}`).
+		AddStopWithUsage(10, 15).
+		Build()
+
+	sess := session.New(session.WithUserMessage("Write a story"))
+	events := runSession(t, sess, stream)
+
+	var partials []*PartialToolCallEvent
+	for _, event := range events {
+		if ev, ok := event.(*PartialToolCallEvent); ok {
+			partials = append(partials, ev)
+		}
+	}
+
+	require.Len(t, partials, 3)
+	require.Equal(t, "write_file", partials[0].ToolCall.Function.Name)
+	require.Empty(t, partials[0].ToolCall.Function.Arguments)
+	require.Equal(t, `{"path":"story.md"`, partials[1].ToolCall.Function.Arguments) //nolint:testifylint // testifylint wants us to use require.JSONEq  but the expected value is not valid JSON
+	require.Nil(t, partials[1].ToolDefinition)
+	require.Equal(t, `,"content":"Once upon a time"}`, partials[2].ToolCall.Function.Arguments)
+	require.Nil(t, partials[2].ToolDefinition)
+
+	secondJSON, err := json.Marshal(partials[1])
+	require.NoError(t, err)
+	require.NotContains(t, string(secondJSON), `"tool_definition"`)
+}
+
+func TestPartialToolCallEventJSONIncludesToolDefinitionOnlyWhenPresent(t *testing.T) {
+	toolDef := &tools.Tool{Name: "write_file", Description: "Create file"}
+	withDef := &PartialToolCallEvent{
+		Type:           "partial_tool_call",
+		ToolCall:       tools.ToolCall{ID: "call_1", Type: "function", Function: tools.FunctionCall{Name: "write_file"}},
+		ToolDefinition: toolDef,
+		AgentContext:   newAgentContext("root"),
+	}
+	withoutDef := &PartialToolCallEvent{
+		Type:         "partial_tool_call",
+		ToolCall:     tools.ToolCall{ID: "call_1", Type: "function", Function: tools.FunctionCall{Name: "write_file", Arguments: `{"path":"story.md"}`}},
+		AgentContext: newAgentContext("root"),
+	}
+
+	withDefJSON, err := json.Marshal(withDef)
+	require.NoError(t, err)
+	require.Contains(t, string(withDefJSON), `"tool_definition"`)
+
+	withoutDefJSON, err := json.Marshal(withoutDef)
+	require.NoError(t, err)
+	require.NotContains(t, string(withoutDefJSON), `"tool_definition"`)
 }

--- a/pkg/runtime/streaming.go
+++ b/pkg/runtime/streaming.go
@@ -144,10 +144,25 @@ func (r *LocalRuntime) handleStream(ctx context.Context, stream chat.MessageStre
 					tc.Function.Arguments += delta.Function.Arguments
 				}
 
-				// Emit PartialToolCall once we have a name, and on subsequent argument deltas
+				// Emit PartialToolCall once we have a name, and on subsequent argument deltas.
+				// Only the newly received argument bytes are sent, not the full
+				// accumulated arguments, to avoid re-transmitting the entire payload
+				// on every token.
 				if tc.Function.Name != "" && (learningName || delta.Function.Arguments != "") {
 					if !emittedPartial[delta.ID] || delta.Function.Arguments != "" {
-						events <- PartialToolCall(*tc, toolDefMap[tc.Function.Name], a.Name())
+						partial := tools.ToolCall{
+							ID:   tc.ID,
+							Type: tc.Type,
+							Function: tools.FunctionCall{
+								Name:      tc.Function.Name,
+								Arguments: delta.Function.Arguments,
+							},
+						}
+						toolDef := tools.Tool{}
+						if !emittedPartial[delta.ID] {
+							toolDef = toolDefMap[tc.Function.Name]
+						}
+						events <- PartialToolCall(partial, toolDef, a.Name())
 						emittedPartial[delta.ID] = true
 					}
 				}

--- a/pkg/tui/components/messages/messages.go
+++ b/pkg/tui/components/messages/messages.go
@@ -1301,7 +1301,11 @@ func (m *model) AddOrUpdateToolCall(agentName string, toolCall tools.ToolCall, t
 		if msg.Type == types.MessageTypeToolCall && msg.ToolCall.ID == toolCall.ID {
 			msg.ToolStatus = status
 			if toolCall.Function.Arguments != "" {
-				msg.ToolCall.Function.Arguments = toolCall.Function.Arguments
+				if status == types.ToolStatusPending {
+					msg.ToolCall.Function.Arguments += toolCall.Function.Arguments
+				} else {
+					msg.ToolCall.Function.Arguments = toolCall.Function.Arguments
+				}
 			}
 			m.invalidateItem(i)
 			return nil

--- a/pkg/tui/components/reasoningblock/reasoningblock.go
+++ b/pkg/tui/components/reasoningblock/reasoningblock.go
@@ -206,7 +206,11 @@ func (m *Model) UpdateToolCall(toolCallID string, status types.ToolStatus, args 
 		}
 		entry.msg.ToolStatus = status
 		if args != "" {
-			entry.msg.ToolCall.Function.Arguments = args
+			if status == types.ToolStatusPending {
+				entry.msg.ToolCall.Function.Arguments += args
+			} else {
+				entry.msg.ToolCall.Function.Arguments = args
+			}
 		}
 		m.toolEntries[i] = entry
 		return

--- a/pkg/tui/page/chat/runtime_events.go
+++ b/pkg/tui/page/chat/runtime_events.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/sound"
+	"github.com/docker/docker-agent/pkg/tools"
 	"github.com/docker/docker-agent/pkg/tui/components/notification"
 	"github.com/docker/docker-agent/pkg/tui/components/sidebar"
 	"github.com/docker/docker-agent/pkg/tui/core"
@@ -273,7 +274,11 @@ func (p *chatPage) handleStreamStopped(msg *runtime.StreamStoppedEvent) tea.Cmd 
 // "pending" indicator (not animated) to show it's receiving data.
 func (p *chatPage) handlePartialToolCall(msg *runtime.PartialToolCallEvent) tea.Cmd {
 	p.setPendingResponse(false)
-	toolCmd := p.messages.AddOrUpdateToolCall(msg.AgentName, msg.ToolCall, msg.ToolDefinition, types.ToolStatusPending)
+	var toolDef tools.Tool
+	if msg.ToolDefinition != nil {
+		toolDef = *msg.ToolDefinition
+	}
+	toolCmd := p.messages.AddOrUpdateToolCall(msg.AgentName, msg.ToolCall, toolDef, types.ToolStatusPending)
 	return tea.Batch(toolCmd, p.messages.ScrollToBottom())
 }
 


### PR DESCRIPTION
Only sends the delta arguments received on each partial tool call. We used to send the whole accumulated tool call arguemnts, which is dumb, the clients should handle accumulation if they care.

Also added sending the tool definition only on the first partial too call