### PR TITLE
feat(hooks): add three observability events around runtime transitions

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -574,6 +574,13 @@
           "items": {
             "$ref": "#/definitions/HookDefinition"
           }
+        },
+        "on_session_resume": {
+          "type": "array",
+          "description": "Hooks that run when the user explicitly approves the runtime to continue past its configured max_iterations limit. Receives previous_max_iterations and new_max_iterations in the input. Observational; useful for alerting on extended-runtime sessions or for billing/quota pipelines that meter resumes.",
+          "items": {
+            "$ref": "#/definitions/HookDefinition"
+          }
         }
       },
       "additionalProperties": false

--- a/agent-schema.json
+++ b/agent-schema.json
@@ -567,6 +567,13 @@
           "items": {
             "$ref": "#/definitions/HookDefinition"
           }
+        },
+        "on_agent_switch": {
+          "type": "array",
+          "description": "Hooks that run whenever the runtime moves the active agent to a new one (transfer_task, handoff, or the return after a transferred task completes). Receives from_agent, to_agent, and agent_switch_kind in the input. Observational; useful for audit, transcript, and metrics pipelines that track which agent ran which tools.",
+          "items": {
+            "$ref": "#/definitions/HookDefinition"
+          }
         }
       },
       "additionalProperties": false

--- a/agent-schema.json
+++ b/agent-schema.json
@@ -581,6 +581,13 @@
           "items": {
             "$ref": "#/definitions/HookDefinition"
           }
+        },
+        "on_tool_approval_decision": {
+          "type": "array",
+          "description": "Hooks that run after the runtime's tool approval chain (yolo / permissions / readonly / ask) resolves a verdict for a tool call, before the call is executed (allow) or its error response is recorded (deny / canceled). Receives approval_decision (\"allow\" | \"deny\" | \"canceled\") and approval_source (a stable classifier of which step decided). Observational; gives audit pipelines a single \"who approved what\" record without re-implementing the chain.",
+          "items": {
+            "$ref": "#/definitions/HookDefinition"
+          }
         }
       },
       "additionalProperties": false

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -1676,6 +1676,11 @@ type HooksConfig struct {
 	// after a transferred task completes. Observational; useful for
 	// audit, transcript, and metrics pipelines.
 	OnAgentSwitch []HookDefinition `json:"on_agent_switch,omitempty" yaml:"on_agent_switch,omitempty"`
+
+	// OnSessionResume hooks run when the user explicitly approves the
+	// runtime to continue past its configured max_iterations limit.
+	// Observational; useful for alerting on extended-runtime sessions.
+	OnSessionResume []HookDefinition `json:"on_session_resume,omitempty" yaml:"on_session_resume,omitempty"`
 }
 
 // IsEmpty returns true if no hooks are configured
@@ -1695,7 +1700,8 @@ func (h *HooksConfig) IsEmpty() bool {
 		len(h.Notification) == 0 &&
 		len(h.OnError) == 0 &&
 		len(h.OnMaxIterations) == 0 &&
-		len(h.OnAgentSwitch) == 0
+		len(h.OnAgentSwitch) == 0 &&
+		len(h.OnSessionResume) == 0
 }
 
 // HookMatcherConfig represents a hook matcher with its hooks.
