### PR TITLE
Add run instructions to creator agent prompt

### DIFF
--- a/pkg/creator/instructions.txt
+++ b/pkg/creator/instructions.txt
@@ -183,3 +183,11 @@ agents:
     toolsets:
       - type: filesystem
 ```
+
+## Running the Generated Agent
+
+After writing the YAML file, tell the user to run their agent with:
+
+```console
+docker agent run <file.yaml>
+```


### PR DESCRIPTION
The creator agent had no instructions on how to tell users to run their generated agent, causing it to hallucinate incorrect commands like `docker agent start file.yaml`.

This adds a "Running the Generated Agent" section to `pkg/creator/instructions.txt` that explicitly tells the creator agent to instruct users to run with:

```console
docker agent run <file.yaml>
```