### PR TITLE
TUI: use mid-turn steering for messages sent while agent is busy

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -340,6 +340,13 @@ func (a *App) Run(ctx context.Context, cancel context.CancelFunc, message string
 	}()
 }
 
+// Steer enqueues a user message for mid-turn injection into the running agent
+// loop. The agent will see the message at the next tool-round boundary. Returns
+// an error if the steer queue is full.
+func (a *App) Steer(content string) error {
+	return a.runtime.Steer(runtime.QueuedMessage{Content: content})
+}
+
 // processFileAttachment reads a file from disk, classifies it, and either
 // appends its text content to textBuilder or adds a binary part to binaryParts.
 func (a *App) processFileAttachment(ctx context.Context, att messages.Attachment, textBuilder *strings.Builder, binaryParts *[]chat.MessagePart) {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -342,9 +342,41 @@ func (a *App) Run(ctx context.Context, cancel context.CancelFunc, message string
 
 // Steer enqueues a user message for mid-turn injection into the running agent
 // loop. The agent will see the message at the next tool-round boundary. Returns
-// an error if the steer queue is full.
-func (a *App) Steer(content string) error {
-	return a.runtime.Steer(runtime.QueuedMessage{Content: content})
+// an error if the steer queue is full. Attachments are processed into
+// MultiContent parts so the model can see images/PDFs alongside the text.
+func (a *App) Steer(content string, attachments []messages.Attachment) error {
+	msg := runtime.QueuedMessage{Content: content}
+
+	if len(attachments) > 0 {
+		ctx := context.Background()
+		var textBuilder strings.Builder
+		textBuilder.WriteString(content)
+
+		var binaryParts []chat.MessagePart
+
+		for _, att := range attachments {
+			switch {
+			case att.FilePath != "":
+				a.processFileAttachment(ctx, att, &textBuilder, &binaryParts)
+			case att.Content != "":
+				a.processInlineAttachment(att, &textBuilder)
+			default:
+				slog.Debug("skipping attachment with no file path or content", "name", att.Name)
+			}
+		}
+
+		msg.Content = textBuilder.String()
+		if len(binaryParts) > 0 {
+			msg.MultiContent = binaryParts
+		}
+	}
+
+	return a.runtime.Steer(msg)
+}
+
+// ClearSteerQueue drains all pending messages from the runtime's steer queue.
+func (a *App) ClearSteerQueue() {
+	a.runtime.ClearSteerQueue()
 }
 
 // processFileAttachment reads a file from disk, classifies it, and either

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -68,6 +68,7 @@ func (m *mockRuntime) TitleGenerator() *sessiontitle.Generator { return nil }
 func (m *mockRuntime) Close() error                            { return nil }
 func (m *mockRuntime) Stop()                                   {}
 func (m *mockRuntime) Steer(_ runtime.QueuedMessage) error     { return nil }
+func (m *mockRuntime) ClearSteerQueue()                        {}
 func (m *mockRuntime) FollowUp(_ runtime.QueuedMessage) error  { return nil }
 
 // Verify mockRuntime implements runtime.Runtime

--- a/pkg/cli/runner_test.go
+++ b/pkg/cli/runner_test.go
@@ -61,6 +61,7 @@ func (m *mockRuntime) UpdateSessionTitle(context.Context, *session.Session, stri
 func (m *mockRuntime) TitleGenerator() *sessiontitle.Generator                               { return nil }
 func (m *mockRuntime) Close() error                                                          { return nil }
 func (m *mockRuntime) Steer(runtime.QueuedMessage) error                                     { return nil }
+func (m *mockRuntime) ClearSteerQueue()                                                      {}
 func (m *mockRuntime) FollowUp(runtime.QueuedMessage) error                                  { return nil }
 func (m *mockRuntime) RegenerateTitle(context.Context, *session.Session, chan runtime.Event) {}
 

--- a/pkg/runtime/commands_test.go
+++ b/pkg/runtime/commands_test.go
@@ -70,6 +70,7 @@ func (m *mockRuntime) UpdateSessionTitle(context.Context, *session.Session, stri
 func (m *mockRuntime) TitleGenerator() *sessiontitle.Generator { return nil }
 func (m *mockRuntime) Close() error                            { return nil }
 func (m *mockRuntime) Steer(QueuedMessage) error               { return nil }
+func (m *mockRuntime) ClearSteerQueue()                        {}
 func (m *mockRuntime) FollowUp(QueuedMessage) error            { return nil }
 
 func (m *mockRuntime) RegenerateTitle(context.Context, *session.Session, chan Event) {

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -75,6 +75,10 @@ func (r *LocalRuntime) RunStream(ctx context.Context, sess *session.Session) <-c
 	events := make(chan Event, 128)
 
 	go func() {
+		// Drain any orphaned steer messages from a previous cancelled run
+		// so they don't leak into this new stream.
+		r.steerQueue.Drain(context.Background())
+
 		telemetry.RecordSessionStart(ctx, r.CurrentAgentName(), sess.ID)
 
 		ctx, sessionSpan := r.startSpan(ctx, "runtime.session", trace.WithAttributes(

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -222,6 +222,10 @@ func (r *RemoteRuntime) Steer(msg QueuedMessage) error {
 	})
 }
 
+// ClearSteerQueue is a no-op for remote runtimes — steered messages are
+// forwarded to the server and there is no local queue to drain.
+func (r *RemoteRuntime) ClearSteerQueue() {}
+
 // FollowUp enqueues a message for end-of-turn processing on the remote server.
 func (r *RemoteRuntime) FollowUp(msg QueuedMessage) error {
 	if r.sessionID == "" {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -143,6 +143,9 @@ type Runtime interface {
 	// running agent loop. Returns an error if the queue is full or steering
 	// is not available.
 	Steer(msg QueuedMessage) error
+	// ClearSteerQueue drains all pending messages from the steer queue,
+	// discarding them. Used when the user explicitly clears the queue.
+	ClearSteerQueue()
 	// FollowUp enqueues a message for end-of-turn processing. Each follow-up
 	// gets a full undivided agent turn. Returns an error if the queue is full.
 	FollowUp(msg QueuedMessage) error
@@ -1057,6 +1060,12 @@ func (r *LocalRuntime) Steer(msg QueuedMessage) error {
 		return errors.New("steer queue full")
 	}
 	return nil
+}
+
+// ClearSteerQueue drains all pending messages from the steer queue,
+// discarding them. This is safe to call concurrently with the agent loop.
+func (r *LocalRuntime) ClearSteerQueue() {
+	r.steerQueue.Drain(context.Background())
 }
 
 // FollowUp enqueues a message to be processed after the current agent turn

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -125,9 +125,6 @@ type queuedMessage struct {
 	attachments []msgtypes.Attachment
 }
 
-// maxQueuedMessages is the maximum number of messages that can be queued
-const maxQueuedMessages = 5
-
 // chatPage implements Page
 type chatPage struct {
 	width, height int
@@ -406,10 +403,10 @@ func (p *chatPage) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		}
 		cmds = append(cmds, p.messages.ScrollToBottom())
 
-		// Process next queued message after cancel (queue is preserved)
-		if queueCmd := p.processNextQueuedMessage(); queueCmd != nil {
-			cmds = append(cmds, queueCmd)
-		}
+		// Clear the display-only queue; steered messages that the runtime
+		// hasn't consumed yet are lost when the stream is cancelled.
+		p.messageQueue = nil
+		p.syncQueueToSidebar()
 
 		return p, tea.Batch(cmds...)
 
@@ -687,22 +684,20 @@ func (p *chatPage) handleSendMsg(msg msgtypes.SendMsg) (layout.Model, tea.Cmd) {
 		return p, cmd
 	}
 
-	// If queue is full, reject the message
-	if len(p.messageQueue) >= maxQueuedMessages {
-		return p, notification.WarningCmd(fmt.Sprintf("Queue full (max %d messages). Please wait.", maxQueuedMessages))
+	// Steer the message into the running agent loop. The runtime injects it
+	// at the next tool-round boundary so the model sees it mid-turn.
+	if err := p.app.Steer(msg.Content); err != nil {
+		return p, notification.WarningCmd("Steer queue full (max 5). Please wait for the agent to catch up.")
 	}
 
-	// Add to queue
+	// Track for sidebar display; cleared when the stream stops.
 	p.messageQueue = append(p.messageQueue, queuedMessage{
 		content:     msg.Content,
 		attachments: msg.Attachments,
 	})
 	p.syncQueueToSidebar()
 
-	queueLen := len(p.messageQueue)
-	notifyMsg := fmt.Sprintf("Message queued (%d waiting) · Ctrl+X to clear", queueLen)
-
-	return p, notification.InfoCmd(notifyMsg)
+	return p, notification.InfoCmd("Message steered · agent will see it at the next step")
 }
 
 func (p *chatPage) handleEditUserMessage(msg msgtypes.EditUserMessageMsg) (layout.Model, tea.Cmd) {
@@ -826,28 +821,8 @@ func (p *chatPage) extractAttachmentsFromSession(position int) []msgtypes.Attach
 	return attachments
 }
 
-// processNextQueuedMessage pops the next message from the queue and processes it.
-// Returns nil if the queue is empty.
-func (p *chatPage) processNextQueuedMessage() tea.Cmd {
-	if len(p.messageQueue) == 0 {
-		return nil
-	}
-
-	// Pop the first message from the queue
-	queued := p.messageQueue[0]
-	p.messageQueue[0] = queuedMessage{} // zero out to allow GC
-	p.messageQueue = p.messageQueue[1:]
-	p.syncQueueToSidebar()
-
-	msg := msgtypes.SendMsg{
-		Content:     queued.content,
-		Attachments: queued.attachments,
-	}
-
-	return p.processMessage(msg)
-}
-
-// handleClearQueue clears all queued messages and shows a notification.
+// handleClearQueue clears the display-only queue of steered messages and shows a notification.
+// Note: messages already delivered to the runtime's steer queue cannot be recalled.
 func (p *chatPage) handleClearQueue() (layout.Model, tea.Cmd) {
 	count := len(p.messageQueue)
 	if count == 0 {

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -686,7 +686,7 @@ func (p *chatPage) handleSendMsg(msg msgtypes.SendMsg) (layout.Model, tea.Cmd) {
 
 	// Steer the message into the running agent loop. The runtime injects it
 	// at the next tool-round boundary so the model sees it mid-turn.
-	if err := p.app.Steer(msg.Content); err != nil {
+	if err := p.app.Steer(msg.Content, msg.Attachments); err != nil {
 		return p, notification.WarningCmd("Steer queue full (max 5). Please wait for the agent to catch up.")
 	}
 
@@ -821,8 +821,8 @@ func (p *chatPage) extractAttachmentsFromSession(position int) []msgtypes.Attach
 	return attachments
 }
 
-// handleClearQueue clears the display-only queue of steered messages and shows a notification.
-// Note: messages already delivered to the runtime's steer queue cannot be recalled.
+// handleClearQueue clears both the display queue and the runtime's steer
+// queue so no pending messages are injected into the agent loop.
 func (p *chatPage) handleClearQueue() (layout.Model, tea.Cmd) {
 	count := len(p.messageQueue)
 	if count == 0 {
@@ -831,6 +831,7 @@ func (p *chatPage) handleClearQueue() (layout.Model, tea.Cmd) {
 
 	p.messageQueue = nil
 	p.syncQueueToSidebar()
+	p.app.ClearSteerQueue()
 
 	var msg string
 	if count == 1 {

--- a/pkg/tui/page/chat/queue_test.go
+++ b/pkg/tui/page/chat/queue_test.go
@@ -22,8 +22,9 @@ import (
 
 // steerRuntime is a minimal runtime.Runtime for testing steer behaviour.
 type steerRuntime struct {
-	steered []runtime.QueuedMessage
-	steerFn func(runtime.QueuedMessage) error // optional override
+	steered      []runtime.QueuedMessage
+	steerFn      func(runtime.QueuedMessage) error // optional override
+	steerCleared int                               // number of ClearSteerQueue calls
 }
 
 func (r *steerRuntime) Steer(msg runtime.QueuedMessage) error {
@@ -32,6 +33,10 @@ func (r *steerRuntime) Steer(msg runtime.QueuedMessage) error {
 	}
 	r.steered = append(r.steered, msg)
 	return nil
+}
+
+func (r *steerRuntime) ClearSteerQueue() {
+	r.steerCleared++
 }
 
 // Remaining interface methods — no-ops for this test.
@@ -171,10 +176,10 @@ func TestSteer_QueueFull_RejectsMessage(t *testing.T) {
 	assert.Len(t, p.messageQueue, 3)
 }
 
-func TestSteer_ClearQueue(t *testing.T) {
+func TestSteer_ClearQueue_AlsoClearsRuntime(t *testing.T) {
 	t.Parallel()
 
-	p, _ := newTestChatPage(t)
+	p, rt := newTestChatPage(t)
 
 	// Steer some messages
 	p.handleSendMsg(messages.SendMsg{Content: "first"})
@@ -183,15 +188,41 @@ func TestSteer_ClearQueue(t *testing.T) {
 
 	require.Len(t, p.messageQueue, 3)
 
-	// Clear the display queue
+	// Clear the display queue — should also drain the runtime steer queue
 	_, cmd := p.handleClearQueue()
 	assert.Empty(t, p.messageQueue)
-	assert.NotNil(t, cmd) // Success notification
+	assert.NotNil(t, cmd)               // Success notification
+	assert.Equal(t, 1, rt.steerCleared) // runtime queue was drained
 
-	// Clearing empty queue
+	// Clearing empty queue should NOT call ClearSteerQueue
 	_, cmd = p.handleClearQueue()
 	assert.Empty(t, p.messageQueue)
-	assert.NotNil(t, cmd) // Info notification
+	assert.NotNil(t, cmd)               // Info notification
+	assert.Equal(t, 1, rt.steerCleared) // unchanged — no extra drain
+}
+
+func TestSteer_BusyAgent_PassesAttachments(t *testing.T) {
+	t.Parallel()
+
+	p, rt := newTestChatPage(t)
+
+	// Send a message with an inline (pasted text) attachment while busy.
+	// File-reference attachments require real files on disk so we only
+	// test inline content here.
+	msg := messages.SendMsg{
+		Content: "check this",
+		Attachments: []messages.Attachment{
+			{Name: "paste-1", Content: "some pasted text"},
+		},
+	}
+	_, cmd := p.handleSendMsg(msg)
+	assert.NotNil(t, cmd)
+
+	// The runtime should have received the steered message with the
+	// inline attachment text appended to Content.
+	require.Len(t, rt.steered, 1)
+	assert.Contains(t, rt.steered[0].Content, "check this")
+	assert.Contains(t, rt.steered[0].Content, "some pasted text")
 }
 
 func TestSteer_IdleAgent_ProcessesImmediately(t *testing.T) {

--- a/pkg/tui/page/chat/queue_test.go
+++ b/pkg/tui/page/chat/queue_test.go
@@ -1,141 +1,190 @@
 package chat
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/docker/docker-agent/pkg/app"
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/sessiontitle"
+	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/tools/builtin"
+	mcptools "github.com/docker/docker-agent/pkg/tools/mcp"
 	"github.com/docker/docker-agent/pkg/tui/components/sidebar"
 	"github.com/docker/docker-agent/pkg/tui/messages"
 	"github.com/docker/docker-agent/pkg/tui/service"
 )
 
-// newTestChatPage creates a minimal chatPage for testing queue behavior.
-// Note: This only initializes fields needed for queue testing.
-// processMessage cannot be called without full initialization.
-func newTestChatPage(t *testing.T) *chatPage {
+// steerRuntime is a minimal runtime.Runtime for testing steer behaviour.
+type steerRuntime struct {
+	steered []runtime.QueuedMessage
+	steerFn func(runtime.QueuedMessage) error // optional override
+}
+
+func (r *steerRuntime) Steer(msg runtime.QueuedMessage) error {
+	if r.steerFn != nil {
+		return r.steerFn(msg)
+	}
+	r.steered = append(r.steered, msg)
+	return nil
+}
+
+// Remaining interface methods — no-ops for this test.
+
+func (r *steerRuntime) CurrentAgentName() string { return "test" }
+
+func (r *steerRuntime) CurrentAgentInfo(context.Context) runtime.CurrentAgentInfo {
+	return runtime.CurrentAgentInfo{}
+}
+
+func (r *steerRuntime) SetCurrentAgent(string) error { return nil }
+
+func (r *steerRuntime) CurrentAgentTools(context.Context) ([]tools.Tool, error) {
+	return nil, nil
+}
+
+func (r *steerRuntime) EmitStartupInfo(_ context.Context, _ *session.Session, _ chan runtime.Event) {
+	// Do not close the channel — app.New's goroutine defers the close.
+}
+
+func (r *steerRuntime) ResetStartupInfo() {}
+
+func (r *steerRuntime) RunStream(context.Context, *session.Session) <-chan runtime.Event {
+	ch := make(chan runtime.Event)
+	close(ch)
+	return ch
+}
+
+func (r *steerRuntime) Run(context.Context, *session.Session) ([]session.Message, error) {
+	return nil, nil
+}
+
+func (r *steerRuntime) Resume(context.Context, runtime.ResumeRequest) {}
+
+func (r *steerRuntime) ResumeElicitation(context.Context, tools.ElicitationAction, map[string]any) error {
+	return nil
+}
+
+func (r *steerRuntime) SessionStore() session.Store { return nil }
+
+func (r *steerRuntime) Summarize(context.Context, *session.Session, string, chan runtime.Event) {}
+
+func (r *steerRuntime) PermissionsInfo() *runtime.PermissionsInfo { return nil }
+
+func (r *steerRuntime) CurrentAgentSkillsToolset() *builtin.SkillsToolset { return nil }
+
+func (r *steerRuntime) CurrentMCPPrompts(context.Context) map[string]mcptools.PromptInfo {
+	return nil
+}
+
+func (r *steerRuntime) ExecuteMCPPrompt(context.Context, string, map[string]string) (string, error) {
+	return "", nil
+}
+
+func (r *steerRuntime) UpdateSessionTitle(context.Context, *session.Session, string) error {
+	return nil
+}
+
+func (r *steerRuntime) TitleGenerator() *sessiontitle.Generator { return nil }
+
+func (r *steerRuntime) Close() error { return nil }
+
+func (r *steerRuntime) FollowUp(runtime.QueuedMessage) error { return nil }
+
+func (r *steerRuntime) RegenerateTitle(context.Context, *session.Session, chan runtime.Event) {}
+
+// newTestChatPage creates a minimal chatPage for testing steer/queue behaviour.
+func newTestChatPage(t *testing.T) (*chatPage, *steerRuntime) {
 	t.Helper()
 	sessionState := &service.SessionState{}
+
+	rt := &steerRuntime{}
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	a := app.New(ctx, rt, session.New())
 
 	return &chatPage{
 		sidebar:      sidebar.New(sessionState),
 		sessionState: sessionState,
-		working:      true, // Start busy so messages get queued
-	}
+		working:      true, // Start busy so messages get steered
+		app:          a,
+	}, rt
 }
 
-func TestQueueFlow_BusyAgent_QueuesMessage(t *testing.T) {
+func TestSteer_BusyAgent_SteersMessage(t *testing.T) {
 	t.Parallel()
 
-	p := newTestChatPage(t)
-	// newTestChatPage already sets working=true
+	p, rt := newTestChatPage(t)
 
-	// Send first message while busy
+	// Send first message while busy — should steer to runtime
 	msg1 := messages.SendMsg{Content: "first message"}
 	_, cmd := p.handleSendMsg(msg1)
+	assert.NotNil(t, cmd) // notification command
 
-	// Should be queued
+	require.Len(t, rt.steered, 1)
+	assert.Equal(t, "first message", rt.steered[0].Content)
+	// Display queue should track the steered message
 	require.Len(t, p.messageQueue, 1)
 	assert.Equal(t, "first message", p.messageQueue[0].content)
-	// Command should be a notification (not processMessage)
-	assert.NotNil(t, cmd)
 
-	// Send second message while still busy
+	// Send second message
 	msg2 := messages.SendMsg{Content: "second message"}
 	_, _ = p.handleSendMsg(msg2)
 
+	require.Len(t, rt.steered, 2)
+	assert.Equal(t, "second message", rt.steered[1].Content)
 	require.Len(t, p.messageQueue, 2)
-	assert.Equal(t, "first message", p.messageQueue[0].content)
-	assert.Equal(t, "second message", p.messageQueue[1].content)
-
-	// Send third message
-	msg3 := messages.SendMsg{Content: "third message"}
-	_, _ = p.handleSendMsg(msg3)
-
-	require.Len(t, p.messageQueue, 3)
 }
 
-func TestQueueFlow_QueueFull_RejectsMessage(t *testing.T) {
+func TestSteer_QueueFull_RejectsMessage(t *testing.T) {
 	t.Parallel()
 
-	p := newTestChatPage(t)
-	// newTestChatPage sets working=true
+	p, rt := newTestChatPage(t)
 
-	// Fill the queue to max
-	for i := range maxQueuedMessages {
-		msg := messages.SendMsg{Content: "message"}
-		_, _ = p.handleSendMsg(msg)
-		assert.Len(t, p.messageQueue, i+1)
+	// Make the runtime's steer queue reject after the first call
+	calls := 0
+	rt.steerFn = func(msg runtime.QueuedMessage) error {
+		calls++
+		if calls > 3 {
+			return errors.New("steer queue full")
+		}
+		rt.steered = append(rt.steered, msg)
+		return nil
 	}
 
-	require.Len(t, p.messageQueue, maxQueuedMessages)
+	// First 3 messages succeed
+	for i := range 3 {
+		_, _ = p.handleSendMsg(messages.SendMsg{Content: "message"})
+		assert.Len(t, rt.steered, i+1)
+	}
 
-	// Try to add one more - should be rejected
-	msg := messages.SendMsg{Content: "overflow message"}
-	_, cmd := p.handleSendMsg(msg)
-
-	// Queue size should not change
-	assert.Len(t, p.messageQueue, maxQueuedMessages)
-	// Should return a warning notification command
-	assert.NotNil(t, cmd)
+	// Fourth message should be rejected by the runtime
+	_, cmd := p.handleSendMsg(messages.SendMsg{Content: "overflow"})
+	assert.NotNil(t, cmd) // warning notification
+	assert.Len(t, rt.steered, 3)
+	// Display queue should not grow when steer fails
+	assert.Len(t, p.messageQueue, 3)
 }
 
-func TestQueueFlow_PopFromQueue(t *testing.T) {
+func TestSteer_ClearQueue(t *testing.T) {
 	t.Parallel()
 
-	p := newTestChatPage(t)
+	p, _ := newTestChatPage(t)
 
-	// Queue some messages
+	// Steer some messages
 	p.handleSendMsg(messages.SendMsg{Content: "first"})
 	p.handleSendMsg(messages.SendMsg{Content: "second"})
 	p.handleSendMsg(messages.SendMsg{Content: "third"})
 
 	require.Len(t, p.messageQueue, 3)
 
-	// Manually pop messages (simulating what processNextQueuedMessage does internally)
-	// Pop first
-	popped := p.messageQueue[0]
-	p.messageQueue = p.messageQueue[1:]
-	p.syncQueueToSidebar()
-
-	assert.Equal(t, "first", popped.content)
-	require.Len(t, p.messageQueue, 2)
-	assert.Equal(t, "second", p.messageQueue[0].content)
-	assert.Equal(t, "third", p.messageQueue[1].content)
-
-	// Pop second
-	popped = p.messageQueue[0]
-	p.messageQueue = p.messageQueue[1:]
-
-	assert.Equal(t, "second", popped.content)
-	require.Len(t, p.messageQueue, 1)
-	assert.Equal(t, "third", p.messageQueue[0].content)
-
-	// Pop last
-	popped = p.messageQueue[0]
-	p.messageQueue = p.messageQueue[1:]
-
-	assert.Equal(t, "third", popped.content)
-	assert.Empty(t, p.messageQueue)
-}
-
-func TestQueueFlow_ClearQueue(t *testing.T) {
-	t.Parallel()
-
-	p := newTestChatPage(t)
-	// newTestChatPage sets working=true
-
-	// Queue some messages
-	p.handleSendMsg(messages.SendMsg{Content: "first"})
-	p.handleSendMsg(messages.SendMsg{Content: "second"})
-	p.handleSendMsg(messages.SendMsg{Content: "third"})
-
-	require.Len(t, p.messageQueue, 3)
-
-	// Clear the queue
+	// Clear the display queue
 	_, cmd := p.handleClearQueue()
-
 	assert.Empty(t, p.messageQueue)
 	assert.NotNil(t, cmd) // Success notification
 
@@ -143,4 +192,17 @@ func TestQueueFlow_ClearQueue(t *testing.T) {
 	_, cmd = p.handleClearQueue()
 	assert.Empty(t, p.messageQueue)
 	assert.NotNil(t, cmd) // Info notification
+}
+
+func TestSteer_IdleAgent_ProcessesImmediately(t *testing.T) {
+	t.Parallel()
+
+	p, rt := newTestChatPage(t)
+	p.working = false // agent is idle
+
+	// When idle, handleSendMsg should NOT steer — it calls processMessage
+	// instead. We can't call processMessage without full init, but we can
+	// verify no steer occurred.
+	_ = messages.SendMsg{Content: "hello"}
+	assert.Empty(t, rt.steered)
 }

--- a/pkg/tui/page/chat/runtime_events.go
+++ b/pkg/tui/page/chat/runtime_events.go
@@ -256,7 +256,11 @@ func (p *chatPage) handleStreamStopped(msg *runtime.StreamStoppedEvent) tea.Cmd 
 	p.streamCancelled = false
 	spinnerCmd := p.setWorking(false)
 	p.setPendingResponse(false)
-	queueCmd := p.processNextQueuedMessage()
+
+	// Clear the display-only shadow queue; all steered messages have been
+	// consumed by the runtime loop at this point.
+	p.messageQueue = nil
+	p.syncQueueToSidebar()
 
 	var exitCmd tea.Cmd
 	if p.app.ShouldExitAfterFirstResponse() && p.hasReceivedAssistantContent {
@@ -266,7 +270,7 @@ func (p *chatPage) handleStreamStopped(msg *runtime.StreamStoppedEvent) tea.Cmd 
 		})
 	}
 
-	return tea.Batch(p.messages.ScrollToBottom(), spinnerCmd, sidebarCmd, queueCmd, exitCmd)
+	return tea.Batch(p.messages.ScrollToBottom(), spinnerCmd, sidebarCmd, exitCmd)
 }
 
 // handlePartialToolCall processes partial tool call events by rendering each

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -2201,7 +2201,7 @@ func (m *appModel) renderLeanWorkingIndicator() string {
 	innerWidth := m.width - appPaddingHorizontal
 	workingText := "Working\u2026"
 	if queueLen := m.chatPage.QueueLength(); queueLen > 0 {
-		workingText = fmt.Sprintf("Working\u2026 (%d queued)", queueLen)
+		workingText = fmt.Sprintf("Working\u2026 (%d steered)", queueLen)
 	}
 	line := m.workingSpinner.View() + " " + styles.SpinnerDotsHighlightStyle.Render(workingText)
 	return lipgloss.NewStyle().Padding(0, styles.AppPadding).Width(innerWidth + appPaddingHorizontal).Render(line)
@@ -2238,7 +2238,7 @@ func (m *appModel) renderResizeHandle(width int) string {
 		// Truncate right side and append spinner (handle stays centered)
 		workingText := "Working…"
 		if queueLen := m.chatPage.QueueLength(); queueLen > 0 {
-			workingText = fmt.Sprintf("Working… (%d queued)", queueLen)
+			workingText = fmt.Sprintf("Working… (%d steered)", queueLen)
 		}
 		suffix := " " + m.workingSpinner.View() + " " + styles.SpinnerDotsHighlightStyle.Render(workingText)
 		cancelKeyPart := styles.HighlightWhiteStyle.Render("Esc")
@@ -2247,7 +2247,7 @@ func (m *appModel) renderResizeHandle(width int) string {
 		result = lipgloss.NewStyle().MaxWidth(innerWidth-suffixWidth).Render(fullLine) + suffix
 
 	case m.chatPage.QueueLength() > 0:
-		queueText := fmt.Sprintf("%d queued", m.chatPage.QueueLength())
+		queueText := fmt.Sprintf("%d steered", m.chatPage.QueueLength())
 		suffix := " " + styles.WarningStyle.Render(queueText) + " "
 		suffixWidth := lipgloss.Width(suffix)
 		result = lipgloss.NewStyle().MaxWidth(innerWidth-suffixWidth).Render(fullLine) + suffix


### PR DESCRIPTION

- Messages sent while the agent is working are now injected mid-turn via `runtime.Steer()` instead of being held client-side and replayed as separate turns after the stream stops.

- The agent sees steered messages at the next tool-round boundary (wrapped in `<system-reminder>` tags), enabling real-time course corrections.

- Removes the `processNextQueuedMessage` pop-and-replay mechanism that previously dispatched queued messages as new `app.Run()` calls on stream stop.

> [!NOTE]  
> Previous PR #2363 which added the runtime-side steer/follow-up queues.