@@ -1832,6 +1838,13 @@ func (h *HooksConfig) validate() error {
 	// Validate OnAgentSwitch hooks
 	for i, hook := range h.OnAgentSwitch {
 		if err := hook.validate("on_agent_switch", i); err != nil {
+			return err
+		}
+	}
+
+	// Validate OnSessionResume hooks
+	for i, hook := range h.OnSessionResume {
+		if err := hook.validate("on_session_resume", i); err != nil {
 			return err
 		}
 	}

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -1670,6 +1670,12 @@ type HooksConfig struct {
 	// max_iterations limit. Fires alongside Notification with
 	// level="warning".
 	OnMaxIterations []HookDefinition `json:"on_max_iterations,omitempty" yaml:"on_max_iterations,omitempty"`
+
+	// OnAgentSwitch hooks run whenever the runtime moves the active
+	// agent to a new one — transfer_task, handoff, or the return
+	// after a transferred task completes. Observational; useful for
+	// audit, transcript, and metrics pipelines.
+	OnAgentSwitch []HookDefinition `json:"on_agent_switch,omitempty" yaml:"on_agent_switch,omitempty"`
 }
 
 // IsEmpty returns true if no hooks are configured
@@ -1688,7 +1694,8 @@ func (h *HooksConfig) IsEmpty() bool {
 		len(h.Stop) == 0 &&
 		len(h.Notification) == 0 &&
 		len(h.OnError) == 0 &&
-		len(h.OnMaxIterations) == 0
+		len(h.OnMaxIterations) == 0 &&
+		len(h.OnAgentSwitch) == 0
 }
 
 // HookMatcherConfig represents a hook matcher with its hooks.
@@ -1818,6 +1825,13 @@ func (h *HooksConfig) validate() error {
 	// Validate OnMaxIterations hooks
 	for i, hook := range h.OnMaxIterations {
 		if err := hook.validate("on_max_iterations", i); err != nil {
+			return err
+		}
+	}
+
+	// Validate OnAgentSwitch hooks
+	for i, hook := range h.OnAgentSwitch {
+		if err := hook.validate("on_agent_switch", i); err != nil {
 			return err
 		}
 	}

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -1681,6 +1681,12 @@ type HooksConfig struct {
 	// runtime to continue past its configured max_iterations limit.
 	// Observational; useful for alerting on extended-runtime sessions.
 	OnSessionResume []HookDefinition `json:"on_session_resume,omitempty" yaml:"on_session_resume,omitempty"`
+
+	// OnToolApprovalDecision hooks run after the runtime's tool
+	// approval chain resolves a verdict for a tool call. Observational;
+	// gives audit pipelines a structured "who approved what" record
+	// without re-implementing the chain.
+	OnToolApprovalDecision []HookDefinition `json:"on_tool_approval_decision,omitempty" yaml:"on_tool_approval_decision,omitempty"`
 }
 
 // IsEmpty returns true if no hooks are configured
@@ -1701,7 +1707,8 @@ func (h *HooksConfig) IsEmpty() bool {
 		len(h.OnError) == 0 &&
 		len(h.OnMaxIterations) == 0 &&
 		len(h.OnAgentSwitch) == 0 &&
-		len(h.OnSessionResume) == 0
+		len(h.OnSessionResume) == 0 &&
+		len(h.OnToolApprovalDecision) == 0
 }
 
 // HookMatcherConfig represents a hook matcher with its hooks.
@@ -1845,6 +1852,13 @@ func (h *HooksConfig) validate() error {
 	// Validate OnSessionResume hooks
 	for i, hook := range h.OnSessionResume {
 		if err := hook.validate("on_session_resume", i); err != nil {
+			return err
+		}
+	}
+
+	// Validate OnToolApprovalDecision hooks
+	for i, hook := range h.OnToolApprovalDecision {
+		if err := hook.validate("on_tool_approval_decision", i); err != nil {
 			return err
 		}
 	}

--- a/pkg/hooks/executor.go
+++ b/pkg/hooks/executor.go
@@ -86,6 +86,7 @@ func compileEvents(c *Config) map[EventType][]matcher {
 		EventOnError:         flat(c.OnError),
 		EventOnMaxIterations: flat(c.OnMaxIterations),
 		EventOnAgentSwitch:   flat(c.OnAgentSwitch),
+		EventOnSessionResume: flat(c.OnSessionResume),
 	}
 }
 

--- a/pkg/hooks/executor.go
+++ b/pkg/hooks/executor.go
@@ -85,6 +85,7 @@ func compileEvents(c *Config) map[EventType][]matcher {
 		EventNotification:    flat(c.Notification),
 		EventOnError:         flat(c.OnError),
 		EventOnMaxIterations: flat(c.OnMaxIterations),
+		EventOnAgentSwitch:   flat(c.OnAgentSwitch),
 	}
 }
 

--- a/pkg/hooks/executor.go
+++ b/pkg/hooks/executor.go
@@ -73,20 +73,21 @@ func compileEvents(c *Config) map[EventType][]matcher {
 		return []matcher{{hooks: hooks}}
 	}
 	return map[EventType][]matcher{
-		EventPreToolUse:      compileMatchers(c.PreToolUse),
-		EventPostToolUse:     compileMatchers(c.PostToolUse),
-		EventSessionStart:    flat(c.SessionStart),
-		EventTurnStart:       flat(c.TurnStart),
-		EventBeforeLLMCall:   flat(c.BeforeLLMCall),
-		EventAfterLLMCall:    flat(c.AfterLLMCall),
-		EventSessionEnd:      flat(c.SessionEnd),
-		EventOnUserInput:     flat(c.OnUserInput),
-		EventStop:            flat(c.Stop),
-		EventNotification:    flat(c.Notification),
-		EventOnError:         flat(c.OnError),
-		EventOnMaxIterations: flat(c.OnMaxIterations),
-		EventOnAgentSwitch:   flat(c.OnAgentSwitch),
-		EventOnSessionResume: flat(c.OnSessionResume),
+		EventPreToolUse:             compileMatchers(c.PreToolUse),
+		EventPostToolUse:            compileMatchers(c.PostToolUse),
+		EventSessionStart:           flat(c.SessionStart),
+		EventTurnStart:              flat(c.TurnStart),
+		EventBeforeLLMCall:          flat(c.BeforeLLMCall),
+		EventAfterLLMCall:           flat(c.AfterLLMCall),
+		EventSessionEnd:             flat(c.SessionEnd),
+		EventOnUserInput:            flat(c.OnUserInput),
+		EventStop:                   flat(c.Stop),
+		EventNotification:           flat(c.Notification),
+		EventOnError:                flat(c.OnError),
+		EventOnMaxIterations:        flat(c.OnMaxIterations),
+		EventOnAgentSwitch:          flat(c.OnAgentSwitch),
+		EventOnSessionResume:        flat(c.OnSessionResume),
+		EventOnToolApprovalDecision: flat(c.OnToolApprovalDecision),
 	}
 }
 

--- a/pkg/hooks/types.go
+++ b/pkg/hooks/types.go
@@ -53,6 +53,11 @@ const (
 	// agent ran which tools without subscribing to the runtime event
 	// channel.
 	EventOnAgentSwitch EventType = "on_agent_switch"
+	// EventOnSessionResume fires when the user explicitly approves the
+	// runtime to continue past its configured max_iterations limit.
+	// Observational; useful for alerting on extended-runtime sessions
+	// or for pipelines that bill / quota-track per resume.
+	EventOnSessionResume EventType = "on_session_resume"
 )
 
 // consumesContext reports whether the runtime emit site for e routes
