### PR TITLE
Bump direct Go dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/clipperhouse/displaywidth v0.11.0
 	github.com/clipperhouse/uax29/v2 v2.7.0
-	github.com/coder/acp-go-sdk v0.6.3
+	github.com/coder/acp-go-sdk v0.12.2
 	github.com/docker/cli v29.4.1+incompatible
 	github.com/docker/go-units v0.5.0
 	github.com/dop251/goja v0.0.0-20260311135729-065cd970411c

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.23
 	github.com/modelcontextprotocol/go-sdk v1.5.0
 	github.com/natefinch/atomic v1.0.1
-	github.com/openai/openai-go/v3 v3.32.0
+	github.com/openai/openai-go/v3 v3.33.0
 	github.com/pb33f/libopenapi v0.36.2
 	github.com/rivo/uniseg v0.4.7
 	github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82

--- a/go.sum
+++ b/go.sum
@@ -168,8 +168,8 @@ github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/Tv1FZd4SCg8axKApyNyRsAt/w=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
-github.com/coder/acp-go-sdk v0.6.3 h1:LsXQytehdjKIYJnoVWON/nf7mqbiarnyuyE3rrjBsXQ=
-github.com/coder/acp-go-sdk v0.6.3/go.mod h1:yKzM/3R9uELp4+nBAwwtkS0aN1FOFjo11CNPy37yFko=
+github.com/coder/acp-go-sdk v0.12.2 h1:fpRJ8Z5HMSr5cZ5IywzFlFZcIxZOsto+laNVu7XelFA=
+github.com/coder/acp-go-sdk v0.12.2/go.mod h1:yKzM/3R9uELp4+nBAwwtkS0aN1FOFjo11CNPy37yFko=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=

--- a/go.sum
+++ b/go.sum
@@ -396,8 +396,8 @@ github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJm
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=
 github.com/onsi/gomega v1.34.1/go.mod h1:kU1QgUvBDLXBJq618Xvm2LUX6rSAfRaFRTcdOeDLwwY=
-github.com/openai/openai-go/v3 v3.32.0 h1:aHp/3wkX1W6jB8zTtf9xV0aK0qPFSVDqS7AHmlJ4hXs=
-github.com/openai/openai-go/v3 v3.32.0/go.mod h1:cdufnVK14cWcT9qA1rRtrXx4FTRsgbDPW7Ia7SS5cZo=
+github.com/openai/openai-go/v3 v3.33.0 h1:aiETRPoLxnk6y3sIakXAdRCvtcLhdhBqHqIvEdOkEuc=
+github.com/openai/openai-go/v3 v3.33.0/go.mod h1:cdufnVK14cWcT9qA1rRtrXx4FTRsgbDPW7Ia7SS5cZo=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=

--- a/pkg/acp/agent.go
+++ b/pkg/acp/agent.go
@@ -188,10 +188,48 @@ func (a *Agent) Authenticate(context.Context, acp.AuthenticateRequest) (acp.Auth
 	return acp.AuthenticateResponse{}, nil
 }
 
