### PR TITLE
docs: add max_old_tool_call_tokens and max_consecutive_tool_calls to agent config reference

### DIFF
--- a/docs/configuration/agents/index.md
+++ b/docs/configuration/agents/index.md
@@ -30,6 +30,8 @@ agents:
     add_description_parameter: bool # Optional: add description to tool schema
     code_mode_tools: boolean # Optional: enable code mode tool format
     max_iterations: int # Optional: max tool-calling loops
+    max_consecutive_tool_calls: int # Optional: max identical consecutive tool calls
+    max_old_tool_call_tokens: int # Optional: token budget for old tool call content
     num_history_items: int # Optional: limit conversation history
     skills: boolean # Optional: enable skill discovery
     commands: # Optional: named prompts
@@ -72,6 +74,8 @@ agents:
 | `add_description_parameter` | boolean | ✗        | When `true`, adds agent descriptions as a parameter in tool schemas. Helps with tool selection in multi-agent scenarios.                                                      |
 | `code_mode_tools`           | boolean | ✗        | When `true`, formats tool responses in a code-optimized format with structured output schemas. Useful for MCP gateway and programmatic access.                                |
 | `max_iterations`            | int     | ✗        | Maximum number of tool-calling loops. Default: unlimited (0). Set this to prevent infinite loops.                                                                             |
+| `max_consecutive_tool_calls` | int     | ✗        | Maximum consecutive identical tool calls before the agent is terminated, preventing degenerate loops. Default: `5`.                                                          |
+| `max_old_tool_call_tokens`  | int     | ✗        | Maximum number of tokens to keep from old tool call arguments and results. Older tool calls beyond this budget have their content replaced with a placeholder, saving context space. Tokens are approximated as `len/4`. Set to `-1` to disable truncation (unlimited). Default: `40000`. |
 | `num_history_items`         | int     | ✗        | Limit the number of conversation history messages sent to the model. Useful for managing context window size with long conversations. Default: unlimited (all messages sent). |
 | `rag`                       | array   | ✗        | List of RAG source names to attach to this agent. References sources defined in the top-level `rag` section. See [RAG]({{ '/features/rag/' | relative_url }}).                                       |
 | `skills`                    | boolean | ✗        | Enable automatic skill discovery from standard directories.                                                                                                                   |


### PR DESCRIPTION
Fixes #2228

Adds documentation for `max_old_tool_call_tokens` and `max_consecutive_tool_calls` to the agent configuration reference page:

- Added both properties to the YAML schema block
- Added both properties to the properties reference table with descriptions and defaults
  - `max_old_tool_call_tokens`: default `40000`, set to `-1` to disable truncation
  - `max_consecutive_tool_calls`: default `5`