### PR TITLE
docs: refresh outdated examples, missing env vars, and CLI options

### DIFF
--- a/docs/community/troubleshooting/index.md
+++ b/docs/community/troubleshooting/index.md
@@ -16,7 +16,7 @@ Error message: `context_length_exceeded` or similar.
 
 - Use `/compact` in the TUI to summarize and reduce conversation history
 - Set `num_history_items` in agent config to limit messages sent to the model
-- Switch to a model with larger context (e.g., Claude 200K, Gemini 2M)
+- Switch to a model with larger context (Claude Sonnet 4.5 supports 1M tokens, Gemini up to 2M)
 - Break large tasks into smaller conversations
 
 ### Max Iterations Reached
@@ -40,9 +40,9 @@ Configure fallback behavior in your agent config:
 ```yaml
 agents:
   root:
-    model: anthropic/claude-sonnet-4-0
+    model: anthropic/claude-sonnet-4-5
     fallback:
-      models: [openai/gpt-4o, openai/gpt-4o-mini]
+      models: [openai/gpt-5-mini, openai/gpt-4o-mini]
       retries: 2 # retries per model for 5xx errors
       cooldown: 1m # how long to stick with fallback after 429
 ```
@@ -98,9 +98,8 @@ $ env | grep API_KEY
 
 Model names must match the provider's naming exactly. Common mistakes:
 
-- Using `gpt-4` instead of `gpt-4o`
-- Using a deprecated model name
-- Model references are case-sensitive: `openai/gpt-4o` ≠ `openai/GPT-4o`
+- Using a deprecated model name (e.g. `gpt-4` instead of `gpt-5-mini` or `gpt-4o`)
+- Model references are case-sensitive: `openai/gpt-5-mini` ≠ `openai/GPT-5-mini`
 
 ### Network connectivity
 
@@ -150,7 +149,7 @@ docker-agent validates config at startup and reports errors with line numbers. C
 ### Missing references
 
 - Local agents in `sub_agents` must be defined in the `agents` section (external OCI references like `agentcatalog/pirate` are resolved from registries automatically)
-- Named model references must exist in the `models` section (or use inline format like `openai/gpt-4o`)
+- Named model references must exist in the `models` section (or use inline format like `openai/gpt-5-mini`)
 - RAG source names referenced by agents must be defined in the `rag` section
 
 ### Toolset validation

--- a/docs/concepts/agents/index.md
+++ b/docs/concepts/agents/index.md
@@ -12,7 +12,7 @@ _Agents are the core building blocks of docker-agent. Each agent is an AI-powere
 
 An agent in docker-agent is defined by:
 
-- **Model** — The AI model powering it (e.g., Claude, GPT-4o, Gemini). See [Models]({{ '/concepts/models/' | relative_url }}).
+- **Model** — The AI model powering it (e.g., Claude, GPT-5, Gemini). See [Models]({{ '/concepts/models/' | relative_url }}).
 - **Description** — A brief summary of what the agent does (used by other agents for delegation)
 - **Instruction** — The system prompt that defines the agent's behavior and personality
 - **Tools** — Capabilities like filesystem access, shell commands, or external APIs
@@ -21,7 +21,7 @@ An agent in docker-agent is defined by:
 ```yaml
 agents:
   root:
-    model: anthropic/claude-sonnet-4-0
+    model: anthropic/claude-sonnet-4-5
     description: Expert software developer
     instruction: |
       You are an expert developer. Write clean, efficient code
@@ -47,7 +47,7 @@ Every docker-agent configuration has a **root agent** — the entry point that r
 
 | Property               | Type    | Required | Description                                                    |
 | ---------------------- | ------- | -------- | -------------------------------------------------------------- |
-| `model`                | string  | ✓        | Model reference (inline like `openai/gpt-4o` or a named model) |
+| `model`                | string  | ✓        | Model reference (inline like `openai/gpt-5-mini` or a named model) |
 | `description`          | string  | ✓        | What the agent does — used by other agents for delegation      |
 | `instruction`          | string  | ✓        | System prompt defining behavior                                |
 | `toolsets`             | array   | ✗        | List of tool configurations                                    |
@@ -66,10 +66,10 @@ Agents can automatically fail over to alternative models when the primary model 
 ```yaml
 agents:
   root:
