### PR TITLE
ci: split PR image builds by platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,31 @@ jobs:
         uses: docker/build-push-action@ee4ca427a2f43b6a16632044ca514c076267da23 # v6.19.0
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
+          push: false
+          sbom: false
+          provenance: false
+          build-args: |
+            GIT_TAG=pr
+            GIT_COMMIT=dev
+          cache-from: type=gha,scope=buildx
+          cache-to: type=gha,mode=min,scope=buildx
+
+  build-image-arm64:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Build image
+        uses: docker/build-push-action@ee4ca427a2f43b6a16632044ca514c076267da23 # v6.19.0
+        with:
+          context: .
+          platforms: linux/arm64
           push: false
           sbom: false
           provenance: false


### PR DESCRIPTION
## Summary

- split PR Docker image validation into separate amd64 and arm64 jobs
- keep both Linux platforms validated on PRs
- run arm64 validation on the native `ubuntu-24.04-arm` runner
- leave main/tag image publishing unchanged

## Expected outcome

The two expensive CGO-enabled Linux image builds no longer contend inside the same BuildKit invocation. Locally, reproducing the merged main build with a fresh BuildKit builder and no cache took ~92s for the combined multi-platform build. Single-platform no-cache runs took ~70s for amd64 and ~82s for arm64; on GitHub Actions these should run in parallel, and the arm64 job should avoid amd64-hosted cross-build contention by using the native arm runner.

This preserves CGO support and does not use the rejected CGO_DISABLED optimization.

## Validation

- docker buildx build --check .
- workflow YAML parse
- git diff --check
- local no-cache build timing for combined linux/amd64,linux/arm64
- local no-cache single-platform timings for linux/amd64 and linux/arm64