### PR TITLE
fix: keep tab switching and chat scroll working while a prompt is open

### DIFF
--- a/pkg/tui/dialog/dialog.go
+++ b/pkg/tui/dialog/dialog.go
@@ -8,9 +8,17 @@ import (
 	"github.com/docker/docker-agent/pkg/tui/messages"
 )
 
-// OpenDialogMsg is sent to open a new dialog
+// OpenDialogMsg is sent to open a new dialog.
+//
+// OriginatingEvent is an optional runtime event whose presence marks the
+// dialog as a background dialog. Background dialogs do not block the rest of
+// the UI: tab navigation, tab-bar mouse clicks and chat scroll-wheel events
+// keep working. When the user switches away from the tab that opened the
+// dialog, the dialog is closed and OriginatingEvent is re-stashed in the
+// supervisor so the same prompt is re-displayed when the user returns.
 type OpenDialogMsg struct {
-	Model Dialog
+	Model            Dialog
+	OriginatingEvent tea.Msg
 }
 
 // CloseDialogMsg is sent to close the current (topmost) dialog
@@ -32,6 +40,13 @@ type Manager interface {
 	GetLayers() []*lipgloss.Layer
 	Open() bool
 	TopIsExitConfirmation() bool
+	// TopIsBackground reports whether the topmost dialog is a background
+	// dialog (i.e. it should not block tab navigation or chat scrolling).
+	TopIsBackground() bool
+	// TopBackgroundEvent returns the originating event of the topmost
+	// background dialog, or nil if the top dialog is not a background dialog
+	// or the dialog stack is empty.
+	TopBackgroundEvent() tea.Msg
 }
 
 // dialogEntry pairs a dialog with its drag offset so the two stay in sync.
@@ -39,6 +54,10 @@ type dialogEntry struct {
 	dialog  Dialog
 	offsetX int // accumulated horizontal drag displacement
 	offsetY int // accumulated vertical drag displacement
+	// originatingEvent is the runtime event that caused this dialog to open,
+	// when applicable. A non-nil value marks the dialog as a background
+	// dialog (see OpenDialogMsg.OriginatingEvent).
+	originatingEvent tea.Msg
 }
 
 // dragState tracks an in-progress drag operation.
