### PR TITLE
Support filtering skills by name in agent YAML (#2404)

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -397,8 +397,26 @@
           "description": "Lifecycle hooks for executing shell commands at various points in the agent's execution"
         },
         "skills": {
-          "type": "boolean",
-          "description": "Enable skills discovery for this agent. When enabled, the agent can discover and load skill files (SKILL.md) from the workspace."
+          "description": "Enable skills discovery for this agent. Set to true to load all discovered skills from local filesystem sources; false disables skills. A list can mix sources (\"local\" or an HTTP/HTTPS URL) and/or skill names to include. If only names are given, local sources are loaded and filtered to just those skills.",
+          "oneOf": [
+            {
+              "type": "boolean",
+              "description": "When true, loads all discovered local skills. When false, skills are disabled."
+            },
+            {
+              "type": "array",
+              "description": "List combining skill sources and/or skill names to include. Items equal to \"local\" or starting with http:// or https:// are treated as sources; any other string is treated as a skill name filter.",
+              "items": {
+                "type": "string"
+              },
+              "examples": [
+                ["local"],
+                ["local", "https://skills.example.com"],
+                ["git", "docker"],
+                ["local", "docker-build"]
+              ]
+            }
+          ]
         }
       },
       "additionalProperties": false

--- a/docs/configuration/agents/index.md
+++ b/docs/configuration/agents/index.md
@@ -33,7 +33,7 @@ agents:
     max_consecutive_tool_calls: int # Optional: max identical consecutive tool calls
     max_old_tool_call_tokens: int # Optional: token budget for old tool call content
     num_history_items: int # Optional: limit conversation history
-    skills: boolean # Optional: enable skill discovery
+    skills: boolean | [list] # Optional: enable skill discovery (true/false or list of names and/or sources)
     commands: # Optional: named prompts
       name: "prompt text"
     welcome_message: string # Optional: message shown at session start
@@ -78,7 +78,7 @@ agents:
 | `max_old_tool_call_tokens`  | int     | ✗        | Maximum number of tokens to keep from old tool call arguments and results. Older tool calls beyond this budget have their content replaced with a placeholder, saving context space. Tokens are approximated as `len/4`. Set to `-1` to disable truncation (unlimited). Default: `40000`. |
 | `num_history_items`         | int     | ✗        | Limit the number of conversation history messages sent to the model. Useful for managing context window size with long conversations. Default: unlimited (all messages sent). |
 | `rag`                       | array   | ✗        | List of RAG source names to attach to this agent. References sources defined in the top-level `rag` section. See [RAG]({{ '/features/rag/' | relative_url }}).                                       |
-| `skills`                    | boolean | ✗        | Enable automatic skill discovery from standard directories.                                                                                                                   |
+| `skills`                    | bool/array | ✗     | Enable automatic skill discovery. `true` loads all discovered local skills, `false` disables them. A list can mix skill sources (`local` or `https://…` URLs) and skill names to include — see [Skills]({{ '/features/skills/' | relative_url }}).                                                     |
 | `commands`                  | object  | ✗        | Named prompts that can be run with `docker agent run config.yaml /command_name`.                                                                                              |
 | `welcome_message`           | string  | ✗        | Message displayed to the user when a session starts. Useful for providing context or instructions.                                                                            |
 | `handoffs`                  | array   | ✗        | List of agent names this agent can hand off the conversation to. Enables the `handoff` tool. See [Handoffs Routing]({{ '/concepts/multi-agent/#handoffs-routing' | relative_url }}).                  |

--- a/docs/features/skills/index.md
+++ b/docs/features/skills/index.md
@@ -34,6 +34,40 @@ agents:
 
 </div>
 