-    model: anthropic/claude-sonnet-4-0
+    model: anthropic/claude-sonnet-4-5
     fallback:
       models:
-        - openai/gpt-4o
+        - openai/gpt-5-mini
         - google/gemini-2.5-flash
       retries: 2 # retries per model for 5xx errors
       cooldown: 1m # stick with fallback after 429
@@ -82,7 +82,7 @@ Define reusable prompts that can be invoked as commands:
 ```yaml
 agents:
   root:
-    model: openai/gpt-4o
+    model: openai/gpt-5-mini
     instruction: You are a helpful assistant.
     commands:
       df: "Check how much free space I have on my disk"

--- a/docs/concepts/distribution/index.md
+++ b/docs/concepts/distribution/index.md
@@ -73,7 +73,7 @@ Registry agents can be used directly as sub-agents in a multi-agent configuratio
 ```yaml
 agents:
   root:
-    model: openai/gpt-4o
+    model: openai/gpt-5-mini
     description: Coordinator
     instruction: Delegate tasks to the right sub-agent.
     sub_agents:

--- a/docs/concepts/models/index.md
+++ b/docs/concepts/models/index.md
@@ -19,7 +19,7 @@ Use the `provider/model` shorthand directly in the agent definition:
 ```yaml
 agents:
   root:
-    model: openai/gpt-4o
+    model: openai/gpt-5-mini
     instruction: You are a helpful assistant.
 ```
 
@@ -31,7 +31,7 @@ Define models in a `models` section and reference them by name:
 models:
   claude:
     provider: anthropic
-    model: claude-sonnet-4-0
+    model: claude-sonnet-4-5
     max_tokens: 64000
     temperature: 0.7
 
@@ -47,8 +47,8 @@ Named models let you configure temperature, token limits, thinking budgets, and 
 
 | Provider            | Key              | Example Models                       | API Key Env Var                     |
 | ------------------- | ---------------- | ------------------------------------ | ----------------------------------- |
-| OpenAI              | `openai`         | gpt-4o, gpt-5, gpt-5-mini            | `OPENAI_API_KEY`                    |
-| Anthropic           | `anthropic`      | claude-sonnet-4-0, claude-sonnet-4-5 | `ANTHROPIC_API_KEY`                 |
+| OpenAI              | `openai`         | gpt-5, gpt-5-mini, gpt-4o            | `OPENAI_API_KEY`                    |
+| Anthropic           | `anthropic`      | claude-sonnet-4-5, claude-opus-4-7   | `ANTHROPIC_API_KEY`                 |
 | Google              | `google`         | gemini-2.5-flash, gemini-3-pro       | `GOOGLE_API_KEY` / `GEMINI_API_KEY` |
 | AWS Bedrock         | `amazon-bedrock` | Claude, Nova, Llama models           | AWS credentials                     |
 | Docker Model Runner | `dmr`            | ai/qwen3, ai/llama3.2                | None (local)                        |
@@ -118,7 +118,7 @@ models:
 ```yaml
 agents:
   root:
-    model: anthropic/claude-sonnet-4-0,openai/gpt-5-mini
+    model: anthropic/claude-sonnet-4-5,openai/gpt-5-mini
     instruction: You are a helpful assistant.
 ```
 

--- a/docs/concepts/multi-agent/index.md
+++ b/docs/concepts/multi-agent/index.md
@@ -120,7 +120,7 @@ agents:
       - researcher
 
   researcher:
-    model: openai/gpt-4o
+    model: openai/gpt-5-mini
     description: Web researcher
     instruction: |
       Search the web, then hand off to the summarizer.
@@ -131,7 +131,7 @@ agents:
       - summarizer
 
   summarizer:
-    model: openai/gpt-4o-mini
+    model: openai/gpt-5-mini
     description: Summarizes findings
     instruction: |
       Summarize the research results, then hand off
@@ -156,7 +156,7 @@ Add it to your coordinator's toolsets:
 ```yaml
 agents:
   root:
-    model: anthropic/claude-sonnet-4-0
+    model: anthropic/claude-sonnet-4-5
     description: Research coordinator
     sub_agents: [researcher, analyst, writer]
     toolsets:
@@ -190,7 +190,7 @@ Sub-agents don't have to be defined locally — you can reference agents from OC
 ```yaml
 agents:
   root:
-    model: openai/gpt-4o
+    model: openai/gpt-5-mini
     description: Coordinator that delegates to local and catalog sub-agents
     instruction: |
       Delegate tasks to the most appropriate sub-agent.
@@ -199,7 +199,7 @@ agents:
       - agentcatalog/pirate # pulled from registry automatically
 
   local_helper:
-    model: openai/gpt-4o
+    model: openai/gpt-5-mini
     description: A local helper agent for simple tasks
     instruction: You are a helpful assistant.
 ```
@@ -224,7 +224,7 @@ External sub-agents are automatically named after their last path segment — fo
 ```yaml
 agents:
   root:
-    model: anthropic/claude-sonnet-4-0
+    model: anthropic/claude-sonnet-4-5
     description: Technical lead coordinating development
     instruction: |
       You are a technical lead managing a development team.
@@ -235,7 +235,7 @@ agents:
       - type: think
 
   developer:
-    model: anthropic/claude-sonnet-4-0
+    model: anthropic/claude-sonnet-4-5
     description: Expert software developer
     instruction: |
       You are an expert developer. Write clean, efficient code
@@ -246,7 +246,7 @@ agents:
       - type: think
 
   reviewer:
-    model: openai/gpt-4o
+    model: openai/gpt-5-mini
     description: Code review specialist
     instruction: |
       You review code for quality, security, and maintainability.
@@ -255,7 +255,7 @@ agents:
       - type: filesystem
 
   tester:
-    model: openai/gpt-4o
+    model: openai/gpt-5-mini
     description: Quality assurance engineer
     instruction: |
       You write tests and ensure software quality. Run tests
@@ -270,7 +270,7 @@ agents:
 ```yaml
 agents:
   root:
-    model: anthropic/claude-sonnet-4-0
+    model: anthropic/claude-sonnet-4-5
     description: Research coordinator
     instruction: |
       Coordinate research tasks. Delegate web searches to
@@ -280,7 +280,7 @@ agents:
       - type: think
 
   researcher:
-    model: openai/gpt-4o
+    model: openai/gpt-5-mini
     description: Web researcher
     instruction: Search the web and gather information.
     toolsets:
@@ -290,7 +290,7 @@ agents:
         path: ./research.db
 
   writer:
-    model: anthropic/claude-sonnet-4-0
+    model: anthropic/claude-sonnet-4-5
     description: Content writer
     instruction: Write clear, well-structured content.
     toolsets:
@@ -310,7 +310,7 @@ models:
 
   creative:
     provider: openai
-    model: gpt-4o
+    model: gpt-5
     temperature: 0.8 # creative
 
   local:

--- a/docs/configuration/agents/index.md
+++ b/docs/configuration/agents/index.md
@@ -68,7 +68,7 @@ agents:
 
 | Property                    | Type    | Required | Description                                                                                                                                                                   |
 | --------------------------- | ------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `model`                     | string  | ✓        | Model reference. Either inline (`openai/gpt-4o`) or a named model from the `models` section.                                                                                  |
+| `model`                     | string  | ✓        | Model reference. Either inline (`openai/gpt-5-mini`) or a named model from the `models` section.                                                                              |
 | `description`               | string  | ✓        | Brief description of the agent's purpose. Used by coordinators to decide delegation.                                                                                          |
 | `instruction`               | string  | ✓        | System prompt that defines the agent's behavior, personality, and constraints.                                                                                                |
 | `sub_agents`                | array   | ✗        | List of agent names or external OCI references this agent can delegate to. Supports local agents, registry references (e.g., `agentcatalog/pirate`), and named references (`name:reference`). Automatically enables the `transfer_task` tool. See [External Sub-Agents]({{ '/concepts/multi-agent/#external-sub-agents-from-registries' | relative_url }}). |
@@ -192,7 +192,7 @@ Display a message when users start a session:
 ```yaml
 agents:
   assistant:
-    model: openai/gpt-4o
+    model: openai/gpt-5-mini
     description: Development assistant
     instruction: You are a helpful coding assistant.
     welcome_message: |