@@ -234,7 +253,10 @@ func (d *manager) adjustMouseMsg(msg tea.Msg) tea.Msg {
 
 // handleOpen processes dialog opening requests and adds to stack
 func (d *manager) handleOpen(msg OpenDialogMsg) (layout.Model, tea.Cmd) {
-	d.stack = append(d.stack, dialogEntry{dialog: msg.Model})
+	d.stack = append(d.stack, dialogEntry{
+		dialog:           msg.Model,
+		originatingEvent: msg.OriginatingEvent,
+	})
 
 	var cmds []tea.Cmd
 	cmd := msg.Model.Init()
@@ -280,6 +302,25 @@ func (d *manager) TopIsExitConfirmation() bool {
 	}
 	_, ok := d.stack[len(d.stack)-1].dialog.(*exitConfirmationDialog)
 	return ok
+}
+
+// TopIsBackground returns true if the topmost dialog is a background dialog
+// (opened with a non-nil OriginatingEvent). See OpenDialogMsg for semantics.
+func (d *manager) TopIsBackground() bool {
+	if len(d.stack) == 0 {
+		return false
+	}
+	return d.stack[len(d.stack)-1].originatingEvent != nil
+}
+
+// TopBackgroundEvent returns the originating event of the topmost background
+// dialog, or nil if the top dialog is not a background dialog or the dialog
+// stack is empty.
+func (d *manager) TopBackgroundEvent() tea.Msg {
+	if len(d.stack) == 0 {
+		return nil
+	}
+	return d.stack[len(d.stack)-1].originatingEvent
 }
 
 func (d *manager) SetSize(width, height int) tea.Cmd {

--- a/pkg/tui/dialog/manager_test.go
+++ b/pkg/tui/dialog/manager_test.go
@@ -1,0 +1,50 @@
+package dialog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestManagerBackgroundDialog verifies that opening a dialog with a non-nil
+// OriginatingEvent marks it as a background dialog, while opening one without
+// an event leaves the manager in regular ("modal") mode.
+func TestManagerBackgroundDialog(t *testing.T) {
+	t.Parallel()
+
+	mgr := New().(*manager)
+
+	assert.False(t, mgr.Open(), "manager starts empty")
+	assert.False(t, mgr.TopIsBackground(), "empty manager has no background dialog")
+	assert.Nil(t, mgr.TopBackgroundEvent())
+
+	// Open a regular (modal) dialog without an event.
+	mgr.handleOpen(OpenDialogMsg{
+		Model: NewExitConfirmationDialog(),
+	})
+	assert.True(t, mgr.Open())
+	assert.False(t, mgr.TopIsBackground(), "dialog opened without OriginatingEvent must NOT be background")
+	assert.Nil(t, mgr.TopBackgroundEvent())
+
+	// Stack a background dialog (i.e. one carrying an originating event) on top.
+	type fakeEvent struct{ id int }
+	event := &fakeEvent{id: 42}
+	mgr.handleOpen(OpenDialogMsg{
+		Model:            NewElicitationDialog("Pick a value", nil, nil),
+		OriginatingEvent: event,
+	})
+	assert.True(t, mgr.TopIsBackground(), "dialog opened with OriginatingEvent IS background")
+	assert.Same(t, event, mgr.TopBackgroundEvent(), "TopBackgroundEvent returns the originating event")
+
+	// Closing the top reveals the modal dialog underneath.
+	mgr.handleClose()
+	assert.True(t, mgr.Open(), "manager still has the modal dialog underneath")
+	assert.False(t, mgr.TopIsBackground(), "underneath is the modal dialog, not background")
+	assert.Nil(t, mgr.TopBackgroundEvent())
+
+	// Closing again empties the stack.
+	mgr.handleClose()
+	assert.False(t, mgr.Open())
+	assert.False(t, mgr.TopIsBackground())
+	assert.Nil(t, mgr.TopBackgroundEvent())
+}

--- a/pkg/tui/page/chat/runtime_events.go
+++ b/pkg/tui/page/chat/runtime_events.go
@@ -286,7 +286,8 @@ func (p *chatPage) handleToolCallConfirmation(msg *runtime.ToolCallConfirmationE
 	spinnerCmd := p.setWorking(false)
 	toolCmd := p.messages.AddOrUpdateToolCall(msg.AgentName, msg.ToolCall, msg.ToolDefinition, types.ToolStatusConfirmation)
 	dialogCmd := core.CmdHandler(dialog.OpenDialogMsg{
-		Model: dialog.NewToolConfirmationDialog(msg, p.sessionState),
+		Model:            dialog.NewToolConfirmationDialog(msg, p.sessionState),
+		OriginatingEvent: msg,
 	})
 	return tea.Batch(toolCmd, p.messages.ScrollToBottom(), spinnerCmd, dialogCmd)
 }
@@ -320,7 +321,8 @@ func (p *chatPage) handleToolCallResponse(msg *runtime.ToolCallResponseEvent) te
 func (p *chatPage) handleMaxIterationsReached(msg *runtime.MaxIterationsReachedEvent) tea.Cmd {
 	spinnerCmd := p.setWorking(false)
 	dialogCmd := core.CmdHandler(dialog.OpenDialogMsg{
-		Model: dialog.NewMaxIterationsDialog(msg.MaxIterations, p.app),
+		Model:            dialog.NewMaxIterationsDialog(msg.MaxIterations, p.app),
+		OriginatingEvent: msg,
 	})
 	return tea.Batch(spinnerCmd, dialogCmd)
 }
@@ -338,7 +340,8 @@ func (p *chatPage) handleElicitationRequest(msg *runtime.ElicitationRequestEvent
 				serverURL = url
 			}
 			dialogCmd := core.CmdHandler(dialog.OpenDialogMsg{
-				Model: dialog.NewOAuthAuthorizationDialog(serverURL, p.app),
+				Model:            dialog.NewOAuthAuthorizationDialog(serverURL, p.app),
+				OriginatingEvent: msg,
 			})
 			return tea.Batch(spinnerCmd, dialogCmd)
 		}
@@ -349,14 +352,16 @@ func (p *chatPage) handleElicitationRequest(msg *runtime.ElicitationRequestEvent
 	case "url":
 		// URL-based elicitation - show URL dialog
 		dialogCmd := core.CmdHandler(dialog.OpenDialogMsg{
-			Model: dialog.NewURLElicitationDialog(msg.Message, msg.URL),
+			Model:            dialog.NewURLElicitationDialog(msg.Message, msg.URL),
+			OriginatingEvent: msg,
 		})
 		return tea.Batch(spinnerCmd, dialogCmd)
 
 	default:
 		// Form-based elicitation (default) - show form dialog
 		dialogCmd := core.CmdHandler(dialog.OpenDialogMsg{
-			Model: dialog.NewElicitationDialog(msg.Message, msg.Schema, msg.Meta),
+			Model:            dialog.NewElicitationDialog(msg.Message, msg.Schema, msg.Meta),
+			OriginatingEvent: msg,
 		})
 		return tea.Batch(spinnerCmd, dialogCmd)
 	}

--- a/pkg/tui/service/supervisor/supervisor.go
+++ b/pkg/tui/service/supervisor/supervisor.go
@@ -269,6 +269,23 @@ func (s *Supervisor) ConsumePendingEvent(sessionID string) tea.Msg {
 	return event
 }
 
+// SetPendingEvent stores an attention event for the given session so it can
+// be replayed when the user later switches to that tab. Used to re-stash a
+// background dialog's originating event when the user navigates away from
+// the tab that opened it.
+//
+// NeedsAttention is intentionally NOT set here: the user is already aware of
+// the prompt (they just chose to step away from it) and we don't want to
+// flag the tab as if a brand-new event had arrived.
+func (s *Supervisor) SetPendingEvent(sessionID string, event tea.Msg) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if runner, ok := s.runners[sessionID]; ok {
+		runner.PendingEvent = event
+	}
+}
+
 // ActiveRunner returns the currently active session runner.
 func (s *Supervisor) ActiveRunner() *SessionRunner {
 	s.mu.RLock()

--- a/pkg/tui/service/supervisor/supervisor_test.go
+++ b/pkg/tui/service/supervisor/supervisor_test.go
@@ -93,3 +93,32 @@ func TestCloseSession_TwoTabs_CloseSecond(t *testing.T) {
 	assert.Equal(t, "A", s.activeID)
 	assert.Equal(t, []string{"A"}, s.order)
 }
+
+// TestSetPendingEvent_RoundTrip verifies that SetPendingEvent stores an event
+// for a session and that ConsumePendingEvent retrieves and clears it. This
+// is the path used to re-stash a background dialog's originating event when
+// the user switches away from the tab that opened it (see #2626).
+func TestSetPendingEvent_RoundTrip(t *testing.T) {
+	s := newTestSupervisor([]string{"A", "B"}, "A")
+
+	type fakeEvent struct{ id int }
+	event := &fakeEvent{id: 7}
+
+	s.SetPendingEvent("A", event)
+
+	assert.Equal(t, event, s.runners["A"].PendingEvent, "event is stored on the runner")
+	assert.False(t, s.runners["A"].NeedsAttn, "SetPendingEvent must NOT raise NeedsAttn (the user is already aware)")
+
+	got := s.ConsumePendingEvent("A")
+	assert.Equal(t, event, got)
+	assert.Nil(t, s.runners["A"].PendingEvent, "event is cleared after consumption")
+}
+
+// TestSetPendingEvent_UnknownSession is a no-op (and must not panic).
+func TestSetPendingEvent_UnknownSession(t *testing.T) {
+	s := newTestSupervisor([]string{"A"}, "A")
+
+	s.SetPendingEvent("does-not-exist", "payload")
+
+	assert.Nil(t, s.runners["A"].PendingEvent, "unrelated runner is untouched")
+}

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -1219,9 +1219,30 @@ func (m *appModel) openWorkingDirPicker() (tea.Model, tea.Cmd) {
 // Existing chat pages and editors are preserved (not recreated) so that in-flight streaming
 // content and draft text are retained when switching back to a tab.
 func (m *appModel) handleSwitchTab(sessionID string) (tea.Model, tea.Cmd) {
+	// If a background dialog (e.g. pending elicitation) is open on the
+	// outgoing tab, capture its originating event and the outgoing tab ID
+	// before the supervisor flips activeID. We only commit the re-stash
+	// after SwitchTo succeeds — otherwise a failed switch would leave the
+	// supervisor with a stale pending event and the dialog still on screen.
+	var (
+		backgroundEvent tea.Msg
+		outgoingTabID   string
+	)
+	if m.dialogMgr.Open() && m.dialogMgr.TopIsBackground() {
+		backgroundEvent = m.dialogMgr.TopBackgroundEvent()
+		outgoingTabID = m.supervisor.ActiveID()
+	}
+
 	runner := m.supervisor.SwitchTo(sessionID)
 	if runner == nil {
 		return m, notification.ErrorCmd("Session not found")
+	}
+
+	// Now that the switch is committed, finalize the dialog hand-off.
+	var closeBackgroundDialogCmd tea.Cmd
+	if backgroundEvent != nil && outgoingTabID != "" && outgoingTabID != sessionID {
+		m.supervisor.SetPendingEvent(outgoingTabID, backgroundEvent)
+		closeBackgroundDialogCmd = core.CmdHandler(dialog.CloseDialogMsg{})
 	}
 
 	// Blur current editor before switching
@@ -1243,7 +1264,7 @@ func (m *appModel) handleSwitchTab(sessionID string) (tea.Model, tea.Cmd) {
 					}
 				}
 
-				cmd = tea.Batch(cmd, m.applySidebarCollapsed(sessionID))
+				cmd = tea.Batch(cmd, m.applySidebarCollapsed(sessionID), closeBackgroundDialogCmd)
 				return model, cmd
 			}
 		}
