### PR TITLE
feat(hooks): expose `stop` hook via CLI

### DIFF
--- a/cmd/root/flags.go
+++ b/cmd/root/flags.go
@@ -35,6 +35,7 @@ func addRuntimeConfigFlags(cmd *cobra.Command, runConfig *config.RuntimeConfig) 
 	cmd.PersistentFlags().StringArrayVar(&runConfig.HookSessionStart, "hook-session-start", nil, "Add a session-start hook command (repeatable)")
 	cmd.PersistentFlags().StringArrayVar(&runConfig.HookSessionEnd, "hook-session-end", nil, "Add a session-end hook command (repeatable)")
 	cmd.PersistentFlags().StringArrayVar(&runConfig.HookOnUserInput, "hook-on-user-input", nil, "Add an on-user-input hook command (repeatable)")
+	cmd.PersistentFlags().StringArrayVar(&runConfig.HookStop, "hook-stop", nil, "Add a stop hook command, fired when the model finishes responding (repeatable)")
 }
 
 func setupWorkingDirectory(workingDir string) error {

--- a/docs/configuration/hooks/index.md
+++ b/docs/configuration/hooks/index.md
@@ -656,6 +656,7 @@ You can add hooks from the command line without modifying the agent's YAML file.
 | `--hook-session-start`  | Run a command when a session starts     |
 | `--hook-session-end`    | Run a command when a session ends       |
 | `--hook-on-user-input`  | Run a command when waiting for input    |
+| `--hook-stop`           | Run a command when the model finishes responding |
 
 All flags are repeatable — pass multiple to register multiple hooks.
 

--- a/docs/features/a2a/index.md
+++ b/docs/features/a2a/index.md
@@ -47,6 +47,7 @@ $ docker agent serve a2a agentcatalog/pirate
 | `--hook-session-start <cmd>`      | (none)           | Add a session-start hook (repeatable).                                                                               |
 | `--hook-session-end <cmd>`        | (none)           | Add a session-end hook (repeatable).                                                                                 |
 | `--hook-on-user-input <cmd>`      | (none)           | Add an on-user-input hook (repeatable).                                                                              |
+| `--hook-stop <cmd>`               | (none)           | Add a stop hook, fired when the model finishes responding (repeatable).                                              |
 
 ## Features
 

--- a/docs/features/acp/index.md
+++ b/docs/features/acp/index.md
@@ -79,6 +79,7 @@ docker agent serve acp <agent-file>|<registry-ref> [flags]
 | `--hook-session-start <cmd>`      | (none)                 | Add a session-start hook (repeatable).                                                                               |
 | `--hook-session-end <cmd>`        | (none)                 | Add a session-end hook (repeatable).                                                                                 |
 | `--hook-on-user-input <cmd>`      | (none)                 | Add an on-user-input hook (repeatable).                                                                              |
+| `--hook-stop <cmd>`               | (none)                 | Add a stop hook, fired when the model finishes responding (repeatable).                                              |
 
 ## Integration Example
 

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -52,6 +52,7 @@ $ docker agent run [config] [message...] [flags]
 | `--hook-session-start <cmd>`            | Add a session-start hook command (repeatable)                                                                                             |
 | `--hook-session-end <cmd>`              | Add a session-end hook command (repeatable)                                                                                               |
 | `--hook-on-user-input <cmd>`            | Add an on-user-input hook command (repeatable)                                                                                            |
+| `--hook-stop <cmd>`                     | Add a stop hook command, fired when the model finishes responding (repeatable)                                                            |
 | `--fake <path>`                         | Replay AI responses from a cassette file (for testing). Mutually exclusive with `--record`.                                               |
 | `--record [path]`                       | Record AI API interactions to a cassette file (auto-generates filename if no path given)                                                  |
 | `-d, --debug`                           | Enable debug logging                                                                                                                      |

--- a/pkg/config/hooks.go
+++ b/pkg/config/hooks.go
@@ -10,13 +10,14 @@ import (
 // HooksFromCLI builds a HooksConfig from CLI flag values.
 // Each string is treated as a shell command to run.
 // Empty strings are silently skipped.
-func HooksFromCLI(preToolUse, postToolUse, sessionStart, sessionEnd, onUserInput []string) *latest.HooksConfig {
+func HooksFromCLI(preToolUse, postToolUse, sessionStart, sessionEnd, onUserInput, stop []string) *latest.HooksConfig {
 	hooks := &latest.HooksConfig{
 		PreToolUse:   matcherFromCommands(preToolUse),
 		PostToolUse:  matcherFromCommands(postToolUse),
 		SessionStart: defsFromCommands(sessionStart),
 		SessionEnd:   defsFromCommands(sessionEnd),
 		OnUserInput:  defsFromCommands(onUserInput),
+		Stop:         defsFromCommands(stop),
 	}
 
 	if hooks.IsEmpty() {
@@ -86,5 +87,6 @@ func (runConfig *RuntimeConfig) CLIHooks() *latest.HooksConfig {
 		runConfig.HookSessionStart,
 		runConfig.HookSessionEnd,
 		runConfig.HookOnUserInput,
+		runConfig.HookStop,
 	)
 }

--- a/pkg/config/hooks_test.go
+++ b/pkg/config/hooks_test.go
@@ -10,18 +10,18 @@ import (
 )
 
 func TestHooksFromCLI_Empty(t *testing.T) {
-	hooks := HooksFromCLI(nil, nil, nil, nil, nil)
+	hooks := HooksFromCLI(nil, nil, nil, nil, nil, nil)
 	assert.Nil(t, hooks)
 }
 
 func TestHooksFromCLI_SkipsEmptyCommands(t *testing.T) {
 	// All empty/whitespace-only commands should be filtered out
-	hooks := HooksFromCLI([]string{""}, []string{"  "}, []string{""}, []string{"  \t"}, nil)
+	hooks := HooksFromCLI([]string{""}, []string{"  "}, []string{""}, []string{"  \t"}, nil, []string{"  "})
 	assert.Nil(t, hooks)
 }
 
 func TestHooksFromCLI_MixedEmptyAndValid(t *testing.T) {
-	hooks := HooksFromCLI([]string{"", "echo pre", "  "}, nil, []string{"echo start", ""}, nil, nil)
+	hooks := HooksFromCLI([]string{"", "echo pre", "  "}, nil, []string{"echo start", ""}, nil, nil, nil)
 	require.NotNil(t, hooks)
 
 	require.Len(t, hooks.PreToolUse, 1)
@@ -33,7 +33,7 @@ func TestHooksFromCLI_MixedEmptyAndValid(t *testing.T) {
 }
 
 func TestHooksFromCLI_PreToolUse(t *testing.T) {
-	hooks := HooksFromCLI([]string{"echo pre1", "echo pre2"}, nil, nil, nil, nil)
+	hooks := HooksFromCLI([]string{"echo pre1", "echo pre2"}, nil, nil, nil, nil, nil)
 	require.NotNil(t, hooks)
 
 	require.Len(t, hooks.PreToolUse, 1)
@@ -52,6 +52,7 @@ func TestHooksFromCLI_AllTypes(t *testing.T) {
 		[]string{"start-cmd"},
 		[]string{"end-cmd"},
 		[]string{"input-cmd"},
+		[]string{"stop-cmd"},
 	)
 	require.NotNil(t, hooks)
 
@@ -60,12 +61,14 @@ func TestHooksFromCLI_AllTypes(t *testing.T) {
 	assert.Len(t, hooks.SessionStart, 1)
 	assert.Len(t, hooks.SessionEnd, 1)
 	assert.Len(t, hooks.OnUserInput, 1)
+	assert.Len(t, hooks.Stop, 1)
 
 	assert.Equal(t, "pre-cmd", hooks.PreToolUse[0].Hooks[0].Command)
 	assert.Equal(t, "post-cmd", hooks.PostToolUse[0].Hooks[0].Command)
 	assert.Equal(t, "start-cmd", hooks.SessionStart[0].Command)
 	assert.Equal(t, "end-cmd", hooks.SessionEnd[0].Command)
 	assert.Equal(t, "input-cmd", hooks.OnUserInput[0].Command)
+	assert.Equal(t, "stop-cmd", hooks.Stop[0].Command)
 }
 
 func TestMergeHooks_BothNil(t *testing.T) {
@@ -153,6 +156,7 @@ func TestRuntimeConfig_Clone_CopiesHooks(t *testing.T) {
 	rc.HookSessionStart = []string{"start"}
 	rc.HookSessionEnd = []string{"end"}
 	rc.HookOnUserInput = []string{"input"}
+	rc.HookStop = []string{"stop"}
 
 	clone := rc.Clone()
 	assert.Equal(t, rc.HookPreToolUse, clone.HookPreToolUse)
@@ -160,6 +164,7 @@ func TestRuntimeConfig_Clone_CopiesHooks(t *testing.T) {
 	assert.Equal(t, rc.HookSessionStart, clone.HookSessionStart)
 	assert.Equal(t, rc.HookSessionEnd, clone.HookSessionEnd)
 	assert.Equal(t, rc.HookOnUserInput, clone.HookOnUserInput)
+	assert.Equal(t, rc.HookStop, clone.HookStop)
 
 	// Mutating clone should not affect original
 	clone.HookPreToolUse[0] = "changed"

--- a/pkg/config/runtime.go
+++ b/pkg/config/runtime.go
@@ -33,6 +33,7 @@ type Config struct {
 	HookSessionStart []string
 	HookSessionEnd   []string
 	HookOnUserInput  []string
+	HookStop         []string
 }
 
 func (runConfig *RuntimeConfig) Clone() *RuntimeConfig {
@@ -48,6 +49,7 @@ func (runConfig *RuntimeConfig) Clone() *RuntimeConfig {
 	clone.HookSessionStart = slices.Clone(runConfig.HookSessionStart)
 	clone.HookSessionEnd = slices.Clone(runConfig.HookSessionEnd)
 	clone.HookOnUserInput = slices.Clone(runConfig.HookOnUserInput)
+	clone.HookStop = slices.Clone(runConfig.HookStop)
 	return clone
 }
 


### PR DESCRIPTION
We have a case where we need to capture event when model finishes responding. There's already existing `stop` hook for that, but it's not exposed via CLI. 