### PR TITLE
feat: support "exit" as a keyword to quit the session

### DIFF
--- a/pkg/tui/commands/commands.go
+++ b/pkg/tui/commands/commands.go
@@ -108,6 +108,26 @@ func builtInSessionCommands() []Item {
 			},
 		},
 		{
+			ID:           "session.quit",
+			Label:        "Quit",
+			SlashCommand: "/quit",
+			Description:  "Quit the application (alias for /exit)",
+			Category:     "Session",
+			Execute: func(string) tea.Cmd {
+				return core.CmdHandler(messages.ExitSessionMsg{})
+			},
+		},
+		{
+			ID:           "session.q",
+			Label:        "Quit (short)",
+			SlashCommand: "/q",
+			Description:  "Quit the application (alias for /exit)",
+			Category:     "Session",
+			Execute: func(string) tea.Cmd {
+				return core.CmdHandler(messages.ExitSessionMsg{})
+			},
+		},
+		{
 			ID:           "session.export",
 			Label:        "Export",
 			SlashCommand: "/export",

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -624,9 +624,10 @@ func (p *chatPage) cancelStream(showCancelMessage bool) tea.Cmd {
 // handleSendMsg handles incoming messages from the editor, either processing
 // them immediately or queuing them if the agent is busy.
 func (p *chatPage) handleSendMsg(msg msgtypes.SendMsg) (layout.Model, tea.Cmd) {
-	// Handle "exit" as a special keyword to quit the session immediately,
-	// equivalent to the /exit slash command.
-	if strings.TrimSpace(strings.ToLower(msg.Content)) == "exit" {
+	// Handle "exit", "quit", and ":q" as special keywords to quit the session
+	// immediately, equivalent to the /exit slash command.
+	switch strings.TrimSpace(msg.Content) {
+	case "exit", "quit", ":q":
 		return p, core.CmdHandler(msgtypes.ExitSessionMsg{})
 	}
 


### PR DESCRIPTION
## Summary

- Typing `exit`, `quit`, or `:q` in the TUI now terminates the session immediately, equivalent to the `/exit` slash command.
- Added `/quit` and `/q` as slash command aliases for `/exit`.
- The bare keyword check is case-sensitive and whitespace-trimmed, matching [opencode's behavior](https://github.com/anomalyco/opencode).
- Works even when the agent is busy (the check runs before queue logic in `handleSendMsg`).