### PR TITLE
feat(fetch): add allowed_domains and blocked_domains filters

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -1319,6 +1319,28 @@
           "description": "Timeout in seconds for the fetch tool",
           "minimum": 1
         },
+        "allowed_domains": {
+          "type": "array",
+          "description": "Allow-list of domains the fetch tool is permitted to fetch (only valid for type 'fetch'). A pattern matches the host exactly (case-insensitive) and any of its subdomains; e.g. 'example.com' matches 'example.com' and 'docs.example.com' but not 'badexample.com'. A leading dot ('.example.com') restricts the match to strict subdomains. Mutually exclusive with 'blocked_domains'.",
+          "items": {
+            "type": "string"
+          },
+          "examples": [
+            ["docker.com", "docs.docker.com"],
+            ["github.com", "raw.githubusercontent.com"]
+          ]
+        },
+        "blocked_domains": {
+          "type": "array",
+          "description": "Deny-list of domains the fetch tool is forbidden to fetch (only valid for type 'fetch'). Uses the same matching rules as 'allowed_domains'. Mutually exclusive with 'allowed_domains'.",
+          "items": {
+            "type": "string"
+          },
+          "examples": [
+            ["internal.example.com"],
+            ["169.254.169.254"]
+          ]
+        },
         "url": {
           "type": "string",
           "description": "URL for the a2a or openapi tool",

--- a/docs/tools/fetch/index.md
+++ b/docs/tools/fetch/index.md
@@ -41,8 +41,17 @@ Domain patterns in `allowed_domains` and `blocked_domains` use the following rul
 - **Bare domain** — `example.com` matches the host `example.com` _and_ any subdomain such as `docs.example.com`. It does **not** match unrelated hosts that share a suffix (e.g. `badexample.com`).
 - **Leading dot** — `.example.com` matches **only** strict subdomains (`docs.example.com`, `a.b.example.com`), not the apex `example.com`.
 - **IP literal** — IP addresses are matched exactly (`169.254.169.254`).
+- **Trailing dots** in FQDN-form URLs (`http://example.com./`) are stripped before matching, so they cannot bypass a deny-list entry.
 
 The lists are mutually exclusive: a single fetch toolset may set either `allowed_domains` or `blocked_domains`, but not both.
+
+When a list is configured, every redirect target is re-checked against the same list. A request to an allowed origin that redirects to a forbidden host is rejected before any data is read from the redirect.
+
+<div class="callout callout-warning" markdown="1">
+<div class="callout-title">⚠️ Limitations
+</div>
+  <p>Matching is purely string-based on the URL host. It does <strong>not</strong> perform DNS resolution and does <strong>not</strong> normalise alternative IP encodings (decimal <code>2852039166</code>, hex <code>0xa9.0xfe.0xa9.0xfe</code>, octal, IPv4-mapped IPv6, etc.). If you need to deny access to a specific IP, also list its alternative encodings, or block at the network layer.</p>
+</div>
 
 ### Custom Timeout
 

--- a/docs/tools/fetch/index.md
+++ b/docs/tools/fetch/index.md
@@ -28,9 +28,21 @@ toolsets:
 
 ### Options
 
-| Property  | Type | Default | Description                                                       |
-| --------- | ---- | ------- | ----------------------------------------------------------------- |
-| `timeout` | int  | `30`    | Default request timeout in seconds (overridable per tool call).   |
+| Property          | Type           | Default | Description                                                                                                                                                                                                                                                                                                                  |
+| ----------------- | -------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `timeout`         | int            | `30`    | Default request timeout in seconds (overridable per tool call).                                                                                                                                                                                                                                                              |
+| `allowed_domains` | array[string]  | _none_  | Allow-list of hosts the tool may fetch. When set, every URL whose host is **not** in the list is rejected before any network call is made. Mutually exclusive with `blocked_domains`.                                                                                                                                        |
+| `blocked_domains` | array[string]  | _none_  | Deny-list of hosts the tool must not fetch. URLs whose host matches one of these patterns are rejected before any network call (including `robots.txt`) is made. Mutually exclusive with `allowed_domains`.                                                                                                                  |
+
+### Domain matching
+
+Domain patterns in `allowed_domains` and `blocked_domains` use the following rules (case-insensitive):
+
+- **Bare domain** — `example.com` matches the host `example.com` _and_ any subdomain such as `docs.example.com`. It does **not** match unrelated hosts that share a suffix (e.g. `badexample.com`).
+- **Leading dot** — `.example.com` matches **only** strict subdomains (`docs.example.com`, `a.b.example.com`), not the apex `example.com`.
+- **IP literal** — IP addresses are matched exactly (`169.254.169.254`).
+
+The lists are mutually exclusive: a single fetch toolset may set either `allowed_domains` or `blocked_domains`, but not both.
 
 ### Custom Timeout
 
@@ -38,6 +50,27 @@ toolsets:
 toolsets:
   - type: fetch
     timeout: 60
+```
+
+### Restrict to specific domains
+
+```yaml
+toolsets:
+  - type: fetch
+    allowed_domains:
+      - docker.com          # docker.com and *.docker.com
+      - github.com          # github.com and *.github.com
+      - .githubusercontent.com  # only subdomains, e.g. raw.githubusercontent.com
+```
+
+### Block sensitive hosts
+
+```yaml
+toolsets:
+  - type: fetch
+    blocked_domains:
+      - 169.254.169.254       # cloud metadata endpoint
+      - internal.example.com  # internal corporate hostnames
 ```
 
 ## Tool Interface

--- a/examples/fetch_domain_filtering.yaml
+++ b/examples/fetch_domain_filtering.yaml
@@ -1,0 +1,41 @@
+#!/usr/bin/env docker agent run
+
+# Demonstrates domain filtering for the fetch tool. The agent is only allowed
+# to fetch URLs whose host matches one of the entries in `allowed_domains`
+# (the host itself or any subdomain). Use `blocked_domains` instead to keep
+# fetch open by default while denying specific hosts.
+
+agents:
+  root:
+    model: anthropic/claude-sonnet-4-5
+    description: An agent restricted to Docker and GitHub documentation.
+    instruction: |
+      You are a documentation assistant. You may only fetch pages from the
+      docker.com and github.com families of domains. If asked about an
+      external resource, politely refuse and suggest a search instead.
+    toolsets:
+      - type: fetch
+        # Each entry matches the bare host AND any subdomain.
+        # Example: "docker.com" matches docker.com AND docs.docker.com.
+        # Use ".github.com" to match strict subdomains only.
+        allowed_domains:
+          - docker.com
+          - github.com
+          - raw.githubusercontent.com
+
+  # Alternative: keep fetch open but deny specific hosts (e.g. cloud
+  # metadata endpoints, internal services). Switch the active agent to
+  # `safe_fetch` with `-a safe_fetch` to try this variant.
+  safe_fetch:
+    model: anthropic/claude-sonnet-4-5
+    description: An agent that can fetch the open web except a few sensitive hosts.
+    instruction: |
+      You are a research assistant. Use the fetch tool to gather information
+      from the public web. Some hosts are blocked for safety; if a fetch is
+      rejected, do not retry and explain the situation to the user.
+    toolsets:
+      - type: fetch
+        blocked_domains:
+          - 169.254.169.254     # cloud instance metadata
+          - 100.100.100.200     # alibaba/oracle metadata
+          - metadata.google.internal

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -816,6 +816,18 @@ type Toolset struct {
 	// For the `fetch` tool
 	Timeout int `json:"timeout,omitempty"`
 
+	// For the `fetch` tool - allow-list of domains the tool is permitted to fetch.
+	// A pattern matches the host exactly (case-insensitive) and any of its subdomains;
+	// e.g. "example.com" matches "example.com" and "docs.example.com" but not
+	// "badexample.com". A leading dot (".example.com") restricts the match to
+	// strict subdomains. Mutually exclusive with `blocked_domains`.
+	AllowedDomains []string `json:"allowed_domains,omitempty" yaml:"allowed_domains,omitempty"`
+
+	// For the `fetch` tool - deny-list of domains the tool is forbidden to fetch.
+	// Uses the same matching rules as `allowed_domains`. Mutually exclusive with
+	// `allowed_domains`.
+	BlockedDomains []string `json:"blocked_domains,omitempty" yaml:"blocked_domains,omitempty"`
+
 	// For the `rag` tool
 	RAGConfig *RAGConfig `json:"rag_config,omitempty" yaml:"rag_config,omitempty"`
 

--- a/pkg/config/latest/validate.go
+++ b/pkg/config/latest/validate.go
@@ -88,6 +88,12 @@ func (t *Toolset) validate() error {
 	if len(t.AllowedDomains) > 0 && len(t.BlockedDomains) > 0 {
 		return errors.New("allowed_domains and blocked_domains are mutually exclusive")
 	}
+	if err := validateDomainPatterns("allowed_domains", t.AllowedDomains); err != nil {
+		return err
+	}
+	if err := validateDomainPatterns("blocked_domains", t.BlockedDomains); err != nil {
+		return err
+	}
 	if len(t.Models) > 0 && t.Type != "model_picker" {
 		return errors.New("models can only be used with type 'model_picker'")
 	}
@@ -200,6 +206,18 @@ func (t *Toolset) validate() error {
 		// no additional validation needed
 	}
 
+	return nil
+}
+
+// validateDomainPatterns rejects empty / whitespace-only entries in a fetch
+// allow- or block-list, since they silently match nothing and turn the list
+// into a foot-gun (e.g. allowed_domains: [""] would reject every URL).
+func validateDomainPatterns(field string, patterns []string) error {
+	for i, p := range patterns {
+		if strings.TrimSpace(p) == "" {
+			return fmt.Errorf("%s[%d] must not be empty", field, i)
+		}
+	}
 	return nil
 }
 

--- a/pkg/config/latest/validate.go
+++ b/pkg/config/latest/validate.go
@@ -79,6 +79,15 @@ func (t *Toolset) validate() error {
 	if len(t.FileTypes) > 0 && t.Type != "lsp" {
 		return errors.New("file_types can only be used with type 'lsp'")
 	}
+	if len(t.AllowedDomains) > 0 && t.Type != "fetch" {
+		return errors.New("allowed_domains can only be used with type 'fetch'")
+	}
+	if len(t.BlockedDomains) > 0 && t.Type != "fetch" {
+		return errors.New("blocked_domains can only be used with type 'fetch'")
+	}
+	if len(t.AllowedDomains) > 0 && len(t.BlockedDomains) > 0 {
+		return errors.New("allowed_domains and blocked_domains are mutually exclusive")
+	}
 	if len(t.Models) > 0 && t.Type != "model_picker" {
 		return errors.New("models can only be used with type 'model_picker'")
 	}

--- a/pkg/config/latest/validate_test.go
+++ b/pkg/config/latest/validate_test.go
@@ -298,6 +298,35 @@ agents:
 `,
 			wantErr: "blocked_domains can only be used with type 'fetch'",
 		},
