### PR TITLE
Support xhigh effort for Anthropic adaptive thinking (Opus 4.7+)

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -615,12 +615,12 @@
           "description": "Whether to track usage"
         },
         "thinking_budget": {
-          "description": "Controls reasoning effort/budget. Use 'none' or 0 to disable thinking. OpenAI: string levels ('minimal','low','medium','high','xhigh'). Anthropic: integer token budget (1024-32768), 'adaptive' (adaptive thinking with high effort by default), 'adaptive/<effort>' where effort is low/medium/high/max (adaptive thinking with specified effort), or effort levels ('low','medium','high','max') which use adaptive thinking with the given effort. Amazon Bedrock (Claude): integer token budget or effort levels ('low','medium','high') mapped to token budgets. Google Gemini 2.5: integer token budget (-1 for dynamic, 0 to disable, 24576 max). Google Gemini 3: string levels ('minimal' Flash only,'low','medium','high'). Thinking is only enabled when explicitly configured.",
+          "description": "Controls reasoning effort/budget. Use 'none' or 0 to disable thinking. OpenAI: string levels ('minimal','low','medium','high','xhigh'). Anthropic: integer token budget (1024-32768), 'adaptive' (adaptive thinking with high effort by default), 'adaptive/<effort>' where effort is low/medium/high/xhigh/max ('xhigh' is supported by Claude Opus 4.7+), or effort levels ('low','medium','high','xhigh','max') which use adaptive thinking with the given effort. Amazon Bedrock (Claude): integer token budget or effort levels ('low','medium','high') mapped to token budgets. Google Gemini 2.5: integer token budget (-1 for dynamic, 0 to disable, 24576 max). Google Gemini 3: string levels ('minimal' Flash only,'low','medium','high'). Thinking is only enabled when explicitly configured.",
           "oneOf": [
             {
               "type": "string",
-              "pattern": "^(none|minimal|low|medium|high|xhigh|max|adaptive(/low|/medium|/high|/max)?)$",
-              "description": "Reasoning effort level. 'adaptive' uses adaptive thinking with high effort (default). 'adaptive/<effort>' specifies the effort level (low/medium/high/max). Use 'none' to disable thinking."
+              "pattern": "^(none|minimal|low|medium|high|xhigh|max|adaptive(/low|/medium|/high|/xhigh|/max)?)$",
+              "description": "Reasoning effort level. 'adaptive' uses adaptive thinking with high effort (default). 'adaptive/<effort>' specifies the effort level (low/medium/high/xhigh/max). 'adaptive/xhigh' requires Claude Opus 4.7+. Use 'none' to disable thinking."
             },
             {
               "type": "integer",
@@ -642,6 +642,7 @@
             "adaptive/low",
             "adaptive/medium",
             "adaptive/high",
+            "adaptive/xhigh",
             "adaptive/max",
             -1,
             1024,

--- a/pkg/config/latest/types_test.go
+++ b/pkg/config/latest/types_test.go
@@ -179,6 +179,7 @@ func TestThinkingBudget_UnmarshalYAML_AdaptiveWithEffort(t *testing.T) {
 		{"adaptive/low", `thinking_budget: adaptive/low`, "adaptive/low"},
 		{"adaptive/medium", `thinking_budget: adaptive/medium`, "adaptive/medium"},
 		{"adaptive/high", `thinking_budget: adaptive/high`, "adaptive/high"},
+		{"adaptive/xhigh", `thinking_budget: adaptive/xhigh`, "adaptive/xhigh"},
 		{"adaptive/max", `thinking_budget: adaptive/max`, "adaptive/max"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -221,6 +222,7 @@ func TestThinkingBudget_IsAdaptive(t *testing.T) {
 		{"adaptive/high", &ThinkingBudget{Effort: "adaptive/high"}, true},
 		{"adaptive/low", &ThinkingBudget{Effort: "adaptive/low"}, true},
 		{"adaptive/medium", &ThinkingBudget{Effort: "adaptive/medium"}, true},
+		{"adaptive/xhigh", &ThinkingBudget{Effort: "adaptive/xhigh"}, true},
 		{"adaptive/max", &ThinkingBudget{Effort: "adaptive/max"}, true},
 		{"medium", &ThinkingBudget{Effort: "medium"}, false},
 		{"tokens", &ThinkingBudget{Tokens: 8192}, false},
@@ -246,6 +248,7 @@ func TestThinkingBudget_AdaptiveEffort(t *testing.T) {
 		{"adaptive/low", &ThinkingBudget{Effort: "adaptive/low"}, "low", true},
 		{"adaptive/medium", &ThinkingBudget{Effort: "adaptive/medium"}, "medium", true},
 		{"adaptive/high", &ThinkingBudget{Effort: "adaptive/high"}, "high", true},
+		{"adaptive/xhigh", &ThinkingBudget{Effort: "adaptive/xhigh"}, "xhigh", true},
 		{"adaptive/max", &ThinkingBudget{Effort: "adaptive/max"}, "max", true},
 		{"not adaptive", &ThinkingBudget{Effort: "medium"}, "", false},
 		{"tokens", &ThinkingBudget{Tokens: 8192}, "", false},

--- a/pkg/effort/effort.go
+++ b/pkg/effort/effort.go
@@ -23,23 +23,28 @@ const (
 	Max     Level = "max"
 )
 
-// allLevels lists every non-adaptive level in ascending order.
-var allLevels = []Level{None, Minimal, Low, Medium, High, XHigh, Max}
+// allLevels is the set of recognised non-adaptive effort levels.
+var allLevels = map[Level]bool{
+	None: true, Minimal: true, Low: true, Medium: true, High: true, XHigh: true, Max: true,
+}
 
 // adaptiveEfforts are the effort sub-levels valid after "adaptive/".
-var adaptiveEfforts = map[string]bool{
-	string(Low): true, string(Medium): true, string(High): true, string(Max): true,
+var adaptiveEfforts = map[Level]bool{
+	Low: true, Medium: true, High: true, XHigh: true, Max: true,
+}
+
+// normalize lowercases and trims s for case-insensitive matching.
+func normalize(s string) Level {
+	return Level(strings.ToLower(strings.TrimSpace(s)))
 }
 
 // Parse normalises s (case-insensitive, trimmed) and returns the matching
 // Level.  It returns ("", false) for unknown strings, adaptive values, and
 // empty input.  Use [IsValid] for full validation including adaptive forms.
 func Parse(s string) (Level, bool) {
-	norm := strings.ToLower(strings.TrimSpace(s))
-	for _, l := range allLevels {
-		if norm == string(l) {
-			return l, true
-		}
+	l := normalize(s)
+	if allLevels[l] {
+		return l, true
 	}
 	return "", false
 }
@@ -48,22 +53,19 @@ func Parse(s string) (Level, bool) {
 // It accepts every [Level] constant, plain "adaptive", and the
 // "adaptive/<effort>" form.
 func IsValid(s string) bool {
-	if _, ok := Parse(s); ok {
+	norm := normalize(s)
+	if allLevels[norm] || norm == "adaptive" {
 		return true
 	}
-	norm := strings.ToLower(strings.TrimSpace(s))
-	if norm == "adaptive" {
-		return true
-	}
-	if after, ok := strings.CutPrefix(norm, "adaptive/"); ok {
-		return adaptiveEfforts[after]
+	if after, ok := strings.CutPrefix(string(norm), "adaptive/"); ok {
+		return adaptiveEfforts[Level(after)]
 	}
 	return false
 }
 
 // IsValidAdaptive reports whether sub is a valid effort for "adaptive/<sub>".
 func IsValidAdaptive(sub string) bool {
-	return adaptiveEfforts[strings.ToLower(strings.TrimSpace(sub))]
+	return adaptiveEfforts[normalize(sub)]
 }
 
 // ValidNames returns a human-readable list of accepted values, suitable for
@@ -88,13 +90,14 @@ func ForOpenAI(l Level) (string, bool) {
 }
 
 // ForAnthropic returns the Anthropic output_config effort string for l.
-// Anthropic accepts: low, medium, high, max.
+// Anthropic accepts: low, medium, high, xhigh, max.
+// xhigh is only supported by newer Claude models (e.g. Opus 4.7+).
 // Minimal is mapped to low as the closest equivalent.
 func ForAnthropic(l Level) (string, bool) {
 	switch l {
 	case Minimal:
 		return string(Low), true
-	case Low, Medium, High, Max:
+	case Low, Medium, High, XHigh, Max:
 		return string(l), true
 	default:
 		return "", false

--- a/pkg/effort/effort_test.go
+++ b/pkg/effort/effort_test.go
@@ -43,7 +43,7 @@ func TestIsValid(t *testing.T) {
 
 	valid := []string{
 		"none", "minimal", "low", "medium", "high", "xhigh", "max",
-		"adaptive", "adaptive/low", "adaptive/medium", "adaptive/high", "adaptive/max",
+		"adaptive", "adaptive/low", "adaptive/medium", "adaptive/high", "adaptive/xhigh", "adaptive/max",
 		"ADAPTIVE/HIGH", "  adaptive  ",
 	}
 	for _, s := range valid {
@@ -54,7 +54,7 @@ func TestIsValid(t *testing.T) {
 	}
 
 	invalid := []string{
-		"", "unknown", "adaptive/none", "adaptive/minimal", "adaptive/xhigh",
+		"", "unknown", "adaptive/none", "adaptive/minimal",
 		"adaptive/", "adaptive/foo",
 	}
 	for _, s := range invalid {
@@ -102,8 +102,8 @@ func TestForAnthropic(t *testing.T) {
 		{Low, "low", true},
 		{Medium, "medium", true},
 		{High, "high", true},
+		{XHigh, "xhigh", true},
 		{Max, "max", true},
-		{XHigh, "", false},
 		{None, "", false},
 	} {
 		t.Run(string(tt.level), func(t *testing.T) {
@@ -168,7 +168,7 @@ func TestForGemini3(t *testing.T) {
 func TestIsValidAdaptive(t *testing.T) {
 	t.Parallel()
 
-	valid := []string{"low", "medium", "high", "max", "HIGH", "  Medium  "}
+	valid := []string{"low", "medium", "high", "xhigh", "max", "HIGH", "  Medium  "}
 	for _, s := range valid {
 		t.Run("valid_"+s, func(t *testing.T) {
 			t.Parallel()
@@ -176,7 +176,7 @@ func TestIsValidAdaptive(t *testing.T) {
 		})
 	}
 
-	invalid := []string{"", "none", "minimal", "xhigh", "unknown", "adaptive", "adaptive/high"}
+	invalid := []string{"", "none", "minimal", "unknown", "adaptive", "adaptive/high"}
 	for _, s := range invalid {
 		t.Run("invalid_"+s, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
Claude Opus 4.7 supports the `xhigh` effort level in adaptive thinking.

## Changes

- Extend the `effort` package to accept `xhigh` for Anthropic via `ForAnthropic`.
- Allow `adaptive/xhigh` as a valid `thinking_budget` value.
- Update `agent-schema.json` pattern, description, and examples to document the new value (with a note that it requires Claude Opus 4.7+).
- Add test coverage for `xhigh` / `adaptive/xhigh` in `pkg/effort` and `pkg/config/latest`.

## Minor refactor (opportunistic)

While touching the effort package, also simplified its internals:
- Unified `allLevels` (slice) and `adaptiveEfforts` (`map[string]bool`) into consistent `map[Level]bool` sets.
- Replaced the linear loop in `Parse` with a direct map lookup.
- Extracted the repeated `strings.ToLower(strings.TrimSpace(...))` into a small `normalize` helper.

No behaviour change beyond adding `xhigh`; all tests and lint pass.