### PR TITLE
Add copy button on hover for assistant messages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -185,7 +185,7 @@ require (
 	github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
-	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/pkg/tui/components/message/message.go
+++ b/pkg/tui/components/message/message.go
@@ -21,6 +21,7 @@ type Model interface {
 	layout.Sizeable
 	SetMessage(msg *types.Message)
 	SetSelected(selected bool)
+	SetHovered(hovered bool)
 }
 
 // messageModel implements Model
@@ -32,6 +33,7 @@ type messageModel struct {
 	height   int
 	focused  bool
 	selected bool
+	hovered  bool
 	spinner  spinner.Spinner
 }
 
@@ -63,6 +65,10 @@ func (mv *messageModel) SetMessage(msg *types.Message) {
 
 func (mv *messageModel) SetSelected(selected bool) {
 	mv.selected = selected
+}
+
+func (mv *messageModel) SetHovered(hovered bool) {
+	mv.hovered = hovered
 }
 
 // Update handles messages and updates the message view state
@@ -134,11 +140,23 @@ func (mv *messageModel) Render(width int) string {
 			rendered = msg.Content
 		}
 
-		if mv.sameAgentAsPrevious(msg) {
-			return messageStyle.Render(rendered)
+		var prefix string
+		if !mv.sameAgentAsPrevious(msg) {
+			prefix = mv.senderPrefix(msg.Sender)
 		}
 
-		return mv.senderPrefix(msg.Sender) + messageStyle.Render(rendered)
+		// Always reserve a top row for the copy icon to avoid layout shifts.
+		// The icon is only visible when hovered or selected.
+		innerWidth := width - messageStyle.GetHorizontalFrameSize()
+		var topRow string
+		if mv.hovered || mv.selected {
+			copyIcon := styles.MutedStyle.Render(types.AssistantMessageCopyLabel)
+			iconWidth := ansi.StringWidth(types.AssistantMessageCopyLabel)
+			padding := max(innerWidth-iconWidth, 0)
+			topRow = strings.Repeat(" ", padding) + copyIcon
+		}
+		noTopPaddingStyle := messageStyle.PaddingTop(0)
+		return prefix + noTopPaddingStyle.Width(width).Render(topRow+"\n"+rendered)
 	case types.MessageTypeShellOutput:
 		if rendered, err := markdown.NewRenderer(width).Render(fmt.Sprintf("```console\n%s\n```", msg.Content)); err == nil {
 			return rendered

--- a/pkg/tui/components/messages/messages.go
+++ b/pkg/tui/components/messages/messages.go
@@ -126,6 +126,9 @@ type model struct {
 	inlineEditTextarea      textarea.Model // Textarea for inline editing
 	inlineEditOriginal      string         // Original content (for cancel)
 	inlineEditPrevSelection int            // Previous selection index before entering inline edit (-1 = was not in selection mode)
+
+	// Hover state for showing copy button on assistant messages
+	hoveredMessageIndex int // Index of message under mouse (-1 = none)
 }
 
 // New creates a new message list component
@@ -152,6 +155,7 @@ func newModel(width, height int, sessionState *service.SessionState) *model {
 		scrollview:           sv,
 		selectedMessageIndex: -1,
 		inlineEditMsgIndex:   -1,
+		hoveredMessageIndex:  -1,
 		renderDirty:          true,
 	}
 }
@@ -294,6 +298,11 @@ func (m *model) handleMouseClick(msg tea.MouseClickMsg) (layout.Model, tea.Cmd) 
 				OriginalContent: msg.Content,
 			})
 		}
+
+		if m.isCopyLabelClick(msgIdx, localLine, col) {
+			cmd := m.copyMessageToClipboard(msgIdx)
+			return m, cmd
+		}
 	}
 
 	clickCount := m.selection.detectClickType(line, col)
@@ -353,6 +362,27 @@ func (m *model) handleMouseMotion(msg tea.MouseMotionMsg) (layout.Model, tea.Cmd
 		cmd := m.autoScroll()
 		return m, cmd
 	}
