### PR TITLE
Fix sidebar agent click zones mapping all lines to first agent

### DIFF
--- a/pkg/tui/components/sidebar/agent_click_test.go
+++ b/pkg/tui/components/sidebar/agent_click_test.go
@@ -1,0 +1,54 @@
+package sidebar
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/tui/service"
+)
+
+func TestSidebar_HandleClickType_Agent(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	sessionState := service.NewSessionState(sess)
+	sessionState.SetCurrentAgentName("agent1")
+	sb := New(sessionState)
+
+	m := sb.(*model)
+	m.sessionHasContent = true
+	m.titleGenerated = true
+	m.sessionTitle = "Test"
+	m.currentAgent = "agent1"
+	m.availableAgents = []runtime.AgentDetails{
+		{Name: "agent1", Provider: "openai", Model: "gpt-4", Description: "First agent"},
+		{Name: "agent2", Provider: "anthropic", Model: "claude", Description: "Second agent"},
+	}
+	m.width = 40
+	m.height = 50
+
+	// Force a render to populate agentClickZones
+	_ = sb.View()
+
+	paddingLeft := m.layoutCfg.PaddingLeft
+
+	// Verify clicking on agent1 lines returns ClickAgent with "agent1"
+	foundAgent1 := false
+	foundAgent2 := false
+	for y := range len(m.cachedLines) {
+		result, agentName := sb.HandleClickType(paddingLeft+2, y)
+		if result == ClickAgent {
+			if agentName == "agent1" {
+				foundAgent1 = true
+			}
+			if agentName == "agent2" {
+				foundAgent2 = true
+			}
+		}
+	}
+	assert.True(t, foundAgent1, "should be able to click on agent1")
+	assert.True(t, foundAgent2, "should be able to click on agent2")
+}

--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -13,6 +13,7 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/docker/docker-agent/pkg/paths"
 	"github.com/docker/docker-agent/pkg/runtime"
@@ -1214,6 +1215,13 @@ func (m *model) renderAgentEntry(content *strings.Builder, agent runtime.AgentDe
 	content.WriteString(toolcommon.TruncateText("Model: "+agent.Model, maxWidth))
 }
 
+// isVisuallyBlank returns true if a rendered line contains no visible content.
+// Lines may contain ANSI escape codes and whitespace padding from lipgloss styles
+// (e.g., TabStyle.Width()), so we strip ANSI sequences and check for whitespace.
+func isVisuallyBlank(line string) bool {
+	return strings.TrimSpace(ansi.Strip(line)) == ""
+}
+
 // buildAgentClickZones populates agentClickZones by scanning the rendered lines
 // to find which lines belong to which agent. It relies on the structure produced
 // by renderTab + agentInfo: a 2-line tab header, then agent blocks separated by
@@ -1230,7 +1238,7 @@ func (m *model) buildAgentClickZones(agentSectionStart int, lines []string) {
 	inBlock := false
 
 	for i := agentSectionStart + tabHeaderLines; i < len(lines) && agentIdx < len(m.availableAgents); i++ {
-		if lipgloss.Width(lines[i]) == 0 {
+		if isVisuallyBlank(lines[i]) {
 			// Blank line: if we were inside a block, advance to the next agent
 			if inBlock {
 				agentIdx++


### PR DESCRIPTION
## Problem

Clicking on an agent in the sidebar always switched to the first agent, regardless of which agent was clicked.

## Root Cause

`buildAgentClickZones` used `lipgloss.Width(lines[i]) == 0` to detect blank separator lines between agent blocks. However, `TabStyle.Width()` pads all lines with whitespace, so separator lines had non-zero width. This caused every agent line to be mapped to the first agent.

## Fix

Replace the width check with `isVisuallyBlank()`, which strips ANSI escape codes and checks for whitespace-only content. Added a regression test that verifies clicking on each agent in a multi-agent sidebar correctly identifies the right agent.