### PR TITLE
fix(tui): remove spurious blank line from every assistant message

### DIFF
--- a/pkg/tui/components/message/message.go
+++ b/pkg/tui/components/message/message.go
@@ -145,18 +145,22 @@ func (mv *messageModel) Render(width int) string {
 			prefix = mv.senderPrefix(msg.Sender)
 		}
 
-		// Always reserve a top row for the copy icon to avoid layout shifts.
-		// The icon is only visible when hovered or selected.
-		innerWidth := width - messageStyle.GetHorizontalFrameSize()
-		var topRow string
+		// Show copy icon in the top-right corner when hovered or selected.
+		// AssistantMessageStyle has PaddingTop=0 (unlike UserMessageStyle which has
+		// PaddingTop=1), so we cannot unconditionally prepend topRow+"\n" — doing so
+		// would add a spurious blank line to every message in the default state.
+		// Accept the 1-line layout shift on hover; it is less disruptive than the
+		// blank-line artifact that affects all messages at all times.
 		if mv.hovered || mv.selected {
+			innerWidth := width - messageStyle.GetHorizontalFrameSize()
 			copyIcon := styles.MutedStyle.Render(types.AssistantMessageCopyLabel)
 			iconWidth := ansi.StringWidth(types.AssistantMessageCopyLabel)
 			padding := max(innerWidth-iconWidth, 0)
-			topRow = strings.Repeat(" ", padding) + copyIcon
+			topRow := strings.Repeat(" ", padding) + copyIcon
+			noTopPaddingStyle := messageStyle.PaddingTop(0)
+			return prefix + noTopPaddingStyle.Width(width).Render(topRow+"\n"+rendered)
 		}
-		noTopPaddingStyle := messageStyle.PaddingTop(0)
-		return prefix + noTopPaddingStyle.Width(width).Render(topRow+"\n"+rendered)
+		return prefix + messageStyle.Render(rendered)
 	case types.MessageTypeShellOutput:
 		if rendered, err := markdown.NewRenderer(width).Render(fmt.Sprintf("```console\n%s\n```", msg.Content)); err == nil {
 			return rendered


### PR DESCRIPTION
## Problem

Since v1.41.0 (commit 574a4669), every assistant message in the TUI has an extra blank line at the top in its normal (non-hovered) state. In longer conversations this accumulates, causing the input area to be displaced and ghost text to appear at unexpected positions on screen. The artifacts are most visible when the session panel is open.

Closes #2368

## Root cause

The copy-button commit applied the user-message "topRow+`\n`" rendering pattern to assistant messages without accounting for a style difference:

| Style | PaddingTop | `PaddingTop(0)` effect | `topRow+"\n"` net change |
|---|---|---|---|
| `UserMessageStyle` | **1** (from `BaseMessageStyle.Padding(1,1)`) | removes 1 line | **0** — replaces removed padding ✓ |
| `AssistantMessageStyle` | **0** (`BaseMessageStyle.Padding(0,1)` override) | no-op | **+1** spurious blank line ✗ |

The unconditional `topRow+"\n"+rendered` always prepends `"\n"` when not hovered/selected (because `topRow == ""`), adding one blank line to every assistant message at all times.

## Fix

Only use the `topRow+"\n"` path when the copy icon is actually visible (hovered or selected). For the common case fall back to the original `messageStyle.Render(rendered)` from before 574a4669.

```diff
-       // Always reserve a top row for the copy icon to avoid layout shifts.
-       // The icon is only visible when hovered or selected.
-       innerWidth := width - messageStyle.GetHorizontalFrameSize()
-       var topRow string
+       // Show copy icon in the top-right corner when hovered or selected.
+       // AssistantMessageStyle has PaddingTop=0 (unlike UserMessageStyle which has
+       // PaddingTop=1), so we cannot unconditionally prepend topRow+"\n" — doing so
+       // would add a spurious blank line to every message in the default state.
+       // Accept the 1-line layout shift on hover; it is less disruptive than the
+       // blank-line artifact that affects all messages at all times.
        if mv.hovered || mv.selected {
+               innerWidth := width - messageStyle.GetHorizontalFrameSize()
                copyIcon := styles.MutedStyle.Render(types.AssistantMessageCopyLabel)
                iconWidth := ansi.StringWidth(types.AssistantMessageCopyLabel)
                padding := max(innerWidth-iconWidth, 0)
-               topRow = strings.Repeat(" ", padding) + copyIcon
+               topRow := strings.Repeat(" ", padding) + copyIcon
+               noTopPaddingStyle := messageStyle.PaddingTop(0)
+               return prefix + noTopPaddingStyle.Width(width).Render(topRow+"\n"+rendered)
        }
-       noTopPaddingStyle := messageStyle.PaddingTop(0)
-       return prefix + noTopPaddingStyle.Width(width).Render(topRow+"\n"+rendered)
+       return prefix + messageStyle.Render(rendered)
```

The trade-off is a 1-line layout shift when transitioning into the hovered/selected state. A layout-shift-free fix would require giving `AssistantMessageStyle` a `PaddingTop(1)` (matching `UserMessageStyle`) and filling `topRow` with spaces when not hovered — but that changes the visual appearance of all assistant messages. The simpler fix here is least-invasive and fully restores v1.40.0 rendering behaviour for the common path.

## Testing

Verified: `go build ./pkg/tui/...` clean on current `main`.