### PR TITLE
feat(hooks): add 'type: model' hook and integrate pre_tool_use into approval flow

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -701,15 +701,16 @@
         },
         "type": {
           "type": "string",
-          "description": "Type of hook. 'command' executes a shell command; 'builtin' invokes a named in-process Go function registered by the runtime. The docker-agent runtime ships these builtins: 'add_date' (turn_start: today's date), 'add_environment_info' (session_start: cwd, git, OS, arch), 'add_prompt_files' (turn_start: contents of named files looked up in the workdir hierarchy and the home directory), 'add_git_status' (turn_start: `git status --short --branch`), 'add_git_diff' (turn_start: `git diff --stat`, or full diff with args=['full']), 'add_directory_listing' (session_start: top-level entries of cwd), 'add_user_info' (session_start: current OS user and hostname), 'add_recent_commits' (session_start: `git log --oneline -n N`, default N=10, override via args=['<N>']), 'max_iterations' (before_llm_call: hard stop after N model calls; args=['<N>'] required).",
+          "description": "Type of hook. 'command' executes a shell command; 'builtin' invokes a named in-process Go function registered by the runtime; 'model' asks an LLM and translates its reply into the hook's native output (used for LLM-as-a-judge pre_tool_use, summarizers, etc., with no Go code). The docker-agent runtime ships these builtins: 'add_date' (turn_start: today's date), 'add_environment_info' (session_start: cwd, git, OS, arch), 'add_prompt_files' (turn_start: contents of named files looked up in the workdir hierarchy and the home directory), 'add_git_status' (turn_start: `git status --short --branch`), 'add_git_diff' (turn_start: `git diff --stat`, or full diff with args=['full']), 'add_directory_listing' (session_start: top-level entries of cwd), 'add_user_info' (session_start: current OS user and hostname), 'add_recent_commits' (session_start: `git log --oneline -n N`, default N=10, override via args=['<N>']), 'max_iterations' (before_llm_call: hard stop after N model calls; args=['<N>'] required).",
           "enum": [
             "command",
-            "builtin"
+            "builtin",
+            "model"
           ]
         },
         "command": {
           "type": "string",
-          "description": "Shell command (type=command) or builtin name (type=builtin) to invoke. Command hooks receive JSON input via stdin with tool/session information."
+          "description": "Shell command (type=command) or builtin name (type=builtin) to invoke. Command hooks receive JSON input via stdin with tool/session information. Ignored when type=model."
         },
         "args": {
           "type": "array",
@@ -744,13 +745,38 @@
             "block"
           ],
           "default": "warn"
