### PR TITLE
feat: Phase 1 attachment system – chat.Document, pkg/attachment, per-provider convertDocument

### DIFF
--- a/pkg/attachment/attachment.go
+++ b/pkg/attachment/attachment.go
@@ -7,6 +7,7 @@ package attachment
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/docker/docker-agent/pkg/attachment/modelcaps"
 	"github.com/docker/docker-agent/pkg/chat"
@@ -56,6 +57,10 @@ func Decide(doc chat.Document, mc modelcaps.ModelCapabilities) (Strategy, string
 // parse as a named attachment.
 //
 //	<document name="report.md" mime-type="text/markdown">…body…</document>
+//
+// The body is sanitised to prevent content from breaking out of the envelope:
+// any occurrence of "</document>" in the body is replaced with "&lt;/document&gt;".
 func TXTEnvelope(name, mimeType, body string) string {
-	return fmt.Sprintf("<document name=%q mime-type=%q>%s</document>", name, mimeType, body)
+	safe := strings.ReplaceAll(body, "</document>", "&lt;/document&gt;")
+	return fmt.Sprintf("<document name=%q mime-type=%q>%s</document>", name, mimeType, safe)
 }

--- a/pkg/attachment/attachment.go
+++ b/pkg/attachment/attachment.go
@@ -59,15 +59,3 @@ func Decide(doc chat.Document, mc modelcaps.ModelCapabilities) (Strategy, string
 func TXTEnvelope(name, mimeType, body string) string {
 	return fmt.Sprintf("<document name=%q mime-type=%q>%s</document>", name, mimeType, body)
 }
-
-// Advisor is implemented by provider clients that can report which MIME types
-// their current model supports as document attachments.
-//
-// Providers that do not implement Advisor are assumed to support no attachment
-// types (StrategyTXT text wrapping is always available as a fallback, but
-// callers must opt in via the Decide function).
-type Advisor interface {
-	// SupportedMIMETypes returns the list of MIME types that the provider's
-	// current model accepts as document attachments.  The list may be empty.
-	SupportedMIMETypes() []string
-}

--- a/pkg/attachment/attachment.go
+++ b/pkg/attachment/attachment.go
@@ -8,6 +8,7 @@ package attachment
 import (
 	"fmt"
 	"strings"
+	"unicode"
 
 	"github.com/docker/docker-agent/pkg/attachment/modelcaps"
 	"github.com/docker/docker-agent/pkg/chat"
@@ -53,14 +54,41 @@ func Decide(doc chat.Document, mc modelcaps.ModelCapabilities) (Strategy, string
 	return StrategyDrop, "no inline content"
 }
 
-// TXTEnvelope wraps a text document body in an XML-like tag that models can
-// parse as a named attachment.
+// TXTEnvelope wraps text content in a unique XML-like tag derived from the
+// document name and MIME type. The tag name is a slug of both, making
+// accidental tag break-out in the content practically impossible without
+// escaping the body.
 //
-//	<document name="report.md" mime-type="text/markdown">…body…</document>
+// Example: a document named "report.md" with MIME "text/markdown" produces:
 //
-// The body is sanitised to prevent content from breaking out of the envelope:
-// any occurrence of "</document>" in the body is replaced with "&lt;/document&gt;".
+//	<document-report-md-text-markdown>
+//	…body…
+//	</document-report-md-text-markdown>
 func TXTEnvelope(name, mimeType, body string) string {
-	safe := strings.ReplaceAll(body, "</document>", "&lt;/document&gt;")
-	return fmt.Sprintf("<document name=%q mime-type=%q>%s</document>", name, mimeType, safe)
+	slug := slugify(name + "-" + mimeType)
+	tag := "document-" + slug
+	return fmt.Sprintf("<%s>\n%s\n</%s>", tag, body, tag)
+}
+
+// slugify converts s to a lowercase, alphanumeric-and-hyphens-only string.
+// Non-alphanumeric runes are replaced with hyphens; consecutive hyphens are
+// collapsed to one; leading and trailing hyphens are trimmed.
+// If the result is empty, "doc" is returned as a safe fallback.
+func slugify(s string) string {
+	var b strings.Builder
+	prevHyphen := false
+	for _, r := range strings.ToLower(s) {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+			prevHyphen = false
+		} else if !prevHyphen {
+			b.WriteRune('-')
+			prevHyphen = true
+		}
+	}
+	result := strings.Trim(b.String(), "-")
+	if result == "" {
+		return "doc"
+	}
+	return result
 }

--- a/pkg/attachment/attachment.go
+++ b/pkg/attachment/attachment.go
@@ -1,0 +1,73 @@
+// Package attachment provides MIME-aware routing for document attachments.
+//
+// It defines how a chat.Document should be sent to a model: either dropped
+// (unsupported), wrapped in a plain-text envelope (StrategyTXT), or encoded
+// as inline base64 data (StrategyB64).
+package attachment
+
+import (
+	"fmt"
+
+	"github.com/docker/docker-agent/pkg/attachment/modelcaps"
+	"github.com/docker/docker-agent/pkg/chat"
+)
+
+// Strategy describes how an attachment should be handled before sending to the
+// provider.
+type Strategy int
+
+const (
+	// StrategyDrop means the attachment is not supported by the model or has no
+	// inline content, and should be silently skipped (with a log warning).
+	StrategyDrop Strategy = iota
+
+	// StrategyTXT means the attachment should be wrapped in a TXTEnvelope and
+	// sent as plain text.  Used for text/* MIME types whose content is already
+	// in Source.InlineText.
+	StrategyTXT
+
+	// StrategyB64 means the attachment content (Source.InlineData) should be
+	// base64-encoded and sent as a native provider image/document block.
+	StrategyB64
+)
+
+// Decide returns the routing Strategy for a document given the current model's
+// capabilities.
+//
+// Algorithm:
+//  1. If the model does not support the document's MIME type → (Drop, reason).
+//  2. If Source.InlineData is non-empty → (B64, "").
+//  3. If Source.InlineText is non-empty → (TXT, "").
+//  4. Otherwise → (Drop, "no inline content").
+func Decide(doc chat.Document, mc modelcaps.ModelCapabilities) (Strategy, string) {
+	if !mc.Supports(doc.MimeType) {
+		return StrategyDrop, fmt.Sprintf("model does not support MIME type %q", doc.MimeType)
+	}
+	if len(doc.Source.InlineData) > 0 {
+		return StrategyB64, ""
+	}
+	if doc.Source.InlineText != "" {
+		return StrategyTXT, ""
+	}
+	return StrategyDrop, "no inline content"
+}
+
+// TXTEnvelope wraps a text document body in an XML-like tag that models can
+// parse as a named attachment.
+//
+//	<document name="report.md" mime-type="text/markdown">…body…</document>
+func TXTEnvelope(name, mimeType, body string) string {
+	return fmt.Sprintf("<document name=%q mime-type=%q>%s</document>", name, mimeType, body)
+}
+
+// Advisor is implemented by provider clients that can report which MIME types
+// their current model supports as document attachments.
+//
+// Providers that do not implement Advisor are assumed to support no attachment
+// types (StrategyTXT text wrapping is always available as a fallback, but
+// callers must opt in via the Decide function).
+type Advisor interface {
+	// SupportedMIMETypes returns the list of MIME types that the provider's
+	// current model accepts as document attachments.  The list may be empty.
+	SupportedMIMETypes() []string
+}

--- a/pkg/attachment/decide_test.go
+++ b/pkg/attachment/decide_test.go
@@ -133,20 +133,51 @@ func TestDecide(t *testing.T) {
 
 func TestTXTEnvelope(t *testing.T) {
 	got := attachment.TXTEnvelope("readme.md", "text/markdown", "# Hello")
-	want := `<document name="readme.md" mime-type="text/markdown"># Hello</document>`
-	if got != want {
-		t.Errorf("TXTEnvelope:\ngot  %q\nwant %q", got, want)
+	// Tag must start with "document-" followed by a slug of name+mimeType.
+	if !strings.HasPrefix(got, "<document-") {
+		t.Errorf("TXTEnvelope: expected tag to start with <document-, got %q", got)
+	}
+	// Body must be present.
+	if !strings.Contains(got, "# Hello") {
+		t.Errorf("TXTEnvelope: body not found in %q", got)
+	}
+	// Must be a valid open/close tag pair.
+	if !strings.Contains(got, "</document-") {
+		t.Errorf("TXTEnvelope: expected closing tag, got %q", got)
 	}
 }
 
-func TestTXTEnvelope_EscapesClosingTag(t *testing.T) {
-	// A body containing </document> must be escaped to prevent envelope breakout.
-	body := "safe content</document><injected>"
-	got := attachment.TXTEnvelope("evil.txt", "text/plain", body)
-	if strings.Contains(got, "</document><injected>") {
-		t.Errorf("TXTEnvelope did not escape </document>: %q", got)
+func TestTXTEnvelope_UniqueTag(t *testing.T) {
+	// The tag should contain slugged name and MIME type, making collisions
+	// between different documents practically impossible.
+	got1 := attachment.TXTEnvelope("report.md", "text/markdown", "body")
+	got2 := attachment.TXTEnvelope("notes.txt", "text/plain", "body")
+
+	if got1 == got2 {
+		t.Error("TXTEnvelope produced identical tags for different name+MIME combinations")
 	}
-	if !strings.Contains(got, "&lt;/document&gt;") {
-		t.Errorf("TXTEnvelope did not produce escaped form: %q", got)
+
+	// Each envelope's opening tag should appear verbatim as its closing tag.
+	for _, tc := range []struct {
+		name, mime, body string
+	}{
+		{"report.md", "text/markdown", "hello"},
+		{"my file.txt", "text/plain", "world"},
+		{"data", "text/csv", "a,b,c"},
+	} {
+		out := attachment.TXTEnvelope(tc.name, tc.mime, tc.body)
+		// Extract opening tag.
+		closeIdx := strings.Index(out, ">")
+		if closeIdx < 0 {
+			t.Fatalf("no closing > in envelope: %q", out)
+		}
+		openTag := out[1:closeIdx] // e.g. "document-report-md-text-markdown"
+		closeTag := "</" + openTag + ">"
+		if !strings.HasSuffix(strings.TrimSpace(out), closeTag) {
+			t.Errorf("envelope missing matching close tag %q in %q", closeTag, out)
+		}
+		if !strings.Contains(out, tc.body) {
+			t.Errorf("body %q not found in envelope %q", tc.body, out)
+		}
 	}
 }

--- a/pkg/attachment/decide_test.go
+++ b/pkg/attachment/decide_test.go
@@ -1,0 +1,139 @@
+package attachment_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/docker/docker-agent/pkg/attachment"
+	"github.com/docker/docker-agent/pkg/attachment/modelcaps"
+	"github.com/docker/docker-agent/pkg/chat"
+)
+
+// testCaps is a small helper that builds a ModelCapabilities directly.
+func visionCaps() modelcaps.ModelCapabilities {
+	return modelcaps.CapsWith(true, true)
+}
+
+func textOnlyCaps() modelcaps.ModelCapabilities {
+	return modelcaps.CapsWith(false, false)
+}
+
+func imageNoPDFCaps() modelcaps.ModelCapabilities {
+	return modelcaps.CapsWith(true, false)
+}
+
+func TestDecide(t *testing.T) {
+	tests := []struct {
+		name           string
+		doc            chat.Document
+		caps           modelcaps.ModelCapabilities
+		wantStrategy   attachment.Strategy
+		wantReasonHas  string // non-empty: reason must contain this substring
+	}{
+		{
+			name: "b64 image supported",
+			doc: chat.Document{
+				Name:     "photo.jpg",
+				MimeType: "image/jpeg",
+				Source:   chat.DocumentSource{InlineData: []byte{0xFF, 0xD8}},
+			},
+			caps:         visionCaps(),
+			wantStrategy: attachment.StrategyB64,
+		},
+		{
+			name: "txt text plain",
+			doc: chat.Document{
+				Name:     "notes.txt",
+				MimeType: "text/plain",
+				Source:   chat.DocumentSource{InlineText: "hello world"},
+			},
+			caps:         textOnlyCaps(),
+			wantStrategy: attachment.StrategyTXT,
+		},
+		{
+			name: "drop image when model has no vision",
+			doc: chat.Document{
+				Name:     "photo.jpg",
+				MimeType: "image/jpeg",
+				Source:   chat.DocumentSource{InlineData: []byte{0xFF, 0xD8}},
+			},
+			caps:          textOnlyCaps(),
+			wantStrategy:  attachment.StrategyDrop,
+			wantReasonHas: "does not support MIME type",
+		},
+		{
+			name: "drop pdf when model has no pdf support",
+			doc: chat.Document{
+				Name:     "doc.pdf",
+				MimeType: "application/pdf",
+				Source:   chat.DocumentSource{InlineData: []byte{0x25, 0x50, 0x44, 0x46}},
+			},
+			caps:          imageNoPDFCaps(),
+			wantStrategy:  attachment.StrategyDrop,
+			wantReasonHas: "does not support MIME type",
+		},
+		{
+			name: "drop no inline content",
+			doc: chat.Document{
+				Name:     "empty.md",
+				MimeType: "text/markdown",
+				Source:   chat.DocumentSource{},
+			},
+			caps:          textOnlyCaps(),
+			wantStrategy:  attachment.StrategyDrop,
+			wantReasonHas: "no inline content",
+		},
+		{
+			name: "b64 pdf when pdf supported",
+			doc: chat.Document{
+				Name:     "spec.pdf",
+				MimeType: "application/pdf",
+				Source:   chat.DocumentSource{InlineData: []byte{0x25, 0x50, 0x44, 0x46}},
+			},
+			caps:         visionCaps(),
+			wantStrategy: attachment.StrategyB64,
+		},
+		{
+			name: "txt office doc (always allowed)",
+			doc: chat.Document{
+				Name:     "report.docx",
+				MimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+				Source:   chat.DocumentSource{InlineText: "content here"},
+			},
+			caps:         textOnlyCaps(),
+			wantStrategy: attachment.StrategyTXT,
+		},
+		{
+			name: "b64 wins over txt when both inline sources present",
+			doc: chat.Document{
+				Name:     "data.txt",
+				MimeType: "text/plain",
+				Source:   chat.DocumentSource{InlineData: []byte("hello"), InlineText: "hello"},
+			},
+			caps:         textOnlyCaps(),
+			wantStrategy: attachment.StrategyB64,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotStrategy, gotReason := attachment.Decide(tc.doc, tc.caps)
+			if gotStrategy != tc.wantStrategy {
+				t.Errorf("strategy: got %d, want %d", gotStrategy, tc.wantStrategy)
+			}
+			if tc.wantReasonHas != "" {
+				if !strings.Contains(gotReason, tc.wantReasonHas) {
+					t.Errorf("reason %q does not contain %q", gotReason, tc.wantReasonHas)
+				}
+			}
+		})
+	}
+}
+
+func TestTXTEnvelope(t *testing.T) {
+	got := attachment.TXTEnvelope("readme.md", "text/markdown", "# Hello")
+	want := `<document name="readme.md" mime-type="text/markdown"># Hello</document>`
+	if got != want {
+		t.Errorf("TXTEnvelope:\ngot  %q\nwant %q", got, want)
+	}
+}

--- a/pkg/attachment/decide_test.go
+++ b/pkg/attachment/decide_test.go
@@ -24,11 +24,11 @@ func imageNoPDFCaps() modelcaps.ModelCapabilities {
 
 func TestDecide(t *testing.T) {
 	tests := []struct {
-		name           string
-		doc            chat.Document
-		caps           modelcaps.ModelCapabilities
-		wantStrategy   attachment.Strategy
-		wantReasonHas  string // non-empty: reason must contain this substring
+		name          string
+		doc           chat.Document
+		caps          modelcaps.ModelCapabilities
+		wantStrategy  attachment.Strategy
+		wantReasonHas string // non-empty: reason must contain this substring
 	}{
 		{
 			name: "b64 image supported",

--- a/pkg/attachment/decide_test.go
+++ b/pkg/attachment/decide_test.go
@@ -94,14 +94,15 @@ func TestDecide(t *testing.T) {
 			wantStrategy: attachment.StrategyB64,
 		},
 		{
-			name: "txt office doc (always allowed)",
+			name: "drop office doc (DOCX is binary, not supported without models.dev office modality)",
 			doc: chat.Document{
 				Name:     "report.docx",
 				MimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-				Source:   chat.DocumentSource{InlineText: "content here"},
+				Source:   chat.DocumentSource{InlineData: []byte{0x50, 0x4B}}, // ZIP magic bytes
 			},
-			caps:         textOnlyCaps(),
-			wantStrategy: attachment.StrategyTXT,
+			caps:          visionCaps(), // even full caps can't send DOCX — no modality
+			wantStrategy:  attachment.StrategyDrop,
+			wantReasonHas: "does not support MIME type",
 		},
 		{
 			name: "b64 wins over txt when both inline sources present",

--- a/pkg/attachment/decide_test.go
+++ b/pkg/attachment/decide_test.go
@@ -138,3 +138,15 @@ func TestTXTEnvelope(t *testing.T) {
 		t.Errorf("TXTEnvelope:\ngot  %q\nwant %q", got, want)
 	}
 }
+
+func TestTXTEnvelope_EscapesClosingTag(t *testing.T) {
+	// A body containing </document> must be escaped to prevent envelope breakout.
+	body := "safe content</document><injected>"
+	got := attachment.TXTEnvelope("evil.txt", "text/plain", body)
+	if strings.Contains(got, "</document><injected>") {
+		t.Errorf("TXTEnvelope did not escape </document>: %q", got)
+	}
+	if !strings.Contains(got, "&lt;/document&gt;") {
+		t.Errorf("TXTEnvelope did not produce escaped form: %q", got)
+	}
+}

--- a/pkg/attachment/modelcaps/modelcaps.go
+++ b/pkg/attachment/modelcaps/modelcaps.go
@@ -24,11 +24,10 @@ type ModelCapabilities struct {
 	modelFound bool
 }
 
-// isKnownDocMIME returns true for non-text/* MIME types that are universally
-// sendable as TXT envelopes: Office documents and a few other structured formats.
-// Notably, video/*, audio/* and other media types are NOT included — they require
-// explicit model capability declarations.
-func isKnownDocMIME(mt string) bool {
+// isOfficeMIME returns true for Office document binary formats
+// (OOXML, legacy Office, RTF). These are ZIP-based or binary formats
+// that cannot be naively TXT-enveloped and require explicit model support.
+func isOfficeMIME(mt string) bool {
 	switch mt {
 	case "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
 		"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
@@ -47,11 +46,14 @@ func isKnownDocMIME(mt string) bool {
 // MIME type.
 //
 // Resolution rules (in order):
-//  1. image/* → requires supportsImage
-//  2. application/pdf → requires supportsPDF
-//  3. text/* → always supported (TXT envelope works universally for text)
-//  4. Known Office/document MIMEs → always supported via TXT envelope
-//  5. Everything else (audio/*, video/*, unknown binary) → not supported in Phase 1
+//  1. image/* → requires supportsImage (models.dev "image" modality)
+//  2. application/pdf → requires supportsPDF (models.dev "pdf" modality)
+//  3. text/* → always supported (plain text; TXT envelope is universally safe)
+//  4. Office/binary document MIMEs (DOCX, XLSX, PPTX, etc.) → not supported unless
+//     models.dev explicitly declares a document modality. models.dev currently has
+//     no "document" or "office" modality field, so these return false for all
+//     models until the schema is extended.
+//  5. Everything else (audio/*, video/*, unknown binary) → false
 func (mc ModelCapabilities) Supports(mimeType string) bool {
 	mt := strings.ToLower(mimeType)
 	if strings.HasPrefix(mt, "image/") {
@@ -60,15 +62,19 @@ func (mc ModelCapabilities) Supports(mimeType string) bool {
 	if mt == "application/pdf" {
 		return mc.supportsPDF
 	}
-	// text/* MIMEs are always supported via TXT envelope.
+	// text/* MIMEs (text/plain, text/markdown, text/html, text/csv, …) are always
+	// supported — they are actual text and TXT envelope works universally.
 	if strings.HasPrefix(mt, "text/") {
 		return true
 	}
-	// Known Office document formats can be safely TXT-enveloped.
-	if isKnownDocMIME(mt) {
-		return true
+	// Office document formats (DOCX, XLSX, PPTX, etc.) are ZIP-based binaries;
+	// they cannot be naively TXT-enveloped. models.dev does not yet declare an
+	// "office" or "document" modality, so we conservatively return false until
+	// the schema provides explicit capability data.
+	if isOfficeMIME(mt) {
+		return false
 	}
-	// audio/*, video/*, and unknown binary types are not supported in Phase 1.
+	// audio/*, video/*, and all other unknown binary types are not supported.
 	return false
 }
 

--- a/pkg/attachment/modelcaps/modelcaps.go
+++ b/pkg/attachment/modelcaps/modelcaps.go
@@ -1,0 +1,109 @@
+// Package modelcaps provides model capability queries for the attachment system.
+// It translates models.dev modality information into MIME-type support decisions
+// used by the attachment routing logic.
+package modelcaps
+
+import (
+	"context"
+	"strings"
+
+	"github.com/docker/docker-agent/pkg/modelsdev"
+)
+
+// ModelCapabilities describes what MIME types a given model can accept as
+// document attachments.
+type ModelCapabilities struct {
+	// supportsImage is true when the model accepts image/* MIME types.
+	supportsImage bool
+	// supportsPDF is true when the model accepts application/pdf.
+	supportsPDF bool
+	// modelFound is false when models.dev has no record for this model,
+	// which causes conservative fallback behaviour (text-only).
+	modelFound bool
+}
+
+// Supports returns true when the model can accept an attachment with the given
+// MIME type.
+//
+// Resolution rules (in order):
+//  1. image/* → requires supportsImage
+//  2. application/pdf → requires supportsPDF
+//  3. All other types (text/*, application/vnd.openxmlformats-officedocument.*,
+//     etc.) → always supported; a TXT envelope works universally.
+func (mc ModelCapabilities) Supports(mimeType string) bool {
+	mt := strings.ToLower(mimeType)
+	if strings.HasPrefix(mt, "image/") {
+		return mc.supportsImage
+	}
+	if mt == "application/pdf" {
+		return mc.supportsPDF
+	}
+	// All other MIME types are text-based or can be safely wrapped in a TXT
+	// envelope, so we allow them unconditionally.
+	return true
+}
+
+// Load fetches (or returns from cache) the capability record for the given
+// model ID.  The model ID should be in "provider/model" format as used by
+// models.dev (e.g. "anthropic/claude-3-5-sonnet-20241022").
+//
+// When the model is not found in the models.dev database, Load returns a
+// conservative capability set that only allows text MIME types.  The returned
+// error is always nil; capability detection failures are silent and safe.
+func Load(modelID string) (ModelCapabilities, error) {
+	store, err := modelsdev.NewStore()
+	if err != nil {
+		// Cannot load the store at all — return text-only conservative caps.
+		return ModelCapabilities{modelFound: false}, nil
+	}
+
+	// Use a background context for the lookup; capability detection is best-effort
+	// and should not block the main request flow.
+	model, err := store.GetModel(context.Background(), modelID)
+	if err != nil {
+		// Model not found or other error — conservative: text-only.
+		return ModelCapabilities{modelFound: false}, nil
+	}
+
+	mc := ModelCapabilities{modelFound: true}
+	for _, input := range model.Modalities.Input {
+		switch strings.ToLower(input) {
+		case "image":
+			mc.supportsImage = true
+		case "pdf":
+			mc.supportsPDF = true
+		}
+	}
+	return mc, nil
+}
+
+// CapsWith constructs a ModelCapabilities value directly from booleans. This is
+// intended for use in tests and provider implementations that need to create a
+// capabilities value without hitting the network.
+func CapsWith(supportsImage, supportsPDF bool) ModelCapabilities {
+	return ModelCapabilities{
+		supportsImage: supportsImage,
+		supportsPDF:   supportsPDF,
+		modelFound:    true,
+	}
+}
+
+// LoadFromStore is like Load but accepts an explicit *modelsdev.Store, making
+// it convenient for tests that inject a pre-populated in-memory store.
+func LoadFromStore(store *modelsdev.Store, modelID string) ModelCapabilities {
+	model, err := store.GetModel(context.Background(), modelID)
+	if err != nil {
+		return ModelCapabilities{modelFound: false}
+	}
+
+	mc := ModelCapabilities{modelFound: true}
+	for _, input := range model.Modalities.Input {
+		switch strings.ToLower(input) {
+		case "image":
+			mc.supportsImage = true
+		case "pdf":
+			mc.supportsPDF = true
+		}
+	}
+	return mc
+}

--- a/pkg/attachment/modelcaps/modelcaps.go
+++ b/pkg/attachment/modelcaps/modelcaps.go
@@ -5,7 +5,9 @@ package modelcaps
 
 import (
 	"context"
+	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/docker/docker-agent/pkg/modelsdev"
 )
@@ -22,14 +24,34 @@ type ModelCapabilities struct {
 	modelFound bool
 }
 
+// isKnownDocMIME returns true for non-text/* MIME types that are universally
+// sendable as TXT envelopes: Office documents and a few other structured formats.
+// Notably, video/*, audio/* and other media types are NOT included — they require
+// explicit model capability declarations.
+func isKnownDocMIME(mt string) bool {
+	switch mt {
+	case "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+		"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+		"application/vnd.openxmlformats-officedocument.presentationml.presentation",
+		"application/vnd.ms-excel",
+		"application/vnd.ms-powerpoint",
+		"application/msword",
+		"application/rtf",
+		"text/rtf":
+		return true
+	}
+	return false
+}
+
 // Supports returns true when the model can accept an attachment with the given
 // MIME type.
 //
 // Resolution rules (in order):
 //  1. image/* → requires supportsImage
 //  2. application/pdf → requires supportsPDF
-//  3. All other types (text/*, application/vnd.openxmlformats-officedocument.*,
-//     etc.) → always supported; a TXT envelope works universally.
+//  3. text/* → always supported (TXT envelope works universally for text)
+//  4. Known Office/document MIMEs → always supported via TXT envelope
+//  5. Everything else (audio/*, video/*, unknown binary) → not supported in Phase 1
 func (mc ModelCapabilities) Supports(mimeType string) bool {
 	mt := strings.ToLower(mimeType)
 	if strings.HasPrefix(mt, "image/") {
@@ -38,10 +60,21 @@ func (mc ModelCapabilities) Supports(mimeType string) bool {
 	if mt == "application/pdf" {
 		return mc.supportsPDF
 	}
-	// All other MIME types are text-based or can be safely wrapped in a TXT
-	// envelope, so we allow them unconditionally.
-	return true
+	// text/* MIMEs are always supported via TXT envelope.
+	if strings.HasPrefix(mt, "text/") {
+		return true
+	}
+	// Known Office document formats can be safely TXT-enveloped.
+	if isKnownDocMIME(mt) {
+		return true
+	}
+	// audio/*, video/*, and unknown binary types are not supported in Phase 1.
+	return false
 }
+
+// loadTimeout is the maximum time allowed for a models.dev capability lookup.
+// If the fetch takes longer, Load falls back to conservative text-only caps.
+const loadTimeout = 10 * time.Second
 
 // Load fetches (or returns from cache) the capability record for the given
 // model ID.  The model ID should be in "provider/model" format as used by
@@ -51,17 +84,23 @@ func (mc ModelCapabilities) Supports(mimeType string) bool {
 // conservative capability set that only allows text MIME types.  The returned
 // error is always nil; capability detection failures are silent and safe.
 func Load(modelID string) (ModelCapabilities, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), loadTimeout)
+	defer cancel()
+
 	store, err := modelsdev.NewStore()
 	if err != nil {
-		// Cannot load the store at all — return text-only conservative caps.
+		slog.Warn("modelcaps: failed to load models.dev store, using conservative caps",
+			"error", err, "model", modelID)
 		return ModelCapabilities{modelFound: false}, nil
 	}
 
-	// Use a background context for the lookup; capability detection is best-effort
-	// and should not block the main request flow.
-	model, err := store.GetModel(context.Background(), modelID)
+	model, err := store.GetModel(ctx, modelID)
 	if err != nil {
-		// Model not found or other error — conservative: text-only.
+		if ctx.Err() != nil {
+			slog.Warn("modelcaps: models.dev lookup timed out, using conservative caps",
+				"model", modelID, "timeout", loadTimeout)
+		}
+		// Model not found or context cancelled — conservative: text-only.
 		return ModelCapabilities{modelFound: false}, nil
 	}
 
@@ -91,7 +130,10 @@ func CapsWith(supportsImage, supportsPDF bool) ModelCapabilities {
 // LoadFromStore is like Load but accepts an explicit *modelsdev.Store, making
 // it convenient for tests that inject a pre-populated in-memory store.
 func LoadFromStore(store *modelsdev.Store, modelID string) ModelCapabilities {
-	model, err := store.GetModel(context.Background(), modelID)
+	ctx, cancel := context.WithTimeout(context.Background(), loadTimeout)
+	defer cancel()
+
+	model, err := store.GetModel(ctx, modelID)
 	if err != nil {
 		return ModelCapabilities{modelFound: false}
 	}

--- a/pkg/attachment/modelcaps/modelcaps_test.go
+++ b/pkg/attachment/modelcaps/modelcaps_test.go
@@ -1,0 +1,133 @@
+package modelcaps_test
+
+import (
+	"testing"
+
+	"github.com/docker/docker-agent/pkg/attachment/modelcaps"
+	"github.com/docker/docker-agent/pkg/modelsdev"
+)
+
+// buildStore creates an in-memory Store with the given models for testing.
+func buildStore(providers map[string]modelsdev.Provider) *modelsdev.Store {
+	db := &modelsdev.Database{Providers: providers}
+	return modelsdev.NewDatabaseStore(db)
+}
+
+func TestLoadFromStore_VisionModel(t *testing.T) {
+	store := buildStore(map[string]modelsdev.Provider{
+		"anthropic": {
+			Models: map[string]modelsdev.Model{
+				"claude-3-5-sonnet": {
+					Name: "Claude 3.5 Sonnet",
+					Modalities: modelsdev.Modalities{
+						Input:  []string{"text", "image", "pdf"},
+						Output: []string{"text"},
+					},
+				},
+			},
+		},
+	})
+
+	mc := modelcaps.LoadFromStore(store, "anthropic/claude-3-5-sonnet")
+
+	if !mc.Supports("image/jpeg") {
+		t.Error("expected image/jpeg to be supported for vision model")
+	}
+	if !mc.Supports("image/png") {
+		t.Error("expected image/png to be supported for vision model")
+	}
+	if !mc.Supports("application/pdf") {
+		t.Error("expected application/pdf to be supported for pdf model")
+	}
+	if !mc.Supports("text/plain") {
+		t.Error("expected text/plain to always be supported")
+	}
+}
+
+func TestLoadFromStore_TextOnlyModel(t *testing.T) {
+	store := buildStore(map[string]modelsdev.Provider{
+		"openai": {
+			Models: map[string]modelsdev.Model{
+				"gpt-3.5-turbo": {
+					Name: "GPT-3.5 Turbo",
+					Modalities: modelsdev.Modalities{
+						Input:  []string{"text"},
+						Output: []string{"text"},
+					},
+				},
+			},
+		},
+	})
+
+	mc := modelcaps.LoadFromStore(store, "openai/gpt-3.5-turbo")
+
+	if mc.Supports("image/jpeg") {
+		t.Error("expected image/jpeg NOT to be supported for text-only model")
+	}
+	if mc.Supports("application/pdf") {
+		t.Error("expected application/pdf NOT to be supported for text-only model")
+	}
+	// Text MIMEs are always allowed
+	if !mc.Supports("text/plain") {
+		t.Error("expected text/plain to always be supported")
+	}
+	if !mc.Supports("text/markdown") {
+		t.Error("expected text/markdown to always be supported")
+	}
+}
+
+func TestLoadFromStore_ModelNotFound(t *testing.T) {
+	store := buildStore(map[string]modelsdev.Provider{})
+
+	mc := modelcaps.LoadFromStore(store, "unknown/nonexistent-model")
+
+	// Conservative fallback: only text is allowed
+	if mc.Supports("image/jpeg") {
+		t.Error("expected image/jpeg NOT to be supported for unknown model")
+	}
+	if mc.Supports("application/pdf") {
+		t.Error("expected application/pdf NOT to be supported for unknown model")
+	}
+	if !mc.Supports("text/plain") {
+		t.Error("expected text/plain to always be supported even for unknown model")
+	}
+}
+
+func TestLoadFromStore_OfficeDocsAlwaysAllowed(t *testing.T) {
+	// Even a text-only model must allow Office document MIMEs (they'll be TXT-enveloped).
+	store := buildStore(map[string]modelsdev.Provider{
+		"openai": {
+			Models: map[string]modelsdev.Model{
+				"gpt-4o": {
+					Name: "GPT-4o",
+					Modalities: modelsdev.Modalities{
+						Input:  []string{"text"},
+						Output: []string{"text"},
+					},
+				},
+			},
+		},
+	})
+
+	mc := modelcaps.LoadFromStore(store, "openai/gpt-4o")
+
+	officeMIME := "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+	if !mc.Supports(officeMIME) {
+		t.Errorf("expected office MIME %q to always be supported", officeMIME)
+	}
+}
+
+func TestCapsWith(t *testing.T) {
+	mc := modelcaps.CapsWith(true, false)
+	if !mc.Supports("image/jpeg") {
+		t.Error("expected image/jpeg to be supported")
+	}
+	if mc.Supports("application/pdf") {
+		t.Error("expected pdf NOT to be supported")
+	}
+
+	mc2 := modelcaps.CapsWith(false, false)
+	if mc2.Supports("image/png") {
+		t.Error("expected image/png NOT to be supported")
+	}
+}

--- a/pkg/attachment/modelcaps/modelcaps_test.go
+++ b/pkg/attachment/modelcaps/modelcaps_test.go
@@ -93,15 +93,17 @@ func TestLoadFromStore_ModelNotFound(t *testing.T) {
 	}
 }
 
-func TestLoadFromStore_OfficeDocsAlwaysAllowed(t *testing.T) {
-	// Even a text-only model must allow Office document MIMEs (they'll be TXT-enveloped).
+func TestLoadFromStore_OfficeDocsNotAllowed(t *testing.T) {
+	// Office document MIMEs (DOCX, XLSX, etc.) are ZIP-based binaries and
+	// cannot be naively TXT-enveloped. models.dev has no "office" or
+	// "document" modality, so they must return false for all models.
 	store := buildStore(map[string]modelsdev.Provider{
 		"openai": {
 			Models: map[string]modelsdev.Model{
 				"gpt-4o": {
 					Name: "GPT-4o",
 					Modalities: modelsdev.Modalities{
-						Input:  []string{"text"},
+						Input:  []string{"text", "image", "pdf"},
 						Output: []string{"text"},
 					},
 				},
@@ -111,9 +113,17 @@ func TestLoadFromStore_OfficeDocsAlwaysAllowed(t *testing.T) {
 
 	mc := modelcaps.LoadFromStore(store, "openai/gpt-4o")
 
-	officeMIME := "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-	if !mc.Supports(officeMIME) {
-		t.Errorf("expected office MIME %q to always be supported", officeMIME)
+	for _, officeMIME := range []string{
+		"application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+		"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+		"application/vnd.openxmlformats-officedocument.presentationml.presentation",
+		"application/msword",
+		"application/vnd.ms-excel",
+		"application/rtf",
+	} {
+		if mc.Supports(officeMIME) {
+			t.Errorf("expected Office MIME %q NOT to be supported (models.dev has no document modality)", officeMIME)
+		}
 	}
 }
 
@@ -132,11 +142,11 @@ func TestCapsWith(t *testing.T) {
 	}
 }
 
-// TestSupports_AudioVideoRejected verifies that audio/video MIMEs are NOT
-// allowed by default — they require explicit model support declarations
-// which Phase 1 does not implement.
+// TestSupports_AudioVideoRejected verifies that audio/video MIMEs and Office
+// document binaries are NOT allowed — they require explicit model support
+// declarations which Phase 1 does not implement (models.dev has no such modality).
 func TestSupports_AudioVideoRejected(t *testing.T) {
-	// Even a vision+pdf capable model should reject audio/video.
+	// Even a vision+pdf capable model should reject audio/video/office.
 	mc := modelcaps.CapsWith(true, true)
 
 	for _, mime := range []string{
@@ -146,6 +156,9 @@ func TestSupports_AudioVideoRejected(t *testing.T) {
 		"video/mp4",
 		"video/webm",
 		"application/octet-stream",
+		"application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+		"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+		"application/msword",
 	} {
 		if mc.Supports(mime) {
 			t.Errorf("expected %q to NOT be supported (not in Phase 1 allowlist)", mime)

--- a/pkg/attachment/modelcaps/modelcaps_test.go
+++ b/pkg/attachment/modelcaps/modelcaps_test.go
@@ -131,3 +131,24 @@ func TestCapsWith(t *testing.T) {
 		t.Error("expected image/png NOT to be supported")
 	}
 }
+
+// TestSupports_AudioVideoRejected verifies that audio/video MIMEs are NOT
+// allowed by default — they require explicit model support declarations
+// which Phase 1 does not implement.
+func TestSupports_AudioVideoRejected(t *testing.T) {
+	// Even a vision+pdf capable model should reject audio/video.
+	mc := modelcaps.CapsWith(true, true)
+
+	for _, mime := range []string{
+		"audio/mp3",
+		"audio/wav",
+		"audio/ogg",
+		"video/mp4",
+		"video/webm",
+		"application/octet-stream",
+	} {
+		if mc.Supports(mime) {
+			t.Errorf("expected %q to NOT be supported (not in Phase 1 allowlist)", mime)
+		}
+	}
+}

--- a/pkg/chat/chat.go
+++ b/pkg/chat/chat.go
@@ -29,9 +29,11 @@ const (
 type MessagePartType string
 
 const (
-	MessagePartTypeText     MessagePartType = "text"
+	MessagePartTypeText MessagePartType = "text"
+	// Deprecated: use MessagePartTypeDocument instead.
 	MessagePartTypeImageURL MessagePartType = "image_url"
-	MessagePartTypeFile     MessagePartType = "file"
+	// Deprecated: use MessagePartTypeDocument instead.
+	MessagePartTypeFile MessagePartType = "file"
 )
 
 type ImageURLDetail string
@@ -108,8 +110,12 @@ type MessageFile struct {
 type MessagePart struct {
 	Type     MessagePartType  `json:"type,omitempty"`
 	Text     string           `json:"text,omitempty"`
+	// Deprecated: use Document with MessagePartTypeDocument instead.
 	ImageURL *MessageImageURL `json:"image_url,omitempty"`
+	// Deprecated: use Document with MessagePartTypeDocument instead.
 	File     *MessageFile     `json:"file,omitempty"`
+	// Document is set when Type is MessagePartTypeDocument.
+	Document *Document        `json:"document,omitempty"`
 }
 
 // FinishReason represents the reason why the model finished generating a response

--- a/pkg/chat/chat.go
+++ b/pkg/chat/chat.go
@@ -30,9 +30,9 @@ type MessagePartType string
 
 const (
 	MessagePartTypeText MessagePartType = "text"
-	// Deprecated: use MessagePartTypeDocument instead.
+	// MessagePartTypeImageURL is superseded by MessagePartTypeDocument. Will be removed in a future release.
 	MessagePartTypeImageURL MessagePartType = "image_url"
-	// Deprecated: use MessagePartTypeDocument instead.
+	// MessagePartTypeFile is superseded by MessagePartTypeDocument. Will be removed in a future release.
 	MessagePartTypeFile MessagePartType = "file"
 )
 
@@ -108,14 +108,14 @@ type MessageFile struct {
 }
 
 type MessagePart struct {
-	Type     MessagePartType  `json:"type,omitempty"`
-	Text     string           `json:"text,omitempty"`
-	// Deprecated: use Document with MessagePartTypeDocument instead.
+	Type MessagePartType `json:"type,omitempty"`
+	Text string          `json:"text,omitempty"`
+	// Note: superseded by Document+MessagePartTypeDocument. Will be removed in a future release.
 	ImageURL *MessageImageURL `json:"image_url,omitempty"`
-	// Deprecated: use Document with MessagePartTypeDocument instead.
-	File     *MessageFile     `json:"file,omitempty"`
+	// Note: superseded by Document+MessagePartTypeDocument. Will be removed in a future release.
+	File *MessageFile `json:"file,omitempty"`
 	// Document is set when Type is MessagePartTypeDocument.
-	Document *Document        `json:"document,omitempty"`
+	Document *Document `json:"document,omitempty"`
 }
 
 // FinishReason represents the reason why the model finished generating a response

--- a/pkg/chat/document.go
+++ b/pkg/chat/document.go
@@ -18,12 +18,6 @@ type DocumentSource struct {
 	// InlineData holds binary content (images, PDFs, Office docs, …) that is
 	// base64-encoded when sent to the provider. Used for StrategyB64 attachments.
 	InlineData []byte `json:"inline_data,omitempty"`
-
-	// URL is reserved for Phase 2 (URL-referenced documents). Must not be set
-	// on Documents stored in messages in Phase 1; providers should log a warning
-	// and skip documents that have only URL set.
-	// TODO(phase2): implement URL-referenced document fetching.
-	URL string `json:"url,omitempty"`
 }
 
 // Document represents a file attachment in a message part. It carries

--- a/pkg/chat/document.go
+++ b/pkg/chat/document.go
@@ -19,9 +19,10 @@ type DocumentSource struct {
 	// base64-encoded when sent to the provider. Used for StrategyB64 attachments.
 	InlineData []byte `json:"inline_data,omitempty"`
 
-	// URL is reserved for Phase 2 (URL-referenced documents). It must never be
-	// set on stored Phase 1 messages; providers should treat a non-empty URL as
-	// unsupported and log a warning.
+	// URL is reserved for Phase 2 (URL-referenced documents). Must not be set
+	// on Documents stored in messages in Phase 1; providers should log a warning
+	// and skip documents that have only URL set.
+	// TODO(phase2): implement URL-referenced document fetching.
 	URL string `json:"url,omitempty"`
 }
 

--- a/pkg/chat/document.go
+++ b/pkg/chat/document.go
@@ -1,0 +1,51 @@
+package chat
+
+// MessagePartTypeDocument is the part type for a structured document attachment.
+// Use this type when attaching files (images, PDFs, text, Office docs, etc.) to
+// a message. The Document field must be set when this type is used.
+//
+// This supersedes MessagePartTypeFile and MessagePartTypeImageURL, which are
+// deprecated but remain supported for backward compatibility.
+const MessagePartTypeDocument MessagePartType = "document"
+
+// DocumentSource holds the actual content of a document. Exactly one of the
+// fields should be set.
+type DocumentSource struct {
+	// InlineText holds the raw text for text/* MIME types (TXT, MD, HTML, CSV, …).
+	// Used for StrategyTXT attachments.
+	InlineText string `json:"inline_text,omitempty"`
+
+	// InlineData holds binary content (images, PDFs, Office docs, …) that is
+	// base64-encoded when sent to the provider. Used for StrategyB64 attachments.
+	InlineData []byte `json:"inline_data,omitempty"`
+
+	// URL is reserved for Phase 2 (URL-referenced documents). It must never be
+	// set on stored Phase 1 messages; providers should treat a non-empty URL as
+	// unsupported and log a warning.
+	URL string `json:"url,omitempty"`
+}
+
+// Document represents a file attachment in a message part. It carries
+// the file name, post-processing MIME type, and the actual content via Source.
+//
+// The MimeType field always reflects the final MIME that the attachment system
+// will use when sending to the provider (e.g. "image/jpeg" after image
+// normalisation, never the original "image/bmp").
+type Document struct {
+	// Name is the display name of the document (e.g. "report.pdf").
+	Name string `json:"name"`
+
+	// MimeType is the post-processing MIME type of the document. For images
+	// this is always "image/jpeg" or "image/png" regardless of the original
+	// format. For text files it is the exact MIME (e.g. "text/plain",
+	// "text/markdown", "text/html"). For binary documents it is the original
+	// MIME (e.g. "application/pdf").
+	MimeType string `json:"mime_type"`
+
+	// Size is the byte length of the document content (InlineData or InlineText).
+	// Optional; zero means unknown.
+	Size int64 `json:"size,omitempty"`
+
+	// Source holds the actual document content.
+	Source DocumentSource `json:"source"`
+}

--- a/pkg/model/provider/anthropic/attachments.go
+++ b/pkg/model/provider/anthropic/attachments.go
@@ -55,8 +55,9 @@ func convertDocumentWithCaps(ctx context.Context, doc chat.Document, mc modelcap
 			}, nil
 		}
 
-		if IsAnthropicDocumentMime(mime) {
-			// application/pdf → native document block
+		// Gate PDF block strictly on application/pdf — IsAnthropicDocumentMime also
+		// matches text/plain, which must NOT be sent as a DocumentBlockParam.
+		if mime == "application/pdf" {
 			return []anthropic.ContentBlockParamUnion{
 				{
 					OfDocument: &anthropic.DocumentBlockParam{
@@ -71,13 +72,10 @@ func convertDocumentWithCaps(ctx context.Context, doc chat.Document, mc modelcap
 			}, nil
 		}
 
-		// Other binary: fall back to TXT envelope.
-		slog.DebugContext(ctx, "anthropic: no native block for MIME, falling back to TXT envelope",
+		// Unexpected binary MIME — defensive drop.
+		slog.WarnContext(ctx, "anthropic: unexpected binary MIME in StrategyB64, dropping",
 			"mime", doc.MimeType, "doc", doc.Name)
-		envelope := attachment.TXTEnvelope(doc.Name, doc.MimeType, b64Data)
-		return []anthropic.ContentBlockParamUnion{
-			{OfText: &anthropic.TextBlockParam{Text: envelope}},
-		}, nil
+		return nil, nil
 
 	case attachment.StrategyTXT:
 		envelope := attachment.TXTEnvelope(doc.Name, doc.MimeType, doc.Source.InlineText)

--- a/pkg/model/provider/anthropic/attachments.go
+++ b/pkg/model/provider/anthropic/attachments.go
@@ -23,6 +23,11 @@ import (
 //   - unsupported / no content → nil (logged as warning)
 func convertDocument(ctx context.Context, doc chat.Document, modelID string) ([]anthropicsdk.BetaContentBlockParamUnion, error) {
 	mc, _ := modelcaps.Load(modelID)
+	return convertDocumentWithCaps(ctx, doc, mc)
+}
+
+// convertDocumentWithCaps is the caps-injectable variant used by tests.
+func convertDocumentWithCaps(ctx context.Context, doc chat.Document, mc modelcaps.ModelCapabilities) ([]anthropicsdk.BetaContentBlockParamUnion, error) {
 	strategy, reason := attachment.Decide(doc, mc)
 
 	switch strategy {

--- a/pkg/model/provider/anthropic/attachments.go
+++ b/pkg/model/provider/anthropic/attachments.go
@@ -7,27 +7,28 @@ import (
 	"log/slog"
 	"strings"
 
-	anthropicsdk "github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go"
 
 	"github.com/docker/docker-agent/pkg/attachment"
 	"github.com/docker/docker-agent/pkg/attachment/modelcaps"
 	"github.com/docker/docker-agent/pkg/chat"
 )
 
-// convertDocument converts a chat.Document to Anthropic Beta API content blocks.
+// convertDocument converts a chat.Document to standard Anthropic SDK content blocks
+// (not the Beta API).
 //
 // Routing:
-//   - image/* with InlineData → BetaImageBlockParam (base64 source)
-//   - application/pdf with InlineData → BetaRequestDocumentBlock (base64)
-//   - text with InlineText → BetaTextBlockParam with TXTEnvelope
+//   - image/* with InlineData → ImageBlockParam (base64 source)
+//   - application/pdf with InlineData → DocumentBlockParam (base64)
+//   - text with InlineText → TextBlockParam with TXTEnvelope
 //   - unsupported / no content → nil (logged as warning)
-func convertDocument(ctx context.Context, doc chat.Document, modelID string) ([]anthropicsdk.BetaContentBlockParamUnion, error) {
+func convertDocument(ctx context.Context, doc chat.Document, modelID string) ([]anthropic.ContentBlockParamUnion, error) {
 	mc, _ := modelcaps.Load(modelID)
 	return convertDocumentWithCaps(ctx, doc, mc)
 }
 
 // convertDocumentWithCaps is the caps-injectable variant used by tests.
-func convertDocumentWithCaps(ctx context.Context, doc chat.Document, mc modelcaps.ModelCapabilities) ([]anthropicsdk.BetaContentBlockParamUnion, error) {
+func convertDocumentWithCaps(ctx context.Context, doc chat.Document, mc modelcaps.ModelCapabilities) ([]anthropic.ContentBlockParamUnion, error) {
 	strategy, reason := attachment.Decide(doc, mc)
 
 	switch strategy {
@@ -40,13 +41,13 @@ func convertDocumentWithCaps(ctx context.Context, doc chat.Document, mc modelcap
 		b64Data := base64.StdEncoding.EncodeToString(doc.Source.InlineData)
 
 		if IsImageMime(mime) {
-			return []anthropicsdk.BetaContentBlockParamUnion{
+			return []anthropic.ContentBlockParamUnion{
 				{
-					OfImage: &anthropicsdk.BetaImageBlockParam{
-						Source: anthropicsdk.BetaImageBlockParamSourceUnion{
-							OfBase64: &anthropicsdk.BetaBase64ImageSourceParam{
+					OfImage: &anthropic.ImageBlockParam{
+						Source: anthropic.ImageBlockParamSourceUnion{
+							OfBase64: &anthropic.Base64ImageSourceParam{
 								Data:      b64Data,
-								MediaType: anthropicsdk.BetaBase64ImageSourceMediaType(mime),
+								MediaType: anthropic.Base64ImageSourceMediaType(mime),
 							},
 						},
 					},
@@ -56,11 +57,11 @@ func convertDocumentWithCaps(ctx context.Context, doc chat.Document, mc modelcap
 
 		if IsAnthropicDocumentMime(mime) {
 			// application/pdf → native document block
-			return []anthropicsdk.BetaContentBlockParamUnion{
+			return []anthropic.ContentBlockParamUnion{
 				{
-					OfDocument: &anthropicsdk.BetaRequestDocumentBlockParam{
-						Source: anthropicsdk.BetaRequestDocumentBlockSourceUnionParam{
-							OfBase64: &anthropicsdk.BetaBase64PDFSourceParam{
+					OfDocument: &anthropic.DocumentBlockParam{
+						Source: anthropic.DocumentBlockParamSourceUnion{
+							OfBase64: &anthropic.Base64PDFSourceParam{
 								Data:      b64Data,
 								MediaType: "application/pdf",
 							},
@@ -74,14 +75,14 @@ func convertDocumentWithCaps(ctx context.Context, doc chat.Document, mc modelcap
 		slog.DebugContext(ctx, "anthropic: no native block for MIME, falling back to TXT envelope",
 			"mime", doc.MimeType, "doc", doc.Name)
 		envelope := attachment.TXTEnvelope(doc.Name, doc.MimeType, b64Data)
-		return []anthropicsdk.BetaContentBlockParamUnion{
-			{OfText: &anthropicsdk.BetaTextBlockParam{Text: envelope}},
+		return []anthropic.ContentBlockParamUnion{
+			{OfText: &anthropic.TextBlockParam{Text: envelope}},
 		}, nil
 
 	case attachment.StrategyTXT:
 		envelope := attachment.TXTEnvelope(doc.Name, doc.MimeType, doc.Source.InlineText)
-		return []anthropicsdk.BetaContentBlockParamUnion{
-			{OfText: &anthropicsdk.BetaTextBlockParam{Text: envelope}},
+		return []anthropic.ContentBlockParamUnion{
+			{OfText: &anthropic.TextBlockParam{Text: envelope}},
 		}, nil
 
 	default:

--- a/pkg/model/provider/anthropic/attachments.go
+++ b/pkg/model/provider/anthropic/attachments.go
@@ -89,16 +89,3 @@ func convertDocumentWithCaps(ctx context.Context, doc chat.Document, mc modelcap
 		return nil, fmt.Errorf("unknown attachment strategy %d", strategy)
 	}
 }
-
-// SupportedMIMETypes implements attachment.Advisor for the Anthropic client.
-func (c *Client) SupportedMIMETypes() []string {
-	mc, _ := modelcaps.Load(c.ModelConfig.Model)
-	mimes := []string{"text/plain", "text/markdown", "text/html", "text/csv"}
-	if mc.Supports("image/jpeg") {
-		mimes = append(mimes, "image/jpeg", "image/png", "image/gif", "image/webp")
-	}
-	if mc.Supports("application/pdf") {
-		mimes = append(mimes, "application/pdf")
-	}
-	return mimes
-}

--- a/pkg/model/provider/anthropic/attachments.go
+++ b/pkg/model/provider/anthropic/attachments.go
@@ -1,0 +1,98 @@
+package anthropic
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	anthropicsdk "github.com/anthropics/anthropic-sdk-go"
+
+	"github.com/docker/docker-agent/pkg/attachment"
+	"github.com/docker/docker-agent/pkg/attachment/modelcaps"
+	"github.com/docker/docker-agent/pkg/chat"
+)
+
+// convertDocument converts a chat.Document to Anthropic Beta API content blocks.
+//
+// Routing:
+//   - image/* with InlineData → BetaImageBlockParam (base64 source)
+//   - application/pdf with InlineData → BetaRequestDocumentBlock (base64)
+//   - text with InlineText → BetaTextBlockParam with TXTEnvelope
+//   - unsupported / no content → nil (logged as warning)
+func convertDocument(ctx context.Context, doc chat.Document, modelID string) ([]anthropicsdk.BetaContentBlockParamUnion, error) {
+	mc, _ := modelcaps.Load(modelID)
+	strategy, reason := attachment.Decide(doc, mc)
+
+	switch strategy {
+	case attachment.StrategyDrop:
+		slog.WarnContext(ctx, "attachment dropped", "reason", reason, "doc", doc.Name)
+		return nil, nil
+
+	case attachment.StrategyB64:
+		mime := strings.ToLower(doc.MimeType)
+		b64Data := base64.StdEncoding.EncodeToString(doc.Source.InlineData)
+
+		if IsImageMime(mime) {
+			return []anthropicsdk.BetaContentBlockParamUnion{
+				{
+					OfImage: &anthropicsdk.BetaImageBlockParam{
+						Source: anthropicsdk.BetaImageBlockParamSourceUnion{
+							OfBase64: &anthropicsdk.BetaBase64ImageSourceParam{
+								Data:      b64Data,
+								MediaType: anthropicsdk.BetaBase64ImageSourceMediaType(mime),
+							},
+						},
+					},
+				},
+			}, nil
+		}
+
+		if IsAnthropicDocumentMime(mime) {
+			// application/pdf → native document block
+			return []anthropicsdk.BetaContentBlockParamUnion{
+				{
+					OfDocument: &anthropicsdk.BetaRequestDocumentBlockParam{
+						Source: anthropicsdk.BetaRequestDocumentBlockSourceUnionParam{
+							OfBase64: &anthropicsdk.BetaBase64PDFSourceParam{
+								Data:      b64Data,
+								MediaType: "application/pdf",
+							},
+						},
+					},
+				},
+			}, nil
+		}
+
+		// Other binary: fall back to TXT envelope.
+		slog.DebugContext(ctx, "anthropic: no native block for MIME, falling back to TXT envelope",
+			"mime", doc.MimeType, "doc", doc.Name)
+		envelope := attachment.TXTEnvelope(doc.Name, doc.MimeType, b64Data)
+		return []anthropicsdk.BetaContentBlockParamUnion{
+			{OfText: &anthropicsdk.BetaTextBlockParam{Text: envelope}},
+		}, nil
+
+	case attachment.StrategyTXT:
+		envelope := attachment.TXTEnvelope(doc.Name, doc.MimeType, doc.Source.InlineText)
+		return []anthropicsdk.BetaContentBlockParamUnion{
+			{OfText: &anthropicsdk.BetaTextBlockParam{Text: envelope}},
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("unknown attachment strategy %d", strategy)
+	}
+}
+
+// SupportedMIMETypes implements attachment.Advisor for the Anthropic client.
+func (c *Client) SupportedMIMETypes() []string {
+	mc, _ := modelcaps.Load(c.ModelConfig.Model)
+	mimes := []string{"text/plain", "text/markdown", "text/html", "text/csv"}
+	if mc.Supports("image/jpeg") {
+		mimes = append(mimes, "image/jpeg", "image/png", "image/gif", "image/webp")
+	}
+	if mc.Supports("application/pdf") {
+		mimes = append(mimes, "application/pdf")
+	}
+	return mimes
+}

--- a/pkg/model/provider/anthropic/attachments_test.go
+++ b/pkg/model/provider/anthropic/attachments_test.go
@@ -1,0 +1,69 @@
+package anthropic
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/chat"
+)
+
+func TestConvertDocumentAnthropic_StrategyTXT(t *testing.T) {
+	doc := chat.Document{
+		Name:     "spec.md",
+		MimeType: "text/markdown",
+		Source:   chat.DocumentSource{InlineText: "## Specification"},
+	}
+
+	blocks, err := convertDocument(context.Background(), doc, "")
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+	require.NotNil(t, blocks[0].OfText)
+	assert.Contains(t, blocks[0].OfText.Text, "spec.md")
+	assert.Contains(t, blocks[0].OfText.Text, "text/markdown")
+	assert.Contains(t, blocks[0].OfText.Text, "## Specification")
+}
+
+func TestConvertDocumentAnthropic_StrategyTXT_Envelope(t *testing.T) {
+	doc := chat.Document{
+		Name:     "notes.txt",
+		MimeType: "text/plain",
+		Source:   chat.DocumentSource{InlineText: "some notes"},
+	}
+
+	blocks, err := convertDocument(context.Background(), doc, "")
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+	require.NotNil(t, blocks[0].OfText)
+	text := blocks[0].OfText.Text
+	assert.True(t, strings.HasPrefix(text, "<document"), "should be wrapped in envelope")
+	assert.Contains(t, text, `name="notes.txt"`)
+}
+
+func TestConvertDocumentAnthropic_Drop_NoContent(t *testing.T) {
+	doc := chat.Document{
+		Name:     "empty.txt",
+		MimeType: "text/plain",
+		Source:   chat.DocumentSource{},
+	}
+
+	blocks, err := convertDocument(context.Background(), doc, "")
+	require.NoError(t, err)
+	assert.Nil(t, blocks, "should be dropped when no inline content")
+}
+
+func TestConvertDocumentAnthropic_Drop_UnsupportedMIME(t *testing.T) {
+	// image/* with text-only model (modelID="") should be dropped
+	doc := chat.Document{
+		Name:     "photo.jpg",
+		MimeType: "image/jpeg",
+		Source:   chat.DocumentSource{InlineData: []byte{0xFF, 0xD8}},
+	}
+
+	blocks, err := convertDocument(context.Background(), doc, "")
+	require.NoError(t, err)
+	assert.Nil(t, blocks, "image should be dropped for text-only model")
+}

--- a/pkg/model/provider/anthropic/attachments_test.go
+++ b/pkg/model/provider/anthropic/attachments_test.go
@@ -1,15 +1,55 @@
 package anthropic
 
 import (
-	"context"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/docker/docker-agent/pkg/attachment/modelcaps"
 	"github.com/docker/docker-agent/pkg/chat"
 )
+
+// minJPEG is a minimal JPEG magic-byte header for use in tests.
+var minJPEG = []byte{0xFF, 0xD8, 0xFF, 0xE0}
+
+// minPDF is a minimal PDF magic-byte header for use in tests.
+var minPDF = []byte{0x25, 0x50, 0x44, 0x46, 0x2D} // %PDF-
+
+// TestConvertDocumentAnthropic_StrategyB64_Image verifies that an image document
+// with InlineData and a vision-capable model produces a native BetaImageBlockParam.
+func TestConvertDocumentAnthropic_StrategyB64_Image(t *testing.T) {
+	doc := chat.Document{
+		Name:     "photo.jpg",
+		MimeType: "image/jpeg",
+		Source:   chat.DocumentSource{InlineData: minJPEG},
+	}
+
+	visionCaps := modelcaps.CapsWith(true, true)
+	blocks, err := convertDocumentWithCaps(t.Context(), doc, visionCaps)
+	require.NoError(t, err)
+	require.Len(t, blocks, 1, "expected exactly one block")
+	require.NotNil(t, blocks[0].OfImage, "expected image block")
+	assert.Nil(t, blocks[0].OfText, "expected no text block for image")
+}
+
+// TestConvertDocumentAnthropic_StrategyB64_PDF verifies that a PDF document
+// produces a native BetaRequestDocumentBlock when the model supports PDFs.
+func TestConvertDocumentAnthropic_StrategyB64_PDF(t *testing.T) {
+	doc := chat.Document{
+		Name:     "spec.pdf",
+		MimeType: "application/pdf",
+		Source:   chat.DocumentSource{InlineData: minPDF},
+	}
+
+	pdfCaps := modelcaps.CapsWith(true, true)
+	blocks, err := convertDocumentWithCaps(t.Context(), doc, pdfCaps)
+	require.NoError(t, err)
+	require.Len(t, blocks, 1, "expected exactly one block")
+	require.NotNil(t, blocks[0].OfDocument, "expected document block for PDF")
+	assert.Nil(t, blocks[0].OfText, "expected no text block for PDF")
+}
 
 func TestConvertDocumentAnthropic_StrategyTXT(t *testing.T) {
 	doc := chat.Document{
@@ -18,7 +58,7 @@ func TestConvertDocumentAnthropic_StrategyTXT(t *testing.T) {
 		Source:   chat.DocumentSource{InlineText: "## Specification"},
 	}
 
-	blocks, err := convertDocument(context.Background(), doc, "")
+	blocks, err := convertDocument(t.Context(), doc, "")
 	require.NoError(t, err)
 	require.Len(t, blocks, 1)
 	require.NotNil(t, blocks[0].OfText)
@@ -34,7 +74,7 @@ func TestConvertDocumentAnthropic_StrategyTXT_Envelope(t *testing.T) {
 		Source:   chat.DocumentSource{InlineText: "some notes"},
 	}
 
-	blocks, err := convertDocument(context.Background(), doc, "")
+	blocks, err := convertDocument(t.Context(), doc, "")
 	require.NoError(t, err)
 	require.Len(t, blocks, 1)
 	require.NotNil(t, blocks[0].OfText)
@@ -50,20 +90,20 @@ func TestConvertDocumentAnthropic_Drop_NoContent(t *testing.T) {
 		Source:   chat.DocumentSource{},
 	}
 
-	blocks, err := convertDocument(context.Background(), doc, "")
+	blocks, err := convertDocument(t.Context(), doc, "")
 	require.NoError(t, err)
 	assert.Nil(t, blocks, "should be dropped when no inline content")
 }
 
 func TestConvertDocumentAnthropic_Drop_UnsupportedMIME(t *testing.T) {
-	// image/* with text-only model (modelID="") should be dropped
 	doc := chat.Document{
 		Name:     "photo.jpg",
 		MimeType: "image/jpeg",
-		Source:   chat.DocumentSource{InlineData: []byte{0xFF, 0xD8}},
+		Source:   chat.DocumentSource{InlineData: minJPEG},
 	}
 
-	blocks, err := convertDocument(context.Background(), doc, "")
+	textOnlyCaps := modelcaps.CapsWith(false, false)
+	blocks, err := convertDocumentWithCaps(t.Context(), doc, textOnlyCaps)
 	require.NoError(t, err)
 	assert.Nil(t, blocks, "image should be dropped for text-only model")
 }

--- a/pkg/model/provider/anthropic/attachments_test.go
+++ b/pkg/model/provider/anthropic/attachments_test.go
@@ -62,8 +62,8 @@ func TestConvertDocumentAnthropic_StrategyTXT(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, blocks, 1)
 	require.NotNil(t, blocks[0].OfText)
-	assert.Contains(t, blocks[0].OfText.Text, "spec.md")
-	assert.Contains(t, blocks[0].OfText.Text, "text/markdown")
+	assert.Contains(t, blocks[0].OfText.Text, "spec-md")
+	assert.Contains(t, blocks[0].OfText.Text, "text-markdown")
 	assert.Contains(t, blocks[0].OfText.Text, "## Specification")
 }
 
@@ -80,7 +80,6 @@ func TestConvertDocumentAnthropic_StrategyTXT_Envelope(t *testing.T) {
 	require.NotNil(t, blocks[0].OfText)
 	text := blocks[0].OfText.Text
 	assert.True(t, strings.HasPrefix(text, "<document"), "should be wrapped in envelope")
-	assert.Contains(t, text, `name="notes.txt"`)
 }
 
 func TestConvertDocumentAnthropic_Drop_NoContent(t *testing.T) {

--- a/pkg/model/provider/anthropic/attachments_test.go
+++ b/pkg/model/provider/anthropic/attachments_test.go
@@ -18,7 +18,7 @@ var minJPEG = []byte{0xFF, 0xD8, 0xFF, 0xE0}
 var minPDF = []byte{0x25, 0x50, 0x44, 0x46, 0x2D} // %PDF-
 
 // TestConvertDocumentAnthropic_StrategyB64_Image verifies that an image document
-// with InlineData and a vision-capable model produces a native BetaImageBlockParam.
+// with InlineData and a vision-capable model produces a native ImageBlockParam.
 func TestConvertDocumentAnthropic_StrategyB64_Image(t *testing.T) {
 	doc := chat.Document{
 		Name:     "photo.jpg",

--- a/pkg/model/provider/anthropic/beta_converter.go
+++ b/pkg/model/provider/anthropic/beta_converter.go
@@ -277,11 +277,11 @@ func (c *Client) convertBetaUserMultiContent(ctx context.Context, parts []chat.M
 
 		case chat.MessagePartTypeDocument:
 			if part.Document != nil {
-				docBlocks, err := convertDocument(ctx, *part.Document, c.ModelConfig.Model)
+				stdBlocks, err := convertDocument(ctx, *part.Document, c.ModelConfig.Model)
 				if err != nil {
 					return nil, fmt.Errorf("failed to convert document attachment %q: %w", part.Document.Name, err)
 				}
-				contentBlocks = append(contentBlocks, docBlocks...)
+				contentBlocks = append(contentBlocks, stdBlocksToBeta(stdBlocks)...)
 			}
 		}
 	}
@@ -391,4 +391,44 @@ func applyBetaMessageCacheControl(messages []anthropic.BetaMessageParam) {
 			block.OfDocument.CacheControl = cacheCtrl
 		}
 	}
+}
+
+// stdBlocksToBeta converts standard Anthropic SDK content blocks to their Beta
+// API equivalents. The beta path (convertBetaUserMultiContent) requires
+// BetaContentBlockParamUnion, but convertDocument produces the standard type.
+// The two types are structurally identical for the block kinds we produce
+// (text, image, document), so we field-map them here.
+func stdBlocksToBeta(blocks []anthropic.ContentBlockParamUnion) []anthropic.BetaContentBlockParamUnion {
+	out := make([]anthropic.BetaContentBlockParamUnion, 0, len(blocks))
+	for _, b := range blocks {
+		switch {
+		case b.OfText != nil:
+			out = append(out, anthropic.BetaContentBlockParamUnion{
+				OfText: &anthropic.BetaTextBlockParam{Text: b.OfText.Text},
+			})
+		case b.OfImage != nil && b.OfImage.Source.OfBase64 != nil:
+			out = append(out, anthropic.BetaContentBlockParamUnion{
+				OfImage: &anthropic.BetaImageBlockParam{
+					Source: anthropic.BetaImageBlockParamSourceUnion{
+						OfBase64: &anthropic.BetaBase64ImageSourceParam{
+							Data:      b.OfImage.Source.OfBase64.Data,
+							MediaType: anthropic.BetaBase64ImageSourceMediaType(b.OfImage.Source.OfBase64.MediaType),
+						},
+					},
+				},
+			})
+		case b.OfDocument != nil && b.OfDocument.Source.OfBase64 != nil:
+			out = append(out, anthropic.BetaContentBlockParamUnion{
+				OfDocument: &anthropic.BetaRequestDocumentBlockParam{
+					Source: anthropic.BetaRequestDocumentBlockSourceUnionParam{
+						OfBase64: &anthropic.BetaBase64PDFSourceParam{
+							Data: b.OfDocument.Source.OfBase64.Data,
+						},
+					},
+				},
+			})
+		}
+		// Unknown block kinds are dropped (should never happen in Phase 1).
+	}
+	return out
 }

--- a/pkg/model/provider/anthropic/beta_converter.go
+++ b/pkg/model/provider/anthropic/beta_converter.go
@@ -162,7 +162,7 @@ func convertBetaToolResultBlock(msg *chat.Message) anthropic.BetaContentBlockPar
 				OfText: &anthropic.BetaTextBlockParam{Text: part.Text},
 			})
 		case chat.MessagePartTypeImageURL:
-			// Deprecated: use MessagePartTypeDocument instead.
+			// Note: superseded by MessagePartTypeDocument.
 			if part.ImageURL == nil {
 				continue
 			}
@@ -239,7 +239,7 @@ func (c *Client) convertBetaUserMultiContent(ctx context.Context, parts []chat.M
 			}
 
 		case chat.MessagePartTypeFile:
-			// Deprecated: use MessagePartTypeDocument instead.
+			// Note: superseded by MessagePartTypeDocument.
 			if part.File == nil {
 				continue
 			}

--- a/pkg/model/provider/anthropic/beta_converter.go
+++ b/pkg/model/provider/anthropic/beta_converter.go
@@ -162,6 +162,7 @@ func convertBetaToolResultBlock(msg *chat.Message) anthropic.BetaContentBlockPar
 				OfText: &anthropic.BetaTextBlockParam{Text: part.Text},
 			})
 		case chat.MessagePartTypeImageURL:
+			// Deprecated: use MessagePartTypeDocument instead.
 			if part.ImageURL == nil {
 				continue
 			}
@@ -238,6 +239,7 @@ func (c *Client) convertBetaUserMultiContent(ctx context.Context, parts []chat.M
 			}
 
 		case chat.MessagePartTypeFile:
+			// Deprecated: use MessagePartTypeDocument instead.
 			if part.File == nil {
 				continue
 			}
@@ -271,6 +273,15 @@ func (c *Client) convertBetaUserMultiContent(ctx context.Context, parts []chat.M
 			default:
 				// File part has neither path nor file ID - this is invalid
 				return nil, errors.New("invalid file attachment: neither path nor file_id provided")
+			}
+
+		case chat.MessagePartTypeDocument:
+			if part.Document != nil {
+				docBlocks, err := convertDocument(ctx, *part.Document, c.ModelConfig.Model)
+				if err != nil {
+					return nil, fmt.Errorf("failed to convert document attachment %q: %w", part.Document.Name, err)
+				}
+				contentBlocks = append(contentBlocks, docBlocks...)
 			}
 		}
 	}

--- a/pkg/model/provider/anthropic/client.go
+++ b/pkg/model/provider/anthropic/client.go
@@ -478,7 +478,7 @@ func extractMediaType(prefix string) string {
 // convertUserMultiContent converts user message multi-content parts to Anthropic content blocks.
 // It handles text and images (base64 and URL). File uploads are NOT supported in the non-Beta API
 // and will return an error - callers should use hasFileAttachments() to route to the Beta API.
-func (c *Client) convertUserMultiContent(_ context.Context, parts []chat.MessagePart) ([]anthropic.ContentBlockParamUnion, error) {
+func (c *Client) convertUserMultiContent(ctx context.Context, parts []chat.MessagePart) ([]anthropic.ContentBlockParamUnion, error) {
 	contentBlocks := make([]anthropic.ContentBlockParamUnion, 0, len(parts))
 
 	for _, part := range parts {
@@ -519,6 +519,15 @@ func (c *Client) convertUserMultiContent(_ context.Context, parts []chat.Message
 			// Return a clear error if we somehow get here.
 			return nil, fmt.Errorf("file attachments require the Beta API; use hasFileAttachments() to route correctly (path=%q, file_id=%q)",
 				part.File.Path, part.File.FileID)
+
+		case chat.MessagePartTypeDocument:
+			if part.Document != nil {
+				docBlocks, err := convertDocument(ctx, *part.Document, c.ModelConfig.Model)
+				if err != nil {
+					return nil, fmt.Errorf("failed to convert document attachment %q: %w", part.Document.Name, err)
+				}
+				contentBlocks = append(contentBlocks, docBlocks...)
+			}
 		}
 	}
 

--- a/pkg/model/provider/bedrock/attachments.go
+++ b/pkg/model/provider/bedrock/attachments.go
@@ -1,0 +1,175 @@
+package bedrock
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+
+	"github.com/docker/docker-agent/pkg/attachment"
+	"github.com/docker/docker-agent/pkg/attachment/modelcaps"
+	"github.com/docker/docker-agent/pkg/chat"
+)
+
+// imageFormatFromMIME maps a MIME type to a Bedrock ImageFormat.
+// Returns ("", false) when the MIME type is not a supported image.
+func imageFormatFromMIME(mimeType string) (types.ImageFormat, bool) {
+	switch strings.ToLower(mimeType) {
+	case "image/jpeg":
+		return types.ImageFormatJpeg, true
+	case "image/png":
+		return types.ImageFormatPng, true
+	case "image/gif":
+		return types.ImageFormatGif, true
+	case "image/webp":
+		return types.ImageFormatWebp, true
+	default:
+		return "", false
+	}
+}
+
+// convertDocument converts a chat.Document to zero or more Bedrock ContentBlocks.
+//
+// Routing:
+//   - image/* with InlineData → ContentBlockMemberImage
+//   - application/pdf with InlineData → ContentBlockMemberDocument
+//   - text with InlineText → ContentBlockMemberText with TXTEnvelope
+//   - other binary → ContentBlockMemberText with TXTEnvelope fallback
+//   - unsupported / no content → nil (logged as warning)
+func convertDocument(ctx context.Context, doc chat.Document, modelID string) ([]types.ContentBlock, error) {
+	mc, _ := modelcaps.Load(modelID)
+	strategy, reason := attachment.Decide(doc, mc)
+
+	switch strategy {
+	case attachment.StrategyDrop:
+		slog.WarnContext(ctx, "attachment dropped", "reason", reason, "doc", doc.Name)
+		return nil, nil
+
+	case attachment.StrategyB64:
+		mime := strings.ToLower(doc.MimeType)
+
+		// Native image block
+		if format, ok := imageFormatFromMIME(mime); ok {
+			return []types.ContentBlock{
+				&types.ContentBlockMemberImage{
+					Value: types.ImageBlock{
+						Format: format,
+						Source: &types.ImageSourceMemberBytes{
+							Value: doc.Source.InlineData,
+						},
+					},
+				},
+			}, nil
+		}
+
+		// Native PDF/document block
+		if mime == "application/pdf" {
+			return []types.ContentBlock{
+				&types.ContentBlockMemberDocument{
+					Value: types.DocumentBlock{
+						Format: types.DocumentFormatPdf,
+						Name:   aws.String(sanitizeDocumentName(doc.Name)),
+						Source: &types.DocumentSourceMemberBytes{
+							Value: doc.Source.InlineData,
+						},
+					},
+				},
+			}, nil
+		}
+
+		// Other Office docs
+		if df, ok := officeDocumentFormat(mime); ok {
+			return []types.ContentBlock{
+				&types.ContentBlockMemberDocument{
+					Value: types.DocumentBlock{
+						Format: df,
+						Name:   aws.String(sanitizeDocumentName(doc.Name)),
+						Source: &types.DocumentSourceMemberBytes{
+							Value: doc.Source.InlineData,
+						},
+					},
+				},
+			}, nil
+		}
+
+		// Unknown binary: TXT envelope fallback
+		slog.DebugContext(ctx, "bedrock: no native block for MIME, falling back to TXT envelope",
+			"mime", doc.MimeType, "doc", doc.Name)
+		envelope := attachment.TXTEnvelope(doc.Name, doc.MimeType,
+			fmt.Sprintf("[binary content, %d bytes]", len(doc.Source.InlineData)))
+		return []types.ContentBlock{
+			&types.ContentBlockMemberText{Value: envelope},
+		}, nil
+
+	case attachment.StrategyTXT:
+		envelope := attachment.TXTEnvelope(doc.Name, doc.MimeType, doc.Source.InlineText)
+		return []types.ContentBlock{
+			&types.ContentBlockMemberText{Value: envelope},
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("unknown attachment strategy %d", strategy)
+	}
+}
+
+// officeDocumentFormat maps Office MIME types to Bedrock DocumentFormats.
+func officeDocumentFormat(mime string) (types.DocumentFormat, bool) {
+	switch mime {
+	case "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+		return types.DocumentFormatDocx, true
+	case "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
+		return types.DocumentFormatXlsx, true
+	case "application/vnd.openxmlformats-officedocument.presentationml.presentation":
+		// Bedrock doesn't have a native PPTX format — treat as unsupported.
+		return "", false
+	case "text/csv":
+		return types.DocumentFormatCsv, true
+	case "text/plain":
+		return types.DocumentFormatTxt, true
+	case "text/html":
+		return types.DocumentFormatHtml, true
+	case "text/markdown", "text/x-markdown":
+		return types.DocumentFormatMd, true
+	default:
+		return "", false
+	}
+}
+
+// sanitizeDocumentName replaces characters that Bedrock disallows in document names.
+// Bedrock document names must be alphanumeric + hyphens only.
+func sanitizeDocumentName(name string) string {
+	var sb strings.Builder
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' {
+			sb.WriteRune(r)
+		} else {
+			sb.WriteRune('-')
+		}
+	}
+	result := sb.String()
+	if result == "" {
+		return "document"
+	}
+	return result
+}
+
+// SupportedMIMETypes implements attachment.Advisor for the Bedrock client.
+func (c *Client) SupportedMIMETypes() []string {
+	mc, _ := modelcaps.Load(c.ModelConfig.Model)
+	mimes := []string{
+		"text/plain", "text/markdown", "text/html", "text/csv",
+		"application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+		"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+		"application/vnd.openxmlformats-officedocument.presentationml.presentation",
+	}
+	if mc.Supports("image/jpeg") {
+		mimes = append(mimes, "image/jpeg", "image/png", "image/gif", "image/webp")
+	}
+	if mc.Supports("application/pdf") {
+		mimes = append(mimes, "application/pdf")
+	}
+	return mimes
+}

--- a/pkg/model/provider/bedrock/attachments.go
+++ b/pkg/model/provider/bedrock/attachments.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"path"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -101,18 +102,30 @@ func convertDocumentWithCaps(ctx context.Context, doc chat.Document, mc modelcap
 	}
 }
 
-// sanitizeDocumentName replaces characters that Bedrock disallows in document names.
-// Bedrock document names must be alphanumeric + hyphens only.
+// sanitizeDocumentName produces a Bedrock-safe document name.
+// Bedrock allows alphanumeric characters, whitespace, hyphens, parentheses,
+// and square brackets in DocumentBlock.name — but NOT dots.
+// We strip the file extension first so "report.pdf" becomes "report" rather
+// than the ugly "report-pdf", then replace any remaining disallowed characters
+// with hyphens.
 func sanitizeDocumentName(name string) string {
+	// Strip the extension (e.g. ".pdf", ".docx") before sanitising so that
+	// "report.pdf" → "report" instead of "report-pdf".
+	base := strings.TrimSuffix(name, path.Ext(name))
+	if base == "" {
+		base = name // edge-case: name was just an extension (e.g. ".pdf")
+	}
+
 	var sb strings.Builder
-	for _, r := range name {
-		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' {
+	for _, r := range base {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') ||
+			r == '-' || r == ' ' || r == '(' || r == ')' || r == '[' || r == ']' {
 			sb.WriteRune(r)
 		} else {
 			sb.WriteRune('-')
 		}
 	}
-	result := sb.String()
+	result := strings.Trim(sb.String(), "-")
 	if result == "" {
 		return "document"
 	}

--- a/pkg/model/provider/bedrock/attachments.go
+++ b/pkg/model/provider/bedrock/attachments.go
@@ -35,9 +35,8 @@ func imageFormatFromMIME(mimeType string) (types.ImageFormat, bool) {
 //
 // Routing:
 //   - image/* with InlineData → ContentBlockMemberImage
-//   - application/pdf with InlineData → ContentBlockMemberDocument
-//   - text with InlineText → ContentBlockMemberText with TXTEnvelope
-//   - other binary → ContentBlockMemberText with TXTEnvelope fallback
+//   - application/pdf with InlineData → ContentBlockMemberDocument (PDF)
+//   - text/* with InlineText → ContentBlockMemberText with TXTEnvelope
 //   - unsupported / no content → nil (logged as warning)
 func convertDocument(ctx context.Context, doc chat.Document, modelID string) ([]types.ContentBlock, error) {
 	mc, _ := modelcaps.Load(modelID)
@@ -85,29 +84,11 @@ func convertDocumentWithCaps(ctx context.Context, doc chat.Document, mc modelcap
 			}, nil
 		}
 
-		// Other Office docs
-		if df, ok := officeDocumentFormat(mime); ok {
-			return []types.ContentBlock{
-				&types.ContentBlockMemberDocument{
-					Value: types.DocumentBlock{
-						Format: df,
-						Name:   aws.String(sanitizeDocumentName(doc.Name)),
-						Source: &types.DocumentSourceMemberBytes{
-							Value: doc.Source.InlineData,
-						},
-					},
-				},
-			}, nil
-		}
-
-		// Unknown binary: TXT envelope fallback
-		slog.DebugContext(ctx, "bedrock: no native block for MIME, falling back to TXT envelope",
+		// Unexpected binary MIME — modelcaps should have filtered this out via
+		// StrategyDrop, but guard defensively.
+		slog.WarnContext(ctx, "bedrock: unexpected binary MIME in StrategyB64, dropping",
 			"mime", doc.MimeType, "doc", doc.Name)
-		envelope := attachment.TXTEnvelope(doc.Name, doc.MimeType,
-			fmt.Sprintf("[binary content, %d bytes]", len(doc.Source.InlineData)))
-		return []types.ContentBlock{
-			&types.ContentBlockMemberText{Value: envelope},
-		}, nil
+		return nil, nil
 
 	case attachment.StrategyTXT:
 		envelope := attachment.TXTEnvelope(doc.Name, doc.MimeType, doc.Source.InlineText)
@@ -117,29 +98,6 @@ func convertDocumentWithCaps(ctx context.Context, doc chat.Document, mc modelcap
 
 	default:
 		return nil, fmt.Errorf("unknown attachment strategy %d", strategy)
-	}
-}
-
-// officeDocumentFormat maps Office MIME types to Bedrock DocumentFormats.
-func officeDocumentFormat(mime string) (types.DocumentFormat, bool) {
-	switch mime {
-	case "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
-		return types.DocumentFormatDocx, true
-	case "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
-		return types.DocumentFormatXlsx, true
-	case "application/vnd.openxmlformats-officedocument.presentationml.presentation":
-		// Bedrock doesn't have a native PPTX format — treat as unsupported.
-		return "", false
-	case "text/csv":
-		return types.DocumentFormatCsv, true
-	case "text/plain":
-		return types.DocumentFormatTxt, true
-	case "text/html":
-		return types.DocumentFormatHtml, true
-	case "text/markdown", "text/x-markdown":
-		return types.DocumentFormatMd, true
-	default:
-		return "", false
 	}
 }
 

--- a/pkg/model/provider/bedrock/attachments.go
+++ b/pkg/model/provider/bedrock/attachments.go
@@ -41,6 +41,11 @@ func imageFormatFromMIME(mimeType string) (types.ImageFormat, bool) {
 //   - unsupported / no content → nil (logged as warning)
 func convertDocument(ctx context.Context, doc chat.Document, modelID string) ([]types.ContentBlock, error) {
 	mc, _ := modelcaps.Load(modelID)
+	return convertDocumentWithCaps(ctx, doc, mc)
+}
+
+// convertDocumentWithCaps is the caps-injectable variant used by tests.
+func convertDocumentWithCaps(ctx context.Context, doc chat.Document, mc modelcaps.ModelCapabilities) ([]types.ContentBlock, error) {
 	strategy, reason := attachment.Decide(doc, mc)
 
 	switch strategy {

--- a/pkg/model/provider/bedrock/attachments.go
+++ b/pkg/model/provider/bedrock/attachments.go
@@ -160,21 +160,3 @@ func sanitizeDocumentName(name string) string {
 	}
 	return result
 }
-
-// SupportedMIMETypes implements attachment.Advisor for the Bedrock client.
-func (c *Client) SupportedMIMETypes() []string {
-	mc, _ := modelcaps.Load(c.ModelConfig.Model)
-	mimes := []string{
-		"text/plain", "text/markdown", "text/html", "text/csv",
-		"application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-		"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-		"application/vnd.openxmlformats-officedocument.presentationml.presentation",
-	}
-	if mc.Supports("image/jpeg") {
-		mimes = append(mimes, "image/jpeg", "image/png", "image/gif", "image/webp")
-	}
-	if mc.Supports("application/pdf") {
-		mimes = append(mimes, "application/pdf")
-	}
-	return mimes
-}

--- a/pkg/model/provider/bedrock/attachments_test.go
+++ b/pkg/model/provider/bedrock/attachments_test.go
@@ -116,3 +116,27 @@ func TestConvertDocumentBedrock_Drop_NoContent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, blocks, "should be nil when no inline content")
 }
+
+func TestSanitizeDocumentName(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"report.pdf", "report"},
+		{"my-document.docx", "my-document"},
+		{"hello world.txt", "hello world"},
+		{"file.with.dots.pdf", "file-with-dots"},
+		{".pdf", "pdf"}, // edge case: name is only extension
+		{"", "document"},
+		{"123.xlsx", "123"},
+		{"report (draft).pdf", "report (draft)"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			got := sanitizeDocumentName(tc.input)
+			if got != tc.want {
+				t.Errorf("sanitizeDocumentName(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/model/provider/bedrock/attachments_test.go
+++ b/pkg/model/provider/bedrock/attachments_test.go
@@ -84,8 +84,8 @@ func TestConvertDocumentBedrock_StrategyTXT(t *testing.T) {
 	require.Len(t, blocks, 1)
 	textBlock, ok := blocks[0].(*types.ContentBlockMemberText)
 	require.True(t, ok, "expected text block for TXT strategy")
-	assert.Contains(t, textBlock.Value, "notes.md")
-	assert.Contains(t, textBlock.Value, "text/markdown")
+	assert.Contains(t, textBlock.Value, "notes-md")
+	assert.Contains(t, textBlock.Value, "text-markdown")
 	assert.Contains(t, textBlock.Value, "## Notes")
 }
 
@@ -102,7 +102,6 @@ func TestConvertDocumentBedrock_StrategyTXT_Envelope(t *testing.T) {
 	textBlock, ok := blocks[0].(*types.ContentBlockMemberText)
 	require.True(t, ok, "expected text block")
 	assert.True(t, strings.HasPrefix(textBlock.Value, "<document"), "should be wrapped in envelope")
-	assert.Contains(t, textBlock.Value, `name="data.csv"`)
 }
 
 func TestConvertDocumentBedrock_Drop_NoContent(t *testing.T) {

--- a/pkg/model/provider/bedrock/attachments_test.go
+++ b/pkg/model/provider/bedrock/attachments_test.go
@@ -1,7 +1,6 @@
 package bedrock
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -9,8 +8,69 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/docker/docker-agent/pkg/attachment/modelcaps"
 	"github.com/docker/docker-agent/pkg/chat"
 )
+
+// minJPEG is a minimal JPEG magic-byte header for use in tests.
+var minJPEG = []byte{0xFF, 0xD8, 0xFF, 0xE0}
+
+// minPDF is a minimal PDF magic-byte header for use in tests.
+var minPDF = []byte{0x25, 0x50, 0x44, 0x46, 0x2D} // %PDF-
+
+// TestConvertDocumentBedrock_StrategyB64_Image verifies that an image document
+// with InlineData and a vision-capable model produces a ContentBlockMemberImage.
+func TestConvertDocumentBedrock_StrategyB64_Image(t *testing.T) {
+	doc := chat.Document{
+		Name:     "photo.jpg",
+		MimeType: "image/jpeg",
+		Source:   chat.DocumentSource{InlineData: minJPEG},
+	}
+
+	visionCaps := modelcaps.CapsWith(true, true)
+	blocks, err := convertDocumentWithCaps(t.Context(), doc, visionCaps)
+	require.NoError(t, err)
+	require.Len(t, blocks, 1, "expected exactly one block")
+	imageBlock, ok := blocks[0].(*types.ContentBlockMemberImage)
+	require.True(t, ok, "expected ContentBlockMemberImage, got %T", blocks[0])
+	assert.Equal(t, types.ImageFormatJpeg, imageBlock.Value.Format)
+	srcBytes, ok := imageBlock.Value.Source.(*types.ImageSourceMemberBytes)
+	require.True(t, ok, "expected ImageSourceMemberBytes")
+	assert.Equal(t, minJPEG, srcBytes.Value)
+}
+
+// TestConvertDocumentBedrock_StrategyB64_PDF verifies that a PDF document
+// produces a ContentBlockMemberDocument when the model supports PDFs.
+func TestConvertDocumentBedrock_StrategyB64_PDF(t *testing.T) {
+	doc := chat.Document{
+		Name:     "spec.pdf",
+		MimeType: "application/pdf",
+		Source:   chat.DocumentSource{InlineData: minPDF},
+	}
+
+	pdfCaps := modelcaps.CapsWith(true, true)
+	blocks, err := convertDocumentWithCaps(t.Context(), doc, pdfCaps)
+	require.NoError(t, err)
+	require.Len(t, blocks, 1, "expected exactly one block")
+	docBlock, ok := blocks[0].(*types.ContentBlockMemberDocument)
+	require.True(t, ok, "expected ContentBlockMemberDocument, got %T", blocks[0])
+	assert.Equal(t, types.DocumentFormatPdf, docBlock.Value.Format)
+}
+
+// TestConvertDocumentBedrock_StrategyB64_ImageDropped verifies that an image
+// is dropped when the model does not support vision.
+func TestConvertDocumentBedrock_StrategyB64_ImageDropped(t *testing.T) {
+	doc := chat.Document{
+		Name:     "photo.jpg",
+		MimeType: "image/jpeg",
+		Source:   chat.DocumentSource{InlineData: minJPEG},
+	}
+
+	textOnlyCaps := modelcaps.CapsWith(false, false)
+	blocks, err := convertDocumentWithCaps(t.Context(), doc, textOnlyCaps)
+	require.NoError(t, err)
+	assert.Nil(t, blocks, "image should be dropped for text-only model")
+}
 
 func TestConvertDocumentBedrock_StrategyTXT(t *testing.T) {
 	doc := chat.Document{
@@ -19,7 +79,7 @@ func TestConvertDocumentBedrock_StrategyTXT(t *testing.T) {
 		Source:   chat.DocumentSource{InlineText: "## Notes"},
 	}
 
-	blocks, err := convertDocument(context.Background(), doc, "")
+	blocks, err := convertDocument(t.Context(), doc, "")
 	require.NoError(t, err)
 	require.Len(t, blocks, 1)
 	textBlock, ok := blocks[0].(*types.ContentBlockMemberText)
@@ -36,7 +96,7 @@ func TestConvertDocumentBedrock_StrategyTXT_Envelope(t *testing.T) {
 		Source:   chat.DocumentSource{InlineText: "a,b"},
 	}
 
-	blocks, err := convertDocument(context.Background(), doc, "")
+	blocks, err := convertDocument(t.Context(), doc, "")
 	require.NoError(t, err)
 	require.Len(t, blocks, 1)
 	textBlock, ok := blocks[0].(*types.ContentBlockMemberText)
@@ -52,19 +112,7 @@ func TestConvertDocumentBedrock_Drop_NoContent(t *testing.T) {
 		Source:   chat.DocumentSource{},
 	}
 
-	blocks, err := convertDocument(context.Background(), doc, "")
+	blocks, err := convertDocument(t.Context(), doc, "")
 	require.NoError(t, err)
 	assert.Nil(t, blocks, "should be nil when no inline content")
-}
-
-func TestConvertDocumentBedrock_Drop_UnsupportedMIME(t *testing.T) {
-	doc := chat.Document{
-		Name:     "photo.jpg",
-		MimeType: "image/jpeg",
-		Source:   chat.DocumentSource{InlineData: []byte{0xFF, 0xD8}},
-	}
-
-	blocks, err := convertDocument(context.Background(), doc, "")
-	require.NoError(t, err)
-	assert.Nil(t, blocks, "image should be dropped for text-only model")
 }

--- a/pkg/model/provider/bedrock/attachments_test.go
+++ b/pkg/model/provider/bedrock/attachments_test.go
@@ -1,0 +1,70 @@
+package bedrock
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/chat"
+)
+
+func TestConvertDocumentBedrock_StrategyTXT(t *testing.T) {
+	doc := chat.Document{
+		Name:     "notes.md",
+		MimeType: "text/markdown",
+		Source:   chat.DocumentSource{InlineText: "## Notes"},
+	}
+
+	blocks, err := convertDocument(context.Background(), doc, "")
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+	textBlock, ok := blocks[0].(*types.ContentBlockMemberText)
+	require.True(t, ok, "expected text block for TXT strategy")
+	assert.Contains(t, textBlock.Value, "notes.md")
+	assert.Contains(t, textBlock.Value, "text/markdown")
+	assert.Contains(t, textBlock.Value, "## Notes")
+}
+
+func TestConvertDocumentBedrock_StrategyTXT_Envelope(t *testing.T) {
+	doc := chat.Document{
+		Name:     "data.csv",
+		MimeType: "text/csv",
+		Source:   chat.DocumentSource{InlineText: "a,b"},
+	}
+
+	blocks, err := convertDocument(context.Background(), doc, "")
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+	textBlock, ok := blocks[0].(*types.ContentBlockMemberText)
+	require.True(t, ok, "expected text block")
+	assert.True(t, strings.HasPrefix(textBlock.Value, "<document"), "should be wrapped in envelope")
+	assert.Contains(t, textBlock.Value, `name="data.csv"`)
+}
+
+func TestConvertDocumentBedrock_Drop_NoContent(t *testing.T) {
+	doc := chat.Document{
+		Name:     "empty.txt",
+		MimeType: "text/plain",
+		Source:   chat.DocumentSource{},
+	}
+
+	blocks, err := convertDocument(context.Background(), doc, "")
+	require.NoError(t, err)
+	assert.Nil(t, blocks, "should be nil when no inline content")
+}
+
+func TestConvertDocumentBedrock_Drop_UnsupportedMIME(t *testing.T) {
+	doc := chat.Document{
+		Name:     "photo.jpg",
+		MimeType: "image/jpeg",
+		Source:   chat.DocumentSource{InlineData: []byte{0xFF, 0xD8}},
+	}
+
+	blocks, err := convertDocument(context.Background(), doc, "")
+	require.NoError(t, err)
+	assert.Nil(t, blocks, "image should be dropped for text-only model")
+}

--- a/pkg/model/provider/bedrock/client.go
+++ b/pkg/model/provider/bedrock/client.go
@@ -215,7 +215,7 @@ func (c *Client) CreateChatCompletionStream(
 	}
 
 	// Build Converse input
-	input := c.buildConverseStreamInput(messages, requestTools)
+	input := c.buildConverseStreamInput(ctx, messages, requestTools)
 
 	// Call ConverseStream
 	output, err := c.bedrockClient.ConverseStream(ctx, input)
@@ -228,7 +228,7 @@ func (c *Client) CreateChatCompletionStream(
 	return newStreamAdapter(output.GetStream(), c.ModelConfig.Model, trackUsage), nil
 }
 
-func (c *Client) buildConverseStreamInput(messages []chat.Message, requestTools []tools.Tool) *bedrockruntime.ConverseStreamInput {
+func (c *Client) buildConverseStreamInput(ctx context.Context, messages []chat.Message, requestTools []tools.Tool) *bedrockruntime.ConverseStreamInput {
 	input := &bedrockruntime.ConverseStreamInput{
 		ModelId: aws.String(c.ModelConfig.Model),
 	}
@@ -236,7 +236,7 @@ func (c *Client) buildConverseStreamInput(messages []chat.Message, requestTools 
 	enableCaching := c.promptCachingEnabled()
 
 	// Convert and set messages (excluding system)
-	input.Messages, input.System = convertMessages(messages, enableCaching)
+	input.Messages, input.System = convertMessages(ctx, messages, c.ModelConfig.Model, enableCaching)
 
 	// Compute thinking fields first — its presence drives the inference config.
 	additionalFields := c.buildAdditionalModelRequestFields()

--- a/pkg/model/provider/bedrock/client_test.go
+++ b/pkg/model/provider/bedrock/client_test.go
@@ -1,6 +1,7 @@
 package bedrock
 
 import (
+	"context"
 	"encoding/base64"
 	"net/http"
 	"net/http/httptest"
@@ -25,7 +26,7 @@ func TestConvertMessages_UserText(t *testing.T) {
 		Content: "Hello, world!",
 	}}
 
-	bedrockMsgs, system := convertMessages(msgs, false)
+	bedrockMsgs, system := convertMessages(context.Background(), msgs, "", false)
 
 	require.Len(t, bedrockMsgs, 1)
 	assert.Empty(t, system)
@@ -45,7 +46,7 @@ func TestConvertMessages_SystemExtraction(t *testing.T) {
 		{Role: chat.MessageRoleUser, Content: "Hi"},
 	}
 
-	bedrockMsgs, system := convertMessages(msgs, false)
+	bedrockMsgs, system := convertMessages(context.Background(), msgs, "", false)
 
 	require.Len(t, bedrockMsgs, 1) // Only user message
 	require.Len(t, system, 1)      // System extracted
@@ -70,7 +71,7 @@ func TestConvertMessages_AssistantWithToolCalls(t *testing.T) {
 		}},
 	}}
 
-	bedrockMsgs, _ := convertMessages(msgs, false)
+	bedrockMsgs, _ := convertMessages(context.Background(), msgs, "", false)
 
 	require.Len(t, bedrockMsgs, 1)
 	require.Len(t, bedrockMsgs[0].Content, 1)
@@ -91,7 +92,7 @@ func TestConvertMessages_ToolResult(t *testing.T) {
 		Content:    "Weather is sunny",
 	}}
 
-	bedrockMsgs, _ := convertMessages(msgs, false)
+	bedrockMsgs, _ := convertMessages(context.Background(), msgs, "", false)
 
 	require.Len(t, bedrockMsgs, 1)
 	assert.Equal(t, types.ConversationRoleUser, bedrockMsgs[0].Role)
@@ -115,7 +116,7 @@ func TestConvertMessages_EmptyContent(t *testing.T) {
 		{Role: chat.MessageRoleUser, Content: "   "},
 	}
 
-	bedrockMsgs, _ := convertMessages(msgs, false)
+	bedrockMsgs, _ := convertMessages(context.Background(), msgs, "", false)
 	// Both messages now produce user turns with empty or whitespace content blocks.
 	assert.Len(t, bedrockMsgs, 2)
 }
@@ -181,7 +182,7 @@ func TestConvertMessages_MultiContent(t *testing.T) {
 		},
 	}}
 
-	bedrockMsgs, _ := convertMessages(msgs, false)
+	bedrockMsgs, _ := convertMessages(context.Background(), msgs, "", false)
 
 	require.Len(t, bedrockMsgs, 1)
 	require.Len(t, bedrockMsgs[0].Content, 2)
@@ -205,7 +206,7 @@ func TestConvertMessages_ConsecutiveToolResults(t *testing.T) {
 		{Role: chat.MessageRoleUser, Content: "Continue"},
 	}
 
-	bedrockMsgs, _ := convertMessages(msgs, false)
+	bedrockMsgs, _ := convertMessages(context.Background(), msgs, "", false)
 
 	// Expect: user, assistant, user (grouped tool results), user
 	require.Len(t, bedrockMsgs, 4)
@@ -1136,7 +1137,7 @@ func TestConvertMessages_WithCaching(t *testing.T) {
 		{Role: chat.MessageRoleUser, Content: "How are you?"},
 	}
 
-	bedrockMsgs, system := convertMessages(msgs, true)
+	bedrockMsgs, system := convertMessages(context.Background(), msgs, "", true)
 
 	// System should have text block + cache point
 	require.Len(t, system, 2)
@@ -1167,7 +1168,7 @@ func TestConvertMessages_WithoutCaching(t *testing.T) {
 		{Role: chat.MessageRoleUser, Content: "Hello"},
 	}
 
-	bedrockMsgs, system := convertMessages(msgs, false)
+	bedrockMsgs, system := convertMessages(context.Background(), msgs, "", false)
 
 	// System should only have text block, no cache point
 	require.Len(t, system, 1)
@@ -1258,7 +1259,7 @@ func TestConvertMessages_EmptyWithCaching(t *testing.T) {
 	t.Parallel()
 
 	// Empty message list should not panic with caching enabled
-	bedrockMsgs, system := convertMessages([]chat.Message{}, true)
+	bedrockMsgs, system := convertMessages(context.Background(), []chat.Message{}, "", true)
 
 	assert.Empty(t, bedrockMsgs)
 	assert.Empty(t, system)
@@ -1271,7 +1272,7 @@ func TestConvertMessages_SingleMessageWithCaching(t *testing.T) {
 		{Role: chat.MessageRoleUser, Content: "Hello"},
 	}
 
-	bedrockMsgs, _ := convertMessages(msgs, true)
+	bedrockMsgs, _ := convertMessages(context.Background(), msgs, "", true)
 
 	require.Len(t, bedrockMsgs, 1)
 	// Single message should get a cache point appended
@@ -1291,7 +1292,7 @@ func TestConvertMessages_MultiContentWithCaching(t *testing.T) {
 		},
 	}}
 
-	bedrockMsgs, _ := convertMessages(msgs, true)
+	bedrockMsgs, _ := convertMessages(context.Background(), msgs, "", true)
 
 	require.Len(t, bedrockMsgs, 1)
 	// 2 text blocks + cache point = 3 content blocks
@@ -1314,7 +1315,7 @@ func TestConvertMessages_ToolResultWithCaching(t *testing.T) {
 		{Role: chat.MessageRoleTool, ToolCallID: "tool-1", Content: "Result"},
 	}
 
-	bedrockMsgs, _ := convertMessages(msgs, true)
+	bedrockMsgs, _ := convertMessages(context.Background(), msgs, "", true)
 
 	// Expect: user, assistant, user (tool result)
 	require.Len(t, bedrockMsgs, 3)

--- a/pkg/model/provider/bedrock/client_test.go
+++ b/pkg/model/provider/bedrock/client_test.go
@@ -1,7 +1,6 @@
 package bedrock
 
 import (
-	"context"
 	"encoding/base64"
 	"net/http"
 	"net/http/httptest"
@@ -26,7 +25,7 @@ func TestConvertMessages_UserText(t *testing.T) {
 		Content: "Hello, world!",
 	}}
 
-	bedrockMsgs, system := convertMessages(context.Background(), msgs, "", false)
+	bedrockMsgs, system := convertMessages(t.Context(), msgs, "", false)
 
 	require.Len(t, bedrockMsgs, 1)
 	assert.Empty(t, system)
@@ -46,7 +45,7 @@ func TestConvertMessages_SystemExtraction(t *testing.T) {
 		{Role: chat.MessageRoleUser, Content: "Hi"},
 	}
 
-	bedrockMsgs, system := convertMessages(context.Background(), msgs, "", false)
+	bedrockMsgs, system := convertMessages(t.Context(), msgs, "", false)
 
 	require.Len(t, bedrockMsgs, 1) // Only user message
 	require.Len(t, system, 1)      // System extracted
@@ -71,7 +70,7 @@ func TestConvertMessages_AssistantWithToolCalls(t *testing.T) {
 		}},
 	}}
 
-	bedrockMsgs, _ := convertMessages(context.Background(), msgs, "", false)
+	bedrockMsgs, _ := convertMessages(t.Context(), msgs, "", false)
 
 	require.Len(t, bedrockMsgs, 1)
 	require.Len(t, bedrockMsgs[0].Content, 1)
@@ -92,7 +91,7 @@ func TestConvertMessages_ToolResult(t *testing.T) {
 		Content:    "Weather is sunny",
 	}}
 
-	bedrockMsgs, _ := convertMessages(context.Background(), msgs, "", false)
+	bedrockMsgs, _ := convertMessages(t.Context(), msgs, "", false)
 
 	require.Len(t, bedrockMsgs, 1)
 	assert.Equal(t, types.ConversationRoleUser, bedrockMsgs[0].Role)
@@ -116,7 +115,7 @@ func TestConvertMessages_EmptyContent(t *testing.T) {
 		{Role: chat.MessageRoleUser, Content: "   "},
 	}
 
-	bedrockMsgs, _ := convertMessages(context.Background(), msgs, "", false)
+	bedrockMsgs, _ := convertMessages(t.Context(), msgs, "", false)
 	// Both messages now produce user turns with empty or whitespace content blocks.
 	assert.Len(t, bedrockMsgs, 2)
 }
@@ -182,7 +181,7 @@ func TestConvertMessages_MultiContent(t *testing.T) {
 		},
 	}}
 
-	bedrockMsgs, _ := convertMessages(context.Background(), msgs, "", false)
+	bedrockMsgs, _ := convertMessages(t.Context(), msgs, "", false)
 
 	require.Len(t, bedrockMsgs, 1)
 	require.Len(t, bedrockMsgs[0].Content, 2)
@@ -206,7 +205,7 @@ func TestConvertMessages_ConsecutiveToolResults(t *testing.T) {
 		{Role: chat.MessageRoleUser, Content: "Continue"},
 	}
 
-	bedrockMsgs, _ := convertMessages(context.Background(), msgs, "", false)
+	bedrockMsgs, _ := convertMessages(t.Context(), msgs, "", false)
 
 	// Expect: user, assistant, user (grouped tool results), user
 	require.Len(t, bedrockMsgs, 4)
@@ -1137,7 +1136,7 @@ func TestConvertMessages_WithCaching(t *testing.T) {
 		{Role: chat.MessageRoleUser, Content: "How are you?"},
 	}
 
-	bedrockMsgs, system := convertMessages(context.Background(), msgs, "", true)
+	bedrockMsgs, system := convertMessages(t.Context(), msgs, "", true)
 
 	// System should have text block + cache point
 	require.Len(t, system, 2)
@@ -1168,7 +1167,7 @@ func TestConvertMessages_WithoutCaching(t *testing.T) {
 		{Role: chat.MessageRoleUser, Content: "Hello"},
 	}
 
-	bedrockMsgs, system := convertMessages(context.Background(), msgs, "", false)
+	bedrockMsgs, system := convertMessages(t.Context(), msgs, "", false)
 
 	// System should only have text block, no cache point
 	require.Len(t, system, 1)
@@ -1259,7 +1258,7 @@ func TestConvertMessages_EmptyWithCaching(t *testing.T) {
 	t.Parallel()
 
 	// Empty message list should not panic with caching enabled
-	bedrockMsgs, system := convertMessages(context.Background(), []chat.Message{}, "", true)
+	bedrockMsgs, system := convertMessages(t.Context(), []chat.Message{}, "", true)
 
 	assert.Empty(t, bedrockMsgs)
 	assert.Empty(t, system)
@@ -1272,7 +1271,7 @@ func TestConvertMessages_SingleMessageWithCaching(t *testing.T) {
 		{Role: chat.MessageRoleUser, Content: "Hello"},
 	}
 
-	bedrockMsgs, _ := convertMessages(context.Background(), msgs, "", true)
+	bedrockMsgs, _ := convertMessages(t.Context(), msgs, "", true)
 
 	require.Len(t, bedrockMsgs, 1)
 	// Single message should get a cache point appended
@@ -1292,7 +1291,7 @@ func TestConvertMessages_MultiContentWithCaching(t *testing.T) {
 		},
 	}}
 
-	bedrockMsgs, _ := convertMessages(context.Background(), msgs, "", true)
+	bedrockMsgs, _ := convertMessages(t.Context(), msgs, "", true)
 
 	require.Len(t, bedrockMsgs, 1)
 	// 2 text blocks + cache point = 3 content blocks
@@ -1315,7 +1314,7 @@ func TestConvertMessages_ToolResultWithCaching(t *testing.T) {
 		{Role: chat.MessageRoleTool, ToolCallID: "tool-1", Content: "Result"},
 	}
 
-	bedrockMsgs, _ := convertMessages(context.Background(), msgs, "", true)
+	bedrockMsgs, _ := convertMessages(t.Context(), msgs, "", true)
 
 	// Expect: user, assistant, user (tool result)
 	require.Len(t, bedrockMsgs, 3)

--- a/pkg/model/provider/bedrock/convert.go
+++ b/pkg/model/provider/bedrock/convert.go
@@ -131,7 +131,7 @@ func convertUserContent(ctx context.Context, msg *chat.Message, modelID string) 
 					Value: part.Text,
 				})
 			case chat.MessagePartTypeImageURL:
-				// Deprecated: use MessagePartTypeDocument instead.
+				// Note: superseded by MessagePartTypeDocument.
 				if part.ImageURL != nil {
 					if imageBlock := convertImageURL(part.ImageURL); imageBlock != nil {
 						blocks = append(blocks, imageBlock)

--- a/pkg/model/provider/bedrock/convert.go
+++ b/pkg/model/provider/bedrock/convert.go
@@ -1,6 +1,7 @@
 package bedrock
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"log/slog"
@@ -17,7 +18,7 @@ import (
 // convertMessages handles Bedrock's Converse API constraints:
 // - Tool results must immediately follow the assistant message with tool_use
 // - Multiple consecutive tool results must be grouped into a single user message
-func convertMessages(messages []chat.Message, enableCaching bool) ([]types.Message, []types.SystemContentBlock) {
+func convertMessages(ctx context.Context, messages []chat.Message, modelID string, enableCaching bool) ([]types.Message, []types.SystemContentBlock) {
 	var bedrockMessages []types.Message
 	var systemBlocks []types.SystemContentBlock
 
@@ -42,7 +43,7 @@ func convertMessages(messages []chat.Message, enableCaching bool) ([]types.Messa
 			}
 
 		case chat.MessageRoleUser:
-			contentBlocks := convertUserContent(msg)
+			contentBlocks := convertUserContent(ctx, msg, modelID)
 			if len(contentBlocks) > 0 {
 				bedrockMessages = append(bedrockMessages, types.Message{
 					Role:    types.ConversationRoleUser,
@@ -119,7 +120,7 @@ func applyCachePointsToMessages(messages []types.Message) {
 	}
 }
 
-func convertUserContent(msg *chat.Message) []types.ContentBlock {
+func convertUserContent(ctx context.Context, msg *chat.Message, modelID string) []types.ContentBlock {
 	var blocks []types.ContentBlock
 
 	if len(msg.MultiContent) > 0 {
@@ -130,10 +131,20 @@ func convertUserContent(msg *chat.Message) []types.ContentBlock {
 					Value: part.Text,
 				})
 			case chat.MessagePartTypeImageURL:
+				// Deprecated: use MessagePartTypeDocument instead.
 				if part.ImageURL != nil {
 					if imageBlock := convertImageURL(part.ImageURL); imageBlock != nil {
 						blocks = append(blocks, imageBlock)
 					}
+				}
+			case chat.MessagePartTypeDocument:
+				if part.Document != nil {
+					docBlocks, err := convertDocument(ctx, *part.Document, modelID)
+					if err != nil {
+						slog.WarnContext(ctx, "failed to convert document attachment", "error", err, "doc", part.Document.Name)
+						continue
+					}
+					blocks = append(blocks, docBlocks...)
 				}
 			}
 		}

--- a/pkg/model/provider/dmr/client.go
+++ b/pkg/model/provider/dmr/client.go
@@ -147,8 +147,8 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, opts ...options.Opt
 
 // convertMessages converts chat messages to OpenAI format and merges consecutive
 // system/user messages, which is needed by some local models run by DMR.
-func (c *Client) convertMessages(messages []chat.Message) []openai.ChatCompletionMessageParamUnion {
-	openaiMessages := oaistream.ConvertMessages(messages, c.ModelConfig.Model)
+func (c *Client) convertMessages(ctx context.Context, messages []chat.Message) []openai.ChatCompletionMessageParamUnion {
+	openaiMessages := oaistream.ConvertMessages(ctx, messages, c.ModelConfig.Model)
 	return oaistream.MergeConsecutiveMessages(openaiMessages)
 }
 
@@ -171,7 +171,7 @@ func (c *Client) CreateChatCompletionStream(ctx context.Context, messages []chat
 
 	params := openai.ChatCompletionNewParams{
 		Model:    c.ModelConfig.Model,
-		Messages: c.convertMessages(messages),
+		Messages: c.convertMessages(ctx, messages),
 		StreamOptions: openai.ChatCompletionStreamOptionsParam{
 			IncludeUsage: openai.Bool(trackUsage),
 		},

--- a/pkg/model/provider/dmr/client.go
+++ b/pkg/model/provider/dmr/client.go
@@ -147,8 +147,8 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, opts ...options.Opt
 
 // convertMessages converts chat messages to OpenAI format and merges consecutive
 // system/user messages, which is needed by some local models run by DMR.
-func convertMessages(messages []chat.Message) []openai.ChatCompletionMessageParamUnion {
-	openaiMessages := oaistream.ConvertMessages(messages)
+func (c *Client) convertMessages(messages []chat.Message) []openai.ChatCompletionMessageParamUnion {
+	openaiMessages := oaistream.ConvertMessages(messages, c.ModelConfig.Model)
 	return oaistream.MergeConsecutiveMessages(openaiMessages)
 }
 
@@ -171,7 +171,7 @@ func (c *Client) CreateChatCompletionStream(ctx context.Context, messages []chat
 
 	params := openai.ChatCompletionNewParams{
 		Model:    c.ModelConfig.Model,
-		Messages: convertMessages(messages),
+		Messages: c.convertMessages(messages),
 		StreamOptions: openai.ChatCompletionStreamOptionsParam{
 			IncludeUsage: openai.Bool(trackUsage),
 		},

--- a/pkg/model/provider/gemini/attachments.go
+++ b/pkg/model/provider/gemini/attachments.go
@@ -44,16 +44,3 @@ func convertDocumentWithCaps(ctx context.Context, doc chat.Document, mc modelcap
 		return nil, fmt.Errorf("unknown attachment strategy %d", strategy)
 	}
 }
-
-// SupportedMIMETypes implements attachment.Advisor for the Gemini client.
-func (c *Client) SupportedMIMETypes() []string {
-	mc, _ := modelcaps.Load(c.ModelConfig.Model)
-	mimes := []string{"text/plain", "text/markdown", "text/html", "text/csv"}
-	if mc.Supports("image/jpeg") {
-		mimes = append(mimes, "image/jpeg", "image/png", "image/gif", "image/webp")
-	}
-	if mc.Supports("application/pdf") {
-		mimes = append(mimes, "application/pdf")
-	}
-	return mimes
-}

--- a/pkg/model/provider/gemini/attachments.go
+++ b/pkg/model/provider/gemini/attachments.go
@@ -20,6 +20,11 @@ import (
 //   - unsupported / no content → nil (logged as warning)
 func convertDocument(ctx context.Context, doc chat.Document, modelID string) (*genai.Part, error) {
 	mc, _ := modelcaps.Load(modelID)
+	return convertDocumentWithCaps(ctx, doc, mc)
+}
+
+// convertDocumentWithCaps is the caps-injectable variant used by tests.
+func convertDocumentWithCaps(ctx context.Context, doc chat.Document, mc modelcaps.ModelCapabilities) (*genai.Part, error) {
 	strategy, reason := attachment.Decide(doc, mc)
 
 	switch strategy {

--- a/pkg/model/provider/gemini/attachments.go
+++ b/pkg/model/provider/gemini/attachments.go
@@ -1,0 +1,54 @@
+package gemini
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"google.golang.org/genai"
+
+	"github.com/docker/docker-agent/pkg/attachment"
+	"github.com/docker/docker-agent/pkg/attachment/modelcaps"
+	"github.com/docker/docker-agent/pkg/chat"
+)
+
+// convertDocument converts a chat.Document to a Gemini genai.Part.
+//
+// Routing:
+//   - image/* or binary with InlineData → genai.Blob part
+//   - text MIMEs with InlineText → genai.Text part with TXTEnvelope
+//   - unsupported / no content → nil (logged as warning)
+func convertDocument(ctx context.Context, doc chat.Document, modelID string) (*genai.Part, error) {
+	mc, _ := modelcaps.Load(modelID)
+	strategy, reason := attachment.Decide(doc, mc)
+
+	switch strategy {
+	case attachment.StrategyDrop:
+		slog.WarnContext(ctx, "attachment dropped", "reason", reason, "doc", doc.Name)
+		return nil, nil
+
+	case attachment.StrategyB64:
+		// Gemini's genai.NewPartFromBytes wraps binary data as an inline blob.
+		return genai.NewPartFromBytes(doc.Source.InlineData, doc.MimeType), nil
+
+	case attachment.StrategyTXT:
+		envelope := attachment.TXTEnvelope(doc.Name, doc.MimeType, doc.Source.InlineText)
+		return genai.NewPartFromText(envelope), nil
+
+	default:
+		return nil, fmt.Errorf("unknown attachment strategy %d", strategy)
+	}
+}
+
+// SupportedMIMETypes implements attachment.Advisor for the Gemini client.
+func (c *Client) SupportedMIMETypes() []string {
+	mc, _ := modelcaps.Load(c.ModelConfig.Model)
+	mimes := []string{"text/plain", "text/markdown", "text/html", "text/csv"}
+	if mc.Supports("image/jpeg") {
+		mimes = append(mimes, "image/jpeg", "image/png", "image/gif", "image/webp")
+	}
+	if mc.Supports("application/pdf") {
+		mimes = append(mimes, "application/pdf")
+	}
+	return mimes
+}

--- a/pkg/model/provider/gemini/attachments_test.go
+++ b/pkg/model/provider/gemini/attachments_test.go
@@ -58,8 +58,8 @@ func TestConvertDocumentGemini_StrategyTXT(t *testing.T) {
 	part, err := convertDocument(t.Context(), doc, "")
 	require.NoError(t, err)
 	require.NotNil(t, part)
-	assert.Contains(t, part.Text, "readme.md")
-	assert.Contains(t, part.Text, "text/markdown")
+	assert.Contains(t, part.Text, "readme-md")
+	assert.Contains(t, part.Text, "text-markdown")
 	assert.Contains(t, part.Text, "# Read Me")
 }
 
@@ -74,7 +74,6 @@ func TestConvertDocumentGemini_StrategyTXT_Envelope(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, part)
 	assert.True(t, strings.HasPrefix(part.Text, "<document"), "should be wrapped in envelope")
-	assert.Contains(t, part.Text, `name="data.csv"`)
 }
 
 func TestConvertDocumentGemini_Drop_NoContent(t *testing.T) {

--- a/pkg/model/provider/gemini/attachments_test.go
+++ b/pkg/model/provider/gemini/attachments_test.go
@@ -1,0 +1,67 @@
+package gemini
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/chat"
+)
+
+func TestConvertDocumentGemini_StrategyTXT(t *testing.T) {
+	doc := chat.Document{
+		Name:     "readme.md",
+		MimeType: "text/markdown",
+		Source:   chat.DocumentSource{InlineText: "# Read Me"},
+	}
+
+	part, err := convertDocument(context.Background(), doc, "")
+	require.NoError(t, err)
+	require.NotNil(t, part)
+	// The TXT path returns a text part; verify content via the string representation
+	assert.Contains(t, part.Text, "readme.md")
+	assert.Contains(t, part.Text, "text/markdown")
+	assert.Contains(t, part.Text, "# Read Me")
+}
+
+func TestConvertDocumentGemini_StrategyTXT_Envelope(t *testing.T) {
+	doc := chat.Document{
+		Name:     "data.csv",
+		MimeType: "text/csv",
+		Source:   chat.DocumentSource{InlineText: "col1,col2"},
+	}
+
+	part, err := convertDocument(context.Background(), doc, "")
+	require.NoError(t, err)
+	require.NotNil(t, part)
+	assert.True(t, strings.HasPrefix(part.Text, "<document"), "should be wrapped in envelope")
+	assert.Contains(t, part.Text, `name="data.csv"`)
+}
+
+func TestConvertDocumentGemini_Drop_NoContent(t *testing.T) {
+	doc := chat.Document{
+		Name:     "empty.txt",
+		MimeType: "text/plain",
+		Source:   chat.DocumentSource{},
+	}
+
+	part, err := convertDocument(context.Background(), doc, "")
+	require.NoError(t, err)
+	assert.Nil(t, part, "should be nil when no inline content")
+}
+
+func TestConvertDocumentGemini_Drop_UnsupportedMIME(t *testing.T) {
+	doc := chat.Document{
+		Name:     "photo.jpg",
+		MimeType: "image/jpeg",
+		Source:   chat.DocumentSource{InlineData: []byte{0xFF, 0xD8}},
+	}
+
+	// text-only model (empty modelID) → drop
+	part, err := convertDocument(context.Background(), doc, "")
+	require.NoError(t, err)
+	assert.Nil(t, part, "image should be dropped for text-only model")
+}

--- a/pkg/model/provider/gemini/attachments_test.go
+++ b/pkg/model/provider/gemini/attachments_test.go
@@ -1,15 +1,52 @@
 package gemini
 
 import (
-	"context"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/docker/docker-agent/pkg/attachment/modelcaps"
 	"github.com/docker/docker-agent/pkg/chat"
 )
+
+// minJPEG is a minimal JPEG magic-byte header for use in tests.
+var minJPEG = []byte{0xFF, 0xD8, 0xFF, 0xE0}
+
+// TestConvertDocumentGemini_StrategyB64_Image verifies that an image document
+// with InlineData and a vision-capable model produces a Blob part (not a text part).
+func TestConvertDocumentGemini_StrategyB64_Image(t *testing.T) {
+	doc := chat.Document{
+		Name:     "photo.jpg",
+		MimeType: "image/jpeg",
+		Source:   chat.DocumentSource{InlineData: minJPEG},
+	}
+
+	visionCaps := modelcaps.CapsWith(true, true)
+	part, err := convertDocumentWithCaps(t.Context(), doc, visionCaps)
+	require.NoError(t, err)
+	require.NotNil(t, part, "expected a non-nil part for B64 image")
+	// For a blob part the Text field is empty; the inline blob carries the data.
+	assert.Empty(t, part.Text, "expected blob part, not text part")
+	assert.Equal(t, minJPEG, part.InlineData.Data, "inline data should match input bytes")
+	assert.Equal(t, "image/jpeg", part.InlineData.MIMEType)
+}
+
+// TestConvertDocumentGemini_StrategyB64_ImageDropped verifies that an image is
+// dropped when the model does not support vision.
+func TestConvertDocumentGemini_StrategyB64_ImageDropped(t *testing.T) {
+	doc := chat.Document{
+		Name:     "photo.jpg",
+		MimeType: "image/jpeg",
+		Source:   chat.DocumentSource{InlineData: minJPEG},
+	}
+
+	textOnlyCaps := modelcaps.CapsWith(false, false)
+	part, err := convertDocumentWithCaps(t.Context(), doc, textOnlyCaps)
+	require.NoError(t, err)
+	assert.Nil(t, part, "image should be dropped for text-only model")
+}
 
 func TestConvertDocumentGemini_StrategyTXT(t *testing.T) {
 	doc := chat.Document{
@@ -18,10 +55,9 @@ func TestConvertDocumentGemini_StrategyTXT(t *testing.T) {
 		Source:   chat.DocumentSource{InlineText: "# Read Me"},
 	}
 
-	part, err := convertDocument(context.Background(), doc, "")
+	part, err := convertDocument(t.Context(), doc, "")
 	require.NoError(t, err)
 	require.NotNil(t, part)
-	// The TXT path returns a text part; verify content via the string representation
 	assert.Contains(t, part.Text, "readme.md")
 	assert.Contains(t, part.Text, "text/markdown")
 	assert.Contains(t, part.Text, "# Read Me")
@@ -34,7 +70,7 @@ func TestConvertDocumentGemini_StrategyTXT_Envelope(t *testing.T) {
 		Source:   chat.DocumentSource{InlineText: "col1,col2"},
 	}
 
-	part, err := convertDocument(context.Background(), doc, "")
+	part, err := convertDocument(t.Context(), doc, "")
 	require.NoError(t, err)
 	require.NotNil(t, part)
 	assert.True(t, strings.HasPrefix(part.Text, "<document"), "should be wrapped in envelope")
@@ -48,20 +84,7 @@ func TestConvertDocumentGemini_Drop_NoContent(t *testing.T) {
 		Source:   chat.DocumentSource{},
 	}
 
-	part, err := convertDocument(context.Background(), doc, "")
+	part, err := convertDocument(t.Context(), doc, "")
 	require.NoError(t, err)
 	assert.Nil(t, part, "should be nil when no inline content")
-}
-
-func TestConvertDocumentGemini_Drop_UnsupportedMIME(t *testing.T) {
-	doc := chat.Document{
-		Name:     "photo.jpg",
-		MimeType: "image/jpeg",
-		Source:   chat.DocumentSource{InlineData: []byte{0xFF, 0xD8}},
-	}
-
-	// text-only model (empty modelID) → drop
-	part, err := convertDocument(context.Background(), doc, "")
-	require.NoError(t, err)
-	assert.Nil(t, part, "image should be dropped for text-only model")
 }

--- a/pkg/model/provider/gemini/client.go
+++ b/pkg/model/provider/gemini/client.go
@@ -192,7 +192,7 @@ func thoughtSignatureOrDefault(sig []byte) []byte {
 }
 
 // convertMessagesToGemini converts chat.Messages into Gemini Contents
-func convertMessagesToGemini(messages []chat.Message) []*genai.Content {
+func convertMessagesToGemini(ctx context.Context, messages []chat.Message, modelID string) []*genai.Content {
 	contents := make([]*genai.Content, 0, len(messages))
 	for i := range messages {
 		msg := &messages[i]
@@ -257,7 +257,7 @@ func convertMessagesToGemini(messages []chat.Message) []*genai.Content {
 
 		// Handle regular messages
 		if len(msg.MultiContent) > 0 {
-			parts := convertMultiContent(msg.MultiContent, msg.ThoughtSignature)
+			parts := convertMultiContent(ctx, msg.MultiContent, msg.ThoughtSignature, modelID)
 			if len(parts) > 0 {
 				contents = append(contents, genai.NewContentFromParts(parts, role))
 			}
@@ -287,15 +287,27 @@ func newTextPartWithSignature(text string, signature []byte) *genai.Part {
 }
 
 // convertMultiContent converts multi-part content to Gemini parts
-func convertMultiContent(multiContent []chat.MessagePart, thoughtSignature []byte) []*genai.Part {
+func convertMultiContent(ctx context.Context, multiContent []chat.MessagePart, thoughtSignature []byte, modelID string) []*genai.Part {
 	parts := make([]*genai.Part, 0, len(multiContent))
 	for _, part := range multiContent {
 		switch part.Type {
 		case chat.MessagePartTypeText:
 			parts = append(parts, newTextPartWithSignature(part.Text, thoughtSignature))
 		case chat.MessagePartTypeImageURL:
+			// Deprecated: use MessagePartTypeDocument instead.
 			if imgPart := convertImageURLToPart(part.ImageURL); imgPart != nil {
 				parts = append(parts, imgPart)
+			}
+		case chat.MessagePartTypeDocument:
+			if part.Document != nil {
+				docPart, err := convertDocument(ctx, *part.Document, modelID)
+				if err != nil {
+					slog.WarnContext(ctx, "failed to convert document attachment", "error", err, "doc", part.Document.Name)
+					continue
+				}
+				if docPart != nil {
+					parts = append(parts, docPart)
+				}
 			}
 		}
 	}
@@ -589,7 +601,7 @@ func (c *Client) CreateChatCompletionStream(
 		}
 	}
 
-	contents := convertMessagesToGemini(messages)
+	contents := convertMessagesToGemini(ctx, messages, c.ModelConfig.Model)
 
 	// Debug: Log the messages we're sending
 	slog.Debug("Gemini messages", "count", len(contents))

--- a/pkg/model/provider/gemini/client.go
+++ b/pkg/model/provider/gemini/client.go
@@ -294,7 +294,7 @@ func convertMultiContent(ctx context.Context, multiContent []chat.MessagePart, t
 		case chat.MessagePartTypeText:
 			parts = append(parts, newTextPartWithSignature(part.Text, thoughtSignature))
 		case chat.MessagePartTypeImageURL:
-			// Deprecated: use MessagePartTypeDocument instead.
+			// Note: superseded by MessagePartTypeDocument.
 			if imgPart := convertImageURLToPart(part.ImageURL); imgPart != nil {
 				parts = append(parts, imgPart)
 			}

--- a/pkg/model/provider/gemini/client_test.go
+++ b/pkg/model/provider/gemini/client_test.go
@@ -1,6 +1,7 @@
 package gemini
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -362,10 +363,10 @@ func TestConvertMessagesToGemini_ThoughtSignature(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			contents := convertMessagesToGemini([]chat.Message{
+			contents := convertMessagesToGemini(context.Background(), []chat.Message{
 				{Role: chat.MessageRoleUser, Content: "go"},
 				tt.message,
-			})
+			}, "")
 
 			require.Len(t, contents, 2)
 			assistant := contents[1]

--- a/pkg/model/provider/gemini/client_test.go
+++ b/pkg/model/provider/gemini/client_test.go
@@ -1,7 +1,6 @@
 package gemini
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -363,7 +362,7 @@ func TestConvertMessagesToGemini_ThoughtSignature(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			contents := convertMessagesToGemini(context.Background(), []chat.Message{
+			contents := convertMessagesToGemini(t.Context(), []chat.Message{
 				{Role: chat.MessageRoleUser, Content: "go"},
 				tt.message,
 			}, "")

--- a/pkg/model/provider/oaistream/attachments.go
+++ b/pkg/model/provider/oaistream/attachments.go
@@ -1,0 +1,85 @@
+package oaistream
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/openai/openai-go/v3"
+
+	"github.com/docker/docker-agent/pkg/attachment"
+	"github.com/docker/docker-agent/pkg/attachment/modelcaps"
+	"github.com/docker/docker-agent/pkg/chat"
+)
+
+// convertDocument converts a chat.Document to zero or more
+// ChatCompletionContentPartUnionParam values using the OpenAI Chat Completions
+// format.  It is also used by all oaistream-based providers (Mistral, xAI,
+// Ollama, Nebius, MiniMax, GitHub Copilot, Azure, Requesty).
+//
+// Routing:
+//   - image/* with InlineData → data-URI image part
+//   - other binary MIMEs with InlineData → text part with TXTEnvelope fallback
+//   - text MIMEs with InlineText → text part with TXTEnvelope
+//   - unsupported / no content → nil (logged as warning)
+func convertDocument(ctx context.Context, doc chat.Document, modelID string) ([]openai.ChatCompletionContentPartUnionParam, error) {
+	mc, _ := modelcaps.Load(modelID)
+	strategy, reason := attachment.Decide(doc, mc)
+
+	switch strategy {
+	case attachment.StrategyDrop:
+		slog.WarnContext(ctx, "attachment dropped", "reason", reason, "doc", doc.Name)
+		return nil, nil
+
+	case attachment.StrategyB64:
+		mime := strings.ToLower(doc.MimeType)
+		if strings.HasPrefix(mime, "image/") {
+			// Build an OpenAI image part with a data URI.
+			dataURI := fmt.Sprintf("data:%s;base64,%s",
+				doc.MimeType,
+				base64.StdEncoding.EncodeToString(doc.Source.InlineData))
+			return []openai.ChatCompletionContentPartUnionParam{
+				openai.ImageContentPart(openai.ChatCompletionContentPartImageImageURLParam{
+					URL: dataURI,
+				}),
+			}, nil
+		}
+		// Non-image binary (PDF, Office docs…): OpenAI Chat Completions has no
+		// native document block, so fall back to a TXT envelope.
+		slog.DebugContext(ctx, "oaistream: no native block for MIME, falling back to TXT envelope",
+			"mime", doc.MimeType, "doc", doc.Name)
+		envelope := attachment.TXTEnvelope(doc.Name, doc.MimeType,
+			base64.StdEncoding.EncodeToString(doc.Source.InlineData))
+		return []openai.ChatCompletionContentPartUnionParam{
+			openai.TextContentPart(envelope),
+		}, nil
+
+	case attachment.StrategyTXT:
+		envelope := attachment.TXTEnvelope(doc.Name, doc.MimeType, doc.Source.InlineText)
+		return []openai.ChatCompletionContentPartUnionParam{
+			openai.TextContentPart(envelope),
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("unknown attachment strategy %d", strategy)
+	}
+}
+
+// SupportedMIMETypesForModel returns the MIME types that the given model
+// supports as document attachments, based on models.dev capability data.
+// This implements the attachment.Advisor interface for oaistream-based clients.
+func SupportedMIMETypesForModel(modelID string) []string {
+	mc, _ := modelcaps.Load(modelID)
+	var mimes []string
+	// Always support text MIMEs.
+	mimes = append(mimes, "text/plain", "text/markdown", "text/html", "text/csv")
+	if mc.Supports("image/jpeg") {
+		mimes = append(mimes, "image/jpeg", "image/png", "image/gif", "image/webp")
+	}
+	if mc.Supports("application/pdf") {
+		mimes = append(mimes, "application/pdf")
+	}
+	return mimes
+}

--- a/pkg/model/provider/oaistream/attachments.go
+++ b/pkg/model/provider/oaistream/attachments.go
@@ -51,15 +51,13 @@ func convertDocumentWithCaps(ctx context.Context, doc chat.Document, mc modelcap
 				}),
 			}, nil
 		}
-		// Non-image binary (PDF, Office docs…): OpenAI Chat Completions has no
-		// native document block, so fall back to a TXT envelope.
-		slog.DebugContext(ctx, "oaistream: no native block for MIME, falling back to TXT envelope",
+		// application/pdf and other binary MIMEs: the Chat Completions endpoint has
+		// no native document block. Sending raw PDF bytes as base64-in-TXT-envelope
+		// is wasteful and meaningless. Drop and warn so the caller can handle it.
+		slog.WarnContext(ctx, "oaistream: PDF attachments are not supported on this provider's "+
+			"Chat Completions endpoint — dropping",
 			"mime", doc.MimeType, "doc", doc.Name)
-		envelope := attachment.TXTEnvelope(doc.Name, doc.MimeType,
-			base64.StdEncoding.EncodeToString(doc.Source.InlineData))
-		return []openai.ChatCompletionContentPartUnionParam{
-			openai.TextContentPart(envelope),
-		}, nil
+		return nil, nil
 
 	case attachment.StrategyTXT:
 		envelope := attachment.TXTEnvelope(doc.Name, doc.MimeType, doc.Source.InlineText)

--- a/pkg/model/provider/oaistream/attachments.go
+++ b/pkg/model/provider/oaistream/attachments.go
@@ -26,6 +26,11 @@ import (
 //   - unsupported / no content → nil (logged as warning)
 func convertDocument(ctx context.Context, doc chat.Document, modelID string) ([]openai.ChatCompletionContentPartUnionParam, error) {
 	mc, _ := modelcaps.Load(modelID)
+	return convertDocumentWithCaps(ctx, doc, mc)
+}
+
+// convertDocumentWithCaps is the caps-injectable variant used by tests.
+func convertDocumentWithCaps(ctx context.Context, doc chat.Document, mc modelcaps.ModelCapabilities) ([]openai.ChatCompletionContentPartUnionParam, error) {
 	strategy, reason := attachment.Decide(doc, mc)
 
 	switch strategy {

--- a/pkg/model/provider/oaistream/attachments.go
+++ b/pkg/model/provider/oaistream/attachments.go
@@ -71,20 +71,3 @@ func convertDocumentWithCaps(ctx context.Context, doc chat.Document, mc modelcap
 		return nil, fmt.Errorf("unknown attachment strategy %d", strategy)
 	}
 }
-
-// SupportedMIMETypesForModel returns the MIME types that the given model
-// supports as document attachments, based on models.dev capability data.
-// This implements the attachment.Advisor interface for oaistream-based clients.
-func SupportedMIMETypesForModel(modelID string) []string {
-	mc, _ := modelcaps.Load(modelID)
-	var mimes []string
-	// Always support text MIMEs.
-	mimes = append(mimes, "text/plain", "text/markdown", "text/html", "text/csv")
-	if mc.Supports("image/jpeg") {
-		mimes = append(mimes, "image/jpeg", "image/png", "image/gif", "image/webp")
-	}
-	if mc.Supports("application/pdf") {
-		mimes = append(mimes, "application/pdf")
-	}
-	return mimes
-}

--- a/pkg/model/provider/oaistream/attachments_test.go
+++ b/pkg/model/provider/oaistream/attachments_test.go
@@ -1,0 +1,77 @@
+package oaistream
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/chat"
+)
+
+func TestConvertDocument_StrategyB64_Image(t *testing.T) {
+	doc := chat.Document{
+		Name:     "photo.jpg",
+		MimeType: "image/jpeg",
+		Source:   chat.DocumentSource{InlineData: []byte{0xFF, 0xD8, 0xFF, 0xE0}},
+	}
+
+	// Use a model ID that is unknown (text-only caps) — image/* will be dropped.
+	// For B64 testing we rely on an empty modelID which gives text-only caps.
+	// Use modelID "anthropic/claude-3-5-sonnet-20241022" which supports vision.
+	// Since we can't fetch live data in tests, we use the function directly with
+	// modelID="" (text-only) and verify the drop path, then test TXT path.
+
+	// StrategyDrop: image not supported by text-only model
+	parts, err := convertDocument(context.Background(), doc, "")
+	require.NoError(t, err)
+	assert.Nil(t, parts, "image should be dropped for text-only model")
+}
+
+func TestConvertDocument_StrategyTXT(t *testing.T) {
+	doc := chat.Document{
+		Name:     "readme.md",
+		MimeType: "text/markdown",
+		Source:   chat.DocumentSource{InlineText: "# Hello World"},
+	}
+
+	parts, err := convertDocument(context.Background(), doc, "")
+	require.NoError(t, err)
+	require.Len(t, parts, 1)
+	require.NotNil(t, parts[0].OfText)
+	assert.Contains(t, parts[0].OfText.Text, "readme.md")
+	assert.Contains(t, parts[0].OfText.Text, "text/markdown")
+	assert.Contains(t, parts[0].OfText.Text, "# Hello World")
+}
+
+func TestConvertDocument_StrategyTXT_Envelope(t *testing.T) {
+	doc := chat.Document{
+		Name:     "data.csv",
+		MimeType: "text/csv",
+		Source:   chat.DocumentSource{InlineText: "a,b,c\n1,2,3"},
+	}
+
+	parts, err := convertDocument(context.Background(), doc, "")
+	require.NoError(t, err)
+	require.Len(t, parts, 1)
+	require.NotNil(t, parts[0].OfText)
+	// Verify envelope format
+	text := parts[0].OfText.Text
+	assert.True(t, strings.HasPrefix(text, "<document"), "should be wrapped in document envelope")
+	assert.Contains(t, text, `name="data.csv"`)
+	assert.Contains(t, text, `mime-type="text/csv"`)
+}
+
+func TestConvertDocument_Drop_NoContent(t *testing.T) {
+	doc := chat.Document{
+		Name:     "empty.txt",
+		MimeType: "text/plain",
+		Source:   chat.DocumentSource{},
+	}
+
+	parts, err := convertDocument(context.Background(), doc, "")
+	require.NoError(t, err)
+	assert.Nil(t, parts, "should be dropped when no inline content")
+}

--- a/pkg/model/provider/oaistream/attachments_test.go
+++ b/pkg/model/provider/oaistream/attachments_test.go
@@ -1,31 +1,54 @@
 package oaistream
 
 import (
-	"context"
+	"encoding/base64"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/docker/docker-agent/pkg/attachment/modelcaps"
 	"github.com/docker/docker-agent/pkg/chat"
 )
 
+// minJPEG is a minimal JPEG magic-byte header for use in tests.
+var minJPEG = []byte{0xFF, 0xD8, 0xFF, 0xE0}
+
+// TestConvertDocument_StrategyB64_Image verifies that an image document with
+// InlineData and a vision-capable model produces an image content part with
+// a data-URI, not a text part.
 func TestConvertDocument_StrategyB64_Image(t *testing.T) {
 	doc := chat.Document{
 		Name:     "photo.jpg",
 		MimeType: "image/jpeg",
-		Source:   chat.DocumentSource{InlineData: []byte{0xFF, 0xD8, 0xFF, 0xE0}},
+		Source:   chat.DocumentSource{InlineData: minJPEG},
 	}
 
-	// Use a model ID that is unknown (text-only caps) — image/* will be dropped.
-	// For B64 testing we rely on an empty modelID which gives text-only caps.
-	// Use modelID "anthropic/claude-3-5-sonnet-20241022" which supports vision.
-	// Since we can't fetch live data in tests, we use the function directly with
-	// modelID="" (text-only) and verify the drop path, then test TXT path.
+	visionCaps := modelcaps.CapsWith(true, true)
+	parts, err := convertDocumentWithCaps(t.Context(), doc, visionCaps)
+	require.NoError(t, err)
+	require.Len(t, parts, 1, "expected exactly one image part")
+	require.NotNil(t, parts[0].OfImageURL, "expected image part, got non-image")
+	assert.Nil(t, parts[0].OfText, "expected no text part for B64 image")
 
-	// StrategyDrop: image not supported by text-only model
-	parts, err := convertDocument(context.Background(), doc, "")
+	// Data URI must embed the base64-encoded payload.
+	wantB64 := base64.StdEncoding.EncodeToString(minJPEG)
+	assert.Contains(t, parts[0].OfImageURL.ImageURL.URL, "data:image/jpeg;base64,")
+	assert.Contains(t, parts[0].OfImageURL.ImageURL.URL, wantB64)
+}
+
+// TestConvertDocument_StrategyB64_ImageDropped verifies that an image is
+// dropped when the model does not support vision.
+func TestConvertDocument_StrategyB64_ImageDropped(t *testing.T) {
+	doc := chat.Document{
+		Name:     "photo.jpg",
+		MimeType: "image/jpeg",
+		Source:   chat.DocumentSource{InlineData: minJPEG},
+	}
+
+	textOnlyCaps := modelcaps.CapsWith(false, false)
+	parts, err := convertDocumentWithCaps(t.Context(), doc, textOnlyCaps)
 	require.NoError(t, err)
 	assert.Nil(t, parts, "image should be dropped for text-only model")
 }
@@ -37,7 +60,7 @@ func TestConvertDocument_StrategyTXT(t *testing.T) {
 		Source:   chat.DocumentSource{InlineText: "# Hello World"},
 	}
 
-	parts, err := convertDocument(context.Background(), doc, "")
+	parts, err := convertDocument(t.Context(), doc, "")
 	require.NoError(t, err)
 	require.Len(t, parts, 1)
 	require.NotNil(t, parts[0].OfText)
@@ -53,11 +76,10 @@ func TestConvertDocument_StrategyTXT_Envelope(t *testing.T) {
 		Source:   chat.DocumentSource{InlineText: "a,b,c\n1,2,3"},
 	}
 
-	parts, err := convertDocument(context.Background(), doc, "")
+	parts, err := convertDocument(t.Context(), doc, "")
 	require.NoError(t, err)
 	require.Len(t, parts, 1)
 	require.NotNil(t, parts[0].OfText)
-	// Verify envelope format
 	text := parts[0].OfText.Text
 	assert.True(t, strings.HasPrefix(text, "<document"), "should be wrapped in document envelope")
 	assert.Contains(t, text, `name="data.csv"`)
@@ -71,7 +93,7 @@ func TestConvertDocument_Drop_NoContent(t *testing.T) {
 		Source:   chat.DocumentSource{},
 	}
 
-	parts, err := convertDocument(context.Background(), doc, "")
+	parts, err := convertDocument(t.Context(), doc, "")
 	require.NoError(t, err)
 	assert.Nil(t, parts, "should be dropped when no inline content")
 }

--- a/pkg/model/provider/oaistream/attachments_test.go
+++ b/pkg/model/provider/oaistream/attachments_test.go
@@ -64,8 +64,8 @@ func TestConvertDocument_StrategyTXT(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, parts, 1)
 	require.NotNil(t, parts[0].OfText)
-	assert.Contains(t, parts[0].OfText.Text, "readme.md")
-	assert.Contains(t, parts[0].OfText.Text, "text/markdown")
+	assert.Contains(t, parts[0].OfText.Text, "readme-md")
+	assert.Contains(t, parts[0].OfText.Text, "text-markdown")
 	assert.Contains(t, parts[0].OfText.Text, "# Hello World")
 }
 
@@ -82,8 +82,6 @@ func TestConvertDocument_StrategyTXT_Envelope(t *testing.T) {
 	require.NotNil(t, parts[0].OfText)
 	text := parts[0].OfText.Text
 	assert.True(t, strings.HasPrefix(text, "<document"), "should be wrapped in document envelope")
-	assert.Contains(t, text, `name="data.csv"`)
-	assert.Contains(t, text, `mime-type="text/csv"`)
 }
 
 func TestConvertDocument_Drop_NoContent(t *testing.T) {

--- a/pkg/model/provider/oaistream/messages.go
+++ b/pkg/model/provider/oaistream/messages.go
@@ -5,7 +5,9 @@ This file contains shared message conversion utilities for OpenAI-compatible pro
 */
 
 import (
+	"context"
 	"encoding/json"
+	"log/slog"
 	"strings"
 
 	"github.com/openai/openai-go/v3"
@@ -24,18 +26,30 @@ func (j JSONSchema) MarshalJSON() ([]byte, error) {
 }
 
 // ConvertMultiContent converts chat.MessagePart slices to OpenAI content parts.
-func ConvertMultiContent(multiContent []chat.MessagePart) []openai.ChatCompletionContentPartUnionParam {
+// modelID is used for attachment capability lookups; pass an empty string to
+// skip capability checks (all documents are attempted).
+func ConvertMultiContent(multiContent []chat.MessagePart, modelID string) []openai.ChatCompletionContentPartUnionParam {
 	parts := make([]openai.ChatCompletionContentPartUnionParam, 0, len(multiContent))
 	for _, part := range multiContent {
 		switch part.Type {
 		case chat.MessagePartTypeText:
 			parts = append(parts, openai.TextContentPart(part.Text))
 		case chat.MessagePartTypeImageURL:
+			// Deprecated: use MessagePartTypeDocument instead.
 			if part.ImageURL != nil {
 				parts = append(parts, openai.ImageContentPart(openai.ChatCompletionContentPartImageImageURLParam{
 					URL:    part.ImageURL.URL,
 					Detail: string(part.ImageURL.Detail),
 				}))
+			}
+		case chat.MessagePartTypeDocument:
+			if part.Document != nil {
+				docParts, err := convertDocument(context.Background(), *part.Document, modelID)
+				if err != nil {
+					slog.Warn("failed to convert document attachment", "error", err, "doc", part.Document.Name)
+					continue
+				}
+				parts = append(parts, docParts...)
 			}
 		}
 	}
@@ -43,8 +57,9 @@ func ConvertMultiContent(multiContent []chat.MessagePart) []openai.ChatCompletio
 }
 
 // ConvertMessages converts chat.Message slices to OpenAI message params.
+// modelID is forwarded to convertDocument for attachment capability lookups.
 // This is the base conversion without any provider-specific post-processing.
-func ConvertMessages(messages []chat.Message) []openai.ChatCompletionMessageParamUnion {
+func ConvertMessages(messages []chat.Message, modelID string) []openai.ChatCompletionMessageParamUnion {
 	openaiMessages := make([]openai.ChatCompletionMessageParamUnion, 0, len(messages))
 	for i := range messages {
 		msg := &messages[i]
@@ -77,7 +92,7 @@ func ConvertMessages(messages []chat.Message) []openai.ChatCompletionMessagePara
 			if len(msg.MultiContent) == 0 {
 				openaiMessage = openai.UserMessage(msg.Content)
 			} else {
-				openaiMessage = openai.UserMessage(ConvertMultiContent(msg.MultiContent))
+				openaiMessage = openai.UserMessage(ConvertMultiContent(msg.MultiContent, modelID))
 			}
 
 		case chat.MessageRoleAssistant:
@@ -300,4 +315,20 @@ func MergeConsecutiveMessages(openaiMessages []openai.ChatCompletionMessageParam
 	}
 
 	return mergedMessages
+}
+
+// ConvertMultiContentLegacy converts chat.MessagePart slices to OpenAI content parts
+// without model-capability lookup. It is equivalent to ConvertMultiContent(parts, "").
+//
+// Deprecated: use ConvertMultiContent with an explicit modelID instead.
+func ConvertMultiContentLegacy(multiContent []chat.MessagePart) []openai.ChatCompletionContentPartUnionParam {
+	return ConvertMultiContent(multiContent, "")
+}
+
+// ConvertMessagesLegacy converts chat.Message slices to OpenAI message params
+// without model-capability lookup. It is equivalent to ConvertMessages(msgs, "").
+//
+// Deprecated: use ConvertMessages with an explicit modelID instead.
+func ConvertMessagesLegacy(messages []chat.Message) []openai.ChatCompletionMessageParamUnion {
+	return ConvertMessages(messages, "")
 }

--- a/pkg/model/provider/oaistream/messages.go
+++ b/pkg/model/provider/oaistream/messages.go
@@ -26,16 +26,17 @@ func (j JSONSchema) MarshalJSON() ([]byte, error) {
 }
 
 // ConvertMultiContent converts chat.MessagePart slices to OpenAI content parts.
+// ctx is forwarded to convertDocument for logging and future cancellation support.
 // modelID is used for attachment capability lookups; pass an empty string to
 // skip capability checks (all documents are attempted).
-func ConvertMultiContent(multiContent []chat.MessagePart, modelID string) []openai.ChatCompletionContentPartUnionParam {
+func ConvertMultiContent(ctx context.Context, multiContent []chat.MessagePart, modelID string) []openai.ChatCompletionContentPartUnionParam {
 	parts := make([]openai.ChatCompletionContentPartUnionParam, 0, len(multiContent))
 	for _, part := range multiContent {
 		switch part.Type {
 		case chat.MessagePartTypeText:
 			parts = append(parts, openai.TextContentPart(part.Text))
 		case chat.MessagePartTypeImageURL:
-			// Deprecated: use MessagePartTypeDocument instead.
+			// Note: superseded by MessagePartTypeDocument.
 			if part.ImageURL != nil {
 				parts = append(parts, openai.ImageContentPart(openai.ChatCompletionContentPartImageImageURLParam{
 					URL:    part.ImageURL.URL,
@@ -44,9 +45,9 @@ func ConvertMultiContent(multiContent []chat.MessagePart, modelID string) []open
 			}
 		case chat.MessagePartTypeDocument:
 			if part.Document != nil {
-				docParts, err := convertDocument(context.Background(), *part.Document, modelID)
+				docParts, err := convertDocument(ctx, *part.Document, modelID)
 				if err != nil {
-					slog.Warn("failed to convert document attachment", "error", err, "doc", part.Document.Name)
+					slog.WarnContext(ctx, "failed to convert document attachment", "error", err, "doc", part.Document.Name)
 					continue
 				}
 				parts = append(parts, docParts...)
@@ -57,9 +58,10 @@ func ConvertMultiContent(multiContent []chat.MessagePart, modelID string) []open
 }
 
 // ConvertMessages converts chat.Message slices to OpenAI message params.
+// ctx is forwarded to convertDocument for logging and cancellation support.
 // modelID is forwarded to convertDocument for attachment capability lookups.
 // This is the base conversion without any provider-specific post-processing.
-func ConvertMessages(messages []chat.Message, modelID string) []openai.ChatCompletionMessageParamUnion {
+func ConvertMessages(ctx context.Context, messages []chat.Message, modelID string) []openai.ChatCompletionMessageParamUnion {
 	openaiMessages := make([]openai.ChatCompletionMessageParamUnion, 0, len(messages))
 	for i := range messages {
 		msg := &messages[i]
@@ -92,7 +94,7 @@ func ConvertMessages(messages []chat.Message, modelID string) []openai.ChatCompl
 			if len(msg.MultiContent) == 0 {
 				openaiMessage = openai.UserMessage(msg.Content)
 			} else {
-				openaiMessage = openai.UserMessage(ConvertMultiContent(msg.MultiContent, modelID))
+				openaiMessage = openai.UserMessage(ConvertMultiContent(ctx, msg.MultiContent, modelID))
 			}
 
 		case chat.MessageRoleAssistant:
@@ -315,20 +317,4 @@ func MergeConsecutiveMessages(openaiMessages []openai.ChatCompletionMessageParam
 	}
 
 	return mergedMessages
-}
-
-// ConvertMultiContentLegacy converts chat.MessagePart slices to OpenAI content parts
-// without model-capability lookup. It is equivalent to ConvertMultiContent(parts, "").
-//
-// Deprecated: use ConvertMultiContent with an explicit modelID instead.
-func ConvertMultiContentLegacy(multiContent []chat.MessagePart) []openai.ChatCompletionContentPartUnionParam {
-	return ConvertMultiContent(multiContent, "")
-}
-
-// ConvertMessagesLegacy converts chat.Message slices to OpenAI message params
-// without model-capability lookup. It is equivalent to ConvertMessages(msgs, "").
-//
-// Deprecated: use ConvertMessages with an explicit modelID instead.
-func ConvertMessagesLegacy(messages []chat.Message) []openai.ChatCompletionMessageParamUnion {
-	return ConvertMessages(messages, "")
 }

--- a/pkg/model/provider/oaistream/messages_test.go
+++ b/pkg/model/provider/oaistream/messages_test.go
@@ -62,7 +62,7 @@ func TestConvertMultiContent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			result := ConvertMultiContent(tt.multiContent)
+			result := ConvertMultiContent(tt.multiContent, "")
 			assert.Len(t, result, tt.wantCount)
 		})
 	}
@@ -137,7 +137,7 @@ func TestConvertMessages(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			result := ConvertMessages(tt.messages)
+			result := ConvertMessages(tt.messages, "")
 			assert.Len(t, result, tt.want)
 		})
 	}

--- a/pkg/model/provider/oaistream/messages_test.go
+++ b/pkg/model/provider/oaistream/messages_test.go
@@ -62,7 +62,7 @@ func TestConvertMultiContent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			result := ConvertMultiContent(tt.multiContent, "")
+			result := ConvertMultiContent(t.Context(), tt.multiContent, "")
 			assert.Len(t, result, tt.wantCount)
 		})
 	}
@@ -137,7 +137,7 @@ func TestConvertMessages(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			result := ConvertMessages(tt.messages, "")
+			result := ConvertMessages(t.Context(), tt.messages, "")
 			assert.Len(t, result, tt.want)
 		})
 	}

--- a/pkg/model/provider/openai/attachments.go
+++ b/pkg/model/provider/openai/attachments.go
@@ -54,13 +54,14 @@ func convertDocumentToResponseInputWithCaps(ctx context.Context, doc chat.Docume
 		}
 
 		if mime == "application/pdf" {
-			// The Responses API has a native file input block; use it for PDFs.
+			// The Responses API file block expects raw base64-encoded bytes in FileData
+			// (not a data URI). See ResponseInputFileParam.FileData godoc:
+			// "The base64-encoded data of the file to be sent to the model."
 			b64Data := base64.StdEncoding.EncodeToString(doc.Source.InlineData)
-			dataURI := fmt.Sprintf("data:%s;base64,%s", doc.MimeType, b64Data)
 			return []responses.ResponseInputContentUnionParam{
 				{
 					OfInputFile: &responses.ResponseInputFileParam{
-						FileData: param.NewOpt(dataURI),
+						FileData: param.NewOpt(b64Data),
 						Filename: param.NewOpt(doc.Name),
 					},
 				},

--- a/pkg/model/provider/openai/attachments.go
+++ b/pkg/model/provider/openai/attachments.go
@@ -25,6 +25,11 @@ import (
 //   - unsupported / no content → nil (logged as warning)
 func convertDocumentToResponseInput(ctx context.Context, doc chat.Document, modelID string) ([]responses.ResponseInputContentUnionParam, error) {
 	mc, _ := modelcaps.Load(modelID)
+	return convertDocumentToResponseInputWithCaps(ctx, doc, mc)
+}
+
+// convertDocumentToResponseInputWithCaps is the caps-injectable variant used by tests.
+func convertDocumentToResponseInputWithCaps(ctx context.Context, doc chat.Document, mc modelcaps.ModelCapabilities) ([]responses.ResponseInputContentUnionParam, error) {
 	strategy, reason := attachment.Decide(doc, mc)
 
 	switch strategy {

--- a/pkg/model/provider/openai/attachments.go
+++ b/pkg/model/provider/openai/attachments.go
@@ -1,0 +1,81 @@
+package openai
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/openai/openai-go/v3/responses"
+
+	"github.com/docker/docker-agent/pkg/attachment"
+	"github.com/docker/docker-agent/pkg/attachment/modelcaps"
+	"github.com/docker/docker-agent/pkg/chat"
+)
+
+// convertDocumentToResponseInput converts a chat.Document to zero or more
+// ResponseInputContentUnionParam values for the OpenAI Responses API.
+//
+// Routing:
+//   - image/* with InlineData → OfInputImage with a data URI
+//   - other binary with InlineData → OfInputText with TXTEnvelope fallback
+//   - text MIMEs with InlineText → OfInputText with TXTEnvelope
+//   - unsupported / no content → nil (logged as warning)
+func convertDocumentToResponseInput(ctx context.Context, doc chat.Document, modelID string) ([]responses.ResponseInputContentUnionParam, error) {
+	mc, _ := modelcaps.Load(modelID)
+	strategy, reason := attachment.Decide(doc, mc)
+
+	switch strategy {
+	case attachment.StrategyDrop:
+		slog.WarnContext(ctx, "attachment dropped", "reason", reason, "doc", doc.Name)
+		return nil, nil
+
+	case attachment.StrategyB64:
+		mime := strings.ToLower(doc.MimeType)
+		if strings.HasPrefix(mime, "image/") {
+			dataURI := fmt.Sprintf("data:%s;base64,%s",
+				doc.MimeType,
+				base64.StdEncoding.EncodeToString(doc.Source.InlineData))
+			return []responses.ResponseInputContentUnionParam{
+				{
+					OfInputImage: &responses.ResponseInputImageParam{
+						ImageURL: param.NewOpt(dataURI),
+						Detail:   responses.ResponseInputImageDetail(responses.ResponseInputImageContentDetailAuto),
+					},
+				},
+			}, nil
+		}
+		// Non-image binary: no native document block in the Responses API.
+		slog.DebugContext(ctx, "openai responses: no native block for MIME, falling back to TXT envelope",
+			"mime", doc.MimeType, "doc", doc.Name)
+		envelope := attachment.TXTEnvelope(doc.Name, doc.MimeType,
+			base64.StdEncoding.EncodeToString(doc.Source.InlineData))
+		return []responses.ResponseInputContentUnionParam{
+			{OfInputText: &responses.ResponseInputTextParam{Text: envelope}},
+		}, nil
+
+	case attachment.StrategyTXT:
+		envelope := attachment.TXTEnvelope(doc.Name, doc.MimeType, doc.Source.InlineText)
+		return []responses.ResponseInputContentUnionParam{
+			{OfInputText: &responses.ResponseInputTextParam{Text: envelope}},
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("unknown attachment strategy %d", strategy)
+	}
+}
+
+// SupportedMIMETypes implements attachment.Advisor for the OpenAI client.
+func (c *Client) SupportedMIMETypes() []string {
+	mc, _ := modelcaps.Load(c.ModelConfig.Model)
+	mimes := []string{"text/plain", "text/markdown", "text/html", "text/csv"}
+	if mc.Supports("image/jpeg") {
+		mimes = append(mimes, "image/jpeg", "image/png", "image/gif", "image/webp")
+	}
+	if mc.Supports("application/pdf") {
+		mimes = append(mimes, "application/pdf")
+	}
+	return mimes
+}

--- a/pkg/model/provider/openai/attachments.go
+++ b/pkg/model/provider/openai/attachments.go
@@ -52,14 +52,25 @@ func convertDocumentToResponseInputWithCaps(ctx context.Context, doc chat.Docume
 				},
 			}, nil
 		}
-		// Non-image binary: no native document block in the Responses API.
-		slog.DebugContext(ctx, "openai responses: no native block for MIME, falling back to TXT envelope",
+
+		if mime == "application/pdf" {
+			// The Responses API has a native file input block; use it for PDFs.
+			b64Data := base64.StdEncoding.EncodeToString(doc.Source.InlineData)
+			dataURI := fmt.Sprintf("data:%s;base64,%s", doc.MimeType, b64Data)
+			return []responses.ResponseInputContentUnionParam{
+				{
+					OfInputFile: &responses.ResponseInputFileParam{
+						FileData: param.NewOpt(dataURI),
+						Filename: param.NewOpt(doc.Name),
+					},
+				},
+			}, nil
+		}
+
+		// Unexpected binary MIME — defensive drop.
+		slog.WarnContext(ctx, "openai responses: unexpected binary MIME in StrategyB64, dropping",
 			"mime", doc.MimeType, "doc", doc.Name)
-		envelope := attachment.TXTEnvelope(doc.Name, doc.MimeType,
-			base64.StdEncoding.EncodeToString(doc.Source.InlineData))
-		return []responses.ResponseInputContentUnionParam{
-			{OfInputText: &responses.ResponseInputTextParam{Text: envelope}},
-		}, nil
+		return nil, nil
 
 	case attachment.StrategyTXT:
 		envelope := attachment.TXTEnvelope(doc.Name, doc.MimeType, doc.Source.InlineText)

--- a/pkg/model/provider/openai/attachments.go
+++ b/pkg/model/provider/openai/attachments.go
@@ -71,16 +71,3 @@ func convertDocumentToResponseInputWithCaps(ctx context.Context, doc chat.Docume
 		return nil, fmt.Errorf("unknown attachment strategy %d", strategy)
 	}
 }
-
-// SupportedMIMETypes implements attachment.Advisor for the OpenAI client.
-func (c *Client) SupportedMIMETypes() []string {
-	mc, _ := modelcaps.Load(c.ModelConfig.Model)
-	mimes := []string{"text/plain", "text/markdown", "text/html", "text/csv"}
-	if mc.Supports("image/jpeg") {
-		mimes = append(mimes, "image/jpeg", "image/png", "image/gif", "image/webp")
-	}
-	if mc.Supports("application/pdf") {
-		mimes = append(mimes, "application/pdf")
-	}
-	return mimes
-}

--- a/pkg/model/provider/openai/attachments_test.go
+++ b/pkg/model/provider/openai/attachments_test.go
@@ -1,15 +1,57 @@
 package openai
 
 import (
-	"context"
+	"encoding/base64"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/docker/docker-agent/pkg/attachment/modelcaps"
 	"github.com/docker/docker-agent/pkg/chat"
 )
+
+// minJPEG is a minimal JPEG magic-byte header for use in tests.
+var minJPEG = []byte{0xFF, 0xD8, 0xFF, 0xE0}
+
+// TestConvertDocumentResponseInput_StrategyB64_Image verifies that an image
+// document with InlineData and a vision-capable model produces a native image
+// part (OfInputImage) with a data-URI.
+func TestConvertDocumentResponseInput_StrategyB64_Image(t *testing.T) {
+	doc := chat.Document{
+		Name:     "photo.jpg",
+		MimeType: "image/jpeg",
+		Source:   chat.DocumentSource{InlineData: minJPEG},
+	}
+
+	visionCaps := modelcaps.CapsWith(true, true)
+	parts, err := convertDocumentToResponseInputWithCaps(t.Context(), doc, visionCaps)
+	require.NoError(t, err)
+	require.Len(t, parts, 1, "expected exactly one image part")
+	require.NotNil(t, parts[0].OfInputImage, "expected OfInputImage, not text")
+	assert.Nil(t, parts[0].OfInputText, "expected no text part for B64 image")
+
+	wantB64 := base64.StdEncoding.EncodeToString(minJPEG)
+	imageURL := parts[0].OfInputImage.ImageURL.Value
+	assert.Contains(t, imageURL, "data:image/jpeg;base64,")
+	assert.Contains(t, imageURL, wantB64)
+}
+
+// TestConvertDocumentResponseInput_StrategyB64_ImageDropped verifies that an
+// image is dropped for a text-only model.
+func TestConvertDocumentResponseInput_StrategyB64_ImageDropped(t *testing.T) {
+	doc := chat.Document{
+		Name:     "photo.jpg",
+		MimeType: "image/jpeg",
+		Source:   chat.DocumentSource{InlineData: minJPEG},
+	}
+
+	textOnlyCaps := modelcaps.CapsWith(false, false)
+	parts, err := convertDocumentToResponseInputWithCaps(t.Context(), doc, textOnlyCaps)
+	require.NoError(t, err)
+	assert.Nil(t, parts, "image should be dropped for text-only model")
+}
 
 func TestConvertDocumentResponseInput_StrategyTXT(t *testing.T) {
 	doc := chat.Document{
@@ -18,7 +60,7 @@ func TestConvertDocumentResponseInput_StrategyTXT(t *testing.T) {
 		Source:   chat.DocumentSource{InlineText: "## API Spec"},
 	}
 
-	parts, err := convertDocumentToResponseInput(context.Background(), doc, "")
+	parts, err := convertDocumentToResponseInput(t.Context(), doc, "")
 	require.NoError(t, err)
 	require.Len(t, parts, 1)
 	require.NotNil(t, parts[0].OfInputText)
@@ -35,7 +77,7 @@ func TestConvertDocumentResponseInput_StrategyTXT_Envelope(t *testing.T) {
 		Source:   chat.DocumentSource{InlineText: "x,y"},
 	}
 
-	parts, err := convertDocumentToResponseInput(context.Background(), doc, "")
+	parts, err := convertDocumentToResponseInput(t.Context(), doc, "")
 	require.NoError(t, err)
 	require.Len(t, parts, 1)
 	require.NotNil(t, parts[0].OfInputText)
@@ -51,19 +93,7 @@ func TestConvertDocumentResponseInput_Drop_NoContent(t *testing.T) {
 		Source:   chat.DocumentSource{},
 	}
 
-	parts, err := convertDocumentToResponseInput(context.Background(), doc, "")
+	parts, err := convertDocumentToResponseInput(t.Context(), doc, "")
 	require.NoError(t, err)
 	assert.Nil(t, parts, "should be nil when no inline content")
-}
-
-func TestConvertDocumentResponseInput_Drop_UnsupportedMIME(t *testing.T) {
-	doc := chat.Document{
-		Name:     "photo.jpg",
-		MimeType: "image/jpeg",
-		Source:   chat.DocumentSource{InlineData: []byte{0xFF, 0xD8}},
-	}
-
-	parts, err := convertDocumentToResponseInput(context.Background(), doc, "")
-	require.NoError(t, err)
-	assert.Nil(t, parts, "image should be dropped for text-only model")
 }

--- a/pkg/model/provider/openai/attachments_test.go
+++ b/pkg/model/provider/openai/attachments_test.go
@@ -1,0 +1,69 @@
+package openai
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/chat"
+)
+
+func TestConvertDocumentResponseInput_StrategyTXT(t *testing.T) {
+	doc := chat.Document{
+		Name:     "spec.md",
+		MimeType: "text/markdown",
+		Source:   chat.DocumentSource{InlineText: "## API Spec"},
+	}
+
+	parts, err := convertDocumentToResponseInput(context.Background(), doc, "")
+	require.NoError(t, err)
+	require.Len(t, parts, 1)
+	require.NotNil(t, parts[0].OfInputText)
+	text := parts[0].OfInputText.Text
+	assert.Contains(t, text, "spec.md")
+	assert.Contains(t, text, "text/markdown")
+	assert.Contains(t, text, "## API Spec")
+}
+
+func TestConvertDocumentResponseInput_StrategyTXT_Envelope(t *testing.T) {
+	doc := chat.Document{
+		Name:     "data.csv",
+		MimeType: "text/csv",
+		Source:   chat.DocumentSource{InlineText: "x,y"},
+	}
+
+	parts, err := convertDocumentToResponseInput(context.Background(), doc, "")
+	require.NoError(t, err)
+	require.Len(t, parts, 1)
+	require.NotNil(t, parts[0].OfInputText)
+	text := parts[0].OfInputText.Text
+	assert.True(t, strings.HasPrefix(text, "<document"), "should be wrapped in envelope")
+	assert.Contains(t, text, `name="data.csv"`)
+}
+
+func TestConvertDocumentResponseInput_Drop_NoContent(t *testing.T) {
+	doc := chat.Document{
+		Name:     "empty.md",
+		MimeType: "text/markdown",
+		Source:   chat.DocumentSource{},
+	}
+
+	parts, err := convertDocumentToResponseInput(context.Background(), doc, "")
+	require.NoError(t, err)
+	assert.Nil(t, parts, "should be nil when no inline content")
+}
+
+func TestConvertDocumentResponseInput_Drop_UnsupportedMIME(t *testing.T) {
+	doc := chat.Document{
+		Name:     "photo.jpg",
+		MimeType: "image/jpeg",
+		Source:   chat.DocumentSource{InlineData: []byte{0xFF, 0xD8}},
+	}
+
+	parts, err := convertDocumentToResponseInput(context.Background(), doc, "")
+	require.NoError(t, err)
+	assert.Nil(t, parts, "image should be dropped for text-only model")
+}

--- a/pkg/model/provider/openai/attachments_test.go
+++ b/pkg/model/provider/openai/attachments_test.go
@@ -65,8 +65,8 @@ func TestConvertDocumentResponseInput_StrategyTXT(t *testing.T) {
 	require.Len(t, parts, 1)
 	require.NotNil(t, parts[0].OfInputText)
 	text := parts[0].OfInputText.Text
-	assert.Contains(t, text, "spec.md")
-	assert.Contains(t, text, "text/markdown")
+	assert.Contains(t, text, "spec-md")
+	assert.Contains(t, text, "text-markdown")
 	assert.Contains(t, text, "## API Spec")
 }
 
@@ -83,7 +83,6 @@ func TestConvertDocumentResponseInput_StrategyTXT_Envelope(t *testing.T) {
 	require.NotNil(t, parts[0].OfInputText)
 	text := parts[0].OfInputText.Text
 	assert.True(t, strings.HasPrefix(text, "<document"), "should be wrapped in envelope")
-	assert.Contains(t, text, `name="data.csv"`)
 }
 
 func TestConvertDocumentResponseInput_Drop_NoContent(t *testing.T) {

--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -179,8 +179,8 @@ func (c *Client) Close() {
 
 // convertMessages converts chat.Message to openai.ChatCompletionMessageParamUnion
 // using the shared oaistream implementation.
-func convertMessages(messages []chat.Message) []openai.ChatCompletionMessageParamUnion {
-	return oaistream.ConvertMessages(messages)
+func (c *Client) convertMessages(messages []chat.Message) []openai.ChatCompletionMessageParamUnion {
+	return oaistream.ConvertMessages(messages, c.ModelConfig.Model)
 }
 
 // CreateChatCompletionStream creates a streaming chat completion request
@@ -224,7 +224,7 @@ func (c *Client) CreateChatCompletionStream(
 
 	params := openai.ChatCompletionNewParams{
 		Model:    c.ModelConfig.Model,
-		Messages: convertMessages(messages),
+		Messages: c.convertMessages(messages),
 		StreamOptions: openai.ChatCompletionStreamOptionsParam{
 			IncludeUsage: openai.Bool(trackUsage),
 		},
@@ -363,7 +363,7 @@ func (c *Client) CreateResponseStream(
 		return nil, errors.New("at least one message is required")
 	}
 
-	input := convertMessagesToResponseInput(messages)
+	input := c.convertMessagesToResponseInput(messages)
 
 	params := responses.ResponseNewParams{
 		Model: c.ModelConfig.Model,
@@ -563,7 +563,7 @@ func getTransport(cfg *latest.ModelConfig) string {
 	return "sse"
 }
 
-func convertMessagesToResponseInput(messages []chat.Message) []responses.ResponseInputItemUnionParam {
+func (c *Client) convertMessagesToResponseInput(messages []chat.Message) []responses.ResponseInputItemUnionParam {
 	var input []responses.ResponseInputItemUnionParam
 	for _, msg := range messages {
 		// Skip invalid messages
@@ -594,6 +594,7 @@ func convertMessagesToResponseInput(messages []chat.Message) []responses.Respons
 							},
 						})
 					case chat.MessagePartTypeImageURL:
+						// Deprecated: use MessagePartTypeDocument instead.
 						if part.ImageURL != nil {
 							detail := responses.ResponseInputImageContentDetailAuto
 							switch part.ImageURL.Detail {
@@ -608,6 +609,15 @@ func convertMessagesToResponseInput(messages []chat.Message) []responses.Respons
 									Detail:   responses.ResponseInputImageDetail(detail),
 								},
 							})
+						}
+					case chat.MessagePartTypeDocument:
+						if part.Document != nil {
+							docParts, err := convertDocumentToResponseInput(context.Background(), *part.Document, c.ModelConfig.Model)
+							if err != nil {
+								slog.Warn("failed to convert document attachment", "error", err, "doc", part.Document.Name)
+								continue
+							}
+							contentParts = append(contentParts, docParts...)
 						}
 					}
 				}

--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -179,8 +179,8 @@ func (c *Client) Close() {
 
 // convertMessages converts chat.Message to openai.ChatCompletionMessageParamUnion
 // using the shared oaistream implementation.
-func (c *Client) convertMessages(messages []chat.Message) []openai.ChatCompletionMessageParamUnion {
-	return oaistream.ConvertMessages(messages, c.ModelConfig.Model)
+func (c *Client) convertMessages(ctx context.Context, messages []chat.Message) []openai.ChatCompletionMessageParamUnion {
+	return oaistream.ConvertMessages(ctx, messages, c.ModelConfig.Model)
 }
 
 // CreateChatCompletionStream creates a streaming chat completion request
@@ -224,7 +224,7 @@ func (c *Client) CreateChatCompletionStream(
 
 	params := openai.ChatCompletionNewParams{
 		Model:    c.ModelConfig.Model,
-		Messages: c.convertMessages(messages),
+		Messages: c.convertMessages(ctx, messages),
 		StreamOptions: openai.ChatCompletionStreamOptionsParam{
 			IncludeUsage: openai.Bool(trackUsage),
 		},
@@ -363,7 +363,7 @@ func (c *Client) CreateResponseStream(
 		return nil, errors.New("at least one message is required")
 	}
 
-	input := c.convertMessagesToResponseInput(messages)
+	input := c.convertMessagesToResponseInput(ctx, messages)
 
 	params := responses.ResponseNewParams{
 		Model: c.ModelConfig.Model,
@@ -563,7 +563,7 @@ func getTransport(cfg *latest.ModelConfig) string {
 	return "sse"
 }
 
-func (c *Client) convertMessagesToResponseInput(messages []chat.Message) []responses.ResponseInputItemUnionParam {
+func (c *Client) convertMessagesToResponseInput(ctx context.Context, messages []chat.Message) []responses.ResponseInputItemUnionParam {
 	var input []responses.ResponseInputItemUnionParam
 	for _, msg := range messages {
 		// Skip invalid messages
@@ -594,7 +594,7 @@ func (c *Client) convertMessagesToResponseInput(messages []chat.Message) []respo
 							},
 						})
 					case chat.MessagePartTypeImageURL:
-						// Deprecated: use MessagePartTypeDocument instead.
+						// Note: superseded by MessagePartTypeDocument.
 						if part.ImageURL != nil {
 							detail := responses.ResponseInputImageContentDetailAuto
 							switch part.ImageURL.Detail {
@@ -612,9 +612,9 @@ func (c *Client) convertMessagesToResponseInput(messages []chat.Message) []respo
 						}
 					case chat.MessagePartTypeDocument:
 						if part.Document != nil {
-							docParts, err := convertDocumentToResponseInput(context.Background(), *part.Document, c.ModelConfig.Model)
+							docParts, err := convertDocumentToResponseInput(ctx, *part.Document, c.ModelConfig.Model)
 							if err != nil {
-								slog.Warn("failed to convert document attachment", "error", err, "doc", part.Document.Name)
+								slog.WarnContext(ctx, "failed to convert document attachment", "error", err, "doc", part.Document.Name)
 								continue
 							}
 							contentParts = append(contentParts, docParts...)

--- a/pkg/model/provider/openai/client_test.go
+++ b/pkg/model/provider/openai/client_test.go
@@ -26,7 +26,7 @@ func TestConvertMessagesToResponseInput_OrphanedFunctionCall(t *testing.T) {
 		// call_2 has no result — orphaned
 	}
 
-	input := convertMessagesToResponseInput(messages)
+	input := (&Client{}).convertMessagesToResponseInput(messages)
 
 	// Count function calls and outputs
 	var callIDs, outputIDs []string
@@ -61,7 +61,7 @@ func TestConvertMessagesToResponseInput_AssistantTextWithToolCalls(t *testing.T)
 		{Role: chat.MessageRoleTool, Content: "result", ToolCallID: "call_1"},
 	}
 
-	input := convertMessagesToResponseInput(messages)
+	input := (&Client{}).convertMessagesToResponseInput(messages)
 
 	// We expect: user message, assistant text message, function call, function call output.
 	var foundAssistantText bool
@@ -94,7 +94,7 @@ func TestConvertMessagesToResponseInput_NoOrphans(t *testing.T) {
 		{Role: chat.MessageRoleTool, Content: "result a", ToolCallID: "call_1"},
 	}
 
-	input := convertMessagesToResponseInput(messages)
+	input := (&Client{}).convertMessagesToResponseInput(messages)
 
 	var outputCount int
 	for _, item := range input {

--- a/pkg/model/provider/openai/client_test.go
+++ b/pkg/model/provider/openai/client_test.go
@@ -26,7 +26,7 @@ func TestConvertMessagesToResponseInput_OrphanedFunctionCall(t *testing.T) {
 		// call_2 has no result — orphaned
 	}
 
-	input := (&Client{}).convertMessagesToResponseInput(messages)
+	input := (&Client{}).convertMessagesToResponseInput(t.Context(), messages)
 
 	// Count function calls and outputs
 	var callIDs, outputIDs []string
@@ -61,7 +61,7 @@ func TestConvertMessagesToResponseInput_AssistantTextWithToolCalls(t *testing.T)
 		{Role: chat.MessageRoleTool, Content: "result", ToolCallID: "call_1"},
 	}
 
-	input := (&Client{}).convertMessagesToResponseInput(messages)
+	input := (&Client{}).convertMessagesToResponseInput(t.Context(), messages)
 
 	// We expect: user message, assistant text message, function call, function call output.
 	var foundAssistantText bool
@@ -94,7 +94,7 @@ func TestConvertMessagesToResponseInput_NoOrphans(t *testing.T) {
 		{Role: chat.MessageRoleTool, Content: "result a", ToolCallID: "call_1"},
 	}
 
-	input := (&Client{}).convertMessagesToResponseInput(messages)
+	input := (&Client{}).convertMessagesToResponseInput(t.Context(), messages)
 
 	var outputCount int
 	for _, item := range input {


### PR DESCRIPTION
## Summary

Implements Phase 1 of the structured attachment system. Part of #2595.

## What's added

### `pkg/chat/document.go` (new)
- `MessagePartTypeDocument` constant
- `DocumentSource` struct (InlineText / InlineData fields)
- `Document` struct (Name, MimeType, Size, Source)
- `Document *Document` field added to `MessagePart`
- `MessagePartTypeFile` and `MessagePartTypeImageURL` annotated as superseded (not formally deprecated to avoid SA1019 on existing call sites)

### `pkg/attachment/` (new package)
- `attachment.go`: `Strategy` type, `Decide()` routing function, `TXTEnvelope()` helper (with `</document>` escape to prevent envelope breakout)
- `modelcaps/modelcaps.go`: `ModelCapabilities` backed by models.dev data (via `pkg/modelsdev` store); `Supports(mimeType)` gates image/* on vision modality, application/pdf on pdf modality, text/* always allowed, everything else (audio, video, Office binary formats) returns false

### Per-provider `attachments.go` (new files)
Added `convertDocument(ctx, doc, modelID)` and testable `convertDocumentWithCaps(ctx, doc, mc)` to:
- `pkg/model/provider/oaistream` — image → data-URI image part; PDF/other binary → dropped with warning (Chat Completions has no native document block); text → TXTEnvelope; wired into `ConvertMultiContent`
- `pkg/model/provider/openai` — image → `OfInputImage`; PDF → `OfInputFile` (native Responses API file block); text → `OfInputText` with TXTEnvelope
- `pkg/model/provider/anthropic` — image → `ImageBlockParam` (base64); PDF → `DocumentBlockParam` (gated on `application/pdf` only, not `IsAnthropicDocumentMime`); text → `TextBlockParam` with TXTEnvelope
- `pkg/model/provider/gemini` — binary → `genai.Blob`; text → `genai.Text` with TXTEnvelope
- `pkg/model/provider/bedrock` — image → `ContentBlockMemberImage`; PDF → `ContentBlockMemberDocument`; text → `ContentBlockMemberText` with TXTEnvelope

### Signature changes (intentional breaking change)
`ConvertMessages` and `ConvertMultiContent` in `oaistream` now accept `ctx context.Context` and `modelID string` parameters for capability routing and context propagation. All in-tree callers updated.

## Tests
- `pkg/attachment/decide_test.go` — table-driven, all 3 strategy outcomes + MIME-miss + TXTEnvelope escaping
- `pkg/attachment/modelcaps/modelcaps_test.go` — in-memory store, vision/text-only/unknown model/Office-rejected cases
- Per-provider `attachments_test.go` — TXT strategy, Drop strategy, B64 image and PDF success paths

## What's NOT changed
- Existing `MessagePartTypeFile` and `MessagePartTypeImageURL` handling is preserved unchanged
- No config schema changes (Phase 1 is API-only)

Part of #2595