### PR TITLE
refactor(hooks/builtins): one file per builtin + simplify registration

### DIFF
--- a/pkg/hooks/builtins/add_date.go
+++ b/pkg/hooks/builtins/add_date.go
@@ -7,6 +7,9 @@ import (
 	"github.com/docker/docker-agent/pkg/hooks"
 )
 
+// AddDate is the registered name of the add_date builtin.
+const AddDate = "add_date"
+
 // addDate emits today's date as turn_start additional context.
 func addDate(_ context.Context, _ *hooks.Input, _ []string) (*hooks.Output, error) {
 	return turnStartContext("Today's date: " + time.Now().Format("2006-01-02")), nil

--- a/pkg/hooks/builtins/add_date.go
+++ b/pkg/hooks/builtins/add_date.go
@@ -1,0 +1,13 @@
+package builtins
+
+import (
+	"context"
+	"time"
+
+	"github.com/docker/docker-agent/pkg/hooks"
+)
+
+// addDate emits today's date as turn_start additional context.
+func addDate(_ context.Context, _ *hooks.Input, _ []string) (*hooks.Output, error) {
+	return turnStartContext("Today's date: " + time.Now().Format("2006-01-02")), nil
+}

--- a/pkg/hooks/builtins/add_environment_info.go
+++ b/pkg/hooks/builtins/add_environment_info.go
@@ -7,6 +7,9 @@ import (
 	"github.com/docker/docker-agent/pkg/session"
 )
 
+// AddEnvironmentInfo is the registered name of the add_environment_info builtin.
+const AddEnvironmentInfo = "add_environment_info"
+
 // addEnvironmentInfo emits cwd / git / OS / arch info as session_start
 // additional context. No-op when Cwd is empty.
 func addEnvironmentInfo(_ context.Context, in *hooks.Input, _ []string) (*hooks.Output, error) {

--- a/pkg/hooks/builtins/add_environment_info.go
+++ b/pkg/hooks/builtins/add_environment_info.go
@@ -1,0 +1,17 @@
+package builtins
+
+import (
+	"context"
+
+	"github.com/docker/docker-agent/pkg/hooks"
+	"github.com/docker/docker-agent/pkg/session"
+)
+
+// addEnvironmentInfo emits cwd / git / OS / arch info as session_start
+// additional context. No-op when Cwd is empty.
+func addEnvironmentInfo(_ context.Context, in *hooks.Input, _ []string) (*hooks.Output, error) {
+	if in == nil || in.Cwd == "" {
+		return nil, nil
+	}
+	return hooks.NewAdditionalContextOutput(hooks.EventSessionStart, session.GetEnvironmentInfo(in.Cwd)), nil
+}

--- a/pkg/hooks/builtins/add_prompt_files.go
+++ b/pkg/hooks/builtins/add_prompt_files.go
@@ -1,0 +1,32 @@
+package builtins
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	"github.com/docker/docker-agent/pkg/hooks"
+	"github.com/docker/docker-agent/pkg/session"
+)
+
+// addPromptFiles reads each filename in args (relative to Input.Cwd) and
+// joins their contents into turn_start additional context. Missing files
+// are logged and skipped; surviving files still contribute.
+func addPromptFiles(_ context.Context, in *hooks.Input, args []string) (*hooks.Output, error) {
+	if in == nil || in.Cwd == "" || len(args) == 0 {
+		return nil, nil
+	}
+	var parts []string
+	for _, name := range args {
+		additional, err := session.ReadPromptFiles(in.Cwd, name)
+		if err != nil {
+			slog.Warn("reading prompt file", "file", name, "error", err)
+			continue
+		}
+		parts = append(parts, additional...)
+	}
+	if len(parts) == 0 {
+		return nil, nil
+	}
+	return turnStartContext(strings.Join(parts, "\n\n")), nil
+}

--- a/pkg/hooks/builtins/add_prompt_files.go
+++ b/pkg/hooks/builtins/add_prompt_files.go
@@ -9,6 +9,9 @@ import (
 	"github.com/docker/docker-agent/pkg/session"
 )
 
+// AddPromptFiles is the registered name of the add_prompt_files builtin.
+const AddPromptFiles = "add_prompt_files"
+
 // addPromptFiles reads each filename in args (relative to Input.Cwd) and
 // joins their contents into turn_start additional context. Missing files
 // are logged and skipped; surviving files still contribute.

--- a/pkg/hooks/builtins/builtins.go
+++ b/pkg/hooks/builtins/builtins.go
@@ -16,7 +16,7 @@
 package builtins
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/docker/docker-agent/pkg/hooks"
 )
