### PR TITLE
Add Calm Roots and Neon Pink themes

### DIFF
--- a/pkg/tui/styles/themes/calm-roots.yaml
+++ b/pkg/tui/styles/themes/calm-roots.yaml
@@ -1,0 +1,99 @@
+version: 1
+name: "Calm Roots"
+colors:
+  # Text colors - warm white palette (shifted hierarchy)
+  text_bright: "#D4D4D8"     # Warm white (Tier 1) - was cool white
+  text_primary: "#C0C0C0"    # Light gray (Tier 2) - standard body
+  text_secondary: "#9A9A9A"  # Medium gray (Tier 3) - de-emphasized
+  text_muted: "#D4D4D8"      # Warm white - used for thinking/reasoning text
+  text_faint: "#6A6A6A"      # Dim gray (Tier 5) - was darker
+  
+  # Accent colors
+  accent: "#D4D4D8"          # Warm white - Links, buttons, cursor, focused elements
+  accent_muted: "#D4D4D8"    # Warm white
+  
+  # Background colors
+  background: "#282c34"      # Ghostty default gray background
+  background_alt: "#363640"  # Lighter background
+  
+  # Border colors
+  border_secondary: "#D4D4D8"  # Warm white - dialogs, resize handle, separators
+  
+  # Status colors
+  success: "#A0D4B4"         # Mint green
+  error: "#F7768E"           # Error red
+  warning: "#D4D4D8"         # Warm white
+  info: "#9ECAB8"            # Sage green
+  highlight: "#98C379"       # Highlight green
+  
+  # Brand colors
+  brand: "#4A4540"           # Dark warm brown - selection backgrounds, brand elements
+  brand_bg: "#363640"        # Warm gray - Brand background areas
+  
+  # Error colors
+  error_strong: "#d74532"
+  error_dark: "#4a2523"
+  
+  # Spinner colors
+  spinner_dim: "#D4D4D8"     # Warm white
+  spinner_bright: "#E0E0E0"  # Lighter warm white
+  spinner_brightest: "#ECECEC" # Brightest warm white
+  
+  # Diff colors
+  diff_add_bg: "#20303B"
+  diff_remove_bg: "#3C2A2A"
+  
+  # UI element colors
+  line_number: "#565F89"
+  separator: "#414868"
+  selected: "#2A3B5C"        # Darker blue-gray - selected items background (for warm white text)
+  selected_fg: "#D4D4D8"     # Warm white - text on selected items, menu highlights
+  suggestion_ghost: "#6B6B6B"
+  tab_bg: "#25252c"
+  tab_active_bg: "#363640"   # User message background
+  tab_active_fg: "#D4D4D8"   # Warm white
+  tab_inactive_fg: "#808080"
+  tab_border: "#9A88C0"      # Lavender border
+  placeholder: "#808080"
+  
+  # Badge colors
+  badge_accent: "#D4D4D8"    # Warm white
+  badge_info: "#9ECAB8"      # Sage green
+  badge_success: "#9ECE6A"
+  
+  # Agent colors (hue values 0-360 for dynamic palette generation)
+  agent_hues: [220, 280, 170, 30, 330, 140, 200, 260, 50, 0, 185, 20, 235, 295, 155, 340]
+
+chroma:
+  # Syntax highlighting colors
+  error_fg: "#F1F1F1"
+  error_bg: "#F05B5B"
+  success: "#A0D4B4"        # Mint green (matching theme success)
+  comment: "#808080"        # Muted gray
+  comment_preproc: "#D4D4D8" # Warm white
+  keyword: "#D4D4D8"        # Warm white
+  keyword_reserved: "#D4D4D8"
+  keyword_namespace: "#D4D4D8"
+  keyword_type: "#D4D4D8"
+  operator: "#D4D4D8"       # Warm white
+  punctuation: "#C0C0C0"    # Light gray
+  name_builtin: "#D4D4D8"   # Warm white
+  name_tag: "#D4D4D8"       # Warm white
+  name_attribute: "#D4D4D8" # Warm white
+  name_decorator: "#D4D4D8" # Warm white
+  literal_number: "#9ECAB8" # Sage green
+  literal_string: "#C69669" # Brown (keep)
+  literal_string_escape: "#D4D4D8" # Warm white
+  generic_deleted: "#FD5B5B"
+  generic_subheading: "#808080"
+  background: "#363640"     # Match background_alt
+
+markdown:
+  heading: "#F2D4D8"         # Soft pinky white
+  link: "#7AA2F7"            # Blue for links
+  strong: "#D4D4D8"          # Warm white for strong
+  code: "#C0C0C0"
+  code_bg: "#363640"         # User message background
+  blockquote: "#808080"
+  list: "#C0C0C0"
+  hr: "#E8C4BE"

