### PR TITLE
update PR review workflow with fork-supporting trigger

### DIFF
--- a/.github/workflows/pr-review-trigger.yml
+++ b/.github/workflows/pr-review-trigger.yml
@@ -1,0 +1,33 @@
+name: PR Review - Trigger
+on:
+  pull_request:
+    types: [ready_for_review, opened]
+  pull_request_review_comment:
+    types: [created]
+
+permissions: {}
+
+jobs:
+  save-context:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save event context
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          COMMENT_JSON: ${{ toJSON(github.event.comment) }}
+        run: |
+          mkdir -p context
+          printf '%s' "${{ github.event_name }}" > context/event_name.txt
+          printf '%s' "$PR_NUMBER" > context/pr_number.txt
+          printf '%s' "$PR_HEAD_SHA" > context/pr_head_sha.txt
+          if [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
+            printf '%s' "$COMMENT_JSON" > context/comment.json
+          fi
+
+      - name: Upload context
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pr-review-context
+          path: context/
+          retention-days: 1

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,27 +1,28 @@
 name: PR Review
 on:
-  issue_comment: # Enables /review command in PR comments
+  issue_comment:
     types: [created]
-  pull_request_review_comment: # Captures feedback on review comments for learning
-    types: [created]
-  pull_request: # Triggers auto-review on PR open (same-repo branches only; fork PRs use /review)
-    types: [ready_for_review, opened]
+  workflow_run:
+    workflows: ["PR Review - Trigger"]
+    types: [completed]
 
 permissions:
   contents: read # Required at top-level to give `issue_comment` events access to the secrets below.
 
 jobs:
   review:
-    uses: docker/cagent-action/.github/workflows/review-pr.yml@d98096f432f2aea5091c811852c4da804e60623a # v1.4.1
+    if: |
+      github.event_name == 'issue_comment' ||
+      github.event.workflow_run.conclusion == 'success'
+    uses: docker/cagent-action/.github/workflows/review-pr.yml@ec4865576952df6285652f2cf8ffb4ad45ff5f80 # v1.4.3
     # Scoped to the job so other jobs in this workflow aren't over-permissioned
     permissions:
       contents: read # Read repository files and PR diffs
-      pull-requests: write # Post review comments and approve/request changes
-      issues: write # Create security incident issues if secrets are detected in output
-      checks: write # (Optional) Show review progress as a check run on the PR
+      pull-requests: write # Post review comments
+      issues: write # Create security incident issues if secrets detected
+      checks: write # (Optional) Show review progress as a check run
       id-token: write # Required for OIDC authentication to AWS Secrets Manager
-    secrets:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      CAGENT_ORG_MEMBERSHIP_TOKEN: ${{ secrets.CAGENT_ORG_MEMBERSHIP_TOKEN }} # PAT with read:org scope; gates auto-reviews to org members only
-      CAGENT_REVIEWER_APP_ID: ${{ secrets.CAGENT_REVIEWER_APP_ID }} # GitHub App ID; reviews appear as your app instead of github-actions[bot]
-      CAGENT_REVIEWER_APP_PRIVATE_KEY: ${{ secrets.CAGENT_REVIEWER_APP_PRIVATE_KEY }} # GitHub App private key; paired with App ID above
+      actions: read # Download artifacts from trigger workflow
+    with:
+      trigger-run-id: ${{ github.event_name == 'workflow_run' && format('{0}', github.event.workflow_run.id) || '' }}
+


### PR DESCRIPTION
## Summary

Refactor PR review workflow to use a fork-supporting trigger pattern. This decouples the review job from direct event triggers and uses artifact passing to support fork PRs, which cannot access secrets in the main workflow.

Closes: https://github.com/docker/gordon/issues/468

## Changes

- **New workflow**: `pr-review-trigger.yml` captures PR and review comment events, saves context (event name, PR number, SHA, comment JSON) as artifacts
- **Updated workflow**: `pr-review.yml` now uses `workflow_run` trigger to run after the trigger workflow completes, downloads artifacts to access saved context
- **Permissions**: Added `actions: read` to allow artifact downloads; simplified permission comments
- **Version bump**: Updated `cagent-action` from v1.4.1 to v1.4.3
- **New input**: Added `trigger-run-id` parameter to pass workflow run ID from trigger workflow

## Test plan

- Verify PR review triggers on `/review` command in PR comments
- Verify auto-review triggers on PR open/ready_for_review (same-repo branches)
- Verify fork PRs can trigger review via `/review` command (previously blocked by secret access)
- Confirm review comments on review feedback still trigger review