### PR TITLE
fix: prevent symlink-based path traversal in ACP filesystem toolset

### DIFF
--- a/pkg/acp/filesystem.go
+++ b/pkg/acp/filesystem.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -71,6 +72,8 @@ func (t *FilesystemToolset) Tools(ctx context.Context) ([]tools.Tool, error) {
 
 // resolvePath resolves a user-supplied path relative to the working directory
 // and validates that the resulting path does not escape the working directory.
+// It follows symlinks to prevent a symlink inside the working directory from
+// pointing outside it.
 func (t *FilesystemToolset) resolvePath(userPath string) (string, error) {
 	resolved := filepath.Clean(filepath.Join(t.workingDir, userPath))
 	absWorkingDir, err := filepath.Abs(t.workingDir)
@@ -81,14 +84,52 @@ func (t *FilesystemToolset) resolvePath(userPath string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve path: %w", err)
 	}
+
+	// Resolve symlinks. For paths that don't exist yet (e.g. a new file
+	// being created), walk up to the nearest existing ancestor, resolve
+	// symlinks on that, then re-append the remaining components.
+	realResolved, err := evalSymlinksAllowMissing(absResolved)
+	if err != nil {
+		return "", fmt.Errorf("failed to evaluate symlinks: %w", err)
+	}
+	realWorkingDir, err := filepath.EvalSymlinks(absWorkingDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to evaluate symlinks for working directory: %w", err)
+	}
+
 	// Normalize paths for comparison to prevent bypasses on case-insensitive
 	// filesystems (macOS, Windows) where differing case could defeat the check.
-	normResolved := normalizePathForComparison(absResolved)
-	normWorkingDir := normalizePathForComparison(absWorkingDir)
+	normResolved := normalizePathForComparison(realResolved)
+	normWorkingDir := normalizePathForComparison(realWorkingDir)
 	if !strings.HasPrefix(normResolved, normWorkingDir+string(filepath.Separator)) && normResolved != normWorkingDir {
 		return "", fmt.Errorf("path %q escapes the working directory", userPath)
 	}
-	return absResolved, nil
+	return realResolved, nil
+}
+
+// evalSymlinksAllowMissing resolves symlinks for a path that may not fully
+// exist. It walks up from the given path until it finds an existing ancestor,
+// resolves symlinks on that ancestor, then re-appends the missing tail.
+func evalSymlinksAllowMissing(path string) (string, error) {
+	real, err := filepath.EvalSymlinks(path)
+	if err == nil {
+		return real, nil
+	}
+	if !os.IsNotExist(err) {
+		return "", err
+	}
+
+	// Walk up to find the nearest existing ancestor.
+	parent := filepath.Dir(path)
+	if parent == path {
+		// Reached filesystem root without finding an existing path.
+		return path, nil
+	}
+	realParent, err := evalSymlinksAllowMissing(parent)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(realParent, filepath.Base(path)), nil
 }
 
 func (t *FilesystemToolset) handleReadFile(ctx context.Context, toolCall tools.ToolCall) (*tools.ToolCallResult, error) {

--- a/pkg/acp/filesystem_test.go
+++ b/pkg/acp/filesystem_test.go
@@ -1,7 +1,9 @@
 package acp
 
 import (
+	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,7 +19,7 @@ func TestResolvePath(t *testing.T) {
 		workingDir: workingDir,
 	}
 
-	absWorkingDir, err := filepath.Abs(workingDir)
+	absWorkingDir, err := filepath.EvalSymlinks(workingDir)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -84,4 +86,82 @@ func TestNormalizePathForComparison(t *testing.T) {
 	// This test validates the function exists and returns a string.
 	// The exact behavior depends on the platform.
 	assert.NotEmpty(t, result)
+}
+
+func TestResolvePath_SymlinkEscape(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink test not reliable on Windows")
+	}
+
+	workingDir := t.TempDir()
+	outsideDir := t.TempDir()
+
+	// Create a secret file outside the working directory.
+	secretFile := filepath.Join(outsideDir, "secret.txt")
+	require.NoError(t, os.WriteFile(secretFile, []byte("secret"), 0o644))
+
+	// Create a symlink inside the working directory pointing outside.
+	symlink := filepath.Join(workingDir, "escape")
+	require.NoError(t, os.Symlink(outsideDir, symlink))
+
+	ts := &FilesystemToolset{workingDir: workingDir}
+
+	// Accessing a file through the symlink should be blocked.
+	_, err := ts.resolvePath("escape/secret.txt")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "escapes the working directory")
+
+	// The symlink target itself should also be blocked.
+	_, err = ts.resolvePath("escape")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "escapes the working directory")
+}
+
+func TestResolvePath_SymlinkWithinWorkingDir(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink test not reliable on Windows")
+	}
+
+	workingDir := t.TempDir()
+
+	// Create a subdirectory and a symlink to it within the working dir.
+	subdir := filepath.Join(workingDir, "real")
+	require.NoError(t, os.Mkdir(subdir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(subdir, "file.txt"), []byte("ok"), 0o644))
+
+	link := filepath.Join(workingDir, "link")
+	require.NoError(t, os.Symlink(subdir, link))
+
+	ts := &FilesystemToolset{workingDir: workingDir}
+
+	// Symlink within working dir should be allowed.
+	resolved, err := ts.resolvePath("link/file.txt")
+	require.NoError(t, err)
+	assert.Contains(t, resolved, "real/file.txt")
+}
+
+func TestResolvePath_NonExistentPathWithSymlinkAncestor(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink test not reliable on Windows")
+	}
+
+	workingDir := t.TempDir()
+	outsideDir := t.TempDir()
+
+	// Symlink inside working dir pointing outside.
+	symlink := filepath.Join(workingDir, "escape")
+	require.NoError(t, os.Symlink(outsideDir, symlink))
+
+	ts := &FilesystemToolset{workingDir: workingDir}
+
+	// Even for a non-existent file under the symlink, traversal should be blocked.
+	_, err := ts.resolvePath("escape/nonexistent.txt")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "escapes the working directory")
 }

