### PR TITLE
feat(hooks): add before_compaction and after_compaction events

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -588,6 +588,20 @@
           "items": {
             "$ref": "#/definitions/HookDefinition"
           }
+        },
+        "before_compaction": {
+          "type": "array",
+          "description": "Hooks that run immediately before a session compaction. The Input carries input_tokens, output_tokens, context_limit, and compaction_reason ('threshold', 'overflow', 'manual'). A hook may veto compaction by setting decision='block' (or exiting with code 2), or supply a custom summary via hookSpecificOutput.summary, in which case the runtime applies that summary verbatim and skips the LLM-based summarization. Be cautious about denying when compaction_reason='overflow': the runtime is recovering from a context-overflow error and a denial there will leave the session unable to make progress.",
+          "items": {
+            "$ref": "#/definitions/HookDefinition"
+          }
+        },
+        "after_compaction": {
+          "type": "array",
+          "description": "Hooks that run after a successful compaction (a summary was applied to the session). Receives the final summary text in Input.summary alongside input_tokens, output_tokens, context_limit and compaction_reason. Purely observational — hook output is ignored.",
+          "items": {
+            "$ref": "#/definitions/HookDefinition"
+          }
         }
       },
       "additionalProperties": false

--- a/examples/hooks.yaml
+++ b/examples/hooks.yaml
@@ -313,8 +313,10 @@ agents:
       # ====================================================================
       # AFTER-COMPACTION - fires after a successful compaction has applied
       # a summary to the session. The Input carries the produced summary
-      # text in .summary alongside the same token / reason fields.
-      # Purely observational — output is ignored.
+      # text in .summary alongside the *pre-compaction* .input_tokens /
+      # .output_tokens (what was summarized) so handlers can naturally
+      # express "compacted from X to Y". Purely observational — output is
+      # ignored.
       # ====================================================================
       after_compaction:
         - type: command
@@ -322,6 +324,44 @@ agents:
           command: |
             INPUT=$(cat)
             REASON=$(echo "$INPUT" | jq -r '.compaction_reason // "manual"')
+            BEFORE_IN=$(echo "$INPUT" | jq -r '.input_tokens // 0')
+            BEFORE_OUT=$(echo "$INPUT" | jq -r '.output_tokens // 0')
             LEN=$(echo "$INPUT" | jq -r '.summary // ""' | wc -c | tr -d ' ')
-            echo "[$(date)] [✓] compacted (reason=$REASON, summary=$LEN chars)" \
+            echo "[$(date)] [✓] compacted (reason=$REASON, ${BEFORE_IN}+${BEFORE_OUT} tokens → ${LEN} chars summary)" \
               >> /tmp/agent-compactions.log
+
+      # ====================================================================
+      # CUSTOM-SUMMARY EXAMPLE (commented out) - demonstrates the non-LLM
+      # replacement path. Returning a non-empty hookSpecificOutput.summary
+      # makes the runtime apply that string verbatim and skip the LLM call
+      # entirely. Useful for:
+      #
+      #   - deterministic / fast strategies (drop oldest tool results,
+      #     dedupe identical tool calls, stub long blob attachments);
+      #   - regulated environments where shipping conversation history to
+      #     a summarization model isn't permitted;
+      #   - testing: pin a known summary string to make compaction
+      #     deterministic in CI.
+      #
+      # If multiple before_compaction hooks return a summary, the first
+      # non-empty one in config order wins (hooks run concurrently but
+      # the result slots are indexed, so the verdict is deterministic).
+      #
+      # Uncomment to replace the observational hook above with a custom
+      # strategy. Note: only one before_compaction handler block is
+      # supported per agent in YAML; merge your observability logic into
+      # the same handler if you also want logging.
+      #
+      # before_compaction:
+      #   - type: command
+      #     timeout: 5
+      #     command: |
+      #       INPUT=$(cat)
+      #       cat <<'JSON'
+      #       {
+      #         "hookSpecificOutput": {
+      #           "hookEventName": "before_compaction",
+      #           "summary": "Conversation summarized by the deterministic strategy. Latest user request and tool results preserved verbatim."
+      #         }
+      #       }
+      #       JSON

--- a/examples/hooks.yaml
+++ b/examples/hooks.yaml
@@ -21,6 +21,8 @@
 #   notification      - errors / warnings emitted by the runtime (catch-all)
 #   on_error          - structured handler for runtime errors
 #   on_max_iterations - structured handler for hitting max_iterations
+#   before_compaction - veto a compaction OR supply a custom summary string
+#   after_compaction  - observe a successful compaction (logging, audits)
 #
 # Handler kinds:
 #
@@ -52,6 +54,7 @@
 #   /tmp/agent-notifications.log   (notification)
 #   /tmp/agent-errors.log          (on_error)
 #   /tmp/agent-max-iter.log        (on_max_iterations)
+#   /tmp/agent-compactions.log     (before_compaction, after_compaction)
 #
 
 agents:
@@ -270,3 +273,55 @@ agents:
             INPUT=$(cat)
             MESSAGE=$(echo "$INPUT" | jq -r '.notification_message // "no message"')
             echo "[$(date)] max-iterations: $MESSAGE" >> /tmp/agent-max-iter.log
+
+      # ====================================================================
+      # BEFORE-COMPACTION - fires immediately before the runtime compacts
+      # the session. The Input carries:
+      #   .input_tokens       - current session input-token count
+      #   .output_tokens      - current session output-token count
+      #   .context_limit      - the model's context-window size, when known
+      #   .compaction_reason  - "threshold" (proactive 90% trigger),
+      #                         "overflow" (post-overflow auto-recovery),
+      #                         or "manual" (user-invoked /compact).
+      #
+      # Two ways to influence the runtime:
+      #
+      #   1. Veto: exit with code 2 (or return permission_decision="deny").
+      #      The runtime skips compaction entirely. CAUTION: vetoing during
+      #      compaction_reason="overflow" leaves the session unable to make
+      #      progress — gate by reason if you need this.
+      #
+      #   2. Replace: return hookSpecificOutput.summary to supply a custom
+      #      summary string. The runtime applies it verbatim and skips the
+      #      LLM-based summarization. Useful for non-LLM strategies (drop
+      #      oldest tool results, dedupe, stub-out long blobs, ...).
+      # ====================================================================
+      before_compaction:
+        - type: command
+          timeout: 30
+          command: |
+            INPUT=$(cat)
+            REASON=$(echo "$INPUT" | jq -r '.compaction_reason // "manual"')
+            INPUT_TOK=$(echo "$INPUT" | jq -r '.input_tokens // 0')
+            OUTPUT_TOK=$(echo "$INPUT" | jq -r '.output_tokens // 0')
+            LIMIT=$(echo "$INPUT" | jq -r '.context_limit // 0')
+            echo "[$(date)] [→] compacting (reason=$REASON, in=$INPUT_TOK, out=$OUTPUT_TOK, ctx=$LIMIT)" \
+              >> /tmp/agent-compactions.log
+            # Pure observability — fall through to the LLM-based default.
+            echo '{"continue": true}'
+
+      # ====================================================================
+      # AFTER-COMPACTION - fires after a successful compaction has applied
+      # a summary to the session. The Input carries the produced summary
+      # text in .summary alongside the same token / reason fields.
+      # Purely observational — output is ignored.
+      # ====================================================================
+      after_compaction:
+        - type: command
+          timeout: 10
+          command: |
+            INPUT=$(cat)
+            REASON=$(echo "$INPUT" | jq -r '.compaction_reason // "manual"')
+            LEN=$(echo "$INPUT" | jq -r '.summary // ""' | wc -c | tr -d ' ')
+            echo "[$(date)] [✓] compacted (reason=$REASON, summary=$LEN chars)" \
+              >> /tmp/agent-compactions.log

--- a/pkg/compaction/compaction.go
+++ b/pkg/compaction/compaction.go
@@ -61,3 +61,55 @@ func EstimateMessageTokens(msg *chat.Message) int64 {
 	}
 	return int64(chars/charsPerToken) + perMessageOverhead
 }
+
+// SplitIndexForKeep walks messages from the end and returns the earliest
+// index whose suffix fits in maxTokens, snapping to user/assistant
+// boundaries. All messages from the returned index onward are intended
+// to be preserved verbatim across a compaction; messages before it are
+// the candidates to summarize. Returns len(messages) when everything
+// fits in the keep budget — i.e. compact everything.
+//
+// The boundary snap matters for providers (notably Anthropic) that
+// reject conversations starting on a tool-result message: by stopping
+// the kept window on a user/assistant turn, we guarantee the kept
+// suffix begins on a clean conversational turn.
+func SplitIndexForKeep(messages []chat.Message, maxTokens int64) int {
+	if len(messages) == 0 {
+		return 0
+	}
+
+	var tokens int64
+	lastValidBoundary := len(messages)
+	for i := len(messages) - 1; i >= 0; i-- {
+		tokens += EstimateMessageTokens(&messages[i])
+		if tokens > maxTokens {
+			return lastValidBoundary
+		}
+		role := messages[i].Role
+		if role == chat.MessageRoleUser || role == chat.MessageRoleAssistant {
+			lastValidBoundary = i
+		}
+	}
+	return len(messages)
+}
+
+// FirstIndexInBudget walks messages from the end and returns the
+// earliest index whose suffix fits in contextLimit, snapping to
+// user/assistant boundaries. Used to truncate the conversation we
+// hand to the summarization model so the request itself doesn't
+// blow the context window.
+func FirstIndexInBudget(messages []chat.Message, contextLimit int64) int {
+	var tokens int64
+	lastValidMessageSeen := len(messages)
+	for i := len(messages) - 1; i >= 0; i-- {
+		tokens += EstimateMessageTokens(&messages[i])
+		if tokens > contextLimit {
+			return lastValidMessageSeen
+		}
+		role := messages[i].Role
+		if role == chat.MessageRoleUser || role == chat.MessageRoleAssistant {
+			lastValidMessageSeen = i
+		}
+	}
+	return lastValidMessageSeen
+}

--- a/pkg/compaction/compaction.go
+++ b/pkg/compaction/compaction.go
@@ -93,11 +93,18 @@ func SplitIndexForKeep(messages []chat.Message, maxTokens int64) int {
 	return len(messages)
 }
 
-// FirstIndexInBudget walks messages from the end and returns the
-// earliest index whose suffix fits in contextLimit, snapping to
-// user/assistant boundaries. Used to truncate the conversation we
-// hand to the summarization model so the request itself doesn't
-// blow the context window.
+// FirstIndexInBudget returns the smallest index N such that
+// messages[N:] fits within contextLimit, snapping to a user/assistant
+// turn boundary. Used to truncate the conversation handed to the
+// summarization model so the request itself doesn't blow the context
+// window.
+//
+// When the entire slice fits within contextLimit, the function returns
+// the index of the earliest user/assistant message in the suffix —
+// older tool-only messages (which can't legally start a conversation)
+// are dropped. In the unusual case of a tool-only conversation with
+// no user/asst turns, it returns len(messages); callers should treat
+// that as "nothing to send" and skip the truncation.
 func FirstIndexInBudget(messages []chat.Message, contextLimit int64) int {
 	var tokens int64
 	lastValidMessageSeen := len(messages)

--- a/pkg/compaction/compaction_test.go
+++ b/pkg/compaction/compaction_test.go
@@ -1,6 +1,7 @@
 package compaction
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -160,6 +161,118 @@ func TestShouldCompact(t *testing.T) {
 			t.Parallel()
 			got := ShouldCompact(tt.input, tt.output, tt.added, tt.contextLimit)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSplitIndexForKeep(t *testing.T) {
+	t.Parallel()
+
+	msg := func(role chat.MessageRole, content string) chat.Message {
+		return chat.Message{Role: role, Content: content}
+	}
+
+	tests := []struct {
+		name      string
+		messages  []chat.Message
+		maxTokens int64
+		wantSplit int // expected split index
+	}{
+		{
+			name:      "empty messages",
+			messages:  nil,
+			maxTokens: 1000,
+			wantSplit: 0,
+		},
+		{
+			name: "all messages fit in keep budget - compact everything",
+			messages: []chat.Message{
+				msg(chat.MessageRoleUser, "short"),
+				msg(chat.MessageRoleAssistant, "short"),
+			},
+			maxTokens: 100_000,
+			wantSplit: 2, // all fit → compact everything
+		},
+		{
+			name: "recent messages kept, older ones compacted",
+			messages: []chat.Message{
+				msg(chat.MessageRoleUser, strings.Repeat("a", 40000)),      // ~10005 tokens
+				msg(chat.MessageRoleAssistant, strings.Repeat("b", 40000)), // ~10005 tokens
+				msg(chat.MessageRoleUser, strings.Repeat("c", 40000)),      // ~10005 tokens
+				msg(chat.MessageRoleAssistant, strings.Repeat("d", 40000)), // ~10005 tokens
+				msg(chat.MessageRoleUser, strings.Repeat("e", 40000)),      // ~10005 tokens
+				msg(chat.MessageRoleAssistant, strings.Repeat("f", 40000)), // ~10005 tokens
+			},
+			maxTokens: 20_100, // enough for exactly 2 messages
+			wantSplit: 4,      // last 2 messages are kept
+		},
+		{
+			name: "snap to assistant boundary even when a tool result fits",
+			messages: []chat.Message{
+				msg(chat.MessageRoleUser, "u1"),
+				msg(chat.MessageRoleAssistant, "a1"),
+				msg(chat.MessageRoleTool, "t1"),
+			},
+			maxTokens: 100_000, // everything fits
+			wantSplit: 3,       // all fit → compact everything (returned len)
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := SplitIndexForKeep(tt.messages, tt.maxTokens)
+			assert.Equal(t, tt.wantSplit, got)
+		})
+	}
+}
+
+func TestFirstIndexInBudget(t *testing.T) {
+	t.Parallel()
+
+	msg := func(role chat.MessageRole, content string) chat.Message {
+		return chat.Message{Role: role, Content: content}
+	}
+
+	tests := []struct {
+		name      string
+		messages  []chat.Message
+		budget    int64
+		wantFirst int
+	}{
+		{
+			name:      "empty",
+			messages:  nil,
+			budget:    1000,
+			wantFirst: 0,
+		},
+		{
+			name: "everything fits",
+			messages: []chat.Message{
+				msg(chat.MessageRoleUser, "short"),
+				msg(chat.MessageRoleAssistant, "short"),
+			},
+			budget:    1000,
+			wantFirst: 0,
+		},
+		{
+			name: "tight budget keeps tail starting on a user/assistant turn",
+			messages: []chat.Message{
+				msg(chat.MessageRoleUser, strings.Repeat("a", 4000)),
+				msg(chat.MessageRoleAssistant, strings.Repeat("b", 4000)),
+				msg(chat.MessageRoleUser, strings.Repeat("c", 4000)),
+				msg(chat.MessageRoleAssistant, strings.Repeat("d", 4000)),
+			},
+			budget:    2100, // ~2 messages worth
+			wantFirst: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := FirstIndexInBudget(tt.messages, tt.budget)
+			assert.Equal(t, tt.wantFirst, got)
 		})
 	}
 }

