### PR TITLE
ci: bump golangci-lint from v2.9 to v2.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.9
+          version: v2.11
 
       - name: Lint GitHub Actions
         uses: raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8 # v2.1.2


### PR DESCRIPTION
Bumps the golangci-lint version used in CI from `v2.9` to `v2.11` (latest stable is v2.11.4, released 2026-03-22).

## New linters

None to activate. Per the [official CHANGELOG](https://github.com/golangci/golangci-lint/blob/main/CHANGELOG.md), v2.10.x and v2.11.x only contain bug fixes and updates to existing linters (e.g. new `gosec` rules, `revive` rule renames, `errcheck` default exclusions, `staticcheck` 0.7). No new standalone linters were introduced.

All relevant linters from recent releases (`modernize`, `godoclint`, `unqueryvet`, `iotamixing`, `embeddedstructfieldcheck`, `nilnesserr`, `exptostd`, `fatcontext`, …) are already enabled in `.golangci.yml`.

## Validation

Run locally against v2.11.3:

- `golangci-lint config verify` → clean
- `golangci-lint run` → 0 issues
- All 63 configured linters resolve correctly

## Note

v2.11.0 has a ⚠️ breaking change in `revive` (package-related checks moved from `var-naming` to a new `package-naming` rule). This only affects configs that explicitly configure `var-naming`, which ours does not — so no action required.