### PR TITLE
feat(runtime): propagate non-interactive mode to child sessions and decline elicitation

### DIFF
--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -170,6 +170,7 @@ func CreateToolHandler(t *team.Team, agentName string) func(context.Context, *mc
 
 		rt, err := runtime.New(t,
 			runtime.WithCurrentAgent(agentName),
+			runtime.WithNonInteractive(true),
 			runtime.WithTracer(otel.Tracer("cagent")),
 		)
 		if err != nil {

--- a/pkg/runtime/agent_delegation.go
+++ b/pkg/runtime/agent_delegation.go
@@ -91,6 +91,10 @@ type SubSessionConfig struct {
 	Title string
 	// ToolsApproved overrides whether tools are pre-approved in the child session.
 	ToolsApproved bool
+	// NonInteractive marks the child session as running without a user present
+	// (e.g. MCP server, A2A adapter, background agent). This causes the runtime
+	// to auto-stop on max iterations instead of blocking for user input.
+	NonInteractive bool
 	// PinAgent, when true, pins the child session to AgentName via
 	// session.WithAgentName. This is required for concurrent background
 	// tasks that must not share the runtime's mutable currentAgent field.
@@ -161,6 +165,7 @@ func newSubSession(parent *session.Session, cfg SubSessionConfig, childAgent *ag
 		session.WithMaxOldToolCallTokens(childAgent.MaxOldToolCallTokens()),
 		session.WithTitle(cfg.Title),
 		session.WithToolsApproved(cfg.ToolsApproved),
+		session.WithNonInteractive(cfg.NonInteractive),
 		session.WithSendUserMessage(false),
 		session.WithParentID(parent.ID),
 		session.WithAttachedFiles(attachedFiles),
@@ -381,6 +386,7 @@ func (r *LocalRuntime) RunAgent(ctx context.Context, params agenttool.RunParams)
 		AgentName:      params.AgentName,
 		Title:          "Background agent task",
 		ToolsApproved:  true,
+		NonInteractive: true,
 		PinAgent:       true,
 	}, params.OnContent)
 }
@@ -416,6 +422,7 @@ func (r *LocalRuntime) handleTaskTransfer(ctx context.Context, sess *session.Ses
 			AgentName:      params.Agent,
 			Title:          "Transferred task",
 			ToolsApproved:  sess.ToolsApproved,
+			NonInteractive: sess.NonInteractive,
 		},
 		SwitchCurrentAgent: true,
 	})

