### PR TITLE
docs: fix outdated CLI references and missing flag tables

### DIFF
--- a/docs/configuration/agents/index.md
+++ b/docs/configuration/agents/index.md
@@ -38,15 +38,30 @@ agents:
       name: "prompt text"
     welcome_message: string # Optional: message shown at session start
     handoffs: [list] # Optional: agent names this agent can hand off to
-    hooks: # Optional: lifecycle hooks
+    hooks: # Optional: lifecycle hooks (see Hooks reference for the full list)
       pre_tool_use: [list]
       tool_response_transform: [list]
       post_tool_use: [list]
+      permission_request: [list]
       session_start: [list]
       session_end: [list]
+      user_prompt_submit: [list]
+      turn_start: [list]
+      turn_end: [list]
+      before_llm_call: [list]
+      after_llm_call: [list]
+      pre_compact: [list]
+      before_compaction: [list]
+      after_compaction: [list]
+      subagent_stop: [list]
       on_user_input: [list]
       stop: [list]
       notification: [list]
+      on_error: [list]
+      on_max_iterations: [list]
+      on_agent_switch: [list]
+      on_session_resume: [list]
+      on_tool_approval_decision: [list]
     structured_output: # Optional: constrain output format
       name: string
       schema: object

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -136,24 +136,48 @@ $ docker agent models --format json | jq
 Start the HTTP API server for programmatic access.
 
 ```bash
-$ docker agent serve api [config] [flags]
+$ docker agent serve api <agent-file>|<agents-dir> [flags]
+```
 
+| Flag               | Default          | Description                                                              |
+| ------------------ | ---------------- | ------------------------------------------------------------------------ |
+| `-l, --listen`     | `127.0.0.1:8080` | Address to listen on                                                     |
+| `-s, --session-db` | `session.db`     | Path to the SQLite session database                                      |
+| `--pull-interval`  | `0` (disabled)   | Auto-pull OCI references every N minutes when serving from the registry |
+| `--fake`           | (none)           | Replay AI responses from a cassette file (testing)                       |
+| `--record`         | (none)           | Record AI API interactions to a cassette file                            |
+
+```bash
 # Examples
 $ docker agent serve api agent.yaml
-$ docker agent serve api agent.yaml --listen :8080
-$ docker agent serve api ociReference --pull-interval 10  # auto-refresh
+$ docker agent serve api ./agents/                          # serve every YAML in a directory
+$ docker agent serve api agent.yaml --listen 0.0.0.0:9090
+$ docker agent serve api agentcatalog/coder --pull-interval 10  # auto-refresh from OCI
 ```
+
+See [API Server]({{ '/features/api-server/' | relative_url }}) for endpoint reference and SSE streaming details.
 
 ### `docker agent serve mcp`
 
 Expose agents as MCP tools for use in Claude Desktop, Claude Code, or other MCP clients.
 
 ```bash
-$ docker agent serve mcp [config] [flags]
+$ docker agent serve mcp <agent-file>|<registry-ref> [flags]
+```
 
+| Flag             | Default            | Description                                                                   |
+| ---------------- | ------------------ | ----------------------------------------------------------------------------- |
+| `--http`         | `false`            | Use streaming HTTP transport instead of stdio                                 |
+| `-l, --listen`   | `127.0.0.1:8081`   | Address to listen on (when `--http` is enabled)                               |
+| `-a, --agent`    | (all agents)       | Expose only the named agent instead of every agent in the config              |
+
+Runtime configuration flags such as `--working-dir`, `--env-from-file`, `--models-gateway`, and the `--hook-*` flags are also available.
+
+```bash
 # Examples
-$ docker agent serve mcp agent.yaml
+$ docker agent serve mcp agent.yaml                                   # stdio transport
 $ docker agent serve mcp agent.yaml --working-dir /path/to/project
+$ docker agent serve mcp agent.yaml --http --listen 0.0.0.0:9090       # streaming HTTP
 $ docker agent serve mcp agentcatalog/coder
 ```
 
