### PR TITLE
feat(mcp-server): add `--tool-name` flag to override the MCP tool identifier

### DIFF
--- a/cmd/root/mcp.go
+++ b/cmd/root/mcp.go
@@ -33,6 +33,7 @@ func newMCPCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&flags.agentName, "agent", "a", "", "Name of the agent to run (all agents if not specified)")
 	cmd.PersistentFlags().BoolVar(&flags.http, "http", false, "Use streaming HTTP transport instead of stdio")
 	cmd.PersistentFlags().StringVarP(&flags.listenAddr, "listen", "l", "127.0.0.1:8081", "Address to listen on")
+	cmd.PersistentFlags().StringVar(&flags.runConfig.MCPToolName, "tool-name", "", "Override the MCP tool identifier clients call (defaults to agent name); only valid when exposing a single agent")
 	addRuntimeConfigFlags(cmd, &flags.runConfig)
 
 	return cmd

--- a/docs/features/mcp-mode/index.md
+++ b/docs/features/mcp-mode/index.md
@@ -51,11 +51,12 @@ $ docker agent serve mcp ./agent.yaml --http
 $ docker agent serve mcp ./agent.yaml --http --listen 0.0.0.0:9090
 ```
 
-| Flag                   | Default            | Description                                                                   |
-| ---------------------- | ------------------ | ----------------------------------------------------------------------------- |
-| `--http`               | `false`            | Use streaming HTTP transport instead of stdio.                                |
-| `-l`, `--listen`       | `127.0.0.1:8081`   | Address to listen on when `--http` is enabled.                                |
-| `-a`, `--agent`        | all agents         | Expose a single named agent instead of every agent in the config.             |
+| Flag                   | Default            | Description                                                                                                  |
+| ---------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------ |
+| `--http`               | `false`            | Use streaming HTTP transport instead of stdio.                                                               |
+| `-l`, `--listen`       | `127.0.0.1:8081`   | Address to listen on when `--http` is enabled.                                                               |
+| `-a`, `--agent`        | all agents         | Expose a single named agent instead of every agent in the config.                                            |
+| `--tool-name`          | (none)             | Override the MCP tool identifier clients call (defaults to agent name); only valid when exposing one agent.  |
 
 Runtime configuration flags such as `--working-dir`, `--env-from-file`, `--models-gateway`, and hook flags are also available — see the [CLI reference]({{ '/features/cli/' | relative_url }}).
 

--- a/pkg/config/runtime.go
+++ b/pkg/config/runtime.go
@@ -34,6 +34,8 @@ type Config struct {
 	HookSessionEnd   []string
 	HookOnUserInput  []string
 	HookStop         []string
+
+	MCPToolName string
 }
 
 func (runConfig *RuntimeConfig) Clone() *RuntimeConfig {

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -114,6 +114,11 @@ func createMCPServer(ctx context.Context, agentFilename, agentName string, runCo
 		agentNames = []string{agentName}
 	}
 
+	if runConfig.MCPToolName != "" && len(agentNames) > 1 {
+		cleanup()
+		return nil, nil, errors.New("--tool-name can only be used when exactly one agent is exposed")
+	}
+
 	slog.Debug("Adding MCP tools for agents", "count", len(agentNames))
 
 	for _, agentName := range agentNames {
@@ -136,7 +141,7 @@ func createMCPServer(ctx context.Context, agentFilename, agentName string, runCo
 		annotations.Title = description
 
 		toolDef := &mcp.Tool{
-			Name:         agentName,
+			Name:         cmp.Or(runConfig.MCPToolName, agentName),
 			Description:  description,
 			Annotations:  annotations,
 			InputSchema:  tools.MustSchemaFor[ToolInput](),

--- a/pkg/mcp/server_test.go
+++ b/pkg/mcp/server_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/tools"
 )
 
@@ -115,4 +116,17 @@ func TestAgentToolAnnotations(t *testing.T) {
 			assert.Equal(t, tt.wantOpenWorld, got.OpenWorldHint, "OpenWorldHint")
 		})
 	}
+}
+
+func TestCreateMCPServer_ToolNameRejectsMultipleAgents(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "DUMMY")
+
+	runConfig := &config.RuntimeConfig{}
+	runConfig.MCPToolName = "my-alias"
+
+	_, _, err := createMCPServer(t.Context(), "testdata/multi.yaml", "", runConfig)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--tool-name")
+	assert.Contains(t, err.Error(), "exactly one agent")
 }

--- a/pkg/mcp/testdata/multi.yaml
+++ b/pkg/mcp/testdata/multi.yaml
@@ -1,0 +1,13 @@
+version: "2"
+
+agents:
+  root:
+    model: openai/gpt-3.5-turbo
+    description: Root agent
+    instruction: You are the root agent.
+    sub_agents:
+      - helper
+  helper:
+    model: openai/gpt-3.5-turbo
+    description: Helper agent
+    instruction: You are a helper agent.


### PR DESCRIPTION
Currently, the agent is exposed as a tool called `root`. Most LLMs use a combination of MCP tool name and description to decide when to use the tool, so having a tool named `root` isn't very helpful.