### PR TITLE
feat: unload local models when switching agents

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -180,6 +180,14 @@
             "ANTHROPIC_API_KEY"
           ]
         },
+        "unload_api": {
+          "type": "string",
+          "description": "Optional path of an HTTP endpoint that unloads a model from this provider's memory. Used in combination with `provider_opts.unload_on_switch: true` on a model: when the runtime switches away from an agent using that model, it issues a `POST <base_url scheme/host><unload_api>` request with body `{\"model\": \"<id>\"}` so local inference engines (DMR, ollama, ramalama, ...) can free GPU/RAM for the next agent. Cloud providers should leave this unset.",
+          "examples": [
+            "/engines/_unload",
+            "/api/unload"
+          ]
+        },
         "temperature": {
           "type": "number",
           "description": "Default sampling temperature for models using this provider.",
@@ -214,7 +222,7 @@
         },
         "provider_opts": {
           "type": "object",
-          "description": "Provider-specific options passed through to the underlying client.",
+          "description": "Provider-specific options passed through to the underlying client. Supports the documented model-level keys plus the runtime-level switch `unload_on_switch` (boolean): when true, the runtime calls the provider's `unload_api` (configured at the provider level) on agent switch so local inference engines can free GPU/RAM held by this model. No-op for providers that don't expose an unload endpoint.",
           "additionalProperties": true
         },
         "track_usage": {
@@ -919,7 +927,7 @@
         },
         "provider_opts": {
           "type": "object",
-          "description": "Provider-specific options. Sampling parameters: top_k (integer, supported by anthropic, google, amazon-bedrock, and custom OpenAI-compatible providers like vLLM/Ollama), repetition_penalty (float, forwarded to custom OpenAI-compatible providers), min_p (float, forwarded to custom providers), seed (integer, forwarded to OpenAI). Infrastructure options: http_headers (map of string to string, adds custom HTTP headers to every request; used for OpenAI-compatible providers like github-copilot which requires Copilot-Integration-Id). dmr: runtime_flags. anthropic/amazon-bedrock (Claude): interleaved_thinking (boolean, default true), thinking_display ('summarized', 'omitted', or 'display') controls whether thinking blocks are returned in responses when thinking is enabled. Claude Opus 4.7 hides thinking by default ('omitted'); set thinking_display: summarized (or thinking_display: display) to receive thinking blocks. openai: transport ('sse' or 'websocket') to choose between SSE and WebSocket streaming for the Responses API. openai/anthropic/google: rerank_prompt (string) to fully override the system prompt used for RAG reranking (advanced - prefer using results.reranking.criteria for domain-specific guidance). Google: google_search (boolean) enables Google Search grounding, google_maps (boolean) enables Google Maps grounding, code_execution (boolean) enables server-side code execution.",
+          "description": "Provider-specific options. Sampling parameters: top_k (integer, supported by anthropic, google, amazon-bedrock, and custom OpenAI-compatible providers like vLLM/Ollama), repetition_penalty (float, forwarded to custom OpenAI-compatible providers), min_p (float, forwarded to custom providers), seed (integer, forwarded to OpenAI). Infrastructure options: http_headers (map of string to string, adds custom HTTP headers to every request; used for OpenAI-compatible providers like github-copilot which requires Copilot-Integration-Id), unload_on_switch (boolean, default false; when true the runtime calls the provider's `unload_api` to release this model's resources whenever the active agent switches — typically used with local inference engines like DMR/ollama/ramalama). dmr: runtime_flags. anthropic/amazon-bedrock (Claude): interleaved_thinking (boolean, default true), thinking_display ('summarized', 'omitted', or 'display') controls whether thinking blocks are returned in responses when thinking is enabled. Claude Opus 4.7 hides thinking by default ('omitted'); set thinking_display: summarized (or thinking_display: display) to receive thinking blocks. openai: transport ('sse' or 'websocket') to choose between SSE and WebSocket streaming for the Responses API. openai/anthropic/google: rerank_prompt (string) to fully override the system prompt used for RAG reranking (advanced - prefer using results.reranking.criteria for domain-specific guidance). Google: google_search (boolean) enables Google Search grounding, google_maps (boolean) enables Google Maps grounding, code_execution (boolean) enables server-side code execution.",
           "additionalProperties": true
         },
         "track_usage": {

--- a/examples/unload_on_switch.yaml
+++ b/examples/unload_on_switch.yaml
@@ -1,0 +1,71 @@
+#!/usr/bin/env docker agent run
+
+# Example: Unload local models when switching agents
+#
+# Local inference engines (DMR, ollama, ramalama, ...) keep models in
+# GPU/RAM until something kicks them out. When two agents in a multi-agent
+# config use different models on the same engine, switching from one to the
+# other risks running out of memory because the previous model is still
+# resident.
+#
+# This example wires up the runtime's "unload on switch" feature:
+#
+#   1. The provider exposes an HTTP endpoint via `unload_api`.
+#   2. Each model that should be evicted on agent switch sets
+#      `provider_opts.unload_on_switch: true`.
+#
+# When the active agent moves between `coder` and `reviewer` (via handoff,
+# transfer_task, or the TUI agent picker), the runtime issues
+#
+#     POST http://model-runner.docker.internal/engines/_unload
+#     Content-Type: application/json
+#
+#     {"model": "ai/qwen3"}
+#
+# so DMR releases the previous model before the next one is activated.
+
+providers:
+  # Docker Model Runner exposes `/engines/_unload` to release resources held
+  # for a given model. The base URL points at the OpenAI-compatible endpoint;
+  # `unload_api` is resolved against its scheme/host (the path component is
+  # ignored), so this is enough to unload regardless of the engine prefix.
+  local_dmr:
+    provider: dmr
+    base_url: http://model-runner.docker.internal/engines/llama.cpp/v1
+    unload_api: /engines/_unload
+
+models:
+  qwen:
+    provider: local_dmr
+    model: ai/qwen3
+    provider_opts:
+      # Opt in: when an agent stops using this model, unload it from VRAM
+      # before the next agent's model is loaded.
+      unload_on_switch: true
+
+  llama:
+    provider: local_dmr
+    model: ai/llama3.2
+    provider_opts:
+      unload_on_switch: true
+
+agents:
+  root:
+    model: qwen
+    description: Orchestrator
+    instruction: |
+      You are the orchestrator. Hand the conversation off to `coder` for
+      programming tasks and to `reviewer` for code review.
+    handoffs:
+      - coder
+      - reviewer
+
+  coder:
+    model: qwen
+    description: Writes code.
+    instruction: You are a programmer. Write clean, idiomatic code.
+
+  reviewer:
+    model: llama
+    description: Reviews code.
+    instruction: You are a code reviewer. Critique the code with empathy.

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -232,6 +232,15 @@ type ProviderConfig struct {
 	APIType string `json:"api_type,omitempty"`
 	// BaseURL is the base URL for the provider's API endpoint
 	BaseURL string `json:"base_url,omitempty"`
+	// UnloadAPI is the path to the provider's model-unload endpoint (relative
+	// to the provider's host). Models that opt in via
+	// `provider_opts.unload_on_switch: true` are unloaded via this endpoint
+	// when the runtime switches to a different agent. Used by local
+	// inference engines (DMR, ollama, ramalama, ...) to free GPU/RAM held
+	// by the previous model. The runtime issues `POST <unload_api>` with a
+	// JSON body of the form `{"model": "<id>"}`. Cloud providers should
+	// leave this unset.
+	UnloadAPI string `json:"unload_api,omitempty"`
 	// TokenKey is the environment variable name containing the API token
 	TokenKey string `json:"token_key,omitempty"`
 	// Temperature is the default sampling temperature for models using this provider
@@ -645,6 +654,28 @@ func (m *ModelConfig) Clone() *ModelConfig {
 // otherwise falls back to Model.
 func (m *ModelConfig) DisplayOrModel() string {
 	return cmp.Or(m.DisplayModel, m.Model)
+}
+
+// UnloadOnSwitch reports whether the model has opted into being unloaded
+// when the runtime switches to a different agent (via
+// `provider_opts.unload_on_switch: true`).
+func (m *ModelConfig) UnloadOnSwitch() bool {
+	if m == nil {
+		return false
+	}
+	v, _ := m.ProviderOpts["unload_on_switch"].(bool)
+	return v
+}
+
+// UnloadAPI returns the unload endpoint path inherited from the model's
+// provider config, or "" when no `unload_api` was set. Populated by the
+// provider-config merge step from [ProviderConfig.UnloadAPI].
+func (m *ModelConfig) UnloadAPI() string {
+	if m == nil {
+		return ""
+	}
+	v, _ := m.ProviderOpts["unload_api"].(string)
+	return strings.TrimSpace(v)
 }
 
 // FlexibleModelConfig wraps ModelConfig to support both shorthand and full syntax.

--- a/pkg/config/latest/unload_test.go
+++ b/pkg/config/latest/unload_test.go
@@ -1,0 +1,55 @@
+package latest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestModelConfigUnloadOnSwitch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cfg  *ModelConfig
+		want bool
+	}{
+		{name: "nil config", cfg: nil, want: false},
+		{name: "no provider opts", cfg: &ModelConfig{}, want: false},
+		{name: "key absent", cfg: &ModelConfig{ProviderOpts: map[string]any{"other": true}}},
+		{name: "explicit false", cfg: &ModelConfig{ProviderOpts: map[string]any{"unload_on_switch": false}}},
+		{name: "explicit true", cfg: &ModelConfig{ProviderOpts: map[string]any{"unload_on_switch": true}}, want: true},
+		{name: "non-bool ignored", cfg: &ModelConfig{ProviderOpts: map[string]any{"unload_on_switch": "true"}}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.cfg.UnloadOnSwitch())
+		})
+	}
+}
+
+func TestModelConfigUnloadAPI(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cfg  *ModelConfig
+		want string
+	}{
+		{name: "nil config", cfg: nil, want: ""},
+		{name: "no provider opts", cfg: &ModelConfig{}, want: ""},
+		{name: "key absent", cfg: &ModelConfig{ProviderOpts: map[string]any{"other": "/foo"}}},
+		{name: "valid path", cfg: &ModelConfig{ProviderOpts: map[string]any{"unload_api": "/api/unload"}}, want: "/api/unload"},
+		{name: "trims whitespace", cfg: &ModelConfig{ProviderOpts: map[string]any{"unload_api": "  /api/unload  "}}, want: "/api/unload"},
+		{name: "non-string ignored", cfg: &ModelConfig{ProviderOpts: map[string]any{"unload_api": 42}}, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.cfg.UnloadAPI())
+		})
+	}
+}

