### PR TITLE
refactor(tui): reduce duplication across picker dialogs

### DIFF
--- a/pkg/tui/dialog/base.go
+++ b/pkg/tui/dialog/base.go
@@ -122,6 +122,15 @@ func RenderSeparator(contentWidth int) string {
 		Render(strings.Repeat("─", separatorWidth))
 }
 
+// RenderGroupSeparator renders a labelled section separator inside a list,
+// like "── Custom themes ──────────────". It is used to visually divide
+// groups of items in a picker list.
+func RenderGroupSeparator(label string, contentWidth int) string {
+	prefix := "── " + strings.TrimSpace(label) + " "
+	dashes := max(0, contentWidth-lipgloss.Width(prefix)-2)
+	return styles.MutedStyle.Render(prefix + strings.Repeat("─", dashes))
+}
+
 // RenderHelp renders help text at the bottom of a dialog in italic muted style.
 func RenderHelp(text string, contentWidth int) string {
 	return styles.DialogHelpStyle.Width(contentWidth).Align(lipgloss.Center).Render(text)

--- a/pkg/tui/dialog/command_palette.go
+++ b/pkg/tui/dialog/command_palette.go
@@ -2,7 +2,6 @@ package dialog
 
 import (
 	"strings"
-	"time"
 
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/textinput"
@@ -10,9 +9,7 @@ import (
 	"charm.land/lipgloss/v2"
 
 	"github.com/docker/docker-agent/pkg/tui/commands"
-	"github.com/docker/docker-agent/pkg/tui/components/scrollview"
 	"github.com/docker/docker-agent/pkg/tui/components/toolcommon"
-	"github.com/docker/docker-agent/pkg/tui/core"
 	"github.com/docker/docker-agent/pkg/tui/core/layout"
 	"github.com/docker/docker-agent/pkg/tui/styles"
 )
@@ -22,72 +19,53 @@ type CommandExecuteMsg struct {
 	Command commands.Item
 }
 
-// commandPaletteDialog implements Dialog for the command palette
+// commandPaletteDialog implements Dialog for the command palette.
+// It uses pickerCore for the shared filter/scroll/select skeleton and only
+// adds the bits that are specific to running commands.
 type commandPaletteDialog struct {
-	BaseDialog
+	pickerCore
 
-	textInput      textinput.Model
-	categories     []commands.Category
-	filtered       []commands.Item
-	selected       int
-	keyMap         commandPaletteKeyMap
-	scrollview     *scrollview.Model
-	lastClickTime  time.Time
-	lastClickIndex int
+	categories []commands.Category
+	filtered   []commands.Item
 }
 
-// commandPaletteKeyMap defines key bindings for the command palette
-type commandPaletteKeyMap struct {
-	Up     key.Binding
-	Down   key.Binding
-	Enter  key.Binding
-	Escape key.Binding
-}
+// Command palette dialog dimension constants
+const (
+	paletteWidthPercent  = 80
+	paletteMinWidth      = 50
+	paletteMaxWidth      = 80
+	paletteHeightPercent = 70
+	paletteMaxHeight     = 30
 
-// defaultCommandPaletteKeyMap returns default key bindings
-func defaultCommandPaletteKeyMap() commandPaletteKeyMap {
-	return commandPaletteKeyMap{
-		Up: key.NewBinding(
-			key.WithKeys("up", "ctrl+k"),
-			key.WithHelp("↑/ctrl+k", "up"),
-		),
-		Down: key.NewBinding(
-			key.WithKeys("down", "ctrl+j"),
-			key.WithHelp("↓/ctrl+j", "down"),
-		),
-		Enter: key.NewBinding(
-			key.WithKeys("enter"),
-			key.WithHelp("enter", "execute"),
-		),
-		Escape: key.NewBinding(
-			key.WithKeys("esc"),
-			key.WithHelp("esc", "close"),
-		),
-	}
+	// paletteListOverhead = title(1) + space(1) + input(1) + separator(1) +
+	// space(1) + help(1) + borders/padding(2)
+	paletteListOverhead = 8
+
+	// paletteListStartY = border(1) + padding(1) + title(1) + space(1) +
+	// input(1) + separator(1)
+	paletteListStartY = 6
+)
+
+// commandPalettePickerLayout is the layout used by the command palette.
+var commandPalettePickerLayout = pickerLayout{
+	WidthPercent:    paletteWidthPercent,
+	MinWidth:        paletteMinWidth,
+	MaxWidth:        paletteMaxWidth,
+	HeightPercent:   paletteHeightPercent,
+	MaxHeight:       paletteMaxHeight,
+	ListOverhead:    paletteListOverhead,
+	ListStartOffset: paletteListStartY,
 }
 
 // NewCommandPaletteDialog creates a new command palette dialog
 func NewCommandPaletteDialog(categories []commands.Category) Dialog {
-	ti := textinput.New()
-	ti.SetStyles(styles.DialogInputStyle)
-	ti.Placeholder = "Type to search commands…"
-	ti.Focus()
-	ti.CharLimit = 100
-	ti.SetWidth(50)
-
-	var allCommands []commands.Item
-	for _, cat := range categories {
-		allCommands = append(allCommands, cat.Commands...)
-	}
-
-	return &commandPaletteDialog{
-		textInput:  ti,
+	d := &commandPaletteDialog{
+		pickerCore: newPickerCore(commandPalettePickerLayout, "Type to search commands…"),
 		categories: categories,
-		filtered:   allCommands,
-		selected:   0,
-		keyMap:     defaultCommandPaletteKeyMap(),
-		scrollview: scrollview.New(scrollview.WithReserveScrollbarSpace(true)),
 	}
+	d.textInput.CharLimit = 100
+	d.filterCommands()
+	return d
 }
 
 // Init initializes the command palette dialog
@@ -116,17 +94,13 @@ func (d *commandPaletteDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 	case tea.MouseClickMsg:
 		// Scrollbar clicks already handled above; this handles list item clicks
 		if msg.Button == tea.MouseLeft {
-			if cmdIdx := d.mouseYToCommandIndex(msg.Y); cmdIdx >= 0 {
-				now := time.Now()
-				if cmdIdx == d.lastClickIndex && now.Sub(d.lastClickTime) < styles.DoubleClickThreshold {
+			if cmdIdx := d.mouseListIndex(msg.Y, d.lineToCmdIndex); cmdIdx >= 0 {
+				if d.recordClick(cmdIdx) {
 					d.selected = cmdIdx
-					d.lastClickTime = time.Time{}
 					cmd := d.executeSelected()
 					return d, cmd
 				}
 				d.selected = cmdIdx
-				d.lastClickTime = now
-				d.lastClickIndex = cmdIdx
 			}
 		}
 		return d, nil
@@ -138,7 +112,7 @@ func (d *commandPaletteDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 
 		switch {
 		case key.Matches(msg, d.keyMap.Escape):
-			return d, core.CmdHandler(CloseDialogMsg{})
+			return d, closeDialogCmd()
 
 		case key.Matches(msg, d.keyMap.Up):
 			if d.selected > 0 {
@@ -175,7 +149,7 @@ func (d *commandPaletteDialog) executeSelected() tea.Cmd {
 		return nil
 	}
 	selectedCmd := d.filtered[d.selected]
-	cmds := []tea.Cmd{core.CmdHandler(CloseDialogMsg{})}
+	cmds := []tea.Cmd{closeDialogCmd()}
 	if selectedCmd.Execute != nil {
 		cmds = append(cmds, selectedCmd.Execute(""))
 	}
@@ -186,23 +160,10 @@ func (d *commandPaletteDialog) executeSelected() tea.Cmd {
 func (d *commandPaletteDialog) filterCommands() {
 	query := strings.ToLower(strings.TrimSpace(d.textInput.Value()))
 
-	if query == "" {
-		d.filtered = make([]commands.Item, 0)
-		for _, cat := range d.categories {
-			d.filtered = append(d.filtered, cat.Commands...)
-		}
-		d.selected = 0
-		d.scrollview.SetScrollOffset(0)
-		return
-	}
-
-	d.filtered = make([]commands.Item, 0)
+	d.filtered = d.filtered[:0]
 	for _, cat := range d.categories {
 		for _, cmd := range cat.Commands {
-			if strings.Contains(strings.ToLower(cmd.Label), query) ||
-				strings.Contains(strings.ToLower(cmd.Description), query) ||
-				strings.Contains(strings.ToLower(cmd.Category), query) ||
-				strings.Contains(strings.ToLower(cmd.SlashCommand), query) {
+			if query == "" || matchesCommandQuery(cmd, query) {
 				d.filtered = append(d.filtered, cmd)
 			}
 		}
@@ -214,83 +175,57 @@ func (d *commandPaletteDialog) filterCommands() {
 	d.scrollview.SetScrollOffset(0)
 }
 
-// Command palette dialog dimension constants
-const (
-	paletteWidthPercent  = 80
-	paletteMinWidth      = 50
-	paletteMaxWidth      = 80
-	paletteHeightPercent = 70
-	paletteMaxHeight     = 30
-	paletteDialogPadding = 6 // horizontal padding inside dialog border
-	paletteListOverhead  = 8 // title(1) + space(1) + input(1) + separator(1) + space(1) + help(1) + borders(2)
-	paletteListStartY    = 6 // border(1) + padding(1) + title(1) + space(1) + input(1) + separator(1)
-)
-
-// dialogSize returns the dialog dimensions.
-func (d *commandPaletteDialog) dialogSize() (dialogWidth, maxHeight, contentWidth int) {
-	dialogWidth = max(min(d.Width()*paletteWidthPercent/100, paletteMaxWidth), paletteMinWidth)
-	maxHeight = min(d.Height()*paletteHeightPercent/100, paletteMaxHeight)
-	contentWidth = dialogWidth - paletteDialogPadding - d.scrollview.ReservedCols()
-	return dialogWidth, maxHeight, contentWidth
-}
-
-// SetSize sets the dialog dimensions and configures the scrollview.
-func (d *commandPaletteDialog) SetSize(width, height int) tea.Cmd {
-	cmd := d.BaseDialog.SetSize(width, height)
-	_, maxHeight, contentWidth := d.dialogSize()
-	regionWidth := contentWidth + d.scrollview.ReservedCols()
-	visLines := max(1, maxHeight-paletteListOverhead)
-	d.scrollview.SetSize(regionWidth, visLines)
-	return cmd
-}
-
-// mouseYToCommandIndex converts a mouse Y position to a command index.
-// Returns -1 if the position is not on a command.
-func (d *commandPaletteDialog) mouseYToCommandIndex(y int) int {
-	dialogRow, _ := d.Position()
-	visLines := d.scrollview.VisibleHeight()
-	listStartY := dialogRow + paletteListStartY
-
-	if y < listStartY || y >= listStartY+visLines {
-		return -1
-	}
-	lineInView := y - listStartY
-	actualLine := d.scrollview.ScrollOffset() + lineInView
-
-	_, lineToCmd := d.buildLines(0)
-	if actualLine < 0 || actualLine >= len(lineToCmd) {
-		return -1
-	}
-	return lineToCmd[actualLine]
+// matchesCommandQuery reports whether the given command matches the lowercase
+// query string by searching label, description, category, or slash command.
+func matchesCommandQuery(cmd commands.Item, query string) bool {
+	return strings.Contains(strings.ToLower(cmd.Label), query) ||
+		strings.Contains(strings.ToLower(cmd.Description), query) ||
+		strings.Contains(strings.ToLower(cmd.Category), query) ||
+		strings.Contains(strings.ToLower(cmd.SlashCommand), query)
 }
 
 // buildLines builds the visual lines for the command list and returns:
-// - lines: the rendered line strings
-// - lineToCmd: maps each line index to command index (-1 for headers/blanks)
+//   - lines: the rendered line strings (with category headers)
+//   - lineToCmd: maps each line index to command index (-1 for headers/blanks)
+//
+// contentWidth controls whether items are rendered with full styling: when 0,
+// raw category names and empty strings are emitted (used by tests and by
+// findSelectedLine, which only needs the mapping).
 func (d *commandPaletteDialog) buildLines(contentWidth int) (lines []string, lineToCmd []int) {
+	gl := newGroupedList()
 	var lastCategory string
+
 	for i, cmd := range d.filtered {
 		if cmd.Category != lastCategory {
 			if lastCategory != "" {
-				lines = append(lines, "")
-				lineToCmd = append(lineToCmd, -1)
+				gl.AddNonItem("")
 			}
 			if contentWidth > 0 {
-				lines = append(lines, styles.PaletteCategoryStyle.MarginTop(0).Render(cmd.Category))
+				gl.AddNonItem(styles.PaletteCategoryStyle.MarginTop(0).Render(cmd.Category))
 			} else {
-				lines = append(lines, cmd.Category)
+				gl.AddNonItem(cmd.Category)
 			}
-			lineToCmd = append(lineToCmd, -1)
 			lastCategory = cmd.Category
 		}
+
 		if contentWidth > 0 {
-			lines = append(lines, d.renderCommand(cmd, i == d.selected, contentWidth))
+			gl.AddItem(d.renderCommand(cmd, i == d.selected, contentWidth))
 		} else {
-			lines = append(lines, "")
+			gl.AddItem("")
 		}
-		lineToCmd = append(lineToCmd, i)
 	}
-	return lines, lineToCmd
+
+	return gl.Lines(), gl.LineToItem()
+}
+
+// lineToCmdIndex returns the command index for a given visual line, or -1
+// when the line is a header or blank. Used for mouse hit-testing.
+func (d *commandPaletteDialog) lineToCmdIndex(line int) int {
+	_, lineToCmd := d.buildLines(0)
+	if line < 0 || line >= len(lineToCmd) {
+		return -1
+	}
+	return lineToCmd[line]
 }
 
 // findSelectedLine returns the line index that corresponds to the selected command.
@@ -310,29 +245,17 @@ func (d *commandPaletteDialog) View() string {
 	d.textInput.SetWidth(contentWidth)
 
 	allLines, _ := d.buildLines(contentWidth)
-	regionWidth := contentWidth + d.scrollview.ReservedCols()
-
-	// Set scrollview position for mouse hit-testing (auto-computed from dialog position)
-	dialogRow, dialogCol := d.Position()
-	d.scrollview.SetPosition(dialogCol+3, dialogRow+paletteListStartY)
-
+	d.updateScrollviewPosition()
 	d.scrollview.SetContent(allLines, len(allLines))
 
 	var scrollableContent string
 	if len(d.filtered) == 0 {
-		visLines := d.scrollview.VisibleHeight()
-		emptyLines := []string{"", styles.DialogContentStyle.
-			Italic(true).Align(lipgloss.Center).Width(contentWidth).
-			Render("No commands found")}
-		for len(emptyLines) < visLines {
-			emptyLines = append(emptyLines, "")
-		}
-		scrollableContent = d.scrollview.ViewWithLines(emptyLines)
+		scrollableContent = d.renderEmptyState("No commands found", contentWidth)
 	} else {
 		scrollableContent = d.scrollview.View()
 	}
 
-	content := NewContent(regionWidth).
+	content := NewContent(d.regionWidth(contentWidth)).
 		AddTitle("Commands").
 		AddSpace().
 		AddContent(d.textInput.View()).
@@ -357,8 +280,7 @@ func (d *commandPaletteDialog) renderCommand(cmd commands.Item, selected bool, c
 	label := " " + cmd.Label
 	labelWidth := lipgloss.Width(actionStyle.Render(label))
 
-	var content string
-	content += actionStyle.Render(label)
+	content := actionStyle.Render(label)
 	if cmd.Description != "" {
 		separator := " • "
 		separatorWidth := lipgloss.Width(separator)
@@ -369,10 +291,4 @@ func (d *commandPaletteDialog) renderCommand(cmd commands.Item, selected bool, c
 		}
 	}
 	return content
-}
-
-// Position calculates the position to center the dialog
-func (d *commandPaletteDialog) Position() (row, col int) {
-	dialogWidth, maxHeight, _ := d.dialogSize()
-	return CenterPosition(d.Width(), d.Height(), dialogWidth, maxHeight)
 }

--- a/pkg/tui/dialog/command_palette.go
+++ b/pkg/tui/dialog/command_palette.go
@@ -14,11 +14,6 @@ import (
 	"github.com/docker/docker-agent/pkg/tui/styles"
 )
 
-// CommandExecuteMsg is sent when a command is selected
-type CommandExecuteMsg struct {
-	Command commands.Item
-}
-
 // commandPaletteDialog implements Dialog for the command palette.
 // It uses pickerCore for the shared filter/scroll/select skeleton and only
 // adds the bits that are specific to running commands.

--- a/pkg/tui/dialog/command_palette.go
+++ b/pkg/tui/dialog/command_palette.go
@@ -130,7 +130,9 @@ func (d *commandPaletteDialog) filterCommands() {
 		}
 	}
 
-	if d.selected >= len(d.filtered) {
+	// Clearing the search returns the cursor to the top, matching the file
+	// picker. Filtered queries preserve the cursor when still in range.
+	if query == "" || d.selected >= len(d.filtered) {
 		d.selected = 0
 	}
 	d.scrollview.SetScrollOffset(0)

--- a/pkg/tui/dialog/command_palette.go
+++ b/pkg/tui/dialog/command_palette.go
@@ -29,38 +29,29 @@ type commandPaletteDialog struct {
 	filtered   []commands.Item
 }
 
-// Command palette dialog dimension constants
-const (
-	paletteWidthPercent  = 80
-	paletteMinWidth      = 50
-	paletteMaxWidth      = 80
-	paletteHeightPercent = 70
-	paletteMaxHeight     = 30
-
-	// paletteListOverhead = title(1) + space(1) + input(1) + separator(1) +
-	// space(1) + help(1) + borders/padding(2)
-	paletteListOverhead = 8
-
-	// paletteListStartY = border(1) + padding(1) + title(1) + space(1) +
-	// input(1) + separator(1)
-	paletteListStartY = 6
-)
-
-// commandPalettePickerLayout is the layout used by the command palette.
-var commandPalettePickerLayout = pickerLayout{
-	WidthPercent:    paletteWidthPercent,
-	MinWidth:        paletteMinWidth,
-	MaxWidth:        paletteMaxWidth,
-	HeightPercent:   paletteHeightPercent,
-	MaxHeight:       paletteMaxHeight,
-	ListOverhead:    paletteListOverhead,
-	ListStartOffset: paletteListStartY,
+// commandPaletteLayout is the layout used by the command palette.
+//
+// ListOverhead = title(1) + space(1) + input(1) + separator(1) + space(1) +
+//
+//	help(1) + borders/padding(2) = 8
+//
+// ListStartOffset = border(1) + padding(1) + title(1) + space(1) + input(1) +
+//
+//	separator(1) = 6
+var commandPaletteLayout = pickerLayout{
+	WidthPercent:    80,
+	MinWidth:        50,
+	MaxWidth:        80,
+	HeightPercent:   70,
+	MaxHeight:       30,
+	ListOverhead:    8,
+	ListStartOffset: 6,
 }
 
-// NewCommandPaletteDialog creates a new command palette dialog
+// NewCommandPaletteDialog creates a new command palette dialog.
 func NewCommandPaletteDialog(categories []commands.Category) Dialog {
 	d := &commandPaletteDialog{
-		pickerCore: newPickerCore(commandPalettePickerLayout, "Type to search commands…"),
+		pickerCore: newPickerCore(commandPaletteLayout, "Type to search commands…"),
 		categories: categories,
 	}
 	d.textInput.CharLimit = 100
@@ -68,12 +59,8 @@ func NewCommandPaletteDialog(categories []commands.Category) Dialog {
 	return d
 }
 
-// Init initializes the command palette dialog
-func (d *commandPaletteDialog) Init() tea.Cmd {
-	return textinput.Blink
-}
+func (d *commandPaletteDialog) Init() tea.Cmd { return textinput.Blink }
 
-// Update handles messages for the command palette dialog
 func (d *commandPaletteDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 	// Scrollview handles mouse scrollbar, wheel, and pgup/pgdn/home/end
 	if handled, cmd := d.scrollview.Update(msg); handled {
@@ -86,22 +73,14 @@ func (d *commandPaletteDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		return d, cmd
 
 	case tea.PasteMsg:
-		var cmd tea.Cmd
-		d.textInput, cmd = d.textInput.Update(msg)
-		d.filterCommands()
+		cmd := d.updateInput(msg, d.filterCommands)
 		return d, cmd
 
 	case tea.MouseClickMsg:
-		// Scrollbar clicks already handled above; this handles list item clicks
-		if msg.Button == tea.MouseLeft {
-			if cmdIdx := d.mouseListIndex(msg.Y, d.lineToCmdIndex); cmdIdx >= 0 {
-				if d.recordClick(cmdIdx) {
-					d.selected = cmdIdx
-					cmd := d.executeSelected()
-					return d, cmd
-				}
-				d.selected = cmdIdx
-			}
+		// Scrollbar clicks already handled above; this handles list item clicks.
+		if dbl, _ := d.handleListClick(msg, d.lineToCmdIndex); dbl {
+			cmd := d.executeSelected()
+			return d, cmd
 		}
 		return d, nil
 
@@ -109,33 +88,20 @@ func (d *commandPaletteDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		if cmd := HandleQuit(msg); cmd != nil {
 			return d, cmd
 		}
-
 		switch {
 		case key.Matches(msg, d.keyMap.Escape):
 			return d, closeDialogCmd()
-
 		case key.Matches(msg, d.keyMap.Up):
-			if d.selected > 0 {
-				d.selected--
-				d.scrollview.EnsureLineVisible(d.findSelectedLine())
-			}
+			d.navigate(-1, len(d.filtered), d.findSelectedLine)
 			return d, nil
-
 		case key.Matches(msg, d.keyMap.Down):
-			if d.selected < len(d.filtered)-1 {
-				d.selected++
-				d.scrollview.EnsureLineVisible(d.findSelectedLine())
-			}
+			d.navigate(+1, len(d.filtered), d.findSelectedLine)
 			return d, nil
-
 		case key.Matches(msg, d.keyMap.Enter):
 			cmd := d.executeSelected()
 			return d, cmd
-
 		default:
-			var cmd tea.Cmd
-			d.textInput, cmd = d.textInput.Update(msg)
-			d.filterCommands()
+			cmd := d.updateInput(msg, d.filterCommands)
 			return d, cmd
 		}
 	}
@@ -156,7 +122,7 @@ func (d *commandPaletteDialog) executeSelected() tea.Cmd {
 	return tea.Sequence(cmds...)
 }
 
-// filterCommands filters the command list based on search input
+// filterCommands filters the command list based on search input.
 func (d *commandPaletteDialog) filterCommands() {
 	query := strings.ToLower(strings.TrimSpace(d.textInput.Value()))
 
@@ -184,14 +150,11 @@ func matchesCommandQuery(cmd commands.Item, query string) bool {
 		strings.Contains(strings.ToLower(cmd.SlashCommand), query)
 }
 
-// buildLines builds the visual lines for the command list and returns:
-//   - lines: the rendered line strings (with category headers)
-//   - lineToCmd: maps each line index to command index (-1 for headers/blanks)
-//
-// contentWidth controls whether items are rendered with full styling: when 0,
-// raw category names and empty strings are emitted (used by tests and by
-// findSelectedLine, which only needs the mapping).
-func (d *commandPaletteDialog) buildLines(contentWidth int) (lines []string, lineToCmd []int) {
+// buildList builds the visual list of commands grouped by category, with a
+// blank line + category header before each new group. Pass contentWidth=0 to
+// produce a layout-only list (used by mouse hit-testing and findSelectedLine,
+// which only need the line→item mapping).
+func (d *commandPaletteDialog) buildList(contentWidth int) *groupedList {
 	gl := newGroupedList()
 	var lastCategory string
 
@@ -200,59 +163,52 @@ func (d *commandPaletteDialog) buildLines(contentWidth int) (lines []string, lin
 			if lastCategory != "" {
 				gl.AddNonItem("")
 			}
-			if contentWidth > 0 {
-				gl.AddNonItem(styles.PaletteCategoryStyle.MarginTop(0).Render(cmd.Category))
-			} else {
-				gl.AddNonItem(cmd.Category)
-			}
+			gl.AddNonItem(d.renderCategoryHeader(cmd.Category, contentWidth))
 			lastCategory = cmd.Category
 		}
-
-		if contentWidth > 0 {
-			gl.AddItem(d.renderCommand(cmd, i == d.selected, contentWidth))
-		} else {
-			gl.AddItem("")
-		}
+		gl.AddItem(d.renderCommand(cmd, i == d.selected, contentWidth))
 	}
 
+	return gl
+}
+
+func (d *commandPaletteDialog) renderCategoryHeader(category string, contentWidth int) string {
+	if contentWidth <= 0 {
+		return category
+	}
+	return styles.PaletteCategoryStyle.MarginTop(0).Render(category)
+}
+
+// lineToCmdIndex returns the command index for a rendered line, or -1
+// when the line is a header or blank. Used for mouse hit-testing.
+func (d *commandPaletteDialog) lineToCmdIndex(line int) int {
+	return d.buildList(0).ItemForLine(line)
+}
+
+// findSelectedLine returns the rendered line index for the selected command.
+func (d *commandPaletteDialog) findSelectedLine() int {
+	return d.buildList(0).LineForItem(d.selected)
+}
+
+// buildLines returns the rendered lines and the line→item mapping. It exists
+// for the test suite; production code uses buildList directly.
+func (d *commandPaletteDialog) buildLines(contentWidth int) (lines []string, lineToCmd []int) {
+	gl := d.buildList(contentWidth)
 	return gl.Lines(), gl.LineToItem()
 }
 
-// lineToCmdIndex returns the command index for a given visual line, or -1
-// when the line is a header or blank. Used for mouse hit-testing.
-func (d *commandPaletteDialog) lineToCmdIndex(line int) int {
-	_, lineToCmd := d.buildLines(0)
-	if line < 0 || line >= len(lineToCmd) {
-		return -1
-	}
-	return lineToCmd[line]
-}
-
-// findSelectedLine returns the line index that corresponds to the selected command.
-func (d *commandPaletteDialog) findSelectedLine() int {
-	_, lineToCmd := d.buildLines(0)
-	for i, cmdIdx := range lineToCmd {
-		if cmdIdx == d.selected {
-			return i
-		}
-	}
-	return 0
-}
-
-// View renders the command palette dialog
+// View renders the command palette dialog.
 func (d *commandPaletteDialog) View() string {
 	dialogWidth, _, contentWidth := d.dialogSize()
 	d.textInput.SetWidth(contentWidth)
 
-	allLines, _ := d.buildLines(contentWidth)
+	gl := d.buildList(contentWidth)
 	d.updateScrollviewPosition()
-	d.scrollview.SetContent(allLines, len(allLines))
+	d.scrollview.SetContent(gl.Lines(), len(gl.Lines()))
 
-	var scrollableContent string
+	scrollableContent := d.scrollview.View()
 	if len(d.filtered) == 0 {
 		scrollableContent = d.renderEmptyState("No commands found", contentWidth)
-	} else {
-		scrollableContent = d.scrollview.View()
 	}
 
 	content := NewContent(d.regionWidth(contentWidth)).
@@ -268,8 +224,12 @@ func (d *commandPaletteDialog) View() string {
 	return styles.DialogStyle.Width(dialogWidth).Render(content)
 }
 
-// renderCommand renders a single command in the list
+// renderCommand renders a single command line in the list.
 func (d *commandPaletteDialog) renderCommand(cmd commands.Item, selected bool, contentWidth int) string {
+	if contentWidth <= 0 {
+		return ""
+	}
+
 	actionStyle := styles.PaletteUnselectedActionStyle
 	descStyle := styles.PaletteUnselectedDescStyle
 	if selected {
@@ -278,17 +238,15 @@ func (d *commandPaletteDialog) renderCommand(cmd commands.Item, selected bool, c
 	}
 
 	label := " " + cmd.Label
-	labelWidth := lipgloss.Width(actionStyle.Render(label))
-
 	content := actionStyle.Render(label)
-	if cmd.Description != "" {
-		separator := " • "
-		separatorWidth := lipgloss.Width(separator)
-		availableWidth := contentWidth - labelWidth - separatorWidth
-		if availableWidth > 0 {
-			truncatedDesc := toolcommon.TruncateText(cmd.Description, availableWidth)
-			content += descStyle.Render(separator + truncatedDesc)
-		}
+	if cmd.Description == "" {
+		return content
 	}
-	return content
+
+	const separator = " • "
+	availableWidth := contentWidth - lipgloss.Width(content) - lipgloss.Width(separator)
+	if availableWidth <= 0 {
+		return content
+	}
+	return content + descStyle.Render(separator+toolcommon.TruncateText(cmd.Description, availableWidth))
 }

--- a/pkg/tui/dialog/file_picker.go
+++ b/pkg/tui/dialog/file_picker.go
@@ -8,11 +8,9 @@ import (
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
-	"charm.land/lipgloss/v2"
 	"github.com/docker/go-units"
 
 	"github.com/docker/docker-agent/pkg/fsx"
-	"github.com/docker/docker-agent/pkg/tui/components/scrollview"
 	"github.com/docker/docker-agent/pkg/tui/core"
 	"github.com/docker/docker-agent/pkg/tui/core/layout"
 	"github.com/docker/docker-agent/pkg/tui/messages"
@@ -27,20 +25,31 @@ type fileEntry struct {
 }
 
 const (
+	// filePickerListOverhead = title(1) + space(1) + dir(1) + input(1) +
+	// separator(1) + space(1) + help row(2) + borders/padding(3)
 	filePickerListOverhead = 11
-	filePickerListStartY   = 7 // border(1) + padding(1) + title(1) + space(1) + dir(1) + input(1) + separator(1)
+	// filePickerListStartY = border(1) + padding(1) + title(1) + space(1) +
+	// dir(1) + input(1) + separator(1)
+	filePickerListStartY = 7
 )
 
-type filePickerDialog struct {
-	BaseDialog
+// filePickerLayout is the layout used by the file picker.
+var filePickerLayout = pickerLayout{
+	WidthPercent:    80,
+	MinWidth:        60,
+	MaxWidth:        80,
+	HeightPercent:   70,
+	MaxHeight:       30,
+	ListOverhead:    filePickerListOverhead,
+	ListStartOffset: filePickerListStartY,
+}
 
-	textInput   textinput.Model
+type filePickerDialog struct {
+	pickerCore
+
 	currentDir  string
 	entries     []fileEntry
 	filtered    []fileEntry
-	selected    int
-	scrollview  *scrollview.Model
-	keyMap      commandPaletteKeyMap
 	err         error
 	showHidden  bool
 	showIgnored bool
@@ -50,12 +59,6 @@ type filePickerDialog struct {
 // If initialPath is provided and is a directory, it starts in that directory.
 // If initialPath is a file, it starts in the file's directory with the file pre-selected.
 func NewFilePickerDialog(initialPath string) Dialog {
-	ti := textinput.New()
-	ti.Placeholder = "Type to filter files…"
-	ti.Focus()
-	ti.CharLimit = 256
-	ti.SetWidth(50)
-
 	cwd, err := os.Getwd()
 	if err != nil {
 		cwd = "."
@@ -68,7 +71,6 @@ func NewFilePickerDialog(initialPath string) Dialog {
 		if !filepath.IsAbs(initialPath) {
 			initialPath = filepath.Join(cwd, initialPath)
 		}
-
 		info, err := os.Stat(initialPath)
 		if err == nil {
 			if info.IsDir() {
@@ -86,10 +88,8 @@ func NewFilePickerDialog(initialPath string) Dialog {
 	}
 
 	d := &filePickerDialog{
-		textInput:  ti,
+		pickerCore: newPickerCore(filePickerLayout, "Type to filter files…"),
 		currentDir: startDir,
-		scrollview: scrollview.New(scrollview.WithReserveScrollbarSpace(true)),
-		keyMap:     defaultCommandPaletteKeyMap(),
 	}
 
 	d.loadDirectory()
@@ -204,7 +204,7 @@ func (d *filePickerDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 
 		switch {
 		case key.Matches(msg, d.keyMap.Escape):
-			return d, core.CmdHandler(CloseDialogMsg{})
+			return d, closeDialogCmd()
 
 		case key.Matches(msg, d.keyMap.Up):
 			if d.selected > 0 {
@@ -230,7 +230,7 @@ func (d *filePickerDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 					return d, nil
 				}
 				return d, tea.Sequence(
-					core.CmdHandler(CloseDialogMsg{}),
+					closeDialogCmd(),
 					core.CmdHandler(messages.InsertFileRefMsg{FilePath: entry.path}),
 				)
 			}
@@ -285,13 +285,6 @@ func (d *filePickerDialog) filterEntries() {
 	d.scrollview.SetScrollOffset(0)
 }
 
-func (d *filePickerDialog) dialogSize() (dialogWidth, maxHeight, contentWidth int) {
-	dialogWidth = max(min(d.Width()*80/100, 80), 60)
-	maxHeight = min(d.Height()*70/100, 30)
-	contentWidth = dialogWidth - 6 - d.scrollview.ReservedCols()
-	return dialogWidth, maxHeight, contentWidth
-}
-
 func (d *filePickerDialog) View() string {
 	dialogWidth, _, contentWidth := d.dialogSize()
 	d.textInput.SetWidth(contentWidth)
@@ -302,45 +295,26 @@ func (d *filePickerDialog) View() string {
 	}
 	dirLine := styles.MutedStyle.Render("📁 " + displayDir)
 
-	// Build all entry lines
 	var allLines []string
 	for i, entry := range d.filtered {
 		allLines = append(allLines, d.renderEntry(entry, i == d.selected, contentWidth))
 	}
 
-	regionWidth := contentWidth + d.scrollview.ReservedCols()
-	visibleLines := d.scrollview.VisibleHeight()
-
-	// Set scrollview position for mouse hit-testing (auto-computed from dialog position)
-	dialogRow, dialogCol := d.Position()
-	d.scrollview.SetPosition(dialogCol+3, dialogRow+filePickerListStartY)
-
+	d.updateScrollviewPosition()
 	d.scrollview.SetContent(allLines, len(allLines))
 
 	var scrollableContent string
 	switch {
 	case d.err != nil:
-		errLines := []string{"", styles.ErrorStyle.
-			Align(lipgloss.Center).Width(contentWidth).
-			Render(d.err.Error())}
-		for len(errLines) < visibleLines {
-			errLines = append(errLines, "")
-		}
-		scrollableContent = d.scrollview.ViewWithLines(errLines)
+		scrollableContent = d.renderErrorState(d.err.Error(), contentWidth)
 	case len(d.filtered) == 0:
-		emptyLines := []string{"", styles.DialogContentStyle.
-			Italic(true).Align(lipgloss.Center).Width(contentWidth).
-			Render("No files found")}
-		for len(emptyLines) < visibleLines {
-			emptyLines = append(emptyLines, "")
-		}
-		scrollableContent = d.scrollview.ViewWithLines(emptyLines)
+		scrollableContent = d.renderEmptyState("No files found", contentWidth)
 	default:
 		scrollableContent = d.scrollview.View()
 	}
 
 	helpRow1, helpRow2 := d.filePickerHelpKeysRows()
-	content := NewContent(regionWidth).
+	content := NewContent(d.regionWidth(contentWidth)).
 		AddTitle("Attach File").
 		AddSpace().
 		AddContent(dirLine).
@@ -353,16 +327,6 @@ func (d *filePickerDialog) View() string {
 		Build()
 
 	return styles.DialogStyle.Width(dialogWidth).Render(content)
-}
-
-// SetSize sets the dialog dimensions and configures the scrollview region.
-func (d *filePickerDialog) SetSize(width, height int) tea.Cmd {
-	cmd := d.BaseDialog.SetSize(width, height)
-	_, maxHeight, contentWidth := d.dialogSize()
-	regionWidth := contentWidth + d.scrollview.ReservedCols()
-	visibleLines := max(1, maxHeight-filePickerListOverhead)
-	d.scrollview.SetSize(regionWidth, visibleLines)
-	return cmd
 }
 
 func (d *filePickerDialog) renderEntry(entry fileEntry, selected bool, maxWidth int) string {
@@ -411,9 +375,4 @@ func (d *filePickerDialog) filePickerHelpKeysRows() (row1, row2 []string) {
 		"alt+i", ignoredLabel,
 	}
 	return row1, row2
-}
-
-func (d *filePickerDialog) Position() (row, col int) {
-	dialogWidth, maxHeight, _ := d.dialogSize()
-	return CenterPosition(d.Width(), d.Height(), dialogWidth, maxHeight)
 }

--- a/pkg/tui/dialog/file_picker.go
+++ b/pkg/tui/dialog/file_picker.go
@@ -176,12 +176,10 @@ func (d *filePickerDialog) loadDirectory() {
 	d.filtered = d.entries
 }
 
-func (d *filePickerDialog) Init() tea.Cmd {
-	return textinput.Blink
-}
+func (d *filePickerDialog) Init() tea.Cmd { return textinput.Blink }
 
 func (d *filePickerDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
-	// Scrollview handles mouse click/motion/release, wheel, and pgup/pgdn/home/end
+	// Scrollview handles mouse click/motion/release, wheel, and pgup/pgdn/home/end.
 	if handled, cmd := d.scrollview.Update(msg); handled {
 		return d, cmd
 	}
@@ -192,71 +190,69 @@ func (d *filePickerDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		return d, cmd
 
 	case tea.PasteMsg:
-		var cmd tea.Cmd
-		d.textInput, cmd = d.textInput.Update(msg)
-		d.filterEntries()
+		cmd := d.updateInput(msg, d.filterEntries)
 		return d, cmd
 
 	case tea.KeyPressMsg:
 		if cmd := HandleQuit(msg); cmd != nil {
 			return d, cmd
 		}
-
 		switch {
 		case key.Matches(msg, d.keyMap.Escape):
 			return d, closeDialogCmd()
-
 		case key.Matches(msg, d.keyMap.Up):
-			if d.selected > 0 {
-				d.selected--
-				d.scrollview.EnsureLineVisible(d.selected)
-			}
+			d.navigate(-1, len(d.filtered), nil)
 			return d, nil
-
 		case key.Matches(msg, d.keyMap.Down):
-			if d.selected < len(d.filtered)-1 {
-				d.selected++
-				d.scrollview.EnsureLineVisible(d.selected)
-			}
+			d.navigate(+1, len(d.filtered), nil)
 			return d, nil
-
 		case key.Matches(msg, d.keyMap.Enter):
-			if d.selected >= 0 && d.selected < len(d.filtered) {
-				entry := d.filtered[d.selected]
-				if entry.isDir {
-					d.currentDir = entry.path
-					d.textInput.SetValue("")
-					d.loadDirectory()
-					return d, nil
-				}
-				return d, tea.Sequence(
-					closeDialogCmd(),
-					core.CmdHandler(messages.InsertFileRefMsg{FilePath: entry.path}),
-				)
-			}
-			return d, nil
-
+			cmd := d.activateSelected()
+			return d, cmd
 		case msg.String() == "alt+h":
-			d.showHidden = !d.showHidden
-			d.loadDirectory()
-			d.filterEntries()
+			d.toggleHidden()
 			return d, nil
-
 		case msg.String() == "alt+i":
-			d.showIgnored = !d.showIgnored
-			d.loadDirectory()
-			d.filterEntries()
+			d.toggleIgnored()
 			return d, nil
-
 		default:
-			var cmd tea.Cmd
-			d.textInput, cmd = d.textInput.Update(msg)
-			d.filterEntries()
+			cmd := d.updateInput(msg, d.filterEntries)
 			return d, cmd
 		}
 	}
 
 	return d, nil
+}
+
+// activateSelected handles enter on the current entry. Directories are
+// navigated into; files are returned to the caller via InsertFileRefMsg.
+func (d *filePickerDialog) activateSelected() tea.Cmd {
+	if d.selected < 0 || d.selected >= len(d.filtered) {
+		return nil
+	}
+	entry := d.filtered[d.selected]
+	if entry.isDir {
+		d.currentDir = entry.path
+		d.textInput.SetValue("")
+		d.loadDirectory()
+		return nil
+	}
+	return tea.Sequence(
+		closeDialogCmd(),
+		core.CmdHandler(messages.InsertFileRefMsg{FilePath: entry.path}),
+	)
+}
+
+func (d *filePickerDialog) toggleHidden() {
+	d.showHidden = !d.showHidden
+	d.loadDirectory()
+	d.filterEntries()
+}
+
+func (d *filePickerDialog) toggleIgnored() {
+	d.showIgnored = !d.showIgnored
+	d.loadDirectory()
+	d.filterEntries()
 }
 
 func (d *filePickerDialog) filterEntries() {

--- a/pkg/tui/dialog/file_picker.go
+++ b/pkg/tui/dialog/file_picker.go
@@ -339,7 +339,7 @@ func (d *filePickerDialog) renderEntry(entry fileEntry, selected bool, maxWidth 
 	}
 
 	name := entry.name
-	maxNameLen := maxWidth - 20
+	maxNameLen := max(1, maxWidth-20)
 	if len(name) > maxNameLen {
 		name = name[:maxNameLen-1] + "…"
 	}

--- a/pkg/tui/dialog/file_picker_test.go
+++ b/pkg/tui/dialog/file_picker_test.go
@@ -8,17 +8,14 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/docker/docker-agent/pkg/tui/components/scrollview"
 )
 
 // newTestFilePickerDialog creates a filePickerDialog pointed at dir without
 // going through NewFilePickerDialog (which uses os.Getwd).
 func newTestFilePickerDialog(dir string) *filePickerDialog {
 	d := &filePickerDialog{
+		pickerCore: newPickerCore(filePickerLayout, "Type to filter files…"),
 		currentDir: dir,
-		scrollview: scrollview.New(scrollview.WithReserveScrollbarSpace(true)),
-		keyMap:     defaultCommandPaletteKeyMap(),
 	}
 	d.loadDirectory()
 	return d

--- a/pkg/tui/dialog/model_picker.go
+++ b/pkg/tui/dialog/model_picker.go
@@ -1,13 +1,11 @@
 package dialog
 
 import (
-	"cmp"
 	"errors"
 	"fmt"
 	"slices"
 	"strconv"
 	"strings"
-	"time"
 
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/textinput"
@@ -16,7 +14,6 @@ import (
 
 	"github.com/docker/docker-agent/pkg/model/provider"
 	"github.com/docker/docker-agent/pkg/runtime"
-	"github.com/docker/docker-agent/pkg/tui/components/scrollview"
 	"github.com/docker/docker-agent/pkg/tui/components/toolcommon"
 	"github.com/docker/docker-agent/pkg/tui/core"
 	"github.com/docker/docker-agent/pkg/tui/core/layout"
@@ -26,73 +23,100 @@ import (
 
 // modelPickerDialog is a dialog for selecting a model for the current agent.
 type modelPickerDialog struct {
-	BaseDialog
+	pickerCore
 
-	textInput  textinput.Model
-	models     []runtime.ModelChoice
-	filtered   []runtime.ModelChoice
-	selected   int
-	keyMap     commandPaletteKeyMap
-	errMsg     string // validation error message
-	scrollview *scrollview.Model
+	models   []runtime.ModelChoice
+	filtered []runtime.ModelChoice
+	errMsg   string // validation error message
 
-	// Double-click detection
-	lastClickTime  time.Time
-	lastClickIndex int
+	// cached grouped list, rebuilt on every render so the layout used by
+	// View() is shared with mouse hit-testing and findSelectedLine.
+	cached *groupedList
+}
+
+// Model picker dialog dimension constants
+const (
+	pickerWidthPercent  = 80
+	pickerMinWidth      = 50
+	pickerMaxWidth      = 100
+	pickerHeightPercent = 70
+	pickerMaxHeight     = 150
+
+	// Column widths for the per-row stats. Values are right-aligned in their
+	// own column so the list reads like a table.
+	pickerInputColWidth   = 10
+	pickerOutputColWidth  = 10
+	pickerContextColWidth = 8
+
+	// pickerDetailsLines is the number of lines reserved for the model
+	// details panel rendered below the model list.
+	pickerDetailsLines = 4
+
+	// pickerListVerticalOverhead is the number of rows used by dialog chrome:
+	// title(1) + space(1) + input(1) + separator(1) + column header(1) +
+	// details separator(1) + details (pickerDetailsLines) + space at bottom(1) +
+	// help keys(1) + borders/padding(2) = 10 + pickerDetailsLines
+	pickerListVerticalOverhead = 10 + pickerDetailsLines
+
+	// pickerListStartOffset is the Y offset from dialog top to where the model list starts:
+	// border(1) + padding(1) + title(1) + space(1) + input(1) + separator(1) +
+	// column header(1) = 7
+	pickerListStartOffset = 7
+
+	// pickerDetailsLabelWidth is the column width for the labels in the
+	// details panel ("Reference", "Pricing", "Limits", "Modalities").
+	pickerDetailsLabelWidth = 12
+
+	// catalogSeparatorLabel labels the separator above the catalog group.
+	catalogSeparatorLabel = "Other models"
+	// customSeparatorLabel labels the separator above the custom-models group.
+	customSeparatorLabel = "Custom models"
+)
+
+// modelPickerLayout is the layout used by the model picker.
+var modelPickerLayout = pickerLayout{
+	WidthPercent:    pickerWidthPercent,
+	MinWidth:        pickerMinWidth,
+	MaxWidth:        pickerMaxWidth,
+	HeightPercent:   pickerHeightPercent,
+	MaxHeight:       pickerMaxHeight,
+	ListOverhead:    pickerListVerticalOverhead,
+	ListStartOffset: pickerListStartOffset,
 }
 
 // NewModelPickerDialog creates a new model picker dialog.
 func NewModelPickerDialog(models []runtime.ModelChoice) Dialog {
-	ti := textinput.New()
-	ti.Placeholder = "Type to search or enter custom model (provider/model)…"
-	ti.Focus()
-	ti.CharLimit = 100
-	ti.SetWidth(50)
+	d := &modelPickerDialog{
+		pickerCore: newPickerCore(modelPickerLayout, "Type to search or enter custom model (provider/model)…"),
+	}
+	d.textInput.CharLimit = 100
 
-	// Sort models: config first, then catalog, then custom. Within each section: current first, then default, then alphabetically
+	// Sort models: config first, then catalog, then custom.
 	sortedModels := make([]runtime.ModelChoice, len(models))
 	copy(sortedModels, models)
 	slices.SortFunc(sortedModels, func(a, b runtime.ModelChoice) int {
-		// Get section priority: config (0) < catalog (1) < custom (2)
-		getPriority := func(m runtime.ModelChoice) int {
-			if m.IsCustom {
-				return 2
-			}
-			if m.IsCatalog {
-				return 1
-			}
-			return 0
-		}
-		pa, pb := getPriority(a), getPriority(b)
-		if pa != pb {
-			return cmp.Compare(pa, pb)
-		}
-		// Within each section: current model first
-		if a.IsCurrent != b.IsCurrent {
-			if a.IsCurrent {
-				return -1
-			}
-			return 1
-		}
-		// Then default model
-		if a.IsDefault != b.IsDefault {
-			if a.IsDefault {
-				return -1
-			}
-			return 1
-		}
-		// Then alphabetically by name
-		return cmp.Compare(a.Name, b.Name)
+		return comparePickerSortKeys(modelSortKeys(a), modelSortKeys(b))
 	})
-
-	d := &modelPickerDialog{
-		textInput:  ti,
-		models:     sortedModels,
-		keyMap:     defaultCommandPaletteKeyMap(),
-		scrollview: scrollview.New(scrollview.WithReserveScrollbarSpace(true)),
-	}
+	d.models = sortedModels
 	d.filterModels()
 	return d
+}
+
+// modelSortKeys derives the sort key tuple from a runtime.ModelChoice.
+func modelSortKeys(m runtime.ModelChoice) pickerSortKeys {
+	section := 0
+	switch {
+	case m.IsCustom:
+		section = 2
+	case m.IsCatalog:
+		section = 1
+	}
+	return pickerSortKeys{
+		Section:   section,
+		IsCurrent: m.IsCurrent,
+		IsDefault: m.IsDefault,
+		Name:      m.Name,
+	}
 }
 
 func (d *modelPickerDialog) Init() tea.Cmd {
@@ -120,17 +144,13 @@ func (d *modelPickerDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 	case tea.MouseClickMsg:
 		// Scrollbar clicks handled above; this handles list item clicks
 		if msg.Button == tea.MouseLeft {
-			if modelIdx := d.mouseYToModelIndex(msg.Y); modelIdx >= 0 {
-				now := time.Now()
-				if modelIdx == d.lastClickIndex && now.Sub(d.lastClickTime) < styles.DoubleClickThreshold {
+			if modelIdx := d.mouseListIndex(msg.Y, d.lineToModelIndex); modelIdx >= 0 {
+				if d.recordClick(modelIdx) {
 					d.selected = modelIdx
-					d.lastClickTime = time.Time{}
 					cmd := d.handleSelection()
 					return d, cmd
 				}
 				d.selected = modelIdx
-				d.lastClickTime = now
-				d.lastClickIndex = modelIdx
 			}
 		}
 		return d, nil
@@ -142,19 +162,19 @@ func (d *modelPickerDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 
 		switch {
 		case key.Matches(msg, d.keyMap.Escape):
-			return d, core.CmdHandler(CloseDialogMsg{})
+			return d, closeDialogCmd()
 
 		case key.Matches(msg, d.keyMap.Up):
 			if d.selected > 0 {
 				d.selected--
-				d.scrollview.EnsureLineVisible(d.findSelectedLine(nil))
+				d.scrollview.EnsureLineVisible(d.findSelectedLine())
 			}
 			return d, nil
 
 		case key.Matches(msg, d.keyMap.Down):
 			if d.selected < len(d.filtered)-1 {
 				d.selected++
-				d.scrollview.EnsureLineVisible(d.findSelectedLine(nil))
+				d.scrollview.EnsureLineVisible(d.findSelectedLine())
 			}
 			return d, nil
 
@@ -174,35 +194,12 @@ func (d *modelPickerDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 	return d, nil
 }
 
-// mouseYToModelIndex converts a mouse Y position to a model index.
-// Returns -1 if the position is not on a model (e.g., on a separator or outside the list).
-func (d *modelPickerDialog) mouseYToModelIndex(y int) int {
-	dialogRow, _ := d.Position()
-	maxItems := d.scrollview.VisibleHeight()
+// buildList rebuilds the cached grouped list of models, including the
+// catalog/custom separators. Pass contentWidth=0 to compute the layout
+// without producing rendered content (for find/hit-test paths).
+func (d *modelPickerDialog) buildList(contentWidth int) *groupedList {
+	gl := newGroupedList()
 
-	listStartY := dialogRow + pickerListStartOffset
-	listEndY := listStartY + maxItems
-
-	// Check if Y is within the model list area
-	if y < listStartY || y >= listEndY {
-		return -1
-	}
-
-	// Calculate which line in the visible area was clicked
-	lineInView := y - listStartY
-	scrollOffset := d.scrollview.ScrollOffset()
-
-	// Calculate the actual line index in allModelLines
-	actualLine := scrollOffset + lineInView
-
-	// Now we need to map the line back to a model index, accounting for separators
-	return d.lineToModelIndex(actualLine)
-}
-
-// lineToModelIndex converts a line index (in allModelLines) to a model index.
-// Returns -1 if the line is a separator.
-func (d *modelPickerDialog) lineToModelIndex(lineIdx int) int {
-	// Pre-compute model type flags (same logic as View)
 	hasConfigModels := false
 	hasCatalogModels := false
 	for _, m := range d.filtered {
@@ -216,40 +213,48 @@ func (d *modelPickerDialog) lineToModelIndex(lineIdx int) int {
 		}
 	}
 
-	// Walk through the models, counting lines including separators
-	currentLine := 0
 	catalogSeparatorShown := false
 	customSeparatorShown := false
 
 	for i, model := range d.filtered {
-		// Check if separator would be added before this model
-		if model.IsCatalog && !catalogSeparatorShown && !model.IsCustom {
+		if model.IsCatalog && !model.IsCustom && !catalogSeparatorShown {
 			if hasConfigModels {
-				if currentLine == lineIdx {
-					return -1 // Clicked on separator
-				}
-				currentLine++
+				gl.AddNonItem(RenderGroupSeparator(catalogSeparatorLabel, contentWidth))
 			}
 			catalogSeparatorShown = true
 		}
-
 		if model.IsCustom && !customSeparatorShown {
 			if hasConfigModels || hasCatalogModels {
-				if currentLine == lineIdx {
-					return -1 // Clicked on separator
-				}
-				currentLine++
+				gl.AddNonItem(RenderGroupSeparator(customSeparatorLabel, contentWidth))
 			}
 			customSeparatorShown = true
 		}
-
-		if currentLine == lineIdx {
-			return i // Found the model at this line
+		if contentWidth > 0 {
+			gl.AddItem(d.renderModel(model, i == d.selected, contentWidth))
+		} else {
+			gl.AddItem("")
 		}
-		currentLine++
 	}
 
-	return -1 // Line index out of range
+	d.cached = gl
+	return gl
+}
+
+// lineToModelIndex returns the model index for a rendered line, or -1 for
+// separators. Used by mouse hit-testing.
+func (d *modelPickerDialog) lineToModelIndex(line int) int {
+	if d.cached == nil {
+		d.buildList(0)
+	}
+	return d.cached.ItemForLine(line)
+}
+
+// findSelectedLine returns the line index for the currently selected model.
+func (d *modelPickerDialog) findSelectedLine() int {
+	if d.cached == nil {
+		d.buildList(0)
+	}
+	return d.cached.LineForItem(d.selected)
 }
 
 func (d *modelPickerDialog) handleSelection() tea.Cmd {
@@ -262,7 +267,7 @@ func (d *modelPickerDialog) handleSelection() tea.Cmd {
 			return nil
 		}
 		return tea.Sequence(
-			core.CmdHandler(CloseDialogMsg{}),
+			closeDialogCmd(),
 			core.CmdHandler(messages.ChangeModelMsg{ModelRef: query}),
 		)
 	}
@@ -276,7 +281,7 @@ func (d *modelPickerDialog) handleSelection() tea.Cmd {
 			modelRef = ""
 		}
 		return tea.Sequence(
-			core.CmdHandler(CloseDialogMsg{}),
+			closeDialogCmd(),
 			core.CmdHandler(messages.ChangeModelMsg{ModelRef: modelRef}),
 		)
 	}
@@ -330,7 +335,7 @@ func (d *modelPickerDialog) filterModels() {
 	// If query contains "/", show "Custom" option as well as matches
 	isCustomQuery := strings.Contains(query, "/")
 
-	d.filtered = nil
+	d.filtered = d.filtered[:0]
 	for _, model := range d.models {
 		if query == "" {
 			d.filtered = append(d.filtered, model)
@@ -355,148 +360,30 @@ func (d *modelPickerDialog) filterModels() {
 	if d.selected >= len(d.filtered) {
 		d.selected = max(0, len(d.filtered)-1)
 	}
-	// Reset scroll when filtering
 	d.scrollview.SetScrollOffset(0)
-}
-
-// Model picker dialog dimension constants
-const (
-	// pickerWidthPercent is the percentage of screen width to use for the dialog
-	pickerWidthPercent = 80
-	// pickerMinWidth is the minimum width of the dialog
-	pickerMinWidth = 50
-	// pickerMaxWidth is the maximum width of the dialog
-	pickerMaxWidth = 100
-	// pickerHeightPercent is the percentage of screen height to use for the dialog
-	pickerHeightPercent = 70
-	// pickerMaxHeight is the maximum height of the dialog
-	pickerMaxHeight = 150
-
-	// pickerDialogPadding is the horizontal padding inside the dialog border (2 on each side + border)
-	pickerDialogPadding = 6
-
-	// Column widths for the per-row stats. Values are right-aligned in their
-	// own column so the list reads like a table.
-	pickerInputColWidth   = 10
-	pickerOutputColWidth  = 10
-	pickerContextColWidth = 8
-
-	// pickerDetailsLines is the number of lines reserved for the model
-	// details panel rendered below the model list.
-	pickerDetailsLines = 4
-
-	// pickerListVerticalOverhead is the number of rows used by dialog chrome:
-	// title(1) + space(1) + input(1) + separator(1) + column header(1) +
-	// details separator(1) + details (pickerDetailsLines) + space at bottom(1) +
-	// help keys(1) + borders/padding(2) = 10 + pickerDetailsLines
-	pickerListVerticalOverhead = 10 + pickerDetailsLines
-
-	// pickerListStartOffset is the Y offset from dialog top to where the model list starts:
-	// border(1) + padding(1) + title(1) + space(1) + input(1) + separator(1) +
-	// column header(1) = 7
-	pickerListStartOffset = 7
-
-	// pickerDetailsLabelWidth is the column width for the labels in the
-	// details panel ("Reference", "Pricing", "Limits", "Modalities").
-	pickerDetailsLabelWidth = 12
-
-	// catalogSeparatorLabel is the text for the catalog section separator
-	catalogSeparatorLabel = "── Other models "
-	// customSeparatorLabel is the text for the custom models section separator
-	customSeparatorLabel = "── Custom models "
-)
-
-func (d *modelPickerDialog) dialogSize() (dialogWidth, maxHeight, contentWidth int) {
-	dialogWidth = max(min(d.Width()*pickerWidthPercent/100, pickerMaxWidth), pickerMinWidth)
-	maxHeight = min(d.Height()*pickerHeightPercent/100, pickerMaxHeight)
-	contentWidth = dialogWidth - pickerDialogPadding - d.scrollview.ReservedCols()
-	return dialogWidth, maxHeight, contentWidth
-}
-
-// SetSize sets the dialog dimensions and configures the scrollview.
-func (d *modelPickerDialog) SetSize(width, height int) tea.Cmd {
-	cmd := d.BaseDialog.SetSize(width, height)
-	_, maxHeight, contentWidth := d.dialogSize()
-	regionWidth := contentWidth + d.scrollview.ReservedCols()
-	visLines := max(1, maxHeight-pickerListVerticalOverhead)
-	d.scrollview.SetSize(regionWidth, visLines)
-	return cmd
+	d.cached = nil
 }
 
 func (d *modelPickerDialog) View() string {
 	dialogWidth, _, contentWidth := d.dialogSize()
-
 	d.textInput.SetWidth(contentWidth)
 
-	// Build all model lines first to calculate total height
-	var allModelLines []string
-	catalogSeparatorShown := false
-	customSeparatorShown := false
-
-	// Pre-compute if we have different model types to decide on separators
-	hasConfigModels := false
-	hasCatalogModels := false
-	for _, m := range d.filtered {
-		switch {
-		case m.IsCustom:
-			// Custom models don't affect separator logic for config/catalog
-		case m.IsCatalog:
-			hasCatalogModels = true
-		default:
-			hasConfigModels = true
-		}
-	}
-
-	for i, model := range d.filtered {
-		// Add separator before first catalog model (if there are config models anywhere in the list)
-		if model.IsCatalog && !catalogSeparatorShown && !model.IsCustom {
-			if hasConfigModels {
-				separatorLine := styles.MutedStyle.Render(catalogSeparatorLabel + strings.Repeat("─", max(0, contentWidth-len(catalogSeparatorLabel)-2)))
-				allModelLines = append(allModelLines, separatorLine)
-			}
-			catalogSeparatorShown = true
-		}
-
-		// Add separator before first custom model (if there are other models anywhere in the list)
-		if model.IsCustom && !customSeparatorShown {
-			if hasConfigModels || hasCatalogModels {
-				separatorLine := styles.MutedStyle.Render(customSeparatorLabel + strings.Repeat("─", max(0, contentWidth-len(customSeparatorLabel)-2)))
-				allModelLines = append(allModelLines, separatorLine)
-			}
-			customSeparatorShown = true
-		}
-
-		allModelLines = append(allModelLines, d.renderModel(model, i == d.selected, contentWidth))
-	}
-
-	regionWidth := contentWidth + d.scrollview.ReservedCols()
-
-	// Set scrollview position for mouse hit-testing (auto-computed from dialog position)
-	dialogRow, dialogCol := d.Position()
-	d.scrollview.SetPosition(dialogCol+3, dialogRow+pickerListStartOffset)
-
-	d.scrollview.SetContent(allModelLines, len(allModelLines))
+	gl := d.buildList(contentWidth)
+	d.updateScrollviewPosition()
+	d.scrollview.SetContent(gl.Lines(), len(gl.Lines()))
 
 	var scrollableContent string
 	if len(d.filtered) == 0 {
-		visLines := d.scrollview.VisibleHeight()
-		emptyLines := []string{"", styles.DialogContentStyle.
-			Italic(true).Align(lipgloss.Center).Width(contentWidth).
-			Render("No models found")}
-		for len(emptyLines) < visLines {
-			emptyLines = append(emptyLines, "")
-		}
-		scrollableContent = d.scrollview.ViewWithLines(emptyLines)
+		scrollableContent = d.renderEmptyState("No models found", contentWidth)
 	} else {
 		scrollableContent = d.scrollview.View()
 	}
 
-	contentBuilder := NewContent(regionWidth).
+	contentBuilder := NewContent(d.regionWidth(contentWidth)).
 		AddTitle("Select Model").
 		AddSpace().
 		AddContent(d.textInput.View())
 
-	// Show error message if present
 	if d.errMsg != "" {
 		contentBuilder.AddContent(styles.ErrorStyle.Render("⚠ " + d.errMsg))
 	}
@@ -512,59 +399,6 @@ func (d *modelPickerDialog) View() string {
 		Build()
 
 	return styles.DialogStyle.Width(dialogWidth).Render(content)
-}
-
-// findSelectedLine returns the line index in allModelLines that corresponds to the selected model.
-// This accounts for separator lines that are inserted before catalog and custom sections.
-func (d *modelPickerDialog) findSelectedLine(allModelLines []string) int {
-	if d.selected < 0 || d.selected >= len(d.filtered) {
-		return 0
-	}
-
-	// Pre-compute model type flags (same logic as View)
-	hasConfigModels := false
-	hasCatalogModels := false
-	for _, m := range d.filtered {
-		switch {
-		case m.IsCustom:
-			// Custom models don't affect separator logic for config/catalog
-		case m.IsCatalog:
-			hasCatalogModels = true
-		default:
-			hasConfigModels = true
-		}
-	}
-
-	// Count lines before the selected model, including separators
-	lineIndex := 0
-	catalogSeparatorShown := false
-	customSeparatorShown := false
-
-	for i := range d.selected + 1 {
-		model := d.filtered[i]
-
-		// Check if separator was added before this model
-		if model.IsCatalog && !catalogSeparatorShown && !model.IsCustom {
-			if hasConfigModels && i <= d.selected {
-				lineIndex++ // Count the separator
-			}
-			catalogSeparatorShown = true
-		}
-
-		if model.IsCustom && !customSeparatorShown {
-			if (hasConfigModels || hasCatalogModels) && i <= d.selected {
-				lineIndex++ // Count the separator
-			}
-			customSeparatorShown = true
-		}
-
-		if i == d.selected {
-			return lineIndex
-		}
-		lineIndex++
-	}
-
-	return min(lineIndex, len(allModelLines)-1)
 }
 
 // pickerRowPalette is the set of styles used to render one row of the
@@ -865,9 +699,4 @@ func joinOrDash(parts []string) string {
 		return "—"
 	}
 	return strings.Join(parts, ", ")
-}
-
-func (d *modelPickerDialog) Position() (row, col int) {
-	dialogWidth, maxHeight, _ := d.dialogSize()
-	return CenterPosition(d.Width(), d.Height(), dialogWidth, maxHeight)
 }

--- a/pkg/tui/dialog/model_picker.go
+++ b/pkg/tui/dialog/model_picker.go
@@ -28,20 +28,10 @@ type modelPickerDialog struct {
 	models   []runtime.ModelChoice
 	filtered []runtime.ModelChoice
 	errMsg   string // validation error message
-
-	// cached grouped list, rebuilt on every render so the layout used by
-	// View() is shared with mouse hit-testing and findSelectedLine.
-	cached *groupedList
 }
 
 // Model picker dialog dimension constants
 const (
-	pickerWidthPercent  = 80
-	pickerMinWidth      = 50
-	pickerMaxWidth      = 100
-	pickerHeightPercent = 70
-	pickerMaxHeight     = 150
-
 	// Column widths for the per-row stats. Values are right-aligned in their
 	// own column so the list reads like a table.
 	pickerInputColWidth   = 10
@@ -92,8 +82,7 @@ func NewModelPickerDialog(models []runtime.ModelChoice) Dialog {
 	d.textInput.CharLimit = 100
 
 	// Sort models: config first, then catalog, then custom.
-	sortedModels := make([]runtime.ModelChoice, len(models))
-	copy(sortedModels, models)
+	sortedModels := slices.Clone(models)
 	slices.SortFunc(sortedModels, func(a, b runtime.ModelChoice) int {
 		return comparePickerSortKeys(modelSortKeys(a), modelSortKeys(b))
 	})
@@ -119,12 +108,10 @@ func modelSortKeys(m runtime.ModelChoice) pickerSortKeys {
 	}
 }
 
-func (d *modelPickerDialog) Init() tea.Cmd {
-	return textinput.Blink
-}
+func (d *modelPickerDialog) Init() tea.Cmd { return textinput.Blink }
 
 func (d *modelPickerDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
-	// Scrollview handles mouse scrollbar, wheel, and pgup/pgdn/home/end
+	// Scrollview handles mouse scrollbar, wheel, and pgup/pgdn/home/end.
 	if handled, cmd := d.scrollview.Update(msg); handled {
 		return d, cmd
 	}
@@ -135,23 +122,13 @@ func (d *modelPickerDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		return d, cmd
 
 	case tea.PasteMsg:
-		var cmd tea.Cmd
-		d.textInput, cmd = d.textInput.Update(msg)
-		d.filterModels()
-		d.errMsg = ""
+		cmd := d.handleInputChange(msg)
 		return d, cmd
 
 	case tea.MouseClickMsg:
-		// Scrollbar clicks handled above; this handles list item clicks
-		if msg.Button == tea.MouseLeft {
-			if modelIdx := d.mouseListIndex(msg.Y, d.lineToModelIndex); modelIdx >= 0 {
-				if d.recordClick(modelIdx) {
-					d.selected = modelIdx
-					cmd := d.handleSelection()
-					return d, cmd
-				}
-				d.selected = modelIdx
-			}
+		if dbl, _ := d.handleListClick(msg, d.lineToModelIndex); dbl {
+			cmd := d.handleSelection()
+			return d, cmd
 		}
 		return d, nil
 
@@ -159,34 +136,20 @@ func (d *modelPickerDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		if cmd := HandleQuit(msg); cmd != nil {
 			return d, cmd
 		}
-
 		switch {
 		case key.Matches(msg, d.keyMap.Escape):
 			return d, closeDialogCmd()
-
 		case key.Matches(msg, d.keyMap.Up):
-			if d.selected > 0 {
-				d.selected--
-				d.scrollview.EnsureLineVisible(d.findSelectedLine())
-			}
+			d.navigate(-1, len(d.filtered), d.findSelectedLine)
 			return d, nil
-
 		case key.Matches(msg, d.keyMap.Down):
-			if d.selected < len(d.filtered)-1 {
-				d.selected++
-				d.scrollview.EnsureLineVisible(d.findSelectedLine())
-			}
+			d.navigate(+1, len(d.filtered), d.findSelectedLine)
 			return d, nil
-
 		case key.Matches(msg, d.keyMap.Enter):
 			cmd := d.handleSelection()
 			return d, cmd
-
 		default:
-			var cmd tea.Cmd
-			d.textInput, cmd = d.textInput.Update(msg)
-			d.filterModels()
-			d.errMsg = ""
+			cmd := d.handleInputChange(msg)
 			return d, cmd
 		}
 	}
@@ -194,67 +157,62 @@ func (d *modelPickerDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 	return d, nil
 }
 
-// buildList rebuilds the cached grouped list of models, including the
-// catalog/custom separators. Pass contentWidth=0 to compute the layout
-// without producing rendered content (for find/hit-test paths).
+// handleInputChange forwards msg to the text input, re-runs the filter, and
+// clears any validation error from a previous submission.
+func (d *modelPickerDialog) handleInputChange(msg tea.Msg) tea.Cmd {
+	return d.updateInput(msg, func() {
+		d.filterModels()
+		d.errMsg = ""
+	})
+}
+
+// buildList constructs the list of models with section separators between
+// the (config -> catalog -> custom) groups. Pass contentWidth=0 to compute
+// the layout without rendering items (used by mouse hit-testing and
+// findSelectedLine).
 func (d *modelPickerDialog) buildList(contentWidth int) *groupedList {
 	gl := newGroupedList()
 
-	hasConfigModels := false
-	hasCatalogModels := false
+	hasConfig := false
+	hasCatalog := false
 	for _, m := range d.filtered {
 		switch {
 		case m.IsCustom:
-			// Custom models don't affect separator logic for config/catalog
+			// Custom models don't affect the catalog/config separator logic.
 		case m.IsCatalog:
-			hasCatalogModels = true
+			hasCatalog = true
 		default:
-			hasConfigModels = true
+			hasConfig = true
 		}
 	}
 
-	catalogSeparatorShown := false
-	customSeparatorShown := false
-
+	catalogSepShown := false
+	customSepShown := false
 	for i, model := range d.filtered {
-		if model.IsCatalog && !model.IsCustom && !catalogSeparatorShown {
-			if hasConfigModels {
+		if model.IsCatalog && !model.IsCustom && !catalogSepShown {
+			if hasConfig {
 				gl.AddNonItem(RenderGroupSeparator(catalogSeparatorLabel, contentWidth))
 			}
-			catalogSeparatorShown = true
+			catalogSepShown = true
 		}
-		if model.IsCustom && !customSeparatorShown {
-			if hasConfigModels || hasCatalogModels {
+		if model.IsCustom && !customSepShown {
+			if hasConfig || hasCatalog {
 				gl.AddNonItem(RenderGroupSeparator(customSeparatorLabel, contentWidth))
 			}
-			customSeparatorShown = true
+			customSepShown = true
 		}
-		if contentWidth > 0 {
-			gl.AddItem(d.renderModel(model, i == d.selected, contentWidth))
-		} else {
-			gl.AddItem("")
-		}
+		gl.AddItem(d.renderModel(model, i == d.selected, contentWidth))
 	}
 
-	d.cached = gl
 	return gl
 }
 
-// lineToModelIndex returns the model index for a rendered line, or -1 for
-// separators. Used by mouse hit-testing.
 func (d *modelPickerDialog) lineToModelIndex(line int) int {
-	if d.cached == nil {
-		d.buildList(0)
-	}
-	return d.cached.ItemForLine(line)
+	return d.buildList(0).ItemForLine(line)
 }
 
-// findSelectedLine returns the line index for the currently selected model.
 func (d *modelPickerDialog) findSelectedLine() int {
-	if d.cached == nil {
-		d.buildList(0)
-	}
-	return d.cached.LineForItem(d.selected)
+	return d.buildList(0).LineForItem(d.selected)
 }
 
 func (d *modelPickerDialog) handleSelection() tea.Cmd {
@@ -361,7 +319,6 @@ func (d *modelPickerDialog) filterModels() {
 		d.selected = max(0, len(d.filtered)-1)
 	}
 	d.scrollview.SetScrollOffset(0)
-	d.cached = nil
 }
 
 func (d *modelPickerDialog) View() string {
@@ -439,6 +396,9 @@ func pickerRowStyles(selected bool) pickerRowPalette {
 }
 
 func (d *modelPickerDialog) renderModel(model runtime.ModelChoice, selected bool, maxWidth int) string {
+	if maxWidth <= 0 {
+		return ""
+	}
 	p := pickerRowStyles(selected)
 	nameWidth := pickerNameColWidth(maxWidth)
 	return renderRowName(model, nameWidth, p) + renderRowStats(model, p)

--- a/pkg/tui/dialog/picker.go
+++ b/pkg/tui/dialog/picker.go
@@ -1,0 +1,320 @@
+package dialog
+
+import (
+	"cmp"
+	"strings"
+	"time"
+
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/docker/docker-agent/pkg/tui/components/scrollview"
+	"github.com/docker/docker-agent/pkg/tui/core"
+	"github.com/docker/docker-agent/pkg/tui/styles"
+)
+
+// pickerKeyMap defines the standard navigation key bindings used by every
+// list-with-filter picker dialog (command palette, theme picker, model
+// picker, file picker, working-directory picker, …).
+type pickerKeyMap struct {
+	Up     key.Binding
+	Down   key.Binding
+	Enter  key.Binding
+	Escape key.Binding
+}
+
+// defaultPickerKeyMap returns the standard picker key bindings.
+func defaultPickerKeyMap() pickerKeyMap {
+	return pickerKeyMap{
+		Up: key.NewBinding(
+			key.WithKeys("up", "ctrl+k"),
+			key.WithHelp("↑/ctrl+k", "up"),
+		),
+		Down: key.NewBinding(
+			key.WithKeys("down", "ctrl+j"),
+			key.WithHelp("↓/ctrl+j", "down"),
+		),
+		Enter: key.NewBinding(
+			key.WithKeys("enter"),
+			key.WithHelp("enter", "execute"),
+		),
+		Escape: key.NewBinding(
+			key.WithKeys("esc"),
+			key.WithHelp("esc", "close"),
+		),
+	}
+}
+
+// pickerLayout describes the dimensions and chrome offsets of a picker
+// dialog. Concrete dialogs vary in how much chrome they have above/below
+// the scrollable list area; pickerLayout captures everything needed for
+// sizing, mouse hit-testing, and scrollview placement.
+type pickerLayout struct {
+	WidthPercent  int // percentage of screen width to fill
+	MinWidth      int // minimum dialog width in cells
+	MaxWidth      int // maximum dialog width in cells
+	HeightPercent int // percentage of screen height to fill
+	MaxHeight     int // maximum dialog height in cells
+
+	// ListOverhead is the total number of rows of chrome (header + footer)
+	// outside the scrollable list area, including dialog borders/padding.
+	ListOverhead int
+
+	// ListStartOffset is the Y offset from the top of the dialog to the
+	// first row of the scrollable list area. Used for mouse hit-testing.
+	ListStartOffset int
+}
+
+// pickerHorizontalChrome is the standard horizontal chrome of styles.DialogStyle
+// (border 1 + padding 2 on each side = 6 cells).
+const pickerHorizontalChrome = 6
+
+// pickerContentStartX is the X offset from the dialog's left edge to the
+// first column of content (border + horizontal padding).
+const pickerContentStartX = 3
+
+// pickerCore bundles the state and behaviour shared by every list-with-filter
+// dialog. Concrete dialogs embed it and add their own item type, filtering,
+// and rendering.
+//
+// pickerCore handles:
+//   - filter text input
+//   - vertical scrollview with double-click detection
+//   - dialog sizing and centred positioning
+type pickerCore struct {
+	BaseDialog
+
+	textInput  textinput.Model
+	scrollview *scrollview.Model
+	keyMap     pickerKeyMap
+
+	selected int
+
+	// Double-click detection
+	lastClickTime  time.Time
+	lastClickIndex int
+
+	layout pickerLayout
+}
+
+// newPickerCore returns a pickerCore initialised with a focused, blank text
+// input, a scroll-bar-reserving scrollview, and the default key map.
+func newPickerCore(layout pickerLayout, placeholder string) pickerCore {
+	ti := textinput.New()
+	ti.SetStyles(styles.DialogInputStyle)
+	ti.Placeholder = placeholder
+	ti.Focus()
+	ti.CharLimit = 256
+	ti.SetWidth(50)
+
+	return pickerCore{
+		textInput:      ti,
+		scrollview:     scrollview.New(scrollview.WithReserveScrollbarSpace(true)),
+		keyMap:         defaultPickerKeyMap(),
+		lastClickIndex: -1,
+		layout:         layout,
+	}
+}
+
+// dialogSize returns the dialog dimensions and the inner content width.
+// Content width subtracts horizontal chrome and reserved scrollbar columns.
+func (p *pickerCore) dialogSize() (dialogWidth, maxHeight, contentWidth int) {
+	l := p.layout
+	dialogWidth = max(min(p.Width()*l.WidthPercent/100, l.MaxWidth), l.MinWidth)
+	maxHeight = min(p.Height()*l.HeightPercent/100, l.MaxHeight)
+	contentWidth = dialogWidth - pickerHorizontalChrome - p.scrollview.ReservedCols()
+	return dialogWidth, maxHeight, contentWidth
+}
+
+// regionWidth returns the scrollview region width (content + reserved cols).
+func (p *pickerCore) regionWidth(contentWidth int) int {
+	return contentWidth + p.scrollview.ReservedCols()
+}
+
+// Position returns the centred (row, col) of the dialog on screen.
+func (p *pickerCore) Position() (row, col int) {
+	dialogWidth, maxHeight, _ := p.dialogSize()
+	return CenterPosition(p.Width(), p.Height(), dialogWidth, maxHeight)
+}
+
+// SetSize updates dialog dimensions and reconfigures the scrollview region.
+func (p *pickerCore) SetSize(width, height int) tea.Cmd {
+	cmd := p.BaseDialog.SetSize(width, height)
+	_, maxHeight, contentWidth := p.dialogSize()
+	visLines := max(1, maxHeight-p.layout.ListOverhead)
+	p.scrollview.SetSize(p.regionWidth(contentWidth), visLines)
+	return cmd
+}
+
+// updateScrollviewPosition repositions the scrollview for accurate mouse
+// hit-testing. Call from View() once content is built.
+func (p *pickerCore) updateScrollviewPosition() {
+	dialogRow, dialogCol := p.Position()
+	p.scrollview.SetPosition(dialogCol+pickerContentStartX, dialogRow+p.layout.ListStartOffset)
+}
+
+// mouseListIndex maps a mouse Y coordinate to an item index, or returns -1
+// when the click is outside the list or on a non-item line.
+//
+// lineToItem maps a rendered line index (which may include separators or
+// headers) to an item index, returning -1 for non-item lines. Pass nil if
+// the rendered list has one line per item (no separators/headers).
+func (p *pickerCore) mouseListIndex(y int, lineToItem func(line int) int) int {
+	dialogRow, _ := p.Position()
+	listStartY := dialogRow + p.layout.ListStartOffset
+	visLines := p.scrollview.VisibleHeight()
+	if y < listStartY || y >= listStartY+visLines {
+		return -1
+	}
+	actualLine := p.scrollview.ScrollOffset() + (y - listStartY)
+	if lineToItem == nil {
+		return actualLine
+	}
+	return lineToItem(actualLine)
+}
+
+// recordClick stores the current click and reports whether it constitutes a
+// double-click on the same item. idx must be a valid item index (>= 0).
+func (p *pickerCore) recordClick(idx int) (doubleClick bool) {
+	now := time.Now()
+	if idx == p.lastClickIndex && now.Sub(p.lastClickTime) < styles.DoubleClickThreshold {
+		p.lastClickTime = time.Time{}
+		p.lastClickIndex = -1
+		return true
+	}
+	p.lastClickTime = now
+	p.lastClickIndex = idx
+	return false
+}
+
+// renderEmptyState returns the scrollview view filled with a centred italic
+// placeholder. It pads the content to occupy the whole visible region so
+// the dialog doesn't shrink.
+func (p *pickerCore) renderEmptyState(message string, contentWidth int) string {
+	return p.renderPaddedState(styles.DialogContentStyle.
+		Italic(true).Align(lipgloss.Center).Width(contentWidth).
+		Render(message))
+}
+
+// renderErrorState returns the scrollview view filled with a centred error
+// message, padded to the full visible region.
+func (p *pickerCore) renderErrorState(message string, contentWidth int) string {
+	return p.renderPaddedState(styles.ErrorStyle.
+		Align(lipgloss.Center).Width(contentWidth).
+		Render(message))
+}
+
+// renderPaddedState fills the scrollview with a single rendered line plus
+// blank padding above and below to keep the dialog at a stable height.
+func (p *pickerCore) renderPaddedState(rendered string) string {
+	visLines := p.scrollview.VisibleHeight()
+	lines := []string{"", rendered}
+	for len(lines) < visLines {
+		lines = append(lines, "")
+	}
+	return p.scrollview.ViewWithLines(lines)
+}
+
+// closeDialogCmd is shorthand for sending a CloseDialogMsg.
+func closeDialogCmd() tea.Cmd { return core.CmdHandler(CloseDialogMsg{}) }
+
+// pickerSortKeys captures the comparison keys for ordering a picker item.
+// Items with smaller Section appear first; within each section, items with
+// IsCurrent=true appear first, then IsDefault=true, then alphabetically by
+// Name (case-insensitive), then by Tiebreak.
+type pickerSortKeys struct {
+	Section   int
+	IsCurrent bool
+	IsDefault bool
+	Name      string
+	Tiebreak  string
+}
+
+// comparePickerSortKeys compares two pickerSortKeys; suitable for slices.SortFunc.
+func comparePickerSortKeys(a, b pickerSortKeys) int {
+	if a.Section != b.Section {
+		return cmp.Compare(a.Section, b.Section)
+	}
+	if a.IsCurrent != b.IsCurrent {
+		if a.IsCurrent {
+			return -1
+		}
+		return 1
+	}
+	if a.IsDefault != b.IsDefault {
+		if a.IsDefault {
+			return -1
+		}
+		return 1
+	}
+	if al, bl := strings.ToLower(a.Name), strings.ToLower(b.Name); al != bl {
+		return cmp.Compare(al, bl)
+	}
+	return cmp.Compare(a.Tiebreak, b.Tiebreak)
+}
+
+// groupedList builds a list of rendered lines mixed with non-item lines
+// (separators, headers) and tracks the mapping between line indices and
+// item indices so callers can do mouse hit-testing and selection scrolling
+// without re-deriving the layout.
+//
+// Usage:
+//
+//	gl := newGroupedList()
+//	for i, item := range filtered {
+//		if needsSeparatorBefore(item) {
+//			gl.AddNonItem(renderSeparator(item))
+//		}
+//		gl.AddItem(renderItem(item, i == selected))
+//	}
+//	lines := gl.Lines()
+//	idx  := gl.ItemForLine(actualLine)   // for mouse hit-testing
+//	line := gl.LineForItem(selected)     // for EnsureLineVisible
+type groupedList struct {
+	lines      []string
+	lineToItem []int // -1 for non-item lines, item index otherwise
+	itemToLine []int // line index for each item, in order of insertion
+}
+
+// newGroupedList returns an empty grouped list.
+func newGroupedList() *groupedList { return &groupedList{} }
+
+// AddNonItem appends a non-selectable line (header, separator, …).
+func (g *groupedList) AddNonItem(line string) {
+	g.lines = append(g.lines, line)
+	g.lineToItem = append(g.lineToItem, -1)
+}
+
+// AddItem appends a selectable item line.
+func (g *groupedList) AddItem(line string) {
+	itemIdx := len(g.itemToLine)
+	g.itemToLine = append(g.itemToLine, len(g.lines))
+	g.lines = append(g.lines, line)
+	g.lineToItem = append(g.lineToItem, itemIdx)
+}
+
+// Lines returns the full ordered list of rendered lines.
+func (g *groupedList) Lines() []string { return g.lines }
+
+// LineToItem returns the full line→item slice (-1 for non-item lines).
+func (g *groupedList) LineToItem() []int { return g.lineToItem }
+
+// ItemForLine returns the item index at the given rendered line, or -1
+// when the line is a separator/header or out of range.
+func (g *groupedList) ItemForLine(line int) int {
+	if line < 0 || line >= len(g.lineToItem) {
+		return -1
+	}
+	return g.lineToItem[line]
+}
+
+// LineForItem returns the rendered line index for the given item index, or 0
+// when the item is out of range.
+func (g *groupedList) LineForItem(item int) int {
+	if item < 0 || item >= len(g.itemToLine) {
+		return 0
+	}
+	return g.itemToLine[item]
+}

--- a/pkg/tui/dialog/picker.go
+++ b/pkg/tui/dialog/picker.go
@@ -306,28 +306,21 @@ func comparePickerSortKeys(a, b pickerSortKeys) int {
 		return cmp.Compare(a.Section, b.Section)
 	}
 	if a.IsCurrent != b.IsCurrent {
-		return boolCompare(b.IsCurrent, a.IsCurrent)
+		if a.IsCurrent {
+			return -1
+		}
+		return 1
 	}
 	if a.IsDefault != b.IsDefault {
-		return boolCompare(b.IsDefault, a.IsDefault)
+		if a.IsDefault {
+			return -1
+		}
+		return 1
 	}
 	if al, bl := strings.ToLower(a.Name), strings.ToLower(b.Name); al != bl {
 		return cmp.Compare(al, bl)
 	}
 	return cmp.Compare(a.Tiebreak, b.Tiebreak)
-}
-
-// boolCompare returns -1/0/1 when comparing booleans where true sorts after
-// false. Pass arguments swapped to invert.
-func boolCompare(a, b bool) int {
-	switch {
-	case a == b:
-		return 0
-	case a:
-		return 1
-	default:
-		return -1
-	}
 }
 
 // -----------------------------------------------------------------------------

--- a/pkg/tui/dialog/picker.go
+++ b/pkg/tui/dialog/picker.go
@@ -15,6 +15,13 @@ import (
 	"github.com/docker/docker-agent/pkg/tui/styles"
 )
 
+// closeDialogCmd is a shorthand used by every picker for sending CloseDialogMsg.
+func closeDialogCmd() tea.Cmd { return core.CmdHandler(CloseDialogMsg{}) }
+
+// -----------------------------------------------------------------------------
+// Key map
+// -----------------------------------------------------------------------------
+
 // pickerKeyMap defines the standard navigation key bindings used by every
 // list-with-filter picker dialog (command palette, theme picker, model
 // picker, file picker, working-directory picker, …).
@@ -28,29 +35,37 @@ type pickerKeyMap struct {
 // defaultPickerKeyMap returns the standard picker key bindings.
 func defaultPickerKeyMap() pickerKeyMap {
 	return pickerKeyMap{
-		Up: key.NewBinding(
-			key.WithKeys("up", "ctrl+k"),
-			key.WithHelp("↑/ctrl+k", "up"),
-		),
-		Down: key.NewBinding(
-			key.WithKeys("down", "ctrl+j"),
-			key.WithHelp("↓/ctrl+j", "down"),
-		),
-		Enter: key.NewBinding(
-			key.WithKeys("enter"),
-			key.WithHelp("enter", "execute"),
-		),
-		Escape: key.NewBinding(
-			key.WithKeys("esc"),
-			key.WithHelp("esc", "close"),
-		),
+		Up:     key.NewBinding(key.WithKeys("up", "ctrl+k"), key.WithHelp("↑/ctrl+k", "up")),
+		Down:   key.NewBinding(key.WithKeys("down", "ctrl+j"), key.WithHelp("↓/ctrl+j", "down")),
+		Enter:  key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "execute")),
+		Escape: key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "close")),
 	}
 }
 
+// -----------------------------------------------------------------------------
+// Layout
+// -----------------------------------------------------------------------------
+
+// Default sizing shared by the model picker and theme picker.
+const (
+	pickerWidthPercent  = 80
+	pickerMinWidth      = 50
+	pickerMaxWidth      = 100
+	pickerHeightPercent = 70
+	pickerMaxHeight     = 150
+
+	// pickerHorizontalChrome is the horizontal chrome of styles.DialogStyle
+	// (border 1 + padding 2 on each side = 6 cells).
+	pickerHorizontalChrome = 6
+	// pickerContentStartX is the X offset from the dialog's left edge to the
+	// first column of content (border + horizontal padding).
+	pickerContentStartX = 3
+)
+
 // pickerLayout describes the dimensions and chrome offsets of a picker
 // dialog. Concrete dialogs vary in how much chrome they have above/below
-// the scrollable list area; pickerLayout captures everything needed for
-// sizing, mouse hit-testing, and scrollview placement.
+// the scrollable list; pickerLayout captures everything needed for sizing,
+// mouse hit-testing, and scrollview placement.
 type pickerLayout struct {
 	WidthPercent  int // percentage of screen width to fill
 	MinWidth      int // minimum dialog width in cells
@@ -58,8 +73,8 @@ type pickerLayout struct {
 	HeightPercent int // percentage of screen height to fill
 	MaxHeight     int // maximum dialog height in cells
 
-	// ListOverhead is the total number of rows of chrome (header + footer)
-	// outside the scrollable list area, including dialog borders/padding.
+	// ListOverhead is the number of rows of chrome (header + footer) outside
+	// the scrollable list area, including dialog borders/padding.
 	ListOverhead int
 
 	// ListStartOffset is the Y offset from the top of the dialog to the
@@ -67,36 +82,26 @@ type pickerLayout struct {
 	ListStartOffset int
 }
 
-// pickerHorizontalChrome is the standard horizontal chrome of styles.DialogStyle
-// (border 1 + padding 2 on each side = 6 cells).
-const pickerHorizontalChrome = 6
-
-// pickerContentStartX is the X offset from the dialog's left edge to the
-// first column of content (border + horizontal padding).
-const pickerContentStartX = 3
+// -----------------------------------------------------------------------------
+// pickerCore
+// -----------------------------------------------------------------------------
 
 // pickerCore bundles the state and behaviour shared by every list-with-filter
 // dialog. Concrete dialogs embed it and add their own item type, filtering,
 // and rendering.
-//
-// pickerCore handles:
-//   - filter text input
-//   - vertical scrollview with double-click detection
-//   - dialog sizing and centred positioning
 type pickerCore struct {
 	BaseDialog
 
 	textInput  textinput.Model
 	scrollview *scrollview.Model
 	keyMap     pickerKeyMap
+	layout     pickerLayout
 
 	selected int
 
 	// Double-click detection
 	lastClickTime  time.Time
 	lastClickIndex int
-
-	layout pickerLayout
 }
 
 // newPickerCore returns a pickerCore initialised with a focused, blank text
@@ -113,10 +118,14 @@ func newPickerCore(layout pickerLayout, placeholder string) pickerCore {
 		textInput:      ti,
 		scrollview:     scrollview.New(scrollview.WithReserveScrollbarSpace(true)),
 		keyMap:         defaultPickerKeyMap(),
-		lastClickIndex: -1,
 		layout:         layout,
+		lastClickIndex: -1,
 	}
 }
+
+// -----------------------------------------------------------------------------
+// Sizing & positioning
+// -----------------------------------------------------------------------------
 
 // dialogSize returns the dialog dimensions and the inner content width.
 // Content width subtracts horizontal chrome and reserved scrollbar columns.
@@ -149,18 +158,77 @@ func (p *pickerCore) SetSize(width, height int) tea.Cmd {
 }
 
 // updateScrollviewPosition repositions the scrollview for accurate mouse
-// hit-testing. Call from View() once content is built.
+// hit-testing. Concrete dialogs call this from their View() method.
 func (p *pickerCore) updateScrollviewPosition() {
 	dialogRow, dialogCol := p.Position()
 	p.scrollview.SetPosition(dialogCol+pickerContentStartX, dialogRow+p.layout.ListStartOffset)
 }
 
-// mouseListIndex maps a mouse Y coordinate to an item index, or returns -1
-// when the click is outside the list or on a non-item line.
+// -----------------------------------------------------------------------------
+// Update helpers
+// -----------------------------------------------------------------------------
+
+// updateInput feeds msg into the embedded text input and runs the optional
+// filter callback. It returns the textinput command (typically Blink) so the
+// caller can pass it back from Update.
+func (p *pickerCore) updateInput(msg tea.Msg, filter func()) tea.Cmd {
+	var cmd tea.Cmd
+	p.textInput, cmd = p.textInput.Update(msg)
+	if filter != nil {
+		filter()
+	}
+	return cmd
+}
+
+// handleListClick processes a mouse click on the list area. lineToItem maps a
+// rendered line index (which may include separators) to an item index, or
+// returns -1 for non-item lines; pass nil when the rendered list maps 1:1
+// to items.
 //
-// lineToItem maps a rendered line index (which may include separators or
-// headers) to an item index, returning -1 for non-item lines. Pass nil if
-// the rendered list has one line per item (no separators/headers).
+// It updates the selection internally and reports:
+//   - doubleClicked: the same item was clicked twice within the threshold
+//     (selection is also updated to the clicked item)
+//   - changed: a single click moved the selection to a different item
+//
+// Both flags are false for non-list, non-left, or out-of-range clicks.
+func (p *pickerCore) handleListClick(msg tea.MouseClickMsg, lineToItem func(int) int) (doubleClicked, changed bool) {
+	if msg.Button != tea.MouseLeft {
+		return false, false
+	}
+	idx := p.mouseListIndex(msg.Y, lineToItem)
+	if idx < 0 {
+		return false, false
+	}
+	if p.recordClick(idx) {
+		p.selected = idx
+		return true, true
+	}
+	changed = idx != p.selected
+	p.selected = idx
+	return false, changed
+}
+
+// navigate moves the selection by delta within [0, num-1] and ensures the
+// new selection stays visible. lineForSelected returns the rendered line
+// index of the selection (used by EnsureLineVisible); pass nil when the
+// list maps 1:1 to items. Returns true when the selection actually moved.
+func (p *pickerCore) navigate(delta, num int, lineForSelected func() int) bool {
+	next := p.selected + delta
+	if next < 0 || next >= num {
+		return false
+	}
+	p.selected = next
+	line := next
+	if lineForSelected != nil {
+		line = lineForSelected()
+	}
+	p.scrollview.EnsureLineVisible(line)
+	return true
+}
+
+// mouseListIndex maps a mouse Y coordinate to an item index, or -1 when the
+// click is outside the list or on a non-item line. lineToItem may be nil
+// when the rendered list maps 1:1 to items.
 func (p *pickerCore) mouseListIndex(y int, lineToItem func(line int) int) int {
 	dialogRow, _ := p.Position()
 	listStartY := dialogRow + p.layout.ListStartOffset
@@ -175,9 +243,9 @@ func (p *pickerCore) mouseListIndex(y int, lineToItem func(line int) int) int {
 	return lineToItem(actualLine)
 }
 
-// recordClick stores the current click and reports whether it constitutes a
+// recordClick stores the current click and reports whether it forms a
 // double-click on the same item. idx must be a valid item index (>= 0).
-func (p *pickerCore) recordClick(idx int) (doubleClick bool) {
+func (p *pickerCore) recordClick(idx int) bool {
 	now := time.Now()
 	if idx == p.lastClickIndex && now.Sub(p.lastClickTime) < styles.DoubleClickThreshold {
 		p.lastClickTime = time.Time{}
@@ -189,26 +257,25 @@ func (p *pickerCore) recordClick(idx int) (doubleClick bool) {
 	return false
 }
 
-// renderEmptyState returns the scrollview view filled with a centred italic
-// placeholder. It pads the content to occupy the whole visible region so
-// the dialog doesn't shrink.
+// -----------------------------------------------------------------------------
+// Empty / error placeholder rendering
+// -----------------------------------------------------------------------------
+
+// renderEmptyState fills the scrollview with a centred italic placeholder.
 func (p *pickerCore) renderEmptyState(message string, contentWidth int) string {
-	return p.renderPaddedState(styles.DialogContentStyle.
-		Italic(true).Align(lipgloss.Center).Width(contentWidth).
-		Render(message))
+	style := styles.DialogContentStyle.Italic(true).Align(lipgloss.Center).Width(contentWidth)
+	return p.renderPlaceholder(style.Render(message))
 }
 
-// renderErrorState returns the scrollview view filled with a centred error
-// message, padded to the full visible region.
+// renderErrorState fills the scrollview with a centred error message.
 func (p *pickerCore) renderErrorState(message string, contentWidth int) string {
-	return p.renderPaddedState(styles.ErrorStyle.
-		Align(lipgloss.Center).Width(contentWidth).
-		Render(message))
+	style := styles.ErrorStyle.Align(lipgloss.Center).Width(contentWidth)
+	return p.renderPlaceholder(style.Render(message))
 }
 
-// renderPaddedState fills the scrollview with a single rendered line plus
-// blank padding above and below to keep the dialog at a stable height.
-func (p *pickerCore) renderPaddedState(rendered string) string {
+// renderPlaceholder fills the visible scrollview area with a single rendered
+// line plus blank padding so the dialog keeps a stable height.
+func (p *pickerCore) renderPlaceholder(rendered string) string {
 	visLines := p.scrollview.VisibleHeight()
 	lines := []string{"", rendered}
 	for len(lines) < visLines {
@@ -217,8 +284,9 @@ func (p *pickerCore) renderPaddedState(rendered string) string {
 	return p.scrollview.ViewWithLines(lines)
 }
 
-// closeDialogCmd is shorthand for sending a CloseDialogMsg.
-func closeDialogCmd() tea.Cmd { return core.CmdHandler(CloseDialogMsg{}) }
+// -----------------------------------------------------------------------------
+// Sort comparator shared by sectioned pickers
+// -----------------------------------------------------------------------------
 
 // pickerSortKeys captures the comparison keys for ordering a picker item.
 // Items with smaller Section appear first; within each section, items with
@@ -238,16 +306,10 @@ func comparePickerSortKeys(a, b pickerSortKeys) int {
 		return cmp.Compare(a.Section, b.Section)
 	}
 	if a.IsCurrent != b.IsCurrent {
-		if a.IsCurrent {
-			return -1
-		}
-		return 1
+		return boolCompare(b.IsCurrent, a.IsCurrent)
 	}
 	if a.IsDefault != b.IsDefault {
-		if a.IsDefault {
-			return -1
-		}
-		return 1
+		return boolCompare(b.IsDefault, a.IsDefault)
 	}
 	if al, bl := strings.ToLower(a.Name), strings.ToLower(b.Name); al != bl {
 		return cmp.Compare(al, bl)
@@ -255,9 +317,26 @@ func comparePickerSortKeys(a, b pickerSortKeys) int {
 	return cmp.Compare(a.Tiebreak, b.Tiebreak)
 }
 
+// boolCompare returns -1/0/1 when comparing booleans where true sorts after
+// false. Pass arguments swapped to invert.
+func boolCompare(a, b bool) int {
+	switch {
+	case a == b:
+		return 0
+	case a:
+		return 1
+	default:
+		return -1
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Grouped list builder (lists with separators / headers)
+// -----------------------------------------------------------------------------
+
 // groupedList builds a list of rendered lines mixed with non-item lines
 // (separators, headers) and tracks the mapping between line indices and
-// item indices so callers can do mouse hit-testing and selection scrolling
+// item indices, so callers can do mouse hit-testing and selection scrolling
 // without re-deriving the layout.
 //
 // Usage:
@@ -270,8 +349,8 @@ func comparePickerSortKeys(a, b pickerSortKeys) int {
 //		gl.AddItem(renderItem(item, i == selected))
 //	}
 //	lines := gl.Lines()
-//	idx  := gl.ItemForLine(actualLine)   // for mouse hit-testing
-//	line := gl.LineForItem(selected)     // for EnsureLineVisible
+//	idx   := gl.ItemForLine(actualLine) // for mouse hit-testing
+//	line  := gl.LineForItem(selected)   // for EnsureLineVisible
 type groupedList struct {
 	lines      []string
 	lineToItem []int // -1 for non-item lines, item index otherwise
@@ -289,16 +368,15 @@ func (g *groupedList) AddNonItem(line string) {
 
 // AddItem appends a selectable item line.
 func (g *groupedList) AddItem(line string) {
-	itemIdx := len(g.itemToLine)
 	g.itemToLine = append(g.itemToLine, len(g.lines))
 	g.lines = append(g.lines, line)
-	g.lineToItem = append(g.lineToItem, itemIdx)
+	g.lineToItem = append(g.lineToItem, len(g.itemToLine)-1)
 }
 
 // Lines returns the full ordered list of rendered lines.
 func (g *groupedList) Lines() []string { return g.lines }
 
-// LineToItem returns the full line→item slice (-1 for non-item lines).
+// LineToItem returns the line→item slice (-1 for non-item lines).
 func (g *groupedList) LineToItem() []int { return g.lineToItem }
 
 // ItemForLine returns the item index at the given rendered line, or -1

--- a/pkg/tui/dialog/theme_picker.go
+++ b/pkg/tui/dialog/theme_picker.go
@@ -1,17 +1,14 @@
 package dialog
 
 import (
-	"cmp"
 	"slices"
 	"strings"
-	"time"
 
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
-	"github.com/docker/docker-agent/pkg/tui/components/scrollview"
 	"github.com/docker/docker-agent/pkg/tui/components/toolcommon"
 	"github.com/docker/docker-agent/pkg/tui/core"
 	"github.com/docker/docker-agent/pkg/tui/core/layout"
@@ -30,80 +27,41 @@ type ThemeChoice struct {
 
 // themePickerDialog is a dialog for selecting a theme.
 type themePickerDialog struct {
-	BaseDialog
+	pickerCore
 
-	textInput  textinput.Model
-	themes     []ThemeChoice
-	filtered   []ThemeChoice
-	selected   int
-	keyMap     commandPaletteKeyMap
-	scrollview *scrollview.Model
-
-	// Double-click detection
-	lastClickTime  time.Time
-	lastClickIndex int
+	themes   []ThemeChoice
+	filtered []ThemeChoice
 
 	// Original theme for restoration on cancel
 	originalThemeRef string
 
 	// Avoid re-applying the same preview repeatedly (e.g., during filtering)
 	lastPreviewRef string
+
+	// Cached grouped list rebuilt on every render so mouse hit-testing
+	// and findSelectedLine share the layout used by View().
+	cached *groupedList
 }
+
+// customThemesSeparatorLabel labels the separator above the custom themes group.
+const customThemesSeparatorLabel = "Custom themes"
 
 // NewThemePickerDialog creates a new theme picker dialog.
 // originalThemeRef is the currently active theme ref (for restoration on cancel).
 func NewThemePickerDialog(themes []ThemeChoice, originalThemeRef string) Dialog {
-	ti := textinput.New()
-	ti.Placeholder = "Type to search themes…"
-	ti.Focus()
-	ti.CharLimit = 100
-	ti.SetWidth(50)
-	ti.SetStyles(styles.DialogInputStyle)
+	d := &themePickerDialog{
+		pickerCore:       newPickerCore(themePickerLayout, "Type to search themes…"),
+		originalThemeRef: originalThemeRef,
+	}
+	d.textInput.CharLimit = 100
 
-	// Sort themes: built-in first, then custom. Within each section:
-	// current first, then default, then alphabetically.
+	// Sort themes: built-in first, then custom. Within each section: current
+	// first, then default, then alphabetically.
 	sortedThemes := make([]ThemeChoice, len(themes))
 	copy(sortedThemes, themes)
 	slices.SortFunc(sortedThemes, func(a, b ThemeChoice) int {
-		getPriority := func(t ThemeChoice) int {
-			if t.IsBuiltin {
-				return 0
-			}
-			return 1
-		}
-		pa, pb := getPriority(a), getPriority(b)
-		if pa != pb {
-			return cmp.Compare(pa, pb)
-		}
-		if a.IsCurrent != b.IsCurrent {
-			if a.IsCurrent {
-				return -1
-			}
-			return 1
-		}
-		if a.IsDefault != b.IsDefault {
-			if a.IsDefault {
-				return -1
-			}
-			return 1
-		}
-		na := strings.ToLower(a.Name)
-		nb := strings.ToLower(b.Name)
-		if na != nb {
-			return cmp.Compare(na, nb)
-		}
-		return cmp.Compare(a.Ref, b.Ref)
+		return comparePickerSortKeys(themeSortKeys(a), themeSortKeys(b))
 	})
-
-	d := &themePickerDialog{
-		textInput:        ti,
-		themes:           themes,
-		filtered:         nil,
-		keyMap:           defaultCommandPaletteKeyMap(),
-		scrollview:       scrollview.New(scrollview.WithReserveScrollbarSpace(true)),
-		originalThemeRef: originalThemeRef,
-	}
-
 	d.themes = sortedThemes
 	d.filterThemes()
 
@@ -111,18 +69,44 @@ func NewThemePickerDialog(themes []ThemeChoice, originalThemeRef string) Dialog 
 	for i, t := range d.filtered {
 		if t.IsCurrent {
 			d.selected = i
-			d.scrollview.EnsureLineVisible(d.findSelectedLine(nil)) // Scroll to current selection on open
+			d.scrollview.EnsureLineVisible(d.findSelectedLine())
 			break
 		}
 	}
 
-	// Initialize preview tracking to current selection (theme is already applied when dialog opens)
+	// Initialize preview tracking to current selection (theme is already
+	// applied when dialog opens).
 	if d.selected >= 0 && d.selected < len(d.filtered) {
-		sel := d.filtered[d.selected]
-		d.lastPreviewRef = sel.Ref
+		d.lastPreviewRef = d.filtered[d.selected].Ref
 	}
 
 	return d
+}
+
+// themeSortKeys derives the sort key tuple from a ThemeChoice.
+func themeSortKeys(t ThemeChoice) pickerSortKeys {
+	section := 1
+	if t.IsBuiltin {
+		section = 0
+	}
+	return pickerSortKeys{
+		Section:   section,
+		IsCurrent: t.IsCurrent,
+		IsDefault: t.IsDefault,
+		Name:      t.Name,
+		Tiebreak:  t.Ref,
+	}
+}
+
+// themePickerLayout is the layout used by the theme picker.
+var themePickerLayout = pickerLayout{
+	WidthPercent:    pickerWidthPercent,
+	MinWidth:        pickerMinWidth,
+	MaxWidth:        pickerMaxWidth,
+	HeightPercent:   pickerHeightPercent,
+	MaxHeight:       pickerMaxHeight,
+	ListOverhead:    pickerListVerticalOverhead,
+	ListStartOffset: pickerListStartOffset,
 }
 
 func (d *themePickerDialog) Init() tea.Cmd {
@@ -147,8 +131,8 @@ func (d *themePickerDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 	case tea.PasteMsg:
 		var cmd tea.Cmd
 		d.textInput, cmd = d.textInput.Update(msg)
-		if selectionChanged := d.filterThemes(); selectionChanged {
-			d.scrollview.EnsureLineVisible(d.findSelectedLine(nil))
+		if d.filterThemes() {
+			d.scrollview.EnsureLineVisible(d.findSelectedLine())
 			return d, tea.Batch(cmd, d.emitPreview())
 		}
 		return d, cmd
@@ -156,18 +140,14 @@ func (d *themePickerDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 	case tea.MouseClickMsg:
 		// Scrollbar clicks handled above; this handles list item clicks
 		if msg.Button == tea.MouseLeft {
-			if themeIdx := d.mouseYToThemeIndex(msg.Y); themeIdx >= 0 {
-				now := time.Now()
-				if themeIdx == d.lastClickIndex && now.Sub(d.lastClickTime) < styles.DoubleClickThreshold {
+			if themeIdx := d.mouseListIndex(msg.Y, d.lineToThemeIndex); themeIdx >= 0 {
+				if d.recordClick(themeIdx) {
 					d.selected = themeIdx
-					d.lastClickTime = time.Time{}
 					cmd := d.handleSelection()
 					return d, cmd
 				}
 				oldSelected := d.selected
 				d.selected = themeIdx
-				d.lastClickTime = now
-				d.lastClickIndex = themeIdx
 				if d.selected != oldSelected {
 					cmd := d.emitPreview()
 					return d, cmd
@@ -184,14 +164,14 @@ func (d *themePickerDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		switch {
 		case key.Matches(msg, d.keyMap.Escape):
 			return d, tea.Sequence(
-				core.CmdHandler(CloseDialogMsg{}),
+				closeDialogCmd(),
 				core.CmdHandler(messages.ThemeCancelPreviewMsg{OriginalRef: d.originalThemeRef}),
 			)
 
 		case key.Matches(msg, d.keyMap.Up):
 			if d.selected > 0 {
 				d.selected--
-				d.scrollview.EnsureLineVisible(d.findSelectedLine(nil))
+				d.scrollview.EnsureLineVisible(d.findSelectedLine())
 				cmd := d.emitPreview()
 				return d, cmd
 			}
@@ -200,7 +180,7 @@ func (d *themePickerDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		case key.Matches(msg, d.keyMap.Down):
 			if d.selected < len(d.filtered)-1 {
 				d.selected++
-				d.scrollview.EnsureLineVisible(d.findSelectedLine(nil))
+				d.scrollview.EnsureLineVisible(d.findSelectedLine())
 				cmd := d.emitPreview()
 				return d, cmd
 			}
@@ -213,8 +193,8 @@ func (d *themePickerDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		default:
 			var cmd tea.Cmd
 			d.textInput, cmd = d.textInput.Update(msg)
-			if selectionChanged := d.filterThemes(); selectionChanged {
-				d.scrollview.EnsureLineVisible(d.findSelectedLine(nil))
+			if d.filterThemes() {
+				d.scrollview.EnsureLineVisible(d.findSelectedLine())
 				return d, tea.Batch(cmd, d.emitPreview())
 			}
 			return d, cmd
@@ -224,29 +204,11 @@ func (d *themePickerDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 	return d, nil
 }
 
-func (d *themePickerDialog) mouseYToThemeIndex(y int) int {
-	dialogRow, _ := d.Position()
-	maxItems := d.scrollview.VisibleHeight()
-
-	listStartY := dialogRow + pickerListStartOffset
-	listEndY := listStartY + maxItems
-
-	if y < listStartY || y >= listEndY {
-		return -1
-	}
-
-	lineInView := y - listStartY
-	scrollOffset := d.scrollview.ScrollOffset()
-	actualLine := scrollOffset + lineInView
-
-	return d.lineToThemeIndex(actualLine)
-}
-
 func (d *themePickerDialog) handleSelection() tea.Cmd {
 	if d.selected >= 0 && d.selected < len(d.filtered) {
 		selected := d.filtered[d.selected]
 		return tea.Sequence(
-			core.CmdHandler(CloseDialogMsg{}),
+			closeDialogCmd(),
 			core.CmdHandler(messages.ChangeThemeMsg{ThemeRef: selected.Ref}),
 		)
 	}
@@ -257,13 +219,11 @@ func (d *themePickerDialog) handleSelection() tea.Cmd {
 func (d *themePickerDialog) emitPreview() tea.Cmd {
 	if d.selected >= 0 && d.selected < len(d.filtered) {
 		selected := d.filtered[d.selected]
-
 		// Skip if we're already previewing this exact selection.
 		if selected.Ref == d.lastPreviewRef {
 			return nil
 		}
 		d.lastPreviewRef = selected.Ref
-
 		return core.CmdHandler(messages.ThemePreviewMsg{
 			ThemeRef:    selected.Ref,
 			OriginalRef: d.originalThemeRef,
@@ -272,34 +232,10 @@ func (d *themePickerDialog) emitPreview() tea.Cmd {
 	return nil
 }
 
-const customThemesSeparatorLabel = "── Custom themes "
+// buildList rebuilds the cached grouped list of themes including separators.
+func (d *themePickerDialog) buildList(contentWidth int) *groupedList {
+	gl := newGroupedList()
 
-func (d *themePickerDialog) dialogSize() (dialogWidth, maxHeight, contentWidth int) {
-	dialogWidth = max(min(d.Width()*pickerWidthPercent/100, pickerMaxWidth), pickerMinWidth)
-	maxHeight = min(d.Height()*pickerHeightPercent/100, pickerMaxHeight)
-	contentWidth = dialogWidth - pickerDialogPadding - d.scrollview.ReservedCols()
-	return dialogWidth, maxHeight, contentWidth
-}
-
-// SetSize sets the dialog dimensions and configures the scrollview.
-func (d *themePickerDialog) SetSize(width, height int) tea.Cmd {
-	cmd := d.BaseDialog.SetSize(width, height)
-	_, maxHeight, contentWidth := d.dialogSize()
-	regionWidth := contentWidth + d.scrollview.ReservedCols()
-	visLines := max(1, maxHeight-pickerListVerticalOverhead)
-	d.scrollview.SetSize(regionWidth, visLines)
-	return cmd
-}
-
-func (d *themePickerDialog) View() string {
-	dialogWidth, _, contentWidth := d.dialogSize()
-	d.textInput.SetWidth(contentWidth)
-
-	// Build all theme lines
-	var allLines []string
-	customSeparatorShown := false
-
-	// Pre-compute which groups exist to decide on separators
 	hasBuiltinThemes := false
 	for _, t := range d.filtered {
 		if t.IsBuiltin {
@@ -308,42 +244,53 @@ func (d *themePickerDialog) View() string {
 		}
 	}
 
+	customSeparatorShown := false
 	for i, theme := range d.filtered {
-		// Add separator before first custom theme if there are built-in themes above.
 		if !theme.IsBuiltin && !customSeparatorShown {
 			if hasBuiltinThemes {
-				separatorLine := styles.MutedStyle.Render(customThemesSeparatorLabel + strings.Repeat("─", max(0, contentWidth-lipgloss.Width(customThemesSeparatorLabel)-2)))
-				allLines = append(allLines, separatorLine)
+				gl.AddNonItem(RenderGroupSeparator(customThemesSeparatorLabel, contentWidth))
 			}
 			customSeparatorShown = true
 		}
-
-		allLines = append(allLines, d.renderTheme(theme, i == d.selected, contentWidth))
+		gl.AddItem(d.renderTheme(theme, i == d.selected, contentWidth))
 	}
+	d.cached = gl
+	return gl
+}
 
-	regionWidth := contentWidth + d.scrollview.ReservedCols()
+// lineToThemeIndex returns the theme index for a rendered line, or -1 for
+// separators. Used by mouse hit-testing.
+func (d *themePickerDialog) lineToThemeIndex(line int) int {
+	if d.cached == nil {
+		d.buildList(0)
+	}
+	return d.cached.ItemForLine(line)
+}
 
-	// Set scrollview position for mouse hit-testing (auto-computed from dialog position)
-	dialogRow, dialogCol := d.Position()
-	d.scrollview.SetPosition(dialogCol+3, dialogRow+pickerListStartOffset)
+// findSelectedLine returns the line index for the currently selected theme.
+func (d *themePickerDialog) findSelectedLine() int {
+	if d.cached == nil {
+		d.buildList(0)
+	}
+	return d.cached.LineForItem(d.selected)
+}
 
-	d.scrollview.SetContent(allLines, len(allLines))
+func (d *themePickerDialog) View() string {
+	dialogWidth, _, contentWidth := d.dialogSize()
+	d.textInput.SetWidth(contentWidth)
+
+	gl := d.buildList(contentWidth)
+	d.updateScrollviewPosition()
+	d.scrollview.SetContent(gl.Lines(), len(gl.Lines()))
 
 	var scrollableContent string
 	if len(d.filtered) == 0 {
-		visLines := d.scrollview.VisibleHeight()
-		emptyLines := []string{"", styles.DialogContentStyle.
-			Italic(true).Align(lipgloss.Center).Width(contentWidth).
-			Render("No themes found")}
-		for len(emptyLines) < visLines {
-			emptyLines = append(emptyLines, "")
-		}
-		scrollableContent = d.scrollview.ViewWithLines(emptyLines)
+		scrollableContent = d.renderEmptyState("No themes found", contentWidth)
 	} else {
 		scrollableContent = d.scrollview.View()
 	}
 
-	content := NewContent(regionWidth).
+	content := NewContent(d.regionWidth(contentWidth)).
 		AddTitle("Select Theme").
 		AddSpace().
 		AddContent(d.textInput.View()).
@@ -366,16 +313,13 @@ func (d *themePickerDialog) renderTheme(theme ThemeChoice, selected bool, maxWid
 		currentBadgeStyle = currentBadgeStyle.Background(styles.MobyBlue)
 	}
 
-	// Display name
 	displayName := theme.Name
 
-	// Build description: for custom themes, show filename (without user: prefix)
-	// For built-in themes, don't show filename - just the name is enough
+	// For custom themes, show filename for identification. Built-in themes
+	// don't need a description.
 	var desc string
 	if !theme.IsBuiltin {
-		// Custom theme - show filename for identification
-		baseRef := strings.TrimPrefix(theme.Ref, styles.UserThemePrefix)
-		desc = baseRef
+		desc = strings.TrimPrefix(theme.Ref, styles.UserThemePrefix)
 	}
 
 	// Calculate badge widths - show all applicable badges
@@ -392,22 +336,18 @@ func (d *themePickerDialog) renderTheme(theme ThemeChoice, selected bool, maxWid
 		separatorWidth = lipgloss.Width(" • ")
 	}
 
-	// Maximum width for name (leaving space for badges and description).
 	maxNameWidth := maxWidth - badgeWidth
 	if desc != "" {
 		minDescWidth := min(10, lipgloss.Width(desc))
 		maxNameWidth = maxWidth - badgeWidth - separatorWidth - minDescWidth
 	}
 
-	// Truncate name if needed.
 	if lipgloss.Width(displayName) > maxNameWidth {
 		displayName = toolcommon.TruncateText(displayName, maxNameWidth)
 	}
 
-	// Build the name with colored badges - show all applicable badges.
-	// Order: name (current) (default) - most important context first.
-	var nameParts []string
-	nameParts = append(nameParts, nameStyle.Render(displayName))
+	// Build the name with colored badges in order: name (current) (default).
+	nameParts := []string{nameStyle.Render(displayName)}
 	if theme.IsCurrent {
 		nameParts = append(nameParts, currentBadgeStyle.Render(" (current)"))
 	}
@@ -428,11 +368,6 @@ func (d *themePickerDialog) renderTheme(theme ThemeChoice, selected bool, maxWid
 	return name
 }
 
-func (d *themePickerDialog) Position() (row, col int) {
-	dialogWidth, maxHeight, _ := d.dialogSize()
-	return CenterPosition(d.Width(), d.Height(), dialogWidth, maxHeight)
-}
-
 func (d *themePickerDialog) filterThemes() (selectionChanged bool) {
 	query := strings.ToLower(strings.TrimSpace(d.textInput.Value()))
 
@@ -442,13 +377,12 @@ func (d *themePickerDialog) filterThemes() (selectionChanged bool) {
 		prevRef = d.filtered[d.selected].Ref
 	}
 
-	d.filtered = nil
+	d.filtered = d.filtered[:0]
 	for _, theme := range d.themes {
 		if query == "" {
 			d.filtered = append(d.filtered, theme)
 			continue
 		}
-
 		searchText := strings.ToLower(theme.Name + " " + theme.Ref)
 		if strings.Contains(searchText, query) {
 			d.filtered = append(d.filtered, theme)
@@ -466,84 +400,12 @@ func (d *themePickerDialog) filterThemes() (selectionChanged bool) {
 		}
 	}
 
-	// Reset scroll when filtering.
 	d.scrollview.SetScrollOffset(0)
+	d.cached = nil // layout will be rebuilt on next render
 
-	// Determine if selection changed.
 	newRef := ""
 	if d.selected >= 0 && d.selected < len(d.filtered) {
 		newRef = d.filtered[d.selected].Ref
 	}
 	return newRef != prevRef
-}
-
-// lineToThemeIndex converts a line index (in the rendered list including separators)
-// to a theme index in d.filtered. Returns -1 if the line is a separator.
-func (d *themePickerDialog) lineToThemeIndex(lineIdx int) int {
-	hasBuiltinThemes := false
-	for _, t := range d.filtered {
-		if t.IsBuiltin {
-			hasBuiltinThemes = true
-			break
-		}
-	}
-
-	currentLine := 0
-	customSeparatorShown := false
-
-	for i, theme := range d.filtered {
-		// Custom separator before first custom theme (if built-in themes exist above).
-		if !theme.IsBuiltin && !customSeparatorShown {
-			if hasBuiltinThemes {
-				if currentLine == lineIdx {
-					return -1
-				}
-				currentLine++
-			}
-			customSeparatorShown = true
-		}
-
-		if currentLine == lineIdx {
-			return i
-		}
-		currentLine++
-	}
-
-	return -1
-}
-
-// findSelectedLine returns the line index (including separators) that corresponds to the selected theme.
-func (d *themePickerDialog) findSelectedLine(_ []string) int {
-	if d.selected < 0 || d.selected >= len(d.filtered) {
-		return 0
-	}
-
-	hasBuiltinThemes := false
-	for _, t := range d.filtered {
-		if t.IsBuiltin {
-			hasBuiltinThemes = true
-			break
-		}
-	}
-
-	lineIndex := 0
-	customSeparatorShown := false
-
-	for i := range d.selected + 1 {
-		theme := d.filtered[i]
-
-		if !theme.IsBuiltin && !customSeparatorShown {
-			if hasBuiltinThemes && i <= d.selected {
-				lineIndex++
-			}
-			customSeparatorShown = true
-		}
-
-		if i == d.selected {
-			return lineIndex
-		}
-		lineIndex++
-	}
-
-	return lineIndex
 }

--- a/pkg/tui/dialog/theme_picker.go
+++ b/pkg/tui/dialog/theme_picker.go
@@ -16,7 +16,7 @@ import (
 	"github.com/docker/docker-agent/pkg/tui/styles"
 )
 
-// ThemeChoice represents a selectable theme option
+// ThemeChoice represents a selectable theme option.
 type ThemeChoice struct {
 	Ref       string // Theme reference ("default" for built-in default)
 	Name      string // Display name
@@ -32,19 +32,29 @@ type themePickerDialog struct {
 	themes   []ThemeChoice
 	filtered []ThemeChoice
 
-	// Original theme for restoration on cancel
+	// originalThemeRef is the theme ref active when the dialog opened. It is
+	// used to restore on cancel.
 	originalThemeRef string
-
-	// Avoid re-applying the same preview repeatedly (e.g., during filtering)
+	// lastPreviewRef avoids re-applying the same preview repeatedly (e.g.,
+	// during filtering).
 	lastPreviewRef string
-
-	// Cached grouped list rebuilt on every render so mouse hit-testing
-	// and findSelectedLine share the layout used by View().
-	cached *groupedList
 }
 
 // customThemesSeparatorLabel labels the separator above the custom themes group.
 const customThemesSeparatorLabel = "Custom themes"
+
+// themePickerLayout is the layout used by the theme picker. It uses the
+// shared sectioned-picker overhead so it can host the same group separators
+// as the model picker.
+var themePickerLayout = pickerLayout{
+	WidthPercent:    pickerWidthPercent,
+	MinWidth:        pickerMinWidth,
+	MaxWidth:        pickerMaxWidth,
+	HeightPercent:   pickerHeightPercent,
+	MaxHeight:       pickerMaxHeight,
+	ListOverhead:    pickerListVerticalOverhead,
+	ListStartOffset: pickerListStartOffset,
+}
 
 // NewThemePickerDialog creates a new theme picker dialog.
 // originalThemeRef is the currently active theme ref (for restoration on cancel).
@@ -57,15 +67,14 @@ func NewThemePickerDialog(themes []ThemeChoice, originalThemeRef string) Dialog 
 
 	// Sort themes: built-in first, then custom. Within each section: current
 	// first, then default, then alphabetically.
-	sortedThemes := make([]ThemeChoice, len(themes))
-	copy(sortedThemes, themes)
+	sortedThemes := slices.Clone(themes)
 	slices.SortFunc(sortedThemes, func(a, b ThemeChoice) int {
 		return comparePickerSortKeys(themeSortKeys(a), themeSortKeys(b))
 	})
 	d.themes = sortedThemes
 	d.filterThemes()
 
-	// Find current theme and select it (if multiple are marked current, pick first)
+	// Find current theme and select it (if multiple are marked current, pick first).
 	for i, t := range d.filtered {
 		if t.IsCurrent {
 			d.selected = i
@@ -73,9 +82,8 @@ func NewThemePickerDialog(themes []ThemeChoice, originalThemeRef string) Dialog 
 			break
 		}
 	}
-
-	// Initialize preview tracking to current selection (theme is already
-	// applied when dialog opens).
+	// The current theme is already applied; avoid emitting a duplicate preview
+	// for it on the first navigation.
 	if d.selected >= 0 && d.selected < len(d.filtered) {
 		d.lastPreviewRef = d.filtered[d.selected].Ref
 	}
@@ -98,23 +106,10 @@ func themeSortKeys(t ThemeChoice) pickerSortKeys {
 	}
 }
 
-// themePickerLayout is the layout used by the theme picker.
-var themePickerLayout = pickerLayout{
-	WidthPercent:    pickerWidthPercent,
-	MinWidth:        pickerMinWidth,
-	MaxWidth:        pickerMaxWidth,
-	HeightPercent:   pickerHeightPercent,
-	MaxHeight:       pickerMaxHeight,
-	ListOverhead:    pickerListVerticalOverhead,
-	ListStartOffset: pickerListStartOffset,
-}
-
-func (d *themePickerDialog) Init() tea.Cmd {
-	return textinput.Blink
-}
+func (d *themePickerDialog) Init() tea.Cmd { return textinput.Blink }
 
 func (d *themePickerDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
-	// Scrollview handles mouse scrollbar, wheel, and pgup/pgdn/home/end
+	// Scrollview handles mouse scrollbar, wheel, and pgup/pgdn/home/end.
 	if handled, cmd := d.scrollview.Update(msg); handled {
 		return d, cmd
 	}
@@ -125,34 +120,23 @@ func (d *themePickerDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		return d, cmd
 
 	case messages.ThemeChangedMsg:
+		// Refresh input styling when a preview swaps the active theme.
 		d.textInput.SetStyles(styles.DialogInputStyle)
 		return d, nil
 
 	case tea.PasteMsg:
-		var cmd tea.Cmd
-		d.textInput, cmd = d.textInput.Update(msg)
-		if d.filterThemes() {
-			d.scrollview.EnsureLineVisible(d.findSelectedLine())
-			return d, tea.Batch(cmd, d.emitPreview())
-		}
+		cmd := d.handleInputChange(msg)
 		return d, cmd
 
 	case tea.MouseClickMsg:
-		// Scrollbar clicks handled above; this handles list item clicks
-		if msg.Button == tea.MouseLeft {
-			if themeIdx := d.mouseListIndex(msg.Y, d.lineToThemeIndex); themeIdx >= 0 {
-				if d.recordClick(themeIdx) {
-					d.selected = themeIdx
-					cmd := d.handleSelection()
-					return d, cmd
-				}
-				oldSelected := d.selected
-				d.selected = themeIdx
-				if d.selected != oldSelected {
-					cmd := d.emitPreview()
-					return d, cmd
-				}
-			}
+		dbl, changed := d.handleListClick(msg, d.lineToThemeIndex)
+		switch {
+		case dbl:
+			cmd := d.handleSelection()
+			return d, cmd
+		case changed:
+			cmd := d.emitPreview()
+			return d, cmd
 		}
 		return d, nil
 
@@ -160,43 +144,23 @@ func (d *themePickerDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		if cmd := HandleQuit(msg); cmd != nil {
 			return d, cmd
 		}
-
 		switch {
 		case key.Matches(msg, d.keyMap.Escape):
 			return d, tea.Sequence(
 				closeDialogCmd(),
 				core.CmdHandler(messages.ThemeCancelPreviewMsg{OriginalRef: d.originalThemeRef}),
 			)
-
 		case key.Matches(msg, d.keyMap.Up):
-			if d.selected > 0 {
-				d.selected--
-				d.scrollview.EnsureLineVisible(d.findSelectedLine())
-				cmd := d.emitPreview()
-				return d, cmd
-			}
-			return d, nil
-
+			cmd := d.navigateAndPreview(-1)
+			return d, cmd
 		case key.Matches(msg, d.keyMap.Down):
-			if d.selected < len(d.filtered)-1 {
-				d.selected++
-				d.scrollview.EnsureLineVisible(d.findSelectedLine())
-				cmd := d.emitPreview()
-				return d, cmd
-			}
-			return d, nil
-
+			cmd := d.navigateAndPreview(+1)
+			return d, cmd
 		case key.Matches(msg, d.keyMap.Enter):
 			cmd := d.handleSelection()
 			return d, cmd
-
 		default:
-			var cmd tea.Cmd
-			d.textInput, cmd = d.textInput.Update(msg)
-			if d.filterThemes() {
-				d.scrollview.EnsureLineVisible(d.findSelectedLine())
-				return d, tea.Batch(cmd, d.emitPreview())
-			}
+			cmd := d.handleInputChange(msg)
 			return d, cmd
 		}
 	}
@@ -204,75 +168,80 @@ func (d *themePickerDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 	return d, nil
 }
 
+// navigateAndPreview moves the selection by delta and emits a preview when
+// the selection actually moved.
+func (d *themePickerDialog) navigateAndPreview(delta int) tea.Cmd {
+	if d.navigate(delta, len(d.filtered), d.findSelectedLine) {
+		return d.emitPreview()
+	}
+	return nil
+}
+
+// handleInputChange forwards msg to the text input, re-runs the filter, and
+// emits a preview when filtering moved the selection.
+func (d *themePickerDialog) handleInputChange(msg tea.Msg) tea.Cmd {
+	cmd := d.updateInput(msg, nil)
+	if d.filterThemes() {
+		d.scrollview.EnsureLineVisible(d.findSelectedLine())
+		return tea.Batch(cmd, d.emitPreview())
+	}
+	return cmd
+}
+
 func (d *themePickerDialog) handleSelection() tea.Cmd {
-	if d.selected >= 0 && d.selected < len(d.filtered) {
-		selected := d.filtered[d.selected]
-		return tea.Sequence(
-			closeDialogCmd(),
-			core.CmdHandler(messages.ChangeThemeMsg{ThemeRef: selected.Ref}),
-		)
+	if d.selected < 0 || d.selected >= len(d.filtered) {
+		return nil
 	}
-	return nil
+	return tea.Sequence(
+		closeDialogCmd(),
+		core.CmdHandler(messages.ChangeThemeMsg{ThemeRef: d.filtered[d.selected].Ref}),
+	)
 }
 
-// emitPreview requests a theme preview via an app-level message.
+// emitPreview requests a theme preview via an app-level message, skipping
+// re-emission for the same theme.
 func (d *themePickerDialog) emitPreview() tea.Cmd {
-	if d.selected >= 0 && d.selected < len(d.filtered) {
-		selected := d.filtered[d.selected]
-		// Skip if we're already previewing this exact selection.
-		if selected.Ref == d.lastPreviewRef {
-			return nil
-		}
-		d.lastPreviewRef = selected.Ref
-		return core.CmdHandler(messages.ThemePreviewMsg{
-			ThemeRef:    selected.Ref,
-			OriginalRef: d.originalThemeRef,
-		})
+	if d.selected < 0 || d.selected >= len(d.filtered) {
+		return nil
 	}
-	return nil
+	selected := d.filtered[d.selected]
+	if selected.Ref == d.lastPreviewRef {
+		return nil
+	}
+	d.lastPreviewRef = selected.Ref
+	return core.CmdHandler(messages.ThemePreviewMsg{
+		ThemeRef:    selected.Ref,
+		OriginalRef: d.originalThemeRef,
+	})
 }
 
-// buildList rebuilds the cached grouped list of themes including separators.
+// buildList constructs the list of themes with a "Custom themes" separator
+// before the first custom entry (when built-in themes precede it). Pass
+// contentWidth=0 to compute the layout without rendering items (used by
+// mouse hit-testing and findSelectedLine).
 func (d *themePickerDialog) buildList(contentWidth int) *groupedList {
 	gl := newGroupedList()
+	hasBuiltin := slices.ContainsFunc(d.filtered, func(t ThemeChoice) bool { return t.IsBuiltin })
 
-	hasBuiltinThemes := false
-	for _, t := range d.filtered {
-		if t.IsBuiltin {
-			hasBuiltinThemes = true
-			break
-		}
-	}
-
-	customSeparatorShown := false
+	customSepShown := false
 	for i, theme := range d.filtered {
-		if !theme.IsBuiltin && !customSeparatorShown {
-			if hasBuiltinThemes {
+		if !theme.IsBuiltin && !customSepShown {
+			if hasBuiltin {
 				gl.AddNonItem(RenderGroupSeparator(customThemesSeparatorLabel, contentWidth))
 			}
-			customSeparatorShown = true
+			customSepShown = true
 		}
 		gl.AddItem(d.renderTheme(theme, i == d.selected, contentWidth))
 	}
-	d.cached = gl
 	return gl
 }
 
-// lineToThemeIndex returns the theme index for a rendered line, or -1 for
-// separators. Used by mouse hit-testing.
 func (d *themePickerDialog) lineToThemeIndex(line int) int {
-	if d.cached == nil {
-		d.buildList(0)
-	}
-	return d.cached.ItemForLine(line)
+	return d.buildList(0).ItemForLine(line)
 }
 
-// findSelectedLine returns the line index for the currently selected theme.
 func (d *themePickerDialog) findSelectedLine() int {
-	if d.cached == nil {
-		d.buildList(0)
-	}
-	return d.cached.LineForItem(d.selected)
+	return d.buildList(0).LineForItem(d.selected)
 }
 
 func (d *themePickerDialog) View() string {
@@ -283,11 +252,9 @@ func (d *themePickerDialog) View() string {
 	d.updateScrollviewPosition()
 	d.scrollview.SetContent(gl.Lines(), len(gl.Lines()))
 
-	var scrollableContent string
+	scrollableContent := d.scrollview.View()
 	if len(d.filtered) == 0 {
 		scrollableContent = d.renderEmptyState("No themes found", contentWidth)
-	} else {
-		scrollableContent = d.scrollview.View()
 	}
 
 	content := NewContent(d.regionWidth(contentWidth)).
@@ -304,6 +271,10 @@ func (d *themePickerDialog) View() string {
 }
 
 func (d *themePickerDialog) renderTheme(theme ThemeChoice, selected bool, maxWidth int) string {
+	if maxWidth <= 0 {
+		return ""
+	}
+
 	nameStyle, descStyle := styles.PaletteUnselectedActionStyle, styles.PaletteUnselectedDescStyle
 	defaultBadgeStyle := styles.BadgeDefaultStyle
 	currentBadgeStyle := styles.BadgeCurrentStyle
@@ -313,16 +284,15 @@ func (d *themePickerDialog) renderTheme(theme ThemeChoice, selected bool, maxWid
 		currentBadgeStyle = currentBadgeStyle.Background(styles.MobyBlue)
 	}
 
-	displayName := theme.Name
-
-	// For custom themes, show filename for identification. Built-in themes
-	// don't need a description.
+	// For custom themes, show the filename as a description. Built-in themes
+	// don't need one.
 	var desc string
 	if !theme.IsBuiltin {
 		desc = strings.TrimPrefix(theme.Ref, styles.UserThemePrefix)
 	}
 
-	// Calculate badge widths - show all applicable badges
+	// Reserve space for badges and the description so the name truncation
+	// keeps everything visible.
 	var badgeWidth int
 	if theme.IsCurrent {
 		badgeWidth += lipgloss.Width(" (current)")
@@ -342,36 +312,34 @@ func (d *themePickerDialog) renderTheme(theme ThemeChoice, selected bool, maxWid
 		maxNameWidth = maxWidth - badgeWidth - separatorWidth - minDescWidth
 	}
 
+	displayName := theme.Name
 	if lipgloss.Width(displayName) > maxNameWidth {
 		displayName = toolcommon.TruncateText(displayName, maxNameWidth)
 	}
 
-	// Build the name with colored badges in order: name (current) (default).
-	nameParts := []string{nameStyle.Render(displayName)}
+	// Build the name with coloured badges in order: name (current) (default).
+	name := nameStyle.Render(displayName)
 	if theme.IsCurrent {
-		nameParts = append(nameParts, currentBadgeStyle.Render(" (current)"))
+		name += currentBadgeStyle.Render(" (current)")
 	}
 	if theme.IsDefault {
-		nameParts = append(nameParts, defaultBadgeStyle.Render(" (default)"))
+		name += defaultBadgeStyle.Render(" (default)")
 	}
-	name := strings.Join(nameParts, "")
 
 	if desc != "" {
-		nameWidth := lipgloss.Width(name)
-		remainingWidth := maxWidth - nameWidth - separatorWidth
+		remainingWidth := maxWidth - lipgloss.Width(name) - separatorWidth
 		if remainingWidth > 0 {
-			truncatedDesc := toolcommon.TruncateText(desc, remainingWidth)
-			return name + descStyle.Render(" • "+truncatedDesc)
+			return name + descStyle.Render(" • "+toolcommon.TruncateText(desc, remainingWidth))
 		}
 	}
-
 	return name
 }
 
+// filterThemes re-applies the search filter. It preserves the current
+// selection when possible. Returns true when the selected theme changed.
 func (d *themePickerDialog) filterThemes() (selectionChanged bool) {
 	query := strings.ToLower(strings.TrimSpace(d.textInput.Value()))
 
-	// Remember current selection so filtering doesn't cause surprising jumps.
 	prevRef := ""
 	if d.selected >= 0 && d.selected < len(d.filtered) {
 		prevRef = d.filtered[d.selected].Ref
@@ -379,17 +347,11 @@ func (d *themePickerDialog) filterThemes() (selectionChanged bool) {
 
 	d.filtered = d.filtered[:0]
 	for _, theme := range d.themes {
-		if query == "" {
-			d.filtered = append(d.filtered, theme)
-			continue
-		}
-		searchText := strings.ToLower(theme.Name + " " + theme.Ref)
-		if strings.Contains(searchText, query) {
+		if query == "" || strings.Contains(strings.ToLower(theme.Name+" "+theme.Ref), query) {
 			d.filtered = append(d.filtered, theme)
 		}
 	}
 
-	// Restore selection if possible; otherwise fall back to first item.
 	d.selected = 0
 	if prevRef != "" {
 		for i, t := range d.filtered {
@@ -399,9 +361,7 @@ func (d *themePickerDialog) filterThemes() (selectionChanged bool) {
 			}
 		}
 	}
-
 	d.scrollview.SetScrollOffset(0)
-	d.cached = nil // layout will be rebuilt on next render
 
 	newRef := ""
 	if d.selected >= 0 && d.selected < len(d.filtered) {

--- a/pkg/tui/dialog/working_dir_picker.go
+++ b/pkg/tui/dialog/working_dir_picker.go
@@ -138,7 +138,7 @@ type workingDirPickerDialog struct {
 	favoriteDirs []string
 	favoriteSet  map[string]bool
 	tuiStore     *tuistate.Store
-	keyMap       commandPaletteKeyMap
+	keyMap       pickerKeyMap
 
 	// Tab click regions (recomputed each render)
 	tabRegions []tabRegion
@@ -191,7 +191,7 @@ func NewWorkingDirPickerDialog(recentDirs, favoriteDirs []string, store *tuistat
 		favoriteDirs: favoriteDirs,
 		favoriteSet:  favSet,
 		tuiStore:     store,
-		keyMap:       defaultCommandPaletteKeyMap(),
+		keyMap:       defaultPickerKeyMap(),
 		pinnedScroll: scrollview.New(scrollview.WithReserveScrollbarSpace(true)),
 		recentScroll: scrollview.New(scrollview.WithReserveScrollbarSpace(true)),
 		browseScroll: scrollview.New(scrollview.WithReserveScrollbarSpace(true)),

--- a/pkg/tui/dialog/working_dir_picker.go
+++ b/pkg/tui/dialog/working_dir_picker.go
@@ -606,11 +606,7 @@ func (d *workingDirPickerDialog) isStarClick(x, entryIdx int) bool {
 
 func (d *workingDirPickerDialog) setSection(s dirSection) {
 	d.section = s
-	if d.section == sectionBrowse {
-		d.textInput.Focus()
-	} else {
-		d.textInput.Blur()
-	}
+	d.updateSectionFocus()
 }
 
 // tabClickTarget returns the section index if the click is on a tab, or -1.

--- a/pkg/tui/dialog/working_dir_picker.go
+++ b/pkg/tui/dialog/working_dir_picker.go
@@ -385,36 +385,43 @@ func (d *workingDirPickerDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 }
 
 func (d *workingDirPickerDialog) activeScrollview() *scrollview.Model {
+	return d.activeSection().scroll
+}
+
+// dirSectionState bundles the entries, selection, and scrollview of one
+// section of the working-directory picker. activeSection returns a snapshot
+// referencing the active section's state so navigation helpers don't have
+// to repeat a switch on d.section.
+type dirSectionState struct {
+	entries  []dirEntry
+	selected *int
+	scroll   *scrollview.Model
+}
+
+func (d *workingDirPickerDialog) activeSection() dirSectionState {
 	switch d.section {
 	case sectionPinned:
-		return d.pinnedScroll
+		return dirSectionState{d.pinnedEntries, &d.pinnedSelected, d.pinnedScroll}
 	case sectionRecent:
-		return d.recentScroll
+		return dirSectionState{d.recentEntries, &d.recentSelected, d.recentScroll}
 	default:
-		return d.browseScroll
+		return dirSectionState{d.browseFiltered, &d.browseSelected, d.browseScroll}
 	}
 }
 
-func (d *workingDirPickerDialog) cycleSectionForward() {
-	switch d.section {
-	case sectionBrowse:
-		d.section = sectionRecent
-	case sectionRecent:
-		d.section = sectionPinned
-	case sectionPinned:
-		d.section = sectionBrowse
-	}
-	d.updateSectionFocus()
-}
+// dirPickerSectionOrder is the cycle order used by tab and shift-tab.
+var dirPickerSectionOrder = []dirSection{sectionBrowse, sectionRecent, sectionPinned}
 
-func (d *workingDirPickerDialog) cycleSectionBackward() {
-	switch d.section {
-	case sectionBrowse:
-		d.section = sectionPinned
-	case sectionPinned:
-		d.section = sectionRecent
-	case sectionRecent:
-		d.section = sectionBrowse
+func (d *workingDirPickerDialog) cycleSectionForward()  { d.cycleSection(+1) }
+func (d *workingDirPickerDialog) cycleSectionBackward() { d.cycleSection(-1) }
+
+func (d *workingDirPickerDialog) cycleSection(delta int) {
+	n := len(dirPickerSectionOrder)
+	for i, s := range dirPickerSectionOrder {
+		if s == d.section {
+			d.section = dirPickerSectionOrder[(i+delta+n)%n]
+			break
+		}
 	}
 	d.updateSectionFocus()
 }
@@ -428,120 +435,55 @@ func (d *workingDirPickerDialog) updateSectionFocus() {
 }
 
 func (d *workingDirPickerDialog) moveUp() {
-	switch d.section {
-	case sectionPinned:
-		if d.pinnedSelected > 0 {
-			d.pinnedSelected--
-			d.pinnedScroll.EnsureLineVisible(d.pinnedSelected)
-		}
-	case sectionRecent:
-		if d.recentSelected > 0 {
-			d.recentSelected--
-			d.recentScroll.EnsureLineVisible(d.recentSelected)
-		}
-	case sectionBrowse:
-		if d.browseSelected > 0 {
-			d.browseSelected--
-			d.browseScroll.EnsureLineVisible(d.browseSelected)
-		}
+	s := d.activeSection()
+	if *s.selected > 0 {
+		*s.selected--
+		s.scroll.EnsureLineVisible(*s.selected)
 	}
 }
 
 func (d *workingDirPickerDialog) moveDown() {
-	switch d.section {
-	case sectionPinned:
-		if d.pinnedSelected < len(d.pinnedEntries)-1 {
-			d.pinnedSelected++
-			d.pinnedScroll.EnsureLineVisible(d.pinnedSelected)
-		}
-	case sectionRecent:
-		if d.recentSelected < len(d.recentEntries)-1 {
-			d.recentSelected++
-			d.recentScroll.EnsureLineVisible(d.recentSelected)
-		}
-	case sectionBrowse:
-		if d.browseSelected < len(d.browseFiltered)-1 {
-			d.browseSelected++
-			d.browseScroll.EnsureLineVisible(d.browseSelected)
-		}
+	s := d.activeSection()
+	if *s.selected < len(s.entries)-1 {
+		*s.selected++
+		s.scroll.EnsureLineVisible(*s.selected)
 	}
 }
 
 func (d *workingDirPickerDialog) handleSelection() tea.Cmd {
-	switch d.section {
-	case sectionPinned:
-		if d.pinnedSelected < 0 || d.pinnedSelected >= len(d.pinnedEntries) {
-			return nil
-		}
-		entry := d.pinnedEntries[d.pinnedSelected]
-		return tea.Sequence(
-			core.CmdHandler(CloseDialogMsg{}),
-			core.CmdHandler(messages.SpawnSessionMsg{WorkingDir: entry.path}),
-		)
-	case sectionRecent:
-		if d.recentSelected < 0 || d.recentSelected >= len(d.recentEntries) {
-			return nil
-		}
-		entry := d.recentEntries[d.recentSelected]
-		return tea.Sequence(
-			core.CmdHandler(CloseDialogMsg{}),
-			core.CmdHandler(messages.SpawnSessionMsg{WorkingDir: entry.path}),
-		)
-	default:
-		// sectionBrowse
-	}
-
-	if d.browseSelected < 0 || d.browseSelected >= len(d.browseFiltered) {
+	s := d.activeSection()
+	if *s.selected < 0 || *s.selected >= len(s.entries) {
 		return nil
 	}
-	entry := d.browseFiltered[d.browseSelected]
+	entry := s.entries[*s.selected]
 
-	switch entry.kind {
-	case entryUseThisDir:
-		return tea.Sequence(
-			core.CmdHandler(CloseDialogMsg{}),
-			core.CmdHandler(messages.SpawnSessionMsg{WorkingDir: entry.path}),
-		)
-	case entryParentDir, entryDir:
-		d.currentDir = entry.path
-		d.textInput.SetValue("")
-		d.loadBrowseDirectory()
-		return nil
+	// Browsing into directories doesn't close the dialog.
+	if d.section == sectionBrowse {
+		switch entry.kind {
+		case entryParentDir, entryDir:
+			d.currentDir = entry.path
+			d.textInput.SetValue("")
+			d.loadBrowseDirectory()
+			return nil
+		}
 	}
 
-	return nil
+	return tea.Sequence(
+		core.CmdHandler(CloseDialogMsg{}),
+		core.CmdHandler(messages.SpawnSessionMsg{WorkingDir: entry.path}),
+	)
 }
 
 func (d *workingDirPickerDialog) toggleFavorite() {
 	if d.tuiStore == nil {
 		return
 	}
-
-	var togglePath string
-	switch d.section {
-	case sectionPinned:
-		if d.pinnedSelected < 0 || d.pinnedSelected >= len(d.pinnedEntries) {
-			return
-		}
-		togglePath = d.pinnedEntries[d.pinnedSelected].path
-	case sectionRecent:
-		if d.recentSelected < 0 || d.recentSelected >= len(d.recentEntries) {
-			return
-		}
-		togglePath = d.recentEntries[d.recentSelected].path
-	case sectionBrowse:
-		if d.browseSelected < 0 || d.browseSelected >= len(d.browseFiltered) {
-			return
-		}
-		entry := d.browseFiltered[d.browseSelected]
-		if entry.kind == entryParentDir {
-			return
-		}
-		togglePath = entry.path
+	togglePath, ok := d.selectedTogglePath()
+	if !ok {
+		return
 	}
 
-	ctx := context.Background()
-	isFav, err := d.tuiStore.ToggleFavoriteDir(ctx, togglePath)
+	isFav, err := d.tuiStore.ToggleFavoriteDir(context.Background(), togglePath)
 	if err != nil {
 		return
 	}
@@ -563,7 +505,7 @@ func (d *workingDirPickerDialog) toggleFavorite() {
 	d.rebuildPinnedEntries()
 	d.rebuildRecentEntries()
 
-	// Restore pinned selection to same path if possible
+	// Restore pinned selection to same path if possible.
 	if savedPinnedPath != "" {
 		for i, e := range d.pinnedEntries {
 			if e.path == savedPinnedPath {
@@ -572,6 +514,20 @@ func (d *workingDirPickerDialog) toggleFavorite() {
 			}
 		}
 	}
+}
+
+// selectedTogglePath returns the currently selected entry's path if it can
+// be pinned/unpinned (false otherwise).
+func (d *workingDirPickerDialog) selectedTogglePath() (string, bool) {
+	s := d.activeSection()
+	if *s.selected < 0 || *s.selected >= len(s.entries) {
+		return "", false
+	}
+	entry := s.entries[*s.selected]
+	if d.section == sectionBrowse && entry.kind == entryParentDir {
+		return "", false
+	}
+	return entry.path, true
 }
 
 // removeFromSlice removes all occurrences of val from s.
@@ -677,53 +633,44 @@ func (d *workingDirPickerDialog) tabClickTarget(x, y int) int {
 }
 
 func (d *workingDirPickerDialog) setSelected(idx int) {
-	switch d.section {
-	case sectionPinned:
-		d.pinnedSelected = idx
-	case sectionRecent:
-		d.recentSelected = idx
-	case sectionBrowse:
-		d.browseSelected = idx
-	}
+	*d.activeSection().selected = idx
 }
 
 func (d *workingDirPickerDialog) mouseYToEntryIndex(y int) int {
 	dialogRow, _ := d.Position()
 	_, maxHeight, _ := d.dialogSize()
 
-	var listStartY, overhead int
-	var entries int
-	switch d.section {
-	case sectionPinned:
-		listStartY = dialogRow + dirPickerListStartSimple
-		overhead = dirPickerOverheadSimple
-		entries = len(d.pinnedEntries)
-	case sectionRecent:
-		listStartY = dialogRow + dirPickerListStartSimple
-		overhead = dirPickerOverheadSimple
-		entries = len(d.recentEntries)
-	case sectionBrowse:
-		listStartY = dialogRow + dirPickerListStartBrowse
-		overhead = dirPickerOverheadBrowse
-		entries = len(d.browseFiltered)
-	}
-
-	maxItems := maxHeight - overhead
-	listEndY := listStartY + maxItems
+	listStartY := dialogRow + d.listStartOffset()
+	listEndY := listStartY + maxHeight - d.sectionOverhead()
 
 	if y < listStartY || y >= listEndY {
 		return -1
 	}
 
-	lineInView := y - listStartY
-	scroll := d.activeScrollview()
-	entryIdx := scroll.ScrollOffset() + lineInView
-
-	if entryIdx < 0 || entryIdx >= entries {
+	s := d.activeSection()
+	entryIdx := s.scroll.ScrollOffset() + (y - listStartY)
+	if entryIdx < 0 || entryIdx >= len(s.entries) {
 		return -1
 	}
-
 	return entryIdx
+}
+
+// listStartOffset is the Y offset (relative to the dialog's top) at which
+// the active section's list begins.
+func (d *workingDirPickerDialog) listStartOffset() int {
+	if d.section == sectionBrowse {
+		return dirPickerListStartBrowse
+	}
+	return dirPickerListStartSimple
+}
+
+// sectionOverhead is the total non-list chrome (header + footer + filter row
+// for browse) of the active section.
+func (d *workingDirPickerDialog) sectionOverhead() int {
+	if d.section == sectionBrowse {
+		return dirPickerOverheadBrowse
+	}
+	return dirPickerOverheadSimple
 }
 
 func (d *workingDirPickerDialog) filterBrowseEntries() {
@@ -766,57 +713,43 @@ func (d *workingDirPickerDialog) View() string {
 	d.textInput.SetWidth(contentWidth)
 	regionWidth := contentWidth + d.pinnedScroll.ReservedCols()
 
-	// Tab header
-	tabLine := d.renderTabs(regionWidth)
+	builder := NewContent(regionWidth).
+		AddTitle("New Session: Select Working Directory").
+		AddSpace().
+		AddContent(d.renderTabs(regionWidth)).
+		AddSpace()
 
-	// Build content based on active section
-	pinLabel := d.pinHelpLabel()
-	helpKeys := []string{"↑/↓", "navigate", "tab/shift+tab", "section", "enter", "select"}
-	if pinLabel != "" {
-		helpKeys = append(helpKeys, "ctrl+p", pinLabel)
+	if d.section == sectionBrowse {
+		builder.AddContent(d.textInput.View()).AddSpace()
 	}
-	helpKeys = append(helpKeys, "esc", "cancel")
-	var contentBuilder *Content
+
+	builder.
+		AddContent(d.renderActiveList(contentWidth)).
+		AddSpace().
+		AddHelpKeys(d.helpKeys()...)
+
+	return styles.DialogStyle.Width(dialogWidth).Render(builder.Build())
+}
+
+// renderActiveList renders the list area for the currently active section.
+func (d *workingDirPickerDialog) renderActiveList(contentWidth int) string {
 	switch d.section {
 	case sectionPinned:
-		scrollableContent := d.renderPinnedList(contentWidth)
-
-		contentBuilder = NewContent(regionWidth).
-			AddTitle("New Session: Select Working Directory").
-			AddSpace().
-			AddContent(tabLine).
-			AddSpace().
-			AddContent(scrollableContent).
-			AddSpace().
-			AddHelpKeys(helpKeys...)
+		return d.renderPinnedList(contentWidth)
 	case sectionRecent:
-		scrollableContent := d.renderRecentList(contentWidth)
-
-		contentBuilder = NewContent(regionWidth).
-			AddTitle("New Session: Select Working Directory").
-			AddSpace().
-			AddContent(tabLine).
-			AddSpace().
-			AddContent(scrollableContent).
-			AddSpace().
-			AddHelpKeys(helpKeys...)
-	case sectionBrowse:
-		scrollableContent := d.renderBrowseList(contentWidth)
-
-		contentBuilder = NewContent(regionWidth).
-			AddTitle("New Session: Select Working Directory").
-			AddSpace().
-			AddContent(tabLine).
-			AddSpace().
-			AddContent(d.textInput.View()).
-			AddSpace().
-			AddContent(scrollableContent).
-			AddSpace().
-			AddHelpKeys(helpKeys...)
+		return d.renderRecentList(contentWidth)
+	default:
+		return d.renderBrowseList(contentWidth)
 	}
+}
 
-	content := contentBuilder.Build()
-	return styles.DialogStyle.Width(dialogWidth).Render(content)
+// helpKeys returns the key/label pairs displayed at the bottom of the dialog.
+func (d *workingDirPickerDialog) helpKeys() []string {
+	keys := []string{"↑/↓", "navigate", "tab/shift+tab", "section", "enter", "select"}
+	if label := d.pinHelpLabel(); label != "" {
+		keys = append(keys, "ctrl+p", label)
+	}
+	return append(keys, "esc", "cancel")
 }
 
 func (d *workingDirPickerDialog) renderTabs(width int) string {
@@ -891,66 +824,46 @@ func (d *workingDirPickerDialog) renderTabs(width int) string {
 }
 
 func (d *workingDirPickerDialog) renderPinnedList(contentWidth int) string {
-	var allLines []string
+	lines := make([]string, 0, len(d.pinnedEntries))
 	for i, entry := range d.pinnedEntries {
-		allLines = append(allLines, d.renderPinnedEntry(entry, i == d.pinnedSelected, contentWidth))
+		lines = append(lines, d.renderPinnedEntry(entry, i == d.pinnedSelected, contentWidth))
 	}
-
-	dialogRow, dialogCol := d.Position()
-	d.pinnedScroll.SetPosition(dialogCol+dirPickerContentOffsetX, dialogRow+dirPickerListStartSimple)
-	d.pinnedScroll.SetContent(allLines, len(allLines))
+	d.placeScrollview(d.pinnedScroll, dirPickerListStartSimple)
+	d.pinnedScroll.SetContent(lines, len(lines))
 
 	if len(d.pinnedEntries) == 0 {
-		visLines := d.pinnedScroll.VisibleHeight()
-		emptyLines := []string{
-			"", styles.DialogContentStyle.
-				Italic(true).Align(lipgloss.Center).Width(contentWidth).
-				Render("No pinned directories"), "",
-			styles.MutedStyle.Align(lipgloss.Center).Width(contentWidth).
-				Render("Use ctrl+p in Browse to pin directories"),
-		}
-		for len(emptyLines) < visLines {
-			emptyLines = append(emptyLines, "")
-		}
-		return d.pinnedScroll.ViewWithLines(emptyLines)
+		return d.renderListPlaceholder(d.pinnedScroll, []string{
+			"",
+			centeredItalic("No pinned directories", contentWidth),
+			"",
+			centeredMuted("Use ctrl+p in Browse to pin directories", contentWidth),
+		})
 	}
-
 	return d.pinnedScroll.View()
 }
 
 func (d *workingDirPickerDialog) renderBrowseList(contentWidth int) string {
-	var allLines []string
+	lines := make([]string, 0, len(d.browseFiltered))
 	for i, entry := range d.browseFiltered {
-		allLines = append(allLines, d.renderBrowseEntry(entry, i == d.browseSelected, contentWidth))
+		lines = append(lines, d.renderBrowseEntry(entry, i == d.browseSelected, contentWidth))
 	}
+	d.placeScrollview(d.browseScroll, dirPickerListStartBrowse)
+	d.browseScroll.SetContent(lines, len(lines))
 
-	dialogRow, dialogCol := d.Position()
-	d.browseScroll.SetPosition(dialogCol+dirPickerContentOffsetX, dialogRow+dirPickerListStartBrowse)
-	d.browseScroll.SetContent(allLines, len(allLines))
-
-	if d.browseErr != nil {
-		visLines := d.browseScroll.VisibleHeight()
-		errLines := []string{"", styles.ErrorStyle.
-			Align(lipgloss.Center).Width(contentWidth).
-			Render(d.browseErr.Error())}
-		for len(errLines) < visLines {
-			errLines = append(errLines, "")
-		}
-		return d.browseScroll.ViewWithLines(errLines)
+	switch {
+	case d.browseErr != nil:
+		return d.renderListPlaceholder(d.browseScroll, []string{
+			"",
+			centeredError(d.browseErr.Error(), contentWidth),
+		})
+	case len(d.browseFiltered) == 0:
+		return d.renderListPlaceholder(d.browseScroll, []string{
+			"",
+			centeredItalic("No directories found", contentWidth),
+		})
+	default:
+		return d.browseScroll.View()
 	}
-
-	if len(d.browseFiltered) == 0 {
-		visLines := d.browseScroll.VisibleHeight()
-		emptyLines := []string{"", styles.DialogContentStyle.
-			Italic(true).Align(lipgloss.Center).Width(contentWidth).
-			Render("No directories found")}
-		for len(emptyLines) < visLines {
-			emptyLines = append(emptyLines, "")
-		}
-		return d.browseScroll.ViewWithLines(emptyLines)
-	}
-
-	return d.browseScroll.View()
 }
 
 func (d *workingDirPickerDialog) renderPinnedEntry(entry dirEntry, selected bool, maxWidth int) string {
@@ -1001,29 +914,55 @@ func (d *workingDirPickerDialog) renderBrowseEntry(entry dirEntry, selected bool
 }
 
 func (d *workingDirPickerDialog) renderRecentList(contentWidth int) string {
-	var allLines []string
+	lines := make([]string, 0, len(d.recentEntries))
 	for i, entry := range d.recentEntries {
-		allLines = append(allLines, d.renderRecentEntry(entry, i == d.recentSelected, contentWidth))
+		lines = append(lines, d.renderRecentEntry(entry, i == d.recentSelected, contentWidth))
 	}
-
-	dialogRow, dialogCol := d.Position()
-	d.recentScroll.SetPosition(dialogCol+dirPickerContentOffsetX, dialogRow+dirPickerListStartSimple)
-	d.recentScroll.SetContent(allLines, len(allLines))
+	d.placeScrollview(d.recentScroll, dirPickerListStartSimple)
+	d.recentScroll.SetContent(lines, len(lines))
 
 	if len(d.recentEntries) == 0 {
-		visLines := d.recentScroll.VisibleHeight()
-		emptyLines := []string{
-			"", styles.DialogContentStyle.
-				Italic(true).Align(lipgloss.Center).Width(contentWidth).
-				Render("No recent directories"),
-		}
-		for len(emptyLines) < visLines {
-			emptyLines = append(emptyLines, "")
-		}
-		return d.recentScroll.ViewWithLines(emptyLines)
+		return d.renderListPlaceholder(d.recentScroll, []string{
+			"",
+			centeredItalic("No recent directories", contentWidth),
+		})
 	}
-
 	return d.recentScroll.View()
+}
+
+// placeScrollview anchors sv to the dialog's content rectangle for accurate
+// mouse hit-testing. listStartY is the Y offset from the dialog's top to
+// the first row of the list area.
+func (d *workingDirPickerDialog) placeScrollview(sv *scrollview.Model, listStartY int) {
+	dialogRow, dialogCol := d.Position()
+	sv.SetPosition(dialogCol+dirPickerContentOffsetX, dialogRow+listStartY)
+}
+
+// renderListPlaceholder fills sv's visible area with the supplied lines plus
+// blank padding so the dialog doesn't shrink while a list is empty.
+func (d *workingDirPickerDialog) renderListPlaceholder(sv *scrollview.Model, lines []string) string {
+	visLines := sv.VisibleHeight()
+	out := make([]string, 0, max(visLines, len(lines)))
+	out = append(out, lines...)
+	for len(out) < visLines {
+		out = append(out, "")
+	}
+	return sv.ViewWithLines(out)
+}
+
+// centeredItalic formats msg as a centred italic placeholder of the given width.
+func centeredItalic(msg string, width int) string {
+	return styles.DialogContentStyle.Italic(true).Align(lipgloss.Center).Width(width).Render(msg)
+}
+
+// centeredMuted formats msg as a centred muted placeholder of the given width.
+func centeredMuted(msg string, width int) string {
+	return styles.MutedStyle.Align(lipgloss.Center).Width(width).Render(msg)
+}
+
+// centeredError formats msg as a centred error placeholder of the given width.
+func centeredError(msg string, width int) string {
+	return styles.ErrorStyle.Align(lipgloss.Center).Width(width).Render(msg)
 }
 
 func (d *workingDirPickerDialog) renderRecentEntry(entry dirEntry, selected bool, maxWidth int) string {
@@ -1059,10 +998,7 @@ func (d *workingDirPickerDialog) pinHelpLabel() string {
 
 func (d *workingDirPickerDialog) pageSize() int {
 	_, maxHeight, _ := d.dialogSize()
-	if d.section == sectionBrowse {
-		return max(1, maxHeight-dirPickerOverheadBrowse)
-	}
-	return max(1, maxHeight-dirPickerOverheadSimple)
+	return max(1, maxHeight-d.sectionOverhead())
 }
 
 // SetSize sets the dialog dimensions and configures both scrollview regions.


### PR DESCRIPTION
## What

Extract shared infrastructure for the TUI list-with-filter picker dialogs (command palette, theme picker, model picker, file picker, working-directory picker) so each dialog focuses on its own filtering / rendering / submission logic instead of repeating the same scrollview/textinput/mouse/keymap plumbing.

## Why

The five picker dialogs each carried a near-identical copy of:

- `textInput` + `scrollview` + `selected` + click-tracking fields
- `commandPaletteKeyMap` (private to one file but used by all five)
- `dialogSize()` / `Position()` / `SetSize()`
- mouse `Y → item index` math with double-click detection
- empty-state and error-state padding loops
- *for `model_picker` and `theme_picker`*: section/group separator rendering plus the `line ↔ item` bookkeeping needed for mouse hit-testing and selection scrolling
- *for `model_picker` and `theme_picker`*: the same priority/current/default/name sort comparator

Bug fixes and improvements to any of these had to be made in 4-5 places.

## How

A new `pkg/tui/dialog/picker.go` introduces:

| Symbol | Purpose |
|---|---|
| `pickerKeyMap` / `defaultPickerKeyMap()` | replaces the old, misnamed `commandPaletteKeyMap` |
| `pickerLayout` | declarative dialog dimensions + chrome offsets |
| `pickerCore` | embeddable struct owning textInput, scrollview, selected, double-click tracking, sizing, position, mouse hit-testing, navigation, placeholder rendering |
| `groupedList` | builder that tracks the `line ↔ item` mapping for lists with separators/headers (used by model and theme pickers) |
| `pickerSortKeys` / `comparePickerSortKeys` | the section/current/default/name comparator |

Plus three small \`pickerCore\` helpers that absorb patterns repeated across every picker:

- `updateInput(msg, filter)` — feed the textInput, run the filter, return the cmd
- `handleListClick(msg, lineToItem)` — mouse hit-test + selection update + double-click detection in one call
- `navigate(delta, num, lineForSelected)` — bounded selection move with `EnsureLineVisible`

\`base.go\` gains \`RenderGroupSeparator(label, contentWidth)\` to replace three hand-rolled \`\"── Label ──…\"\` constructions.

For \`working_dir_picker.go\`, an \`activeSection()\` snapshot returning \`{entries, *selected, scroll}\` collapses what used to be 3-arm switches in \`moveUp\` / \`moveDown\` / \`setSelected\` / \`handleSelection\` / \`toggleFavorite\` / \`mouseYToEntryIndex\` / \`cycleSection*\`.

## Per-dialog impact

| File | Before | After |
|---|---:|---:|
| `command_palette.go` | 378 | 252 |
| `theme_picker.go` | 549 | 371 |
| `model_picker.go` | 873 | 662 |
| `file_picker.go` | 419 | 374 |
| `working_dir_picker.go` | 1087 | 1023 |
| `picker.go` (NEW) | – | 391 |

Net diff: **-275 lines**, and each dialog now reads as orchestration over the shared helpers.

## No behaviour change

- Diff-reviewed against the pre-refactor commit (\`3bc200cd3\`).
- Two real fixes folded into the series:
  - \`file_picker\`: \`maxNameLen := maxWidth - 20\` could go negative in narrow terminals and panic on \`name[:maxNameLen-1]\`. Now clamped to \`max(1, …)\`. (**Pre-existing bug**, surfaced during review.)
  - \`command_palette.filterCommands\`: restored the original \`reset selected to 0 when query is cleared\` behaviour (matches the file picker; preserves selection only when filtering with a non-empty query).
  - \`working_dir_picker.setSection\`: now delegates to \`updateSectionFocus\` instead of duplicating its body.

## Validation

- \`go build ./...\` ✅
- \`go test ./pkg/tui/dialog/...\` ✅
- \`mise lint\` ✅ 0 issues
- Manual diff review of every \`Update()\` / \`View()\` / filter / selection / sort path against the pre-refactor baseline (most of this code isn't covered by tests).

## Commits

\`\`\`
09beb18a fix(tui/dialog): preserve original behaviour after picker refactor
f246707d fix(tui/dialog): avoid negative slice index when truncating file names
199a80cd refactor(tui/dialog): inline boolCompare, drop unused CommandExecuteMsg
0146793e refactor(tui): simplify picker dialogs around shared helpers
6ba31b4f refactor(tui): extract shared picker infrastructure
\`\`\`