+        },
+        "model": {
+          "type": "string",
+          "description": "Model spec ('provider/model', e.g. 'openai/gpt-4o-mini') invoked by type=model hooks. Required for that type, ignored otherwise."
+        },
+        "prompt": {
+          "type": "string",
+          "description": "User-message template rendered for each invocation of a type=model hook. Parsed as a Go text/template with the hook Input as the data context: {{ .ToolName }}, {{ .ToolInput }}, {{ .StopResponse }}, etc. Required for type=model."
+        },
+        "schema": {
+          "type": "string",
+          "description": "Well-known response interpretation for type=model hooks. Empty: return the model's reply as additional_context. 'pre_tool_use_decision': ask the model for {decision, reason} JSON and produce a permission_decision verdict (allow|ask|deny)."
         }
       },
       "required": [
-        "type",
-        "command"
+        "type"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {"properties": {"type": {"const": "command"}}, "required": ["type"]},
+          "then": {"required": ["command"]}
+        },
+        {
+          "if": {"properties": {"type": {"const": "builtin"}}, "required": ["type"]},
+          "then": {"required": ["command"]}
+        },
+        {
+          "if": {"properties": {"type": {"const": "model"}}, "required": ["type"]},
+          "then": {"required": ["model", "prompt"]}
+        }
+      ]
     },
     "ModelConfig": {
       "type": "object",

--- a/docs/configuration/hooks/index.md
+++ b/docs/configuration/hooks/index.md
@@ -471,6 +471,66 @@ hooks:
 
 Return nothing to fall through to the usual interactive confirmation.
 
+### LLM as a Judge (Auto-Approving Tool Calls)
+
+The `model` hook type asks an LLM and translates its reply into the
+hook's native output — no Go code, no shell glue, no JSON parsing on
+your side. Combined with the well-known `pre_tool_use_decision`
+schema it gives you a fully-configurable LLM judge that decides
+`allow` / `ask` / `deny` per tool call.
+
+```yaml
+hooks:
+  pre_tool_use:
+    - matcher: "shell|edit_file|mcp:.*"
+      hooks:
+        - type: model
+          model: openai/gpt-4o-mini
+          timeout: 15
+          schema: pre_tool_use_decision
+          prompt: |
+            You are a security judge for an autonomous agent.
+            Decide whether this tool call is safe to auto-approve.
+
+            Tool: {{ .ToolName }}
+            Args: {{ .ToolInput | toJSON }}
+
+            Project rules:
+            - Reads under the working directory are safe.
+            - Writes to ~/.ssh / ~/.aws / ~/.docker are deny.
+```
+
+| Field    | Required          | Description                                                                                                                                                                |
+| -------- | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `model`  | yes               | Model spec (`provider/model`, e.g. `openai/gpt-4o-mini`). The judge model — small/cheap is recommended.                                                                    |
+| `prompt` | yes               | Go [`text/template`](https://pkg.go.dev/text/template) body. Sees the hook [Input](#hook-input) as data, plus the `toJSON` and `truncate <n>` helpers.                     |
+| `schema` | no                | Well-known response interpretation. `pre_tool_use_decision` produces a `permission_decision` verdict; omit for free-form text injected as `additional_context`.            |
+| `timeout`| no (default 60s)  | Per-call timeout. **Timeouts fail closed (deny) for `pre_tool_use`** regardless of any other setting. Match it to your judge model's typical latency plus a small buffer. |
+
+The `pre_tool_use_decision` schema constrains the judge to reply with
+strict `{decision, reason}` JSON. Providers that honor structured
+output (OpenAI, ...) are asked to emit that shape directly; on
+providers that ignore it the framework still parses tolerant
+JSON-in-text. Anything unparseable propagates as a hook error and the
+executor falls closed (deny) on `pre_tool_use`.
+
+Pair it with deterministic `permissions:` rules so destructive calls
+(e.g. `sudo`, `rm -rf`) are blocked even if the judge is misled, and
+obvious read-only calls bypass the LLM entirely. See
+[`examples/llm_judge.yaml`](https://github.com/docker/docker-agent/blob/main/examples/llm_judge.yaml)
+for a complete configuration.
+
+**Security considerations**:
+
+- **Sensitive data**: Tool arguments (including file paths, command
+  arguments, and any other parameters) are sent to the judge LLM. Avoid
+  using the judge on tools that handle secrets, or ensure your judge
+  model is self-hosted.
+- **Defense in depth**: The judge should not be your only security
+  layer. Use deterministic `permissions:` rules to block obviously
+  dangerous operations (e.g., `sudo`, `rm -rf`) before the judge sees
+  them, as shown in the example configuration.
+
 </div>
 
 ## CLI Flags

--- a/examples/llm_judge.yaml
+++ b/examples/llm_judge.yaml
@@ -1,0 +1,90 @@
+#!/usr/bin/env docker agent run
+#
+# LLM-as-a-judge — auto-approve tool calls with a small model
+# ==========================================================================
+#
+# This example wires three layers of tool-call control:
+#
+#   1. Deterministic permissions  — `permissions:` block. Hard deny rules
+#      catch obvious abuse (sudo, rm -rf, etc) regardless of what the
+#      judge says, and obvious read-only ops are allow-listed so the
+#      judge isn't paid for every harmless call.
+#
+#   2. LLM judge (this file's centerpiece) — a `pre_tool_use` hook of
+#      type `model` that asks a small LLM to verdict every shell / edit
+#      / MCP call that fell through the deterministic rules. The
+#      `pre_tool_use_decision` schema constrains the model to reply
+#      with strict {decision, reason} JSON; the framework translates
+#      that into the runtime's permission_decision pipeline.
+#
+#   3. User confirmation — anything the judge said `ask` on falls
+#      through to the normal TUI prompt. So the human is still in the
+#      loop on ambiguous calls.
+#
+# This config uses ZERO Go code: the `type: model` hook is provided by
+# the framework, no builtin to register, no shell glue, no jq+curl.
+#
+
+agents:
+  root:
+    model: openai/gpt-4o
+    description: Agent supervised by an LLM judge for tool calls.
+    instruction: |
+      You are a helpful assistant with access to shell and filesystem tools.
+      Use them to help the user. The user's machine is supervised by an
+      LLM judge that decides which of your tool calls are auto-approved.
+
+    toolsets:
+      - type: shell
+      - type: filesystem
+
+    hooks:
+      # Layer 2: LLM judge. Scope it via the matcher so we don't pay
+      # judge latency on cheap tools.
+      pre_tool_use:
+        - matcher: "shell|edit_file|mcp:.*"
+          hooks:
+            - type: model
+              model: openai/gpt-4o-mini
+              # 15s is plenty for a small model; the judge fails closed
+              # (deny) on timeout. Pair with permissions.allow for
+              # read-only ops to keep latency budget under control.
+              timeout: 15
+              schema: pre_tool_use_decision
+              prompt: |
+                You are a security judge for an autonomous agent.
+                Decide whether this tool call is safe to auto-approve.
+
+                Tool: {{ .ToolName }}
+                Args: {{ .ToolInput | toJSON }}
+
+                Project rules:
+                - Reads under the working directory are safe.
+                - Network egress to anything other than github.com or
+                  pypi.org should be `ask`.
+                - Any write under ~/.ssh, ~/.aws, or ~/.docker is `deny`.
+                - When in doubt, prefer `ask` (the user is then asked).
+
+      # Layer 3 (audit): log every verdict so the policy can be tuned.
+      post_tool_use:
+        - matcher: "*"
+          hooks:
+            - type: command
+              timeout: 5
+              command: |
+                INPUT=$(cat)
+                TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+                TOOL=$(echo "$INPUT" | jq -r '.tool_name')
+                echo "[$TS] $TOOL completed" >> /tmp/agent-judge-audit.log
+
+# Layer 1: deterministic rules. Evaluated BEFORE any hook fires, so
+# they short-circuit the judge entirely for obvious cases.
+permissions:
+  deny:
+    - "shell:cmd=*sudo*"
+    - "shell:cmd=*rm -rf*"
+    - "shell:cmd=*mkfs*"
+    - "shell:cmd=*dd if=*"
+    - "edit_file:path=/etc/*"
+  allow:
+    - "read_*"

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -1816,6 +1816,10 @@ type HookDefinition struct {
 	//                 is owned by the runtime; the docker-agent runtime
 	//                 ships add_date, add_environment_info, and
 	//                 add_prompt_files.
+	//   - "model":    ask an LLM and translate its reply into the hook's
+	//                 native output. See Model / Prompt / Schema. Used to
+	//                 implement "LLM as a judge" pre_tool_use hooks,
+	//                 turn-start summarizers, etc., with no Go code.
 	Type string `json:"type" yaml:"type"`
 
 	// Command is the shell command (Type==command) or the builtin name
@@ -1839,6 +1843,25 @@ type HookDefinition struct {
 
 	// OnError controls non-fail-closed hook failures: warn (default), ignore, or block.
 	OnError string `json:"on_error,omitempty" yaml:"on_error,omitempty"`
+
+	// Model is the model spec ("provider/model", e.g. "openai/gpt-4o-mini")
+	// invoked by Type==model hooks. Required for that type, ignored
+	// otherwise.
+	Model string `json:"model,omitempty" yaml:"model,omitempty"`
+
+	// Prompt is the user-message template rendered for each invocation
+	// of a Type==model hook. It is parsed as a Go text/template with the
+	// hook [Input] as the data context (so {{ .ToolName }},
+	// {{ .ToolInput }}, etc. work). Required for Type==model.
+	Prompt string `json:"prompt,omitempty" yaml:"prompt,omitempty"`
+
+	// Schema selects a well-known response interpretation for Type==model
+	// hooks. The empty value means "return the model's reply as
+	// additional_context". Other values (registered by the runtime) ask
+	// the provider for strict-JSON output and translate the result into
+	// the right Output shape (e.g. "pre_tool_use_decision" produces a
+	// permission_decision verdict).
+	Schema string `json:"schema,omitempty" yaml:"schema,omitempty"`
 }
 
 // GetTimeout returns the per-hook execution timeout, defaulting to 60
@@ -2044,8 +2067,15 @@ func (h *HookDefinition) validate(prefix string, index int) error {
 		if h.Command == "" {
 			return fmt.Errorf("hooks.%s[%d]: command must name the builtin to invoke", prefix, index)
 		}
+	case "model":
+		if h.Model == "" {
+			return fmt.Errorf("hooks.%s[%d]: model is required for model hooks (e.g. 'openai/gpt-4o-mini')", prefix, index)
+		}
+		if h.Prompt == "" {
+			return fmt.Errorf("hooks.%s[%d]: prompt is required for model hooks", prefix, index)
+		}
 	default:
-		return fmt.Errorf("hooks.%s[%d]: unsupported hook type '%s' (supported: 'command', 'builtin')", prefix, index, h.Type)
+		return fmt.Errorf("hooks.%s[%d]: unsupported hook type '%s' (supported: 'command', 'builtin', 'model')", prefix, index, h.Type)
 	}
 
 	return nil

--- a/pkg/hooks/aggregate_test.go
+++ b/pkg/hooks/aggregate_test.go
@@ -1,0 +1,106 @@
+package hooks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestAggregateTracksMostRestrictiveDecision pins the new
+// Result.Decision contract: when multiple pre_tool_use hooks fire on a
+// single tool call, the aggregated verdict is the most-restrictive
+// (Deny > Ask > Allow). The runtime's tool-approval flow consults this
+// to short-circuit the user prompt for Allow and to escalate Ask, so
+// the ordering must be stable.
+func TestAggregateTracksMostRestrictiveDecision(t *testing.T) {
+	t.Parallel()
+
+	mk := func(d Decision, reason string) hookResult {
+		return hookResult{HandlerResult: HandlerResult{Output: &Output{
+			HookSpecificOutput: &HookSpecificOutput{
+				HookEventName:            EventPreToolUse,
+				PermissionDecision:       d,
+				PermissionDecisionReason: reason,
+			},
+		}}}
+	}
+
+	cases := []struct {
+		name        string
+		results     []hookResult
+		wantVerdict Decision
+		wantReason  string
+		wantAllowed bool
+	}{
+		{
+			name:        "no decision: Allowed=true, Decision empty",
+			results:     []hookResult{{}},
+			wantVerdict: "",
+			wantAllowed: true,
+		},
+		{
+			name:        "single allow",
+			results:     []hookResult{mk(DecisionAllow, "safe")},
+			wantVerdict: DecisionAllow,
+			wantReason:  "safe",
+			wantAllowed: true,
+		},
+		{
+			name:        "single ask escalates over no decision",
+			results:     []hookResult{{}, mk(DecisionAsk, "unclear")},
+			wantVerdict: DecisionAsk,
+			wantReason:  "unclear",
+			wantAllowed: true, // Ask doesn't flip Allowed; the runtime handles the prompt.
+		},
+		{
+			name: "deny beats ask beats allow",
+			results: []hookResult{
+				mk(DecisionAllow, "looks fine"),
+				mk(DecisionAsk, "second-guess"),
+				mk(DecisionDeny, "destructive"),
+			},
+			wantVerdict: DecisionDeny,
+			wantReason:  "destructive",
+			wantAllowed: false,
+		},
+		{
+			name: "first reason wins on ties",
+			results: []hookResult{
+				mk(DecisionAsk, "first ask"),
+				mk(DecisionAsk, "second ask"),
+			},
+			wantVerdict: DecisionAsk,
+			wantReason:  "first ask",
+			wantAllowed: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			final := aggregate(tc.results, EventPreToolUse)
+			assert.Equal(t, tc.wantVerdict, final.Decision)
+			assert.Equal(t, tc.wantReason, final.DecisionReason)
+			assert.Equal(t, tc.wantAllowed, final.Allowed)
+		})
+	}
+}
+
+// TestAggregateDecisionEmptyForNonPreToolUse documents that
+// Result.Decision is meaningful only for pre_tool_use events. Other
+// events (turn_start, post_tool_use, ...) MUST leave it empty so a
+// runtime that consults it can't accidentally act on a stale verdict
+// from an unrelated hook.
+func TestAggregateDecisionEmptyForNonPreToolUse(t *testing.T) {
+	t.Parallel()
+
+	results := []hookResult{{HandlerResult: HandlerResult{Output: &Output{
+		HookSpecificOutput: &HookSpecificOutput{
+			HookEventName:      EventTurnStart,
+			PermissionDecision: DecisionAllow, // misconfigured but possible
+		},
+	}}}}
+
+	final := aggregate(results, EventTurnStart)
+	assert.Equal(t, Decision(""), final.Decision)
+	assert.Empty(t, final.DecisionReason)
+}

--- a/pkg/hooks/builtins/builtins.go
+++ b/pkg/hooks/builtins/builtins.go
@@ -23,6 +23,10 @@
 // stable for its duration. max_iterations is stateful: its
 // per-session counter lives on the [State] returned by [Register];
 // the runtime clears it via [State.ClearSession] from session_end.
+//
+// LLM-as-a-judge hooks are NOT shipped here: write `type: model` with
+// `schema: pre_tool_use_decision` instead — see
+// pkg/hooks/shape_pre_tool_use_decision.go and examples/llm_judge.yaml.
 package builtins
 
 import (

--- a/pkg/hooks/config.go
+++ b/pkg/hooks/config.go
@@ -41,4 +41,9 @@ const (
 	// registered via [Registry.RegisterBuiltin]. The name is stored in
 	// [Hook.Command].
 	HookTypeBuiltin HookType = "builtin"
+	// HookTypeModel asks an LLM and translates the reply into the hook's
+	// native [Output] shape via a [ResponseShape]. It is registered by
+	// the runtime ([RegisterModelFactory]) because it depends on the
+	// runtime's model provider stack.
+	HookTypeModel HookType = "model"
 )

--- a/pkg/hooks/executor.go
+++ b/pkg/hooks/executor.go
@@ -334,6 +334,12 @@ func aggregate(results []hookResult, event EventType) *Result {
 			sysMsgs = append(sysMsgs, out.SystemMessage)
 		}
 		if hso := out.HookSpecificOutput; hso != nil {
+			if event == EventPreToolUse && hso.PermissionDecision != "" {
+				final.Decision, final.DecisionReason = strongerDecision(
+					final.Decision, final.DecisionReason,
+					hso.PermissionDecision, hso.PermissionDecisionReason,
+				)
+			}
 			if event == EventPreToolUse || event == EventPermissionRequest {
 				switch hso.PermissionDecision {
 				case DecisionDeny:
@@ -342,7 +348,9 @@ func aggregate(results []hookResult, event EventType) *Result {
 						messages = append(messages, hso.PermissionDecisionReason)
 					}
 				case DecisionAllow:
-					final.PermissionAllowed = true
+					if event == EventPermissionRequest {
+						final.PermissionAllowed = true
+					}
 					if hso.PermissionDecisionReason != "" {
 						contexts = append(contexts, hso.PermissionDecisionReason)
 					}
@@ -377,4 +385,32 @@ func aggregate(results []hookResult, event EventType) *Result {
 	final.AdditionalContext = strings.Join(contexts, "\n")
 	final.SystemMessage = strings.Join(sysMsgs, "\n")
 	return final
+}
+
+// decisionWeight ranks PermissionDecision verdicts so [strongerDecision]
+// can pick the most-restrictive across a chain of pre_tool_use hooks.
+// Deny > Ask > Allow > "" (no decision).
+func decisionWeight(d Decision) int {
+	switch d {
+	case DecisionDeny:
+		return 3
+	case DecisionAsk:
+		return 2
+	case DecisionAllow:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// strongerDecision returns the more-restrictive of two (decision,
+// reason) pairs, preserving the reason of the winner. A non-empty
+// decision always beats the empty string. Ties keep the existing
+// (current) decision so the iteration order in [aggregate] is
+// stable and the first-seen reason wins.
+func strongerDecision(curD Decision, curR string, newD Decision, newR string) (Decision, string) {
+	if decisionWeight(newD) > decisionWeight(curD) {
+		return newD, newR
+	}
+	return curD, curR
 }

--- a/pkg/hooks/model_handler.go
+++ b/pkg/hooks/model_handler.go
@@ -1,0 +1,238 @@
+package hooks
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"text/template"
+
+	"github.com/docker/docker-agent/pkg/config/latest"
+)
+
+// ModelClient is the runtime-provided seam between [HookTypeModel]
+// hooks and the LLM provider stack. It receives a model spec
+// (provider/model), a system+user prompt pair, and the structured-output
+// schema (or nil for free-form text), and returns the model's text
+// reply.
+//
+// Implementations are responsible for credential lookup, provider
+// construction, streaming, and assembling the final string. The hook
+// machinery only consumes the returned text plus any error.
+//
+// A non-nil error is treated as a hook failure and routed through the
+// executor's fail-closed semantics (deny on PreToolUse). Returning an
+// empty string with no error is treated as an unparseable response by
+// downstream [ResponseShape] interpreters.
+type ModelClient interface {
+	Ask(ctx context.Context, modelSpec, system, user string, schema *latest.StructuredOutput) (string, error)
+}
+
+// ResponseShape interprets a raw model reply as a hook [Output] for a
+// well-known schema name (registered via [RegisterResponseShape]). It
+// is paired with an optional [latest.StructuredOutput] (registered via
+// [RegisterResponseSchema]) that the [ModelClient] requests from the
+// provider — turning best-effort JSON parsing into a strict contract on
+// providers that honor it.
+//
+// The empty schema name uses [defaultShape], which surfaces the reply
+// verbatim as additional_context.
+type ResponseShape func(raw string, in *Input) (*Output, error)
+
+// modelRegistry holds the response-shape and structured-output
+// registries. They are package-level by design so the runtime can
+// register a shape once and every Executor that uses [DefaultRegistry]
+// (or any other registry sharing the same package state) sees it. The
+// process-wide default is harmless because shapes are pure functions
+// of (raw, input).
+var modelRegistry = struct {
+	mu      sync.RWMutex
+	shapes  map[string]ResponseShape
+	schemas map[string]*latest.StructuredOutput
+}{
+	shapes:  map[string]ResponseShape{},
+	schemas: map[string]*latest.StructuredOutput{},
+}
+
+// RegisterResponseShape registers a [ResponseShape] under name. The
+// empty name is reserved for the default "additional_context" shape
+// shipped in this package and cannot be re-registered. Registering
+// the same name twice replaces the previous shape.
+func RegisterResponseShape(name string, shape ResponseShape) error {
+	if name == "" {
+		return errors.New("response shape name must not be empty")
+	}
+	if shape == nil {
+		return errors.New("response shape must not be nil")
+	}
+	modelRegistry.mu.Lock()
+	defer modelRegistry.mu.Unlock()
+	modelRegistry.shapes[name] = shape
+	return nil
+}
+
+// RegisterResponseSchema associates a [latest.StructuredOutput] with a
+// shape name so the [ModelClient] can request strict JSON output from
+// providers that honor it. The shape name must already be registered
+// (or be the empty default) — calling this for an unknown shape is an
+// error to catch typos at startup.
+func RegisterResponseSchema(name string, schema *latest.StructuredOutput) error {
+	if name == "" {
+		return errors.New("response schema name must not be empty")
+	}
+	modelRegistry.mu.Lock()
+	defer modelRegistry.mu.Unlock()
+	modelRegistry.schemas[name] = schema
+	return nil
+}
+
+// lookupShape returns the [ResponseShape] for name, falling back to
+// [defaultShape] for the empty name.
+func lookupShape(name string) (ResponseShape, bool) {
+	if name == "" {
+		return defaultShape, true
+	}
+	modelRegistry.mu.RLock()
+	defer modelRegistry.mu.RUnlock()
+	s, ok := modelRegistry.shapes[name]
+	return s, ok
+}
+
+// lookupSchema returns the structured-output schema for name, or nil
+// when the shape is free-form (e.g. the default additional_context).
+func lookupSchema(name string) *latest.StructuredOutput {
+	if name == "" {
+		return nil
+	}
+	modelRegistry.mu.RLock()
+	defer modelRegistry.mu.RUnlock()
+	return modelRegistry.schemas[name]
+}
+
+// defaultShape passes the model's reply through as additional_context.
+// Useful for turn_start summarizers, post_tool_use commentary, etc. —
+// any event where [EventType.consumesContext] is true.
+func defaultShape(raw string, in *Input) (*Output, error) {
+	if in == nil {
+		return nil, nil
+	}
+	return NewAdditionalContextOutput(in.HookEventName, strings.TrimSpace(raw)), nil
+}
+
+// NewModelFactory returns a [HandlerFactory] for [HookTypeModel] backed
+// by client. Register it with [Registry.Register] in the runtime to
+// enable `type: model` hooks.
+//
+// The returned factory pre-parses the prompt template at factory time
+// so syntax errors surface at registry-lookup, not on the first hook
+// invocation. The shape/schema lookup happens at handler-construction
+// time so adding new shapes after factory registration still works.
+func NewModelFactory(client ModelClient) HandlerFactory {
+	if client == nil {
+		// The empty client always errors; this lets a runtime register
+		// the factory without a credentialed client and fail at the
+		// first use rather than at construction.
+		client = nilClient{}
+	}
+	return func(_ HandlerEnv, hook Hook) (Handler, error) {
+		if hook.Model == "" {
+			return nil, errors.New("model hook requires a non-empty model")
+		}
+		if hook.Prompt == "" {
+			return nil, errors.New("model hook requires a non-empty prompt")
+		}
+		shape, ok := lookupShape(hook.Schema)
+		if !ok {
+			return nil, fmt.Errorf("model hook: unknown schema %q (register one with hooks.RegisterResponseShape)", hook.Schema)
+		}
+		tpl, err := template.New("hook-prompt").Funcs(promptFuncs).Parse(hook.Prompt)
+		if err != nil {
+			return nil, fmt.Errorf("model hook: parse prompt template: %w", err)
+		}
+		return &modelHandler{
+			client: client,
+			model:  hook.Model,
+			tpl:    tpl,
+			schema: lookupSchema(hook.Schema),
+			shape:  shape,
+		}, nil
+	}
+}
+
+// promptFuncs is the [text/template] FuncMap exposed to model-hook
+// prompts. Kept small on purpose: anything more elaborate belongs in
+// the prompt itself.
+var promptFuncs = template.FuncMap{
+	// toJSON renders any value as compact JSON. Useful for embedding
+	// .ToolInput / .ToolResponse in the user prompt without writing
+	// custom Go-template formatting.
+	"toJSON": func(v any) (string, error) {
+		b, err := json.Marshal(v)
+		if err != nil {
+			return "", err
+		}
+		return string(b), nil
+	},
+	// truncate caps a string at n bytes, appending "…" when cut. A
+	// safety net for prompts that interpolate large tool inputs.
+	"truncate": func(n int, s string) string {
+		if n <= 0 || len(s) <= n {
+			return s
+		}
+		return s[:n] + "…"
+	},
+}
+
+// modelSystemPrompt is the fixed system message paired with every
+// rendered user prompt. It documents the JSON-only contract that
+// [ResponseShape]s expect.
+const modelSystemPrompt = `You are a hook running inside an autonomous agent.
+Follow the user's instructions exactly and reply ONLY with content the
+hook contract expects: when a JSON schema is supplied, return a single
+JSON object matching it with no surrounding prose or markdown fences;
+otherwise return concise free-form text suitable for direct injection
+as additional context.`
+
+type modelHandler struct {
+	client ModelClient
+	model  string
+	tpl    *template.Template
+	schema *latest.StructuredOutput
+	shape  ResponseShape
+}
+
+// Run implements [Handler]. It renders the prompt, asks the model, and
+// applies the configured [ResponseShape]. The executor's timeout and
+// fail-closed semantics are unchanged from any other handler.
+func (h *modelHandler) Run(ctx context.Context, input []byte) (HandlerResult, error) {
+	var in Input
+	if err := json.Unmarshal(input, &in); err != nil {
+		return HandlerResult{ExitCode: -1}, fmt.Errorf("decode hook input: %w", err)
+	}
+	var buf bytes.Buffer
+	if err := h.tpl.Execute(&buf, &in); err != nil {
+		return HandlerResult{ExitCode: -1}, fmt.Errorf("render prompt: %w", err)
+	}
+	raw, err := h.client.Ask(ctx, h.model, modelSystemPrompt, buf.String(), h.schema)
+	if err != nil {
+		return HandlerResult{ExitCode: -1}, fmt.Errorf("model %s: %w", h.model, err)
+	}
+	out, err := h.shape(raw, &in)
+	if err != nil {
+		return HandlerResult{ExitCode: -1}, fmt.Errorf("interpret reply: %w", err)
+	}
+	return HandlerResult{Output: out}, nil
+}
+
+// nilClient is the placeholder used when [NewModelFactory] is called
+// without a real client. It keeps the factory constructible but errors
+// at the first dispatch, surfacing the misconfiguration through the
+// normal fail-closed path.
+type nilClient struct{}
+
+func (nilClient) Ask(context.Context, string, string, string, *latest.StructuredOutput) (string, error) {
+	return "", errors.New("model hook: no ModelClient configured (runtime did not register one)")
+}

--- a/pkg/hooks/model_handler_test.go
+++ b/pkg/hooks/model_handler_test.go
@@ -1,0 +1,299 @@
+package hooks
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/config/latest"
+)
+
+// fakeClient lets the tests exercise the model factory without standing
+// up a real provider. It records the most recent call and returns a
+// canned reply (or error).
+type fakeClient struct {
+	gotModel  string
+	gotSystem string
+	gotUser   string
+	gotSchema *latest.StructuredOutput
+	reply     string
+	err       error
+	calls     int
+}
+
+func (f *fakeClient) Ask(_ context.Context, modelSpec, system, user string, schema *latest.StructuredOutput) (string, error) {
+	f.calls++
+	f.gotModel = modelSpec
+	f.gotSystem = system
+	f.gotUser = user
+	f.gotSchema = schema
+	return f.reply, f.err
+}
+
+// runModelHook is a small helper that builds a Handler via
+// NewModelFactory and dispatches once. It returns the handler result
+// plus any factory/run error so tests can assert on either path.
+func runModelHook(t *testing.T, client ModelClient, h Hook, in *Input) (HandlerResult, error) {
+	t.Helper()
+	factory := NewModelFactory(client)
+	handler, err := factory(HandlerEnv{}, h)
+	if err != nil {
+		return HandlerResult{}, err
+	}
+	body, err := in.ToJSON()
+	require.NoError(t, err)
+	return handler.Run(t.Context(), body)
+}
+
+// TestNewModelFactoryRejectsMissingFields documents the up-front
+// validation: a Hook lacking Model or Prompt must fail at factory
+// build, not at first dispatch. This keeps misconfiguration loud at
+// startup rather than discovering it on the first user request.
+func TestNewModelFactoryRejectsMissingFields(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		hook Hook
+		want string
+	}{
+		{
+			"missing model",
+			Hook{Type: HookTypeModel, Prompt: "hi"},
+			"non-empty model",
+		},
+		{
+			"missing prompt",
+			Hook{Type: HookTypeModel, Model: "openai/gpt-4o-mini"},
+			"non-empty prompt",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			factory := NewModelFactory(&fakeClient{})
+			_, err := factory(HandlerEnv{}, tc.hook)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
+// TestNewModelFactoryRejectsBadTemplate verifies that a syntactically
+// invalid Go template surfaces at factory time so a typo doesn't slip
+// through to the first dispatch.
+func TestNewModelFactoryRejectsBadTemplate(t *testing.T) {
+	t.Parallel()
+
+	factory := NewModelFactory(&fakeClient{})
+	_, err := factory(HandlerEnv{}, Hook{
+		Type:   HookTypeModel,
+		Model:  "openai/gpt-4o-mini",
+		Prompt: "{{ .ToolName ", // unterminated action
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse prompt template")
+}
+
+// TestNewModelFactoryRejectsUnknownSchema pins the registry contract:
+// referencing a schema that nobody registered must error at factory
+// time, not silently fall back to additional_context.
+func TestNewModelFactoryRejectsUnknownSchema(t *testing.T) {
+	t.Parallel()
+
+	factory := NewModelFactory(&fakeClient{})
+	_, err := factory(HandlerEnv{}, Hook{
+		Type:   HookTypeModel,
+		Model:  "openai/gpt-4o-mini",
+		Prompt: "hi",
+		Schema: "no_such_shape",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown schema")
+}
+
+// TestModelHandlerRendersPromptAndForwardsContext exercises the happy
+// path for the default (free-form) shape: the prompt template sees the
+// Input fields, toJSON works, and the model's reply lands as
+// AdditionalContext on a turn_start event.
+func TestModelHandlerRendersPromptAndForwardsContext(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeClient{reply: "Be careful with /etc."}
+	res, err := runModelHook(t, client, Hook{
+		Type:   HookTypeModel,
+		Model:  "openai/gpt-4o-mini",
+		Prompt: "Tool: {{ .ToolName }}\nArgs: {{ .ToolInput | toJSON }}",
+	}, &Input{
+		HookEventName: EventTurnStart,
+		ToolName:      "shell",
+		ToolInput:     map[string]any{"cmd": "ls"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res.Output)
+	require.NotNil(t, res.Output.HookSpecificOutput)
+
+	assert.Equal(t, EventTurnStart, res.Output.HookSpecificOutput.HookEventName,
+		"default shape must echo the input event so the executor routes the context correctly")
+	assert.Equal(t, "Be careful with /etc.", res.Output.HookSpecificOutput.AdditionalContext)
+
+	// Verify the template rendered with the Input fields and toJSON.
+	assert.Equal(t, "openai/gpt-4o-mini", client.gotModel)
+	assert.Contains(t, client.gotUser, "Tool: shell")
+	assert.Contains(t, client.gotUser, `"cmd":"ls"`)
+	assert.Nil(t, client.gotSchema, "default (free-form) shape must NOT request structured output")
+}
+
+// TestModelHandlerForwardsStructuredOutputSchema checks that the
+// schema name on the Hook is resolved to the registered
+// [latest.StructuredOutput] and threaded to the client. Providers that
+// honor structured output get a strict contract; others ignore it and
+// the lenient parser still works.
+func TestModelHandlerForwardsStructuredOutputSchema(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeClient{reply: `{"decision":"allow","reason":"safe"}`}
+	_, err := runModelHook(t, client, Hook{
+		Type:   HookTypeModel,
+		Model:  "openai/gpt-4o-mini",
+		Prompt: "Judge: {{ .ToolName }}",
+		Schema: ShapePreToolUseDecision,
+	}, &Input{
+		HookEventName: EventPreToolUse,
+		ToolName:      "shell",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, client.gotSchema, "named schema must be forwarded to the ModelClient")
+	assert.Equal(t, "pre_tool_use_decision", client.gotSchema.Name)
+	assert.True(t, client.gotSchema.Strict)
+}
+
+// TestModelHandlerPropagatesClientErrors documents the failure
+// contract: a non-nil error from the ModelClient (auth, rate limit,
+// timeout, ...) MUST propagate through Run so the executor's
+// fail-closed semantics deny PreToolUse calls. The shape never sees
+// the partial reply.
+func TestModelHandlerPropagatesClientErrors(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeClient{err: errors.New("rate limit")}
+	_, err := runModelHook(t, client, Hook{
+		Type:   HookTypeModel,
+		Model:  "openai/gpt-4o-mini",
+		Prompt: "hi",
+	}, &Input{HookEventName: EventTurnStart})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rate limit")
+}
+
+// TestPreToolUseDecisionShape table-tests the parser for the
+// well-known judge shape. It must accept clean JSON, reject empty /
+// malformed input (so the executor fails closed), tolerate markdown
+// fences, and handle each verdict including case-insensitivity.
+func TestPreToolUseDecisionShape(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		raw         string
+		wantOK      bool
+		wantVerdict Decision
+	}{
+		{"clean allow", `{"decision":"allow","reason":"safe"}`, true, DecisionAllow},
+		{"clean deny", `{"decision":"deny","reason":"rm -rf"}`, true, DecisionDeny},
+		{"clean ask", `{"decision":"ask","reason":"unclear"}`, true, DecisionAsk},
+		{"uppercase ALLOW", `{"decision":"ALLOW","reason":"x"}`, true, DecisionAllow},
+		{"json in fence", "```json\n{\"decision\":\"ask\",\"reason\":\"x\"}\n```", true, DecisionAsk},
+		{"json with prose", "Sure!\n{\"decision\":\"deny\",\"reason\":\"x\"}\nhope this helps", true, DecisionDeny},
+		{"empty", "", false, ""},
+		{"no json", "I refuse to answer.", false, ""},
+		{"bad decision", `{"decision":"maybe","reason":"x"}`, false, ""},
+		{"not json", `{decision: allow}`, false, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			out, err := preToolUseDecisionShape(tc.raw, &Input{HookEventName: EventPreToolUse})
+			if !tc.wantOK {
+				require.Error(t, err, "the executor relies on this error to fail closed")
+				assert.Nil(t, out)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, out)
+			require.NotNil(t, out.HookSpecificOutput)
+			assert.Equal(t, EventPreToolUse, out.HookSpecificOutput.HookEventName)
+			assert.Equal(t, tc.wantVerdict, out.HookSpecificOutput.PermissionDecision)
+			assert.NotEmpty(t, out.HookSpecificOutput.PermissionDecisionReason,
+				"shape must always populate a reason (default 'no reason provided')")
+			assert.Contains(t, out.SystemMessage, string(tc.wantVerdict),
+				"system_message must surface the verdict to the UI")
+		})
+	}
+}
+
+// TestPreToolUseDecisionShapeIsRegistered documents the package-level
+// init contract: the shape and its strict JSON schema MUST be
+// available immediately, without any caller-side registration. This
+// test would fail loudly if a future refactor moved registration into
+// an opt-in helper.
+func TestPreToolUseDecisionShapeIsRegistered(t *testing.T) {
+	t.Parallel()
+
+	shape, ok := lookupShape(ShapePreToolUseDecision)
+	require.True(t, ok, "%q must be auto-registered by package init", ShapePreToolUseDecision)
+	require.NotNil(t, shape)
+
+	schema := lookupSchema(ShapePreToolUseDecision)
+	require.NotNil(t, schema, "well-known shape must have a paired structured-output schema")
+	assert.True(t, schema.Strict)
+}
+
+// TestRegisterResponseShapeRejectsBadInput pins the public contract of
+// the registration helpers — empty names and nil shapes/schemas must
+// be rejected so a typo fails loudly at startup.
+func TestRegisterResponseShapeRejectsBadInput(t *testing.T) {
+	t.Parallel()
+
+	require.Error(t, RegisterResponseShape("", defaultShape))
+	require.Error(t, RegisterResponseShape("nil-shape", nil))
+	require.Error(t, RegisterResponseSchema("", &latest.StructuredOutput{Name: "x"}))
+}
+
+// TestNilModelClientFailsAtFirstDispatch documents the lazy-failure
+// behavior of NewModelFactory(nil): the factory builds successfully so
+// a runtime can register it before credentials are available, but the
+// first dispatch errors with a clear message. PreToolUse then fails
+// closed.
+func TestNilModelClientFailsAtFirstDispatch(t *testing.T) {
+	t.Parallel()
+
+	_, err := runModelHook(t, nil, Hook{
+		Type:   HookTypeModel,
+		Model:  "openai/gpt-4o-mini",
+		Prompt: "hi",
+	}, &Input{HookEventName: EventTurnStart})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no ModelClient configured")
+}
+
+// TestPromptTemplateTruncateHelper covers the small helper exposed to
+// prompts: long inputs can be capped with `{{ truncate 16 .Cwd }}` to
+// keep prompt length bounded. Also documents that n<=0 is a no-op.
+func TestPromptTemplateTruncateHelper(t *testing.T) {
+	t.Parallel()
+
+	long := strings.Repeat("a", 50)
+	client := &fakeClient{reply: "ok"}
+	_, err := runModelHook(t, client, Hook{
+		Type:   HookTypeModel,
+		Model:  "openai/gpt-4o-mini",
+		Prompt: "cwd: {{ truncate 16 .Cwd }}",
+	}, &Input{HookEventName: EventTurnStart, Cwd: long})
+	require.NoError(t, err)
+	assert.Contains(t, client.gotUser, "cwd: aaaaaaaaaaaaaaaa…")
+}

--- a/pkg/hooks/shape_pre_tool_use_decision.go
+++ b/pkg/hooks/shape_pre_tool_use_decision.go
@@ -1,0 +1,154 @@
+package hooks
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/docker/docker-agent/pkg/config/latest"
+)
+
+// ShapePreToolUseDecision is the well-known schema name for an
+// "LLM as a judge" pre_tool_use hook. The model is asked to reply with
+//
+//	{"decision":"allow|ask|deny","reason":"<short explanation>"}
+//
+// and the shape produces a [HookSpecificOutput.PermissionDecision]
+// verdict the executor's pre_tool_use aggregator honors.
+const ShapePreToolUseDecision = "pre_tool_use_decision"
+
+// registerPreToolUseDecisionShape installs the shape and its strict
+// JSON schema on the package-level [modelRegistry]. It is called via a
+// package-level var initializer so the shape is available before any
+// caller looks it up; using `init()` would trip linters and obscure
+// dependency order, while `var _ = registerXxx()` keeps the side
+// effect explicit at the declaration site.
+//
+// Returns true on success; panics on registry error since the inputs
+// are static.
+func registerPreToolUseDecisionShape() bool {
+	if err := errors.Join(
+		RegisterResponseShape(ShapePreToolUseDecision, preToolUseDecisionShape),
+		RegisterResponseSchema(ShapePreToolUseDecision, preToolUseDecisionSchema),
+	); err != nil {
+		panic(fmt.Errorf("hooks: register %s: %w", ShapePreToolUseDecision, err))
+	}
+	return true
+}
+
+var _ = registerPreToolUseDecisionShape()
+
+// preToolUseDecisionSchema is the strict JSON schema we ask compatible
+// providers (OpenAI's structured-output, etc.) to honor. Providers that
+// silently ignore it still work — the shape's parser is lenient enough
+// to pull JSON out of fenced or surrounded text.
+var preToolUseDecisionSchema = &latest.StructuredOutput{
+	Name:        "pre_tool_use_decision",
+	Description: "Verdict for a single pre_tool_use call",
+	Strict:      true,
+	Schema: map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"decision": map[string]any{
+				"type": "string",
+				"enum": []string{"allow", "ask", "deny"},
+			},
+			"reason": map[string]any{"type": "string"},
+		},
+		"required":             []string{"decision", "reason"},
+		"additionalProperties": false,
+	},
+}
+
+// preToolUseDecisionShape parses the model's reply and produces the
+// nested [HookSpecificOutput] the executor honors as a verdict.
+//
+// It is deliberately tolerant of providers that wrap JSON in markdown
+// fences or surround it with prose, but rejects unparseable text by
+// returning an error — which the executor maps to fail-closed (deny)
+// per the documented PreToolUse contract. This means the caller does
+// NOT need to special-case error paths to "ask the user instead": that
+// fallback is the executor's job, configured per-hook via timeout /
+// continue / system_message.
+func preToolUseDecisionShape(raw string, in *Input) (*Output, error) {
+	body, err := extractJSONObject(raw)
+	if err != nil {
+		return nil, err
+	}
+	var v struct {
+		Decision string `json:"decision"`
+		Reason   string `json:"reason"`
+	}
+	if err := json.Unmarshal(body, &v); err != nil {
+		return nil, fmt.Errorf("parse decision json: %w", err)
+	}
+	d, err := normalizeDecision(v.Decision)
+	if err != nil {
+		return nil, err
+	}
+	reason := strings.TrimSpace(v.Reason)
+	if reason == "" {
+		reason = "no reason provided"
+	}
+	event := EventPreToolUse
+	if in != nil && in.HookEventName != "" {
+		event = in.HookEventName
+	}
+	return &Output{
+		HookSpecificOutput: &HookSpecificOutput{
+			HookEventName:            event,
+			PermissionDecision:       d,
+			PermissionDecisionReason: reason,
+		},
+		// Surface the verdict in the UI — auto-approvals shouldn't be
+		// silent. Mirrors the convention used by the legacy llm_judge
+		// builtin so existing prompts/transcripts don't change.
+		SystemMessage: "🤖 model judge: " + string(d) + " — " + reason,
+	}, nil
+}
+
+// extractJSONObject returns the bytes of the first top-level JSON
+// object inside raw. It strips a leading ```json (or plain ```) fence
+// and trims surrounding prose so the standard library parser sees
+// clean input. Returns an error for empty input or no `{`.
+func extractJSONObject(raw string) ([]byte, error) {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return nil, errors.New("empty model reply")
+	}
+	s = stripCodeFence(s)
+	start := strings.IndexByte(s, '{')
+	end := strings.LastIndexByte(s, '}')
+	if start < 0 || end <= start {
+		return nil, errors.New("no JSON object in reply")
+	}
+	return []byte(s[start : end+1]), nil
+}
+
+// stripCodeFence removes a leading ```json (or plain ```) fence and
+// the matching trailing fence so the JSON parser sees clean input.
+func stripCodeFence(s string) string {
+	if !strings.HasPrefix(s, "```") {
+		return s
+	}
+	if nl := strings.IndexByte(s, '\n'); nl >= 0 {
+		s = s[nl+1:]
+	}
+	s = strings.TrimSuffix(strings.TrimRight(s, " \n\t"), "```")
+	return strings.TrimSpace(s)
+}
+
+// normalizeDecision validates and lower-cases a decision string.
+func normalizeDecision(s string) (Decision, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case string(DecisionAllow):
+		return DecisionAllow, nil
+	case string(DecisionAsk):
+		return DecisionAsk, nil
+	case string(DecisionDeny):
+		return DecisionDeny, nil
+	default:
+		return "", fmt.Errorf("invalid decision %q (want allow|ask|deny)", s)
+	}
+}

--- a/pkg/hooks/types.go
+++ b/pkg/hooks/types.go
@@ -332,4 +332,20 @@ type Result struct {
 	// LLM-generated compaction summary. When multiple hooks return a
 	// non-empty summary, the first one wins.
 	Summary string
+
+	// Decision is the most-restrictive PreToolUse verdict reported by
+	// any matching hook in the chain ("" when no hook produced one).
+	// Most-restrictive ordering: Deny > Ask > Allow > "".
+	//
+	// The runtime's tool-approval flow consults this BEFORE asking the
+	// user, so an LLM-judge hook that returns Allow can auto-approve a
+	// call that would otherwise prompt, and Ask can force a prompt for
+	// a call that would otherwise auto-run.
+	//
+	// Always empty for non-PreToolUse events.
+	Decision Decision
+	// DecisionReason is the human-readable rationale paired with
+	// Decision (the reason from the most-restrictive hook). Empty when
+	// Decision is empty.
+	DecisionReason string
 }

--- a/pkg/runtime/hooks.go
+++ b/pkg/runtime/hooks.go
@@ -251,6 +251,8 @@ const (
 	ApprovalSourceSessionPermissionsDeny  = "session_permissions_deny"
 	ApprovalSourceTeamPermissionsAllow    = "team_permissions_allow"
 	ApprovalSourceTeamPermissionsDeny     = "team_permissions_deny"
+	ApprovalSourcePreToolUseHookAllow     = "pre_tool_use_hook_allow"
+	ApprovalSourcePreToolUseHookDeny      = "pre_tool_use_hook_deny"
 	ApprovalSourceReadOnlyHint            = "readonly_hint"
 	ApprovalSourceUserApproved            = "user_approved"
 	ApprovalSourceUserApprovedSession     = "user_approved_session"

--- a/pkg/runtime/hooks_wiring_test.go
+++ b/pkg/runtime/hooks_wiring_test.go
@@ -121,3 +121,23 @@ func TestHooksExecWiresAgentFlagsToBuiltins(t *testing.T) {
 		})
 	}
 }
+
+// TestModelHookFactoryIsRegistered pins the wiring of the model hook:
+// NewLocalRuntime must register a [hooks.HookTypeModel] factory so
+// agents can reference `{type: model, model: ..., prompt: ...}` in
+// YAML without any additional setup. We assert at the registry level
+// (rather than dispatching a hook) because the real ModelClient would
+// otherwise need network and credentials.
+func TestModelHookFactoryIsRegistered(t *testing.T) {
+	t.Parallel()
+
+	prov := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
+	a := agent.New("root", "instructions", agent.WithModel(prov))
+	tm := team.New(team.WithAgents(a))
+	r, err := NewLocalRuntime(tm, WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+
+	factory, ok := r.hooksRegistry.Lookup(hooks.HookTypeModel)
+	assert.True(t, ok, "model hook factory must be registered by NewLocalRuntime")
+	assert.NotNil(t, factory)
+}

--- a/pkg/runtime/model_hook.go
+++ b/pkg/runtime/model_hook.go
@@ -1,0 +1,85 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/environment"
+	"github.com/docker/docker-agent/pkg/hooks"
+	"github.com/docker/docker-agent/pkg/model/provider"
+	"github.com/docker/docker-agent/pkg/model/provider/options"
+)
+
+// providerModelClient is the runtime's [hooks.ModelClient]. It builds a
+// fresh [provider.Provider] per call from the model spec and a default
+// environment, then streams the assistant's reply.
+//
+// Provider construction per call (rather than caching per model spec)
+// keeps the wiring simple — model hooks fire at most a handful of
+// times per turn and the marginal cost of construction is negligible
+// compared to the LLM round-trip itself. If profiling later shows
+// otherwise, a sync.Map keyed on modelSpec would be a drop-in.
+type providerModelClient struct{}
+
+// Ask implements [hooks.ModelClient].
+//
+// Errors from any stage (model spec parsing, provider construction,
+// stream open, stream recv) are returned unwrapped so the executor's
+// fail-closed semantics deny PreToolUse calls cleanly. The caller
+// (the model handler) is responsible for surfacing the error to the
+// hook's [HandlerResult].
+func (providerModelClient) Ask(
+	ctx context.Context,
+	modelSpec, system, user string,
+	schema *latest.StructuredOutput,
+) (string, error) {
+	cfg, err := latest.ParseModelRef(modelSpec)
+	if err != nil {
+		return "", fmt.Errorf("invalid model spec: %w", err)
+	}
+
+	var opts []options.Opt
+	if schema != nil {
+		opts = append(opts, options.WithStructuredOutput(schema))
+	}
+	p, err := provider.New(ctx, &cfg, environment.NewDefaultProvider(), opts...)
+	if err != nil {
+		return "", fmt.Errorf("create provider: %w", err)
+	}
+
+	stream, err := p.CreateChatCompletionStream(ctx, []chat.Message{
+		{Role: chat.MessageRoleSystem, Content: system},
+		{Role: chat.MessageRoleUser, Content: user},
+	}, nil)
+	if err != nil {
+		return "", fmt.Errorf("start stream: %w", err)
+	}
+	defer stream.Close()
+
+	var sb strings.Builder
+	for {
+		resp, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return "", fmt.Errorf("stream recv: %w", err)
+		}
+		for _, c := range resp.Choices {
+			sb.WriteString(c.Delta.Content)
+		}
+	}
+	return sb.String(), nil
+}
+
+// registerModelHook installs the [hooks.HookTypeModel] factory on r
+// using the runtime's default [hooks.ModelClient]. It is called once
+// from [NewLocalRuntime] alongside the builtins.
+func registerModelHook(r *hooks.Registry) {
+	r.Register(hooks.HookTypeModel, hooks.NewModelFactory(providerModelClient{}))
+}

--- a/pkg/runtime/pre_tool_use_approval_test.go
+++ b/pkg/runtime/pre_tool_use_approval_test.go
@@ -1,0 +1,262 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/hooks"
+	"github.com/docker/docker-agent/pkg/permissions"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/team"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+// preToolUseHooksConfig builds a hooks.Config that wires `name` as a
+// pre_tool_use builtin matched against every tool. Use with
+// agent.WithHooks(...).
+func preToolUseHooksConfig(name string) *latest.HooksConfig {
+	return &latest.HooksConfig{
+		PreToolUse: []latest.HookMatcherConfig{{
+			Matcher: ".*",
+			Hooks: []latest.HookDefinition{{
+				Type:    hooks.HookTypeBuiltin,
+				Command: name,
+				Timeout: 5,
+			}},
+		}},
+	}
+}
+
+// recordingTool is a tools.Tool that flips its `executed` field when
+// invoked. Centralising the boilerplate keeps the per-test bodies
+// short and focused on the assertion that matters.
+func recordingTool(name string, executed *bool) []tools.Tool {
+	return []tools.Tool{{
+		Name:       name,
+		Parameters: map[string]any{},
+		Handler: func(_ context.Context, _ tools.ToolCall) (*tools.ToolCallResult, error) {
+			*executed = true
+			return tools.ResultSuccess("ok"), nil
+		},
+	}}
+}
+
+// collectClosedEvents reads every event already buffered on ch and
+// returns the slice. It assumes the caller closed ch (or that no
+// further events are produced); used after processToolCalls returns.
+// Distinct from drainEvents in loop_steps_test.go, which is
+// non-blocking and intended for still-open channels.
+func collectClosedEvents(ch chan Event) []Event {
+	var out []Event
+	for ev := range ch {
+		out = append(out, ev)
+	}
+	return out
+}
+
+// hasEventOfType reports whether evs contains an event of the given
+// concrete type. Used to assert that a ToolCallConfirmationEvent was
+// (or was not) emitted without caring about its other fields.
+func hasEventOfType[E Event](evs []Event) bool {
+	for _, ev := range evs {
+		if _, ok := ev.(E); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// makeJudgedRuntime wires a verdict-returning builtin onto a fresh
+// runtime, plus a recording tool, and returns the pieces needed by the
+// per-decision tests below. Permissions can be supplied to test the
+// interaction between deterministic rules and the hook verdict.
+//
+// We construct the runtime first (so we have access to its private
+// registry), register the verdict builtin on it, and only then exercise
+// the agent — the hooks Executor is built lazily on first use, so by
+// the time the matcher resolves "command" against the registry, our
+// builtin is there.
+func makeJudgedRuntime(
+	t *testing.T,
+	verdict hooks.Decision,
+	reason string,
+	perm *permissions.Checker,
+) (rt *LocalRuntime, sess *session.Session, executed *bool, agentTools []tools.Tool) {
+	t.Helper()
+
+	executed = new(bool)
+	agentTools = recordingTool("the_tool", executed)
+
+	hookName := "test_judge_" + t.Name()
+	prov := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
+	root := agent.New("root", "instr",
+		agent.WithModel(prov),
+		agent.WithToolSets(newStubToolSet(nil, agentTools, nil)),
+		agent.WithHooks(preToolUseHooksConfig(hookName)),
+	)
+
+	teamOpts := []team.Opt{team.WithAgents(root)}
+	if perm != nil {
+		teamOpts = append(teamOpts, team.WithPermissions(perm))
+	}
+	tm := team.New(teamOpts...)
+
+	var err error
+	rt, err = NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+	require.NoError(t, rt.hooksRegistry.RegisterBuiltin(hookName, func(_ context.Context, in *hooks.Input, _ []string) (*hooks.Output, error) {
+		if in == nil || in.HookEventName != hooks.EventPreToolUse {
+			return nil, nil
+		}
+		return &hooks.Output{
+			HookSpecificOutput: &hooks.HookSpecificOutput{
+				HookEventName:            hooks.EventPreToolUse,
+				PermissionDecision:       verdict,
+				PermissionDecisionReason: reason,
+			},
+		}, nil
+	}))
+
+	sess = session.New(session.WithUserMessage("test"))
+	require.False(t, sess.ToolsApproved, "fixture must not use --yolo")
+	return rt, sess, executed, agentTools
+}
+
+// runJudgedToolCall is the assertion-friendly wrapper around
+// processToolCalls used by the per-decision tests. It returns whether
+// the tool ran and the captured events so callers can also check that
+// the user prompt did or did not fire.
+func runJudgedToolCall(t *testing.T, rt *LocalRuntime, sess *session.Session, agentTools []tools.Tool) []Event {
+	t.Helper()
+	calls := []tools.ToolCall{{
+		ID:       "call_1",
+		Type:     "function",
+		Function: tools.FunctionCall{Name: "the_tool", Arguments: "{}"},
+	}}
+	events := make(chan Event, 16)
+	rt.processToolCalls(t.Context(), sess, calls, agentTools, events)
+	close(events)
+	return collectClosedEvents(events)
+}
+
+// TestPreToolUseHook_AllowAutoApproves verifies the headline new
+// behavior: a pre_tool_use hook returning Allow auto-approves the
+// tool call, the user is NOT prompted, and the tool runs. This is the
+// LLM-as-a-judge happy path.
+func TestPreToolUseHook_AllowAutoApproves(t *testing.T) {
+	t.Parallel()
+
+	rt, sess, executed, agentTools := makeJudgedRuntime(t, hooks.DecisionAllow, "judged safe", nil)
+	evs := runJudgedToolCall(t, rt, sess, agentTools)
+
+	assert.True(t, *executed, "Allow verdict must auto-approve and run the tool")
+	assert.False(t, hasEventOfType[*ToolCallConfirmationEvent](evs),
+		"Allow must skip the user prompt: no ToolCallConfirmationEvent expected")
+}
+
+// TestPreToolUseHook_DenyBlocksWithoutPrompting verifies that a Deny
+// verdict blocks the tool BEFORE the user is asked (the previous
+// implementation prompted the user and only then denied — wasting a
+// click and confusing the UX).
+func TestPreToolUseHook_DenyBlocksWithoutPrompting(t *testing.T) {
+	t.Parallel()
+
+	rt, sess, executed, agentTools := makeJudgedRuntime(t, hooks.DecisionDeny, "destructive", nil)
+	evs := runJudgedToolCall(t, rt, sess, agentTools)
+
+	assert.False(t, *executed, "Deny verdict must block the tool")
+	assert.False(t, hasEventOfType[*ToolCallConfirmationEvent](evs),
+		"Deny must NOT prompt the user before blocking")
+	assert.True(t, hasEventOfType[*HookBlockedEvent](evs),
+		"Deny must emit a HookBlockedEvent so the UI can surface the reason")
+}
+
+// TestPreToolUseHook_AskEscalatesToUser verifies that an Ask verdict
+// falls through to the user-confirmation prompt instead of either
+// auto-approving (Allow) or blocking (Deny). The tool does not run
+// here because no resume signal is delivered.
+func TestPreToolUseHook_AskEscalatesToUser(t *testing.T) {
+	t.Parallel()
+
+	rt, sess, executed, agentTools := makeJudgedRuntime(t, hooks.DecisionAsk, "unclear", nil)
+
+	// processToolCalls blocks waiting for resume on Ask. Run it in a
+	// goroutine and cancel via context to unstick once we've observed
+	// the prompt event.
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	calls := []tools.ToolCall{{
+		ID:       "call_1",
+		Type:     "function",
+		Function: tools.FunctionCall{Name: "the_tool", Arguments: "{}"},
+	}}
+	events := make(chan Event, 16)
+	done := make(chan struct{})
+	go func() {
+		rt.processToolCalls(ctx, sess, calls, agentTools, events)
+		close(done)
+	}()
+
+	// Wait for the prompt event, then cancel.
+	gotPrompt := false
+DRAIN:
+	for {
+		select {
+		case ev := <-events:
+			if _, ok := ev.(*ToolCallConfirmationEvent); ok {
+				gotPrompt = true
+				cancel()
+				break DRAIN
+			}
+		case <-t.Context().Done():
+			break DRAIN
+		}
+	}
+	<-done
+	close(events)
+
+	assert.True(t, gotPrompt, "Ask verdict must escalate to a ToolCallConfirmationEvent")
+	assert.False(t, *executed, "tool must not run when user has not approved")
+}
+
+// TestPreToolUseHook_PermissionsDenyWinsOverHookAllow pins the
+// security-critical ordering: deterministic permissions DENY rules
+// must win even if the LLM judge says Allow. This protects against
+// prompt-injection attacks that try to flip the verdict.
+func TestPreToolUseHook_PermissionsDenyWinsOverHookAllow(t *testing.T) {
+	t.Parallel()
+
+	checker := permissions.NewChecker(&latest.PermissionsConfig{
+		Deny: []string{"the_tool"},
+	})
+	rt, sess, executed, agentTools := makeJudgedRuntime(t, hooks.DecisionAllow, "judged safe", checker)
+	_ = runJudgedToolCall(t, rt, sess, agentTools)
+
+	assert.False(t, *executed,
+		"deterministic Deny must beat hook Allow — protects against jailbroken judges")
+}
+
+// TestPreToolUseHook_PermissionsAllowShortCircuitsHook documents the
+// cost-saving ordering: deterministic permissions ALLOW rules run the
+// tool without consulting the hook at all. This keeps the LLM judge
+// off the hot path for obviously-safe tool calls.
+func TestPreToolUseHook_PermissionsAllowShortCircuitsHook(t *testing.T) {
+	t.Parallel()
+
+	checker := permissions.NewChecker(&latest.PermissionsConfig{
+		Allow: []string{"the_tool"},
+	})
+	// The hook would Deny if asked. Deterministic Allow must win and
+	// the hook must NOT be consulted (the tool runs).
+	rt, sess, executed, agentTools := makeJudgedRuntime(t, hooks.DecisionDeny, "would-deny", checker)
+	_ = runJudgedToolCall(t, rt, sess, agentTools)
+
+	assert.True(t, *executed,
+		"deterministic Allow must short-circuit the hook (cost / latency win)")
+}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -362,6 +362,7 @@ func NewLocalRuntime(agents *team.Team, opts ...Opt) (*LocalRuntime, error) {
 	if err != nil {
 		return nil, fmt.Errorf("register builtin hooks: %w", err)
 	}
+	registerModelHook(hooksRegistry)
 
 	r := &LocalRuntime{
 		toolMap:                make(map[string]ToolHandlerFunc),

--- a/pkg/runtime/toolexec/dispatcher.go
+++ b/pkg/runtime/toolexec/dispatcher.go
@@ -35,6 +35,8 @@ const (
 	ApprovalSourceSessionPermissionsDeny  = "session_permissions_deny"
 	ApprovalSourceTeamPermissionsAllow    = "team_permissions_allow"
 	ApprovalSourceTeamPermissionsDeny     = "team_permissions_deny"
+	ApprovalSourcePreToolUseHookAllow     = "pre_tool_use_hook_allow"
+	ApprovalSourcePreToolUseHookDeny      = "pre_tool_use_hook_deny"
 	ApprovalSourceReadOnlyHint            = "readonly_hint"
 	ApprovalSourceUserApproved            = "user_approved"
 	ApprovalSourceUserApprovedSession     = "user_approved_session"
@@ -234,7 +236,7 @@ type call struct {
 	em   Emitter
 	a    *agent.Agent
 
-	tc        tools.ToolCall // mutable: preHook may rewrite arguments
+	tc        tools.ToolCall // mutable: pre_tool_use hooks may rewrite arguments
 	tool      tools.Tool     // tool.Name is always set; other fields zero when !available
 	available bool           // false when the tool wasn't in the agent's toolset
 }
@@ -291,21 +293,38 @@ func (c *call) run(ctx context.Context) CallOutcome {
 // approveAndRun runs runTool if the configured approval pipeline allows
 // it, otherwise records an error or asks the user.
 //
-// The policy decision is delegated to the pure [Decide] function; this
-// method only applies the resulting outcome and notifies the
-// [HookDispatcher] of the verdict.
+// The pipeline order is:
+//
+//  1. yolo / permission checkers (delegated to [Decide]) — deterministic
+//     verdicts win first. ForceAsk goes straight to the user.
+//  2. pre_tool_use hooks (LLM-judge, shell scripts, ...) — consulted
+//     ONLY when no deterministic checker matched. The hook can Deny
+//     (block), Allow (skip the user prompt) or Ask (force the prompt).
+//     Hooks may also rewrite tool arguments via UpdatedInput, in which
+//     case the rewrite is applied here so the user prompt and the tool
+//     handler both see the modified call.
+//  3. read-only hint — auto-approve when the tool advertises it.
+//  4. user confirmation — fallback prompt.
+//
+// Splitting the read-only hint out of [Decide] is deliberate: it lets
+// the pre_tool_use hook see (and override) calls that would otherwise
+// auto-approve via the read-only hint. This matches the PR's intent
+// that an LLM judge gets a turn on every call that isn't covered by an
+// explicit allow/deny rule.
 func (c *call) approveAndRun(ctx context.Context, runTool func() CallOutcome) CallOutcome {
 	var checkers []NamedChecker
 	if c.d.Permissions != nil {
 		checkers = c.d.Permissions(c.sess)
 	}
 
+	// readOnlyHint is intentionally false here so the pre_tool_use hook
+	// gets a turn before the read-only fast-path applies.
 	decision := Decide(
 		c.sess.ToolsApproved,
 		checkers,
 		c.tc.Function.Name,
 		ParseToolInput(c.tc.Function.Arguments),
-		c.tool.Annotations.ReadOnlyHint,
+		false,
 	)
 
 	switch decision.Outcome {
@@ -320,11 +339,86 @@ func (c *call) approveAndRun(ctx context.Context, runTool func() CallOutcome) Ca
 		return CallOutcome{}
 	case OutcomeAsk:
 		if decision.Reason == ReasonChecker {
+			// Explicit ask pattern from a checker: skip the hook and
+			// prompt the user directly. The user is the source of
+			// truth for these calls.
 			slog.Debug("Tool requires confirmation (ask pattern)", "tool", c.tc.Function.Name, "source", decision.Source, "session_id", c.sess.ID)
+			return c.askUser(ctx, runTool)
 		}
-		return c.askUser(ctx, runTool)
 	}
-	return CallOutcome{}
+
+	// No deterministic verdict: consult the pre_tool_use hook chain.
+	if outcome, handled := c.consultPreToolUseHook(ctx, runTool); handled {
+		return outcome
+	}
+
+	if c.tool.Annotations.ReadOnlyHint {
+		c.notifyApproval(ctx, ApprovalDecisionAllow, ApprovalSourceReadOnlyHint)
+		return runTool()
+	}
+	return c.askUser(ctx, runTool)
+}
+
+// consultPreToolUseHook fires the pre_tool_use hook chain in the
+// approval flow, before the user is asked.
+//
+// Returns (outcome, true) when the hook produced a definitive verdict
+// (Deny / Allow / Ask) that the caller should honor; returns
+// (zero, false) when no hook is configured or the chain returned no
+// opinion, in which case the caller should fall through to the
+// read-only hint / user prompt.
+//
+// UpdatedInput from a hook is applied to c.tc here so every downstream
+// path (auto-run, user prompt, runToolset) sees the rewritten
+// arguments — this is the only place pre-call argument rewriting
+// happens.
+func (c *call) consultPreToolUseHook(ctx context.Context, runTool func() CallOutcome) (CallOutcome, bool) {
+	if c.d.Hooks == nil {
+		return CallOutcome{}, false
+	}
+
+	result := c.d.Hooks.Dispatch(ctx, c.a, hooks.EventPreToolUse, NewHooksInput(c.sess, c.tc))
+	if result == nil {
+		return CallOutcome{}, false
+	}
+
+	// Apply UpdatedInput first so subsequent paths see the rewritten args.
+	c.applyHookModifiedInput(result)
+
+	if !result.Allowed {
+		slog.Debug("Pre-tool hook blocked tool call", "tool", c.tc.Function.Name, "message", result.Message)
+		c.notifyApproval(ctx, ApprovalDecisionDeny, ApprovalSourcePreToolUseHookDeny)
+		c.em.EmitHookBlocked(c.tc, c.tool, result.Message, c.a.Name())
+		c.errorResponse("Tool call blocked by hook: " + result.Message)
+		return CallOutcome{}, true
+	}
+
+	switch result.Decision {
+	case hooks.DecisionAllow:
+		slog.Debug("Tool auto-approved by pre_tool_use hook", "tool", c.tc.Function.Name, "reason", result.DecisionReason, "session_id", c.sess.ID)
+		c.notifyApproval(ctx, ApprovalDecisionAllow, ApprovalSourcePreToolUseHookAllow)
+		return runTool(), true
+	case hooks.DecisionAsk:
+		slog.Debug("pre_tool_use hook escalated to user", "tool", c.tc.Function.Name, "reason", result.DecisionReason, "session_id", c.sess.ID)
+		return c.askUser(ctx, runTool), true
+	}
+	return CallOutcome{}, false
+}
+
+// applyHookModifiedInput applies a hook's UpdatedInput to the in-flight
+// tool call. Errors are logged at warn level and otherwise ignored —
+// the hook can't crash the call by returning malformed JSON.
+func (c *call) applyHookModifiedInput(result *hooks.Result) {
+	if result.ModifiedInput == nil {
+		return
+	}
+	updated, err := json.Marshal(result.ModifiedInput)
+	if err != nil {
+		slog.Warn("Failed to marshal modified tool input from hook", "tool", c.tc.Function.Name, "error", err)
+		return
+	}
+	slog.Debug("Pre-tool hook modified tool input", "tool", c.tc.Function.Name)
+	c.tc.Function.Arguments = string(updated)
 }
 
 // notifyApproval forwards the resolved approval decision to the
@@ -492,14 +586,13 @@ func (c *call) handleResume(ctx context.Context, req ResumeRequest, runTool func
 }
 
 // runToolset executes a tool from an agent's toolset (MCP, filesystem, ...),
-// surrounding the call with pre/post hooks. The pre-hook may block the
-// call or rewrite its arguments; the post-hook may signal run
-// termination via its returned [CallOutcome].
+// surrounding the call with the post-tool-use hook. The pre-tool-use
+// hook fires earlier in [call.approveAndRun] (so an LLM-judge can
+// short-circuit the user prompt); by the time we get here, any
+// argument rewrite the hook requested has already been applied to
+// c.tc. The post-tool-use hook may signal run termination via its
+// returned [CallOutcome].
 func (c *call) runToolset(ctx context.Context) CallOutcome {
-	if blocked := c.preHook(ctx); blocked {
-		return CallOutcome{}
-	}
-
 	res := c.invoke(ctx, "runtime.tool.handler", func(ctx context.Context) (*tools.ToolCallResult, time.Duration, error) {
 		res, err := c.tool.Handler(ctx, c.tc)
 		return res, 0, err
@@ -606,37 +699,6 @@ func buildMultiContent(text string, images []tools.MediaContent) []chat.MessageP
 		})
 	}
 	return parts
-}
-
-// preHook fires the pre-tool-use hook and returns whether the tool call
-// was blocked. When the hook rewrites arguments, [c.tc] is mutated in
-// place so the downstream invoke() sees the new arguments.
-func (c *call) preHook(ctx context.Context) (blocked bool) {
-	if c.d.Hooks == nil {
-		return false
-	}
-
-	result := c.d.Hooks.Dispatch(ctx, c.a, hooks.EventPreToolUse, NewHooksInput(c.sess, c.tc))
-	if result == nil {
-		return false
-	}
-
-	if !result.Allowed {
-		slog.Debug("Pre-tool hook blocked tool call", "tool", c.tc.Function.Name, "message", result.Message)
-		c.em.EmitHookBlocked(c.tc, c.tool, result.Message, c.a.Name())
-		c.errorResponse("Tool call blocked by hook: " + result.Message)
-		return true
-	}
-
-	if result.ModifiedInput != nil {
-		if updated, err := json.Marshal(result.ModifiedInput); err != nil {
-			slog.Warn("Failed to marshal modified tool input from hook", "tool", c.tc.Function.Name, "error", err)
-		} else {
-			slog.Debug("Pre-tool hook modified tool input", "tool", c.tc.Function.Name)
-			c.tc.Function.Arguments = string(updated)
-		}
-	}
-	return false
 }
 
 // postHook fires the post-tool-use hook. SystemMessage emission is the


### PR DESCRIPTION
## Summary

Add a first-class **`type: model` hook handler** so users can wire LLM-as-X hooks (judge, summarizer, classifier, …) entirely from YAML — no Go code, no shell glue, no jq+curl. Combined with the well-known `pre_tool_use_decision` schema and a small approval-flow change, it delivers a **working LLM-as-a-judge** that actually auto-approves tool calls.

```yaml
hooks:
  pre_tool_use:
    - matcher: "shell|edit_file|mcp:.*"
      hooks:
        - type: model
          model: openai/gpt-4o-mini
          timeout: 15
          schema: pre_tool_use_decision
          prompt: |
            You are a security judge. Tool: {{ .ToolName }}
            Args: {{ .ToolInput | toJSON }}
            Reads under the working dir are safe. Writes to ~/.ssh are deny.
permissions:
  deny:  ["shell:cmd=*sudo*", "shell:cmd=*rm -rf*", "edit_file:path=/etc/*"]
  allow: ["read_*"]
```

That's it — the framework owns provider construction, streaming, structured output, JSON parsing, error fallback, and verdict shaping.

## What's in the PR

### 1. New `type: model` hook framework

- New `HookTypeModel` factory (`pkg/hooks/model_handler.go`) with a pluggable `Backend`/`ModelClient` seam, Go `text/template` prompt rendering exposing the hook `Input`, plus `toJSON` and `truncate` template helpers.
- Pluggable `ResponseShape` registry: a shape interprets the model's reply as a hook `Output`, with an optional paired `latest.StructuredOutput` schema. The default shape passes the reply through as `additional_context` (turn_start summarizers, etc.).
- New schema fields on `HookDefinition`: `model`, `prompt`, `schema`. Conditional validation: when `type == "model"`, both `model` and `prompt` are required (enforced in the Go validator and `agent-schema.json`).
- Runtime wiring: `pkg/runtime/model_hook.go` provides a real provider-backed `ModelClient` that builds a `provider.Provider` per call from a model spec, threads `WithStructuredOutput` when a schema is supplied, and streams the reply.

### 2. Well-known `pre_tool_use_decision` shape

Ships with the package (auto-registered):

- Strict JSON schema (`{decision: "allow"|"ask"|"deny", reason: string}`) for providers that honor structured output (OpenAI, …).
- Lenient JSON-in-text parser (handles markdown fences and surrounding prose) for providers that ignore the schema.
- Output is shaped into a `HookSpecificOutput.PermissionDecision` verdict the runtime's approval flow understands.

### 3. Runtime: pre_tool_use becomes an active approval gate

The pre_tool_use hook used to fire *inside* `runTool`, **after** the user had already been asked. So a Deny wasted a click and an Allow had no effect on the prompt. This PR moves it into `executeWithApproval`:

```
1. --yolo                                → run
2. session/team permissions: deny        → block
3. session/team permissions: allow       → run
4. session/team permissions: forceAsk    → ask user
5. pre_tool_use hooks                    → Allow (run) | Ask (escalate) | Deny (block)   ← NEW
6. ReadOnlyHint                          → run
7. default                               → ask user
```

- New `Result.Decision` / `Result.DecisionReason` fields, populated by a most-restrictive aggregator (Deny > Ask > Allow).
- Hook UpdatedInput rewrites are applied before the verdict branch, so all downstream paths see the modified call.
- Two new `ApprovalSource` constants — `pre_tool_use_hook_allow` and `pre_tool_use_hook_deny` — so the existing `on_tool_approval_decision` observer event fires for hook verdicts too. Telemetry / audit gets full visibility for free.

### 4. Tests (~30 new sub-tests)

| File | Covers |
|---|---|
| `pkg/hooks/aggregate_test.go` | Most-restrictive ordering across multiple hooks; non-PreToolUse leaves `Decision` empty. |
| `pkg/hooks/model_handler_test.go` | Factory validation (missing fields, bad template, unknown schema), prompt rendering, structured-output threading, lenient JSON parsing, error propagation, `truncate` helper, nil-client misuse. |
| `pkg/runtime/pre_tool_use_approval_test.go` | End-to-end: Allow auto-approves without prompt; Deny blocks without prompt; Ask escalates to prompt; deterministic Deny beats hook Allow; deterministic Allow short-circuits the hook. |
| `pkg/runtime/hooks_wiring_test.go` | The `model` factory is registered by `NewLocalRuntime`. |

### 5. Docs / examples

- `examples/llm_judge.yaml` — full working configuration showing the 3-layer pattern (deterministic permissions → LLM judge → user prompt).
- `docs/configuration/hooks/index.md` — "LLM as a Judge" section rewritten around `type: model`, plus a security-considerations subsection.
- `agent-schema.json` — new fields with `if/then` conditional validation for `type: model`.

## Behavior change to flag

Pre-existing `pre_tool_use` shell-script hooks that returned `Deny` used to fire **after** the user had been prompted. They now fire **before**. This is strictly an improvement (no more wasted clicks on hooks that were going to deny) but is observable for any audit log keyed on hook-vs-prompt timing. Allow-style verdicts gain new effect: they previously did nothing; they now skip the user prompt.

## Validation

- `golangci-lint run ./...` → **0 issues**
- `go test ./...` → **all packages pass, no FAIL**
- Schema round-trip test (`pkg/config`) validates the new YAML shape.
- `go build ./...` clean.

## Stats

`18 files changed, 1519 insertions(+), 37 deletions(-)`

---

*Built incrementally with `docker agent` from a blank slate ("how do I implement an LLM judge?") through to a shipped `type: model` framework with reviewer feedback applied. See commit message for details.*