--- a/pkg/runtime/elicitation.go
+++ b/pkg/runtime/elicitation.go
@@ -115,6 +115,15 @@ func (r *LocalRuntime) ResumeElicitation(ctx context.Context, action tools.Elici
 func (r *LocalRuntime) elicitationHandler(ctx context.Context, req *mcp.ElicitParams) (tools.ElicitationResult, error) {
 	slog.Debug("Elicitation request received from MCP server", "message", req.Message)
 
+	// In non-interactive mode (e.g., MCP serve), there is no user to respond
+	// to elicitation requests. Decline immediately instead of blocking forever.
+	if r.nonInteractive {
+		slog.Debug("Declining elicitation in non-interactive mode", "message", req.Message)
+		return tools.ElicitationResult{
+			Action: tools.ElicitationActionDecline,
+		}, nil
+	}
+
 	r.executeOnUserInputHooks(ctx, "", "elicitation")
 
 	slog.Debug("Sending elicitation request event to client",

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -146,6 +146,7 @@ type LocalRuntime struct {
 	modelsStore          ModelStore
 	sessionCompaction    bool
 	managedOAuth         bool
+	nonInteractive       bool
 	startupInfoEmitted   bool                   // Track if startup info has been emitted to avoid unnecessary duplication
 	elicitationRequestCh chan ElicitationResult // Channel for receiving elicitation responses
 	elicitation          elicitationBridge      // Owns the per-stream events channel for outbound elicitation requests
@@ -248,6 +249,21 @@ func WithCurrentAgent(agentName string) Opt {
 func WithManagedOAuth(managed bool) Opt {
 	return func(r *LocalRuntime) {
 		r.managedOAuth = managed
+	}
+}
+
+// WithNonInteractive marks the runtime as headless (e.g., MCP serve mode).
+// When set, blocking operations like elicitation requests are automatically
+// declined instead of waiting for user interaction that will never come.
+//
+// Note: this complements session.WithNonInteractive, which controls per-session
+// loop behavior (e.g., auto-stop on max iterations). Both should be set for
+// fully headless operation - the runtime flag prevents elicitation hangs, while
+// the session flag adjusts iteration behavior. In MCP serve mode, both are set
+// by the server code in pkg/mcp/server.go.
+func WithNonInteractive(nonInteractive bool) Opt {
+	return func(r *LocalRuntime) {
+		r.nonInteractive = nonInteractive
 	}
 }
 

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace"
@@ -3263,4 +3264,45 @@ func TestPostToolHookEmitsLifecycleEvents(t *testing.T) {
 	assert.Equal(t, sess.ID, finished.SessionID)
 	assert.True(t, finished.Allowed)
 	assert.Empty(t, finished.Error)
+}
+
+func TestElicitationHandler_NonInteractive(t *testing.T) {
+	t.Parallel()
+
+	prov := &mockProvider{id: "test/mock-model", stream: newStreamBuilder().AddContent("ok").AddStopWithUsage(1, 1).Build()}
+	root := agent.New("root", "test", agent.WithModel(prov))
+	tm := team.New(team.WithAgents(root))
+
+	rt, err := NewLocalRuntime(tm, WithNonInteractive(true))
+	require.NoError(t, err)
+
+	params := &mcp.ElicitParams{
+		Message: "Authorize OAuth?",
+	}
+
+	result, err := rt.elicitationHandler(t.Context(), params)
+
+	require.NoError(t, err)
+	assert.Equal(t, tools.ElicitationActionDecline, result.Action, "non-interactive runtime should decline elicitation")
+}
+
+func TestElicitationHandler_Interactive_NoChannel(t *testing.T) {
+	t.Parallel()
+
+	prov := &mockProvider{id: "test/mock-model", stream: newStreamBuilder().AddContent("ok").AddStopWithUsage(1, 1).Build()}
+	root := agent.New("root", "test", agent.WithModel(prov))
+	tm := team.New(team.WithAgents(root))
+
+	// Default runtime (interactive mode) with no events channel set
+	rt, err := NewLocalRuntime(tm)
+	require.NoError(t, err)
+
+	params := &mcp.ElicitParams{
+		Message: "Authorize OAuth?",
+	}
+
+	_, err = rt.elicitationHandler(t.Context(), params)
+
+	require.Error(t, err, "interactive runtime with no events channel should error")
+	assert.ErrorIs(t, err, errNoElicitationChannel)
 }

--- a/pkg/runtime/skill_runner.go
+++ b/pkg/runtime/skill_runner.go
@@ -91,6 +91,7 @@ func (r *LocalRuntime) handleRunSkill(ctx context.Context, sess *session.Session
 			AgentName:           ca,
 			Title:               "Skill: " + prepared.SkillName,
 			ToolsApproved:       sess.ToolsApproved,
+			NonInteractive:      sess.NonInteractive,
 			ExcludedTools:       []string{builtin.ToolNameRunSkill},
 		},
 	})


### PR DESCRIPTION
Covers the missing parts from #2208:

- Add `NonInteractive` field to `SubSessionConfig` and propagate through `RunAgent` (background tasks), `handleTaskTransfer` (transfers), and `handleRunSkill` (skill execution)
- Add `runtime.WithNonInteractive` option to `LocalRuntime` that auto-declines incoming MCP elicitation requests instead of blocking the handler indefinitely
- Wire `runtime.WithNonInteractive(true)` alongside the existing `session.WithNonInteractive(true)` in the MCP server so headless serve mode is fully deadlock-free on elicitation
- Document the relationship between `runtime.WithNonInteractive` and `session.WithNonInteractive` (runtime flag prevents elicitation hangs; session flag drives auto-stop on max iterations — both should be set together for headless operation)
- Cover the new branch with `TestElicitationHandler_NonInteractive` and `TestElicitationHandler_Interactive_NoChannel`