### PR TITLE
feat: Phase 1 attachment – per-provider convertDocument wiring

### DIFF
--- a/pkg/attachment/advisor.go
+++ b/pkg/attachment/advisor.go
@@ -1,0 +1,10 @@
+package attachment
+
+// Advisor is implemented by providers that support document attachments.
+// The UI layer uses SupportedMIMETypes to populate file-picker filters so that
+// only files the active provider can handle are offered to the user.
+type Advisor interface {
+	// SupportedMIMETypes returns the list of MIME types that this provider
+	// can accept as document attachments (e.g. "application/pdf", "image/png").
+	SupportedMIMETypes() []string
+}

--- a/pkg/attachment/attachment.go
+++ b/pkg/attachment/attachment.go
@@ -41,35 +41,41 @@ type CapabilityTable map[string]Capability
 // capability table. It returns the chosen strategy and, when the strategy is
 // a fallback or a drop, a human-readable reason string.
 //
+// When multiple source fields are set, URL takes priority over InlineData,
+// which takes priority over InlineText.
+//
 // Decision order (exact — do not deviate):
 //  1. MIME type not in table → Drop
-//  2. Source is URL + provider supports URL → URL
+//  2. Source is URL + provider supports URL → URL (reason: "")
 //  3. Source is URL + provider does NOT support URL:
-//     a. provider supports B64 → FetchAsB64
-//     b. provider supports TXT → FetchAsTXT
+//     a. provider supports B64 → FetchAsB64 (reason: "url not supported, will fetch as b64")
+//     b. provider supports TXT → FetchAsTXT (reason: "url not supported, will fetch as text")
 //     c. otherwise → Drop
-//  4. Source is InlineData + provider supports B64 → B64
-//  5. Source is InlineText + provider supports TXT → TXT
+//  4. Source is InlineData (non-nil) + provider supports B64 → B64 (reason: "")
+//  5. Source is InlineText (non-empty) + provider supports TXT → TXT (reason: "")
 //  6. → Drop