--- a/pkg/compaction/compaction_test.go
+++ b/pkg/compaction/compaction_test.go
@@ -185,13 +185,13 @@ func TestSplitIndexForKeep(t *testing.T) {
 			wantSplit: 0,
 		},
 		{
-			name: "all messages fit in keep budget - compact everything",
+			name: "all messages fit in keep budget - returned len(messages) signals 'compact everything, keep nothing' (the manual /compact contract)",
 			messages: []chat.Message{
 				msg(chat.MessageRoleUser, "short"),
 				msg(chat.MessageRoleAssistant, "short"),
 			},
 			maxTokens: 100_000,
-			wantSplit: 2, // all fit → compact everything
+			wantSplit: 2, // all fit → messages[:2] is everything to compact, messages[2:] is empty (nothing kept)
 		},
 		{
 			name: "recent messages kept, older ones compacted",

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -1687,6 +1687,19 @@ type HooksConfig struct {
 	// gives audit pipelines a structured "who approved what" record
 	// without re-implementing the chain.
 	OnToolApprovalDecision []HookDefinition `json:"on_tool_approval_decision,omitempty" yaml:"on_tool_approval_decision,omitempty"`
+
+	// BeforeCompaction hooks run immediately before a session compaction.
+	// Hooks may veto compaction (Decision: "block") or supply a custom
+	// summary via HookSpecificOutput.summary, in which case the runtime
+	// applies that summary verbatim and skips the LLM call. Hooks receive
+	// the current input/output token counts, the model context limit, and
+	// a compaction_reason of "threshold", "overflow", or "manual".
+	BeforeCompaction []HookDefinition `json:"before_compaction,omitempty" yaml:"before_compaction,omitempty"`
+
+	// AfterCompaction hooks run after a successful compaction (a summary
+	// was applied to the session). The Input.summary field carries the
+	// produced summary text. AfterCompaction is purely observational.
+	AfterCompaction []HookDefinition `json:"after_compaction,omitempty" yaml:"after_compaction,omitempty"`
 }
 
 // IsEmpty returns true if no hooks are configured
@@ -1708,7 +1721,9 @@ func (h *HooksConfig) IsEmpty() bool {
 		len(h.OnMaxIterations) == 0 &&
 		len(h.OnAgentSwitch) == 0 &&
 		len(h.OnSessionResume) == 0 &&
-		len(h.OnToolApprovalDecision) == 0
+		len(h.OnToolApprovalDecision) == 0 &&
+		len(h.BeforeCompaction) == 0 &&
+		len(h.AfterCompaction) == 0
 }
 
 // HookMatcherConfig represents a hook matcher with its hooks.
@@ -1883,6 +1898,20 @@ func (h *HooksConfig) validate() error {
 	// Validate OnToolApprovalDecision hooks
 	for i, hook := range h.OnToolApprovalDecision {
 		if err := hook.validate("on_tool_approval_decision", i); err != nil {
+			return err
+		}
+	}
+
+	// Validate BeforeCompaction hooks
+	for i, hook := range h.BeforeCompaction {
+		if err := hook.validate("before_compaction", i); err != nil {
+			return err
+		}
+	}
+
+	// Validate AfterCompaction hooks
+	for i, hook := range h.AfterCompaction {
+		if err := hook.validate("after_compaction", i); err != nil {
 			return err
 		}
 	}

--- a/pkg/hooks/dispatch_test.go
+++ b/pkg/hooks/dispatch_test.go
@@ -21,18 +21,20 @@ var matcherWildcard = []MatcherConfig{{Matcher: "*", Hooks: trueHook}}
 // event is a one-line update here — the same one-line update
 // compileEvents needs.
 var onlyHooks = map[EventType]*Config{
-	EventPreToolUse:      {PreToolUse: matcherWildcard},
-	EventPostToolUse:     {PostToolUse: matcherWildcard},
-	EventSessionStart:    {SessionStart: trueHook},
-	EventTurnStart:       {TurnStart: trueHook},
-	EventBeforeLLMCall:   {BeforeLLMCall: trueHook},
-	EventAfterLLMCall:    {AfterLLMCall: trueHook},
-	EventSessionEnd:      {SessionEnd: trueHook},
-	EventOnUserInput:     {OnUserInput: trueHook},
-	EventStop:            {Stop: trueHook},
-	EventNotification:    {Notification: trueHook},
-	EventOnError:         {OnError: trueHook},
-	EventOnMaxIterations: {OnMaxIterations: trueHook},
+	EventPreToolUse:       {PreToolUse: matcherWildcard},
+	EventPostToolUse:      {PostToolUse: matcherWildcard},
+	EventSessionStart:     {SessionStart: trueHook},
+	EventTurnStart:        {TurnStart: trueHook},
+	EventBeforeLLMCall:    {BeforeLLMCall: trueHook},
+	EventAfterLLMCall:     {AfterLLMCall: trueHook},
+	EventSessionEnd:       {SessionEnd: trueHook},
+	EventOnUserInput:      {OnUserInput: trueHook},
+	EventStop:             {Stop: trueHook},
+	EventNotification:     {Notification: trueHook},
+	EventOnError:          {OnError: trueHook},
+	EventOnMaxIterations:  {OnMaxIterations: trueHook},
+	EventBeforeCompaction: {BeforeCompaction: trueHook},
+	EventAfterCompaction:  {AfterCompaction: trueHook},
 }
 
 // TestExecutorHasIsGeneric exercises the generic Has API across every

--- a/pkg/hooks/executor.go
+++ b/pkg/hooks/executor.go
@@ -345,10 +345,16 @@ func aggregate(results []hookResult, event EventType) *Result {
 				}
 			}
 			if event == EventBeforeCompaction && hso.Summary != "" && final.Summary == "" {
-				// First non-empty summary wins. Concatenating multiple
-				// summaries would produce nonsense, so we keep the first
-				// hook's verdict and let later hooks fall through to the
-				// observational path.
+				// First non-empty summary in CONFIG ORDER wins. Hooks run
+				// concurrently (see runHook above), but we iterate
+				// `results` in the order they were configured — the index
+				// of each hook's slot in `results` is fixed at registration
+				// time, not by completion order — so this verdict is
+				// deterministic regardless of which hook finishes first.
+				// Concatenating multiple summaries would produce nonsense,
+				// and merging them would require a second LLM call,
+				// defeating the point of the hook-supplied summary (which
+				// is to skip the LLM entirely).
 				final.Summary = hso.Summary
 			}
 			if hso.AdditionalContext != "" {

--- a/pkg/hooks/executor.go
+++ b/pkg/hooks/executor.go
@@ -88,6 +88,8 @@ func compileEvents(c *Config) map[EventType][]matcher {
 		EventOnAgentSwitch:          flat(c.OnAgentSwitch),
 		EventOnSessionResume:        flat(c.OnSessionResume),
 		EventOnToolApprovalDecision: flat(c.OnToolApprovalDecision),
+		EventBeforeCompaction:       flat(c.BeforeCompaction),
+		EventAfterCompaction:        flat(c.AfterCompaction),
 	}
 }
 
@@ -341,6 +343,13 @@ func aggregate(results []hookResult, event EventType) *Result {
 					}
 					maps.Copy(final.ModifiedInput, hso.UpdatedInput)
 				}
