### PR TITLE
fix: make Ctrl+W context-aware to preserve word deletion in editor

### DIFF
--- a/pkg/tui/components/tabbar/tabbar.go
+++ b/pkg/tui/components/tabbar/tabbar.go
@@ -146,6 +146,12 @@ func New(maxTitleLen int) *TabBar {
 	}
 }
 
+// SetCloseTabEnabled enables or disables the close-tab key binding.
+// When disabled, Ctrl+W passes through to the editor for word deletion.
+func (t *TabBar) SetCloseTabEnabled(v bool) {
+	t.keyMap.CloseTab.SetEnabled(v)
+}
+
 // SetWidth sets the available width for the tab bar.
 func (t *TabBar) SetWidth(width int) {
 	t.width = width

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -1775,7 +1775,10 @@ func (m *appModel) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 	// Tab bar keys (Ctrl+t, Ctrl+p, Ctrl+n, Ctrl+w) are suppressed during
 	// history search so that ctrl+n/ctrl+p cycle through matches instead.
+	// Ctrl+w (close tab) is disabled when the editor is focused so that the
+	// standard "delete word" shortcut works while typing.
 	if !m.leanMode && !m.editor.IsHistorySearchActive() {
+		m.tabBar.SetCloseTabEnabled(m.focusedPanel != PanelEditor)
 		if cmd := m.tabBar.Update(msg); cmd != nil {
 			return m, cmd
 		}


### PR DESCRIPTION
When the editor is focused, Ctrl+W now passes through for standard word deletion instead of closing the tab. A new `SetCloseTabEnabled` method on `TabBar` toggles the binding based on focus state before forwarding keys, keeping the logic encapsulated within the tab bar component.

Fixes #1771