--- a/pkg/model/provider/base/unload.go
+++ b/pkg/model/provider/base/unload.go
@@ -1,0 +1,85 @@
+package base
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// PostUnloadModel issues `POST <endpoint>` with body `{"model": "<modelID>"}`
+// and reads the response so the connection can be reused.
+//
+// It is shared by [provider.Unloader] implementations that talk to OpenAI-
+// compatible engines (DMR, ollama, ramalama, ...). The endpoint is built
+// by the caller; see [JoinHostAndPath] for the standard "scheme/host of
+// base_url + provider-supplied path" join.
+func PostUnloadModel(ctx context.Context, client *http.Client, endpoint, modelID string) error {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	body, err := json.Marshal(map[string]string{"model": modelID})
+	if err != nil {
+		return fmt.Errorf("encoding unload request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("building unload request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	slog.Debug("Unloading model", "url", endpoint, "model", modelID)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("calling unload endpoint %s: %w", endpoint, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4*1024))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("unload endpoint returned %d: %s",
+			resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	return nil
+}
+
+// JoinHostAndPath joins baseURL's scheme + host with path, dropping any
+// path component baseURL may carry.
+//
+//   - If path is itself an absolute URL (http:// or https://), it is
+//     returned as-is.
+//   - Otherwise scheme://host from baseURL is prepended to path. This
+//     lets users point base_url at e.g. http://localhost:11434/v1 and
+//     configure unload_api: /api/unload without the version prefix
+//     bleeding through.
+func JoinHostAndPath(baseURL, path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", errors.New("path is empty")
+	}
+	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+		return path, nil
+	}
+	if baseURL == "" {
+		return "", fmt.Errorf("base_url is empty; cannot resolve relative path %q", path)
+	}
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return "", fmt.Errorf("parsing base_url %q: %w", baseURL, err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("base_url %q must include a scheme and host", baseURL)
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return u.Scheme + "://" + u.Host + path, nil
+}

--- a/pkg/model/provider/base/unload_test.go
+++ b/pkg/model/provider/base/unload_test.go
@@ -1,0 +1,163 @@
+package base
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJoinHostAndPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		baseURL     string
+		path        string
+		want        string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:    "absolute https URL",
+			baseURL: "http://anything",
+			path:    "https://api.example.com/unload",
+			want:    "https://api.example.com/unload",
+		},
+		{
+			name: "absolute http URL",
+			path: "http://api.example.com/unload",
+			want: "http://api.example.com/unload",
+		},
+		{
+			name:    "rooted path drops base path",
+			baseURL: "http://localhost:11434/v1",
+			path:    "/api/unload",
+			want:    "http://localhost:11434/api/unload",
+		},
+		{
+			name:    "engines prefix on base, /engines/_unload path",
+			baseURL: "http://model-runner.docker.internal/engines/llama.cpp/v1",
+			path:    "/engines/_unload",
+			want:    "http://model-runner.docker.internal/engines/_unload",
+		},
+		{
+			name:    "relative path is rooted",
+			baseURL: "http://localhost:11434/v1",
+			path:    "api/unload",
+			want:    "http://localhost:11434/api/unload",
+		},
+		{
+			name:        "empty path",
+			baseURL:     "http://localhost:11434",
+			wantErr:     true,
+			errContains: "path is empty",
+		},
+		{
+			name:        "whitespace only path",
+			baseURL:     "http://localhost:11434",
+			path:        "   ",
+			wantErr:     true,
+			errContains: "path is empty",
+		},
+		{
+			name:        "empty base URL with relative path",
+			path:        "/api/unload",
+			wantErr:     true,
+			errContains: "base_url is empty",
+		},
+		{
+			name:        "base URL without scheme",
+			baseURL:     "localhost:11434/v1",
+			path:        "/api/unload",
+			wantErr:     true,
+			errContains: "must include a scheme and host",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := JoinHostAndPath(tt.baseURL, tt.path)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestPostUnloadModel(t *testing.T) {
+	t.Parallel()
+
+	t.Run("posts JSON body and returns nil on 2xx", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			gotMethod string
+			gotPath   string
+			gotCT     string
+			gotBody   map[string]string
+		)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotMethod = r.Method
+			gotPath = r.URL.Path
+			gotCT = r.Header.Get("Content-Type")
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, &gotBody)
+			w.WriteHeader(http.StatusAccepted)
+		}))
+		defer server.Close()
+
+		err := PostUnloadModel(t.Context(), server.Client(), server.URL+"/api/unload", "ai/qwen3")
+		require.NoError(t, err)
+
+		assert.Equal(t, http.MethodPost, gotMethod)
+		assert.Equal(t, "/api/unload", gotPath)
+		assert.Equal(t, "application/json", gotCT)
+		assert.Equal(t, map[string]string{"model": "ai/qwen3"}, gotBody)
+	})
+
+	t.Run("returns error on non-2xx", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("model busy"))
+		}))
+		defer server.Close()
+
+		err := PostUnloadModel(t.Context(), server.Client(), server.URL+"/api/unload", "ai/qwen3")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "500")
+		assert.Contains(t, err.Error(), "model busy")
+	})
+
+	t.Run("nil http client falls back to default", func(t *testing.T) {
+		t.Parallel()
+
+		called := make(chan struct{}, 1)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			called <- struct{}{}
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer server.Close()
+
+		err := PostUnloadModel(t.Context(), nil, server.URL+"/api/unload", "ai/qwen3")
+		require.NoError(t, err)
+		select {
+		case <-called:
+		default:
+			t.Fatal("server was not called")
+		}
+	})
+}

