### PR TITLE
refactor(runtime): drop unused receiver from handleStream

### DIFF
--- a/pkg/runtime/fallback.go
+++ b/pkg/runtime/fallback.go
@@ -285,7 +285,7 @@ func (r *LocalRuntime) tryModelWithFallback(
 				}
 			}
 
-			res, err := r.handleStream(ctx, stream, a, agentTools, sess, m, events)
+			res, err := handleStream(ctx, stream, a, agentTools, sess, m, events)
 			if err != nil {
 				lastErr = err
 

--- a/pkg/runtime/streaming.go
+++ b/pkg/runtime/streaming.go
@@ -34,7 +34,13 @@ type streamResult struct {
 // events (content deltas, partial tool calls, reasoning tokens) and returning
 // the aggregated streamResult. The caller is responsible for adding the
 // resulting assistant message to the session.
-func (r *LocalRuntime) handleStream(ctx context.Context, stream chat.MessageStream, a *agent.Agent, agentTools []tools.Tool, sess *session.Session, m *modelsdev.Model, events chan Event) (streamResult, error) {
+//
+// handleStream is a pure stream-aggregation routine: it does not touch
+// runtime state and can be unit-tested by feeding a mock chat.MessageStream.
+// It is intentionally a free function rather than a method on *LocalRuntime
+// so the dependency direction is explicit (the loop calls into the chunker,
+// never the reverse).
+func handleStream(ctx context.Context, stream chat.MessageStream, a *agent.Agent, agentTools []tools.Tool, sess *session.Session, m *modelsdev.Model, events chan<- Event) (streamResult, error) {
 	defer stream.Close()
 
 	var fullContent strings.Builder


### PR DESCRIPTION
## Summary

`handleStream` is the chunked-stream aggregator in
`pkg/runtime/streaming.go` — it consumes an LLM provider's
`chat.MessageStream` and turns the deltas into an aggregated
`streamResult` plus events on the `events` channel.

It was declared as a method on `*LocalRuntime`, but its body never
touches `r`. The receiver is a pure artefact of where the file sits.

Drop it, tighten the events channel direction, document why.

## What this is, and what it isn't

This is a **pure isolation win**:

- `handleStream` becomes a free function. It is now unit-testable
  with a mock `chat.MessageStream` alone — no `LocalRuntime`, team,
  hooks, model store, or any of the other runtime wiring required.
- `events chan Event` → `events chan<- Event` matches the rest of
  the package's send-only conventions (`swapCurrentAgent` etc.) and
  documents at compile time that the function never reads.
- Doc comment now spells out the dependency direction: the loop
  calls into the chunker, never the reverse.

This is **not**:

- A behaviour change. Same logic, same events, same return values.
- A package extraction. `streamResult` stays unexported in
  `pkg/runtime`. Lifting this into `pkg/runtime/internal/streamproc`
  would require inverting the events-channel dependency (`Event` is
  currently a runtime-defined type), which is a much larger refactor
  and explicitly out of scope here.
- A function split. `handleStream` is still ~200 lines doing tool-call
  aggregation, content/reasoning aggregation, usage tracking, and
  finish-reason coercion. Those concerns could be split, but that's
  a separate refactor.

## Diff

Two files, six lines of substantive change:

- `pkg/runtime/streaming.go`: drop `(r *LocalRuntime)`, tighten
  channel direction, add doc paragraph explaining why.
- `pkg/runtime/fallback.go`: drop the `r.` qualifier at the single
  call site.

`streamResult` and `stripImageContent` are unchanged.

## Validation

- `mise lint` — 0 issues
- `mise test` — full suite passes (existing `stripImageContent`
  table test still works since both functions live in the same
  package)