### PR TITLE
fix: hold mutex for instructions read in MCP Toolset.Instructions()

### DIFF
--- a/pkg/tools/mcp/mcp.go
+++ b/pkg/tools/mcp/mcp.go
@@ -339,9 +339,8 @@ func (ts *Toolset) tryRestart(ctx context.Context) bool {
 
 func (ts *Toolset) Instructions() string {
 	ts.mu.Lock()
-	started := ts.started
-	ts.mu.Unlock()
-	if !started {
+	defer ts.mu.Unlock()
+	if !ts.started {
 		// TODO: this should never happen...
 		return ""
 	}

--- a/pkg/tools/mcp/mcp_race_test.go
+++ b/pkg/tools/mcp/mcp_race_test.go
@@ -1,0 +1,32 @@
+package mcp
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestInstructions_Concurrent(t *testing.T) {
+	t.Parallel()
+
+	ts := &Toolset{
+		started:      true,
+		instructions: "initial",
+	}
+
+	var wg sync.WaitGroup
+	for range 100 {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			// Simulate what doStart does (always called under ts.mu)
+			ts.mu.Lock()
+			ts.instructions = "updated"
+			ts.mu.Unlock()
+		}()
+		go func() {
+			defer wg.Done()
+			_ = ts.Instructions()
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Assisted-By: docker-agent