+## Filtering Skills
+
+The `skills` field also accepts a list, letting you restrict the agent to a specific subset of skills instead of exposing every discovered one. List items are classified automatically:
+
+- `"local"` or any `http://` / `https://` URL → a **source** to load skills from
+- any other string → the **name** of a skill to include
+
+When only names are given, local sources are used by default.
+
+```yaml
+agents:
+  # Load every discovered local skill (same as `skills: true`).
+  full:
+    skills: true
+
+  # Load local skills, but only expose "commit" and "poem".
+  scoped:
+    skills:
+      - commit
+      - poem
+
+  # Combine an explicit source with a name filter.
+  remote_filtered:
+    skills:
+      - https://skills.example.com
+      - commit
+
+  # Disable skills entirely.
+  none:
+    skills: false
+```
+
+A name that doesn't match any discovered skill is logged as a warning at startup but is otherwise ignored.
+
 ## SKILL.md Format
 
 <!-- yaml-lint:skip -->
@@ -171,11 +205,11 @@ When asked to create a Dockerfile:
 EOF
 ```
 
-The skill will automatically be available to any agent with `skills: true`.
+The skill will automatically be available to any agent with skills enabled (`skills: true`, or a list that targets its name — see [Filtering Skills](#filtering-skills)).
 
 <div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ See also
 </div>
-  <p>Skills are enabled in the <a href="{{ '/configuration/agents/' | relative_url }}">Agent Config</a> with the <code>skills: true</code> property. For tool-based capabilities, see <a href="{{ '/concepts/tools/' | relative_url }}">Tools</a>.</p>
+  <p>Skills are enabled in the <a href="{{ '/configuration/agents/' | relative_url }}">Agent Config</a> with the <code>skills</code> property (boolean or list). For tool-based capabilities, see <a href="{{ '/concepts/tools/' | relative_url }}">Tools</a>.</p>
 
 </div>

--- a/examples/skills_filter.yaml
+++ b/examples/skills_filter.yaml
@@ -1,0 +1,29 @@
+#!yaml
+# Skills filter example.
+#
+# The `skills` field accepts either:
+#   - `true` / `false` to enable/disable skills discovery entirely.
+#   - A list combining skill sources and/or skill names to include.
+#
+# Items equal to "local" or starting with http:// or https:// are treated as
+# sources (where to discover skills from). Any other string is treated as the
+# name of a specific skill to expose to the agent. When only skill names are
+# given, the `local` source is used by default.
+#
+# The agent below loads skills from the local workspace but only exposes the
+# `commit` and `poem` skills. Any other discovered skills (including the
+# built-in `bump-go-dependencies`) will be hidden from the model.
+agents:
+  root:
+    model: openai/gpt-4o-mini
+    description: A small agent that demonstrates filtering skills by name.
+    instruction: |
+      You are a helpful assistant. Use the available skills when the user's
+      request matches one.
+    # Only expose the "commit" and "poem" skills from the locally discovered set.
+    skills:
+      - commit
+      - poem
+    toolsets:
+      - type: shell
+      - type: filesystem

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -247,5 +247,10 @@ func validateSkillsConfiguration(_ string, agent *latest.AgentConfig) error {
 			return fmt.Errorf("agent '%s' has unknown skills source '%s' (must be 'local' or an HTTP/HTTPS URL)", agent.Name, source)
 		}
 	}
+	for _, name := range agent.Skills.Include {
+		if strings.TrimSpace(name) == "" {
+			return fmt.Errorf("agent '%s' has an empty skills entry", agent.Name)
+		}
+	}
 	return nil
 }

--- a/pkg/config/latest/skills_config_test.go
+++ b/pkg/config/latest/skills_config_test.go
@@ -54,6 +54,30 @@ func TestSkillsConfig_UnmarshalYAML(t *testing.T) {
 				"http://internal.corp",
 			}},
 		},
+		{
+			name:  "list of skill names implies local source",
+			input: "[git, docker]",
+			expected: SkillsConfig{
+				Sources: []string{"local"},
+				Include: []string{"git", "docker"},
+			},
+		},
+		{
+			name:  "list mixing local source and skill names",
+			input: "[local, git]",
+			expected: SkillsConfig{
+				Sources: []string{"local"},
+				Include: []string{"git"},
+			},
+		},
+		{
+			name:  "list mixing remote source and skill names",
+			input: "[\"https://skills.example.com\", git]",
+			expected: SkillsConfig{
+				Sources: []string{"https://skills.example.com"},
+				Include: []string{"git"},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -92,6 +116,22 @@ func TestSkillsConfig_MarshalYAML(t *testing.T) {
 			input:    SkillsConfig{Sources: []string{"https://example.com"}},
 			expected: "- https://example.com\n",
 		},
+		{
+			name: "include with default local source omits local",
+			input: SkillsConfig{
+				Sources: []string{"local"},
+				Include: []string{"git", "docker"},
+			},
+			expected: "- git\n- docker\n",
+		},
+		{
+			name: "include with explicit remote keeps both",
+			input: SkillsConfig{
+				Sources: []string{"https://example.com"},
+				Include: []string{"git"},
+			},
+			expected: "- https://example.com\n- git\n",
+		},
 	}
 
 	for _, tt := range tests {
@@ -129,6 +169,22 @@ func TestSkillsConfig_UnmarshalJSON(t *testing.T) {
 			input:    `["local", "https://skills.example.com"]`,
 			expected: SkillsConfig{Sources: []string{"local", "https://skills.example.com"}},
 		},
+		{
+			name:  "list with skill names defaults to local",
+			input: `["git", "docker"]`,
+			expected: SkillsConfig{
+				Sources: []string{"local"},
+				Include: []string{"git", "docker"},
+			},
+		},
+		{
+			name:  "list mixing source and names",
+			input: `["local", "git"]`,
+			expected: SkillsConfig{
+				Sources: []string{"local"},
+				Include: []string{"git"},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -161,6 +217,22 @@ func TestSkillsConfig_MarshalJSON(t *testing.T) {
 			name:     "list with remote",
 			input:    SkillsConfig{Sources: []string{"local", "https://example.com"}},
 			expected: `["local","https://example.com"]`,
+		},
+		{
+			name: "include with default local source omits local",
+			input: SkillsConfig{
+				Sources: []string{"local"},
+				Include: []string{"git", "docker"},
+			},
+			expected: `["git","docker"]`,
+		},
+		{
+			name: "include with remote source keeps both",
+			input: SkillsConfig{
+				Sources: []string{"https://example.com"},
+				Include: []string{"git"},
+			},
+			expected: `["https://example.com","git"]`,
 		},
 	}
 
@@ -267,4 +339,73 @@ toolsets:
 	assert.True(t, agent.Skills.Enabled())
 	assert.True(t, agent.Skills.HasLocal())
 	assert.Empty(t, agent.Skills.RemoteURLs())
+}
+
+func TestSkillsConfig_InAgentConfigIncludeOnly(t *testing.T) {
+	yamlInput := `
+model: openai/gpt-4
+skills:
+  - git
+  - docker
+toolsets:
+  - type: filesystem
+`
+	var agent AgentConfig
+	err := yaml.Unmarshal([]byte(yamlInput), &agent)
+	require.NoError(t, err)
+	assert.True(t, agent.Skills.Enabled())
+	assert.True(t, agent.Skills.HasLocal())
+	assert.Equal(t, []string{"git", "docker"}, agent.Skills.Include)
+}
+
+func TestSkillsConfig_InAgentConfigMixedSourcesAndIncludes(t *testing.T) {
+	yamlInput := `
+model: openai/gpt-4
+skills:
+  - local
+  - https://skills.example.com
+  - git
+toolsets:
+  - type: filesystem
+`
+	var agent AgentConfig
+	err := yaml.Unmarshal([]byte(yamlInput), &agent)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"local", "https://skills.example.com"}, agent.Skills.Sources)
+	assert.Equal(t, []string{"git"}, agent.Skills.Include)
+}
+
+func TestSkillsConfig_EmptyListIsDisabled(t *testing.T) {
+	// An empty list (no sources and no names) means disabled, like `skills: false`.
+	var s SkillsConfig
+	require.NoError(t, yaml.Unmarshal([]byte("[]"), &s))
+	assert.False(t, s.Enabled())
+	assert.Empty(t, s.Include)
+
+	s = SkillsConfig{}
+	require.NoError(t, json.Unmarshal([]byte("[]"), &s))
+	assert.False(t, s.Enabled())
+	assert.Empty(t, s.Include)
+}
+
+func TestSkillsConfig_UnmarshalResetsReceiver(t *testing.T) {
+	// Unmarshaling into an already-populated receiver must not leak previous state.
+	t.Run("bool into populated receiver", func(t *testing.T) {
+		s := SkillsConfig{Sources: []string{"https://old"}, Include: []string{"old"}}
+		require.NoError(t, yaml.Unmarshal([]byte("true"), &s))
+		assert.Equal(t, []string{"local"}, s.Sources)
+		assert.Nil(t, s.Include)
+	})
+	t.Run("list into populated receiver", func(t *testing.T) {
+		s := SkillsConfig{Sources: []string{"https://old"}, Include: []string{"old"}}
+		require.NoError(t, yaml.Unmarshal([]byte("[git]"), &s))
+		assert.Equal(t, []string{"local"}, s.Sources)
+		assert.Equal(t, []string{"git"}, s.Include)
+	})
+	t.Run("false into populated receiver", func(t *testing.T) {
+		s := SkillsConfig{Sources: []string{"https://old"}, Include: []string{"old"}}
+		require.NoError(t, json.Unmarshal([]byte("false"), &s))
+		assert.Nil(t, s.Sources)
+		assert.Nil(t, s.Include)
+	})
 }

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -385,15 +385,32 @@ type AgentConfig struct {
 
 const SkillSourceLocal = "local"
 
-// SkillsConfig controls skill discovery sources for an agent.
+// errSkillsFormat is returned when the `skills` value is neither a boolean nor
+// a list of strings.
+var errSkillsFormat = errors.New("skills must be a boolean or a list of skill sources and/or names")
+
+// SkillsConfig controls skill discovery sources and filtering for an agent.
 // Supports three YAML formats:
 //   - Boolean: `skills: true` (equivalent to ["local"]) or `skills: false` (disabled)
-//   - List:    `skills: ["local", "http://example.com"]`
+//   - List:    `skills: ["local", "http://example.com"]` — sources to load from
+//   - List:    `skills: ["git", "docker"]`               — names of skills to include
+//   - List:    `skills: ["local", "git"]`                — mix of sources and names
+//
+// Items in the list are classified automatically:
+//   - "local" or any HTTP/HTTPS URL → a skill source (added to Sources)
+//   - any other string             → a skill name filter (added to Include)
+//
+// When Include is non-empty but no explicit sources are provided, Sources defaults
+// to ["local"] so that `skills: ["git"]` loads local skills and keeps only "git".
 //
 // The special source "local" loads skills from the filesystem (standard locations).
 // HTTP/HTTPS URLs load skills from remote servers per the well-known skills discovery spec.
 type SkillsConfig struct { //nolint:recvcheck // MarshalYAML/MarshalJSON must use value receiver, UnmarshalYAML/UnmarshalJSON must use pointer
+	// Sources lists where to load skills from: "local" and/or HTTP/HTTPS URLs.
 	Sources []string
+	// Include optionally filters loaded skills by name. When non-empty, only
+	// skills whose Name matches an entry in this list are exposed to the agent.
+	Include []string
 }
 
 func (s SkillsConfig) Enabled() bool {
@@ -407,69 +424,111 @@ func (s SkillsConfig) HasLocal() bool {
 func (s SkillsConfig) RemoteURLs() []string {
 	var urls []string
 	for _, src := range s.Sources {
-		if strings.HasPrefix(src, "http://") || strings.HasPrefix(src, "https://") {
+		if isRemoteURL(src) {
 			urls = append(urls, src)
 		}
 	}
 	return urls
 }
 
+// isRemoteURL reports whether s looks like an HTTP or HTTPS URL.
+func isRemoteURL(s string) bool {
+	return strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://")
+}
+
+// isSkillSource reports whether a list item should be treated as a skill source
+// (the special value "local" or an HTTP/HTTPS URL) rather than a skill name.
+func isSkillSource(item string) bool {
+	return item == SkillSourceLocal || isRemoteURL(item)
+}
+
+// setFromBool is the shared "boolean shorthand" logic for YAML and JSON
+// unmarshaling: `true` means load local skills, `false` disables skills.
+func (s *SkillsConfig) setFromBool(b bool) {
+	s.Include = nil
+	if b {
+		s.Sources = []string{SkillSourceLocal}
+	} else {
+		s.Sources = nil
+	}
+}
+
+// setFromList splits items into Sources ("local" + URLs) and Include (skill
+// name filters). When Include is non-empty and Sources is empty, Sources
+// defaults to ["local"] so that `skills: ["git"]` filters local skills
+// without requiring the user to spell out the source.
+func (s *SkillsConfig) setFromList(items []string) {
+	s.Sources = nil
+	s.Include = nil
+	for _, item := range items {
+		if isSkillSource(item) {
+			s.Sources = append(s.Sources, item)
+		} else {
+			s.Include = append(s.Include, item)
+		}
+	}
+	if len(s.Sources) == 0 && len(s.Include) > 0 {
+		s.Sources = []string{SkillSourceLocal}
+	}
+}
+
+// marshalValue returns the canonical encoded representation: `false` when
+// disabled, `true` when only the default local source is set, otherwise a
+// flat []string combining Sources and Include. The default local source is
+// omitted from the list when Include is non-empty so the output round-trips
+// back through setFromList.
+func (s SkillsConfig) marshalValue() any {
+	switch {
+	case len(s.Sources) == 0 && len(s.Include) == 0:
+		return false
+	case len(s.Include) == 0 && len(s.Sources) == 1 && s.Sources[0] == SkillSourceLocal:
+		return true
+	}
+
+	sources := s.Sources
+	if len(s.Include) > 0 && len(sources) == 1 && sources[0] == SkillSourceLocal {
+		sources = nil
+	}
+	out := make([]string, 0, len(sources)+len(s.Include))
+	out = append(out, sources...)
+	out = append(out, s.Include...)
+	return out
+}
+
 func (s *SkillsConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	var b bool
 	if err := unmarshal(&b); err == nil {
-		if b {
-			s.Sources = []string{SkillSourceLocal}
-		} else {
-			s.Sources = nil
-		}
+		s.setFromBool(b)
 		return nil
 	}
-
-	var sources []string
-	if err := unmarshal(&sources); err != nil {
-		return errors.New("skills must be a boolean or a list of sources")
+	var items []string
+	if err := unmarshal(&items); err != nil {
+		return errSkillsFormat
 	}
-	s.Sources = sources
+	s.setFromList(items)
 	return nil
 }
 
 func (s SkillsConfig) MarshalYAML() (any, error) {
-	if len(s.Sources) == 0 {
-		return false, nil
-	}
-	if len(s.Sources) == 1 && s.Sources[0] == SkillSourceLocal {
-		return true, nil
-	}
-	return s.Sources, nil
+	return s.marshalValue(), nil
 }
 
 func (s *SkillsConfig) UnmarshalJSON(data []byte) error {
 	var b bool
 	if err := json.Unmarshal(data, &b); err == nil {
-		if b {
-			s.Sources = []string{SkillSourceLocal}
-		} else {
-			s.Sources = nil
-		}
+		s.setFromBool(b)
 		return nil
 	}
-
-	var sources []string
-	if err := json.Unmarshal(data, &sources); err != nil {
-		return errors.New("skills must be a boolean or a list of sources")
+	var items []string
+	if err := json.Unmarshal(data, &items); err != nil {
+		return errSkillsFormat
 	}
-	s.Sources = sources
+	s.setFromList(items)
 	return nil
 }
 
 func (s SkillsConfig) MarshalJSON() ([]byte, error) {
-	if len(s.Sources) == 0 {
-		return json.Marshal(false)
-	}
-	if len(s.Sources) == 1 && s.Sources[0] == SkillSourceLocal {
-		return json.Marshal(true)
-	}
-	return json.Marshal(s.Sources)
+	return json.Marshal(s.marshalValue())
 }
 
 // GetFallbackModels returns the fallback models from the config.

--- a/pkg/config/testdata/skills_with_include.yaml
+++ b/pkg/config/testdata/skills_with_include.yaml
@@ -1,0 +1,11 @@
+version: "7"
+
+agents:
+  root:
+    model: openai/gpt-4o
+    # Load local skills but only expose the "git" and "docker" skills.
+    skills:
+      - git
+      - docker
+    toolsets:
+      - type: filesystem

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -121,19 +121,46 @@ func TestValidSkillsConfiguration(t *testing.T) {
 	}
 }
 
-func TestInvalidSkillsSources(t *testing.T) {
+func TestSkillsConfigRejectsEmptyEntry(t *testing.T) {
 	t.Parallel()
 
+	// Empty entries in the skills list should be rejected.
 	cfgStr := `version: "5"
 agents:
   root:
     model: openai/gpt-4o
     skills:
-      - invalid_source
+      - local
+      - ""
     toolsets:
       - type: filesystem
 `
 	_, err := Load(t.Context(), NewBytesSource("test", []byte(cfgStr)))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unknown skills source")
+	assert.Contains(t, err.Error(), "empty skills entry")
+}
+
+func TestSkillsNameFilter(t *testing.T) {
+	t.Parallel()
+
+	// A string that is not "local" and not a URL is interpreted as a skill
+	// name to include. This must load successfully — the filter simply keeps
+	// only matching skills at runtime.
+	cfgStr := `version: "7"
+agents:
+  root:
+    model: openai/gpt-4o
+    skills:
+      - git
+      - docker
+    toolsets:
+      - type: filesystem
+`
+	cfg, err := Load(t.Context(), NewBytesSource("test", []byte(cfgStr)))
+	require.NoError(t, err)
+	agent, ok := cfg.Agents.Lookup("root")
+	require.True(t, ok)
+	require.True(t, agent.Skills.Enabled())
+	require.True(t, agent.Skills.HasLocal())
+	assert.Equal(t, []string{"git", "docker"}, agent.Skills.Include)
 }

--- a/pkg/teamloader/skills_filter_test.go
+++ b/pkg/teamloader/skills_filter_test.go
@@ -1,0 +1,85 @@
+package teamloader
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/docker/docker-agent/pkg/skills"
+)
+
+func TestFilterSkillsByName_NoFilterReturnsAll(t *testing.T) {
+	loaded := []skills.Skill{
+		{Name: "git"},
+		{Name: "docker"},
+		{Name: "kubernetes"},
+	}
+
+	result := filterSkillsByName(loaded, nil)
+	assert.Equal(t, loaded, result)
+
+	result = filterSkillsByName(loaded, []string{})
+	assert.Equal(t, loaded, result)
+}
+
+func TestFilterSkillsByName_KeepsMatchingSkills(t *testing.T) {
+	loaded := []skills.Skill{
+		{Name: "git"},
+		{Name: "docker"},
+		{Name: "kubernetes"},
+	}
+
+	result := filterSkillsByName(loaded, []string{"git", "kubernetes"})
+	assert.Equal(t, []skills.Skill{
+		{Name: "git"},
+		{Name: "kubernetes"},
+	}, result)
+}
+
+func TestFilterSkillsByName_PreservesOriginalOrder(t *testing.T) {
+	loaded := []skills.Skill{
+		{Name: "a"},
+		{Name: "b"},
+		{Name: "c"},
+	}
+
+	// Include list order should not reorder filtered output.
+	result := filterSkillsByName(loaded, []string{"c", "a"})
+	assert.Equal(t, []skills.Skill{
+		{Name: "a"},
+		{Name: "c"},
+	}, result)
+}
+
+func TestFilterSkillsByName_IgnoresUnknownNames(t *testing.T) {
+	loaded := []skills.Skill{
+		{Name: "git"},
+	}
+
+	result := filterSkillsByName(loaded, []string{"git", "does-not-exist"})
+	assert.Equal(t, []skills.Skill{{Name: "git"}}, result)
+}
+
+func TestFilterSkillsByName_EmptyLoaded(t *testing.T) {
+	result := filterSkillsByName(nil, []string{"git"})
+	assert.Empty(t, result)
+}
+
+func TestFilterSkillsByName_KeepsAllDuplicateNameMatches(t *testing.T) {
+	// The loaded slice may contain multiple skills with the same name (e.g. one
+	// from the local filesystem and one from a remote source, which are keyed
+	// separately in skills.Load). The filter must not silently drop duplicates
+	// — both should be included so downstream code (NewSkillsToolset) can apply
+	// its own precedence rules.
+	loaded := []skills.Skill{
+		{Name: "git", Description: "local"},
+		{Name: "git", Description: "remote"},
+		{Name: "docker"},
+	}
+
+	result := filterSkillsByName(loaded, []string{"git"})
+	assert.Equal(t, []skills.Skill{
+		{Name: "git", Description: "local"},
+		{Name: "git", Description: "remote"},
+	}, result)
+}

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -206,6 +206,7 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 		// Add skills toolset if skills are enabled
 		if agentConfig.Skills.Enabled() {
 			loadedSkills := skills.Load(agentConfig.Skills.Sources)
+			loadedSkills = filterSkillsByName(loadedSkills, agentConfig.Skills.Include)
 			if len(loadedSkills) > 0 {
 				agentTools = append(agentTools, builtin.NewSkillsToolset(loadedSkills, runConfig.WorkingDir))
 			}
@@ -464,6 +465,34 @@ func getToolsForAgent(ctx context.Context, a *latest.AgentConfig, parentDir stri
 	}
 
 	return toolSets, warnings
+}
+
+// filterSkillsByName returns the subset of skills whose Name matches one of
+// the include filters. When include is empty, skills is returned unchanged.
+// Skills are not reordered; each matching skill keeps its original position.
+// Any include entry that does not match any loaded skill is logged as a warning.
+func filterSkillsByName(loaded []skills.Skill, include []string) []skills.Skill {
+	if len(include) == 0 {
+		return loaded
+	}
+	wanted := make(map[string]bool, len(include))
+	for _, name := range include {
+		wanted[name] = true
+	}
+	matched := make(map[string]bool, len(wanted))
+	filtered := make([]skills.Skill, 0, len(loaded))
+	for _, s := range loaded {
+		if wanted[s.Name] {
+			filtered = append(filtered, s)
+			matched[s.Name] = true
+		}
+	}
+	for _, name := range include {
+		if !matched[name] {
+			slog.Warn("Skill filter does not match any loaded skill", "name", name)
+		}
+	}
+	return filtered
 }
 
 // configNameFromSource extracts a clean config name from a source name.


### PR DESCRIPTION
## What

The agent `skills` field now accepts a list that mixes sources and
skill names. Items equal to `"local"` or starting with `http://` or
`https://` are classified as sources; any other string is treated as
the name of a specific skill to expose to the agent.

