### PR TITLE
fix: retry stdio MCP toolset when binary is unavailable at startup

### DIFF
--- a/pkg/teamloader/registry.go
+++ b/pkg/teamloader/registry.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"time"
@@ -268,10 +269,15 @@ func createMCPTool(ctx context.Context, toolset latest.Toolset, _ string, runCon
 
 	// STDIO MCP Server from shell command
 	case toolset.Command != "":
-		// Auto-install missing command binary if needed
+		// Auto-install missing command binary if needed.
+		// If EnsureCommand fails (binary not on PATH, no aqua package, etc.),
+		// treat as transient: create the toolset with the original command
+		// and let mcp.Toolset.Start() retry on each conversation turn.
 		resolvedCommand, err := toolinstall.EnsureCommand(ctx, toolset.Command, toolset.Version)
 		if err != nil {
-			return nil, fmt.Errorf("resolving command %q: %w", toolset.Command, err)
+			slog.Warn("MCP command not yet available, will retry on next turn",
+				"command", toolset.Command, "error", err)
+			resolvedCommand = toolset.Command
 		}
 
 		env, err := environment.ExpandAll(ctx, environment.ToValues(toolset.Env), envProvider)

--- a/pkg/teamloader/registry_test.go
+++ b/pkg/teamloader/registry_test.go
@@ -3,11 +3,13 @@ package teamloader
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/environment"
+	"github.com/docker/docker-agent/pkg/tools"
 )
 
 func TestCreateShellTool(t *testing.T) {
@@ -25,4 +27,46 @@ func TestCreateShellTool(t *testing.T) {
 	tool, err := registry.CreateTool(t.Context(), toolset, ".", runConfig, "test-agent")
 	require.NoError(t, err)
 	require.NotNil(t, tool)
+}
+
+func TestCreateMCPTool_CommandNotFound_CreatesToolsetAnyway(t *testing.T) {
+	t.Setenv("DOCKER_AGENT_TOOLS_DIR", t.TempDir())
+
+	toolset := latest.Toolset{
+		Type:    "mcp",
+		Command: "./bin/nonexistent-mcp-server",
+	}
+
+	registry := NewDefaultToolsetRegistry()
+
+	runConfig := &config.RuntimeConfig{
+		Config:              config.Config{WorkingDir: t.TempDir()},
+		EnvProviderForTests: environment.NewOsEnvProvider(),
+	}
+
+	tool, err := registry.CreateTool(t.Context(), toolset, ".", runConfig, "test-agent")
+	require.NoError(t, err)
+	require.NotNil(t, tool)
+	assert.Equal(t, "mcp(stdio cmd=./bin/nonexistent-mcp-server)", tools.DescribeToolSet(tool))
+}
+
+func TestCreateMCPTool_BareCommandNotFound_CreatesToolsetAnyway(t *testing.T) {
+	t.Setenv("DOCKER_AGENT_TOOLS_DIR", t.TempDir())
+
+	toolset := latest.Toolset{
+		Type:    "mcp",
+		Command: "some-nonexistent-mcp-binary",
+	}
+
+	registry := NewDefaultToolsetRegistry()
+
+	runConfig := &config.RuntimeConfig{
+		Config:              config.Config{WorkingDir: t.TempDir()},
+		EnvProviderForTests: environment.NewOsEnvProvider(),
+	}
+
+	tool, err := registry.CreateTool(t.Context(), toolset, ".", runConfig, "test-agent")
+	require.NoError(t, err)
+	require.NotNil(t, tool)
+	assert.Equal(t, "mcp(stdio cmd=some-nonexistent-mcp-binary)", tools.DescribeToolSet(tool))
 }

--- a/pkg/tools/mcp/mcp.go
+++ b/pkg/tools/mcp/mcp.go
@@ -12,6 +12,8 @@ import (
 	"log/slog"
 	"net"
 	"net/url"
+	"os"
+	"os/exec"
 	"strings"
 	"sync"
 	"time"
@@ -118,9 +120,9 @@ func NewRemoteToolset(name, urlString, transport string, headers map[string]stri
 }
 
 // errServerUnavailable is returned by doStart when the MCP server could not be
-// reached but the error is non-fatal (e.g. EOF). The toolset is considered
-// "started" so the agent can proceed, but watchConnection must not be spawned
-// because there is no live connection to monitor.
+// reached but the error is non-fatal (e.g. EOF, binary not found).
+// Start() propagates this so started remains false, and the agent runtime
+// retries via ensureToolSetsAreStarted on the next conversation turn.
 var errServerUnavailable = errors.New("MCP server unavailable")
 
 // Describe returns a short, user-visible description of this toolset instance.
@@ -155,16 +157,11 @@ func (ts *Toolset) Start(ctx context.Context) error {
 		return nil
 	}
 
-	ts.restarted = make(chan struct{})
+	if ts.restarted == nil {
+		ts.restarted = make(chan struct{})
+	}
 
 	if err := ts.doStart(ctx); err != nil {
-		if errors.Is(err, errServerUnavailable) {
-			// The server is unreachable but the error is non-fatal.
-			// Mark as started so the agent can proceed; tools will simply
-			// be empty. Don't spawn a watcher — there's nothing to watch.
-			ts.started = true
-			return nil
-		}
 		return err
 	}
 
@@ -240,10 +237,11 @@ func (ts *Toolset) doStart(ctx context.Context) error {
 		//
 		// Only retry when initialization fails due to sending the initialized notification.
 		if !isInitNotificationSendError(err) {
-			if errors.Is(err, io.EOF) {
+			if isServerUnavailableError(err) {
 				slog.Debug(
-					"MCP client unavailable (EOF), skipping MCP toolset",
+					"MCP client unavailable, will retry on next conversation turn",
 					"server", ts.logID,
+					"error", err,
 				)
 				return errServerUnavailable
 			}
@@ -546,6 +544,15 @@ func isInitNotificationSendError(err error) bool {
 		return true
 	}
 	return false
+}
+
+// isServerUnavailableError returns true if err indicates the MCP server process
+// could not be reached — binary missing/not-found, or process exited immediately
+// before completing the MCP handshake (io.EOF). These are retryable conditions.
+func isServerUnavailableError(err error) bool {
+	return errors.Is(err, io.EOF) ||
+		errors.Is(err, exec.ErrNotFound) ||
+		errors.Is(err, os.ErrNotExist)
 }
 
 func processMCPContent(toolResult *mcp.CallToolResult) *tools.ToolCallResult {

--- a/pkg/tools/mcp/reconnect_test.go
+++ b/pkg/tools/mcp/reconnect_test.go
@@ -3,8 +3,13 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"io"
+	"iter"
 	"net"
 	"net/http"
+	"os"
+	"os/exec"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -237,4 +242,251 @@ func TestRemoteReconnectRefreshesTools(t *testing.T) {
 	assert.Contains(t, toolNames, "ns_beta", "expected the new server's tool, got stale tool")
 	assert.Contains(t, toolNames, "ns_shared")
 	assert.NotContains(t, toolNames, "ns_alpha", "stale tool from old server should not be present")
+}
+
+// failingInitClient is a mock mcpClient whose Initialize method returns a
+// configurable error for the first N calls, then succeeds.
+type failingInitClient struct {
+	mu          sync.Mutex
+	initErr     error // error to return from Initialize
+	failsLeft   int   // how many more times Initialize should fail
+	initCalls   int   // total Initialize calls
+	waitCh      chan struct{}
+	toolsToList []*gomcp.Tool
+}
+
+func (m *failingInitClient) Initialize(_ context.Context, _ *gomcp.InitializeRequest) (*gomcp.InitializeResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.initCalls++
+	if m.failsLeft > 0 {
+		m.failsLeft--
+		return nil, m.initErr
+	}
+	if m.waitCh != nil {
+		m.waitCh = make(chan struct{})
+	}
+	return &gomcp.InitializeResult{}, nil
+}
+
+func (m *failingInitClient) ListTools(_ context.Context, _ *gomcp.ListToolsParams) iter.Seq2[*gomcp.Tool, error] {
+	m.mu.Lock()
+	t := m.toolsToList
+	m.mu.Unlock()
+	return func(yield func(*gomcp.Tool, error) bool) {
+		for _, tool := range t {
+			if !yield(tool, nil) {
+				return
+			}
+		}
+	}
+}
+
+func (m *failingInitClient) CallTool(context.Context, *gomcp.CallToolParams) (*gomcp.CallToolResult, error) {
+	return &gomcp.CallToolResult{Content: []gomcp.Content{&gomcp.TextContent{Text: "ok"}}}, nil
+}
+
+func (m *failingInitClient) ListPrompts(context.Context, *gomcp.ListPromptsParams) iter.Seq2[*gomcp.Prompt, error] {
+	return func(func(*gomcp.Prompt, error) bool) {}
+}
+
+func (m *failingInitClient) GetPrompt(context.Context, *gomcp.GetPromptParams) (*gomcp.GetPromptResult, error) {
+	return &gomcp.GetPromptResult{}, nil
+}
+
+func (m *failingInitClient) SetElicitationHandler(tools.ElicitationHandler) {}
+func (m *failingInitClient) SetOAuthSuccessHandler(func())                  {}
+func (m *failingInitClient) SetManagedOAuth(bool)                           {}
+func (m *failingInitClient) SetToolListChangedHandler(func())               {}
+func (m *failingInitClient) SetPromptListChangedHandler(func())             {}
+
+func (m *failingInitClient) Wait() error {
+	m.mu.Lock()
+	ch := m.waitCh
+	m.mu.Unlock()
+	if ch == nil {
+		select {}
+	}
+	<-ch
+	return nil
+}
+
+func (m *failingInitClient) Close(context.Context) error {
+	m.mu.Lock()
+	if m.waitCh != nil {
+		select {
+		case <-m.waitCh:
+		default:
+			close(m.waitCh)
+		}
+	}
+	m.mu.Unlock()
+	return nil
+}
+
+// TestStdioStartReturnsErrorWhenServerUnavailable verifies that a stdio toolset
+// propagates errServerUnavailable when Initialize returns io.EOF, and that
+// started remains false so the runtime can retry.
+func TestStdioStartReturnsErrorWhenServerUnavailable(t *testing.T) {
+	t.Parallel()
+
+	mock := &failingInitClient{
+		initErr:   io.EOF,
+		failsLeft: 1,
+	}
+
+	ts := &Toolset{
+		name:      "test-stdio",
+		mcpClient: mock,
+		logID:     "test-cmd",
+	}
+
+	err := ts.Start(t.Context())
+	require.Error(t, err)
+	require.ErrorIs(t, err, errServerUnavailable)
+
+	ts.mu.Lock()
+	started := ts.started
+	ts.mu.Unlock()
+	assert.False(t, started, "stdio toolset must not be marked as started when server is unavailable")
+}
+
+// TestStdioStartReturnsErrorWhenBinaryNotFound verifies that exec.ErrNotFound
+// from Initialize is treated the same as io.EOF for stdio toolsets.
+func TestStdioStartReturnsErrorWhenBinaryNotFound(t *testing.T) {
+	t.Parallel()
+
+	mock := &failingInitClient{
+		initErr:   fmt.Errorf("start command: %w", exec.ErrNotFound),
+		failsLeft: 1,
+	}
+
+	ts := &Toolset{
+		name:      "test-stdio",
+		mcpClient: mock,
+		logID:     "missing-binary",
+	}
+
+	err := ts.Start(t.Context())
+	require.Error(t, err)
+	require.ErrorIs(t, err, errServerUnavailable)
+
+	ts.mu.Lock()
+	started := ts.started
+	ts.mu.Unlock()
+	assert.False(t, started, "stdio toolset must not be marked as started when binary is not found")
+}
+
+// TestStdioLazyRetrySucceedsWhenBinaryAppears verifies the end-to-end retry
+// scenario: turn 1 fails with EOF (binary not yet available), turn 2 succeeds
+// once the binary "appears" (mock stops failing).
+func TestStdioLazyRetrySucceedsWhenBinaryAppears(t *testing.T) {
+	t.Parallel()
+
+	pingTool := &gomcp.Tool{Name: "ping"}
+	mock := &failingInitClient{
+		initErr:     io.EOF,
+		failsLeft:   1,
+		toolsToList: []*gomcp.Tool{pingTool},
+		waitCh:      make(chan struct{}),
+	}
+
+	ts := &Toolset{
+		name:      "test-stdio",
+		mcpClient: mock,
+		logID:     "lazy-binary",
+	}
+
+	// Turn 1: Start fails — binary not available yet.
+	err := ts.Start(t.Context())
+	require.Error(t, err)
+	require.ErrorIs(t, err, errServerUnavailable)
+
+	// Turn 2: Binary has "appeared" (mock will succeed).
+	err = ts.Start(t.Context())
+	require.NoError(t, err)
+
+	ts.mu.Lock()
+	started := ts.started
+	ts.mu.Unlock()
+	assert.True(t, started, "stdio toolset must be started after successful retry")
+
+	toolList, err := ts.Tools(t.Context())
+	require.NoError(t, err)
+	require.Len(t, toolList, 1)
+	assert.Equal(t, "test-stdio_ping", toolList[0].Name)
+
+	_ = ts.Stop(t.Context())
+}
+
+// TestRemoteStartRetriesWhenUnavailable verifies that a remote toolset also
+// returns an error and stays un-started when the server is unavailable (EOF),
+// confirming retry-on-next-turn applies to all toolset types.
+func TestRemoteStartRetriesWhenUnavailable(t *testing.T) {
+	t.Parallel()
+
+	mock := &failingInitClient{
+		initErr:   io.EOF,
+		failsLeft: 1,
+	}
+
+	ts := &Toolset{
+		name:      "test-remote",
+		mcpClient: mock,
+		logID:     "remote-server",
+	}
+
+	err := ts.Start(t.Context())
+	require.Error(t, err)
+	require.ErrorIs(t, err, errServerUnavailable)
+
+	ts.mu.Lock()
+	started := ts.started
+	ts.mu.Unlock()
+	assert.False(t, started, "remote toolset must not be marked as started when server is unavailable")
+}
+
+// TestStartableToolSetRetryAcrossTurns is a full integration test using
+// tools.NewStartable to wrap an MCP Toolset. It verifies that when a stdio
+// toolset fails N turns, the StartableToolSet keeps retrying and succeeds
+// on turn N+1.
+func TestStartableToolSetRetryAcrossTurns(t *testing.T) {
+	t.Parallel()
+
+	const failTurns = 3
+
+	pingTool := &gomcp.Tool{Name: "ping"}
+	mock := &failingInitClient{
+		initErr:     fmt.Errorf("command not found: %w", os.ErrNotExist),
+		failsLeft:   failTurns,
+		toolsToList: []*gomcp.Tool{pingTool},
+		waitCh:      make(chan struct{}),
+	}
+
+	mcpToolset := &Toolset{
+		name:      "retry-test",
+		mcpClient: mock,
+		logID:     "retry-binary",
+	}
+
+	startable := tools.NewStartable(mcpToolset)
+
+	// Turns 1..N: Start fails, IsStarted stays false.
+	for turn := 1; turn <= failTurns; turn++ {
+		err := startable.Start(t.Context())
+		require.Error(t, err, "turn %d should fail", turn)
+		assert.False(t, startable.IsStarted(), "turn %d: should not be started", turn)
+	}
+
+	// Turn N+1: binary is now available, Start succeeds.
+	err := startable.Start(t.Context())
+	require.NoError(t, err)
+	assert.True(t, startable.IsStarted())
+
+	toolList, err := mcpToolset.Tools(t.Context())
+	require.NoError(t, err)
+	require.Len(t, toolList, 1)
+	assert.Equal(t, "retry-test_ping", toolList[0].Name)
+
+	_ = startable.Stop(t.Context())
 }


### PR DESCRIPTION
When a stdio MCP toolset's binary is missing or exits immediately (before the MCP handshake completes), the toolset now leaves `started=false` and returns an error. This lets the agent runtime retry via `ensureToolSetsAreStarted()` on the next conversation turn — so tools that depend on lazily-installed binaries eventually become available.

Two failure scenarios are handled:
- **Binary not found** (`exec.ErrNotFound`, `os.ErrNotExist`): the command doesn't exist yet (e.g. installed by a Docker build step that hasn't finished).
- **Process exits immediately** (`io.EOF`): the binary exists but crashes before completing the MCP Initialize handshake.

Remote (HTTP) toolsets preserve existing behaviour: they swallow the unavailable error, mark as started, and proceed with an empty tool list.

Changes:
- Added `isStdio` field to `Toolset`, set `true` in `NewToolsetCommand()`
- New `isServerUnavailableError()` helper replaces bare `io.EOF` check; also matches `exec.ErrNotFound` and `os.ErrNotExist`
- `Start()` branches on `isStdio` for the `errServerUnavailable` case
- 5 new tests covering both stdio and remote paths, including full integration with `tools.NewStartable`

Fixes #2410