### PR TITLE
fix: replace time.Sleep with context-aware select in MCP tryRestart

### DIFF
--- a/pkg/model/provider/anthropic/client.go
+++ b/pkg/model/provider/anthropic/client.go
@@ -671,7 +671,7 @@ func extractSystemBlocks(messages []chat.Message) []anthropic.TextBlockParam {
 			})
 		}
 
-		if msg.CacheControl {
+		if msg.CacheControl && len(systemBlocks) > 0 {
 			systemBlocks[len(systemBlocks)-1].CacheControl = anthropic.NewCacheControlEphemeralParam()
 		}
 	}

--- a/pkg/model/provider/anthropic/client_test.go
+++ b/pkg/model/provider/anthropic/client_test.go
@@ -523,3 +523,20 @@ func TestExtractSystemBlocksCacheControl(t *testing.T) {
 	assert.Equal(t, "ephemeral", string(blocks[3].CacheControl.Type))
 	assert.Empty(t, string(blocks[3].CacheControl.TTL))
 }
+
+func TestExtractSystemBlocks_EmptyContentWithCacheControl(t *testing.T) {
+	t.Parallel()
+
+	// An empty system message with CacheControl must not panic.
+	msgs := []chat.Message{
+		{
+			Role:         chat.MessageRoleSystem,
+			Content:      "",
+			CacheControl: true,
+		},
+	}
+
+	// Before the fix this panicked with index out of range [-1].
+	blocks := extractSystemBlocks(msgs)
+	assert.Empty(t, blocks)
+}

--- a/pkg/model/provider/rulebased/client.go
+++ b/pkg/model/provider/rulebased/client.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
 
 	"github.com/blevesearch/bleve/v2"
 	"github.com/blevesearch/bleve/v2/mapping"
@@ -45,6 +46,7 @@ type Client struct {
 	routes         []Provider
 	fallback       Provider
 	index          bleve.Index
+	mu             sync.RWMutex
 	lastSelectedID string // ID of the provider selected by the most recent call
 }
 
@@ -165,10 +167,13 @@ func (c *Client) CreateChatCompletionStream(
 		return nil, errors.New("no provider available for routing")
 	}
 
-	c.lastSelectedID = provider.ID()
+	selectedID := provider.ID()
+	c.mu.Lock()
+	c.lastSelectedID = selectedID
+	c.mu.Unlock()
 	slog.Debug("Rule-based router selected model",
 		"router", c.ID(),
-		"selected_model", c.lastSelectedID,
+		"selected_model", selectedID,
 		"message_count", len(messages),
 	)
 
@@ -179,6 +184,8 @@ func (c *Client) CreateChatCompletionStream(
 // recent CreateChatCompletionStream call. This allows callers to display
 // the YAML-configured sub-model name for rule-based routing.
 func (c *Client) LastSelectedModelID() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	return c.lastSelectedID
 }
 

--- a/pkg/model/provider/rulebased/client_race_test.go
+++ b/pkg/model/provider/rulebased/client_race_test.go
@@ -1,0 +1,44 @@
+package rulebased
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLastSelectedModelID_Concurrent(t *testing.T) {
+	t.Parallel()
+
+	cfg := &latest.ModelConfig{
+		Provider: "openai",
+		Model:    "gpt-4o",
+		Routing: []latest.RoutingRule{
+			{
+				Model:    "anthropic/claude-3-haiku",
+				Examples: []string{"hello", "hi there"},
+			},
+		},
+	}
+
+	client, err := NewClient(t.Context(), cfg, nil, nil, mockProviderFactory)
+	require.NoError(t, err)
+	defer client.Close()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			messages := []chat.Message{{Role: chat.MessageRoleUser, Content: "hello"}}
+			_, _ = client.CreateChatCompletionStream(t.Context(), messages, nil)
+		}()
+		go func() {
+			defer wg.Done()
+			_ = client.LastSelectedModelID()
+		}()
+	}
+	wg.Wait()
+}

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -110,7 +110,7 @@ func (r *LocalRuntime) RunStream(ctx context.Context, sess *session.Session) <-c
 		events <- ToolsetInfo(len(agentTools), false, a.Name())
 
 		messages := sess.GetMessages(a)
-		if sess.SendUserMessage {
+		if sess.SendUserMessage && len(messages) > 0 {
 			lastMsg := messages[len(messages)-1]
 			events <- UserMessage(lastMsg.Content, sess.ID, lastMsg.MultiContent, len(sess.Messages)-1)
 		}

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -1950,3 +1950,34 @@ func TestMergeExcludedTools(t *testing.T) {
 		assert.ElementsMatch(t, []string{"run_skill", "shell", "read_skill"}, result)
 	})
 }
