### PR TITLE
fix: /exit closes only the current tab when multiple tabs are open

### DIFF
--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -812,6 +812,11 @@ func (m *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// --- Exit ---
 
 	case messages.ExitSessionMsg:
+		// If multiple tabs are open, close only the current tab instead of
+		// quitting the entire application (see #2373).
+		if m.supervisor != nil && m.supervisor.Count() > 1 {
+			return m.handleCloseTab(m.supervisor.ActiveID())
+		}
 		m.cleanupAll()
 		return m, tea.Quit
 


### PR DESCRIPTION
When multiple tabs are open, `/exit` now closes only the active tab instead of quitting the entire application. Single-tab behavior (quit) is unchanged.

Fixes #2373