### PR TITLE
ci: switch to OIDC auth and Docker Build Cloud for image builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,15 +90,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Hub login
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+      - name: OIDC token
+        id: docker_oidc
+        uses: docker/oidc-action@a6a1b02766c2c807a353e645def5bcf9f2babbdf # v0.2.0
         with:
-          username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
-          password: ${{ secrets.DOCKERPUBLICBOT_WRITE_PAT }}
+          connection_id: "fc5234a6-aee3-4f2b-ae8a-75a1c690c1b2"
+
+      - name: Docker login
+        uses: docker/login-action@v3
+        with:
+          username: docker
+          password: ${{ steps.docker_oidc.outputs.token }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        with:
+          driver: cloud
+          endpoint: "docker/cagent"
 
       - name: Docker metadata
         id: meta


### PR DESCRIPTION
## Changes

- Replace Hub login with Docker OIDC token authentication (`docker/oidc-action`)
- Switch Docker Buildx to use Docker Build Cloud driver (`docker/cagent` endpoint)
- Remove dependency on `DOCKERPUBLICBOT_USERNAME` / `DOCKERPUBLICBOT_WRITE_PAT` secrets

This modernizes the CI image build pipeline to use OIDC-based authentication and cloud-based builds.