### PR TITLE
lint: add 7 architectural-sync cops (catches 10 real bugs)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -145,7 +145,7 @@ require (
 	github.com/containerd/stargz-snapshotter/estargz v0.18.2 // indirect
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/dgageot/rubocop-go v0.0.0-20260323134452-aecdd6345645
+	github.com/dgageot/rubocop-go v0.0.0-20260429095109-a9cea3bf3e72
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/danieljoos/wincred v1.2.2/go.mod h1:w7w4Utbrz8lqeMbDAK0lkNJUv5sAOkFi7
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgageot/rubocop-go v0.0.0-20260323134452-aecdd6345645 h1:7UgEWAo69Dgbtii1j1FLWE88+Rem9Qly4LLrrQhAN0s=
-github.com/dgageot/rubocop-go v0.0.0-20260323134452-aecdd6345645/go.mod h1:r8YOJV5+/30NZ8HW/2NbWUObBGDXGvfHrjgury5YlFI=
+github.com/dgageot/rubocop-go v0.0.0-20260429095109-a9cea3bf3e72 h1:2BdfP/9nnmcCHUBZhOueTb6rQojfZdlh2hI3E65cY2I=
+github.com/dgageot/rubocop-go v0.0.0-20260429095109-a9cea3bf3e72/go.mod h1:r8YOJV5+/30NZ8HW/2NbWUObBGDXGvfHrjgury5YlFI=
 github.com/dgageot/ultraviolet v0.0.0-20260313154905-9451997d56b6 h1:88fWkkjwzuI4tRTqadbJIbA9O+gO67oyu+2OpHHuuT8=
 github.com/dgageot/ultraviolet v0.0.0-20260313154905-9451997d56b6/go.mod h1:SQpCTRNBtzJkwku5ye4S3HEuthAlGy2n9VXZnWkEW98=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=

--- a/lint/config_latest_tag_consistency.go
+++ b/lint/config_latest_tag_consistency.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"go/ast"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/dgageot/rubocop-go/cop"
+)
+
+// ConfigLatestTagConsistency enforces that struct fields under
+// pkg/config/latest/ keep their `json` and `yaml` struct tags in sync with
+// respect to the omit-when-empty modifier:
+//
+//   - both tags carry `omitempty` (or `omitzero` on the json side), or
+//   - neither tag carries an omit modifier.
+//
+// Mismatched modifiers silently produce different serialisations depending
+// on the format: a value that round-trips through YAML may be lost when the
+// same struct is encoded as JSON (or vice-versa). Because pkg/config/latest
+// is the work-in-progress schema, such drift is almost always a typo, not
+// an intentional design choice.
+//
+// Frozen versioned packages (pkg/config/vN/) are intentionally exempt: they
+// must reproduce the exact wire format that shipped, including any historical
+// quirks.
+//
+// Recognised modifiers:
+//   - json: `omitempty`, `omitzero` (the latter introduced in Go 1.24)
+//   - yaml: `omitempty`
+//
+// Fields without a `yaml` tag are skipped — yaml.v3 derives a default name
+// from the field, which is a separate concern handled elsewhere.
+type ConfigLatestTagConsistency struct {
+	cop.Meta
+}
+
+// NewConfigLatestTagConsistency returns a fully configured
+// ConfigLatestTagConsistency cop.
+func NewConfigLatestTagConsistency() *ConfigLatestTagConsistency {
+	return &ConfigLatestTagConsistency{Meta: cop.Meta{
+		CopName:     "Lint/ConfigLatestTagConsistency",
+		CopDesc:     "json and yaml tags in pkg/config/latest must agree on omitempty/omitzero",
+		CopSeverity: cop.Error,
+	}}
+}
+
+func (c *ConfigLatestTagConsistency) Check(p *cop.Pass) {
+	if configDir(p.Filename()) != "latest" {
+		return
+	}
+	// Black-box test files don't ship struct definitions for the wire format.
+	if p.IsBlackBoxTest() {
+		return
+	}
+
+	ast.Inspect(p.File, func(n ast.Node) bool {
+		field, ok := n.(*ast.Field)
+		if !ok || field.Tag == nil {
+			return true
+		}
+		raw, err := strconv.Unquote(field.Tag.Value)
+		if err != nil {
+			return true
+		}
+		tag := reflect.StructTag(raw)
+
+		jsonTag, hasJSON := tag.Lookup("json")
+		yamlTag, hasYAML := tag.Lookup("yaml")
+		if !hasJSON || !hasYAML {
+			return true
+		}
+		// Embedded fields use ",inline" on both sides; nothing to compare.
+		if isInline(jsonTag) || isInline(yamlTag) {
+			return true
+		}
+
+		jsonOmit, jsonMod := jsonOmitModifier(jsonTag)
+		yamlOmit := hasOption(yamlTag, "omitempty")
+
+		if jsonOmit != yamlOmit {
+			p.Report(field.Tag,
+				"json and yaml tags disagree on omit-when-empty: json has %q, yaml has %q (field %s)",
+				modifierLabel(jsonOmit, jsonMod), modifierLabel(yamlOmit, "omitempty"),
+				fieldNames(field))
+		}
+		return true
+	})
+}
+
+// jsonOmitModifier reports whether the json tag opts out of empty values,
+// returning the specific modifier that triggered the match (omitempty or
+// omitzero). When neither is present, it returns false and "".
+func jsonOmitModifier(tag string) (bool, string) {
+	switch {
+	case hasOption(tag, "omitempty"):
+		return true, "omitempty"
+	case hasOption(tag, "omitzero"):
+		return true, "omitzero"
+	default:
+		return false, ""
+	}
+}
+
+// hasOption reports whether the comma-separated options on tag include opt.
+// The first comma-separated entry is the field name; only later entries are
+// modifiers (`omitempty`, `omitzero`, `inline`, …).
+func hasOption(tag, opt string) bool {
+	for i, part := range strings.Split(tag, ",") {
+		if i == 0 {
+			continue
+		}
+		if part == opt {
+			return true
+		}
+	}
+	return false
+}
+
+// isInline reports whether the tag carries a ",inline" option, which is used
+// by both json/yaml libraries to flatten an embedded struct into the parent.
+func isInline(tag string) bool {
+	return hasOption(tag, "inline")
+}
+
+// modifierLabel renders a human-readable description of the modifier for an
+// error message: the modifier name when present, "<none>" otherwise.
+func modifierLabel(present bool, name string) string {
+	if !present {
+		return "<none>"
+	}
+	return name
+}
+
+// fieldNames returns the comma-separated list of field identifiers for use in
+// diagnostic messages. Anonymous (embedded) fields fall back to "<embedded>".
+func fieldNames(field *ast.Field) string {
+	if len(field.Names) == 0 {
+		return "<embedded>"
+	}
+	names := make([]string, 0, len(field.Names))
+	for _, n := range field.Names {
+		names = append(names, n.Name)
+	}
+	return strings.Join(names, ", ")
+}

--- a/lint/config_package_name.go
+++ b/lint/config_package_name.go
@@ -1,11 +1,6 @@
 package main
 
 import (
-	"fmt"
-	"go/ast"
-	"go/token"
-	"strings"
-
 	"github.com/dgageot/rubocop-go/cop"
 )
 