@@ -1294,6 +1315,9 @@ func (m *appModel) handleSwitchTab(sessionID string) (tea.Model, tea.Cmd) {
 	if pendingCmd := m.replayPendingEvent(sessionID); pendingCmd != nil {
 		cmds = append(cmds, pendingCmd)
 	}
+	if closeBackgroundDialogCmd != nil {
+		cmds = append(cmds, closeBackgroundDialogCmd)
+	}
 
 	return m, tea.Batch(cmds...)
 }
@@ -1328,12 +1352,14 @@ func (m *appModel) replayPendingEvent(sessionID string) tea.Cmd {
 	switch ev := pendingEvent.(type) {
 	case *runtime.ToolCallConfirmationEvent:
 		return core.CmdHandler(dialog.OpenDialogMsg{
-			Model: dialog.NewToolConfirmationDialog(ev, sessionState),
+			Model:            dialog.NewToolConfirmationDialog(ev, sessionState),
+			OriginatingEvent: ev,
 		})
 
 	case *runtime.MaxIterationsReachedEvent:
 		return core.CmdHandler(dialog.OpenDialogMsg{
-			Model: dialog.NewMaxIterationsDialog(ev.MaxIterations, m.application),
+			Model:            dialog.NewMaxIterationsDialog(ev.MaxIterations, m.application),
+			OriginatingEvent: ev,
 		})
 
 	case *runtime.ElicitationRequestEvent:
@@ -1353,7 +1379,8 @@ func (m *appModel) replayElicitationEvent(ev *runtime.ElicitationRequestEvent) t
 				serverURL = url
 			}
 			return core.CmdHandler(dialog.OpenDialogMsg{
-				Model: dialog.NewOAuthAuthorizationDialog(serverURL, m.application),
+				Model:            dialog.NewOAuthAuthorizationDialog(serverURL, m.application),
+				OriginatingEvent: ev,
 			})
 		}
 	}