-// LoadSession implements [acp.Agent] (optional, not supported)
+// LoadSession implements [acp.AgentLoader] (optional, not supported)
 func (a *Agent) LoadSession(context.Context, acp.LoadSessionRequest) (acp.LoadSessionResponse, error) {
 	slog.Debug("ACP LoadSession called (not supported)")
 	return acp.LoadSessionResponse{}, errors.New("load session not supported")
+}
+
+// CloseSession implements [acp.Agent] (optional, not advertised in capabilities)
+func (a *Agent) CloseSession(_ context.Context, params acp.CloseSessionRequest) (acp.CloseSessionResponse, error) {
+	sid := string(params.SessionId)
+	slog.Debug("ACP CloseSession called", "session_id", sid)
+
+	a.mu.Lock()
+	acpSess, ok := a.sessions[sid]
+	if ok {
+		delete(a.sessions, sid)
+	}
+	a.mu.Unlock()
+
+	// Cancel any ongoing work for this session.
+	if ok && acpSess != nil && acpSess.cancel != nil {
+		acpSess.cancel()
+	}
+
+	return acp.CloseSessionResponse{}, nil
+}
+
+// ListSessions implements [acp.Agent] (optional, not advertised in capabilities)
+func (a *Agent) ListSessions(context.Context, acp.ListSessionsRequest) (acp.ListSessionsResponse, error) {
+	slog.Debug("ACP ListSessions called (not supported)")
+	return acp.ListSessionsResponse{}, errors.New("list sessions not supported")
+}
+
+// ResumeSession implements [acp.Agent] (optional, not advertised in capabilities)
+func (a *Agent) ResumeSession(context.Context, acp.ResumeSessionRequest) (acp.ResumeSessionResponse, error) {
+	slog.Debug("ACP ResumeSession called (not supported)")
+	return acp.ResumeSessionResponse{}, errors.New("resume session not supported")
+}
+
+// SetSessionConfigOption implements [acp.Agent] (optional, not advertised in capabilities)
+func (a *Agent) SetSessionConfigOption(context.Context, acp.SetSessionConfigOptionRequest) (acp.SetSessionConfigOptionResponse, error) {
+	slog.Debug("ACP SetSessionConfigOption called (not supported)")
+	return acp.SetSessionConfigOptionResponse{}, nil
 }
 
 // Cancel implements [acp.Agent]
@@ -522,7 +560,7 @@ func (a *Agent) handleToolCallConfirmation(ctx context.Context, acpSess *Session
 func (a *Agent) handleMaxIterationsReached(ctx context.Context, acpSess *Session, e *runtime.MaxIterationsReachedEvent) error {
 	permResp, err := a.conn.RequestPermission(ctx, acp.RequestPermissionRequest{
 		SessionId: acp.SessionId(acpSess.id),
-		ToolCall: acp.RequestPermissionToolCall{
+		ToolCall: acp.ToolCallUpdate{
 			ToolCallId: "max_iterations",
 			Title:      new(fmt.Sprintf("Maximum iterations (%d) reached", e.MaxIterations)),
 			Kind:       acp.Ptr(acp.ToolKindExecute),
@@ -755,7 +793,7 @@ func extractDiffContent(toolCallName, arguments string) *acp.ToolCallContent {
 }
 
 // buildToolCallUpdate creates a tool call update for permission requests
-func buildToolCallUpdate(toolCall tools.ToolCall, tool tools.Tool, status acp.ToolCallStatus) acp.RequestPermissionToolCall {
+func buildToolCallUpdate(toolCall tools.ToolCall, tool tools.Tool, status acp.ToolCallStatus) acp.ToolCallUpdate {
 	kind := acp.ToolKindExecute
 	title := cmp.Or(tool.Annotations.Title, toolCall.Function.Name)
 
@@ -763,7 +801,7 @@ func buildToolCallUpdate(toolCall tools.ToolCall, tool tools.Tool, status acp.To
 		kind = acp.ToolKindRead
 	}
 
-	return acp.RequestPermissionToolCall{
+	return acp.ToolCallUpdate{
 		ToolCallId: acp.ToolCallId(toolCall.ID),
 		Title:      &title,
 		Kind:       &kind,


### PR DESCRIPTION
Bump direct Go dependencies.

| Module | From | To | Notes |
|--------|------|----|-------|
| github.com/openai/openai-go/v3 | v3.32.0 | v3.33.0 | drop-in |
| github.com/coder/acp-go-sdk | v0.6.3 | v0.12.2 | required code adaptation in `pkg/acp/agent.go` (see below) |

### `acp-go-sdk` v0.12.2 adaptation

The new `acp.Agent` interface adds several methods. Implemented them in `pkg/acp/agent.go`:

- `CloseSession` — cancels in-flight work and removes the session from the in-memory map.
- `ListSessions`, `ResumeSession`, `SetSessionConfigOption` — stubs since we don't advertise these capabilities.

The `acp.RequestPermissionToolCall` type was removed. The three existing usages (and the `buildToolCallUpdate` return type) were switched to the unified `acp.ToolCallUpdate`, which is what `RequestPermissionRequest.ToolCall` now expects.

Validation: `mise lint` and `mise test` pass.