### PR TITLE
Remove model alias resolution for inline agent model references

### DIFF
--- a/pkg/config/model_alias.go
+++ b/pkg/config/model_alias.go
@@ -44,28 +44,6 @@ func ResolveModelAliases(ctx context.Context, cfg *latest.Config, store *modelsd
 		}
 		cfg.Models[name] = modelCfg
 	}
-
-	// Resolve inline model references in agents (e.g., "anthropic/claude-sonnet-4-5")
-	for _, agent := range cfg.Agents {
-		if agent.Model == "" || agent.Model == "auto" {
-			continue
-		}
-
-		var resolvedModels []string
-		for modelRef := range strings.SplitSeq(agent.Model, ",") {
-			if provider, model, ok := strings.Cut(modelRef, "/"); ok {
-				if resolved := store.ResolveModelAlias(ctx, provider, model); resolved != model {
-					resolvedModels = append(resolvedModels, provider+"/"+resolved)
-					continue
-				}
-			}
-			resolvedModels = append(resolvedModels, modelRef)
-		}
-
-		cfg.Agents.Update(agent.Name, func(a *latest.AgentConfig) {
-			a.Model = strings.Join(resolvedModels, ",")
-		})
-	}
 }
 
 // hasCustomBaseURL checks if a model config has a custom base_url, either directly

--- a/pkg/config/model_alias_test.go
+++ b/pkg/config/model_alias_test.go
@@ -45,7 +45,7 @@ func TestResolveModelAliases(t *testing.T) {
 			},
 		},
 		{
-			name: "resolves inline model in agent",
+			name: "does not resolve inline model in agent",
 			cfg: &latest.Config{
 				Models: map[string]latest.ModelConfig{},
 				Agents: []latest.AgentConfig{
@@ -55,7 +55,7 @@ func TestResolveModelAliases(t *testing.T) {
 			expected: &latest.Config{
 				Models: map[string]latest.ModelConfig{},
 				Agents: []latest.AgentConfig{
-					{Name: "root", Model: "anthropic/claude-sonnet-4-5-20250929"},
+					{Name: "root", Model: "anthropic/claude-sonnet-4-5"},
 				},
 			},
 		},
@@ -107,7 +107,7 @@ func TestResolveModelAliases(t *testing.T) {
 			},
 		},
 		{
-			name: "handles comma-separated models",
+			name: "does not resolve comma-separated inline models in agent",
 			cfg: &latest.Config{
 				Models: map[string]latest.ModelConfig{},
 				Agents: []latest.AgentConfig{
@@ -117,7 +117,7 @@ func TestResolveModelAliases(t *testing.T) {
 			expected: &latest.Config{
 				Models: map[string]latest.ModelConfig{},
 				Agents: []latest.AgentConfig{
-					{Name: "root", Model: "anthropic/claude-sonnet-4-5-20250929,my_ref"},
+					{Name: "root", Model: "anthropic/claude-sonnet-4-5,my_ref"},
 				},
 			},
 		},


### PR DESCRIPTION
This avoids seeing e.g. `claude-haiku-4-5-20251001` when using inline mode `anthropic/claude-haiku-4-5`.

Assisted-By: docker-agent