When only skill names are given, the `local` source is used by
default, so `skills: [git, docker]` loads local skills and keeps only
those two. `skills: true` and `skills: false` still work as before.

```yaml
# Load all discovered local skills (unchanged)
skills: true

# Disable skills (unchanged)
skills: false

# Load only the "commit" and "poem" skills from local sources (new)
skills:
  - commit
  - poem

# Combine explicit sources with a name filter (new)
skills:
  - local
  - https://skills.example.com
  - commit
```

## Why

Closes #2404 — agents should be able to opt into a specific subset of
the skills available on the host instead of loading every discovered
skill.

## How

- Added an `Include` field to `latest.SkillsConfig`; the YAML/JSON
  (Un)marshal methods classify list items into `Sources` and
  `Include`, with symmetric round-trip.
- `teamloader.LoadWithConfig` applies the filter through a new
  `filterSkillsByName` helper. Unmatched filter names are logged as a
  warning; duplicate-name skills (e.g. one local + one remote with the
  same name) are all kept so downstream code (`NewSkillsToolset`) can
  resolve precedence.
- `validateSkillsConfiguration` rejects empty strings inside the list.
- `agent-schema.json` now declares `skills` as `oneOf { boolean, array }`.
- New `examples/skills_filter.yaml` and updated docs
  (`docs/features/skills/index.md`,
  `docs/configuration/agents/index.md`).
- Tests cover every list/bool form, both codecs, the empty-list case,
  receiver reset on re-decode, duplicate-name preservation in the
  filter, and the migration path from older versions.
