### PR TITLE
refactor(skills): split package into focused files

### DIFF
--- a/pkg/skills/frontmatter.go
+++ b/pkg/skills/frontmatter.go
@@ -1,0 +1,122 @@
+package skills
+
+import "strings"
+
+// parseFrontmatter extracts and parses the YAML-like frontmatter from a
+// markdown file. Instead of using a full YAML parser (which rejects unquoted
+// colons in values), we do simple line-by-line key: value splitting on the
+// first ": ". This is more robust for the simple frontmatter format used by
+// skill files.
+func parseFrontmatter(content string) (Skill, bool) {
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	content = strings.ReplaceAll(content, "\r", "\n")
+
+	if !strings.HasPrefix(content, "---") {
+		return Skill{}, false
+	}
+
+	endIndex := strings.Index(content[3:], "\n---")
+	if endIndex == -1 {
+		return Skill{}, false
+	}
+
+	block := content[4 : endIndex+3]
+
+	var skill Skill
+	var currentKey string // tracks multi-line keys like "metadata" or "allowed-tools"
+
+	for line := range strings.SplitSeq(block, "\n") {
+		// Indented lines belong to the current multi-line key.
+		if line != "" && (line[0] == ' ' || line[0] == '\t') {
+			parseIndentedLine(&skill, currentKey, strings.TrimSpace(line))
+			continue
+		}
+
+		currentKey = ""
+		key, value, ok := splitKeyValue(line)
+		if !ok {
+			continue
+		}
+
+		if multi := parseTopLevelLine(&skill, key, value); multi {
+			currentKey = key
+		}
+	}
+
+	return skill, true
+}
+
+// parseTopLevelLine assigns a frontmatter key/value to the right Skill field.
+// It returns true if the key opens a multi-line block whose subsequent
+// indented lines must be collected by parseIndentedLine.
+func parseTopLevelLine(skill *Skill, key, value string) bool {
+	switch key {
+	case "name":
+		skill.Name = unquote(value)
+	case "description":
+		skill.Description = unquote(value)
+	case "license":
+		skill.License = unquote(value)
+	case "compatibility":
+		skill.Compatibility = unquote(value)
+	case "context":
+		skill.Context = unquote(value)
+	case "model":
+		skill.Model = unquote(value)
+	case "metadata":
+		// metadata is always multi-line.
+		return true
+	case "allowed-tools":
+		if value == "" {
+			// Block form: subsequent indented "- item" lines.
+			return true
+		}
+		// Inline comma-separated list.
+		for item := range strings.SplitSeq(value, ",") {
+			if t := unquote(strings.TrimSpace(item)); t != "" {
+				skill.AllowedTools = append(skill.AllowedTools, t)
+			}
+		}
+	}
+	return false
+}
+
+// parseIndentedLine accumulates an indented child line into the multi-line
+// block identified by parentKey.
+func parseIndentedLine(skill *Skill, parentKey, line string) {
+	switch parentKey {
+	case "metadata":
+		if k, v, ok := splitKeyValue(line); ok {
+			if skill.Metadata == nil {
+				skill.Metadata = make(map[string]string)
+			}
+			skill.Metadata[k] = unquote(v)
+		}
+	case "allowed-tools":
+		if item, ok := strings.CutPrefix(line, "- "); ok {
+			skill.AllowedTools = append(skill.AllowedTools, unquote(strings.TrimSpace(item)))
+		}
+	}
+}
+
+// splitKeyValue splits a line on the first ": " into key and value.
+// It also handles bare "key:" (no value) for keys that introduce a block.
+func splitKeyValue(line string) (string, string, bool) {
+	if key, value, ok := strings.Cut(line, ": "); ok {
+		return key, value, true
+	}
+	if strings.HasSuffix(line, ":") {
+		return line[:len(line)-1], "", true
+	}
+	return "", "", false
+}
+
+// unquote strips matching surrounding single or double quotes.
+func unquote(s string) string {
+	if len(s) >= 2 {
+		if (s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'') {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
+}

--- a/pkg/skills/local.go
+++ b/pkg/skills/local.go
@@ -134,7 +134,9 @@ func loadSkillsFromDir(dir string, recursive bool) []Skill {
 	return loadSkillsFlat(dir)
 }
 
-// loadSkillsFlat loads skills from immediate subdirectories only (Claude format).
+// loadSkillsFlat loads skills from immediate subdirectories only (Claude
+// format). Symlinks are explicitly skipped here because flat-mode skills are
+// expected to live as plain directories under the search root.
 func loadSkillsFlat(dir string) []Skill {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -154,8 +156,15 @@ func loadSkillsFlat(dir string) []Skill {
 	return skills
 }
 
-// loadSkillsRecursive walks dir for SKILL.md files (Codex format), tracking
-// real directory paths so symlink cycles can't loop forever.
+// loadSkillsRecursive walks dir for SKILL.md files (Codex format).
+//
+// filepath.WalkDir does not follow symlinks inside the tree (it uses
+// fs.DirEntry which is Lstat-based), so a symlink-to-directory has
+// IsDir() == false and is naturally not entered. The visited map is
+// defensive: it catches the (rare) cases where the same real directory
+// is reachable via two non-symlink paths — e.g. Linux bind mounts, or
+// when the search root itself is a symlink whose target also appears
+// as a sibling deeper in the tree.
 func loadSkillsRecursive(dir string) []Skill {
 	visited := make(map[string]bool)
 	if realDir, err := filepath.EvalSymlinks(dir); err == nil {

--- a/pkg/skills/local.go
+++ b/pkg/skills/local.go
@@ -1,0 +1,232 @@
+package skills
+
+import (
+	"cmp"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+
+	"github.com/docker/docker-agent/pkg/paths"
+)
+
+const skillFile = "SKILL.md"
+
+// localSearchPath describes one directory to scan for local skills, and
+// whether subdirectories should be walked recursively (Codex/agents format)
+// or only as immediate children of the search root (Claude format).
+type localSearchPath struct {
+	dir       string
+	recursive bool
+}
+
+// localSearchPaths returns every directory to scan for local skills, in
+// load order. Entries appearing later in the list override skills with the
+// same name from earlier entries:
+//
+//  1. Global directories (under $HOME).
+//  2. .claude/skills under cwd (Claude project format, flat).
+//  3. .agents/skills from the git root down to cwd (closest wins).
+func localSearchPaths() []localSearchPath {
+	var searchPaths []localSearchPath
+
+	if home := paths.GetHomeDir(); home != "" {
+		searchPaths = append(searchPaths,
+			localSearchPath{filepath.Join(home, ".codex", "skills"), true},
+			localSearchPath{filepath.Join(home, ".claude", "skills"), false},
+			localSearchPath{filepath.Join(home, ".agents", "skills"), true},
+		)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return searchPaths
+	}
+
+	searchPaths = append(searchPaths, localSearchPath{filepath.Join(cwd, ".claude", "skills"), false})
+	for _, dir := range projectSearchDirs(cwd) {
+		searchPaths = append(searchPaths, localSearchPath{filepath.Join(dir, ".agents", "skills"), false})
+	}
+	return searchPaths
+}
+
+// loadLocalSkillsInto populates skillMap with every local skill, with later
+// search paths overriding earlier ones.
+func loadLocalSkillsInto(skillMap map[string]Skill) {
+	for _, p := range localSearchPaths() {
+		for _, skill := range loadSkillsFromDir(p.dir, p.recursive) {
+			skillMap[skill.Name] = skill
+		}
+	}
+}
+
+// projectSearchDirs returns directories from the enclosing git root down to
+// cwd (inclusive), ordered from root to cwd. If cwd is not inside a git
+// repository, it returns just cwd.
+//
+// The ordering matters: later (deeper) entries override skills from parents,
+// so a project subdirectory can shadow a skill defined at the repo root.
+func projectSearchDirs(cwd string) []string {
+	abs, err := filepath.Abs(cwd)
+	if err != nil {
+		return []string{cwd}
+	}
+
+	// Walk up from cwd, recording each dir, until we either hit a git
+	// marker or run out of parents. This collects findGitRoot's result
+	// and the dir list in a single traversal.
+	var dirs []string
+	var gitRoot string
+	for current := abs; ; {
+		dirs = append(dirs, current)
+		if hasGitMarker(current) {
+			gitRoot = current
+			break
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
+		current = parent
+	}
+
+	if gitRoot == "" {
+		return []string{abs}
+	}
+
+	slices.Reverse(dirs)
+	return dirs
+}
+
+// hasGitMarker reports whether dir contains a .git directory or .git file
+// (the latter is used by worktrees and submodules).
+func hasGitMarker(dir string) bool {
+	info, err := os.Stat(filepath.Join(dir, ".git"))
+	if err != nil {
+		return false
+	}
+	return info.IsDir() || info.Mode().IsRegular()
+}
+
+// findGitRoot finds the enclosing git repository root, or returns "" if dir
+// is not inside a git repository. Kept as a thin wrapper for test coverage
+// and callers that don't need the full directory list.
+func findGitRoot(dir string) string {
+	for current := dir; ; {
+		if hasGitMarker(current) {
+			return current
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return ""
+		}
+		current = parent
+	}
+}
+
+// loadSkillsFromDir loads skills from a directory.
+// If recursive is true, it walks all subdirectories looking for SKILL.md.
+// If recursive is false, it only looks at immediate subdirectories.
+func loadSkillsFromDir(dir string, recursive bool) []Skill {
+	if recursive {
+		return loadSkillsRecursive(dir)
+	}
+	return loadSkillsFlat(dir)
+}
+
+// loadSkillsFlat loads skills from immediate subdirectories only (Claude format).
+func loadSkillsFlat(dir string) []Skill {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+
+	var skills []Skill
+	for _, entry := range entries {
+		if !entry.IsDir() || isHidden(entry) || isSymlink(entry) {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name(), skillFile)
+		if skill, ok := loadSkillFile(path, entry.Name()); ok {
+			skills = append(skills, skill)
+		}
+	}
+	return skills
+}
+
+// loadSkillsRecursive walks dir for SKILL.md files (Codex format), tracking
+// real directory paths so symlink cycles can't loop forever.
+func loadSkillsRecursive(dir string) []Skill {
+	visited := make(map[string]bool)
+	if realDir, err := filepath.EvalSymlinks(dir); err == nil {
+		visited[realDir] = true
+	}
+
+	var skills []Skill
+	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+
+		if d.IsDir() {
+			if path == dir {
+				return nil
+			}
+			if isHidden(d) {
+				return fs.SkipDir
+			}
+			// De-duplicate by real path so symlink cycles are skipped.
+			realPath, err := filepath.EvalSymlinks(path)
+			if err == nil {
+				if visited[realPath] {
+					return fs.SkipDir
+				}
+				visited[realPath] = true
+			}
+			return nil
+		}
+
+		if d.Name() != skillFile {
+			return nil
+		}
+		dirName := filepath.Base(filepath.Dir(path))
+		if skill, ok := loadSkillFile(path, dirName); ok {
+			skills = append(skills, skill)
+		}
+		return nil
+	})
+	return skills
+}
+
+// loadSkillFile reads and parses a SKILL.md file. dirName is used as the
+// skill name when the frontmatter does not declare one.
+func loadSkillFile(path, dirName string) (Skill, bool) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return Skill{}, false
+	}
+
+	skill, ok := parseFrontmatter(string(content))
+	if !ok {
+		return Skill{}, false
+	}
+
+	skill.Name = cmp.Or(skill.Name, dirName)
+	if skill.Name == "" || skill.Description == "" {
+		return Skill{}, false
+	}
+
+	skill.FilePath = path
+	skill.BaseDir = filepath.Dir(path)
+	skill.Local = true
+	return skill, true
+}
+
+func isHidden(entry fs.DirEntry) bool {
+	name := entry.Name()
+	return name != "" && name[0] == '.'
+}
+
+func isSymlink(entry fs.DirEntry) bool {
+	return entry.Type()&os.ModeSymlink != 0
+}

--- a/pkg/skills/remote.go
+++ b/pkg/skills/remote.go
@@ -10,8 +10,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-
-	"github.com/docker/docker-agent/pkg/paths"
 )
 
 // remoteIndex represents the index.json served at /.well-known/skills/index.json
@@ -25,19 +23,11 @@ type remoteSkillEntry struct {
 	Files       []string `json:"files"`
 }
 
-func defaultCache() *diskCache {
-	return newDiskCache(filepath.Join(paths.GetCacheDir(), "skills"))
-}
-
-// loadRemoteSkills fetches skills from a remote URL per the well-known skills discovery spec.
-// It fetches /.well-known/skills/index.json, then prefetches all listed files
-// into a disk cache so the agent can read them without network requests during
-// task execution.
-func loadRemoteSkills(baseURL string) []Skill {
-	return loadRemoteSkillsWithCache(context.Background(), baseURL, defaultCache())
-}
-
-func loadRemoteSkillsWithCache(ctx context.Context, baseURL string, cache *diskCache) []Skill {
+// loadRemoteSkills fetches skills from a remote URL per the well-known skills
+// discovery spec. It fetches /.well-known/skills/index.json, then prefetches
+// all listed files into the given disk cache so the agent can read them
+// without network requests during task execution.
+func loadRemoteSkills(ctx context.Context, baseURL string, cache *diskCache) []Skill {
 	baseURL = strings.TrimRight(baseURL, "/")
 	indexURL := baseURL + "/.well-known/skills/index.json"
 

--- a/pkg/skills/remote_test.go
+++ b/pkg/skills/remote_test.go
@@ -47,7 +47,7 @@ func TestLoadRemoteSkills(t *testing.T) {
 
 		cacheDir := t.TempDir()
 		cache := newDiskCache(cacheDir)
-		skills := loadRemoteSkillsWithCache(t.Context(), srv.URL, cache)
+		skills := loadRemoteSkills(t.Context(), srv.URL, cache)
 
 		require.Len(t, skills, 2)
 
@@ -84,7 +84,7 @@ func TestLoadRemoteSkills(t *testing.T) {
 		defer srv.Close()
 
 		cache := newDiskCache(t.TempDir())
-		skills := loadRemoteSkillsWithCache(t.Context(), srv.URL+"/", cache)
+		skills := loadRemoteSkills(t.Context(), srv.URL+"/", cache)
 		require.Len(t, skills, 1)
 
 		content, err := os.ReadFile(skills[0].FilePath)
@@ -99,7 +99,7 @@ func TestLoadRemoteSkills(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		skills := loadRemoteSkillsWithCache(t.Context(), srv.URL, newDiskCache(t.TempDir()))
+		skills := loadRemoteSkills(t.Context(), srv.URL, newDiskCache(t.TempDir()))
 		assert.Empty(t, skills)
 	})
 
@@ -110,7 +110,7 @@ func TestLoadRemoteSkills(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		skills := loadRemoteSkillsWithCache(t.Context(), srv.URL, newDiskCache(t.TempDir()))
+		skills := loadRemoteSkills(t.Context(), srv.URL, newDiskCache(t.TempDir()))
 		assert.Empty(t, skills)
 	})
 
@@ -121,7 +121,7 @@ func TestLoadRemoteSkills(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		skills := loadRemoteSkillsWithCache(t.Context(), srv.URL, newDiskCache(t.TempDir()))
+		skills := loadRemoteSkills(t.Context(), srv.URL, newDiskCache(t.TempDir()))
 		assert.Empty(t, skills)
 	})
 
@@ -129,7 +129,7 @@ func TestLoadRemoteSkills(t *testing.T) {
 		srv := httptest.NewServer(http.NotFoundHandler())
 		defer srv.Close()
 
-		skills := loadRemoteSkillsWithCache(t.Context(), srv.URL, newDiskCache(t.TempDir()))
+		skills := loadRemoteSkills(t.Context(), srv.URL, newDiskCache(t.TempDir()))
 		assert.Empty(t, skills)
 	})
 
@@ -139,12 +139,12 @@ func TestLoadRemoteSkills(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		skills := loadRemoteSkillsWithCache(t.Context(), srv.URL, newDiskCache(t.TempDir()))
+		skills := loadRemoteSkills(t.Context(), srv.URL, newDiskCache(t.TempDir()))
 		assert.Empty(t, skills)
 	})
 
 	t.Run("unreachable server", func(t *testing.T) {
-		skills := loadRemoteSkillsWithCache(t.Context(), "http://127.0.0.1:1", newDiskCache(t.TempDir()))
+		skills := loadRemoteSkills(t.Context(), "http://127.0.0.1:1", newDiskCache(t.TempDir()))
 		assert.Empty(t, skills)
 	})
 
