### PR TITLE
fix(session): prevent race condition in session cleanup

### DIFF
--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -207,6 +207,13 @@ func (sm *SessionManager) RunSession(ctx context.Context, sessionID, agentFilena
 	needsTitle := sess.Title == "" && len(userMessages) > 0 && titleGen != nil
 
 	go func() {
+		// Defers run LIFO: close(streamChan) last, so by the time the
+		// consumer's range loop terminates, streaming.Unlock has already
+		// fired. Otherwise a caller that immediately calls RunSession
+		// after draining the channel can race the Unlock and spuriously
+		// see ErrSessionBusy.
+		defer close(streamChan)
+		defer cancel()
 		defer runtimeSession.streaming.Unlock()
 
 		// Start title generation in parallel if needed
@@ -215,8 +222,6 @@ func (sm *SessionManager) RunSession(ctx context.Context, sessionID, agentFilena
 		}
 
 		stream := runtimeSession.runtime.RunStream(streamCtx, sess)
-		defer cancel()
-		defer close(streamChan)
 		for event := range stream {
 			if streamCtx.Err() != nil {
 				return


### PR DESCRIPTION
`SessionManager.RunSession` defers `streaming.Unlock` first and `close(streamChan)` last inside the background goroutine. Because defers run LIFO, close fires before Unlock, so a caller that drains the channel and immediately calls `RunSession` again can race the unlock and spuriously see `ErrSessionBusy`.

Reorder the defers so `Unlock` fires before close, making the channel-close the observable "session is idle" signal. Surfaced intermittently by `TestRunSession_ConcurrentRequestReturnsErrSessionBusy` in CI.