### PR TITLE
fix(examples): correct MCP catalog ref in mcp-definitions.yaml

### DIFF
--- a/examples/mcp-definitions.yaml
+++ b/examples/mcp-definitions.yaml
@@ -17,7 +17,7 @@ mcps:
     ref: docker:context7
 
   github:
-    ref: docker:github
+    ref: docker:github-official
     env:
       GITHUB_PERSONAL_ACCESS_TOKEN: "${GITHUB_PERSONAL_ACCESS_TOKEN}"
     tools:


### PR DESCRIPTION
\`docker:github\` is not a valid Docker MCP catalog entry. The correct name is \`docker:github-official\`.

At runtime this would fail with: \`MCP server "github" not found in MCP catalog\`.

All other examples in the repo already use \`docker:github-official\`:
- \`examples/github.yaml\`
- \`examples/code_mode.yaml\`
- \`examples/github-toon.yaml\`
- \`examples/github_issue_manager.yaml\`

**Change:** \`ref: docker:github\` → \`ref: docker:github-official\` (one line fix).