--- a/pkg/model/provider/defaults.go
+++ b/pkg/model/provider/defaults.go
@@ -96,6 +96,12 @@ func mergeFromProviderConfig(dst *latest.ModelConfig, src latest.ProviderConfig)
 	if dst.TokenKey == "" {
 		dst.TokenKey = src.TokenKey
 	}
+	// Stash the provider-level unload endpoint into the model's ProviderOpts so
+	// the provider implementation can pick it up at unload time without needing
+	// a back-reference to the parent ProviderConfig.
+	if src.UnloadAPI != "" {
+		setProviderOptIfAbsent(dst, "unload_api", src.UnloadAPI)
+	}
 	setIfNil(&dst.Temperature, src.Temperature)
 	setIfNil(&dst.MaxTokens, src.MaxTokens)
 	setIfNil(&dst.TopP, src.TopP)

--- a/pkg/model/provider/dmr/unload.go
+++ b/pkg/model/provider/dmr/unload.go
@@ -1,0 +1,51 @@
+package dmr
+
+import (
+	"context"
+	"net/url"
+	"strings"
+
+	"github.com/docker/docker-agent/pkg/model/provider/base"
+)
+
+// Unload asks Docker Model Runner to release the resources held for the
+// configured model. It is invoked by the runtime when switching away from
+// an agent whose model has `provider_opts.unload_on_switch: true`.
+//
+// User-configured `unload_api` on the provider wins; otherwise the default
+// `_unload` endpoint is derived from the OpenAI base URL by replacing the
+// `/v1` suffix, mirroring how [buildConfigureURL] derives `_configure`.
+func (c *Client) Unload(ctx context.Context) error {
+	endpoint, err := c.unloadEndpoint()
+	if err != nil || endpoint == "" {
+		return err
+	}
+	return base.PostUnloadModel(ctx, c.httpClient, endpoint, c.ModelConfig.Model)
+}
+
+// unloadEndpoint returns the URL to POST to in order to unload the
+// configured model, or "" when no endpoint can be determined.
+func (c *Client) unloadEndpoint() (string, error) {
+	if path := c.ModelConfig.UnloadAPI(); path != "" {
+		return base.JoinHostAndPath(c.baseURL, path)
+	}
+	if c.baseURL == "" {
+		return "", nil
+	}
+	return defaultUnloadURL(c.baseURL), nil
+}
+
+// defaultUnloadURL derives the `_unload` endpoint URL from the OpenAI base
+// URL by replacing the trailing `/v1` segment, mirroring [buildConfigureURL]:
+//
+//	http://host:port/engines/v1/             → http://host:port/engines/_unload
+//	http://host:port/engines/llama.cpp/v1/   → http://host:port/engines/llama.cpp/_unload
+//	http://_/exp/vDD4.40/engines/v1          → http://_/exp/vDD4.40/engines/_unload
+func defaultUnloadURL(baseURL string) string {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return strings.TrimSuffix(strings.TrimSuffix(baseURL, "/"), "/v1") + "/_unload"
+	}
+	u.Path = strings.TrimSuffix(strings.TrimSuffix(u.Path, "/"), "/v1") + "/_unload"
+	return u.String()
+}

