### PR TITLE
rag/treesitter: add nocgo build support

### DIFF
--- a/pkg/rag/treesitter/treesitter.go
+++ b/pkg/rag/treesitter/treesitter.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package treesitter
 
 import (

--- a/pkg/rag/treesitter/treesitter_nocgo.go
+++ b/pkg/rag/treesitter/treesitter_nocgo.go
@@ -1,0 +1,24 @@
+//go:build !cgo
+
+package treesitter
+
+import (
+	"errors"
+
+	"github.com/docker/docker-agent/pkg/rag/chunk"
+)
+
+// DocumentProcessor implements chunk.DocumentProcessor and always returns an
+// error when the application is built without CGO and uses RAG. For applications
+// that do not use RAG, this allows building without any CGO requirement.
+type DocumentProcessor struct{}
+
+// NewDocumentProcessor creates a new DocumentProcessor.
+func NewDocumentProcessor(_, _ int, _ bool) *DocumentProcessor {
+	return &DocumentProcessor{}
+}
+
+// Process implements chunk.DocumentProcessor.
+func (p *DocumentProcessor) Process(_ string, _ []byte) ([]chunk.Chunk, error) {
+	return nil, errors.New("rag/treesitter: document processor must be built with CGO_ENABLED=1")
+}


### PR DESCRIPTION
I'm building a CLI tool that uses docker-agent but doesn't need RAG functionality. Currently, the tree-sitter dependency forces CGO even when RAG isn't used, which causes Go stdlib and other 3rd party packages to also be built with CGO.

This PR adds a `!cgo` build variant for the treesitter package. Applications that don't use RAG can now build with `CGO_ENABLED=0`. If RAG is used without CGO, it returns a clear error explaining the requirement.