### PR TITLE
docs: fill in missing CLI flags and fix outdated content

### DIFF
--- a/docs/community/troubleshooting/index.md
+++ b/docs/community/troubleshooting/index.md
@@ -188,12 +188,13 @@ For remote MCP servers, verify the endpoint is reachable:
 $ curl -v https://mcp-server.example.com/sse
 ```
 
-### Multi-tenant isolation
+### Session isolation
 
-In API server mode, each client gets isolated sessions. If sessions are mixing up:
+The API server stores every conversation as a distinct session in the SQLite database (`session.db` by default). Each session is identified by its UUID and only mixes messages when the same session ID is reused. If conversations seem to bleed into each other:
 
-- Verify client IDs are unique per connection
-- Check session timeouts and cleanup in debug logs
+- Make sure each client creates a fresh session via `POST /api/sessions` (don't reuse session IDs across users).
+- Confirm `--session-db` points to the path you expect — a stale database from another run can resurface old sessions.
+- Use `GET /api/sessions/:id` to inspect what is actually stored, and `DELETE /api/sessions/:id` to clear sessions you don't want anymore.
 
 ## Performance Issues
 

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -54,6 +54,7 @@ $ docker agent run [config] [message...] [flags]
 | `--hook-on-user-input <cmd>`            | Add an on-user-input hook command (repeatable)                                                                                            |
 | `--hook-stop <cmd>`                     | Add a stop hook command, fired when the model finishes responding (repeatable)                                                            |
 | `--fake <path>`                         | Replay AI responses from a cassette file (for testing). Mutually exclusive with `--record`.                                               |
+| `--fake-stream [ms]`                    | When replaying with `--fake`, simulate streaming with a delay between chunks (defaults to 15ms when given without a value).               |
 | `--record [path]`                       | Record AI API interactions to a cassette file (auto-generates filename if no path given)                                                  |
 | `-d, --debug`                           | Enable debug logging                                                                                                                      |
 | `--log-file <path>`                     | Custom debug log location                                                                                                                 |
@@ -133,26 +134,52 @@ $ docker agent models --format json | jq
 
 ### `docker agent serve api`
 
-Start the HTTP API server for programmatic access.
+Start the HTTP API server for programmatic access. The argument can be a single agent file, a registry reference, or a directory — when given a directory, every `.yaml`/`.yml`/`.hcl` file in it is exposed as a separate entry under `/api/agents`.
 
 ```bash
-$ docker agent serve api [config] [flags]
+$ docker agent serve api <agent-file>|<agents-dir>|<registry-ref> [flags]
+```
 
+| Flag                       | Default            | Description                                                                                                |
+| -------------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------- |
+| `-l, --listen <addr>`      | `127.0.0.1:8080`   | Address to listen on.                                                                                      |
+| `-s, --session-db <path>`  | `session.db`       | Path to the SQLite session database (relative paths resolve against the working directory).                |
+| `--pull-interval <minutes>`| `0`                | Periodically re-pull OCI/URL references and refresh the agent definition. `0` disables auto-pull.          |
+| `--fake <path>`             | (none)             | Replay AI responses from a cassette file (for testing). Mutually exclusive with `--record`.               |
+| `--record [path]`           | (none)             | Record AI API interactions to a cassette file.                                                            |
+
+All [runtime configuration flags](#runtime-configuration-flags) (`--working-dir`, `--env-from-file`, `--models-gateway`, `--hook-*`, …) are also accepted.
+
+```bash
 # Examples
 $ docker agent serve api agent.yaml
 $ docker agent serve api agent.yaml --listen :8080
-$ docker agent serve api ociReference --pull-interval 10  # auto-refresh
+$ docker agent serve api ./agents/                          # directory of agent YAMLs
+$ docker agent serve api ociReference --pull-interval 10    # auto-refresh
 ```
+
+See [API Server]({{ '/features/api-server/' | relative_url }}) for the full HTTP API reference.
 
 ### `docker agent serve mcp`
 
-Expose agents as MCP tools for use in Claude Desktop, Claude Code, or other MCP clients.
+Expose agents as MCP tools for use in Claude Desktop, Claude Code, or other MCP clients. Defaults to stdio transport; use `--http` to start a streaming HTTP server instead.
 
 ```bash
