### PR TITLE
Fix gpt-5-chat-latest model not supported error

### DIFF
--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -903,6 +903,10 @@ func isResponsesModel(model string) bool {
 
 func isOpenAIReasoningModel(model string) bool {
 	m := strings.ToLower(model)
+	// Exclude -chat-latest variants which don't support reasoning parameters
+	if strings.Contains(m, "-chat-latest") {
+		return false
+	}
 	return strings.HasPrefix(m, "o1") ||
 		strings.HasPrefix(m, "o3") ||
 		strings.HasPrefix(m, "o4") ||

--- a/pkg/model/provider/openai/thinking_budget_test.go
+++ b/pkg/model/provider/openai/thinking_budget_test.go
@@ -40,6 +40,11 @@ func TestIsOpenAIReasoningModel(t *testing.T) {
 		{"gpt-5-turbo", "gpt-5-turbo", true},
 		{"GPT-5 uppercase", "GPT-5", true},
 
+		// GPT-5 -chat-latest variants - should NOT support reasoning
+		{"gpt-5-chat-latest", "gpt-5-chat-latest", false},
+		{"gpt-5-chat-latest with suffix", "gpt-5-chat-latest-2025-10-01", false},
+		{"GPT-5-CHAT-LATEST uppercase", "GPT-5-CHAT-LATEST", false},
+
 		// GPT-4 series models - should NOT support reasoning
 		{"gpt-4", "gpt-4", false},
 		{"gpt-4o", "gpt-4o", false},


### PR DESCRIPTION
## Description

Fixes issue #2166 where the `gpt-5-chat-latest` model was incorrectly treated as a reasoning model, causing a 400 Bad Request error due to the unsupported `reasoning.summary` parameter.

## Root Cause

The `isOpenAIReasoningModel()` function in `pkg/model/provider/openai/client.go` was returning `true` for all models starting with `gpt-5`, but the `-chat-latest` variants are non-reasoning models that don't support the `reasoning.summary` parameter.

## Changes

### pkg/model/provider/openai/client.go
- Updated `isOpenAIReasoningModel()` to exclude models containing `-chat-latest` in their name
- Added comment explaining the exclusion

### pkg/model/provider/openai/thinking_budget_test.go
- Added test cases for `gpt-5-chat-latest` and similar variants to ensure they're correctly identified as non-reasoning models

## Verification

- ✅ All existing tests pass
- ✅ New test cases for `gpt-5-chat-latest` variants pass
- ✅ Race detector tests pass (`go test -race`)
- ✅ go vet passes with no issues
- ✅ gosec security scan passes
- ✅ Code is properly formatted (gofmt)

## Testing

The fix was verified with:
- Unit tests for `TestIsOpenAIReasoningModel` including new test cases
- Full test suite (`go test ./... -short`)
- Race detector (`go test -race`)
- Security scanning with gosec

## Related Issue

Fixes #2166