### PR TITLE
fix: surface completed title responses

### DIFF
--- a/pkg/model/provider/openai/response_stream.go
+++ b/pkg/model/provider/openai/response_stream.go
@@ -222,6 +222,26 @@ func (a *ResponseStreamAdapter) Recv() (chat.MessageStreamResponse, error) {
 
 	case "response.done", "response.completed":
 		slog.Info("Response done received", "event_type", event.Type)
+		if len(event.Response.Output) > 0 {
+			for _, output := range event.Response.Output {
+				if output.Type != "message" || a.itemHasContent[output.ID] {
+					continue
+				}
+				for _, content := range output.Content {
+					if content.Type != "text" || content.Text == "" {
+						continue
+					}
+					response.Choices = append(response.Choices, chat.MessageStreamChoice{
+						Delta: chat.MessageDelta{
+							Content: content.Text,
+							Role:    "assistant",
+						},
+					})
+					a.itemHasContent[output.ID] = true
+					break
+				}
+			}
+		}
 		// Extract usage
 		u := event.Response.Usage
 		if u.TotalTokens > 0 {
@@ -244,11 +264,7 @@ func (a *ResponseStreamAdapter) Recv() (chat.MessageStreamResponse, error) {
 		if hasToolCalls {
 			finishReason = chat.FinishReasonToolCalls
 		}
-		response.Choices = []chat.MessageStreamChoice{
-			{
-				FinishReason: finishReason,
-			},
-		}
+		response.Choices = append(response.Choices, chat.MessageStreamChoice{FinishReason: finishReason})
 	default:
 		slog.Info("Unhandled stream event type", "type", event.Type)
 	}

--- a/pkg/model/provider/openai/ws_stream_test.go
+++ b/pkg/model/provider/openai/ws_stream_test.go
@@ -134,6 +134,64 @@ func TestWSStream_TextDelta(t *testing.T) {
 	assert.ErrorIs(t, err, io.EOF)
 }
 
+func TestWSStream_CompletedResponseIncludesFinalMessageText(t *testing.T) {
+	t.Parallel()
+
+	events := []map[string]any{
+		{
+			"type": "response.completed",
+			"response": map[string]any{
+				"id": "resp_789",
+				"output": []any{
+					map[string]any{
+						"type": "message",
+						"id":   "item_3",
+						"content": []any{
+							map[string]any{
+								"type": "text",
+								"text": "Generated title",
+							},
+						},
+					},
+				},
+				"usage": map[string]any{
+					"input_tokens":  7,
+					"output_tokens": 3,
+					"total_tokens":  10,
+					"input_tokens_details": map[string]any{
+						"cached_tokens": 0,
+					},
+					"output_tokens_details": map[string]any{
+						"reasoning_tokens": 0,
+					},
+				},
+			},
+		},
+	}
+
+	srv := testWSServer(t, events)
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	stream, err := dialWebSocket(t.Context(), wsURL, http.Header{}, defaultTestParams())
+	require.NoError(t, err)
+	defer stream.Close()
+
+	adapter := newResponseStreamAdapter(stream, true)
+
+	resp, err := adapter.Recv()
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 2)
+	assert.Equal(t, "Generated title", resp.Choices[0].Delta.Content)
+	assert.Equal(t, chat.FinishReasonStop, resp.Choices[1].FinishReason)
+	require.NotNil(t, resp.Usage)
+	assert.Equal(t, int64(7), resp.Usage.InputTokens)
+	assert.Equal(t, int64(3), resp.Usage.OutputTokens)
+
+	_, err = adapter.Recv()
+	assert.ErrorIs(t, err, io.EOF)
+}
+
 func TestWSStream_ToolCall(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- surface final message text from `response.completed` / `response.done` when the stream did not emit text deltas
- preserve the existing finish-reason handling so title generation can succeed for GPT-5 responses that only include text in the terminal event
- add websocket regression coverage for completed-response-only message output

Closes #2318

## Testing
- `docker run --rm -v "$PWD":/src -w /src golang:1.26 go test ./pkg/model/provider/openai -run 'TestWSStream_(TextDelta|CompletedResponseIncludesFinalMessageText|ToolCall|EndToEnd_WithClient)' -count=1`