--- a/pkg/model/provider/anthropic/client.go
+++ b/pkg/model/provider/anthropic/client.go
@@ -671,7 +671,7 @@ func extractSystemBlocks(messages []chat.Message) []anthropic.TextBlockParam {
 			})
 		}
 
-		if msg.CacheControl {
+		if msg.CacheControl && len(systemBlocks) > 0 {
 			systemBlocks[len(systemBlocks)-1].CacheControl = anthropic.NewCacheControlEphemeralParam()
 		}
 	}

--- a/pkg/model/provider/anthropic/client_test.go
+++ b/pkg/model/provider/anthropic/client_test.go
@@ -523,3 +523,20 @@ func TestExtractSystemBlocksCacheControl(t *testing.T) {
 	assert.Equal(t, "ephemeral", string(blocks[3].CacheControl.Type))
 	assert.Empty(t, string(blocks[3].CacheControl.TTL))
 }
+
+func TestExtractSystemBlocks_EmptyContentWithCacheControl(t *testing.T) {
+	t.Parallel()
+
+	// An empty system message with CacheControl must not panic.
+	msgs := []chat.Message{
+		{
+			Role:         chat.MessageRoleSystem,
+			Content:      "",
+			CacheControl: true,
+		},
+	}
+
+	// Before the fix this panicked with index out of range [-1].
+	blocks := extractSystemBlocks(msgs)
+	assert.Empty(t, blocks)
+}

--- a/pkg/model/provider/rulebased/client.go
+++ b/pkg/model/provider/rulebased/client.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
 
 	"github.com/blevesearch/bleve/v2"
 	"github.com/blevesearch/bleve/v2/mapping"
