### PR TITLE
speed up PR image builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,11 +100,12 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: false
           sbom: false
+          provenance: false
           build-args: |
             GIT_TAG=pr
             GIT_COMMIT=dev
           cache-from: type=gha,scope=buildx
-          cache-to: type=gha,mode=max,scope=buildx
+          cache-to: type=gha,mode=min,scope=buildx
 
   build-and-push-image:
     if: github.event_name != 'pull_request'

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,25 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download
 ENV CGO_ENABLED=1
 
-FROM builder-base AS builder
+FROM builder-base AS builder-linux
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+RUN --mount=type=cache,target=/var/cache/apk,id=apk-$TARGETPLATFORM,sharing=locked \
+    xx-apk add musl-dev
+COPY . ./
+ARG GIT_TAG
+ARG GIT_COMMIT
+RUN --mount=type=cache,target=/root/.cache/go-build,id=go-build-$TARGETPLATFORM \
+    --mount=type=cache,target=/go/pkg/mod <<EOT
+    set -ex
+    test "$TARGETOS" = "linux"
+    export XX_GO_PREFER_C_COMPILER=zig
+    xx-go build -trimpath -tags no_audio -ldflags "-s -w -linkmode=external -X 'github.com/docker/docker-agent/pkg/version.Version=$GIT_TAG' -X 'github.com/docker/docker-agent/pkg/version.Commit=$GIT_COMMIT'" -o /binaries/docker-agent-$TARGETOS-$TARGETARCH .
+    xx-verify --static /binaries/docker-agent-$TARGETOS-$TARGETARCH
+EOT
+
+FROM builder-base AS builder-cross
 ARG TARGETPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
@@ -45,10 +63,10 @@ EOT
 
 FROM scratch AS local
 ARG TARGETOS TARGETARCH
-COPY --from=builder /binaries/docker-agent-$TARGETOS-$TARGETARCH* docker-agent
+COPY --from=builder-cross /binaries/docker-agent-$TARGETOS-$TARGETARCH* docker-agent
 
 FROM scratch AS cross
-COPY --from=builder /binaries .
+COPY --from=builder-cross /binaries .
 
 FROM alpine:${ALPINE_VERSION}
 RUN apk add --no-cache ca-certificates docker-cli && \
@@ -58,7 +76,7 @@ ARG TARGETOS TARGETARCH
 ENV DOCKER_MCP_IN_CONTAINER=1
 ENV TERM=xterm-256color
 COPY --from=docker/mcp-gateway:v2 /docker-mcp /usr/local/lib/docker/cli-plugins/
-COPY --from=builder /binaries/docker-agent-$TARGETOS-$TARGETARCH /docker-agent
+COPY --from=builder-linux /binaries/docker-agent-$TARGETOS-$TARGETARCH /docker-agent
 USER docker-agent
 WORKDIR /work
 ENTRYPOINT ["/docker-agent"]


### PR DESCRIPTION
## Summary

- keep PR image validation multi-arch for linux/amd64 and linux/arm64
- skip provenance generation for PR-only image builds
- export a smaller BuildKit cache for PR builds
- split the Dockerfile Linux image builder from the cross-platform binary builder so Linux image builds avoid the osxcross SDK path

## Expected outcome

PR image builds should spend less time on metadata/cache export and avoid unnecessary osxcross work, while main/tag image publishing keeps full multi-arch SBOM and max provenance behavior.

## Validation

- docker buildx build --check .
- docker buildx build --platform linux/amd64 --build-arg GIT_TAG=pr --build-arg GIT_COMMIT=dev --progress=plain .
- workflow YAML parse