### PR TITLE
fix: strip CacheControl from messages during compaction

### DIFF
--- a/pkg/compaction/compaction.go
+++ b/pkg/compaction/compaction.go
@@ -65,6 +65,7 @@ func BuildPrompt(messages []chat.Message, additionalPrompt string) []chat.Messag
 	for i, msg := range messages {
 		cloned := msg
 		cloned.Cost = 0
+		cloned.CacheControl = false
 		out[i] = cloned
 	}
 	out = append(out, chat.Message{

--- a/pkg/compaction/compaction_test.go
+++ b/pkg/compaction/compaction_test.go
@@ -268,6 +268,26 @@ func TestBuildPrompt(t *testing.T) {
 		assert.InDelta(t, 0.05, original[0].Cost, 1e-9)
 		assert.Len(t, original, 1)
 	})
+
+	t.Run("strips CacheControl from cloned messages", func(t *testing.T) {
+		t.Parallel()
+
+		input := []chat.Message{
+			{Role: chat.MessageRoleSystem, Content: "system", CacheControl: true},
+			{Role: chat.MessageRoleSystem, Content: "context", CacheControl: true},
+			{Role: chat.MessageRoleUser, Content: "hello"},
+		}
+
+		out := BuildPrompt(input, "")
+
+		// All cloned messages should have CacheControl=false
+		for i, msg := range out {
+			assert.False(t, msg.CacheControl, "message %d should have CacheControl stripped", i)
+		}
+		// Original should be unchanged
+		assert.True(t, input[0].CacheControl)
+		assert.True(t, input[1].CacheControl)
+	})
 }
 
 func TestPromptsAreEmbedded(t *testing.T) {


### PR DESCRIPTION
When compaction runs, `doCompact` calls `sess.GetMessages(a)` which returns messages with `CacheControl=true` on the last invariant and last context system messages. These markers were preserved through `compaction.BuildPrompt` into the summarization session, which then added its own system message marker plus 2 more from `applyMessageCacheControl`, totaling 5 cache control breakpoints — exceeding Anthropic's limit of 4.

**Fix:** Strip `CacheControl` from cloned messages in `BuildPrompt`, just like `Cost` is already zeroed.