### PR TITLE
Suppress spurious 'is now available' MCP toolset notice

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -313,30 +313,26 @@ func (a *Agent) ToolSets() []tools.ToolSet {
 	return toolSets
 }
 
+// ensureToolSetsAreStarted starts every toolset, surfacing the first
+// failure of each streak as a user-visible warning and silently retrying
+// on every subsequent turn. A successful Start() automatically resets the
+// streak inside StartableToolSet, so a future failure is again reported
+// as fresh — no recovery callback is needed here, and we deliberately do
+// not surface a "now available" notice (the OAuth dialog completing or
+// the model just using the tool already makes a successful start
+// obvious; a follow-up notification just reads as a spurious warning).
 func (a *Agent) ensureToolSetsAreStarted(ctx context.Context) {
 	for _, toolSet := range a.toolsets {
-		if err := toolSet.Start(ctx); err != nil {
-			// Only warn on the first failure in a streak; suppress duplicate
-			// warnings for subsequent retries that also fail.
-			if toolSet.ShouldReportFailure() {
-				desc := tools.DescribeToolSet(toolSet)
-				slog.Warn("Toolset start failed; will retry on next turn", "agent", a.Name(), "toolset", desc, "error", err)
-				a.AddToolWarning(fmt.Sprintf("%s start failed: %v", desc, err))
-			} else {
-				desc := tools.DescribeToolSet(toolSet)
-				slog.Debug("Toolset still unavailable; retrying next turn", "agent", a.Name(), "toolset", desc, "error", err)
-			}
+		err := toolSet.Start(ctx)
+		if err == nil {
 			continue
 		}
-		// Reset the failure-streak flag when a previously-failed toolset
-		// recovers, so the next failure is again reported as a fresh one.
-		// We deliberately do not surface a user-visible "now available"
-		// notice: for OAuth-driven recoveries the user already sees the
-		// authorization dialog complete, and for other recoveries the
-		// model simply uses the tool — a follow-up notification just
-		// reads as a spurious warning.
-		if toolSet.ConsumeRecovery() {
-			slog.Info("Toolset now available", "agent", a.Name(), "toolset", tools.DescribeToolSet(toolSet))
+		desc := tools.DescribeToolSet(toolSet)
+		if toolSet.ShouldReportFailure() {
+			slog.Warn("Toolset start failed; will retry on next turn", "agent", a.Name(), "toolset", desc, "error", err)
+			a.AddToolWarning(fmt.Sprintf("%s start failed: %v", desc, err))
+		} else {
+			slog.Debug("Toolset still unavailable; retrying next turn", "agent", a.Name(), "toolset", desc, "error", err)
 		}
 	}
 }

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -44,13 +44,11 @@ type Agent struct {
 	hooks                   *latest.HooksConfig
 	cache                   *cache.Cache
 
-	// warningsMu guards pendingWarnings and pendingNotices. AddToolWarning,
-	// AddToolNotice, DrainWarnings and DrainNotices may be called
-	// concurrently from the runtime loop, the MCP server, the TUI and
-	// session manager.
+	// warningsMu guards pendingWarnings. AddToolWarning and DrainWarnings
+	// may be called concurrently from the runtime loop, the MCP server,
+	// the TUI and session manager.
 	warningsMu      sync.Mutex
 	pendingWarnings []string
-	pendingNotices  []string
 }
 
 // New creates a new agent
@@ -330,39 +328,31 @@ func (a *Agent) ensureToolSetsAreStarted(ctx context.Context) {
 			}
 			continue
 		}
-		// Emit a one-time notice when a previously-failed toolset recovers.
+		// Reset the failure-streak flag when a previously-failed toolset
+		// recovers, so the next failure is again reported as a fresh one.
+		// We deliberately do not surface a user-visible "now available"
+		// notice: for OAuth-driven recoveries the user already sees the
+		// authorization dialog complete, and for other recoveries the
+		// model simply uses the tool — a follow-up notification just
+		// reads as a spurious warning.
 		if toolSet.ConsumeRecovery() {
-			desc := tools.DescribeToolSet(toolSet)
-			slog.Info("Toolset now available", "agent", a.Name(), "toolset", desc)
-			a.AddToolNotice(desc + " is now available")
+			slog.Info("Toolset now available", "agent", a.Name(), "toolset", tools.DescribeToolSet(toolSet))
 		}
 	}
 }
 
 // AddToolWarning records a warning generated while loading or starting toolsets.
 // Warnings represent real failures the user should know about (a remote MCP
