### PR TITLE
Fix desktop proxy socket name on WSL

### DIFF
--- a/pkg/desktop/sockets_darwin.go
+++ b/pkg/desktop/sockets_darwin.go
@@ -18,3 +18,7 @@ func getDockerDesktopPaths() (DockerDesktopPaths, error) {
 		ProxySocket:   filepath.Join(data, "httpproxy.sock"),
 	}, nil
 }
+
+func IsWSL() bool {
+	return false
+}

--- a/pkg/desktop/sockets_linux.go
+++ b/pkg/desktop/sockets_linux.go
@@ -20,16 +20,11 @@ func getDockerDesktopPaths() (DockerDesktopPaths, error) {
 		return DockerDesktopPaths{}, err
 	}
 
-	if _, err = os.Stat("/mnt/wsl/docker-desktop/shared-sockets/host-services/backend.sock"); err == nil {
-		// Inside WSL2
+	if IsWSL() {
 		return DockerDesktopPaths{
 			BackendSocket: "/mnt/wsl/docker-desktop/shared-sockets/host-services/backend.sock",
 			ProxySocket:   "/mnt/wsl/docker-desktop/shared-sockets/host-services/http-proxy.sock",
 		}, nil
-	}
-
-	if !errors.Is(err, os.ErrNotExist) {
-		return DockerDesktopPaths{}, err
 	}
 
 	home, err := os.UserHomeDir()
@@ -42,4 +37,11 @@ func getDockerDesktopPaths() (DockerDesktopPaths, error) {
 		BackendSocket: filepath.Join(home, ".docker", "desktop", "backend.sock"),
 		ProxySocket:   filepath.Join(home, ".docker", "desktop", "httpproxy.sock"),
 	}, nil
+}
+
+func IsWSL() bool {
+	if _, err := os.Stat("/mnt/wsl/docker-desktop/shared-sockets/host-services/backend.sock"); err == nil {
+		return true
+	}
+	return false
 }

--- a/pkg/desktop/sockets_windows.go
+++ b/pkg/desktop/sockets_windows.go
@@ -16,3 +16,7 @@ func getDockerDesktopPaths() (DockerDesktopPaths, error) {
 		ProxySocket:   `\\.\pipe\dockerHTTPProxy`,
 	}, nil
 }
+
+func IsWSL() bool {
+	return false
+}

--- a/pkg/remote/transport.go
+++ b/pkg/remote/transport.go
@@ -29,7 +29,7 @@ func NewTransport(ctx context.Context) http.RoundTripper {
 	if err != nil {
 		return transport
 	}
-	if running, ok := desktopRunning.(bool); ok && running {
+	if running, ok := desktopRunning.(bool); ok && running && !desktop.IsWSL() {
 		transport.Proxy = http.ProxyURL(&url.URL{
 			Scheme: "http",
 		})


### PR DESCRIPTION
desktop http-proxy socket is not allowed to users in WSL, bypassing the desktop proxy form WSL