### PR TITLE
refactor(runtime): extract tool execution into pkg/runtime/toolexec

### DIFF
--- a/pkg/runtime/hooks.go
+++ b/pkg/runtime/hooks.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/hooks"
 	"github.com/docker/docker-agent/pkg/hooks/builtins"
+	"github.com/docker/docker-agent/pkg/runtime/toolexec"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/tools"
 )
@@ -258,7 +259,7 @@ func (r *LocalRuntime) executeOnToolApprovalDecisionHooks(
 	toolCall tools.ToolCall,
 	decision, source string,
 ) {
-	input := newHooksInput(sess, toolCall)
+	input := toolexec.NewHooksInput(sess, toolCall)
 	input.ApprovalDecision = decision
 	input.ApprovalSource = source
 	r.dispatchHook(ctx, a, hooks.EventOnToolApprovalDecision, input, nil)

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/compaction"
 	"github.com/docker/docker-agent/pkg/modelsdev"
+	"github.com/docker/docker-agent/pkg/runtime/toolexec"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/tools"
 	"github.com/docker/docker-agent/pkg/tools/builtin"
@@ -225,7 +226,7 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 	if loopThreshold == 0 {
 		loopThreshold = 5 // default: always active
 	}
-	loopDetector := newToolLoopDetector(loopThreshold,
+	loopDetector := toolexec.NewLoopDetector(loopThreshold,
 		bgagent.ToolNameViewBackgroundAgent,
 		builtin.ToolNameViewBackgroundJob,
 	)
@@ -318,7 +319,6 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 		if err != nil {
 			slog.Debug("Failed to get model definition", "error", err)
 		}
-
 		// We can only compact if we know the limit.
 		var contextLimit int64
 		if m != nil {
@@ -423,21 +423,22 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 		}
 
 		// Check for degenerate tool call loops
-		if loopDetector.record(res.Calls) {
+		if loopDetector.Record(res.Calls) {
 			toolName := "unknown"
 			if len(res.Calls) > 0 {
 				toolName = res.Calls[0].Function.Name
 			}
+			consecutive := loopDetector.Consecutive()
 			slog.Warn("Repetitive tool call loop detected",
 				"agent", a.Name(), "tool", toolName,
-				"consecutive", loopDetector.consecutive, "session_id", sess.ID)
+				"consecutive", consecutive, "session_id", sess.ID)
 			errMsg := fmt.Sprintf(
 				"Agent terminated: detected %d consecutive identical calls to %s. "+
 					"This indicates a degenerate loop where the model is not making progress.",
-				loopDetector.consecutive, toolName)
+				consecutive, toolName)
 			events <- Error(errMsg)
 			r.notifyError(ctx, a, sess.ID, errMsg)
-			loopDetector.reset()
+			loopDetector.Reset()
 			return
 		}
 
@@ -454,7 +455,7 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 		}
 
 		// Record per-toolset model override for the next LLM turn.