@@ -213,7 +213,7 @@ Toolsets support `defer` to load tools on-demand and speed up agent startup. See
 ```yaml
 agents:
   root:
-    model: anthropic/claude-sonnet-4-0
+    model: anthropic/claude-sonnet-4-5
     description: Multi-purpose assistant
     instruction: You have access to many tools.
     toolsets:
@@ -241,10 +241,10 @@ Automatically switch to backup models when the primary fails:
 ```yaml
 agents:
   root:
-    model: anthropic/claude-sonnet-4-0
+    model: anthropic/claude-sonnet-4-5
     fallback:
       models:
-        - openai/gpt-4o
+        - openai/gpt-5-mini
         - google/gemini-2.5-flash
       retries: 2
       cooldown: 1m
@@ -257,7 +257,7 @@ Define reusable prompt shortcuts:
 ```yaml
 agents:
   root:
-    model: openai/gpt-4o
+    model: openai/gpt-5-mini
     instruction: You are a system administrator.
     commands:
       df: "Check how much free space I have on my disk"
@@ -281,7 +281,7 @@ Commands use JavaScript template literal syntax for environment variable interpo
 models:
   claude:
     provider: anthropic
-    model: claude-sonnet-4-0
+    model: claude-sonnet-4-5
     max_tokens: 64000
 
 agents:
@@ -296,7 +296,7 @@ agents:
     add_date: true
     add_environment_info: true
     fallback:
-      models: [openai/gpt-4o]
+      models: [openai/gpt-5-mini]
     toolsets:
       - type: think
     commands:
@@ -318,7 +318,7 @@ agents:
       - type: todo
 
   researcher:
-    model: openai/gpt-4o
+    model: openai/gpt-5-mini
     description: Web researcher with memory
     instruction: Search for information and remember findings.
     toolsets:

--- a/docs/configuration/overview/index.md
+++ b/docs/configuration/overview/index.md
@@ -26,7 +26,7 @@ metadata:
 models:
   claude:
     provider: anthropic
-    model: claude-sonnet-4-0
+    model: claude-sonnet-4-5
     max_tokens: 64000
 
 # 4. Agents — define AI agents with their behavior
@@ -74,7 +74,7 @@ The simplest possible configuration — a single agent with an inline model:
 ```yaml
 agents:
   root:
-    model: openai/gpt-4o
+    model: openai/gpt-5-mini
     description: A helpful assistant
     instruction: You are a helpful assistant.
 ```
@@ -87,7 +87,7 @@ Models can be referenced inline or defined in the `models` section:
   <div class="card" style="cursor:default;">
     <h3>Inline</h3>
     <p>Quick and simple. Use <code>provider/model</code> syntax directly.</p>
-    <pre style="margin-top:12px"><code class="language-yaml">model: openai/gpt-4o</code></pre>
+    <pre style="margin-top:12px"><code class="language-yaml">model: openai/gpt-5-mini</code></pre>
   </div>
   <div class="card" style="cursor:default;">
     <h3>Named</h3>
@@ -145,14 +145,19 @@ Models can be referenced inline or defined in the `models` section:
 
 API keys and secrets are read from environment variables — never stored in config files. See [Managing Secrets]({{ '/guides/secrets/' | relative_url }}) for all the ways to provide credentials (env files, Docker Compose secrets, macOS Keychain, `pass`):
 
-| Variable            | Provider      |
-| ------------------- | ------------- |
-| `OPENAI_API_KEY`    | OpenAI        |
-| `ANTHROPIC_API_KEY` | Anthropic     |
-| `GOOGLE_API_KEY`    | Google Gemini |
-| `MISTRAL_API_KEY`   | Mistral       |
-| `XAI_API_KEY`       | xAI           |
-| `NEBIUS_API_KEY`    | Nebius        |
+| Variable                   | Provider                                            |
+| -------------------------- | --------------------------------------------------- |
+| `OPENAI_API_KEY`           | OpenAI                                              |
+| `ANTHROPIC_API_KEY`        | Anthropic                                           |
+| `GOOGLE_API_KEY` / `GEMINI_API_KEY` | Google Gemini                              |
+| `MISTRAL_API_KEY`          | Mistral                                             |
+| `XAI_API_KEY`              | xAI                                                 |
+| `NEBIUS_API_KEY`           | Nebius                                              |
+| `MINIMAX_API_KEY`          | MiniMax                                             |
+| `REQUESTY_API_KEY`         | Requesty                                            |
+| `GITHUB_TOKEN`             | GitHub Copilot (PAT with `copilot` scope)           |
+| `AZURE_API_KEY`            | Azure OpenAI (override with `token_key`)            |
+| `AWS_BEARER_TOKEN_BEDROCK` | AWS Bedrock (or the standard AWS credentials chain) |
 
 **Tool Auto-Installation:**
 
@@ -161,10 +166,25 @@ API keys and secrets are read from environment variables — never stored in con
 | `DOCKER_AGENT_AUTO_INSTALL` | Set to `false` to disable automatic tool installation           |
 | `DOCKER_AGENT_TOOLS_DIR`    | Override the base directory for installed tools (default: `~/.cagent/tools/`) |
 
+**Runtime overrides:**
+
+| Variable                            | Description                                                                                          |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `DOCKER_AGENT_DEFAULT_MODEL`        | Default model used when none is specified, in `provider/model` form (e.g. `openai/gpt-5-mini`).      |
+| `DOCKER_AGENT_MODELS_GATEWAY`       | Route model traffic through a gateway. Equivalent to the `--models-gateway` flag.                    |
+| `DOCKER_AGENT_HIDE_TELEMETRY_BANNER`| Set to `1` to suppress the first-run telemetry notice.                                               |
+
+<div class="callout callout-info" markdown="1">
+<div class="callout-title">ℹ️ Legacy <code>CAGENT_*</code> aliases
+</div>
+  <p>The same variables are also accepted with the legacy <code>CAGENT_</code> prefix (e.g. <code>CAGENT_DEFAULT_MODEL</code>, <code>CAGENT_MODELS_GATEWAY</code>, <code>CAGENT_HIDE_TELEMETRY_BANNER</code>) for backward compatibility. Prefer the <code>DOCKER_AGENT_*</code> form in new setups.</p>
+
+</div>
+
 <div class="callout callout-warning" markdown="1">
 <div class="callout-title">⚠️ Important
 </div>
-  <p>Model references are case-sensitive: <code>openai/gpt-4o</code> is not the same as <code>openai/GPT-4o</code>.</p>
+  <p>Model references are case-sensitive: <code>openai/gpt-5-mini</code> is not the same as <code>openai/GPT-5-mini</code>.</p>
 
 </div>
 
@@ -195,7 +215,7 @@ version: 8
 
 agents:
   root:
-    model: openai/gpt-4o
+    model: openai/gpt-5-mini
     # ...
 ```
 
@@ -241,7 +261,7 @@ mcps:
 
 agents:
   root:
-    model: openai/gpt-4o
+    model: openai/gpt-5-mini
     toolsets:
       - type: mcp
         ref: github        # reuse the definition above

--- a/docs/configuration/routing/index.md
+++ b/docs/configuration/routing/index.md
@@ -28,25 +28,25 @@ models:
   smart_router:
     # Fallback model when no routing rule matches
     provider: openai
-    model: gpt-4o-mini
+    model: gpt-5-mini
 
     # Routing rules
     routing:
-      - model: anthropic/claude-sonnet-4-0
+      - model: anthropic/claude-sonnet-4-5
         examples:
           - "Write a detailed technical document"
           - "Help me architect this system"
           - "Review this code for security issues"
           - "Explain this complex algorithm"
 
-      - model: openai/gpt-4o
+      - model: openai/gpt-5
         examples:
           - "Generate some creative ideas"
           - "Write a story about"
           - "Help me brainstorm"
           - "Come up with names for"
 
-      - model: openai/gpt-4o-mini
+      - model: openai/gpt-5-mini
         examples:
           - "What time is it"
           - "Convert this to JSON"
@@ -100,9 +100,9 @@ Route simple queries to cheaper models:
 models:
   cost_optimizer:
     provider: openai
-    model: gpt-4o-mini # Cheap fallback
+    model: gpt-5-mini # Cheap fallback
     routing:
-      - model: anthropic/claude-sonnet-4-0
+      - model: anthropic/claude-sonnet-4-5
         examples:
           - "Complex analysis"
           - "Detailed research"