-$ docker agent serve mcp [config] [flags]
+$ docker agent serve mcp <config> [flags]
+```
 
+| Flag                   | Default            | Description                                                                                       |
+| ---------------------- | ------------------ | ------------------------------------------------------------------------------------------------- |
+| `-a, --agent <name>`   | (all agents)       | Name of the agent to expose. If omitted, every agent in the config is exposed as a separate tool. |
+| `--http`               | `false`            | Use streaming HTTP transport instead of stdio.                                                    |
+| `-l, --listen <addr>`  | `127.0.0.1:8081`   | Address to listen on (only used with `--http`).                                                   |
+
+All [runtime configuration flags](#runtime-configuration-flags) are also accepted.
+
+```bash
 # Examples
-$ docker agent serve mcp agent.yaml
+$ docker agent serve mcp agent.yaml                                # stdio transport
+$ docker agent serve mcp agent.yaml --http --listen 127.0.0.1:9090 # streaming HTTP
 $ docker agent serve mcp agent.yaml --working-dir /path/to/project
 $ docker agent serve mcp agentcatalog/coder
 ```
@@ -164,11 +191,21 @@ See [MCP Mode]({{ '/features/mcp-mode/' | relative_url }}) for detailed setup.
 Start an A2A (Agent-to-Agent) protocol server.
 
 ```bash
-$ docker agent serve a2a [config] [flags]
+$ docker agent serve a2a <config> [flags]
+```
 
+| Flag                   | Default            | Description                                                                                |
+| ---------------------- | ------------------ | ------------------------------------------------------------------------------------------ |
+| `-a, --agent <name>`   | (team default)     | Name of the agent to run. Defaults to the team's first agent if not specified.             |
+| `-l, --listen <addr>`  | `127.0.0.1:8082`   | Address to listen on.                                                                       |
+
+All [runtime configuration flags](#runtime-configuration-flags) are also accepted.
+
+```bash
 # Examples
 $ docker agent serve a2a agent.yaml
 $ docker agent serve a2a agent.yaml --listen 127.0.0.1:9000
+$ docker agent serve a2a agentcatalog/pirate
 ```
 
 ### `docker agent serve acp`
@@ -176,10 +213,20 @@ $ docker agent serve a2a agent.yaml --listen 127.0.0.1:9000
 Start an ACP (Agent Client Protocol) server over stdio. This allows external clients to interact with your agents using the ACP protocol.
 
 ```bash
-$ docker agent serve acp [config] [flags]
+$ docker agent serve acp <config> [flags]
+```
 
+| Flag                      | Default                     | Description                                       |
+| ------------------------- | --------------------------- | ------------------------------------------------- |
+| `-s, --session-db <path>` | `~/.cagent/session.db`      | Path to the SQLite session database.              |
+
+All [runtime configuration flags](#runtime-configuration-flags) are also accepted.
+
+```bash
 # Examples
 $ docker agent serve acp agent.yaml
+$ docker agent serve acp ./team.yaml
+$ docker agent serve acp agentcatalog/pirate
 ```
 
 See [ACP]({{ '/features/acp/' | relative_url }}) for details on the Agent Client Protocol.
@@ -189,7 +236,7 @@ See [ACP]({{ '/features/acp/' | relative_url }}) for details on the Agent Client
 Start an HTTP server that exposes one or more agents through an **OpenAI-compatible Chat Completions API** at `/v1/chat/completions` and `/v1/models`. This lets any tool that already speaks the OpenAI protocol — for example [Open WebUI](https://github.com/open-webui/open-webui), `curl`, the OpenAI Python SDK, or LangChain — drive a docker-agent agent without any custom integration.
 
 ```bash
-$ docker agent serve chat [config] [flags]
+$ docker agent serve chat <config> [flags]
 ```
 
 | Flag                          | Default            | Description                                                                                                       |
@@ -228,23 +275,49 @@ $ docker agent share push ./agent.yaml docker.io/username/my-agent:latest
 
 # Pull an agent
 $ docker agent share pull docker.io/username/my-agent:latest
+
+# Force pull, overwriting the local copy
+$ docker agent share pull docker.io/username/my-agent:latest --force
 ```
+
+| Flag       | Applies to | Description                                                |
+| ---------- | ---------- | ---------------------------------------------------------- |
+| `--force`  | `pull`     | Force pull even if the configuration already exists locally |
 
 See [Agent Distribution]({{ '/concepts/distribution/' | relative_url }}) for full registry workflow details.
 
 ### `docker agent eval`
 
