### PR TITLE
tui: add custom component for user_prompt tool calls

### DIFF
--- a/pkg/tui/components/tool/factory.go
+++ b/pkg/tui/components/tool/factory.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker-agent/pkg/tui/components/tool/shell"
 	"github.com/docker/docker-agent/pkg/tui/components/tool/todotool"
 	"github.com/docker/docker-agent/pkg/tui/components/tool/transfertask"
+	"github.com/docker/docker-agent/pkg/tui/components/tool/userprompt"
 	"github.com/docker/docker-agent/pkg/tui/components/tool/writefile"
 	"github.com/docker/docker-agent/pkg/tui/core/layout"
 	"github.com/docker/docker-agent/pkg/tui/service"
@@ -72,6 +73,7 @@ func newDefaultRegistry() *Registry {
 		{[]string{builtin.ToolNameDirectoryTree}, directorytree.New},
 		{[]string{builtin.ToolNameSearchFilesContent}, searchfilescontent.New},
 		{[]string{builtin.ToolNameShell}, shell.New},
+		{[]string{builtin.ToolNameUserPrompt}, userprompt.New},
 		{[]string{builtin.ToolNameFetch, "category:api"}, api.New},
 		{
 			[]string{

--- a/pkg/tui/components/tool/userprompt/userprompt.go
+++ b/pkg/tui/components/tool/userprompt/userprompt.go
@@ -1,0 +1,21 @@
+package userprompt
+
+import (
+	"github.com/docker/docker-agent/pkg/tui/components/spinner"
+	"github.com/docker/docker-agent/pkg/tui/components/toolcommon"
+	"github.com/docker/docker-agent/pkg/tui/core/layout"
+	"github.com/docker/docker-agent/pkg/tui/service"
+	"github.com/docker/docker-agent/pkg/tui/types"
+)
+
+// New creates a component for the user_prompt tool call.
+// It intentionally does not render the tool call's arguments (the question,
+// title or schema). It only indicates that a question is being asked to the
+// user, via the tool's status icon and display name.
+func New(msg *types.Message, sessionState service.SessionStateReader) layout.Model {
+	return toolcommon.NewBase(msg, sessionState, render)
+}
+
+func render(msg *types.Message, s spinner.Spinner, sessionState service.SessionStateReader, width, _ int) string {
+	return toolcommon.RenderTool(msg, s, "", "", width, sessionState.HideToolResults())
+}


### PR DESCRIPTION
Render user_prompt tool calls with just the status icon and display name, without exposing the prompt message, title or schema arguments.

Assisted-By: docker-agent