### PR TITLE
chore: bump Go to 1.26.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
           cache: true
 
       - name: Lint
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
           cache: true
 
       - name: Install mise
@@ -74,7 +74,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
           cache: true
 
       - name: Install go-licences

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION="1.26.1"
+ARG GO_VERSION="1.26.2"
 ARG ALPINE_VERSION="3.22"
 ARG XX_VERSION="1.9.0"
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/docker/docker-agent
 
-go 1.26.1
+go 1.26.2
 
 require (
 	charm.land/bubbles/v2 v2.1.0


### PR DESCRIPTION
Bumps Go from 1.26.1 to 1.26.2.

Updates:
- `go.mod` — `go 1.26.2`
- `Dockerfile` — `ARG GO_VERSION="1.26.2"`
- `.github/workflows/ci.yml` — 3 occurrences of `go-version: "1.26.2"` (lint, build-and-test, license-check jobs)