--- a/pkg/model/provider/dmr/unload_test.go
+++ b/pkg/model/provider/dmr/unload_test.go
@@ -1,0 +1,187 @@
+package dmr
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/model/provider/base"
+)
+
+func TestDefaultUnloadURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		baseURL  string
+		expected string
+	}{
+		{
+			name:     "standard engines path",
+			baseURL:  "http://127.0.0.1:12434/engines/v1/",
+			expected: "http://127.0.0.1:12434/engines/_unload",
+		},
+		{
+			name:     "no trailing slash",
+			baseURL:  "http://127.0.0.1:12434/engines/v1",
+			expected: "http://127.0.0.1:12434/engines/_unload",
+		},
+		{
+			name:     "Docker Desktop experimental prefix",
+			baseURL:  "http://_/exp/vDD4.40/engines/v1",
+			expected: "http://_/exp/vDD4.40/engines/_unload",
+		},
+		{
+			name:     "backend-scoped path",
+			baseURL:  "http://127.0.0.1:12434/engines/llama.cpp/v1/",
+			expected: "http://127.0.0.1:12434/engines/llama.cpp/_unload",
+		},
+		{
+			name:     "container internal host",
+			baseURL:  "http://model-runner.docker.internal/engines/v1/",
+			expected: "http://model-runner.docker.internal/engines/_unload",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, defaultUnloadURL(tt.baseURL))
+		})
+	}
+}
+
+// newClient builds a [Client] just well-formed enough to drive Unload.
+func newClient(t *testing.T, baseURL string, httpClient *http.Client, cfg latest.ModelConfig) *Client {
+	t.Helper()
+	return &Client{
+		Config:     base.Config{ModelConfig: cfg},
+		baseURL:    baseURL,
+		httpClient: httpClient,
+	}
+}
+
+func TestClientUnloadEndpoint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		baseURL string
+		cfg     latest.ModelConfig
+		want    string
+	}{
+		{
+			name:    "user-configured absolute URL wins",
+			baseURL: "http://default.example/engines/v1",
+			cfg: latest.ModelConfig{
+				ProviderOpts: map[string]any{"unload_api": "https://other.example/api/unload"},
+			},
+			want: "https://other.example/api/unload",
+		},
+		{
+			name:    "user-configured relative path resolves against base host",
+			baseURL: "http://localhost:12434/engines/llama.cpp/v1",
+			cfg: latest.ModelConfig{
+				ProviderOpts: map[string]any{"unload_api": "/api/unload"},
+			},
+			want: "http://localhost:12434/api/unload",
+		},
+		{
+			name:    "default endpoint derived from base URL",
+			baseURL: "http://localhost:12434/engines/llama.cpp/v1",
+			want:    "http://localhost:12434/engines/llama.cpp/_unload",
+		},
+		{
+			name: "empty base URL returns empty endpoint",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c := newClient(t, tt.baseURL, nil, tt.cfg)
+			got, err := c.unloadEndpoint()
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestClientUnload(t *testing.T) {
+	t.Parallel()
+
+	t.Run("posts model id to default unload endpoint", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			gotPath string
+			gotBody map[string]string
+		)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, &gotBody)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		c := newClient(t, server.URL+"/engines/llama.cpp/v1", server.Client(), latest.ModelConfig{
+			Provider: "dmr",
+			Model:    "ai/qwen3",
+		})
+
+		require.NoError(t, c.Unload(t.Context()))
+		assert.Equal(t, "/engines/llama.cpp/_unload", gotPath)
+		assert.Equal(t, map[string]string{"model": "ai/qwen3"}, gotBody)
+	})
+
+	t.Run("honours user-configured unload_api path", func(t *testing.T) {
+		t.Parallel()
+
+		var gotPath string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		c := newClient(t, server.URL+"/engines/v1", server.Client(), latest.ModelConfig{
+			Model:        "ai/qwen3",
+			ProviderOpts: map[string]any{"unload_api": "/custom/unload"},
+		})
+
+		require.NoError(t, c.Unload(t.Context()))
+		assert.Equal(t, "/custom/unload", gotPath)
+	})
+
+	t.Run("returns error on non-2xx", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("boom"))
+		}))
+		defer server.Close()
+
+		c := newClient(t, server.URL+"/engines/v1", server.Client(), latest.ModelConfig{
+			Model: "ai/qwen3",
+		})
+
+		err := c.Unload(t.Context())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "500")
+		assert.Contains(t, err.Error(), "boom")
+	})
+
+	t.Run("no-op when neither base URL nor unload_api are set", func(t *testing.T) {
+		t.Parallel()
+		c := newClient(t, "", nil, latest.ModelConfig{Model: "ai/qwen3"})
+		require.NoError(t, c.Unload(t.Context()))
+	})
+}

--- a/pkg/model/provider/openai/unload.go
+++ b/pkg/model/provider/openai/unload.go
@@ -1,0 +1,28 @@
+package openai
+
+import (
+	"context"
+
+	"github.com/docker/docker-agent/pkg/httpclient"
+	"github.com/docker/docker-agent/pkg/model/provider/base"
+)
+
+// Unload asks the upstream provider to release the resources held for the
+// configured model. It is a no-op when the provider config does not declare
+// an `unload_api`, which is the case for cloud providers (OpenAI, Anthropic
+// gateways, ...) that don't expose such an endpoint.
+//
+// Local OpenAI-compatible inference engines (ollama, ramalama, vLLM, ...)
+// typically do, and the runtime triggers Unload when switching away from an
+// agent whose model has `provider_opts.unload_on_switch: true`.
+func (c *Client) Unload(ctx context.Context) error {
+	path := c.ModelConfig.UnloadAPI()
+	if path == "" {
+		return nil
+	}
+	endpoint, err := base.JoinHostAndPath(c.ModelConfig.BaseURL, path)
+	if err != nil {
+		return err
+	}
+	return base.PostUnloadModel(ctx, httpclient.NewHTTPClient(ctx), endpoint, c.ModelConfig.Model)
+}