-// server returning 4xx, an MCP binary missing, ...). For positive notices
-// (a previously-failed toolset becoming available again) use AddToolNotice
-// instead so the message isn't framed as a failure.
+// server returning 4xx, an MCP binary missing, ...). Recoveries from a
+// previous failure are intentionally not surfaced: the OAuth dialog and
+// subsequent tool use already make a successful start obvious, so emitting
+// a "now available" notification only adds noise.
 func (a *Agent) AddToolWarning(msg string) {
 	if msg == "" {
 		return
 	}
 	a.warningsMu.Lock()
 	a.pendingWarnings = append(a.pendingWarnings, msg)
-	a.warningsMu.Unlock()
-}
-
-// AddToolNotice records a positive, informational notice about a toolset
-// (typically: a previously-failed toolset is now available). Notices are
-// surfaced to the user separately from warnings so the framing doesn't
-// say "failed to initialize" for a recovery message.
-func (a *Agent) AddToolNotice(msg string) {
-	if msg == "" {
-		return
-	}
-	a.warningsMu.Lock()
-	a.pendingNotices = append(a.pendingNotices, msg)
 	a.warningsMu.Unlock()
 }
 
@@ -373,15 +363,6 @@ func (a *Agent) DrainWarnings() []string {
 	warnings := a.pendingWarnings
 	a.pendingWarnings = nil
 	return warnings
-}
-
-// DrainNotices returns pending notices and clears them.
-func (a *Agent) DrainNotices() []string {
-	a.warningsMu.Lock()
-	defer a.warningsMu.Unlock()
-	notices := a.pendingNotices
-	a.pendingNotices = nil
-	return notices
 }
 
 func (a *Agent) StopToolSets(ctx context.Context) error {

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -358,9 +358,12 @@ func TestModelOverride_ConcurrentAccess(t *testing.T) {
 	// If we got here without a race condition panic, the test passes
 }
 
-// TestAgentReProbeEmitsWarningThenNotice verifies the full retry lifecycle:
-// turn 1 fails → warning emitted; turn 2 succeeds → notice emitted; tools available.
-func TestAgentReProbeEmitsWarningThenNotice(t *testing.T) {
+// TestAgentReProbeRecoveryDoesNotEmitNotice verifies the full retry
+// lifecycle: turn 1 fails → warning emitted; turn 2 succeeds → tools
+// available, NO follow-up notification. Recoveries are intentionally
+// silent: "X is now available" right after the user completes an OAuth
+// dance reads as a spurious warning, not a useful signal.
+func TestAgentReProbeRecoveryDoesNotEmitNotice(t *testing.T) {
 	t.Parallel()
 
 	errBoom := errors.New("server unavailable")
@@ -370,23 +373,19 @@ func TestAgentReProbeEmitsWarningThenNotice(t *testing.T) {
 	}
 	a := New("root", "test", WithToolSets(stub))
 
-	// Turn 1: start fails → 1 warning, 0 tools, no notice yet.
+	// Turn 1: start fails → 1 warning, 0 tools.
 	got, err := a.Tools(t.Context())
 	require.NoError(t, err)
 	assert.Empty(t, got, "turn 1: no tools while toolset is unavailable")
 	warnings := a.DrainWarnings()
 	require.Len(t, warnings, 1, "turn 1: exactly one warning expected")
 	assert.Contains(t, warnings[0], "start failed")
-	assert.Empty(t, a.DrainNotices(), "turn 1: no recovery notice while still failing")
 
-	// Turn 2: start succeeds → 1 recovery NOTICE (not warning), tools available.
+	// Turn 2: start succeeds → tools available, NO recovery warning.
 	got, err = a.Tools(t.Context())
 	require.NoError(t, err)
 	assert.Len(t, got, 1, "turn 2: tool should be available after recovery")
-	assert.Empty(t, a.DrainWarnings(), "turn 2: recovery is a notice, not a failure warning")
-	notices := a.DrainNotices()
-	require.Len(t, notices, 1, "turn 2: exactly one recovery notice expected")
-	assert.Contains(t, notices[0], "now available", "turn 2: recovery notice must mention availability")
+	assert.Empty(t, a.DrainWarnings(), "turn 2: recovery must not emit any user-visible warning")
 }
 
 // TestAgentNoDuplicateStartWarnings verifies that repeated failures generate

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -688,23 +688,19 @@ func (r *LocalRuntime) configureToolsetHandlers(a *agent.Agent, events chan Even
 	}
 }
 
-// emitAgentWarnings drains and emits any pending toolset warnings and notices
-// as persistent TUI notifications. Failures ("start failed", "list failed")
-// and recoveries ("is now available") flow through separate queues on the
-// agent so each can be framed correctly — a single mixed message saying
-// "Some toolsets failed to initialize ... is now available" reads as a
-// contradiction.
+// emitAgentWarnings drains and emits any pending toolset warnings as
+// persistent TUI notifications. Failures ("start failed", "list failed")
+// are surfaced so the user can act on them; recoveries are intentionally
+// not emitted — "X is now available" reads as a spurious warning right
+// after the user completes an OAuth dance, and adds no signal for other
+// recoveries either.
 func (r *LocalRuntime) emitAgentWarnings(a *agent.Agent, send func(Event)) {
 	warnings := a.DrainWarnings()
-	if len(warnings) > 0 {
-		slog.Warn("Tool setup partially failed; continuing", "agent", a.Name(), "warnings", warnings)
-		send(Warning(formatToolWarning(a, warnings), a.Name()))
+	if len(warnings) == 0 {
+		return
 	}
-	notices := a.DrainNotices()
-	if len(notices) > 0 {
-		slog.Info("Toolset status update", "agent", a.Name(), "notices", notices)
-		send(Warning(formatToolNotice(a, notices), a.Name()))
-	}
+	slog.Warn("Tool setup partially failed; continuing", "agent", a.Name(), "warnings", warnings)
+	send(Warning(formatToolWarning(a, warnings), a.Name()))
 }
 
 func formatToolWarning(a *agent.Agent, warnings []string) string {
@@ -712,15 +708,6 @@ func formatToolWarning(a *agent.Agent, warnings []string) string {
 	fmt.Fprintf(&builder, "Some toolsets failed to initialize for agent '%s'.\n\nDetails:\n\n", a.Name())
 	for _, warning := range warnings {
 		fmt.Fprintf(&builder, "- %s\n", warning)
-	}
-	return strings.TrimSuffix(builder.String(), "\n")
-}
-
-func formatToolNotice(a *agent.Agent, notices []string) string {
-	var builder strings.Builder
-	fmt.Fprintf(&builder, "Toolset status update for agent '%s':\n\n", a.Name())
-	for _, notice := range notices {
-		fmt.Fprintf(&builder, "- %s\n", notice)
 	}
 	return strings.TrimSuffix(builder.String(), "\n")
 }
@@ -760,9 +747,9 @@ func chanSend(ch chan Event) func(Event) {
 }
 
 // reprobe re-runs ensureToolSetsAreStarted after a batch of tool calls.
-// If new tools became available (by name-set diff), it emits recovery notices
-// and a ToolsetInfo event to update the TUI immediately. The new tools will be
-// picked up by the next iteration's getTools() call at the top of the loop.
+// If new tools became available (by name-set diff), it emits a ToolsetInfo
+// event to update the TUI immediately. The new tools will be picked up by
+// the next iteration's getTools() call at the top of the loop.
 //
 // reprobe deliberately does NOT return the new tool list: the top-of-loop
 // getTools() is the single authoritative source for agentTools each iteration.
@@ -781,7 +768,7 @@ func (r *LocalRuntime) reprobe(
 	}
 	updated = filterExcludedTools(updated, sess.ExcludedTools)
 
-	// Emit any pending warnings/notices that getTools just generated.
+	// Emit any pending warnings that getTools just generated.
 	r.emitAgentWarnings(a, chanSend(events))
 
 	// Compute added tools by comparing name-sets (not just counts), so we

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -920,8 +920,8 @@ func (r *LocalRuntime) emitToolsProgressively(ctx context.Context, a *agent.Agen
 					desc := tools.DescribeToolSet(startable.ToolSet)
 					// IsAuthorizationRequired must be checked BEFORE
 					// ShouldReportFailure: this is the first — expected —
-					// failure of a deferred-OAuth toolset, and consuming
-					// freshFailure here would suppress the *real*
+					// failure of a deferred-OAuth toolset, and consuming the
+					// failure-reported flag here would suppress the *real*
 					// failure (e.g. server 4xx on the eventual interactive
 					// retry) that the user actually needs to see.
 					if mcptools.IsAuthorizationRequired(err) {

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -1091,47 +1091,16 @@ func TestEmitStartupInfo_DeferredAuthPreservesFreshFailureFlag(t *testing.T) {
 			"and the user sees zero tools with no explanation")
 }
 
-// TestEmitAgentWarnings_RecoveryNoticeIsNotFramedAsFailure verifies that
-// when a previously-failed toolset recovers ("is now available"), the
-// emitted WarningEvent is framed neutrally rather than wrapped in the
-// "Some toolsets failed to initialize" framing used for real failures.
+// TestEmitAgentWarnings_OnlyEmitsFailures verifies that emitAgentWarnings
+// only surfaces real failures to the user. Recovery is intentionally
+// silent: a previously-failed toolset becoming available again does NOT
+// produce a follow-up "is now available" notification, because that reads
+// as a spurious warning right after the user completes an OAuth dance.
 //
-// Regression test for: after lazy-init OAuth completes and the toolset
-// reconnects, the user saw a notification that read
-//
-//	"Some toolsets failed to initialize for agent 'root'.
-//	 Details:
-//	 - mcp(remote host=mcp.slack.com transport=streamable) is now available"
-//
-// The body says "is now available" (success) but the framing says "failed"
-// (failure), which the user reasonably read as "is NOT available".
-func TestEmitAgentWarnings_RecoveryNoticeIsNotFramedAsFailure(t *testing.T) {
-	prov := &mockProvider{id: "test/m", stream: &mockStream{}}
-	root := agent.New("root", "agent", agent.WithModel(prov))
-	tm := team.New(team.WithAgents(root))
-	rt, err := NewLocalRuntime(tm, WithCurrentAgent("root"), WithModelStore(mockModelStore{}))
-	require.NoError(t, err)
-
-	root.AddToolNotice("mcp(remote host=mcp.slack.com transport=streamable) is now available")
-
-	var emitted []Event
-	rt.emitAgentWarnings(root, func(e Event) { emitted = append(emitted, e) })
-
-	require.Len(t, emitted, 1, "expected exactly one event from a single notice")
-	w, ok := emitted[0].(*WarningEvent)
-	require.True(t, ok, "expected a *WarningEvent, got %T", emitted[0])
-
-	assert.NotContains(t, strings.ToLower(w.Message), "failed",
-		"recovery notice must not be framed as a failure; got: %q", w.Message)
-	assert.Contains(t, w.Message, "is now available",
-		"recovery notice must preserve the actual content; got: %q", w.Message)
-}
-
-// TestEmitAgentWarnings_FailureAndRecoveryAreEmittedSeparately verifies that
-// when both a real failure and a recovery notice are pending, they are
-// emitted as two separate events with appropriate framing each — not
-// merged into a single message that conflates them.
-func TestEmitAgentWarnings_FailureAndRecoveryAreEmittedSeparately(t *testing.T) {
+// Regression test for: after lazy-init OAuth completed and the toolset
+// reconnected, the user saw a notification framed as a warning saying
+// "mcp(…) is now available" — noise, not signal.
+func TestEmitAgentWarnings_OnlyEmitsFailures(t *testing.T) {
 	prov := &mockProvider{id: "test/m", stream: &mockStream{}}
 	root := agent.New("root", "agent", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
@@ -1139,7 +1108,6 @@ func TestEmitAgentWarnings_FailureAndRecoveryAreEmittedSeparately(t *testing.T) 
 	require.NoError(t, err)
 
 	root.AddToolWarning("toolset_a start failed: connection refused")
-	root.AddToolNotice("toolset_b is now available")
 
 	var emitted []*WarningEvent
 	rt.emitAgentWarnings(root, func(e Event) {
@@ -1148,17 +1116,28 @@ func TestEmitAgentWarnings_FailureAndRecoveryAreEmittedSeparately(t *testing.T) 
 		}
 	})
 
-	require.Len(t, emitted, 2, "failures and notices must be emitted as separate events")
+	require.Len(t, emitted, 1, "expected exactly one event for one failure (recoveries are silent)")
+	w := emitted[0]
+	assert.Contains(t, strings.ToLower(w.Message), "failed",
+		"failure event must use the failure framing; got: %q", w.Message)
+	assert.Contains(t, w.Message, "toolset_a start failed: connection refused")
+	assert.NotContains(t, w.Message, "is now available",
+		"recovery notices must never be emitted as warnings; got: %q", w.Message)
+}
 
-	// Identify which is which (order is failure first, then notice).
-	failure, notice := emitted[0], emitted[1]
-	assert.Contains(t, strings.ToLower(failure.Message), "failed",
-		"failure event must use the failure framing; got: %q", failure.Message)
-	assert.Contains(t, failure.Message, "toolset_a start failed: connection refused")
+// TestEmitAgentWarnings_NoEventsWhenQueueEmpty verifies that draining an
+// agent with no pending warnings emits nothing — in particular, no empty
+// "Some toolsets failed to initialize" envelope.
+func TestEmitAgentWarnings_NoEventsWhenQueueEmpty(t *testing.T) {
+	prov := &mockProvider{id: "test/m", stream: &mockStream{}}
+	root := agent.New("root", "agent", agent.WithModel(prov))
+	tm := team.New(team.WithAgents(root))
+	rt, err := NewLocalRuntime(tm, WithCurrentAgent("root"), WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
 
-	assert.NotContains(t, strings.ToLower(notice.Message), "failed",
-		"recovery event must NOT use the failure framing; got: %q", notice.Message)
-	assert.Contains(t, notice.Message, "toolset_b is now available")
+	var emitted int
+	rt.emitAgentWarnings(root, func(Event) { emitted++ })
+	assert.Zero(t, emitted, "empty warnings queue must produce zero events")
 }
 
 func TestEmitStartupInfo(t *testing.T) {

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -1038,21 +1038,21 @@ func TestEmitStartupInfo_AuthRequiredIsSilent(t *testing.T) {
 	}
 }
 
-// TestEmitStartupInfo_DeferredAuthPreservesFreshFailureFlag verifies that
+// TestEmitStartupInfo_DeferredAuthDoesNotConsumeFailureGate verifies that
 // when a toolset's Start fails with AuthorizationRequiredError during the
-// non-interactive startup phase, the StartableToolSet's freshFailure flag is
-// LEFT INTACT — not silently consumed by the "is this the first failure?"
-// check.
+// non-interactive startup phase, the StartableToolSet's once-per-streak
+// gate is LEFT INTACT — not silently consumed by the "is this the first
+// failure?" check.
 //
 // Why this matters: the deferred-OAuth case is an *expected*, transient
 // failure. The first user-visible failure that should produce a warning is
 // whatever happens on the eventual interactive retry (e.g. "server
 // responded 400: App is not enabled for Slack MCP server access"). If the
-// flag is consumed during startup, the StartableToolSet's once-per-streak
+// gate is consumed during startup, the StartableToolSet's once-per-streak
 // guard fires for the deferred case and silently swallows the real cause,
 // leaving the user staring at "0 tools" with nothing in the UI explaining
 // why.
-func TestEmitStartupInfo_DeferredAuthPreservesFreshFailureFlag(t *testing.T) {
+func TestEmitStartupInfo_DeferredAuthDoesNotConsumeFailureGate(t *testing.T) {
 	prov := &mockProvider{id: "test/startup-model", stream: &mockStream{}}
 
 	deferralErr := &mcptools.AuthorizationRequiredError{URL: "https://example.test/mcp"}
@@ -1086,7 +1086,7 @@ func TestEmitStartupInfo_DeferredAuthPreservesFreshFailureFlag(t *testing.T) {
 	require.NotNil(t, wrapped, "agent.ToolSets() should return a *StartableToolSet wrapper")
 
 	require.True(t, wrapped.ShouldReportFailure(),
-		"deferred-OAuth must NOT consume freshFailure during EmitStartupInfo: "+
+		"deferred-OAuth must NOT consume the failure-reported gate during EmitStartupInfo: "+
 			"otherwise the next real failure (Slack 4xx after OAuth, etc.) is silently dropped "+
 			"and the user sees zero tools with no explanation")
 }

--- a/pkg/tools/startable.go
+++ b/pkg/tools/startable.go
@@ -31,23 +31,18 @@ func DescribeToolSet(ts ToolSet) string {
 // StartableToolSet wraps a ToolSet with lazy, single-flight start semantics.
 // This is the canonical way to manage toolset lifecycle.
 //
-// Failure and recovery tracking:
-//   - freshFailure is set to true on the first Start() failure in a streak
-//     (i.e. when hasEverFailed transitions false→true). It is consumed by
-//     ShouldReportFailure() which returns true exactly once per streak.
-//   - hasEverFailed stays true for the duration of the failure streak.
-//   - pendingRecovery is set to true on the first successful Start() after a
-//     failure streak. It is consumed by ConsumeRecovery().
-//   - ConsumeRecovery() also resets hasEverFailed, so the next failure streak
-//     generates a fresh warning.
+// It also de-duplicates start-failure warnings: when Start() fails repeatedly
+// (e.g. an MCP server is down), only the *first* failure of each streak is
+// reported via ShouldReportFailure(). A successful Start() automatically
+// clears the streak, so a future failure is again reported as fresh — no
+// caller-visible "recovery" event is needed.
 type StartableToolSet struct {
 	ToolSet
 
 	mu              sync.Mutex
 	started         bool
-	hasEverFailed   bool // true for the duration of a failure streak
-	freshFailure    bool // true only for the first failure in a streak; consumed by ShouldReportFailure
-	pendingRecovery bool // true when a recovery notice is pending; consumed by ConsumeRecovery
+	inFailureStreak bool // true between the first failed Start and the next successful Start (or Stop)
+	pendingWarning  bool // true if the current streak's first failure has not yet been reported
 }
 
 // NewStartable wraps a ToolSet for lazy initialization.
@@ -77,21 +72,21 @@ func (s *StartableToolSet) Start(ctx context.Context) error {
 
 	if startable, ok := As[Startable](s.ToolSet); ok {
 		if err := startable.Start(ctx); err != nil {
-			// Only set freshFailure on the very first failure in a streak so
-			// that repeated failed retries don't each emit a new warning.
-			if !s.hasEverFailed {
-				s.hasEverFailed = true
-				s.freshFailure = true
+			// Queue a warning ONLY on the first failure of a streak so
+			// repeated retries don't re-queue duplicate warnings.
+			if !s.inFailureStreak {
+				s.inFailureStreak = true
+				s.pendingWarning = true
 			}
 			return err
 		}
 	}
 
-	// Successful start: if this followed a failure streak, signal recovery.
-	if s.hasEverFailed {
-		s.pendingRecovery = true
-	}
+	// Successful start: clear the streak so any future failure is reported
+	// as fresh. This is the recovery path — it is intentionally silent.
 	s.started = true
+	s.inFailureStreak = false
+	s.pendingWarning = false
 	return nil
 }
 
@@ -102,42 +97,25 @@ func (s *StartableToolSet) Stop(ctx context.Context) error {
 	defer s.mu.Unlock()
 
 	s.started = false
-	s.hasEverFailed = false
-	s.freshFailure = false
-	s.pendingRecovery = false
+	s.inFailureStreak = false
+	s.pendingWarning = false
 	if startable, ok := As[Startable](s.ToolSet); ok {
 		return startable.Stop(ctx)
 	}
 	return nil
 }
 
-// ShouldReportFailure returns true the first time Start() fails in a new
-// failure streak — i.e. when hasEverFailed transitions from false to true.
-// It returns false for all subsequent failures in the same streak, preventing
-// repeated "start failed" warnings from flooding the user. It is safe to call
-// even when Start() did not return an error (it will return false).
+// ShouldReportFailure returns true exactly once per failure streak — after
+// the first failed Start() and before the streak ends (a successful
+// Start() or Stop()). Subsequent calls return false until a new streak
+// begins. Calling it when no failure is pending always returns false.
 func (s *StartableToolSet) ShouldReportFailure() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if !s.freshFailure {
+	if !s.pendingWarning {
 		return false
 	}
-	s.freshFailure = false
-	return true
-}
-
-// ConsumeRecovery returns true exactly once after a Start() that succeeded
-// following a previously-reported failure streak. Calling it also resets
-// hasEverFailed and freshFailure so that a future failure generates a fresh warning.
-func (s *StartableToolSet) ConsumeRecovery() bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if !s.pendingRecovery {
-		return false
-	}
-	s.pendingRecovery = false
-	s.hasEverFailed = false
-	s.freshFailure = false
+	s.pendingWarning = false
 	return true
 }
 

--- a/pkg/tools/startable_test.go
+++ b/pkg/tools/startable_test.go
@@ -98,40 +98,23 @@ func TestStartableToolSet_ShouldReportFailure_OncePerStreak(t *testing.T) {
 	s := tools.NewStartable(f)
 
 	// Turn 1: first failure — should report.
-	err := s.Start(t.Context())
-	assert.Check(t, err != nil, "expected error on turn 1")
+	assert.Check(t, s.Start(t.Context()) != nil, "expected error on turn 1")
 	assert.Check(t, is.Equal(s.ShouldReportFailure(), true), "turn 1: first failure should be reported")
 	assert.Check(t, is.Equal(s.ShouldReportFailure(), false), "turn 1: second call must return false")
 
 	// Turn 2: second failure in same streak — must NOT report again.
-	err = s.Start(t.Context())
-	assert.Check(t, err != nil, "expected error on turn 2")
+	assert.Check(t, s.Start(t.Context()) != nil, "expected error on turn 2")
 	assert.Check(t, is.Equal(s.ShouldReportFailure(), false), "turn 2: duplicate failure must not report")
 
-	// Turn 3: success — ConsumeRecovery fires exactly once.
-	err = s.Start(t.Context())
-	assert.Check(t, err == nil, "expected success on turn 3")
-	assert.Check(t, is.Equal(s.ConsumeRecovery(), true), "turn 3: recovery must be signalled")
-	assert.Check(t, is.Equal(s.ConsumeRecovery(), false), "turn 3: recovery must fire only once")
+	// Turn 3: success — silent recovery, no caller-visible event.
+	assert.Check(t, s.Start(t.Context()) == nil, "expected success on turn 3")
+	assert.Check(t, is.Equal(s.ShouldReportFailure(), false), "turn 3: success must not report a failure")
 }
 
-// TestStartableToolSet_NoRecoveryWithoutPriorFailure verifies that
-// ConsumeRecovery returns false when Start succeeds on the very first try.
-func TestStartableToolSet_NoRecoveryWithoutPriorFailure(t *testing.T) {
-	t.Parallel()
-
-	f := &flappyToolSet{errs: []error{nil}}
-	s := tools.NewStartable(f)
-
-	err := s.Start(t.Context())
-	assert.Check(t, err == nil)
-	assert.Check(t, is.Equal(s.ShouldReportFailure(), false), "no failure: ShouldReportFailure must be false")
-	assert.Check(t, is.Equal(s.ConsumeRecovery(), false), "no prior failure: ConsumeRecovery must be false")
-}
-
-// TestStartableToolSet_RecoveryThenFailureWarnsAgain verifies that after a full
-// fail→report→recover cycle, a subsequent new failure generates a fresh warning.
-func TestStartableToolSet_RecoveryThenFailureWarnsAgain(t *testing.T) {
+// TestStartableToolSet_RecoveryResetsStreak verifies that a successful
+// Start() implicitly resets the failure streak: after a fail → succeed
+// cycle, a fresh failure on the *next* streak is reported again.
+func TestStartableToolSet_RecoveryResetsStreak(t *testing.T) {
 	t.Parallel()
 
 	errBoom := errors.New("boom")
@@ -139,20 +122,18 @@ func TestStartableToolSet_RecoveryThenFailureWarnsAgain(t *testing.T) {
 	s := tools.NewStartable(f)
 
 	// Cycle 1: fail then recover.
-	err := s.Start(t.Context())
-	assert.Check(t, err != nil)
+	assert.Check(t, s.Start(t.Context()) != nil)
 	assert.Check(t, is.Equal(s.ShouldReportFailure(), true))
 
-	err = s.Start(t.Context())
-	assert.Check(t, err == nil)
-	assert.Check(t, is.Equal(s.ConsumeRecovery(), true))
+	assert.Check(t, s.Start(t.Context()) == nil)
 
-	// Now stop so we can start again (resets started flag).
+	// Stop so we can attempt to start again — a successful Start() marks
+	// the toolset as started, so subsequent Start() calls short-circuit.
 	assert.Check(t, s.Stop(t.Context()) == nil)
 
-	// Cycle 2: new failure — must warn again.
-	err = s.Start(t.Context())
-	assert.Check(t, err != nil)
+	// Cycle 2: new failure must warn again, proving the recovery reset
+	// the streak even though no caller signalled it.
+	assert.Check(t, s.Start(t.Context()) != nil)
 	assert.Check(t, is.Equal(s.ShouldReportFailure(), true), "fresh failure after recovery must warn")
 }
 
@@ -166,15 +147,13 @@ func TestStartableToolSet_StopResetsFailureState(t *testing.T) {
 	s := tools.NewStartable(f)
 
 	// First failure: consume the warning.
-	err := s.Start(t.Context())
-	assert.Check(t, err != nil)
+	assert.Check(t, s.Start(t.Context()) != nil)
 	assert.Check(t, is.Equal(s.ShouldReportFailure(), true))
 
 	// Stop resets state.
 	assert.Check(t, s.Stop(t.Context()) == nil)
 
 	// Second failure after Stop: must warn again.
-	err = s.Start(t.Context())
-	assert.Check(t, err != nil)
+	assert.Check(t, s.Start(t.Context()) != nil)
 	assert.Check(t, is.Equal(s.ShouldReportFailure(), true), "failure after Stop must produce fresh warning")
 }


### PR DESCRIPTION
## What

After completing an OAuth flow for a remote MCP server, the TUI displayed a notification framed as a warning:

> mcp(remote host=mcp.slack.com transport=streamable) is now available

This is not a valid warning. The OAuth dialog completing already makes a successful start obvious, and for non-OAuth recoveries the model just uses the tool — the follow-up notification is pure noise.

## Changes

### Commit 1 — Suppress the notice

Drop the entire tool-notice path in the agent and runtime:

- **`pkg/agent/agent.go`**: remove `pendingNotices` field, `AddToolNotice`, `DrainNotices`. `ensureToolSetsAreStarted` still resets the failure-streak flag on a successful start (so the next failure is reported as fresh), but only logs at `slog.Info` — never user-visible.
- **`pkg/runtime/loop.go`**: `emitAgentWarnings` only drains warnings now; `formatToolNotice` is gone.
- Tests updated to assert recoveries are silent.

### Commit 2 — Simplify the resulting state machine

With the recovery notice gone, the only consumer of `ConsumeRecovery()` was a state-reset call in `agent.ensureToolSetsAreStarted`. Folded that reset into `Start()` itself: a successful `Start` now implicitly clears the failure streak.

|                              | Before                                                       | After                                            |
| ---                          | ---                                                          | ---                                              |
| `StartableToolSet` flags     | 3 (`hasEverFailed`, `freshFailure`, `pendingRecovery`)       | 2 (`inFailureStreak`, `pendingWarning`)          |
| Public methods               | `Start`, `Stop`, `ShouldReportFailure`, `ConsumeRecovery`    | `Start`, `Stop`, `ShouldReportFailure`           |
| `ensureToolSetsAreStarted`   | fail-branch + recover-branch (2-arm)                         | one flat try/warn-once loop                      |
| Doc comment                  | 4-bullet state-machine spec                                  | 1 paragraph                                      |
| Net diff                     | —                                                            | **−47 lines**                                    |

## Behavioural guarantees preserved

- **Failure-once-per-streak**: `inFailureStreak` gate prevents re-queueing `pendingWarning` on repeated retries.
- **Post-recovery freshness**: a successful `Start` resets both flags, so the next failure is again surfaced as a fresh warning.
- **Deferred-OAuth must not consume the gate**: `emitToolsProgressively` still checks `IsAuthorizationRequired(err)` *before* `ShouldReportFailure()`, so the eventual real failure (Slack 4xx, etc.) is the one the user sees.

These three properties are pinned by tests in `pkg/tools/startable_test.go`, `pkg/agent/agent_test.go`, and `pkg/runtime/runtime_test.go`.

## Validation

- `mise lint` → `0 issues` (golangci-lint) + `no offenses detected` (in-tree linter, 886 files)
- `mise test` → all packages pass

## Files touched

```
pkg/agent/agent.go
pkg/agent/agent_test.go
pkg/runtime/loop.go
pkg/runtime/runtime.go
pkg/runtime/runtime_test.go
pkg/tools/startable.go
pkg/tools/startable_test.go
```