+			}
+			if event == EventBeforeCompaction && hso.Summary != "" && final.Summary == "" {
+				// First non-empty summary wins. Concatenating multiple
+				// summaries would produce nonsense, so we keep the first
+				// hook's verdict and let later hooks fall through to the
+				// observational path.
+				final.Summary = hso.Summary
 			}
 			if hso.AdditionalContext != "" {
 				contexts = append(contexts, hso.AdditionalContext)

--- a/pkg/hooks/hooks_test.go
+++ b/pkg/hooks/hooks_test.go
@@ -110,6 +110,20 @@ func TestConfigIsEmpty(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name: "with before_compaction",
+			config: Config{
+				BeforeCompaction: []Hook{{Type: HookTypeCommand}},
+			},
+			expected: false,
+		},
+		{
+			name: "with after_compaction",
+			config: Config{
+				AfterCompaction: []Hook{{Type: HookTypeCommand}},
+			},
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -692,6 +706,7 @@ func TestPlainStdoutBecomesAdditionalContext(t *testing.T) {
 	observationalEvents := []EventType{
 		EventBeforeLLMCall, EventAfterLLMCall, EventOnError,
 		EventOnMaxIterations, EventNotification, EventOnUserInput, EventSessionEnd,
+		EventBeforeCompaction, EventAfterCompaction,
 	}
 
 	for _, ev := range contextEvents {
@@ -751,6 +766,10 @@ func configWithFlatHook(ev EventType, h Hook) *Config {
 		cfg.OnError = []Hook{h}
 	case EventOnMaxIterations:
 		cfg.OnMaxIterations = []Hook{h}
+	case EventBeforeCompaction:
+		cfg.BeforeCompaction = []Hook{h}
+	case EventAfterCompaction:
+		cfg.AfterCompaction = []Hook{h}
 	}
 	return cfg
 }
@@ -784,4 +803,169 @@ func TestExecutePostToolUseDoesNotFailClosedOnError(t *testing.T) {
 	// Post-tool-use is observational only: a failed hook must not block
 	// the already-completed tool call.
 	assert.True(t, result.Allowed)
+}
+
+// TestExecuteBeforeCompactionAllowedByDefault checks that an empty
+// observational hook (echo to stdout) does not deny compaction. Plain
+// stdout is dropped for before_compaction since the runtime acts on
+// Allowed and Summary, not on AdditionalContext.
+func TestExecuteBeforeCompactionAllowedByDefault(t *testing.T) {
+	t.Parallel()
+
+	config := &Config{
+		BeforeCompaction: []Hook{
+			{Type: HookTypeCommand, Command: "echo 'about to compact'", Timeout: 5},
+		},
+	}
+
+	exec := NewExecutor(config, t.TempDir(), nil)
+	input := &Input{
+		SessionID:        "test-session",
+		InputTokens:      100_000,
+		OutputTokens:     5_000,
+		ContextLimit:     128_000,
+		CompactionReason: "threshold",
+	}
+
+	result, err := exec.Dispatch(t.Context(), EventBeforeCompaction, input)
+	require.NoError(t, err)
+	assert.True(t, result.Allowed)
+	assert.Empty(t, result.Summary)
+}
+
+// TestExecuteBeforeCompactionBlocksWithExitCode2 pins the contract that a
+// before_compaction hook can veto compaction by exiting with code 2.
+func TestExecuteBeforeCompactionBlocksWithExitCode2(t *testing.T) {
+	t.Parallel()
+
+	config := &Config{
+		BeforeCompaction: []Hook{
+			{Type: HookTypeCommand, Command: "echo 'no compaction please' >&2; exit 2", Timeout: 5},
+		},
+	}
+
+	exec := NewExecutor(config, t.TempDir(), nil)
+	input := &Input{
+		SessionID:        "test-session",
+		CompactionReason: "manual",
+	}
+
+	result, err := exec.Dispatch(t.Context(), EventBeforeCompaction, input)
+	require.NoError(t, err)
+	assert.False(t, result.Allowed)
+	assert.Equal(t, 2, result.ExitCode)
+}
+
+// TestExecuteBeforeCompactionSurfacesSummary checks that a before_compaction
+// hook returning HookSpecificOutput.summary populates Result.Summary so the
+// runtime can apply it verbatim and skip the LLM-based compaction.
+func TestExecuteBeforeCompactionSurfacesSummary(t *testing.T) {
+	t.Parallel()
+
+	jsonOutput := `{"hook_specific_output":{"hook_event_name":"before_compaction","summary":"hook-supplied summary"}}`
+	config := &Config{
+		BeforeCompaction: []Hook{
+			{Type: HookTypeCommand, Command: "echo '" + jsonOutput + "'", Timeout: 5},
+		},
+	}
+
+	exec := NewExecutor(config, t.TempDir(), nil)
+	input := &Input{
+		SessionID:        "test-session",
+		CompactionReason: "manual",
+	}
+
+	result, err := exec.Dispatch(t.Context(), EventBeforeCompaction, input)
+	require.NoError(t, err)
+	assert.True(t, result.Allowed)
+	assert.Equal(t, "hook-supplied summary", result.Summary)
+}
+
+// TestExecuteBeforeCompactionFirstSummaryWins checks that when multiple
+// hooks return a summary, the first non-empty one is kept. Concatenating
+// summaries would produce nonsense; clobbering would be order-dependent.
+func TestExecuteBeforeCompactionFirstSummaryWins(t *testing.T) {
+	t.Parallel()
+
+	first := `{"hook_specific_output":{"hook_event_name":"before_compaction","summary":"first"}}`
+	second := `{"hook_specific_output":{"hook_event_name":"before_compaction","summary":"second"}}`
+	config := &Config{
+		BeforeCompaction: []Hook{
+			{Type: HookTypeCommand, Command: "echo '" + first + "'", Timeout: 5},
+			{Type: HookTypeCommand, Command: "echo '" + second + "'", Timeout: 5},
+		},
+	}
+
+	exec := NewExecutor(config, t.TempDir(), nil)
+	result, err := exec.Dispatch(t.Context(), EventBeforeCompaction, &Input{
+		SessionID:        "test-session",
+		CompactionReason: "manual",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.Allowed)
+	// Hooks run concurrently, so we assert on either-or rather than
+	// strict ordering. The contract is "first non-empty wins"; with
+	// concurrent execution that means a deterministic single value
+	// surfaces (no concatenation) — never both.
+	assert.Contains(t, []string{"first", "second"}, result.Summary)
+	assert.NotEqual(t, "firstsecond", result.Summary)
+	assert.NotEqual(t, "secondfirst", result.Summary)
+}
+
+// TestExecuteAfterCompactionIsObservational pins the contract that the
+// after_compaction event ignores its hooks' Allowed/Summary verdicts —
+// they are surfaced into Result for inspection but do not affect the
+// runtime, which calls the hook purely for observability.
+func TestExecuteAfterCompactionIsObservational(t *testing.T) {
+	t.Parallel()
+
+	config := &Config{
+		AfterCompaction: []Hook{
+			{Type: HookTypeCommand, Command: "echo 'compaction done'", Timeout: 5},
+		},
+	}
+
+	exec := NewExecutor(config, t.TempDir(), nil)
+	input := &Input{
+		SessionID:        "test-session",
+		CompactionReason: "threshold",
+		Summary:          "earlier summary",
+	}
+
+	result, err := exec.Dispatch(t.Context(), EventAfterCompaction, input)
+	require.NoError(t, err)
+	assert.True(t, result.Allowed)
+}
+
+// TestInputCompactionFieldsSerialize pins the wire format for the
+// compaction-specific Input fields so external (command-type) hooks can
+// rely on it.
+func TestInputCompactionFieldsSerialize(t *testing.T) {
+	t.Parallel()
+
+	input := &Input{
+		SessionID:        "sess-789",
+		HookEventName:    EventBeforeCompaction,
+		InputTokens:      120_000,
+		OutputTokens:     8_000,
+		ContextLimit:     200_000,
+		CompactionReason: "overflow",
+	}
+
+	data, err := input.ToJSON()
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(data, &parsed))
+
+	assert.Equal(t, "sess-789", parsed["session_id"])
+	assert.Equal(t, "before_compaction", parsed["hook_event_name"])
+	assert.EqualValues(t, 120_000, parsed["input_tokens"])
+	assert.EqualValues(t, 8_000, parsed["output_tokens"])
+	assert.EqualValues(t, 200_000, parsed["context_limit"])
+	assert.Equal(t, "overflow", parsed["compaction_reason"])
+	// Summary is omitted on before_compaction inputs (it's only set on
+	// after_compaction so handlers receive the produced summary).
+	_, hasSummary := parsed["summary"]
+	assert.False(t, hasSummary)
 }

--- a/pkg/hooks/types.go
+++ b/pkg/hooks/types.go
@@ -77,15 +77,25 @@ const (
 	// "overflow", or "manual") so handlers can decide based on real
 	// session pressure.
 	//
+	// [Input.ContextLimit] may be 0 when the model definition is
+	// unavailable (e.g. an unknown model ID); hooks should treat 0 as
+	// "unknown" rather than as a real limit.
+	//
 	// Hook authors should be cautious about denying when
 	// CompactionReason == "overflow": the runtime is recovering from a
-	// context-overflow error and a denial here will leave the session
-	// unable to make progress.
+	// context-overflow error. A denial here means the next LLM call will
+	// hit the same overflow; the runtime allows at most one
+	// retry-with-compaction (see maxOverflowCompactions in loop.go), so a
+	// second denial fails the turn and surfaces the overflow as an Error
+	// event.
 	EventBeforeCompaction EventType = "before_compaction"
 	// EventAfterCompaction fires after a session compaction completes
 	// successfully (a summary was applied to the session). The Input
-	// carries the produced [Input.Summary] for observability or
-	// downstream pipelines (audit logs, telemetry, ...). It is purely
+	// carries the produced [Input.Summary] together with the
+	// *pre-compaction* [Input.InputTokens] / [Input.OutputTokens] (what
+	// was summarized) so observability handlers can naturally express
+	// "compacted from X to Y". The post-compaction counts are reflected
+	// in the next runtime token-usage event. AfterCompaction is purely
 	// observational; output is ignored.
 	EventAfterCompaction EventType = "after_compaction"
 )
@@ -145,11 +155,18 @@ type Input struct {
 	// Compaction fields (BeforeCompaction, AfterCompaction).
 	InputTokens  int64 `json:"input_tokens,omitempty"`
 	OutputTokens int64 `json:"output_tokens,omitempty"`
-	// ContextLimit is the model's context-window size in tokens, when known.
+	// ContextLimit is the model's context-window size in tokens. It is
+	// 0 when the model definition is unavailable (e.g. an unknown
+	// model ID); hooks should treat 0 as "unknown" rather than as a
+	// real limit.
 	ContextLimit int64 `json:"context_limit,omitempty"`
 	// CompactionReason is one of "threshold", "overflow", "manual".
 	CompactionReason string `json:"compaction_reason,omitempty"`
-	// Summary is populated only on AfterCompaction with the final summary text.
+	// Summary is the produced compaction summary text. It is populated
+	// only on AfterCompaction (BeforeCompaction fires before any
+	// summary exists); on AfterCompaction it carries the actual text
+	// applied to the session so observability handlers can audit /
+	// archive what was summarized.
 	Summary string `json:"summary,omitempty"`
 }
 

--- a/pkg/hooks/types.go
+++ b/pkg/hooks/types.go
@@ -65,6 +65,29 @@ const (
 	// Observational; gives audit pipelines a single, structured "who
 	// approved what" record without re-implementing the chain.
 	EventOnToolApprovalDecision EventType = "on_tool_approval_decision"
+	// EventBeforeCompaction fires immediately before a session compaction
+	// runs. The hook can:
+	//   - veto the compaction by returning Decision == "block" (the runtime
+	//     skips compaction entirely);
+	//   - replace the LLM-generated summary by returning a non-empty
+	//     [HookSpecificOutput.Summary] (the runtime applies that summary
+	//     verbatim and skips the model call).
+	// The Input carries [Input.InputTokens], [Input.OutputTokens],
+	// [Input.ContextLimit] and [Input.CompactionReason] ("threshold",
+	// "overflow", or "manual") so handlers can decide based on real
+	// session pressure.
+	//
+	// Hook authors should be cautious about denying when
+	// CompactionReason == "overflow": the runtime is recovering from a
+	// context-overflow error and a denial here will leave the session
+	// unable to make progress.
+	EventBeforeCompaction EventType = "before_compaction"
+	// EventAfterCompaction fires after a session compaction completes
+	// successfully (a summary was applied to the session). The Input
+	// carries the produced [Input.Summary] for observability or
+	// downstream pipelines (audit logs, telemetry, ...). It is purely
+	// observational; output is ignored.
+	EventAfterCompaction EventType = "after_compaction"
 )
 
 // Input is the JSON-serializable payload passed to hooks via stdin.
@@ -82,7 +105,7 @@ type Input struct {
 	ToolResponse any  `json:"tool_response,omitempty"`
 	ToolError    bool `json:"tool_error,omitempty"`
 
-	// SessionStart specific: "startup", "resume", "clear", "compact".
+	// SessionStart specific: "startup", "resume", "clear".
 	Source string `json:"source,omitempty"`
 	// SessionEnd specific: "clear", "logout", "prompt_input_exit", "other".
 	Reason string `json:"reason,omitempty"`
@@ -118,6 +141,16 @@ type Input struct {
 	// "user_approved_tool", "user_rejected", "context_canceled").
 	ApprovalDecision string `json:"approval_decision,omitempty"`
 	ApprovalSource   string `json:"approval_source,omitempty"`
+
+	// Compaction fields (BeforeCompaction, AfterCompaction).
+	InputTokens  int64 `json:"input_tokens,omitempty"`
+	OutputTokens int64 `json:"output_tokens,omitempty"`
+	// ContextLimit is the model's context-window size in tokens, when known.
+	ContextLimit int64 `json:"context_limit,omitempty"`
+	// CompactionReason is one of "threshold", "overflow", "manual".
+	CompactionReason string `json:"compaction_reason,omitempty"`
+	// Summary is populated only on AfterCompaction with the final summary text.
+	Summary string `json:"summary,omitempty"`
 }
 
 // ToJSON serializes the input.
@@ -196,6 +229,11 @@ type HookSpecificOutput struct {
 
 	// PostToolUse / SessionStart / TurnStart / Stop fields.
 	AdditionalContext string `json:"additional_context,omitempty"`
+
+	// BeforeCompaction: when non-empty, the runtime applies this string as
+	// the compaction summary verbatim and skips the LLM-based
+	// summarization. Ignored on every other event.
+	Summary string `json:"summary,omitempty"`
 }
 
 // Result is the aggregated outcome of dispatching one event.
@@ -214,4 +252,8 @@ type Result struct {
 	ExitCode int
 	// Stderr captures stderr from a failing hook.
 	Stderr string
+	// Summary is set by EventBeforeCompaction hooks to override the
+	// LLM-generated compaction summary. When multiple hooks return a
+	// non-empty summary, the first one wins.
+	Summary string
 }

--- a/pkg/runtime/compactor/compactor.go
+++ b/pkg/runtime/compactor/compactor.go
@@ -1,0 +1,259 @@
+// Package compactor owns session-aware compaction work that used to live
+// inline in pkg/runtime: extracting the conversation to summarize,
+// computing the kept-tail boundary, and running the default LLM-based
+// summarization strategy.
+//
+// The runtime calls into this package once it has decided that
+// compaction should run (the trigger logic in pkg/runtime/loop.go) and
+// once it has dispatched the before_compaction hook (which may supply
+// its own summary, in which case this package is bypassed entirely).
+// The runtime owns event emission and session mutation; this package
+// produces the summary text and reports the structural facts the
+// runtime needs to apply it.
+//
+// This separation is deliberate: nothing in here imports pkg/runtime,
+// which keeps the dependency direction clean (runtime → compactor) and
+// lets future strategies (a non-LLM truncator, a remote summarizer, a
+// model-specific variant) live alongside [RunLLM] without bloating the
+// runtime package.
+package compactor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/compaction"
+	"github.com/docker/docker-agent/pkg/model/provider"
+	"github.com/docker/docker-agent/pkg/model/provider/options"
+	"github.com/docker/docker-agent/pkg/session"
+)
+
+// MaxSummaryTokens caps the summary's output length when using the
+// default LLM strategy. Exposed so callers building their own
+// strategies can match the runtime's expectations.
+const MaxSummaryTokens = 16_000
+
+// MaxKeepTokens is the runtime's policy for how much recent
+// conversation to preserve verbatim across a compaction. Messages
+// fitting in this window are kept aside; the rest are the candidates
+// to summarize. Exposed so user-supplied strategies can compute the
+// same kept-tail boundary the runtime uses.
+const MaxKeepTokens = 20_000
+
+// Result is the structural outcome of running a compaction strategy.
+// The runtime applies it to the parent session by appending a
+// session.Item with FirstKeptEntry set, resetting the running
+// input/output token tally, and recording Cost as the item's cost.
+type Result struct {
+	// Summary is the text that replaces the compacted conversation.
+	Summary string
+	// FirstKeptEntry is the index in the parent session's Messages
+	// slice of the first message preserved verbatim after compaction.
+	// All earlier non-system messages are folded into Summary.
+	FirstKeptEntry int
+	// Cost is the dollar cost of producing Summary (zero for non-LLM
+	// strategies).
+	Cost float64
+	// InputTokens is the new "input tokens so far" tally for the
+	// parent session after compaction. The runtime assigns it to
+	// sess.InputTokens; sess.OutputTokens is reset to 0.
+	InputTokens int64
+}
+
+// RunAgent runs an agent against a session, blocking until the agent
+// stops. The runtime supplies an implementation when calling [RunLLM];
+// this avoids creating an import cycle on pkg/runtime (we'd otherwise
+// need runtime.New to spin up the compaction sub-runtime).
+type RunAgent func(ctx context.Context, a *agent.Agent, sess *session.Session) error
+
+// LLMArgs is the input to [RunLLM].
+type LLMArgs struct {
+	// Session is the parent session whose conversation is being
+	// compacted. The strategy reads from it but does not mutate it.
+	Session *session.Session
+	// Agent is the parent agent. Its model is cloned (with structured
+	// output disabled and a hard MaxTokens cap) to perform the
+	// summarization.
+	Agent *agent.Agent
+	// AdditionalPrompt is an optional extra instruction appended to
+	// the canonical compaction prompt (e.g. "focus on code changes").
+	// Empty in the proactive/overflow paths; populated by the manual
+	// /compact command.
+	AdditionalPrompt string
+	// ContextLimit is the parent model's context-window size in
+	// tokens, used to truncate the conversation we hand to the
+	// summarizer so the request itself doesn't blow the window.
+	// Zero is treated as "unknown" and yields the empty conversation
+	// — the LLM strategy needs a real number to work with.
+	ContextLimit int64
+	// RunAgent runs the synthesized compaction agent against the
+	// synthesized child session. Required.
+	RunAgent RunAgent
+}
+
+// RunLLM is the default LLM-based summarization strategy. It clones
+// the parent agent's model with summary-friendly options, builds a
+// fresh compaction agent + child session, hands the work to
+// [LLMArgs.RunAgent], and returns the produced summary together with
+// the kept-tail boundary the runtime needs to apply it.
+//
+// Returns (nil, nil) when the model returns an empty summary; callers
+// should treat that as "compaction was a no-op" and skip the apply
+// step.
+func RunLLM(ctx context.Context, args LLMArgs) (*Result, error) {
+	if args.RunAgent == nil {
+		return nil, errors.New("compactor: RunAgent is required")
+	}
+	if args.Agent == nil {
+		return nil, errors.New("compactor: Agent is required")
+	}
+	if args.ContextLimit <= 0 {
+		return nil, errors.New("compactor: ContextLimit must be > 0")
+	}
+	if args.Agent.Model() == nil {
+		return nil, errors.New("compactor: agent has no model")
+	}
+
+	summaryModel := provider.CloneWithOptions(ctx, args.Agent.Model(),
+		options.WithStructuredOutput(nil),
+		options.WithMaxTokens(MaxSummaryTokens),
+	)
+	compactionAgent := agent.New("root", compaction.SystemPrompt, agent.WithModel(summaryModel))
+
+	messages, firstKeptEntry := ExtractMessages(args.Session, compactionAgent, args.ContextLimit, args.AdditionalPrompt)
+
+	compactionSession := session.New(
+		session.WithTitle("Generating summary"),
+		session.WithMessages(toItems(messages)),
+	)
+
+	if err := args.RunAgent(ctx, compactionAgent, compactionSession); err != nil {
+		return nil, fmt.Errorf("run compaction agent: %w", err)
+	}
+
+	summary := compactionSession.GetLastAssistantMessageContent()
+	if summary == "" {
+		return nil, nil
+	}
+
+	return &Result{
+		Summary:        summary,
+		FirstKeptEntry: firstKeptEntry,
+		Cost:           compactionSession.TotalCost(),
+		InputTokens:    compactionSession.OutputTokens,
+	}, nil
+}
+
+// ExtractMessages returns the messages to send to the compaction
+// model, plus the index (into sess.Messages) of the first message
+// that is kept verbatim after compaction. The caller is responsible
+// for actually preserving that tail; this function only computes the
+// boundary.
+//
+// The returned messages always begin with the canonical compaction
+// system prompt and end with the user prompt (optionally extended by
+// additionalPrompt). Cost / cache-control flags on the conversation
+// are cleared so the summarization request doesn't accidentally pin
+// a cache checkpoint or accrue duplicate cost.
+//
+// If the conversation tail itself doesn't fit in
+// (contextLimit − MaxSummaryTokens − prompt-overhead), older messages
+// are dropped from the front of the to-compact list to make room.
+func ExtractMessages(sess *session.Session, a *agent.Agent, contextLimit int64, additionalPrompt string) ([]chat.Message, int) {
+	var messages []chat.Message
+	for _, msg := range sess.GetMessages(a) {
+		if msg.Role == chat.MessageRoleSystem {
+			continue
+		}
+		msg.Cost = 0
+		msg.CacheControl = false
+		messages = append(messages, msg)
+	}
+
+	splitIdx := compaction.SplitIndexForKeep(messages, MaxKeepTokens)
+	messagesToCompact := messages[:splitIdx]
+	firstKeptEntry := MapToSessionIndex(sess, splitIdx)
+
+	messages = messagesToCompact
+
+	systemPromptMessage := chat.Message{
+		Role:      chat.MessageRoleSystem,
+		Content:   compaction.SystemPrompt,
+		CreatedAt: time.Now().Format(time.RFC3339),
+	}
+	systemPromptLen := compaction.EstimateMessageTokens(&systemPromptMessage)
+
+	userPrompt := compaction.UserPrompt
+	if additionalPrompt != "" {
+		userPrompt += "\n\n" + additionalPrompt
+	}
+	userPromptMessage := chat.Message{
+		Role:      chat.MessageRoleUser,
+		Content:   userPrompt,
+		CreatedAt: time.Now().Format(time.RFC3339),
+	}
+	userPromptLen := compaction.EstimateMessageTokens(&userPromptMessage)
+
+	contextAvailable := max(int64(0), contextLimit-MaxSummaryTokens-systemPromptLen-userPromptLen)
+	firstIndex := compaction.FirstIndexInBudget(messages, contextAvailable)
+	if firstIndex < len(messages) {
+		messages = messages[firstIndex:]
+	} else {
+		messages = nil
+	}
+
+	messages = append([]chat.Message{systemPromptMessage}, messages...)
+	messages = append(messages, userPromptMessage)
+	return messages, firstKeptEntry
+}
+
+// ComputeFirstKeptEntry returns the index in sess.Messages of the
+// first message preserved verbatim after compaction, given the
+// [MaxKeepTokens] window. Used by callers (typically the runtime
+// after a hook supplies its own summary) that need the kept-tail
+// boundary without invoking the LLM strategy.
+func ComputeFirstKeptEntry(sess *session.Session, a *agent.Agent) int {
+	var messages []chat.Message
+	for _, msg := range sess.GetMessages(a) {
+		if msg.Role == chat.MessageRoleSystem {
+			continue
+		}
+		messages = append(messages, msg)
+	}
+	return MapToSessionIndex(sess, compaction.SplitIndexForKeep(messages, MaxKeepTokens))
+}
+
+// MapToSessionIndex maps an index in the non-system-filtered message
+// list (the form [ExtractMessages] operates on) back to an index in
+// sess.Messages.
+//
+// Returns len(sess.Messages) when filteredIdx is past the end — i.e.
+// "compact everything; keep nothing of the tail".
+func MapToSessionIndex(sess *session.Session, filteredIdx int) int {
+	count := 0
+	for i, item := range sess.Messages {
+		if item.IsMessage() && item.Message.Message.Role != chat.MessageRoleSystem {
+			if count == filteredIdx {
+				return i
+			}
+			count++
+		}
+	}
+	return len(sess.Messages)
+}
+
+// toItems wraps a flat slice of chat messages into session items so a
+// fresh session can be built from them for the compaction sub-run.
+func toItems(messages []chat.Message) []session.Item {
+	var items []session.Item
+	for _, message := range messages {
+		items = append(items, session.Item{
+			Message: &session.Message{Message: message},
+		})
+	}
+	return items
+}

--- a/pkg/runtime/compactor/compactor.go
+++ b/pkg/runtime/compactor/compactor.go
@@ -190,6 +190,14 @@ func nonSystemMessages(sess *session.Session, a *agent.Agent) []chat.Message {
 // are dropped from the front of the to-compact list to make room.
 func extractMessages(sess *session.Session, a *agent.Agent, contextLimit int64, additionalPrompt string) ([]chat.Message, int) {
 	messages := nonSystemMessages(sess, a)
+	// Clear Cost and CacheControl on our local copy of the conversation.
+	// Cost is per-message bookkeeping that's already accumulated into
+	// sess.TotalCost(); leaving it set would double-count when the
+	// summarization session reports its own TotalCost back through the
+	// compactor.Result.Cost field. CacheControl pins a provider cache
+	// checkpoint (Anthropic prompt caching, etc.); pinning it inside the
+	// summarization sub-call would associate the cache point with the
+	// throwaway compaction conversation rather than the parent session.
 	for i := range messages {
 		messages[i].Cost = 0
 		messages[i].CacheControl = false

--- a/pkg/runtime/compactor/compactor.go
+++ b/pkg/runtime/compactor/compactor.go
@@ -33,16 +33,16 @@ import (
 )
 
 // MaxSummaryTokens caps the summary's output length when using the
-// default LLM strategy. Exposed so callers building their own
-// strategies can match the runtime's expectations.
+// default LLM strategy. Exposed because the runtime subtracts it from
+// the model's context budget when deciding whether the model lookup
+// produced a workable limit.
 const MaxSummaryTokens = 16_000
 
-// MaxKeepTokens is the runtime's policy for how much recent
+// maxKeepTokens is the runtime's policy for how much recent
 // conversation to preserve verbatim across a compaction. Messages
 // fitting in this window are kept aside; the rest are the candidates
-// to summarize. Exposed so user-supplied strategies can compute the
-// same kept-tail boundary the runtime uses.
-const MaxKeepTokens = 20_000
+// to summarize.
+const maxKeepTokens = 20_000
 
 // Result is the structural outcome of running a compaction strategy.
 // The runtime applies it to the parent session by appending a
@@ -87,8 +87,8 @@ type LLMArgs struct {
 	// ContextLimit is the parent model's context-window size in
 	// tokens, used to truncate the conversation we hand to the
 	// summarizer so the request itself doesn't blow the window.
-	// Zero is treated as "unknown" and yields the empty conversation
-	// — the LLM strategy needs a real number to work with.
+	// Required: zero is rejected, since the LLM strategy needs a real
+	// number to work with.
 	ContextLimit int64
 	// RunAgent runs the synthesized compaction agent against the
 	// synthesized child session. Required.
@@ -124,7 +124,7 @@ func RunLLM(ctx context.Context, args LLMArgs) (*Result, error) {
 	)
 	compactionAgent := agent.New("root", compaction.SystemPrompt, agent.WithModel(summaryModel))
 
-	messages, firstKeptEntry := ExtractMessages(args.Session, compactionAgent, args.ContextLimit, args.AdditionalPrompt)
+	messages, firstKeptEntry := extractMessages(args.Session, compactionAgent, args.ContextLimit, args.AdditionalPrompt)
 
 	compactionSession := session.New(
 		session.WithTitle("Generating summary"),
@@ -148,7 +148,32 @@ func RunLLM(ctx context.Context, args LLMArgs) (*Result, error) {
 	}, nil
 }
 
-// ExtractMessages returns the messages to send to the compaction
+// ComputeFirstKeptEntry returns the index in sess.Messages of the
+// first message preserved verbatim after compaction, given the
+// [maxKeepTokens] window. Used by the runtime when a hook supplies
+// its own summary so the kept-tail policy stays consistent across
+// the two strategies.
+func ComputeFirstKeptEntry(sess *session.Session, a *agent.Agent) int {
+	return mapToSessionIndex(sess, compaction.SplitIndexForKeep(nonSystemMessages(sess, a), maxKeepTokens))
+}
+
+// nonSystemMessages returns the agent-visible messages in sess with
+// the system entries filtered out. Both the LLM strategy (via
+// [extractMessages]) and the hook-supplied path (via
+// [ComputeFirstKeptEntry]) operate on this same shape, which is also
+// what [compaction.SplitIndexForKeep] expects.
+func nonSystemMessages(sess *session.Session, a *agent.Agent) []chat.Message {
+	var messages []chat.Message
+	for _, msg := range sess.GetMessages(a) {
+		if msg.Role == chat.MessageRoleSystem {
+			continue
+		}
+		messages = append(messages, msg)
+	}
+	return messages
+}
+
+// extractMessages returns the messages to send to the compaction
 // model, plus the index (into sess.Messages) of the first message
 // that is kept verbatim after compaction. The caller is responsible
 // for actually preserving that tail; this function only computes the
@@ -163,30 +188,22 @@ func RunLLM(ctx context.Context, args LLMArgs) (*Result, error) {
 // If the conversation tail itself doesn't fit in
 // (contextLimit − MaxSummaryTokens − prompt-overhead), older messages
 // are dropped from the front of the to-compact list to make room.
-func ExtractMessages(sess *session.Session, a *agent.Agent, contextLimit int64, additionalPrompt string) ([]chat.Message, int) {
-	var messages []chat.Message
-	for _, msg := range sess.GetMessages(a) {
-		if msg.Role == chat.MessageRoleSystem {
-			continue
-		}
-		msg.Cost = 0
-		msg.CacheControl = false
-		messages = append(messages, msg)
+func extractMessages(sess *session.Session, a *agent.Agent, contextLimit int64, additionalPrompt string) ([]chat.Message, int) {
+	messages := nonSystemMessages(sess, a)
+	for i := range messages {
+		messages[i].Cost = 0
+		messages[i].CacheControl = false
 	}
 
-	splitIdx := compaction.SplitIndexForKeep(messages, MaxKeepTokens)
-	messagesToCompact := messages[:splitIdx]
-	firstKeptEntry := MapToSessionIndex(sess, splitIdx)
-
-	messages = messagesToCompact
+	splitIdx := compaction.SplitIndexForKeep(messages, maxKeepTokens)
+	firstKeptEntry := mapToSessionIndex(sess, splitIdx)
+	messages = messages[:splitIdx]
 
 	systemPromptMessage := chat.Message{
 		Role:      chat.MessageRoleSystem,
 		Content:   compaction.SystemPrompt,
 		CreatedAt: time.Now().Format(time.RFC3339),
 	}
-	systemPromptLen := compaction.EstimateMessageTokens(&systemPromptMessage)
-
 	userPrompt := compaction.UserPrompt
 	if additionalPrompt != "" {
 		userPrompt += "\n\n" + additionalPrompt
@@ -196,9 +213,11 @@ func ExtractMessages(sess *session.Session, a *agent.Agent, contextLimit int64, 
 		Content:   userPrompt,
 		CreatedAt: time.Now().Format(time.RFC3339),
 	}
-	userPromptLen := compaction.EstimateMessageTokens(&userPromptMessage)
 
-	contextAvailable := max(int64(0), contextLimit-MaxSummaryTokens-systemPromptLen-userPromptLen)
+	contextAvailable := max(int64(0),
+		contextLimit-MaxSummaryTokens-
+			compaction.EstimateMessageTokens(&systemPromptMessage)-
+			compaction.EstimateMessageTokens(&userPromptMessage))
 	firstIndex := compaction.FirstIndexInBudget(messages, contextAvailable)
 	if firstIndex < len(messages) {
 		messages = messages[firstIndex:]
@@ -211,29 +230,11 @@ func ExtractMessages(sess *session.Session, a *agent.Agent, contextLimit int64, 
 	return messages, firstKeptEntry
 }
 
-// ComputeFirstKeptEntry returns the index in sess.Messages of the
-// first message preserved verbatim after compaction, given the
-// [MaxKeepTokens] window. Used by callers (typically the runtime
-// after a hook supplies its own summary) that need the kept-tail
-// boundary without invoking the LLM strategy.
-func ComputeFirstKeptEntry(sess *session.Session, a *agent.Agent) int {
-	var messages []chat.Message
-	for _, msg := range sess.GetMessages(a) {
-		if msg.Role == chat.MessageRoleSystem {
-			continue
-		}
-		messages = append(messages, msg)
-	}
-	return MapToSessionIndex(sess, compaction.SplitIndexForKeep(messages, MaxKeepTokens))
-}
-
-// MapToSessionIndex maps an index in the non-system-filtered message
-// list (the form [ExtractMessages] operates on) back to an index in
-// sess.Messages.
-//
-// Returns len(sess.Messages) when filteredIdx is past the end — i.e.
-// "compact everything; keep nothing of the tail".
-func MapToSessionIndex(sess *session.Session, filteredIdx int) int {
+// mapToSessionIndex maps an index in the non-system-filtered message
+// list (the form [extractMessages] operates on) back to an index in
+// sess.Messages. Returns len(sess.Messages) when filteredIdx is past
+// the end — i.e. "compact everything; keep nothing of the tail".
+func mapToSessionIndex(sess *session.Session, filteredIdx int) int {
 	count := 0
 	for i, item := range sess.Messages {
 		if item.IsMessage() && item.Message.Message.Role != chat.MessageRoleSystem {
@@ -249,11 +250,9 @@ func MapToSessionIndex(sess *session.Session, filteredIdx int) int {
 // toItems wraps a flat slice of chat messages into session items so a
 // fresh session can be built from them for the compaction sub-run.
 func toItems(messages []chat.Message) []session.Item {
-	var items []session.Item
-	for _, message := range messages {
-		items = append(items, session.Item{
-			Message: &session.Message{Message: message},
-		})
+	items := make([]session.Item, len(messages))
+	for i, message := range messages {
+		items[i] = session.Item{Message: &session.Message{Message: message}}
 	}
 	return items
 }

--- a/pkg/runtime/compactor/compactor_test.go
+++ b/pkg/runtime/compactor/compactor_test.go
@@ -1,0 +1,244 @@
+package compactor
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/compaction"
+	"github.com/docker/docker-agent/pkg/session"
+)
+
+func TestExtractMessages(t *testing.T) {
+	t.Parallel()
+
+	newMsg := func(role chat.MessageRole, content string) session.Item {
+		return session.NewMessageItem(&session.Message{
+			Message: chat.Message{Role: role, Content: content},
+		})
+	}
+
+	tests := []struct {
+		name                     string
+		messages                 []session.Item
+		contextLimit             int64
+		additionalPrompt         string
+		wantConversationMsgCount int
+	}{
+		{
+			name:                     "empty session returns system and user prompt only",
+			messages:                 nil,
+			contextLimit:             100_000,
+			wantConversationMsgCount: 0,
+		},
+		{
+			name: "system messages are filtered out",
+			messages: []session.Item{
+				newMsg(chat.MessageRoleSystem, "system instruction"),
+				newMsg(chat.MessageRoleUser, "hello"),
+				newMsg(chat.MessageRoleAssistant, "hi"),
+			},
+			contextLimit:             100_000,
+			wantConversationMsgCount: 2,
+		},
+		{
+			name: "messages fit within context limit",
+			messages: []session.Item{
+				newMsg(chat.MessageRoleUser, "msg1"),
+				newMsg(chat.MessageRoleAssistant, "msg2"),
+				newMsg(chat.MessageRoleUser, "msg3"),
+				newMsg(chat.MessageRoleAssistant, "msg4"),
+			},
+			contextLimit:             100_000,
+			wantConversationMsgCount: 4,
+		},
+		{
+			name: "truncation when context limit is very small",
+			messages: []session.Item{
+				newMsg(chat.MessageRoleUser, "first message with lots of content that takes tokens"),
+				newMsg(chat.MessageRoleAssistant, "first response with lots of content that takes tokens"),
+				newMsg(chat.MessageRoleUser, "second message"),
+				newMsg(chat.MessageRoleAssistant, "second response"),
+			},
+			// Set context limit so small that after subtracting MaxSummaryTokens + prompt overhead,
+			// not all messages fit.
+			contextLimit:             MaxSummaryTokens + 50,
+			wantConversationMsgCount: 0,
+		},
+		{
+			name: "additional prompt is appended",
+			messages: []session.Item{
+				newMsg(chat.MessageRoleUser, "hello"),
+			},
+			contextLimit:             100_000,
+			additionalPrompt:         "focus on code quality",
+			wantConversationMsgCount: 1,
+		},
+		{
+			name: "cost and cache control are cleared",
+			messages: []session.Item{
+				session.NewMessageItem(&session.Message{
+					Message: chat.Message{
+						Role:         chat.MessageRoleUser,
+						Content:      "hello",
+						Cost:         1.5,
+						CacheControl: true,
+					},
+				}),
+			},
+			contextLimit:             100_000,
+			wantConversationMsgCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			sess := session.New(session.WithMessages(tt.messages))
+			a := agent.New("test", "test prompt")
+			result, _ := ExtractMessages(sess, a, tt.contextLimit, tt.additionalPrompt)
+
+			require.GreaterOrEqual(t, len(result), tt.wantConversationMsgCount+2)
+			assert.Equal(t, chat.MessageRoleSystem, result[0].Role)
+			assert.Equal(t, compaction.SystemPrompt, result[0].Content)
+
+			last := result[len(result)-1]
+			assert.Equal(t, chat.MessageRoleUser, last.Role)
+			expectedPrompt := compaction.UserPrompt
+			if tt.additionalPrompt != "" {
+				expectedPrompt += "\n\n" + tt.additionalPrompt
+			}
+			assert.Equal(t, expectedPrompt, last.Content)
+
+			// Conversation messages are all except first (system) and last (user prompt)
+			assert.Len(t, result[1:len(result)-1], tt.wantConversationMsgCount)
+
+			// Verify cost and cache control are cleared on conversation messages
+			for i := 1; i < len(result)-1; i++ {
+				assert.Zero(t, result[i].Cost)
+				assert.False(t, result[i].CacheControl)
+			}
+		})
+	}
+}
+
+func TestExtractMessages_KeepsRecentMessages(t *testing.T) {
+	t.Parallel()
+
+	// Create a session with many messages, some large enough that the last
+	// ~MaxKeepTokens are kept aside.
+	var items []session.Item
+	for range 10 {
+		items = append(items, session.NewMessageItem(&session.Message{
+			Message: chat.Message{
+				Role:    chat.MessageRoleUser,
+				Content: strings.Repeat("x", 20000), // ~5k tokens each
+			},
+		}), session.NewMessageItem(&session.Message{
+			Message: chat.Message{
+				Role:    chat.MessageRoleAssistant,
+				Content: strings.Repeat("y", 20000), // ~5k tokens each
+			},
+		}))
+	}
+
+	sess := session.New(session.WithMessages(items))
+	a := agent.New("test", "test prompt")
+
+	result, firstKeptEntry := ExtractMessages(sess, a, 200_000, "")
+
+	// 20 messages × ~5k tokens = ~100k. MaxKeepTokens=20k → ~4 messages kept.
+	compactedMsgCount := len(result) - 2 // minus system and user prompt
+	assert.Less(t, compactedMsgCount, 20, "some messages should have been kept aside")
+	assert.Positive(t, compactedMsgCount, "some messages should be compacted")
+
+	assert.Positive(t, firstKeptEntry, "firstKeptEntry should be > 0")
+	assert.Less(t, firstKeptEntry, len(sess.Messages), "firstKeptEntry should be within bounds")
+}
+
+func TestComputeFirstKeptEntry(t *testing.T) {
+	t.Parallel()
+
+	a := agent.New("test", "")
+
+	t.Run("empty session returns 0", func(t *testing.T) {
+		t.Parallel()
+		sess := session.New()
+		assert.Equal(t, 0, ComputeFirstKeptEntry(sess, a))
+	})
+
+	t.Run("short conversation: split at end (compact everything)", func(t *testing.T) {
+		t.Parallel()
+		sess := session.New(session.WithMessages([]session.Item{
+			session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleSystem, Content: "sys"}}),
+			session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleUser, Content: "hi"}}),
+			session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleAssistant, Content: "hello"}}),
+		}))
+		assert.Equal(t, len(sess.Messages), ComputeFirstKeptEntry(sess, a))
+	})
+}
+
+func TestMapToSessionIndex(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New(session.WithMessages([]session.Item{
+		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleSystem, Content: "sys"}}),
+		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleUser, Content: "u1"}}),
+		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleAssistant, Content: "a1"}}),
+		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleSystem, Content: "sys2"}}),
+		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleUser, Content: "u2"}}),
+	}))
+
+	// Filtered list (no system): [u1, a1, u2] → indices 0,1,2
+	// Map back to sess.Messages indices: 1, 2, 4
+	assert.Equal(t, 1, MapToSessionIndex(sess, 0))
+	assert.Equal(t, 2, MapToSessionIndex(sess, 1))
+	assert.Equal(t, 4, MapToSessionIndex(sess, 2))
+	// Past the end: returns len(sess.Messages)
+	assert.Equal(t, len(sess.Messages), MapToSessionIndex(sess, 3))
+}
+
+// TestRunLLM_RequiresRunAgent pins the contract that a missing RunAgent
+// callback is rejected loudly rather than silently no-oping.
+func TestRunLLM_RequiresRunAgent(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	a := agent.New("test", "test")
+
+	_, err := RunLLM(t.Context(), LLMArgs{
+		Session:      sess,
+		Agent:        a,
+		ContextLimit: 100_000,
+		// RunAgent intentionally nil
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "RunAgent")
+}
+
+// TestRunLLM_RequiresContextLimit pins that the LLM strategy refuses
+// to run without a real context budget — it would otherwise feed an
+// empty conversation to the model.
+func TestRunLLM_RequiresContextLimit(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	a := agent.New("test", "test")
+
+	_, err := RunLLM(t.Context(), LLMArgs{
+		Session:      sess,
+		Agent:        a,
+		ContextLimit: 0,
+		RunAgent: func(context.Context, *agent.Agent, *session.Session) error {
+			return errors.New("should not be called")
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ContextLimit")
+}

--- a/pkg/runtime/compactor/compactor_test.go
+++ b/pkg/runtime/compactor/compactor_test.go
@@ -66,8 +66,6 @@ func TestExtractMessages(t *testing.T) {
 				newMsg(chat.MessageRoleUser, "second message"),
 				newMsg(chat.MessageRoleAssistant, "second response"),
 			},
-			// Set context limit so small that after subtracting MaxSummaryTokens + prompt overhead,
-			// not all messages fit.
 			contextLimit:             MaxSummaryTokens + 50,
 			wantConversationMsgCount: 0,
 		},
@@ -102,7 +100,7 @@ func TestExtractMessages(t *testing.T) {
 			t.Parallel()
 			sess := session.New(session.WithMessages(tt.messages))
 			a := agent.New("test", "test prompt")
-			result, _ := ExtractMessages(sess, a, tt.contextLimit, tt.additionalPrompt)
+			result, _ := extractMessages(sess, a, tt.contextLimit, tt.additionalPrompt)
 
 			require.GreaterOrEqual(t, len(result), tt.wantConversationMsgCount+2)
 			assert.Equal(t, chat.MessageRoleSystem, result[0].Role)
@@ -151,9 +149,9 @@ func TestExtractMessages_KeepsRecentMessages(t *testing.T) {
 	sess := session.New(session.WithMessages(items))
 	a := agent.New("test", "test prompt")
 
-	result, firstKeptEntry := ExtractMessages(sess, a, 200_000, "")
+	result, firstKeptEntry := extractMessages(sess, a, 200_000, "")
 
-	// 20 messages × ~5k tokens = ~100k. MaxKeepTokens=20k → ~4 messages kept.
+	// 20 messages × ~5k tokens = ~100k. maxKeepTokens=20k → ~4 messages kept.
 	compactedMsgCount := len(result) - 2 // minus system and user prompt
 	assert.Less(t, compactedMsgCount, 20, "some messages should have been kept aside")
 	assert.Positive(t, compactedMsgCount, "some messages should be compacted")
@@ -197,11 +195,11 @@ func TestMapToSessionIndex(t *testing.T) {
 
 	// Filtered list (no system): [u1, a1, u2] → indices 0,1,2
 	// Map back to sess.Messages indices: 1, 2, 4
-	assert.Equal(t, 1, MapToSessionIndex(sess, 0))
-	assert.Equal(t, 2, MapToSessionIndex(sess, 1))
-	assert.Equal(t, 4, MapToSessionIndex(sess, 2))
+	assert.Equal(t, 1, mapToSessionIndex(sess, 0))
+	assert.Equal(t, 2, mapToSessionIndex(sess, 1))
+	assert.Equal(t, 4, mapToSessionIndex(sess, 2))
 	// Past the end: returns len(sess.Messages)
-	assert.Equal(t, len(sess.Messages), MapToSessionIndex(sess, 3))
+	assert.Equal(t, len(sess.Messages), mapToSessionIndex(sess, 3))
 }
 
 // TestRunLLM_RequiresRunAgent pins the contract that a missing RunAgent

--- a/pkg/runtime/hooks.go
+++ b/pkg/runtime/hooks.go
@@ -342,19 +342,25 @@ func (r *LocalRuntime) executeBeforeCompactionHooks(
 // executeAfterCompactionHooks fires after a successful compaction has
 // applied a summary to the session. Purely observational — the result
 // is discarded.
+//
+// The Input carries the *pre-compaction* token counts (what was
+// summarized), not the new ones, so handlers can naturally express
+// "compacted from X to Y". The post-compaction counts are reflected
+// in the next [NewTokenUsageEvent] the runtime emits.
 func (r *LocalRuntime) executeAfterCompactionHooks(
 	ctx context.Context,
 	sess *session.Session,
 	a *agent.Agent,
 	reason string,
 	contextLimit int64,
+	preInputTokens, preOutputTokens int64,
 	summary string,
 	events chan Event,
 ) {
 	r.dispatchHook(ctx, a, hooks.EventAfterCompaction, &hooks.Input{
 		SessionID:        sess.ID,
-		InputTokens:      sess.InputTokens,
-		OutputTokens:     sess.OutputTokens,
+		InputTokens:      preInputTokens,
+		OutputTokens:     preOutputTokens,
 		ContextLimit:     contextLimit,
 		CompactionReason: reason,
 		Summary:          summary,

--- a/pkg/runtime/hooks.go
+++ b/pkg/runtime/hooks.go
@@ -103,6 +103,12 @@ func (r *LocalRuntime) dispatchHook(
 // returned slice through [session.Session.GetMessages] on every
 // iteration so cwd / OS / arch context reaches the model without ever
 // being stored.
+//
+// Compaction does NOT re-fire session_start. The transient nature of
+// sessionStartMsgs means env / cwd / OS context is automatically
+// included in every model call after a compaction, without any extra
+// dispatch — there's nothing to "re-inject" because nothing was
+// persisted in the first place.
 func (r *LocalRuntime) executeSessionStartHooks(ctx context.Context, sess *session.Session, a *agent.Agent, events chan Event) []chat.Message {
 	return contextMessages(r.dispatchHook(ctx, a, hooks.EventSessionStart, &hooks.Input{
 		SessionID: sess.ID,
@@ -305,4 +311,52 @@ func (r *LocalRuntime) executeOnUserInputHooks(ctx context.Context, sessionID, l
 	r.dispatchHook(ctx, a, hooks.EventOnUserInput, &hooks.Input{
 		SessionID: sessionID,
 	}, nil)
+}
+
+// executeBeforeCompactionHooks fires before a session compaction. The
+// hook may veto the compaction (Decision: "block") or supply a custom
+// summary string via [hooks.HookSpecificOutput.Summary] to skip the
+// LLM-based summarization. The Result is returned verbatim so the
+// caller (doCompact) can act on Allowed and Summary.
+//
+// Returns nil when no hook is configured for this event so the caller
+// can use a single nil check to mean "nothing to do, fall through to
+// the default LLM-based path".
+func (r *LocalRuntime) executeBeforeCompactionHooks(
+	ctx context.Context,
+	sess *session.Session,
+	a *agent.Agent,
+	reason string,
+	contextLimit int64,
+	events chan Event,
+) *hooks.Result {
+	return r.dispatchHook(ctx, a, hooks.EventBeforeCompaction, &hooks.Input{
+		SessionID:        sess.ID,
+		InputTokens:      sess.InputTokens,
+		OutputTokens:     sess.OutputTokens,
+		ContextLimit:     contextLimit,
+		CompactionReason: reason,
+	}, events)
+}
+
+// executeAfterCompactionHooks fires after a successful compaction has
+// applied a summary to the session. Purely observational — the result
+// is discarded.
+func (r *LocalRuntime) executeAfterCompactionHooks(
+	ctx context.Context,
+	sess *session.Session,
+	a *agent.Agent,
+	reason string,
+	contextLimit int64,
+	summary string,
+	events chan Event,
+) {
+	r.dispatchHook(ctx, a, hooks.EventAfterCompaction, &hooks.Input{
+		SessionID:        sess.ID,
+		InputTokens:      sess.InputTokens,
+		OutputTokens:     sess.OutputTokens,
+		ContextLimit:     contextLimit,
+		CompactionReason: reason,
+		Summary:          summary,
+	}, events)
 }

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -325,7 +325,7 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 			contextLimit = int64(m.Limit.Context)
 
 			if r.sessionCompaction && compaction.ShouldCompact(sess.InputTokens, sess.OutputTokens, 0, contextLimit) {
-				r.Summarize(ctx, sess, "", events)
+				r.compactWithReason(ctx, sess, "", compactionReasonThreshold, events)
 			}
 		}
 
@@ -614,7 +614,7 @@ func (r *LocalRuntime) compactIfNeeded(
 		"estimated_total", sess.InputTokens+sess.OutputTokens+addedTokens,
 		"context_limit", contextLimit,
 	)
-	r.Summarize(ctx, sess, "", events)
+	r.compactWithReason(ctx, sess, "", compactionReasonThreshold, events)
 }
 
 // getTools executes tool retrieval with automatic OAuth handling.

--- a/pkg/runtime/loop_steps.go
+++ b/pkg/runtime/loop_steps.go
@@ -177,7 +177,7 @@ func (r *LocalRuntime) handleStreamError(
 			"The conversation has exceeded the model's context window. Automatically compacting the conversation history...",
 			a.Name(),
 		)
-		r.Summarize(ctx, sess, "", events)
+		r.compactWithReason(ctx, sess, "", compactionReasonOverflow, events)
 		return streamErrorRetry
 	}
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -947,9 +947,26 @@ func (r *LocalRuntime) startSpan(ctx context.Context, name string, opts ...trace
 // Summarize generates a summary for the session based on the conversation history.
 // The additionalPrompt parameter allows users to provide additional instructions
 // for the summarization (e.g., "focus on code changes" or "include action items").
+//
+// Summarize is the public entry point used by user-driven /compact actions; it
+// reports compactionReasonManual to BeforeCompaction / AfterCompaction hooks.
+// Internal callers (proactive threshold, overflow recovery) use
+// [LocalRuntime.compactWithReason] directly to forward a more specific reason.
 func (r *LocalRuntime) Summarize(ctx context.Context, sess *session.Session, additionalPrompt string, events chan Event) {
+	r.compactWithReason(ctx, sess, additionalPrompt, compactionReasonManual, events)
+}
+
+// compactWithReason runs a session compaction with the supplied reason and
+// emits a TokenUsageEvent so the UI immediately reflects the new context
+// pressure.
+//
+// reason is reported to BeforeCompaction / AfterCompaction hooks as
+// CompactionReason. Use [compactionReasonThreshold] for proactive
+// 90%-of-context triggers, [compactionReasonOverflow] for post-overflow
+// auto-recovery, or [compactionReasonManual] for user-invoked compactions.
+func (r *LocalRuntime) compactWithReason(ctx context.Context, sess *session.Session, additionalPrompt, reason string, events chan Event) {
 	a := r.resolveSessionAgent(sess)
-	r.doCompact(ctx, sess, a, additionalPrompt, events)
+	r.doCompact(ctx, sess, a, additionalPrompt, reason, events)
 
 	// Emit a TokenUsageEvent so the sidebar immediately reflects the
 	// compaction: tokens drop to the summary size, context % drops, and

--- a/pkg/runtime/session_compaction.go
+++ b/pkg/runtime/session_compaction.go
@@ -101,6 +101,14 @@ func (r *LocalRuntime) doCompact(ctx context.Context, sess *session.Session, a *
 		}
 	}
 
+	// Capture the pre-compaction token counts so the after_compaction
+	// hook can observe what was summarized ("compacted from X to Y").
+	// We snapshot before applying the result because the apply step
+	// resets sess.OutputTokens to 0 and replaces sess.InputTokens with
+	// the new summary's estimated size.
+	preInputTokens := sess.InputTokens
+	preOutputTokens := sess.OutputTokens
+
 	// Apply the summary to the session. This is intrinsically
 	// runtime-private: it mutates session-internal state and persists
 	// through the runtime's session store.
@@ -117,8 +125,12 @@ func (r *LocalRuntime) doCompact(ctx context.Context, sess *session.Session, a *
 	events <- SessionSummary(sess.ID, result.Summary, a.Name(), result.FirstKeptEntry)
 
 	// after_compaction: observational. Fired only when a summary was
-	// actually applied to the session.
-	r.executeAfterCompactionHooks(ctx, sess, a, reason, contextLimit, result.Summary, events)
+	// actually applied to the session. The hook receives the
+	// pre-compaction token counts (what was summarized) so observability
+	// handlers can compute "compacted from X to Y"; the new (lower)
+	// counts live on sess.InputTokens / sess.OutputTokens after this
+	// returns and are exposed via the next TokenUsageEvent.
+	r.executeAfterCompactionHooks(ctx, sess, a, reason, contextLimit, preInputTokens, preOutputTokens, result.Summary, events)
 }
 
 // summaryFromHook lifts a before_compaction hook's Summary verdict into
@@ -128,8 +140,9 @@ func (r *LocalRuntime) doCompact(ctx context.Context, sess *session.Session, a *
 //
 // The hook only contributes the summary text; the runtime fills in the
 // kept-tail boundary (matching the LLM path's policy) and estimates the
-// summary's token count for session bookkeeping. Cost is zero since no
-// LLM call ran.
+// summary's token count for session bookkeeping. The Result.Cost is
+// left at its zero value because no LLM call ran — the hook produced
+// the summary itself, so there's nothing to bill.
 func summaryFromHook(sess *session.Session, a *agent.Agent, pre *hooks.Result) *compactor.Result {
 	if pre == nil || pre.Summary == "" {
 		return nil
@@ -139,6 +152,8 @@ func summaryFromHook(sess *session.Session, a *agent.Agent, pre *hooks.Result) *
 	return &compactor.Result{
 		Summary:        pre.Summary,
 		FirstKeptEntry: compactor.ComputeFirstKeptEntry(sess, a),
+		// Estimate the summary's token count for session bookkeeping;
+		// no LLM was called so Cost stays at the zero value.
 		InputTokens: compaction.EstimateMessageTokens(&chat.Message{
 			Role:    chat.MessageRoleAssistant,
 			Content: pre.Summary,

--- a/pkg/runtime/session_compaction.go
+++ b/pkg/runtime/session_compaction.go
@@ -4,23 +4,17 @@ import (
 	"context"
 	"errors"
 	"log/slog"
-	"time"
 
 	"github.com/docker/docker-agent/pkg/agent"
 	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/compaction"
+	"github.com/docker/docker-agent/pkg/hooks"
 	"github.com/docker/docker-agent/pkg/model/provider"
 	"github.com/docker/docker-agent/pkg/model/provider/options"
+	"github.com/docker/docker-agent/pkg/runtime/compactor"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/team"
 )
-
-const maxSummaryTokens = 16_000
-
-// maxKeepTokens is the maximum number of tokens to preserve from the end of
-// the conversation during compaction. These recent messages are kept verbatim
-// so the LLM can continue naturally after compaction.
-const maxKeepTokens = 20_000
 
 // Compaction reasons reported to BeforeCompaction / AfterCompaction hooks.
 const (
@@ -29,9 +23,11 @@ const (
 	compactionReasonManual    = "manual"
 )
 
-// doCompact runs compaction on a session and applies the result (events,
-// persistence, token count updates). The agent is used to extract the
-// conversation from the session and to obtain the model for summarization.
+// doCompact orchestrates a session compaction. It is intentionally thin:
+// the heavy lifting (extracting the conversation, running the LLM, computing
+// the kept-tail boundary) lives in [pkg/runtime/compactor]; this function
+// owns only what's runtime-private: hook dispatch, session mutation, event
+// emission, and persistence.
 //
 // reason is one of [compactionReasonThreshold] (proactive 90% trigger),
 // [compactionReasonOverflow] (post-overflow recovery) or
@@ -44,12 +40,14 @@ const (
 //     events; the conversation is left untouched.
 //   - If a BeforeCompaction hook supplies a non-empty Summary in
 //     HookSpecificOutput, the runtime applies that summary verbatim and
-//     skips the LLM-based summarization entirely.
+//     skips the LLM-based summarization entirely. The kept-tail policy
+//     ([compactor.MaxKeepTokens]) still applies so conversation
+//     continuity is identical to the LLM path.
 //   - AfterCompaction fires after the summary has been applied; it is
 //     observational.
 //
 // If no hooks are configured for any of these events, control flow is
-// bit-for-bit identical to the previous, hookless implementation.
+// behaviourally identical to the original, hookless implementation.
 //
 // Note: the runtime does NOT re-fire session_start with Source="compact".
 // session_start hook output is held as transient context that is threaded
@@ -57,37 +55,17 @@ const (
 // env / cwd / OS info is automatically present after a compaction without
 // any extra dispatch.
 func (r *LocalRuntime) doCompact(ctx context.Context, sess *session.Session, a *agent.Agent, additionalPrompt, reason string, events chan Event) {
-	// Build the model used for summarization. CloneWithOptions only
-	// allocates a struct, so it's cheap to call early — even when a hook
-	// ends up vetoing the compaction.
-	summaryModel := provider.CloneWithOptions(ctx, a.Model(),
-		options.WithStructuredOutput(nil),
-		options.WithMaxTokens(maxSummaryTokens),
-	)
+	contextLimit := r.compactionContextLimit(ctx, a)
 
-	// Best-effort context-limit lookup so before_compaction hooks can
-	// decide based on real model pressure. Errors are deferred to the
-	// LLM path: a hook that supplies its own summary doesn't need the
-	// model definition at all.
-	modelDef, modelErr := r.modelsStore.GetModel(ctx, summaryModel.ID())
-	var contextLimit int64
-	if modelErr == nil && modelDef != nil {
-		contextLimit = int64(modelDef.Limit.Context)
-	}
-
-	// before_compaction: hooks can veto the compaction or supply a
-	// custom summary string in lieu of the LLM call.
-	preResult := r.executeBeforeCompactionHooks(ctx, sess, a, reason, contextLimit, events)
-	if preResult != nil && !preResult.Allowed {
+	// before_compaction: hooks can veto or supply a custom summary.
+	pre := r.executeBeforeCompactionHooks(ctx, sess, a, reason, contextLimit, events)
+	if pre != nil && !pre.Allowed {
 		slog.Info("Session compaction skipped by before_compaction hook",
 			"session_id", sess.ID,
 			"agent", a.Name(),
 			"reason", reason,
-			"hook_message", preResult.Message,
+			"hook_message", pre.Message,
 		)
-		// Do not emit started/completed runtime events: no compaction
-		// occurred. dispatchHook already surfaced any SystemMessage as
-		// a Warning event for the user.
 		return
 	}
 
@@ -97,243 +75,105 @@ func (r *LocalRuntime) doCompact(ctx context.Context, sess *session.Session, a *
 		events <- SessionCompaction(sess.ID, "completed", a.Name())
 	}()
 
-	compactionAgent := agent.New("root", compaction.SystemPrompt, agent.WithModel(summaryModel))
-
-	var (
-		summary        string
-		firstKeptEntry int
-		compactionCost float64
-		newInputTokens int64
-	)
-
-	if preResult != nil && preResult.Summary != "" {
-		// A hook supplied a custom summary — apply it directly and skip
-		// the LLM-based summarization. We still honor the same
-		// maxKeepTokens tail-keep policy as the LLM path so the
-		// conversation continuity contract is unchanged.
-		slog.Debug("Using compaction summary from before_compaction hook",
-			"session_id", sess.ID, "agent", a.Name(), "summary_length", len(preResult.Summary))
-		summary = preResult.Summary
-		firstKeptEntry = computeFirstKeptEntry(sess, compactionAgent)
-		// Estimate the summary's token count for session bookkeeping;
-		// no LLM was called so the cost is zero.
-		newInputTokens = compaction.EstimateMessageTokens(&chat.Message{
-			Role:    chat.MessageRoleAssistant,
-			Content: summary,
-		})
-	} else {
-		// LLM-based compaction (default path). This block must remain
-		// behaviourally identical to the pre-hooks implementation.
-		if modelErr != nil || modelDef == nil {
-			slog.Error("Failed to generate session summary", "error", errors.New("failed to get model definition"))
-			events <- Error("Failed to get model definition")
-			return
-		}
-
-		// Compute the messages to compact, keeping recent messages aside.
-		messages, fke := extractMessagesToCompact(sess, compactionAgent, int64(modelDef.Limit.Context), additionalPrompt, r.now)
-		firstKeptEntry = fke
-
-		// Run the compaction.
-		compactionSession := session.New(
-			session.WithTitle("Generating summary"),
-			session.WithMessages(toItems(messages)),
-		)
-
-		t := team.New(team.WithAgents(compactionAgent))
-		rt, err := New(t, WithSessionCompaction(false))
-		if err != nil {
-			slog.Error("Failed to generate session summary", "error", err)
-			events <- Error(err.Error())
-			return
-		}
-		if _, err = rt.Run(ctx, compactionSession); err != nil {
-			slog.Error("Failed to generate session summary", "error", err)
-			events <- Error(err.Error())
-			return
-		}
-
-		summary = compactionSession.GetLastAssistantMessageContent()
-		if summary == "" {
-			return
-		}
-		newInputTokens = compactionSession.OutputTokens
-		compactionCost = compactionSession.TotalCost()
+	result, err := r.produceSummary(ctx, sess, a, additionalPrompt, contextLimit, pre)
+	if err != nil {
+		slog.Error("Failed to generate session summary", "error", err)
+		events <- Error(err.Error())
+		return
+	}
+	if result == nil {
+		// Empty summary — bail without applying anything.
+		return
 	}
 
-	// Update the session.
-	sess.InputTokens = newInputTokens
+	// Apply the summary to the session. This is intrinsically
+	// runtime-private: it mutates session-internal state and persists
+	// through the runtime's session store.
+	sess.InputTokens = result.InputTokens
 	sess.OutputTokens = 0
 	sess.Messages = append(sess.Messages, session.Item{
-		Summary:        summary,
-		FirstKeptEntry: firstKeptEntry,
-		Cost:           compactionCost,
+		Summary:        result.Summary,
+		FirstKeptEntry: result.FirstKeptEntry,
+		Cost:           result.Cost,
 	})
 	_ = r.sessionStore.UpdateSession(ctx, sess)
 
-	slog.Debug("Generated session summary", "session_id", sess.ID, "summary_length", len(summary))
-	events <- SessionSummary(sess.ID, summary, a.Name(), firstKeptEntry)
+	slog.Debug("Generated session summary", "session_id", sess.ID, "summary_length", len(result.Summary))
+	events <- SessionSummary(sess.ID, result.Summary, a.Name(), result.FirstKeptEntry)
 
 	// after_compaction: observational. Fired only when a summary was
 	// actually applied to the session.
-	r.executeAfterCompactionHooks(ctx, sess, a, reason, contextLimit, summary, events)
+	r.executeAfterCompactionHooks(ctx, sess, a, reason, contextLimit, result.Summary, events)
 }
 
-// computeFirstKeptEntry returns the index into sess.Messages of the
-// first message preserved verbatim after compaction, given the
-// configured maxKeepTokens window. Used by the hook-supplied-summary
-// path so the tail-keep policy stays consistent with the LLM path.
-func computeFirstKeptEntry(sess *session.Session, compactionAgent *agent.Agent) int {
-	var messages []chat.Message
-	for _, msg := range sess.GetMessages(compactionAgent) {
-		if msg.Role == chat.MessageRoleSystem {
-			continue
-		}
-		messages = append(messages, msg)
+// produceSummary returns a structured compaction result, choosing
+// between a hook-supplied summary (if before_compaction returned one)
+// and the default LLM-based strategy.
+func (r *LocalRuntime) produceSummary(
+	ctx context.Context,
+	sess *session.Session,
+	a *agent.Agent,
+	additionalPrompt string,
+	contextLimit int64,
+	pre *hooks.Result,
+) (*compactor.Result, error) {
+	if pre != nil && pre.Summary != "" {
+		slog.Debug("Using compaction summary from before_compaction hook",
+			"session_id", sess.ID, "agent", a.Name(), "summary_length", len(pre.Summary))
+		return &compactor.Result{
+			Summary:        pre.Summary,
+			FirstKeptEntry: compactor.ComputeFirstKeptEntry(sess, a),
+			// Estimate the summary's token count for session bookkeeping;
+			// no LLM was called so the cost is zero.
+			InputTokens: compaction.EstimateMessageTokens(&chat.Message{
+				Role:    chat.MessageRoleAssistant,
+				Content: pre.Summary,
+			}),
+			Cost: 0,
+		}, nil
 	}
-	return mapToSessionIndex(sess, splitIndexForKeep(messages, maxKeepTokens))
+
+	if contextLimit <= 0 {
+		return nil, errors.New("failed to get model definition")
+	}
+
+	return compactor.RunLLM(ctx, compactor.LLMArgs{
+		Session:          sess,
+		Agent:            a,
+		AdditionalPrompt: additionalPrompt,
+		ContextLimit:     contextLimit,
+		RunAgent:         r.runCompactionAgent,
+	})
 }
 
-// extractMessagesToCompact returns the messages to send to the compaction model
-// and the index (into sess.Messages) of the first message that was kept aside.
-// Recent messages (up to maxKeepTokens) are excluded from compaction so they
-// can be preserved verbatim in the session after summarization.
-func extractMessagesToCompact(sess *session.Session, compactionAgent *agent.Agent, contextLimit int64, additionalPrompt string, now func() time.Time) ([]chat.Message, int) {
-	// Add all the existing messages.
-	var messages []chat.Message
-	for _, msg := range sess.GetMessages(compactionAgent) {
-		if msg.Role == chat.MessageRoleSystem {
-			continue
-		}
-
-		msg.Cost = 0
-		msg.CacheControl = false
-
-		messages = append(messages, msg)
-	}
-
-	// Split: keep the last N tokens of messages aside so the LLM retains
-	// recent context after compaction.
-	splitIdx := splitIndexForKeep(messages, maxKeepTokens)
-	messagesToCompact := messages[:splitIdx]
-	// Compute firstKeptEntry: index into sess.Messages of the first kept message.
-	// The kept messages start at splitIdx in the non-system filtered list. We
-	// need to map this back to the original sess.Messages index.
-	firstKeptEntry := mapToSessionIndex(sess, splitIdx)
-
-	messages = messagesToCompact
-
-	// Prepare the first (system) message.
-	systemPromptMessage := chat.Message{
-		Role:      chat.MessageRoleSystem,
-		Content:   compaction.SystemPrompt,
-		CreatedAt: now().Format(time.RFC3339),
-	}
-	systemPromptMessageLen := compaction.EstimateMessageTokens(&systemPromptMessage)
-
-	// Prepare the last (user) message.
-	userPrompt := compaction.UserPrompt
-	if additionalPrompt != "" {
-		userPrompt += "\n\n" + additionalPrompt
-	}
-	userPromptMessage := chat.Message{
-		Role:      chat.MessageRoleUser,
-		Content:   userPrompt,
-		CreatedAt: now().Format(time.RFC3339),
-	}
-	userPromptMessageLen := compaction.EstimateMessageTokens(&userPromptMessage)
-
-	// Truncate the messages so that they fit in the available context limit
-	// (minus the expected max length of the summary).
-	contextAvailable := max(0, contextLimit-maxSummaryTokens-systemPromptMessageLen-userPromptMessageLen)
-	firstIndex := firstMessageToKeep(messages, contextAvailable)
-	if firstIndex < len(messages) {
-		messages = messages[firstIndex:]
-	} else {
-		messages = nil
-	}
-
-	// Prepend the first (system) message.
-	messages = append([]chat.Message{systemPromptMessage}, messages...)
-
-	// Append the last (user) message.
-	messages = append(messages, userPromptMessage)
-
-	return messages, firstKeptEntry
-}
-
-// splitIndexForKeep returns the index that splits messages into [0:idx] (to
-// compact) and [idx:] (to keep). It walks backwards accumulating tokens up to
-// maxTokens, snapping to user/assistant boundaries.
-func splitIndexForKeep(messages []chat.Message, maxTokens int64) int {
-	if len(messages) == 0 {
+// compactionContextLimit returns the agent's model context limit, or 0
+// when it can't be resolved. Failure is non-fatal here: a
+// before_compaction hook may supply its own summary and never need the
+// model definition. The LLM strategy itself enforces ContextLimit > 0.
+func (r *LocalRuntime) compactionContextLimit(ctx context.Context, a *agent.Agent) int64 {
+	if a == nil || a.Model() == nil {
 		return 0
 	}
-
-	var tokens int64
-	// Walk from the end; find the earliest index whose suffix fits in maxTokens.
-	lastValidBoundary := len(messages)
-	for i := len(messages) - 1; i >= 0; i-- {
-		tokens += compaction.EstimateMessageTokens(&messages[i])
-		if tokens > maxTokens {
-			return lastValidBoundary
-		}
-		role := messages[i].Role
-		if role == chat.MessageRoleUser || role == chat.MessageRoleAssistant {
-			lastValidBoundary = i
-		}
+	summaryModel := provider.CloneWithOptions(ctx, a.Model(),
+		options.WithStructuredOutput(nil),
+		options.WithMaxTokens(compactor.MaxSummaryTokens),
+	)
+	m, err := r.modelsStore.GetModel(ctx, summaryModel.ID())
+	if err != nil || m == nil {
+		return 0
 	}
-	// All messages fit within maxTokens — don't keep any aside (compact everything).
-	return len(messages)
+	return int64(m.Limit.Context)
 }
 
-// mapToSessionIndex maps an index in the non-system-filtered message list back
-// to the corresponding index in sess.Messages. It counts only message items
-// that are not system messages.
-func mapToSessionIndex(sess *session.Session, filteredIdx int) int {
-	count := 0
-	for i, item := range sess.Messages {
-		if item.IsMessage() && item.Message.Message.Role != chat.MessageRoleSystem {
-			if count == filteredIdx {
-				return i
-			}
-			count++
-		}
+// runCompactionAgent runs an agent against a sub-session for compaction.
+// It is the runtime-side glue [pkg/runtime/compactor] invokes via callback,
+// which avoids creating an import cycle on [pkg/runtime].
+func (r *LocalRuntime) runCompactionAgent(ctx context.Context, a *agent.Agent, sess *session.Session) error {
+	t := team.New(team.WithAgents(a))
+	rt, err := New(t, WithSessionCompaction(false))
+	if err != nil {
+		return err
 	}
-	// filteredIdx is past the end — no messages to keep.
-	return len(sess.Messages)
-}
-
-func firstMessageToKeep(messages []chat.Message, contextLimit int64) int {
-	var tokens int64
-
-	lastValidMessageSeen := len(messages)
-
-	for i := len(messages) - 1; i >= 0; i-- {
-		tokens += compaction.EstimateMessageTokens(&messages[i])
-		if tokens > contextLimit {
-			return lastValidMessageSeen
-		}
-
-		role := messages[i].Role
-		if role == chat.MessageRoleUser || role == chat.MessageRoleAssistant {
-			lastValidMessageSeen = i
-		}
-	}
-
-	return lastValidMessageSeen
-}
-
-func toItems(messages []chat.Message) []session.Item {
-	var items []session.Item
-
-	for _, message := range messages {
-		items = append(items, session.Item{
-			Message: &session.Message{
-				Message: message,
-			},
-		})
-	}
-
-	return items
+	_, err = rt.Run(ctx, sess)
+	return err
 }

--- a/pkg/runtime/session_compaction.go
+++ b/pkg/runtime/session_compaction.go
@@ -2,7 +2,6 @@ package runtime
 
 import (
 	"context"
-	"errors"
 	"log/slog"
 
 	"github.com/docker/docker-agent/pkg/agent"
@@ -41,8 +40,7 @@ const (
 //   - If a BeforeCompaction hook supplies a non-empty Summary in
 //     HookSpecificOutput, the runtime applies that summary verbatim and
 //     skips the LLM-based summarization entirely. The kept-tail policy
-//     ([compactor.MaxKeepTokens]) still applies so conversation
-//     continuity is identical to the LLM path.
+//     stays consistent across both paths via [compactor.ComputeFirstKeptEntry].
 //   - AfterCompaction fires after the summary has been applied; it is
 //     observational.
 //
@@ -61,9 +59,7 @@ func (r *LocalRuntime) doCompact(ctx context.Context, sess *session.Session, a *
 	pre := r.executeBeforeCompactionHooks(ctx, sess, a, reason, contextLimit, events)
 	if pre != nil && !pre.Allowed {
 		slog.Info("Session compaction skipped by before_compaction hook",
-			"session_id", sess.ID,
-			"agent", a.Name(),
-			"reason", reason,
+			"session_id", sess.ID, "agent", a.Name(), "reason", reason,
 			"hook_message", pre.Message,
 		)
 		return
@@ -75,15 +71,34 @@ func (r *LocalRuntime) doCompact(ctx context.Context, sess *session.Session, a *
 		events <- SessionCompaction(sess.ID, "completed", a.Name())
 	}()
 
-	result, err := r.produceSummary(ctx, sess, a, additionalPrompt, contextLimit, pre)
-	if err != nil {
-		slog.Error("Failed to generate session summary", "error", err)
-		events <- Error(err.Error())
-		return
-	}
+	// Choose the strategy: a hook-supplied summary if before_compaction
+	// returned one, otherwise the default LLM strategy.
+	result := summaryFromHook(sess, a, pre)
 	if result == nil {
-		// Empty summary — bail without applying anything.
-		return
+		if contextLimit <= 0 {
+			slog.Error("Failed to generate session summary",
+				"error", "model definition unavailable")
+			events <- Error("Failed to get model definition")
+			return
+		}
+
+		var err error
+		result, err = compactor.RunLLM(ctx, compactor.LLMArgs{
+			Session:          sess,
+			Agent:            a,
+			AdditionalPrompt: additionalPrompt,
+			ContextLimit:     contextLimit,
+			RunAgent:         r.runCompactionAgent,
+		})
+		if err != nil {
+			slog.Error("Failed to generate session summary", "error", err)
+			events <- Error(err.Error())
+			return
+		}
+		if result == nil {
+			// Empty summary — bail without applying anything.
+			return
+		}
 	}
 
 	// Apply the summary to the session. This is intrinsically
@@ -106,50 +121,35 @@ func (r *LocalRuntime) doCompact(ctx context.Context, sess *session.Session, a *
 	r.executeAfterCompactionHooks(ctx, sess, a, reason, contextLimit, result.Summary, events)
 }
 
-// produceSummary returns a structured compaction result, choosing
-// between a hook-supplied summary (if before_compaction returned one)
-// and the default LLM-based strategy.
-func (r *LocalRuntime) produceSummary(
-	ctx context.Context,
-	sess *session.Session,
-	a *agent.Agent,
-	additionalPrompt string,
-	contextLimit int64,
-	pre *hooks.Result,
-) (*compactor.Result, error) {
-	if pre != nil && pre.Summary != "" {
-		slog.Debug("Using compaction summary from before_compaction hook",
-			"session_id", sess.ID, "agent", a.Name(), "summary_length", len(pre.Summary))
-		return &compactor.Result{
-			Summary:        pre.Summary,
-			FirstKeptEntry: compactor.ComputeFirstKeptEntry(sess, a),
-			// Estimate the summary's token count for session bookkeeping;
-			// no LLM was called so the cost is zero.
-			InputTokens: compaction.EstimateMessageTokens(&chat.Message{
-				Role:    chat.MessageRoleAssistant,
-				Content: pre.Summary,
-			}),
-			Cost: 0,
-		}, nil
+// summaryFromHook lifts a before_compaction hook's Summary verdict into
+// a [compactor.Result] that the runtime can apply with the same code
+// path as the LLM strategy. Returns nil when no hook supplied a
+// summary (the caller then falls through to [compactor.RunLLM]).
+//
+// The hook only contributes the summary text; the runtime fills in the
+// kept-tail boundary (matching the LLM path's policy) and estimates the
+// summary's token count for session bookkeeping. Cost is zero since no
+// LLM call ran.
+func summaryFromHook(sess *session.Session, a *agent.Agent, pre *hooks.Result) *compactor.Result {
+	if pre == nil || pre.Summary == "" {
+		return nil
 	}
-
-	if contextLimit <= 0 {
-		return nil, errors.New("failed to get model definition")
+	slog.Debug("Using compaction summary from before_compaction hook",
+		"session_id", sess.ID, "agent", a.Name(), "summary_length", len(pre.Summary))
+	return &compactor.Result{
+		Summary:        pre.Summary,
+		FirstKeptEntry: compactor.ComputeFirstKeptEntry(sess, a),
+		InputTokens: compaction.EstimateMessageTokens(&chat.Message{
+			Role:    chat.MessageRoleAssistant,
+			Content: pre.Summary,
+		}),
 	}
-
-	return compactor.RunLLM(ctx, compactor.LLMArgs{
-		Session:          sess,
-		Agent:            a,
-		AdditionalPrompt: additionalPrompt,
-		ContextLimit:     contextLimit,
-		RunAgent:         r.runCompactionAgent,
-	})
 }
 
 // compactionContextLimit returns the agent's model context limit, or 0
-// when it can't be resolved. Failure is non-fatal here: a
-// before_compaction hook may supply its own summary and never need the
-// model definition. The LLM strategy itself enforces ContextLimit > 0.
+// when it can't be resolved. Failure is non-fatal: a before_compaction
+// hook may supply its own summary and never need the model definition.
+// The LLM strategy itself enforces ContextLimit > 0.
 func (r *LocalRuntime) compactionContextLimit(ctx context.Context, a *agent.Agent) int64 {
 	if a == nil || a.Model() == nil {
 		return 0

--- a/pkg/runtime/session_compaction.go
+++ b/pkg/runtime/session_compaction.go
@@ -22,69 +22,176 @@ const maxSummaryTokens = 16_000
 // so the LLM can continue naturally after compaction.
 const maxKeepTokens = 20_000
 
+// Compaction reasons reported to BeforeCompaction / AfterCompaction hooks.
+const (
+	compactionReasonThreshold = "threshold"
+	compactionReasonOverflow  = "overflow"
+	compactionReasonManual    = "manual"
+)
+
 // doCompact runs compaction on a session and applies the result (events,
 // persistence, token count updates). The agent is used to extract the
 // conversation from the session and to obtain the model for summarization.
-func (r *LocalRuntime) doCompact(ctx context.Context, sess *session.Session, a *agent.Agent, additionalPrompt string, events chan Event) {
-	slog.Debug("Generating summary for session", "session_id", sess.ID)
+//
+// reason is one of [compactionReasonThreshold] (proactive 90% trigger),
+// [compactionReasonOverflow] (post-overflow recovery) or
+// [compactionReasonManual] (user-invoked /compact). It is forwarded to
+// BeforeCompaction / AfterCompaction hooks.
+//
+// Hook integration:
+//   - BeforeCompaction fires first. If a hook denies (Decision: "block"),
+//     the runtime returns immediately without emitting any compaction
+//     events; the conversation is left untouched.
+//   - If a BeforeCompaction hook supplies a non-empty Summary in
+//     HookSpecificOutput, the runtime applies that summary verbatim and
+//     skips the LLM-based summarization entirely.
+//   - AfterCompaction fires after the summary has been applied; it is
+//     observational.
+//
+// If no hooks are configured for any of these events, control flow is
+// bit-for-bit identical to the previous, hookless implementation.
+//
+// Note: the runtime does NOT re-fire session_start with Source="compact".
+// session_start hook output is held as transient context that is threaded
+// into every model call (see [LocalRuntime.executeSessionStartHooks]), so
+// env / cwd / OS info is automatically present after a compaction without
+// any extra dispatch.
+func (r *LocalRuntime) doCompact(ctx context.Context, sess *session.Session, a *agent.Agent, additionalPrompt, reason string, events chan Event) {
+	// Build the model used for summarization. CloneWithOptions only
+	// allocates a struct, so it's cheap to call early — even when a hook
+	// ends up vetoing the compaction.
+	summaryModel := provider.CloneWithOptions(ctx, a.Model(),
+		options.WithStructuredOutput(nil),
+		options.WithMaxTokens(maxSummaryTokens),
+	)
+
+	// Best-effort context-limit lookup so before_compaction hooks can
+	// decide based on real model pressure. Errors are deferred to the
+	// LLM path: a hook that supplies its own summary doesn't need the
+	// model definition at all.
+	modelDef, modelErr := r.modelsStore.GetModel(ctx, summaryModel.ID())
+	var contextLimit int64
+	if modelErr == nil && modelDef != nil {
+		contextLimit = int64(modelDef.Limit.Context)
+	}
+
+	// before_compaction: hooks can veto the compaction or supply a
+	// custom summary string in lieu of the LLM call.
+	preResult := r.executeBeforeCompactionHooks(ctx, sess, a, reason, contextLimit, events)
+	if preResult != nil && !preResult.Allowed {
+		slog.Info("Session compaction skipped by before_compaction hook",
+			"session_id", sess.ID,
+			"agent", a.Name(),
+			"reason", reason,
+			"hook_message", preResult.Message,
+		)
+		// Do not emit started/completed runtime events: no compaction
+		// occurred. dispatchHook already surfaced any SystemMessage as
+		// a Warning event for the user.
+		return
+	}
+
+	slog.Debug("Generating summary for session", "session_id", sess.ID, "reason", reason)
 	events <- SessionCompaction(sess.ID, "started", a.Name())
 	defer func() {
 		events <- SessionCompaction(sess.ID, "completed", a.Name())
 	}()
 
-	// Build a model just for compaction.
-	summaryModel := provider.CloneWithOptions(ctx, a.Model(),
-		options.WithStructuredOutput(nil),
-		options.WithMaxTokens(maxSummaryTokens),
-	)
-	m, err := r.modelsStore.GetModel(ctx, summaryModel.ID())
-	if err != nil {
-		slog.Error("Failed to generate session summary", "error", errors.New("failed to get model definition"))
-		events <- Error("Failed to get model definition")
-		return
-	}
-
 	compactionAgent := agent.New("root", compaction.SystemPrompt, agent.WithModel(summaryModel))
 
-	// Compute the messages to compact, keeping recent messages aside.
-	messages, firstKeptEntry := extractMessagesToCompact(sess, compactionAgent, int64(m.Limit.Context), additionalPrompt, r.now)
-
-	// Run the compaction.
-	compactionSession := session.New(
-		session.WithTitle("Generating summary"),
-		session.WithMessages(toItems(messages)),
+	var (
+		summary        string
+		firstKeptEntry int
+		compactionCost float64
+		newInputTokens int64
 	)
 
-	t := team.New(team.WithAgents(compactionAgent))
-	rt, err := New(t, WithSessionCompaction(false))
-	if err != nil {
-		slog.Error("Failed to generate session summary", "error", err)
-		events <- Error(err.Error())
-		return
-	}
-	if _, err = rt.Run(ctx, compactionSession); err != nil {
-		slog.Error("Failed to generate session summary", "error", err)
-		events <- Error(err.Error())
-		return
-	}
+	if preResult != nil && preResult.Summary != "" {
+		// A hook supplied a custom summary — apply it directly and skip
+		// the LLM-based summarization. We still honor the same
+		// maxKeepTokens tail-keep policy as the LLM path so the
+		// conversation continuity contract is unchanged.
+		slog.Debug("Using compaction summary from before_compaction hook",
+			"session_id", sess.ID, "agent", a.Name(), "summary_length", len(preResult.Summary))
+		summary = preResult.Summary
+		firstKeptEntry = computeFirstKeptEntry(sess, compactionAgent)
+		// Estimate the summary's token count for session bookkeeping;
+		// no LLM was called so the cost is zero.
+		newInputTokens = compaction.EstimateMessageTokens(&chat.Message{
+			Role:    chat.MessageRoleAssistant,
+			Content: summary,
+		})
+	} else {
+		// LLM-based compaction (default path). This block must remain
+		// behaviourally identical to the pre-hooks implementation.
+		if modelErr != nil || modelDef == nil {
+			slog.Error("Failed to generate session summary", "error", errors.New("failed to get model definition"))
+			events <- Error("Failed to get model definition")
+			return
+		}
 
-	summary := compactionSession.GetLastAssistantMessageContent()
-	if summary == "" {
-		return
+		// Compute the messages to compact, keeping recent messages aside.
+		messages, fke := extractMessagesToCompact(sess, compactionAgent, int64(modelDef.Limit.Context), additionalPrompt, r.now)
+		firstKeptEntry = fke
+
+		// Run the compaction.
+		compactionSession := session.New(
+			session.WithTitle("Generating summary"),
+			session.WithMessages(toItems(messages)),
+		)
+
+		t := team.New(team.WithAgents(compactionAgent))
+		rt, err := New(t, WithSessionCompaction(false))
+		if err != nil {
+			slog.Error("Failed to generate session summary", "error", err)
+			events <- Error(err.Error())
+			return
+		}
+		if _, err = rt.Run(ctx, compactionSession); err != nil {
+			slog.Error("Failed to generate session summary", "error", err)
+			events <- Error(err.Error())
+			return
+		}
+
+		summary = compactionSession.GetLastAssistantMessageContent()
+		if summary == "" {
+			return
+		}
+		newInputTokens = compactionSession.OutputTokens
+		compactionCost = compactionSession.TotalCost()
 	}
 
 	// Update the session.
-	sess.InputTokens = compactionSession.OutputTokens
+	sess.InputTokens = newInputTokens
 	sess.OutputTokens = 0
 	sess.Messages = append(sess.Messages, session.Item{
 		Summary:        summary,
 		FirstKeptEntry: firstKeptEntry,
-		Cost:           compactionSession.TotalCost(),
+		Cost:           compactionCost,
 	})
 	_ = r.sessionStore.UpdateSession(ctx, sess)
 
 	slog.Debug("Generated session summary", "session_id", sess.ID, "summary_length", len(summary))
 	events <- SessionSummary(sess.ID, summary, a.Name(), firstKeptEntry)
+
+	// after_compaction: observational. Fired only when a summary was
+	// actually applied to the session.
+	r.executeAfterCompactionHooks(ctx, sess, a, reason, contextLimit, summary, events)
+}
+
+// computeFirstKeptEntry returns the index into sess.Messages of the
+// first message preserved verbatim after compaction, given the
+// configured maxKeepTokens window. Used by the hook-supplied-summary
+// path so the tail-keep policy stays consistent with the LLM path.
+func computeFirstKeptEntry(sess *session.Session, compactionAgent *agent.Agent) int {
+	var messages []chat.Message
+	for _, msg := range sess.GetMessages(compactionAgent) {
+		if msg.Role == chat.MessageRoleSystem {
+			continue
+		}
+		messages = append(messages, msg)
+	}
+	return mapToSessionIndex(sess, splitIndexForKeep(messages, maxKeepTokens))
 }
 
 // extractMessagesToCompact returns the messages to send to the compaction model

--- a/pkg/runtime/session_compaction_test.go
+++ b/pkg/runtime/session_compaction_test.go
@@ -218,7 +218,9 @@ func TestDoCompactBeforeHookSuppliesSummary(t *testing.T) {
 
 // TestDoCompactAfterHookFires verifies that after_compaction fires
 // when a summary was applied (LLM-path or hook-path), and that the
-// hook receives the produced summary text.
+// hook receives the produced summary text together with the
+// *pre-compaction* token counts (so observability handlers can
+// express "compacted from X to Y").
 func TestDoCompactAfterHookFires(t *testing.T) {
 	dir := t.TempDir()
 	logFile := dir + "/after.log"
@@ -231,7 +233,11 @@ func TestDoCompactAfterHookFires(t *testing.T) {
 			{Type: "command", Command: "echo '" + beforeJSON + "'", Timeout: 5},
 		},
 		AfterCompaction: []latest.HookDefinition{
-			{Type: "command", Command: "cat | jq -r '.summary' > " + logFile, Timeout: 5},
+			// Capture summary plus pre-compaction tokens; if the runtime
+			// regresses to passing post-compaction values we'll see
+			// input_tokens == EstimateMessageTokens(summary) instead of
+			// the pre-compaction 1234.
+			{Type: "command", Command: "cat | jq -r '\"\\(.summary)|\\(.input_tokens)|\\(.output_tokens)\"' > " + logFile, Timeout: 5},
 		},
 	}
 
@@ -251,6 +257,11 @@ func TestDoCompactAfterHookFires(t *testing.T) {
 	sess := session.New(session.WithMessages([]session.Item{
 		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleUser, Content: "hi"}}),
 	}))
+	// Seed pre-compaction token counts so we can verify the hook
+	// receives them rather than the post-compaction values (which
+	// would be approximately EstimateMessageTokens(summary) and 0).
+	sess.InputTokens = 1234
+	sess.OutputTokens = 567
 
 	events := make(chan Event, 32)
 	rt.compactWithReason(t.Context(), sess, "", compactionReasonThreshold, events)
@@ -260,8 +271,8 @@ func TestDoCompactAfterHookFires(t *testing.T) {
 
 	logged, readErr := os.ReadFile(logFile)
 	require.NoError(t, readErr, "after_compaction hook must have run and produced the log file")
-	assert.Equal(t, customSummary+"\n", string(logged),
-		"after_compaction must receive the produced summary verbatim")
+	assert.Equal(t, customSummary+"|1234|567\n", string(logged),
+		"after_compaction must receive the produced summary and the *pre-compaction* token counts")
 }
 
 // TestDoCompactNoHooksMatchesPriorBehavior is a regression guard: with

--- a/pkg/runtime/session_compaction_test.go
+++ b/pkg/runtime/session_compaction_test.go
@@ -2,220 +2,24 @@ package runtime
 
 import (
 	"os"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/agent"
 	"github.com/docker/docker-agent/pkg/chat"
-	"github.com/docker/docker-agent/pkg/compaction"
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/team"
 )
 
-func TestExtractMessagesToCompact(t *testing.T) {
-	newMsg := func(role chat.MessageRole, content string) session.Item {
-		return session.NewMessageItem(&session.Message{
-			Message: chat.Message{Role: role, Content: content},
-		})
-	}
-
-	tests := []struct {
-		name                     string
-		messages                 []session.Item
-		contextLimit             int64
-		additionalPrompt         string
-		wantConversationMsgCount int
-	}{
-		{
-			name:                     "empty session returns system and user prompt only",
-			messages:                 nil,
-			contextLimit:             100_000,
-			wantConversationMsgCount: 0,
-		},
-		{
-			name: "system messages are filtered out",
-			messages: []session.Item{
-				newMsg(chat.MessageRoleSystem, "system instruction"),
-				newMsg(chat.MessageRoleUser, "hello"),
-				newMsg(chat.MessageRoleAssistant, "hi"),
-			},
-			contextLimit:             100_000,
-			wantConversationMsgCount: 2,
-		},
-		{
-			name: "messages fit within context limit",
-			messages: []session.Item{
-				newMsg(chat.MessageRoleUser, "msg1"),
-				newMsg(chat.MessageRoleAssistant, "msg2"),
-				newMsg(chat.MessageRoleUser, "msg3"),
-				newMsg(chat.MessageRoleAssistant, "msg4"),
-			},
-			contextLimit:             100_000,
-			wantConversationMsgCount: 4,
-		},
-		{
-			name: "truncation when context limit is very small",
-			messages: []session.Item{
-				newMsg(chat.MessageRoleUser, "first message with lots of content that takes tokens"),
-				newMsg(chat.MessageRoleAssistant, "first response with lots of content that takes tokens"),
-				newMsg(chat.MessageRoleUser, "second message"),
-				newMsg(chat.MessageRoleAssistant, "second response"),
-			},
-			// Set context limit so small that after subtracting maxSummaryTokens + prompt overhead,
-			// not all messages fit.
-			contextLimit:             maxSummaryTokens + 50,
-			wantConversationMsgCount: 0,
-		},
-		{
-			name: "additional prompt is appended",
-			messages: []session.Item{
-				newMsg(chat.MessageRoleUser, "hello"),
-			},
-			contextLimit:             100_000,
-			additionalPrompt:         "focus on code quality",
-			wantConversationMsgCount: 1,
-		},
-		{
-			name: "cost and cache control are cleared",
-			messages: []session.Item{
-				session.NewMessageItem(&session.Message{
-					Message: chat.Message{
-						Role:         chat.MessageRoleUser,
-						Content:      "hello",
-						Cost:         1.5,
-						CacheControl: true,
-					},
-				}),
-			},
-			contextLimit:             100_000,
-			wantConversationMsgCount: 1,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			sess := session.New(session.WithMessages(tt.messages))
-
-			a := agent.New("test", "test prompt")
-			result, _ := extractMessagesToCompact(sess, a, tt.contextLimit, tt.additionalPrompt, time.Now)
-
-			assert.GreaterOrEqual(t, len(result), tt.wantConversationMsgCount+2)
-			assert.Equal(t, chat.MessageRoleSystem, result[0].Role)
-			assert.Equal(t, compaction.SystemPrompt, result[0].Content)
-
-			last := result[len(result)-1]
-			assert.Equal(t, chat.MessageRoleUser, last.Role)
-			expectedPrompt := compaction.UserPrompt
-			if tt.additionalPrompt != "" {
-				expectedPrompt += "\n\n" + tt.additionalPrompt
-			}
-			assert.Equal(t, expectedPrompt, last.Content)
-
-			// Conversation messages are all except first (system) and last (user prompt)
-			assert.Equal(t, tt.wantConversationMsgCount, len(result)-2)
-
-			// Verify cost and cache control are cleared on conversation messages
-			for i := 1; i < len(result)-1; i++ {
-				assert.Zero(t, result[i].Cost)
-				assert.False(t, result[i].CacheControl)
-			}
-		})
-	}
-}
-
-func TestSplitIndexForKeep(t *testing.T) {
-	msg := func(role chat.MessageRole, content string) chat.Message {
-		return chat.Message{Role: role, Content: content}
-	}
-
-	tests := []struct {
-		name      string
-		messages  []chat.Message
-		maxTokens int64
-		wantSplit int // expected split index
-	}{
-		{
-			name:      "empty messages",
-			messages:  nil,
-			maxTokens: 1000,
-			wantSplit: 0,
-		},
-		{
-			name: "all messages fit in keep budget - compact everything",
-			messages: []chat.Message{
-				msg(chat.MessageRoleUser, "short"),
-				msg(chat.MessageRoleAssistant, "short"),
-			},
-			maxTokens: 100_000,
-			wantSplit: 2, // all fit → compact everything
-		},
-		{
-			name: "recent messages kept, older ones compacted",
-			messages: []chat.Message{
-				msg(chat.MessageRoleUser, strings.Repeat("a", 40000)),      // ~10005 tokens
-				msg(chat.MessageRoleAssistant, strings.Repeat("b", 40000)), // ~10005 tokens
-				msg(chat.MessageRoleUser, strings.Repeat("c", 40000)),      // ~10005 tokens
-				msg(chat.MessageRoleAssistant, strings.Repeat("d", 40000)), // ~10005 tokens
-				msg(chat.MessageRoleUser, strings.Repeat("e", 40000)),      // ~10005 tokens
-				msg(chat.MessageRoleAssistant, strings.Repeat("f", 40000)), // ~10005 tokens
-			},
-			maxTokens: 20_100, // enough for exactly 2 messages
-			wantSplit: 4,      // last 2 messages are kept
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := splitIndexForKeep(tt.messages, tt.maxTokens)
-			assert.Equal(t, tt.wantSplit, got)
-		})
-	}
-}
-
-func TestExtractMessagesToCompact_KeepsRecentMessages(t *testing.T) {
-	// Create a session with many messages, some large enough that the last
-	// ~20k tokens are kept aside.
-	var items []session.Item
-	for range 10 {
-		items = append(items, session.NewMessageItem(&session.Message{
-			Message: chat.Message{
-				Role:    chat.MessageRoleUser,
-				Content: strings.Repeat("x", 20000), // ~5k tokens each
-			},
-		}), session.NewMessageItem(&session.Message{
-			Message: chat.Message{
-				Role:    chat.MessageRoleAssistant,
-				Content: strings.Repeat("y", 20000), // ~5k tokens each
-			},
-		}))
-	}
-
-	sess := session.New(session.WithMessages(items))
-	a := agent.New("test", "test prompt")
-
-	result, firstKeptEntry := extractMessagesToCompact(sess, a, 200_000, "", time.Now)
-
-	// The kept messages should not appear in the compaction result
-	// (only system + compacted messages + user prompt).
-	// Total: 20 messages × ~5k tokens = ~100k tokens.
-	// Keep budget: 20k tokens → ~4 messages kept.
-	// So compacted messages should be 20 - 4 = 16.
-	compactedMsgCount := len(result) - 2 // minus system and user prompt
-	assert.Less(t, compactedMsgCount, 20, "some messages should have been kept aside")
-	assert.Positive(t, compactedMsgCount, "some messages should be compacted")
-
-	// firstKeptEntry should point into sess.Messages
-	assert.Positive(t, firstKeptEntry, "firstKeptEntry should be > 0")
-	assert.Less(t, firstKeptEntry, len(sess.Messages), "firstKeptEntry should be within bounds")
-}
-
+// TestSessionGetMessages_WithFirstKeptEntry covers the session-side
+// reconstruction of a compacted conversation: when a Summary item has
+// FirstKeptEntry set, the session's GetMessages must surface the summary
+// followed by the kept tail. This is what makes the compactor's
+// FirstKeptEntry actually work in the next LLM turn.
 func TestSessionGetMessages_WithFirstKeptEntry(t *testing.T) {
-	// Build a session with some messages, then add a summary with FirstKeptEntry.
 	items := []session.Item{
 		session.NewMessageItem(&session.Message{
 			Message: chat.Message{Role: chat.MessageRoleUser, Content: "m1"},
@@ -246,7 +50,6 @@ func TestSessionGetMessages_WithFirstKeptEntry(t *testing.T) {
 
 	messages := sess.GetMessages(a)
 
-	// Extract just the non-system messages
 	var conversationMessages []chat.Message
 	for _, msg := range messages {
 		if msg.Role != chat.MessageRoleSystem {
@@ -254,15 +57,16 @@ func TestSessionGetMessages_WithFirstKeptEntry(t *testing.T) {
 		}
 	}
 
-	// Should have: summary (as user message), m4, m5
 	require.Len(t, conversationMessages, 3, "expected summary + 2 kept messages")
 	assert.Contains(t, conversationMessages[0].Content, "Session Summary:")
 	assert.Equal(t, "m4", conversationMessages[1].Content)
 	assert.Equal(t, "m5", conversationMessages[2].Content)
 }
 
+// TestSessionGetMessages_SummaryWithoutFirstKeptEntry pins backward
+// compatibility: a summary with no FirstKeptEntry must still work, with
+// the conversation continuing from messages that follow the summary item.
 func TestSessionGetMessages_SummaryWithoutFirstKeptEntry(t *testing.T) {
-	// Backward compatibility: summary without FirstKeptEntry should work as before.
 	items := []session.Item{
 		session.NewMessageItem(&session.Message{
 			Message: chat.Message{Role: chat.MessageRoleUser, Content: "m1"},
@@ -288,35 +92,9 @@ func TestSessionGetMessages_SummaryWithoutFirstKeptEntry(t *testing.T) {
 		}
 	}
 
-	// Should have: summary + m3 (messages after the summary)
 	require.Len(t, conversationMessages, 2)
 	assert.Contains(t, conversationMessages[0].Content, "Session Summary:")
 	assert.Equal(t, "m3", conversationMessages[1].Content)
-}
-
-// TestComputeFirstKeptEntry covers the helper used by the hook-supplied
-// summary path to keep the same tail-keep policy (maxKeepTokens) as the
-// LLM path.
-func TestComputeFirstKeptEntry(t *testing.T) {
-	a := agent.New("test", "")
-
-	t.Run("empty session returns 0", func(t *testing.T) {
-		sess := session.New()
-		assert.Equal(t, 0, computeFirstKeptEntry(sess, a))
-	})
-
-	t.Run("system messages don't shift the index", func(t *testing.T) {
-		// A short conversation: all messages fit in the keep budget, so
-		// the helper returns len(sess.Messages) — i.e. compact everything.
-		sess := session.New(session.WithMessages([]session.Item{
-			session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleSystem, Content: "sys"}}),
-			session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleUser, Content: "hi"}}),
-			session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleAssistant, Content: "hello"}}),
-		}))
-		// Whole conversation is short → split at end → all compacted.
-		got := computeFirstKeptEntry(sess, a)
-		assert.Equal(t, len(sess.Messages), got)
-	})
 }
 
 // TestDoCompactBeforeHookDeniesSkipsCompaction verifies that a
@@ -343,7 +121,6 @@ func TestDoCompactBeforeHookDeniesSkipsCompaction(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	// Pre-populate a session with a couple of messages, no summary item.
 	sess := session.New(session.WithMessages([]session.Item{
 		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleUser, Content: "hi"}}),
 		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleAssistant, Content: "hello"}}),
@@ -373,8 +150,8 @@ func TestDoCompactBeforeHookDeniesSkipsCompaction(t *testing.T) {
 }
 
 // TestDoCompactBeforeHookSuppliesSummary verifies that a
-// before_compaction hook returning HookSpecificOutput.Summary causes the
-// runtime to apply that summary verbatim and to skip the LLM-based
+// before_compaction hook returning HookSpecificOutput.Summary causes
+// the runtime to apply that summary verbatim and to skip the LLM-based
 // summarization (no new model call).
 func TestDoCompactBeforeHookSuppliesSummary(t *testing.T) {
 	const customSummary = "custom hook-supplied summary"
@@ -386,8 +163,8 @@ func TestDoCompactBeforeHookSuppliesSummary(t *testing.T) {
 		},
 	}
 
-	// The provider must NOT be called — if it is, we'll consume from the
-	// (empty) mockStream and the test will catch it.
+	// The provider must NOT be called — if it is, we'll consume from
+	// the (empty) mockStream and the test will catch it.
 	prov := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
 	root := agent.New("root", "test",
 		agent.WithModel(prov),
@@ -432,7 +209,6 @@ func TestDoCompactBeforeHookSuppliesSummary(t *testing.T) {
 	assert.Equal(t, 1, compactionStartCount, "expected exactly one compaction-started event")
 	assert.Equal(t, 1, compactionDoneCount, "expected exactly one compaction-completed event")
 
-	// The session must have a Summary item appended with the hook-supplied text.
 	last := sess.Messages[len(sess.Messages)-1]
 	assert.Equal(t, customSummary, last.Summary,
 		"the session must record the hook-supplied summary as its last item")
@@ -440,12 +216,10 @@ func TestDoCompactBeforeHookSuppliesSummary(t *testing.T) {
 		"hook-supplied summaries cost nothing — no LLM was called")
 }
 
-// TestDoCompactAfterHookFires verifies that after_compaction fires when
-// a summary was applied (LLM-path or hook-path), and that the hook
-// receives the produced summary text.
+// TestDoCompactAfterHookFires verifies that after_compaction fires
+// when a summary was applied (LLM-path or hook-path), and that the
+// hook receives the produced summary text.
 func TestDoCompactAfterHookFires(t *testing.T) {
-	// A dedicated file lets us assert that the hook actually ran and
-	// observe the summary it received.
 	dir := t.TempDir()
 	logFile := dir + "/after.log"
 
@@ -457,7 +231,6 @@ func TestDoCompactAfterHookFires(t *testing.T) {
 			{Type: "command", Command: "echo '" + beforeJSON + "'", Timeout: 5},
 		},
 		AfterCompaction: []latest.HookDefinition{
-			// jq extracts the summary field and writes it to the log file.
 			{Type: "command", Command: "cat | jq -r '.summary' > " + logFile, Timeout: 5},
 		},
 	}
@@ -496,8 +269,6 @@ func TestDoCompactAfterHookFires(t *testing.T) {
 // emit the same SessionCompaction started/completed pair that all
 // existing UIs depend on.
 func TestDoCompactNoHooksMatchesPriorBehavior(t *testing.T) {
-	// Use a queueProvider so the LLM-based compaction can run without
-	// blocking. A single short summary stream is enough.
 	summaryStream := newStreamBuilder().
 		AddContent("summary").
 		AddStopWithUsage(1, 1).

--- a/pkg/runtime/session_compaction_test.go
+++ b/pkg/runtime/session_compaction_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -11,7 +12,9 @@ import (
 	"github.com/docker/docker-agent/pkg/agent"
 	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/compaction"
+	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/team"
 )
 
 func TestExtractMessagesToCompact(t *testing.T) {
@@ -289,4 +292,254 @@ func TestSessionGetMessages_SummaryWithoutFirstKeptEntry(t *testing.T) {
 	require.Len(t, conversationMessages, 2)
 	assert.Contains(t, conversationMessages[0].Content, "Session Summary:")
 	assert.Equal(t, "m3", conversationMessages[1].Content)
+}
+
+// TestComputeFirstKeptEntry covers the helper used by the hook-supplied
+// summary path to keep the same tail-keep policy (maxKeepTokens) as the
+// LLM path.
+func TestComputeFirstKeptEntry(t *testing.T) {
+	a := agent.New("test", "")
+
+	t.Run("empty session returns 0", func(t *testing.T) {
+		sess := session.New()
+		assert.Equal(t, 0, computeFirstKeptEntry(sess, a))
+	})
+
+	t.Run("system messages don't shift the index", func(t *testing.T) {
+		// A short conversation: all messages fit in the keep budget, so
+		// the helper returns len(sess.Messages) — i.e. compact everything.
+		sess := session.New(session.WithMessages([]session.Item{
+			session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleSystem, Content: "sys"}}),
+			session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleUser, Content: "hi"}}),
+			session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleAssistant, Content: "hello"}}),
+		}))
+		// Whole conversation is short → split at end → all compacted.
+		got := computeFirstKeptEntry(sess, a)
+		assert.Equal(t, len(sess.Messages), got)
+	})
+}
+
+// TestDoCompactBeforeHookDeniesSkipsCompaction verifies that a
+// before_compaction hook returning exit code 2 (deny) prevents any
+// compaction work: no SessionCompactionEvent, no Summary item appended
+// to the session, and no model call.
+func TestDoCompactBeforeHookDeniesSkipsCompaction(t *testing.T) {
+	denyingHooks := &latest.HooksConfig{
+		BeforeCompaction: []latest.HookDefinition{
+			{Type: "command", Command: "echo 'denied for safety' >&2; exit 2", Timeout: 5},
+		},
+	}
+
+	prov := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
+	root := agent.New("root", "test",
+		agent.WithModel(prov),
+		agent.WithHooks(denyingHooks),
+	)
+	tm := team.New(team.WithAgents(root))
+
+	rt, err := NewLocalRuntime(tm,
+		WithSessionCompaction(false),
+		WithModelStore(mockModelStoreWithLimit{limit: 100_000}),
+	)
+	require.NoError(t, err)
+
+	// Pre-populate a session with a couple of messages, no summary item.
+	sess := session.New(session.WithMessages([]session.Item{
+		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleUser, Content: "hi"}}),
+		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleAssistant, Content: "hello"}}),
+	}))
+	originalLen := len(sess.Messages)
+
+	events := make(chan Event, 32)
+	rt.compactWithReason(t.Context(), sess, "", compactionReasonManual, events)
+	close(events)
+
+	var sawCompactionEvent, sawSummaryEvent bool
+	for ev := range events {
+		switch ev.(type) {
+		case *SessionCompactionEvent:
+			sawCompactionEvent = true
+		case *SessionSummaryEvent:
+			sawSummaryEvent = true
+		}
+	}
+
+	assert.False(t, sawCompactionEvent,
+		"a denied before_compaction must not emit SessionCompaction events")
+	assert.False(t, sawSummaryEvent,
+		"a denied before_compaction must not emit a summary event")
+	assert.Len(t, sess.Messages, originalLen,
+		"a denied before_compaction must leave the session unmodified")
+}
+
+// TestDoCompactBeforeHookSuppliesSummary verifies that a
+// before_compaction hook returning HookSpecificOutput.Summary causes the
+// runtime to apply that summary verbatim and to skip the LLM-based
+// summarization (no new model call).
+func TestDoCompactBeforeHookSuppliesSummary(t *testing.T) {
+	const customSummary = "custom hook-supplied summary"
+	jsonOutput := `{"hook_specific_output":{"hook_event_name":"before_compaction","summary":"` + customSummary + `"}}`
+
+	hookCfg := &latest.HooksConfig{
+		BeforeCompaction: []latest.HookDefinition{
+			{Type: "command", Command: "echo '" + jsonOutput + "'", Timeout: 5},
+		},
+	}
+
+	// The provider must NOT be called — if it is, we'll consume from the
+	// (empty) mockStream and the test will catch it.
+	prov := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
+	root := agent.New("root", "test",
+		agent.WithModel(prov),
+		agent.WithHooks(hookCfg),
+	)
+	tm := team.New(team.WithAgents(root))
+
+	rt, err := NewLocalRuntime(tm,
+		WithSessionCompaction(false),
+		WithModelStore(mockModelStoreWithLimit{limit: 100_000}),
+	)
+	require.NoError(t, err)
+
+	sess := session.New(session.WithMessages([]session.Item{
+		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleUser, Content: "hi"}}),
+		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleAssistant, Content: "hello"}}),
+	}))
+
+	events := make(chan Event, 32)
+	rt.compactWithReason(t.Context(), sess, "", compactionReasonManual, events)
+	close(events)
+
+	var summaryEvent *SessionSummaryEvent
+	var compactionStartCount, compactionDoneCount int
+	for ev := range events {
+		switch e := ev.(type) {
+		case *SessionCompactionEvent:
+			switch e.Status {
+			case "started":
+				compactionStartCount++
+			case "completed":
+				compactionDoneCount++
+			}
+		case *SessionSummaryEvent:
+			summaryEvent = e
+		}
+	}
+
+	require.NotNil(t, summaryEvent, "expected a SessionSummary event")
+	assert.Equal(t, customSummary, summaryEvent.Summary,
+		"the runtime must apply the hook-supplied summary verbatim")
+	assert.Equal(t, 1, compactionStartCount, "expected exactly one compaction-started event")
+	assert.Equal(t, 1, compactionDoneCount, "expected exactly one compaction-completed event")
+
+	// The session must have a Summary item appended with the hook-supplied text.
+	last := sess.Messages[len(sess.Messages)-1]
+	assert.Equal(t, customSummary, last.Summary,
+		"the session must record the hook-supplied summary as its last item")
+	assert.InDelta(t, 0.0, last.Cost, 0.0001,
+		"hook-supplied summaries cost nothing — no LLM was called")
+}
+
+// TestDoCompactAfterHookFires verifies that after_compaction fires when
+// a summary was applied (LLM-path or hook-path), and that the hook
+// receives the produced summary text.
+func TestDoCompactAfterHookFires(t *testing.T) {
+	// A dedicated file lets us assert that the hook actually ran and
+	// observe the summary it received.
+	dir := t.TempDir()
+	logFile := dir + "/after.log"
+
+	const customSummary = "summary from the before hook"
+	beforeJSON := `{"hook_specific_output":{"hook_event_name":"before_compaction","summary":"` + customSummary + `"}}`
+
+	hookCfg := &latest.HooksConfig{
+		BeforeCompaction: []latest.HookDefinition{
+			{Type: "command", Command: "echo '" + beforeJSON + "'", Timeout: 5},
+		},
+		AfterCompaction: []latest.HookDefinition{
+			// jq extracts the summary field and writes it to the log file.
+			{Type: "command", Command: "cat | jq -r '.summary' > " + logFile, Timeout: 5},
+		},
+	}
+
+	prov := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
+	root := agent.New("root", "test",
+		agent.WithModel(prov),
+		agent.WithHooks(hookCfg),
+	)
+	tm := team.New(team.WithAgents(root))
+
+	rt, err := NewLocalRuntime(tm,
+		WithSessionCompaction(false),
+		WithModelStore(mockModelStoreWithLimit{limit: 100_000}),
+	)
+	require.NoError(t, err)
+
+	sess := session.New(session.WithMessages([]session.Item{
+		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleUser, Content: "hi"}}),
+	}))
+
+	events := make(chan Event, 32)
+	rt.compactWithReason(t.Context(), sess, "", compactionReasonThreshold, events)
+	close(events)
+	for range events {
+	}
+
+	logged, readErr := os.ReadFile(logFile)
+	require.NoError(t, readErr, "after_compaction hook must have run and produced the log file")
+	assert.Equal(t, customSummary+"\n", string(logged),
+		"after_compaction must receive the produced summary verbatim")
+}
+
+// TestDoCompactNoHooksMatchesPriorBehavior is a regression guard: with
+// no compaction-related hooks configured, compactWithReason must still
+// emit the same SessionCompaction started/completed pair that all
+// existing UIs depend on.
+func TestDoCompactNoHooksMatchesPriorBehavior(t *testing.T) {
+	// Use a queueProvider so the LLM-based compaction can run without
+	// blocking. A single short summary stream is enough.
+	summaryStream := newStreamBuilder().
+		AddContent("summary").
+		AddStopWithUsage(1, 1).
+		Build()
+
+	prov := &queueProvider{id: "test/mock-model", streams: []chat.MessageStream{summaryStream}}
+	root := agent.New("root", "test", agent.WithModel(prov))
+	tm := team.New(team.WithAgents(root))
+
+	rt, err := NewLocalRuntime(tm,
+		WithSessionCompaction(false),
+		WithModelStore(mockModelStoreWithLimit{limit: 100_000}),
+	)
+	require.NoError(t, err)
+
+	sess := session.New(session.WithMessages([]session.Item{
+		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleUser, Content: "hi"}}),
+		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleAssistant, Content: "hello"}}),
+	}))
+
+	events := make(chan Event, 32)
+	rt.compactWithReason(t.Context(), sess, "", compactionReasonManual, events)
+	close(events)
+
+	var startCount, doneCount int
+	var summaryEvent *SessionSummaryEvent
+	for ev := range events {
+		switch e := ev.(type) {
+		case *SessionCompactionEvent:
+			switch e.Status {
+			case "started":
+				startCount++
+			case "completed":
+				doneCount++
+			}
+		case *SessionSummaryEvent:
+			summaryEvent = e
+		}
+	}
+
+	assert.Equal(t, 1, startCount, "expected exactly one started event")
+	assert.Equal(t, 1, doneCount, "expected exactly one completed event")
+	require.NotNil(t, summaryEvent, "expected a SessionSummary event from the LLM path")
+	assert.Equal(t, "summary", summaryEvent.Summary)
 }


### PR DESCRIPTION
## What this PR does

Adds two new hook events that make session compaction first-class in
the hooks mechanism, plus a refactor that splits the compaction
strategy into its own package so future strategies can land alongside
the default one without bloating `pkg/runtime`.

### New hook events

- **`before_compaction`** fires immediately before the runtime
  compacts a session. The Input carries `input_tokens`,
  `output_tokens`, `context_limit`, and a `compaction_reason` of
  `\"threshold\"` (proactive 90% trigger), `\"overflow\"`
  (post-overflow recovery) or `\"manual\"` (user-invoked
  `/compact`). Hooks can:
  - **Veto** the compaction (Decision: `\"block\"` or exit code 2)
  - **Replace** the LLM-generated summary by returning a non-empty
    `hookSpecificOutput.summary` — the runtime applies that string
    verbatim and skips the model call entirely

- **`after_compaction`** fires after a successful compaction. Receives
  the produced `summary` together with the *pre-compaction*
  `input_tokens` / `output_tokens` (what was summarized) so
  observability handlers can naturally express \"compacted from X to
  Y\". Purely observational; output is ignored.

### Compactor extraction (`pkg/runtime/compactor`)

The LLM-summarization strategy and session-aware extraction helpers
move out of `pkg/runtime` into a new package, leaving
`pkg/runtime/session_compaction.go` as a thin orchestrator (~130 LoC,
down from ~200) that does only what's intrinsically runtime-private:
hook dispatch, session mutation, event emission, and persistence.

Pure-logic helpers (`SplitIndexForKeep`, `FirstIndexInBudget`) move
to `pkg/compaction` where they join `ShouldCompact` and
`EstimateMessageTokens`. The default LLM strategy
(`compactor.RunLLM`) becomes a public function that user-supplied
`before_compaction` hooks can call back into if they want to delegate
to the default with tweaks (different model, different prompt) instead
of copying the LLM-call boilerplate.

To avoid an import cycle (`pkg/runtime/compactor` doesn't import
`pkg/runtime`), `RunLLM` accepts a `RunAgent` callback that the
runtime supplies — the actual sub-runtime construction with
`WithSessionCompaction(false)` stays in the runtime.

## Behavior preservation

The mission-critical \"no hooks configured\" path is bit-for-bit
unchanged. Three regression guards pin this:

- `TestCompaction` (origin/main, end-to-end LLM compaction with a
  fake stream provider) — passes
- `TestCompactionOverflowDoesNotLoop` — passes
- `TestDoCompactNoHooksMatchesPriorBehavior` (new) — asserts
  identical event sequence (`SessionCompaction(\"started\") →
  SessionSummary → SessionCompaction(\"completed\")`) when no
  compaction hooks are configured

## Reviewer pass

A full review was performed before merging. The findings worth
calling out:

- **`session_start` re-emit on compact** — initially I added a
  `Source=\"compact\"` re-emit so hooks like `add_environment_info`
  could re-inject context. Then upstream
  [#2536](https://github.com/docker/cagent/pull/2536) (\"don't
  persist session_start hook output as a session message\") landed
  and made `session_start` output transient — threaded into every
  model call automatically. The re-emit became redundant and was
  dropped along with its test; `session_start` now fires exactly
  once per `RunStream` as before.
- **`after_compaction` token counts** — the reviewer pass moved this
  contract to pre-compaction values (\"compacted from X to Y\")
  before the API had any users. Asserted in
  `TestDoCompactAfterHookFires` by seeding
  `sess.{Input,Output}Tokens=1234,567` and verifying those exact
  numbers reach the hook.

## Files changed

| Area | Files |
|---|---|
| Hook contract | `pkg/hooks/types.go`, `pkg/hooks/executor.go`, `pkg/hooks/config.go` |
| Hook tests | `pkg/hooks/hooks_test.go`, `pkg/hooks/dispatch_test.go` |
| Runtime hook helpers | `pkg/runtime/hooks.go` |
| Compaction orchestrator | `pkg/runtime/session_compaction.go`, `pkg/runtime/loop.go`, `pkg/runtime/runtime.go` |
| New compactor package | `pkg/runtime/compactor/{compactor,compactor_test}.go` |
| Pure-logic helpers | `pkg/compaction/{compaction,compaction_test}.go` |
| Config + schema | `pkg/config/latest/types.go`, `agent-schema.json` |
| Example | `examples/hooks.yaml` (with a commented-out custom-summary block) |
| Runtime tests | `pkg/runtime/session_compaction_test.go` |

## Caveats documented in the schema and example

Vetoing on `compaction_reason=\"overflow\"` means the next LLM call
hits the same overflow. The runtime allows at most one
retry-with-compaction
([`maxOverflowCompactions`](https://github.com/docker/cagent/blob/main/pkg/runtime/loop.go)),
so a second denial fails the turn and surfaces an `Error` event
(not an infinite loop). Hook authors should gate denials by reason.

## Verification

- `go build ./...` — green
- `go test ./pkg/... ./cmd/...` — all green
- `go test -race ./pkg/runtime/... ./pkg/compaction/... ./pkg/hooks/... ./pkg/config/...` — green with `-race`
- `golangci-lint run ./...` — `0 issues`