### PR TITLE
fix: use agent accent color for working spinners in sidebar

### DIFF
--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -1159,7 +1159,7 @@ func (m *model) renderAgentEntry(content *strings.Builder, agent runtime.AgentDe
 	var prefix string
 	if isCurrent {
 		if m.workingAgent == agent.Name {
-			prefix = agentStyle.Render(m.spinner.View()) + " "
+			prefix = agentStyle.Render(m.spinner.RawFrame()) + " "
 		} else {
 			prefix = agentStyle.Render("▶") + " "
 		}

--- a/pkg/tui/components/spinner/spinner.go
+++ b/pkg/tui/components/spinner/spinner.go
@@ -23,6 +23,8 @@ type Spinner interface {
 	layout.Model
 	Reset() Spinner
 	Stop()
+	// RawFrame returns the current spinner character without any styling applied.
+	RawFrame() string
 }
 type spinner struct {
 	animSub             *animation.Subscription // manages animation tick subscription
@@ -134,6 +136,11 @@ func (s *spinner) Init() tea.Cmd {
 // Call this when the spinner is no longer active/visible.
 func (s *spinner) Stop() {
 	s.animSub.Stop()
+}
+
+// RawFrame returns the current spinner character without any styling applied.
+func (s *spinner) RawFrame() string {
+	return spinnerFrames[s.frame%len(spinnerFrames)]
 }
 
 // spinnerFrames holds the animation frames for the current terminal.


### PR DESCRIPTION
## Summary

- Add `RawFrame()` method to the `Spinner` interface that returns the current frame character without pre-applied styling
- Use `RawFrame()` instead of `View()` in `renderAgentEntry` so the agent's accent color is correctly applied to the working spinner

## Problem

In multi-agent teams, each agent name is rendered with a distinct accent color in the sidebar. However, the working spinner next to the active agent always used a fixed color (`SpinnerDotsHighlightStyle`), making it visually inconsistent with the agent name.

This happened because `spinner.View()` returns pre-rendered frames with a baked-in style, and wrapping it with `agentStyle.Render()` cannot override the inner ANSI color codes.

## Fix

Added `RawFrame()` to return the unstyled spinner character, allowing the caller to apply the correct agent accent color. Only the agent entry rendering is changed — all other spinner usages (`View()`) remain unaffected.

Fixes #2310

## Test plan

- [x] Build passes (`go build ./...`)
- [x] Run `docker agent run examples/dev-team.yaml` (or any multi-agent config)
- [x] Verify spinner color matches each agent's name color in the sidebar
- [x] Verify other spinners (title generation, MCP init, tool loading) are unaffected