@@ -31,16 +31,11 @@ const (
 
 // Register installs the stock builtin hooks on r.
 func Register(r *hooks.Registry) error {
-	for name, fn := range map[string]hooks.BuiltinFunc{
-		AddDate:            addDate,
-		AddEnvironmentInfo: addEnvironmentInfo,
-		AddPromptFiles:     addPromptFiles,
-	} {
-		if err := r.RegisterBuiltin(name, fn); err != nil {
-			return fmt.Errorf("register %q builtin: %w", name, err)
-		}
-	}
-	return nil
+	return errors.Join(
+		r.RegisterBuiltin(AddDate, addDate),
+		r.RegisterBuiltin(AddEnvironmentInfo, addEnvironmentInfo),
+		r.RegisterBuiltin(AddPromptFiles, addPromptFiles),
+	)
 }
 
 // AgentDefaults captures the agent-level flags that map onto stock
@@ -59,10 +54,6 @@ func (d AgentDefaults) IsZero() bool {
 // ApplyAgentDefaults appends the stock builtin hook entries implied by
 // d to cfg, returning the (possibly mutated) config.
 //
-// add_date and add_prompt_files target turn_start so they recompute
-// every turn; add_environment_info targets session_start because cwd /
-// OS / arch don't change during a session.
-//
 // A nil cfg is treated as empty; the returned value is non-nil iff at
 // least one hook (user-configured or auto-injected) is present.
 func ApplyAgentDefaults(cfg *hooks.Config, d AgentDefaults) *hooks.Config {
@@ -70,28 +61,23 @@ func ApplyAgentDefaults(cfg *hooks.Config, d AgentDefaults) *hooks.Config {
 		cfg = &hooks.Config{}
 	}
 	if d.AddDate {
-		cfg.TurnStart = append(cfg.TurnStart, hooks.Hook{
-			Type:    hooks.HookTypeBuiltin,
-			Command: AddDate,
-		})
+		cfg.TurnStart = append(cfg.TurnStart, builtinHook(AddDate))
 	}
 	if len(d.AddPromptFiles) > 0 {
-		cfg.TurnStart = append(cfg.TurnStart, hooks.Hook{
-			Type:    hooks.HookTypeBuiltin,
-			Command: AddPromptFiles,
-			Args:    d.AddPromptFiles,
-		})
+		cfg.TurnStart = append(cfg.TurnStart, builtinHook(AddPromptFiles, d.AddPromptFiles...))
 	}
 	if d.AddEnvironmentInfo {
-		cfg.SessionStart = append(cfg.SessionStart, hooks.Hook{
-			Type:    hooks.HookTypeBuiltin,
-			Command: AddEnvironmentInfo,
-		})
+		cfg.SessionStart = append(cfg.SessionStart, builtinHook(AddEnvironmentInfo))
 	}
 	if cfg.IsEmpty() {
 		return nil
 	}
 	return cfg
+}
+
+// builtinHook returns a hook entry that dispatches to the named builtin.
+func builtinHook(name string, args ...string) hooks.Hook {
+	return hooks.Hook{Type: hooks.HookTypeBuiltin, Command: name, Args: args}
 }
 
 // turnStartContext wraps additional context as a turn_start output.

--- a/pkg/hooks/builtins/builtins.go
+++ b/pkg/hooks/builtins/builtins.go
@@ -12,21 +12,14 @@
 // don't change during a session.
 //
 // Each builtin lives in its own file (add_date.go, add_environment_info.go,
-// add_prompt_files.go); this file holds the shared registration plumbing.
+// add_prompt_files.go) along with its registered-name constant; this file
+// holds the shared registration plumbing.
 package builtins
 
 import (
 	"errors"
 
 	"github.com/docker/docker-agent/pkg/hooks"
-)
-
-// Builtin hook names. They match the `command` field of a
-// `{type: builtin}` hook entry in YAML.
-const (
-	AddDate            = "add_date"
-	AddEnvironmentInfo = "add_environment_info"
-	AddPromptFiles     = "add_prompt_files"
 )
 
 // Register installs the stock builtin hooks on r.

--- a/pkg/hooks/builtins/builtins.go
+++ b/pkg/hooks/builtins/builtins.go
@@ -10,17 +10,15 @@
 // AddDate and AddPromptFiles target turn_start so they recompute every
 // turn. AddEnvironmentInfo targets session_start because cwd / OS / arch
 // don't change during a session.
+//
+// Each builtin lives in its own file (add_date.go, add_environment_info.go,
+// add_prompt_files.go); this file holds the shared registration plumbing.
 package builtins
 
 import (
-	"context"
 	"fmt"
-	"log/slog"
-	"strings"
-	"time"
 
 	"github.com/docker/docker-agent/pkg/hooks"
-	"github.com/docker/docker-agent/pkg/session"
 )
 
 // Builtin hook names. They match the `command` field of a
@@ -97,42 +95,8 @@ func ApplyAgentDefaults(cfg *hooks.Config, d AgentDefaults) *hooks.Config {
 }
 
 // turnStartContext wraps additional context as a turn_start output.
+// Shared by builtins that contribute per-turn context (add_date,
+// add_prompt_files).
 func turnStartContext(content string) *hooks.Output {
 	return hooks.NewAdditionalContextOutput(hooks.EventTurnStart, content)
-}
-
-// addDate emits today's date as turn_start additional context.
-func addDate(_ context.Context, _ *hooks.Input, _ []string) (*hooks.Output, error) {
-	return turnStartContext("Today's date: " + time.Now().Format("2006-01-02")), nil
-}
-
-// addEnvironmentInfo emits cwd / git / OS / arch info as session_start
-// additional context. No-op when Cwd is empty.
-func addEnvironmentInfo(_ context.Context, in *hooks.Input, _ []string) (*hooks.Output, error) {
-	if in == nil || in.Cwd == "" {
-		return nil, nil
-	}
-	return hooks.NewAdditionalContextOutput(hooks.EventSessionStart, session.GetEnvironmentInfo(in.Cwd)), nil
-}
-
-// addPromptFiles reads each filename in args (relative to Input.Cwd) and
-// joins their contents into turn_start additional context. Missing files
-// are logged and skipped; surviving files still contribute.
-func addPromptFiles(_ context.Context, in *hooks.Input, args []string) (*hooks.Output, error) {
-	if in == nil || in.Cwd == "" || len(args) == 0 {
-		return nil, nil
-	}
-	var parts []string
-	for _, name := range args {
-		additional, err := session.ReadPromptFiles(in.Cwd, name)
-		if err != nil {
-			slog.Warn("reading prompt file", "file", name, "error", err)
-			continue
-		}
-		parts = append(parts, additional...)
-	}
-	if len(parts) == 0 {
-		return nil, nil
-	}
-	return turnStartContext(strings.Join(parts, "\n\n")), nil
 }


### PR DESCRIPTION
Small readability/maintainability refactor of `pkg/hooks/builtins`. No
public API change, no behaviour change, all existing tests pass as-is.

## What changed

### 1. Split each builtin into its own file
`builtins.go` was a 130-line file mixing registration plumbing with three
unrelated builtin implementations. Now each builtin lives in its own file:

- `add_date.go` — `AddDate` constant + `addDate` function
- `add_environment_info.go` — `AddEnvironmentInfo` constant + `addEnvironmentInfo` function
- `add_prompt_files.go` — `AddPromptFiles` constant + `addPromptFiles` function

Each file is now fully self-contained: registered name **and** behaviour
sit next to each other. `builtins.go` keeps only the package doc and the
generic plumbing: `Register`, `AgentDefaults`, `ApplyAgentDefaults`, and
the small `builtinHook` / `turnStartContext` helpers.

Adding a fourth builtin is now a clear mechanical change: drop a new
`add_*.go` file with `const + func`, plus one line in `Register`.

### 2. Simplify `Register` and `ApplyAgentDefaults`

- **`Register`** previously iterated a `map[string]BuiltinFunc{...}`
  and wrapped each error with `fmt.Errorf("register %q builtin: %w", ...)`.
  The wrapping wasn't reachable in practice (`RegisterBuiltin` only fails
  on empty name / nil fn, neither possible with package constants), and
  map iteration is non-deterministic. Replaced with three explicit
  `RegisterBuiltin` calls combined via `errors.Join` — shorter, ordered,
  and reads top-to-bottom.

- **`ApplyAgentDefaults`** had three near-identical 4-line struct
  literals (`hooks.Hook{Type: HookTypeBuiltin, Command: ...}`). A tiny
  `builtinHook(name, args...)` helper turns each branch into a
  one-liner, halving the function's size and aligning the three
  flag-handling branches visually.

- Dropped the duplicated "turn_start vs session_start" rationale
  paragraph from `ApplyAgentDefaults`' doc — it was already in the
  package comment verbatim.

## Validation

Rebased on latest `origin/main`. Repo-wide clean:

- `go build ./...` ✅
- `go vet ./...` ✅
- `golangci-lint run ./...` → 0 issues ✅
- `go test ./...` → all packages pass ✅
- Existing `pkg/hooks/builtins` tests pass unchanged (no test edits
  needed — public API is identical).

## Out of scope

- `AgentDefaults.IsZero()` is currently only consumed by its own test.
  Left in place since it's a documented part of the public API and the
  brief said "don't remove any feature."

Assisted-By: docker-agent