### PR TITLE
lint: add config-versioning robustness cops + fix v6/v7 package names

### DIFF
--- a/lint/config_package_name.go
+++ b/lint/config_package_name.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/dgageot/rubocop-go/cop"
+)
+
+// ConfigPackageName enforces that files under pkg/config/<dir>/ declare a
+// package name that matches their directory:
+//
+//   - pkg/config/vN/      → package vN
+//   - pkg/config/latest/  → package latest
+//   - pkg/config/types/   → package types
+//
+// This catches a class of copy-paste bugs that occur when a "latest" version
+// is frozen into a numbered vN directory: the package clause is easy to
+// forget, and the broken state remains compilable as long as importers use
+// an explicit alias.
+type ConfigPackageName struct{}
+
+func (*ConfigPackageName) Name() string { return "Lint/ConfigPackageName" }
+func (*ConfigPackageName) Description() string {
+	return "Files under pkg/config/<dir>/ must declare package <dir>"
+}
+func (*ConfigPackageName) Severity() cop.Severity { return cop.Error }
+
+// configDirRe matches files under pkg/config/<dir>/. The captured group is
+// the directory name immediately under pkg/config/. It accepts both
+// absolute and relative paths.
+var configDirRe = regexp.MustCompile(`(?:^|/)pkg/config/([^/]+)/[^/]+\.go$`)
+
+func (c *ConfigPackageName) Check(fset *token.FileSet, file *ast.File) []cop.Offense {
+	filename := fset.Position(file.Package).Filename
+	normalized := filepath.ToSlash(filename)
+
+	m := configDirRe.FindStringSubmatch(normalized)
+	if m == nil {
+		return nil
+	}
+
+	dir := m[1]
+
+	// pkg/config/<dir> contains the parsers/dispatcher; skip files that live
+	// directly in pkg/config/.
+	if strings.HasSuffix(dir, ".go") {
+		return nil
+	}
+
+	expected := dir
+	got := file.Name.Name
+	if got == expected {
+		return nil
+	}
+	// Black-box test packages (<dir>_test) are a legitimate Go convention.
+	if strings.HasSuffix(filename, "_test.go") && got == expected+"_test" {
+		return nil
+	}
+
+	return []cop.Offense{cop.NewOffense(c, fset, file.Name.Pos(), file.Name.End(),
+		fmt.Sprintf("file in pkg/config/%s/ must declare package %s, got %s", dir, expected, got))}
+}

--- a/lint/config_package_name.go
+++ b/lint/config_package_name.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
-	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/dgageot/rubocop-go/cop"
@@ -30,38 +28,24 @@ func (*ConfigPackageName) Description() string {
 }
 func (*ConfigPackageName) Severity() cop.Severity { return cop.Error }
 