+		{
+			name: "empty allowed_domains entry is rejected",
+			config: `
+version: "8"
+agents:
+  root:
+    model: "openai/gpt-4"
+    toolsets:
+      - type: fetch
+        allowed_domains:
+          - ""
+          - docker.com
+`,
+			wantErr: "allowed_domains[0] must not be empty",
+		},
+		{
+			name: "whitespace-only blocked_domains entry is rejected",
+			config: `
+version: "8"
+agents:
+  root:
+    model: "openai/gpt-4"
+    toolsets:
+      - type: fetch
+        blocked_domains:
+          - "   "
+`,
+			wantErr: "blocked_domains[0] must not be empty",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/config/latest/validate_test.go
+++ b/pkg/config/latest/validate_test.go
@@ -217,6 +217,106 @@ agents:
 	}
 }
 
+func TestToolset_Validate_Fetch_Domains(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		config  string
+		wantErr string
+	}{
+		{
+			name: "fetch with allowed_domains",
+			config: `
+version: "8"
+agents:
+  root:
+    model: "openai/gpt-4"
+    toolsets:
+      - type: fetch
+        allowed_domains:
+          - docker.com
+          - github.com
+`,
+			wantErr: "",
+		},
+		{
+			name: "fetch with blocked_domains",
+			config: `
+version: "8"
+agents:
+  root:
+    model: "openai/gpt-4"
+    toolsets:
+      - type: fetch
+        blocked_domains:
+          - 169.254.169.254
+`,
+			wantErr: "",
+		},
+		{
+			name: "fetch with both is rejected",
+			config: `
+version: "8"
+agents:
+  root:
+    model: "openai/gpt-4"
+    toolsets:
+      - type: fetch
+        allowed_domains:
+          - docker.com
+        blocked_domains:
+          - example.com
+`,
+			wantErr: "allowed_domains and blocked_domains are mutually exclusive",
+		},
+		{
+			name: "allowed_domains on non-fetch toolset is rejected",
+			config: `
+version: "8"
+agents:
+  root:
+    model: "openai/gpt-4"
+    toolsets:
+      - type: shell
+        allowed_domains:
+          - docker.com
+`,
+			wantErr: "allowed_domains can only be used with type 'fetch'",
+		},
+		{
+			name: "blocked_domains on non-fetch toolset is rejected",
+			config: `
+version: "8"
+agents:
+  root:
+    model: "openai/gpt-4"
+    toolsets:
+      - type: shell
+        blocked_domains:
+          - docker.com
+`,
+			wantErr: "blocked_domains can only be used with type 'fetch'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var cfg Config
+			err := yaml.Unmarshal([]byte(tt.config), &cfg)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestToolset_Validate_MCP_RemoteOAuth_CallbackRedirectURL(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/teamloader/registry.go
+++ b/pkg/teamloader/registry.go
@@ -291,6 +291,12 @@ func createFetchTool(_ context.Context, toolset latest.Toolset, _ string, _ *con
 		timeout := time.Duration(toolset.Timeout) * time.Second
 		opts = append(opts, builtin.WithTimeout(timeout))
 	}
+	if len(toolset.AllowedDomains) > 0 {
+		opts = append(opts, builtin.WithAllowedDomains(toolset.AllowedDomains))
+	}
+	if len(toolset.BlockedDomains) > 0 {
+		opts = append(opts, builtin.WithBlockedDomains(toolset.BlockedDomains))
+	}
 	return builtin.NewFetchTool(opts...), nil
 }
 

--- a/pkg/tools/builtin/fetch.go
+++ b/pkg/tools/builtin/fetch.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 
@@ -270,56 +271,38 @@ func (h *fetchHandler) checkDomainAllowed(u *url.URL) error {
 	if host == "" {
 		return errors.New("URL has no host")
 	}
-	if len(h.blockedDomains) > 0 && matchesAnyDomain(host, h.blockedDomains) {
-		return fmt.Errorf("URL host %q is blocked by blocked_domains", host)
+	matchesAny := func(patterns []string) bool {
+		return slices.ContainsFunc(patterns, func(p string) bool {
+			return matchesDomain(host, p)
+		})
 	}
-	if len(h.allowedDomains) > 0 && !matchesAnyDomain(host, h.allowedDomains) {
+	switch {
+	case len(h.blockedDomains) > 0 && matchesAny(h.blockedDomains):
+		return fmt.Errorf("URL host %q is blocked by blocked_domains", host)
+	case len(h.allowedDomains) > 0 && !matchesAny(h.allowedDomains):
 		return fmt.Errorf("URL host %q is not in allowed_domains", host)
 	}
 	return nil
 }
 
-// matchesAnyDomain reports whether host matches any of the supplied patterns.
-// See matchesDomain for the matching rules.
-func matchesAnyDomain(host string, patterns []string) bool {
-	for _, p := range patterns {
-		if matchesDomain(host, p) {
-			return true
-		}
-	}
-	return false
-}
-
-// matchesDomain reports whether host matches pattern.
+// matchesDomain reports whether host matches pattern (case-insensitive).
 //
-// Matching rules (case-insensitive):
-//   - An empty pattern matches nothing.
-//   - A pattern with a leading dot (".example.com") matches strict subdomains
-//     of example.com but NOT example.com itself.
-//   - Any other pattern ("example.com") matches the host exactly and any of
-//     its subdomains (e.g. "docs.example.com"). It does NOT match unrelated
-//     hosts that share a suffix (e.g. "badexample.com").
+// A bare pattern ("example.com") matches the host exactly or any subdomain
+// ("docs.example.com"); it does NOT match unrelated hosts that share a suffix
+// ("badexample.com"). A pattern with a leading dot (".example.com") matches
+// strict subdomains only — the apex "example.com" is excluded.
 func matchesDomain(host, pattern string) bool {
 	host = strings.ToLower(strings.TrimSpace(host))
 	pattern = strings.ToLower(strings.TrimSpace(pattern))
-	if host == "" || pattern == "" {
+	if host == "" || pattern == "" || pattern == "." {
 		return false
 	}
-	// Strip IPv6 brackets if any (url.URL.Hostname already does this, but be safe).
-	host = strings.Trim(host, "[]")
-
-	subdomainOnly := strings.HasPrefix(pattern, ".")
-	if subdomainOnly {
-		pattern = strings.TrimPrefix(pattern, ".")
-		if pattern == "" {
-			return false
-		}
-		return strings.HasSuffix(host, "."+pattern)
+	if strings.HasPrefix(pattern, ".") {
+		// Strict subdomain match: ".example.com" matches "x.example.com" but not "example.com".
+		return strings.HasSuffix(host, pattern)
 	}
-	if host == pattern {
-		return true
-	}
-	return strings.HasSuffix(host, "."+pattern)
+	// Apex or subdomain match.
+	return host == pattern || strings.HasSuffix(host, "."+pattern)
 }
 
 func htmlToMarkdown(html string) string {
@@ -376,17 +359,12 @@ func WithBlockedDomains(domains []string) FetchToolOption {
 
 func (t *FetchTool) Instructions() string {
 	var b strings.Builder
-	b.WriteString("## Fetch Tool\n\n")
-	b.WriteString("Fetch content from HTTP/HTTPS URLs. Supports multiple URLs per call, output format selection (text, markdown, html), and respects robots.txt.")
-	if len(t.handler.allowedDomains) > 0 {
-		b.WriteString("\n\nThis tool is restricted to the following domains (and their subdomains): ")
-		b.WriteString(strings.Join(t.handler.allowedDomains, ", "))
-		b.WriteString(". Requests to any other host will fail without making a network call.")
+	b.WriteString("## Fetch Tool\n\nFetch content from HTTP/HTTPS URLs. Supports multiple URLs per call, output format selection (text, markdown, html), and respects robots.txt.")
+	if d := t.handler.allowedDomains; len(d) > 0 {
+		fmt.Fprintf(&b, "\n\nThis tool is restricted to these domains (and any subdomain): %s. Other hosts are rejected without a network call.", strings.Join(d, ", "))
 	}
-	if len(t.handler.blockedDomains) > 0 {
-		b.WriteString("\n\nThis tool is forbidden from fetching the following domains (and their subdomains): ")
-		b.WriteString(strings.Join(t.handler.blockedDomains, ", "))
-		b.WriteString(". Requests to those hosts will fail without making a network call.")
+	if d := t.handler.blockedDomains; len(d) > 0 {
+		fmt.Fprintf(&b, "\n\nThis tool must not fetch these domains (or any subdomain): %s. They are rejected without a network call.", strings.Join(d, ", "))
 	}
 	return b.String()
 }

--- a/pkg/tools/builtin/fetch.go
+++ b/pkg/tools/builtin/fetch.go
@@ -55,6 +55,15 @@ func (h *fetchHandler) CallTool(ctx context.Context, params FetchToolArgs) (*too
 	client := &http.Client{
 		Timeout:   h.timeout,
 		Transport: remote.NewTransport(ctx),
+		// Re-check the domain allow/deny lists on every redirect: without this,
+		// an allowed origin could redirect into a denied one and bypass the
+		// policy. The 10-redirect cap mirrors the net/http default.
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return errors.New("stopped after 10 redirects")
+			}
+			return h.checkDomainAllowed(req.URL)
+		},
 	}
 	if params.Timeout > 0 {
 		client.Timeout = time.Duration(params.Timeout) * time.Second
@@ -291,9 +300,13 @@ func (h *fetchHandler) checkDomainAllowed(u *url.URL) error {
 // ("docs.example.com"); it does NOT match unrelated hosts that share a suffix
 // ("badexample.com"). A pattern with a leading dot (".example.com") matches
 // strict subdomains only — the apex "example.com" is excluded.
+//
+// Trailing dots used in FQDN form ("example.com.") are stripped from both
+// host and pattern before matching, so a URL like http://example.com./ cannot
+// be used to bypass a deny-list entry for example.com.
 func matchesDomain(host, pattern string) bool {
-	host = strings.ToLower(strings.TrimSpace(host))
-	pattern = strings.ToLower(strings.TrimSpace(pattern))
+	host = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
+	pattern = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(pattern)), ".")
 	if host == "" || pattern == "" || pattern == "." {
 		return false
 	}

--- a/pkg/tools/builtin/fetch.go
+++ b/pkg/tools/builtin/fetch.go
@@ -34,7 +34,9 @@ var (
 )
 
 type fetchHandler struct {
-	timeout time.Duration
+	timeout        time.Duration
+	allowedDomains []string
+	blockedDomains []string
 }
 
 type FetchToolArgs struct {
@@ -110,6 +112,12 @@ func (h *fetchHandler) fetchURL(ctx context.Context, client *http.Client, urlStr
 	// Only allow HTTP and HTTPS
 	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
 		result.Error = "only HTTP and HTTPS URLs are supported"
+		return result
+	}
+
+	// Enforce domain allow/deny lists configured on the toolset.
+	if err := h.checkDomainAllowed(parsedURL); err != nil {
+		result.Error = err.Error()
 		return result
 	}
 
@@ -254,6 +262,66 @@ func (h *fetchHandler) fetchRobots(ctx context.Context, client *http.Client, tar
 	return robots, nil
 }
 
+// checkDomainAllowed returns nil if u's host is permitted by the configured
+// allow- and block-lists, or a descriptive error otherwise. When neither list
+// is configured, every URL is allowed.
+func (h *fetchHandler) checkDomainAllowed(u *url.URL) error {
+	host := u.Hostname()
+	if host == "" {
+		return errors.New("URL has no host")
+	}
+	if len(h.blockedDomains) > 0 && matchesAnyDomain(host, h.blockedDomains) {
+		return fmt.Errorf("URL host %q is blocked by blocked_domains", host)
+	}
+	if len(h.allowedDomains) > 0 && !matchesAnyDomain(host, h.allowedDomains) {
+		return fmt.Errorf("URL host %q is not in allowed_domains", host)
+	}
+	return nil
+}
+
+// matchesAnyDomain reports whether host matches any of the supplied patterns.
+// See matchesDomain for the matching rules.
+func matchesAnyDomain(host string, patterns []string) bool {
+	for _, p := range patterns {
+		if matchesDomain(host, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchesDomain reports whether host matches pattern.
+//
+// Matching rules (case-insensitive):
+//   - An empty pattern matches nothing.
+//   - A pattern with a leading dot (".example.com") matches strict subdomains
+//     of example.com but NOT example.com itself.
+//   - Any other pattern ("example.com") matches the host exactly and any of
+//     its subdomains (e.g. "docs.example.com"). It does NOT match unrelated
+//     hosts that share a suffix (e.g. "badexample.com").
+func matchesDomain(host, pattern string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	pattern = strings.ToLower(strings.TrimSpace(pattern))
+	if host == "" || pattern == "" {
+		return false
+	}
+	// Strip IPv6 brackets if any (url.URL.Hostname already does this, but be safe).
+	host = strings.Trim(host, "[]")
+
+	subdomainOnly := strings.HasPrefix(pattern, ".")
+	if subdomainOnly {
+		pattern = strings.TrimPrefix(pattern, ".")
+		if pattern == "" {
+			return false
+		}
+		return strings.HasSuffix(host, "."+pattern)
+	}
+	if host == pattern {
+		return true
+	}
+	return strings.HasSuffix(host, "."+pattern)
+}
+
 func htmlToMarkdown(html string) string {
 	markdown, err := htmltomarkdown.ConvertString(html)
 	if err != nil {
@@ -288,10 +356,39 @@ func WithTimeout(timeout time.Duration) FetchToolOption {
 	}
 }
 
-func (t *FetchTool) Instructions() string {
-	return `## Fetch Tool
+// WithAllowedDomains restricts the fetch tool to URLs whose host matches one
+// of the supplied domain patterns. See matchesDomain for matching rules.
+// An empty or nil slice disables the allow-list (every host is allowed).
+func WithAllowedDomains(domains []string) FetchToolOption {
+	return func(t *FetchTool) {
+		t.handler.allowedDomains = domains
+	}
+}
 
-Fetch content from HTTP/HTTPS URLs. Supports multiple URLs per call, output format selection (text, markdown, html), and respects robots.txt.`
+// WithBlockedDomains forbids the fetch tool from fetching URLs whose host
+// matches one of the supplied domain patterns. See matchesDomain for matching
+// rules. An empty or nil slice disables the deny-list.
+func WithBlockedDomains(domains []string) FetchToolOption {
+	return func(t *FetchTool) {
+		t.handler.blockedDomains = domains
+	}
+}
+
+func (t *FetchTool) Instructions() string {
+	var b strings.Builder
+	b.WriteString("## Fetch Tool\n\n")
+	b.WriteString("Fetch content from HTTP/HTTPS URLs. Supports multiple URLs per call, output format selection (text, markdown, html), and respects robots.txt.")
+	if len(t.handler.allowedDomains) > 0 {
+		b.WriteString("\n\nThis tool is restricted to the following domains (and their subdomains): ")
+		b.WriteString(strings.Join(t.handler.allowedDomains, ", "))
+		b.WriteString(". Requests to any other host will fail without making a network call.")
+	}
+	if len(t.handler.blockedDomains) > 0 {
+		b.WriteString("\n\nThis tool is forbidden from fetching the following domains (and their subdomains): ")
+		b.WriteString(strings.Join(t.handler.blockedDomains, ", "))
+		b.WriteString(". Requests to those hosts will fail without making a network call.")
+	}
+	return b.String()
 }
 
 func (t *FetchTool) Tools(context.Context) ([]tools.Tool, error) {

--- a/pkg/tools/builtin/fetch_test.go
+++ b/pkg/tools/builtin/fetch_test.go
@@ -399,7 +399,7 @@ func TestFetchTool_AllowedDomainsAppearInInstructions(t *testing.T) {
 
 	instructions := tools.GetInstructions(tool)
 
-	assert.Contains(t, instructions, "restricted to the following domains")
+	assert.Contains(t, instructions, "restricted to these domains")
 	assert.Contains(t, instructions, "docker.com")
 	assert.Contains(t, instructions, "github.com")
 }
@@ -409,7 +409,7 @@ func TestFetchTool_BlockedDomainsAppearInInstructions(t *testing.T) {
 
 	instructions := tools.GetInstructions(tool)
 
-	assert.Contains(t, instructions, "forbidden from fetching")
+	assert.Contains(t, instructions, "must not fetch")
 	assert.Contains(t, instructions, "169.254.169.254")
 }
 

--- a/pkg/tools/builtin/fetch_test.go
+++ b/pkg/tools/builtin/fetch_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	neturl "net/url"
 	"testing"
 	"time"
 
@@ -433,6 +434,11 @@ func TestMatchesDomain(t *testing.T) {
 		{"only-dot pattern matches nothing", "example.com", ".", false},
 		{"whitespace tolerated", " example.com ", " example.com ", true},
 		{"ip address exact", "169.254.169.254", "169.254.169.254", true},
+		// FQDN trailing dot (regression: must not bypass the matcher).
+		{"trailing dot host matches apex pattern", "example.com.", "example.com", true},
+		{"trailing dot host matches subdomain pattern", "docs.example.com.", "example.com", true},
+		{"trailing dot pattern matches apex host", "example.com", "example.com.", true},
+		{"trailing dot host matches strict-subdomain pattern", "docs.example.com.", ".example.com", true},
 	}
 
 	for _, tc := range tests {
@@ -522,4 +528,60 @@ func TestFetch_BlockedDomains_DeniesIgnoringRobots(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, result.Output, "is blocked by blocked_domains")
 	assert.False(t, robotsRequested, "blocked URLs must not trigger any network call, including robots.txt")
+}
+
+// TestFetch_AllowedDomains_RejectsRedirectToBlockedHost is a regression test for an
+// SSRF-style bypass: an allow-listed origin returning a redirect to a host
+// that is NOT in the allow-list must be rejected before the redirect is
+// followed, otherwise the policy is hollow.
+func TestFetch_AllowedDomains_RejectsRedirectToBlockedHost(t *testing.T) {
+	redirected := false
+	url := runHTTPServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/robots.txt" {
+			http.NotFound(w, r)
+			return
+		}
+		redirected = true
+		http.Redirect(w, r, "http://attacker.example.com/secret", http.StatusFound)
+	})
+	parsed, err := neturl.Parse(url)
+	require.NoError(t, err)
+
+	// Allow only the test server's host. The redirect target must be
+	// rejected without any network call to attacker.example.com.
+	tool := NewFetchTool(WithAllowedDomains([]string{parsed.Hostname()}))
+
+	result, err := tool.handler.CallTool(t.Context(), FetchToolArgs{
+		URLs:   []string{url + "/start"},
+		Format: "text",
+	})
+	require.NoError(t, err)
+	assert.True(t, redirected, "the test server should have been hit at least once to issue the redirect")
+	assert.Contains(t, result.Output, "Error fetching")
+	assert.Contains(t, result.Output, "attacker.example.com", "the error should mention the rejected redirect target")
+	assert.Contains(t, result.Output, "is not in allowed_domains")
+}
+
+// TestFetch_BlockedDomains_RejectsRedirectToBlockedHost mirrors the allow-list
+// regression test for the deny-list path: a redirect to a deny-listed host
+// must not be followed.
+func TestFetch_BlockedDomains_RejectsRedirectToBlockedHost(t *testing.T) {
+	url := runHTTPServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/robots.txt" {
+			http.NotFound(w, r)
+			return
+		}
+		http.Redirect(w, r, "http://169.254.169.254/metadata", http.StatusFound)
+	})
+
+	tool := NewFetchTool(WithBlockedDomains([]string{"169.254.169.254"}))
+
+	result, err := tool.handler.CallTool(t.Context(), FetchToolArgs{
+		URLs:   []string{url + "/innocent"},
+		Format: "text",
+	})
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, "Error fetching")
+	assert.Contains(t, result.Output, "is blocked by blocked_domains")
+	assert.Contains(t, result.Output, "169.254.169.254")
 }

--- a/pkg/tools/builtin/fetch_test.go
+++ b/pkg/tools/builtin/fetch_test.go
@@ -379,3 +379,147 @@ func TestFetchTool_ParametersAreObjects(t *testing.T) {
 		assert.Equal(t, "object", m["type"])
 	}
 }
+
+func TestFetchTool_WithAllowedDomainsOption(t *testing.T) {
+	tool := NewFetchTool(WithAllowedDomains([]string{"example.com"}))
+
+	assert.Equal(t, []string{"example.com"}, tool.handler.allowedDomains)
+	assert.Empty(t, tool.handler.blockedDomains)
+}
+
+func TestFetchTool_WithBlockedDomainsOption(t *testing.T) {
+	tool := NewFetchTool(WithBlockedDomains([]string{"evil.example.com"}))
+
+	assert.Equal(t, []string{"evil.example.com"}, tool.handler.blockedDomains)
+	assert.Empty(t, tool.handler.allowedDomains)
+}
+
+func TestFetchTool_AllowedDomainsAppearInInstructions(t *testing.T) {
+	tool := NewFetchTool(WithAllowedDomains([]string{"docker.com", "github.com"}))
+
+	instructions := tools.GetInstructions(tool)
+
+	assert.Contains(t, instructions, "restricted to the following domains")
+	assert.Contains(t, instructions, "docker.com")
+	assert.Contains(t, instructions, "github.com")
+}
+
+func TestFetchTool_BlockedDomainsAppearInInstructions(t *testing.T) {
+	tool := NewFetchTool(WithBlockedDomains([]string{"169.254.169.254"}))
+
+	instructions := tools.GetInstructions(tool)
+
+	assert.Contains(t, instructions, "forbidden from fetching")
+	assert.Contains(t, instructions, "169.254.169.254")
+}
+
+func TestMatchesDomain(t *testing.T) {
+	tests := []struct {
+		name    string
+		host    string
+		pattern string
+		want    bool
+	}{
+		{"exact match", "example.com", "example.com", true},
+		{"case insensitive", "Example.COM", "example.com", true},
+		{"subdomain match", "docs.example.com", "example.com", true},
+		{"deep subdomain match", "a.b.example.com", "example.com", true},
+		{"unrelated suffix does NOT match", "badexample.com", "example.com", false},
+		{"different domain", "other.com", "example.com", false},
+		{"leading dot pattern excludes apex", "example.com", ".example.com", false},
+		{"leading dot pattern allows subdomain", "docs.example.com", ".example.com", true},
+		{"empty host", "", "example.com", false},
+		{"empty pattern", "example.com", "", false},
+		{"only-dot pattern matches nothing", "example.com", ".", false},
+		{"whitespace tolerated", " example.com ", " example.com ", true},
+		{"ip address exact", "169.254.169.254", "169.254.169.254", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, matchesDomain(tc.host, tc.pattern))
+		})
+	}
+}
+
+func TestFetch_AllowedDomains_DeniesUnknownHost(t *testing.T) {
+	url := runHTTPServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, "should not be reached")
+	})
+
+	// httptest servers run on 127.0.0.1; an allow-list that does not include
+	// it must short-circuit the request.
+	tool := NewFetchTool(WithAllowedDomains([]string{"example.com"}))
+
+	result, err := tool.handler.CallTool(t.Context(), FetchToolArgs{
+		URLs:   []string{url + "/whatever"},
+		Format: "text",
+	})
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, "Error fetching")
+	assert.Contains(t, result.Output, "is not in allowed_domains")
+}
+
+func TestFetch_AllowedDomains_PermitsKnownHost(t *testing.T) {
+	requests := 0
+	url := runHTTPServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.URL.Path == "/robots.txt" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		fmt.Fprint(w, "hello")
+	})
+
+	tool := NewFetchTool(WithAllowedDomains([]string{"127.0.0.1"}))
+
+	result, err := tool.handler.CallTool(t.Context(), FetchToolArgs{
+		URLs:   []string{url + "/page"},
+		Format: "text",
+	})
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, "Successfully fetched")
+	assert.Contains(t, result.Output, "hello")
+	assert.Positive(t, requests, "the upstream should have been hit when the host is allow-listed")
+}
+
+func TestFetch_BlockedDomains_DeniesMatchingHost(t *testing.T) {
+	url := runHTTPServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, "should not be reached")
+	})
+
+	tool := NewFetchTool(WithBlockedDomains([]string{"127.0.0.1"}))
+
+	result, err := tool.handler.CallTool(t.Context(), FetchToolArgs{
+		URLs:   []string{url + "/page"},
+		Format: "text",
+	})
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, "Error fetching")
+	assert.Contains(t, result.Output, "is blocked by blocked_domains")
+}
+
+func TestFetch_BlockedDomains_DeniesIgnoringRobots(t *testing.T) {
+	// The deny check must happen before robots.txt is fetched, so a server
+	// that errors on /robots.txt should still produce a clear domain error.
+	robotsRequested := false
+	url := runHTTPServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/robots.txt" {
+			robotsRequested = true
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		fmt.Fprint(w, "should not be reached")
+	})
+
+	tool := NewFetchTool(WithBlockedDomains([]string{"127.0.0.1"}))
+
+	result, err := tool.handler.CallTool(t.Context(), FetchToolArgs{
+		URLs:   []string{url + "/page"},
+		Format: "text",
+	})
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, "is blocked by blocked_domains")
+	assert.False(t, robotsRequested, "blocked URLs must not trigger any network call, including robots.txt")
+}


