### PR TITLE
Fix TUI stuck in Working state after failed sub-agent transfer_task

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -185,7 +185,7 @@ require (
 	github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
-	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/pkg/runtime/agent_delegation.go
+++ b/pkg/runtime/agent_delegation.go
@@ -125,9 +125,15 @@ func newSubSession(parent *session.Session, cfg SubSessionConfig, childAgent *ag
 // This is the "interactive" path used by transfer_task where the parent agent
 // loop is blocked while the child executes.
 func (r *LocalRuntime) runSubSessionForwarding(ctx context.Context, parent, child *session.Session, span trace.Span, evts chan Event, callerAgent string) (*tools.ToolCallResult, error) {
-	for event := range r.RunStream(ctx, child) {
+	childEvents := r.RunStream(ctx, child)
+	for event := range childEvents {
 		evts <- event
 		if errEvent, ok := event.(*ErrorEvent); ok {
+			// Drain remaining events (including StreamStoppedEvent) so the
+			// TUI's streamDepth counter stays balanced.
+			for remaining := range childEvents {
+				evts <- remaining
+			}
 			span.RecordError(fmt.Errorf("%s", errEvent.Error))
 			span.SetStatus(codes.Error, "sub-session error")
 			return nil, fmt.Errorf("%s", errEvent.Error)


### PR DESCRIPTION
## Summary

When a `transfer_task` to a sub-agent fails mid-stream (e.g. `unexpected EOF`), the TUI gets permanently stuck in the `Working…` state because `StreamStoppedEvent` is never forwarded to the parent.

## Root Cause

In `runSubSessionForwarding`, when an `ErrorEvent` is received, the function returned immediately without reading remaining events from the child channel. This meant the `StreamStoppedEvent` was never forwarded, leaving the TUI's `streamDepth` counter permanently incremented.

## Fix

Drain all remaining child events (including `StreamStoppedEvent`) before returning on error, keeping `streamDepth` balanced. This mirrors the pattern already used in `runSubSessionCollecting`.

Fixes #2255