-		toolModelOverride = resolveToolCallModelOverride(res.Calls, agentTools)
+		toolModelOverride = toolexec.ResolveModelOverride(res.Calls, agentTools)
 
 		// Drain steer messages that arrived during tool calls.
 		if drained, _ := r.drainAndEmitSteered(ctx, sess, events); drained {

--- a/pkg/runtime/resume.go
+++ b/pkg/runtime/resume.go
@@ -1,32 +1,36 @@
 package runtime
 
+import "github.com/docker/docker-agent/pkg/runtime/toolexec"
+
 // ResumeType identifies the user's response to a confirmation request.
 //
 // The runtime emits a TOOL_PERMISSION_REQUEST event whenever a tool call
 // requires user approval, then blocks until the embedder calls Resume(...)
 // with one of the values below.
-type ResumeType string
+//
+// ResumeType, ResumeRequest, and the ResumeType* constants are aliased
+// from [toolexec] so the dispatcher and the runtime share one definition
+// without circular imports.
+type ResumeType = toolexec.ResumeType
 
 const (
 	// ResumeTypeApprove approves the single pending tool call.
-	ResumeTypeApprove ResumeType = "approve"
+	ResumeTypeApprove = toolexec.ResumeTypeApprove
 	// ResumeTypeApproveSession approves the pending tool call and every
 	// subsequent permission-gated call for the rest of the session.
-	ResumeTypeApproveSession ResumeType = "approve-session"
+	ResumeTypeApproveSession = toolexec.ResumeTypeApproveSession
 	// ResumeTypeApproveTool approves the pending call and every future
 	// call to the same tool name within the session.
-	ResumeTypeApproveTool ResumeType = "approve-tool"
+	ResumeTypeApproveTool = toolexec.ResumeTypeApproveTool
 	// ResumeTypeReject rejects the pending tool call.
-	ResumeTypeReject ResumeType = "reject"
+	ResumeTypeReject = toolexec.ResumeTypeReject
 )
 
 // ResumeRequest carries the user's confirmation decision along with an optional
 // reason (used when rejecting a tool call to help the model understand why).
-type ResumeRequest struct {
-	Type     ResumeType
-	Reason   string // Optional; primarily used with ResumeTypeReject
-	ToolName string // Optional; used with ResumeTypeApproveTool to specify which tool to always allow
-}
+// The struct fields live in [toolexec.ResumeRequest]; this alias is kept
+// for readers who land here from the runtime API.
+type ResumeRequest = toolexec.ResumeRequest
 
 // ResumeApprove creates a ResumeRequest to approve a single tool call.
 func ResumeApprove() ResumeRequest {

--- a/pkg/runtime/tool_dispatch.go
+++ b/pkg/runtime/tool_dispatch.go
@@ -13,14 +13,15 @@ import (
 	"github.com/docker/docker-agent/pkg/tools"
 )
 
-// processToolCalls builds a [toolexec.Dispatcher] for the current event
-// channel and delegates the per-call orchestration to it. The dispatcher
-// owns the approval flow, hook dispatch, tracing, telemetry, and event
-// emission; this method only assembles the runtime-side adapters.
+// processToolCalls builds a per-stream [toolexec.Dispatcher] and delegates
+// the per-call orchestration to it. The dispatcher owns the approval flow,
+// hook dispatch, tracing, telemetry, and event emission; this file only
+// supplies the runtime-side adapters that bridge them to the runtime's
+// chan Event.
 //
-// A new dispatcher is constructed per call (cheap: a struct literal plus
-// a small handler-binding map) so its handlers and emitter capture the
-// current RunStream's events channel.
+// The dispatcher is constructed per call (cheap: a struct literal plus a
+// small handler-binding map) so its handlers and emitter capture this
+// RunStream's events channel.
 //
 // Returns (stopRun, message) when a post_tool_use hook signalled a
 // terminating verdict during this batch; the run loop then fans out the
@@ -29,33 +30,29 @@ import (
 // halts the *batch* but keeps the loop alive so the synthesised tool
 // error responses can be sent back to the model on the next turn.
 func (r *LocalRuntime) processToolCalls(ctx context.Context, sess *session.Session, calls []tools.ToolCall, agentTools []tools.Tool, events chan Event) (stopRun bool, stopMessage string) {
-	d := &toolexec.Dispatcher{
-		Tracer:      r.tracer,
-		Hooks:       newHookDispatcher(r, events),
-		Resume:      r.resumeChan,
-		AgentFor:    r.resolveSessionAgent,
-		Permissions: r.permissionCheckers,
-		Handlers:    r.bindRuntimeHandlers(events),
-	}
-	return d.Process(ctx, sess, calls, agentTools, &chanEmitter{events: events})
-}
-
-// bindRuntimeHandlers wraps every entry in [r.toolMap] (which receives
-// chan Event) into a [toolexec.ToolHandler] (which doesn't), capturing
-// the current events channel via closure. Doing this once per dispatch
-// keeps the toolexec interface clean of runtime-specific event types.
-func (r *LocalRuntime) bindRuntimeHandlers(events chan Event) map[string]toolexec.ToolHandler {
+	// Bind runtime-managed handlers (transfer_task, handoff, change_model, ...)
+	// to the current events channel: r.toolMap entries take chan Event,
+	// toolexec.ToolHandler doesn't.
 	handlers := make(map[string]toolexec.ToolHandler, len(r.toolMap))
 	for name, h := range r.toolMap {
 		handlers[name] = func(ctx context.Context, sess *session.Session, tc tools.ToolCall) (*tools.ToolCallResult, error) {
 			return h(ctx, sess, tc, events)
 		}
 	}
-	return handlers
+
+	d := &toolexec.Dispatcher{
+		Tracer:      r.tracer,
+		Hooks:       &hookDispatcher{r: r, events: events},
+		Resume:      r.resumeChan,
+		AgentFor:    r.resolveSessionAgent,
+		Permissions: r.permissionCheckers,
+		Handlers:    handlers,
+	}
+	return d.Process(ctx, sess, calls, agentTools, &chanEmitter{events: events})
 }
 
-// permissionCheckers returns the ordered list of permission checkers to evaluate
-// (session-level first, then team-level).
+// permissionCheckers returns the ordered list of permission checkers to
+// evaluate (session-level first, then team-level).
 func (r *LocalRuntime) permissionCheckers(sess *session.Session) []toolexec.NamedChecker {
 	var checkers []toolexec.NamedChecker
 	if sess.Permissions != nil {
@@ -77,10 +74,10 @@ func (r *LocalRuntime) permissionCheckers(sess *session.Session) []toolexec.Name
 	return checkers
 }
 
-// chanEmitter adapts a chan Event into a [toolexec.Emitter]. It is the
+// chanEmitter adapts a chan Event into a [toolexec.Emitter]. It's the
 // only place where the dispatcher's typed event surface meets the
-// runtime's event channel; new dispatcher events should grow this type
-// in lockstep with the [toolexec.Emitter] interface.
+// runtime's event channel; new dispatcher events grow this type in
+// lockstep with the [toolexec.Emitter] interface.
 type chanEmitter struct {
 	events chan Event
 }
@@ -107,15 +104,11 @@ func (e *chanEmitter) EmitMessageAdded(sessionID string, msg *session.Message, a
 
 // hookDispatcher adapts the runtime's per-agent [hooks.Executor] machinery
 // into the small [toolexec.HookDispatcher] interface. The events channel
-// is captured here so [LocalRuntime.dispatchHook] can surface
-// SystemMessage as a Warning event during dispatch.
+// is captured here so [LocalRuntime.dispatchHook] can surface SystemMessage
+// as a Warning event during dispatch.
 type hookDispatcher struct {
 	r      *LocalRuntime
 	events chan Event
-}
-
-func newHookDispatcher(r *LocalRuntime, events chan Event) toolexec.HookDispatcher {
-	return &hookDispatcher{r: r, events: events}
 }
 
 func (h *hookDispatcher) Dispatch(ctx context.Context, a *agent.Agent, event hooks.EventType, in *hooks.Input) *hooks.Result {
@@ -149,7 +142,7 @@ func denySourceFor(checkerSource string) string {
 	return ApprovalSourceTeamPermissionsDeny
 }
 
-// addAgentMessage records a chat message to the session and emits the
+// addAgentMessage records a chat message in the session and emits the
 // resulting MessageAdded event. Used by the loop for assistant messages
 // and max-iteration stop messages. The dispatcher emits its own variant
 // directly via the [toolexec.Emitter] interface.

--- a/pkg/runtime/tool_dispatch.go
+++ b/pkg/runtime/tool_dispatch.go
@@ -139,13 +139,11 @@ func (r *LocalRuntime) toolInvoker(
 }
 
 // executeWithApproval handles the approval flow and runs the tool when
-// approved. The approval flow considers (in order):
+// approved.
 //
-//  1. sess.ToolsApproved (--yolo flag) — auto-approve everything.
-//  2. Session-level permissions (if configured) — Allow/Ask/Deny rules.
-//  3. Team-level permissions config.
-//  4. Read-only hint — auto-approve.
-//  5. Default: ask the user for confirmation.
+// The approval flow is fully resolved by [toolexec.Decide]; this function
+// only translates the resulting decision into the runtime side effects
+// (run, deny-with-error-response, ask-and-wait).
 //
 // The returned [toolApprovalOutcome] captures user cancellation and
 // any post_tool_use stopRun verdict propagated from invoke.
@@ -160,51 +158,64 @@ func (r *LocalRuntime) executeWithApproval(
 ) toolApprovalOutcome {
 	toolName := toolCall.Function.Name
 
-	if sess.ToolsApproved {
-		slog.Debug("Tool auto-approved by --yolo flag", "tool", toolName, "session_id", sess.ID)
-		r.executeOnToolApprovalDecisionHooks(ctx, sess, a, toolCall, ApprovalDecisionAllow, ApprovalSourceYolo)
+	decision := toolexec.Decide(
+		sess.ToolsApproved,
+		r.permissionCheckers(sess),
+		toolName,
+		toolexec.ParseToolInput(toolCall.Function.Arguments),
+		tool.Annotations.ReadOnlyHint,
+	)
+
+	switch decision.Outcome {
+	case toolexec.OutcomeAllow:
+		logAllow(decision, toolName, sess.ID)
+		r.executeOnToolApprovalDecisionHooks(ctx, sess, a, toolCall, ApprovalDecisionAllow, allowSourceForDecision(decision))
 		return invoke()
-	}
-
-	// Parse tool arguments once for permission matching.
-	var toolArgs map[string]any
-	if toolCall.Function.Arguments != "" {
-		if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &toolArgs); err != nil {
-			slog.Debug("Failed to parse tool arguments for permission check", "tool", toolName, "error", err)
-			// Fall through with nil args — only tool name patterns can match.
+	case toolexec.OutcomeDeny:
+		slog.Debug("Tool denied by permissions", "tool", toolName, "source", decision.Source, "session_id", sess.ID)
+		r.executeOnToolApprovalDecisionHooks(ctx, sess, a, toolCall, ApprovalDecisionDeny, denySourceFor(decision.Source))
+		r.addToolErrorResponse(ctx, sess, toolCall, tool, events, a,
+			fmt.Sprintf("Tool '%s' is denied by %s.", toolName, decision.Source))
+		return toolApprovalOutcome{}
+	case toolexec.OutcomeAsk:
+		if decision.Reason == toolexec.ReasonChecker {
+			slog.Debug("Tool requires confirmation (ask pattern)", "tool", toolName, "source", decision.Source, "session_id", sess.ID)
 		}
+		return r.askUserForConfirmation(ctx, sess, toolCall, tool, events, a, invoke)
 	}
+	return toolApprovalOutcome{}
+}
 
-	for _, pc := range r.permissionCheckers(sess) {
-		switch pc.checker.CheckWithArgs(toolName, toolArgs) {
-		case permissions.Deny:
-			slog.Debug("Tool denied by permissions", "tool", toolName, "source", pc.source, "session_id", sess.ID)
-			r.executeOnToolApprovalDecisionHooks(ctx, sess, a, toolCall, ApprovalDecisionDeny, denySourceFor(pc.source))
-			r.addToolErrorResponse(ctx, sess, toolCall, tool, events, a,
-				fmt.Sprintf("Tool '%s' is denied by %s.", toolName, pc.source))
-			return toolApprovalOutcome{}
-		case permissions.Allow:
-			slog.Debug("Tool auto-approved by permissions", "tool", toolName, "source", pc.source, "session_id", sess.ID)
-			r.executeOnToolApprovalDecisionHooks(ctx, sess, a, toolCall, ApprovalDecisionAllow, allowSourceFor(pc.source))
-			return invoke()
-		case permissions.ForceAsk:
-			slog.Debug("Tool requires confirmation (ask pattern)", "tool", toolName, "source", pc.source, "session_id", sess.ID)
-			return r.askUserForConfirmation(ctx, sess, toolCall, tool, events, a, invoke)
-		case permissions.Ask:
-			// No explicit match at this level; fall through.
-		}
+// logAllow emits the auto-approval debug log appropriate to the reason
+// (--yolo, an explicit checker rule, or the read-only hint).
+func logAllow(d toolexec.PermissionDecision, toolName, sessionID string) {
+	switch d.Reason {
+	case toolexec.ReasonYolo:
+		slog.Debug("Tool auto-approved by --yolo flag", "tool", toolName, "session_id", sessionID)
+	case toolexec.ReasonChecker:
+		slog.Debug("Tool auto-approved by permissions", "tool", toolName, "source", d.Source, "session_id", sessionID)
+		// ReasonReadOnlyHint is intentionally silent (matches prior behaviour).
 	}
+}
 
-	if tool.Annotations.ReadOnlyHint {
-		r.executeOnToolApprovalDecisionHooks(ctx, sess, a, toolCall, ApprovalDecisionAllow, ApprovalSourceReadOnlyHint)
-		return invoke()
+// allowSourceForDecision maps a [toolexec.PermissionDecision] with
+// [toolexec.OutcomeAllow] onto the corresponding ApprovalSource* string
+// emitted by [executeOnToolApprovalDecisionHooks].
+func allowSourceForDecision(d toolexec.PermissionDecision) string {
+	switch d.Reason {
+	case toolexec.ReasonYolo:
+		return ApprovalSourceYolo
+	case toolexec.ReasonReadOnlyHint:
+		return ApprovalSourceReadOnlyHint
+	case toolexec.ReasonChecker:
+		return allowSourceFor(d.Source)
 	}
-	return r.askUserForConfirmation(ctx, sess, toolCall, tool, events, a, invoke)
+	return allowSourceFor(d.Source)
 }
 
 // allowSourceFor maps a permission-checker source label to the
 // corresponding approval-decision source classifier. Centralised so
-// the strings stay aligned with [permissionChecker.source].
+// the strings stay aligned with [toolexec.NamedChecker.Source].
 func allowSourceFor(checkerSource string) string {
 	if checkerSource == "session permissions" {
 		return ApprovalSourceSessionPermissionsAllow
@@ -220,29 +231,24 @@ func denySourceFor(checkerSource string) string {
 	return ApprovalSourceTeamPermissionsDeny
 }
 
-// permissionChecker pairs a checker with a human-readable source label.
-type permissionChecker struct {
-	checker *permissions.Checker
-	source  string
-}
-
-// permissionCheckers returns the ordered list of permission checkers to evaluate.
-func (r *LocalRuntime) permissionCheckers(sess *session.Session) []permissionChecker {
-	var checkers []permissionChecker
+// permissionCheckers returns the ordered list of permission checkers to evaluate
+// (session-level first, then team-level).
+func (r *LocalRuntime) permissionCheckers(sess *session.Session) []toolexec.NamedChecker {
+	var checkers []toolexec.NamedChecker
 	if sess.Permissions != nil {
-		checkers = append(checkers, permissionChecker{
-			checker: permissions.NewChecker(&latest.PermissionsConfig{
+		checkers = append(checkers, toolexec.NamedChecker{
+			Checker: permissions.NewChecker(&latest.PermissionsConfig{
 				Allow: sess.Permissions.Allow,
 				Ask:   sess.Permissions.Ask,
 				Deny:  sess.Permissions.Deny,
 			}),
-			source: "session permissions",
+			Source: "session permissions",
 		})
 	}
 	if tc := r.team.Permissions(); tc != nil {
-		checkers = append(checkers, permissionChecker{
-			checker: tc,
-			source:  "permissions configuration",
+		checkers = append(checkers, toolexec.NamedChecker{
+			Checker: tc,
+			Source:  "permissions configuration",
 		})
 	}
 	return checkers

--- a/pkg/runtime/tool_dispatch.go
+++ b/pkg/runtime/tool_dispatch.go
@@ -2,17 +2,6 @@ package runtime
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"log/slog"
-	"slices"
-	"strings"
-	"time"
-
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/trace"
 
 	"github.com/docker/docker-agent/pkg/agent"
 	"github.com/docker/docker-agent/pkg/chat"
@@ -24,211 +13,45 @@ import (
 	"github.com/docker/docker-agent/pkg/tools"
 )
 
-// processToolCalls executes a batch of tool calls for an agent.
+// processToolCalls builds a [toolexec.Dispatcher] for the current event
+// channel and delegates the per-call orchestration to it. The dispatcher
+// owns the approval flow, hook dispatch, tracing, telemetry, and event
+// emission; this method only assembles the runtime-side adapters.
+//
+// A new dispatcher is constructed per call (cheap: a struct literal plus
+// a small handler-binding map) so its handlers and emitter capture the
+// current RunStream's events channel.
 //
 // Returns (stopRun, message) when a post_tool_use hook signalled a
-// terminating verdict during this batch; the run loop then fans out
-// the standard Error / notification / on_error stanzas before exiting.
-// (false, "") in every other path — including user cancellation,
-// which halts the *batch* but keeps the loop alive so the synthesised
-// tool error responses can be sent back to the model on the next turn.
+// terminating verdict during this batch; the run loop then fans out the
+// standard Error / notification / on_error stanzas before exiting.
+// (false, "") in every other path — including user cancellation, which
+// halts the *batch* but keeps the loop alive so the synthesised tool
+// error responses can be sent back to the model on the next turn.
 func (r *LocalRuntime) processToolCalls(ctx context.Context, sess *session.Session, calls []tools.ToolCall, agentTools []tools.Tool, events chan Event) (stopRun bool, stopMessage string) {
-	a := r.resolveSessionAgent(sess)
-	slog.Debug("Processing tool calls", "agent", a.Name(), "call_count", len(calls))
-
-	agentToolMap := make(map[string]tools.Tool, len(agentTools))
-	for _, t := range agentTools {
-		agentToolMap[t.Name] = t
+	d := &toolexec.Dispatcher{
+		Tracer:      r.tracer,
+		Hooks:       newHookDispatcher(r, events),
+		Resume:      r.resumeChan,
+		AgentFor:    r.resolveSessionAgent,
+		Permissions: r.permissionCheckers,
+		Handlers:    r.bindRuntimeHandlers(events),
 	}
+	return d.Process(ctx, sess, calls, agentTools, &chanEmitter{events: events})
+}
 
-	// synthesizeRemaining adds error responses for tool calls we won't
-	// run because the batch was halted (user cancellation or post-tool
-	// stopRun). Orphan function calls without matching outputs are
-	// rejected by the Responses API, so we surface them as errors
-	// rather than dropping them.
-	synthesizeRemaining := func(remaining []tools.ToolCall, reason string) {
-		for _, tc := range remaining {
-			r.addToolErrorResponse(ctx, sess, tc, agentToolMap[tc.Function.Name], events, a, reason)
+// bindRuntimeHandlers wraps every entry in [r.toolMap] (which receives
+// chan Event) into a [toolexec.ToolHandler] (which doesn't), capturing
+// the current events channel via closure. Doing this once per dispatch
+// keeps the toolexec interface clean of runtime-specific event types.
+func (r *LocalRuntime) bindRuntimeHandlers(events chan Event) map[string]toolexec.ToolHandler {
+	handlers := make(map[string]toolexec.ToolHandler, len(r.toolMap))
+	for name, h := range r.toolMap {
+		handlers[name] = func(ctx context.Context, sess *session.Session, tc tools.ToolCall) (*tools.ToolCallResult, error) {
+			return h(ctx, sess, tc, events)
 		}
 	}
-
-	for i, toolCall := range calls {
-		callCtx, callSpan := r.startSpan(ctx, "runtime.tool.call", trace.WithAttributes(
-			attribute.String("tool.name", toolCall.Function.Name),
-			attribute.String("tool.type", string(toolCall.Type)),
-			attribute.String("agent", a.Name()),
-			attribute.String("session.id", sess.ID),
-			attribute.String("tool.call_id", toolCall.ID),
-		))
-
-		slog.Debug("Processing tool call", "agent", a.Name(), "tool", toolCall.Function.Name, "session_id", sess.ID)
-
-		// Tools the model invokes must be in the agent's tool set. After
-		// a handoff the model may hallucinate tools it saw in history
-		// from a previous agent; surfacing an error response lets it
-		// self-correct.
-		tool, available := agentToolMap[toolCall.Function.Name]
-		if !available {
-			slog.Warn("Tool call for unavailable tool", "agent", a.Name(), "tool", toolCall.Function.Name, "session_id", sess.ID)
-			r.addToolErrorResponse(ctx, sess, toolCall, tools.Tool{Name: toolCall.Function.Name}, events, a,
-				fmt.Sprintf("Tool '%s' is not available. You can only use the tools provided to you.", toolCall.Function.Name))
-			callSpan.SetStatus(codes.Error, "tool not available")
-			callSpan.End()
-			continue
-		}
-
-		// Build the tool invoker. Runtime-managed tools (transfer_task,
-		// handoff, ...) skip pre/post hooks; user tools go through the
-		// hook-aware path and may produce a stopRun outcome.
-		invoke := r.toolInvoker(callCtx, sess, toolCall, tool, events, a)
-
-		outcome := r.executeWithApproval(callCtx, sess, toolCall, tool, events, a, invoke)
-
-		if outcome.canceled {
-			callSpan.SetStatus(codes.Ok, "tool call canceled by user")
-		} else {
-			callSpan.SetStatus(codes.Ok, "tool call processed")
-		}
-		callSpan.End()
-
-		switch {
-		case outcome.canceled:
-			synthesizeRemaining(calls[i+1:],
-				"The tool call was canceled because a previous tool call in the same batch was canceled by the user.")
-			return false, ""
-		case outcome.stopRun:
-			synthesizeRemaining(calls[i+1:],
-				"The tool call was skipped because a post_tool_use hook signalled run termination.")
-			return true, outcome.stopMessage
-		}
-	}
-	return false, ""
-}
-
-// toolApprovalOutcome carries the verdicts of [LocalRuntime.executeWithApproval].
-// canceled and stopRun are mutually exclusive in practice but the loop
-// treats them differently: cancellation halts the current batch silently;
-// stopRun also terminates the agent's run loop with a user-visible reason.
-type toolApprovalOutcome struct {
-	canceled    bool
-	stopRun     bool
-	stopMessage string
-}
-
-// toolInvoker returns a closure that runs the tool when approved.
-// Runtime-managed tools (those registered in r.toolMap) skip pre/post
-// hooks; everything else goes through [LocalRuntime.runTool] and may
-// yield a stopRun outcome from a post_tool_use hook.
-func (r *LocalRuntime) toolInvoker(
-	ctx context.Context,
-	sess *session.Session,
-	toolCall tools.ToolCall,
-	tool tools.Tool,
-	events chan Event,
-	a *agent.Agent,
-) func() toolApprovalOutcome {
-	if handler, ok := r.toolMap[toolCall.Function.Name]; ok {
-		return func() toolApprovalOutcome {
-			r.runAgentTool(ctx, handler, sess, toolCall, tool, events, a)
-			return toolApprovalOutcome{}
-		}
-	}
-	return func() toolApprovalOutcome {
-		return r.runTool(ctx, tool, toolCall, events, sess, a)
-	}
-}
-
-// executeWithApproval handles the approval flow and runs the tool when
-// approved.
-//
-// The approval flow is fully resolved by [toolexec.Decide]; this function
-// only translates the resulting decision into the runtime side effects
-// (run, deny-with-error-response, ask-and-wait).
-//
-// The returned [toolApprovalOutcome] captures user cancellation and
-// any post_tool_use stopRun verdict propagated from invoke.
-func (r *LocalRuntime) executeWithApproval(
-	ctx context.Context,
-	sess *session.Session,
-	toolCall tools.ToolCall,
-	tool tools.Tool,
-	events chan Event,
-	a *agent.Agent,
-	invoke func() toolApprovalOutcome,
-) toolApprovalOutcome {
-	toolName := toolCall.Function.Name
-
-	decision := toolexec.Decide(
-		sess.ToolsApproved,
-		r.permissionCheckers(sess),
-		toolName,
-		toolexec.ParseToolInput(toolCall.Function.Arguments),
-		tool.Annotations.ReadOnlyHint,
-	)
-
-	switch decision.Outcome {
-	case toolexec.OutcomeAllow:
-		logAllow(decision, toolName, sess.ID)
-		r.executeOnToolApprovalDecisionHooks(ctx, sess, a, toolCall, ApprovalDecisionAllow, allowSourceForDecision(decision))
-		return invoke()
-	case toolexec.OutcomeDeny:
-		slog.Debug("Tool denied by permissions", "tool", toolName, "source", decision.Source, "session_id", sess.ID)
-		r.executeOnToolApprovalDecisionHooks(ctx, sess, a, toolCall, ApprovalDecisionDeny, denySourceFor(decision.Source))
-		r.addToolErrorResponse(ctx, sess, toolCall, tool, events, a,
-			fmt.Sprintf("Tool '%s' is denied by %s.", toolName, decision.Source))
-		return toolApprovalOutcome{}
-	case toolexec.OutcomeAsk:
-		if decision.Reason == toolexec.ReasonChecker {
-			slog.Debug("Tool requires confirmation (ask pattern)", "tool", toolName, "source", decision.Source, "session_id", sess.ID)
-		}
-		return r.askUserForConfirmation(ctx, sess, toolCall, tool, events, a, invoke)
-	}
-	return toolApprovalOutcome{}
-}
-
-// logAllow emits the auto-approval debug log appropriate to the reason
-// (--yolo, an explicit checker rule, or the read-only hint).
-func logAllow(d toolexec.PermissionDecision, toolName, sessionID string) {
-	switch d.Reason {
-	case toolexec.ReasonYolo:
-		slog.Debug("Tool auto-approved by --yolo flag", "tool", toolName, "session_id", sessionID)
-	case toolexec.ReasonChecker:
-		slog.Debug("Tool auto-approved by permissions", "tool", toolName, "source", d.Source, "session_id", sessionID)
-		// ReasonReadOnlyHint is intentionally silent (matches prior behaviour).
-	}
-}
-
-// allowSourceForDecision maps a [toolexec.PermissionDecision] with
-// [toolexec.OutcomeAllow] onto the corresponding ApprovalSource* string
-// emitted by [executeOnToolApprovalDecisionHooks].
-func allowSourceForDecision(d toolexec.PermissionDecision) string {
-	switch d.Reason {
-	case toolexec.ReasonYolo:
-		return ApprovalSourceYolo
-	case toolexec.ReasonReadOnlyHint:
-		return ApprovalSourceReadOnlyHint
-	case toolexec.ReasonChecker:
-		return allowSourceFor(d.Source)
-	}
-	return allowSourceFor(d.Source)
-}
-
-// allowSourceFor maps a permission-checker source label to the
-// corresponding approval-decision source classifier. Centralised so
-// the strings stay aligned with [toolexec.NamedChecker.Source].
-func allowSourceFor(checkerSource string) string {
-	if checkerSource == "session permissions" {
-		return ApprovalSourceSessionPermissionsAllow
-	}
-	return ApprovalSourceTeamPermissionsAllow
-}
-
-// denySourceFor mirrors allowSourceFor for the deny path.
-func denySourceFor(checkerSource string) string {
-	if checkerSource == "session permissions" {
-		return ApprovalSourceSessionPermissionsDeny
-	}
-	return ApprovalSourceTeamPermissionsDeny
+	return handlers
 }
 
 // permissionCheckers returns the ordered list of permission checkers to evaluate
@@ -254,251 +77,84 @@ func (r *LocalRuntime) permissionCheckers(sess *session.Session) []toolexec.Name
 	return checkers
 }
 
-// askUserForConfirmation sends a confirmation event and waits for the
-// user's response. Only called when --yolo is not active and no
-// permission rule auto-approved the tool.
-func (r *LocalRuntime) askUserForConfirmation(
-	ctx context.Context,
-	sess *session.Session,
-	toolCall tools.ToolCall,
-	tool tools.Tool,
-	events chan Event,
-	a *agent.Agent,
-	invoke func() toolApprovalOutcome,
-) toolApprovalOutcome {
-	toolName := toolCall.Function.Name
-	slog.Debug("Tools not approved, waiting for resume", "tool", toolName, "session_id", sess.ID)
-	events <- ToolCallConfirmation(toolCall, tool, a.Name())
-
-	r.executeOnUserInputHooks(ctx, sess.ID, "tool confirmation")
-
-	select {
-	case req := <-r.resumeChan:
-		switch req.Type {
-		case ResumeTypeApprove:
-			slog.Debug("Resume signal received, approving tool", "tool", toolName, "session_id", sess.ID)
-			r.executeOnToolApprovalDecisionHooks(ctx, sess, a, toolCall, ApprovalDecisionAllow, ApprovalSourceUserApproved)
-			return invoke()
-		case ResumeTypeApproveSession:
-			slog.Debug("Resume signal received, approving session", "tool", toolName, "session_id", sess.ID)
-			sess.ToolsApproved = true
-			r.executeOnToolApprovalDecisionHooks(ctx, sess, a, toolCall, ApprovalDecisionAllow, ApprovalSourceUserApprovedSession)
-			return invoke()
-		case ResumeTypeApproveTool:
-			approvedTool := req.ToolName
-			if approvedTool == "" {
-				approvedTool = toolName
-			}
-			if sess.Permissions == nil {
-				sess.Permissions = &session.PermissionsConfig{}
-			}
-			if !slices.Contains(sess.Permissions.Allow, approvedTool) {
-				sess.Permissions.Allow = append(sess.Permissions.Allow, approvedTool)
-			}
-			slog.Debug("Resume signal received, approving tool permanently", "tool", approvedTool, "session_id", sess.ID)
-			r.executeOnToolApprovalDecisionHooks(ctx, sess, a, toolCall, ApprovalDecisionAllow, ApprovalSourceUserApprovedTool)
-			return invoke()
-		case ResumeTypeReject:
-			slog.Debug("Resume signal received, rejecting tool", "tool", toolName, "session_id", sess.ID, "reason", req.Reason)
-			r.executeOnToolApprovalDecisionHooks(ctx, sess, a, toolCall, ApprovalDecisionDeny, ApprovalSourceUserRejected)
-			rejectMsg := "The user rejected the tool call."
-			if strings.TrimSpace(req.Reason) != "" {
-				rejectMsg += " Reason: " + strings.TrimSpace(req.Reason)
-			}
-			r.addToolErrorResponse(ctx, sess, toolCall, tool, events, a, rejectMsg)
-		}
-		return toolApprovalOutcome{}
-	case <-ctx.Done():
-		slog.Debug("Context cancelled while waiting for resume", "tool", toolName, "session_id", sess.ID)
-		r.executeOnToolApprovalDecisionHooks(ctx, sess, a, toolCall, ApprovalDecisionCanceled, ApprovalSourceContextCanceled)
-		r.addToolErrorResponse(ctx, sess, toolCall, tool, events, a, "The tool call was canceled by the user.")
-		return toolApprovalOutcome{canceled: true}
-	}
+// chanEmitter adapts a chan Event into a [toolexec.Emitter]. It is the
+// only place where the dispatcher's typed event surface meets the
+// runtime's event channel; new dispatcher events should grow this type
+// in lockstep with the [toolexec.Emitter] interface.
+type chanEmitter struct {
+	events chan Event
 }
 
-// executeToolWithHandler is a common helper that handles tool execution, error handling,
-// event emission, and session updates. It reduces duplication between runTool and runAgentTool.
-func (r *LocalRuntime) executeToolWithHandler(
-	ctx context.Context,
-	toolCall tools.ToolCall,
-	tool tools.Tool,
-	events chan Event,
-	sess *session.Session,
-	a *agent.Agent,
-	spanName string,
-	execute func(ctx context.Context) (*tools.ToolCallResult, time.Duration, error),
-) *tools.ToolCallResult {
-	ctx, span := r.startSpan(ctx, spanName, trace.WithAttributes(
-		attribute.String("tool.name", toolCall.Function.Name),
-		attribute.String("agent", a.Name()),
-		attribute.String("session.id", sess.ID),
-		attribute.String("tool.call_id", toolCall.ID),
-	))
-	defer span.End()
-
-	events <- ToolCall(toolCall, tool, a.Name())
-
-	res, duration, err := execute(ctx)
-
-	r.telemetry.RecordToolCall(ctx, toolCall.Function.Name, sess.ID, a.Name(), duration, err)
-
-	if err != nil {
-		if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
-			slog.Debug("Tool handler canceled by context", "tool", toolCall.Function.Name, "agent", a.Name(), "session_id", sess.ID)
-			res = tools.ResultError("The tool call was canceled by the user.")
-			span.SetStatus(codes.Ok, "tool handler canceled by user")
-		} else {
-			span.RecordError(err)
-			span.SetStatus(codes.Error, "tool handler error")
-			slog.Error("Error calling tool", "tool", toolCall.Function.Name, "error", err)
-			res = tools.ResultError(fmt.Sprintf("Error calling tool: %v", err))
-		}
-	} else {
-		span.SetStatus(codes.Ok, "tool handler completed")
-		slog.Debug("Tool call completed", "tool", toolCall.Function.Name, "output_length", len(res.Output))
-	}
-
-	events <- ToolCallResponse(toolCall.ID, tool, res, res.Output, a.Name())
-
-	// Ensure tool response content is not empty for API compatibility
-	content := res.Output
-	if strings.TrimSpace(content) == "" {
-		content = "(no output)"
-	}
-
-	toolResponseMsg := chat.Message{
-		Role:       chat.MessageRoleTool,
-		Content:    content,
-		ToolCallID: toolCall.ID,
-		IsError:    res.IsError,
-		CreatedAt:  r.now().Format(time.RFC3339),
-	}
-
-	// If the tool result contains images, attach them as MultiContent
-	if len(res.Images) > 0 {
-		multiContent := []chat.MessagePart{
-			{
-				Type: chat.MessagePartTypeText,
-				Text: content,
-			},
-		}
-		for _, img := range res.Images {
-			multiContent = append(multiContent, chat.MessagePart{
-				Type: chat.MessagePartTypeImageURL,
-				ImageURL: &chat.MessageImageURL{
-					URL:    "data:" + img.MimeType + ";base64," + img.Data,
-					Detail: chat.ImageURLDetailAuto,
-				},
-			})
-		}
-		toolResponseMsg.MultiContent = multiContent
-	}
-
-	addAgentMessage(sess, a, &toolResponseMsg, events)
-	return res
+func (e *chanEmitter) EmitToolCall(toolCall tools.ToolCall, tool tools.Tool, agentName string) {
+	e.events <- ToolCall(toolCall, tool, agentName)
 }
 
-// runTool executes a user tool from a toolset (MCP, filesystem, ...).
-// Returns a [toolApprovalOutcome] whose stopRun/stopMessage fields
-// reflect any post_tool_use deny verdict; canceled stays false (user
-// cancellation only happens during the approval flow, before this).
-func (r *LocalRuntime) runTool(ctx context.Context, tool tools.Tool, toolCall tools.ToolCall, events chan Event, sess *session.Session, a *agent.Agent) toolApprovalOutcome {
-	blocked, toolCall := r.executePreToolHook(ctx, sess, toolCall, tool, events, a)
-	if blocked {
-		return toolApprovalOutcome{}
-	}
-
-	res := r.executeToolWithHandler(ctx, toolCall, tool, events, sess, a, "runtime.tool.handler",
-		func(ctx context.Context) (*tools.ToolCallResult, time.Duration, error) {
-			res, err := tool.Handler(ctx, toolCall)
-			return res, 0, err
-		})
-
-	stop, msg := r.executePostToolHook(ctx, sess, toolCall, res, a, events)
-	return toolApprovalOutcome{stopRun: stop, stopMessage: msg}
+func (e *chanEmitter) EmitToolCallResponse(toolCallID string, tool tools.Tool, result *tools.ToolCallResult, output, agentName string) {
+	e.events <- ToolCallResponse(toolCallID, tool, result, output, agentName)
 }
 
-// executePreToolHook runs the pre-tool-use hook and returns whether the tool
-// call was blocked and the (possibly modified) tool call.
-func (r *LocalRuntime) executePreToolHook(
-	ctx context.Context,
-	sess *session.Session,
-	toolCall tools.ToolCall,
-	tool tools.Tool,
-	events chan Event,
-	a *agent.Agent,
-) (blocked bool, modifiedTC tools.ToolCall) {
-	// dispatchHook returns nil when no hook is configured, the agent is
-	// missing, or dispatch failed — in every case the right move is to
-	// run the tool unchanged.
-	result := r.dispatchHook(ctx, a, hooks.EventPreToolUse, toolexec.NewHooksInput(sess, toolCall), events)
-	if result == nil {
-		return false, toolCall
-	}
-
-	if !result.Allowed {
-		slog.Debug("Pre-tool hook blocked tool call", "tool", toolCall.Function.Name, "message", result.Message)
-		events <- HookBlocked(toolCall, tool, result.Message, a.Name())
-		r.addToolErrorResponse(ctx, sess, toolCall, tool, events, a, "Tool call blocked by hook: "+result.Message)
-		return true, toolCall
-	}
-
-	if result.ModifiedInput != nil {
-		if updated, merr := json.Marshal(result.ModifiedInput); merr != nil {
-			slog.Warn("Failed to marshal modified tool input from hook", "tool", toolCall.Function.Name, "error", merr)
-		} else {
-			slog.Debug("Pre-tool hook modified tool input", "tool", toolCall.Function.Name)
-			toolCall.Function.Arguments = string(updated)
-		}
-	}
-	return false, toolCall
+func (e *chanEmitter) EmitToolCallConfirmation(toolCall tools.ToolCall, tool tools.Tool, agentName string) {
+	e.events <- ToolCallConfirmation(toolCall, tool, agentName)
 }
 
-// executePostToolHook runs the post-tool-use hook. SystemMessage is
-// emitted as a Warning by [dispatchHook]. A terminating verdict
-// (decision="block" / continue=false / exit 2) is propagated to the
-// run loop via the (stop, message) return.
-func (r *LocalRuntime) executePostToolHook(
-	ctx context.Context,
-	sess *session.Session,
-	toolCall tools.ToolCall,
-	res *tools.ToolCallResult,
-	a *agent.Agent,
-	events chan Event,
-) (stop bool, message string) {
-	result := r.dispatchHook(ctx, a, hooks.EventPostToolUse, toolexec.NewPostToolHooksInput(sess, toolCall, res), events)
-	if result == nil || result.Allowed {
-		return false, ""
+func (e *chanEmitter) EmitHookBlocked(toolCall tools.ToolCall, tool tools.Tool, message, agentName string) {
+	e.events <- HookBlocked(toolCall, tool, message, agentName)
+}
+
+func (e *chanEmitter) EmitMessageAdded(sessionID string, msg *session.Message, agentName string) {
+	e.events <- MessageAdded(sessionID, msg, agentName)
+}
+
+// hookDispatcher adapts the runtime's per-agent [hooks.Executor] machinery
+// into the small [toolexec.HookDispatcher] interface. The events channel
+// is captured here so [LocalRuntime.dispatchHook] can surface
+// SystemMessage as a Warning event during dispatch.
+type hookDispatcher struct {
+	r      *LocalRuntime
+	events chan Event
+}
+
+func newHookDispatcher(r *LocalRuntime, events chan Event) toolexec.HookDispatcher {
+	return &hookDispatcher{r: r, events: events}
+}
+
+func (h *hookDispatcher) Dispatch(ctx context.Context, a *agent.Agent, event hooks.EventType, in *hooks.Input) *hooks.Result {
+	return h.r.dispatchHook(ctx, a, event, in, h.events)
+}
+
+func (h *hookDispatcher) NotifyUserInput(ctx context.Context, sessionID, label string) {
+	h.r.executeOnUserInputHooks(ctx, sessionID, label)
+}
+
+func (h *hookDispatcher) NotifyApprovalDecision(ctx context.Context, sess *session.Session, a *agent.Agent, tc tools.ToolCall, decision, source string) {
+	h.r.executeOnToolApprovalDecisionHooks(ctx, sess, a, tc, decision, source)
+}
+
+// allowSourceFor maps a permission-checker source label to the
+// corresponding approval-decision source classifier. Thin wrapper kept
+// in the runtime package so tests can pin the stable mapping without
+// reaching into [toolexec]'s internals.
+func allowSourceFor(checkerSource string) string {
+	if checkerSource == "session permissions" {
+		return ApprovalSourceSessionPermissionsAllow
 	}
-	return true, result.Message
+	return ApprovalSourceTeamPermissionsAllow
 }
 
-func (r *LocalRuntime) runAgentTool(ctx context.Context, handler ToolHandlerFunc, sess *session.Session, toolCall tools.ToolCall, tool tools.Tool, events chan Event, a *agent.Agent) {
-	r.executeToolWithHandler(ctx, toolCall, tool, events, sess, a, "runtime.tool.handler.runtime",
-		func(ctx context.Context) (*tools.ToolCallResult, time.Duration, error) {
-			start := r.now()
-			res, err := handler(ctx, sess, toolCall, events)
-			return res, r.now().Sub(start), err
-		})
+// denySourceFor mirrors allowSourceFor for the deny path.
+func denySourceFor(checkerSource string) string {
+	if checkerSource == "session permissions" {
+		return ApprovalSourceSessionPermissionsDeny
+	}
+	return ApprovalSourceTeamPermissionsDeny
 }
 
+// addAgentMessage records a chat message to the session and emits the
+// resulting MessageAdded event. Used by the loop for assistant messages
+// and max-iteration stop messages. The dispatcher emits its own variant
+// directly via the [toolexec.Emitter] interface.
 func addAgentMessage(sess *session.Session, a *agent.Agent, msg *chat.Message, events chan Event) {
 	agentMsg := session.NewAgentMessage(a.Name(), msg)
 	sess.AddMessage(agentMsg)
 	events <- MessageAdded(sess.ID, agentMsg, a.Name())
-}
-
-// addToolErrorResponse adds a tool error response to the session and emits the event.
-// This consolidates the common pattern used by validation, rejection, and cancellation responses.
-func (r *LocalRuntime) addToolErrorResponse(_ context.Context, sess *session.Session, toolCall tools.ToolCall, tool tools.Tool, events chan Event, a *agent.Agent, errorMsg string) {
-	events <- ToolCallResponse(toolCall.ID, tool, tools.ResultError(errorMsg), errorMsg, a.Name())
-
-	toolResponseMsg := chat.Message{
-		Role:       chat.MessageRoleTool,
-		Content:    errorMsg,
-		ToolCallID: toolCall.ID,
-		IsError:    true,
-		CreatedAt:  r.now().Format(time.RFC3339),
-	}
-	addAgentMessage(sess, a, &toolResponseMsg, events)
 }

--- a/pkg/runtime/tool_dispatch.go
+++ b/pkg/runtime/tool_dispatch.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/hooks"
 	"github.com/docker/docker-agent/pkg/permissions"
+	"github.com/docker/docker-agent/pkg/runtime/toolexec"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/tools"
 )
@@ -411,27 +412,6 @@ func (r *LocalRuntime) runTool(ctx context.Context, tool tools.Tool, toolCall to
 	return toolApprovalOutcome{stopRun: stop, stopMessage: msg}
 }
 
-// newHooksInput builds a hooks.Input from the common tool-call fields.
-// [hooks.Executor.Dispatch] auto-fills Cwd from the executor's working
-// directory, so callers don't set it here.
-func newHooksInput(sess *session.Session, toolCall tools.ToolCall) *hooks.Input {
-	return &hooks.Input{
-		SessionID: sess.ID,
-		ToolName:  toolCall.Function.Name,
-		ToolUseID: toolCall.ID,
-		ToolInput: parseToolInput(toolCall.Function.Arguments),
-	}
-}
-
-func newPostToolHookInput(sess *session.Session, toolCall tools.ToolCall, res *tools.ToolCallResult) *hooks.Input {
-	input := newHooksInput(sess, toolCall)
-	if res != nil {
-		input.ToolResponse = res.Output
-		input.ToolError = res.IsError
-	}
-	return input
-}
-
 // executePreToolHook runs the pre-tool-use hook and returns whether the tool
 // call was blocked and the (possibly modified) tool call.
 func (r *LocalRuntime) executePreToolHook(
@@ -445,7 +425,7 @@ func (r *LocalRuntime) executePreToolHook(
 	// dispatchHook returns nil when no hook is configured, the agent is
 	// missing, or dispatch failed — in every case the right move is to
 	// run the tool unchanged.
-	result := r.dispatchHook(ctx, a, hooks.EventPreToolUse, newHooksInput(sess, toolCall), events)
+	result := r.dispatchHook(ctx, a, hooks.EventPreToolUse, toolexec.NewHooksInput(sess, toolCall), events)
 	if result == nil {
 		return false, toolCall
 	}
@@ -480,20 +460,11 @@ func (r *LocalRuntime) executePostToolHook(
 	a *agent.Agent,
 	events chan Event,
 ) (stop bool, message string) {
-	result := r.dispatchHook(ctx, a, hooks.EventPostToolUse, newPostToolHookInput(sess, toolCall, res), events)
+	result := r.dispatchHook(ctx, a, hooks.EventPostToolUse, toolexec.NewPostToolHooksInput(sess, toolCall, res), events)
 	if result == nil || result.Allowed {
 		return false, ""
 	}
 	return true, result.Message
-}
-
-// parseToolInput parses tool arguments JSON into a map
-func parseToolInput(arguments string) map[string]any {
-	var result map[string]any
-	if err := json.Unmarshal([]byte(arguments), &result); err != nil {
-		return nil
-	}
-	return result
 }
 
 func (r *LocalRuntime) runAgentTool(ctx context.Context, handler ToolHandlerFunc, sess *session.Session, toolCall tools.ToolCall, tool tools.Tool, events chan Event, a *agent.Agent) {

--- a/pkg/runtime/toolexec/dispatcher.go
+++ b/pkg/runtime/toolexec/dispatcher.go
@@ -78,10 +78,9 @@ type Emitter interface {
 // "user is being prompted" notification.
 type HookDispatcher interface {
 	// Dispatch fires a tool-related hook (typically [hooks.EventPreToolUse]
-	// or [hooks.EventPostToolUse]).  Return nil when no hook is configured
-	// or dispatch failed: the dispatcher treats nil uniformly as
-	// "carry on with the original call". SystemMessage emission is the
-	// implementation's responsibility.
+	// or [hooks.EventPostToolUse]). Returning nil is the "carry on with the
+	// original call" signal — used uniformly when no hook is configured,
+	// the agent is missing, or dispatch failed.
 	Dispatch(ctx context.Context, a *agent.Agent, event hooks.EventType, in *hooks.Input) *hooks.Result
 
 	// NotifyUserInput is invoked just before the dispatcher blocks waiting
@@ -99,14 +98,10 @@ type HookDispatcher interface {
 }
 
 // ToolHandler is the signature for runtime-managed tool handlers
-// (e.g. transfer_task, handoff, change_model). Handlers receive the
-// parsed call and return the result.
-//
-// The dispatcher wraps every handler in the same tracing/telemetry/event-
-// emission pipeline used for ordinary toolset tools, so handlers MUST NOT
-// emit ToolCall/ToolCallResponse themselves. Handlers that need to emit
-// additional runtime-specific events (e.g. an agent-info event after a
-// model change) should be wired by the caller to capture the relevant
+// (e.g. transfer_task, handoff, change_model). The dispatcher wraps every
+// handler in tracing/telemetry/event-emission, so handlers MUST NOT emit
+// ToolCall/ToolCallResponse themselves. Handlers that need to emit other
+// event types should be wired by the caller to capture the relevant
 // channel via closure when registering the handler.
 type ToolHandler func(ctx context.Context, sess *session.Session, tc tools.ToolCall) (*tools.ToolCallResult, error)
 
@@ -130,8 +125,8 @@ const (
 )
 
 // Dispatcher executes batches of tool calls. Construct one per runtime
-// and call [Dispatcher.Process] for each LLM response. The dispatcher is
-// goroutine-safe only insofar as its dependencies are.
+// (or per RunStream) and call [Dispatcher.Process] for each LLM response.
+// The dispatcher is goroutine-safe only insofar as its dependencies are.
 type Dispatcher struct {
 	// Tracer records per-call spans. May be nil (no-op tracing).
 	Tracer trace.Tracer
@@ -148,7 +143,8 @@ type Dispatcher struct {
 	AgentFor func(*session.Session) *agent.Agent
 
 	// Permissions returns the ordered list of permission checkers for a
-	// session (typically session-level first, then team-level).
+	// session (typically session-level first, then team-level). May be
+	// nil; treated the same as returning an empty slice.
 	Permissions func(*session.Session) []NamedChecker
 
 	// Handlers maps tool names to runtime-managed handlers (transfer_task,
@@ -170,9 +166,9 @@ func (d *Dispatcher) Process(ctx context.Context, sess *session.Session, calls [
 	a := d.AgentFor(sess)
 	slog.Debug("Processing tool calls", "agent", a.Name(), "call_count", len(calls))
 
-	agentToolMap := make(map[string]tools.Tool, len(agentTools))
+	toolByName := make(map[string]tools.Tool, len(agentTools))
 	for _, t := range agentTools {
-		agentToolMap[t.Name] = t
+		toolByName[t.Name] = t
 	}
 
 	// synthesizeRemaining adds error responses for tool calls we won't
@@ -181,61 +177,15 @@ func (d *Dispatcher) Process(ctx context.Context, sess *session.Session, calls [
 	// rejected by the Responses API, so we surface them as errors
 	// rather than dropping them.
 	synthesizeRemaining := func(remaining []tools.ToolCall, reason string) {
-		for _, tc := range remaining {
-			d.addToolErrorResponse(sess, tc, agentToolMap[tc.Function.Name], em, a, reason)
+		for _, rc := range remaining {
+			c := d.newCall(sess, em, a, rc, toolByName)
+			c.errorResponse(reason)
 		}
 	}
 
-	for i, toolCall := range calls {
-		callCtx, callSpan := d.startSpan(ctx, "runtime.tool.call", trace.WithAttributes(
-			attribute.String("tool.name", toolCall.Function.Name),
-			attribute.String("tool.type", string(toolCall.Type)),
-			attribute.String("agent", a.Name()),
-			attribute.String("session.id", sess.ID),
-			attribute.String("tool.call_id", toolCall.ID),
-		))
-
-		slog.Debug("Processing tool call", "agent", a.Name(), "tool", toolCall.Function.Name, "session_id", sess.ID)
-
-		// Resolve the tool: it must be in the agent's tool set to be callable.
-		// After a handoff the model may hallucinate tools it saw in the
-		// conversation history from a previous agent; rejecting unknown
-		// tools with an error response lets it self-correct.
-		tool, available := agentToolMap[toolCall.Function.Name]
-		if !available {
-			slog.Warn("Tool call for unavailable tool", "agent", a.Name(), "tool", toolCall.Function.Name, "session_id", sess.ID)
-			errTool := tools.Tool{Name: toolCall.Function.Name}
-			d.addToolErrorResponse(sess, toolCall, errTool, em, a, fmt.Sprintf("Tool '%s' is not available. You can only use the tools provided to you.", toolCall.Function.Name))
-			callSpan.SetStatus(codes.Error, "tool not available")
-			callSpan.End()
-			continue
-		}
-
-		// Pick the handler: runtime-managed tools (transfer_task, handoff)
-		// have dedicated handlers; everything else goes through the toolset.
-		// Runtime-managed handlers skip pre/post hooks; toolset tools go
-		// through the hook-aware path and may produce a stopRun outcome.
-		var runTool func() CallOutcome
-		if handler, exists := d.Handlers[toolCall.Function.Name]; exists {
-			runTool = func() CallOutcome {
-				d.runHandlerTool(callCtx, handler, sess, toolCall, tool, em, a)
-				return CallOutcome{}
-			}
-		} else {
-			runTool = func() CallOutcome {
-				return d.runToolsetTool(callCtx, tool, toolCall, em, sess, a)
-			}
-		}
-
-		outcome := d.executeWithApproval(callCtx, sess, toolCall, tool, em, a, runTool)
-
-		if outcome.Canceled {
-			callSpan.SetStatus(codes.Ok, "tool call canceled by user")
-		} else {
-			callSpan.SetStatus(codes.Ok, "tool call processed")
-		}
-		callSpan.End()
-
+	for i, tc := range calls {
+		c := d.newCall(sess, em, a, tc, toolByName)
+		outcome := c.run(ctx)
 		switch {
 		case outcome.Canceled:
 			synthesizeRemaining(calls[i+1:],
@@ -250,67 +200,153 @@ func (d *Dispatcher) Process(ctx context.Context, sess *session.Session, calls [
 	return false, ""
 }
 
-// executeWithApproval handles the tool approval flow and executes the tool.
+// newCall assembles a [call] for a single tool invocation, looking up the
+// referenced tool in the agent's toolset. When the tool isn't found, the
+// call is marked unavailable and tool.Name is set to the requested name
+// so error events still carry a meaningful label.
+func (d *Dispatcher) newCall(sess *session.Session, em Emitter, a *agent.Agent, tc tools.ToolCall, toolByName map[string]tools.Tool) *call {
+	tool, available := toolByName[tc.Function.Name]
+	if !available {
+		tool = tools.Tool{Name: tc.Function.Name}
+	}
+	return &call{
+		d:         d,
+		sess:      sess,
+		em:        em,
+		a:         a,
+		tc:        tc,
+		tool:      tool,
+		available: available,
+	}
+}
+
+// call bundles the per-tool-call state used by the dispatcher's helpers.
+// Carrying it as a single value cuts the helpers' parameter lists from
+// 7-8 arguments down to a method receiver, and groups the mutable state
+// (pre-hook may rewrite tc.Function.Arguments) in one place.
 //
-// The approval flow is fully resolved by [Decide]; this function only
-// translates the resulting decision into runtime side effects (run,
-// deny-with-error-response, ask-and-wait) and forwards the decision to
-// [HookDispatcher.NotifyApprovalDecision] for hook tracking.
-func (d *Dispatcher) executeWithApproval(
-	ctx context.Context,
-	sess *session.Session,
-	toolCall tools.ToolCall,
-	tool tools.Tool,
-	em Emitter,
-	a *agent.Agent,
-	runTool func() CallOutcome,
-) CallOutcome {
-	toolName := toolCall.Function.Name
+// ctx is intentionally NOT a field: storing context.Context in a struct
+// is a documented Go anti-pattern (it hides cancellation flow). Methods
+// that need ctx accept it explicitly as the first argument.
+type call struct {
+	d    *Dispatcher
+	sess *session.Session
+	em   Emitter
+	a    *agent.Agent
+
+	tc        tools.ToolCall // mutable: preHook may rewrite arguments
+	tool      tools.Tool     // tool.Name is always set; other fields zero when !available
+	available bool           // false when the tool wasn't in the agent's toolset
+}
+
+// run processes a single tool call and returns its outcome. All span
+// and approval bookkeeping lives here so the call lifecycle is visible
+// at a glance.
+func (c *call) run(ctx context.Context) CallOutcome {
+	ctx, span := c.d.startSpan(ctx, "runtime.tool.call", trace.WithAttributes(
+		attribute.String("tool.name", c.tc.Function.Name),
+		attribute.String("tool.type", string(c.tc.Type)),
+		attribute.String("agent", c.a.Name()),
+		attribute.String("session.id", c.sess.ID),
+		attribute.String("tool.call_id", c.tc.ID),
+	))
+	defer span.End()
+
+	slog.Debug("Processing tool call", "agent", c.a.Name(), "tool", c.tc.Function.Name, "session_id", c.sess.ID)
+
+	// After a handoff the model may hallucinate tools it saw earlier in
+	// the conversation. Reject unknown tools with an error response so it
+	// can self-correct.
+	if !c.available {
+		slog.Warn("Tool call for unavailable tool", "agent", c.a.Name(), "tool", c.tc.Function.Name, "session_id", c.sess.ID)
+		c.errorResponse(fmt.Sprintf("Tool '%s' is not available. You can only use the tools provided to you.", c.tc.Function.Name))
+		span.SetStatus(codes.Error, "tool not available")
+		return CallOutcome{}
+	}
+
+	// Pick the deferred work that runs once approval clears: runtime-managed
+	// tools (transfer_task, handoff) have dedicated handlers; everything
+	// else goes through the toolset.
+	var runTool func() CallOutcome
+	if handler, ok := c.d.Handlers[c.tc.Function.Name]; ok {
+		runTool = func() CallOutcome {
+			c.runHandler(ctx, handler)
+			return CallOutcome{}
+		}
+	} else {
+		runTool = func() CallOutcome {
+			return c.runToolset(ctx)
+		}
+	}
+
+	outcome := c.approveAndRun(ctx, runTool)
+	if outcome.Canceled {
+		span.SetStatus(codes.Ok, "tool call canceled by user")
+	} else {
+		span.SetStatus(codes.Ok, "tool call processed")
+	}
+	return outcome
+}
+
+// approveAndRun runs runTool if the configured approval pipeline allows
+// it, otherwise records an error or asks the user.
+//
+// The policy decision is delegated to the pure [Decide] function; this
+// method only applies the resulting outcome and notifies the
+// [HookDispatcher] of the verdict.
+func (c *call) approveAndRun(ctx context.Context, runTool func() CallOutcome) CallOutcome {
+	var checkers []NamedChecker
+	if c.d.Permissions != nil {
+		checkers = c.d.Permissions(c.sess)
+	}
 
 	decision := Decide(
-		sess.ToolsApproved,
-		d.permissionsFor(sess),
-		toolName,
-		ParseToolInput(toolCall.Function.Arguments),
-		tool.Annotations.ReadOnlyHint,
+		c.sess.ToolsApproved,
+		checkers,
+		c.tc.Function.Name,
+		ParseToolInput(c.tc.Function.Arguments),
+		c.tool.Annotations.ReadOnlyHint,
 	)
 
 	switch decision.Outcome {
 	case OutcomeAllow:
-		logAllow(decision, toolName, sess.ID)
-		d.notifyApproval(ctx, sess, a, toolCall, ApprovalDecisionAllow, allowSourceForDecision(decision))
+		c.logAllow(decision)
+		c.notifyApproval(ctx, ApprovalDecisionAllow, allowSourceForDecision(decision))
 		return runTool()
 	case OutcomeDeny:
-		slog.Debug("Tool denied by permissions", "tool", toolName, "source", decision.Source, "session_id", sess.ID)
-		d.notifyApproval(ctx, sess, a, toolCall, ApprovalDecisionDeny, denySourceForChecker(decision.Source))
-		d.addToolErrorResponse(sess, toolCall, tool, em, a, fmt.Sprintf("Tool '%s' is denied by %s.", toolName, decision.Source))
+		slog.Debug("Tool denied by permissions", "tool", c.tc.Function.Name, "source", decision.Source, "session_id", c.sess.ID)
+		c.notifyApproval(ctx, ApprovalDecisionDeny, denySourceForChecker(decision.Source))
+		c.errorResponse(fmt.Sprintf("Tool '%s' is denied by %s.", c.tc.Function.Name, decision.Source))
 		return CallOutcome{}
 	case OutcomeAsk:
 		if decision.Reason == ReasonChecker {
-			slog.Debug("Tool requires confirmation (ask pattern)", "tool", toolName, "source", decision.Source, "session_id", sess.ID)
+			slog.Debug("Tool requires confirmation (ask pattern)", "tool", c.tc.Function.Name, "source", decision.Source, "session_id", c.sess.ID)
 		}
-		return d.askUserForConfirmation(ctx, sess, toolCall, tool, em, a, runTool)
+		return c.askUser(ctx, runTool)
 	}
 	return CallOutcome{}
-}
-
-// permissionsFor returns the ordered checkers for sess, or nil when none
-// are configured. Centralizing the nil-guard keeps callers terse.
-func (d *Dispatcher) permissionsFor(sess *session.Session) []NamedChecker {
-	if d.Permissions == nil {
-		return nil
-	}
-	return d.Permissions(sess)
 }
 
 // notifyApproval forwards the resolved approval decision to the
 // HookDispatcher, when one is configured. Centralised so the nil-guard
 // stays in one place.
-func (d *Dispatcher) notifyApproval(ctx context.Context, sess *session.Session, a *agent.Agent, tc tools.ToolCall, decision, source string) {
-	if d.Hooks == nil {
+func (c *call) notifyApproval(ctx context.Context, decision, source string) {
+	if c.d.Hooks == nil {
 		return
 	}
-	d.Hooks.NotifyApprovalDecision(ctx, sess, a, tc, decision, source)
+	c.d.Hooks.NotifyApprovalDecision(ctx, c.sess, c.a, c.tc, decision, source)
+}
+
+// logAllow emits the auto-approval debug log appropriate to the reason
+// that produced the [OutcomeAllow] decision.
+func (c *call) logAllow(d PermissionDecision) {
+	switch d.Reason {
+	case ReasonYolo:
+		slog.Debug("Tool auto-approved by --yolo flag", "tool", c.tc.Function.Name, "session_id", c.sess.ID)
+	case ReasonChecker:
+		slog.Debug("Tool auto-approved by permissions", "tool", c.tc.Function.Name, "source", d.Source, "session_id", c.sess.ID)
+		// ReasonReadOnlyHint is intentionally silent (matches prior behaviour).
+	}
 }
 
 // allowSourceForDecision maps a [PermissionDecision] with [OutcomeAllow]
@@ -345,274 +381,251 @@ func denySourceForChecker(checkerSource string) string {
 	return ApprovalSourceTeamPermissionsDeny
 }
 
-// logAllow emits the auto-approval debug log appropriate to the reason
-// (--yolo, an explicit checker rule, or the read-only hint).
-func logAllow(decision PermissionDecision, toolName, sessionID string) {
-	switch decision.Reason {
-	case ReasonYolo:
-		slog.Debug("Tool auto-approved by --yolo flag", "tool", toolName, "session_id", sessionID)
-	case ReasonChecker:
-		slog.Debug("Tool auto-approved by permissions", "tool", toolName, "source", decision.Source, "session_id", sessionID)
-		// ReasonReadOnlyHint is intentionally silent (matches prior behaviour).
-	}
-}
+// askUser sends a confirmation event and waits for the user's response
+// on the resume channel or for ctx cancellation. Only called when no
+// permission rule auto-approved the tool.
+func (c *call) askUser(ctx context.Context, runTool func() CallOutcome) CallOutcome {
+	slog.Debug("Tools not approved, waiting for resume", "tool", c.tc.Function.Name, "session_id", c.sess.ID)
+	c.em.EmitToolCallConfirmation(c.tc, c.tool, c.a.Name())
 
-// askUserForConfirmation sends a confirmation event and waits for user
-// response. Only called when no permission rule auto-approved the tool.
-func (d *Dispatcher) askUserForConfirmation(
-	ctx context.Context,
-	sess *session.Session,
-	toolCall tools.ToolCall,
-	tool tools.Tool,
-	em Emitter,
-	a *agent.Agent,
-	runTool func() CallOutcome,
-) CallOutcome {
-	toolName := toolCall.Function.Name
-	slog.Debug("Tools not approved, waiting for resume", "tool", toolName, "session_id", sess.ID)
-	em.EmitToolCallConfirmation(toolCall, tool, a.Name())
-
-	if d.Hooks != nil {
-		d.Hooks.NotifyUserInput(ctx, sess.ID, "tool confirmation")
+	if c.d.Hooks != nil {
+		c.d.Hooks.NotifyUserInput(ctx, c.sess.ID, "tool confirmation")
 	}
 
 	select {
-	case req := <-d.Resume:
-		switch req.Type {
-		case ResumeTypeApprove:
-			slog.Debug("Resume signal received, approving tool", "tool", toolName, "session_id", sess.ID)
-			d.notifyApproval(ctx, sess, a, toolCall, ApprovalDecisionAllow, ApprovalSourceUserApproved)
-			return runTool()
-		case ResumeTypeApproveSession:
-			slog.Debug("Resume signal received, approving session", "tool", toolName, "session_id", sess.ID)
-			sess.ToolsApproved = true
-			d.notifyApproval(ctx, sess, a, toolCall, ApprovalDecisionAllow, ApprovalSourceUserApprovedSession)
-			return runTool()
-		case ResumeTypeApproveTool:
-			// Add the tool to session's allow list for future auto-approval.
-			approvedTool := req.ToolName
-			if approvedTool == "" {
-				approvedTool = toolName
-			}
-			if sess.Permissions == nil {
-				sess.Permissions = &session.PermissionsConfig{}
-			}
-			if !slices.Contains(sess.Permissions.Allow, approvedTool) {
-				sess.Permissions.Allow = append(sess.Permissions.Allow, approvedTool)
-			}
-			slog.Debug("Resume signal received, approving tool permanently", "tool", approvedTool, "session_id", sess.ID)
-			d.notifyApproval(ctx, sess, a, toolCall, ApprovalDecisionAllow, ApprovalSourceUserApprovedTool)
-			return runTool()
-		case ResumeTypeReject:
-			slog.Debug("Resume signal received, rejecting tool", "tool", toolName, "session_id", sess.ID, "reason", req.Reason)
-			d.notifyApproval(ctx, sess, a, toolCall, ApprovalDecisionDeny, ApprovalSourceUserRejected)
-			rejectMsg := "The user rejected the tool call."
-			if strings.TrimSpace(req.Reason) != "" {
-				rejectMsg += " Reason: " + strings.TrimSpace(req.Reason)
-			}
-			d.addToolErrorResponse(sess, toolCall, tool, em, a, rejectMsg)
-		}
-		return CallOutcome{}
+	case req := <-c.d.Resume:
+		return c.handleResume(ctx, req, runTool)
 	case <-ctx.Done():
-		slog.Debug("Context cancelled while waiting for resume", "tool", toolName, "session_id", sess.ID)
-		d.notifyApproval(ctx, sess, a, toolCall, ApprovalDecisionCanceled, ApprovalSourceContextCanceled)
-		d.addToolErrorResponse(sess, toolCall, tool, em, a, "The tool call was canceled by the user.")
+		slog.Debug("Context cancelled while waiting for resume", "tool", c.tc.Function.Name, "session_id", c.sess.ID)
+		c.notifyApproval(ctx, ApprovalDecisionCanceled, ApprovalSourceContextCanceled)
+		c.errorResponse("The tool call was canceled by the user.")
 		return CallOutcome{Canceled: true}
 	}
 }
 
-// executeToolWithHandler is the common pipeline shared by toolset tools and
-// runtime-managed handlers: tracing, event emission, telemetry, error
-// translation, and session message persistence.
-func (d *Dispatcher) executeToolWithHandler(
-	ctx context.Context,
-	toolCall tools.ToolCall,
-	tool tools.Tool,
-	em Emitter,
-	sess *session.Session,
-	a *agent.Agent,
-	spanName string,
-	execute func(ctx context.Context) (*tools.ToolCallResult, time.Duration, error),
-) *tools.ToolCallResult {
-	ctx, span := d.startSpan(ctx, spanName, trace.WithAttributes(
-		attribute.String("tool.name", toolCall.Function.Name),
-		attribute.String("agent", a.Name()),
-		attribute.String("session.id", sess.ID),
-		attribute.String("tool.call_id", toolCall.ID),
+// handleResume applies the user's confirmation decision: run the tool
+// (with optional session/tool-wide approval persistence) or emit a
+// rejection error response.
+func (c *call) handleResume(ctx context.Context, req ResumeRequest, runTool func() CallOutcome) CallOutcome {
+	switch req.Type {
+	case ResumeTypeApprove:
+		slog.Debug("Resume signal received, approving tool", "tool", c.tc.Function.Name, "session_id", c.sess.ID)
+		c.notifyApproval(ctx, ApprovalDecisionAllow, ApprovalSourceUserApproved)
+		return runTool()
+	case ResumeTypeApproveSession:
+		slog.Debug("Resume signal received, approving session", "tool", c.tc.Function.Name, "session_id", c.sess.ID)
+		c.sess.ToolsApproved = true
+		c.notifyApproval(ctx, ApprovalDecisionAllow, ApprovalSourceUserApprovedSession)
+		return runTool()
+	case ResumeTypeApproveTool:
+		approvedTool := req.ToolName
+		if approvedTool == "" {
+			approvedTool = c.tc.Function.Name
+		}
+		if c.sess.Permissions == nil {
+			c.sess.Permissions = &session.PermissionsConfig{}
+		}
+		if !slices.Contains(c.sess.Permissions.Allow, approvedTool) {
+			c.sess.Permissions.Allow = append(c.sess.Permissions.Allow, approvedTool)
+		}
+		slog.Debug("Resume signal received, approving tool permanently", "tool", approvedTool, "session_id", c.sess.ID)
+		c.notifyApproval(ctx, ApprovalDecisionAllow, ApprovalSourceUserApprovedTool)
+		return runTool()
+	case ResumeTypeReject:
+		slog.Debug("Resume signal received, rejecting tool", "tool", c.tc.Function.Name, "session_id", c.sess.ID, "reason", req.Reason)
+		c.notifyApproval(ctx, ApprovalDecisionDeny, ApprovalSourceUserRejected)
+		msg := "The user rejected the tool call."
+		if reason := strings.TrimSpace(req.Reason); reason != "" {
+			msg += " Reason: " + reason
+		}
+		c.errorResponse(msg)
+	}
+	return CallOutcome{}
+}
+
+// runToolset executes a tool from an agent's toolset (MCP, filesystem, ...),
+// surrounding the call with pre/post hooks. The pre-hook may block the
+// call or rewrite its arguments; the post-hook may signal run
+// termination via its returned [CallOutcome].
+func (c *call) runToolset(ctx context.Context) CallOutcome {
+	if blocked := c.preHook(ctx); blocked {
+		return CallOutcome{}
+	}
+
+	res := c.invoke(ctx, "runtime.tool.handler", func(ctx context.Context) (*tools.ToolCallResult, time.Duration, error) {
+		res, err := c.tool.Handler(ctx, c.tc)
+		return res, 0, err
+	})
+
+	stop, msg := c.postHook(ctx, res)
+	return CallOutcome{StopRun: stop, StopMessage: msg}
+}
+
+// runHandler executes a runtime-managed tool handler. Hooks do not fire
+// for runtime-managed handlers — they're internal plumbing, not user-
+// configurable tools.
+func (c *call) runHandler(ctx context.Context, handler ToolHandler) {
+	c.invoke(ctx, "runtime.tool.handler.runtime", func(ctx context.Context) (*tools.ToolCallResult, time.Duration, error) {
+		start := time.Now()
+		res, err := handler(ctx, c.sess, c.tc)
+		return res, time.Since(start), err
+	})
+}
+
+// invoke is the common pipeline shared by toolset tools and runtime-
+// managed handlers: tracing, event emission, telemetry, error
+// translation, and session message persistence. It is the only place
+// where a tool actually runs.
+func (c *call) invoke(ctx context.Context, spanName string, exec func(ctx context.Context) (*tools.ToolCallResult, time.Duration, error)) *tools.ToolCallResult {
+	ctx, span := c.d.startSpan(ctx, spanName, trace.WithAttributes(
+		attribute.String("tool.name", c.tc.Function.Name),
+		attribute.String("agent", c.a.Name()),
+		attribute.String("session.id", c.sess.ID),
+		attribute.String("tool.call_id", c.tc.ID),
 	))
 	defer span.End()
 
-	em.EmitToolCall(toolCall, tool, a.Name())
+	c.em.EmitToolCall(c.tc, c.tool, c.a.Name())
 
-	res, duration, err := execute(ctx)
-
-	telemetry.RecordToolCall(ctx, toolCall.Function.Name, sess.ID, a.Name(), duration, err)
+	res, duration, err := exec(ctx)
+	telemetry.RecordToolCall(ctx, c.tc.Function.Name, c.sess.ID, c.a.Name(), duration, err)
 
 	if err != nil {
-		if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
-			slog.Debug("Tool handler canceled by context", "tool", toolCall.Function.Name, "agent", a.Name(), "session_id", sess.ID)
-			res = tools.ResultError("The tool call was canceled by the user.")
-			span.SetStatus(codes.Ok, "tool handler canceled by user")
-		} else {
-			span.RecordError(err)
-			span.SetStatus(codes.Error, "tool handler error")
-			slog.Error("Error calling tool", "tool", toolCall.Function.Name, "error", err)
-			res = tools.ResultError(fmt.Sprintf("Error calling tool: %v", err))
-		}
+		res = c.translateError(ctx, span, err)
 	} else {
 		span.SetStatus(codes.Ok, "tool handler completed")
-		slog.Debug("Tool call completed", "tool", toolCall.Function.Name, "output_length", len(res.Output))
+		slog.Debug("Tool call completed", "tool", c.tc.Function.Name, "output_length", len(res.Output))
 	}
 
-	em.EmitToolCallResponse(toolCall.ID, tool, res, res.Output, a.Name())
+	c.em.EmitToolCallResponse(c.tc.ID, c.tool, res, res.Output, c.a.Name())
+	c.recordToolResponse(res)
+	return res
+}
 
-	// Ensure tool response content is not empty for API compatibility.
+// translateError converts a tool-handler error into a [tools.ToolCallResult]
+// suitable for the conversation, while annotating the span. Context-cancel
+// errors are reported as user cancellation (Ok status); everything else is
+// recorded as an error.
+func (c *call) translateError(ctx context.Context, span trace.Span, err error) *tools.ToolCallResult {
+	if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
+		slog.Debug("Tool handler canceled by context", "tool", c.tc.Function.Name, "agent", c.a.Name(), "session_id", c.sess.ID)
+		span.SetStatus(codes.Ok, "tool handler canceled by user")
+		return tools.ResultError("The tool call was canceled by the user.")
+	}
+	span.RecordError(err)
+	span.SetStatus(codes.Error, "tool handler error")
+	slog.Error("Error calling tool", "tool", c.tc.Function.Name, "error", err)
+	return tools.ResultError(fmt.Sprintf("Error calling tool: %v", err))
+}
+
+// recordToolResponse builds the chat message for a successful (or
+// error-translated) tool result and adds it to the session.
+func (c *call) recordToolResponse(res *tools.ToolCallResult) {
+	// Tool response content must not be empty for API compatibility.
 	content := res.Output
 	if strings.TrimSpace(content) == "" {
 		content = "(no output)"
 	}
 
-	toolResponseMsg := chat.Message{
+	msg := chat.Message{
 		Role:       chat.MessageRoleTool,
 		Content:    content,
-		ToolCallID: toolCall.ID,
+		ToolCallID: c.tc.ID,
 		IsError:    res.IsError,
 		CreatedAt:  time.Now().Format(time.RFC3339),
 	}
 
-	// If the tool result contains images, attach them as MultiContent.
 	if len(res.Images) > 0 {
-		multiContent := []chat.MessagePart{
-			{Type: chat.MessagePartTypeText, Text: content},
-		}
-		for _, img := range res.Images {
-			multiContent = append(multiContent, chat.MessagePart{
-				Type: chat.MessagePartTypeImageURL,
-				ImageURL: &chat.MessageImageURL{
-					URL:    "data:" + img.MimeType + ";base64," + img.Data,
-					Detail: chat.ImageURLDetailAuto,
-				},
-			})
-		}
-		toolResponseMsg.MultiContent = multiContent
+		msg.MultiContent = buildMultiContent(content, res.Images)
 	}
 
-	addAgentMessage(sess, a, &toolResponseMsg, em)
-	return res
+	c.addMessage(&msg)
 }
 
-// runToolsetTool executes a tool from an agent's toolset (MCP, filesystem, ...).
-// Returns a [CallOutcome] whose StopRun/StopMessage fields reflect any
-// post_tool_use deny verdict; Canceled stays false (user cancellation
-// only happens during the approval flow, before this).
-func (d *Dispatcher) runToolsetTool(ctx context.Context, tool tools.Tool, toolCall tools.ToolCall, em Emitter, sess *session.Session, a *agent.Agent) CallOutcome {
-	// Pre-tool hook: may block the call or rewrite its arguments.
-	blocked, toolCall := d.preHook(ctx, sess, toolCall, tool, em, a)
-	if blocked {
-		return CallOutcome{}
-	}
-
-	res := d.executeToolWithHandler(ctx, toolCall, tool, em, sess, a, "runtime.tool.handler",
-		func(ctx context.Context) (*tools.ToolCallResult, time.Duration, error) {
-			res, err := tool.Handler(ctx, toolCall)
-			return res, 0, err
+// buildMultiContent attaches inline images to a tool response as a
+// MultiContent payload, following the data-URL convention expected by
+// chat clients.
+func buildMultiContent(text string, images []tools.MediaContent) []chat.MessagePart {
+	parts := make([]chat.MessagePart, 0, 1+len(images))
+	parts = append(parts, chat.MessagePart{Type: chat.MessagePartTypeText, Text: text})
+	for _, img := range images {
+		parts = append(parts, chat.MessagePart{
+			Type: chat.MessagePartTypeImageURL,
+			ImageURL: &chat.MessageImageURL{
+				URL:    "data:" + img.MimeType + ";base64," + img.Data,
+				Detail: chat.ImageURLDetailAuto,
+			},
 		})
-
-	// Post-tool hook: SystemMessage is surfaced by the HookDispatcher
-	// implementation; a terminating verdict (decision="block" /
-	// continue=false / exit 2) is propagated to the run loop via
-	// CallOutcome.
-	stop, msg := d.postHook(ctx, sess, toolCall, res, a)
-	return CallOutcome{StopRun: stop, StopMessage: msg}
+	}
+	return parts
 }
 
-// runHandlerTool executes a runtime-managed tool handler.
-func (d *Dispatcher) runHandlerTool(ctx context.Context, handler ToolHandler, sess *session.Session, toolCall tools.ToolCall, tool tools.Tool, em Emitter, a *agent.Agent) {
-	d.executeToolWithHandler(ctx, toolCall, tool, em, sess, a, "runtime.tool.handler.runtime",
-		func(ctx context.Context) (*tools.ToolCallResult, time.Duration, error) {
-			start := time.Now()
-			res, err := handler(ctx, sess, toolCall)
-			return res, time.Since(start), err
-		})
-}
-
-// preHook fires the pre-tool-use hook and reports whether the tool call
-// was blocked (along with the possibly modified call when allowed).
-func (d *Dispatcher) preHook(
-	ctx context.Context,
-	sess *session.Session,
-	toolCall tools.ToolCall,
-	tool tools.Tool,
-	em Emitter,
-	a *agent.Agent,
-) (blocked bool, modifiedTC tools.ToolCall) {
-	if d.Hooks == nil {
-		return false, toolCall
+// preHook fires the pre-tool-use hook and returns whether the tool call
+// was blocked. When the hook rewrites arguments, [c.tc] is mutated in
+// place so the downstream invoke() sees the new arguments.
+func (c *call) preHook(ctx context.Context) (blocked bool) {
+	if c.d.Hooks == nil {
+		return false
 	}
 
-	// Dispatch returns nil when no hook is configured, the agent is
-	// missing, or dispatch failed — in every case the right move is to
-	// run the tool unchanged.
-	result := d.Hooks.Dispatch(ctx, a, hooks.EventPreToolUse, NewHooksInput(sess, toolCall))
+	result := c.d.Hooks.Dispatch(ctx, c.a, hooks.EventPreToolUse, NewHooksInput(c.sess, c.tc))
 	if result == nil {
-		return false, toolCall
+		return false
 	}
 
 	if !result.Allowed {
-		slog.Debug("Pre-tool hook blocked tool call", "tool", toolCall.Function.Name, "message", result.Message)
-		em.EmitHookBlocked(toolCall, tool, result.Message, a.Name())
-		d.addToolErrorResponse(sess, toolCall, tool, em, a, "Tool call blocked by hook: "+result.Message)
-		return true, toolCall
+		slog.Debug("Pre-tool hook blocked tool call", "tool", c.tc.Function.Name, "message", result.Message)
+		c.em.EmitHookBlocked(c.tc, c.tool, result.Message, c.a.Name())
+		c.errorResponse("Tool call blocked by hook: " + result.Message)
+		return true
 	}
 
 	if result.ModifiedInput != nil {
-		if updated, merr := json.Marshal(result.ModifiedInput); merr != nil {
-			slog.Warn("Failed to marshal modified tool input from hook", "tool", toolCall.Function.Name, "error", merr)
+		if updated, err := json.Marshal(result.ModifiedInput); err != nil {
+			slog.Warn("Failed to marshal modified tool input from hook", "tool", c.tc.Function.Name, "error", err)
 		} else {
-			slog.Debug("Pre-tool hook modified tool input", "tool", toolCall.Function.Name)
-			toolCall.Function.Arguments = string(updated)
+			slog.Debug("Pre-tool hook modified tool input", "tool", c.tc.Function.Name)
+			c.tc.Function.Arguments = string(updated)
 		}
 	}
-	return false, toolCall
+	return false
 }
 
 // postHook fires the post-tool-use hook. SystemMessage emission is the
 // [HookDispatcher]'s responsibility. A terminating verdict
 // (decision="block" / continue=false / exit 2) is propagated via the
-// (stop, message) return.
-func (d *Dispatcher) postHook(ctx context.Context, sess *session.Session, toolCall tools.ToolCall, res *tools.ToolCallResult, a *agent.Agent) (stop bool, message string) {
-	if d.Hooks == nil {
+// (stop, message) return. The tool result is forwarded to the hook so
+// post_tool_use handlers can inspect ToolResponse / ToolError.
+func (c *call) postHook(ctx context.Context, res *tools.ToolCallResult) (stop bool, message string) {
+	if c.d.Hooks == nil {
 		return false, ""
 	}
-	result := d.Hooks.Dispatch(ctx, a, hooks.EventPostToolUse, NewPostToolHooksInput(sess, toolCall, res))
+	result := c.d.Hooks.Dispatch(ctx, c.a, hooks.EventPostToolUse, NewPostToolHooksInput(c.sess, c.tc, res))
 	if result == nil || result.Allowed {
 		return false, ""
 	}
 	return true, result.Message
 }
 
-// addToolErrorResponse appends an error tool-response to the session and
-// emits the corresponding events. Consolidates the pattern shared by
-// validation, rejection, and cancellation responses.
-func (d *Dispatcher) addToolErrorResponse(sess *session.Session, toolCall tools.ToolCall, tool tools.Tool, em Emitter, a *agent.Agent, errorMsg string) {
-	em.EmitToolCallResponse(toolCall.ID, tool, tools.ResultError(errorMsg), errorMsg, a.Name())
-
-	toolResponseMsg := chat.Message{
+// errorResponse appends an error tool-response to the session and emits
+// the corresponding events. Used by validation, rejection, hook-block,
+// and cancellation paths.
+func (c *call) errorResponse(errorMsg string) {
+	c.em.EmitToolCallResponse(c.tc.ID, c.tool, tools.ResultError(errorMsg), errorMsg, c.a.Name())
+	c.addMessage(&chat.Message{
 		Role:       chat.MessageRoleTool,
 		Content:    errorMsg,
-		ToolCallID: toolCall.ID,
+		ToolCallID: c.tc.ID,
 		IsError:    true,
 		CreatedAt:  time.Now().Format(time.RFC3339),
-	}
-	addAgentMessage(sess, a, &toolResponseMsg, em)
+	})
 }
 
-// addAgentMessage records a chat message to the session and emits the
-// resulting [*session.Message] via the [Emitter].
-func addAgentMessage(sess *session.Session, a *agent.Agent, msg *chat.Message, em Emitter) {
-	agentMsg := session.NewAgentMessage(a.Name(), msg)
-	sess.AddMessage(agentMsg)
-	em.EmitMessageAdded(sess.ID, agentMsg, a.Name())
+// addMessage records msg in the session and emits MessageAdded.
+func (c *call) addMessage(msg *chat.Message) {
+	agentMsg := session.NewAgentMessage(c.a.Name(), msg)
+	c.sess.AddMessage(agentMsg)
+	c.em.EmitMessageAdded(c.sess.ID, agentMsg, c.a.Name())
 }
 
 // startSpan wraps Tracer.Start; a nil tracer is a no-op so callers don't

--- a/pkg/runtime/toolexec/dispatcher.go
+++ b/pkg/runtime/toolexec/dispatcher.go
@@ -1,0 +1,625 @@
+package toolexec
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"slices"
+	"strings"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/hooks"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/telemetry"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+// Verdicts and sources surfaced via [HookDispatcher.NotifyApprovalDecision].
+// The strings are part of the on_tool_approval_decision hook contract and
+// must stay stable.
+const (
+	ApprovalDecisionAllow    = "allow"
+	ApprovalDecisionDeny     = "deny"
+	ApprovalDecisionCanceled = "canceled"
+
+	ApprovalSourceYolo                    = "yolo"
+	ApprovalSourceSessionPermissionsAllow = "session_permissions_allow"
+	ApprovalSourceSessionPermissionsDeny  = "session_permissions_deny"
+	ApprovalSourceTeamPermissionsAllow    = "team_permissions_allow"
+	ApprovalSourceTeamPermissionsDeny     = "team_permissions_deny"
+	ApprovalSourceReadOnlyHint            = "readonly_hint"
+	ApprovalSourceUserApproved            = "user_approved"
+	ApprovalSourceUserApprovedSession     = "user_approved_session"
+	ApprovalSourceUserApprovedTool        = "user_approved_tool"
+	ApprovalSourceUserRejected            = "user_rejected"
+	ApprovalSourceContextCanceled         = "context_canceled"
+)
+
+// CallOutcome captures the verdicts of a single tool invocation as
+// observed by the dispatcher.
+//
+// Canceled and StopRun are mutually exclusive in practice but signal
+// different things to the caller: cancellation halts the current batch
+// silently (the run loop continues so the synthesised tool error
+// responses can be sent back to the model on the next turn); StopRun
+// also terminates the agent's run loop with a user-visible reason
+// produced by a post_tool_use hook deny verdict.
+type CallOutcome struct {
+	Canceled    bool
+	StopRun     bool
+	StopMessage string
+}
+
+// Emitter receives the events the [Dispatcher] emits while processing a
+// batch of tool calls. Runtimes typically implement this by sending typed
+// events to their event channel.
+//
+// The dispatcher only emits the five events below. Runtime-managed
+// handlers (registered via [Dispatcher.Handlers]) emit any additional
+// runtime-specific events directly via the channel they captured at
+// registration time.
+type Emitter interface {
+	EmitToolCall(toolCall tools.ToolCall, tool tools.Tool, agentName string)
+	EmitToolCallResponse(toolCallID string, tool tools.Tool, result *tools.ToolCallResult, output, agentName string)
+	EmitToolCallConfirmation(toolCall tools.ToolCall, tool tools.Tool, agentName string)
+	EmitHookBlocked(toolCall tools.ToolCall, tool tools.Tool, message, agentName string)
+	EmitMessageAdded(sessionID string, msg *session.Message, agentName string)
+}
+
+// HookDispatcher abstracts pre/post tool-use hook dispatch and the
+// "user is being prompted" notification.
+type HookDispatcher interface {
+	// Dispatch fires a tool-related hook (typically [hooks.EventPreToolUse]
+	// or [hooks.EventPostToolUse]).  Return nil when no hook is configured
+	// or dispatch failed: the dispatcher treats nil uniformly as
+	// "carry on with the original call". SystemMessage emission is the
+	// implementation's responsibility.
+	Dispatch(ctx context.Context, a *agent.Agent, event hooks.EventType, in *hooks.Input) *hooks.Result
+
+	// NotifyUserInput is invoked just before the dispatcher blocks waiting
+	// for the user (tool confirmation). Implementations typically fire
+	// [hooks.EventOnUserInput].
+	NotifyUserInput(ctx context.Context, sessionID, label string)
+
+	// NotifyApprovalDecision is invoked once per tool call after the
+	// approval pipeline (auto-allow, deny, user confirmation, ...) has
+	// resolved a verdict. Implementations typically fire
+	// [hooks.EventOnToolApprovalDecision] with decision and source set
+	// to the supplied strings (see ApprovalDecision* / ApprovalSource*
+	// constants).
+	NotifyApprovalDecision(ctx context.Context, sess *session.Session, a *agent.Agent, tc tools.ToolCall, decision, source string)
+}
+
+// ToolHandler is the signature for runtime-managed tool handlers
+// (e.g. transfer_task, handoff, change_model). Handlers receive the
+// parsed call and return the result.
+//
+// The dispatcher wraps every handler in the same tracing/telemetry/event-
+// emission pipeline used for ordinary toolset tools, so handlers MUST NOT
+// emit ToolCall/ToolCallResponse themselves. Handlers that need to emit
+// additional runtime-specific events (e.g. an agent-info event after a
+// model change) should be wired by the caller to capture the relevant
+// channel via closure when registering the handler.
+type ToolHandler func(ctx context.Context, sess *session.Session, tc tools.ToolCall) (*tools.ToolCallResult, error)
+
+// ResumeRequest carries the user's response to a tool-confirmation prompt.
+// The runtime aliases this type publicly via runtime.ResumeRequest so the
+// dispatcher and the runtime share one definition.
+type ResumeRequest struct {
+	Type     ResumeType
+	Reason   string // Optional; primarily used with [ResumeTypeReject]
+	ToolName string // Optional; used with [ResumeTypeApproveTool]
+}
+
+// ResumeType identifies the kind of confirmation a user responded with.
+type ResumeType string
+
+const (
+	ResumeTypeApprove        ResumeType = "approve"
+	ResumeTypeApproveSession ResumeType = "approve-session"
+	ResumeTypeApproveTool    ResumeType = "approve-tool"
+	ResumeTypeReject         ResumeType = "reject"
+)
+
+// Dispatcher executes batches of tool calls. Construct one per runtime
+// and call [Dispatcher.Process] for each LLM response. The dispatcher is
+// goroutine-safe only insofar as its dependencies are.
+type Dispatcher struct {
+	// Tracer records per-call spans. May be nil (no-op tracing).
+	Tracer trace.Tracer
+
+	// Hooks dispatches pre/post tool-use hooks. May be nil for runtimes
+	// without hook support; in that case every call runs unchanged.
+	Hooks HookDispatcher
+
+	// Resume receives user-confirmation responses. Must be set; the
+	// dispatcher blocks on it whenever a tool requires confirmation.
+	Resume <-chan ResumeRequest
+
+	// AgentFor returns the active agent for a session. Required.
+	AgentFor func(*session.Session) *agent.Agent
+
+	// Permissions returns the ordered list of permission checkers for a
+	// session (typically session-level first, then team-level).
+	Permissions func(*session.Session) []NamedChecker
+
+	// Handlers maps tool names to runtime-managed handlers (transfer_task,
+	// handoff, change_model, ...). Tools not in this map are routed to
+	// their toolset Handler.
+	Handlers map[string]ToolHandler
+}
+
+// Process runs every tool call in calls in order, emitting events through
+// em.
+//
+// Returns (stopRun, message) when a post_tool_use hook signalled a
+// terminating verdict during this batch; the run loop then fans out the
+// standard Error / notification / on_error stanzas before exiting.
+// (false, "") in every other path — including user cancellation, which
+// halts the *batch* but keeps the loop alive so the synthesised tool
+// error responses can be sent back to the model on the next turn.
+func (d *Dispatcher) Process(ctx context.Context, sess *session.Session, calls []tools.ToolCall, agentTools []tools.Tool, em Emitter) (stopRun bool, stopMessage string) {
+	a := d.AgentFor(sess)
+	slog.Debug("Processing tool calls", "agent", a.Name(), "call_count", len(calls))
+
+	agentToolMap := make(map[string]tools.Tool, len(agentTools))
+	for _, t := range agentTools {
+		agentToolMap[t.Name] = t
+	}
+
+	// synthesizeRemaining adds error responses for tool calls we won't
+	// run because the batch was halted (user cancellation or post-tool
+	// stopRun). Orphan function calls without matching outputs are
+	// rejected by the Responses API, so we surface them as errors
+	// rather than dropping them.
+	synthesizeRemaining := func(remaining []tools.ToolCall, reason string) {
+		for _, tc := range remaining {
+			d.addToolErrorResponse(sess, tc, agentToolMap[tc.Function.Name], em, a, reason)
+		}
+	}
+
+	for i, toolCall := range calls {
+		callCtx, callSpan := d.startSpan(ctx, "runtime.tool.call", trace.WithAttributes(
+			attribute.String("tool.name", toolCall.Function.Name),
+			attribute.String("tool.type", string(toolCall.Type)),
+			attribute.String("agent", a.Name()),
+			attribute.String("session.id", sess.ID),
+			attribute.String("tool.call_id", toolCall.ID),
+		))
+
+		slog.Debug("Processing tool call", "agent", a.Name(), "tool", toolCall.Function.Name, "session_id", sess.ID)
+
+		// Resolve the tool: it must be in the agent's tool set to be callable.
+		// After a handoff the model may hallucinate tools it saw in the
+		// conversation history from a previous agent; rejecting unknown
+		// tools with an error response lets it self-correct.
+		tool, available := agentToolMap[toolCall.Function.Name]
+		if !available {
+			slog.Warn("Tool call for unavailable tool", "agent", a.Name(), "tool", toolCall.Function.Name, "session_id", sess.ID)
+			errTool := tools.Tool{Name: toolCall.Function.Name}
+			d.addToolErrorResponse(sess, toolCall, errTool, em, a, fmt.Sprintf("Tool '%s' is not available. You can only use the tools provided to you.", toolCall.Function.Name))
+			callSpan.SetStatus(codes.Error, "tool not available")
+			callSpan.End()
+			continue
+		}
+
+		// Pick the handler: runtime-managed tools (transfer_task, handoff)
+		// have dedicated handlers; everything else goes through the toolset.
+		// Runtime-managed handlers skip pre/post hooks; toolset tools go
+		// through the hook-aware path and may produce a stopRun outcome.
+		var runTool func() CallOutcome
+		if handler, exists := d.Handlers[toolCall.Function.Name]; exists {
+			runTool = func() CallOutcome {
+				d.runHandlerTool(callCtx, handler, sess, toolCall, tool, em, a)
+				return CallOutcome{}
+			}
+		} else {
+			runTool = func() CallOutcome {
+				return d.runToolsetTool(callCtx, tool, toolCall, em, sess, a)
+			}
+		}
+
+		outcome := d.executeWithApproval(callCtx, sess, toolCall, tool, em, a, runTool)
+
+		if outcome.Canceled {
+			callSpan.SetStatus(codes.Ok, "tool call canceled by user")
+		} else {
+			callSpan.SetStatus(codes.Ok, "tool call processed")
+		}
+		callSpan.End()
+
+		switch {
+		case outcome.Canceled:
+			synthesizeRemaining(calls[i+1:],
+				"The tool call was canceled because a previous tool call in the same batch was canceled by the user.")
+			return false, ""
+		case outcome.StopRun:
+			synthesizeRemaining(calls[i+1:],
+				"The tool call was skipped because a post_tool_use hook signalled run termination.")
+			return true, outcome.StopMessage
+		}
+	}
+	return false, ""
+}
+
+// executeWithApproval handles the tool approval flow and executes the tool.
+//
+// The approval flow is fully resolved by [Decide]; this function only
+// translates the resulting decision into runtime side effects (run,
+// deny-with-error-response, ask-and-wait) and forwards the decision to
+// [HookDispatcher.NotifyApprovalDecision] for hook tracking.
+func (d *Dispatcher) executeWithApproval(
+	ctx context.Context,
+	sess *session.Session,
+	toolCall tools.ToolCall,
+	tool tools.Tool,
+	em Emitter,
+	a *agent.Agent,
+	runTool func() CallOutcome,
+) CallOutcome {
+	toolName := toolCall.Function.Name
+
+	decision := Decide(
+		sess.ToolsApproved,
+		d.permissionsFor(sess),
+		toolName,
+		ParseToolInput(toolCall.Function.Arguments),
+		tool.Annotations.ReadOnlyHint,
+	)
+
+	switch decision.Outcome {
+	case OutcomeAllow:
+		logAllow(decision, toolName, sess.ID)
+		d.notifyApproval(ctx, sess, a, toolCall, ApprovalDecisionAllow, allowSourceForDecision(decision))
+		return runTool()
+	case OutcomeDeny:
+		slog.Debug("Tool denied by permissions", "tool", toolName, "source", decision.Source, "session_id", sess.ID)
+		d.notifyApproval(ctx, sess, a, toolCall, ApprovalDecisionDeny, denySourceForChecker(decision.Source))
+		d.addToolErrorResponse(sess, toolCall, tool, em, a, fmt.Sprintf("Tool '%s' is denied by %s.", toolName, decision.Source))
+		return CallOutcome{}
+	case OutcomeAsk:
+		if decision.Reason == ReasonChecker {
+			slog.Debug("Tool requires confirmation (ask pattern)", "tool", toolName, "source", decision.Source, "session_id", sess.ID)
+		}
+		return d.askUserForConfirmation(ctx, sess, toolCall, tool, em, a, runTool)
+	}
+	return CallOutcome{}
+}
+
+// permissionsFor returns the ordered checkers for sess, or nil when none
+// are configured. Centralizing the nil-guard keeps callers terse.
+func (d *Dispatcher) permissionsFor(sess *session.Session) []NamedChecker {
+	if d.Permissions == nil {
+		return nil
+	}
+	return d.Permissions(sess)
+}
+
+// notifyApproval forwards the resolved approval decision to the
+// HookDispatcher, when one is configured. Centralised so the nil-guard
+// stays in one place.
+func (d *Dispatcher) notifyApproval(ctx context.Context, sess *session.Session, a *agent.Agent, tc tools.ToolCall, decision, source string) {
+	if d.Hooks == nil {
+		return
+	}
+	d.Hooks.NotifyApprovalDecision(ctx, sess, a, tc, decision, source)
+}
+
+// allowSourceForDecision maps a [PermissionDecision] with [OutcomeAllow]
+// onto the corresponding ApprovalSource* constant.
+func allowSourceForDecision(d PermissionDecision) string {
+	switch d.Reason {
+	case ReasonYolo:
+		return ApprovalSourceYolo
+	case ReasonReadOnlyHint:
+		return ApprovalSourceReadOnlyHint
+	case ReasonChecker:
+		return allowSourceForChecker(d.Source)
+	}
+	return allowSourceForChecker(d.Source)
+}
+
+// allowSourceForChecker maps a checker source label ("session permissions"
+// or "permissions configuration") onto the corresponding ApprovalSource*
+// allow constant.
+func allowSourceForChecker(checkerSource string) string {
+	if checkerSource == "session permissions" {
+		return ApprovalSourceSessionPermissionsAllow
+	}
+	return ApprovalSourceTeamPermissionsAllow
+}
+
+// denySourceForChecker mirrors allowSourceForChecker for the deny path.
+func denySourceForChecker(checkerSource string) string {
+	if checkerSource == "session permissions" {
+		return ApprovalSourceSessionPermissionsDeny
+	}
+	return ApprovalSourceTeamPermissionsDeny
+}
+
+// logAllow emits the auto-approval debug log appropriate to the reason
+// (--yolo, an explicit checker rule, or the read-only hint).
+func logAllow(decision PermissionDecision, toolName, sessionID string) {
+	switch decision.Reason {
+	case ReasonYolo:
+		slog.Debug("Tool auto-approved by --yolo flag", "tool", toolName, "session_id", sessionID)
+	case ReasonChecker:
+		slog.Debug("Tool auto-approved by permissions", "tool", toolName, "source", decision.Source, "session_id", sessionID)
+		// ReasonReadOnlyHint is intentionally silent (matches prior behaviour).
+	}
+}
+
+// askUserForConfirmation sends a confirmation event and waits for user
+// response. Only called when no permission rule auto-approved the tool.
+func (d *Dispatcher) askUserForConfirmation(
+	ctx context.Context,
+	sess *session.Session,
+	toolCall tools.ToolCall,
+	tool tools.Tool,
+	em Emitter,
+	a *agent.Agent,
+	runTool func() CallOutcome,
+) CallOutcome {
+	toolName := toolCall.Function.Name
+	slog.Debug("Tools not approved, waiting for resume", "tool", toolName, "session_id", sess.ID)
+	em.EmitToolCallConfirmation(toolCall, tool, a.Name())
+
+	if d.Hooks != nil {
+		d.Hooks.NotifyUserInput(ctx, sess.ID, "tool confirmation")
+	}
+
+	select {
+	case req := <-d.Resume:
+		switch req.Type {
+		case ResumeTypeApprove:
+			slog.Debug("Resume signal received, approving tool", "tool", toolName, "session_id", sess.ID)
+			d.notifyApproval(ctx, sess, a, toolCall, ApprovalDecisionAllow, ApprovalSourceUserApproved)
+			return runTool()
+		case ResumeTypeApproveSession:
+			slog.Debug("Resume signal received, approving session", "tool", toolName, "session_id", sess.ID)
+			sess.ToolsApproved = true
+			d.notifyApproval(ctx, sess, a, toolCall, ApprovalDecisionAllow, ApprovalSourceUserApprovedSession)
+			return runTool()
+		case ResumeTypeApproveTool:
+			// Add the tool to session's allow list for future auto-approval.
+			approvedTool := req.ToolName
+			if approvedTool == "" {
+				approvedTool = toolName
+			}
+			if sess.Permissions == nil {
+				sess.Permissions = &session.PermissionsConfig{}
+			}
+			if !slices.Contains(sess.Permissions.Allow, approvedTool) {
+				sess.Permissions.Allow = append(sess.Permissions.Allow, approvedTool)
+			}
+			slog.Debug("Resume signal received, approving tool permanently", "tool", approvedTool, "session_id", sess.ID)
+			d.notifyApproval(ctx, sess, a, toolCall, ApprovalDecisionAllow, ApprovalSourceUserApprovedTool)
+			return runTool()
+		case ResumeTypeReject:
+			slog.Debug("Resume signal received, rejecting tool", "tool", toolName, "session_id", sess.ID, "reason", req.Reason)
+			d.notifyApproval(ctx, sess, a, toolCall, ApprovalDecisionDeny, ApprovalSourceUserRejected)
+			rejectMsg := "The user rejected the tool call."
+			if strings.TrimSpace(req.Reason) != "" {
+				rejectMsg += " Reason: " + strings.TrimSpace(req.Reason)
+			}
+			d.addToolErrorResponse(sess, toolCall, tool, em, a, rejectMsg)
+		}
+		return CallOutcome{}
+	case <-ctx.Done():
+		slog.Debug("Context cancelled while waiting for resume", "tool", toolName, "session_id", sess.ID)
+		d.notifyApproval(ctx, sess, a, toolCall, ApprovalDecisionCanceled, ApprovalSourceContextCanceled)
+		d.addToolErrorResponse(sess, toolCall, tool, em, a, "The tool call was canceled by the user.")
+		return CallOutcome{Canceled: true}
+	}
+}
+
+// executeToolWithHandler is the common pipeline shared by toolset tools and
+// runtime-managed handlers: tracing, event emission, telemetry, error
+// translation, and session message persistence.
+func (d *Dispatcher) executeToolWithHandler(
+	ctx context.Context,
+	toolCall tools.ToolCall,
+	tool tools.Tool,
+	em Emitter,
+	sess *session.Session,
+	a *agent.Agent,
+	spanName string,
+	execute func(ctx context.Context) (*tools.ToolCallResult, time.Duration, error),
+) *tools.ToolCallResult {
+	ctx, span := d.startSpan(ctx, spanName, trace.WithAttributes(
+		attribute.String("tool.name", toolCall.Function.Name),
+		attribute.String("agent", a.Name()),
+		attribute.String("session.id", sess.ID),
+		attribute.String("tool.call_id", toolCall.ID),
+	))
+	defer span.End()
+
+	em.EmitToolCall(toolCall, tool, a.Name())
+
+	res, duration, err := execute(ctx)
+
+	telemetry.RecordToolCall(ctx, toolCall.Function.Name, sess.ID, a.Name(), duration, err)
+
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
+			slog.Debug("Tool handler canceled by context", "tool", toolCall.Function.Name, "agent", a.Name(), "session_id", sess.ID)
+			res = tools.ResultError("The tool call was canceled by the user.")
+			span.SetStatus(codes.Ok, "tool handler canceled by user")
+		} else {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "tool handler error")
+			slog.Error("Error calling tool", "tool", toolCall.Function.Name, "error", err)
+			res = tools.ResultError(fmt.Sprintf("Error calling tool: %v", err))
+		}
+	} else {
+		span.SetStatus(codes.Ok, "tool handler completed")
+		slog.Debug("Tool call completed", "tool", toolCall.Function.Name, "output_length", len(res.Output))
+	}
+
+	em.EmitToolCallResponse(toolCall.ID, tool, res, res.Output, a.Name())
+
+	// Ensure tool response content is not empty for API compatibility.
+	content := res.Output
+	if strings.TrimSpace(content) == "" {
+		content = "(no output)"
+	}
+
+	toolResponseMsg := chat.Message{
+		Role:       chat.MessageRoleTool,
+		Content:    content,
+		ToolCallID: toolCall.ID,
+		IsError:    res.IsError,
+		CreatedAt:  time.Now().Format(time.RFC3339),
+	}
+
+	// If the tool result contains images, attach them as MultiContent.
+	if len(res.Images) > 0 {
+		multiContent := []chat.MessagePart{
+			{Type: chat.MessagePartTypeText, Text: content},
+		}
+		for _, img := range res.Images {
+			multiContent = append(multiContent, chat.MessagePart{
+				Type: chat.MessagePartTypeImageURL,
+				ImageURL: &chat.MessageImageURL{
+					URL:    "data:" + img.MimeType + ";base64," + img.Data,
+					Detail: chat.ImageURLDetailAuto,
+				},
+			})
+		}
+		toolResponseMsg.MultiContent = multiContent
+	}
+
+	addAgentMessage(sess, a, &toolResponseMsg, em)
+	return res
+}
+
+// runToolsetTool executes a tool from an agent's toolset (MCP, filesystem, ...).
+// Returns a [CallOutcome] whose StopRun/StopMessage fields reflect any
+// post_tool_use deny verdict; Canceled stays false (user cancellation
+// only happens during the approval flow, before this).
+func (d *Dispatcher) runToolsetTool(ctx context.Context, tool tools.Tool, toolCall tools.ToolCall, em Emitter, sess *session.Session, a *agent.Agent) CallOutcome {
+	// Pre-tool hook: may block the call or rewrite its arguments.
+	blocked, toolCall := d.preHook(ctx, sess, toolCall, tool, em, a)
+	if blocked {
+		return CallOutcome{}
+	}
+
+	res := d.executeToolWithHandler(ctx, toolCall, tool, em, sess, a, "runtime.tool.handler",
+		func(ctx context.Context) (*tools.ToolCallResult, time.Duration, error) {
+			res, err := tool.Handler(ctx, toolCall)
+			return res, 0, err
+		})
+
+	// Post-tool hook: SystemMessage is surfaced by the HookDispatcher
+	// implementation; a terminating verdict (decision="block" /
+	// continue=false / exit 2) is propagated to the run loop via
+	// CallOutcome.
+	stop, msg := d.postHook(ctx, sess, toolCall, res, a)
+	return CallOutcome{StopRun: stop, StopMessage: msg}
+}
+
+// runHandlerTool executes a runtime-managed tool handler.
+func (d *Dispatcher) runHandlerTool(ctx context.Context, handler ToolHandler, sess *session.Session, toolCall tools.ToolCall, tool tools.Tool, em Emitter, a *agent.Agent) {
+	d.executeToolWithHandler(ctx, toolCall, tool, em, sess, a, "runtime.tool.handler.runtime",
+		func(ctx context.Context) (*tools.ToolCallResult, time.Duration, error) {
+			start := time.Now()
+			res, err := handler(ctx, sess, toolCall)
+			return res, time.Since(start), err
+		})
+}
+
+// preHook fires the pre-tool-use hook and reports whether the tool call
+// was blocked (along with the possibly modified call when allowed).
+func (d *Dispatcher) preHook(
+	ctx context.Context,
+	sess *session.Session,
+	toolCall tools.ToolCall,
+	tool tools.Tool,
+	em Emitter,
+	a *agent.Agent,
+) (blocked bool, modifiedTC tools.ToolCall) {
+	if d.Hooks == nil {
+		return false, toolCall
+	}
+
+	// Dispatch returns nil when no hook is configured, the agent is
+	// missing, or dispatch failed — in every case the right move is to
+	// run the tool unchanged.
+	result := d.Hooks.Dispatch(ctx, a, hooks.EventPreToolUse, NewHooksInput(sess, toolCall))
+	if result == nil {
+		return false, toolCall
+	}
+
+	if !result.Allowed {
+		slog.Debug("Pre-tool hook blocked tool call", "tool", toolCall.Function.Name, "message", result.Message)
+		em.EmitHookBlocked(toolCall, tool, result.Message, a.Name())
+		d.addToolErrorResponse(sess, toolCall, tool, em, a, "Tool call blocked by hook: "+result.Message)
+		return true, toolCall
+	}
+
+	if result.ModifiedInput != nil {
+		if updated, merr := json.Marshal(result.ModifiedInput); merr != nil {
+			slog.Warn("Failed to marshal modified tool input from hook", "tool", toolCall.Function.Name, "error", merr)
+		} else {
+			slog.Debug("Pre-tool hook modified tool input", "tool", toolCall.Function.Name)
+			toolCall.Function.Arguments = string(updated)
+		}
+	}
+	return false, toolCall
+}
+
+// postHook fires the post-tool-use hook. SystemMessage emission is the
+// [HookDispatcher]'s responsibility. A terminating verdict
+// (decision="block" / continue=false / exit 2) is propagated via the
+// (stop, message) return.
+func (d *Dispatcher) postHook(ctx context.Context, sess *session.Session, toolCall tools.ToolCall, res *tools.ToolCallResult, a *agent.Agent) (stop bool, message string) {
+	if d.Hooks == nil {
+		return false, ""
+	}
+	result := d.Hooks.Dispatch(ctx, a, hooks.EventPostToolUse, NewPostToolHooksInput(sess, toolCall, res))
+	if result == nil || result.Allowed {
+		return false, ""
+	}
+	return true, result.Message
+}
+
+// addToolErrorResponse appends an error tool-response to the session and
+// emits the corresponding events. Consolidates the pattern shared by
+// validation, rejection, and cancellation responses.
+func (d *Dispatcher) addToolErrorResponse(sess *session.Session, toolCall tools.ToolCall, tool tools.Tool, em Emitter, a *agent.Agent, errorMsg string) {
+	em.EmitToolCallResponse(toolCall.ID, tool, tools.ResultError(errorMsg), errorMsg, a.Name())
+
+	toolResponseMsg := chat.Message{
+		Role:       chat.MessageRoleTool,
+		Content:    errorMsg,
+		ToolCallID: toolCall.ID,
+		IsError:    true,
+		CreatedAt:  time.Now().Format(time.RFC3339),
+	}
+	addAgentMessage(sess, a, &toolResponseMsg, em)
+}
+
+// addAgentMessage records a chat message to the session and emits the
+// resulting [*session.Message] via the [Emitter].
+func addAgentMessage(sess *session.Session, a *agent.Agent, msg *chat.Message, em Emitter) {
+	agentMsg := session.NewAgentMessage(a.Name(), msg)
+	sess.AddMessage(agentMsg)
+	em.EmitMessageAdded(sess.ID, agentMsg, a.Name())
+}
+
+// startSpan wraps Tracer.Start; a nil tracer is a no-op so callers don't
+// need a guard.
+func (d *Dispatcher) startSpan(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	if d.Tracer == nil {
+		return ctx, trace.SpanFromContext(ctx)
+	}
+	return d.Tracer.Start(ctx, name, opts...)
+}

--- a/pkg/runtime/toolexec/dispatcher_test.go
+++ b/pkg/runtime/toolexec/dispatcher_test.go
@@ -1,0 +1,360 @@
+package toolexec_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/runtime/toolexec"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+// captureEmitter records every event the dispatcher emits, in order, so
+// tests can make precise assertions about the dispatch flow. A confirm
+// channel signals when a confirmation event lands so cancellation tests
+// don't need to busy-wait.
+type captureEmitter struct {
+	calls         []tools.ToolCall
+	responses     []responseRecord
+	confirmations []tools.ToolCall
+	hookBlocks    []hookBlockRecord
+	messages      []*session.Message
+	confirmed     chan struct{} // optional; closed after the first confirmation event
+}
+
+type responseRecord struct {
+	ToolCallID string
+	Output     string
+	IsError    bool
+}
+
+type hookBlockRecord struct {
+	ToolCall tools.ToolCall
+	Message  string
+}
+
+func (e *captureEmitter) EmitToolCall(tc tools.ToolCall, _ tools.Tool, _ string) {
+	e.calls = append(e.calls, tc)
+}
+
+func (e *captureEmitter) EmitToolCallResponse(toolCallID string, _ tools.Tool, result *tools.ToolCallResult, output, _ string) {
+	e.responses = append(e.responses, responseRecord{
+		ToolCallID: toolCallID,
+		Output:     output,
+		IsError:    result.IsError,
+	})
+}
+
+func (e *captureEmitter) EmitToolCallConfirmation(tc tools.ToolCall, _ tools.Tool, _ string) {
+	e.confirmations = append(e.confirmations, tc)
+	if e.confirmed != nil {
+		select {
+		case <-e.confirmed:
+			// already closed
+		default:
+			close(e.confirmed)
+		}
+	}
+}
+
+func (e *captureEmitter) EmitHookBlocked(tc tools.ToolCall, _ tools.Tool, message, _ string) {
+	e.hookBlocks = append(e.hookBlocks, hookBlockRecord{ToolCall: tc, Message: message})
+}
+
+func (e *captureEmitter) EmitMessageAdded(_ string, msg *session.Message, _ string) {
+	e.messages = append(e.messages, msg)
+}
+
+func newAgent() *agent.Agent {
+	return agent.New("test", "test agent")
+}
+
+func TestDispatcher_RoutesToToolsetHandler(t *testing.T) {
+	a := newAgent()
+	sess := session.New()
+	sess.ToolsApproved = true // skip approval so we exercise the happy path
+
+	var handlerCalls int
+	tool := tools.Tool{
+		Name: "echo",
+		Handler: func(_ context.Context, tc tools.ToolCall) (*tools.ToolCallResult, error) {
+			handlerCalls++
+			return tools.ResultSuccess("hello " + tc.Function.Arguments), nil
+		},
+	}
+
+	d := &toolexec.Dispatcher{
+		AgentFor: func(*session.Session) *agent.Agent { return a },
+	}
+	em := &captureEmitter{}
+
+	d.Process(t.Context(), sess, []tools.ToolCall{{
+		ID:       "call_1",
+		Function: tools.FunctionCall{Name: "echo", Arguments: `{"x":1}`},
+	}}, []tools.Tool{tool}, em)
+
+	assert.Equal(t, 1, handlerCalls)
+	require.Len(t, em.responses, 1)
+	assert.Equal(t, `hello {"x":1}`, em.responses[0].Output)
+	assert.False(t, em.responses[0].IsError)
+}
+
+func TestDispatcher_RoutesToRuntimeHandler(t *testing.T) {
+	a := newAgent()
+	sess := session.New()
+	sess.ToolsApproved = true
+
+	var handlerCalls int
+	d := &toolexec.Dispatcher{
+		AgentFor: func(*session.Session) *agent.Agent { return a },
+		Handlers: map[string]toolexec.ToolHandler{
+			"transfer_task": func(_ context.Context, _ *session.Session, _ tools.ToolCall) (*tools.ToolCallResult, error) {
+				handlerCalls++
+				return tools.ResultSuccess("transferred"), nil
+			},
+		},
+	}
+	em := &captureEmitter{}
+
+	// Toolset handler must NOT be called when a runtime handler is registered
+	// for the same name.
+	tool := tools.Tool{
+		Name: "transfer_task",
+		Handler: func(context.Context, tools.ToolCall) (*tools.ToolCallResult, error) {
+			t.Fatal("toolset handler must not be called when runtime handler exists")
+			return nil, nil
+		},
+	}
+
+	d.Process(t.Context(), sess, []tools.ToolCall{{
+		ID:       "call_t",
+		Function: tools.FunctionCall{Name: "transfer_task", Arguments: "{}"},
+	}}, []tools.Tool{tool}, em)
+
+	assert.Equal(t, 1, handlerCalls)
+	require.Len(t, em.responses, 1)
+	assert.Equal(t, "transferred", em.responses[0].Output)
+}
+
+func TestDispatcher_UnknownToolEmitsErrorResponse(t *testing.T) {
+	a := newAgent()
+	sess := session.New()
+
+	d := &toolexec.Dispatcher{
+		AgentFor: func(*session.Session) *agent.Agent { return a },
+	}
+	em := &captureEmitter{}
+
+	d.Process(t.Context(), sess, []tools.ToolCall{{
+		ID:       "ghost",
+		Function: tools.FunctionCall{Name: "non_existent", Arguments: "{}"},
+	}}, []tools.Tool{}, em)
+
+	require.Len(t, em.responses, 1)
+	assert.Equal(t, "ghost", em.responses[0].ToolCallID)
+	assert.True(t, em.responses[0].IsError)
+	assert.Contains(t, em.responses[0].Output, "not available")
+}
+
+func TestDispatcher_UserCancellationStopsBatchAndSynthesizesRemaining(t *testing.T) {
+	a := newAgent()
+	sess := session.New()
+
+	resume := make(chan toolexec.ResumeRequest, 1)
+	d := &toolexec.Dispatcher{
+		AgentFor: func(*session.Session) *agent.Agent { return a },
+		Resume:   resume,
+	}
+	em := &captureEmitter{confirmed: make(chan struct{})}
+
+	tool := tools.Tool{
+		Name:    "shell",
+		Handler: func(context.Context, tools.ToolCall) (*tools.ToolCallResult, error) { panic("must not run") },
+	}
+
+	// Cancel as soon as the dispatcher asks for confirmation on the first
+	// call. The remaining two calls in the batch must receive synthetic
+	// error responses so the conversation history stays consistent (the
+	// Responses API rejects orphaned tool calls).
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	go func() {
+		<-em.confirmed
+		cancel()
+	}()
+
+	calls := []tools.ToolCall{
+		{ID: "a", Function: tools.FunctionCall{Name: "shell", Arguments: "{}"}},
+		{ID: "b", Function: tools.FunctionCall{Name: "shell", Arguments: "{}"}},
+		{ID: "c", Function: tools.FunctionCall{Name: "shell", Arguments: "{}"}},
+	}
+	d.Process(ctx, sess, calls, []tools.Tool{tool}, em)
+
+	require.Len(t, em.responses, 3, "every call must produce a response")
+	for _, r := range em.responses {
+		assert.True(t, r.IsError, "every cancelled call must surface as an error response")
+	}
+	assert.Contains(t, em.responses[0].Output, "canceled by the user")
+	assert.Contains(t, em.responses[1].Output, "previous tool call")
+	assert.Contains(t, em.responses[2].Output, "previous tool call")
+}
+
+func TestDispatcher_ResumeApproveRunsTool(t *testing.T) {
+	a := newAgent()
+	sess := session.New()
+
+	var ran bool
+	tool := tools.Tool{
+		Name: "shell",
+		Handler: func(context.Context, tools.ToolCall) (*tools.ToolCallResult, error) {
+			ran = true
+			return tools.ResultSuccess("done"), nil
+		},
+	}
+
+	resume := make(chan toolexec.ResumeRequest, 1)
+	d := &toolexec.Dispatcher{
+		AgentFor: func(*session.Session) *agent.Agent { return a },
+		Resume:   resume,
+	}
+	em := &captureEmitter{}
+
+	// Pre-approve via the resume channel before invoking Process.
+	resume <- toolexec.ResumeRequest{Type: toolexec.ResumeTypeApprove}
+
+	d.Process(t.Context(), sess, []tools.ToolCall{{
+		ID:       "x",
+		Function: tools.FunctionCall{Name: "shell", Arguments: "{}"},
+	}}, []tools.Tool{tool}, em)
+
+	assert.True(t, ran)
+	require.Len(t, em.responses, 1)
+	assert.False(t, em.responses[0].IsError)
+	assert.Equal(t, "done", em.responses[0].Output)
+}
+
+func TestDispatcher_ResumeRejectEmitsErrorResponseWithReason(t *testing.T) {
+	a := newAgent()
+	sess := session.New()
+
+	tool := tools.Tool{
+		Name:    "shell",
+		Handler: func(context.Context, tools.ToolCall) (*tools.ToolCallResult, error) { panic("must not run") },
+	}
+
+	resume := make(chan toolexec.ResumeRequest, 1)
+	d := &toolexec.Dispatcher{
+		AgentFor: func(*session.Session) *agent.Agent { return a },
+		Resume:   resume,
+	}
+	em := &captureEmitter{}
+
+	resume <- toolexec.ResumeRequest{Type: toolexec.ResumeTypeReject, Reason: "wrong arguments"}
+
+	d.Process(t.Context(), sess, []tools.ToolCall{{
+		ID:       "x",
+		Function: tools.FunctionCall{Name: "shell", Arguments: "{}"},
+	}}, []tools.Tool{tool}, em)
+
+	require.Len(t, em.responses, 1)
+	assert.True(t, em.responses[0].IsError)
+	assert.Contains(t, em.responses[0].Output, "user rejected")
+	assert.Contains(t, em.responses[0].Output, "wrong arguments")
+}
+
+func TestDispatcher_ResumeApproveToolPersistsToSessionPermissions(t *testing.T) {
+	a := newAgent()
+	sess := session.New()
+
+	var ran bool
+	tool := tools.Tool{
+		Name: "shell",
+		Handler: func(context.Context, tools.ToolCall) (*tools.ToolCallResult, error) {
+			ran = true
+			return tools.ResultSuccess("ok"), nil
+		},
+	}
+
+	resume := make(chan toolexec.ResumeRequest, 1)
+	d := &toolexec.Dispatcher{
+		AgentFor: func(*session.Session) *agent.Agent { return a },
+		Resume:   resume,
+	}
+	em := &captureEmitter{}
+
+	resume <- toolexec.ResumeRequest{Type: toolexec.ResumeTypeApproveTool, ToolName: "shell"}
+
+	d.Process(t.Context(), sess, []tools.ToolCall{{
+		ID:       "x",
+		Function: tools.FunctionCall{Name: "shell", Arguments: "{}"},
+	}}, []tools.Tool{tool}, em)
+
+	assert.True(t, ran)
+	require.NotNil(t, sess.Permissions, "approve-tool must seed session permissions")
+	assert.Contains(t, sess.Permissions.Allow, "shell")
+}
+
+func TestDispatcher_ReadOnlyHintAutoApproves(t *testing.T) {
+	a := newAgent()
+	sess := session.New() // ToolsApproved=false; no permissions configured
+
+	var ran bool
+	tool := tools.Tool{
+		Name: "read_file",
+		Annotations: tools.ToolAnnotations{
+			ReadOnlyHint: true,
+		},
+		Handler: func(context.Context, tools.ToolCall) (*tools.ToolCallResult, error) {
+			ran = true
+			return tools.ResultSuccess("contents"), nil
+		},
+	}
+
+	d := &toolexec.Dispatcher{
+		AgentFor: func(*session.Session) *agent.Agent { return a },
+	}
+	em := &captureEmitter{}
+
+	d.Process(t.Context(), sess, []tools.ToolCall{{
+		ID:       "r",
+		Function: tools.FunctionCall{Name: "read_file", Arguments: "{}"},
+	}}, []tools.Tool{tool}, em)
+
+	assert.True(t, ran)
+	assert.Empty(t, em.confirmations, "read-only tool must not prompt the user")
+	require.Len(t, em.responses, 1)
+	assert.False(t, em.responses[0].IsError)
+}
+
+func TestDispatcher_DenyByPermissionsEmitsErrorResponse(t *testing.T) {
+	a := newAgent()
+	sess := session.New()
+
+	tool := tools.Tool{
+		Name:    "shell",
+		Handler: func(context.Context, tools.ToolCall) (*tools.ToolCallResult, error) { panic("must not run") },
+	}
+
+	d := &toolexec.Dispatcher{
+		AgentFor: func(*session.Session) *agent.Agent { return a },
+		Permissions: func(*session.Session) []toolexec.NamedChecker {
+			return []toolexec.NamedChecker{
+				{Checker: newDenyChecker("shell"), Source: "test policy"},
+			}
+		},
+	}
+	em := &captureEmitter{}
+
+	d.Process(t.Context(), sess, []tools.ToolCall{{
+		ID:       "x",
+		Function: tools.FunctionCall{Name: "shell", Arguments: "{}"},
+	}}, []tools.Tool{tool}, em)
+
+	require.Len(t, em.responses, 1)
+	assert.True(t, em.responses[0].IsError)
+	assert.Contains(t, em.responses[0].Output, "denied by test policy")
+}

--- a/pkg/runtime/toolexec/doc.go
+++ b/pkg/runtime/toolexec/doc.go
@@ -1,0 +1,17 @@
+// Package toolexec hosts utilities used by the runtime to execute tool
+// calls. It is intentionally free of runtime-private state so its
+// primitives can be reused, tested in isolation, and incrementally
+// grown into a fully fledged tool dispatcher.
+//
+// The package currently provides:
+//
+//   - LoopDetector: detects consecutive identical tool-call batches so the
+//     runtime can break degenerate loops where the model is not making
+//     progress.
+//   - ResolveModelOverride: extracts the per-toolset model override that
+//     should apply to the next LLM turn from a batch of tool calls.
+//
+// Future extractions (approval flow, hooks dispatch, tool handler
+// registry) belong here so that the runtime keeps shrinking toward
+// pure orchestration.
+package toolexec

--- a/pkg/runtime/toolexec/helpers_test.go
+++ b/pkg/runtime/toolexec/helpers_test.go
@@ -1,0 +1,14 @@
+package toolexec_test
+
+import (
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/permissions"
+)
+
+// newDenyChecker returns a [*permissions.Checker] that denies the given
+// tool name and ignores everything else.
+func newDenyChecker(toolName string) *permissions.Checker {
+	return permissions.NewChecker(&latest.PermissionsConfig{
+		Deny: []string{toolName},
+	})
+}

--- a/pkg/runtime/toolexec/hooks_input.go
+++ b/pkg/runtime/toolexec/hooks_input.go
@@ -1,0 +1,44 @@
+package toolexec
+
+import (
+	"encoding/json"
+
+	"github.com/docker/docker-agent/pkg/hooks"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+// NewHooksInput builds a [hooks.Input] from the common tool-call fields.
+// [hooks.Executor.Dispatch] auto-fills Cwd from the executor's working
+// directory, so callers don't set it here.
+func NewHooksInput(sess *session.Session, toolCall tools.ToolCall) *hooks.Input {
+	return &hooks.Input{
+		SessionID: sess.ID,
+		ToolName:  toolCall.Function.Name,
+		ToolUseID: toolCall.ID,
+		ToolInput: ParseToolInput(toolCall.Function.Arguments),
+	}
+}
+
+// NewPostToolHooksInput builds a [hooks.Input] for the post-tool-use event.
+// It enriches the common fields built by [NewHooksInput] with the tool
+// result so post-tool-use hooks can inspect the response and error flag.
+func NewPostToolHooksInput(sess *session.Session, toolCall tools.ToolCall, res *tools.ToolCallResult) *hooks.Input {
+	input := NewHooksInput(sess, toolCall)
+	if res != nil {
+		input.ToolResponse = res.Output
+		input.ToolError = res.IsError
+	}
+	return input
+}
+
+// ParseToolInput parses a tool-call arguments JSON string into a map.
+// Invalid or empty input yields a nil map; callers that need to distinguish
+// "no arguments" from "invalid arguments" must inspect the input themselves.
+func ParseToolInput(arguments string) map[string]any {
+	var result map[string]any
+	if err := json.Unmarshal([]byte(arguments), &result); err != nil {
+		return nil
+	}
+	return result
+}

--- a/pkg/runtime/toolexec/hooks_input_test.go
+++ b/pkg/runtime/toolexec/hooks_input_test.go
@@ -1,0 +1,62 @@
+package toolexec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+func TestParseToolInput_EmptyString(t *testing.T) {
+	assert.Nil(t, ParseToolInput(""))
+}
+
+func TestParseToolInput_InvalidJSON(t *testing.T) {
+	assert.Nil(t, ParseToolInput("{not json"))
+}
+
+func TestParseToolInput_ValidJSON(t *testing.T) {
+	got := ParseToolInput(`{"path":"a.txt","mode":"r"}`)
+	assert.Equal(t, map[string]any{"path": "a.txt", "mode": "r"}, got)
+}
+
+func TestParseToolInput_EmptyObject(t *testing.T) {
+	got := ParseToolInput(`{}`)
+	assert.Equal(t, map[string]any{}, got)
+}
+
+func TestNewHooksInput_PopulatesFields(t *testing.T) {
+	sess := session.New()
+	tc := tools.ToolCall{
+		ID: "call_42",
+		Function: tools.FunctionCall{
+			Name:      "read_file",
+			Arguments: `{"path":"a.txt"}`,
+		},
+	}
+
+	in := NewHooksInput(sess, tc)
+	require.NotNil(t, in)
+	assert.Equal(t, sess.ID, in.SessionID)
+	assert.Equal(t, "read_file", in.ToolName)
+	assert.Equal(t, "call_42", in.ToolUseID)
+	assert.Equal(t, map[string]any{"path": "a.txt"}, in.ToolInput)
+}
+
+func TestNewHooksInput_InvalidArgumentsYieldsNilToolInput(t *testing.T) {
+	sess := session.New()
+	tc := tools.ToolCall{
+		ID: "call_43",
+		Function: tools.FunctionCall{
+			Name:      "noop",
+			Arguments: "",
+		},
+	}
+
+	in := NewHooksInput(sess, tc)
+	require.NotNil(t, in)
+	assert.Nil(t, in.ToolInput)
+}

--- a/pkg/runtime/toolexec/loop_detector.go
+++ b/pkg/runtime/toolexec/loop_detector.go
@@ -1,4 +1,4 @@
-package runtime
+package toolexec
 
 import (
 	"encoding/json"
@@ -9,40 +9,49 @@ import (
 	"github.com/docker/docker-agent/pkg/tools"
 )
 
-// toolLoopDetector detects consecutive identical tool call batches.
+// LoopDetector detects consecutive identical tool call batches.
 // When the model issues the same tool call(s) N times in a row without
 // making progress, the detector signals that the agent should be terminated.
-type toolLoopDetector struct {
+//
+// The zero value is not usable; callers must construct a detector with
+// [NewLoopDetector].
+type LoopDetector struct {
 	lastSignature string
 	consecutive   int
 	threshold     int
 	exemptTools   map[string]struct{}
 }
 
-// newToolLoopDetector creates a detector that triggers after threshold
+// NewLoopDetector creates a detector that triggers after threshold
 // consecutive identical call batches. Tool names passed in exemptTools
 // are polling-safe: batches composed entirely of exempt tools (e.g.
 // view_background_agent, view_background_job) never count toward the
 // consecutive-duplicate limit.
-func newToolLoopDetector(threshold int, exemptTools ...string) *toolLoopDetector {
+func NewLoopDetector(threshold int, exemptTools ...string) *LoopDetector {
 	exempt := make(map[string]struct{}, len(exemptTools))
 	for _, name := range exemptTools {
 		exempt[name] = struct{}{}
 	}
-	return &toolLoopDetector{threshold: threshold, exemptTools: exempt}
+	return &LoopDetector{threshold: threshold, exemptTools: exempt}
 }
 
-// reset clears the detector state so it can be reused after recovery.
-func (d *toolLoopDetector) reset() {
+// Consecutive returns the number of consecutive identical batches recorded
+// since the last reset (or since a non-matching batch was seen).
+func (d *LoopDetector) Consecutive() int {
+	return d.consecutive
+}
+
+// Reset clears the detector state so it can be reused after recovery.
+func (d *LoopDetector) Reset() {
 	d.lastSignature = ""
 	d.consecutive = 0
 }
 
-// record updates the detector with the latest tool call batch and returns
+// Record updates the detector with the latest tool call batch and returns
 // true if the consecutive-duplicate threshold has been reached.
 // Batches composed entirely of exempt (polling) tools are silently
 // skipped so that expected polling patterns are not flagged.
-func (d *toolLoopDetector) record(calls []tools.ToolCall) bool {
+func (d *LoopDetector) Record(calls []tools.ToolCall) bool {
 	if len(calls) == 0 {
 		return false
 	}
@@ -69,7 +78,7 @@ func (d *toolLoopDetector) record(calls []tools.ToolCall) bool {
 
 // isExemptBatch returns true when every call in the batch targets a
 // polling-exempt tool.
-func (d *toolLoopDetector) isExemptBatch(calls []tools.ToolCall) bool {
+func (d *LoopDetector) isExemptBatch(calls []tools.ToolCall) bool {
 	if len(d.exemptTools) == 0 {
 		return false
 	}

--- a/pkg/runtime/toolexec/loop_detector_test.go
+++ b/pkg/runtime/toolexec/loop_detector_test.go
@@ -191,20 +191,20 @@ func TestToolLoopDetector_Reset(t *testing.T) {
 		Function: tools.FunctionCall{Name: "read_file", Arguments: `{"path":"a.txt"}`},
 	}}
 
-	d := newToolLoopDetector(3)
-	d.record(calls)
-	d.record(calls)
-	if d.consecutive != 2 {
-		t.Fatalf("consecutive = %d, want 2 before reset", d.consecutive)
+	d := NewLoopDetector(3)
+	d.Record(calls)
+	d.Record(calls)
+	if d.Consecutive() != 2 {
+		t.Fatalf("consecutive = %d, want 2 before reset", d.Consecutive())
 	}
 	if d.lastSignature == "" {
 		t.Fatalf("lastSignature should be populated before reset")
 	}
 
-	d.reset()
+	d.Reset()
 
-	if d.consecutive != 0 {
-		t.Errorf("consecutive = %d, want 0 after reset", d.consecutive)
+	if d.Consecutive() != 0 {
+		t.Errorf("consecutive = %d, want 0 after reset", d.Consecutive())
 	}
 	if d.lastSignature != "" {
 		t.Errorf("lastSignature = %q, want empty after reset", d.lastSignature)
@@ -212,10 +212,10 @@ func TestToolLoopDetector_Reset(t *testing.T) {
 
 	// After reset, identical calls should restart counting from 1, not
 	// continue from the pre-reset count.
-	if tripped := d.record(calls); tripped {
+	if tripped := d.Record(calls); tripped {
 		t.Errorf("detector tripped on first call after reset; counter not cleared")
 	}
-	if d.consecutive != 1 {
-		t.Errorf("consecutive = %d, want 1 after first record post-reset", d.consecutive)
+	if d.Consecutive() != 1 {
+		t.Errorf("consecutive = %d, want 1 after first record post-reset", d.Consecutive())
 	}
 }

--- a/pkg/runtime/toolexec/loop_detector_test.go
+++ b/pkg/runtime/toolexec/loop_detector_test.go
@@ -1,4 +1,4 @@
-package runtime
+package toolexec
 
 import (
 	"testing"
@@ -8,7 +8,7 @@ import (
 	bgagent "github.com/docker/docker-agent/pkg/tools/builtin/agent"
 )
 
-func TestToolLoopDetector(t *testing.T) {
+func TestLoopDetector(t *testing.T) {
 	makeCalls := func(pairs ...string) []tools.ToolCall {
 		var calls []tools.ToolCall
 		for i := 0; i < len(pairs); i += 2 {
@@ -169,18 +169,18 @@ func TestToolLoopDetector(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			d := newToolLoopDetector(tt.threshold, tt.exemptTools...)
+			d := NewLoopDetector(tt.threshold, tt.exemptTools...)
 			var tripped bool
 			for _, batch := range tt.batches {
-				if d.record(batch) {
+				if d.Record(batch) {
 					tripped = true
 				}
 			}
 			if tripped != tt.wantTrip {
 				t.Errorf("tripped = %v, want %v", tripped, tt.wantTrip)
 			}
-			if d.consecutive != tt.wantCount {
-				t.Errorf("consecutive = %d, want %d", d.consecutive, tt.wantCount)
+			if d.Consecutive() != tt.wantCount {
+				t.Errorf("consecutive = %d, want %d", d.Consecutive(), tt.wantCount)
 			}
 		})
 	}

--- a/pkg/runtime/toolexec/model_override.go
+++ b/pkg/runtime/toolexec/model_override.go
@@ -1,4 +1,4 @@
-package runtime
+package toolexec
 
 import (
 	"log/slog"
@@ -6,10 +6,10 @@ import (
 	"github.com/docker/docker-agent/pkg/tools"
 )
 
-// resolveToolCallModelOverride returns the per-toolset model override from the
+// ResolveModelOverride returns the per-toolset model override from the
 // given tool calls, or "" if none. When multiple tools specify different
 // overrides, the first one wins.
-func resolveToolCallModelOverride(calls []tools.ToolCall, agentTools []tools.Tool) string {
+func ResolveModelOverride(calls []tools.ToolCall, agentTools []tools.Tool) string {
 	if len(calls) == 0 {
 		return ""
 	}

--- a/pkg/runtime/toolexec/model_override_test.go
+++ b/pkg/runtime/toolexec/model_override_test.go
@@ -1,4 +1,4 @@
-package runtime
+package toolexec
 
 import (
 	"testing"
@@ -8,12 +8,12 @@ import (
 	"github.com/docker/docker-agent/pkg/tools"
 )
 
-func TestResolveToolCallModelOverride_NoCalls(t *testing.T) {
-	result := resolveToolCallModelOverride(nil, nil)
+func TestResolveModelOverride_NoCalls(t *testing.T) {
+	result := ResolveModelOverride(nil, nil)
 	assert.Empty(t, result)
 }
 
-func TestResolveToolCallModelOverride_NoOverride(t *testing.T) {
+func TestResolveModelOverride_NoOverride(t *testing.T) {
 	agentTools := []tools.Tool{
 		{Name: "read_file"},
 		{Name: "write_file"},
@@ -22,11 +22,11 @@ func TestResolveToolCallModelOverride_NoOverride(t *testing.T) {
 		{Function: tools.FunctionCall{Name: "read_file"}},
 	}
 
-	result := resolveToolCallModelOverride(calls, agentTools)
+	result := ResolveModelOverride(calls, agentTools)
 	assert.Empty(t, result)
 }
 
-func TestResolveToolCallModelOverride_SingleOverride(t *testing.T) {
+func TestResolveModelOverride_SingleOverride(t *testing.T) {
 	agentTools := []tools.Tool{
 		{Name: "read_file", ModelOverride: "openai/gpt-4o-mini"},
 		{Name: "write_file"},
@@ -35,11 +35,11 @@ func TestResolveToolCallModelOverride_SingleOverride(t *testing.T) {
 		{Function: tools.FunctionCall{Name: "read_file"}},
 	}
 
-	result := resolveToolCallModelOverride(calls, agentTools)
+	result := ResolveModelOverride(calls, agentTools)
 	assert.Equal(t, "openai/gpt-4o-mini", result)
 }
 
-func TestResolveToolCallModelOverride_FirstOverrideWins(t *testing.T) {
+func TestResolveModelOverride_FirstOverrideWins(t *testing.T) {
 	agentTools := []tools.Tool{
 		{Name: "read_file", ModelOverride: "openai/gpt-4o-mini"},
 		{Name: "search_kb", ModelOverride: "anthropic/claude-haiku"},
@@ -49,11 +49,11 @@ func TestResolveToolCallModelOverride_FirstOverrideWins(t *testing.T) {
 		{Function: tools.FunctionCall{Name: "search_kb"}},
 	}
 
-	result := resolveToolCallModelOverride(calls, agentTools)
+	result := ResolveModelOverride(calls, agentTools)
 	assert.Equal(t, "openai/gpt-4o-mini", result)
 }
 
-func TestResolveToolCallModelOverride_MixedOverrideAndNonOverride(t *testing.T) {
+func TestResolveModelOverride_MixedOverrideAndNonOverride(t *testing.T) {
 	agentTools := []tools.Tool{
 		{Name: "read_file"},
 		{Name: "search_kb", ModelOverride: "openai/gpt-4o-mini"},
@@ -65,11 +65,11 @@ func TestResolveToolCallModelOverride_MixedOverrideAndNonOverride(t *testing.T) 
 
 	// read_file has no override, search_kb does. Since read_file is first
 	// but has no override, we skip it and use search_kb's.
-	result := resolveToolCallModelOverride(calls, agentTools)
+	result := ResolveModelOverride(calls, agentTools)
 	assert.Equal(t, "openai/gpt-4o-mini", result)
 }
 
-func TestResolveToolCallModelOverride_UnknownTool(t *testing.T) {
+func TestResolveModelOverride_UnknownTool(t *testing.T) {
 	agentTools := []tools.Tool{
 		{Name: "read_file"},
 	}
@@ -77,6 +77,6 @@ func TestResolveToolCallModelOverride_UnknownTool(t *testing.T) {
 		{Function: tools.FunctionCall{Name: "unknown_tool"}},
 	}
 
-	result := resolveToolCallModelOverride(calls, agentTools)
+	result := ResolveModelOverride(calls, agentTools)
 	assert.Empty(t, result)
 }

--- a/pkg/runtime/toolexec/permissions.go
+++ b/pkg/runtime/toolexec/permissions.go
@@ -1,0 +1,99 @@
+package toolexec
+
+import (
+	"github.com/docker/docker-agent/pkg/permissions"
+)
+
+// PermissionOutcome is the resolved decision after evaluating the full
+// approval pipeline.
+type PermissionOutcome int
+
+const (
+	// OutcomeAllow means the tool can run without asking the user.
+	OutcomeAllow PermissionOutcome = iota
+	// OutcomeDeny means the tool must be rejected; the caller should
+	// surface a tool-error response that mentions Source.
+	OutcomeDeny
+	// OutcomeAsk means the user must be asked for explicit confirmation.
+	OutcomeAsk
+)
+
+// PermissionReason explains *why* a [PermissionDecision] was reached.
+// Callers use it to produce accurate log messages and to know which
+// auto-approval path was taken (yolo, checker rule, read-only hint, or
+// default).
+type PermissionReason int
+
+const (
+	// ReasonYolo: --yolo (sess.ToolsApproved) auto-approved the tool.
+	ReasonYolo PermissionReason = iota
+	// ReasonChecker: a configured permission checker (session-level or
+	// team-level) produced a definitive Allow/Deny/ForceAsk verdict.
+	// PermissionDecision.Source identifies which checker.
+	ReasonChecker
+	// ReasonReadOnlyHint: no checker matched and the tool's ReadOnlyHint
+	// annotation auto-approved it.
+	ReasonReadOnlyHint
+	// ReasonDefault: nothing matched; the user must confirm.
+	ReasonDefault
+)
+
+// NamedChecker pairs a [permissions.Checker] with a human-readable source
+// label (e.g. "session permissions", "permissions configuration") used to
+// construct denial messages and debug logs.
+type NamedChecker struct {
+	Checker *permissions.Checker
+	Source  string
+}
+
+// PermissionDecision is the result of [Decide]: an outcome plus the
+// reason and (when the reason is [ReasonChecker]) the source label of the
+// checker that produced it.
+type PermissionDecision struct {
+	Outcome PermissionOutcome
+	Reason  PermissionReason
+	Source  string
+}
+
+// Decide resolves the final permission outcome for a tool call by walking
+// the configured pipeline in priority order:
+//
+//  1. yoloApproved (--yolo) — auto-allow everything.
+//  2. checkers (in order; typically session-level first, then team-level)
+//     — the first checker that returns Allow / Deny / ForceAsk wins.
+//     ForceAsk produces [OutcomeAsk]: an explicit ask pattern always
+//     overrides the read-only fast path below.
+//  3. readOnlyHint — auto-allow.
+//  4. default — Ask.
+//
+// Decide is pure (no I/O, no side effects) so the entire approval matrix
+// can be exhaustively unit-tested without a runtime.
+func Decide(
+	yoloApproved bool,
+	checkers []NamedChecker,
+	toolName string,
+	toolArgs map[string]any,
+	readOnlyHint bool,
+) PermissionDecision {
+	if yoloApproved {
+		return PermissionDecision{Outcome: OutcomeAllow, Reason: ReasonYolo}
+	}
+
+	for _, pc := range checkers {
+		switch pc.Checker.CheckWithArgs(toolName, toolArgs) {
+		case permissions.Deny:
+			return PermissionDecision{Outcome: OutcomeDeny, Reason: ReasonChecker, Source: pc.Source}
+		case permissions.Allow:
+			return PermissionDecision{Outcome: OutcomeAllow, Reason: ReasonChecker, Source: pc.Source}
+		case permissions.ForceAsk:
+			return PermissionDecision{Outcome: OutcomeAsk, Reason: ReasonChecker, Source: pc.Source}
+		case permissions.Ask:
+			// No explicit match at this level; fall through to next checker.
+		}
+	}
+
+	if readOnlyHint {
+		return PermissionDecision{Outcome: OutcomeAllow, Reason: ReasonReadOnlyHint}
+	}
+	return PermissionDecision{Outcome: OutcomeAsk, Reason: ReasonDefault}
+}

--- a/pkg/runtime/toolexec/permissions_test.go
+++ b/pkg/runtime/toolexec/permissions_test.go
@@ -1,0 +1,103 @@
+package toolexec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/permissions"
+)
+
+func newChecker(t *testing.T, allow, ask, deny []string) *permissions.Checker {
+	t.Helper()
+	return permissions.NewChecker(&latest.PermissionsConfig{
+		Allow: allow,
+		Ask:   ask,
+		Deny:  deny,
+	})
+}
+
+func TestDecide_YoloShortCircuits(t *testing.T) {
+	d := Decide(true, []NamedChecker{
+		{Checker: newChecker(t, nil, nil, []string{"shell"}), Source: "team"},
+	}, "shell", nil, false)
+
+	assert.Equal(t, PermissionDecision{Outcome: OutcomeAllow, Reason: ReasonYolo}, d)
+}
+
+func TestDecide_DenyFromCheckerWins(t *testing.T) {
+	d := Decide(false, []NamedChecker{
+		{Checker: newChecker(t, nil, nil, []string{"shell"}), Source: "session"},
+	}, "shell", nil, true /* read-only doesn't bypass deny */)
+
+	assert.Equal(t, PermissionDecision{Outcome: OutcomeDeny, Reason: ReasonChecker, Source: "session"}, d)
+}
+
+func TestDecide_AllowFromChecker(t *testing.T) {
+	d := Decide(false, []NamedChecker{
+		{Checker: newChecker(t, []string{"read_*"}, nil, nil), Source: "session"},
+	}, "read_file", nil, false)
+
+	assert.Equal(t, PermissionDecision{Outcome: OutcomeAllow, Reason: ReasonChecker, Source: "session"}, d)
+}
+
+func TestDecide_ForceAskFromCheckerOverridesReadOnly(t *testing.T) {
+	d := Decide(false, []NamedChecker{
+		{Checker: newChecker(t, nil, []string{"read_file"}, nil), Source: "team"},
+	}, "read_file", nil, true /* read-only would normally bypass ask */)
+
+	assert.Equal(t, PermissionDecision{Outcome: OutcomeAsk, Reason: ReasonChecker, Source: "team"}, d)
+}
+
+func TestDecide_FirstCheckerWins_SessionBeforeTeam(t *testing.T) {
+	// Session allows; team denies. Session is checked first → Allow.
+	d := Decide(false, []NamedChecker{
+		{Checker: newChecker(t, []string{"shell"}, nil, nil), Source: "session permissions"},
+		{Checker: newChecker(t, nil, nil, []string{"shell"}), Source: "permissions configuration"},
+	}, "shell", nil, false)
+
+	assert.Equal(t, PermissionDecision{Outcome: OutcomeAllow, Reason: ReasonChecker, Source: "session permissions"}, d)
+}
+
+func TestDecide_FallsThroughWhenNoCheckerMatches(t *testing.T) {
+	// First checker doesn't match anything (no patterns) → falls through to second.
+	d := Decide(false, []NamedChecker{
+		{Checker: newChecker(t, nil, nil, nil), Source: "session permissions"},
+		{Checker: newChecker(t, []string{"shell"}, nil, nil), Source: "permissions configuration"},
+	}, "shell", nil, false)
+
+	assert.Equal(t, PermissionDecision{Outcome: OutcomeAllow, Reason: ReasonChecker, Source: "permissions configuration"}, d)
+}
+
+func TestDecide_ReadOnlyHintAutoApproves(t *testing.T) {
+	d := Decide(false, nil, "read_file", nil, true)
+	assert.Equal(t, PermissionDecision{Outcome: OutcomeAllow, Reason: ReasonReadOnlyHint}, d)
+}
+
+func TestDecide_DefaultAsk(t *testing.T) {
+	d := Decide(false, nil, "shell", nil, false)
+	assert.Equal(t, PermissionDecision{Outcome: OutcomeAsk, Reason: ReasonDefault}, d)
+}
+
+func TestDecide_NoCheckersWithReadOnly(t *testing.T) {
+	d := Decide(false, []NamedChecker{}, "read_file", nil, true)
+	assert.Equal(t, PermissionDecision{Outcome: OutcomeAllow, Reason: ReasonReadOnlyHint}, d)
+}
+
+func TestDecide_ArgPatternMatching(t *testing.T) {
+	// A checker that only allows shell when cmd starts with "ls".
+	d := Decide(false, []NamedChecker{
+		{Checker: newChecker(t, []string{"shell:cmd=ls*"}, nil, nil), Source: "session"},
+	}, "shell", map[string]any{"cmd": "ls -la"}, false)
+
+	assert.Equal(t, PermissionDecision{Outcome: OutcomeAllow, Reason: ReasonChecker, Source: "session"}, d)
+}
+
+func TestDecide_ArgPatternNoMatchFallsToDefault(t *testing.T) {
+	d := Decide(false, []NamedChecker{
+		{Checker: newChecker(t, []string{"shell:cmd=ls*"}, nil, nil), Source: "session"},
+	}, "shell", map[string]any{"cmd": "rm -rf /"}, false)
+
+	assert.Equal(t, PermissionDecision{Outcome: OutcomeAsk, Reason: ReasonDefault}, d)
+}


### PR DESCRIPTION
## Goal

Make tool execution easier to read, test, and build on top of, by extracting it from `pkg/runtime` into a self-contained `pkg/runtime/toolexec` sub-package — following the existing `pkg/runtime/compactor` and `pkg/runtime/delegator` precedents.

`pkg/runtime/tool_dispatch.go` shrinks from **442 LOC of orchestration** to **123 LOC of runtime adapters**, and the new package is fully unit-testable without spinning up a runtime.

## Public API

**Zero changes.** `runtime.Runtime`, `runtime.ResumeRequest`, `runtime.ResumeType`, the `ResumeType*` constants, `runtime.LocalRuntime.Resume(...)`, the `Run`/`RunStream`/`Steer`/`FollowUp` flow — all byte-for-byte identical. Resume types are now type aliases over `toolexec`.

## Commits (each one builds, lints, and tests cleanly)

| # | Commit | What moved |
|---|---|---|
| 1 | `extract pure tool-execution utilities into pkg/runtime/toolexec` | Loop detector + per-tool model override (already pure helpers) |
| 2 | `move hooks-input helpers into toolexec` | `parseToolInput`, `newHooksInput` (+ tests) |
| 3 | `extract approval-pipeline decision into toolexec.Decide` | The yolo → checkers → read-only → default ladder, as a pure `Decide` function with full unit-test matrix |
| 4 | `extract Dispatcher into pkg/runtime/toolexec` | `toolexec.Dispatcher` + `Emitter` / `HookDispatcher` interfaces, with 10 dispatcher unit tests covering routing, approval outcomes, and batch-cancellation synthesis |
| 5 | `simplify dispatcher with per-call value type` | Internal cleanup: per-call `*call` value type to cut 7-arg method signatures, plus 4 review fixes (see below) |

## What lives in `pkg/runtime/toolexec` now

```
pkg/runtime/toolexec/
├── doc.go                      # explains the package's purpose
├── loop_detector.go            # consecutive-duplicate detector
├── model_override.go           # per-toolset model-override resolution
├── hooks_input.go              # ParseToolInput, NewHooksInput
├── permissions.go              # Decide(yolo, checkers, name, args, readOnly)
├── dispatcher.go               # Dispatcher + Process(ctx, sess, calls, tools, em)
└── *_test.go                   # 30+ unit tests, no runtime needed
```

## Design highlights

- **`Dispatcher` carries its dependencies as struct fields**: `Tracer`, `Hooks`, `Resume`, `AgentFor`, `Permissions`, `Handlers`. No method-on-LocalRuntime hidden state.
- **`Emitter` is a 5-method interface** covering only the dispatch-shaped events (ToolCall, ToolCallResponse, ToolCallConfirmation, HookBlocked, MessageAdded). Anything else stays runtime-private.
- **`HookDispatcher` is a 2-method interface** so the dispatcher doesn't depend on the runtime's hook registry directly.
- **Approval policy is pure**: `toolexec.Decide(...) → PermissionDecision{Outcome, Reason, Source}`. Every log message the original code emitted is preserved via the `Reason` field, with no behavior change.
- **Per-call state lives in a `*call` value type** so helper methods take `(ctx)` or `(ctx, runTool)` instead of 7 arguments.
- **`ctx` is never stored in a struct** — passed explicitly to every method that needs it (idiomatic Go, satisfies `containedctx`).

## Validation

- `go build ./...` ✅
- `go vet ./...` ✅
- `mise lint` (golangci-lint + custom 800-file Go cop + `go mod tidy --diff`) → **0 issues** ✅
- `mise test` → **all packages pass**, no failures ✅
- `go test -race -count=1 ./pkg/runtime/...` ✅

## Reviewing tip

Each commit is independently reviewable. For the cleanest reading order:

1. Start with **commit 1** to see the package's seed (pure utilities).
2. Skim **commits 2–3** for the small, mechanical extractions.
3. Spend most time on **commit 4** (the Dispatcher extraction) — that's where the architectural shape lives.
4. **Commit 5** is internal cleanup of commit 4; the diff is mostly mechanical (per-call struct rather than wide signatures).

## Suggested follow-ups (not in this PR)

- Move `ToolHandlerFunc` and `r.toolMap` registration into `toolexec` so the runtime stops needing to bind handlers to a `chan Event` per stream.
- Move `pkg/runtime/event.go` constructors to `pkg/runtime/events`, then drop the `chanEmitter` adapter in favour of a direct `chan Event` implementation of `Emitter`.

