### PR TITLE
Add redact_secrets builtin hook + before_llm_call transform

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -268,6 +268,10 @@
           "type": "boolean",
           "description": "Whether to add environment information"
         },
+        "redact_secrets": {
+          "type": "boolean",
+          "description": "When true, the runtime auto-installs the redact_secrets builtin pre_tool_use hook (scrubs detected secrets from tool arguments) AND attaches a before_llm_call message transform that scrubs the same patterns from the messages sent to the LLM. Detection uses the docker-agent secretsscan ruleset (GitHub PATs, AWS keys, Stripe / Slack / GitLab tokens, JWTs, private keys, etc.). Each detected span is replaced with the literal '[REDACTED]'."
+        },
         "max_iterations": {
           "type": "integer",
           "description": "Maximum number of iterations",
@@ -701,7 +705,7 @@
         },
         "type": {
           "type": "string",
-          "description": "Type of hook. 'command' executes a shell command; 'builtin' invokes a named in-process Go function registered by the runtime; 'model' asks an LLM and translates its reply into the hook's native output (used for LLM-as-a-judge pre_tool_use, summarizers, etc., with no Go code). The docker-agent runtime ships these builtins: 'add_date' (turn_start: today's date), 'add_environment_info' (session_start: cwd, git, OS, arch), 'add_prompt_files' (turn_start: contents of named files looked up in the workdir hierarchy and the home directory), 'add_git_status' (turn_start: `git status --short --branch`), 'add_git_diff' (turn_start: `git diff --stat`, or full diff with args=['full']), 'add_directory_listing' (session_start: top-level entries of cwd), 'add_user_info' (session_start: current OS user and hostname), 'add_recent_commits' (session_start: `git log --oneline -n N`, default N=10, override via args=['<N>']), 'max_iterations' (before_llm_call: hard stop after N model calls; args=['<N>'] required).",
+          "description": "Type of hook. 'command' executes a shell command; 'builtin' invokes a named in-process Go function registered by the runtime; 'model' asks an LLM and translates its reply into the hook's native output (used for LLM-as-a-judge pre_tool_use, summarizers, etc., with no Go code). The docker-agent runtime ships these builtins: 'add_date' (turn_start: today's date), 'add_environment_info' (session_start: cwd, git, OS, arch), 'add_prompt_files' (turn_start: contents of named files looked up in the workdir hierarchy and the home directory), 'add_git_status' (turn_start: `git status --short --branch`), 'add_git_diff' (turn_start: `git diff --stat`, or full diff with args=['full']), 'add_directory_listing' (session_start: top-level entries of cwd), 'add_user_info' (session_start: current OS user and hostname), 'add_recent_commits' (session_start: `git log --oneline -n N`, default N=10, override via args=['<N>']), 'max_iterations' (before_llm_call: hard stop after N model calls; args=['<N>'] required), 'redact_secrets' (pre_tool_use: scrub detected secrets from tool arguments; the matching agent-level 'redact_secrets: true' flag also enables a before_llm_call message transform).",
           "enum": [
             "command",
             "builtin",

--- a/examples/redact_secrets.yaml
+++ b/examples/redact_secrets.yaml
@@ -1,0 +1,37 @@
+#!/usr/bin/env docker agent run
+
+# Demonstrates the redact_secrets feature.
+#
+# `redact_secrets: true` is a single agent-level switch that wires up two
+# defenses against accidentally leaking credentials, tokens, or private keys:
+#
+#   1. A pre_tool_use builtin hook that scrubs detected secrets from the
+#      arguments of every tool call, before the tool sees them.
+#
+#   2. A before_llm_call message transform that scrubs the same patterns
+#      from outgoing chat messages — Content, MultiContent text parts,
+#      and the JSON-encoded arguments of any prior tool call still in the
+#      conversation — before the model provider sees them.
+#
+# Detection uses the docker-agent secretsscan ruleset (GitHub PATs, AWS
+# access keys, Stripe / Slack / GitLab tokens, JWTs, private keys, Docker
+# Hub PATs, …). Each detected span is replaced with the literal
+# `[REDACTED]`; the surrounding text is preserved so a redacted argument
+# still looks like a legitimate flag (e.g. `--token=[REDACTED]`).
+#
+# False positives are extremely rare: every rule pairs a regex with a
+# discriminating keyword, so plain English never trips detection. False
+# negatives are possible — only patterns the ruleset recognises are
+# scrubbed; this is a defense-in-depth feature, not a substitute for
+# keeping secrets out of the conversation in the first place.
+
+agents:
+  root:
+    model: openai/gpt-5-mini
+    description: A helpful AI assistant that scrubs secrets before they leak
+    instruction: |
+      You are a helpful assistant. If the user accidentally pastes a token,
+      do your best work without echoing the secret back.
+    redact_secrets: true
+    toolsets:
+      - type: shell

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -86,17 +86,10 @@ func (a *Agent) AddEnvironmentInfo() bool {
 }
 
 // RedactSecrets reports whether the agent has opted into the
-// redact_secrets feature: when true, the runtime auto-injects the
-// redact_secrets pre_tool_use builtin hook (scrubs tool arguments)
-// AND enables the runtime-shipped before_llm_call message transform
-// (scrubs outgoing chat content). Together they bracket every place
-// where a secret could leak to an external party.
-//
-// The flag is read in two places: ApplyAgentDefaults in
-// pkg/hooks/builtins (for the pre_tool_use auto-injection) and
-// LocalRuntime.redactSecretsTransform in pkg/runtime (for the
-// LLM-side gate). Wire it via [WithRedactSecrets] from agent
-// loaders that surface AgentConfig.RedactSecrets.
+// redact_secrets feature. When true, the runtime auto-injects the
+// redact_secrets pre_tool_use builtin (scrubs tool arguments) AND
+// enables the runtime's before_llm_call message transform (scrubs
+// outgoing chat content).
 func (a *Agent) RedactSecrets() bool {
 	return a.redactSecrets
 }

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -34,6 +34,7 @@ type Agent struct {
 	addDate                 bool
 	addEnvironmentInfo      bool
 	addDescriptionParameter bool
+	redactSecrets           bool
 	maxIterations           int
 	maxConsecutiveToolCalls int
 	maxOldToolCallTokens    int
@@ -82,6 +83,22 @@ func (a *Agent) AddDate() bool {
 
 func (a *Agent) AddEnvironmentInfo() bool {
 	return a.addEnvironmentInfo
+}
+
+// RedactSecrets reports whether the agent has opted into the
+// redact_secrets feature: when true, the runtime auto-injects the
+// redact_secrets pre_tool_use builtin hook (scrubs tool arguments)
+// AND enables the runtime-shipped before_llm_call message transform
+// (scrubs outgoing chat content). Together they bracket every place
+// where a secret could leak to an external party.
+//
+// The flag is read in two places: ApplyAgentDefaults in
+// pkg/hooks/builtins (for the pre_tool_use auto-injection) and
+// LocalRuntime.redactSecretsTransform in pkg/runtime (for the
+// LLM-side gate). Wire it via [WithRedactSecrets] from agent
+// loaders that surface AgentConfig.RedactSecrets.
+func (a *Agent) RedactSecrets() bool {
+	return a.redactSecrets
 }
 
 func (a *Agent) MaxIterations() int {

--- a/pkg/agent/opts.go
+++ b/pkg/agent/opts.go
@@ -111,13 +111,8 @@ func WithAddEnvironmentInfo(addEnvironmentInfo bool) Opt {
 }
 
 // WithRedactSecrets enables both halves of the redact_secrets
-// feature. When true, the agent's hooks config is augmented (in
-// pkg/hooks/builtins.ApplyAgentDefaults) with the redact_secrets
-// pre_tool_use builtin and the runtime's before_llm_call message
-// transform applies [secretsscan.Redact] to outgoing chat content.
-//
-// Wire it from agent loaders (e.g. teamloader) that read
-// AgentConfig.RedactSecrets out of the YAML.
+// feature: the pre_tool_use builtin (via ApplyAgentDefaults) and the
+// runtime's before_llm_call message transform.
 func WithRedactSecrets(redactSecrets bool) Opt {
 	return func(a *Agent) {
 		a.redactSecrets = redactSecrets

--- a/pkg/agent/opts.go
+++ b/pkg/agent/opts.go
@@ -110,6 +110,20 @@ func WithAddEnvironmentInfo(addEnvironmentInfo bool) Opt {
 	}
 }
 
+// WithRedactSecrets enables both halves of the redact_secrets
+// feature. When true, the agent's hooks config is augmented (in
+// pkg/hooks/builtins.ApplyAgentDefaults) with the redact_secrets
+// pre_tool_use builtin and the runtime's before_llm_call message
+// transform applies [secretsscan.Redact] to outgoing chat content.
+//
+// Wire it from agent loaders (e.g. teamloader) that read
+// AgentConfig.RedactSecrets out of the YAML.
+func WithRedactSecrets(redactSecrets bool) Opt {
+	return func(a *Agent) {
+		a.redactSecrets = redactSecrets
+	}
+}
+
 func WithAddDescriptionParameter(addDescriptionParameter bool) Opt {
 	return func(a *Agent) {
 		a.addDescriptionParameter = addDescriptionParameter

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -368,8 +368,15 @@ type AgentConfig struct {
 	SubAgents      []string        `json:"sub_agents,omitempty"`
 	Handoffs       []string        `json:"handoffs,omitempty"`
 
-	AddDate                 bool              `json:"add_date,omitempty"`
-	AddEnvironmentInfo      bool              `json:"add_environment_info,omitempty"`
+	AddDate            bool `json:"add_date,omitempty"`
+	AddEnvironmentInfo bool `json:"add_environment_info,omitempty"`
+	// RedactSecrets, when true, enables both halves of the
+	// redact_secrets feature: the runtime auto-injects the
+	// redact_secrets pre_tool_use builtin (scrubs secrets from tool
+	// arguments) AND attaches its before_llm_call message transform
+	// (scrubs secrets from outgoing chat content). One agent-level
+	// switch covers both leak vectors.
+	RedactSecrets           bool              `json:"redact_secrets,omitempty"`
 	CodeModeTools           bool              `json:"code_mode_tools,omitempty"`
 	AddDescriptionParameter bool              `json:"add_description_parameter,omitempty"`
 	MaxIterations           int               `json:"max_iterations,omitempty"`
@@ -1814,8 +1821,10 @@ type HookDefinition struct {
 	//   - "builtin":  invoke a named, in-process Go function (the name
 	//                 lives in Command). The set of registered builtins
 	//                 is owned by the runtime; the docker-agent runtime
-	//                 ships add_date, add_environment_info, and
-	//                 add_prompt_files.
+	//                 ships add_date, add_environment_info,
+	//                 add_prompt_files, redact_secrets (see also the
+	//                 redact_secrets agent flag), and several others
+	//                 documented in pkg/hooks/builtins.
 	//   - "model":    ask an LLM and translate its reply into the hook's
 	//                 native output. See Model / Prompt / Schema. Used to
 	//                 implement "LLM as a judge" pre_tool_use hooks,

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -370,12 +370,9 @@ type AgentConfig struct {
 
 	AddDate            bool `json:"add_date,omitempty"`
 	AddEnvironmentInfo bool `json:"add_environment_info,omitempty"`
-	// RedactSecrets, when true, enables both halves of the
-	// redact_secrets feature: the runtime auto-injects the
-	// redact_secrets pre_tool_use builtin (scrubs secrets from tool
-	// arguments) AND attaches its before_llm_call message transform
-	// (scrubs secrets from outgoing chat content). One agent-level
-	// switch covers both leak vectors.
+	// RedactSecrets enables both halves of the redact_secrets feature:
+	// the pre_tool_use builtin (scrubs tool arguments) AND the
+	// before_llm_call message transform (scrubs outgoing chat content).
 	RedactSecrets           bool              `json:"redact_secrets,omitempty"`
 	CodeModeTools           bool              `json:"code_mode_tools,omitempty"`
 	AddDescriptionParameter bool              `json:"add_description_parameter,omitempty"`

--- a/pkg/hooks/builtins/builtins.go
+++ b/pkg/hooks/builtins/builtins.go
@@ -84,11 +84,10 @@ type AgentDefaults struct {
 	AddDate            bool
 	AddEnvironmentInfo bool
 	AddPromptFiles     []string
-	// RedactSecrets, when true, auto-injects the redact_secrets
-	// builtin as a pre_tool_use hook. The runtime separately enables
-	// the matching before_llm_call message transform when this flag
-	// is set; the agent flag is therefore the single switch that
-	// covers both leak vectors (tool-args and LLM-input).
+	// RedactSecrets auto-injects the redact_secrets pre_tool_use
+	// builtin. It also enables the runtime's matching before_llm_call
+	// message transform, so this single flag covers both leak vectors
+	// (tool args and outgoing chat content).
 	RedactSecrets bool
 }
 

--- a/pkg/hooks/builtins/builtins.go
+++ b/pkg/hooks/builtins/builtins.go
@@ -12,11 +12,15 @@
 //   - add_user_info         (session_start)   — current OS user and host
 //   - add_recent_commits    (session_start)   — `git log --oneline -n N`
 //   - max_iterations        (before_llm_call) — hard stop after N model calls
+//   - redact_secrets        (pre_tool_use)    — scrub secrets from tool args
 //
 // Reference any of them from a hook YAML entry as
 // `{type: builtin, command: "<name>"}`. The runtime additionally
-// auto-injects add_date / add_environment_info / add_prompt_files
-// from the matching agent flags.
+// auto-injects add_date / add_environment_info / add_prompt_files /
+// redact_secrets from the matching agent flags. The redact_secrets
+// flag also enables the runtime-shipped before_llm_call message
+// transform that scrubs the same patterns from outgoing chat
+// content; see pkg/runtime/redact_secrets.go for the LLM side.
 //
 // turn_start builtins recompute every turn (date, git state).
 // session_start builtins run once per session for context that's
@@ -67,6 +71,7 @@ func Register(r *hooks.Registry) (*State, error) {
 		r.RegisterBuiltin(AddUserInfo, addUserInfo),
 		r.RegisterBuiltin(AddRecentCommits, addRecentCommits),
 		r.RegisterBuiltin(MaxIterations, state.maxIterations.hook),
+		r.RegisterBuiltin(RedactSecrets, redactSecrets),
 	); err != nil {
 		return nil, err
 	}
@@ -79,6 +84,12 @@ type AgentDefaults struct {
 	AddDate            bool
 	AddEnvironmentInfo bool
 	AddPromptFiles     []string
+	// RedactSecrets, when true, auto-injects the redact_secrets
+	// builtin as a pre_tool_use hook. The runtime separately enables
+	// the matching before_llm_call message transform when this flag
+	// is set; the agent flag is therefore the single switch that
+	// covers both leak vectors (tool-args and LLM-input).
+	RedactSecrets bool
 }
 
 // ApplyAgentDefaults appends the stock builtin hook entries implied by
@@ -96,6 +107,12 @@ func ApplyAgentDefaults(cfg *hooks.Config, d AgentDefaults) *hooks.Config {
 	}
 	if d.AddEnvironmentInfo {
 		cfg.SessionStart = append(cfg.SessionStart, builtinHook(AddEnvironmentInfo))
+	}
+	if d.RedactSecrets {
+		cfg.PreToolUse = append(cfg.PreToolUse, hooks.MatcherConfig{
+			Matcher: "*",
+			Hooks:   []hooks.Hook{builtinHook(RedactSecrets)},
+		})
 	}
 	if cfg.IsEmpty() {
 		return nil

--- a/pkg/hooks/builtins/builtins_test.go
+++ b/pkg/hooks/builtins/builtins_test.go
@@ -34,6 +34,7 @@ func TestRegisterInstallsAllBuiltins(t *testing.T) {
 		builtins.AddUserInfo,
 		builtins.AddRecentCommits,
 		builtins.MaxIterations,
+		builtins.RedactSecrets,
 	} {
 		fn, ok := r.LookupBuiltin(name)
 		assert.True(t, ok, "builtin %q must be registered", name)

--- a/pkg/hooks/builtins/redact_secrets.go
+++ b/pkg/hooks/builtins/redact_secrets.go
@@ -25,29 +25,51 @@ const RedactSecrets = "redact_secrets"
 // with [secretsscan.RedactionMarker]. When nothing matched it returns
 // a nil [hooks.Output] so unaffected tool calls take the cheap path
 // through the executor.
+//
+// The returned UpdatedInput contains ONLY keys whose value was
+// actually rewritten. This matters because pre_tool_use hooks run
+// concurrently and aggregate via shallow maps.Copy: emitting unchanged
+// keys would clobber another hook's modifications on the same input.
 func redactSecrets(_ context.Context, in *hooks.Input, _ []string) (*hooks.Output, error) {
 	if in == nil || len(in.ToolInput) == 0 {
 		return nil, nil
 	}
-	updated, changed := redactAny(in.ToolInput)
-	if !changed {
+	updated := redactToolInput(in.ToolInput)
+	if len(updated) == 0 {
 		return nil, nil
 	}
 	return &hooks.Output{
 		SystemMessage: fmt.Sprintf("redact_secrets: redacted secret material from arguments of tool %q", in.ToolName),
 		HookSpecificOutput: &hooks.HookSpecificOutput{
 			HookEventName: hooks.EventPreToolUse,
-			UpdatedInput:  updated.(map[string]any),
+			UpdatedInput:  updated,
 		},
 	}, nil
+}
+
+// redactToolInput returns a map containing only the top-level keys of
+// m whose redacted value differs from the original. Returns nil when
+// nothing changed so the caller can short-circuit cheaply.
+func redactToolInput(m map[string]any) map[string]any {
+	var changed map[string]any
+	for k, v := range m {
+		nv, c := redactAny(v)
+		if !c {
+			continue
+		}
+		if changed == nil {
+			changed = make(map[string]any, 1)
+		}
+		changed[k] = nv
+	}
+	return changed
 }
 
 // redactAny recursively scrubs secrets out of v, returning the new
 // value and a "did anything change" flag. Strings go through
 // [secretsscan.Redact]; map[string]any / []any are walked to catch
-// secrets nested inside JSON-style payloads (e.g. an MCP tool's
-// structured arguments). Every other Go type passes through unchanged
-// because the scanner only operates on text.
+// secrets nested inside JSON-style payloads. Every other Go type
+// passes through unchanged because the scanner only operates on text.
 func redactAny(v any) (any, bool) {
 	switch val := v.(type) {
 	case string:

--- a/pkg/hooks/builtins/redact_secrets.go
+++ b/pkg/hooks/builtins/redact_secrets.go
@@ -8,107 +8,69 @@ import (
 	"github.com/docker/docker-agent/pkg/secretsscan"
 )
 
-// RedactSecretsName is the type alias for the builtin's name
-// (matches the constant pattern used by add_environment_info etc.).
-type RedactSecretsName = string
+// RedactSecrets is the registered name of the pre_tool_use builtin
+// that scrubs secret material from a tool call's arguments before the
+// runtime hands them to the tool.
+//
+// It pairs with the runtime-shipped before_llm_call message transform
+// (see pkg/runtime/redact_secrets.go); together they bracket the two
+// places where chat content can leak secrets to a third party (the
+// LLM provider on input, and a tool process on invocation). The
+// redact_secrets agent flag enables both at once.
+const RedactSecrets = "redact_secrets"
 
-// RedactSecrets is the registered name of the builtin pre_tool_use
-// hook that scrubs secret material from a tool call's arguments
-// before the runtime hands them to the tool.
-//
-// The builtin pairs with the runtime-shipped before_llm_call message
-// transform (see pkg/runtime/redact_secrets.go) — together they bracket
-// every place where chat content can leak secrets to a third party:
-// the LLM provider on input, and a tool process on invocation. Either
-// can be enabled in isolation; the agent flag wires both up at once.
-const RedactSecrets RedactSecretsName = "redact_secrets"
-
-// redactSecrets is the [hooks.BuiltinFunc] for [RedactSecrets].
-// It walks every value in [hooks.Input.ToolInput] and replaces secret
-// spans (per [secretsscan]) with [secretsscan.RedactionMarker], then
-// returns the modified map via [hooks.HookSpecificOutput.UpdatedInput].
-//
-// Returning a nil [hooks.Output] when nothing changed is the
-// no-overhead path: the runtime's hook executor treats a nil output
-// as "this builtin contributed nothing", so an unaffected tool call
-// flows through with no allocation beyond the input scan.
-//
-// Maps and slices nested inside ToolInput are walked recursively so
-// secrets buried in structured arguments (a JSON object passed as a
-// shell command's --config payload, a list of HTTP headers, ...) are
-// caught alongside top-level string values. Non-string scalars
-// (numbers, booleans, nil) are passed through unchanged.
+// redactSecrets is the [hooks.BuiltinFunc] registered under
+// [RedactSecrets]. It walks every value in [hooks.Input.ToolInput]
+// (recursively into nested maps and slices) and replaces secret spans
+// with [secretsscan.RedactionMarker]. When nothing matched it returns
+// a nil [hooks.Output] so unaffected tool calls take the cheap path
+// through the executor.
 func redactSecrets(_ context.Context, in *hooks.Input, _ []string) (*hooks.Output, error) {
 	if in == nil || len(in.ToolInput) == 0 {
 		return nil, nil
 	}
-
-	updated, changed := redactMap(in.ToolInput)
+	updated, changed := redactAny(in.ToolInput)
 	if !changed {
 		return nil, nil
 	}
-
 	return &hooks.Output{
 		SystemMessage: fmt.Sprintf("redact_secrets: redacted secret material from arguments of tool %q", in.ToolName),
 		HookSpecificOutput: &hooks.HookSpecificOutput{
 			HookEventName: hooks.EventPreToolUse,
-			UpdatedInput:  updated,
+			UpdatedInput:  updated.(map[string]any),
 		},
 	}, nil
 }
 
-// redactMap returns a redacted shallow copy of m alongside a
-// "did anything change" flag. Returning a fresh map (rather than
-// mutating in place) keeps the executor's [hooks.Result.ModifiedInput]
-// merge predictable: the caller only sees a copy when a redaction
-// actually happened.
-//
-// changed is the OR of every nested update so the top-level caller
-// can short-circuit when the entire payload was already clean.
-func redactMap(m map[string]any) (map[string]any, bool) {
-	out := make(map[string]any, len(m))
-	changed := false
-	for k, v := range m {
-		nv, c := redactValue(v)
-		out[k] = nv
-		if c {
-			changed = true
-		}
-	}
-	return out, changed
-}
-
-// redactValue recursively scrubs secrets out of v. Strings go through
-// [secretsscan.Redact]; maps and slices are walked element-wise so
-// secrets nested inside structured arguments (json.Unmarshal-style
-// map[string]any payloads, []any lists) are still caught. Every
-// other Go type passes through unchanged because the secret scanner
-// only operates on text.
-func redactValue(v any) (any, bool) {
+// redactAny recursively scrubs secrets out of v, returning the new
+// value and a "did anything change" flag. Strings go through
+// [secretsscan.Redact]; map[string]any / []any are walked to catch
+// secrets nested inside JSON-style payloads (e.g. an MCP tool's
+// structured arguments). Every other Go type passes through unchanged
+// because the scanner only operates on text.
+func redactAny(v any) (any, bool) {
 	switch val := v.(type) {
 	case string:
 		redacted := secretsscan.Redact(val)
 		return redacted, redacted != val
 	case map[string]any:
-		return redactMap(val)
+		out := make(map[string]any, len(val))
+		changed := false
+		for k, item := range val {
+			nv, c := redactAny(item)
+			out[k] = nv
+			changed = changed || c
+		}
+		return out, changed
 	case []any:
 		out := make([]any, len(val))
 		changed := false
 		for i, item := range val {
-			nv, c := redactValue(item)
+			nv, c := redactAny(item)
 			out[i] = nv
-			if c {
-				changed = true
-			}
+			changed = changed || c
 		}
-		if !changed {
-			// Preserve identity when nothing changed so downstream
-			// consumers that compare slice headers (rare, but the
-			// hooks.Result.ModifiedInput merge spreads the value back
-			// into the live ToolInput) don't see a spurious diff.
-			return val, false
-		}
-		return out, true
+		return out, changed
 	default:
 		return v, false
 	}

--- a/pkg/hooks/builtins/redact_secrets.go
+++ b/pkg/hooks/builtins/redact_secrets.go
@@ -1,0 +1,115 @@
+package builtins
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/docker/docker-agent/pkg/hooks"
+	"github.com/docker/docker-agent/pkg/secretsscan"
+)
+
+// RedactSecretsName is the type alias for the builtin's name
+// (matches the constant pattern used by add_environment_info etc.).
+type RedactSecretsName = string
+
+// RedactSecrets is the registered name of the builtin pre_tool_use
+// hook that scrubs secret material from a tool call's arguments
+// before the runtime hands them to the tool.
+//
+// The builtin pairs with the runtime-shipped before_llm_call message
+// transform (see pkg/runtime/redact_secrets.go) — together they bracket
+// every place where chat content can leak secrets to a third party:
+// the LLM provider on input, and a tool process on invocation. Either
+// can be enabled in isolation; the agent flag wires both up at once.
+const RedactSecrets RedactSecretsName = "redact_secrets"
+
+// redactSecrets is the [hooks.BuiltinFunc] for [RedactSecrets].
+// It walks every value in [hooks.Input.ToolInput] and replaces secret
+// spans (per [secretsscan]) with [secretsscan.RedactionMarker], then
+// returns the modified map via [hooks.HookSpecificOutput.UpdatedInput].
+//
+// Returning a nil [hooks.Output] when nothing changed is the
+// no-overhead path: the runtime's hook executor treats a nil output
+// as "this builtin contributed nothing", so an unaffected tool call
+// flows through with no allocation beyond the input scan.
+//
+// Maps and slices nested inside ToolInput are walked recursively so
+// secrets buried in structured arguments (a JSON object passed as a
+// shell command's --config payload, a list of HTTP headers, ...) are
+// caught alongside top-level string values. Non-string scalars
+// (numbers, booleans, nil) are passed through unchanged.
+func redactSecrets(_ context.Context, in *hooks.Input, _ []string) (*hooks.Output, error) {
+	if in == nil || len(in.ToolInput) == 0 {
+		return nil, nil
+	}
+
+	updated, changed := redactMap(in.ToolInput)
+	if !changed {
+		return nil, nil
+	}
+
+	return &hooks.Output{
+		SystemMessage: fmt.Sprintf("redact_secrets: redacted secret material from arguments of tool %q", in.ToolName),
+		HookSpecificOutput: &hooks.HookSpecificOutput{
+			HookEventName: hooks.EventPreToolUse,
+			UpdatedInput:  updated,
+		},
+	}, nil
+}
+
+// redactMap returns a redacted shallow copy of m alongside a
+// "did anything change" flag. Returning a fresh map (rather than
+// mutating in place) keeps the executor's [hooks.Result.ModifiedInput]
+// merge predictable: the caller only sees a copy when a redaction
+// actually happened.
+//
+// changed is the OR of every nested update so the top-level caller
+// can short-circuit when the entire payload was already clean.
+func redactMap(m map[string]any) (map[string]any, bool) {
+	out := make(map[string]any, len(m))
+	changed := false
+	for k, v := range m {
+		nv, c := redactValue(v)
+		out[k] = nv
+		if c {
+			changed = true
+		}
+	}
+	return out, changed
+}
+
+// redactValue recursively scrubs secrets out of v. Strings go through
+// [secretsscan.Redact]; maps and slices are walked element-wise so
+// secrets nested inside structured arguments (json.Unmarshal-style
+// map[string]any payloads, []any lists) are still caught. Every
+// other Go type passes through unchanged because the secret scanner
+// only operates on text.
+func redactValue(v any) (any, bool) {
+	switch val := v.(type) {
+	case string:
+		redacted := secretsscan.Redact(val)
+		return redacted, redacted != val
+	case map[string]any:
+		return redactMap(val)
+	case []any:
+		out := make([]any, len(val))
+		changed := false
+		for i, item := range val {
+			nv, c := redactValue(item)
+			out[i] = nv
+			if c {
+				changed = true
+			}
+		}
+		if !changed {
+			// Preserve identity when nothing changed so downstream
+			// consumers that compare slice headers (rare, but the
+			// hooks.Result.ModifiedInput merge spreads the value back
+			// into the live ToolInput) don't see a spurious diff.
+			return val, false
+		}
+		return out, true
+	default:
+		return v, false
+	}
+}

--- a/pkg/hooks/builtins/redact_secrets_test.go
+++ b/pkg/hooks/builtins/redact_secrets_test.go
@@ -11,8 +11,11 @@ import (
 )
 
 // TestRedactSecretsScrubsTopLevelStringValue: a recognised secret in
-// a top-level string argument is replaced and other scalars pass
-// through untouched.
+// a top-level string argument is replaced and ONLY the rewritten key
+// is emitted in UpdatedInput. The latter is critical because
+// pre_tool_use hooks aggregate via shallow maps.Copy in config order
+// — returning unchanged keys would clobber concurrent hooks'
+// modifications.
 func TestRedactSecretsScrubsTopLevelStringValue(t *testing.T) {
 	t.Parallel()
 
@@ -33,10 +36,12 @@ func TestRedactSecretsScrubsTopLevelStringValue(t *testing.T) {
 	require.NotNil(t, out.HookSpecificOutput)
 
 	updated := out.HookSpecificOutput.UpdatedInput
-	cmd, _ := updated["command"].(string)
+	cmd, ok := updated["command"].(string)
+	require.True(t, ok, "changed key must appear in UpdatedInput")
 	assert.NotContains(t, cmd, secret, "raw secret must be gone")
 	assert.Contains(t, cmd, secretsscan.RedactionMarker)
-	assert.Equal(t, 30, updated["timeout"], "non-string scalars pass through unchanged")
+	assert.NotContains(t, updated, "timeout",
+		"unchanged keys must NOT appear in UpdatedInput (would clobber concurrent hooks)")
 	assert.Equal(t, hooks.EventPreToolUse, out.HookSpecificOutput.HookEventName)
 }
 
@@ -73,7 +78,10 @@ func TestRedactSecretsHandlesNilAndEmptyInputs(t *testing.T) {
 
 // TestRedactSecretsWalksNestedStructures: secrets nested inside
 // map[string]any / []any payloads (the shape MCP and OpenAPI bridges
-// pass through) are caught alongside top-level values.
+// pass through) are caught alongside top-level values. The rebuilt
+// nested container preserves unchanged sibling values — the
+// "only changed keys" rule applies at the TOP level only, since the
+// executor's maps.Copy is shallow.
 func TestRedactSecretsWalksNestedStructures(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/hooks/builtins/redact_secrets_test.go
+++ b/pkg/hooks/builtins/redact_secrets_test.go
@@ -10,10 +10,9 @@ import (
 	"github.com/docker/docker-agent/pkg/secretsscan"
 )
 
-// TestRedactSecretsScrubsTopLevelStringValue locks in the headline
-// behavior: a string tool argument carrying a recognised secret is
-// replaced with [secretsscan.RedactionMarker] before the runtime
-// hands it off to the tool.
+// TestRedactSecretsScrubsTopLevelStringValue: a recognised secret in
+// a top-level string argument is replaced and other scalars pass
+// through untouched.
 func TestRedactSecretsScrubsTopLevelStringValue(t *testing.T) {
 	t.Parallel()
 
@@ -34,43 +33,30 @@ func TestRedactSecretsScrubsTopLevelStringValue(t *testing.T) {
 	require.NotNil(t, out.HookSpecificOutput)
 
 	updated := out.HookSpecificOutput.UpdatedInput
-	require.Contains(t, updated, "command")
-
-	cmd, ok := updated["command"].(string)
-	require.True(t, ok)
+	cmd, _ := updated["command"].(string)
 	assert.NotContains(t, cmd, secret, "raw secret must be gone")
 	assert.Contains(t, cmd, secretsscan.RedactionMarker)
 	assert.Equal(t, 30, updated["timeout"], "non-string scalars pass through unchanged")
 	assert.Equal(t, hooks.EventPreToolUse, out.HookSpecificOutput.HookEventName)
 }
 
-// TestRedactSecretsReturnsNilWhenNothingChanged keeps the
-// no-overhead path explicit. The executor treats nil Output as
-// "this builtin contributed nothing" (no system message, no
-// UpdatedInput merge), which is the cheapest possible flow for the
-// 99% case where a tool call carries no secrets.
+// TestRedactSecretsReturnsNilWhenNothingChanged: clean tool calls
+// take the no-overhead path (executor treats nil Output as "this
+// builtin contributed nothing").
 func TestRedactSecretsReturnsNilWhenNothingChanged(t *testing.T) {
 	t.Parallel()
 
-	in := &hooks.Input{
+	out, err := redactSecrets(t.Context(), &hooks.Input{
 		HookEventName: hooks.EventPreToolUse,
 		ToolName:      "shell",
-		ToolInput: map[string]any{
-			"command": "ls -la",
-			"timeout": 30,
-		},
-	}
-
-	out, err := redactSecrets(t.Context(), in, nil)
+		ToolInput:     map[string]any{"command": "ls -la", "timeout": 30},
+	}, nil)
 	require.NoError(t, err)
 	assert.Nil(t, out, "no secrets ⇒ no Output")
 }
 
-// TestRedactSecretsHandlesNilAndEmptyInputs documents the safety
-// floor: a missing or empty ToolInput must not panic and must not
-// fabricate an UpdatedInput. The executor calls redactSecrets on
-// every pre_tool_use match, including for tools that take no
-// arguments.
+// TestRedactSecretsHandlesNilAndEmptyInputs: missing/empty ToolInput
+// must not panic and must not fabricate an UpdatedInput.
 func TestRedactSecretsHandlesNilAndEmptyInputs(t *testing.T) {
 	t.Parallel()
 
@@ -85,12 +71,9 @@ func TestRedactSecretsHandlesNilAndEmptyInputs(t *testing.T) {
 	}
 }
 
-// TestRedactSecretsWalksNestedStructures pins the recursion contract.
-// Tool args produced by an MCP server / OpenAPI bridge often arrive
-// as map[string]any / []any payloads (json.Unmarshal-style); we must
-// dive into them so a token nested two levels deep is still caught.
-// Without this, a bash heredoc, a JSON --config payload, or a list
-// of HTTP headers becomes a backdoor.
+// TestRedactSecretsWalksNestedStructures: secrets nested inside
+// map[string]any / []any payloads (the shape MCP and OpenAPI bridges
+// pass through) are caught alongside top-level values.
 func TestRedactSecretsWalksNestedStructures(t *testing.T) {
 	t.Parallel()
 
@@ -111,19 +94,15 @@ func TestRedactSecretsWalksNestedStructures(t *testing.T) {
 	out, err := redactSecrets(t.Context(), in, nil)
 	require.NoError(t, err)
 	require.NotNil(t, out)
-	require.NotNil(t, out.HookSpecificOutput)
-
 	updated := out.HookSpecificOutput.UpdatedInput
 
-	headers, ok := updated["headers"].(map[string]any)
-	require.True(t, ok, "nested map should be walked & rebuilt")
+	headers := updated["headers"].(map[string]any)
 	auth, _ := headers["Authorization"].(string)
 	assert.NotContains(t, auth, secret)
 	assert.Contains(t, auth, secretsscan.RedactionMarker)
 	assert.Equal(t, "application/json", headers["Accept"], "non-secret header preserved")
 
-	tags, ok := updated["tags"].([]any)
-	require.True(t, ok, "nested slice should be walked & rebuilt")
+	tags := updated["tags"].([]any)
 	require.Len(t, tags, 3)
 	assert.Equal(t, "prod", tags[0])
 	tag1, _ := tags[1].(string)
@@ -132,10 +111,9 @@ func TestRedactSecretsWalksNestedStructures(t *testing.T) {
 	assert.Equal(t, 42, tags[2])
 }
 
-// TestRedactSecretsIsRegistered is the round-trip guard: invoking the
-// builtin via [hooks.Registry] (the path the YAML config takes) must
-// produce the same UpdatedInput as a direct call. A regression here
-// usually means we forgot the [hooks.Registry.RegisterBuiltin] line.
+// TestRedactSecretsIsRegistered: the builtin is reachable via
+// hooks.Registry (the path YAML config takes), not just by direct
+// call. Regressions usually mean a missing RegisterBuiltin line.
 func TestRedactSecretsIsRegistered(t *testing.T) {
 	t.Parallel()
 
@@ -155,23 +133,18 @@ func TestRedactSecretsIsRegistered(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, out)
-	require.NotNil(t, out.HookSpecificOutput)
-
 	cmd, _ := out.HookSpecificOutput.UpdatedInput["cmd"].(string)
 	assert.NotContains(t, cmd, secret)
 }
 
-// TestApplyAgentDefaultsInjectsRedactSecrets covers the agent-flag
-// wiring: setting AgentDefaults.RedactSecrets must materialise a
-// pre_tool_use matcher targeting the redact_secrets builtin with a
-// wildcard tool match. This is the runtime behavior for the
-// agent-level "redact_secrets: true" flag; without this test a future
-// refactor of ApplyAgentDefaults could silently drop it.
+// TestApplyAgentDefaultsInjectsRedactSecrets: setting the agent flag
+// must materialise a wildcard pre_tool_use matcher pointing at the
+// redact_secrets builtin.
 func TestApplyAgentDefaultsInjectsRedactSecrets(t *testing.T) {
 	t.Parallel()
 
 	cfg := ApplyAgentDefaults(nil, AgentDefaults{RedactSecrets: true})
-	require.NotNil(t, cfg, "redact_secrets alone should keep the config non-empty")
+	require.NotNil(t, cfg)
 	require.Len(t, cfg.PreToolUse, 1)
 	matcher := cfg.PreToolUse[0]
 	assert.Equal(t, "*", matcher.Matcher)

--- a/pkg/hooks/builtins/redact_secrets_test.go
+++ b/pkg/hooks/builtins/redact_secrets_test.go
@@ -1,0 +1,181 @@
+package builtins
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/hooks"
+	"github.com/docker/docker-agent/pkg/secretsscan"
+)
+
+// TestRedactSecretsScrubsTopLevelStringValue locks in the headline
+// behavior: a string tool argument carrying a recognised secret is
+// replaced with [secretsscan.RedactionMarker] before the runtime
+// hands it off to the tool.
+func TestRedactSecretsScrubsTopLevelStringValue(t *testing.T) {
+	t.Parallel()
+
+	const secret = "ghp_cxLeRrvbJfmYdUtr70xnNE3Q7Gvli43s19PD"
+
+	in := &hooks.Input{
+		HookEventName: hooks.EventPreToolUse,
+		ToolName:      "shell",
+		ToolInput: map[string]any{
+			"command": "curl -H 'Authorization: token " + secret + "' https://api.github.com",
+			"timeout": 30,
+		},
+	}
+
+	out, err := redactSecrets(t.Context(), in, nil)
+	require.NoError(t, err)
+	require.NotNil(t, out, "must return Output when redaction happened")
+	require.NotNil(t, out.HookSpecificOutput)
+
+	updated := out.HookSpecificOutput.UpdatedInput
+	require.Contains(t, updated, "command")
+
+	cmd, ok := updated["command"].(string)
+	require.True(t, ok)
+	assert.NotContains(t, cmd, secret, "raw secret must be gone")
+	assert.Contains(t, cmd, secretsscan.RedactionMarker)
+	assert.Equal(t, 30, updated["timeout"], "non-string scalars pass through unchanged")
+	assert.Equal(t, hooks.EventPreToolUse, out.HookSpecificOutput.HookEventName)
+}
+
+// TestRedactSecretsReturnsNilWhenNothingChanged keeps the
+// no-overhead path explicit. The executor treats nil Output as
+// "this builtin contributed nothing" (no system message, no
+// UpdatedInput merge), which is the cheapest possible flow for the
+// 99% case where a tool call carries no secrets.
+func TestRedactSecretsReturnsNilWhenNothingChanged(t *testing.T) {
+	t.Parallel()
+
+	in := &hooks.Input{
+		HookEventName: hooks.EventPreToolUse,
+		ToolName:      "shell",
+		ToolInput: map[string]any{
+			"command": "ls -la",
+			"timeout": 30,
+		},
+	}
+
+	out, err := redactSecrets(t.Context(), in, nil)
+	require.NoError(t, err)
+	assert.Nil(t, out, "no secrets ⇒ no Output")
+}
+
+// TestRedactSecretsHandlesNilAndEmptyInputs documents the safety
+// floor: a missing or empty ToolInput must not panic and must not
+// fabricate an UpdatedInput. The executor calls redactSecrets on
+// every pre_tool_use match, including for tools that take no
+// arguments.
+func TestRedactSecretsHandlesNilAndEmptyInputs(t *testing.T) {
+	t.Parallel()
+
+	for _, in := range []*hooks.Input{
+		nil,
+		{HookEventName: hooks.EventPreToolUse},
+		{HookEventName: hooks.EventPreToolUse, ToolInput: map[string]any{}},
+	} {
+		out, err := redactSecrets(t.Context(), in, nil)
+		require.NoError(t, err)
+		assert.Nil(t, out)
+	}
+}
+
+// TestRedactSecretsWalksNestedStructures pins the recursion contract.
+// Tool args produced by an MCP server / OpenAPI bridge often arrive
+// as map[string]any / []any payloads (json.Unmarshal-style); we must
+// dive into them so a token nested two levels deep is still caught.
+// Without this, a bash heredoc, a JSON --config payload, or a list
+// of HTTP headers becomes a backdoor.
+func TestRedactSecretsWalksNestedStructures(t *testing.T) {
+	t.Parallel()
+
+	const secret = "dckr_pat_" + "AAAAAAAAAAAAAAAAAAAAAAAAAAA"
+
+	in := &hooks.Input{
+		HookEventName: hooks.EventPreToolUse,
+		ToolName:      "http_request",
+		ToolInput: map[string]any{
+			"headers": map[string]any{
+				"Authorization": "Bearer " + secret,
+				"Accept":        "application/json",
+			},
+			"tags": []any{"prod", secret, 42},
+		},
+	}
+
+	out, err := redactSecrets(t.Context(), in, nil)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	require.NotNil(t, out.HookSpecificOutput)
+
+	updated := out.HookSpecificOutput.UpdatedInput
+
+	headers, ok := updated["headers"].(map[string]any)
+	require.True(t, ok, "nested map should be walked & rebuilt")
+	auth, _ := headers["Authorization"].(string)
+	assert.NotContains(t, auth, secret)
+	assert.Contains(t, auth, secretsscan.RedactionMarker)
+	assert.Equal(t, "application/json", headers["Accept"], "non-secret header preserved")
+
+	tags, ok := updated["tags"].([]any)
+	require.True(t, ok, "nested slice should be walked & rebuilt")
+	require.Len(t, tags, 3)
+	assert.Equal(t, "prod", tags[0])
+	tag1, _ := tags[1].(string)
+	assert.NotContains(t, tag1, secret)
+	assert.Contains(t, tag1, secretsscan.RedactionMarker)
+	assert.Equal(t, 42, tags[2])
+}
+
+// TestRedactSecretsIsRegistered is the round-trip guard: invoking the
+// builtin via [hooks.Registry] (the path the YAML config takes) must
+// produce the same UpdatedInput as a direct call. A regression here
+// usually means we forgot the [hooks.Registry.RegisterBuiltin] line.
+func TestRedactSecretsIsRegistered(t *testing.T) {
+	t.Parallel()
+
+	reg := hooks.NewRegistry()
+	state, err := Register(reg)
+	require.NoError(t, err)
+	t.Cleanup(func() { state.ClearSession("") })
+
+	handler, ok := reg.LookupBuiltin(RedactSecrets)
+	require.Truef(t, ok, "builtin %q must be registered", RedactSecrets)
+
+	const secret = "ghp_cxLeRrvbJfmYdUtr70xnNE3Q7Gvli43s19PD"
+	out, err := handler(t.Context(), &hooks.Input{
+		HookEventName: hooks.EventPreToolUse,
+		ToolName:      "shell",
+		ToolInput:     map[string]any{"cmd": secret},
+	}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	require.NotNil(t, out.HookSpecificOutput)
+
+	cmd, _ := out.HookSpecificOutput.UpdatedInput["cmd"].(string)
+	assert.NotContains(t, cmd, secret)
+}
+
+// TestApplyAgentDefaultsInjectsRedactSecrets covers the agent-flag
+// wiring: setting AgentDefaults.RedactSecrets must materialise a
+// pre_tool_use matcher targeting the redact_secrets builtin with a
+// wildcard tool match. This is the runtime behavior for the
+// agent-level "redact_secrets: true" flag; without this test a future
+// refactor of ApplyAgentDefaults could silently drop it.
+func TestApplyAgentDefaultsInjectsRedactSecrets(t *testing.T) {
+	t.Parallel()
+
+	cfg := ApplyAgentDefaults(nil, AgentDefaults{RedactSecrets: true})
+	require.NotNil(t, cfg, "redact_secrets alone should keep the config non-empty")
+	require.Len(t, cfg.PreToolUse, 1)
+	matcher := cfg.PreToolUse[0]
+	assert.Equal(t, "*", matcher.Matcher)
+	require.Len(t, matcher.Hooks, 1)
+	assert.Equal(t, hooks.HookTypeBuiltin, matcher.Hooks[0].Type)
+	assert.Equal(t, RedactSecrets, matcher.Hooks[0].Command)
+}

--- a/pkg/runtime/hooks.go
+++ b/pkg/runtime/hooks.go
@@ -36,6 +36,7 @@ func (r *LocalRuntime) buildHooksExecutors() {
 			AddDate:            a.AddDate(),
 			AddEnvironmentInfo: a.AddEnvironmentInfo(),
 			AddPromptFiles:     a.AddPromptFiles(),
+			RedactSecrets:      a.RedactSecrets(),
 		})
 		cfg = applyCacheDefault(cfg, a)
 		if cfg == nil {

--- a/pkg/runtime/redact_secrets.go
+++ b/pkg/runtime/redact_secrets.go
@@ -3,41 +3,33 @@ package runtime
 import (
 	"context"
 	"log/slog"
+	"slices"
 
 	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/hooks"
 	"github.com/docker/docker-agent/pkg/secretsscan"
-	"github.com/docker/docker-agent/pkg/tools"
 )
 
 // BuiltinRedactSecrets is the registered name of the runtime-shipped
 // before_llm_call message transform that scrubs secret material from
-// the chat messages about to be sent to the LLM.
+// outgoing chat messages.
 //
-// It pairs with the redact_secrets pre_tool_use builtin hook in
-// pkg/hooks/builtins (the constant of the same name there is the
-// matching string): both leak vectors — outgoing chat content on one
-// side, tool arguments on the other — share a single agent-level
-// switch (AgentConfig.RedactSecrets / agent.RedactSecrets()). The
-// transform constant exists for log filtering and parity with
-// [BuiltinStripUnsupportedModalities] / [BuiltinCacheResponse].
+// It pairs with the redact_secrets pre_tool_use builtin in
+// pkg/hooks/builtins; both are gated on the agent's RedactSecrets
+// flag so a single switch covers the two leak vectors (outgoing chat
+// content and outgoing tool args).
 const BuiltinRedactSecrets = "redact_secrets"
 
 // redactSecretsTransform is the [MessageTransform] registered under
-// [BuiltinRedactSecrets]. It is no-op for every agent that didn't
-// opt in via the redact_secrets flag — the flag is the single source
-// of truth, so adding the pre_tool_use builtin manually in YAML does
-// NOT enable the LLM-side scrubbing (and vice versa). Coupling the
-// two via the same flag avoids surprising "secrets leak to LLM but
-// not to tools" gaps when only one side is configured.
+// [BuiltinRedactSecrets]. It is a no-op for agents that did not opt
+// in via the redact_secrets flag.
 //
 // Resolving the agent through r.team.Agent (rather than holding a
 // direct reference) means the transform automatically picks up the
-// final flag value even when WithRedactSecrets is applied late in
-// the construction chain. A missing agent (corrupt input, deleted
-// since registration) silently falls through; the run-loop owner of
-// the input gets a chance to surface a clearer error than this
-// transform ever could.
+// final flag value even when the option is applied late in the
+// construction chain. A missing agent silently falls through; the
+// run-loop owner of the input gets a chance to surface a clearer
+// error than this transform ever could.
 func (r *LocalRuntime) redactSecretsTransform(
 	_ context.Context,
 	in *hooks.Input,
@@ -55,92 +47,41 @@ func (r *LocalRuntime) redactSecretsTransform(
 	if !a.RedactSecrets() {
 		return msgs, nil
 	}
-	return redactMessageSecrets(msgs), nil
-}
 
-// redactMessageSecrets returns a copy of messages with every text
-// field passed through [secretsscan.Redact]. Messages whose text
-// fields contain no secrets are returned by reference inside the
-// new slice — the per-message [chat.Message] value is only cloned
-// when at least one field actually changes — so the typical
-// "no secrets anywhere" case allocates exactly one slice header.
-//
-// The fields scrubbed are the ones a model can actually read from
-// the wire: [chat.Message.Content], [chat.Message.MultiContent]
-// text parts, and [tools.FunctionCall.Arguments] (the
-// JSON-encoded argument blob a previous turn's tool call carries
-// forward into the conversation history). Reasoning fields,
-// thinking signatures, and image payloads are left untouched —
-// they're either opaque to text scanning or unlikely vehicles for
-// secret leakage in the first place.
-//
-// Lives in this file (rather than secretsscan) because it depends
-// on the chat package; secretsscan stays free of internal
-// imports so it can be reused from the hooks builtin without
-// dragging in chat.
-func redactMessageSecrets(msgs []chat.Message) []chat.Message {
 	out := make([]chat.Message, len(msgs))
 	for i, m := range msgs {
-		out[i] = redactSingleMessage(m)
+		out[i] = redactMessage(m)
 	}
-	return out
+	return out, nil
 }
 
-// redactSingleMessage scrubs every text-bearing field of m and
-// returns the (possibly-modified) result. Split out from
-// [redactMessageSecrets] so the per-message logic is easy to test
-// and reason about — and so a future addition (e.g. scrubbing a
-// new chat.Message field) lives next to the existing rules rather
-// than buried in a slice loop.
-func redactSingleMessage(m chat.Message) chat.Message {
-	if scrubbed := secretsscan.Redact(m.Content); scrubbed != m.Content {
-		m.Content = scrubbed
-	}
+// redactMessage scrubs every text-bearing field of m: [chat.Message.Content],
+// the text parts of [chat.Message.MultiContent], and the JSON-encoded
+// arguments of any [chat.Message.ToolCalls] (so a previous turn's tool
+// call doesn't carry a secret forward into the next LLM call).
+//
+// MultiContent and ToolCalls slices are cloned before being mutated
+// so the caller's message history is left untouched. We don't bother
+// with copy-on-write: secretsscan.Redact is essentially free on
+// inputs that don't match a rule (it returns the same string), so the
+// only cost on a clean conversation is the per-message slice clone —
+// negligible compared to the LLM call this transform is gating.
+func redactMessage(m chat.Message) chat.Message {
+	m.Content = secretsscan.Redact(m.Content)
 
 	if len(m.MultiContent) > 0 {
-		// Walk-and-rebuild only when at least one part needs a
-		// rewrite, otherwise preserve the original slice header.
-		// Nothing is gained from cloning a slice of unchanged
-		// pointers and it would force every downstream comparator
-		// (history dedup, cache-key hashing) to do extra work.
-		var newParts []chat.MessagePart
-		for j, part := range m.MultiContent {
-			if part.Type != chat.MessagePartTypeText || part.Text == "" {
-				continue
+		m.MultiContent = slices.Clone(m.MultiContent)
+		for i := range m.MultiContent {
+			if m.MultiContent[i].Type == chat.MessagePartTypeText {
+				m.MultiContent[i].Text = secretsscan.Redact(m.MultiContent[i].Text)
 			}
-			scrubbed := secretsscan.Redact(part.Text)
-			if scrubbed == part.Text {
-				continue
-			}
-			if newParts == nil {
-				newParts = make([]chat.MessagePart, len(m.MultiContent))
-				copy(newParts, m.MultiContent)
-			}
-			newParts[j].Text = scrubbed
-		}
-		if newParts != nil {
-			m.MultiContent = newParts
 		}
 	}
 
 	if len(m.ToolCalls) > 0 {
-		var newCalls []tools.ToolCall
-		for j, call := range m.ToolCalls {
-			if call.Function.Arguments == "" {
-				continue
-			}
-			scrubbed := secretsscan.Redact(call.Function.Arguments)
-			if scrubbed == call.Function.Arguments {
-				continue
-			}
-			if newCalls == nil {
-				newCalls = make([]tools.ToolCall, len(m.ToolCalls))
-				copy(newCalls, m.ToolCalls)
-			}
-			newCalls[j].Function.Arguments = scrubbed
-		}
-		if newCalls != nil {
-			m.ToolCalls = newCalls
+		m.ToolCalls = slices.Clone(m.ToolCalls)
+		for i := range m.ToolCalls {
+			m.ToolCalls[i].Function.Arguments = secretsscan.Redact(m.ToolCalls[i].Function.Arguments)
 		}
 	}
 

--- a/pkg/runtime/redact_secrets.go
+++ b/pkg/runtime/redact_secrets.go
@@ -1,0 +1,148 @@
+package runtime
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/hooks"
+	"github.com/docker/docker-agent/pkg/secretsscan"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+// BuiltinRedactSecrets is the registered name of the runtime-shipped
+// before_llm_call message transform that scrubs secret material from
+// the chat messages about to be sent to the LLM.
+//
+// It pairs with the redact_secrets pre_tool_use builtin hook in
+// pkg/hooks/builtins (the constant of the same name there is the
+// matching string): both leak vectors — outgoing chat content on one
+// side, tool arguments on the other — share a single agent-level
+// switch (AgentConfig.RedactSecrets / agent.RedactSecrets()). The
+// transform constant exists for log filtering and parity with
+// [BuiltinStripUnsupportedModalities] / [BuiltinCacheResponse].
+const BuiltinRedactSecrets = "redact_secrets"
+
+// redactSecretsTransform is the [MessageTransform] registered under
+// [BuiltinRedactSecrets]. It is no-op for every agent that didn't
+// opt in via the redact_secrets flag — the flag is the single source
+// of truth, so adding the pre_tool_use builtin manually in YAML does
+// NOT enable the LLM-side scrubbing (and vice versa). Coupling the
+// two via the same flag avoids surprising "secrets leak to LLM but
+// not to tools" gaps when only one side is configured.
+//
+// Resolving the agent through r.team.Agent (rather than holding a
+// direct reference) means the transform automatically picks up the
+// final flag value even when WithRedactSecrets is applied late in
+// the construction chain. A missing agent (corrupt input, deleted
+// since registration) silently falls through; the run-loop owner of
+// the input gets a chance to surface a clearer error than this
+// transform ever could.
+func (r *LocalRuntime) redactSecretsTransform(
+	_ context.Context,
+	in *hooks.Input,
+	msgs []chat.Message,
+) ([]chat.Message, error) {
+	if in == nil || in.AgentName == "" {
+		return msgs, nil
+	}
+	a, err := r.team.Agent(in.AgentName)
+	if err != nil || a == nil {
+		slog.Debug("redact_secrets: skipping, agent not resolvable",
+			"agent_name", in.AgentName, "error", err)
+		return msgs, nil
+	}
+	if !a.RedactSecrets() {
+		return msgs, nil
+	}
+	return redactMessageSecrets(msgs), nil
+}
+
+// redactMessageSecrets returns a copy of messages with every text
+// field passed through [secretsscan.Redact]. Messages whose text
+// fields contain no secrets are returned by reference inside the
+// new slice — the per-message [chat.Message] value is only cloned
+// when at least one field actually changes — so the typical
+// "no secrets anywhere" case allocates exactly one slice header.
+//
+// The fields scrubbed are the ones a model can actually read from
+// the wire: [chat.Message.Content], [chat.Message.MultiContent]
+// text parts, and [tools.FunctionCall.Arguments] (the
+// JSON-encoded argument blob a previous turn's tool call carries
+// forward into the conversation history). Reasoning fields,
+// thinking signatures, and image payloads are left untouched —
+// they're either opaque to text scanning or unlikely vehicles for
+// secret leakage in the first place.
+//
+// Lives in this file (rather than secretsscan) because it depends
+// on the chat package; secretsscan stays free of internal
+// imports so it can be reused from the hooks builtin without
+// dragging in chat.
+func redactMessageSecrets(msgs []chat.Message) []chat.Message {
+	out := make([]chat.Message, len(msgs))
+	for i, m := range msgs {
+		out[i] = redactSingleMessage(m)
+	}
+	return out
+}
+
+// redactSingleMessage scrubs every text-bearing field of m and
+// returns the (possibly-modified) result. Split out from
+// [redactMessageSecrets] so the per-message logic is easy to test
+// and reason about — and so a future addition (e.g. scrubbing a
+// new chat.Message field) lives next to the existing rules rather
+// than buried in a slice loop.
+func redactSingleMessage(m chat.Message) chat.Message {
+	if scrubbed := secretsscan.Redact(m.Content); scrubbed != m.Content {
+		m.Content = scrubbed
+	}
+
+	if len(m.MultiContent) > 0 {
+		// Walk-and-rebuild only when at least one part needs a
+		// rewrite, otherwise preserve the original slice header.
+		// Nothing is gained from cloning a slice of unchanged
+		// pointers and it would force every downstream comparator
+		// (history dedup, cache-key hashing) to do extra work.
+		var newParts []chat.MessagePart
+		for j, part := range m.MultiContent {
+			if part.Type != chat.MessagePartTypeText || part.Text == "" {
+				continue
+			}
+			scrubbed := secretsscan.Redact(part.Text)
+			if scrubbed == part.Text {
+				continue
+			}
+			if newParts == nil {
+				newParts = make([]chat.MessagePart, len(m.MultiContent))
+				copy(newParts, m.MultiContent)
+			}
+			newParts[j].Text = scrubbed
+		}
+		if newParts != nil {
+			m.MultiContent = newParts
+		}
+	}
+
+	if len(m.ToolCalls) > 0 {
+		var newCalls []tools.ToolCall
+		for j, call := range m.ToolCalls {
+			if call.Function.Arguments == "" {
+				continue
+			}
+			scrubbed := secretsscan.Redact(call.Function.Arguments)
+			if scrubbed == call.Function.Arguments {
+				continue
+			}
+			if newCalls == nil {
+				newCalls = make([]tools.ToolCall, len(m.ToolCalls))
+				copy(newCalls, m.ToolCalls)
+			}
+			newCalls[j].Function.Arguments = scrubbed
+		}
+		if newCalls != nil {
+			m.ToolCalls = newCalls
+		}
+	}
+
+	return m
+}

--- a/pkg/runtime/redact_secrets.go
+++ b/pkg/runtime/redact_secrets.go
@@ -55,19 +55,33 @@ func (r *LocalRuntime) redactSecretsTransform(
 	return out, nil
 }
 
-// redactMessage scrubs every text-bearing field of m: [chat.Message.Content],
-// the text parts of [chat.Message.MultiContent], and the JSON-encoded
-// arguments of any [chat.Message.ToolCalls] (so a previous turn's tool
-// call doesn't carry a secret forward into the next LLM call).
+// redactMessage scrubs every text-bearing field of m that round-trips
+// to a model provider:
 //
-// MultiContent and ToolCalls slices are cloned before being mutated
-// so the caller's message history is left untouched. We don't bother
-// with copy-on-write: secretsscan.Redact is essentially free on
-// inputs that don't match a rule (it returns the same string), so the
-// only cost on a clean conversation is the per-message slice clone —
-// negligible compared to the LLM call this transform is gating.
+//   - [chat.Message.Content]
+//   - [chat.Message.ReasoningContent] (sent back to Anthropic, Bedrock,
+//     DeepSeek as a thinking block, so a previous turn's reasoning
+//     trace must not leak a secret it mentioned)
+//   - text parts of [chat.Message.MultiContent]
+//   - the legacy singular [chat.Message.FunctionCall].Arguments
+//     (still sent by the OpenAI provider when set)
+//   - the JSON-encoded arguments of every entry in
+//     [chat.Message.ToolCalls]
+//
+// Other fields (image URLs, file references, ThinkingSignature,
+// ThoughtSignature) are not scanned: they're either opaque provider
+// tokens or non-text payloads outside the secretsscan ruleset's reach.
+//
+// MultiContent and ToolCalls slices are cloned (and FunctionCall
+// pointers are deep-copied) before being mutated so the caller's
+// message history is left untouched. We don't bother with
+// copy-on-write: secretsscan.Redact is essentially free on inputs
+// that don't match a rule (it returns the same string), so the only
+// cost on a clean conversation is the per-message slice/struct clone
+// — negligible compared to the LLM call this transform is gating.
 func redactMessage(m chat.Message) chat.Message {
 	m.Content = secretsscan.Redact(m.Content)
+	m.ReasoningContent = secretsscan.Redact(m.ReasoningContent)
 
 	if len(m.MultiContent) > 0 {
 		m.MultiContent = slices.Clone(m.MultiContent)
@@ -76,6 +90,12 @@ func redactMessage(m chat.Message) chat.Message {
 				m.MultiContent[i].Text = secretsscan.Redact(m.MultiContent[i].Text)
 			}
 		}
+	}
+
+	if m.FunctionCall != nil {
+		fc := *m.FunctionCall
+		fc.Arguments = secretsscan.Redact(fc.Arguments)
+		m.FunctionCall = &fc
 	}
 
 	if len(m.ToolCalls) > 0 {

--- a/pkg/runtime/redact_secrets_test.go
+++ b/pkg/runtime/redact_secrets_test.go
@@ -84,21 +84,28 @@ func TestRedactSecretsTransform_GatedOnAgentFlag(t *testing.T) {
 }
 
 // TestRedactSecretsTransform_ScrubsAllSurfaces: every text-bearing
-// field a model can read on the wire (Content, MultiContent text,
-// ToolCall.Arguments) must be scrubbed. A miss on any of these is a
-// real leak — e.g. a previous turn's tool call with a secret in its
-// arguments would otherwise round-trip to the next LLM call.
+// field a model can read on the wire (Content, ReasoningContent,
+// MultiContent text, the legacy singular FunctionCall.Arguments, and
+// each ToolCall.Function.Arguments) must be scrubbed. A miss on any
+// of these is a real leak — e.g. a previous turn's reasoning trace
+// or tool call carrying a secret would otherwise round-trip to the
+// next LLM call.
 func TestRedactSecretsTransform_ScrubsAllSurfaces(t *testing.T) {
 	t.Parallel()
 
 	r := newRedactRuntime(t, true)
 
 	in := []chat.Message{{
-		Role:    chat.MessageRoleAssistant,
-		Content: "primary content with " + secretGitHubPAT,
+		Role:             chat.MessageRoleAssistant,
+		Content:          "primary content with " + secretGitHubPAT,
+		ReasoningContent: "thinking about " + secretGitHubPAT,
 		MultiContent: []chat.MessagePart{
 			{Type: chat.MessagePartTypeText, Text: "part with " + secretGitHubPAT},
 			{Type: chat.MessagePartTypeText, Text: "clean part"},
+		},
+		FunctionCall: &tools.FunctionCall{
+			Name:      "legacy_call",
+			Arguments: `{"token":"` + secretGitHubPAT + `"}`,
 		},
 		ToolCalls: []tools.ToolCall{{
 			ID:   "call_1",
@@ -115,10 +122,14 @@ func TestRedactSecretsTransform_ScrubsAllSurfaces(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 
-	assert.NotContains(t, out[0].Content, secretGitHubPAT)
+	assert.NotContains(t, out[0].Content, secretGitHubPAT, "Content must be scrubbed")
+	assert.NotContains(t, out[0].ReasoningContent, secretGitHubPAT, "ReasoningContent must be scrubbed")
 	require.Len(t, out[0].MultiContent, 2)
 	assert.NotContains(t, out[0].MultiContent[0].Text, secretGitHubPAT)
 	assert.Equal(t, "clean part", out[0].MultiContent[1].Text, "clean parts pass through")
+	require.NotNil(t, out[0].FunctionCall)
+	assert.NotContains(t, out[0].FunctionCall.Arguments, secretGitHubPAT,
+		"legacy singular FunctionCall.Arguments must be scrubbed")
 	require.Len(t, out[0].ToolCalls, 1)
 	assert.NotContains(t, out[0].ToolCalls[0].Function.Arguments, secretGitHubPAT)
 }
@@ -147,20 +158,23 @@ func TestRedactSecretsTransform_PreservesCleanContent(t *testing.T) {
 }
 
 // TestRedactSecretsTransform_DoesNotMutateInput: scrubbing produces a
-// fresh slice/MultiContent/ToolCalls — the caller's history is left
-// unchanged. Critical because callers (history compactors, cache
-// stores) keep references to the pre-transform values.
+// fresh slice/MultiContent/FunctionCall/ToolCalls — the caller's
+// history is left unchanged. Critical because callers (history
+// compactors, cache stores) keep references to the pre-transform
+// values; mutating them would corrupt persisted state.
 func TestRedactSecretsTransform_DoesNotMutateInput(t *testing.T) {
 	t.Parallel()
 
 	r := newRedactRuntime(t, true)
 
 	in := []chat.Message{{
-		Role:    chat.MessageRoleAssistant,
-		Content: "with " + secretGitHubPAT,
+		Role:             chat.MessageRoleAssistant,
+		Content:          "with " + secretGitHubPAT,
+		ReasoningContent: "thinking with " + secretGitHubPAT,
 		MultiContent: []chat.MessagePart{
 			{Type: chat.MessagePartTypeText, Text: "part with " + secretGitHubPAT},
 		},
+		FunctionCall: &tools.FunctionCall{Arguments: secretGitHubPAT},
 		ToolCalls: []tools.ToolCall{{
 			Function: tools.FunctionCall{Arguments: secretGitHubPAT},
 		}},
@@ -171,8 +185,12 @@ func TestRedactSecretsTransform_DoesNotMutateInput(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Contains(t, in[0].Content, secretGitHubPAT, "input.Content must be untouched")
+	assert.Contains(t, in[0].ReasoningContent, secretGitHubPAT,
+		"input.ReasoningContent must be untouched")
 	assert.Contains(t, in[0].MultiContent[0].Text, secretGitHubPAT,
 		"input.MultiContent must be untouched")
+	assert.Contains(t, in[0].FunctionCall.Arguments, secretGitHubPAT,
+		"input.FunctionCall must be untouched (deep copy needed)")
 	assert.Contains(t, in[0].ToolCalls[0].Function.Arguments, secretGitHubPAT,
 		"input.ToolCalls must be untouched")
 }

--- a/pkg/runtime/redact_secrets_test.go
+++ b/pkg/runtime/redact_secrets_test.go
@@ -16,15 +16,11 @@ import (
 
 // secretGitHubPAT is a syntactically-valid (but obviously fake) GitHub
 // personal access token shape that the secretsscan ruleset detects.
-// Centralising it makes the assertions below easier to read and keeps
-// the secret value out of every individual test body.
 const secretGitHubPAT = "ghp_cxLeRrvbJfmYdUtr70xnNE3Q7Gvli43s19PD"
 
 // newRedactRuntime returns a [LocalRuntime] hosting a single agent
-// with redactSecrets toggled per the flag. It exists so the per-case
-// setup in [TestRedactSecretsTransform_GatedOnAgentFlag] stays a
-// one-liner; tests need a real runtime because the transform looks
-// the agent up via r.team.Agent.
+// with redactSecrets toggled per the flag. Tests need a real runtime
+// because the transform looks the agent up via r.team.Agent.
 func newRedactRuntime(t *testing.T, redact bool) *LocalRuntime {
 	t.Helper()
 	prov := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
@@ -38,11 +34,9 @@ func newRedactRuntime(t *testing.T, redact bool) *LocalRuntime {
 	return r
 }
 
-// TestRedactSecretsTransform_GatedOnAgentFlag pins the central design
-// invariant: the LLM-side scrubbing only fires for agents that opted
-// in via [agent.WithRedactSecrets] (a.k.a. AgentConfig.RedactSecrets:
-// true). When the flag is off the message slice must reach the
-// provider unchanged — no allocations beyond the slice header copy.
+// TestRedactSecretsTransform_GatedOnAgentFlag: scrubbing only fires
+// for agents that opted in via the redact_secrets flag; flag-off,
+// missing, and nil-input cases must passthrough untouched.
 func TestRedactSecretsTransform_GatedOnAgentFlag(t *testing.T) {
 	t.Parallel()
 
@@ -58,8 +52,7 @@ func TestRedactSecretsTransform_GatedOnAgentFlag(t *testing.T) {
 			&hooks.Input{AgentName: "root"}, dirty)
 		require.NoError(t, err)
 		require.Len(t, got, 1)
-		assert.NotContains(t, got[0].Content, secretGitHubPAT,
-			"flag-on agent must scrub Content")
+		assert.NotContains(t, got[0].Content, secretGitHubPAT)
 		assert.Contains(t, got[0].Content, secretsscan.RedactionMarker)
 	})
 
@@ -69,7 +62,7 @@ func TestRedactSecretsTransform_GatedOnAgentFlag(t *testing.T) {
 		got, err := r.redactSecretsTransform(t.Context(),
 			&hooks.Input{AgentName: "root"}, dirty)
 		require.NoError(t, err)
-		assert.Equal(t, dirty, got, "flag-off agent must passthrough untouched")
+		assert.Equal(t, dirty, got)
 	})
 
 	t.Run("missing agent → passthrough", func(t *testing.T) {
@@ -78,8 +71,7 @@ func TestRedactSecretsTransform_GatedOnAgentFlag(t *testing.T) {
 		got, err := r.redactSecretsTransform(t.Context(),
 			&hooks.Input{AgentName: "no-such-agent"}, dirty)
 		require.NoError(t, err)
-		assert.Equal(t, dirty, got,
-			"unknown agent must not panic or modify the slice")
+		assert.Equal(t, dirty, got)
 	})
 
 	t.Run("nil input → passthrough", func(t *testing.T) {
@@ -91,13 +83,11 @@ func TestRedactSecretsTransform_GatedOnAgentFlag(t *testing.T) {
 	})
 }
 
-// TestRedactSecretsTransform_ScrubsAllSurfaces locks in the field
-// coverage: the transform must scrub Content, MultiContent text
-// parts, AND the JSON-encoded ToolCall arguments — that's the full
-// set of text-bearing fields a future model call can read. A miss
-// on any of these surfaces is a real leak (a previous turn's tool
-// call with a secret in its arguments would otherwise round-trip
-// to the LLM unchanged).
+// TestRedactSecretsTransform_ScrubsAllSurfaces: every text-bearing
+// field a model can read on the wire (Content, MultiContent text,
+// ToolCall.Arguments) must be scrubbed. A miss on any of these is a
+// real leak — e.g. a previous turn's tool call with a secret in its
+// arguments would otherwise round-trip to the next LLM call.
 func TestRedactSecretsTransform_ScrubsAllSurfaces(t *testing.T) {
 	t.Parallel()
 
@@ -125,26 +115,18 @@ func TestRedactSecretsTransform_ScrubsAllSurfaces(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 
-	assert.NotContains(t, out[0].Content, secretGitHubPAT, "Content must be scrubbed")
+	assert.NotContains(t, out[0].Content, secretGitHubPAT)
 	require.Len(t, out[0].MultiContent, 2)
-	assert.NotContains(t, out[0].MultiContent[0].Text, secretGitHubPAT,
-		"MultiContent text must be scrubbed")
-	assert.Equal(t, "clean part", out[0].MultiContent[1].Text,
-		"clean parts must remain identity-equal so downstream caches don't churn")
+	assert.NotContains(t, out[0].MultiContent[0].Text, secretGitHubPAT)
+	assert.Equal(t, "clean part", out[0].MultiContent[1].Text, "clean parts pass through")
 	require.Len(t, out[0].ToolCalls, 1)
-	assert.NotContains(t, out[0].ToolCalls[0].Function.Arguments, secretGitHubPAT,
-		"ToolCall.Arguments must be scrubbed")
+	assert.NotContains(t, out[0].ToolCalls[0].Function.Arguments, secretGitHubPAT)
 }
 
-// TestRedactSecretsTransform_PreservesIdentityWhenClean is the
-// negative-symmetry test for the copy-on-write contract: a fully
-// clean conversation must reach the provider as the SAME slice
-// values (the loop allocates a fresh slice header but per-message
-// values are passed by value via the loop, so equality is the
-// observable check). A regression here — e.g. a future "always copy
-// MultiContent" change — would silently double allocations on every
-// LLM call for the 99% case.
-func TestRedactSecretsTransform_PreservesIdentityWhenClean(t *testing.T) {
+// TestRedactSecretsTransform_PreservesCleanContent: a fully clean
+// conversation must reach the provider with values equal to the
+// originals.
+func TestRedactSecretsTransform_PreservesCleanContent(t *testing.T) {
 	t.Parallel()
 
 	r := newRedactRuntime(t, true)
@@ -161,6 +143,36 @@ func TestRedactSecretsTransform_PreservesIdentityWhenClean(t *testing.T) {
 		&hooks.Input{AgentName: "root"}, clean)
 	require.NoError(t, err)
 	require.Len(t, out, 1)
-	assert.Equal(t, clean[0], out[0],
-		"clean messages must reach the provider value-equal")
+	assert.Equal(t, clean[0], out[0])
+}
+
+// TestRedactSecretsTransform_DoesNotMutateInput: scrubbing produces a
+// fresh slice/MultiContent/ToolCalls — the caller's history is left
+// unchanged. Critical because callers (history compactors, cache
+// stores) keep references to the pre-transform values.
+func TestRedactSecretsTransform_DoesNotMutateInput(t *testing.T) {
+	t.Parallel()
+
+	r := newRedactRuntime(t, true)
+
+	in := []chat.Message{{
+		Role:    chat.MessageRoleAssistant,
+		Content: "with " + secretGitHubPAT,
+		MultiContent: []chat.MessagePart{
+			{Type: chat.MessagePartTypeText, Text: "part with " + secretGitHubPAT},
+		},
+		ToolCalls: []tools.ToolCall{{
+			Function: tools.FunctionCall{Arguments: secretGitHubPAT},
+		}},
+	}}
+
+	_, err := r.redactSecretsTransform(t.Context(),
+		&hooks.Input{AgentName: "root"}, in)
+	require.NoError(t, err)
+
+	assert.Contains(t, in[0].Content, secretGitHubPAT, "input.Content must be untouched")
+	assert.Contains(t, in[0].MultiContent[0].Text, secretGitHubPAT,
+		"input.MultiContent must be untouched")
+	assert.Contains(t, in[0].ToolCalls[0].Function.Arguments, secretGitHubPAT,
+		"input.ToolCalls must be untouched")
 }

--- a/pkg/runtime/redact_secrets_test.go
+++ b/pkg/runtime/redact_secrets_test.go
@@ -1,0 +1,166 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/hooks"
+	"github.com/docker/docker-agent/pkg/secretsscan"
+	"github.com/docker/docker-agent/pkg/team"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+// secretGitHubPAT is a syntactically-valid (but obviously fake) GitHub
+// personal access token shape that the secretsscan ruleset detects.
+// Centralising it makes the assertions below easier to read and keeps
+// the secret value out of every individual test body.
+const secretGitHubPAT = "ghp_cxLeRrvbJfmYdUtr70xnNE3Q7Gvli43s19PD"
+
+// newRedactRuntime returns a [LocalRuntime] hosting a single agent
+// with redactSecrets toggled per the flag. It exists so the per-case
+// setup in [TestRedactSecretsTransform_GatedOnAgentFlag] stays a
+// one-liner; tests need a real runtime because the transform looks
+// the agent up via r.team.Agent.
+func newRedactRuntime(t *testing.T, redact bool) *LocalRuntime {
+	t.Helper()
+	prov := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
+	a := agent.New("root", "instructions",
+		agent.WithModel(prov),
+		agent.WithRedactSecrets(redact),
+	)
+	tm := team.New(team.WithAgents(a))
+	r, err := NewLocalRuntime(tm, WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+	return r
+}
+
+// TestRedactSecretsTransform_GatedOnAgentFlag pins the central design
+// invariant: the LLM-side scrubbing only fires for agents that opted
+// in via [agent.WithRedactSecrets] (a.k.a. AgentConfig.RedactSecrets:
+// true). When the flag is off the message slice must reach the
+// provider unchanged — no allocations beyond the slice header copy.
+func TestRedactSecretsTransform_GatedOnAgentFlag(t *testing.T) {
+	t.Parallel()
+
+	dirty := []chat.Message{{
+		Role:    chat.MessageRoleUser,
+		Content: "use this token: " + secretGitHubPAT,
+	}}
+
+	t.Run("flag on → redacts", func(t *testing.T) {
+		t.Parallel()
+		r := newRedactRuntime(t, true)
+		got, err := r.redactSecretsTransform(t.Context(),
+			&hooks.Input{AgentName: "root"}, dirty)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.NotContains(t, got[0].Content, secretGitHubPAT,
+			"flag-on agent must scrub Content")
+		assert.Contains(t, got[0].Content, secretsscan.RedactionMarker)
+	})
+
+	t.Run("flag off → passthrough", func(t *testing.T) {
+		t.Parallel()
+		r := newRedactRuntime(t, false)
+		got, err := r.redactSecretsTransform(t.Context(),
+			&hooks.Input{AgentName: "root"}, dirty)
+		require.NoError(t, err)
+		assert.Equal(t, dirty, got, "flag-off agent must passthrough untouched")
+	})
+
+	t.Run("missing agent → passthrough", func(t *testing.T) {
+		t.Parallel()
+		r := newRedactRuntime(t, true)
+		got, err := r.redactSecretsTransform(t.Context(),
+			&hooks.Input{AgentName: "no-such-agent"}, dirty)
+		require.NoError(t, err)
+		assert.Equal(t, dirty, got,
+			"unknown agent must not panic or modify the slice")
+	})
+
+	t.Run("nil input → passthrough", func(t *testing.T) {
+		t.Parallel()
+		r := newRedactRuntime(t, true)
+		got, err := r.redactSecretsTransform(t.Context(), nil, dirty)
+		require.NoError(t, err)
+		assert.Equal(t, dirty, got)
+	})
+}
+
+// TestRedactSecretsTransform_ScrubsAllSurfaces locks in the field
+// coverage: the transform must scrub Content, MultiContent text
+// parts, AND the JSON-encoded ToolCall arguments — that's the full
+// set of text-bearing fields a future model call can read. A miss
+// on any of these surfaces is a real leak (a previous turn's tool
+// call with a secret in its arguments would otherwise round-trip
+// to the LLM unchanged).
+func TestRedactSecretsTransform_ScrubsAllSurfaces(t *testing.T) {
+	t.Parallel()
+
+	r := newRedactRuntime(t, true)
+
+	in := []chat.Message{{
+		Role:    chat.MessageRoleAssistant,
+		Content: "primary content with " + secretGitHubPAT,
+		MultiContent: []chat.MessagePart{
+			{Type: chat.MessagePartTypeText, Text: "part with " + secretGitHubPAT},
+			{Type: chat.MessagePartTypeText, Text: "clean part"},
+		},
+		ToolCalls: []tools.ToolCall{{
+			ID:   "call_1",
+			Type: "function",
+			Function: tools.FunctionCall{
+				Name:      "shell",
+				Arguments: `{"cmd":"curl -H 'Authorization: token ` + secretGitHubPAT + `' https://api.github.com"}`,
+			},
+		}},
+	}}
+
+	out, err := r.redactSecretsTransform(t.Context(),
+		&hooks.Input{AgentName: "root"}, in)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+
+	assert.NotContains(t, out[0].Content, secretGitHubPAT, "Content must be scrubbed")
+	require.Len(t, out[0].MultiContent, 2)
+	assert.NotContains(t, out[0].MultiContent[0].Text, secretGitHubPAT,
+		"MultiContent text must be scrubbed")
+	assert.Equal(t, "clean part", out[0].MultiContent[1].Text,
+		"clean parts must remain identity-equal so downstream caches don't churn")
+	require.Len(t, out[0].ToolCalls, 1)
+	assert.NotContains(t, out[0].ToolCalls[0].Function.Arguments, secretGitHubPAT,
+		"ToolCall.Arguments must be scrubbed")
+}
+
+// TestRedactSecretsTransform_PreservesIdentityWhenClean is the
+// negative-symmetry test for the copy-on-write contract: a fully
+// clean conversation must reach the provider as the SAME slice
+// values (the loop allocates a fresh slice header but per-message
+// values are passed by value via the loop, so equality is the
+// observable check). A regression here — e.g. a future "always copy
+// MultiContent" change — would silently double allocations on every
+// LLM call for the 99% case.
+func TestRedactSecretsTransform_PreservesIdentityWhenClean(t *testing.T) {
+	t.Parallel()
+
+	r := newRedactRuntime(t, true)
+
+	clean := []chat.Message{{
+		Role:    chat.MessageRoleUser,
+		Content: "summarise the README please",
+		MultiContent: []chat.MessagePart{
+			{Type: chat.MessagePartTypeText, Text: "no secrets here"},
+		},
+	}}
+
+	out, err := r.redactSecretsTransform(t.Context(),
+		&hooks.Input{AgentName: "root"}, clean)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	assert.Equal(t, clean[0], out[0],
+		"clean messages must reach the provider value-equal")
+}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -405,10 +405,25 @@ func NewLocalRuntime(agents *team.Team, opts ...Opt) (*LocalRuntime, error) {
 	// cache_response it captures the runtime closure (to resolve the
 	// agent and its model from Input.AgentName) and is therefore
 	// registered here rather than in pkg/hooks/builtins.
-	r.transforms = append(r.transforms, registeredTransform{
-		name: BuiltinStripUnsupportedModalities,
-		fn:   r.stripUnsupportedModalitiesTransform,
-	})
+	//
+	// redact_secrets is the LLM-side peer of the redact_secrets
+	// pre_tool_use builtin hook (see pkg/hooks/builtins/redact_secrets.go).
+	// Both are gated on the agent's RedactSecrets flag so a single
+	// agent-level switch covers the two leak vectors (outgoing chat
+	// content + outgoing tool args). Like the strip transform, it
+	// captures the runtime closure to resolve the agent from
+	// Input.AgentName, so it must be registered here rather than as a
+	// stateless builtin in pkg/hooks/builtins.
+	r.transforms = append(r.transforms,
+		registeredTransform{
+			name: BuiltinStripUnsupportedModalities,
+			fn:   r.stripUnsupportedModalitiesTransform,
+		},
+		registeredTransform{
+			name: BuiltinRedactSecrets,
+			fn:   r.redactSecretsTransform,
+		},
+	)
 
 	for _, opt := range opts {
 		opt(r)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -399,21 +399,14 @@ func NewLocalRuntime(agents *team.Team, opts ...Opt) (*LocalRuntime, error) {
 		return nil, fmt.Errorf("register %q builtin: %w", BuiltinCacheResponse, err)
 	}
 
-	// strip_unsupported_modalities is the runtime-shipped
-	// before_llm_call message transform that drops image content from
-	// messages when the agent's model is text-only. Like
-	// cache_response it captures the runtime closure (to resolve the
-	// agent and its model from Input.AgentName) and is therefore
-	// registered here rather than in pkg/hooks/builtins.
+	// Both message transforms below capture the runtime closure to
+	// resolve the agent from Input.AgentName, so they live here rather
+	// than as stateless builtins in pkg/hooks/builtins.
 	//
-	// redact_secrets is the LLM-side peer of the redact_secrets
-	// pre_tool_use builtin hook (see pkg/hooks/builtins/redact_secrets.go).
-	// Both are gated on the agent's RedactSecrets flag so a single
-	// agent-level switch covers the two leak vectors (outgoing chat
-	// content + outgoing tool args). Like the strip transform, it
-	// captures the runtime closure to resolve the agent from
-	// Input.AgentName, so it must be registered here rather than as a
-	// stateless builtin in pkg/hooks/builtins.
+	// strip_unsupported_modalities drops image content for text-only
+	// models. redact_secrets is the LLM-side peer of the redact_secrets
+	// pre_tool_use builtin (gated on the agent's RedactSecrets flag,
+	// see pkg/hooks/builtins/redact_secrets.go).
 	r.transforms = append(r.transforms,
 		registeredTransform{
 			name: BuiltinStripUnsupportedModalities,

--- a/pkg/runtime/transforms_test.go
+++ b/pkg/runtime/transforms_test.go
@@ -359,7 +359,10 @@ func TestWithMessageTransform_RejectsEmptyAndNil(t *testing.T) {
 	)
 	require.NoError(t, err, "WithMessageTransform must not surface a constructor error")
 
-	// Only the runtime-shipped strip transform should remain.
-	require.Len(t, r.transforms, 1, "invalid transforms must be silently ignored")
+	// Only the two runtime-shipped transforms (strip_unsupported_modalities
+	// and redact_secrets) should remain — invalid user transforms are
+	// dropped silently.
+	require.Len(t, r.transforms, 2, "invalid transforms must be silently ignored")
 	assert.Equal(t, BuiltinStripUnsupportedModalities, r.transforms[0].name)
+	assert.Equal(t, BuiltinRedactSecrets, r.transforms[1].name)
 }

--- a/pkg/secretsscan/doc.go
+++ b/pkg/secretsscan/doc.go
@@ -1,0 +1,21 @@
+// Package secretsscan provides a small, dependency-free scanner that
+// recognises common API tokens, cloud credentials, and other secret
+// material in arbitrary text. It exposes two operations:
+//
+//   - [ContainsSecrets] reports whether any rule matches the input
+//     (used for fail-closed checks).
+//   - [Redact] replaces the secret span of every matching rule with
+//     [RedactionMarker], leaving the surrounding text untouched.
+//
+// The ruleset is derived from the MIT-licensed
+// github.com/docker/mcp-gateway/pkg/secretsscan package, which itself
+// adapted the patterns from
+// github.com/aquasecurity/trivy/pkg/fanal/secret/builtin-rules.go.
+// Every rule pairs a keyword shortlist (cheap [strings.Contains]
+// pre-filter) with a regular expression; only inputs that contain
+// one of the keywords pay the regex cost.
+//
+// The package is intentionally allocation-light and concurrency-safe
+// so it can be called on every outgoing chat message and tool input
+// without measurable overhead.
+package secretsscan

--- a/pkg/secretsscan/doc.go
+++ b/pkg/secretsscan/doc.go
@@ -1,21 +1,12 @@
-// Package secretsscan provides a small, dependency-free scanner that
-// recognises common API tokens, cloud credentials, and other secret
-// material in arbitrary text. It exposes two operations:
+// Package secretsscan recognises common API tokens, cloud credentials,
+// and other secret material in arbitrary text.
 //
-//   - [ContainsSecrets] reports whether any rule matches the input
-//     (used for fail-closed checks).
-//   - [Redact] replaces the secret span of every matching rule with
-//     [RedactionMarker], leaving the surrounding text untouched.
+// [ContainsSecrets] reports whether any rule matches the input;
+// [Redact] replaces every detected secret span with [RedactionMarker]
+// while preserving the surrounding text. Both are safe for concurrent
+// use and idempotent.
 //
 // The ruleset is derived from the MIT-licensed
-// github.com/docker/mcp-gateway/pkg/secretsscan package, which itself
-// adapted the patterns from
-// github.com/aquasecurity/trivy/pkg/fanal/secret/builtin-rules.go.
-// Every rule pairs a keyword shortlist (cheap [strings.Contains]
-// pre-filter) with a regular expression; only inputs that contain
-// one of the keywords pay the regex cost.
-//
-// The package is intentionally allocation-light and concurrency-safe
-// so it can be called on every outgoing chat message and tool input
-// without measurable overhead.
+// github.com/docker/mcp-gateway/pkg/secretsscan package, which adapted
+// it from github.com/aquasecurity/trivy/pkg/fanal/secret.
 package secretsscan

--- a/pkg/secretsscan/rules.go
+++ b/pkg/secretsscan/rules.go
@@ -1,0 +1,547 @@
+// The rules in this file are derived from the MIT-licensed
+// github.com/docker/mcp-gateway/pkg/secretsscan package, which itself
+// copied the patterns from
+// github.com/aquasecurity/trivy/pkg/fanal/secret/builtin-rules.go.
+//
+// Copyright (c) 2025 Docker (MIT). Re-licensed here under Apache-2.0
+// per the license-compatibility allowances of the MIT License.
+
+package secretsscan
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+const (
+	quote     = `["']?`
+	connect   = `\s*(:|=>|=)?\s*`
+	endSecret = `[.,]?(\s+|$)`
+	startWord = "([^0-9a-zA-Z]|^)"
+	aws       = `aws_?`
+)
+
+// rule is the source-form of a detection rule: the regular expression
+// to evaluate and the keyword shortlist used as a cheap pre-filter.
+//
+// A rule matches when the input (lower-cased) contains any of
+// keywords AND the (case-sensitive) expression matches. Keywords are
+// compared case-insensitively; the regex itself decides whether case
+// matters for the actual secret span.
+type rule struct {
+	expression string
+	keywords   []string
+}
+
+// withoutWordPrefix wraps str in a leading word-boundary so the rule
+// only fires at the start of a token (or after a non-alphanumeric
+// character). The trick of accepting "?P<secret>..." as input —
+// turning it into a named group only after wrapping — keeps the
+// per-rule expressions short and is preserved verbatim from the
+// upstream ruleset for diff hygiene.
+func withoutWordPrefix(str string) string {
+	return fmt.Sprintf("%s(%s)", startWord, str)
+}
+
+// rules returns the complete catalogue of detection rules. Wrapped in
+// [sync.OnceValue] because the slice is read-only after construction
+// and rebuilding it on every scan would be wasteful.
+//
+//nolint:funlen // deliberate single-source-of-truth for the ruleset
+var rules = sync.OnceValue(func() []rule {
+	return []rule{
+		{
+			// aws-access-key-id
+			expression: withoutWordPrefix(fmt.Sprintf(`(?P<secret>(A3T[A-Z0-9]|AKIA|AGPA|AidA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16})%s%s`, quote, endSecret)),
+			keywords:   []string{"AKIA", "AGPA", "AidA", "AROA", "AIPA", "ANPA", "ANVA", "ASIA"},
+		},
+		{
+			// aws-secret-access-key
+			expression: fmt.Sprintf(`(?i)%s%s(sec(ret)?)?_?(access)?_?key%s%s%s(?P<secret>[A-Za-z0-9\/\+=]{40})%s%s`, quote, aws, quote, connect, quote, quote, endSecret),
+			keywords:   []string{"key"},
+		},
+		{
+			// github-pat
+			expression: withoutWordPrefix(`?P<secret>ghp_[0-9a-zA-Z]{36}`),
+			keywords:   []string{"ghp_"},
+		},
+		{
+			// github-oauth
+			expression: withoutWordPrefix(`?P<secret>gho_[0-9a-zA-Z]{36}`),
+			keywords:   []string{"gho_"},
+		},
+		{
+			// github-app-token
+			expression: withoutWordPrefix(`?P<secret>(ghu|ghs)_[0-9a-zA-Z]{36}`),
+			keywords:   []string{"ghu_", "ghs_"},
+		},
+		{
+			// github-refresh-token
+			expression: withoutWordPrefix(`?P<secret>ghr_[0-9a-zA-Z]{76}`),
+			keywords:   []string{"ghr_"},
+		},
+		{
+			// github-fine-grained-pat
+			expression: `github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}`,
+			keywords:   []string{"github_pat_"},
+		},
+		{
+			// gitlab-pat
+			expression: withoutWordPrefix(`?P<secret>glpat-[0-9a-zA-Z\-\_]{20}`),
+			keywords:   []string{"glpat-"},
+		},
+		{
+			// hugging-face-access-token
+			expression: withoutWordPrefix(`?P<secret>hf_[A-Za-z0-9]{34,40}`),
+			keywords:   []string{"hf_"},
+		},
+		{
+			// private-key
+			expression: `(?i)-----\s*?BEGIN[ A-Z0-9_-]*?PRIVATE KEY( BLOCK)?\s*?-----[\s]*?(?P<secret>[A-Za-z0-9=+/\\\r\n][A-Za-z0-9=+/\\\s]+)[\s]*?-----\s*?END[ A-Z0-9_-]*? PRIVATE KEY( BLOCK)?\s*?-----`,
+			keywords:   []string{"-----"},
+		},
+		{
+			// shopify-token
+			expression: `shp(ss|at|ca|pa)_[a-fA-F0-9]{32}`,
+			keywords:   []string{"shpss_", "shpat_", "shpca_", "shppa_"},
+		},
+		{
+			// slack-access-token
+			expression: withoutWordPrefix(`?P<secret>xox[baprs]-([0-9a-zA-Z]{10,48})`),
+			keywords:   []string{"xoxb-", "xoxa-", "xoxp-", "xoxr-", "xoxs-"},
+		},
+		{
+			// stripe-publishable-token
+			expression: withoutWordPrefix(`?P<secret>(?i)pk_(test|live)_[0-9a-z]{10,32}`),
+			keywords:   []string{"pk_test_", "pk_live_"},
+		},
+		{
+			// stripe-secret-token
+			expression: withoutWordPrefix(`?P<secret>(?i)sk_(test|live)_[0-9a-z]{10,32}`),
+			keywords:   []string{"sk_test_", "sk_live_"},
+		},
+		{
+			// pypi-upload-token
+			expression: `pypi-AgEIcHlwaS5vcmc[A-Za-z0-9\-_]{50,1000}`,
+			keywords:   []string{"pypi-AgEIcHlwaS5vcmc"},
+		},
+		{
+			// gcp-service-account
+			expression: `\"type\": \"service_account\"`,
+			keywords:   []string{"\"type\": \"service_account\""},
+		},
+		{
+			// heroku-api-key
+			expression: ` (?i)(?P<key>heroku[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](?P<secret>[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})['\"]`,
+			keywords:   []string{"heroku"},
+		},
+		{
+			// slack-web-hook
+			expression: `https:\/\/hooks.slack.com\/services\/[A-Za-z0-9+\/]{44,48}`,
+			keywords:   []string{"hooks.slack.com"},
+		},
+		{
+			// twilio-api-key
+			expression: `SK[0-9a-fA-F]{32}`,
+			keywords:   []string{"SK"},
+		},
+		{
+			// age-secret-key
+			expression: `AGE-SECRET-KEY-1[QPZRY9X8GF2TVDW0S3JN54KHCE6MUA7L]{58}`,
+			keywords:   []string{"AGE-SECRET-KEY-1"},
+		},
+		{
+			// facebook-token
+			expression: `(?i)(?P<key>facebook[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](?P<secret>[a-f0-9]{32})['\"]`,
+			keywords:   []string{"facebook"},
+		},
+		{
+			// twitter-token
+			expression: `(?i)(?P<key>twitter[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](?P<secret>[a-f0-9]{35,44})['\"]`,
+			keywords:   []string{"twitter"},
+		},
+		{
+			// adobe-client-id
+			expression: `(?i)(?P<key>adobe[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](?P<secret>[a-f0-9]{32})['\"]`,
+			keywords:   []string{"adobe"},
+		},
+		{
+			// adobe-client-secret
+			expression: `(p8e-)(?i)[a-z0-9]{32}`,
+			keywords:   []string{"p8e-"},
+		},
+		{
+			// alibaba-access-key-id
+			expression: `([^0-9A-Za-z]|^)(?P<secret>(LTAI)(?i)[a-z0-9]{20})([^0-9A-Za-z]|$)`,
+			keywords:   []string{"LTAI"},
+		},
+		{
+			// alibaba-secret-key
+			expression: `(?i)(?P<key>alibaba[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](?P<secret>[a-z0-9]{30})['\"]`,
+			keywords:   []string{"alibaba"},
+		},
+		{
+			// asana-client-id
+			expression: `(?i)(?P<key>asana[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](?P<secret>[0-9]{16})['\"]`,
+			keywords:   []string{"asana"},
+		},
+		{
+			// asana-client-secret
+			expression: `(?i)(?P<key>asana[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](?P<secret>[a-z0-9]{32})['\"]`,
+			keywords:   []string{"asana"},
+		},
+		{
+			// atlassian-api-token
+			expression: `(?i)(?P<key>atlassian[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](?P<secret>[a-z0-9]{24})['\"]`,
+			keywords:   []string{"atlassian"},
+		},
+		{
+			// bitbucket-client-id
+			expression: `(?i)(?P<key>bitbucket[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](?P<secret>[a-z0-9]{32})['\"]`,
+			keywords:   []string{"bitbucket"},
+		},
+		{
+			// bitbucket-client-secret
+			expression: `(?i)(?P<key>bitbucket[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](?P<secret>[a-z0-9_\-]{64})['\"]`,
+			keywords:   []string{"bitbucket"},
+		},
+		{
+			// beamer-api-token
+			expression: `(?i)(?P<key>beamer[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](?P<secret>b_[a-z0-9=_\-]{44})['\"]`,
+			keywords:   []string{"beamer"},
+		},
+		{
+			// clojars-api-token
+			expression: `(CLOJARS_)(?i)[a-z0-9]{60}`,
+			keywords:   []string{"CLOJARS_"},
+		},
+		{
+			// contentful-delivery-api-token
+			expression: `(?i)(?P<key>contentful[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](?P<secret>[a-z0-9\-=_]{43})['\"]`,
+			keywords:   []string{"contentful"},
+		},
+		{
+			// databricks-api-token
+			expression: `dapi[a-h0-9]{32}`,
+			keywords:   []string{"dapi"},
+		},
+		{
+			// discord-api-token
+			expression: `(?i)(?P<key>discord[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](?P<secret>[a-h0-9]{64})['\"]`,
+			keywords:   []string{"discord"},
+		},
+		{
+			// discord-client-id
+			expression: `(?i)(?P<key>discord[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](?P<secret>[0-9]{18})['\"]`,
+			keywords:   []string{"discord"},
+		},
+		{
+			// discord-client-secret
+			expression: `(?i)(?P<key>discord[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](?P<secret>[a-z0-9=_\-]{32})['\"]`,
+			keywords:   []string{"discord"},
+		},
+		{
+			// doppler-api-token
+			expression: `['\"](dp\.pt\.)(?i)[a-z0-9]{43}['\"]`,
+			keywords:   []string{"dp.pt."},
+		},
+		{
+			// dropbox-api-secret
+			expression: `(?i)(dropbox[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"]([a-z0-9]{15})['\"]`,
+			keywords:   []string{"dropbox"},
+		},
+		{
+			// dropbox-short-lived-api-token
+			expression: `(?i)(dropbox[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](sl\.[a-z0-9\-=_]{135})['\"]`,
+			keywords:   []string{"dropbox"},
+		},
+		{
+			// dropbox-long-lived-api-token
+			expression: `(?i)(dropbox[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"][a-z0-9]{11}(AAAAAAAAAA)[a-z0-9\-_=]{43}['\"]`,
+			keywords:   []string{"dropbox"},
+		},
+		{
+			// duffel-api-token
+			expression: `['\"]duffel_(test|live)_(?i)[a-z0-9_-]{43}['\"]`,
+			keywords:   []string{"duffel_test_", "duffel_live_"},
+		},
+		{
+			// dynatrace-api-token
+			expression: `['\"]dt0c01\.(?i)[a-z0-9]{24}\.[a-z0-9]{64}['\"]`,
+			keywords:   []string{"dt0c01."},
+		},
+		{
+			// easypost-api-token
+			expression: `['\"]EZ[AT]K(?i)[a-z0-9]{54}['\"]`,
+			keywords:   []string{"EZAK", "EZAT"},
+		},
+		{
+			// fastly-api-token
+			expression: `(?i)(?P<key>fastly[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](?P<secret>[a-z0-9\-=_]{32})['\"]`,
+			keywords:   []string{"fastly"},
+		},
+		{
+			// finicity-client-secret
+			expression: `(?i)(?P<key>finicity[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](?P<secret>[a-z0-9]{20})['\"]`,
+			keywords:   []string{"finicity"},
+		},
+		{
+			// finicity-api-token
+			expression: `(?i)(?P<key>finicity[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](?P<secret>[a-f0-9]{32})['\"]`,
+			keywords:   []string{"finicity"},
+		},
+		{
+			// flutterwave-public-key
+			expression: withoutWordPrefix(`?P<secret>FLW(PUB|SEC)K_TEST-(?i)[a-h0-9]{32}-X`),
+			keywords:   []string{"FLWSECK_TEST-", "FLWPUBK_TEST-"},
+		},
+		{
+			// flutterwave-enc-key
+			expression: withoutWordPrefix(`?P<secret>FLWSECK_TEST[a-h0-9]{12}`),
+			keywords:   []string{"FLWSECK_TEST"},
+		},
+		{
+			// frameio-api-token
+			expression: `fio-u-(?i)[a-z0-9\-_=]{64}`,
+			keywords:   []string{"fio-u-"},
+		},
+		{
+			// gocardless-api-token
+			expression: `['\"]live_(?i)[a-z0-9\-_=]{40}['\"]`,
+			keywords:   []string{"live_"},
+		},
+		{
+			// grafana-api-token
+			expression: `['\"]?eyJrIjoi(?i)[a-z0-9\-_=]{72,92}['\"]?`,
+			keywords:   []string{"eyJrIjoi"},
+		},
+		{
+			// hashicorp-tf-api-token
+			expression: `['\"](?i)[a-z0-9]{14}\.atlasv1\.[a-z0-9\-_=]{60,70}['\"]`,
+			keywords:   []string{"atlasv1."},
+		},
+		{
+			// hubspot-api-token
+			expression: `(?i)(?P<key>hubspot[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](?P<secret>[a-h0-9]{8}-[a-h0-9]{4}-[a-h0-9]{4}-[a-h0-9]{4}-[a-h0-9]{12})['\"]`,
+			keywords:   []string{"hubspot"},
+		},
+		{
+			// intercom-api-token
+			expression: `(?i)(?P<key>intercom[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](?P<secret>[a-z0-9=_]{60})['\"]`,
+			keywords:   []string{"intercom"},
+		},
+		{
+			// intercom-client-secret
+			expression: `(?i)(?P<key>intercom[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](?P<secret>[a-h0-9]{8}-[a-h0-9]{4}-[a-h0-9]{4}-[a-h0-9]{4}-[a-h0-9]{12})['\"]`,
+			keywords:   []string{"intercom"},
+		},
+		{
+			// ionic-api-token
+			expression: `(?i)(ionic[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](ion_[a-z0-9]{42})['\"]`,
+			keywords:   []string{"ionic"},
+		},
+		{
+			// jwt-token
+			expression: `ey[a-zA-Z0-9]{17,}\.ey[a-zA-Z0-9\/\\_-]{17,}\.(?:[a-zA-Z0-9\/\\_-]{10,}={0,2})?`,
+			keywords:   []string{".eyJ"},
+		},
+		{
+			// linear-api-token
+			expression: `lin_api_(?i)[a-z0-9]{40}`,
+			keywords:   []string{"lin_api_"},
+		},
+		{
+			// linear-client-secret
+			expression: `(?i)(?P<key>linear[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](?P<secret>[a-f0-9]{32})['\"]`,
+			keywords:   []string{"linear"},
+		},
+		{
+			// lob-api-key
+			expression: `(?i)(?P<key>lob[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](?P<secret>(live|test)_[a-f0-9]{35})['\"]`,
+			keywords:   []string{"lob"},
+		},
+		{
+			// lob-pub-api-key
+			expression: `(?i)(?P<key>lob[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](?P<secret>(test|live)_pub_[a-f0-9]{31})['\"]`,
+			keywords:   []string{"lob"},
+		},
+		{
+			// mailchimp-api-key
+			expression: `(?i)(?P<key>mailchimp[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](?P<secret>[a-f0-9]{32}-us20)['\"]`,
+			keywords:   []string{"mailchimp"},
+		},
+		{
+			// mailgun-token
+			expression: `(?i)(?P<key>mailgun[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](?P<secret>(pub)?key-[a-f0-9]{32})['\"]`,
+			keywords:   []string{"mailgun"},
+		},
+		{
+			// mailgun-signing-key
+			expression: `(?i)(?P<key>mailgun[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](?P<secret>[a-h0-9]{32}-[a-h0-9]{8}-[a-h0-9]{8})['\"]`,
+			keywords:   []string{"mailgun"},
+		},
+		{
+			// mapbox-api-token
+			expression: `(?i)(pk\.[a-z0-9]{60}\.[a-z0-9]{22})`,
+			keywords:   []string{"pk."},
+		},
+		{
+			// messagebird-api-token
+			expression: `(?i)(?P<key>messagebird[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](?P<secret>[a-z0-9]{25})['\"]`,
+			keywords:   []string{"messagebird"},
+		},
+		{
+			// messagebird-client-id
+			expression: `(?i)(?P<key>messagebird[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](?P<secret>[a-h0-9]{8}-[a-h0-9]{4}-[a-h0-9]{4}-[a-h0-9]{4}-[a-h0-9]{12})['\"]`,
+			keywords:   []string{"messagebird"},
+		},
+		{
+			// new-relic-user-api-key
+			expression: `['\"](NRAK-[A-Z0-9]{27})['\"]`,
+			keywords:   []string{"NRAK-"},
+		},
+		{
+			// new-relic-user-api-id
+			expression: `(?i)(?P<key>newrelic[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](?P<secret>[A-Z0-9]{64})['\"]`,
+			keywords:   []string{"newrelic"},
+		},
+		{
+			// new-relic-browser-api-token
+			expression: `['\"](NRJS-[a-f0-9]{19})['\"]`,
+			keywords:   []string{"NRJS-"},
+		},
+		{
+			// npm-access-token
+			expression: `['\"](npm_(?i)[a-z0-9]{36})['\"]`,
+			keywords:   []string{"npm_"},
+		},
+		{
+			// planetscale-password
+			expression: `pscale_pw_(?i)[a-z0-9\-_\.]{43}`,
+			keywords:   []string{"pscale_pw_"},
+		},
+		{
+			// planetscale-api-token
+			expression: `pscale_tkn_(?i)[a-z0-9\-_\.]{43}`,
+			keywords:   []string{"pscale_tkn_"},
+		},
+		{
+			// private-packagist-token
+			expression: `packagist_[ou][ru]t_(?i)[a-f0-9]{68}`,
+			keywords:   []string{"packagist_uut_", "packagist_ort_", "packagist_out_"},
+		},
+		{
+			// postman-api-token
+			expression: `PMAK-(?i)[a-f0-9]{24}\-[a-f0-9]{34}`,
+			keywords:   []string{"PMAK-"},
+		},
+		{
+			// pulumi-api-token
+			expression: `pul-[a-f0-9]{40}`,
+			keywords:   []string{"pul-"},
+		},
+		{
+			// rubygems-api-token
+			expression: `rubygems_[a-f0-9]{48}`,
+			keywords:   []string{"rubygems_"},
+		},
+		{
+			// sendgrid-api-token
+			expression: `SG\.(?i)[a-z0-9_\-\.]{66}`,
+			keywords:   []string{"SG."},
+		},
+		{
+			// sendinblue-api-token
+			expression: `xkeysib-[a-f0-9]{64}\-(?i)[a-z0-9]{16}`,
+			keywords:   []string{"xkeysib-"},
+		},
+		{
+			// shippo-api-token
+			expression: `shippo_(live|test)_[a-f0-9]{40}`,
+			keywords:   []string{"shippo_live_", "shippo_test_"},
+		},
+		{
+			// linkedin-client-secret
+			expression: `(?i)(?P<key>linkedin[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](?P<secret>[a-z]{16})['\"]`,
+			keywords:   []string{"linkedin"},
+		},
+		{
+			// linkedin-client-id
+			expression: `(?i)(?P<key>linkedin[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](?P<secret>[a-z0-9]{14})['\"]`,
+			keywords:   []string{"linkedin"},
+		},
+		{
+			// twitch-api-token
+			expression: `(?i)(?P<key>twitch[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}['\"](?P<secret>[a-z0-9]{30})['\"]`,
+			keywords:   []string{"twitch"},
+		},
+		{
+			// typeform-api-token
+			expression: `(?i)(?P<key>typeform[a-z0-9_ .\-,]{0,25})(=|>|:=|\|\|:|<=|=>|:).{0,5}(?P<secret>tfp_[a-z0-9\-_\.=]{59})`,
+			keywords:   []string{"typeform"},
+		},
+		{
+			// dockerconfig-secret
+			expression: `(?i)(\.(dockerconfigjson|dockercfg):\s*\|*\s*(?P<secret>(ey|ew)+[A-Za-z0-9\/\+=]+))`,
+			keywords:   []string{"dockerc"},
+		},
+		{
+			// docker pat
+			expression: `(?i)(dckr_pat_[-0-9a-zA-Z]{27})`,
+			keywords:   []string{"dckr_pat"},
+		},
+	}
+})
+
+// compiledRule is the resolved form of [rule]: the source regex
+// pre-compiled into a [regexp.Regexp] and the index (or -1) of the
+// "secret" named subgroup. Pre-compiling is critical for the
+// per-message hot path — a fresh [regexp.MustCompile] on every scan
+// dominates the work of [Redact] for long inputs and turns the rule
+// catalogue into an O(rules×len) regex compile every call.
+type compiledRule struct {
+	re        *regexp.Regexp
+	keywords  []string // already lower-cased
+	secretIdx int      // -1 when the rule has no (?P<secret>…) subgroup
+}
+
+// compiledRules returns the resolved ruleset, computed exactly once
+// at first use. Co-located with [rules] so the two-step "source
+// rules → compiled rules" relationship is obvious; the source slice
+// is preserved verbatim for diff parity with the upstream catalogue.
+var compiledRules = sync.OnceValue(func() []compiledRule {
+	src := rules()
+	out := make([]compiledRule, 0, len(src))
+	for _, r := range src {
+		re := regexp.MustCompile(r.expression)
+		idx := -1
+		for i, name := range re.SubexpNames() {
+			if name == "secret" {
+				idx = i
+				break
+			}
+		}
+		kws := make([]string, len(r.keywords))
+		for i, k := range r.keywords {
+			kws[i] = strings.ToLower(k)
+		}
+		out = append(out, compiledRule{re: re, keywords: kws, secretIdx: idx})
+	}
+	return out
+})
+
+// hasKeyword reports whether lower (already lower-cased by the
+// caller) contains any of the rule's keywords. Cheaper than running
+// the regex first; every detection rule encodes a discriminating
+// keyword, so this filter typically eliminates >99% of inputs from
+// the regex hot path.
+func (c *compiledRule) hasKeyword(lower string) bool {
+	for _, kw := range c.keywords {
+		if strings.Contains(lower, kw) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/secretsscan/rules.go
+++ b/pkg/secretsscan/rules.go
@@ -23,13 +23,10 @@ const (
 	aws       = `aws_?`
 )
 
-// rule is the source-form of a detection rule: the regular expression
-// to evaluate and the keyword shortlist used as a cheap pre-filter.
-//
-// A rule matches when the input (lower-cased) contains any of
-// keywords AND the (case-sensitive) expression matches. Keywords are
-// compared case-insensitively; the regex itself decides whether case
-// matters for the actual secret span.
+// rule pairs a regular expression with a keyword shortlist. A rule
+// matches when the (lower-cased) input contains any of the keywords
+// AND the (case-sensitive) expression matches; the keyword filter is
+// what keeps detection fast for typical inputs.
 type rule struct {
 	expression string
 	keywords   []string
@@ -37,19 +34,19 @@ type rule struct {
 
 // withoutWordPrefix wraps str in a leading word-boundary so the rule
 // only fires at the start of a token (or after a non-alphanumeric
-// character). The trick of accepting "?P<secret>..." as input —
-// turning it into a named group only after wrapping — keeps the
-// per-rule expressions short and is preserved verbatim from the
-// upstream ruleset for diff hygiene.
+// character). Accepting "?P<secret>..." as input — turning it into a
+// named group only after wrapping — keeps the per-rule expressions
+// short and is preserved verbatim from the upstream ruleset for diff
+// hygiene.
 func withoutWordPrefix(str string) string {
 	return fmt.Sprintf("%s(%s)", startWord, str)
 }
 
-// rules returns the complete catalogue of detection rules. Wrapped in
-// [sync.OnceValue] because the slice is read-only after construction
-// and rebuilding it on every scan would be wasteful.
+// rules is the source-form catalogue, kept verbatim from upstream so
+// future updates apply cleanly. [compiledRules] resolves it into the
+// regex-compiled form actually used at scan time.
 //
-//nolint:funlen // deliberate single-source-of-truth for the ruleset
+//nolint:funlen // single-source-of-truth for the ruleset
 var rules = sync.OnceValue(func() []rule {
 	return []rule{
 		{
@@ -495,53 +492,31 @@ var rules = sync.OnceValue(func() []rule {
 	}
 })
 
-// compiledRule is the resolved form of [rule]: the source regex
-// pre-compiled into a [regexp.Regexp] and the index (or -1) of the
-// "secret" named subgroup. Pre-compiling is critical for the
-// per-message hot path — a fresh [regexp.MustCompile] on every scan
-// dominates the work of [Redact] for long inputs and turns the rule
-// catalogue into an O(rules×len) regex compile every call.
+// compiledRule is [rule] with its regex pre-compiled and the index
+// of the "secret" named subgroup resolved. Pre-compilation is what
+// makes [Redact] cheap on the hot path — without it every scan would
+// rebuild the entire ruleset's worth of regular expressions.
 type compiledRule struct {
 	re        *regexp.Regexp
-	keywords  []string // already lower-cased
+	keywords  []string // lower-cased
 	secretIdx int      // -1 when the rule has no (?P<secret>…) subgroup
 }
 
-// compiledRules returns the resolved ruleset, computed exactly once
-// at first use. Co-located with [rules] so the two-step "source
-// rules → compiled rules" relationship is obvious; the source slice
-// is preserved verbatim for diff parity with the upstream catalogue.
+// compiledRules resolves the source ruleset exactly once.
 var compiledRules = sync.OnceValue(func() []compiledRule {
 	src := rules()
-	out := make([]compiledRule, 0, len(src))
-	for _, r := range src {
+	out := make([]compiledRule, len(src))
+	for i, r := range src {
 		re := regexp.MustCompile(r.expression)
-		idx := -1
-		for i, name := range re.SubexpNames() {
-			if name == "secret" {
-				idx = i
-				break
-			}
-		}
 		kws := make([]string, len(r.keywords))
-		for i, k := range r.keywords {
-			kws[i] = strings.ToLower(k)
+		for j, k := range r.keywords {
+			kws[j] = strings.ToLower(k)
 		}
-		out = append(out, compiledRule{re: re, keywords: kws, secretIdx: idx})
+		out[i] = compiledRule{
+			re:        re,
+			keywords:  kws,
+			secretIdx: re.SubexpIndex("secret"),
+		}
 	}
 	return out
 })
-
-// hasKeyword reports whether lower (already lower-cased by the
-// caller) contains any of the rule's keywords. Cheaper than running
-// the regex first; every detection rule encodes a discriminating
-// keyword, so this filter typically eliminates >99% of inputs from
-// the regex hot path.
-func (c *compiledRule) hasKeyword(lower string) bool {
-	for _, kw := range c.keywords {
-		if strings.Contains(lower, kw) {
-			return true
-		}
-	}
-	return false
-}

--- a/pkg/secretsscan/secrets.go
+++ b/pkg/secretsscan/secrets.go
@@ -1,0 +1,104 @@
+package secretsscan
+
+import (
+	"strings"
+)
+
+// RedactionMarker is the literal string that replaces every detected
+// secret span. Exported so callers (tests, runtime hooks that want to
+// double-check the result) can refer to it without hard-coding the
+// literal.
+const RedactionMarker = "[REDACTED]"
+
+// ContainsSecrets reports whether text matches any detection rule.
+// The keyword shortlist filter keeps the cost proportional to the
+// number of rules whose keyword actually appears in text — for
+// typical chat content that's zero.
+func ContainsSecrets(text string) bool {
+	if text == "" {
+		return false
+	}
+	lower := strings.ToLower(text)
+	for i := range compiledRules() {
+		r := &compiledRules()[i]
+		if !r.hasKeyword(lower) {
+			continue
+		}
+		if r.re.MatchString(text) {
+			return true
+		}
+	}
+	return false
+}
+
+// Redact returns a copy of text with every detected secret span
+// replaced by [RedactionMarker]. When a rule defines a (?P<secret>…)
+// named subgroup, only the secret span is replaced (the surrounding
+// keyword/connector context is preserved so the caller still sees
+// "AWS_SECRET_ACCESS_KEY=[REDACTED]"); otherwise the entire match is
+// replaced.
+//
+// Idempotent: [RedactionMarker] does not match any rule, so calling
+// Redact twice yields the same result. Safe for concurrent use.
+func Redact(text string) string {
+	if text == "" {
+		return text
+	}
+	out := text
+	// Iterate via index to avoid copying compiledRule (it carries a
+	// *regexp.Regexp that is safe to share but still cheaper to point at).
+	for i := range compiledRules() {
+		r := &compiledRules()[i]
+		if !r.hasKeyword(strings.ToLower(out)) {
+			continue
+		}
+		out = redactWithRule(r, out)
+	}
+	return out
+}
+
+// redactWithRule applies a single compiled rule to text, replacing
+// either the "secret" subgroup span (when defined) or the entire
+// match. Split out so the rule-iteration logic in [Redact] reads as
+// a straight loop.
+//
+// We can't use [regexp.Regexp.ReplaceAllStringFunc] directly because
+// it gives the function the matched substring (string), not the
+// match indices — and we need indices to slice out the "secret"
+// subgroup while keeping the rest of the match intact. Walking
+// FindAllStringSubmatchIndex and rebuilding the string by hand is
+// the standard pattern.
+func redactWithRule(r *compiledRule, text string) string {
+	idxs := r.re.FindAllStringSubmatchIndex(text, -1)
+	if len(idxs) == 0 {
+		return text
+	}
+
+	var b strings.Builder
+	b.Grow(len(text))
+	cursor := 0
+	for _, m := range idxs {
+		matchStart, matchEnd := m[0], m[1]
+		var redactStart, redactEnd int
+		if r.secretIdx >= 0 && 2*r.secretIdx+1 < len(m) && m[2*r.secretIdx] >= 0 {
+			redactStart, redactEnd = m[2*r.secretIdx], m[2*r.secretIdx+1]
+		} else {
+			redactStart, redactEnd = matchStart, matchEnd
+		}
+
+		// Defensive: a malformed subgroup span (start>end) should
+		// fall back to redacting the full match rather than producing
+		// a corrupt output. Hard to construct in practice — the regex
+		// engine guarantees ordered indices for successful submatches —
+		// but the cost of guarding is nil.
+		if redactStart < cursor || redactEnd < redactStart {
+			redactStart, redactEnd = matchStart, matchEnd
+		}
+
+		b.WriteString(text[cursor:redactStart])
+		b.WriteString(RedactionMarker)
+		cursor = redactEnd
+	}
+	b.WriteString(text[cursor:])
+	return b.String()
+}

--- a/pkg/secretsscan/secrets.go
+++ b/pkg/secretsscan/secrets.go
@@ -4,7 +4,10 @@ import (
 	"strings"
 )
 
-// RedactionMarker replaces every detected secret span.
+// RedactionMarker replaces every detected secret span. Chosen so it
+// doesn't match any rule's keyword pre-filter — see
+// TestRedactionMarkerIsNotASecret for the safety property that makes
+// [Redact] idempotent.
 const RedactionMarker = "[REDACTED]"
 
 // ContainsSecrets reports whether text matches any detection rule.
@@ -33,9 +36,17 @@ func Redact(text string) string {
 	if text == "" {
 		return text
 	}
+	// Lower-case once outside the rule loop. The redaction can only
+	// REMOVE keywords from the input (RedactionMarker contains none —
+	// see TestRedactionMarkerIsNotASecret), so the keyword pre-filter
+	// stays correct against the original lower-cased text even after
+	// earlier rules have rewritten part of out: a false-positive on
+	// the filter just means we run a regex that won't match.
+	rules := compiledRules()
+	lower := strings.ToLower(text)
 	out := text
-	for _, r := range compiledRules() {
-		if !hasAnyKeyword(strings.ToLower(out), r.keywords) {
+	for _, r := range rules {
+		if !hasAnyKeyword(lower, r.keywords) {
 			continue
 		}
 		out = redactWithRule(r, out)

--- a/pkg/secretsscan/secrets.go
+++ b/pkg/secretsscan/secrets.go
@@ -4,27 +4,17 @@ import (
 	"strings"
 )
 
-// RedactionMarker is the literal string that replaces every detected
-// secret span. Exported so callers (tests, runtime hooks that want to
-// double-check the result) can refer to it without hard-coding the
-// literal.
+// RedactionMarker replaces every detected secret span.
 const RedactionMarker = "[REDACTED]"
 
 // ContainsSecrets reports whether text matches any detection rule.
-// The keyword shortlist filter keeps the cost proportional to the
-// number of rules whose keyword actually appears in text — for
-// typical chat content that's zero.
 func ContainsSecrets(text string) bool {
 	if text == "" {
 		return false
 	}
 	lower := strings.ToLower(text)
-	for i := range compiledRules() {
-		r := &compiledRules()[i]
-		if !r.hasKeyword(lower) {
-			continue
-		}
-		if r.re.MatchString(text) {
+	for _, r := range compiledRules() {
+		if hasAnyKeyword(lower, r.keywords) && r.re.MatchString(text) {
 			return true
 		}
 	}
@@ -33,23 +23,19 @@ func ContainsSecrets(text string) bool {
 
 // Redact returns a copy of text with every detected secret span
 // replaced by [RedactionMarker]. When a rule defines a (?P<secret>…)
-// named subgroup, only the secret span is replaced (the surrounding
-// keyword/connector context is preserved so the caller still sees
-// "AWS_SECRET_ACCESS_KEY=[REDACTED]"); otherwise the entire match is
+// named subgroup, only that span is replaced (so callers still see
+// "AWS_SECRET_ACCESS_KEY=[REDACTED]"); otherwise the whole match is
 // replaced.
 //
 // Idempotent: [RedactionMarker] does not match any rule, so calling
-// Redact twice yields the same result. Safe for concurrent use.
+// Redact twice yields the same result.
 func Redact(text string) string {
 	if text == "" {
 		return text
 	}
 	out := text
-	// Iterate via index to avoid copying compiledRule (it carries a
-	// *regexp.Regexp that is safe to share but still cheaper to point at).
-	for i := range compiledRules() {
-		r := &compiledRules()[i]
-		if !r.hasKeyword(strings.ToLower(out)) {
+	for _, r := range compiledRules() {
+		if !hasAnyKeyword(strings.ToLower(out), r.keywords) {
 			continue
 		}
 		out = redactWithRule(r, out)
@@ -57,47 +43,40 @@ func Redact(text string) string {
 	return out
 }
 
-// redactWithRule applies a single compiled rule to text, replacing
-// either the "secret" subgroup span (when defined) or the entire
-// match. Split out so the rule-iteration logic in [Redact] reads as
-// a straight loop.
-//
-// We can't use [regexp.Regexp.ReplaceAllStringFunc] directly because
-// it gives the function the matched substring (string), not the
-// match indices — and we need indices to slice out the "secret"
-// subgroup while keeping the rest of the match intact. Walking
-// FindAllStringSubmatchIndex and rebuilding the string by hand is
-// the standard pattern.
-func redactWithRule(r *compiledRule, text string) string {
-	idxs := r.re.FindAllStringSubmatchIndex(text, -1)
-	if len(idxs) == 0 {
+// hasAnyKeyword is the cheap pre-filter that lets us skip the regex
+// hot path on inputs that don't even mention a rule's discriminating
+// keyword. lower must already be lower-cased; rule keywords are
+// stored lower-cased at compile time.
+func hasAnyKeyword(lower string, keywords []string) bool {
+	for _, kw := range keywords {
+		if strings.Contains(lower, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// redactWithRule applies a single compiled rule to text. We can't use
+// [regexp.Regexp.ReplaceAllStringFunc] directly because we need the
+// match indices to slice out the "secret" subgroup while keeping the
+// rest of the match intact.
+func redactWithRule(r compiledRule, text string) string {
+	matches := r.re.FindAllStringSubmatchIndex(text, -1)
+	if len(matches) == 0 {
 		return text
 	}
 
 	var b strings.Builder
 	b.Grow(len(text))
 	cursor := 0
-	for _, m := range idxs {
-		matchStart, matchEnd := m[0], m[1]
-		var redactStart, redactEnd int
-		if r.secretIdx >= 0 && 2*r.secretIdx+1 < len(m) && m[2*r.secretIdx] >= 0 {
-			redactStart, redactEnd = m[2*r.secretIdx], m[2*r.secretIdx+1]
-		} else {
-			redactStart, redactEnd = matchStart, matchEnd
+	for _, m := range matches {
+		start, end := m[0], m[1]
+		if r.secretIdx >= 0 && m[2*r.secretIdx] >= 0 {
+			start, end = m[2*r.secretIdx], m[2*r.secretIdx+1]
 		}
-
-		// Defensive: a malformed subgroup span (start>end) should
-		// fall back to redacting the full match rather than producing
-		// a corrupt output. Hard to construct in practice — the regex
-		// engine guarantees ordered indices for successful submatches —
-		// but the cost of guarding is nil.
-		if redactStart < cursor || redactEnd < redactStart {
-			redactStart, redactEnd = matchStart, matchEnd
-		}
-
-		b.WriteString(text[cursor:redactStart])
+		b.WriteString(text[cursor:start])
 		b.WriteString(RedactionMarker)
-		cursor = redactEnd
+		cursor = end
 	}
 	b.WriteString(text[cursor:])
 	return b.String()

--- a/pkg/secretsscan/secrets_bench_test.go
+++ b/pkg/secretsscan/secrets_bench_test.go
@@ -1,0 +1,34 @@
+package secretsscan_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/docker/docker-agent/pkg/secretsscan"
+)
+
+// BenchmarkRedactCleanInput is the headline scenario: most messages
+// contain no secrets, so the keyword pre-filter must skip every rule's
+// regex. Optimisations to the per-rule loop (e.g. lower-casing once
+// outside the loop) show up here as a multi-x speedup; a regression
+// that re-introduces per-rule allocation is the kind of thing this
+// benchmark catches.
+func BenchmarkRedactCleanInput(b *testing.B) {
+	text := strings.Repeat("the quick brown fox jumps over the lazy dog. ", 200)
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = secretsscan.Redact(text)
+	}
+}
+
+// BenchmarkRedactWithSecret exercises the full path: lower-case +
+// keyword hit + regex match + cursor-rebuild redaction.
+func BenchmarkRedactWithSecret(b *testing.B) {
+	text := strings.Repeat("noise ", 100) +
+		"ghp_cxLeRrvbJfmYdUtr70xnNE3Q7Gvli43s19PD" +
+		strings.Repeat(" trailing", 100)
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = secretsscan.Redact(text)
+	}
+}

--- a/pkg/secretsscan/secrets_test.go
+++ b/pkg/secretsscan/secrets_test.go
@@ -122,3 +122,27 @@ func TestRedactHandlesMultipleSecretsInOneInput(t *testing.T) {
 	assert.Contains(t, out, " and second ")
 	assert.Contains(t, out, " end")
 }
+
+// TestRedactionMarkerIsNotASecret locks in the safety property that
+// makes [secretsscan.Redact] idempotent and the keyword pre-filter
+// hoist in [secretsscan.Redact] sound: the literal RedactionMarker
+// must not match any detection rule. If a future rule were added
+// whose keyword overlapped "[redacted]", redaction would either
+// recurse forever or amplify the marker on every pass, and any
+// downstream pipeline that calls Redact twice (the pre_tool_use
+// builtin + the before_llm_call transform on the same string) would
+// silently corrupt content.
+func TestRedactionMarkerIsNotASecret(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, secretsscan.ContainsSecrets(secretsscan.RedactionMarker),
+		"the redaction marker must not match any rule")
+	assert.Equal(t, secretsscan.RedactionMarker,
+		secretsscan.Redact(secretsscan.RedactionMarker),
+		"redacting the marker must be a no-op")
+
+	// Embedded in arbitrary surrounding text the marker still must not
+	// match — some rules only fire mid-string after a non-word boundary.
+	assert.Equal(t, "prefix "+secretsscan.RedactionMarker+" suffix",
+		secretsscan.Redact("prefix "+secretsscan.RedactionMarker+" suffix"))
+}

--- a/pkg/secretsscan/secrets_test.go
+++ b/pkg/secretsscan/secrets_test.go
@@ -1,0 +1,137 @@
+package secretsscan_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/secretsscan"
+)
+
+// TestContainsSecretsRecognisesKnownTokens locks in the parity
+// guarantee with the upstream
+// github.com/docker/mcp-gateway/pkg/secretsscan tests: the well-known
+// GitHub PAT and Docker Hub PAT shapes that the upstream package
+// detects must keep being detected here. Failing this test means we
+// either dropped a rule or broke the keyword pre-filter.
+func TestContainsSecretsRecognisesKnownTokens(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		text string
+	}{
+		{"github_pat", "ghp_cxLeRrvbJfmYdUtr70xnNE3Q7Gvli43s19PD"},
+		{"docker_pat", "dckr_pat_" + "AAAAAAAAAAAAAAAAAAAAAAAAAAA"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Truef(t, secretsscan.ContainsSecrets(tc.text), "must detect %s", tc.name)
+		})
+	}
+}
+
+// TestContainsSecretsIgnoresHarmlessText documents the false-positive
+// floor: pure digit strings, plain English, and the empty string must
+// never trip detection. Two-step keyword + regex filtering makes this
+// cheap; the assertion exists so a future "be more aggressive" change
+// can't quietly start flagging invoice numbers.
+func TestContainsSecretsIgnoresHarmlessText(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{
+		"",
+		"1234567890",
+		"hello world",
+		"please summarise the README",
+		// "key" is a keyword for aws-secret-access-key but the regex
+		// requires a 40-char base64-ish span next to "aws_*key=" so a
+		// bare mention must not trip.
+		"the api key is documented in README",
+	}
+	for _, in := range cases {
+		assert.Falsef(t, secretsscan.ContainsSecrets(in), "must not flag %q", in)
+	}
+}
+
+// TestRedactReplacesSecretSpan pins the headline behavior of the
+// redactor: the secret material is replaced by [secretsscan.RedactionMarker]
+// while the surrounding text (including the keyword that triggered
+// the match) is preserved. We don't assert the exact match boundary
+// because the rule's leading-context group ([^0-9a-zA-Z]|^) may
+// consume the preceding space — only the secret value must
+// disappear.
+func TestRedactReplacesSecretSpan(t *testing.T) {
+	t.Parallel()
+
+	const ghp = "ghp_cxLeRrvbJfmYdUtr70xnNE3Q7Gvli43s19PD"
+	in := "Run this with token=" + ghp + " and you're set"
+
+	out := secretsscan.Redact(in)
+
+	assert.Containsf(t, out, secretsscan.RedactionMarker, "redaction marker must appear: %q", out)
+	assert.NotContainsf(t, out, ghp, "raw secret must be gone: %q", out)
+	assert.Contains(t, out, "Run this with token=", "non-secret prefix preserved")
+	assert.Contains(t, out, "and you're set", "non-secret suffix preserved")
+}
+
+// TestRedactIsIdempotent locks in the safety property the runtime
+// transforms rely on: passing already-redacted text through Redact
+// again leaves it untouched. Without this we'd risk amplification
+// (e.g. the marker overlapping a future, broader rule) when both the
+// pre_tool_use builtin and the before_llm_call transform fire on the
+// same content.
+func TestRedactIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	once := secretsscan.Redact("dckr_pat_" + "AAAAAAAAAAAAAAAAAAAAAAAAAAA in logs")
+	twice := secretsscan.Redact(once)
+
+	assert.Equal(t, once, twice)
+	assert.False(t, secretsscan.ContainsSecrets(once),
+		"redacted output must no longer trip ContainsSecrets")
+}
+
+// TestRedactPreservesNonMatchingText is the negative-symmetry of
+// [TestContainsSecretsIgnoresHarmlessText]: text without secrets must
+// pass through untouched. Equality (not "Contains marker") catches a
+// regression where a too-broad rule inserts a marker into innocent
+// content.
+func TestRedactPreservesNonMatchingText(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{
+		"",
+		"1234567890",
+		"please refactor the helper into its own file",
+	}
+	for _, in := range cases {
+		assert.Equalf(t, in, secretsscan.Redact(in), "must not modify %q", in)
+	}
+}
+
+// TestRedactHandlesMultipleSecretsInOneInput verifies the
+// FindAllStringSubmatchIndex loop: two distinct secrets in the same
+// string must both be replaced, and nothing in between should leak
+// out. This is the regression test for the rebuild-by-cursor logic
+// in redactWithRule.
+func TestRedactHandlesMultipleSecretsInOneInput(t *testing.T) {
+	t.Parallel()
+
+	const a = "ghp_cxLeRrvbJfmYdUtr70xnNE3Q7Gvli43s19PD"
+	const b = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+	in := "first " + a + " and second " + b + " end"
+
+	out := secretsscan.Redact(in)
+
+	require.NotContains(t, out, a)
+	require.NotContains(t, out, b)
+	assert.Equal(t, 2, strings.Count(out, secretsscan.RedactionMarker),
+		"both secrets must be redacted: %q", out)
+	assert.Contains(t, out, "first ")
+	assert.Contains(t, out, " and second ")
+	assert.Contains(t, out, " end")
+}

--- a/pkg/secretsscan/secrets_test.go
+++ b/pkg/secretsscan/secrets_test.go
@@ -10,12 +10,9 @@ import (
 	"github.com/docker/docker-agent/pkg/secretsscan"
 )
 
-// TestContainsSecretsRecognisesKnownTokens locks in the parity
-// guarantee with the upstream
-// github.com/docker/mcp-gateway/pkg/secretsscan tests: the well-known
-// GitHub PAT and Docker Hub PAT shapes that the upstream package
-// detects must keep being detected here. Failing this test means we
-// either dropped a rule or broke the keyword pre-filter.
+// TestContainsSecretsRecognisesKnownTokens: parity guarantee with the
+// upstream docker/mcp-gateway/pkg/secretsscan tests. Failing this test
+// means we either dropped a rule or broke the keyword pre-filter.
 func TestContainsSecretsRecognisesKnownTokens(t *testing.T) {
 	t.Parallel()
 
@@ -34,11 +31,8 @@ func TestContainsSecretsRecognisesKnownTokens(t *testing.T) {
 	}
 }
 
-// TestContainsSecretsIgnoresHarmlessText documents the false-positive
-// floor: pure digit strings, plain English, and the empty string must
-// never trip detection. Two-step keyword + regex filtering makes this
-// cheap; the assertion exists so a future "be more aggressive" change
-// can't quietly start flagging invoice numbers.
+// TestContainsSecretsIgnoresHarmlessText: pure digit strings, plain
+// English, and the empty string must never trip detection.
 func TestContainsSecretsIgnoresHarmlessText(t *testing.T) {
 	t.Parallel()
 
@@ -47,9 +41,9 @@ func TestContainsSecretsIgnoresHarmlessText(t *testing.T) {
 		"1234567890",
 		"hello world",
 		"please summarise the README",
-		// "key" is a keyword for aws-secret-access-key but the regex
+		// "key" is a keyword for aws-secret-access-key, but the regex
 		// requires a 40-char base64-ish span next to "aws_*key=" so a
-		// bare mention must not trip.
+		// bare mention must not trip detection.
 		"the api key is documented in README",
 	}
 	for _, in := range cases {
@@ -57,12 +51,11 @@ func TestContainsSecretsIgnoresHarmlessText(t *testing.T) {
 	}
 }
 
-// TestRedactReplacesSecretSpan pins the headline behavior of the
-// redactor: the secret material is replaced by [secretsscan.RedactionMarker]
-// while the surrounding text (including the keyword that triggered
-// the match) is preserved. We don't assert the exact match boundary
-// because the rule's leading-context group ([^0-9a-zA-Z]|^) may
-// consume the preceding space — only the secret value must
+// TestRedactReplacesSecretSpan: the secret material is replaced by
+// [secretsscan.RedactionMarker] while the surrounding text (including
+// the keyword that triggered the match) is preserved. We don't assert
+// the exact match boundary because the rule's leading-context group
+// may consume the preceding space — only the secret value must
 // disappear.
 func TestRedactReplacesSecretSpan(t *testing.T) {
 	t.Parallel()
@@ -78,12 +71,10 @@ func TestRedactReplacesSecretSpan(t *testing.T) {
 	assert.Contains(t, out, "and you're set", "non-secret suffix preserved")
 }
 
-// TestRedactIsIdempotent locks in the safety property the runtime
-// transforms rely on: passing already-redacted text through Redact
-// again leaves it untouched. Without this we'd risk amplification
-// (e.g. the marker overlapping a future, broader rule) when both the
-// pre_tool_use builtin and the before_llm_call transform fire on the
-// same content.
+// TestRedactIsIdempotent: passing already-redacted text through
+// Redact again leaves it untouched. Without this we'd risk
+// amplification when both the pre_tool_use builtin and the
+// before_llm_call transform fire on the same content.
 func TestRedactIsIdempotent(t *testing.T) {
 	t.Parallel()
 
@@ -95,11 +86,9 @@ func TestRedactIsIdempotent(t *testing.T) {
 		"redacted output must no longer trip ContainsSecrets")
 }
 
-// TestRedactPreservesNonMatchingText is the negative-symmetry of
-// [TestContainsSecretsIgnoresHarmlessText]: text without secrets must
-// pass through untouched. Equality (not "Contains marker") catches a
-// regression where a too-broad rule inserts a marker into innocent
-// content.
+// TestRedactPreservesNonMatchingText: text without secrets must pass
+// through untouched (catches a regression where a too-broad rule
+// inserts a marker into innocent content).
 func TestRedactPreservesNonMatchingText(t *testing.T) {
 	t.Parallel()
 
@@ -113,11 +102,9 @@ func TestRedactPreservesNonMatchingText(t *testing.T) {
 	}
 }
 
-// TestRedactHandlesMultipleSecretsInOneInput verifies the
-// FindAllStringSubmatchIndex loop: two distinct secrets in the same
-// string must both be replaced, and nothing in between should leak
-// out. This is the regression test for the rebuild-by-cursor logic
-// in redactWithRule.
+// TestRedactHandlesMultipleSecretsInOneInput: two distinct secrets in
+// the same string must both be replaced, and nothing in between
+// should leak out (regression test for the cursor-rebuild loop).
 func TestRedactHandlesMultipleSecretsInOneInput(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -160,6 +160,7 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 			agent.WithAddDate(agentConfig.AddDate),
 			agent.WithAddEnvironmentInfo(agentConfig.AddEnvironmentInfo),
 			agent.WithAddDescriptionParameter(agentConfig.AddDescriptionParameter),
+			agent.WithRedactSecrets(agentConfig.RedactSecrets),
 			agent.WithAddPromptFiles(promptFiles),
 			agent.WithMaxIterations(agentConfig.MaxIterations),
 			agent.WithMaxConsecutiveToolCalls(agentConfig.MaxConsecutiveToolCalls),


### PR DESCRIPTION
Adds a single agent-level switch — `redact_secrets: true` — that brackets every place where credential material can leak from a docker-agent run to a third party. It scrubs known secret patterns (GitHub PATs, AWS keys, Stripe / Slack / GitLab tokens, JWTs, private keys, Docker Hub PATs, …) at two enforcement points:

1. **Before the LLM call** — a runtime-shipped `MessageTransform` walks every text-bearing field of the outgoing chat history (`Content`, `ReasoningContent`, `MultiContent` text parts, the legacy singular `FunctionCall.Arguments`, and each `ToolCalls[i].Function.Arguments`) and replaces detected secrets with `[REDACTED]`.
2. **Before a tool call** — a `pre_tool_use` builtin hook (`redact_secrets`) walks `ToolInput` recursively (into nested maps and slices) and emits an `UpdatedInput` with only the keys whose value actually changed.

Detection mirrors the MIT-licensed [`docker/mcp-gateway/pkg/secretsscan`](https://github.com/docker/mcp-gateway/tree/main/pkg/secretsscan) ruleset (re-licensed under Apache-2.0 in attribution) and is kept fast by a keyword pre-filter in front of every regex.

## Files

- `pkg/secretsscan/` — new package: ruleset, `ContainsSecrets`, `Redact`, tests, benchmarks.
- `pkg/hooks/builtins/redact_secrets.go` — the `pre_tool_use` builtin and its registration.
- `pkg/runtime/redact_secrets.go` — the `before_llm_call` `MessageTransform` (gated on `Agent.RedactSecrets()`).
- `pkg/agent/{agent.go,opts.go}`, `pkg/teamloader/teamloader.go`, `pkg/config/latest/types.go` — the `redact_secrets: true` agent flag plumbing.
- `agent-schema.json` + `examples/redact_secrets.yaml` — schema entry and a runnable example.

## Try it

\`\`\`yaml
agents:
  root:
    model: openai/gpt-5-mini
    instruction: You are a helpful assistant.
    redact_secrets: true
    toolsets:
      - type: shell
\`\`\`

Now any secret pasted by the user — or generated by a previous turn's tool — is replaced with \`[REDACTED]\` before it reaches the model OR a tool process. The surrounding text is preserved (\`--token=[REDACTED]\` rather than the whole arg disappearing).

## Notes

- **False positive floor**: every rule pairs a regex with a discriminating keyword, so plain English never trips detection. The new \`TestRedactionMarkerIsNotASecret\` locks in that the marker itself can't loop through the ruleset.
- **False negatives are possible**: only patterns the ruleset recognises are scrubbed. This is defense-in-depth, not a substitute for keeping secrets out of the conversation in the first place.
- **No mutation of caller history**: the transform clones \`MultiContent\` / \`ToolCalls\` / \`FunctionCall\` before rewriting, so persisted session messages stay byte-identical to what the user sent.
- **Concurrent-hook safety**: pre_tool_use hooks aggregate via shallow \`maps.Copy\` in config order — the builtin emits only the keys it actually rewrote so it doesn't clobber a sibling hook's modifications.
- **Performance**: \`Redact\` is \`O(rules)\` for clean inputs (just a keyword scan against a single lower-cased copy); 2 allocations on a 9 KB clean message in the benchmark.

## Tests

\`mise lint\` and \`mise test\` are green. The new tests cover detection parity with upstream, redaction span correctness, idempotence, multi-secret handling, marker safety, the pre_tool_use builtin's recursion + "only changed keys" output, agent-flag wiring, and the runtime transform's per-surface scrubbing + non-mutation contract.

Assisted-By: docker-agent