### PR TITLE
Reset tool loop detector after degenerate loop error

### DIFF
--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -352,6 +352,7 @@ func (r *LocalRuntime) RunStream(ctx context.Context, sess *session.Session) <-c
 					loopDetector.consecutive, toolName)
 				events <- Error(errMsg)
 				r.executeNotificationHooks(ctx, a, sess.ID, "error", errMsg)
+				loopDetector.reset()
 				return
 			}
 

--- a/pkg/runtime/tool_loop_detector.go
+++ b/pkg/runtime/tool_loop_detector.go
@@ -24,6 +24,12 @@ func newToolLoopDetector(threshold int) *toolLoopDetector {
 	return &toolLoopDetector{threshold: threshold}
 }
 
+// reset clears the detector state so it can be reused after recovery.
+func (d *toolLoopDetector) reset() {
+	d.lastSignature = ""
+	d.consecutive = 0
+}
+
 // record updates the detector with the latest tool call batch and returns
 // true if the consecutive-duplicate threshold has been reached.
 func (d *toolLoopDetector) record(calls []tools.ToolCall) bool {


### PR DESCRIPTION
When a degenerate tool call loop is detected, reset the loop detector so that the user can resume the conversation without immediately hitting the same error on the next tool call.