+//
+// Note: FetchAsB64 and FetchAsTXT carry non-empty reason strings intentionally —
+// they signal an automatic fallback that callers may want to surface in logs or UI.
 func Decide(doc chat.Document, table CapabilityTable) (Strategy, string) {
 	capability, ok := table[doc.MimeType]
 	if !ok {
 		return StrategyDrop, "mime not in provider table"
 	}
 
-	if doc.Source.URL != "" && capability.URL {
-		return StrategyURL, ""
-	}
-	if doc.Source.URL != "" && !capability.URL {
-		if capability.B64 {
+	if doc.Source.URL != "" {
+		switch {
+		case capability.URL:
+			return StrategyURL, ""
+		case capability.B64:
 			return StrategyFetchAsB64, "url not supported, will fetch as b64"
-		}
-		if capability.TXT {
+		case capability.TXT:
 			return StrategyFetchAsTXT, "url not supported, will fetch as text"
+		default:
+			return StrategyDrop, "provider cannot handle url or inline for this mime"
 		}
-		return StrategyDrop, "provider cannot handle url or inline for this mime"
 	}
-	if len(doc.Source.InlineData) > 0 && capability.B64 {
+	if doc.Source.InlineData != nil && capability.B64 {
 		return StrategyB64, ""
 	}
 	if doc.Source.InlineText != "" && capability.TXT {
@@ -84,9 +90,9 @@ func Decide(doc chat.Document, table CapabilityTable) (Strategy, string) {
 //
 // Example output:
 //
-//	<document name="foo.md" type="text/markdown">
+//	<document name="foo.md" mime-type="text/markdown">
 //	...content...
 //	</document>
 func TXTEnvelope(name, mimeType, body string) string {
-	return fmt.Sprintf("<document name=%q type=%q>\n%s\n</document>", name, mimeType, body)
+	return fmt.Sprintf("<document name=%q mime-type=%q>\n%s\n</document>", name, mimeType, body)
 }

--- a/pkg/attachment/attachment.go
+++ b/pkg/attachment/attachment.go
@@ -1,0 +1,92 @@
+// Package attachment provides helpers for deciding how document attachments
+// should be delivered to LLM providers and for fetching remote content.
+package attachment
+
+import (
+	"fmt"
+
+	"github.com/docker/docker-agent/pkg/chat"
+)
+
+// Strategy describes how a document attachment should be delivered to a provider.
+type Strategy int
+
+const (
+	// StrategyDrop means the attachment cannot be handled and should be omitted.
+	StrategyDrop Strategy = iota
+	// StrategyTXT means the document's inline text should be sent as a text envelope.
+	StrategyTXT
+	// StrategyB64 means the document's inline binary data should be base64-encoded and sent inline.
+	StrategyB64
+	// StrategyURL means the document's URL should be passed directly to the provider.
+	StrategyURL
+	// StrategyFetchAsB64 means the URL should be fetched and its bytes sent as base64.
+	StrategyFetchAsB64
+	// StrategyFetchAsTXT means the URL should be fetched and its content sent as plain text.
+	StrategyFetchAsTXT
+)
+
+// Capability describes which delivery modes a provider supports for a given MIME type.
+type Capability struct {
+	TXT bool // provider accepts plain text for this MIME type
+	B64 bool // provider accepts base64-encoded binary for this MIME type
+	URL bool // provider accepts a public URL for this MIME type
+}
+
+// CapabilityTable maps MIME types to provider capabilities.
+// Providers build this table to declare what they can handle.
+type CapabilityTable map[string]Capability
+
+// Decide selects the best delivery Strategy for doc given the provider's
+// capability table. It returns the chosen strategy and, when the strategy is
+// a fallback or a drop, a human-readable reason string.
+//
+// Decision order (exact — do not deviate):
+//  1. MIME type not in table → Drop
+//  2. Source is URL + provider supports URL → URL
+//  3. Source is URL + provider does NOT support URL:
+//     a. provider supports B64 → FetchAsB64
+//     b. provider supports TXT → FetchAsTXT
+//     c. otherwise → Drop
+//  4. Source is InlineData + provider supports B64 → B64
+//  5. Source is InlineText + provider supports TXT → TXT
+//  6. → Drop
+func Decide(doc chat.Document, table CapabilityTable) (Strategy, string) {
+	capability, ok := table[doc.MimeType]
+	if !ok {
+		return StrategyDrop, "mime not in provider table"
+	}
+
+	if doc.Source.URL != "" && capability.URL {
+		return StrategyURL, ""
+	}
+	if doc.Source.URL != "" && !capability.URL {
+		if capability.B64 {
+			return StrategyFetchAsB64, "url not supported, will fetch as b64"
+		}
+		if capability.TXT {
+			return StrategyFetchAsTXT, "url not supported, will fetch as text"
+		}
+		return StrategyDrop, "provider cannot handle url or inline for this mime"
+	}
+	if len(doc.Source.InlineData) > 0 && capability.B64 {
+		return StrategyB64, ""
+	}
+	if doc.Source.InlineText != "" && capability.TXT {
+		return StrategyTXT, ""
+	}
+	return StrategyDrop, "no supported variant for this provider"
+}
+
+// TXTEnvelope wraps plain-text document content in an XML-like tag for
+// inclusion in a chat message. The envelope makes the document's name and
+// MIME type visible to the model.
+//
+// Example output:
+//
+//	<document name="foo.md" type="text/markdown">
+//	...content...
+//	</document>
+func TXTEnvelope(name, mimeType, body string) string {
+	return fmt.Sprintf("<document name=%q type=%q>\n%s\n</document>", name, mimeType, body)
+}

--- a/pkg/attachment/decide_test.go
+++ b/pkg/attachment/decide_test.go
@@ -1,0 +1,179 @@
+package attachment_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/docker/docker-agent/pkg/attachment"
+	"github.com/docker/docker-agent/pkg/chat"
+)
+
+func TestDecide(t *testing.T) {
+	// A table that exercises every capability combination used in the tests.
+	table := attachment.CapabilityTable{
+		"text/plain":      {TXT: true, B64: false, URL: false},
+		"image/png":       {TXT: false, B64: true, URL: true},
+		"application/pdf": {TXT: false, B64: true, URL: false},
+		"text/markdown":   {TXT: true, B64: false, URL: true},
+		"video/mp4":       {TXT: false, B64: false, URL: false}, // nothing supported
+	}
+
+	tests := []struct {
+		name           string
+		doc            chat.Document
+		wantStrategy   attachment.Strategy
+		wantReasonSubs string // non-empty substring that must appear in the reason
+	}{
+		// ── 1. MIME miss ────────────────────────────────────────────────────────
+		{
+			name: "mime not in table → Drop",
+			doc: chat.Document{
+				MimeType: "application/zip",
+				Source:   chat.DocumentSource{InlineData: []byte("data")},
+			},
+			wantStrategy:   attachment.StrategyDrop,
+			wantReasonSubs: "mime not in provider table",
+		},
+
+		// ── 2. URL + provider supports URL → URL ─────────────────────────────
+		{
+			name: "url source + URL cap → URL",
+			doc: chat.Document{
+				MimeType: "image/png",
+				Source:   chat.DocumentSource{URL: "https://example.com/img.png"},
+			},
+			wantStrategy: attachment.StrategyURL,
+		},
+
+		// ── 3a. URL + no URL cap + B64 cap → FetchAsB64 ──────────────────────
+		{
+			name: "url source + no URL cap + B64 → FetchAsB64",
+			doc: chat.Document{
+				MimeType: "application/pdf",
+				Source:   chat.DocumentSource{URL: "https://example.com/doc.pdf"},
+			},
+			wantStrategy:   attachment.StrategyFetchAsB64,
+			wantReasonSubs: "url not supported",
+		},
+
+		// ── 3b. URL + no URL cap + no B64 + TXT cap → FetchAsTXT ─────────────
+		{
+			name: "url source + no URL cap + TXT → FetchAsTXT",
+			doc: chat.Document{
+				MimeType: "text/plain",
+				Source:   chat.DocumentSource{URL: "https://example.com/readme.txt"},
+			},
+			wantStrategy:   attachment.StrategyFetchAsTXT,
+			wantReasonSubs: "url not supported",
+		},
+
+		// ── 3c. URL + no URL cap + no B64 + no TXT → Drop ────────────────────
+		{
+			name: "url source + nothing supported → Drop",
+			doc: chat.Document{
+				MimeType: "video/mp4",
+				Source:   chat.DocumentSource{URL: "https://example.com/clip.mp4"},
+			},
+			wantStrategy:   attachment.StrategyDrop,
+			wantReasonSubs: "provider cannot handle",
+		},
+
+		// ── 4. InlineData + B64 cap → B64 ────────────────────────────────────
+		{
+			name: "inline binary + B64 cap → B64",
+			doc: chat.Document{
+				MimeType: "image/png",
+				Source:   chat.DocumentSource{InlineData: []byte("\x89PNG\r\n\x1a\n")},
+			},
+			wantStrategy: attachment.StrategyB64,
+		},
+
+		// ── 5. InlineText + TXT cap → TXT ────────────────────────────────────
+		{
+			name: "inline text + TXT cap → TXT",
+			doc: chat.Document{
+				MimeType: "text/plain",
+				Source:   chat.DocumentSource{InlineText: "hello world"},
+			},
+			wantStrategy: attachment.StrategyTXT,
+		},
+
+		// ── 6. InlineData present but only TXT supported → Drop ──────────────
+		{
+			name: "inline binary but only TXT cap → Drop",
+			doc: chat.Document{
+				MimeType: "text/plain",
+				Source:   chat.DocumentSource{InlineData: []byte("binary-data")},
+			},
+			wantStrategy:   attachment.StrategyDrop,
+			wantReasonSubs: "no supported variant",
+		},
+
+		// ── 7. InlineText present but only B64/URL supported → Drop ──────────
+		{
+			name: "inline text but only B64/URL cap → Drop",
+			doc: chat.Document{
+				MimeType: "image/png",
+				Source:   chat.DocumentSource{InlineText: "not really an image"},
+			},
+			wantStrategy:   attachment.StrategyDrop,
+			wantReasonSubs: "no supported variant",
+		},
+
+		// ── 8. No source at all → Drop ────────────────────────────────────────
+		{
+			name: "empty source → Drop",
+			doc: chat.Document{
+				MimeType: "text/plain",
+				Source:   chat.DocumentSource{},
+			},
+			wantStrategy:   attachment.StrategyDrop,
+			wantReasonSubs: "no supported variant",
+		},
+
+		// ── 9. URL mime that also supports URL ────────────────────────────────
+		{
+			name: "url source + URL cap (text/markdown) → URL",
+			doc: chat.Document{
+				MimeType: "text/markdown",
+				Source:   chat.DocumentSource{URL: "https://example.com/readme.md"},
+			},
+			wantStrategy: attachment.StrategyURL,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, reason := attachment.Decide(tc.doc, table)
+			if got != tc.wantStrategy {
+				t.Errorf("Decide() strategy = %v, want %v (reason: %q)", got, tc.wantStrategy, reason)
+			}
+			if tc.wantReasonSubs != "" && !strings.Contains(reason, tc.wantReasonSubs) {
+				t.Errorf("Decide() reason = %q, want substring %q", reason, tc.wantReasonSubs)
+			}
+			if tc.wantReasonSubs == "" && reason != "" {
+				// For happy-path strategies the reason should be empty.
+				t.Errorf("Decide() reason = %q, want empty", reason)
+			}
+		})
+	}
+}
+
+func TestTXTEnvelope(t *testing.T) {
+	got := attachment.TXTEnvelope("readme.md", "text/markdown", "# Hello\nworld")
+	if !strings.Contains(got, `name="readme.md"`) {
+		t.Errorf("TXTEnvelope missing name attribute: %s", got)
+	}
+	if !strings.Contains(got, `type="text/markdown"`) {
+		t.Errorf("TXTEnvelope missing type attribute: %s", got)
+	}
+	if !strings.Contains(got, "# Hello\nworld") {
+		t.Errorf("TXTEnvelope missing body: %s", got)
+	}
+	if !strings.HasPrefix(got, "<document ") {
+		t.Errorf("TXTEnvelope should start with <document: %s", got)
+	}
+	if !strings.HasSuffix(got, "</document>") {
+		t.Errorf("TXTEnvelope should end with </document>: %s", got)
+	}
+}

--- a/pkg/attachment/decide_test.go
+++ b/pkg/attachment/decide_test.go
@@ -46,6 +46,7 @@ func TestDecide(t *testing.T) {
 		},
 
 		// ── 3a. URL + no URL cap + B64 cap → FetchAsB64 ──────────────────────
+		// Non-empty reason is intentional: signals an automatic fallback for logging/UI.
 		{
 			name: "url source + no URL cap + B64 → FetchAsB64",
 			doc: chat.Document{
@@ -57,6 +58,7 @@ func TestDecide(t *testing.T) {
 		},
 
 		// ── 3b. URL + no URL cap + no B64 + TXT cap → FetchAsTXT ─────────────
+		// Non-empty reason is intentional: signals an automatic fallback for logging/UI.
 		{
 			name: "url source + no URL cap + TXT → FetchAsTXT",
 			doc: chat.Document{
@@ -78,12 +80,22 @@ func TestDecide(t *testing.T) {
 			wantReasonSubs: "provider cannot handle",
 		},
 
-		// ── 4. InlineData + B64 cap → B64 ────────────────────────────────────
+		// ── 4. InlineData (non-nil) + B64 cap → B64 ──────────────────────────
 		{
 			name: "inline binary + B64 cap → B64",
 			doc: chat.Document{
 				MimeType: "image/png",
 				Source:   chat.DocumentSource{InlineData: []byte("\x89PNG\r\n\x1a\n")},
+			},
+			wantStrategy: attachment.StrategyB64,
+		},
+
+		// ── 4b. InlineData non-nil but zero-length → B64 (spec: nil check, not len) ──
+		{
+			name: "inline binary (empty slice, non-nil) + B64 cap → B64",
+			doc: chat.Document{
+				MimeType: "image/png",
+				Source:   chat.DocumentSource{InlineData: []byte{}},
 			},
 			wantStrategy: attachment.StrategyB64,
 		},
@@ -103,7 +115,8 @@ func TestDecide(t *testing.T) {
 			name: "inline binary but only TXT cap → Drop",
 			doc: chat.Document{
 				MimeType: "text/plain",
-				Source:   chat.DocumentSource{InlineData: []byte("binary-data")},
+				// validates step-6 fall-through: B64 variant present but provider only supports TXT
+				Source: chat.DocumentSource{InlineData: []byte("binary-data")},
 			},
 			wantStrategy:   attachment.StrategyDrop,
 			wantReasonSubs: "no supported variant",
@@ -152,7 +165,7 @@ func TestDecide(t *testing.T) {
 				t.Errorf("Decide() reason = %q, want substring %q", reason, tc.wantReasonSubs)
 			}
 			if tc.wantReasonSubs == "" && reason != "" {
-				// For happy-path strategies the reason should be empty.
+				// For happy-path strategies (URL, B64, TXT) the reason should be empty.
 				t.Errorf("Decide() reason = %q, want empty", reason)
 			}
 		})
@@ -164,8 +177,8 @@ func TestTXTEnvelope(t *testing.T) {
 	if !strings.Contains(got, `name="readme.md"`) {
 		t.Errorf("TXTEnvelope missing name attribute: %s", got)
 	}
-	if !strings.Contains(got, `type="text/markdown"`) {
-		t.Errorf("TXTEnvelope missing type attribute: %s", got)
+	if !strings.Contains(got, `mime-type="text/markdown"`) {
+		t.Errorf("TXTEnvelope missing mime-type attribute: %s", got)
 	}
 	if !strings.Contains(got, "# Hello\nworld") {
 		t.Errorf("TXTEnvelope missing body: %s", got)

--- a/pkg/attachment/fetch.go
+++ b/pkg/attachment/fetch.go
@@ -1,0 +1,42 @@
+package attachment
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// fetchTimeout is the maximum time allowed for a URL fetch.
+const fetchTimeout = 10 * time.Second
+
+// FetchURL fetches a public URL with a 10-second timeout.
+// Returns the raw response body bytes on success.
+// Returns an error if the request fails or the server responds with a non-2xx status.
+func FetchURL(ctx context.Context, url string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, fetchTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("attachment: creating request for %q: %w", url, err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("attachment: fetching %q: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("attachment: fetching %q: unexpected status %d", url, resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("attachment: reading response from %q: %w", url, err)
+	}
+
+	return data, nil
+}

--- a/pkg/attachment/fetch.go
+++ b/pkg/attachment/fetch.go
@@ -9,11 +9,14 @@ import (
 )
 
 // fetchTimeout is the maximum time allowed for a URL fetch.
+// TODO: make fetchTimeout per-runtime-configurable in Phase 2.
 const fetchTimeout = 10 * time.Second
 
 // FetchURL fetches a public URL with a 10-second timeout.
 // Returns the raw response body bytes on success.
 // Returns an error if the request fails or the server responds with a non-2xx status.
+//
+// TODO: consider bounding redirects / restricting schemes for user-supplied URLs (SSRF) in Phase 2.
 func FetchURL(ctx context.Context, url string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(ctx, fetchTimeout)
 	defer cancel()

--- a/pkg/attachment/fetch_test.go
+++ b/pkg/attachment/fetch_test.go
@@ -1,0 +1,107 @@
+package attachment_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker-agent/pkg/attachment"
+)
+
+func TestFetchURL_Success(t *testing.T) {
+	t.Parallel()
+
+	const body = "hello from test server"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	got, err := attachment.FetchURL(t.Context(), srv.URL)
+	if err != nil {
+		t.Fatalf("FetchURL returned unexpected error: %v", err)
+	}
+	if string(got) != body {
+		t.Errorf("FetchURL body = %q, want %q", string(got), body)
+	}
+}
+
+func TestFetchURL_Non2xx(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	_, err := attachment.FetchURL(t.Context(), srv.URL)
+	if err == nil {
+		t.Fatal("FetchURL expected an error for 404 response, got nil")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Errorf("error should mention status code 404, got: %v", err)
+	}
+}
+
+func TestFetchURL_ServerError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	_, err := attachment.FetchURL(t.Context(), srv.URL)
+	if err == nil {
+		t.Fatal("FetchURL expected an error for 500 response, got nil")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("error should mention status code 500, got: %v", err)
+	}
+}
+
+func TestFetchURL_CancelledContext(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Never respond — let the context cancel first.
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // cancel immediately
+
+	_, err := attachment.FetchURL(ctx, srv.URL)
+	if err == nil {
+		t.Fatal("FetchURL expected an error for cancelled context, got nil")
+	}
+}
+
+func TestFetchURL_BinaryContent(t *testing.T) {
+	t.Parallel()
+
+	content := []byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a} // PNG magic bytes
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(content)
+	}))
+	defer srv.Close()
+
+	got, err := attachment.FetchURL(t.Context(), srv.URL)
+	if err != nil {
+		t.Fatalf("FetchURL returned unexpected error: %v", err)
+	}
+	if len(got) != len(content) {
+		t.Errorf("FetchURL returned %d bytes, want %d", len(got), len(content))
+	}
+	for i, b := range content {
+		if got[i] != b {
+			t.Errorf("byte %d: got %02x, want %02x", i, got[i], b)
+		}
+	}
+}

--- a/pkg/chat/chat.go
+++ b/pkg/chat/chat.go
@@ -32,6 +32,7 @@ const (
 	MessagePartTypeText     MessagePartType = "text"
 	MessagePartTypeImageURL MessagePartType = "image_url"
 	MessagePartTypeFile     MessagePartType = "file"
+	MessagePartTypeDocument MessagePartType = "document"
 )
 
 type ImageURLDetail string
@@ -110,6 +111,7 @@ type MessagePart struct {
 	Text     string           `json:"text,omitempty"`
 	ImageURL *MessageImageURL `json:"image_url,omitempty"`
 	File     *MessageFile     `json:"file,omitempty"`
+	Document *Document        `json:"document,omitempty"`
 }
 
 // FinishReason represents the reason why the model finished generating a response

--- a/pkg/chat/document.go
+++ b/pkg/chat/document.go
@@ -1,0 +1,20 @@
+package chat
+
+// DocumentSource holds the actual content of a document attachment.
+// Exactly one of InlineText, InlineData, or URL should be set.
+type DocumentSource struct {
+	InlineText string `json:"inline_text,omitempty"` // plain text (TXT/MD/HTML/CSV)
+	InlineData []byte `json:"inline_data,omitempty"` // binary bytes (images, PDFs, etc.)
+	URL        string `json:"url,omitempty"`         // public HTTPS URL
+}
+
+// Document represents a file or document attachment that can be included in a
+// message part (set Type = MessagePartTypeDocument when populating this field).
+// Providers use the attachment package to decide how to handle the document
+// based on their capability tables.
+type Document struct {
+	Name     string         `json:"name"`
+	MimeType string         `json:"mime_type"`
+	Size     int64          `json:"size,omitempty"`
+	Source   DocumentSource `json:"source"`
+}

--- a/pkg/model/provider/anthropic/attachments.go
+++ b/pkg/model/provider/anthropic/attachments.go
@@ -85,7 +85,10 @@ func (c *Client) convertDocument(
 }
 
 // convertDocViaURL builds a content block that passes the URL directly.
-// For images: image block with URL source. Not used for PDFs (no URL cap).
+// NOTE: this function assumes URL is only set for image MIMEs per the capability
+// table. If application/pdf:{URL:true} is ever added, use
+// NewDocumentBlock(URLPDFSourceParam{URL: doc.Source.URL}) instead of
+// NewImageBlock — the Anthropic API rejects an image block for a PDF URL.
 func convertDocViaURL(doc chat.Document) []anthropic.ContentBlockParamUnion {
 	return []anthropic.ContentBlockParamUnion{
 		anthropic.NewImageBlock(anthropic.URLImageSourceParam{

--- a/pkg/model/provider/anthropic/attachments.go
+++ b/pkg/model/provider/anthropic/attachments.go
@@ -1,0 +1,256 @@
+package anthropic
+
+// attachments.go — Phase 1 attachment support for the Anthropic provider.
+//
+// convertDocument dispatches via attachment.Decide and returns zero or more
+// anthropic.ContentBlockParamUnion values ready for inclusion in a user message.
+// It handles both the standard and Beta API paths identically: images become
+// image blocks, text documents become text blocks (wrapped with TXTEnvelope),
+// and PDFs become document blocks with base64 source.
+//
+// Wire-up: convertUserMultiContent and convertBetaUserMultiContent both call
+// convertDocument for chat.MessagePartTypeDocument parts.
+
+import (
+	"context"
+	"encoding/base64"
+	"log/slog"
+	"sort"
+
+	"github.com/anthropics/anthropic-sdk-go"
+
+	"github.com/docker/docker-agent/pkg/attachment"
+	"github.com/docker/docker-agent/pkg/chat"
+)
+
+// capabilityTable is the Anthropic Phase 1 capability table.
+// Phase 1: TXT / B64 / URL only — no Files API.
+var capabilityTable = attachment.CapabilityTable{
+	"image/jpeg":      {B64: true, URL: true},
+	"image/png":       {B64: true, URL: true},
+	"image/gif":       {B64: true, URL: true},
+	"image/webp":      {B64: true, URL: true},
+	"application/pdf": {B64: true},
+	"text/plain":      {TXT: true},
+	"text/markdown":   {TXT: true},
+	"text/html":       {TXT: true},
+	"text/csv":        {TXT: true},
+}
+
+// SupportedMIMETypes implements attachment.Advisor.
+// Returns every MIME type that has at least one capability, sorted for determinism.
+func (c *Client) SupportedMIMETypes() []string {
+	mimes := make([]string, 0, len(capabilityTable))
+	for mime, cap := range capabilityTable {
+		if cap.TXT || cap.B64 || cap.URL {
+			mimes = append(mimes, mime)
+		}
+	}
+	sort.Strings(mimes)
+	return mimes
+}
+
+// convertDocument converts a chat.Document into zero or more
+// anthropic.ContentBlockParamUnion values.
+//
+// On StrategyDrop the attachment is silently skipped (a Warn is logged).
+func (c *Client) convertDocument(
+	ctx context.Context,
+	doc chat.Document,
+) ([]anthropic.ContentBlockParamUnion, error) {
+	strategy, reason := attachment.Decide(doc, capabilityTable)
+
+	switch strategy {
+	case attachment.StrategyURL:
+		return convertDocViaURL(doc), nil
+
+	case attachment.StrategyB64:
+		return convertDocViaB64(doc), nil
+
+	case attachment.StrategyTXT:
+		return convertDocViaTXT(doc), nil
+
+	case attachment.StrategyFetchAsB64:
+		slog.Warn("attachment: fetching URL as base64", "name", doc.Name, "reason", reason)
+		return convertDocViaFetchAsB64(ctx, doc)
+
+	case attachment.StrategyFetchAsTXT:
+		slog.Warn("attachment: fetching URL as text", "name", doc.Name, "reason", reason)
+		return convertDocViaFetchAsTXT(ctx, doc)
+
+	default: // StrategyDrop
+		slog.Warn("attachment: dropping document", "name", doc.Name, "mime", doc.MimeType, "reason", reason)
+		return nil, nil
+	}
+}
+
+// convertDocViaURL builds a content block that passes the URL directly.
+// For images: image block with URL source. Not used for PDFs (no URL cap).
+func convertDocViaURL(doc chat.Document) []anthropic.ContentBlockParamUnion {
+	return []anthropic.ContentBlockParamUnion{
+		anthropic.NewImageBlock(anthropic.URLImageSourceParam{
+			URL: doc.Source.URL,
+		}),
+	}
+}
+
+// convertDocViaB64 encodes inline binary as a base64 block.
+// Images use image blocks; PDFs use document blocks.
+func convertDocViaB64(doc chat.Document) []anthropic.ContentBlockParamUnion {
+	encoded := base64.StdEncoding.EncodeToString(doc.Source.InlineData)
+
+	if IsImageMime(doc.MimeType) {
+		return []anthropic.ContentBlockParamUnion{
+			anthropic.NewImageBlock(anthropic.Base64ImageSourceParam{
+				Data:      encoded,
+				MediaType: anthropic.Base64ImageSourceMediaType(doc.MimeType),
+			}),
+		}
+	}
+
+	// PDF or other binary document
+	return []anthropic.ContentBlockParamUnion{
+		anthropic.NewDocumentBlock(anthropic.Base64PDFSourceParam{
+			Data: encoded,
+		}),
+	}
+}
+
+// convertDocViaTXT wraps inline text in an XML envelope and returns a text block.
+func convertDocViaTXT(doc chat.Document) []anthropic.ContentBlockParamUnion {
+	envelope := attachment.TXTEnvelope(doc.Name, doc.MimeType, doc.Source.InlineText)
+	return []anthropic.ContentBlockParamUnion{
+		anthropic.NewTextBlock(envelope),
+	}
+}
+
+// convertDocViaFetchAsB64 fetches the URL and returns the bytes as a base64 block.
+func convertDocViaFetchAsB64(ctx context.Context, doc chat.Document) ([]anthropic.ContentBlockParamUnion, error) {
+	data, err := attachment.FetchURL(ctx, doc.Source.URL)
+	if err != nil {
+		slog.Warn("attachment: failed to fetch url for b64", "name", doc.Name, "url", doc.Source.URL, "error", err)
+		return nil, nil
+	}
+	fetched := doc
+	fetched.Source.InlineData = data
+	return convertDocViaB64(fetched), nil
+}
+
+// convertDocViaFetchAsTXT fetches the URL and returns its content as a text envelope.
+func convertDocViaFetchAsTXT(ctx context.Context, doc chat.Document) ([]anthropic.ContentBlockParamUnion, error) {
+	data, err := attachment.FetchURL(ctx, doc.Source.URL)
+	if err != nil {
+		slog.Warn("attachment: failed to fetch url for text", "name", doc.Name, "url", doc.Source.URL, "error", err)
+		return nil, nil
+	}
+	fetched := doc
+	fetched.Source.InlineText = string(data)
+	return convertDocViaTXT(fetched), nil
+}
+
+// convertBetaDocument converts a chat.Document into zero or more
+// anthropic.BetaContentBlockParamUnion values (Beta API).
+//
+// On StrategyDrop the attachment is silently skipped (a Warn is logged).
+func (c *Client) convertBetaDocument(
+	ctx context.Context,
+	doc chat.Document,
+) ([]anthropic.BetaContentBlockParamUnion, error) {
+	strategy, reason := attachment.Decide(doc, capabilityTable)
+
+	switch strategy {
+	case attachment.StrategyURL:
+		return convertBetaDocViaURL(doc), nil
+
+	case attachment.StrategyB64:
+		return convertBetaDocViaB64(doc), nil
+
+	case attachment.StrategyTXT:
+		return convertBetaDocViaTXT(doc), nil
+
+	case attachment.StrategyFetchAsB64:
+		slog.Warn("attachment: fetching URL as base64 (beta)", "name", doc.Name, "reason", reason)
+		return convertBetaDocViaFetchAsB64(ctx, doc)
+
+	case attachment.StrategyFetchAsTXT:
+		slog.Warn("attachment: fetching URL as text (beta)", "name", doc.Name, "reason", reason)
+		return convertBetaDocViaFetchAsTXT(ctx, doc)
+
+	default: // StrategyDrop
+		slog.Warn("attachment: dropping document (beta)", "name", doc.Name, "mime", doc.MimeType, "reason", reason)
+		return nil, nil
+	}
+}
+
+func convertBetaDocViaURL(doc chat.Document) []anthropic.BetaContentBlockParamUnion {
+	return []anthropic.BetaContentBlockParamUnion{
+		{
+			OfImage: &anthropic.BetaImageBlockParam{
+				Source: anthropic.BetaImageBlockParamSourceUnion{
+					OfURL: &anthropic.BetaURLImageSourceParam{URL: doc.Source.URL},
+				},
+			},
+		},
+	}
+}
+
+func convertBetaDocViaB64(doc chat.Document) []anthropic.BetaContentBlockParamUnion {
+	encoded := base64.StdEncoding.EncodeToString(doc.Source.InlineData)
+
+	if IsImageMime(doc.MimeType) {
+		return []anthropic.BetaContentBlockParamUnion{
+			{
+				OfImage: &anthropic.BetaImageBlockParam{
+					Source: anthropic.BetaImageBlockParamSourceUnion{
+						OfBase64: &anthropic.BetaBase64ImageSourceParam{
+							Data:      encoded,
+							MediaType: anthropic.BetaBase64ImageSourceMediaType(doc.MimeType),
+						},
+					},
+				},
+			},
+		}
+	}
+
+	// PDF document
+	return []anthropic.BetaContentBlockParamUnion{
+		{
+			OfDocument: &anthropic.BetaRequestDocumentBlockParam{
+				Source: anthropic.BetaRequestDocumentBlockSourceUnionParam{
+					OfBase64: &anthropic.BetaBase64PDFSourceParam{
+						Data: encoded,
+					},
+				},
+			},
+		},
+	}
+}
+
+func convertBetaDocViaTXT(doc chat.Document) []anthropic.BetaContentBlockParamUnion {
+	envelope := attachment.TXTEnvelope(doc.Name, doc.MimeType, doc.Source.InlineText)
+	return []anthropic.BetaContentBlockParamUnion{
+		{OfText: &anthropic.BetaTextBlockParam{Text: envelope}},
+	}
+}
+
+func convertBetaDocViaFetchAsB64(ctx context.Context, doc chat.Document) ([]anthropic.BetaContentBlockParamUnion, error) {
+	data, err := attachment.FetchURL(ctx, doc.Source.URL)
+	if err != nil {
+		slog.Warn("attachment: failed to fetch url for b64 (beta)", "name", doc.Name, "url", doc.Source.URL, "error", err)
+		return nil, nil
+	}
+	fetched := doc
+	fetched.Source.InlineData = data
+	return convertBetaDocViaB64(fetched), nil
+}
+
+func convertBetaDocViaFetchAsTXT(ctx context.Context, doc chat.Document) ([]anthropic.BetaContentBlockParamUnion, error) {
+	data, err := attachment.FetchURL(ctx, doc.Source.URL)
+	if err != nil {
+		slog.Warn("attachment: failed to fetch url for text (beta)", "name", doc.Name, "url", doc.Source.URL, "error", err)
+		return nil, nil
+	}
+	fetched := doc
+	fetched.Source.InlineText = string(data)
+	return convertBetaDocViaTXT(fetched), nil
+}

--- a/pkg/model/provider/anthropic/attachments_test.go
+++ b/pkg/model/provider/anthropic/attachments_test.go
@@ -1,0 +1,212 @@
+package anthropic
+
+// attachments_test.go — unit tests for the Anthropic attachment wiring.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/model/provider/base"
+)
+
+func buildTestClient() *Client {
+	return &Client{
+		Config: base.Config{
+			ModelConfig: latest.ModelConfig{
+				Provider: "anthropic",
+				Model:    "claude-3-5-sonnet-20241022",
+			},
+		},
+	}
+}
+
+func TestAnthropic_SupportedMIMETypes(t *testing.T) {
+	t.Parallel()
+
+	c := buildTestClient()
+	mimes := c.SupportedMIMETypes()
+	if len(mimes) == 0 {
+		t.Fatal("SupportedMIMETypes should return at least one MIME type")
+	}
+	mimeSet := make(map[string]bool, len(mimes))
+	for _, m := range mimes {
+		mimeSet[m] = true
+	}
+	for _, want := range []string{"image/png", "image/jpeg", "application/pdf", "text/plain", "text/markdown"} {
+		if !mimeSet[want] {
+			t.Errorf("expected MIME %q in SupportedMIMETypes, got %v", want, mimes)
+		}
+	}
+}
+
+func TestAnthropic_ConvertDocument_URL(t *testing.T) {
+	t.Parallel()
+
+	c := buildTestClient()
+	doc := chat.Document{
+		Name:     "photo.png",
+		MimeType: "image/png",
+		Source:   chat.DocumentSource{URL: "https://example.com/photo.png"},
+	}
+	blocks, err := c.convertDocument(t.Context(), doc)
+	if err != nil {
+		t.Fatalf("convertDocument: %v", err)
+	}
+	if len(blocks) != 1 {
+		t.Fatalf("want 1 block, got %d", len(blocks))
+	}
+	if blocks[0].OfImage == nil {
+		t.Fatal("expected image block")
+	}
+	if blocks[0].OfImage.Source.OfURL == nil {
+		t.Fatal("expected URL source")
+	}
+}
+
+func TestAnthropic_ConvertDocument_B64_Image(t *testing.T) {
+	t.Parallel()
+
+	c := buildTestClient()
+	doc := chat.Document{
+		Name:     "photo.png",
+		MimeType: "image/png",
+		Source:   chat.DocumentSource{InlineData: []byte("\x89PNG\r\n")},
+	}
+	blocks, err := c.convertDocument(t.Context(), doc)
+	if err != nil {
+		t.Fatalf("convertDocument: %v", err)
+	}
+	if len(blocks) != 1 {
+		t.Fatalf("want 1 block, got %d", len(blocks))
+	}
+	if blocks[0].OfImage == nil {
+		t.Fatal("expected image block")
+	}
+	if blocks[0].OfImage.Source.OfBase64 == nil {
+		t.Fatal("expected base64 source")
+	}
+}
+
+func TestAnthropic_ConvertDocument_B64_PDF(t *testing.T) {
+	t.Parallel()
+
+	c := buildTestClient()
+	doc := chat.Document{
+		Name:     "doc.pdf",
+		MimeType: "application/pdf",
+		Source:   chat.DocumentSource{InlineData: []byte("%PDF-1.4")},
+	}
+	blocks, err := c.convertDocument(t.Context(), doc)
+	if err != nil {
+		t.Fatalf("convertDocument: %v", err)
+	}
+	if len(blocks) != 1 {
+		t.Fatalf("want 1 block, got %d", len(blocks))
+	}
+	if blocks[0].OfDocument == nil {
+		t.Fatal("expected document block for PDF")
+	}
+}
+
+func TestAnthropic_ConvertDocument_TXT(t *testing.T) {
+	t.Parallel()
+
+	c := buildTestClient()
+	doc := chat.Document{
+		Name:     "readme.md",
+		MimeType: "text/markdown",
+		Source:   chat.DocumentSource{InlineText: "# Title"},
+	}
+	blocks, err := c.convertDocument(t.Context(), doc)
+	if err != nil {
+		t.Fatalf("convertDocument: %v", err)
+	}
+	if len(blocks) != 1 {
+		t.Fatalf("want 1 block, got %d", len(blocks))
+	}
+	if blocks[0].OfText == nil {
+		t.Fatal("expected text block for TXT strategy")
+	}
+	if !strings.Contains(blocks[0].OfText.Text, "# Title") {
+		t.Errorf("expected body in text block, got: %s", blocks[0].OfText.Text)
+	}
+}
+
+func TestAnthropic_ConvertDocument_FetchAsB64(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/pdf")
+		_, _ = w.Write([]byte("%PDF-1.4 test"))
+	}))
+	defer srv.Close()
+
+	c := buildTestClient()
+	doc := chat.Document{
+		Name:     "report.pdf",
+		MimeType: "application/pdf",
+		Source:   chat.DocumentSource{URL: srv.URL},
+	}
+	// application/pdf has B64 but no URL in Anthropic table → FetchAsB64
+	blocks, err := c.convertDocument(t.Context(), doc)
+	if err != nil {
+		t.Fatalf("convertDocument: %v", err)
+	}
+	if len(blocks) != 1 {
+		t.Fatalf("want 1 block, got %d", len(blocks))
+	}
+	if blocks[0].OfDocument == nil {
+		t.Fatal("expected document block after FetchAsB64")
+	}
+}
+
+func TestAnthropic_ConvertDocument_FetchAsTXT(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("plain text content"))
+	}))
+	defer srv.Close()
+
+	c := buildTestClient()
+	doc := chat.Document{
+		Name:     "notes.txt",
+		MimeType: "text/plain",
+		Source:   chat.DocumentSource{URL: srv.URL},
+	}
+	blocks, err := c.convertDocument(t.Context(), doc)
+	if err != nil {
+		t.Fatalf("convertDocument: %v", err)
+	}
+	if len(blocks) != 1 {
+		t.Fatalf("want 1 block, got %d", len(blocks))
+	}
+	if blocks[0].OfText == nil {
+		t.Fatal("expected text block after FetchAsTXT")
+	}
+	if !strings.Contains(blocks[0].OfText.Text, "plain text content") {
+		t.Errorf("expected fetched body in envelope, got: %s", blocks[0].OfText.Text)
+	}
+}
+
+func TestAnthropic_ConvertDocument_Drop(t *testing.T) {
+	t.Parallel()
+
+	c := buildTestClient()
+	doc := chat.Document{
+		Name:     "clip.mp4",
+		MimeType: "video/mp4",
+		Source:   chat.DocumentSource{InlineData: []byte("data")},
+	}
+	blocks, err := c.convertDocument(t.Context(), doc)
+	if err != nil {
+		t.Fatalf("convertDocument returned error on drop: %v", err)
+	}
+	if len(blocks) != 0 {
+		t.Errorf("expected 0 blocks on drop, got %d", len(blocks))
+	}
+}

--- a/pkg/model/provider/anthropic/beta_converter.go
+++ b/pkg/model/provider/anthropic/beta_converter.go
@@ -237,6 +237,16 @@ func (c *Client) convertBetaUserMultiContent(ctx context.Context, parts []chat.M
 				})
 			}
 
