### PR TITLE
tui/messages: Add URL click detection for terminals with mouse tracking

### DIFF
--- a/pkg/tui/components/messages/messages.go
+++ b/pkg/tui/components/messages/messages.go
@@ -396,6 +396,16 @@ func (m *model) handleMouseRelease(msg tea.MouseReleaseMsg) (layout.Model, tea.C
 		if m.selection.active {
 			line, col := m.mouseToLineCol(msg.X, msg.Y)
 			m.selection.update(line, col)
+
+			// If the mouse didn't move, this was a plain click — open URL if any
+			if line == m.selection.startLine && col == m.selection.startCol {
+				m.selection.clear()
+				if url := m.urlAt(line, col); url != "" {
+					return m, core.CmdHandler(messages.OpenURLMsg{URL: url})
+				}
+				return m, nil
+			}
+
 			m.selection.end()
 			cmd := m.copySelectionToClipboard()
 			return m, cmd

--- a/pkg/tui/components/messages/urldetect.go
+++ b/pkg/tui/components/messages/urldetect.go
@@ -1,0 +1,130 @@
+package messages
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/mattn/go-runewidth"
+)
+
+// urlAtPosition extracts a URL from the rendered line at the given display column.
+// Returns the URL string if found, or empty string if the click position is not on a URL.
+func urlAtPosition(renderedLine string, col int) string {
+	plainLine := ansi.Strip(renderedLine)
+	if plainLine == "" {
+		return ""
+	}
+
+	// Find all URL spans in the plain text
+	for _, span := range findURLSpans(plainLine) {
+		if col >= span.startCol && col < span.endCol {
+			return span.url
+		}
+	}
+	return ""
+}
+
+type urlSpan struct {
+	url      string
+	startCol int // display column where URL starts
+	endCol   int // display column where URL ends (exclusive)
+}
+
+// findURLSpans finds all URLs in plain text and returns their display column ranges.
+func findURLSpans(text string) []urlSpan {
+	var spans []urlSpan
+	runes := []rune(text)
+	n := len(runes)
+
+	for i := 0; i < n; {
+		// Look for http:// or https://
+		remaining := string(runes[i:])
+		var prefixLen int
+		switch {
+		case strings.HasPrefix(remaining, "https://"):
+			prefixLen = len("https://")
+		case strings.HasPrefix(remaining, "http://"):
+			prefixLen = len("http://")
+		default:
+			i++
+			continue
+		}
+
+		// Must not be preceded by a word character (avoid matching mid-word)
+		if i > 0 && isURLWordChar(runes[i-1]) {
+			i++
+			continue
+		}
+
+		urlStart := i
+		j := i + prefixLen
+		// Extend to cover the URL body
+		for j < n && isURLChar(runes[j]) {
+			j++
+		}
+		// Strip common trailing punctuation that's unlikely part of the URL
+		for j > urlStart+prefixLen && isTrailingPunct(runes[j-1]) {
+			j--
+		}
+		// Balance parentheses: strip trailing ')' only if unmatched
+		url := string(runes[urlStart:j])
+		url = balanceParens(url)
+		j = urlStart + len([]rune(url))
+
+		startCol := runeSliceWidth(runes[:urlStart])
+		endCol := startCol + runeSliceWidth(runes[urlStart:j])
+
+		spans = append(spans, urlSpan{
+			url:      url,
+			startCol: startCol,
+			endCol:   endCol,
+		})
+		i = j
+	}
+	return spans
+}
+
+func runeSliceWidth(runes []rune) int {
+	w := 0
+	for _, r := range runes {
+		w += runewidth.RuneWidth(r)
+	}
+	return w
+}
+
+func isURLChar(r rune) bool {
+	if r <= ' ' || r == '"' || r == '<' || r == '>' || r == '{' || r == '}' || r == '|' || r == '\\' || r == '^' || r == '`' {
+		return false
+	}
+	return true
+}
+
+func isURLWordChar(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
+}
+
+func isTrailingPunct(r rune) bool {
+	return r == '.' || r == ',' || r == ';' || r == ':' || r == '!' || r == '?'
+}
+
+// balanceParens strips a trailing ')' if there are more closing than opening parens.
+// This handles the common case of URLs wrapped in parentheses like (https://example.com).
+func balanceParens(url string) string {
+	if !strings.HasSuffix(url, ")") {
+		return url
+	}
+	open := strings.Count(url, "(")
+	if strings.Count(url, ")") > open {
+		return url[:len(url)-1]
+	}
+	return url
+}
+
+// urlAt returns the URL at the given global line and display column, or empty string.
+func (m *model) urlAt(line, col int) string {
+	m.ensureAllItemsRendered()
+	if line < 0 || line >= len(m.renderedLines) {
+		return ""
+	}
+	return urlAtPosition(m.renderedLines[line], col)
+}

--- a/pkg/tui/components/messages/urldetect_test.go
+++ b/pkg/tui/components/messages/urldetect_test.go
@@ -1,0 +1,164 @@
+package messages
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestFindURLSpans(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		wantURLs []string
+		wantCols [][2]int // [startCol, endCol] pairs
+	}{
+		{
+			name:     "no URLs",
+			text:     "hello world",
+			wantURLs: nil,
+		},
+		{
+			name:     "simple https URL",
+			text:     "visit https://example.com for more",
+			wantURLs: []string{"https://example.com"},
+			wantCols: [][2]int{{6, 25}},
+		},
+		{
+			name:     "http URL",
+			text:     "go to http://example.com/path",
+			wantURLs: []string{"http://example.com/path"},
+			wantCols: [][2]int{{6, 29}},
+		},
+		{
+			name:     "URL at start",
+			text:     "https://example.com is a site",
+			wantURLs: []string{"https://example.com"},
+			wantCols: [][2]int{{0, 19}},
+		},
+		{
+			name:     "URL at end",
+			text:     "visit https://example.com",
+			wantURLs: []string{"https://example.com"},
+			wantCols: [][2]int{{6, 25}},
+		},
+		{
+			name:     "URL with path and query",
+			text:     "see https://example.com/path?q=1&b=2#frag for details",
+			wantURLs: []string{"https://example.com/path?q=1&b=2#frag"},
+			wantCols: [][2]int{{4, 41}},
+		},
+		{
+			name:     "URL followed by period",
+			text:     "Visit https://example.com.",
+			wantURLs: []string{"https://example.com"},
+			wantCols: [][2]int{{6, 25}},
+		},
+		{
+			name:     "URL in parentheses",
+			text:     "(https://example.com)",
+			wantURLs: []string{"https://example.com"},
+			wantCols: [][2]int{{1, 20}},
+		},
+		{
+			name:     "URL with balanced parens in path",
+			text:     "see https://en.wikipedia.org/wiki/Go_(programming_language) for more",
+			wantURLs: []string{"https://en.wikipedia.org/wiki/Go_(programming_language)"},
+			wantCols: [][2]int{{4, 59}},
+		},
+		{
+			name:     "multiple URLs",
+			text:     "see https://a.com and https://b.com for info",
+			wantURLs: []string{"https://a.com", "https://b.com"},
+			wantCols: [][2]int{{4, 17}, {22, 35}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findURLSpans(tt.text)
+			assert.Equal(t, len(tt.wantURLs), len(got), "span count mismatch")
+			for i, span := range got {
+				assert.Equal(t, tt.wantURLs[i], span.url, "url mismatch at index %d", i)
+				assert.Equal(t, tt.wantCols[i][0], span.startCol, "startCol mismatch at index %d", i)
+				assert.Equal(t, tt.wantCols[i][1], span.endCol, "endCol mismatch at index %d", i)
+			}
+		})
+	}
+}
+
+func TestURLAtPosition(t *testing.T) {
+	tests := []struct {
+		name     string
+		line     string
+		col      int
+		expected string
+	}{
+		{
+			name:     "click on URL",
+			line:     "visit https://example.com for more",
+			col:      10,
+			expected: "https://example.com",
+		},
+		{
+			name:     "click before URL",
+			line:     "visit https://example.com for more",
+			col:      3,
+			expected: "",
+		},
+		{
+			name:     "click after URL",
+			line:     "visit https://example.com for more",
+			col:      28,
+			expected: "",
+		},
+		{
+			name:     "click on URL start",
+			line:     "visit https://example.com for more",
+			col:      6,
+			expected: "https://example.com",
+		},
+		{
+			name:     "click on URL last char",
+			line:     "visit https://example.com for more",
+			col:      24,
+			expected: "https://example.com",
+		},
+		{
+			name:     "line with ANSI codes",
+			line:     "visit \x1b[34mhttps://example.com\x1b[0m for more",
+			col:      10,
+			expected: "https://example.com",
+		},
+		{
+			name:     "empty line",
+			line:     "",
+			col:      0,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := urlAtPosition(tt.line, tt.col)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestBalanceParens(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"https://example.com)", "https://example.com"},
+		{"https://example.com/wiki/Go_(lang)", "https://example.com/wiki/Go_(lang)"},
+		{"https://example.com", "https://example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, balanceParens(tt.input))
+		})
+	}
+}


### PR DESCRIPTION
When mouse cell motion tracking is enabled (tea.MouseModeCellMotion), terminals like Kitty cannot detect and open URLs natively because all mouse events are captured by the application.

Add URL detection on single click so that clicking on a URL in rendered messages opens it in the browser via OpenURLMsg.