### PR TITLE
fix(skills): unbreak main after fork-skill refactor merge

### DIFF
--- a/pkg/runtime/skill_runner.go
+++ b/pkg/runtime/skill_runner.go
@@ -64,14 +64,14 @@ func (r *LocalRuntime) handleRunSkill(ctx context.Context, sess *session.Session
 	// model, alloy, inline provider/model, inline alloy) and returns a
 	// CAS-safe restore func that is always non-nil; on failure we log a
 	// warning and fall back to the agent's currently-active model.
-	if skill.Model != "" {
-		restore, err := r.WithAgentModel(ctx, ca, skill.Model)
+	if prepared.Model != "" {
+		restore, err := r.WithAgentModel(ctx, ca, prepared.Model)
 		defer restore()
 		if err != nil {
 			slog.Warn("Failed to apply skill model override; using current model",
 				"agent", ca,
-				"skill", params.Name,
-				"model", skill.Model,
+				"skill", prepared.SkillName,
+				"model", prepared.Model,
 				"error", err,
 			)
 		}

--- a/pkg/tools/builtin/skills.go
+++ b/pkg/tools/builtin/skills.go
@@ -247,6 +247,9 @@ type PreparedSkillFork struct {
 	// Content is the expanded SKILL.md content, intended to be used as the
 	// system message of the child session.
 	Content string
+	// Model is the optional model override declared in the SKILL.md
+	// frontmatter. Empty means "use the parent agent's current model".
+	Model string
 }
 
 // PrepareForkSubSession validates a run_skill request and loads the expanded
@@ -277,6 +280,7 @@ func (s *SkillsToolset) PrepareForkSubSession(ctx context.Context, args RunSkill
 		SkillName: args.Name,
 		Task:      args.Task,
 		Content:   content,
+		Model:     skill.Model,
 	}, nil
 }
 

--- a/pkg/tools/builtin/skills_test.go
+++ b/pkg/tools/builtin/skills_test.go
@@ -367,7 +367,7 @@ func TestSkillsToolset_PrepareForkSubSession(t *testing.T) {
 	require.NoError(t, os.WriteFile(skillFile, []byte("system instructions"), 0o644))
 
 	st := NewSkillsToolset([]skills.Skill{
-		{Name: "forked", Description: "Forked", Context: "fork", FilePath: skillFile, BaseDir: tmpDir},
+		{Name: "forked", Description: "Forked", Context: "fork", FilePath: skillFile, BaseDir: tmpDir, Model: "openai/gpt-4o-mini"},
 	}, "")
 
 	prepared, errResult := st.PrepareForkSubSession(t.Context(), RunSkillArgs{Name: "forked", Task: "do the thing"})
@@ -376,6 +376,23 @@ func TestSkillsToolset_PrepareForkSubSession(t *testing.T) {
 	assert.Equal(t, "forked", prepared.SkillName)
 	assert.Equal(t, "do the thing", prepared.Task)
 	assert.Equal(t, "system instructions", prepared.Content)
+	assert.Equal(t, "openai/gpt-4o-mini", prepared.Model)
+}
+
+func TestSkillsToolset_PrepareForkSubSession_NoModelOverride(t *testing.T) {
+	tmpDir := t.TempDir()
+	skillFile := filepath.Join(tmpDir, "SKILL.md")
+	require.NoError(t, os.WriteFile(skillFile, []byte("system instructions"), 0o644))
+
+	st := NewSkillsToolset([]skills.Skill{
+		// No Model set in the frontmatter — Prepared.Model must be empty.
+		{Name: "forked", Description: "Forked", Context: "fork", FilePath: skillFile, BaseDir: tmpDir},
+	}, "")
+
+	prepared, errResult := st.PrepareForkSubSession(t.Context(), RunSkillArgs{Name: "forked", Task: "x"})
+	require.Nil(t, errResult)
+	require.NotNil(t, prepared)
+	assert.Empty(t, prepared.Model)
 }
 
 func TestSkillsToolset_PrepareForkSubSession_NotFound(t *testing.T) {


### PR DESCRIPTION
## Why

`main` is currently broken: `package github.com/docker/docker-agent/pkg/runtime` fails to build because `pkg/runtime/skill_runner.go` references identifiers that no longer exist in scope:

```
pkg/runtime/skill_runner.go:67:5:  undefined: skill
pkg/runtime/skill_runner.go:68:45: undefined: skill
pkg/runtime/skill_runner.go:73:14: undefined: params
pkg/runtime/skill_runner.go:74:14: undefined: skill
```

The breakage was introduced by the merge of two PRs that touched `handleRunSkill`:

- **#2525** — *Skills: allow fork skills to override the model* — added a model-override block using local variables `skill.Model` and `params.Name`.
- **#2524** — *refactor(skills): move fork-skill validation into SkillsToolset* — refactored `handleRunSkill` to delegate to `SkillsToolset.PrepareForkSubSession`, dropping the local `skill` variable and renaming `params` → `args`.

The merge applied #2524 cleanly on top of #2525 but did not update the new model-override block, leaving four references to undefined identifiers.

## Fix

Restore the build by surfacing the model override through the toolset, in line with the refactor's intent of keeping skill-specific business rules out of the runtime.

- Add `Model string` to `PreparedSkillFork` and populate it from `skill.Model` inside `(*SkillsToolset).PrepareForkSubSession`. The runtime no longer needs a direct `skills.Skill` reference.
- Switch `handleRunSkill`'s override block to `prepared.Model` and `prepared.SkillName`. The `WithAgentModel` call, `defer restore()`, and warning log are otherwise unchanged — runtime behaviour is identical to what #2525 intended.
- Extend `TestSkillsToolset_PrepareForkSubSession` to assert the `Model` field is propagated, and add `TestSkillsToolset_PrepareForkSubSession_NoModelOverride` to pin down the empty-`Model` contract the runtime relies on to skip the override path.

## Validation

- `go build ./...` — clean
- `go vet ./...` — clean
- `golangci-lint run ./pkg/runtime/... ./pkg/tools/builtin/...` — 0 issues
- `go test ./pkg/runtime/... ./pkg/tools/builtin/... ./pkg/skills/... ./pkg/agent/...` — all green

## Diffstat

```
 pkg/runtime/skill_runner.go      |  8 ++++----
 pkg/tools/builtin/skills.go      |  4 ++++
 pkg/tools/builtin/skills_test.go | 19 ++++++++++++++++++-
 3 files changed, 26 insertions(+), 5 deletions(-)
```

Assisted-By: docker-agent