@@ -164,22 +188,39 @@ See [MCP Mode]({{ '/features/mcp-mode/' | relative_url }}) for detailed setup.
 Start an A2A (Agent-to-Agent) protocol server.
 
 ```bash
-$ docker agent serve a2a [config] [flags]
+$ docker agent serve a2a <agent-file>|<registry-ref> [flags]
+```
 
+| Flag           | Default          | Description                                                            |
+| -------------- | ---------------- | ---------------------------------------------------------------------- |
+| `-l, --listen` | `127.0.0.1:8082` | Address to listen on                                                   |
+| `-a, --agent`  | (all agents)     | Expose only the named agent instead of every agent in the config       |
+
+```bash
 # Examples
 $ docker agent serve a2a agent.yaml
 $ docker agent serve a2a agent.yaml --listen 127.0.0.1:9000
+$ docker agent serve a2a ./team.yaml --agent reviewer
 ```
+
+See [A2A Protocol]({{ '/features/a2a/' | relative_url }}) for the protocol reference.
 
 ### `docker agent serve acp`
 
 Start an ACP (Agent Client Protocol) server over stdio. This allows external clients to interact with your agents using the ACP protocol.
 
 ```bash
-$ docker agent serve acp [config] [flags]
+$ docker agent serve acp <agent-file>|<registry-ref> [flags]
+```
 
+| Flag               | Default                  | Description                                  |
+| ------------------ | ------------------------ | -------------------------------------------- |
+| `-s, --session-db` | `~/.cagent/session.db`   | Path to the SQLite session database          |
+
+```bash
 # Examples
 $ docker agent serve acp agent.yaml
+$ docker agent serve acp agent.yaml --session-db ./sessions.db
 ```
 
 See [ACP]({{ '/features/acp/' | relative_url }}) for details on the Agent Client Protocol.
