### PR TITLE
feat(anthropic): add task_budget for Claude Opus 4.7

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -171,6 +171,33 @@
               "description": "Effort level (e.g., \"low\", \"medium\", \"high\", \"none\", \"adaptive\")"
             }
           ]
+        },
+        "task_budget": {
+          "description": "Default total-token budget for an agentic task (forwarded to Anthropic as `output_config.task_budget`, with the required `task-budgets-2026-03-13` beta header attached automatically). Configurable on any Claude model — docker-agent does not gate by model name — but at the time of writing only Claude Opus 4.7 honors it. Accepts an integer token count or an object {type: tokens, total: N}.",
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Token budget for the full task (combined thinking, tool calls, and output)."
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["tokens"],
+                  "description": "Budget kind. Only \"tokens\" is supported today."
+                },
+                "total": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "description": "Total budget value."
+                }
+              },
+              "required": ["total"],
+              "additionalProperties": false
+            }
+          ]
         }
       },
       "additionalProperties": false
@@ -647,6 +674,38 @@
             1024,
             8192,
             32768
+          ]
+        },
+        "task_budget": {
+          "description": "Total-token budget for a full agentic task (forwarded to Anthropic as `output_config.task_budget`, with the required `task-budgets-2026-03-13` beta header attached automatically). Limits the combined tokens spent on thinking, tool calls, and output across the whole task. Configurable on any Claude model — docker-agent does not gate by model name — but at the time of writing only Claude Opus 4.7 honors it. Accepts an integer token count or an object {type: tokens, total: N}.",
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Total token budget for the task (e.g., 128000)."
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["tokens"],
+                  "description": "Budget kind. Only \"tokens\" is supported today."
+                },
+                "total": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "description": "Total budget value."
+                }
+              },
+              "required": ["total"],
+              "additionalProperties": false
+            }
+          ],
+          "examples": [
+            64000,
+            128000,
+            { "type": "tokens", "total": 128000 }
           ]
         },
         "routing": {

--- a/docs/concepts/models/index.md
+++ b/docs/concepts/models/index.md
@@ -70,6 +70,7 @@ See the [Model Providers]({{ '/providers/overview/' | relative_url }}) section f
 | `presence_penalty`  | float      | Encourage topic diversity: 0.0 to 2.0             |
 | `base_url`          | string     | Custom API endpoint                               |
 | `thinking_budget`   | string/int | Reasoning effort configuration                    |
+| `task_budget`       | int/object | Total token budget for an agentic task (Anthropic; honored by Opus 4.7 today) |
 | `provider_opts`     | object     | Provider-specific options                         |
 
 ## Reasoning / Thinking Budget

--- a/docs/configuration/models/index.md
+++ b/docs/configuration/models/index.md
@@ -24,6 +24,7 @@ models:
     base_url: string # Optional: custom API endpoint
     token_key: string # Optional: env var for API token
     thinking_budget: string|int # Optional: reasoning effort
+    task_budget: int|object # Optional: total task token budget (Anthropic)
     parallel_tool_calls: boolean # Optional: allow parallel tool calls
     track_usage: boolean # Optional: track token usage
     routing: [list] # Optional: rule-based model routing
@@ -45,6 +46,7 @@ models:
 | `base_url`            | string     | ✗        | Custom API endpoint URL (for self-hosted or proxied endpoints)                        |
 | `token_key`           | string     | ✗        | Environment variable name containing the API token (overrides provider default)       |
 | `thinking_budget`     | string/int | ✗        | Reasoning effort control                                                              |
+| `task_budget`         | int/object | ✗        | Total token budget for an agentic task (forwarded to Anthropic; see [Task Budget](#task-budget)). |
 | `parallel_tool_calls` | boolean    | ✗        | Allow model to call multiple tools at once                                            |
 | `track_usage`         | boolean    | ✗        | Track and report token usage for this model                                           |
 | `routing`             | array      | ✗        | Rule-based routing to different models. See [Model Routing]({{ '/configuration/routing/' | relative_url }}). |
@@ -109,6 +111,58 @@ Works for all providers:
 ```yaml
 thinking_budget: none # or 0
 ```
+
+## Task Budget
+
+**Anthropic-only.**
+
+`task_budget` caps the **total** number of tokens the model may spend across a
+multi-step agentic task — combining thinking, tool calls, and final output
+tokens. It lets long-running agents self-regulate effort without having to
+choose a tight per-call `max_tokens`.
+
+It is forwarded to Anthropic's
+[`output_config.task_budget`](https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7)
+request field. docker-agent automatically attaches the required
+`task-budgets-2026-03-13` beta header whenever this field is set.
+
+You can configure `task_budget` on **any** Claude model — docker-agent never
+gates it by model name. At the time of writing only **Claude Opus 4.7**
+actually honors the field; other Claude models will reject requests that
+include it. Check the Anthropic release notes linked above for the current
+list of supported models.
+
+### Integer shorthand
+
+```yaml
+models:
+  opus:
+    provider: anthropic
+    model: claude-opus-4-7
+    task_budget: 128000 # total tokens for the whole task
+    thinking_budget: adaptive # works nicely together
+```
+
+### Object form
+
+Equivalent, and forward-compatible with future budget types:
+
+```yaml
+models:
+  opus:
+    provider: anthropic
+    model: claude-opus-4-7
+    task_budget:
+      type: tokens # only "tokens" is supported today
+      total: 128000
+```
+
+Setting `task_budget: 0` (or omitting the field) disables the feature — the
+model falls back to the provider's default behavior.
+
+Like other inheritable model settings, `task_budget` can also be declared on a
+[provider definition]({{ '/providers/custom/' | relative_url }}) and is
+inherited by every model that references that provider.
 
 ## Interleaved Thinking
 

--- a/docs/configuration/overview/index.md
+++ b/docs/configuration/overview/index.md
@@ -261,6 +261,7 @@ agents:
 | `temperature`         | Default sampling temperature.                                                             |
 | `max_tokens`          | Default maximum response tokens.                                                          |
 | `thinking_budget`     | Default reasoning effort/budget.                                                          |
+| `task_budget`         | Default total token budget for an agentic task (Anthropic; honored by Claude Opus 4.7 today).  |
 | `top_p`               | Default top-p sampling parameter.                                                         |
 | `frequency_penalty`   | Default frequency penalty.                                                                |
 | `presence_penalty`    | Default presence penalty.                                                                 |

--- a/docs/providers/anthropic/index.md
+++ b/docs/providers/anthropic/index.md
@@ -67,6 +67,45 @@ models:
       interleaved_thinking: false # disable if needed
 ```
 
+## Task Budget
+
+`task_budget` caps the **total** number of tokens the model may spend across a
+multi-step agentic task — combined thinking, tool calls, and final output. It
+is forwarded as
+[`output_config.task_budget`](https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7)
+and is ideal for letting long-running agents self-regulate effort without
+tightening `max_tokens` on every call.
+
+docker-agent automatically attaches the required `task-budgets-2026-03-13`
+beta header whenever this field is set. You can configure `task_budget` on
+**any** Claude model — docker-agent never gates it by model name. At the time
+of writing, only **Claude Opus 4.7** actually honors the field; other Claude
+models (Sonnet 4.5, Opus 4.5 / 4.6, etc.) are expected to reject requests
+that include it. Check the Anthropic release notes linked above for the
+current list of supported models.
+
+```yaml
+models:
+  opus:
+    provider: anthropic
+    model: claude-opus-4-7
+    task_budget: 128000 # integer shorthand → { type: tokens, total: 128000 }
+    thinking_budget: adaptive
+```
+
+Object form (forward-compatible with future budget types):
+
+```yaml
+  opus:
+    provider: anthropic
+    model: claude-opus-4-7
+    task_budget:
+      type: tokens
+      total: 128000
+```
+
+See the full schema on the [Model Configuration]({{ '/configuration/models/#task-budget' | relative_url }}) page.
+
 <div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ Note
 </div>

--- a/docs/providers/custom/index.md
+++ b/docs/providers/custom/index.md
@@ -108,6 +108,7 @@ agents:
 | `parallel_tool_calls` | boolean    | Whether to enable parallel tool calls by default.                                     | —                        |
 | `track_usage`         | boolean    | Whether to track token usage by default.                                              | —                        |
 | `thinking_budget`     | string/int | Default reasoning effort/budget.                                                      | —                        |
+| `task_budget`         | int/object | Default total token budget for an agentic task (forwarded to Anthropic; honored by Claude Opus 4.7 today). Integer shorthand or `{type: tokens, total: N}`. | —                        |
 | `provider_opts`       | object     | Provider-specific options passed through to the client.                               | —                        |
 
 ## Default Inheritance

--- a/examples/task_budget.yaml
+++ b/examples/task_budget.yaml
@@ -1,0 +1,46 @@
+#!/usr/bin/env docker agent run
+
+# Anthropic `task_budget` caps the total tokens a model spends across a
+# multi-step agentic task (thinking + tool calls + final output). docker-agent
+# forwards it as `output_config.task_budget` and automatically attaches the
+# `task-budgets-2026-03-13` beta header.
+#
+# It can be set on any Claude model; at the time of writing only Claude
+# Opus 4.7 actually honors it. See:
+# https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7
+#
+# Run the demo command with:  docker agent run task_budget.yaml -c demo
+
+# Declare the provider explicitly so we can reference claude-opus-4-7 before
+# it lands in the public models.dev catalog. For catalog-known models you can
+# set `task_budget` directly under `models.<name>` without this block.
+providers:
+  anthropic-opus-47:
+    provider: anthropic
+    token_key: ANTHROPIC_API_KEY
+
+agents:
+  root:
+    model: opus-bounded
+    description: a helpful assistant with a bounded task token budget
+    instruction: Stay within the configured task token budget.
+    commands:
+      demo: "design and sketch a small Python CLI that fetches weather data"
+    toolsets:
+      - type: shell
+
+models:
+  # Integer shorthand = a "tokens" budget of 128k for the whole task.
+  opus-bounded:
+    provider: anthropic-opus-47
+    model: claude-opus-4-7
+    task_budget: 128000
+    thinking_budget: adaptive # task_budget pairs well with adaptive thinking
+
+  # Explicit object form, equivalent to `task_budget: 64000`.
+  opus-bounded-tight:
+    provider: anthropic-opus-47
+    model: claude-opus-4-7
+    task_budget:
+      type: tokens
+      total: 64000

--- a/pkg/config/latest/model_config_clone_test.go
+++ b/pkg/config/latest/model_config_clone_test.go
@@ -24,6 +24,7 @@ func TestModelConfig_Clone_DeepCopiesPointerFields(t *testing.T) {
 		ParallelToolCalls: &parallel,
 		TrackUsage:        &trackUsage,
 		ThinkingBudget:    &ThinkingBudget{Effort: "high"},
+		TaskBudget:        &TaskBudget{Type: "tokens", Total: 128000},
 		ProviderOpts:      map[string]any{"key": "value"},
 		Routing: []RoutingRule{
 			{Model: "fast", Examples: []string{"quick question"}},
@@ -39,6 +40,7 @@ func TestModelConfig_Clone_DeepCopiesPointerFields(t *testing.T) {
 	*original.ParallelToolCalls = false
 	*original.TrackUsage = false
 	original.ThinkingBudget.Effort = "low"
+	original.TaskBudget.Total = 1
 	original.ProviderOpts["key"] = "mutated"
 	original.Routing[0].Examples[0] = "mutated"
 
@@ -49,6 +51,8 @@ func TestModelConfig_Clone_DeepCopiesPointerFields(t *testing.T) {
 	assert.True(t, *clone.ParallelToolCalls)
 	assert.True(t, *clone.TrackUsage)
 	assert.Equal(t, "high", clone.ThinkingBudget.Effort)
+	assert.Equal(t, 128000, clone.TaskBudget.Total)
+	assert.Equal(t, "tokens", clone.TaskBudget.Type)
 	assert.Equal(t, "value", clone.ProviderOpts["key"])
 	assert.Equal(t, "quick question", clone.Routing[0].Examples[0])
 }

--- a/pkg/config/latest/task_budget_test.go
+++ b/pkg/config/latest/task_budget_test.go
@@ -1,0 +1,129 @@
+package latest
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/goccy/go-yaml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTaskBudget_Unmarshal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		yaml     string
+		want     TaskBudget
+		wantZero bool
+		wantErr  bool
+	}{
+		{"integer shorthand", "128000\n", TaskBudget{Type: "tokens", Total: 128000}, false, false},
+		{"zero shorthand disables", "0\n", TaskBudget{Type: "tokens", Total: 0}, true, false},
+		{"full object", "type: tokens\ntotal: 64000\n", TaskBudget{Type: "tokens", Total: 64000}, false, false},
+		{"zero object disables", "type: tokens\ntotal: 0\n", TaskBudget{Type: "tokens", Total: 0}, true, false},
+		{"invalid type", "type: bogus\ntotal: 1\n", TaskBudget{}, false, true},
+		{"negative total", "type: tokens\ntotal: -5\n", TaskBudget{}, false, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var tb TaskBudget
+			err := yaml.Unmarshal([]byte(tc.yaml), &tb)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, tb)
+			assert.Equal(t, tc.wantZero, tb.IsZero(),
+				"IsZero mismatch for %q", tc.yaml)
+			if tc.wantZero {
+				assert.Nil(t, tb.AsMap(),
+					"AsMap must return nil when budget is disabled (task_budget=0)")
+			}
+		})
+	}
+}
+
+func TestTaskBudget_MarshalShorthand(t *testing.T) {
+	t.Parallel()
+
+	tb := TaskBudget{Type: "tokens", Total: 42}
+
+	y, err := yaml.Marshal(&tb)
+	require.NoError(t, err)
+	assert.Equal(t, "42\n", string(y))
+
+	j, err := json.Marshal(&tb)
+	require.NoError(t, err)
+	assert.JSONEq(t, `42`, string(j))
+}
+
+func TestTaskBudget_JSONRoundtrip(t *testing.T) {
+	t.Parallel()
+
+	orig := TaskBudget{Type: "tokens", Total: 200000}
+	data, err := json.Marshal(&orig)
+	require.NoError(t, err)
+
+	var decoded TaskBudget
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, orig, decoded)
+}
+
+func TestTaskBudget_IsZeroAndAsMap(t *testing.T) {
+	t.Parallel()
+
+	var nilTB *TaskBudget
+	assert.True(t, nilTB.IsZero())
+	assert.Nil(t, nilTB.AsMap())
+
+	assert.True(t, (&TaskBudget{}).IsZero())
+	assert.Nil(t, (&TaskBudget{}).AsMap())
+
+	// task_budget: 0 disables the feature: the integer shorthand produces
+	// {Type: "tokens", Total: 0}, which must still be treated as zero.
+	zero := &TaskBudget{Type: "tokens", Total: 0}
+	assert.True(t, zero.IsZero(), "Total==0 must be treated as disabled")
+	assert.Nil(t, zero.AsMap())
+
+	tb := &TaskBudget{Total: 100}
+	assert.False(t, tb.IsZero())
+	assert.Equal(t, map[string]any{"type": "tokens", "total": 100}, tb.AsMap())
+}
+
+func TestModelConfig_TaskBudgetParsing(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		yaml string
+		want TaskBudget
+	}{
+		{
+			name: "integer shorthand",
+			yaml: "provider: anthropic\nmodel: claude-opus-4-7\ntask_budget: 128000\n",
+			want: TaskBudget{Type: "tokens", Total: 128000},
+		},
+		{
+			name: "object form",
+			yaml: "provider: anthropic\nmodel: claude-opus-4-7\ntask_budget:\n  type: tokens\n  total: 64000\n",
+			want: TaskBudget{Type: "tokens", Total: 64000},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var cfg ModelConfig
+			require.NoError(t, yaml.Unmarshal([]byte(tc.yaml), &cfg))
+			require.NotNil(t, cfg.TaskBudget)
+			assert.Equal(t, tc.want, *cfg.TaskBudget)
+		})
+	}
+}

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -252,6 +252,12 @@ type ProviderConfig struct {
 	TrackUsage *bool `json:"track_usage,omitempty"`
 	// ThinkingBudget controls reasoning effort/budget for models using this provider
 	ThinkingBudget *ThinkingBudget `json:"thinking_budget,omitempty"`
+	// TaskBudget caps the total tokens a model can spend across an agentic task.
+	// Forwarded to Anthropic as `output_config.task_budget` for every Claude
+	// model — docker-agent does not gate by model name. At the time of writing,
+	// only Claude Opus 4.7 actually honors it; other models will reject the
+	// field. Accepts an integer token count or a {type: tokens, total: N} object.
+	TaskBudget *TaskBudget `json:"task_budget,omitempty"`
 }
 
 // FallbackConfig represents fallback model configuration for an agent.
@@ -519,6 +525,12 @@ type ModelConfig struct {
 	// See [effort.ValidNames] for the full list of accepted strings.
 	// Provider-specific mappings are in the effort package.
 	ThinkingBudget *ThinkingBudget `json:"thinking_budget,omitempty"`
+	// TaskBudget caps the total tokens a model can spend across an agentic task.
+	// Forwarded to Anthropic as `output_config.task_budget` for every Claude
+	// model — docker-agent does not gate by model name. At the time of writing,
+	// only Claude Opus 4.7 actually honors it; other models will reject the
+	// field. Accepts an integer token count or a {type: tokens, total: N} object.
+	TaskBudget *TaskBudget `json:"task_budget,omitempty"`
 	// Routing defines rules for routing requests to different models.
 	// When routing is configured, this model becomes a rule-based router:
 	// - The provider/model fields define the fallback model
@@ -597,6 +609,7 @@ func (f *FlexibleModelConfig) isShorthandOnly() bool {
 		len(f.ProviderOpts) == 0 &&
 		f.TrackUsage == nil &&
 		f.ThinkingBudget == nil &&
+		f.TaskBudget == nil &&
 		len(f.Routing) == 0
 }
 
@@ -945,6 +958,112 @@ func (t *ThinkingBudget) UnmarshalJSON(data []byte) error {
 	}
 
 	return nil
+}
+
+// TaskBudget caps the total tokens a model can spend across an agentic task
+// (combined thinking, tool calls, and final output). It is forwarded to
+// Anthropic as `output_config.task_budget` and docker-agent automatically
+// attaches the required `task-budgets-2026-03-13` beta header when set.
+//
+// docker-agent does not gate by model name — any Claude model accepts the
+// configuration, though at the time of writing only Claude Opus 4.7 actually
+// honors it; other models will reject requests containing the field. See:
+// https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7
+//
+// Accepted YAML/JSON forms:
+//   - Integer shorthand ("tokens" budget):  task_budget: 128000
+//   - Full object:                          task_budget: {type: tokens, total: 128000}
+//
+// A value of 0 (or an empty object) disables the feature.
+type TaskBudget struct {
+	// Type is the budget kind. Only "tokens" is supported today; defaults to
+	// "tokens" when Total is set via the integer shorthand.
+	Type string `json:"type,omitempty"`
+	// Total is the total budget value (token count for Type == "tokens").
+	Total int `json:"total,omitempty"`
+}
+
+// IsZero reports whether the task budget is effectively unset.
+//
+// A budget is considered unset when Total <= 0 (there is no meaningful
+// "zero-token" budget, and validate() already rejects negative totals for
+// explicit object forms). This is what lets users disable the feature with
+// the shorthand `task_budget: 0`, which otherwise unmarshals to a non-empty
+// {Type: "tokens", Total: 0} struct.
+func (t *TaskBudget) IsZero() bool {
+	return t == nil || t.Total <= 0
+}
+
+// AsMap returns the API representation, or nil when the budget is zero.
+func (t *TaskBudget) AsMap() map[string]any {
+	if t.IsZero() {
+		return nil
+	}
+	typ := t.Type
+	if typ == "" {
+		typ = "tokens"
+	}
+	return map[string]any{"type": typ, "total": t.Total}
+}
+
+// validate checks the invariants shared by both YAML and JSON decoding.
+func (t *TaskBudget) validate() error {
+	if t.Total < 0 {
+		return fmt.Errorf("task_budget.total must be non-negative, got %d", t.Total)
+	}
+	if t.Type != "" && t.Type != "tokens" {
+		return fmt.Errorf("task_budget.type %q is not supported (only %q)", t.Type, "tokens")
+	}
+	return nil
+}
+
+// UnmarshalYAML accepts either an integer shorthand (tokens) or a full object.
+func (t *TaskBudget) UnmarshalYAML(unmarshal func(any) error) error {
+	var n int
+	if err := unmarshal(&n); err == nil {
+		*t = TaskBudget{Type: "tokens", Total: n}
+		return t.validate()
+	}
+	type alias TaskBudget
+	var raw alias
+	if err := unmarshal(&raw); err != nil {
+		return errors.New("task_budget must be an integer or a {type,total} object")
+	}
+	*t = TaskBudget(raw)
+	return t.validate()
+}
+
+// MarshalYAML emits the integer shorthand for a plain token budget, otherwise
+// the full {type, total} object.
+func (t TaskBudget) MarshalYAML() (any, error) {
+	if t.Type == "" || t.Type == "tokens" {
+		return t.Total, nil
+	}
+	return map[string]any{"type": t.Type, "total": t.Total}, nil
+}
+
+// UnmarshalJSON mirrors UnmarshalYAML: accepts int shorthand or full object.
+func (t *TaskBudget) UnmarshalJSON(data []byte) error {
+	var n int
+	if err := json.Unmarshal(data, &n); err == nil {
+		*t = TaskBudget{Type: "tokens", Total: n}
+		return t.validate()
+	}
+	type alias TaskBudget
+	var raw alias
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return errors.New("task_budget must be an integer or a {type,total} object")
+	}
+	*t = TaskBudget(raw)
+	return t.validate()
+}
+
+// MarshalJSON emits the integer shorthand for a plain token budget.
+func (t TaskBudget) MarshalJSON() ([]byte, error) {
+	if t.Type == "" || t.Type == "tokens" {
+		return json.Marshal(t.Total)
+	}
+	return json.Marshal(map[string]any{"type": t.Type, "total": t.Total})
 }
 
 // StructuredOutput defines a JSON schema for structured output

--- a/pkg/model/provider/anthropic/beta_client.go
+++ b/pkg/model/provider/anthropic/beta_client.go
@@ -13,14 +13,17 @@ import (
 	"github.com/anthropics/anthropic-sdk-go/packages/ssestream"
 
 	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/model/provider/providerutil"
 	"github.com/docker/docker-agent/pkg/rag/prompts"
 	"github.com/docker/docker-agent/pkg/rag/types"
 	"github.com/docker/docker-agent/pkg/tools"
 )
 
-// createBetaStream creates a streaming chat completion using the Beta Messages API
-// This is used when extended thinking is enabled via thinking_budget
+// createBetaStream creates a streaming chat completion using the Beta
+// Messages API. It is used when any feature that requires a beta header is
+// enabled: extended/interleaved thinking, structured output, file attachments
+// (Files API), or task_budget.
 func (c *Client) createBetaStream(
 	ctx context.Context,
 	client anthropic.Client,
@@ -98,6 +101,11 @@ func (c *Client) createBetaStream(
 			slog.Debug("Anthropic Beta API using thinking_budget", "budget_tokens", tokens)
 		}
 	}
+
+	// Forward task_budget via `output_config.task_budget` (Anthropic
+	// Opus 4.7+) and enable the corresponding beta header. Older Claude
+	// models will reject the field — docker-agent does not gate by model.
+	configureTaskBudget(&params, c.ModelConfig.TaskBudget)
 
 	if len(requestTools) > 0 {
 		slog.Debug("Anthropic Beta API: Adding tools to request", "tool_count", len(requestTools))
@@ -457,4 +465,22 @@ func accumulateBetaStreamResponse(stream *ssestream.Stream[anthropic.BetaRawMess
 	}
 
 	return &msg, nil
+}
+
+// taskBudgetBeta is the Anthropic beta header required to send
+// `output_config.task_budget`. docker-agent attaches it automatically
+// whenever a TaskBudget is configured.
+const taskBudgetBeta anthropic.AnthropicBeta = "task-budgets-2026-03-13"
+
+// configureTaskBudget mutates params so the request carries the
+// `task-budgets` beta header and an `output_config.task_budget` payload.
+// No-op when tb is nil or zero.
+func configureTaskBudget(params *anthropic.BetaMessageNewParams, tb *latest.TaskBudget) {
+	payload := tb.AsMap()
+	if payload == nil {
+		return
+	}
+	params.Betas = append(params.Betas, taskBudgetBeta)
+	params.OutputConfig.SetExtraFields(map[string]any{"task_budget": payload})
+	slog.Debug("Anthropic Beta API using task_budget", "type", payload["type"], "total", payload["total"])
 }

--- a/pkg/model/provider/anthropic/client.go
+++ b/pkg/model/provider/anthropic/client.go
@@ -251,12 +251,15 @@ func (c *Client) CreateChatCompletionStream(
 		return nil, err
 	}
 
-	// Use Beta API when:
-	// 1. Interleaved thinking is enabled, or
-	// 2. Structured output is configured, or
-	// 3. Messages contain file attachments (Files API is Beta-only)
-	// Note: Structured outputs require beta header support (only available on BetaMessageNewParams)
-	if c.interleavedThinkingEnabled() || c.ModelOptions.StructuredOutput() != nil || hasFileAttachments(messages) {
+	// Route to the Beta Messages API when any of the following are set:
+	//  - interleaved thinking
+	//  - structured output (requires beta header)
+	//  - file attachments (Files API is Beta-only)
+	//  - task_budget (requires the task-budgets beta header)
+	if c.interleavedThinkingEnabled() ||
+		c.ModelOptions.StructuredOutput() != nil ||
+		hasFileAttachments(messages) ||
+		!c.ModelConfig.TaskBudget.IsZero() {
 		return c.createBetaStream(ctx, client, messages, requestTools, maxTokens)
 	}
 

--- a/pkg/model/provider/anthropic/task_budget_test.go
+++ b/pkg/model/provider/anthropic/task_budget_test.go
@@ -1,0 +1,216 @@
+package anthropic
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/option"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/model/provider/base"
+)
+
+// TestConfigureTaskBudget_NoBudget verifies that nil / zero budgets don't
+// touch the request params.
+func TestConfigureTaskBudget_NoBudget(t *testing.T) {
+	t.Parallel()
+
+	for name, tb := range map[string]*latest.TaskBudget{
+		"nil":  nil,
+		"zero": {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			params := anthropic.BetaMessageNewParams{}
+			configureTaskBudget(&params, tb)
+
+			assert.Empty(t, params.Betas)
+			data, err := json.Marshal(params.OutputConfig)
+			require.NoError(t, err)
+			assert.NotContains(t, string(data), "task_budget")
+		})
+	}
+}
+
+// TestConfigureTaskBudget_AttachesPayloadAndBeta verifies the happy path:
+// the beta header is appended and `task_budget` is serialized under
+// `output_config`, coexisting with existing fields like `effort`.
+func TestConfigureTaskBudget_AttachesPayloadAndBeta(t *testing.T) {
+	t.Parallel()
+
+	params := anthropic.BetaMessageNewParams{
+		Betas:        []anthropic.AnthropicBeta{"existing"},
+		OutputConfig: anthropic.BetaOutputConfigParam{Effort: anthropic.BetaOutputConfigEffortHigh},
+	}
+	configureTaskBudget(&params, &latest.TaskBudget{Total: 128000})
+
+	assert.Equal(t,
+		[]anthropic.AnthropicBeta{"existing", taskBudgetBeta},
+		params.Betas)
+
+	var out map[string]any
+	data, err := json.Marshal(params.OutputConfig)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(data, &out))
+
+	assert.Equal(t, "high", out["effort"])
+	tb, ok := out["task_budget"].(map[string]any)
+	require.True(t, ok, "expected task_budget object, got %s", string(data))
+	assert.Equal(t, "tokens", tb["type"])
+	assert.InDelta(t, 128000, tb["total"], 0.001)
+}
+
+// anthropicTestServer returns a minimal stub that captures request metadata
+// and replies with an empty SSE stream so the client can terminate cleanly.
+func anthropicTestServer(t *testing.T, capture func(*http.Request, []byte)) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		capture(r, body)
+		w.Header().Set("content-type", "text/event-stream")
+		_, _ = w.Write([]byte("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// drain fully consumes a stream so the underlying HTTP handler runs to completion.
+func drain(stream chat.MessageStream) {
+	for {
+		if _, err := stream.Recv(); err != nil {
+			break
+		}
+	}
+	stream.Close()
+}
+
+// newTestClient builds an anthropic Client wired to a test HTTP server.
+func newTestClient(srv *httptest.Server, cfg latest.ModelConfig) *Client {
+	return &Client{
+		Config: base.Config{ModelConfig: cfg},
+		clientFn: func(_ context.Context) (anthropic.Client, error) {
+			return anthropic.NewClient(
+				option.WithAPIKey("test-key"),
+				option.WithBaseURL(srv.URL),
+			), nil
+		},
+	}
+}
+
+// TestTaskBudget_RoutesToBetaAPIWithBetaHeader verifies end-to-end that
+// configuring `task_budget`:
+//  1. routes the request through the Beta Messages API, and
+//  2. attaches the `task-budgets-2026-03-13` beta header, and
+//  3. serializes `output_config.task_budget` in the request body.
+func TestTaskBudget_RoutesToBetaAPIWithBetaHeader(t *testing.T) {
+	var (
+		gotPath  string
+		gotBetas []string
+		gotBody  []byte
+	)
+	srv := anthropicTestServer(t, func(r *http.Request, body []byte) {
+		gotPath = r.URL.Path
+		// The SDK emits one `anthropic-beta` header per beta via
+		// WithHeaderAdd, so use Values (not Get) to see every entry.
+		gotBetas = r.Header.Values("anthropic-beta")
+		gotBody = body
+	})
+
+	client := newTestClient(srv, latest.ModelConfig{
+		Provider:   "anthropic",
+		Model:      "claude-opus-4-7",
+		TaskBudget: &latest.TaskBudget{Total: 128000},
+	})
+
+	stream, err := client.CreateChatCompletionStream(
+		t.Context(),
+		[]chat.Message{{Role: chat.MessageRoleUser, Content: "hello"}},
+		nil,
+	)
+	require.NoError(t, err)
+	drain(stream)
+
+	assert.Equal(t, "/v1/messages", gotPath, "expected Beta messages path")
+	assert.Contains(t, gotBetas, taskBudgetBeta,
+		"anthropic-beta headers must contain %s; got %v", taskBudgetBeta, gotBetas)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(gotBody, &body), "raw body: %s", string(gotBody))
+	outputCfg, ok := body["output_config"].(map[string]any)
+	require.True(t, ok, "expected output_config in body, got %s", string(gotBody))
+	tb, ok := outputCfg["task_budget"].(map[string]any)
+	require.True(t, ok, "expected task_budget in output_config, got %s", string(gotBody))
+	assert.Equal(t, "tokens", tb["type"])
+	assert.InDelta(t, 128000, tb["total"], 0.001)
+}
+
+// TestNoTaskBudget_UsesStandardPath sanity-checks that without task_budget
+// (and no other beta-only features) the request targets /v1/messages and
+// does not carry the task-budgets beta header.
+func TestNoTaskBudget_UsesStandardPath(t *testing.T) {
+	var (
+		gotPath  string
+		gotBetas []string
+	)
+	srv := anthropicTestServer(t, func(r *http.Request, _ []byte) {
+		gotPath = r.URL.Path
+		gotBetas = r.Header.Values("anthropic-beta")
+	})
+
+	client := newTestClient(srv, latest.ModelConfig{
+		Provider: "anthropic",
+		Model:    "claude-sonnet-4-5-20250929",
+	})
+
+	stream, err := client.CreateChatCompletionStream(
+		t.Context(),
+		[]chat.Message{{Role: chat.MessageRoleUser, Content: "hi"}},
+		nil,
+	)
+	require.NoError(t, err)
+	drain(stream)
+
+	assert.Equal(t, "/v1/messages", gotPath)
+	assert.NotContains(t, gotBetas, taskBudgetBeta)
+}
+
+// TestZeroTaskBudget_DisablesFeature verifies that `task_budget: 0`
+// (shorthand for "disabled") does NOT route through the Beta path and does
+// NOT emit the task-budgets beta header, matching the documented behavior.
+func TestZeroTaskBudget_DisablesFeature(t *testing.T) {
+	var gotBetas []string
+	var gotBody []byte
+	srv := anthropicTestServer(t, func(r *http.Request, body []byte) {
+		gotBetas = r.Header.Values("anthropic-beta")
+		gotBody = body
+	})
+
+	// Simulate what UnmarshalYAML produces for `task_budget: 0`.
+	client := newTestClient(srv, latest.ModelConfig{
+		Provider:   "anthropic",
+		Model:      "claude-sonnet-4-5-20250929",
+		TaskBudget: &latest.TaskBudget{Type: "tokens", Total: 0},
+	})
+
+	stream, err := client.CreateChatCompletionStream(
+		t.Context(),
+		[]chat.Message{{Role: chat.MessageRoleUser, Content: "hi"}},
+		nil,
+	)
+	require.NoError(t, err)
+	drain(stream)
+
+	assert.NotContains(t, gotBetas, taskBudgetBeta,
+		"task_budget: 0 must not emit the task-budgets beta header")
+	assert.NotContains(t, string(gotBody), "task_budget",
+		"task_budget: 0 must not serialize task_budget in the request body")
+}

--- a/pkg/model/provider/provider.go
+++ b/pkg/model/provider/provider.go
@@ -286,7 +286,7 @@ func resolveProviderType(cfg *latest.ModelConfig) string {
 // This sets default base URLs, token keys, api_type, and model-specific defaults (like thinking budget).
 //
 // The returned config is a deep-enough copy: the caller's ModelConfig, ProviderOpts map,
-// and ThinkingBudget pointer are never mutated.
+// and ThinkingBudget/TaskBudget pointers are never mutated.
 func applyProviderDefaults(cfg *latest.ModelConfig, customProviders map[string]latest.ProviderConfig) *latest.ModelConfig {
 	// Create a copy to avoid modifying the original.
 	// cloneModelConfig also deep-copies ProviderOpts so writes are safe.
@@ -336,6 +336,9 @@ func applyProviderDefaults(cfg *latest.ModelConfig, customProviders map[string]l
 			}
 			if enhancedCfg.ThinkingBudget == nil && providerCfg.ThinkingBudget != nil {
 				enhancedCfg.ThinkingBudget = providerCfg.ThinkingBudget
+			}
+			if enhancedCfg.TaskBudget == nil && providerCfg.TaskBudget != nil {
+				enhancedCfg.TaskBudget = providerCfg.TaskBudget
 			}
 
 			// Merge provider_opts from provider config (model opts take precedence)


### PR DESCRIPTION
## What

Adds a new **`task_budget`** configuration field forwarded to Anthropic as
[`output_config.task_budget`](https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7).
The field caps the total number of tokens a Claude model may spend across a
multi-step agentic task (combined thinking, tool calls, and final output),
letting long-running agents self-regulate effort without a tight per-call
`max_tokens`.

## Why

Claude **Opus 4.7** introduced `output_config.task_budget` for agentic
workloads. Users asked to expose it as a first-class model setting instead of
stuffing it into `provider_opts`.

## Usage

```yaml
models:
  opus:
    provider: anthropic
    model: claude-opus-4-7
    task_budget: 128000          # integer shorthand (tokens)
    thinking_budget: adaptive    # pairs well with adaptive thinking

  opus-object:
    provider: anthropic
    model: claude-opus-4-7
    task_budget:                 # equivalent object form
      type: tokens
      total: 128000
```

`task_budget: 0` disables the feature. The field is inheritable from a
provider definition, like the other model settings.

## Implementation notes

- `task_budget` is configurable on **any** Claude model — `docker-agent` does
  not gate by model name. Only Opus 4.7 actually honors it today; other
  models will reject the field at the API layer.
- When set, the request is routed through the Beta Messages API; a single
  `configureTaskBudget` helper appends the required
  `task-budgets-2026-03-13` beta header and attaches the payload via the
  SDK's `SetExtraFields` escape hatch (the anthropic-sdk-go v1.36.0 we
  depend on does not yet model the field natively).
- `task_budget: 0` short-circuits early: no Beta routing, no header, no
  payload — matching the documented \"disabled\" behavior.

## Tests

- Table-driven (un)marshaling, validation, and `IsZero`/`AsMap` coverage for
  `TaskBudget`, including the `task_budget: 0` disables path.
- Unit tests for `configureTaskBudget` (no-op on nil/zero, attaches payload
  and beta header, coexists with existing `OutputConfig` fields like
  `effort`).
- Integration tests with a real `httptest` server asserting both the happy
  path (Beta routing, `anthropic-beta` header, request body shape) and the
  disabled path (no header, no payload).
- Updated `ModelConfig` clone test to cover the new pointer field.

`mise lint` and `mise test` are both clean.

## Docs & schema

- `agent-schema.json`: `task_budget` added under `ModelConfig` and
  `ProviderConfig`.
- `examples/task_budget.yaml`: demonstrates integer shorthand and object form.
- `docs/`: updated `configuration/models`, `configuration/overview`,
  `concepts/models`, `providers/anthropic`, and `providers/custom` pages.

Assisted-By: docker-agent