### PR TITLE
refactor(hooks): drop runtime shadow types and tighten the executor

### DIFF
--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -1727,6 +1727,15 @@ type HookDefinition struct {
 	Timeout int `json:"timeout,omitempty" yaml:"timeout,omitempty"`
 }
 
+// GetTimeout returns the per-hook execution timeout, defaulting to 60
+// seconds when [HookDefinition.Timeout] is zero or negative.
+func (h *HookDefinition) GetTimeout() time.Duration {
+	if h.Timeout <= 0 {
+		return 60 * time.Second
+	}
+	return time.Duration(h.Timeout) * time.Second
+}
+
 // validate validates the HooksConfig
 func (h *HooksConfig) validate() error {
 	// Validate PreToolUse matchers

--- a/pkg/hooks/config.go
+++ b/pkg/hooks/config.go
@@ -4,50 +4,26 @@ import (
 	"github.com/docker/docker-agent/pkg/config/latest"
 )
 
-// FromConfig converts a [latest.HooksConfig] into the runtime [Config].
-func FromConfig(cfg *latest.HooksConfig) *Config {
-	if cfg == nil {
-		return nil
-	}
-	return &Config{
-		PreToolUse:      convertMatchers(cfg.PreToolUse),
-		PostToolUse:     convertMatchers(cfg.PostToolUse),
-		SessionStart:    convertHooks(cfg.SessionStart),
-		TurnStart:       convertHooks(cfg.TurnStart),
-		BeforeLLMCall:   convertHooks(cfg.BeforeLLMCall),
-		AfterLLMCall:    convertHooks(cfg.AfterLLMCall),
-		SessionEnd:      convertHooks(cfg.SessionEnd),
-		OnUserInput:     convertHooks(cfg.OnUserInput),
-		Stop:            convertHooks(cfg.Stop),
-		Notification:    convertHooks(cfg.Notification),
-		OnError:         convertHooks(cfg.OnError),
-		OnMaxIterations: convertHooks(cfg.OnMaxIterations),
-	}
-}
-
-func convertMatchers(in []latest.HookMatcherConfig) []MatcherConfig {
-	if len(in) == 0 {
-		return nil
-	}
-	out := make([]MatcherConfig, len(in))
-	for i, m := range in {
-		out[i] = MatcherConfig{Matcher: m.Matcher, Hooks: convertHooks(m.Hooks)}
-	}
-	return out
-}
-
-func convertHooks(in []latest.HookDefinition) []Hook {
-	if len(in) == 0 {
-		return nil
-	}
-	out := make([]Hook, len(in))
-	for i, h := range in {
-		out[i] = Hook{
-			Type:    HookType(h.Type),
-			Command: h.Command,
-			Args:    h.Args,
-			Timeout: h.Timeout,
-		}
-	}
-	return out
-}
+// The hooks package and the persisted [latest.HooksConfig] used to
+// declare two parallel struct hierarchies with identical fields, just
+// to attach a single helper method (GetTimeout) and a typed Type
+// string. The cost was a 12-events-listed-in-four-places translation
+// layer that grew every time a new event was added.
+//
+// Today they're the same types: aliases below give the runtime the
+// short names it always used, while the single source of truth (and
+// the YAML/JSON tags, the validate() method, and IsEmpty) lives next
+// to the schema in pkg/config/latest. Adding a new event is a one-line
+// change on [latest.HooksConfig] plus one line in the executor's
+// compile loop.
+type (
+	// Config is the hooks configuration for an agent.
+	Config = latest.HooksConfig
+	// Hook is a single hook entry. The Type field is one of the
+	// HookType* constants below; unrecognised values are rejected by
+	// the executor at registry lookup.
+	Hook = latest.HookDefinition
+	// MatcherConfig pairs a tool-name regex with the hooks to run when
+	// it matches (used by EventPreToolUse and EventPostToolUse).
+	MatcherConfig = latest.HookMatcherConfig
+)

--- a/pkg/hooks/config.go
+++ b/pkg/hooks/config.go
@@ -14,8 +14,7 @@ import (
 // short names it always used, while the single source of truth (and
 // the YAML/JSON tags, the validate() method, and IsEmpty) lives next
 // to the schema in pkg/config/latest. Adding a new event is a one-line
-// change on [latest.HooksConfig] plus one line in the executor's
-// compile loop.
+// change on [latest.HooksConfig] plus one line in compileEvents.
 type (
 	// Config is the hooks configuration for an agent.
 	Config = latest.HooksConfig
@@ -26,4 +25,19 @@ type (
 	// MatcherConfig pairs a tool-name regex with the hooks to run when
 	// it matches (used by EventPreToolUse and EventPostToolUse).
 	MatcherConfig = latest.HookMatcherConfig
+)
+
+// HookType values populate [Hook.Type]. It is an alias for string so
+// hooks authored in YAML round-trip through [latest.HookDefinition]
+// without any conversion; the executor validates the value at registry
+// lookup time.
+type HookType = string
+
+const (
+	// HookTypeCommand runs a shell command.
+	HookTypeCommand HookType = "command"
+	// HookTypeBuiltin dispatches to a named in-process Go function
+	// registered via [Registry.RegisterBuiltin]. The name is stored in
+	// [Hook.Command].
+	HookTypeBuiltin HookType = "builtin"
 )

--- a/pkg/hooks/dispatch_test.go
+++ b/pkg/hooks/dispatch_test.go
@@ -6,60 +6,61 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestExecutorHasIsGeneric exercises the generic Has API across all
-// configured event kinds to ensure the eventTable is wired correctly. It
-// guards against regressions where adding a new event to the Config
-// struct silently fails to surface in Has/Dispatch.
+// trueHook is a minimal hook reused as the body of every per-event
+// fixture below — the hook's identity doesn't matter to Has, only its
+// presence does.
+var trueHook = []Hook{{Type: HookTypeCommand, Command: "true"}}
+
+// matcherWildcard wraps trueHook in the structure tool-scoped events
+// (PreToolUse, PostToolUse) require.
+var matcherWildcard = []MatcherConfig{{Matcher: "*", Hooks: trueHook}}
+
+// onlyHooks maps each known event to a Config that lights up exactly
+// that event. The cross-product test below iterates this map (once for
+// the empty check, once for the per-event check), so adding a new
+// event is a one-line update here — the same one-line update
+// compileEvents needs.
+var onlyHooks = map[EventType]*Config{
+	EventPreToolUse:      {PreToolUse: matcherWildcard},
+	EventPostToolUse:     {PostToolUse: matcherWildcard},
+	EventSessionStart:    {SessionStart: trueHook},
+	EventTurnStart:       {TurnStart: trueHook},
+	EventBeforeLLMCall:   {BeforeLLMCall: trueHook},
+	EventAfterLLMCall:    {AfterLLMCall: trueHook},
+	EventSessionEnd:      {SessionEnd: trueHook},
+	EventOnUserInput:     {OnUserInput: trueHook},
+	EventStop:            {Stop: trueHook},
+	EventNotification:    {Notification: trueHook},
+	EventOnError:         {OnError: trueHook},
+	EventOnMaxIterations: {OnMaxIterations: trueHook},
+}
+
+// TestExecutorHasIsGeneric exercises the generic Has API across every
+// event kind to ensure compileEvents is wired correctly. It guards
+// against regressions where adding a new event to the Config struct
+// silently fails to surface in Has/Dispatch.
 func TestExecutorHasIsGeneric(t *testing.T) {
 	t.Parallel()
 
 	// Empty config: no event has hooks.
 	empty := NewExecutor(nil, "/tmp", nil)
-	for _, ev := range []EventType{
-		EventPreToolUse, EventPostToolUse, EventSessionStart, EventTurnStart,
-		EventBeforeLLMCall, EventAfterLLMCall,
-		EventSessionEnd, EventOnUserInput, EventStop, EventNotification,
-		EventOnError, EventOnMaxIterations,
-	} {
+	for ev := range onlyHooks {
 		assert.Falsef(t, empty.Has(ev), "empty executor must not report Has(%s)", ev)
 	}
 
-	// Each event populated in turn — the cross-product test ensures that
-	// configuring event X never makes Has(Y) true for Y != X.
-	cases := []struct {
-		event  EventType
-		config *Config
-	}{
-		{EventPreToolUse, &Config{PreToolUse: []MatcherConfig{{Matcher: "*", Hooks: []Hook{{Type: HookTypeCommand, Command: "true"}}}}}},
-		{EventPostToolUse, &Config{PostToolUse: []MatcherConfig{{Matcher: "*", Hooks: []Hook{{Type: HookTypeCommand, Command: "true"}}}}}},
-		{EventSessionStart, &Config{SessionStart: []Hook{{Type: HookTypeCommand, Command: "true"}}}},
-		{EventTurnStart, &Config{TurnStart: []Hook{{Type: HookTypeCommand, Command: "true"}}}},
-		{EventBeforeLLMCall, &Config{BeforeLLMCall: []Hook{{Type: HookTypeCommand, Command: "true"}}}},
-		{EventAfterLLMCall, &Config{AfterLLMCall: []Hook{{Type: HookTypeCommand, Command: "true"}}}},
-		{EventSessionEnd, &Config{SessionEnd: []Hook{{Type: HookTypeCommand, Command: "true"}}}},
-		{EventOnUserInput, &Config{OnUserInput: []Hook{{Type: HookTypeCommand, Command: "true"}}}},
-		{EventStop, &Config{Stop: []Hook{{Type: HookTypeCommand, Command: "true"}}}},
-		{EventNotification, &Config{Notification: []Hook{{Type: HookTypeCommand, Command: "true"}}}},
-		{EventOnError, &Config{OnError: []Hook{{Type: HookTypeCommand, Command: "true"}}}},
-		{EventOnMaxIterations, &Config{OnMaxIterations: []Hook{{Type: HookTypeCommand, Command: "true"}}}},
-	}
-
-	for _, tc := range cases {
-		exec := NewExecutor(tc.config, "/tmp", nil)
-		for _, other := range []EventType{
-			EventPreToolUse, EventPostToolUse, EventSessionStart, EventTurnStart,
-			EventBeforeLLMCall, EventAfterLLMCall,
-			EventSessionEnd, EventOnUserInput, EventStop, EventNotification,
-			EventOnError, EventOnMaxIterations,
-		} {
-			if other == tc.event {
-				assert.Truef(t, exec.Has(other), "configuring %s must light up Has(%s)", tc.event, other)
+	// Cross-product: configuring event ev must light up Has(ev) and
+	// only Has(ev).
+	for ev, cfg := range onlyHooks {
+		exec := NewExecutor(cfg, "/tmp", nil)
+		for other := range onlyHooks {
+			if other == ev {
+				assert.Truef(t, exec.Has(other), "configuring %s must light up Has(%s)", ev, other)
 			} else {
-				assert.Falsef(t, exec.Has(other), "configuring %s must NOT light up Has(%s)", tc.event, other)
+				assert.Falsef(t, exec.Has(other), "configuring %s must NOT light up Has(%s)", ev, other)
 			}
 		}
 	}
 
 	// Unknown events fall through cleanly rather than panicking.
-	assert.False(t, NewExecutor(nil, "/tmp", nil).Has(EventType("does-not-exist")))
+	assert.False(t, empty.Has(EventType("does-not-exist")))
 }

--- a/pkg/hooks/executor.go
+++ b/pkg/hooks/executor.go
@@ -22,12 +22,14 @@ type Executor struct {
 	registry   *Registry
 	// events maps each event to its compiled matcher list. Flat events
 	// (everything except pre/post_tool_use) are stored as a single
-	// matcher with an empty pattern, unifying the dispatch path.
+	// matcher with a nil pattern, unifying the dispatch path.
 	events map[EventType][]matcher
 }
 
-// matcher is the compiled form of a [MatcherConfig]: an optional regex
-// pattern (nil means "match all") and the hooks to fire when it matches.
+// matcher is the compiled form of a [MatcherConfig]: a tool-name regex
+// plus the hooks to fire when it matches. A nil pattern matches every
+// tool — both "" and "*" matchers compile to nil, as do flat events
+// where the tool-name dimension doesn't apply.
 type matcher struct {
 	pattern *regexp.Regexp
 	hooks   []Hook
@@ -35,15 +37,6 @@ type matcher struct {
 
 func (m *matcher) matches(toolName string) bool {
 	return m.pattern == nil || m.pattern.MatchString(toolName)
-}
-
-// hookResult is the outcome of a single hook invocation.
-type hookResult struct {
-	output   *Output
-	stdout   string
-	stderr   string
-	exitCode int
-	err      error
 }
 
 // NewExecutor creates a new hook executor backed by [DefaultRegistry].
@@ -188,6 +181,17 @@ func dedupKey(h Hook) string {
 	return b.String()
 }
 
+// hookResult is the outcome of a single hook invocation: the raw
+// [HandlerResult] reported by the handler plus a post-execution err
+// (factory failure, timeout, exec error). When err is non-nil the
+// handler-reported fields are reset to a uniform "did not run"
+// representation so [aggregate] can rely on the err alone.
+type hookResult struct {
+	HandlerResult
+
+	err error
+}
+
 // runHook resolves the hook's [HookType] in the registry, applies its
 // timeout, and returns the structured outcome. JSON-on-stdout is parsed
 // into [Output] when the handler didn't already provide one.
@@ -205,7 +209,7 @@ func (e *Executor) runHook(ctx context.Context, hook Hook, inputJSON []byte) hoo
 	defer cancel()
 
 	res, err := handler.Run(timeoutCtx, inputJSON)
-	r := hookResult{stdout: res.Stdout, stderr: res.Stderr, exitCode: res.ExitCode, output: res.Output}
+	r := hookResult{HandlerResult: res}
 
 	// Normalize timeout/cancellation: handler error types vary, so we
 	// rewrite to a uniform error so PreToolUse fails closed cleanly.
@@ -214,40 +218,33 @@ func (e *Executor) runHook(ctx context.Context, hook Hook, inputJSON []byte) hoo
 		if errors.Is(ctxErr, context.DeadlineExceeded) {
 			reason = fmt.Sprintf("timed out after %s", hook.GetTimeout())
 		}
-		r.err = fmt.Errorf("hook %q %s: %w", hook.Command, reason, ctxErr)
-		r.exitCode = -1
-		r.output = nil
-		return r
+		return hookResult{err: fmt.Errorf("hook %q %s: %w", hook.Command, reason, ctxErr)}
 	}
 	if err != nil {
-		r.err = err
-		r.exitCode = -1
-		r.output = nil
-		return r
+		return hookResult{err: err}
 	}
 
 	// Fall back to the legacy "parse JSON from stdout" protocol.
-	if r.output == nil && r.exitCode == 0 && r.stdout != "" {
-		s := strings.TrimSpace(r.stdout)
-		if strings.HasPrefix(s, "{") {
-			var parsed Output
-			if jerr := json.Unmarshal([]byte(s), &parsed); jerr == nil {
-				r.output = &parsed
-			}
-		}
+	if r.Output == nil && r.ExitCode == 0 {
+		r.Output = parseStdoutJSON(r.Stdout)
 	}
 	return r
 }
 
-// contextEvents are the events whose runtime emit sites consume
-// Result.AdditionalContext. Plain stdout from a hook is routed there
-// for these events; for observational events it is silently dropped to
-// avoid the impression that it mattered.
-var contextEvents = map[EventType]bool{
-	EventSessionStart: true,
-	EventTurnStart:    true,
-	EventPostToolUse:  true,
-	EventStop:         true,
+// parseStdoutJSON returns a parsed [Output] when stdout begins with '{'
+// and decodes cleanly, or nil otherwise. Used for the legacy "JSON on
+// stdout" hook protocol where handlers don't pre-populate
+// [HandlerResult.Output].
+func parseStdoutJSON(stdout string) *Output {
+	s := strings.TrimSpace(stdout)
+	if !strings.HasPrefix(s, "{") {
+		return nil
+	}
+	var parsed Output
+	if err := json.Unmarshal([]byte(s), &parsed); err != nil {
+		return nil
+	}
+	return &parsed
 }
 
 // aggregate combines per-hook results into a single [Result].
@@ -263,36 +260,36 @@ func aggregate(results []hookResult, event EventType) *Result {
 				slog.Warn("PreToolUse hook failed to execute; denying tool call", "error", r.err)
 				final.Allowed = false
 				final.ExitCode = -1
-				final.Stderr = r.stderr
+				final.Stderr = r.Stderr
 				messages = append(messages, fmt.Sprintf("PreToolUse hook failed to execute: %v", r.err))
 			} else {
 				slog.Warn("Hook execution error", "error", r.err)
 			}
 			continue
 
-		case r.exitCode == 2:
+		case r.ExitCode == 2:
 			final.Allowed = false
 			final.ExitCode = 2
-			if r.stderr != "" {
-				final.Stderr = r.stderr
-				messages = append(messages, strings.TrimSpace(r.stderr))
+			if r.Stderr != "" {
+				final.Stderr = r.Stderr
+				messages = append(messages, strings.TrimSpace(r.Stderr))
 			}
 			continue
 
-		case r.exitCode != 0:
-			slog.Debug("Hook returned non-zero exit code", "exit_code", r.exitCode, "stderr", r.stderr)
+		case r.ExitCode != 0:
+			slog.Debug("Hook returned non-zero exit code", "exit_code", r.ExitCode, "stderr", r.Stderr)
 			continue
 
-		case r.output == nil:
+		case r.Output == nil:
 			// Plain stdout becomes AdditionalContext only for events
 			// whose runtime consumes it.
-			if r.stdout != "" && contextEvents[event] {
-				contexts = append(contexts, strings.TrimSpace(r.stdout))
+			if r.Stdout != "" && event.consumesContext() {
+				contexts = append(contexts, strings.TrimSpace(r.Stdout))
 			}
 			continue
 		}
 
-		out := r.output
+		out := r.Output
 		if !out.ShouldContinue() {
 			final.Allowed = false
 			if out.StopReason != "" {

--- a/pkg/hooks/executor.go
+++ b/pkg/hooks/executor.go
@@ -68,8 +68,10 @@ func NewExecutorWithRegistry(config *Config, workingDir string, env []string, re
 	}
 }
 
-// compileEvents builds the per-event matcher lookup. Adding a new event
-// is a one-line change here.
+// compileEvents builds the per-event matcher lookup. This is the only
+// place in the runtime that enumerates events; the persisted side
+// owns the struct itself, its IsEmpty, and validate, all on
+// [latest.HooksConfig]. Adding a new event is a one-line change here.
 func compileEvents(c *Config) map[EventType][]matcher {
 	flat := func(hooks []Hook) []matcher {
 		if len(hooks) == 0 {
@@ -176,7 +178,7 @@ func (e *Executor) hooksFor(event EventType, toolName string) []Hook {
 // dedupKey returns a deterministic key identifying a hook by (type, command, args).
 func dedupKey(h Hook) string {
 	var b strings.Builder
-	b.WriteString(string(h.Type))
+	b.WriteString(h.Type)
 	b.WriteByte(0)
 	b.WriteString(h.Command)
 	for _, a := range h.Args {

--- a/pkg/hooks/executor.go
+++ b/pkg/hooks/executor.go
@@ -218,10 +218,16 @@ func (e *Executor) runHook(ctx context.Context, hook Hook, inputJSON []byte) hoo
 		if errors.Is(ctxErr, context.DeadlineExceeded) {
 			reason = fmt.Sprintf("timed out after %s", hook.GetTimeout())
 		}
-		return hookResult{err: fmt.Errorf("hook %q %s: %w", hook.Command, reason, ctxErr)}
+		return hookResult{
+			HandlerResult: HandlerResult{Stderr: res.Stderr, ExitCode: -1},
+			err:           fmt.Errorf("hook %q %s: %w", hook.Command, reason, ctxErr),
+		}
 	}
 	if err != nil {
-		return hookResult{err: err}
+		return hookResult{
+			HandlerResult: HandlerResult{Stderr: res.Stderr, ExitCode: -1},
+			err:           err,
+		}
 	}
 
 	// Fall back to the legacy "parse JSON from stdout" protocol.

--- a/pkg/hooks/executor.go
+++ b/pkg/hooks/executor.go
@@ -211,6 +211,20 @@ func (e *Executor) runHook(ctx context.Context, hook Hook, inputJSON []byte) hoo
 	res, err := handler.Run(timeoutCtx, inputJSON)
 	r := hookResult{HandlerResult: res}
 
+	// markFailed turns r into a "did not complete" outcome: the
+	// handler's diagnostic stdout/stderr survive (aggregate surfaces
+	// stderr in the PreToolUse fail-closed message), ExitCode is
+	// pinned to -1 to match the documented [Result.ExitCode]
+	// convention, any partial Output is dropped (it can't have been
+	// authoritative if the run didn't complete), and rerr lands in
+	// hookResult.err for the err-!= nil branch in [aggregate].
+	markFailed := func(rerr error) hookResult {
+		r.ExitCode = -1
+		r.Output = nil
+		r.err = rerr
+		return r
+	}
+
 	// Normalize timeout/cancellation: handler error types vary, so we
 	// rewrite to a uniform error so PreToolUse fails closed cleanly.
 	if ctxErr := timeoutCtx.Err(); ctxErr != nil {
@@ -218,16 +232,10 @@ func (e *Executor) runHook(ctx context.Context, hook Hook, inputJSON []byte) hoo
 		if errors.Is(ctxErr, context.DeadlineExceeded) {
 			reason = fmt.Sprintf("timed out after %s", hook.GetTimeout())
 		}
-		return hookResult{
-			HandlerResult: HandlerResult{Stderr: res.Stderr, ExitCode: -1},
-			err:           fmt.Errorf("hook %q %s: %w", hook.Command, reason, ctxErr),
-		}
+		return markFailed(fmt.Errorf("hook %q %s: %w", hook.Command, reason, ctxErr))
 	}
 	if err != nil {
-		return hookResult{
-			HandlerResult: HandlerResult{Stderr: res.Stderr, ExitCode: -1},
-			err:           err,
-		}
+		return markFailed(err)
 	}
 
 	// Fall back to the legacy "parse JSON from stdout" protocol.

--- a/pkg/hooks/handler_test.go
+++ b/pkg/hooks/handler_test.go
@@ -160,6 +160,46 @@ func TestExecutorHandlerErrorDeniesPreToolUse(t *testing.T) {
 	assert.Equal(t, -1, result.ExitCode)
 }
 
+// TestExecutorHandlerErrorPreservesStderr pins the contract that when a
+// handler returns an error, the diagnostic stderr it captured before
+// failing survives all the way to [Result.Stderr]. aggregate routes
+// that field into the user-visible PreToolUse fail-closed message; if
+// runHook ever drops it on the floor (as it briefly did during the
+// HandlerResult-embedding refactor) PreToolUse denials would lose
+// their explanatory text.
+func TestExecutorHandlerErrorPreservesStderr(t *testing.T) {
+	t.Parallel()
+
+	const customType HookType = "errors-with-stderr"
+	const diagnostic = "BOOM: subprocess crashed at line 42"
+
+	registry := NewRegistry()
+	registry.Register(customType, func(_ HandlerEnv, _ Hook) (Handler, error) {
+		return handlerFunc(func(context.Context, []byte) (HandlerResult, error) {
+			// Mirrors what commandHandler does on a spawn failure: it
+			// captured stderr, then surfaces an exec-level error.
+			return HandlerResult{Stderr: diagnostic, ExitCode: -1}, errors.New("spawn failed")
+		}), nil
+	})
+
+	config := &Config{
+		PreToolUse: []MatcherConfig{
+			{Matcher: "*", Hooks: []Hook{{Type: customType, Timeout: 5}}},
+		},
+	}
+
+	exec := NewExecutorWithRegistry(config, t.TempDir(), nil, registry)
+	result, err := exec.Dispatch(t.Context(), EventPreToolUse, &Input{
+		SessionID: "s", ToolName: "shell", ToolUseID: "t",
+	})
+	require.NoError(t, err)
+
+	assert.False(t, result.Allowed)
+	assert.Equal(t, -1, result.ExitCode)
+	assert.Equal(t, diagnostic, result.Stderr,
+		"handler-captured stderr must survive the err != nil normalization in runHook")
+}
+
 // handlerFunc adapts a function value into a [Handler] for terse tests.
 type handlerFunc func(context.Context, []byte) (HandlerResult, error)
 

--- a/pkg/hooks/types.go
+++ b/pkg/hooks/types.go
@@ -41,20 +41,18 @@ const (
 	EventOnMaxIterations EventType = "on_max_iterations"
 )
 
-// HookType values populate [Hook.Type]. It is an alias for string so a
-// hook authored in YAML round-trips through [latest.HookDefinition]
-// without any conversion; the executor validates the value at registry
-// lookup time.
-type HookType = string
-
-const (
-	// HookTypeCommand runs a shell command.
-	HookTypeCommand HookType = "command"
-	// HookTypeBuiltin dispatches to a named in-process Go function
-	// registered via [Registry.RegisterBuiltin]. The name is stored in
-	// [Hook.Command].
-	HookTypeBuiltin HookType = "builtin"
-)
+// consumesContext reports whether the runtime emit site for e routes
+// [Result.AdditionalContext] somewhere meaningful (a system message, a
+// transient turn_start prompt, ...). For observational events it is
+// silently dropped, so plain stdout from a hook is also discarded for
+// those.
+func (e EventType) consumesContext() bool {
+	switch e {
+	case EventSessionStart, EventTurnStart, EventPostToolUse, EventStop:
+		return true
+	}
+	return false
+}
 
 // Input is the JSON-serializable payload passed to hooks via stdin.
 type Input struct {

--- a/pkg/hooks/types.go
+++ b/pkg/hooks/types.go
@@ -6,7 +6,6 @@ package hooks
 
 import (
 	"encoding/json"
-	"time"
 )
 
 // EventType identifies a hook event.
@@ -42,8 +41,11 @@ const (
 	EventOnMaxIterations EventType = "on_max_iterations"
 )
 
-// HookType identifies the kind of handler used to run a hook.
-type HookType string
+// HookType values populate [Hook.Type]. It is an alias for string so a
+// hook authored in YAML round-trips through [latest.HookDefinition]
+// without any conversion; the executor validates the value at registry
+// lookup time.
+type HookType = string
 
 const (
 	// HookTypeCommand runs a shell command.
@@ -53,58 +55,6 @@ const (
 	// [Hook.Command].
 	HookTypeBuiltin HookType = "builtin"
 )
-
-// Hook is a single hook configuration entry.
-type Hook struct {
-	Type    HookType `json:"type" yaml:"type"`
-	Command string   `json:"command,omitempty" yaml:"command,omitempty"`
-	// Args are arbitrary string arguments passed to the hook handler.
-	// Builtin hooks receive them as the args parameter of [BuiltinFunc].
-	Args []string `json:"args,omitempty" yaml:"args,omitempty"`
-	// Timeout is the execution timeout in seconds (default: 60).
-	Timeout int `json:"timeout,omitempty" yaml:"timeout,omitempty"`
-}
-
-// GetTimeout returns the timeout duration, defaulting to 60 seconds.
-func (h *Hook) GetTimeout() time.Duration {
-	if h.Timeout <= 0 {
-		return 60 * time.Second
-	}
-	return time.Duration(h.Timeout) * time.Second
-}
-
-// MatcherConfig is a hook matcher with its hooks. Matcher is a regex
-// pattern matched against tool names; "" or "*" matches all tools.
-type MatcherConfig struct {
-	Matcher string `json:"matcher,omitempty" yaml:"matcher,omitempty"`
-	Hooks   []Hook `json:"hooks" yaml:"hooks"`
-}
-
-// Config is the hooks configuration for an agent.
-type Config struct {
-	PreToolUse      []MatcherConfig `json:"pre_tool_use,omitempty" yaml:"pre_tool_use,omitempty"`
-	PostToolUse     []MatcherConfig `json:"post_tool_use,omitempty" yaml:"post_tool_use,omitempty"`
-	SessionStart    []Hook          `json:"session_start,omitempty" yaml:"session_start,omitempty"`
-	TurnStart       []Hook          `json:"turn_start,omitempty" yaml:"turn_start,omitempty"`
-	BeforeLLMCall   []Hook          `json:"before_llm_call,omitempty" yaml:"before_llm_call,omitempty"`
-	AfterLLMCall    []Hook          `json:"after_llm_call,omitempty" yaml:"after_llm_call,omitempty"`
-	SessionEnd      []Hook          `json:"session_end,omitempty" yaml:"session_end,omitempty"`
-	OnUserInput     []Hook          `json:"on_user_input,omitempty" yaml:"on_user_input,omitempty"`
-	Stop            []Hook          `json:"stop,omitempty" yaml:"stop,omitempty"`
-	Notification    []Hook          `json:"notification,omitempty" yaml:"notification,omitempty"`
-	OnError         []Hook          `json:"on_error,omitempty" yaml:"on_error,omitempty"`
-	OnMaxIterations []Hook          `json:"on_max_iterations,omitempty" yaml:"on_max_iterations,omitempty"`
-}
-
-// IsEmpty returns true if no hooks are configured.
-func (c *Config) IsEmpty() bool {
-	return len(c.PreToolUse) == 0 && len(c.PostToolUse) == 0 &&
-		len(c.SessionStart) == 0 && len(c.TurnStart) == 0 &&
-		len(c.BeforeLLMCall) == 0 && len(c.AfterLLMCall) == 0 &&
-		len(c.SessionEnd) == 0 && len(c.OnUserInput) == 0 &&
-		len(c.Stop) == 0 && len(c.Notification) == 0 &&
-		len(c.OnError) == 0 && len(c.OnMaxIterations) == 0
-}
 
 // Input is the JSON-serializable payload passed to hooks via stdin.
 type Input struct {

--- a/pkg/runtime/hooks.go
+++ b/pkg/runtime/hooks.go
@@ -28,7 +28,7 @@ func (r *LocalRuntime) buildHooksExecutors() {
 		if err != nil {
 			continue
 		}
-		cfg := builtins.ApplyAgentDefaults(hooks.FromConfig(a.Hooks()), builtins.AgentDefaults{
+		cfg := builtins.ApplyAgentDefaults(a.Hooks(), builtins.AgentDefaults{
 			AddDate:            a.AddDate(),
 			AddEnvironmentInfo: a.AddEnvironmentInfo(),
 			AddPromptFiles:     a.AddPromptFiles(),


### PR DESCRIPTION
## What

`pkg/hooks/config.go` had grown a 12-events-listed-in-four-places translation layer on top of `pkg/hooks.Config`/`Hook`/`MatcherConfig` — pure shadow copies of `latest.HooksConfig`/`HookDefinition`/`HookMatcherConfig` that existed only to attach `Hook.GetTimeout()` and a typed `HookType`. This series replaces the shadow with type aliases, deletes the conversion code, and tightens a few executor types along the way.

The four commits are independently buildable so they can be reviewed in order.

## Commits

1. **`refactor(hooks): drop runtime shadow types in favor of latest aliases`** — `pkg/hooks.Config`/`Hook`/`MatcherConfig` become type aliases for the persisted types. Deletes `FromConfig`, the two converter helpers, and the duplicate `Config.IsEmpty`. Moves `GetTimeout` to `latest.HookDefinition` so both names share it through the alias. Softens `HookType` to a string alias to keep existing test fixtures compiling without conversion churn. Net **−63 lines**.

2. **`refactor(hooks): tighten executor types and dispatch test`** — five small, related cleanups now that the types are unified:
   - drop `matcher.raw` ("" and "*" already short-circuit to a nil regexp); `matches()` collapses to one return statement
   - merge `hookResult` and `HandlerResult` (they had parallel field names); `hookResult` now embeds `HandlerResult` and only adds `err`
   - extract `parseStdoutJSON` so the JSON-on-stdout fallback isn't three nested ifs inside `runHook`
   - replace the `contextEvents` map with `EventType.consumesContext()` (same four events, reads as a question about the event)
   - move `HookType` + constants from `types.go` to `config.go` next to the `Hook` alias they describe
   - compress `dispatch_test.go`'s per-event fixtures into one `onlyHooks` map literal iterated twice

3. **`fix(hooks): preserve stderr and exitCode in hookResult error paths`** — fixes a regression introduced in commit 2: when `runHook` hit a timeout or handler error, returning a fresh `hookResult{err:...}` silently dropped the handler-captured `Stderr` that `aggregate` reads to build the PreToolUse fail-closed message. Restores `Stderr` and `ExitCode = -1` on both error returns.

4. **`fix(hooks): also preserve stdout in failed-hook results, pin contract`** — tightens commit 3: replaces the explicit `HandlerResult{Stderr: ..., ExitCode: -1}` literal with a small `markFailed` closure that mutates the already-built `r` in place. This preserves both `Stdout` and `Stderr` (matching pre-refactor behaviour exactly) and is robust to future fields on `HandlerResult`. Adds `TestExecutorHandlerErrorPreservesStderr` to pin the contract — this test fails against commit 2's code, so it would have caught the original regression.

## Net effect

- `pkg/hooks/config.go` shrinks from a 12-event translation layer to **a 44-line file containing only type aliases and `HookType` constants**
- The 12-event listing now exists in exactly two places: the `HooksConfig` struct itself (which owns `IsEmpty` and `validate`) and `compileEvents` in the executor — down from five
- Adding a new event is one field on `latest.HooksConfig` plus one line in `compileEvents`
- Public API surface (`hooks.Config`, `hooks.Hook`, `hooks.MatcherConfig`, `hooks.HookType`, all the constants) is unchanged — every existing struct literal, YAML key, and runtime path still works
- New test `TestExecutorHandlerErrorPreservesStderr` pins the PreToolUse fail-closed stderr contract that previously had no coverage

## Verified

- `mise lint` — 0 issues
- `mise test` — 97 packages green
- Rebased on top of current `origin/main` (resolved a conflict with the recent `buildHooksExecutors` extraction; the change there is just dropping the now-unnecessary `hooks.FromConfig` wrapper)