@@ -100,6 +105,14 @@ type Input struct {
 	FromAgent       string `json:"from_agent,omitempty"`
 	ToAgent         string `json:"to_agent,omitempty"`
 	AgentSwitchKind string `json:"agent_switch_kind,omitempty"`
+
+	// OnSessionResume specific: the iteration cap that was reached
+	// (PreviousMaxIterations) and the new cap after the user approved
+	// continuation (NewMaxIterations). Carrying both lets audit
+	// pipelines compute how much extra runtime was granted without
+	// reconstructing it from the iteration counter.
+	PreviousMaxIterations int `json:"previous_max_iterations,omitempty"`
+	NewMaxIterations      int `json:"new_max_iterations,omitempty"`
 }
 
 // ToJSON serializes the input.

--- a/pkg/hooks/types.go
+++ b/pkg/hooks/types.go
@@ -45,6 +45,14 @@ const (
 	EventOnError EventType = "on_error"
 	// EventOnMaxIterations fires when the runtime reaches its max_iterations limit.
 	EventOnMaxIterations EventType = "on_max_iterations"
+	// EventOnAgentSwitch fires whenever the runtime moves the active
+	// agent to a new one — either delegating a task (transfer_task),
+	// handing off the conversation (handoff), or returning to the
+	// caller after a transferred task completes. Observational; useful
+	// for audit, transcript, and metrics pipelines that track which
+	// agent ran which tools without subscribing to the runtime event
+	// channel.
+	EventOnAgentSwitch EventType = "on_agent_switch"
 )
 
 // consumesContext reports whether the runtime emit site for e routes
@@ -83,6 +91,15 @@ type Input struct {
 	// Notification specific.
 	NotificationLevel   string `json:"notification_level,omitempty"`
 	NotificationMessage string `json:"notification_message,omitempty"`
+
+	// OnAgentSwitch specific: the agent the runtime is moving away
+	// from (FromAgent) and the one it's switching to (ToAgent), plus
+	// the cause of the transition ("transfer_task", "handoff",
+	// "transfer_task_return"). Empty FromAgent is valid for the
+	// initial switch into the team's default agent.
+	FromAgent       string `json:"from_agent,omitempty"`
+	ToAgent         string `json:"to_agent,omitempty"`
+	AgentSwitchKind string `json:"agent_switch_kind,omitempty"`
 }
 
 // ToJSON serializes the input.

--- a/pkg/hooks/types.go
+++ b/pkg/hooks/types.go
@@ -58,6 +58,13 @@ const (
 	// Observational; useful for alerting on extended-runtime sessions
 	// or for pipelines that bill / quota-track per resume.
 	EventOnSessionResume EventType = "on_session_resume"
+	// EventOnToolApprovalDecision fires after the runtime's tool
+	// approval chain (yolo / permissions / readonly / ask) has resolved
+	// a verdict for a tool call, before the call is executed (for
+	// allow) or its error response is recorded (for deny / canceled).
+	// Observational; gives audit pipelines a single, structured "who
+	// approved what" record without re-implementing the chain.
+	EventOnToolApprovalDecision EventType = "on_tool_approval_decision"
 )
 
 // consumesContext reports whether the runtime emit site for e routes
@@ -113,6 +120,16 @@ type Input struct {
 	// reconstructing it from the iteration counter.
 	PreviousMaxIterations int `json:"previous_max_iterations,omitempty"`
 	NewMaxIterations      int `json:"new_max_iterations,omitempty"`
+
+	// OnToolApprovalDecision specific: the verdict resolved by the
+	// approval chain ("allow", "deny", "canceled") and a stable
+	// classifier for what produced it ("yolo",
+	// "session_permissions_allow", "session_permissions_deny",
+	// "team_permissions_allow", "team_permissions_deny",
+	// "readonly_hint", "user_approved", "user_approved_session",
+	// "user_approved_tool", "user_rejected", "context_canceled").
+	ApprovalDecision string `json:"approval_decision,omitempty"`
+	ApprovalSource   string `json:"approval_source,omitempty"`
 }
 
 // ToJSON serializes the input.

