### PR TITLE
tui: don't let user_prompt freeze the rest of the UI

### DIFF
--- a/pkg/tui/dialog/dialog.go
+++ b/pkg/tui/dialog/dialog.go
@@ -32,6 +32,12 @@ type Manager interface {
 	GetLayers() []*lipgloss.Layer
 	Open() bool
 	TopIsExitConfirmation() bool
+	// ContainsPoint reports whether the point (x, y) in screen coordinates
+	// falls within the bounds of any dialog currently in the stack. This is
+	// used by the top-level mouse handler to let events that target the
+	// chrome (chat content, tab bar) fall through to the underlying region
+	// instead of being absorbed by an open dialog (see #2626).
+	ContainsPoint(x, y int) bool
 }
 
 // dialogEntry pairs a dialog with its drag offset so the two stay in sync.
@@ -280,6 +286,23 @@ func (d *manager) TopIsExitConfirmation() bool {
 	}
 	_, ok := d.stack[len(d.stack)-1].dialog.(*exitConfirmationDialog)
 	return ok
+}
+
+// ContainsPoint reports whether (x, y) in screen coordinates falls within the
+// rendered bounds of any dialog currently on the stack.
+func (d *manager) ContainsPoint(x, y int) bool {
+	for _, e := range d.stack {
+		view := e.dialog.View()
+		row, col := e.dialog.Position()
+		col += e.offsetX
+		row += e.offsetY
+		w := lipgloss.Width(view)
+		h := lipgloss.Height(view)
+		if x >= col && x < col+w && y >= row && y < row+h {
+			return true
+		}
+	}
+	return false
 }
 
 func (d *manager) SetSize(width, height int) tea.Cmd {

--- a/pkg/tui/dialog/dialog_test.go
+++ b/pkg/tui/dialog/dialog_test.go
@@ -1,0 +1,93 @@
+package dialog
+
+import (
+	"fmt"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestContainsPoint_NoDialog verifies the manager reports no point as
+// contained when the stack is empty.
+func TestContainsPoint_NoDialog(t *testing.T) {
+	t.Parallel()
+
+	mgr := New()
+	assert.False(t, mgr.ContainsPoint(0, 0))
+	assert.False(t, mgr.ContainsPoint(50, 50))
+}
+
+// TestContainsPoint_WithDialog verifies the manager correctly reports points
+// inside and outside an open dialog. The help dialog uses the screen size to
+// compute its dimensions, so we feed in a known WindowSizeMsg first.
+func TestContainsPoint_WithDialog(t *testing.T) {
+	t.Parallel()
+
+	mgr := New()
+
+	// Initialize size and open a help dialog (a stable, simple dialog).
+	updated, _ := mgr.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	mgr = updated.(Manager)
+	updated, _ = mgr.Update(OpenDialogMsg{Model: NewHelpDialog(nil)})
+	mgr = updated.(Manager)
+
+	require.True(t, mgr.Open(), "dialog should be open")
+
+	// Compute the actual rendered bounds of the dialog to make the test
+	// independent of styling tweaks.
+	layers := mgr.GetLayers()
+	require.Len(t, layers, 1, "expected exactly one dialog layer")
+	view := mgr.View()
+	dialogW := lipgloss.Width(view)
+	dialogH := lipgloss.Height(view)
+	col := layers[0].GetX()
+	row := layers[0].GetY()
+	require.Positive(t, dialogW, "dialog should have non-zero width")
+	require.Positive(t, dialogH, "dialog should have non-zero height")
+
+	debug := fmt.Sprintf("dialog at row=%d col=%d size=%dx%d", row, col, dialogW, dialogH)
+
+	// Negative coordinates always fall outside.
+	assert.False(t, mgr.ContainsPoint(-1, -1), debug)
+
+	// (0,0) sits in the screen corner — well outside the centred dialog.
+	assert.False(t, mgr.ContainsPoint(0, 0), debug)
+
+	// Point inside the dialog (its top-left corner).
+	assert.True(t, mgr.ContainsPoint(col, row), debug)
+
+	// Point at the dialog's last cell.
+	assert.True(t, mgr.ContainsPoint(col+dialogW-1, row+dialogH-1), debug)
+
+	// One column past the dialog's right edge falls outside.
+	assert.False(t, mgr.ContainsPoint(col+dialogW, row), debug)
+}
+
+// TestContainsPoint_AfterClose verifies that closing the dialog removes it
+// from hit-testing.
+func TestContainsPoint_AfterClose(t *testing.T) {
+	t.Parallel()
+
+	mgr := New()
+	updated, _ := mgr.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	mgr = updated.(Manager)
+	updated, _ = mgr.Update(OpenDialogMsg{Model: NewHelpDialog(nil)})
+	mgr = updated.(Manager)
+
+	layers := mgr.GetLayers()
+	require.Len(t, layers, 1)
+	view := mgr.View()
+	col := layers[0].GetX()
+	row := layers[0].GetY()
+	require.True(t, mgr.ContainsPoint(col, row), "sanity: point inside the dialog should match before close")
+	_ = lipgloss.Width(view)
+
+	updated, _ = mgr.Update(CloseDialogMsg{})
+	mgr = updated.(Manager)
+	assert.False(t, mgr.Open())
+	assert.False(t, mgr.ContainsPoint(col, row),
+		"after closing, no point should be reported as contained")
+}

--- a/pkg/tui/dispatch.go
+++ b/pkg/tui/dispatch.go
@@ -38,11 +38,42 @@ func (m *appModel) updateEditorCmd(msg tea.Msg) tea.Cmd {
 	return cmd
 }
 
-// updateDialogCmd forwards a message to the dialog manager and returns its cmd.
+// updateDialogCmd forwards a message to the active session's dialog manager
+// and returns its cmd. Each tab has its own dialog stack (see #2626) so the
+// helper also keeps dialogMgrs in sync with the active alias.
 func (m *appModel) updateDialogCmd(msg tea.Msg) tea.Cmd {
 	updated, cmd := m.dialogMgr.Update(msg)
 	m.dialogMgr = updated.(dialog.Manager)
+	if m.dialogMgrs != nil && m.supervisor != nil {
+		m.dialogMgrs[m.supervisor.ActiveID()] = m.dialogMgr
+	}
 	return cmd
+}
+
+// updateAllDialogsCmd forwards a message to every per-tab dialog manager and
+// batches the resulting commands. Used for global state updates that need to
+// apply to every dialog stack — e.g. WindowSizeMsg and ThemeChangedMsg.
+func (m *appModel) updateAllDialogsCmd(msg tea.Msg) tea.Cmd {
+	if len(m.dialogMgrs) == 0 {
+		return m.updateDialogCmd(msg)
+	}
+	activeID := ""
+	if m.supervisor != nil {
+		activeID = m.supervisor.ActiveID()
+	}
+	var cmds []tea.Cmd
+	for id, mgr := range m.dialogMgrs {
+		updated, cmd := mgr.Update(msg)
+		newMgr := updated.(dialog.Manager)
+		m.dialogMgrs[id] = newMgr
+		if id == activeID {
+			m.dialogMgr = newMgr
+		}
+		if cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	}
+	return tea.Batch(cmds...)
 }
 
 // updateCompletionsCmd forwards a message to the completion manager and

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -79,7 +79,7 @@ func (m *appModel) handleBranchFromEdit(msg messages.BranchFromEditMsg) (tea.Mod
 	// Replace the session in the app and rebuild all per-session components.
 	m.application.ReplaceSession(ctx, newSess)
 	m.initSessionComponents(activeID, m.application, newSess)
-	m.dialogMgr = dialog.New()
+	m.resetActiveDialogMgr()
 
 	// Restore sidebar settings
 	m.chatPage.SetSidebarSettings(sidebarSettings)
@@ -548,7 +548,7 @@ func (m *appModel) invalidateCachesForThemeChange() {
 func (m *appModel) applyThemeChanged() (tea.Model, tea.Cmd) {
 	m.invalidateCachesForThemeChange()
 	return m, tea.Batch(
-		m.updateDialogCmd(messages.ThemeChangedMsg{}),
+		m.updateAllDialogsCmd(messages.ThemeChangedMsg{}),
 		m.updateChatCmd(messages.ThemeChangedMsg{}),
 	)
 }

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -74,6 +74,12 @@ type appModel struct {
 	// Per-session editors (preserved across tab switches for draft text)
 	editors map[string]editor.Editor
 
+	// Per-session dialog stacks. Dialogs (elicitation, tool confirmation,
+	// theme picker, …) are scoped to the tab from which they originated, so
+	// switching tabs naturally hides any open dialog without losing its
+	// state. See #2626.
+	dialogMgrs map[string]dialog.Manager
+
 	// Active session (convenience pointers to the currently visible session)
 	application  *app.App
 	sessionState *service.SessionState
@@ -85,7 +91,7 @@ type appModel struct {
 
 	// UI components
 	notification notification.Manager
-	dialogMgr    dialog.Manager
+	dialogMgr    dialog.Manager // active session's dialog stack (alias into dialogMgrs)
 	statusBar    statusbar.StatusBar
 	completions  completion.Manager
 
@@ -262,6 +268,8 @@ func New(ctx context.Context, spawner SessionSpawner, initialApp *app.App, initi
 	initialSessionState := service.NewSessionState(initialApp.Session())
 	sessID := initialApp.Session().ID
 
+	initialDialogMgr := dialog.New()
+
 	m := &appModel{
 		buildCommandCategories: func(ctx context.Context, _ tea.Model) []commands.Category {
 			return commands.BuildCommandCategories(ctx, initialApp)
@@ -271,6 +279,7 @@ func New(ctx context.Context, spawner SessionSpawner, initialApp *app.App, initi
 		tuiStore:                ts,
 		chatPages:               map[string]chat.Page{},
 		editors:                 map[string]editor.Editor{},
+		dialogMgrs:              map[string]dialog.Manager{sessID: initialDialogMgr},
 		sessionStates:           map[string]*service.SessionState{sessID: initialSessionState},
 		application:             initialApp,
 		sessionState:            initialSessionState,
@@ -278,7 +287,7 @@ func New(ctx context.Context, spawner SessionSpawner, initialApp *app.App, initi
 		pendingRestores:         make(map[string]string),
 		pendingSidebarCollapsed: make(map[string]bool),
 		notification:            notification.New(),
-		dialogMgr:               dialog.New(),
+		dialogMgr:               initialDialogMgr,
 		completions:             completion.New(),
 		transcriber:             transcribe.New(os.Getenv("OPENAI_API_KEY")),
 		workingSpinner:          spinner.New(spinner.ModeSpinnerOnly, styles.SpinnerDotsHighlightStyle),
@@ -410,6 +419,39 @@ func (m *appModel) initSessionComponents(tabID string, a *app.App, sess *session
 	m.sessionState = ss
 	m.chatPage = cp
 	m.editor = ed
+
+	m.setActiveDialogMgr(tabID)
+}
+
+// setActiveDialogMgr selects the dialog manager that belongs to the given
+// session, creating an empty one (sized to the current window) when no
+// manager exists yet. Each tab keeps its own dialog stack so a non-modal
+// prompt (e.g. user_prompt elicitation) does not freeze interaction with
+// other tabs (#2626).
+func (m *appModel) setActiveDialogMgr(sessionID string) {
+	mgr, ok := m.dialogMgrs[sessionID]
+	if !ok {
+		mgr = dialog.New()
+		if m.width > 0 || m.height > 0 {
+			updated, _ := mgr.Update(tea.WindowSizeMsg{Width: m.width, Height: m.height})
+			mgr = updated.(dialog.Manager)
+		}
+		m.dialogMgrs[sessionID] = mgr
+	}
+	m.dialogMgr = mgr
+}
+
+// resetActiveDialogMgr replaces the active session's dialog stack with an empty
+// one. Used when the active session is cleared or branched.
+func (m *appModel) resetActiveDialogMgr() {
+	activeID := m.supervisor.ActiveID()
+	newMgr := dialog.New()
+	if m.width > 0 || m.height > 0 {
+		updated, _ := newMgr.Update(tea.WindowSizeMsg{Width: m.width, Height: m.height})
+		newMgr = updated.(dialog.Manager)
+	}
+	m.dialogMgrs[activeID] = newMgr
+	m.dialogMgr = newMgr
 }
 
 // initAndFocusComponents returns a batch of commands that initializes and focuses
@@ -1146,7 +1188,7 @@ func (m *appModel) handleClearSession() (tea.Model, tea.Cmd) {
 
 	// Rebuild all per-session UI components.
 	m.initSessionComponents(activeID, m.application, newSess)
-	m.dialogMgr = dialog.New()
+	m.resetActiveDialogMgr()
 	m.supervisor.SetRunnerTitle(activeID, "")
 	m.sessionState.SetSessionTitle("")
 	m.sessionState.SetPreviousMessage(nil)
@@ -1264,6 +1306,7 @@ func (m *appModel) handleSwitchTab(sessionID string) (tea.Model, tea.Cmd) {
 		m.sessionState = m.sessionStates[sessionID]
 		m.chatPage = m.chatPages[sessionID]
 		m.editor = m.editors[sessionID]
+		m.setActiveDialogMgr(sessionID)
 	}
 
 	m.reapplyKeyboardEnhancements()
@@ -1410,6 +1453,7 @@ func (m *appModel) handleCloseTab(sessionID string) (tea.Model, tea.Cmd) {
 		delete(m.editors, sessionID)
 	}
 	delete(m.sessionStates, sessionID)
+	delete(m.dialogMgrs, sessionID)
 	delete(m.pendingRestores, sessionID)
 	delete(m.pendingSidebarCollapsed, sessionID)
 
@@ -1501,7 +1545,7 @@ func (m *appModel) resizeAll() tea.Cmd {
 	}
 
 	// Full mode: update overlay components
-	cmds = append(cmds, m.updateDialogCmd(tea.WindowSizeMsg{Width: width, Height: height}))
+	cmds = append(cmds, m.updateAllDialogsCmd(tea.WindowSizeMsg{Width: width, Height: height}))
 
 	m.completions.SetEditorBottom(editorHeight + m.tabBar.Height())
 	m.completions.Update(tea.WindowSizeMsg{Width: width, Height: height})
@@ -1682,8 +1726,17 @@ func (m *appModel) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		})
 	}
 
-	// Dialog gets priority when open
+	// Dialog gets priority when open, except for tab navigation shortcuts
+	// (Ctrl+t, Ctrl+p, Ctrl+n) which let the user move between tabs even
+	// while a non-modal dialog — such as a user_prompt elicitation — is
+	// waiting for input. Each tab has its own dialog stack so switching
+	// away preserves the dialog state for when the user returns (#2626).
 	if m.dialogMgr.Open() {
+		if !m.leanMode && isTabNavigationKey(msg) {
+			if cmd := m.tabBar.Update(msg); cmd != nil {
+				return m, cmd
+			}
+		}
 		return m.forwardDialog(msg)
 	}
 
@@ -1799,6 +1852,20 @@ func parseCtrlNumberKey(msg tea.KeyPressMsg) int {
 	return -1
 }
 
+// isTabNavigationKey reports whether msg is one of the non-destructive tab
+// navigation shortcuts (new tab, next tab, prev tab) that should bypass any
+// open dialog so the user can switch tabs while a non-modal prompt is
+// waiting for input. Ctrl+w (close tab) is intentionally excluded because
+// closing a tab while a dialog is open is destructive — the user can press
+// Esc to dismiss the dialog first.
+func isTabNavigationKey(msg tea.KeyPressMsg) bool {
+	switch msg.String() {
+	case "ctrl+t", "ctrl+n", "ctrl+p":
+		return true
+	}
+	return false
+}
+
 // switchFocus toggles between content and editor panels.
 func (m *appModel) switchFocus() (tea.Model, tea.Cmd) {
 	switch m.focusedPanel {
@@ -1827,8 +1894,19 @@ func (m *appModel) handleMouseClick(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) 
 		return m, cmd
 	}
 
-	// Dialogs use full-window coordinates (they're positioned over the entire screen)
+	// Dialogs use full-window coordinates (they're positioned over the entire
+	// screen). Clicks that land on a dialog go to the dialog. Clicks that
+	// fall outside any dialog go to the underlying region as long as that
+	// region is the tab bar — letting the user switch tabs while a
+	// non-modal prompt is open (#2626). Other regions (chat, editor, etc.)
+	// are still treated as modal so background clicks don't accidentally
+	// steal focus or interact with hidden state.
 	if m.dialogMgr.Open() {
+		if !m.dialogMgr.ContainsPoint(msg.X, msg.Y) {
+			if !m.leanMode && m.hitTestRegion(msg.Y) == regionTabBar {
+				return m.forwardTabBarClick(msg)
+			}
+		}
 		return m.forwardDialog(msg)
 	}
 
@@ -1845,14 +1923,7 @@ func (m *appModel) handleMouseClick(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) 
 		return m, nil
 
 	case regionTabBar:
-		// Adjust coordinates for tab bar (relative to its start, accounting for padding)
-		adjustedMsg := msg
-		adjustedMsg.X = msg.X - styles.AppPadding
-		adjustedMsg.Y = msg.Y - m.contentHeight - 1
-		if cmd := m.tabBar.Update(adjustedMsg); cmd != nil {
-			return m, cmd
-		}
-		return m, nil
+		return m.forwardTabBarClick(msg)
 
 	case regionEditor:
 		// Focus editor on click
@@ -1873,6 +1944,20 @@ func (m *appModel) handleMouseClick(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) 
 		}
 	}
 
+	return m, nil
+}
+
+// forwardTabBarClick translates a window-relative click into tab-bar local
+// coordinates and forwards it to the tab bar component. Returns the model
+// and any tab-bar command (typically SwitchTabMsg, CloseTabMsg, or
+// SpawnSessionMsg).
+func (m *appModel) forwardTabBarClick(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) {
+	adjustedMsg := msg
+	adjustedMsg.X = msg.X - styles.AppPadding
+	adjustedMsg.Y = msg.Y - m.contentHeight - 1
+	if cmd := m.tabBar.Update(adjustedMsg); cmd != nil {
+		return m, cmd
+	}
 	return m, nil
 }
 
@@ -1952,7 +2037,11 @@ func (m *appModel) handleWheelCoalesced(msg messages.WheelCoalescedMsg) (tea.Mod
 		return m, nil
 	}
 
-	if m.dialogMgr.Open() {
+	// Forward to the dialog only when the wheel is over the dialog itself.
+	// Outside the dialog (e.g. in the chat content area) the user expects
+	// scrolling to operate on the underlying region so they can read the
+	// conversation while a non-modal prompt is waiting for input (#2626).
+	if m.dialogMgr.Open() && m.dialogMgr.ContainsPoint(msg.X, msg.Y) {
 		return m.forwardDialog(msg)
 	}
 

--- a/pkg/tui/tui_dialog_bypass_test.go
+++ b/pkg/tui/tui_dialog_bypass_test.go
@@ -1,0 +1,159 @@
+package tui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/tui/components/tabbar"
+	"github.com/docker/docker-agent/pkg/tui/dialog"
+	"github.com/docker/docker-agent/pkg/tui/messages"
+)
+
+// dialogBypassFixture wires up a minimal appModel with a tabbar holding two
+// tabs and an open help dialog. It is shared by the tests below so each one
+// can focus on a single aspect of the dialog-bypass behaviour added in
+// #2626.
+func dialogBypassFixture(t *testing.T) *appModel {
+	t.Helper()
+
+	m, _ := newTestModel()
+
+	// A tab bar with two tabs so Ctrl+n / Ctrl+p have somewhere to go.
+	tb := tabbar.New(20)
+	tb.SetWidth(80)
+	tb.SetTabs([]messages.TabInfo{
+		{SessionID: "tab-a", Title: "A"},
+		{SessionID: "tab-b", Title: "B"},
+	}, 0)
+	m.tabBar = tb
+	m.width = 120
+	m.height = 40
+
+	// Initialise the dialog manager's window size, then open a dialog so
+	// m.dialogMgr.Open() is true for the rest of the test.
+	updated, _ := m.dialogMgr.Update(tea.WindowSizeMsg{Width: m.width, Height: m.height})
+	m.dialogMgr = updated.(dialog.Manager)
+	updated, _ = m.dialogMgr.Update(dialog.OpenDialogMsg{Model: dialog.NewHelpDialog(nil)})
+	m.dialogMgr = updated.(dialog.Manager)
+	require.True(t, m.dialogMgr.Open(), "fixture should leave a dialog open")
+
+	return m
+}
+
+// TestKeyPress_TabNavigationBypassesOpenDialog verifies that Ctrl+n is
+// forwarded to the tab bar (producing a SwitchTabMsg) instead of being
+// absorbed by the open dialog. This is the headline fix for #2626.
+func TestKeyPress_TabNavigationBypassesOpenDialog(t *testing.T) {
+	t.Parallel()
+
+	m := dialogBypassFixture(t)
+
+	_, cmd := m.handleKeyPress(tea.KeyPressMsg{Code: 'n', Mod: tea.ModCtrl})
+	require.NotNil(t, cmd, "Ctrl+n with two tabs should produce a SwitchTabMsg")
+
+	msgs := collectMsgs(cmd)
+	assert.True(t, hasMsg[messages.SwitchTabMsg](msgs),
+		"Ctrl+n with an open dialog should still switch tabs (#2626)")
+
+	// The dialog must remain open — switching tabs only swaps the active
+	// dialog stack; it does not dismiss the dialog on the originating tab.
+	assert.True(t, m.dialogMgr.Open(),
+		"tab navigation must not dismiss an open dialog")
+}
+
+// TestKeyPress_NewTabBypassesOpenDialog verifies Ctrl+t is forwarded to the
+// tab bar even with a dialog open.
+func TestKeyPress_NewTabBypassesOpenDialog(t *testing.T) {
+	t.Parallel()
+
+	m := dialogBypassFixture(t)
+
+	_, cmd := m.handleKeyPress(tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl})
+	require.NotNil(t, cmd, "Ctrl+t should always produce a SpawnSessionMsg")
+
+	msgs := collectMsgs(cmd)
+	assert.True(t, hasMsg[messages.SpawnSessionMsg](msgs),
+		"Ctrl+t with an open dialog should still spawn a new session (#2626)")
+}
+
+// TestKeyPress_NonTabKeyForwardsToDialog verifies that ordinary key presses
+// (e.g. a printable character) are still absorbed by the open dialog and not
+// re-routed to the tab bar.
+func TestKeyPress_NonTabKeyForwardsToDialog(t *testing.T) {
+	t.Parallel()
+
+	m := dialogBypassFixture(t)
+
+	_, cmd := m.handleKeyPress(tea.KeyPressMsg{Code: 'a'})
+
+	for _, msg := range collectMsgs(cmd) {
+		assert.IsNotType(t, messages.SwitchTabMsg{}, msg)
+		assert.IsNotType(t, messages.SpawnSessionMsg{}, msg)
+		assert.IsNotType(t, messages.CloseTabMsg{}, msg)
+	}
+}
+
+// TestKeyPress_CloseTabIsForwardedToDialog verifies that Ctrl+w is *not*
+// part of the bypass set: it is handled by the dialog (so the user can,
+// say, focus a button) rather than destructively closing the tab and
+// orphaning a pending elicitation. The user can dismiss the dialog with
+// Esc first if they want to close the tab.
+func TestKeyPress_CloseTabIsForwardedToDialog(t *testing.T) {
+	t.Parallel()
+
+	m := dialogBypassFixture(t)
+
+	_, cmd := m.handleKeyPress(tea.KeyPressMsg{Code: 'w', Mod: tea.ModCtrl})
+
+	for _, msg := range collectMsgs(cmd) {
+		assert.IsNotType(t, messages.CloseTabMsg{}, msg,
+			"Ctrl+w with a dialog open must NOT close the tab (#2626)")
+	}
+}
+
+// TestWheelCoalesced_OutsideDialogScrollsChat verifies that a mouse wheel
+// event whose coordinates fall outside the open dialog's bounds is routed
+// to the chat content region instead of being absorbed by the dialog.
+// This lets the user scroll the conversation while a non-modal prompt is
+// waiting for input (#2626).
+func TestWheelCoalesced_OutsideDialogScrollsChat(t *testing.T) {
+	t.Parallel()
+
+	m := dialogBypassFixture(t)
+	m.contentHeight = 30 // large enough that y=0 lands in the content region
+
+	// Sanity: the help dialog is centred, so (0, 0) is outside its bounds.
+	require.False(t, m.dialogMgr.ContainsPoint(0, 0),
+		"sanity: (0,0) should be outside the centred help dialog")
+
+	_, _ = m.handleWheelCoalesced(messages.WheelCoalescedMsg{X: 0, Y: 0, Delta: -1})
+
+	// The dialog must remain open after a wheel event passes through.
+	assert.True(t, m.dialogMgr.Open(),
+		"wheel events outside the dialog must not dismiss it")
+}
+
+// TestWheelCoalesced_OverDialogIsForwardedToDialog verifies that a wheel
+// event whose coordinates fall over the open dialog is still forwarded to
+// the dialog (so the dialog's own scrolling continues to work).
+func TestWheelCoalesced_OverDialogIsForwardedToDialog(t *testing.T) {
+	t.Parallel()
+
+	m := dialogBypassFixture(t)
+
+	// Find a point that lies inside the dialog.
+	layers := m.dialogMgr.GetLayers()
+	require.Len(t, layers, 1)
+	col := layers[0].GetX()
+	row := layers[0].GetY()
+	require.True(t, m.dialogMgr.ContainsPoint(col, row),
+		"sanity: dialog corner should be inside the dialog")
+
+	_, _ = m.handleWheelCoalesced(messages.WheelCoalescedMsg{X: col, Y: row, Delta: -1})
+
+	assert.True(t, m.dialogMgr.Open(),
+		"wheel events over the dialog must keep it open")
+}


### PR DESCRIPTION
Fixes #2626.

## Problem

The `user_prompt` tool (and other dialogs that prompt the user, like elicitation, tool confirmation, etc.) absorbed *all* keyboard, mouse, and wheel input while open. While an agent was waiting for input, the user could not:

- Switch to another tab and keep working there.
- Scroll the conversation to re-read what led up to the question.

## Approach

### 1. Per-tab dialog stack

The dialog manager (`m.dialogMgr`) was a single, app-wide instance. It is now backed by a per-session map (`m.dialogMgrs`) and the existing field is just an alias for the active session's manager.

This way, switching tabs naturally hides any open dialog — including a pending elicitation — without losing its state. When the user returns to the originating tab, the dialog is still there.

`updateAllDialogsCmd` is added so window-resize and theme-change messages propagate to every dialog manager (so a dialog opened in an inactive tab stays correctly sized when revealed).

### 2. Bypass open dialogs for specific inputs

In `handleKeyPress` / `handleMouseClick` / `handleWheelCoalesced`:

- **Tab navigation** (`Ctrl+t`, `Ctrl+n`, `Ctrl+p`) still goes to the tab bar even when a dialog is open. `Ctrl+w` (close tab) is intentionally **not** part of the bypass set — closing a tab while a dialog is open is destructive (it would orphan a pending elicitation), so we keep that behind an explicit Esc.
- **Mouse wheel** is hit-tested against the dialog's rendered bounds (new `dialog.Manager.ContainsPoint`). Wheel over the dialog stays in the dialog; wheel outside scrolls the chat as usual.
- **Mouse clicks on the tab bar region** (above the editor, when the dialog isn't covering it) are routed to the tab bar instead of being absorbed by the dialog.

## Tests

- `pkg/tui/dialog/dialog_test.go`: covers `ContainsPoint` (no dialog, with dialog, after close).
- `pkg/tui/tui_dialog_bypass_test.go`: covers the key/wheel bypass — Ctrl+t/n produce tab-bar messages with a dialog open; Ctrl+w does not close the tab; ordinary keys are still forwarded to the dialog; wheel events outside the dialog don't dismiss it.
- All existing tests in `pkg/tui/...` continue to pass.