@@ -45,6 +46,7 @@ type Client struct {
 	routes         []Provider
 	fallback       Provider
 	index          bleve.Index
+	mu             sync.RWMutex
 	lastSelectedID string // ID of the provider selected by the most recent call
 }
 
@@ -165,10 +167,13 @@ func (c *Client) CreateChatCompletionStream(
 		return nil, errors.New("no provider available for routing")
 	}
 
-	c.lastSelectedID = provider.ID()
+	selectedID := provider.ID()
+	c.mu.Lock()
+	c.lastSelectedID = selectedID
+	c.mu.Unlock()
 	slog.Debug("Rule-based router selected model",
 		"router", c.ID(),
-		"selected_model", c.lastSelectedID,
+		"selected_model", selectedID,
 		"message_count", len(messages),
 	)
 
@@ -179,6 +184,8 @@ func (c *Client) CreateChatCompletionStream(
 // recent CreateChatCompletionStream call. This allows callers to display
 // the YAML-configured sub-model name for rule-based routing.
 func (c *Client) LastSelectedModelID() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	return c.lastSelectedID
 }
 

--- a/pkg/model/provider/rulebased/client_race_test.go
+++ b/pkg/model/provider/rulebased/client_race_test.go
@@ -1,0 +1,44 @@
+package rulebased
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLastSelectedModelID_Concurrent(t *testing.T) {
+	t.Parallel()
+
+	cfg := &latest.ModelConfig{
+		Provider: "openai",
+		Model:    "gpt-4o",
+		Routing: []latest.RoutingRule{
+			{
+				Model:    "anthropic/claude-3-haiku",
+				Examples: []string{"hello", "hi there"},
+			},
+		},
+	}
+
+	client, err := NewClient(t.Context(), cfg, nil, nil, mockProviderFactory)
+	require.NoError(t, err)
+	defer client.Close()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			messages := []chat.Message{{Role: chat.MessageRoleUser, Content: "hello"}}
+			_, _ = client.CreateChatCompletionStream(t.Context(), messages, nil)
+		}()
+		go func() {
+			defer wg.Done()
+			_ = client.LastSelectedModelID()
+		}()
+	}
+	wg.Wait()
+}

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -110,7 +110,7 @@ func (r *LocalRuntime) RunStream(ctx context.Context, sess *session.Session) <-c
 		events <- ToolsetInfo(len(agentTools), false, a.Name())
 
 		messages := sess.GetMessages(a)
-		if sess.SendUserMessage {
+		if sess.SendUserMessage && len(messages) > 0 {
 			lastMsg := messages[len(messages)-1]
 			events <- UserMessage(lastMsg.Content, sess.ID, lastMsg.MultiContent, len(sess.Messages)-1)
 		}

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -1950,3 +1950,34 @@ func TestMergeExcludedTools(t *testing.T) {
 		assert.ElementsMatch(t, []string{"run_skill", "shell", "read_skill"}, result)
 	})
 }
