### PR TITLE
fix(session): close data races on session token and message writes

### DIFF
--- a/pkg/runtime/session_compaction.go
+++ b/pkg/runtime/session_compaction.go
@@ -106,15 +106,12 @@ func (r *LocalRuntime) doCompact(ctx context.Context, sess *session.Session, a *
 	// We snapshot before applying the result because the apply step
 	// resets sess.OutputTokens to 0 and replaces sess.InputTokens with
 	// the new summary's estimated size.
-	preInputTokens := sess.InputTokens
-	preOutputTokens := sess.OutputTokens
+	preInputTokens, preOutputTokens := sess.Usage()
 
 	// Apply the summary to the session. This is intrinsically
 	// runtime-private: it mutates session-internal state and persists
 	// through the runtime's session store.
-	sess.InputTokens = result.InputTokens
-	sess.OutputTokens = 0
-	sess.Messages = append(sess.Messages, session.Item{
+	sess.ApplyCompaction(result.InputTokens, 0, session.Item{
 		Summary:        result.Summary,
 		FirstKeptEntry: result.FirstKeptEntry,
 		Cost:           result.Cost,

--- a/pkg/runtime/streaming.go
+++ b/pkg/runtime/streaming.go
@@ -65,14 +65,14 @@ func handleStream(ctx context.Context, stream chat.MessageStream, a *agent.Agent
 		}
 		usageRecorded = true
 
-		sess.InputTokens = messageUsage.InputTokens + messageUsage.CachedInputTokens + messageUsage.CacheWriteTokens
-		sess.OutputTokens = messageUsage.OutputTokens
+		input := messageUsage.InputTokens + messageUsage.CachedInputTokens + messageUsage.CacheWriteTokens
+		sess.SetUsage(input, messageUsage.OutputTokens)
 
 		modelName := "unknown"
 		if m != nil {
 			modelName = m.Name
 		}
-		tel.RecordTokenUsage(ctx, modelName, sess.InputTokens, sess.OutputTokens, sess.TotalCost())
+		tel.RecordTokenUsage(ctx, modelName, input, messageUsage.OutputTokens, sess.TotalCost())
 	}
 
 	for {

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -401,6 +401,36 @@ func (s *Session) AddMessage(msg *Message) {
 	s.mu.Unlock()
 }
 
+// SetUsage records cumulative input/output token counts under s.mu.
+// The runtime stream goroutine and the persistence observer race on
+// these fields without it.
+func (s *Session) SetUsage(input, output int64) {
+	s.mu.Lock()
+	s.InputTokens = input
+	s.OutputTokens = output
+	s.mu.Unlock()
+}
+
+// Usage returns a consistent snapshot of the cumulative input/output
+// token counts.
+func (s *Session) Usage() (input, output int64) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.InputTokens, s.OutputTokens
+}
+
+// ApplyCompaction atomically resets the session's cumulative token
+// counts and appends a summary item under s.mu so concurrent readers
+// (e.g. the persistence observer's UpdateSession snapshot) cannot
+// observe the new tokens without the matching summary item.
+func (s *Session) ApplyCompaction(inputTokens, outputTokens int64, item Item) {
+	s.mu.Lock()
+	s.InputTokens = inputTokens
+	s.OutputTokens = outputTokens
+	s.Messages = append(s.Messages, item)
+	s.mu.Unlock()
+}
+
 // AddSubSession adds a sub-session to the session
 func (s *Session) AddSubSession(subSession *Session) {
 	s.mu.Lock()

--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -197,9 +197,11 @@ func (s *InMemorySessionStore) UpdateSession(_ context.Context, session *Session
 		return ErrEmptyID
 	}
 
-	// Build a new session with the same metadata but a fresh mutex.
-	// Messages are stored separately via AddMessage.
+	// Snapshot the input session under its mu so the field copy
+	// doesn't race with concurrent writers (e.g. the runtime stream
+	// goroutine updating token counts via SetUsage).
 	// MAINTENANCE: when adding new persisted fields to Session, add them here too.
+	session.mu.RLock()
 	newSession := &Session{
 		ID:                  session.ID,
 		Title:               session.Title,
@@ -214,12 +216,13 @@ func (s *InMemorySessionStore) UpdateSession(_ context.Context, session *Session
 		InputTokens:         session.InputTokens,
 		OutputTokens:        session.OutputTokens,
 		Cost:                session.Cost,
-		Permissions:         session.Permissions,
-		AgentModelOverrides: session.AgentModelOverrides,
-		CustomModelsUsed:    session.CustomModelsUsed,
-		AttachedFiles:       session.AttachedFilesSnapshot(),
+		Permissions:         clonePermissionsConfig(session.Permissions),
+		AgentModelOverrides: cloneStringMap(session.AgentModelOverrides),
+		CustomModelsUsed:    cloneStringSlice(session.CustomModelsUsed),
+		AttachedFiles:       slices.Clone(session.AttachedFiles),
 		ParentID:            session.ParentID,
 	}
+	session.mu.RUnlock()
 
 	// Preserve existing messages if session already exists
 	if existing, exists := s.sessions.Load(session.ID); exists {
@@ -257,9 +260,13 @@ func (s *InMemorySessionStore) AddMessage(_ context.Context, sessionID string, m
 	if !exists {
 		return 0, ErrNotFound
 	}
+	// Deep-copy before mutating ID. The caller's pointer may be held
+	// concurrently by another goroutine (snapshotItems → cloneMessage),
+	// and writing msg.ID directly races with those reads.
+	stored := cloneMessage(msg)
 	s.messageID++
-	msg.ID = s.messageID
-	session.AddMessage(msg)
+	stored.ID = s.messageID
+	session.AddMessage(stored)
 	return s.messageID, nil
 }
 


### PR DESCRIPTION
Eliminates 100+ data-race warnings across the `pkg/runtime` test suite under `-race`. Tests now pass cleanly.

Three concurrent paths were racing on session state:
- The runtime stream goroutine writing cumulative token counts during streaming;
- The persistence observer reading the same fields via `UpdateSession` to snapshot for storage;
- The compaction path resetting tokens and appending the summary item.

Fix is encapsulation: token reads/writes and the compaction apply step go through `Session` methods that hold `s.mu`, and `UpdateSession` snapshots the source session under `s.mu.RLock` (deep-cloning the mutable metadata fields so the persisted copy doesn't share references with the live session). `AddMessage` also deep-copies the message before assigning its persisted ID, since the caller pointer can be held concurrently by `snapshotItems` readers.