### PR TITLE
fix: preserve assistant text when tool calls present in Responses API conversion

### DIFF
--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -565,20 +565,30 @@ func convertMessagesToResponseInput(messages []chat.Message) []responses.Respons
 					},
 				}
 			} else {
-				// Assistant message with tool calls - convert to response input item with function calls
+				// Assistant message with tool calls - emit text as a separate assistant
+				// message before the function calls so it is not lost.
+				if strings.TrimSpace(msg.Content) != "" {
+					input = append(input, responses.ResponseInputItemUnionParam{
+						OfMessage: &responses.EasyInputMessageParam{
+							Role: responses.EasyInputMessageRoleAssistant,
+							Content: responses.EasyInputMessageContentUnionParam{
+								OfString: param.NewOpt(msg.Content),
+							},
+						},
+					})
+				}
 				for _, toolCall := range msg.ToolCalls {
 					if toolCall.Type == "function" {
-						funcCallItem := responses.ResponseInputItemUnionParam{
+						input = append(input, responses.ResponseInputItemUnionParam{
 							OfFunctionCall: &responses.ResponseFunctionToolCallParam{
 								CallID:    toolCall.ID,
 								Name:      toolCall.Function.Name,
 								Arguments: toolCall.Function.Arguments,
 							},
-						}
-						input = append(input, funcCallItem)
+						})
 					}
 				}
-				continue // Don't add the assistant message itself
+				continue
 			}
 
 		case chat.MessageRoleSystem:

--- a/pkg/model/provider/openai/client_test.go
+++ b/pkg/model/provider/openai/client_test.go
@@ -46,6 +46,41 @@ func TestConvertMessagesToResponseInput_OrphanedFunctionCall(t *testing.T) {
 	assert.Contains(t, outputIDs, "call_2")
 }
 
+func TestConvertMessagesToResponseInput_AssistantTextWithToolCalls(t *testing.T) {
+	// When an assistant message has both text content and tool calls,
+	// the text must not be silently discarded.
+	messages := []chat.Message{
+		{Role: chat.MessageRoleUser, Content: "hello"},
+		{
+			Role:    chat.MessageRoleAssistant,
+			Content: "Let me search that for you.",
+			ToolCalls: []tools.ToolCall{
+				{ID: "call_1", Type: "function", Function: tools.FunctionCall{Name: "search", Arguments: `{"q":"test"}`}},
+			},
+		},
+		{Role: chat.MessageRoleTool, Content: "result", ToolCallID: "call_1"},
+	}
+
+	input := convertMessagesToResponseInput(messages)
+
+	// We expect: user message, assistant text message, function call, function call output.
+	var foundAssistantText bool
+	var foundFunctionCall bool
+	for _, item := range input {
+		if item.OfMessage != nil && item.OfMessage.Role == "assistant" {
+			if item.OfMessage.Content.OfString.Valid() && item.OfMessage.Content.OfString.Value == "Let me search that for you." {
+				foundAssistantText = true
+			}
+		}
+		if item.OfFunctionCall != nil && item.OfFunctionCall.CallID == "call_1" {
+			foundFunctionCall = true
+		}
+	}
+
+	assert.True(t, foundFunctionCall, "function call should be present")
+	assert.True(t, foundAssistantText, "assistant text content should not be discarded when tool calls are present")
+}
+
 func TestConvertMessagesToResponseInput_NoOrphans(t *testing.T) {
 	// All tool calls have matching results — no placeholder needed.
 	messages := []chat.Message{


### PR DESCRIPTION
When converting assistant messages with both text and tool calls to the Responses API format, the text content was silently discarded via continue. Emit the text as a separate assistant message before the function calls.

Includes a regression test.

Assisted-By: docker-agent