--- a/pkg/runtime/agent_delegation.go
+++ b/pkg/runtime/agent_delegation.go
@@ -311,6 +311,7 @@ func (r *LocalRuntime) handleTaskTransfer(ctx context.Context, sess *session.Ses
 
 	// Emit agent switching start event
 	evts <- AgentSwitching(true, a.Name(), params.Agent)
+	r.executeOnAgentSwitchHooks(ctx, a, sess.ID, a.Name(), params.Agent, agentSwitchKindTransferTask)
 
 	r.setCurrentAgent(params.Agent)
 	defer func() {
@@ -318,6 +319,7 @@ func (r *LocalRuntime) handleTaskTransfer(ctx context.Context, sess *session.Ses
 
 		// Emit agent switching end event
 		evts <- AgentSwitching(false, params.Agent, a.Name())
+		r.executeOnAgentSwitchHooks(ctx, a, sess.ID, params.Agent, a.Name(), agentSwitchKindTransferTaskReturn)
 
 		// Restore original agent info in sidebar
 		evts <- AgentInfo(a.Name(), getAgentModelID(a), a.Description(), a.WelcomeMessage())
@@ -345,7 +347,7 @@ func (r *LocalRuntime) handleTaskTransfer(ctx context.Context, sess *session.Ses
 	return r.runSubSessionForwarding(ctx, sess, s, span, evts, a.Name())
 }
 
-func (r *LocalRuntime) handleHandoff(_ context.Context, _ *session.Session, toolCall tools.ToolCall, _ chan Event) (*tools.ToolCallResult, error) {
+func (r *LocalRuntime) handleHandoff(ctx context.Context, sess *session.Session, toolCall tools.ToolCall, _ chan Event) (*tools.ToolCallResult, error) {
 	var params builtin.HandoffArgs
 	if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &params); err != nil {
 		return nil, fmt.Errorf("invalid arguments: %w", err)
@@ -367,6 +369,7 @@ func (r *LocalRuntime) handleHandoff(_ context.Context, _ *session.Session, tool
 		return nil, err
 	}
 
+	r.executeOnAgentSwitchHooks(ctx, currentAgent, sess.ID, ca, next.Name(), agentSwitchKindHandoff)
 	r.setCurrentAgent(next.Name())
 	handoffMessage := "The agent " + ca + " handed off the conversation to you. " +
 		"Your available handoff agents and tools are specified in the system messages that follow. " +

--- a/pkg/runtime/hooks.go
+++ b/pkg/runtime/hooks.go
@@ -201,6 +201,20 @@ func (r *LocalRuntime) executeOnAgentSwitchHooks(ctx context.Context, a *agent.A
 	}, nil)
 }
 
+// executeOnSessionResumeHooks fires on_session_resume when the user
+// explicitly approves continuation past the configured
+// max_iterations limit. Observational; failures are logged. The hook
+// runs alongside the existing event-channel signalling so audit /
+// quota / alerting pipelines can react without subscribing to the
+// per-session channel.
+func (r *LocalRuntime) executeOnSessionResumeHooks(ctx context.Context, a *agent.Agent, sessionID string, prevMax, newMax int) {
+	r.dispatchHook(ctx, a, hooks.EventOnSessionResume, &hooks.Input{
+		SessionID:             sessionID,
+		PreviousMaxIterations: prevMax,
+		NewMaxIterations:      newMax,
+	}, nil)
+}
+
 // executeBeforeLLMCallHooks fires before_llm_call just before each
 // model call. A terminating verdict (decision="block" / continue=false
 // / exit 2) stops the run loop — see [hooks.EventBeforeLLMCall] for

--- a/pkg/runtime/hooks.go
+++ b/pkg/runtime/hooks.go
@@ -177,6 +177,30 @@ func (r *LocalRuntime) notify(ctx context.Context, a *agent.Agent, event hooks.E
 	}, nil)
 }
 
+// Agent-switch kinds passed via [hooks.Input.AgentSwitchKind] to
+// describe what kind of transition triggered the on_agent_switch
+// event. Constants instead of literals so the hook contract is
+// discoverable from the runtime side and a typo trips a compile
+// error.
+const (
+	agentSwitchKindTransferTask       = "transfer_task"
+	agentSwitchKindTransferTaskReturn = "transfer_task_return"
+	agentSwitchKindHandoff            = "handoff"
+)
+
+// executeOnAgentSwitchHooks fires on_agent_switch when the runtime
+// changes the active agent. Observational; failures are logged. The
+// hook runs alongside the existing [AgentSwitching] event, so users
+// who already consume that event see no behaviour change.
+func (r *LocalRuntime) executeOnAgentSwitchHooks(ctx context.Context, a *agent.Agent, sessionID, fromAgent, toAgent, kind string) {
+	r.dispatchHook(ctx, a, hooks.EventOnAgentSwitch, &hooks.Input{
+		SessionID:       sessionID,
+		FromAgent:       fromAgent,
+		ToAgent:         toAgent,
+		AgentSwitchKind: kind,
+	}, nil)
+}
+
 // executeBeforeLLMCallHooks fires before_llm_call just before each
 // model call. A terminating verdict (decision="block" / continue=false
 // / exit 2) stops the run loop — see [hooks.EventBeforeLLMCall] for

--- a/pkg/runtime/hooks.go
+++ b/pkg/runtime/hooks.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/docker-agent/pkg/hooks"
 	"github.com/docker/docker-agent/pkg/hooks/builtins"
 	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/tools"
 )
 
 // buildHooksExecutors builds a [hooks.Executor] for every agent in the
@@ -213,6 +214,46 @@ func (r *LocalRuntime) executeOnSessionResumeHooks(ctx context.Context, a *agent
 		PreviousMaxIterations: prevMax,
 		NewMaxIterations:      newMax,
 	}, nil)
