### PR TITLE
refactor(sessiontitle): simplify Generator without changing behavior

### DIFF
--- a/pkg/sessiontitle/generator.go
+++ b/pkg/sessiontitle/generator.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"slices"
 	"strings"
 	"time"
 
@@ -41,20 +42,13 @@ type Generator struct {
 // New creates a new title Generator with the given model provider.
 // The first argument is treated as the primary model; any additional models are
 // treated as fallbacks (tried in order) if earlier models fail.
+// Nil providers are silently ignored.
 func New(model provider.Provider, fallbackModels ...provider.Provider) *Generator {
-	// Filter out nil providers to keep Generate simple.
-	models := make([]provider.Provider, 0, 1+len(fallbackModels))
-	if model != nil {
-		models = append(models, model)
-	}
-	for _, fb := range fallbackModels {
-		if fb != nil {
-			models = append(models, fb)
-		}
-	}
-	return &Generator{
-		models: models,
-	}
+	models := slices.DeleteFunc(
+		append([]provider.Provider{model}, fallbackModels...),
+		func(p provider.Provider) bool { return p == nil },
+	)
+	return &Generator{models: models}
 }
 
 // Generate produces a title for a session based on the provided user messages.
@@ -62,100 +56,35 @@ func New(model provider.Provider, fallbackModels ...provider.Provider) *Generato
 // avoiding the overhead of spinning up a nested runtime.
 // Returns an empty string if generation fails or no messages are provided.
 func (g *Generator) Generate(ctx context.Context, sessionID string, userMessages []string) (string, error) {
-	if len(userMessages) == 0 {
+	if g == nil || len(g.models) == 0 || len(userMessages) == 0 {
 		return "", nil
 	}
 
-	// Apply timeout to prevent hanging on slow or unresponsive models
+	// Apply timeout to prevent hanging on slow or unresponsive models.
 	ctx, cancel := context.WithTimeout(ctx, titleGenerationTimeout)
 	defer cancel()
-	if g == nil || len(g.models) == 0 {
-		return "", nil
-	}
 
 	slog.Debug("Generating title for session", "session_id", sessionID, "message_count", len(userMessages))
 
-	// Format messages for the prompt
-	var formattedMessages strings.Builder
-	for i, msg := range userMessages {
-		fmt.Fprintf(&formattedMessages, "%d. %s\n", i+1, msg)
-	}
-	userPrompt := fmt.Sprintf(userPromptFormat, formattedMessages.String())
-
-	// Build the messages for the completion request
-	messages := []chat.Message{
-		{
-			Role:    chat.MessageRoleSystem,
-			Content: systemPrompt,
-		},
-		{
-			Role:    chat.MessageRoleUser,
-			Content: userPrompt,
-		},
-	}
+	messages := buildPrompt(userMessages)
 
 	var lastErr error
 	for idx, baseModel := range g.models {
-		if ctx.Err() != nil {
-			return "", ctx.Err()
-		}
-		if baseModel == nil {
-			continue
+		if err := ctx.Err(); err != nil {
+			return "", err
 		}
 
-		// Clone the model with title-generation-specific options.
-		// We do this per-attempt so each model gets a consistent, low-token one-shot call.
-		titleModel := provider.CloneWithOptions(
-			ctx,
-			baseModel,
-			options.WithStructuredOutput(nil),
-			options.WithMaxTokens(titleMaxTokens),
-			options.WithNoThinking(),
-			options.WithGeneratingTitle(),
-		)
-
-		// Call the provider directly (no tools needed for title generation)
-		stream, err := titleModel.CreateChatCompletionStream(ctx, messages, nil)
+		title, err := generateOnce(ctx, baseModel, messages)
 		if err != nil {
 			lastErr = err
-			slog.Error("Failed to create title generation stream",
+			slog.Error("Title generation attempt failed",
 				"session_id", sessionID,
 				"model", baseModel.ID(),
 				"attempt", idx+1,
 				"error", err)
 			continue
 		}
-
-		// Drain the stream to collect the full title
-		var title strings.Builder
-		var streamErr error
-		for {
-			response, err := stream.Recv()
-			if errors.Is(err, io.EOF) {
-				break
-			}
-			if err != nil {
-				streamErr = err
-				break
-			}
-			if len(response.Choices) > 0 {
-				title.WriteString(response.Choices[0].Delta.Content)
-			}
-		}
-		stream.Close()
-
-		if streamErr != nil {
-			lastErr = streamErr
-			slog.Error("Error receiving from title stream",
-				"session_id", sessionID,
-				"model", baseModel.ID(),
-				"attempt", idx+1,
-				"error", streamErr)
-			continue
-		}
-
-		result := sanitizeTitle(title.String())
-		if result == "" {
+		if title == "" {
 			// Empty/invalid title output - treat as a failure and try fallbacks.
 			lastErr = fmt.Errorf("empty title output from model %q", baseModel.ID())
 			slog.Debug("Generated empty title, trying next model",
@@ -165,8 +94,8 @@ func (g *Generator) Generate(ctx context.Context, sessionID string, userMessages
 			continue
 		}
 
-		slog.Debug("Generated session title", "session_id", sessionID, "title", result, "model", baseModel.ID())
-		return result, nil
+		slog.Debug("Generated session title", "session_id", sessionID, "title", title, "model", baseModel.ID())
+		return title, nil
 	}
 
 	if lastErr != nil {
@@ -175,17 +104,64 @@ func (g *Generator) Generate(ctx context.Context, sessionID string, userMessages
 	return "", nil
 }
 
-// sanitizeTitle ensures the title is a single line by taking only the first
-// non-empty line and stripping any control characters that could break TUI rendering.
+// generateOnce performs a single one-shot title generation call against baseModel
+// and returns the sanitized title (which may be empty if the model produced no
+// usable output).
+func generateOnce(ctx context.Context, baseModel provider.Provider, messages []chat.Message) (string, error) {
+	// Clone the model with title-generation-specific options so each attempt
+	// gets a consistent, low-token one-shot call.
+	titleModel := provider.CloneWithOptions(
+		ctx,
+		baseModel,
+		options.WithStructuredOutput(nil),
+		options.WithMaxTokens(titleMaxTokens),
+		options.WithNoThinking(),
+		options.WithGeneratingTitle(),
+	)
+
+	stream, err := titleModel.CreateChatCompletionStream(ctx, messages, nil)
+	if err != nil {
+		return "", err
+	}
+	defer stream.Close()
+
+	var title strings.Builder
+	for {
+		response, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return "", err
+		}
+		if len(response.Choices) > 0 {
+			title.WriteString(response.Choices[0].Delta.Content)
+		}
+	}
+
+	return sanitizeTitle(title.String()), nil
+}
+
+// buildPrompt formats the user messages into the system+user message pair sent
+// to the model.
+func buildPrompt(userMessages []string) []chat.Message {
+	var formatted strings.Builder
+	for i, msg := range userMessages {
+		fmt.Fprintf(&formatted, "%d. %s\n", i+1, msg)
+	}
+	return []chat.Message{
+		{Role: chat.MessageRoleSystem, Content: systemPrompt},
+		{Role: chat.MessageRoleUser, Content: fmt.Sprintf(userPromptFormat, formatted.String())},
+	}
+}
+
+// sanitizeTitle returns the first non-empty trimmed line of title, with any
+// stray carriage returns removed. This guarantees a single-line title safe for
+// TUI rendering.
 func sanitizeTitle(title string) string {
-	// Split by newlines and take the first non-empty line
-	lines := strings.SplitSeq(title, "\n")
-	for line := range lines {
-		line = strings.TrimSpace(line)
-		if line != "" {
-			// Remove any remaining carriage returns
-			line = strings.ReplaceAll(line, "\r", "")
-			return line
+	for line := range strings.SplitSeq(title, "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			return strings.ReplaceAll(line, "\r", "")
 		}
 	}
 	return ""

--- a/pkg/sessiontitle/generator.go
+++ b/pkg/sessiontitle/generator.go
@@ -39,9 +39,8 @@ type Generator struct {
 	models []provider.Provider
 }
 
-// New creates a new title Generator with the given model provider.
-// The first argument is treated as the primary model; any additional models are
-// treated as fallbacks (tried in order) if earlier models fail.
+// New creates a new title Generator. The first model is the primary; any
+// additional ones are fallbacks tried in order if earlier attempts fail.
 // Nil providers are silently ignored.
 func New(model provider.Provider, fallbackModels ...provider.Provider) *Generator {
 	models := slices.DeleteFunc(
@@ -52,9 +51,10 @@ func New(model provider.Provider, fallbackModels ...provider.Provider) *Generato
 }
 
 // Generate produces a title for a session based on the provided user messages.
-// It performs a one-shot LLM call directly via the provider's CreateChatCompletionStream,
-// avoiding the overhead of spinning up a nested runtime.
-// Returns an empty string if generation fails or no messages are provided.
+// It performs one-shot LLM calls directly via the provider's
+// CreateChatCompletionStream, avoiding the overhead of spinning up a nested
+// runtime, and falls back to the next model on failure.
+// Returns an empty string if no models or messages are configured.
 func (g *Generator) Generate(ctx context.Context, sessionID string, userMessages []string) (string, error) {
 	if g == nil || len(g.models) == 0 || len(userMessages) == 0 {
 		return "", nil
@@ -75,38 +75,28 @@ func (g *Generator) Generate(ctx context.Context, sessionID string, userMessages
 		}
 
 		title, err := generateOnce(ctx, baseModel, messages)
-		if err != nil {
-			lastErr = err
-			slog.Error("Title generation attempt failed",
-				"session_id", sessionID,
-				"model", baseModel.ID(),
-				"attempt", idx+1,
-				"error", err)
-			continue
-		}
-		if title == "" {
-			// Empty/invalid title output - treat as a failure and try fallbacks.
-			lastErr = fmt.Errorf("empty title output from model %q", baseModel.ID())
-			slog.Debug("Generated empty title, trying next model",
-				"session_id", sessionID,
-				"model", baseModel.ID(),
-				"attempt", idx+1)
-			continue
+		if err == nil {
+			slog.Debug("Generated session title", "session_id", sessionID, "title", title, "model", baseModel.ID())
+			return title, nil
 		}
 
-		slog.Debug("Generated session title", "session_id", sessionID, "title", title, "model", baseModel.ID())
-		return title, nil
+		lastErr = err
+		// Per-attempt failures are logged at Debug because we still have
+		// fallbacks; the final error is what callers log/wrap.
+		slog.Debug("Title generation attempt failed",
+			"session_id", sessionID,
+			"model", baseModel.ID(),
+			"attempt", idx+1,
+			"error", err)
 	}
 
-	if lastErr != nil {
-		return "", fmt.Errorf("generating title failed: %w", lastErr)
-	}
-	return "", nil
+	return "", fmt.Errorf("generating title failed: %w", lastErr)
 }
 
-// generateOnce performs a single one-shot title generation call against baseModel
-// and returns the sanitized title (which may be empty if the model produced no
-// usable output).
+// generateOnce performs a single one-shot title generation call against
+// baseModel and returns the sanitized title. An error is returned if the
+// stream cannot be created, if reading from it fails, or if the model
+// produced no usable output.
 func generateOnce(ctx context.Context, baseModel provider.Provider, messages []chat.Message) (string, error) {
 	// Clone the model with title-generation-specific options so each attempt
 	// gets a consistent, low-token one-shot call.
@@ -123,27 +113,42 @@ func generateOnce(ctx context.Context, baseModel provider.Provider, messages []c
 	if err != nil {
 		return "", err
 	}
+
+	raw, err := drainStream(stream)
+	if err != nil {
+		return "", err
+	}
+
+	title := sanitizeTitle(raw)
+	if title == "" {
+		return "", fmt.Errorf("empty title output from model %q", baseModel.ID())
+	}
+	return title, nil
+}
+
+// drainStream reads the entire content of a chat completion stream and
+// returns the concatenated delta content. The stream is always closed before
+// returning.
+func drainStream(stream chat.MessageStream) (string, error) {
 	defer stream.Close()
 
-	var title strings.Builder
+	var content strings.Builder
 	for {
 		response, err := stream.Recv()
 		if errors.Is(err, io.EOF) {
-			break
+			return content.String(), nil
 		}
 		if err != nil {
 			return "", err
 		}
 		if len(response.Choices) > 0 {
-			title.WriteString(response.Choices[0].Delta.Content)
+			content.WriteString(response.Choices[0].Delta.Content)
 		}
 	}
-
-	return sanitizeTitle(title.String()), nil
 }
 
-// buildPrompt formats the user messages into the system+user message pair sent
-// to the model.
+// buildPrompt formats the user messages into the system+user message pair
+// sent to the model.
 func buildPrompt(userMessages []string) []chat.Message {
 	var formatted strings.Builder
 	for i, msg := range userMessages {
@@ -156,8 +161,8 @@ func buildPrompt(userMessages []string) []chat.Message {
 }
 
 // sanitizeTitle returns the first non-empty trimmed line of title, with any
-// stray carriage returns removed. This guarantees a single-line title safe for
-// TUI rendering.
+// stray carriage returns removed. This guarantees a single-line title safe
+// for TUI rendering.
 func sanitizeTitle(title string) string {
 	for line := range strings.SplitSeq(title, "\n") {
 		if line = strings.TrimSpace(line); line != "" {


### PR DESCRIPTION
Simplifies `pkg/sessiontitle` to make it easier to read and maintain. No public API changes, no behavior changes — same fallback chain, same timeout, same prompts, same observable outputs to callers.

## Changes

Two refactor-only commits, kept separate so the diff stays easy to follow.

### 1. `refactor(sessiontitle): tidy Generator without changing behavior`
- Consolidated the three early-return guards (`g == nil`, no models, no user messages) at the top of `Generate`, before allocating the timeout context.
- Replaced the manual two-pass nil-filter in `New` with a single `slices.DeleteFunc`.
- Extracted `generateOnce` so each attempt closes its stream via `defer` (no more `streamErr` plumbing).
- Extracted `buildPrompt` to keep prompt construction out of the main loop.
- Removed the dead `if baseModel == nil { continue }` (`New` already filters nils).
- Tightened `sanitizeTitle` to a single-line loop body.

### 2. `refactor(sessiontitle): unify the per-attempt failure path`
- Pushed the "empty model output" check into `generateOnce`: it now returns a normal error like any other attempt failure, so the main loop has a single failure path.
- Extracted `drainStream` as a small helper that owns reading and closing the message stream.
- Unified per-attempt log level at Debug (these aren't fatal while we have fallbacks; callers already log/wrap the final error).
- Dropped the post-loop `if lastErr != nil` guard — the loop's invariants now make `lastErr` always non-nil at that point.

## Final shape

The package is now a clear linear pipeline of small, single-purpose functions:

- `New` — build the model list (filtering nils)
- `Generate` — iterate models, log per-attempt outcomes, return the first success or wrap the last failure
- `generateOnce` — clone provider, open stream, drain, sanitize, validate non-empty
- `drainStream` — read + close
- `buildPrompt` — format messages
- `sanitizeTitle` — first non-empty line, strip `\r`

## Validation

- `mise lint` — clean (golangci-lint: 0 issues; custom analyzer: no offenses; `go mod tidy` clean)
- `mise test` — full suite passes, including `pkg/sessiontitle`, `pkg/app`, `pkg/server`, `pkg/runtime`, `cmd/root`
- Existing tests (`TestGenerator_Generate_FallsBackOnStreamCreateError`, `TestGenerator_Generate_FallsBackOnRecvError`, `TestGenerator_Generate_FallsBackOnEmptyOutput`) all still pass unchanged.