@@ -1361,11 +1388,13 @@ func (m *appModel) replayElicitationEvent(ev *runtime.ElicitationRequestEvent) t
 	switch ev.Mode {
 	case "url":
 		return core.CmdHandler(dialog.OpenDialogMsg{
-			Model: dialog.NewURLElicitationDialog(ev.Message, ev.URL),
+			Model:            dialog.NewURLElicitationDialog(ev.Message, ev.URL),
+			OriginatingEvent: ev,
 		})
 	default:
 		return core.CmdHandler(dialog.OpenDialogMsg{
-			Model: dialog.NewElicitationDialog(ev.Message, ev.Schema, ev.Meta),
+			Model:            dialog.NewElicitationDialog(ev.Message, ev.Schema, ev.Meta),
+			OriginatingEvent: ev,
 		})
 	}
 }
@@ -1682,8 +1711,16 @@ func (m *appModel) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		})
 	}
 
-	// Dialog gets priority when open
+	// Dialog gets priority when open, EXCEPT for background dialogs (e.g.
+	// pending elicitations) which let tab-navigation keys keep working so
+	// the user can switch to another conversation while the prompt waits.
 	if m.dialogMgr.Open() {
+		if m.dialogMgr.TopIsBackground() && !m.leanMode && !m.editor.IsHistorySearchActive() {
+			m.tabBar.SetCloseTabEnabled(true)
+			if cmd := m.tabBar.Update(msg); cmd != nil {
+				return m, cmd
+			}
+		}
 		return m.forwardDialog(msg)
 	}
 
