### PR TITLE
Support explicit OAuth credentials for remote MCP servers

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -1253,6 +1253,10 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "oauth": {
+          "$ref": "#/definitions/RemoteOAuthConfig",
+          "description": "Explicit OAuth credentials for servers that do not support Dynamic Client Registration"
         }
       },
       "required": [
@@ -1686,6 +1690,36 @@
         "strategies"
       ],
       "additionalProperties": false
+    },
+    "RemoteOAuthConfig": {
+      "type": "object",
+      "description": "OAuth configuration for remote MCP servers that do not support Dynamic Client Registration (RFC 7591)",
+      "properties": {
+        "clientId": {
+          "type": "string",
+          "description": "OAuth client ID"
+        },
+        "clientSecret": {
+          "type": "string",
+          "description": "OAuth client secret"
+        },
+        "callbackPort": {
+          "type": "integer",
+          "description": "Fixed port for the OAuth callback server (default: random available port)",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "scopes": {
+          "type": "array",
+          "description": "OAuth scopes to request",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "clientId"
+      ]
     }
   }
 }

--- a/examples/remote_mcp_oauth.yaml
+++ b/examples/remote_mcp_oauth.yaml
@@ -1,0 +1,23 @@
+#!/usr/bin/env docker agent run
+
+# Example: Remote MCP server with explicit OAuth credentials.
+# Use this when connecting to MCP servers that do NOT support
+# Dynamic Client Registration (RFC 7591), such as Slack or GitHub.
+
+agents:
+  root:
+    model: openai/gpt-4.1-mini
+    description: Assistant with remote MCP tools using explicit OAuth credentials
+    instruction: You are a helpful assistant with access to remote tools.
+    toolsets:
+      - type: mcp
+        remote:
+          url: "https://mcp.example.com/sse"
+          transport_type: sse
+          oauth:
+            clientId: "your-client-id"
+            clientSecret: "your-client-secret"
+            callbackPort: 8080
+            scopes:
+              - "read"
+              - "write"

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -741,9 +741,19 @@ func (t *Toolset) UnmarshalYAML(unmarshal func(any) error) error {
 }
 
 type Remote struct {
-	URL           string            `json:"url"`
-	TransportType string            `json:"transport_type,omitempty"`
-	Headers       map[string]string `json:"headers,omitempty"`
+	URL           string             `json:"url"`
+	TransportType string             `json:"transport_type,omitempty"`
+	Headers       map[string]string  `json:"headers,omitempty"`
+	OAuth         *RemoteOAuthConfig `json:"oauth,omitempty"`
+}
+
+// RemoteOAuthConfig holds explicit OAuth credentials for remote MCP servers
+// that do not support Dynamic Client Registration (RFC 7591).
+type RemoteOAuthConfig struct {
+	ClientID     string   `json:"clientId"`
+	ClientSecret string   `json:"clientSecret,omitempty"`
+	CallbackPort int      `json:"callbackPort,omitempty"`
+	Scopes       []string `json:"scopes,omitempty"`
 }
 
 // DeferConfig represents the deferred loading configuration for a toolset.