-Run agent evaluations.
+Run agent evaluations against a directory of recorded sessions.
 
 ```bash
-$ docker agent eval eval-config.yaml
-
-# With flags
-$ docker agent eval agent.yaml ./evals -c 8              # 8 concurrent evaluations
-$ docker agent eval agent.yaml --keep-containers         # Keep containers for debugging
-$ docker agent eval agent.yaml --only "auth*"            # Only run matching evals
-$ docker agent eval agent.yaml --repeat 5                # Repeat each eval 5 times
+$ docker agent eval <agent-file>|<registry-ref> [<eval-dir>|./evals] [flags]
 ```
+
+| Flag                | Default                              | Description                                                                |
+| ------------------- | ------------------------------------ | -------------------------------------------------------------------------- |
+| `-c, --concurrency` | num CPUs                             | Number of concurrent evaluation runs                                       |
+| `--judge-model`     | `anthropic/claude-opus-4-5-20251101` | Model for LLM-as-a-judge relevance scoring (format: `provider/model`)      |
+| `--output <dir>`    | `<eval-dir>/results`                 | Directory for results, logs, and session databases                         |
+| `--only <pattern>`  | (all)                                | Only run evals with file names matching these patterns (repeatable)        |
+| `--base-image`      | (default)                            | Custom base Docker image for eval containers                               |
+| `--keep-containers` | `false`                              | Keep containers after evaluation (don't remove with `--rm`)                |
+| `-e, --env`         | (none)                               | Environment variables to pass to container (`KEY` or `KEY=VALUE`, repeatable) |
+| `--repeat <n>`      | `1`                                  | Number of times to repeat each evaluation (useful for computing baselines) |
+
+All [runtime configuration flags](#runtime-configuration-flags) are also accepted.
+
+```bash
+# Examples
+$ docker agent eval agent.yaml                            # use ./evals
+$ docker agent eval agent.yaml ./my-evals                 # custom directory
+$ docker agent eval agent.yaml -c 8                       # 8 concurrent evaluations
+$ docker agent eval agent.yaml --keep-containers          # keep containers for debugging
+$ docker agent eval agent.yaml --only "auth*"             # only run matching evals
+$ docker agent eval agent.yaml --repeat 5                 # repeat each eval 5 times
+```
+
+See [Evaluation]({{ '/features/evaluation/' | relative_url }}) for details on creating eval sessions and interpreting results.
 
 ### `docker agent version`
 
@@ -326,6 +399,23 @@ These flags are available on every `docker agent` command:
 | `--config-dir <path>`     | Override the config directory (default: `~/.config/cagent`)                            |
 | `--data-dir <path>`       | Override the data directory (default: `~/.cagent`)                                     |
 | `--help`                  | Show help for any command                                                              |
+
+## Runtime Configuration Flags
+
+These flags are accepted by every command that loads an agent (`run`, `run --exec`, `new`, `eval`, `serve api`, `serve mcp`, `serve a2a`, `serve acp`, `serve chat`). They are listed once here to avoid repetition in the per-command tables above.
+
+| Flag                            | Description                                                                                                              |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `--working-dir <path>`          | Set the working directory for the session (applies to tools and relative paths).                                         |
+| `--env-from-file <path>`        | Load environment variables from file (repeatable).                                                                       |
+| `--code-mode-tools`             | Provide a single tool to call other tools via JavaScript (forces code-mode tools globally).                              |
+| `--models-gateway <addr>`       | Route model traffic through a gateway. Reads `DOCKER_AGENT_MODELS_GATEWAY` (legacy `CAGENT_MODELS_GATEWAY`) env var.      |
+| `--hook-pre-tool-use <cmd>`     | Add a pre-tool-use hook command (repeatable). See [Hooks]({{ '/configuration/hooks/' | relative_url }}).                 |
+| `--hook-post-tool-use <cmd>`    | Add a post-tool-use hook command (repeatable).                                                                           |
+| `--hook-session-start <cmd>`    | Add a session-start hook command (repeatable).                                                                           |
+| `--hook-session-end <cmd>`      | Add a session-end hook command (repeatable).                                                                             |
+| `--hook-on-user-input <cmd>`    | Add an on-user-input hook command (repeatable).                                                                          |
+| `--hook-stop <cmd>`             | Add a stop hook command, fired when the model finishes responding (repeatable).                                          |
 
 ## Agent References
 

--- a/docs/features/evaluation/index.md
+++ b/docs/features/evaluation/index.md
@@ -129,7 +129,7 @@ The `evals` object inside each session controls what gets scored:
 
 ## Scoring Metrics
 
-docker-agent evaluates agents across four dimensions:
+docker-agent evaluates agents across three dimensions:
 
 | Metric              | How It's Measured                                                                                                         |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------- |
@@ -195,10 +195,11 @@ $ docker agent eval demo.yaml ./evals
   ✓ Checking the Content of README.md File
     ✓ tool calls  ✓ relevance 1/1
 
-Summary: 2/2 passed
-  Sizes:      0/0
-  Tool Calls: avg F1 1.00 (2 evals)
-  Relevance:  3/3
+✅     Tool Calls: 100.0% avg F1 (2 evals)
+✅      Relevance: 3/3 passed (100.0%)
+
+Total Cost: $0.012345
+Total Time: 12s
 
 Sessions DB: ./evals/results/happy-panda-1234.db
 Sessions JSON: ./evals/results/happy-panda-1234-sessions.json

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -51,6 +51,7 @@ Type `/` during a session to see available commands, or press <kbd>Ctrl</kbd>+<k
 | `/star`            | Star/unstar the current session                                                      |
 | `/cost`            | Show cost breakdown for this session                                                 |
 | `/eval`            | Create an evaluation report                                                          |
+| `/pause`           | Pause/resume the runtime loop after the current request                              |
 | `/tools`           | Show every toolset (with lifecycle state) and the tools they expose                  |
 | `/toolset-restart` | Force a supervisor-driven reconnect of the named toolset (`/toolset-restart <name>`) |
 | `/permissions`     | Inspect and edit tool permission rules                                               |


### PR DESCRIPTION
Several documentation pages had drifted from what the code actually does. This PR catches them up.

## What was wrong / missing

### `docs/features/cli/index.md`

- `docker agent serve api`, `serve mcp`, `serve a2a`, and `serve acp` had a one-line description and an examples block, but **no flags tables**. The defaults (`127.0.0.1:8080` / `8081` / `8082`, `session.db`, `--http`, `--pull-interval`, …) were only documented in scattered prose, if at all.
- `docker agent share pull` supports `--force`, but the CLI ref didn't mention it.
- `docker agent eval` had a single inline example block; the actual flags (`--judge-model`, `--output`, `--base-image`, `-e/--env`, `--keep-containers`, …) were not listed.
- `docker agent run` table was missing `--fake-stream`.
- The text referenced a `--gateway` runtime flag that doesn't exist — only `--models-gateway` is real.
- The runtime config flags (`--working-dir`, `--env-from-file`, `--code-mode-tools`, `--models-gateway`, `--hook-*`) are accepted by **every** command that loads an agent (`run`, `new`, `eval`, `serve api/mcp/a2a/acp/chat`), but the doc only showed them under `run`. Added a shared **Runtime Configuration Flags** section and linked to it from each subcommand instead of repeating the table.

### `docs/features/evaluation/index.md`

- Said agents are evaluated across **\"four dimensions\"** but the table listed three. The scoring code (`pkg/evaluation/scoring.go`) confirms there are exactly three: Tool Calls (F1), Relevance, Size. Fixed the wording to \"three dimensions\".
- The example output was the legacy \`Summary: 2/2 passed\` format. The current `printSummary` emits per-metric lines with status icons and the trailing \`Total Cost\` / \`Total Time\` block. Refreshed the example to match.

### `docs/features/tui/index.md`

- The `/pause` slash command (registered in `pkg/tui/commands/commands.go`) was missing from the slash-commands table.

### `docs/community/troubleshooting/index.md`

- The \"Multi-tenant isolation\" section claimed every API client gets a \"client ID\" that needs to be unique. **There is no such concept** — sessions are identified by a UUID returned from `POST /api/sessions`, and there is no per-client/per-connection identifier. Rewrote the section as \"Session isolation\" with accurate guidance (use fresh sessions, check `--session-db`, use `GET`/`DELETE /api/sessions/:id` to inspect or clear).

## Verification

All flag names, defaults, and command syntax in the new tables are taken from `cmd/root/{api,mcp,a2a,acp,chat,run,eval,push,pull,flags}.go`. The evaluation output sample is consistent with `pkg/evaluation/scoring.go`.