### PR TITLE
fetch: support custom request headers

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -1454,7 +1454,7 @@
         },
         "headers": {
           "type": "object",
-          "description": "HTTP headers for API requests (supports ${env.VAR} interpolation)",
+          "description": "HTTP headers (supports ${env.VAR} interpolation). Valid for type 'openapi', 'a2a', and 'fetch'. For 'fetch', the headers are sent on every request the toolset issues — typical use is supplying API tokens (e.g. Authorization: Bearer ${env.MY_TOKEN}). Caller-supplied values override the format-driven Accept header and the default User-Agent.",
           "additionalProperties": {
             "type": "string"
           }

--- a/examples/fetch_headers.yaml
+++ b/examples/fetch_headers.yaml
@@ -1,0 +1,33 @@
+#!/usr/bin/env docker agent run
+
+# Demonstrates the `headers` field on the fetch toolset. The agent attaches
+# the configured headers to every fetch request, with `${env.VAR}` expansion
+# so secrets stay out of the YAML.
+#
+# Use case: an internal documentation portal protected by a static bearer
+# token. Caller-supplied headers also override the format-driven Accept and
+# the default User-Agent — set them only if you really mean to override.
+#
+# Setup before running:
+#
+#   export INTERNAL_DOCS_TOKEN="<your token>"
+
+agents:
+  root:
+    model: anthropic/claude-sonnet-4-5
+    description: Fetches pages from an internal documentation portal that requires a bearer token.
+    instruction: |
+      You can fetch pages from the internal documentation portal at
+      https://docs.internal.example.com. Always summarise the response.
+    toolsets:
+      - type: fetch
+        # Restrict the tool to the internal portal so a stray URL never
+        # leaks the bearer token to a third-party host.
+        allowed_domains:
+          - docs.internal.example.com
+        # Static headers attached to every request. `${env.VAR}` expansion
+        # happens at config-load time, before the toolset is constructed,
+        # so the literal token never reaches disk via the agent config.
+        headers:
+          Authorization: "Bearer ${env.INTERNAL_DOCS_TOKEN}"
+          X-Internal-Client: "docker-agent"

--- a/examples/fetch_headers.yaml
+++ b/examples/fetch_headers.yaml
@@ -1,33 +1,25 @@
 #!/usr/bin/env docker agent run
 
-# Demonstrates the `headers` field on the fetch toolset. The agent attaches
-# the configured headers to every fetch request, with `${env.VAR}` expansion
-# so secrets stay out of the YAML.
+# Demonstrates the `headers` field on the fetch toolset. Headers are
+# attached to every request, with `${env.VAR}` expansion so secrets stay
+# out of YAML. Caller-supplied headers override the default User-Agent
+# and the format-driven Accept header.
 #
-# Use case: an internal documentation portal protected by a static bearer
-# token. Caller-supplied headers also override the format-driven Accept and
-# the default User-Agent — set them only if you really mean to override.
-#
-# Setup before running:
-#
-#   export INTERNAL_DOCS_TOKEN="<your token>"
+# Run with: INTERNAL_DOCS_TOKEN=<token> docker agent run examples/fetch_headers.yaml
 
 agents:
   root:
     model: anthropic/claude-sonnet-4-5
     description: Fetches pages from an internal documentation portal that requires a bearer token.
     instruction: |
-      You can fetch pages from the internal documentation portal at
-      https://docs.internal.example.com. Always summarise the response.
+      You can fetch pages from https://docs.internal.example.com.
+      Always summarise the response.
     toolsets:
       - type: fetch
-        # Restrict the tool to the internal portal so a stray URL never
-        # leaks the bearer token to a third-party host.
+        # Restrict to the internal portal so the bearer token never leaks
+        # to a third-party host.
         allowed_domains:
           - docs.internal.example.com
-        # Static headers attached to every request. `${env.VAR}` expansion
-        # happens at config-load time, before the toolset is constructed,
-        # so the literal token never reaches disk via the agent config.
         headers:
           Authorization: "Bearer ${env.INTERNAL_DOCS_TOKEN}"
           X-Internal-Client: "docker-agent"

--- a/pkg/config/latest/validate.go
+++ b/pkg/config/latest/validate.go
@@ -130,8 +130,8 @@ func (t *Toolset) validate() error {
 	if (len(t.Remote.Headers) > 0) && (t.Type != "mcp" && t.Type != "a2a") {
 		return errors.New("remote headers can only be used with type 'mcp' or 'a2a'")
 	}
-	if len(t.Headers) > 0 && t.Type != "openapi" && t.Type != "a2a" {
-		return errors.New("headers can only be used with type 'openapi' or 'a2a'")
+	if len(t.Headers) > 0 && t.Type != "openapi" && t.Type != "a2a" && t.Type != "fetch" {
+		return errors.New("headers can only be used with type 'openapi', 'a2a' or 'fetch'")
 	}
 	if t.Config != nil && t.Type != "mcp" {
 		return errors.New("config can only be used with type 'mcp'")

--- a/pkg/config/latest/validate_test.go
+++ b/pkg/config/latest/validate_test.go
@@ -446,6 +446,92 @@ agents:
 	}
 }
 
+func TestToolset_Validate_Fetch_Headers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		config  string
+		wantErr string
+	}{
+		{
+			name: "fetch with headers is accepted",
+			config: `
+version: "8"
+agents:
+  root:
+    model: "openai/gpt-4"
+    toolsets:
+      - type: fetch
+        headers:
+          Authorization: "Bearer token"
+          X-Api-Key: "key-123"
+`,
+			wantErr: "",
+		},
+		{
+			name: "openapi with headers is accepted",
+			config: `
+version: "8"
+agents:
+  root:
+    model: "openai/gpt-4"
+    toolsets:
+      - type: openapi
+        url: https://api.example.com/openapi.json
+        headers:
+          Authorization: "Bearer token"
+`,
+			wantErr: "",
+		},
+		{
+			name: "a2a with headers is accepted",
+			config: `
+version: "8"
+agents:
+  root:
+    model: "openai/gpt-4"
+    toolsets:
+      - type: a2a
+        url: https://a2a.example.com
+        headers:
+          Authorization: "Bearer token"
+`,
+			wantErr: "",
+		},
+		{
+			name: "headers on shell toolset is rejected",
+			config: `
+version: "8"
+agents:
+  root:
+    model: "openai/gpt-4"
+    toolsets:
+      - type: shell
+        headers:
+          Authorization: "Bearer token"
+`,
+			wantErr: "headers can only be used with type 'openapi', 'a2a' or 'fetch'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var cfg Config
+			err := yaml.Unmarshal([]byte(tt.config), &cfg)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestToolset_Validate_MCP_RemoteOAuth_CallbackRedirectURL(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/teamloader/registry.go
+++ b/pkg/teamloader/registry.go
@@ -305,7 +305,7 @@ func createAPITool(ctx context.Context, toolset latest.Toolset, _ string, runCon
 	return builtin.NewAPITool(toolset.APIConfig, expander), nil
 }
 
-func createFetchTool(_ context.Context, toolset latest.Toolset, _ string, _ *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
+func createFetchTool(ctx context.Context, toolset latest.Toolset, _ string, runConfig *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
 	var opts []builtin.FetchToolOption
 	if toolset.Timeout > 0 {
 		timeout := time.Duration(toolset.Timeout) * time.Second
@@ -316,6 +316,14 @@ func createFetchTool(_ context.Context, toolset latest.Toolset, _ string, _ *con
 	}
 	if len(toolset.BlockedDomains) > 0 {
 		opts = append(opts, builtin.WithBlockedDomains(toolset.BlockedDomains))
+	}
+	if len(toolset.Headers) > 0 {
+		// Expand ${env.X} references so secrets (API tokens, ...) can be
+		// pulled from the environment instead of being inlined in YAML —
+		// matches the behaviour of openapi/a2a/mcp.remote/api headers.
+		expander := js.NewJsExpander(runConfig.EnvProvider())
+		headers := expander.ExpandMap(ctx, toolset.Headers)
+		opts = append(opts, builtin.WithHeaders(headers))
 	}
 	return builtin.NewFetchTool(opts...), nil
 }

--- a/pkg/teamloader/registry.go
+++ b/pkg/teamloader/registry.go
@@ -306,10 +306,15 @@ func createAPITool(ctx context.Context, toolset latest.Toolset, _ string, runCon
 }
 
 func createFetchTool(ctx context.Context, toolset latest.Toolset, _ string, runConfig *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
+	// Expand ${env.X} in headers so secrets (API tokens, ...) can come from
+	// the environment instead of being inlined in YAML — same behaviour as
+	// openapi/a2a/mcp.remote/api headers. ExpandMap and WithHeaders are both
+	// nil-safe, so no guard is needed when the user hasn't configured any.
+	expander := js.NewJsExpander(runConfig.EnvProvider())
+
 	var opts []builtin.FetchToolOption
 	if toolset.Timeout > 0 {
-		timeout := time.Duration(toolset.Timeout) * time.Second
-		opts = append(opts, builtin.WithTimeout(timeout))
+		opts = append(opts, builtin.WithTimeout(time.Duration(toolset.Timeout)*time.Second))
 	}
 	if len(toolset.AllowedDomains) > 0 {
 		opts = append(opts, builtin.WithAllowedDomains(toolset.AllowedDomains))
@@ -317,14 +322,7 @@ func createFetchTool(ctx context.Context, toolset latest.Toolset, _ string, runC
 	if len(toolset.BlockedDomains) > 0 {
 		opts = append(opts, builtin.WithBlockedDomains(toolset.BlockedDomains))
 	}
-	if len(toolset.Headers) > 0 {
-		// Expand ${env.X} references so secrets (API tokens, ...) can be
-		// pulled from the environment instead of being inlined in YAML —
-		// matches the behaviour of openapi/a2a/mcp.remote/api headers.
-		expander := js.NewJsExpander(runConfig.EnvProvider())
-		headers := expander.ExpandMap(ctx, toolset.Headers)
-		opts = append(opts, builtin.WithHeaders(headers))
-	}
+	opts = append(opts, builtin.WithHeaders(expander.ExpandMap(ctx, toolset.Headers)))
 	return builtin.NewFetchTool(opts...), nil
 }
 

--- a/pkg/tools/builtin/fetch.go
+++ b/pkg/tools/builtin/fetch.go
@@ -151,25 +151,15 @@ func (h *fetchHandler) fetchURL(ctx context.Context, client *http.Client, urlStr
 		return result
 	}
 
+	fmtHandler := formatHandlerFor(format)
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, http.NoBody)
 	if err != nil {
 		result.Error = fmt.Sprintf("failed to create request: %v", err)
 		return result
 	}
-
 	req.Header.Set("User-Agent", useragent.Header)
-
-	switch format {
-	case "markdown":
-		req.Header.Set("Accept", "text/markdown;q=1.0, text/plain;q=0.9, text/html;q=0.7, */*;q=0.1")
-	case "html":
-		req.Header.Set("Accept", "text/html;q=1.0, text/plain;q=0.8, */*;q=0.1")
-	case "text":
-		req.Header.Set("Accept", "text/plain;q=1.0,  text/markdown;q=0.9, text/html;q=0.8, */*;q=0.1")
-	default:
-		req.Header.Set("Accept", "text/plain;q=1.0, */*;q=0.1")
-	}
-
+	req.Header.Set("Accept", fmtHandler.accept)
 	// Apply caller-configured headers last so an operator-supplied
 	// Authorization, User-Agent, Accept, ... wins over the defaults set above.
 	for k, v := range h.headers {
@@ -196,27 +186,10 @@ func (h *fetchHandler) fetchURL(ctx context.Context, client *http.Client, urlStr
 		return result
 	}
 
-	contentType := resp.Header.Get("Content-Type")
-
-	switch format {
-	case "markdown":
-		if strings.Contains(contentType, "text/html") {
-			result.Body = htmlToMarkdown(string(body))
-		} else {
-			result.Body = string(body)
-		}
-	case "html":
-		result.Body = string(body)
-	case "text":
-		if strings.Contains(contentType, "text/html") {
-			result.Body = htmlToText(string(body))
-		} else {
-			result.Body = string(body)
-		}
-	default:
-		result.Body = string(body)
+	result.Body = string(body)
+	if fmtHandler.convertFromHTML != nil && strings.Contains(result.ContentType, "text/html") {
+		result.Body = fmtHandler.convertFromHTML(result.Body)
 	}
-
 	result.ContentLength = len(result.Body)
 
 	return result
@@ -393,6 +366,42 @@ func matchesDomain(host, pattern string) bool {
 	return host == pattern || strings.HasSuffix(host, "."+pattern)
 }
 
+// formatHandler describes how a fetch output format negotiates with the
+// server (`Accept` header) and how an HTML response body is post-processed
+// into that format. A nil convertFromHTML means the body is returned as-is.
+type formatHandler struct {
+	accept          string
+	convertFromHTML func(string) string
+}
+
+var formatHandlers = map[string]formatHandler{
+	"markdown": {
+		accept:          "text/markdown;q=1.0, text/plain;q=0.9, text/html;q=0.7, */*;q=0.1",
+		convertFromHTML: htmlToMarkdown,
+	},
+	"html": {
+		accept: "text/html;q=1.0, text/plain;q=0.8, */*;q=0.1",
+	},
+	"text": {
+		accept:          "text/plain;q=1.0, text/markdown;q=0.9, text/html;q=0.8, */*;q=0.1",
+		convertFromHTML: htmlToText,
+	},
+}
+
+// defaultFormatHandler is used when the caller passes an unknown / empty
+// format string. The JSON schema enums to text|markdown|html, but we keep a
+// safe fallback for forwards compatibility and direct (non-tool) callers.
+var defaultFormatHandler = formatHandler{
+	accept: "text/plain;q=1.0, */*;q=0.1",
+}
+
+func formatHandlerFor(format string) formatHandler {
+	if h, ok := formatHandlers[format]; ok {
+		return h
+	}
+	return defaultFormatHandler
+}
+
 func htmlToMarkdown(html string) string {
 	markdown, err := htmltomarkdown.ConvertString(html)
 	if err != nil {
@@ -445,13 +454,10 @@ func WithBlockedDomains(domains []string) FetchToolOption {
 	}
 }
 
-// WithHeaders attaches a static set of HTTP headers to every request issued
-// by the fetch tool. Typical use is supplying authentication credentials
-// (e.g. an `Authorization: Bearer ${env.MY_TOKEN}` header expanded at config
-// load time) for endpoints that require them. The format-driven Accept
-// header and the default User-Agent are applied first, so caller-provided
-// values for the same header names override them. An empty or nil map is a
-// no-op.
+// WithHeaders sets static HTTP headers attached to every fetch request.
+// Typical use is supplying credentials such as `Authorization: Bearer ...`.
+// These are applied last, so they override the default User-Agent and the
+// format-driven Accept header. An empty or nil map is a no-op.
 func WithHeaders(headers map[string]string) FetchToolOption {
 	return func(t *FetchTool) {
 		t.handler.headers = headers

--- a/pkg/tools/builtin/fetch.go
+++ b/pkg/tools/builtin/fetch.go
@@ -64,6 +64,20 @@ func (h *fetchHandler) CallTool(ctx context.Context, params FetchToolArgs) (*too
 			if len(via) >= 10 {
 				return errors.New("stopped after 10 redirects")
 			}
+			// Strip caller-supplied headers when redirecting to a different
+			// host so credentials (Authorization, X-Api-Key, ...) never leak
+			// to a third-party host. Go's stdlib already strips a small
+			// allow-list (Authorization, WWW-Authenticate, Cookie) on cross-
+			// domain redirects but does NOT strip arbitrary custom headers,
+			// so we strip everything the operator configured. via[0] is the
+			// original request; comparing req.URL.Host against it (rather
+			// than the previous hop) guarantees that headers cannot reappear
+			// after a chain like A -> B -> A.
+			if origHost := via[0].URL.Host; origHost != req.URL.Host {
+				for k := range h.headers {
+					req.Header.Del(k)
+				}
+			}
 			return h.checkDomainAllowed(req.URL)
 		},
 	}
@@ -198,6 +212,16 @@ func (h *fetchHandler) fetchURL(ctx context.Context, client *http.Client, urlStr
 // fetchRobots fetches and parses robots.txt for the given URL's host.
 // Returns nil (allow all) if robots.txt is missing or unreachable.
 // Returns an error if the server returns a non-OK status or the content cannot be read/parsed.
+//
+// We deliberately reuse the caller-supplied client (rather than building a
+// separate one) so that robots.txt requests inherit the same CheckRedirect
+// policy as the main fetch:
+//   - allowed_domains / blocked_domains are re-evaluated on every redirect,
+//     so an allow-listed origin's robots.txt cannot redirect into a denied
+//     host (e.g. cloud-metadata IPs) to bypass the policy.
+//   - caller-supplied headers (Authorization, X-Api-Key, ...) are stripped
+//     when crossing host boundaries, so credentials never leak to a
+//     third-party host that handles a robots.txt redirect.
 func (h *fetchHandler) fetchRobots(ctx context.Context, client *http.Client, targetURL *url.URL, userAgent string) (*robotstxt.RobotsData, error) {
 	// Build robots.txt URL
 	robotsURL := &url.URL{
@@ -214,16 +238,19 @@ func (h *fetchHandler) fetchRobots(ctx context.Context, client *http.Client, tar
 	}
 
 	req.Header.Set("User-Agent", userAgent)
-
-	// Create robots client with same timeout and transport as main client
-	robotsClient := &http.Client{
-		Timeout:   client.Timeout,   // Same timeout as main client
-		Transport: client.Transport, // Inherit proxy/transport settings
+	// Apply custom headers to robots.txt requests too, so authenticated
+	// endpoints that also protect robots.txt work correctly. Cross-host
+	// leaks are prevented by the shared client's CheckRedirect.
+	for k, v := range h.headers {
+		req.Header.Set(k, v)
 	}
 
-	resp, err := robotsClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
-		// If robots.txt is unreachable, allow the fetch
+		// If robots.txt is unreachable, allow the fetch. This also covers the
+		// case where CheckRedirect blocks a robots.txt redirect into a denied
+		// host: we treat it as "no robots.txt available" and proceed with the
+		// main fetch, which itself runs through the same allow/deny checks.
 		return nil, nil
 	}
 	defer resp.Body.Close()

--- a/pkg/tools/builtin/fetch.go
+++ b/pkg/tools/builtin/fetch.go
@@ -39,6 +39,7 @@ type fetchHandler struct {
 	timeout        time.Duration
 	allowedDomains []string
 	blockedDomains []string
+	headers        map[string]string
 }
 
 type FetchToolArgs struct {
@@ -167,6 +168,12 @@ func (h *fetchHandler) fetchURL(ctx context.Context, client *http.Client, urlStr
 		req.Header.Set("Accept", "text/plain;q=1.0,  text/markdown;q=0.9, text/html;q=0.8, */*;q=0.1")
 	default:
 		req.Header.Set("Accept", "text/plain;q=1.0, */*;q=0.1")
+	}
+
+	// Apply caller-configured headers last so an operator-supplied
+	// Authorization, User-Agent, Accept, ... wins over the defaults set above.
+	for k, v := range h.headers {
+		req.Header.Set(k, v)
 	}
 
 	// Execute request
@@ -435,6 +442,19 @@ func WithAllowedDomains(domains []string) FetchToolOption {
 func WithBlockedDomains(domains []string) FetchToolOption {
 	return func(t *FetchTool) {
 		t.handler.blockedDomains = domains
+	}
+}
+
+// WithHeaders attaches a static set of HTTP headers to every request issued
+// by the fetch tool. Typical use is supplying authentication credentials
+// (e.g. an `Authorization: Bearer ${env.MY_TOKEN}` header expanded at config
+// load time) for endpoints that require them. The format-driven Accept
+// header and the default User-Agent are applied first, so caller-provided
+// values for the same header names override them. An empty or nil map is a
+// no-op.
+func WithHeaders(headers map[string]string) FetchToolOption {
+	return func(t *FetchTool) {
+		t.handler.headers = headers
 	}
 }
 

--- a/pkg/tools/builtin/fetch_test.go
+++ b/pkg/tools/builtin/fetch_test.go
@@ -414,6 +414,72 @@ func TestFetchTool_BlockedDomainsAppearInInstructions(t *testing.T) {
 	assert.Contains(t, instructions, "169.254.169.254")
 }
 
+func TestFetchTool_WithHeadersOption(t *testing.T) {
+	headers := map[string]string{
+		"Authorization": "Bearer secret-token",
+		"X-Api-Key":     "key-123",
+	}
+	tool := NewFetchTool(WithHeaders(headers))
+
+	assert.Equal(t, headers, tool.handler.headers)
+}
+
+func TestFetch_Headers_SentOnRequest(t *testing.T) {
+	var gotAuthorization, gotAPIKey string
+	url := runHTTPServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/robots.txt" {
+			http.NotFound(w, r)
+			return
+		}
+		gotAuthorization = r.Header.Get("Authorization")
+		gotAPIKey = r.Header.Get("X-Api-Key")
+		w.Header().Set("Content-Type", "text/plain")
+		fmt.Fprint(w, "ok")
+	})
+
+	tool := NewFetchTool(WithHeaders(map[string]string{
+		"Authorization": "Bearer secret-token",
+		"X-Api-Key":     "key-123",
+	}))
+
+	result, err := tool.handler.CallTool(t.Context(), FetchToolArgs{
+		URLs:   []string{url + "/page"},
+		Format: "text",
+	})
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, "Successfully fetched")
+	assert.Equal(t, "Bearer secret-token", gotAuthorization)
+	assert.Equal(t, "key-123", gotAPIKey)
+}
+
+// TestFetch_Headers_OverrideDefaults pins the precedence rule: caller-supplied
+// headers win over the default User-Agent and the format-driven Accept header.
+func TestFetch_Headers_OverrideDefaults(t *testing.T) {
+	var gotUserAgent, gotAccept string
+	url := runHTTPServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/robots.txt" {
+			http.NotFound(w, r)
+			return
+		}
+		gotUserAgent = r.Header.Get("User-Agent")
+		gotAccept = r.Header.Get("Accept")
+		fmt.Fprint(w, "ok")
+	})
+
+	tool := NewFetchTool(WithHeaders(map[string]string{
+		"User-Agent": "CustomAgent/1.0",
+		"Accept":     "application/json",
+	}))
+
+	_, err := tool.handler.CallTool(t.Context(), FetchToolArgs{
+		URLs:   []string{url + "/page"},
+		Format: "text", // would normally set a text/plain Accept header
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "CustomAgent/1.0", gotUserAgent)
+	assert.Equal(t, "application/json", gotAccept)
+}
+
 func TestMatchesDomain(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/tools/builtin/fetch_test.go
+++ b/pkg/tools/builtin/fetch_test.go
@@ -710,3 +710,132 @@ func TestMatchesDomain_EdgeCases(t *testing.T) {
 		})
 	}
 }
+
+// TestFetch_Headers_StrippedOnCrossHostRedirect verifies that custom headers
+// configured on the fetch tool are NOT leaked when a request redirects to a
+// different host. We test with `X-Api-Key` because Go's stdlib already strips
+// `Authorization` on cross-domain redirects automatically — using a non-stdlib
+// header guarantees the test exercises the toolset's own CheckRedirect logic
+// rather than passing accidentally on stdlib behaviour.
+func TestFetch_Headers_StrippedOnCrossHostRedirect(t *testing.T) {
+	var gotAPIKeyOnInitial, gotAPIKeyOnRedirect string
+	var redirectURL string
+
+	// Server 1: initial target that redirects to server 2.
+	url1 := runHTTPServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/robots.txt" {
+			http.NotFound(w, r)
+			return
+		}
+		gotAPIKeyOnInitial = r.Header.Get("X-Api-Key")
+		http.Redirect(w, r, redirectURL, http.StatusFound)
+	})
+
+	// Server 2: redirect target on a different host (different port, so
+	// req.URL.Host differs).
+	url2 := runHTTPServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/robots.txt" {
+			http.NotFound(w, r)
+			return
+		}
+		gotAPIKeyOnRedirect = r.Header.Get("X-Api-Key")
+		w.Header().Set("Content-Type", "text/plain")
+		fmt.Fprint(w, "redirected content")
+	})
+
+	redirectURL = url2 + "/target"
+
+	tool := NewFetchTool(WithHeaders(map[string]string{
+		"X-Api-Key": "secret-key-must-not-leak",
+	}))
+
+	result, err := tool.handler.CallTool(t.Context(), FetchToolArgs{
+		URLs:   []string{url1 + "/start"},
+		Format: "text",
+	})
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, "redirected content")
+
+	assert.Equal(t, "secret-key-must-not-leak", gotAPIKeyOnInitial,
+		"custom header should reach the initial host")
+	assert.Empty(t, gotAPIKeyOnRedirect,
+		"custom header MUST NOT leak to a redirect target on a different host")
+}
+
+// TestFetch_Headers_PreservedOnSameHostRedirect verifies that headers ARE
+// preserved when redirecting within the same host (e.g., http -> https upgrade,
+// or path-only redirects).
+func TestFetch_Headers_PreservedOnSameHostRedirect(t *testing.T) {
+	var gotAuthOnInitial, gotAuthOnRedirect string
+
+	url := runHTTPServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/robots.txt" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.URL.Path == "/start" {
+			gotAuthOnInitial = r.Header.Get("Authorization")
+			// Redirect to a different path on the same host
+			http.Redirect(w, r, "/target", http.StatusFound)
+			return
+		}
+		gotAuthOnRedirect = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "text/plain")
+		fmt.Fprint(w, "same-host redirect")
+	})
+
+	tool := NewFetchTool(WithHeaders(map[string]string{
+		"Authorization": "Bearer secret-token",
+	}))
+
+	result, err := tool.handler.CallTool(t.Context(), FetchToolArgs{
+		URLs:   []string{url + "/start"},
+		Format: "text",
+	})
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, "same-host redirect")
+
+	// Verify the Authorization header was sent to both requests (same host)
+	assert.Equal(t, "Bearer secret-token", gotAuthOnInitial)
+	assert.Equal(t, "Bearer secret-token", gotAuthOnRedirect,
+		"Authorization header should be preserved for same-host redirects")
+}
+
+// TestFetch_Headers_StrippedOnRobotsCrossHostRedirect is a regression test for
+// a header-leak through robots.txt: the toolset fetches `/robots.txt` first,
+// and an attacker controlling that file (or whose host is allow-listed) could
+// redirect the robots fetch to a third-party host. Because robots.txt sends
+// the same custom headers as the main request, those credentials must be
+// stripped on cross-host redirects too.
+func TestFetch_Headers_StrippedOnRobotsCrossHostRedirect(t *testing.T) {
+	var leaked string
+
+	// External host that observes any leaked credential.
+	externalURL := runHTTPServer(t, func(w http.ResponseWriter, r *http.Request) {
+		leaked = r.Header.Get("X-Api-Key")
+		fmt.Fprint(w, "")
+	})
+
+	// Origin whose robots.txt 302-redirects to the external host.
+	originURL := runHTTPServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/robots.txt" {
+			http.Redirect(w, r, externalURL+"/robots.txt", http.StatusFound)
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		fmt.Fprint(w, "page content")
+	})
+
+	tool := NewFetchTool(WithHeaders(map[string]string{
+		"X-Api-Key": "secret-key-must-not-leak",
+	}))
+
+	_, err := tool.handler.CallTool(t.Context(), FetchToolArgs{
+		URLs:   []string{originURL + "/page"},
+		Format: "text",
+	})
+	require.NoError(t, err)
+
+	assert.Empty(t, leaked,
+		"custom header MUST NOT leak via a robots.txt cross-host redirect")
+}


### PR DESCRIPTION
Closes #2613.

Adds support for static custom request headers on the `fetch` toolset, so
agents can hit private/authenticated endpoints (Bearer tokens, API keys, ...).
Values support `${env.VAR}` expansion so secrets don't have to live in YAML.

```yaml
toolsets:
  - type: fetch
    allowed_domains: [docs.internal.example.com]
    headers:
      Authorization: "Bearer ${env.INTERNAL_DOCS_TOKEN}"
```

The bulk of the feature was already there in two earlier commits; this PR
also lands the security hardening that was missing:

- Strip caller-supplied headers on cross-host redirects. `net/http` only
  auto-strips `Authorization` / `WWW-Authenticate` / `Cookie`, so a custom
  `X-Api-Key` would otherwise leak to a redirect target on a different host.
- Use the main client (with its `CheckRedirect`) for `robots.txt` too. The
  previous code built a separate client with no redirect policy, which both
  bypassed `allowed_domains` / `blocked_domains` on robots.txt redirects
  (an SSRF vector — e.g. into `169.254.169.254`) and would have leaked the
  newly-added custom headers via the same path.

New regression tests cover all three cases (cross-host strip with a custom
header that the stdlib does *not* auto-strip, same-host preservation, and
robots.txt cross-host strip).