-// configDirRe matches files under pkg/config/<dir>/. The captured group is
-// the directory name immediately under pkg/config/. It accepts both
-// absolute and relative paths.
-var configDirRe = regexp.MustCompile(`(?:^|/)pkg/config/([^/]+)/[^/]+\.go$`)
-
 func (c *ConfigPackageName) Check(fset *token.FileSet, file *ast.File) []cop.Offense {
 	filename := fset.Position(file.Package).Filename
-	normalized := filepath.ToSlash(filename)
-
-	m := configDirRe.FindStringSubmatch(normalized)
-	if m == nil {
+	dir := configDir(filename)
+	if dir == "" {
 		return nil
 	}
 
-	dir := m[1]
-
-	// pkg/config/<dir> contains the parsers/dispatcher; skip files that live
-	// directly in pkg/config/.
-	if strings.HasSuffix(dir, ".go") {
-		return nil
-	}
-
-	expected := dir
 	got := file.Name.Name
-	if got == expected {
+	switch got {
+	case dir:
 		return nil
-	}
-	// Black-box test packages (<dir>_test) are a legitimate Go convention.
-	if strings.HasSuffix(filename, "_test.go") && got == expected+"_test" {
-		return nil
+	case dir + "_test":
+		// Black-box test packages are a legitimate Go convention.
+		if strings.HasSuffix(filename, "_test.go") {
+			return nil
+		}
 	}
 
-	return []cop.Offense{cop.NewOffense(c, fset, file.Name.Pos(), file.Name.End(),
-		fmt.Sprintf("file in pkg/config/%s/ must declare package %s, got %s", dir, expected, got))}
+	return []cop.Offense{offense(c, fset, file.Name,
+		fmt.Sprintf("file in pkg/config/%s/ must declare package %s, got %s", dir, dir, got))}
 }

--- a/lint/config_version_constant.go
+++ b/lint/config_version_constant.go
@@ -4,10 +4,7 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
-	"path/filepath"
-	"regexp"
 	"strconv"
-	"strings"
 
 	"github.com/dgageot/rubocop-go/cop"
 )
@@ -15,11 +12,11 @@ import (
 // ConfigVersionConstant enforces that a file under pkg/config/vN/ declaring a
 // `const Version = "<value>"` uses "<N>" as its value.
 //
-// This is a robustness check against the very common mistake of bumping the
-// directory name without bumping the constant (or vice-versa) when freezing
-// the work-in-progress config and creating a new "latest". A mismatch would
-// break the parser dispatch in pkg/config/versions.go silently, since the
-// runtime registers parsers keyed by `Version`.
+// This guards against the common mistake of bumping the directory name
+// without bumping the constant (or vice versa) when freezing the
+// work-in-progress config and creating a new "latest". A mismatch would
+// silently break the parser dispatch in pkg/config/versions.go, which
+// registers parsers keyed by `Version`.
 //
 // Files under pkg/config/latest/ are intentionally exempt: their `Version`
 // is the next, work-in-progress value (one greater than the highest vN).
@@ -31,21 +28,29 @@ func (*ConfigVersionConstant) Description() string {
 }
 func (*ConfigVersionConstant) Severity() cop.Severity { return cop.Error }
 
-// vDirRe captures the numeric version in pkg/config/vN/.
-// It accepts both absolute and relative paths.
-var vDirRe = regexp.MustCompile(`(?:^|/)pkg/config/v(\d+)/[^/]+\.go$`)
-
 func (c *ConfigVersionConstant) Check(fset *token.FileSet, file *ast.File) []cop.Offense {
-	filename := fset.Position(file.Package).Filename
-	normalized := filepath.ToSlash(filename)
-
-	m := vDirRe.FindStringSubmatch(normalized)
-	if m == nil {
+	dirVersion, ok := versionFromDir(configDir(fset.Position(file.Package).Filename))
+	if !ok {
 		return nil
 	}
-	expected := m[1]
+	expected := strconv.Itoa(dirVersion)
 
 	var offenses []cop.Offense
+	for _, lit := range versionStringLiterals(file) {
+		got, err := strconv.Unquote(lit.Value)
+		if err != nil || got == expected {
+			continue
+		}
+		offenses = append(offenses, offense(c, fset, lit,
+			fmt.Sprintf("Version in pkg/config/v%s/ must be %q, got %q", expected, expected, got)))
+	}
+	return offenses
+}
+
+// versionStringLiterals returns the value literal of every top-level
+// `const Version = "<string>"` declaration in file.
+func versionStringLiterals(file *ast.File) []*ast.BasicLit {
+	var lits []*ast.BasicLit
 	for _, decl := range file.Decls {
 		gen, ok := decl.(*ast.GenDecl)
 		if !ok || gen.Tok != token.CONST {
@@ -57,33 +62,16 @@ func (c *ConfigVersionConstant) Check(fset *token.FileSet, file *ast.File) []cop
 				continue
 			}
 			for i, name := range vs.Names {
-				if name.Name != "Version" {
-					continue
-				}
-				if i >= len(vs.Values) {
+				if name.Name != "Version" || i >= len(vs.Values) {
 					continue
 				}
 				lit, ok := vs.Values[i].(*ast.BasicLit)
 				if !ok || lit.Kind != token.STRING {
 					continue
 				}
-				got, err := strconv.Unquote(lit.Value)
-				if err != nil {
-					continue
-				}
-				if got == expected {
-					continue
-				}
-				offenses = append(offenses, cop.NewOffense(c, fset, lit.Pos(), lit.End(),
-					fmt.Sprintf("Version in pkg/config/v%s/ must be %q, got %q", expected, expected, got)))
+				lits = append(lits, lit)
 			}
 		}
 	}
-
-	return offenses
-}
-
-// isLatestPath reports whether the given path lives under pkg/config/latest/.
-func isLatestPath(normalized string) bool {
-	return strings.Contains(normalized, "pkg/config/latest/")
+	return lits
 }

--- a/lint/config_version_constant.go
+++ b/lint/config_version_constant.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/dgageot/rubocop-go/cop"
+)
+
+// ConfigVersionConstant enforces that a file under pkg/config/vN/ declaring a
+// `const Version = "<value>"` uses "<N>" as its value.
+//
+// This is a robustness check against the very common mistake of bumping the
+// directory name without bumping the constant (or vice-versa) when freezing
+// the work-in-progress config and creating a new "latest". A mismatch would
+// break the parser dispatch in pkg/config/versions.go silently, since the
+// runtime registers parsers keyed by `Version`.
+//
+// Files under pkg/config/latest/ are intentionally exempt: their `Version`
+// is the next, work-in-progress value (one greater than the highest vN).
+type ConfigVersionConstant struct{}
+
+func (*ConfigVersionConstant) Name() string { return "Lint/ConfigVersionConstant" }
+func (*ConfigVersionConstant) Description() string {
+	return "Version constant in pkg/config/vN/ must equal \"N\""
+}
+func (*ConfigVersionConstant) Severity() cop.Severity { return cop.Error }
+
+// vDirRe captures the numeric version in pkg/config/vN/.
+// It accepts both absolute and relative paths.
+var vDirRe = regexp.MustCompile(`(?:^|/)pkg/config/v(\d+)/[^/]+\.go$`)
+
+func (c *ConfigVersionConstant) Check(fset *token.FileSet, file *ast.File) []cop.Offense {
+	filename := fset.Position(file.Package).Filename
+	normalized := filepath.ToSlash(filename)
+
+	m := vDirRe.FindStringSubmatch(normalized)
+	if m == nil {
+		return nil
+	}
+	expected := m[1]
+
+	var offenses []cop.Offense
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, name := range vs.Names {
+				if name.Name != "Version" {
+					continue
+				}
+				if i >= len(vs.Values) {
+					continue
+				}
+				lit, ok := vs.Values[i].(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					continue
+				}
+				got, err := strconv.Unquote(lit.Value)
+				if err != nil {
+					continue
+				}
+				if got == expected {
+					continue
+				}
+				offenses = append(offenses, cop.NewOffense(c, fset, lit.Pos(), lit.End(),
+					fmt.Sprintf("Version in pkg/config/v%s/ must be %q, got %q", expected, expected, got)))
+			}
+		}
+	}
+
+	return offenses
+}
+
+// isLatestPath reports whether the given path lives under pkg/config/latest/.
+func isLatestPath(normalized string) bool {
+	return strings.Contains(normalized, "pkg/config/latest/")
+}

