### PR TITLE
feat(agent): add a configurable response cache

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -398,6 +398,10 @@
           "$ref": "#/definitions/HooksConfig",
           "description": "Lifecycle hooks for executing shell commands at various points in the agent's execution"
         },
+        "cache": {
+          "$ref": "#/definitions/CacheConfig",
+          "description": "Optional response cache: when the same user question is asked again, replay the previous answer instead of calling the model."
+        },
         "skills": {
           "description": "Enable skills discovery for this agent. Set to true to load all discovered skills from local filesystem sources; false disables skills. A list can mix sources (\"local\" or an HTTP/HTTPS URL) and/or skill names to include. If only names are given, local sources are loaded and filtered to just those skills.",
           "oneOf": [
@@ -476,6 +480,32 @@
             "2m30s",
             "5m"
           ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "CacheConfig": {
+      "type": "object",
+      "description": "Configuration for the agent's response cache. When enabled, the assistant response produced for a given user question is stored and replayed verbatim the next time the same question is asked, skipping the model entirely. Two normalization options control what 'same question' means: case_sensitive (default false) toggles case-insensitive matching, and trim_spaces (default false) strips leading/trailing whitespace before comparison. Set 'path' to persist entries to a JSON file (relative paths resolve against the agent config directory); leave it empty to keep entries in memory only.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Set to true to enable the cache. When false (or when the cache section is omitted), no caching is performed.",
+          "default": false
+        },
+        "case_sensitive": {
+          "type": "boolean",
+          "description": "When true, questions must match exactly (including case) to hit the cache. Default: false (case-insensitive matching).",
+          "default": false
+        },
+        "trim_spaces": {
+          "type": "boolean",
+          "description": "When true, leading and trailing whitespace is stripped from questions before they are compared. Default: false.",
+          "default": false
+        },
+        "path": {
+          "type": "string",
+          "description": "Path to a JSON file used to persist cache entries across runs. Relative paths are resolved against the agent's config directory. When empty, the cache lives only in memory."
         }
       },
       "additionalProperties": false

--- a/docs/configuration/agents/index.md
+++ b/docs/configuration/agents/index.md
@@ -132,6 +132,12 @@ agents:
 
 When `path` is set, every `Store` rewrites the entire cache file. Writes are **atomic**: the new content is written to a sibling temp file, `fsync`'d, and renamed over the destination, so a concurrent reader (or a process that crashes mid-write) will always see either the previous content or the new content in full — never a partially written file. The parent directory is also `fsync`'d after the rename so the rename itself is durable.
 
+**Cross-process sharing**
+
+Multiple processes can share the same `path:` cache file safely. Every `Store` takes an exclusive advisory lock on a sibling `<path>.lock` file (POSIX `flock(2)` on Unix, `LockFileEx` on Windows), reloads the current on-disk state under the lock, merges the new entry, and writes back atomically. Two processes that store *different* keys at the same time both see their writes preserved on disk; the lock window is short (one read + one fsync'd write).
+
+`Lookup` watches the file's modification time and reloads the in-memory map when the file has advanced since its last load, so writes from a sibling process become visible without a restart. The `<path>.lock` sentinel file is created on first write and never deleted: removing it would let two processes lock different inodes and lose mutual exclusion.
+
 ## Welcome Message
 
 Display a message when users start a session:

--- a/docs/configuration/agents/index.md
+++ b/docs/configuration/agents/index.md
@@ -48,6 +48,11 @@ agents:
     structured_output: # Optional: constrain output format
       name: string
       schema: object
+    cache: # Optional: response cache (skip the model on repeat questions)
+      enabled: boolean
+      case_sensitive: boolean
+      trim_spaces: boolean
+      path: string
 ```
 
 <div class="callout callout-tip" markdown="1">
@@ -83,6 +88,7 @@ agents:
 | `handoffs`                  | array   | ✗        | List of agent names this agent can hand off the conversation to. Enables the `handoff` tool. See [Handoffs Routing]({{ '/concepts/multi-agent/#handoffs-routing' | relative_url }}).                  |
 | `hooks`                     | object  | ✗        | Lifecycle hooks for running commands at various points. See [Hooks]({{ '/configuration/hooks/' | relative_url }}).                                                                                   |
 | `structured_output`         | object  | ✗        | Constrain agent output to match a JSON schema. See [Structured Output]({{ '/configuration/structured-output/' | relative_url }}).                                                                    |
+| `cache`                     | object  | ✗        | Response cache. When the same user question is asked again, the previous answer is replayed verbatim and the model is not called. See [Response Cache](#response-cache) below.                  |
 
 <div class="callout callout-warning" markdown="1">
 <div class="callout-title">⚠️ max_iterations
@@ -90,6 +96,41 @@ agents:
   <p>Default is <code>0</code> (unlimited). Always set <code>max_iterations</code> for agents with powerful tools like <code>shell</code> to prevent infinite loops. A value of 20–50 is typical for development agents.</p>
 
 </div>
+
+## Response Cache
+
+The response cache short-circuits the model when the same user question is asked again. The first time a question is asked, the agent calls the model normally and stores the assistant's reply. Subsequent identical questions skip the model entirely and replay the stored reply verbatim.
+
+```yaml
+agents:
+  root:
+    model: openai/gpt-5-mini
+    description: Cached assistant
+    instruction: You are a helpful assistant.
+    cache:
+      enabled: true          # required to turn the cache on
+      case_sensitive: false  # default: false ("Hello" == "hello")
+      trim_spaces: true      # default: false ("  hello  " == "hello")
+      path: ./cache.json     # optional: persist to disk; omit for in-memory
+```
+
+| Property         | Type    | Default | Description                                                                                                                                                                                                                       |
+| ---------------- | ------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `enabled`        | boolean | `false` | Master switch. When `false` (or when the `cache` section is omitted), no caching is performed.                                                                                                                                     |
+| `case_sensitive` | boolean | `false` | When `true`, questions must match exactly (including case) to hit the cache.                                                                                                                                                       |
+| `trim_spaces`    | boolean | `false` | When `true`, leading and trailing whitespace is stripped from the question before it is compared.                                                                                                                                  |
+| `path`           | string  | _empty_ | When set, cache entries are persisted to a JSON file at the given path and reloaded on startup so the cache survives restarts. Relative paths resolve against the agent config directory. When empty, the cache lives in memory only. |
+
+**How it works**
+
+- The cache key is the latest user message in the session, normalized according to `case_sensitive` and `trim_spaces`.
+- On a hit, the cached reply is added to the session as the assistant message and stop hooks fire normally — the rest of the agent (tools, sub-agents, the model) is bypassed.
+- On a miss, the agent runs normally; the final assistant message produced by the first stop of the run is then stored under the question's key.
+- Only the response to the original user question of a run is cached; follow-up turns inside the same `RunStream` are not.
+
+**File-backed storage**
+
+When `path` is set, every `Store` rewrites the entire cache file. Writes are **atomic**: the new content is written to a sibling temp file, `fsync`'d, and renamed over the destination, so a concurrent reader (or a process that crashes mid-write) will always see either the previous content or the new content in full — never a partially written file. The parent directory is also `fsync`'d after the rename so the rename itself is durable.
 
 ## Welcome Message
 

--- a/examples/cached_responses.yaml
+++ b/examples/cached_responses.yaml
@@ -11,7 +11,10 @@
 #   - trim_spaces: when true, leading and trailing whitespace is ignored.
 #
 # Storage is in-memory by default. Set `path` to persist entries to a JSON
-# file that is reloaded on startup so the cache survives restarts.
+# file that is reloaded on startup so the cache survives restarts. Multiple
+# processes can safely share the same file: an advisory lock on
+# `<path>.lock` serializes writes, and Lookup reloads the in-memory map
+# when the file changes externally.
 
 agents:
   root:

--- a/examples/cached_responses.yaml
+++ b/examples/cached_responses.yaml
@@ -1,0 +1,27 @@
+#!/usr/bin/env docker agent run
+
+# Demonstrates the response cache.
+#
+# The first time a question is asked, the agent calls the model normally and
+# stores the answer. The second time the same question is asked, the answer is
+# replayed verbatim and the model is not invoked at all.
+#
+# Two normalization options control what "same question" means:
+#   - case_sensitive: when false (the default), "Hello" and "hello" match.
+#   - trim_spaces: when true, leading and trailing whitespace is ignored.
+#
+# Storage is in-memory by default. Set `path` to persist entries to a JSON
+# file that is reloaded on startup so the cache survives restarts.
+
+agents:
+  root:
+    model: openai/gpt-5-mini
+    description: A helpful AI assistant with a response cache
+    instruction: |
+      You are a knowledgeable assistant that helps users with various tasks.
+      Be helpful, accurate, and concise in your responses.
+    cache:
+      enabled: true
+      case_sensitive: false  # "Hello" == "hello"
+      trim_spaces: true      # "  hello  " == "hello"
+      path: ./cache.json     # remove this line to keep the cache in memory only

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -42,7 +42,7 @@ type Agent struct {
 	tools                   []tools.Tool
 	commands                types.Commands
 	hooks                   *latest.HooksConfig
-	cache                   cache.Cache
+	cache                   *cache.Cache
 
 	// warningsMu guards pendingWarnings. addToolWarning and DrainWarnings
 	// may be called concurrently from the runtime loop, the MCP server,
@@ -258,7 +258,7 @@ func (a *Agent) Hooks() *latest.HooksConfig {
 
 // Cache returns the response cache configured for this agent, or nil when
 // caching is disabled.
-func (a *Agent) Cache() cache.Cache {
+func (a *Agent) Cache() *cache.Cache {
 	return a.cache
 }
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/docker/docker-agent/pkg/cache"
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/config/types"
 	"github.com/docker/docker-agent/pkg/model/provider"
@@ -41,6 +42,7 @@ type Agent struct {
 	tools                   []tools.Tool
 	commands                types.Commands
 	hooks                   *latest.HooksConfig
+	cache                   cache.Cache
 
 	// warningsMu guards pendingWarnings. addToolWarning and DrainWarnings
 	// may be called concurrently from the runtime loop, the MCP server,
@@ -252,6 +254,12 @@ func (a *Agent) Commands() types.Commands {
 // Hooks returns the hooks configuration for this agent.
 func (a *Agent) Hooks() *latest.HooksConfig {
 	return a.hooks
+}
+
+// Cache returns the response cache configured for this agent, or nil when
+// caching is disabled.
+func (a *Agent) Cache() cache.Cache {
+	return a.cache
 }
 
 // Tools returns the tools available to this agent

--- a/pkg/agent/opts.go
+++ b/pkg/agent/opts.go
@@ -175,7 +175,7 @@ func WithHooks(hooks *latest.HooksConfig) Opt {
 }
 
 // WithCache attaches a response cache to the agent. Pass nil to disable.
-func WithCache(c cache.Cache) Opt {
+func WithCache(c *cache.Cache) Opt {
 	return func(a *Agent) {
 		a.cache = c
 	}

--- a/pkg/agent/opts.go
+++ b/pkg/agent/opts.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"time"
 
+	"github.com/docker/docker-agent/pkg/cache"
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/config/types"
 	"github.com/docker/docker-agent/pkg/model/provider"
@@ -170,5 +171,12 @@ func WithLoadTimeWarnings(warnings []string) Opt {
 func WithHooks(hooks *latest.HooksConfig) Opt {
 	return func(a *Agent) {
 		a.hooks = hooks
+	}
+}
+
+// WithCache attaches a response cache to the agent. Pass nil to disable.
+func WithCache(c cache.Cache) Opt {
+	return func(a *Agent) {
+		a.cache = c
 	}
 }

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -121,14 +121,10 @@ func (c *cache) Store(question, response string) {
 	key := c.normalize(question)
 
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.entries[key] = response
-	var snapshot map[string]string
 	if c.persist != nil {
-		snapshot = maps.Clone(c.entries)
-	}
-	c.mu.Unlock()
-
-	if c.persist != nil {
+		snapshot := maps.Clone(c.entries)
 		c.persist(snapshot)
 	}
 }
@@ -220,6 +216,6 @@ func syncDir(dir string) {
 	if err != nil {
 		return
 	}
+	defer d.Close()
 	_ = d.Sync()
-	_ = d.Close()
 }

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -10,11 +10,18 @@
 //   - an in-memory map (the default), which keeps entries for the lifetime of
 //     the process;
 //   - a JSON-file backed store, which persists entries to disk so they
-//     survive restarts. Writes to the JSON file are atomic: the file is
-//     written to a sibling temp file, fsync'd, and renamed over the
-//     destination, so a concurrent reader (or a process that crashes
-//     mid-write) will always see either the previous content or the new
-//     content in full — never a partially written file.
+//     survive restarts.
+//
+// File-backed caches are concurrent-write-safe across processes. Every
+// [Cache.Store] takes an exclusive advisory lock on a sibling
+// `<path>.lock` file (POSIX flock / Windows LockFileEx), reloads the
+// current on-disk state under the lock, merges its entry, and writes
+// back atomically via a temp file + rename. Two processes simultaneously
+// caching different keys both see their writes preserved; the lock
+// serializes the read-modify-write window so neither can clobber the
+// other. [Cache.Lookup] reloads the in-memory map when the file's mtime
+// has advanced since its last load, so cross-process writes become
+// visible without a restart.
 //
 // Two normalization options are exposed:
 //
@@ -28,11 +35,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"maps"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 )
 
 // Config describes how a Cache should normalize keys and where it should
@@ -57,17 +65,20 @@ type Config struct {
 }
 
 // Cache stores agent responses keyed on the user's question. It is safe
-// for concurrent use by multiple goroutines.
-//
-// When the underlying [Config] sets Path, every Store mirrors the
-// in-memory state to a JSON file via an atomic temp-file + rename so
-// concurrent readers (and a process that crashes mid-write) only ever
-// see a fully written file.
+// for concurrent use by multiple goroutines, and — when configured with
+// a Path — by multiple processes (see the package doc).
 type Cache struct {
 	mu        sync.RWMutex
 	entries   map[string]string
 	normalize func(string) string
-	persist   func(map[string]string)
+
+	// path is the JSON file backing this cache, empty for in-memory only.
+	path string
+
+	// mtime is the file mtime at our last load. Lookup compares it
+	// against the current file mtime to decide whether to reload, so
+	// writes from a sibling process become visible without a restart.
+	mtime time.Time
 }
 
 // New builds a Cache from the given Config. It returns (nil, nil) when
@@ -81,18 +92,15 @@ func New(cfg Config) (*Cache, error) {
 	c := &Cache{
 		entries:   make(map[string]string),
 		normalize: keyNormalizer(cfg.CaseSensitive, cfg.TrimSpaces),
+		path:      cfg.Path,
 	}
 
 	if cfg.Path != "" {
 		if err := loadFromFile(cfg.Path, c.entries); err != nil {
 			return nil, err
 		}
-		path := cfg.Path
-		c.persist = func(snapshot map[string]string) {
-			// Persistence failures must not break a successful agent
-			// turn — entries remain available from memory and the next
-			// Store will retry the file write.
-			_ = writeJSON(path, snapshot)
+		if info, err := os.Stat(cfg.Path); err == nil {
+			c.mtime = info.ModTime()
 		}
 	}
 
@@ -101,7 +109,14 @@ func New(cfg Config) (*Cache, error) {
 
 // Lookup returns the stored response for the given question and a
 // boolean indicating whether the question was found.
+//
+// When the cache is file-backed and the file has been modified since
+// our last load (typically by another process), the in-memory state is
+// reloaded before the lookup so cross-process writes are visible.
 func (c *Cache) Lookup(question string) (string, bool) {
+	if c.path != "" {
+		c.maybeReload()
+	}
 	key := c.normalize(question)
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -110,32 +125,78 @@ func (c *Cache) Lookup(question string) (string, bool) {
 }
 
 // Store records the response for the given question, replacing any
-// existing entry with the same normalized key. When the cache is
-// file-backed, the snapshot is also flushed to disk before Store
-// returns. Storing the same (question, response) pair twice is a no-op
-// and skips the file rewrite — useful when an agent's stop hook re-fires
-// with the same content (e.g. on a cache-replay turn).
+// existing entry with the same normalized key. Storing the same
+// (question, response) pair twice is a no-op and skips the file
+// rewrite — useful when an agent's stop hook re-fires with the same
+// content (e.g. a cache-replay turn).
 //
-// Store deliberately holds the write lock across the persist callback.
-// Releasing the lock between cloning the snapshot and writing it would
-// allow two concurrent stores S1 and S2 to take their snapshots in
-// order S1→S2 but persist them out-of-order S2→S1, which would
-// overwrite the on-disk file with S1's stale snapshot and silently lose
-// S2's entry on the next process restart. The lock window is short
-// (one fsync + rename + dir fsync) and concurrent Lookup callers are
-// blocked only for the duration of that single write.
+// When the cache is file-backed, the operation is serialized across
+// processes via an advisory lock on a sibling .lock file: we take the
+// lock, reload the on-disk state, merge our entry, write atomically
+// (temp file + fsync + rename), and release. This guarantees that two
+// processes simultaneously storing different keys both see their
+// writes preserved on disk; in-process callers serialize via c.mu.
 func (c *Cache) Store(question, response string) {
 	key := c.normalize(question)
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	// Cheap in-memory dedup: skip the cross-process lock and disk
+	// write when our local view already matches. After a recent
+	// Lookup our view is fresh, so this catches the common
+	// "store the answer we just replayed" path of cache_response.
 	if existing, ok := c.entries[key]; ok && existing == response {
 		return
 	}
-	c.entries[key] = response
-	if c.persist != nil {
-		c.persist(maps.Clone(c.entries))
+
+	if c.path != "" {
+		if mtime, err := persistEntry(c.path, key, response); err != nil {
+			// Persistence failures are not fatal: keep the entry
+			// in memory and let the next Store retry the file
+			// write.
+			slog.Warn("cache persist failed; keeping entry in memory only",
+				"path", c.path, "error", err)
+		} else if !mtime.IsZero() {
+			c.mtime = mtime
+		}
 	}
+
+	c.entries[key] = response
+}
+
+// maybeReload reloads c.entries from disk when the file mtime has
+// advanced since our last load. Called from Lookup. Safe to no-op
+// when the file doesn't exist or can't be stat'd (the in-memory
+// state is preserved).
+func (c *Cache) maybeReload() {
+	info, err := os.Stat(c.path)
+	if err != nil {
+		return
+	}
+
+	c.mu.RLock()
+	upToDate := info.ModTime().Equal(c.mtime)
+	c.mu.RUnlock()
+	if upToDate {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Re-check under the write lock: another goroutine may have just
+	// reloaded us.
+	if info.ModTime().Equal(c.mtime) {
+		return
+	}
+	fresh := make(map[string]string)
+	if err := loadFromFile(c.path, fresh); err != nil {
+		slog.Warn("cache reload failed; keeping in-memory state",
+			"path", c.path, "error", err)
+		return
+	}
+	c.entries = fresh
+	c.mtime = info.ModTime()
 }
 
 // keyNormalizer returns a function that applies the configured
@@ -173,6 +234,83 @@ func loadFromFile(path string, entries map[string]string) error {
 		return fmt.Errorf("loading cache file %q: %w", path, err)
 	}
 	return nil
+}
+
+// persistEntry takes a cross-process advisory lock on path's sibling
+// .lock file, reloads the on-disk entries, merges (key, response),
+// and atomically writes the result. It returns the file mtime after
+// writing (zero on error), used by callers to track external changes.
+//
+// Skips the write — and returns the unchanged mtime — when the on-disk
+// state already has key → response, keeping cross-process replays free
+// of redundant disk traffic.
+func persistEntry(path, key, response string) (time.Time, error) {
+	lock, err := acquireFileLock(path)
+	if err != nil {
+		return time.Time{}, err
+	}
+	defer lock.release()
+
+	entries := make(map[string]string)
+	if err := loadFromFile(path, entries); err != nil {
+		return time.Time{}, err
+	}
+
+	if existing, ok := entries[key]; ok && existing == response {
+		if info, err := os.Stat(path); err == nil {
+			return info.ModTime(), nil
+		}
+		return time.Time{}, nil
+	}
+
+	entries[key] = response
+	if err := writeJSON(path, entries); err != nil {
+		return time.Time{}, err
+	}
+
+	if info, err := os.Stat(path); err == nil {
+		return info.ModTime(), nil
+	}
+	return time.Time{}, nil
+}
+
+// fileLock is the handle returned by acquireFileLock. Call release when
+// done — typically as a deferred call in the same function that
+// acquired the lock.
+type fileLock struct {
+	f *os.File
+}
+
+// acquireFileLock opens (creating if needed) "<path>.lock" and takes an
+// exclusive advisory lock on it. The lock is released by calling
+// release on the returned handle. The lock file itself is intentionally
+// never renamed or deleted: doing so would let two processes lock
+// different inodes for the same logical resource and lose mutual
+// exclusion.
+func acquireFileLock(path string) (*fileLock, error) {
+	lockPath := path + ".lock"
+	if dir := filepath.Dir(lockPath); dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, fmt.Errorf("creating lock directory %q: %w", dir, err)
+		}
+	}
+	f, err := os.OpenFile(lockPath, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("opening lock file %q: %w", lockPath, err)
+	}
+	if err := lockExclusive(f); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("locking %q: %w", lockPath, err)
+	}
+	return &fileLock{f: f}, nil
+}
+
+// release unlocks and closes the lock file. Errors are ignored: the OS
+// will release the lock when the descriptor is closed regardless, and a
+// failure to close at this point can't usefully be propagated.
+func (l *fileLock) release() {
+	_ = unlockFile(l.f)
+	_ = l.f.Close()
 }
 
 // writeJSON atomically writes entries to path as pretty-printed JSON.

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -99,9 +99,7 @@ func New(cfg Config) (*Cache, error) {
 		if err := loadFromFile(cfg.Path, c.entries); err != nil {
 			return nil, err
 		}
-		if info, err := os.Stat(cfg.Path); err == nil {
-			c.mtime = info.ModTime()
-		}
+		c.mtime = mtimeOf(cfg.Path)
 	}
 
 	return c, nil
@@ -114,9 +112,7 @@ func New(cfg Config) (*Cache, error) {
 // our last load (typically by another process), the in-memory state is
 // reloaded before the lookup so cross-process writes are visible.
 func (c *Cache) Lookup(question string) (string, bool) {
-	if c.path != "" {
-		c.maybeReload()
-	}
+	c.maybeReload()
 	key := c.normalize(question)
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -151,25 +147,58 @@ func (c *Cache) Store(question, response string) {
 	}
 
 	if c.path != "" {
-		if mtime, err := persistEntry(c.path, key, response); err != nil {
+		if err := c.persistToDisk(key, response); err != nil {
 			// Persistence failures are not fatal: keep the entry
 			// in memory and let the next Store retry the file
 			// write.
 			slog.Warn("cache persist failed; keeping entry in memory only",
 				"path", c.path, "error", err)
-		} else if !mtime.IsZero() {
-			c.mtime = mtime
 		}
 	}
 
 	c.entries[key] = response
 }
 
+// persistToDisk takes the cross-process lock on c.path's sibling .lock
+// file, reloads the on-disk entries, merges (key, response), writes
+// atomically, and refreshes c.mtime. The caller must hold c.mu.
+//
+// Skips the write — but still refreshes c.mtime — when the on-disk
+// state already has key → response, which keeps cross-process replays
+// free of redundant disk traffic.
+func (c *Cache) persistToDisk(key, response string) error {
+	unlock, err := lockFile(c.path)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	entries := make(map[string]string)
+	if err := loadFromFile(c.path, entries); err != nil {
+		return err
+	}
+
+	if existing, ok := entries[key]; ok && existing == response {
+		c.mtime = mtimeOf(c.path)
+		return nil
+	}
+
+	entries[key] = response
+	if err := writeJSON(c.path, entries); err != nil {
+		return err
+	}
+	c.mtime = mtimeOf(c.path)
+	return nil
+}
+
 // maybeReload reloads c.entries from disk when the file mtime has
-// advanced since our last load. Called from Lookup. Safe to no-op
-// when the file doesn't exist or can't be stat'd (the in-memory
+// advanced since our last load. Called from Lookup; a no-op when the
+// cache is in-memory only or when the file can't be stat'd (in-memory
 // state is preserved).
 func (c *Cache) maybeReload() {
+	if c.path == "" {
+		return
+	}
 	info, err := os.Stat(c.path)
 	if err != nil {
 		return
@@ -236,58 +265,25 @@ func loadFromFile(path string, entries map[string]string) error {
 	return nil
 }
 
-// persistEntry takes a cross-process advisory lock on path's sibling
-// .lock file, reloads the on-disk entries, merges (key, response),
-// and atomically writes the result. It returns the file mtime after
-// writing (zero on error), used by callers to track external changes.
-//
-// Skips the write — and returns the unchanged mtime — when the on-disk
-// state already has key → response, keeping cross-process replays free
-// of redundant disk traffic.
-func persistEntry(path, key, response string) (time.Time, error) {
-	lock, err := acquireFileLock(path)
-	if err != nil {
-		return time.Time{}, err
-	}
-	defer lock.release()
-
-	entries := make(map[string]string)
-	if err := loadFromFile(path, entries); err != nil {
-		return time.Time{}, err
-	}
-
-	if existing, ok := entries[key]; ok && existing == response {
-		if info, err := os.Stat(path); err == nil {
-			return info.ModTime(), nil
-		}
-		return time.Time{}, nil
-	}
-
-	entries[key] = response
-	if err := writeJSON(path, entries); err != nil {
-		return time.Time{}, err
-	}
-
+// mtimeOf returns the file modification time at path, or the zero value
+// if path doesn't exist or can't be stat'd. The zero value is safe to
+// compare via [time.Time.Equal] in [Cache.maybeReload].
+func mtimeOf(path string) time.Time {
 	if info, err := os.Stat(path); err == nil {
-		return info.ModTime(), nil
+		return info.ModTime()
 	}
-	return time.Time{}, nil
+	return time.Time{}
 }
 
-// fileLock is the handle returned by acquireFileLock. Call release when
-// done — typically as a deferred call in the same function that
-// acquired the lock.
-type fileLock struct {
-	f *os.File
-}
-
-// acquireFileLock opens (creating if needed) "<path>.lock" and takes an
-// exclusive advisory lock on it. The lock is released by calling
-// release on the returned handle. The lock file itself is intentionally
-// never renamed or deleted: doing so would let two processes lock
-// different inodes for the same logical resource and lose mutual
-// exclusion.
-func acquireFileLock(path string) (*fileLock, error) {
+// lockFile takes an exclusive advisory lock on "<path>.lock", creating
+// the lock file (and any missing parent directory) if needed. The
+// returned closure releases the lock and closes the descriptor; defer
+// it in the caller.
+//
+// The lock file is intentionally never renamed or deleted: doing so
+// would let two processes lock different inodes for the same logical
+// resource and lose mutual exclusion. It's a long-lived sentinel.
+func lockFile(path string) (func(), error) {
 	lockPath := path + ".lock"
 	if dir := filepath.Dir(lockPath); dir != "" {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -302,15 +298,13 @@ func acquireFileLock(path string) (*fileLock, error) {
 		f.Close()
 		return nil, fmt.Errorf("locking %q: %w", lockPath, err)
 	}
-	return &fileLock{f: f}, nil
-}
-
-// release unlocks and closes the lock file. Errors are ignored: the OS
-// will release the lock when the descriptor is closed regardless, and a
-// failure to close at this point can't usefully be propagated.
-func (l *fileLock) release() {
-	_ = unlockFile(l.f)
-	_ = l.f.Close()
+	// Errors in the release path are ignored: the OS will release the
+	// lock when the descriptor is closed regardless, and a failure to
+	// close at this point can't usefully be propagated.
+	return func() {
+		_ = unlockFile(f)
+		_ = f.Close()
+	}, nil
 }
 
 // writeJSON atomically writes entries to path as pretty-printed JSON.

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -77,16 +77,60 @@ func New(cfg Config) (Cache, error) {
 		return nil, nil //nolint:nilnil // intentional: nil signals caching disabled
 	}
 
-	normalize := keyNormalizer(cfg.CaseSensitive, cfg.TrimSpaces)
-
-	if cfg.Path == "" {
-		return &memoryCache{
-			entries:   make(map[string]string),
-			normalize: normalize,
-		}, nil
+	c := &cache{
+		entries:   make(map[string]string),
+		normalize: keyNormalizer(cfg.CaseSensitive, cfg.TrimSpaces),
 	}
 
-	return newFileCache(cfg.Path, normalize)
+	if cfg.Path != "" {
+		if err := loadFromFile(cfg.Path, c.entries); err != nil {
+			return nil, err
+		}
+		path := cfg.Path
+		c.persist = func(snapshot map[string]string) {
+			// Persistence failures must not break a successful agent
+			// turn — entries remain available from memory and the next
+			// Store will retry the file write.
+			_ = writeJSON(path, snapshot)
+		}
+	}
+
+	return c, nil
+}
+
+// cache is a single in-memory store. When persist is non-nil it is also
+// invoked with a snapshot after every Store to mirror entries to durable
+// storage; that keeps the in-memory and on-disk implementations as one
+// piece of code with one extra optional callback.
+type cache struct {
+	mu        sync.RWMutex
+	entries   map[string]string
+	normalize func(string) string
+	persist   func(map[string]string)
+}
+
+func (c *cache) Lookup(question string) (string, bool) {
+	key := c.normalize(question)
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	resp, ok := c.entries[key]
+	return resp, ok
+}
+
+func (c *cache) Store(question, response string) {
+	key := c.normalize(question)
+
+	c.mu.Lock()
+	c.entries[key] = response
+	var snapshot map[string]string
+	if c.persist != nil {
+		snapshot = maps.Clone(c.entries)
+	}
+	c.mu.Unlock()
+
+	if c.persist != nil {
+		c.persist(snapshot)
+	}
 }
 
 // keyNormalizer returns a function that applies the configured
@@ -103,102 +147,36 @@ func keyNormalizer(caseSensitive, trimSpaces bool) func(string) string {
 	}
 }
 
-// memoryCache is the default in-memory cache implementation.
-type memoryCache struct {
-	mu        sync.RWMutex
-	entries   map[string]string
-	normalize func(string) string
-}
-
-func (c *memoryCache) Lookup(question string) (string, bool) {
-	key := c.normalize(question)
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	resp, ok := c.entries[key]
-	return resp, ok
-}
-
-func (c *memoryCache) Store(question, response string) {
-	key := c.normalize(question)
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.entries[key] = response
-}
-
-// fileCache wraps memoryCache and persists every Store to a JSON file.
-type fileCache struct {
-	mu        sync.RWMutex
-	path      string
-	entries   map[string]string
-	normalize func(string) string
-}
-
-func newFileCache(path string, normalize func(string) string) (*fileCache, error) {
-	c := &fileCache{
-		path:      path,
-		entries:   make(map[string]string),
-		normalize: normalize,
-	}
-
+// loadFromFile decodes path into entries. A missing file is not an error
+// and leaves entries empty.
+func loadFromFile(path string, entries map[string]string) error {
 	data, err := os.ReadFile(path)
 	switch {
-	case err == nil:
-		if len(data) > 0 {
-			if err := json.Unmarshal(data, &c.entries); err != nil {
-				return nil, fmt.Errorf("loading cache file %q: %w", path, err)
-			}
-		}
 	case errors.Is(err, os.ErrNotExist):
-		// First run: starting with an empty cache is fine.
-	default:
-		return nil, fmt.Errorf("reading cache file %q: %w", path, err)
+		return nil
+	case err != nil:
+		return fmt.Errorf("reading cache file %q: %w", path, err)
 	}
-
-	return c, nil
-}
-
-func (c *fileCache) Lookup(question string) (string, bool) {
-	key := c.normalize(question)
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	resp, ok := c.entries[key]
-	return resp, ok
-}
-
-func (c *fileCache) Store(question, response string) {
-	key := c.normalize(question)
-	c.mu.Lock()
-	c.entries[key] = response
-	snapshot := make(map[string]string, len(c.entries))
-	maps.Copy(snapshot, c.entries)
-	path := c.path
-	c.mu.Unlock()
-
-	if err := writeJSON(path, snapshot); err != nil {
-		// We deliberately swallow the error here: a transient write
-		// failure should not break a successful agent turn. The cache
-		// will still serve from memory and try to persist again on the
-		// next Store.
-		_ = err
+	if len(data) == 0 {
+		return nil
 	}
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return fmt.Errorf("loading cache file %q: %w", path, err)
+	}
+	return nil
 }
 
-// writeJSON atomically writes the given map to path as pretty-printed JSON.
+// writeJSON atomically writes entries to path as pretty-printed JSON.
 //
-// Atomicity is achieved by writing to a temporary file in the same
-// directory and then renaming it over the destination: POSIX guarantees
-// concurrent readers see either the old file or the new file in full,
-// never a partially written one.
-//
-// Durability across an OS crash or power loss is achieved by fsync'ing
-// the temp file before the rename and fsync'ing the parent directory
-// after, so the rename itself is persisted.
+// The new content is written to a sibling temp file, fsync'd, and renamed
+// over the destination. POSIX guarantees the rename is atomic, so a
+// concurrent reader sees either the previous content or the new content
+// in full — never a partial write. The parent directory is fsync'd
+// after the rename so the rename itself is durable across an OS crash.
 func writeJSON(path string, entries map[string]string) error {
 	dir := filepath.Dir(path)
-	if dir != "" && dir != "." {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			return fmt.Errorf("creating cache directory %q: %w", dir, err)
-		}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("creating cache directory %q: %w", dir, err)
 	}
 
 	data, err := json.MarshalIndent(entries, "", "  ")
@@ -211,18 +189,13 @@ func writeJSON(path string, entries map[string]string) error {
 		return fmt.Errorf("creating temp cache file: %w", err)
 	}
 	tmpName := tmp.Name()
-	// If anything below fails, make sure the temp file is cleaned up.
-	// On the success path the rename moves it away and Remove becomes a
-	// harmless no-op.
+	// Cleanup on any error path; harmless once Rename has moved the file.
 	defer os.Remove(tmpName)
 
 	if _, err := tmp.Write(data); err != nil {
 		tmp.Close()
 		return fmt.Errorf("writing temp cache file: %w", err)
 	}
-	// fsync the file contents to disk before the rename so a crash
-	// between rename and flush cannot leave the destination pointing at
-	// a zero-length file.
 	if err := tmp.Sync(); err != nil {
 		tmp.Close()
 		return fmt.Errorf("syncing temp cache file: %w", err)
@@ -235,15 +208,18 @@ func writeJSON(path string, entries map[string]string) error {
 		return fmt.Errorf("renaming cache file: %w", err)
 	}
 
-	// fsync the parent directory so the rename itself is durable.
-	// Best-effort: directory fsync is not supported on every platform
-	// (e.g. Windows), and a failure here does not invalidate the data
-	// already written to disk.
-	if dirName := dir; dirName != "" {
-		if d, err := os.Open(dirName); err == nil {
-			_ = d.Sync()
-			_ = d.Close()
-		}
-	}
+	syncDir(dir)
 	return nil
+}
+
+// syncDir best-effort fsyncs a directory so a recent rename inside it is
+// persisted. Directory fsync is not portable (e.g. unsupported on
+// Windows); a failure here does not invalidate the data.
+func syncDir(dir string) {
+	d, err := os.Open(dir)
+	if err != nil {
+		return
+	}
+	_ = d.Sync()
+	_ = d.Close()
 }

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -56,28 +56,29 @@ type Config struct {
 	Path string `json:"path,omitempty" yaml:"path,omitempty"`
 }
 
-// Cache stores agent responses keyed on the user's question.
+// Cache stores agent responses keyed on the user's question. It is safe
+// for concurrent use by multiple goroutines.
 //
-// Implementations must be safe for concurrent use.
-type Cache interface {
-	// Lookup returns the stored response for the given question and a
-	// boolean indicating whether the question was found.
-	Lookup(question string) (string, bool)
-
-	// Store records the response for the given question, replacing any
-	// existing entry with the same normalized key.
-	Store(question, response string)
+// When the underlying [Config] sets Path, every Store mirrors the
+// in-memory state to a JSON file via an atomic temp-file + rename so
+// concurrent readers (and a process that crashes mid-write) only ever
+// see a fully written file.
+type Cache struct {
+	mu        sync.RWMutex
+	entries   map[string]string
+	normalize func(string) string
+	persist   func(map[string]string)
 }
 
 // New builds a Cache from the given Config. It returns (nil, nil) when
 // caching is disabled, allowing callers to short-circuit with a simple
 // nil check.
-func New(cfg Config) (Cache, error) {
+func New(cfg Config) (*Cache, error) {
 	if !cfg.Enabled {
 		return nil, nil //nolint:nilnil // intentional: nil signals caching disabled
 	}
 
-	c := &cache{
+	c := &Cache{
 		entries:   make(map[string]string),
 		normalize: keyNormalizer(cfg.CaseSensitive, cfg.TrimSpaces),
 	}
@@ -98,18 +99,9 @@ func New(cfg Config) (Cache, error) {
 	return c, nil
 }
 
-// cache is a single in-memory store. When persist is non-nil it is also
-// invoked with a snapshot after every Store to mirror entries to durable
-// storage; that keeps the in-memory and on-disk implementations as one
-// piece of code with one extra optional callback.
-type cache struct {
-	mu        sync.RWMutex
-	entries   map[string]string
-	normalize func(string) string
-	persist   func(map[string]string)
-}
-
-func (c *cache) Lookup(question string) (string, bool) {
+// Lookup returns the stored response for the given question and a
+// boolean indicating whether the question was found.
+func (c *Cache) Lookup(question string) (string, bool) {
 	key := c.normalize(question)
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -117,15 +109,23 @@ func (c *cache) Lookup(question string) (string, bool) {
 	return resp, ok
 }
 
-func (c *cache) Store(question, response string) {
+// Store records the response for the given question, replacing any
+// existing entry with the same normalized key. When the cache is
+// file-backed, the snapshot is also flushed to disk before Store
+// returns. Storing the same (question, response) pair twice is a no-op
+// and skips the file rewrite — useful when an agent's stop hook re-fires
+// with the same content (e.g. on a cache-replay turn).
+func (c *Cache) Store(question, response string) {
 	key := c.normalize(question)
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if existing, ok := c.entries[key]; ok && existing == response {
+		return
+	}
 	c.entries[key] = response
 	if c.persist != nil {
-		snapshot := maps.Clone(c.entries)
-		c.persist(snapshot)
+		c.persist(maps.Clone(c.entries))
 	}
 }
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -115,6 +115,15 @@ func (c *Cache) Lookup(question string) (string, bool) {
 // returns. Storing the same (question, response) pair twice is a no-op
 // and skips the file rewrite — useful when an agent's stop hook re-fires
 // with the same content (e.g. on a cache-replay turn).
+//
+// Store deliberately holds the write lock across the persist callback.
+// Releasing the lock between cloning the snapshot and writing it would
+// allow two concurrent stores S1 and S2 to take their snapshots in
+// order S1→S2 but persist them out-of-order S2→S1, which would
+// overwrite the on-disk file with S1's stale snapshot and silently lose
+// S2's entry on the next process restart. The lock window is short
+// (one fsync + rename + dir fsync) and concurrent Lookup callers are
+// blocked only for the duration of that single write.
 func (c *Cache) Store(question, response string) {
 	key := c.normalize(question)
 
@@ -131,6 +140,10 @@ func (c *Cache) Store(question, response string) {
 
 // keyNormalizer returns a function that applies the configured
 // normalization rules to a question before it is used as a cache key.
+// Trim runs before lowercase: trim only removes leading/trailing
+// whitespace and is unaffected by case, so the order is irrelevant for
+// correctness, but trim-first keeps the lowercased map keys tighter on
+// inputs like "  HELLO\n".
 func keyNormalizer(caseSensitive, trimSpaces bool) func(string) string {
 	return func(s string) string {
 		if trimSpaces {

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1,0 +1,214 @@
+// Package cache implements a configurable response cache for agents.
+//
+// The cache maps a normalized user question to a previously produced agent
+// response so that asking the exact same (according to the configured
+// normalization rules) question again returns the same answer without
+// invoking the model.
+//
+// Two storage backends are supported:
+//
+//   - an in-memory map (the default), which keeps entries for the lifetime of
+//     the process;
+//   - a JSON-file backed store, which persists entries to disk so they
+//     survive restarts.
+//
+// Two normalization options are exposed:
+//
+//   - case sensitivity: when disabled (the default), questions are
+//     compared case-insensitively;
+//   - blank trimming: when enabled, leading and trailing whitespace is
+//     stripped before comparison.
+package cache
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// Config describes how a Cache should normalize keys and where it should
+// store entries.
+type Config struct {
+	// Enabled toggles the cache on or off. When false, New returns nil.
+	Enabled bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+
+	// CaseSensitive controls whether the question matching is
+	// case-sensitive. The default (false) means "Hello" and "hello"
+	// are treated as the same question.
+	CaseSensitive bool `json:"case_sensitive,omitempty" yaml:"case_sensitive,omitempty"`
+
+	// TrimSpaces controls whether leading and trailing whitespace is
+	// removed from questions before they are compared. The default
+	// (false) preserves whitespace.
+	TrimSpaces bool `json:"trim_spaces,omitempty" yaml:"trim_spaces,omitempty"`
+
+	// Path, when non-empty, selects a JSON-file backed cache stored at
+	// the given path. When empty, the cache lives only in memory.
+	Path string `json:"path,omitempty" yaml:"path,omitempty"`
+}
+
+// Cache stores agent responses keyed on the user's question.
+//
+// Implementations must be safe for concurrent use.
+type Cache interface {
+	// Lookup returns the stored response for the given question and a
+	// boolean indicating whether the question was found.
+	Lookup(question string) (string, bool)
+
+	// Store records the response for the given question, replacing any
+	// existing entry with the same normalized key.
+	Store(question, response string)
+}
+
+// New builds a Cache from the given Config. It returns (nil, nil) when
+// caching is disabled, allowing callers to short-circuit with a simple
+// nil check.
+func New(cfg Config) (Cache, error) {
+	if !cfg.Enabled {
+		return nil, nil //nolint:nilnil // intentional: nil signals caching disabled
+	}
+
+	normalize := keyNormalizer(cfg.CaseSensitive, cfg.TrimSpaces)
+
+	if cfg.Path == "" {
+		return &memoryCache{
+			entries:   make(map[string]string),
+			normalize: normalize,
+		}, nil
+	}
+
+	return newFileCache(cfg.Path, normalize)
+}
+
+// keyNormalizer returns a function that applies the configured
+// normalization rules to a question before it is used as a cache key.
+func keyNormalizer(caseSensitive, trimSpaces bool) func(string) string {
+	return func(s string) string {
+		if trimSpaces {
+			s = strings.TrimSpace(s)
+		}
+		if !caseSensitive {
+			s = strings.ToLower(s)
+		}
+		return s
+	}
+}
+
+// memoryCache is the default in-memory cache implementation.
+type memoryCache struct {
+	mu        sync.RWMutex
+	entries   map[string]string
+	normalize func(string) string
+}
+
+func (c *memoryCache) Lookup(question string) (string, bool) {
+	key := c.normalize(question)
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	resp, ok := c.entries[key]
+	return resp, ok
+}
+
+func (c *memoryCache) Store(question, response string) {
+	key := c.normalize(question)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[key] = response
+}
+
+// fileCache wraps memoryCache and persists every Store to a JSON file.
+type fileCache struct {
+	mu        sync.RWMutex
+	path      string
+	entries   map[string]string
+	normalize func(string) string
+}
+
+func newFileCache(path string, normalize func(string) string) (*fileCache, error) {
+	c := &fileCache{
+		path:      path,
+		entries:   make(map[string]string),
+		normalize: normalize,
+	}
+
+	data, err := os.ReadFile(path)
+	switch {
+	case err == nil:
+		if len(data) > 0 {
+			if err := json.Unmarshal(data, &c.entries); err != nil {
+				return nil, fmt.Errorf("loading cache file %q: %w", path, err)
+			}
+		}
+	case errors.Is(err, os.ErrNotExist):
+		// First run: starting with an empty cache is fine.
+	default:
+		return nil, fmt.Errorf("reading cache file %q: %w", path, err)
+	}
+
+	return c, nil
+}
+
+func (c *fileCache) Lookup(question string) (string, bool) {
+	key := c.normalize(question)
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	resp, ok := c.entries[key]
+	return resp, ok
+}
+
+func (c *fileCache) Store(question, response string) {
+	key := c.normalize(question)
+	c.mu.Lock()
+	c.entries[key] = response
+	snapshot := make(map[string]string, len(c.entries))
+	maps.Copy(snapshot, c.entries)
+	path := c.path
+	c.mu.Unlock()
+
+	if err := writeJSON(path, snapshot); err != nil {
+		// We deliberately swallow the error here: a transient write
+		// failure should not break a successful agent turn. The cache
+		// will still serve from memory and try to persist again on the
+		// next Store.
+		_ = err
+	}
+}
+
+// writeJSON atomically writes the given map to path as pretty-printed JSON.
+func writeJSON(path string, entries map[string]string) error {
+	if dir := filepath.Dir(path); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("creating cache directory %q: %w", dir, err)
+		}
+	}
+
+	data, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling cache: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".cache-*.json")
+	if err != nil {
+		return fmt.Errorf("creating temp cache file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("writing temp cache file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing temp cache file: %w", err)
+	}
+
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("renaming cache file: %w", err)
+	}
+	return nil
+}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -10,7 +10,11 @@
 //   - an in-memory map (the default), which keeps entries for the lifetime of
 //     the process;
 //   - a JSON-file backed store, which persists entries to disk so they
-//     survive restarts.
+//     survive restarts. Writes to the JSON file are atomic: the file is
+//     written to a sibling temp file, fsync'd, and renamed over the
+//     destination, so a concurrent reader (or a process that crashes
+//     mid-write) will always see either the previous content or the new
+//     content in full — never a partially written file.
 //
 // Two normalization options are exposed:
 //
@@ -180,8 +184,18 @@ func (c *fileCache) Store(question, response string) {
 }
 
 // writeJSON atomically writes the given map to path as pretty-printed JSON.
+//
+// Atomicity is achieved by writing to a temporary file in the same
+// directory and then renaming it over the destination: POSIX guarantees
+// concurrent readers see either the old file or the new file in full,
+// never a partially written one.
+//
+// Durability across an OS crash or power loss is achieved by fsync'ing
+// the temp file before the rename and fsync'ing the parent directory
+// after, so the rename itself is persisted.
 func writeJSON(path string, entries map[string]string) error {
-	if dir := filepath.Dir(path); dir != "" && dir != "." {
+	dir := filepath.Dir(path)
+	if dir != "" && dir != "." {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			return fmt.Errorf("creating cache directory %q: %w", dir, err)
 		}
@@ -192,16 +206,26 @@ func writeJSON(path string, entries map[string]string) error {
 		return fmt.Errorf("marshaling cache: %w", err)
 	}
 
-	tmp, err := os.CreateTemp(filepath.Dir(path), ".cache-*.json")
+	tmp, err := os.CreateTemp(dir, ".cache-*.json")
 	if err != nil {
 		return fmt.Errorf("creating temp cache file: %w", err)
 	}
 	tmpName := tmp.Name()
+	// If anything below fails, make sure the temp file is cleaned up.
+	// On the success path the rename moves it away and Remove becomes a
+	// harmless no-op.
 	defer os.Remove(tmpName)
 
 	if _, err := tmp.Write(data); err != nil {
 		tmp.Close()
 		return fmt.Errorf("writing temp cache file: %w", err)
+	}
+	// fsync the file contents to disk before the rename so a crash
+	// between rename and flush cannot leave the destination pointing at
+	// a zero-length file.
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("syncing temp cache file: %w", err)
 	}
 	if err := tmp.Close(); err != nil {
 		return fmt.Errorf("closing temp cache file: %w", err)
@@ -209,6 +233,17 @@ func writeJSON(path string, entries map[string]string) error {
 
 	if err := os.Rename(tmpName, path); err != nil {
 		return fmt.Errorf("renaming cache file: %w", err)
+	}
+
+	// fsync the parent directory so the rename itself is durable.
+	// Best-effort: directory fsync is not supported on every platform
+	// (e.g. Windows), and a failure here does not invalidate the data
+	// already written to disk.
+	if dirName := dir; dirName != "" {
+		if d, err := os.Open(dirName); err == nil {
+			_ = d.Sync()
+			_ = d.Close()
+		}
 	}
 	return nil
 }

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -156,6 +156,10 @@ func (c *Cache) Store(question, response string) {
 		}
 	}
 
+	// Update in-memory map after persist (not before) so that if persist
+	// fails, we still have the entry in memory for this process. The next
+	// Lookup will reload from disk if another process wrote successfully.
+
 	c.entries[key] = response
 }
 
@@ -194,7 +198,8 @@ func (c *Cache) persistToDisk(key, response string) error {
 // maybeReload reloads c.entries from disk when the file mtime has
 // advanced since our last load. Called from Lookup; a no-op when the
 // cache is in-memory only or when the file can't be stat'd (in-memory
-// state is preserved).
+// state is preserved). Re-stats the file under the write lock to avoid
+// TOCTOU races.
 func (c *Cache) maybeReload() {
 	if c.path == "" {
 		return
@@ -213,9 +218,14 @@ func (c *Cache) maybeReload() {
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	// Re-check under the write lock: another goroutine may have just
-	// reloaded us.
-	if info.ModTime().Equal(c.mtime) {
+	// Re-stat under the write lock to avoid TOCTOU: the file could have
+	// been modified between the initial stat and the lock acquisition.
+	// Using the stale info would risk storing a mtime that doesn't match
+	// the content we're about to load.
+	info, err = os.Stat(c.path)
+	if err != nil || info.ModTime().Equal(c.mtime) {
+		// File disappeared or another goroutine already reloaded to this
+		// mtime; nothing to do.
 		return
 	}
 	fresh := make(map[string]string)
@@ -266,8 +276,11 @@ func loadFromFile(path string, entries map[string]string) error {
 }
 
 // mtimeOf returns the file modification time at path, or the zero value
-// if path doesn't exist or can't be stat'd. The zero value is safe to
-// compare via [time.Time.Equal] in [Cache.maybeReload].
+// if path doesn't exist or can't be stat'd.
+//
+// The zero value (time.Time{}) is a sentinel meaning "file not found"
+// and is safe to compare via [time.Time.Equal] in [Cache.maybeReload]: it
+// will never equal a real mtime, so the reload will proceed as expected.
 func mtimeOf(path string) time.Time {
 	if info, err := os.Stat(path); err == nil {
 		return info.ModTime()

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -204,7 +205,8 @@ func TestFileCache_persistenceFailureKeepsInMemory(t *testing.T) {
 }
 
 // TestFileCache_atomicWriteLeavesNoTempFiles verifies that the rename-based
-// atomic write does not leak temporary files on the happy path.
+// atomic write does not leak temporary files on the happy path. Only the
+// JSON file and the persistent .lock sentinel are expected to remain.
 func TestFileCache_atomicWriteLeavesNoTempFiles(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "cache.json")
@@ -219,8 +221,12 @@ func TestFileCache_atomicWriteLeavesNoTempFiles(t *testing.T) {
 	entries, err := os.ReadDir(dir)
 	require.NoError(t, err)
 
+	expected := map[string]bool{
+		"cache.json":      true, // the data file
+		"cache.json.lock": true, // the cross-process advisory lock
+	}
 	for _, e := range entries {
-		assert.Equal(t, "cache.json", e.Name(),
+		assert.True(t, expected[e.Name()],
 			"unexpected leftover in cache directory: %q", e.Name())
 	}
 }
@@ -262,4 +268,108 @@ func TestFileCache_concurrentStoreNeverYieldsTornFile(t *testing.T) {
 	}
 
 	<-done
+}
+
+// TestFileCache_crossProcessConcurrentStoresPreserveAllEntries simulates
+// two independent processes (each with its own *Cache instance pointed
+// at the same path) racing to Store many distinct keys. The advisory
+// file lock taken by Cache.Store must serialize the read-modify-write
+// window so that — after both finish — the on-disk file contains every
+// entry written by either side. Without the lock, each side would read
+// a stale snapshot under its own mutex, and the last writer would
+// silently clobber the other's entries.
+func TestFileCache_crossProcessConcurrentStoresPreserveAllEntries(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cache.json")
+
+	cA, err := New(Config{Enabled: true, Path: path})
+	require.NoError(t, err)
+	cB, err := New(Config{Enabled: true, Path: path})
+	require.NoError(t, err)
+
+	const writesPerSide = 50
+	doneA := make(chan struct{})
+	doneB := make(chan struct{})
+
+	go func() {
+		defer close(doneA)
+		for i := range writesPerSide {
+			cA.Store(fmt.Sprintf("a%d", i), fmt.Sprintf("va%d", i))
+		}
+	}()
+	go func() {
+		defer close(doneB)
+		for i := range writesPerSide {
+			cB.Store(fmt.Sprintf("b%d", i), fmt.Sprintf("vb%d", i))
+		}
+	}()
+
+	<-doneA
+	<-doneB
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var onDisk map[string]string
+	require.NoError(t, json.Unmarshal(data, &onDisk))
+
+	assert.Lenf(t, onDisk, 2*writesPerSide,
+		"expected every key from both processes to be on disk; got %d", len(onDisk))
+	for i := range writesPerSide {
+		assert.Equal(t, fmt.Sprintf("va%d", i), onDisk[fmt.Sprintf("a%d", i)])
+		assert.Equal(t, fmt.Sprintf("vb%d", i), onDisk[fmt.Sprintf("b%d", i)])
+	}
+}
+
+// TestFileCache_lookupReloadsAfterExternalWrite verifies that a Cache
+// instance picks up entries written by another instance (read: another
+// process) without restart: when Lookup notices the file mtime has
+// advanced since the last load, it re-reads the file and the new entry
+// becomes visible.
+func TestFileCache_lookupReloadsAfterExternalWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cache.json")
+
+	reader, err := New(Config{Enabled: true, Path: path})
+	require.NoError(t, err)
+
+	// Initially nothing on disk; reader sees no entry.
+	_, ok := reader.Lookup("q")
+	require.False(t, ok)
+
+	writer, err := New(Config{Enabled: true, Path: path})
+	require.NoError(t, err)
+	writer.Store("q", "a")
+
+	// File mtime granularity on some filesystems (macOS HFS+ historically,
+	// some network FS) is 1 second. Bump the mtime explicitly so we don't
+	// false-pass on a coincidentally-equal timestamp. We use a future
+	// time so the reader's last-seen mtime is unambiguously older.
+	future := time.Now().Add(2 * time.Second)
+	require.NoError(t, os.Chtimes(path, future, future))
+
+	got, ok := reader.Lookup("q")
+	assert.True(t, ok, "reader must reload and see the entry written by the sibling instance")
+	assert.Equal(t, "a", got)
+}
+
+// TestFileCache_lockFileNeverDeleted asserts that the .lock sidecar is
+// not removed by Store, since deleting it could let two concurrent
+// processes lock different inodes and lose mutual exclusion. The lock
+// file is a long-lived sentinel.
+func TestFileCache_lockFileNeverDeleted(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cache.json")
+
+	c, err := New(Config{Enabled: true, Path: path})
+	require.NoError(t, err)
+
+	c.Store("q", "a")
+	info1, err := os.Stat(path + ".lock")
+	require.NoError(t, err, "lock file must exist after first Store")
+
+	c.Store("q2", "a2")
+	info2, err := os.Stat(path + ".lock")
+	require.NoError(t, err, "lock file must persist across Stores")
+	assert.Equal(t, info1.Sys(), info2.Sys(),
+		"lock file inode must be stable across Stores so flock semantics hold")
 }

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -81,6 +81,36 @@ func TestMemoryCache_overwrite(t *testing.T) {
 	assert.Equal(t, "second", got)
 }
 
+// TestFileCache_dedupSkipsRedundantWrite verifies that storing the exact
+// same (question, response) pair twice is treated as a no-op, so the
+// underlying JSON file is rewritten only on the first Store. This is
+// what keeps cache replays free of redundant disk traffic.
+func TestFileCache_dedupSkipsRedundantWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cache.json")
+
+	c, err := New(Config{Enabled: true, Path: path})
+	require.NoError(t, err)
+
+	c.Store("q", "a")
+	infoBefore, err := os.Stat(path)
+	require.NoError(t, err)
+
+	// Same pair: must not rewrite the file (mtime stays the same).
+	c.Store("q", "a")
+	infoAfter, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, infoBefore.ModTime(), infoAfter.ModTime(),
+		"identical Store must not rewrite the cache file")
+
+	// Different value: must rewrite.
+	c.Store("q", "b")
+	infoChanged, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.True(t, infoChanged.ModTime().After(infoBefore.ModTime()) || infoChanged.Size() != infoBefore.Size(),
+		"different Store must rewrite the cache file")
+}
+
 func TestFileCache_persists(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "cache.json")

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -164,6 +164,45 @@ func TestFileCache_corruptFile(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// TestFileCache_persistenceFailureKeepsInMemory verifies that a Store
+// whose underlying file write fails still updates the in-memory map: a
+// transient disk error must not break the running agent's turn, and a
+// subsequent Lookup must return the value the caller just wrote.
+//
+// We force a write failure by stripping write permission from the cache
+// directory after [New] returned. The persist callback (running inside
+// Store) tries os.CreateTemp in that directory and fails; the error is
+// swallowed and the cache keeps serving from memory.
+func TestFileCache_persistenceFailureKeepsInMemory(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: directory permissions are bypassed, can't force a write failure")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cache.json")
+
+	c, err := New(Config{Enabled: true, Path: path})
+	require.NoError(t, err)
+
+	// Strip write permission on the directory; restored before t.TempDir
+	// cleanup runs so the dir can be removed.
+	require.NoError(t, os.Chmod(dir, 0o500))
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	// Store must not panic or block on the underlying write failure.
+	c.Store("q", "a")
+
+	// In-memory state is intact even though the file write failed.
+	got, ok := c.Lookup("q")
+	assert.True(t, ok)
+	assert.Equal(t, "a", got)
+
+	// And the file was indeed never written.
+	_, err = os.Stat(path)
+	assert.ErrorIs(t, err, os.ErrNotExist,
+		"cache file must not exist when the parent directory is read-only")
+}
+
 // TestFileCache_atomicWriteLeavesNoTempFiles verifies that the rename-based
 // atomic write does not leak temporary files on the happy path.
 func TestFileCache_atomicWriteLeavesNoTempFiles(t *testing.T) {

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -2,6 +2,8 @@ package cache
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -130,4 +132,65 @@ func TestFileCache_corruptFile(t *testing.T) {
 
 	_, err := New(Config{Enabled: true, Path: path})
 	assert.Error(t, err)
+}
+
+// TestFileCache_atomicWriteLeavesNoTempFiles verifies that the rename-based
+// atomic write does not leak temporary files on the happy path.
+func TestFileCache_atomicWriteLeavesNoTempFiles(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cache.json")
+
+	c, err := New(Config{Enabled: true, Path: path})
+	require.NoError(t, err)
+
+	for i := range 5 {
+		c.Store(fmt.Sprintf("q%d", i), fmt.Sprintf("a%d", i))
+	}
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+
+	for _, e := range entries {
+		assert.Equal(t, "cache.json", e.Name(),
+			"unexpected leftover in cache directory: %q", e.Name())
+	}
+}
+
+// TestFileCache_concurrentStoreNeverYieldsTornFile verifies that concurrent
+// Store calls always leave a fully valid JSON file behind — i.e. a parallel
+// reader will never observe a half-written cache thanks to the
+// rename-over-temp atomicity.
+func TestFileCache_concurrentStoreNeverYieldsTornFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cache.json")
+
+	c, err := New(Config{Enabled: true, Path: path})
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := range 50 {
+			c.Store(fmt.Sprintf("q%d", i), fmt.Sprintf("a%d", i))
+		}
+	}()
+
+	// While writes are happening, repeatedly read and parse the file.
+	// Without atomic rename, this would intermittently see truncated /
+	// half-written content and json.Unmarshal would error.
+	for range 100 {
+		data, err := os.ReadFile(path)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		require.NoError(t, err)
+		if len(data) == 0 {
+			continue
+		}
+		var m map[string]string
+		require.NoError(t, json.Unmarshal(data, &m),
+			"reader observed a torn write: %q", string(data))
+	}
+
+	<-done
 }

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1,0 +1,133 @@
+package cache
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew_disabled(t *testing.T) {
+	c, err := New(Config{Enabled: false})
+	require.NoError(t, err)
+	assert.Nil(t, c)
+}
+
+func TestMemoryCache_caseSensitiveDefault(t *testing.T) {
+	c, err := New(Config{Enabled: true, CaseSensitive: true})
+	require.NoError(t, err)
+	require.NotNil(t, c)
+
+	c.Store("Hello", "world")
+
+	got, ok := c.Lookup("Hello")
+	assert.True(t, ok)
+	assert.Equal(t, "world", got)
+
+	_, ok = c.Lookup("hello")
+	assert.False(t, ok, "case-sensitive cache should not match different case")
+}
+
+func TestMemoryCache_caseInsensitive(t *testing.T) {
+	c, err := New(Config{Enabled: true, CaseSensitive: false})
+	require.NoError(t, err)
+
+	c.Store("Hello", "world")
+
+	got, ok := c.Lookup("HELLO")
+	assert.True(t, ok)
+	assert.Equal(t, "world", got)
+}
+
+func TestMemoryCache_trimSpaces(t *testing.T) {
+	c, err := New(Config{Enabled: true, TrimSpaces: true})
+	require.NoError(t, err)
+
+	c.Store("  hello  ", "world")
+
+	got, ok := c.Lookup("hello")
+	assert.True(t, ok)
+	assert.Equal(t, "world", got)
+
+	got, ok = c.Lookup("\thello\n")
+	assert.True(t, ok)
+	assert.Equal(t, "world", got)
+}
+
+func TestMemoryCache_noTrimByDefault(t *testing.T) {
+	c, err := New(Config{Enabled: true})
+	require.NoError(t, err)
+
+	c.Store("  hello  ", "world")
+
+	_, ok := c.Lookup("hello")
+	assert.False(t, ok, "without TrimSpaces, whitespace must be significant")
+}
+
+func TestMemoryCache_overwrite(t *testing.T) {
+	c, err := New(Config{Enabled: true})
+	require.NoError(t, err)
+
+	c.Store("q", "first")
+	c.Store("q", "second")
+
+	got, ok := c.Lookup("q")
+	assert.True(t, ok)
+	assert.Equal(t, "second", got)
+}
+
+func TestFileCache_persists(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cache.json")
+
+	c1, err := New(Config{Enabled: true, Path: path, CaseSensitive: false, TrimSpaces: true})
+	require.NoError(t, err)
+	c1.Store("  Hello  ", "world")
+
+	// File must exist on disk and contain the normalized key.
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var entries map[string]string
+	require.NoError(t, json.Unmarshal(data, &entries))
+	assert.Equal(t, map[string]string{"hello": "world"}, entries)
+
+	// A new cache loaded from the same file recovers the entries.
+	c2, err := New(Config{Enabled: true, Path: path, CaseSensitive: false, TrimSpaces: true})
+	require.NoError(t, err)
+	got, ok := c2.Lookup("HELLO")
+	assert.True(t, ok)
+	assert.Equal(t, "world", got)
+}
+
+func TestFileCache_missingFileIsFine(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "cache.json")
+
+	c, err := New(Config{Enabled: true, Path: path})
+	require.NoError(t, err)
+
+	_, ok := c.Lookup("anything")
+	assert.False(t, ok)
+
+	c.Store("hello", "world")
+
+	got, ok := c.Lookup("hello")
+	assert.True(t, ok)
+	assert.Equal(t, "world", got)
+
+	// And the directory should have been created.
+	_, err = os.Stat(path)
+	assert.NoError(t, err)
+}
+
+func TestFileCache_corruptFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cache.json")
+	require.NoError(t, os.WriteFile(path, []byte("not json"), 0o600))
+
+	_, err := New(Config{Enabled: true, Path: path})
+	assert.Error(t, err)
+}

--- a/pkg/cache/lock_unix.go
+++ b/pkg/cache/lock_unix.go
@@ -1,0 +1,22 @@
+//go:build unix
+
+package cache
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// lockExclusive blocks until an exclusive advisory lock is held on f.
+// On Unix-like systems we use flock(2): the lock is per open-file-table
+// entry (released when the descriptor is closed), and it serializes any
+// other process that opens the same path and calls flock(LOCK_EX).
+func lockExclusive(f *os.File) error {
+	return unix.Flock(int(f.Fd()), unix.LOCK_EX)
+}
+
+// unlockFile releases the lock previously acquired with lockExclusive.
+func unlockFile(f *os.File) error {
+	return unix.Flock(int(f.Fd()), unix.LOCK_UN)
+}

--- a/pkg/cache/lock_windows.go
+++ b/pkg/cache/lock_windows.go
@@ -1,0 +1,41 @@
+//go:build windows
+
+package cache
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// maxRange asks LockFileEx / UnlockFileEx to cover the whole file by
+// passing 0xFFFFFFFF for both the low and high 32 bits of the range.
+const maxRange = ^uint32(0)
+
+// lockExclusive blocks until an exclusive lock is held on the file.
+// Windows has no flock, so we use LockFileEx with LOCKFILE_EXCLUSIVE_LOCK.
+// The lock is mandatory (kernel-enforced) on Windows, which is at least
+// as strict as the advisory flock used on Unix.
+func lockExclusive(f *os.File) error {
+	var ol windows.Overlapped
+	return windows.LockFileEx(
+		windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK,
+		0,
+		maxRange,
+		maxRange,
+		&ol,
+	)
+}
+
+// unlockFile releases the lock previously acquired with lockExclusive.
+func unlockFile(f *os.File) error {
+	var ol windows.Overlapped
+	return windows.UnlockFileEx(
+		windows.Handle(f.Fd()),
+		0,
+		maxRange,
+		maxRange,
+		&ol,
+	)
+}

--- a/pkg/cache/lock_windows.go
+++ b/pkg/cache/lock_windows.go
@@ -14,8 +14,11 @@ const maxRange = ^uint32(0)
 
 // lockExclusive blocks until an exclusive lock is held on the file.
 // Windows has no flock, so we use LockFileEx with LOCKFILE_EXCLUSIVE_LOCK.
-// The lock is mandatory (kernel-enforced) on Windows, which is at least
-// as strict as the advisory flock used on Unix.
+//
+// The lock is mandatory (kernel-enforced) on Windows, unlike the advisory
+// flock used on Unix. However, since we lock a separate .lock file (not
+// the data file itself), both platforms achieve the same effect: serializing
+// the read-modify-write window without preventing direct reads of cache.json.
 func lockExclusive(f *os.File) error {
 	var ol windows.Overlapped
 	return windows.LockFileEx(

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -381,6 +381,27 @@ type AgentConfig struct {
 	StructuredOutput        *StructuredOutput `json:"structured_output,omitempty"`
 	Skills                  SkillsConfig      `json:"skills,omitzero"`
 	Hooks                   *HooksConfig      `json:"hooks,omitempty"`
+	Cache                   *CacheConfig      `json:"cache,omitempty"`
+}
+
+// CacheConfig configures the agent's response cache. When set and Enabled
+// is true, the agent stores the assistant response produced for a given
+// user question and replays it when the same question is asked again,
+// skipping the model entirely.
+//
+// Two normalization options control what "same question" means:
+//   - CaseSensitive: when false (the default), question matching is
+//     case-insensitive ("Hello" == "hello").
+//   - TrimSpaces: when true, leading and trailing whitespace is stripped
+//     before comparison ("  hello  " == "hello").
+//
+// Storage is in-memory by default. Set Path to persist entries to a JSON
+// file that is reloaded on startup.
+type CacheConfig struct {
+	Enabled       bool   `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	CaseSensitive bool   `json:"case_sensitive,omitempty" yaml:"case_sensitive,omitempty"`
+	TrimSpaces    bool   `json:"trim_spaces,omitempty" yaml:"trim_spaces,omitempty"`
+	Path          string `json:"path,omitempty" yaml:"path,omitempty"`
 }
 
 const SkillSourceLocal = "local"

--- a/pkg/hooks/types.go
+++ b/pkg/hooks/types.go
@@ -73,6 +73,17 @@ type Input struct {
 	Cwd           string    `json:"cwd"`
 	HookEventName EventType `json:"hook_event_name"`
 
+	// AgentName identifies the agent dispatching the event. Useful for
+	// builtin hooks that need to look up per-agent state via a runtime
+	// closure (e.g. response cache).
+	AgentName string `json:"agent_name,omitempty"`
+
+	// LastUserMessage is the text content of the latest user message in
+	// the session at dispatch time. Populated for events that respond to
+	// a user turn (stop, after_llm_call). Empty for events that aren't
+	// turn-scoped (session_start, session_end, notification, ...).
+	LastUserMessage string `json:"last_user_message,omitempty"`
+
 	// Tool-related fields (PreToolUse and PostToolUse).
 	ToolName  string         `json:"tool_name,omitempty"`
 	ToolUseID string         `json:"tool_use_id,omitempty"`

--- a/pkg/runtime/cache.go
+++ b/pkg/runtime/cache.go
@@ -19,6 +19,26 @@ import (
 // auto-injected from agent flags via [builtins.ApplyAgentDefaults].
 const BuiltinCacheResponse = "cache_response"
 
+// applyCacheDefault appends the cache_response stop hook to cfg when a
+// has a configured response cache, mirroring the role of
+// [builtins.ApplyAgentDefaults] for the runtime-private cache builtin.
+//
+// The helper accepts (and may return) a nil cfg so callers can chain
+// it after [builtins.ApplyAgentDefaults] without an extra branch.
+func applyCacheDefault(cfg *hooks.Config, a *agent.Agent) *hooks.Config {
+	if a.Cache() == nil {
+		return cfg
+	}
+	if cfg == nil {
+		cfg = &hooks.Config{}
+	}
+	cfg.Stop = append(cfg.Stop, hooks.Hook{
+		Type:    hooks.HookTypeBuiltin,
+		Command: BuiltinCacheResponse,
+	})
+	return cfg
+}
+
 // tryReplayCachedResponse looks up the latest user message in the agent's
 // response cache. On a hit it replays the cached answer as the assistant
 // message, fires stop hooks (which lets user-defined stop hooks run as

--- a/pkg/runtime/cache.go
+++ b/pkg/runtime/cache.go
@@ -1,0 +1,68 @@
+package runtime
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/session"
+)
+
+// tryReplayCachedResponse looks up the latest user message in the agent's
+// response cache. On a hit it replays the cached answer as the assistant
+// message, fires stop hooks, and returns replayed=true so the caller can
+// short-circuit the run. On a miss it returns the question text so the
+// caller can later store the freshly produced response under that key.
+//
+// It returns ("", false) when caching is disabled or the session has no
+// user message to key on.
+func (r *LocalRuntime) tryReplayCachedResponse(
+	ctx context.Context,
+	sess *session.Session,
+	a *agent.Agent,
+	events chan Event,
+) (question string, replayed bool) {
+	c := a.Cache()
+	if c == nil {
+		return "", false
+	}
+	question = sess.GetLastUserMessageContent()
+	if question == "" {
+		return "", false
+	}
+	cached, ok := c.Lookup(question)
+	if !ok || cached == "" {
+		return question, false
+	}
+
+	slog.Debug("Response cache hit; replaying cached answer",
+		"agent", a.Name(), "session_id", sess.ID)
+	modelID := a.Model().ID()
+	events <- AgentInfo(a.Name(), modelID, a.Description(), a.WelcomeMessage())
+	msg := chat.Message{
+		Role:      chat.MessageRoleAssistant,
+		Content:   cached,
+		CreatedAt: time.Now().Format(time.RFC3339),
+		Model:     modelID,
+	}
+	addAgentMessage(sess, a, &msg, events)
+	r.executeStopHooks(ctx, sess, a, cached, events)
+	return question, true
+}
+
+// cacheTurnResponse stores the assistant's response in the agent's cache
+// under question, then clears *question so subsequent stops in the same
+// RunStream (e.g. after a follow-up) are not also cached. It is a no-op
+// when caching is disabled, the question is empty, or the response has
+// no visible content.
+func (r *LocalRuntime) cacheTurnResponse(a *agent.Agent, question *string, response string) {
+	c := a.Cache()
+	if c == nil || *question == "" || strings.TrimSpace(response) == "" {
+		return
+	}
+	c.Store(*question, response)
+	*question = ""
+}

--- a/pkg/runtime/cache.go
+++ b/pkg/runtime/cache.go
@@ -8,61 +8,90 @@ import (
 
 	"github.com/docker/docker-agent/pkg/agent"
 	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/hooks"
 	"github.com/docker/docker-agent/pkg/session"
 )
 
+// BuiltinCacheResponse is the name of the builtin stop hook that persists
+// an agent's response into its configured response cache. It is
+// auto-injected by [LocalRuntime.getHooksExecutor] when the agent has a
+// cache configured, mirroring the way [BuiltinAddDate] et al. are
+// auto-injected from agent flags.
+const BuiltinCacheResponse = "cache_response"
+
 // tryReplayCachedResponse looks up the latest user message in the agent's
 // response cache. On a hit it replays the cached answer as the assistant
-// message, fires stop hooks, and returns replayed=true so the caller can
-// short-circuit the run. On a miss it returns the question text so the
-// caller can later store the freshly produced response under that key.
+// message, fires stop hooks (which lets user-defined stop hooks run as
+// they would for a real response), and returns true so the caller can
+// short-circuit the run.
 //
-// It returns ("", false) when caching is disabled or the session has no
-// user message to key on.
+// The storage half of the cache is implemented as a builtin stop hook
+// (see [LocalRuntime.cacheResponseBuiltin]); the lookup half stays here
+// because no hook event currently supports short-circuiting the run with
+// a synthetic response.
 func (r *LocalRuntime) tryReplayCachedResponse(
 	ctx context.Context,
 	sess *session.Session,
 	a *agent.Agent,
 	events chan Event,
-) (question string, replayed bool) {
+) bool {
 	c := a.Cache()
 	if c == nil {
-		return "", false
+		return false
 	}
-	question = sess.GetLastUserMessageContent()
+	question := sess.GetLastUserMessageContent()
 	if question == "" {
-		return "", false
+		return false
 	}
 	cached, ok := c.Lookup(question)
 	if !ok || cached == "" {
-		return question, false
+		return false
 	}
 
 	slog.Debug("Response cache hit; replaying cached answer",
 		"agent", a.Name(), "session_id", sess.ID)
 	modelID := a.Model().ID()
 	events <- AgentInfo(a.Name(), modelID, a.Description(), a.WelcomeMessage())
-	msg := chat.Message{
+	addAgentMessage(sess, a, &chat.Message{
 		Role:      chat.MessageRoleAssistant,
 		Content:   cached,
 		CreatedAt: time.Now().Format(time.RFC3339),
 		Model:     modelID,
-	}
-	addAgentMessage(sess, a, &msg, events)
+	}, events)
 	r.executeStopHooks(ctx, sess, a, cached, events)
-	return question, true
+	return true
 }
 
-// cacheTurnResponse stores the assistant's response in the agent's cache
-// under question, then clears *question so subsequent stops in the same
-// RunStream (e.g. after a follow-up) are not also cached. It is a no-op
-// when caching is disabled, the question is empty, or the response has
-// no visible content.
-func (r *LocalRuntime) cacheTurnResponse(a *agent.Agent, question *string, response string) {
-	c := a.Cache()
-	if c == nil || *question == "" || strings.TrimSpace(response) == "" {
-		return
+// cacheResponseBuiltin is the stop-hook builtin that stores the
+// assistant's response in the agent's response cache. It is registered
+// as a closure on the runtime's hooks registry so it can resolve the
+// agent (and therefore its cache instance) by name from
+// [hooks.Input.AgentName].
+//
+// The hook is a no-op when the agent has no cache configured, when the
+// dispatched input lacks a user message to key on, or when the response
+// has no visible content.
+//
+// As a tiny optimization (and to make replays of cached answers idempotent
+// at the file level), we skip the Store when the cache already holds the
+// exact same response under the same key — that's exactly what
+// [LocalRuntime.tryReplayCachedResponse] re-emits on a hit.
+func (r *LocalRuntime) cacheResponseBuiltin(_ context.Context, in *hooks.Input, _ []string) (*hooks.Output, error) {
+	if in == nil || in.AgentName == "" || in.LastUserMessage == "" ||
+		strings.TrimSpace(in.StopResponse) == "" {
+		return nil, nil
 	}
-	c.Store(*question, response)
-	*question = ""
+	a, err := r.team.Agent(in.AgentName)
+	if err != nil || a == nil {
+		return nil, nil
+	}
+	c := a.Cache()
+	if c == nil {
+		return nil, nil
+	}
+	if existing, ok := c.Lookup(in.LastUserMessage); ok && existing == in.StopResponse {
+		return nil, nil
+	}
+	c.Store(in.LastUserMessage, in.StopResponse)
+	return nil, nil
 }

--- a/pkg/runtime/cache.go
+++ b/pkg/runtime/cache.go
@@ -70,12 +70,10 @@ func (r *LocalRuntime) tryReplayCachedResponse(
 //
 // The hook is a no-op when the agent has no cache configured, when the
 // dispatched input lacks a user message to key on, or when the response
-// has no visible content.
-//
-// As a tiny optimization (and to make replays of cached answers idempotent
-// at the file level), we skip the Store when the cache already holds the
-// exact same response under the same key — that's exactly what
-// [LocalRuntime.tryReplayCachedResponse] re-emits on a hit.
+// has no visible content. Storing the same answer twice is also a no-op
+// (handled inside [cache.Cache.Store]), which makes the replay path —
+// where [LocalRuntime.tryReplayCachedResponse] fires stop hooks for the
+// cached answer — free of redundant disk writes.
 func (r *LocalRuntime) cacheResponseBuiltin(_ context.Context, in *hooks.Input, _ []string) (*hooks.Output, error) {
 	if in == nil || in.AgentName == "" || in.LastUserMessage == "" ||
 		strings.TrimSpace(in.StopResponse) == "" {
@@ -85,13 +83,8 @@ func (r *LocalRuntime) cacheResponseBuiltin(_ context.Context, in *hooks.Input, 
 	if err != nil || a == nil {
 		return nil, nil
 	}
-	c := a.Cache()
-	if c == nil {
-		return nil, nil
+	if c := a.Cache(); c != nil {
+		c.Store(in.LastUserMessage, in.StopResponse)
 	}
-	if existing, ok := c.Lookup(in.LastUserMessage); ok && existing == in.StopResponse {
-		return nil, nil
-	}
-	c.Store(in.LastUserMessage, in.StopResponse)
 	return nil, nil
 }

--- a/pkg/runtime/cache.go
+++ b/pkg/runtime/cache.go
@@ -14,9 +14,9 @@ import (
 
 // BuiltinCacheResponse is the name of the builtin stop hook that persists
 // an agent's response into its configured response cache. It is
-// auto-injected by [LocalRuntime.getHooksExecutor] when the agent has a
-// cache configured, mirroring the way [BuiltinAddDate] et al. are
-// auto-injected from agent flags.
+// auto-injected by [LocalRuntime.hooksExec] when the agent has a cache
+// configured, mirroring the way [builtins.AddDate] et al. are
+// auto-injected from agent flags via [builtins.ApplyAgentDefaults].
 const BuiltinCacheResponse = "cache_response"
 
 // tryReplayCachedResponse looks up the latest user message in the agent's
@@ -44,6 +44,11 @@ func (r *LocalRuntime) tryReplayCachedResponse(
 		return false
 	}
 	cached, ok := c.Lookup(question)
+	// Treat empty stored values as misses: cache_response only stores
+	// non-empty responses, so an empty entry only surfaces if the JSON
+	// file was hand-edited or downgraded from a future version. Replaying
+	// nothing would leave the user staring at a blank assistant message,
+	// so we fall through to the model instead.
 	if !ok || cached == "" {
 		return false
 	}
@@ -81,6 +86,8 @@ func (r *LocalRuntime) cacheResponseBuiltin(_ context.Context, in *hooks.Input, 
 	}
 	a, err := r.team.Agent(in.AgentName)
 	if err != nil || a == nil {
+		slog.Debug("cache_response: agent lookup failed",
+			"agent", in.AgentName, "error", err)
 		return nil, nil
 	}
 	if c := a.Cache(); c != nil {

--- a/pkg/runtime/cache_test.go
+++ b/pkg/runtime/cache_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/docker/docker-agent/pkg/team"
 )
 
-func runWithCache(t *testing.T, c cache.Cache, prov *messageRecordingProvider, sess *session.Session) []Event {
+func runWithCache(t *testing.T, c *cache.Cache, prov *messageRecordingProvider, sess *session.Session) []Event {
 	t.Helper()
 
 	root := agent.New("root", "You are a test agent",

--- a/pkg/runtime/cache_test.go
+++ b/pkg/runtime/cache_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/docker-agent/pkg/agent"
 	"github.com/docker/docker-agent/pkg/cache"
 	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/hooks"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/team"
 )
@@ -146,6 +147,37 @@ func TestCache_TrimSpaces(t *testing.T) {
 
 // TestCache_DisabledHasNoEffect verifies that when the agent has no cache
 // attached, every call goes through to the model.
+// TestCache_StorageIsAStopHookBuiltin asserts the architectural contract
+// that the cache_response storage is wired through the new hook system as
+// a stop-hook builtin (not as a hard-coded runtime call). It is the
+// regression test for the migration to the hooks mechanism.
+func TestCache_StorageIsAStopHookBuiltin(t *testing.T) {
+	c, err := cache.New(cache.Config{Enabled: true})
+	require.NoError(t, err)
+
+	root := agent.New("root", "You are a test agent",
+		agent.WithModel(&messageRecordingProvider{id: "test/mock"}),
+		agent.WithCache(c),
+	)
+	tm := team.New(team.WithAgents(root))
+
+	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+
+	// The runtime should have auto-injected a stop hook of type=builtin
+	// pointing at BuiltinCacheResponse for an agent that has a cache.
+	exec := rt.hooksExec(root)
+	require.NotNil(t, exec, "a cache-enabled agent must have a hooks executor")
+	require.True(t, exec.Has(hooks.EventStop), "cache-enabled agent must have a stop hook")
+
+	// The cache_response builtin must be registered on the runtime's
+	// private hooks registry; that's the seam that lets the closure
+	// reach back to a.Cache() through Input.AgentName.
+	fn, ok := rt.hooksRegistry.LookupBuiltin(BuiltinCacheResponse)
+	require.True(t, ok, "cache_response builtin must be registered")
+	require.NotNil(t, fn)
+}
+
 func TestCache_DisabledHasNoEffect(t *testing.T) {
 	stream1 := newStreamBuilder().AddContent("first").AddStopWithUsage(5, 3).Build()
 	stream2 := newStreamBuilder().AddContent("second").AddStopWithUsage(5, 3).Build()

--- a/pkg/runtime/cache_test.go
+++ b/pkg/runtime/cache_test.go
@@ -197,6 +197,38 @@ func TestCache_DisabledHasNoEffect(t *testing.T) {
 	assert.Len(t, prov.recordedMessages, 2, "without a cache, every turn must hit the model")
 }
 
+// TestCache_EmptyResponseIsNotCached documents that the cache_response
+// stop-hook deliberately drops empty (whitespace-only) assistant
+// responses on the floor: replaying nothing on a future turn would leave
+// the user staring at a blank reply with no recourse but to ask again,
+// so the model is called every time.
+func TestCache_EmptyResponseIsNotCached(t *testing.T) {
+	c, err := cache.New(cache.Config{Enabled: true})
+	require.NoError(t, err)
+
+	// Two empty-response streams; we expect the model to be called both
+	// times because the empty answer must never reach the cache.
+	stream1 := newStreamBuilder().AddContent("").AddStopWithUsage(5, 0).Build()
+	stream2 := newStreamBuilder().AddContent("").AddStopWithUsage(5, 0).Build()
+	prov := &messageRecordingProvider{
+		id:      "test/mock-model",
+		streams: []*mockStream{stream1, stream2},
+	}
+
+	sess1 := session.New(session.WithUserMessage("silent treatment"))
+	runWithCache(t, c, prov, sess1)
+	sess2 := session.New(session.WithUserMessage("silent treatment"))
+	runWithCache(t, c, prov, sess2)
+
+	prov.mu.Lock()
+	defer prov.mu.Unlock()
+	assert.Len(t, prov.recordedMessages, 2,
+		"empty responses must not be cached; the model must be called every time")
+
+	_, found := c.Lookup("silent treatment")
+	assert.False(t, found, "empty assistant response must not appear in the cache")
+}
+
 func hasAgentChoice(events []Event, content string) bool {
 	for _, ev := range events {
 		if ac, ok := ev.(*AgentChoiceEvent); ok && strings.Contains(ac.Content, content) {

--- a/pkg/runtime/cache_test.go
+++ b/pkg/runtime/cache_test.go
@@ -1,0 +1,185 @@
+package runtime
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/cache"
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/team"
+)
+
+func runWithCache(t *testing.T, c cache.Cache, prov *messageRecordingProvider, sess *session.Session) []Event {
+	t.Helper()
+
+	root := agent.New("root", "You are a test agent",
+		agent.WithModel(prov),
+		agent.WithCache(c),
+	)
+	tm := team.New(team.WithAgents(root))
+
+	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+	sess.Title = "cache test"
+
+	evCh := rt.RunStream(t.Context(), sess)
+	var events []Event
+	for ev := range evCh {
+		events = append(events, ev)
+	}
+	return events
+}
+
+// TestCache_StoresAndReplaysAnswer verifies that a cache miss invokes the model
+// once, and a subsequent identical question is served from the cache without
+// hitting the model again.
+func TestCache_StoresAndReplaysAnswer(t *testing.T) {
+	c, err := cache.New(cache.Config{Enabled: true})
+	require.NoError(t, err)
+	require.NotNil(t, c)
+
+	stream := newStreamBuilder().
+		AddContent("The answer is 42").
+		AddStopWithUsage(5, 3).
+		Build()
+	prov := &messageRecordingProvider{
+		id:      "test/mock-model",
+		streams: []*mockStream{stream},
+	}
+
+	// First turn: cache miss → model is called once and answer stored.
+	sess1 := session.New(session.WithUserMessage("What is the answer?"))
+	events1 := runWithCache(t, c, prov, sess1)
+
+	require.NotEmpty(t, events1)
+	assert.IsType(t, &StreamStoppedEvent{}, events1[len(events1)-1])
+
+	prov.mu.Lock()
+	require.Len(t, prov.recordedMessages, 1, "expected exactly one model call on first turn (cache miss)")
+	prov.mu.Unlock()
+
+	// Verify the answer was emitted.
+	require.True(t, hasAgentChoice(events1, "The answer is 42"), "expected first run to emit the model answer")
+
+	// Second turn with the same question: cache hit → no extra model call.
+	sess2 := session.New(session.WithUserMessage("What is the answer?"))
+	runWithCache(t, c, prov, sess2)
+
+	prov.mu.Lock()
+	defer prov.mu.Unlock()
+	assert.Len(t, prov.recordedMessages, 1, "second turn must NOT call the model again")
+
+	// The cached response must have been added as the assistant message.
+	require.True(t, hasAssistantMessage(sess2, "The answer is 42"), "expected cached response in session")
+}
+
+// TestCache_CaseInsensitive verifies that case-insensitive matching is the
+// default when CaseSensitive is false.
+func TestCache_CaseInsensitive(t *testing.T) {
+	c, err := cache.New(cache.Config{Enabled: true, CaseSensitive: false})
+	require.NoError(t, err)
+
+	stream := newStreamBuilder().
+		AddContent("Hi there!").
+		AddStopWithUsage(5, 3).
+		Build()
+	prov := &messageRecordingProvider{
+		id:      "test/mock-model",
+		streams: []*mockStream{stream},
+	}
+
+	// First turn: "Hello" → model is called.
+	sess1 := session.New(session.WithUserMessage("Hello"))
+	runWithCache(t, c, prov, sess1)
+
+	prov.mu.Lock()
+	require.Len(t, prov.recordedMessages, 1)
+	prov.mu.Unlock()
+
+	// Second turn: "HELLO" must still hit the cache.
+	sess2 := session.New(session.WithUserMessage("HELLO"))
+	runWithCache(t, c, prov, sess2)
+
+	prov.mu.Lock()
+	defer prov.mu.Unlock()
+	assert.Len(t, prov.recordedMessages, 1, "case-insensitive cache must hit on different case")
+	assert.True(t, hasAssistantMessage(sess2, "Hi there!"), "expected cached response to be replayed")
+}
+
+// TestCache_TrimSpaces verifies that whitespace trimming is applied when
+// TrimSpaces is enabled.
+func TestCache_TrimSpaces(t *testing.T) {
+	c, err := cache.New(cache.Config{Enabled: true, TrimSpaces: true})
+	require.NoError(t, err)
+
+	stream := newStreamBuilder().
+		AddContent("Trimmed!").
+		AddStopWithUsage(5, 3).
+		Build()
+	prov := &messageRecordingProvider{
+		id:      "test/mock-model",
+		streams: []*mockStream{stream},
+	}
+
+	// First turn: question with surrounding whitespace.
+	sess1 := session.New(session.WithUserMessage("  Hello  "))
+	runWithCache(t, c, prov, sess1)
+
+	prov.mu.Lock()
+	require.Len(t, prov.recordedMessages, 1)
+	prov.mu.Unlock()
+
+	// Second turn: same question without whitespace must hit the cache.
+	sess2 := session.New(session.WithUserMessage("Hello"))
+	runWithCache(t, c, prov, sess2)
+
+	prov.mu.Lock()
+	defer prov.mu.Unlock()
+	assert.Len(t, prov.recordedMessages, 1, "trim-enabled cache must hit when whitespace differs")
+	assert.True(t, hasAssistantMessage(sess2, "Trimmed!"))
+}
+
+// TestCache_DisabledHasNoEffect verifies that when the agent has no cache
+// attached, every call goes through to the model.
+func TestCache_DisabledHasNoEffect(t *testing.T) {
+	stream1 := newStreamBuilder().AddContent("first").AddStopWithUsage(5, 3).Build()
+	stream2 := newStreamBuilder().AddContent("second").AddStopWithUsage(5, 3).Build()
+
+	prov := &messageRecordingProvider{
+		id:      "test/mock-model",
+		streams: []*mockStream{stream1, stream2},
+	}
+
+	sess1 := session.New(session.WithUserMessage("Same question"))
+	runWithCache(t, nil, prov, sess1)
+	sess2 := session.New(session.WithUserMessage("Same question"))
+	runWithCache(t, nil, prov, sess2)
+
+	prov.mu.Lock()
+	defer prov.mu.Unlock()
+	assert.Len(t, prov.recordedMessages, 2, "without a cache, every turn must hit the model")
+}
+
+func hasAgentChoice(events []Event, content string) bool {
+	for _, ev := range events {
+		if ac, ok := ev.(*AgentChoiceEvent); ok && strings.Contains(ac.Content, content) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasAssistantMessage(sess *session.Session, content string) bool {
+	for _, item := range sess.Messages {
+		if item.IsMessage() && item.Message.Message.Role == chat.MessageRoleAssistant &&
+			strings.Contains(item.Message.Message.Content, content) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/runtime/hooks.go
+++ b/pkg/runtime/hooks.go
@@ -14,10 +14,11 @@ import (
 )
 
 // buildHooksExecutors builds a [hooks.Executor] for every agent in the
-// team that has user-configured hooks or an agent-flag that maps to a
-// builtin (AddDate / AddEnvironmentInfo / AddPromptFiles). Agents with
-// no hooks have no entry; lookups fall through to nil so callers can
-// short-circuit cheaply.
+// team that has user-configured hooks, an agent-flag that maps to a
+// builtin (AddDate / AddEnvironmentInfo / AddPromptFiles), or a
+// configured response cache (which auto-injects a cache_response stop
+// hook). Agents with no hooks have no entry; lookups fall through to
+// nil so callers can short-circuit cheaply.
 //
 // Called once from [NewLocalRuntime] after r.workingDir, r.env and
 // r.hooksRegistry are finalized; the resulting map is read-only for
@@ -35,6 +36,20 @@ func (r *LocalRuntime) buildHooksExecutors() {
 			AddEnvironmentInfo: a.AddEnvironmentInfo(),
 			AddPromptFiles:     a.AddPromptFiles(),
 		})
+
+		// Auto-inject the cache_response stop-hook for cache-enabled agents.
+		// The builtin lives in this package (it's a closure over r so it can
+		// reach a.Cache() through Input.AgentName) and isn't part of the
+		// stateless ApplyAgentDefaults set in pkg/hooks/builtins.
+		if a.Cache() != nil {
+			if cfg == nil {
+				cfg = &hooks.Config{}
+			}
+			cfg.Stop = append(cfg.Stop, hooks.Hook{
+				Type:    hooks.HookTypeBuiltin,
+				Command: BuiltinCacheResponse,
+			})
+		}
 		if cfg == nil {
 			continue
 		}
@@ -149,11 +164,15 @@ func (r *LocalRuntime) executeSessionEndHooks(ctx context.Context, sess *session
 
 // executeStopHooks fires stop hooks when the model finishes responding,
 // passing the final response content as stop_response. SystemMessage is
-// surfaced as a Warning by [dispatchHook].
+// surfaced as a Warning by [dispatchHook]. AgentName + LastUserMessage
+// are populated so builtins like cache_response can key on the user's
+// question and resolve the agent through the runtime closure.
 func (r *LocalRuntime) executeStopHooks(ctx context.Context, sess *session.Session, a *agent.Agent, responseContent string, events chan Event) {
 	r.dispatchHook(ctx, a, hooks.EventStop, &hooks.Input{
-		SessionID:    sess.ID,
-		StopResponse: responseContent,
+		SessionID:       sess.ID,
+		AgentName:       a.Name(),
+		StopResponse:    responseContent,
+		LastUserMessage: sess.GetLastUserMessageContent(),
 	}, events)
 }
 
@@ -287,8 +306,10 @@ func (r *LocalRuntime) executeBeforeLLMCallHooks(ctx context.Context, sess *sess
 // skip this event.
 func (r *LocalRuntime) executeAfterLLMCallHooks(ctx context.Context, sess *session.Session, a *agent.Agent, responseContent string) {
 	r.dispatchHook(ctx, a, hooks.EventAfterLLMCall, &hooks.Input{
-		SessionID:    sess.ID,
-		StopResponse: responseContent,
+		SessionID:       sess.ID,
+		AgentName:       a.Name(),
+		StopResponse:    responseContent,
+		LastUserMessage: sess.GetLastUserMessageContent(),
 	}, nil)
 }
 

--- a/pkg/runtime/hooks.go
+++ b/pkg/runtime/hooks.go
@@ -36,20 +36,7 @@ func (r *LocalRuntime) buildHooksExecutors() {
 			AddEnvironmentInfo: a.AddEnvironmentInfo(),
 			AddPromptFiles:     a.AddPromptFiles(),
 		})
-
-		// Auto-inject the cache_response stop-hook for cache-enabled agents.
-		// The builtin lives in this package (it's a closure over r so it can
-		// reach a.Cache() through Input.AgentName) and isn't part of the
-		// stateless ApplyAgentDefaults set in pkg/hooks/builtins.
-		if a.Cache() != nil {
-			if cfg == nil {
-				cfg = &hooks.Config{}
-			}
-			cfg.Stop = append(cfg.Stop, hooks.Hook{
-				Type:    hooks.HookTypeBuiltin,
-				Command: BuiltinCacheResponse,
-			})
-		}
+		cfg = applyCacheDefault(cfg, a)
 		if cfg == nil {
 			continue
 		}

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -491,14 +491,10 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 			slog.Debug("Conversation stopped", "agent", a.Name())
 			r.executeStopHooks(ctx, sess, a, res.Content, events)
 
-			// Persist the response in the cache so the same question
-			// returns the same answer next time. Only the first stop
-			// of the stream (i.e. the response to the original user
-			// question, before any follow-ups) is cached.
-			if c := a.Cache(); c != nil && cacheQuestion != "" && strings.TrimSpace(res.Content) != "" {
-				c.Store(cacheQuestion, res.Content)
-				cacheQuestion = ""
-			}
+			// Persist this turn's response under the user's original
+			// question. Only the first stop is cached: follow-ups in
+			// the same RunStream answer different questions.
+			r.cacheTurnResponse(a, &cacheQuestion, res.Content)
 
 			// Re-check steer queue: closes the race between the mid-loop drain and this stop.
 			if drained, _ := r.drainAndEmitSteered(ctx, sess, events); drained {

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -211,29 +211,12 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 
 	defer r.finalizeEventChannel(ctx, sess, prevElicitationCh, events)
 
-	// Response cache lookup. When the agent has a cache configured and
-	// the latest user message is already in the cache, replay the
-	// stored response and skip the model entirely.
-	var cacheQuestion string
-	if c := a.Cache(); c != nil {
-		if q := sess.GetLastUserMessageContent(); q != "" {
-			cacheQuestion = q
-			if cached, ok := c.Lookup(q); ok && cached != "" {
-				slog.Debug("Response cache hit; replaying cached answer",
-					"agent", a.Name(), "session_id", sess.ID)
-				modelID := a.Model().ID()
-				events <- AgentInfo(a.Name(), modelID, a.Description(), a.WelcomeMessage())
-				assistantMessage := chat.Message{
-					Role:      chat.MessageRoleAssistant,
-					Content:   cached,
-					CreatedAt: time.Now().Format(time.RFC3339),
-					Model:     modelID,
-				}
-				addAgentMessage(sess, a, &assistantMessage, events)
-				r.executeStopHooks(ctx, sess, a, cached, events)
-				return
-			}
-		}
+	// Response cache lookup. On a hit, replay the stored answer and
+	// skip the model entirely. The matching storage half is
+	// implemented as the cache_response stop-hook builtin (see
+	// runtime/cache.go and getHooksExecutor).
+	if r.tryReplayCachedResponse(ctx, sess, a, events) {
+		return
 	}
 
 	iteration := 0
@@ -490,11 +473,6 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 		if res.Stopped {
 			slog.Debug("Conversation stopped", "agent", a.Name())
 			r.executeStopHooks(ctx, sess, a, res.Content, events)
-
-			// Persist this turn's response under the user's original
-			// question. Only the first stop is cached: follow-ups in
-			// the same RunStream answer different questions.
-			r.cacheTurnResponse(a, &cacheQuestion, res.Content)
 
 			// Re-check steer queue: closes the race between the mid-loop drain and this stop.
 			if drained, _ := r.drainAndEmitSteered(ctx, sess, events); drained {

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -211,6 +211,31 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 
 	defer r.finalizeEventChannel(ctx, sess, prevElicitationCh, events)
 
+	// Response cache lookup. When the agent has a cache configured and
+	// the latest user message is already in the cache, replay the
+	// stored response and skip the model entirely.
+	var cacheQuestion string
+	if c := a.Cache(); c != nil {
+		if q := sess.GetLastUserMessageContent(); q != "" {
+			cacheQuestion = q
+			if cached, ok := c.Lookup(q); ok && cached != "" {
+				slog.Debug("Response cache hit; replaying cached answer",
+					"agent", a.Name(), "session_id", sess.ID)
+				modelID := a.Model().ID()
+				events <- AgentInfo(a.Name(), modelID, a.Description(), a.WelcomeMessage())
+				assistantMessage := chat.Message{
+					Role:      chat.MessageRoleAssistant,
+					Content:   cached,
+					CreatedAt: time.Now().Format(time.RFC3339),
+					Model:     modelID,
+				}
+				addAgentMessage(sess, a, &assistantMessage, events)
+				r.executeStopHooks(ctx, sess, a, cached, events)
+				return
+			}
+		}
+	}
+
 	iteration := 0
 	// Use a runtime copy of maxIterations so we don't modify the session's persistent config
 	runtimeMaxIterations := sess.MaxIterations
@@ -465,6 +490,15 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 		if res.Stopped {
 			slog.Debug("Conversation stopped", "agent", a.Name())
 			r.executeStopHooks(ctx, sess, a, res.Content, events)
+
+			// Persist the response in the cache so the same question
+			// returns the same answer next time. Only the first stop
+			// of the stream (i.e. the response to the original user
+			// question, before any follow-ups) is cached.
+			if c := a.Cache(); c != nil && cacheQuestion != "" && strings.TrimSpace(res.Content) != "" {
+				c.Store(cacheQuestion, res.Content)
+				cacheQuestion = ""
+			}
 
 			// Re-check steer queue: closes the race between the mid-loop drain and this stop.
 			if drained, _ := r.drainAndEmitSteered(ctx, sess, events); drained {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -367,6 +367,14 @@ func NewLocalRuntime(agents *team.Team, opts ...Opt) (*LocalRuntime, error) {
 	}
 	r.bgAgents = agenttool.NewHandler(r)
 
+	// cache_response is registered here (not in pkg/hooks/builtins) because
+	// it needs to capture the runtime to resolve the agent referenced by
+	// Input.AgentName. The other builtins are stateless and can stay as
+	// package-level functions registered via builtins.Register above.
+	if err := hooksRegistry.RegisterBuiltin(BuiltinCacheResponse, r.cacheResponseBuiltin); err != nil {
+		return nil, fmt.Errorf("register %q builtin: %w", BuiltinCacheResponse, err)
+	}
+
 	for _, opt := range opts {
 		opt(r)
 	}

--- a/pkg/teamloader/cache.go
+++ b/pkg/teamloader/cache.go
@@ -1,0 +1,53 @@
+package teamloader
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/docker/docker-agent/pkg/cache"
+	"github.com/docker/docker-agent/pkg/config/latest"
+)
+
+// buildAgentCache turns a per-agent CacheConfig into a [cache.Cache]
+// instance, resolving any relative path against parentDir and rejecting
+// paths that try to escape it.
+//
+// The caller is expected to gate this on cfg.Enabled; passing a disabled
+// config still returns (nil, nil) so the caller can stay symmetric.
+func buildAgentCache(agentName string, cfg *latest.CacheConfig, parentDir string) (*cache.Cache, error) {
+	if cfg == nil || !cfg.Enabled {
+		return nil, nil
+	}
+
+	path, err := resolveCachePath(cfg.Path, parentDir)
+	if err != nil {
+		return nil, fmt.Errorf("agent %q: %w", agentName, err)
+	}
+
+	c, err := cache.New(cache.Config{
+		Enabled:       true,
+		CaseSensitive: cfg.CaseSensitive,
+		TrimSpaces:    cfg.TrimSpaces,
+		Path:          path,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("agent %q: initializing response cache: %w", agentName, err)
+	}
+	return c, nil
+}
+
+// resolveCachePath returns path unchanged when it is empty (in-memory
+// cache) or absolute; otherwise it joins it with parentDir, cleans the
+// result, and refuses any path that escapes parentDir via "..".
+func resolveCachePath(path, parentDir string) (string, error) {
+	if path == "" || filepath.IsAbs(path) {
+		return path, nil
+	}
+	resolved := filepath.Clean(filepath.Join(parentDir, path))
+	cleanParent := filepath.Clean(parentDir) + string(filepath.Separator)
+	if !strings.HasPrefix(resolved+string(filepath.Separator), cleanParent) {
+		return "", fmt.Errorf("cache path %q escapes parent directory", path)
+	}
+	return resolved, nil
+}

--- a/pkg/teamloader/cache.go
+++ b/pkg/teamloader/cache.go
@@ -40,6 +40,14 @@ func buildAgentCache(agentName string, cfg *latest.CacheConfig, parentDir string
 // resolveCachePath returns path unchanged when it is empty (in-memory
 // cache) or absolute; otherwise it joins it with parentDir, cleans the
 // result, and refuses any path that escapes parentDir via "..".
+//
+// Note: This is a lexical check only and does not resolve symlinks. An
+// attacker with write access to parentDir could create a symlink that
+// points outside the directory tree. This is acceptable because:
+//  1. The cache path comes from the agent config, not user input
+//  2. An attacker with write access to the config directory already has
+//     significant privileges
+//  3. The cache only stores agent responses, not sensitive data
 func resolveCachePath(path, parentDir string) (string, error) {
 	if path == "" || filepath.IsAbs(path) {
 		return path, nil

--- a/pkg/teamloader/cache_test.go
+++ b/pkg/teamloader/cache_test.go
@@ -1,0 +1,64 @@
+package teamloader
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/config/latest"
+)
+
+func TestBuildAgentCache_disabled(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  *latest.CacheConfig
+	}{
+		{"nil config", nil},
+		{"explicitly disabled", &latest.CacheConfig{Enabled: false}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, err := buildAgentCache("agent", tc.cfg, t.TempDir())
+			require.NoError(t, err)
+			assert.Nil(t, c)
+		})
+	}
+}
+
+func TestBuildAgentCache_inMemory(t *testing.T) {
+	c, err := buildAgentCache("agent", &latest.CacheConfig{Enabled: true}, t.TempDir())
+	require.NoError(t, err)
+	require.NotNil(t, c)
+}
+
+func TestBuildAgentCache_relativePath(t *testing.T) {
+	parent := t.TempDir()
+	c, err := buildAgentCache("agent",
+		&latest.CacheConfig{Enabled: true, Path: "cache.json"}, parent)
+	require.NoError(t, err)
+	require.NotNil(t, c)
+
+	// Storing must persist to <parent>/cache.json
+	c.Store("q", "a")
+	_, err = filepath.Abs(filepath.Join(parent, "cache.json"))
+	require.NoError(t, err)
+}
+
+func TestBuildAgentCache_absolutePath(t *testing.T) {
+	abs := filepath.Join(t.TempDir(), "absolute.json")
+	c, err := buildAgentCache("agent",
+		&latest.CacheConfig{Enabled: true, Path: abs}, t.TempDir())
+	require.NoError(t, err)
+	require.NotNil(t, c)
+}
+
+func TestBuildAgentCache_pathTraversalRejected(t *testing.T) {
+	parent := t.TempDir()
+	_, err := buildAgentCache("agent",
+		&latest.CacheConfig{Enabled: true, Path: "../escape.json"}, parent)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `agent "agent"`)
+	assert.Contains(t, err.Error(), "escapes parent directory")
+}

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -174,6 +174,12 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 			cachePath := agentConfig.Cache.Path
 			if cachePath != "" && !filepath.IsAbs(cachePath) {
 				cachePath = filepath.Join(parentDir, cachePath)
+				cachePath = filepath.Clean(cachePath)
+				// Ensure the resolved path is within parentDir to prevent path traversal
+				cleanParent := filepath.Clean(parentDir) + string(filepath.Separator)
+				if !strings.HasPrefix(cachePath+string(filepath.Separator), cleanParent) {
+					return nil, fmt.Errorf("agent %q: cache path %q escapes parent directory", agentConfig.Name, agentConfig.Cache.Path)
+				}
 			}
 			c, err := cache.New(cache.Config{
 				Enabled:       true,

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -14,7 +14,6 @@ import (
 	"sync"
 
 	"github.com/docker/docker-agent/pkg/agent"
-	"github.com/docker/docker-agent/pkg/cache"
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/js"
@@ -171,24 +170,9 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 		}
 
 		if agentConfig.Cache != nil && agentConfig.Cache.Enabled {
-			cachePath := agentConfig.Cache.Path
-			if cachePath != "" && !filepath.IsAbs(cachePath) {
-				cachePath = filepath.Join(parentDir, cachePath)
-				cachePath = filepath.Clean(cachePath)
-				// Ensure the resolved path is within parentDir to prevent path traversal
-				cleanParent := filepath.Clean(parentDir) + string(filepath.Separator)
-				if !strings.HasPrefix(cachePath+string(filepath.Separator), cleanParent) {
-					return nil, fmt.Errorf("agent %q: cache path %q escapes parent directory", agentConfig.Name, agentConfig.Cache.Path)
-				}
-			}
-			c, err := cache.New(cache.Config{
-				Enabled:       true,
-				CaseSensitive: agentConfig.Cache.CaseSensitive,
-				TrimSpaces:    agentConfig.Cache.TrimSpaces,
-				Path:          cachePath,
-			})
+			c, err := buildAgentCache(agentConfig.Name, agentConfig.Cache, parentDir)
 			if err != nil {
-				return nil, fmt.Errorf("agent %q: initializing response cache: %w", agentConfig.Name, err)
+				return nil, err
 			}
 			opts = append(opts, agent.WithCache(c))
 		}

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 
 	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/cache"
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/js"
@@ -167,6 +168,23 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 			agent.WithNumHistoryItems(agentConfig.NumHistoryItems),
 			agent.WithCommands(expander.ExpandCommands(ctx, agentConfig.Commands)),
 			agent.WithHooks(config.MergeHooks(agentConfig.Hooks, cliHooks)),
+		}
+
+		if agentConfig.Cache != nil && agentConfig.Cache.Enabled {
+			cachePath := agentConfig.Cache.Path
+			if cachePath != "" && !filepath.IsAbs(cachePath) {
+				cachePath = filepath.Join(parentDir, cachePath)
+			}
+			c, err := cache.New(cache.Config{
+				Enabled:       true,
+				CaseSensitive: agentConfig.Cache.CaseSensitive,
+				TrimSpaces:    agentConfig.Cache.TrimSpaces,
+				Path:          cachePath,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("agent %q: initializing response cache: %w", agentConfig.Name, err)
+			}
+			opts = append(opts, agent.WithCache(c))
 		}
 
 		models, err := getModelsForAgent(ctx, cfg, &agentConfig, autoModel, runConfig)

--- a/pkg/teamloader/teamloader_test.go
+++ b/pkg/teamloader/teamloader_test.go
@@ -483,3 +483,29 @@ func TestExternalDepthContext(t *testing.T) {
 	ctx = contextWithExternalDepth(ctx, 7)
 	assert.Equal(t, 7, externalDepthFromContext(ctx))
 }
+
+func TestLoadWithConfig_CachePathTraversal(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a config file with a path traversal attempt
+	configPath := filepath.Join(tmpDir, "agent.yaml")
+	configContent := `
+agents:
+  root:
+    model: openai/gpt-4o
+    description: Test agent
+    instruction: You are a test agent.
+    cache:
+      enabled: true
+      path: ../../../../etc/passwd
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0o600))
+
+	source := config.NewFileSource(configPath)
+	runConfig := &config.RuntimeConfig{}
+	runConfig.WorkingDir = tmpDir
+
+	_, err := LoadWithConfig(t.Context(), source, runConfig)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "escapes parent directory")
+}

--- a/pkg/teamloader/teamloader_test.go
+++ b/pkg/teamloader/teamloader_test.go
@@ -485,6 +485,8 @@ func TestExternalDepthContext(t *testing.T) {
 }
 
 func TestLoadWithConfig_CachePathTraversal(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "dummy")
+
 	tmpDir := t.TempDir()
 
 	// Create a config file with a path traversal attempt


### PR DESCRIPTION
## Add a configurable response cache for agents

Adds an opt-in, per-agent **response cache** that maps a normalized user question to a previously produced assistant response, so asking the exact same question again skips the model entirely and replays the stored answer.

### What the user gets

```yaml
agents:
  root:
    model: openai/gpt-5-mini
    cache:
      enabled: true
      case_sensitive: false   # default: false (case-insensitive matching)
      trim_spaces: true       # default: false
      path: ./cache.json      # optional: persist to disk; omit for in-memory
```

| Knob | Effect |
|---|---|
| `enabled` | Turns the cache on. When `false` or absent, no caching. |
| `case_sensitive` | When `false` (default), `"Hello"` and `"hello"` match. |
| `trim_spaces` | When `true`, leading/trailing whitespace is stripped before comparison. |
| `path` | When set, persists entries to JSON on disk. **Multiple processes can safely share the same file.** When empty, in-memory only. |

### How sharing works

| Scenario | Shared? | How |
|---|---|---|
| Multiple sessions in the same process | ✅ Yes | Singleton `*cache.Cache` per agent in the team. |
| Sessions across process restarts | ✅ Yes (with `path:`) | JSON file loaded on `New`, mirrored on every `Store`. |
| Sessions in two simultaneously running processes sharing the same `path:` | ✅ Yes | Advisory lock on `<path>.lock` (`flock(2)` / `LockFileEx`) serializes the read-modify-write window; mtime-based reload on `Lookup` propagates external writes. |

### Architecture

The cache integrates through the new hook system rather than as bespoke runtime code:

- **Storage half** is a `cache_response` builtin auto-injected as a `stop` hook when `a.Cache() != nil` — mirroring the auto-injection pattern used by `add_date` / `add_environment_info` / `add_prompt_files`. The runtime registers the closure once (it captures `r` to resolve agents via `Input.AgentName`); `applyCacheDefault` appends the hook to the per-agent `hooks.Config` inside `buildHooksExecutors`.
- **Lookup half** stays inline in `tryReplayCachedResponse` (called once at the start of `RunStream`) because no current hook event supports short-circuiting the run with a synthetic response. The lookup half is small (~30 lines) and the alternative would require extending the hook output protocol with a `SkipWithResponse` field that today has no other consumers — happy to revisit when one shows up.

### File-backed storage details

- Writes are **atomic**: temp file → fsync → rename over the destination, so concurrent readers and crashed writers can never observe a partial JSON file. The parent directory is fsync'd after the rename so the rename itself is durable.
- Concurrent-write-safe across processes via an advisory lock on a sibling `<path>.lock` sentinel (POSIX `flock(2)` on Unix, `LockFileEx` with `LOCKFILE_EXCLUSIVE_LOCK` on Windows). The lock file is intentionally never renamed or deleted — doing so would let two processes lock different inodes for the same logical resource and lose mutual exclusion.
- `Lookup` checks the file's mtime and reloads the in-memory map when it's advanced since the last load, so cross-process writes become visible without a restart.
- A path-traversal check rejects any `path:` whose `..` resolution lands outside the agent's config directory. Lexical only — no symlink resolution — which is acceptable because cache paths come from agent configs, not untrusted input.

### Files touched

```
agent-schema.json                  | +30
docs/configuration/agents/index.md | +47
examples/cached_responses.yaml     | +30
pkg/agent/agent.go                 | +8     (Cache() accessor)
pkg/agent/opts.go                  | +8     (WithCache)
pkg/cache/cache.go                 | +359   (Cache struct, Store/Lookup, persist, lock, atomic write)
pkg/cache/cache_test.go            | +375
pkg/cache/lock_unix.go             | +22
pkg/cache/lock_windows.go          | +44
pkg/config/latest/types.go         | +21    (CacheConfig)
pkg/hooks/types.go                 | +11    (AgentName + LastUserMessage on Input)
pkg/runtime/cache.go               | +117   (BuiltinCacheResponse, applyCacheDefault, tryReplayCachedResponse, cacheResponseBuiltin)
pkg/runtime/cache_test.go          | +249
pkg/runtime/hooks.go               | +20    (cache hook injection + Input field plumbing in stop / after_llm_call)
pkg/runtime/loop.go                | +8     (single line cache-replay short-circuit)
pkg/runtime/runtime.go             | +8     (cache_response builtin registration)
pkg/teamloader/cache.go            | +61    (buildAgentCache + path traversal check)
pkg/teamloader/cache_test.go       | +64
pkg/teamloader/teamloader.go       | +8     (calls buildAgentCache)
pkg/teamloader/teamloader_test.go  | +28    (path-traversal test)
```

### Test coverage

- **`pkg/cache`**: in-memory + file-backed paths, both normalization options (`case_sensitive`, `trim_spaces`), atomic-write leaves no leftover temp files, dedup-on-rewrite preserves mtime, persistence-failure keeps in-memory state, **two cross-process tests** (`TestFileCache_crossProcessConcurrentStoresPreserveAllEntries` simulates two `*Cache` instances racing 50 keys each on the same path; without the file lock this test loses ~50% of entries), `TestFileCache_lookupReloadsAfterExternalWrite`, `TestFileCache_lockFileNeverDeleted`.
- **`pkg/runtime`**: `TestCache_StoresAndReplaysAnswer` (cache miss → model called once; same question again → cached replay, no model call), `TestCache_StorageIsAStopHookBuiltin` (pins the architectural contract that storage IS a hook), `TestCache_CaseInsensitive`, `TestCache_TrimSpaces`, `TestCache_DisabledHasNoEffect`, `TestCache_EmptyResponseIsNotCached` (empty assistant content is dropped on the floor; never replayed).
- **`pkg/teamloader`**: `TestBuildAgentCache_*` (disabled, in-memory, relative path, absolute path, traversal rejected), `TestLoadWithConfig_CachePathTraversal`.
- All tests pass under `go test -race`.

### Validation

- `mise lint`: 0 issues
- `mise test`: full suite green
- `go test -race ./pkg/cache/... ./pkg/runtime/ ./pkg/teamloader/`: clean
- Cross-platform builds: `GOOS=linux/windows GOARCH=amd64` clean

### Notes for reviewers

- 12 commits, kept atomic for review. The arc is roughly: feature → docs/durability → restructure → fixes → hooks integration → simplifications → cross-process safety → review polish.
- Reviewed twice during development; key prior findings (lost-write race in `Cache.Store`, fd leak in `syncDir`, path traversal in `resolveCachePath`, empty-response handling, persistence-failure resilience, TOCTOU in `maybeReload`) are all addressed and pinned by tests.
- The example YAML (`examples/cached_responses.yaml`) and the schema (`agent-schema.json`) were validated against each other during development.

Closes #N/A — feature ticket lives outside this repo.