### PR DESCRIPTION
## Summary

Adds two new options to the `fetch` toolset — `allowed_domains` and `blocked_domains` — letting operators restrict which hosts an agent can reach, mirroring Anthropic's web-fetch tool and Claude Code's `WebFetch` permission model.

The check runs **before any network call** (including `robots.txt`), so blocked URLs never leak DNS or TCP traffic. Redirect targets are re-checked against the same lists, closing an SSRF-style bypass.

## Configuration

```yaml
toolsets:
  - type: fetch
    allowed_domains:
      - docker.com               # docker.com AND *.docker.com
      - github.com
      - .githubusercontent.com   # leading dot = strict subdomains only
```

```yaml
toolsets:
  - type: fetch
    blocked_domains:
      - 169.254.169.254          # cloud metadata endpoint
      - internal.example.com
```

The two lists are mutually exclusive on a single fetch toolset.

### Matching rules

- **Bare domain** (`example.com`) — matches the host exactly *and* any subdomain (`docs.example.com`); does **not** match unrelated hosts that share a suffix (`badexample.com`).
- **Leading dot** (`.example.com`) — matches **only** strict subdomains, not the apex.
- **IP literal** — exact match (`169.254.169.254`).
- **Trailing dot** in FQDN-form URLs (`http://example.com./`) is stripped before matching, so it can't bypass a deny-list entry.
- Case-insensitive throughout.

