### PR TITLE
Add /fork slash command to duplicate current session into a new tab

### DIFF
--- a/pkg/session/branch.go
+++ b/pkg/session/branch.go
@@ -16,7 +16,7 @@ func BranchSession(parent *Session, branchAtPosition int) (*Session, error) {
 	if parent == nil {
 		return nil, errors.New("parent session is nil")
 	}
-	if branchAtPosition < 0 || branchAtPosition >= len(parent.Messages) {
+	if branchAtPosition < 0 || branchAtPosition > len(parent.Messages) {
 		return nil, fmt.Errorf("branch position %d out of range", branchAtPosition)
 	}
 

--- a/pkg/session/branch_test.go
+++ b/pkg/session/branch_test.go
@@ -111,11 +111,10 @@ func TestBranchSession(t *testing.T) {
 		assert.Contains(t, err.Error(), "out of range")
 	})
 
-	t.Run("position equal to messages length returns error", func(t *testing.T) {
+	t.Run("position equal to messages length no error", func(t *testing.T) {
 		parent := &Session{Messages: []Item{NewMessageItem(UserMessage("test"))}}
 		_, err := BranchSession(parent, 1)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "out of range")
+		require.NoError(t, err)
 	})
 
 	t.Run("valid branch copies messages up to position", func(t *testing.T) {

--- a/pkg/tui/commands/commands.go
+++ b/pkg/tui/commands/commands.go
@@ -118,6 +118,17 @@ func builtInSessionCommands() []Item {
 			},
 		},
 		{
+			ID:           "session.fork",
+			Label:        "Fork",
+			SlashCommand: "/fork",
+			Description:  "Fork the current session into a new tab",
+			Category:     "Session",
+			Immediate:    true,
+			Execute: func(string) tea.Cmd {
+				return core.CmdHandler(messages.ForkSessionMsg{})
+			},
+		},
+		{
 			ID:           "session.exit",
 			Label:        "Exit",
 			SlashCommand: "/exit",

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -97,6 +97,51 @@ func (m *appModel) handleBranchFromEdit(msg messages.BranchFromEditMsg) (tea.Mod
 	)
 }
 
+func (m *appModel) handleForkSession() (tea.Model, tea.Cmd) {
+	currentSession := m.application.Session()
+	if currentSession == nil {
+		return m, notification.ErrorCmd("No active session to fork")
+	}
+
+	store := m.application.SessionStore()
+	if store == nil {
+		return m, notification.ErrorCmd("No session store configured")
+	}
+
+	spawner := m.supervisor.Spawner()
+	if spawner == nil {
+		return m, notification.ErrorCmd("Session spawning not available")
+	}
+
+	ctx := context.Background()
+
+	// Fork the session and clone all messages.
+	forkedSession, err := session.BranchSession(currentSession, len(currentSession.Messages))
+	if err != nil {
+		return m, notification.ErrorCmd(fmt.Sprintf("Failed to fork session: %v", err))
+	}
+
+	if err := store.AddSession(ctx, forkedSession); err != nil {
+		return m, notification.ErrorCmd(fmt.Sprintf("Failed to save forked session: %v", err))
+	}
+
+	a, _, cleanup, err := spawner(ctx, forkedSession.WorkingDir)
+	if err != nil {
+		return m, notification.ErrorCmd(fmt.Sprintf("Failed to create runtime for fork: %v", err))
+	}
+
+	a.ReplaceSession(ctx, forkedSession)
+	m.supervisor.AddSession(ctx, a, forkedSession, forkedSession.WorkingDir, cleanup)
+
+	if m.tuiStore != nil {
+		if err := m.tuiStore.AddTab(ctx, forkedSession.ID, forkedSession.WorkingDir); err != nil {
+			slog.Warn("Failed to persist forked tab", "error", err)
+		}
+	}
+
+	return m.handleSwitchTab(forkedSession.ID)
+}
+
 func (m *appModel) handleToggleSessionStar(sessionID string) (tea.Model, tea.Cmd) {
 	store := m.application.SessionStore()
 	if store == nil {

--- a/pkg/tui/messages/session.go
+++ b/pkg/tui/messages/session.go
@@ -68,6 +68,9 @@ type (
 	// RegenerateTitleMsg regenerates the session title using the AI.
 	RegenerateTitleMsg struct{}
 
+	// ForkSessionMsg requests forking the current session into a new tab.
+	ForkSessionMsg struct{}
+
 	// StreamCancelledMsg notifies components that the stream has been cancelled.
 	StreamCancelledMsg struct{ ShowMessage bool }
 

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -884,6 +884,9 @@ func (m *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case messages.BranchFromEditMsg:
 		return m.handleBranchFromEdit(msg)
 
+	case messages.ForkSessionMsg:
+		return m.handleForkSession()
+
 	// --- Session commands (slash commands, command palette) ---
 
 	case messages.ToggleYoloMsg:


### PR DESCRIPTION
When pursuing a multi-step objective and the user asks a side question (e.g., "how does X work?" or "what's the right approach for Y?"), LLM may shifts its entire objective to answering that question, which may losing all context of the original goal. Claude Code handles this well with its /fork command, which branches the session so side quests don't derail the main task 

**Start:** 
<img width="1001" height="336" alt="image" src="https://github.com/user-attachments/assets/25c999da-be47-4601-8d66-1e57c9a4cab8" />



**Fork** 
<img width="974" height="395" alt="image" src="https://github.com/user-attachments/assets/926b7a67-2c9c-4378-8d90-1b3719c9310b" />


**After forking:** 
<img width="991" height="585" alt="image" src="https://github.com/user-attachments/assets/08d94c12-871d-4c9c-8f2b-0a94c198ca28" />

<img width="979" height="399" alt="image" src="https://github.com/user-attachments/assets/e77b049b-8f35-4c1e-8543-8151dfd66be8" />