--- a/pkg/tui/styles/themes/neon-pink.yaml
+++ b/pkg/tui/styles/themes/neon-pink.yaml
@@ -1,0 +1,99 @@
+version: 1
+name: "Neon Pink"
+colors:
+  # Text colors - kin CLI inspired pink palette
+  text_bright: "#FF69B4"      # Pink
+  text_primary: "#FFB6C1"    # LightPink
+  text_secondary: "#FFFFFF"  # White (was Fuchsia)
+  text_muted: "#DB7093"      # Rose
+  text_faint: "#7a5570"      # Dim rose
+  
+  # Accent colors - pastel pink
+  accent: "#FFB3D9"          # Pastel pink (softer)
+  accent_muted: "#E6A8CF"    # Muted pastel pink
+  
+  # Background colors - Ghostty default grey
+  background: "#1c1c1c"      # Ghostty default grey
+  background_alt: "#262626"  # Slightly lighter grey
+  
+  # Border colors
+  border_secondary: "#DB7093" # Rose
+  
+  # Status colors - keeping practical colors
+  success: "#FFFFFF"         # White (was Magenta)
+  error: "#FF0066"           # Kin error color
+  warning: "#DB7093"         # Rose
+  info: "#FFFFFF"            # White (was Fuchsia)
+  highlight: "#FFB3D9"       # Pastel pink (softer highlights)
+  
+  # Brand colors
+  brand: "#4A4540"           # Dark warm brown - selection backgrounds (for readability)
+  brand_bg: "#1a0a12"        # BgSubtle
+  
+  # Error colors
+  error_strong: "#FFFFFF"
+  error_dark: "#2a0a15"
+  
+  # Spinner colors - pink gradient
+  spinner_dim: "#DB7093"     # Rose
+  spinner_bright: "#FF69B4"  # Pink
+  spinner_brightest: "#FFB6C1" # LightPink
+  
+  # Diff colors
+  diff_add_bg: "#0a2a0a"
+  diff_remove_bg: "#2a0a15"
+  
+  # UI element colors
+  line_number: "#7a5570"     # Dim
+  separator: "#DB7093"       # Rose
+  selected: "#E6A8CF"        # Muted pastel pink
+  selected_fg: "#FFFFFF"     # White text on selection
+  suggestion_ghost: "#7a5570"
+  tab_bg: "#1c1c1c"
+  tab_active_bg: "#262626"   # Lighter grey
+  tab_active_fg: "#FF69B4"   # Pink
+  tab_inactive_fg: "#DB7093" # Rose
+  tab_border: "#FFB3D9"      # Pastel pink
+  placeholder: "#DB7093"     # Rose
+  
+  # Badge colors
+  badge_accent: "#98D8C8"    # Pastel green (for start)
+  badge_info: "#6BA4E8"      # Pastel blue (for Sandbox)
+  badge_success: "#FFFFFF"   # White (was Magenta)
+  
+  # Agent colors (hue values 0-360 for dynamic palette generation)
+  agent_hues: [220, 280, 170, 30, 330, 140, 200, 260, 50, 0, 185, 20, 235, 295, 155, 340]
+
+chroma:
+  # Syntax highlighting - kin inspired
+  comment: "#7a5570"         # Dim
+  comment_preproc: "#FFFFFF" # White (was Magenta)
+  keyword: "#FFFFFF"         # White (was Magenta)
+  keyword_reserved: "#FFFFFF" # White (was HotPink)
+  keyword_namespace: "#FFFFFF" # White (was Fuchsia)
+  keyword_type: "#FF69B4"    # Pink
+  operator: "#DB7093"        # Rose
+  punctuation: "#FFB6C1"     # LightPink
+  name_builtin: "#FFFFFF"    # White (was Fuchsia)
+  name_tag: "#FFFFFF"        # White (was HotPink)
+  name_attribute: "#FF69B4"  # Pink
+  name_decorator: "#FFFFFF"  # White (was Magenta)
+  literal_number: "#FFFFFF"  # White (was Fuchsia)
+  literal_string: "#FFB6C1"  # LightPink
+  literal_string_escape: "#FF69B4" # Pink
+  generic_deleted: "#FFFFFF" # White (was error pink)
+  generic_subheading: "#7a5570"
+  background: "#1c1c1c"
+  error_fg: "#FFFFFF"
+  error_bg: "#2a0a15"
+  success: "#FFFFFF"         # White (was Magenta)
+
+markdown:
+  heading: "#FFFFFF"         # White (was HotPink)
+  link: "#FFFFFF"            # White (was Fuchsia)
+  strong: "#FF69B4"          # Pink (bold)
+  code: "#FFFFFF"            # White (was Fuchsia)
+  code_bg: "#262626"         # Lighter grey
+  blockquote: "#DB7093"      # Rose
+  list: "#FFB6C1"            # LightPink
+  hr: "#DB7093"              # Rose (separator)


### PR DESCRIPTION
## Summary
Add two new TUI color themes for docker-agent:

### Calm Roots
A soft, cohesive warm palette featuring:
- Warm white accents (`#D4D4D8`)
- Sage green info messages (`#9ECAB8`)
- Mint green success indicators (`#A0D4B4`)
- Charcoal background matching Ghostty terminal defaults (`#282c34`)

### Neon Pink
A vibrant pink-focused theme featuring:
- Hot pink, light pink, and rose tones
- High-contrast white accents for readability
- Dark backgrounds for comfortable viewing
- Cohesive pink color palette throughout

Both themes:
- Follow the existing theme structure
- Work seamlessly with the theme picker (`/theme` command)
- Are fully compatible with all TUI features

## Testing
Tested with docker-agent TUI, switching between themes via the theme picker.

---
Assisted-By: cagent