## Changes

### Config & schema (`pkg/config/latest`)

- New `AllowedDomains` and `BlockedDomains` fields on `Toolset`.
- Validation rejects: using either list on a non-`fetch` toolset, setting both lists at once, and empty/whitespace-only entries (which would silently match nothing and turn the list into a foot-gun).
- `agent-schema.json` updated with descriptions and examples.

### Fetch tool (`pkg/tools/builtin/fetch.go`)

- New `WithAllowedDomains` / `WithBlockedDomains` options.
- New `checkDomainAllowed` enforces the lists on the initial URL.
- New `http.Client.CheckRedirect` re-checks every redirect target against the same lists (10-redirect cap mirrors `net/http` default).
- New `matchesDomain` helper implements the rules above.
- `Instructions()` advertises the configured lists to the model so it can avoid futile calls.

### Wiring (`pkg/teamloader/registry.go`)

- `createFetchTool` propagates the new fields from YAML into the tool options.

### Docs & examples

- `docs/tools/fetch/index.md` documents the new options, matching rules, redirect re-check, and the IP-encoding limitation (matching is purely string-based on the URL host: it does not normalize alternative IP encodings — decimal, hex, octal, IPv4-mapped IPv6, etc.).
- New `examples/fetch_domain_filtering.yaml` shows both an allow-list agent and a deny-list agent.

