### PR TITLE
feat(runtime): add auto-stop for max iterations in non-interactive mode

### DIFF
--- a/pkg/a2a/adapter.go
+++ b/pkg/a2a/adapter.go
@@ -49,6 +49,7 @@ func runDockerAgent(ctx agent.InvocationContext, t *team.Team, agentName string,
 			session.WithMaxConsecutiveToolCalls(a.MaxConsecutiveToolCalls()),
 			session.WithMaxOldToolCallTokens(a.MaxOldToolCallTokens()),
 			session.WithToolsApproved(true),
+			session.WithNonInteractive(true),
 		)
 
 		// Create runtime

--- a/pkg/evaluation/save.go
+++ b/pkg/evaluation/save.go
@@ -59,6 +59,7 @@ func SessionFromEvents(events []map[string]any, title string, questions []string
 	sess := session.New(
 		session.WithTitle(title),
 		session.WithToolsApproved(true),
+		session.WithNonInteractive(true),
 	)
 
 	// Add user questions as initial messages.

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -164,6 +164,7 @@ func CreateToolHandler(t *team.Team, agentName string) func(context.Context, *mc
 			session.WithMaxOldToolCallTokens(ag.MaxOldToolCallTokens()),
 			session.WithUserMessage(input.Message),
 			session.WithToolsApproved(true),
+			session.WithNonInteractive(true),
 		)
 
 		rt, err := runtime.New(t,

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -175,6 +175,24 @@ func (r *LocalRuntime) RunStream(ctx context.Context, sess *session.Session) <-c
 				r.executeNotificationHooks(ctx, a, sess.ID, "warning", maxIterMsg)
 				r.executeOnUserInputHooks(ctx, sess.ID, "max iterations reached")
 
+				// In non-interactive mode (e.g. MCP server), auto-stop instead of
+				// blocking forever waiting for user input.
+				if sess.ToolsApproved {
+					slog.Debug("Auto-stopping after max iterations (non-interactive)", "agent", a.Name())
+
+					assistantMessage := chat.Message{
+						Role: chat.MessageRoleAssistant,
+						Content: fmt.Sprintf(
+							"Execution stopped after reaching the configured max_iterations limit (%d).",
+							runtimeMaxIterations,
+						),
+						CreatedAt: time.Now().Format(time.RFC3339),
+					}
+
+					addAgentMessage(sess, a, &assistantMessage, events)
+					return
+				}
+
 				// Wait for user decision (resume / reject)
 				select {
 				case req := <-r.resumeChan:

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -177,7 +177,7 @@ func (r *LocalRuntime) RunStream(ctx context.Context, sess *session.Session) <-c
 
 				// In non-interactive mode (e.g. MCP server), auto-stop instead of
 				// blocking forever waiting for user input.
-				if sess.ToolsApproved {
+				if sess.NonInteractive {
 					slog.Debug("Auto-stopping after max iterations (non-interactive)", "agent", a.Name())
 
 					assistantMessage := chat.Message{

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -76,6 +76,12 @@ type Session struct {
 	// ToolsApproved is a flag to indicate if the tools have been approved
 	ToolsApproved bool `json:"tools_approved"`
 
+	// NonInteractive indicates the session is running in a non-interactive context
+	// (e.g. MCP server, A2A adapter, evaluation framework) where there is no user
+	// to provide input. This is distinct from ToolsApproved which can also be set
+	// in interactive TUI sessions when a user approves all tools.
+	NonInteractive bool `json:"non_interactive,omitempty"`
+
 	// HideToolResults is a flag to indicate if tool results should be hidden
 	HideToolResults bool `json:"hide_tool_results"`
 
@@ -473,6 +479,12 @@ func WithTitle(title string) Opt {
 func WithToolsApproved(toolsApproved bool) Opt {
 	return func(s *Session) {
 		s.ToolsApproved = toolsApproved
+	}
+}
+
+func WithNonInteractive(nonInteractive bool) Opt {
+	return func(s *Session) {
+		s.NonInteractive = nonInteractive
 	}
 }
 


### PR DESCRIPTION
When max iterations are reached in non-interactive mode (e.g., MCP server), the runtime now automatically stops execution instead of blocking indefinitely waiting for user input. This prevents the system from hanging when `ToolsApproved` is true and provides a clear assistant message explaining why execution was stopped.