### PR TITLE
feat(hooks): lifecycle events, per-hook options, and event-spec refactor

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -602,6 +602,10 @@
       "type": "object",
       "description": "Definition of a single hook command",
       "properties": {
+        "name": {
+          "type": "string",
+          "description": "Optional friendly hook name used in logs and runtime hook events."
+        },
         "type": {
           "type": "string",
           "description": "Type of hook. 'command' executes a shell command; 'builtin' invokes a named in-process Go function registered by the runtime. The docker-agent runtime ships these builtins: 'add_date', 'add_environment_info', 'add_prompt_files'.",
@@ -626,6 +630,27 @@
           "description": "Execution timeout in seconds (default: 60)",
           "minimum": 1,
           "default": 60
+        },
+        "env": {
+          "type": "object",
+          "description": "Environment variables to add or override for this hook only.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "working_dir": {
+          "type": "string",
+          "description": "Working directory for this hook. Relative paths are resolved from the agent working directory."
+        },
+        "on_error": {
+          "type": "string",
+          "description": "How non-fail-closed hook failures are handled. 'warn' logs and continues (default), 'ignore' continues silently, and 'block' denies the event.",
+          "enum": [
+            "warn",
+            "ignore",
+            "block"
+          ],
+          "default": "warn"
         }
       },
       "required": [

--- a/docs/configuration/hooks/index.md
+++ b/docs/configuration/hooks/index.md
@@ -200,19 +200,26 @@ Hook exit codes have special meaning:
 | `2`       | Blocking error — stop the operation    |
 | Other     | Error — logged but execution continues |
 
-## Timeout
+## Per-hook options
 
-Hooks have a default timeout of 60 seconds. You can customize this per hook:
+Hooks have a default timeout of 60 seconds. You can also give hooks a name, add environment variables, choose a working directory, and control how non-security hook failures behave:
 
 ```yaml
 hooks:
-  pre_tool_use:
-    - matcher: "*"
+  post_tool_use:
+    - matcher: "shell"
       hooks:
-        - type: command
-          command: "./slow-validation.sh"
+        - name: "summarize shell output"
+          type: command
+          command: "./summarize.sh"
           timeout: 120 # 2 minutes
+          working_dir: ./hooks
+          env:
+            PROFILE: dev
+          on_error: warn # warn | ignore | block
 ```
+
+`pre_tool_use` is fail-closed for safety: a failed pre-tool hook blocks the tool call regardless of `on_error`.
 
 <div class="callout callout-warning" markdown="1">
 <div class="callout-title">⚠️ Performance

--- a/examples/hooks.yaml
+++ b/examples/hooks.yaml
@@ -102,11 +102,19 @@ agents:
       post_tool_use:
         - matcher: "shell"
           hooks:
-            - type: command
+            - name: summarize shell output
+              type: command
+              timeout: 10
+              working_dir: .
+              env:
+                HOOK_PROFILE: dev
+              on_error: warn
               command: |
                 INPUT=$(cat)
                 TOOL=$(echo "$INPUT" | jq -r '.tool_name')
-                echo "✅ Post-hook: $TOOL completed"
+                ERROR=$(echo "$INPUT" | jq -r '.tool_error // false')
+                OUTPUT_LEN=$(echo "$INPUT" | jq -r '.tool_response // ""' | wc -c | tr -d ' ')
+                echo "✅ Post-hook: $TOOL completed (error=$ERROR, output=$OUTPUT_LEN chars, profile=$HOOK_PROFILE)"
 
       # ====================================================================
       # SESSION-START - runs ONCE when the session begins.

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -1704,6 +1704,9 @@ type HookMatcherConfig struct {
 
 // HookDefinition represents a single hook configuration
 type HookDefinition struct {
+	// Name gives the hook a friendly label for logs and runtime events.
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
 	// Type specifies the hook type. Supported values:
 	//   - "command":  run a shell command (default)
 	//   - "builtin":  invoke a named, in-process Go function (the name
@@ -1725,6 +1728,15 @@ type HookDefinition struct {
 
 	// Timeout is the execution timeout in seconds (default: 60)
 	Timeout int `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+
+	// Env adds or overrides environment variables for this hook only.
+	Env map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
+
+	// WorkingDir overrides the runtime working directory for this hook.
+	WorkingDir string `json:"working_dir,omitempty" yaml:"working_dir,omitempty"`
+
+	// OnError controls non-fail-closed hook failures: warn (default), ignore, or block.
+	OnError string `json:"on_error,omitempty" yaml:"on_error,omitempty"`
 }
 
 // GetTimeout returns the per-hook execution timeout, defaulting to 60
@@ -1734,6 +1746,18 @@ func (h *HookDefinition) GetTimeout() time.Duration {
 		return 60 * time.Second
 	}
 	return time.Duration(h.Timeout) * time.Second
+}
+
+// DisplayName returns a human-friendly identifier for the hook: the
+// configured Name when set, otherwise the Command, otherwise the Type.
+func (h *HookDefinition) DisplayName() string {
+	if h.Name != "" {
+		return h.Name
+	}
+	if h.Command != "" {
+		return h.Command
+	}
+	return h.Type
 }
 
 // validate validates the HooksConfig

--- a/pkg/hooks/events.go
+++ b/pkg/hooks/events.go
@@ -1,0 +1,56 @@
+package hooks
+
+// StdoutPolicy describes how plain stdout from a successful hook is
+// interpreted when it is not JSON. Most events ignore it; context events
+// route it to Result.AdditionalContext.
+type StdoutPolicy int
+
+const (
+	StdoutIgnored StdoutPolicy = iota
+	StdoutAdditionalContext
+)
+
+// EventSpec is the single place that describes hook-event semantics.
+// Keep behavior here rather than scattering event-specific conditionals
+// through the executor.
+type EventSpec struct {
+	Type         EventType
+	ToolScoped   bool
+	FailClosed   bool
+	StdoutPolicy StdoutPolicy
+}
+
+var eventSpecs = []EventSpec{
+	{Type: EventPreToolUse, ToolScoped: true, FailClosed: true},
+	{Type: EventPostToolUse, ToolScoped: true, StdoutPolicy: StdoutAdditionalContext},
+	{Type: EventSessionStart, StdoutPolicy: StdoutAdditionalContext},
+	{Type: EventTurnStart, StdoutPolicy: StdoutAdditionalContext},
+	{Type: EventBeforeLLMCall},
+	{Type: EventAfterLLMCall},
+	{Type: EventSessionEnd},
+	{Type: EventOnUserInput},
+	{Type: EventStop, StdoutPolicy: StdoutAdditionalContext},
+	{Type: EventNotification},
+	{Type: EventOnError},
+	{Type: EventOnMaxIterations},
+}
+
+var eventSpecByType = func() map[EventType]EventSpec {
+	m := make(map[EventType]EventSpec, len(eventSpecs))
+	for _, spec := range eventSpecs {
+		m[spec.Type] = spec
+	}
+	return m
+}()
+
+// EventSpecs returns the known hook event specifications in stable order.
+func EventSpecs() []EventSpec {
+	return append([]EventSpec(nil), eventSpecs...)
+}
+
+func eventSpec(event EventType) EventSpec {
+	if spec, ok := eventSpecByType[event]; ok {
+		return spec
+	}
+	return EventSpec{Type: event}
+}

--- a/pkg/hooks/executor.go
+++ b/pkg/hooks/executor.go
@@ -263,14 +263,14 @@ func parseStdoutJSON(stdout string) *Output {
 
 // aggregate combines per-hook results into a single [Result].
 func aggregate(results []hookResult, event EventType) *Result {
+	spec := eventSpec(event)
 	final := &Result{Allowed: true}
 	var messages, contexts, sysMsgs []string
 
 	for _, r := range results {
 		switch {
 		case r.err != nil:
-			// PreToolUse is a security boundary: an exec failure denies.
-			if event == EventPreToolUse {
+			if spec.FailClosed {
 				slog.Warn("PreToolUse hook failed to execute; denying tool call", "error", r.err)
 				final.Allowed = false
 				final.ExitCode = -1
@@ -297,7 +297,7 @@ func aggregate(results []hookResult, event EventType) *Result {
 		case r.Output == nil:
 			// Plain stdout becomes AdditionalContext only for events
 			// whose runtime consumes it.
-			if r.Stdout != "" && event.consumesContext() {
+			if r.Stdout != "" && spec.StdoutPolicy == StdoutAdditionalContext {
 				contexts = append(contexts, strings.TrimSpace(r.Stdout))
 			}
 			continue

--- a/pkg/hooks/executor.go
+++ b/pkg/hooks/executor.go
@@ -189,7 +189,8 @@ func dedupKey(h Hook) string {
 type hookResult struct {
 	HandlerResult
 
-	err error
+	hook Hook
+	err  error
 }
 
 // runHook resolves the hook's [HookType] in the registry, applies its
@@ -198,18 +199,18 @@ type hookResult struct {
 func (e *Executor) runHook(ctx context.Context, hook Hook, inputJSON []byte) hookResult {
 	factory, ok := e.registry.Lookup(hook.Type)
 	if !ok {
-		return hookResult{err: fmt.Errorf("unsupported hook type: %s", hook.Type)}
+		return hookResult{hook: hook, err: fmt.Errorf("unsupported hook type: %s", hook.Type)}
 	}
 	handler, err := factory(HandlerEnv{WorkingDir: e.workingDir, Env: e.env}, hook)
 	if err != nil {
-		return hookResult{err: err}
+		return hookResult{hook: hook, err: err}
 	}
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, hook.GetTimeout())
 	defer cancel()
 
 	res, err := handler.Run(timeoutCtx, inputJSON)
-	r := hookResult{HandlerResult: res}
+	r := hookResult{HandlerResult: res, hook: hook}
 
 	// markFailed turns r into a "did not complete" outcome: the
 	// handler's diagnostic stdout/stderr survive (aggregate surfaces
@@ -270,14 +271,18 @@ func aggregate(results []hookResult, event EventType) *Result {
 	for _, r := range results {
 		switch {
 		case r.err != nil:
-			if spec.FailClosed {
-				slog.Warn("PreToolUse hook failed to execute; denying tool call", "error", r.err)
+			policy := ErrorPolicy(r.hook.OnError)
+			if policy == "" {
+				policy = ErrorPolicyWarn
+			}
+			if spec.FailClosed || policy == ErrorPolicyBlock {
+				slog.Warn("Hook failed; blocking event", "hook", r.hook.DisplayName(), "error", r.err)
 				final.Allowed = false
 				final.ExitCode = -1
 				final.Stderr = r.Stderr
 				messages = append(messages, fmt.Sprintf("PreToolUse hook failed to execute: %v", r.err))
-			} else {
-				slog.Warn("Hook execution error", "error", r.err)
+			} else if policy != ErrorPolicyIgnore {
+				slog.Warn("Hook execution error", "hook", r.hook.DisplayName(), "error", r.err)
 			}
 			continue
 

--- a/pkg/hooks/handler.go
+++ b/pkg/hooks/handler.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"sync"
 
 	"github.com/docker/docker-agent/pkg/shellpath"
@@ -125,13 +127,52 @@ func newCommandFactory() HandlerFactory {
 			return nil, errors.New("command hook requires a non-empty command")
 		}
 		return &commandHandler{
-			workingDir: env.WorkingDir,
-			env:        env.Env,
+			workingDir: hookWorkingDir(env.WorkingDir, hook.WorkingDir),
+			env:        hookEnv(env.Env, hook.Env),
 			shell:      shell,
 			shellArgs:  shellArgs,
 			command:    hook.Command,
 		}, nil
 	}
+}
+
+func hookWorkingDir(base, override string) string {
+	if override == "" || filepath.IsAbs(override) {
+		return override
+	}
+	if base == "" {
+		return override
+	}
+	return filepath.Join(base, override)
+}
+
+func hookEnv(base []string, overrides map[string]string) []string {
+	if len(overrides) == 0 {
+		return base
+	}
+	env := append([]string{}, base...)
+	if len(env) == 0 {
+		env = os.Environ()
+	}
+	index := make(map[string]int, len(env))
+	for i, entry := range env {
+		for j, ch := range entry {
+			if ch == '=' {
+				index[entry[:j]] = i
+				break
+			}
+		}
+	}
+	for key, value := range overrides {
+		entry := key + "=" + value
+		if i, ok := index[key]; ok {
+			env[i] = entry
+			continue
+		}
+		index[key] = len(env)
+		env = append(env, entry)
+	}
+	return env
 }
 
 // commandHandler runs a hook by exec'ing its command under a shell.

--- a/pkg/hooks/handler_test.go
+++ b/pkg/hooks/handler_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -205,4 +208,43 @@ type handlerFunc func(context.Context, []byte) (HandlerResult, error)
 
 func (f handlerFunc) Run(ctx context.Context, input []byte) (HandlerResult, error) {
 	return f(ctx, input)
+}
+
+func TestCommandHookUsesPerHookEnvAndWorkingDir(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	scriptsDir := filepath.Join(baseDir, "scripts")
+	require.NoError(t, os.Mkdir(scriptsDir, 0o755))
+
+	exec := NewExecutor(&Config{SessionStart: []Hook{{
+		Type:       HookTypeCommand,
+		Command:    `printf '{"hook_specific_output":{"additional_context":"%s:%s"}}' "$HOOK_VALUE" "$(pwd)"`,
+		Env:        map[string]string{"HOOK_VALUE": "from-hook"},
+		WorkingDir: "scripts",
+	}}}, baseDir, os.Environ())
+
+	result, err := exec.Dispatch(t.Context(), EventSessionStart, &Input{SessionID: "s"})
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(result.AdditionalContext, "from-hook:"), result.AdditionalContext)
+	assert.True(t, strings.HasSuffix(result.AdditionalContext, "/scripts"), result.AdditionalContext)
+}
+
+func TestHookOnErrorBlockCanDenyNonFailClosedEvent(t *testing.T) {
+	t.Parallel()
+
+	exec := NewExecutor(&Config{PostToolUse: []MatcherConfig{{
+		Matcher: "*",
+		Hooks: []Hook{{
+			Type:    HookTypeBuiltin,
+			Command: "missing",
+			Name:    "missing builtin",
+			OnError: string(ErrorPolicyBlock),
+		}},
+	}}}, t.TempDir(), nil)
+
+	result, err := exec.Dispatch(t.Context(), EventPostToolUse, &Input{SessionID: "s", ToolName: "shell"})
+	require.NoError(t, err)
+	assert.False(t, result.Allowed)
+	assert.Contains(t, result.Message, "no builtin hook registered")
 }

--- a/pkg/hooks/types.go
+++ b/pkg/hooks/types.go
@@ -72,7 +72,8 @@ type Input struct {
 	ToolInput map[string]any `json:"tool_input,omitempty"`
 
 	// PostToolUse specific.
-	ToolResponse any `json:"tool_response,omitempty"`
+	ToolResponse any  `json:"tool_response,omitempty"`
+	ToolError    bool `json:"tool_error,omitempty"`
 
 	// SessionStart specific: "startup", "resume", "clear", "compact".
 	Source string `json:"source,omitempty"`

--- a/pkg/hooks/types.go
+++ b/pkg/hooks/types.go
@@ -47,19 +47,6 @@ const (
 	EventOnMaxIterations EventType = "on_max_iterations"
 )
 
-// consumesContext reports whether the runtime emit site for e routes
-// [Result.AdditionalContext] somewhere meaningful (a system message, a
-// transient turn_start prompt, ...). For observational events it is
-// silently dropped, so plain stdout from a hook is also discarded for
-// those.
-func (e EventType) consumesContext() bool {
-	switch e {
-	case EventSessionStart, EventTurnStart, EventPostToolUse, EventStop:
-		return true
-	}
-	return false
-}
-
 // Input is the JSON-serializable payload passed to hooks via stdin.
 type Input struct {
 	SessionID     string    `json:"session_id"`

--- a/pkg/hooks/types.go
+++ b/pkg/hooks/types.go
@@ -76,7 +76,15 @@ type Input struct {
 // ToJSON serializes the input.
 func (i *Input) ToJSON() ([]byte, error) { return json.Marshal(i) }
 
-// Decision is a permission decision returned by a hook.
+// ErrorPolicy controls what happens when a non-fail-closed hook fails.
+type ErrorPolicy string
+
+const (
+	ErrorPolicyWarn   ErrorPolicy = "warn"
+	ErrorPolicyIgnore ErrorPolicy = "ignore"
+	ErrorPolicyBlock  ErrorPolicy = "block"
+)
+
 type Decision string
 
 const (

--- a/pkg/runtime/client.go
+++ b/pkg/runtime/client.go
@@ -85,6 +85,8 @@ func NewClient(baseURL string, opts ...ClientOption) (*Client, error) {
 			"agent_switching":        func() Event { return &AgentSwitchingEvent{} },
 			"warning":                func() Event { return &WarningEvent{} },
 			"hook_blocked":           func() Event { return &HookBlockedEvent{} },
+			"hook_started":           func() Event { return &HookStartedEvent{} },
+			"hook_finished":          func() Event { return &HookFinishedEvent{} },
 			"rag_indexing_started":   func() Event { return &RAGIndexingStartedEvent{} },
 			"rag_indexing_progress":  func() Event { return &RAGIndexingProgressEvent{} },
 			"rag_indexing_completed": func() Event { return &RAGIndexingCompletedEvent{} },

--- a/pkg/runtime/event.go
+++ b/pkg/runtime/event.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/config/types"
+	"github.com/docker/docker-agent/pkg/hooks"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/tools"
 )
@@ -605,6 +606,61 @@ func RAGIndexingCompleted(ragName, strategyName string) Event {
 		StrategyName: strategyName,
 		AgentContext: newAgentContext(""),
 	}
+}
+
+// HookStartedEvent is emitted when a configured hook event begins dispatching.
+type HookStartedEvent struct {
+	AgentContext
+
+	Type      string          `json:"type"`
+	SessionID string          `json:"session_id"`
+	HookEvent hooks.EventType `json:"hook_event"`
+}
+
+func (e *HookStartedEvent) GetSessionID() string { return e.SessionID }
+
+func HookStarted(event hooks.EventType, sessionID, agentName string) Event {
+	return &HookStartedEvent{
+		Type:         "hook_started",
+		SessionID:    sessionID,
+		HookEvent:    event,
+		AgentContext: newAgentContext(agentName),
+	}
+}
+
+// HookFinishedEvent is emitted when a configured hook event completes.
+type HookFinishedEvent struct {
+	AgentContext
+
+	Type       string          `json:"type"`
+	SessionID  string          `json:"session_id"`
+	HookEvent  hooks.EventType `json:"hook_event"`
+	DurationMs int64           `json:"duration_ms"`
+	Allowed    bool            `json:"allowed"`
+	Error      string          `json:"error,omitempty"`
+	Message    string          `json:"message,omitempty"`
+}
+
+func (e *HookFinishedEvent) GetSessionID() string { return e.SessionID }
+
+func HookFinished(event hooks.EventType, sessionID string, result *hooks.Result, dispatchErr error, duration time.Duration, agentName string) Event {
+	e := &HookFinishedEvent{
+		Type:         "hook_finished",
+		SessionID:    sessionID,
+		HookEvent:    event,
+		DurationMs:   duration.Milliseconds(),
+		Allowed:      true,
+		AgentContext: newAgentContext(agentName),
+	}
+	if result != nil {
+		e.Allowed = result.Allowed
+		e.Message = result.Message
+	}
+	if dispatchErr != nil {
+		e.Allowed = false
+		e.Error = dispatchErr.Error()
+	}
+	return e
 }
 
 // HookBlockedEvent is sent when a pre-tool hook blocks a tool call

--- a/pkg/runtime/hooks.go
+++ b/pkg/runtime/hooks.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"log/slog"
+	"time"
 
 	"github.com/docker/docker-agent/pkg/agent"
 	"github.com/docker/docker-agent/pkg/chat"
@@ -69,11 +70,18 @@ func (r *LocalRuntime) dispatchHook(
 	events chan Event,
 ) *hooks.Result {
 	exec := r.hooksExec(a)
-	if exec == nil {
+	if exec == nil || !exec.Has(event) {
 		return nil
 	}
 
+	started := time.Now()
+	if events != nil {
+		events <- HookStarted(event, input.SessionID, a.Name())
+	}
 	result, err := exec.Dispatch(ctx, event, input)
+	if events != nil {
+		events <- HookFinished(event, input.SessionID, result, err, time.Since(started), a.Name())
+	}
 	if err != nil {
 		slog.Warn("Hook execution failed", "event", event, "agent", a.Name(), "error", err)
 		return nil

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker-agent/pkg/agent"
 	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/hooks"
 	"github.com/docker/docker-agent/pkg/model/provider/base"
 	"github.com/docker/docker-agent/pkg/modelerrors"
 	"github.com/docker/docker-agent/pkg/modelsdev"
@@ -2838,4 +2839,59 @@ func TestDrainAndEmitSteered_MultiContent(t *testing.T) {
 	secondParts := items[1].Message.Message.MultiContent
 	require.Len(t, secondParts, 1)
 	assert.Equal(t, "second", secondParts[0].Text, "last message must not be modified")
+}
+
+func TestPostToolHookReceivesToolResult(t *testing.T) {
+	var got *hooks.Input
+	registry := hooks.NewRegistry()
+	require.NoError(t, registry.RegisterBuiltin("capture_post_tool", func(_ context.Context, in *hooks.Input, _ []string) (*hooks.Output, error) {
+		inputCopy := *in
+		got = &inputCopy
+		return nil, nil
+	}))
+
+	agentTools := []tools.Tool{{
+		Name:       "echo_tool",
+		Parameters: map[string]any{},
+		Handler: func(_ context.Context, _ tools.ToolCall) (*tools.ToolCallResult, error) {
+			return tools.ResultSuccess("actual tool output"), nil
+		},
+	}}
+
+	root := agent.New("root", "You are a test agent",
+		agent.WithModel(&mockProvider{id: "test/mock-model", stream: &mockStream{}}),
+		agent.WithToolSets(newStubToolSet(nil, agentTools, nil)),
+		agent.WithHooks(&latest.HooksConfig{
+			PostToolUse: []latest.HookMatcherConfig{{
+				Matcher: "echo_tool",
+				Hooks: []latest.HookDefinition{{
+					Type:    "builtin",
+					Command: "capture_post_tool",
+				}},
+			}},
+		}),
+	)
+	tm := team.New(team.WithAgents(root))
+	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+	rt.hooksRegistry = registry
+	rt.buildHooksExecutors()
+
+	sess := session.New(session.WithUserMessage("Test"), session.WithToolsApproved(true))
+	calls := []tools.ToolCall{{
+		ID:       "call_1",
+		Type:     "function",
+		Function: tools.FunctionCall{Name: "echo_tool", Arguments: `{"message":"hello"}`},
+	}}
+
+	events := make(chan Event, 10)
+	rt.processToolCalls(t.Context(), sess, calls, agentTools, events)
+
+	require.NotNil(t, got)
+	assert.Equal(t, hooks.EventPostToolUse, got.HookEventName)
+	assert.Equal(t, "echo_tool", got.ToolName)
+	assert.Equal(t, "call_1", got.ToolUseID)
+	assert.Equal(t, "actual tool output", got.ToolResponse)
+	assert.False(t, got.ToolError)
+	assert.Equal(t, "hello", got.ToolInput["message"])
 }

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -2895,3 +2895,69 @@ func TestPostToolHookReceivesToolResult(t *testing.T) {
 	assert.False(t, got.ToolError)
 	assert.Equal(t, "hello", got.ToolInput["message"])
 }
+
+func TestPostToolHookEmitsLifecycleEvents(t *testing.T) {
+	registry := hooks.NewRegistry()
+	require.NoError(t, registry.RegisterBuiltin("noop_post_tool", func(_ context.Context, _ *hooks.Input, _ []string) (*hooks.Output, error) {
+		return nil, nil
+	}))
+
+	agentTools := []tools.Tool{{
+		Name:       "echo_tool",
+		Parameters: map[string]any{},
+		Handler: func(_ context.Context, _ tools.ToolCall) (*tools.ToolCallResult, error) {
+			return tools.ResultSuccess("ok"), nil
+		},
+	}}
+
+	root := agent.New("root", "You are a test agent",
+		agent.WithModel(&mockProvider{id: "test/mock-model", stream: &mockStream{}}),
+		agent.WithToolSets(newStubToolSet(nil, agentTools, nil)),
+		agent.WithHooks(&latest.HooksConfig{
+			PostToolUse: []latest.HookMatcherConfig{{
+				Matcher: "echo_tool",
+				Hooks: []latest.HookDefinition{{
+					Type:    "builtin",
+					Command: "noop_post_tool",
+				}},
+			}},
+		}),
+	)
+	tm := team.New(team.WithAgents(root))
+	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+	rt.hooksRegistry = registry
+	rt.buildHooksExecutors()
+
+	sess := session.New(session.WithUserMessage("Test"), session.WithToolsApproved(true))
+	calls := []tools.ToolCall{{
+		ID:       "call_1",
+		Type:     "function",
+		Function: tools.FunctionCall{Name: "echo_tool", Arguments: `{}`},
+	}}
+
+	events := make(chan Event, 10)
+	rt.processToolCalls(t.Context(), sess, calls, agentTools, events)
+
+	var started *HookStartedEvent
+	var finished *HookFinishedEvent
+	for len(events) > 0 {
+		switch ev := (<-events).(type) {
+		case *HookStartedEvent:
+			started = ev
+		case *HookFinishedEvent:
+			finished = ev
+		}
+	}
+
+	require.NotNil(t, started)
+	assert.Equal(t, hooks.EventPostToolUse, started.HookEvent)
+	assert.Equal(t, sess.ID, started.SessionID)
+	assert.Equal(t, "root", started.AgentName)
+
+	require.NotNil(t, finished)
+	assert.Equal(t, hooks.EventPostToolUse, finished.HookEvent)
+	assert.Equal(t, sess.ID, finished.SessionID)
+	assert.True(t, finished.Allowed)
+	assert.Empty(t, finished.Error)
+}

--- a/pkg/runtime/tool_dispatch.go
+++ b/pkg/runtime/tool_dispatch.go
@@ -294,7 +294,7 @@ func (r *LocalRuntime) executeToolWithHandler(
 	a *agent.Agent,
 	spanName string,
 	execute func(ctx context.Context) (*tools.ToolCallResult, time.Duration, error),
-) {
+) *tools.ToolCallResult {
 	ctx, span := r.startSpan(ctx, spanName, trace.WithAttributes(
 		attribute.String("tool.name", toolCall.Function.Name),
 		attribute.String("agent", a.Name()),
@@ -362,6 +362,7 @@ func (r *LocalRuntime) executeToolWithHandler(
 	}
 
 	addAgentMessage(sess, a, &toolResponseMsg, events)
+	return res
 }
 
 // runTool executes a user tool from a toolset (MCP, filesystem, ...).
@@ -374,13 +375,13 @@ func (r *LocalRuntime) runTool(ctx context.Context, tool tools.Tool, toolCall to
 		return toolApprovalOutcome{}
 	}
 
-	r.executeToolWithHandler(ctx, toolCall, tool, events, sess, a, "runtime.tool.handler",
+	res := r.executeToolWithHandler(ctx, toolCall, tool, events, sess, a, "runtime.tool.handler",
 		func(ctx context.Context) (*tools.ToolCallResult, time.Duration, error) {
 			res, err := tool.Handler(ctx, toolCall)
 			return res, 0, err
 		})
 
-	stop, msg := r.executePostToolHook(ctx, sess, toolCall, a, events)
+	stop, msg := r.executePostToolHook(ctx, sess, toolCall, res, a, events)
 	return toolApprovalOutcome{stopRun: stop, stopMessage: msg}
 }
 
@@ -394,6 +395,15 @@ func newHooksInput(sess *session.Session, toolCall tools.ToolCall) *hooks.Input 
 		ToolUseID: toolCall.ID,
 		ToolInput: parseToolInput(toolCall.Function.Arguments),
 	}
+}
+
+func newPostToolHookInput(sess *session.Session, toolCall tools.ToolCall, res *tools.ToolCallResult) *hooks.Input {
+	input := newHooksInput(sess, toolCall)
+	if res != nil {
+		input.ToolResponse = res.Output
+		input.ToolError = res.IsError
+	}
+	return input
 }
 
 // executePreToolHook runs the pre-tool-use hook and returns whether the tool
@@ -440,10 +450,11 @@ func (r *LocalRuntime) executePostToolHook(
 	ctx context.Context,
 	sess *session.Session,
 	toolCall tools.ToolCall,
+	res *tools.ToolCallResult,
 	a *agent.Agent,
 	events chan Event,
 ) (stop bool, message string) {
-	result := r.dispatchHook(ctx, a, hooks.EventPostToolUse, newHooksInput(sess, toolCall), events)
+	result := r.dispatchHook(ctx, a, hooks.EventPostToolUse, newPostToolHookInput(sess, toolCall, res), events)
 	if result == nil || result.Allowed {
 		return false, ""
 	}


### PR DESCRIPTION
Adds runtime visibility and per-hook customization on top of the recent
`pkg/hooks` alias-based refactor.

## Commits

- **feat(hooks): include tool results in post hooks** — pass the actual
  `ToolCallResult` (response + error flag) into `post_tool_use` hooks so
  they can audit, summarize, or react to what the tool returned instead
  of only seeing the original call metadata.

- **refactor(hooks): centralize event semantics** — describe each event's
  tool-scoping, fail-closed behavior, and stdout-routing policy in a
  single `EventSpec` table (`pkg/hooks/events.go`) instead of scattering
  conditionals across the executor. The aggregator now consults `spec`
  rather than hard-coding `event == EventPreToolUse` / `consumesContext`.

- **feat(hooks): emit lifecycle events** — emit `hook_started` and
  `hook_finished` events around every dispatch so API/TUI consumers can
  see when a hook event ran, how long it took, and whether it allowed
  the operation. Includes session, agent, hook event, duration, result,
  and any dispatch error.

- **feat(hooks): add per-hook execution options** — adds `name`, `env`,
  `working_dir`, and `on_error` to hook definitions. `env` and
  `working_dir` are applied per-hook (relative dirs resolve against the
  executor's working dir); `on_error: warn|ignore|block` lets
  non-fail-closed events opt into blocking on hook failure, while
  `pre_tool_use` stays fail-closed regardless. Schema, docs, and
  `examples/hooks.yaml` updated.

## Validation

- `go build ./...` ✅
- `mise test` ✅
- `golangci-lint run` ✅

Assisted-By: docker-agent
