### PR TITLE
docs: fix doc-code divergences reported in #2464

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://github.com/docker/docker-agent/blob/main/agent-schema.json",
   "title": "Docker Agent Configuration",
-  "description": "Configuration schema for Docker Agent v7",
+  "description": "Configuration schema for Docker Agent v8",
   "type": "object",
   "properties": {
     "version": {
@@ -16,7 +16,8 @@
         "4",
         "5",
         "6",
-        "7"
+        "7",
+        "8"
       ],
       "examples": [
         "0",
@@ -26,7 +27,8 @@
         "4",
         "5",
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     "providers": {

--- a/docs/concepts/agents/index.md
+++ b/docs/concepts/agents/index.md
@@ -57,7 +57,7 @@ Every docker-agent configuration has a **root agent** — the entry point that r
 | `add_environment_info` | boolean | ✗        | Include OS, working directory, git info in context             |
 | `max_iterations`       | int     | ✗        | Max tool-calling loops (default: unlimited)                    |
 | `commands`             | object  | ✗        | Named prompts callable via `/command`                          |
-| `skills`               | boolean | ✗        | Enable skill discovery and loading                             |
+| `skills`               | boolean \| list | ✗    | Enable skill discovery and loading. `true` = `["local"]`; list values may combine `"local"` with remote skill-server URLs. |
 
 ## Model Fallbacks
 

--- a/docs/concepts/models/index.md
+++ b/docs/concepts/models/index.md
@@ -45,15 +45,21 @@ Named models let you configure temperature, token limits, thinking budgets, and 
 
 ## Supported Providers
 
-| Provider            | Key              | Example Models                       | API Key Env Var     |
-| ------------------- | ---------------- | ------------------------------------ | ------------------- |
-| OpenAI              | `openai`         | gpt-4o, gpt-5, gpt-5-mini            | `OPENAI_API_KEY`    |
-| Anthropic           | `anthropic`      | claude-sonnet-4-0, claude-sonnet-4-5 | `ANTHROPIC_API_KEY` |
-| Google              | `google`         | gemini-2.5-flash, gemini-3-pro       | `GOOGLE_API_KEY`    |
-| AWS Bedrock         | `amazon-bedrock` | Claude, Nova, Llama models           | AWS credentials     |
-| Docker Model Runner | `dmr`            | ai/qwen3, ai/llama3.2                | None (local)        |
-| Mistral             | `mistral`        | Mistral models                       | `MISTRAL_API_KEY`   |
-| xAI                 | `xai`            | Grok models                          | `XAI_API_KEY`       |
+| Provider            | Key              | Example Models                       | API Key Env Var                     |
+| ------------------- | ---------------- | ------------------------------------ | ----------------------------------- |
+| OpenAI              | `openai`         | gpt-4o, gpt-5, gpt-5-mini            | `OPENAI_API_KEY`                    |
+| Anthropic           | `anthropic`      | claude-sonnet-4-0, claude-sonnet-4-5 | `ANTHROPIC_API_KEY`                 |
+| Google              | `google`         | gemini-2.5-flash, gemini-3-pro       | `GOOGLE_API_KEY` / `GEMINI_API_KEY` |
+| AWS Bedrock         | `amazon-bedrock` | Claude, Nova, Llama models           | AWS credentials                     |
+| Docker Model Runner | `dmr`            | ai/qwen3, ai/llama3.2                | None (local)                        |
+| Mistral             | `mistral`        | Mistral models                       | `MISTRAL_API_KEY`                   |
+| xAI                 | `xai`            | Grok models                          | `XAI_API_KEY`                       |
+| Nebius              | `nebius`         | Open-source and specialised models   | `NEBIUS_API_KEY`                    |
+| MiniMax             | `minimax`        | MiniMax models                       | `MINIMAX_API_KEY`                   |
+| Requesty            | `requesty`       | Multi-provider gateway               | `REQUESTY_API_KEY`                  |
+| Azure OpenAI        | `azure`          | gpt-4o, gpt-5 on Azure               | `AZURE_OPENAI_API_KEY` + `base_url` |
+| Ollama              | `ollama`         | Any local Ollama model               | None (local; optional `base_url`)   |
+| GitHub Copilot      | `github-copilot` | Copilot-hosted OpenAI/Anthropic      | GitHub CLI auth (`gh auth login`)   |
 
 See the [Model Providers]({{ '/providers/overview/' | relative_url }}) section for detailed configuration guides.
 

--- a/docs/concepts/tools/index.md
+++ b/docs/concepts/tools/index.md
@@ -30,18 +30,22 @@ docker-agent ships with several built-in tools that require no external dependen
 | Tool | Description |
 | --- | --- |
 | [Filesystem]({{ '/tools/filesystem/' | relative_url }}) | Read, write, list, search, and navigate files and directories |
-| [Shell]({{ '/tools/shell/' | relative_url }}) | Execute arbitrary shell commands in the user's environment |
+| [Shell]({{ '/tools/shell/' | relative_url }}) | Execute synchronous and background shell commands |
 | [Think]({{ '/tools/think/' | relative_url }}) | Step-by-step reasoning scratchpad for planning and decision-making |
 | [Todo]({{ '/tools/todo/' | relative_url }}) | Task list management for complex multi-step workflows |
+| [Tasks]({{ '/tools/tasks/' | relative_url }}) | Persistent task database shared across sessions |
 | [Memory]({{ '/tools/memory/' | relative_url }}) | Persistent key-value storage backed by SQLite |
-| [Fetch]({{ '/tools/fetch/' | relative_url }}) | Make HTTP requests to external APIs and web services |
+| [Fetch]({{ '/tools/fetch/' | relative_url }}) | Read content from HTTP/HTTPS URLs (GET only) |
 | [Script]({{ '/tools/script/' | relative_url }}) | Define custom shell scripts as named tools |
 | [LSP]({{ '/tools/lsp/' | relative_url }}) | Connect to Language Server Protocol servers for code intelligence |
 | [API]({{ '/tools/api/' | relative_url }}) | Create custom tools that call HTTP APIs without writing code |
+| [OpenAPI]({{ '/tools/openapi/' | relative_url }}) | Generate tools from an OpenAPI 3.x document |
+| [RAG]({{ '/features/rag/' | relative_url }}) | Retrieval-augmented generation over indexed sources |
+| [Model Picker]({{ '/tools/model-picker/' | relative_url }}) | Let the agent pick between several models per turn |
 | [User Prompt]({{ '/tools/user-prompt/' | relative_url }}) | Ask users questions and collect interactive input |
 | [Transfer Task]({{ '/tools/transfer-task/' | relative_url }}) | Delegate tasks to sub-agents (auto-enabled with `sub_agents`) |
 | [Background Agents]({{ '/tools/background-agents/' | relative_url }}) | Dispatch work to sub-agents concurrently |
-| [Handoff]({{ '/tools/handoff/' | relative_url }}) | Delegate tasks to remote agents via A2A |
+| [Handoff]({{ '/tools/handoff/' | relative_url }}) | Hand the conversation off to another local agent in the same config (auto-enabled with `handoffs:`) |
 | [A2A]({{ '/tools/a2a/' | relative_url }}) | Connect to remote agents via the Agent-to-Agent protocol |
 
 ## MCP Tools

--- a/docs/configuration/agents/index.md
+++ b/docs/configuration/agents/index.md
@@ -18,8 +18,7 @@ agents:
     description: string # Required: what this agent does
     instruction: string # Required: system prompt
     sub_agents: [list] # Optional: local or external sub-agent references
-    toolsets: [list] # Optional: tool configurations
-    rag: [list] # Optional: RAG source references
+    toolsets: [list] # Optional: tool configurations (use `type: rag` for RAG sources)
     fallback: # Optional: fallback config
       models: [list]
       retries: 2

--- a/docs/configuration/models/index.md
+++ b/docs/configuration/models/index.md
@@ -14,7 +14,10 @@ _Complete reference for defining models with providers, parameters, and reasonin
 ```yaml
 models:
   model_name:
-    provider: string # Required: openai, anthropic, google, amazon-bedrock, dmr
+    provider: string # Required. One of: openai, anthropic, google, amazon-bedrock,
+                     # dmr, mistral, xai, nebius, minimax, requesty, azure, ollama,
+                     # github-copilot, or a named provider defined under the top-level
+                     # `providers:` section.
     model: string # Required: model identifier
     temperature: float # Optional: 0.0–1.0
     max_tokens: integer # Optional: response length limit
@@ -65,7 +68,7 @@ models:
   gpt:
     provider: openai
     model: gpt-5-mini
-    thinking_budget: low # minimal | low | medium | high
+    thinking_budget: low # minimal | low | medium | high | xhigh | max | adaptive/<level>
 ```
 
 ### Anthropic
@@ -101,7 +104,7 @@ models:
   gemini3:
     provider: google
     model: gemini-3-flash
-    thinking_budget: medium # minimal | low | medium | high
+    thinking_budget: medium # minimal | low | medium | high | xhigh | max | adaptive/<level>
 ```
 
 ### Disabling Thinking

--- a/docs/configuration/overview/index.md
+++ b/docs/configuration/overview/index.md
@@ -14,7 +14,7 @@ A docker-agent YAML config has these main sections:
 
 ```bash
 # 1. Version — configuration schema version (optional but recommended)
-version: 6
+version: 8
 
 # 2. Metadata — optional agent metadata for distribution
 metadata:
@@ -46,14 +46,21 @@ rag:
       - type: chunked-embeddings
         model: openai/text-embedding-3-small
 
-# 6. Providers — optional reusable provider definitions
+# 6. MCPs — reusable MCP server definitions (optional)
+mcps:
+  github:
+    remote:
+      url: https://api.githubcopilot.com/mcp
+      transport_type: sse
+
+# 7. Providers — optional reusable provider definitions
 providers:
   my_provider:
     provider: anthropic  # or openai (default), google, amazon-bedrock, etc.
     token_key: MY_API_KEY
     max_tokens: 16384
 
-# 7. Permissions — agent-level tool permission rules (optional)
+# 8. Permissions — agent-level tool permission rules (optional)
 #    For user-wide global permissions, see ~/.config/cagent/config.yaml
 permissions:
   allow: ["read_*"]
@@ -181,10 +188,10 @@ For editor autocompletion and validation, use the [Docker Agent JSON Schema](htt
 
 ## Config Versioning
 
-docker-agent configs are versioned. The current version is `5`. Add the version at the top of your config:
+docker-agent configs are versioned. The current version is `8`. Add the version at the top of your config:
 
 ```yaml
-version: 5
+version: 8
 
 agents:
   root:
@@ -217,6 +224,32 @@ metadata:
 | `version`     | Semantic version string                    |
 
 See [Agent Distribution]({{ '/concepts/distribution/' | relative_url }}) for publishing agents to registries.
+
+## Reusable MCP Servers (`mcps:`)
+
+The top-level `mcps:` section defines named MCP server configurations that agents can reference with `toolsets: [{type: mcp, ref: <name>}]`. This avoids repeating the same command / URL / headers across agents and keeps credentials in one place.
+
+```yaml
+mcps:
+  github:
+    remote:
+      url: https://api.githubcopilot.com/mcp
+      transport_type: sse
+  playwright:
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-playwright"]
+
+agents:
+  root:
+    model: openai/gpt-4o
+    toolsets:
+      - type: mcp
+        ref: github        # reuse the definition above
+      - type: mcp
+        ref: playwright
+```
+
+An `mcps` entry accepts every field a regular `type: mcp` toolset accepts (command/args/env, `remote` with `url`/`transport_type`/`headers`/`oauth`, `tools` filter, `instruction`, `defer`, …) — the `type: mcp` is implicit. See the [Tool Config]({{ '/configuration/tools/' | relative_url }}) page for all options and the [Remote MCP Servers]({{ '/features/remote-mcp/' | relative_url }}) guide for remote setups.
 
 ## Custom Providers Section
 

--- a/docs/configuration/permissions/index.md
+++ b/docs/configuration/permissions/index.md
@@ -46,12 +46,19 @@ permissions:
     - "read_*" # Glob patterns
     - "shell:cmd=ls*" # With argument matching
 
+  # Always ask before running these tools, even if an allow pattern would match
+  ask:
+    - "shell:cmd=git push*"
+    - "write_file:path=/home/user/important/*"
+
   # Block these tools entirely
   deny:
     - "shell:cmd=sudo*"
     - "shell:cmd=rm*-rf*"
     - "dangerous_tool"
 ```
+
+The three lists are evaluated in order `deny` → `allow` → `ask`, so an `ask:` entry lets you add a confirmation layer on top of an otherwise-allowed tool.
 
 ## Global Permissions
 

--- a/docs/configuration/sandbox/index.md
+++ b/docs/configuration/sandbox/index.md
@@ -1,21 +1,23 @@
 ---
 title: "Sandbox Mode"
-description: "Run agents in an isolated Docker container for enhanced security."
+description: "Run agents in an isolated Docker sandbox VM for enhanced security."
 permalink: /configuration/sandbox/
 ---
 
 # Sandbox Mode
 
-_Run agents in an isolated Docker container for enhanced security._
+_Run agents in an isolated Docker sandbox VM for enhanced security._
 
 ## Overview
 
-Sandbox mode runs the entire agent inside a Docker container instead of directly on the host system. This provides an additional layer of isolation, limiting the potential impact of unintended or malicious commands.
+Sandbox mode runs the entire agent inside a disposable sandbox VM instead of directly on the host system. All shell, filesystem, and process activity happens inside that VM, so a misbehaving agent cannot touch files outside the mounted working directory or reach long-lived host state.
+
+The backend is provided by the [`docker sandbox`](https://docs.docker.com/desktop/features/sandbox/) CLI plugin (ships with Docker Desktop) or the standalone [`sbx`](https://github.com/docker/sbx) CLI if it is on `PATH`.
 
 <div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ Requirements
 </div>
-  <p>Sandbox mode requires Docker to be installed and running on the host system.</p>
+  <p>Sandbox mode requires Docker Desktop with sandbox support (or a working <code>sbx</code> CLI). docker-agent shells out to these tools, it does not start raw <code>docker run</code> containers.</p>
 
 </div>
 
@@ -27,7 +29,23 @@ Enable sandbox mode with the `--sandbox` flag on the `docker agent run` command:
 docker agent run --sandbox agent.yaml
 ```
 
-This runs the agent inside a Docker container with the current working directory mounted.
+docker-agent launches a sandbox VM, copies itself into it, mounts the current working directory, and re-runs the agent from inside.
+
+## Flags
+
+| Flag          | Default                                      | Description                                                                                               |
+| ------------- | -------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `--sandbox`   | `false`                                      | Enable sandbox mode.                                                                                      |
+| `--template`  | `docker/sandbox-templates:docker-agent`      | OCI image used as the sandbox template. Passed to `docker sandbox create -t` / `sbx create -t`.           |
+| `--sbx`       | `true`                                       | Prefer the `sbx` CLI backend when it is available. Set `--sbx=false` to always use `docker sandbox`.      |
+
+```bash
+# Use a custom template image
+docker agent run --sandbox --template myorg/custom-agent-template:latest agent.yaml
+
+# Force the docker sandbox backend even if sbx is on PATH
+docker agent run --sandbox --sbx=false agent.yaml
+```
 
 ## Example
 
@@ -48,15 +66,18 @@ docker agent run --sandbox agent.yaml
 
 ## How It Works
 
-1. When `--sandbox` is specified, docker-agent launches a Docker container
-2. The current working directory is mounted into the container
-3. All agent tools (shell, filesystem, etc.) operate inside the container
-4. When the session ends, the container is automatically stopped and removed
+1. `--sandbox` tells docker-agent to prefer the `sbx` CLI (if available and `--sbx` is true), otherwise it falls back to `docker sandbox`.
+2. A new sandbox VM is created from the image passed via `--template`.
+3. The current working directory is mounted into the VM; the agent binary is copied in.
+4. All tools (shell, filesystem, background jobs, etc.) run inside the VM.
+5. When the session ends, the sandbox VM is stopped and removed.
 
 <div class="callout callout-warning" markdown="1">
 <div class="callout-title">⚠️ Limitations
 </div>
 
-- Container starts fresh each session (no persistence between sessions)
+- Sandbox VMs start fresh each session (no persistence between sessions).
+- Only the working directory is mounted; files outside it are not visible to the agent.
+- Network egress is constrained by the sandbox backend's policy.
 
 </div>

--- a/docs/configuration/tools/index.md
+++ b/docs/configuration/tools/index.md
@@ -15,18 +15,22 @@ Built-in tools are included with docker-agent and require no external dependenci
 | Type | Description | Page |
 | --- | --- | --- |
 | `filesystem` | Read, write, list, search, navigate | [Filesystem]({{ '/tools/filesystem/' | relative_url }}) |
-| `shell` | Execute shell commands | [Shell]({{ '/tools/shell/' | relative_url }}) |
+| `shell` | Execute shell commands (sync + background jobs) | [Shell]({{ '/tools/shell/' | relative_url }}) |
 | `think` | Reasoning scratchpad | [Think]({{ '/tools/think/' | relative_url }}) |
 | `todo` | Task list management | [Todo]({{ '/tools/todo/' | relative_url }}) |
+| `tasks` | Persistent task database shared across sessions | [Tasks]({{ '/tools/tasks/' | relative_url }}) |
 | `memory` | Persistent key-value storage (SQLite) | [Memory]({{ '/tools/memory/' | relative_url }}) |
-| `fetch` | HTTP requests | [Fetch]({{ '/tools/fetch/' | relative_url }}) |
+| `fetch` | HTTP `GET` requests with text/markdown/html output | [Fetch]({{ '/tools/fetch/' | relative_url }}) |
 | `script` | Custom shell scripts as tools | [Script]({{ '/tools/script/' | relative_url }}) |
 | `lsp` | Language Server Protocol integration | [LSP]({{ '/tools/lsp/' | relative_url }}) |
 | `api` | Custom HTTP API tools | [API]({{ '/tools/api/' | relative_url }}) |
+| `openapi` | Import every operation of an OpenAPI 3.x document as tools | [OpenAPI]({{ '/tools/openapi/' | relative_url }}) |
+| `rag` | Retrieval-augmented generation over indexed sources | [RAG]({{ '/features/rag/' | relative_url }}) |
+| `model_picker` | Let the agent pick between several models per turn | [Model Picker]({{ '/tools/model-picker/' | relative_url }}) |
 | `user_prompt` | Interactive user input | [User Prompt]({{ '/tools/user-prompt/' | relative_url }}) |
 | `transfer_task` | Delegate to sub-agents (auto-enabled) | [Transfer Task]({{ '/tools/transfer-task/' | relative_url }}) |
 | `background_agents` | Parallel sub-agent dispatch | [Background Agents]({{ '/tools/background-agents/' | relative_url }}) |
-| `handoff` | A2A remote agent delegation | [Handoff]({{ '/tools/handoff/' | relative_url }}) |
+| `handoff` | Local conversation handoff to another agent in the same config (auto-enabled by `handoffs:`) | [Handoff]({{ '/tools/handoff/' | relative_url }}) |
 | `a2a` | A2A remote agent connection | [A2A]({{ '/tools/a2a/' | relative_url }}) |
 
 **Example:**

--- a/docs/features/a2a/index.md
+++ b/docs/features/a2a/index.md
@@ -32,6 +32,22 @@ $ docker agent serve a2a ./agent.yaml --listen 127.0.0.1:9000
 $ docker agent serve a2a agentcatalog/pirate
 ```
 
+## Flags
+
+| Flag                              | Default          | Description                                                                                                          |
+| --------------------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `-l, --listen <addr>`             | `127.0.0.1:8082` | Address to listen on.                                                                                                |
+| `-a, --agent <name>`              | `root`           | Name of the agent to expose when the config contains multiple agents.                                                |
+| `--working-dir <path>`            | current dir      | Working directory the agent runs in.                                                                                 |
+| `--env-from-file <file>`          | (none)           | Load additional environment variables from a `.env` file (repeatable).                                               |
+| `--models-gateway <url>`          | (none)           | Route all provider traffic through a models gateway URL.                                                             |
+| `--code-mode-tools`               | `false`          | Expose tools as a single "code" toolset that accepts a JavaScript snippet to run.                                    |
+| `--hook-pre-tool-use <cmd>`       | (none)           | Add a pre-tool-use hook (repeatable). See [Hooks]({{ '/configuration/hooks/' | relative_url }}).                     |
+| `--hook-post-tool-use <cmd>`      | (none)           | Add a post-tool-use hook (repeatable).                                                                               |
+| `--hook-session-start <cmd>`      | (none)           | Add a session-start hook (repeatable).                                                                               |
+| `--hook-session-end <cmd>`        | (none)           | Add a session-end hook (repeatable).                                                                                 |
+| `--hook-on-user-input <cmd>`      | (none)           | Add an on-user-input hook (repeatable).                                                                              |
+
 ## Features
 
 - **Auto port selection** — Picks an available port if not specified

--- a/docs/features/acp/index.md
+++ b/docs/features/acp/index.md
@@ -67,9 +67,18 @@ Host Application
 docker agent serve acp <agent-file>|<registry-ref> [flags]
 ```
 
-| Flag               | Default                | Description                         |
-| ------------------ | ---------------------- | ----------------------------------- |
-| `-s, --session-db` | `~/.cagent/session.db` | Path to the SQLite session database |
+| Flag                              | Default                | Description                                                                                                          |
+| --------------------------------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `-s, --session-db <path>`         | `~/.cagent/session.db` | Path to the SQLite session database.                                                                                 |
+| `--working-dir <path>`            | current dir            | Working directory the agent runs in.                                                                                 |
+| `--env-from-file <file>`          | (none)                 | Load additional environment variables from a `.env` file (repeatable).                                               |
+| `--models-gateway <url>`          | (none)                 | Route all provider traffic through a models gateway URL.                                                             |
+| `--code-mode-tools`               | `false`                | Expose tools as a single "code" toolset that accepts a JavaScript snippet to run.                                    |
+| `--hook-pre-tool-use <cmd>`       | (none)                 | Add a pre-tool-use hook (repeatable). See [Hooks]({{ '/configuration/hooks/' | relative_url }}).                     |
+| `--hook-post-tool-use <cmd>`      | (none)                 | Add a post-tool-use hook (repeatable).                                                                               |
+| `--hook-session-start <cmd>`      | (none)                 | Add a session-start hook (repeatable).                                                                               |
+| `--hook-session-end <cmd>`        | (none)                 | Add a session-end hook (repeatable).                                                                                 |
+| `--hook-on-user-input <cmd>`      | (none)                 | Add an on-user-input hook (repeatable).                                                                              |
 
 ## Integration Example
 

--- a/docs/features/api-server/index.md
+++ b/docs/features/api-server/index.md
@@ -39,24 +39,27 @@ All endpoints are under the `/api` prefix.
 
 ### Sessions
 
-| Method   | Path                                | Description                                         |
-| -------- | ----------------------------------- | --------------------------------------------------- |
-| `GET`    | `/api/sessions`                     | List all sessions                                   |
-| `POST`   | `/api/sessions`                     | Create a new session                                |
-| `GET`    | `/api/sessions/:id`                 | Get a session by ID (messages, tokens, permissions) |
-| `DELETE` | `/api/sessions/:id`                 | Delete a session                                    |
-| `PATCH`  | `/api/sessions/:id/title`           | Update session title                                |
-| `PATCH`  | `/api/sessions/:id/permissions`     | Update session permissions                          |
-| `POST`   | `/api/sessions/:id/resume`          | Resume a paused session (after tool confirmation)   |
-| `POST`   | `/api/sessions/:id/tools/toggle`    | Toggle auto-approve (YOLO) mode                     |
-| `POST`   | `/api/sessions/:id/elicitation`     | Respond to an MCP tool elicitation request          |
+| Method   | Path                                | Description                                             |
+| -------- | ----------------------------------- | ------------------------------------------------------- |
+| `GET`    | `/api/sessions`                     | List all sessions                                       |
+| `POST`   | `/api/sessions`                     | Create a new session                                    |
+| `GET`    | `/api/sessions/:id`                 | Get a session by ID (messages, tokens, permissions)     |
+| `DELETE` | `/api/sessions/:id`                 | Delete a session                                        |
+| `PATCH`  | `/api/sessions/:id/title`           | Update session title                                    |
+| `PATCH`  | `/api/sessions/:id/permissions`     | Update session permissions                              |
+| `POST`   | `/api/sessions/:id/resume`          | Resume a paused session (after tool confirmation)       |
+| `POST`   | `/api/sessions/:id/tools/toggle`    | Toggle auto-approve (YOLO) mode                         |
+| `POST`   | `/api/sessions/:id/elicitation`     | Respond to an MCP tool elicitation request              |
+| `POST`   | `/api/sessions/:id/steer`           | Inject messages into a running turn (pre-empts current) |
+| `POST`   | `/api/sessions/:id/followup`        | Enqueue messages to run after the current turn finishes |
 
 ### Agent Execution
 
-| Method | Path                                   | Description                                   |
-| ------ | -------------------------------------- | --------------------------------------------- |
-| `POST` | `/api/sessions/:id/agent/:agent`       | Run the root agent for a session (SSE stream) |
-| `POST` | `/api/sessions/:id/agent/:agent/:name` | Run a specific named agent (SSE stream)       |
+| Method | Path                                       | Description                                                                          |
+| ------ | ------------------------------------------ | ------------------------------------------------------------------------------------ |
+| `POST` | `/api/sessions/:id/agent/:agent`           | Run the root agent for a session (SSE stream)                                        |
+| `POST` | `/api/sessions/:id/agent/:agent/:name`     | Run a specific named agent (SSE stream)                                              |
+| `GET`  | `/api/agents/:id/:agent_name/tools/count`  | Count tools currently available to `:agent_name` (accounts for deferred toolsets).   |
 
 **Path parameters:**
 

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -27,18 +27,28 @@ $ docker agent run [config] [message...] [flags]
 
 | Flag                                    | Description                                                                                                                               |
 | --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `-a, --agent &lt;name&gt;`              | Run a specific agent from the config                                                                                                      |
+| `-a, --agent <name>`                    | Run a specific agent from the config                                                                                                      |
 | `--yolo`                                | Auto-approve all tool calls                                                                                                               |
-| `--model &lt;ref&gt;`                   | Override model(s). Use `provider/model` for all agents, or `agent=provider/model` for specific agents. Comma-separate multiple overrides. |
-| `--session &lt;id&gt;`                  | Resume a previous session. Supports relative refs (`-1` = last, `-2` = second to last)                                                    |
-| `--prompt-file &lt;path&gt;`            | Include file contents as additional system context (repeatable)                                                                           |
-| `--hook-pre-tool-use &lt;cmd&gt;`       | Add a pre-tool-use hook command (repeatable). See [Hooks]({{ '/configuration/hooks/' | relative_url }}).                                  |
-| `--hook-post-tool-use &lt;cmd&gt;`      | Add a post-tool-use hook command (repeatable)                                                                                             |
-| `--hook-session-start &lt;cmd&gt;`      | Add a session-start hook command (repeatable)                                                                                             |
-| `--hook-session-end &lt;cmd&gt;`        | Add a session-end hook command (repeatable)                                                                                               |
-| `--hook-on-user-input &lt;cmd&gt;`      | Add an on-user-input hook command (repeatable)                                                                                            |
+| `--model <ref>`                         | Override model(s). Use `provider/model` for all agents, or `agent=provider/model` for specific agents. Comma-separate multiple overrides. |
+| `--session <id>`                        | Resume a previous session. Supports relative refs (`-1` = last, `-2` = second to last)                                                    |
+| `-s, --session-db <path>`               | Path to the SQLite session database (default: `~/.cagent/session.db`)                                                                     |
+| `--prompt-file <path>`                  | Include file contents as additional system context (repeatable)                                                                           |
+| `--attach <path>`                       | Attach an image file to the initial message                                                                                               |
+| `--dry-run`                             | Initialize the agent without executing anything (useful for validating a config)                                                          |
+| `--lean`                                | Use a simplified TUI with minimal chrome                                                                                                  |
+| `--json`                                | Output results as newline-delimited JSON (use with `--exec`)                                                                              |
+| `--hide-tool-calls`                     | Hide tool calls in the output                                                                                                             |
+| `--hide-tool-results`                   | Hide tool call results in the output                                                                                                      |
+| `--sandbox`                             | Run the agent inside a Docker sandbox (see [Sandbox]({{ '/configuration/sandbox/' | relative_url }}))                                     |
+| `--template <image>`                    | Template image for the sandbox (default: `docker/sandbox-templates:docker-agent`)                                                         |
+| `--sbx`                                 | Prefer the `sbx` CLI backend when available (default `true`; set `--sbx=false` to force `docker sandbox`)                                 |
+| `--hook-pre-tool-use <cmd>`             | Add a pre-tool-use hook command (repeatable). See [Hooks]({{ '/configuration/hooks/' | relative_url }}).                                  |
+| `--hook-post-tool-use <cmd>`            | Add a post-tool-use hook command (repeatable)                                                                                             |
+| `--hook-session-start <cmd>`            | Add a session-start hook command (repeatable)                                                                                             |
+| `--hook-session-end <cmd>`              | Add a session-end hook command (repeatable)                                                                                               |
+| `--hook-on-user-input <cmd>`            | Add an on-user-input hook command (repeatable)                                                                                            |
 | `-d, --debug`                           | Enable debug logging                                                                                                                      |
-| `--log-file &lt;path&gt;`               | Custom debug log location                                                                                                                 |
+| `--log-file <path>`                     | Custom debug log location                                                                                                                 |
 | `-o, --otel`                            | Enable OpenTelemetry tracing                                                                                                              |
 
 ```bash
@@ -89,6 +99,28 @@ $ docker agent new [flags]
 $ docker agent new
 $ docker agent new --model openai/gpt-5-mini
 $ docker agent new --model dmr/ai/gemma3-qat:12B --max-iterations 15
+```
+
+### `docker agent models`
+
+List models available for use with `--model`. By default only shows models for providers you have credentials for. Aliases: `docker agent models list`, `docker agent models ls`.
+
+```bash
+$ docker agent models [flags]
+```
+
+| Flag                   | Default | Description                                                                        |
+| ---------------------- | ------- | ---------------------------------------------------------------------------------- |
+| `-p, --provider <id>`  | (none)  | Filter models by provider name (e.g. `openai`, `anthropic`, `dmr`, `ollama`, …).   |
+| `--format <fmt>`       | `table` | Output format: `table` or `json`.                                                  |
+| `-a, --all`            | `false` | Include models from all providers, not just those you have credentials for.        |
+
+```bash
+# Examples
+$ docker agent models                                 # only providers you can use
+$ docker agent models --all                           # every provider the catalog knows about
+$ docker agent models --provider openai
+$ docker agent models --format json | jq
 ```
 
 ### `docker agent serve api`

--- a/docs/features/evaluation/index.md
+++ b/docs/features/evaluation/index.md
@@ -162,7 +162,7 @@ $ docker agent eval <agent-file>|<registry-ref> [<eval-dir>|./evals]
 | Flag                | Default                     | Description                                                       |
 | ------------------- | --------------------------- | ----------------------------------------------------------------- |
 | `-c, --concurrency` | num CPUs                    | Number of concurrent evaluation runs                              |
-| `--judge-model`     | `anthropic/claude-opus-4-5` | Model for LLM-as-a-judge relevance scoring                        |
+| `--judge-model`     | `anthropic/claude-opus-4-5-20251101` | Model for LLM-as-a-judge relevance scoring                        |
 | `--output`          | `&lt;eval-dir&gt;/results`  | Directory for results, logs, and session databases                |
 | `--only`            | (all)                       | Only run evals with file names matching these patterns            |
 | `--base-image`      | (default)                   | Custom base Docker image for eval containers                      |

--- a/docs/features/mcp-mode/index.md
+++ b/docs/features/mcp-mode/index.md
@@ -27,7 +27,7 @@ The `docker agent serve mcp` command makes your agents available to any applicat
 ## Basic Usage
 
 ```bash
-# Expose a local config
+# Expose a local config (stdio transport, the default)
 $ docker agent serve mcp ./agent.yaml
 
 # Expose from a registry
@@ -36,6 +36,28 @@ $ docker agent serve mcp agentcatalog/pirate
 # Set the working directory
 $ docker agent serve mcp ./agent.yaml --working-dir /path/to/project
 ```
+
+## Transports
+
+By default, `serve mcp` uses the stdio transport — ideal for clients that spawn the server as a subprocess (Claude Desktop, Claude Code, Cursor, …).
+
+To expose the MCP server over streaming HTTP instead, pass `--http`:
+
+```bash
+# Streaming HTTP transport on the default 127.0.0.1:8081
+$ docker agent serve mcp ./agent.yaml --http
+
+# Override the listen address / port
+$ docker agent serve mcp ./agent.yaml --http --listen 0.0.0.0:9090
+```
+
+| Flag                   | Default            | Description                                                                   |
+| ---------------------- | ------------------ | ----------------------------------------------------------------------------- |
+| `--http`               | `false`            | Use streaming HTTP transport instead of stdio.                                |
+| `-l`, `--listen`       | `127.0.0.1:8081`   | Address to listen on when `--http` is enabled.                                |
+| `-a`, `--agent`        | all agents         | Expose a single named agent instead of every agent in the config.             |
+
+Runtime configuration flags such as `--working-dir`, `--env-from-file`, `--models-gateway`, and hook flags are also available — see the [CLI reference]({{ '/features/cli/' | relative_url }}).
 
 ## Using with Claude Desktop
 

--- a/docs/features/remote-mcp/index.md
+++ b/docs/features/remote-mcp/index.md
@@ -41,6 +41,36 @@ toolsets:
 
 For full configuration details, see the [Tool Config]({{ '/configuration/tools/' | relative_url }}) page.
 
+### OAuth for servers without Dynamic Client Registration
+
+Most remote MCP servers that require OAuth support [Dynamic Client Registration (RFC 7591)]({{ 'https://datatracker.ietf.org/doc/html/rfc7591' }}) — no configuration is needed, docker-agent handles the flow for you.
+
+For servers that do **not** support DCR, provide explicit OAuth credentials with the `oauth:` block:
+
+```yaml
+toolsets:
+  - type: mcp
+    remote:
+      url: "https://mcp.example.com/mcp"
+      transport_type: "streamable"
+      oauth:
+        clientId: "my-app-client-id"
+        clientSecret: "my-app-client-secret" # optional (public clients may omit)
+        callbackPort: 8765                   # optional; picks a free port otherwise
+        scopes:                              # optional; server-specific
+          - read
+          - write
+```
+
+| Field          | Type            | Required | Description                                                                                      |
+| -------------- | --------------- | -------- | ------------------------------------------------------------------------------------------------ |
+| `clientId`     | string          | ✓        | OAuth client ID registered with the remote MCP server.                                           |
+| `clientSecret` | string          | ✗        | OAuth client secret. Omit for public clients using PKCE.                                         |
+| `callbackPort` | integer         | ✗        | Local port to receive the OAuth redirect. If omitted, docker-agent picks a random free port.    |
+| `scopes`       | array[string]   | ✗        | Scopes to request during the authorization step. Values are server-specific.                     |
+
+Secrets should be stored in a credential helper or environment variable rather than committed — see [Secrets]({{ '/guides/secrets/' | relative_url }}) for interpolation patterns.
+
 ## Project Management &amp; Collaboration
 
 | Service    | URL                                | Transport | Description                           |

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -34,21 +34,28 @@ Type `/` during a session to see available commands, or press <kbd>Ctrl</kbd>+<k
 
 | Command     | Description                                    |
 | ----------- | ---------------------------------------------- |
-| `/new`      | Start a new conversation                       |
-| `/compact`  | Summarize and compact the conversation history |
-| `/copy`     | Copy the conversation to clipboard             |
-| `/export`   | Export the session as HTML                     |
-| `/sessions` | Browse and load past sessions                  |
-| `/model`    | Change the model for the current agent         |
-| `/theme`    | Change the color theme                         |
-| `/yolo`     | Toggle automatic tool call approval            |
-| `/title`    | Set or regenerate session title                |
-| `/attach`   | Attach a file to your message                  |
-| `/shell`    | Open a shell                                   |
-| `/star`     | Star/unstar the current session                |
-| `/cost`     | Show cost breakdown for this session           |
-| `/eval`     | Create an evaluation report                    |
-| `/exit`     | Exit the application                           |
+| `/new`         | Start a new conversation                                              |
+| `/clear`       | Clear the current conversation (keep session, drop messages)          |
+| `/compact`     | Summarize and compact the conversation history                        |
+| `/fork`        | Fork the current session into a new branch                            |
+| `/copy`        | Copy the entire conversation to clipboard                             |
+| `/copy-last`   | Copy only the last assistant message to clipboard                     |
+| `/export`      | Export the session as HTML                                            |
+| `/sessions`    | Browse and load past sessions                                         |
+| `/model`       | Change the model for the current agent                                |
+| `/theme`       | Change the color theme                                                |
+| `/yolo`        | Toggle automatic tool call approval                                   |
+| `/title`       | Set or regenerate session title                                       |
+| `/attach`      | Attach a file to your message                                         |
+| `/shell`       | Open a shell                                                          |
+| `/star`        | Star/unstar the current session                                       |
+| `/cost`        | Show cost breakdown for this session                                  |
+| `/eval`        | Create an evaluation report                                           |
+| `/tools`       | Browse available tools for the current agent                          |
+| `/permissions` | Inspect and edit tool permission rules                                |
+| `/split-diff`  | Toggle split-diff view for file edits                                 |
+| `/speak`       | Voice input via system speech-to-text (macOS only)                    |
+| `/exit`        | Exit the application (aliases: `/quit`, `/q`)                         |
 
 ## File Attachments
 
@@ -120,17 +127,26 @@ Customize session titles to make them more meaningful and easier to find. By def
 
 ## Keyboard Shortcuts
 
-| Shortcut | Action                                          |
-| -------- | ----------------------------------------------- |
-| Ctrl+K   | Open command palette                            |
-| Ctrl+M   | Switch model                                    |
-| Ctrl+R   | Reverse history search (search previous inputs) |
-| Ctrl+L   | Start audio listening mode (voice input)        |
-| Ctrl+Z   | Suspend TUI to background (resume with `fg`)    |
-| Ctrl+X   | Clear queued messages                           |
-| Escape   | Cancel current operation                        |
-| Enter    | Send message (or newline with Shift+Enter)      |
-| Up/Down  | Navigate message history                        |
+| Shortcut     | Action                                          |
+| ------------ | ----------------------------------------------- |
+| Ctrl+K       | Open command palette                            |
+| Ctrl+M       | Switch model                                    |
+| Ctrl+R       | Reverse history search (search previous inputs) |
+| Ctrl+G       | Cancel reverse history search                   |
+| Ctrl+S       | Cycle to next agent in the team                 |
+| Ctrl+1 – 9   | Switch directly to agent _N_ in the team list   |
+| Ctrl+T       | Open a new tab (additional agent session)       |
+| Ctrl+W       | Close the current tab                           |
+| Ctrl+N       | Next tab                                        |
+| Ctrl+P       | Previous tab                                    |
+| Ctrl+B       | Toggle the sidebar (full-UI mode only)          |
+| Ctrl+Y       | Toggle YOLO mode (auto-approve tool calls)      |
+| Ctrl+O       | Toggle hide tool results                        |
+| Ctrl+Z       | Suspend TUI to background (resume with `fg`)    |
+| Ctrl+X       | Clear queued messages                           |
+| Escape       | Cancel current operation                        |
+| Enter        | Send message (or newline with Shift+Enter)      |
+| Up/Down      | Navigate message history                        |
 
 Press <kbd>Ctrl</kbd>+<kbd>H</kbd> to view the complete list of all available keyboard shortcuts.
 

--- a/docs/getting-started/installation/index.md
+++ b/docs/getting-started/installation/index.md
@@ -15,7 +15,7 @@ _Get docker-agent running on your system in minutes._
 
 ## Docker Desktop (Pre-installed)
 
-Starting with [Docker Desktop 4.49.0](https://docs.docker.com/desktop/release-notes/#4490), **docker-agent is already available**. No separate installation needed — just open a terminal and run:
+Starting with [Docker Desktop 4.63](https://docs.docker.com/desktop/release-notes/#4630), **docker-agent is already available**. No separate installation needed — just open a terminal and run:
 
 ```bash
 $ docker agent version

--- a/docs/guides/go-sdk/index.md
+++ b/docs/guides/go-sdk/index.md
@@ -264,7 +264,7 @@ func createAgentWithBuiltinTools(llm provider.Provider) *agent.Agent {
         agent.WithModel(llm),
         agent.WithToolSets(
             // Shell tool for running commands
-            builtin.NewShellTool(os.Environ(), rtConfig, nil),
+            builtin.NewShellTool(os.Environ(), rtConfig),
             // Filesystem tools
             builtin.NewFilesystemTool(rtConfig.Config.WorkingDir),
             // Think tool for reasoning

--- a/docs/guides/secrets/index.md
+++ b/docs/guides/secrets/index.md
@@ -10,16 +10,20 @@ _How to securely provide API keys and credentials to docker-agent._
 
 ## Overview
 
-docker-agent needs API keys to talk to model providers (OpenAI, Anthropic, etc.) and MCP tool servers (GitHub, Slack, etc.). These keys are **never stored in config files**. Instead, docker-agent resolves them at runtime through a chain of secret providers, checked in order:
+docker-agent needs API keys to talk to model providers (OpenAI, Anthropic, etc.) and MCP tool servers (GitHub, Slack, etc.). These keys are **never stored in config files**. Instead, docker-agent resolves them at runtime through a chain of secret providers, checked in order (see `pkg/environment/default.go`):
 
 | Priority | Provider | Description |
 | --- | --- | --- |
 | 1 | [Environment variables](#environment-variables) | `export OPENAI_API_KEY=sk-...` |
-| 2 | [Docker secrets](#docker-compose-secrets) | Files in `/run/secrets/` |
-| 3 | [`pass` password manager](#pass-password-manager) | `pass insert OPENAI_API_KEY` |
-| 4 | [macOS Keychain](#macos-keychain) | `security add-generic-password` |
+| 2 | [Docker Compose secrets](#docker-compose-secrets) | Files in `/run/secrets/` |
+| 3 | [Credential helper](#credential-helper) | Custom command declared in `~/.config/cagent/config.yaml` under `credential_helper:` |
+| 4 | [Docker Desktop](#docker-desktop) | Secrets stored by the Docker Desktop backend (no setup on a Desktop install) |
+| 5 | [`pass` password manager](#pass-password-manager) | `pass insert OPENAI_API_KEY` |
+| 6 | [macOS Keychain](#macos-keychain) | `security add-generic-password` |
 
 The first provider that has a value wins. You can mix and match — for example, use environment variables for one key and Keychain for another.
+
+When docker-agent runs inside a Docker sandbox (detected via `SANDBOX_VM_ID`), a sandbox token provider is prepended to the chain so that `DOCKER_TOKEN` is read from a continuously-refreshed file instead of a stale environment variable.
 
 ## Environment Variables
 
@@ -146,6 +150,25 @@ secrets:
 | Storage | In memory, visible via `docker inspect` | Mounted as tmpfs files under `/run/secrets/` |
 | Visibility | Shown in process list and inspect output | Not exposed in `docker inspect` |
 | Best for | Development | Production and CI/CD |
+
+## Credential Helper
+
+docker-agent can shell out to an external credential helper you define in your user config. This is useful when your organisation already has a secrets daemon you want to reuse (HashiCorp Vault, 1Password CLI, `bitwarden-cli`, etc.).
+
+Declare the helper in `~/.config/cagent/config.yaml`:
+
+```yaml
+# ~/.config/cagent/config.yaml
+credential_helper:
+  command: op
+  args: ["read", "op://Personal/docker-agent"]
+```
+
+The command is invoked with the variable name appended as the final argument, and must print the secret value to stdout.
+
+## Docker Desktop
+
+On machines where Docker Desktop is installed, docker-agent queries Docker Desktop's backend for secrets stored against your signed-in Docker account. This is transparent — no extra configuration — and it is how signed-in Docker users get provider API keys without setting any environment variables.
 
 ## `pass` Password Manager
 

--- a/docs/guides/tips/index.md
+++ b/docs/guides/tips/index.md
@@ -18,7 +18,7 @@ Don't have a config file? docker-agent can automatically detect your available A
 # Automatically uses the best available provider
 $ docker agent run
 
-# Provider priority: OpenAI → Anthropic → Google → Mistral → DMR
+# Provider priority: Anthropic → OpenAI → Google → Mistral → Amazon Bedrock → DMR
 ```
 
 The special `auto` model value also works in configs:

--- a/docs/providers/anthropic/index.md
+++ b/docs/providers/anthropic/index.md
@@ -37,10 +37,12 @@ models:
 
 ## Available Models
 
-| Model               | Best For                            |
-| ------------------- | ----------------------------------- |
-| `claude-sonnet-4-5` | Most capable, extended thinking     |
-| `claude-sonnet-4-0` | Strong coding, balanced performance |
+| Model ID            | Description                                         |
+| ------------------- | --------------------------------------------------- |
+| `claude-opus-4-7`   | Highest-capability Opus model; supports task budget |
+| `claude-sonnet-4-5` | Most capable Sonnet, extended thinking (default)    |
+| `claude-sonnet-4-0` | Strong coding, balanced performance                 |
+| `claude-haiku-4-5`  | Fast and inexpensive, good for tight loops          |
 
 ## Thinking Budget
 

--- a/docs/providers/bedrock/index.md
+++ b/docs/providers/bedrock/index.md
@@ -92,6 +92,7 @@ Use inference profile prefixes for optimal routing:
 | `global.` | All commercial AWS regions (recommended) |
 | `us.`     | US regions only                          |
 | `eu.`     | EU regions only (GDPR compliance)        |
+| `apac.`   | Asia Pacific regions only                |
 
 <div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Inference profiles

--- a/docs/providers/google/index.md
+++ b/docs/providers/google/index.md
@@ -10,9 +10,25 @@ _Use Gemini 2.5 Flash, Gemini 3 Pro, and other Google models with docker-agent._
 
 ## Setup
 
+docker-agent reads the first credential it finds from these environment variables (see `pkg/model/provider/gemini/client.go`):
+
+| Variable                    | Purpose                                                                             |
+| --------------------------- | ----------------------------------------------------------------------------------- |
+| `GOOGLE_API_KEY`            | Primary Gemini API key.                                                             |
+| `GEMINI_API_KEY`            | Alternative name for the Gemini API key (also used by the official Google SDK).     |
+| `GOOGLE_GENAI_USE_VERTEXAI` | When set (any value), routes through Vertex AI instead of the Gemini Developer API. |
+| `GOOGLE_CLOUD_PROJECT`      | GCP project used when `GOOGLE_GENAI_USE_VERTEXAI` is set or for Vertex AI Model Garden. |
+| `GOOGLE_CLOUD_LOCATION`     | GCP region for Vertex AI (defaults to the SDK default).                             |
+
 ```bash
-# Set your API key
-export GOOGLE_API_KEY="AI..."
+# Gemini Developer API
+export GOOGLE_API_KEY="AI..."   # or GEMINI_API_KEY
+
+# Vertex AI (no API key; uses Application Default Credentials)
+gcloud auth application-default login
+export GOOGLE_GENAI_USE_VERTEXAI=1
+export GOOGLE_CLOUD_PROJECT="my-gcp-project"
+export GOOGLE_CLOUD_LOCATION="us-central1"
 ```
 
 ## Configuration

--- a/docs/providers/mistral/index.md
+++ b/docs/providers/mistral/index.md
@@ -74,17 +74,17 @@ When you run `docker agent run` without specifying a config, docker-agent automa
 
 ## Extended Thinking
 
-Mistral models support thinking mode through the OpenAI-compatible API. By default, docker-agent enables `medium` thinking effort:
+Mistral models support thinking mode through the OpenAI-compatible API. Thinking is **not enabled by default** — you must set `thinking_budget` explicitly on the model:
 
 ```yaml
 models:
   mistral:
     provider: mistral
     model: mistral-large-latest
-    thinking_budget: high # minimal, low, medium, high, or none
+    thinking_budget: high # minimal, low, medium, high, xhigh, or none
 ```
 
-To disable thinking:
+To disable thinking (the default):
 
 ```yaml
 models:

--- a/docs/providers/nebius/index.md
+++ b/docs/providers/nebius/index.md
@@ -69,7 +69,7 @@ Nebius hosts various open models. Check the [Nebius documentation](https://nebiu
 Nebius is implemented as a built-in alias in docker-agent:
 
 - **API Type:** OpenAI-compatible (`openai_chatcompletions`)
-- **Base URL:** `https://api.studio.nebius.ai/v1`
+- **Base URL:** `https://api.studio.nebius.com/v1`
 - **Token Variable:** `NEBIUS_API_KEY`
 
 ## Example: Code Assistant

--- a/docs/providers/openai/index.md
+++ b/docs/providers/openai/index.md
@@ -56,7 +56,7 @@ models:
   gpt-thinking:
     provider: openai
     model: gpt-5-mini
-    thinking_budget: low # minimal | low | medium (default) | high
+    thinking_budget: low # minimal | low | medium (default) | high | xhigh | max | none | adaptive/<level>
 ```
 
 <div class="callout callout-tip" markdown="1">

--- a/docs/providers/overview/index.md
+++ b/docs/providers/overview/index.md
@@ -57,12 +57,16 @@ _docker-agent supports multiple AI model providers. Choose the right one for you
 
 docker-agent also includes built-in aliases for these providers:
 
-| Provider   | API Key Variable  |
-| ---------- | ----------------- |
-| Mistral    | `MISTRAL_API_KEY` |
-| xAI (Grok) | `XAI_API_KEY`     |
-| Nebius     | `NEBIUS_API_KEY`  |
-| MiniMax    | `MINIMAX_API_KEY` |
+| Provider       | Alias            | API Key / Env Variable              |
+| -------------- | ---------------- | ----------------------------------- |
+| Mistral        | `mistral`        | `MISTRAL_API_KEY`                   |
+| xAI (Grok)     | `xai`            | `XAI_API_KEY`                       |
+| Nebius         | `nebius`         | `NEBIUS_API_KEY`                    |
+| MiniMax        | `minimax`        | `MINIMAX_API_KEY`                   |
+| Requesty       | `requesty`       | `REQUESTY_API_KEY`                  |
+| Azure OpenAI   | `azure`          | `AZURE_OPENAI_API_KEY` + `base_url` |
+| Ollama         | `ollama`         | None (local; optional `base_url`)   |
+| GitHub Copilot | `github-copilot` | GitHub CLI auth (`gh auth login`)   |
 
 ```bash
 # Use built-in providers inline

--- a/docs/providers/xai/index.md
+++ b/docs/providers/xai/index.md
@@ -76,7 +76,7 @@ models:
   grok:
     provider: xai
     model: grok-3
-    thinking_budget: high # minimal, low, medium, high, or none
+    thinking_budget: high # minimal, low, medium, high, xhigh, max, none, or adaptive/<level>
 ```
 
 ## How It Works

--- a/docs/tools/a2a/index.md
+++ b/docs/tools/a2a/index.md
@@ -10,23 +10,29 @@ _Connect to remote agents via the Agent-to-Agent protocol._
 
 ## Overview
 
-The A2A tool connects to remote agents via the A2A (Agent-to-Agent) protocol. Similar to the [handoff tool]({{ '/tools/handoff/' | relative_url }}) but configured as a toolset.
+The A2A tool connects to a remote agent exposed over the A2A (Agent-to-Agent) protocol. Unlike [`handoff`]({{ '/tools/handoff/' | relative_url }}), which only targets local agents declared in the same config, `a2a` reaches out to an agent running on the network.
 
 ## Configuration
 
 ```yaml
 toolsets:
   - type: a2a
-    name: research_agent
     url: "http://localhost:8080/a2a"
+    # Optional: custom tool name (defaults to a sanitized form of the URL / agent card name)
+    name: research_agent
+    # Optional: custom HTTP headers (typically for auth)
+    headers:
+      Authorization: "Bearer ${A2A_TOKEN}"
+      X-Tenant: "acme"
 ```
 
 ## Properties
 
-| Property | Type   | Required | Description                    |
-| -------- | ------ | -------- | ------------------------------ |
-| `name`   | string | ✓        | Tool name for the remote agent |
-| `url`    | string | ✓        | A2A server endpoint URL        |
+| Property   | Type             | Required | Description                                                                                              |
+| ---------- | ---------------- | -------- | -------------------------------------------------------------------------------------------------------- |
+| `url`      | string           | ✓        | A2A server endpoint URL (must include scheme).                                                           |
+| `name`     | string           | ✗        | Tool name registered for the remote agent. Defaults to a name derived from the server's agent card.     |
+| `headers`  | map\[string\]string | ✗     | Extra HTTP headers sent with every request (useful for `Authorization`, tenant selection, tracing, \u2026). |
 
 <div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 See also

--- a/docs/tools/background-agents/index.md
+++ b/docs/tools/background-agents/index.md
@@ -21,6 +21,24 @@ The background agents tool lets an orchestrator dispatch work to sub-agents conc
 | `view_background_agent`  | View live output or final result of a task by ID                |
 | `stop_background_agent`  | Cancel a running task by ID                                     |
 
+### `run_background_agent` parameters
+
+| Parameter         | Type   | Required | Description                                                                 |
+| ----------------- | ------ | -------- | --------------------------------------------------------------------------- |
+| `agent`           | string | ✓        | Name of the sub-agent to run. Must be listed under the caller's `sub_agents`. |
+| `task`            | string | ✓        | Clear, concise description of the task the sub-agent should achieve.        |
+| `expected_output` | string | ✗        | Optional description of the result format the caller expects.               |
+
+`run_background_agent` returns a **task ID** string. Tools run by the sub-agent are pre-approved, so only dispatch to trusted sub-agents with well-scoped tasks.
+
+### `view_background_agent` and `stop_background_agent` parameters
+
+| Parameter | Type   | Required | Description                                                    |
+| --------- | ------ | -------- | -------------------------------------------------------------- |
+| `task_id` | string | ✓        | Task ID returned by `run_background_agent` or `list_background_agents`. |
+
+`list_background_agents` takes no parameters.
+
 ## Configuration
 
 ```yaml

--- a/docs/tools/fetch/index.md
+++ b/docs/tools/fetch/index.md
@@ -1,16 +1,23 @@
 ---
 title: "Fetch Tool"
-description: "Make HTTP requests to external APIs and web services."
+description: "Read content from HTTP/HTTPS URLs."
 permalink: /tools/fetch/
 ---
 
 # Fetch Tool
 
-_Make HTTP requests to external APIs and web services._
+_Read content from HTTP/HTTPS URLs._
 
 ## Overview
 
-The fetch tool lets agents make HTTP requests (GET, POST, PUT, DELETE, etc.) to external APIs. The agent can read web pages, call REST APIs, download data, and interact with web services.
+The fetch tool lets agents retrieve content from one or more HTTP/HTTPS URLs. It is **read-only** — only `GET` requests are supported. The tool respects `robots.txt`, limits response size (1 MB per URL), and can return content as plain text, Markdown (converted from HTML), or raw HTML.
+
+<div class="callout callout-info" markdown="1">
+<div class="callout-title">ℹ️ GET only
+</div>
+  <p>The fetch tool does <strong>not</strong> support <code>POST</code>, <code>PUT</code>, <code>DELETE</code> or other methods, and does not expose request bodies or custom headers. To call REST endpoints with other verbs, use the <a href="{{ '/tools/api/' | relative_url }}">API tool</a> or an <a href="{{ '/configuration/tools/#openapi' | relative_url }}">OpenAPI toolset</a>.</p>
+
+</div>
 
 ## Configuration
 
@@ -21,9 +28,9 @@ toolsets:
 
 ### Options
 
-| Property  | Type | Default | Description                |
-| --------- | ---- | ------- | -------------------------- |
-| `timeout` | int  | `30`    | Request timeout in seconds |
+| Property  | Type | Default | Description                                                       |
+| --------- | ---- | ------- | ----------------------------------------------------------------- |
+| `timeout` | int  | `30`    | Default request timeout in seconds (overridable per tool call).   |
 
 ### Custom Timeout
 
@@ -33,8 +40,20 @@ toolsets:
     timeout: 60
 ```
 
+## Tool Interface
+
+The toolset exposes a single tool, `fetch`, with the following parameters:
+
+| Parameter | Type           | Required | Description                                                                                                 |
+| --------- | -------------- | -------- | ----------------------------------------------------------------------------------------------------------- |
+| `urls`    | array[string]  | ✓        | One or more HTTP/HTTPS URLs to fetch (all via `GET`).                                                       |
+| `format`  | string         | ✓        | Output format: `text`, `markdown`, or `html`. HTML responses are converted to text/markdown when requested. |
+| `timeout` | integer        | ✗        | Per-call request timeout in seconds. Overrides the toolset default. Valid range: `1`–`300`.                 |
+
+Responses are capped at **1 MB** per URL. Hosts that disallow the agent's user-agent via `robots.txt` are skipped with a clear error.
+
 <div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Fetch vs. API Tool
 </div>
-  <p>The fetch tool gives the agent full control over HTTP requests at runtime. The <a href="{{ '/tools/api/' | relative_url }}">API tool</a> lets you predefine specific API calls as named tools with typed parameters. Use fetch for general-purpose HTTP access; use the API tool for well-known endpoints you want to expose as structured tools.</p>
+  <p>Use <code>fetch</code> when the agent needs to read arbitrary public URLs at runtime. Use the <a href="{{ '/tools/api/' | relative_url }}">API tool</a> to expose specific, structured HTTP endpoints (including non-<code>GET</code> verbs) as named tools.</p>
 </div>

--- a/docs/tools/filesystem/index.md
+++ b/docs/tools/filesystem/index.md
@@ -22,6 +22,8 @@ The filesystem tool gives agents the ability to explore codebases, read and edit
 | `edit_file`            | Make line-based edits (find-and-replace) in an existing file              |
 | `list_directory`       | List files and directories at a given path                                |
 | `directory_tree`       | Recursive tree view of a directory                                        |
+| `create_directory`     | Create a new directory (creates parent directories as needed)             |
+| `remove_directory`     | Remove an empty directory                                                 |
 | `search_files_content` | Search for text or regex patterns across files                            |
 
 ## Configuration

--- a/docs/tools/handoff/index.md
+++ b/docs/tools/handoff/index.md
@@ -1,39 +1,66 @@
 ---
 title: "Handoff Tool"
-description: "Delegate tasks to remote agents via the A2A protocol."
+description: "Hand off the active conversation to another local agent defined in the same config."
 permalink: /tools/handoff/
 ---
 
 # Handoff Tool
 
-_Delegate tasks to remote agents via the A2A protocol._
+_Hand off the active conversation to another local agent defined in the same config._
 
 ## Overview
 
-The handoff tool lets agents delegate tasks to remote agents via the A2A (Agent-to-Agent) protocol. Use this to connect to agents running as separate services or on different machines.
+The `handoff` tool lets an agent transfer control of the **current conversation** to another agent in the **same config file**. Unlike [`transfer_task`]({{ '/tools/transfer-task/' | relative_url }}), which delegates a sub-task and collects the result, `handoff` rewires the session so the receiving agent continues the conversation directly with the user.
+
+This is the core mechanism for **handoffs routing** — a pattern where a router agent classifies the user's request and hands it off to a specialist, which then owns the rest of the session.
+
+<div class="callout callout-info" markdown="1">
+<div class="callout-title">ℹ️ Local only
+</div>
+  <p>The <code>handoff</code> tool only targets agents declared in the <strong>same</strong> config file by their local name. It does <strong>not</strong> open network connections. To delegate to a remote agent over the network, use the <a href="{{ '/tools/a2a/' | relative_url }}">A2A toolset</a> instead.</p>
+
+</div>
 
 ## Configuration
 
+The tool is enabled implicitly when an agent declares a non-empty `handoffs:` list. You do **not** add `- type: handoff` under `toolsets:` — it is not a toolset type.
+
 ```yaml
-toolsets:
-  - type: handoff
-    name: research_agent
-    description: Specialized research agent
-    url: "http://localhost:8080/a2a"
-    timeout: 5m
+agents:
+  router:
+    model: openai/gpt-4o
+    description: Routes questions to the right specialist
+    instruction: |
+      Classify the user's question and hand off to the most appropriate
+      specialist. If unsure, ask a clarifying question first.
+    handoffs: [billing, support]
+
+  billing:
+    model: openai/gpt-4o
+    description: Billing specialist
+    instruction: Answer billing questions.
+
+  support:
+    model: openai/gpt-4o
+    description: Technical support specialist
+    instruction: Help with technical issues.
 ```
 
-## Properties
+The router agent automatically gets a `handoff` tool it can call to switch the conversation to `billing` or `support`.
 
-| Property      | Type   | Required | Description                          |
-| ------------- | ------ | -------- | ------------------------------------ |
-| `name`        | string | ✓        | Tool name for delegation             |
-| `description` | string | ✗        | Description shown to the agent       |
-| `url`         | string | ✓        | A2A server endpoint URL              |
-| `timeout`     | string | ✗        | Request timeout (default: `5m`)      |
+## Tool Interface
+
+The `handoff` tool takes a single parameter:
+
+| Parameter | Type   | Required | Description                                                       |
+| --------- | ------ | -------- | ----------------------------------------------------------------- |
+| `agent`   | string | ✓        | The local name of the agent to hand off the conversation to.      |
+
+Only names listed in the current agent's `handoffs:` field are valid targets.
 
 <div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 See also
 </div>
-  <p>For full details on the A2A protocol and serving agents as A2A endpoints, see <a href="{{ '/features/a2a/' | relative_url }}">A2A Protocol</a>.</p>
+  <p>For sub-task delegation (caller stays in control, waits for the result), see <a href="{{ '/tools/transfer-task/' | relative_url }}">Transfer Task</a>. For remote agent connections over the network, see the <a href="{{ '/tools/a2a/' | relative_url }}">A2A toolset</a>. For the broader pattern, see <a href="{{ '/concepts/multi-agent/#handoffs-routing' | relative_url }}">Handoffs Routing</a>.</p>
+
 </div>

--- a/docs/tools/model-picker/index.md
+++ b/docs/tools/model-picker/index.md
@@ -1,0 +1,68 @@
+---
+title: "Model Picker Tool"
+description: "Let the agent pick between several models per turn."
+permalink: /tools/model-picker/
+---
+
+# Model Picker Tool
+
+_Let the agent pick between several models per turn._
+
+## Overview
+
+The model picker tool gives an agent the ability to dynamically choose which model to use for each turn of the conversation. This is useful when you want the agent to route different types of requests to different models — for example, using a fast, inexpensive model for simple queries and a more capable model for complex reasoning tasks.
+
+## Configuration
+
+```yaml
+toolsets:
+  - type: model_picker
+    models:
+      - openai/gpt-5-mini
+      - anthropic/claude-sonnet-4-5
+      - openai/gpt-5
+```
+
+### Options
+
+| Property | Type           | Required | Description                                                  |
+| -------- | -------------- | -------- | ------------------------------------------------------------ |
+| `models` | array[string]  | ✓        | List of model references the agent can choose from. Use `provider/model` format. |
+
+## How It Works
+
+When the model picker toolset is enabled, the agent gets a `pick_model` tool it can call to switch to a different model for the next turn. The agent decides which model to use based on the complexity of the task, cost considerations, or other factors you describe in its instruction.
+
+## Example
+
+```yaml
+agents:
+  root:
+    model: openai/gpt-5-mini  # Default model
+    instruction: |
+      You are a helpful assistant. For simple questions, use gpt-5-mini.
+      For complex reasoning or coding tasks, switch to claude-sonnet-4-5 or gpt-5.
+    toolsets:
+      - type: model_picker
+        models:
+          - openai/gpt-5-mini
+          - anthropic/claude-sonnet-4-5
+          - openai/gpt-5
+```
+
+<div class="callout callout-tip" markdown="1">
+<div class="callout-title">💡 Cost optimization
+</div>
+  <p>The model picker tool is particularly useful for cost optimization: let the agent use a cheap model by default and only escalate to expensive models when necessary.</p>
+
+</div>
+
+## Tool Interface
+
+The toolset exposes a single tool, `pick_model`, with one parameter:
+
+| Parameter | Type   | Required | Description                                                                 |
+| --------- | ------ | -------- | --------------------------------------------------------------------------- |
+| `model`   | string | ✓        | The model to use for the next turn. Must be one of the configured models.   |
+
+The model switch takes effect on the **next** turn — the current turn continues with the model that was active when `pick_model` was called.

--- a/docs/tools/shell/index.md
+++ b/docs/tools/shell/index.md
@@ -37,6 +37,37 @@ toolsets:
       PATH: "${PATH}:/custom/bin"
 ```
 
+## Available Tools
+
+The shell toolset exposes five tools:
+
+| Tool Name              | Description                                                                                    |
+| ---------------------- | ---------------------------------------------------------------------------------------------- |
+| `shell`                | Run a command synchronously and return its combined output when it finishes.                   |
+| `run_background_job`   | Start a command asynchronously and return a job ID immediately. Use for servers/watchers/etc. |
+| `list_background_jobs` | List all background jobs with their status, runtime, and metadata.                             |
+| `view_background_job`  | View the buffered output and status of a specific background job by ID.                        |
+| `stop_background_job`  | Stop a running background job. Child processes are terminated too.                             |
+
+Background job output is captured up to 10 MB per job. All background jobs are automatically terminated when the agent session ends.
+
+### `shell` parameters
+
+| Parameter | Type    | Required | Description                                                               |
+| --------- | ------- | -------- | ------------------------------------------------------------------------- |
+| `cmd`     | string  | ✓        | The shell command to execute.                                             |
+| `cwd`     | string  | ✗        | Working directory to run the command in (default: `.`).                   |
+| `timeout` | integer | ✗        | Per-call execution timeout in seconds (default: `30`).                    |
+
+### `run_background_job` parameters
+
+| Parameter | Type   | Required | Description                                                             |
+| --------- | ------ | -------- | ----------------------------------------------------------------------- |
+| `cmd`     | string | ✓        | The shell command to execute in the background.                         |
+| `cwd`     | string | ✗        | Working directory to run the command in (default: `.`).                 |
+
+`view_background_job` and `stop_background_job` each take a single required `job_id` string returned by `run_background_job` or `list_background_jobs`.
+
 <div class="callout callout-warning" markdown="1">
 <div class="callout-title">⚠️ Safety
 </div>

--- a/docs/tools/tasks/index.md
+++ b/docs/tools/tasks/index.md
@@ -1,0 +1,56 @@
+---
+title: "Tasks Tool"
+description: "Persistent task database shared across sessions."
+permalink: /tools/tasks/
+---
+
+# Tasks Tool
+
+_Persistent task database shared across sessions._
+
+## Overview
+
+The tasks tool provides a persistent task database that survives across agent sessions. Unlike the [Todo tool]({{ '/tools/todo/' | relative_url }}), which maintains an in-memory task list for the current session only, the tasks tool stores tasks in a SQLite database so they can be accessed and updated across multiple sessions.
+
+## Configuration
+
+```yaml
+toolsets:
+  - type: tasks
+    path: ~/.cagent/tasks.db  # Optional: custom database path
+```
+
+### Options
+
+| Property | Type   | Default              | Description                    |
+| -------- | ------ | -------------------- | ------------------------------ |
+| `path`   | string | `~/.cagent/tasks.db` | Path to the SQLite task database |
+
+## Available Tools
+
+The tasks toolset exposes these tools:
+
+| Tool Name      | Description                                      |
+| -------------- | ------------------------------------------------ |
+| `add_task`     | Add a new task to the database                   |
+| `list_tasks`   | List all tasks, optionally filtered by status    |
+| `update_task`  | Update a task's title, description, or status    |
+| `delete_task`  | Remove a task from the database                  |
+
+## Example
+
+```yaml
+agents:
+  root:
+    model: openai/gpt-4o
+    toolsets:
+      - type: tasks
+        path: ./project-tasks.db
+```
+
+<div class="callout callout-tip" markdown="1">
+<div class="callout-title">💡 Tasks vs. Todo
+</div>
+  <p>Use the <strong>tasks</strong> tool when you need persistence across sessions (e.g., long-running projects, recurring work). Use the <a href="{{ '/tools/todo/' | relative_url }}">todo tool</a> for ephemeral, session-scoped task lists.</p>
+
+</div>

--- a/docs/tools/transfer-task/index.md
+++ b/docs/tools/transfer-task/index.md
@@ -45,6 +45,18 @@ agents:
 
 The coordinator agent automatically gets a `transfer_task` tool that can delegate to `developer` or `researcher`.
 
+## Tool Interface
+
+The `transfer_task` tool takes three parameters:
+
+| Parameter         | Type   | Required | Description                                                                                 |
+| ----------------- | ------ | -------- | ------------------------------------------------------------------------------------------- |
+| `agent`           | string | ✓        | Name of the sub-agent to delegate to. Must be listed under the caller's `sub_agents`.        |
+| `task`            | string | ✓        | Clear, concise description of the task the sub-agent should achieve.                        |
+| `expected_output` | string | ✓        | Description of the result/format the caller expects back.                                   |
+
+The call blocks until the sub-agent returns its result, which becomes the tool's response. For non-blocking parallel delegation, use [`background_agents`]({{ '/tools/background-agents/' | relative_url }}) instead.
+
 <div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 See also
 </div>

--- a/docs/tools/user-prompt/index.md
+++ b/docs/tools/user-prompt/index.md
@@ -43,10 +43,11 @@ agents:
 
 The `user_prompt` tool takes these parameters:
 
-| Parameter | Type   | Required | Description                                      |
-| --------- | ------ | -------- | ------------------------------------------------ |
-| `message` | string | ✓        | The question or prompt to display                |
-| `schema`  | object | ✗        | JSON Schema defining expected response structure |
+| Parameter | Type   | Required | Description                                                                                        |
+| --------- | ------ | -------- | -------------------------------------------------------------------------------------------------- |
+| `message` | string | ✓        | The question or prompt to display.                                                                 |
+| `title`   | string | ✗        | Optional title for the dialog window in the TUI. Defaults to `"Question"` when not provided.       |
+| `schema`  | object | ✗        | JSON Schema defining the expected response structure (object or primitive).                        |
 
 ## Response Format
 


### PR DESCRIPTION
Audit of every claim in #2464 against the source code, followed by targeted fixes. All 35 real issues reported in the audit plus one broken cross-reference discovered during review are addressed here (36 logical fixes, squashed into a single commit).

All changes are documentation / JSON Schema only — no Go source is touched, so `mise lint` and `go test ./...` stay green.

## Coverage

### Schema / overview

- Bump the config schema version to **8** in `docs/configuration/overview` and `agent-schema.json` (enum, examples, description) to match `pkg/config/latest/parse.go` (`currentVersion = 8`).
- Document the top-level `mcps:` section for reusable MCP server definitions (`pkg/config/latest/types.go`, `Config.MCPs`).
- Remove the non-existent `rag:` agent-level property from the agent reference — RAG is now attached via `toolsets:`.
- Document `skills` accepting either a boolean or a list of sources (`SkillsConfig` supports `"local"` plus HTTP/HTTPS URLs).
- Show `ask:` in the main permissions YAML example.

### Providers

- Fix Nebius base URL (`.com`, not `.ai`) to match `pkg/model/provider/provider.go`.
- Fix the provider auto-detection priority order in `guides/tips` (Anthropic → OpenAI → Google → Mistral → Amazon Bedrock → DMR per `pkg/config/auto.go`).
- Add the missing built-in aliases (`requesty`, `azure`, `ollama`, `github-copilot`) to the providers overview and concepts/models tables.
- Document `GEMINI_API_KEY` and the Vertex AI env vars for Google.
- List `claude-opus-4-7` and `claude-haiku-4-5` in the Anthropic models table.
- Add the `apac.` inference profile prefix to the Bedrock doc.
- Remove the false "medium thinking by default" claim from Mistral — default thinking is only applied to OpenAI o-series models.
- Add `xhigh`, `max`, and `adaptive/<level>` to the thinking-effort lists in OpenAI, xAI, and configuration/models.

### CLI and features

- Align Docker Desktop minimum version to **4.63+** in the installation doc.
- Document the `docker agent models` command and the missing `docker agent run` flags (`--lean`, `--sandbox`, `--template`, `--sbx`, `--json`, `--session-db`, `--attach`, `--dry-run`, `--hide-tool-calls`, `--hide-tool-results`).
- Document `serve mcp` `--http` and `--listen` flags.
- Document `serve a2a` and `serve acp` runtime flags (`--working-dir`, `--env-from-file`, `--models-gateway`, `--code-mode-tools`, `--hook-*`, `--agent`, `--listen`, `--session-db`).
- Describe the real sandbox backend (`docker sandbox` / `sbx` CLI) and add `--template` / `--sbx` flags.
- Fix the default `--judge-model` string to `anthropic/claude-opus-4-5-20251101` per `cmd/root/eval.go`.
- Document the `/api/sessions/:id/steer`, `/followup`, and `/api/agents/:id/:agent_name/tools/count` endpoints.
- Document the OAuth config block for remote MCP servers that don't support Dynamic Client Registration.
- Expand the secrets priority chain with the credential helper and Docker Desktop providers (`pkg/environment/default.go`).

### TUI

- Remove the non-existent Ctrl+L audio keybinding.
- Add the missing slash commands: `/clear`, `/copy-last`, `/fork`, `/permissions`, `/tools`, `/split-diff`, `/speak` (plus `/quit` and `/q` aliases).
- Add tab/multi-agent and yolo/sidebar keybindings (Ctrl+T/W/N/P, Ctrl+1–9, Ctrl+S, Ctrl+B, Ctrl+Y, Ctrl+O, Ctrl+G).

### Tools

- Rewrite the `handoff` tool reference: it is local peer-to-peer, auto-enabled by `handoffs:`, not an A2A remote toolset with `url`/`timeout` fields.
- Document the `fetch` tool as GET-only with `urls`, `format`, and per-call `timeout` parameters, and a 1 MB / robots.txt note.
- Add `create_directory` and `remove_directory` to the filesystem tools table.
- Document the shell toolset's background-job tools (`run_background_job`, `list_background_jobs`, `view_background_job`, `stop_background_job`) plus `cwd`/`timeout` parameters.
- Document parameters for `background_agents` (`agent`/`task`/`expected_output`/`task_id`), `transfer_task` (`agent`/`task`/`expected_output`), and `user_prompt` (`title`).
- Mark `name` as optional and document `headers` on the `a2a` toolset.
- Add `rag`, `openapi`, `tasks`, and `model_picker` to the configuration/tools and concepts/tools tables.
- Add the missing `/tools/tasks/` and `/tools/model-picker/` reference pages (cross-referenced from the tables above).

### Go SDK

- Fix the `builtin.NewShellTool` example to use the actual 2-argument signature from `pkg/tools/builtin/shell.go`.

## Validation

- `go build ./...` — passes
- `go vet ./...` — clean
- `gofmt -l .` — clean
- `golangci-lint run` — 0 issues
- `go run ./lint .` — 754 files, no offenses
- `go test ./...` — 96 packages pass, 0 failures

Closes #2464

---
Assisted-By: docker-agent
