### PR TITLE
fix: retry MCP stdio toolset when binary is unavailable at startup

### DIFF
--- a/pkg/tools/mcp/mcp.go
+++ b/pkg/tools/mcp/mcp.go
@@ -118,9 +118,11 @@ func NewRemoteToolset(name, urlString, transport string, headers map[string]stri
 }
 
 // errServerUnavailable is returned by doStart when the MCP server could not be
-// reached but the error is non-fatal (e.g. EOF). The toolset is considered
-// "started" so the agent can proceed, but watchConnection must not be spawned
-// because there is no live connection to monitor.
+// reached but the error is non-fatal (e.g. EOF during stdio exec). Start()
+// propagates this error so the caller (StartableToolSet) does not mark the
+// toolset as started. The agent runtime calls ensureToolSetsAreStarted() at
+// the beginning of every conversation turn, which will retry Start() and
+// pick up the binary once it becomes available—no background goroutine needed.
 var errServerUnavailable = errors.New("MCP server unavailable")
 
 // Describe returns a short, user-visible description of this toolset instance.
@@ -158,13 +160,11 @@ func (ts *Toolset) Start(ctx context.Context) error {
 	ts.restarted = make(chan struct{})
 
 	if err := ts.doStart(ctx); err != nil {
-		if errors.Is(err, errServerUnavailable) {
-			// The server is unreachable but the error is non-fatal.
-			// Mark as started so the agent can proceed; tools will simply
-			// be empty. Don't spawn a watcher — there's nothing to watch.
-			ts.started = true
-			return nil
-		}
+		// errServerUnavailable is non-fatal: the binary is missing but may
+		// appear later. We propagate the error so that StartableToolSet does
+		// not mark us as started. The agent runtime retries Start() at the
+		// beginning of every conversation turn, which will pick up the
+		// binary once it is installed.
 		return err
 	}
 

--- a/pkg/tools/mcp/mcp.go
+++ b/pkg/tools/mcp/mcp.go
@@ -157,7 +157,9 @@ func (ts *Toolset) Start(ctx context.Context) error {
 		return nil
 	}
 
-	ts.restarted = make(chan struct{})
+	if ts.restarted == nil {
+		ts.restarted = make(chan struct{})
+	}
 
 	if err := ts.doStart(ctx); err != nil {
 		// errServerUnavailable is non-fatal: the binary is missing but may
@@ -242,7 +244,7 @@ func (ts *Toolset) doStart(ctx context.Context) error {
 		if !isInitNotificationSendError(err) {
 			if errors.Is(err, io.EOF) {
 				slog.Debug(
-					"MCP client unavailable (EOF), skipping MCP toolset",
+					"MCP client unavailable (EOF), will retry on next conversation turn",
 					"server", ts.logID,
 				)
 				return errServerUnavailable

--- a/pkg/tools/mcp/reconnect_test.go
+++ b/pkg/tools/mcp/reconnect_test.go
@@ -3,6 +3,8 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"io"
+	"iter"
 	"net"
 	"net/http"
 	"sync/atomic"
@@ -55,6 +57,154 @@ func allocateAddr(t *testing.T) string {
 	addr := ln.Addr().String()
 	ln.Close()
 	return addr
+}
+
+// unavailableThenAvailableMock is a mock client that returns io.EOF from
+// Initialize for a configurable number of calls, then starts succeeding.
+// This simulates a binary that is not installed at agent startup but later
+// becomes available on PATH.
+type unavailableThenAvailableMock struct {
+	reconnectableMockClient
+
+	initCount     atomic.Int32
+	availableFrom int32 // Initialize succeeds starting at this call number (1-based)
+	listToolsFn   func(context.Context, *gomcp.ListToolsParams) iter.Seq2[*gomcp.Tool, error]
+}
+
+func newUnavailableThenAvailableMock(availableFrom int32) *unavailableThenAvailableMock {
+	m := &unavailableThenAvailableMock{
+		availableFrom: availableFrom,
+	}
+	m.waitCh = make(chan struct{})
+	return m
+}
+
+func (m *unavailableThenAvailableMock) Initialize(ctx context.Context, req *gomcp.InitializeRequest) (*gomcp.InitializeResult, error) {
+	n := m.initCount.Add(1)
+	if n < m.availableFrom {
+		return nil, io.EOF
+	}
+	return m.reconnectableMockClient.Initialize(ctx, req)
+}
+
+func (m *unavailableThenAvailableMock) ListTools(ctx context.Context, req *gomcp.ListToolsParams) iter.Seq2[*gomcp.Tool, error] {
+	if m.listToolsFn != nil {
+		return m.listToolsFn(ctx, req)
+	}
+	return m.reconnectableMockClient.ListTools(ctx, req)
+}
+
+// TestStartReturnsErrorWhenBinaryUnavailable verifies that Start() returns
+// errServerUnavailable when the MCP binary is not found (EOF from Initialize).
+// The toolset must NOT be marked as started so the caller can retry later.
+func TestStartReturnsErrorWhenBinaryUnavailable(t *testing.T) {
+	t.Parallel()
+
+	mock := newUnavailableThenAvailableMock(1_000_000) // never available
+
+	ts := &Toolset{
+		mcpClient: mock,
+		logID:     "test-unavailable",
+	}
+
+	err := ts.Start(t.Context())
+	require.ErrorIs(t, err, errServerUnavailable)
+
+	ts.mu.Lock()
+	assert.False(t, ts.started, "should not be started when binary is unavailable")
+	ts.mu.Unlock()
+}
+
+// TestLazyRetryStartSucceedsWhenBinaryAppears verifies the lazy retry
+// pattern: Start() fails on the first call because the binary is missing,
+// then succeeds on a subsequent call once the binary is installed.
+// This mirrors the agent runtime's ensureToolSetsAreStarted() which calls
+// Start() at the beginning of every conversation turn.
+func TestLazyRetryStartSucceedsWhenBinaryAppears(t *testing.T) {
+	t.Parallel()
+
+	expectedTool := &gomcp.Tool{Name: "greet", InputSchema: &jsonschema.Schema{Type: "object"}}
+
+	mock := newUnavailableThenAvailableMock(2) // succeed from 2nd Initialize call
+	mock.listToolsFn = func(_ context.Context, _ *gomcp.ListToolsParams) iter.Seq2[*gomcp.Tool, error] {
+		return func(yield func(*gomcp.Tool, error) bool) {
+			yield(expectedTool, nil)
+		}
+	}
+
+	ts := &Toolset{
+		mcpClient: mock,
+		logID:     "test-lazy-retry",
+	}
+
+	// Turn 1: binary not installed yet — Start fails.
+	err := ts.Start(t.Context())
+	require.ErrorIs(t, err, errServerUnavailable)
+
+	ts.mu.Lock()
+	assert.False(t, ts.started)
+	ts.mu.Unlock()
+
+	// Turn 2: binary is now installed — Start succeeds.
+	err = ts.Start(t.Context())
+	require.NoError(t, err)
+
+	ts.mu.Lock()
+	assert.True(t, ts.started)
+	ts.mu.Unlock()
+
+	// Tools are now available.
+	toolList, toolErr := ts.Tools(t.Context())
+	require.NoError(t, toolErr)
+	require.Len(t, toolList, 1)
+	assert.Equal(t, "greet", toolList[0].Name)
+
+	_ = ts.Stop(t.Context())
+}
+
+// TestStartableToolSetRetryOnNextTurn verifies the full integration with
+// StartableToolSet: when the inner MCP Start() fails with errServerUnavailable,
+// StartableToolSet does not mark itself as started. On the next turn
+// (simulated by calling Start() again), the retry succeeds and tools appear.
+func TestStartableToolSetRetryOnNextTurn(t *testing.T) {
+	t.Parallel()
+
+	expectedTool := &gomcp.Tool{Name: "hello", InputSchema: &jsonschema.Schema{Type: "object"}}
+
+	mock := newUnavailableThenAvailableMock(3) // succeed from 3rd Initialize call
+	mock.listToolsFn = func(_ context.Context, _ *gomcp.ListToolsParams) iter.Seq2[*gomcp.Tool, error] {
+		return func(yield func(*gomcp.Tool, error) bool) {
+			yield(expectedTool, nil)
+		}
+	}
+
+	inner := &Toolset{
+		mcpClient: mock,
+		logID:     "test-startable",
+	}
+	startable := tools.NewStartable(inner)
+
+	// Turn 1: unavailable.
+	err := startable.Start(t.Context())
+	require.Error(t, err)
+	assert.False(t, startable.IsStarted())
+
+	// Turn 2: still unavailable.
+	err = startable.Start(t.Context())
+	require.Error(t, err)
+	assert.False(t, startable.IsStarted())
+
+	// Turn 3: binary appeared.
+	err = startable.Start(t.Context())
+	require.NoError(t, err)
+	assert.True(t, startable.IsStarted())
+
+	toolList, toolErr := startable.Tools(t.Context())
+	require.NoError(t, toolErr)
+	require.Len(t, toolList, 1)
+	assert.Equal(t, "hello", toolList[0].Name)
+
+	_ = startable.Stop(t.Context())
 }
 
 // TestRemoteReconnectAfterServerRestart verifies that a Toolset backed by a


### PR DESCRIPTION
When a stdio MCP toolset binary is not found at startup (EOF from Initialize), `Start()` now propagates `errServerUnavailable` instead of silently marking the toolset as started with empty tools.

- The agent runtime already calls `ensureToolSetsAreStarted()` at the beginning of every conversation turn, which calls `StartableToolSet.Start()`
- `StartableToolSet` only sets `started=true` when the inner `Start()` returns nil, so a failed start is automatically retried next turn
- Once the binary appears on PATH, `Start()` succeeds and tools become available — no background goroutine needed

Tests added:
- `Start()` returns error and does not mark started when binary is unavailable
- Lazy retry across turns: fail on turn 1, succeed on turn 2
- Full `StartableToolSet` integration across multiple turns

Fixes #2410