+
+func TestRunStream_EmptyMessages_SendUserMessage(t *testing.T) {
+	t.Parallel()
+
+	// session.New() defaults to SendUserMessage=true with no messages.
+	// With an empty instruction the system prompt is also empty, so
+	// GetMessages returns an empty slice.
+	// Before the fix, messages[len(messages)-1] panicked with index -1.
+	stream := newStreamBuilder().
+		AddContent("hello").
+		AddStopWithUsage(5, 5).
+		Build()
+
+	prov := &mockProvider{id: "test/mock-model", stream: stream}
+	root := agent.New("root", "", agent.WithModel(prov))
+	tm := team.New(team.WithAgents(root))
+
+	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+
+	sess := session.New() // SendUserMessage=true, no messages
+	sess.Title = "Unit Test"
+
+	// Must not panic.
+	evCh := rt.RunStream(t.Context(), sess)
+	var events []Event
+	for ev := range evCh {
+		events = append(events, ev)
+	}
+	require.NotEmpty(t, events)
+}

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -472,6 +472,8 @@ func (s *Session) AddMessageUsageRecord(agentName, model string, cost float64, u
 	if usage == nil {
 		return
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.MessageUsageHistory = append(s.MessageUsageHistory, MessageUsageRecord{
 		AgentName: agentName,
 		Model:     model,

--- a/pkg/session/session_race_test.go
+++ b/pkg/session/session_race_test.go
@@ -1,0 +1,24 @@
+package session
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/docker/docker-agent/pkg/chat"
+)
+
+func TestAddMessageUsageRecordConcurrent(t *testing.T) {
+	s := New()
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s.AddMessageUsageRecord("agent", "model", 0.1, &chat.Usage{InputTokens: 10, OutputTokens: 5})
+		}()
+	}
+	wg.Wait()
+	if got := len(s.MessageUsageHistory); got != 100 {
+		t.Errorf("expected 100 records, got %d", got)
+	}
+}

--- a/pkg/tools/mcp/mcp.go
+++ b/pkg/tools/mcp/mcp.go
@@ -341,9 +341,8 @@ func (ts *Toolset) tryRestart(ctx context.Context) bool {
 
 func (ts *Toolset) Instructions() string {
 	ts.mu.Lock()
-	started := ts.started
-	ts.mu.Unlock()
-	if !started {
+	defer ts.mu.Unlock()
+	if !ts.started {
 		// TODO: this should never happen...
 		return ""
 	}

--- a/pkg/tools/mcp/mcp.go
+++ b/pkg/tools/mcp/mcp.go
@@ -311,7 +311,14 @@ func (ts *Toolset) tryRestart(ctx context.Context) bool {
 	for attempt := range maxAttempts {
 		backoff := time.Duration(1<<uint(attempt)) * time.Second
 		slog.Debug("Restarting MCP server", "server", ts.logID, "attempt", attempt+1, "backoff", backoff)
-		time.Sleep(backoff)
+
+		timer := time.NewTimer(backoff)
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			timer.Stop()
+			return false
+		}
 
 		ts.mu.Lock()
 		if ts.stopping {

--- a/pkg/tools/mcp/mcp_race_test.go
+++ b/pkg/tools/mcp/mcp_race_test.go
@@ -1,8 +1,12 @@
 package mcp
 
 import (
+	"context"
 	"sync"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestInstructions_Concurrent(t *testing.T) {
@@ -29,4 +33,32 @@ func TestInstructions_Concurrent(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+func TestTryRestart_RespectsContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	ts := &Toolset{
+		logID: "test",
+		mcpClient: &mockMCPClient{},
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	done := make(chan bool, 1)
+	go func() {
+		done <- ts.tryRestart(ctx)
+	}()
+
+	// Cancel almost immediately; tryRestart should return promptly
+	// instead of sleeping through the full backoff.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case result := <-done:
+		assert.False(t, result, "tryRestart should return false on cancellation")
+	case <-time.After(2 * time.Second):
+		t.Fatal("tryRestart did not return promptly after context cancellation")
+	}
 }

--- a/pkg/tools/mcp/mcp_race_test.go
+++ b/pkg/tools/mcp/mcp_race_test.go
@@ -1,0 +1,32 @@
+package mcp
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestInstructions_Concurrent(t *testing.T) {
+	t.Parallel()
+
+	ts := &Toolset{
+		started:      true,
+		instructions: "initial",
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			// Simulate what doStart does (always called under ts.mu)
+			ts.mu.Lock()
+			ts.instructions = "updated"
+			ts.mu.Unlock()
+		}()
+		go func() {
+			defer wg.Done()
+			_ = ts.Instructions()
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
resolvePath uses filepath.Abs which doesn't follow symlinks. A symlink inside the working directory pointing outside it passes the prefix check. Uses filepath.EvalSymlinks with a recursive ancestor walk for non-existent paths. Security fix.