### PR TITLE
fix(otel): support http/https scheme in OTLP endpoint URL

### DIFF
--- a/cmd/root/otel.go
+++ b/cmd/root/otel.go
@@ -29,11 +29,18 @@ func initOTelSDK(ctx context.Context) (err error) {
 
 	// Only initialize if endpoint is configured
 	if endpoint != "" {
-		opts := []otlptracehttp.Option{
-			otlptracehttp.WithEndpoint(endpoint),
-		}
-		if isLocalhostEndpoint(endpoint) {
-			opts = append(opts, otlptracehttp.WithInsecure())
+		var opts []otlptracehttp.Option
+		// An endpoint with an http:// or https:// scheme goes through
+		// WithEndpointURL so the SDK picks the transport from the scheme
+		// (per the OTLP/HTTP spec). Bare host:port still flows through
+		// WithEndpoint with the loopback-insecure shortcut preserved.
+		if strings.HasPrefix(endpoint, "http://") || strings.HasPrefix(endpoint, "https://") {
+			opts = []otlptracehttp.Option{otlptracehttp.WithEndpointURL(endpoint)}
+		} else {
+			opts = []otlptracehttp.Option{otlptracehttp.WithEndpoint(endpoint)}
+			if isLocalhostEndpoint(endpoint) {
+				opts = append(opts, otlptracehttp.WithInsecure())
+			}
 		}
 		traceExporter, err = otlptracehttp.New(ctx, opts...)
 		if err != nil {


### PR DESCRIPTION
The OTLP exporter now correctly handles endpoints with explicit `http://` or `https://` schemes by using `WithEndpointURL` instead of `WithEndpoint`. This allows the SDK to determine the transport protocol from the scheme as specified in the OTLP/HTTP specification.

Bare `host:port` endpoints continue to use `WithEndpoint` with the existing localhost-insecure behavior preserved for backward compatibility.