+}
+
+// Verdicts and sources for [hooks.EventOnToolApprovalDecision]. Constants
+// instead of literals so the contract between executeWithApproval and
+// the hook protocol is discoverable from the runtime side and a typo
+// trips a compile error.
+const (
+	ApprovalDecisionAllow    = "allow"
+	ApprovalDecisionDeny     = "deny"
+	ApprovalDecisionCanceled = "canceled"
+
+	ApprovalSourceYolo                    = "yolo"
+	ApprovalSourceSessionPermissionsAllow = "session_permissions_allow"
+	ApprovalSourceSessionPermissionsDeny  = "session_permissions_deny"
+	ApprovalSourceTeamPermissionsAllow    = "team_permissions_allow"
+	ApprovalSourceTeamPermissionsDeny     = "team_permissions_deny"
+	ApprovalSourceReadOnlyHint            = "readonly_hint"
+	ApprovalSourceUserApproved            = "user_approved"
+	ApprovalSourceUserApprovedSession     = "user_approved_session"
+	ApprovalSourceUserApprovedTool        = "user_approved_tool"
+	ApprovalSourceUserRejected            = "user_rejected"
+	ApprovalSourceContextCanceled         = "context_canceled"
+)
+
+// executeOnToolApprovalDecisionHooks fires on_tool_approval_decision
+// after the runtime's approval chain has resolved a verdict for a
+// tool call. Fired once per call from each return path of
+// [executeWithApproval], so a single hook gets one record per tool
+// call regardless of which step decided.
+func (r *LocalRuntime) executeOnToolApprovalDecisionHooks(
+	ctx context.Context,
+	sess *session.Session,
+	a *agent.Agent,
+	toolCall tools.ToolCall,
+	decision, source string,
+) {
+	input := newHooksInput(sess, toolCall)
+	input.ApprovalDecision = decision
+	input.ApprovalSource = source
+	r.dispatchHook(ctx, a, hooks.EventOnToolApprovalDecision, input, nil)
 }
 
 // executeBeforeLLMCallHooks fires before_llm_call just before each

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -302,7 +302,9 @@ func (r *LocalRuntime) RunStream(ctx context.Context, sess *session.Session) <-c
 				case req := <-r.resumeChan:
 					if req.Type == ResumeTypeApprove {
 						slog.Debug("User chose to continue after max iterations", "agent", a.Name())
-						runtimeMaxIterations = iteration + 10
+						newMax := iteration + 10
+						r.executeOnSessionResumeHooks(ctx, a, sess.ID, runtimeMaxIterations, newMax)
+						runtimeMaxIterations = newMax
 					} else {
 						slog.Debug("User rejected continuation", "agent", a.Name())
 

--- a/pkg/runtime/on_agent_switch_test.go
+++ b/pkg/runtime/on_agent_switch_test.go
@@ -1,0 +1,118 @@
+package runtime
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/hooks"
+	"github.com/docker/docker-agent/pkg/team"
+)
+
+// recordingBuiltin captures the [hooks.Input] passed on every dispatch
+// so tests can assert exactly what the runtime forwards into the hook
+// protocol. Concurrency-safe because hook dispatch can run from
+// arbitrary goroutines.
+type recordingBuiltin struct {
+	mu     sync.Mutex
+	inputs []*hooks.Input
+}
+
+func (rb *recordingBuiltin) hook(_ context.Context, in *hooks.Input, _ []string) (*hooks.Output, error) {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+	if in != nil {
+		// Defensive copy: don't depend on whether the executor mutates
+		// the pointer after the call returns.
+		c := *in
+		rb.inputs = append(rb.inputs, &c)
+	}
+	return nil, nil
+}
+
+func (rb *recordingBuiltin) snapshot() []*hooks.Input {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+	out := make([]*hooks.Input, len(rb.inputs))
+	copy(out, rb.inputs)
+	return out
+}
+
+// runtimeWithRecordedAgentSwitch wires a recording builtin onto the
+// runtime's private hook registry, then registers an on_agent_switch
+// entry on the agent that points at it. This is the most direct way
+// to assert on dispatched input from a runtime test: the builtin
+// system already does the type validation we'd otherwise duplicate.
+func runtimeWithRecordedAgentSwitch(t *testing.T, agentName string, opts ...agent.Opt) (*LocalRuntime, *recordingBuiltin) {
+	t.Helper()
+
+	rb := &recordingBuiltin{}
+	prov := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
+	allOpts := append([]agent.Opt{
+		agent.WithModel(prov),
+		agent.WithHooks(&hooks.Config{
+			OnAgentSwitch: []hooks.Hook{{
+				Type:    hooks.HookTypeBuiltin,
+				Command: "test_record_agent_switch",
+			}},
+		}),
+	}, opts...)
+	a := agent.New(agentName, "instructions", allOpts...)
+	tm := team.New(team.WithAgents(a))
+
+	r, err := NewLocalRuntime(tm, WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+
+	// Register our recording builtin on the runtime's private registry
+	// after construction, then rebuild the per-agent executors so they
+	// pick up the new builtin. This is the smallest test seam that
+	// avoids exporting a WithHooksRegistry option on LocalRuntime.
+	require.NoError(t, r.hooksRegistry.RegisterBuiltin("test_record_agent_switch", rb.hook))
+	r.buildHooksExecutors()
+
+	return r, rb
+}
+
+// TestExecuteOnAgentSwitchHooks_ForwardsTransitionFields pins the
+// contract: the runtime puts the FromAgent / ToAgent / AgentSwitchKind
+// triple onto the hook input verbatim, plus the SessionID. This is the
+// data downstream audit pipelines rely on.
+func TestExecuteOnAgentSwitchHooks_ForwardsTransitionFields(t *testing.T) {
+	t.Parallel()
+
+	r, rb := runtimeWithRecordedAgentSwitch(t, "root")
+	a := r.CurrentAgent()
+	require.NotNil(t, a)
+
+	r.executeOnAgentSwitchHooks(t.Context(), a, "session-x", "root", "planner", agentSwitchKindTransferTask)
+
+	got := rb.snapshot()
+	require.Len(t, got, 1, "exactly one dispatch must have happened")
+	in := got[0]
+	assert.Equal(t, "session-x", in.SessionID)
+	assert.Equal(t, "root", in.FromAgent)
+	assert.Equal(t, "planner", in.ToAgent)
+	assert.Equal(t, agentSwitchKindTransferTask, in.AgentSwitchKind)
+}
+
+// TestExecuteOnAgentSwitchHooks_NoopWhenNoHookRegistered documents
+// the cheap-when-unused property: an agent without an on_agent_switch
+// hook produces no dispatch at all (the runtime short-circuits via
+// the executor lookup), so audit-free deployments pay nothing.
+func TestExecuteOnAgentSwitchHooks_NoopWhenNoHookRegistered(t *testing.T) {
+	t.Parallel()
+
+	prov := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
+	a := agent.New("root", "instructions", agent.WithModel(prov))
+	tm := team.New(team.WithAgents(a))
+
+	r, err := NewLocalRuntime(tm, WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+
+	// Should be a successful no-op rather than a panic or error.
+	r.executeOnAgentSwitchHooks(t.Context(), a, "s", "root", "next", agentSwitchKindHandoff)
+}

--- a/pkg/runtime/on_session_resume_test.go
+++ b/pkg/runtime/on_session_resume_test.go
@@ -1,0 +1,79 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/hooks"
+	"github.com/docker/docker-agent/pkg/team"
+)
+
+// runtimeWithRecordedSessionResume mirrors runtimeWithRecordedAgentSwitch
+// for the on_session_resume event. Same pattern: register a recording
+// builtin on the runtime's private registry post-construction so the
+// test can assert on dispatched input without exposing a runtime
+// option that production callers shouldn't reach for.
+func runtimeWithRecordedSessionResume(t *testing.T) (*LocalRuntime, *recordingBuiltin) {
+	t.Helper()
+
+	rb := &recordingBuiltin{}
+	prov := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
+	a := agent.New("root", "instructions",
+		agent.WithModel(prov),
+		agent.WithHooks(&hooks.Config{
+			OnSessionResume: []hooks.Hook{{
+				Type:    hooks.HookTypeBuiltin,
+				Command: "test_record_session_resume",
+			}},
+		}),
+	)
+	tm := team.New(team.WithAgents(a))
+
+	r, err := NewLocalRuntime(tm, WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+
+	require.NoError(t, r.hooksRegistry.RegisterBuiltin("test_record_session_resume", rb.hook))
+	r.buildHooksExecutors()
+
+	return r, rb
+}
+
+// TestExecuteOnSessionResumeHooks_ForwardsLimits pins the contract:
+// PreviousMaxIterations and NewMaxIterations both reach the hook
+// verbatim. Audit pipelines compute the granted-runtime delta from
+// these directly without rebuilding it from the iteration counter.
+func TestExecuteOnSessionResumeHooks_ForwardsLimits(t *testing.T) {
+	t.Parallel()
+
+	r, rb := runtimeWithRecordedSessionResume(t)
+	a := r.CurrentAgent()
+	require.NotNil(t, a)
+
+	r.executeOnSessionResumeHooks(t.Context(), a, "session-y", 5, 15)
+
+	got := rb.snapshot()
+	require.Len(t, got, 1)
+	in := got[0]
+	assert.Equal(t, "session-y", in.SessionID)
+	assert.Equal(t, 5, in.PreviousMaxIterations)
+	assert.Equal(t, 15, in.NewMaxIterations)
+}
+
+// TestExecuteOnSessionResumeHooks_NoopWhenNoHookRegistered keeps the
+// cheap-when-unused property symmetric with on_agent_switch: no
+// dispatch, no panic, no error when no hook is configured.
+func TestExecuteOnSessionResumeHooks_NoopWhenNoHookRegistered(t *testing.T) {
+	t.Parallel()
+
+	prov := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
+	a := agent.New("root", "instructions", agent.WithModel(prov))
+	tm := team.New(team.WithAgents(a))
+
+	r, err := NewLocalRuntime(tm, WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+
+	r.executeOnSessionResumeHooks(t.Context(), a, "s", 5, 15)
+}

--- a/pkg/runtime/on_tool_approval_decision_test.go
+++ b/pkg/runtime/on_tool_approval_decision_test.go
@@ -1,0 +1,92 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/hooks"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/team"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+// runtimeWithRecordedToolApproval mirrors the runtimeWithRecorded*
+// helpers for the on_tool_approval_decision event. Same pattern: a
+// recording builtin on the runtime's private registry so the test
+// can assert on the dispatched verdict + source without exposing a
+// production Opt that would tempt users to inject builtins ad hoc.
+func runtimeWithRecordedToolApproval(t *testing.T) (*LocalRuntime, *recordingBuiltin) {
+	t.Helper()
+
+	rb := &recordingBuiltin{}
+	prov := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
+	a := agent.New("root", "instructions",
+		agent.WithModel(prov),
+		agent.WithHooks(&hooks.Config{
+			OnToolApprovalDecision: []hooks.Hook{{
+				Type:    hooks.HookTypeBuiltin,
+				Command: "test_record_tool_approval",
+			}},
+		}),
+	)
+	tm := team.New(team.WithAgents(a))
+
+	r, err := NewLocalRuntime(tm, WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+
+	require.NoError(t, r.hooksRegistry.RegisterBuiltin("test_record_tool_approval", rb.hook))
+	r.buildHooksExecutors()
+
+	return r, rb
+}
+
+// TestExecuteOnToolApprovalDecisionHooks_ForwardsVerdictAndSource pins
+// the contract: the dispatched Input carries the verdict and source
+// classifier verbatim, plus the tool-call identifying fields the
+// existing PreToolUse / PostToolUse hooks already use. That gives
+// audit pipelines a uniform "tool call X resulted in verdict Y from
+// source Z" record across the whole approval chain.
+func TestExecuteOnToolApprovalDecisionHooks_ForwardsVerdictAndSource(t *testing.T) {
+	t.Parallel()
+
+	r, rb := runtimeWithRecordedToolApproval(t)
+	a := r.CurrentAgent()
+	require.NotNil(t, a)
+
+	sess := &session.Session{ID: "session-z"}
+	tc := tools.ToolCall{
+		ID: "call-1",
+		Function: tools.FunctionCall{
+			Name:      "read_file",
+			Arguments: `{"path":"/tmp/x"}`,
+		},
+	}
+	r.executeOnToolApprovalDecisionHooks(t.Context(), sess, a, tc, ApprovalDecisionAllow, ApprovalSourceReadOnlyHint)
+
+	got := rb.snapshot()
+	require.Len(t, got, 1)
+	in := got[0]
+	assert.Equal(t, "read_file", in.ToolName)
+	assert.Equal(t, "call-1", in.ToolUseID)
+	assert.Equal(t, ApprovalDecisionAllow, in.ApprovalDecision)
+	assert.Equal(t, ApprovalSourceReadOnlyHint, in.ApprovalSource)
+}
+
+// TestApprovalSourceMappersAreStable pins the stable classifier
+// strings used by [allowSourceFor] and [denySourceFor]. Tests that
+// the team-permissions vs session-permissions split (today: by
+// checker.source string match) survives changes to the inner labels.
+func TestApprovalSourceMappersAreStable(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, ApprovalSourceSessionPermissionsAllow, allowSourceFor("session permissions"))
+	assert.Equal(t, ApprovalSourceTeamPermissionsAllow, allowSourceFor("permissions configuration"))
+	assert.Equal(t, ApprovalSourceTeamPermissionsAllow, allowSourceFor("anything-else"),
+		"unknown source must default to team_permissions to avoid silent misclassification on future label changes")
+
+	assert.Equal(t, ApprovalSourceSessionPermissionsDeny, denySourceFor("session permissions"))
+	assert.Equal(t, ApprovalSourceTeamPermissionsDeny, denySourceFor("permissions configuration"))
+}

--- a/pkg/runtime/tool_dispatch.go
+++ b/pkg/runtime/tool_dispatch.go
@@ -162,6 +162,7 @@ func (r *LocalRuntime) executeWithApproval(
 
 	if sess.ToolsApproved {
 		slog.Debug("Tool auto-approved by --yolo flag", "tool", toolName, "session_id", sess.ID)
+		r.executeOnToolApprovalDecisionHooks(ctx, sess, a, toolCall, ApprovalDecisionAllow, ApprovalSourceYolo)
 		return invoke()
 	}
 
@@ -178,11 +179,13 @@ func (r *LocalRuntime) executeWithApproval(
 		switch pc.checker.CheckWithArgs(toolName, toolArgs) {
 		case permissions.Deny:
 			slog.Debug("Tool denied by permissions", "tool", toolName, "source", pc.source, "session_id", sess.ID)
+			r.executeOnToolApprovalDecisionHooks(ctx, sess, a, toolCall, ApprovalDecisionDeny, denySourceFor(pc.source))
 			r.addToolErrorResponse(ctx, sess, toolCall, tool, events, a,
 				fmt.Sprintf("Tool '%s' is denied by %s.", toolName, pc.source))
 			return toolApprovalOutcome{}
 		case permissions.Allow:
 			slog.Debug("Tool auto-approved by permissions", "tool", toolName, "source", pc.source, "session_id", sess.ID)
+			r.executeOnToolApprovalDecisionHooks(ctx, sess, a, toolCall, ApprovalDecisionAllow, allowSourceFor(pc.source))
 			return invoke()
 		case permissions.ForceAsk:
 			slog.Debug("Tool requires confirmation (ask pattern)", "tool", toolName, "source", pc.source, "session_id", sess.ID)
@@ -193,9 +196,28 @@ func (r *LocalRuntime) executeWithApproval(
 	}
 
 	if tool.Annotations.ReadOnlyHint {
+		r.executeOnToolApprovalDecisionHooks(ctx, sess, a, toolCall, ApprovalDecisionAllow, ApprovalSourceReadOnlyHint)
 		return invoke()
 	}
 	return r.askUserForConfirmation(ctx, sess, toolCall, tool, events, a, invoke)
+}
+
+// allowSourceFor maps a permission-checker source label to the
+// corresponding approval-decision source classifier. Centralised so
+// the strings stay aligned with [permissionChecker.source].
+func allowSourceFor(checkerSource string) string {
+	if checkerSource == "session permissions" {
+		return ApprovalSourceSessionPermissionsAllow
+	}
+	return ApprovalSourceTeamPermissionsAllow
+}
+
+// denySourceFor mirrors allowSourceFor for the deny path.
+func denySourceFor(checkerSource string) string {
+	if checkerSource == "session permissions" {
+		return ApprovalSourceSessionPermissionsDeny
+	}
+	return ApprovalSourceTeamPermissionsDeny
 }
 
 // permissionChecker pairs a checker with a human-readable source label.
@@ -249,10 +271,12 @@ func (r *LocalRuntime) askUserForConfirmation(
 		switch req.Type {
 		case ResumeTypeApprove:
 			slog.Debug("Resume signal received, approving tool", "tool", toolName, "session_id", sess.ID)
+			r.executeOnToolApprovalDecisionHooks(ctx, sess, a, toolCall, ApprovalDecisionAllow, ApprovalSourceUserApproved)
 			return invoke()
 		case ResumeTypeApproveSession:
 			slog.Debug("Resume signal received, approving session", "tool", toolName, "session_id", sess.ID)
 			sess.ToolsApproved = true
+			r.executeOnToolApprovalDecisionHooks(ctx, sess, a, toolCall, ApprovalDecisionAllow, ApprovalSourceUserApprovedSession)
 			return invoke()
 		case ResumeTypeApproveTool:
 			approvedTool := req.ToolName
@@ -266,9 +290,11 @@ func (r *LocalRuntime) askUserForConfirmation(
 				sess.Permissions.Allow = append(sess.Permissions.Allow, approvedTool)
 			}
 			slog.Debug("Resume signal received, approving tool permanently", "tool", approvedTool, "session_id", sess.ID)
+			r.executeOnToolApprovalDecisionHooks(ctx, sess, a, toolCall, ApprovalDecisionAllow, ApprovalSourceUserApprovedTool)
 			return invoke()
 		case ResumeTypeReject:
 			slog.Debug("Resume signal received, rejecting tool", "tool", toolName, "session_id", sess.ID, "reason", req.Reason)
+			r.executeOnToolApprovalDecisionHooks(ctx, sess, a, toolCall, ApprovalDecisionDeny, ApprovalSourceUserRejected)
 			rejectMsg := "The user rejected the tool call."
 			if strings.TrimSpace(req.Reason) != "" {
 				rejectMsg += " Reason: " + strings.TrimSpace(req.Reason)
@@ -278,6 +304,7 @@ func (r *LocalRuntime) askUserForConfirmation(
 		return toolApprovalOutcome{}
 	case <-ctx.Done():
 		slog.Debug("Context cancelled while waiting for resume", "tool", toolName, "session_id", sess.ID)
+		r.executeOnToolApprovalDecisionHooks(ctx, sess, a, toolCall, ApprovalDecisionCanceled, ApprovalSourceContextCanceled)
 		r.addToolErrorResponse(ctx, sess, toolCall, tool, events, a, "The tool call was canceled by the user.")
 		return toolApprovalOutcome{canceled: true}
 	}


### PR DESCRIPTION
Three small, additive observability events covering runtime transitions
that today are visible only via the per-session event channel. Each
gives audit / transcript / metrics / billing pipelines a structured,
typed entry point without forcing them to subscribe to the channel
and reconstruct state from the existing event stream.

| Event | Typed Input fields | What it unlocks |
|---|---|---|
| \`on_agent_switch\` | \`FromAgent\`, \`ToAgent\`, \`AgentSwitchKind\` | Track which agent ran which tools across \`transfer_task\`, \`transfer_task_return\`, and \`handoff\` without correlating \`AgentSwitching(start, ...)\` / \`AgentSwitching(end, ...)\` triples. |
| \`on_session_resume\` | \`PreviousMaxIterations\`, \`NewMaxIterations\` | Alert on extended-runtime sessions; bill / quota-track per user-approved continuation past \`max_iterations\` without parsing notification messages or watching the resume channel. |
| \`on_tool_approval_decision\` | \`ApprovalDecision\`, \`ApprovalSource\` | One structured \"who approved what\" record per tool call, covering all 11 outcomes of the approval chain (yolo / 4 permissions outcomes / readonly / 4 user-confirmation outcomes / context-canceled). Replaces the audit code that today correlates \`ToolCall\` + \`ToolCallConfirmation\` + \`ToolCallResponse\` + \`HookBlocked\`. |

## Mechanics (per commit)

Each commit follows the now-established one-event template and is
deliberately minimal:

- one constant in \`pkg/hooks/types.go\`
- one entry in \`compileEvents\`
- one field (with \`validate\` + \`IsEmpty\`) in \`latest.HooksConfig\`
- one entry in \`agent-schema.json\`
- one \`executeOnXxxHooks\` wrapper in \`pkg/runtime/hooks.go\` using the
  existing \`dispatchHook\` helper
- typed Input fields for the event-specific data (no
  \`notification_message\` string-parsing)
- call sites wired alongside the corresponding existing
  event-channel emissions, so consumers that already listen to
  \`AgentSwitching\` / \`MaxIterationsReached\` / \`ToolCallConfirmation\` +
  \`HookBlocked\` see no behaviour change

For \`on_tool_approval_decision\`, the source classifier is fired at
every return path of \`executeWithApproval\` and \`askUserForConfirmation\`
so a single hook gets exactly one record per tool call regardless of
which step decided. Stable string constants live on the runtime side
(\`ApprovalSource*\`, \`ApprovalDecision*\`, \`agentSwitchKind*\`) so the
contract between the runtime and the hook protocol is discoverable
and a typo trips a compile error.

## Tests

A \`recordingBuiltin\` helper (introduced in the first commit, reused
by the next two) registers itself on the runtime's private
\`hooksRegistry\` post-construction. The pattern (\`runtimeWithRecorded*\`)
keeps the assertions close to a real call path without exposing a
\`WithHooksRegistry\` option that production callers would reach for.
Each event has its own \`pkg/runtime/on_*_test.go\` covering:

- the dispatched Input fields (verdict / source / from / to / kind /
  iteration limits all forwarded verbatim)
- the cheap-when-unused property (no panic / no error when no hook is
  configured, since the executor lookup short-circuits)
- for \`on_tool_approval_decision\`: the \`allowSourceFor\` /
  \`denySourceFor\` mapping is pinned, including the
  unknown-label-defaults-to-team-permissions safety behaviour.

\`mise test\` and \`mise lint\` are both clean.

## Commits

- \`feat(hooks): add on_agent_switch event\`
- \`feat(hooks): add on_session_resume event\`
- \`feat(hooks): add on_tool_approval_decision event\`