### PR TITLE
fix(security): bump jose2go to v1.7.0 (GO-2025-4123, GO-2023-2409)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,7 @@ require (
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 // indirect
 	github.com/danieljoos/wincred v1.2.2 // indirect
-	github.com/dvsekhvalnov/jose2go v1.5.0 // indirect
+	github.com/dvsekhvalnov/jose2go v1.7.0 // indirect
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -216,6 +216,10 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/dvsekhvalnov/jose2go v1.5.0 h1:3j8ya4Z4kMCwT5nXIKFSV84YS+HdqSSO0VsTQxaLAeM=
 github.com/dvsekhvalnov/jose2go v1.5.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
+github.com/dvsekhvalnov/jose2go v1.7.0 h1:bnQc8+GMnidJZA8zc6lLEAb4xNrIqHwO+9TzqvtQZPo=
+github.com/dvsekhvalnov/jose2go v1.7.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
+github.com/dvsekhvalnov/jose2go v1.8.0 h1:LqkkVKAlHFfH9LOEl5fe4p/zL02OhWE7pCufMBG2jLA=
+github.com/dvsekhvalnov/jose2go v1.8.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
 github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o=
 github.com/elazarl/goproxy v1.7.2/go.mod h1:82vkLNir0ALaW14Rc399OTTjyNREgmdL2cVoIbS6XaE=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=


### PR DESCRIPTION
Addresses the following reported by `govulncheck`:

```plain
=== Symbol Results ===

Vulnerability #1: GO-2025-4123
    Denial-of-Service (DoS) via crafted JSON Web Encryption (JWE) token high
    compression ratio in github.com/dvsekhvalnov/jose2go
  More info: https://pkg.go.dev/vuln/GO-2025-4123
  Module: github.com/dvsekhvalnov/jose2go
    Found in: github.com/dvsekhvalnov/jose2go@v1.5.0
    Fixed in: github.com/dvsekhvalnov/jose2go@v1.7.0
    Example traces found:
      #1: pkg/tools/mcp/tokenstore_keyring.go:94:25: mcp.KeyringTokenStore.load calls keyring.fileKeyring.Get, which calls jose2go.Decode

Vulnerability #2: GO-2023-2409
    Denial of service when decrypting attacker controlled input in
    github.com/dvsekhvalnov/jose2go
  More info: https://pkg.go.dev/vuln/GO-2023-2409
  Module: github.com/dvsekhvalnov/jose2go
    Found in: github.com/dvsekhvalnov/jose2go@v1.5.0
    Fixed in: github.com/dvsekhvalnov/jose2go@v1.5.1-0.20231206184617-48ba0b76bc88
    Example traces found:
      #1: pkg/tools/mcp/tokenstore_keyring.go:94:25: mcp.KeyringTokenStore.load calls keyring.fileKeyring.Get, which calls jose2go.Decode
      #2: pkg/tools/mcp/tokenstore_keyring.go:156:19: mcp.KeyringTokenStore.persistLocked calls keyring.fileKeyring.Set, which calls jose2go.Encrypt

Your code is affected by 2 vulnerabilities from 1 module.
```

There was already #2361 - not sure about the reason it was closed.