### PR TITLE
update cagent-action to latest (with better permissions)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,22 +1,26 @@
 name: PR Review
-
 on:
-  issue_comment:
+  issue_comment: # Enables /review command in PR comments
     types: [created]
-  pull_request_review_comment:
+  pull_request_review_comment: # Captures feedback on review comments for learning
     types: [created]
-  pull_request_target:
+  pull_request: # Triggers auto-review on PR open (same-repo branches only; fork PRs use /review)
     types: [ready_for_review, opened]
 
 permissions:
-  contents: read
+  contents: read # Required at top-level to give `issue_comment` events access to the secrets below.
 
 jobs:
   review:
-    uses: docker/cagent-action/.github/workflows/review-pr.yml@3a12dbd0c6cd7dda3d4e05f24f0143c9701456de # latest (v1.2.13)
+    uses: docker/cagent-action/.github/workflows/review-pr.yml@dba0ca51938c78afb363625363c50582243218d6 # v1.3.1
+    # Scoped to the job so other jobs in this workflow aren't over-permissioned
     permissions:
-      contents: read
-      pull-requests: write
-      issues: write
-      checks: write
-    secrets: inherit
+      contents: read # Read repository files and PR diffs
+      pull-requests: write # Post review comments and approve/request changes
+      issues: write # Create security incident issues if secrets are detected in output
+      checks: write # (Optional) Show review progress as a check run on the PR
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      CAGENT_ORG_MEMBERSHIP_TOKEN: ${{ secrets.CAGENT_ORG_MEMBERSHIP_TOKEN }} # PAT with read:org scope; gates auto-reviews to org members only
+      CAGENT_REVIEWER_APP_ID: ${{ secrets.CAGENT_REVIEWER_APP_ID }} # GitHub App ID; reviews appear as your app instead of github-actions[bot]
+      CAGENT_REVIEWER_APP_PRIVATE_KEY: ${{ secrets.CAGENT_REVIEWER_APP_PRIVATE_KEY }} # GitHub App private key; paired with App ID above


### PR DESCRIPTION
## Summary

Hardens the PR Review workflow by pinning cagent-action to `v1.3.1` (from `v1.2.13`), switching from `pull_request_target` to `pull_request` for safer secret handling, and explicitly passing only the secrets the reusable workflow needs instead of `secrets: inherit`.

Closes: https://github.com/docker/gordon/issues/281

## Changes

- **Pinned workflow version**: Updated `docker/cagent-action` from `@3a12dbd` (`v1.2.13`) to `@dba0ca5` (`v1.3.1`).
- **Trigger change**: Replaced `pull_request_target` with `pull_request` — auto-reviews now run only for same-repo branches (fork PRs use the `/review` command via `issue_comment`).
- **Scoped permissions**: Added inline comments explaining each permission. Added a job-level scoping comment for clarity.
- **Explicit secrets**: Replaced `secrets: inherit` with individually named secrets (`ANTHROPIC_API_KEY`, `CAGENT_ORG_MEMBERSHIP_TOKEN`, `CAGENT_REVIEWER_APP_ID`, `CAGENT_REVIEWER_APP_PRIVATE_KEY`), reducing exposure of unrelated repository secrets.
- **Inline documentation**: Added comments explaining each trigger, permission, and secret for future maintainers.

## Test plan

- Open or re-open a PR against `main` and verify the review workflow triggers automatically.
- Post a `/review` comment on a PR and verify the workflow triggers via `issue_comment`.
- Confirm review comments appear under the configured GitHub App identity (not `github-actions[bot]`).