@@ -117,15 +117,15 @@ Route coding tasks to code-specialized models:
 models:
   task_router:
     provider: openai
-    model: gpt-4o # General fallback
+    model: gpt-5-mini # General fallback
     routing:
-      - model: anthropic/claude-sonnet-4-0
+      - model: anthropic/claude-sonnet-4-5
         examples:
           - "Write code"
           - "Debug this function"
           - "Review my implementation"
           - "Fix this bug"
-      - model: openai/gpt-4o
+      - model: openai/gpt-5
         examples:
           - "Write a blog post"
           - "Help me with writing"
@@ -140,9 +140,9 @@ Distribute load across equivalent models from different providers:
 models:
   load_balancer:
     provider: openai
-    model: gpt-4o
+    model: gpt-5-mini
     routing:
-      - model: anthropic/claude-sonnet-4-0
+      - model: anthropic/claude-sonnet-4-5
         examples:
           - "First request pattern"
           - "Another request type"
@@ -163,8 +163,8 @@ $ docker agent run config.yaml --debug
 Look for log entries like:
 
 ```text
-"Rule-based router selected model" router=smart_router selected_model=anthropic/claude-sonnet-4-0
-"Route matched" model=anthropic/claude-sonnet-4-0 score=2.45
+"Rule-based router selected model" router=smart_router selected_model=anthropic/claude-sonnet-4-5
+"Route matched" model=anthropic/claude-sonnet-4-5 score=2.45
 ```
 
 <div class="callout callout-warning" markdown="1">

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -46,7 +46,7 @@ $ docker agent run [config] [message...] [flags]
 | `--working-dir <path>`                  | Set the working directory for the session (applies to tools and relative paths)                                                           |
 | `--env-from-file <path>`                | Load environment variables from file (repeatable)                                                                                         |
 | `--code-mode-tools`                     | Provide a single tool to call other tools via JavaScript (forces code-mode tools globally)                                                |
-| `--models-gateway <addr>`               | Route model traffic through a gateway. Also reads `DOCKER_AGENT_MODELS_GATEWAY` env var.                                                  |
+| `--models-gateway <addr>`               | Route model traffic through a gateway. Also reads `DOCKER_AGENT_MODELS_GATEWAY` (legacy `CAGENT_MODELS_GATEWAY`) env var.                  |
 | `--hook-pre-tool-use <cmd>`             | Add a pre-tool-use hook command (repeatable). See [Hooks]({{ '/configuration/hooks/' | relative_url }}).                                  |
 | `--hook-post-tool-use <cmd>`            | Add a post-tool-use hook command (repeatable)                                                                                             |
 | `--hook-session-start <cmd>`            | Add a session-start hook command (repeatable)                                                                                             |
@@ -281,6 +281,7 @@ $ docker agent run yolo-coder
 
 - `--yolo` — Auto-approve all tool calls when running the alias
 - `--model &lt;ref&gt;` — Override the model for the alias
+- `--hide-tool-results` — Hide tool call results in the TUI when running the alias
 
 When listing aliases, options are shown in brackets:
 

--- a/docs/getting-started/installation/index.md
+++ b/docs/getting-started/installation/index.md
@@ -104,9 +104,11 @@ docker-agent needs API keys for the model providers you want to use. Set them as
 # Pick one (or more) depending on your provider
 export OPENAI_API_KEY="sk-..."           # OpenAI
 export ANTHROPIC_API_KEY="sk-ant-..."    # Anthropic
-export GOOGLE_API_KEY="AI..."           # Google Gemini
-export MISTRAL_API_KEY="..."            # Mistral
+export GOOGLE_API_KEY="AI..."            # Google Gemini (or GEMINI_API_KEY)
+export MISTRAL_API_KEY="..."             # Mistral
 ```
+
+See [Configuration Overview]({{ '/configuration/overview/#environment-variables' | relative_url }}) for the full list of supported providers and environment variables.
 
 <div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ Note

--- a/docs/getting-started/introduction/index.md
+++ b/docs/getting-started/introduction/index.md
@@ -76,7 +76,7 @@ At its core, docker-agent follows a simple loop:
 # A minimal agent definition
 agents:
   root:
-    model: openai/gpt-4o
+    model: openai/gpt-5-mini
     description: A helpful assistant
     instruction: You are a helpful assistant.
     toolsets:

--- a/docs/getting-started/quickstart/index.md
+++ b/docs/getting-started/quickstart/index.md
@@ -40,7 +40,7 @@ Use the `docker agent new` command to scaffold a config file through prompts:
 $ docker agent new
 
 # Or specify options directly
-$ docker agent new --model openai/gpt-4o
+$ docker agent new --model openai/gpt-5-mini
 
 # Override iteration limits
 $ docker agent new --model dmr/ai/gemma3-qat:12B --max-iterations 15
@@ -59,7 +59,7 @@ Create an `agent.yaml` by hand for full control. Here's a minimal example:
 ```yaml
 agents:
   root:
-    model: anthropic/claude-sonnet-4-0
+    model: anthropic/claude-sonnet-4-5
     description: A helpful coding assistant
     instruction: |
       You are an expert software developer. Help users write
@@ -72,7 +72,7 @@ agents:
 
 This gives your agent:
 
-- **Claude Sonnet 4** as the underlying model
+- **Claude Sonnet 4.5** as the underlying model
 - **Filesystem access** to read and write files
 - **Shell access** to run commands
 - **Think tool** for step-by-step reasoning
@@ -116,7 +116,7 @@ Give your agent persistent memory and web search:
 ```yaml
 agents:
   root:
-    model: anthropic/claude-sonnet-4-0
+    model: anthropic/claude-sonnet-4-5
     description: Research assistant with memory
     instruction: |
       You are a research assistant. Search the web for information,

--- a/docs/providers/anthropic/index.md
+++ b/docs/providers/anthropic/index.md
@@ -22,7 +22,7 @@ export ANTHROPIC_API_KEY="sk-ant-..."
 ```yaml
 agents:
   root:
-    model: anthropic/claude-sonnet-4-0
+    model: anthropic/claude-sonnet-4-5
 ```
 
 ### Named Model
@@ -31,7 +31,7 @@ agents:
 models:
   claude:
     provider: anthropic
-    model: claude-sonnet-4-0
+    model: claude-sonnet-4-5
     max_tokens: 64000
 ```
 
@@ -41,7 +41,7 @@ models:
 | ------------------- | --------------------------------------------------- |
 | `claude-opus-4-7`   | Highest-capability Opus model; supports task budget |
 | `claude-sonnet-4-5` | Most capable Sonnet, extended thinking (default)    |
-| `claude-sonnet-4-0` | Strong coding, balanced performance                 |
+| `claude-sonnet-4-0` | Previous Sonnet generation, still supported         |
 | `claude-haiku-4-5`  | Fast and inexpensive, good for tight loops          |
 
 ## Thinking Budget

--- a/docs/providers/openai/index.md
+++ b/docs/providers/openai/index.md
@@ -22,7 +22,7 @@ export OPENAI_API_KEY="sk-..."
 ```yaml
 agents:
   root:
-    model: openai/gpt-4o
+    model: openai/gpt-5-mini
 ```
 
 ### Named Model
@@ -31,7 +31,7 @@ agents:
 models:
   gpt:
     provider: openai
-    model: gpt-4o
+    model: gpt-5-mini
     temperature: 0.7
     max_tokens: 4000
 ```
@@ -74,7 +74,7 @@ Use `base_url` to connect to OpenAI-compatible APIs:
 models:
   custom:
     provider: openai
-    model: gpt-4o
+    model: gpt-5-mini
     base_url: https://your-proxy.example.com/v1
 ```
 

--- a/docs/providers/overview/index.md
+++ b/docs/providers/overview/index.md
@@ -14,12 +14,12 @@ _docker-agent supports multiple AI model providers. Choose the right one for you
   <a class="card" href="{{ '/providers/openai/' | relative_url }}">
     <div class="card-icon">🟢</div>
     <h3>OpenAI</h3>
-    <p>GPT-4o, GPT-5, GPT-5-mini. The most widely used AI models.</p>
+    <p>GPT-5, GPT-5-mini, GPT-4o. The most widely used AI models.</p>
   </a>
   <a class="card" href="{{ '/providers/anthropic/' | relative_url }}">
     <div class="card-icon">🟠</div>
     <h3>Anthropic</h3>
