### PR TITLE
fix(lifecycle): order state transition before waking restart waiters

### DIFF
--- a/pkg/tools/lifecycle/supervisor.go
+++ b/pkg/tools/lifecycle/supervisor.go
@@ -446,13 +446,14 @@ func (s *Supervisor) tryRestart(ctx context.Context) bool {
 			return false
 		}
 		s.session = sess
-		// Wake any RestartAndWait callers, then prepare for the next cycle.
+		// Transition to Ready before unblocking RestartAndWait so callers
+		// observe the new state, not a stale Restarting.
+		s.tracker.Set(StateReady)
+		s.tracker.ResetRestarts()
 		close(s.restarted)
 		s.restarted = make(chan struct{})
 		s.mu.Unlock()
 
-		s.tracker.Set(StateReady)
-		s.tracker.ResetRestarts()
 		log.Info("supervisor: restarted", "name", s.name, "attempt", attempt+1)
 		return true
 	}


### PR DESCRIPTION
`tryRestart` was closing `s.restarted` before calling `s.tracker.Set(StateReady)`, so a `RestartAndWait` caller could observe a stale `StateRestarting` immediately after the call returned `nil`. Move the tracker update ahead of the channel close so the new state is visible to any caller that wakes up

This was observed via flaky tests when running with `-race` and `-shuffle=on`:

```
2026/05/04 08:55:05 WARN supervisor: session lost name=test error=crash forced=false
2026/05/04 08:55:05 WARN supervisor: session lost name=test error=<nil> forced=true
2026/05/04 08:55:05 INFO supervisor: restarted name=test attempt=1
2026/05/04 08:55:05 WARN supervisor: session lost name=test error=<nil> forced=true
2026/05/04 08:55:05 INFO supervisor: restarted name=test attempt=1
2026/05/04 08:55:05 WARN supervisor: restart failed name=test attempt=1 error=fail-1
2026/05/04 08:55:05 WARN supervisor: session lost name=test error="authentication required" forced=false
2026/05/04 08:55:05 WARN supervisor: restart failed name=test attempt=2 error=fail-2
2026/05/04 08:55:05 ERROR supervisor: giving up after max attempts name=test attempts=2
2026/05/04 08:55:05 WARN supervisor: session lost name=test error=crash forced=false
2026/05/04 08:55:05 WARN supervisor: session lost name=test error=crash forced=false
2026/05/04 08:55:05 WARN supervisor: restart failed name=test attempt=1 error=r1
2026/05/04 08:55:05 WARN supervisor: restart failed name=test attempt=2 error=r2
2026/05/04 08:55:05 ERROR supervisor: giving up after max attempts name=test attempts=2
2026/05/04 08:55:05 WARN supervisor: session lost name=test error=<nil> forced=true
2026/05/04 08:55:05 INFO supervisor: restarted name=test attempt=1
2026/05/04 08:55:05 WARN supervisor: session lost name=test error=<nil> forced=true
2026/05/04 08:55:05 WARN supervisor: restart failed name=test attempt=1 error="scripted connector exhausted"
2026/05/04 08:55:05 WARN supervisor: restart failed name=test attempt=2 error="scripted connector exhausted"
2026/05/04 08:55:05 WARN supervisor: restart failed name=test attempt=3 error="scripted connector exhausted"
2026/05/04 08:55:05 WARN supervisor: restart failed name=test attempt=4 error="scripted connector exhausted"
2026/05/04 08:55:05 WARN supervisor: restart failed name=test attempt=5 error="scripted connector exhausted"
2026/05/04 08:55:05 ERROR supervisor: giving up after max attempts name=test attempts=5
--- FAIL: TestSupervisor_RecoverFromFailedViaStart (0.03s)
    supervisor_test.go:396: assertion failed: restarting (s.State().State lifecycle.State) != ready (lifecycle.StateReady lifecycle.State)
2026/05/04 08:55:05 WARN supervisor: session lost name=test error=crash forced=false
2026/05/04 08:55:05 WARN supervisor: restart failed name=test attempt=1 error=fail-1
2026/05/04 08:55:05 WARN supervisor: restart failed name=test attempt=2 error=fail-2
2026/05/04 08:55:05 WARN supervisor: restart failed name=test attempt=3 error=fail-3
2026/05/04 08:55:05 ERROR supervisor: giving up after max attempts name=test attempts=3
FAIL
```