@@ -189,7 +230,7 @@ See [ACP]({{ '/features/acp/' | relative_url }}) for details on the Agent Client
 Start an HTTP server that exposes one or more agents through an **OpenAI-compatible Chat Completions API** at `/v1/chat/completions` and `/v1/models`. This lets any tool that already speaks the OpenAI protocol — for example [Open WebUI](https://github.com/open-webui/open-webui), `curl`, the OpenAI Python SDK, or LangChain — drive a docker-agent agent without any custom integration.
 
 ```bash
-$ docker agent serve chat [config] [flags]
+$ docker agent serve chat <agent-file>|<registry-ref> [flags]
 ```
 
 | Flag                          | Default            | Description                                                                                                       |
@@ -234,17 +275,34 @@ See [Agent Distribution]({{ '/concepts/distribution/' | relative_url }}) for ful
 
 ### `docker agent eval`
 
-Run agent evaluations.
+Run agent evaluations against a directory of recorded eval sessions.
 
 ```bash
-$ docker agent eval eval-config.yaml
+$ docker agent eval <agent-file>|<registry-ref> [<eval-dir>|./evals] [flags]
+```
 
-# With flags
-$ docker agent eval agent.yaml ./evals -c 8              # 8 concurrent evaluations
+| Flag                | Default                                | Description                                                                |
+| ------------------- | -------------------------------------- | -------------------------------------------------------------------------- |
+| `-c, --concurrency` | num CPUs                               | Number of concurrent evaluation runs                                       |
+| `--judge-model`     | `anthropic/claude-opus-4-5-20251101`   | Model used for LLM-as-a-judge relevance scoring                            |
+| `--output`          | `<eval-dir>/results`                   | Directory for results, logs, and session databases                         |
+| `--only`            | (all)                                  | Only run evaluations whose file names match these patterns (repeatable)    |
+| `--base-image`      | (default)                              | Custom base Docker image for evaluation containers                         |
+| `--keep-containers` | `false`                                | Keep containers after evaluation (skip `--rm`) for debugging               |
+| `-e, --env`         | (none)                                 | Environment variables to pass to containers (`KEY` or `KEY=VALUE`)         |
+| `--repeat`          | `1`                                    | Number of times to repeat each evaluation (useful for computing baselines) |
+
+```bash
+# Examples
+$ docker agent eval agent.yaml                           # default ./evals dir
+$ docker agent eval agent.yaml ./my-evals
+$ docker agent eval agent.yaml -c 8                      # 8 concurrent evaluations
 $ docker agent eval agent.yaml --keep-containers         # Keep containers for debugging
 $ docker agent eval agent.yaml --only "auth*"            # Only run matching evals
 $ docker agent eval agent.yaml --repeat 5                # Repeat each eval 5 times
 ```
+
+See [Evaluation]({{ '/features/evaluation/' | relative_url }}) for the eval session format and scoring metrics.
 
 ### `docker agent version`
 

--- a/docs/features/evaluation/index.md
+++ b/docs/features/evaluation/index.md
@@ -129,7 +129,7 @@ The `evals` object inside each session controls what gets scored:
 
 ## Scoring Metrics
 
-docker-agent evaluates agents across four dimensions:
+docker-agent evaluates agents across three dimensions:
 
 | Metric              | How It's Measured                                                                                                         |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/providers/openai/index.md
+++ b/docs/providers/openai/index.md
@@ -45,7 +45,7 @@ models:
 | `gpt-4o`      | Multimodal, balanced performance     |
 | `gpt-4o-mini` | Cheapest, fast for simple tasks      |
 
-Find more model names at [modelname.ai](https://modelname.ai/).
+Run `docker agent models --provider openai` to list the models the catalog currently knows about, or browse the OpenAI [model docs](https://platform.openai.com/docs/models) for the full catalog. The community-maintained [models.dev](https://models.dev/) is also a useful cross-provider reference.
 
 ## Thinking Budget
 
@@ -101,7 +101,7 @@ models:
 ### Requirements
 
 - Only works with Responses API models: `gpt-4.1+`, `o1`, `o3`, `o4`, `gpt-5`
-- NOT compatible with `--gateway` flag (automatically falls back to SSE)
+- NOT compatible with `--models-gateway` flag (automatically falls back to SSE)
 - Requires `OPENAI_API_KEY` environment variable
 
 ### Example


### PR DESCRIPTION
## What

Audit pass over the user-facing docs against the current source, fixing things that are outright wrong and filling in flag tables that were silently missing.

### Fixes

- **`features/cli/index.md`** – Replace `[config]` placeholders for `serve api`, `serve mcp`, `serve a2a`, `serve acp`, `serve chat` with the required `<agent-file>|<registry-ref>` (these commands require the argument; `[config]` incorrectly suggested otherwise). Add proper flag tables (with defaults pulled from the source) for `serve api`, `serve mcp`, `serve a2a`, `serve acp`, and `eval`.
- **`features/cli/index.md`** – `docker agent eval eval-config.yaml` was wrong: the command takes an agent file (and an optional eval-dir), not an eval-config.yaml. Updated the usage line and added the missing flags (`--judge-model`, `--output`, `--base-image`, `-e/--env`).
- **`providers/openai/index.md`** – `--gateway` → `--models-gateway` (the real flag name in `cmd/root/flags.go`). Replaced the `modelname.ai` link with `docker agent models --provider openai`, plus pointers to OpenAI's official model catalog and `models.dev`.
- **`configuration/agents/index.md`** – The `hooks:` block in the schema reference only listed the original 8 events; bring it in line with the full event list documented in `configuration/hooks/index.md` (and the `HooksConfig` struct in `pkg/config/latest`): `permission_request`, `user_prompt_submit`, `turn_start`, `turn_end`, `before_llm_call`, `after_llm_call`, `pre_compact`, `before_compaction`, `after_compaction`, `subagent_stop`, `on_error`, `on_max_iterations`, `on_agent_switch`, `on_session_resume`, `on_tool_approval_decision`.
- **`features/evaluation/index.md`** – \"four dimensions\" → \"three dimensions\" so the prose matches the three-row metrics table that follows.

### How I checked

- Cross-referenced flag names, defaults, and argument arity against `cmd/root/{run,api,mcp,a2a,acp,chat,eval}.go` and `cmd/root/flags.go`.
- Cross-referenced the hooks list against `pkg/config/latest/types.go` (`HooksConfig`) and `docs/configuration/hooks/index.md`.
- No source code changes; docs only.