### PR TITLE
docs: clarify think tool is for models without native reasoning

### DIFF
--- a/docs/concepts/multi-agent/index.md
+++ b/docs/concepts/multi-agent/index.md
@@ -211,7 +211,7 @@ toolsets:
 - **Keep agents focused** — Each agent should have a clear, narrow role
 - **Write clear descriptions** — The coordinator uses descriptions to decide who to delegate to
 - **Give minimal tools** — Only give each agent the tools it needs for its specific role
-- **Use the think tool** — Give coordinators the think tool so they reason about delegation
+- **Use the think tool when needed** — For models without native reasoning, give coordinators the think tool so they reason about delegation. Models with built-in thinking (e.g., via `thinking_budget`) don't need it
 - **Use the right model** — Use capable models for complex reasoning, cheap models for simple tasks
 
 <div class="callout callout-info">

--- a/docs/guides/tips/index.md
+++ b/docs/guides/tips/index.md
@@ -169,16 +169,16 @@ agents:
 - Order by preference (best first)
 - Include a cheaper/faster model as last resort
 
-### Use Think Tool for Complex Tasks
+### Use Think Tool for Non-Reasoning Models
 
-The `think` tool dramatically improves reasoning quality with minimal overhead:
+The `think` tool provides a reasoning scratchpad for models that lack built-in thinking capabilities:
 
 ```yaml
 toolsets:
-  - type: think # Always include for complex agents
+  - type: think # Useful for models without native reasoning
 ```
 
-The agent uses it as a scratchpad for planning and decision-making.
+The agent uses it as a scratchpad for planning and decision-making. If your model already supports a [thinking budget]({{ '/configuration/models/#thinking-budget' | relative_url }}) (e.g., Claude with extended thinking, OpenAI o-series, Gemini with thinking enabled), you don't need this tool — the model can reason internally.
 
 ## Security Tips
 

--- a/docs/tools/think/index.md
+++ b/docs/tools/think/index.md
@@ -12,7 +12,7 @@ _Step-by-step reasoning scratchpad for planning and decision-making._
 
 The think tool is a reasoning scratchpad that lets agents think step-by-step before acting. The agent can write its thoughts without producing visible output to the user — ideal for planning complex tasks, breaking down problems, and reasoning through multi-step solutions.
 
-This is a lightweight tool with no side effects. It's recommended for all agents — it improves the quality of reasoning on complex tasks at minimal cost.
+This is a lightweight tool with no side effects. It is most useful for models that lack built-in reasoning or thinking capabilities (e.g., smaller or older models). For models that already support native thinking — such as Claude with extended thinking, OpenAI o-series, or Gemini with a thinking budget — this tool is unnecessary since the model can reason internally.
 
 ## Configuration
 
@@ -24,7 +24,7 @@ toolsets:
 No configuration options.
 
 <div class="callout callout-tip">
-<div class="callout-title">💡 Tip
+<div class="callout-title">💡 When to use
 </div>
-  <p>Include the think tool in every agent. It adds minimal overhead while significantly improving reasoning quality on complex tasks.</p>
+  <p>Use the think tool with models that don't have native reasoning capabilities. If your model already supports a <a href="{{ '/configuration/models/#thinking-budget' | relative_url }}">thinking budget</a>, you likely don't need this tool.</p>
 </div>


### PR DESCRIPTION
The documentation previously recommended including the think tool in every agent. In reality, it is only useful for models that lack built-in reasoning capabilities (e.g., smaller or older models). Models with native thinking — such as Claude with extended thinking, OpenAI o-series, or Gemini with a thinking budget — do not need it.

### Changes

- **docs/tools/think**: reword overview and tip to explain when to use it
- **docs/guides/tips**: rename section and clarify it targets non-reasoning models
- **docs/concepts/multi-agent**: qualify the best-practice bullet as conditional

Fixes #2190