### PR TITLE
fix(httpclient): drop comment-only SSE events that crash openai-go

### DIFF
--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -43,7 +43,7 @@ func NewHTTPClient(ctx context.Context, opts ...Opt) *http.Client {
 	return &http.Client{
 		Transport: &userAgentTransport{
 			httpOptions: httpOptions,
-			rt:          rt,
+			rt:          &sseFilterTransport{base: rt},
 		},
 	}
 }

--- a/pkg/httpclient/sse_filter.go
+++ b/pkg/httpclient/sse_filter.go
@@ -1,0 +1,108 @@
+package httpclient
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// sseFilterTransport wraps a base RoundTripper and, when the response is a
+// `text/event-stream`, replaces the body with one that strips SSE events
+// containing no `data:` lines.
+//
+// Why this exists: some upstreams (notably OpenRouter) inject comment-only
+// keep-alive frames into their streams:
+//
+//	: OPENROUTER PROCESSING
+//	<blank line>
+//	data: {"id":"...", ...}
+//	<blank line>
+//
+// A correct SSE consumer ignores comment lines but still treats the blank
+// line that follows them as an event boundary. The OpenAI Go SDK's
+// `ssestream.Stream` does exactly that, then unconditionally calls
+// `json.Unmarshal` on the resulting empty `Data` slice — which fails with
+// "unexpected end of JSON input" and tears down the whole completion.
+//
+// The filter normalises the byte stream so events with no `data:` lines
+// (comment-only events, or events bearing only `event:` / `id:` headers)
+// never reach the SDK. Well-formed events pass through verbatim, and the
+// filter is a no-op on non-SSE responses.
+type sseFilterTransport struct {
+	base http.RoundTripper
+}
+
+func (t *sseFilterTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	res, err := t.base.RoundTrip(req)
+	if err != nil || res == nil || res.Body == nil {
+		return res, err
+	}
+	// Match the prefix so charset suffixes (e.g. "text/event-stream;
+	// charset=utf-8") still trigger filtering.
+	if strings.HasPrefix(strings.ToLower(res.Header.Get("Content-Type")), "text/event-stream") {
+		res.Body = newSSEFilterReader(res.Body)
+	}
+	return res, err
+}
+
+// sseFilterReader buffers the lines of a single SSE event and only emits
+// them once it has seen the trailing blank line AND the event contained at
+// least one `data:` line. A half-built event still pending at EOF is
+// dropped silently — without the terminating blank line a downstream parser
+// would not have dispatched it anyway.
+type sseFilterReader struct {
+	src     io.ReadCloser
+	scn     *bufio.Scanner
+	out     bytes.Buffer // bytes ready to hand back to the caller
+	pending bytes.Buffer // accumulated lines for the current event
+	hasData bool         // saw at least one `data:` line in `pending`
+}
+
+func newSSEFilterReader(src io.ReadCloser) *sseFilterReader {
+	scn := bufio.NewScanner(src)
+	// SSE events can be large (long completion tokens, image URLs, …). Match
+	// the buffer size used by openai-go's own SSE decoder so we don't trip
+	// `bufio.ErrTooLong` on payloads it would happily accept.
+	scn.Buffer(make([]byte, 0, 64*1024), bufio.MaxScanTokenSize<<9)
+	return &sseFilterReader{src: src, scn: scn}
+}
+
+func (r *sseFilterReader) Read(p []byte) (int, error) {
+	for r.out.Len() == 0 {
+		if !r.scn.Scan() {
+			if err := r.scn.Err(); err != nil {
+				return 0, err
+			}
+			return 0, io.EOF
+		}
+		r.consumeLine(r.scn.Bytes())
+	}
+	return r.out.Read(p)
+}
+
+func (r *sseFilterReader) consumeLine(line []byte) {
+	switch {
+	case len(line) == 0:
+		// Event boundary: emit the buffered event iff it had data.
+		if r.hasData {
+			r.out.Write(r.pending.Bytes())
+			r.out.WriteByte('\n')
+		}
+		r.pending.Reset()
+		r.hasData = false
+	case line[0] == ':':
+		// SSE comment — drop entirely.
+	default:
+		r.pending.Write(line)
+		r.pending.WriteByte('\n')
+		if bytes.HasPrefix(line, []byte("data:")) {
+			r.hasData = true
+		}
+	}
+}
+
+func (r *sseFilterReader) Close() error {
+	return r.src.Close()
+}