+		case chat.MessagePartTypeDocument:
+			if part.Document == nil {
+				continue
+			}
+			docBlocks, err := c.convertBetaDocument(ctx, *part.Document)
+			if err != nil {
+				return nil, err
+			}
+			contentBlocks = append(contentBlocks, docBlocks...)
+
 		case chat.MessagePartTypeFile:
 			if part.File == nil {
 				continue

--- a/pkg/model/provider/anthropic/client.go
+++ b/pkg/model/provider/anthropic/client.go
@@ -478,7 +478,7 @@ func extractMediaType(prefix string) string {
 // convertUserMultiContent converts user message multi-content parts to Anthropic content blocks.
 // It handles text and images (base64 and URL). File uploads are NOT supported in the non-Beta API
 // and will return an error - callers should use hasFileAttachments() to route to the Beta API.
-func (c *Client) convertUserMultiContent(_ context.Context, parts []chat.MessagePart) ([]anthropic.ContentBlockParamUnion, error) {
+func (c *Client) convertUserMultiContent(ctx context.Context, parts []chat.MessagePart) ([]anthropic.ContentBlockParamUnion, error) {
 	contentBlocks := make([]anthropic.ContentBlockParamUnion, 0, len(parts))
 
 	for _, part := range parts {
@@ -508,6 +508,16 @@ func (c *Client) convertUserMultiContent(_ context.Context, parts []chat.Message
 					URL: part.ImageURL.URL,
 				}))
 			}
+
+		case chat.MessagePartTypeDocument:
+			if part.Document == nil {
+				continue
+			}
+			docBlocks, err := c.convertDocument(ctx, *part.Document)
+			if err != nil {
+				return nil, err
+			}
+			contentBlocks = append(contentBlocks, docBlocks...)
 
 		case chat.MessagePartTypeFile:
 			if part.File == nil {

--- a/pkg/model/provider/bedrock/attachments.go
+++ b/pkg/model/provider/bedrock/attachments.go
@@ -1,0 +1,333 @@
+package bedrock
+
+// attachments.go — Phase 1 attachment support for the Bedrock provider.
+//
+// Wire-up: convertUserContentCtx replaces convertUserContent in the context-aware
+// convertMessagesCtx method, handling MessagePartTypeDocument parts by calling
+// convertDocument and injecting the resulting ContentBlocks inline.
+// The existing package-level convertMessages / convertUserContent functions are
+// unchanged so pre-existing tests continue to compile and pass.
+
+import (
+	"context"
+	"log/slog"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+
+	"github.com/docker/docker-agent/pkg/attachment"
+	"github.com/docker/docker-agent/pkg/chat"
+)
+
+// capabilityTable is the Bedrock Phase 1 capability table.
+// Bedrock Converse API: images and PDFs as B64 bytes; text documents as TXT envelopes.
+// Phase 1: no URL delivery, no Files API.
+var capabilityTable = attachment.CapabilityTable{
+	"image/jpeg":      {B64: true},
+	"image/png":       {B64: true},
+	"image/gif":       {B64: true},
+	"image/webp":      {B64: true},
+	"application/pdf": {B64: true},
+	"text/plain":      {TXT: true},
+	"text/markdown":   {TXT: true},
+	"text/html":       {TXT: true},
+	"text/csv":        {TXT: true},
+}
+
+// SupportedMIMETypes implements attachment.Advisor.
+// Returns every MIME type that has at least one capability, sorted for determinism.
+func (c *Client) SupportedMIMETypes() []string {
+	mimes := make([]string, 0, len(capabilityTable))
+	for mime, cap := range capabilityTable {
+		if cap.TXT || cap.B64 || cap.URL {
+			mimes = append(mimes, mime)
+		}
+	}
+	sort.Strings(mimes)
+	return mimes
+}
+
+// convertDocument converts a chat.Document into zero or more types.ContentBlock values.
+//
+// On StrategyDrop the attachment is silently skipped (a Warn is logged).
+func (c *Client) convertDocument(ctx context.Context, doc chat.Document) ([]types.ContentBlock, error) {
+	strategy, reason := attachment.Decide(doc, capabilityTable)
+
+	switch strategy {
+	case attachment.StrategyB64:
+		return convertDocViaB64(doc), nil
+
+	case attachment.StrategyTXT:
+		return convertDocViaTXT(doc), nil
+
+	case attachment.StrategyFetchAsB64:
+		slog.Warn("attachment: fetching URL as base64", "name", doc.Name, "reason", reason)
+		return convertDocViaFetchAsB64(ctx, doc)
+
+	case attachment.StrategyFetchAsTXT:
+		slog.Warn("attachment: fetching URL as text", "name", doc.Name, "reason", reason)
+		return convertDocViaFetchAsTXT(ctx, doc)
+
+	default: // StrategyDrop (and StrategyURL — not in Bedrock table)
+		slog.Warn("attachment: dropping document", "name", doc.Name, "mime", doc.MimeType, "reason", reason)
+		return nil, nil
+	}
+}
+
+// mimeToImageFormat converts a MIME type to a Bedrock ImageFormat.
+func mimeToImageFormat(mimeType string) (types.ImageFormat, bool) {
+	switch mimeType {
+	case "image/jpeg":
+		return types.ImageFormatJpeg, true
+	case "image/png":
+		return types.ImageFormatPng, true
+	case "image/gif":
+		return types.ImageFormatGif, true
+	case "image/webp":
+		return types.ImageFormatWebp, true
+	default:
+		return "", false
+	}
+}
+
+// mimeToDocumentFormat converts a MIME type to a Bedrock DocumentFormat.
+func mimeToDocumentFormat(mimeType string) (types.DocumentFormat, bool) {
+	switch mimeType {
+	case "application/pdf":
+		return types.DocumentFormatPdf, true
+	case "text/plain":
+		return types.DocumentFormatTxt, true
+	case "text/markdown":
+		return types.DocumentFormatMd, true
+	case "text/html":
+		return types.DocumentFormatHtml, true
+	case "text/csv":
+		return types.DocumentFormatCsv, true
+	default:
+		return "", false
+	}
+}
+
+// sanitizeDocName removes characters disallowed by Bedrock's DocumentBlock.Name
+// constraint: only alphanumerics, single spaces, hyphens, parentheses, and
+// square brackets are permitted.
+var invalidDocNameChar = regexp.MustCompile(`[^a-zA-Z0-9 \-()\[\]]`)
+
+func sanitizeDocName(name string) string {
+	base := strings.TrimSuffix(filepath.Base(name), filepath.Ext(name))
+	if base == "" || base == "." {
+		return "document"
+	}
+	clean := invalidDocNameChar.ReplaceAllString(base, "-")
+	// Collapse runs of spaces to a single space (Bedrock requirement).
+	result := strings.Join(strings.Fields(clean), " ")
+	if result == "" {
+		return "document"
+	}
+	return result
+}
+
+// convertDocViaB64 encodes inline binary and returns the appropriate Bedrock block.
+// Images → ImageBlock; documents (PDF etc.) → DocumentBlock with bytes source.
+func convertDocViaB64(doc chat.Document) []types.ContentBlock {
+	if format, ok := mimeToImageFormat(doc.MimeType); ok {
+		return []types.ContentBlock{
+			&types.ContentBlockMemberImage{
+				Value: types.ImageBlock{
+					Format: format,
+					Source: &types.ImageSourceMemberBytes{
+						Value: doc.Source.InlineData,
+					},
+				},
+			},
+		}
+	}
+
+	if format, ok := mimeToDocumentFormat(doc.MimeType); ok {
+		return []types.ContentBlock{
+			&types.ContentBlockMemberDocument{
+				Value: types.DocumentBlock{
+					Name:   aws.String(sanitizeDocName(doc.Name)),
+					Format: format,
+					Source: &types.DocumentSourceMemberBytes{
+						Value: doc.Source.InlineData,
+					},
+				},
+			},
+		}
+	}
+
+	slog.Warn("attachment: bedrock cannot encode mime as B64", "mime", doc.MimeType)
+	return nil
+}
+
+// convertDocViaTXT wraps inline text in an XML envelope and returns a text block.
+func convertDocViaTXT(doc chat.Document) []types.ContentBlock {
+	envelope := attachment.TXTEnvelope(doc.Name, doc.MimeType, doc.Source.InlineText)
+	return []types.ContentBlock{
+		&types.ContentBlockMemberText{Value: envelope},
+	}
+}
+
+// convertDocViaFetchAsB64 fetches the URL and returns the bytes as a B64 block.
+func convertDocViaFetchAsB64(ctx context.Context, doc chat.Document) ([]types.ContentBlock, error) {
+	data, err := attachment.FetchURL(ctx, doc.Source.URL)
+	if err != nil {
+		slog.Warn("attachment: failed to fetch url for b64", "name", doc.Name, "url", doc.Source.URL, "error", err)
+		return nil, nil
+	}
+	fetched := doc
+	fetched.Source.InlineData = data
+	return convertDocViaB64(fetched), nil
+}
+
+// convertDocViaFetchAsTXT fetches the URL and returns its content as a text envelope.
+func convertDocViaFetchAsTXT(ctx context.Context, doc chat.Document) ([]types.ContentBlock, error) {
+	data, err := attachment.FetchURL(ctx, doc.Source.URL)
+	if err != nil {
+		slog.Warn("attachment: failed to fetch url for text", "name", doc.Name, "url", doc.Source.URL, "error", err)
+		return nil, nil
+	}
+	fetched := doc
+	fetched.Source.InlineText = string(data)
+	return convertDocViaTXT(fetched), nil
+}
+
+// convertUserContentCtx is the context-aware variant of convertUserContent.
+// It handles MessagePartTypeDocument parts via convertDocument, passing all
+// other parts to the existing convertImageURL / text logic.
+func (c *Client) convertUserContentCtx(ctx context.Context, msg *chat.Message) ([]types.ContentBlock, error) {
+	if len(msg.MultiContent) == 0 {
+		return []types.ContentBlock{
+			&types.ContentBlockMemberText{Value: msg.Content},
+		}, nil
+	}
+
+	var blocks []types.ContentBlock
+	for _, part := range msg.MultiContent {
+		switch part.Type {
+		case chat.MessagePartTypeText:
+			blocks = append(blocks, &types.ContentBlockMemberText{Value: part.Text})
+
+		case chat.MessagePartTypeImageURL:
+			if part.ImageURL != nil {
+				if imageBlock := convertImageURL(part.ImageURL); imageBlock != nil {
+					blocks = append(blocks, imageBlock)
+				}
+			}
+
+		case chat.MessagePartTypeDocument:
+			if part.Document == nil {
+				continue
+			}
+			docBlocks, err := c.convertDocument(ctx, *part.Document)
+			if err != nil {
+				return nil, err
+			}
+			blocks = append(blocks, docBlocks...)
+		}
+	}
+	return blocks, nil
+}
+
+// hasDocumentParts reports whether any message contains a document part.
+func hasDocumentParts(messages []chat.Message) bool {
+	for i := range messages {
+		for _, part := range messages[i].MultiContent {
+			if part.Type == chat.MessagePartTypeDocument {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// convertMessagesCtx is the context-aware variant of the package-level
+// convertMessages function. It handles document parts; everything else
+// delegates to the existing logic.
+func (c *Client) convertMessagesCtx(ctx context.Context, messages []chat.Message, enableCaching bool) ([]types.Message, []types.SystemContentBlock, error) {
+	if !hasDocumentParts(messages) {
+		msgs, sys := convertMessages(messages, enableCaching)
+		return msgs, sys, nil
+	}
+
+	var bedrockMessages []types.Message
+	var systemBlocks []types.SystemContentBlock
+
+	for i := 0; i < len(messages); i++ {
+		msg := &messages[i]
+
+		switch msg.Role {
+		case chat.MessageRoleSystem:
+			if len(msg.MultiContent) > 0 {
+				for _, part := range msg.MultiContent {
+					if part.Type == chat.MessagePartTypeText {
+						systemBlocks = append(systemBlocks, &types.SystemContentBlockMemberText{Value: part.Text})
+					}
+				}
+			} else {
+				systemBlocks = append(systemBlocks, &types.SystemContentBlockMemberText{Value: msg.Content})
+			}
+
+		case chat.MessageRoleUser:
+			contentBlocks, err := c.convertUserContentCtx(ctx, msg)
+			if err != nil {
+				return nil, nil, err
+			}
+			if len(contentBlocks) > 0 {
+				bedrockMessages = append(bedrockMessages, types.Message{
+					Role:    types.ConversationRoleUser,
+					Content: contentBlocks,
+				})
+			}
+
+		case chat.MessageRoleAssistant:
+			contentBlocks := convertAssistantContent(msg)
+			if len(contentBlocks) > 0 {
+				bedrockMessages = append(bedrockMessages, types.Message{
+					Role:    types.ConversationRoleAssistant,
+					Content: contentBlocks,
+				})
+			}
+
+		case chat.MessageRoleTool:
+			var toolResultBlocks []types.ContentBlock
+			j := i
+			for j < len(messages) && messages[j].Role == chat.MessageRoleTool {
+				if messages[j].ToolCallID != "" {
+					toolResultBlocks = append(toolResultBlocks, &types.ContentBlockMemberToolResult{
+						Value: types.ToolResultBlock{
+							ToolUseId: aws.String(messages[j].ToolCallID),
+							Content: []types.ToolResultContentBlock{
+								&types.ToolResultContentBlockMemberText{Value: messages[j].Content},
+							},
+						},
+					})
+				}
+				j++
+			}
+			if len(toolResultBlocks) > 0 {
+				bedrockMessages = append(bedrockMessages, types.Message{
+					Role:    types.ConversationRoleUser,
+					Content: toolResultBlocks,
+				})
+			}
+			i = j - 1
+		}
+	}
+
+	if enableCaching {
+		if len(systemBlocks) > 0 {
+			systemBlocks = append(systemBlocks, &types.SystemContentBlockMemberCachePoint{
+				Value: types.CachePointBlock{Type: types.CachePointTypeDefault},
+			})
+		}
+		applyCachePointsToMessages(bedrockMessages)
+	}
+
+	return bedrockMessages, systemBlocks, nil
+}

--- a/pkg/model/provider/bedrock/attachments_test.go
+++ b/pkg/model/provider/bedrock/attachments_test.go
@@ -1,0 +1,217 @@
+package bedrock
+
+// attachments_test.go — unit tests for the Bedrock attachment wiring.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/model/provider/base"
+)
+
+func buildTestBedrockClient() *Client {
+	return &Client{
+		Config: base.Config{
+			ModelConfig: latest.ModelConfig{
+				Provider: "amazon-bedrock",
+				Model:    "anthropic.claude-3-5-sonnet-20241022-v2:0",
+			},
+		},
+	}
+}
+
+func TestBedrock_SupportedMIMETypes(t *testing.T) {
+	t.Parallel()
+
+	c := buildTestBedrockClient()
+	mimes := c.SupportedMIMETypes()
+	if len(mimes) == 0 {
+		t.Fatal("SupportedMIMETypes should return at least one MIME type")
+	}
+	mimeSet := make(map[string]bool, len(mimes))
+	for _, m := range mimes {
+		mimeSet[m] = true
+	}
+	for _, want := range []string{"image/png", "image/jpeg", "application/pdf", "text/plain", "text/markdown"} {
+		if !mimeSet[want] {
+			t.Errorf("expected MIME %q in SupportedMIMETypes, got %v", want, mimes)
+		}
+	}
+}
+
+func TestBedrock_ConvertDocument_B64_Image(t *testing.T) {
+	t.Parallel()
+
+	c := buildTestBedrockClient()
+	doc := chat.Document{
+		Name:     "photo.png",
+		MimeType: "image/png",
+		Source:   chat.DocumentSource{InlineData: []byte("\x89PNG\r\n\x1a\n")},
+	}
+	blocks, err := c.convertDocument(t.Context(), doc)
+	if err != nil {
+		t.Fatalf("convertDocument: %v", err)
+	}
+	if len(blocks) != 1 {
+		t.Fatalf("want 1 block, got %d", len(blocks))
+	}
+	imgBlock, ok := blocks[0].(*types.ContentBlockMemberImage)
+	if !ok {
+		t.Fatalf("expected ContentBlockMemberImage, got %T", blocks[0])
+	}
+	if imgBlock.Value.Format != types.ImageFormatPng {
+		t.Errorf("expected PNG format, got %v", imgBlock.Value.Format)
+	}
+}
+
+func TestBedrock_ConvertDocument_B64_PDF(t *testing.T) {
+	t.Parallel()
+
+	c := buildTestBedrockClient()
+	doc := chat.Document{
+		Name:     "report.pdf",
+		MimeType: "application/pdf",
+		Source:   chat.DocumentSource{InlineData: []byte("%PDF-1.4")},
+	}
+	blocks, err := c.convertDocument(t.Context(), doc)
+	if err != nil {
+		t.Fatalf("convertDocument: %v", err)
+	}
+	if len(blocks) != 1 {
+		t.Fatalf("want 1 block, got %d", len(blocks))
+	}
+	docBlock, ok := blocks[0].(*types.ContentBlockMemberDocument)
+	if !ok {
+		t.Fatalf("expected ContentBlockMemberDocument, got %T", blocks[0])
+	}
+	if docBlock.Value.Format != types.DocumentFormatPdf {
+		t.Errorf("expected PDF format, got %v", docBlock.Value.Format)
+	}
+}
+
+func TestBedrock_ConvertDocument_TXT(t *testing.T) {
+	t.Parallel()
+
+	c := buildTestBedrockClient()
+	doc := chat.Document{
+		Name:     "notes.txt",
+		MimeType: "text/plain",
+		Source:   chat.DocumentSource{InlineText: "hello bedrock"},
+	}
+	blocks, err := c.convertDocument(t.Context(), doc)
+	if err != nil {
+		t.Fatalf("convertDocument: %v", err)
+	}
+	if len(blocks) != 1 {
+		t.Fatalf("want 1 block, got %d", len(blocks))
+	}
+	textBlock, ok := blocks[0].(*types.ContentBlockMemberText)
+	if !ok {
+		t.Fatalf("expected ContentBlockMemberText, got %T", blocks[0])
+	}
+	if !strings.Contains(textBlock.Value, "hello bedrock") {
+		t.Errorf("expected body in text block, got: %s", textBlock.Value)
+	}
+}
+
+func TestBedrock_ConvertDocument_FetchAsB64(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/pdf")
+		_, _ = w.Write([]byte("%PDF-1.4"))
+	}))
+	defer srv.Close()
+
+	c := buildTestBedrockClient()
+	doc := chat.Document{
+		Name:     "doc.pdf",
+		MimeType: "application/pdf",
+		Source:   chat.DocumentSource{URL: srv.URL},
+	}
+	blocks, err := c.convertDocument(t.Context(), doc)
+	if err != nil {
+		t.Fatalf("convertDocument: %v", err)
+	}
+	if len(blocks) != 1 {
+		t.Fatalf("want 1 block after FetchAsB64, got %d", len(blocks))
+	}
+	if _, ok := blocks[0].(*types.ContentBlockMemberDocument); !ok {
+		t.Fatalf("expected ContentBlockMemberDocument after FetchAsB64, got %T", blocks[0])
+	}
+}
+
+func TestBedrock_ConvertDocument_FetchAsTXT(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("fetched text"))
+	}))
+	defer srv.Close()
+
+	c := buildTestBedrockClient()
+	doc := chat.Document{
+		Name:     "notes.txt",
+		MimeType: "text/plain",
+		Source:   chat.DocumentSource{URL: srv.URL},
+	}
+	blocks, err := c.convertDocument(t.Context(), doc)
+	if err != nil {
+		t.Fatalf("convertDocument: %v", err)
+	}
+	if len(blocks) != 1 {
+		t.Fatalf("want 1 block after FetchAsTXT, got %d", len(blocks))
+	}
+	textBlock, ok := blocks[0].(*types.ContentBlockMemberText)
+	if !ok {
+		t.Fatalf("expected ContentBlockMemberText, got %T", blocks[0])
+	}
+	if !strings.Contains(textBlock.Value, "fetched text") {
+		t.Errorf("expected fetched content in envelope, got: %s", textBlock.Value)
+	}
+}
+
+func TestBedrock_ConvertDocument_Drop(t *testing.T) {
+	t.Parallel()
+
+	c := buildTestBedrockClient()
+	doc := chat.Document{
+		Name:     "archive.zip",
+		MimeType: "application/zip",
+		Source:   chat.DocumentSource{InlineData: []byte("data")},
+	}
+	blocks, err := c.convertDocument(t.Context(), doc)
+	if err != nil {
+		t.Fatalf("convertDocument returned error on drop: %v", err)
+	}
+	if len(blocks) != 0 {
+		t.Errorf("expected 0 blocks on drop, got %d", len(blocks))
+	}
+}
+
+func TestBedrock_SanitizeDocName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"report.pdf", "report"},
+		{"my report.pdf", "my report"},
+		{"bad@chars!.pdf", "bad-chars-"},
+		{"  .pdf", "document"},
+		{"my  doc.pdf", "my doc"}, // double space collapsed
+	}
+	for _, tc := range tests {
+		got := sanitizeDocName(tc.input)
+		if got != tc.want {
+			t.Errorf("sanitizeDocName(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}

--- a/pkg/model/provider/bedrock/client.go
+++ b/pkg/model/provider/bedrock/client.go
@@ -215,7 +215,11 @@ func (c *Client) CreateChatCompletionStream(
 	}
 
 	// Build Converse input
-	input := c.buildConverseStreamInput(messages, requestTools)
+	input, err := c.buildConverseStreamInput(ctx, messages, requestTools)
+	if err != nil {
+		slog.Error("Failed to convert messages for Bedrock request", "error", err)
+		return nil, err
+	}
 
 	// Call ConverseStream
 	output, err := c.bedrockClient.ConverseStream(ctx, input)
@@ -228,15 +232,19 @@ func (c *Client) CreateChatCompletionStream(
 	return newStreamAdapter(output.GetStream(), c.ModelConfig.Model, trackUsage), nil
 }
 
-func (c *Client) buildConverseStreamInput(messages []chat.Message, requestTools []tools.Tool) *bedrockruntime.ConverseStreamInput {
+func (c *Client) buildConverseStreamInput(ctx context.Context, messages []chat.Message, requestTools []tools.Tool) (*bedrockruntime.ConverseStreamInput, error) {
 	input := &bedrockruntime.ConverseStreamInput{
 		ModelId: aws.String(c.ModelConfig.Model),
 	}
 
 	enableCaching := c.promptCachingEnabled()
 
-	// Convert and set messages (excluding system)
-	input.Messages, input.System = convertMessages(messages, enableCaching)
+	// Convert messages; document parts are expanded context-awarely.
+	var err error
+	input.Messages, input.System, err = c.convertMessagesCtx(ctx, messages, enableCaching)
+	if err != nil {
+		return nil, err
+	}
 
 	// Compute thinking fields first — its presence drives the inference config.
 	additionalFields := c.buildAdditionalModelRequestFields()
@@ -252,7 +260,7 @@ func (c *Client) buildConverseStreamInput(messages []chat.Message, requestTools 
 		input.ToolConfig = convertToolConfig(requestTools, enableCaching)
 	}
 
-	return input
+	return input, nil
 }
 
 func (c *Client) buildInferenceConfig(thinkingEnabled bool) *types.InferenceConfiguration {

--- a/pkg/model/provider/gemini/attachments.go
+++ b/pkg/model/provider/gemini/attachments.go
@@ -1,0 +1,121 @@
+package gemini
+
+// attachments.go — Phase 1 attachment support for the Gemini provider.
+
+import (
+	"context"
+	"log/slog"
+	"sort"
+
+	"google.golang.org/genai"
+
+	"github.com/docker/docker-agent/pkg/attachment"
+	"github.com/docker/docker-agent/pkg/chat"
+)
+
+// capabilityTable is the Gemini Phase 1 capability table.
+// Gemini only supports B64 (inline binary) and TXT; no URL delivery for documents.
+// Phase 1: no Files API.
+var capabilityTable = attachment.CapabilityTable{
+	"image/jpeg":      {B64: true},
+	"image/png":       {B64: true},
+	"image/gif":       {B64: true},
+	"image/webp":      {B64: true},
+	"image/heic":      {B64: true},
+	"image/heif":      {B64: true},
+	"application/pdf": {B64: true},
+	"text/plain":      {TXT: true},
+	"text/markdown":   {TXT: true},
+	"text/html":       {TXT: true},
+	"text/csv":        {TXT: true},
+	"video/mp4":       {B64: true},
+	"video/mov":       {B64: true},
+	"video/webm":      {B64: true},
+	"video/avi":       {B64: true},
+	"video/mkv":       {B64: true},
+	"audio/wav":       {B64: true},
+	"audio/mp3":       {B64: true},
+	"audio/flac":      {B64: true},
+	"audio/aac":       {B64: true},
+	"audio/ogg":       {B64: true},
+	"audio/aiff":      {B64: true},
+}
+
+// SupportedMIMETypes implements attachment.Advisor.
+// Returns every MIME type that has at least one capability, sorted for determinism.
+func (c *Client) SupportedMIMETypes() []string {
+	mimes := make([]string, 0, len(capabilityTable))
+	for mime, cap := range capabilityTable {
+		if cap.TXT || cap.B64 || cap.URL {
+			mimes = append(mimes, mime)
+		}
+	}
+	sort.Strings(mimes)
+	return mimes
+}
+
+// convertDocument converts a chat.Document into zero or more *genai.Part values.
+//
+// On StrategyDrop the attachment is silently skipped (a Warn is logged).
+func (c *Client) convertDocument(ctx context.Context, doc chat.Document) ([]*genai.Part, error) {
+	strategy, reason := attachment.Decide(doc, capabilityTable)
+
+	switch strategy {
+	case attachment.StrategyB64:
+		return convertDocViaB64(doc), nil
+
+	case attachment.StrategyTXT:
+		return convertDocViaTXT(doc), nil
+
+	case attachment.StrategyFetchAsB64:
+		slog.Warn("attachment: fetching URL as base64", "name", doc.Name, "reason", reason)
+		return convertDocViaFetchAsB64(ctx, doc)
+
+	case attachment.StrategyFetchAsTXT:
+		slog.Warn("attachment: fetching URL as text", "name", doc.Name, "reason", reason)
+		return convertDocViaFetchAsTXT(ctx, doc)
+
+	default: // StrategyDrop (and StrategyURL — not in Gemini table)
+		slog.Warn("attachment: dropping document", "name", doc.Name, "mime", doc.MimeType, "reason", reason)
+		return nil, nil
+	}
+}
+
+// convertDocViaB64 creates a Blob part from inline binary data.
+func convertDocViaB64(doc chat.Document) []*genai.Part {
+	return []*genai.Part{
+		genai.NewPartFromBytes(doc.Source.InlineData, doc.MimeType),
+	}
+}
+
+// convertDocViaTXT wraps inline text in an XML envelope and returns a text part.
+func convertDocViaTXT(doc chat.Document) []*genai.Part {
+	envelope := attachment.TXTEnvelope(doc.Name, doc.MimeType, doc.Source.InlineText)
+	return []*genai.Part{
+		genai.NewPartFromText(envelope),
+	}
+}
+
+// convertDocViaFetchAsB64 fetches the URL and returns its bytes as a Blob part.
+func convertDocViaFetchAsB64(ctx context.Context, doc chat.Document) ([]*genai.Part, error) {
+	data, err := attachment.FetchURL(ctx, doc.Source.URL)
+	if err != nil {
+		slog.Warn("attachment: failed to fetch url for b64", "name", doc.Name, "url", doc.Source.URL, "error", err)
+		return nil, nil
+	}
+	fetched := doc
+	fetched.Source.InlineData = data
+	return convertDocViaB64(fetched), nil
+}
+
+// convertDocViaFetchAsTXT fetches the URL and returns its content as a text envelope.
+func convertDocViaFetchAsTXT(ctx context.Context, doc chat.Document) ([]*genai.Part, error) {
+	data, err := attachment.FetchURL(ctx, doc.Source.URL)
+	if err != nil {
+		slog.Warn("attachment: failed to fetch url for text", "name", doc.Name, "url", doc.Source.URL, "error", err)
+		return nil, nil
+	}
+	fetched := doc
+	fetched.Source.InlineText = string(data)
+	return convertDocViaTXT(fetched), nil
+}

--- a/pkg/model/provider/gemini/attachments_test.go
+++ b/pkg/model/provider/gemini/attachments_test.go
@@ -1,0 +1,158 @@
+package gemini
+
+// attachments_test.go — unit tests for the Gemini attachment wiring.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker-agent/pkg/chat"
+)
+
+func TestGemini_SupportedMIMETypes(t *testing.T) {
+	t.Parallel()
+
+	c := &Client{}
+	mimes := c.SupportedMIMETypes()
+	if len(mimes) == 0 {
+		t.Fatal("SupportedMIMETypes should return at least one MIME type")
+	}
+	mimeSet := make(map[string]bool, len(mimes))
+	for _, m := range mimes {
+		mimeSet[m] = true
+	}
+	// Gemini-specific: images, video, audio, PDF, text
+	for _, want := range []string{
+		"image/png", "image/jpeg", "image/heic", "image/heif",
+		"video/mp4", "audio/wav", "application/pdf", "text/plain",
+	} {
+		if !mimeSet[want] {
+			t.Errorf("expected MIME %q in SupportedMIMETypes, got %v", want, mimes)
+		}
+	}
+}
+
+func TestGemini_ConvertDocument_B64(t *testing.T) {
+	t.Parallel()
+
+	c := &Client{}
+	doc := chat.Document{
+		Name:     "photo.png",
+		MimeType: "image/png",
+		Source:   chat.DocumentSource{InlineData: []byte("\x89PNG\r\n\x1a\n")},
+	}
+	parts, err := c.convertDocument(t.Context(), doc)
+	if err != nil {
+		t.Fatalf("convertDocument: %v", err)
+	}
+	if len(parts) != 1 {
+		t.Fatalf("want 1 part, got %d", len(parts))
+	}
+	if parts[0].InlineData == nil {
+		t.Fatal("expected InlineData part")
+	}
+	if parts[0].InlineData.MIMEType != "image/png" {
+		t.Errorf("unexpected MIME type: %s", parts[0].InlineData.MIMEType)
+	}
+}
+
+func TestGemini_ConvertDocument_TXT(t *testing.T) {
+	t.Parallel()
+
+	c := &Client{}
+	doc := chat.Document{
+		Name:     "readme.md",
+		MimeType: "text/markdown",
+		Source:   chat.DocumentSource{InlineText: "# Hello"},
+	}
+	parts, err := c.convertDocument(t.Context(), doc)
+	if err != nil {
+		t.Fatalf("convertDocument: %v", err)
+	}
+	if len(parts) != 1 {
+		t.Fatalf("want 1 part, got %d", len(parts))
+	}
+	if parts[0].Text == "" {
+		t.Fatal("expected Text part")
+	}
+	if !strings.Contains(parts[0].Text, "# Hello") {
+		t.Errorf("expected body in text part, got: %s", parts[0].Text)
+	}
+}
+
+func TestGemini_ConvertDocument_FetchAsB64(t *testing.T) {
+	t.Parallel()
+
+	pdfBytes := []byte("%PDF-1.4 test content")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/pdf")
+		_, _ = w.Write(pdfBytes)
+	}))
+	defer srv.Close()
+
+	c := &Client{}
+	doc := chat.Document{
+		Name:     "doc.pdf",
+		MimeType: "application/pdf",
+		Source:   chat.DocumentSource{URL: srv.URL},
+	}
+	parts, err := c.convertDocument(t.Context(), doc)
+	if err != nil {
+		t.Fatalf("convertDocument: %v", err)
+	}
+	if len(parts) != 1 {
+		t.Fatalf("want 1 part, got %d", len(parts))
+	}
+	if parts[0].InlineData == nil {
+		t.Fatal("expected InlineData part after FetchAsB64")
+	}
+}
+
+func TestGemini_ConvertDocument_FetchAsTXT(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("plain text"))
+	}))
+	defer srv.Close()
+
+	c := &Client{}
+	doc := chat.Document{
+		Name:     "notes.txt",
+		MimeType: "text/plain",
+		Source:   chat.DocumentSource{URL: srv.URL},
+	}
+	parts, err := c.convertDocument(t.Context(), doc)
+	if err != nil {
+		t.Fatalf("convertDocument: %v", err)
+	}
+	if len(parts) != 1 {
+		t.Fatalf("want 1 part, got %d", len(parts))
+	}
+	if parts[0].Text == "" {
+		t.Fatal("expected Text part after FetchAsTXT")
+	}
+	if !strings.Contains(parts[0].Text, "plain text") {
+		t.Errorf("expected fetched content in envelope, got: %s", parts[0].Text)
+	}
+}
+
+func TestGemini_ConvertDocument_Drop(t *testing.T) {
+	t.Parallel()
+
+	c := &Client{}
+	doc := chat.Document{
+		Name:     "archive.zip",
+		MimeType: "application/zip",
+		Source:   chat.DocumentSource{InlineData: []byte("data")},
+	}
+	parts, err := c.convertDocument(t.Context(), doc)
+	if err != nil {
+		t.Fatalf("convertDocument returned error on drop: %v", err)
+	}
+	if len(parts) != 0 {
+		t.Errorf("expected 0 parts on drop, got %d", len(parts))
+	}
+}