--- a/lint/config_version_import.go
+++ b/lint/config_version_import.go
@@ -4,17 +4,14 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
-	"path/filepath"
-	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/dgageot/rubocop-go/cop"
 )
 
-// ConfigVersionImport enforces that config version packages (pkg/config/vN)
-// only import their immediate predecessor (pkg/config/v{N-1}) and the shared
-// types package (pkg/config/types). This preserves the strict migration chain:
+// ConfigVersionImport enforces that config version packages (pkg/config/vN
+// and pkg/config/latest) only import their immediate predecessor and the
+// shared types package, preserving the strict migration chain:
 // v0 → v1 → v2 → … → latest.
 type ConfigVersionImport struct{}
 
@@ -24,106 +21,69 @@ func (*ConfigVersionImport) Description() string {
 }
 func (*ConfigVersionImport) Severity() cop.Severity { return cop.Error }
 
-// configVersionRe matches "pkg/config/vN" at the end of an import path.
-var configVersionRe = regexp.MustCompile(`pkg/config/v(\d+)$`)
-
-// Check inspects import declarations in config version packages.
 func (c *ConfigVersionImport) Check(fset *token.FileSet, file *ast.File) []cop.Offense {
 	if len(file.Imports) == 0 {
 		return nil
 	}
 
-	// Determine which config version package this file belongs to.
-	filename := fset.Position(file.Package).Filename
-	dirVersion, isVersioned := extractDirVersion(filename)
-	dirIsLatest := isLatestDir(filename)
-
-	if !isVersioned && !dirIsLatest {
+	dir := configDir(fset.Position(file.Package).Filename)
+	if dir == "" {
 		return nil
 	}
-
-	// Black-box test files (package <dir>_test) live alongside the package
-	// but are external to it; they're allowed to import what they please.
+	// Black-box test files (package <dir>_test) are external to the package
+	// and may import what they please.
 	if strings.HasSuffix(file.Name.Name, "_test") {
 		return nil
 	}
 
-	var offenses []cop.Offense
-
-	for _, imp := range file.Imports {
-		importPath := strings.Trim(imp.Path.Value, `"`)
-
-		if !strings.Contains(importPath, "pkg/config/") {
-			continue
-		}
-
-		if strings.HasSuffix(importPath, "pkg/config/types") {
-			continue
-		}
-
-		if isVersioned {
-			offenses = append(offenses, c.checkVersionedImport(fset, imp, importPath, dirVersion)...)
-		} else if dirIsLatest {
-			offenses = append(offenses, c.checkLatestImport(fset, imp, importPath)...)
-		}
+	dirVersion, isVersioned := versionFromDir(dir)
+	isLatest := dir == "latest"
+	if !isVersioned && !isLatest {
+		return nil
 	}
 
+	var offenses []cop.Offense
+	for _, imp := range file.Imports {
+		path := importPath(imp)
+
+		if !strings.Contains(path, "pkg/config/") || strings.HasSuffix(path, "pkg/config/types") {
+			continue
+		}
+		if msg := importViolation(path, dirVersion, isLatest); msg != "" {
+			offenses = append(offenses, offense(c, fset, imp.Path, msg))
+		}
+	}
 	return offenses
 }
 
-func (c *ConfigVersionImport) checkVersionedImport(fset *token.FileSet, imp *ast.ImportSpec, importPath string, dirVersion int) []cop.Offense {
-	if strings.HasSuffix(importPath, "pkg/config/latest") {
-		return []cop.Offense{cop.NewOffense(c, fset, imp.Path.Pos(), imp.Path.End(),
-			fmt.Sprintf("config v%d must not import pkg/config/latest", dirVersion))}
+// importViolation returns a non-empty error message if the given import path
+// is forbidden inside a config-version package, or "" if the import is fine.
+// dirVersion is the importing package's N (only meaningful when !isLatest).
+func importViolation(path string, dirVersion int, isLatest bool) string {
+	if isLatest {
+		// pkg/config/latest may only import other config-version packages.
+		// (The "must be the immediate predecessor" rule lives in the
+		// LatestImportsPredecessor cop.)
+		if _, ok := versionFromImport(path); ok {
+			return ""
+		}
+		return "pkg/config/latest should only import config version or types packages, not " + path
 	}
 
-	m := configVersionRe.FindStringSubmatch(importPath)
-	if m == nil {
-		return nil
+	// Versioned package (vN).
+	if strings.HasSuffix(path, "pkg/config/latest") {
+		return fmt.Sprintf("config v%d must not import pkg/config/latest", dirVersion)
 	}
-
-	importedVersion, _ := strconv.Atoi(m[1])
+	imported, ok := versionFromImport(path)
+	if !ok {
+		return ""
+	}
 	expected := dirVersion - 1
-
 	if expected < 0 {
-		return []cop.Offense{cop.NewOffense(c, fset, imp.Path.Pos(), imp.Path.End(),
-			"config v0 must not import other config version packages")}
+		return "config v0 must not import other config version packages"
 	}
-
-	if importedVersion != expected {
-		return []cop.Offense{cop.NewOffense(c, fset, imp.Path.Pos(), imp.Path.End(),
-			fmt.Sprintf("config v%d must import v%d (its predecessor), not v%d", dirVersion, expected, importedVersion))}
+	if imported != expected {
+		return fmt.Sprintf("config v%d must import v%d (its predecessor), not v%d", dirVersion, expected, imported)
 	}
-
-	return nil
-}
-
-func (c *ConfigVersionImport) checkLatestImport(fset *token.FileSet, imp *ast.ImportSpec, importPath string) []cop.Offense {
-	if configVersionRe.MatchString(importPath) {
-		return nil
-	}
-
-	return []cop.Offense{cop.NewOffense(c, fset, imp.Path.Pos(), imp.Path.End(),
-		"pkg/config/latest should only import config version or types packages, not "+importPath)}
-}
-
-func extractDirVersion(filename string) (int, bool) {
-	normalized := filepath.ToSlash(filename)
-
-	re := regexp.MustCompile(`(?:^|/)pkg/config/v(\d+)/`)
-	m := re.FindStringSubmatch(normalized)
-	if m == nil {
-		return 0, false
-	}
-
-	v, err := strconv.Atoi(m[1])
-	if err != nil {
-		return 0, false
-	}
-	return v, true
-}
-
-func isLatestDir(filename string) bool {
-	normalized := filepath.ToSlash(filename)
-	return strings.Contains(normalized, "pkg/config/latest/")
+	return ""
 }

--- a/lint/config_version_import.go
+++ b/lint/config_version_import.go
@@ -42,6 +42,12 @@ func (c *ConfigVersionImport) Check(fset *token.FileSet, file *ast.File) []cop.O
 		return nil
 	}
 
+	// Black-box test files (package <dir>_test) live alongside the package
+	// but are external to it; they're allowed to import what they please.
+	if strings.HasSuffix(file.Name.Name, "_test") {
+		return nil
+	}
+
 	var offenses []cop.Offense
 
 	for _, imp := range file.Imports {
@@ -104,7 +110,7 @@ func (c *ConfigVersionImport) checkLatestImport(fset *token.FileSet, imp *ast.Im
 func extractDirVersion(filename string) (int, bool) {
 	normalized := filepath.ToSlash(filename)
 
-	re := regexp.MustCompile(`/pkg/config/v(\d+)/`)
+	re := regexp.MustCompile(`(?:^|/)pkg/config/v(\d+)/`)
 	m := re.FindStringSubmatch(normalized)
 	if m == nil {
 		return 0, false
@@ -119,5 +125,5 @@ func extractDirVersion(filename string) (int, bool) {
 
 func isLatestDir(filename string) bool {
 	normalized := filepath.ToSlash(filename)
-	return strings.Contains(normalized, "/pkg/config/latest/")
+	return strings.Contains(normalized, "pkg/config/latest/")
 }

--- a/lint/config_version_import.go
+++ b/lint/config_version_import.go
@@ -67,7 +67,7 @@ func importViolation(path string, dirVersion int, isLatest bool) string {
 		if _, ok := versionFromImport(path); ok {
 			return ""
 		}
-		return "pkg/config/latest should only import config version or types packages, not " + path
+		return "pkg/config/latest must only import config version or types packages, not " + path
 	}
 
 	// Versioned package (vN).

--- a/lint/configpath.go
+++ b/lint/configpath.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"go/ast"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/dgageot/rubocop-go/cop"
+)
+
+// Helpers shared by the cops in this package. They centralise the parsing of
+// pkg/config/<dir>/ paths and pkg/config/vN import paths, so each cop can
+// focus on its rule rather than on regular expressions.
+
+// configDirRe matches files under pkg/config/<dir>/. The captured group is
+// the directory name immediately under pkg/config/. It accepts both
+// absolute and relative paths.
+var configDirRe = regexp.MustCompile(`(?:^|/)pkg/config/([^/]+)/[^/]+\.go$`)
+
+// configDir returns the directory name immediately under pkg/config/ for
+// filename, or "" if filename is not under pkg/config/<dir>/.
+func configDir(filename string) string {
+	m := configDirRe.FindStringSubmatch(filepath.ToSlash(filename))
+	if m == nil {
+		return ""
+	}
+	return m[1]
+}
+
+// versionFromDir parses a "vN" directory name and returns N. Returns false
+// for any other name (latest, types, vendor, ...).
+func versionFromDir(dir string) (int, bool) {
+	if len(dir) < 2 || dir[0] != 'v' {
+		return 0, false
+	}
+	n, err := strconv.Atoi(dir[1:])
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// versionedImportRe matches a versioned config import path of the form
+// ".../pkg/config/vN" at the end of an import path.
+var versionedImportRe = regexp.MustCompile(`pkg/config/v(\d+)$`)
+
+// versionFromImport returns N if importPath ends with "pkg/config/vN".
+func versionFromImport(importPath string) (int, bool) {
+	m := versionedImportRe.FindStringSubmatch(importPath)
+	if m == nil {
+		return 0, false
+	}
+	n, _ := strconv.Atoi(m[1])
+	return n, true
+}
+
+// importPath returns the unquoted import path of an ImportSpec.
+func importPath(imp *ast.ImportSpec) string {
+	return strings.Trim(imp.Path.Value, `"`)
+}
+
+// offense builds an Offense covering the source span of node n.
+func offense(c cop.Cop, fset *token.FileSet, n ast.Node, message string) cop.Offense {
+	return cop.NewOffense(c, fset, n.Pos(), n.End(), message)
+}
+
+// highestSiblingVersion returns the largest N such that pkg/config/vN/
+// exists as a sibling of filename's directory. Result is cached per
+// parent directory so callers can invoke it once per file cheaply.
+func highestSiblingVersion(filename string) (int, bool) {
+	abs, err := filepath.Abs(filename)
+	if err != nil {
+		return 0, false
+	}
+	parent := filepath.Dir(filepath.Dir(abs))
+
+	if v, ok := highestCache.Load(parent); ok {
+		n := v.(int)
+		return n, n >= 0
+	}
+	n := scanHighestVN(parent)
+	highestCache.Store(parent, n)
+	return n, n >= 0
+}
+
+// highestCache memoises highestSiblingVersion. Value is -1 when no vN/
+// directory exists under the key.
+var highestCache sync.Map
+
+func scanHighestVN(dir string) int {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return -1
+	}
+	highest := -1
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if n, ok := versionFromDir(e.Name()); ok && n > highest {
+			highest = n
+		}
+	}
+	return highest
+}

--- a/lint/configpath.go
+++ b/lint/configpath.go
@@ -55,7 +55,11 @@ func versionFromImport(importPath string) (int, bool) {
 	if m == nil {
 		return 0, false
 	}
-	n, _ := strconv.Atoi(m[1])
+	n, err := strconv.Atoi(m[1])
+	if err != nil {
+		// Should never happen since regex only captures digits.
+		return 0, false
+	}
 	return n, true
 }
 

--- a/lint/latest_imports_predecessor.go
+++ b/lint/latest_imports_predecessor.go
@@ -4,12 +4,6 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
-	"os"
-	"path/filepath"
-	"regexp"
-	"strconv"
-	"strings"
-	"sync"
 
 	"github.com/dgageot/rubocop-go/cop"
 )
@@ -18,12 +12,11 @@ import (
 // import a historical config version package (pkg/config/vN) only ever
 // import the immediate predecessor: the highest vN under pkg/config/.
 //
-// The existing Lint/ConfigVersionImport cop only verifies that *numbered*
-// versions follow the v0 → v1 → v2 → … chain. It accepts any vN inside
-// pkg/config/latest/. This cop closes that gap and ensures pkg/config/latest
-// also obeys the chain (i.e. latest imports the highest vN, never an older
-// version), which is required for the upgrade pipeline to reach the latest
-// schema in a single hop.
+// The Lint/ConfigVersionImport cop verifies that *numbered* versions follow
+// the v0 → v1 → v2 → … chain but accepts any vN inside pkg/config/latest/.
+// This cop closes that gap so pkg/config/latest also obeys the chain
+// (latest imports the highest vN, never an older version), which is required
+// for the upgrade pipeline to reach the latest schema in a single hop.
 type LatestImportsPredecessor struct{}
 
 func (*LatestImportsPredecessor) Name() string { return "Lint/LatestImportsPredecessor" }
@@ -32,89 +25,27 @@ func (*LatestImportsPredecessor) Description() string {
 }
 func (*LatestImportsPredecessor) Severity() cop.Severity { return cop.Error }
 
-var versionedImportRe = regexp.MustCompile(`pkg/config/v(\d+)$`)
-
 func (c *LatestImportsPredecessor) Check(fset *token.FileSet, file *ast.File) []cop.Offense {
 	if len(file.Imports) == 0 {
 		return nil
 	}
 	filename := fset.Position(file.Package).Filename
-	normalized := filepath.ToSlash(filename)
-	if !isLatestPath(normalized) {
+	if configDir(filename) != "latest" {
 		return nil
 	}
-
 	highest, ok := highestSiblingVersion(filename)
 	if !ok {
-		// Cannot determine highest sibling vN; skip silently.
 		return nil
 	}
 
 	var offenses []cop.Offense
 	for _, imp := range file.Imports {
-		importPath := strings.Trim(imp.Path.Value, `"`)
-		m := versionedImportRe.FindStringSubmatch(importPath)
-		if m == nil {
+		got, ok := versionFromImport(importPath(imp))
+		if !ok || got == highest {
 			continue
 		}
-		got, err := strconv.Atoi(m[1])
-		if err != nil {
-			continue
-		}
-		if got == highest {
-			continue
-		}
-		offenses = append(offenses, cop.NewOffense(c, fset, imp.Path.Pos(), imp.Path.End(),
+		offenses = append(offenses, offense(c, fset, imp.Path,
 			fmt.Sprintf("pkg/config/latest must import its predecessor v%d, not v%d", highest, got)))
 	}
 	return offenses
-}
-
-var (
-	highestCacheMu sync.Mutex
-	highestCache   = map[string]int{}
-)
-
-// highestSiblingVersion returns the largest N such that pkg/config/vN/ exists
-// among the siblings of the file's directory.
-func highestSiblingVersion(filename string) (int, bool) {
-	abs, err := filepath.Abs(filename)
-	if err != nil {
-		return 0, false
-	}
-	configDir := filepath.Dir(filepath.Dir(abs)) // strip /<pkg>/<file.go>
-
-	highestCacheMu.Lock()
-	defer highestCacheMu.Unlock()
-	if v, ok := highestCache[configDir]; ok {
-		return v, v >= 0
-	}
-
-	entries, err := os.ReadDir(configDir)
-	if err != nil {
-		highestCache[configDir] = -1
-		return 0, false
-	}
-
-	highest := -1
-	re := regexp.MustCompile(`^v(\d+)$`)
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-		m := re.FindStringSubmatch(e.Name())
-		if m == nil {
-			continue
-		}
-		n, err := strconv.Atoi(m[1])
-		if err != nil {
-			continue
-		}
-		if n > highest {
-			highest = n
-		}
-	}
-
-	highestCache[configDir] = highest
-	return highest, highest >= 0
 }

--- a/lint/latest_imports_predecessor.go
+++ b/lint/latest_imports_predecessor.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/dgageot/rubocop-go/cop"
+)
+
+// LatestImportsPredecessor enforces that files under pkg/config/latest/ that
+// import a historical config version package (pkg/config/vN) only ever
+// import the immediate predecessor: the highest vN under pkg/config/.
+//
+// The existing Lint/ConfigVersionImport cop only verifies that *numbered*
+// versions follow the v0 → v1 → v2 → … chain. It accepts any vN inside
+// pkg/config/latest/. This cop closes that gap and ensures pkg/config/latest
+// also obeys the chain (i.e. latest imports the highest vN, never an older
+// version), which is required for the upgrade pipeline to reach the latest
+// schema in a single hop.
+type LatestImportsPredecessor struct{}
+
+func (*LatestImportsPredecessor) Name() string { return "Lint/LatestImportsPredecessor" }
+func (*LatestImportsPredecessor) Description() string {
+	return "pkg/config/latest must only import its immediate predecessor (highest vN)"
+}
+func (*LatestImportsPredecessor) Severity() cop.Severity { return cop.Error }
+
+var versionedImportRe = regexp.MustCompile(`pkg/config/v(\d+)$`)
+
+func (c *LatestImportsPredecessor) Check(fset *token.FileSet, file *ast.File) []cop.Offense {
+	if len(file.Imports) == 0 {
+		return nil
+	}
+	filename := fset.Position(file.Package).Filename
+	normalized := filepath.ToSlash(filename)
+	if !isLatestPath(normalized) {
+		return nil
+	}
+
+	highest, ok := highestSiblingVersion(filename)
+	if !ok {
+		// Cannot determine highest sibling vN; skip silently.
+		return nil
+	}
+
+	var offenses []cop.Offense
+	for _, imp := range file.Imports {
+		importPath := strings.Trim(imp.Path.Value, `"`)
+		m := versionedImportRe.FindStringSubmatch(importPath)
+		if m == nil {
+			continue
+		}
+		got, err := strconv.Atoi(m[1])
+		if err != nil {
+			continue
+		}
+		if got == highest {
+			continue
+		}
+		offenses = append(offenses, cop.NewOffense(c, fset, imp.Path.Pos(), imp.Path.End(),
+			fmt.Sprintf("pkg/config/latest must import its predecessor v%d, not v%d", highest, got)))
+	}
+	return offenses
+}
+
+var (
+	highestCacheMu sync.Mutex
+	highestCache   = map[string]int{}
+)
+
+// highestSiblingVersion returns the largest N such that pkg/config/vN/ exists
+// among the siblings of the file's directory.
+func highestSiblingVersion(filename string) (int, bool) {
+	abs, err := filepath.Abs(filename)
+	if err != nil {
+		return 0, false
+	}
+	configDir := filepath.Dir(filepath.Dir(abs)) // strip /<pkg>/<file.go>
+
+	highestCacheMu.Lock()
+	defer highestCacheMu.Unlock()
+	if v, ok := highestCache[configDir]; ok {
+		return v, v >= 0
+	}
+
+	entries, err := os.ReadDir(configDir)
+	if err != nil {
+		highestCache[configDir] = -1
+		return 0, false
+	}
+
+	highest := -1
+	re := regexp.MustCompile(`^v(\d+)$`)
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		m := re.FindStringSubmatch(e.Name())
+		if m == nil {
+			continue
+		}
+		n, err := strconv.Atoi(m[1])
+		if err != nil {
+			continue
+		}
+		if n > highest {
+			highest = n
+		}
+	}
+
+	highestCache[configDir] = highest
+	return highest, highest >= 0
+}

--- a/lint/latest_imports_predecessor.go
+++ b/lint/latest_imports_predecessor.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
+	"strings"
 
 	"github.com/dgageot/rubocop-go/cop"
 )
@@ -31,6 +32,11 @@ func (c *LatestImportsPredecessor) Check(fset *token.FileSet, file *ast.File) []
 	}
 	filename := fset.Position(file.Package).Filename
 	if configDir(filename) != "latest" {
+		return nil
+	}
+	// Black-box test files (package latest_test) are external to the package
+	// and may import what they please.
+	if strings.HasSuffix(file.Name.Name, "_test") {
 		return nil
 	}
 	highest, ok := highestSiblingVersion(filename)

--- a/lint/main.go
+++ b/lint/main.go
@@ -14,6 +14,9 @@ import (
 
 func main() {
 	cop.Register(&ConfigVersionImport{})
+	cop.Register(&ConfigPackageName{})
+	cop.Register(&ConfigVersionConstant{})
+	cop.Register(&LatestImportsPredecessor{})
 	cops := cop.All()
 	fmt.Printf("Inspecting Go files with %d cop(s)\n", len(cops))
 

--- a/lint/main.go
+++ b/lint/main.go
@@ -1,6 +1,6 @@
 // Package main runs project-specific linting cops using rubocop-go.
 //
-// Usage: go run ./lint ./...
+// Usage: go run ./lint [path...]
 package main
 
 import (
@@ -12,28 +12,32 @@ import (
 	"github.com/dgageot/rubocop-go/runner"
 )
 
-func main() {
-	cop.Register(&ConfigVersionImport{})
-	cop.Register(&ConfigPackageName{})
-	cop.Register(&ConfigVersionConstant{})
-	cop.Register(&LatestImportsPredecessor{})
-	cops := cop.All()
-	fmt.Printf("Inspecting Go files with %d cop(s)\n", len(cops))
+// cops is the registry of project-specific cops, in declaration order.
+// To add a cop: implement cop.Cop and append it here.
+var cops = []cop.Cop{
+	&ConfigVersionImport{},
+	&ConfigPackageName{},
+	&ConfigVersionConstant{},
+	&LatestImportsPredecessor{},
+}
 
-	cfg := config.DefaultConfig()
-	r := runner.New(cops, cfg, os.Stdout)
+func main() {
+	for _, c := range cops {
+		cop.Register(c)
+	}
+	fmt.Printf("Inspecting Go files with %d cop(s)\n", len(cops))
 
 	paths := os.Args[1:]
 	if len(paths) == 0 {
 		paths = []string{"."}
 	}
 
+	r := runner.New(cop.All(), config.DefaultConfig(), os.Stdout)
 	offenseCount, err := r.Run(paths)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
-
 	if offenseCount > 0 {
 		os.Exit(1)
 	}

--- a/pkg/config/v6/model_config_clone_test.go
+++ b/pkg/config/v6/model_config_clone_test.go
@@ -1,4 +1,4 @@
-package latest
+package v6
 
 import (
 	"testing"

--- a/pkg/config/v6/model_ref.go
+++ b/pkg/config/v6/model_ref.go
@@ -1,4 +1,4 @@
-package latest
+package v6
 
 import (
 	"fmt"

--- a/pkg/config/v6/parse.go
+++ b/pkg/config/v6/parse.go
@@ -1,4 +1,4 @@
-package latest
+package v6
 
 import (
 	"github.com/goccy/go-yaml"

--- a/pkg/config/v6/skills_config_test.go
+++ b/pkg/config/v6/skills_config_test.go
@@ -1,4 +1,4 @@
-package latest
+package v6
 
 import (
 	"encoding/json"

--- a/pkg/config/v6/types.go
+++ b/pkg/config/v6/types.go
@@ -1,4 +1,4 @@
-package latest
+package v6
 
 import (
 	"cmp"

--- a/pkg/config/v6/types_test.go
+++ b/pkg/config/v6/types_test.go
@@ -1,4 +1,4 @@
-package latest
+package v6
 
 import (
 	"testing"

--- a/pkg/config/v6/validate.go
+++ b/pkg/config/v6/validate.go
@@ -1,4 +1,4 @@
-package latest
+package v6
 
 import (
 	"errors"

--- a/pkg/config/v6/validate_test.go
+++ b/pkg/config/v6/validate_test.go
@@ -1,4 +1,4 @@
-package latest
+package v6
 
 import (
 	"testing"

--- a/pkg/config/v7/model_config_clone_test.go
+++ b/pkg/config/v7/model_config_clone_test.go
@@ -1,4 +1,4 @@
-package latest
+package v7
 
 import (
 	"testing"

--- a/pkg/config/v7/model_ref.go
+++ b/pkg/config/v7/model_ref.go
@@ -1,4 +1,4 @@
-package latest
+package v7
 
 import (
 	"fmt"

--- a/pkg/config/v7/parse.go
+++ b/pkg/config/v7/parse.go
@@ -1,4 +1,4 @@
-package latest
+package v7
 
 import (
 	"github.com/goccy/go-yaml"

--- a/pkg/config/v7/skills_config_test.go
+++ b/pkg/config/v7/skills_config_test.go
@@ -1,4 +1,4 @@
-package latest
+package v7
 
 import (
 	"encoding/json"

--- a/pkg/config/v7/types.go
+++ b/pkg/config/v7/types.go
@@ -1,4 +1,4 @@
-package latest
+package v7
 
 import (
 	"cmp"

--- a/pkg/config/v7/types_test.go
+++ b/pkg/config/v7/types_test.go
@@ -1,4 +1,4 @@
-package latest
+package v7
 
 import (
 	"encoding/json"

--- a/pkg/config/v7/validate.go
+++ b/pkg/config/v7/validate.go
@@ -1,4 +1,4 @@
-package latest
+package v7
 
 import (
 	"errors"

--- a/pkg/config/v7/validate_test.go
+++ b/pkg/config/v7/validate_test.go
@@ -1,4 +1,4 @@
-package latest
+package v7
 
 import (
 	"testing"


### PR DESCRIPTION
## Summary

Adds three new project-specific linter cops under `./lint/` to harden the
`pkg/config/` versioned-schema invariants, fixes a latent regex bug in the
existing `Lint/ConfigVersionImport` cop that prevented it from firing
under `mise lint`, and corrects 16 stale `package latest` declarations in
`pkg/config/v6/` and `pkg/config/v7/`.

## Bugs caught and fixed

1. **`pkg/config/v6/*.go` and `pkg/config/v7/*.go` declared `package latest`**
   instead of `package v6` / `package v7`. Copy-paste artifact from when those
   directories were the work-in-progress version. Stayed compilable only
   because every importer used an explicit alias (`v6`, `v7`, `previous`).
2. **`Lint/ConfigVersionImport`'s path regexes required a leading `/`**, so
   they never matched when invoked as `go run ./lint .` (the form `mise lint`
   uses). Anchored with `(?:^|/)` and added a black-box test-package skip.

## New cops

| Cop | What it enforces |
|---|---|
| `Lint/ConfigPackageName` | Files under `pkg/config/<dir>/` must declare `package <dir>` (allowing `<dir>_test` for black-box tests). Catches the v6/v7 class of bug. |
| `Lint/ConfigVersionConstant` | `const Version = "N"` in `pkg/config/vN/` must literally be `"N"`. Guards against version-constant / directory-name drift. |
| `Lint/LatestImportsPredecessor` | `pkg/config/latest/` may only import the highest existing `vN/` sibling, not arbitrary historical versions. Closes a gap in `Lint/ConfigVersionImport` for the latest case. |

## Architecture

A small shared helper file `lint/configpath.go` centralises path/version
parsing so each cop is small (50–90 LOC) and focused on its rule:

- `configDir(filename)` → name of the dir under `pkg/config/`
- `versionFromDir("vN")` → `N` or `false`
- `versionFromImport(path)` → `N` if path ends in `pkg/config/vN`
- `importPath(*ast.ImportSpec)` → unquoted import path
- `offense(c, fset, node, msg)` → `Offense` covering an AST node
- `highestSiblingVersion(...)` → cached scan for the highest `vN` (`sync.Map`-backed)

Cops are registered in a single `var cops = []cop.Cop{...}` slice in
`main.go` — adding a new cop is one line.

## Validation

- `mise lint` → `golangci-lint`: 0 issues; custom cops: 880 files, 0 offenses; `go mod tidy --diff`: clean.
- `mise test` → all packages pass.
- Fault injection — confirmed each cop still fires on:
  - bad package name (`Lint/ConfigPackageName`)
  - bad `Version` constant (`Lint/ConfigVersionConstant`)
  - latest importing wrong predecessor (`Lint/LatestImportsPredecessor`)
  - vN importing latest (`Lint/ConfigVersionImport`)
  - vN importing wrong predecessor (`Lint/ConfigVersionImport`)

## Commits

1. `fix(config): use proper package names for v6 and v7` — 16 files, package clause only.
2. `lint: add config-versioning robustness cops` — adds 3 new cops + fixes the path regex bug in the existing one.
3. `lint: extract shared config-path helpers to simplify cops` — refactor; ~130 lines of duplication removed across cops.
4. `fix(lint): add test file exemption and improve error handling` — review-fix pass: black-box test exemption in `LatestImportsPredecessor`, explicit `strconv.Atoi` error handling, error-message wording consistency.
