### PR TITLE
fix: avoid triggering toolset startup from emitToolsChanged callback

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -209,11 +209,23 @@ func (a *Agent) Hooks() *latest.HooksConfig {
 // Tools returns the tools available to this agent
 func (a *Agent) Tools(ctx context.Context) ([]tools.Tool, error) {
 	a.ensureToolSetsAreStarted(ctx)
+	return a.collectTools(ctx)
+}
 
+// StartedTools returns tools only from toolsets that have already been started,
+// without triggering initialization of unstarted toolsets. This is useful for
+// notifications (e.g. MCP tool list changes) that should not block on slow
+// toolset startup such as RAG file indexing.
+func (a *Agent) StartedTools(ctx context.Context) ([]tools.Tool, error) {
+	return a.collectTools(ctx)
+}
+
+// collectTools gathers tools from all started toolsets plus static tools.
+func (a *Agent) collectTools(ctx context.Context) ([]tools.Tool, error) {
 	var agentTools []tools.Tool
 	for _, toolSet := range a.toolsets {
 		if !toolSet.IsStarted() {
-			// Toolset failed to start; skip it
+			// Toolset not started; skip it
 			continue
 		}
 		ta, err := toolSet.Tools(ctx)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -808,7 +808,8 @@ func (r *LocalRuntime) emitToolsChanged() {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	agentTools, err := r.CurrentAgentTools(ctx)
+	a := r.CurrentAgent()
+	agentTools, err := a.StartedTools(ctx)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
## Problem

When the TUI starts, RAG and MCP toolsets initialize concurrently. If an MCP server connects and fires `OnToolsChanged` before RAG finishes file indexing, `emitToolsChanged()` creates a 5-second timeout context and calls `CurrentAgentTools()`, which triggers `ensureToolSetsAreStarted()`. For projects with many files, RAG initialization exceeds 5 seconds, causing a spurious "context deadline exceeded" warning in the TUI.

## Fix

Add `Agent.StartedTools()` that lists tools only from already-started toolsets without triggering initialization. Use it in `emitToolsChanged()` so the MCP callback never starts slow toolsets under a tight deadline. RAG continues to initialize normally through the startup path with a proper long-lived context.