### PR TITLE
fix: guard against empty messages slice in SendUserMessage path

### DIFF
--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -110,7 +110,7 @@ func (r *LocalRuntime) RunStream(ctx context.Context, sess *session.Session) <-c
 		events <- ToolsetInfo(len(agentTools), false, a.Name())
 
 		messages := sess.GetMessages(a)
-		if sess.SendUserMessage {
+		if sess.SendUserMessage && len(messages) > 0 {
 			lastMsg := messages[len(messages)-1]
 			events <- UserMessage(lastMsg.Content, sess.ID, lastMsg.MultiContent, len(sess.Messages)-1)
 		}

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -1950,3 +1950,34 @@ func TestMergeExcludedTools(t *testing.T) {
 		assert.ElementsMatch(t, []string{"run_skill", "shell", "read_skill"}, result)
 	})
 }
+
+func TestRunStream_EmptyMessages_SendUserMessage(t *testing.T) {
+	t.Parallel()
+
+	// session.New() defaults to SendUserMessage=true with no messages.
+	// With an empty instruction the system prompt is also empty, so
+	// GetMessages returns an empty slice.
+	// Before the fix, messages[len(messages)-1] panicked with index -1.
+	stream := newStreamBuilder().
+		AddContent("hello").
+		AddStopWithUsage(5, 5).
+		Build()
+
+	prov := &mockProvider{id: "test/mock-model", stream: stream}
+	root := agent.New("root", "", agent.WithModel(prov))
+	tm := team.New(team.WithAgents(root))
+
+	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+
+	sess := session.New() // SendUserMessage=true, no messages
+	sess.Title = "Unit Test"
+
+	// Must not panic.
+	evCh := rt.RunStream(t.Context(), sess)
+	var events []Event
+	for ev := range evCh {
+		events = append(events, ev)
+	}
+	require.NotEmpty(t, events)
+}


### PR DESCRIPTION
Assisted-By: docker-agent