### PR TITLE
Log selected model in Agent.Model() for alloy observability

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -132,13 +132,16 @@ func (a *Agent) HasSubAgents() bool {
 // Otherwise, it returns a random model from the available models.
 func (a *Agent) Model() provider.Provider {
 	var selected provider.Provider
+	var poolSize int
 	// Check for model override first (set via TUI model switching)
 	if overrides := a.modelOverrides.Load(); overrides != nil && len(*overrides) > 0 {
 		selected = (*overrides)[rand.Intn(len(*overrides))]
+		poolSize = len(*overrides)
 	} else {
 		selected = a.models[rand.Intn(len(a.models))]
+		poolSize = len(a.models)
 	}
-	slog.Info("Model selected", "agent", a.name, "model", selected.ID(), "pool_size", len(a.models))
+	slog.Info("Model selected", "agent", a.name, "model", selected.ID(), "pool_size", poolSize)
 	return selected
 }
 

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -155,12 +155,26 @@ func TestModel_LogsSelection(t *testing.T) {
 
 	a := New("scanner", "test", WithModel(model1), WithModel(model2))
 
-	_ = a.Model()
+	// Verify basic selection logging
+	selected := a.Model()
 	logOutput := buf.String()
 
 	assert.Contains(t, logOutput, "Model selected")
 	assert.Contains(t, logOutput, "agent=scanner")
+	assert.Contains(t, logOutput, selected.ID())
 	assert.Contains(t, logOutput, "pool_size=2")
+
+	// Verify override scenario logs correct pool_size
+	buf.Reset()
+	override := &mockProvider{id: "google/gemini-2.0-flash"}
+	a.SetModelOverride(override)
+
+	selected = a.Model()
+	logOutput = buf.String()
+
+	assert.Equal(t, "google/gemini-2.0-flash", selected.ID())
+	assert.Contains(t, logOutput, "google/gemini-2.0-flash")
+	assert.Contains(t, logOutput, "pool_size=1")
 }
 
 func TestModelOverride_ConcurrentAccess(t *testing.T) {


### PR DESCRIPTION
## Summary
- Adds `slog.Info("Model selected", ...)` to `Agent.Model()` so the chosen `provider/model` ID and pool size are logged on every model selection
- Enables correlating which model handled each agent turn in the verbose log artifact, without needing API provider dashboard access
- Particularly useful for alloy configurations where models are randomly selected — `pool_size > 1` indicates alloy was in play

## Motivation
Model usage metrics (model name, tokens, cost) are already tracked via telemetry events through the Marlin → Snowflake → Sigma pipeline, but that data is aggregate — useful for dashboarding trends, not for debugging a specific run.

This change surfaces model selection **inline with the agent conversation** in the verbose log artifact, making it possible to see exactly which model handled each agent turn during a particular workflow run. Different use case: debugging a specific run vs. dashboarding trends.

## Test plan
- [x] Existing `TestModelOverride` and `TestModelOverride_ConcurrentAccess` pass
- [x] New `TestModel_LogsSelection` verifies the log line contains agent name, "Model selected" message, and correct pool size
- [ ] Verify log lines appear in verbose artifact on a real workflow run

Closes https://github.com/docker/gordon/issues/236