@@ -168,12 +168,12 @@ func TestLoadRemoteSkills(t *testing.T) {
 		cache := newDiskCache(t.TempDir())
 
 		// First load
-		skills1 := loadRemoteSkillsWithCache(t.Context(), srv.URL, cache)
+		skills1 := loadRemoteSkills(t.Context(), srv.URL, cache)
 		require.Len(t, skills1, 1)
 		assert.Equal(t, 2, fetchCount) // index.json + SKILL.md
 
 		// Second load — SKILL.md should be cached
-		skills2 := loadRemoteSkillsWithCache(t.Context(), srv.URL, cache)
+		skills2 := loadRemoteSkills(t.Context(), srv.URL, cache)
 		require.Len(t, skills2, 1)
 		assert.Equal(t, 3, fetchCount) // only index.json re-fetched, SKILL.md from cache
 	})
@@ -193,7 +193,7 @@ func TestLoadRemoteSkills(t *testing.T) {
 		defer srv.Close()
 
 		cache := newDiskCache(t.TempDir())
-		skills := loadRemoteSkillsWithCache(t.Context(), srv.URL, cache)
+		skills := loadRemoteSkills(t.Context(), srv.URL, cache)
 		require.Len(t, skills, 1)
 		// Only SKILL.md should have been fetched, not the malicious paths
 	})
