### PR TITLE
fix: make chanSend non-blocking to prevent panic on closed channel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -185,7 +185,7 @@ require (
 	github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
-	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -576,7 +576,17 @@ func formatToolWarning(a *agent.Agent, warnings []string) string {
 	return strings.TrimSuffix(builder.String(), "\n")
 }
 
-// chanSend wraps a channel as a func(Event) for use with emitAgentWarnings.
+// chanSend wraps a channel as a func(Event) for use with emitAgentWarnings
+// and RAG event forwarding. The send is non-blocking: if the channel is full
+// or closed, the event is silently dropped. This prevents a panic when a
+// long-lived goroutine (e.g. RAG file watcher) tries to forward an event
+// after the per-message events channel has been closed.
 func chanSend(ch chan Event) func(Event) {
-	return func(e Event) { ch <- e }
+	return func(e Event) {
+		defer func() { recover() }() //nolint:errcheck // swallow send-on-closed-channel panic
+		select {
+		case ch <- e:
+		default:
+		}
+	}
 }


### PR DESCRIPTION
The RAG file watcher runs for the lifetime of the agent but holds a closure over the per-message events channel. When `finalizeEventChannel` closes that channel between messages, the watcher panics with `send on closed channel`.

Make `chanSend` non-blocking with `select`/`default` and recover from panics on closed channels, so late-arriving RAG events are safely dropped.

Fixes #2266