--- a/pkg/httpclient/sse_filter_test.go
+++ b/pkg/httpclient/sse_filter_test.go
@@ -1,0 +1,346 @@
+package httpclient
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSSEFilter_FiltersStream covers the streaming-body filter: each case
+// sends `in` through the transport and expects `want` to come out.
+func TestSSEFilter_FiltersStream(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			// OpenRouter scenario: a comment-only keep-alive frame
+			// followed by a real data frame. The pre-filter must drop
+			// the keep-alive so the OpenAI SDK only sees well-formed
+			// events.
+			name: "drops comment-only events",
+			in: ": OPENROUTER PROCESSING\n" +
+				"\n" +
+				"data: {\"id\":\"1\"}\n" +
+				"\n",
+			want: "data: {\"id\":\"1\"}\n\n",
+		},
+		{
+			// Guard against the filter breaking ordinary streams that
+			// don't contain comments.
+			name: "passes through well-formed events",
+			in: "data: {\"id\":\"1\"}\n\n" +
+				"data: {\"id\":\"2\"}\n\n" +
+				"data: [DONE]\n\n",
+			want: "data: {\"id\":\"1\"}\n\n" +
+				"data: {\"id\":\"2\"}\n\n" +
+				"data: [DONE]\n\n",
+		},
+		{
+			// Some upstreams emit `event:` / `id:` headers without a
+			// `data:` line — the SDK would still try to JSON-unmarshal
+			// the empty payload.
+			name: "drops events with only event/id headers",
+			in: "event: ping\n" +
+				"id: abc\n" +
+				"\n" +
+				"data: {\"id\":\"1\"}\n" +
+				"\n",
+			want: "data: {\"id\":\"1\"}\n\n",
+		},
+		{
+			// Make sure we don't accidentally drop event/id headers
+			// that are part of a real event.
+			name: "preserves event/id headers when data is present",
+			in: "event: chunk\n" +
+				"data: {\"id\":\"1\"}\n" +
+				"\n",
+			want: "event: chunk\n" +
+				"data: {\"id\":\"1\"}\n" +
+				"\n",
+		},
+		{
+			// `data:` without a space is also a data line per the SSE
+			// grammar (the leading space is purely cosmetic). Verify the
+			// filter recognises it and lets it through.
+			name: "recognises data: prefix without a leading space",
+			in:   "data:test\n\n",
+			want: "data:test\n\n",
+		},
+		{
+			// Mixed CRLF and LF terminators in the same stream — both
+			// must be normalised to LF on the way out.
+			name: "normalises mixed CRLF and LF line endings",
+			in:   "data: a\r\n\r\ndata: b\n\n",
+			want: "data: a\n\ndata: b\n\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, fetchSSE(t, tt.in))
+		})
+	}
+}
+
+// TestSSEFilter_ContentTypeMatching covers the cases where the filter must
+// activate even though Content-Type isn't bare lowercase
+// `text/event-stream`. To prove the filter actually ran (rather than the
+// payload happening to round-trip unchanged), each input contains a comment
+// line that the filter strips.
+func TestSSEFilter_ContentTypeMatching(t *testing.T) {
+	t.Parallel()
+
+	const in = ": keepalive\n\ndata: ok\n\n"
+	const want = "data: ok\n\n"
+
+	tests := []struct {
+		name        string
+		contentType string
+	}{
+		{name: "with charset parameter", contentType: "text/event-stream; charset=utf-8"},
+		{name: "mixed case", contentType: "Text/Event-Stream"},
+		{name: "uppercase", contentType: "TEXT/EVENT-STREAM"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", tt.contentType)
+				_, _ = io.WriteString(w, in)
+			}))
+			t.Cleanup(srv.Close)
+
+			assert.Equal(t, want, fetchThroughFilter(t, srv.URL))
+		})
+	}
+}
+
+// TestSSEFilter_NoOpOnNonSSEResponse confirms the wrapper is transparent
+// for responses that are not SSE: the body is passed through verbatim,
+// including bytes that would have been stripped from an SSE stream.
+func TestSSEFilter_NoOpOnNonSSEResponse(t *testing.T) {
+	t.Parallel()
+
+	const body = ": this colon-prefixed line would be dropped from SSE\n\nplain payload"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	assert.Equal(t, body, fetchThroughFilter(t, srv.URL))
+}
+
+// TestSSEFilter_LargeEvent verifies that events larger than the default
+// scanner buffer are handled correctly. The filter raises the cap to 32 MB
+// (matching openai-go) so payloads up to that size don't trip
+// bufio.ErrTooLong.
+func TestSSEFilter_LargeEvent(t *testing.T) {
+	t.Parallel()
+
+	largeData := "data: " + strings.Repeat("x", 256*1024) + "\n\n"
+	r := newSSEFilterReader(io.NopCloser(strings.NewReader(largeData)))
+
+	output, err := io.ReadAll(r)
+	require.NoError(t, err)
+	assert.Equal(t, largeData, string(output))
+}
+
+// TestSSEFilter_PartialReads exercises the io.Reader contract: a caller
+// passing in a tiny buffer must still observe the full output across
+// multiple Read calls.
+func TestSSEFilter_PartialReads(t *testing.T) {
+	t.Parallel()
+
+	input := "data: test1\n\ndata: test2\n\n"
+	r := newSSEFilterReader(io.NopCloser(strings.NewReader(input)))
+
+	var output []byte
+	buf := make([]byte, 5)
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			output = append(output, buf[:n]...)
+		}
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, input, string(output))
+}
+
+// TestSSEFilter_IncompleteEventAtEOF documents that an event missing its
+// trailing blank line is dropped silently — without that boundary the
+// downstream SSE parser would not have dispatched it anyway.
+func TestSSEFilter_IncompleteEventAtEOF(t *testing.T) {
+	t.Parallel()
+
+	input := "data: complete\n\ndata: incomplete"
+	r := newSSEFilterReader(io.NopCloser(strings.NewReader(input)))
+
+	output, err := io.ReadAll(r)
+	require.NoError(t, err)
+	assert.Equal(t, "data: complete\n\n", string(output))
+}
+
+// TestSSEFilter_EmptyInput verifies the reader handles a closed-immediately
+// stream without error.
+func TestSSEFilter_EmptyInput(t *testing.T) {
+	t.Parallel()
+
+	r := newSSEFilterReader(io.NopCloser(strings.NewReader("")))
+
+	output, err := io.ReadAll(r)
+	require.NoError(t, err)
+	assert.Empty(t, output)
+}
+
+// TestSSEFilter_OnlyComments verifies that a stream containing nothing but
+// comments produces an empty body — the filter must not surface the
+// keep-alives.
+func TestSSEFilter_OnlyComments(t *testing.T) {
+	t.Parallel()
+
+	input := ": comment1\n\n: comment2\n\n"
+	r := newSSEFilterReader(io.NopCloser(strings.NewReader(input)))
+
+	output, err := io.ReadAll(r)
+	require.NoError(t, err)
+	assert.Empty(t, output)
+}
+
+// TestSSEFilter_ScannerError verifies that errors from the underlying
+// reader are propagated to the caller (not swallowed as EOF).
+func TestSSEFilter_ScannerError(t *testing.T) {
+	t.Parallel()
+
+	r := newSSEFilterReader(io.NopCloser(&errorReader{err: io.ErrUnexpectedEOF}))
+
+	_, err := io.ReadAll(r)
+	assert.ErrorIs(t, err, io.ErrUnexpectedEOF)
+}
+
+type errorReader struct {
+	err error
+}
+
+func (e *errorReader) Read(_ []byte) (int, error) {
+	return 0, e.err
+}
+
+// TestSSEFilter_CloseWithoutRead verifies Close still tears down the
+// underlying body even when the caller never read from it (e.g. early
+// abort after inspecting the response headers).
+func TestSSEFilter_CloseWithoutRead(t *testing.T) {
+	t.Parallel()
+
+	var closed bool
+	tracker := &closeTracker{
+		Reader:  strings.NewReader("data: test\n\n"),
+		onClose: func() { closed = true },
+	}
+
+	r := newSSEFilterReader(tracker)
+	require.NoError(t, r.Close())
+	assert.True(t, closed, "underlying reader should be closed")
+}
+
+type closeTracker struct {
+	io.Reader
+
+	onClose func()
+}
+
+func (c *closeTracker) Close() error {
+	if c.onClose != nil {
+		c.onClose()
+	}
+	return nil
+}
+
+// TestSSEFilter_ConcurrentRequests verifies the transport has no shared
+// mutable state and is safe to use across goroutines (also caught by
+// `go test -race`).
+func TestSSEFilter_ConcurrentRequests(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(": comment\n\ndata: test\n\n"))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := &http.Client{Transport: &sseFilterTransport{base: http.DefaultTransport}}
+
+	const numRequests = 10
+	var wg sync.WaitGroup
+	wg.Add(numRequests)
+	for range numRequests {
+		go func() {
+			defer wg.Done()
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, http.NoBody)
+			assert.NoError(t, err)
+
+			res, err := client.Do(req)
+			if !assert.NoError(t, err) {
+				return
+			}
+			defer func() { _ = res.Body.Close() }()
+
+			body, err := io.ReadAll(res.Body)
+			assert.NoError(t, err)
+			assert.Equal(t, "data: test\n\n", string(body))
+		}()
+	}
+	wg.Wait()
+}
+
+// fetchSSE serves `payload` as `text/event-stream` and returns the body a
+// client would observe after pulling it through the filtering transport.
+// Going via a real HTTP server (rather than the reader directly) also
+// exercises the Content-Type sniffing in sseFilterTransport.RoundTrip.
+func fetchSSE(t *testing.T, payload string) string {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.Copy(w, strings.NewReader(payload))
+	}))
+	t.Cleanup(srv.Close)
+
+	return fetchThroughFilter(t, srv.URL)
+}
+
+// fetchThroughFilter performs a GET against `url` through the filtering
+// transport and returns the response body as a string.
+func fetchThroughFilter(t *testing.T, url string) string {
+	t.Helper()
+
+	client := &http.Client{Transport: &sseFilterTransport{base: http.DefaultTransport}}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, http.NoBody)
+	require.NoError(t, err)
+
+	res, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = res.Body.Close() }()
+
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	return string(body)
+}


