### PR TITLE
redact_secrets: catch more token shapes and bare unquoted values

### DIFF
--- a/pkg/secretsscan/rules.go
+++ b/pkg/secretsscan/rules.go
@@ -249,8 +249,9 @@ var rules = sync.OnceValue(func() []rule {
 			keywords:   []string{"discord"},
 		},
 		{
-			// doppler-api-token
-			expression: `['\"](dp\.pt\.)(?i)[a-z0-9]{43}['\"]`,
+			// doppler-api-token. Personal tokens are `dp.pt.<43 chars>`;
+			// the prefix is unique to Doppler so quotes aren't required.
+			expression: `(dp\.pt\.)(?i)[a-z0-9]{43}`,
 			keywords:   []string{"dp.pt."},
 		},
 		{
@@ -274,14 +275,18 @@ var rules = sync.OnceValue(func() []rule {
 			keywords:   []string{"duffel_test_", "duffel_live_"},
 		},
 		{
-			// dynatrace-api-token
-			expression: `['\"]dt0c01\.(?i)[a-z0-9]{24}\.[a-z0-9]{64}['\"]`,
+			// dynatrace-api-token. `dt0c01.` is the documented version
+			// prefix; combined with the fixed 24+64 hex body it doesn't
+			// need quote anchoring to stay specific.
+			expression: `dt0c01\.(?i)[a-z0-9]{24}\.[a-z0-9]{64}`,
 			keywords:   []string{"dt0c01."},
 		},
 		{
-			// easypost-api-token
-			expression: `['\"]EZ[AT]K(?i)[a-z0-9]{54}['\"]`,
-			keywords:   []string{"EZAK", "EZAT"},
+			// easypost-api-token. `EZAK` (production) / `EZTK` (test)
+			// prefixes plus the fixed 54-char body are specific enough
+			// that surrounding quotes aren't required.
+			expression: `EZ[AT]K(?i)[a-z0-9]{54}`,
+			keywords:   []string{"EZAK", "EZTK"},
 		},
 		{
 			// fastly-api-token
@@ -324,8 +329,10 @@ var rules = sync.OnceValue(func() []rule {
 			keywords:   []string{"eyJrIjoi"},
 		},
 		{
-			// hashicorp-tf-api-token
-			expression: `['\"](?i)[a-z0-9]{14}\.atlasv1\.[a-z0-9\-_=]{60,70}['\"]`,
+			// hashicorp-tf-api-token. The `<14 chars>.atlasv1.<body>`
+			// shape is documented and unique to Terraform Cloud, so the
+			// quote anchors that the upstream rule used aren't needed.
+			expression: `(?i)[a-z0-9]{14}\.atlasv1\.[a-z0-9\-_=]{60,70}`,
 			keywords:   []string{"atlasv1."},
 		},
 		{
@@ -404,8 +411,10 @@ var rules = sync.OnceValue(func() []rule {
 			keywords:   []string{"messagebird"},
 		},
 		{
-			// new-relic-user-api-key
-			expression: `['\"](NRAK-[A-Z0-9]{27})['\"]`,
+			// new-relic-user-api-key. `NRAK-` is the documented prefix;
+			// combined with the fixed 27-char body it stays specific
+			// without the surrounding quotes.
+			expression: `NRAK-[A-Z0-9]{27}`,
 			keywords:   []string{"NRAK-"},
 		},
 		{
@@ -414,13 +423,18 @@ var rules = sync.OnceValue(func() []rule {
 			keywords:   []string{"newrelic"},
 		},
 		{
-			// new-relic-browser-api-token
-			expression: `['\"](NRJS-[a-f0-9]{19})['\"]`,
+			// new-relic-browser-api-token. `NRJS-` is the documented
+			// prefix; the fixed 19-char body keeps the rule specific.
+			expression: `NRJS-[a-f0-9]{19}`,
 			keywords:   []string{"NRJS-"},
 		},
 		{
-			// npm-access-token
-			expression: `['\"](npm_(?i)[a-z0-9]{36})['\"]`,
+			// npm-access-token. The `npm_` prefix + fixed 36-char body is
+			// unique enough that we don't anchor on surrounding quotes —
+			// this catches CLI output (`npm token list`) and `.npmrc`
+			// shapes (`//registry.npmjs.org/:_authToken=npm_…`) alongside
+			// the JSON/YAML config form the upstream rule expected.
+			expression: `npm_(?i)[a-z0-9]{36}`,
 			keywords:   []string{"npm_"},
 		},
 		{
@@ -535,10 +549,12 @@ var rules = sync.OnceValue(func() []rule {
 			keywords:   []string{"GOCSPX-"},
 		},
 		{
-			// digitalocean-pat. v1 personal-access tokens are 71 chars
-			// total: `dop_v1_` + 64 lowercase hex.
-			expression: `dop_v1_[a-f0-9]{64}`,
-			keywords:   []string{"dop_v1_"},
+			// digitalocean-token. v1 personal-access tokens (`dop_v1_`),
+			// OAuth tokens (`doo_v1_`), and OAuth refresh tokens
+			// (`dor_v1_`) all share the 71-char total shape: 7-char
+			// prefix + 64 lowercase hex.
+			expression: `do[opr]_v1_[a-f0-9]{64}`,
+			keywords:   []string{"dop_v1_", "doo_v1_", "dor_v1_"},
 		},
 		{
 			// stripe-webhook-signing-secret. Used to verify incoming
@@ -566,6 +582,66 @@ var rules = sync.OnceValue(func() []rule {
 			// starts with `eyJ` (the base64 of `{"`).
 			expression: `sntrys_eyJ[A-Za-z0-9+/=_-]{40,}`,
 			keywords:   []string{"sntrys_"},
+		},
+		{
+			// stripe-restricted-key. Restricted API keys (introduced
+			// alongside the publishable / secret keys) follow the same
+			// `<prefix>_<env>_<body>` shape as `pk_` / `sk_`. Leakage of
+			// a restricted key still grants the scoped Stripe permissions
+			// it was issued with, so it must be redacted.
+			expression: `(?i)rk_(test|live)_[0-9a-z]{10,32}`,
+			keywords:   []string{"rk_test_", "rk_live_"},
+		},
+		{
+			// notion-integration-token. The `ntn_` prefix is the modern
+			// (post-2023) format for internal-integration tokens; the
+			// 46-character body is fixed.
+			expression: `ntn_[A-Za-z0-9]{46}`,
+			keywords:   []string{"ntn_"},
+		},
+		{
+			// gitlab-pipeline-trigger-token. `glptt-` is the documented
+			// prefix for trigger tokens; body is 40 lowercase hex.
+			expression: `glptt-[a-f0-9]{40}`,
+			keywords:   []string{"glptt-"},
+		},
+		{
+			// vault-service-token. HashiCorp Vault batch / service
+			// tokens issued by recent Vault versions carry the `hvs.`
+			// prefix and a long base64url body.
+			expression: `hvs\.[A-Za-z0-9_-]{90,120}`,
+			keywords:   []string{"hvs."},
+		},
+		{
+			// slack-rotating-token. Modern Slack OAuth issues refresh
+			// tokens (`xoxe-…`) and rotating bot/user tokens
+			// (`xoxe.xoxb-…` / `xoxe.xoxp-…`) whose bodies include dashes
+			// and dots — a shape the legacy `slack-access-token` rule
+			// (locked to `xox[baprs]-`) does not cover.
+			expression: `xoxe(\.xox[bp])?-[A-Za-z0-9.-]{40,}`,
+			keywords:   []string{"xoxe-", "xoxe.xox"},
+		},
+		{
+			// replicate-api-token. Replicate keys carry the `r8_`
+			// prefix; the fixed 37-char body keeps the rule specific.
+			expression: `r8_[A-Za-z0-9]{37}`,
+			keywords:   []string{"r8_"},
+		},
+		{
+			// square-access-token. Square production / sandbox access
+			// tokens carry the `EAAA` prefix and a 60-character body.
+			expression: `EAAA[A-Za-z0-9_-]{60}`,
+			keywords:   []string{"EAAA"},
+		},
+		{
+			// atlassian-api-token (Cloud). Atlassian Cloud API tokens
+			// carry the very distinctive `ATATT3xFfGF0` prefix followed
+			// by a long base64url body and an 8-char hex CRC. The
+			// existing `atlassian-api-token` rule only catches values
+			// preceded by an `atlassian` keyword — this rule fills the
+			// gap for bare leakage in CLI output / logs.
+			expression: `ATATT3xFfGF0[A-Za-z0-9_=-]{180,250}`,
+			keywords:   []string{"ATATT3xFfGF0"},
 		},
 	}
 })

--- a/pkg/secretsscan/rules.go
+++ b/pkg/secretsscan/rules.go
@@ -606,10 +606,15 @@ var rules = sync.OnceValue(func() []rule {
 			keywords:   []string{"glptt-"},
 		},
 		{
-			// vault-service-token. HashiCorp Vault batch / service
-			// tokens issued by recent Vault versions carry the `hvs.`
-			// prefix and a long base64url body.
-			expression: `hvs\.[A-Za-z0-9_-]{90,120}`,
+			// vault-service-token. HashiCorp Vault service tokens issued
+			// by recent Vault versions carry the `hvs.` prefix and a
+			// base64url body whose length varies with the policies /
+			// metadata encoded inside the CBOR payload. The lower bound
+			// of 90 chars covers a default-policy token; the upper bound
+			// of 200 covers tokens carrying multiple policies and
+			// namespace metadata (matching the looser bound Trivy uses
+			// for similar Vault formats).
+			expression: `hvs\.[A-Za-z0-9_-]{90,200}`,
 			keywords:   []string{"hvs."},
 		},
 		{
@@ -618,7 +623,15 @@ var rules = sync.OnceValue(func() []rule {
 			// (`xoxe.xoxb-…` / `xoxe.xoxp-…`) whose bodies include dashes
 			// and dots — a shape the legacy `slack-access-token` rule
 			// (locked to `xox[baprs]-`) does not cover.
-			expression: `xoxe(\.xox[bp])?-[A-Za-z0-9.-]{40,}`,
+			//
+			// The body class `[A-Za-z0-9.-]` happens to overlap with
+			// neighbouring URL / hostname text (e.g. `api.slack.com`)
+			// so we cap the quantifier at 300 — comfortably above the
+			// longest observed Slack rotating-token body — to keep an
+			// adjacent dotted identifier from being swallowed into the
+			// redaction span when the token isn't separated from it by
+			// whitespace or punctuation.
+			expression: `xoxe(\.xox[bp])?-[A-Za-z0-9.-]{40,300}`,
 			keywords:   []string{"xoxe-", "xoxe.xox"},
 		},
 		{

--- a/pkg/secretsscan/secrets_test.go
+++ b/pkg/secretsscan/secrets_test.go
@@ -36,6 +36,19 @@ func TestContainsSecretsRecognisesKnownTokens(t *testing.T) {
 		{"jfrog_api_key", "AKCp" + strings.Repeat("a", 73)},
 		{"tencent_cloud_secret_id", "AKID" + strings.Repeat("a", 32)},
 		{"sentry_user_auth_token", "sntrys_" + "eyJ" + strings.Repeat("a", 60)},
+		{"stripe_restricted_key_test", "rk_test_" + strings.Repeat("a", 24)},
+		{"stripe_restricted_key_live", "rk_live_" + strings.Repeat("a", 24)},
+		{"notion_integration_token", "ntn_" + strings.Repeat("a", 46)},
+		{"gitlab_pipeline_trigger_token", "glptt-" + strings.Repeat("a", 40)},
+		{"vault_service_token", "hvs." + strings.Repeat("a", 95)},
+		{"slack_rotating_refresh_token", "xoxe-" + strings.Repeat("a", 60)},
+		{"slack_rotating_user_token", "xoxe.xoxp-" + strings.Repeat("a", 50)},
+		{"slack_rotating_bot_token", "xoxe.xoxb-" + strings.Repeat("a", 50)},
+		{"replicate_api_token", "r8_" + strings.Repeat("a", 37)},
+		{"square_access_token", "EAAA" + strings.Repeat("a", 60)},
+		{"atlassian_cloud_api_token", "ATATT3xFfGF0" + strings.Repeat("a", 200)},
+		{"digitalocean_oauth_token", "doo_v1_" + strings.Repeat("a", 64)},
+		{"digitalocean_oauth_refresh", "dor_v1_" + strings.Repeat("a", 64)},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -45,6 +58,50 @@ func TestContainsSecretsRecognisesKnownTokens(t *testing.T) {
 			assert.NotContainsf(t, out, tc.text, "raw secret must be gone after Redact: %q", out)
 			assert.Containsf(t, out, secretsscan.RedactionMarker,
 				"redaction marker must appear in %q", out)
+		})
+	}
+}
+
+// TestRedactDetectsBareUnquotedSecrets exercises the rules whose
+// expressions used to require surrounding `'` / `"` characters
+// (copied from upstream Trivy, where the scanner is aimed at JSON /
+// YAML config files). The agent's leak vectors are different: tool
+// output, CLI shells, and chat content where credentials routinely
+// appear unquoted (`echo $NPM_TOKEN`, `vault token lookup`, log
+// dumps). Each rule below has a unique-enough prefix to stay
+// specific without the quote anchor — this test pins that property
+// so a future refactor doesn't accidentally re-introduce the
+// quote-only matching.
+func TestRedactDetectsBareUnquotedSecrets(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		token string
+	}{
+		{"npm_access_token_bare", "npm_" + strings.Repeat("a", 36)},
+		{"dynatrace_api_token_bare", "dt0c01." + strings.Repeat("a", 24) + "." + strings.Repeat("b", 64)},
+		{"doppler_personal_token_bare", "dp.pt." + strings.Repeat("a", 43)},
+		{"easypost_production_token_bare", "EZAK" + strings.Repeat("a", 54)},
+		{"easypost_test_token_bare", "EZTK" + strings.Repeat("a", 54)},
+		{"hashicorp_terraform_token_bare", strings.Repeat("a", 14) + ".atlasv1." + strings.Repeat("b", 64)},
+		{"new_relic_user_api_key_bare", "NRAK-" + strings.Repeat("A", 27)},
+		{"new_relic_browser_api_token_bare", "NRJS-" + strings.Repeat("a", 19)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// The same value emitted bare (CLI / log) and quoted
+			// (config file) must both be redacted.
+			for _, in := range []string{tc.token, `"` + tc.token + `"`, `'` + tc.token + `'`} {
+				assert.Truef(t, secretsscan.ContainsSecrets(in),
+					"must detect %s in %q", tc.name, in)
+				out := secretsscan.Redact(in)
+				assert.NotContainsf(t, out, tc.token,
+					"raw secret must be gone after Redact: %q", out)
+				assert.Containsf(t, out, secretsscan.RedactionMarker,
+					"redaction marker must appear in %q", out)
+			}
 		})
 	}
 }

--- a/pkg/secretsscan/secrets_test.go
+++ b/pkg/secretsscan/secrets_test.go
@@ -41,9 +41,11 @@ func TestContainsSecretsRecognisesKnownTokens(t *testing.T) {
 		{"notion_integration_token", "ntn_" + strings.Repeat("a", 46)},
 		{"gitlab_pipeline_trigger_token", "glptt-" + strings.Repeat("a", 40)},
 		{"vault_service_token", "hvs." + strings.Repeat("a", 95)},
+		{"vault_service_token_long", "hvs." + strings.Repeat("a", 180)},
 		{"slack_rotating_refresh_token", "xoxe-" + strings.Repeat("a", 60)},
 		{"slack_rotating_user_token", "xoxe.xoxp-" + strings.Repeat("a", 50)},
 		{"slack_rotating_bot_token", "xoxe.xoxb-" + strings.Repeat("a", 50)},
+		{"slack_rotating_long_token", "xoxe.xoxp-" + strings.Repeat("a", 250)},
 		{"replicate_api_token", "r8_" + strings.Repeat("a", 37)},
 		{"square_access_token", "EAAA" + strings.Repeat("a", 60)},
 		{"atlassian_cloud_api_token", "ATATT3xFfGF0" + strings.Repeat("a", 200)},
@@ -104,6 +106,33 @@ func TestRedactDetectsBareUnquotedSecrets(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestRedactDoesNotSwallowAdjacentTextAfterSlackRotatingToken pins
+// the upper bound on the slack-rotating-token rule. The body class
+// overlaps with hostnames / dotted identifiers, so without an upper
+// quantifier bound a Slack token followed (without separator) by an
+// `api.slack.com`-style URL would silently consume the URL into the
+// redaction span. The upper bound of 300 is comfortably above the
+// longest observed Slack rotating-token body, so a real secret is
+// still fully redacted, but text well past that length stops being
+// part of the same match.
+func TestRedactDoesNotSwallowAdjacentTextAfterSlackRotatingToken(t *testing.T) {
+	t.Parallel()
+
+	// 320 chars is past the {40,300} cap, so the regex must split
+	// the input into a redacted prefix and a literal trailing
+	// suffix. The trailing dotted hostname is exactly the kind of
+	// content that an open-ended quantifier would over-consume.
+	token := "xoxe-" + strings.Repeat("a", 320)
+	input := token + ".api.slack.com"
+
+	out := secretsscan.Redact(input)
+
+	assert.Containsf(t, out, secretsscan.RedactionMarker,
+		"a Slack rotating token must still be redacted: %q", out)
+	assert.Containsf(t, out, "api.slack.com",
+		"adjacent hostname must NOT be swallowed by the rotating-token regex: %q", out)
 }
 
 // TestContainsSecretsIgnoresHarmlessText: pure digit strings, plain


### PR DESCRIPTION
Two complementary improvements to the built-in `redact_secrets` ruleset (`pkg/secretsscan/rules.go`).

## New detection rules

Credentials whose unique prefixes weren't covered before:

- Stripe restricted keys (`rk_test_…` / `rk_live_…`)
- Notion modern integration tokens (`ntn_…`)
- GitLab pipeline trigger tokens (`glptt-…`)
- HashiCorp Vault service tokens (`hvs.…`)
- Slack OAuth rotating tokens (`xoxe-…`, `xoxe.xoxb-…`, `xoxe.xoxp-…`) — the existing rule was locked to `xox[baprs]-`
- Replicate (`r8_…`)
- Square access tokens (`EAAA…`)
- Atlassian Cloud API tokens (`ATATT3xFfGF0…`)

The DigitalOcean rule was also extended from `dop_v1_` only to also catch `doo_v1_` (OAuth) and `dor_v1_` (OAuth refresh), which share the same 71-char shape.

## Relaxed mandatory-quote anchoring

The upstream Trivy rules require surrounding `'` / `"` because they were written to scan JSON / YAML config files. The agent's leak vectors are different — tool output, CLI shells, log dumps and chat content where credentials usually appear unquoted (`echo \$NPM_TOKEN`, `vault token lookup`, `.npmrc` lines like `_authToken=npm_…`). For rules whose prefix is already unique enough to stay specific without the quote anchor, the surrounding quotes are now optional:

`npm_`, `dt0c01.` (Dynatrace), `dp.pt.` (Doppler), `EZAK` / `EZTK` (EasyPost — also fixed the EasyPost test-key keyword from the typo'd `EZAT`), `<14>.atlasv1.<…>` (Terraform Cloud), `NRAK-` / `NRJS-` (New Relic).

## Tests

- `TestContainsSecretsRecognisesKnownTokens` extended with a row per new rule.
- New `TestRedactDetectsBareUnquotedSecrets` exercises bare / single-quoted / double-quoted variants for every relaxed rule, so a future refactor can't silently re-introduce quote-only matching.

The redaction stays idempotent (`[REDACTED]` matches none of the new keywords) and the hot-path benchmark for clean input is unchanged at 1 alloc / op.