### PR TITLE
Fix --attach flag

### DIFF
--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -485,6 +485,11 @@ func (f *runExecFlags) buildAppOpts(args []string) ([]app.Opt, error) {
 	var opts []app.Opt
 	if firstMessage != nil {
 		opts = append(opts, app.WithFirstMessage(*firstMessage))
+	} else if f.attachmentPath != "" {
+		// When --attach is used without an explicit message, provide a default
+		// so that SendFirstMessage processes the attachment.
+		defaultMsg := ""
+		opts = append(opts, app.WithFirstMessage(defaultMsg))
 	}
 	if len(args) > 2 {
 		opts = append(opts, app.WithQueuedMessages(args[2:]))

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"cmp"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -436,19 +437,44 @@ func CreateUserMessageWithAttachment(userContent, attachmentPath string) *sessio
 		})
 
 	default:
-		// Binary files (images, PDFs) are kept as file references.
+		// Binary files (images, PDFs) are handled based on type.
 		mimeType := chat.DetectMimeType(absPath)
 		if !chat.IsSupportedMimeType(mimeType) {
 			slog.Warn("Unsupported attachment file type", "path", absPath, "mime_type", mimeType)
 			return session.UserMessage(userContent)
 		}
-		multiContent = append(multiContent, chat.MessagePart{
-			Type: chat.MessagePartTypeFile,
-			File: &chat.MessageFile{
-				Path:     absPath,
-				MimeType: mimeType,
-			},
-		})
+		if chat.IsImageMimeType(mimeType) {
+			// Read, resize if needed, and inline as base64 data URL.
+			// This ensures cross-provider compatibility (not all providers
+			// support file references).
+			imgData, readErr := os.ReadFile(absPath)
+			if readErr != nil {
+				slog.Warn("Failed to read image attachment", "path", absPath, "error", readErr)
+				return session.UserMessage(userContent)
+			}
+			resized, resizeErr := chat.ResizeImage(imgData, mimeType)
+			if resizeErr != nil {
+				slog.Warn("Image resize failed for attachment", "path", absPath, "error", resizeErr)
+				return session.UserMessage(userContent)
+			}
+			dataURL := fmt.Sprintf("data:%s;base64,%s", resized.MimeType, base64.StdEncoding.EncodeToString(resized.Data))
+			multiContent = append(multiContent, chat.MessagePart{
+				Type: chat.MessagePartTypeImageURL,
+				ImageURL: &chat.MessageImageURL{
+					URL:    dataURL,
+					Detail: chat.ImageURLDetailAuto,
+				},
+			})
+		} else {
+			// Non-image binary files (e.g. PDFs) are kept as file references.
+			multiContent = append(multiContent, chat.MessagePart{
+				Type: chat.MessagePartTypeFile,
+				File: &chat.MessageFile{
+					Path:     absPath,
+					MimeType: mimeType,
+				},
+			})
+		}
 	}
 
 	return session.UserMessage(textContent, multiContent...)


### PR DESCRIPTION
Fix --attach flag and inline image attachments for cross-provider compatibility

Problem

docker-agent run --attach image.png without an explicit message argument silently discarded the attachment. Additionally,
image attachments were stored as file references, which not all providers support.

Changes

### Fix --attach without a message argument

When --attach is used without a message, readInitialMessage returns nil, so WithFirstMessage was never called. This caused
SendFirstMessage to bail out immediately, silently ignoring the attachment.

Now, when --attach is provided without an explicit message, a default empty first message is synthesized so SendFirstMessage
proceeds to process the attachment. The downstream CreateUserMessageWithAttachment already handles empty text by substituting
"Please analyze this attached file."

### Inline image attachments as base64 data URLs

Instead of keeping image attachments as file references (which not all providers support), images are now read, resized if
needed, and inlined as base64 data URLs. Non-image binary files (e.g. PDFs) continue to use file references.