### PR TITLE
fix(otel): align service resource schema

### DIFF
--- a/cmd/root/otel.go
+++ b/cmd/root/otel.go
@@ -68,8 +68,6 @@ func initOTelSDK(ctx context.Context) (err error) {
 	return nil
 }
 
-// isLocalhostEndpoint reports whether the given endpoint refers to a
-// loopback address so that we can safely skip TLS.
 func newOTelResource() (*resource.Resource, error) {
 	return resource.Merge(
 		resource.Default(),
@@ -81,6 +79,8 @@ func newOTelResource() (*resource.Resource, error) {
 	)
 }
 
+// isLocalhostEndpoint reports whether the given endpoint refers to a
+// loopback address so that we can safely skip TLS.
 func isLocalhostEndpoint(endpoint string) bool {
 	host := endpoint
 	// Strip port if present.

--- a/cmd/root/otel.go
+++ b/cmd/root/otel.go
@@ -12,21 +12,14 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 )
 
 const AppName = "cagent"
 
 // initOTelSDK initializes OpenTelemetry SDK with OTLP exporter
 func initOTelSDK(ctx context.Context) (err error) {
-	res, err := resource.Merge(
-		resource.Default(),
-		resource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceName(AppName),
-			semconv.ServiceVersion("dev"), // TODO: use actual version
-		),
-	)
+	res, err := newOTelResource()
 	if err != nil {
 		return fmt.Errorf("failed to create resource: %w", err)
 	}
@@ -77,6 +70,17 @@ func initOTelSDK(ctx context.Context) (err error) {
 
 // isLocalhostEndpoint reports whether the given endpoint refers to a
 // loopback address so that we can safely skip TLS.
+func newOTelResource() (*resource.Resource, error) {
+	return resource.Merge(
+		resource.Default(),
+		resource.NewWithAttributes(
+			semconv.SchemaURL,
+			semconv.ServiceName(AppName),
+			semconv.ServiceVersion("dev"), // TODO: use actual version
+		),
+	)
+}
+
 func isLocalhostEndpoint(endpoint string) bool {
 	host := endpoint
 	// Strip port if present.

--- a/cmd/root/otel_test.go
+++ b/cmd/root/otel_test.go
@@ -3,10 +3,9 @@ package root
 import (
 	"testing"
 
-	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 )
 
 func TestNewOTelResourceUsesCurrentSchemaURL(t *testing.T) {

--- a/cmd/root/otel_test.go
+++ b/cmd/root/otel_test.go
@@ -3,8 +3,19 @@ package root
 import (
 	"testing"
 
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestNewOTelResourceUsesCurrentSchemaURL(t *testing.T) {
+	t.Parallel()
+
+	res, err := newOTelResource()
+	require.NoError(t, err)
+	assert.Equal(t, semconv.SchemaURL, res.SchemaURL())
+}
 
 func TestIsLocalhostEndpoint(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary
- align the custom OTel service resource with the SDK default schema URL
- extract the resource construction into a helper and add a regression test for the schema URL

## Related issue
- Closes #2416

## Testing
- `docker run --rm -v "$PWD":/src -w /src golang:1.26 sh -lc '/usr/local/go/bin/gofmt -w cmd/root/otel.go cmd/root/otel_test.go && /usr/local/go/bin/go test ./cmd/root -run "Test(NewOTelResourceUsesCurrentSchemaURL|IsLocalhostEndpoint)" -count=1'`
