### PR TITLE
chore: update cagent-action to v1.4.1

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -12,13 +12,14 @@ permissions:
 
 jobs:
   review:
-    uses: docker/cagent-action/.github/workflows/review-pr.yml@dba0ca51938c78afb363625363c50582243218d6 # v1.3.1
+    uses: docker/cagent-action/.github/workflows/review-pr.yml@d98096f432f2aea5091c811852c4da804e60623a # v1.4.1
     # Scoped to the job so other jobs in this workflow aren't over-permissioned
     permissions:
       contents: read # Read repository files and PR diffs
       pull-requests: write # Post review comments and approve/request changes
       issues: write # Create security incident issues if secrets are detected in output
       checks: write # (Optional) Show review progress as a check run on the PR
+      id-token: write # Required for OIDC authentication to AWS Secrets Manager
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       CAGENT_ORG_MEMBERSHIP_TOKEN: ${{ secrets.CAGENT_ORG_MEMBERSHIP_TOKEN }} # PAT with read:org scope; gates auto-reviews to org members only


### PR DESCRIPTION
Automated update of `docker/cagent-action` reusable workflow reference.

| Field | Value |
|-------|-------|
| Version | `v1.4.1` |
| SHA | `d98096f432f2aea5091c811852c4da804e60623a` |
| Release | https://github.com/docker/cagent-action/releases/tag/v1.4.1 |

This PR was created automatically by `scripts/update-consumers.sh`.
