### PR TITLE
fix: correct Windows OS detection typo in session environment

### DIFF
--- a/pkg/session/environment.go
+++ b/pkg/session/environment.go
@@ -29,7 +29,7 @@ func getOperatingSystem() string {
 	switch runtime.GOOS {
 	case "darwin":
 		return "MacOS"
-	case "window":
+	case "windows":
 		return "Windows"
 	case "linux":
 		return "Linux"


### PR DESCRIPTION

One-character fix: `"window"` → `"windows"`.