### PR TITLE
fix: use platform-aware shell for skill expansion, script_shell, post-edit hooks, and bang command

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -24,6 +24,7 @@ import (
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/sessiontitle"
+	"github.com/docker/docker-agent/pkg/shellpath"
 	"github.com/docker/docker-agent/pkg/skills"
 	"github.com/docker/docker-agent/pkg/tools"
 	mcptools "github.com/docker/docker-agent/pkg/tools/mcp"
@@ -503,7 +504,8 @@ func (a *App) RunBangCommand(ctx context.Context, command string) {
 		return
 	}
 
-	out, err := exec.CommandContext(ctx, "/bin/sh", "-c", command).CombinedOutput()
+	shell, argsPrefix := shellpath.DetectShell()
+	out, err := exec.CommandContext(ctx, shell, append(argsPrefix, command)...).CombinedOutput()
 	output := "$ " + command + "\n" + string(out)
 	if err != nil && len(out) == 0 {
 		output = "$ " + command + "\nError: " + err.Error()

--- a/pkg/skills/expand.go
+++ b/pkg/skills/expand.go
@@ -10,6 +10,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/docker/docker-agent/pkg/shellpath"
 )
 
 // commandTimeout is the maximum time allowed for a single command expansion.
@@ -47,7 +49,8 @@ func runCommand(ctx context.Context, command, workDir string) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, commandTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "sh", "-c", command)
+	shell, argsPrefix := shellpath.DetectShell()
+	cmd := exec.CommandContext(ctx, shell, append(argsPrefix, command)...)
 	cmd.Dir = workDir
 
 	var stderr bytes.Buffer

--- a/pkg/tools/builtin/filesystem.go
+++ b/pkg/tools/builtin/filesystem.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/fsx"
+	"github.com/docker/docker-agent/pkg/shellpath"
 	"github.com/docker/docker-agent/pkg/tools"
 )
 
@@ -354,9 +355,10 @@ func (t *FilesystemTool) executePostEditCommands(ctx context.Context, filePath s
 			continue
 		}
 
-		cmd := exec.CommandContext(ctx, "/bin/sh", "-c", postEdit.Cmd)
+		shell, argsPrefix := shellpath.DetectShell()
+		cmd := exec.CommandContext(ctx, shell, append(argsPrefix, postEdit.Cmd)...)
 		cmd.Env = cmd.Environ()
-		cmd.Env = append(cmd.Env, "path="+filePath)
+		cmd.Env = append(cmd.Env, "file="+filePath)
 
 		if err := cmd.Run(); err != nil {
 			return fmt.Errorf("post-edit command failed for %s: %w", filePath, err)

--- a/pkg/tools/builtin/filesystem_test.go
+++ b/pkg/tools/builtin/filesystem_test.go
@@ -413,7 +413,7 @@ func main() {
 	postEditConfigs := []PostEditConfig{
 		{
 			Path: "*.go",
-			Cmd:  "touch $path.formatted",
+			Cmd:  "touch $file.formatted",
 		},
 	}
 	tool := NewFilesystemTool(tmpDir, WithPostEditCommands(postEditConfigs))

--- a/pkg/tools/builtin/script_shell.go
+++ b/pkg/tools/builtin/script_shell.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/shellpath"
 	"github.com/docker/docker-agent/pkg/tools"
 )
 
@@ -137,10 +138,9 @@ func (t *ScriptShellTool) execute(ctx context.Context, toolConfig *latest.Script
 		}
 	}
 
-	// Use default shell
-	shell := cmp.Or(os.Getenv("SHELL"), "/bin/sh")
+	shell, argsPrefix := shellpath.DetectShell()
 
-	cmd := exec.CommandContext(ctx, shell, "-c", toolConfig.Cmd)
+	cmd := exec.CommandContext(ctx, shell, append(argsPrefix, toolConfig.Cmd)...)
 	cmd.Dir = toolConfig.WorkingDir
 	cmd.Env = t.env
 	for key, value := range params {


### PR DESCRIPTION
## Why

Four code paths hardcoded Unix shell invocation (`/bin/sh -c` or `$SHELL`), causing silent failures on Windows where neither exists by default:

| Location | Old | Problem |
|---|---|---|
| `pkg/skills/expand.go` | `exec.Command("sh", "-c", ...)` | `sh` not in PATH on Windows |
| `pkg/tools/builtin/script_shell.go` | `$SHELL \|\| /bin/sh` | `$SHELL` unset on Windows; `/bin/sh` absent |
| `pkg/tools/builtin/filesystem.go` | `exec.Command("/bin/sh", "-c", ...)` | Absolute path doesn't exist on Windows |
| `pkg/app/app.go` | `exec.Command("/bin/sh", "-c", ...)` | Absolute path doesn't exist on Windows |

`shellpath.DetectShell()` already existed and is used correctly by the `shell` tool — these four callers just weren't using it.

## What changed

All four now call `shellpath.DetectShell()`, which returns PowerShell (or `cmd.exe`) on Windows and the user's `$SHELL` (falling back to `/bin/sh`) on Unix.

### Breaking change: post-edit hook variable renamed `path` → `file`

The `post_edit` hook previously set a `path=<filepath>` environment variable for use in commands. This is renamed to `file=<filepath>` for two reasons:

1. **Doc/code mismatch**: the docs already documented it as `${file}` (`gofmt -w ${file}`, `prettier --write ${file}`) — `path` was the implementation bug.
2. **zsh conflict**: `$path` is a special tied variable in zsh (mirrors `$PATH`), so `$path` in a post-edit command silently expanded to the system PATH array instead of the edited file path on macOS.

Existing configs using `$path` in `post_edit.cmd` should be updated to `$file` (or `${file}`).