+
+	// Track hovered message for showing copy button on assistant messages
+	line, _ := m.mouseToLineCol(msg.X, msg.Y)
+	newHovered := -1
+	if msgIdx, _ := m.globalLineToMessageLine(line); msgIdx >= 0 && msgIdx < len(m.messages) {
+		if m.messages[msgIdx].Type == types.MessageTypeAssistant {
+			newHovered = msgIdx
+		}
+	}
+	if newHovered != m.hoveredMessageIndex {
+		oldHovered := m.hoveredMessageIndex
+		m.hoveredMessageIndex = newHovered
+		if oldHovered >= 0 {
+			m.invalidateItem(oldHovered)
+		}
+		if newHovered >= 0 {
+			m.invalidateItem(newHovered)
+		}
+		m.renderDirty = true
+	}
+
 	return m, nil
 }
 
@@ -905,15 +935,17 @@ func (m *model) renderItem(index int, view layout.Model) renderedItem {
 	}
 
 	isSelected := m.focused && index == m.selectedMessageIndex
+	isHovered := index == m.hoveredMessageIndex
 
 	switch v := view.(type) {
 	case message.Model:
 		v.SetSelected(isSelected)
+		v.SetHovered(isHovered)
 	case *reasoningblock.Model:
 		v.SetSelected(isSelected)
 	}
 
-	shouldCache := !isSelected && m.shouldCacheMessage(index)
+	shouldCache := !isSelected && !isHovered && m.shouldCacheMessage(index)
 	if shouldCache {
 		if cached, exists := m.renderedItems[index]; exists {
 			return cached
@@ -1195,6 +1227,7 @@ func (m *model) LoadFromSession(sess *session.Session) tea.Cmd {
 	m.totalHeight = 0
 	m.bottomSlack = 0
 	m.selectedMessageIndex = -1
+	m.hoveredMessageIndex = -1
 
 	var cmds []tea.Cmd
 
@@ -1612,6 +1645,52 @@ func (m *model) isEditLabelClick(msgIdx, localLine, col int) (bool, *types.Messa
 	}
 
 	return false, nil
+}
+
+// isCopyLabelClick checks if the click is on the copy label of an assistant message.
+func (m *model) isCopyLabelClick(msgIdx, localLine, col int) bool {
+	if msgIdx < 0 || msgIdx >= len(m.messages) {
+		return false
+	}
+	msg := m.messages[msgIdx]
+	if msg.Type != types.MessageTypeAssistant {
+		return false
+	}
+	// Only clickable when hovered or selected
+	if msgIdx != m.hoveredMessageIndex && (!m.focused || msgIdx != m.selectedMessageIndex) {
+		return false
+	}
+	if msgIdx >= len(m.views) {
+		return false
+	}
+
+	item := m.renderItem(msgIdx, m.views[msgIdx])
+	lines := strings.Split(item.view, "\n")
+	if localLine < 0 || localLine >= len(lines) {
+		return false
+	}
+
+	plainLine := ansi.Strip(lines[localLine])
+	before, _, ok := strings.Cut(plainLine, types.AssistantMessageCopyLabel)
+	if !ok {
+		return false
+	}
+
+	labelStart := ansi.StringWidth(before)
+	labelEnd := labelStart + ansi.StringWidth(types.AssistantMessageCopyLabel)
+	return col >= labelStart && col < labelEnd
+}
+
+// copyMessageToClipboard copies the content of a specific message to clipboard.
+func (m *model) copyMessageToClipboard(msgIdx int) tea.Cmd {
+	if msgIdx < 0 || msgIdx >= len(m.messages) {
+		return nil
+	}
+	content := m.messages[msgIdx].Content
+	if content == "" {
+		return nil
+	}
+	return copyTextToClipboard(content)
 }
 
 func (m *model) mouseToLineCol(x, y int) (line, col int) {

--- a/pkg/tui/types/types.go
+++ b/pkg/tui/types/types.go
@@ -23,7 +23,10 @@ const (
 	MessageTypeLoading
 )
 
-const UserMessageEditLabel = "✎"
+const (
+	UserMessageEditLabel      = "✎"
+	AssistantMessageCopyLabel = "⎘"
+)
 
 // ToolStatus represents the status of a tool call
 type ToolStatus int


### PR DESCRIPTION
Show a ⎘ icon in the top-right corner of assistant messages when hovered or selected via keyboard. Clicking the icon copies the message content to the clipboard.

- Add `SetHovered` to `message.Model` interface and track hover state
- Render copy icon in assistant message top-right on hover/selection
- Detect copy icon clicks and copy message content to clipboard
- Track hovered message index via mouse motion events
- Always reserve top row for icon to prevent layout shifts

Fixes #2258