### PR TITLE
fix: hold mutex for instructions read in MCP Toolset.Instructions()

### DIFF
--- a/pkg/model/provider/rulebased/client.go
+++ b/pkg/model/provider/rulebased/client.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
 
 	"github.com/blevesearch/bleve/v2"
 	"github.com/blevesearch/bleve/v2/mapping"
@@ -45,6 +46,7 @@ type Client struct {
 	routes         []Provider
 	fallback       Provider
 	index          bleve.Index
+	mu             sync.RWMutex
 	lastSelectedID string // ID of the provider selected by the most recent call
 }
 
@@ -165,10 +167,13 @@ func (c *Client) CreateChatCompletionStream(
 		return nil, errors.New("no provider available for routing")
 	}
 
-	c.lastSelectedID = provider.ID()
+	selectedID := provider.ID()
+	c.mu.Lock()
+	c.lastSelectedID = selectedID
+	c.mu.Unlock()
 	slog.Debug("Rule-based router selected model",
 		"router", c.ID(),
-		"selected_model", c.lastSelectedID,
+		"selected_model", selectedID,
 		"message_count", len(messages),
 	)
 
@@ -179,6 +184,8 @@ func (c *Client) CreateChatCompletionStream(
 // recent CreateChatCompletionStream call. This allows callers to display
 // the YAML-configured sub-model name for rule-based routing.
 func (c *Client) LastSelectedModelID() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	return c.lastSelectedID
 }
 

--- a/pkg/model/provider/rulebased/client_race_test.go
+++ b/pkg/model/provider/rulebased/client_race_test.go
@@ -1,0 +1,44 @@
+package rulebased
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLastSelectedModelID_Concurrent(t *testing.T) {
+	t.Parallel()
+
+	cfg := &latest.ModelConfig{
+		Provider: "openai",
+		Model:    "gpt-4o",
+		Routing: []latest.RoutingRule{
+			{
+				Model:    "anthropic/claude-3-haiku",
+				Examples: []string{"hello", "hi there"},
+			},
+		},
+	}
+
+	client, err := NewClient(t.Context(), cfg, nil, nil, mockProviderFactory)
+	require.NoError(t, err)
+	defer client.Close()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			messages := []chat.Message{{Role: chat.MessageRoleUser, Content: "hello"}}
+			_, _ = client.CreateChatCompletionStream(t.Context(), messages, nil)
+		}()
+		go func() {
+			defer wg.Done()
+			_ = client.LastSelectedModelID()
+		}()
+	}
+	wg.Wait()
+}

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -472,6 +472,8 @@ func (s *Session) AddMessageUsageRecord(agentName, model string, cost float64, u
 	if usage == nil {
 		return
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.MessageUsageHistory = append(s.MessageUsageHistory, MessageUsageRecord{
 		AgentName: agentName,
 		Model:     model,

--- a/pkg/session/session_race_test.go
+++ b/pkg/session/session_race_test.go
@@ -1,0 +1,24 @@
+package session
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/docker/docker-agent/pkg/chat"
+)
+
+func TestAddMessageUsageRecordConcurrent(t *testing.T) {
+	s := New()
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s.AddMessageUsageRecord("agent", "model", 0.1, &chat.Usage{InputTokens: 10, OutputTokens: 5})
+		}()
+	}
+	wg.Wait()
+	if got := len(s.MessageUsageHistory); got != 100 {
+		t.Errorf("expected 100 records, got %d", got)
+	}
+}

--- a/pkg/tools/mcp/mcp.go
+++ b/pkg/tools/mcp/mcp.go
@@ -341,9 +341,8 @@ func (ts *Toolset) tryRestart(ctx context.Context) bool {
 
 func (ts *Toolset) Instructions() string {
 	ts.mu.Lock()
-	started := ts.started
-	ts.mu.Unlock()
-	if !started {
+	defer ts.mu.Unlock()
+	if !ts.started {
 		// TODO: this should never happen...
 		return ""
 	}

--- a/pkg/tools/mcp/mcp_race_test.go
+++ b/pkg/tools/mcp/mcp_race_test.go
@@ -1,0 +1,32 @@
+package mcp
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestInstructions_Concurrent(t *testing.T) {
+	t.Parallel()
+
+	ts := &Toolset{
+		started:      true,
+		instructions: "initial",
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			// Simulate what doStart does (always called under ts.mu)
+			ts.mu.Lock()
+			ts.instructions = "updated"
+			ts.mu.Unlock()
+		}()
+		go func() {
+			defer wg.Done()
+			_ = ts.Instructions()
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Instructions() checked ts.started under the lock, released it, then read ts.instructions unlocked. A concurrent doStart could write ts.instructions in between. Keeps the lock held with defer for the entire method.