### PR TITLE
feat(modelerrors): surface structured provider error details on non-2xx responses

### DIFF
--- a/pkg/modelerrors/modelerrors.go
+++ b/pkg/modelerrors/modelerrors.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -499,16 +500,31 @@ func formatProviderError(p *providerErrorBody) string {
 
 // firstJSONObject returns the first complete JSON object found in s, or nil.
 // encoding/json handles escaped quotes and braces inside string values.
+// Limits parsing to 1MB to prevent memory exhaustion from malicious or
+// accidentally huge error responses.
+//
+// To handle '{' characters in URLs or status text (e.g., "param={value}"),
+// we try parsing from each '{' position until we find valid JSON.
 func firstJSONObject(s string) []byte {
-	start := strings.IndexByte(s, '{')
-	if start < 0 {
-		return nil
+	const maxJSONSize = 1 << 20 // 1MB
+
+	pos := 0
+	for {
+		idx := strings.IndexByte(s[pos:], '{')
+		if idx < 0 {
+			return nil
+		}
+		start := pos + idx
+
+		reader := io.LimitReader(strings.NewReader(s[start:]), maxJSONSize)
+		var raw json.RawMessage
+		if err := json.NewDecoder(reader).Decode(&raw); err == nil {
+			// Successfully decoded JSON
+			return raw
+		}
+		// Try next '{' position
+		pos = start + 1
 	}
-	var raw json.RawMessage
-	if err := json.NewDecoder(strings.NewReader(s[start:])).Decode(&raw); err != nil {
-		return nil
-	}
-	return raw
 }
 
 // scalarString renders a JSON scalar as text. JSON numbers decode to float64;

--- a/pkg/modelerrors/modelerrors.go
+++ b/pkg/modelerrors/modelerrors.go
@@ -32,17 +32,11 @@ type StatusError struct {
 
 func (e *StatusError) Error() string {
 	underlying := e.Err.Error()
-	// Try to lift structured details out of the SDK error message (URL +
-	// JSON body envelope produced by anthropic-sdk-go / openai-go / etc.).
-	// When successful, this strips the URL noise and surfaces the actual
-	// fields the provider sent (error.type, error.message, error.code,
-	// error.param, status, request id) instead of just "400 Bad Request".
-	if details, requestID := parseProviderErrorDetails(underlying); details != "" {
-		msg := fmt.Sprintf("HTTP %d: %s", e.StatusCode, details)
-		if requestID != "" {
-			msg += fmt.Sprintf(" (Request-ID: %s)", requestID)
-		}
-		return msg
+	// Lift structured details out of the SDK error envelope (URL + status +
+	// JSON body) when possible, so the user sees what the provider actually
+	// said instead of a generic "400 Bad Request".
+	if details := parseProviderError(underlying); details != "" {
+		return fmt.Sprintf("HTTP %d: %s", e.StatusCode, details)
 	}
 	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, underlying)
 }
@@ -409,8 +403,8 @@ func ClassifyModelError(err error) (retryable, rateLimited bool, retryAfter time
 
 // FormatError returns a user-friendly error message for model errors.
 // Context overflow gets a dedicated actionable message; other errors fall
-// through to err.Error() — for HTTP errors that comes from *StatusError,
-// which itself extracts structured provider details (see parseProviderErrorDetails).
+// through to err.Error(). For HTTP errors that text comes from *StatusError,
+// which itself extracts structured provider details (see parseProviderError).
 func FormatError(err error) string {
 	if err == nil {
 		return ""
@@ -429,8 +423,8 @@ func FormatError(err error) string {
 // and openai-go append between the status text and the response body.
 var requestIDRegex = regexp.MustCompile(`\(Request-ID:\s*([^)\s]+)\)`)
 
-// providerErrorBody is the union of the JSON shapes returned by major LLM
-// providers in non-2xx responses:
+// providerErrorBody is the union of JSON shapes returned by major LLM
+// providers in non-2xx response bodies:
 //
 //	Anthropic   {"type":"error","error":{"type":"...","message":"..."}}
 //	OpenAI      {"error":{"message":"...","type":"...","code":"...","param":"..."}}
@@ -438,123 +432,100 @@ var requestIDRegex = regexp.MustCompile(`\(Request-ID:\s*([^)\s]+)\)`)
 //	Proxies     {"message":"Bad Request"}
 type providerErrorBody struct {
 	Error *struct {
-		Type    string          `json:"type"`
-		Message string          `json:"message"`
-		Code    json.RawMessage `json:"code"`  // string (OpenAI) or int (Gemini)
-		Param   json.RawMessage `json:"param"` // string or null
-		Status  string          `json:"status"`
+		Type    string `json:"type"`
+		Message string `json:"message"`
+		Code    any    `json:"code"`  // string (OpenAI) or number (Gemini)
+		Param   any    `json:"param"` // string or null
+		Status  string `json:"status"`
 	} `json:"error"`
 	Message string `json:"message"`
 }
 
-// parseProviderErrorDetails extracts a focused, human-readable details line
-// and the request id (if present) from a provider SDK error message.
+// parseProviderError returns a focused details line lifted from an SDK error
+// message of the form
 //
-// Input is the full err.Error() string of the underlying SDK error, which
-// for anthropic-sdk-go / openai-go has the shape:
+//	<METHOD> "<URL>": <code> <statusText>[ (Request-ID: <id>)] <jsonBody>
 //
-//	POST "<URL>": <code> <statusText> [(Request-ID: <id>)] <jsonBody>
-//
-// Output is the structured details from the JSON body (provider error type,
-// message, code, param, status). Returns ("", "") when no JSON body is
-// present or it parses to nothing useful.
-func parseProviderErrorDetails(s string) (details, requestID string) {
-	if m := requestIDRegex.FindStringSubmatch(s); len(m) >= 2 {
-		requestID = m[1]
-	}
-	body := extractFirstJSONObject(s)
-	if body == "" {
-		return "", requestID
+// Returns "" when no JSON body is present or it has no recognised fields.
+func parseProviderError(s string) string {
+	body := firstJSONObject(s)
+	if body == nil {
+		return ""
 	}
 	var parsed providerErrorBody
-	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
-		return "", requestID
+	if json.Unmarshal(body, &parsed) != nil {
+		return ""
 	}
-
-	switch {
-	case parsed.Error != nil && parsed.Error.Message != "":
-		var b strings.Builder
-		if parsed.Error.Type != "" {
-			b.WriteString(parsed.Error.Type)
-			b.WriteString(": ")
-		}
-		b.WriteString(parsed.Error.Message)
-
-		var meta []string
-		if code := unquoteJSONScalar(parsed.Error.Code); code != "" {
-			meta = append(meta, "code="+code)
-		}
-		if param := unquoteJSONScalar(parsed.Error.Param); param != "" {
-			meta = append(meta, "param="+param)
-		}
-		if parsed.Error.Status != "" && !strings.EqualFold(parsed.Error.Status, parsed.Error.Type) {
-			meta = append(meta, "status="+parsed.Error.Status)
-		}
-		if len(meta) > 0 {
-			b.WriteString(" (")
-			b.WriteString(strings.Join(meta, ", "))
-			b.WriteString(")")
-		}
-		return b.String(), requestID
-	case parsed.Message != "":
-		return parsed.Message, requestID
+	details := formatProviderError(&parsed)
+	if details == "" {
+		return ""
 	}
-	return "", requestID
+	if m := requestIDRegex.FindStringSubmatch(s); len(m) >= 2 {
+		details += " (Request-ID: " + m[1] + ")"
+	}
+	return details
 }
 
-// extractFirstJSONObject returns the first balanced top-level JSON object
-// substring of s (from the first '{' through its matching '}'), correctly
-// skipping braces that appear inside JSON string literals. Returns "" if
-// no balanced object is found.
-func extractFirstJSONObject(s string) string {
+// formatProviderError renders a parsed body as
+//
+//	<error.type>: <error.message> (code=..., param=..., status=...)
+//
+// Falls back to the top-level `message` field for minimal/proxy bodies.
+// Returns "" when the body has nothing useful.
+func formatProviderError(p *providerErrorBody) string {
+	if p.Error == nil || p.Error.Message == "" {
+		return p.Message
+	}
+	msg := p.Error.Message
+	if p.Error.Type != "" {
+		msg = p.Error.Type + ": " + msg
+	}
+
+	var meta []string
+	if code := scalarString(p.Error.Code); code != "" {
+		meta = append(meta, "code="+code)
+	}
+	if param := scalarString(p.Error.Param); param != "" {
+		meta = append(meta, "param="+param)
+	}
+	if p.Error.Status != "" && !strings.EqualFold(p.Error.Status, p.Error.Type) {
+		meta = append(meta, "status="+p.Error.Status)
+	}
+	if len(meta) > 0 {
+		msg += " (" + strings.Join(meta, ", ") + ")"
+	}
+	return msg
+}
+
+// firstJSONObject returns the first complete JSON object found in s, or nil.
+// encoding/json handles escaped quotes and braces inside string values.
+func firstJSONObject(s string) []byte {
 	start := strings.IndexByte(s, '{')
 	if start < 0 {
-		return ""
+		return nil
 	}
-	depth := 0
-	inString := false
-	escaped := false
-	for i := start; i < len(s); i++ {
-		c := s[i]
-		if escaped {
-			escaped = false
-			continue
-		}
-		if inString {
-			switch c {
-			case '\\':
-				escaped = true
-			case '"':
-				inString = false
-			}
-			continue
-		}
-		switch c {
-		case '"':
-			inString = true
-		case '{':
-			depth++
-		case '}':
-			depth--
-			if depth == 0 {
-				return s[start : i+1]
-			}
-		}
+	var raw json.RawMessage
+	if err := json.NewDecoder(strings.NewReader(s[start:])).Decode(&raw); err != nil {
+		return nil
 	}
-	return ""
+	return raw
 }
 
-// unquoteJSONScalar returns the textual representation of a JSON scalar
-// (string or number). Returns "" for null / empty / non-scalar values.
-func unquoteJSONScalar(raw json.RawMessage) string {
-	s := strings.TrimSpace(string(raw))
-	if s == "" || s == "null" {
+// scalarString renders a JSON scalar as text. JSON numbers decode to float64;
+// whole numbers are rendered without a trailing ".0" so a code of 400 prints
+// as "400". Returns "" for nil and empty strings.
+func scalarString(v any) string {
+	switch x := v.(type) {
+	case nil:
 		return ""
+	case string:
+		return x
+	case float64:
+		if x == float64(int64(x)) {
+			return strconv.FormatInt(int64(x), 10)
+		}
+		return strconv.FormatFloat(x, 'g', -1, 64)
+	default:
+		return fmt.Sprint(v)
 	}
-	var str string
-	if err := json.Unmarshal(raw, &str); err == nil {
-		return str
-	}
-	// Numeric or other scalar — return as-is.
-	return s
 }

--- a/pkg/modelerrors/modelerrors.go
+++ b/pkg/modelerrors/modelerrors.go
@@ -6,6 +6,7 @@ package modelerrors
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -30,7 +31,20 @@ type StatusError struct {
 }
 
 func (e *StatusError) Error() string {
-	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Err.Error())
+	underlying := e.Err.Error()
+	// Try to lift structured details out of the SDK error message (URL +
+	// JSON body envelope produced by anthropic-sdk-go / openai-go / etc.).
+	// When successful, this strips the URL noise and surfaces the actual
+	// fields the provider sent (error.type, error.message, error.code,
+	// error.param, status, request id) instead of just "400 Bad Request".
+	if details, requestID := parseProviderErrorDetails(underlying); details != "" {
+		msg := fmt.Sprintf("HTTP %d: %s", e.StatusCode, details)
+		if requestID != "" {
+			msg += fmt.Sprintf(" (Request-ID: %s)", requestID)
+		}
+		return msg
+	}
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, underlying)
 }
 
 func (e *StatusError) Unwrap() error {
@@ -394,8 +408,9 @@ func ClassifyModelError(err error) (retryable, rateLimited bool, retryAfter time
 }
 
 // FormatError returns a user-friendly error message for model errors.
-// Context overflow gets a dedicated actionable message; all other errors
-// pass through their original message.
+// Context overflow gets a dedicated actionable message; other errors fall
+// through to err.Error() — for HTTP errors that comes from *StatusError,
+// which itself extracts structured provider details (see parseProviderErrorDetails).
 func FormatError(err error) string {
 	if err == nil {
 		return ""
@@ -408,4 +423,138 @@ func FormatError(err error) string {
 	}
 
 	return err.Error()
+}
+
+// requestIDRegex matches the `(Request-ID: <id>)` segment that anthropic-sdk-go
+// and openai-go append between the status text and the response body.
+var requestIDRegex = regexp.MustCompile(`\(Request-ID:\s*([^)\s]+)\)`)
+
+// providerErrorBody is the union of the JSON shapes returned by major LLM
+// providers in non-2xx responses:
+//
+//	Anthropic   {"type":"error","error":{"type":"...","message":"..."}}
+//	OpenAI      {"error":{"message":"...","type":"...","code":"...","param":"..."}}
+//	Gemini      {"error":{"code":N,"message":"...","status":"..."}}
+//	Proxies     {"message":"Bad Request"}
+type providerErrorBody struct {
+	Error *struct {
+		Type    string          `json:"type"`
+		Message string          `json:"message"`
+		Code    json.RawMessage `json:"code"`  // string (OpenAI) or int (Gemini)
+		Param   json.RawMessage `json:"param"` // string or null
+		Status  string          `json:"status"`
+	} `json:"error"`
+	Message string `json:"message"`
+}
+
+// parseProviderErrorDetails extracts a focused, human-readable details line
+// and the request id (if present) from a provider SDK error message.
+//
+// Input is the full err.Error() string of the underlying SDK error, which
+// for anthropic-sdk-go / openai-go has the shape:
+//
+//	POST "<URL>": <code> <statusText> [(Request-ID: <id>)] <jsonBody>
+//
+// Output is the structured details from the JSON body (provider error type,
+// message, code, param, status). Returns ("", "") when no JSON body is
+// present or it parses to nothing useful.
+func parseProviderErrorDetails(s string) (details, requestID string) {
+	if m := requestIDRegex.FindStringSubmatch(s); len(m) >= 2 {
+		requestID = m[1]
+	}
+	body := extractFirstJSONObject(s)
+	if body == "" {
+		return "", requestID
+	}
+	var parsed providerErrorBody
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		return "", requestID
+	}
+
+	switch {
+	case parsed.Error != nil && parsed.Error.Message != "":
+		var b strings.Builder
+		if parsed.Error.Type != "" {
+			b.WriteString(parsed.Error.Type)
+			b.WriteString(": ")
+		}
+		b.WriteString(parsed.Error.Message)
+
+		var meta []string
+		if code := unquoteJSONScalar(parsed.Error.Code); code != "" {
+			meta = append(meta, "code="+code)
+		}
+		if param := unquoteJSONScalar(parsed.Error.Param); param != "" {
+			meta = append(meta, "param="+param)
+		}
+		if parsed.Error.Status != "" && !strings.EqualFold(parsed.Error.Status, parsed.Error.Type) {
+			meta = append(meta, "status="+parsed.Error.Status)
+		}
+		if len(meta) > 0 {
+			b.WriteString(" (")
+			b.WriteString(strings.Join(meta, ", "))
+			b.WriteString(")")
+		}
+		return b.String(), requestID
+	case parsed.Message != "":
+		return parsed.Message, requestID
+	}
+	return "", requestID
+}
+
+// extractFirstJSONObject returns the first balanced top-level JSON object
+// substring of s (from the first '{' through its matching '}'), correctly
+// skipping braces that appear inside JSON string literals. Returns "" if
+// no balanced object is found.
+func extractFirstJSONObject(s string) string {
+	start := strings.IndexByte(s, '{')
+	if start < 0 {
+		return ""
+	}
+	depth := 0
+	inString := false
+	escaped := false
+	for i := start; i < len(s); i++ {
+		c := s[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if inString {
+			switch c {
+			case '\\':
+				escaped = true
+			case '"':
+				inString = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inString = true
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return s[start : i+1]
+			}
+		}
+	}
+	return ""
+}
+
+// unquoteJSONScalar returns the textual representation of a JSON scalar
+// (string or number). Returns "" for null / empty / non-scalar values.
+func unquoteJSONScalar(raw json.RawMessage) string {
+	s := strings.TrimSpace(string(raw))
+	if s == "" || s == "null" {
+		return ""
+	}
+	var str string
+	if err := json.Unmarshal(raw, &str); err == nil {
+		return str
+	}
+	// Numeric or other scalar — return as-is.
+	return s
 }

--- a/pkg/modelerrors/modelerrors_test.go
+++ b/pkg/modelerrors/modelerrors_test.go
@@ -533,3 +533,94 @@ func TestClassifyModelError(t *testing.T) {
 		assert.Equal(t, time.Duration(0), retryAfter)
 	})
 }
+
+func TestStatusErrorEdgeCases(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty JSON object falls back to underlying", func(t *testing.T) {
+		t.Parallel()
+		inner := errors.New(`POST "/v1/x": 400 Bad Request {}`)
+		se := &StatusError{StatusCode: 400, Err: inner}
+		assert.Equal(t, `HTTP 400: POST "/v1/x": 400 Bad Request {}`, se.Error())
+	})
+
+	t.Run("malformed JSON falls back to underlying", func(t *testing.T) {
+		t.Parallel()
+		inner := errors.New(`POST "/v1/x": 400 Bad Request {"error":{"message":"test"`)
+		se := &StatusError{StatusCode: 400, Err: inner}
+		assert.Equal(t, `HTTP 400: POST "/v1/x": 400 Bad Request {"error":{"message":"test"`, se.Error())
+	})
+
+	t.Run("multiple JSON objects extracts first", func(t *testing.T) {
+		t.Parallel()
+		inner := errors.New(`POST "/v1/x": 400 Bad Request {"message":"First"} {"message":"Second"}`)
+		se := &StatusError{StatusCode: 400, Err: inner}
+		assert.Equal(t, "HTTP 400: First", se.Error())
+	})
+
+	t.Run("unicode in error message", func(t *testing.T) {
+		t.Parallel()
+		inner := errors.New(`POST "/v1/x": 400 Bad Request {"message":"Invalid emoji: 😀"}`)
+		se := &StatusError{StatusCode: 400, Err: inner}
+		assert.Equal(t, "HTTP 400: Invalid emoji: 😀", se.Error())
+	})
+
+	t.Run("very large number in code field", func(t *testing.T) {
+		t.Parallel()
+		inner := errors.New(`{"error":{"code":9007199254740992,"message":"test"}}`)
+		se := &StatusError{StatusCode: 400, Err: inner}
+		// Large float64 that exceeds int64 range should still format
+		assert.Contains(t, se.Error(), "test")
+		assert.Contains(t, se.Error(), "code=")
+	})
+
+	t.Run("request-id with special characters", func(t *testing.T) {
+		t.Parallel()
+		inner := errors.New(`POST "/v1/x": 400 Bad Request (Request-ID: req_abc-123_XYZ) {"message":"test"}`)
+		se := &StatusError{StatusCode: 400, Err: inner}
+		assert.Equal(t, "HTTP 400: test (Request-ID: req_abc-123_XYZ)", se.Error())
+	})
+
+	t.Run("brace in URL before JSON", func(t *testing.T) {
+		t.Parallel()
+		// Ensure we don't mistake a '{' in the URL for the start of JSON
+		inner := errors.New(`POST "https://api.example.com/v1/messages?param={value}": 400 Bad Request {"message":"test"}`)
+		se := &StatusError{StatusCode: 400, Err: inner}
+		assert.Equal(t, "HTTP 400: test", se.Error())
+	})
+
+	t.Run("nested JSON in message field", func(t *testing.T) {
+		t.Parallel()
+		// The message field itself contains JSON-like text
+		inner := errors.New(`{"error":{"message":"Expected format: {\"key\":\"value\"}"}}`)
+		se := &StatusError{StatusCode: 400, Err: inner}
+		assert.Contains(t, se.Error(), `Expected format: {"key":"value"}`)
+	})
+}
+
+func TestScalarStringEdgeCases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    any
+		expected string
+	}{
+		{name: "nil", input: nil, expected: ""},
+		{name: "empty string", input: "", expected: ""},
+		{name: "normal string", input: "test", expected: "test"},
+		{name: "whole number", input: float64(400), expected: "400"},
+		{name: "decimal number", input: float64(3.14), expected: "3.14"},
+		{name: "negative whole", input: float64(-500), expected: "-500"},
+		{name: "zero", input: float64(0), expected: "0"},
+		{name: "bool true", input: true, expected: "true"},
+		{name: "bool false", input: false, expected: "false"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, scalarString(tt.input))
+		})
+	}
+}

--- a/pkg/modelerrors/modelerrors_test.go
+++ b/pkg/modelerrors/modelerrors_test.go
@@ -239,6 +239,103 @@ func TestFormatError(t *testing.T) {
 		err := errors.New("authentication failed")
 		assert.Equal(t, "authentication failed", FormatError(err))
 	})
+
+	t.Run("context overflow takes precedence over status formatting", func(t *testing.T) {
+		t.Parallel()
+		underlying := errors.New("prompt is too long: 226360 tokens > 200000 maximum")
+		wrapped := NewContextOverflowError(&StatusError{StatusCode: 400, Err: underlying})
+		msg := FormatError(wrapped)
+		assert.Contains(t, msg, "context window")
+		assert.Contains(t, msg, "/compact")
+	})
+}
+
+func TestStatusErrorParsesProviderBody(t *testing.T) {
+	t.Parallel()
+
+	t.Run("opaque proxy body strips URL noise but keeps the message", func(t *testing.T) {
+		t.Parallel()
+		// This is the case the user reported: the Docker AI gateway returns
+		// only {"message":"Bad Request"}, no structured details.
+		inner := errors.New(`POST "https://ai-backend-service-stage.docker.com/proxy/v1/messages?beta=true": 400 Bad Request {"message":"Bad Request"}`)
+		se := &StatusError{StatusCode: 400, Err: inner}
+		assert.Equal(t, "HTTP 400: Bad Request", se.Error())
+	})
+
+	t.Run("anthropic-style body surfaces error.type and error.message", func(t *testing.T) {
+		t.Parallel()
+		inner := errors.New(`POST "https://api.anthropic.com/v1/messages": 400 Bad Request {"type":"error","error":{"type":"invalid_request_error","message":"prompt is too long: 226360 tokens > 200000 maximum"}}`)
+		se := &StatusError{StatusCode: 400, Err: inner}
+		assert.Equal(t,
+			"HTTP 400: invalid_request_error: prompt is too long: 226360 tokens > 200000 maximum",
+			se.Error())
+	})
+
+	t.Run("anthropic-style body keeps the request id", func(t *testing.T) {
+		t.Parallel()
+		inner := errors.New(`POST "https://api.anthropic.com/v1/messages": 400 Bad Request (Request-ID: req_abc123) {"type":"error","error":{"type":"invalid_request_error","message":"max_tokens: Field required"}}`)
+		se := &StatusError{StatusCode: 400, Err: inner}
+		assert.Equal(t,
+			"HTTP 400: invalid_request_error: max_tokens: Field required (Request-ID: req_abc123)",
+			se.Error())
+	})
+
+	t.Run("openai-style body surfaces type, message, code and param", func(t *testing.T) {
+		t.Parallel()
+		inner := errors.New(`POST "https://api.openai.com/v1/chat/completions": 400 Bad Request {"error":{"message":"Invalid model 'foo-bar'","type":"invalid_request_error","param":"model","code":"model_not_found"}}`)
+		se := &StatusError{StatusCode: 400, Err: inner}
+		assert.Equal(t,
+			"HTTP 400: invalid_request_error: Invalid model 'foo-bar' (code=model_not_found, param=model)",
+			se.Error())
+	})
+
+	t.Run("gemini-style body surfaces numeric code and status", func(t *testing.T) {
+		t.Parallel()
+		inner := errors.New(`{"error":{"code":400,"message":"Invalid value at 'contents[0].parts[0]'","status":"INVALID_ARGUMENT"}}`)
+		se := &StatusError{StatusCode: 400, Err: inner}
+		assert.Equal(t,
+			"HTTP 400: Invalid value at 'contents[0].parts[0]' (code=400, status=INVALID_ARGUMENT)",
+			se.Error())
+	})
+
+	t.Run("openai-style body with null param omits param meta", func(t *testing.T) {
+		t.Parallel()
+		inner := errors.New(`POST "/v1/chat": 401 Unauthorized {"error":{"message":"Incorrect API key provided","type":"invalid_request_error","param":null,"code":"invalid_api_key"}}`)
+		se := &StatusError{StatusCode: 401, Err: inner}
+		assert.Equal(t,
+			"HTTP 401: invalid_request_error: Incorrect API key provided (code=invalid_api_key)",
+			se.Error())
+	})
+
+	t.Run("falls back to underlying message when no JSON body", func(t *testing.T) {
+		t.Parallel()
+		// No JSON, no URL — keep the existing simple format.
+		se := &StatusError{StatusCode: 429, Err: errors.New("rate limit exceeded")}
+		assert.Equal(t, "HTTP 429: rate limit exceeded", se.Error())
+	})
+
+	t.Run("falls back to underlying message when JSON has no useful fields", func(t *testing.T) {
+		t.Parallel()
+		se := &StatusError{StatusCode: 500, Err: errors.New(`POST "/v1/x": 500 Internal Server Error {"foo":"bar"}`)}
+		assert.Equal(t, `HTTP 500: POST "/v1/x": 500 Internal Server Error {"foo":"bar"}`, se.Error())
+	})
+
+	t.Run("handles braces inside string values", func(t *testing.T) {
+		t.Parallel()
+		inner := errors.New(`POST "/v1/x": 400 Bad Request {"error":{"type":"invalid_request_error","message":"unexpected token '}' in payload"}}`)
+		se := &StatusError{StatusCode: 400, Err: inner}
+		assert.Equal(t,
+			"HTTP 400: invalid_request_error: unexpected token '}' in payload",
+			se.Error())
+	})
+
+	t.Run("context overflow detection still works on cleaned message", func(t *testing.T) {
+		t.Parallel()
+		inner := errors.New(`POST "/v1/messages": 400 Bad Request {"type":"error","error":{"type":"invalid_request_error","message":"prompt is too long: 226360 tokens > 200000 maximum"}}`)
+		se := &StatusError{StatusCode: 400, Err: inner}
+		assert.True(t, IsContextOverflowError(se),
+			"context-overflow phrasing must remain detectable in StatusError.Error()")
+	})
 }
 
 func TestParseRetryAfterHeader(t *testing.T) {


### PR DESCRIPTION
## What

Adds the four lifecycle hook events that Claude Code, OpenCode, and `pi` all expose but docker-agent did not, plus a small documentation fix.

## Why

While auditing how docker-agent's hook system compares to peer AI coding agents, four events stood out as universally supported by competitors but missing from us. Each one unlocks a real use case that today either has to be hacked in via `pre_tool_use`/`on_user_input` or simply isn't possible.

## New hook events

| Event | When it fires | Can shape behaviour? |
|---|---|---|
| `user_prompt_submit` | Once per real user message in `RunStream`, after `session_start` and before the first model call. Skipped for sub-sessions (whose kick-off message is synthesised by the runtime). | Block submission, or contribute transient `additional_context` for that turn. |
| `pre_compact` | Inside `summarizeWithSource` before context compaction. Trigger source (`manual` / `auto` / `overflow` / `tool_overflow`) is reported in `Input.Source`. | Cancel compaction, or append guidance to the compaction prompt. |
| `subagent_stop` | After `runSubSessionForwarding` and `runSubSessionCollecting` complete — **success or failure** (deferred dispatch). | Observational. |
| `permission_request` | Inside `askUserForConfirmation` just before the runtime would prompt the user. | Auto-allow (skip the prompt) or auto-deny (`permission_decision: allow / deny`), mirroring `pre_tool_use`. Returning nothing falls through to the interactive confirmation. |

## Also fixed

- `post_tool_use` doc / schema / example wording: it fires on **both success and failure**, with `tool_response.is_error` distinguishing them. The previous "after a tool completes successfully" claim was wrong.
- `EventPermissionRequest`'s doc comment now spells out the asymmetry with `pre_tool_use` (where allow is the implicit default vs. permission_request where it's an explicit auto-approve verdict). That's why `Result.PermissionAllowed` exists separately from `Result.Allowed`.

## Files touched

- `pkg/config/latest/types.go` — 4 new fields on `HooksConfig` + validation
- `pkg/hooks/{types,executor,config}.go` — 4 new `EventType` constants, `Result.PermissionAllowed`, `Input.{Prompt, AgentName, ParentSessionID}`, executor wiring
- `pkg/runtime/{hooks,loop,runtime,agent_delegation,skill_runner,tool_dispatch}.go` — dispatch helpers and call-site integration
- `agent-schema.json`, `examples/hooks.yaml`, `docs/configuration/hooks/index.md` — schema, example yaml demonstrating all events, and user-facing docs

## Testing

- 7 contract tests in `pkg/hooks/contract_widening_test.go` pin the wire format for every new event (block-produces-deny, allow-produces-permission-allowed, fields-reach-the-hook, …).
- 2 runtime tests in `pkg/runtime/user_prompt_submit_test.go` pin the gating contract: fires-once for top-level submissions, never for sub-sessions (`SendUserMessage=false`).
- The example `examples/hooks.yaml` parses through `config.Load` and validates against `agent-schema.json`.
- `mise run lint` → 0 issues. `go test -count=1 ./...` → 0 failures across ~150 packages.

## Commits

1. `feat(hooks): add 4 new hook events to match Claude Code / OpenCode / pi` — the feature
2. `refactor(hooks): simplify the call sites added for the new events` — small in-place readability cleanup (merge duplicated guards, switch on `PermissionDecision`, stop double-decoding tool args, take `*agent.Agent` directly instead of name + lookup)
3. `fix(hooks): address review findings on the new hook events` — `subagent_stop` now fires on the error path of both sub-session helpers (`defer`); `EventPermissionRequest` doc clarification; `examples/hooks.yaml` jq-dependency note; user_prompt_submit gating regression test

## Backward compatibility

- The four new fields on `HooksConfig` are all `omitempty`; existing configs continue to parse unchanged.
- `Summarize`'s public signature is unchanged; internal call-sites use a private `summarizeWithSource` to attribute the trigger to `pre_compact` hooks.
- `runSubSessionForwarding`'s parameter list changed (string → `*agent.Agent`) but the function is package-private; both call-sites updated.
