### PR TITLE
Add JS placeholders support in instructions

### DIFF
--- a/docs/configuration/agents/index.md
+++ b/docs/configuration/agents/index.md
@@ -274,6 +274,8 @@ $ PROJECT_NAME=myapp ENV=production docker agent run agent.yaml /deploy
 
 Commands use JavaScript template literal syntax for environment variable interpolation. Undefined variables expand to empty strings.
 
+The same syntax is also expanded in agent and toolset instructions: `agents.<name>.instruction` and `toolsets[*].instruction` now support `${env.X}` placeholders (with optional `||` defaults and ternary expressions). Note that `agents.<name>.description` and `agents.<name>.welcome_message` already supported this syntax.
+
 ## Complete Example
 
 ```yaml

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -207,7 +207,7 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 			)
 		}
 
-		agentTools, warnings := getToolsForAgent(ctx, &agentConfig, parentDir, runConfig, loadOpts.toolsetRegistry, configName)
+		agentTools, warnings := getToolsForAgent(ctx, &agentConfig, parentDir, runConfig, loadOpts.toolsetRegistry, configName, expander)
 		if len(warnings) > 0 {
 			opts = append(opts, agent.WithLoadTimeWarnings(warnings))
 		}
@@ -223,7 +223,7 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 
 		opts = append(opts, agent.WithToolSets(agentTools...))
 
-		ag := agent.New(agentConfig.Name, agentConfig.Instruction, opts...)
+		ag := agent.New(agentConfig.Name, expander.Expand(ctx, agentConfig.Instruction, nil), opts...)
 		agents = append(agents, ag)
 		agentsByName[agentConfig.Name] = ag
 	}
@@ -394,8 +394,10 @@ func getFallbackModelsForAgent(ctx context.Context, cfg *latest.Config, a *lates
 	return fallbackModels, nil
 }
 
-// getToolsForAgent returns the tool definitions for an agent based on its configuration
-func getToolsForAgent(ctx context.Context, a *latest.AgentConfig, parentDir string, runConfig *config.RuntimeConfig, registry *ToolsetRegistry, configName string) ([]tools.ToolSet, []string) {
+// getToolsForAgent returns the tool definitions for an agent based on its
+// configuration. Toolset instructions support ${...} JavaScript placeholders
+// (e.g. ${env.X}); they are expanded here using the runtime env provider.
+func getToolsForAgent(ctx context.Context, a *latest.AgentConfig, parentDir string, runConfig *config.RuntimeConfig, registry *ToolsetRegistry, configName string, expander *js.Expander) ([]tools.ToolSet, []string) {
 	var (
 		toolSets    []tools.ToolSet
 		warnings    []string
@@ -416,7 +418,7 @@ func getToolsForAgent(ctx context.Context, a *latest.AgentConfig, parentDir stri
 		}
 
 		wrapped := WithToolsFilter(tool, toolset.Tools...)
-		wrapped = WithInstructions(wrapped, toolset.Instruction)
+		wrapped = WithInstructions(wrapped, expander.Expand(ctx, toolset.Instruction, nil))
 		wrapped = WithToon(wrapped, toolset.Toon)
 		wrapped = WithModelOverride(wrapped, toolset.Model)
 

--- a/pkg/teamloader/teamloader_test.go
+++ b/pkg/teamloader/teamloader_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/environment"
+	"github.com/docker/docker-agent/pkg/js"
 	"github.com/docker/docker-agent/pkg/model/provider/dmr"
 	"github.com/docker/docker-agent/pkg/tools"
 )
@@ -66,7 +67,9 @@ func TestGetToolsForAgent_ContinuesOnCreateToolError(t *testing.T) {
 		EnvProviderForTests: &noEnvProvider{},
 	}
 
-	got, warnings := getToolsForAgent(t.Context(), a, ".", &runConfig, NewToolsetRegistry(), "test-config")
+	expander := js.NewJsExpander(runConfig.EnvProvider())
+
+	got, warnings := getToolsForAgent(t.Context(), a, ".", &runConfig, NewToolsetRegistry(), "test-config", expander)
 
 	require.Empty(t, got)
 	require.NotEmpty(t, warnings)
@@ -217,6 +220,31 @@ func TestToolsetInstructions(t *testing.T) {
 	instructions := tools.GetInstructions(toolsets[0])
 	expected := "Dummy fetch tool instruction"
 	require.Equal(t, expected, instructions)
+}
+
+// TestInstructionExpansion verifies that ${env.X} placeholders are expanded
+// at load time both in agent.instruction and in toolsets[*].instruction.
+// See https://github.com/docker/docker-agent/issues/2614.
+func TestInstructionExpansion(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "dummy")
+	t.Setenv("USER", "alice")
+
+	agentSource, err := config.Resolve("testdata/instruction-expansion.yaml", nil)
+	require.NoError(t, err)
+
+	team, err := Load(t.Context(), agentSource, &config.RuntimeConfig{})
+	require.NoError(t, err)
+
+	rootAgent, err := team.Agent("root")
+	require.NoError(t, err)
+
+	// agents.<name>.instruction must be expanded.
+	assert.Equal(t, "Hello alice, you are running in staging", rootAgent.Instruction())
+
+	// toolsets[*].instruction must also be expanded.
+	toolsets := rootAgent.ToolSets()
+	require.Len(t, toolsets, 1)
+	assert.Equal(t, "Fetch as alice", tools.GetInstructions(toolsets[0]))
 }
 
 func TestAutoModelFallbackError(t *testing.T) {
@@ -414,7 +442,9 @@ func TestGetToolsForAgent_MultipleLSPToolsetsAreCombined(t *testing.T) {
 		EnvProviderForTests: &noEnvProvider{},
 	}
 
-	got, warnings := getToolsForAgent(t.Context(), a, ".", &runConfig, NewDefaultToolsetRegistry(), "test-config")
+	expander := js.NewJsExpander(runConfig.EnvProvider())
+
+	got, warnings := getToolsForAgent(t.Context(), a, ".", &runConfig, NewDefaultToolsetRegistry(), "test-config", expander)
 	require.Empty(t, warnings)
 
 	// Should have exactly one toolset (the multiplexer)
@@ -454,7 +484,9 @@ func TestGetToolsForAgent_SingleLSPToolsetNotWrapped(t *testing.T) {
 		EnvProviderForTests: &noEnvProvider{},
 	}
 
-	got, warnings := getToolsForAgent(t.Context(), a, ".", &runConfig, NewDefaultToolsetRegistry(), "test-config")
+	expander := js.NewJsExpander(runConfig.EnvProvider())
+
+	got, warnings := getToolsForAgent(t.Context(), a, ".", &runConfig, NewDefaultToolsetRegistry(), "test-config", expander)
 	require.Empty(t, warnings)
 
 	// Should have exactly one toolset that provides LSP tools.

--- a/pkg/teamloader/testdata/instruction-expansion.yaml
+++ b/pkg/teamloader/testdata/instruction-expansion.yaml
@@ -1,0 +1,7 @@
+agents:
+  root:
+    model: openai/gpt-4o
+    instruction: "Hello ${env.USER}, you are running in ${env.ENVIRONMENT || 'staging'}"
+    toolsets:
+      - type: fetch
+        instruction: "Fetch as ${env.USER}"


### PR DESCRIPTION
Expand `${...}` JavaScript placeholders (e.g. `${env.X}`, with `||` defaults and ternary expressions) in agent and toolset instructions at load time.

This was already supported for `agents.<name>.description`, `agents.<name>.welcome_message`, and commands. This PR extends it to:

- `agents.<name>.instruction`
- `toolsets[*].instruction`

## Changes

- `pkg/teamloader/teamloader.go`: pass the existing `js.Expander` (already constructed in `LoadWithConfig` for description/welcome_message/commands) down to `getToolsForAgent`, and use it to expand the agent and toolset instructions before they reach the runtime.
- `pkg/teamloader/teamloader_test.go` + `pkg/teamloader/testdata/instruction-expansion.yaml`: new `TestInstructionExpansion` covering both expansions; updated existing `getToolsForAgent` test call sites for the new parameter.
- `docs/configuration/agents/index.md`: documents the newly supported fields.

Originally proposed in #2614 and rebased on top of current `main`.

Assisted-By: docker-agent