### PR TITLE
refactor(logging): pass context to all slog calls for correlation

### DIFF
--- a/cmd/root/debug.go
+++ b/cmd/root/debug.go
@@ -157,7 +157,7 @@ func (f *debugFlags) runDebugTitleCommand(cmd *cobra.Command, args []string) (co
 		return err
 	}
 
-	model := agent.Model()
+	model := agent.Model(ctx)
 	if model == nil {
 		return fmt.Errorf("agent %q has no model configured", agent.Name())
 	}

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -156,7 +156,7 @@ func (f *runExecFlags) runRunCommand(cmd *cobra.Command, args []string) (command
 }
 
 func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []string, useTUI bool) error {
-	slog.Debug("Starting agent", "agent", f.agentName)
+	slog.DebugContext(ctx, "Starting agent", "agent", f.agentName)
 
 	// Start profiling if requested
 	stopProfiling, err := profiling.Start(f.cpuProfile, f.memProfile)
@@ -165,7 +165,7 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 	}
 	defer func() {
 		if err := stopProfiling(); err != nil {
-			slog.Error("Profiling cleanup failed", "error", err)
+			slog.ErrorContext(ctx, "Profiling cleanup failed", "error", err)
 		}
 	}()
 
@@ -179,17 +179,17 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 	userSettings := userconfig.Get()
 	if userSettings.HideToolResults && !f.hideToolResults {
 		f.hideToolResults = true
-		slog.Debug("Applying user settings", "hide_tool_results", true)
+		slog.DebugContext(ctx, "Applying user settings", "hide_tool_results", true)
 	}
 	if userSettings.YOLO && !f.autoApprove {
 		f.autoApprove = true
-		slog.Debug("Applying user settings", "YOLO", true)
+		slog.DebugContext(ctx, "Applying user settings", "YOLO", true)
 	}
 
 	// Apply alias options if this is an alias reference
 	// Alias options only apply if the flag wasn't explicitly set by the user
 	if alias := config.ResolveAlias(agentFileName); alias != nil {
-		slog.Debug("Applying alias options", "yolo", alias.Yolo, "model", alias.Model, "hide_tool_results", alias.HideToolResults)
+		slog.DebugContext(ctx, "Applying alias options", "yolo", alias.Yolo, "model", alias.Model, "hide_tool_results", alias.HideToolResults)
 		if alias.Yolo && !f.autoApprove {
 			f.autoApprove = true
 		}
@@ -213,7 +213,7 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 	}
 	defer func() {
 		if err := fakeCleanup(); err != nil {
-			slog.Error("Failed to cleanup fake proxy", "error", err)
+			slog.ErrorContext(ctx, "Failed to cleanup fake proxy", "error", err)
 		}
 	}()
 
@@ -225,7 +225,7 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 	if cassettePath != "" {
 		defer func() {
 			if err := recordCleanup(); err != nil {
-				slog.Error("Failed to cleanup recording proxy", "error", err)
+				slog.ErrorContext(ctx, "Failed to cleanup recording proxy", "error", err)
 			}
 		}()
 		out.Println("Recording mode enabled, cassette: " + cassettePath)
@@ -257,7 +257,7 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 	}
 	defer func() {
 		if err := rt.Close(); err != nil {
-			slog.Error("Failed to close runtime", "error", err)
+			slog.ErrorContext(ctx, "Failed to close runtime", "error", err)
 		}
 	}()
 	var initialTeamCleanupOnce sync.Once
@@ -320,7 +320,7 @@ func (f *runExecFlags) createRemoteRuntimeAndSession(ctx context.Context, origin
 		return nil, nil, fmt.Errorf("failed to create remote runtime: %w", err)
 	}
 
-	slog.Debug("Using remote runtime", "address", f.remoteAddress, "agent", f.agentName)
+	slog.DebugContext(ctx, "Using remote runtime", "address", f.remoteAddress, "agent", f.agentName)
 	return remoteRt, sess, nil
 }
 
@@ -390,19 +390,19 @@ func (f *runExecFlags) createLocalRuntimeAndSession(ctx context.Context, loadRes
 			if modelSwitcher, ok := localRt.(runtime.ModelSwitcher); ok {
 				for agentName, modelRef := range sess.AgentModelOverrides {
 					if err := modelSwitcher.SetAgentModel(ctx, agentName, modelRef); err != nil {
-						slog.Warn("Failed to apply stored model override", "agent", agentName, "model", modelRef, "error", err)
+						slog.WarnContext(ctx, "Failed to apply stored model override", "agent", agentName, "model", modelRef, "error", err)
 					}
 				}
 			}
 		}
 
-		slog.Debug("Loaded existing session", "session_id", resolvedID, "session_ref", f.sessionID, "agent", agentName)
+		slog.DebugContext(ctx, "Loaded existing session", "session_id", resolvedID, "session_ref", f.sessionID, "agent", agentName)
 	} else {
 		wd, _ := os.Getwd()
 		sess = session.New(f.buildSessionOpts(agt, wd)...)
 		// Session is stored lazily on first UpdateSession call (when content is added)
 		// This avoids creating empty sessions in the database
-		slog.Debug("Using local runtime", "agent", agentName)
+		slog.DebugContext(ctx, "Using local runtime", "agent", agentName)
 	}
 
 	return localRt, sess, nil

--- a/cmd/root/sandbox.go
+++ b/cmd/root/sandbox.go
@@ -69,7 +69,7 @@ func runInSandbox(ctx context.Context, cmd *cobra.Command, args []string, runCon
 	}
 
 	dockerCmd := backend.BuildExecCmd(ctx, name, wd, dockerAgentArgs, envFlags, envVars)
-	slog.Debug("Executing in sandbox", "name", name, "args", dockerCmd.Args)
+	slog.DebugContext(ctx, "Executing in sandbox", "name", name, "args", dockerCmd.Args)
 
 	if err := dockerCmd.Run(); err != nil {
 		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {

--- a/pkg/a2a/server.go
+++ b/pkg/a2a/server.go
@@ -37,7 +37,7 @@ func routableAddr(addr string) string {
 }
 
 func Run(ctx context.Context, agentFilename, agentName string, runConfig *config.RuntimeConfig, ln net.Listener) error {
-	slog.Debug("Starting A2A server", "source", agentFilename, "agent", agentName, "addr", ln.Addr().String())
+	slog.DebugContext(ctx, "Starting A2A server", "source", agentFilename, "agent", agentName, "addr", ln.Addr().String())
 
 	agentSource, err := config.Resolve(agentFilename, nil)
 	if err != nil {
@@ -50,7 +50,7 @@ func Run(ctx context.Context, agentFilename, agentName string, runConfig *config
 	}
 	defer func() {
 		if err := t.StopToolSets(ctx); err != nil {
-			slog.Error("Failed to stop tool sets", "error", err)
+			slog.ErrorContext(ctx, "Failed to stop tool sets", "error", err)
 		}
 	}()
 
@@ -61,7 +61,7 @@ func Run(ctx context.Context, agentFilename, agentName string, runConfig *config
 
 	baseURL := &url.URL{Scheme: "http", Host: routableAddr(ln.Addr().String())}
 
-	slog.Debug("A2A server listening", "url", baseURL.String())
+	slog.DebugContext(ctx, "A2A server listening", "url", baseURL.String())
 
 	name := strings.TrimSuffix(filepath.Base(agentFilename), filepath.Ext(agentFilename))
 
@@ -108,7 +108,7 @@ func Run(ctx context.Context, agentFilename, agentName string, runConfig *config
 	e.POST(agentPath, echo.WrapHandler(a2asrv.NewJSONRPCHandler(a2asrv.NewHandler(executor))))
 
 	if err := e.Server.Serve(ln); err != nil && ctx.Err() == nil {
-		slog.Error("Failed to start server", "error", err)
+		slog.ErrorContext(ctx, "Failed to start server", "error", err)
 		return err
 	}
 

--- a/pkg/acp/agent.go
+++ b/pkg/acp/agent.go
@@ -64,7 +64,7 @@ func (a *Agent) Stop(ctx context.Context) {
 	defer a.mu.Unlock()
 	if a.team != nil {
 		if err := a.team.StopToolSets(ctx); err != nil {
-			slog.Error("Failed to stop tool sets", "error", err)
+			slog.ErrorContext(ctx, "Failed to stop tool sets", "error", err)
 		}
 	}
 }
@@ -76,7 +76,7 @@ func (a *Agent) SetAgentConnection(conn *acp.AgentSideConnection) {
 
 // Initialize implements [acp.Agent]
 func (a *Agent) Initialize(ctx context.Context, params acp.InitializeRequest) (acp.InitializeResponse, error) {
-	slog.Debug("ACP Initialize called", "client_version", params.ProtocolVersion)
+	slog.DebugContext(ctx, "ACP Initialize called", "client_version", params.ProtocolVersion)
 
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -85,7 +85,7 @@ func (a *Agent) Initialize(ctx context.Context, params acp.InitializeRequest) (a
 		return acp.InitializeResponse{}, fmt.Errorf("failed to load teams: %w", err)
 	}
 	a.team = t
-	slog.Debug("Teams loaded successfully", "source", a.agentSource.Name(), "agent_count", t.Size())
+	slog.DebugContext(ctx, "Teams loaded successfully", "source", a.agentSource.Name(), "agent_count", t.Size())
 
 	agentTitle := "docker agent"
 	return acp.InitializeResponse{
@@ -112,11 +112,11 @@ func (a *Agent) Initialize(ctx context.Context, params acp.InitializeRequest) (a
 
 // NewSession implements [acp.Agent]
 func (a *Agent) NewSession(ctx context.Context, params acp.NewSessionRequest) (acp.NewSessionResponse, error) {
-	slog.Debug("ACP NewSession called", "cwd", params.Cwd)
+	slog.DebugContext(ctx, "ACP NewSession called", "cwd", params.Cwd)
 
 	// Log warning if MCP servers are provided (not yet supported)
 	if len(params.McpServers) > 0 {
-		slog.Warn("MCP servers provided by client are not yet supported", "count", len(params.McpServers))
+		slog.WarnContext(ctx, "MCP servers provided by client are not yet supported", "count", len(params.McpServers))
 	}
 
 	// Validate and normalize working directory
@@ -168,7 +168,7 @@ func (a *Agent) NewSession(ctx context.Context, params acp.NewSessionRequest) (a
 		return acp.NewSessionResponse{}, fmt.Errorf("failed to persist session: %w", err)
 	}
 
-	slog.Debug("ACP session created", "session_id", sess.ID)
+	slog.DebugContext(ctx, "ACP session created", "session_id", sess.ID)
 
 	a.mu.Lock()
 	a.sessions[sess.ID] = &Session{
@@ -251,7 +251,7 @@ func (a *Agent) Cancel(_ context.Context, params acp.CancelNotification) error {
 // Prompt implements [acp.Agent]
 func (a *Agent) Prompt(ctx context.Context, params acp.PromptRequest) (acp.PromptResponse, error) {
 	sid := string(params.SessionId)
-	slog.Debug("ACP Prompt called", "session_id", sid)
+	slog.DebugContext(ctx, "ACP Prompt called", "session_id", sid)
 
 	a.mu.Lock()
 	acpSess, ok := a.sessions[sid]
@@ -311,7 +311,7 @@ func (a *Agent) buildUserContent(ctx context.Context, sessionID string, prompt [
 		case content.ResourceLink != nil:
 			// Try to read the file content via ACP client
 			rl := content.ResourceLink
-			slog.Debug("Processing resource link", "uri", rl.Uri, "name", rl.Name)
+			slog.DebugContext(ctx, "Processing resource link", "uri", rl.Uri, "name", rl.Name)
 
 			// Attempt to read file content if it's a file URI
 			if fileContent := a.readResourceLink(ctx, sessionID, rl); fileContent != "" {
@@ -325,21 +325,21 @@ func (a *Agent) buildUserContent(ctx context.Context, sessionID string, prompt [
 			// Embedded resource - extract content directly
 			res := content.Resource.Resource
 			if res.TextResourceContents != nil {
-				slog.Debug("Processing embedded text resource", "uri", res.TextResourceContents.Uri)
+				slog.DebugContext(ctx, "Processing embedded text resource", "uri", res.TextResourceContents.Uri)
 				parts = append(parts, fmt.Sprintf("\n\n--- Resource: %s ---\n%s\n--- End Resource ---\n",
 					res.TextResourceContents.Uri, res.TextResourceContents.Text))
 			} else if res.BlobResourceContents != nil {
-				slog.Debug("Processing embedded blob resource", "uri", res.BlobResourceContents.Uri)
+				slog.DebugContext(ctx, "Processing embedded blob resource", "uri", res.BlobResourceContents.Uri)
 				parts = append(parts, fmt.Sprintf("\n[Binary resource: %s (type: %s)]\n",
 					res.BlobResourceContents.Uri, stringOrDefault(res.BlobResourceContents.MimeType, "unknown")))
 			}
 
 		case content.Image != nil:
-			slog.Debug("Image content received but not yet fully supported")
+			slog.DebugContext(ctx, "Image content received but not yet fully supported")
 			parts = append(parts, "[Image content provided]")
 
 		case content.Audio != nil:
-			slog.Debug("Audio content received but not yet supported")
+			slog.DebugContext(ctx, "Audio content received but not yet supported")
 			parts = append(parts, "[Audio content provided]")
 		}
 	}
@@ -374,7 +374,7 @@ func (a *Agent) readResourceLink(
 	// Basic hardening: block absolute paths and path traversal
 	// This prevents access outside the intended working directory.
 	if filepath.IsAbs(clean) || strings.HasPrefix(clean, "..") {
-		slog.Warn("Blocked unsafe file resource link", "path", path)
+		slog.WarnContext(ctx, "Blocked unsafe file resource link", "path", path)
 		return ""
 	}
 
@@ -384,7 +384,7 @@ func (a *Agent) readResourceLink(
 		Path:      clean,
 	})
 	if err != nil {
-		slog.Debug("Failed to read resource link", "path", clean, "error", err)
+		slog.DebugContext(ctx, "Failed to read resource link", "path", clean, "error", err)
 		return ""
 	}
 
@@ -407,13 +407,13 @@ func (a *Agent) SetSessionMode(context.Context, acp.SetSessionModeRequest) (acp.
 
 // runAgent runs a single agent loop and streams updates to the ACP client
 func (a *Agent) runAgent(ctx context.Context, acpSess *Session) error {
-	slog.Debug("Running agent turn", "session_id", acpSess.id)
+	slog.DebugContext(ctx, "Running agent turn", "session_id", acpSess.id)
 
 	ctx = withSessionID(ctx, acpSess.id)
 
 	// Emit available commands at start of first turn
 	if err := a.emitAvailableCommands(ctx, acpSess); err != nil {
-		slog.Debug("Failed to emit available commands", "error", err)
+		slog.DebugContext(ctx, "Failed to emit available commands", "error", err)
 		// Don't fail the turn, this is not critical
 	}
 

--- a/pkg/acp/run.go
+++ b/pkg/acp/run.go
@@ -13,7 +13,7 @@ import (
 )
 
 func Run(ctx context.Context, agentFilename string, stdin io.Reader, stdout io.Writer, runConfig *config.RuntimeConfig, sessionDB string) error {
-	slog.Debug("Starting ACP server", "agent", agentFilename, "session_db", sessionDB)
+	slog.DebugContext(ctx, "Starting ACP server", "agent", agentFilename, "session_db", sessionDB)
 
 	agentSource, err := config.Resolve(agentFilename, nil)
 	if err != nil {
@@ -36,7 +36,7 @@ func Run(ctx context.Context, agentFilename string, stdin io.Reader, stdout io.W
 	acpAgent.SetAgentConnection(conn)
 	defer acpAgent.Stop(ctx)
 
-	slog.Debug("acp started, waiting for conn")
+	slog.DebugContext(ctx, "acp started, waiting for conn")
 	select {
 	case <-ctx.Done():
 		return ctx.Err()

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -148,7 +148,11 @@ func (a *Agent) HasSubAgents() bool {
 // Model returns the model to use for this agent.
 // If model override(s) are set, it returns one of the overrides (randomly for alloy).
 // Otherwise, it returns a random model from the available models.
-func (a *Agent) Model() provider.Provider {
+//
+// ctx is used for log correlation only — the selection itself is local.
+// Pass [context.TODO] from callers that don't have a request context
+// (configuration validation, debug commands).
+func (a *Agent) Model(ctx context.Context) provider.Provider {
 	var selected provider.Provider
 	var poolSize int
 	// Check for model override first (set via TUI model switching)
@@ -159,7 +163,7 @@ func (a *Agent) Model() provider.Provider {
 		selected = a.models[rand.Intn(len(a.models))]
 		poolSize = len(a.models)
 	}
-	slog.Info("Model selected", "agent", a.name, "model", selected.ID(), "pool_size", poolSize)
+	slog.InfoContext(ctx, "Model selected", "agent", a.name, "model", selected.ID(), "pool_size", poolSize)
 	return selected
 }
 
@@ -300,7 +304,7 @@ func (a *Agent) collectTools(ctx context.Context) ([]tools.Tool, error) {
 		ta, err := toolSet.Tools(ctx)
 		if err != nil {
 			desc := tools.DescribeToolSet(toolSet)
-			slog.Warn("Toolset listing failed; skipping", "agent", a.Name(), "toolset", desc, "error", err)
+			slog.WarnContext(ctx, "Toolset listing failed; skipping", "agent", a.Name(), "toolset", desc, "error", err)
 			a.AddToolWarning(fmt.Sprintf("%s list failed: %v", desc, err))
 			continue
 		}
@@ -342,10 +346,10 @@ func (a *Agent) ensureToolSetsAreStarted(ctx context.Context) {
 		}
 		desc := tools.DescribeToolSet(toolSet)
 		if toolSet.ShouldReportFailure() {
-			slog.Warn("Toolset start failed; will retry on next turn", "agent", a.Name(), "toolset", desc, "error", err)
+			slog.WarnContext(ctx, "Toolset start failed; will retry on next turn", "agent", a.Name(), "toolset", desc, "error", err)
 			a.AddToolWarning(fmt.Sprintf("%s start failed: %v", desc, err))
 		} else {
-			slog.Debug("Toolset still unavailable; retrying next turn", "agent", a.Name(), "toolset", desc, "error", err)
+			slog.DebugContext(ctx, "Toolset still unavailable; retrying next turn", "agent", a.Name(), "toolset", desc, "error", err)
 		}
 	}
 }

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -145,13 +145,13 @@ func TestModelOverride(t *testing.T) {
 	a := New("root", "test", WithModel(defaultModel))
 
 	// Initially should return the default model
-	assert.Equal(t, "openai/gpt-4o", a.Model().ID())
+	assert.Equal(t, "openai/gpt-4o", a.Model(t.Context()).ID())
 	assert.False(t, a.HasModelOverride())
 
 	// Set an override
 	a.SetModelOverride(overrideModel)
 	assert.True(t, a.HasModelOverride())
-	assert.Equal(t, "anthropic/claude-sonnet-4-0", a.Model().ID())
+	assert.Equal(t, "anthropic/claude-sonnet-4-0", a.Model(t.Context()).ID())
 
 	// ConfiguredModels still reflects the originally configured models
 	configuredModels := a.ConfiguredModels()
@@ -161,7 +161,7 @@ func TestModelOverride(t *testing.T) {
 	// Clear the override
 	a.SetModelOverride(nil)
 	assert.False(t, a.HasModelOverride())
-	assert.Equal(t, "openai/gpt-4o", a.Model().ID())
+	assert.Equal(t, "openai/gpt-4o", a.Model(t.Context()).ID())
 }
 
 func TestSetModelOverride_ReturnsSnapshotOfStoredValue(t *testing.T) {
@@ -187,12 +187,12 @@ func TestSetModelOverride_ReturnsSnapshotOfStoredValue(t *testing.T) {
 	// Simulate a concurrent caller storing a different override _after_ we
 	// stored ours but _before_ a hypothetical post-store SnapshotModelOverride.
 	a.SetModelOverride(othersModel)
-	require.Equal(t, "others", a.Model().ID())
+	require.Equal(t, "others", a.Model(t.Context()).ID())
 
 	// The deferred restore must be a no-op because oursSnap holds the
 	// pointer we stored, not the current pointer.
 	a.RestoreModelOverride(prev, oursSnap)
-	assert.Equal(t, "others", a.Model().ID(),
+	assert.Equal(t, "others", a.Model(t.Context()).ID(),
 		"concurrent override must be preserved; the snapshot returned by SetModelOverride captures the stored pointer")
 }
 
@@ -228,11 +228,11 @@ func TestSnapshotAndRestoreModelOverride(t *testing.T) {
 		prev := a.SnapshotModelOverride()
 		a.SetModelOverride(skillModel)
 		ours := a.SnapshotModelOverride()
-		assert.Equal(t, "openai/gpt-4o-mini", a.Model().ID())
+		assert.Equal(t, "openai/gpt-4o-mini", a.Model(t.Context()).ID())
 
 		a.RestoreModelOverride(prev, ours)
 		assert.False(t, a.HasModelOverride())
-		assert.Equal(t, "openai/gpt-4o", a.Model().ID())
+		assert.Equal(t, "openai/gpt-4o", a.Model(t.Context()).ID())
 	})
 
 	t.Run("restores back to a pre-existing override", func(t *testing.T) {
@@ -243,10 +243,10 @@ func TestSnapshotAndRestoreModelOverride(t *testing.T) {
 		prev := a.SnapshotModelOverride()
 		a.SetModelOverride(skillModel)
 		ours := a.SnapshotModelOverride()
-		assert.Equal(t, "openai/gpt-4o-mini", a.Model().ID())
+		assert.Equal(t, "openai/gpt-4o-mini", a.Model(t.Context()).ID())
 
 		a.RestoreModelOverride(prev, ours)
-		assert.Equal(t, "anthropic/claude-sonnet-4-0", a.Model().ID())
+		assert.Equal(t, "anthropic/claude-sonnet-4-0", a.Model(t.Context()).ID())
 	})
 
 	t.Run("keeps a concurrent change instead of restoring", func(t *testing.T) {
@@ -266,7 +266,7 @@ func TestSnapshotAndRestoreModelOverride(t *testing.T) {
 
 		a.RestoreModelOverride(prev, ours)
 		require.True(t, a.HasModelOverride(), "user's model choice must be preserved")
-		assert.Equal(t, "anthropic/claude-sonnet-4-0", a.Model().ID())
+		assert.Equal(t, "anthropic/claude-sonnet-4-0", a.Model(t.Context()).ID())
 	})
 
 	t.Run("keeps a concurrent clear instead of restoring", func(t *testing.T) {
@@ -303,7 +303,7 @@ func TestModel_LogsSelection(t *testing.T) {
 	a := New("scanner", "test", WithModel(model1), WithModel(model2))
 
 	// Verify basic selection logging
-	selected := a.Model()
+	selected := a.Model(t.Context())
 	logOutput := buf.String()
 
 	assert.Contains(t, logOutput, "Model selected")
@@ -316,7 +316,7 @@ func TestModel_LogsSelection(t *testing.T) {
 	override := &mockProvider{id: "google/gemini-2.0-flash"}
 	a.SetModelOverride(override)
 
-	selected = a.Model()
+	selected = a.Model(t.Context())
 	logOutput = buf.String()
 
 	assert.Equal(t, "google/gemini-2.0-flash", selected.ID())
@@ -347,7 +347,7 @@ func TestModelOverride_ConcurrentAccess(t *testing.T) {
 	// Reader goroutine
 	go func() {
 		for range 100 {
-			_ = a.Model()
+			_ = a.Model(t.Context())
 			_ = a.HasModelOverride()
 		}
 		done <- true

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -325,7 +325,7 @@ func (a *App) Run(ctx context.Context, cancel context.CancelFunc, message string
 					// Inline content attachment (e.g. pasted text).
 					a.processInlineAttachment(att, &textBuilder)
 				default:
-					slog.Debug("skipping attachment with no file path or content", "name", att.Name)
+					slog.DebugContext(ctx, "skipping attachment with no file path or content", "name", att.Name)
 				}
 			}
 
@@ -382,20 +382,20 @@ func (a *App) processFileAttachment(ctx context.Context, att messages.Attachment
 		default:
 			reason = fmt.Sprintf("cannot access file: %v", err)
 		}
-		slog.Warn("skipping attachment", "path", absPath, "reason", reason)
+		slog.WarnContext(ctx, "skipping attachment", "path", absPath, "reason", reason)
 		a.sendEvent(ctx, runtime.Warning(fmt.Sprintf("Skipped attachment %s: %s", att.Name, reason), ""))
 		return false
 	}
 
 	if !fi.Mode().IsRegular() {
-		slog.Warn("skipping attachment: not a regular file", "path", absPath, "mode", fi.Mode().String())
+		slog.WarnContext(ctx, "skipping attachment: not a regular file", "path", absPath, "mode", fi.Mode().String())
 		a.sendEvent(ctx, runtime.Warning(fmt.Sprintf("Skipped attachment %s: not a regular file", att.Name), ""))
 		return false
 	}
 
 	const maxAttachmentSize = 100 * 1024 * 1024 // 100MB
 	if fi.Size() > maxAttachmentSize {
-		slog.Warn("skipping attachment: file too large", "path", absPath, "size", fi.Size(), "max", maxAttachmentSize)
+		slog.WarnContext(ctx, "skipping attachment: file too large", "path", absPath, "size", fi.Size(), "max", maxAttachmentSize)
 		a.sendEvent(ctx, runtime.Warning(fmt.Sprintf("Skipped attachment %s: file too large (max 100MB)", att.Name), ""))
 		return true
 	}
@@ -405,13 +405,13 @@ func (a *App) processFileAttachment(ctx context.Context, att messages.Attachment
 	switch {
 	case chat.IsTextFile(absPath):
 		if fi.Size() > chat.MaxInlineFileSize {
-			slog.Warn("skipping attachment: text file too large to inline", "path", absPath, "size", fi.Size(), "max", chat.MaxInlineFileSize)
+			slog.WarnContext(ctx, "skipping attachment: text file too large to inline", "path", absPath, "size", fi.Size(), "max", chat.MaxInlineFileSize)
 			a.sendEvent(ctx, runtime.Warning(fmt.Sprintf("Skipped attachment %s: text file too large to inline (max 5MB)", att.Name), ""))
 			return true
 		}
 		content, err := chat.ReadFileForInline(absPath)
 		if err != nil {
-			slog.Warn("skipping attachment: failed to read file", "path", absPath, "error", err)
+			slog.WarnContext(ctx, "skipping attachment: failed to read file", "path", absPath, "error", err)
 			a.sendEvent(ctx, runtime.Warning(fmt.Sprintf("Skipped attachment %s: failed to read file", att.Name), ""))
 			return true
 		}
@@ -424,14 +424,14 @@ func (a *App) processFileAttachment(ctx context.Context, att messages.Attachment
 			// This works across all providers (not just Anthropic's File API).
 			imgData, readErr := os.ReadFile(absPath)
 			if readErr != nil {
-				slog.Warn("skipping attachment: failed to read image", "path", absPath, "error", readErr)
+				slog.WarnContext(ctx, "skipping attachment: failed to read image", "path", absPath, "error", readErr)
 				a.sendEvent(ctx, runtime.Warning(fmt.Sprintf("Skipped attachment %s: failed to read image", att.Name), ""))
 				return true
 			}
 			resized, resizeErr := chat.ResizeImage(imgData, mimeType)
 			if resizeErr != nil {
 				// Don't bypass security checks - reject the file if resize failed
-				slog.Warn("skipping attachment: image resize failed", "path", absPath, "error", resizeErr)
+				slog.WarnContext(ctx, "skipping attachment: image resize failed", "path", absPath, "error", resizeErr)
 				a.sendEvent(ctx, runtime.Warning(fmt.Sprintf("Skipped attachment %s: %s", att.Name, resizeErr), ""))
 				return true
 			}
@@ -458,7 +458,7 @@ func (a *App) processFileAttachment(ctx context.Context, att messages.Attachment
 		}
 
 	default:
-		slog.Warn("skipping attachment: unsupported file type", "path", absPath, "mime_type", mimeType)
+		slog.WarnContext(ctx, "skipping attachment: unsupported file type", "path", absPath, "mime_type", mimeType)
 		a.sendEvent(ctx, runtime.Warning(fmt.Sprintf("Skipped attachment %s: unsupported file type", att.Name), ""))
 	}
 
@@ -701,14 +701,14 @@ func (a *App) SetCurrentAgentModel(ctx context.Context, modelRef string) error {
 	if modelRef == "" {
 		// Clear the override - remove from map
 		delete(a.session.AgentModelOverrides, agentName)
-		slog.Debug("Cleared model override from session", "session_id", a.session.ID, "agent", agentName)
+		slog.DebugContext(ctx, "Cleared model override from session", "session_id", a.session.ID, "agent", agentName)
 	} else {
 		// Set the override
 		if a.session.AgentModelOverrides == nil {
 			a.session.AgentModelOverrides = make(map[string]string)
 		}
 		a.session.AgentModelOverrides[agentName] = modelRef
-		slog.Debug("Set model override in session", "session_id", a.session.ID, "agent", agentName, "model", modelRef)
+		slog.DebugContext(ctx, "Set model override in session", "session_id", a.session.ID, "agent", agentName, "model", modelRef)
 
 		// Track custom models (inline provider/model format) in the session
 		if strings.Contains(modelRef, "/") {
@@ -721,7 +721,7 @@ func (a *App) SetCurrentAgentModel(ctx context.Context, modelRef string) error {
 		if err := store.UpdateSession(ctx, a.session); err != nil {
 			return fmt.Errorf("failed to persist model override: %w", err)
 		}
-		slog.Debug("Persisted session with model override", "session_id", a.session.ID, "overrides", a.session.AgentModelOverrides)
+		slog.DebugContext(ctx, "Persisted session with model override", "session_id", a.session.ID, "overrides", a.session.AgentModelOverrides)
 	}
 
 	// Re-emit startup info so the sidebar updates with the new model
@@ -891,25 +891,25 @@ func (a *App) ReplaceSession(ctx context.Context, sess *session.Session) {
 // applySessionModelOverrides applies any stored model overrides from a loaded session.
 func (a *App) applySessionModelOverrides(ctx context.Context, sess *session.Session) {
 	if len(sess.AgentModelOverrides) == 0 {
-		slog.Debug("No model overrides to apply from session", "session_id", sess.ID)
+		slog.DebugContext(ctx, "No model overrides to apply from session", "session_id", sess.ID)
 		return
 	}
 
 	// Check if runtime supports model switching
 	modelSwitcher, ok := a.runtime.(runtime.ModelSwitcher)
 	if !ok {
-		slog.Debug("Runtime does not support model switching, skipping overrides")
+		slog.DebugContext(ctx, "Runtime does not support model switching, skipping overrides")
 		return
 	}
 
-	slog.Debug("Applying model overrides from session", "session_id", sess.ID, "overrides", sess.AgentModelOverrides)
+	slog.DebugContext(ctx, "Applying model overrides from session", "session_id", sess.ID, "overrides", sess.AgentModelOverrides)
 	for agentName, modelRef := range sess.AgentModelOverrides {
 		if err := modelSwitcher.SetAgentModel(ctx, agentName, modelRef); err != nil {
 			// Log but don't fail - the session can still be used with default models
-			slog.Warn("Failed to apply model override from session", "agent", agentName, "model", modelRef, "error", err)
+			slog.WarnContext(ctx, "Failed to apply model override from session", "agent", agentName, "model", modelRef, "error", err)
 			a.events <- runtime.Warning(fmt.Sprintf("Failed to apply model override for agent %q: %v", agentName, err), agentName)
 		} else {
-			slog.Info("Applied model override from session", "agent", agentName, "model", modelRef)
+			slog.InfoContext(ctx, "Applied model override from session", "agent", agentName, "model", modelRef)
 		}
 	}
 }
@@ -1107,7 +1107,7 @@ func (a *App) generateTitle(ctx context.Context, userMessages []string) {
 	defer a.titleGenerating.Store(false)
 
 	if a.titleGen == nil {
-		slog.Debug("No title generator available, skipping title generation")
+		slog.DebugContext(ctx, "No title generator available, skipping title generation")
 		// Emit empty title event so the UI clears any title-generation spinner
 		select {
 		case a.events <- runtime.SessionTitle(a.session.ID, ""):
@@ -1118,7 +1118,7 @@ func (a *App) generateTitle(ctx context.Context, userMessages []string) {
 
 	title, err := a.titleGen.Generate(ctx, a.session.ID, userMessages)
 	if err != nil {
-		slog.Error("Failed to generate session title", "session_id", a.session.ID, "error", err)
+		slog.ErrorContext(ctx, "Failed to generate session title", "session_id", a.session.ID, "error", err)
 		// Emit empty title event so the UI clears any title-generation spinner
 		select {
 		case a.events <- runtime.SessionTitle(a.session.ID, ""):
@@ -1138,7 +1138,7 @@ func (a *App) generateTitle(ctx context.Context, userMessages []string) {
 
 	// Persist the title
 	if err := a.runtime.UpdateSessionTitle(ctx, a.session, title); err != nil {
-		slog.Error("Failed to persist title", "session_id", a.session.ID, "error", err)
+		slog.ErrorContext(ctx, "Failed to persist title", "session_id", a.session.ID, "error", err)
 	}
 
 	// Emit the title event to update the UI
@@ -1178,6 +1178,6 @@ func (a *App) RegenerateSessionTitle(ctx context.Context) error {
 
 	// For remote runtime, title regeneration is not yet supported
 	// (the server would need to implement this)
-	slog.Debug("Title regeneration not available for remote runtime", "session_id", a.session.ID)
+	slog.DebugContext(ctx, "Title regeneration not available for remote runtime", "session_id", a.session.ID)
 	return errors.New("title regeneration not available")
 }

--- a/pkg/chatserver/server.go
+++ b/pkg/chatserver/server.go
@@ -108,7 +108,7 @@ const (
 // once from agentFilename and shared across requests; every chat completion
 // request gets a fresh session.
 func Run(ctx context.Context, agentFilename string, opts Options, ln net.Listener) error {
-	slog.Debug("Starting chat completions server", "agent", agentFilename, "addr", ln.Addr())
+	slog.DebugContext(ctx, "Starting chat completions server", "agent", agentFilename, "addr", ln.Addr())
 
 	t, err := loadTeam(ctx, agentFilename, opts.RunConfig)
 	if err != nil {
@@ -116,7 +116,7 @@ func Run(ctx context.Context, agentFilename string, opts Options, ln net.Listene
 	}
 	defer func() {
 		if err := t.StopToolSets(ctx); err != nil {
-			slog.Error("Failed to stop tool sets", "error", err)
+			slog.ErrorContext(ctx, "Failed to stop tool sets", "error", err)
 		}
 	}()
 

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -226,7 +226,7 @@ func Run(ctx context.Context, out *Printer, cfg Config, rt runtime.Runtime, sess
 			case *runtime.ElicitationRequestEvent:
 				serverURL, ok := e.Meta["cagent/server_url"].(string)
 				if !ok || serverURL == "" {
-					slog.Warn("Skipping elicitation: missing or invalid server_url (non-interactive session?)")
+					slog.WarnContext(ctx, "Skipping elicitation: missing or invalid server_url (non-interactive session?)")
 					_ = rt.ResumeElicitation(ctx, "decline", nil)
 					return nil
 				}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -76,7 +76,7 @@ func CheckRequiredEnvVars(ctx context.Context, cfg *latest.Config, modelsGateway
 	missing, err := gatherMissingEnvVars(ctx, cfg, modelsGateway, env)
 	if err != nil {
 		// If there's a tool preflight error, log it but continue
-		slog.Warn("Failed to preflight toolset environment variables; continuing", "error", err)
+		slog.WarnContext(ctx, "Failed to preflight toolset environment variables; continuing", "error", err)
 	}
 
 	// Return error if there are missing environment variables

--- a/pkg/config/model_alias.go
+++ b/pkg/config/model_alias.go
@@ -23,7 +23,7 @@ func ResolveModelAliases(ctx context.Context, cfg *latest.Config, store *modelsd
 		// Skip alias resolution for models with custom base_url (direct or via provider)
 		// Custom endpoints like Azure Foundry use alias names as deployment names
 		if hasCustomBaseURL(&modelCfg, cfg.Providers) {
-			slog.Debug("Skipping model alias resolution for model with custom base_url",
+			slog.DebugContext(ctx, "Skipping model alias resolution for model with custom base_url",
 				"model_name", name, "provider", modelCfg.Provider, "model", modelCfg.Model)
 			continue
 		}

--- a/pkg/config/sources.go
+++ b/pkg/config/sources.go
@@ -136,7 +136,7 @@ func (a ociSource) Read(ctx context.Context) ([]byte, error) {
 	// the artifact locally, serve it directly without any network call.
 	if remote.IsDigestReference(a.reference) {
 		if data, loadErr := loadArtifact(store, storeKey); loadErr == nil {
-			slog.Debug("Serving digest-pinned OCI artifact from cache", "ref", a.reference)
+			slog.DebugContext(ctx, "Serving digest-pinned OCI artifact from cache", "ref", a.reference)
 			return data, nil
 		}
 	}
@@ -149,7 +149,7 @@ func (a ociSource) Read(ctx context.Context) ([]byte, error) {
 		if !hasLocal {
 			return nil, fmt.Errorf("failed to pull OCI image %s: %w", a.reference, pullErr)
 		}
-		slog.Debug("Failed to check for OCI reference updates, using cached version",
+		slog.DebugContext(ctx, "Failed to check for OCI reference updates, using cached version",
 			"ref", a.reference, "error", pullErr)
 	}
 
@@ -164,7 +164,7 @@ func (a ociSource) Read(ctx context.Context) ([]byte, error) {
 		return nil, fmt.Errorf("failed to load agent from OCI source %s: %w", a.reference, err)
 	}
 
-	slog.Warn("Local OCI store corrupted, forcing re-pull", "ref", a.reference)
+	slog.WarnContext(ctx, "Local OCI store corrupted, forcing re-pull", "ref", a.reference)
 	if _, pullErr := remote.Pull(ctx, a.reference, true); pullErr != nil {
 		return nil, fmt.Errorf("failed to force re-pull OCI image %s: %w", a.reference, pullErr)
 	}
@@ -264,7 +264,7 @@ func (a urlSource) Read(ctx context.Context) ([]byte, error) {
 	if err != nil {
 		// Network error - try to use cached version
 		if cachedData, cacheErr := os.ReadFile(cachePath); cacheErr == nil {
-			slog.Debug("Network error fetching URL, using cached version", "url", a.url, "error", err)
+			slog.DebugContext(ctx, "Network error fetching URL, using cached version", "url", a.url, "error", err)
 			return cachedData, nil
 		}
 		return nil, fmt.Errorf("fetching %s: %w", a.url, err)
@@ -274,7 +274,7 @@ func (a urlSource) Read(ctx context.Context) ([]byte, error) {
 	// 304 Not Modified - return cached content
 	if resp.StatusCode == http.StatusNotModified {
 		if cachedData, cacheErr := os.ReadFile(cachePath); cacheErr == nil {
-			slog.Debug("URL not modified, using cached version", "url", a.url)
+			slog.DebugContext(ctx, "URL not modified, using cached version", "url", a.url)
 			return cachedData, nil
 		}
 		// Cache file missing despite 304, fall through to fetch again
@@ -283,7 +283,7 @@ func (a urlSource) Read(ctx context.Context) ([]byte, error) {
 	if resp.StatusCode != http.StatusOK {
 		// HTTP error - try to use cached version
 		if cachedData, cacheErr := os.ReadFile(cachePath); cacheErr == nil {
-			slog.Debug("HTTP error fetching URL, using cached version", "url", a.url, "status", resp.Status)
+			slog.DebugContext(ctx, "HTTP error fetching URL, using cached version", "url", a.url, "status", resp.Status)
 			return cachedData, nil
 		}
 		return nil, fmt.Errorf("fetching %s: %s", a.url, resp.Status)
@@ -297,13 +297,13 @@ func (a urlSource) Read(ctx context.Context) ([]byte, error) {
 	// Cache the response
 	if err := os.MkdirAll(cacheDir, 0o755); err == nil {
 		if err := os.WriteFile(cachePath, data, 0o644); err != nil {
-			slog.Debug("Failed to cache URL content", "url", a.url, "error", err)
+			slog.DebugContext(ctx, "Failed to cache URL content", "url", a.url, "error", err)
 		}
 
 		// Save ETag if present
 		if etag := resp.Header.Get("ETag"); etag != "" {
 			if err := os.WriteFile(etagPath, []byte(etag), 0o644); err != nil {
-				slog.Debug("Failed to cache ETag", "url", a.url, "error", err)
+				slog.DebugContext(ctx, "Failed to cache ETag", "url", a.url, "error", err)
 			}
 		} else {
 			// Remove stale ETag file if server no longer provides ETag
@@ -350,7 +350,7 @@ func (a urlSource) addGitHubAuth(ctx context.Context, req *http.Request) {
 	}
 
 	req.Header.Set("Authorization", "Bearer "+token)
-	slog.Debug("Added GitHub token authorization to request", "url", a.url)
+	slog.DebugContext(ctx, "Added GitHub token authorization to request", "url", a.url)
 }
 
 // hashURL creates a safe filename from a URL.

--- a/pkg/environment/cmd_provider.go
+++ b/pkg/environment/cmd_provider.go
@@ -21,7 +21,7 @@ func runCommand(ctx context.Context, logLabel, name string, args ...string) (str
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		slog.Debug("Failed to find secret in "+logLabel, "error", err)
+		slog.DebugContext(ctx, "Failed to find secret in "+logLabel, "error", err)
 		return "", false
 	}
 

--- a/pkg/environment/sandbox_tokens.go
+++ b/pkg/environment/sandbox_tokens.go
@@ -141,27 +141,27 @@ func (w *SandboxTokenWriter) Stop() {
 func (w *SandboxTokenWriter) writeOnce(ctx context.Context) {
 	token, ok := w.provider.Get(ctx, DockerDesktopTokenEnv)
 	if !ok {
-		slog.Debug("No DOCKER_TOKEN available to write to sandbox tokens file")
+		slog.DebugContext(ctx, "No DOCKER_TOKEN available to write to sandbox tokens file")
 		return
 	}
 
 	tokens := sandboxTokens{DockerToken: token}
 	data, err := json.Marshal(tokens)
 	if err != nil {
-		slog.Debug("Failed to marshal sandbox tokens", "error", err)
+		slog.DebugContext(ctx, "Failed to marshal sandbox tokens", "error", err)
 		return
 	}
 
 	// Ensure the parent directory exists.
 	if err := os.MkdirAll(filepath.Dir(w.path), 0o700); err != nil {
-		slog.Debug("Failed to create sandbox tokens directory", "path", w.path, "error", err)
+		slog.DebugContext(ctx, "Failed to create sandbox tokens directory", "path", w.path, "error", err)
 		return
 	}
 
 	if err := atomic.WriteFile(w.path, bytes.NewReader(data)); err != nil {
-		slog.Debug("Failed to rename sandbox tokens file", "to", w.path, "error", err)
+		slog.DebugContext(ctx, "Failed to rename sandbox tokens file", "to", w.path, "error", err)
 		return
 	}
 
-	slog.Debug("Wrote sandbox tokens file", "path", w.path)
+	slog.DebugContext(ctx, "Wrote sandbox tokens file", "path", w.path)
 }

--- a/pkg/evaluation/eval.go
+++ b/pkg/evaluation/eval.go
@@ -164,7 +164,7 @@ func (r *Runner) Run(ctx context.Context, ttyOut, out io.Writer, isTTY bool) ([]
 				result, runErr := r.runSingleEval(ctx, item.eval)
 				if runErr != nil {
 					result.Error = runErr.Error()
-					slog.Error("Evaluation failed", "title", item.eval.displayTitle(), "error", runErr)
+					slog.ErrorContext(ctx, "Evaluation failed", "title", item.eval.displayTitle(), "error", runErr)
 				}
 
 				results[item.index] = result
@@ -323,7 +323,7 @@ func (r *Runner) runSingleEval(ctx context.Context, evalSess *InputSession) (Res
 	startTime := time.Now()
 	title := evalSess.displayTitle()
 
-	slog.Debug("Starting evaluation", "title", title)
+	slog.DebugContext(ctx, "Starting evaluation", "title", title)
 
 	var evals *session.EvalCriteria
 	if evalSess.Evals != nil {
@@ -393,7 +393,7 @@ func (r *Runner) runSingleEval(ctx context.Context, evalSess *InputSession) (Res
 		result.RelevanceResults = results
 	}
 
-	slog.Debug("Evaluation complete", "title", title, "duration", time.Since(startTime))
+	slog.DebugContext(ctx, "Evaluation complete", "title", title, "duration", time.Since(startTime))
 	return result, nil
 }
 
@@ -506,19 +506,19 @@ func (r *Runner) runDockerAgentInContainer(ctx context.Context, imageID string, 
 
 		var event map[string]any
 		if err := json.Unmarshal([]byte(line), &event); err != nil {
-			slog.Debug("Failed to parse JSON event", "line", line, "error", err)
+			slog.DebugContext(ctx, "Failed to parse JSON event", "line", line, "error", err)
 			continue
 		}
 		events = append(events, event)
 	}
 
 	if err := scanner.Err(); err != nil {
-		slog.Warn("Error reading container output", "error", err)
+		slog.WarnContext(ctx, "Error reading container output", "error", err)
 	}
 
 	waitErr := cmd.Wait()
 	if waitErr != nil {
-		slog.Debug("Container exited with error", "stderr", string(stderrData), "error", waitErr)
+		slog.DebugContext(ctx, "Container exited with error", "stderr", string(stderrData), "error", waitErr)
 	}
 
 	if len(events) == 0 {

--- a/pkg/evaluation/judge.go
+++ b/pkg/evaluation/judge.go
@@ -202,7 +202,7 @@ func (j *Judge) checkSingle(ctx context.Context, response, criterion string) (pa
 	raw := fullResponse.String()
 	passed, reason, err = parseJudgeResponse(raw)
 	if err != nil {
-		slog.Warn("Failed to parse judge response",
+		slog.WarnContext(ctx, "Failed to parse judge response",
 			"criterion", criterion,
 			"raw_response", raw,
 			"error", err,
@@ -210,7 +210,7 @@ func (j *Judge) checkSingle(ctx context.Context, response, criterion string) (pa
 		return false, "", fmt.Errorf("parsing judge response (length=%d): %w", len(raw), err)
 	}
 
-	slog.Debug("Judge response parsed successfully",
+	slog.DebugContext(ctx, "Judge response parsed successfully",
 		"criterion", criterion,
 		"passed", passed,
 		"reason", reason,

--- a/pkg/gateway/catalog.go
+++ b/pkg/gateway/catalog.go
@@ -83,7 +83,7 @@ func fetchAndCache(ctx context.Context) (Catalog, error) {
 
 	catalog, newETag, err := fetchFromNetwork(ctx, cached.ETag)
 	if err != nil {
-		slog.Debug("Failed to fetch MCP catalog from network, using cache", "error", err)
+		slog.DebugContext(ctx, "Failed to fetch MCP catalog from network, using cache", "error", err)
 		if cached.Catalog != nil {
 			return cached.Catalog, nil
 		}
@@ -92,11 +92,11 @@ func fetchAndCache(ctx context.Context) (Catalog, error) {
 
 	// A nil catalog means 304 Not Modified — the cached copy is still valid.
 	if catalog == nil {
-		slog.Debug("MCP catalog not modified (ETag match)")
+		slog.DebugContext(ctx, "MCP catalog not modified (ETag match)")
 		return cached.Catalog, nil
 	}
 
-	slog.Debug("MCP catalog fetched from network")
+	slog.DebugContext(ctx, "MCP catalog fetched from network")
 	saveToDisk(cacheFile, catalog, newETag)
 
 	return catalog, nil

--- a/pkg/hooks/builtins/add_git_diff.go
+++ b/pkg/hooks/builtins/add_git_diff.go
@@ -37,7 +37,7 @@ func addGitDiff(ctx context.Context, in *hooks.Input, args []string) (*hooks.Out
 
 	out, err := gitOutput(ctx, in.Cwd, gitArgs...)
 	if err != nil {
-		slog.Debug("add_git_diff: git diff failed; skipping", "cwd", in.Cwd, "error", err)
+		slog.DebugContext(ctx, "add_git_diff: git diff failed; skipping", "cwd", in.Cwd, "error", err)
 		return nil, nil
 	}
 	if out == "" {

--- a/pkg/hooks/builtins/add_git_status.go
+++ b/pkg/hooks/builtins/add_git_status.go
@@ -28,7 +28,7 @@ func addGitStatus(ctx context.Context, in *hooks.Input, _ []string) (*hooks.Outp
 	}
 	out, err := gitOutput(ctx, in.Cwd, "status", "--short", "--branch")
 	if err != nil {
-		slog.Debug("add_git_status: git status failed; skipping", "cwd", in.Cwd, "error", err)
+		slog.DebugContext(ctx, "add_git_status: git status failed; skipping", "cwd", in.Cwd, "error", err)
 		return nil, nil
 	}
 	if out == "" {

--- a/pkg/hooks/builtins/add_recent_commits.go
+++ b/pkg/hooks/builtins/add_recent_commits.go
@@ -40,13 +40,13 @@ func addRecentCommits(ctx context.Context, in *hooks.Input, args []string) (*hoo
 		if n, err := strconv.Atoi(args[0]); err == nil && n > 0 {
 			limit = n
 		} else {
-			slog.Debug("add_recent_commits: ignoring invalid limit arg", "arg", args[0], "error", err)
+			slog.DebugContext(ctx, "add_recent_commits: ignoring invalid limit arg", "arg", args[0], "error", err)
 		}
 	}
 
 	out, err := gitOutput(ctx, in.Cwd, "log", "--oneline", "-n", strconv.Itoa(limit))
 	if err != nil {
-		slog.Debug("add_recent_commits: git log failed; skipping", "cwd", in.Cwd, "error", err)
+		slog.DebugContext(ctx, "add_recent_commits: git log failed; skipping", "cwd", in.Cwd, "error", err)
 		return nil, nil
 	}
 	if out == "" {

--- a/pkg/hooks/executor.go
+++ b/pkg/hooks/executor.go
@@ -139,7 +139,7 @@ func (e *Executor) Dispatch(ctx context.Context, event EventType, input *Input) 
 		input.Cwd = e.workingDir
 	}
 
-	slog.Debug("Executing hooks", "event", event, "session_id", input.SessionID, "count", len(hooks))
+	slog.DebugContext(ctx, "Executing hooks", "event", event, "session_id", input.SessionID, "count", len(hooks))
 
 	inputJSON, err := input.ToJSON()
 	if err != nil {

--- a/pkg/js/expand.go
+++ b/pkg/js/expand.go
@@ -79,7 +79,7 @@ func (exp *Expander) Evaluate(ctx context.Context, input string, args []string) 
 	}
 	_ = vm.Set("args", args)
 
-	slog.Debug("Evaluating JS template", "input", input)
+	slog.DebugContext(ctx, "Evaluating JS template", "input", input)
 
 	return runExpansion(vm, input)
 }

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -32,7 +32,7 @@ type ToolOutput struct {
 }
 
 func StartMCPServer(ctx context.Context, agentFilename, agentName string, runConfig *config.RuntimeConfig) error {
-	slog.Debug("Starting MCP server", "agent", agentFilename)
+	slog.DebugContext(ctx, "Starting MCP server", "agent", agentFilename)
 
 	server, cleanup, err := createMCPServer(ctx, agentFilename, agentName, runConfig)
 	if err != nil {
@@ -40,7 +40,7 @@ func StartMCPServer(ctx context.Context, agentFilename, agentName string, runCon
 	}
 	defer cleanup()
 
-	slog.Debug("MCP server starting with stdio transport")
+	slog.DebugContext(ctx, "MCP server starting with stdio transport")
 
 	if err := server.Run(ctx, &mcp.StdioTransport{}); err != nil {
 		return fmt.Errorf("MCP server error: %w", err)
@@ -51,7 +51,7 @@ func StartMCPServer(ctx context.Context, agentFilename, agentName string, runCon
 
 // StartHTTPServer starts a streaming HTTP MCP server on the given listener
 func StartHTTPServer(ctx context.Context, agentFilename, agentName string, runConfig *config.RuntimeConfig, ln net.Listener) error {
-	slog.Debug("Starting HTTP MCP server", "agent", agentFilename, "addr", ln.Addr())
+	slog.DebugContext(ctx, "Starting HTTP MCP server", "agent", agentFilename, "addr", ln.Addr())
 
 	server, cleanup, err := createMCPServer(ctx, agentFilename, agentName, runConfig)
 	if err != nil {
@@ -96,7 +96,7 @@ func createMCPServer(ctx context.Context, agentFilename, agentName string, runCo
 
 	cleanup := func() {
 		if err := t.StopToolSets(ctx); err != nil {
-			slog.Error("Failed to stop tool sets", "error", err)
+			slog.ErrorContext(ctx, "Failed to stop tool sets", "error", err)
 		}
 	}
 
@@ -122,7 +122,7 @@ func createMCPServer(ctx context.Context, agentFilename, agentName string, runCo
 		return nil, nil, errors.New("--tool-name can only be used when exactly one agent is exposed")
 	}
 
-	slog.Debug("Adding MCP tools for agents", "count", len(agentNames))
+	slog.DebugContext(ctx, "Adding MCP tools for agents", "count", len(agentNames))
 
 	for _, agentName := range agentNames {
 		ag, err := t.Agent(agentName)
@@ -133,7 +133,7 @@ func createMCPServer(ctx context.Context, agentFilename, agentName string, runCo
 
 		description := cmp.Or(ag.Description(), fmt.Sprintf("Run the %s agent", agentName))
 
-		slog.Debug("Adding MCP tool", "agent", agentName, "description", description)
+		slog.DebugContext(ctx, "Adding MCP tool", "agent", agentName, "description", description)
 
 		annotations, err := agentToolAnnotations(ctx, ag)
 		if err != nil {
@@ -159,7 +159,7 @@ func createMCPServer(ctx context.Context, agentFilename, agentName string, runCo
 
 func CreateToolHandler(t *team.Team, agentName string) func(context.Context, *mcp.CallToolRequest, ToolInput) (*mcp.CallToolResult, ToolOutput, error) {
 	return func(ctx context.Context, req *mcp.CallToolRequest, input ToolInput) (*mcp.CallToolResult, ToolOutput, error) {
-		slog.Debug("MCP tool called", "agent", agentName, "message", input.Message)
+		slog.DebugContext(ctx, "MCP tool called", "agent", agentName, "message", input.Message)
 
 		ag, err := t.Agent(agentName)
 		if err != nil {
@@ -187,13 +187,13 @@ func CreateToolHandler(t *team.Team, agentName string) func(context.Context, *mc
 
 		_, err = rt.Run(ctx, sess)
 		if err != nil {
-			slog.Error("Agent execution failed", "agent", agentName, "error", err)
+			slog.ErrorContext(ctx, "Agent execution failed", "agent", agentName, "error", err)
 			return nil, ToolOutput{}, fmt.Errorf("agent execution failed: %w", err)
 		}
 
 		result := cmp.Or(sess.GetLastAssistantMessageContent(), "No response from agent")
 
-		slog.Debug("Agent execution completed", "agent", agentName, "response_length", len(result))
+		slog.DebugContext(ctx, "Agent execution completed", "agent", agentName, "response_length", len(result))
 
 		return nil, ToolOutput{Response: result}, nil
 	}

--- a/pkg/model/provider/anthropic/beta_client.go
+++ b/pkg/model/provider/anthropic/beta_client.go
@@ -38,13 +38,13 @@ func (c *Client) createBetaStream(
 
 	allTools, err := convertBetaTools(requestTools)
 	if err != nil {
-		slog.Error("Failed to convert tools for Anthropic Beta request", "error", err)
+		slog.ErrorContext(ctx, "Failed to convert tools for Anthropic Beta request", "error", err)
 		return nil, err
 	}
 
 	converted, err := c.convertBetaMessages(ctx, messages)
 	if err != nil {
-		slog.Error("Failed to convert messages for Anthropic Beta request", "error", err)
+		slog.ErrorContext(ctx, "Failed to convert messages for Anthropic Beta request", "error", err)
 		return nil, err
 	}
 	if len(converted) == 0 {
@@ -62,7 +62,7 @@ func (c *Client) createBetaStream(
 	}
 	if needsFilesAPI {
 		betas = append(betas, filesAPIBeta)
-		slog.Debug("Anthropic Beta API: Including files-api beta header for file attachments")
+		slog.DebugContext(ctx, "Anthropic Beta API: Including files-api beta header for file attachments")
 	}
 
 	params := anthropic.BetaMessageNewParams{
@@ -76,7 +76,7 @@ func (c *Client) createBetaStream(
 
 	// Apply structured output configuration
 	if structuredOutput := c.ModelOptions.StructuredOutput(); structuredOutput != nil {
-		slog.Debug("Anthropic Beta API using structured output", "name", structuredOutput.Name)
+		slog.DebugContext(ctx, "Anthropic Beta API using structured output", "name", structuredOutput.Name)
 
 		// Add structured outputs beta header
 		params.Betas = append(params.Betas, "structured-outputs-2025-11-13")
@@ -98,10 +98,10 @@ func (c *Client) createBetaStream(
 	configureTaskBudget(&params, c.ModelConfig.TaskBudget)
 
 	if len(requestTools) > 0 {
-		slog.Debug("Anthropic Beta API: Adding tools to request", "tool_count", len(requestTools))
+		slog.DebugContext(ctx, "Anthropic Beta API: Adding tools to request", "tool_count", len(requestTools))
 	}
 
-	slog.Debug("Anthropic Beta API chat completion stream request",
+	slog.DebugContext(ctx, "Anthropic Beta API chat completion stream request",
 		"model", params.Model,
 		"max_tokens", maxTokens,
 		"message_count", len(params.Messages))
@@ -109,7 +109,7 @@ func (c *Client) createBetaStream(
 	// Forward top_k from provider_opts (Anthropic natively supports it)
 	if topK, ok := providerutil.GetProviderOptInt64(c.ModelConfig.ProviderOpts, "top_k"); ok {
 		params.TopK = param.NewOpt(topK)
-		slog.Debug("Anthropic Beta provider_opts: set top_k", "value", topK)
+		slog.DebugContext(ctx, "Anthropic Beta provider_opts: set top_k", "value", topK)
 	}
 
 	stream := client.Beta.Messages.NewStreaming(ctx, params)
@@ -120,21 +120,21 @@ func (c *Client) createBetaStream(
 	ad.retryFn = func() *ssestream.Stream[anthropic.BetaRawMessageStreamEventUnion] {
 		used, err := countAnthropicTokensBeta(ctx, client, c.ModelConfig.Model, converted, sys, allTools)
 		if err != nil {
-			slog.Warn("Failed to count tokens for retry, skipping", "error", err)
+			slog.WarnContext(ctx, "Failed to count tokens for retry, skipping", "error", err)
 			return nil
 		}
 		newMaxTokens := clampMaxTokens(anthropicContextLimit(c.ModelConfig.Model), used, maxTokens)
 		if newMaxTokens >= maxTokens {
-			slog.Warn("Token count does not require clamping, not retrying")
+			slog.WarnContext(ctx, "Token count does not require clamping, not retrying")
 			return nil
 		}
-		slog.Warn("Retrying with clamped max_tokens after context length error", "original", maxTokens, "clamped", newMaxTokens, "used", used)
+		slog.WarnContext(ctx, "Retrying with clamped max_tokens after context length error", "original", maxTokens, "clamped", newMaxTokens, "used", used)
 		retryParams := params
 		retryParams.MaxTokens = newMaxTokens
 		return client.Beta.Messages.NewStreaming(ctx, retryParams)
 	}
 
-	slog.Debug("Anthropic Beta API chat completion stream created successfully", "model", c.ModelConfig.Model)
+	slog.DebugContext(ctx, "Anthropic Beta API chat completion stream created successfully", "model", c.ModelConfig.Model)
 	return ad, nil
 }
 
@@ -183,11 +183,11 @@ func (c *Client) Rerank(ctx context.Context, query string, documents []types.Doc
 	const logPrefix = "Anthropic reranking request"
 
 	if len(documents) == 0 {
-		slog.Debug(logPrefix, "model", c.ModelConfig.Model, "num_documents", 0)
+		slog.DebugContext(ctx, logPrefix, "model", c.ModelConfig.Model, "num_documents", 0)
 		return []float64{}, nil
 	}
 
-	slog.Debug(logPrefix,
+	slog.DebugContext(ctx, logPrefix,
 		"model", c.ModelConfig.Model,
 		"query_length", len(query),
 		"num_documents", len(documents),
@@ -195,7 +195,7 @@ func (c *Client) Rerank(ctx context.Context, query string, documents []types.Doc
 
 	client, err := c.clientFn(ctx)
 	if err != nil {
-		slog.Error("Failed to create Anthropic client for reranking", "error", err)
+		slog.ErrorContext(ctx, "Failed to create Anthropic client for reranking", "error", err)
 		return nil, err
 	}
 
@@ -264,7 +264,7 @@ func (c *Client) Rerank(ctx context.Context, query string, documents []types.Doc
 	// Forward top_k from provider_opts (Anthropic natively supports it)
 	if topK, ok := providerutil.GetProviderOptInt64(c.ModelConfig.ProviderOpts, "top_k"); ok {
 		params.TopK = param.NewOpt(topK)
-		slog.Debug("Anthropic Beta provider_opts: set top_k", "value", topK)
+		slog.DebugContext(ctx, "Anthropic Beta provider_opts: set top_k", "value", topK)
 	}
 
 	// Use streaming API to avoid timeout errors for operations that may take longer than 10 minutes
@@ -273,23 +273,23 @@ func (c *Client) Rerank(ctx context.Context, query string, documents []types.Doc
 	// Accumulate the full response from the stream
 	resp, err := accumulateBetaStreamResponse(stream)
 	if err != nil {
-		slog.Error("Anthropic rerank streaming request failed", "error", err)
+		slog.ErrorContext(ctx, "Anthropic rerank streaming request failed", "error", err)
 		return nil, fmt.Errorf("anthropic rerank request failed: %w", err)
 	}
 
 	rawJSON, err := extractAnthropicStructuredOutputJSON(resp)
 	if err != nil {
-		slog.Error("Failed to extract Anthropic structured output JSON", "error", err)
+		slog.ErrorContext(ctx, "Failed to extract Anthropic structured output JSON", "error", err)
 		return nil, err
 	}
 
 	scores, err := parseRerankScoresAnthropic(rawJSON, len(documents))
 	if err != nil {
-		slog.Error("Failed to parse Anthropic rerank scores", "error", err)
+		slog.ErrorContext(ctx, "Failed to parse Anthropic rerank scores", "error", err)
 		return nil, err
 	}
 
-	slog.Debug("Anthropic reranking complete",
+	slog.DebugContext(ctx, "Anthropic reranking complete",
 		"model", c.ModelConfig.Model,
 		"num_scores", len(scores))
 

--- a/pkg/model/provider/anthropic/client.go
+++ b/pkg/model/provider/anthropic/client.go
@@ -37,17 +37,17 @@ type Client struct {
 // NewClient creates a new Anthropic client from the provided configuration
 func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Provider, opts ...options.Opt) (*Client, error) {
 	if cfg == nil {
-		slog.Error("Anthropic client creation failed", "error", "model configuration is required")
+		slog.ErrorContext(ctx, "Anthropic client creation failed", "error", "model configuration is required")
 		return nil, errors.New("model configuration is required")
 	}
 
 	if cfg.Provider != "anthropic" {
-		slog.Error("Anthropic client creation failed", "error", "model type must be 'anthropic'", "actual_type", cfg.Provider)
+		slog.ErrorContext(ctx, "Anthropic client creation failed", "error", "model type must be 'anthropic'", "actual_type", cfg.Provider)
 		return nil, errors.New("model type must be 'anthropic'")
 	}
 
 	if env == nil {
-		slog.Error("Anthropic client creation failed", "error", "environment provider is required")
+		slog.ErrorContext(ctx, "Anthropic client creation failed", "error", "environment provider is required")
 		return nil, errors.New("environment provider is required")
 	}
 
@@ -72,7 +72,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 			return nil, errors.New("ANTHROPIC_API_KEY environment variable is required")
 		}
 
-		slog.Debug("Anthropic API key found, creating client")
+		slog.DebugContext(ctx, "Anthropic API key found, creating client")
 		requestOptions := []option.RequestOption{
 			option.WithAPIKey(authToken),
 			option.WithHTTPClient(httpclient.NewHTTPClient(ctx)),
@@ -87,7 +87,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 	} else {
 		// Fail fast if Docker Desktop's auth token isn't available
 		if token, _ := env.Get(ctx, environment.DockerDesktopTokenEnv); token == "" {
-			slog.Error("Anthropic client creation failed", "error", "failed to get Docker Desktop's authentication token")
+			slog.ErrorContext(ctx, "Anthropic client creation failed", "error", "failed to get Docker Desktop's authentication token")
 			return nil, errors.New("sorry, you first need to sign in Docker Desktop to use the Docker AI Gateway")
 		}
 
@@ -128,7 +128,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 		}
 	}
 
-	slog.Debug("Anthropic client created successfully", "model", cfg.Model)
+	slog.DebugContext(ctx, "Anthropic client created successfully", "model", cfg.Model)
 
 	// Initialize FileManager for file uploads
 	anthropicClient.fileManager = NewFileManager(anthropicClient.clientFn)
@@ -155,7 +155,7 @@ func (c *Client) CreateChatCompletionStream(
 	messages []chat.Message,
 	requestTools []tools.Tool,
 ) (chat.MessageStream, error) {
-	slog.Debug("Creating Anthropic chat completion stream",
+	slog.DebugContext(ctx, "Creating Anthropic chat completion stream",
 		"model", c.ModelConfig.Model,
 		"message_count", len(messages),
 		"tool_count", len(requestTools))
@@ -173,7 +173,7 @@ func (c *Client) CreateChatCompletionStream(
 
 	client, err := c.clientFn(ctx)
 	if err != nil {
-		slog.Error("Failed to create Anthropic client", "error", err)
+		slog.ErrorContext(ctx, "Failed to create Anthropic client", "error", err)
 		return nil, err
 	}
 
@@ -191,13 +191,13 @@ func (c *Client) CreateChatCompletionStream(
 
 	allTools, err := convertTools(requestTools)
 	if err != nil {
-		slog.Error("Failed to convert tools for Anthropic request", "error", err)
+		slog.ErrorContext(ctx, "Failed to convert tools for Anthropic request", "error", err)
 		return nil, err
 	}
 
 	converted, err := c.convertMessages(ctx, messages)
 	if err != nil {
-		slog.Error("Failed to convert messages for Anthropic request", "error", err)
+		slog.ErrorContext(ctx, "Failed to convert messages for Anthropic request", "error", err)
 		return nil, err
 	}
 	if len(converted) == 0 {
@@ -226,21 +226,21 @@ func (c *Client) CreateChatCompletionStream(
 			params.TopP = param.NewOpt(*c.ModelConfig.TopP)
 		}
 	} else if c.ModelConfig.Temperature != nil || c.ModelConfig.TopP != nil {
-		slog.Debug("Anthropic extended thinking enabled, ignoring temperature/top_p settings")
+		slog.DebugContext(ctx, "Anthropic extended thinking enabled, ignoring temperature/top_p settings")
 	}
 
 	// Forward top_k from provider_opts (Anthropic natively supports it)
 	if topK, ok := providerutil.GetProviderOptInt64(c.ModelConfig.ProviderOpts, "top_k"); ok {
 		params.TopK = param.NewOpt(topK)
-		slog.Debug("Anthropic provider_opts: set top_k", "value", topK)
+		slog.DebugContext(ctx, "Anthropic provider_opts: set top_k", "value", topK)
 	}
 
 	if len(requestTools) > 0 {
-		slog.Debug("Adding tools to Anthropic request", "tool_count", len(requestTools))
+		slog.DebugContext(ctx, "Adding tools to Anthropic request", "tool_count", len(requestTools))
 	}
 
 	// Log the request details for debugging
-	slog.Debug("Anthropic chat completion stream request",
+	slog.DebugContext(ctx, "Anthropic chat completion stream request",
 		"model", params.Model,
 		"max_tokens", maxTokens,
 		"message_count", len(params.Messages))
@@ -248,9 +248,9 @@ func (c *Client) CreateChatCompletionStream(
 	if slog.Default().Enabled(ctx, slog.LevelDebug) {
 		b, err := json.Marshal(params)
 		if err != nil {
-			slog.Error("Failed to marshal Anthropic request", "error", err)
+			slog.ErrorContext(ctx, "Failed to marshal Anthropic request", "error", err)
 		}
-		slog.Debug("Request", "request", string(b))
+		slog.DebugContext(ctx, "Request", "request", string(b))
 	}
 
 	// Add fine-grained tool streaming beta header
@@ -264,21 +264,21 @@ func (c *Client) CreateChatCompletionStream(
 	ad.retryFn = func() *ssestream.Stream[anthropic.MessageStreamEventUnion] {
 		used, err := countAnthropicTokens(ctx, client, c.ModelConfig.Model, converted, sys, allTools)
 		if err != nil {
-			slog.Warn("Failed to count tokens for retry, skipping", "error", err)
+			slog.WarnContext(ctx, "Failed to count tokens for retry, skipping", "error", err)
 			return nil
 		}
 		newMaxTokens := clampMaxTokens(anthropicContextLimit(c.ModelConfig.Model), used, maxTokens)
 		if newMaxTokens >= maxTokens {
-			slog.Warn("Token count does not require clamping, not retrying")
+			slog.WarnContext(ctx, "Token count does not require clamping, not retrying")
 			return nil
 		}
-		slog.Warn("Retrying with clamped max_tokens after context length error", "original max_tokens", maxTokens, "clamped max_tokens", newMaxTokens, "used tokens", used)
+		slog.WarnContext(ctx, "Retrying with clamped max_tokens after context length error", "original max_tokens", maxTokens, "clamped max_tokens", newMaxTokens, "used tokens", used)
 		retryParams := params
 		retryParams.MaxTokens = newMaxTokens
 		return client.Messages.NewStreaming(ctx, retryParams, betaHeader)
 	}
 
-	slog.Debug("Anthropic chat completion stream created successfully", "model", c.ModelConfig.Model)
+	slog.DebugContext(ctx, "Anthropic chat completion stream created successfully", "model", c.ModelConfig.Model)
 	return ad, nil
 }
 

--- a/pkg/model/provider/anthropic/files.go
+++ b/pkg/model/provider/anthropic/files.go
@@ -211,7 +211,7 @@ func (fm *FileManager) upload(ctx context.Context, filePath, contentHash, mimeTy
 
 	filename := filepath.Base(filePath)
 
-	slog.Debug("Uploading file to Anthropic Files API",
+	slog.DebugContext(ctx, "Uploading file to Anthropic Files API",
 		"filename", filename,
 		"mime_type", mimeType,
 		"size", fileSize)
@@ -237,7 +237,7 @@ func (fm *FileManager) upload(ctx context.Context, filePath, contentHash, mimeTy
 		ContentHash: contentHash,
 	}
 
-	slog.Info("File uploaded to Anthropic",
+	slog.InfoContext(ctx, "File uploaded to Anthropic",
 		"file_id", upload.FileID,
 		"filename", upload.Filename,
 		"size", upload.SizeBytes)
@@ -261,7 +261,7 @@ func (fm *FileManager) Delete(ctx context.Context, fileID string) error {
 		return fmt.Errorf("failed to delete file: %w", err)
 	}
 
-	slog.Debug("Deleted file from Anthropic", "file_id", fileID)
+	slog.DebugContext(ctx, "Deleted file from Anthropic", "file_id", fileID)
 	return nil
 }
 
@@ -283,7 +283,7 @@ func (fm *FileManager) Cleanup(ctx context.Context, ttl time.Duration) error {
 	for key, upload := range fm.uploads {
 		if upload.UploadedAt.Before(cutoff) {
 			if err := fm.deleteUnlocked(ctx, upload.FileID); err != nil {
-				slog.Warn("Failed to delete expired file", "file_id", upload.FileID, "error", err)
+				slog.WarnContext(ctx, "Failed to delete expired file", "file_id", upload.FileID, "error", err)
 				errs = append(errs, err)
 				continue
 			}
@@ -325,7 +325,7 @@ func (fm *FileManager) CleanupAll(ctx context.Context) error {
 
 	for key, upload := range fm.uploads {
 		if err := fm.deleteUnlocked(ctx, upload.FileID); err != nil {
-			slog.Warn("Failed to delete file during cleanup", "file_id", upload.FileID, "error", err)
+			slog.WarnContext(ctx, "Failed to delete file during cleanup", "file_id", upload.FileID, "error", err)
 			errs = append(errs, err)
 			continue
 		}

--- a/pkg/model/provider/anthropic/vertex.go
+++ b/pkg/model/provider/anthropic/vertex.go
@@ -58,7 +58,7 @@ func NewVertexClient(ctx context.Context, cfg *latest.ModelConfig, env environme
 		return nil, fmt.Errorf("failed to obtain GCP credentials for Vertex AI: %w (run 'gcloud auth application-default login')", err)
 	}
 
-	slog.Debug("Creating Anthropic client for Vertex AI",
+	slog.DebugContext(ctx, "Creating Anthropic client for Vertex AI",
 		"project", project,
 		"location", location,
 		"model", cfg.Model,
@@ -96,6 +96,6 @@ func NewVertexClient(ctx context.Context, cfg *latest.ModelConfig, env environme
 	// but the FileManager is lazy and harmless if unused.
 	anthropicClient.fileManager = NewFileManager(anthropicClient.clientFn)
 
-	slog.Debug("Anthropic (Vertex AI) client created successfully", "model", cfg.Model)
+	slog.DebugContext(ctx, "Anthropic (Vertex AI) client created successfully", "model", cfg.Model)
 	return anthropicClient, nil
 }

--- a/pkg/model/provider/bedrock/client.go
+++ b/pkg/model/provider/bedrock/client.go
@@ -46,12 +46,12 @@ func (t *bearerTokenTransport) RoundTrip(req *http.Request) (*http.Response, err
 
 func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Provider, opts ...options.Opt) (*Client, error) {
 	if cfg == nil {
-		slog.Error("Bedrock client creation failed", "error", "model configuration is required")
+		slog.ErrorContext(ctx, "Bedrock client creation failed", "error", "model configuration is required")
 		return nil, errors.New("model configuration is required")
 	}
 
 	if cfg.Provider != "amazon-bedrock" {
-		slog.Error("Bedrock client creation failed", "error", "model type must be 'amazon-bedrock'", "actual_type", cfg.Provider)
+		slog.ErrorContext(ctx, "Bedrock client creation failed", "error", "model type must be 'amazon-bedrock'", "actual_type", cfg.Provider)
 		return nil, errors.New("model type must be 'amazon-bedrock'")
 	}
 
@@ -70,7 +70,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 	if cfg.TokenKey != "" {
 		bearerToken, _ = env.Get(ctx, cfg.TokenKey)
 		if bearerToken == "" {
-			slog.Debug("Bedrock token_key configured but env var is empty, falling back to AWS credential chain",
+			slog.DebugContext(ctx, "Bedrock token_key configured but env var is empty, falling back to AWS credential chain",
 				"token_key", cfg.TokenKey)
 		}
 	} else {
@@ -80,7 +80,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 	// Build AWS config using default credential chain
 	awsCfg, err := buildAWSConfig(ctx, cfg, env)
 	if err != nil {
-		slog.Error("Failed to build AWS config", "error", err)
+		slog.ErrorContext(ctx, "Failed to build AWS config", "error", err)
 		return nil, fmt.Errorf("failed to build AWS config: %w", err)
 	}
 
@@ -96,7 +96,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 
 	// If bearer token is set, use it instead of SigV4
 	if bearerToken != "" {
-		slog.Debug("Bedrock using bearer token authentication")
+		slog.DebugContext(ctx, "Bedrock using bearer token authentication")
 		clientOpts = append(clientOpts, func(o *bedrockruntime.Options) {
 			// Use anonymous credentials to skip SigV4 signing
 			o.Credentials = aws.AnonymousCredentials{}
@@ -116,7 +116,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 	// Uses models.dev cache pricing as proxy for capability detection.
 	cachingSupported := detectCachingSupport(ctx, cfg.Model)
 
-	slog.Debug("Bedrock client created successfully",
+	slog.DebugContext(ctx, "Bedrock client created successfully",
 		"model", cfg.Model,
 		"region", awsCfg.Region,
 		"caching_supported", cachingSupported)
@@ -138,14 +138,14 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 func detectCachingSupport(ctx context.Context, model string) bool {
 	store, err := modelsdev.NewStore()
 	if err != nil {
-		slog.Debug("Bedrock models store unavailable, prompt caching disabled", "error", err)
+		slog.DebugContext(ctx, "Bedrock models store unavailable, prompt caching disabled", "error", err)
 		return false
 	}
 
 	modelID := "amazon-bedrock/" + model
 	m, err := store.GetModel(ctx, modelID)
 	if err != nil {
-		slog.Debug("Bedrock prompt caching disabled: model not found in models.dev",
+		slog.DebugContext(ctx, "Bedrock prompt caching disabled: model not found in models.dev",
 			"model_id", modelID, "error", err)
 		return false
 	}
@@ -194,7 +194,7 @@ func buildAWSConfig(ctx context.Context, cfg *latest.ModelConfig, env environmen
 			}
 		})
 		awsCfg.Credentials = aws.NewCredentialsCache(creds)
-		slog.Debug("Bedrock using assumed role", "role_arn", roleARN)
+		slog.DebugContext(ctx, "Bedrock using assumed role", "role_arn", roleARN)
 	}
 
 	return awsCfg, nil
@@ -205,7 +205,7 @@ func (c *Client) CreateChatCompletionStream(
 	messages []chat.Message,
 	requestTools []tools.Tool,
 ) (chat.MessageStream, error) {
-	slog.Debug("Creating Bedrock chat completion stream",
+	slog.DebugContext(ctx, "Creating Bedrock chat completion stream",
 		"model", c.ModelConfig.Model,
 		"message_count", len(messages),
 		"tool_count", len(requestTools))
@@ -220,7 +220,7 @@ func (c *Client) CreateChatCompletionStream(
 	// Call ConverseStream
 	output, err := c.bedrockClient.ConverseStream(ctx, input)
 	if err != nil {
-		slog.Error("Bedrock ConverseStream failed", "error", err)
+		slog.ErrorContext(ctx, "Bedrock ConverseStream failed", "error", err)
 		return nil, wrapBedrockError(fmt.Errorf("bedrock converse stream failed: %w", err))
 	}
 

--- a/pkg/model/provider/clone.go
+++ b/pkg/model/provider/clone.go
@@ -20,7 +20,7 @@ func CloneWithOptions(ctx context.Context, baseProvider Provider, opts ...option
 	// cfg.Models is populated by routers; for other providers it's nil (which is fine).
 	clone, err := NewWithModels(ctx, &modelConfig, cfg.Models, cfg.Env, mergedOpts...)
 	if err != nil {
-		slog.Debug("Failed to clone provider; using base provider", "error", err, "id", baseProvider.ID())
+		slog.DebugContext(ctx, "Failed to clone provider; using base provider", "error", err, "id", baseProvider.ID())
 		return baseProvider
 	}
 

--- a/pkg/model/provider/dmr/client.go
+++ b/pkg/model/provider/dmr/client.go
@@ -61,12 +61,12 @@ type Client struct {
 // NewClient creates a new DMR client from the provided configuration
 func NewClient(ctx context.Context, cfg *latest.ModelConfig, opts ...options.Opt) (*Client, error) {
 	if cfg == nil {
-		slog.Error("DMR client creation failed", "error", "model configuration is required")
+		slog.ErrorContext(ctx, "DMR client creation failed", "error", "model configuration is required")
 		return nil, errors.New("model configuration is required")
 	}
 
 	if cfg.Provider != "dmr" {
-		slog.Error("DMR client creation failed", "error", "model type must be 'dmr'", "actual_type", cfg.Provider)
+		slog.ErrorContext(ctx, "DMR client creation failed", "error", "model type must be 'dmr'", "actual_type", cfg.Provider)
 		return nil, errors.New("model type must be 'dmr'")
 	}
 
@@ -83,14 +83,14 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, opts ...options.Opt
 		endpoint, engine, err = getDockerModelEndpointAndEngine(ctx)
 		if err != nil {
 			if err.Error() == "unknown flag: --json\n\nUsage:  docker [OPTIONS] COMMAND [ARG...]\n\nRun 'docker --help' for more information" {
-				slog.Debug("docker model status query failed", "error", err)
+				slog.DebugContext(ctx, "docker model status query failed", "error", err)
 				return nil, ErrNotInstalled
 			}
-			slog.Error("docker model status query failed", "error", err)
+			slog.ErrorContext(ctx, "docker model status query failed", "error", err)
 		} else {
 			// Auto-pull the model if needed
 			if err := pullDockerModelIfNeeded(ctx, cfg.Model); err != nil {
-				slog.Debug("docker model pull failed", "error", err)
+				slog.DebugContext(ctx, "docker model pull failed", "error", err)
 				return nil, err
 			}
 		}
@@ -107,11 +107,11 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, opts ...options.Opt
 
 	parsed, err := parseDMRProviderOpts(engine, cfg)
 	if err != nil {
-		slog.Error("DMR provider_opts invalid", "error", err, "model", cfg.Model)
+		slog.ErrorContext(ctx, "DMR provider_opts invalid", "error", err, "model", cfg.Model)
 		return nil, err
 	}
 	backendCfg := buildConfigureBackendConfig(parsed.contextSize, parsed.runtimeFlags, parsed.specOpts, parsed.llamaCpp, parsed.vllm, parsed.keepAlive)
-	slog.Debug("DMR provider_opts parsed",
+	slog.DebugContext(ctx, "DMR provider_opts parsed",
 		"model", cfg.Model,
 		"engine", engine,
 		"context_size", derefInt64(parsed.contextSize),
@@ -127,11 +127,11 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, opts ...options.Opt
 	// with different settings (e.g., smaller max_tokens) that would affect the main agent.
 	if !globalOptions.GeneratingTitle() {
 		if err := configureModel(ctx, httpClient, baseURL, cfg.Model, backendCfg, parsed.mode, parsed.rawRuntimeFlags); err != nil {
-			slog.Debug("model configure via API skipped or failed", "error", err)
+			slog.DebugContext(ctx, "model configure via API skipped or failed", "error", err)
 		}
 	}
 
-	slog.Debug("DMR client created successfully", "model", cfg.Model, "base_url", baseURL)
+	slog.DebugContext(ctx, "DMR client created successfully", "model", cfg.Model, "base_url", baseURL)
 
 	return &Client{
 		Config: base.Config{
@@ -155,7 +155,7 @@ func convertMessages(messages []chat.Message) []openai.ChatCompletionMessagePara
 // CreateChatCompletionStream creates a streaming chat completion request
 // It returns a stream that can be iterated over to get completion chunks
 func (c *Client) CreateChatCompletionStream(ctx context.Context, messages []chat.Message, requestTools []tools.Tool) (chat.MessageStream, error) {
-	slog.Debug("Creating DMR chat completion stream",
+	slog.DebugContext(ctx, "Creating DMR chat completion stream",
 		"model", c.ModelConfig.Model,
 		"message_count", len(messages),
 		"tool_count", len(requestTools),
@@ -163,7 +163,7 @@ func (c *Client) CreateChatCompletionStream(ctx context.Context, messages []chat
 	)
 
 	if len(messages) == 0 {
-		slog.Error("DMR stream creation failed", "error", "at least one message is required")
+		slog.ErrorContext(ctx, "DMR stream creation failed", "error", "at least one message is required")
 		return nil, errors.New("at least one message is required")
 	}
 
@@ -192,22 +192,22 @@ func (c *Client) CreateChatCompletionStream(ctx context.Context, messages []chat
 
 	if c.ModelConfig.MaxTokens != nil {
 		params.MaxTokens = openai.Int(*c.ModelConfig.MaxTokens)
-		slog.Debug("DMR request configured with max tokens", "max_tokens", *c.ModelConfig.MaxTokens)
+		slog.DebugContext(ctx, "DMR request configured with max tokens", "max_tokens", *c.ModelConfig.MaxTokens)
 	}
 
 	if len(requestTools) > 0 {
-		slog.Debug("Adding tools to DMR request", "tool_count", len(requestTools))
+		slog.DebugContext(ctx, "Adding tools to DMR request", "tool_count", len(requestTools))
 		toolsParam := make([]openai.ChatCompletionToolUnionParam, len(requestTools))
 		for i, tool := range requestTools {
 			parameters, err := ConvertParametersToSchema(tool.Parameters)
 			if err != nil {
-				slog.Error("Failed to convert tool parameters to DMR schema", "error", err, "tool", tool.Name)
+				slog.ErrorContext(ctx, "Failed to convert tool parameters to DMR schema", "error", err, "tool", tool.Name)
 				return nil, fmt.Errorf("failed to convert tool parameters to DMR schema for tool %s: %w", tool.Name, err)
 			}
 
 			paramsMap, ok := parameters.(map[string]any)
 			if !ok {
-				slog.Error("Converted parameters is not a map", "tool", tool.Name)
+				slog.ErrorContext(ctx, "Converted parameters is not a map", "tool", tool.Name)
 				return nil, fmt.Errorf("converted parameters is not a map for tool %s", tool.Name)
 			}
 
@@ -247,7 +247,7 @@ func (c *Client) CreateChatCompletionStream(ctx context.Context, messages []chat
 		extraFields["chat_template_kwargs"] = map[string]any{"enable_thinking": false}
 		if c.ModelConfig.MaxTokens != nil && *c.ModelConfig.MaxTokens < noThinkingMinOutputTokens {
 			params.MaxTokens = openai.Int(noThinkingMinOutputTokens)
-			slog.Debug("DMR NoThinking: bumped max_tokens floor",
+			slog.DebugContext(ctx, "DMR NoThinking: bumped max_tokens floor",
 				"from", *c.ModelConfig.MaxTokens, "to", noThinkingMinOutputTokens)
 		}
 	}
@@ -261,18 +261,18 @@ func (c *Client) CreateChatCompletionStream(ctx context.Context, messages []chat
 
 	if len(extraFields) > 0 {
 		params.SetExtraFields(extraFields)
-		slog.Debug("DMR extra request fields applied", "fields", extraFields)
+		slog.DebugContext(ctx, "DMR extra request fields applied", "fields", extraFields)
 	}
 
 	// Log the request in JSON format for debugging
 	if requestJSON, err := json.Marshal(params); err == nil {
-		slog.Debug("DMR chat completion request", "request", string(requestJSON))
+		slog.DebugContext(ctx, "DMR chat completion request", "request", string(requestJSON))
 	} else {
-		slog.Error("Failed to marshal DMR request to JSON", "error", err)
+		slog.ErrorContext(ctx, "Failed to marshal DMR request to JSON", "error", err)
 	}
 
 	if structuredOutput := c.ModelOptions.StructuredOutput(); structuredOutput != nil {
-		slog.Debug("Adding structured output to DMR request", "name", structuredOutput.Name, "strict", structuredOutput.Strict)
+		slog.DebugContext(ctx, "Adding structured output to DMR request", "name", structuredOutput.Name, "strict", structuredOutput.Strict)
 
 		params.ResponseFormat.OfJSONSchema = &openai.ResponseFormatJSONSchemaParam{
 			JSONSchema: openai.ResponseFormatJSONSchemaJSONSchemaParam{
@@ -286,7 +286,7 @@ func (c *Client) CreateChatCompletionStream(ctx context.Context, messages []chat
 
 	stream := c.client.Chat.Completions.NewStreaming(ctx, params)
 
-	slog.Debug("DMR chat completion stream created successfully", "model", c.ModelConfig.Model, "base_url", c.baseURL)
+	slog.DebugContext(ctx, "DMR chat completion stream created successfully", "model", c.ModelConfig.Model, "base_url", c.baseURL)
 	return newStreamAdapter(stream, trackUsage), nil
 }
 

--- a/pkg/model/provider/dmr/configure.go
+++ b/pkg/model/provider/dmr/configure.go
@@ -104,7 +104,7 @@ func configureModel(ctx context.Context, httpClient *http.Client, baseURL, model
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	slog.Debug("Sending model configure request",
+	slog.DebugContext(ctx, "Sending model configure request",
 		"model", model,
 		"url", configureURL,
 		"context_size", derefInt32(backend.ContextSize),
@@ -127,7 +127,7 @@ func configureModel(ctx context.Context, httpClient *http.Client, baseURL, model
 		return fmt.Errorf("configure request failed with status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 
-	slog.Debug("Model configure completed", "model", model)
+	slog.DebugContext(ctx, "Model configure completed", "model", model)
 	return nil
 }
 

--- a/pkg/model/provider/dmr/embed.go
+++ b/pkg/model/provider/dmr/embed.go
@@ -43,7 +43,7 @@ func (c *Client) CreateBatchEmbedding(ctx context.Context, texts []string) (*bas
 		return &base.BatchEmbeddingResult{Embeddings: [][]float64{}}, nil
 	}
 
-	slog.Debug("Creating DMR embeddings", "model", c.ModelConfig.Model, "batch_size", len(texts), "base_url", c.baseURL)
+	slog.DebugContext(ctx, "Creating DMR embeddings", "model", c.ModelConfig.Model, "batch_size", len(texts), "base_url", c.baseURL)
 
 	response, err := c.client.Embeddings.New(ctx, openai.EmbeddingNewParams{
 		Input: openai.EmbeddingNewParamsInputUnion{OfArrayOfStrings: texts},
@@ -64,7 +64,7 @@ func (c *Client) CreateBatchEmbedding(ctx context.Context, texts []string) (*bas
 		embeddings[i] = vec
 	}
 
-	slog.Debug("DMR embeddings created",
+	slog.DebugContext(ctx, "DMR embeddings created",
 		"batch_size", len(embeddings),
 		"dimension", len(embeddings[0]),
 		"input_tokens", response.Usage.PromptTokens,
@@ -119,7 +119,7 @@ func (c *Client) Rerank(ctx context.Context, query string, documents []types.Doc
 	startTime := time.Now()
 
 	if criteria != "" {
-		slog.Warn("DMR reranking does not support custom criteria", "model", c.ModelConfig.Model)
+		slog.WarnContext(ctx, "DMR reranking does not support custom criteria", "model", c.ModelConfig.Model)
 	}
 
 	documentStrings := make([]string, len(documents))
@@ -142,7 +142,7 @@ func (c *Client) Rerank(ctx context.Context, query string, documents []types.Doc
 		return nil, fmt.Errorf("failed to marshal rerank request: %w", err)
 	}
 
-	slog.Debug("DMR reranking", "model", c.ModelConfig.Model, "url", rerankURL, "num_documents", len(documents))
+	slog.DebugContext(ctx, "DMR reranking", "model", c.ModelConfig.Model, "url", rerankURL, "num_documents", len(documents))
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rerankURL, bytes.NewReader(reqData))
 	if err != nil {
@@ -180,7 +180,7 @@ func (c *Client) Rerank(ctx context.Context, query string, documents []types.Doc
 		scores[result.Index] = sigmoid(result.RelevanceScore)
 	}
 
-	slog.Debug("DMR reranking complete",
+	slog.DebugContext(ctx, "DMR reranking complete",
 		"model", c.ModelConfig.Model,
 		"num_scores", len(scores),
 		"prompt_tokens", rerankResp.Usage.PromptTokens,

--- a/pkg/model/provider/dmr/pull.go
+++ b/pkg/model/provider/dmr/pull.go
@@ -18,7 +18,7 @@ import (
 
 func pullDockerModelIfNeeded(ctx context.Context, model string) error {
 	if modelExists(ctx, model) {
-		slog.Debug("Model already exists, skipping pull", "model", model)
+		slog.DebugContext(ctx, "Model already exists, skipping pull", "model", model)
 		return nil
 	}
 
@@ -26,7 +26,7 @@ func pullDockerModelIfNeeded(ctx context.Context, model string) error {
 		return err
 	}
 
-	slog.Info("Pulling DMR model", "model", model)
+	slog.InfoContext(ctx, "Pulling DMR model", "model", model)
 	fmt.Printf("Pulling model %s...\n", model)
 
 	cmd := exec.CommandContext(ctx, "docker", "model", "pull", model)
@@ -36,7 +36,7 @@ func pullDockerModelIfNeeded(ctx context.Context, model string) error {
 		return fmt.Errorf("failed to pull model %s: %w", model, err)
 	}
 
-	slog.Info("Model pulled successfully", "model", model)
+	slog.InfoContext(ctx, "Model pulled successfully", "model", model)
 	fmt.Printf("Model %s pulled successfully.\n", model)
 
 	return nil
@@ -46,7 +46,7 @@ func pullDockerModelIfNeeded(ctx context.Context, model string) error {
 // In non-interactive mode (e.g. devcontainers, CI), it proceeds automatically.
 func confirmModelPull(ctx context.Context, model string) error {
 	if !term.IsTerminal(int(os.Stdin.Fd())) {
-		slog.Info("Model not found locally, pulling automatically (non-interactive mode)", "model", model)
+		slog.InfoContext(ctx, "Model not found locally, pulling automatically (non-interactive mode)", "model", model)
 		return nil
 	}
 
@@ -72,7 +72,7 @@ func modelExists(ctx context.Context, model string) bool {
 	cmd.Stdout = io.Discard
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		slog.Debug("Model does not exist", "model", model, "error", strings.TrimSpace(stderr.String()))
+		slog.DebugContext(ctx, "Model does not exist", "model", model, "error", strings.TrimSpace(stderr.String()))
 		return false
 	}
 	return true

--- a/pkg/model/provider/dmr/resolve.go
+++ b/pkg/model/provider/dmr/resolve.go
@@ -62,19 +62,19 @@ func testDMRConnectivity(ctx context.Context, httpClient *http.Client, baseURL s
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, http.NoBody)
 	if err != nil {
-		slog.Debug("DMR connectivity check: failed to create request", "url", healthURL, "error", err)
+		slog.DebugContext(ctx, "DMR connectivity check: failed to create request", "url", healthURL, "error", err)
 		return false
 	}
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		slog.Debug("DMR connectivity check: request failed", "url", healthURL, "error", err)
+		slog.DebugContext(ctx, "DMR connectivity check: request failed", "url", healthURL, "error", err)
 		return false
 	}
 	defer resp.Body.Close()
 
 	// Any response (even 4xx/5xx) means the server is reachable
-	slog.Debug("DMR connectivity check: success", "url", healthURL, "status", resp.StatusCode)
+	slog.DebugContext(ctx, "DMR connectivity check: success", "url", healthURL, "status", resp.StatusCode)
 	return true
 }
 
@@ -112,12 +112,12 @@ func getDMRFallbackURLs(containerized bool) []string {
 func resolveDMRBaseURL(ctx context.Context, cfg *latest.ModelConfig, endpoint string) (string, []option.RequestOption, *http.Client) {
 	// Explicit configuration — return immediately without fallback testing.
 	if cfg != nil && cfg.BaseURL != "" {
-		slog.Debug("DMR using explicitly configured BaseURL", "url", cfg.BaseURL)
+		slog.DebugContext(ctx, "DMR using explicitly configured BaseURL", "url", cfg.BaseURL)
 		return cfg.BaseURL, nil, nil
 	}
 	if host := os.Getenv("MODEL_RUNNER_HOST"); host != "" {
 		baseURL := strings.TrimRight(host, "/") + dmrInferencePrefix + "/v1/"
-		slog.Debug("DMR using MODEL_RUNNER_HOST", "url", baseURL)
+		slog.DebugContext(ctx, "DMR using MODEL_RUNNER_HOST", "url", baseURL)
 		return baseURL, nil, nil
 	}
 
@@ -129,23 +129,23 @@ func resolveDMRBaseURL(ctx context.Context, cfg *latest.ModelConfig, endpoint st
 	containerized := inContainer()
 
 	if !testDMRConnectivity(ctx, testClient, baseURL) {
-		slog.Debug("DMR primary endpoint unreachable, trying fallbacks", "primary_url", baseURL, "in_container", containerized)
+		slog.DebugContext(ctx, "DMR primary endpoint unreachable, trying fallbacks", "primary_url", baseURL, "in_container", containerized)
 
 		for _, fallbackURL := range getDMRFallbackURLs(containerized) {
 			if fallbackURL == baseURL {
 				continue
 			}
-			slog.Debug("DMR trying fallback endpoint", "url", fallbackURL)
+			slog.DebugContext(ctx, "DMR trying fallback endpoint", "url", fallbackURL)
 			if testDMRConnectivity(ctx, &http.Client{}, fallbackURL) {
-				slog.Info("DMR using fallback endpoint", "fallback_url", fallbackURL, "original_url", baseURL)
+				slog.InfoContext(ctx, "DMR using fallback endpoint", "fallback_url", fallbackURL, "original_url", baseURL)
 				return fallbackURL, nil, nil
 			}
 		}
 		// All endpoints unreachable — continue with primary URL.
 		// The client will fail on first actual use, providing a better error.
-		slog.Error("DMR all endpoints currently unreachable, will fail on first use", "primary_url", baseURL, "in_container", containerized)
+		slog.ErrorContext(ctx, "DMR all endpoints currently unreachable, will fail on first use", "primary_url", baseURL, "in_container", containerized)
 	} else {
-		slog.Debug("DMR primary endpoint reachable", "url", baseURL)
+		slog.DebugContext(ctx, "DMR primary endpoint reachable", "url", baseURL)
 	}
 
 	return baseURL, clientOptions, httpClient

--- a/pkg/model/provider/factory.go
+++ b/pkg/model/provider/factory.go
@@ -68,7 +68,7 @@ func createDirectProvider(ctx context.Context, cfg *latest.ModelConfig, env envi
 
 	factory, ok := providerFactories[providerType]
 	if !ok {
-		slog.Error("Unknown provider type", "type", providerType)
+		slog.ErrorContext(ctx, "Unknown provider type", "type", providerType)
 		return nil, fmt.Errorf("unknown provider type: %s", providerType)
 	}
 	return factory(ctx, enhancedCfg, env, opts...)

--- a/pkg/model/provider/gemini/client.go
+++ b/pkg/model/provider/gemini/client.go
@@ -121,7 +121,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 	} else {
 		// Fail fast if Docker Desktop's auth token isn't available
 		if token, _ := env.Get(ctx, environment.DockerDesktopTokenEnv); token == "" {
-			slog.Error("Gemini client creation failed", "error", "failed to get Docker Desktop's authentication token")
+			slog.ErrorContext(ctx, "Gemini client creation failed", "error", "failed to get Docker Desktop's authentication token")
 			return nil, errors.New("sorry, you first need to sign in Docker Desktop to use the Docker AI Gateway")
 		}
 
@@ -164,7 +164,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 		}
 	}
 
-	slog.Debug("Gemini client created successfully", "model", cfg.Model)
+	slog.DebugContext(ctx, "Gemini client created successfully", "model", cfg.Model)
 
 	return &Client{
 		Config: base.Config{
@@ -562,7 +562,7 @@ func (c *Client) CreateChatCompletionStream(
 	if len(requestTools) > 0 {
 		allTools, err := convertToolsToGemini(requestTools)
 		if err != nil {
-			slog.Error("Failed to convert tools to Gemini format", "error", err)
+			slog.ErrorContext(ctx, "Failed to convert tools to Gemini format", "error", err)
 			return nil, err
 		}
 
@@ -581,10 +581,10 @@ func (c *Client) CreateChatCompletionStream(
 		}
 
 		// Debug: Log the tools we're sending
-		slog.Debug("Gemini tools config", "tools", config.Tools)
+		slog.DebugContext(ctx, "Gemini tools config", "tools", config.Tools)
 		for _, tool := range config.Tools {
 			for _, fn := range tool.FunctionDeclarations {
-				slog.Debug("Function", "name", fn.Name, "desc", fn.Description, "params", fn.Parameters)
+				slog.DebugContext(ctx, "Function", "name", fn.Name, "desc", fn.Description, "params", fn.Parameters)
 			}
 		}
 	}
@@ -592,14 +592,14 @@ func (c *Client) CreateChatCompletionStream(
 	contents := convertMessagesToGemini(messages)
 
 	// Debug: Log the messages we're sending
-	slog.Debug("Gemini messages", "count", len(contents))
+	slog.DebugContext(ctx, "Gemini messages", "count", len(contents))
 	for i, content := range contents {
-		slog.Debug("Message", "index", i, "role", content.Role)
+		slog.DebugContext(ctx, "Message", "index", i, "role", content.Role)
 	}
 
 	client, err := c.clientFn(ctx)
 	if err != nil {
-		slog.Error("Failed to create Gemini client", "error", err)
+		slog.ErrorContext(ctx, "Failed to create Gemini client", "error", err)
 		return nil, err
 	}
 
@@ -615,11 +615,11 @@ func (c *Client) Rerank(ctx context.Context, query string, documents []types.Doc
 	const logPrefix = "Gemini reranking request"
 
 	if len(documents) == 0 {
-		slog.Debug(logPrefix, "model", c.ModelConfig.Model, "num_documents", 0)
+		slog.DebugContext(ctx, logPrefix, "model", c.ModelConfig.Model, "num_documents", 0)
 		return []float64{}, nil
 	}
 
-	slog.Debug(logPrefix,
+	slog.DebugContext(ctx, logPrefix,
 		"model", c.ModelConfig.Model,
 		"query_length", len(query),
 		"num_documents", len(documents),
@@ -627,7 +627,7 @@ func (c *Client) Rerank(ctx context.Context, query string, documents []types.Doc
 
 	client, err := c.clientFn(ctx)
 	if err != nil {
-		slog.Error("Failed to create Gemini client for reranking", "error", err)
+		slog.ErrorContext(ctx, "Failed to create Gemini client for reranking", "error", err)
 		return nil, err
 	}
 
@@ -685,7 +685,7 @@ func (c *Client) Rerank(ctx context.Context, query string, documents []types.Doc
 
 	resp, err := client.Models.GenerateContent(ctx, c.ModelConfig.Model, []*genai.Content{content}, cfg)
 	if err != nil {
-		slog.Error("Gemini rerank request failed", "error", err)
+		slog.ErrorContext(ctx, "Gemini rerank request failed", "error", err)
 		return nil, fmt.Errorf("gemini rerank request failed: %w", err)
 	}
 
@@ -696,17 +696,17 @@ func (c *Client) Rerank(ctx context.Context, query string, documents []types.Doc
 
 	rawJSON, err := extractGeminiStructuredJSON(resp)
 	if err != nil {
-		slog.Error("Failed to extract Gemini structured JSON", "error", err)
+		slog.ErrorContext(ctx, "Failed to extract Gemini structured JSON", "error", err)
 		return nil, err
 	}
 
 	scores, err := parseRerankScoresStrict(rawJSON, len(documents))
 	if err != nil {
-		slog.Error("Failed to parse Gemini rerank scores", "error", err)
+		slog.ErrorContext(ctx, "Failed to parse Gemini rerank scores", "error", err)
 		return nil, err
 	}
 
-	slog.Debug("Gemini reranking complete",
+	slog.DebugContext(ctx, "Gemini reranking complete",
 		"model", c.ModelConfig.Model,
 		"num_scores", len(scores))
 

--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -45,7 +45,7 @@ type Client struct {
 // NewClient creates a new OpenAI client from the provided configuration
 func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Provider, opts ...options.Opt) (*Client, error) {
 	if cfg == nil {
-		slog.Error("OpenAI client creation failed", "error", "model configuration is required")
+		slog.ErrorContext(ctx, "OpenAI client creation failed", "error", "model configuration is required")
 		return nil, errors.New("model configuration is required")
 	}
 
@@ -67,7 +67,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 			clientOptions = append(clientOptions, option.WithAPIKey(authToken))
 		} else if isCustomProvider(cfg) {
 			// Custom provider (has api_type in ProviderOpts) without token_key - no auth
-			slog.Debug("Custom provider with no token_key, sending requests without authentication",
+			slog.DebugContext(ctx, "Custom provider with no token_key, sending requests without authentication",
 				"provider", cfg.Provider, "base_url", cfg.BaseURL)
 			clientOptions = append(clientOptions, option.WithAPIKey(""))
 		}
@@ -82,7 +82,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 			// Azure API version from provider opts
 			if cfg.ProviderOpts != nil {
 				if apiVersion, exists := cfg.ProviderOpts["api_version"]; exists {
-					slog.Debug("Setting API version", "api_version", apiVersion)
+					slog.DebugContext(ctx, "Setting API version", "api_version", apiVersion)
 					if apiVersionStr, ok := apiVersion.(string); ok {
 						clientOptions = append(clientOptions, option.WithQueryAdd("api-version", apiVersionStr))
 					}
@@ -106,7 +106,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 	} else {
 		// Fail fast if Docker Desktop's auth token isn't available
 		if token, _ := env.Get(ctx, environment.DockerDesktopTokenEnv); token == "" {
-			slog.Error("OpenAI client creation failed", "error", "failed to get Docker Desktop's authentication token")
+			slog.ErrorContext(ctx, "OpenAI client creation failed", "error", "failed to get Docker Desktop's authentication token")
 			return nil, errors.New("sorry, you first need to sign in Docker Desktop to use the Docker AI Gateway")
 		}
 
@@ -147,7 +147,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 		}
 	}
 
-	slog.Debug("OpenAI client created successfully", "model", cfg.Model)
+	slog.DebugContext(ctx, "OpenAI client created successfully", "model", cfg.Model)
 
 	client := &Client{
 		Config: base.Config{
@@ -190,7 +190,7 @@ func (c *Client) CreateChatCompletionStream(
 	messages []chat.Message,
 	requestTools []tools.Tool,
 ) (chat.MessageStream, error) {
-	slog.Debug("Creating OpenAI chat completion stream",
+	slog.DebugContext(ctx, "Creating OpenAI chat completion stream",
 		"model", c.ModelConfig.Model,
 		"message_count", len(messages),
 		"tool_count", len(requestTools))
@@ -202,21 +202,21 @@ func (c *Client) CreateChatCompletionStream(
 	switch apiType {
 	case "openai_responses":
 		// Force Responses API
-		slog.Debug("Using Responses API", "api_type", apiType, "model", c.ModelConfig.Model)
+		slog.DebugContext(ctx, "Using Responses API", "api_type", apiType, "model", c.ModelConfig.Model)
 		return c.CreateResponseStream(ctx, messages, requestTools)
 	case "openai_chatcompletions":
-		slog.Debug("Using Chat Completions API", "api_type", apiType, "model", c.ModelConfig.Model)
+		slog.DebugContext(ctx, "Using Chat Completions API", "api_type", apiType, "model", c.ModelConfig.Model)
 	default:
 		// Auto-detect based on model name for OpenAI provider
 		// Use Responses API for newer models that support it (gpt-4.1+, o-series, gpt-5)
 		if c.ModelConfig.Provider == "openai" && isResponsesModel(c.ModelConfig.Model) {
-			slog.Debug("Auto-selecting Responses API", "model", c.ModelConfig.Model)
+			slog.DebugContext(ctx, "Auto-selecting Responses API", "model", c.ModelConfig.Model)
 			return c.CreateResponseStream(ctx, messages, requestTools)
 		}
 	}
 
 	if len(messages) == 0 {
-		slog.Error("OpenAI stream creation failed", "error", "at least one message is required")
+		slog.ErrorContext(ctx, "OpenAI stream creation failed", "error", "at least one message is required")
 		return nil, errors.New("at least one message is required")
 	}
 
@@ -246,20 +246,20 @@ func (c *Client) CreateChatCompletionStream(
 	if maxToken := c.ModelConfig.MaxTokens; maxToken != nil && *maxToken > 0 {
 		if !isResponsesModel(c.ModelConfig.Model) {
 			params.MaxTokens = openai.Int(*maxToken)
-			slog.Debug("OpenAI request configured with max tokens", "max_tokens", *maxToken, "model", c.ModelConfig.Model)
+			slog.DebugContext(ctx, "OpenAI request configured with max tokens", "max_tokens", *maxToken, "model", c.ModelConfig.Model)
 		} else {
 			params.MaxCompletionTokens = openai.Int(*maxToken)
-			slog.Debug("using max_completion_tokens instead of max_tokens for Responses-API models", "model", c.ModelConfig.Model)
+			slog.DebugContext(ctx, "using max_completion_tokens instead of max_tokens for Responses-API models", "model", c.ModelConfig.Model)
 		}
 	}
 
 	if len(requestTools) > 0 {
-		slog.Debug("Adding tools to OpenAI request", "tool_count", len(requestTools))
+		slog.DebugContext(ctx, "Adding tools to OpenAI request", "tool_count", len(requestTools))
 		toolsParam := make([]openai.ChatCompletionToolUnionParam, len(requestTools))
 		for i, tool := range requestTools {
 			parameters, err := ConvertParametersToSchema(tool.Parameters)
 			if err != nil {
-				slog.Debug("Failed to convert tool parameters to OpenAI schema", "tool_name", tool.Name, "error", err)
+				slog.DebugContext(ctx, "Failed to convert tool parameters to OpenAI schema", "tool_name", tool.Name, "error", err)
 				return nil, err
 			}
 
@@ -269,7 +269,7 @@ func (c *Client) CreateChatCompletionStream(
 				Parameters:  parameters,
 			})
 
-			slog.Debug("Added tool to OpenAI request", "tool_name", tool.Name)
+			slog.DebugContext(ctx, "Added tool to OpenAI request", "tool_name", tool.Name)
 		}
 		params.Tools = toolsParam
 
@@ -301,21 +301,21 @@ func (c *Client) CreateChatCompletionStream(
 					params.MaxCompletionTokens = openai.Int(noThinkingMinOutputTokens)
 				}
 			}
-			slog.Debug("OpenAI request using low reasoning (NoThinking)")
+			slog.DebugContext(ctx, "OpenAI request using low reasoning (NoThinking)")
 		} else if c.ModelConfig.ThinkingBudget != nil {
 			effortStr, err := openAIReasoningEffort(c.ModelConfig.ThinkingBudget)
 			if err != nil {
-				slog.Error("OpenAI request using thinking_budget failed", "error", err)
+				slog.ErrorContext(ctx, "OpenAI request using thinking_budget failed", "error", err)
 				return nil, err
 			}
 			params.ReasoningEffort = shared.ReasoningEffort(effortStr)
-			slog.Debug("OpenAI request using thinking_budget", "reasoning_effort", effortStr)
+			slog.DebugContext(ctx, "OpenAI request using thinking_budget", "reasoning_effort", effortStr)
 		}
 	}
 
 	// Apply structured output configuration
 	if structuredOutput := c.ModelOptions.StructuredOutput(); structuredOutput != nil {
-		slog.Debug("OpenAI request using structured output", "name", structuredOutput.Name, "strict", structuredOutput.Strict)
+		slog.DebugContext(ctx, "OpenAI request using structured output", "name", structuredOutput.Name, "strict", structuredOutput.Strict)
 
 		params.ResponseFormat.OfJSONSchema = &openai.ResponseFormatJSONSchemaParam{
 			JSONSchema: openai.ResponseFormatJSONSchemaJSONSchemaParam{
@@ -329,14 +329,14 @@ func (c *Client) CreateChatCompletionStream(
 
 	// Log the request in JSON format for debugging
 	if requestJSON, err := json.Marshal(params); err == nil {
-		slog.Debug("OpenAI chat completion request", "request", string(requestJSON))
+		slog.DebugContext(ctx, "OpenAI chat completion request", "request", string(requestJSON))
 	} else {
-		slog.Error("Failed to marshal OpenAI request to JSON", "error", err)
+		slog.ErrorContext(ctx, "Failed to marshal OpenAI request to JSON", "error", err)
 	}
 
 	client, err := c.clientFn(ctx)
 	if err != nil {
-		slog.Error("Failed to create OpenAI client", "error", err)
+		slog.ErrorContext(ctx, "Failed to create OpenAI client", "error", err)
 		return nil, err
 	}
 
@@ -347,7 +347,7 @@ func (c *Client) CreateChatCompletionStream(
 
 	stream := client.Chat.Completions.NewStreaming(ctx, params)
 
-	slog.Debug("OpenAI chat completion stream created successfully", "model", c.ModelConfig.Model)
+	slog.DebugContext(ctx, "OpenAI chat completion stream created successfully", "model", c.ModelConfig.Model)
 	return newStreamAdapter(stream, trackUsage), nil
 }
 
@@ -356,10 +356,10 @@ func (c *Client) CreateResponseStream(
 	messages []chat.Message,
 	requestTools []tools.Tool,
 ) (chat.MessageStream, error) {
-	slog.Debug("Creating OpenAI responses stream", "model", c.ModelConfig.Model)
+	slog.DebugContext(ctx, "Creating OpenAI responses stream", "model", c.ModelConfig.Model)
 
 	if len(messages) == 0 {
-		slog.Error("OpenAI responses stream creation failed", "error", "at least one message is required")
+		slog.ErrorContext(ctx, "OpenAI responses stream creation failed", "error", "at least one message is required")
 		return nil, errors.New("at least one message is required")
 	}
 
@@ -380,16 +380,16 @@ func (c *Client) CreateResponseStream(
 	if maxToken := c.ModelConfig.MaxTokens; maxToken != nil && *maxToken > 0 {
 		maxTokens := *maxToken
 		params.MaxOutputTokens = param.NewOpt(maxTokens)
-		slog.Debug("OpenAI responses request configured with max output tokens", "max_output_tokens", maxTokens)
+		slog.DebugContext(ctx, "OpenAI responses request configured with max output tokens", "max_output_tokens", maxTokens)
 	}
 
 	if len(requestTools) > 0 {
-		slog.Debug("Adding tools to OpenAI responses request", "tool_count", len(requestTools))
+		slog.DebugContext(ctx, "Adding tools to OpenAI responses request", "tool_count", len(requestTools))
 		toolsParam := make([]responses.ToolUnionParam, len(requestTools))
 		for i, tool := range requestTools {
 			parameters, err := ConvertParametersToSchema(tool.Parameters)
 			if err != nil {
-				slog.Debug("Failed to convert tool parameters to OpenAI schema", "tool_name", tool.Name, "error", err)
+				slog.DebugContext(ctx, "Failed to convert tool parameters to OpenAI schema", "tool_name", tool.Name, "error", err)
 				return nil, err
 			}
 
@@ -402,7 +402,7 @@ func (c *Client) CreateResponseStream(
 				},
 			}
 
-			slog.Debug("Added tool to OpenAI responses request", "tool_name", tool.Name)
+			slog.DebugContext(ctx, "Added tool to OpenAI responses request", "tool_name", tool.Name)
 		}
 		params.Tools = toolsParam
 
@@ -436,7 +436,7 @@ func (c *Client) CreateResponseStream(
 			if c.ModelConfig.MaxTokens != nil && *c.ModelConfig.MaxTokens < noThinkingMinOutputTokens {
 				params.MaxOutputTokens = param.NewOpt(noThinkingMinOutputTokens)
 			}
-			slog.Debug("OpenAI responses request using low reasoning (NoThinking)")
+			slog.DebugContext(ctx, "OpenAI responses request using low reasoning (NoThinking)")
 		} else {
 			params.Reasoning = shared.ReasoningParam{
 				Summary: shared.ReasoningSummaryDetailed,
@@ -444,18 +444,18 @@ func (c *Client) CreateResponseStream(
 			if c.ModelConfig.ThinkingBudget != nil {
 				effortStr, err := openAIReasoningEffort(c.ModelConfig.ThinkingBudget)
 				if err != nil {
-					slog.Error("OpenAI responses request using thinking_budget failed", "error", err)
+					slog.ErrorContext(ctx, "OpenAI responses request using thinking_budget failed", "error", err)
 					return nil, err
 				}
 				params.Reasoning.Effort = shared.ReasoningEffort(effortStr)
-				slog.Debug("OpenAI responses request using thinking_budget", "reasoning_effort", effortStr)
+				slog.DebugContext(ctx, "OpenAI responses request using thinking_budget", "reasoning_effort", effortStr)
 			}
 		}
 	}
 
 	// Apply structured output configuration
 	if structuredOutput := c.ModelOptions.StructuredOutput(); structuredOutput != nil {
-		slog.Debug("OpenAI responses request using structured output", "name", structuredOutput.Name, "strict", structuredOutput.Strict)
+		slog.DebugContext(ctx, "OpenAI responses request using structured output", "name", structuredOutput.Name, "strict", structuredOutput.Strict)
 
 		params.Text.Format.OfJSONSchema = &responses.ResponseFormatTextJSONSchemaConfigParam{
 			Name:        structuredOutput.Name,
@@ -467,9 +467,9 @@ func (c *Client) CreateResponseStream(
 
 	// Log the request in JSON format for debugging
 	if requestJSON, err := json.Marshal(params); err == nil {
-		slog.Debug("OpenAI responses request", "request", string(requestJSON))
+		slog.DebugContext(ctx, "OpenAI responses request", "request", string(requestJSON))
 	} else {
-		slog.Error("Failed to marshal OpenAI responses request to JSON", "error", err)
+		slog.ErrorContext(ctx, "Failed to marshal OpenAI responses request to JSON", "error", err)
 	}
 
 	// Choose transport: WebSocket or SSE (default).
@@ -480,26 +480,26 @@ func (c *Client) CreateResponseStream(
 	if transport == "websocket" && c.ModelOptions.Gateway() == "" {
 		stream, err := c.createWebSocketStream(ctx, params)
 		if err != nil {
-			slog.Warn("WebSocket stream failed, falling back to SSE", "error", err)
+			slog.WarnContext(ctx, "WebSocket stream failed, falling back to SSE", "error", err)
 			// Fall through to SSE below.
 		} else {
-			slog.Debug("OpenAI responses WebSocket stream created successfully", "model", c.ModelConfig.Model)
+			slog.DebugContext(ctx, "OpenAI responses WebSocket stream created successfully", "model", c.ModelConfig.Model)
 			return newResponseStreamAdapter(stream, trackUsage), nil
 		}
 	} else if transport == "websocket" {
-		slog.Debug("WebSocket transport requested but Gateway is configured, using SSE",
+		slog.DebugContext(ctx, "WebSocket transport requested but Gateway is configured, using SSE",
 			"model", c.ModelConfig.Model,
 			"gateway", c.ModelOptions.Gateway())
 	}
 
 	client, err := c.clientFn(ctx)
 	if err != nil {
-		slog.Error("Failed to create OpenAI client", "error", err)
+		slog.ErrorContext(ctx, "Failed to create OpenAI client", "error", err)
 		return nil, err
 	}
 	stream := client.Responses.NewStreaming(ctx, params)
 
-	slog.Debug("OpenAI responses stream created successfully", "model", c.ModelConfig.Model)
+	slog.DebugContext(ctx, "OpenAI responses stream created successfully", "model", c.ModelConfig.Model)
 	return newResponseStreamAdapter(stream, trackUsage), nil
 }
 
@@ -764,7 +764,7 @@ func convertMessagesToResponseInput(messages []chat.Message) []responses.Respons
 
 // CreateEmbedding generates an embedding vector for the given text
 func (c *Client) CreateEmbedding(ctx context.Context, text string) (*base.EmbeddingResult, error) {
-	slog.Debug("Creating OpenAI embedding", "model", c.ModelConfig.Model, "text_length", len(text))
+	slog.DebugContext(ctx, "Creating OpenAI embedding", "model", c.ModelConfig.Model, "text_length", len(text))
 
 	batchResult, err := c.CreateBatchEmbedding(ctx, []string{text})
 	if err != nil {
@@ -777,7 +777,7 @@ func (c *Client) CreateEmbedding(ctx context.Context, text string) (*base.Embedd
 
 	embedding := batchResult.Embeddings[0]
 
-	slog.Debug("OpenAI embedding created successfully",
+	slog.DebugContext(ctx, "OpenAI embedding created successfully",
 		"dimension", len(embedding),
 		"input_tokens", batchResult.InputTokens,
 		"total_tokens", batchResult.TotalTokens)
@@ -805,11 +805,11 @@ func (c *Client) CreateBatchEmbedding(ctx context.Context, texts []string) (*bas
 		return nil, fmt.Errorf("batch size %d exceeds OpenAI limit of %d", len(texts), maxBatchSize)
 	}
 
-	slog.Debug("Creating OpenAI batch embeddings", "model", c.ModelConfig.Model, "batch_size", len(texts))
+	slog.DebugContext(ctx, "Creating OpenAI batch embeddings", "model", c.ModelConfig.Model, "batch_size", len(texts))
 
 	client, err := c.clientFn(ctx)
 	if err != nil {
-		slog.Error("Failed to create OpenAI client for batch embedding", "error", err)
+		slog.ErrorContext(ctx, "Failed to create OpenAI client for batch embedding", "error", err)
 		return nil, err
 	}
 
@@ -822,7 +822,7 @@ func (c *Client) CreateBatchEmbedding(ctx context.Context, texts []string) (*bas
 
 	response, err := client.Embeddings.New(ctx, params)
 	if err != nil {
-		slog.Error("OpenAI batch embedding request failed", "error", err)
+		slog.ErrorContext(ctx, "OpenAI batch embedding request failed", "error", err)
 		return nil, fmt.Errorf("failed to create batch embeddings: %w", err)
 	}
 
@@ -846,7 +846,7 @@ func (c *Client) CreateBatchEmbedding(ctx context.Context, texts []string) (*bas
 	// Cost calculation is handled at the strategy level using models.dev pricing
 	// Provider just returns token counts
 
-	slog.Debug("OpenAI batch embeddings created successfully",
+	slog.DebugContext(ctx, "OpenAI batch embeddings created successfully",
 		"batch_size", len(embeddings),
 		"dimension", len(embeddings[0]),
 		"input_tokens", inputTokens,
@@ -865,11 +865,11 @@ func (c *Client) CreateBatchEmbedding(ctx context.Context, texts []string) (*bas
 func (c *Client) Rerank(ctx context.Context, query string, documents []types.Document, criteria string) ([]float64, error) {
 	startMsg := "OpenAI reranking request"
 	if len(documents) == 0 {
-		slog.Debug(startMsg, "model", c.ModelConfig.Model, "num_documents", 0)
+		slog.DebugContext(ctx, startMsg, "model", c.ModelConfig.Model, "num_documents", 0)
 		return []float64{}, nil
 	}
 
-	slog.Debug(startMsg,
+	slog.DebugContext(ctx, startMsg,
 		"model", c.ModelConfig.Model,
 		"query_length", len(query),
 		"num_documents", len(documents),
@@ -877,7 +877,7 @@ func (c *Client) Rerank(ctx context.Context, query string, documents []types.Doc
 
 	client, err := c.clientFn(ctx)
 	if err != nil {
-		slog.Error("Failed to create OpenAI client for reranking", "error", err)
+		slog.ErrorContext(ctx, "Failed to create OpenAI client for reranking", "error", err)
 		return nil, err
 	}
 
@@ -947,7 +947,7 @@ func (c *Client) Rerank(ctx context.Context, query string, documents []types.Doc
 
 	resp, err := client.Chat.Completions.New(ctx, params)
 	if err != nil {
-		slog.Error("OpenAI rerank request failed", "error", err)
+		slog.ErrorContext(ctx, "OpenAI rerank request failed", "error", err)
 		return nil, fmt.Errorf("openai rerank request failed: %w", err)
 	}
 
@@ -957,17 +957,17 @@ func (c *Client) Rerank(ctx context.Context, query string, documents []types.Doc
 
 	raw, err := extractOpenAIContentAsString(resp.Choices[0].Message)
 	if err != nil {
-		slog.Error("Failed to extract OpenAI rerank content", "error", err)
+		slog.ErrorContext(ctx, "Failed to extract OpenAI rerank content", "error", err)
 		return nil, err
 	}
 
 	scores, err := parseRerankScores(raw, len(documents))
 	if err != nil {
-		slog.Error("Failed to parse OpenAI rerank scores", "error", err)
+		slog.ErrorContext(ctx, "Failed to parse OpenAI rerank scores", "error", err)
 		return nil, err
 	}
 
-	slog.Debug("OpenAI reranking complete",
+	slog.DebugContext(ctx, "OpenAI reranking complete",
 		"model", c.ModelConfig.Model,
 		"num_scores", len(scores))
 

--- a/pkg/model/provider/openai/ws_pool.go
+++ b/pkg/model/provider/openai/ws_pool.go
@@ -81,7 +81,7 @@ func (p *wsPool) Stream(
 
 	// Close stale connections.
 	if p.conn != nil && p.conn.isExpired() {
-		slog.Debug("Closing expired WebSocket connection",
+		slog.DebugContext(ctx, "Closing expired WebSocket connection",
 			"age", time.Since(p.conn.createdAt))
 		p.closeLocked()
 	}
@@ -95,7 +95,7 @@ func (p *wsPool) Stream(
 	stream, err := sendOnExisting(p.conn.conn, params)
 	if err != nil {
 		// Connection is broken; tear down and reconnect once.
-		slog.Warn("Existing WebSocket connection failed, reconnecting", "error", err)
+		slog.WarnContext(ctx, "Existing WebSocket connection failed, reconnecting", "error", err)
 		p.closeLocked()
 		return p.dialLocked(ctx, params)
 	}

--- a/pkg/model/provider/openai/ws_stream.go
+++ b/pkg/model/provider/openai/ws_stream.go
@@ -93,7 +93,7 @@ func dialWebSocket(
 		HandshakeTimeout: wsHandshakeTimeout,
 	}
 
-	slog.Debug("Opening WebSocket connection", "url", wsURL)
+	slog.DebugContext(ctx, "Opening WebSocket connection", "url", wsURL)
 
 	conn, resp, err := dialer.DialContext(ctx, wsURL, headers)
 	if err != nil {
@@ -101,7 +101,7 @@ func dialWebSocket(
 			if resp.Body != nil {
 				_ = resp.Body.Close()
 			}
-			slog.Error("WebSocket handshake failed",
+			slog.ErrorContext(ctx, "WebSocket handshake failed",
 				"status", resp.StatusCode,
 				"error", err)
 		}
@@ -113,7 +113,7 @@ func dialWebSocket(
 		return nil, err
 	}
 
-	slog.Debug("WebSocket response.create sent", "url", wsURL)
+	slog.DebugContext(ctx, "WebSocket response.create sent", "url", wsURL)
 
 	return &wsStream{conn: conn}, nil
 }

--- a/pkg/model/provider/provider.go
+++ b/pkg/model/provider/provider.go
@@ -80,7 +80,7 @@ func New(ctx context.Context, cfg *latest.ModelConfig, env environment.Provider,
 // NewWithModels creates a new provider from a model config with access to the full models map.
 // The models map is used to resolve model references in routing rules.
 func NewWithModels(ctx context.Context, cfg *latest.ModelConfig, models map[string]latest.ModelConfig, env environment.Provider, opts ...options.Opt) (Provider, error) {
-	slog.Debug("Creating model provider", "type", cfg.Provider, "model", cfg.Model)
+	slog.DebugContext(ctx, "Creating model provider", "type", cfg.Provider, "model", cfg.Model)
 
 	// Check if this model has routing rules - if so, create a rule-based router
 	if len(cfg.Routing) > 0 {

--- a/pkg/model/provider/rulebased/client.go
+++ b/pkg/model/provider/rulebased/client.go
@@ -54,7 +54,7 @@ type Client struct {
 // The cfg parameter should have Routing rules configured. The provider/model
 // fields of cfg define the fallback model that is used when no routing rule matches.
 func NewClient(ctx context.Context, cfg *latest.ModelConfig, models map[string]latest.ModelConfig, env environment.Provider, providerFactory ProviderFactory, opts ...options.Opt) (*Client, error) {
-	slog.Debug("Creating rule-based router", "provider", cfg.Provider, "model", cfg.Model)
+	slog.DebugContext(ctx, "Creating rule-based router", "provider", cfg.Provider, "model", cfg.Model)
 
 	if len(cfg.Routing) == 0 {
 		return nil, errors.New("no routing rules configured")
@@ -171,7 +171,7 @@ func (c *Client) CreateChatCompletionStream(
 	c.mu.Lock()
 	c.lastSelectedID = selectedID
 	c.mu.Unlock()
-	slog.Debug("Rule-based router selected model",
+	slog.DebugContext(ctx, "Rule-based router selected model",
 		"router", c.ID(),
 		"selected_model", selectedID,
 		"message_count", len(messages),

--- a/pkg/model/provider/vertexai/modelgarden.go
+++ b/pkg/model/provider/vertexai/modelgarden.go
@@ -147,7 +147,7 @@ func newOpenAIClient(ctx context.Context, cfg *latest.ModelConfig, env environme
 	baseURL := "https://" + location + "-aiplatform.googleapis.com/v1beta1/projects/" +
 		url.PathEscape(project) + "/locations/" + url.PathEscape(location) + "/endpoints/openapi"
 
-	slog.Debug("Creating Vertex AI Model Garden client",
+	slog.DebugContext(ctx, "Creating Vertex AI Model Garden client",
 		"publisher", publisher(cfg),
 		"project", project,
 		"location", location,
@@ -213,7 +213,7 @@ func (e *tokenEnv) Get(ctx context.Context, name string) (string, bool) {
 
 	tok, err := e.ts.Token()
 	if err != nil {
-		slog.Warn("Failed to refresh GCP access token, using cached", "error", err)
+		slog.WarnContext(ctx, "Failed to refresh GCP access token, using cached", "error", err)
 		return e.tok, true
 	}
 	e.tok = tok.AccessToken

--- a/pkg/modelsdev/store.go
+++ b/pkg/modelsdev/store.go
@@ -148,7 +148,7 @@ func loadDatabase(ctx context.Context, cacheFile string) (*Database, error) {
 	if fetchErr != nil {
 		// If API fetch fails but we have cached data, use it regardless of age.
 		if cached != nil {
-			slog.Debug("API fetch failed, using stale cache", "error", fetchErr)
+			slog.DebugContext(ctx, "API fetch failed, using stale cache", "error", fetchErr)
 			return &cached.Database, nil
 		}
 		return nil, fmt.Errorf("failed to fetch from API and no cached data available: %w", fetchErr)
@@ -159,14 +159,14 @@ func loadDatabase(ctx context.Context, cacheFile string) (*Database, error) {
 		// Bump LastRefresh so we don't re-check until the next interval.
 		cached.LastRefresh = time.Now()
 		if saveErr := saveToCache(cacheFile, &cached.Database, cached.ETag); saveErr != nil {
-			slog.Warn("Failed to update cache timestamp", "error", saveErr)
+			slog.WarnContext(ctx, "Failed to update cache timestamp", "error", saveErr)
 		}
 		return &cached.Database, nil
 	}
 
 	// Save the fresh data to cache.
 	if saveErr := saveToCache(cacheFile, database, newETag); saveErr != nil {
-		slog.Warn("Failed to save to cache", "error", saveErr)
+		slog.WarnContext(ctx, "Failed to save to cache", "error", saveErr)
 	}
 
 	return database, nil
@@ -192,7 +192,7 @@ func fetchFromAPI(ctx context.Context, etag string) (*Database, string, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotModified {
-		slog.Debug("models.dev data not modified (304)")
+		slog.DebugContext(ctx, "models.dev data not modified (304)")
 		return nil, etag, nil
 	}
 

--- a/pkg/rag/builder.go
+++ b/pkg/rag/builder.go
@@ -79,7 +79,7 @@ func NewManager(
 	for i, sc := range strategyConfigs {
 		strategyNames[i] = sc.Name
 	}
-	slog.Debug("Created RAG manager",
+	slog.DebugContext(ctx, "Created RAG manager",
 		"name", ragName,
 		"strategies", strategyNames,
 		"docs", len(managerCfg.Docs))
@@ -103,20 +103,20 @@ func buildManagerConfig(
 
 	// Build reranking config if configured
 	if ragCfg.Results.Reranking != nil {
-		slog.Debug("Building reranking configuration",
+		slog.DebugContext(ctx, "Building reranking configuration",
 			"model", ragCfg.Results.Reranking.Model,
 			"top_k", ragCfg.Results.Reranking.TopK,
 			"threshold", ragCfg.Results.Reranking.Threshold)
 
 		rerankingCfg, err := buildRerankingConfig(ctx, ragCfg.Results.Reranking, buildCfg, results.Limit)
 		if err != nil {
-			slog.Error("Failed to build reranking config",
+			slog.ErrorContext(ctx, "Failed to build reranking config",
 				"model", ragCfg.Results.Reranking.Model,
 				"error", err)
 			return Config{}, fmt.Errorf("failed to build reranking config: %w", err)
 		}
 		results.RerankingConfig = rerankingCfg
-		slog.Debug("Reranking configuration built successfully",
+		slog.DebugContext(ctx, "Reranking configuration built successfully",
 			"model", ragCfg.Results.Reranking.Model)
 	}
 
@@ -147,38 +147,38 @@ func buildRerankingConfig(
 	}
 
 	if rerankCfg.Model == "" {
-		slog.Error("Reranking model name is empty")
+		slog.ErrorContext(ctx, "Reranking model name is empty")
 		return nil, errors.New("reranking model is required")
 	}
 
-	slog.Debug("Resolving reranking model",
+	slog.DebugContext(ctx, "Resolving reranking model",
 		"model_ref", rerankCfg.Model)
 
 	// Resolve model config - check if it's a reference to a defined model or inline
 	modelCfgVal, err := strategy.ResolveModelConfig(rerankCfg.Model, buildCfg.Models)
 	if err != nil {
-		slog.Error("Failed to resolve reranking model",
+		slog.ErrorContext(ctx, "Failed to resolve reranking model",
 			"model_ref", rerankCfg.Model,
 			"error", err)
 		return nil, fmt.Errorf("failed to resolve reranking model %q: %w", rerankCfg.Model, err)
 	}
 	modelCfg := &modelCfgVal
 
-	slog.Debug("Resolved reranking model config",
+	slog.DebugContext(ctx, "Resolved reranking model config",
 		"provider", modelCfg.Provider,
 		"model", modelCfg.Model)
 
 	// Create provider for reranking model
 	rerankProvider, err := buildCfg.NewProvider(ctx, modelCfg)
 	if err != nil {
-		slog.Error("Failed to create reranking provider",
+		slog.ErrorContext(ctx, "Failed to create reranking provider",
 			"provider", modelCfg.Provider,
 			"model", modelCfg.Model,
 			"error", err)
 		return nil, fmt.Errorf("failed to create reranking provider: %w", err)
 	}
 
-	slog.Debug("Created reranking provider",
+	slog.DebugContext(ctx, "Created reranking provider",
 		"provider_id", rerankProvider.ID())
 
 	// Determine effective TopK:
@@ -202,7 +202,7 @@ func buildRerankingConfig(
 		return nil, fmt.Errorf("failed to create reranker: %w", err)
 	}
 
-	slog.Info("Built reranking configuration successfully",
+	slog.InfoContext(ctx, "Built reranking configuration successfully",
 		"model", rerankCfg.Model,
 		"provider_id", rerankProvider.ID(),
 		"top_k", effectiveTopK,

--- a/pkg/rag/embed/embed.go
+++ b/pkg/rag/embed/embed.go
@@ -71,7 +71,7 @@ func (e *Embedder) Embed(ctx context.Context, text string) ([]float64, error) {
 			e.usageHandler(result.TotalTokens, result.Cost)
 		}
 
-		slog.Debug("Embedding generated",
+		slog.DebugContext(ctx, "Embedding generated",
 			"provider", e.provider.ID(),
 			"tokens", result.TotalTokens,
 			"cost", result.Cost)
@@ -97,7 +97,7 @@ func (e *Embedder) EmbedBatch(ctx context.Context, texts []string) ([][]float64,
 	}
 
 	// Fall back to sequential processing for providers without batch support
-	slog.Debug("Provider doesn't support batch embeddings, using sequential processing",
+	slog.DebugContext(ctx, "Provider doesn't support batch embeddings, using sequential processing",
 		"provider", e.provider.ID(),
 		"text_count", len(texts))
 
@@ -116,7 +116,7 @@ func (e *Embedder) EmbedBatch(ctx context.Context, texts []string) ([][]float64,
 // embedBatchOptimized processes texts in optimized batches with parallel API calls
 func (e *Embedder) embedBatchOptimized(ctx context.Context, batchProvider provider.BatchEmbeddingProvider, texts []string) ([][]float64, error) {
 	totalTexts := len(texts)
-	slog.Debug("Starting optimized batch embedding",
+	slog.DebugContext(ctx, "Starting optimized batch embedding",
 		"provider", e.provider.ID(),
 		"total_texts", totalTexts,
 		"batch_size", e.batchSize,
@@ -139,7 +139,7 @@ func (e *Embedder) embedBatchOptimized(ctx context.Context, batchProvider provid
 			batchNum := start/e.batchSize + 1
 			numBatches := (totalTexts + e.batchSize - 1) / e.batchSize
 
-			slog.Debug("Processing batch",
+			slog.DebugContext(ctx, "Processing batch",
 				"batch", batchNum,
 				"total_batches", numBatches,
 				"batch_size", len(batchTexts),
@@ -161,7 +161,7 @@ func (e *Embedder) embedBatchOptimized(ctx context.Context, batchProvider provid
 				e.usageHandler(result.TotalTokens, result.Cost)
 			}
 
-			slog.Debug("Batch completed",
+			slog.DebugContext(ctx, "Batch completed",
 				"batch", batchNum,
 				"embeddings", len(result.Embeddings),
 				"tokens", result.TotalTokens,
@@ -176,7 +176,7 @@ func (e *Embedder) embedBatchOptimized(ctx context.Context, batchProvider provid
 		return nil, err
 	}
 
-	slog.Debug("Batch embedding completed",
+	slog.DebugContext(ctx, "Batch embedding completed",
 		"provider", e.provider.ID(),
 		"total_embeddings", len(embeddings),
 		"batches_processed", (totalTexts+e.batchSize-1)/e.batchSize)

--- a/pkg/rag/manager.go
+++ b/pkg/rag/manager.go
@@ -144,7 +144,7 @@ func New(_ context.Context, name string, config Config, strategyEvents <-chan ty
 // Each strategy indexes its own document set (shared + strategy-specific)
 // Strategies are initialized in parallel for better performance
 func (m *Manager) Initialize(ctx context.Context) error {
-	slog.Debug("[RAG Manager] Starting initialization",
+	slog.DebugContext(ctx, "[RAG Manager] Starting initialization",
 		"rag_name", m.name,
 		"num_strategies", len(m.strategies))
 
@@ -160,7 +160,7 @@ func (m *Manager) Initialize(ctx context.Context) error {
 		strategyCfg := m.strategyConfigs[strategyName]
 
 		go func() {
-			slog.Debug("[RAG Manager] Initializing strategy",
+			slog.DebugContext(ctx, "[RAG Manager] Initializing strategy",
 				"rag_name", m.name,
 				"strategy", strategyName,
 				"num_docs", len(strategyCfg.Docs),
@@ -172,17 +172,17 @@ func (m *Manager) Initialize(ctx context.Context) error {
 			start := time.Now()
 			err := strategyImpl.Initialize(ctx, strategyCfg.Docs, strategyCfg.Chunking)
 			indexDuration := time.Since(start)
-			slog.Debug("[RAG Manager] Strategy indexing duration",
+			slog.DebugContext(ctx, "[RAG Manager] Strategy indexing duration",
 				"rag_name", m.name,
 				"strategy", strategyName,
 				"duration", indexDuration)
 			if err != nil {
-				slog.Error("[RAG Manager] Strategy initialization failed",
+				slog.ErrorContext(ctx, "[RAG Manager] Strategy initialization failed",
 					"rag_name", m.name,
 					"strategy", strategyName,
 					"error", err)
 			} else {
-				slog.Info("[RAG Manager] Strategy initialized successfully",
+				slog.InfoContext(ctx, "[RAG Manager] Strategy initialized successfully",
 					"rag_name", m.name,
 					"strategy", strategyName)
 			}
@@ -203,7 +203,7 @@ func (m *Manager) Initialize(ctx context.Context) error {
 		return fmt.Errorf("one or more strategies failed to initialize: %w", firstError)
 	}
 
-	slog.Info("[RAG Manager] Initialization complete",
+	slog.InfoContext(ctx, "[RAG Manager] Initialization complete",
 		"rag_name", m.name)
 
 	return nil
@@ -212,7 +212,7 @@ func (m *Manager) Initialize(ctx context.Context) error {
 // Query searches for relevant documents using all configured strategies
 // If multiple strategies are configured, results are combined using the fusion strategy
 func (m *Manager) Query(ctx context.Context, query string) ([]database.SearchResult, error) {
-	slog.Debug("[RAG Manager] Starting query",
+	slog.DebugContext(ctx, "[RAG Manager] Starting query",
 		"rag_name", m.name,
 		"num_strategies", len(m.strategies),
 		"query_length", len(query))
@@ -222,7 +222,7 @@ func (m *Manager) Query(ctx context.Context, query string) ([]database.SearchRes
 		for strategyName, strategyImpl := range m.strategies {
 			strategyCfg := m.strategyConfigs[strategyName]
 
-			slog.Debug("[RAG Manager] Single strategy query",
+			slog.DebugContext(ctx, "[RAG Manager] Single strategy query",
 				"rag_name", m.name,
 				"strategy", strategyName,
 				"strategy_limit", strategyCfg.Limit,
@@ -230,14 +230,14 @@ func (m *Manager) Query(ctx context.Context, query string) ([]database.SearchRes
 
 			results, err := strategyImpl.Query(ctx, query, strategyCfg.Limit, strategyCfg.Threshold)
 			if err != nil {
-				slog.Error("[RAG Manager] Strategy query failed",
+				slog.ErrorContext(ctx, "[RAG Manager] Strategy query failed",
 					"rag_name", m.name,
 					"strategy", strategyName,
 					"error", err)
 				return nil, err
 			}
 
-			slog.Debug("[RAG Manager] Single strategy results",
+			slog.DebugContext(ctx, "[RAG Manager] Single strategy results",
 				"rag_name", m.name,
 				"strategy", strategyName,
 				"num_results", len(results))
@@ -245,21 +245,21 @@ func (m *Manager) Query(ctx context.Context, query string) ([]database.SearchRes
 			// Apply reranking if configured
 			if m.reranker != nil {
 				beforeCount := len(results)
-				slog.Debug("[RAG Manager] Applying reranking to single-strategy results",
+				slog.DebugContext(ctx, "[RAG Manager] Applying reranking to single-strategy results",
 					"rag_name", m.name,
 					"strategy", strategyName,
 					"result_count_before", beforeCount)
 
 				rerankedResults, rerankErr := m.reranker.Rerank(ctx, query, results)
 				if rerankErr != nil {
-					slog.Warn("[RAG Manager] Reranking failed, using original results",
+					slog.WarnContext(ctx, "[RAG Manager] Reranking failed, using original results",
 						"rag_name", m.name,
 						"strategy", strategyName,
 						"error", rerankErr)
 					// Continue with original results rather than failing completely
 				} else {
 					results = rerankedResults
-					slog.Debug("[RAG Manager] Reranked single-strategy results",
+					slog.DebugContext(ctx, "[RAG Manager] Reranked single-strategy results",
 						"rag_name", m.name,
 						"strategy", strategyName,
 						"result_count_before", beforeCount,
@@ -269,7 +269,7 @@ func (m *Manager) Query(ctx context.Context, query string) ([]database.SearchRes
 			}
 
 			if limit := m.config.Results.Limit; limit > 0 && len(results) > limit {
-				slog.Debug("[RAG Manager] Truncating to global result limit",
+				slog.DebugContext(ctx, "[RAG Manager] Truncating to global result limit",
 					"rag_name", m.name,
 					"strategy", strategyName,
 					"before", len(results),
@@ -284,7 +284,7 @@ func (m *Manager) Query(ctx context.Context, query string) ([]database.SearchRes
 
 			if m.config.Results.Deduplicate {
 				results = m.deduplicateResults(results)
-				slog.Debug("[RAG Manager] Deduplicated single-strategy results",
+				slog.DebugContext(ctx, "[RAG Manager] Deduplicated single-strategy results",
 					"rag_name", m.name,
 					"strategy", strategyName,
 					"num_results", len(results))
@@ -295,7 +295,7 @@ func (m *Manager) Query(ctx context.Context, query string) ([]database.SearchRes
 	}
 
 	// Multi-strategy - query all in parallel with per-strategy limits, then fuse results
-	slog.Debug("[RAG Manager] Multi-strategy query (hybrid)",
+	slog.DebugContext(ctx, "[RAG Manager] Multi-strategy query (hybrid)",
 		"rag_name", m.name,
 		"strategies", getStrategyNames(m.strategies))
 
@@ -311,7 +311,7 @@ func (m *Manager) Query(ctx context.Context, query string) ([]database.SearchRes
 	for strategyName, strategyImpl := range m.strategies {
 		strategyCfg := m.strategyConfigs[strategyName]
 
-		slog.Debug("[RAG Manager] Launching parallel query for strategy",
+		slog.DebugContext(ctx, "[RAG Manager] Launching parallel query for strategy",
 			"rag_name", m.name,
 			"strategy", strategyName,
 			"strategy_limit", strategyCfg.Limit,
@@ -333,14 +333,14 @@ func (m *Manager) Query(ctx context.Context, query string) ([]database.SearchRes
 		result := <-resultsChan
 
 		if result.err != nil {
-			slog.Error("[RAG Manager] Strategy query failed",
+			slog.ErrorContext(ctx, "[RAG Manager] Strategy query failed",
 				"rag_name", m.name,
 				"strategy", result.name,
 				"error", result.err)
 			return nil, fmt.Errorf("strategy %s failed: %w", result.name, result.err)
 		}
 
-		slog.Debug("[RAG Manager] Strategy returned results",
+		slog.DebugContext(ctx, "[RAG Manager] Strategy returned results",
 			"rag_name", m.name,
 			"strategy", result.name,
 			"num_results", len(result.results),
@@ -350,7 +350,7 @@ func (m *Manager) Query(ctx context.Context, query string) ([]database.SearchRes
 	}
 
 	// Fuse results from all strategies
-	slog.Debug("[RAG Manager] Starting fusion",
+	slog.DebugContext(ctx, "[RAG Manager] Starting fusion",
 		"rag_name", m.name,
 		"num_strategies", len(strategyResults))
 
@@ -361,13 +361,13 @@ func (m *Manager) Query(ctx context.Context, query string) ([]database.SearchRes
 
 	fusedResults, err := m.fusion.Fuse(strategyResults)
 	if err != nil {
-		slog.Error("[RAG Manager] Fusion failed",
+		slog.ErrorContext(ctx, "[RAG Manager] Fusion failed",
 			"rag_name", m.name,
 			"error", err)
 		return nil, fmt.Errorf("failed to fuse results: %w", err)
 	}
 
-	slog.Debug("[RAG Manager] Fusion complete",
+	slog.DebugContext(ctx, "[RAG Manager] Fusion complete",
 		"rag_name", m.name,
 		"fused_results", len(fusedResults),
 		"result_limit", m.config.Results.Limit)
@@ -375,19 +375,19 @@ func (m *Manager) Query(ctx context.Context, query string) ([]database.SearchRes
 	// Apply reranking if configured (before limit and deduplication)
 	if m.reranker != nil {
 		beforeCount := len(fusedResults)
-		slog.Debug("[RAG Manager] Applying reranking to fused results",
+		slog.DebugContext(ctx, "[RAG Manager] Applying reranking to fused results",
 			"rag_name", m.name,
 			"result_count_before", beforeCount)
 
 		rerankedResults, rerankErr := m.reranker.Rerank(ctx, query, fusedResults)
 		if rerankErr != nil {
-			slog.Warn("[RAG Manager] Reranking failed, using original fused results",
+			slog.WarnContext(ctx, "[RAG Manager] Reranking failed, using original fused results",
 				"rag_name", m.name,
 				"error", rerankErr)
 			// Continue with original fused results rather than failing completely
 		} else {
 			fusedResults = rerankedResults
-			slog.Debug("[RAG Manager] Reranked fused results",
+			slog.DebugContext(ctx, "[RAG Manager] Reranked fused results",
 				"rag_name", m.name,
 				"result_count_before", beforeCount,
 				"result_count_after", len(fusedResults),
@@ -397,7 +397,7 @@ func (m *Manager) Query(ctx context.Context, query string) ([]database.SearchRes
 
 	// Apply result limit if configured
 	if limit := m.config.Results.Limit; limit > 0 && len(fusedResults) > limit {
-		slog.Debug("[RAG Manager] Truncating to result limit",
+		slog.DebugContext(ctx, "[RAG Manager] Truncating to result limit",
 			"rag_name", m.name,
 			"before", len(fusedResults),
 			"after", limit)
@@ -413,7 +413,7 @@ func (m *Manager) Query(ctx context.Context, query string) ([]database.SearchRes
 	// (full documents or chunks).
 	if m.config.Results.Deduplicate {
 		fusedResults = m.deduplicateResults(fusedResults)
-		slog.Debug("[RAG Manager] Deduplicated fused results",
+		slog.DebugContext(ctx, "[RAG Manager] Deduplicated fused results",
 			"rag_name", m.name,
 			"num_results", len(fusedResults))
 	}

--- a/pkg/rag/rerank/rerank.go
+++ b/pkg/rag/rerank/rerank.go
@@ -61,7 +61,7 @@ func (r *LLMReranker) Rerank(ctx context.Context, query string, results []databa
 		return results, nil
 	}
 
-	slog.Debug("[Reranker] Starting reranking",
+	slog.DebugContext(ctx, "[Reranker] Starting reranking",
 		"model_id", r.config.Model.ID(),
 		"query_length", len(query),
 		"num_results", len(results),
@@ -72,7 +72,7 @@ func (r *LLMReranker) Rerank(ctx context.Context, query string, results []databa
 	numToRerank := len(results)
 	if r.config.TopK > 0 && r.config.TopK < len(results) {
 		numToRerank = r.config.TopK
-		slog.Debug("[Reranker] TopK configured, limiting reranking",
+		slog.DebugContext(ctx, "[Reranker] TopK configured, limiting reranking",
 			"original_count", len(results),
 			"will_rerank", numToRerank)
 	}
@@ -80,7 +80,7 @@ func (r *LLMReranker) Rerank(ctx context.Context, query string, results []databa
 	// Get reranking provider that supports the reranking operation
 	rerankProvider, ok := r.config.Model.(provider.RerankingProvider)
 	if !ok {
-		slog.Error("[Reranker] Model does not support reranking",
+		slog.ErrorContext(ctx, "[Reranker] Model does not support reranking",
 			"model_id", r.config.Model.ID(),
 			"model_type", fmt.Sprintf("%T", r.config.Model))
 		return nil, fmt.Errorf("model %s does not support reranking operation", r.config.Model.ID())
@@ -107,7 +107,7 @@ func (r *LLMReranker) Rerank(ctx context.Context, query string, results []databa
 		totalContentLength += len(doc.Content)
 	}
 
-	slog.Debug("[Reranker] Prepared documents for reranking",
+	slog.DebugContext(ctx, "[Reranker] Prepared documents for reranking",
 		"num_documents", len(documents),
 		"total_content_length", totalContentLength,
 		"avg_doc_length", totalContentLength/len(documents))
@@ -115,7 +115,7 @@ func (r *LLMReranker) Rerank(ctx context.Context, query string, results []databa
 	// Call the reranking model with criteria
 	scores, err := rerankProvider.Rerank(ctx, query, documents, r.config.Criteria)
 	if err != nil {
-		slog.Error("[Reranker] Reranking call failed",
+		slog.ErrorContext(ctx, "[Reranker] Reranking call failed",
 			"model_id", r.config.Model.ID(),
 			"num_documents", len(documents),
 			"error", err)
@@ -123,7 +123,7 @@ func (r *LLMReranker) Rerank(ctx context.Context, query string, results []databa
 	}
 
 	if len(scores) != numToRerank {
-		slog.Error("[Reranker] Score count mismatch",
+		slog.ErrorContext(ctx, "[Reranker] Score count mismatch",
 			"expected", numToRerank,
 			"received", len(scores))
 		return nil, fmt.Errorf("reranking returned %d scores but expected %d", len(scores), numToRerank)
@@ -131,7 +131,7 @@ func (r *LLMReranker) Rerank(ctx context.Context, query string, results []databa
 
 	// Log score statistics
 	minScore, maxScore, avgScore := calculateScoreStats(scores)
-	slog.Debug("[Reranker] Received reranking scores",
+	slog.DebugContext(ctx, "[Reranker] Received reranking scores",
 		"num_scores", len(scores),
 		"min_score", minScore,
 		"max_score", maxScore,
@@ -144,7 +144,7 @@ func (r *LLMReranker) Rerank(ctx context.Context, query string, results []databa
 		// Apply minimum score threshold if configured
 		if r.config.Threshold > 0 && scores[i] < r.config.Threshold {
 			filteredCount++
-			slog.Debug("[Reranker] Filtering result below threshold",
+			slog.DebugContext(ctx, "[Reranker] Filtering result below threshold",
 				"index", i,
 				"original_score", results[i].Similarity,
 				"rerank_score", scores[i],
@@ -155,7 +155,7 @@ func (r *LLMReranker) Rerank(ctx context.Context, query string, results []databa
 
 		// Log score changes for top results
 		if i < 5 {
-			slog.Debug("[Reranker] Score update",
+			slog.DebugContext(ctx, "[Reranker] Score update",
 				"index", i,
 				"original_score", results[i].Similarity,
 				"rerank_score", scores[i],
@@ -170,7 +170,7 @@ func (r *LLMReranker) Rerank(ctx context.Context, query string, results []databa
 	}
 
 	if filteredCount > 0 {
-		slog.Debug("[Reranker] Filtered results below threshold",
+		slog.DebugContext(ctx, "[Reranker] Filtered results below threshold",
 			"filtered_count", filteredCount,
 			"threshold", r.config.Threshold)
 	}
@@ -178,7 +178,7 @@ func (r *LLMReranker) Rerank(ctx context.Context, query string, results []databa
 	// Add any remaining results that weren't reranked (if TopK was used)
 	if numToRerank < len(results) {
 		notRerankedCount := len(results) - numToRerank
-		slog.Debug("[Reranker] Adding unranked results",
+		slog.DebugContext(ctx, "[Reranker] Adding unranked results",
 			"count", notRerankedCount)
 		rerankedResults = append(rerankedResults, results[numToRerank:]...)
 	}
@@ -193,7 +193,7 @@ func (r *LLMReranker) Rerank(ctx context.Context, query string, results []databa
 
 	if len(rerankedResults) > 0 {
 		finalMinScore, finalMaxScore, finalAvgScore := calculateScoreStats(extractScores(rerankedResults))
-		slog.Debug("[Reranker] Reranking complete",
+		slog.DebugContext(ctx, "[Reranker] Reranking complete",
 			"input_count", len(results),
 			"reranked_count", numToRerank,
 			"filtered_count", numToRerank-len(rerankedResults)+(len(results)-numToRerank),
@@ -203,7 +203,7 @@ func (r *LLMReranker) Rerank(ctx context.Context, query string, results []databa
 			"final_avg_score", finalAvgScore,
 			"duration_ms", totalDuration.Milliseconds())
 	} else {
-		slog.Debug("[Reranker] Reranking complete",
+		slog.DebugContext(ctx, "[Reranker] Reranking complete",
 			"input_count", len(results),
 			"reranked_count", numToRerank,
 			"output_count", len(rerankedResults),

--- a/pkg/rag/strategy/bm25.go
+++ b/pkg/rag/strategy/bm25.go
@@ -142,7 +142,7 @@ func newBM25Strategy(name string, db *bm25DB, events chan<- types.Event, k1, b f
 
 // Initialize indexes all documents for BM25 retrieval
 func (s *BM25Strategy) Initialize(ctx context.Context, docPaths []string, chunking ChunkingConfig) error {
-	slog.Info("Starting BM25 strategy initialization",
+	slog.InfoContext(ctx, "Starting BM25 strategy initialization",
 		"name", s.name,
 		"doc_paths", docPaths,
 		"chunk_size", chunking.Size,
@@ -150,13 +150,13 @@ func (s *BM25Strategy) Initialize(ctx context.Context, docPaths []string, chunki
 		"respect_word_boundaries", chunking.RespectWordBoundaries)
 
 	// Load existing file hashes
-	slog.Debug("Loading existing file hashes", "strategy", s.name)
+	slog.DebugContext(ctx, "Loading existing file hashes", "strategy", s.name)
 	if err := s.loadExistingHashes(ctx); err != nil {
-		slog.Warn("Failed to load existing file hashes", "strategy", s.name, "error", err)
+		slog.WarnContext(ctx, "Failed to load existing file hashes", "strategy", s.name, "error", err)
 	}
 
 	// Collect all files
-	slog.Debug("Collecting files", "strategy", s.name, "paths", docPaths)
+	slog.DebugContext(ctx, "Collecting files", "strategy", s.name, "paths", docPaths)
 	files, err := fsx.CollectFiles(ctx, docPaths, s.shouldIgnore)
 	if err != nil {
 		s.emitEvent(types.Event{Type: types.EventTypeError, Error: err})
@@ -175,11 +175,11 @@ func (s *BM25Strategy) Initialize(ctx context.Context, docPaths []string, chunki
 	}
 
 	if err := s.cleanupOrphanedDocuments(ctx, seenFilesForCleanup); err != nil {
-		slog.Error("Failed to cleanup orphaned documents", "error", err)
+		slog.ErrorContext(ctx, "Failed to cleanup orphaned documents", "error", err)
 	}
 
 	if len(files) == 0 {
-		slog.Warn("No files found for BM25 strategy", "name", s.name)
+		slog.WarnContext(ctx, "No files found for BM25 strategy", "name", s.name)
 		return nil
 	}
 
@@ -205,7 +205,7 @@ func (s *BM25Strategy) Initialize(ctx context.Context, docPaths []string, chunki
 
 		needsIndexing, err := s.needsIndexing(ctx, filePath)
 		if err != nil {
-			slog.Error("Failed to check if file needs indexing", "path", filePath, "error", err)
+			slog.ErrorContext(ctx, "Failed to check if file needs indexing", "path", filePath, "error", err)
 			fileStatuses = append(fileStatuses, fileStatus{path: filePath, needsIndexing: false})
 			continue
 		}
@@ -217,7 +217,7 @@ func (s *BM25Strategy) Initialize(ctx context.Context, docPaths []string, chunki
 	}
 
 	if filesToIndex == 0 {
-		slog.Info("All files up to date, no indexing needed", "name", s.name)
+		slog.InfoContext(ctx, "All files up to date, no indexing needed", "name", s.name)
 		return nil
 	}
 
@@ -246,23 +246,23 @@ func (s *BM25Strategy) Initialize(ctx context.Context, docPaths []string, chunki
 		})
 
 		if err := s.indexFile(ctx, status.path); err != nil {
-			slog.Error("Failed to index file", "path", status.path, "error", err)
+			slog.ErrorContext(ctx, "Failed to index file", "path", status.path, "error", err)
 			continue
 		}
 	}
 
 	if err := s.cleanupOrphanedDocuments(ctx, seenFiles); err != nil {
-		slog.Error("Failed to cleanup orphaned documents", "error", err)
+		slog.ErrorContext(ctx, "Failed to cleanup orphaned documents", "error", err)
 	}
 
 	// Calculate average document length for BM25
 	if err := s.calculateAvgDocLength(ctx); err != nil {
-		slog.Error("Failed to calculate average document length", "error", err)
+		slog.ErrorContext(ctx, "Failed to calculate average document length", "error", err)
 	}
 
 	s.emitEvent(types.Event{Type: types.EventTypeIndexingComplete})
 
-	slog.Info("BM25 strategy initialization completed",
+	slog.InfoContext(ctx, "BM25 strategy initialization completed",
 		"name", s.name,
 		"indexed", indexed)
 
@@ -356,25 +356,25 @@ func (s *BM25Strategy) CheckAndReindexChangedFiles(ctx context.Context, docPaths
 
 		needsIndexing, err := s.needsIndexing(ctx, filePath)
 		if err != nil {
-			slog.Error("Failed to check if file needs indexing", "path", filePath, "error", err)
+			slog.ErrorContext(ctx, "Failed to check if file needs indexing", "path", filePath, "error", err)
 			continue
 		}
 
 		if needsIndexing {
-			slog.Info("File changed, re-indexing", "path", filePath)
+			slog.InfoContext(ctx, "File changed, re-indexing", "path", filePath)
 			if err := s.indexFile(ctx, filePath); err != nil {
-				slog.Error("Failed to re-index file", "path", filePath, "error", err)
+				slog.ErrorContext(ctx, "Failed to re-index file", "path", filePath, "error", err)
 			}
 		}
 	}
 
 	if err := s.cleanupOrphanedDocuments(ctx, seenFiles); err != nil {
-		slog.Error("Failed to cleanup orphaned documents", "error", err)
+		slog.ErrorContext(ctx, "Failed to cleanup orphaned documents", "error", err)
 	}
 
 	// Recalculate average document length
 	if err := s.calculateAvgDocLength(ctx); err != nil {
-		slog.Error("Failed to recalculate average document length", "error", err)
+		slog.ErrorContext(ctx, "Failed to recalculate average document length", "error", err)
 	}
 
 	return nil
@@ -393,14 +393,14 @@ func (s *BM25Strategy) StartFileWatcher(ctx context.Context, docPaths []string, 
 
 	for _, docPath := range docPaths {
 		if err := s.addPathToWatcher(ctx, docPath); err != nil {
-			slog.Warn("Failed to watch path", "strategy", s.name, "path", docPath, "error", err)
+			slog.WarnContext(ctx, "Failed to watch path", "strategy", s.name, "path", docPath, "error", err)
 			continue
 		}
 	}
 
 	go s.watchLoop(ctx, docPaths)
 
-	slog.Info("File watcher started", "strategy", s.name)
+	slog.InfoContext(ctx, "File watcher started", "strategy", s.name)
 	return nil
 }
 
@@ -510,7 +510,7 @@ func (s *BM25Strategy) calculateAvgDocLength(ctx context.Context) error {
 	}
 
 	s.avgDocLength = float64(totalLength) / float64(len(docs))
-	slog.Debug("Calculated average document length",
+	slog.DebugContext(ctx, "Calculated average document length",
 		"strategy", s.name,
 		"avgLength", s.avgDocLength,
 		"docCount", len(docs))
@@ -598,7 +598,7 @@ func (s *BM25Strategy) indexFile(ctx context.Context, filePath string) error {
 	}
 
 	s.fileHashes[filePath] = fileHash
-	slog.Debug("Indexed file with BM25", "path", filePath, "chunks", storedChunks)
+	slog.DebugContext(ctx, "Indexed file with BM25", "path", filePath, "chunks", storedChunks)
 	return nil
 }
 
@@ -618,12 +618,12 @@ func (s *BM25Strategy) cleanupOrphanedDocuments(ctx context.Context, seenFiles m
 
 		if !seenFiles[meta.SourcePath] {
 			if err := s.db.DeleteDocumentsByPath(ctx, meta.SourcePath); err != nil {
-				slog.Error("Failed to delete orphaned documents", "path", meta.SourcePath, "error", err)
+				slog.ErrorContext(ctx, "Failed to delete orphaned documents", "path", meta.SourcePath, "error", err)
 				continue
 			}
 
 			if err := s.db.DeleteFileMetadata(ctx, meta.SourcePath); err != nil {
-				slog.Error("Failed to delete orphaned metadata", "path", meta.SourcePath, "error", err)
+				slog.ErrorContext(ctx, "Failed to delete orphaned metadata", "path", meta.SourcePath, "error", err)
 				continue
 			}
 
@@ -710,7 +710,7 @@ func (s *BM25Strategy) watchLoop(ctx context.Context, docPaths []string) {
 			// Check if the file matches any of the configured document paths/patterns
 			matches, matchErr := fsx.Matches(file, docPaths)
 			if matchErr != nil {
-				slog.Error("Failed to match path", "file", file, "error", matchErr)
+				slog.ErrorContext(ctx, "Failed to match path", "file", file, "error", matchErr)
 				continue
 			}
 			if !matches {
@@ -718,7 +718,7 @@ func (s *BM25Strategy) watchLoop(ctx context.Context, docPaths []string) {
 			}
 			// Check if the file should be ignored (e.g., gitignore)
 			if s.shouldIgnore != nil && s.shouldIgnore(file) {
-				slog.Debug("File changed but is ignored by filter, skipping", "path", file)
+				slog.DebugContext(ctx, "File changed but is ignored by filter, skipping", "path", file)
 				continue
 			}
 
@@ -727,9 +727,9 @@ func (s *BM25Strategy) watchLoop(ctx context.Context, docPaths []string) {
 				continue
 			}
 
-			slog.Debug("Indexing file", "path", file, "strategy", s.name)
+			slog.DebugContext(ctx, "Indexing file", "path", file, "strategy", s.name)
 			if err := s.indexFile(ctx, file); err != nil {
-				slog.Error("Failed to re-index file", "path", file, "error", err)
+				slog.ErrorContext(ctx, "Failed to re-index file", "path", file, "error", err)
 			}
 		}
 
@@ -784,7 +784,7 @@ func (s *BM25Strategy) watchLoop(ctx context.Context, docPaths []string) {
 			if !ok {
 				return
 			}
-			slog.Error("File watcher error", "strategy", s.name, "error", err)
+			slog.ErrorContext(ctx, "File watcher error", "strategy", s.name, "error", err)
 		}
 	}
 }

--- a/pkg/rag/strategy/embedding.go
+++ b/pkg/rag/strategy/embedding.go
@@ -57,7 +57,7 @@ func CreateEmbeddingProvider(ctx context.Context, modelName string, buildCtx Bui
 	// Create models.dev store for pricing
 	modelsStore, err := modelsdev.NewStore()
 	if err != nil {
-		slog.Debug("Failed to create models.dev store for RAG pricing; cost tracking disabled",
+		slog.DebugContext(ctx, "Failed to create models.dev store for RAG pricing; cost tracking disabled",
 			"error", err)
 	}
 

--- a/pkg/rag/strategy/semantic_embeddings.go
+++ b/pkg/rag/strategy/semantic_embeddings.go
@@ -113,7 +113,7 @@ func NewSemanticEmbeddingsFromConfig(ctx context.Context, cfg latest.RAGStrategy
 	semanticPrompt := GetParam(cfg.Params, "semantic_prompt", defaultSemanticPrompt())
 	useASTContext := GetParam(cfg.Params, "ast_context", false)
 	if useASTContext && !cfg.Chunking.CodeAware {
-		slog.Warn("semantic-embeddings ast_context is enabled but chunking.code_aware is false; AST metadata may be unavailable",
+		slog.WarnContext(ctx, "semantic-embeddings ast_context is enabled but chunking.code_aware is false; AST metadata may be unavailable",
 			"rag", buildCtx.RAGName)
 	}
 
@@ -304,7 +304,7 @@ func (b *llmSemanticEmbeddingBuilder) BuildEmbeddingInput(ctx context.Context, s
 
 	if summary == "" {
 		// If the semantic model returns no content, fall back to truncated chunk
-		slog.Warn("Semantic model returned empty summary; falling back to truncated chunk content",
+		slog.WarnContext(ctx, "Semantic model returned empty summary; falling back to truncated chunk content",
 			"path", sourcePath,
 			"chunk_index", ch.Index,
 			"original_length", len(ch.Content))
@@ -312,7 +312,7 @@ func (b *llmSemanticEmbeddingBuilder) BuildEmbeddingInput(ctx context.Context, s
 		fallback := ch.Content
 		if len(fallback) > maxEmbeddingInputLength {
 			fallback = fallback[:maxEmbeddingInputLength] + "..."
-			slog.Debug("Truncated fallback content to fit embedding model limits",
+			slog.DebugContext(ctx, "Truncated fallback content to fit embedding model limits",
 				"original_length", len(ch.Content),
 				"truncated_length", len(fallback))
 		}
@@ -326,7 +326,7 @@ func (b *llmSemanticEmbeddingBuilder) BuildEmbeddingInput(ctx context.Context, s
 
 	// Truncate if embedding input is unexpectedly long
 	if len(embeddingInput) > maxEmbeddingInputLength {
-		slog.Warn("Semantic embedding input exceeds model limits; truncating",
+		slog.WarnContext(ctx, "Semantic embedding input exceeds model limits; truncating",
 			"path", sourcePath,
 			"chunk_index", ch.Index,
 			"original_length", len(embeddingInput),
@@ -334,7 +334,7 @@ func (b *llmSemanticEmbeddingBuilder) BuildEmbeddingInput(ctx context.Context, s
 		embeddingInput = embeddingInput[:maxEmbeddingInputLength] + "..."
 	}
 
-	slog.Debug("Generated semantic embedding input for chunk",
+	slog.DebugContext(ctx, "Generated semantic embedding input for chunk",
 		"path", sourcePath,
 		"chunk_index", ch.Index,
 		"embedding_input", embeddingInput)

--- a/pkg/rag/strategy/vector_store.go
+++ b/pkg/rag/strategy/vector_store.go
@@ -216,7 +216,7 @@ func (s *VectorStore) recordUsage(tokens int64, cost float64) {
 
 // Initialize indexes all documents
 func (s *VectorStore) Initialize(ctx context.Context, docPaths []string, chunking ChunkingConfig) error {
-	slog.Info("Starting vector store initialization",
+	slog.InfoContext(ctx, "Starting vector store initialization",
 		"name", s.name,
 		"doc_paths", docPaths,
 		"chunk_size", chunking.Size,
@@ -225,13 +225,13 @@ func (s *VectorStore) Initialize(ctx context.Context, docPaths []string, chunkin
 		"code_aware", chunking.CodeAware)
 
 	// Load existing file hashes from metadata
-	slog.Debug("Loading existing file hashes", "strategy", s.name)
+	slog.DebugContext(ctx, "Loading existing file hashes", "strategy", s.name)
 	if err := s.loadExistingHashes(ctx); err != nil {
-		slog.Warn("Failed to load existing file hashes", "strategy", s.name, "error", err)
+		slog.WarnContext(ctx, "Failed to load existing file hashes", "strategy", s.name, "error", err)
 	}
 
 	// Collect all files
-	slog.Debug("Collecting files", "strategy", s.name, "paths", docPaths)
+	slog.DebugContext(ctx, "Collecting files", "strategy", s.name, "paths", docPaths)
 	files, err := fsx.CollectFiles(ctx, docPaths, s.shouldIgnore)
 	if err != nil {
 		s.emitEvent(types.Event{Type: types.EventTypeError, Error: err})
@@ -252,15 +252,15 @@ func (s *VectorStore) Initialize(ctx context.Context, docPaths []string, chunkin
 
 	// Clean up orphaned documents
 	if err := s.cleanupOrphanedDocuments(ctx, seenFilesForCleanup); err != nil {
-		slog.Error("Failed to cleanup orphaned documents during initialization", "error", err)
+		slog.ErrorContext(ctx, "Failed to cleanup orphaned documents during initialization", "error", err)
 	}
 
 	if len(files) == 0 {
-		slog.Warn("No files found for vector store", "name", s.name, "paths", docPaths)
+		slog.WarnContext(ctx, "No files found for vector store", "name", s.name, "paths", docPaths)
 		return nil
 	}
 
-	slog.Debug("Collected files for indexing check",
+	slog.DebugContext(ctx, "Collected files for indexing check",
 		"strategy", s.name,
 		"file_count", len(files))
 
@@ -286,7 +286,7 @@ func (s *VectorStore) Initialize(ctx context.Context, docPaths []string, chunkin
 
 		needsIndexing, err := s.needsIndexing(ctx, filePath)
 		if err != nil {
-			slog.Error("Failed to check if file needs indexing",
+			slog.ErrorContext(ctx, "Failed to check if file needs indexing",
 				"path", filePath, "error", err)
 			fileStatuses = append(fileStatuses, fileStatus{path: filePath, needsIndexing: false})
 			continue
@@ -299,7 +299,7 @@ func (s *VectorStore) Initialize(ctx context.Context, docPaths []string, chunkin
 	}
 
 	if filesToIndex == 0 {
-		slog.Info("All files up to date, no indexing needed",
+		slog.InfoContext(ctx, "All files up to date, no indexing needed",
 			"name", s.name,
 			"total_files", len(files))
 		return nil
@@ -316,7 +316,7 @@ func (s *VectorStore) Initialize(ctx context.Context, docPaths []string, chunkin
 
 	for _, status := range fileStatuses {
 		if !status.needsIndexing {
-			slog.Debug("File unchanged, skipping", "path", status.path)
+			slog.DebugContext(ctx, "File unchanged, skipping", "path", status.path)
 			continue
 		}
 
@@ -330,7 +330,7 @@ func (s *VectorStore) Initialize(ctx context.Context, docPaths []string, chunkin
 
 			// Index the file
 			if err := s.indexFile(gctx, status.path); err != nil {
-				slog.Error("Failed to index file", "path", status.path, "error", err)
+				slog.ErrorContext(ctx, "Failed to index file", "path", status.path, "error", err)
 				// Don't return error - continue indexing other files
 				return nil
 			}
@@ -360,12 +360,12 @@ func (s *VectorStore) Initialize(ctx context.Context, docPaths []string, chunkin
 	}
 
 	if err := s.cleanupOrphanedDocuments(ctx, seenFiles); err != nil {
-		slog.Error("Failed to cleanup orphaned documents", "error", err)
+		slog.ErrorContext(ctx, "Failed to cleanup orphaned documents", "error", err)
 	}
 
 	s.emitEvent(types.Event{Type: types.EventTypeIndexingComplete})
 
-	slog.Info("Vector store initialization completed",
+	slog.InfoContext(ctx, "Vector store initialization completed",
 		"name", s.name,
 		"total_files", len(files),
 		"indexed", indexed,
@@ -422,20 +422,20 @@ func (s *VectorStore) CheckAndReindexChangedFiles(ctx context.Context, docPaths 
 
 		needsIndexing, err := s.needsIndexing(ctx, filePath)
 		if err != nil {
-			slog.Error("Failed to check if file needs indexing", "path", filePath, "error", err)
+			slog.ErrorContext(ctx, "Failed to check if file needs indexing", "path", filePath, "error", err)
 			continue
 		}
 
 		if needsIndexing {
-			slog.Info("File changed, re-indexing", "path", filePath)
+			slog.InfoContext(ctx, "File changed, re-indexing", "path", filePath)
 			if err := s.indexFile(ctx, filePath); err != nil {
-				slog.Error("Failed to re-index file", "path", filePath, "error", err)
+				slog.ErrorContext(ctx, "Failed to re-index file", "path", filePath, "error", err)
 			}
 		}
 	}
 
 	if err := s.cleanupOrphanedDocuments(ctx, seenFiles); err != nil {
-		slog.Error("Failed to cleanup orphaned documents during file watch", "error", err)
+		slog.ErrorContext(ctx, "Failed to cleanup orphaned documents during file watch", "error", err)
 	}
 
 	return nil
@@ -454,15 +454,15 @@ func (s *VectorStore) StartFileWatcher(ctx context.Context, docPaths []string, c
 
 	for _, docPath := range docPaths {
 		if err := s.addPathToWatcher(ctx, docPath); err != nil {
-			slog.Warn("Failed to watch path", "strategy", s.name, "path", docPath, "error", err)
+			slog.WarnContext(ctx, "Failed to watch path", "strategy", s.name, "path", docPath, "error", err)
 			continue
 		}
-		slog.Debug("Watching path for changes", "strategy", s.name, "path", docPath)
+		slog.DebugContext(ctx, "Watching path for changes", "strategy", s.name, "path", docPath)
 	}
 
 	go s.watchLoop(ctx, docPaths)
 
-	slog.Info("File watcher started", "strategy", s.name, "paths", docPaths)
+	slog.InfoContext(ctx, "File watcher started", "strategy", s.name, "paths", docPaths)
 	return nil
 }
 
@@ -513,12 +513,12 @@ func (s *VectorStore) loadExistingHashes(ctx context.Context) error {
 
 	for _, meta := range metadata {
 		s.fileHashes[meta.SourcePath] = meta.FileHash
-		slog.Debug("Loaded file hash from metadata",
+		slog.DebugContext(ctx, "Loaded file hash from metadata",
 			"path", meta.SourcePath,
 			"hash", meta.FileHash)
 	}
 
-	slog.Debug("Loaded existing file hashes from metadata",
+	slog.DebugContext(ctx, "Loaded existing file hashes from metadata",
 		"strategy", s.name,
 		"count", len(s.fileHashes))
 
@@ -580,7 +580,7 @@ func (s *VectorStore) indexFile(ctx context.Context, filePath string) error {
 	}
 
 	if len(validChunks) == 0 {
-		slog.Debug("No valid chunks in file", "path", filePath)
+		slog.DebugContext(ctx, "No valid chunks in file", "path", filePath)
 		return nil
 	}
 
@@ -591,7 +591,7 @@ func (s *VectorStore) indexFile(ctx context.Context, filePath string) error {
 	}
 
 	// Generate embeddings for all chunks in batch
-	slog.Debug("Generating embeddings for file",
+	slog.DebugContext(ctx, "Generating embeddings for file",
 		"path", filePath,
 		"chunk_count", len(validChunks))
 
@@ -645,7 +645,7 @@ func (s *VectorStore) indexFile(ctx context.Context, filePath string) error {
 	s.fileHashes[filePath] = fileHash
 	s.fileHashesMu.Unlock()
 
-	slog.Debug("Indexed file", "path", filePath, "chunks", storedChunks)
+	slog.DebugContext(ctx, "Indexed file", "path", filePath, "chunks", storedChunks)
 	return nil
 }
 
@@ -676,7 +676,7 @@ func (s *VectorStore) buildEmbeddingInputs(ctx context.Context, filePath string,
 
 				text, berr := s.embeddingInputBuilder.BuildEmbeddingInput(gctx, filePath, ch)
 				if berr != nil || strings.TrimSpace(text) == "" {
-					slog.Warn("Embedding input builder failed; falling back to raw chunk content",
+					slog.WarnContext(ctx, "Embedding input builder failed; falling back to raw chunk content",
 						"strategy", s.name,
 						"path", filePath,
 						"chunk_index", ch.Index,
@@ -702,7 +702,7 @@ func (s *VectorStore) buildEmbeddingInputs(ctx context.Context, filePath string,
 
 			text, berr := s.embeddingInputBuilder.BuildEmbeddingInput(ctx, filePath, ch)
 			if berr != nil || strings.TrimSpace(text) == "" {
-				slog.Warn("Embedding input builder failed; falling back to raw chunk content",
+				slog.WarnContext(ctx, "Embedding input builder failed; falling back to raw chunk content",
 					"strategy", s.name,
 					"path", filePath,
 					"chunk_index", ch.Index,
@@ -735,16 +735,16 @@ func (s *VectorStore) cleanupOrphanedDocuments(ctx context.Context, seenFiles ma
 			continue
 		}
 
-		slog.Info("Removing embeddings of orphaned documents", "path", meta.SourcePath)
+		slog.InfoContext(ctx, "Removing embeddings of orphaned documents", "path", meta.SourcePath)
 
 		if err := s.db.DeleteDocumentsByPath(ctx, meta.SourcePath); err != nil {
-			slog.Error("Failed to delete orphaned documents",
+			slog.ErrorContext(ctx, "Failed to delete orphaned documents",
 				"path", meta.SourcePath, "error", err)
 			continue
 		}
 
 		if err := s.db.DeleteFileMetadata(ctx, meta.SourcePath); err != nil {
-			slog.Error("Failed to delete orphaned metadata",
+			slog.ErrorContext(ctx, "Failed to delete orphaned metadata",
 				"path", meta.SourcePath, "error", err)
 			continue
 		}
@@ -757,7 +757,7 @@ func (s *VectorStore) cleanupOrphanedDocuments(ctx context.Context, seenFiles ma
 	}
 
 	if deletedCount > 0 {
-		slog.Info("Cleaned up orphaned documents", "strategy", s.name, "count", deletedCount)
+		slog.InfoContext(ctx, "Cleaned up orphaned documents", "strategy", s.name, "count", deletedCount)
 	}
 
 	return nil
@@ -771,7 +771,7 @@ func (s *VectorStore) addPathToWatcher(ctx context.Context, path string) error {
 	}
 
 	if len(files) == 0 {
-		slog.Debug("No files found to watch", "path", path)
+		slog.DebugContext(ctx, "No files found to watch", "path", path)
 		return nil
 	}
 
@@ -781,10 +781,10 @@ func (s *VectorStore) addPathToWatcher(ctx context.Context, path string) error {
 		dir := filepath.Dir(file)
 		if !watchedDirs[dir] {
 			if err := s.watcher.Add(dir); err != nil {
-				slog.Warn("Failed to watch directory", "dir", dir, "error", err)
+				slog.WarnContext(ctx, "Failed to watch directory", "dir", dir, "error", err)
 			} else {
 				watchedDirs[dir] = true
-				slog.Debug("Added directory to watcher", "dir", dir)
+				slog.DebugContext(ctx, "Added directory to watcher", "dir", dir)
 			}
 		}
 	}
@@ -830,7 +830,7 @@ func (s *VectorStore) watchLoop(ctx context.Context, docPaths []string) {
 	processChanges := func() {
 		// Prevent concurrent reindexing operations
 		if !s.reindexMu.TryLock() {
-			slog.Debug("Skipping file change processing - reindexing already in progress", "strategy", s.name)
+			slog.DebugContext(ctx, "Skipping file change processing - reindexing already in progress", "strategy", s.name)
 			return
 		}
 		defer s.reindexMu.Unlock()
@@ -847,7 +847,7 @@ func (s *VectorStore) watchLoop(ctx context.Context, docPaths []string) {
 			return
 		}
 
-		slog.Info("Processing file changes", "strategy", s.name, "count", len(changedFiles))
+		slog.InfoContext(ctx, "Processing file changes", "strategy", s.name, "count", len(changedFiles))
 
 		filesToReindex := make([]string, 0)
 		for _, file := range changedFiles {
@@ -861,22 +861,22 @@ func (s *VectorStore) watchLoop(ctx context.Context, docPaths []string) {
 			// Check if the file matches any of the configured document paths/patterns
 			matches, matchErr := fsx.Matches(file, docPaths)
 			if matchErr != nil {
-				slog.Error("Failed to match path", "file", file, "error", matchErr)
+				slog.ErrorContext(ctx, "Failed to match path", "file", file, "error", matchErr)
 				continue
 			}
 			if !matches {
-				slog.Debug("File changed but does not match configured docs, ignoring", "path", file)
+				slog.DebugContext(ctx, "File changed but does not match configured docs, ignoring", "path", file)
 				continue
 			}
 			// Check if the file should be ignored (e.g., gitignore)
 			if s.shouldIgnore != nil && s.shouldIgnore(file) {
-				slog.Debug("File changed but is ignored by filter, skipping", "path", file)
+				slog.DebugContext(ctx, "File changed but is ignored by filter, skipping", "path", file)
 				continue
 			}
 
 			needsIndexing, err := s.needsIndexing(ctx, file)
 			if err != nil {
-				slog.Debug("File no longer exists or inaccessible", "path", file, "error", err)
+				slog.DebugContext(ctx, "File no longer exists or inaccessible", "path", file, "error", err)
 				continue
 			}
 			if needsIndexing {
@@ -894,7 +894,7 @@ func (s *VectorStore) watchLoop(ctx context.Context, docPaths []string) {
 				// Check for context cancellation
 				select {
 				case <-ctx.Done():
-					slog.Info("File watcher stopped during reindexing due to context cancellation", "strategy", s.name)
+					slog.InfoContext(ctx, "File watcher stopped during reindexing due to context cancellation", "strategy", s.name)
 					return
 				default:
 				}
@@ -909,7 +909,7 @@ func (s *VectorStore) watchLoop(ctx context.Context, docPaths []string) {
 				})
 
 				if err := s.indexFile(ctx, file); err != nil {
-					slog.Error("Failed to re-index file", "path", file, "error", err)
+					slog.ErrorContext(ctx, "Failed to re-index file", "path", file, "error", err)
 					s.emitEvent(types.Event{
 						Type:    "error",
 						Message: "Failed to re-index: " + filepath.Base(file),
@@ -919,7 +919,7 @@ func (s *VectorStore) watchLoop(ctx context.Context, docPaths []string) {
 			}
 
 			if err := s.cleanupOrphanedDocumentsFromDisk(ctx, docPaths); err != nil {
-				slog.Error("Failed to cleanup orphaned documents", "error", err)
+				slog.ErrorContext(ctx, "Failed to cleanup orphaned documents", "error", err)
 			}
 
 			s.emitEvent(types.Event{
@@ -935,7 +935,7 @@ func (s *VectorStore) watchLoop(ctx context.Context, docPaths []string) {
 			if debounceTimer != nil {
 				debounceTimer.Stop()
 			}
-			slog.Info("File watcher stopped", "strategy", s.name)
+			slog.InfoContext(ctx, "File watcher stopped", "strategy", s.name)
 			return
 
 		case event, ok := <-watcher.Events:
@@ -951,7 +951,7 @@ func (s *VectorStore) watchLoop(ctx context.Context, docPaths []string) {
 				s.watcherMu.Lock()
 				if s.watcher != nil {
 					if err := s.addPathToWatcher(ctx, event.Name); err != nil {
-						slog.Debug("Could not watch new path", "path", event.Name, "error", err)
+						slog.DebugContext(ctx, "Could not watch new path", "path", event.Name, "error", err)
 					}
 				}
 				s.watcherMu.Unlock()
@@ -960,7 +960,7 @@ func (s *VectorStore) watchLoop(ctx context.Context, docPaths []string) {
 			// Early filter: only track changes for files that match configured doc patterns
 			matches, err := fsx.Matches(event.Name, docPaths)
 			if err != nil {
-				slog.Debug("Could not match path against doc patterns", "path", event.Name, "error", err)
+				slog.DebugContext(ctx, "Could not match path against doc patterns", "path", event.Name, "error", err)
 				continue
 			}
 			if !matches {
@@ -971,7 +971,7 @@ func (s *VectorStore) watchLoop(ctx context.Context, docPaths []string) {
 				continue
 			}
 
-			slog.Debug("File system event detected",
+			slog.DebugContext(ctx, "File system event detected",
 				"strategy", s.name,
 				"event", event.Op.String(),
 				"path", event.Name)
@@ -989,7 +989,7 @@ func (s *VectorStore) watchLoop(ctx context.Context, docPaths []string) {
 			if !ok {
 				return
 			}
-			slog.Error("File watcher error", "strategy", s.name, "error", err)
+			slog.ErrorContext(ctx, "File watcher error", "strategy", s.name, "error", err)
 		}
 	}
 }

--- a/pkg/runtime/agent_delegation.go
+++ b/pkg/runtime/agent_delegation.go
@@ -406,7 +406,7 @@ func (r *LocalRuntime) handleTaskTransfer(ctx context.Context, sess *session.Ses
 		return errResult, nil
 	}
 
-	slog.Debug("Transferring task to agent", "from_agent", a.Name(), "to_agent", params.Agent, "task", params.Task)
+	slog.DebugContext(ctx, "Transferring task to agent", "from_agent", a.Name(), "to_agent", params.Agent, "task", params.Task)
 
 	ctx, span := r.startSpan(ctx, "runtime.task_transfer", trace.WithAttributes(
 		attribute.String("from.agent", a.Name()),

--- a/pkg/runtime/cache.go
+++ b/pkg/runtime/cache.go
@@ -73,9 +73,9 @@ func (r *LocalRuntime) tryReplayCachedResponse(
 		return false
 	}
 
-	slog.Debug("Response cache hit; replaying cached answer",
+	slog.DebugContext(ctx, "Response cache hit; replaying cached answer",
 		"agent", a.Name(), "session_id", sess.ID)
-	modelID := a.Model().ID()
+	modelID := a.Model(ctx).ID()
 	events <- AgentInfo(a.Name(), modelID, a.Description(), a.WelcomeMessage())
 	addAgentMessage(sess, a, &chat.Message{
 		Role:      chat.MessageRoleAssistant,

--- a/pkg/runtime/client.go
+++ b/pkg/runtime/client.go
@@ -365,27 +365,27 @@ func (c *Client) runAgentWithAgentName(ctx context.Context, sessionID, agent, ag
 				continue
 			}
 
-			slog.Debug("event", "event", string(after))
+			slog.DebugContext(ctx, "event", "event", string(after))
 
 			// First unmarshal to get the type
 			var baseEvent struct {
 				Type string `json:"type"`
 			}
 			if err := json.Unmarshal(after, &baseEvent); err != nil {
-				slog.Debug("event", "error", err)
+				slog.DebugContext(ctx, "event", "error", err)
 				continue
 			}
 
 			// Then unmarshal the full event
 			createEvent, found := c.registry[baseEvent.Type]
 			if !found {
-				slog.Debug("event", "invalid_type", baseEvent.Type)
+				slog.DebugContext(ctx, "event", "invalid_type", baseEvent.Type)
 				continue
 			}
 
 			e := createEvent()
 			if err := json.Unmarshal(after, &e); err != nil {
-				slog.Debug("event", "error", err)
+				slog.DebugContext(ctx, "event", "error", err)
 				continue
 			}
 

--- a/pkg/runtime/commands.go
+++ b/pkg/runtime/commands.go
@@ -46,7 +46,7 @@ func ResolveCommand(ctx context.Context, rt Runtime, userInput string) string {
 	// which would be a security vulnerability (injection).
 	agentTools, err := rt.CurrentAgentTools(ctx)
 	if err != nil {
-		slog.Warn("Failed to get agent tools for JS expression execution", "error", err)
+		slog.WarnContext(ctx, "Failed to get agent tools for JS expression execution", "error", err)
 	} else {
 		evaluator := js.NewEvaluator(agentTools)
 		instruction = evaluator.Evaluate(ctx, instruction, args)
@@ -191,7 +191,7 @@ func executeToolCommands(ctx context.Context, rt Runtime, instruction string) st
 
 	agentTools, err := rt.CurrentAgentTools(ctx)
 	if err != nil {
-		slog.Warn("Failed to get agent tools for command execution", "error", err)
+		slog.WarnContext(ctx, "Failed to get agent tools for command execution", "error", err)
 		return instruction
 	}
 
@@ -213,21 +213,21 @@ func executeToolCommands(ctx context.Context, rt Runtime, instruction string) st
 
 // executeSingleToolCommand executes a single tool command and returns the output.
 func executeSingleToolCommand(ctx context.Context, toolMap map[string]tools.Tool, toolName, argsStr string) string {
-	slog.Debug("Executing tool command", "tool", toolName, "args", argsStr)
+	slog.DebugContext(ctx, "Executing tool command", "tool", toolName, "args", argsStr)
 
 	tool, exists := toolMap[toolName]
 	if !exists {
-		slog.Warn("Tool not found for command execution", "tool", toolName)
+		slog.WarnContext(ctx, "Tool not found for command execution", "tool", toolName)
 		return "Error: tool '" + toolName + "' not found"
 	}
 	if tool.Handler == nil {
-		slog.Warn("Tool has no handler", "tool", toolName)
+		slog.WarnContext(ctx, "Tool has no handler", "tool", toolName)
 		return "Error: tool '" + toolName + "' has no handler"
 	}
 
 	argsJSON, err := json.Marshal(parseToolArgs(argsStr))
 	if err != nil {
-		slog.Warn("Failed to marshal tool arguments", "tool", toolName, "error", err)
+		slog.WarnContext(ctx, "Failed to marshal tool arguments", "tool", toolName, "error", err)
 		return "Error: failed to marshal arguments for '" + toolName + "'"
 	}
 
@@ -245,12 +245,12 @@ func executeSingleToolCommand(ctx context.Context, toolMap map[string]tools.Tool
 
 	result, err := tool.Handler(toolCtx, toolCall)
 	if err != nil {
-		slog.Warn("Tool execution failed", "tool", toolName, "error", err)
+		slog.WarnContext(ctx, "Tool execution failed", "tool", toolName, "error", err)
 		return "Error executing '" + toolName + "': " + err.Error()
 	}
 
 	output := strings.TrimSpace(result.Output)
-	slog.Debug("Tool command output", "tool", toolName, "output_length", len(output))
+	slog.DebugContext(ctx, "Tool command output", "tool", toolName, "output_length", len(output))
 	return output
 }
 

--- a/pkg/runtime/compactor/compactor.go
+++ b/pkg/runtime/compactor/compactor.go
@@ -114,11 +114,11 @@ func RunLLM(ctx context.Context, args LLMArgs) (*Result, error) {
 	if args.ContextLimit <= 0 {
 		return nil, errors.New("compactor: ContextLimit must be > 0")
 	}
-	if args.Agent.Model() == nil {
+	if args.Agent.Model(ctx) == nil {
 		return nil, errors.New("compactor: agent has no model")
 	}
 
-	summaryModel := provider.CloneWithOptions(ctx, args.Agent.Model(),
+	summaryModel := provider.CloneWithOptions(ctx, args.Agent.Model(ctx),
 		options.WithStructuredOutput(nil),
 		options.WithMaxTokens(MaxSummaryTokens),
 	)

--- a/pkg/runtime/elicitation.go
+++ b/pkg/runtime/elicitation.go
@@ -88,7 +88,7 @@ func (b *elicitationBridge) send(ev Event) error {
 // elicitation request. Returns an error if no elicitation is in progress
 // or if the context is cancelled before the response can be delivered.
 func (r *LocalRuntime) ResumeElicitation(ctx context.Context, action tools.ElicitationAction, content map[string]any) error {
-	slog.Debug("Resuming runtime with elicitation response", "agent", r.CurrentAgentName(), "action", action)
+	slog.DebugContext(ctx, "Resuming runtime with elicitation response", "agent", r.CurrentAgentName(), "action", action)
 
 	result := ElicitationResult{
 		Action:  action,
@@ -97,13 +97,13 @@ func (r *LocalRuntime) ResumeElicitation(ctx context.Context, action tools.Elici
 
 	select {
 	case <-ctx.Done():
-		slog.Debug("Context cancelled while sending elicitation response")
+		slog.DebugContext(ctx, "Context cancelled while sending elicitation response")
 		return ctx.Err()
 	case r.elicitationRequestCh <- result:
-		slog.Debug("Elicitation response sent successfully", "action", action)
+		slog.DebugContext(ctx, "Elicitation response sent successfully", "action", action)
 		return nil
 	default:
-		slog.Debug("Elicitation channel not ready")
+		slog.DebugContext(ctx, "Elicitation channel not ready")
 		return errors.New("no elicitation request in progress")
 	}
 }
@@ -113,12 +113,12 @@ func (r *LocalRuntime) ResumeElicitation(ctx context.Context, action tools.Elici
 // active stream's events channel and waits for the embedder's response on
 // elicitationRequestCh.
 func (r *LocalRuntime) elicitationHandler(ctx context.Context, req *mcp.ElicitParams) (tools.ElicitationResult, error) {
-	slog.Debug("Elicitation request received from MCP server", "message", req.Message)
+	slog.DebugContext(ctx, "Elicitation request received from MCP server", "message", req.Message)
 
 	// In non-interactive mode (e.g., MCP serve), there is no user to respond
 	// to elicitation requests. Decline immediately instead of blocking forever.
 	if r.nonInteractive {
-		slog.Debug("Declining elicitation in non-interactive mode", "message", req.Message)
+		slog.DebugContext(ctx, "Declining elicitation in non-interactive mode", "message", req.Message)
 		return tools.ElicitationResult{
 			Action: tools.ElicitationActionDecline,
 		}, nil
@@ -126,12 +126,12 @@ func (r *LocalRuntime) elicitationHandler(ctx context.Context, req *mcp.ElicitPa
 
 	r.executeOnUserInputHooks(ctx, "", "elicitation")
 
-	slog.Debug("Sending elicitation request event to client",
+	slog.DebugContext(ctx, "Sending elicitation request event to client",
 		"message", req.Message,
 		"mode", req.Mode,
 		"requested_schema", req.RequestedSchema,
 		"url", req.URL)
-	slog.Debug("Elicitation request meta", "meta", req.Meta)
+	slog.DebugContext(ctx, "Elicitation request meta", "meta", req.Meta)
 
 	if err := r.elicitation.send(
 		ElicitationRequest(req.Message, req.Mode, req.RequestedSchema, req.URL, req.ElicitationID, req.Meta, r.CurrentAgentName()),
@@ -147,7 +147,7 @@ func (r *LocalRuntime) elicitationHandler(ctx context.Context, req *mcp.ElicitPa
 			Content: result.Content,
 		}, nil
 	case <-ctx.Done():
-		slog.Debug("Context cancelled while waiting for elicitation response")
+		slog.DebugContext(ctx, "Context cancelled while waiting for elicitation response")
 		return tools.ElicitationResult{}, ctx.Err()
 	}
 }

--- a/pkg/runtime/fallback.go
+++ b/pkg/runtime/fallback.go
@@ -282,7 +282,7 @@ func (e *fallbackExecutor) execute(
 				)
 			}
 
-			slog.Debug("Creating chat completion stream",
+			slog.DebugContext(ctx, "Creating chat completion stream",
 				"agent", a.Name(),
 				"model", modelEntry.provider.ID(),
 				"is_fallback", modelEntry.isFallback,
@@ -302,7 +302,7 @@ func (e *fallbackExecutor) execute(
 				continue
 			}
 
-			slog.Debug("Processing stream", "agent", a.Name(), "model", modelEntry.provider.ID())
+			slog.DebugContext(ctx, "Processing stream", "agent", a.Name(), "model", modelEntry.provider.ID())
 
 			// If the provider is a rule-based router, notify the sidebar
 			// of the selected sub-model's YAML-configured name.
@@ -382,7 +382,7 @@ func (e *fallbackExecutor) handleModelError(
 		// Default behavior (retryOnRateLimit=false) treats 429 as non-retryable,
 		// identical to today's behavior before this feature was added.
 		if !e.retryOnRateLimit || hasFallbacks {
-			slog.Warn("Rate limited, treating as non-retryable",
+			slog.WarnContext(ctx, "Rate limited, treating as non-retryable",
 				"agent", a.Name(),
 				"model", modelEntry.provider.ID(),
 				"retry_on_rate_limit_enabled", e.retryOnRateLimit,
@@ -399,14 +399,14 @@ func (e *fallbackExecutor) handleModelError(
 		if waitDuration <= 0 {
 			waitDuration = backoff.Calculate(attempt)
 		} else if waitDuration > backoff.MaxRetryAfterWait {
-			slog.Warn("Retry-After exceeds maximum, capping",
+			slog.WarnContext(ctx, "Retry-After exceeds maximum, capping",
 				"agent", a.Name(),
 				"model", modelEntry.provider.ID(),
 				"retry_after", retryAfter,
 				"max", backoff.MaxRetryAfterWait)
 			waitDuration = backoff.MaxRetryAfterWait
 		}
-		slog.Warn("Rate limited, retrying (opt-in enabled)",
+		slog.WarnContext(ctx, "Rate limited, retrying (opt-in enabled)",
 			"agent", a.Name(),
 			"model", modelEntry.provider.ID(),
 			"attempt", attempt+1,
@@ -420,7 +420,7 @@ func (e *fallbackExecutor) handleModelError(
 	}
 
 	if !retryable {
-		slog.Error("Non-retryable error from model",
+		slog.ErrorContext(ctx, "Non-retryable error from model",
 			"agent", a.Name(),
 			"model", modelEntry.provider.ID(),
 			"error", err)
@@ -430,7 +430,7 @@ func (e *fallbackExecutor) handleModelError(
 		return retryDecisionBreak
 	}
 
-	slog.Warn("Retryable error from model",
+	slog.WarnContext(ctx, "Retryable error from model",
 		"agent", a.Name(),
 		"model", modelEntry.provider.ID(),
 		"attempt", attempt+1,

--- a/pkg/runtime/hooks.go
+++ b/pkg/runtime/hooks.go
@@ -88,7 +88,7 @@ func (r *LocalRuntime) dispatchHook(
 		events <- HookFinished(event, input.SessionID, result, err, time.Since(started), a.Name())
 	}
 	if err != nil {
-		slog.Warn("Hook execution failed", "event", event, "agent", a.Name(), "error", err)
+		slog.WarnContext(ctx, "Hook execution failed", "event", event, "agent", a.Name(), "error", err)
 		return nil
 	}
 
@@ -396,7 +396,7 @@ func (r *LocalRuntime) executeOnUserInputHooks(ctx context.Context, sessionID, l
 	if a == nil {
 		return
 	}
-	slog.Debug("Executing on-user-input hooks", "context", logContext)
+	slog.DebugContext(ctx, "Executing on-user-input hooks", "context", logContext)
 	r.dispatchHook(ctx, a, hooks.EventOnUserInput, &hooks.Input{
 		SessionID: sessionID,
 	}, nil)

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -161,7 +161,7 @@ func (r *LocalRuntime) finalizeEventChannel(ctx context.Context, sess *session.S
 // the response, executes any tool calls, and loops until the model signals stop
 // or the iteration limit is reached.
 func (r *LocalRuntime) RunStream(ctx context.Context, sess *session.Session) <-chan Event {
-	slog.Debug("Starting runtime stream", "agent", r.CurrentAgentName(), "session_id", sess.ID)
+	slog.DebugContext(ctx, "Starting runtime stream", "agent", r.CurrentAgentName(), "session_id", sess.ID)
 	events := make(chan Event, defaultEventChannelCapacity)
 
 	go r.runStreamLoop(ctx, sess, events)
@@ -232,7 +232,7 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 		if lastMsg.Role == chat.MessageRoleUser {
 			stop, msg, ctxMsgs := r.executeUserPromptSubmitHooks(ctx, sess, a, lastMsg.Content, events)
 			if stop {
-				slog.Warn("user_prompt_submit hook signalled run termination",
+				slog.WarnContext(ctx, "user_prompt_submit hook signalled run termination",
 					"agent", a.Name(), "session_id", sess.ID, "reason", msg)
 				r.emitHookDrivenShutdown(ctx, a, sess, msg, events)
 				return
@@ -327,21 +327,21 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 
 		// Exit immediately if the stream context has been cancelled (e.g., Ctrl+C)
 		if err := ctx.Err(); err != nil {
-			slog.Debug("Runtime stream context cancelled, stopping loop", "agent", a.Name(), "session_id", sess.ID)
+			slog.DebugContext(ctx, "Runtime stream context cancelled, stopping loop", "agent", a.Name(), "session_id", sess.ID)
 			return
 		}
-		slog.Debug("Starting conversation loop iteration", "agent", a.Name())
+		slog.DebugContext(ctx, "Starting conversation loop iteration", "agent", a.Name())
 
-		model := a.Model()
+		model := a.Model(ctx)
 
 		// Per-tool model routing: use a cheaper model for this turn
 		// if the previous tool calls specified one, then reset.
 		if toolModelOverride != "" {
 			if overrideModel, err := r.resolveModelRef(ctx, toolModelOverride); err != nil {
-				slog.Warn("Failed to resolve per-tool model override; using agent default",
+				slog.WarnContext(ctx, "Failed to resolve per-tool model override; using agent default",
 					"model_override", toolModelOverride, "error", err)
 			} else {
-				slog.Info("Using per-tool model override for this turn",
+				slog.InfoContext(ctx, "Using per-tool model override for this turn",
 					"agent", a.Name(), "override", overrideModel.ID(), "primary", model.ID())
 				model = overrideModel
 			}
@@ -355,11 +355,11 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 		// stream once the first chunk arrives.
 		events <- AgentInfo(a.Name(), modelID, a.Description(), a.WelcomeMessage())
 
-		slog.Debug("Using agent", "agent", a.Name(), "model", modelID)
-		slog.Debug("Getting model definition", "model_id", modelID)
+		slog.DebugContext(ctx, "Using agent", "agent", a.Name(), "model", modelID)
+		slog.DebugContext(ctx, "Getting model definition", "model_id", modelID)
 		m, err := r.modelsStore.GetModel(ctx, modelID)
 		if err != nil {
-			slog.Debug("Failed to get model definition", "error", err)
+			slog.DebugContext(ctx, "Failed to get model definition", "error", err)
 		}
 		// We can only compact if we know the limit.
 		var contextLimit int64
@@ -492,7 +492,7 @@ func (r *LocalRuntime) runTurn(
 	// arch) stays stable — all without bloating the stored history.
 	turnStartMsgs := r.executeTurnStartHooks(ctx, sess, a, events)
 	messages := sess.GetMessages(a, slices.Concat(priorExtras, turnStartMsgs)...)
-	slog.Debug("Retrieved messages for processing", "agent", a.Name(), "message_count", len(messages))
+	slog.DebugContext(ctx, "Retrieved messages for processing", "agent", a.Name(), "message_count", len(messages))
 
 	// before_llm_call hooks fire just before the model is invoked.
 	// A terminating verdict (e.g. from the max_iterations builtin)
@@ -506,7 +506,7 @@ func (r *LocalRuntime) runTurn(
 	// silently overridden by a transform later in the chain.
 	stop, msg, rewritten := r.executeBeforeLLMCallHooks(ctx, sess, a, modelID, messages)
 	if stop {
-		slog.Warn("before_llm_call hook signalled run termination",
+		slog.WarnContext(ctx, "before_llm_call hook signalled run termination",
 			"agent", a.Name(), "session_id", sess.ID, "reason", msg)
 		r.emitHookDrivenShutdown(ctx, a, sess, msg, events)
 		endStreamSpan()
@@ -549,7 +549,7 @@ func (r *LocalRuntime) runTurn(
 	r.executeAfterLLMCallHooks(ctx, sess, a, res.Content)
 
 	if usedModel != nil && usedModel.ID() != model.ID() {
-		slog.Info("Used fallback model", "agent", a.Name(), "primary", model.ID(), "used", usedModel.ID())
+		slog.InfoContext(ctx, "Used fallback model", "agent", a.Name(), "primary", model.ID(), "used", usedModel.ID())
 		events <- AgentInfo(a.Name(), usedModel.ID(), a.Description(), a.WelcomeMessage())
 	}
 	streamSpan.SetAttributes(
@@ -558,7 +558,7 @@ func (r *LocalRuntime) runTurn(
 		attribute.Bool("stopped", res.Stopped),
 	)
 	endStreamSpan()
-	slog.Debug("Stream processed", "agent", a.Name(), "tool_calls", len(res.Calls), "content_length", len(res.Content), "stopped", res.Stopped)
+	slog.DebugContext(ctx, "Stream processed", "agent", a.Name(), "tool_calls", len(res.Calls), "content_length", len(res.Content), "stopped", res.Stopped)
 
 	msgUsage := r.recordAssistantMessage(sess, a, res, agentTools, modelID, m, events)
 
@@ -593,7 +593,7 @@ func (r *LocalRuntime) runTurn(
 			toolName = res.Calls[0].Function.Name
 		}
 		consecutive := loopDetector.Consecutive()
-		slog.Warn("Repetitive tool call loop detected",
+		slog.WarnContext(ctx, "Repetitive tool call loop detected",
 			"agent", a.Name(), "tool", toolName,
 			"consecutive", consecutive, "session_id", sess.ID)
 		errMsg := fmt.Sprintf(
@@ -613,7 +613,7 @@ func (r *LocalRuntime) runTurn(
 	// runtime fans out the standard Error / notification /
 	// on_error stanzas before exiting.
 	if stopRun {
-		slog.Warn("post_tool_use hook signalled run termination",
+		slog.WarnContext(ctx, "post_tool_use hook signalled run termination",
 			"agent", a.Name(), "session_id", sess.ID, "reason", stopMsg)
 		r.emitHookDrivenShutdown(ctx, a, sess, stopMsg, events)
 		endReason = turnEndReasonHookBlocked
@@ -631,7 +631,7 @@ func (r *LocalRuntime) runTurn(
 	}
 
 	if res.Stopped {
-		slog.Debug("Conversation stopped", "agent", a.Name())
+		slog.DebugContext(ctx, "Conversation stopped", "agent", a.Name())
 		r.executeStopHooks(ctx, sess, a, res.Content, events)
 
 		// Re-check steer queue: closes the race between the mid-loop drain and this stop.
@@ -778,7 +778,7 @@ func (r *LocalRuntime) compactIfNeeded(
 		return
 	}
 
-	slog.Info("Proactive compaction: tool results pushed estimated context past 90%% threshold",
+	slog.InfoContext(ctx, "Proactive compaction: tool results pushed estimated context past 90%% threshold",
 		"agent", a.Name(),
 		"input_tokens", sess.InputTokens,
 		"output_tokens", sess.OutputTokens,
@@ -800,14 +800,14 @@ func (r *LocalRuntime) getTools(ctx context.Context, a *agent.Agent, sessionSpan
 
 	agentTools, err := a.Tools(ctx)
 	if err != nil {
-		slog.Error("Failed to get agent tools", "agent", a.Name(), "error", err)
+		slog.ErrorContext(ctx, "Failed to get agent tools", "agent", a.Name(), "error", err)
 		sessionSpan.RecordError(err)
 		sessionSpan.SetStatus(codes.Error, "failed to get tools")
 		r.telemetry.RecordError(ctx, err.Error())
 		return nil, err
 	}
 
-	slog.Debug("Retrieved agent tools", "agent", a.Name(), "tool_count", len(agentTools))
+	slog.DebugContext(ctx, "Retrieved agent tools", "agent", a.Name(), "tool_count", len(agentTools))
 	return agentTools, nil
 }
 
@@ -902,7 +902,7 @@ func (r *LocalRuntime) reprobe(
 ) {
 	updated, err := r.getTools(ctx, a, sessionSpan, events, false)
 	if err != nil {
-		slog.Warn("reprobe: getTools failed", "agent", a.Name(), "error", err)
+		slog.WarnContext(ctx, "reprobe: getTools failed", "agent", a.Name(), "error", err)
 		return
 	}
 	updated = filterExcludedTools(updated, sess.ExcludedTools)
@@ -927,7 +927,7 @@ func (r *LocalRuntime) reprobe(
 		return
 	}
 
-	slog.Info("New tools available after toolset re-probe",
+	slog.InfoContext(ctx, "New tools available after toolset re-probe",
 		"agent", a.Name(), "added", added)
 
 	// Emit updated tool count to the TUI immediately.

--- a/pkg/runtime/loop_steps.go
+++ b/pkg/runtime/loop_steps.go
@@ -57,8 +57,7 @@ func (r *LocalRuntime) enforceMaxIterations(
 		return runtimeMaxIterations, iterationContinue
 	}
 
-	slog.Debug(
-		"Maximum iterations reached",
+	slog.DebugContext(ctx, "Maximum iterations reached",
 		"agent", a.Name(),
 		"iterations", iteration,
 		"max", runtimeMaxIterations,
@@ -85,7 +84,7 @@ func (r *LocalRuntime) enforceMaxIterations(
 	// In non-interactive mode (e.g. MCP server), auto-stop instead of
 	// blocking forever waiting for user input.
 	if sess.NonInteractive {
-		slog.Debug("Auto-stopping after max iterations (non-interactive)", "agent", a.Name())
+		slog.DebugContext(ctx, "Auto-stopping after max iterations (non-interactive)", "agent", a.Name())
 		appendStopMsg()
 		return runtimeMaxIterations, iterationStop
 	}
@@ -94,18 +93,17 @@ func (r *LocalRuntime) enforceMaxIterations(
 	select {
 	case req := <-r.resumeChan:
 		if req.Type == ResumeTypeApprove {
-			slog.Debug("User chose to continue after max iterations", "agent", a.Name())
+			slog.DebugContext(ctx, "User chose to continue after max iterations", "agent", a.Name())
 			newMax := iteration + 10
 			r.executeOnSessionResumeHooks(ctx, a, sess.ID, runtimeMaxIterations, newMax)
 			return newMax, iterationContinue
 		}
-		slog.Debug("User rejected continuation", "agent", a.Name())
+		slog.DebugContext(ctx, "User rejected continuation", "agent", a.Name())
 		appendStopMsg()
 		return runtimeMaxIterations, iterationStop
 
 	case <-ctx.Done():
-		slog.Debug(
-			"Context cancelled while waiting for resume confirmation",
+		slog.DebugContext(ctx, "Context cancelled while waiting for resume confirmation",
 			"agent", a.Name(),
 			"session_id", sess.ID,
 		)
@@ -154,7 +152,7 @@ func (r *LocalRuntime) handleStreamError(
 ) streamErrorOutcome {
 	// Treat context cancellation as a graceful stop.
 	if errors.Is(err, context.Canceled) {
-		slog.Debug("Model stream canceled by context", "agent", a.Name(), "session_id", sess.ID)
+		slog.DebugContext(ctx, "Model stream canceled by context", "agent", a.Name(), "session_id", sess.ID)
 		return streamErrorFatal
 	}
 
@@ -165,7 +163,7 @@ func (r *LocalRuntime) handleStreamError(
 	// loop when compaction cannot reduce the context enough.
 	if _, ok := errors.AsType[*modelerrors.ContextOverflowError](err); ok && r.sessionCompaction && *overflowCompactions < r.maxOverflowCompactions {
 		*overflowCompactions++
-		slog.Warn("Context window overflow detected, attempting auto-compaction",
+		slog.WarnContext(ctx, "Context window overflow detected, attempting auto-compaction",
 			"agent", a.Name(),
 			"session_id", sess.ID,
 			"input_tokens", sess.InputTokens,
@@ -183,7 +181,7 @@ func (r *LocalRuntime) handleStreamError(
 
 	streamSpan.RecordError(err)
 	streamSpan.SetStatus(codes.Error, "error handling stream")
-	slog.Error("All models failed", "agent", a.Name(), "error", err)
+	slog.ErrorContext(ctx, "All models failed", "agent", a.Name(), "error", err)
 	r.telemetry.RecordError(ctx, err.Error())
 	errMsg := modelerrors.FormatError(err)
 	events <- Error(errMsg)

--- a/pkg/runtime/model_picker.go
+++ b/pkg/runtime/model_picker.go
@@ -73,13 +73,13 @@ func (r *LocalRuntime) setModelAndEmitInfo(ctx context.Context, modelRef string,
 	if a, err := r.team.Agent(currentName); err == nil {
 		events <- AgentInfo(a.Name(), r.getEffectiveModelID(a), a.Description(), a.WelcomeMessage())
 	} else {
-		slog.Warn("Failed to retrieve agent after model change; UI may not reflect the update", "agent", currentName, "error", err)
+		slog.WarnContext(ctx, "Failed to retrieve agent after model change; UI may not reflect the update", "agent", currentName, "error", err)
 	}
 
 	if modelRef == "" {
-		slog.Info("Model reverted via model_picker tool", "agent", currentName)
+		slog.InfoContext(ctx, "Model reverted via model_picker tool", "agent", currentName)
 		return tools.ResultSuccess("Model reverted to the agent's default model"), nil
 	}
-	slog.Info("Model changed via model_picker tool", "agent", currentName, "model", modelRef)
+	slog.InfoContext(ctx, "Model changed via model_picker tool", "agent", currentName, "model", modelRef)
 	return tools.ResultSuccess("Model changed to " + modelRef), nil
 }

--- a/pkg/runtime/model_switcher.go
+++ b/pkg/runtime/model_switcher.go
@@ -120,7 +120,7 @@ func (r *LocalRuntime) setAgentModelInternal(ctx context.Context, agentName, mod
 	// Empty modelRef means clear the override (use agent's default)
 	if modelRef == "" {
 		snap := a.SetModelOverride()
-		slog.Info("Cleared agent model override (using default)", "agent", agentName)
+		slog.InfoContext(ctx, "Cleared agent model override (using default)", "agent", agentName)
 		return snap, nil
 	}
 
@@ -134,7 +134,7 @@ func (r *LocalRuntime) setAgentModelInternal(ctx context.Context, agentName, mod
 				return agent.ModelOverrideSnapshot{}, fmt.Errorf("failed to create alloy model from config: %w", err)
 			}
 			snap := a.SetModelOverride(providers...)
-			slog.Info("Set agent model override (alloy)", "agent", agentName, "config_name", modelRef, "model_count", len(providers))
+			slog.InfoContext(ctx, "Set agent model override (alloy)", "agent", agentName, "config_name", modelRef, "model_count", len(providers))
 			return snap, nil
 		}
 
@@ -143,7 +143,7 @@ func (r *LocalRuntime) setAgentModelInternal(ctx context.Context, agentName, mod
 			return agent.ModelOverrideSnapshot{}, fmt.Errorf("failed to create model from config: %w", err)
 		}
 		snap := a.SetModelOverride(prov)
-		slog.Info("Set agent model override", "agent", agentName, "model", prov.ID(), "config_name", modelRef)
+		slog.InfoContext(ctx, "Set agent model override", "agent", agentName, "model", prov.ID(), "config_name", modelRef)
 		return snap, nil
 	}
 
@@ -155,7 +155,7 @@ func (r *LocalRuntime) setAgentModelInternal(ctx context.Context, agentName, mod
 			return agent.ModelOverrideSnapshot{}, fmt.Errorf("failed to create inline alloy model: %w", err)
 		}
 		snap := a.SetModelOverride(providers...)
-		slog.Info("Set agent model override (inline alloy)", "agent", agentName, "model_count", len(providers))
+		slog.InfoContext(ctx, "Set agent model override (inline alloy)", "agent", agentName, "model_count", len(providers))
 		return snap, nil
 	}
 
@@ -165,7 +165,7 @@ func (r *LocalRuntime) setAgentModelInternal(ctx context.Context, agentName, mod
 		return agent.ModelOverrideSnapshot{}, fmt.Errorf("failed to resolve model %q: %w", modelRef, err)
 	}
 	snap := a.SetModelOverride(prov)
-	slog.Info("Set agent model override (inline)", "agent", agentName, "model", prov.ID())
+	slog.InfoContext(ctx, "Set agent model override (inline)", "agent", agentName, "model", prov.ID())
 	return snap, nil
 }
 
@@ -333,7 +333,7 @@ func (r *LocalRuntime) AvailableModels(ctx context.Context) []ModelChoice {
 func (r *LocalRuntime) buildCatalogChoices(ctx context.Context) []ModelChoice {
 	db, err := r.modelsStore.GetDatabase(ctx)
 	if err != nil {
-		slog.Debug("Failed to get models.dev database for catalog", "error", err)
+		slog.DebugContext(ctx, "Failed to get models.dev database for catalog", "error", err)
 		return nil
 	}
 
@@ -349,7 +349,7 @@ func (r *LocalRuntime) buildCatalogChoices(ctx context.Context) []ModelChoice {
 	// Check which providers the user has credentials for
 	availableProviders := r.getAvailableProviders(ctx)
 	if len(availableProviders) == 0 {
-		slog.Debug("No provider credentials available, skipping catalog")
+		slog.DebugContext(ctx, "No provider credentials available, skipping catalog")
 		return nil
 	}
 
@@ -392,7 +392,7 @@ func (r *LocalRuntime) buildCatalogChoices(ctx context.Context) []ModelChoice {
 		}
 	}
 
-	slog.Debug("Built catalog choices", "count", len(choices), "available_providers", len(availableProviders))
+	slog.DebugContext(ctx, "Built catalog choices", "count", len(choices), "available_providers", len(availableProviders))
 	return choices
 }
 

--- a/pkg/runtime/persistence_observer.go
+++ b/pkg/runtime/persistence_observer.go
@@ -61,7 +61,7 @@ func (p *PersistenceObserver) OnRunStart(ctx context.Context, sess *session.Sess
 		return
 	}
 	if err := p.store.UpdateSession(ctx, sess); err != nil {
-		slog.Warn("Failed to persist initial session", "session_id", sess.ID, "error", err)
+		slog.WarnContext(ctx, "Failed to persist initial session", "session_id", sess.ID, "error", err)
 	}
 }
 
@@ -92,7 +92,7 @@ func (p *PersistenceObserver) OnEvent(ctx context.Context, sess *session.Session
 	case *UserMessageEvent:
 		p.streaming = streamingState{}
 		if _, err := p.store.AddMessage(ctx, e.SessionID, session.UserMessage(e.Message, e.MultiContent...)); err != nil {
-			slog.Warn("Failed to persist user message", "session_id", e.SessionID, "error", err)
+			slog.WarnContext(ctx, "Failed to persist user message", "session_id", e.SessionID, "error", err)
 		}
 
 	case *MessageAddedEvent:
@@ -105,7 +105,7 @@ func (p *PersistenceObserver) OnEvent(ctx context.Context, sess *session.Session
 			_, err = p.store.AddMessage(ctx, e.SessionID, e.Message)
 		}
 		if err != nil {
-			slog.Warn("Failed to persist message",
+			slog.WarnContext(ctx, "Failed to persist message",
 				"session_id", e.SessionID, "message_id", p.streaming.messageID, "error", err)
 		}
 		p.streaming = streamingState{}
@@ -113,25 +113,25 @@ func (p *PersistenceObserver) OnEvent(ctx context.Context, sess *session.Session
 	case *SubSessionCompletedEvent:
 		if subSess, ok := e.SubSession.(*session.Session); ok {
 			if err := p.store.AddSubSession(ctx, e.ParentSessionID, subSess); err != nil {
-				slog.Warn("Failed to persist sub-session", "parent_id", e.ParentSessionID, "error", err)
+				slog.WarnContext(ctx, "Failed to persist sub-session", "parent_id", e.ParentSessionID, "error", err)
 			}
 		}
 
 	case *SessionSummaryEvent:
 		if err := p.store.AddSummary(ctx, e.SessionID, e.Summary, e.FirstKeptEntry); err != nil {
-			slog.Warn("Failed to persist summary", "session_id", e.SessionID, "error", err)
+			slog.WarnContext(ctx, "Failed to persist summary", "session_id", e.SessionID, "error", err)
 		}
 
 	case *TokenUsageEvent:
 		if e.Usage != nil {
 			if err := p.store.UpdateSessionTokens(ctx, sess.ID, e.Usage.InputTokens, e.Usage.OutputTokens, e.Usage.Cost); err != nil {
-				slog.Warn("Failed to persist token usage", "session_id", sess.ID, "error", err)
+				slog.WarnContext(ctx, "Failed to persist token usage", "session_id", sess.ID, "error", err)
 			}
 		}
 
 	case *SessionTitleEvent:
 		if err := p.store.UpdateSessionTitle(ctx, sess.ID, e.Title); err != nil {
-			slog.Warn("Failed to persist session title", "session_id", sess.ID, "error", err)
+			slog.WarnContext(ctx, "Failed to persist session title", "session_id", sess.ID, "error", err)
 		}
 	}
 }
@@ -154,17 +154,17 @@ func (p *PersistenceObserver) persistStreamingContent(ctx context.Context, sessi
 	if p.streaming.messageID == 0 {
 		id, err := p.store.AddMessage(ctx, sessionID, msg)
 		if err != nil {
-			slog.Warn("Failed to create streaming message", "session_id", sessionID, "error", err)
+			slog.WarnContext(ctx, "Failed to create streaming message", "session_id", sessionID, "error", err)
 			return
 		}
 		p.streaming.messageID = id
-		slog.Debug("[PERSIST] Created streaming message",
+		slog.DebugContext(ctx, "[PERSIST] Created streaming message",
 			"session_id", sessionID, "message_id", id, "agent", p.streaming.agentName)
 		return
 	}
 
 	if err := p.store.UpdateMessage(ctx, p.streaming.messageID, msg); err != nil {
-		slog.Warn("Failed to update streaming message",
+		slog.WarnContext(ctx, "Failed to update streaming message",
 			"session_id", sessionID, "message_id", p.streaming.messageID, "error", err)
 	}
 }

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -152,7 +152,7 @@ func (r *RemoteRuntime) EmitStartupInfo(ctx context.Context, _ *session.Session,
 
 	toolCount, err := r.client.GetAgentToolCount(ctx, r.agentFilename, agentName)
 	if err != nil {
-		slog.Warn("Failed to get agent tool count", "error", err)
+		slog.WarnContext(ctx, "Failed to get agent tool count", "error", err)
 		return
 	}
 
@@ -211,7 +211,7 @@ func (r *RemoteRuntime) readCurrentAgentConfig(ctx context.Context) latest.Agent
 
 // RunStream starts the agent's interaction loop and returns a channel of events
 func (r *RemoteRuntime) RunStream(ctx context.Context, sess *session.Session) <-chan Event {
-	slog.Debug("Starting remote runtime stream", "agent", r.currentAgent, "session_id", r.sessionID)
+	slog.DebugContext(ctx, "Starting remote runtime stream", "agent", r.currentAgent, "session_id", r.sessionID)
 	events := make(chan Event, defaultEventChannelCapacity)
 
 	go func() {
@@ -281,15 +281,15 @@ func (r *RemoteRuntime) FollowUp(msg QueuedMessage) error {
 
 // Resume allows resuming execution after user confirmation
 func (r *RemoteRuntime) Resume(ctx context.Context, req ResumeRequest) {
-	slog.Debug("Resuming remote runtime", "agent", r.currentAgent, "type", req.Type, "reason", req.Reason, "tool_name", req.ToolName, "session_id", r.sessionID)
+	slog.DebugContext(ctx, "Resuming remote runtime", "agent", r.currentAgent, "type", req.Type, "reason", req.Reason, "tool_name", req.ToolName, "session_id", r.sessionID)
 
 	if r.sessionID == "" {
-		slog.Error("Cannot resume: no session ID available")
+		slog.ErrorContext(ctx, "Cannot resume: no session ID available")
 		return
 	}
 
 	if err := r.client.ResumeSession(ctx, r.sessionID, string(req.Type), req.Reason, req.ToolName); err != nil {
-		slog.Error("Failed to resume remote session", "error", err, "session_id", r.sessionID)
+		slog.ErrorContext(ctx, "Failed to resume remote session", "error", err, "session_id", r.sessionID)
 	}
 }
 
@@ -317,7 +317,7 @@ func (r *RemoteRuntime) convertSessionMessages(sess *session.Session) []api.Mess
 
 // ResumeElicitation sends an elicitation response back to a waiting elicitation request
 func (r *RemoteRuntime) ResumeElicitation(ctx context.Context, action tools.ElicitationAction, content map[string]any) error {
-	slog.Debug("Resuming remote runtime with elicitation response", "agent", r.currentAgent, "action", action, "session_id", r.sessionID)
+	slog.DebugContext(ctx, "Resuming remote runtime with elicitation response", "agent", r.currentAgent, "action", action, "session_id", r.sessionID)
 
 	err := r.handleOAuthElicitation(ctx, r.pendingOAuthElicitation)
 	if err != nil {
@@ -336,12 +336,12 @@ func (r *RemoteRuntime) handleOAuthElicitation(ctx context.Context, req *Elicita
 		return nil
 	}
 
-	slog.Debug("Handling OAuth elicitation request", "server_url", req.Meta["cagent/server_url"])
+	slog.DebugContext(ctx, "Handling OAuth elicitation request", "server_url", req.Meta["cagent/server_url"])
 
 	serverURL, ok := req.Meta["cagent/server_url"].(string)
 	if !ok {
 		err := errors.New("server_url missing from elicitation metadata")
-		slog.Error("Failed to extract server_url", "error", err)
+		slog.ErrorContext(ctx, "Failed to extract server_url", "error", err)
 		_ = r.client.ResumeElicitation(ctx, r.sessionID, "decline", nil)
 		return err
 	}
@@ -349,7 +349,7 @@ func (r *RemoteRuntime) handleOAuthElicitation(ctx context.Context, req *Elicita
 	authServerMetadata, ok := req.Meta["auth_server_metadata"].(map[string]any)
 	if !ok {
 		err := errors.New("auth_server_metadata missing from elicitation metadata")
-		slog.Error("Failed to extract auth_server_metadata", "error", err)
+		slog.ErrorContext(ctx, "Failed to extract auth_server_metadata", "error", err)
 		_ = r.client.ResumeElicitation(ctx, r.sessionID, "decline", nil)
 		return err
 	}
@@ -357,25 +357,25 @@ func (r *RemoteRuntime) handleOAuthElicitation(ctx context.Context, req *Elicita
 	var authMetadata mcp.AuthorizationServerMetadata
 	metadataBytes, err := json.Marshal(authServerMetadata)
 	if err != nil {
-		slog.Error("Failed to marshal auth_server_metadata", "error", err)
+		slog.ErrorContext(ctx, "Failed to marshal auth_server_metadata", "error", err)
 		_ = r.client.ResumeElicitation(ctx, r.sessionID, "decline", nil)
 		return fmt.Errorf("failed to marshal auth_server_metadata: %w", err)
 	}
 	if err := json.Unmarshal(metadataBytes, &authMetadata); err != nil {
-		slog.Error("Failed to unmarshal auth_server_metadata", "error", err)
+		slog.ErrorContext(ctx, "Failed to unmarshal auth_server_metadata", "error", err)
 		_ = r.client.ResumeElicitation(ctx, r.sessionID, "decline", nil)
 		return fmt.Errorf("failed to unmarshal auth_server_metadata: %w", err)
 	}
 
-	slog.Debug("Authorization server metadata extracted", "issuer", authMetadata.Issuer)
+	slog.DebugContext(ctx, "Authorization server metadata extracted", "issuer", authMetadata.Issuer)
 
 	oauthCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 
-	slog.Debug("Creating OAuth callback server")
+	slog.DebugContext(ctx, "Creating OAuth callback server")
 	callbackServer, err := mcp.NewCallbackServer()
 	if err != nil {
-		slog.Error("Failed to create callback server", "error", err)
+		slog.ErrorContext(ctx, "Failed to create callback server", "error", err)
 		_ = r.client.ResumeElicitation(ctx, r.sessionID, "decline", nil)
 		return fmt.Errorf("failed to create callback server: %w", err)
 	}
@@ -383,39 +383,39 @@ func (r *RemoteRuntime) handleOAuthElicitation(ctx context.Context, req *Elicita
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer shutdownCancel()
 		if err := callbackServer.Shutdown(shutdownCtx); err != nil {
-			slog.Error("Failed to shutdown callback server", "error", err)
+			slog.ErrorContext(ctx, "Failed to shutdown callback server", "error", err)
 		}
 	}()
 
 	if err := callbackServer.Start(); err != nil {
-		slog.Error("Failed to start callback server", "error", err)
+		slog.ErrorContext(ctx, "Failed to start callback server", "error", err)
 		_ = r.client.ResumeElicitation(ctx, r.sessionID, "decline", nil)
 		return fmt.Errorf("failed to start callback server: %w", err)
 	}
 
 	redirectURI := callbackServer.GetRedirectURI()
-	slog.Debug("Callback server started", "redirect_uri", redirectURI)
+	slog.DebugContext(ctx, "Callback server started", "redirect_uri", redirectURI)
 
 	var clientID, clientSecret string
 	if authMetadata.RegistrationEndpoint != "" {
-		slog.Debug("Attempting dynamic client registration")
+		slog.DebugContext(ctx, "Attempting dynamic client registration")
 		clientID, clientSecret, err = mcp.RegisterClient(oauthCtx, &authMetadata, redirectURI, nil)
 		if err != nil {
-			slog.Error("Dynamic client registration failed", "error", err)
+			slog.ErrorContext(ctx, "Dynamic client registration failed", "error", err)
 			_ = r.client.ResumeElicitation(ctx, r.sessionID, "decline", nil)
 			return fmt.Errorf("failed to register client: %w", err)
 		}
-		slog.Debug("Client registered successfully", "client_id", clientID)
+		slog.DebugContext(ctx, "Client registered successfully", "client_id", clientID)
 	} else {
 		err := errors.New("authorization server does not support dynamic client registration")
-		slog.Error("Client registration not supported", "error", err)
+		slog.ErrorContext(ctx, "Client registration not supported", "error", err)
 		_ = r.client.ResumeElicitation(ctx, r.sessionID, "decline", nil)
 		return err
 	}
 
 	state, err := mcp.GenerateState()
 	if err != nil {
-		slog.Error("Failed to generate state", "error", err)
+		slog.ErrorContext(ctx, "Failed to generate state", "error", err)
 		_ = r.client.ResumeElicitation(ctx, r.sessionID, "decline", nil)
 		return fmt.Errorf("failed to generate state: %w", err)
 	}
@@ -433,24 +433,24 @@ func (r *RemoteRuntime) handleOAuthElicitation(ctx context.Context, req *Elicita
 		nil,
 	)
 
-	slog.Debug("Authorization URL built", "url", authURL)
+	slog.DebugContext(ctx, "Authorization URL built", "url", authURL)
 
-	slog.Debug("Requesting authorization code")
+	slog.DebugContext(ctx, "Requesting authorization code")
 	code, receivedState, err := mcp.RequestAuthorizationCode(oauthCtx, authURL, callbackServer, state)
 	if err != nil {
-		slog.Error("Failed to get authorization code", "error", err)
+		slog.ErrorContext(ctx, "Failed to get authorization code", "error", err)
 		_ = r.client.ResumeElicitation(ctx, r.sessionID, "decline", nil)
 		return fmt.Errorf("failed to get authorization code: %w", err)
 	}
 
 	if receivedState != state {
 		err := fmt.Errorf("state mismatch: expected %s, got %s", state, receivedState)
-		slog.Error("State mismatch in authorization response", "error", err)
+		slog.ErrorContext(ctx, "State mismatch in authorization response", "error", err)
 		_ = r.client.ResumeElicitation(ctx, r.sessionID, "decline", nil)
 		return err
 	}
 
-	slog.Debug("Authorization code received, exchanging for token")
+	slog.DebugContext(ctx, "Authorization code received, exchanging for token")
 
 	token, err := mcp.ExchangeCodeForToken(
 		oauthCtx,
@@ -462,12 +462,12 @@ func (r *RemoteRuntime) handleOAuthElicitation(ctx context.Context, req *Elicita
 		redirectURI,
 	)
 	if err != nil {
-		slog.Error("Failed to exchange code for token", "error", err)
+		slog.ErrorContext(ctx, "Failed to exchange code for token", "error", err)
 		_ = r.client.ResumeElicitation(ctx, r.sessionID, "decline", nil)
 		return fmt.Errorf("failed to exchange code for token: %w", err)
 	}
 
-	slog.Debug("Token obtained successfully", "token_type", token.TokenType)
+	slog.DebugContext(ctx, "Token obtained successfully", "token_type", token.TokenType)
 
 	tokenData := map[string]any{
 		"access_token": token.AccessToken,
@@ -480,13 +480,13 @@ func (r *RemoteRuntime) handleOAuthElicitation(ctx context.Context, req *Elicita
 		tokenData["refresh_token"] = token.RefreshToken
 	}
 
-	slog.Debug("Sending token to server")
+	slog.DebugContext(ctx, "Sending token to server")
 	if err := r.client.ResumeElicitation(ctx, r.sessionID, tools.ElicitationActionAccept, tokenData); err != nil {
-		slog.Error("Failed to send token to server", "error", err)
+		slog.ErrorContext(ctx, "Failed to send token to server", "error", err)
 		return fmt.Errorf("failed to send token to server: %w", err)
 	}
 
-	slog.Debug("OAuth flow completed successfully")
+	slog.DebugContext(ctx, "OAuth flow completed successfully")
 	return nil
 }
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -485,7 +485,7 @@ func NewLocalRuntime(agents *team.Team, opts ...Opt) (*LocalRuntime, error) {
 		return nil, err
 	}
 
-	if defaultAgent.Model() == nil {
+	if defaultAgent.Model(context.TODO()) == nil {
 		return nil, fmt.Errorf("agent %s has no valid model", defaultAgent.Name())
 	}
 
@@ -645,14 +645,14 @@ func (r *LocalRuntime) CurrentMCPPrompts(ctx context.Context) map[string]mcptool
 	// Get the current agent to access its toolsets
 	currentAgent := r.CurrentAgent()
 	if currentAgent == nil {
-		slog.Warn("No current agent available for MCP prompt discovery")
+		slog.WarnContext(ctx, "No current agent available for MCP prompt discovery")
 		return prompts
 	}
 
 	// Iterate through all toolsets of the current agent
 	for _, toolset := range currentAgent.ToolSets() {
 		if mcpToolset, ok := tools.As[*mcptools.Toolset](toolset); ok {
-			slog.Debug("Found MCP toolset", "toolset", mcpToolset)
+			slog.DebugContext(ctx, "Found MCP toolset", "toolset", mcpToolset)
 			// Discover prompts from this MCP toolset
 			mcpPrompts := r.discoverMCPPrompts(ctx, mcpToolset)
 
@@ -660,11 +660,11 @@ func (r *LocalRuntime) CurrentMCPPrompts(ctx context.Context) map[string]mcptool
 			// If there are name conflicts, the later toolset's prompt will override
 			maps.Copy(prompts, mcpPrompts)
 		} else {
-			slog.Debug("Toolset is not an MCP toolset", "type", fmt.Sprintf("%T", toolset))
+			slog.DebugContext(ctx, "Toolset is not an MCP toolset", "type", fmt.Sprintf("%T", toolset))
 		}
 	}
 
-	slog.Debug("Discovered MCP prompts", "agent", currentAgent.Name(), "prompt_count", len(prompts))
+	slog.DebugContext(ctx, "Discovered MCP prompts", "agent", currentAgent.Name(), "prompt_count", len(prompts))
 	return prompts
 }
 
@@ -674,7 +674,7 @@ func (r *LocalRuntime) CurrentMCPPrompts(ctx context.Context) map[string]mcptool
 func (r *LocalRuntime) discoverMCPPrompts(ctx context.Context, toolset *mcptools.Toolset) map[string]mcptools.PromptInfo {
 	mcpPrompts, err := toolset.ListPrompts(ctx)
 	if err != nil {
-		slog.Warn("Failed to list MCP prompts from toolset", "error", err)
+		slog.WarnContext(ctx, "Failed to list MCP prompts from toolset", "error", err)
 		return nil
 	}
 
@@ -695,7 +695,7 @@ func (r *LocalRuntime) discoverMCPPrompts(ctx context.Context, toolset *mcptools
 		}
 
 		prompts[mcpPrompt.Name] = promptInfo
-		slog.Debug("Discovered MCP prompt", "name", mcpPrompt.Name, "args_count", len(promptInfo.Arguments))
+		slog.DebugContext(ctx, "Discovered MCP prompt", "name", mcpPrompt.Name, "args_count", len(promptInfo.Arguments))
 	}
 
 	return prompts
@@ -777,7 +777,10 @@ func (r *LocalRuntime) TitleGenerator() *sessiontitle.Generator {
 	if a == nil {
 		return nil
 	}
-	model := a.Model()
+	// Title-gen setup happens before any session ctx exists; the resulting
+	// generator carries its own ctx when actually invoked. context.TODO is
+	// the right marker here.
+	model := a.Model(context.TODO())
 	if model == nil {
 		return nil
 	}
@@ -786,7 +789,7 @@ func (r *LocalRuntime) TitleGenerator() *sessiontitle.Generator {
 
 // getAgentModelID returns the model ID for an agent, or empty string if no model is set.
 func getAgentModelID(a *agent.Agent) string {
-	if model := a.Model(); model != nil {
+	if model := a.Model(context.TODO()); model != nil {
 		return model.ID()
 	}
 	return ""
@@ -1065,7 +1068,7 @@ func (r *LocalRuntime) emitToolsProgressively(ctx context.Context, a *agent.Agen
 						// deliberately deferred until the user is interacting
 						// with the agent. The dialog will appear naturally on
 						// the first RunStream — no need to pre-announce it.
-						slog.Debug("Toolset deferred until first message", "agent", a.Name(), "toolset", desc, "reason", err)
+						slog.DebugContext(ctx, "Toolset deferred until first message", "agent", a.Name(), "toolset", desc, "reason", err)
 						continue
 					}
 					// Route real failures through the agent's warning
@@ -1077,10 +1080,10 @@ func (r *LocalRuntime) emitToolsProgressively(ctx context.Context, a *agent.Agen
 					// so a failing toolset doesn't flood the UI with a
 					// new warning every time the agent is restarted.
 					if !startable.ShouldReportFailure() {
-						slog.Debug("Toolset still unavailable; skipping", "agent", a.Name(), "toolset", desc, "error", err)
+						slog.DebugContext(ctx, "Toolset still unavailable; skipping", "agent", a.Name(), "toolset", desc, "error", err)
 						continue
 					}
-					slog.Warn("Toolset start failed; skipping", "agent", a.Name(), "toolset", desc, "error", err)
+					slog.WarnContext(ctx, "Toolset start failed; skipping", "agent", a.Name(), "toolset", desc, "error", err)
 					a.AddToolWarning(fmt.Sprintf("%s start failed: %v", desc, err))
 					continue
 				}
@@ -1090,7 +1093,7 @@ func (r *LocalRuntime) emitToolsProgressively(ctx context.Context, a *agent.Agen
 		// Get tools from this toolset
 		ts, err := toolset.Tools(ctx)
 		if err != nil {
-			slog.Warn("Failed to get tools from toolset", "agent", a.Name(), "error", err)
+			slog.WarnContext(ctx, "Failed to get tools from toolset", "agent", a.Name(), "error", err)
 			continue
 		}
 
@@ -1211,7 +1214,7 @@ func (r *LocalRuntime) compactWithReason(ctx context.Context, sess *session.Sess
 	source := preCompactSourceFor(reason)
 	skip, msg, extraPrompt := r.executePreCompactHooks(ctx, sess, a, source, events)
 	if skip {
-		slog.Warn("pre_compact hook signalled skip",
+		slog.WarnContext(ctx, "pre_compact hook signalled skip",
 			"agent", a.Name(), "session_id", sess.ID, "source", source, "reason", msg)
 		if msg != "" {
 			events <- Warning(msg, a.Name())

--- a/pkg/runtime/session_compaction.go
+++ b/pkg/runtime/session_compaction.go
@@ -58,14 +58,14 @@ func (r *LocalRuntime) doCompact(ctx context.Context, sess *session.Session, a *
 	// before_compaction: hooks can veto or supply a custom summary.
 	pre := r.executeBeforeCompactionHooks(ctx, sess, a, reason, contextLimit, events)
 	if pre != nil && !pre.Allowed {
-		slog.Info("Session compaction skipped by before_compaction hook",
+		slog.InfoContext(ctx, "Session compaction skipped by before_compaction hook",
 			"session_id", sess.ID, "agent", a.Name(), "reason", reason,
 			"hook_message", pre.Message,
 		)
 		return
 	}
 
-	slog.Debug("Generating summary for session", "session_id", sess.ID, "reason", reason)
+	slog.DebugContext(ctx, "Generating summary for session", "session_id", sess.ID, "reason", reason)
 	events <- SessionCompaction(sess.ID, "started", a.Name())
 	defer func() {
 		events <- SessionCompaction(sess.ID, "completed", a.Name())
@@ -76,7 +76,7 @@ func (r *LocalRuntime) doCompact(ctx context.Context, sess *session.Session, a *
 	result := summaryFromHook(sess, a, pre)
 	if result == nil {
 		if contextLimit <= 0 {
-			slog.Error("Failed to generate session summary",
+			slog.ErrorContext(ctx, "Failed to generate session summary",
 				"error", "model definition unavailable")
 			events <- Error("Failed to get model definition")
 			return
@@ -91,7 +91,7 @@ func (r *LocalRuntime) doCompact(ctx context.Context, sess *session.Session, a *
 			RunAgent:         r.runCompactionAgent,
 		})
 		if err != nil {
-			slog.Error("Failed to generate session summary", "error", err)
+			slog.ErrorContext(ctx, "Failed to generate session summary", "error", err)
 			events <- Error(err.Error())
 			return
 		}
@@ -118,7 +118,7 @@ func (r *LocalRuntime) doCompact(ctx context.Context, sess *session.Session, a *
 	})
 	_ = r.sessionStore.UpdateSession(ctx, sess)
 
-	slog.Debug("Generated session summary", "session_id", sess.ID, "summary_length", len(result.Summary))
+	slog.DebugContext(ctx, "Generated session summary", "session_id", sess.ID, "summary_length", len(result.Summary))
 	events <- SessionSummary(sess.ID, result.Summary, a.Name(), result.FirstKeptEntry)
 
 	// after_compaction: observational. Fired only when a summary was
@@ -163,10 +163,10 @@ func summaryFromHook(sess *session.Session, a *agent.Agent, pre *hooks.Result) *
 // hook may supply its own summary and never need the model definition.
 // The LLM strategy itself enforces ContextLimit > 0.
 func (r *LocalRuntime) compactionContextLimit(ctx context.Context, a *agent.Agent) int64 {
-	if a == nil || a.Model() == nil {
+	if a == nil || a.Model(ctx) == nil {
 		return 0
 	}
-	summaryModel := provider.CloneWithOptions(ctx, a.Model(),
+	summaryModel := provider.CloneWithOptions(ctx, a.Model(ctx),
 		options.WithStructuredOutput(nil),
 		options.WithMaxTokens(compactor.MaxSummaryTokens),
 	)

--- a/pkg/runtime/skill_runner.go
+++ b/pkg/runtime/skill_runner.go
@@ -56,7 +56,7 @@ func (r *LocalRuntime) handleRunSkill(ctx context.Context, sess *session.Session
 	))
 	defer span.End()
 
-	slog.Debug("Running skill as sub-agent",
+	slog.DebugContext(ctx, "Running skill as sub-agent",
 		"agent", ca,
 		"skill", prepared.SkillName,
 		"task", prepared.Task,
@@ -71,7 +71,7 @@ func (r *LocalRuntime) handleRunSkill(ctx context.Context, sess *session.Session
 		restore, err := r.WithAgentModel(ctx, ca, prepared.Model)
 		defer restore()
 		if err != nil {
-			slog.Warn("Failed to apply skill model override; using current model",
+			slog.WarnContext(ctx, "Failed to apply skill model override; using current model",
 				"agent", ca,
 				"skill", prepared.SkillName,
 				"model", prepared.Model,

--- a/pkg/runtime/strip_modalities.go
+++ b/pkg/runtime/strip_modalities.go
@@ -51,7 +51,7 @@ func (r *LocalRuntime) stripUnsupportedModalitiesTransform(
 	msgs []chat.Message,
 ) ([]chat.Message, error) {
 	if in == nil || in.ModelID == "" {
-		slog.Debug("strip_unsupported_modalities: skipping, no ModelID on input")
+		slog.DebugContext(ctx, "strip_unsupported_modalities: skipping, no ModelID on input")
 		return msgs, nil
 	}
 	m, err := r.modelsStore.GetModel(ctx, in.ModelID)
@@ -59,7 +59,7 @@ func (r *LocalRuntime) stripUnsupportedModalitiesTransform(
 		// Unknown model: keep the previous (inline) behavior of
 		// passing messages through untouched. The model call will
 		// surface any modality mismatch as a provider error.
-		slog.Debug("strip_unsupported_modalities: skipping, model definition unavailable",
+		slog.DebugContext(ctx, "strip_unsupported_modalities: skipping, model definition unavailable",
 			"model_id", in.ModelID, "error", err)
 		return msgs, nil
 	}

--- a/pkg/runtime/toolexec/dispatcher.go
+++ b/pkg/runtime/toolexec/dispatcher.go
@@ -166,7 +166,7 @@ type Dispatcher struct {
 // error responses can be sent back to the model on the next turn.
 func (d *Dispatcher) Process(ctx context.Context, sess *session.Session, calls []tools.ToolCall, agentTools []tools.Tool, em Emitter) (stopRun bool, stopMessage string) {
 	a := d.AgentFor(sess)
-	slog.Debug("Processing tool calls", "agent", a.Name(), "call_count", len(calls))
+	slog.DebugContext(ctx, "Processing tool calls", "agent", a.Name(), "call_count", len(calls))
 
 	toolByName := make(map[string]tools.Tool, len(agentTools))
 	for _, t := range agentTools {
@@ -254,13 +254,13 @@ func (c *call) run(ctx context.Context) CallOutcome {
 	))
 	defer span.End()
 
-	slog.Debug("Processing tool call", "agent", c.a.Name(), "tool", c.tc.Function.Name, "session_id", c.sess.ID)
+	slog.DebugContext(ctx, "Processing tool call", "agent", c.a.Name(), "tool", c.tc.Function.Name, "session_id", c.sess.ID)
 
 	// After a handoff the model may hallucinate tools it saw earlier in
 	// the conversation. Reject unknown tools with an error response so it
 	// can self-correct.
 	if !c.available {
-		slog.Warn("Tool call for unavailable tool", "agent", c.a.Name(), "tool", c.tc.Function.Name, "session_id", c.sess.ID)
+		slog.WarnContext(ctx, "Tool call for unavailable tool", "agent", c.a.Name(), "tool", c.tc.Function.Name, "session_id", c.sess.ID)
 		c.errorResponse(ctx, fmt.Sprintf("Tool '%s' is not available. You can only use the tools provided to you.", c.tc.Function.Name))
 		span.SetStatus(codes.Error, "tool not available")
 		return CallOutcome{}
@@ -333,7 +333,7 @@ func (c *call) approveAndRun(ctx context.Context, runTool func() CallOutcome) Ca
 		c.notifyApproval(ctx, ApprovalDecisionAllow, allowSourceForDecision(decision))
 		return runTool()
 	case OutcomeDeny:
-		slog.Debug("Tool denied by permissions", "tool", c.tc.Function.Name, "source", decision.Source, "session_id", c.sess.ID)
+		slog.DebugContext(ctx, "Tool denied by permissions", "tool", c.tc.Function.Name, "source", decision.Source, "session_id", c.sess.ID)
 		c.notifyApproval(ctx, ApprovalDecisionDeny, denySourceForChecker(decision.Source))
 		c.errorResponse(ctx, fmt.Sprintf("Tool '%s' is denied by %s.", c.tc.Function.Name, decision.Source))
 		return CallOutcome{}
@@ -342,7 +342,7 @@ func (c *call) approveAndRun(ctx context.Context, runTool func() CallOutcome) Ca
 			// Explicit ask pattern from a checker: skip the hook and
 			// prompt the user directly. The user is the source of
 			// truth for these calls.
-			slog.Debug("Tool requires confirmation (ask pattern)", "tool", c.tc.Function.Name, "source", decision.Source, "session_id", c.sess.ID)
+			slog.DebugContext(ctx, "Tool requires confirmation (ask pattern)", "tool", c.tc.Function.Name, "source", decision.Source, "session_id", c.sess.ID)
 			return c.askUser(ctx, runTool)
 		}
 	}
@@ -386,7 +386,7 @@ func (c *call) consultPreToolUseHook(ctx context.Context, runTool func() CallOut
 	c.applyHookModifiedInput(result)
 
 	if !result.Allowed {
-		slog.Debug("Pre-tool hook blocked tool call", "tool", c.tc.Function.Name, "message", result.Message)
+		slog.DebugContext(ctx, "Pre-tool hook blocked tool call", "tool", c.tc.Function.Name, "message", result.Message)
 		c.notifyApproval(ctx, ApprovalDecisionDeny, ApprovalSourcePreToolUseHookDeny)
 		c.em.EmitHookBlocked(c.tc, c.tool, result.Message, c.a.Name())
 		c.errorResponse(ctx, "Tool call blocked by hook: "+result.Message)
@@ -395,11 +395,11 @@ func (c *call) consultPreToolUseHook(ctx context.Context, runTool func() CallOut
 
 	switch result.Decision {
 	case hooks.DecisionAllow:
-		slog.Debug("Tool auto-approved by pre_tool_use hook", "tool", c.tc.Function.Name, "reason", result.DecisionReason, "session_id", c.sess.ID)
+		slog.DebugContext(ctx, "Tool auto-approved by pre_tool_use hook", "tool", c.tc.Function.Name, "reason", result.DecisionReason, "session_id", c.sess.ID)
 		c.notifyApproval(ctx, ApprovalDecisionAllow, ApprovalSourcePreToolUseHookAllow)
 		return runTool(), true
 	case hooks.DecisionAsk:
-		slog.Debug("pre_tool_use hook escalated to user", "tool", c.tc.Function.Name, "reason", result.DecisionReason, "session_id", c.sess.ID)
+		slog.DebugContext(ctx, "pre_tool_use hook escalated to user", "tool", c.tc.Function.Name, "reason", result.DecisionReason, "session_id", c.sess.ID)
 		return c.askUser(ctx, runTool), true
 	}
 	return CallOutcome{}, false
@@ -487,7 +487,7 @@ func (c *call) askUser(ctx context.Context, runTool func() CallOutcome) CallOutc
 		return outcome
 	}
 
-	slog.Debug("Tools not approved, waiting for resume", "tool", c.tc.Function.Name, "session_id", c.sess.ID)
+	slog.DebugContext(ctx, "Tools not approved, waiting for resume", "tool", c.tc.Function.Name, "session_id", c.sess.ID)
 	c.em.EmitToolCallConfirmation(c.tc, c.tool, c.a.Name())
 
 	if c.d.Hooks != nil {
@@ -498,7 +498,7 @@ func (c *call) askUser(ctx context.Context, runTool func() CallOutcome) CallOutc
 	case req := <-c.d.Resume:
 		return c.handleResume(ctx, req, runTool)
 	case <-ctx.Done():
-		slog.Debug("Context cancelled while waiting for resume", "tool", c.tc.Function.Name, "session_id", c.sess.ID)
+		slog.DebugContext(ctx, "Context cancelled while waiting for resume", "tool", c.tc.Function.Name, "session_id", c.sess.ID)
 		c.notifyApproval(ctx, ApprovalDecisionCanceled, ApprovalSourceContextCanceled)
 		c.errorResponse(ctx, "The tool call was canceled by the user.")
 		return CallOutcome{Canceled: true}
@@ -528,7 +528,7 @@ func (c *call) runPermissionRequestHook(ctx context.Context, runTool func() Call
 	}
 
 	if !result.Allowed {
-		slog.Debug("Tool denied by permission_request hook", "tool", toolName, "session_id", c.sess.ID, "reason", result.Message)
+		slog.DebugContext(ctx, "Tool denied by permission_request hook", "tool", toolName, "session_id", c.sess.ID, "reason", result.Message)
 		rejectMsg := "The tool call was rejected by a permission_request hook."
 		if reason := strings.TrimSpace(result.Message); reason != "" {
 			rejectMsg += " Reason: " + reason
@@ -538,7 +538,7 @@ func (c *call) runPermissionRequestHook(ctx context.Context, runTool func() Call
 	}
 
 	if result.PermissionAllowed {
-		slog.Debug("Tool auto-approved by permission_request hook", "tool", toolName, "session_id", c.sess.ID, "reason", result.AdditionalContext)
+		slog.DebugContext(ctx, "Tool auto-approved by permission_request hook", "tool", toolName, "session_id", c.sess.ID, "reason", result.AdditionalContext)
 		return runTool(), true
 	}
 
@@ -551,11 +551,11 @@ func (c *call) runPermissionRequestHook(ctx context.Context, runTool func() Call
 func (c *call) handleResume(ctx context.Context, req ResumeRequest, runTool func() CallOutcome) CallOutcome {
 	switch req.Type {
 	case ResumeTypeApprove:
-		slog.Debug("Resume signal received, approving tool", "tool", c.tc.Function.Name, "session_id", c.sess.ID)
+		slog.DebugContext(ctx, "Resume signal received, approving tool", "tool", c.tc.Function.Name, "session_id", c.sess.ID)
 		c.notifyApproval(ctx, ApprovalDecisionAllow, ApprovalSourceUserApproved)
 		return runTool()
 	case ResumeTypeApproveSession:
-		slog.Debug("Resume signal received, approving session", "tool", c.tc.Function.Name, "session_id", c.sess.ID)
+		slog.DebugContext(ctx, "Resume signal received, approving session", "tool", c.tc.Function.Name, "session_id", c.sess.ID)
 		c.sess.ToolsApproved = true
 		c.notifyApproval(ctx, ApprovalDecisionAllow, ApprovalSourceUserApprovedSession)
 		return runTool()
@@ -570,11 +570,11 @@ func (c *call) handleResume(ctx context.Context, req ResumeRequest, runTool func
 		if !slices.Contains(c.sess.Permissions.Allow, approvedTool) {
 			c.sess.Permissions.Allow = append(c.sess.Permissions.Allow, approvedTool)
 		}
-		slog.Debug("Resume signal received, approving tool permanently", "tool", approvedTool, "session_id", c.sess.ID)
+		slog.DebugContext(ctx, "Resume signal received, approving tool permanently", "tool", approvedTool, "session_id", c.sess.ID)
 		c.notifyApproval(ctx, ApprovalDecisionAllow, ApprovalSourceUserApprovedTool)
 		return runTool()
 	case ResumeTypeReject:
-		slog.Debug("Resume signal received, rejecting tool", "tool", c.tc.Function.Name, "session_id", c.sess.ID, "reason", req.Reason)
+		slog.DebugContext(ctx, "Resume signal received, rejecting tool", "tool", c.tc.Function.Name, "session_id", c.sess.ID, "reason", req.Reason)
 		c.notifyApproval(ctx, ApprovalDecisionDeny, ApprovalSourceUserRejected)
 		msg := "The user rejected the tool call."
 		if reason := strings.TrimSpace(req.Reason); reason != "" {
@@ -635,7 +635,7 @@ func (c *call) invoke(ctx context.Context, spanName string, exec func(ctx contex
 		res = c.translateError(ctx, span, err)
 	} else {
 		span.SetStatus(codes.Ok, "tool handler completed")
-		slog.Debug("Tool call completed", "tool", c.tc.Function.Name, "output_length", len(res.Output))
+		slog.DebugContext(ctx, "Tool call completed", "tool", c.tc.Function.Name, "output_length", len(res.Output))
 	}
 
 	// tool_response_transform fires here — BEFORE event emission, the
@@ -683,13 +683,13 @@ func (c *call) applyToolResponseTransform(ctx context.Context, payload string, i
 // recorded as an error.
 func (c *call) translateError(ctx context.Context, span trace.Span, err error) *tools.ToolCallResult {
 	if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
-		slog.Debug("Tool handler canceled by context", "tool", c.tc.Function.Name, "agent", c.a.Name(), "session_id", c.sess.ID)
+		slog.DebugContext(ctx, "Tool handler canceled by context", "tool", c.tc.Function.Name, "agent", c.a.Name(), "session_id", c.sess.ID)
 		span.SetStatus(codes.Ok, "tool handler canceled by user")
 		return tools.ResultError("The tool call was canceled by the user.")
 	}
 	span.RecordError(err)
 	span.SetStatus(codes.Error, "tool handler error")
-	slog.Error("Error calling tool", "tool", c.tc.Function.Name, "error", err)
+	slog.ErrorContext(ctx, "Error calling tool", "tool", c.tc.Function.Name, "error", err)
 	return tools.ResultError(fmt.Sprintf("Error calling tool: %v", err))
 }
 

--- a/pkg/runtime/transforms.go
+++ b/pkg/runtime/transforms.go
@@ -91,7 +91,7 @@ func (r *LocalRuntime) applyBeforeLLMCallTransforms(
 	for _, t := range r.transforms {
 		out, err := t.fn(ctx, in, msgs)
 		if err != nil {
-			slog.Warn("Message transform failed; continuing with previous messages",
+			slog.WarnContext(ctx, "Message transform failed; continuing with previous messages",
 				"transform", t.name, "agent", a.Name(), "error", err)
 			continue
 		}

--- a/pkg/runtime/with_agent_model_test.go
+++ b/pkg/runtime/with_agent_model_test.go
@@ -70,7 +70,7 @@ func TestWithAgentModel(t *testing.T) {
 		userPick := &mockProvider{id: "user/pick"}
 		root := agent.New("root", "test", agent.WithModel(&mockProvider{id: "default/model"}))
 		root.SetModelOverride(userPick)
-		require.Equal(t, "user/pick", root.Model().ID())
+		require.Equal(t, "user/pick", root.Model(t.Context()).ID())
 
 		tm := team.New(team.WithAgents(root))
 		r := &LocalRuntime{
@@ -86,12 +86,12 @@ func TestWithAgentModel(t *testing.T) {
 
 		// Inside the scope: override is cleared.
 		assert.False(t, root.HasModelOverride())
-		assert.Equal(t, "default/model", root.Model().ID())
+		assert.Equal(t, "default/model", root.Model(t.Context()).ID())
 
 		// After restore: user's pick is back.
 		restore()
 		assert.True(t, root.HasModelOverride())
-		assert.Equal(t, "user/pick", root.Model().ID())
+		assert.Equal(t, "user/pick", root.Model(t.Context()).ID())
 	})
 
 	t.Run("restore is idempotent", func(t *testing.T) {
@@ -110,10 +110,10 @@ func TestWithAgentModel(t *testing.T) {
 		require.NoError(t, err)
 
 		restore()
-		assert.Equal(t, "user/pick", root.Model().ID())
+		assert.Equal(t, "user/pick", root.Model(t.Context()).ID())
 		// Second call is a CAS no-op (the state is already restored).
 		assert.NotPanics(t, restore)
-		assert.Equal(t, "user/pick", root.Model().ID())
+		assert.Equal(t, "user/pick", root.Model(t.Context()).ID())
 	})
 
 	t.Run("concurrent change is preserved by restore", func(t *testing.T) {
@@ -140,6 +140,6 @@ func TestWithAgentModel(t *testing.T) {
 		// Restore must be a no-op because the override changed.
 		restore()
 		require.True(t, root.HasModelOverride(), "concurrent change must be preserved")
-		assert.Equal(t, "user/pick", root.Model().ID())
+		assert.Equal(t, "user/pick", root.Model(t.Context()).ID())
 	})
 }

--- a/pkg/sandbox/sandbox.go
+++ b/pkg/sandbox/sandbox.go
@@ -104,13 +104,13 @@ func (b *Backend) Ensure(ctx context.Context, wd, extra, template, configDir str
 	if existing != nil &&
 		(extra == "" || existing.HasWorkspace(extra)) &&
 		existing.HasWorkspace(configDir) {
-		slog.Debug("Reusing existing sandbox", "name", existing.Name)
+		slog.DebugContext(ctx, "Reusing existing sandbox", "name", existing.Name)
 		return existing.Name, nil
 	}
 
 	// Remove a stale sandbox whose mounts don't match.
 	if existing != nil {
-		slog.Debug("Removing existing sandbox to change workspace mounts", "name", existing.Name)
+		slog.DebugContext(ctx, "Removing existing sandbox to change workspace mounts", "name", existing.Name)
 		rmCmd := exec.CommandContext(ctx, b.program, b.args("rm", existing.Name)...)
 		b.applyEnv(rmCmd)
 		_ = rmCmd.Run()
@@ -129,7 +129,7 @@ func (b *Backend) Ensure(ctx context.Context, wd, extra, template, configDir str
 	createExtra = append(createExtra, configDir+":ro")
 
 	createArgs := b.args("create", createExtra...)
-	slog.Debug("Creating sandbox", "args", createArgs)
+	slog.DebugContext(ctx, "Creating sandbox", "args", createArgs)
 
 	createCmd := exec.CommandContext(ctx, b.program, createArgs...)
 	b.applyEnv(createCmd)
@@ -220,7 +220,7 @@ func EnvForAgent(ctx context.Context, agentRef string, env environment.Provider)
 
 	names, err := gatherAgentEnvVars(ctx, agentRef, env)
 	if err != nil {
-		slog.Debug("Failed to gather agent env vars for sandbox", "error", err)
+		slog.DebugContext(ctx, "Failed to gather agent env vars for sandbox", "error", err)
 		return nil, nil
 	}
 
@@ -257,7 +257,7 @@ func gatherAgentEnvVars(ctx context.Context, agentRef string, env environment.Pr
 
 	toolNames, err := config.GatherEnvVarsForTools(ctx, cfg)
 	if err != nil {
-		slog.Debug("Failed to gather tool env vars", "error", err)
+		slog.DebugContext(ctx, "Failed to gather tool env vars", "error", err)
 	}
 	names = append(names, toolNames...)
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -85,7 +85,7 @@ func (s *Server) Serve(ctx context.Context, ln net.Listener) error {
 	}
 
 	if err := srv.Serve(ln); err != nil && ctx.Err() == nil {
-		slog.Error("Failed to start server", "error", err)
+		slog.ErrorContext(ctx, "Failed to start server", "error", err)
 		return err
 	}
 

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -352,7 +352,7 @@ func (sm *SessionManager) UpdateSessionTitle(ctx context.Context, sessionID, tit
 	// This ensures the runtime's saveSession won't overwrite our manual edit.
 	if rt, ok := sm.runtimeSessions.Load(sessionID); ok && rt.session != nil {
 		rt.session.Title = title
-		slog.Debug("Updated title for active session", "session_id", sessionID, "title", title)
+		slog.DebugContext(ctx, "Updated title for active session", "session_id", sessionID, "title", title)
 		return sm.sessionStore.UpdateSession(ctx, rt.session)
 	}
 
@@ -376,7 +376,7 @@ func (sm *SessionManager) generateTitle(ctx context.Context, sess *session.Sessi
 
 	title, err := gen.Generate(ctx, sess.ID, userMessages)
 	if err != nil {
-		slog.Error("Failed to generate session title", "session_id", sess.ID, "error", err)
+		slog.ErrorContext(ctx, "Failed to generate session title", "session_id", sess.ID, "error", err)
 		return
 	}
 
@@ -389,16 +389,16 @@ func (sm *SessionManager) generateTitle(ctx context.Context, sess *session.Sessi
 
 	// Persist the title
 	if err := sm.sessionStore.UpdateSession(ctx, sess); err != nil {
-		slog.Error("Failed to persist generated title", "session_id", sess.ID, "error", err)
+		slog.ErrorContext(ctx, "Failed to persist generated title", "session_id", sess.ID, "error", err)
 		return
 	}
 
 	// Emit the title event
 	select {
 	case events <- runtime.SessionTitle(sess.ID, title):
-		slog.Debug("Generated and emitted session title", "session_id", sess.ID, "title", title)
+		slog.DebugContext(ctx, "Generated and emitted session title", "session_id", sess.ID, "title", title)
 	case <-ctx.Done():
-		slog.Debug("Context cancelled while emitting title event", "session_id", sess.ID)
+		slog.DebugContext(ctx, "Context cancelled while emitting title event", "session_id", sess.ID)
 	}
 }
 
@@ -434,9 +434,9 @@ func (sm *SessionManager) runtimeForSession(ctx context.Context, sess *session.S
 		return nil, nil, err
 	}
 
-	titleGen := sessiontitle.New(agt.Model(), agt.FallbackModels()...)
+	titleGen := sessiontitle.New(agt.Model(ctx), agt.FallbackModels()...)
 
-	slog.Debug("Runtime created for session", "session_id", sess.ID)
+	slog.DebugContext(ctx, "Runtime created for session", "session_id", sess.ID)
 
 	return run, titleGen, nil
 }
@@ -460,7 +460,7 @@ func (sm *SessionManager) GetAgentToolCount(ctx context.Context, agentFilename, 
 	}
 	defer func() {
 		if stopErr := t.StopToolSets(ctx); stopErr != nil {
-			slog.Error("Failed to stop tool sets", "error", stopErr)
+			slog.ErrorContext(ctx, "Failed to stop tool sets", "error", stopErr)
 		}
 	}()
 

--- a/pkg/server/source_loader.go
+++ b/pkg/server/source_loader.go
@@ -60,7 +60,7 @@ func (sl *sourceLoader) load(ctx context.Context) {
 
 	if err != nil {
 		// Only log errors, keep previous data if available
-		slog.Warn("Failed to refresh source",
+		slog.WarnContext(ctx, "Failed to refresh source",
 			"source", sl.inner.Name(),
 			"error", err)
 		// Only update error if we don't have data yet

--- a/pkg/session/migrations.go
+++ b/pkg/session/migrations.go
@@ -405,7 +405,7 @@ func getAllMigrations() []Migration {
 
 // migrateMessagesToSessionItems migrates data from the messages JSON column to the session_items table
 func migrateMessagesToSessionItems(ctx context.Context, db *sql.DB) error {
-	slog.Info("Starting migration of messages to session_items")
+	slog.InfoContext(ctx, "Starting migration of messages to session_items")
 
 	// Get all sessions that have messages but no items yet
 	rows, err := db.QueryContext(ctx, `
@@ -440,17 +440,17 @@ func migrateMessagesToSessionItems(ctx context.Context, db *sql.DB) error {
 		return fmt.Errorf("iterating sessions: %w", err)
 	}
 
-	slog.Info("Found sessions to migrate", "count", len(sessionsToMigrate))
+	slog.InfoContext(ctx, "Found sessions to migrate", "count", len(sessionsToMigrate))
 
 	// Migrate each session
 	for _, sess := range sessionsToMigrate {
 		if err := migrateSessionMessages(ctx, db, sess.id, sess.messages, ""); err != nil {
-			slog.Warn("Failed to migrate session, skipping", "session_id", sess.id, "error", err)
+			slog.WarnContext(ctx, "Failed to migrate session, skipping", "session_id", sess.id, "error", err)
 			continue
 		}
 	}
 
-	slog.Info("Completed migration of messages to session_items")
+	slog.InfoContext(ctx, "Completed migration of messages to session_items")
 	return nil
 }
 

--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -735,7 +735,7 @@ func (s *SQLiteSessionStore) loadSessionItems(ctx context.Context, q querier, se
 			// Skip if subsession_id is NULL (can happen if the sub-session was deleted
 			// and the foreign key set the reference to NULL)
 			if !row.subsessionID.Valid || row.subsessionID.String == "" {
-				slog.Warn("Skipping subsession item with NULL reference", "session_id", sessionID, "position", row.position)
+				slog.WarnContext(ctx, "Skipping subsession item with NULL reference", "session_id", sessionID, "position", row.position)
 				continue
 			}
 			// Recursively load sub-session
@@ -743,7 +743,7 @@ func (s *SQLiteSessionStore) loadSessionItems(ctx context.Context, q querier, se
 			if err != nil {
 				if errors.Is(err, ErrNotFound) {
 					// Sub-session was deleted but item reference remains (orphaned reference)
-					slog.Warn("Skipping orphaned subsession reference", "session_id", sessionID, "subsession_id", row.subsessionID.String)
+					slog.WarnContext(ctx, "Skipping orphaned subsession reference", "session_id", sessionID, "subsession_id", row.subsessionID.String)
 					continue
 				}
 				return nil, fmt.Errorf("getting sub-session %s: %w", row.subsessionID.String, err)
@@ -984,7 +984,7 @@ func (s *SQLiteSessionStore) AddMessage(ctx context.Context, sessionID string, m
 		return 0, fmt.Errorf("getting last insert id: %w", err)
 	}
 
-	slog.Debug("[STORE] AddMessage", "session_id", sessionID, "message_id", id, "role", msg.Message.Role, "agent", msg.AgentName)
+	slog.DebugContext(ctx, "[STORE] AddMessage", "session_id", sessionID, "message_id", id, "role", msg.Message.Role, "agent", msg.AgentName)
 	return id, nil
 }
 

--- a/pkg/sessiontitle/generator.go
+++ b/pkg/sessiontitle/generator.go
@@ -71,7 +71,7 @@ func (g *Generator) Generate(ctx context.Context, sessionID string, userMessages
 	ctx, cancel := context.WithTimeout(ctx, titleGenerationTimeout)
 	defer cancel()
 
-	slog.Debug("Generating title for session", "session_id", sessionID, "message_count", len(userMessages))
+	slog.DebugContext(ctx, "Generating title for session", "session_id", sessionID, "message_count", len(userMessages))
 
 	messages := buildPrompt(userMessages)
 
@@ -83,14 +83,14 @@ func (g *Generator) Generate(ctx context.Context, sessionID string, userMessages
 
 		title, err := generateOnce(ctx, baseModel, messages)
 		if err == nil {
-			slog.Debug("Generated session title", "session_id", sessionID, "title", title, "model", baseModel.ID())
+			slog.DebugContext(ctx, "Generated session title", "session_id", sessionID, "title", title, "model", baseModel.ID())
 			return title, nil
 		}
 
 		lastErr = err
 		// Per-attempt failures are logged at Debug because we still have
 		// fallbacks; the final error is what callers log/wrap.
-		slog.Debug("Title generation attempt failed",
+		slog.DebugContext(ctx, "Title generation attempt failed",
 			"session_id", sessionID,
 			"model", baseModel.ID(),
 			"attempt", idx+1,

--- a/pkg/skills/cache.go
+++ b/pkg/skills/cache.go
@@ -86,7 +86,7 @@ func (c *diskCache) Get(baseURL, skillName, filePath string) (string, bool) {
 // FetchAndStore downloads a file from the given URL and stores it in the cache.
 // It respects Cache-Control headers to determine expiry.
 func (c *diskCache) FetchAndStore(ctx context.Context, baseURL, skillName, filePath, fileURL string) (string, error) {
-	slog.Debug("Fetching remote skill file", "url", fileURL)
+	slog.DebugContext(ctx, "Fetching remote skill file", "url", fileURL)
 
 	resp, err := httpGet(ctx, fileURL)
 	if err != nil {
@@ -125,7 +125,7 @@ func (c *diskCache) FetchAndStore(ctx context.Context, baseURL, skillName, fileP
 	metaJSON, _ := json.Marshal(meta)
 	if err := os.WriteFile(metaPath, metaJSON, 0o644); err != nil {
 		// Non-fatal: the content is cached, just the metadata isn't
-		slog.Debug("Failed to write cache metadata", "path", metaPath, "error", err)
+		slog.DebugContext(ctx, "Failed to write cache metadata", "path", metaPath, "error", err)
 	}
 
 	return string(body), nil

--- a/pkg/skills/expand.go
+++ b/pkg/skills/expand.go
@@ -35,7 +35,7 @@ func ExpandCommands(ctx context.Context, content, workDir string) string {
 
 		output, err := runCommand(ctx, command, workDir)
 		if err != nil {
-			slog.Warn("Skill command expansion failed", "command", command, "error", err)
+			slog.WarnContext(ctx, "Skill command expansion failed", "command", command, "error", err)
 			return fmt.Sprintf("[error executing `%s`: %s]", command, err)
 		}
 

--- a/pkg/skills/remote.go
+++ b/pkg/skills/remote.go
@@ -31,29 +31,29 @@ func loadRemoteSkills(ctx context.Context, baseURL string, cache *diskCache) []S
 	baseURL = strings.TrimRight(baseURL, "/")
 	indexURL := baseURL + "/.well-known/skills/index.json"
 
-	slog.Debug("Fetching remote skills index", "url", indexURL)
+	slog.DebugContext(ctx, "Fetching remote skills index", "url", indexURL)
 
 	resp, err := httpGet(ctx, indexURL)
 	if err != nil {
-		slog.Warn("Failed to fetch remote skills index", "url", indexURL, "error", err)
+		slog.WarnContext(ctx, "Failed to fetch remote skills index", "url", indexURL, "error", err)
 		return nil
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		slog.Warn("Remote skills index returned non-OK status", "url", indexURL, "status", resp.StatusCode)
+		slog.WarnContext(ctx, "Remote skills index returned non-OK status", "url", indexURL, "status", resp.StatusCode)
 		return nil
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1MB limit
 	if err != nil {
-		slog.Warn("Failed to read remote skills index", "url", indexURL, "error", err)
+		slog.WarnContext(ctx, "Failed to read remote skills index", "url", indexURL, "error", err)
 		return nil
 	}
 
 	var index remoteIndex
 	if err := json.Unmarshal(body, &index); err != nil {
-		slog.Warn("Failed to parse remote skills index", "url", indexURL, "error", err)
+		slog.WarnContext(ctx, "Failed to parse remote skills index", "url", indexURL, "error", err)
 		return nil
 	}
 
@@ -63,7 +63,7 @@ func loadRemoteSkills(ctx context.Context, baseURL string, cache *diskCache) []S
 			continue
 		}
 		if !isValidSkillName(entry.Name) {
-			slog.Warn("Skipping remote skill with invalid name", "url", baseURL, "name", entry.Name)
+			slog.WarnContext(ctx, "Skipping remote skill with invalid name", "url", baseURL, "name", entry.Name)
 			continue
 		}
 
@@ -80,7 +80,7 @@ func loadRemoteSkills(ctx context.Context, baseURL string, cache *diskCache) []S
 		skills = append(skills, skill)
 	}
 
-	slog.Debug("Loaded remote skills", "url", baseURL, "count", len(skills))
+	slog.DebugContext(ctx, "Loaded remote skills", "url", baseURL, "count", len(skills))
 	return skills
 }
 
@@ -90,7 +90,7 @@ func loadRemoteSkills(ctx context.Context, baseURL string, cache *diskCache) []S
 func prefetchFiles(ctx context.Context, cache *diskCache, baseURL, skillName string, files []string) {
 	for _, file := range files {
 		if !isValidFilePath(file) {
-			slog.Debug("Skipping invalid file path in skill", "skill", skillName, "file", file)
+			slog.DebugContext(ctx, "Skipping invalid file path in skill", "skill", skillName, "file", file)
 			continue
 		}
 
@@ -100,7 +100,7 @@ func prefetchFiles(ctx context.Context, cache *diskCache, baseURL, skillName str
 
 		fileURL := fmt.Sprintf("%s/.well-known/skills/%s/%s", baseURL, skillName, file)
 		if _, err := cache.FetchAndStore(ctx, baseURL, skillName, file, fileURL); err != nil {
-			slog.Warn("Failed to prefetch skill file", "skill", skillName, "file", file, "error", err)
+			slog.WarnContext(ctx, "Failed to prefetch skill file", "skill", skillName, "file", file, "error", err)
 		}
 	}
 }

--- a/pkg/team/team.go
+++ b/pkg/team/team.go
@@ -64,7 +64,7 @@ func (t *Team) AgentsInfo() []AgentInfo {
 			Description: a.Description(),
 			Commands:    a.Commands(),
 		}
-		if model := a.Model(); model != nil {
+		if model := a.Model(context.TODO()); model != nil {
 			modelID := model.ID()
 			if prov, modelName, found := strings.Cut(modelID, "/"); found {
 				info.Provider = prov

--- a/pkg/teamloader/filter.go
+++ b/pkg/teamloader/filter.go
@@ -72,7 +72,7 @@ func (f *filterTools) Tools(ctx context.Context) ([]tools.Tool, error) {
 		// Exclude mode: keep only tools NOT in the list
 		// Include mode: keep only tools in the list
 		if (f.exclude && contains) || (!f.exclude && !contains) {
-			slog.Debug("Filtering out tool", "tool", tool.Name)
+			slog.DebugContext(ctx, "Filtering out tool", "tool", tool.Name)
 			continue
 		}
 

--- a/pkg/teamloader/registry.go
+++ b/pkg/teamloader/registry.go
@@ -409,7 +409,7 @@ func createMCPTool(ctx context.Context, toolset latest.Toolset, _ string, runCon
 		// and let mcp.Toolset.Start() retry on each conversation turn.
 		resolvedCommand, err := toolinstall.EnsureCommand(ctx, toolset.Command, toolset.Version)
 		if err != nil {
-			slog.Warn("MCP command not yet available, will retry on next turn",
+			slog.WarnContext(ctx, "MCP command not yet available, will retry on next turn",
 				"command", toolset.Command, "error", err)
 			resolvedCommand = toolset.Command
 		}

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -109,7 +109,7 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 	// in DisplayModel so the sidebar and other UI elements show the user-configured name.
 	modelsStore, err := modelsdev.NewStore()
 	if err != nil {
-		slog.Debug("Failed to create modelsdev store for alias resolution", "error", err)
+		slog.DebugContext(ctx, "Failed to create modelsdev store for alias resolution", "error", err)
 	} else {
 		config.ResolveModelAliases(ctx, cfg, modelsStore)
 	}
@@ -416,7 +416,7 @@ func getToolsForAgent(ctx context.Context, a *latest.AgentConfig, parentDir stri
 		tool, err := registry.CreateTool(ctx, toolset, parentDir, runConfig, configName)
 		if err != nil {
 			// Collect error but continue loading other toolsets
-			slog.Warn("Toolset configuration failed; skipping", "type", toolset.Type, "ref", toolset.Ref, "command", toolset.Command, "error", err)
+			slog.WarnContext(ctx, "Toolset configuration failed; skipping", "type", toolset.Type, "ref", toolset.Ref, "command", toolset.Command, "error", err)
 			warnings = append(warnings, fmt.Sprintf("toolset %s failed: %v", toolset.Type, err))
 			continue
 		}
@@ -446,7 +446,7 @@ func getToolsForAgent(ctx context.Context, a *latest.AgentConfig, parentDir stri
 				lspBackends = append(lspBackends, lsp.Backend{LSP: lspTool, Toolset: wrapped})
 				continue
 			}
-			slog.Warn("Toolset configured as type 'lsp' but registry returned unexpected type; treating as regular toolset",
+			slog.WarnContext(ctx, "Toolset configured as type 'lsp' but registry returned unexpected type; treating as regular toolset",
 				"type", fmt.Sprintf("%T", tool), "command", toolset.Command)
 		}
 

--- a/pkg/teamloader/teamloader_test.go
+++ b/pkg/teamloader/teamloader_test.go
@@ -196,7 +196,7 @@ func TestOverrideModel(t *testing.T) {
 				require.NoError(t, err)
 				rootAgent, err := team.Agent("root")
 				require.NoError(t, err)
-				require.Equal(t, test.expected, rootAgent.Model().ID())
+				require.Equal(t, test.expected, rootAgent.Model(t.Context()).ID())
 			}
 		})
 	}

--- a/pkg/toolinstall/resolver.go
+++ b/pkg/toolinstall/resolver.go
@@ -78,7 +78,7 @@ func doInstall(ctx context.Context, command, versionRef string) (string, error) 
 		return binPath, nil
 	}
 
-	slog.Info("Auto-installing missing command via aqua registry", "command", command)
+	slog.InfoContext(ctx, "Auto-installing missing command via aqua registry", "command", command)
 
 	registry := SharedRegistry()
 
@@ -95,14 +95,14 @@ func doInstall(ctx context.Context, command, versionRef string) (string, error) 
 	}
 
 	pkgName := pkg.RepoOwner + "/" + pkg.RepoName
-	slog.Info("Installing tool", "command", command, "package", pkgName, "version", version)
+	slog.InfoContext(ctx, "Installing tool", "command", command, "package", pkgName, "version", version)
 
 	binaryPath, err := registry.Install(ctx, pkg, version)
 	if err != nil {
 		return "", fmt.Errorf("installing %s@%s: %w", pkgName, version, err)
 	}
 
-	slog.Info("Successfully installed command",
+	slog.InfoContext(ctx, "Successfully installed command",
 		"command", command, "package", fmt.Sprintf("%s@%s", pkgName, version), "path", binaryPath)
 
 	return binaryPath, nil

--- a/pkg/tools/a2a/a2a.go
+++ b/pkg/tools/a2a/a2a.go
@@ -114,7 +114,7 @@ func (t *Toolset) Tools(_ context.Context) ([]tools.Tool, error) {
 
 // Start connects to the A2A agent and fetches the agent card.
 func (t *Toolset) Start(ctx context.Context) error {
-	slog.Debug("Starting A2A toolset", "url", t.url)
+	slog.DebugContext(ctx, "Starting A2A toolset", "url", t.url)
 
 	card, err := agentcard.DefaultResolver.Resolve(ctx, t.url)
 	if err != nil {
@@ -136,7 +136,7 @@ func (t *Toolset) Start(ctx context.Context) error {
 	t.card = card
 	t.mu.Unlock()
 
-	slog.Debug("A2A toolset started", "agent", card.Name, "skills", len(card.Skills))
+	slog.DebugContext(ctx, "A2A toolset started", "agent", card.Name, "skills", len(card.Skills))
 	return nil
 }
 

--- a/pkg/tools/builtin/agent/agent.go
+++ b/pkg/tools/builtin/agent/agent.go
@@ -308,7 +308,7 @@ func (h *Handler) HandleRun(ctx context.Context, sess *session.Session, toolCall
 	h.wg.Go(func() {
 		defer cancel()
 
-		slog.Debug("Starting background agent task", "task_id", taskID, "agent", params.Agent)
+		slog.DebugContext(ctx, "Starting background agent task", "task_id", taskID, "agent", params.Agent)
 
 		result := h.runner.RunAgent(taskCtx, RunParams{
 			AgentName:      params.Agent,
@@ -321,13 +321,13 @@ func (h *Handler) HandleRun(ctx context.Context, sess *session.Session, toolCall
 		if result.ErrMsg != "" {
 			t.errMsg = result.ErrMsg
 			t.storeStatus(taskFailed)
-			slog.Debug("Background agent task failed", "task_id", taskID, "agent", params.Agent, "error", result.ErrMsg)
+			slog.DebugContext(ctx, "Background agent task failed", "task_id", taskID, "agent", params.Agent, "error", result.ErrMsg)
 			return
 		}
 
 		if taskCtx.Err() != nil && t.loadStatus() == taskRunning {
 			t.storeStatus(taskStopped)
-			slog.Debug("Background agent task stopped", "task_id", taskID)
+			slog.DebugContext(ctx, "Background agent task stopped", "task_id", taskID)
 			return
 		}
 
@@ -335,7 +335,7 @@ func (h *Handler) HandleRun(ctx context.Context, sess *session.Session, toolCall
 		// always see the populated result field.
 		t.result = result.Result
 		if t.casStatus(taskRunning, taskCompleted) {
-			slog.Debug("Background agent task completed", "task_id", taskID, "agent", params.Agent)
+			slog.DebugContext(ctx, "Background agent task completed", "task_id", taskID, "agent", params.Agent)
 		}
 	})
 

--- a/pkg/tools/builtin/lsp/lsp.go
+++ b/pkg/tools/builtin/lsp/lsp.go
@@ -748,7 +748,7 @@ func (h *lspHandler) prepareFileRequest(ctx context.Context, file string) (strin
 	}
 	uri := pathToURI(file)
 	if err := h.openFileOnDemand(ctx, uri); err != nil {
-		slog.Debug("Failed to auto-open file", "file", file, "error", err)
+		slog.DebugContext(ctx, "Failed to auto-open file", "file", file, "error", err)
 	}
 	return uri, nil
 }
@@ -971,7 +971,7 @@ func (h *lspHandler) getDiagnostics(ctx context.Context, args FileArgs) (*tools.
 	uri := pathToURI(args.File)
 	wasOpen := h.isFileOpen(uri)
 	if err := h.openFileOnDemand(ctx, uri); err != nil {
-		slog.Debug("Failed to auto-open file for diagnostics", "file", args.File, "error", err)
+		slog.DebugContext(ctx, "Failed to auto-open file for diagnostics", "file", args.File, "error", err)
 	}
 
 	if !wasOpen {
@@ -1106,7 +1106,7 @@ func (h *lspHandler) format(ctx context.Context, args FileArgs) (*tools.ToolCall
 	}
 
 	if err := h.notifyFileChangeLocked(uri); err != nil {
-		slog.Debug("Failed to notify LSP of format changes", "error", err)
+		slog.DebugContext(ctx, "Failed to notify LSP of format changes", "error", err)
 	}
 
 	return tools.ResultSuccess(fmt.Sprintf("Formatted %s\nApplied %d formatting change(s)", args.File, len(edits))), nil
@@ -1547,7 +1547,7 @@ func (h *lspHandler) readNotifications(ctx context.Context, stderrBuf *concurren
 			return
 		case <-ticker.C:
 			if content := stderrBuf.Drain(); content != "" {
-				slog.Debug("LSP stderr", "content", content)
+				slog.DebugContext(ctx, "LSP stderr", "content", content)
 			}
 		}
 	}

--- a/pkg/tools/builtin/lsp/lsp_lifecycle.go
+++ b/pkg/tools/builtin/lsp/lsp_lifecycle.go
@@ -26,7 +26,7 @@ type lspConnector struct{ h *lspHandler }
 // methods can use them without going through the supervisor.
 func (c *lspConnector) Connect(ctx context.Context) (lifecycle.Session, error) {
 	h := c.h
-	slog.Debug("Starting LSP server", "command", h.command, "args", h.args)
+	slog.DebugContext(ctx, "Starting LSP server", "command", h.command, "args", h.args)
 
 	p, err := spawnLSPProcess(h)
 	if err != nil {
@@ -46,7 +46,7 @@ func (c *lspConnector) Connect(ctx context.Context) (lifecycle.Session, error) {
 		return nil, lifecycle.Classify(err)
 	}
 
-	slog.Debug("LSP server initialized", "command", h.command)
+	slog.DebugContext(ctx, "LSP server initialized", "command", h.command)
 	h.fireToolsChanged()
 
 	return &lspSession{
@@ -260,7 +260,7 @@ func (s *lspSession) Close(ctx context.Context) error {
 	s.closed = true
 	s.mu.Unlock()
 
-	slog.Debug("Stopping LSP server")
+	slog.DebugContext(ctx, "Stopping LSP server")
 
 	// Hold h.mu across the entire teardown (shutdown handshake AND state
 	// clearing) so a concurrent per-request method can't slip in between
@@ -286,6 +286,6 @@ func (s *lspSession) Close(ctx context.Context) error {
 	if ctx.Err() != nil {
 		return nil
 	}
-	slog.Debug("LSP server stopped")
+	slog.DebugContext(ctx, "LSP server stopped")
 	return nil
 }

--- a/pkg/tools/builtin/openapi/openapi.go
+++ b/pkg/tools/builtin/openapi/openapi.go
@@ -104,7 +104,7 @@ func (t *Tool) fetchSpec(ctx context.Context) (*v3.Document, error) {
 	if buildErr != nil {
 		// Log validation issues but don't fail — some valid OpenAPI 3.1
 		// features may not be fully supported by the validator.
-		slog.Warn("OpenAPI spec validation reported issues; proceeding anyway", "url", t.specURL, "error", buildErr)
+		slog.WarnContext(ctx, "OpenAPI spec validation reported issues; proceeding anyway", "url", t.specURL, "error", buildErr)
 	}
 
 	if model == nil {

--- a/pkg/tools/builtin/rag/rag.go
+++ b/pkg/tools/builtin/rag/rag.go
@@ -68,7 +68,7 @@ func (t *Tool) Start(ctx context.Context) error {
 
 	go func() {
 		if err := t.manager.StartFileWatcher(ctx); err != nil {
-			slog.Error("Failed to start RAG file watcher", "tool", t.toolName, "error", err)
+			slog.ErrorContext(ctx, "Failed to start RAG file watcher", "tool", t.toolName, "error", err)
 		}
 	}()
 	return nil

--- a/pkg/tools/builtin/shell/shell.go
+++ b/pkg/tools/builtin/shell/shell.go
@@ -199,7 +199,7 @@ func (h *shellHandler) RunShell(ctx context.Context, params RunShellArgs) (*tool
 
 	cwd := h.resolveWorkDir(params.Cwd)
 
-	slog.Debug("Executing native shell command", "command", params.Cmd, "cwd", cwd)
+	slog.DebugContext(ctx, "Executing native shell command", "command", params.Cmd, "cwd", cwd)
 
 	return h.runNativeCommand(timeoutCtx, ctx, params.Cmd, cwd, timeout), nil
 }

--- a/pkg/tools/mcp/gateway.go
+++ b/pkg/tools/mcp/gateway.go
@@ -24,7 +24,7 @@ type GatewayToolset struct {
 var _ tools.ToolSet = (*GatewayToolset)(nil)
 
 func NewGatewayToolset(ctx context.Context, name, mcpServerName string, secrets []gateway.Secret, config any, envProvider environment.Provider, cwd string) (*GatewayToolset, error) {
-	slog.Debug("Creating MCP Gateway toolset", "name", mcpServerName)
+	slog.DebugContext(ctx, "Creating MCP Gateway toolset", "name", mcpServerName)
 
 	// Make sure all the required secrets are available in the environment.
 	// TODO(dga): Ideally, the MCP gateway would use the same provider that we have.
@@ -65,7 +65,7 @@ func (t *GatewayToolset) Stop(ctx context.Context) error {
 
 	cleanUpErr := t.cleanUp()
 	if cleanUpErr != nil {
-		slog.Warn("Failed to clean up MCP Gateway temp files", "error", cleanUpErr)
+		slog.WarnContext(ctx, "Failed to clean up MCP Gateway temp files", "error", cleanUpErr)
 	}
 
 	return errors.Join(stopErr, cleanUpErr)

--- a/pkg/tools/mcp/mcp.go
+++ b/pkg/tools/mcp/mcp.go
@@ -291,15 +291,15 @@ func (ts *Toolset) Start(ctx context.Context) error {
 
 // Stop tears the supervisor down. Idempotent.
 func (ts *Toolset) Stop(ctx context.Context) error {
-	slog.Debug("Stopping MCP toolset", "server", ts.logID)
+	slog.DebugContext(ctx, "Stopping MCP toolset", "server", ts.logID)
 	if ts.supervisor == nil {
 		return nil
 	}
 	if err := ts.supervisor.Stop(ctx); err != nil && ctx.Err() == nil {
-		slog.Error("Failed to stop MCP toolset", "server", ts.logID, "error", err)
+		slog.ErrorContext(ctx, "Failed to stop MCP toolset", "server", ts.logID, "error", err)
 		return err
 	}
-	slog.Debug("Stopped MCP toolset successfully", "server", ts.logID)
+	slog.DebugContext(ctx, "Stopped MCP toolset successfully", "server", ts.logID)
 	return nil
 }
 
@@ -322,7 +322,7 @@ func (c *clientConnector) Connect(ctx context.Context) (lifecycle.Session, error
 	// connection even though OAuth succeeded.
 	ctx = context.WithoutCancel(ctx)
 
-	slog.Debug("Starting MCP toolset", "server", ts.logID)
+	slog.DebugContext(ctx, "Starting MCP toolset", "server", ts.logID)
 
 	// Register notification handlers: they invalidate caches and refresh
 	// eagerly so subsequent Tools()/ListPrompts() calls see fresh data.
@@ -332,14 +332,14 @@ func (c *clientConnector) Connect(ctx context.Context) (lifecycle.Session, error
 		ts.mu.Lock()
 		ts.invalidateCache()
 		ts.mu.Unlock()
-		slog.Debug("MCP server notified tool list changed, refreshing", "server", ts.logID)
+		slog.DebugContext(ctx, "MCP server notified tool list changed, refreshing", "server", ts.logID)
 		ts.refreshToolCache(ctx)
 	})
 	ts.mcpClient.SetPromptListChangedHandler(func() {
 		ts.mu.Lock()
 		ts.invalidateCache()
 		ts.mu.Unlock()
-		slog.Debug("MCP server notified prompt list changed, refreshing", "server", ts.logID)
+		slog.DebugContext(ctx, "MCP server notified prompt list changed, refreshing", "server", ts.logID)
 		ts.refreshPromptCache(ctx)
 	})
 
@@ -373,22 +373,21 @@ func (c *clientConnector) Connect(ctx context.Context) (lifecycle.Session, error
 		if !isInitNotificationSendError(err) {
 			classified := lifecycle.Classify(err)
 			if errors.Is(classified, lifecycle.ErrServerUnavailable) {
-				slog.Debug(
-					"MCP client unavailable, will retry on next conversation turn",
+				slog.DebugContext(ctx, "MCP client unavailable, will retry on next conversation turn",
 					"server", ts.logID,
 					"error", err,
 				)
 				return nil, errServerUnavailable
 			}
-			slog.Error("Failed to initialize MCP client", "error", err)
+			slog.ErrorContext(ctx, "Failed to initialize MCP client", "error", err)
 			return nil, fmt.Errorf("failed to initialize MCP client: %w", err)
 		}
 		if attempt >= maxRetries {
-			slog.Error("Failed to initialize MCP client after retries", "error", err)
+			slog.ErrorContext(ctx, "Failed to initialize MCP client after retries", "error", err)
 			return nil, fmt.Errorf("failed to initialize MCP client after retries: %w", err)
 		}
 		backoff := time.Duration(200*(attempt+1)) * time.Millisecond
-		slog.Debug("MCP initialize failed to send initialized notification; retrying", "id", ts.logID, "attempt", attempt+1, "backoff_ms", backoff.Milliseconds())
+		slog.DebugContext(ctx, "MCP initialize failed to send initialized notification; retrying", "id", ts.logID, "attempt", attempt+1, "backoff_ms", backoff.Milliseconds())
 		select {
 		case <-time.After(backoff):
 		case <-ctx.Done():
@@ -396,7 +395,7 @@ func (c *clientConnector) Connect(ctx context.Context) (lifecycle.Session, error
 		}
 	}
 
-	slog.Debug("Started MCP toolset successfully", "server", ts.logID)
+	slog.DebugContext(ctx, "Started MCP toolset successfully", "server", ts.logID)
 	ts.mu.Lock()
 	ts.instructions = result.Instructions
 	ts.mu.Unlock()
@@ -434,7 +433,7 @@ func (ts *Toolset) Tools(ctx context.Context) ([]tools.Tool, error) {
 	gen := ts.cacheGen
 	ts.mu.Unlock()
 
-	slog.Debug("Listing MCP tools (cache miss)", "server", ts.logID)
+	slog.DebugContext(ctx, "Listing MCP tools (cache miss)", "server", ts.logID)
 
 	resp := ts.mcpClient.ListTools(ctx, &mcp.ListToolsParams{})
 
@@ -462,10 +461,10 @@ func (ts *Toolset) Tools(ctx context.Context) ([]tools.Tool, error) {
 		}
 		toolsList = append(toolsList, tool)
 
-		slog.Debug("Added MCP tool", "tool", name)
+		slog.DebugContext(ctx, "Added MCP tool", "tool", name)
 	}
 
-	slog.Debug("Listed MCP tools", "count", len(toolsList), "server", ts.logID)
+	slog.DebugContext(ctx, "Listed MCP tools", "count", len(toolsList), "server", ts.logID)
 
 	ts.mu.Lock()
 	// Only populate the cache if no invalidation happened while we were
@@ -484,7 +483,7 @@ func (ts *Toolset) Tools(ctx context.Context) ([]tools.Tool, error) {
 // the cache is already warm by the time the runtime loop calls Tools().
 func (ts *Toolset) refreshToolCache(ctx context.Context) {
 	if _, err := ts.Tools(ctx); err != nil {
-		slog.Warn("Failed to refresh tools after notification", "server", ts.logID, "error", err)
+		slog.WarnContext(ctx, "Failed to refresh tools after notification", "server", ts.logID, "error", err)
 		return
 	}
 
@@ -501,17 +500,17 @@ func (ts *Toolset) refreshToolCache(ctx context.Context) {
 // the cache. It is called by the PromptListChanged notification handler.
 func (ts *Toolset) refreshPromptCache(ctx context.Context) {
 	if _, err := ts.ListPrompts(ctx); err != nil {
-		slog.Warn("Failed to refresh prompts after notification", "server", ts.logID, "error", err)
+		slog.WarnContext(ctx, "Failed to refresh prompts after notification", "server", ts.logID, "error", err)
 	}
 }
 
 func (ts *Toolset) callTool(ctx context.Context, toolCall tools.ToolCall) (*tools.ToolCallResult, error) {
-	slog.Debug("Calling MCP tool", "tool", toolCall.Function.Name, "arguments", toolCall.Function.Arguments)
+	slog.DebugContext(ctx, "Calling MCP tool", "tool", toolCall.Function.Name, "arguments", toolCall.Function.Arguments)
 
 	toolCall.Function.Arguments = cmp.Or(toolCall.Function.Arguments, "{}")
 	var args map[string]any
 	if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &args); err != nil {
-		slog.Error("Failed to parse tool arguments", "tool", toolCall.Function.Name, "error", err)
+		slog.ErrorContext(ctx, "Failed to parse tool arguments", "tool", toolCall.Function.Name, "error", err)
 		return nil, fmt.Errorf("failed to parse tool arguments: %w", err)
 	}
 
@@ -535,7 +534,7 @@ func (ts *Toolset) callTool(ctx context.Context, toolCall tools.ToolCall) (*tool
 	// server restarted), trigger or wait for a reconnection and retry
 	// the call once.
 	if err != nil && isConnectionError(err) && ctx.Err() == nil {
-		slog.Warn("MCP call failed, forcing reconnect and retrying", "tool", toolCall.Function.Name, "server", ts.logID, "error", err)
+		slog.WarnContext(ctx, "MCP call failed, forcing reconnect and retrying", "tool", toolCall.Function.Name, "server", ts.logID, "error", err)
 		if waitErr := ts.supervisor.RestartAndWait(ctx, sessionMissingRetryTimeout); waitErr != nil {
 			return nil, fmt.Errorf("failed to reconnect after call failure: %w", waitErr)
 		}
@@ -543,16 +542,16 @@ func (ts *Toolset) callTool(ctx context.Context, toolCall tools.ToolCall) (*tool
 	}
 	if err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
-			slog.Debug("CallTool canceled by context", "tool", toolCall.Function.Name)
+			slog.DebugContext(ctx, "CallTool canceled by context", "tool", toolCall.Function.Name)
 			return nil, err
 		}
-		slog.Error("Failed to call MCP tool", "tool", toolCall.Function.Name, "error", err)
+		slog.ErrorContext(ctx, "Failed to call MCP tool", "tool", toolCall.Function.Name, "error", err)
 		return nil, fmt.Errorf("failed to call tool: %w", err)
 	}
 
 	result := processMCPContent(resp)
-	slog.Debug("MCP tool call completed", "tool", toolCall.Function.Name, "output_length", len(result.Output))
-	slog.Debug(result.Output)
+	slog.DebugContext(ctx, "MCP tool call completed", "tool", toolCall.Function.Name, "output_length", len(result.Output))
+	slog.DebugContext(ctx, result.Output)
 	return result, nil
 }
 
@@ -659,7 +658,7 @@ func (ts *Toolset) ListPrompts(ctx context.Context) ([]PromptInfo, error) {
 	gen := ts.cacheGen
 	ts.mu.Unlock()
 
-	slog.Debug("Listing MCP prompts (cache miss)", "server", ts.logID)
+	slog.DebugContext(ctx, "Listing MCP prompts (cache miss)", "server", ts.logID)
 
 	// Call the underlying MCP client to list prompts
 	resp := ts.mcpClient.ListPrompts(ctx, &mcp.ListPromptsParams{})
@@ -667,7 +666,7 @@ func (ts *Toolset) ListPrompts(ctx context.Context) ([]PromptInfo, error) {
 	var promptsList []PromptInfo
 	for prompt, err := range resp {
 		if err != nil {
-			slog.Warn("Error listing MCP prompt", "error", err)
+			slog.WarnContext(ctx, "Error listing MCP prompt", "error", err)
 			return promptsList, err
 		}
 
@@ -691,10 +690,10 @@ func (ts *Toolset) ListPrompts(ctx context.Context) ([]PromptInfo, error) {
 		}
 
 		promptsList = append(promptsList, promptInfo)
-		slog.Debug("Added MCP prompt", "prompt", prompt.Name, "args_count", len(promptInfo.Arguments))
+		slog.DebugContext(ctx, "Added MCP prompt", "prompt", prompt.Name, "args_count", len(promptInfo.Arguments))
 	}
 
-	slog.Debug("Listed MCP prompts", "count", len(promptsList), "server", ts.logID)
+	slog.DebugContext(ctx, "Listed MCP prompts", "count", len(promptsList), "server", ts.logID)
 
 	ts.mu.Lock()
 	if ts.cacheGen == gen {
@@ -712,7 +711,7 @@ func (ts *Toolset) GetPrompt(ctx context.Context, name string, arguments map[str
 		return nil, lifecycle.ErrNotStarted
 	}
 
-	slog.Debug("Getting MCP prompt", "prompt", name, "arguments", arguments)
+	slog.DebugContext(ctx, "Getting MCP prompt", "prompt", name, "arguments", arguments)
 
 	// Prepare the request parameters
 	request := &mcp.GetPromptParams{
@@ -723,11 +722,11 @@ func (ts *Toolset) GetPrompt(ctx context.Context, name string, arguments map[str
 	// Call the underlying MCP client to get the prompt
 	result, err := ts.mcpClient.GetPrompt(ctx, request)
 	if err != nil {
-		slog.Error("Failed to get MCP prompt", "prompt", name, "error", err)
+		slog.ErrorContext(ctx, "Failed to get MCP prompt", "prompt", name, "error", err)
 		return nil, fmt.Errorf("failed to get prompt %s: %w", name, err)
 	}
 
-	slog.Debug("Retrieved MCP prompt", "prompt", name, "messages_count", len(result.Messages))
+	slog.DebugContext(ctx, "Retrieved MCP prompt", "prompt", name, "messages_count", len(result.Messages))
 	return result, nil
 }
 

--- a/pkg/tools/mcp/oauth.go
+++ b/pkg/tools/mcp/oauth.go
@@ -445,13 +445,13 @@ func (t *oauthTransport) getValidToken(ctx context.Context) *OAuthToken {
 	}
 
 	if !t.tokenCoversConfiguredScopes(token) {
-		slog.Debug("Stored token scopes no longer cover configured scopes; discarding to force re-auth",
+		slog.DebugContext(ctx, "Stored token scopes no longer cover configured scopes; discarding to force re-auth",
 			"url", t.baseURL,
 			"stored", token.RequestedScopes,
 			"configured", configuredScopes(t.oauthConfig),
 		)
 		if err := t.tokenStore.RemoveToken(t.baseURL); err != nil {
-			slog.Debug("Failed to remove stale token", "url", t.baseURL, "error", err)
+			slog.DebugContext(ctx, "Failed to remove stale token", "url", t.baseURL, "error", err)
 		}
 		return nil
 	}
@@ -473,19 +473,19 @@ func (t *oauthTransport) getValidToken(ctx context.Context) *OAuthToken {
 		return nil
 	}
 
-	slog.Debug("Attempting silent token refresh", "url", t.baseURL)
+	slog.DebugContext(ctx, "Attempting silent token refresh", "url", t.baseURL)
 
 	o := &oauth{metadataClient: &http.Client{Timeout: 5 * time.Second}}
 	authServer := cmp.Or(token.AuthServer, t.baseURL)
 	metadata, err := o.getAuthorizationServerMetadata(ctx, authServer)
 	if err != nil {
-		slog.Debug("Failed to fetch auth server metadata for refresh", "auth_server", authServer, "error", err)
+		slog.DebugContext(ctx, "Failed to fetch auth server metadata for refresh", "auth_server", authServer, "error", err)
 		return nil
 	}
 
 	newToken, err := RefreshAccessToken(ctx, metadata.TokenEndpoint, token.RefreshToken, token.ClientID, token.ClientSecret)
 	if err != nil {
-		slog.Debug("Token refresh failed, will require interactive auth", "error", err)
+		slog.DebugContext(ctx, "Token refresh failed, will require interactive auth", "error", err)
 		t.mu.Lock()
 		t.refreshFailedAt = time.Now()
 		t.mu.Unlock()
@@ -499,10 +499,10 @@ func (t *oauthTransport) getValidToken(ctx context.Context) *OAuthToken {
 	t.mu.Unlock()
 
 	if err := t.tokenStore.StoreToken(t.baseURL, newToken); err != nil {
-		slog.Warn("Failed to store refreshed token", "error", err)
+		slog.WarnContext(ctx, "Failed to store refreshed token", "error", err)
 	}
 
-	slog.Debug("Token refreshed successfully", "url", t.baseURL)
+	slog.DebugContext(ctx, "Token refreshed successfully", "url", t.baseURL)
 	return newToken
 }
 
@@ -555,7 +555,7 @@ func (t *oauthTransport) handleOAuthFlow(ctx context.Context, authServer, wwwAut
 }
 
 func (t *oauthTransport) handleManagedOAuthFlow(ctx context.Context, authServer, wwwAuth string) error {
-	slog.Debug("Starting OAuth flow for server", "url", t.baseURL)
+	slog.DebugContext(ctx, "Starting OAuth flow for server", "url", t.baseURL)
 
 	resourceURL := cmp.Or(resourceMetadataFromWWWAuth(wwwAuth), authServer+"/.well-known/oauth-protected-resource")
 
@@ -581,7 +581,7 @@ func (t *oauthTransport) handleManagedOAuthFlow(ctx context.Context, authServer,
 	}
 
 	if len(resourceMetadata.AuthorizationServers) == 0 {
-		slog.Debug("No authorization servers in resource metadata, using auth server from WWW-Authenticate header")
+		slog.DebugContext(ctx, "No authorization servers in resource metadata, using auth server from WWW-Authenticate header")
 		resourceMetadata.AuthorizationServers = []string{authServer}
 	}
 
@@ -591,7 +591,7 @@ func (t *oauthTransport) handleManagedOAuthFlow(ctx context.Context, authServer,
 		return fmt.Errorf("failed to fetch authorization server metadata: %w", err)
 	}
 
-	slog.Debug("Creating OAuth callback server")
+	slog.DebugContext(ctx, "Creating OAuth callback server")
 	var callbackPort int
 	if t.oauthConfig != nil {
 		callbackPort = t.oauthConfig.CallbackPort
@@ -604,7 +604,7 @@ func (t *oauthTransport) handleManagedOAuthFlow(ctx context.Context, authServer,
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		if err := callbackServer.Shutdown(shutdownCtx); err != nil {
-			slog.Error("Failed to shutdown callback server", "error", err)
+			slog.ErrorContext(ctx, "Failed to shutdown callback server", "error", err)
 		}
 	}()
 
@@ -613,7 +613,7 @@ func (t *oauthTransport) handleManagedOAuthFlow(ctx context.Context, authServer,
 	}
 
 	redirectURI := callbackServer.resolveRedirectURI(callbackRedirectURLFrom(t.oauthConfig))
-	slog.Debug("Using redirect URI", "uri", redirectURI)
+	slog.DebugContext(ctx, "Using redirect URI", "uri", redirectURI)
 
 	var clientID string
 	var clientSecret string
@@ -622,15 +622,15 @@ func (t *oauthTransport) handleManagedOAuthFlow(ctx context.Context, authServer,
 	switch {
 	case t.oauthConfig != nil && t.oauthConfig.ClientID != "":
 		// Use explicit credentials from config
-		slog.Debug("Using explicit OAuth credentials from config")
+		slog.DebugContext(ctx, "Using explicit OAuth credentials from config")
 		clientID = t.oauthConfig.ClientID
 		clientSecret = t.oauthConfig.ClientSecret
 		scopes = t.oauthConfig.Scopes
 	case authServerMetadata.RegistrationEndpoint != "":
-		slog.Debug("Attempting dynamic client registration")
+		slog.DebugContext(ctx, "Attempting dynamic client registration")
 		clientID, clientSecret, err = RegisterClient(ctx, authServerMetadata, redirectURI, nil)
 		if err != nil {
-			slog.Debug("Dynamic registration failed", "error", err)
+			slog.DebugContext(ctx, "Dynamic registration failed", "error", err)
 			// TODO(rumpl): fall back to requesting client ID from user
 			return err
 		}
@@ -669,13 +669,13 @@ func (t *oauthTransport) handleManagedOAuthFlow(ctx context.Context, authServer,
 		return fmt.Errorf("failed to send elicitation request: %w", err)
 	}
 
-	slog.Debug("Elicitation response received", "result", result)
+	slog.DebugContext(ctx, "Elicitation response received", "result", result)
 
 	if result.Action != tools.ElicitationActionAccept {
 		return errors.New("user declined OAuth authorization")
 	}
 
-	slog.Debug("Requesting authorization code", "url", authURL)
+	slog.DebugContext(ctx, "Requesting authorization code", "url", authURL)
 
 	code, receivedState, err := RequestAuthorizationCode(ctx, authURL, callbackServer, state)
 	if err != nil {
@@ -686,7 +686,7 @@ func (t *oauthTransport) handleManagedOAuthFlow(ctx context.Context, authServer,
 		return errors.New("state mismatch in authorization response")
 	}
 
-	slog.Debug("Exchanging authorization code for token")
+	slog.DebugContext(ctx, "Exchanging authorization code for token")
 	token, err := ExchangeCodeForToken(
 		ctx,
 		authServerMetadata.TokenEndpoint,
@@ -712,14 +712,14 @@ func (t *oauthTransport) handleManagedOAuthFlow(ctx context.Context, authServer,
 	// Notify the runtime that the OAuth flow was successful
 	t.client.oauthSuccess()
 
-	slog.Debug("OAuth flow completed successfully")
+	slog.DebugContext(ctx, "OAuth flow completed successfully")
 	return nil
 }
 
 // handleUnmanagedOAuthFlow performs the OAuth flow for remote/unmanaged scenarios
 // where the client handles the OAuth interaction instead of us
 func (t *oauthTransport) handleUnmanagedOAuthFlow(ctx context.Context, authServer, wwwAuth string) error {
-	slog.Debug("Starting unmanaged OAuth flow for server", "url", t.baseURL)
+	slog.DebugContext(ctx, "Starting unmanaged OAuth flow for server", "url", t.baseURL)
 
 	// Extract resource URL from WWW-Authenticate header
 	resourceURL := cmp.Or(resourceMetadataFromWWWAuth(wwwAuth), authServer+"/.well-known/oauth-protected-resource")
@@ -746,7 +746,7 @@ func (t *oauthTransport) handleUnmanagedOAuthFlow(ctx context.Context, authServe
 	}
 
 	if len(resourceMetadata.AuthorizationServers) == 0 {
-		slog.Debug("No authorization servers in resource metadata, using auth server from WWW-Authenticate header")
+		slog.DebugContext(ctx, "No authorization servers in resource metadata, using auth server from WWW-Authenticate header")
 		resourceMetadata.AuthorizationServers = []string{authServer}
 	}
 
@@ -756,7 +756,7 @@ func (t *oauthTransport) handleUnmanagedOAuthFlow(ctx context.Context, authServe
 		return fmt.Errorf("failed to fetch authorization server metadata: %w", err)
 	}
 
-	slog.Debug("Sending OAuth elicitation request to client")
+	slog.DebugContext(ctx, "Sending OAuth elicitation request to client")
 
 	result, err := t.client.requestElicitation(ctx, &mcpsdk.ElicitParams{
 		Message:         "OAuth authorization required for " + t.baseURL,
@@ -773,7 +773,7 @@ func (t *oauthTransport) handleUnmanagedOAuthFlow(ctx context.Context, authServe
 		return fmt.Errorf("failed to send elicitation request: %w", err)
 	}
 
-	slog.Debug("Received elicitation response from client", "action", result.Action)
+	slog.DebugContext(ctx, "Received elicitation response from client", "action", result.Action)
 
 	if result.Action != tools.ElicitationActionAccept {
 		return errors.New("OAuth flow declined or cancelled by client")
@@ -815,6 +815,6 @@ func (t *oauthTransport) handleUnmanagedOAuthFlow(ctx context.Context, authServe
 	// Notify the runtime that the OAuth flow was successful
 	t.client.oauthSuccess()
 
-	slog.Debug("Managed OAuth flow completed successfully")
+	slog.DebugContext(ctx, "Managed OAuth flow completed successfully")
 	return nil
 }

--- a/pkg/tools/mcp/oauth_login.go
+++ b/pkg/tools/mcp/oauth_login.go
@@ -64,7 +64,7 @@ func PerformOAuthLogin(ctx context.Context, serverURL string) error {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		if err := callbackServer.Shutdown(shutdownCtx); err != nil {
-			slog.Error("Failed to shutdown callback server", "error", err)
+			slog.ErrorContext(ctx, "Failed to shutdown callback server", "error", err)
 		}
 	}()
 

--- a/pkg/tools/mcp/remote.go
+++ b/pkg/tools/mcp/remote.go
@@ -88,7 +88,7 @@ func (c *remoteMCPClient) Initialize(ctx context.Context, _ *gomcp.InitializeReq
 
 	c.setSession(session)
 
-	slog.Debug("Remote MCP client connected successfully")
+	slog.DebugContext(ctx, "Remote MCP client connected successfully")
 	return session.InitializeResult(), nil
 }
 

--- a/pkg/tools/mcp/session_client.go
+++ b/pkg/tools/mcp/session_client.go
@@ -128,7 +128,7 @@ func (c *sessionClient) GetPrompt(ctx context.Context, request *gomcp.GetPromptP
 // server to the registered handler. It is used as the gomcp ElicitationHandler
 // callback for both stdio and remote clients.
 func (c *sessionClient) handleElicitationRequest(ctx context.Context, req *gomcp.ElicitRequest) (*gomcp.ElicitResult, error) {
-	slog.Debug("Received elicitation request from MCP server", "message", req.Params.Message)
+	slog.DebugContext(ctx, "Received elicitation request from MCP server", "message", req.Params.Message)
 
 	c.mu.RLock()
 	handler := c.elicitationHandler
@@ -176,7 +176,7 @@ func (c *sessionClient) requestElicitation(ctx context.Context, req *gomcp.Elici
 	c.mu.RUnlock()
 
 	if handler == nil {
-		slog.Debug("OAuth flow requested elicitation before the runtime wired up a handler; deferring")
+		slog.DebugContext(ctx, "OAuth flow requested elicitation before the runtime wired up a handler; deferring")
 		return tools.ElicitationResult{}, &AuthorizationRequiredError{}
 	}
 

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -49,7 +49,7 @@ func NewHandler[T any](fn func(context.Context, T) (*ToolCallResult, error)) Too
 			// the repair-layer's complaint about a synthesised payload.
 			return nil, err
 		}
-		slog.Info("tool_input_repaired",
+		slog.InfoContext(ctx, "tool_input_repaired",
 			"tool", toolCall.Function.Name,
 			"repairs", kinds,
 		)

--- a/pkg/tui/tabs.go
+++ b/pkg/tui/tabs.go
@@ -37,13 +37,13 @@ func (m *appModel) persistFreshTab(ctx context.Context, sessionID, workingDir st
 		return
 	}
 	if err := m.tuiStore.ClearTabs(ctx); err != nil {
-		slog.Warn("Failed to clear tabs", "error", err)
+		slog.WarnContext(ctx, "Failed to clear tabs", "error", err)
 	}
 	if err := m.tuiStore.AddTab(ctx, sessionID, workingDir); err != nil {
-		slog.Warn("Failed to persist initial tab", "error", err)
+		slog.WarnContext(ctx, "Failed to persist initial tab", "error", err)
 	}
 	if err := m.tuiStore.SetActiveTab(ctx, sessionID); err != nil {
-		slog.Warn("Failed to set active tab", "error", err)
+		slog.WarnContext(ctx, "Failed to set active tab", "error", err)
 	}
 }
 
@@ -81,7 +81,7 @@ func (m *appModel) restoreTabs(
 		// Validate the saved session still exists.
 		if sessionStore != nil && saved.SessionID != "" {
 			if _, err := sessionStore.GetSession(ctx, saved.SessionID); err != nil {
-				slog.Warn("Saved session no longer exists, removing stale tab",
+				slog.WarnContext(ctx, "Saved session no longer exists, removing stale tab",
 					"session_id", saved.SessionID, "error", err)
 				_ = ts.RemoveTab(ctx, saved.SessionID)
 				continue
@@ -96,7 +96,7 @@ func (m *appModel) restoreTabs(
 		} else {
 			a, newSess, spawnCleanup, err := spawner(ctx, saved.WorkingDir)
 			if err != nil {
-				slog.Warn("Failed to restore tab", "working_dir", saved.WorkingDir, "error", err)
+				slog.WarnContext(ctx, "Failed to restore tab", "working_dir", saved.WorkingDir, "error", err)
 				_ = ts.RemoveTab(ctx, saved.SessionID)
 				continue
 			}

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -250,13 +250,13 @@ func New(ctx context.Context, spawner SessionSpawner, initialApp *app.App, initi
 	var tsErr error
 	ts, tsErr = tuistate.New()
 	if tsErr != nil {
-		slog.Warn("Failed to open TUI state store, tabs won't persist", "error", tsErr)
+		slog.WarnContext(ctx, "Failed to open TUI state store, tabs won't persist", "error", tsErr)
 	}
 
 	// Initialize shared command history
 	historyStore, err := history.New("")
 	if err != nil {
-		slog.Warn("Failed to initialize command history", "error", err)
+		slog.WarnContext(ctx, "Failed to initialize command history", "error", err)
 	}
 
 	initialSessionState := service.NewSessionState(initialApp.Session())
@@ -1092,7 +1092,7 @@ func (m *appModel) handleLoadSession(sessionID string) (tea.Model, tea.Cmd) {
 func (m *appModel) replaceActiveSession(ctx context.Context, sess *session.Session) (tea.Model, tea.Cmd) {
 	activeID := m.supervisor.ActiveID()
 
-	slog.Debug("Replacing empty session in-place", "tab_id", activeID, "loaded_session", sess.ID)
+	slog.DebugContext(ctx, "Replacing empty session in-place", "tab_id", activeID, "loaded_session", sess.ID)
 
 	// Cleanup old editor for the active session
 	if ed, ok := m.editors[activeID]; ok {
@@ -1106,14 +1106,14 @@ func (m *appModel) replaceActiveSession(ctx context.Context, sess *session.Sessi
 	if sessWorkingDir != "" && runner != nil && sessWorkingDir != runner.WorkingDir {
 		newApp, _, spawnCleanup, err := m.supervisor.Spawner()(ctx, sessWorkingDir)
 		if err == nil {
-			slog.Debug("Respawning runtime for working dir mismatch",
+			slog.DebugContext(ctx, "Respawning runtime for working dir mismatch",
 				"tab_id", activeID,
 				"old_dir", runner.WorkingDir,
 				"new_dir", sessWorkingDir)
 			m.supervisor.ReplaceRunnerApp(ctx, activeID, newApp, sessWorkingDir, spawnCleanup)
 			m.application = newApp
 		} else {
-			slog.Warn("Failed to respawn runtime for working dir, using existing",
+			slog.WarnContext(ctx, "Failed to respawn runtime for working dir, using existing",
 				"working_dir", sessWorkingDir, "error", err)
 		}
 	}


### PR DESCRIPTION
Go 1.21's `log/slog` added `DebugContext`/`InfoContext`/`WarnContext`/`ErrorContext` so handlers can read the active context (OTel span, etc.). Today most of docker-agent's slog calls drop the context, so any context-aware handler stamps nothing.

Pass `context.Context` to `slog.*Context` throughout the codebase. This enables automatic trace ID injection when OpenTelemetry tracing is active, improving observability and log correlation.

In a few locations where no request context exists (e.g., agent.Model() called during configuration validation), context.TODO() is passed with explanatory comments.

No behavior change with stdlib's default handlers — output is byte-identical. Rewrite is mechanical, generated by an AST tool. Build + vet + tests pass.