### PR TITLE
make every dialog close on ctrl+c, twice exits

### DIFF
--- a/pkg/tui/dialog/dialog.go
+++ b/pkg/tui/dialog/dialog.go
@@ -31,6 +31,7 @@ type Manager interface {
 
 	GetLayers() []*lipgloss.Layer
 	Open() bool
+	TopIsExitConfirmation() bool
 }
 
 // dialogEntry pairs a dialog with its drag offset so the two stay in sync.
@@ -267,6 +268,18 @@ func (d *manager) handleCloseAll() (layout.Model, tea.Cmd) {
 // Open returns true if there is at least one active dialog
 func (d *manager) Open() bool {
 	return len(d.stack) > 0
+}
+
+// TopIsExitConfirmation returns true if the topmost dialog is the exit
+// confirmation dialog. Used by the top-level key handler to route ctrl+c to
+// the exit confirmation (which exits the program) instead of stacking another
+// exit confirmation on top.
+func (d *manager) TopIsExitConfirmation() bool {
+	if len(d.stack) == 0 {
+		return false
+	}
+	_, ok := d.stack[len(d.stack)-1].dialog.(*exitConfirmationDialog)
+	return ok
 }
 
 func (d *manager) SetSize(width, height int) tea.Cmd {

--- a/pkg/tui/dialog/elicitation.go
+++ b/pkg/tui/dialog/elicitation.go
@@ -173,10 +173,6 @@ func (d *ElicitationDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		}
 		return d, nil
 	case tea.KeyPressMsg:
-		if msg.String() == "ctrl+c" {
-			cmd := d.close(tools.ElicitationActionDecline, nil)
-			return d, tea.Sequence(cmd, tea.Quit)
-		}
 		return d.handleKeyPress(msg)
 	}
 	return d, nil

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -1662,6 +1662,23 @@ func (m *appModel) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 
+	// Ctrl+c is intercepted before any dialog handling so that every dialog
+	// reacts to it consistently:
+	//   - With no dialog open: open the exit confirmation dialog.
+	//   - With any other dialog open: stack the exit confirmation on top so
+	//     that the user can confirm exit (a second ctrl+c or Y exits) or
+	//     cancel it (N/Esc) and return to the original dialog.
+	//   - With the exit confirmation already on top: forward the key so it
+	//     can exit the program via its own Yes binding.
+	if msg.String() == "ctrl+c" {
+		if m.dialogMgr.TopIsExitConfirmation() {
+			return m.forwardDialog(msg)
+		}
+		return m, core.CmdHandler(dialog.OpenDialogMsg{
+			Model: dialog.NewExitConfirmationDialog(),
+		})
+	}
+
 	// Dialog gets priority when open
 	if m.dialogMgr.Open() {
 		return m.forwardDialog(msg)
@@ -1689,11 +1706,6 @@ func (m *appModel) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 	// Global keyboard shortcuts (active even during history search)
 	switch {
-	case key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+c"))):
-		return m, core.CmdHandler(dialog.OpenDialogMsg{
-			Model: dialog.NewExitConfirmationDialog(),
-		})
-
 	case key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+z"))):
 		return m, tea.Suspend
 

--- a/pkg/tui/tui_ctrlc_test.go
+++ b/pkg/tui/tui_ctrlc_test.go
@@ -1,0 +1,90 @@
+package tui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/tui/dialog"
+)
+
+// applyOpenDialogMsgs feeds every dialog.OpenDialogMsg in cmd back into the
+// model, so the dialog manager actually receives them. This mirrors how the
+// real bubbletea event loop drains commands.
+func applyOpenDialogMsgs(t *testing.T, m *appModel, cmd tea.Cmd) {
+	t.Helper()
+	for _, msg := range collectMsgs(cmd) {
+		if open, ok := msg.(dialog.OpenDialogMsg); ok {
+			_, _ = m.Update(open)
+		}
+	}
+}
+
+func TestCtrlC_NoDialog_OpensExitConfirmation(t *testing.T) {
+	t.Parallel()
+
+	m, _ := newTestModel()
+	require.False(t, m.dialogMgr.Open(), "no dialog should be open initially")
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})
+	applyOpenDialogMsgs(t, m, cmd)
+
+	assert.True(t, m.dialogMgr.Open(), "ctrl+c should open a dialog")
+	assert.True(t, m.dialogMgr.TopIsExitConfirmation(),
+		"ctrl+c with no dialog should open the exit confirmation dialog")
+}
+
+func TestCtrlC_OnOtherDialog_StacksExitConfirmation(t *testing.T) {
+	t.Parallel()
+
+	m, _ := newTestModel()
+
+	// Open an arbitrary, non-exit dialog first.
+	_, cmd := m.Update(dialog.OpenDialogMsg{Model: dialog.NewHelpDialog(nil)})
+	applyOpenDialogMsgs(t, m, cmd)
+	require.True(t, m.dialogMgr.Open(), "help dialog should be open")
+	require.False(t, m.dialogMgr.TopIsExitConfirmation(),
+		"help dialog should be on top, not exit confirmation")
+
+	// Press ctrl+c — must stack the exit confirmation, not exit immediately.
+	_, cmd = m.Update(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})
+	applyOpenDialogMsgs(t, m, cmd)
+
+	msgs := collectMsgs(cmd)
+	assert.False(t, hasMsg[tea.QuitMsg](msgs),
+		"first ctrl+c on a non-exit dialog must NOT quit the program")
+	assert.True(t, m.dialogMgr.TopIsExitConfirmation(),
+		"ctrl+c on a non-exit dialog should put the exit confirmation on top")
+}
+
+func TestCtrlC_OnExitConfirmation_ForwardsAndExits(t *testing.T) {
+	neutralizeExitFunc(t)
+
+	m, _ := newTestModel()
+
+	// Put the exit confirmation dialog on top first (via a regular ctrl+c).
+	_, cmd := m.Update(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})
+	applyOpenDialogMsgs(t, m, cmd)
+	require.True(t, m.dialogMgr.TopIsExitConfirmation(),
+		"exit confirmation should be the topmost dialog")
+
+	// A second ctrl+c is forwarded to the exit confirmation, which signals
+	// ExitConfirmedMsg. Feed every produced message back through the model
+	// so we end up at tea.Quit.
+	_, cmd = m.Update(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})
+	require.NotNil(t, cmd, "second ctrl+c should produce a command")
+
+	sawQuit := false
+	for _, msg := range collectMsgs(cmd) {
+		if _, ok := msg.(dialog.ExitConfirmedMsg); ok {
+			_, exitCmd := m.Update(msg)
+			if hasMsg[tea.QuitMsg](collectMsgs(exitCmd)) {
+				sawQuit = true
+			}
+		}
+	}
+	assert.True(t, sawQuit,
+		"two ctrl+c presses must result in tea.Quit (exit the program)")
+}


