### PR TITLE
fix(runtime): add OpenTelemetry tracer to runtime initialization

### DIFF
--- a/pkg/a2a/adapter.go
+++ b/pkg/a2a/adapter.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"strings"
 
+	"go.opentelemetry.io/otel"
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/model"
 	adksession "google.golang.org/adk/session"
@@ -56,6 +57,7 @@ func runDockerAgent(ctx agent.InvocationContext, t *team.Team, agentName string,
 		// Create runtime
 		rt, err := runtime.New(t,
 			runtime.WithCurrentAgent(agentName),
+			runtime.WithTracer(otel.Tracer("cagent")),
 		)
 		if err != nil {
 			yield(nil, fmt.Errorf("failed to create runtime: %w", err))

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"go.opentelemetry.io/otel"
 
 	"github.com/docker/docker-agent/pkg/agent"
 	"github.com/docker/docker-agent/pkg/config"
@@ -169,6 +170,7 @@ func CreateToolHandler(t *team.Team, agentName string) func(context.Context, *mc
 
 		rt, err := runtime.New(t,
 			runtime.WithCurrentAgent(agentName),
+			runtime.WithTracer(otel.Tracer("cagent")),
 		)
 		if err != nil {
 			return nil, ToolOutput{}, fmt.Errorf("failed to create runtime: %w", err)

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/otel"
+
 	"github.com/docker/docker-agent/pkg/api"
 	"github.com/docker/docker-agent/pkg/concurrent"
 	"github.com/docker/docker-agent/pkg/config"
@@ -418,6 +420,7 @@ func (sm *SessionManager) runtimeForSession(ctx context.Context, sess *session.S
 		runtime.WithCurrentAgent(currentAgent),
 		runtime.WithManagedOAuth(false),
 		runtime.WithSessionStore(sm.sessionStore),
+		runtime.WithTracer(otel.Tracer("cagent")),
 	}
 	run, err := runtime.New(t, opts...)
 	if err != nil {


### PR DESCRIPTION
Wire an OpenTelemetry tracer into the runtime instances created by the non-interactive entry points so they emit spans like the CLI already does:

- Agent-to-agent adapter runtime
- MCP server tool handler runtime
- Session manager runtime

Without this, `LocalRuntime.startSpan` sees `r.tracer == nil` and silently returns a noop, so users running in MCP, API or A2A mode with `OTEL_EXPORTER_OTLP_ENDPOINT` set get an initialized SDK that never emits anything.

It uses the same `"cagent"` scope as `cmd/root/run.go` for consistency. No behavior change when OTel is disabled — the global tracer provider is a noop until `initOTelSDK` runs.