### PR TITLE
Simplify the history package

### DIFF
--- a/pkg/history/history.go
+++ b/pkg/history/history.go
@@ -1,11 +1,11 @@
 package history
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"slices"
-	"strconv"
 	"strings"
 )
 
@@ -86,13 +86,8 @@ func (h *History) migrateOldHistory(homeDir string) error {
 }
 
 func (h *History) Add(message string) error {
-	// Update in-memory list: remove duplicate and append to end
-	h.Messages = slices.DeleteFunc(h.Messages, func(m string) bool {
-		return m == message
-	})
-	h.Messages = append(h.Messages, message)
+	h.addInMemory(message)
 	h.current = len(h.Messages)
-
 	return h.append(message)
 }
 
@@ -100,19 +95,12 @@ func (h *History) Previous() string {
 	if len(h.Messages) == 0 {
 		return ""
 	}
-
-	// If we're at -1 (initial state), start from the end
-	if h.current == -1 {
+	switch {
+	case h.current == -1:
 		h.current = len(h.Messages) - 1
-		return h.Messages[h.current]
+	case h.current > 0:
+		h.current--
 	}
-
-	// If we're at the beginning, stay there
-	if h.current <= 0 {
-		return h.Messages[0]
-	}
-
-	h.current--
 	return h.Messages[h.current]
 }
 
@@ -120,21 +108,18 @@ func (h *History) Next() string {
 	if len(h.Messages) == 0 {
 		return ""
 	}
-
 	if h.current >= len(h.Messages)-1 {
 		h.current = len(h.Messages)
 		return ""
 	}
-
 	h.current++
 	return h.Messages[h.current]
 }
 
 // LatestMatch returns the most recent history entry that extends the provided
-// prefix, or the latest message when no prefix is supplied.
+// prefix, or an empty string when none does.
 func (h *History) LatestMatch(prefix string) string {
-	for i := len(h.Messages) - 1; i >= 0; i-- {
-		msg := h.Messages[i]
+	for _, msg := range slices.Backward(h.Messages) {
 		if strings.HasPrefix(msg, prefix) && len(msg) > len(prefix) {
 			return msg
 		}
@@ -147,44 +132,40 @@ func (h *History) LatestMatch(prefix string) string {
 // Returns the matched message, its index, and whether a match was found.
 // An empty query matches any entry.
 func (h *History) FindPrevContains(query string, from int) (msg string, idx int, ok bool) {
-	if len(h.Messages) == 0 {
-		return "", -1, false
-	}
-
-	start := min(from-1, len(h.Messages)-1)
-
 	query = strings.ToLower(query)
-	for i := start; i >= 0; i-- {
+	for i := min(from-1, len(h.Messages)-1); i >= 0; i-- {
 		if query == "" || strings.Contains(strings.ToLower(h.Messages[i]), query) {
 			return h.Messages[i], i, true
 		}
 	}
-
 	return "", -1, false
 }
 
 // FindNextContains searches forward through history for a message containing query.
 // from is an exclusive lower bound index. Pass -1 to start from the oldest.
 // Returns the matched message, its index, and whether a match was found.
+// An empty query matches any entry.
 func (h *History) FindNextContains(query string, from int) (msg string, idx int, ok bool) {
-	if len(h.Messages) == 0 {
-		return "", -1, false
-	}
-
-	start := max(from+1, 0)
-
 	query = strings.ToLower(query)
-	for i := start; i < len(h.Messages); i++ {
+	for i := max(from+1, 0); i < len(h.Messages); i++ {
 		if query == "" || strings.Contains(strings.ToLower(h.Messages[i]), query) {
 			return h.Messages[i], i, true
 		}
 	}
-
 	return "", -1, false
 }
 
 func (h *History) SetCurrent(i int) {
 	h.current = i
+}
+
+// addInMemory removes any prior occurrence of message and appends it as the
+// most recent entry.
+func (h *History) addInMemory(message string) {
+	h.Messages = slices.DeleteFunc(h.Messages, func(m string) bool {
+		return m == message
+	})
+	h.Messages = append(h.Messages, message)
 }
 
 func (h *History) append(message string) error {
@@ -213,51 +194,19 @@ func (h *History) load() error {
 		return err
 	}
 
-	// Count lines to pre-size the slice.
-	n := 0
-	for _, b := range data {
-		if b == '\n' {
-			n++
-		}
-	}
-
-	// Parse all lines. Each line is a JSON-encoded string (e.g. "hello").
-	// strconv.Unquote handles the same escape sequences as JSON and is
-	// much faster than json.Unmarshal for quoted strings.
-	all := make([]string, 0, n)
-	s := string(data)
-	for s != "" {
-		i := strings.IndexByte(s, '\n')
-		var line string
-		if i < 0 {
-			line = s
-			s = ""
-		} else {
-			line = s[:i]
-			s = s[i+1:]
-		}
-		if line == "" {
+	// The file is append-only with one JSON-encoded string per line.
+	// Replaying each entry through addInMemory naturally deduplicates,
+	// keeping the latest occurrence of each message.
+	for line := range bytes.Lines(data) {
+		line = bytes.TrimRight(line, "\n")
+		if len(line) == 0 {
 			continue
 		}
-
-		message, err := strconv.Unquote(line)
-		if err != nil {
+		var msg string
+		if err := json.Unmarshal(line, &msg); err != nil {
 			continue
 		}
-		all = append(all, message)
+		h.addInMemory(msg)
 	}
-
-	// Deduplicate keeping the latest occurrence of each message.
-	seen := make(map[string]struct{}, len(all))
-	h.Messages = make([]string, 0, len(all))
-	for i := len(all) - 1; i >= 0; i-- {
-		if _, dup := seen[all[i]]; dup {
-			continue
-		}
-		seen[all[i]] = struct{}{}
-		h.Messages = append(h.Messages, all[i])
-	}
-	slices.Reverse(h.Messages)
-
 	return nil
 }

--- a/pkg/history/history.go
+++ b/pkg/history/history.go
@@ -71,9 +71,11 @@ func (h *History) Next() string {
 	return h.Messages[h.current]
 }
 
-// SetCurrent positions the cursor at index i.
+// SetCurrent positions the cursor at index i, clamped to [0, len(Messages)].
+// Keeping the cursor in this range guarantees that subsequent Previous and
+// Next calls never index out of bounds.
 func (h *History) SetCurrent(i int) {
-	h.current = i
+	h.current = max(0, min(i, len(h.Messages)))
 }
 
 // LatestMatch returns the most recent entry that strictly extends prefix, or
@@ -152,7 +154,7 @@ func (h *History) load() error {
 	}
 
 	for line := range bytes.Lines(data) {
-		line = bytes.TrimRight(line, "\n")
+		line = bytes.TrimSuffix(line, []byte("\n"))
 		if len(line) == 0 {
 			continue
 		}

--- a/pkg/history/history.go
+++ b/pkg/history/history.go
@@ -1,3 +1,5 @@
+// Package history persists the user's command/message history in an
+// append-only file and provides cursor-based navigation and search over it.
 package history
 
 import (
@@ -9,57 +11,164 @@ import (
 	"strings"
 )
 
+// History is the in-memory view of a persistent message history. The cursor
+// (used by [History.Previous] and [History.Next]) stays in [0, len(Messages)],
+// where len(Messages) means "past the most recent entry".
 type History struct {
-	Messages []string `json:"messages"`
+	Messages []string
 
 	path    string
 	current int
 }
 
-type options struct {
-	homeDir string
-}
-
-type Opt func(*options)
-
-func WithBaseDir(dir string) Opt {
-	return func(o *options) {
-		o.homeDir = dir
-	}
-}
-
-func New(opts ...Opt) (*History, error) {
-	o := &options{}
-	for _, opt := range opts {
-		opt(o)
-	}
-
-	homeDir := o.homeDir
-	if homeDir == "" {
+// New loads the history stored under baseDir/.cagent/history. If baseDir is
+// empty, the user's home directory is used.
+func New(baseDir string) (*History, error) {
+	if baseDir == "" {
 		var err error
-		if homeDir, err = os.UserHomeDir(); err != nil {
+		if baseDir, err = os.UserHomeDir(); err != nil {
 			return nil, err
 		}
 	}
 
-	h := &History{
-		path:    filepath.Join(homeDir, ".cagent", "history"),
-		current: -1,
-	}
-
-	if err := h.migrateOldHistory(homeDir); err != nil {
+	h := &History{path: filepath.Join(baseDir, ".cagent", "history")}
+	if err := h.migrateOldHistory(baseDir); err != nil {
 		return nil, err
 	}
-
 	if err := h.load(); err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
-
+	h.current = len(h.Messages)
 	return h, nil
 }
 
-func (h *History) migrateOldHistory(homeDir string) error {
-	oldPath := filepath.Join(homeDir, ".cagent", "history.json")
+// Add records a new message. Any prior occurrence of the same message is
+// removed and the new one becomes the most recent entry.
+func (h *History) Add(message string) error {
+	h.addInMemory(message)
+	h.current = len(h.Messages)
+	return h.append(message)
+}
+
+// Previous moves the cursor one step toward older entries and returns the
+// entry under it. At the oldest entry, the cursor stays put.
+func (h *History) Previous() string {
+	if len(h.Messages) == 0 {
+		return ""
+	}
+	h.current = max(h.current-1, 0)
+	return h.Messages[h.current]
+}
+
+// Next moves the cursor one step toward newer entries and returns the entry
+// under it. Past the most recent entry, returns an empty string.
+func (h *History) Next() string {
+	if h.current >= len(h.Messages)-1 {
+		h.current = len(h.Messages)
+		return ""
+	}
+	h.current++
+	return h.Messages[h.current]
+}
+
+// SetCurrent positions the cursor at index i.
+func (h *History) SetCurrent(i int) {
+	h.current = i
+}
+
+// LatestMatch returns the most recent entry that strictly extends prefix, or
+// an empty string when none does.
+func (h *History) LatestMatch(prefix string) string {
+	for _, msg := range slices.Backward(h.Messages) {
+		if strings.HasPrefix(msg, prefix) && len(msg) > len(prefix) {
+			return msg
+		}
+	}
+	return ""
+}
+
+// FindPrevContains searches backward from index from-1 for an entry containing
+// query (case-insensitive). An empty query matches any entry. Pass
+// len(Messages) to start from the most recent entry.
+func (h *History) FindPrevContains(query string, from int) (msg string, idx int, ok bool) {
+	query = strings.ToLower(query)
+	for i := min(from-1, len(h.Messages)-1); i >= 0; i-- {
+		if query == "" || strings.Contains(strings.ToLower(h.Messages[i]), query) {
+			return h.Messages[i], i, true
+		}
+	}
+	return "", -1, false
+}
+
+// FindNextContains searches forward from index from+1 for an entry containing
+// query (case-insensitive). An empty query matches any entry. Pass -1 to
+// start from the oldest entry.
+func (h *History) FindNextContains(query string, from int) (msg string, idx int, ok bool) {
+	query = strings.ToLower(query)
+	for i := max(from+1, 0); i < len(h.Messages); i++ {
+		if query == "" || strings.Contains(strings.ToLower(h.Messages[i]), query) {
+			return h.Messages[i], i, true
+		}
+	}
+	return "", -1, false
+}
+
+// addInMemory removes any prior occurrence of message and appends it as the
+// most recent entry.
+func (h *History) addInMemory(message string) {
+	h.Messages = slices.DeleteFunc(h.Messages, func(m string) bool {
+		return m == message
+	})
+	h.Messages = append(h.Messages, message)
+}
+
+// append writes message to the persistent history file as one JSON-encoded
+// line.
+func (h *History) append(message string) error {
+	if err := os.MkdirAll(filepath.Dir(h.path), 0o755); err != nil {
+		return err
+	}
+	encoded, err := json.Marshal(message)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.OpenFile(h.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = f.Write(append(encoded, '\n'))
+	return err
+}
+
+// load reads the persistent history file and populates Messages, deduplicating
+// entries while keeping the latest occurrence of each.
+func (h *History) load() error {
+	data, err := os.ReadFile(h.path)
+	if err != nil {
+		return err
+	}
+
+	for line := range bytes.Lines(data) {
+		line = bytes.TrimRight(line, "\n")
+		if len(line) == 0 {
+			continue
+		}
+		var msg string
+		if err := json.Unmarshal(line, &msg); err != nil {
+			continue
+		}
+		h.addInMemory(msg)
+	}
+	return nil
+}
+
+// migrateOldHistory imports messages from the legacy history.json file (if it
+// exists) into the new line-oriented format and removes the old file.
+func (h *History) migrateOldHistory(baseDir string) error {
+	oldPath := filepath.Join(baseDir, ".cagent", "history.json")
 
 	data, err := os.ReadFile(oldPath)
 	if os.IsNotExist(err) {
@@ -81,132 +190,5 @@ func (h *History) migrateOldHistory(homeDir string) error {
 			return err
 		}
 	}
-
 	return os.Remove(oldPath)
-}
-
-func (h *History) Add(message string) error {
-	h.addInMemory(message)
-	h.current = len(h.Messages)
-	return h.append(message)
-}
-
-func (h *History) Previous() string {
-	if len(h.Messages) == 0 {
-		return ""
-	}
-	switch {
-	case h.current == -1:
-		h.current = len(h.Messages) - 1
-	case h.current > 0:
-		h.current--
-	}
-	return h.Messages[h.current]
-}
-
-func (h *History) Next() string {
-	if len(h.Messages) == 0 {
-		return ""
-	}
-	if h.current >= len(h.Messages)-1 {
-		h.current = len(h.Messages)
-		return ""
-	}
-	h.current++
-	return h.Messages[h.current]
-}
-
-// LatestMatch returns the most recent history entry that extends the provided
-// prefix, or an empty string when none does.
-func (h *History) LatestMatch(prefix string) string {
-	for _, msg := range slices.Backward(h.Messages) {
-		if strings.HasPrefix(msg, prefix) && len(msg) > len(prefix) {
-			return msg
-		}
-	}
-	return ""
-}
-
-// FindPrevContains searches backward through history for a message containing query.
-// from is an exclusive upper bound index. Pass len(Messages) to start from the most recent.
-// Returns the matched message, its index, and whether a match was found.
-// An empty query matches any entry.
-func (h *History) FindPrevContains(query string, from int) (msg string, idx int, ok bool) {
-	query = strings.ToLower(query)
-	for i := min(from-1, len(h.Messages)-1); i >= 0; i-- {
-		if query == "" || strings.Contains(strings.ToLower(h.Messages[i]), query) {
-			return h.Messages[i], i, true
-		}
-	}
-	return "", -1, false
-}
-
-// FindNextContains searches forward through history for a message containing query.
-// from is an exclusive lower bound index. Pass -1 to start from the oldest.
-// Returns the matched message, its index, and whether a match was found.
-// An empty query matches any entry.
-func (h *History) FindNextContains(query string, from int) (msg string, idx int, ok bool) {
-	query = strings.ToLower(query)
-	for i := max(from+1, 0); i < len(h.Messages); i++ {
-		if query == "" || strings.Contains(strings.ToLower(h.Messages[i]), query) {
-			return h.Messages[i], i, true
-		}
-	}
-	return "", -1, false
-}
-
-func (h *History) SetCurrent(i int) {
-	h.current = i
-}
-
-// addInMemory removes any prior occurrence of message and appends it as the
-// most recent entry.
-func (h *History) addInMemory(message string) {
-	h.Messages = slices.DeleteFunc(h.Messages, func(m string) bool {
-		return m == message
-	})
-	h.Messages = append(h.Messages, message)
-}
-
-func (h *History) append(message string) error {
-	if err := os.MkdirAll(filepath.Dir(h.path), 0o755); err != nil {
-		return err
-	}
-
-	f, err := os.OpenFile(h.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	encoded, err := json.Marshal(message)
-	if err != nil {
-		return err
-	}
-
-	_, err = f.Write(append(encoded, '\n'))
-	return err
-}
-
-func (h *History) load() error {
-	data, err := os.ReadFile(h.path)
-	if err != nil {
-		return err
-	}
-
-	// The file is append-only with one JSON-encoded string per line.
-	// Replaying each entry through addInMemory naturally deduplicates,
-	// keeping the latest occurrence of each message.
-	for line := range bytes.Lines(data) {
-		line = bytes.TrimRight(line, "\n")
-		if len(line) == 0 {
-			continue
-		}
-		var msg string
-		if err := json.Unmarshal(line, &msg); err != nil {
-			continue
-		}
-		h.addInMemory(msg)
-	}
-	return nil
 }

--- a/pkg/history/history_test.go
+++ b/pkg/history/history_test.go
@@ -418,6 +418,36 @@ func TestHistory_SetCurrent(t *testing.T) {
 	assert.Empty(t, h.Next())
 }
 
+func TestHistory_SetCurrentOutOfRange(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	h, err := New(tmpDir)
+	require.NoError(t, err)
+
+	require.NoError(t, h.Add("first"))
+	require.NoError(t, h.Add("second"))
+
+	// A negative value clamps to 0; Previous returns the oldest entry.
+	h.SetCurrent(-5)
+	assert.Equal(t, "first", h.Previous())
+
+	// A value past the end clamps to len(Messages); Next returns empty.
+	h.SetCurrent(100)
+	assert.Empty(t, h.Next())
+
+	// And from the clamped position, Previous returns the latest entry.
+	h.SetCurrent(100)
+	assert.Equal(t, "second", h.Previous())
+
+	// On empty history, SetCurrent never causes a panic.
+	empty, err := New(t.TempDir())
+	require.NoError(t, err)
+	empty.SetCurrent(-5)
+	assert.Empty(t, empty.Previous())
+	empty.SetCurrent(100)
+	assert.Empty(t, empty.Next())
+}
+
 func TestHistory_VeryLongMessage(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/pkg/history/history_test.go
+++ b/pkg/history/history_test.go
@@ -12,17 +12,17 @@ import (
 func TestNew(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	h, err := New()
+	h, err := New("")
 	require.NoError(t, err)
 
-	assert.Equal(t, -1, h.current)
+	assert.Equal(t, 0, h.current)
 	assert.Empty(t, h.Messages)
 }
 
 func TestHistory_AddAndSave(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	h, err := New()
+	h, err := New("")
 	require.NoError(t, err)
 
 	messages := []string{"first", "second", "third"}
@@ -34,7 +34,7 @@ func TestHistory_AddAndSave(t *testing.T) {
 	assert.Equal(t, messages, h.Messages)
 	assert.Len(t, messages, h.current)
 
-	h2, err := New()
+	h2, err := New("")
 	require.NoError(t, err)
 	assert.Equal(t, messages, h2.Messages)
 }
@@ -42,7 +42,7 @@ func TestHistory_AddAndSave(t *testing.T) {
 func TestHistory_Navigation(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	h, err := New()
+	h, err := New("")
 	require.NoError(t, err)
 
 	assert.Empty(t, h.Previous())
@@ -66,7 +66,7 @@ func TestHistory_Navigation(t *testing.T) {
 func TestHistory_EdgeCases(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	h, err := New()
+	h, err := New("")
 	require.NoError(t, err)
 
 	assert.Empty(t, h.Previous())
@@ -82,7 +82,7 @@ func TestHistory_EdgeCases(t *testing.T) {
 func TestHistory_StayAtTheBeginning(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	h, err := New()
+	h, err := New("")
 	require.NoError(t, err)
 
 	require.NoError(t, h.Add("first"))
@@ -94,7 +94,7 @@ func TestHistory_StayAtTheBeginning(t *testing.T) {
 func TestHistory_NoDuplicateMessages(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	h, err := New()
+	h, err := New("")
 	require.NoError(t, err)
 
 	require.NoError(t, h.Add("first"))
@@ -109,7 +109,7 @@ func TestHistory_NoDuplicateMessages(t *testing.T) {
 func TestHistory_MoveDuplicateLast(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	h, err := New()
+	h, err := New("")
 	require.NoError(t, err)
 
 	require.NoError(t, h.Add("first"))
@@ -126,13 +126,13 @@ func TestHistory_MoveDuplicateLast(t *testing.T) {
 func TestHistory_MultilineMessage(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	h, err := New(WithBaseDir(tmpDir))
+	h, err := New(tmpDir)
 	require.NoError(t, err)
 
 	multiline := "line1\nline2\nline3"
 	require.NoError(t, h.Add(multiline))
 
-	h2, err := New(WithBaseDir(tmpDir))
+	h2, err := New(tmpDir)
 	require.NoError(t, err)
 
 	require.Len(t, h2.Messages, 1)
@@ -148,7 +148,7 @@ func TestHistory_MigrateOldFormat(t *testing.T) {
 
 	require.NoError(t, os.WriteFile(oldHistFile, []byte(`{"messages":["old1","old2","old3"]}`), 0o644))
 
-	h, err := New(WithBaseDir(tmpDir))
+	h, err := New(tmpDir)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"old1", "old2", "old3"}, h.Messages)
 
@@ -162,7 +162,7 @@ func TestHistory_MigrateOldFormat(t *testing.T) {
 func TestHistory_LatestMatch(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	h, err := New(WithBaseDir(tmpDir))
+	h, err := New(tmpDir)
 	require.NoError(t, err)
 
 	// Empty history returns empty string
@@ -194,7 +194,7 @@ func TestHistory_FindPrevContains(t *testing.T) {
 	t.Run("empty history", func(t *testing.T) {
 		t.Parallel()
 		tmpDir := t.TempDir()
-		h, err := New(WithBaseDir(tmpDir))
+		h, err := New(tmpDir)
 		require.NoError(t, err)
 
 		msg, idx, ok := h.FindPrevContains("test", len(h.Messages))
@@ -206,7 +206,7 @@ func TestHistory_FindPrevContains(t *testing.T) {
 	t.Run("empty query matches latest", func(t *testing.T) {
 		t.Parallel()
 		tmpDir := t.TempDir()
-		h, err := New(WithBaseDir(tmpDir))
+		h, err := New(tmpDir)
 		require.NoError(t, err)
 
 		require.NoError(t, h.Add("first"))
@@ -222,7 +222,7 @@ func TestHistory_FindPrevContains(t *testing.T) {
 	t.Run("substring match", func(t *testing.T) {
 		t.Parallel()
 		tmpDir := t.TempDir()
-		h, err := New(WithBaseDir(tmpDir))
+		h, err := New(tmpDir)
 		require.NoError(t, err)
 
 		require.NoError(t, h.Add("deploy staging"))
@@ -238,7 +238,7 @@ func TestHistory_FindPrevContains(t *testing.T) {
 	t.Run("case insensitive match", func(t *testing.T) {
 		t.Parallel()
 		tmpDir := t.TempDir()
-		h, err := New(WithBaseDir(tmpDir))
+		h, err := New(tmpDir)
 		require.NoError(t, err)
 
 		require.NoError(t, h.Add("Deploy Staging"))
@@ -253,7 +253,7 @@ func TestHistory_FindPrevContains(t *testing.T) {
 	t.Run("cycling through matches", func(t *testing.T) {
 		t.Parallel()
 		tmpDir := t.TempDir()
-		h, err := New(WithBaseDir(tmpDir))
+		h, err := New(tmpDir)
 		require.NoError(t, err)
 
 		require.NoError(t, h.Add("deploy v1"))
@@ -288,7 +288,7 @@ func TestHistory_FindPrevContains(t *testing.T) {
 	t.Run("no match", func(t *testing.T) {
 		t.Parallel()
 		tmpDir := t.TempDir()
-		h, err := New(WithBaseDir(tmpDir))
+		h, err := New(tmpDir)
 		require.NoError(t, err)
 
 		require.NoError(t, h.Add("hello"))
@@ -303,7 +303,7 @@ func TestHistory_FindPrevContains(t *testing.T) {
 	t.Run("from out of bounds", func(t *testing.T) {
 		t.Parallel()
 		tmpDir := t.TempDir()
-		h, err := New(WithBaseDir(tmpDir))
+		h, err := New(tmpDir)
 		require.NoError(t, err)
 
 		require.NoError(t, h.Add("hello"))
@@ -321,7 +321,7 @@ func TestHistory_FindNextContains(t *testing.T) {
 	t.Run("basic forward search", func(t *testing.T) {
 		t.Parallel()
 		tmpDir := t.TempDir()
-		h, err := New(WithBaseDir(tmpDir))
+		h, err := New(tmpDir)
 		require.NoError(t, err)
 
 		require.NoError(t, h.Add("deploy v1"))
@@ -337,7 +337,7 @@ func TestHistory_FindNextContains(t *testing.T) {
 	t.Run("sequential forward search", func(t *testing.T) {
 		t.Parallel()
 		tmpDir := t.TempDir()
-		h, err := New(WithBaseDir(tmpDir))
+		h, err := New(tmpDir)
 		require.NoError(t, err)
 
 		require.NoError(t, h.Add("echo 1"))
@@ -366,7 +366,7 @@ func TestHistory_FindNextContains(t *testing.T) {
 	t.Run("no match", func(t *testing.T) {
 		t.Parallel()
 		tmpDir := t.TempDir()
-		h, err := New(WithBaseDir(tmpDir))
+		h, err := New(tmpDir)
 		require.NoError(t, err)
 
 		require.NoError(t, h.Add("hello"))
@@ -380,7 +380,7 @@ func TestHistory_FindNextContains(t *testing.T) {
 	t.Run("empty history", func(t *testing.T) {
 		t.Parallel()
 		tmpDir := t.TempDir()
-		h, err := New(WithBaseDir(tmpDir))
+		h, err := New(tmpDir)
 		require.NoError(t, err)
 
 		_, _, ok := h.FindNextContains("test", -1)
@@ -390,7 +390,7 @@ func TestHistory_FindNextContains(t *testing.T) {
 	t.Run("case insensitive", func(t *testing.T) {
 		t.Parallel()
 		tmpDir := t.TempDir()
-		h, err := New(WithBaseDir(tmpDir))
+		h, err := New(tmpDir)
 		require.NoError(t, err)
 
 		require.NoError(t, h.Add("Deploy Staging"))
@@ -404,7 +404,7 @@ func TestHistory_FindNextContains(t *testing.T) {
 func TestHistory_SetCurrent(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
-	h, err := New(WithBaseDir(tmpDir))
+	h, err := New(tmpDir)
 	require.NoError(t, err)
 
 	require.NoError(t, h.Add("first"))
@@ -421,7 +421,7 @@ func TestHistory_SetCurrent(t *testing.T) {
 func TestHistory_VeryLongMessage(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	h, err := New(WithBaseDir(tmpDir))
+	h, err := New(tmpDir)
 	require.NoError(t, err)
 
 	// Create a message longer than bufio.Scanner's default 64KB limit
@@ -435,7 +435,7 @@ func TestHistory_VeryLongMessage(t *testing.T) {
 	require.NoError(t, h.Add("short message after"))
 
 	// Reload history from disk
-	h2, err := New(WithBaseDir(tmpDir))
+	h2, err := New(tmpDir)
 	require.NoError(t, err)
 
 	require.Len(t, h2.Messages, 2)

--- a/pkg/tui/components/editor/historysearch_test.go
+++ b/pkg/tui/components/editor/historysearch_test.go
@@ -22,7 +22,7 @@ func TestHistorySearch(t *testing.T) {
 	setupEditor := func(t *testing.T, messages []string) *editor {
 		t.Helper()
 		tmpDir := t.TempDir()
-		h, err := history.New(history.WithBaseDir(tmpDir))
+		h, err := history.New(tmpDir)
 		require.NoError(t, err)
 
 		for _, msg := range messages {

--- a/pkg/tui/components/editor/suggestion_test.go
+++ b/pkg/tui/components/editor/suggestion_test.go
@@ -60,7 +60,7 @@ func TestApplySuggestionOverlay(t *testing.T) {
 			t.Parallel()
 
 			// Create a simple editor for testing
-			hist, _ := history.New()
+			hist, _ := history.New("")
 			e := New(hist).(*editor)
 
 			// Set up textarea with test content
@@ -94,7 +94,7 @@ func TestApplySuggestionOverlay(t *testing.T) {
 func TestApplySuggestionOverlayScrolledView(t *testing.T) {
 	t.Parallel()
 
-	hist, _ := history.New()
+	hist, _ := history.New("")
 	e := New(hist).(*editor)
 
 	// Set up a multi-line textarea that's scrolled
@@ -191,7 +191,7 @@ func TestApplySuggestionOverlayWithVariousLineCount(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			hist, _ := history.New()
+			hist, _ := history.New("")
 			e := New(hist).(*editor)
 
 			e.textarea.SetValue(tt.textareaText)
@@ -269,7 +269,7 @@ func TestApplySuggestionOverlayWithMultiLineSuggestion(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			hist, _ := history.New()
+			hist, _ := history.New("")
 			e := New(hist).(*editor)
 
 			e.textarea.SetValue(tt.textareaText)
@@ -383,7 +383,7 @@ func TestIsCursorAtEnd(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			hist, _ := history.New()
+			hist, _ := history.New("")
 			e := New(hist).(*editor)
 
 			e.textarea.SetValue(tt.value)
@@ -454,7 +454,7 @@ func TestExtractLineText(t *testing.T) {
 func TestMultiLineSuggestionWithSmallEditor(t *testing.T) {
 	t.Parallel()
 
-	hist, _ := history.New()
+	hist, _ := history.New("")
 	e := New(hist).(*editor)
 
 	// Set up editor with minimal height
@@ -488,7 +488,7 @@ func TestMultiLineSuggestionWithSmallEditor(t *testing.T) {
 func TestLongSuggestionWrapping(t *testing.T) {
 	t.Parallel()
 
-	hist, _ := history.New()
+	hist, _ := history.New("")
 	e := New(hist).(*editor)
 
 	// Set up editor with narrow width

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -254,7 +254,7 @@ func New(ctx context.Context, spawner SessionSpawner, initialApp *app.App, initi
 	}
 
 	// Initialize shared command history
-	historyStore, err := history.New()
+	historyStore, err := history.New("")
 	if err != nil {
 		slog.Warn("Failed to initialize command history", "error", err)
 	}


### PR DESCRIPTION
Tidy up `pkg/history` so it's easier to read and maintain, without
changing any user-facing behaviour or the on-disk file format.

### What changed

- **`load()`**: replaced the manual byte counting / line splitting /
  `strconv.Unquote` parser with `bytes.Lines` + `json.Unmarshal`,
  symmetric with how entries are written.
- **Shared dedup helper**: extracted `addInMemory` so `Add` and `load`
  share the "remove prior occurrence + append" logic instead of
  carrying two different implementations.
- **`LatestMatch`**: uses `slices.Backward` for cleaner backward
  iteration.
- **Dropped the options pattern**: `New(opts ...Opt)` + `Opt` +
  `WithBaseDir` + private `options` struct collapsed into a single
  `New(baseDir string)`. Empty string falls back to the user's home
  directory.
- **Dropped the `current == -1` cursor sentinel**: the cursor is now
  always a valid index in `[0, len(Messages)]`, which kills a special
  case in `Previous()`.
- **`SetCurrent` clamps** to `[0, len(Messages)]`, eliminating latent
  out-of-bounds panics in `Previous`/`Next` if a caller ever passed an
  invalid index.
- Reordered the file so the public navigation/search API is at the top
  and the persistence/migration helpers are grouped at the bottom.
- Removed the unused `json:"messages"` struct tag (the file format is
  one JSON-encoded string per line, the struct itself is never
  marshalled).
- Tightened doc comments and added a test for `SetCurrent` with
  out-of-range values.