### PR DESCRIPTION
Some upstreams (notably OpenRouter) inject SSE comment frames as keep-alives:

```
: OPENROUTER PROCESSING

data: {"id":"...", ...}

```

The OpenAI Go SDK's `ssestream.Stream` correctly ignores comment lines but still treats the trailing blank line as an event boundary, then unconditionally JSON-unmarshals the resulting empty payload. That fails with `unexpected end of JSON input` and tears down the whole completion.

## Fix

Wrap the HTTP transport with a streaming pre-filter that, on responses whose `Content-Type` starts with `text/event-stream` (case-insensitive, charset parameters allowed), drops events containing no `data:` lines. Well-formed events pass through verbatim and non-SSE responses are untouched.

The filter:

- handles arbitrary `data:` payload sizes (32 MB scanner buffer, matching openai-go's own decoder);
- normalises CRLF / mixed line endings to LF;
- propagates underlying-reader errors instead of swallowing them as EOF;
- silently drops half-built events at EOF (a downstream parser would not have dispatched them anyway);
- is safe for concurrent use (verified under `go test -race`).

## Tests

`pkg/httpclient/sse_filter_test.go` covers, among other things:

- the OpenRouter comment-only keep-alive scenario;
- pass-through of well-formed streams;
- events bearing only `event:` / `id:` headers (also dropped);
- preservation of `event:` / `id:` when accompanied by `data:`;
- `Content-Type` matching with charset parameter, mixed case, and uppercase (the case-insensitive matching is verified to actually catch a regression);
- 256 KB events, partial reads with tiny caller buffers, empty input, comment-only streams;
- scanner error propagation, Close-without-Read, and concurrent requests.

## Validation

- `go build ./...` ✅
- `go test ./pkg/httpclient/... -race -count=1` ✅
- `mise lint` ✅ (golangci-lint and the project's custom linter)

Assisted-By: docker-agent