--- a/pkg/model/provider/openai/unload_test.go
+++ b/pkg/model/provider/openai/unload_test.go
@@ -1,0 +1,95 @@
+package openai
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/model/provider/base"
+)
+
+func TestUnload(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no-op when unload_api is not configured", func(t *testing.T) {
+		t.Parallel()
+
+		c := &Client{
+			Config: base.Config{
+				ModelConfig: latest.ModelConfig{
+					Provider: "openai",
+					Model:    "gpt-4",
+					BaseURL:  "https://api.openai.com/v1",
+				},
+			},
+		}
+		require.NoError(t, c.Unload(t.Context()))
+	})
+
+	t.Run("posts model id to configured unload endpoint", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			gotPath string
+			gotBody map[string]string
+		)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, &gotBody)
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer server.Close()
+
+		c := &Client{
+			Config: base.Config{
+				ModelConfig: latest.ModelConfig{
+					Provider: "ollama",
+					Model:    "llama3.2",
+					BaseURL:  server.URL + "/v1",
+					ProviderOpts: map[string]any{
+						"unload_api": "/api/unload",
+					},
+				},
+			},
+		}
+
+		require.NoError(t, c.Unload(t.Context()))
+		assert.Equal(t, "/api/unload", gotPath)
+		assert.Equal(t, map[string]string{"model": "llama3.2"}, gotBody)
+	})
+
+	t.Run("returns error on non-2xx", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte("upstream gone"))
+		}))
+		defer server.Close()
+
+		c := &Client{
+			Config: base.Config{
+				ModelConfig: latest.ModelConfig{
+					Provider: "ollama",
+					Model:    "llama3.2",
+					BaseURL:  server.URL + "/v1",
+					ProviderOpts: map[string]any{
+						"unload_api": "/api/unload",
+					},
+				},
+			},
+		}
+
+		err := c.Unload(t.Context())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "502")
+		assert.Contains(t, err.Error(), "upstream gone")
+	})
+}

--- a/pkg/model/provider/provider.go
+++ b/pkg/model/provider/provider.go
@@ -71,6 +71,24 @@ type RerankingProvider interface {
 	Rerank(ctx context.Context, query string, documents []types.Document, criteria string) ([]float64, error)
 }
 
