### PR TITLE
Fix/deduplicate tool names

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -240,6 +240,21 @@ func (a *Agent) collectTools(ctx context.Context) ([]tools.Tool, error) {
 
 	agentTools = append(agentTools, a.tools...)
 
+	// Deduplicate tools by name, keeping the first occurrence.
+	// Duplicate tool names cause provider API errors (e.g. Anthropic 400).
+	seen := make(map[string]struct{}, len(agentTools))
+	deduped := make([]tools.Tool, 0, len(agentTools))
+	for _, t := range agentTools {
+		if _, exists := seen[t.Name]; exists {
+			slog.Warn("Duplicate tool name; keeping first occurrence",
+				"agent", a.Name(), "tool", t.Name)
+			continue
+		}
+		seen[t.Name] = struct{}{}
+		deduped = append(deduped, t)
+	}
+	agentTools = deduped
+
 	if a.addDescriptionParameter {
 		agentTools = tools.AddDescriptionParameter(agentTools)
 	}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -248,6 +248,7 @@ func (a *Agent) collectTools(ctx context.Context) ([]tools.Tool, error) {
 		if _, exists := seen[t.Name]; exists {
 			slog.Warn("Duplicate tool name; keeping first occurrence",
 				"agent", a.Name(), "tool", t.Name)
+			a.addToolWarning(fmt.Sprintf("duplicate tool %q: keeping first occurrence", t.Name))
 			continue
 		}
 		seen[t.Name] = struct{}{}

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -88,7 +88,7 @@ func TestAgentTools(t *testing.T) {
 				}, nil),
 			},
 			wantToolCount: 3,
-			wantWarnings:  0,
+			wantWarnings:  1,
 		},
 	}
 

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -75,6 +75,21 @@ func TestAgentTools(t *testing.T) {
 			wantToolCount: 0,
 			wantWarnings:  0,
 		},
+		{
+			name: "duplicate tool names are deduplicated",
+			toolsets: []tools.ToolSet{
+				newStubToolSet(nil, []tools.Tool{
+					{Name: "read_file", Parameters: map[string]any{}},
+					{Name: "write_file", Parameters: map[string]any{}},
+				}, nil),
+				newStubToolSet(nil, []tools.Tool{
+					{Name: "read_file", Parameters: map[string]any{}},
+					{Name: "shell", Parameters: map[string]any{}},
+				}, nil),
+			},
+			wantToolCount: 3,
+			wantWarnings:  0,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
When multiple toolsets contain tools with the same name, the Agent's Tools() method returns duplicates. This causes Anthropic API 400 errors because the API rejects requests with duplicate tool names.

This fix adds deduplication logic to the Tools() method in pkg/agent/agent.go. After all toolsets are collected, it filters out duplicate tool names, keeping the first occurrence and logging a warning for
any that are skipped. A corresponding test case ("duplicate tool names are deduplicated") is added in pkg/agent/agent_test.go to verify the behavior.
Fixes #2251