### PR TITLE
docs: fix broken links and outdated/incorrect snippets

### DIFF
--- a/docs/configuration/hooks/index.md
+++ b/docs/configuration/hooks/index.md
@@ -396,8 +396,8 @@ if [[ "$TOOL_NAME" == "shell" ]]; then
   fi
 fi
 
-# Allow everything else
-echo '{"decision": "allow"}'
+# Allow everything else (returning {} means "do nothing, continue normally")
+echo '{}'
 exit 0
 ```
 

--- a/docs/configuration/models/index.md
+++ b/docs/configuration/models/index.md
@@ -195,7 +195,7 @@ models:
       thinking_display: summarized # "summarized", "display", or "omitted"
 ```
 
-See the [Anthropic provider page](/providers/anthropic/#thinking-display) for details.
+See the [Anthropic provider page]({{ '/providers/anthropic/#thinking-display' | relative_url }}) for details.
 
 ## Custom HTTP Headers
 

--- a/docs/configuration/overview/index.md
+++ b/docs/configuration/overview/index.md
@@ -46,7 +46,7 @@ rag:
     docs: ["./docs"]
     strategies:
       - type: chunked-embeddings
-        model: openai/text-embedding-3-small
+        embedding_model: openai/text-embedding-3-small
 
 # 6. MCPs — reusable MCP server definitions (optional)
 mcps:

--- a/docs/tools/fetch/index.md
+++ b/docs/tools/fetch/index.md
@@ -15,7 +15,7 @@ The fetch tool lets agents retrieve content from one or more HTTP/HTTPS URLs. It
 <div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ GET only
 </div>
-  <p>The fetch tool does <strong>not</strong> support <code>POST</code>, <code>PUT</code>, <code>DELETE</code> or other methods, and does not expose request bodies or custom headers. To call REST endpoints with other verbs, use the <a href="{{ '/tools/api/' | relative_url }}">API tool</a> or an <a href="{{ '/configuration/tools/#openapi' | relative_url }}">OpenAPI toolset</a>.</p>
+  <p>The fetch tool does <strong>not</strong> support <code>POST</code>, <code>PUT</code>, <code>DELETE</code> or other methods, and does not expose request bodies or custom headers. To call REST endpoints with other verbs, use the <a href="{{ '/tools/api/' | relative_url }}">API tool</a> or an <a href="{{ '/tools/openapi/' | relative_url }}">OpenAPI toolset</a>.</p>
 
 </div>
 

--- a/docs/tools/lsp/index.md
+++ b/docs/tools/lsp/index.md
@@ -59,14 +59,14 @@ agents:
 
 ## Properties
 
-| Property      | Type   | Required | Description                                                                                                                                                              |
-| ------------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------- |
-| `command`     | string | ✓        | LSP server executable command                                                                                                                                            |
-| `args`        | array  | ✗        | Command-line arguments for the LSP server                                                                                                                                |
-| `env`         | object | ✗        | Environment variables for the LSP process                                                                                                                                |
-| `file_types`  | array  | ✗        | File extensions this LSP handles (e.g., `[".go", ".mod"]`)                                                                                                               |
+| Property      | Type   | Required | Description                                                                                                                  |
+| ------------- | ------ | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `command`     | string | ✓        | LSP server executable command                                                                                                |
+| `args`        | array  | ✗        | Command-line arguments for the LSP server                                                                                    |
+| `env`         | object | ✗        | Environment variables for the LSP process                                                                                    |
+| `file_types`  | array  | ✗        | File extensions this LSP handles (e.g., `[".go", ".mod"]`)                                                                   |
 | `working_dir` | string | ✗        | Working directory for the LSP server process. Relative paths are resolved against the agent's working directory. Defaults to the agent's working directory when omitted. |
-| `version`     | string | ✗        | Package reference for [auto-installing]({{ '/configuration/tools/#auto-installing-tools'                                                                                 | relative_url }}) the command binary |
+| `version`     | string | ✗        | Package reference for [auto-installing]({{ '/configuration/tools/#auto-installing-tools' | relative_url }}) the command binary |
 
 ## Common LSP Servers
 


### PR DESCRIPTION
While auditing the documentation I found a handful of small but real issues — broken links, a malformed table, and a couple of incorrect / misleading snippets. None of them require any code changes.

## Fixes

| Page | Issue | Fix |
|------|-------|-----|
| `docs/configuration/models/index.md` | The "Anthropic provider page" link was a bare absolute URL (`/providers/anthropic/#thinking-display`), which would 404 on the published site (it's hosted under `/docker-agent`). | Wrap in `{{ '…' \| relative_url }}` like every other intra-doc link. |
| `docs/tools/fetch/index.md` | Linked to `/configuration/tools/#openapi`, but `configuration/tools/` has no `openapi` heading. | Point to the existing `/tools/openapi/` page. |
| `docs/tools/lsp/index.md` | The **Properties** table separator row had 5 columns while the header / data rows had 4, so the table rendered with a phantom empty 5th column. | Make the separator row 4 columns to match. |
| `docs/configuration/overview/index.md` | RAG snippet used `model:` for the embedding strategy. The actual schema field is `embedding_model:` (and every other RAG example/doc uses that name). | Rename `model` → `embedding_model`. |
| `docs/configuration/hooks/index.md` | `validate-command.sh` example ended with `echo '{"decision": "allow"}'`. At the top level only `decision: block` is meaningful — `"allow"` is a no-op and the docs themselves say returning `{}` means "do nothing, continue normally". The example was misleading. | Replace with `echo '{}'` and a clarifying comment. |

## Verification

I built the docs locally with Jekyll using both `_config.yml` and `_config.yml,_config.dev.yml`, and confirmed:

- `/configuration/models/` → "Anthropic provider page" now resolves to `/docker-agent/providers/anthropic/#thinking-display` and the `#thinking-display` anchor exists.
- `/tools/fetch/` → "OpenAPI toolset" now resolves to `/docker-agent/tools/openapi/`.
- `/tools/lsp/` → the Properties table renders with exactly 4 columns and all rows aligned.
- `/configuration/overview/` → RAG example matches `examples/rag/*.yaml` and `pkg/config/latest/types.go`.
- `/configuration/hooks/` → the `validate-command.sh` block is consistent with the documented "return `{}` to continue normally" semantics.

No new Liquid warnings, no broken anchor targets.