### PR TITLE
refactor(skills): move fork-skill validation into SkillsToolset

### DIFF
--- a/pkg/runtime/skill_runner.go
+++ b/pkg/runtime/skill_runner.go
@@ -20,11 +20,16 @@ import (
 // runs in a child session using the current agent's model and tools, and
 // its final response is returned as the tool result.
 //
-// This implements the `context: fork` behaviour from the SKILL.md
-// frontmatter, following the same convention as Claude Code.
+// All skill-specific business rules (lookup, fork-mode validation, content
+// expansion) live in (*builtin.SkillsToolset).PrepareForkSubSession; this
+// handler keeps only the runtime-private orchestration: sub-session creation,
+// OpenTelemetry tracing, and event forwarding.
+//
+// This implements the `context: fork` behaviour from the SKILL.md frontmatter,
+// following the same convention as Claude Code.
 func (r *LocalRuntime) handleRunSkill(ctx context.Context, sess *session.Session, toolCall tools.ToolCall, evts chan Event) (*tools.ToolCallResult, error) {
-	var params builtin.RunSkillArgs
-	if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &params); err != nil {
+	var args builtin.RunSkillArgs
+	if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &args); err != nil {
 		return nil, fmt.Errorf("invalid arguments: %w", err)
 	}
 
@@ -33,22 +38,9 @@ func (r *LocalRuntime) handleRunSkill(ctx context.Context, sess *session.Session
 		return tools.ResultError("no skills are available for the current agent"), nil
 	}
 
-	skill := st.FindSkill(params.Name)
-	if skill == nil {
-		return tools.ResultError(fmt.Sprintf("skill %q not found", params.Name)), nil
-	}
-
-	if !skill.IsFork() {
-		return tools.ResultError(fmt.Sprintf(
-			"skill %q is not configured for sub-agent execution (missing context: fork in SKILL.md frontmatter); use read_skill instead",
-			params.Name,
-		)), nil
-	}
-
-	// Load and expand the skill content for the system prompt.
-	skillContent, err := st.ReadSkillContent(ctx, params.Name)
-	if err != nil {
-		return tools.ResultError(fmt.Sprintf("failed to read skill content: %s", err)), nil
+	prepared, errResult := st.PrepareForkSubSession(ctx, args)
+	if errResult != nil {
+		return errResult, nil
 	}
 
 	a := r.CurrentAgent()
@@ -56,23 +48,23 @@ func (r *LocalRuntime) handleRunSkill(ctx context.Context, sess *session.Session
 
 	ctx, span := r.startSpan(ctx, "runtime.run_skill", trace.WithAttributes(
 		attribute.String("agent", ca),
-		attribute.String("skill", params.Name),
+		attribute.String("skill", prepared.SkillName),
 		attribute.String("session.id", sess.ID),
 	))
 	defer span.End()
 
 	slog.Debug("Running skill as sub-agent",
 		"agent", ca,
-		"skill", params.Name,
-		"task", params.Task,
+		"skill", prepared.SkillName,
+		"task", prepared.Task,
 	)
 
 	cfg := SubSessionConfig{
-		Task:                params.Task,
-		SystemMessage:       skillContent,
-		ImplicitUserMessage: params.Task,
+		Task:                prepared.Task,
+		SystemMessage:       prepared.Content,
+		ImplicitUserMessage: prepared.Task,
 		AgentName:           ca,
-		Title:               "Skill: " + params.Name,
+		Title:               "Skill: " + prepared.SkillName,
 		ToolsApproved:       sess.ToolsApproved,
 		ExcludedTools:       []string{builtin.ToolNameRunSkill},
 	}

--- a/pkg/tools/builtin/skills.go
+++ b/pkg/tools/builtin/skills.go
@@ -232,6 +232,54 @@ type RunSkillArgs struct {
 	Task string `json:"task" jsonschema:"A clear description of the task the skill sub-agent should achieve"`
 }
 
+// PreparedSkillFork carries the validated and expanded data needed to launch a
+// skill as an isolated sub-agent. Callers (typically the runtime) use it to
+// build the child session; this lets the skill-specific business rules
+// (lookup, fork validation, content expansion) live with the toolset rather
+// than the runtime.
+type PreparedSkillFork struct {
+	// SkillName is the validated skill name, suitable for span attributes,
+	// log fields, and sub-session titles ("Skill: <name>").
+	SkillName string
+	// Task is the caller-supplied task description, intended to be used as
+	// the implicit user message of the child session.
+	Task string
+	// Content is the expanded SKILL.md content, intended to be used as the
+	// system message of the child session.
+	Content string
+}
+
+// PrepareForkSubSession validates a run_skill request and loads the expanded
+// skill content. It returns either a populated PreparedSkillFork, or a
+// ToolCallResult describing why the call cannot proceed (skill missing,
+// skill not configured for fork mode, content read failure). The caller is
+// responsible for the runtime-specific orchestration (sub-session creation,
+// tracing, event forwarding).
+func (s *SkillsToolset) PrepareForkSubSession(ctx context.Context, args RunSkillArgs) (*PreparedSkillFork, *tools.ToolCallResult) {
+	skill := s.findSkill(args.Name)
+	if skill == nil {
+		return nil, tools.ResultError(fmt.Sprintf("skill %q not found", args.Name))
+	}
+
+	if !skill.IsFork() {
+		return nil, tools.ResultError(fmt.Sprintf(
+			"skill %q is not configured for sub-agent execution (missing context: fork in SKILL.md frontmatter); use read_skill instead",
+			args.Name,
+		))
+	}
+
+	content, err := s.ReadSkillContent(ctx, args.Name)
+	if err != nil {
+		return nil, tools.ResultError(fmt.Sprintf("failed to read skill content: %s", err))
+	}
+
+	return &PreparedSkillFork{
+		SkillName: args.Name,
+		Task:      args.Task,
+		Content:   content,
+	}, nil
+}
+
 func (s *SkillsToolset) Tools(context.Context) ([]tools.Tool, error) {
 	if len(s.skills) == 0 {
 		return nil, nil

--- a/pkg/tools/builtin/skills_test.go
+++ b/pkg/tools/builtin/skills_test.go
@@ -361,6 +361,66 @@ func TestSkillsToolset_Tools_NoForkSkills(t *testing.T) {
 	assert.Equal(t, ToolNameReadSkill, result[0].Name)
 }
 
+func TestSkillsToolset_PrepareForkSubSession(t *testing.T) {
+	tmpDir := t.TempDir()
+	skillFile := filepath.Join(tmpDir, "SKILL.md")
+	require.NoError(t, os.WriteFile(skillFile, []byte("system instructions"), 0o644))
+
+	st := NewSkillsToolset([]skills.Skill{
+		{Name: "forked", Description: "Forked", Context: "fork", FilePath: skillFile, BaseDir: tmpDir},
+	}, "")
+
+	prepared, errResult := st.PrepareForkSubSession(t.Context(), RunSkillArgs{Name: "forked", Task: "do the thing"})
+	require.Nil(t, errResult)
+	require.NotNil(t, prepared)
+	assert.Equal(t, "forked", prepared.SkillName)
+	assert.Equal(t, "do the thing", prepared.Task)
+	assert.Equal(t, "system instructions", prepared.Content)
+}
+
+func TestSkillsToolset_PrepareForkSubSession_NotFound(t *testing.T) {
+	st := NewSkillsToolset([]skills.Skill{
+		{Name: "exists", Description: "Exists", Context: "fork", FilePath: "/tmp/nonexistent"},
+	}, "")
+
+	prepared, errResult := st.PrepareForkSubSession(t.Context(), RunSkillArgs{Name: "missing", Task: "x"})
+	assert.Nil(t, prepared)
+	require.NotNil(t, errResult)
+	assert.True(t, errResult.IsError)
+	assert.Contains(t, errResult.Output, "not found")
+}
+
+func TestSkillsToolset_PrepareForkSubSession_NotFork(t *testing.T) {
+	tmpDir := t.TempDir()
+	skillFile := filepath.Join(tmpDir, "SKILL.md")
+	require.NoError(t, os.WriteFile(skillFile, []byte("inline"), 0o644))
+
+	st := NewSkillsToolset([]skills.Skill{
+		// No Context: "fork" — this is an inline skill.
+		{Name: "inline-only", Description: "Inline", FilePath: skillFile, BaseDir: tmpDir},
+	}, "")
+
+	prepared, errResult := st.PrepareForkSubSession(t.Context(), RunSkillArgs{Name: "inline-only", Task: "x"})
+	assert.Nil(t, prepared)
+	require.NotNil(t, errResult)
+	assert.True(t, errResult.IsError)
+	assert.Contains(t, errResult.Output, "not configured for sub-agent execution")
+	assert.Contains(t, errResult.Output, "use read_skill instead")
+}
+
+func TestSkillsToolset_PrepareForkSubSession_ReadFailure(t *testing.T) {
+	st := NewSkillsToolset([]skills.Skill{
+		// FilePath does not exist on disk; ReadSkillContent will fail.
+		{Name: "forked", Description: "Forked", Context: "fork", FilePath: "/does/not/exist/SKILL.md"},
+	}, "")
+
+	prepared, errResult := st.PrepareForkSubSession(t.Context(), RunSkillArgs{Name: "forked", Task: "x"})
+	assert.Nil(t, prepared)
+	require.NotNil(t, errResult)
+	assert.True(t, errResult.IsError)
+	assert.Contains(t, errResult.Output, "failed to read skill content")
+}
+
 func TestSkillsToolset_Tools_ForkAndFiles(t *testing.T) {
 	st := NewSkillsToolset([]skills.Skill{
 		{Name: "full", Description: "Full skill", Context: "fork", Files: []string{"SKILL.md", "ref.md"}},


### PR DESCRIPTION
Extract skill-specific business rules (lookup, fork-mode validation, content
expansion) from the runtime's `handleRunSkill` into a new
`SkillsToolset.PrepareForkSubSession` method. The runtime handler now keeps
only the parts that genuinely need its private internals: sub-session
creation, OpenTelemetry tracing, and event forwarding.

### What changed

- Add `PreparedSkillFork` struct + `PrepareForkSubSession` method to
  `pkg/tools/builtin/skills.go`. It returns either a populated bundle or a
  `*tools.ToolCallResult` describing the failure (skill missing, not
  configured for fork, content read error).
- Shrink `handleRunSkill` from ~80 to ~50 lines; it now delegates
  validation/expansion to the toolset and focuses on runtime-private
  orchestration.
- Add unit tests for `PrepareForkSubSession` covering the happy path,
  not-found, not-fork, and read-failure cases. These previously had no
  equivalent at the toolset layer.

### Why stop here

Going further — moving `handleRunSkill` itself out of `pkg/runtime` (like
the `bgAgents` pattern in `pkg/tools/builtin/agent`) — runs into a real
obstacle: `run_skill` needs **live event forwarding** to the user's stream
so the skill execution streams in the TUI, and the events channel is typed
as `chan runtime.Event`. The bgAgent pattern sidesteps this by collecting
output via a plain `OnContent func(string)` callback, which `run_skill`
can't use without changing UX. Fully extracting would require either
pushing `Event` out into a shared package (a much larger refactor) or
loose-typing the channel as `chan any`. Neither felt worth it for the ~50
lines that remain — those genuinely *are* runtime concerns (sub-session
creation, OTEL span, event channel).

### Validation

- ` + "`mise lint`" + ` — 0 issues
- ` + "`mise test`" + ` — all packages pass

Assisted-By: docker-agent