### PR TITLE
feat(mcp): add support for embedded resource content type

### DIFF
--- a/pkg/tools/mcp/mcp.go
+++ b/pkg/tools/mcp/mcp.go
@@ -591,6 +591,19 @@ func processMCPContent(toolResult *mcp.CallToolResult) *tools.ToolCallResult {
 			} else {
 				text.WriteString(c.URI)
 			}
+		case *mcp.EmbeddedResource:
+			if c.Resource == nil {
+				continue
+			}
+			if c.Resource.Text != "" {
+				text.WriteString(c.Resource.Text)
+				continue
+			}
+			if len(c.Resource.Blob) > 0 {
+				// Binary blobs can't be inlined as text; surface a marker the model can reason about.
+				fmt.Fprintf(&text, "[embedded resource %s (%s, %d bytes)]",
+					c.Resource.URI, c.Resource.MIMEType, len(c.Resource.Blob))
+			}
 		}
 	}
 

--- a/pkg/tools/mcp/mcp_test.go
+++ b/pkg/tools/mcp/mcp_test.go
@@ -245,6 +245,51 @@ func TestProcessMCPContent(t *testing.T) {
 			wantOutput: "[doc](file:///path(1%29/doc.txt)",
 		},
 
+		// --- embedded resources ---
+		{
+			name: "embedded text resource",
+			input: callToolResult(&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "file:///notes.txt",
+					MIMEType: "text/plain",
+					Text:     "hello world",
+				},
+			}),
+			wantOutput: "hello world",
+		},
+		{
+			name: "text ack and embedded text resource concatenate",
+			input: callToolResult(
+				&mcp.TextContent{Text: "downloaded "},
+				&mcp.EmbeddedResource{
+					Resource: &mcp.ResourceContents{
+						URI:      "file:///notes.txt",
+						MIMEType: "text/plain",
+						Text:     "hello world",
+					},
+				},
+			),
+			wantOutput: "downloaded hello world",
+		},
+		{
+			name: "embedded blob resource emits a marker",
+			input: callToolResult(&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "file:///image.png",
+					MIMEType: "image/png",
+					Blob:     []byte("PNGBYTES"),
+				},
+			}),
+			wantOutput: "[embedded resource file:///image.png (image/png, 8 bytes)]",
+		},
+		{
+			name: "embedded resource with nil contents is no-op",
+			input: callToolResult(&mcp.EmbeddedResource{
+				Resource: nil,
+			}),
+			wantOutput: "no output",
+		},
+
 		// --- structured content ---
 		{
 			name:           "structured content passed through",


### PR DESCRIPTION
## Summary

`processMCPContent` ignored `*mcp.EmbeddedResource` content blocks. The switch only handled `TextContent`, `ImageContent`, `AudioContent`, and `ResourceLink` — anything inside an embedded resource was silently discarded.

This bites tools that return file bodies as embedded resources rather than inline text. The most visible case is `github-mcp-server`'s `get_file_contents`: for text files it emits a short `TextContent` acknowledgement (`"successfully downloaded text file (SHA: …)"`) followed by the actual file body wrapped in an `EmbeddedResource`. The model only ever saw the ~80-byte ack and never the file.

## Reproduction

A trivial agent with the github toolset, asking for any text file:

```yaml
agents:
  root:
    model: sonnet
    instruction: |
      Call `get_file_contents` once and return what the tool returned, with its byte length.
    toolsets:
      - type: mcp
        ref: github-official
```

Before this change, the tool result returned to the model was 83 bytes:

```
successfully downloaded text file (SHA: 60848fee0a1df04b85c0ea866717185355cda8f1)
```

After this change, the same call returns the ack plus the full file body, and the model can reason over the content.