-    <p>Claude Sonnet 4, Claude Sonnet 4.5. Excellent for coding and analysis.</p>
+    <p>Claude Sonnet 4.5, Claude Opus 4.7. Excellent for coding and analysis.</p>
   </a>
   <a class="card" href="{{ '/providers/google/' | relative_url }}">
     <div class="card-icon">🔵</div>
@@ -90,11 +90,11 @@ Different agents can use different providers in the same configuration:
 models:
   claude:
     provider: anthropic
-    model: claude-sonnet-4-0
+    model: claude-sonnet-4-5
     max_tokens: 64000
   gpt:
     provider: openai
-    model: gpt-4o
+    model: gpt-5-mini
   local:
     provider: dmr
     model: ai/qwen3
@@ -104,7 +104,7 @@ agents:
     model: claude # coordinator uses Claude
     sub_agents: [coder, helper]
   coder:
-    model: gpt # coder uses GPT-4o
+    model: gpt # coder uses GPT-5-mini
   helper:
     model: local # helper runs locally for free
 ```


### PR DESCRIPTION
## What this PR fixes

A pass through the docs surfaced a handful of issues that were either **outdated**, **wrong**, or simply **missing**. This PR brings the most-read pages back in sync with the codebase.

### Outdated model examples

Most introductory pages still showed `openai/gpt-4o` / `anthropic/claude-sonnet-4-0` everywhere, even though [`pkg/config/auto.go`](https://github.com/docker/docker-agent/blob/main/pkg/config/auto.go) and the README itself default to `openai/gpt-5-mini` and `anthropic/claude-sonnet-4-5`. Updated:

- ` getting-started/{introduction,quickstart,installation}`
- `concepts/{agents,multi-agent,models,distribution}`
- `configuration/{overview,agents,routing}`
- `providers/{overview,openai,anthropic}`
- `community/troubleshooting`

### Internally-inconsistent Anthropic page

`docs/providers/anthropic/index.md` had `claude-sonnet-4-0` in the inline / named-model examples while the *Available Models* table called `claude-sonnet-4-5` the default. The page now leads with `claude-sonnet-4-5` and keeps `claude-sonnet-4-0` in the table as a *previous Sonnet generation, still supported* entry.

### Missing environment variables

`docs/configuration/overview/index.md` only listed 6 of the 11 supported provider keys and didn't mention several runtime env vars at all. Added:

| New entry                              | Where it comes from                                                                                                |
| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
| `GEMINI_API_KEY`                       | `pkg/model/provider/gemini/client.go`                                                                              |
| `MINIMAX_API_KEY`, `REQUESTY_API_KEY`  | `pkg/model/provider/aliases.go`                                                                                    |
| `AZURE_API_KEY`                        | `pkg/model/provider/aliases.go`                                                                                    |
| `GITHUB_TOKEN` (Copilot)               | `pkg/model/provider/aliases.go`                                                                                    |
| `AWS_BEARER_TOKEN_BEDROCK`             | bedrock provider                                                                                                   |
| `DOCKER_AGENT_DEFAULT_MODEL`           | `cmd/root/flags.go` (`envDefaultModel`)                                                                            |
| `DOCKER_AGENT_HIDE_TELEMETRY_BANNER`   | `cmd/root/root.go`                                                                                                 |
| `DOCKER_AGENT_MODELS_GATEWAY`          | already documented for `--models-gateway`, now also in the env-var table                                           |

A short callout points readers at the legacy `CAGENT_*` aliases that the same code paths still accept.

### CLI Reference gaps

- `docker agent alias add` supports `--hide-tool-results` (see `cmd/root/alias.go`) but the *Alias Options* bullet list didn't mention it.
- The row for `--models-gateway` now also notes the legacy `CAGENT_MODELS_GATEWAY` env var alias.

### Troubleshooting nits

- *Context Length Exceeded* claimed *Claude 200K, Gemini 2M* — Sonnet 4.5 is now 1M tokens.
- *Incorrect model name* example used `gpt-4` vs `gpt-4o`; updated to `gpt-5-mini` / `gpt-4o`.

## How to verify

```bash
git diff upstream/main -- docs
```

No source code is touched, so existing tests and `mise lint` are unaffected.