### PR TITLE
docs(github): update issue templates and triage workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-.md
+++ b/.github/ISSUE_TEMPLATE/bug-.md
@@ -1,42 +1,53 @@
 ---
-name: Bug!
-about: Create a report to help us squash the bugs
-title: "<short bug description>"
-labels: kind/bug
+name: Bug Report
+about: Report a defect, crash, or unexpected behavior
+title: "<short description>"
+type: Bug
 assignees: ""
 ---
 
-**Describe the bug**
+## Description
 
 A clear and concise description of what the bug is.
 
-**Version affected**
+## Expected Behavior
 
-Please include the version of the software that you are using.  
-(paste the output of the `version` command)
+What you expected to happen.
 
-**How To Reproduce**
+## Actual Behavior
 
-Detailed steps to reproduce the behavior:
+What actually happened instead.
 
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+## Steps to Reproduce
 
-**Expectation**
+Detailed steps to reproduce the bug:
 
-A clear and concise description of what you expected to see/happen.
+1. 
+2. 
+3. 
 
-**Screenshots**
+## Environment
 
-If applicable, add screenshots to help explain your problem.
-Especially useful if the problem is visual (rendering issues etc.) or you're not totally sure how to explain the problem and need to show it to us
+- **Docker Agent Version**: (output of `docker agent --version`)
+- **OS & Terminal**: macOS / Linux / Windows + terminal app
+- **Model Used**: (e.g., claude-opus-4-1, gpt-4, etc.)
 
-**OS and Terminal type**
+## Error Output
 
-Please include what OS and terminal you are using
+If applicable, paste the full error message or stack trace:
 
-**Additional context**
+```
+<error output>
+```
 
-Any other info you consider useful can be included here
+## Screenshots
+
+If this is a visual issue (TUI rendering, output formatting, etc.), add screenshots.
+
+## Additional Context
+
+Any other information that might help us debug:
+- Recent changes you made to your agent config
+- Tools or MCPs being used
+- Whether this is a regression (used to work in a previous version)
+- Links to related issues

--- a/.github/ISSUE_TEMPLATE/feature-.md
+++ b/.github/ISSUE_TEMPLATE/feature-.md
@@ -1,27 +1,49 @@
 ---
-name: Feature!
-about: Suggest a new feature you'd like to see
-title: "<your feature>"
-labels: kind/feature
+name: Feature Request
+about: Suggest a new feature or improvement
+title: "<short description>"
+type: Enhancement
 assignees: ""
 ---
 
-**What you'd like to see**
+## Overview
 
-Describe in as much detail as possible the feature you'd like to see.
-Please limit this to a single small feature whenever possible to ease development and contribution efforts
+Describe the feature or improvement you'd like to see. Be as specific as possible.
 
-**Why you'd like to see it**
+## Motivation
 
-Tell us why it's important for you.
-`x` thing would help me do ...
-`y` feature frustrates me.
-`z` feature would get rid of these issues ...
+Why is this important? What problem does it solve?
 
-**Workarounds?**
+Examples:
+- "This would let me do..."
+- "Currently, I have to work around this by..."
+- "This is needed for..."
 
-Are you using any workarounds at the moment? If so, tell us about them
+## Use Cases
 
-**Additional context**
+Describe concrete scenarios where this feature would help:
 
-Any other info you consider useful can be included here
+1. 
+2. 
+3. 
+
+## Proposed Solution
+
+If you have ideas on how to implement this, describe them here.
+
+Examples:
+- New CLI flag: `--option value`
+- New agent config field: `agents.root.new_field: value`
+- New tool: `xyz_tool`
+
+## Alternatives
+
+Are there any workarounds available currently? What are the alternatives?
+
+## Related Issues
+
+Link any related issues or discussions.
+
+## Additional Context
+
+Any other information relevant to this feature request.

--- a/.github/agents/nightly-scanner.yaml
+++ b/.github/agents/nightly-scanner.yaml
@@ -389,7 +389,6 @@ agents:
          cat << 'EOF' | gh issue create \
            --title "$ISSUE_TITLE" \
            --label "automated" \
-           --label "kind/bug" \
            --body-file -
          Issue body content here...
          EOF
@@ -401,11 +400,9 @@ agents:
 
       Title: `[security] Brief title` or `[bug] Brief title` or `[documentation] Brief title`
 
-      Labels (select based on category):
+      Labels:
       - Always add `automated`
-      - `security` category → add `kind/bug` (security issues are bugs)
-      - `bug` category → add `kind/bug`
-      - `documentation` category → add `kind/documentation`
+      - Issue type is set separately via GitHub's native type system, not labels
 
       Body template (use heredoc to handle backticks and special characters):
       ```bash
@@ -414,7 +411,6 @@ agents:
       cat << 'EOF' | gh issue create \
         --title "$ISSUE_TITLE" \
         --label "automated" \
-        --label "kind/bug" \
         --body-file -
       ## 🔴 critical - security
 

--- a/.github/workflows/auto-issue-triage.yml
+++ b/.github/workflows/auto-issue-triage.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   triage:
-    if: github.event.label.name == 'kind/bug'
+    if: github.event.issue.node_id != '' && github.event.issue.type == 'Bug'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:


### PR DESCRIPTION
Modernize the GitHub issue templates for bugs and feature requests,
replacing informal formatting with structured Markdown sections.
Update the auto-triage workflow and nightly scanner to use GitHub's
native issue type system instead of kind/* labels.

Key changes:

- Rewrite bug report template with clearer sections for expected
  vs actual behavior, environment details, and error output
- Rewrite feature request template with motivation, use cases,
  proposed solution, and alternatives sections
- Add `type: Bug` and `type: Enhancement` frontmatter to use
  GitHub's native issue type system
- Remove `kind/bug` and `kind/documentation` labels from both
  templates and the nightly scanner, as issue type is now set
  via GitHub's native type field
- Update auto-triage workflow condition from checking for the
  `kind/bug` label to checking for issues with type `Bug`