--- a/pkg/model/provider/gemini/client.go
+++ b/pkg/model/provider/gemini/client.go
@@ -191,8 +191,9 @@ func thoughtSignatureOrDefault(sig []byte) []byte {
 	return defaultThoughtSignature
 }
 
-// convertMessagesToGemini converts chat.Messages into Gemini Contents
-func convertMessagesToGemini(messages []chat.Message) []*genai.Content {
+// convertMessagesToGemini converts chat.Messages into Gemini Contents.
+// It requires a context because document parts may need to fetch remote URLs.
+func (c *Client) convertMessagesToGemini(ctx context.Context, messages []chat.Message) ([]*genai.Content, error) {
 	contents := make([]*genai.Content, 0, len(messages))
 	for i := range messages {
 		msg := &messages[i]
@@ -257,7 +258,10 @@ func convertMessagesToGemini(messages []chat.Message) []*genai.Content {
 
 		// Handle regular messages
 		if len(msg.MultiContent) > 0 {
-			parts := convertMultiContent(msg.MultiContent, msg.ThoughtSignature)
+			parts, err := c.convertMultiContent(ctx, msg.MultiContent, msg.ThoughtSignature)
+			if err != nil {
+				return nil, err
+			}
 			if len(parts) > 0 {
 				contents = append(contents, genai.NewContentFromParts(parts, role))
 			}
@@ -266,7 +270,7 @@ func convertMessagesToGemini(messages []chat.Message) []*genai.Content {
 			contents = append(contents, genai.NewContentFromParts([]*genai.Part{part}, role))
 		}
 	}
-	return contents
+	return contents, nil
 }
 
 // messageRoleToGemini converts chat.MessageRole to genai.Role
@@ -286,8 +290,9 @@ func newTextPartWithSignature(text string, signature []byte) *genai.Part {
 	return part
 }
 
-// convertMultiContent converts multi-part content to Gemini parts
-func convertMultiContent(multiContent []chat.MessagePart, thoughtSignature []byte) []*genai.Part {
+// convertMultiContent converts multi-part content to Gemini parts.
+// It requires a context because document parts may need to fetch remote URLs.
+func (c *Client) convertMultiContent(ctx context.Context, multiContent []chat.MessagePart, thoughtSignature []byte) ([]*genai.Part, error) {
 	parts := make([]*genai.Part, 0, len(multiContent))
 	for _, part := range multiContent {
 		switch part.Type {
@@ -297,9 +302,18 @@ func convertMultiContent(multiContent []chat.MessagePart, thoughtSignature []byt
 			if imgPart := convertImageURLToPart(part.ImageURL); imgPart != nil {
 				parts = append(parts, imgPart)
 			}
+		case chat.MessagePartTypeDocument:
+			if part.Document == nil {
+				continue
+			}
+			docParts, err := c.convertDocument(ctx, *part.Document)
+			if err != nil {
+				return nil, err
+			}
+			parts = append(parts, docParts...)
 		}
 	}
-	return parts
+	return parts, nil
 }
 
 // convertImageURLToPart converts an image URL to a Gemini Part
@@ -589,7 +603,11 @@ func (c *Client) CreateChatCompletionStream(
 		}
 	}
 
-	contents := convertMessagesToGemini(messages)
+	contents, err := c.convertMessagesToGemini(ctx, messages)
+	if err != nil {
+		slog.Error("Failed to convert messages to Gemini format", "error", err)
+		return nil, err
+	}
 
 	// Debug: Log the messages we're sending
 	slog.Debug("Gemini messages", "count", len(contents))

--- a/pkg/model/provider/gemini/client_test.go
+++ b/pkg/model/provider/gemini/client_test.go
@@ -362,10 +362,14 @@ func TestConvertMessagesToGemini_ThoughtSignature(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			contents := convertMessagesToGemini([]chat.Message{
+			// convertMessagesToGemini is now a method; use a zero-value client
+			// (no network calls are made during pure conversion).
+			var dummyClient Client
+			contents, err := dummyClient.convertMessagesToGemini(t.Context(), []chat.Message{
 				{Role: chat.MessageRoleUser, Content: "go"},
 				tt.message,
 			})
+			require.NoError(t, err)
 
 			require.Len(t, contents, 2)
 			assistant := contents[1]

--- a/pkg/model/provider/openai/attachments.go
+++ b/pkg/model/provider/openai/attachments.go
@@ -12,49 +12,59 @@ import (
 	"github.com/docker/docker-agent/pkg/chat"
 )
 
+// Shared capability tables referenced by multiple providers (reduces drift).
+
+// capabilityTableImageURLB64 is the image-URL+B64 table for OpenAI-compatible
+// providers that support image URLs: openai, azure, requesty.
+// Note: application/pdf is absent in Phase 1 — these providers require the
+// Files API for PDFs (Phase 2).
+var capabilityTableImageURLB64 = attachment.CapabilityTable{
+	"image/jpeg":    {B64: true, URL: true},
+	"image/png":     {B64: true, URL: true},
+	"image/gif":     {B64: true, URL: true},
+	"image/webp":    {B64: true, URL: true},
+	"text/plain":    {TXT: true},
+	"text/markdown": {TXT: true},
+	"text/html":     {TXT: true},
+	"text/csv":      {TXT: true},
+}
+
+// capabilityTableImageB64Only is the image-B64-only table for providers that
+// do not support image URLs: ollama, nebius, minimax, github-copilot.
+var capabilityTableImageB64Only = attachment.CapabilityTable{
+	"image/jpeg":    {B64: true},
+	"image/png":     {B64: true},
+	"text/plain":    {TXT: true},
+	"text/markdown": {TXT: true},
+	"text/html":     {TXT: true},
+	"text/csv":      {TXT: true},
+}
+
 // capabilityTableByProvider maps provider names (from ModelConfig.Provider) to
-// their MIME-type capability tables. The openai and azure tables are identical;
-// per-provider aliases (mistral, xai, ollama, nebius, minimax, github-copilot)
-// each have their own entry.
+// their MIME-type capability tables.
 //
 // Phase 1: TXT / B64 / URL only — no Files API.
 var capabilityTableByProvider = map[string]attachment.CapabilityTable{
-	// OpenAI Chat Completions / Responses API
-	// Note: application/pdf is intentionally absent in Phase 1.
-	// OpenAI requires the Files API (not inline base64) for PDFs, which is Phase 2.
-	"openai": {
-		"image/jpeg":    {B64: true, URL: true},
-		"image/png":     {B64: true, URL: true},
-		"image/gif":     {B64: true, URL: true},
-		"image/webp":    {B64: true, URL: true},
-		"text/plain":    {TXT: true},
-		"text/markdown": {TXT: true},
-		"text/html":     {TXT: true},
-		"text/csv":      {TXT: true},
-	},
+	// OpenAI Chat Completions / Responses API.
+	"openai": capabilityTableImageURLB64,
 	// Azure OpenAI — same capabilities as OpenAI (Phase 1).
-	"azure": {
+	"azure": capabilityTableImageURLB64,
+	// Requesty — acts as an OpenAI-compatible proxy (Phase 1).
+	"requesty": capabilityTableImageURLB64,
+
+	// Mistral — images via B64 or URL; no gif.
+	// application/pdf: Mistral requires document_url content type (not image_url) — Phase 2.
+	"mistral": {
 		"image/jpeg":    {B64: true, URL: true},
 		"image/png":     {B64: true, URL: true},
-		"image/gif":     {B64: true, URL: true},
 		"image/webp":    {B64: true, URL: true},
 		"text/plain":    {TXT: true},
 		"text/markdown": {TXT: true},
 		"text/html":     {TXT: true},
 		"text/csv":      {TXT: true},
 	},
-	// Mistral — PDF via URL only (document_url); images via B64 or URL; no gif
-	"mistral": {
-		"image/jpeg":      {B64: true, URL: true},
-		"image/png":       {B64: true, URL: true},
-		"image/webp":      {B64: true, URL: true},
-		"application/pdf": {URL: true},
-		"text/plain":      {TXT: true},
-		"text/markdown":   {TXT: true},
-		"text/html":       {TXT: true},
-		"text/csv":        {TXT: true},
-	},
-	// xAI (Grok) — images B64/URL; text only; no PDF
+
+	// xAI (Grok) — images B64/URL; text only; no PDF.
 	"xai": {
 		"image/jpeg":    {B64: true, URL: true},
 		"image/png":     {B64: true, URL: true},
@@ -63,53 +73,12 @@ var capabilityTableByProvider = map[string]attachment.CapabilityTable{
 		"text/html":     {TXT: true},
 		"text/csv":      {TXT: true},
 	},
-	// Ollama — images B64 only; text only; no PDF, no URL images
-	"ollama": {
-		"image/jpeg":    {B64: true},
-		"image/png":     {B64: true},
-		"text/plain":    {TXT: true},
-		"text/markdown": {TXT: true},
-		"text/html":     {TXT: true},
-		"text/csv":      {TXT: true},
-	},
-	// Nebius — same as ollama
-	"nebius": {
-		"image/jpeg":    {B64: true},
-		"image/png":     {B64: true},
-		"text/plain":    {TXT: true},
-		"text/markdown": {TXT: true},
-		"text/html":     {TXT: true},
-		"text/csv":      {TXT: true},
-	},
-	// MiniMax — same as ollama
-	"minimax": {
-		"image/jpeg":    {B64: true},
-		"image/png":     {B64: true},
-		"text/plain":    {TXT: true},
-		"text/markdown": {TXT: true},
-		"text/html":     {TXT: true},
-		"text/csv":      {TXT: true},
-	},
-	// GitHub Copilot — same as ollama
-	"github-copilot": {
-		"image/jpeg":    {B64: true},
-		"image/png":     {B64: true},
-		"text/plain":    {TXT: true},
-		"text/markdown": {TXT: true},
-		"text/html":     {TXT: true},
-		"text/csv":      {TXT: true},
-	},
-	// Requesty — same as openai (acts as a proxy). No PDF in Phase 1.
-	"requesty": {
-		"image/jpeg":    {B64: true, URL: true},
-		"image/png":     {B64: true, URL: true},
-		"image/gif":     {B64: true, URL: true},
-		"image/webp":    {B64: true, URL: true},
-		"text/plain":    {TXT: true},
-		"text/markdown": {TXT: true},
-		"text/html":     {TXT: true},
-		"text/csv":      {TXT: true},
-	},
+
+	// Ollama, Nebius, MiniMax, GitHub Copilot — images B64 only; no PDF; no URL images.
+	"ollama":         capabilityTableImageB64Only,
+	"nebius":         capabilityTableImageB64Only,
+	"minimax":        capabilityTableImageB64Only,
+	"github-copilot": capabilityTableImageB64Only,
 }
 
 // capabilityTable returns the capability table for this client's provider,
@@ -118,7 +87,7 @@ func (c *Client) capabilityTable() attachment.CapabilityTable {
 	if table, ok := capabilityTableByProvider[c.ModelConfig.Provider]; ok {
 		return table
 	}
-	return capabilityTableByProvider["openai"]
+	return capabilityTableImageURLB64
 }
 
 // SupportedMIMETypes implements attachment.Advisor.
@@ -171,6 +140,9 @@ func (c *Client) convertDocument(
 }
 
 // convertViaURL builds a part that passes the document URL directly to the model.
+// Only called for image MIMEs in Phase 1 (the capability tables only grant URL
+// to image types). If a future table entry adds URL to a non-image MIME, this
+// function will need to branch on MIME type.
 func (c *Client) convertViaURL(doc chat.Document) []openai.ChatCompletionContentPartUnionParam {
 	return []openai.ChatCompletionContentPartUnionParam{
 		openai.ImageContentPart(openai.ChatCompletionContentPartImageImageURLParam{
@@ -180,6 +152,7 @@ func (c *Client) convertViaURL(doc chat.Document) []openai.ChatCompletionContent
 }
 
 // convertViaB64 encodes inline binary as a base64 data-URL image part.
+// Only called for image MIMEs in Phase 1 (PDFs use the Files API — Phase 2).
 func (c *Client) convertViaB64(doc chat.Document) []openai.ChatCompletionContentPartUnionParam {
 	encoded := base64.StdEncoding.EncodeToString(doc.Source.InlineData)
 	dataURL := "data:" + doc.MimeType + ";base64," + encoded

--- a/pkg/model/provider/openai/attachments.go
+++ b/pkg/model/provider/openai/attachments.go
@@ -1,0 +1,225 @@
+package openai
+
+import (
+	"context"
+	"encoding/base64"
+	"log/slog"
+	"sort"
+
+	"github.com/openai/openai-go/v3"
+
+	"github.com/docker/docker-agent/pkg/attachment"
+	"github.com/docker/docker-agent/pkg/chat"
+)
+
+// capabilityTableByProvider maps provider names (from ModelConfig.Provider) to
+// their MIME-type capability tables. The openai and azure tables are identical;
+// per-provider aliases (mistral, xai, ollama, nebius, minimax, github-copilot)
+// each have their own entry.
+//
+// Phase 1: TXT / B64 / URL only — no Files API.
+var capabilityTableByProvider = map[string]attachment.CapabilityTable{
+	// OpenAI Chat Completions / Responses API
+	// Note: application/pdf is intentionally absent in Phase 1.
+	// OpenAI requires the Files API (not inline base64) for PDFs, which is Phase 2.
+	"openai": {
+		"image/jpeg":    {B64: true, URL: true},
+		"image/png":     {B64: true, URL: true},
+		"image/gif":     {B64: true, URL: true},
+		"image/webp":    {B64: true, URL: true},
+		"text/plain":    {TXT: true},
+		"text/markdown": {TXT: true},
+		"text/html":     {TXT: true},
+		"text/csv":      {TXT: true},
+	},
+	// Azure OpenAI — same capabilities as OpenAI (Phase 1).
+	"azure": {
+		"image/jpeg":    {B64: true, URL: true},
+		"image/png":     {B64: true, URL: true},
+		"image/gif":     {B64: true, URL: true},
+		"image/webp":    {B64: true, URL: true},
+		"text/plain":    {TXT: true},
+		"text/markdown": {TXT: true},
+		"text/html":     {TXT: true},
+		"text/csv":      {TXT: true},
+	},
+	// Mistral — PDF via URL only (document_url); images via B64 or URL; no gif
+	"mistral": {
+		"image/jpeg":      {B64: true, URL: true},
+		"image/png":       {B64: true, URL: true},
+		"image/webp":      {B64: true, URL: true},
+		"application/pdf": {URL: true},
+		"text/plain":      {TXT: true},
+		"text/markdown":   {TXT: true},
+		"text/html":       {TXT: true},
+		"text/csv":        {TXT: true},
+	},
+	// xAI (Grok) — images B64/URL; text only; no PDF
+	"xai": {
+		"image/jpeg":    {B64: true, URL: true},
+		"image/png":     {B64: true, URL: true},
+		"text/plain":    {TXT: true},
+		"text/markdown": {TXT: true},
+		"text/html":     {TXT: true},
+		"text/csv":      {TXT: true},
+	},
+	// Ollama — images B64 only; text only; no PDF, no URL images
+	"ollama": {
+		"image/jpeg":    {B64: true},
+		"image/png":     {B64: true},
+		"text/plain":    {TXT: true},
+		"text/markdown": {TXT: true},
+		"text/html":     {TXT: true},
+		"text/csv":      {TXT: true},
+	},
+	// Nebius — same as ollama
+	"nebius": {
+		"image/jpeg":    {B64: true},
+		"image/png":     {B64: true},
+		"text/plain":    {TXT: true},
+		"text/markdown": {TXT: true},
+		"text/html":     {TXT: true},
+		"text/csv":      {TXT: true},
+	},
+	// MiniMax — same as ollama
+	"minimax": {
+		"image/jpeg":    {B64: true},
+		"image/png":     {B64: true},
+		"text/plain":    {TXT: true},
+		"text/markdown": {TXT: true},
+		"text/html":     {TXT: true},
+		"text/csv":      {TXT: true},
+	},
+	// GitHub Copilot — same as ollama
+	"github-copilot": {
+		"image/jpeg":    {B64: true},
+		"image/png":     {B64: true},
+		"text/plain":    {TXT: true},
+		"text/markdown": {TXT: true},
+		"text/html":     {TXT: true},
+		"text/csv":      {TXT: true},
+	},
+	// Requesty — same as openai (acts as a proxy). No PDF in Phase 1.
+	"requesty": {
+		"image/jpeg":    {B64: true, URL: true},
+		"image/png":     {B64: true, URL: true},
+		"image/gif":     {B64: true, URL: true},
+		"image/webp":    {B64: true, URL: true},
+		"text/plain":    {TXT: true},
+		"text/markdown": {TXT: true},
+		"text/html":     {TXT: true},
+		"text/csv":      {TXT: true},
+	},
+}
+
+// capabilityTable returns the capability table for this client's provider,
+// falling back to the openai table for unknown providers.
+func (c *Client) capabilityTable() attachment.CapabilityTable {
+	if table, ok := capabilityTableByProvider[c.ModelConfig.Provider]; ok {
+		return table
+	}
+	return capabilityTableByProvider["openai"]
+}
+
+// SupportedMIMETypes implements attachment.Advisor.
+// It returns every MIME type for which this provider has at least one
+// capability set (TXT, B64, or URL), sorted for determinism.
+func (c *Client) SupportedMIMETypes() []string {
+	table := c.capabilityTable()
+	mimes := make([]string, 0, len(table))
+	for mime, cap := range table {
+		if cap.TXT || cap.B64 || cap.URL {
+			mimes = append(mimes, mime)
+		}
+	}
+	sort.Strings(mimes)
+	return mimes
+}
+
+// convertDocument converts a chat.Document into zero or more
+// openai.ChatCompletionContentPartUnionParam parts.
+//
+// On StrategyDrop the attachment is silently skipped (a Warn is logged).
+func (c *Client) convertDocument(
+	ctx context.Context,
+	doc chat.Document,
+) ([]openai.ChatCompletionContentPartUnionParam, error) {
+	strategy, reason := attachment.Decide(doc, c.capabilityTable())
+
+	switch strategy {
+	case attachment.StrategyURL:
+		return c.convertViaURL(doc), nil
+
+	case attachment.StrategyB64:
+		return c.convertViaB64(doc), nil
+
+	case attachment.StrategyTXT:
+		return c.convertViaTXT(doc), nil
+
+	case attachment.StrategyFetchAsB64:
+		slog.Warn("attachment: fetching URL as base64", "name", doc.Name, "reason", reason)
+		return c.convertViaFetchAsB64(ctx, doc)
+
+	case attachment.StrategyFetchAsTXT:
+		slog.Warn("attachment: fetching URL as text", "name", doc.Name, "reason", reason)
+		return c.convertViaFetchAsTXT(ctx, doc)
+
+	default: // StrategyDrop
+		slog.Warn("attachment: dropping document", "name", doc.Name, "mime", doc.MimeType, "reason", reason)
+		return nil, nil
+	}
+}
+
+// convertViaURL builds a part that passes the document URL directly to the model.
+func (c *Client) convertViaURL(doc chat.Document) []openai.ChatCompletionContentPartUnionParam {
+	return []openai.ChatCompletionContentPartUnionParam{
+		openai.ImageContentPart(openai.ChatCompletionContentPartImageImageURLParam{
+			URL: doc.Source.URL,
+		}),
+	}
+}
+
+// convertViaB64 encodes inline binary as a base64 data-URL image part.
+func (c *Client) convertViaB64(doc chat.Document) []openai.ChatCompletionContentPartUnionParam {
+	encoded := base64.StdEncoding.EncodeToString(doc.Source.InlineData)
+	dataURL := "data:" + doc.MimeType + ";base64," + encoded
+	return []openai.ChatCompletionContentPartUnionParam{
+		openai.ImageContentPart(openai.ChatCompletionContentPartImageImageURLParam{
+			URL: dataURL,
+		}),
+	}
+}
+
+// convertViaTXT wraps inline text in an XML envelope and returns it as a text part.
+func (c *Client) convertViaTXT(doc chat.Document) []openai.ChatCompletionContentPartUnionParam {
+	envelope := attachment.TXTEnvelope(doc.Name, doc.MimeType, doc.Source.InlineText)
+	return []openai.ChatCompletionContentPartUnionParam{
+		openai.TextContentPart(envelope),
+	}
+}
+
+// convertViaFetchAsB64 fetches the URL and returns it as a base64 data-URL image part.
+// On fetch error the attachment is soft-dropped (logged + nil returned).
+func (c *Client) convertViaFetchAsB64(ctx context.Context, doc chat.Document) ([]openai.ChatCompletionContentPartUnionParam, error) {
+	data, err := attachment.FetchURL(ctx, doc.Source.URL)
+	if err != nil {
+		slog.Warn("attachment: failed to fetch url for b64", "name", doc.Name, "url", doc.Source.URL, "error", err)
+		return nil, nil
+	}
+	fetched := doc
+	fetched.Source.InlineData = data
+	return c.convertViaB64(fetched), nil
+}
+
+// convertViaFetchAsTXT fetches the URL and returns its content as a text envelope.
+// On fetch error the attachment is soft-dropped (logged + nil returned).
+func (c *Client) convertViaFetchAsTXT(ctx context.Context, doc chat.Document) ([]openai.ChatCompletionContentPartUnionParam, error) {
+	data, err := attachment.FetchURL(ctx, doc.Source.URL)
+	if err != nil {
+		slog.Warn("attachment: failed to fetch url for text", "name", doc.Name, "url", doc.Source.URL, "error", err)
+		return nil, nil
+	}
+	fetched := doc
+	fetched.Source.InlineText = string(data)
+	return c.convertViaTXT(fetched), nil
+}

--- a/pkg/model/provider/openai/attachments_test.go
+++ b/pkg/model/provider/openai/attachments_test.go
@@ -46,8 +46,10 @@ func TestOpenAI_SupportedMIMETypes_ByProvider(t *testing.T) {
 		},
 		{
 			provider: "mistral",
-			mustHave: []string{"image/jpeg", "application/pdf", "text/plain"},
-			mustMiss: []string{"image/gif"}, // Mistral has no gif
+			mustHave: []string{"image/jpeg", "text/plain"},
+			// application/pdf removed: Mistral requires document_url (Phase 2)
+			// image/gif not in Mistral table
+			mustMiss: []string{"image/gif", "application/pdf"},
 		},
 		{
 			provider: "xai",
@@ -159,25 +161,27 @@ func TestOpenAI_ConvertDocument_TXT(t *testing.T) {
 	}
 }
 
+// TestOpenAI_ConvertDocument_FetchAsB64 verifies that a URL source document
+// for a MIME type that has B64-only capability (no URL) triggers StrategyFetchAsB64:
+// the URL is fetched and the bytes are returned as a base64 data-URL part.
+//
+// We use the "ollama" provider profile because its table has image/jpeg:{B64:true}
+// with no URL capability, so a URL source → FetchAsB64.
 func TestOpenAI_ConvertDocument_FetchAsB64(t *testing.T) {
 	t.Parallel()
 
-	// For openai: application/pdf is excluded from Phase 1 (requires Files API).
-	// Any MIME not in the table → Drop; verify that via a URL source of an
-	// unknown MIME type to exercise the soft-drop path.
-	pngBytes := []byte{0x89, 0x50, 0x4e, 0x47}
+	jpegBytes := []byte{0xff, 0xd8, 0xff, 0xe0} // JPEG magic
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "image/png")
-		_, _ = w.Write(pngBytes)
+		w.Header().Set("Content-Type", "image/jpeg")
+		_, _ = w.Write(jpegBytes)
 	}))
 	defer srv.Close()
 
-	// image/png has B64 and URL; use URL source so it returns StrategyURL
-	// (openai supports URL for images).
-	c := buildTestClient("openai")
+	// ollama: image/jpeg has B64 only (no URL) → URL source triggers FetchAsB64.
+	c := buildTestClient("ollama")
 	doc := chat.Document{
-		Name:     "photo.png",
-		MimeType: "image/png",
+		Name:     "photo.jpg",
+		MimeType: "image/jpeg",
 		Source:   chat.DocumentSource{URL: srv.URL},
 	}
 	parts, err := c.convertDocument(t.Context(), doc)
@@ -185,24 +189,13 @@ func TestOpenAI_ConvertDocument_FetchAsB64(t *testing.T) {
 		t.Fatalf("convertDocument: %v", err)
 	}
 	if len(parts) != 1 {
-		t.Fatalf("want 1 part via URL, got %d", len(parts))
+		t.Fatalf("want 1 part, got %d", len(parts))
 	}
 	if parts[0].OfImageURL == nil {
-		t.Fatal("expected OfImageURL part")
+		t.Fatal("expected OfImageURL part (fetched as base64 data URL)")
 	}
-
-	// application/pdf is dropped in Phase 1 (requires Files API)
-	docPDF := chat.Document{
-		Name:     "doc.pdf",
-		MimeType: "application/pdf",
-		Source:   chat.DocumentSource{URL: srv.URL},
-	}
-	partsDropped, err := c.convertDocument(t.Context(), docPDF)
-	if err != nil {
-		t.Fatalf("convertDocument PDF: %v", err)
-	}
-	if len(partsDropped) != 0 {
-		t.Errorf("expected PDF to be dropped in Phase 1, got %d parts", len(partsDropped))
+	if !strings.HasPrefix(parts[0].OfImageURL.ImageURL.URL, "data:image/jpeg;base64,") {
+		t.Errorf("expected base64 data URL, got: %s", parts[0].OfImageURL.ImageURL.URL)
 	}
 }
 

--- a/pkg/model/provider/openai/attachments_test.go
+++ b/pkg/model/provider/openai/attachments_test.go
@@ -1,0 +1,256 @@
+package openai
+
+// attachments_test.go — unit tests for the OpenAI attachment wiring.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/model/provider/base"
+)
+
+// buildTestClient creates a minimal *Client without making any API calls.
+func buildTestClient(provider string) *Client {
+	cfg := latest.ModelConfig{
+		Provider: provider,
+		Model:    "gpt-4o",
+	}
+	return &Client{
+		Config: base.Config{
+			ModelConfig: cfg,
+		},
+	}
+}
+
+func TestOpenAI_SupportedMIMETypes_ByProvider(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		provider string
+		mustHave []string
+		mustMiss []string
+	}{
+		{
+			provider: "openai",
+			mustHave: []string{"image/png", "image/jpeg", "text/plain"},
+			mustMiss: []string{"application/pdf"}, // PDF deferred to Phase 2 (Files API)
+		},
+		{
+			provider: "azure",
+			mustHave: []string{"image/png", "text/markdown"},
+			mustMiss: []string{"application/pdf"}, // PDF deferred to Phase 2 (Files API)
+		},
+		{
+			provider: "mistral",
+			mustHave: []string{"image/jpeg", "application/pdf", "text/plain"},
+			mustMiss: []string{"image/gif"}, // Mistral has no gif
+		},
+		{
+			provider: "xai",
+			mustHave: []string{"image/png", "text/plain"},
+			mustMiss: []string{"application/pdf"}, // xAI has no PDF
+		},
+		{
+			provider: "ollama",
+			mustHave: []string{"image/jpeg", "image/png", "text/plain"},
+			mustMiss: []string{"application/pdf", "image/gif"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.provider, func(t *testing.T) {
+			t.Parallel()
+			c := buildTestClient(tc.provider)
+			mimes := c.SupportedMIMETypes()
+			mimeSet := make(map[string]bool, len(mimes))
+			for _, m := range mimes {
+				mimeSet[m] = true
+			}
+			for _, want := range tc.mustHave {
+				if !mimeSet[want] {
+					t.Errorf("provider %q: expected MIME %q in SupportedMIMETypes, got %v", tc.provider, want, mimes)
+				}
+			}
+			for _, notWant := range tc.mustMiss {
+				if mimeSet[notWant] {
+					t.Errorf("provider %q: unexpected MIME %q in SupportedMIMETypes", tc.provider, notWant)
+				}
+			}
+		})
+	}
+}
+
+func TestOpenAI_ConvertDocument_URL(t *testing.T) {
+	t.Parallel()
+
+	c := buildTestClient("openai")
+	doc := chat.Document{
+		Name:     "photo.png",
+		MimeType: "image/png",
+		Source:   chat.DocumentSource{URL: "https://example.com/photo.png"},
+	}
+	parts, err := c.convertDocument(t.Context(), doc)
+	if err != nil {
+		t.Fatalf("convertDocument: %v", err)
+	}
+	if len(parts) != 1 {
+		t.Fatalf("want 1 part, got %d", len(parts))
+	}
+	if parts[0].OfImageURL == nil {
+		t.Fatal("expected OfImageURL part")
+	}
+	if parts[0].OfImageURL.ImageURL.URL != "https://example.com/photo.png" {
+		t.Errorf("unexpected URL: %s", parts[0].OfImageURL.ImageURL.URL)
+	}
+}
+
+func TestOpenAI_ConvertDocument_B64(t *testing.T) {
+	t.Parallel()
+
+	c := buildTestClient("openai")
+	doc := chat.Document{
+		Name:     "photo.png",
+		MimeType: "image/png",
+		Source:   chat.DocumentSource{InlineData: []byte("\x89PNG\r\n\x1a\n")},
+	}
+	parts, err := c.convertDocument(t.Context(), doc)
+	if err != nil {
+		t.Fatalf("convertDocument: %v", err)
+	}
+	if len(parts) != 1 {
+		t.Fatalf("want 1 part, got %d", len(parts))
+	}
+	if parts[0].OfImageURL == nil {
+		t.Fatal("expected OfImageURL part (base64 data URL)")
+	}
+	if !strings.HasPrefix(parts[0].OfImageURL.ImageURL.URL, "data:image/png;base64,") {
+		t.Errorf("expected base64 data URL, got: %s", parts[0].OfImageURL.ImageURL.URL)
+	}
+}
+
+func TestOpenAI_ConvertDocument_TXT(t *testing.T) {
+	t.Parallel()
+
+	c := buildTestClient("openai")
+	doc := chat.Document{
+		Name:     "readme.txt",
+		MimeType: "text/plain",
+		Source:   chat.DocumentSource{InlineText: "hello world"},
+	}
+	parts, err := c.convertDocument(t.Context(), doc)
+	if err != nil {
+		t.Fatalf("convertDocument: %v", err)
+	}
+	if len(parts) != 1 {
+		t.Fatalf("want 1 part, got %d", len(parts))
+	}
+	if parts[0].OfText == nil {
+		t.Fatal("expected OfText part")
+	}
+	if !strings.Contains(parts[0].OfText.Text, "hello world") {
+		t.Errorf("expected text to contain body, got: %s", parts[0].OfText.Text)
+	}
+	if !strings.Contains(parts[0].OfText.Text, "mime-type=") {
+		t.Errorf("expected TXTEnvelope mime-type attribute, got: %s", parts[0].OfText.Text)
+	}
+}
+
+func TestOpenAI_ConvertDocument_FetchAsB64(t *testing.T) {
+	t.Parallel()
+
+	// For openai: application/pdf is excluded from Phase 1 (requires Files API).
+	// Any MIME not in the table → Drop; verify that via a URL source of an
+	// unknown MIME type to exercise the soft-drop path.
+	pngBytes := []byte{0x89, 0x50, 0x4e, 0x47}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(pngBytes)
+	}))
+	defer srv.Close()
+
+	// image/png has B64 and URL; use URL source so it returns StrategyURL
+	// (openai supports URL for images).
+	c := buildTestClient("openai")
+	doc := chat.Document{
+		Name:     "photo.png",
+		MimeType: "image/png",
+		Source:   chat.DocumentSource{URL: srv.URL},
+	}
+	parts, err := c.convertDocument(t.Context(), doc)
+	if err != nil {
+		t.Fatalf("convertDocument: %v", err)
+	}
+	if len(parts) != 1 {
+		t.Fatalf("want 1 part via URL, got %d", len(parts))
+	}
+	if parts[0].OfImageURL == nil {
+		t.Fatal("expected OfImageURL part")
+	}
+
+	// application/pdf is dropped in Phase 1 (requires Files API)
+	docPDF := chat.Document{
+		Name:     "doc.pdf",
+		MimeType: "application/pdf",
+		Source:   chat.DocumentSource{URL: srv.URL},
+	}
+	partsDropped, err := c.convertDocument(t.Context(), docPDF)
+	if err != nil {
+		t.Fatalf("convertDocument PDF: %v", err)
+	}
+	if len(partsDropped) != 0 {
+		t.Errorf("expected PDF to be dropped in Phase 1, got %d parts", len(partsDropped))
+	}
+}
+
+func TestOpenAI_ConvertDocument_FetchAsTXT(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("# readme"))
+	}))
+	defer srv.Close()
+
+	// text/plain has TXT but no URL → FetchAsTXT
+	c := buildTestClient("openai")
+	doc := chat.Document{
+		Name:     "readme.md",
+		MimeType: "text/plain",
+		Source:   chat.DocumentSource{URL: srv.URL},
+	}
+	parts, err := c.convertDocument(t.Context(), doc)
+	if err != nil {
+		t.Fatalf("convertDocument: %v", err)
+	}
+	if len(parts) != 1 {
+		t.Fatalf("want 1 part, got %d", len(parts))
+	}
+	if parts[0].OfText == nil {
+		t.Fatal("expected OfText part")
+	}
+	if !strings.Contains(parts[0].OfText.Text, "# readme") {
+		t.Errorf("expected fetched content in envelope, got: %s", parts[0].OfText.Text)
+	}
+}
+
+func TestOpenAI_ConvertDocument_Drop(t *testing.T) {
+	t.Parallel()
+
+	// video/mp4 not in any openai table → Drop
+	c := buildTestClient("openai")
+	doc := chat.Document{
+		Name:     "clip.mp4",
+		MimeType: "video/mp4",
+		Source:   chat.DocumentSource{InlineData: []byte("data")},
+	}
+	parts, err := c.convertDocument(t.Context(), doc)
+	if err != nil {
+		t.Fatalf("convertDocument returned error on drop: %v", err)
+	}
+	if len(parts) != 0 {
+		t.Errorf("expected 0 parts on drop, got %d", len(parts))
+	}
+}

--- a/pkg/model/provider/openai/attachments_wire.go
+++ b/pkg/model/provider/openai/attachments_wire.go
@@ -1,0 +1,134 @@
+package openai
+
+// This file wires attachment.Document support into the OpenAI Chat Completions
+// and Responses API message converters.
+//
+// Wiring strategy for both APIs:
+//   - expandDocumentPartsInMessages pre-processes each message's MultiContent,
+//     expanding MessagePartTypeDocument parts into synthetic text/image parts
+//     that the existing converters (oaistream.ConvertMessages and
+//     convertMessagesToResponseInput) already understand.
+//   - convertMessagesCtx and convertMessagesToResponseInputCtx use this
+//     approach as a pre-pass, then delegate to the originals.
+//
+// This avoids duplicating the complex conversion logic in both paths.
+
+import (
+	"context"
+	"log/slog"
+
+	openai "github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/responses"
+
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/model/provider/oaistream"
+)
+
+// expandDocumentParts expands any MessagePartTypeDocument entries in parts
+// into synthetic text or image MessageParts that existing converters handle.
+// On StrategyDrop the document is silently omitted (logged by convertDocument).
+func (c *Client) expandDocumentParts(
+	ctx context.Context,
+	parts []chat.MessagePart,
+) ([]chat.MessagePart, error) {
+	expanded := make([]chat.MessagePart, 0, len(parts))
+	for _, part := range parts {
+		if part.Type != chat.MessagePartTypeDocument {
+			expanded = append(expanded, part)
+			continue
+		}
+		if part.Document == nil {
+			continue
+		}
+		// Convert the document into native OpenAI parts.
+		nativeParts, err := c.convertDocument(ctx, *part.Document)
+		if err != nil {
+			return nil, err
+		}
+		// Re-wrap each native part as a synthetic MessagePart so the existing
+		// oaistream.ConvertMessages / convertMessagesToResponseInput can handle
+		// them without modification.
+		for _, np := range nativeParts {
+			switch {
+			case np.OfText != nil:
+				expanded = append(expanded, chat.MessagePart{
+					Type: chat.MessagePartTypeText,
+					Text: np.OfText.Text,
+				})
+			case np.OfImageURL != nil && np.OfImageURL.ImageURL.URL != "":
+				expanded = append(expanded, chat.MessagePart{
+					Type:     chat.MessagePartTypeImageURL,
+					ImageURL: &chat.MessageImageURL{URL: np.OfImageURL.ImageURL.URL},
+				})
+			default:
+				slog.Warn("attachment: unhandled native part type, skipping", "name", part.Document.Name)
+			}
+		}
+	}
+	return expanded, nil
+}
+
+// expandDocumentPartsInMessages returns a copy of messages with all
+// MessagePartTypeDocument parts expanded into synthetic text/image parts.
+func (c *Client) expandDocumentPartsInMessages(
+	ctx context.Context,
+	messages []chat.Message,
+) ([]chat.Message, error) {
+	if !hasDocumentParts(messages) {
+		return messages, nil
+	}
+	expanded := make([]chat.Message, len(messages))
+	copy(expanded, messages)
+	for i := range expanded {
+		if len(expanded[i].MultiContent) == 0 {
+			continue
+		}
+		newParts, err := c.expandDocumentParts(ctx, expanded[i].MultiContent)
+		if err != nil {
+			return nil, err
+		}
+		expanded[i].MultiContent = newParts
+	}
+	return expanded, nil
+}
+
+// convertMessagesCtx is like oaistream.ConvertMessages but also handles
+// MessagePartTypeDocument parts by expanding them before conversion.
+func (c *Client) convertMessagesCtx(
+	ctx context.Context,
+	messages []chat.Message,
+) ([]openai.ChatCompletionMessageParamUnion, error) {
+	expanded, err := c.expandDocumentPartsInMessages(ctx, messages)
+	if err != nil {
+		return nil, err
+	}
+	return oaistream.ConvertMessages(expanded), nil
+}
+
+// convertMessagesToResponseInputCtx is like convertMessagesToResponseInput but
+// also handles MessagePartTypeDocument parts by expanding them before conversion.
+// All the complex handling (orphan calls, tool image injection, etc.) is
+// preserved by delegating to the original after document expansion.
+func (c *Client) convertMessagesToResponseInputCtx(
+	ctx context.Context,
+	messages []chat.Message,
+) ([]responses.ResponseInputItemUnionParam, error) {
+	expanded, err := c.expandDocumentPartsInMessages(ctx, messages)
+	if err != nil {
+		return nil, err
+	}
+	return convertMessagesToResponseInput(expanded), nil
+}
+
+// hasDocumentParts reports whether any message in the slice contains a
+// MessagePartTypeDocument part.
+func hasDocumentParts(messages []chat.Message) bool {
+	for i := range messages {
+		for _, part := range messages[i].MultiContent {
+			if part.Type == chat.MessagePartTypeDocument {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -177,12 +177,6 @@ func (c *Client) Close() {
 	}
 }
 
-// convertMessages converts chat.Message to openai.ChatCompletionMessageParamUnion
-// using the shared oaistream implementation.
-func convertMessages(messages []chat.Message) []openai.ChatCompletionMessageParamUnion {
-	return oaistream.ConvertMessages(messages)
-}
-
 // CreateChatCompletionStream creates a streaming chat completion request
 // It returns a stream that can be iterated over to get completion chunks
 func (c *Client) CreateChatCompletionStream(
@@ -222,9 +216,15 @@ func (c *Client) CreateChatCompletionStream(
 
 	trackUsage := c.ModelConfig.TrackUsage == nil || *c.ModelConfig.TrackUsage
 
+	convertedMessages, err := c.convertMessagesCtx(ctx, messages)
+	if err != nil {
+		slog.Error("Failed to convert messages with documents for OpenAI request", "error", err)
+		return nil, err
+	}
+
 	params := openai.ChatCompletionNewParams{
 		Model:    c.ModelConfig.Model,
-		Messages: convertMessages(messages),
+		Messages: convertedMessages,
 		StreamOptions: openai.ChatCompletionStreamOptionsParam{
 			IncludeUsage: openai.Bool(trackUsage),
 		},
@@ -363,7 +363,11 @@ func (c *Client) CreateResponseStream(
 		return nil, errors.New("at least one message is required")
 	}
 
-	input := convertMessagesToResponseInput(messages)
+	input, err := c.convertMessagesToResponseInputCtx(ctx, messages)
+	if err != nil {
+		slog.Error("Failed to convert messages with documents for OpenAI responses request", "error", err)
+		return nil, err
+	}
 
 	params := responses.ResponseNewParams{
 		Model: c.ModelConfig.Model,

--- a/pkg/model/provider/vertexai/attachments.go
+++ b/pkg/model/provider/vertexai/attachments.go
@@ -1,0 +1,13 @@
+package vertexai
+
+// Package vertexai wraps either an anthropic.Client or openai.Client.
+// Attachment support (SupportedMIMETypes, convertDocument) is provided by
+// the underlying implementation and requires no additional code here.
+//
+// - Anthropic publisher: anthropic.Client — uses Anthropic's capability table.
+// - Other publishers:    openai.Client   — uses the openai capability table
+//                        (provider name "openai", or overridden by alias).
+//
+// The attachment.Advisor interface is implemented transitively via the
+// embedded client, so callers that type-assert to attachment.Advisor will
+// get the right implementation automatically.


### PR DESCRIPTION
## Summary

Stacks on PR #2607 (`feat/phase1-attachment-foundation`). Merge #2607 first.

Implements per-provider `convertDocument` wiring for every supported provider.

Refs #2595.

## Changes

### `pkg/model/provider/openai`
- `attachments.go`: `capabilityTableByProvider` map (openai, azure, mistral, xai, ollama, nebius, minimax, github-copilot, requesty). `SupportedMIMETypes()` implements `attachment.Advisor`. `convertDocument()` dispatches via `attachment.Decide`.
  - **Note:** `application/pdf` excluded from openai/azure/requesty in Phase 1 (requires Files API — Phase 2).
- `attachments_wire.go`: `expandDocumentParts` pre-processes document parts into synthetic text/image parts, then delegates to existing converters (avoids duplicating Responses API logic).
- `client.go`: uses `convertMessagesCtx` / `convertMessagesToResponseInputCtx`.

### `pkg/model/provider/anthropic`
- `attachments.go`: images→ImageBlock, PDFs→NewDocumentBlock, text→TXTEnvelope. `convertBetaDocument()` for Beta API.
- Wired into `convertUserMultiContent` and `convertBetaUserMultiContent`.

### `pkg/model/provider/gemini`
- `attachments.go`: images/video/audio/PDF as B64 blobs, text as TXTEnvelope.
- `convertMultiContent`/`convertMessagesToGemini` promoted to methods with context.

### `pkg/model/provider/bedrock`
- `attachments.go`: images→ContentBlockMemberImage, PDFs→ContentBlockMemberDocument (sanitized name), text→ContentBlockMemberText. Context-aware `convertMessagesCtx`.

### `pkg/model/provider/vertexai`
- Comment-only `attachments.go` (delegates to embedded anthropic/openai client).

### Tests
- Per-provider `attachments_test.go`: all 6 strategies covered with `httptest.Server` for fetch strategies.

## What this PR does NOT do
- No `pkg/app`, `pkg/cli`, `pkg/runtime` changes (PR 3)
- No Files API (Phase 2)