### PR TITLE
feat(mcp-server): add keep-alive support

### DIFF
--- a/cmd/root/mcp.go
+++ b/cmd/root/mcp.go
@@ -34,6 +34,7 @@ func newMCPCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&flags.http, "http", false, "Use streaming HTTP transport instead of stdio")
 	cmd.PersistentFlags().StringVarP(&flags.listenAddr, "listen", "l", "127.0.0.1:8081", "Address to listen on")
 	cmd.PersistentFlags().StringVar(&flags.runConfig.MCPToolName, "tool-name", "", "Override the MCP tool identifier clients call (defaults to agent name); only valid when exposing a single agent")
+	cmd.PersistentFlags().DurationVar(&flags.runConfig.MCPKeepAlive, "mcp-keepalive", 0, "Interval between MCP keep-alive pings (e.g. 30s); 0 disables keep-alive")
 	addRuntimeConfigFlags(cmd, &flags.runConfig)
 
 	return cmd

--- a/docs/features/mcp-mode/index.md
+++ b/docs/features/mcp-mode/index.md
@@ -57,6 +57,7 @@ $ docker agent serve mcp ./agent.yaml --http --listen 0.0.0.0:9090
 | `-l`, `--listen`       | `127.0.0.1:8081`   | Address to listen on when `--http` is enabled.                                                               |
 | `-a`, `--agent`        | all agents         | Expose a single named agent instead of every agent in the config.                                            |
 | `--tool-name`          | (none)             | Override the MCP tool identifier clients call (defaults to agent name); only valid when exposing one agent.  |
+| `--mcp-keepalive`      | `0`                | Interval between MCP keep-alive pings (e.g. `30s`); `0` disables keep-alive.                                 |
 
 Runtime configuration flags such as `--working-dir`, `--env-from-file`, `--models-gateway`, and hook flags are also available — see the [CLI reference]({{ '/features/cli/' | relative_url }}).
 

--- a/pkg/config/runtime.go
+++ b/pkg/config/runtime.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 	"slices"
 	"sync"
+	"time"
 
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/environment"
@@ -35,7 +36,8 @@ type Config struct {
 	HookOnUserInput  []string
 	HookStop         []string
 
-	MCPToolName string
+	MCPToolName  string
+	MCPKeepAlive time.Duration
 }
 
 func (runConfig *RuntimeConfig) Clone() *RuntimeConfig {

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -100,10 +100,13 @@ func createMCPServer(ctx context.Context, agentFilename, agentName string, runCo
 		}
 	}
 
+	// The SDK only starts keep-alive when KeepAlive > 0.
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "docker agent",
 		Version: version.Version,
-	}, nil)
+	}, &mcp.ServerOptions{
+		KeepAlive: runConfig.MCPKeepAlive,
+	})
 
 	agentNames := t.AgentNames()
 	if agentName != "" {


### PR DESCRIPTION
Enables keep-alive support for `serve mcp`. Defaults to `0` to keep the existing behavior and be opt-in.