## Security fixes folded in

Three issues were caught during review of the initial implementation and fixed in this PR:

1. **SSRF via redirect (critical)** — the `http.Client` had no `CheckRedirect`, so an allow-listed origin returning a 3xx to a forbidden host would be followed and its body returned to the caller. Now every redirect target is re-checked. Regression test `TestFetch_AllowedDomains_RejectsRedirectToBlockedHost` uses `http://169.254.169.254/` (AWS metadata IP) to demonstrate the fix.
2. **FQDN trailing-dot bypass** — `url.URL.Hostname()` keeps the trailing dot for FQDN-form URLs like `http://host./`, which slipped past patterns like `host`. The matcher now strips trailing dots from both inputs.
3. **Silent empty entries** — `allowed_domains: [""]` would have rejected every URL; `blocked_domains: [""]` would have matched nothing. Validation now rejects empty/whitespace-only entries at config-load time.

## Validation

- `mise lint` ✓
- `mise test` ✓
- New tests cover: matcher truth table (exact, subdomain, suffix-collision, leading-dot, IP, case, trailing dot, whitespace, empty), allow-list deny + permit, deny-list deny (and that it short-circuits *before* `robots.txt`), redirect re-check on both lists, instructions surfacing the lists, validation errors for misuse.

## Commits

1. `feat(fetch): add allowed_domains and blocked_domains filters` — initial implementation, config plumbing, docs, example, tests.
2. `refactor(fetch): simplify domain matcher and instructions` — collapse `checkDomainAllowed` branches into a switch, drop the `matchesAnyDomain` helper in favor of inline `slices.ContainsFunc`, simplify `matchesDomain` by leveraging the leading dot directly (drop `subdomainOnly` bool, drop dead IPv6 bracket-strip), tighten `Instructions()`. No functional change — matcher truth table and integration tests unchanged.
3. `fix(fetch): close redirect/FQDN bypasses in domain filtering` — the three security fixes above, plus the IP-encoding limitation note in the user-facing docs.

Assisted-By: docker-agent
