### PR TITLE
tui: pause animation ticks while the terminal is blurred

### DIFF
--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -131,11 +131,20 @@ type appModel struct {
 	// environment.
 	dockerDesktop bool
 
-	// focused tracks whether the terminal currently has focus. Used both
-	// to filter spurious FocusMsg events (RestoreTerminal re-enables focus
-	// reporting and delivers one) and to skip animation ticks when nobody
-	// is looking at the terminal — the chain re-arms on FocusMsg.
+	// focused tracks whether the terminal currently has focus. Used to
+	// filter spurious FocusMsg events (RestoreTerminal re-enables focus
+	// reporting and delivers one even though we never blurred). Starts
+	// at the zero value (false) so the first FocusMsg is treated as a
+	// real focus event — in Docker Desktop that runs the release/restore
+	// cycle which re-emits terminal mode escape sequences.
 	focused bool
+
+	// tickPaused is true while we should drop animation.TickMsg events
+	// (and let the tick chain die). Set on BlurMsg and cleared on the
+	// next real FocusMsg. Tracked separately from `focused` so that ticks
+	// keep flowing at startup even before any focus event arrives — some
+	// terminals never send FocusMsg.
+	tickPaused bool
 
 	// pendingRestores maps runtime tab IDs (supervisor routing keys) to
 	// persisted session-store IDs. When a tab with a pending restore is first
@@ -489,10 +498,10 @@ func (m *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleRoutedMsg(msg)
 
 	case animation.TickMsg:
-		// Drop the tick (and let the chain die) when the terminal is
-		// blurred. animation.StartTick re-arms the chain on FocusMsg so
+		// Drop the tick (and let the chain die) while we're blurred.
+		// animation.StartTick re-arms the chain on the next FocusMsg so
 		// spinners resume immediately when the user comes back.
-		if !m.focused {
+		if m.tickPaused {
 			return m, nil
 		}
 		cmds := []tea.Cmd{m.updateChatCmd(msg)}
@@ -596,6 +605,7 @@ func (m *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.BlurMsg:
 		m.focused = false
+		m.tickPaused = true
 		return m, nil
 
 	case tea.FocusMsg:
@@ -607,9 +617,12 @@ func (m *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.focused = true
 
 		var cmds []tea.Cmd
-		if animation.HasActive() {
+		if m.tickPaused {
 			// Re-arm the tick chain that died while we were blurred.
-			cmds = append(cmds, animation.StartTick())
+			m.tickPaused = false
+			if animation.HasActive() {
+				cmds = append(cmds, animation.StartTick())
+			}
 		}
 		if m.dockerDesktop && m.program != nil {
 			// Docker Desktop: the terminal may have lost all mode state (alt

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -131,9 +131,10 @@ type appModel struct {
 	// environment.
 	dockerDesktop bool
 
-	// focused tracks whether the terminal currently has focus. Used to
-	// detect real blur→focus transitions and ignore spurious FocusMsg
-	// events emitted by RestoreTerminal re-enabling focus reporting.
+	// focused tracks whether the terminal currently has focus. Used both
+	// to filter spurious FocusMsg events (RestoreTerminal re-enables focus
+	// reporting and delivers one) and to skip animation ticks when nobody
+	// is looking at the terminal — the chain re-arms on FocusMsg.
 	focused bool
 
 	// pendingRestores maps runtime tab IDs (supervisor routing keys) to
@@ -283,6 +284,7 @@ func New(ctx context.Context, spawner SessionSpawner, initialApp *app.App, initi
 		transcriber:             transcribe.New(os.Getenv("OPENAI_API_KEY")),
 		workingSpinner:          spinner.New(spinner.ModeSpinnerOnly, styles.SpinnerDotsHighlightStyle),
 		focusedPanel:            PanelEditor,
+		focused:                 true,
 		editorLines:             3,
 		dockerDesktop:           os.Getenv("TERM_PROGRAM") == "docker_desktop",
 		appName:                 "docker agent",
@@ -488,6 +490,12 @@ func (m *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleRoutedMsg(msg)
 
 	case animation.TickMsg:
+		// Drop the tick (and let the chain die) when the terminal is
+		// blurred. animation.StartTick re-arms the chain on FocusMsg so
+		// spinners resume immediately when the user comes back.
+		if !m.focused {
+			return m, nil
+		}
 		cmds := []tea.Cmd{m.updateChatCmd(msg)}
 		// Update working spinner
 		if m.chatPage.IsWorking() {
@@ -592,25 +600,30 @@ func (m *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.FocusMsg:
-		// Only act on a real blur→focus transition. RestoreTerminal
-		// re-enables focus reporting which delivers a spurious FocusMsg;
-		// since m.focused is already true at that point, we skip it.
-		if m.focused || m.program == nil {
+		// Filter spurious FocusMsg: RestoreTerminal re-enables focus
+		// reporting which delivers a FocusMsg even when we never blurred.
+		if m.focused {
 			return m, nil
 		}
 		m.focused = true
-		if !m.dockerDesktop {
-			return m, nil
+
+		var cmds []tea.Cmd
+		if animation.HasActive() {
+			// Re-arm the tick chain that died while we were blurred.
+			cmds = append(cmds, animation.StartTick())
 		}
-		// Docker Desktop: the terminal may have lost all mode state (alt
-		// screen, mouse tracking, keyboard enhancements, background color,
-		// etc.). A full release/restore cycle re-emits every mode sequence
-		// and forces a complete repaint.
-		return m, func() tea.Msg {
-			_ = m.program.ReleaseTerminal()
-			_ = m.program.RestoreTerminal()
-			return nil
+		if m.dockerDesktop && m.program != nil {
+			// Docker Desktop: the terminal may have lost all mode state (alt
+			// screen, mouse tracking, keyboard enhancements, background
+			// color, etc.). A full release/restore cycle re-emits every mode
+			// sequence and forces a complete repaint.
+			cmds = append(cmds, func() tea.Msg {
+				_ = m.program.ReleaseTerminal()
+				_ = m.program.RestoreTerminal()
+				return nil
+			})
 		}
+		return m, tea.Batch(cmds...)
 
 	case tea.KeyboardEnhancementsMsg:
 		m.keyboardEnhancements = &msg

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -284,7 +284,6 @@ func New(ctx context.Context, spawner SessionSpawner, initialApp *app.App, initi
 		transcriber:             transcribe.New(os.Getenv("OPENAI_API_KEY")),
 		workingSpinner:          spinner.New(spinner.ModeSpinnerOnly, styles.SpinnerDotsHighlightStyle),
 		focusedPanel:            PanelEditor,
-		focused:                 true,
 		editorLines:             3,
 		dockerDesktop:           os.Getenv("TERM_PROGRAM") == "docker_desktop",
 		appName:                 "docker agent",


### PR DESCRIPTION
## Why

When docker-agent runs in a background tab while the agent is streaming, the bubbletea animation tick chain (14 fps spinner + cache invalidations + view rebuilds) keeps firing into a screen nobody is looking at. That's pure CPU waste.

## What

Drop \`animation.TickMsg\` while the terminal is blurred and let the chain die. Re-arm it on the next \`FocusMsg\` via \`animation.StartTick()\` so spinners resume immediately when the user comes back. The existing Docker Desktop release/restore cycle (commit cc2dfcfb) is preserved.

## Why not just \`tea.WithFPS(30)\`?

Static FPS reduction halves the ~60 cheap goroutine wake-ups per second everywhere — well under 1 % CPU savings. This change targets the **expensive** work — full \`Update\` + \`View\` + cache invalidation per spinner tick — exactly when the user can't see it (background tab), and **costs nothing** when they're looking at the terminal (foreground stays at full responsiveness).

## Implementation note

Two flags rather than one:

- \`focused\` — for the spurious-\`FocusMsg\` filter introduced by Docker Desktop's release/restore (must default to \`false\` so the first real \`FocusMsg\` is treated as a transition).
- \`tickPaused\` — for animation gating (must default to \`false\` so ticks flow at startup, before any focus event arrives — some terminals never send one).

They share most transitions but their initial values differ, so keeping them separate avoids cute-but-wrong overloading.