@@ -363,7 +363,7 @@ func TestLoadRemoteSkills_RejectsSkillNameTraversal(t *testing.T) {
 
 	cacheBase := t.TempDir()
 	cache := newDiskCache(cacheBase)
-	skills := loadRemoteSkillsWithCache(t.Context(), srv.URL, cache)
+	skills := loadRemoteSkills(t.Context(), srv.URL, cache)
 
 	require.Len(t, skills, 1)
 	assert.Equal(t, "ok-skill", skills[0].Name)

--- a/pkg/skills/skills.go
+++ b/pkg/skills/skills.go
@@ -72,7 +72,13 @@ func Load(sources []string) []Skill {
 	}
 
 	return slices.SortedFunc(maps.Values(skillMap), func(a, b Skill) int {
-		return strings.Compare(a.Name, b.Name)
+		if c := strings.Compare(a.Name, b.Name); c != 0 {
+			return c
+		}
+		// FilePath is unique per skill, so this gives a fully
+		// deterministic ordering even when a local and a remote source
+		// expose a skill with the same name.
+		return strings.Compare(a.FilePath, b.FilePath)
 	})
 }
 

--- a/pkg/skills/skills.go
+++ b/pkg/skills/skills.go
@@ -2,7 +2,9 @@ package skills
 
 import (
 	"cmp"
+	"context"
 	"io/fs"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -57,6 +59,7 @@ func (s *Skill) IsFork() bool {
 func Load(sources []string) []Skill {
 	skillMap := make(map[string]Skill)
 
+	var remoteCache *diskCache
 	for _, source := range sources {
 		switch {
 		case source == "local":
@@ -64,17 +67,16 @@ func Load(sources []string) []Skill {
 				skillMap[skill.Name] = skill
 			}
 		case strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://"):
-			for _, skill := range loadRemoteSkills(source) {
+			if remoteCache == nil {
+				remoteCache = newDiskCache(filepath.Join(paths.GetCacheDir(), "skills"))
+			}
+			for _, skill := range loadRemoteSkills(context.Background(), source, remoteCache) {
 				skillMap[source+"/"+skill.Name] = skill
 			}
 		}
 	}
 
-	result := make([]Skill, 0, len(skillMap))
-	for _, skill := range skillMap {
-		result = append(result, skill)
-	}
-	return result
+	return slices.Collect(maps.Values(skillMap))
 }
 
 // loadLocalSkills loads skills from standard filesystem locations.
@@ -113,11 +115,7 @@ func loadLocalSkills() []Skill {
 		}
 	}
 
-	result := make([]Skill, 0, len(skillMap))
-	for _, skill := range skillMap {
-		result = append(result, skill)
-	}
-	return result
+	return slices.Collect(maps.Values(skillMap))
 }
 
 // projectSearchDirs returns directories from git root to cwd (inclusive).
@@ -185,11 +183,6 @@ func findGitRoot(dir string) string {
 // If recursive is true, it walks all subdirectories looking for SKILL.md files.
 // If recursive is false, it only looks for SKILL.md in immediate subdirectories.
 func loadSkillsFromDir(dir string, recursive bool) []Skill {
-	info, err := os.Stat(dir)
-	if err != nil || !info.IsDir() {
-		return nil
-	}
-
 	if recursive {
 		return loadSkillsRecursive(dir)
 	}
@@ -220,9 +213,8 @@ func loadSkillsFlat(dir string) []Skill {
 	return skills
 }
 
-// loadSkillsRecursive loads skills from all subdirectories (Codex format).
-// It tracks visited real directory paths to avoid infinite loops caused by
-// symlinks that form cycles.
+// loadSkillsRecursive walks dir for SKILL.md files (Codex format), tracking
+// real directory paths so symlink cycles can't loop forever.
 func loadSkillsRecursive(dir string) []Skill {
 	visited := make(map[string]bool)
 
@@ -231,14 +223,7 @@ func loadSkillsRecursive(dir string) []Skill {
 		visited[realDir] = true
 	}
 
-	return walkSkillsRecursive(dir, visited)
-}
-
-// walkSkillsRecursive walks dir for SKILL.md files, using visited to skip
-// directories whose real path has already been traversed.
-func walkSkillsRecursive(dir string, visited map[string]bool) []Skill {
 	var skills []Skill
-
 	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return nil
@@ -267,9 +252,7 @@ func walkSkillsRecursive(dir string, visited map[string]bool) []Skill {
 		}
 
 		skillDir := filepath.Dir(path)
-		dirName := filepath.Base(skillDir)
-
-		if skill, ok := loadSkillFile(path, dirName); ok {
+		if skill, ok := loadSkillFile(path, filepath.Base(skillDir)); ok {
 			skills = append(skills, skill)
 		}
 		return nil

--- a/pkg/skills/skills.go
+++ b/pkg/skills/skills.go
@@ -1,19 +1,14 @@
 package skills
 
 import (
-	"cmp"
 	"context"
-	"io/fs"
 	"maps"
-	"os"
 	"path/filepath"
 	"slices"
 	"strings"
 
 	"github.com/docker/docker-agent/pkg/paths"
 )
-
-const skillFile = "SKILL.md"
 
 // Skill represents a loaded skill with its metadata and content location.
 type Skill struct {
@@ -38,24 +33,26 @@ type Skill struct {
 // IsFork returns true when the skill should be executed in an isolated
 // sub-agent context rather than inline in the current conversation.
 // This matches Claude Code's `context: fork` frontmatter syntax.
-func (s *Skill) IsFork() bool {
+func (s Skill) IsFork() bool {
 	return s.Context == "fork"
 }
 
 // Load discovers and loads skills from the given sources.
-// Each source is either "local" (for filesystem-based skills) or an HTTP/HTTPS URL
-// (for remote skills per the well-known skills discovery spec).
+// Each source is either "local" (for filesystem-based skills) or an HTTP/HTTPS
+// URL (for remote skills per the well-known skills discovery spec).
 //
 // Local skills are loaded from (in order, later overrides earlier):
 //
-// Global locations (from home directory):
+// Global locations (under $HOME):
 //   - ~/.codex/skills/ (recursive)
 //   - ~/.claude/skills/ (flat)
 //   - ~/.agents/skills/ (recursive)
 //
-// Project locations (from git root up to cwd, closest wins):
+// Project locations (under cwd, closest wins):
 //   - .claude/skills/ (flat, only at cwd)
 //   - .agents/skills/ (flat, scanned from git root to cwd)
+//
+// The returned slice is sorted by skill name for deterministic ordering.
 func Load(sources []string) []Skill {
 	skillMap := make(map[string]Skill)
 
@@ -63,10 +60,8 @@ func Load(sources []string) []Skill {
 	for _, source := range sources {
 		switch {
 		case source == "local":
-			for _, skill := range loadLocalSkills() {
-				skillMap[skill.Name] = skill
-			}
-		case strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://"):
+			loadLocalSkillsInto(skillMap)
+		case isHTTPSource(source):
 			if remoteCache == nil {
 				remoteCache = newDiskCache(filepath.Join(paths.GetCacheDir(), "skills"))
 			}
@@ -76,327 +71,12 @@ func Load(sources []string) []Skill {
 		}
 	}
 
-	return slices.Collect(maps.Values(skillMap))
-}
-
-// loadLocalSkills loads skills from standard filesystem locations.
-func loadLocalSkills() []Skill {
-	skillMap := make(map[string]Skill)
-
-	homeDir := paths.GetHomeDir()
-	if homeDir != "" {
-		// Load from codex directory (recursive)
-		for _, skill := range loadSkillsFromDir(filepath.Join(homeDir, ".codex", "skills"), true) {
-			skillMap[skill.Name] = skill
-		}
-		// Load from claude user directory (flat)
-		for _, skill := range loadSkillsFromDir(filepath.Join(homeDir, ".claude", "skills"), false) {
-			skillMap[skill.Name] = skill
-		}
-		// Load from agents user directory (recursive)
-		for _, skill := range loadSkillsFromDir(filepath.Join(homeDir, ".agents", "skills"), true) {
-			skillMap[skill.Name] = skill
-		}
-	}
-
-	// Load from project directories
-	if cwd, err := os.Getwd(); err == nil {
-		// Load .claude/skills from cwd only (backward compatibility)
-		for _, skill := range loadSkillsFromDir(filepath.Join(cwd, ".claude", "skills"), false) {
-			skillMap[skill.Name] = skill
-		}
-
-		// Load .agents/skills from git root up to cwd (closest wins)
-		// We iterate from root to cwd so that later (closer) directories override earlier ones
-		for _, dir := range projectSearchDirs(cwd) {
-			for _, skill := range loadSkillsFromDir(filepath.Join(dir, ".agents", "skills"), false) {
-				skillMap[skill.Name] = skill
-			}
-		}
-	}
-
-	return slices.Collect(maps.Values(skillMap))
-}
-
-// projectSearchDirs returns directories from git root to cwd (inclusive).
-// If not in a git repo, returns only cwd.
-// The returned slice is ordered from root to cwd so that closer directories
-// can override skills from parent directories.
-func projectSearchDirs(cwd string) []string {
-	absPath, err := filepath.Abs(cwd)
-	if err != nil {
-		return []string{cwd}
-	}
-
-	// Find git root by walking up
-	gitRoot := findGitRoot(absPath)
-	if gitRoot == "" {
-		// Not in a git repo, just return cwd
-		return []string{absPath}
-	}
-
-	// Build list of directories from git root to cwd
-	var dirs []string
-	current := absPath
-	for {
-		dirs = append(dirs, current)
-		if current == gitRoot {
-			break
-		}
-		parent := filepath.Dir(current)
-		if parent == current {
-			// Reached filesystem root without finding git root (shouldn't happen)
-			break
-		}
-		current = parent
-	}
-
-	// Reverse so we go from root to cwd (earlier entries get overridden by later)
-	slices.Reverse(dirs)
-
-	return dirs
-}
-
-// findGitRoot finds the git repository root by looking for .git directory or file.
-// Returns empty string if not in a git repository.
-func findGitRoot(dir string) string {
-	current := dir
-	for {
-		gitPath := filepath.Join(current, ".git")
-		if info, err := os.Stat(gitPath); err == nil {
-			// .git can be a directory (normal repo) or a file (worktree/submodule)
-			if info.IsDir() || info.Mode().IsRegular() {
-				return current
-			}
-		}
-
-		parent := filepath.Dir(current)
-		if parent == current {
-			// Reached filesystem root
-			return ""
-		}
-		current = parent
-	}
-}
-
-// loadSkillsFromDir loads skills from a directory.
-// If recursive is true, it walks all subdirectories looking for SKILL.md files.
-// If recursive is false, it only looks for SKILL.md in immediate subdirectories.
-func loadSkillsFromDir(dir string, recursive bool) []Skill {
-	if recursive {
-		return loadSkillsRecursive(dir)
-	}
-	return loadSkillsFlat(dir)
-}
-
-// loadSkillsFlat loads skills from immediate subdirectories only (Claude format).
-func loadSkillsFlat(dir string) []Skill {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return nil
-	}
-
-	var skills []Skill
-	for _, entry := range entries {
-		if !entry.IsDir() || (isHidden(entry) || isSymlink(entry)) {
-			continue
-		}
-
-		skillDir := filepath.Join(dir, entry.Name())
-		skillFilePath := filepath.Join(skillDir, skillFile)
-
-		skill, ok := loadSkillFile(skillFilePath, entry.Name())
-		if ok {
-			skills = append(skills, skill)
-		}
-	}
-	return skills
-}
-
-// loadSkillsRecursive walks dir for SKILL.md files (Codex format), tracking
-// real directory paths so symlink cycles can't loop forever.
-func loadSkillsRecursive(dir string) []Skill {
-	visited := make(map[string]bool)
-
-	// Resolve the root so cycles back to it are detected.
-	if realDir, err := filepath.EvalSymlinks(dir); err == nil {
-		visited[realDir] = true
-	}
-
-	var skills []Skill
-	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return nil
-		}
-
-		if d.IsDir() {
-			if path != dir && isHidden(d) {
-				return fs.SkipDir
-			}
-
-			// Resolve and de-duplicate real directory paths to catch
-			// cycles introduced through symlinks higher up.
-			if path != dir {
-				if realPath, err := filepath.EvalSymlinks(path); err == nil {
-					if visited[realPath] {
-						return fs.SkipDir
-					}
-					visited[realPath] = true
-				}
-			}
-			return nil
-		}
-
-		if d.Name() != skillFile {
-			return nil
-		}
-
-		skillDir := filepath.Dir(path)
-		if skill, ok := loadSkillFile(path, filepath.Base(skillDir)); ok {
-			skills = append(skills, skill)
-		}
-		return nil
+	return slices.SortedFunc(maps.Values(skillMap), func(a, b Skill) int {
+		return strings.Compare(a.Name, b.Name)
 	})
-
-	return skills
 }
 
-// loadSkillFile reads and parses a SKILL.md file.
-func loadSkillFile(path, dirName string) (Skill, bool) {
-	content, err := os.ReadFile(path)
-	if err != nil {
-		return Skill{}, false
-	}
-
-	skill, ok := parseFrontmatter(string(content))
-	if !ok {
-		return Skill{}, false
-	}
-
-	skill.Name = cmp.Or(skill.Name, dirName)
-
-	if !isValidSkill(skill) {
-		return Skill{}, false
-	}
-	skill.FilePath = path
-	skill.BaseDir = filepath.Dir(path)
-	skill.Local = true
-
-	return skill, true
-}
-
-// parseFrontmatter extracts and parses the YAML-like frontmatter from a
-// markdown file. Instead of using a full YAML parser (which rejects unquoted
-// colons in values), we do simple line-by-line key: value splitting on the
-// first ": ". This is more robust for the simple frontmatter format used by
-// skill files.
-func parseFrontmatter(content string) (Skill, bool) {
-	content = strings.ReplaceAll(content, "\r\n", "\n")
-	content = strings.ReplaceAll(content, "\r", "\n")
-
-	if !strings.HasPrefix(content, "---") {
-		return Skill{}, false
-	}
-
-	endIndex := strings.Index(content[3:], "\n---")
-	if endIndex == -1 {
-		return Skill{}, false
-	}
-
-	block := content[4 : endIndex+3]
-	lines := strings.Split(block, "\n")
-
-	var skill Skill
-	var currentKey string // tracks multi-line keys like "metadata" or "allowed-tools"
-
-	for _, line := range lines {
-		// Indented lines belong to the current multi-line key.
-		if line != "" && (line[0] == ' ' || line[0] == '\t') {
-			trimmed := strings.TrimSpace(line)
-			switch currentKey {
-			case "metadata":
-				if k, v, ok := splitKeyValue(trimmed); ok {
-					if skill.Metadata == nil {
-						skill.Metadata = make(map[string]string)
-					}
-					skill.Metadata[k] = unquote(v)
-				}
-			case "allowed-tools":
-				if strings.HasPrefix(trimmed, "- ") {
-					skill.AllowedTools = append(skill.AllowedTools, unquote(strings.TrimSpace(trimmed[2:])))
-				}
-			}
-			continue
-		}
-
-		currentKey = ""
-		key, value, ok := splitKeyValue(line)
-		if !ok {
-			continue
-		}
-
-		switch key {
-		case "name":
-			skill.Name = unquote(value)
-		case "description":
-			skill.Description = unquote(value)
-		case "license":
-			skill.License = unquote(value)
-		case "compatibility":
-			skill.Compatibility = unquote(value)
-		case "context":
-			skill.Context = unquote(value)
-		case "model":
-			skill.Model = unquote(value)
-		case "metadata":
-			currentKey = "metadata"
-		case "allowed-tools":
-			if value != "" {
-				// Inline comma-separated list.
-				for item := range strings.SplitSeq(value, ",") {
-					if t := unquote(strings.TrimSpace(item)); t != "" {
-						skill.AllowedTools = append(skill.AllowedTools, t)
-					}
-				}
-			} else {
-				currentKey = "allowed-tools"
-			}
-		}
-	}
-
-	return skill, true
-}
-
-// splitKeyValue splits a line on the first ": " into key and value.
-func splitKeyValue(line string) (string, string, bool) {
-	if key, value, ok := strings.Cut(line, ": "); ok {
-		return key, value, true
-	}
-	// Handle "key:" with no value (e.g. "metadata:").
-	if strings.HasSuffix(line, ":") {
-		return line[:len(line)-1], "", true
-	}
-	return "", "", false
-}
-
-// unquote strips matching surrounding quotes from a string value.
-func unquote(s string) string {
-	if len(s) >= 2 {
-		if (s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'') {
-			return s[1 : len(s)-1]
-		}
-	}
-	return s
-}
-
-func isValidSkill(skill Skill) bool {
-	return skill.Description != "" && skill.Name != ""
-}
-
-func isHidden(entry fs.DirEntry) bool {
-	return strings.HasPrefix(entry.Name(), ".")
-}
-
-func isSymlink(entry fs.DirEntry) bool {
-	return entry.Type()&os.ModeSymlink != 0
+// isHTTPSource reports whether s is an HTTP(S) URL source.
+func isHTTPSource(s string) bool {
+	return strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://")
 }


### PR DESCRIPTION
## Summary

Internal refactor of `pkg/skills` to make the package easier to read and maintain. **No public API or behavior change.**

## Why

`pkg/skills/skills.go` had grown to 402 lines doing five different jobs (types, public API, local discovery, frontmatter parsing, helpers). The precedence rules for local skill loading were buried in nested for-loops. A few one-line wrappers (`loadRemoteSkills` → `loadRemoteSkillsWithCache`, `defaultCache()`) added indirection without value.

## What changed

Three small commits:

1. **`refactor(skills): inline trivial wrappers and use maps.Values`**
   - Merge `loadRemoteSkills` wrapper + `defaultCache()` helper.
   - Merge `loadSkillsRecursive` + `walkSkillsRecursive`.
   - Use `slices.Collect(maps.Values(...))` for map → slice conversions.
   - Drop redundant `os.Stat` in `loadSkillsFromDir`.

2. **`refactor(skills): split package into focused files`**
   - `skills.go` (402 → 82 lines): public API only — `Skill` type + `Load`.
   - `local.go` (new): filesystem discovery, with a declarative `localSearchPaths()` table that makes the precedence rules (codex → claude → agents → project) easy to read at a glance. `findGitRoot`+`projectSearchDirs` share a single walk-up.
   - `frontmatter.go` (new): YAML-ish frontmatter parsing, split into `parseTopLevelLine` and `parseIndentedLine`.
   - `Load` now sorts its result by `Name` for deterministic output.
   - `Load` avoids the double map → slice → map round-trip via `loadLocalSkillsInto`.
   - `Skill.IsFork` uses a value receiver for consistency.
   - `isHTTPSource` extracted from `Load`.

3. **`fix(skills): tighten review nits from refactor`**
   - `Load`: add `FilePath` tiebreaker to the sort. `slices.SortedFunc` uses pdqsort which is unstable, so two skills sharing a `Name` (e.g. local + remote both exposing `foo`) would have non-deterministic relative order. `FilePath` is unique → fully deterministic output.
   - Clarify symlink behavior in `loadSkillsFlat` (skips symlinks explicitly) and `loadSkillsRecursive` (`filepath.WalkDir` does not follow symlinks; the visited map is defensive against bind mounts and symlinked roots, not symlinks inside the tree).

## File sizes (before → after)

| File | Before | After |
|---|---|---|
| `skills.go` | 402 | 82 |
| `local.go` | — | 232 |
| `frontmatter.go` | — | 122 |
| `remote.go` | 153 | 136 |

## Validation

- `mise lint` — clean (golangci-lint + custom cop + `go mod tidy --diff`)
- `mise test` — all packages pass
- Public API unchanged: `Skill`, `Skill.IsFork`, `Load`, `ExpandCommands` keep the same signatures
