### PR TITLE
Show total session count in session browser dialog title

### DIFF
--- a/pkg/tui/dialog/session_browser.go
+++ b/pkg/tui/dialog/session_browser.go
@@ -3,6 +3,7 @@ package dialog
 import (
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -314,13 +315,20 @@ func (d *sessionBrowserDialog) View() string {
 		scrollableContent = d.scrollview.View()
 	}
 
-	// Build title with filter indicator
-	title := "Sessions"
+	// Build title with session count and optional star-filter indicator.
+	// Show "filtered/total" when a search or star filter reduces the list.
+	var countLabel string
+	if len(d.filtered) == len(d.sessions) {
+		countLabel = strconv.Itoa(len(d.sessions))
+	} else {
+		countLabel = fmt.Sprintf("%d/%d", len(d.filtered), len(d.sessions))
+	}
+	title := fmt.Sprintf("Sessions (%s)", countLabel)
 	switch d.starFilter {
 	case 1:
-		title = "Sessions " + styles.StarredStyle.Render("★")
+		title += " " + styles.StarredStyle.Render("★")
 	case 2:
-		title = "Sessions " + styles.UnstarredStyle.Render("☆")
+		title += " " + styles.UnstarredStyle.Render("☆")
 	}
 
 	var filterDesc string


### PR DESCRIPTION
Display session count in the browser dialog title. Shows `Sessions (N)` normally, and `Sessions (3/10)` when a search query or star filter reduces the visible list, so the count always matches what the user sees.