### PR TITLE
Faster PR CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,30 @@ jobs:
         run: go-licenses check . --allowed_licenses=Apache-2.0,MIT,BSD-3-Clause,BSD-2-Clause --ignore modernc.org/mathutil
 
   build-image:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Build image
+        uses: docker/build-push-action@ee4ca427a2f43b6a16632044ca514c076267da23 # v6.19.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: false
+          sbom: false
+          build-args: |
+            GIT_TAG=pr
+            GIT_COMMIT=dev
+          cache-from: type=gha,scope=buildx
+          cache-to: type=gha,mode=max,scope=buildx
+
+  build-and-push-image:
+    if: github.event_name != 'pull_request'
     needs: [lint, build-and-test, license-check]
     runs-on: ubuntu-latest
     steps:
@@ -91,7 +115,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Hub login
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
@@ -116,13 +139,13 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           sbom: true
           provenance: mode=max
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            GIT_TAG=${{ github.event_name == 'pull_request' && 'pr' || github.ref_name }}
-            GIT_COMMIT=${{ github.event_name == 'pull_request' && 'dev' || github.sha }}
+            GIT_TAG=${{ github.ref_name }}
+            GIT_COMMIT=${{ github.sha }}
           cache-from: type=gha,scope=buildx
           cache-to: type=gha,mode=max,scope=buildx


### PR DESCRIPTION
Use a different image build job:

- doesn't push
- doesn't need sbom
- doesn't need provenance
- doesn't need the metadata step