### PR TITLE
chore: tighten file/directory permissions for per-user data

### DIFF
--- a/cmd/root/eval.go
+++ b/cmd/root/eval.go
@@ -70,7 +70,7 @@ func (f *evalFlags) runEvalCommand(cmd *cobra.Command, args []string) (commandEr
 	}
 
 	// Create output directory
-	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+	if err := os.MkdirAll(outputDir, 0o700); err != nil {
 		return fmt.Errorf("creating output directory: %w", err)
 	}
 
@@ -79,7 +79,7 @@ func (f *evalFlags) runEvalCommand(cmd *cobra.Command, args []string) (commandEr
 
 	// Set up log file with debug logging
 	logPath := filepath.Join(outputDir, runName+".log")
-	logFile, err := os.Create(logPath)
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
 		return fmt.Errorf("creating log file: %w", err)
 	}

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -265,7 +265,7 @@ func isFirstRun() bool {
 	markerFile := filepath.Join(configDir, ".cagent_first_run")
 
 	// Ensure the config directory exists before trying to create the marker file
-	if err := os.MkdirAll(configDir, 0o755); err != nil {
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
 		slog.Warn("Failed to create config directory for first run marker", "error", err)
 		return false
 	}

--- a/pkg/atomicfile/atomicfile.go
+++ b/pkg/atomicfile/atomicfile.go
@@ -1,11 +1,24 @@
 // Package atomicfile writes files atomically (write-to-temp + rename)
 // with a configurable file mode.
 //
-// It wraps [github.com/natefinch/atomic], which performs the atomic
-// rename but does not let the caller specify a permission bitmask on
-// the resulting file. [Write] addresses that gap by chmod-ing the file
-// after the rename, so the same call site can both publish the file
-// atomically and ensure it is not world-readable.
+// It wraps [github.com/natefinch/atomic.WriteFile], which performs the
+// atomic rename but does not let the caller specify a permission bitmask
+// on the resulting file. [Write] addresses that gap by chmod-ing the file
+// after the rename, so the same call site can both publish the file atomically
+// and ensure it is not world-readable.
+//
+// # Platform Support
+//
+// File modes are POSIX-only. On Windows, the mode parameter is ignored and
+// the file inherits default ACLs from the parent directory.
+//
+// # Security Note
+//
+// The chmod happens after the rename, creating a small window (typically
+// microseconds) where the file exists at the default umask permissions before
+// being tightened. Callers that require strict secrecy should ensure the parent
+// directory has restrictive permissions (e.g., 0o700) to limit access during
+// this window.
 package atomicfile
 
 import (

--- a/pkg/atomicfile/atomicfile.go
+++ b/pkg/atomicfile/atomicfile.go
@@ -1,0 +1,31 @@
+// Package atomicfile writes files atomically (write-to-temp + rename)
+// with a configurable file mode.
+//
+// It wraps [github.com/natefinch/atomic], which performs the atomic
+// rename but does not let the caller specify a permission bitmask on
+// the resulting file. [Write] addresses that gap by chmod-ing the file
+// after the rename, so the same call site can both publish the file
+// atomically and ensure it is not world-readable.
+package atomicfile
+
+import (
+	"io"
+	"os"
+
+	"github.com/natefinch/atomic"
+)
+
+// Write atomically writes data from r to path and sets the file's mode.
+//
+// The write goes to a temporary file in the same directory and is then
+// renamed into place; readers therefore observe either the previous
+// contents or the new contents, never a partial write. The chmod is
+// applied after the rename: callers that care about secrecy should
+// avoid having a third party already holding an open descriptor on
+// path before the call.
+func Write(path string, r io.Reader, mode os.FileMode) error {
+	if err := atomic.WriteFile(path, r); err != nil {
+		return err
+	}
+	return os.Chmod(path, mode)
+}

--- a/pkg/atomicfile/atomicfile_test.go
+++ b/pkg/atomicfile/atomicfile_test.go
@@ -1,0 +1,61 @@
+package atomicfile_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/atomicfile"
+)
+
+func TestWriteCreatesFileWithMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file modes are POSIX-only")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret")
+
+	require.NoError(t, atomicfile.Write(path, bytes.NewReader([]byte("hello")), 0o600))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(data))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func TestWriteOverwritesAndRetightensMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file modes are POSIX-only")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret")
+
+	require.NoError(t, os.WriteFile(path, []byte("old"), 0o644))
+	require.NoError(t, atomicfile.Write(path, bytes.NewReader([]byte("new")), 0o600))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "new", string(data))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func TestWriteReturnsErrorForMissingDirectory(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "missing", "file")
+
+	err := atomicfile.Write(path, bytes.NewReader([]byte("x")), 0o600)
+	assert.Error(t, err)
+}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -299,7 +299,7 @@ func mtimeOf(path string) time.Time {
 func lockFile(path string) (func(), error) {
 	lockPath := path + ".lock"
 	if dir := filepath.Dir(lockPath); dir != "" {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
 			return nil, fmt.Errorf("creating lock directory %q: %w", dir, err)
 		}
 	}
@@ -329,7 +329,7 @@ func lockFile(path string) (func(), error) {
 // after the rename so the rename itself is durable across an OS crash.
 func writeJSON(path string, entries map[string]string) error {
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("creating cache directory %q: %w", dir, err)
 	}
 

--- a/pkg/config/sources.go
+++ b/pkg/config/sources.go
@@ -295,14 +295,14 @@ func (a urlSource) Read(ctx context.Context) ([]byte, error) {
 	}
 
 	// Cache the response
-	if err := os.MkdirAll(cacheDir, 0o755); err == nil {
-		if err := os.WriteFile(cachePath, data, 0o644); err != nil {
+	if err := os.MkdirAll(cacheDir, 0o700); err == nil {
+		if err := os.WriteFile(cachePath, data, 0o600); err != nil {
 			slog.DebugContext(ctx, "Failed to cache URL content", "url", a.url, "error", err)
 		}
 
 		// Save ETag if present
 		if etag := resp.Header.Get("ETag"); etag != "" {
-			if err := os.WriteFile(etagPath, []byte(etag), 0o644); err != nil {
+			if err := os.WriteFile(etagPath, []byte(etag), 0o600); err != nil {
 				slog.DebugContext(ctx, "Failed to cache ETag", "url", a.url, "error", err)
 			}
 		} else {

--- a/pkg/content/store.go
+++ b/pkg/content/store.go
@@ -81,7 +81,7 @@ func NewStore(opts ...Opt) (*Store, error) {
 		store.baseDir = filepath.Join(homeDir, ".cagent", "store")
 	}
 
-	if err := os.MkdirAll(store.baseDir, 0o755); err != nil {
+	if err := os.MkdirAll(store.baseDir, 0o700); err != nil {
 		return nil, fmt.Errorf("creating store directory: %w", err)
 	}
 
@@ -353,14 +353,14 @@ func (s *Store) resolveReference(reference string) (string, error) {
 // createReferenceLink creates a link from reference to digest
 func (s *Store) createReferenceLink(reference, digest string) error {
 	refsDir := filepath.Join(s.baseDir, "refs")
-	if err := os.MkdirAll(refsDir, 0o755); err != nil {
+	if err := os.MkdirAll(refsDir, 0o700); err != nil {
 		return fmt.Errorf("creating refs directory: %w", err)
 	}
 
 	refHash := sha256.Sum256([]byte(reference))
 	refFile := filepath.Join(refsDir, hex.EncodeToString(refHash[:]))
 
-	return os.WriteFile(refFile, []byte(digest), 0o644)
+	return os.WriteFile(refFile, []byte(digest), 0o600)
 }
 
 // removeReferenceLinks removes all reference links pointing to the given digest
@@ -398,7 +398,7 @@ func (s *Store) saveMetadata(digest string, metadata *ArtifactMetadata) error {
 		return fmt.Errorf("marshaling metadata: %w", err)
 	}
 
-	return os.WriteFile(metadataPath, data, 0o644)
+	return os.WriteFile(metadataPath, data, 0o600)
 }
 
 // loadMetadata loads metadata for an artifact

--- a/pkg/environment/sandbox_tokens.go
+++ b/pkg/environment/sandbox_tokens.go
@@ -162,6 +162,12 @@ func (w *SandboxTokenWriter) writeOnce(ctx context.Context) {
 		slog.DebugContext(ctx, "Failed to rename sandbox tokens file", "to", w.path, "error", err)
 		return
 	}
+	// natefinch/atomic does not allow specifying a file mode; the file holds
+	// a bearer token, so restrict it to the user.
+	if err := os.Chmod(w.path, 0o600); err != nil {
+		slog.Debug("Failed to chmod sandbox tokens file", "path", w.path, "error", err)
+		return
+	}
 
 	slog.DebugContext(ctx, "Wrote sandbox tokens file", "path", w.path)
 }

--- a/pkg/environment/sandbox_tokens.go
+++ b/pkg/environment/sandbox_tokens.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/natefinch/atomic"
+	"github.com/docker/docker-agent/pkg/atomicfile"
 )
 
 // sandboxTokens is the JSON schema for the file.
@@ -158,14 +158,8 @@ func (w *SandboxTokenWriter) writeOnce(ctx context.Context) {
 		return
 	}
 
-	if err := atomic.WriteFile(w.path, bytes.NewReader(data)); err != nil {
-		slog.DebugContext(ctx, "Failed to rename sandbox tokens file", "to", w.path, "error", err)
-		return
-	}
-	// natefinch/atomic does not allow specifying a file mode; the file holds
-	// a bearer token, so restrict it to the user.
-	if err := os.Chmod(w.path, 0o600); err != nil {
-		slog.Debug("Failed to chmod sandbox tokens file", "path", w.path, "error", err)
+	if err := atomicfile.Write(w.path, bytes.NewReader(data), 0o600); err != nil {
+		slog.DebugContext(ctx, "Failed to write sandbox tokens file", "path", w.path, "error", err)
 		return
 	}
 

--- a/pkg/evaluation/save.go
+++ b/pkg/evaluation/save.go
@@ -22,7 +22,7 @@ func SaveRunSessions(ctx context.Context, run *EvalRun, outputDir string) (strin
 	dbPath := filepath.Join(outputDir, run.Name+".db")
 
 	// Create output directory if needed
-	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+	if err := os.MkdirAll(outputDir, 0o700); err != nil {
 		return "", fmt.Errorf("creating output directory: %w", err)
 	}
 
@@ -493,11 +493,11 @@ func saveJSON(value any, outputPath string) (string, error) {
 		return "", err
 	}
 
-	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0o700); err != nil {
 		return "", err
 	}
 
-	if err := os.WriteFile(outputPath, data, 0o644); err != nil {
+	if err := os.WriteFile(outputPath, data, 0o600); err != nil {
 		return "", err
 	}
 

--- a/pkg/history/history.go
+++ b/pkg/history/history.go
@@ -127,7 +127,7 @@ func (h *History) addInMemory(message string) {
 // append writes message to the persistent history file as one JSON-encoded
 // line.
 func (h *History) append(message string) error {
-	if err := os.MkdirAll(filepath.Dir(h.path), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(h.path), 0o700); err != nil {
 		return err
 	}
 	encoded, err := json.Marshal(message)
@@ -135,7 +135,7 @@ func (h *History) append(message string) error {
 		return err
 	}
 
-	f, err := os.OpenFile(h.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	f, err := os.OpenFile(h.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		return err
 	}

--- a/pkg/profiling/profiling.go
+++ b/pkg/profiling/profiling.go
@@ -22,7 +22,7 @@ func Start(cpuProfile, memProfile string) (Stop, error) {
 	var closers []func() error
 
 	if cpuProfile != "" {
-		f, err := os.Create(cpuProfile)
+		f, err := os.OpenFile(cpuProfile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 		if err != nil {
 			return noop, fmt.Errorf("failed to create CPU profile: %w", err)
 		}
@@ -38,7 +38,7 @@ func Start(cpuProfile, memProfile string) (Stop, error) {
 
 	if memProfile != "" {
 		closers = append(closers, func() error {
-			f, err := os.Create(memProfile)
+			f, err := os.OpenFile(memProfile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 			if err != nil {
 				return fmt.Errorf("failed to create memory profile: %w", err)
 			}

--- a/pkg/rag/strategy/bm25_database.go
+++ b/pkg/rag/strategy/bm25_database.go
@@ -219,7 +219,7 @@ func ensureDir(filePath string) error {
 	}
 
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		return os.MkdirAll(dir, 0o755)
+		return os.MkdirAll(dir, 0o700)
 	}
 
 	return nil

--- a/pkg/skills/cache.go
+++ b/pkg/skills/cache.go
@@ -109,11 +109,11 @@ func (c *diskCache) FetchAndStore(ctx context.Context, baseURL, skillName, fileP
 	contentPath := filepath.Join(dir, filePath)
 	metaPath := contentPath + ".meta"
 
-	if err := os.MkdirAll(filepath.Dir(contentPath), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(contentPath), 0o700); err != nil {
 		return "", fmt.Errorf("creating cache directory: %w", err)
 	}
 
-	if err := os.WriteFile(contentPath, body, 0o644); err != nil {
+	if err := os.WriteFile(contentPath, body, 0o600); err != nil {
 		return "", fmt.Errorf("writing cache file: %w", err)
 	}
 
@@ -123,7 +123,7 @@ func (c *diskCache) FetchAndStore(ctx context.Context, baseURL, skillName, fileP
 		ExpiresAt: expiresAt,
 	}
 	metaJSON, _ := json.Marshal(meta)
-	if err := os.WriteFile(metaPath, metaJSON, 0o644); err != nil {
+	if err := os.WriteFile(metaPath, metaJSON, 0o600); err != nil {
 		// Non-fatal: the content is cached, just the metadata isn't
 		slog.DebugContext(ctx, "Failed to write cache metadata", "path", metaPath, "error", err)
 	}

--- a/pkg/toolinstall/registry.go
+++ b/pkg/toolinstall/registry.go
@@ -13,7 +13,8 @@ import (
 	"sync"
 
 	"github.com/goccy/go-yaml"
-	"github.com/natefinch/atomic"
+
+	"github.com/docker/docker-agent/pkg/atomicfile"
 )
 
 // githubToken returns a GitHub personal access token from the environment,
@@ -226,7 +227,7 @@ func (r *Registry) fetchIndex(ctx context.Context) (*registryIndex, error) {
 	} else {
 		// Best-effort: persist to disk for future fallback.
 		_ = os.MkdirAll(filepath.Dir(cachePath), 0o755)
-		_ = atomic.WriteFile(cachePath, bytes.NewReader(data))
+		_ = atomicfile.Write(cachePath, bytes.NewReader(data), 0o644)
 	}
 
 	var index registryIndex

--- a/pkg/toolinstall/registry.go
+++ b/pkg/toolinstall/registry.go
@@ -226,8 +226,8 @@ func (r *Registry) fetchIndex(ctx context.Context) (*registryIndex, error) {
 		}
 	} else {
 		// Best-effort: persist to disk for future fallback.
-		_ = os.MkdirAll(filepath.Dir(cachePath), 0o755)
-		_ = atomicfile.Write(cachePath, bytes.NewReader(data), 0o644)
+		_ = os.MkdirAll(filepath.Dir(cachePath), 0o700)
+		_ = atomicfile.Write(cachePath, bytes.NewReader(data), 0o600)
 	}
 
 	var index registryIndex

--- a/pkg/tools/builtin/tasks/tasks.go
+++ b/pkg/tools/builtin/tasks/tasks.go
@@ -137,7 +137,7 @@ func (t *Tool) save(store taskStore) error {
 	if err != nil {
 		return fmt.Errorf("marshaling task store: %w", err)
 	}
-	return os.WriteFile(t.filePath, data, 0o644)
+	return os.WriteFile(t.filePath, data, 0o600)
 }
 
 func effectiveStatus(task Task, tasks map[string]Task) TaskStatus {

--- a/pkg/userconfig/userconfig.go
+++ b/pkg/userconfig/userconfig.go
@@ -242,7 +242,7 @@ func (c *Config) Save() error {
 }
 
 func (c *Config) saveTo(path string) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return fmt.Errorf("failed to create config directory: %w", err)
 	}
 
@@ -254,7 +254,12 @@ func (c *Config) saveTo(path string) error {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
-	return atomic.WriteFile(path, bytes.NewReader(data))
+	if err := atomic.WriteFile(path, bytes.NewReader(data)); err != nil {
+		return err
+	}
+	// natefinch/atomic does not allow specifying a file mode; the config
+	// may contain a credential helper command, so restrict it to the user.
+	return os.Chmod(path, 0o600)
 }
 
 // GetAlias retrieves the alias configuration for a given name.

--- a/pkg/userconfig/userconfig.go
+++ b/pkg/userconfig/userconfig.go
@@ -14,8 +14,8 @@ import (
 	"sync"
 
 	"github.com/goccy/go-yaml"
-	"github.com/natefinch/atomic"
 
+	"github.com/docker/docker-agent/pkg/atomicfile"
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/paths"
 )
@@ -254,12 +254,9 @@ func (c *Config) saveTo(path string) error {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
-	if err := atomic.WriteFile(path, bytes.NewReader(data)); err != nil {
-		return err
-	}
-	// natefinch/atomic does not allow specifying a file mode; the config
-	// may contain a credential helper command, so restrict it to the user.
-	return os.Chmod(path, 0o600)
+	// The config may contain a credential helper command, so restrict it
+	// to the user.
+	return atomicfile.Write(path, bytes.NewReader(data), 0o600)
 }
 
 // GetAlias retrieves the alias configuration for a given name.


### PR DESCRIPTION
## Summary

Audit and tighten file/directory permissions for everything `docker-agent` writes under per-user paths (`~/.cagent`, `~/.config/cagent`, `~/.cache/...`, eval/profile output dirs). Other users on the host had no reason to read most of these files — defense in depth.

This branch covers all 27 entries from the audit, grouped into atomic per-package commits, plus one small refactor that extracts a duplicated `atomic.WriteFile + os.Chmod` idiom into a new `pkg/atomicfile` helper.

## What changed

### Permission tightening (13 commits)

| Package | Before | After | Notes |
|---|---|---|---|
| `pkg/history` | `0o755` / `0o644` | `0o700` / `0o600` | Chat history is private |
| `pkg/userconfig` | `0o755` / `0o644` (lib default) | `0o700` / `0o600` | Config may include credential helper command |
| `pkg/environment/sandbox_tokens` | file `0o644` | file `0o600` | File holds a Docker bearer token; mounted into containers |
| `cmd/root` (`isFirstRun`) | `0o755` | `0o700` | Same dir as userconfig |
| `pkg/content/store` (OCI store) | `0o755` / `0o644` | `0o700` / `0o600` | Cached agent prompts may be proprietary |
| `pkg/cache` | `0o755` | `0o700` | Per-user response cache |
| `pkg/skills/cache` | `0o755` / `0o644` | `0o700` / `0o600` | Per-user skill cache |
| `pkg/config/sources` (URL cache) | `0o755` / `0o644` | `0o700` / `0o600` | Per-user agent YAML cache |
| `pkg/tools/builtin/tasks` | file `0o644` | file `0o600` | Dir was already `0o700` |
| `cmd/root/eval` | `0o755` / `os.Create` (`~0o644`) | `0o700` / `0o600` | Eval logs contain prompts/responses |
| `pkg/evaluation/save` | `0o755` / `0o644` | `0o700` / `0o600` | Eval output JSONs |
| `pkg/profiling` | `os.Create` (`~0o644`) | `0o600` | Profile dumps include in-memory data |
| `pkg/rag/strategy` (`ensureDir`) | `0o755` | `0o700` | Indexed RAG content |
| `pkg/toolinstall/registry` | `0o755` / `0o644` | `0o700` / `0o600` | Public data, but consistency with all other caches |

### Refactor (1 commit) + docs (1 commit)

`refactor(atomicfile): extract atomic write+chmod helper`

`natefinch/atomic.WriteFile` doesn't accept a file mode, so the call sites that need a tight mode followed up with `os.Chmod`. That was duplicated in two places (with the same explanatory comment) and would be needed in any future caller.

- New: `pkg/atomicfile.Write(path, reader, mode)` — does both steps in one call, with tests.
- Migrated all three direct `natefinch/atomic` users (`userconfig`, `environment/sandbox_tokens`, `toolinstall/registry`) so the library is now referenced from a single package.
- Net at the call sites: e.g. `sandbox_tokens.go` went from 12 lines (write + chmod, both with debug logging) to 4.

`docs(atomicfile): document Windows behavior and chmod race window`

Documents that file modes are POSIX-only and that `chmod` happens *after* the rename — there's a microsecond window at default umask that callers mitigate by using a restrictive parent dir (every current caller already does).

## What I deliberately did **not** change

- `os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)` in `pkg/profiling` and `cmd/root/eval` — idiomatic Go; wrapping it would add indirection without improving readability.
- `pkg/cache/cache.go`'s manual atomic-write logic — it does `CreateTemp → write → fsync(file) → rename → fsync(dir)`, which is **stronger** than `natefinch/atomic` (no parent-dir fsync). Replacing it would lose durability guarantees.
- Tool binaries installed via `pkg/toolinstall/archive.go` keep `0o755` — they need to be executable.
- The Unix-socket parent dir (`pkg/server/listen.go`) keeps `0o755` — clients in other processes need to traverse it.
- User-explicit outputs (`gh agent pull` writing `agent.yaml` to CWD, HTML export, filesystem tools, LSP edits) keep their existing modes — they match user expectations for files in user-controlled paths.

## Validation

- `mise lint` ✅ 0 issues (`golangci-lint` + custom `./lint` over 942 files)
- `mise test` ✅ all packages pass
- `mise build` ✅ binary builds cleanly

## Commits

```
80e94baa6 docs(atomicfile): document Windows behavior and chmod race window
05546b319 fix(toolinstall): tighten registry cache dir/file permissions to 0o700/0o600
1996d7f3a refactor(atomicfile): extract atomic write+chmod helper
f1d5e0c2c chore(rag): tighten RAG database directory permissions to 0o700
4d94442bc chore(profiling): tighten cpu/mem profile file permissions to 0o600
3325bc0bd chore(evaluation): tighten saved eval output dir/file permissions to 0o700/0o600
0bd6f2de3 chore(eval): tighten eval output dir and log file permissions to 0o700/0o600
64d962ece chore(tasks): tighten tasks JSON file permissions to 0o600
e52874452 chore(config): tighten URL cache dir/file permissions to 0o700/0o600
c190af7e9 chore(skills): tighten skill cache dir/file permissions to 0o700/0o600
4568a28fd chore(cache): tighten cache directory permissions to 0o700
bc77b343a chore(content): tighten OCI content store dir/file permissions to 0o700/0o600
045eb7b7a chore(root): tighten config dir permissions to 0o700 on first-run
66dbab934 chore(environment): chmod sandbox tokens file to 0o600 after atomic write
1a2047d42 chore(userconfig): tighten config dir/file permissions to 0o700/0o600
8a5a1530f chore(history): tighten history dir/file permissions to 0o700/0o600
```