@@ -20,32 +15,35 @@ import (
 // is frozen into a numbered vN directory: the package clause is easy to
 // forget, and the broken state remains compilable as long as importers use
 // an explicit alias.
-type ConfigPackageName struct{}
-
-func (*ConfigPackageName) Name() string { return "Lint/ConfigPackageName" }
-func (*ConfigPackageName) Description() string {
-	return "Files under pkg/config/<dir>/ must declare package <dir>"
+type ConfigPackageName struct {
+	cop.Meta
 }
-func (*ConfigPackageName) Severity() cop.Severity { return cop.Error }
 
-func (c *ConfigPackageName) Check(fset *token.FileSet, file *ast.File) []cop.Offense {
-	filename := fset.Position(file.Package).Filename
-	dir := configDir(filename)
+// NewConfigPackageName returns a fully configured ConfigPackageName cop.
+func NewConfigPackageName() *ConfigPackageName {
+	return &ConfigPackageName{Meta: cop.Meta{
+		CopName:     "Lint/ConfigPackageName",
+		CopDesc:     "Files under pkg/config/<dir>/ must declare package <dir>",
+		CopSeverity: cop.Error,
+	}}
+}
+
+func (c *ConfigPackageName) Check(p *cop.Pass) {
+	dir := configDir(p.Filename())
 	if dir == "" {
-		return nil
+		return
 	}
 
-	got := file.Name.Name
+	got := p.PackageName()
 	switch got {
 	case dir:
-		return nil
+		return
 	case dir + "_test":
 		// Black-box test packages are a legitimate Go convention.
-		if strings.HasSuffix(filename, "_test.go") {
-			return nil
+		if p.IsTestFile() {
+			return
 		}
 	}
 
-	return []cop.Offense{offense(c, fset, file.Name,
-		fmt.Sprintf("file in pkg/config/%s/ must declare package %s, got %s", dir, dir, got))}
+	p.Report(p.File.Name, "file in pkg/config/%s/ must declare package %s, got %s", dir, dir, got)
 }

--- a/lint/config_version_constant.go
+++ b/lint/config_version_constant.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"go/ast"
 	"go/token"
 	"strconv"
@@ -20,42 +19,40 @@ import (
 //
 // Files under pkg/config/latest/ are intentionally exempt: their `Version`
 // is the next, work-in-progress value (one greater than the highest vN).
-type ConfigVersionConstant struct{}
-
-func (*ConfigVersionConstant) Name() string { return "Lint/ConfigVersionConstant" }
-func (*ConfigVersionConstant) Description() string {
-	return "Version constant in pkg/config/vN/ must equal \"N\""
+type ConfigVersionConstant struct {
+	cop.Meta
 }
-func (*ConfigVersionConstant) Severity() cop.Severity { return cop.Error }
 
-func (c *ConfigVersionConstant) Check(fset *token.FileSet, file *ast.File) []cop.Offense {
-	dirVersion, ok := versionFromDir(configDir(fset.Position(file.Package).Filename))
+// NewConfigVersionConstant returns a fully configured ConfigVersionConstant cop.
+func NewConfigVersionConstant() *ConfigVersionConstant {
+	return &ConfigVersionConstant{Meta: cop.Meta{
+		CopName:     "Lint/ConfigVersionConstant",
+		CopDesc:     "Version constant in pkg/config/vN/ must equal \"N\"",
+		CopSeverity: cop.Error,
+	}}
+}
+
+func (c *ConfigVersionConstant) Check(p *cop.Pass) {
+	dirVersion, ok := versionFromDir(configDir(p.Filename()))
 	if !ok {
-		return nil
+		return
 	}
 	expected := strconv.Itoa(dirVersion)
 
-	var offenses []cop.Offense
-	for _, lit := range versionStringLiterals(file) {
+	for _, lit := range versionStringLiterals(p) {
 		got, err := strconv.Unquote(lit.Value)
 		if err != nil || got == expected {
 			continue
 		}
-		offenses = append(offenses, offense(c, fset, lit,
-			fmt.Sprintf("Version in pkg/config/v%s/ must be %q, got %q", expected, expected, got)))
+		p.Report(lit, "Version in pkg/config/v%s/ must be %q, got %q", expected, expected, got)
 	}
-	return offenses
 }
 
 // versionStringLiterals returns the value literal of every top-level
-// `const Version = "<string>"` declaration in file.
-func versionStringLiterals(file *ast.File) []*ast.BasicLit {
+// `const Version = "<string>"` declaration in the file under inspection.
+func versionStringLiterals(p *cop.Pass) []*ast.BasicLit {
 	var lits []*ast.BasicLit
-	for _, decl := range file.Decls {
-		gen, ok := decl.(*ast.GenDecl)
-		if !ok || gen.Tok != token.CONST {
-			continue
-		}
+	p.ForEachConst(func(gen *ast.GenDecl) {
 		for _, spec := range gen.Specs {
 			vs, ok := spec.(*ast.ValueSpec)
 			if !ok {
@@ -72,6 +69,6 @@ func versionStringLiterals(file *ast.File) []*ast.BasicLit {
 				lits = append(lits, lit)
 			}
 		}
-	}
+	})
 	return lits
 }

--- a/lint/config_version_import.go
+++ b/lint/config_version_import.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"fmt"
-	"go/ast"
-	"go/token"
 	"strings"
 
 	"github.com/dgageot/rubocop-go/cop"
@@ -13,47 +11,49 @@ import (
 // and pkg/config/latest) only import their immediate predecessor and the
 // shared types package, preserving the strict migration chain:
 // v0 → v1 → v2 → … → latest.
-type ConfigVersionImport struct{}
-
-func (*ConfigVersionImport) Name() string { return "Lint/ConfigVersionImport" }
-func (*ConfigVersionImport) Description() string {
-	return "Config version packages must only import their immediate predecessor"
+type ConfigVersionImport struct {
+	cop.Meta
 }
-func (*ConfigVersionImport) Severity() cop.Severity { return cop.Error }
 
-func (c *ConfigVersionImport) Check(fset *token.FileSet, file *ast.File) []cop.Offense {
-	if len(file.Imports) == 0 {
-		return nil
-	}
+// NewConfigVersionImport returns a fully configured ConfigVersionImport cop.
+func NewConfigVersionImport() *ConfigVersionImport {
+	return &ConfigVersionImport{Meta: cop.Meta{
+		CopName:     "Lint/ConfigVersionImport",
+		CopDesc:     "Config version packages must only import their immediate predecessor",
+		CopSeverity: cop.Error,
+	}}
+}
 
-	dir := configDir(fset.Position(file.Package).Filename)
-	if dir == "" {
-		return nil
+func (c *ConfigVersionImport) Check(p *cop.Pass) {
+	if len(p.File.Imports) == 0 {
+		return
 	}
 	// Black-box test files (package <dir>_test) are external to the package
 	// and may import what they please.
-	if strings.HasSuffix(file.Name.Name, "_test") {
-		return nil
+	if p.IsBlackBoxTest() {
+		return
 	}
 
+	dir := configDir(p.Filename())
+	if dir == "" {
+		return
+	}
 	dirVersion, isVersioned := versionFromDir(dir)
 	isLatest := dir == "latest"
 	if !isVersioned && !isLatest {
-		return nil
+		return
 	}
 
-	var offenses []cop.Offense
-	for _, imp := range file.Imports {
-		path := importPath(imp)
+	for _, imp := range p.File.Imports {
+		path := cop.ImportPath(imp)
 
 		if !strings.Contains(path, "pkg/config/") || strings.HasSuffix(path, "pkg/config/types") {
 			continue
 		}
 		if msg := importViolation(path, dirVersion, isLatest); msg != "" {
-			offenses = append(offenses, offense(c, fset, imp.Path, msg))
+			p.Report(imp.Path, "%s", msg)
 		}
 	}
-	return offenses
 }
 
 // importViolation returns a non-empty error message if the given import path

--- a/lint/config_versions_registered.go
+++ b/lint/config_versions_registered.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"go/ast"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/dgageot/rubocop-go/cop"
+)
+
+// ConfigVersionsRegistered enforces that pkg/config/versions.go registers
+// every config-version package that exists on disk.
+//
+// pkg/config/versions.go is the dispatch table for parsing and upgrading: it
+// builds the parser map by calling `Register` on each of v0…vN and `latest`.
+// When a new version is frozen (or an old one removed) the file must be
+// updated in lock-step, otherwise:
+//
+//   - a newly added vN/ has no parser and produces "unsupported config
+//     version" at runtime, which is invisible at compile time because
+//     versions.go does not import the new package, and
+//   - a removed vN/ would leave behind a dangling Register call and fail
+//     the build — already caught by the compiler — so this cop focuses on
+//     the silent-failure direction.
+//
+// The cop only inspects pkg/config/versions.go and reports any package that
+// exists under pkg/config/ but is not registered.
+type ConfigVersionsRegistered struct {
+	cop.Meta
+}
+
+// NewConfigVersionsRegistered returns a fully configured
+// ConfigVersionsRegistered cop.
+func NewConfigVersionsRegistered() *ConfigVersionsRegistered {
+	return &ConfigVersionsRegistered{Meta: cop.Meta{
+		CopName:     "Lint/ConfigVersionsRegistered",
+		CopDesc:     "pkg/config/versions.go must register every pkg/config/vN and pkg/config/latest package",
+		CopSeverity: cop.Error,
+	}}
+}
+
+func (c *ConfigVersionsRegistered) Check(p *cop.Pass) {
+	filename := p.Filename()
+	if !isVersionsGo(filename) {
+		return
+	}
+
+	want, err := versionPackagesOnDisk(filepath.Dir(filename))
+	if err != nil || len(want) == 0 {
+		return
+	}
+	got := registeredPackages(p)
+
+	var missing []string
+	for _, name := range want {
+		if !got[name] {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) == 0 {
+		return
+	}
+	slices.Sort(missing)
+
+	// Anchor the diagnostic on the function declaration so the message points
+	// at the registry rather than at the package clause.
+	p.Report(registryAnchor(p),
+		"pkg/config/versions.go is missing Register call(s) for: %s", strings.Join(missing, ", "))
+}
+
+// isVersionsGo reports whether filename is the canonical
+// pkg/config/versions.go used by the dispatch table.
+func isVersionsGo(filename string) bool {
+	slash := filepath.ToSlash(filename)
+	return strings.HasSuffix(slash, "/pkg/config/versions.go") || slash == "pkg/config/versions.go"
+}
+
+// versionPackagesOnDisk lists the package directories under pkg/config/ that
+// the dispatch table is expected to register: every vN/ and latest/.
+func versionPackagesOnDisk(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if name == "latest" {
+			names = append(names, name)
+			continue
+		}
+		if _, ok := versionFromDir(name); ok {
+			names = append(names, name)
+		}
+	}
+	slices.Sort(names)
+	return names, nil
+}
+
+// registeredPackages returns the set of package selectors that appear as
+// `<pkg>.Register(...)` call expressions anywhere in the file. The cop only
+// cares about whether a name is mentioned, not how many times.
+func registeredPackages(p *cop.Pass) map[string]bool {
+	got := map[string]bool{}
+	p.ForEachCall(func(call *ast.CallExpr) {
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "Register" {
+			return
+		}
+		ident, ok := sel.X.(*ast.Ident)
+		if !ok {
+			return
+		}
+		got[ident.Name] = true
+	})
+	return got
+}
+
+// registryAnchor picks the AST node used to position the offense. Preferring
+// the `versions` function declaration keeps the diagnostic close to the
+// dispatch table; if that function is absent (unexpected), the file's
+// package clause is used as a fallback.
+func registryAnchor(p *cop.Pass) ast.Node {
+	var anchor ast.Node = p.File.Name
+	p.ForEachFunc(func(fn *ast.FuncDecl) {
+		if fn.Name.Name == "versions" {
+			anchor = fn.Name
+		}
+	})
+	return anchor
+}

--- a/lint/configpath.go
+++ b/lint/configpath.go
@@ -1,16 +1,11 @@
 package main
 
 import (
-	"go/ast"
-	"go/token"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
-	"strings"
 	"sync"
-
-	"github.com/dgageot/rubocop-go/cop"
 )
 
 // Helpers shared by the cops in this package. They centralise the parsing of
@@ -61,16 +56,6 @@ func versionFromImport(importPath string) (int, bool) {
 		return 0, false
 	}
 	return n, true
-}
-
-// importPath returns the unquoted import path of an ImportSpec.
-func importPath(imp *ast.ImportSpec) string {
-	return strings.Trim(imp.Path.Value, `"`)
-}
-
-// offense builds an Offense covering the source span of node n.
-func offense(c cop.Cop, fset *token.FileSet, n ast.Node, message string) cop.Offense {
-	return cop.NewOffense(c, fset, n.Pos(), n.End(), message)
 }
 
 // highestSiblingVersion returns the largest N such that pkg/config/vN/

--- a/lint/hook_builtins_registered.go
+++ b/lint/hook_builtins_registered.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/dgageot/rubocop-go/cop"
+)
+
+// HookBuiltinsRegistered enforces that every builtin-name constant declared
+// under pkg/hooks/builtins/ is wired into the package's Register() function
+// in pkg/hooks/builtins/builtins.go.
+//
+// Each in-process builtin lives in its own file with a name constant and an
+// implementation:
+//
+//	pkg/hooks/builtins/add_date.go     : const AddDate = "add_date"
+//	                                     func addDate(...) { ... }
+//
+// The Register() function in builtins.go wires the constants to the
+// implementations:
+//
+//	r.RegisterBuiltin(AddDate, addDate),
+//
+// A new builtin file ships its own constant + impl, but the wiring is in a
+// different file. Forgetting that step compiles cleanly: the constant is
+// just an unused identifier (no error because it is exported), the impl
+// is dead code (also no error in another package), and the only signal
+// that something is wrong is a runtime "unknown builtin" failure when an
+// agent YAML references the new name.
+//
+// The cop runs on pkg/hooks/builtins/builtins.go (where Register() lives),
+// scans every *.go file in the same directory for `const Name = "wire"`
+// declarations whose value is a string literal, and reports any whose
+// identifier never appears as the first argument of a RegisterBuiltin
+// call in the inspected file.
+//
+// Files named builtins.go itself, *_test.go, and testhelpers_test.go are
+// excluded from the constant scan because they are not where new
+// builtins land.
+type HookBuiltinsRegistered struct {
+	cop.Meta
+}
+
+// NewHookBuiltinsRegistered returns a fully configured
+// HookBuiltinsRegistered cop.
+func NewHookBuiltinsRegistered() *HookBuiltinsRegistered {
+	return &HookBuiltinsRegistered{Meta: cop.Meta{
+		CopName:     "Lint/HookBuiltinsRegistered",
+		CopDesc:     "every builtin name constant under pkg/hooks/builtins/ must appear in a RegisterBuiltin call",
+		CopSeverity: cop.Error,
+	}}
+}
+
+func (c *HookBuiltinsRegistered) Check(p *cop.Pass) {
+	if !isHookBuiltinsRegisterFile(p.Filename()) {
+		return
+	}
+
+	declared, err := builtinNameConstants(filepath.Dir(p.Filename()))
+	if err != nil || len(declared) == 0 {
+		return
+	}
+
+	registered, anchor := registerBuiltinIdents(p)
+	if anchor == nil {
+		return
+	}
+
+	var missing []string
+	for _, name := range declared {
+		if !registered[name] {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) == 0 {
+		return
+	}
+	slices.Sort(missing)
+	p.Report(anchor,
+		"pkg/hooks/builtins/builtins.go is missing RegisterBuiltin call(s) for: %s",
+		strings.Join(missing, ", "))
+}
+
+// isHookBuiltinsRegisterFile reports whether filename is the canonical
+// pkg/hooks/builtins/builtins.go that owns the Register() entry point.
+func isHookBuiltinsRegisterFile(filename string) bool {
+	slash := filepath.ToSlash(filename)
+	return strings.HasSuffix(slash, "/pkg/hooks/builtins/builtins.go") ||
+		slash == "pkg/hooks/builtins/builtins.go"
+}
+
+// builtinNameConstants returns the identifier of every `const Name = "..."`
+// declaration in dir whose value is a string literal — but only from
+// per-builtin files. builtins.go itself and any _test.go files are
+// excluded so the cop doesn't flag them or pick up unrelated test
+// constants.
+func builtinNameConstants(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	fset := token.NewFileSet()
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		fname := e.Name()
+		if !strings.HasSuffix(fname, ".go") || strings.HasSuffix(fname, "_test.go") {
+			continue
+		}
+		if fname == "builtins.go" {
+			continue
+		}
+		f, err := parser.ParseFile(fset, filepath.Join(dir, fname), nil, 0)
+		if err != nil {
+			continue
+		}
+		for _, decl := range f.Decls {
+			gd, ok := decl.(*ast.GenDecl)
+			if !ok || gd.Tok != token.CONST {
+				continue
+			}
+			for _, spec := range gd.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for i, n := range vs.Names {
+					if i >= len(vs.Values) {
+						continue
+					}
+					lit, ok := vs.Values[i].(*ast.BasicLit)
+					if !ok || lit.Kind != token.STRING {
+						continue
+					}
+					if !ast.IsExported(n.Name) {
+						continue
+					}
+					names = append(names, n.Name)
+				}
+			}
+		}
+	}
+	slices.Sort(names)
+	names = slices.Compact(names)
+	return names, nil
+}
+
+// registerBuiltinIdents collects the set of identifiers that appear as the
+// first positional argument of a `RegisterBuiltin(<name>, …)` call anywhere
+// in the inspected file. It also returns the call expression that the cop
+// uses to anchor diagnostics; nil means no Register() body was found and
+// the cop should bail out.
+func registerBuiltinIdents(p *cop.Pass) (map[string]bool, ast.Node) {
+	registered := map[string]bool{}
+	var anchor ast.Node
+	p.ForEachCall(func(call *ast.CallExpr) {
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "RegisterBuiltin" || len(call.Args) == 0 {
+			return
+		}
+		if anchor == nil {
+			anchor = call
+		}
+		id, ok := call.Args[0].(*ast.Ident)
+		if !ok {
+			return
+		}
+		registered[id.Name] = true
+	})
+	if anchor == nil {
+		// Fall back to the file's package clause so the diagnostic still
+		// surfaces if Register() was reshaped beyond recognition.
+		anchor = p.File.Name
+	}
+	return registered, anchor
+}

--- a/lint/hook_config_sync.go
+++ b/lint/hook_config_sync.go
@@ -1,0 +1,210 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/dgageot/rubocop-go/cop"
+)
+
+// HookConfigSync enforces that the EventXxx constants in pkg/hooks/types.go
+// stay in lock-step with the HooksConfig fields in pkg/config/latest/types.go.
+//
+// The two are coupled: every hook event the runtime knows how to dispatch
+// has to be configurable in the agent YAML, and every YAML field has to
+// correspond to an event the runtime actually fires. The mapping is by
+// snake-case wire string:
+//
+//	pkg/hooks/types.go        : EventPreToolUse EventType = "pre_tool_use"
+//	pkg/config/latest/types.go: PreToolUse []HookMatcherConfig `json:"pre_tool_use,…"`
+//
+// Drift in either direction is silently broken at runtime:
+//
+//   - A new EventXxx constant without a matching HooksConfig field means
+//     the YAML schema cannot express that hook — users have no way to
+//     register one, and the event fires with no listeners.
+//   - A new HooksConfig field without a matching EventXxx constant means
+//     the runtime parses the YAML but never dispatches the event — the
+//     hook is wired up but inert.
+//
+// Neither failure mode produces a build error or a runtime warning. The
+// cop runs on pkg/config/latest/types.go (where the diagnostic anchors
+// on the HooksConfig type spec) and parses pkg/hooks/types.go from disk
+// for the source of truth.
+type HookConfigSync struct {
+	cop.Meta
+}
+
+// NewHookConfigSync returns a fully configured HookConfigSync cop.
+func NewHookConfigSync() *HookConfigSync {
+	return &HookConfigSync{Meta: cop.Meta{
+		CopName:     "Lint/HookConfigSync",
+		CopDesc:     "EventXxx constants in pkg/hooks/types.go must match HooksConfig fields in pkg/config/latest",
+		CopSeverity: cop.Error,
+	}}
+}
+
+func (c *HookConfigSync) Check(p *cop.Pass) {
+	if !isLatestConfigTypesGo(p.Filename()) {
+		return
+	}
+
+	hookEvents, err := readHookEventConstants(hooksTypesGoPath(p.Filename()))
+	if err != nil || len(hookEvents) == 0 {
+		return
+	}
+
+	cfgFields, hooksConfigSpec := readHooksConfigFields(p)
+	if hooksConfigSpec == nil {
+		// Schema didn't ship HooksConfig (or this isn't the right
+		// types.go) — nothing meaningful the cop can say.
+		return
+	}
+
+	// Build reverse map for diagnostics.
+	cfgByJSON := map[string]string{} // wire-string -> Go field name
+	for goName, jsonName := range cfgFields {
+		cfgByJSON[jsonName] = goName
+	}
+
+	// Direction 1: every event must have a config field.
+	var missingFields []string
+	for constName, wire := range hookEvents {
+		if _, ok := cfgByJSON[wire]; !ok {
+			missingFields = append(missingFields, constName+"="+strconv.Quote(wire))
+		}
+	}
+	if len(missingFields) > 0 {
+		slices.Sort(missingFields)
+		p.Report(hooksConfigSpec.Name,
+			"HooksConfig is missing field(s) for hook event(s): %s", strings.Join(missingFields, ", "))
+	}
+
+	// Direction 2: every config field must have an event constant.
+	wireSet := map[string]string{} // wire -> const name
+	for n, w := range hookEvents {
+		wireSet[w] = n
+	}
+	var orphanFields []string
+	for goName, jsonName := range cfgFields {
+		if _, ok := wireSet[jsonName]; !ok {
+			orphanFields = append(orphanFields, goName+" json:"+strconv.Quote(jsonName))
+		}
+	}
+	if len(orphanFields) > 0 {
+		slices.Sort(orphanFields)
+		p.Report(hooksConfigSpec.Name,
+			"HooksConfig field(s) without a matching EventXxx constant in pkg/hooks/types.go: %s",
+			strings.Join(orphanFields, ", "))
+	}
+}
+
+// isLatestConfigTypesGo reports whether filename is the canonical
+// pkg/config/latest/types.go that owns HooksConfig.
+func isLatestConfigTypesGo(filename string) bool {
+	slash := filepath.ToSlash(filename)
+	return strings.HasSuffix(slash, "/pkg/config/latest/types.go") ||
+		slash == "pkg/config/latest/types.go"
+}
+
+// hooksTypesGoPath returns the location of pkg/hooks/types.go relative to
+// the repository root inferred from the latest config file's path. The
+// cop walks up from `.../pkg/config/latest/types.go` to find the repo root.
+func hooksTypesGoPath(latestTypesGo string) string {
+	// .../pkg/config/latest/types.go -> .../pkg/hooks/types.go
+	return filepath.Join(filepath.Dir(filepath.Dir(filepath.Dir(latestTypesGo))), "hooks", "types.go")
+}
+
+// readHookEventConstants parses the file at path and returns a map of
+// EventXxx constant name -> string value for every const whose name
+// starts with "Event" and whose value is a string literal.
+func readHookEventConstants(path string) (map[string]string, error) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]string{}
+	for _, decl := range f.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok || gd.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gd.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, name := range vs.Names {
+				if !strings.HasPrefix(name.Name, "Event") {
+					continue
+				}
+				if i >= len(vs.Values) {
+					continue
+				}
+				lit, ok := vs.Values[i].(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					continue
+				}
+				val, err := strconv.Unquote(lit.Value)
+				if err != nil {
+					continue
+				}
+				out[name.Name] = val
+			}
+		}
+	}
+	return out, nil
+}
+
+// readHooksConfigFields scans the file in p for the HooksConfig type and
+// returns the field-name -> json-tag-name map together with the type spec
+// itself (so the caller can anchor diagnostics on it).
+func readHooksConfigFields(p *cop.Pass) (map[string]string, *ast.TypeSpec) {
+	fields := map[string]string{}
+	var spec *ast.TypeSpec
+	for _, decl := range p.File.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok {
+			continue
+		}
+		for _, s := range gd.Specs {
+			ts, ok := s.(*ast.TypeSpec)
+			if !ok || ts.Name.Name != "HooksConfig" {
+				continue
+			}
+			st, ok := ts.Type.(*ast.StructType)
+			if !ok {
+				continue
+			}
+			spec = ts
+			for _, fld := range st.Fields.List {
+				if fld.Tag == nil {
+					continue
+				}
+				raw, err := strconv.Unquote(fld.Tag.Value)
+				if err != nil {
+					continue
+				}
+				jsonTag, ok := reflect.StructTag(raw).Lookup("json")
+				if !ok {
+					continue
+				}
+				name, _, _ := strings.Cut(jsonTag, ",")
+				if name == "" || name == "-" {
+					continue
+				}
+				for _, n := range fld.Names {
+					fields[n.Name] = name
+				}
+			}
+		}
+	}
+	return fields, spec
+}

--- a/lint/latest_imports_predecessor.go
+++ b/lint/latest_imports_predecessor.go
@@ -1,11 +1,6 @@
 package main
 
 import (
-	"fmt"
-	"go/ast"
-	"go/token"
-	"strings"
-
 	"github.com/dgageot/rubocop-go/cop"
 )
 
@@ -18,40 +13,41 @@ import (
 // This cop closes that gap so pkg/config/latest also obeys the chain
 // (latest imports the highest vN, never an older version), which is required
 // for the upgrade pipeline to reach the latest schema in a single hop.
-type LatestImportsPredecessor struct{}
-
-func (*LatestImportsPredecessor) Name() string { return "Lint/LatestImportsPredecessor" }
-func (*LatestImportsPredecessor) Description() string {
-	return "pkg/config/latest must only import its immediate predecessor (highest vN)"
+type LatestImportsPredecessor struct {
+	cop.Meta
 }
-func (*LatestImportsPredecessor) Severity() cop.Severity { return cop.Error }
 
-func (c *LatestImportsPredecessor) Check(fset *token.FileSet, file *ast.File) []cop.Offense {
-	if len(file.Imports) == 0 {
-		return nil
-	}
-	filename := fset.Position(file.Package).Filename
-	if configDir(filename) != "latest" {
-		return nil
+// NewLatestImportsPredecessor returns a fully configured LatestImportsPredecessor cop.
+func NewLatestImportsPredecessor() *LatestImportsPredecessor {
+	return &LatestImportsPredecessor{Meta: cop.Meta{
+		CopName:     "Lint/LatestImportsPredecessor",
+		CopDesc:     "pkg/config/latest must only import its immediate predecessor (highest vN)",
+		CopSeverity: cop.Error,
+	}}
+}
+
+func (c *LatestImportsPredecessor) Check(p *cop.Pass) {
+	if len(p.File.Imports) == 0 {
+		return
 	}
 	// Black-box test files (package latest_test) are external to the package
 	// and may import what they please.
-	if strings.HasSuffix(file.Name.Name, "_test") {
-		return nil
+	if p.IsBlackBoxTest() {
+		return
 	}
-	highest, ok := highestSiblingVersion(filename)
+	if configDir(p.Filename()) != "latest" {
+		return
+	}
+	highest, ok := highestSiblingVersion(p.Filename())
 	if !ok {
-		return nil
+		return
 	}
 
-	var offenses []cop.Offense
-	for _, imp := range file.Imports {
-		got, ok := versionFromImport(importPath(imp))
+	for _, imp := range p.File.Imports {
+		got, ok := versionFromImport(cop.ImportPath(imp))
 		if !ok || got == highest {
 			continue
 		}
-		offenses = append(offenses, offense(c, fset, imp.Path,
-			fmt.Sprintf("pkg/config/latest must import its predecessor v%d, not v%d", highest, got)))
+		p.Report(imp.Path, "pkg/config/latest must import its predecessor v%d, not v%d", highest, got)
 	}
-	return offenses
 }

--- a/lint/main.go
+++ b/lint/main.go
@@ -23,6 +23,8 @@ func allCops() []cop.Cop {
 		NewConfigLatestTagConsistency(),
 		NewConfigVersionsRegistered(),
 		NewTUIViewPurity(),
+		NewRuntimeEventRegistry(),
+		NewRuntimeSessionScoped(),
 	}
 }
 

--- a/lint/main.go
+++ b/lint/main.go
@@ -12,27 +12,24 @@ import (
 	"github.com/dgageot/rubocop-go/runner"
 )
 
-// cops is the registry of project-specific cops, in declaration order.
+// allCops returns the project-specific cops, in declaration order.
 // To add a cop: implement cop.Cop and append it here.
-var cops = []cop.Cop{
-	&ConfigVersionImport{},
-	&ConfigPackageName{},
-	&ConfigVersionConstant{},
-	&LatestImportsPredecessor{},
+func allCops() []cop.Cop {
+	return []cop.Cop{
+		NewConfigVersionImport(),
+		NewConfigPackageName(),
+		NewConfigVersionConstant(),
+		NewLatestImportsPredecessor(),
+	}
 }
 
 func main() {
-	for _, c := range cops {
-		cop.Register(c)
-	}
-	fmt.Printf("Inspecting Go files with %d cop(s)\n", len(cops))
-
 	paths := os.Args[1:]
 	if len(paths) == 0 {
 		paths = []string{"."}
 	}
 
-	r := runner.New(cop.All(), config.DefaultConfig(), os.Stdout)
+	r := runner.New(allCops(), config.DefaultConfig(), os.Stdout)
 	offenseCount, err := r.Run(paths)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)

--- a/lint/main.go
+++ b/lint/main.go
@@ -25,6 +25,8 @@ func allCops() []cop.Cop {
 		NewTUIViewPurity(),
 		NewRuntimeEventRegistry(),
 		NewRuntimeSessionScoped(),
+		NewHookConfigSync(),
+		NewHookBuiltinsRegistered(),
 	}
 }
 

--- a/lint/main.go
+++ b/lint/main.go
@@ -20,6 +20,9 @@ func allCops() []cop.Cop {
 		NewConfigPackageName(),
 		NewConfigVersionConstant(),
 		NewLatestImportsPredecessor(),
+		NewConfigLatestTagConsistency(),
+		NewConfigVersionsRegistered(),
+		NewTUIViewPurity(),
 	}
 }
 

--- a/lint/runtime_event_registry.go
+++ b/lint/runtime_event_registry.go
@@ -1,0 +1,242 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/dgageot/rubocop-go/cop"
+)
+
+// RuntimeEventRegistry enforces that pkg/runtime/client.go registers every
+// runtime event type defined in pkg/runtime/event.go.
+//
+// The remote-runtime client decodes incoming JSON events by reading the
+// "type" discriminator and looking it up in a static registry built in
+// pkg/runtime/client.go:
+//
+//	registry: map[string]func() Event{
+//	    "user_message": func() Event { return &UserMessageEvent{} },
+//	    …
+//	}
+//
+// When an event type appears in the JSON stream but not in the registry the
+// client logs a single Debug-level "invalid_type" line and silently drops
+// the event. That is essentially invisible: a sub-agent's
+// MessageAddedEvent, ModelFallbackEvent or SubSessionCompletedEvent
+// reaching a remote frontend would never be rendered, with no visible
+// error.
+//
+// The cop runs on pkg/runtime/client.go (the registry's home) and
+// cross-references every &XxxEvent{Type: "yyy"} composite literal it
+// finds in pkg/runtime/event.go. Each event type whose Type-string is
+// missing from the registry is reported with a diagnostic anchored on
+// the registry map literal, where the fix lives.
+type RuntimeEventRegistry struct {
+	cop.Meta
+}
+
+// NewRuntimeEventRegistry returns a fully configured RuntimeEventRegistry cop.
+func NewRuntimeEventRegistry() *RuntimeEventRegistry {
+	return &RuntimeEventRegistry{Meta: cop.Meta{
+		CopName:     "Lint/RuntimeEventRegistry",
+		CopDesc:     "pkg/runtime/client.go must register every runtime event type",
+		CopSeverity: cop.Error,
+	}}
+}
+
+func (c *RuntimeEventRegistry) Check(p *cop.Pass) {
+	if !isRuntimeClientGo(p.Filename()) {
+		return
+	}
+
+	// Sibling event.go is the source of truth for the set of emitted events.
+	eventGo := filepath.Join(filepath.Dir(p.Filename()), "event.go")
+	emitted, err := emittedEventTypes(eventGo)
+	if err != nil || len(emitted) == 0 {
+		return
+	}
+
+	registryNode, registered := registryEntries(p)
+	if registryNode == nil {
+		return
+	}
+
+	var missing []string
+	for typeName, typeStr := range emitted {
+		if got, ok := registered[typeStr]; !ok {
+			missing = append(missing, typeName+" (Type: "+strconv.Quote(typeStr)+")")
+		} else if got != typeName {
+			// The registry key is correct but it constructs the wrong
+			// concrete type. That is a different bug from "missing entry"
+			// so we keep it as a separate diagnostic anchored on the
+			// registry map for clarity.
+			p.Report(registryNode,
+				"registry key %q constructs %s but %s emits Type=%q",
+				typeStr, got, typeName, typeStr)
+		}
+	}
+	if len(missing) == 0 {
+		return
+	}
+	slices.Sort(missing)
+	p.Report(registryNode,
+		"pkg/runtime/client.go is missing registry entries for: %s", strings.Join(missing, ", "))
+}
+
+// isRuntimeClientGo reports whether filename is the canonical
+// pkg/runtime/client.go that owns the event-decoder registry.
+func isRuntimeClientGo(filename string) bool {
+	slash := filepath.ToSlash(filename)
+	return strings.HasSuffix(slash, "/pkg/runtime/client.go") || slash == "pkg/runtime/client.go"
+}
+
+// emittedEventTypes returns a map of EventTypeName -> wire-format Type
+// string for every &XxxEvent{Type: "yyy"} composite literal in the file
+// at path (typically pkg/runtime/event.go). Constructors that don't
+// initialise the Type field are skipped — a separate cop could enforce
+// that they always do.
+func emittedEventTypes(path string) (map[string]string, error) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		return nil, err
+	}
+	emitted := map[string]string{}
+	ast.Inspect(f, func(n ast.Node) bool {
+		cl, ok := n.(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		id, ok := cl.Type.(*ast.Ident)
+		if !ok || !strings.HasSuffix(id.Name, "Event") {
+			return true
+		}
+		for _, elt := range cl.Elts {
+			kv, ok := elt.(*ast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+			k, ok := kv.Key.(*ast.Ident)
+			if !ok || k.Name != "Type" {
+				continue
+			}
+			lit, ok := kv.Value.(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				continue
+			}
+			val, err := strconv.Unquote(lit.Value)
+			if err != nil {
+				continue
+			}
+			emitted[id.Name] = val
+		}
+		return true
+	})
+	return emitted, nil
+}
+
+// registryEntries finds the registry map literal in pkg/runtime/client.go and
+// returns it together with a typeString -> EventTypeName mapping built from
+// its `"type-string": func() Event { return &XxxEvent{} }` entries.
+//
+// The registry is identified syntactically as the only map[string]func() Event
+// composite literal in the file. Returning the literal itself lets the
+// caller anchor diagnostics on the map so the diff is obvious.
+func registryEntries(p *cop.Pass) (ast.Node, map[string]string) {
+	var found *ast.CompositeLit
+	registered := map[string]string{}
+	ast.Inspect(p.File, func(n ast.Node) bool {
+		cl, ok := n.(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		if !isEventRegistryType(cl.Type) {
+			return true
+		}
+		found = cl
+		for _, elt := range cl.Elts {
+			kv, ok := elt.(*ast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+			klit, ok := kv.Key.(*ast.BasicLit)
+			if !ok || klit.Kind != token.STRING {
+				continue
+			}
+			key, err := strconv.Unquote(klit.Value)
+			if err != nil {
+				continue
+			}
+			if name, ok := returnedEventType(kv.Value); ok {
+				registered[key] = name
+			}
+		}
+		return false
+	})
+	if found == nil {
+		return nil, nil
+	}
+	return found, registered
+}
+
+// isEventRegistryType reports whether expr describes the registry's value
+// type, i.e. `map[string]func() Event`. The check is syntactic: the cop
+// runs without type information.
+func isEventRegistryType(expr ast.Expr) bool {
+	mt, ok := expr.(*ast.MapType)
+	if !ok {
+		return false
+	}
+	keyID, ok := mt.Key.(*ast.Ident)
+	if !ok || keyID.Name != "string" {
+		return false
+	}
+	ft, ok := mt.Value.(*ast.FuncType)
+	if !ok {
+		return false
+	}
+	if ft.Params != nil && len(ft.Params.List) != 0 {
+		return false
+	}
+	if ft.Results == nil || len(ft.Results.List) != 1 {
+		return false
+	}
+	rid, ok := ft.Results.List[0].Type.(*ast.Ident)
+	return ok && rid.Name == "Event"
+}
+
+// returnedEventType pulls "FooEvent" out of a `func() Event { return &FooEvent{} }`
+// literal. Returns "" if the closure has any other shape, in which case the
+// cop simply ignores the entry (an unrelated map happening to share the
+// registry's value type would otherwise produce noise).
+func returnedEventType(expr ast.Expr) (string, bool) {
+	fl, ok := expr.(*ast.FuncLit)
+	if !ok || fl.Body == nil {
+		return "", false
+	}
+	for _, stmt := range fl.Body.List {
+		ret, ok := stmt.(*ast.ReturnStmt)
+		if !ok || len(ret.Results) != 1 {
+			continue
+		}
+		ue, ok := ret.Results[0].(*ast.UnaryExpr)
+		if !ok || ue.Op != token.AND {
+			continue
+		}
+		cl, ok := ue.X.(*ast.CompositeLit)
+		if !ok {
+			continue
+		}
+		id, ok := cl.Type.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		return id.Name, true
+	}
+	return "", false
+}

--- a/lint/runtime_session_scoped.go
+++ b/lint/runtime_session_scoped.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"go/ast"
+	"path/filepath"
+	"strings"
+
+	"github.com/dgageot/rubocop-go/cop"
+)
+
+// RuntimeSessionScoped enforces that every runtime event struct carrying a
+// SessionID field also implements the SessionScoped interface, i.e. exposes
+// a `GetSessionID() string` method on its pointer receiver.
+//
+// SessionScoped is the discriminator the persistence pipeline uses to keep
+// sub-agent events out of the parent session's transcript:
+//
+//	if scoped, ok := event.(SessionScoped); ok && scoped.GetSessionID() != sess.ID {
+//	    return // forwarded sub-agent event for a different session — drop
+//	}
+//
+// An event that carries SessionID but skips the method silently bypasses the
+// filter — the type assertion fails, the conditional short-circuits, and
+// the event is persisted into whatever session happens to be on the parent
+// observer when it arrives. That contaminates transcripts with sub-agent
+// chatter and there is no signal at the call site to suggest the rule was
+// missed.
+//
+// The cop runs on pkg/runtime/event.go and reports any *Event struct with
+// a SessionID field whose pointer type lacks GetSessionID().
+type RuntimeSessionScoped struct {
+	cop.Meta
+}
+
+// NewRuntimeSessionScoped returns a fully configured RuntimeSessionScoped cop.
+func NewRuntimeSessionScoped() *RuntimeSessionScoped {
+	return &RuntimeSessionScoped{Meta: cop.Meta{
+		CopName:     "Lint/RuntimeSessionScoped",
+		CopDesc:     "runtime events with a SessionID field must implement GetSessionID() (SessionScoped)",
+		CopSeverity: cop.Error,
+	}}
+}
+
+func (c *RuntimeSessionScoped) Check(p *cop.Pass) {
+	if !isRuntimeEventGo(p.Filename()) {
+		return
+	}
+
+	withSessionID := eventStructsWithSessionID(p)
+	if len(withSessionID) == 0 {
+		return
+	}
+	implementsScoped := pointerReceiversWithMethod(p, "GetSessionID")
+
+	for typeName, typeSpec := range withSessionID {
+		if !implementsScoped[typeName] {
+			p.Report(typeSpec.Name,
+				"%s carries a SessionID field but does not implement GetSessionID() (SessionScoped); "+
+					"sub-agent events of this type would bypass the persistence-observer session filter",
+				typeName)
+		}
+	}
+}
+
+// isRuntimeEventGo reports whether filename is the canonical
+// pkg/runtime/event.go that defines all runtime event types.
+func isRuntimeEventGo(filename string) bool {
+	slash := filepath.ToSlash(filename)
+	return strings.HasSuffix(slash, "/pkg/runtime/event.go") || slash == "pkg/runtime/event.go"
+}
+
+// eventStructsWithSessionID maps EventTypeName -> its declaring *ast.TypeSpec
+// for every top-level struct type whose name ends in "Event" and that
+// declares (or transitively re-declares via its own field — embedded fields
+// are out of scope here) a SessionID field.
+func eventStructsWithSessionID(p *cop.Pass) map[string]*ast.TypeSpec {
+	out := map[string]*ast.TypeSpec{}
+	for _, decl := range p.File.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok {
+			continue
+		}
+		for _, spec := range gd.Specs {
+			ts, ok := spec.(*ast.TypeSpec)
+			if !ok || !strings.HasSuffix(ts.Name.Name, "Event") {
+				continue
+			}
+			st, ok := ts.Type.(*ast.StructType)
+			if !ok || st.Fields == nil {
+				continue
+			}
+			for _, fld := range st.Fields.List {
+				for _, name := range fld.Names {
+					if name.Name == "SessionID" {
+						out[ts.Name.Name] = ts
+					}
+				}
+			}
+		}
+	}
+	return out
+}
+
+// pointerReceiversWithMethod returns the set of type names T for which the
+// file declares `func (* T) <method>(...)`. Used to detect interface
+// satisfaction without invoking the type checker.
+func pointerReceiversWithMethod(p *cop.Pass, method string) map[string]bool {
+	with := map[string]bool{}
+	p.ForEachFunc(func(fn *ast.FuncDecl) {
+		if fn.Name.Name != method || fn.Recv == nil || len(fn.Recv.List) != 1 {
+			return
+		}
+		star, ok := fn.Recv.List[0].Type.(*ast.StarExpr)
+		if !ok {
+			return
+		}
+		id, ok := star.X.(*ast.Ident)
+		if !ok {
+			return
+		}
+		with[id.Name] = true
+	})
+	return with
+}

--- a/lint/tui_view_purity.go
+++ b/lint/tui_view_purity.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"go/ast"
+	"go/token"
+	"strings"
+
+	"github.com/dgageot/rubocop-go/cop"
+)
+
+// TUIViewPurity enforces that `View() string` methods on TUI models do not
+// mutate the receiver's fields. This is the Bubble Tea / Elm-Architecture
+// purity contract: rendering must be a pure function of state, otherwise
+// rendering twice in a row can produce different output and the runtime is
+// free to do exactly that (e.g. on resize, on a missed alt-screen redraw).
+//
+// The cop runs on every Go file under pkg/tui/ and inspects each method
+// named View whose signature is `View() string`. Any assignment whose
+// left-hand side is `recv.field` is flagged, with two pragmatic exemptions:
+//
+//   - Slice cache patterns are allowed:
+//     recv.field = nil
+//     recv.field = recv.field[:0]
+//     recv.field = append(recv.field, …)
+//     These are common for click-zone caches that View populates while
+//     rendering and Update consumes when handling mouse events. They are a
+//     known compromise; the field is not used elsewhere in View to influence
+//     control flow.
+//
+//   - Lines carrying a //rubocop:disable Lint/TUIViewPurity comment (the
+//     rubocop-go suppression form, distinct from golangci-lint's //nolint
+//     so the two tools do not validate each other's rule names) are
+//     skipped, allowing deliberate caches to be marked locally with a
+//     short justification.
+//
+// Anything else — assigning a literal, a method call result, or a value
+// that is also read elsewhere in View — is reported. Such mutations make
+// View() effectively part of the state machine, which is exactly what
+// Update() exists for.
+type TUIViewPurity struct {
+	cop.Meta
+}
+
+// NewTUIViewPurity returns a fully configured TUIViewPurity cop.
+func NewTUIViewPurity() *TUIViewPurity {
+	return &TUIViewPurity{Meta: cop.Meta{
+		CopName:     "Lint/TUIViewPurity",
+		CopDesc:     "View() methods on TUI models must not mutate the receiver",
+		CopSeverity: cop.Warning,
+	}}
+}
+
+func (c *TUIViewPurity) Check(p *cop.Pass) {
+	if !isTUIFile(p.Filename()) {
+		return
+	}
+
+	suppress := suppressedLines(p, c.Name())
+
+	p.ForEachFunc(func(fn *ast.FuncDecl) {
+		recv, ok := pointerReceiver(fn)
+		if !ok || !isViewMethod(fn) {
+			return
+		}
+		c.checkBody(p, fn.Body, recv, suppress)
+	})
+}
+
+// checkBody walks fn body and reports an offense for every assignment to a
+// receiver field that is not part of the slice-cache exemption set.
+func (c *TUIViewPurity) checkBody(p *cop.Pass, body *ast.BlockStmt, recv string, suppress map[int]bool) {
+	if body == nil {
+		return
+	}
+	ast.Inspect(body, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok || assign.Tok != token.ASSIGN {
+			return true
+		}
+		for i, lhs := range assign.Lhs {
+			field, ok := receiverField(lhs, recv)
+			if !ok {
+				continue
+			}
+			if i < len(assign.Rhs) && isSliceCachePattern(assign.Rhs[i], recv, field) {
+				continue
+			}
+			line := p.FileSet.Position(assign.Pos()).Line
+			if suppress[line] {
+				continue
+			}
+			p.Report(assign,
+				"View() must not mutate %s.%s; move the side effect to Update or compute it in a local variable"+
+					" (or annotate the line with //rubocop:disable Lint/TUIViewPurity if it is an intentional click-zone cache)",
+				recv, field)
+		}
+		return true
+	})
+}
+
+// pointerReceiver returns the receiver name when fn has exactly one
+// pointer receiver, e.g. (d *fooDialog).
+func pointerReceiver(fn *ast.FuncDecl) (string, bool) {
+	if fn.Recv == nil || len(fn.Recv.List) != 1 {
+		return "", false
+	}
+	r := fn.Recv.List[0]
+	if _, ok := r.Type.(*ast.StarExpr); !ok {
+		return "", false
+	}
+	if len(r.Names) == 0 {
+		return "", false
+	}
+	return r.Names[0].Name, true
+}
+
+// isViewMethod reports whether fn is exactly `func (...) View() string`.
+// The cop intentionally ignores helpers that happen to be called View*
+// because they are not part of the Bubble Tea contract.
+func isViewMethod(fn *ast.FuncDecl) bool {
+	if fn.Name.Name != "View" {
+		return false
+	}
+	if fn.Type.Params != nil && len(fn.Type.Params.List) > 0 {
+		return false
+	}
+	if fn.Type.Results == nil || len(fn.Type.Results.List) != 1 {
+		return false
+	}
+	id, ok := fn.Type.Results.List[0].Type.(*ast.Ident)
+	return ok && id.Name == "string"
+}
+
+// receiverField returns the field name when expr is `recv.<field>` (a direct
+// selector on the receiver) and reports whether the match succeeded.
+// Nested selectors like recv.sub.field are intentionally not flagged because
+// the cop cannot tell whether `recv.sub` aliases the receiver state.
+func receiverField(expr ast.Expr, recv string) (string, bool) {
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return "", false
+	}
+	id, ok := sel.X.(*ast.Ident)
+	if !ok || id.Name != recv {
+		return "", false
+	}
+	return sel.Sel.Name, true
+}
+
+// isSliceCachePattern reports whether rhs is one of the recognised
+// "slice cache" idioms for the field recv.field:
+//
+//	nil
+//	recv.field[:0]
+//	append(recv.field, …)
+//
+// These are the shapes used by the click-zone caches that several TUI
+// components populate during rendering.
+func isSliceCachePattern(rhs ast.Expr, recv, field string) bool {
+	if id, ok := rhs.(*ast.Ident); ok && id.Name == "nil" {
+		return true
+	}
+	if slc, ok := rhs.(*ast.SliceExpr); ok && isReceiverField(slc.X, recv, field) {
+		return true
+	}
+	if call, ok := rhs.(*ast.CallExpr); ok {
+		if id, ok := call.Fun.(*ast.Ident); ok && id.Name == "append" && len(call.Args) > 0 {
+			if isReceiverField(call.Args[0], recv, field) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isReceiverField reports whether expr is exactly `recv.field`.
+func isReceiverField(expr ast.Expr, recv, field string) bool {
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	id, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	return id.Name == recv && sel.Sel.Name == field
+}
+
+// isTUIFile reports whether filename lives under pkg/tui/, which is where
+// Bubble Tea models are defined. The cop is scoped to this directory so
+// that ad-hoc View() helpers elsewhere in the repository (e.g. test fakes)
+// are not subject to the rule.
+func isTUIFile(filename string) bool {
+	slash := strings.ReplaceAll(filename, "\\", "/")
+	return strings.Contains(slash, "/pkg/tui/") || strings.HasPrefix(slash, "pkg/tui/")
+}
+
+// suppressedLines builds the set of source lines that carry a
+// //rubocop:disable <copName> comment. The directive intentionally uses a
+// different prefix from golangci-lint's //nolint so that the two tools do
+// not validate each other's rule names — golangci-lint's `nolintlint`
+// rejects custom cops it has never heard of.
+// Both inline trailing comments and full-line comments above the
+// offending statement are honoured (covering the line on which the
+// comment ends and the next line, respectively).
+func suppressedLines(p *cop.Pass, copName string) map[int]bool {
+	suppressed := map[int]bool{}
+	for _, group := range p.File.Comments {
+		for _, c := range group.List {
+			if !mentionsCop(c.Text, copName) {
+				continue
+			}
+			pos := p.FileSet.Position(c.Slash)
+			end := p.FileSet.Position(c.End())
+			// Inline comment: applies to the line where the comment ends
+			// (Go scanner positions inline //... on the same line as code).
+			suppressed[end.Line] = true
+			// Full-line comment: applies to the next non-blank line.
+			suppressed[pos.Line+1] = true
+		}
+	}
+	return suppressed
+}
+
+// mentionsCop reports whether comment is a //rubocop:disable directive that
+// names copName (case-sensitive, matched as a comma-separated token to
+// avoid substring false positives such as "Lint/TUIViewPurityExtra").
+func mentionsCop(comment, copName string) bool {
+	const prefix = "//rubocop:disable"
+	rest, ok := strings.CutPrefix(comment, prefix)
+	if !ok {
+		return false
+	}
+	rest = strings.TrimLeft(rest, " \t")
+	// Trim any trailing " // explanation" that follows the directive.
+	if idx := strings.Index(rest, " "); idx >= 0 {
+		rest = rest[:idx]
+	}
+	for name := range strings.SplitSeq(rest, ",") {
+		if strings.TrimSpace(name) == copName {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -780,7 +780,7 @@ type Toolset struct {
 	// model name from the models section or "provider/model" (e.g. "openai/gpt-4o-mini").
 	Model string `json:"model,omitempty"`
 
-	Defer DeferConfig `json:"defer" yaml:"defer,omitempty"`
+	Defer DeferConfig `json:"defer,omitzero" yaml:"defer,omitempty"`
 
 	// For the `mcp` tool
 	Command string   `json:"command,omitempty"`

--- a/pkg/runtime/client.go
+++ b/pkg/runtime/client.go
@@ -90,6 +90,9 @@ func NewClient(baseURL string, opts ...ClientOption) (*Client, error) {
 			"rag_indexing_started":   func() Event { return &RAGIndexingStartedEvent{} },
 			"rag_indexing_progress":  func() Event { return &RAGIndexingProgressEvent{} },
 			"rag_indexing_completed": func() Event { return &RAGIndexingCompletedEvent{} },
+			"message_added":          func() Event { return &MessageAddedEvent{} },
+			"model_fallback":         func() Event { return &ModelFallbackEvent{} },
+			"sub_session_completed":  func() Event { return &SubSessionCompletedEvent{} },
 		},
 	}
 

--- a/pkg/runtime/event.go
+++ b/pkg/runtime/event.go
@@ -62,6 +62,8 @@ func UserMessage(message, sessionID string, multiContent []chat.MessagePart, ses
 	}
 }
 
+func (e *UserMessageEvent) GetSessionID() string { return e.SessionID }
+
 // PartialToolCallEvent is sent when a tool call is first received (partial/complete)
 type PartialToolCallEvent struct {
 	AgentContext
@@ -155,6 +157,8 @@ func StreamStarted(sessionID, agentName string) Event {
 		AgentContext: newAgentContext(agentName),
 	}
 }
+
+func (e *StreamStartedEvent) GetSessionID() string { return e.SessionID }
 
 type AgentChoiceEvent struct {
 	AgentContext
@@ -336,6 +340,8 @@ func SessionTitle(sessionID, title string) Event {
 	}
 }
 
+func (e *SessionTitleEvent) GetSessionID() string { return e.SessionID }
+
 type SessionSummaryEvent struct {
 	AgentContext
 
@@ -355,6 +361,8 @@ func SessionSummary(sessionID, summary, agentName string, firstKeptEntry int) Ev
 	}
 }
 
+func (e *SessionSummaryEvent) GetSessionID() string { return e.SessionID }
+
 type SessionCompactionEvent struct {
 	AgentContext
 
@@ -372,6 +380,8 @@ func SessionCompaction(sessionID, status, agentName string) Event {
 	}
 }
 
+func (e *SessionCompactionEvent) GetSessionID() string { return e.SessionID }
+
 type StreamStoppedEvent struct {
 	AgentContext
 
@@ -386,6 +396,8 @@ func StreamStopped(sessionID, agentName string) Event {
 		AgentContext: newAgentContext(agentName),
 	}
 }
+
+func (e *StreamStoppedEvent) GetSessionID() string { return e.SessionID }
 
 // ElicitationRequestEvent is sent when an elicitation request is received from an MCP server
 type ElicitationRequestEvent struct {

--- a/pkg/tui/components/tabbar/tabbar.go
+++ b/pkg/tui/components/tabbar/tabbar.go
@@ -407,12 +407,16 @@ func (t *TabBar) View() string {
 	needsScroll := totalWidth > availWidth
 
 	if !needsScroll {
-		t.scrollOffset = 0
+		// Reset persistent scroll position once everything fits, so the next
+		// time the bar overflows again the user starts from the leftmost
+		// tab. The mutation lives here, rather than in SetTabs/SetWidth,
+		// because only the rendering pass knows the actual tab widths.
+		t.scrollOffset = 0 //rubocop:disable Lint/TUIViewPurity // intentional reset; see comment above
 	} else if t.activeIdx != t.lastEnsuredIdx {
 		// Only auto-scroll when the active tab changes (e.g. tab switch),
 		// not on every render — otherwise manual scroll via arrows is undone.
 		t.ensureActiveVisible(allTabs, availWidth)
-		t.lastEnsuredIdx = t.activeIdx
+		t.lastEnsuredIdx = t.activeIdx //rubocop:disable Lint/TUIViewPurity // memo to avoid re-running ensureActiveVisible on every render
 	}
 
 	// Compute "+" and arrow colors dynamically from the terminal background.

--- a/pkg/tui/dialog/elicitation.go
+++ b/pkg/tui/dialog/elicitation.go
@@ -508,7 +508,11 @@ func (d *ElicitationDialog) buildBody(width int) (lines []string, fieldStarts []
 
 func (d *ElicitationDialog) View() string {
 	l := d.layout()
-	d.fieldStarts = l.fieldStarts
+	// Cache the per-field row offsets and the dialog's screen-space top row
+	// so mouse-click handling in Update() can hit-test against the geometry
+	// produced by this render. View() is the only place that knows the final
+	// layout, so we accept the mutation as a render-cache compromise.
+	d.fieldStarts = l.fieldStarts //rubocop:disable Lint/TUIViewPurity // click-zone cache consumed by Update()
 
 	// Configure the scrollview viewport, give it the body, and scroll so the
 	// focused field stays visible.
@@ -521,7 +525,7 @@ func (d *ElicitationDialog) View() string {
 	row, col := CenterPosition(d.Width(), d.Height(), l.dialogWidth, l.dialogHeight())
 	frameTop := styles.DialogStyle.GetBorderTopSize() + styles.DialogStyle.GetPaddingTop()
 	frameLeft := styles.DialogStyle.GetBorderLeftSize() + styles.DialogStyle.GetPaddingLeft()
-	d.scrollableRow = row + frameTop + elicitationHeaderLines
+	d.scrollableRow = row + frameTop + elicitationHeaderLines //rubocop:disable Lint/TUIViewPurity // click-zone cache consumed by Update()
 	d.scrollview.SetPosition(col+frameLeft, d.scrollableRow)
 
 	parts := []string{

--- a/pkg/tui/dialog/multi_choice.go
+++ b/pkg/tui/dialog/multi_choice.go
@@ -622,7 +622,9 @@ func (d *multiChoiceDialog) View() string {
 	// Help text and buttons on same row
 	helpAndButtons := d.renderHelpAndButtons(contentWidth)
 	content.AddContent(helpAndButtons)
-	d.btnRow = rowIdx
+	// Cache the button row index so click handling in Update() can hit-test
+	// against the same layout that was just rendered.
+	d.btnRow = rowIdx //rubocop:disable Lint/TUIViewPurity // click-zone cache consumed by Update()
 
 	return styles.DialogStyle.Width(dialogWidth).Render(content.Build())
 }


### PR DESCRIPTION
Adds **7 new project-specific cops** to the custom rubocop-go linter, focused on architectural sync invariants that golangci-lint cannot reach. Caught **10 real bugs** along the way and locked in **5 architectural caches** with documented justifications.

## New cops

| Cop | What it enforces | Real findings |
|---|---|---|
| `Lint/ConfigLatestTagConsistency` | `json` and `yaml` struct tags in `pkg/config/latest/` agree on `omitempty`/`omitzero`. Frozen `vN/` versions are exempt. | 1 bug — `Defer DeferConfig` had `json:"defer"` but `yaml:"defer,omitempty"`, so JSON always serialised the empty struct while YAML omitted it. Fixed with `omitzero` (consistent with the existing `lifecycle.go` pattern; `DeferConfig.IsEmpty()` makes `omitzero` semantically correct). |
| `Lint/ConfigVersionsRegistered` | `pkg/config/versions.go` calls `Register` for every `pkg/config/vN/` and `pkg/config/latest/` package on disk. | Preventive — currently in sync; locks the invariant. |
| `Lint/TUIViewPurity` | `View() string` methods on TUI models do not mutate the receiver (Bubble Tea purity). Slice-cache idioms (`nil`, `[:0]`, `append`) are auto-exempt; intentional click-zone caches use `//rubocop:disable Lint/TUIViewPurity` (the `//nolint` prefix would collide with golangci-lint's `nolintlint`). | 5 surfaced — 2 in `tabbar.go` (scroll-state mutations) + 3 in dialog click-zone caches; all annotated with one-line justifications. |
| `Lint/RuntimeEventRegistry` | Every `&XxxEvent{Type: "yyy"}` constructor in `pkg/runtime/event.go` has a matching entry in the decoder registry map in `pkg/runtime/client.go`. | 3 bugs — `MessageAddedEvent`, `ModelFallbackEvent`, `SubSessionCompletedEvent` were silently dropped by remote-runtime clients (only a `slog.Debug("invalid_type")` log line). Now registered. |
| `Lint/RuntimeSessionScoped` | Every `*Event` struct with a `SessionID` field implements `GetSessionID() string` (the `SessionScoped` interface used by the persistence pipeline). | 6 bugs — `UserMessageEvent`, `StreamStartedEvent`, `StreamStoppedEvent`, `SessionTitleEvent`, `SessionSummaryEvent`, `SessionCompactionEvent`. Without `GetSessionID`, the persistence-observer's sub-session filter `if scoped, ok := event.(SessionScoped); ok && scoped.GetSessionID() != sess.ID` short-circuits and lets sub-agent events leak into the parent's transcript. Now all six implement the method. |
| `Lint/HookConfigSync` | `EventXxx` constants in `pkg/hooks/types.go` and `HooksConfig` fields in `pkg/config/latest/types.go` stay 1:1, matched by snake-case wire string. | Preventive — currently in sync (22↔22); locks the invariant. |
| `Lint/HookBuiltinsRegistered` | Every exported `const Foo = "wire"` in `pkg/hooks/builtins/*.go` (excluding `builtins.go` and tests) appears as the first arg of a `RegisterBuiltin(Foo, …)` call in `pkg/hooks/builtins/builtins.go`. | Preventive — currently in sync (10 builtins); locks the invariant. |

## Why these cops

The codebase has several **multi-file architectural invariants** that the Go compiler cannot enforce:

- **Config versions** — list of `pkg/config/vN/` directories ↔ `versions.go` registry
- **Wire-format events** — runtime event constructors ↔ remote-decoder registry
- **Session ownership** — `SessionID` field ↔ `SessionScoped` interface
- **Hook coverage** — `EventXxx` constants ↔ YAML schema fields ↔ in-process builtin registry
- **Render purity** — Bubble Tea `View()` is supposed to be a pure function of state

Each of these is a "two declarations that must agree" pattern. Forgetting one of the slots compiles cleanly and only blows up at runtime — usually as a silent drop, not an error. The cops fail the lint gate at PR time instead.

All seven cops follow the same idioms as the existing four (`config_package_name.go`, `config_version_constant.go`, `config_version_import.go`, `latest_imports_predecessor.go`): embed `cop.Meta`, expose a `New<Cop>()` constructor, implement `Check(p *cop.Pass)`, report via `p.Report(node, format, args...)`.

## Bugs caught & fixed

```
pkg/config/latest/types.go         Defer DeferConfig: json missing omitzero
pkg/runtime/client.go              registry missing 3 events
pkg/runtime/event.go               6 events missing GetSessionID
```

## Cumulative state

```
63377309a lint: add two hook-architecture sync cops
92d1a6498 lint: add two runtime-architecture cops (catches 9 bugs)
ec5b3ce66 lint: add three project-specific cops              (catches 1 bug)
e5a4b67cd lint: adopt new rubocop-go API                     (already in main)
```

**11 cops total**, **10 real bugs caught & fixed**, **5 architectural caches documented**, **3 pure preventive invariants locked in**.

## Validation

- `mise lint` ✅ (golangci-lint, 11 custom cops, `go mod tidy --diff`)
- `mise test` ✅ (105 packages, 0 failures)
- Each cop verified to fire on a seeded violation and to go silent again when restored — including bidirectional sync cops (3 drift scenarios for `HookConfigSync`).
