### PR TITLE
anthropic: switch opus 4.6/4.7 token thinking budgets to adaptive

### DIFF
--- a/pkg/model/provider/anthropic/thinking.go
+++ b/pkg/model/provider/anthropic/thinking.go
@@ -140,6 +140,12 @@ func (c *Client) coerceAdaptiveThinking() *latest.ThinkingBudget {
 	if _, ok := anthropicThinkingEffort(budget); ok {
 		return budget // already adaptive or effort-based.
 	}
+	// Only coerce a real, positive token budget. Disabled/zero/negative
+	// budgets are passed through so downstream code keeps treating them as
+	// "thinking off" instead of silently enabling adaptive thinking.
+	if budget.IsDisabled() || budget.Tokens <= 0 {
+		return budget
+	}
 	if !requiresAdaptiveThinking(c.ModelConfig.Model) {
 		return budget
 	}

--- a/pkg/model/provider/anthropic/thinking.go
+++ b/pkg/model/provider/anthropic/thinking.go
@@ -32,6 +32,11 @@ func (c *Client) adjustMaxTokensForThinking(maxTokens int64) (int64, error) {
 	if _, ok := anthropicThinkingEffort(c.ModelConfig.ThinkingBudget); ok {
 		return maxTokens, nil
 	}
+	// Models that require adaptive thinking will have their token budget coerced
+	// to adaptive at request time, so no adjustment is needed here either.
+	if requiresAdaptiveThinking(c.ModelConfig.Model) {
+		return maxTokens, nil
+	}
 
 	thinkingTokens := int64(c.ModelConfig.ThinkingBudget.Tokens)
 	if thinkingTokens <= 0 {
@@ -105,6 +110,45 @@ func validThinkingTokens(tokens, maxTokens int64) (int64, bool) {
 	return tokens, true
 }
 
+// requiresAdaptiveThinking reports whether the given Anthropic model rejects
+// `thinking.type=enabled` (token-based extended thinking) and instead requires
+// `thinking.type=adaptive`.
+//
+// As of late 2025, Anthropic's API rejects token-based thinking budgets for
+// Claude Opus 4.6 and 4.7 (and their dated variants). For these models we
+// transparently switch token-based budgets to adaptive thinking. See:
+// https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking
+func requiresAdaptiveThinking(model string) bool {
+	m := strings.ToLower(strings.TrimSpace(model))
+	for _, prefix := range []string{"claude-opus-4-6", "claude-opus-4-7"} {
+		if m == prefix || strings.HasPrefix(m, prefix+"-") {
+			return true
+		}
+	}
+	return false
+}
+
+// coerceAdaptiveThinking returns an adaptive ThinkingBudget when the configured
+// model rejects token-based thinking budgets but the user supplied one.
+// Otherwise it returns the configured budget unchanged. It never mutates
+// c.ModelConfig.ThinkingBudget.
+func (c *Client) coerceAdaptiveThinking() *latest.ThinkingBudget {
+	budget := c.ModelConfig.ThinkingBudget
+	if budget == nil {
+		return nil
+	}
+	if _, ok := anthropicThinkingEffort(budget); ok {
+		return budget // already adaptive or effort-based.
+	}
+	if !requiresAdaptiveThinking(c.ModelConfig.Model) {
+		return budget
+	}
+	slog.Warn("Anthropic: model rejects token-based thinking budgets; switching to adaptive thinking",
+		"model", c.ModelConfig.Model,
+		"thinking_budget_tokens", budget.Tokens)
+	return &latest.ThinkingBudget{Effort: "adaptive"}
+}
+
 // anthropicThinkingEffort returns the Anthropic API effort level for the given
 // ThinkingBudget. It covers both explicit adaptive mode and string effort
 // levels. Returns ("", false) when the budget uses token counts or is nil.
@@ -165,7 +209,7 @@ func anthropicThinkingDisplay(opts map[string]any) (string, bool) {
 // based on the model's ThinkingBudget and provider_opts.thinking_display.
 // Returns true when thinking is enabled (i.e., temperature/top_p must not be set).
 func (c *Client) applyThinkingConfig(params *anthropic.MessageNewParams, maxTokens int64) bool {
-	budget := c.ModelConfig.ThinkingBudget
+	budget := c.coerceAdaptiveThinking()
 	if budget == nil {
 		return false
 	}
@@ -197,7 +241,7 @@ func (c *Client) applyThinkingConfig(params *anthropic.MessageNewParams, maxToke
 // applyBetaThinkingConfig configures extended thinking on a BetaMessageNewParams
 // based on the model's ThinkingBudget and provider_opts.thinking_display.
 func (c *Client) applyBetaThinkingConfig(params *anthropic.BetaMessageNewParams, maxTokens int64) {
-	budget := c.ModelConfig.ThinkingBudget
+	budget := c.coerceAdaptiveThinking()
 	if budget == nil {
 		return
 	}

--- a/pkg/model/provider/anthropic/thinking.go
+++ b/pkg/model/provider/anthropic/thinking.go
@@ -114,9 +114,9 @@ func validThinkingTokens(tokens, maxTokens int64) (int64, bool) {
 // `thinking.type=enabled` (token-based extended thinking) and instead requires
 // `thinking.type=adaptive`.
 //
-// As of late 2025, Anthropic's API rejects token-based thinking budgets for
-// Claude Opus 4.6 and 4.7 (and their dated variants). For these models we
-// transparently switch token-based budgets to adaptive thinking. See:
+// Anthropic's API rejects token-based thinking budgets for Claude Opus 4.6 and
+// 4.7 (and their dated variants). For these models we transparently switch
+// token-based budgets to adaptive thinking. See:
 // https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking
 func requiresAdaptiveThinking(model string) bool {
 	m := strings.ToLower(strings.TrimSpace(model))

--- a/pkg/model/provider/anthropic/thinking_test.go
+++ b/pkg/model/provider/anthropic/thinking_test.go
@@ -480,6 +480,22 @@ func TestCoerceAdaptiveThinking(t *testing.T) {
 		c := clientWithModel("claude-opus-4-7", in, nil)
 		assert.Same(t, in, c.coerceAdaptiveThinking())
 	})
+
+	// Disabled or non-positive token budgets must NOT be silently coerced to
+	// adaptive thinking on Opus 4.6/4.7 — the user has either explicitly
+	// disabled thinking or supplied an invalid value.
+	disabledCases := map[string]*latest.ThinkingBudget{
+		"thinking_budget: 0":            {Tokens: 0},
+		"thinking_budget: none":         {Effort: "none"},
+		"effort=none with stray tokens": {Effort: "none", Tokens: 99},
+		"negative tokens":               {Tokens: -5},
+	}
+	for name, in := range disabledCases {
+		t.Run("opus-4-7 "+name+" passes through", func(t *testing.T) {
+			c := clientWithModel("claude-opus-4-7", in, nil)
+			assert.Same(t, in, c.coerceAdaptiveThinking())
+		})
+	}
 }
 
 func TestInterleavedThinkingEnabled(t *testing.T) {

--- a/pkg/model/provider/anthropic/thinking_test.go
+++ b/pkg/model/provider/anthropic/thinking_test.go
@@ -1,6 +1,7 @@
 package anthropic
 
 import (
+	"cmp"
 	"encoding/json"
 	"testing"
 
@@ -96,14 +97,25 @@ func TestAnthropicThinkingDisplay(t *testing.T) {
 	}
 }
 
+// defaultTestModel is an Anthropic model that does NOT require the
+// adaptive-thinking workaround, so token-based thinking budgets are
+// preserved as-is.
+const defaultTestModel = "claude-sonnet-4-5"
+
 // clientWith builds a minimal Client with the given ThinkingBudget and
-// provider_opts for use in thinking-config tests.
+// provider_opts on defaultTestModel.
 func clientWith(budget *latest.ThinkingBudget, opts map[string]any) *Client {
+	return clientWithModel(defaultTestModel, budget, opts)
+}
+
+// clientWithModel is like clientWith but lets the test pick the model name,
+// which matters for behaviors like the Opus 4.6/4.7 adaptive-thinking switch.
+func clientWithModel(model string, budget *latest.ThinkingBudget, opts map[string]any) *Client {
 	return &Client{
 		Config: base.Config{
 			ModelConfig: latest.ModelConfig{
 				Provider:       "anthropic",
-				Model:          "claude-opus-4-7",
+				Model:          model,
 				ThinkingBudget: budget,
 				ProviderOpts:   opts,
 			},
@@ -114,6 +126,7 @@ func clientWith(budget *latest.ThinkingBudget, opts map[string]any) *Client {
 func TestApplyThinkingConfig(t *testing.T) {
 	tests := []struct {
 		name            string
+		model           string // optional; defaults to a non-Opus-4-6/4-7 model.
 		budget          *latest.ThinkingBudget
 		opts            map[string]any
 		maxTokens       int64
@@ -193,11 +206,49 @@ func TestApplyThinkingConfig(t *testing.T) {
 			wantEnabled: true,
 			wantTokens:  2048,
 		},
+		{
+			name:         "opus-4-6 token budget auto-switches to adaptive",
+			model:        "claude-opus-4-6",
+			budget:       &latest.ThinkingBudget{Tokens: 4096},
+			maxTokens:    8192,
+			wantEnabled:  true,
+			wantAdaptive: true,
+			wantEffort:   "high",
+		},
+		{
+			name:         "opus-4-7 token budget auto-switches to adaptive",
+			model:        "claude-opus-4-7",
+			budget:       &latest.ThinkingBudget{Tokens: 4096},
+			maxTokens:    8192,
+			wantEnabled:  true,
+			wantAdaptive: true,
+			wantEffort:   "high",
+		},
+		{
+			name:            "opus-4-6 dated variant token budget auto-switches to adaptive",
+			model:           "claude-opus-4-6-20251101",
+			budget:          &latest.ThinkingBudget{Tokens: 8000},
+			opts:            map[string]any{"thinking_display": "summarized"},
+			maxTokens:       16384,
+			wantEnabled:     true,
+			wantAdaptive:    true,
+			wantEffort:      "high",
+			wantDisplayJSON: "summarized",
+		},
+		{
+			name:         "opus-4-6 explicit adaptive budget is preserved",
+			model:        "claude-opus-4-6",
+			budget:       &latest.ThinkingBudget{Effort: "adaptive/low"},
+			maxTokens:    8192,
+			wantEnabled:  true,
+			wantAdaptive: true,
+			wantEffort:   "low",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := clientWith(tt.budget, tt.opts)
+			c := clientWithModel(cmp.Or(tt.model, defaultTestModel), tt.budget, tt.opts)
 			params := anthropic.MessageNewParams{}
 
 			gotEnabled := c.applyThinkingConfig(&params, tt.maxTokens)
@@ -235,6 +286,7 @@ func TestApplyThinkingConfig(t *testing.T) {
 func TestApplyBetaThinkingConfig(t *testing.T) {
 	tests := []struct {
 		name            string
+		model           string // optional; defaults to a non-Opus-4-6/4-7 model.
 		budget          *latest.ThinkingBudget
 		opts            map[string]any
 		maxTokens       int64
@@ -272,11 +324,29 @@ func TestApplyBetaThinkingConfig(t *testing.T) {
 			budget:    &latest.ThinkingBudget{Tokens: 100},
 			maxTokens: 8192,
 		},
+		{
+			name:         "opus-4-6 token budget auto-switches to adaptive",
+			model:        "claude-opus-4-6",
+			budget:       &latest.ThinkingBudget{Tokens: 4096},
+			maxTokens:    8192,
+			wantAdaptive: true,
+			wantEffort:   "high",
+		},
+		{
+			name:            "opus-4-7 token budget auto-switches to adaptive with display",
+			model:           "claude-opus-4-7",
+			budget:          &latest.ThinkingBudget{Tokens: 4096},
+			opts:            map[string]any{"thinking_display": "omitted"},
+			maxTokens:       8192,
+			wantAdaptive:    true,
+			wantEffort:      "high",
+			wantDisplayJSON: "omitted",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := clientWith(tt.budget, tt.opts)
+			c := clientWithModel(cmp.Or(tt.model, defaultTestModel), tt.budget, tt.opts)
 			params := anthropic.BetaMessageNewParams{}
 
 			c.applyBetaThinkingConfig(&params, tt.maxTokens)
@@ -334,6 +404,81 @@ func TestAdjustMaxTokensForThinking(t *testing.T) {
 		_, err := c.adjustMaxTokensForThinking(8192)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "max_tokens")
+	})
+
+	t.Run("opus-4-6 with token budget skips adjustment (will be coerced to adaptive)", func(t *testing.T) {
+		c := clientWithModel("claude-opus-4-6", &latest.ThinkingBudget{Tokens: 16384}, nil)
+		got, err := c.adjustMaxTokensForThinking(8192)
+		require.NoError(t, err)
+		assert.Equal(t, int64(8192), got)
+	})
+
+	t.Run("opus-4-7 with token budget skips adjustment (will be coerced to adaptive)", func(t *testing.T) {
+		c := clientWithModel("claude-opus-4-7-20251101", &latest.ThinkingBudget{Tokens: 16384}, nil)
+		userMax := int64(8192)
+		c.ModelConfig.MaxTokens = &userMax
+		got, err := c.adjustMaxTokensForThinking(8192)
+		require.NoError(t, err)
+		assert.Equal(t, int64(8192), got)
+	})
+}
+
+func TestRequiresAdaptiveThinking(t *testing.T) {
+	tests := []struct {
+		model string
+		want  bool
+	}{
+		{"claude-opus-4-6", true},
+		{"claude-opus-4-7", true},
+		{"claude-opus-4-6-20251101", true},
+		{"claude-opus-4-7-20260101", true},
+		{"CLAUDE-OPUS-4-7", true},     // case-insensitive
+		{"  claude-opus-4-6  ", true}, // trims whitespace
+		{"claude-opus-4-5", false},
+		{"claude-opus-4-5-20251015", false},
+		{"claude-opus-4-8", false},
+		{"claude-sonnet-4-7", false},
+		{"claude-sonnet-4-5", false},
+		{"claude-haiku-4-5", false},
+		{"claude-opus-4-60", false}, // not a real model and must not match
+		{"claude-opus-4-70", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			assert.Equal(t, tt.want, requiresAdaptiveThinking(tt.model))
+		})
+	}
+}
+
+func TestCoerceAdaptiveThinking(t *testing.T) {
+	t.Run("nil budget stays nil", func(t *testing.T) {
+		c := clientWithModel("claude-opus-4-7", nil, nil)
+		assert.Nil(t, c.coerceAdaptiveThinking())
+	})
+
+	t.Run("non-affected model preserves token budget", func(t *testing.T) {
+		in := &latest.ThinkingBudget{Tokens: 4096}
+		c := clientWithModel(defaultTestModel, in, nil)
+		assert.Same(t, in, c.coerceAdaptiveThinking(), "budget pointer must not be replaced")
+	})
+
+	t.Run("opus-4-6 token budget is coerced to adaptive", func(t *testing.T) {
+		in := &latest.ThinkingBudget{Tokens: 4096}
+		c := clientWithModel("claude-opus-4-6", in, nil)
+		got := c.coerceAdaptiveThinking()
+		require.NotNil(t, got)
+		assert.Equal(t, "adaptive", got.Effort)
+		assert.Equal(t, 0, got.Tokens)
+		// Original must not be mutated.
+		assert.Equal(t, 4096, in.Tokens)
+		assert.Empty(t, in.Effort)
+	})
+
+	t.Run("opus-4-7 adaptive budget is preserved as-is", func(t *testing.T) {
+		in := &latest.ThinkingBudget{Effort: "adaptive/low"}
+		c := clientWithModel("claude-opus-4-7", in, nil)
+		assert.Same(t, in, c.coerceAdaptiveThinking())
 	})
 }
 


### PR DESCRIPTION
Anthropic's API rejects `thinking.type=enabled` (token-based extended thinking) for Claude Opus 4.6 and 4.7. When a user configures a token-based `thinking_budget` for those models, the request now fails at the provider.

This change makes the Anthropic provider transparently switch a token-based budget to adaptive thinking (default `high` effort) on Opus 4.6 / 4.7 (including dated variants like `claude-opus-4-6-20251101`), with a `slog.Warn` so the substitution is visible. Other models keep the existing token-based path unchanged.

### Behavior

- `claude-opus-4-6` / `claude-opus-4-7` (and `*-<date>`) + `thinking_budget: <tokens>` → `thinking.type=adaptive`, `output_config.effort=high`.
- Same models + explicit `thinking_budget: adaptive` (or `adaptive/<level>`) → preserved as-is.
- Same models + disabled / zero / negative budgets (`thinking_budget: 0`, `thinking_budget: none`, negative tokens) → passed through untouched, so thinking stays off. (Important: without this guard, those would have been silently flipped to adaptive thinking.)
- Any other model → unchanged.
- `max_tokens` auto-adjustment is skipped when the budget will be coerced, so an oversized token budget on Opus 4.6/4.7 no longer errors out or inflates `max_tokens`.

### Tests

- `TestRequiresAdaptiveThinking` covers prefix matching, dated variants, case/whitespace, and non-matches like `claude-opus-4-60`, sonnet/haiku models, etc.
- `TestCoerceAdaptiveThinking` covers the coercion path, the no-op paths (already adaptive, non-affected model), and the disabled/non-positive guards.
- `TestApplyThinkingConfig` and `TestApplyBetaThinkingConfig` gain Opus 4.6/4.7 cases verifying both SDK type families end up with `OfAdaptive` set, the right effort, and `thinking_display` preserved.
- `TestAdjustMaxTokensForThinking` gains Opus 4.6/4.7 cases verifying no error / no auto-adjust.

`golangci-lint run ./...` → 0 issues. `go test ./...` → all packages pass.