### PR TITLE
test: stop example tests from writing SQLite files into examples/

### DIFF
--- a/pkg/teamloader/teamloader_test.go
+++ b/pkg/teamloader/teamloader_test.go
@@ -76,9 +76,51 @@ func TestGetToolsForAgent_ContinuesOnCreateToolError(t *testing.T) {
 func TestLoadExamples(t *testing.T) {
 	examples := collectExamples(t)
 
-	// Collect required env vars from all examples by checking configs directly.
-	// This avoids calling Load() twice for each example.
-	missingEnvs := make(map[string]bool)
+	// Set every env var referenced by the examples to a dummy value so model
+	// and tool initialisation succeeds without real credentials.
+	for env := range gatherExampleEnvVars(t, examples) {
+		t.Setenv(env, "dummy")
+	}
+
+	for _, agentFilename := range examples {
+		t.Run(agentFilename, func(t *testing.T) {
+			t.Parallel()
+
+			data, err := os.ReadFile(agentFilename)
+			require.NoError(t, err)
+
+			// Examples must not pin a version: they should always parse with
+			// the latest config schema.
+			var v struct {
+				Version string `yaml:"version"`
+			}
+			require.NoError(t, yaml.Unmarshal(data, &v))
+			require.Empty(t, v.Version, "example %s should not define a version", agentFilename)
+
+			// Use a bytes source (ParentDir == "") plus a temp WorkingDir so
+			// toolsets that write to disk (memory, RAG, cache, ...) land in
+			// the temp dir instead of the examples/ tree.
+			agentSource := config.NewBytesSource(agentFilename, data)
+			runConfig := &config.RuntimeConfig{}
+			runConfig.WorkingDir = t.TempDir()
+
+			teams, err := Load(t.Context(), agentSource, runConfig)
+			if errors.Is(err, dmr.ErrNotInstalled) && filepath.Base(agentFilename) == "dmr.yaml" {
+				t.Skip("Skipping DMR example: Docker Model Runner not installed")
+			}
+			require.NoError(t, err)
+			assert.NotEmpty(t, teams)
+		})
+	}
+}
+
+// gatherExampleEnvVars returns the union of env vars referenced by the given
+// example files (both for models and toolsets). The set is collected up-front
+// so t.Setenv can be called before any subtest starts.
+func gatherExampleEnvVars(t *testing.T, examples []string) map[string]bool {
+	t.Helper()
+
+	envs := make(map[string]bool)
 	for _, agentFilename := range examples {
 		agentSource, err := config.Resolve(agentFilename, nil)
 		require.NoError(t, err)
@@ -87,57 +129,14 @@ func TestLoadExamples(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, env := range config.GatherEnvVarsForModels(cfg) {
-			missingEnvs[env] = true
+			envs[env] = true
 		}
-
 		toolEnvs, _ := config.GatherEnvVarsForTools(t.Context(), cfg)
 		for _, env := range toolEnvs {
-			missingEnvs[env] = true
+			envs[env] = true
 		}
 	}
-
-	for name := range missingEnvs {
-		t.Setenv(name, "dummy")
-	}
-
-	type versioned struct {
-		Version string `yaml:"version"`
-	}
-
-	// Load all the examples.
-	for _, agentFilename := range examples {
-		t.Run(agentFilename, func(t *testing.T) {
-			t.Parallel()
-
-			data, err := os.ReadFile(agentFilename)
-			require.NoError(t, err)
-
-			// First make sure it doesn't define a version
-			var v versioned
-			err = yaml.Unmarshal(data, &v)
-			require.NoError(t, err)
-			require.Empty(t, v.Version, "example %s should not define a version", agentFilename)
-
-			// Use a bytes source (ParentDir == "") combined with a temp WorkingDir
-			// so toolsets that create files on disk write into the temp dir.
-			agentSource := config.NewBytesSource(agentFilename, data)
-			runConfig := &config.RuntimeConfig{
-				Config: config.Config{
-					WorkingDir: t.TempDir(),
-				},
-			}
-
-			// Then make sure the config loads successfully
-			teams, err := Load(t.Context(), agentSource, runConfig)
-			if err != nil {
-				if errors.Is(err, dmr.ErrNotInstalled) && filepath.Base(agentFilename) == "dmr.yaml" {
-					t.Skip("Skipping DMR example: Docker Model Runner not installed")
-				}
-			}
-			require.NoError(t, err)
-			assert.NotEmpty(t, teams)
-		})
-	}
+	return envs
 }
 
 func TestLoadDefaultAgent(t *testing.T) {

--- a/pkg/teamloader/teamloader_test.go
+++ b/pkg/teamloader/teamloader_test.go
@@ -100,28 +100,32 @@ func TestLoadExamples(t *testing.T) {
 		t.Setenv(name, "dummy")
 	}
 
-	runConfig := &config.RuntimeConfig{}
-
 	type versioned struct {
 		Version string `yaml:"version"`
 	}
 
 	// Load all the examples.
-	// Note: don't use t.Parallel() to avoid SQLite lock contention when
-	// multiple RAG examples share the same relative database paths (e.g., ./bm25.db).
 	for _, agentFilename := range examples {
 		t.Run(agentFilename, func(t *testing.T) {
-			agentSource, err := config.Resolve(agentFilename, nil)
+			t.Parallel()
+
+			data, err := os.ReadFile(agentFilename)
 			require.NoError(t, err)
 
 			// First make sure it doesn't define a version
-			data, err := agentSource.Read(t.Context())
-			require.NoError(t, err)
-
 			var v versioned
 			err = yaml.Unmarshal(data, &v)
 			require.NoError(t, err)
 			require.Empty(t, v.Version, "example %s should not define a version", agentFilename)
+
+			// Use a bytes source (ParentDir == "") combined with a temp WorkingDir
+			// so toolsets that create files on disk write into the temp dir.
+			agentSource := config.NewBytesSource(agentFilename, data)
+			runConfig := &config.RuntimeConfig{
+				Config: config.Config{
+					WorkingDir: t.TempDir(),
+				},
+			}
 
 			// Then make sure the config loads successfully
 			teams, err := Load(t.Context(), agentSource, runConfig)


### PR DESCRIPTION
Some examples (memory, RAG, response cache) define toolsets with relative paths
like \`./funny.db\`, \`./bm25.db\`, \`./cache.json\`. When \`TestLoadExamples\` ran,
the loader resolved those against the example file's parent directory, so the
test was creating real SQLite/JSON files inside the \`examples/\` tree.

Fix: in the test, wrap the example bytes in a \`config.NewBytesSource\` (whose
\`ParentDir()\` returns \`""\`) and set \`runConfig.WorkingDir\` to a per-subtest
\`t.TempDir()\`. The existing \`cmp.Or(agentSource.ParentDir(), runConfig.WorkingDir)\`
fallback in the loader then redirects every relative path into the temp dir.

Bonus: since each subtest now has its own temp dir, the previous SQLite-lock
contention between examples that share relative DB names is gone, so the
subtests run in parallel.

A second commit tidies up \`TestLoadExamples\` (extracts an env-gathering
helper, inlines the anonymous \`versioned\` struct, drops a redundant
\`if err != nil\` wrapper around an \`errors.Is\` check, and flattens the
\`RuntimeConfig\` literal).