### PR TITLE
stop hard-coding "root" as the default agent name

### DIFF
--- a/cmd/root/a2a.go
+++ b/cmd/root/a2a.go
@@ -28,7 +28,7 @@ func newA2ACmd() *cobra.Command {
 		RunE: flags.runA2ACommand,
 	}
 
-	cmd.PersistentFlags().StringVarP(&flags.agentName, "agent", "a", "root", "Name of the agent to run")
+	cmd.PersistentFlags().StringVarP(&flags.agentName, "agent", "a", "", "Name of the agent to run (defaults to the team's first agent)")
 	cmd.PersistentFlags().StringVarP(&flags.listenAddr, "listen", "l", "127.0.0.1:8082", "Address to listen on")
 	addRuntimeConfigFlags(cmd, &flags.runConfig)
 

--- a/cmd/root/completion.go
+++ b/cmd/root/completion.go
@@ -71,7 +71,16 @@ func completeMessage(cmd *cobra.Command, args []string, toComplete string) ([]st
 
 	agent, _ := cmd.Flags().GetString("agent")
 	if agent == "" {
-		agent = "root"
+		if len(cfg.Agents) == 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		// Mirror team.DefaultAgent: prefer "root" when present, otherwise
+		// the first agent declared. This keeps shell completion in sync
+		// with the agent the runtime would actually run.
+		agent = cfg.Agents[0].Name
+		if _, hasRoot := cfg.Agents.Lookup("root"); hasRoot {
+			agent = "root"
+		}
 	}
 	agentCfg, found := cfg.Agents.Lookup(agent)
 	if !found {

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -95,7 +95,7 @@ func newRunCmd() *cobra.Command {
 }
 
 func addRunOrExecFlags(cmd *cobra.Command, flags *runExecFlags) {
-	cmd.PersistentFlags().StringVarP(&flags.agentName, "agent", "a", "root", "Name of the agent to run")
+	cmd.PersistentFlags().StringVarP(&flags.agentName, "agent", "a", "", "Name of the agent to run (defaults to the team's first agent)")
 	cmd.PersistentFlags().BoolVar(&flags.autoApprove, "yolo", false, "Automatically approve all tool calls without prompting")
 	cmd.PersistentFlags().BoolVar(&flags.hideToolResults, "hide-tool-results", false, "Hide tool call results")
 	cmd.PersistentFlags().StringVar(&flags.attachmentPath, "attach", "", "Attach an image file to the message")
@@ -333,10 +333,11 @@ func (f *runExecFlags) createLocalRuntimeAndSession(ctx context.Context, loadRes
 		t.SetPermissions(permissions.Merge(t.Permissions(), f.globalPermissions))
 	}
 
-	agt, err := t.Agent(f.agentName)
+	agt, err := t.AgentOrDefault(f.agentName)
 	if err != nil {
 		return nil, nil, err
 	}
+	agentName := agt.Name()
 
 	// Expand tilde in session database path
 	sessionDB, err := expandTilde(f.sessionDB)
@@ -360,7 +361,7 @@ func (f *runExecFlags) createLocalRuntimeAndSession(ctx context.Context, loadRes
 
 	localRt, err := runtime.New(t,
 		runtime.WithSessionStore(sessStore),
-		runtime.WithCurrentAgent(f.agentName),
+		runtime.WithCurrentAgent(agentName),
 		runtime.WithTracer(otel.Tracer(AppName)),
 		runtime.WithModelSwitcherConfig(modelSwitcherCfg),
 	)
@@ -395,13 +396,13 @@ func (f *runExecFlags) createLocalRuntimeAndSession(ctx context.Context, loadRes
 			}
 		}
 
-		slog.Debug("Loaded existing session", "session_id", resolvedID, "session_ref", f.sessionID, "agent", f.agentName)
+		slog.Debug("Loaded existing session", "session_id", resolvedID, "session_ref", f.sessionID, "agent", agentName)
 	} else {
 		wd, _ := os.Getwd()
 		sess = session.New(f.buildSessionOpts(agt, wd)...)
 		// Session is stored lazily on first UpdateSession call (when content is added)
 		// This avoids creating empty sessions in the database
-		slog.Debug("Using local runtime", "agent", f.agentName)
+		slog.Debug("Using local runtime", "agent", agentName)
 	}
 
 	return localRt, sess, nil
@@ -529,8 +530,8 @@ func (f *runExecFlags) createSessionSpawner(agentSource config.Source, sessStore
 			return nil, nil, nil, err
 		}
 
-		team := loadResult.Team
-		agt, err := team.Agent(f.agentName)
+		t := loadResult.Team
+		agt, err := t.AgentOrDefault(f.agentName)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -546,13 +547,13 @@ func (f *runExecFlags) createSessionSpawner(agentSource config.Source, sessStore
 
 		// Merge global permissions into the team's checker
 		if f.globalPermissions != nil && !f.globalPermissions.IsEmpty() {
-			team.SetPermissions(permissions.Merge(team.Permissions(), f.globalPermissions))
+			t.SetPermissions(permissions.Merge(t.Permissions(), f.globalPermissions))
 		}
 
 		// Create the local runtime
-		localRt, err := runtime.New(team,
+		localRt, err := runtime.New(t,
 			runtime.WithSessionStore(sessStore),
-			runtime.WithCurrentAgent(f.agentName),
+			runtime.WithCurrentAgent(agt.Name()),
 			runtime.WithTracer(otel.Tracer(AppName)),
 			runtime.WithModelSwitcherConfig(modelSwitcherCfg),
 		)
@@ -565,7 +566,7 @@ func (f *runExecFlags) createSessionSpawner(agentSource config.Source, sessStore
 
 		// Create cleanup function
 		cleanup := func() {
-			stopToolSets(team)
+			stopToolSets(t)
 		}
 
 		// Create the app

--- a/pkg/a2a/adapter.go
+++ b/pkg/a2a/adapter.go
@@ -18,12 +18,15 @@ import (
 	"github.com/docker/docker-agent/pkg/team"
 )
 
-// newDockerAgentAdapter creates a new ADK agent adapter from a docker agent team and agent name
+// newDockerAgentAdapter creates a new ADK agent adapter from a docker agent team and agent name.
+// When agentName is empty, the team's default agent (one explicitly named "root" if it
+// exists, otherwise the first agent declared) is used.
 func newDockerAgentAdapter(t *team.Team, agentName string) (agent.Agent, error) {
-	a, err := t.Agent(agentName)
+	a, err := t.AgentOrDefault(agentName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get agent %s: %w", agentName, err)
 	}
+	agentName = a.Name()
 
 	desc := cmp.Or(a.Description(), "Agent "+agentName)
 

--- a/pkg/acp/agent.go
+++ b/pkg/acp/agent.go
@@ -136,25 +136,24 @@ func (a *Agent) NewSession(ctx context.Context, params acp.NewSessionRequest) (a
 		workingDir = absWd
 	}
 
+	defaultAgent, err := a.team.DefaultAgent()
+	if err != nil {
+		return acp.NewSessionResponse{}, fmt.Errorf("failed to resolve default agent: %w", err)
+	}
+
 	rt, err := runtime.New(a.team,
-		runtime.WithCurrentAgent("root"),
+		runtime.WithCurrentAgent(defaultAgent.Name()),
 		runtime.WithSessionStore(a.sessionStore),
 	)
 	if err != nil {
 		return acp.NewSessionResponse{}, fmt.Errorf("failed to create runtime: %w", err)
 	}
 
-	// Get root agent config for session settings
-	rootAgent, err := a.team.Agent("root")
-	if err != nil {
-		return acp.NewSessionResponse{}, fmt.Errorf("failed to get root agent: %w", err)
-	}
-
 	// Build session options (title will be set after we have the session ID)
 	sessOpts := []session.Opt{
-		session.WithMaxIterations(rootAgent.MaxIterations()),
-		session.WithMaxConsecutiveToolCalls(rootAgent.MaxConsecutiveToolCalls()),
-		session.WithMaxOldToolCallTokens(rootAgent.MaxOldToolCallTokens()),
+		session.WithMaxIterations(defaultAgent.MaxIterations()),
+		session.WithMaxConsecutiveToolCalls(defaultAgent.MaxConsecutiveToolCalls()),
+		session.WithMaxOldToolCallTokens(defaultAgent.MaxOldToolCallTokens()),
 	}
 	if workingDir != "" {
 		sessOpts = append(sessOpts, session.WithWorkingDir(workingDir))

--- a/pkg/creator/instructions.txt
+++ b/pkg/creator/instructions.txt
@@ -2,7 +2,7 @@ You are an agent builder. Take the user's request and create a YAML file that de
 
 Use the filesystem tool to write the agent YAML configuration to a file named after the agent's purpose (keep the filename short and descriptive).
 
-You MUST define at least one agent named "root" - this is the entrypoint.
+You MUST define at least one agent. By convention, the entrypoint is named "root"; otherwise the first agent declared is used.
 
 ## Configuration Reference
 

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -1,12 +1,14 @@
 package runtime
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -32,6 +34,12 @@ type RemoteRuntime struct {
 	sessionID               string
 	team                    *team.Team
 	pendingOAuthElicitation *ElicitationRequestEvent
+
+	// resolvedDefault caches the team's default agent name fetched from the
+	// server, so [CurrentAgentName] stays an O(1) field read after the first
+	// call when no specific agent has been selected.
+	resolvedDefault     string
+	resolvedDefaultOnce sync.Once
 }
 
 // RemoteRuntimeOption is a function for configuring the RemoteRuntime
@@ -60,7 +68,6 @@ func NewRemoteRuntime(client RemoteClient, opts ...RemoteRuntimeOption) (*Remote
 
 	r := &RemoteRuntime{
 		client:        client,
-		currentAgent:  "root",
 		agentFilename: "agent.yaml",
 		team:          team.New(),
 	}
@@ -72,15 +79,33 @@ func NewRemoteRuntime(client RemoteClient, opts ...RemoteRuntimeOption) (*Remote
 	return r, nil
 }
 
-// CurrentAgentName returns the name of the currently active agent
+// resolvedAgent returns the active agent's name and config from the remote
+// team. When no specific agent has been selected, both come from the team's
+// first agent — the server owns the notion of "default agent" instead of the
+// client hard-coding the historical "root" name.
+func (r *RemoteRuntime) resolvedAgent(ctx context.Context) (string, latest.AgentConfig) {
+	cfg := r.readCurrentAgentConfig(ctx)
+	return cmp.Or(r.currentAgent, cfg.Name), cfg
+}
+
+// CurrentAgentName returns the name of the currently active agent.
+// When no specific agent has been selected, it falls back to the first agent
+// declared by the remote team config. The remote lookup happens at most once;
+// the result is cached so subsequent calls are O(1).
 func (r *RemoteRuntime) CurrentAgentName() string {
-	return r.currentAgent
+	if r.currentAgent != "" {
+		return r.currentAgent
+	}
+	r.resolvedDefaultOnce.Do(func() {
+		r.resolvedDefault, _ = r.resolvedAgent(context.Background())
+	})
+	return r.resolvedDefault
 }
 
 func (r *RemoteRuntime) CurrentAgentInfo(ctx context.Context) CurrentAgentInfo {
-	cfg := r.readCurrentAgentConfig(ctx)
+	name, cfg := r.resolvedAgent(ctx)
 	return CurrentAgentInfo{
-		Name:        r.currentAgent,
+		Name:        name,
 		Description: cfg.Description,
 		Commands:    cfg.Commands,
 	}
@@ -101,23 +126,23 @@ func (r *RemoteRuntime) CurrentAgentTools(_ context.Context) ([]tools.Tool, erro
 
 // EmitStartupInfo emits initial agent, team, and toolset information
 func (r *RemoteRuntime) EmitStartupInfo(ctx context.Context, _ *session.Session, events chan Event) {
-	cfg := r.readCurrentAgentConfig(ctx)
+	agentName, cfg := r.resolvedAgent(ctx)
 
-	events <- AgentInfo(r.currentAgent, cfg.Model, cfg.Description, cfg.WelcomeMessage)
-	events <- TeamInfo(r.agentDetailsFromConfig(ctx), r.currentAgent)
+	events <- AgentInfo(agentName, cfg.Model, cfg.Description, cfg.WelcomeMessage)
+	events <- TeamInfo(r.agentDetailsFromConfig(ctx), agentName)
 
 	// Emit a loading indicator while we fetch the real tool count from the server.
 	if len(cfg.Toolsets) > 0 {
-		events <- ToolsetInfo(0, true, r.currentAgent)
+		events <- ToolsetInfo(0, true, agentName)
 	}
 
-	toolCount, err := r.client.GetAgentToolCount(ctx, r.agentFilename, r.currentAgent)
+	toolCount, err := r.client.GetAgentToolCount(ctx, r.agentFilename, agentName)
 	if err != nil {
 		slog.Warn("Failed to get agent tool count", "error", err)
 		return
 	}
 
-	events <- ToolsetInfo(toolCount, false, r.currentAgent)
+	events <- ToolsetInfo(toolCount, false, agentName)
 }
 
 func (r *RemoteRuntime) agentDetailsFromConfig(ctx context.Context) []AgentDetails {
@@ -147,10 +172,18 @@ func (r *RemoteRuntime) agentDetailsFromConfig(ctx context.Context) []AgentDetai
 	return details
 }
 
+// readCurrentAgentConfig fetches the active agent's config from the server.
+// When no specific agent has been selected, it falls back to the first agent
+// in the team — letting the server own the notion of "default agent" instead
+// of hard-coding the historical "root" name.
 func (r *RemoteRuntime) readCurrentAgentConfig(ctx context.Context) latest.AgentConfig {
 	cfg, err := r.client.GetAgent(ctx, r.agentFilename)
-	if err != nil {
+	if err != nil || len(cfg.Agents) == 0 {
 		return latest.AgentConfig{}
+	}
+
+	if r.currentAgent == "" {
+		return cfg.Agents[0]
 	}
 
 	for _, agent := range cfg.Agents {
@@ -176,7 +209,7 @@ func (r *RemoteRuntime) RunStream(ctx context.Context, sess *session.Session) <-
 		var streamChan <-chan Event
 		var err error
 
-		if r.currentAgent != "" && r.currentAgent != "root" {
+		if r.currentAgent != "" {
 			streamChan, err = r.client.RunAgentWithAgentName(ctx, r.sessionID, r.agentFilename, r.currentAgent, messages)
 		} else {
 			streamChan, err = r.client.RunAgent(ctx, r.sessionID, r.agentFilename, messages)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -279,7 +279,11 @@ func (s *Server) deleteSession(c echo.Context) error {
 func (s *Server) runAgent(c echo.Context) error {
 	sessionID := c.Param("id")
 	agentFilename := c.Param("agent")
-	currentAgent := cmp.Or(c.Param("agent_name"), "root")
+	// agent_name may be empty when the route /api/sessions/:id/agent/:agent
+	// is used. In that case, the session manager resolves the team's default
+	// agent (one explicitly named "root" if it exists, otherwise the first
+	// agent declared).
+	currentAgent := c.Param("agent_name")
 
 	slog.Debug("Running agent", "agent_filename", agentFilename, "session_id", sessionID, "current_agent", currentAgent)
 

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -411,13 +411,15 @@ func (sm *SessionManager) runtimeForSession(ctx context.Context, sess *session.S
 		return nil, nil, err
 	}
 
-	agent, err := t.Agent(currentAgent)
+	// Resolve the team's default agent when no specific agent was requested.
+	agt, err := t.AgentOrDefault(currentAgent)
 	if err != nil {
 		return nil, nil, err
 	}
-	sess.MaxIterations = agent.MaxIterations()
-	sess.MaxConsecutiveToolCalls = agent.MaxConsecutiveToolCalls()
-	sess.MaxOldToolCallTokens = agent.MaxOldToolCallTokens()
+	currentAgent = agt.Name()
+	sess.MaxIterations = agt.MaxIterations()
+	sess.MaxConsecutiveToolCalls = agt.MaxConsecutiveToolCalls()
+	sess.MaxOldToolCallTokens = agt.MaxOldToolCallTokens()
 
 	opts := []runtime.Opt{
 		runtime.WithCurrentAgent(currentAgent),
@@ -429,7 +431,7 @@ func (sm *SessionManager) runtimeForSession(ctx context.Context, sess *session.S
 		return nil, nil, err
 	}
 
-	titleGen := sessiontitle.New(agent.Model(), agent.FallbackModels()...)
+	titleGen := sessiontitle.New(agt.Model(), agt.FallbackModels()...)
 
 	sm.runtimeSessions.Store(sess.ID, &activeRuntimes{
 		runtime:  run,
@@ -452,7 +454,8 @@ func (sm *SessionManager) loadTeam(ctx context.Context, agentFilename string, ru
 }
 
 // GetAgentToolCount loads the agent's team and returns the number of
-// tools available to the given agent.
+// tools available to the given agent. When agentName is empty, it
+// resolves to the team's default agent.
 func (sm *SessionManager) GetAgentToolCount(ctx context.Context, agentFilename, agentName string) (int, error) {
 	t, err := sm.loadTeam(ctx, agentFilename, sm.runConfig)
 	if err != nil {
@@ -464,7 +467,7 @@ func (sm *SessionManager) GetAgentToolCount(ctx context.Context, agentFilename, 
 		}
 	}()
 
-	a, err := t.Agent(agentName)
+	a, err := t.AgentOrDefault(agentName)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/team/team.go
+++ b/pkg/team/team.go
@@ -108,6 +108,19 @@ func (t *Team) Agent(name string) (*agent.Agent, error) {
 	return nil, fmt.Errorf("agent not found: %s (available agents: %s)", name, strings.Join(t.AgentNames(), ", "))
 }
 
+// AgentOrDefault returns the agent identified by name, or the team's
+// [DefaultAgent] when name is empty. It is a convenience for the many
+// call sites that accept an optional agent selector (CLI flag, HTTP
+// route, ...) and want "empty means whatever the team considers
+// default" semantics without sprinkling the same `if name == ""` check
+// everywhere.
+func (t *Team) AgentOrDefault(name string) (*agent.Agent, error) {
+	if name == "" {
+		return t.DefaultAgent()
+	}
+	return t.Agent(name)
+}
+
 func (t *Team) Size() int {
 	return len(t.agents)
 }

--- a/pkg/team/team_test.go
+++ b/pkg/team/team_test.go
@@ -1,0 +1,83 @@
+package team
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/agent"
+)
+
+func newAgent(name string) *agent.Agent {
+	return agent.New(name, "")
+}
+
+func TestDefaultAgent(t *testing.T) {
+	t.Run("empty team returns error", func(t *testing.T) {
+		_, err := New().DefaultAgent()
+		require.Error(t, err)
+	})
+
+	t.Run("returns the agent named root when present", func(t *testing.T) {
+		team := New(WithAgents(newAgent("first"), newAgent("root"), newAgent("other")))
+
+		got, err := team.DefaultAgent()
+		require.NoError(t, err)
+		assert.Equal(t, "root", got.Name())
+	})
+
+	t.Run("falls back to the first agent when there is no root", func(t *testing.T) {
+		team := New(WithAgents(newAgent("alice"), newAgent("bob")))
+
+		got, err := team.DefaultAgent()
+		require.NoError(t, err)
+		assert.Equal(t, "alice", got.Name())
+	})
+}
+
+func TestAgentOrDefault(t *testing.T) {
+	t.Run("empty name resolves to the default agent", func(t *testing.T) {
+		team := New(WithAgents(newAgent("alice"), newAgent("root")))
+
+		got, err := team.AgentOrDefault("")
+		require.NoError(t, err)
+		assert.Equal(t, "root", got.Name())
+	})
+
+	t.Run("empty name without root falls back to the first agent", func(t *testing.T) {
+		team := New(WithAgents(newAgent("alice"), newAgent("bob")))
+
+		got, err := team.AgentOrDefault("")
+		require.NoError(t, err)
+		assert.Equal(t, "alice", got.Name())
+	})
+
+	t.Run("explicit name is honored even when a root exists", func(t *testing.T) {
+		team := New(WithAgents(newAgent("root"), newAgent("alice")))
+
+		got, err := team.AgentOrDefault("alice")
+		require.NoError(t, err)
+		assert.Equal(t, "alice", got.Name())
+	})
+
+	t.Run("unknown name returns an error listing the available agents", func(t *testing.T) {
+		team := New(WithAgents(newAgent("alice"), newAgent("bob")))
+
+		_, err := team.AgentOrDefault("missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing")
+		assert.Contains(t, err.Error(), "alice")
+		assert.Contains(t, err.Error(), "bob")
+	})
+
+	t.Run("empty team returns an error for both empty and explicit names", func(t *testing.T) {
+		team := New()
+
+		_, err := team.AgentOrDefault("")
+		require.Error(t, err)
+
+		_, err = team.AgentOrDefault("anything")
+		require.Error(t, err)
+	})
+}

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -567,7 +567,10 @@ func resolveAgentRefs(
 		}
 
 		// Rename the external agent so it doesn't collide with locally-defined
-		// agents (external agents typically have the name "root").
+		// agents. External agents resolve to their team's default agent (one
+		// explicitly named "root" if it exists, otherwise the first agent
+		// declared), which we may want to expose under a different name in
+		// the importing team.
 		agent.WithName(agentName)(a)
 
 		*agents = append(*agents, a)


### PR DESCRIPTION
Removes the remaining places that hard-coded `"root"` as the default/initial agent name and routes every "default agent" lookup through a single helper.

## What changed

- New `team.Team.AgentOrDefault(name)` method: returns the agent identified by `name`, falling back to `team.DefaultAgent()` when `name` is empty. Centralizes the "empty means default" pattern that was being open-coded in many places.
- All CLI commands with an `--agent` flag now default to `""` (the empty string) instead of `"root"`. The flag is resolved against the team via `AgentOrDefault`, so any agent name works.
- Every hard-coded `t.Agent("root")` / `WithCurrentAgent("root")` call site replaced with a resolved name (`AgentOrDefault` / `DefaultAgent`) — `cmd/root/run.go`, `pkg/a2a/adapter.go`, `pkg/acp/agent.go`, `pkg/server/server.go`, `pkg/server/session_manager.go`.
- `pkg/runtime/remote_runtime.go`: `currentAgent` now defaults to `""` (server-side resolves), `RunStream` no longer special-cases the literal `"root"`, and a `sync.Once`-cached `resolvedAgent(ctx)` helper keeps `CurrentAgentName()` cheap on hot paths.
- `cmd/root/completion.go`: shell completion now mirrors `team.DefaultAgent()` (prefer `"root"` if present, otherwise the first agent declared) so completion stays in sync with what the runtime would actually run.
- Comments and the LLM-creator instructions wording updated to match the new reality.
- Added unit tests for `Team.DefaultAgent` and `Team.AgentOrDefault` covering the empty-team / has-root / no-root / explicit-name / unknown-name paths.

## Backwards compatibility

`team.DefaultAgent()` keeps preferring an agent literally named `"root"` when one exists, so any existing config / API consumer that relied on that name continues to behave identically. Configs without a `root` agent now resolve to the first declared agent instead of failing.