--- a/pkg/config/latest/validate.go
+++ b/pkg/config/latest/validate.go
@@ -93,7 +93,7 @@ func (t *Toolset) validate() error {
 	if t.Ref != "" && t.Type != "mcp" && t.Type != "rag" {
 		return errors.New("ref can only be used with type 'mcp' or 'rag'")
 	}
-	if (t.Remote.URL != "" || t.Remote.TransportType != "") && t.Type != "mcp" {
+	if (t.Remote.URL != "" || t.Remote.TransportType != "" || t.Remote.OAuth != nil) && t.Type != "mcp" {
 		return errors.New("remote can only be used with type 'mcp'")
 	}
 	if (len(t.Remote.Headers) > 0) && (t.Type != "mcp" && t.Type != "a2a") {
@@ -138,6 +138,17 @@ func (t *Toolset) validate() error {
 		}
 		if count > 1 {
 			return errors.New("either command, remote or ref must be set, but only one of those")
+		}
+		if t.Remote.OAuth != nil {
+			if t.Remote.URL == "" {
+				return errors.New("oauth requires remote url to be set")
+			}
+			if t.Remote.OAuth.ClientID == "" {
+				return errors.New("oauth requires clientId to be set")
+			}
+			if t.Remote.OAuth.CallbackPort != 0 && (t.Remote.OAuth.CallbackPort < 1 || t.Remote.OAuth.CallbackPort > 65535) {
+				return errors.New("oauth callbackPort must be between 1 and 65535")
+			}
 		}
 	case "a2a":
 		if t.URL == "" {

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -362,6 +362,7 @@ func (r *RemoteRuntime) handleOAuthElicitation(ctx context.Context, req *Elicita
 		state,
 		oauth2.S256ChallengeFromVerifier(verifier),
 		serverURL,
+		nil,
 	)
 
 	slog.Debug("Authorization URL built", "url", authURL)

--- a/pkg/teamloader/registry.go
+++ b/pkg/teamloader/registry.go
@@ -251,7 +251,7 @@ func createMCPTool(ctx context.Context, toolset latest.Toolset, _ string, runCon
 
 		// TODO(dga): until the MCP Gateway supports oauth with docker agent, we fetch the remote url and directly connect to it.
 		if serverSpec.Type == "remote" {
-			return mcp.NewRemoteToolset(toolset.Name, serverSpec.Remote.URL, serverSpec.Remote.TransportType, nil), nil
+			return mcp.NewRemoteToolset(toolset.Name, serverSpec.Remote.URL, serverSpec.Remote.TransportType, nil, nil), nil
 		}
 
 		env, err := environment.ExpandAll(ctx, environment.ToValues(toolset.Env), envProvider)
@@ -292,7 +292,7 @@ func createMCPTool(ctx context.Context, toolset latest.Toolset, _ string, runCon
 		headers := expander.ExpandMap(ctx, toolset.Remote.Headers)
 		url := expander.Expand(ctx, toolset.Remote.URL, nil)
 
-		return mcp.NewRemoteToolset(toolset.Name, url, toolset.Remote.TransportType, headers), nil
+		return mcp.NewRemoteToolset(toolset.Name, url, toolset.Remote.TransportType, headers, toolset.Remote.OAuth), nil
 
 	default:
 		return nil, errors.New("mcp toolset requires either ref, command, or remote configuration")

--- a/pkg/tools/mcp/describe_test.go
+++ b/pkg/tools/mcp/describe_test.go
@@ -24,21 +24,21 @@ func TestToolsetDescribe_StdioNoArgs(t *testing.T) {
 func TestToolsetDescribe_RemoteHostAndPort(t *testing.T) {
 	t.Parallel()
 
-	ts := NewRemoteToolset("", "http://example.com:8443/mcp/v1?key=secret", "sse", nil)
+	ts := NewRemoteToolset("", "http://example.com:8443/mcp/v1?key=secret", "sse", nil, nil)
 	assert.Check(t, is.Equal(ts.Describe(), "mcp(remote host=example.com:8443 transport=sse)"))
 }
 
 func TestToolsetDescribe_RemoteDefaultPort(t *testing.T) {
 	t.Parallel()
 
-	ts := NewRemoteToolset("", "https://api.example.com/mcp", "streamable", nil)
+	ts := NewRemoteToolset("", "https://api.example.com/mcp", "streamable", nil, nil)
 	assert.Check(t, is.Equal(ts.Describe(), "mcp(remote host=api.example.com transport=streamable)"))
 }
 
 func TestToolsetDescribe_RemoteInvalidURL(t *testing.T) {
 	t.Parallel()
 
-	ts := NewRemoteToolset("", "://bad-url", "sse", nil)
+	ts := NewRemoteToolset("", "://bad-url", "sse", nil, nil)
 	assert.Check(t, is.Equal(ts.Describe(), "mcp(remote transport=sse)"))
 }
 

--- a/pkg/tools/mcp/mcp.go
+++ b/pkg/tools/mcp/mcp.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/tools"
 )
 
@@ -105,13 +106,13 @@ func NewToolsetCommand(name, command string, args, env []string, cwd string) *To
 }
 
 // NewRemoteToolset creates a new MCP toolset from a remote MCP Server.
-func NewRemoteToolset(name, urlString, transport string, headers map[string]string) *Toolset {
+func NewRemoteToolset(name, urlString, transport string, headers map[string]string, oauthConfig *latest.RemoteOAuthConfig) *Toolset {
 	slog.Debug("Creating Remote MCP toolset", "url", urlString, "transport", transport, "headers", headers)
 
 	desc := buildRemoteDescription(urlString, transport)
 	return &Toolset{
 		name:        name,
-		mcpClient:   newRemoteClient(urlString, transport, headers, NewKeyringTokenStore()),
+		mcpClient:   newRemoteClient(urlString, transport, headers, NewKeyringTokenStore(), oauthConfig),
 		logID:       urlString,
 		description: desc,
 	}

--- a/pkg/tools/mcp/oauth.go
+++ b/pkg/tools/mcp/oauth.go
@@ -17,6 +17,7 @@ import (
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 	"golang.org/x/oauth2"
 
+	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/tools"
 )
 
@@ -135,7 +136,8 @@ func validateAndFillDefaults(metadata *AuthorizationServerMetadata, authServerUR
 
 	metadata.AuthorizationEndpoint = cmp.Or(metadata.AuthorizationEndpoint, authServerURL+"/authorize")
 	metadata.TokenEndpoint = cmp.Or(metadata.TokenEndpoint, authServerURL+"/token")
-	metadata.RegistrationEndpoint = cmp.Or(metadata.RegistrationEndpoint, authServerURL+"/register")
+	// Do NOT fabricate a registration_endpoint — if the server doesn't
+	// advertise one, dynamic client registration is not supported.
 
 	return metadata
 }
@@ -146,7 +148,6 @@ func createDefaultMetadata(authServerURL string) *AuthorizationServerMetadata {
 		Issuer:                                 authServerURL,
 		AuthorizationEndpoint:                  authServerURL + "/authorize",
 		TokenEndpoint:                          authServerURL + "/token",
-		RegistrationEndpoint:                   authServerURL + "/register",
 		ResponseTypesSupported:                 []string{"code"},
 		ResponseModesSupported:                 []string{"query", "fragment"},
 		GrantTypesSupported:                    []string{"authorization_code"},
@@ -168,10 +169,11 @@ func resourceMetadataFromWWWAuth(wwwAuth string) string {
 type oauthTransport struct {
 	base http.RoundTripper
 	// TODO(rumpl): remove client reference, we need to find a better way to send elicitation requests
-	client     *remoteMCPClient
-	tokenStore OAuthTokenStore
-	baseURL    string
-	managed    bool
+	client      *remoteMCPClient
+	tokenStore  OAuthTokenStore
+	baseURL     string
+	managed     bool
+	oauthConfig *latest.RemoteOAuthConfig
 
 	// mu protects refreshFailedAt from concurrent access.
 	mu sync.Mutex
@@ -331,7 +333,11 @@ func (t *oauthTransport) handleManagedOAuthFlow(ctx context.Context, authServer,
 	}
 
 	slog.Debug("Creating OAuth callback server")
-	callbackServer, err := NewCallbackServer()
+	var callbackPort int
+	if t.oauthConfig != nil {
+		callbackPort = t.oauthConfig.CallbackPort
+	}
+	callbackServer, err := NewCallbackServerOnPort(callbackPort)
 	if err != nil {
 		return fmt.Errorf("failed to create callback server: %w", err)
 	}
@@ -352,8 +358,16 @@ func (t *oauthTransport) handleManagedOAuthFlow(ctx context.Context, authServer,
 
 	var clientID string
 	var clientSecret string
+	var scopes []string
 
-	if authServerMetadata.RegistrationEndpoint != "" {
+	switch {
+	case t.oauthConfig != nil && t.oauthConfig.ClientID != "":
+		// Use explicit credentials from config
+		slog.Debug("Using explicit OAuth credentials from config")
+		clientID = t.oauthConfig.ClientID
+		clientSecret = t.oauthConfig.ClientSecret
+		scopes = t.oauthConfig.Scopes
+	case authServerMetadata.RegistrationEndpoint != "":
 		slog.Debug("Attempting dynamic client registration")
 		clientID, clientSecret, err = RegisterClient(ctx, authServerMetadata, redirectURI, nil)
 		if err != nil {
@@ -361,9 +375,9 @@ func (t *oauthTransport) handleManagedOAuthFlow(ctx context.Context, authServer,
 			// TODO(rumpl): fall back to requesting client ID from user
 			return err
 		}
-	} else {
+	default:
 		// TODO(rumpl): fall back to requesting client ID from user
-		return errors.New("authorization server does not support dynamic client registration")
+		return errors.New("authorization server does not support dynamic client registration and no explicit OAuth credentials configured")
 	}
 
 	state, err := GenerateState()
@@ -381,6 +395,7 @@ func (t *oauthTransport) handleManagedOAuthFlow(ctx context.Context, authServer,
 		state,
 		oauth2.S256ChallengeFromVerifier(verifier),
 		t.baseURL,
+		scopes,
 	)
 
 	result, err := t.client.requestElicitation(ctx, &mcpsdk.ElicitParams{

--- a/pkg/tools/mcp/oauth_helpers.go
+++ b/pkg/tools/mcp/oauth_helpers.go
@@ -28,7 +28,7 @@ func GenerateState() (string, error) {
 }
 
 // BuildAuthorizationURL builds the OAuth authorization URL with PKCE
-func BuildAuthorizationURL(authEndpoint, clientID, redirectURI, state, codeChallenge, resourceURL string) string {
+func BuildAuthorizationURL(authEndpoint, clientID, redirectURI, state, codeChallenge, resourceURL string, scopes []string) string {
 	params := url.Values{}
 	params.Set("response_type", "code")
 	params.Set("client_id", clientID)
@@ -37,6 +37,9 @@ func BuildAuthorizationURL(authEndpoint, clientID, redirectURI, state, codeChall
 	params.Set("code_challenge", codeChallenge)
 	params.Set("code_challenge_method", "S256")
 	params.Set("resource", resourceURL) // RFC 8707: Resource Indicators
+	if len(scopes) > 0 {
+		params.Set("scope", strings.Join(scopes, " "))
+	}
 	return authEndpoint + "?" + params.Encode()
 }
 

--- a/pkg/tools/mcp/oauth_login.go
+++ b/pkg/tools/mcp/oauth_login.go
@@ -100,6 +100,7 @@ func PerformOAuthLogin(ctx context.Context, serverURL string) error {
 		state,
 		oauth2.S256ChallengeFromVerifier(verifier),
 		serverURL,
+		nil,
 	)
 
 	// Open the browser and wait for the callback.

--- a/pkg/tools/mcp/oauth_server.go
+++ b/pkg/tools/mcp/oauth_server.go
@@ -27,10 +27,15 @@ type CallbackServer struct {
 	expectedState string
 }
 
-// NewCallbackServer creates a new OAuth callback server
+// NewCallbackServer creates a new OAuth callback server on a random available port
 func NewCallbackServer() (*CallbackServer, error) {
-	// Find an available port
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	return NewCallbackServerOnPort(0)
+}
+
+// NewCallbackServerOnPort creates a new OAuth callback server on a specific port.
+// Use port 0 to let the OS pick a random available port.
+func NewCallbackServerOnPort(port int) (*CallbackServer, error) {
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
 	if err != nil {
 		return nil, fmt.Errorf("failed to find available port: %w", err)
 	}

--- a/pkg/tools/mcp/reconnect_test.go
+++ b/pkg/tools/mcp/reconnect_test.go
@@ -121,7 +121,7 @@ func TestRemoteReconnectAfterServerRestart(t *testing.T) {
 	// --- Step 1–2: Start first server, connect toolset ---
 	shutdown1 := startServer(t)
 
-	ts := NewRemoteToolset("test", fmt.Sprintf("http://%s/mcp", addr), "streamable-http", nil)
+	ts := NewRemoteToolset("test", fmt.Sprintf("http://%s/mcp", addr), "streamable-http", nil, nil)
 	require.NoError(t, ts.Start(t.Context()))
 
 	toolList, err := ts.Tools(t.Context())
@@ -184,7 +184,7 @@ func TestRemoteReconnectRefreshesTools(t *testing.T) {
 	// --- Start server v1 with tools "alpha" + "shared" ---
 	shutdown1 := startMCPServer(t, addr, alphaTool, sharedTool)
 
-	ts := NewRemoteToolset("ns", fmt.Sprintf("http://%s/mcp", addr), "streamable-http", nil)
+	ts := NewRemoteToolset("ns", fmt.Sprintf("http://%s/mcp", addr), "streamable-http", nil, nil)
 
 	// Track toolsChangedHandler invocations.
 	toolsChangedCh := make(chan struct{}, 1)

--- a/pkg/tools/mcp/remote.go
+++ b/pkg/tools/mcp/remote.go
@@ -8,6 +8,7 @@ import (
 
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/upstream"
 )
 
@@ -19,9 +20,10 @@ type remoteMCPClient struct {
 	headers       map[string]string
 	tokenStore    OAuthTokenStore
 	managed       bool
+	oauthConfig   *latest.RemoteOAuthConfig
 }
 
-func newRemoteClient(url, transportType string, headers map[string]string, tokenStore OAuthTokenStore) *remoteMCPClient {
+func newRemoteClient(url, transportType string, headers map[string]string, tokenStore OAuthTokenStore, oauthConfig *latest.RemoteOAuthConfig) *remoteMCPClient {
 	slog.Debug("Creating remote MCP client", "url", url, "transport", transportType, "headers", headers)
 
 	if tokenStore == nil {
@@ -33,6 +35,7 @@ func newRemoteClient(url, transportType string, headers map[string]string, token
 		transportType: transportType,
 		headers:       headers,
 		tokenStore:    tokenStore,
+		oauthConfig:   oauthConfig,
 	}
 }
 
@@ -102,11 +105,12 @@ func (c *remoteMCPClient) createHTTPClient() *http.Client {
 
 	// Then wrap with OAuth support
 	transport = &oauthTransport{
-		base:       transport,
-		client:     c,
-		tokenStore: c.tokenStore,
-		baseURL:    c.url,
-		managed:    c.managed,
+		base:        transport,
+		client:      c,
+		tokenStore:  c.tokenStore,
+		baseURL:     c.url,
+		managed:     c.managed,
+		oauthConfig: c.oauthConfig,
 	}
 
 	return &http.Client{

--- a/pkg/tools/mcp/remote_test.go
+++ b/pkg/tools/mcp/remote_test.go
@@ -42,7 +42,7 @@ func TestRemoteClientCustomHeaders(t *testing.T) {
 		"Authorization": "Bearer custom-token",
 	}
 
-	client := newRemoteClient(server.URL, "sse", expectedHeaders, NewInMemoryTokenStore())
+	client := newRemoteClient(server.URL, "sse", expectedHeaders, NewInMemoryTokenStore(), nil)
 
 	// Try to initialize (which will make the HTTP request)
 	// We don't care if it succeeds or fails, we just need it to make the request
@@ -91,7 +91,7 @@ func TestRemoteClientHeadersWithStreamable(t *testing.T) {
 		"X-Custom-Auth": "custom-auth-value",
 	}
 
-	client := newRemoteClient(server.URL, "streamable", expectedHeaders, NewInMemoryTokenStore())
+	client := newRemoteClient(server.URL, "streamable", expectedHeaders, NewInMemoryTokenStore(), nil)
 
 	// Try to initialize
 	_, _ = client.Initialize(t.Context(), nil)
@@ -131,7 +131,7 @@ func TestRemoteClientNoHeaders(t *testing.T) {
 	defer server.Close()
 
 	// Create remote client without custom headers (nil)
-	client := newRemoteClient(server.URL, "sse", nil, NewInMemoryTokenStore())
+	client := newRemoteClient(server.URL, "sse", nil, NewInMemoryTokenStore(), nil)
 
 	_, _ = client.Initialize(t.Context(), nil)
 
@@ -167,7 +167,7 @@ func TestRemoteClientEmptyHeaders(t *testing.T) {
 	defer server.Close()
 
 	// Create remote client with empty headers map
-	client := newRemoteClient(server.URL, "sse", map[string]string{}, NewInMemoryTokenStore())
+	client := newRemoteClient(server.URL, "sse", map[string]string{}, NewInMemoryTokenStore(), nil)
 
 	_, _ = client.Initialize(t.Context(), nil)
 


### PR DESCRIPTION
This PR is an attempt at continuing the work started in #2273 and #2274 to fix #2248.

## Problem

Remote MCP servers that don't support Dynamic Client Registration (RFC 7591) — such as Slack and GitHub — fail because the code fabricates a `registration_endpoint` when none is advertised, then tries (and fails) to dynamically register.

## Solution

Allow users to configure explicit OAuth credentials (`clientId`, `clientSecret`, `callbackPort`, `scopes`) directly in the remote MCP toolset config. The managed OAuth flow now resolves credentials in priority order:

1. **Explicit config** — use `clientId`/`clientSecret` from the YAML
2. **Dynamic registration** — if the server advertises a `registration_endpoint`
3. **Error** — clear message explaining neither option is available

## Key changes

- Add `RemoteOAuthConfig` to config types with `clientId`, `clientSecret`, `callbackPort`, and `scopes` fields
- Stop fabricating `registration_endpoint` in `validateAndFillDefaults()` and `createDefaultMetadata()`
- Use explicit credentials in the managed OAuth flow when configured
- Support fixed callback port for OAuth redirect URI
- Add `scopes` parameter to `BuildAuthorizationURL`
- Validate `callbackPort` range (1–65535) and `oauth` on non-mcp types
- Update `agent-schema.json` with `RemoteOAuthConfig` definition
- Add example config (`examples/remote_mcp_oauth.yaml`)

## Example

```yaml
toolsets:
  - type: mcp
    remote:
      url: "https://mcp.example.com/sse"
      transport_type: sse
      oauth:
        clientId: "your-client-id"
        clientSecret: "your-client-secret"
        callbackPort: 8080
        scopes:
          - "read"
          - "write"
```

Co-authored-by: nicholasgasior <nicholasgasior@users.noreply.github.com>
Co-authored-by: rumpl <rumpl@users.noreply.github.com>