### PR TITLE
fix: replace removed claude-3-7-sonnet-latest alias in examples

### DIFF
--- a/examples/42.yaml
+++ b/examples/42.yaml
@@ -2,7 +2,7 @@
 
 agents:
   root:
-    model: anthropic/claude-3-7-sonnet-latest
+    model: anthropic/claude-3-7-sonnet-20250219
     description: "Douglas Adams-style witty AI assistant"
     instruction: |
       You are an AI assistant with the distinctive voice and style of Douglas Adams' "The Hitchhiker's Guide to the Galaxy." Your responses should capture the book's characteristic blend of absurdist humor, witty observations, and deadpan delivery of the most outlandish concepts.

--- a/examples/fetch_docker.yaml
+++ b/examples/fetch_docker.yaml
@@ -2,7 +2,7 @@
 
 agents:
   root:
-    model: anthropic/claude-3-7-sonnet-latest
+    model: anthropic/claude-3-7-sonnet-20250219
     description: An agent that fetches and summarizes web content
     instruction: |
       You are a web content analyzer that fetches web pages and provides concise summaries.

--- a/examples/moby.yaml
+++ b/examples/moby.yaml
@@ -2,7 +2,7 @@
 
 agents:
   root:
-    model: anthropic/claude-3-7-sonnet-latest
+    model: anthropic/claude-3-7-sonnet-20250219
     description: Moby Project Expert
     instruction: You are an AI assistant with expertise in the moby/moby project's documentation.
     toolsets:

--- a/examples/notion-expert.yaml
+++ b/examples/notion-expert.yaml
@@ -2,7 +2,7 @@
 
 agents:
   root:
-    model: anthropic/claude-3-7-sonnet-latest
+    model: anthropic/claude-3-7-sonnet-20250219
     description: Notion Expert
     instruction: You are an AI assistant with expertise in the Notion project's documentation.
     toolsets:

--- a/examples/silvia.yaml
+++ b/examples/silvia.yaml
@@ -2,7 +2,7 @@
 
 agents:
   root:
-    model: anthropic/claude-3-7-sonnet-latest
+    model: anthropic/claude-3-7-sonnet-20250219
     description: Sylvia Plath-inspired poetic AI
     instruction: |
       You are Sylvia Plath, the renowned American poet and novelist. Channel her distinctive voice - one that is deeply introspective, emotionally raw, and often tinged with both beauty and darkness. Your responses should reflect her characteristic style: vivid imagery, intense emotional depth, and a unique blend of vulnerability and strength.

--- a/examples/todo.yaml
+++ b/examples/todo.yaml
@@ -2,7 +2,7 @@
 
 agents:
   root:
-    model: anthropic/claude-3-7-sonnet-latest
+    model: anthropic/claude-3-7-sonnet-20250219
     description: Expert developer
     instruction: |
       You are an expert developer, your only purpose in life is to help the user with their query.


### PR DESCRIPTION
## Why

The `claude-3-7-sonnet-latest` alias was removed from models.dev, causing `TestParseExamples` to fail for 6 example configs with:

```
model "claude-3-7-sonnet-latest" not found in provider "anthropic"
```

## Change

Replace the alias with the explicit dated model ID `claude-3-7-sonnet-20250219` across the 6 affected examples (`42.yaml`, `fetch_docker.yaml`, `silvia.yaml`, `todo.yaml`, `moby.yaml`, `notion-expert.yaml`).