### PR TITLE
docs: fix binary download URLs to match release artifact naming

### DIFF
--- a/docs/getting-started/installation/index.md
+++ b/docs/getting-started/installation/index.md
@@ -49,8 +49,10 @@ Download [prebuilt binary releases](https://github.com/docker/docker-agent/relea
 ### macOS / Linux
 
 ```bash
-# Download the latest release (adjust URL for your platform)
-curl -L https://github.com/docker/docker-agent/releases/latest/download/docker-agent-$(uname -s)-$(uname -m) -o docker-agent
+# Download the latest release
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m); case "$ARCH" in x86_64) ARCH=amd64;; aarch64) ARCH=arm64;; esac
+curl -L "https://github.com/docker/docker-agent/releases/latest/download/docker-agent-${OS}-${ARCH}" -o docker-agent
 chmod +x docker-agent
 sudo mv docker-agent /usr/local/bin/
 docker-agent version
@@ -63,7 +65,7 @@ docker agent version
 
 ### Windows
 
-Download `docker-agent-Windows-amd64.exe` from the [releases page](https://github.com/docker/docker-agent/releases), rename it to `docker-agent.exe` and add it to your PATH. Alternatively you can move it to `~/.docker/cli-plugins`
+Download `docker-agent-windows-amd64.exe` from the [releases page](https://github.com/docker/docker-agent/releases), rename it to `docker-agent.exe` and add it to your PATH. Alternatively you can move it to `~/.docker/cli-plugins`
 
 ## Build from Source
 


### PR DESCRIPTION
## Problem

The installation guide's download script used `$(uname -s)-$(uname -m)` which produces OS/arch values like `Linux-x86_64`, but the release binaries use Go's `GOOS-GOARCH` convention (e.g. `linux-amd64`). This made the download command fail on Linux (and potentially other platforms).

## Fix

- Map `uname -s` to lowercase (`Linux` → `linux`, `Darwin` → `darwin`)
- Map `uname -m` to Go arch names (`x86_64` → `amd64`, `aarch64` → `arm64`)
- Fix Windows section to reference `docker-agent-windows-amd64.exe` (lowercase)

Fixes #2117