@@ -1829,6 +1866,17 @@ func (m *appModel) handleMouseClick(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) 
 
 	// Dialogs use full-window coordinates (they're positioned over the entire screen)
 	if m.dialogMgr.Open() {
+		// Background dialogs (e.g. pending elicitations) let tab-bar clicks
+		// pass through so the user can keep navigating between tabs.
+		if m.dialogMgr.TopIsBackground() && !m.leanMode && m.hitTestRegion(msg.Y) == regionTabBar {
+			adjustedMsg := msg
+			adjustedMsg.X = msg.X - styles.AppPadding
+			adjustedMsg.Y = msg.Y - m.contentHeight - 1
+			if cmd := m.tabBar.Update(adjustedMsg); cmd != nil {
+				return m, cmd
+			}
+			return m, nil
+		}
 		return m.forwardDialog(msg)
 	}
 
@@ -1953,6 +2001,12 @@ func (m *appModel) handleWheelCoalesced(msg messages.WheelCoalescedMsg) (tea.Mod
 	}
 
 	if m.dialogMgr.Open() {
+		// Background dialogs (e.g. pending elicitations) let chat-area scroll
+		// wheel events fall through so the user can review the conversation
+		// behind the dialog while the prompt waits.
+		if m.dialogMgr.TopIsBackground() && m.hitTestRegion(msg.Y) == regionContent {
+			return m.forwardChat(msg)
+		}
 		return m.forwardDialog(msg)
 	}
 


### PR DESCRIPTION
Fixes #2626.

Until now, an open `user_prompt` (elicitation), URL elicitation, OAuth, tool-confirmation or max-iterations dialog took over the whole TUI: tab navigation keys were swallowed, the tab bar didn't react to clicks, and the chat behind the dialog couldn't be scrolled. That made it impossible to consult another tab — or even just review the conversation history — while a prompt was waiting for an answer.

## What changes

These dialogs are now treated as **background dialogs**: the dialog still grabs typing focus, but it lets through the inputs that don't make sense to capture.

- `Ctrl+T`, `Ctrl+W`, `Ctrl+P`, `Ctrl+N` and `Ctrl+1`–`Ctrl+9` switch tabs as usual.
- Mouse clicks on the tab bar still select / close tabs.
- Scrolling the wheel over the chat content scrolls the conversation behind the dialog.
- Mouse wheel over the dialog itself still scrolls the dialog (unchanged).

When the user switches away from a tab whose top dialog is a background dialog, the dialog is closed and its originating runtime event is re-stashed in `Supervisor.PendingEvent`. Coming back to the tab replays the event through the existing `replayPendingEvent` path, so a fresh equivalent dialog re-opens — the prompt is never lost, and answering it still resolves the original request.

## How it's wired

- `dialog.OpenDialogMsg` gets an optional `OriginatingEvent tea.Msg`. A non-nil value is what marks a dialog as "background" — no new dialog interface and no constructor churn.
- `dialog.Manager` exposes `TopIsBackground()` and `TopBackgroundEvent()` for the routing layer.
- The four dialogs that wait on user input (`Elicitation`, `URLElicitation`, `OAuthAuthorization`, `ToolConfirmation`, `MaxIterations`) set the originating event when opened, both in the initial handlers (`pkg/tui/page/chat/runtime_events.go`) and in the replay path (`pkg/tui/tui.go`).
- `appModel.handleKeyPress`, `handleMouseClick` and `handleWheelCoalesced` consult `TopIsBackground()` and let the relevant inputs through to the tab bar / chat page.
- `appModel.handleSwitchTab` snapshots the outgoing tab ID and originating event _before_ `Supervisor.SwitchTo`, then commits the re-stash + close-dialog command only after the switch succeeds (so a failed switch leaves no stale state).
- New `Supervisor.SetPendingEvent` stores the event but intentionally does **not** raise `NeedsAttn` — the user already saw the prompt, they just stepped away.

## Tests

- `pkg/tui/dialog/manager_test.go` — `TopIsBackground` / `TopBackgroundEvent` semantics, including the modal-dialog-underneath case.
- `pkg/tui/service/supervisor/supervisor_test.go` — round-trip and unknown-session no-op coverage for `SetPendingEvent`.
- Existing TUI / supervisor / chat tests still pass.

## Validation

- `golangci-lint run ./...` — 0 issues
- `go run ./lint .` — no offenses (934 files)
- `go mod tidy --diff` — clean
- `mise test` — full suite passes
- `go build ./...` — clean