### PR TITLE
Reject unknown thinking_budget effort levels at parse time

### DIFF
--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -683,6 +683,20 @@ type ThinkingBudget struct {
 	Tokens int `json:"tokens,omitempty"`
 }
 
+// validThinkingEfforts lists all accepted string values for thinking_budget.
+const validThinkingEfforts = "none, minimal, low, medium, high, max, adaptive"
+
+// isValidThinkingEffort reports whether s (case-insensitive, trimmed) is a
+// recognised thinking_budget effort level.
+func isValidThinkingEffort(s string) bool {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "none", "minimal", "low", "medium", "high", "max", "adaptive":
+		return true
+	default:
+		return false
+	}
+}
+
 func (t *ThinkingBudget) UnmarshalYAML(unmarshal func(any) error) error {
 	// Try integer tokens first
 	var n int
@@ -694,6 +708,9 @@ func (t *ThinkingBudget) UnmarshalYAML(unmarshal func(any) error) error {
 	// Try string level
 	var s string
 	if err := unmarshal(&s); err == nil {
+		if !isValidThinkingEffort(s) {
+			return fmt.Errorf("invalid thinking_budget effort %q: must be one of %s", s, validThinkingEfforts)
+		}
 		*t = ThinkingBudget{Effort: s}
 		return nil
 	}
@@ -793,6 +810,9 @@ func (t *ThinkingBudget) UnmarshalJSON(data []byte) error {
 	// Try string level
 	var s string
 	if err := json.Unmarshal(data, &s); err == nil {
+		if !isValidThinkingEffort(s) {
+			return fmt.Errorf("invalid thinking_budget effort %q: must be one of %s", s, validThinkingEfforts)
+		}
 		*t = ThinkingBudget{Effort: s}
 		return nil
 	}

--- a/pkg/config/latest/types_test.go
+++ b/pkg/config/latest/types_test.go
@@ -1,6 +1,7 @@
 package latest
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/goccy/go-yaml"
@@ -142,6 +143,32 @@ func TestThinkingBudget_IsDisabled(t *testing.T) {
 			require.Equal(t, tt.want, tt.b.IsDisabled())
 		})
 	}
+}
+
+func TestThinkingBudget_UnmarshalYAML_InvalidEffort(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`thinking_budget: adaptative`)
+	var config struct {
+		ThinkingBudget *ThinkingBudget `yaml:"thinking_budget"`
+	}
+
+	err := yaml.Unmarshal(input, &config)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `invalid thinking_budget effort "adaptative"`)
+}
+
+func TestThinkingBudget_UnmarshalJSON_InvalidEffort(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`{"thinking_budget": "adaptative"}`)
+	var config struct {
+		ThinkingBudget *ThinkingBudget `json:"thinking_budget"`
+	}
+
+	err := json.Unmarshal(data, &config)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `invalid thinking_budget effort "adaptative"`)
 }
 
 func TestThinkingBudget_IsAdaptive(t *testing.T) {


### PR DESCRIPTION
Previously, a typo like 'thinking_budget: adaptative' was silently accepted but no provider recognized it, so thinking was never enabled. Now the YAML and JSON unmarshalers validate the effort string against the set of accepted values (none, minimal, low, medium, high, max, adaptive) and return a clear error on unrecognized input.

Assisted-By: docker-agent