### PR DESCRIPTION
Pressing ctrl+c on any TUI dialog now opens the exit-confirmation dialog instead of quitting immediately (via `HandleQuit` / dialog-specific handlers). A second ctrl+c on the exit-confirmation exits, matching the existing two-press flow when no dialog is shown.

If the user cancels exit (`N`/`Esc`), the original dialog is restored — the exit-confirmation is stacked on top of it, not replacing it, so blocking dialogs (tool confirmation, elicitation, max iterations) don't leave the agent stuck waiting.

### Behavior

| State | 1st ctrl+c | 2nd ctrl+c |
|---|---|---|
| no dialog | opens exit confirmation | exits |
| any other dialog | stacks exit confirmation on top | exits |
| exit confirmation | exits | — |

### Implementation

- **`pkg/tui/tui.go`** — `handleKeyPress` intercepts ctrl+c **before** forwarding to the dialog manager. If the exit confirmation is already on top, the key is forwarded so it can exit via its own `Yes` binding; otherwise the exit-confirmation dialog is pushed onto the stack.
- **`pkg/tui/dialog/dialog.go`** — added `Manager.TopIsExitConfirmation()` so the top-level handler can route the key correctly.
- **`pkg/tui/dialog/elicitation.go`** — removed the now-redundant special-case that declined the elicitation and called `tea.Quit` on ctrl+c.
- **`pkg/tui/tui_ctrlc_test.go`** — three unit tests covering the table above.