### PR TITLE
Fix markdown rendering in documentation callout notes

### DIFF
--- a/docs/community/contributing/index.md
+++ b/docs/community/contributing/index.md
@@ -17,7 +17,7 @@ _docker-agent is open source. Here's how to set up your development environment 
 - [Task 3.44](https://taskfile.dev/installation/) or higher
 - [golangci-lint](https://golangci-lint.run/docs/welcome/install/local/)
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ Platform Support
 </div>
   <p>macOS and Linux are fully supported for development. On Windows, use <code>task build-local</code> to build via Docker.</p>
@@ -86,7 +86,7 @@ Key conventions:
 
 File issues on the [GitHub issue tracker](https://github.com/docker/docker-agent/issues). Please:
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ See also
 </div>
   <a href="{{ '/community/troubleshooting/' | relative_url }}">Troubleshooting</a> — Common issues and debug mode. <a href="{{ '/community/telemetry/' | relative_url }}">Telemetry</a> — What data is collected and how to opt out.
@@ -105,7 +105,7 @@ File issues on the [GitHub issue tracker](https://github.com/docker/docker-agent
 4. **Sign** your commits with `git commit -s` (DCO required)
 5. **Open a pull request** against the `main` branch
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Tip
 </div>
   <p>Use the dogfooding agent (<code>docker agent run ./golang_developer.yaml</code>) to help write and review your changes before submitting.</p>

--- a/docs/community/telemetry/index.md
+++ b/docs/community/telemetry/index.md
@@ -20,7 +20,7 @@ $ TELEMETRY_ENABLED=false docker agent run agent.yaml
 $ export TELEMETRY_ENABLED=false
 ```
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ Default
 </div>
   <p>Telemetry is **enabled by default**. Set <code>TELEMETRY_ENABLED=false</code> to opt out.</p>
@@ -43,7 +43,7 @@ $ export TELEMETRY_ENABLED=false
 - API keys or credentials
 - Personally identifying information (PII)
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 See events locally
 </div>
   <p>Use <code>--debug</code> to see telemetry events printed to the debug log without sending them anywhere additional.</p>

--- a/docs/community/troubleshooting/index.md
+++ b/docs/community/troubleshooting/index.md
@@ -62,7 +62,7 @@ $ docker agent run config.yaml --debug --log-file ./debug.log
 $ docker agent run config.yaml --otel
 ```
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Tip
 </div>
   <p>Always enable <code>--debug</code> when reporting issues. The log file contains detailed traces of API calls, tool executions, and agent interactions.</p>
@@ -146,7 +146,7 @@ docker-agent validates config at startup and reports errors with line numbers. C
 - MCP toolsets need either `command` (stdio), `remote` (SSE/HTTP), or `ref` (Docker)
 - Provider names must be one of: `openai`, `anthropic`, `google`, `amazon-bedrock`, `dmr`, etc.
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ Schema Validation
 </div>
   <p>Use the <a href="https://github.com/docker/docker-agent/blob/main/agent-schema.json">JSON schema</a> in your editor for real-time config validation and autocompletion.</p>
@@ -234,7 +234,7 @@ When reviewing debug logs, search for these key patterns:
 | `[RAG Manager]`             | RAG retrieval operations                                                   |
 | `[Reranker]`                | Reranking operations                                                       |
 
-<div class="callout callout-warning">
+<div class="callout callout-warning" markdown="1">
 <div class="callout-title">⚠️ Still stuck?
 </div>
   <p>If these steps don't resolve your issue, file a bug on the <a href="https://github.com/docker/docker-agent/issues">GitHub issue tracker</a> with your debug log attached, or ask on <a href="https://dockercommunity.slack.com/archives/C09DASHHRU4">Slack</a>.</p>

--- a/docs/concepts/agents/index.md
+++ b/docs/concepts/agents/index.md
@@ -36,7 +36,7 @@ agents:
 
 Every docker-agent configuration has a **root agent** — the entry point that receives user messages. In a single-agent setup, this is the only agent. In a multi-agent setup, the root agent acts as a coordinator, delegating tasks to specialized sub-agents.
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ Naming
 </div>
   <p>The first agent defined in your YAML (or the one named <code>root</code>) is the root agent by default. You can also specify which agent to start with using <code>docker agent run config.yaml -a agent_name</code>.</p>
@@ -110,7 +110,7 @@ $ docker agent alias add default /path/to/my-agent.yaml
 $ docker agent run  # now runs your custom agent
 ```
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 See also
 </div>
   <p>For reusable task-specific instructions, see <a href="{{ '/features/skills/' | relative_url }}">Skills</a>. For multi-agent patterns, see <a href="{{ '/concepts/multi-agent/' | relative_url }}">Multi-Agent</a>. For full config reference, see <a href="{{ '/configuration/agents/' | relative_url }}">Agent Config</a>.</p>

--- a/docs/concepts/distribution/index.md
+++ b/docs/concepts/distribution/index.md
@@ -12,7 +12,7 @@ _Package, share, and run agents via OCI-compatible registries — just like cont
 
 docker-agent agents can be pushed to any OCI-compatible registry (Docker Hub, GitHub Container Registry, etc.) and pulled/run anywhere. This makes sharing agents as easy as sharing Docker images.
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Tip
 </div>
   <p>For CLI commands related to distribution, see <a href="{{ '/features/cli/' | relative_url }}">CLI Reference</a> (<code>docker agent share push</code>, <code>docker agent share pull</code>, <code>docker agent alias</code>).</p>
@@ -119,7 +119,7 @@ $ docker agent share push ./agent.yaml docker.io/myorg/private-agent:latest
 $ docker agent run docker.io/myorg/private-agent:latest
 ```
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ Troubleshooting
 </div>
   <p>Having issues with push/pull? See <a href="{{ '/community/troubleshooting/' | relative_url }}">Troubleshooting</a> for common registry issues.</p>

--- a/docs/concepts/models/index.md
+++ b/docs/concepts/models/index.md
@@ -97,7 +97,7 @@ models:
     thinking_budget: none # disable thinking
 ```
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ Multi-provider teams
 </div>
   <p>Different agents can use different providers in the same config. See <a href="{{ '/concepts/multi-agent/' | relative_url }}">Multi-Agent</a> for patterns.</p>

--- a/docs/concepts/multi-agent/index.md
+++ b/docs/concepts/multi-agent/index.md
@@ -34,7 +34,7 @@ docker-agent supports two multi-agent patterns:
 
 You can combine both patterns in the same configuration — an agent can have both `sub_agents` and `handoffs`.
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 When to use which
 </div>
   <p><strong><code>sub_agents</code></strong> — Use when a coordinator needs to send tasks to specialists and synthesize their results.</p>
@@ -62,7 +62,7 @@ transfer_task(
 )
 ```
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ Auto-Approved
 </div>
   <p>Unlike other tools, <code>transfer_task</code> is always auto-approved — no user confirmation needed. This allows seamless delegation between agents.</p>
@@ -94,7 +94,7 @@ handoff(
 )
 ```
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ Scoped Handoff Targets
 </div>
   <p>Each agent can only hand off to agents listed in its own <code>handoffs</code> array. The <code>handoff</code> tool is automatically injected — you don't need to add it manually.</p>
@@ -140,7 +140,7 @@ agents:
       - root
 ```
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Full pipeline example
 </div>
   <p>For a more complex handoff graph with branching and multiple processing stages, see <a href="https://github.com/docker/docker-agent/blob/main/examples/handoff.yaml"><code>examples/handoff.yaml</code></a>.</p>
@@ -212,7 +212,7 @@ External sub-agents are automatically named after their last path segment — fo
       - reviewer:docker.io/myorg/review-agent:latest
 ```
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Tip
 </div>
   <p>External sub-agents work with any OCI-compatible registry, not just the Docker Agent Catalog. See <a href="{{ '/concepts/distribution/' | relative_url }}">Agent Distribution</a> for more on registry references.</p>
@@ -345,7 +345,7 @@ toolsets:
 - **Use the right model** — Use capable models for complex reasoning, cheap models for simple tasks
 - **Choose the right pattern** — Use `sub_agents` for hierarchical task delegation, `handoffs` for pipeline workflows and conversational routing
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ Beyond docker-agent
 </div>
   <p>For interoperability with other agent frameworks, docker-agent supports the <a href="{{ '/features/a2a/' | relative_url }}">A2A protocol</a> and can expose agents via <a href="{{ '/features/mcp-mode/' | relative_url }}">MCP Mode</a>.</p>

--- a/docs/concepts/tools/index.md
+++ b/docs/concepts/tools/index.md
@@ -17,7 +17,7 @@ When an agent needs to perform an action, it makes a **tool call**. The docker-a
 3. docker-agent executes the tool and returns the result
 4. Agent incorporates the result and responds
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ Tool Confirmation
 </div>
   <p>By default, docker-agent asks for user confirmation before executing tools that have side effects (shell commands, file writes). Use <code>--yolo</code> to auto-approve all tool calls.</p>
@@ -60,7 +60,7 @@ toolsets:
 
 See [Tool Config]({{ '/configuration/tools/#mcp-tools' | relative_url }}) for full MCP configuration reference.
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 See also
 </div>
   <p>For full configuration reference, see <a href="{{ '/configuration/tools/' | relative_url }}">Tool Config</a>. For RAG (document retrieval), see <a href="{{ '/features/rag/' | relative_url }}">RAG</a>.</p>

--- a/docs/configuration/agents/index.md
+++ b/docs/configuration/agents/index.md
@@ -51,7 +51,7 @@ agents:
       schema: object
 ```
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 See also
 </div>
   <p>For model parameters, see <a href="{{ '/configuration/models/' | relative_url }}">Model Config</a>. For tool details, see <a href="{{ '/configuration/tools/' | relative_url }}">Tool Config</a>. For multi-agent patterns, see <a href="{{ '/concepts/multi-agent/' | relative_url }}">Multi-Agent</a>.</p>
@@ -85,7 +85,7 @@ agents:
 | `hooks`                     | object  | ✗        | Lifecycle hooks for running commands at various points. See [Hooks]({{ '/configuration/hooks/' | relative_url }}).                                                                                   |
 | `structured_output`         | object  | ✗        | Constrain agent output to match a JSON schema. See [Structured Output]({{ '/configuration/structured-output/' | relative_url }}).                                                                    |
 
-<div class="callout callout-warning">
+<div class="callout callout-warning" markdown="1">
 <div class="callout-title">⚠️ max_iterations
 </div>
   <p>Default is <code>0</code> (unlimited). Always set <code>max_iterations</code> for agents with powerful tools like <code>shell</code> to prevent infinite loops. A value of 20–50 is typical for development agents.</p>

--- a/docs/configuration/hooks/index.md
+++ b/docs/configuration/hooks/index.md
@@ -12,7 +12,7 @@ _Run shell commands at various points during agent execution for deterministic c
 
 Hooks allow you to execute shell commands or scripts at key points in an agent's lifecycle. They provide deterministic control that works alongside the LLM's behavior, enabling validation, logging, environment setup, and more.
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ Use Cases
 </div>
 
@@ -214,14 +214,14 @@ hooks:
           timeout: 120 # 2 minutes
 ```
 
-<div class="callout callout-warning">
+<div class="callout callout-warning" markdown="1">
 <div class="callout-title">⚠️ Performance
 </div>
   <p>Hooks run synchronously and can slow down agent execution. Keep hook scripts fast and efficient. Consider using <code>suppress_output: true</code> for logging hooks to reduce noise.</p>
 
 </div>
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ Session End and Cancellation
 </div>
   <p><code>session_end</code> hooks are designed to run even when the session is interrupted (e.g., Ctrl+C). They are still subject to their configured timeout.</p>
@@ -376,7 +376,7 @@ $ docker agent run agentcatalog/coder \
   --hook-pre-tool-use "./audit.sh"
 ```
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ Merging behavior
 </div>
   <p>CLI hooks are <strong>appended</strong> to any hooks already defined in the agent's YAML config. They don't replace existing hooks. Pre/post-tool-use hooks added via CLI match all tools (equivalent to <code>matcher: "*"</code>).</p>

--- a/docs/configuration/overview/index.md
+++ b/docs/configuration/overview/index.md
@@ -154,7 +154,7 @@ API keys and secrets are read from environment variables — never stored in con
 | `DOCKER_AGENT_AUTO_INSTALL` | Set to `false` to disable automatic tool installation           |
 | `DOCKER_AGENT_TOOLS_DIR`    | Override the base directory for installed tools (default: `~/.cagent/tools/`) |
 
-<div class="callout callout-warning">
+<div class="callout callout-warning" markdown="1">
 <div class="callout-title">⚠️ Important
 </div>
   <p>Model references are case-sensitive: <code>openai/gpt-4o</code> is not the same as <code>openai/GPT-4o</code>.</p>

--- a/docs/configuration/permissions/index.md
+++ b/docs/configuration/permissions/index.md
@@ -12,7 +12,7 @@ _Control which tools can execute automatically, require confirmation, or are blo
 
 Permissions provide fine-grained control over tool execution. You can configure which tools are auto-approved (run without asking), which require user confirmation, and which are completely blocked.
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ Evaluation Order
 </div>
   <p>Permissions are evaluated in this order: **Deny → Allow → Ask**. Deny patterns take priority, then allow patterns, and anything else defaults to asking for user confirmation.</p>
@@ -82,7 +82,7 @@ When both global and agent-level permissions are present, they are merged into a
 
 The evaluation order remains the same after merging: **Deny > Allow > Ask > default Ask**.
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">Example: Global deny + agent allow
 </div>
   <p>If your global config denies <code>shell:cmd=sudo*</code> and an agent config allows <code>shell:cmd=sudo apt update</code>, the deny wins. Deny patterns always take priority regardless of source.</p>
@@ -151,7 +151,7 @@ Patterns follow filepath.Match semantics with some extensions:
 
 Matching is **case-insensitive**.
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Trailing Wildcards
 </div>
   <p>Trailing wildcards like <code>sudo*</code> match any characters including spaces, so <code>sudo*</code> matches <code>sudo rm -rf /</code>.</p>
@@ -236,7 +236,7 @@ Permissions work alongside [hooks]({{ '/configuration/hooks/' | relative_url }})
 
 Hooks can override allow decisions but cannot override deny decisions.
 
-<div class="callout callout-warning">
+<div class="callout callout-warning" markdown="1">
 <div class="callout-title">⚠️ Security Note
 </div>
   <p>Permissions are enforced client-side. They help prevent accidental operations but should not be relied upon as a security boundary for untrusted agents. For stronger isolation, use <a href="{{ '/configuration/sandbox/' | relative_url }}">sandbox mode</a>.</p>

--- a/docs/configuration/routing/index.md
+++ b/docs/configuration/routing/index.md
@@ -12,7 +12,7 @@ _Route requests to different models based on the content of user messages._
 
 Model routing lets you define a "router" model that automatically selects the best underlying model based on the user's message. This is useful for cost optimization, specialized handling, or load balancing across models.
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ How It Works
 </div>
   <p>docker-agent uses NLP-based text similarity (via Bleve full-text search) to match user messages against example phrases you define. The route with the best-matching examples wins, and that model handles the request.</p>
@@ -79,7 +79,7 @@ The router:
 4. Selects the route with the highest overall score
 5. Falls back to the base model if no good match is found
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Writing Good Examples
 </div>
 
@@ -167,7 +167,7 @@ Look for log entries like:
 "Route matched" model=anthropic/claude-sonnet-4-0 score=2.45
 ```
 
-<div class="callout callout-warning">
+<div class="callout callout-warning" markdown="1">
 <div class="callout-title">⚠️ Limitations
 </div>
 

--- a/docs/configuration/sandbox/index.md
+++ b/docs/configuration/sandbox/index.md
@@ -12,7 +12,7 @@ _Run agents in an isolated Docker container for enhanced security._
 
 Sandbox mode runs the entire agent inside a Docker container instead of directly on the host system. This provides an additional layer of isolation, limiting the potential impact of unintended or malicious commands.
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ Requirements
 </div>
   <p>Sandbox mode requires Docker to be installed and running on the host system.</p>
@@ -53,7 +53,7 @@ docker agent run --sandbox agent.yaml
 3. All agent tools (shell, filesystem, etc.) operate inside the container
 4. When the session ends, the container is automatically stopped and removed
 
-<div class="callout callout-warning">
+<div class="callout callout-warning" markdown="1">
 <div class="callout-title">⚠️ Limitations
 </div>
 

--- a/docs/configuration/structured-output/index.md
+++ b/docs/configuration/structured-output/index.md
@@ -12,7 +12,7 @@ _Force the agent to respond with JSON matching a specific schema._
 
 Structured output constrains the agent's responses to match a predefined JSON schema. This is useful for building agents that need to produce machine-readable output for downstream processing, API responses, or integration with other systems.
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ When to Use</div>
 <ul>
 <li>Building API endpoints that need consistent JSON responses</li>
@@ -221,7 +221,7 @@ agents:
         required: ["category", "priority", "confidence"]
 ```
 
-<div class="callout callout-warning">
+<div class="callout callout-warning" markdown="1">
 <div class="callout-title">⚠️ Tool Limitations</div>
 <p>When using structured output, the agent typically cannot use tools since its response format is constrained to the schema. Design your agent workflow accordingly — structured output agents work best for single-turn analysis or extraction tasks.</p>
 </div>

--- a/docs/configuration/tools/index.md
+++ b/docs/configuration/tools/index.md
@@ -176,7 +176,7 @@ export DOCKER_AGENT_AUTO_INSTALL=false
 
 Installed binaries are placed in `~/.cagent/tools/bin/` and cached so they are only downloaded once.
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Tip
 </div>
   <p>Auto-install supports both Go packages (via <code>go install</code>) and GitHub release binaries (via archive download). The aqua registry metadata determines which method is used.</p>
@@ -197,7 +197,7 @@ toolsets:
     tools: ["shell"]
 ```
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Tip
 </div>
   <p>Filtering tools improves agent performance — fewer tools means less confusion for the model about which tool to use.</p>
@@ -295,7 +295,7 @@ agents:
             Authorization: "Bearer ${INTERNAL_TOKEN}"
 ```
 
-<div class="callout callout-warning">
+<div class="callout callout-warning" markdown="1">
 <div class="callout-title">⚠️ Toolset Order Matters
 </div>
   <p>If multiple toolsets provide a tool with the same name, the first one wins. Order your toolsets intentionally.</p>

--- a/docs/features/a2a/index.md
+++ b/docs/features/a2a/index.md
@@ -12,7 +12,7 @@ _Expose docker-agent agents via Google's Agent-to-Agent (A2A) protocol for inter
 
 The `docker agent serve a2a` command starts an A2A server that exposes your agents using the [A2A protocol](https://a2a-protocol.org/latest/). This enables communication between Docker Agent and other agent frameworks that support A2A.
 
-<div class="callout callout-warning">
+<div class="callout callout-warning" markdown="1">
 <div class="callout-title">⚠️ Early support
 </div>
   <p>A2A support is functional but still evolving. Tool calls, artifacts, and memory features have limited A2A integration. See limitations below.</p>
@@ -39,7 +39,7 @@ $ docker agent serve a2a agentcatalog/pirate
 - **Full docker-agent features** — Supports all tools, models, and gateway features
 - **Multiple sources** — Load agents from files or the agent catalog
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 See also
 </div>
   <p>For exposing agents via MCP instead, see <a href="{{ '/features/mcp-mode/' | relative_url }}">MCP Mode</a>. For stdio-based integration, see <a href="{{ '/features/acp/' | relative_url }}">ACP</a>. For the HTTP API, see <a href="{{ '/features/api-server/' | relative_url }}">API Server</a>.</p>

--- a/docs/features/acp/index.md
+++ b/docs/features/acp/index.md
@@ -14,7 +14,7 @@ The `docker agent serve acp` command starts an ACP server that communicates over
 
 ACP is built on the [ACP Go SDK](https://github.com/coder/acp-go-sdk) and provides a standardized way for client applications to interact with AI agents.
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ ACP vs A2A vs MCP
 </div>
   **ACP** connects an agent to a *host application* (IDE, CLI tool) via stdio. **A2A** connects *agents to other agents* over HTTP. **MCP** exposes agents as *tools* for other MCP clients. Choose based on your integration target.
@@ -95,14 +95,14 @@ child.stdout.on("data", (data) => {
 });
 ```
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 When to use ACP
 </div>
   <p>Use ACP when building **IDE integrations**, **editor plugins**, or any tool that wants to embed a docker-agent agent as a subprocess. For HTTP-based integrations, use the <a href="{{ '/features/api-server/' | relative_url }}">API Server</a> instead.</p>
 
 </div>
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ See also
 </div>
   <p>For HTTP-based agent access, see the <a href="{{ '/features/api-server/' | relative_url }}">API Server</a>. For agent-to-agent communication, see <a href="{{ '/features/a2a/' | relative_url }}">A2A Protocol</a>. For exposing agents as MCP tools, see <a href="{{ '/features/mcp-mode/' | relative_url }}">MCP Mode</a>.</p>

--- a/docs/features/api-server/index.md
+++ b/docs/features/api-server/index.md
@@ -159,7 +159,7 @@ docker agent serve api <agent-file>|<agents-dir> [flags]
 | `--fake`           | (none)           | Replay AI responses from cassette file (testing) |
 | `--record`         | (none)           | Record AI API interactions to cassette file      |
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Multi-agent configs
 </div>
   <p>You can point <code>docker agent serve api</code> at a directory containing multiple agent YAML files. Each becomes a separate agent accessible via <code>/api/agents</code>. Combine with <code>--pull-interval</code> to auto-refresh agents from an OCI registry.</p>
@@ -184,7 +184,7 @@ By default, tool calls require approval. In the API workflow:
 
 Toggle auto-approve with `POST /api/sessions/:id/tools/toggle` for automated workflows.
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ See also
 </div>
   <p>For interactive use, see the <a href="{{ '/features/tui/' | relative_url }}">Terminal UI</a>. For agent-to-agent communication, see <a href="{{ '/features/a2a/' | relative_url }}">A2A Protocol</a> and <a href="{{ '/features/acp/' | relative_url }}">ACP</a>. For MCP integration, see <a href="{{ '/features/mcp-mode/' | relative_url }}">MCP Mode</a>.</p>

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -8,7 +8,7 @@ permalink: /features/cli/
 
 _Complete reference for all docker-agent command-line commands and flags._
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 No config needed
 </div>
   <p>Running <code>docker agent run</code> without a config file uses a built-in default agent. Perfect for quick experimentation.</p>
@@ -211,14 +211,14 @@ Registered aliases (3):
 Run an alias with: docker agent run <alias>
 ```
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Override alias options
 </div>
   <p>Command-line flags override alias options. For example, <code>docker agent run yolo-coder --yolo=false</code> disables yolo mode even though the alias has it enabled.</p>
 
 </div>
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Set a default agent
 </div>
   <p>Create a <code>default</code> alias to customize what <code>docker agent</code> starts with no arguments:</p>
@@ -248,7 +248,7 @@ Commands that accept a config support multiple reference types:
 | Alias         | `pirate` (after `docker agent alias add`)   |
 | Default       | (no argument) — uses built-in default agent |
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ Debugging
 </div>
   <p>Having issues? See <a href="{{ '/community/troubleshooting/' | relative_url }}">Troubleshooting</a> for debug mode, log analysis, and common solutions.</p>

--- a/docs/features/evaluation/index.md
+++ b/docs/features/evaluation/index.md
@@ -12,7 +12,7 @@ _Measure agent quality with automated evaluations — tool call accuracy, respon
 
 The `docker agent eval` command runs your agent against a set of recorded sessions and scores the results. Each eval session captures a user question, the expected tool calls, and criteria the response must satisfy. docker-agent replays the question, compares the agent's behavior to expectations, and produces a report.
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ Docker required
 </div>
   <p>Evaluations run inside Docker containers for isolation. Each eval gets a clean environment with optional setup scripts. Docker Desktop (or Docker Engine) must be running.</p>
@@ -140,7 +140,7 @@ The easiest way to create eval sessions is from real conversations:
 3. Use the `/eval` slash command in the TUI to save the session as an eval file
 4. Edit the generated JSON to add `evals` criteria (relevance, size, etc.)
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Tip
 </div>
   <p>Start with tool call scoring (automatic from recorded sessions), then add relevance criteria for the responses you care most about.</p>
@@ -173,7 +173,7 @@ After a run completes, docker-agent produces:
 - **Sessions JSON** — Exported session data for analysis
 - **Log file** — Debug-level log of the entire evaluation run
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Debugging Failed Evals
 </div>
   <p>Use <code>--keep-containers</code> to preserve containers after evaluation. You can then inspect them with <code>docker exec</code> to understand why an eval failed. The session database (<code>.db</code> file) contains the full conversation history for each eval.</p>
@@ -222,7 +222,7 @@ $ docker agent run agent.yaml
 $ docker agent eval agent.yaml ./evals
 ```
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ See also
 </div>
   <p>Use <code>/eval</code> in the <a href="{{ '/features/tui/' | relative_url }}">TUI</a> to create eval sessions from conversations. See the <a href="{{ '/features/cli/' | relative_url }}">CLI Reference</a> for all <code>docker agent eval</code> flags. Example eval configs are in <a href="https://github.com/docker/docker-agent/tree/main/examples/eval">examples/eval</a> on GitHub.</p>

--- a/docs/features/mcp-mode/index.md
+++ b/docs/features/mcp-mode/index.md
@@ -17,7 +17,7 @@ The `docker agent serve mcp` command makes your agents available to any applicat
 - Build reusable agent teams consumable from any MCP client
 - Integrate domain-specific agents into existing workflows
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ What is MCP?
 </div>
   <p>The <a href="https://modelcontextprotocol.io/">Model Context Protocol</a> is an open standard for connecting AI tools. See also <a href="{{ '/features/remote-mcp/' | relative_url }}">Remote MCP Servers</a> for connecting to cloud services.</p>

--- a/docs/features/rag/index.md
+++ b/docs/features/rag/index.md
@@ -79,7 +79,7 @@ strategies:
       code_aware: true # AST-aware chunking
 ```
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ Trade-offs
 </div>
   <p>Semantic embeddings provide higher quality retrieval but slower indexing (LLM call per chunk) and additional API costs.</p>
@@ -166,7 +166,7 @@ chunking:
   code_aware: true # Uses tree-sitter for AST-based chunking
 ```
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ Language Support
 </div>
   <p>Currently supports Go (<code>.go</code>) files. More languages will be added. Falls back to plain text chunking for unsupported file types.</p>
@@ -183,7 +183,7 @@ $ docker agent run config.yaml --debug --log-file debug.log
 
 Look for log tags: `[RAG Manager]`, `[Chunked-Embeddings Strategy]`, `[BM25 Strategy]`, `[RRF Fusion]`, `[Reranker]`.
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Examples
 </div>
   <p>See the <a href="https://github.com/docker/docker-agent/tree/main/examples/rag">RAG examples</a> in the GitHub repo for complete, runnable configurations.</p>

--- a/docs/features/remote-mcp/index.md
+++ b/docs/features/remote-mcp/index.md
@@ -20,7 +20,7 @@ toolsets:
       transport_type: "sse"
 ```
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 OAuth flow
 </div>
   <p>When you connect to a remote MCP server that requires OAuth, docker-agent opens your browser automatically for authentication. Tokens are cached for subsequent sessions.</p>
@@ -148,7 +148,7 @@ agents:
         instruction: Use Vercel for deployments.
 ```
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ Growing list
 </div>
   <p>This list is updated as more services add MCP support. If a service you use isn't listed, check their documentation — many providers are adding MCP endpoints regularly.</p>

--- a/docs/features/skills/index.md
+++ b/docs/features/skills/index.md
@@ -27,7 +27,7 @@ agents:
       - type: filesystem # required for reading skill files
 ```
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Tip
 </div>
   <p>Skills are perfect for encoding team-specific workflows (PR review, deployment, coding standards) that apply across projects.</p>
@@ -97,7 +97,7 @@ When the agent encounters a task that matches a `context: fork` skill, it uses t
 - **Folds the result** — only the sub-agent's final answer is returned to the parent as the tool result
 - **Inherits the parent's model and tools** — the sub-agent can use all tools available to the parent agent
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 When to use context: fork
 </div>
   <p>Use <code>context: fork</code> for skills that involve many steps, heavy tool usage, or that should not clutter the main conversation — for example dependency bumping, large refactors, or code generation pipelines.</p>
@@ -173,7 +173,7 @@ EOF
 
 The skill will automatically be available to any agent with `skills: true`.
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ See also
 </div>
   <p>Skills are enabled in the <a href="{{ '/configuration/agents/' | relative_url }}">Agent Config</a> with the <code>skills: true</code> property. For tool-based capabilities, see <a href="{{ '/concepts/tools/' | relative_url }}">Tools</a>.</p>

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -73,7 +73,7 @@ Change the AI model during a session with `/model` or <kbd>Ctrl</kbd>+<kbd>M</kb
 2. Select from config models or type a custom `provider/model`
 3. The model switch is saved with the session and restored on reload
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Tip
 </div>
   <p>Use model switching to try a more capable model for complex tasks, or a cheaper one for simple queries — without modifying your YAML config.</p>
@@ -111,7 +111,7 @@ Customize session titles to make them more meaningful and easier to find. By def
 2. Type your new title
 3. Press <kbd>Enter</kbd> to save, or <kbd>Escape</kbd> to cancel
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ Note
 </div>
   <p>Manually set titles are preserved and won’t be overwritten by auto-generation. Title changes are persisted immediately to the session.</p>
@@ -202,14 +202,14 @@ settings:
 
 **At runtime:** Use the `/theme` command to open the theme picker and select from available themes. Your selection is saved globally in `~/.config/cagent/config.yaml` under `settings.theme` and persists across sessions.
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Hot Reload
 </div>
   <p>Custom themes auto-reload when you save changes to the file — no restart needed. This makes it easy to tweak colors in real-time.</p>
 
 </div>
 
-<div class="callout callout-warning">
+<div class="callout callout-warning" markdown="1">
 <div class="callout-title">⚠️ Partial overrides
 </div>
   <p>All user themes are applied on top of the <code>default</code> theme. If you want to customize a built-in theme (e.g., <code>dracula</code>), copy its full YAML from the <a href="https://github.com/docker/docker-agent/tree/main/pkg/tui/styles/themes">built-in themes on GitHub</a> into <code>~/.cagent/themes/</code> and edit the copy. Otherwise, omitted values will use <code>default</code> colors, not the original theme's colors.</p>
@@ -226,7 +226,7 @@ When an agent calls a tool, docker-agent shows a confirmation dialog by default.
 
 **Granular permissions:** The permission system supports pattern-based matching. When you “Always allow” a specific tool command, only that exact pattern is auto-approved — other commands from the same tool still require confirmation. This lets you auto-approve safe, read-only operations while maintaining control over destructive ones.
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 YOLO mode
 </div>
   <p>Use <code>--yolo</code> or the <code>/yolo</code> command to auto-approve all tool calls. You can also toggle this mid-session. For aliases, set <code>--yolo</code> when creating the alias: <code>docker agent alias add fast agentcatalog/coder --yolo</code>.</p>

--- a/docs/getting-started/installation/index.md
+++ b/docs/getting-started/installation/index.md
@@ -21,7 +21,7 @@ Starting with [Docker Desktop 4.49.0](https://docs.docker.com/desktop/release-no
 $ docker agent version
 ```
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Tip
 </div>
   <p>Docker Desktop bundles docker-agent and keeps it up to date. This is the easiest way to get started, especially if you want to use Docker MCP tools and Docker Model Runner.</p>
@@ -89,7 +89,7 @@ task build
 ./bin/docker-agent --help
 ```
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Building on Windows
 </div>
   <p>On Windows, use <code>task build-local</code> instead of <code>task build</code>. This builds the binary inside a Docker container using Docker Buildx, which avoids issues with Windows-specific toolchain setup and CGo cross-compilation. The output goes to the <code>./dist</code> directory.</p>
@@ -108,7 +108,7 @@ export GOOGLE_API_KEY="AI..."           # Google Gemini
 export MISTRAL_API_KEY="..."            # Mistral
 ```
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ Note
 </div>
   <p>You only need the key(s) for the provider(s) you configure in your agent YAML. If you use Docker Model Runner (DMR), no API key is needed — models run locally.</p>

--- a/docs/getting-started/introduction/index.md
+++ b/docs/getting-started/introduction/index.md
@@ -88,7 +88,7 @@ agents:
 $ docker agent run agent.yaml
 ```
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Tip
 </div>
   <p>Jump straight to the <a href="{{ '/getting-started/quickstart/' | relative_url }}">Quick Start</a> if you want to build your first agent right away.</p>

--- a/docs/getting-started/quickstart/index.md
+++ b/docs/getting-started/quickstart/index.md
@@ -90,7 +90,7 @@ Once your agent is running, try asking it to:
 - _"Create a Python script that fetches weather data"_
 - _"Explain what the code in main.go does"_
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Tip
 </div>
   <p>Add <code>--yolo</code> to auto-approve all tool calls: `docker agent run agent.yaml --yolo`</p>
@@ -129,7 +129,7 @@ agents:
         ref: docker:duckduckgo
 ```
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ Docker MCP Tools
 </div>
   <p>The <code>ref: docker:duckduckgo</code> syntax runs the DuckDuckGo MCP server in a Docker container. This is the recommended way to use MCP tools — secure, isolated, and easy to configure. Requires Docker Desktop.</p>

--- a/docs/guides/go-sdk/index.md
+++ b/docs/guides/go-sdk/index.md
@@ -12,7 +12,7 @@ _Use docker-agent as a Go library to embed AI agents in your applications._
 
 docker-agent can be used as a Go library, allowing you to build AI agents directly into your Go applications. This gives you full programmatic control over agent creation, tool integration, and execution.
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ Import Path
 </div>
 <pre><code class="language-go">import "github.com/docker/docker-agent/pkg/..."</code></pre>

--- a/docs/guides/secrets/index.md
+++ b/docs/guides/secrets/index.md
@@ -74,7 +74,7 @@ The file format supports:
 - Quoted values: `KEY="value with spaces"`
 - Blank lines are ignored
 
-<div class="callout callout-warning">
+<div class="callout callout-warning" markdown="1">
 <div class="callout-title">⚠️ Important</div>
 <p>Add <code>.env</code> to your <code>.gitignore</code> to avoid committing secrets to version control.</p>
 </div>

--- a/docs/providers/anthropic/index.md
+++ b/docs/providers/anthropic/index.md
@@ -67,7 +67,7 @@ models:
       interleaved_thinking: false # disable if needed
 ```
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ Note
 </div>
   <p>Anthropic thinking budget values below 1024 or greater than or equal to <code>max_tokens</code> are ignored (a warning is logged).</p>

--- a/docs/providers/bedrock/index.md
+++ b/docs/providers/bedrock/index.md
@@ -93,7 +93,7 @@ Use inference profile prefixes for optimal routing:
 | `us.`     | US regions only                          |
 | `eu.`     | EU regions only (GDPR compliance)        |
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Inference profiles
 </div>
   <p>Use <code>global.</code> prefix on model IDs for automatic cross-region routing. Use <code>eu.</code> prefix for GDPR compliance.</p>

--- a/docs/providers/custom/index.md
+++ b/docs/providers/custom/index.md
@@ -17,7 +17,7 @@ The `providers` section in your agent YAML lets you define custom providers that
 - Enterprise deployments with custom endpoints
 - Any service with an OpenAI-compatible chat completions API
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ Works with any OpenAI-compatible API
 </div>
   <p>If a service supports the <code>/v1/chat/completions</code> endpoint, you can use it with docker-agent. No source code changes needed.</p>

--- a/docs/providers/dmr/index.md
+++ b/docs/providers/dmr/index.md
@@ -12,7 +12,7 @@ _Run AI models locally with Docker — no API keys, no costs, full data privacy.
 
 Docker Model Runner (DMR) lets you run open-source AI models directly on your machine. Models run in Docker, so there's no API key needed and no data leaves your computer.
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 No API key needed
 </div>
   <p>DMR runs models locally — your data never leaves your machine. Great for development, sensitive data, or offline use.</p>

--- a/docs/providers/google/index.md
+++ b/docs/providers/google/index.md
@@ -48,7 +48,7 @@ models:
 
 Gemini supports two approaches depending on the model version:
 
-<div class="callout callout-warning">
+<div class="callout callout-warning" markdown="1">
 <div class="callout-title">⚠️ Different thinking formats
 </div>
   <p>Gemini 2.5 uses **token-based** budgets (integers). Gemini 3 uses **level-based** budgets (strings like <code>low</code>, <code>high</code>). Make sure you use the right format for your model version.</p>

--- a/docs/providers/local/index.md
+++ b/docs/providers/local/index.md
@@ -16,7 +16,7 @@ docker-agent can connect to any OpenAI-compatible local model server. This guide
 - **vLLM** — High-performance inference server
 - **LocalAI** — OpenAI-compatible API for various backends
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Docker Model Runner
 </div>
   <p>For the easiest local model experience, consider <a href="{{ '/providers/dmr/' | relative_url }}">Docker Model Runner</a> which is built into Docker Desktop and requires no additional setup.</p>
@@ -169,7 +169,7 @@ agents:
 
 ## Performance Tips
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ Local Model Considerations
 </div>
 

--- a/docs/providers/openai/index.md
+++ b/docs/providers/openai/index.md
@@ -59,7 +59,7 @@ models:
     thinking_budget: low # minimal | low | medium (default) | high
 ```
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Custom endpoints
 </div>
   <p>Use <code>base_url</code> for proxies and OpenAI-compatible services. See <a href="{{ '/providers/custom/' | relative_url }}">Custom Providers</a> for full setup.</p>

--- a/docs/providers/overview/index.md
+++ b/docs/providers/overview/index.md
@@ -71,7 +71,7 @@ agents:
     model: mistral/mistral-large-latest
 ```
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Multi-provider teams
 </div>
   <p>Use expensive models for complex reasoning and cheaper/local models for routine tasks. See the example below.</p>

--- a/docs/tools/a2a/index.md
+++ b/docs/tools/a2a/index.md
@@ -28,7 +28,7 @@ toolsets:
 | `name`   | string | ✓        | Tool name for the remote agent |
 | `url`    | string | ✓        | A2A server endpoint URL        |
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 See also
 </div>
   <p>For full details on the A2A protocol and serving agents as A2A endpoints, see <a href="{{ '/features/a2a/' | relative_url }}">A2A Protocol</a>.</p>

--- a/docs/tools/api/index.md
+++ b/docs/tools/api/index.md
@@ -12,7 +12,7 @@ _Create custom tools that call HTTP APIs._
 
 The API tool type lets you define custom tools that make HTTP requests to external APIs. This is useful for integrating agents with REST APIs, webhooks, or any HTTP-based service without writing code.
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ When to Use
 </div>
 
@@ -213,13 +213,13 @@ agents:
 - Only HTTP and HTTPS URLs are supported
 - No support for file uploads or multipart forms
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 For Complex APIs
 </div>
   <p>For APIs that need authentication flows, pagination, or complex request/response handling, consider using an MCP server instead. The API tool is best for simple, stateless HTTP operations.</p>
 </div>
 
-<div class="callout callout-warning">
+<div class="callout callout-warning" markdown="1">
 <div class="callout-title">⚠️ Security
 </div>
   <p>API keys and tokens in headers are visible in debug logs. Use environment variables (<code>${env.VAR}</code>) rather than hardcoding secrets in configuration files.</p>

--- a/docs/tools/background-agents/index.md
+++ b/docs/tools/background-agents/index.md
@@ -52,7 +52,7 @@ agents:
         ref: docker:duckduckgo
 ```
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 When to Use
 </div>
   <p>Use <code>background_agents</code> when your orchestrator needs to fan out work to multiple specialists in parallel — for example, researching several topics simultaneously or running independent code analyses side by side.</p>

--- a/docs/tools/fetch/index.md
+++ b/docs/tools/fetch/index.md
@@ -33,7 +33,7 @@ toolsets:
     timeout: 60
 ```
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Fetch vs. API Tool
 </div>
   <p>The fetch tool gives the agent full control over HTTP requests at runtime. The <a href="{{ '/tools/api/' | relative_url }}">API tool</a> lets you predefine specific API calls as named tools with typed parameters. Use fetch for general-purpose HTTP access; use the API tool for well-known endpoints you want to expose as structured tools.</p>

--- a/docs/tools/filesystem/index.md
+++ b/docs/tools/filesystem/index.md
@@ -55,7 +55,7 @@ toolsets:
         cmd: "prettier --write ${file}"
 ```
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Tip
 </div>
   <p>The filesystem tool resolves paths relative to the working directory. Agents can also use absolute paths.</p>

--- a/docs/tools/handoff/index.md
+++ b/docs/tools/handoff/index.md
@@ -32,7 +32,7 @@ toolsets:
 | `url`         | string | ✓        | A2A server endpoint URL              |
 | `timeout`     | string | ✗        | Request timeout (default: `5m`)      |
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 See also
 </div>
   <p>For full details on the A2A protocol and serving agents as A2A endpoints, see <a href="{{ '/features/a2a/' | relative_url }}">A2A Protocol</a>.</p>

--- a/docs/tools/lsp/index.md
+++ b/docs/tools/lsp/index.md
@@ -12,7 +12,7 @@ _Connect to Language Server Protocol servers for code intelligence._
 
 The LSP tool connects your agent to any Language Server Protocol (LSP) server, providing comprehensive code intelligence capabilities like go-to-definition, find references, diagnostics, and more.
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ What is LSP?
 </div>
   <p>The <a href="https://microsoft.github.io/language-server-protocol/">Language Server Protocol</a> is a standard for providing language features like autocomplete, go-to-definition, and diagnostics. Most programming languages have LSP servers available.</p>
@@ -153,7 +153,7 @@ The LSP tool includes built-in instructions that guide the agent on how to use i
 4. Check `lsp_diagnostics` after every code change
 5. Apply `lsp_format` after edits are complete
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Best Practice
 </div>
   <p>Always include the <code>filesystem</code> tool alongside LSP. The agent needs filesystem access to read and write code files, while LSP provides intelligence about the code.</p>
@@ -196,7 +196,7 @@ All LSP tools use **1-based** line and character positions:
 }
 ```
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Auto-Installation
 </div>
   <p>docker-agent can automatically download and install LSP servers if they are not found in your PATH. Use the <code>version</code> property to specify a package, or let docker-agent auto-detect it from the command name. See <a href="{{ '/configuration/tools/#auto-installing-tools' | relative_url }}">Auto-Installing Tools</a> for details.</p>

--- a/docs/tools/memory/index.md
+++ b/docs/tools/memory/index.md
@@ -54,7 +54,7 @@ Memories support an optional `category` field for organization and filtering. Co
 - `project` — Project-specific context
 - `decision` — Past decisions and their rationale
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Tip
 </div>
   <p>Memory is especially useful for long-running assistants that need to recall information across conversations — like coding preferences, project conventions, or context discovered during previous sessions.</p>

--- a/docs/tools/script/index.md
+++ b/docs/tools/script/index.md
@@ -57,7 +57,7 @@ toolsets:
 | `shell.<name>.env`                | object | Environment variables for this script                      |
 | `shell.<name>.working_dir`        | string | Working directory for script execution                     |
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Script vs. Shell
 </div>
   <p>Use the <a href="{{ '/tools/shell/' | relative_url }}">shell tool</a> when the agent needs to run arbitrary commands. Use the script tool when you want to expose specific, predefined operations with clear names and typed parameters — giving the agent less freedom but more safety.</p>

--- a/docs/tools/shell/index.md
+++ b/docs/tools/shell/index.md
@@ -37,13 +37,13 @@ toolsets:
       PATH: "${PATH}:/custom/bin"
 ```
 
-<div class="callout callout-warning">
+<div class="callout callout-warning" markdown="1">
 <div class="callout-title">⚠️ Safety
 </div>
   <p>The shell tool gives agents full access to the system shell. Always set <code>max_iterations</code> on agents that use the shell tool to prevent infinite loops. A value of 20–50 is typical for development agents. Use <a href="{{ '/configuration/sandbox/' | relative_url }}">Sandbox Mode</a> for additional isolation.</p>
 </div>
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ Tool Confirmation
 </div>
   <p>By default, docker-agent asks for user confirmation before executing shell commands. Use <code>--yolo</code> to auto-approve all tool calls.</p>

--- a/docs/tools/think/index.md
+++ b/docs/tools/think/index.md
@@ -23,7 +23,7 @@ toolsets:
 
 No configuration options.
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 When to use
 </div>
   <p>Use the think tool with models that don't have native reasoning capabilities. If your model already supports a <a href="{{ '/configuration/models/#thinking-budget' | relative_url }}">thinking budget</a>, you likely don't need this tool.</p>

--- a/docs/tools/transfer-task/index.md
+++ b/docs/tools/transfer-task/index.md
@@ -45,7 +45,7 @@ agents:
 
 The coordinator agent automatically gets a `transfer_task` tool that can delegate to `developer` or `researcher`.
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 See also
 </div>
   <p>For parallel task delegation, see <a href="{{ '/tools/background-agents/' | relative_url }}">Background Agents</a>. For multi-agent patterns, see <a href="{{ '/concepts/multi-agent/' | relative_url }}">Multi-Agent</a>.</p>

--- a/docs/tools/user-prompt/index.md
+++ b/docs/tools/user-prompt/index.md
@@ -12,7 +12,7 @@ _Ask the user questions and collect interactive input during agent execution._
 
 The user prompt tool allows agents to ask questions and collect input from users during execution. This enables interactive workflows where the agent needs clarification, confirmation, or additional information before proceeding.
 
-<div class="callout callout-info">
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ When to Use
 </div>
 
@@ -168,7 +168,7 @@ How the prompt appears depends on the interface:
 - **CLI (exec mode)**: Prints the prompt and reads from stdin
 - **API/MCP**: Returns an elicitation request to the client
 
-<div class="callout callout-tip">
+<div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Best Practice
 </div>
   <p>Provide clear, concise messages. Include context about why you're asking and what the information will be used for. Use schemas with descriptions to guide users on expected input format.</p>
@@ -182,7 +182,7 @@ The agent should handle all possible actions:
 - **decline**: Acknowledge and try an alternative approach or explain what's needed
 - **cancel**: Stop the current operation gracefully
 
-<div class="callout callout-warning">
+<div class="callout callout-warning" markdown="1">
 <div class="callout-title">⚠️ Context Requirement
 </div>
   <p>The user prompt tool requires an elicitation handler to be configured. It works in the TUI and CLI modes but may not be available in all contexts (e.g., some MCP client configurations).</p>


### PR DESCRIPTION
Add `markdown="1"` attribute to all callout div elements so that kramdown processes markdown syntax (bold, italic, links) inside HTML blocks. Without this attribute, content like `**bold**` and `*italic*` was rendered as plain text on the documentation website.

Fixes #2282