### PR TITLE
refactor(session): improve testability and simplify the session package

### DIFF
--- a/pkg/session/branch.go
+++ b/pkg/session/branch.go
@@ -40,7 +40,11 @@ func BranchSession(parent *Session, branchAtPosition int) (*Session, error) {
 func cloneSessionItem(item Item) (Item, error) {
 	switch {
 	case item.Message != nil:
-		return Item{Message: cloneMessage(item.Message)}, nil
+		cloned := cloneMessage(item.Message)
+		// Branched messages must get fresh database IDs when persisted, so
+		// drop the parent's row ID.
+		cloned.ID = 0
+		return Item{Message: cloned}, nil
 	case item.SubSession != nil:
 		clonedSub, err := cloneSubSession(item.SubSession)
 		if err != nil {
@@ -147,56 +151,6 @@ func cloneStringSlice(src []string) []string {
 		return nil
 	}
 	return slices.Clone(src)
-}
-
-func cloneMessage(src *Message) *Message {
-	if src == nil {
-		return nil
-	}
-	msgCopy := *src
-	msgCopy.ID = 0
-	msgCopy.Message = cloneChatMessage(src.Message)
-	return &msgCopy
-}
-
-func cloneChatMessage(src chat.Message) chat.Message {
-	dst := src
-
-	if src.MultiContent != nil {
-		dst.MultiContent = make([]chat.MessagePart, len(src.MultiContent))
-		for i, part := range src.MultiContent {
-			cloned := part
-			if part.ImageURL != nil {
-				imageCopy := *part.ImageURL
-				cloned.ImageURL = &imageCopy
-			}
-			dst.MultiContent[i] = cloned
-		}
-	}
-
-	if src.FunctionCall != nil {
-		fnCopy := *src.FunctionCall
-		dst.FunctionCall = &fnCopy
-	}
-
-	if src.ToolCalls != nil {
-		dst.ToolCalls = slices.Clone(src.ToolCalls)
-	}
-
-	if src.ToolDefinitions != nil {
-		dst.ToolDefinitions = slices.Clone(src.ToolDefinitions)
-	}
-
-	if src.Usage != nil {
-		usageCopy := *src.Usage
-		dst.Usage = &usageCopy
-	}
-
-	if src.ThoughtSignature != nil {
-		dst.ThoughtSignature = slices.Clone(src.ThoughtSignature)
-	}
-
-	return dst
 }
 
 func setParentIDs(sess *Session) {

--- a/pkg/session/branch_test.go
+++ b/pkg/session/branch_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/chat"
 )
 
 func TestGenerateBranchTitle(t *testing.T) {
@@ -137,5 +139,44 @@ func TestBranchSession(t *testing.T) {
 		assert.Len(t, branched.Messages, 2)
 		assert.Equal(t, "msg1", branched.Messages[0].Message.Message.Content)
 		assert.Equal(t, "msg2", branched.Messages[1].Message.Message.Content)
+	})
+
+	t.Run("deep-copies pointer fields in MultiContent", func(t *testing.T) {
+		// Regression test: the previous branch.go cloneChatMessage forgot to
+		// duplicate MessagePart.File, leaving branched sessions sharing the
+		// pointer with the parent. Mutating either side now must NOT affect
+		// the other.
+		parent := &Session{
+			Messages: []Item{NewMessageItem(&Message{
+				Message: chat.Message{
+					Role: chat.MessageRoleUser,
+					MultiContent: []chat.MessagePart{
+						{
+							Type:     chat.MessagePartTypeImageURL,
+							ImageURL: &chat.MessageImageURL{URL: "http://parent"},
+						},
+						{
+							Type: chat.MessagePartTypeFile,
+							File: &chat.MessageFile{Path: "/tmp/parent.txt", MimeType: "text/plain"},
+						},
+					},
+				},
+			})},
+		}
+
+		branched, err := BranchSession(parent, 1)
+		require.NoError(t, err)
+		require.Len(t, branched.Messages, 1)
+
+		parts := branched.Messages[0].Message.Message.MultiContent
+		require.Len(t, parts, 2)
+
+		// Mutate branched copies; parent must be unaffected.
+		parts[0].ImageURL.URL = "http://branched"
+		parts[1].File.Path = "/tmp/branched.txt"
+
+		parentParts := parent.Messages[0].Message.Message.MultiContent
+		assert.Equal(t, "http://parent", parentParts[0].ImageURL.URL, "ImageURL must be deep-copied")
+		assert.Equal(t, "/tmp/parent.txt", parentParts[1].File.Path, "File must be deep-copied")
 	})
 }

--- a/pkg/session/clock_test.go
+++ b/pkg/session/clock_test.go
@@ -1,0 +1,126 @@
+package session
+
+import (
+	"testing"
+	"time"
+
+	"github.com/docker/docker-agent/pkg/chat"
+)
+
+// setNowForTest installs a fixed clock for the duration of t and restores the
+// previous clock on cleanup. Tests use this to assert on CreatedAt fields
+// without flakiness.
+func setNowForTest(t *testing.T, fixed time.Time) {
+	t.Helper()
+	prev := nowFn
+	nowFn = func() time.Time { return fixed }
+	t.Cleanup(func() { nowFn = prev })
+}
+
+// setIDForTest installs a deterministic ID generator for the duration of t and
+// restores the previous generator on cleanup. The supplied IDs are returned
+// in order; running out triggers t.Fatalf.
+func setIDForTest(t *testing.T, ids ...string) {
+	t.Helper()
+	prev := newIDFn
+	i := 0
+	newIDFn = func() string {
+		if i >= len(ids) {
+			t.Fatalf("setIDForTest: ran out of IDs after %d calls", i)
+		}
+		id := ids[i]
+		i++
+		return id
+	}
+	t.Cleanup(func() { newIDFn = prev })
+}
+
+func TestNew_UsesInjectedClockAndID(t *testing.T) {
+	fixed := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	setNowForTest(t, fixed)
+	setIDForTest(t, "test-session-1")
+
+	s := New()
+
+	if s.ID != "test-session-1" {
+		t.Errorf("ID = %q, want %q", s.ID, "test-session-1")
+	}
+	if !s.CreatedAt.Equal(fixed) {
+		t.Errorf("CreatedAt = %v, want %v", s.CreatedAt, fixed)
+	}
+	if !s.SendUserMessage {
+		t.Error("SendUserMessage should default to true")
+	}
+}
+
+func TestNew_WithIDOverridesGenerator(t *testing.T) {
+	setIDForTest(t, "should-not-be-used")
+
+	s := New(WithID("explicit-id"))
+
+	if s.ID != "explicit-id" {
+		t.Errorf("ID = %q, want %q", s.ID, "explicit-id")
+	}
+}
+
+func TestUserMessage_UsesInjectedClock(t *testing.T) {
+	fixed := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+	setNowForTest(t, fixed)
+
+	msg := UserMessage("hello")
+
+	if msg.Message.Role != chat.MessageRoleUser {
+		t.Errorf("Role = %v, want user", msg.Message.Role)
+	}
+	if msg.Message.CreatedAt != fixed.Format(time.RFC3339) {
+		t.Errorf("CreatedAt = %q, want %q", msg.Message.CreatedAt, fixed.Format(time.RFC3339))
+	}
+	if msg.Message.Content != "hello" {
+		t.Errorf("Content = %q, want %q", msg.Message.Content, "hello")
+	}
+}
+
+func TestSystemMessage_UsesInjectedClock(t *testing.T) {
+	fixed := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+	setNowForTest(t, fixed)
+
+	msg := SystemMessage("you are a helpful assistant")
+
+	if msg.Message.Role != chat.MessageRoleSystem {
+		t.Errorf("Role = %v, want system", msg.Message.Role)
+	}
+	if msg.Message.CreatedAt != fixed.Format(time.RFC3339) {
+		t.Errorf("CreatedAt = %q, want %q", msg.Message.CreatedAt, fixed.Format(time.RFC3339))
+	}
+}
+
+func TestImplicitUserMessage_IsImplicitAndUsesClock(t *testing.T) {
+	fixed := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+	setNowForTest(t, fixed)
+
+	msg := ImplicitUserMessage("delegated task")
+
+	if !msg.Implicit {
+		t.Error("Implicit = false, want true")
+	}
+	if msg.Message.CreatedAt != fixed.Format(time.RFC3339) {
+		t.Errorf("CreatedAt = %q, want %q", msg.Message.CreatedAt, fixed.Format(time.RFC3339))
+	}
+}
+
+func TestDuration_DeterministicWithInjectedClock(t *testing.T) {
+	t0 := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
+	s := New()
+
+	setNowForTest(t, t0)
+	s.AddMessage(UserMessage("first"))
+
+	setNowForTest(t, t0.Add(5*time.Second))
+	s.AddMessage(UserMessage("second"))
+
+	got := s.Duration()
+	want := 5 * time.Second
+	if got != want {
+		t.Errorf("Duration() = %v, want %v", got, want)
+	}
+}

--- a/pkg/session/clock_test.go
+++ b/pkg/session/clock_test.go
@@ -10,6 +10,9 @@ import (
 // setNowForTest installs a fixed clock for the duration of t and restores the
 // previous clock on cleanup. Tests use this to assert on CreatedAt fields
 // without flakiness.
+//
+// The clock is a package-level variable, so tests using this helper MUST NOT
+// call t.Parallel(): two parallel tests would race on nowFn.
 func setNowForTest(t *testing.T, fixed time.Time) {
 	t.Helper()
 	prev := nowFn
@@ -20,6 +23,12 @@ func setNowForTest(t *testing.T, fixed time.Time) {
 // setIDForTest installs a deterministic ID generator for the duration of t and
 // restores the previous generator on cleanup. The supplied IDs are returned
 // in order; running out triggers t.Fatalf.
+//
+// Like setNowForTest, this helper mutates a package-level variable and is not
+// safe to use with t.Parallel(). Additionally, the installed generator calls
+// t.Fatalf if exhausted, which is only valid on the test goroutine — do not
+// use this helper if production code under test may call New() from a
+// background goroutine.
 func setIDForTest(t *testing.T, ids ...string) {
 	t.Helper()
 	prev := newIDFn

--- a/pkg/session/migrations.go
+++ b/pkg/session/migrations.go
@@ -28,12 +28,25 @@ type Migration struct {
 
 // MigrationManager handles database migrations
 type MigrationManager struct {
-	db *sql.DB
+	db         *sql.DB
+	migrations []Migration
 }
 
-// NewMigrationManager creates a new migration manager
+// NewMigrationManager creates a migration manager that runs the production
+// migration list against db. Tests that need to drive the manager with a
+// synthetic migration list should use NewMigrationManagerWithMigrations
+// instead.
 func NewMigrationManager(db *sql.DB) *MigrationManager {
-	return &MigrationManager{db: db}
+	return NewMigrationManagerWithMigrations(db, getAllMigrations())
+}
+
+// NewMigrationManagerWithMigrations creates a migration manager bound to the
+// supplied migration list. The list is treated as ordered by ID; callers must
+// not mutate it after construction. Intended primarily for tests that want to
+// exercise specific migration paths without dragging in the full production
+// list.
+func NewMigrationManagerWithMigrations(db *sql.DB, migrations []Migration) *MigrationManager {
+	return &MigrationManager{db: db, migrations: migrations}
 }
 
 // InitializeMigrations sets up the migrations table and runs pending migrations
@@ -75,8 +88,10 @@ func (m *MigrationManager) createMigrationsTable(ctx context.Context) error {
 // doesn't know about, which indicates the database was created by a newer version.
 // This produces a clear error instead of cryptic SQL failures from schema mismatches.
 func (m *MigrationManager) checkForUnknownMigrations(ctx context.Context) error {
-	known := getAllMigrations()
-	maxKnownID := known[len(known)-1].ID
+	if len(m.migrations) == 0 {
+		return nil
+	}
+	maxKnownID := m.migrations[len(m.migrations)-1].ID
 
 	var maxAppliedID int
 	err := m.db.QueryRowContext(ctx, "SELECT COALESCE(MAX(id), 0) FROM migrations").Scan(&maxAppliedID)
@@ -97,9 +112,7 @@ func (m *MigrationManager) checkForUnknownMigrations(ctx context.Context) error 
 
 // RunPendingMigrations executes all migrations that haven't been applied yet
 func (m *MigrationManager) RunPendingMigrations(ctx context.Context) error {
-	migrations := getAllMigrations()
-
-	for _, migration := range migrations {
+	for _, migration := range m.migrations {
 		applied, err := m.isMigrationApplied(ctx, migration.Name)
 		if err != nil {
 			return fmt.Errorf("failed to check if migration %s is applied: %w", migration.Name, err)

--- a/pkg/session/migrations_unit_test.go
+++ b/pkg/session/migrations_unit_test.go
@@ -1,0 +1,170 @@
+package session
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+)
+
+// openMigrationsDB returns a fresh in-memory database with the migrations
+// table already created. Tests that exercise MigrationManager use it instead
+// of the production setupAndMigrate helper so the manager is the only thing
+// under test.
+func openMigrationsDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = db.Close() })
+
+	mgr := NewMigrationManagerWithMigrations(db, nil)
+	require.NoError(t, mgr.createMigrationsTable(t.Context()))
+	return db
+}
+
+func TestMigrationManager_RunPendingMigrations_AppliesAllAndIsIdempotent(t *testing.T) {
+	db := openMigrationsDB(t)
+	migrations := []Migration{
+		{
+			ID:    1,
+			Name:  "001_create_widgets",
+			UpSQL: `CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT)`,
+		},
+		{
+			ID:    2,
+			Name:  "002_add_color_column",
+			UpSQL: `ALTER TABLE widgets ADD COLUMN color TEXT DEFAULT ''`,
+		},
+	}
+	mgr := NewMigrationManagerWithMigrations(db, migrations)
+	ctx := t.Context()
+
+	require.NoError(t, mgr.RunPendingMigrations(ctx))
+
+	applied, err := mgr.GetAppliedMigrations(ctx)
+	require.NoError(t, err)
+	require.Len(t, applied, 2)
+	assert.Equal(t, "001_create_widgets", applied[0].Name)
+	assert.Equal(t, "002_add_color_column", applied[1].Name)
+
+	// Schema is in place: insert and select work.
+	_, err = db.ExecContext(ctx, `INSERT INTO widgets (id, name, color) VALUES (1, 'sprocket', 'red')`)
+	require.NoError(t, err)
+
+	// Running again is a no-op.
+	require.NoError(t, mgr.RunPendingMigrations(ctx))
+	applied2, err := mgr.GetAppliedMigrations(ctx)
+	require.NoError(t, err)
+	assert.Len(t, applied2, 2)
+}
+
+func TestMigrationManager_RunPendingMigrations_OnlyAppliesNewMigrations(t *testing.T) {
+	db := openMigrationsDB(t)
+	first := []Migration{{ID: 1, Name: "001_a", UpSQL: `CREATE TABLE a (id INTEGER)`}}
+	require.NoError(t, NewMigrationManagerWithMigrations(db, first).RunPendingMigrations(t.Context()))
+
+	// Bring in the second migration; only it should be applied.
+	both := []Migration{
+		first[0],
+		{ID: 2, Name: "002_b", UpSQL: `CREATE TABLE b (id INTEGER)`},
+	}
+	mgr := NewMigrationManagerWithMigrations(db, both)
+	require.NoError(t, mgr.RunPendingMigrations(t.Context()))
+
+	applied, err := mgr.GetAppliedMigrations(t.Context())
+	require.NoError(t, err)
+	assert.Len(t, applied, 2)
+
+	// Both tables must exist; if 001 had been re-run we would have got an error.
+	_, err = db.ExecContext(t.Context(), `INSERT INTO a (id) VALUES (1)`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(t.Context(), `INSERT INTO b (id) VALUES (1)`)
+	require.NoError(t, err)
+}
+
+func TestMigrationManager_BadUpSQL_RollsBackAndIsRetryable(t *testing.T) {
+	db := openMigrationsDB(t)
+	bad := []Migration{{
+		ID:    1,
+		Name:  "001_bad",
+		UpSQL: `THIS IS NOT VALID SQL`,
+	}}
+	mgr := NewMigrationManagerWithMigrations(db, bad)
+
+	err := mgr.RunPendingMigrations(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "001_bad")
+
+	// The transaction must have been rolled back, so the migration is NOT
+	// recorded and the manager will retry it next time.
+	applied, err := mgr.GetAppliedMigrations(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, applied, "failed migration must not be recorded")
+}
+
+func TestMigrationManager_UpFuncFailure_DoesNotRetryButReturnsError(t *testing.T) {
+	db := openMigrationsDB(t)
+	wantErr := errors.New("boom")
+	mgr := NewMigrationManagerWithMigrations(db, []Migration{{
+		ID:   1,
+		Name: "001_func",
+		UpFunc: func(_ context.Context, _ *sql.DB) error {
+			return wantErr
+		},
+	}})
+
+	err := mgr.RunPendingMigrations(t.Context())
+	require.Error(t, err)
+	require.ErrorIs(t, err, wantErr)
+
+	// The current implementation commits the SQL phase before running UpFunc,
+	// so the migration row IS recorded even if UpFunc fails. This test pins
+	// that behaviour so any change to it (e.g. wrapping UpFunc in the same
+	// transaction) is intentional.
+	applied, err := mgr.GetAppliedMigrations(t.Context())
+	require.NoError(t, err)
+	assert.Len(t, applied, 1)
+}
+
+func TestMigrationManager_CheckForUnknownMigrations_RejectsNewerDB(t *testing.T) {
+	db := openMigrationsDB(t)
+	// Apply two migrations as a "newer" docker-agent would.
+	full := []Migration{
+		{ID: 1, Name: "001_a", UpSQL: `CREATE TABLE a (id INTEGER)`},
+		{ID: 2, Name: "002_b", UpSQL: `CREATE TABLE b (id INTEGER)`},
+	}
+	require.NoError(t, NewMigrationManagerWithMigrations(db, full).RunPendingMigrations(t.Context()))
+
+	// Now an "older" binary only knows about migration 1.
+	older := NewMigrationManagerWithMigrations(db, full[:1])
+	err := older.checkForUnknownMigrations(t.Context())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNewerDatabase)
+}
+
+func TestMigrationManager_CheckForUnknownMigrations_AllowsEqualOrOlderDB(t *testing.T) {
+	db := openMigrationsDB(t)
+	migrations := []Migration{{ID: 1, Name: "001_a", UpSQL: `CREATE TABLE a (id INTEGER)`}}
+	require.NoError(t, NewMigrationManagerWithMigrations(db, migrations).RunPendingMigrations(t.Context()))
+
+	// Same set: fine.
+	require.NoError(t, NewMigrationManagerWithMigrations(db, migrations).checkForUnknownMigrations(t.Context()))
+
+	// Newer binary that knows about more migrations than the DB has applied: fine.
+	newer := append([]Migration{}, migrations...)
+	newer = append(newer, Migration{ID: 2, Name: "002_b", UpSQL: `CREATE TABLE b (id INTEGER)`})
+	require.NoError(t, NewMigrationManagerWithMigrations(db, newer).checkForUnknownMigrations(t.Context()))
+}
+
+func TestMigrationManager_EmptyMigrations_NoOp(t *testing.T) {
+	db := openMigrationsDB(t)
+	mgr := NewMigrationManagerWithMigrations(db, nil)
+
+	require.NoError(t, mgr.RunPendingMigrations(t.Context()))
+	require.NoError(t, mgr.checkForUnknownMigrations(t.Context()))
+}

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -337,6 +337,23 @@ func cloneMessage(m *Message) *Message {
 	return &cp
 }
 
+// snapshotItems returns a copy of s.Messages safe to use without holding
+// s.mu. Each Message value is deep-copied so concurrent UpdateMessage calls
+// cannot mutate the snapshot; non-Message fields (Summary, SubSession, Cost,
+// FirstKeptEntry) are shallow-copied since they are not mutated in place.
+func (s *Session) snapshotItems() []Item {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	items := make([]Item, len(s.Messages))
+	for i, item := range s.Messages {
+		items[i] = item
+		if item.Message != nil {
+			items[i].Message = cloneMessage(item.Message)
+		}
+	}
+	return items
+}
+
 // cloneChatMessage returns a deep copy of a chat.Message, duplicating
 // all slice and pointer fields that would otherwise alias the original.
 func cloneChatMessage(m chat.Message) chat.Message {
@@ -421,16 +438,7 @@ func (s *Session) AllowedDirectories() []string {
 
 // GetAllMessages extracts all messages from the session, including from sub-sessions
 func (s *Session) GetAllMessages() []Message {
-	s.mu.RLock()
-	items := make([]Item, len(s.Messages))
-	for i, item := range s.Messages {
-		if item.Message != nil {
-			items[i] = Item{Message: cloneMessage(item.Message)}
-		} else {
-			items[i] = item
-		}
-	}
-	s.mu.RUnlock()
+	items := s.snapshotItems()
 
 	var messages []Message
 	for _, item := range items {
@@ -881,16 +889,7 @@ func (s *Session) GetMessages(a *agent.Agent, extraSystemMessages ...chat.Messag
 
 	// Take a snapshot of Messages under the lock, copying Message structs
 	// to avoid racing with UpdateMessage which may modify the pointed-to objects.
-	s.mu.RLock()
-	items := make([]Item, len(s.Messages))
-	for i, item := range s.Messages {
-		if item.Message != nil {
-			items[i] = Item{Message: cloneMessage(item.Message), Summary: item.Summary, SubSession: item.SubSession, Cost: item.Cost}
-		} else {
-			items[i] = item
-		}
-	}
-	s.mu.RUnlock()
+	items := s.snapshotItems()
 
 	// Build session summary messages (vary per session)
 	summaryMessages, startIndex := buildSessionSummaryMessages(items)

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -17,6 +17,15 @@ import (
 	"github.com/docker/docker-agent/pkg/tools"
 )
 
+// nowFn returns the current time. Indirected through a package-level variable
+// so that tests can install a deterministic clock via setNowForTest.
+var nowFn = time.Now
+
+// newIDFn returns a fresh session ID. Indirected through a package-level
+// variable so that tests can install a deterministic ID generator via
+// setIDForTest.
+var newIDFn = func() string { return uuid.New().String() }
+
 const (
 	// DefaultMaxOldToolCallTokens is the default maximum number of tokens to keep from tool call
 	// arguments and results. Older tool calls beyond this budget will have their
@@ -212,7 +221,7 @@ func UserMessage(content string, multiContent ...chat.MessagePart) *Message {
 			Role:         chat.MessageRoleUser,
 			Content:      content,
 			MultiContent: multiContent,
-			CreatedAt:    time.Now().Format(time.RFC3339),
+			CreatedAt:    nowFn().Format(time.RFC3339),
 		},
 	}
 }
@@ -229,7 +238,7 @@ func SystemMessage(content string) *Message {
 		Message: chat.Message{
 			Role:      chat.MessageRoleSystem,
 			Content:   content,
-			CreatedAt: time.Now().Format(time.RFC3339),
+			CreatedAt: nowFn().Format(time.RFC3339),
 		},
 	}
 }
@@ -721,8 +730,8 @@ func (s *Session) OwnCost() float64 {
 // New creates a new agent session
 func New(opts ...Opt) *Session {
 	s := &Session{
-		ID:              uuid.New().String(),
-		CreatedAt:       time.Now(),
+		ID:              newIDFn(),
+		CreatedAt:       nowFn(),
 		SendUserMessage: true,
 	}
 
@@ -843,7 +852,7 @@ func buildSessionSummaryMessages(items []Item) ([]chat.Message, int) {
 		messages = append(messages, chat.Message{
 			Role:      chat.MessageRoleUser,
 			Content:   "Session Summary: " + items[lastSummaryIndex].Summary,
-			CreatedAt: time.Now().Format(time.RFC3339),
+			CreatedAt: nowFn().Format(time.RFC3339),
 		})
 	}
 

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -29,7 +29,8 @@ var newIDFn = func() string { return uuid.New().String() }
 const (
 	// DefaultMaxOldToolCallTokens is the default maximum number of tokens to keep from tool call
 	// arguments and results. Older tool calls beyond this budget will have their
-	// content replaced with a placeholder. Tokens are approximated as len/4.
+	// content replaced with a placeholder. Tokens are approximated by
+	// approximateTokens (len/4).
 	DefaultMaxOldToolCallTokens = 40000
 
 	// toolContentPlaceholder is the text used to replace truncated tool content
@@ -121,7 +122,8 @@ type Session struct {
 
 	// MaxOldToolCallTokens is the maximum number of tokens to keep from old tool call
 	// arguments and results. Older tool calls beyond this budget will have their
-	// content replaced with a placeholder. Tokens are approximated as len/4.
+	// content replaced with a placeholder. Tokens are approximated by
+	// approximateTokens (len/4).
 	// Set to -1 to disable truncation (unlimited tool content).
 	// Default: 40000 (when not configured or set to 0).
 	MaxOldToolCallTokens int `json:"max_old_tool_call_tokens,omitempty"`
@@ -1136,6 +1138,15 @@ func sanitizeToolCalls(messages []chat.Message) []chat.Message {
 	return out
 }
 
+// approximateTokens returns a coarse token count for a string, using the
+// industry rule-of-thumb of ~4 characters per token. The heuristic is good
+// enough for budgeting tool-content truncation; we do not need provider-exact
+// counts here. Centralised so tests can reason about budgets without
+// hard-coding the divisor.
+func approximateTokens(s string) int {
+	return len(s) / 4
+}
+
 // truncateOldToolContent replaces tool results with placeholders for older
 // messages that exceed the token budget. It processes messages from newest to
 // oldest, keeping recent tool content intact while truncating older content
@@ -1154,7 +1165,7 @@ func truncateOldToolContent(messages []chat.Message, maxTokens int) []chat.Messa
 		msg := &result[i]
 
 		if msg.Role == chat.MessageRoleTool {
-			tokens := len(msg.Content) / 4
+			tokens := approximateTokens(msg.Content)
 			if tokenBudget >= tokens {
 				tokenBudget -= tokens
 			} else {

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -328,18 +328,18 @@ func (e *EvalCriteria) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// deepCopyMessage returns a deep copy of a session Message.
+// cloneMessage returns a deep copy of a session Message.
 // It copies the inner chat.Message's slice and pointer fields so that the
 // returned value shares no mutable state with the original.
-func deepCopyMessage(m *Message) *Message {
+func cloneMessage(m *Message) *Message {
 	cp := *m
-	cp.Message = deepCopyChatMessage(m.Message)
+	cp.Message = cloneChatMessage(m.Message)
 	return &cp
 }
 
-// deepCopyChatMessage returns a deep copy of a chat.Message, duplicating
+// cloneChatMessage returns a deep copy of a chat.Message, duplicating
 // all slice and pointer fields that would otherwise alias the original.
-func deepCopyChatMessage(m chat.Message) chat.Message {
+func cloneChatMessage(m chat.Message) chat.Message {
 	if m.MultiContent != nil {
 		orig := m.MultiContent
 		m.MultiContent = make([]chat.MessagePart, len(orig))
@@ -425,7 +425,7 @@ func (s *Session) GetAllMessages() []Message {
 	items := make([]Item, len(s.Messages))
 	for i, item := range s.Messages {
 		if item.Message != nil {
-			items[i] = Item{Message: deepCopyMessage(item.Message)}
+			items[i] = Item{Message: cloneMessage(item.Message)}
 		} else {
 			items[i] = item
 		}
@@ -885,7 +885,7 @@ func (s *Session) GetMessages(a *agent.Agent, extraSystemMessages ...chat.Messag
 	items := make([]Item, len(s.Messages))
 	for i, item := range s.Messages {
 		if item.Message != nil {
-			items[i] = Item{Message: deepCopyMessage(item.Message), Summary: item.Summary, SubSession: item.SubSession, Cost: item.Cost}
+			items[i] = Item{Message: cloneMessage(item.Message), Summary: item.Summary, SubSession: item.SubSession, Cost: item.Cost}
 		} else {
 			items[i] = item
 		}

--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -660,26 +660,7 @@ func (s *SQLiteSessionStore) GetSession(ctx context.Context, id string) (*Sessio
 	if id == "" {
 		return nil, ErrEmptyID
 	}
-
-	row := s.db.QueryRowContext(ctx,
-		"SELECT "+sessionSelectColumns+" FROM sessions WHERE id = ?", id)
-
-	sess, err := scanSession(row)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, ErrNotFound
-		}
-		return nil, err
-	}
-
-	// Load messages from session_items table
-	items, err := s.loadSessionItems(ctx, id)
-	if err != nil {
-		return nil, fmt.Errorf("loading session items: %w", err)
-	}
-	sess.Messages = items
-
-	return sess, nil
+	return s.loadSession(ctx, s.db, id)
 }
 
 // sessionItemRow holds the raw data from a session_items row
@@ -694,13 +675,10 @@ type sessionItemRow struct {
 	firstKeptEntry int
 }
 
-// loadSessionItems loads all items for a session from the session_items table.
-func (s *SQLiteSessionStore) loadSessionItems(ctx context.Context, sessionID string) ([]Item, error) {
-	return s.loadSessionItemsWith(ctx, s.db, sessionID)
-}
-
-// loadSessionItemsWith loads items using the provided querier (db or tx).
-func (s *SQLiteSessionStore) loadSessionItemsWith(ctx context.Context, q querier, sessionID string) ([]Item, error) {
+// loadSessionItems loads all items for a session from session_items.
+// Used both as the public read path (q == s.db) and recursively from inside
+// loadSession when resolving sub-sessions inside a transaction.
+func (s *SQLiteSessionStore) loadSessionItems(ctx context.Context, q querier, sessionID string) ([]Item, error) {
 	rows, err := q.QueryContext(ctx,
 		`SELECT position, item_type, agent_name, message_json, implicit, subsession_id, summary_text, COALESCE(first_kept_entry, 0)
 		 FROM session_items WHERE session_id = ? ORDER BY position`, sessionID)
@@ -752,7 +730,7 @@ func (s *SQLiteSessionStore) loadSessionItemsWith(ctx context.Context, q querier
 				continue
 			}
 			// Recursively load sub-session
-			subSession, err := s.loadSessionWith(ctx, q, row.subsessionID.String)
+			subSession, err := s.loadSession(ctx, q, row.subsessionID.String)
 			if err != nil {
 				if errors.Is(err, ErrNotFound) {
 					// Sub-session was deleted but item reference remains (orphaned reference)
@@ -771,8 +749,8 @@ func (s *SQLiteSessionStore) loadSessionItemsWith(ctx context.Context, q querier
 	return items, nil
 }
 
-// loadSessionWith loads a session using the provided querier.
-func (s *SQLiteSessionStore) loadSessionWith(ctx context.Context, q querier, id string) (*Session, error) {
+// loadSession retrieves a session by ID using the supplied querier.
+func (s *SQLiteSessionStore) loadSession(ctx context.Context, q querier, id string) (*Session, error) {
 	row := q.QueryRowContext(ctx,
 		"SELECT "+sessionSelectColumns+" FROM sessions WHERE id = ?", id)
 
@@ -784,12 +762,10 @@ func (s *SQLiteSessionStore) loadSessionWith(ctx context.Context, q querier, id 
 		return nil, err
 	}
 
-	// Load messages
-	items, err := s.loadSessionItemsWith(ctx, q, id)
+	sess.Messages, err = s.loadSessionItems(ctx, q, id)
 	if err != nil {
 		return nil, fmt.Errorf("loading session items: %w", err)
 	}
-	sess.Messages = items
 
 	return sess, nil
 }
@@ -818,7 +794,7 @@ func (s *SQLiteSessionStore) GetSessions(ctx context.Context) ([]*Session, error
 
 	// Load messages for each session
 	for _, session := range sessions {
-		items, err := s.loadSessionItems(ctx, session.ID)
+		items, err := s.loadSessionItems(ctx, s.db, session.ID)
 		if err != nil {
 			return nil, fmt.Errorf("loading items for session %s: %w", session.ID, err)
 		}

--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -365,7 +365,10 @@ func (s *InMemorySessionStore) Close() error {
 	return nil
 }
 
-// NewSQLiteSessionStore creates a new SQLite session store
+// NewSQLiteSessionStore creates a new SQLite session store backed by a file
+// at path. If migrations fail (other than a version mismatch or a filesystem
+// open failure) the existing database is moved aside to <path>.bak and a
+// fresh one is created.
 func NewSQLiteSessionStore(path string) (Store, error) {
 	store, err := openAndMigrateSQLiteStore(path)
 	if err != nil {
@@ -406,6 +409,24 @@ func NewSQLiteSessionStore(path string) (Store, error) {
 	return store, nil
 }
 
+// NewSQLiteSessionStoreFromDB wraps an already-open *sql.DB in a session store,
+// running the bootstrap schema and migrations against it. The caller retains
+// ownership of db: it is not closed on error, and Store.Close() will close it
+// when the store is closed.
+//
+// This is intended primarily for tests that want to use an in-memory database
+// (sql.Open("sqlite", ":memory:")) or pre-seed a database with non-default
+// state. Production callers should use NewSQLiteSessionStore.
+func NewSQLiteSessionStoreFromDB(db *sql.DB) (*SQLiteSessionStore, error) {
+	if db == nil {
+		return nil, errors.New("db is nil")
+	}
+	if err := setupAndMigrate(db); err != nil {
+		return nil, err
+	}
+	return &SQLiteSessionStore{db: db}, nil
+}
+
 // openAndMigrateSQLiteStore opens the database and runs migrations
 func openAndMigrateSQLiteStore(path string) (*SQLiteSessionStore, error) {
 	db, err := sqliteutil.OpenDB(path)
@@ -413,14 +434,7 @@ func openAndMigrateSQLiteStore(path string) (*SQLiteSessionStore, error) {
 		return nil, err
 	}
 
-	_, err = db.ExecContext(context.Background(), `
-		CREATE TABLE IF NOT EXISTS sessions (
-			id TEXT PRIMARY KEY,
-			messages TEXT,
-			created_at TEXT
-		)
-	`)
-	if err != nil {
+	if err := setupAndMigrate(db); err != nil {
 		db.Close()
 		if sqliteutil.IsCantOpenError(err) {
 			return nil, sqliteutil.DiagnoseDBOpenError(path, err)
@@ -428,15 +442,27 @@ func openAndMigrateSQLiteStore(path string) (*SQLiteSessionStore, error) {
 		return nil, err
 	}
 
-	// Initialize and run migrations
-	migrationManager := NewMigrationManager(db)
-	err = migrationManager.InitializeMigrations(context.Background())
+	return &SQLiteSessionStore{db: db}, nil
+}
+
+// setupAndMigrate creates the bootstrap sessions table (if missing) and runs
+// all pending schema migrations. The bootstrap schema only declares the
+// columns the very first migration expects to find; later columns are added
+// by subsequent ALTER TABLE migrations.
+func setupAndMigrate(db *sql.DB) error {
+	_, err := db.ExecContext(context.Background(), `
+		CREATE TABLE IF NOT EXISTS sessions (
+			id TEXT PRIMARY KEY,
+			messages TEXT,
+			created_at TEXT
+		)
+	`)
 	if err != nil {
-		db.Close()
-		return nil, err
+		return err
 	}
 
-	return &SQLiteSessionStore{db: db}, nil
+	migrationManager := NewMigrationManager(db)
+	return migrationManager.InitializeMigrations(context.Background())
 }
 
 // backupDatabase moves the database file (and related WAL files) to a backup

--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -596,108 +596,63 @@ func (s *SQLiteSessionStore) AddSession(ctx context.Context, session *Session) e
 	return tx.Commit()
 }
 
-// scanSession scans a single row into a Session struct
-// Note: Messages are loaded separately from session_items table
+// scanSession scans a single row into a Session struct.
+// Note: Messages are loaded separately from session_items table.
+// The thinking column is read but discarded — it is kept in the schema for
+// backward compatibility with older docker-agent versions that wrote it.
 func scanSession(scanner interface {
 	Scan(dest ...any) error
 },
 ) (*Session, error) {
-	var toolsApprovedStr, inputTokensStr, outputTokensStr, titleStr, costStr, sendUserMessageStr, maxIterationsStr, createdAtStr, starredStr, agentModelOverridesJSON, customModelsUsedJSON string
-	var thinkingStr string // read from DB but not used (kept for backward compatibility)
-	var sessionID string
-	var workingDir sql.NullString
-	var permissionsJSON sql.NullString
-	var parentID sql.NullString
-	err := scanner.Scan(&sessionID, &toolsApprovedStr, &inputTokensStr, &outputTokensStr, &titleStr, &costStr, &sendUserMessageStr, &maxIterationsStr, &workingDir, &createdAtStr, &starredStr, &permissionsJSON, &agentModelOverridesJSON, &customModelsUsedJSON, &thinkingStr, &parentID)
+	var (
+		sess                    Session
+		workingDir              sql.NullString
+		permissionsJSON         sql.NullString
+		parentID                sql.NullString
+		agentModelOverridesJSON string
+		customModelsUsedJSON    string
+		createdAtStr            string
+		thinking                bool // discarded
+	)
+
+	err := scanner.Scan(
+		&sess.ID, &sess.ToolsApproved, &sess.InputTokens, &sess.OutputTokens,
+		&sess.Title, &sess.Cost, &sess.SendUserMessage, &sess.MaxIterations,
+		&workingDir, &createdAtStr, &sess.Starred, &permissionsJSON,
+		&agentModelOverridesJSON, &customModelsUsedJSON, &thinking, &parentID,
+	)
 	if err != nil {
 		return nil, err
 	}
 
-	toolsApproved, err := strconv.ParseBool(toolsApprovedStr)
+	sess.CreatedAt, err = time.Parse(time.RFC3339, createdAtStr)
 	if err != nil {
 		return nil, err
 	}
 
-	inputTokens, err := strconv.ParseInt(inputTokensStr, 10, 64)
-	if err != nil {
-		return nil, err
-	}
+	sess.WorkingDir = workingDir.String
+	sess.ParentID = parentID.String
 
-	outputTokens, err := strconv.ParseInt(outputTokensStr, 10, 64)
-	if err != nil {
-		return nil, err
-	}
-
-	cost, err := strconv.ParseFloat(costStr, 64)
-	if err != nil {
-		return nil, err
-	}
-
-	sendUserMessage, err := strconv.ParseBool(sendUserMessageStr)
-	if err != nil {
-		return nil, err
-	}
-
-	maxIterations, err := strconv.Atoi(maxIterationsStr)
-	if err != nil {
-		return nil, err
-	}
-
-	createdAt, err := time.Parse(time.RFC3339, createdAtStr)
-	if err != nil {
-		return nil, err
-	}
-
-	starred, err := strconv.ParseBool(starredStr)
-	if err != nil {
-		return nil, err
-	}
-
-	// thinkingStr is read from the DB but ignored (column kept for backward compatibility).
-
-	// Parse permissions if present
-	var permissions *PermissionsConfig
 	if permissionsJSON.Valid && permissionsJSON.String != "" {
-		permissions = &PermissionsConfig{}
-		if err := json.Unmarshal([]byte(permissionsJSON.String), permissions); err != nil {
+		sess.Permissions = &PermissionsConfig{}
+		if err := json.Unmarshal([]byte(permissionsJSON.String), sess.Permissions); err != nil {
 			return nil, err
 		}
 	}
 
-	// Parse agent model overrides (may be empty or "{}")
-	var agentModelOverrides map[string]string
 	if agentModelOverridesJSON != "" && agentModelOverridesJSON != "{}" {
-		if err := json.Unmarshal([]byte(agentModelOverridesJSON), &agentModelOverrides); err != nil {
+		if err := json.Unmarshal([]byte(agentModelOverridesJSON), &sess.AgentModelOverrides); err != nil {
 			return nil, err
 		}
 	}
 
-	// Parse custom models used (may be empty or "[]")
-	var customModelsUsed []string
 	if customModelsUsedJSON != "" && customModelsUsedJSON != "[]" {
-		if err := json.Unmarshal([]byte(customModelsUsedJSON), &customModelsUsed); err != nil {
+		if err := json.Unmarshal([]byte(customModelsUsedJSON), &sess.CustomModelsUsed); err != nil {
 			return nil, err
 		}
 	}
 
-	return &Session{
-		ID:                  sessionID,
-		Title:               titleStr,
-		Messages:            nil, // Loaded separately from session_items
-		ToolsApproved:       toolsApproved,
-		InputTokens:         inputTokens,
-		OutputTokens:        outputTokens,
-		Cost:                cost,
-		SendUserMessage:     sendUserMessage,
-		MaxIterations:       maxIterations,
-		CreatedAt:           createdAt,
-		WorkingDir:          workingDir.String,
-		Starred:             starred,
-		Permissions:         permissions,
-		AgentModelOverrides: agentModelOverrides,
-		CustomModelsUsed:    customModelsUsed,
-		ParentID:            parentID.String,
-	}, nil
+	return &sess, nil
 }
 
 // GetSession retrieves a session by ID
@@ -889,26 +844,18 @@ func (s *SQLiteSessionStore) GetSessionSummaries(ctx context.Context) ([]Summary
 
 	var summaries []Summary
 	for rows.Next() {
-		var id, title, createdAtStr, starredStr string
-		var numMessages int
-		if err := rows.Scan(&id, &title, &createdAtStr, &starredStr, &numMessages); err != nil {
+		var (
+			summary      Summary
+			createdAtStr string
+		)
+		if err := rows.Scan(&summary.ID, &summary.Title, &createdAtStr, &summary.Starred, &summary.NumMessages); err != nil {
 			return nil, err
 		}
-		createdAt, err := time.Parse(time.RFC3339, createdAtStr)
+		summary.CreatedAt, err = time.Parse(time.RFC3339, createdAtStr)
 		if err != nil {
 			return nil, err
 		}
-		starred, err := strconv.ParseBool(starredStr)
-		if err != nil {
-			return nil, err
-		}
-		summaries = append(summaries, Summary{
-			ID:          id,
-			Title:       title,
-			CreatedAt:   createdAt,
-			Starred:     starred,
-			NumMessages: numMessages,
-		})
+		summaries = append(summaries, summary)
 	}
 
 	if err := rows.Err(); err != nil {

--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -265,7 +265,7 @@ func (s *InMemorySessionStore) AddMessage(_ context.Context, sessionID string, m
 func (s *InMemorySessionStore) UpdateMessage(_ context.Context, messageID int64, msg *Message) error {
 	// Create a deep copy of the message to avoid mutating the caller's pointer,
 	// which may be shared with another Session object.
-	updated := deepCopyMessage(msg)
+	updated := cloneMessage(msg)
 	updated.ID = messageID
 
 	// For in-memory store, we need to find the message across all sessions

--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -332,6 +332,62 @@ type SQLiteSessionStore struct {
 	db *sql.DB
 }
 
+// sessionSelectColumns is the canonical SELECT list for the sessions table.
+// The column order matches what scanSession expects; all read paths use this
+// constant so that adding a column requires updating exactly one place.
+const sessionSelectColumns = `id, tools_approved, input_tokens, output_tokens, title, cost, send_user_message, max_iterations, working_dir, created_at, starred, permissions, agent_model_overrides, custom_models_used, thinking, parent_id`
+
+// sessionPersistedFields holds the encoded form of a Session's JSON-bearing
+// columns plus the SQL representation of parent_id (nil for the empty
+// string, which keeps the foreign key constraint happy).
+type sessionPersistedFields struct {
+	PermissionsJSON         string
+	AgentModelOverridesJSON string
+	CustomModelsUsedJSON    string
+	ParentID                any // string or nil
+}
+
+// sessionPersistedFieldsOf marshals the JSON-bearing columns of session and
+// derives the SQL parent_id value. INSERT/UPDATE call sites use this helper
+// so the marshaling rules ("" / "{}" / "[]" defaults, NULL parent_id) live
+// in one place.
+func sessionPersistedFieldsOf(session *Session) (sessionPersistedFields, error) {
+	var f sessionPersistedFields
+
+	if session.Permissions != nil {
+		permBytes, err := json.Marshal(session.Permissions)
+		if err != nil {
+			return f, err
+		}
+		f.PermissionsJSON = string(permBytes)
+	}
+
+	f.AgentModelOverridesJSON = "{}"
+	if len(session.AgentModelOverrides) > 0 {
+		overridesBytes, err := json.Marshal(session.AgentModelOverrides)
+		if err != nil {
+			return f, err
+		}
+		f.AgentModelOverridesJSON = string(overridesBytes)
+	}
+
+	f.CustomModelsUsedJSON = "[]"
+	if len(session.CustomModelsUsed) > 0 {
+		customBytes, err := json.Marshal(session.CustomModelsUsed)
+		if err != nil {
+			return f, err
+		}
+		f.CustomModelsUsedJSON = string(customBytes)
+	}
+
+	// Use NULL for empty parent_id to avoid foreign key constraint issues.
+	if session.ParentID != "" {
+		f.ParentID = session.ParentID
+	}
+
+	return f, nil
+}
+
 // UpdateSessionTokens updates only token/cost fields.
 func (s *InMemorySessionStore) UpdateSessionTokens(_ context.Context, sessionID string, inputTokens, outputTokens int64, cost float64) error {
 	if sessionID == "" {
@@ -504,40 +560,11 @@ func (s *SQLiteSessionStore) AddSession(ctx context.Context, session *Session) e
 		return ErrEmptyID
 	}
 
-	permissionsJSON := ""
-	if session.Permissions != nil {
-		permBytes, err := json.Marshal(session.Permissions)
-		if err != nil {
-			return err
-		}
-		permissionsJSON = string(permBytes)
+	fields, err := sessionPersistedFieldsOf(session)
+	if err != nil {
+		return err
 	}
 
-	// Marshal agent model overrides (default to empty object if nil)
-	agentModelOverridesJSON := "{}"
-	if len(session.AgentModelOverrides) > 0 {
-		overridesBytes, err := json.Marshal(session.AgentModelOverrides)
-		if err != nil {
-			return err
-		}
-		agentModelOverridesJSON = string(overridesBytes)
-	}
-
-	// Marshal custom models used (default to empty array if nil)
-	customModelsUsedJSON := "[]"
-	if len(session.CustomModelsUsed) > 0 {
-		customBytes, err := json.Marshal(session.CustomModelsUsed)
-		if err != nil {
-			return err
-		}
-		customModelsUsedJSON = string(customBytes)
-	}
-
-	// Use NULL for empty parent_id to avoid foreign key constraint issues
-	var parentID any
-	if session.ParentID != "" {
-		parentID = session.ParentID
-	}
 	// Use a transaction to insert session and its items
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -553,8 +580,8 @@ func (s *SQLiteSessionStore) AddSession(ctx context.Context, session *Session) e
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		session.ID, session.ToolsApproved, session.InputTokens, session.OutputTokens, session.Title,
 		session.Cost, session.SendUserMessage, session.MaxIterations, session.WorkingDir,
-		session.CreatedAt.Format(time.RFC3339), permissionsJSON, agentModelOverridesJSON,
-		customModelsUsedJSON, false, parentID)
+		session.CreatedAt.Format(time.RFC3339), fields.PermissionsJSON, fields.AgentModelOverridesJSON,
+		fields.CustomModelsUsedJSON, false, fields.ParentID)
 	if err != nil {
 		return err
 	}
@@ -680,7 +707,7 @@ func (s *SQLiteSessionStore) GetSession(ctx context.Context, id string) (*Sessio
 	}
 
 	row := s.db.QueryRowContext(ctx,
-		"SELECT id, tools_approved, input_tokens, output_tokens, title, cost, send_user_message, max_iterations, working_dir, created_at, starred, permissions, agent_model_overrides, custom_models_used, thinking, parent_id FROM sessions WHERE id = ?", id)
+		"SELECT "+sessionSelectColumns+" FROM sessions WHERE id = ?", id)
 
 	sess, err := scanSession(row)
 	if err != nil {
@@ -792,7 +819,7 @@ func (s *SQLiteSessionStore) loadSessionItemsWith(ctx context.Context, q querier
 // loadSessionWith loads a session using the provided querier.
 func (s *SQLiteSessionStore) loadSessionWith(ctx context.Context, q querier, id string) (*Session, error) {
 	row := q.QueryRowContext(ctx,
-		"SELECT id, tools_approved, input_tokens, output_tokens, title, cost, send_user_message, max_iterations, working_dir, created_at, starred, permissions, agent_model_overrides, custom_models_used, thinking, parent_id FROM sessions WHERE id = ?", id)
+		"SELECT "+sessionSelectColumns+" FROM sessions WHERE id = ?", id)
 
 	sess, err := scanSession(row)
 	if err != nil {
@@ -815,7 +842,7 @@ func (s *SQLiteSessionStore) loadSessionWith(ctx context.Context, q querier, id 
 // GetSessions retrieves all root sessions (excludes sub-sessions)
 func (s *SQLiteSessionStore) GetSessions(ctx context.Context) ([]*Session, error) {
 	rows, err := s.db.QueryContext(ctx,
-		"SELECT id, tools_approved, input_tokens, output_tokens, title, cost, send_user_message, max_iterations, working_dir, created_at, starred, permissions, agent_model_overrides, custom_models_used, thinking, parent_id FROM sessions WHERE parent_id IS NULL OR parent_id = '' ORDER BY created_at DESC")
+		"SELECT "+sessionSelectColumns+" FROM sessions WHERE parent_id IS NULL OR parent_id = '' ORDER BY created_at DESC")
 	if err != nil {
 		return nil, err
 	}
@@ -922,40 +949,11 @@ func (s *SQLiteSessionStore) UpdateSession(ctx context.Context, session *Session
 		return ErrEmptyID
 	}
 
-	permissionsJSON := ""
-	if session.Permissions != nil {
-		permBytes, err := json.Marshal(session.Permissions)
-		if err != nil {
-			return err
-		}
-		permissionsJSON = string(permBytes)
+	fields, err := sessionPersistedFieldsOf(session)
+	if err != nil {
+		return err
 	}
 
-	// Marshal agent model overrides (default to empty object if nil)
-	agentModelOverridesJSON := "{}"
-	if len(session.AgentModelOverrides) > 0 {
-		overridesBytes, err := json.Marshal(session.AgentModelOverrides)
-		if err != nil {
-			return err
-		}
-		agentModelOverridesJSON = string(overridesBytes)
-	}
-
-	// Marshal custom models used (default to empty array if nil)
-	customModelsUsedJSON := "[]"
-	if len(session.CustomModelsUsed) > 0 {
-		customBytes, err := json.Marshal(session.CustomModelsUsed)
-		if err != nil {
-			return err
-		}
-		customModelsUsedJSON = string(customBytes)
-	}
-
-	// Use NULL for empty parent_id to avoid foreign key constraint issues
-	var parentID any
-	if session.ParentID != "" {
-		parentID = session.ParentID
-	}
 	// Use a transaction
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -988,8 +986,8 @@ func (s *SQLiteSessionStore) UpdateSession(ctx context.Context, session *Session
 		   parent_id = excluded.parent_id`,
 		session.ID, session.ToolsApproved, session.InputTokens, session.OutputTokens,
 		session.Title, session.Cost, session.SendUserMessage, session.MaxIterations, session.WorkingDir,
-		session.CreatedAt.Format(time.RFC3339), session.Starred, permissionsJSON, agentModelOverridesJSON,
-		customModelsUsedJSON, false, parentID)
+		session.CreatedAt.Format(time.RFC3339), session.Starred, fields.PermissionsJSON, fields.AgentModelOverridesJSON,
+		fields.CustomModelsUsedJSON, false, fields.ParentID)
 	if err != nil {
 		return err
 	}
@@ -1127,39 +1125,12 @@ func (s *SQLiteSessionStore) AddSubSession(ctx context.Context, parentSessionID 
 
 // addSessionTx inserts a session within a transaction.
 func (s *SQLiteSessionStore) addSessionTx(ctx context.Context, tx *sql.Tx, session *Session) error {
-	permissionsJSON := ""
-	if session.Permissions != nil {
-		permBytes, err := json.Marshal(session.Permissions)
-		if err != nil {
-			return err
-		}
-		permissionsJSON = string(permBytes)
+	fields, err := sessionPersistedFieldsOf(session)
+	if err != nil {
+		return err
 	}
 
-	agentModelOverridesJSON := "{}"
-	if len(session.AgentModelOverrides) > 0 {
-		overridesBytes, err := json.Marshal(session.AgentModelOverrides)
-		if err != nil {
-			return err
-		}
-		agentModelOverridesJSON = string(overridesBytes)
-	}
-
-	customModelsUsedJSON := "[]"
-	if len(session.CustomModelsUsed) > 0 {
-		customBytes, err := json.Marshal(session.CustomModelsUsed)
-		if err != nil {
-			return err
-		}
-		customModelsUsedJSON = string(customBytes)
-	}
-
-	// Use NULL for empty parent_id to avoid foreign key constraint issues
-	var parentID any
-	if session.ParentID != "" {
-		parentID = session.ParentID
-	}
-	_, err := tx.ExecContext(ctx,
+	_, err = tx.ExecContext(ctx,
 		`INSERT INTO sessions (
 			id, tools_approved, input_tokens, output_tokens, title, cost, send_user_message,
 			max_iterations, working_dir, created_at, starred, permissions, agent_model_overrides,
@@ -1169,8 +1140,8 @@ func (s *SQLiteSessionStore) addSessionTx(ctx context.Context, tx *sql.Tx, sessi
 		session.ID, session.ToolsApproved, session.InputTokens, session.OutputTokens,
 		session.Title, session.Cost, session.SendUserMessage, session.MaxIterations,
 		session.WorkingDir, session.CreatedAt.Format(time.RFC3339), session.Starred,
-		permissionsJSON, agentModelOverridesJSON, customModelsUsedJSON, false,
-		parentID)
+		fields.PermissionsJSON, fields.AgentModelOverridesJSON, fields.CustomModelsUsedJSON, false,
+		fields.ParentID)
 	return err
 }
 

--- a/pkg/session/store_memory_test.go
+++ b/pkg/session/store_memory_test.go
@@ -1,0 +1,69 @@
+package session
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+)
+
+// openMemoryStore returns a SQLiteSessionStore backed by an in-memory database
+// and a t.Cleanup that closes it. Tests use this to avoid the overhead of
+// allocating a temp directory and writing WAL files to disk.
+func openMemoryStore(t *testing.T) *SQLiteSessionStore {
+	t.Helper()
+	// SQLite ":memory:" databases are private to a single connection, so the
+	// store's MaxOpenConns=1 setting (applied by sqliteutil for file DBs) is
+	// implicitly satisfied here too. We open with database/sql directly so
+	// the test does not depend on a working filesystem.
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	db.SetMaxOpenConns(1)
+
+	store, err := NewSQLiteSessionStoreFromDB(db)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func TestNewSQLiteSessionStoreFromDB_NilDB(t *testing.T) {
+	_, err := NewSQLiteSessionStoreFromDB(nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil")
+}
+
+func TestNewSQLiteSessionStoreFromDB_RunsMigrations(t *testing.T) {
+	store := openMemoryStore(t)
+
+	// The applied migration list should be the full production list. We don't
+	// pin the exact count here — just verify the store is usable end-to-end,
+	// which proves the schema is in place.
+	ctx := t.Context()
+	session := New(WithID("from-db-1"), WithTitle("hello"))
+	require.NoError(t, store.AddSession(ctx, session))
+
+	got, err := store.GetSession(ctx, "from-db-1")
+	require.NoError(t, err)
+	assert.Equal(t, "hello", got.Title)
+}
+
+func TestNewSQLiteSessionStoreFromDB_RoundTripWithMessages(t *testing.T) {
+	store := openMemoryStore(t)
+	ctx := t.Context()
+
+	session := New(WithID("rt-1"), WithTitle("round trip"))
+	require.NoError(t, store.AddSession(ctx, session))
+
+	_, err := store.AddMessage(ctx, session.ID, UserMessage("hello"))
+	require.NoError(t, err)
+	_, err = store.AddMessage(ctx, session.ID, UserMessage("world"))
+	require.NoError(t, err)
+
+	got, err := store.GetSession(ctx, session.ID)
+	require.NoError(t, err)
+	require.Len(t, got.Messages, 2)
+	assert.Equal(t, "hello", got.Messages[0].Message.Message.Content)
+	assert.Equal(t, "world", got.Messages[1].Message.Message.Content)
+}

--- a/pkg/session/store_memory_test.go
+++ b/pkg/session/store_memory_test.go
@@ -20,6 +20,11 @@ func openMemoryStore(t *testing.T) *SQLiteSessionStore {
 	// the test does not depend on a working filesystem.
 	db, err := sql.Open("sqlite", ":memory:")
 	require.NoError(t, err)
+	// Register the db cleanup before any potentially failing call so the
+	// connection is released even if NewSQLiteSessionStoreFromDB returns an
+	// error. Calling Close on an already-closed *sql.DB is a no-op, so the
+	// store.Close() registered below is harmless when both run.
+	t.Cleanup(func() { _ = db.Close() })
 	db.SetMaxOpenConns(1)
 
 	store, err := NewSQLiteSessionStoreFromDB(db)

--- a/pkg/session/store_persisted_fields_test.go
+++ b/pkg/session/store_persisted_fields_test.go
@@ -1,0 +1,50 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionPersistedFieldsOf_Defaults(t *testing.T) {
+	got, err := sessionPersistedFieldsOf(&Session{ID: "x"})
+	require.NoError(t, err)
+
+	assert.Empty(t, got.PermissionsJSON, "nil permissions should serialise to empty string")
+	assert.Equal(t, "{}", got.AgentModelOverridesJSON, "nil overrides should default to {}")
+	assert.Equal(t, "[]", got.CustomModelsUsedJSON, "nil models should default to []")
+	assert.Nil(t, got.ParentID, "empty parent_id must encode as SQL NULL")
+}
+
+func TestSessionPersistedFieldsOf_PopulatedValues(t *testing.T) {
+	session := &Session{
+		ID:       "x",
+		ParentID: "parent-1",
+		Permissions: &PermissionsConfig{
+			Allow: []string{"shell"},
+		},
+		AgentModelOverrides: map[string]string{"root": "openai/gpt-5"},
+		CustomModelsUsed:    []string{"openai/gpt-5"},
+	}
+
+	got, err := sessionPersistedFieldsOf(session)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"allow":["shell"]}`, got.PermissionsJSON)
+	assert.JSONEq(t, `{"root":"openai/gpt-5"}`, got.AgentModelOverridesJSON)
+	assert.JSONEq(t, `["openai/gpt-5"]`, got.CustomModelsUsedJSON)
+	assert.Equal(t, "parent-1", got.ParentID)
+}
+
+func TestSessionPersistedFieldsOf_EmptyMapsAndSlicesUseDefaults(t *testing.T) {
+	// len() == 0 for non-nil empty values must take the default branch
+	// because JSON encoding "{}" / "[]" matches what the schema expects.
+	got, err := sessionPersistedFieldsOf(&Session{
+		AgentModelOverrides: map[string]string{},
+		CustomModelsUsed:    []string{},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "{}", got.AgentModelOverridesJSON)
+	assert.Equal(t, "[]", got.CustomModelsUsedJSON)
+}

--- a/pkg/session/truncate_test.go
+++ b/pkg/session/truncate_test.go
@@ -11,6 +11,28 @@ import (
 	"github.com/docker/docker-agent/pkg/tools"
 )
 
+func TestApproximateTokens(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want int
+	}{
+		{"empty", "", 0},
+		{"shorter than divisor", "abc", 0},
+		{"exact divisor", "abcd", 1},
+		{"twice divisor", "abcdefgh", 2},
+		{"rounds down", "abcdefg", 1},
+		{"large input", strings.Repeat("x", 4000), 1000},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := approximateTokens(tt.in); got != tt.want {
+				t.Errorf("approximateTokens(%d chars) = %d, want %d", len(tt.in), got, tt.want)
+			}
+		})
+	}
+}
+
 func TestTruncateOldToolContent(t *testing.T) {
 	t.Run("keeps recent tool content within budget", func(t *testing.T) {
 		messages := []chat.Message{


### PR DESCRIPTION
## Summary

Improves the testability and readability of `pkg/session/` without changing any behaviour observable by callers. The branch is structured as 9 small, focused commits — each with its own validation — so it can be reviewed (and reverted) one piece at a time.

## Why

The `session` package was hard to test in isolation:

- `session.New()`, `UserMessage()`, `SystemMessage()`, `ImplicitUserMessage()` all called `time.Now()` and `uuid.New()` directly, so tests had to overwrite `CreatedAt`/`ID` after construction or rebuild `chat.Message` literals by hand.
- The token-budget heuristic in `truncateOldToolContent` was an inline `len(s)/4`, so the test had to encode the divisor in comments.
- `NewSQLiteSessionStore` only accepted a path, forcing every store test to allocate a temp directory and write WAL files.
- `MigrationManager` baked in the production migration list, so any test of ordering, idempotency, version-mismatch or per-step failure had to drag in all 21 migrations.
- `AddSession`, `UpdateSession` and `addSessionTx` each had their own copy of the JSON marshalling for `Permissions` / `AgentModelOverrides` / `CustomModelsUsed` plus the `parent_id` NULL dance — adding a column meant editing 3+ places.
- Two near-identical message deep-copy implementations existed, and one of them (in `branch.go`) silently forgot to duplicate `MessagePart.File`, so branched sessions shared that pointer with the parent.
- `scanSession` read 7 columns as strings and then `strconv.Parse{Bool,Int,Float}`'d them.
- `GetSession`/`loadSessionWith` and `loadSessionItems`/`loadSessionItemsWith` were thin wrapper pairs, and `GetMessages`/`GetAllMessages` duplicated the same lock-snapshot-clone pattern (and disagreed on which `Item` fields to preserve).

## What

### Testability (commits 1–5)

| # | Commit | Effect |
|---|---|---|
| 1 | `test(session): inject clock and ID generator for deterministic tests` | Package-level seams `nowFn`/`newIDFn` plus `setNowForTest`/`setIDForTest` test helpers. Constructors now produce deterministic `CreatedAt`/`ID`. Persisted `migrations.applied_at` keeps using real `time.Now()`. |
| 2 | `refactor(session): extract approximateTokens helper` | The `len(content)/4` heuristic becomes a named function with its own table-driven test; doc comments updated. |
| 3 | `feat(session): add NewSQLiteSessionStoreFromDB for in-memory tests` | New constructor accepts a caller-supplied `*sql.DB`. Tests can use `sql.Open("sqlite", ":memory:")` instead of needing a temp dir & WAL files. Shared `setupAndMigrate` helper is the new bootstrap path. |
| 4 | `refactor(session): make MigrationManager migration list injectable` | `NewMigrationManager(db)` keeps the production list (callers unchanged); `NewMigrationManagerWithMigrations(db, migrations)` lets tests drive synthetic migrations. Adds 7 unit tests covering rollback, retry, UpFunc failure, and version mismatch — paths that were previously unreachable. |
| 5 | `refactor(session): collapse duplicated session marshalling/SQL` | `sessionPersistedFieldsOf(*Session)` is now the single source of truth for JSON-bearing columns + parent_id NULL handling. `sessionSelectColumns` is the canonical SELECT list. ~30 fewer lines in `store.go`; future column additions become one-place changes. |

### Simplification (commits 6–8)

| # | Commit | Effect |
|---|---|---|
| 6 | `refactor(session): consolidate the two deep-copy implementations` | One `cloneMessage`/`cloneChatMessage` pair instead of two. **Bonus: fixes a latent bug** — branch.go's version forgot to deep-copy `MessagePart.File`, leaving branched sessions sharing that pointer with the parent. Added a regression test that mutates the branched copy and asserts the parent is untouched. |
| 7 | `refactor(session): scan SQL columns into native Go types` | Modernc/sqlite returns INTEGER/BOOLEAN as their native Go types; the `strconv.Parse*` layer (and 7 untestable error branches) goes away. `scanSession` drops from ~95 to ~55 lines. |
| 8 | `refactor(session): extract snapshot helper and collapse store loaders` | One `Session.snapshotItems()` for `GetMessages`/`GetAllMessages` (which now agree on which Item fields to preserve). One `loadSession(ctx, q, id)` and one `loadSessionItems(ctx, q, sessionID)` instead of two thin-wrapper pairs. |

### Review polish (commit 9)

| # | Commit | Effect |
|---|---|---|
| 9 | `fix(session): plug review nits in test helpers` | Defensive `t.Cleanup(db.Close)` in `openMemoryStore` so a migration-time failure can't leak the connection. Doc comments on `setNowForTest`/`setIDForTest` calling out that they mutate package-level state and must not be combined with `t.Parallel()`. |

## Diffstat

```
 pkg/session/branch.go                      |  56 +---
 pkg/session/branch_test.go                 |  41 +++
 pkg/session/clock_test.go                  | 135 +++++++++
 pkg/session/migrations.go                  |  29 ++-
 pkg/session/migrations_unit_test.go        | 170 ++++++++++++
 pkg/session/session.go                     |  85 +++---
 pkg/session/store.go                       | 404 ++++++++++++-----------------
 pkg/session/store_memory_test.go           |  74 ++++++
 pkg/session/store_persisted_fields_test.go |  50 ++++
 pkg/session/truncate_test.go               |  22 ++
 10 files changed, 732 insertions(+), 334 deletions(-)
```

## No behaviour change

- No public API removed. New constructors / helpers are additive: `NewSQLiteSessionStoreFromDB`, `NewMigrationManagerWithMigrations`, `approximateTokens`, `sessionPersistedFieldsOf`, `Session.snapshotItems`.
- All previous tests pass unchanged.
- One pre-existing bug fixed (the missing `MessagePart.File` deep-copy on branched sessions), with a regression test.

## Validation

- `mise lint` (golangci-lint + custom lint + `go mod tidy --diff`): **0 issues**
- `go test ./...` across the whole repo (~125 packages, including all consumers of `pkg/session`): **all green**
- `go test -race ./pkg/session/...`: **green** (run multiple times)
- `go vet ./...`: clean

## How to review

The commits are deliberately self-contained and stand on their own — reviewing them in order tells the story:

1. Start with **commits 1–2** (clock seam + token helper) — small, low-risk seams.
2. **Commit 3** introduces the in-memory test path; **commits 4–5** broaden it to migrations and SQL marshalling.
3. **Commit 6** is the only one that fixes a behaviour bug (with the regression test that locks it in).
4. **Commits 7–8** are pure code-shape simplification.
5. **Commit 9** is review polish.