+
+func TestRunStream_EmptyMessages_SendUserMessage(t *testing.T) {
+	t.Parallel()
+
+	// session.New() defaults to SendUserMessage=true with no messages.
+	// With an empty instruction the system prompt is also empty, so
+	// GetMessages returns an empty slice.
+	// Before the fix, messages[len(messages)-1] panicked with index -1.
+	stream := newStreamBuilder().
+		AddContent("hello").
+		AddStopWithUsage(5, 5).
+		Build()
+
+	prov := &mockProvider{id: "test/mock-model", stream: stream}
+	root := agent.New("root", "", agent.WithModel(prov))
+	tm := team.New(team.WithAgents(root))
+
+	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+
+	sess := session.New() // SendUserMessage=true, no messages
+	sess.Title = "Unit Test"
+
+	// Must not panic.
+	evCh := rt.RunStream(t.Context(), sess)
+	var events []Event
+	for ev := range evCh {
+		events = append(events, ev)
+	}
+	require.NotEmpty(t, events)
+}

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -472,6 +472,8 @@ func (s *Session) AddMessageUsageRecord(agentName, model string, cost float64, u
 	if usage == nil {
 		return
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.MessageUsageHistory = append(s.MessageUsageHistory, MessageUsageRecord{
 		AgentName: agentName,
 		Model:     model,

--- a/pkg/session/session_race_test.go
+++ b/pkg/session/session_race_test.go
@@ -1,0 +1,24 @@
+package session
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/docker/docker-agent/pkg/chat"
+)
+
+func TestAddMessageUsageRecordConcurrent(t *testing.T) {
+	s := New()
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s.AddMessageUsageRecord("agent", "model", 0.1, &chat.Usage{InputTokens: 10, OutputTokens: 5})
+		}()
+	}
+	wg.Wait()
+	if got := len(s.MessageUsageHistory); got != 100 {
+		t.Errorf("expected 100 records, got %d", got)
+	}
+}

--- a/pkg/tools/mcp/mcp.go
+++ b/pkg/tools/mcp/mcp.go
@@ -341,9 +341,8 @@ func (ts *Toolset) tryRestart(ctx context.Context) bool {
 
 func (ts *Toolset) Instructions() string {
 	ts.mu.Lock()
-	started := ts.started
-	ts.mu.Unlock()
-	if !started {
+	defer ts.mu.Unlock()
+	if !ts.started {
 		// TODO: this should never happen...
 		return ""
 	}

--- a/pkg/tools/mcp/mcp.go
+++ b/pkg/tools/mcp/mcp.go
@@ -311,7 +311,14 @@ func (ts *Toolset) tryRestart(ctx context.Context) bool {
 	for attempt := range maxAttempts {
 		backoff := time.Duration(1<<uint(attempt)) * time.Second
 		slog.Debug("Restarting MCP server", "server", ts.logID, "attempt", attempt+1, "backoff", backoff)
-		time.Sleep(backoff)
+
+		timer := time.NewTimer(backoff)
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			timer.Stop()
+			return false
+		}
 
 		ts.mu.Lock()
 		if ts.stopping {

--- a/pkg/tools/mcp/mcp_race_test.go
+++ b/pkg/tools/mcp/mcp_race_test.go
@@ -1,8 +1,12 @@
 package mcp
 
 import (
+	"context"
 	"sync"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestInstructions_Concurrent(t *testing.T) {
@@ -29,4 +33,32 @@ func TestInstructions_Concurrent(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+func TestTryRestart_RespectsContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	ts := &Toolset{
+		logID: "test",
+		mcpClient: &mockMCPClient{},
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	done := make(chan bool, 1)
+	go func() {
+		done <- ts.tryRestart(ctx)
+	}()
+
+	// Cancel almost immediately; tryRestart should return promptly
+	// instead of sleeping through the full backoff.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case result := <-done:
+		assert.False(t, result, "tryRestart should return false on cancellation")
+	case <-time.After(2 * time.Second):
+		t.Fatal("tryRestart did not return promptly after context cancellation")
+	}
 }

--- a/pkg/tools/mcp/mcp_race_test.go
+++ b/pkg/tools/mcp/mcp_race_test.go
@@ -1,0 +1,32 @@
+package mcp
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestInstructions_Concurrent(t *testing.T) {
+	t.Parallel()
+
+	ts := &Toolset{
+		started:      true,
+		instructions: "initial",
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			// Simulate what doStart does (always called under ts.mu)
+			ts.mu.Lock()
+			ts.instructions = "updated"
+			ts.mu.Unlock()
+		}()
+		go func() {
+			defer wg.Done()
+			_ = ts.Instructions()
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
tryRestart uses time.Sleep for exponential backoff (up to 16s) which ignores context cancellation and Stop(). Replaces with a select on time.NewTimer and ctx.Done() for prompt shutdown.