### PR TITLE
Add --show-gitignored flag to allow showing gitignored files in file picker

### DIFF
--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -62,6 +62,7 @@ type runExecFlags struct {
 	// Run only
 	hideToolResults bool
 	lean            bool
+	showGitignored  bool
 
 	// globalPermissions holds the user-level global permission checker built
 	// from user config settings. Nil when no global permissions are configured.
@@ -120,6 +121,7 @@ func addRunOrExecFlags(cmd *cobra.Command, flags *runExecFlags) {
 	cmd.PersistentFlags().BoolVar(&flags.forceTUI, "force-tui", false, "Force TUI mode even when not in a terminal")
 	_ = cmd.PersistentFlags().MarkHidden("force-tui")
 	cmd.PersistentFlags().BoolVar(&flags.lean, "lean", false, "Use a simplified TUI with minimal chrome")
+	cmd.PersistentFlags().BoolVar(&flags.showGitignored, "show-gitignored", false, "Show gitignored files in the file picker")
 	cmd.PersistentFlags().BoolVar(&flags.sandbox, "sandbox", false, "Run the agent inside a Docker sandbox (requires Docker Desktop with sandbox support)")
 	cmd.PersistentFlags().StringVar(&flags.sandboxTemplate, "template", "docker/sandbox-templates:docker-agent", "Template image for the sandbox (passed to docker sandbox create -t)")
 	cmd.PersistentFlags().BoolVar(&flags.sbx, "sbx", true, "Prefer the sbx CLI backend when available (set --sbx=false to force docker sandbox)")
@@ -472,6 +474,9 @@ func (f *runExecFlags) tuiOpts() []tui.Option {
 	var opts []tui.Option
 	if f.lean {
 		opts = append(opts, tui.WithLeanMode())
+	}
+	if f.showGitignored {
+		opts = append(opts, tui.WithShowGitignored())
 	}
 	return opts
 }

--- a/pkg/tui/components/editor/completions/file.go
+++ b/pkg/tui/components/editor/completions/file.go
@@ -16,13 +16,16 @@ const (
 )
 
 type fileCompletion struct {
-	mu     sync.Mutex
-	items  []completion.Item
-	loaded bool
+	mu             sync.Mutex
+	items          []completion.Item
+	loaded         bool
+	showGitignored bool
 }
 
-func NewFileCompletion() Completion {
-	return &fileCompletion{}
+func NewFileCompletion(showGitignored bool) Completion {
+	return &fileCompletion{
+		showGitignored: showGitignored,
+	}
 }
 
 func (c *fileCompletion) AutoSubmit() bool {
@@ -47,12 +50,11 @@ func (c *fileCompletion) Items() []completion.Item {
 	}
 
 	// Try to create VCS matcher for current directory
-	vcsMatcher, _ := fsx.NewVCSMatcher(".")
-
-	// Prepare shouldIgnore function
 	var shouldIgnore func(string) bool
-	if vcsMatcher != nil {
-		shouldIgnore = vcsMatcher.ShouldIgnore
+	if !c.showGitignored {
+		if vcsMatcher, _ := fsx.NewVCSMatcher("."); vcsMatcher != nil {
+			shouldIgnore = vcsMatcher.ShouldIgnore
+		}
 	}
 
 	// Use bounded walker to avoid scanning huge directories
@@ -103,11 +105,11 @@ func (c *fileCompletion) LoadInitialItemsAsync(ctx context.Context) <-chan []com
 		c.mu.Unlock()
 
 		// Try to create VCS matcher for current directory
-		vcsMatcher, _ := fsx.NewVCSMatcher(".")
-
 		var shouldIgnore func(string) bool
-		if vcsMatcher != nil {
-			shouldIgnore = vcsMatcher.ShouldIgnore
+		if !c.showGitignored {
+			if vcsMatcher, _ := fsx.NewVCSMatcher("."); vcsMatcher != nil {
+				shouldIgnore = vcsMatcher.ShouldIgnore
+			}
 		}
 
 		// Shallow scan: 2 levels deep, max 100 files
@@ -167,12 +169,11 @@ func (c *fileCompletion) LoadItemsAsync(ctx context.Context) <-chan []completion
 		c.mu.Unlock()
 
 		// Try to create VCS matcher for current directory
-		vcsMatcher, _ := fsx.NewVCSMatcher(".")
-
-		// Prepare shouldIgnore function
 		var shouldIgnore func(string) bool
-		if vcsMatcher != nil {
-			shouldIgnore = vcsMatcher.ShouldIgnore
+		if !c.showGitignored {
+			if vcsMatcher, _ := fsx.NewVCSMatcher("."); vcsMatcher != nil {
+				shouldIgnore = vcsMatcher.ShouldIgnore
+			}
 		}
 
 		// Full scan with default limits

--- a/pkg/tui/dialog/file_picker.go
+++ b/pkg/tui/dialog/file_picker.go
@@ -34,20 +34,22 @@ const (
 type filePickerDialog struct {
 	BaseDialog
 
-	textInput  textinput.Model
-	currentDir string
-	entries    []fileEntry
-	filtered   []fileEntry
-	selected   int
-	scrollview *scrollview.Model
-	keyMap     commandPaletteKeyMap
-	err        error
+	textInput      textinput.Model
+	currentDir     string
+	entries        []fileEntry
+	filtered       []fileEntry
+	selected       int
+	scrollview     *scrollview.Model
+	keyMap         commandPaletteKeyMap
+	err            error
+	showGitignored bool
 }
 
 // NewFilePickerDialog creates a new file picker dialog for attaching files.
 // If initialPath is provided and is a directory, it starts in that directory.
 // If initialPath is a file, it starts in the file's directory with the file pre-selected.
-func NewFilePickerDialog(initialPath string) Dialog {
+// If showGitignored is true, gitignored files will be shown in the picker.
+func NewFilePickerDialog(initialPath string, showGitignored bool) Dialog {
 	ti := textinput.New()
 	ti.Placeholder = "Type to filter files…"
 	ti.Focus()
@@ -84,10 +86,11 @@ func NewFilePickerDialog(initialPath string) Dialog {
 	}
 
 	d := &filePickerDialog{
-		textInput:  ti,
-		currentDir: startDir,
-		scrollview: scrollview.New(scrollview.WithReserveScrollbarSpace(true)),
-		keyMap:     defaultCommandPaletteKeyMap(),
+		textInput:      ti,
+		currentDir:     startDir,
+		scrollview:     scrollview.New(scrollview.WithReserveScrollbarSpace(true)),
+		keyMap:         defaultCommandPaletteKeyMap(),
+		showGitignored: showGitignored,
 	}
 
 	d.loadDirectory()
@@ -120,8 +123,10 @@ func (d *filePickerDialog) loadDirectory() {
 	}
 
 	var shouldIgnore func(string) bool
-	if vcsMatcher, err := fsx.NewVCSMatcher(d.currentDir); err == nil && vcsMatcher != nil {
-		shouldIgnore = vcsMatcher.ShouldIgnore
+	if !d.showGitignored {
+		if vcsMatcher, err := fsx.NewVCSMatcher(d.currentDir); err == nil && vcsMatcher != nil {
+			shouldIgnore = vcsMatcher.ShouldIgnore
+		}
 	}
 
 	dirEntries, err := os.ReadDir(d.currentDir)

--- a/pkg/tui/dialog/file_picker_test.go
+++ b/pkg/tui/dialog/file_picker_test.go
@@ -1,0 +1,95 @@
+package dialog
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewFilePickerDialog_ShowGitignored(t *testing.T) {
+	// Create a temporary directory with a .gitignore file
+	tmpDir := t.TempDir()
+
+	// Initialize a git repo
+	cmd := exec.Command("git", "init")
+	cmd.Dir = tmpDir
+	err := cmd.Run()
+	require.NoError(t, err)
+
+	// Create .gitignore
+	gitignoreContent := "*.log\ntest.txt\n"
+	err = os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte(gitignoreContent), 0o644)
+	require.NoError(t, err)
+
+	// Create files that should be ignored
+	err = os.WriteFile(filepath.Join(tmpDir, "debug.log"), []byte("log content"), 0o644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, "test.txt"), []byte("test content"), 0o644)
+	require.NoError(t, err)
+
+	// Create a file that should NOT be ignored
+	err = os.WriteFile(filepath.Join(tmpDir, "readme.md"), []byte("readme content"), 0o644)
+	require.NoError(t, err)
+
+	t.Run("without show gitignored flag", func(t *testing.T) {
+		d := NewFilePickerDialog(tmpDir, false).(*filePickerDialog)
+
+		// Count visible files (excluding .. and .git directory)
+		visibleFiles := 0
+		for _, entry := range d.entries {
+			if entry.name != ".." && entry.name != ".git" {
+				visibleFiles++
+			}
+		}
+
+		// Should only show readme.md (not the gitignored files)
+		assert.Equal(t, 1, visibleFiles, "Should only show non-gitignored files")
+
+		// Verify readme.md is present
+		foundReadme := false
+		for _, entry := range d.entries {
+			if entry.name == "readme.md" {
+				foundReadme = true
+				break
+			}
+		}
+		assert.True(t, foundReadme, "Should include readme.md")
+	})
+
+	t.Run("with show gitignored flag", func(t *testing.T) {
+		d := NewFilePickerDialog(tmpDir, true).(*filePickerDialog)
+
+		// Count visible files (excluding .. and .git directory)
+		visibleFiles := 0
+		for _, entry := range d.entries {
+			if entry.name != ".." && entry.name != ".git" {
+				visibleFiles++
+			}
+		}
+
+		// Should show all files including gitignored ones
+		assert.Equal(t, 3, visibleFiles, "Should show all files when showGitignored is true")
+
+		// Verify all files are present
+		foundReadme := false
+		foundLog := false
+		foundTest := false
+		for _, entry := range d.entries {
+			switch entry.name {
+			case "readme.md":
+				foundReadme = true
+			case "debug.log":
+				foundLog = true
+			case "test.txt":
+				foundTest = true
+			}
+		}
+		assert.True(t, foundReadme, "Should include readme.md")
+		assert.True(t, foundLog, "Should include debug.log (gitignored)")
+		assert.True(t, foundTest, "Should include test.txt (gitignored)")
+	})
+}

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -555,7 +555,7 @@ func (m *appModel) handleAttachFile(filePath string) (tea.Model, tea.Cmd) {
 			return m, tea.Batch(
 				notification.ErrorCmd("Failed to attach "+filePath),
 				core.CmdHandler(dialog.OpenDialogMsg{
-					Model: dialog.NewFilePickerDialog(filePath),
+					Model: dialog.NewFilePickerDialog(filePath, m.showGitignored),
 				}),
 			)
 		}
@@ -564,7 +564,7 @@ func (m *appModel) handleAttachFile(filePath string) (tea.Model, tea.Cmd) {
 
 	// No path provided — open the file picker dialog
 	return m, core.CmdHandler(dialog.OpenDialogMsg{
-		Model: dialog.NewFilePickerDialog(filePath),
+		Model: dialog.NewFilePickerDialog(filePath, m.showGitignored),
 	})
 }
 

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -162,6 +162,9 @@ type appModel struct {
 	// leanMode enables a simplified TUI with minimal chrome.
 	leanMode bool
 
+	// showGitignored determines whether gitignored files are shown in the file picker.
+	showGitignored bool
+
 	// buildCommandCategories is a function that returns the list of command categories.
 	buildCommandCategories func(context.Context, tea.Model) []commands.Category
 
@@ -171,6 +174,13 @@ type appModel struct {
 
 // Option configures the TUI.
 type Option func(*appModel)
+
+// WithShowGitignored enables showing gitignored files in the file picker.
+func WithShowGitignored() Option {
+	return func(m *appModel) {
+		m.showGitignored = true
+	}
+}
 
 // WithLeanMode enables a simplified TUI with minimal chrome:
 // no sidebar, no tab bar, no overlays, no resize handle.

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -380,7 +380,7 @@ func (m *appModel) editorOpts() []editor.Option {
 	return []editor.Option{
 		editor.WithCompletions(
 			completions.NewCommandCompletion(m.commandCategories()),
-			completions.NewFileCompletion(),
+			completions.NewFileCompletion(m.showGitignored),
 		),
 	}
 }


### PR DESCRIPTION
Implements issue #2490 by adding a --show-gitignored flag to the 'docker agent run' command.
When enabled, the file picker (@-syntax) will show gitignored files that are normally hidden.

Changes:
- Added --show-gitignored flag to run command in cmd/root/run.go
- Added WithShowGitignored() option to TUI in pkg/tui/tui.go
- Modified file picker dialog to accept showGitignored parameter
- Updated file picker to conditionally skip VCS ignore checking
- Same with file completion popup (inline list when pressing @)
- Added comprehensive test for the new functionality

Closes #2490

Assisted-By: docker-agent