### PR TITLE
log history init failure via slog instead of stderr

### DIFF
--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -256,7 +256,7 @@ func New(ctx context.Context, spawner SessionSpawner, initialApp *app.App, initi
 	// Initialize shared command history
 	historyStore, err := history.New()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to initialize command history: %v\n", err)
+		slog.Warn("Failed to initialize command history", "error", err)
 	}
 
 	initialSessionState := service.NewSessionState(initialApp.Session())


### PR DESCRIPTION
Writing directly to `os.Stderr` while the Bubble Tea TUI is starting up can corrupt the alt-screen rendering, and it was also inconsistent with the surrounding code (the sibling `tuistate.New()` failure right above it already uses `slog.Warn`).

Switch the `history.New()` failure path in `pkg/tui/tui.go` to use `slog.Warn` so it lands in the debug log like every other non-fatal TUI startup error.