+// Unloader is an optional interface implemented by providers that can
+// release the resources held for the provider's currently configured
+// model. Local inference engines (DMR, ollama, ramalama, ...) typically
+// do; remote cloud APIs do not.
+//
+// The runtime calls Unload when switching away from an agent whose model
+// has `provider_opts.unload_on_switch: true` so that the next agent's
+// model can claim the freed GPU/RAM. Implementations are expected to be
+// best-effort: returning an error logs a warning but never blocks the
+// agent switch.
+type Unloader interface {
+	Provider
+	// Unload asks the provider to release any resources held for the
+	// model in its [base.Config]. Implementations should be idempotent
+	// — repeated calls on an already-unloaded model must succeed.
+	Unload(ctx context.Context) error
+}
+
 // New creates a new provider from a model config.
 // This is a convenience wrapper for NewWithModels with no models map.
 func New(ctx context.Context, cfg *latest.ModelConfig, env environment.Provider, opts ...options.Opt) (Provider, error) {

--- a/pkg/model/provider/provider_defaults_test.go
+++ b/pkg/model/provider/provider_defaults_test.go
@@ -199,6 +199,37 @@ func TestMergeFromProviderConfig_Fields(t *testing.T) {
 			},
 		},
 		{
+			name: "UnloadAPI plumbed into ProviderOpts.unload_api",
+			dst:  &latest.ModelConfig{},
+			src:  latest.ProviderConfig{UnloadAPI: "/engines/_unload"},
+			assert: func(t *testing.T, got *latest.ModelConfig) {
+				t.Helper()
+				require.NotNil(t, got.ProviderOpts)
+				assert.Equal(t, "/engines/_unload", got.ProviderOpts["unload_api"])
+			},
+		},
+		{
+			name: "UnloadAPI does not overwrite an existing model-level unload_api",
+			dst:  &latest.ModelConfig{ProviderOpts: map[string]any{"unload_api": "/custom"}},
+			src:  latest.ProviderConfig{UnloadAPI: "/engines/_unload"},
+			assert: func(t *testing.T, got *latest.ModelConfig) {
+				t.Helper()
+				assert.Equal(t, "/custom", got.ProviderOpts["unload_api"])
+			},
+		},
+		{
+			name: "empty UnloadAPI doesn't pollute ProviderOpts",
+			dst:  &latest.ModelConfig{},
+			src:  latest.ProviderConfig{},
+			assert: func(t *testing.T, got *latest.ModelConfig) {
+				t.Helper()
+				if got.ProviderOpts != nil {
+					_, has := got.ProviderOpts["unload_api"]
+					assert.False(t, has)
+				}
+			},
+		},
+		{
 			name: "explicit APIType wins over OpenAI-compatible default",
 			dst:  &latest.ModelConfig{},
 			src:  latest.ProviderConfig{APIType: "openai_responses"},

--- a/pkg/runtime/agent_delegation.go
+++ b/pkg/runtime/agent_delegation.go
@@ -217,9 +217,11 @@ func mergeExcludedTools(parent, child []string) []string {
 func (r *LocalRuntime) swapCurrentAgent(ctx context.Context, sessionID string, from, to *agent.Agent, evts chan<- Event) func() {
 	evts <- AgentSwitching(true, from.Name(), to.Name())
 	r.executeOnAgentSwitchHooks(ctx, from, sessionID, from.Name(), to.Name(), agentSwitchKindTransferTask)
+	r.unloadOnSwitch(ctx, from, to)
 	r.setCurrentAgent(to.Name())
 	evts <- AgentInfo(to.Name(), getAgentModelID(to), to.Description(), to.WelcomeMessage())
 	return func() {
+		r.unloadOnSwitch(ctx, to, from)
 		r.setCurrentAgent(from.Name())
 		evts <- AgentSwitching(false, to.Name(), from.Name())
 		r.executeOnAgentSwitchHooks(ctx, from, sessionID, to.Name(), from.Name(), agentSwitchKindTransferTaskReturn)
@@ -450,6 +452,7 @@ func (r *LocalRuntime) handleHandoff(ctx context.Context, sess *session.Session,
 	}
 
 	r.executeOnAgentSwitchHooks(ctx, currentAgent, sess.ID, ca, next.Name(), agentSwitchKindHandoff)
+	r.unloadOnSwitch(ctx, currentAgent, next)
 	r.setCurrentAgent(next.Name())
 	handoffMessage := "The agent " + ca + " handed off the conversation to you. " +
 		"Your available handoff agents and tools are specified in the system messages that follow. " +

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -530,7 +530,18 @@ func (r *LocalRuntime) CurrentAgentInfo(context.Context) CurrentAgentInfo {
 }
 
 func (r *LocalRuntime) SetCurrentAgent(agentName string) error {
-	return r.agents.SetValidated(agentName)
+	prev := r.CurrentAgent()
+	if err := r.agents.SetValidated(agentName); err != nil {
+		return err
+	}
+	next := r.CurrentAgent()
+	if prev != next {
+		// User-driven switches don't carry a request context, but Unload
+		// must be bounded so a slow engine doesn't stall the picker.
+		// unloadOnSwitch already wraps each call in a per-call timeout.
+		r.unloadOnSwitch(context.Background(), prev, next)
+	}
+	return nil
 }
 
 func (r *LocalRuntime) CurrentAgentCommands(context.Context) types.Commands {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -535,12 +535,16 @@ func (r *LocalRuntime) SetCurrentAgent(agentName string) error {
 		return err
 	}
 	next := r.CurrentAgent()
-	if prev != next {
-		// User-driven switches don't carry a request context, but Unload
-		// must be bounded so a slow engine doesn't stall the picker.
-		// unloadOnSwitch already wraps each call in a per-call timeout.
-		r.unloadOnSwitch(context.Background(), prev, next)
+	if prev == next {
+		return nil
 	}
+	// Run the unload in the background: the TUI agent picker drives this
+	// path from the bubbletea Update loop, so a synchronous call would
+	// freeze the UI for as long as the engine takes to acknowledge the
+	// unload (up to unloadOnSwitchTimeout). Fire-and-forget is safe here
+	// because the new agent's model isn't loaded until the user sends a
+	// message — typically long after the unload completes.
+	go r.unloadOnSwitch(context.Background(), prev, next)
 	return nil
 }
 

--- a/pkg/runtime/unload.go
+++ b/pkg/runtime/unload.go
@@ -1,0 +1,46 @@
+package runtime
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/model/provider"
+)
+
+// unloadOnSwitchTimeout caps each Unload() call. The runtime invokes
+// Unload during agent switches; a stalled or unreachable engine must not
+// block the user, so we time out aggressively and keep going.
+const unloadOnSwitchTimeout = 10 * time.Second
+
+// unloadOnSwitch asks the previous agent's models to release any
+// resources they hold, when they have explicitly opted in via
+// `provider_opts.unload_on_switch: true`. It is best-effort: providers
+// that don't implement [provider.Unloader] are silently skipped, and any
+// error from Unload is logged but never propagated, so a slow or
+// unreachable engine cannot break agent switching.
+//
+// Every configured model is considered (not just the currently-selected
+// one) so alloyed agents free every variant they may have loaded.
+func (r *LocalRuntime) unloadOnSwitch(ctx context.Context, prev, next *agent.Agent) {
+	if prev == nil || prev == next {
+		return
+	}
+	for _, m := range prev.ConfiguredModels() {
+		cfg := m.BaseConfig().ModelConfig
+		if !cfg.UnloadOnSwitch() {
+			continue
+		}
+		unloader, ok := m.(provider.Unloader)
+		if !ok {
+			continue
+		}
+		callCtx, cancel := context.WithTimeout(ctx, unloadOnSwitchTimeout)
+		if err := unloader.Unload(callCtx); err != nil {
+			slog.Warn("unload-on-switch failed",
+				"agent", prev.Name(), "model", m.ID(), "error", err)
+		}
+		cancel()
+	}
+}

--- a/pkg/runtime/unload.go
+++ b/pkg/runtime/unload.go
@@ -28,6 +28,9 @@ func (r *LocalRuntime) unloadOnSwitch(ctx context.Context, prev, next *agent.Age
 		return
 	}
 	for _, m := range prev.ConfiguredModels() {
+		if m == nil {
+			continue
+		}
 		cfg := m.BaseConfig().ModelConfig
 		if !cfg.UnloadOnSwitch() {
 			continue

--- a/pkg/runtime/unload_test.go
+++ b/pkg/runtime/unload_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -205,4 +206,66 @@ func TestUnloadOnSwitch_UnloadErrorDoesNotPropagate(t *testing.T) {
 	rt.unloadOnSwitch(t.Context(), prevAgent, nextAgent)
 	assert.Equal(t, int32(1), prev.calls.Load(),
 		"Unload should still be invoked even though it returns an error")
+}
+
+func TestSetCurrentAgent_UnloadIsAsync(t *testing.T) {
+	t.Parallel()
+
+	// A blocking unloader that lets the test assert SetCurrentAgent
+	// returns BEFORE the unload completes.
+	done := make(chan struct{})
+	release := make(chan struct{})
+	prev := &unloadingProvider{
+		id: "dmr/qwen3",
+		cfg: latest.ModelConfig{
+			ProviderOpts: map[string]any{"unload_on_switch": true},
+		},
+	}
+	// Wrap the default Unload to block until release is closed.
+	slowPrev := &slowUnloadingProvider{unloadingProvider: prev, released: release, started: done}
+	next := &unloadingProvider{id: "dmr/llama3.2"}
+
+	agents := []*agent.Agent{
+		agent.New("prev", "", agent.WithModel(slowPrev)),
+		agent.New("next", "", agent.WithModel(next)),
+	}
+	tm := team.New(team.WithAgents(agents...))
+	rt, err := NewLocalRuntime(tm, WithModelStore(mockModelStore{}), WithCurrentAgent("prev"))
+	require.NoError(t, err)
+
+	// SetCurrentAgent must return immediately, not wait for unload.
+	require.NoError(t, rt.SetCurrentAgent("next"))
+
+	// Confirm the goroutine actually started Unload.
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("unload goroutine never started")
+	}
+
+	// Releasing the slow unloader lets it finish so the test cleans up.
+	close(release)
+}
+
+// slowUnloadingProvider is an [unloadingProvider] whose Unload blocks on
+// the released channel. Used to assert that SetCurrentAgent does not wait
+// for unload to complete.
+type slowUnloadingProvider struct {
+	*unloadingProvider
+
+	released <-chan struct{}
+	started  chan<- struct{}
+}
+
+func (s *slowUnloadingProvider) Unload(ctx context.Context) error {
+	select {
+	case s.started <- struct{}{}:
+	default:
+	}
+	select {
+	case <-s.released:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	return s.unloadingProvider.Unload(ctx)
 }

--- a/pkg/runtime/unload_test.go
+++ b/pkg/runtime/unload_test.go
@@ -1,0 +1,208 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/model/provider/base"
+	"github.com/docker/docker-agent/pkg/team"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+// unloadingProvider is a [provider.Unloader] that lets tests count and
+// inspect the calls the runtime makes when switching agents.
+type unloadingProvider struct {
+	id          string
+	stream      chat.MessageStream
+	cfg         latest.ModelConfig
+	calls       atomic.Int32
+	returnError error
+}
+
+func (m *unloadingProvider) ID() string { return m.id }
+
+func (m *unloadingProvider) CreateChatCompletionStream(context.Context, []chat.Message, []tools.Tool) (chat.MessageStream, error) {
+	if m.stream != nil {
+		return m.stream, nil
+	}
+	return &mockStream{}, nil
+}
+
+func (m *unloadingProvider) BaseConfig() base.Config { return base.Config{ModelConfig: m.cfg} }
+
+func (m *unloadingProvider) MaxTokens() int { return 0 }
+
+func (m *unloadingProvider) Unload(context.Context) error {
+	m.calls.Add(1)
+	return m.returnError
+}
+
+func newUnloadingAgentRuntime(t *testing.T, providers map[string]*unloadingProvider) *LocalRuntime {
+	t.Helper()
+	var agents []*agent.Agent
+	for name, p := range providers {
+		agents = append(agents, agent.New(name, name+" instructions", agent.WithModel(p)))
+	}
+	tm := team.New(team.WithAgents(agents...))
+	rt, err := NewLocalRuntime(tm, WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+	return rt
+}
+
+func TestUnloadOnSwitch_OptedInModelIsUnloaded(t *testing.T) {
+	t.Parallel()
+
+	prev := &unloadingProvider{
+		id: "dmr/qwen3",
+		cfg: latest.ModelConfig{
+			Provider: "dmr",
+			Model:    "ai/qwen3",
+			ProviderOpts: map[string]any{
+				"unload_on_switch": true,
+			},
+		},
+	}
+	next := &unloadingProvider{
+		id: "dmr/llama3.2",
+		cfg: latest.ModelConfig{
+			Provider: "dmr",
+			Model:    "ai/llama3.2",
+		},
+	}
+
+	rt := newUnloadingAgentRuntime(t, map[string]*unloadingProvider{
+		"prev": prev,
+		"next": next,
+	})
+
+	prevAgent, err := rt.team.Agent("prev")
+	require.NoError(t, err)
+	nextAgent, err := rt.team.Agent("next")
+	require.NoError(t, err)
+
+	rt.unloadOnSwitch(t.Context(), prevAgent, nextAgent)
+
+	assert.Equal(t, int32(1), prev.calls.Load(), "previous agent's model must be unloaded")
+	assert.Equal(t, int32(0), next.calls.Load(), "next agent's model must NOT be unloaded")
+}
+
+func TestUnloadOnSwitch_NoOptInDoesNothing(t *testing.T) {
+	t.Parallel()
+
+	prev := &unloadingProvider{
+		id: "dmr/qwen3",
+		cfg: latest.ModelConfig{
+			Provider: "dmr",
+			Model:    "ai/qwen3",
+			// No unload_on_switch.
+		},
+	}
+	next := &unloadingProvider{
+		id:  "dmr/llama3.2",
+		cfg: latest.ModelConfig{Provider: "dmr", Model: "ai/llama3.2"},
+	}
+
+	rt := newUnloadingAgentRuntime(t, map[string]*unloadingProvider{
+		"prev": prev,
+		"next": next,
+	})
+
+	prevAgent, err := rt.team.Agent("prev")
+	require.NoError(t, err)
+	nextAgent, err := rt.team.Agent("next")
+	require.NoError(t, err)
+
+	rt.unloadOnSwitch(t.Context(), prevAgent, nextAgent)
+	assert.Equal(t, int32(0), prev.calls.Load(),
+		"unload must NOT happen when the model didn't opt in")
+}
+
+func TestUnloadOnSwitch_SameAgentIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	prev := &unloadingProvider{
+		id: "dmr/qwen3",
+		cfg: latest.ModelConfig{
+			ProviderOpts: map[string]any{"unload_on_switch": true},
+		},
+	}
+
+	rt := newUnloadingAgentRuntime(t, map[string]*unloadingProvider{
+		"only": prev,
+	})
+
+	a, err := rt.team.Agent("only")
+	require.NoError(t, err)
+	rt.unloadOnSwitch(t.Context(), a, a)
+	assert.Equal(t, int32(0), prev.calls.Load(),
+		"unload must NOT happen when prev == next")
+}
+
+func TestUnloadOnSwitch_NilPrevIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	next := &unloadingProvider{
+		id:  "dmr/qwen3",
+		cfg: latest.ModelConfig{},
+	}
+
+	rt := newUnloadingAgentRuntime(t, map[string]*unloadingProvider{"next": next})
+	a, err := rt.team.Agent("next")
+	require.NoError(t, err)
+
+	rt.unloadOnSwitch(t.Context(), nil, a)
+	assert.Equal(t, int32(0), next.calls.Load())
+}
+
+func TestUnloadOnSwitch_ProviderWithoutUnloaderIsSkipped(t *testing.T) {
+	t.Parallel()
+
+	// mockProvider is the runtime test fixture without an Unload method.
+	prev := &mockProvider{id: "openai/gpt-4"}
+	next := &mockProvider{id: "openai/gpt-3.5"}
+
+	prevAgent := agent.New("prev", "prev", agent.WithModel(prev))
+	nextAgent := agent.New("next", "next", agent.WithModel(next))
+	tm := team.New(team.WithAgents(prevAgent, nextAgent))
+	rt, err := NewLocalRuntime(tm, WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+
+	// Should not panic, even though the provider doesn't implement Unloader.
+	rt.unloadOnSwitch(t.Context(), prevAgent, nextAgent)
+}
+
+func TestUnloadOnSwitch_UnloadErrorDoesNotPropagate(t *testing.T) {
+	t.Parallel()
+
+	prev := &unloadingProvider{
+		id: "dmr/qwen3",
+		cfg: latest.ModelConfig{
+			ProviderOpts: map[string]any{"unload_on_switch": true},
+		},
+		returnError: errors.New("engine unreachable"),
+	}
+	next := &unloadingProvider{id: "dmr/llama3.2"}
+
+	rt := newUnloadingAgentRuntime(t, map[string]*unloadingProvider{
+		"prev": prev,
+		"next": next,
+	})
+
+	prevAgent, err := rt.team.Agent("prev")
+	require.NoError(t, err)
+	nextAgent, err := rt.team.Agent("next")
+	require.NoError(t, err)
+
+	// Must not panic and must not return an error.
+	rt.unloadOnSwitch(t.Context(), prevAgent, nextAgent)
+	assert.Equal(t, int32(1), prev.calls.Load(),
+		"Unload should still be invoked even though it returns an error")
+}


### PR DESCRIPTION
Closes #2636.

## What

Adds an opt-in mechanism for local inference engines (DMR, ollama, ramalama, ...) to release a model from memory when the active agent switches to one that uses a different model.

## User-facing surface

Two new pieces of config (latest only — older versions are frozen):

- **\`provider_opts.unload_on_switch: true\`** on a model — the runtime calls the engine's unload endpoint when switching away from any agent using this model.
- **\`unload_api: <path>\`** on a \`ProviderConfig\` — endpoint the runtime hits with \`POST {scheme://host}{unload_api}\` and body \`{\"model\": \"<id>\"}\`.

For DMR specifically, the default \`/_unload\` endpoint is auto-derived from the OpenAI base URL (mirroring how \`_configure\` is derived), so DMR users don't need to set \`unload_api\` unless they want to override it.

\`\`\`yaml
providers:
  local_dmr:
    provider: dmr
    base_url: http://model-runner.docker.internal/engines/llama.cpp/v1
    unload_api: /engines/_unload   # optional for DMR; defaults to /_unload

models:
  qwen:
    provider: local_dmr
    model: ai/qwen3
    provider_opts:
      unload_on_switch: true
\`\`\`

A runnable example lives at \`examples/unload_on_switch.yaml\`.

## Wiring

The unload runs at every agent-switch entry point:

- \`swapCurrentAgent\` (transfer_task forward + return)
- \`handleHandoff\` (handoff)
- \`SetCurrentAgent\` (TUI agent picker — async, see below)

Best-effort: each call is wrapped in a 10s timeout, providers that don't implement \`Unloader\` are silently skipped, and any error is logged but never propagated, so a slow or unreachable engine cannot break agent switching.

## Architecture

- \`latest.ProviderConfig.UnloadAPI\` — new field; merged into \`ModelConfig.ProviderOpts[\"unload_api\"]\` so provider implementations don't need a back-reference to the parent config.
- \`latest.ModelConfig.UnloadOnSwitch()\` / \`UnloadAPI()\` — small accessor methods next to the existing \`DisplayOrModel()\`.
- \`provider.Unloader\` — optional interface in \`pkg/model/provider/provider.go\` (sibling of \`RerankingProvider\`).
- \`base.PostUnloadModel\` / \`base.JoinHostAndPath\` — shared HTTP + URL helpers in \`pkg/model/provider/base\`. DMR and OpenAI both already import \`base\`, so no new package and no import cycle.
- \`dmr.Client.Unload\` — DMR-specific URL derivation (\`/v1\` → \`/_unload\`) plus the shared HTTP helper.
- \`openai.Client.Unload\` — no-op when no \`unload_api\` is configured (cloud providers don't have one).
- \`runtime.LocalRuntime.unloadOnSwitch\` — iterates the previous agent's configured models and calls \`Unload\` on opted-in ones.

## TUI freeze fix

\`SetCurrentAgent\` is called from the bubbletea Update loop, so a synchronous unload would freeze the TUI for up to 10s. The runtime spawns the unload in a goroutine for that path only — fire-and-forget is safe because the new agent's model isn't loaded until the user sends a message, by which time the unload almost certainly finished. The other two switch paths (\`swapCurrentAgent\`, \`handleHandoff\`) stay synchronous because there a new model IS loaded immediately and we want unload to complete first.

## Tests

- \`pkg/config/latest/unload_test.go\` — \`UnloadOnSwitch\` / \`UnloadAPI\` accessors.
- \`pkg/model/provider/base/unload_test.go\` — URL resolution + HTTP behaviour (happy path, non-2xx, nil client fallback).
- \`pkg/model/provider/dmr/unload_test.go\` — default \`_unload\` derivation, custom path override, error propagation, no-op when nothing is configured.
- \`pkg/model/provider/openai/unload_test.go\` — no-op without \`unload_api\`, happy path, error path.
- \`pkg/model/provider/provider_defaults_test.go\` — three new cases for the \`UnloadAPI\` plumbing.
- \`pkg/runtime/unload_test.go\` — opt-in respected, no-op when not opted in or same agent or nil prev, errors don't propagate, providers without \`Unloader\` are skipped, and \`TestSetCurrentAgent_UnloadIsAsync\` (uses a blocking unloader) asserts the picker returns before \`Unload\` completes. Runs cleanly under \`-race\`.

## Validation

- \`mise build\` ✓
- \`mise lint\` ✓ (\`golangci-lint\` and the in-tree \`./lint\` cop both clean)
- \`mise test\` ✓