### PR TITLE
Fix frozen spinner during MCP tool loading

### DIFF
--- a/pkg/tui/page/chat/runtime_events.go
+++ b/pkg/tui/page/chat/runtime_events.go
@@ -120,9 +120,8 @@ func (p *chatPage) handleRuntimeEvent(msg tea.Msg) (bool, tea.Cmd) {
 		return true, nil
 
 	case *runtime.ToolsetInfoEvent:
-		p.sidebar.SetToolsetInfo(msg.AvailableTools, msg.Loading)
 		p.sidebar.SetSkillsInfo(len(p.app.CurrentAgentSkills()))
-		return true, nil
+		return true, p.forwardToSidebar(msg)
 
 	case *runtime.SessionTitleEvent:
 		return true, p.forwardToSidebar(msg)


### PR DESCRIPTION
When MCP tools take a bit of time to start, the TUI feels irresponsive because it starts showing a spinner next to the number of tools but the spinner is frozen in spinning state until the final number of tools is received.

Assisted-By: docker-agent