### PR TITLE
Enable bodyclose, makezero, and sqlclosecheck linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -63,6 +63,9 @@ linters:
     - usetesting
     - whitespace
     - wastedassign
+    - bodyclose
+    - makezero
+    - sqlclosecheck
   settings:
     forbidigo:
       forbid:

--- a/pkg/audio/transcribe/transcribe_darwin.go
+++ b/pkg/audio/transcribe/transcribe_darwin.go
@@ -67,7 +67,7 @@ func (t *Transcriber) Start(ctx context.Context, handler TranscriptHandler) erro
 	t.cancel = cancel
 
 	// Connect to OpenAI Realtime API
-	conn, _, err := websocket.DefaultDialer.DialContext(ctx, openAIRealtimeURL, http.Header{
+	conn, _, err := websocket.DefaultDialer.DialContext(ctx, openAIRealtimeURL, http.Header{ //nolint:bodyclose // websocket upgrade response
 		"Authorization": []string{"Bearer " + t.apiKey},
 		"OpenAI-Beta":   []string{"realtime=v1"},
 	})

--- a/pkg/model/provider/oaistream/middleware_test.go
+++ b/pkg/model/provider/oaistream/middleware_test.go
@@ -102,6 +102,7 @@ func TestErrorBodyMiddleware(t *testing.T) {
 
 		resp, err := middleware(req, next)
 		require.NoError(t, err)
+		defer resp.Body.Close()
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	})
 
@@ -121,6 +122,7 @@ func TestErrorBodyMiddleware(t *testing.T) {
 
 		resp, err := middleware(req, next)
 		require.NoError(t, err)
+		defer resp.Body.Close()
 		assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
 
 		body, err := io.ReadAll(resp.Body)
@@ -144,6 +146,7 @@ func TestErrorBodyMiddleware(t *testing.T) {
 
 		resp, err := middleware(req, next)
 		require.NoError(t, err)
+		defer resp.Body.Close()
 		assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
 
 		body, err := io.ReadAll(resp.Body)
@@ -167,6 +170,7 @@ func TestErrorBodyMiddleware(t *testing.T) {
 
 		resp, err := middleware(req, next)
 		require.NoError(t, err)
+		defer resp.Body.Close()
 		assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
 
 		body, err := io.ReadAll(resp.Body)
@@ -191,6 +195,7 @@ func TestErrorBodyMiddleware(t *testing.T) {
 
 		resp, err := middleware(req, next)
 		require.NoError(t, err)
+		defer resp.Body.Close()
 
 		body, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)

--- a/pkg/runtime/client.go
+++ b/pkg/runtime/client.go
@@ -311,7 +311,7 @@ func (c *Client) runAgentWithAgentName(ctx context.Context, sessionID, agent, ag
 	req.Header.Set("Accept", "text/event-stream")
 	req.Header.Set("Cache-Control", "no-cache")
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.httpClient.Do(req) //nolint:bodyclose // body is closed in the goroutine below
 	if err != nil {
 		return nil, fmt.Errorf("performing request: %w", err)
 	}

--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -680,6 +680,7 @@ func (s *SQLiteSessionStore) loadSessionItemsWith(ctx context.Context, q querier
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 
 	// First, collect all raw row data so we can close the result set
 	// before making any recursive calls (SQLite doesn't allow concurrent queries)
@@ -687,16 +688,13 @@ func (s *SQLiteSessionStore) loadSessionItemsWith(ctx context.Context, q querier
 	for rows.Next() {
 		var row sessionItemRow
 		if err := rows.Scan(&row.position, &row.itemType, &row.agentName, &row.messageJSON, &row.implicit, &row.subsessionID, &row.summaryText); err != nil {
-			rows.Close()
 			return nil, err
 		}
 		rawRows = append(rawRows, row)
 	}
 	if err := rows.Err(); err != nil {
-		rows.Close()
 		return nil, err
 	}
-	rows.Close()
 
 	if len(rawRows) == 0 {
 		return nil, nil

--- a/pkg/tools/builtin/tasks.go
+++ b/pkg/tools/builtin/tasks.go
@@ -155,8 +155,8 @@ func effectiveStatus(task Task, tasks map[string]Task) TaskStatus {
 
 func hasCycle(tasks map[string]Task, startID string, deps []string) bool {
 	visited := make(map[string]bool)
-	stack := make([]string, len(deps))
-	copy(stack, deps)
+	stack := make([]string, 0, len(deps))
+	stack = append(stack, deps...)
 	for len(stack) > 0 {
 		current := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]


### PR DESCRIPTION
Add three new linters to golangci-lint configuration and fix all reported issues:

- **bodyclose**: ensure HTTP response bodies are closed in tests; add nolint for false positives (websocket upgrade, goroutine-deferred close)
- **makezero**: use make+append instead of make+copy in `hasCycle`
- **sqlclosecheck**: use `defer rows.Close()` instead of manual close calls