### PR TITLE
Handle case when session started with Docker Desktop proxy available, and the Desktop is stopped

### DIFF
--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -102,10 +102,13 @@ func newTransport(ctx context.Context) http.RoundTripper {
 	// Get the base transport with Desktop proxy support from remote package
 	rt := remote.NewTransport(ctx)
 
-	// If it's an http.Transport, disable compression for SSE streaming compatibility
-	if transport, ok := rt.(*http.Transport); ok {
-		transport.DisableCompression = true
-		return transport
+	// Disable compression for SSE streaming compatibility
+	// Handle both direct *http.Transport and the fallback transport wrapper
+	switch t := rt.(type) {
+	case *http.Transport:
+		t.DisableCompression = true
+	case interface{ DisableCompression() }:
+		t.DisableCompression()
 	}
 
 	return rt

--- a/pkg/model/provider/anthropic/client.go
+++ b/pkg/model/provider/anthropic/client.go
@@ -96,7 +96,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 			// Query a fresh auth token each time the client is used
 			authToken, _ := env.Get(ctx, environment.DockerDesktopTokenEnv)
 			if authToken == "" {
-				return anthropic.Client{}, errors.New("failed to get Docker Desktop token for Gateway")
+				return anthropic.Client{}, errors.New(base.NoDesktopTokenErrorMessage)
 			}
 
 			url, err := url.Parse(gateway)

--- a/pkg/model/provider/base/base.go
+++ b/pkg/model/provider/base/base.go
@@ -6,6 +6,8 @@ import (
 	"github.com/docker/docker-agent/pkg/model/provider/options"
 )
 
+const NoDesktopTokenErrorMessage = "failed to get Docker Desktop token for Gateway. Is Docker Desktop running and are you signed in?"
+
 // Config is a common base configuration shared by all provider clients.
 // It can be embedded in provider-specific Client structs to avoid code duplication.
 type Config struct {

--- a/pkg/model/provider/gemini/client.go
+++ b/pkg/model/provider/gemini/client.go
@@ -130,7 +130,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 			// Query a fresh auth token each time the client is used
 			authToken, _ := env.Get(ctx, environment.DockerDesktopTokenEnv)
 			if authToken == "" {
-				return nil, errors.New("failed to get Docker Desktop token for Gateway")
+				return nil, errors.New(base.NoDesktopTokenErrorMessage)
 			}
 
 			url, err := url.Parse(gateway)

--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -115,7 +115,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 			// Query a fresh auth token each time the client is used
 			authToken, _ := env.Get(ctx, environment.DockerDesktopTokenEnv)
 			if authToken == "" {
-				return nil, errors.New("failed to get Docker Desktop token for Gateway")
+				return nil, errors.New(base.NoDesktopTokenErrorMessage)
 			}
 
 			url, err := url.Parse(gateway)

--- a/pkg/remote/transport.go
+++ b/pkg/remote/transport.go
@@ -2,9 +2,12 @@ package remote
 
 import (
 	"context"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
+	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/kofalt/go-memoize"
@@ -16,6 +19,8 @@ import (
 var memoizer = memoize.NewMemoizer(1*time.Minute, 1*time.Minute)
 
 // NewTransport returns an HTTP transport that uses Docker Desktop proxy if available.
+// If the proxy becomes unavailable during the session, it automatically falls back
+// to direct connections.
 func NewTransport(ctx context.Context) http.RoundTripper {
 	t, ok := http.DefaultTransport.(*http.Transport)
 	if !ok {
@@ -30,14 +35,118 @@ func NewTransport(ctx context.Context) http.RoundTripper {
 		return transport
 	}
 	if running, ok := desktopRunning.(bool); ok && running {
-		transport.Proxy = http.ProxyURL(&url.URL{
+		// Create a proxy transport
+		proxyTransport := t.Clone()
+		proxyTransport.Proxy = http.ProxyURL(&url.URL{
 			Scheme: "http",
 		})
 		// Override the dialer to connect to the Unix socket for the proxy
-		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		proxyTransport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
 			return socket.DialUnix(ctx, desktop.Paths().ProxySocket)
 		}
+
+		// Return a fallback transport that tries the proxy first, then falls back to direct
+		return newFallbackTransport(proxyTransport, transport)
 	}
 
 	return transport
+}
+
+// fallbackTransport wraps a proxy transport and falls back to a direct transport
+// when the proxy socket becomes unavailable (e.g., Docker Desktop proxy dies).
+type fallbackTransport struct {
+	proxy  *http.Transport
+	direct *http.Transport
+
+	// proxyDisabled is set to true when the proxy socket becomes unavailable.
+	// Once set, all subsequent requests go directly without trying the proxy.
+	proxyDisabled atomic.Bool
+}
+
+// newFallbackTransport creates a transport that tries the proxy first, then falls back to direct.
+func newFallbackTransport(proxy, direct *http.Transport) *fallbackTransport {
+	return &fallbackTransport{
+		proxy:  proxy,
+		direct: direct,
+	}
+}
+
+// DisableCompression disables automatic gzip compression on both transports.
+// This is needed for SSE streaming compatibility.
+func (f *fallbackTransport) DisableCompression() {
+	f.proxy.DisableCompression = true
+	f.direct.DisableCompression = true
+}
+
+// RoundTrip implements http.RoundTripper.
+func (f *fallbackTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// If proxy is already known to be disabled, go direct
+	if f.proxyDisabled.Load() {
+		return f.direct.RoundTrip(req)
+	}
+
+	// Try the proxy first
+	resp, err := f.proxy.RoundTrip(req)
+	if err == nil {
+		return resp, nil
+	}
+
+	// Check if this is a proxy socket error (socket gone, connection refused, etc.)
+	if isProxySocketError(err) {
+		slog.Warn("Docker Desktop proxy unavailable, falling back to direct connection",
+			"error", err.Error(),
+			"url", req.URL.String())
+
+		// Disable proxy for future requests
+		f.proxyDisabled.Store(true)
+
+		// Clone the request for retry (the body may have been partially read)
+		// For requests without a body or with GetBody set, we can retry
+		if req.Body == nil || req.GetBody != nil {
+			retryReq := req.Clone(req.Context())
+			if req.GetBody != nil {
+				var bodyErr error
+				retryReq.Body, bodyErr = req.GetBody()
+				if bodyErr != nil {
+					return nil, err // Return original error if we can't get the body
+				}
+			}
+			return f.direct.RoundTrip(retryReq)
+		}
+
+		// Can't retry requests with consumed bodies
+		return nil, err
+	}
+
+	return nil, err
+}
+
+// isProxySocketError checks if the error indicates the proxy socket is unavailable.
+// This includes:
+// - "no such file or directory" - socket file was deleted
+// - "connection refused" - socket exists but nothing is listening
+// - "dial unix" errors - general Unix socket connection failures
+func isProxySocketError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	errStr := strings.ToLower(err.Error())
+
+	// Check for common proxy socket failure patterns
+	proxyErrorPatterns := []string{
+		"no such file or directory",   // Socket file deleted
+		"connect: connection refused", // Socket exists but no listener
+		"proxyconnect tcp",            // Proxy connection failure
+		"dial unix",                   // Unix socket dial failure
+		"unix socket",                 // Generic Unix socket error
+	}
+
+	for _, pattern := range proxyErrorPatterns {
+		if strings.Contains(errStr, pattern) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/remote/transport_test.go
+++ b/pkg/remote/transport_test.go
@@ -20,14 +20,14 @@ func TestNewTransport_UsesDesktopProxyWhenAvailable(t *testing.T) {
 	transport := NewTransport(ctx)
 	require.NotNil(t, transport)
 
-	// Verify that it's an http.Transport
-	httpTransport, ok := transport.(*http.Transport)
-	require.True(t, ok, "transport should be *http.Transport")
-
-	// If Docker Desktop is running, verify proxy is configured
+	// If Docker Desktop is running, verify fallback transport is used
 	if desktop.IsDockerDesktopRunning(ctx) {
-		assert.NotNil(t, httpTransport.Proxy, "proxy should be configured when Docker Desktop is running")
-		assert.NotNil(t, httpTransport.DialContext, "custom DialContext should be set when Docker Desktop is running")
+		_, ok := transport.(*fallbackTransport)
+		assert.True(t, ok, "transport should be *fallbackTransport when Docker Desktop is running")
+	} else {
+		// Otherwise, it should be a plain *http.Transport
+		_, ok := transport.(*http.Transport)
+		assert.True(t, ok, "transport should be *http.Transport when Docker Desktop is not running")
 	}
 }
 
@@ -55,4 +55,91 @@ func TestNewTransport_WorksWithoutDesktopProxy(t *testing.T) {
 	defer resp.Body.Close()
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestIsProxySocketError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		errStr   string
+		expected bool
+	}{
+		{
+			name:     "no such file or directory",
+			errStr:   "proxyconnect tcp: dial unix /path/to/httpproxy.sock: connect: no such file or directory",
+			expected: true,
+		},
+		{
+			name:     "connection refused",
+			errStr:   "proxyconnect tcp: dial unix /path/to/httpproxy.sock: connect: connection refused",
+			expected: true,
+		},
+		{
+			name:     "proxyconnect tcp error",
+			errStr:   "Post https://api.anthropic.com/v1/messages: proxyconnect tcp: some error",
+			expected: true,
+		},
+		{
+			name:     "dial unix error",
+			errStr:   "dial unix /var/run/docker.sock: operation timed out",
+			expected: true,
+		},
+		{
+			name:     "regular network error",
+			errStr:   "dial tcp 192.168.1.1:443: i/o timeout",
+			expected: false,
+		},
+		{
+			name:     "HTTP error",
+			errStr:   "HTTP 500: internal server error",
+			expected: false,
+		},
+		{
+			name:     "nil error",
+			errStr:   "",
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var err error
+			if tc.errStr != "" {
+				err = &testError{msg: tc.errStr}
+			}
+			result := isProxySocketError(err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestFallbackTransport_DisableCompression(t *testing.T) {
+	t.Parallel()
+
+	proxy := &http.Transport{}
+	direct := &http.Transport{}
+
+	ft := newFallbackTransport(proxy, direct)
+
+	// Verify compression is not disabled initially
+	assert.False(t, proxy.DisableCompression)
+	assert.False(t, direct.DisableCompression)
+
+	// Disable compression
+	ft.DisableCompression()
+
+	// Verify compression is now disabled on both transports
+	assert.True(t, proxy.DisableCompression)
+	assert.True(t, direct.DisableCompression)
+}
+
+// testError is a simple error type for testing
+type testError struct {
+	msg string
+}
+
+func (e *testError) Error() string {
+	return e.msg
 }


### PR DESCRIPTION
* detect if proxy is not avaiable anymore in the middle of a session and fallback to no proxy. 
* improve error message if using the gateway but no auth token is available

Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>