### PR TITLE
fix(tui): make /speak slash command dispatch immediately

### DIFF
--- a/pkg/tui/commands/speak_darwin.go
+++ b/pkg/tui/commands/speak_darwin.go
@@ -16,6 +16,7 @@ func speakCommand() *Item {
 		SlashCommand: "/speak",
 		Description:  "Start speech-to-text transcription (press Enter or Escape to stop)",
 		Category:     "Session",
+		Immediate:    true,
 		Execute: func(string) tea.Cmd {
 			return core.CmdHandler(messages.StartSpeakMsg{})
 		},

--- a/pkg/tui/commands/speak_darwin_test.go
+++ b/pkg/tui/commands/speak_darwin_test.go
@@ -1,0 +1,24 @@
+//go:build darwin
+
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/tui/messages"
+)
+
+func TestParseSlashCommand_Speak(t *testing.T) {
+	t.Parallel()
+	parser := newTestParser()
+
+	cmd := parser.Parse("/speak")
+	require.NotNil(t, cmd, "should return a command for /speak")
+
+	msg := cmd()
+	_, ok := msg.(messages.StartSpeakMsg)
+	assert.True(t, ok, "should return StartSpeakMsg")
+}


### PR DESCRIPTION
## Problem

Typing `/speak` in the chat input did nothing — the text was silently forwarded to the agent as a regular message instead of starting speech-to-text transcription.

## Root cause

`commands.Parser.Parse` only dispatches slash commands that have `Immediate: true`:

```go
if item.SlashCommand == cmd && item.Immediate {
    return item.Execute(arg)
}
```

Every session slash command (`/clear`, `/new`, `/exit`, `/yolo`, …) sets `Immediate: true`, but `speakCommand` in `pkg/tui/commands/speak_darwin.go` was missing the flag, so `/speak` fell through to the regular message path.

## Fix

- Set `Immediate: true` on the `/speak` command. Starting transcription is a local UI action that does not interrupt any ongoing stream, consistent with the other session slash commands.
- Add a darwin-only regression test asserting that `parser.Parse("/speak")` returns a command that emits `StartSpeakMsg`.

## Validation

- `go build ./...`
- `go test ./pkg/tui/commands/...`
- `mise lint`