### PR TITLE
add js/wasm browser build with OpenRouter PKCE, agentic loop, and demo page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ vendor
 /cagent-*
 /docker-mcp-*
 docker-agent
+
+# Generated wasm artifacts (built locally; see cmd/wasm/README.md)
+/wasm
+cmd/wasm/web/docker-agent.wasm
+cmd/wasm/web/wasm_exec.js

--- a/cmd/wasm/README.md
+++ b/cmd/wasm/README.md
@@ -1,0 +1,215 @@
+# docker-agent in the browser (js/wasm)
+
+`cmd/wasm` is a `GOOS=js GOARCH=wasm` entry point that exposes a thin slice
+of docker-agent — config parsing and a single-round streaming chat — to a
+JavaScript host (a browser tab or Node).
+
+It is **not** a port of the full agent. It is a proof-of-concept for the
+"realistic plan" outlined when we surveyed which parts of docker-agent could
+even be cross-compiled to wasm. See the *Limits* section below.
+
+## Build
+
+```sh
+# Compile.
+GOOS=js GOARCH=wasm go build -o cmd/wasm/web/docker-agent.wasm ./cmd/wasm
+
+# Copy the matching wasm_exec.js shim from the Go toolchain (its API is
+# tied to the compiler version and must match the binary).
+cp "$(go env GOROOT)/lib/wasm/wasm_exec.js" cmd/wasm/web/wasm_exec.js
+```
+
+The output is a ~75 MB `.wasm`. It includes the entire YAML parser, three LLM
+provider clients (OpenAI, Anthropic, Google) and their dependencies. With
+`tinygo` or `-ldflags="-s -w"` plus `wasm-opt` you can roughly halve it; we
+have not optimised the size.
+
+## Run (Node smoke test)
+
+```sh
+node cmd/wasm/smoke_test.js
+```
+
+Prints the parsed config of a small two-agent YAML and exits 0. This proves
+that the Go runtime starts under wasm, that `globalThis.dockerAgent` gets
+registered, and that `parseConfig` returns the expected shape.
+
+## Run (browser, with OpenRouter sign-in)
+
+The demo page implements OpenRouter's [PKCE OAuth flow](https://openrouter.ai/docs/use-cases/oauth-pkce):
+
+1. Serve `cmd/wasm/web/` over HTTP (`WebAssembly.instantiateStreaming`
+   needs the `application/wasm` MIME type, so `file://` won't work):
+
+   ```sh
+   cd cmd/wasm/web && python3 -m http.server 8765
+   ```
+
+2. Open <http://localhost:8765/>.
+
+3. Click **Sign in with OpenRouter** — you'll be redirected to
+   `openrouter.ai`, log in, approve the app, and bounced back. The page
+   exchanges the `?code=` for a user-controlled API key (PKCE / S256) and
+   stores it in `localStorage`.
+
+4. Pick a free model from the dropdown (the YAML textarea updates
+   automatically) and click **Run**. Streaming completion deltas appear in
+   the output box.
+
+5. To revoke the key: click **Sign out** in the page (clears local copy)
+   and/or visit
+   <https://openrouter.ai/settings/keys> to revoke server-side.
+
+### Why this works in a browser
+
+Most LLM providers block direct browser fetches because anyone could read
+the API key out of the Network tab. OpenRouter solves this by issuing
+*per-app, per-user* keys via PKCE — the user owns the key, can revoke it,
+and the app never sees a master credential.
+
+We verified the relevant CORS posture before shipping:
+
+```
+$ curl -is -X OPTIONS https://openrouter.ai/api/v1/auth/keys \
+    -H "Origin: http://localhost:8765" \
+    -H "Access-Control-Request-Method: POST"
+HTTP/2 204
+access-control-allow-origin: *
+access-control-allow-headers: Authorization,...,Content-Type,...
+```
+
+Both `/api/v1/auth/keys` (token exchange) and `/api/v1/chat/completions`
+(inference) return `access-control-allow-origin: *` with `Authorization`
+in the allowed headers. No proxy needed.
+
+### What the YAML looks like
+
+OpenRouter exposes an OpenAI-compatible API, so it slots in as a custom
+provider:
+
+```yaml
+providers:
+  openrouter:
+    provider: openai
+    base_url: https://openrouter.ai/api/v1
+    token_key: OPENROUTER_API_KEY
+agents:
+  root:
+    model: openrouter/meta-llama/llama-3.3-70b-instruct:free
+    instruction: |
+      You are a helpful assistant ...
+```
+
+When the user clicks **Run**, the page passes the stored key as
+`env.OPENROUTER_API_KEY` to `dockerAgent.chat(...)`, the existing
+`pkg/model/provider/openai` reads it via `env.Get(ctx, cfg.TokenKey)`, and
+the Go HTTP transport (mapped to `fetch` under js/wasm) sends the
+request. **Same code path the CLI uses** — no special browser-only branch.
+
+### Bring-your-own-key fallback
+
+The `<details>` block on the page lets advanced users paste OpenAI /
+Anthropic / Gemini keys directly. Anthropic recently added
+`anthropic-dangerous-direct-browser-access` so it actually works from a
+tab; OpenAI and Gemini still block CORS for browser origins, so those
+fields are mostly there for use against a self-hosted proxy.
+
+## JavaScript API
+
+Once the wasm boots, two functions are exported on `globalThis.dockerAgent`:
+
+### `parseConfig(yamlString) -> object`
+
+Synchronous. Loads the YAML through `pkg/config.Load` (so all the version
+upgraders run) and returns a small JS-shaped projection:
+
+```js
+dockerAgent.parseConfig(`
+version: "2"
+agents:
+  root:
+    model: openai/gpt-4o-mini
+    instruction: hi
+`);
+// =>
+// {
+//   version: "2",
+//   agents: [{ name: "root", model: "openai/gpt-4o-mini", instruction: "hi", ... }],
+//   models: { "openai/gpt-4o-mini": { provider: "openai", model: "gpt-4o-mini" } }
+// }
+```
+
+Throws a JS `Error` on invalid YAML / unsupported version / failed validation.
+
+### `chat({yaml, agentName?, env?, messages}, onEvent) -> Promise`
+
+Asynchronous. Loads the config, picks the agent (or the only one), builds
+its model provider, and opens one streaming chat completion.
+
+- `yaml` — the YAML document, same as for `parseConfig`.
+- `agentName` — required if the config defines more than one agent.
+- `env` — `{ OPENAI_API_KEY: "...", ANTHROPIC_API_KEY: "...", GEMINI_API_KEY: "..." }`.
+  Whatever your model needs.
+- `messages` — array of `{role, content}` objects, OpenAI-style. The agent's
+  `instruction` is automatically prepended as a `system` message if you
+  haven't already supplied one.
+- `onEvent(ev)` — called from Go for every stream event:
+  - `{type: "delta",  content?: string, reasoning?: string}`
+  - `{type: "finish", reason: string}`
+
+Resolves to `{message: {role, content, reasoning, finish}}` once the stream
+ends. Rejects with an `Error` on any failure.
+
+## Limits
+
+These are not bugs to fix; they are direct consequences of `GOOS=js`:
+
+- **No tools, no MCP, no hooks, no sub-agent handoffs.** Anything that needs
+  `os/exec` or local file I/O is excluded from the build.
+- **No sessions.** `pkg/session` and `pkg/memory/database/sqlite` pull in
+  `modernc.org/libc` which does not have a js port. The browser caller is
+  responsible for keeping the message history.
+- **No fallbacks, no rule-based routing.** The rule-based router uses bleve,
+  which depends on `mmap` / file-locking primitives that don't exist on
+  js/wasm. A js-only `factory_js.go` swaps the full provider factory for a
+  slim variant with only openai / anthropic / google.
+- **No Docker Model Runner, no Bedrock, no Vertex AI.** Same reason —
+  `dmr` shells out, `bedrock` and `vertexai` pull in cloud SDKs that don't
+  cross-compile to wasm.
+- **No Docker Desktop integration.** `pkg/desktop` has stubs for js that
+  return empty paths and refuse to dial.
+- **CORS.** Mentioned above. Real deployment needs a proxy.
+
+## Where the cross-compilation work lives
+
+The shims that make the existing tree compile under `GOOS=js GOARCH=wasm`
+are intentionally tiny:
+
+| File | Purpose |
+| --- | --- |
+| `pkg/cache/lock_js.go` | No-op file-lock stubs (single-threaded js). |
+| `pkg/desktop/sockets_js.go` | Returns empty Docker Desktop paths. |
+| `pkg/desktop/connection_js.go` | Refuses Unix-socket / named-pipe dials. |
+| `pkg/desktop/connection_other.go` | Build tag updated to `!windows && !js`. |
+| `pkg/model/provider/factory.go` | Build tag added: `!js`. |
+| `pkg/model/provider/factory_js.go` | js-only provider dispatch (openai / anthropic / google). |
+
+Everything else compiles unchanged because docker-agent already had the
+`os/exec`, sandbox, sound, audio, server, browser, keyring code well-isolated
+behind their own packages — the wasm entry just doesn't import them.
+
+## Sanity check
+
+```sh
+# Native build still happy.
+go build ./...
+
+# Wasm build still happy.
+GOOS=js GOARCH=wasm go build -o /tmp/cagent.wasm ./cmd/wasm
+
+# Existing tests of the touched packages still pass.
+go test ./pkg/cache/... ./pkg/desktop/... ./pkg/model/provider/...
+
+# End-to-end runtime smoke test.
+node cmd/wasm/smoke_test.js
+```

--- a/cmd/wasm/bridge.go
+++ b/cmd/wasm/bridge.go
@@ -1,0 +1,147 @@
+//go:build js && wasm
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"syscall/js"
+
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/config/latest"
+)
+
+// ---------------------------------------------------------------------------
+// JS <-> Go conversion helpers
+// ---------------------------------------------------------------------------
+
+// throwingError builds a JS object the JS-side wrapper recognises as an
+// error to re-throw. We use a sentinel field so plain return values can never
+// collide with it (real config output never includes a `__error` key).
+func throwingError(msg string) any {
+	return js.ValueOf(map[string]any{"__error": msg})
+}
+
+// jsError wraps a Go error in a JS Error so it can be passed to Promise.reject.
+func jsError(err error) js.Value {
+	return js.Global().Get("Error").New(err.Error())
+}
+
+// rejectedPromise returns a Promise that rejects immediately with msg.
+// Used when we can detect a bad call before launching a goroutine.
+func rejectedPromise(msg string) js.Value {
+	return newPromise(func(_, reject func(any)) {
+		reject(jsError(fmt.Errorf("%s", msg)))
+	})
+}
+
+// newPromise builds a JavaScript Promise whose executor is a Go function.
+// The returned js.Value is the Promise itself; resolve/reject are passed
+// to executor and may be called from any goroutine.
+func newPromise(executor func(resolve, reject func(any))) js.Value {
+	promiseCtor := js.Global().Get("Promise")
+	handler := js.FuncOf(func(_ js.Value, args []js.Value) any {
+		resolve := args[0]
+		reject := args[1]
+		executor(
+			func(v any) { resolve.Invoke(v) },
+			func(v any) { reject.Invoke(v) },
+		)
+		return nil
+	})
+	// Note: handler is a one-shot Func. The Promise executor is invoked
+	// synchronously from the constructor, so it is safe to Release the
+	// handler immediately afterwards. We don't, because the executor
+	// captures goroutines that may continue to call resolve/reject — which
+	// only invoke the captured `resolve`/`reject` js.Values, not the handler
+	// itself, so leaking the handler is OK and avoids a subtle race.
+	return promiseCtor.New(handler)
+}
+
+// emit invokes onEvent(payload) on the JS side, swallowing any error if the
+// caller passed something other than a function (or nothing at all).
+func emit(onEvent js.Value, payload any) {
+	if onEvent.Type() != js.TypeFunction {
+		return
+	}
+	onEvent.Invoke(js.ValueOf(payload))
+}
+
+// jsObjectToStringMap converts a flat JS object {k: "v", ...} into a Go
+// map[string]string. Non-string values are stringified via Object.toString.
+// A null/undefined input yields a nil map.
+func jsObjectToStringMap(v js.Value) map[string]string {
+	if v.Type() != js.TypeObject {
+		return nil
+	}
+	keys := js.Global().Get("Object").Call("keys", v)
+	out := make(map[string]string, keys.Length())
+	for i := 0; i < keys.Length(); i++ {
+		k := keys.Index(i).String()
+		val := v.Get(k)
+		if val.Type() == js.TypeString {
+			out[k] = val.String()
+		} else {
+			out[k] = val.Call("toString").String()
+		}
+	}
+	return out
+}
+
+// jsToMessages decodes a JS array of {role, content} objects into a slice of
+// chat.Message. We round-trip through JSON so any extra fields the JS side
+// supplies (e.g. tool_calls in a future iteration) flow through naturally.
+func jsToMessages(v js.Value) ([]chat.Message, error) {
+	if v.Type() != js.TypeObject {
+		return nil, fmt.Errorf("messages must be an array")
+	}
+	jsonStr := js.Global().Get("JSON").Call("stringify", v).String()
+	var msgs []chat.Message
+	if err := json.Unmarshal([]byte(jsonStr), &msgs); err != nil {
+		return nil, fmt.Errorf("decoding messages: %w", err)
+	}
+	return msgs, nil
+}
+
+// configToMap reduces a fully-parsed *latest.Config to the small JS-friendly
+// shape returned by parseConfig. We deliberately omit fields that wouldn't
+// mean anything in the browser (toolsets, hooks, sandbox).
+func configToMap(cfg *latest.Config) map[string]any {
+	agents := make([]any, 0, len(cfg.Agents))
+	for _, a := range cfg.Agents {
+		agents = append(agents, map[string]any{
+			"name":         a.Name,
+			"description":  a.Description,
+			"model":        a.Model,
+			"instruction":  a.Instruction,
+			"sub_agents":   stringsToAny(a.SubAgents),
+			"handoffs":     stringsToAny(a.Handoffs),
+			"add_date":     a.AddDate,
+			"add_env_info": a.AddEnvironmentInfo,
+		})
+	}
+
+	models := map[string]any{}
+	for k, m := range cfg.Models {
+		models[k] = map[string]any{
+			"provider": m.Provider,
+			"model":    m.Model,
+			"base_url": m.BaseURL,
+		}
+	}
+
+	return map[string]any{
+		"version": cfg.Version,
+		"agents":  agents,
+		"models":  models,
+	}
+}
+
+// stringsToAny widens a []string to []any so syscall/js.ValueOf accepts it.
+func stringsToAny(in []string) []any {
+	out := make([]any, len(in))
+	for i, s := range in {
+		out[i] = s
+	}
+	return out
+}

--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -1,0 +1,264 @@
+//go:build js && wasm
+
+// Package main is a js/wasm entry point that exposes docker-agent's agentic
+// loop to the browser. It provides:
+//
+//   - Config parsing (any version → latest via pkg/config).
+//   - Agent enumeration.
+//   - A full agentic loop: streaming chat with tool calling, multi-agent
+//     handoffs, fallback models, hooks, and remote MCP tool support.
+//   - Request cancellation via abort().
+//
+// The binary is built with:
+//
+//	GOOS=js GOARCH=wasm go build -o web/docker-agent.wasm ./cmd/wasm
+//
+// and loaded by web/index.html via wasm_exec.js.
+//
+// What this entry point does NOT do:
+//
+//   - Run shell commands (no os/exec under js/wasm).
+//   - Open files or listen on sockets.
+//   - Persist sessions to sqlite.
+//   - Render a TUI.
+//
+// What it DOES do:
+//
+//   - Full tool-calling loop (model requests tools → execute → return results).
+//   - Multi-agent handoffs (transfer_task, handoff).
+//   - Remote MCP tool support (HTTP/SSE transport, NOT stdio).
+//   - Hooks (session_start, turn_start, pre_tool_use, post_tool_use).
+//   - Fallback models with retry + backoff.
+//   - Request cancellation via abort().
+//   - Token usage reporting.
+//
+// The JS API (registered on `globalThis.dockerAgent`):
+//
+//	dockerAgent.parseConfig(yamlString) -> {version, agents, models}
+//	dockerAgent.listAgents(yamlString) -> [{name, model, description, instruction}]
+//	dockerAgent.chat({yaml, agentName?, env?, messages}, onEvent) -> Promise<{message, usage?}>
+//	dockerAgent.abort() -> void   // cancels any in-flight chat request
+//
+// `onEvent` is called with one of:
+//
+//	{type: "delta",  content?: string, reasoning?: string}
+//	{type: "tool_call", id: string, name: string, args: string}
+//	{type: "tool_call_delta", id: string, name: string, arguments: string}
+//	{type: "tool_result", id: string, name: string, output: string}
+//	{type: "tool_blocked", id: string, name: string, reason: string}
+//	{type: "handoff", from: string, to: string}
+//	{type: "fallback", from: string, to: string, attempt: number, reason: string}
+//	{type: "finish", reason: string}
+//	{type: "usage",  input_tokens: number, output_tokens: number}
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"syscall/js"
+
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/environment"
+)
+
+// abortState holds the cancellation machinery for the active chat request.
+// Only one chat can be in flight at a time; calling abort() cancels it.
+var abortState struct {
+	mu     sync.Mutex
+	cancel context.CancelFunc
+}
+
+func main() {
+	api := js.Global().Get("Object").New()
+	api.Set("_parseConfig", js.FuncOf(parseConfigJS))
+	api.Set("_listAgents", js.FuncOf(listAgentsJS))
+	api.Set("chat", js.FuncOf(chatJS))
+	api.Set("abort", js.FuncOf(abortJS))
+	js.Global().Set("dockerAgent", api)
+
+	// Wrap _parseConfig and _listAgents with JS shims that detect the
+	// {__error: "..."} sentinel and throw a real Error.
+	js.Global().Call("eval", `
+(function () {
+  function wrapSync(name) {
+    const raw = globalThis.dockerAgent["_" + name];
+    globalThis.dockerAgent[name] = function () {
+      const r = raw.apply(null, arguments);
+      if (r && typeof r === "object" && typeof r.__error === "string") {
+        throw new Error(r.__error);
+      }
+      return r;
+    };
+    delete globalThis.dockerAgent["_" + name];
+  }
+  wrapSync("parseConfig");
+  wrapSync("listAgents");
+})();
+	`)
+
+	// Block forever: the runtime needs the Go scheduler alive so callbacks
+	// keep working.
+	select {}
+}
+
+// ---------------------------------------------------------------------------
+// parseConfig
+// ---------------------------------------------------------------------------
+
+func parseConfigJS(_ js.Value, args []js.Value) any {
+	if len(args) < 1 {
+		return throwingError("parseConfig: expected yaml string argument")
+	}
+	yamlStr := args[0].String()
+
+	cfg, err := config.Load(context.Background(), config.NewBytesSource("config.yaml", []byte(yamlStr)))
+	if err != nil {
+		return throwingError(fmt.Sprintf("parseConfig: %v", err))
+	}
+
+	return js.ValueOf(configToMap(cfg))
+}
+
+// ---------------------------------------------------------------------------
+// listAgents
+// ---------------------------------------------------------------------------
+
+func listAgentsJS(_ js.Value, args []js.Value) any {
+	if len(args) < 1 {
+		return throwingError("listAgents: expected yaml string argument")
+	}
+	yamlStr := args[0].String()
+
+	cfg, err := config.Load(context.Background(), config.NewBytesSource("config.yaml", []byte(yamlStr)))
+	if err != nil {
+		return throwingError(fmt.Sprintf("listAgents: %v", err))
+	}
+
+	agents := make([]any, 0, len(cfg.Agents))
+	for _, a := range cfg.Agents {
+		agents = append(agents, map[string]any{
+			"name":        a.Name,
+			"model":       a.Model,
+			"description": a.Description,
+			"instruction": a.Instruction,
+		})
+	}
+	return js.ValueOf(agents)
+}
+
+// ---------------------------------------------------------------------------
+// abort
+// ---------------------------------------------------------------------------
+
+func abortJS(_ js.Value, _ []js.Value) any {
+	abortState.mu.Lock()
+	defer abortState.mu.Unlock()
+	if abortState.cancel != nil {
+		abortState.cancel()
+		abortState.cancel = nil
+	}
+	return js.Undefined()
+}
+
+// ---------------------------------------------------------------------------
+// chat
+// ---------------------------------------------------------------------------
+
+func chatJS(_ js.Value, args []js.Value) any {
+	if len(args) < 1 {
+		return rejectedPromise("chat: expected at least one argument (options object)")
+	}
+	opts := args[0]
+	var onEvent js.Value
+	if len(args) >= 2 && args[1].Type() == js.TypeFunction {
+		onEvent = args[1]
+	}
+
+	yamlStr := opts.Get("yaml").String()
+	agentName := ""
+	if v := opts.Get("agentName"); v.Type() == js.TypeString {
+		agentName = v.String()
+	}
+	envMap := jsObjectToStringMap(opts.Get("env"))
+	messages, err := jsToMessages(opts.Get("messages"))
+	if err != nil {
+		return rejectedPromise(fmt.Sprintf("chat: parsing messages: %v", err))
+	}
+
+	// Set up cancellable context.
+	ctx, cancel := context.WithCancel(context.Background())
+	abortState.mu.Lock()
+	if abortState.cancel != nil {
+		abortState.cancel()
+	}
+	abortState.cancel = cancel
+	abortState.mu.Unlock()
+
+	return newPromise(func(resolve, reject func(any)) {
+		go func() {
+			defer func() {
+				abortState.mu.Lock()
+				cancel()
+				abortState.mu.Unlock()
+			}()
+
+			result, err := runChat(ctx, yamlStr, agentName, envMap, messages, onEvent)
+			if err != nil {
+				if ctx.Err() != nil {
+					reject(jsError(fmt.Errorf("chat aborted")))
+				} else {
+					reject(jsError(err))
+				}
+				return
+			}
+			resolve(result)
+		}()
+	})
+}
+
+// runChat loads the config, builds the runtime, and runs the agentic loop.
+func runChat(ctx context.Context, yamlStr, agentName string, envMap map[string]string, messages []chat.Message, onEvent js.Value) (any, error) {
+	cfg, err := config.Load(ctx, config.NewBytesSource("config.yaml", []byte(yamlStr)))
+	if err != nil {
+		return nil, fmt.Errorf("loading config: %w", err)
+	}
+
+	// Mirror the JS-supplied env map into the Go runtime's process env so any
+	// provider that bypasses environment.Provider still finds its key.
+	for k, v := range envMap {
+		_ = os.Setenv(k, v)
+	}
+
+	env := environment.NewMapEnvProvider(envMap)
+
+	// Build the full runtime with agents, tools, hooks, fallbacks.
+	rt, err := buildRuntime(ctx, cfg, env, onEvent)
+	if err != nil {
+		return nil, fmt.Errorf("building runtime: %w", err)
+	}
+
+	// Run the agentic loop.
+	result, err := rt.runAgentLoop(ctx, agentName, messages)
+	if err != nil {
+		return nil, err
+	}
+
+	return js.ValueOf(result), nil
+}
+
+// resolveModel resolves the agent's model field, which is either a key into
+// cfg.Models or an inline "provider/model" reference.
+func resolveModel(cfg *latest.Config, modelName string) (latest.ModelConfig, error) {
+	if mc, ok := cfg.Models[modelName]; ok {
+		return mc, nil
+	}
+	mc, err := latest.ParseModelRef(modelName)
+	if err != nil {
+		return latest.ModelConfig{}, fmt.Errorf("model %q: %w", modelName, err)
+	}
+	return mc, nil
+}

--- a/cmd/wasm/runtime_wasm.go
+++ b/cmd/wasm/runtime_wasm.go
@@ -1,0 +1,797 @@
+//go:build js && wasm
+
+package main
+
+// runtime_wasm.go implements a lightweight agentic loop for the browser-based
+// wasm build. It provides:
+//   - Tool calling loop (model requests tools → we execute → send results back)
+//   - Multi-agent handoffs (transfer_task / handoff)
+//   - Remote MCP tool support (HTTP/SSE transport)
+//   - Hooks (session_start, turn_start, pre_tool_use, post_tool_use)
+//   - Fallback models with retry + backoff
+//
+// It intentionally does NOT use pkg/runtime (blocked by sqlite) or
+// pkg/teamloader. Instead, it builds agents from config using pkg/agent
+// directly, constructs an in-process hook executor, and runs a simplified
+// version of the streaming loop.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"syscall/js"
+	"time"
+
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/environment"
+	"github.com/docker/docker-agent/pkg/hooks"
+	"github.com/docker/docker-agent/pkg/hooks/builtins"
+	"github.com/docker/docker-agent/pkg/model/provider"
+	"github.com/docker/docker-agent/pkg/model/provider/options"
+	"github.com/docker/docker-agent/pkg/team"
+	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/tools/builtin/filesystem"
+	mcptools "github.com/docker/docker-agent/pkg/tools/mcp"
+)
+
+// maxIterations prevents infinite tool-call loops.
+const maxIterations = 50
+
+// wasmRuntime holds the state for one chat session.
+type wasmRuntime struct {
+	cfg          *latest.Config
+	env          environment.Provider
+	team         *team.Team
+	agents       map[string]*agent.Agent
+	providers    map[string]provider.Provider
+	fallbacks    map[string][]provider.Provider
+	hookExec     map[string]*hooks.Executor
+	currentAgent string
+	onEvent      js.Value
+}
+
+// buildRuntime constructs a team of agents from the config, with providers,
+// MCP toolsets, hooks, and fallback models wired up.
+func buildRuntime(ctx context.Context, cfg *latest.Config, env environment.Provider, onEvent js.Value) (*wasmRuntime, error) {
+	rt := &wasmRuntime{
+		cfg:       cfg,
+		env:       env,
+		agents:    make(map[string]*agent.Agent),
+		providers: make(map[string]provider.Provider),
+		fallbacks: make(map[string][]provider.Provider),
+		hookExec:  make(map[string]*hooks.Executor),
+		onEvent:   onEvent,
+	}
+
+	// Build providers for each agent.
+	for _, agentCfg := range cfg.Agents {
+		modelCfg, err := resolveModel(cfg, agentCfg.Model)
+		if err != nil {
+			return nil, fmt.Errorf("agent %q: %w", agentCfg.Name, err)
+		}
+
+		prov, err := provider.NewWithModels(ctx, &modelCfg, cfg.Models, env, options.WithProviders(cfg.Providers))
+		if err != nil {
+			return nil, fmt.Errorf("agent %q: building model provider: %w", agentCfg.Name, err)
+		}
+		rt.providers[agentCfg.Name] = prov
+
+		// Build fallback providers.
+		for _, fbModel := range agentCfg.GetFallbackModels() {
+			fbCfg, err := resolveModel(cfg, fbModel)
+			if err != nil {
+				slog.Warn("Skipping fallback model", "agent", agentCfg.Name, "model", fbModel, "error", err)
+				continue
+			}
+			fbProv, err := provider.NewWithModels(ctx, &fbCfg, cfg.Models, env, options.WithProviders(cfg.Providers))
+			if err != nil {
+				slog.Warn("Skipping fallback model", "agent", agentCfg.Name, "model", fbModel, "error", err)
+				continue
+			}
+			rt.fallbacks[agentCfg.Name] = append(rt.fallbacks[agentCfg.Name], fbProv)
+		}
+	}
+
+	// Build agent objects. Two passes: first create all agents, then wire
+	// handoffs and sub-agents (which require the targets to exist already).
+	type agentBuildInfo struct {
+		name     string
+		opts     []agent.Opt
+		handoffs []string
+		subs     []string
+	}
+	var buildInfos []agentBuildInfo
+
+	for _, agentCfg := range cfg.Agents {
+		opts := []agent.Opt{
+			agent.WithModel(rt.providers[agentCfg.Name]),
+			agent.WithDescription(agentCfg.Description),
+		}
+
+		// Fallback models.
+		for _, fb := range rt.fallbacks[agentCfg.Name] {
+			opts = append(opts, agent.WithFallbackModel(fb))
+		}
+
+		// Toolsets: filesystem, remote MCP, etc.
+		for _, ts := range agentCfg.Toolsets {
+			switch {
+			case ts.Type == "filesystem" || ts.Type == "":
+				// Default toolset type is filesystem.
+				if ts.Type == "filesystem" {
+					fsTool := filesystem.NewFilesystemTool("/")
+					opts = append(opts, agent.WithToolSets(fsTool))
+				}
+			case ts.Remote.URL != "":
+				transport := ts.Remote.TransportType
+				if transport == "" {
+					transport = "streamable-http"
+				}
+				mcpTS := mcptools.NewRemoteToolset(
+					ts.Name,
+					ts.Remote.URL,
+					transport,
+					ts.Remote.Headers,
+					ts.Remote.OAuth,
+				)
+				opts = append(opts, agent.WithToolSets(mcpTS))
+			case ts.URL != "":
+				// URL directly on the toolset (legacy format)
+				transport := "streamable-http"
+				mcpTS := mcptools.NewRemoteToolset(
+					ts.Name,
+					ts.URL,
+					transport,
+					ts.Headers,
+					nil,
+				)
+				opts = append(opts, agent.WithToolSets(mcpTS))
+			}
+		}
+
+		// Hooks.
+		if agentCfg.Hooks != nil {
+			opts = append(opts, agent.WithHooks(agentCfg.Hooks))
+
+			// Build a hook executor for this agent.
+			registry := hooks.NewRegistry()
+			builtins.Register(registry)
+			hookExec := hooks.NewExecutorWithRegistry(agentCfg.Hooks, "", nil, registry)
+			rt.hookExec[agentCfg.Name] = hookExec
+		}
+
+		buildInfos = append(buildInfos, agentBuildInfo{
+			name:     agentCfg.Name,
+			opts:     opts,
+			handoffs: agentCfg.Handoffs,
+			subs:     agentCfg.SubAgents,
+		})
+	}
+
+	// First pass: create all agent objects (without cross-references).
+	agentsByName := make(map[string]*agent.Agent)
+	for _, info := range buildInfos {
+		a := agent.New(info.name, rt.agentInstruction(info.name), info.opts...)
+		agentsByName[info.name] = a
+		rt.agents[info.name] = a
+	}
+
+	// Second pass: wire handoffs and sub-agents. Since agent.WithHandoffs
+	// and agent.WithSubAgents are construction-time options, we rebuild
+	// agents that have cross-references.
+	for _, info := range buildInfos {
+		needsRebuild := false
+		var extraOpts []agent.Opt
+
+		if len(info.handoffs) > 0 {
+			var handoffs []*agent.Agent
+			for _, h := range info.handoffs {
+				if ha, ok := agentsByName[h]; ok {
+					handoffs = append(handoffs, ha)
+				}
+			}
+			if len(handoffs) > 0 {
+				extraOpts = append(extraOpts, agent.WithHandoffs(handoffs...))
+				needsRebuild = true
+			}
+		}
+
+		if len(info.subs) > 0 {
+			var subAgents []*agent.Agent
+			for _, s := range info.subs {
+				if sa, ok := agentsByName[s]; ok {
+					subAgents = append(subAgents, sa)
+				}
+			}
+			if len(subAgents) > 0 {
+				extraOpts = append(extraOpts, agent.WithSubAgents(subAgents...))
+				needsRebuild = true
+			}
+		}
+
+		if needsRebuild {
+			allOpts := append(info.opts, extraOpts...)
+			a := agent.New(info.name, rt.agentInstruction(info.name), allOpts...)
+			agentsByName[info.name] = a
+			rt.agents[info.name] = a
+		}
+	}
+
+	// Build team.
+	var allAgents []*agent.Agent
+	for _, agentCfg := range cfg.Agents {
+		allAgents = append(allAgents, agentsByName[agentCfg.Name])
+	}
+	rt.team = team.New(team.WithAgents(allAgents...))
+
+	return rt, nil
+}
+
+// agentInstruction returns the instruction for the named agent from cfg.
+func (rt *wasmRuntime) agentInstruction(name string) string {
+	for _, a := range rt.cfg.Agents {
+		if a.Name == name {
+			return a.Instruction
+		}
+	}
+	return ""
+}
+
+// runAgentLoop runs the full agentic loop: stream completions, process tool
+// calls, handle handoffs, and loop until the model says stop or we hit
+// maxIterations.
+func (rt *wasmRuntime) runAgentLoop(ctx context.Context, agentName string, messages []chat.Message) (map[string]any, error) {
+	if agentName == "" {
+		if len(rt.cfg.Agents) == 1 {
+			agentName = rt.cfg.Agents[0].Name
+		} else {
+			agentName = rt.cfg.Agents[0].Name
+		}
+	}
+	rt.currentAgent = agentName
+
+	a, ok := rt.agents[rt.currentAgent]
+	if !ok {
+		return nil, fmt.Errorf("agent %q not found", rt.currentAgent)
+	}
+
+	// Prepend system instruction.
+	if a.Instruction() != "" && (len(messages) == 0 || messages[0].Role != chat.MessageRoleSystem) {
+		sys := chat.Message{Role: chat.MessageRoleSystem, Content: a.Instruction()}
+		messages = append([]chat.Message{sys}, messages...)
+	}
+
+	// Fire session_start hook.
+	rt.fireHook(ctx, rt.currentAgent, hooks.EventSessionStart, &hooks.Input{})
+
+	var totalUsage chat.Usage
+	iteration := 0
+
+	for iteration < maxIterations {
+		iteration++
+
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		a = rt.agents[rt.currentAgent]
+
+		// Fire turn_start hook.
+		turnCtx := rt.fireHook(ctx, rt.currentAgent, hooks.EventTurnStart, &hooks.Input{})
+		if turnCtx != nil && turnCtx.AdditionalContext != "" {
+			// Inject context as a transient system message.
+			ctxMsg := chat.Message{Role: chat.MessageRoleSystem, Content: turnCtx.AdditionalContext}
+			messages = append(messages, ctxMsg)
+		}
+
+		// Get tools for this agent.
+		agentTools, err := a.Tools(ctx)
+		if err != nil {
+			slog.Warn("Failed to get tools", "agent", rt.currentAgent, "error", err)
+			agentTools = nil
+		}
+
+		// Add delegation tools if agent has handoffs or sub-agents.
+		agentTools = rt.addDelegationTools(a, agentTools)
+
+		// Try primary model with fallback chain.
+		streamResult, err := rt.streamWithFallback(ctx, a, messages, agentTools)
+		if err != nil {
+			return nil, fmt.Errorf("model call failed: %w", err)
+		}
+
+		// Accumulate usage.
+		if streamResult.usage != nil {
+			totalUsage.InputTokens += streamResult.usage.InputTokens
+			totalUsage.OutputTokens += streamResult.usage.OutputTokens
+		}
+
+		// Record assistant message in conversation history.
+		assistantMsg := chat.Message{
+			Role:             chat.MessageRoleAssistant,
+			Content:          streamResult.content,
+			ReasoningContent: streamResult.reasoning,
+			ToolCalls:        streamResult.toolCalls,
+		}
+		messages = append(messages, assistantMsg)
+
+		// No tool calls → model is done.
+		if len(streamResult.toolCalls) == 0 {
+			rt.emitEvent(map[string]any{"type": "finish", "reason": string(streamResult.finishReason)})
+			break
+		}
+
+		// Process tool calls.
+		toolMessages, handoff, err := rt.processToolCalls(ctx, streamResult.toolCalls, agentTools, messages)
+		if err != nil {
+			return nil, fmt.Errorf("processing tool calls: %w", err)
+		}
+		messages = append(messages, toolMessages...)
+
+		// Handle agent handoff.
+		if handoff != "" {
+			rt.emitEvent(map[string]any{
+				"type": "handoff",
+				"from": rt.currentAgent,
+				"to":   handoff,
+			})
+			rt.currentAgent = handoff
+			// Update system instruction for new agent.
+			newAgent := rt.agents[handoff]
+			if newAgent.Instruction() != "" {
+				sysMsg := chat.Message{
+					Role:    chat.MessageRoleSystem,
+					Content: newAgent.Instruction(),
+				}
+				messages = append(messages, sysMsg)
+			}
+		}
+	}
+
+	// Emit final usage.
+	if totalUsage.InputTokens > 0 || totalUsage.OutputTokens > 0 {
+		rt.emitEvent(map[string]any{
+			"type":          "usage",
+			"input_tokens":  float64(totalUsage.InputTokens),
+			"output_tokens": float64(totalUsage.OutputTokens),
+		})
+	}
+
+	// Build result.
+	result := map[string]any{
+		"message": map[string]any{
+			"role":    "assistant",
+			"content": rt.lastAssistantContent(messages),
+		},
+	}
+	if totalUsage.InputTokens > 0 || totalUsage.OutputTokens > 0 {
+		result["usage"] = map[string]any{
+			"input_tokens":  float64(totalUsage.InputTokens),
+			"output_tokens": float64(totalUsage.OutputTokens),
+		}
+	}
+	return result, nil
+}
+
+// streamResult holds the aggregated result of one completion call.
+type wasmStreamResult struct {
+	content      string
+	reasoning    string
+	toolCalls    []tools.ToolCall
+	finishReason chat.FinishReason
+	usage        *chat.Usage
+}
+
+// streamWithFallback tries the primary model, then fallbacks on failure.
+func (rt *wasmRuntime) streamWithFallback(ctx context.Context, a *agent.Agent, messages []chat.Message, agentTools []tools.Tool) (*wasmStreamResult, error) {
+	prov := rt.providers[a.Name()]
+	fallbacks := rt.fallbacks[a.Name()]
+
+	chain := append([]provider.Provider{prov}, fallbacks...)
+
+	var lastErr error
+	for i, p := range chain {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		if i > 0 {
+			rt.emitEvent(map[string]any{
+				"type":    "fallback",
+				"from":    chain[i-1].ID(),
+				"to":      p.ID(),
+				"attempt": float64(i + 1),
+				"reason":  lastErr.Error(),
+			})
+			// Brief backoff between fallback attempts.
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(time.Duration(i) * 500 * time.Millisecond):
+			}
+		}
+
+		result, err := rt.streamCompletion(ctx, p, a, messages, agentTools)
+		if err != nil {
+			lastErr = err
+			slog.Warn("Model attempt failed", "model", p.ID(), "attempt", i+1, "error", err)
+			continue
+		}
+		return result, nil
+	}
+
+	return nil, fmt.Errorf("all models failed: %w", lastErr)
+}
+
+// streamCompletion runs one streaming completion call and emits deltas.
+func (rt *wasmRuntime) streamCompletion(ctx context.Context, prov provider.Provider, a *agent.Agent, messages []chat.Message, agentTools []tools.Tool) (*wasmStreamResult, error) {
+	stream, err := prov.CreateChatCompletionStream(ctx, messages, agentTools)
+	if err != nil {
+		return nil, fmt.Errorf("opening stream: %w", err)
+	}
+	defer stream.Close()
+
+	var content strings.Builder
+	var reasoning strings.Builder
+	var toolCalls []tools.ToolCall
+	var usage *chat.Usage
+	var finishReason chat.FinishReason
+
+	toolCallIndex := make(map[string]int)
+
+	for {
+		resp, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("reading stream: %w", err)
+		}
+
+		if resp.Usage != nil {
+			usage = resp.Usage
+		}
+
+		for _, choice := range resp.Choices {
+			// Tool call deltas.
+			if len(choice.Delta.ToolCalls) > 0 {
+				for _, delta := range choice.Delta.ToolCalls {
+					idx, exists := toolCallIndex[delta.ID]
+					if !exists {
+						idx = len(toolCalls)
+						toolCallIndex[delta.ID] = idx
+						toolCalls = append(toolCalls, tools.ToolCall{
+							ID:   delta.ID,
+							Type: delta.Type,
+						})
+					}
+					tc := &toolCalls[idx]
+					if delta.Type != "" {
+						tc.Type = delta.Type
+					}
+					if delta.Function.Name != "" {
+						tc.Function.Name = delta.Function.Name
+					}
+					if delta.Function.Arguments != "" {
+						tc.Function.Arguments += delta.Function.Arguments
+					}
+
+					// Emit partial tool call event.
+					if tc.Function.Name != "" {
+						rt.emitEvent(map[string]any{
+							"type":      "tool_call_delta",
+							"id":        tc.ID,
+							"name":      tc.Function.Name,
+							"arguments": delta.Function.Arguments,
+						})
+					}
+				}
+				continue
+			}
+
+			// Content delta.
+			if choice.Delta.Content != "" {
+				content.WriteString(choice.Delta.Content)
+				rt.emitEvent(map[string]any{"type": "delta", "content": choice.Delta.Content})
+			}
+
+			// Reasoning delta.
+			if choice.Delta.ReasoningContent != "" {
+				reasoning.WriteString(choice.Delta.ReasoningContent)
+				rt.emitEvent(map[string]any{"type": "delta", "reasoning": choice.Delta.ReasoningContent})
+			}
+
+			if choice.FinishReason != "" {
+				finishReason = choice.FinishReason
+			}
+		}
+	}
+
+	// Infer finish reason if not set.
+	if finishReason == "" {
+		if len(toolCalls) > 0 {
+			finishReason = chat.FinishReasonToolCalls
+		} else {
+			finishReason = chat.FinishReasonStop
+		}
+	}
+
+	return &wasmStreamResult{
+		content:      content.String(),
+		reasoning:    reasoning.String(),
+		toolCalls:    toolCalls,
+		finishReason: finishReason,
+		usage:        usage,
+	}, nil
+}
+
+// processToolCalls executes tool calls and returns the tool result messages.
+// Returns (messages, handoffAgentName, error).
+func (rt *wasmRuntime) processToolCalls(ctx context.Context, calls []tools.ToolCall, agentTools []tools.Tool, _ []chat.Message) ([]chat.Message, string, error) {
+	toolByName := make(map[string]tools.Tool, len(agentTools))
+	for _, t := range agentTools {
+		toolByName[t.Name] = t
+	}
+
+	var resultMessages []chat.Message
+	var handoffAgent string
+
+	for _, tc := range calls {
+		if ctx.Err() != nil {
+			return nil, "", ctx.Err()
+		}
+
+		// Emit tool_call event.
+		rt.emitEvent(map[string]any{
+			"type": "tool_call",
+			"id":   tc.ID,
+			"name": tc.Function.Name,
+			"args": tc.Function.Arguments,
+		})
+
+		// Fire pre_tool_use hook.
+		preResult := rt.fireHook(ctx, rt.currentAgent, hooks.EventPreToolUse, &hooks.Input{
+			ToolName:  tc.Function.Name,
+			ToolUseID: tc.ID,
+			ToolInput: parseToolArgs(tc.Function.Arguments),
+		})
+		if preResult != nil && !preResult.Allowed {
+			// Hook denied the tool call.
+			rt.emitEvent(map[string]any{
+				"type":   "tool_blocked",
+				"id":     tc.ID,
+				"name":   tc.Function.Name,
+				"reason": preResult.Message,
+			})
+			resultMessages = append(resultMessages, chat.Message{
+				Role:       chat.MessageRoleTool,
+				ToolCallID: tc.ID,
+				Content:    fmt.Sprintf("Tool call denied by hook: %s", preResult.Message),
+			})
+			continue
+		}
+
+		// Handle built-in delegation tools.
+		switch tc.Function.Name {
+		case "transfer_task":
+			result, target := rt.handleTransferTask(tc)
+			resultMessages = append(resultMessages, chat.Message{
+				Role:       chat.MessageRoleTool,
+				ToolCallID: tc.ID,
+				Content:    result,
+			})
+			if target != "" {
+				handoffAgent = target
+			}
+			continue
+		case "handoff":
+			result, target := rt.handleHandoff(tc)
+			resultMessages = append(resultMessages, chat.Message{
+				Role:       chat.MessageRoleTool,
+				ToolCallID: tc.ID,
+				Content:    result,
+			})
+			if target != "" {
+				handoffAgent = target
+			}
+			continue
+		}
+
+		// Execute via toolset.
+		tool, exists := toolByName[tc.Function.Name]
+		if !exists {
+			errMsg := fmt.Sprintf("Tool %q not found", tc.Function.Name)
+			resultMessages = append(resultMessages, chat.Message{
+				Role:       chat.MessageRoleTool,
+				ToolCallID: tc.ID,
+				Content:    errMsg,
+			})
+			continue
+		}
+
+		toolResult, err := tool.Handler(ctx, tc)
+		var output string
+		if err != nil {
+			output = fmt.Sprintf("Error: %v", err)
+		} else if toolResult != nil {
+			output = toolResult.Output
+		}
+
+		// Emit tool result event.
+		rt.emitEvent(map[string]any{
+			"type":   "tool_result",
+			"id":     tc.ID,
+			"name":   tc.Function.Name,
+			"output": truncateOutput(output, 500),
+		})
+
+		// Fire post_tool_use hook.
+		rt.fireHook(ctx, rt.currentAgent, hooks.EventPostToolUse, &hooks.Input{
+			ToolName:     tc.Function.Name,
+			ToolUseID:    tc.ID,
+			ToolInput:    parseToolArgs(tc.Function.Arguments),
+			ToolResponse: output,
+			ToolError:    err != nil,
+		})
+
+		resultMessages = append(resultMessages, chat.Message{
+			Role:       chat.MessageRoleTool,
+			ToolCallID: tc.ID,
+			Content:    output,
+		})
+	}
+
+	return resultMessages, handoffAgent, nil
+}
+
+// addDelegationTools injects transfer_task and/or handoff tools into the
+// tool list when the agent has sub-agents or handoffs configured.
+func (rt *wasmRuntime) addDelegationTools(a *agent.Agent, existingTools []tools.Tool) []tools.Tool {
+	if len(a.Handoffs()) > 0 {
+		var names []string
+		for _, h := range a.Handoffs() {
+			names = append(names, h.Name())
+		}
+		existingTools = append(existingTools, tools.Tool{
+			Name:        "handoff",
+			Description: fmt.Sprintf("Hand off the conversation to another agent. Available agents: %s", strings.Join(names, ", ")),
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"agent": map[string]any{
+						"type":        "string",
+						"description": "The name of the agent to hand off to",
+						"enum":        names,
+					},
+				},
+				"required": []string{"agent"},
+			},
+		})
+	}
+
+	if len(a.SubAgents()) > 0 {
+		var names []string
+		var descriptions []string
+		for _, s := range a.SubAgents() {
+			names = append(names, s.Name())
+			descriptions = append(descriptions, fmt.Sprintf("- %s: %s", s.Name(), s.Description()))
+		}
+		existingTools = append(existingTools, tools.Tool{
+			Name:        "transfer_task",
+			Description: fmt.Sprintf("Transfer a task to a sub-agent. Available agents:\n%s", strings.Join(descriptions, "\n")),
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"agent": map[string]any{
+						"type":        "string",
+						"description": "The name of the agent to transfer to",
+						"enum":        names,
+					},
+					"task": map[string]any{
+						"type":        "string",
+						"description": "The task to perform",
+					},
+					"expected_output": map[string]any{
+						"type":        "string",
+						"description": "Expected output from the agent",
+					},
+				},
+				"required": []string{"agent", "task"},
+			},
+		})
+	}
+
+	return existingTools
+}
+
+// handleTransferTask processes the transfer_task tool call.
+func (rt *wasmRuntime) handleTransferTask(tc tools.ToolCall) (string, string) {
+	var params struct {
+		Agent          string `json:"agent"`
+		Task           string `json:"task"`
+		ExpectedOutput string `json:"expected_output"`
+	}
+	if err := json.Unmarshal([]byte(tc.Function.Arguments), &params); err != nil {
+		return fmt.Sprintf("Invalid arguments: %v", err), ""
+	}
+
+	if _, ok := rt.agents[params.Agent]; !ok {
+		return fmt.Sprintf("Agent %q not found", params.Agent), ""
+	}
+
+	return fmt.Sprintf("Task transferred to %s: %s", params.Agent, params.Task), params.Agent
+}
+
+// handleHandoff processes the handoff tool call.
+func (rt *wasmRuntime) handleHandoff(tc tools.ToolCall) (string, string) {
+	var params struct {
+		Agent string `json:"agent"`
+	}
+	if err := json.Unmarshal([]byte(tc.Function.Arguments), &params); err != nil {
+		return fmt.Sprintf("Invalid arguments: %v", err), ""
+	}
+
+	if _, ok := rt.agents[params.Agent]; !ok {
+		return fmt.Sprintf("Agent %q not found", params.Agent), ""
+	}
+
+	return fmt.Sprintf("Conversation handed off to %s. The agent %s handed off the conversation to you. "+
+		"Complete your part of the task and hand off to the next appropriate agent "+
+		"(if any are available to you), or respond directly to the user.", params.Agent, rt.currentAgent), params.Agent
+}
+
+// fireHook dispatches a hook event and returns the result.
+func (rt *wasmRuntime) fireHook(ctx context.Context, agentName string, event hooks.EventType, input *hooks.Input) *hooks.Result {
+	exec, ok := rt.hookExec[agentName]
+	if !ok || exec == nil {
+		return nil
+	}
+	if !exec.Has(event) {
+		return nil
+	}
+
+	result, err := exec.Dispatch(ctx, event, input)
+	if err != nil {
+		slog.Warn("Hook dispatch failed", "event", event, "agent", agentName, "error", err)
+		return nil
+	}
+	return result
+}
+
+// emitEvent sends a typed event to the JS onEvent callback.
+func (rt *wasmRuntime) emitEvent(event map[string]any) {
+	emit(rt.onEvent, event)
+}
+
+// lastAssistantContent returns the content of the last assistant message.
+func (rt *wasmRuntime) lastAssistantContent(messages []chat.Message) string {
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role == chat.MessageRoleAssistant && messages[i].Content != "" {
+			return messages[i].Content
+		}
+	}
+	return ""
+}
+
+// parseToolArgs attempts to parse a JSON string into a map.
+func parseToolArgs(args string) map[string]any {
+	var result map[string]any
+	if err := json.Unmarshal([]byte(args), &result); err != nil {
+		return nil
+	}
+	return result
+}
+
+// truncateOutput truncates a string to maxLen characters, appending "…" if truncated.
+func truncateOutput(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "…"
+}

--- a/cmd/wasm/smoke_test.js
+++ b/cmd/wasm/smoke_test.js
@@ -1,0 +1,133 @@
+// Node-side smoke test for cmd/wasm/web/docker-agent.wasm.
+//
+// We mirror the polyfill setup from Go's stock wasm_exec_node.js but stop
+// short of its auto-exit logic — instead we call dockerAgent.parseConfig
+// after the runtime is up and assert two YAML shapes parse correctly:
+//   1. A two-agent config (validates the full version-upgrade pipeline).
+//   2. An OpenRouter-style custom provider with a slash-laden model name
+//      (validates the path our browser demo exercises).
+//
+// Run with:  node cmd/wasm/smoke_test.js
+
+"use strict";
+
+globalThis.require = require;
+globalThis.fs = require("node:fs");
+globalThis.path = require("node:path");
+globalThis.TextEncoder = require("node:util").TextEncoder;
+globalThis.TextDecoder = require("node:util").TextDecoder;
+globalThis.performance ??= require("node:perf_hooks").performance;
+globalThis.crypto ??= require("node:crypto").webcrypto;
+
+require("/opt/homebrew/Cellar/go/1.26.2/libexec/lib/wasm/wasm_exec.js");
+
+function assert(cond, msg) {
+  if (!cond) {
+    console.error("ASSERTION FAILED:", msg);
+    process.exit(1);
+  }
+}
+
+(async () => {
+  const wasm = fs.readFileSync(__dirname + "/web/docker-agent.wasm");
+  const go = new Go();
+  go.argv = ["docker-agent.wasm"];
+  const { instance } = await WebAssembly.instantiate(wasm, go.importObject);
+  // Don't await go.run — main() blocks on `select{}`. Fire and forget.
+  go.run(instance);
+
+  for (let i = 0; i < 100 && !globalThis.dockerAgent; i++) {
+    await new Promise((r) => setTimeout(r, 10));
+  }
+  if (!globalThis.dockerAgent) {
+    console.error("dockerAgent global was never registered");
+    process.exit(1);
+  }
+
+  // --- Case 1: two-agent config exercising the version migration path. ---
+  const twoAgents = globalThis.dockerAgent.parseConfig(`
+version: "2"
+agents:
+  root:
+    model: openai/gpt-4o-mini
+    instruction: hi
+  helper:
+    model: anthropic/claude-3-5-sonnet-latest
+    instruction: be helpful
+models:
+  custom:
+    provider: openai
+    model: gpt-4o-mini
+`);
+  assert(Array.isArray(twoAgents.agents) && twoAgents.agents.length === 2,
+    "two-agent config should yield two agents");
+  assert(
+    twoAgents.agents.some((a) => a.name === "helper"),
+    "two-agent config should include 'helper'",
+  );
+  assert(
+    twoAgents.models.custom && twoAgents.models.custom.provider === "openai",
+    "two-agent config: models.custom.provider should be 'openai'",
+  );
+
+  // --- Case 2: OpenRouter custom provider — exact YAML the browser demo
+  //     ships in its default textarea, with a slash-laden model name. ---
+  let orStyle;
+  try {
+    orStyle = globalThis.dockerAgent.parseConfig(`
+providers:
+  openrouter:
+    provider: openai
+    base_url: https://openrouter.ai/api/v1
+    token_key: OPENROUTER_API_KEY
+agents:
+  root:
+    model: openrouter/meta-llama/llama-3.3-70b-instruct:free
+    instruction: be helpful
+`);
+  } catch (e) {
+    console.error("OR-style YAML parseConfig threw:");
+    console.error(" ", e && e.message ? e.message : e);
+    process.exit(1);
+  }
+  assert(orStyle.agents.length === 1, "OR-style config should have one agent");
+  assert(
+    orStyle.agents[0].model === "openrouter/meta-llama/llama-3.3-70b-instruct:free",
+    "OR-style model field should round-trip with both slashes intact",
+  );
+
+  // --- Case 3: listAgents API ---
+  const agents = globalThis.dockerAgent.listAgents(`
+providers:
+  openrouter:
+    provider: openai
+    base_url: https://openrouter.ai/api/v1
+    token_key: OPENROUTER_API_KEY
+agents:
+  root:
+    model: openrouter/meta-llama/llama-3.3-70b-instruct:free
+    description: The main agent
+    instruction: be helpful
+  helper:
+    model: openrouter/google/gemma-3-27b-it:free
+    description: A helper
+    instruction: assist the user
+`);
+  assert(Array.isArray(agents) && agents.length === 2,
+    "listAgents should return 2 agents");
+  assert(agents[0].name === "root" && agents[0].description === "The main agent",
+    "listAgents[0] should be root with description");
+  assert(agents[1].name === "helper",
+    "listAgents[1] should be helper");
+
+  // --- Case 4: abort() should be callable without error ---
+  assert(typeof globalThis.dockerAgent.abort === "function",
+    "abort should be a function");
+  globalThis.dockerAgent.abort(); // should not throw
+
+  console.log("OK — all smoke tests pass (parseConfig, listAgents, abort).");
+  process.exit(0);
+})().catch((e) => {
+  console.error("smoke test failed:", e);
+  process.exit(1);
+});

--- a/cmd/wasm/web/auth.js
+++ b/cmd/wasm/web/auth.js
@@ -1,0 +1,138 @@
+// OpenRouter PKCE OAuth helpers for the docker-agent wasm browser demo.
+//
+// Implements the flow described at:
+//   https://openrouter.ai/docs/use-cases/oauth-pkce
+//
+// Lifecycle:
+//   1. signIn():
+//        - generates a 64-byte random code verifier (base64url),
+//        - derives the S256 code challenge,
+//        - stashes the verifier in sessionStorage,
+//        - redirects the tab to https://openrouter.ai/auth?...
+//   2. handleCallback() (call once on every page load):
+//        - if the URL has a ?code= param, POST it together with the stashed
+//          verifier to https://openrouter.ai/api/v1/auth/keys, store the
+//          returned API key in localStorage, clean the URL.
+//        - returns the freshly minted key, or null if there was no callback.
+//   3. getKey() / signOut():
+//        - read / clear the persisted key.
+//
+// The persisted key is a regular OpenRouter user-controlled API key. It is
+// scoped, revocable from https://openrouter.ai/settings/keys, and lives only
+// in the user's browser — there is no backend.
+//
+// Why localStorage for the key but sessionStorage for the verifier?
+//   - The verifier is a one-shot secret that must survive the redirect to
+//     OpenRouter and back; sessionStorage is the right scope.
+//   - The key is meant to persist across reloads so the user doesn't re-auth
+//     every time. localStorage matches that. This is a deliberate trade-off:
+//     anything in localStorage is reachable by other scripts on the same
+//     origin (XSS), so we treat the key as "user-equivalent credential" and
+//     remind the user they can revoke it at the OpenRouter dashboard.
+
+"use strict";
+
+const STORAGE_KEY = "openrouter_api_key";
+const VERIFIER_KEY = "openrouter_pkce_verifier";
+
+// base64url-encodes an ArrayBuffer (or Uint8Array) per RFC 4648 §5.
+function base64url(buf) {
+  const bytes = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
+  // String.fromCharCode is fine for the byte sizes we use here (<= 64 bytes
+  // for the verifier, 32 for the SHA-256 digest), so no chunking needed.
+  let s = "";
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+  return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+// randomVerifier returns a fresh PKCE code_verifier. RFC 7636 mandates
+// 43..128 characters drawn from the URL-safe alphabet; 64 bytes of randomness
+// → ~86 chars after base64url, well within the range.
+function randomVerifier() {
+  const bytes = new Uint8Array(64);
+  crypto.getRandomValues(bytes);
+  return base64url(bytes);
+}
+
+// s256 hashes the verifier with SHA-256 and base64url-encodes the digest.
+async function s256(verifier) {
+  const data = new TextEncoder().encode(verifier);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return base64url(digest);
+}
+
+// callbackURL is the URL OpenRouter redirects back to after the user grants
+// access. Whatever path the page is currently served from will do; we strip
+// any query/hash so the redirect target is canonical.
+function callbackURL() {
+  return location.origin + location.pathname;
+}
+
+// signIn kicks off the PKCE flow. The function does not return — the tab
+// navigates away to OpenRouter.
+export async function signIn() {
+  const verifier = randomVerifier();
+  sessionStorage.setItem(VERIFIER_KEY, verifier);
+  const challenge = await s256(verifier);
+
+  const url = new URL("https://openrouter.ai/auth");
+  url.searchParams.set("callback_url", callbackURL());
+  url.searchParams.set("code_challenge", challenge);
+  url.searchParams.set("code_challenge_method", "S256");
+
+  location.assign(url.toString());
+}
+
+// handleCallback completes the PKCE flow if the page was loaded with a `code`
+// query parameter. It removes the param from the URL on success so a refresh
+// doesn't re-attempt the exchange (codes are single-use) and so the key isn't
+// leaked into browser history beyond the redirect itself.
+//
+// Returns the new API key on a successful exchange, null if there was no
+// callback in progress, or throws on failure.
+export async function handleCallback() {
+  const params = new URLSearchParams(location.search);
+  const code = params.get("code");
+  if (!code) return null;
+
+  const verifier = sessionStorage.getItem(VERIFIER_KEY);
+  sessionStorage.removeItem(VERIFIER_KEY);
+
+  // Always clean the URL, even on failure, so a stale ?code= doesn't haunt
+  // future loads.
+  history.replaceState({}, "", callbackURL());
+
+  if (!verifier) {
+    throw new Error("PKCE verifier missing — please click Sign in again.");
+  }
+
+  const r = await fetch("https://openrouter.ai/api/v1/auth/keys", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      code,
+      code_verifier: verifier,
+      code_challenge_method: "S256",
+    }),
+  });
+  if (!r.ok) {
+    const body = await r.text().catch(() => "");
+    throw new Error(`OpenRouter token exchange failed: ${r.status} ${body}`);
+  }
+  const { key } = await r.json();
+  if (!key) throw new Error("OpenRouter token exchange returned no key");
+  localStorage.setItem(STORAGE_KEY, key);
+  return key;
+}
+
+// getKey returns the stored API key, or null if the user is not signed in.
+export function getKey() {
+  return localStorage.getItem(STORAGE_KEY);
+}
+
+// signOut clears the local copy of the key. The key itself remains live on
+// the OpenRouter side until the user revokes it from
+// https://openrouter.ai/settings/keys — there is no remote logout endpoint.
+export function signOut() {
+  localStorage.removeItem(STORAGE_KEY);
+}

--- a/cmd/wasm/web/index.html
+++ b/cmd/wasm/web/index.html
@@ -1,0 +1,1043 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>docker-agent in the browser</title>
+<style>
+  /* ---- Design tokens ---------------------------------------------------
+     One block per surface: colours, depth, geometry, typography. The dark
+     palette is set on either an explicit data-theme="dark" or the OS
+     preference (when the user hasn't pinned a theme). Light is the default
+     and gets re-applied for an explicit data-theme="light".
+  ---------------------------------------------------------------------- */
+  :root {
+    color-scheme: light;
+
+    /* Greyscale + radial accent for the page background */
+    --bg: #f4f4f5;
+    --bg-accent:
+      radial-gradient(circle at top left, rgba(0, 0, 0, .04), transparent 34rem),
+      radial-gradient(circle at top right, rgba(34, 197, 94, .07), transparent 30rem),
+      var(--bg);
+
+    /* Surfaces (panels, headers, hover wash) */
+    --panel: rgba(255, 255, 255, .85);
+    --panel-solid: #ffffff;
+    --panel-muted: rgba(0, 0, 0, .04);
+    --panel-muted-strong: rgba(0, 0, 0, .07);
+
+    /* Lines */
+    --border: rgba(0, 0, 0, .12);
+    --border-strong: rgba(0, 0, 0, .20);
+
+    /* Foreground */
+    --text: #18181b;
+    --muted: #6b7280;
+    --muted-2: #9ca3af;
+
+    /* Roles */
+    --link: #2563eb;
+    --accent: #16a34a;
+    --accent-hover: #15803d;
+    --accent-text: #ffffff;
+    --danger: #dc2626;
+    --warning: #d97706;
+
+    /* Depth + geometry */
+    --shadow: 0 18px 45px rgba(0, 0, 0, .08);
+    --shadow-soft: 0 8px 24px rgba(0, 0, 0, .06);
+    --radius: 16px;
+    --radius-sm: 10px;
+
+    /* Type */
+    --mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  }
+
+  /* Dark palette — applied via OS preference, unless the user pinned light. */
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      color-scheme: dark;
+      --bg: #18181b;
+      --panel: rgba(39, 39, 42, .82);
+      --panel-solid: #27272a;
+      --panel-muted: rgba(255, 255, 255, .04);
+      --panel-muted-strong: rgba(255, 255, 255, .07);
+      --border: rgba(255, 255, 255, .10);
+      --border-strong: rgba(255, 255, 255, .18);
+      --text: #f4f4f5;
+      --muted: #a1a1aa;
+      --muted-2: #71717a;
+      --link: #93c5fd;
+      --accent: #22c55e;
+      --accent-hover: #16a34a;
+      --accent-text: #04130a;
+      --danger: #f87171;
+      --warning: #fbbf24;
+      --shadow: 0 22px 60px rgba(0, 0, 0, .40);
+      --shadow-soft: 0 10px 28px rgba(0, 0, 0, .28);
+      --bg-accent:
+        radial-gradient(circle at top left, rgba(255, 255, 255, .035), transparent 34rem),
+        radial-gradient(circle at top right, rgba(34, 197, 94, .07), transparent 30rem),
+        var(--bg);
+    }
+  }
+
+  /* Same dark palette, this time with the user's explicit pin. */
+  :root[data-theme="dark"] {
+    color-scheme: dark;
+    --bg: #18181b;
+    --panel: rgba(39, 39, 42, .82);
+    --panel-solid: #27272a;
+    --panel-muted: rgba(255, 255, 255, .04);
+    --panel-muted-strong: rgba(255, 255, 255, .07);
+    --border: rgba(255, 255, 255, .10);
+    --border-strong: rgba(255, 255, 255, .18);
+    --text: #f4f4f5;
+    --muted: #a1a1aa;
+    --muted-2: #71717a;
+    --link: #93c5fd;
+    --accent: #22c55e;
+    --accent-hover: #16a34a;
+    --accent-text: #04130a;
+    --danger: #f87171;
+    --warning: #fbbf24;
+    --shadow: 0 22px 60px rgba(0, 0, 0, .40);
+    --shadow-soft: 0 10px 28px rgba(0, 0, 0, .28);
+    --bg-accent:
+      radial-gradient(circle at top left, rgba(255, 255, 255, .035), transparent 34rem),
+      radial-gradient(circle at top right, rgba(34, 197, 94, .07), transparent 30rem),
+      var(--bg);
+  }
+  :root[data-theme="light"] { color-scheme: light; }
+
+  /* ---- Reset + base ---------------------------------------------------- */
+  *, *::before, *::after { box-sizing: border-box; }
+  html, body { height: 100%; margin: 0; }
+  body {
+    font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    display: flex;
+    flex-direction: column;
+    padding: 1rem;
+    gap: .9rem;
+    color: var(--text);
+    background: var(--bg-accent);
+
+    & a {
+      color: var(--link);
+      text-decoration: none;
+
+      &:hover { text-decoration: underline; }
+    }
+  }
+
+  /* ---- Top bar --------------------------------------------------------- */
+  .topbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    flex: 0 0 auto;
+
+    & h1 {
+      margin: 0;
+      letter-spacing: -0.025em;
+      font-size: clamp(1.25rem, 1.8vw, 1.65rem);
+      line-height: 1.1;
+      white-space: nowrap;
+
+      & small {
+        font-weight: 500;
+        color: var(--muted);
+        font-size: .56em;
+      }
+    }
+
+    & .spacer { flex: 1 1 auto; }
+  }
+
+  .theme-toggle {
+    width: 2.35rem;
+    height: 2.35rem;
+    border-radius: 999px;
+    padding: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1rem;
+    background: var(--panel);
+    border: 1px solid var(--border);
+    box-shadow: var(--shadow-soft);
+    backdrop-filter: blur(14px);
+  }
+
+  /* ---- Utilities ------------------------------------------------------- */
+  .muted { color: var(--muted); font-size: 12px; }
+  .err   { color: var(--danger); }
+  .ok    { color: var(--accent); }
+  .row   { display: flex; gap: .6rem; align-items: center; flex-wrap: wrap; }
+  code   { background: var(--panel-muted-strong); padding: 1px 4px; border-radius: 5px; }
+
+  /* ---- Form controls --------------------------------------------------- */
+  textarea, input, select {
+    width: 100%;
+    font: inherit;
+    padding: .48rem .65rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--panel-solid);
+    color: var(--text);
+    outline: none;
+    transition: border-color .16s ease, box-shadow .16s ease, background .16s ease;
+
+    &:focus {
+      border-color: color-mix(in srgb, var(--accent) 70%, var(--border));
+      box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 20%, transparent);
+    }
+  }
+  textarea { font-family: var(--mono); resize: vertical; }
+
+  button {
+    padding: .5rem .95rem;
+    font: inherit;
+    font-weight: 600;
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--panel-solid);
+    cursor: pointer;
+    transition: transform .12s ease, border-color .16s ease, background .16s ease, box-shadow .16s ease;
+
+    &:hover:not([disabled]) {
+      transform: translateY(-1px);
+      border-color: var(--border-strong);
+      box-shadow: var(--shadow-soft);
+    }
+    &:active:not([disabled]) { transform: translateY(0); }
+    &[disabled]              { opacity: .5; cursor: not-allowed; }
+
+    &.primary {
+      background: var(--accent);
+      color: var(--accent-text);
+      border-color: transparent;
+
+      &:hover:not([disabled]) { background: var(--accent-hover); }
+    }
+
+    &.danger {
+      background: var(--danger);
+      color: #fff;
+      border-color: transparent;
+
+      &:hover:not([disabled]) { background: color-mix(in srgb, var(--danger) 85%, black); }
+    }
+
+    &.sign-in-btn {
+      background: linear-gradient(135deg, var(--accent), var(--accent-hover));
+      color: var(--accent-text);
+      border-color: transparent;
+      box-shadow: 0 10px 24px color-mix(in srgb, var(--accent) 24%, transparent);
+
+      &:hover:not([disabled]) {
+        background: linear-gradient(135deg, var(--accent-hover), var(--accent));
+        box-shadow: 0 14px 30px color-mix(in srgb, var(--accent) 32%, transparent);
+      }
+    }
+  }
+
+  /* ---- Workbench layout ------------------------------------------------ */
+  .workbench {
+    flex: 1 1 auto;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: .9rem;
+    min-height: 0;
+
+    @media (max-width: 900px) { grid-template-columns: 1fr; }
+  }
+
+  .panel {
+    display: flex;
+    flex-direction: column;
+    min-height: 18em;
+    overflow: hidden;
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    backdrop-filter: blur(18px);
+
+    & > header {
+      min-height: 2.55rem;
+      padding: .45rem .85rem;
+      background: var(--panel-muted);
+      border-bottom: 1px solid var(--border);
+      color: var(--muted);
+      font-size: 12px;
+      font-weight: 600;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: .8rem;
+    }
+
+    & > .body {
+      flex: 1 1 auto;
+      min-height: 0;
+      overflow: auto;
+      background: var(--panel-solid);
+    }
+  }
+
+  /* Panel-edge strips: prompt bar at the bottom of chat, model picker
+     under the YAML editor. Same chrome, different content. */
+  .prompt-bar, .panel-footer {
+    display: flex;
+    gap: .65rem;
+    align-items: center;
+    padding: .75rem .85rem;
+    border-top: 1px solid var(--border);
+    background: var(--panel-muted);
+    flex: 0 0 auto;
+  }
+  .panel-footer {
+    font-size: 12px;
+    color: var(--muted);
+
+    & label  { white-space: nowrap; font-weight: 600; }
+    & select { flex: 1 1 auto; }
+  }
+
+  /* ---- YAML editor (CodeMirror) ----------------------------------------
+     The official One Dark theme handles dark mode; light mode uses CM6's
+     built-in default highlight style. */
+  #yaml { height: 100%; }
+  .cm-editor {
+    height: 100%;
+    font-size: 13px;
+
+    &.cm-focused { outline: none; }
+  }
+  .cm-scroller { overflow: auto; font-family: var(--mono); }
+
+  /* ---- Chat transcript ------------------------------------------------- */
+  #chat {
+    min-height: 100%;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: .7rem;
+    background: rgb(41, 44, 51);
+
+    &:empty::before {
+      content: "No messages yet — type a prompt below and hit Send.";
+      color: var(--muted);
+      font-size: 12px;
+      align-self: center;
+      margin-top: 2em;
+    }
+  }
+
+  .msg {
+    max-width: min(48em, 88%);
+    padding: .68rem .9rem;
+    border-radius: 16px;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    line-height: 1.45;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, .04);
+
+    &.user {
+      align-self: flex-end;
+      background: linear-gradient(135deg, var(--accent), var(--accent-hover));
+      color: var(--accent-text);
+      border-bottom-right-radius: 5px;
+    }
+    &.assistant {
+      align-self: flex-start;
+      background: var(--panel-muted-strong);
+      border: 1px solid var(--border);
+      border-bottom-left-radius: 5px;
+
+      &.streaming::after {
+        content: "▋";
+        animation: blink 1s steps(2) infinite;
+      }
+    }
+    &.error {
+      align-self: stretch;
+      max-width: none;
+      font-size: 13px;
+      background: color-mix(in srgb, var(--danger) 12%, transparent);
+      color: var(--danger);
+      border: 1px solid color-mix(in srgb, var(--danger) 28%, transparent);
+    }
+    &.system {
+      align-self: stretch;
+      max-width: none;
+      font-size: 12px;
+      padding: .4rem .7rem;
+      background: color-mix(in srgb, var(--accent) 8%, transparent);
+      color: var(--muted);
+      border: 1px solid color-mix(in srgb, var(--accent) 18%, transparent);
+      border-radius: 8px;
+    }
+
+    & .reason {
+      display: block;
+      font-style: italic;
+      color: var(--muted);
+      font-size: 12px;
+      margin-bottom: .35em;
+      padding-bottom: .35em;
+      border-bottom: 1px dashed var(--border-strong);
+    }
+
+    /* Inline markdown rendering */
+    & code {
+      font-family: var(--mono);
+      font-size: .9em;
+      background: var(--panel-muted-strong);
+      padding: .1em .35em;
+      border-radius: 4px;
+    }
+    & pre {
+      margin: .5em 0;
+      padding: .6em .8em;
+      background: var(--panel-muted-strong);
+      border-radius: 8px;
+      overflow-x: auto;
+      white-space: pre;
+      font-family: var(--mono);
+      font-size: .85em;
+      line-height: 1.4;
+    }
+    & pre code {
+      background: none;
+      padding: 0;
+      border-radius: 0;
+    }
+    & strong { font-weight: 700; }
+    & em { font-style: italic; }
+  }
+
+  @keyframes blink { 0%, 100% { opacity: 1; } 50% { opacity: 0; } }
+
+  /* ---- Prompt bar widgets --------------------------------------------- */
+  #prompt {
+    flex: 1 1 auto;
+    min-width: 0;
+    resize: none;
+    min-height: 2.6em;
+    max-height: 9em;
+  }
+  #send, #abort { white-space: nowrap; align-self: stretch; }
+  #abort { display: none; }
+  .streaming-active #send { display: none; }
+  .streaming-active #abort { display: inline-flex; }
+
+  /* ---- Token usage badge --------------------------------------------- */
+  .token-badge {
+    font-size: 11px;
+    color: var(--muted);
+    padding: .15em .5em;
+    border-radius: 6px;
+    background: var(--panel-muted-strong);
+    white-space: nowrap;
+  }
+
+  /* ---- Account-health dot --------------------------------------------- */
+  .health {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--muted-2);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--muted-2) 18%, transparent);
+    flex: 0 0 auto;
+    cursor: help;
+
+    &.green  { background: var(--accent);  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent)  22%, transparent); }
+    &.yellow { background: var(--warning); box-shadow: 0 0 0 3px color-mix(in srgb, var(--warning) 24%, transparent); }
+    &.red    { background: var(--danger);  box-shadow: 0 0 0 3px color-mix(in srgb, var(--danger)  20%, transparent); }
+  }
+
+  /* ---- Loading overlay ------------------------------------------------- */
+  .wasm-loading {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: color-mix(in srgb, var(--bg) 85%, transparent);
+    backdrop-filter: blur(6px);
+    z-index: 1000;
+    transition: opacity .3s ease;
+
+    &.loaded { opacity: 0; pointer-events: none; }
+
+    & .spinner {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: .8rem;
+      font-size: 13px;
+      color: var(--muted);
+    }
+    & .spinner::before {
+      content: "";
+      width: 32px;
+      height: 32px;
+      border: 3px solid var(--border);
+      border-top-color: var(--accent);
+      border-radius: 50%;
+      animation: spin .8s linear infinite;
+    }
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+
+  /* ---- YAML validation status ----------------------------------------- */
+  #yaml-status {
+    font-size: 11px;
+    font-weight: 500;
+    margin-left: .4em;
+    transition: color .15s ease;
+  }
+  #yaml-status.valid { color: var(--accent); }
+  #yaml-status.invalid { color: var(--danger); }
+  #yaml-status .error-text {
+    display: inline;
+    cursor: help;
+  }
+</style>
+</head>
+<body>
+
+<!-- Loading overlay shown until wasm boots -->
+<div id="wasm-loading" class="wasm-loading">
+  <div class="spinner">Loading WebAssembly runtime…</div>
+</div>
+
+<header class="topbar">
+  <h1>Docker Agent Demo <small>· powered by <a href="https://openrouter.ai" target="_blank" rel="noopener" style="color: var(--accent);">OpenRouter</a></small></h1>
+  <div class="spacer"></div>
+  <div class="row">
+    <button id="sign-in" class="sign-in-btn">Sign in with OpenRouter</button>
+    <button id="sign-out" hidden>Sign out</button>
+    <span id="health-dot" class="health" title="" hidden></span>
+    <span id="auth-state" class="muted">not signed in</span>
+    <button id="theme-toggle" class="theme-toggle" title="Toggle light/dark mode" aria-label="Toggle light/dark mode">◐</button>
+  </div>
+</header>
+
+<section class="workbench">
+  <div class="panel">
+    <header>
+      <span>Agent config <span id="yaml-status"></span></span>
+      <span class="row">
+        <label for="agent-picker" class="muted" style="font-size: 11px;">Agent:</label>
+        <select id="agent-picker" style="width: auto; font-size: 11px; padding: .2em .4em;">
+          <option value="">root</option>
+        </select>
+      </span>
+    </header>
+    <div class="body"><div id="yaml"></div></div>
+    <div class="panel-footer">
+      <label for="model">Model</label>
+      <select id="model">
+        <option value="openai/gpt-oss-120b:free">openai / gpt-oss-120b (free)</option>
+        <option value="meta-llama/llama-3.3-70b-instruct:free">meta-llama / llama-3.3-70b-instruct (free)</option>
+        <option value="google/gemma-3-27b-it:free">google / gemma-3-27b-it (free)</option>
+        <option value="qwen/qwen3-coder:free">qwen / qwen3-coder (free)</option>
+        <option value="openai/gpt-oss-20b:free">openai / gpt-oss-20b (free)</option>
+        <option value="z-ai/glm-4.5-air:free">z-ai / glm-4.5-air (free)</option>
+        <option value="meta-llama/llama-3.2-3b-instruct:free">meta-llama / llama-3.2-3b-instruct (free)</option>
+        <option value="nousresearch/hermes-3-llama-3.1-405b:free">nous / hermes-3-llama-3.1-405b (free)</option>
+      </select>
+    </div>
+  </div>
+
+  <div class="panel">
+    <header>
+      <span>Chat</span>
+      <span class="row" style="font-size: 12px;">
+        <span id="token-usage" class="token-badge" hidden></span>
+        <span id="finish" class="muted"></span>
+        <button id="clear" title="Clear conversation" style="padding: .2em .6em; font-size: 12px;">Clear</button>
+      </span>
+    </header>
+    <div class="body" id="chat-body">
+      <div id="chat"></div>
+    </div>
+    <div class="prompt-bar">
+      <textarea id="prompt" rows="2" spellcheck="false" placeholder="Type a message and press Enter to send (Shift-Enter for newline)…">What can you do in this browser-only Docker Agent demo? Keep it short.</textarea>
+      <button id="send" class="primary" disabled>Send</button>
+      <button id="abort" class="danger">Stop</button>
+    </div>
+  </div>
+</section>
+
+<script src="wasm_exec.js"></script>
+<script type="module">
+import { signIn, signOut, handleCallback, getKey } from "./auth.js";
+import { EditorView, basicSetup } from "https://esm.sh/codemirror@6.0.2";
+import { yaml as yamlLang }       from "https://esm.sh/@codemirror/lang-yaml@6.1.2";
+import { oneDark }                from "https://esm.sh/@codemirror/theme-one-dark@6.1.2";
+
+const themeBtn      = document.getElementById("theme-toggle");
+const sendBtn       = document.getElementById("send");
+const abortBtn      = document.getElementById("abort");
+const clearBtn      = document.getElementById("clear");
+const finish        = document.getElementById("finish");
+const tokenUsageEl  = document.getElementById("token-usage");
+const modelEl       = document.getElementById("model");
+const agentPicker   = document.getElementById("agent-picker");
+const signInB       = document.getElementById("sign-in");
+const signOutB      = document.getElementById("sign-out");
+const authEl        = document.getElementById("auth-state");
+const healthDot     = document.getElementById("health-dot");
+const promptEl      = document.getElementById("prompt");
+const chatEl        = document.getElementById("chat");
+const chatBody      = document.getElementById("chat-body");
+const loadingEl     = document.getElementById("wasm-loading");
+
+// ---- Theme ---------------------------------------------------------------
+function preferredTheme() {
+  return localStorage.getItem("theme") ||
+    (matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+}
+function applyTheme(theme) {
+  document.documentElement.dataset.theme = theme;
+  themeBtn.textContent = theme === "dark" ? "☀" : "☾";
+  themeBtn.title = theme === "dark" ? "Switch to light mode" : "Switch to dark mode";
+}
+applyTheme(preferredTheme());
+themeBtn.addEventListener("click", () => {
+  const next = document.documentElement.dataset.theme === "dark" ? "light" : "dark";
+  localStorage.setItem("theme", next);
+  location.reload();
+});
+
+// ---- YAML editor (CodeMirror 6) -----------------------------------------
+const yamlEditor = new EditorView({
+  doc: "",
+  extensions: [
+    basicSetup,
+    yamlLang(),
+    ...(preferredTheme() === "dark" ? [oneDark] : []),
+    EditorView.theme({ "&": { height: "100%" } }),
+  ],
+  parent: document.getElementById("yaml"),
+});
+function getYaml() { return yamlEditor.state.doc.toString(); }
+function setYaml(text) {
+  yamlEditor.dispatch({
+    changes: { from: 0, to: yamlEditor.state.doc.length, insert: text },
+  });
+}
+
+// ---- Default YAML, regenerated whenever the model dropdown changes -------
+function defaultYaml(model) {
+  return `providers:
+  openrouter:
+    provider: openai
+    base_url: https://openrouter.ai/api/v1
+    token_key: OPENROUTER_API_KEY
+agents:
+  root:
+    model: openrouter/${model}
+    instruction: |
+      You are a helpful assistant running entirely inside a browser tab,
+      compiled to WebAssembly. Keep answers short and friendly.
+`;
+}
+
+let lastDefault = defaultYaml(modelEl.value);
+setYaml(lastDefault);
+modelEl.addEventListener("change", () => {
+  if (getYaml() === lastDefault) {
+    lastDefault = defaultYaml(modelEl.value);
+    setYaml(lastDefault);
+  } else {
+    lastDefault = defaultYaml(modelEl.value);
+  }
+});
+
+// ---- Agent picker: refresh when YAML changes -----------------------------
+function refreshAgentPicker() {
+  if (typeof globalThis.dockerAgent === "undefined") return;
+  try {
+    const agents = dockerAgent.listAgents(getYaml());
+    agentPicker.innerHTML = "";
+    for (const a of agents) {
+      const opt = document.createElement("option");
+      opt.value = a.name;
+      opt.textContent = a.name + (a.description ? ` — ${a.description}` : "");
+      agentPicker.appendChild(opt);
+    }
+    // Show picker only when multiple agents exist
+    agentPicker.parentElement.style.display = agents.length > 1 ? "" : "none";
+  } catch {
+    // YAML might be invalid while typing — ignore silently
+  }
+}
+
+// Debounce YAML change detection for agent picker
+let agentRefreshTimer = null;
+const onYamlChange = EditorView.updateListener.of((update) => {
+  if (update.docChanged) {
+    clearTimeout(agentRefreshTimer);
+    agentRefreshTimer = setTimeout(refreshAgentPicker, 400);
+  }
+});
+yamlEditor.dispatch({ effects: [] }); // no-op to ensure listener is wired
+// We'll wire the updateListener after appending it as an extension — but CM6
+// doesn't support adding extensions post-creation without reconfigure. Instead
+// we poll on meaningful events. We'll call refreshAgentPicker after wasm loads.
+
+// ---- Auth state UI -------------------------------------------------------
+function refreshAuth() {
+  const key = getKey();
+  if (key) {
+    authEl.textContent = "signed in (key: " + key.slice(0, 10) + "…)";
+    authEl.classList.add("ok");
+    authEl.classList.remove("muted");
+    signInB.hidden = true;
+    signOutB.hidden = false;
+    healthDot.hidden = false;
+    refreshHealth();
+  } else {
+    authEl.textContent = "not signed in";
+    authEl.classList.remove("ok");
+    authEl.classList.add("muted");
+    signInB.hidden = false;
+    signOutB.hidden = true;
+    healthDot.hidden = true;
+    healthDot.className = "health";
+    healthDot.title = "";
+  }
+}
+signInB.addEventListener("click", () => signIn());
+signOutB.addEventListener("click", () => { signOut(); refreshAuth(); });
+
+function setHealth(colour, tooltip) {
+  healthDot.className = "health " + colour;
+  healthDot.title = tooltip;
+}
+
+async function refreshHealth() {
+  const key = getKey();
+  if (!key) return;
+  try {
+    const r = await fetch("https://openrouter.ai/api/v1/auth/key", {
+      headers: { Authorization: "Bearer " + key },
+    });
+    if (r.status === 401 || r.status === 403) {
+      setHealth("red", "Key rejected (" + r.status + ") — sign out and back in.");
+      return;
+    }
+    if (!r.ok) {
+      setHealth("yellow", "OpenRouter returned HTTP " + r.status);
+      return;
+    }
+    const { data } = await r.json();
+    const limit = data.limit;
+    const remaining = data.limit_remaining;
+
+    if (limit != null && remaining != null && remaining <= 0) {
+      setHealth("red", "Account quota exhausted (limit " + limit + ").");
+      return;
+    }
+    if (data.is_free_tier) {
+      setHealth("yellow",
+        "Free tier — inference works but popular :free models are " +
+        "often rate-limited upstream. Add $10 of credits at " +
+        "openrouter.ai/settings/credits to lift the cap.");
+      return;
+    }
+    setHealth("green",
+      "Account healthy" +
+      (limit != null ? " (" + remaining + " / " + limit + " remaining)" : "") +
+      ".");
+  } catch (e) {
+    setHealth("red", "Health probe failed: " + (e && e.message ? e.message : e));
+  }
+}
+
+// ---- Lightweight markdown rendering --------------------------------------
+// Handles: **bold**, *italic*, `inline code`, ```code blocks```, and basic
+// line breaks. Returns an HTML string. Does NOT handle full CommonMark; this
+// is intentionally minimal to avoid pulling in a 50 KB library.
+function renderMarkdown(text) {
+  // Escape HTML entities
+  let html = text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+
+  // Fenced code blocks: ```lang\n...\n```
+  html = html.replace(/```(\w*)\n([\s\S]*?)```/g, (_, lang, code) => {
+    return `<pre><code>${code.replace(/\n$/, "")}</code></pre>`;
+  });
+
+  // Inline code: `...`
+  html = html.replace(/`([^`\n]+)`/g, "<code>$1</code>");
+
+  // Bold: **...**
+  html = html.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
+
+  // Italic: *...*
+  html = html.replace(/(?<!\*)\*([^*]+)\*(?!\*)/g, "<em>$1</em>");
+
+  return html;
+}
+
+// ---- Chat transcript -----------------------------------------------------
+let conversation = [];
+let totalInputTokens = 0;
+let totalOutputTokens = 0;
+
+function scrollToBottomIfPinned() {
+  const slack = 80;
+  const nearBottom = chatBody.scrollHeight - chatBody.scrollTop - chatBody.clientHeight < slack;
+  if (nearBottom) chatBody.scrollTop = chatBody.scrollHeight;
+}
+
+function appendMessage(role, content = "") {
+  const el = document.createElement("div");
+  el.className = "msg " + role;
+  if (role === "assistant" && content === "") el.classList.add("streaming");
+  if (role === "assistant") {
+    el.innerHTML = content ? renderMarkdown(content) : "";
+  } else {
+    el.textContent = content;
+  }
+  chatEl.appendChild(el);
+  scrollToBottomIfPinned();
+  return el;
+}
+
+function appendError(message) {
+  const el = document.createElement("div");
+  el.className = "msg error";
+  el.textContent = message;
+  chatEl.appendChild(el);
+  scrollToBottomIfPinned();
+  return el;
+}
+
+function appendSystemMessage(message) {
+  const el = document.createElement("div");
+  el.className = "msg system";
+  el.innerHTML = renderMarkdown(message);
+  chatEl.appendChild(el);
+  scrollToBottomIfPinned();
+  return el;
+}
+
+function updateTokenUsage() {
+  if (totalInputTokens === 0 && totalOutputTokens === 0) {
+    tokenUsageEl.hidden = true;
+    return;
+  }
+  tokenUsageEl.hidden = false;
+  tokenUsageEl.textContent = `↑${totalInputTokens.toLocaleString()} ↓${totalOutputTokens.toLocaleString()} tokens`;
+  tokenUsageEl.title = `Total tokens this session: ${totalInputTokens.toLocaleString()} input, ${totalOutputTokens.toLocaleString()} output`;
+}
+
+clearBtn.addEventListener("click", () => {
+  conversation = [];
+  chatEl.innerHTML = "";
+  finish.textContent = "";
+  totalInputTokens = 0;
+  totalOutputTokens = 0;
+  updateTokenUsage();
+  promptEl.focus();
+});
+
+// ---- Streaming state management ------------------------------------------
+let isStreaming = false;
+
+function setStreaming(active) {
+  isStreaming = active;
+  document.body.classList.toggle("streaming-active", active);
+  promptEl.disabled = active;
+}
+
+// ---- Wasm boot -----------------------------------------------------------
+(async () => {
+  try {
+    try {
+      await handleCallback();
+    } catch (e) {
+      alert("Auth callback failed: " + e.message);
+    }
+    refreshAuth();
+
+    const go = new Go();
+    const result = await WebAssembly.instantiateStreaming(fetch("docker-agent.wasm"), go.importObject);
+    go.run(result.instance);
+
+    // Wasm is ready
+    loadingEl.classList.add("loaded");
+    sendBtn.disabled = false;
+    promptEl.focus();
+    refreshAgentPicker();
+    validateYaml();
+  } catch (e) {
+    loadingEl.querySelector(".spinner").textContent = "Failed to load: " + e.message;
+  }
+})();
+
+// ---- Send a turn ---------------------------------------------------------
+async function run() {
+  const text = promptEl.value.trim();
+  if (!text) return;
+
+  setStreaming(true);
+  finish.textContent = "";
+
+  conversation.push({ role: "user", content: text });
+  appendMessage("user", text);
+  promptEl.value = "";
+
+  const bubble = appendMessage("assistant", "");
+  let assistantContent = "";
+  let assistantReason  = "";
+
+  const yaml = getYaml();
+  const env  = { OPENROUTER_API_KEY: getKey() || "" };
+  const agentName = agentPicker.value || undefined;
+
+  try {
+    // Validate YAML before calling the LLM.
+    dockerAgent.parseConfig(yaml);
+
+    await dockerAgent.chat(
+      { yaml, env, messages: conversation.slice(), agentName },
+      (event) => {
+        if (event.type === "delta") {
+          if (event.content) {
+            assistantContent += event.content;
+            bubble.classList.remove("streaming");
+            renderAssistant(bubble, assistantReason, assistantContent);
+          }
+          if (event.reasoning) {
+            assistantReason += event.reasoning;
+            bubble.classList.remove("streaming");
+            renderAssistant(bubble, assistantReason, assistantContent);
+          }
+          scrollToBottomIfPinned();
+        } else if (event.type === "tool_call") {
+          appendSystemMessage(`🔧 Calling tool: **${event.name}**`);
+        } else if (event.type === "tool_result") {
+          appendSystemMessage(`✅ ${event.name} → ${event.output.slice(0, 200)}${event.output.length > 200 ? "…" : ""}`);
+        } else if (event.type === "tool_blocked") {
+          appendSystemMessage(`🚫 Tool ${event.name} blocked: ${event.reason}`);
+        } else if (event.type === "handoff") {
+          appendSystemMessage(`🔄 Agent handoff: ${event.from} → **${event.to}**`);
+        } else if (event.type === "fallback") {
+          appendSystemMessage(`⚠️ Model fallback: ${event.from} → ${event.to} (attempt ${event.attempt})`);
+        } else if (event.type === "finish") {
+          finish.textContent = "(" + event.reason + ")";
+        } else if (event.type === "usage") {
+          totalInputTokens += event.input_tokens || 0;
+          totalOutputTokens += event.output_tokens || 0;
+          updateTokenUsage();
+        }
+      },
+    );
+
+    bubble.classList.remove("streaming");
+
+    if (assistantContent) {
+      conversation.push({ role: "assistant", content: assistantContent });
+    } else {
+      conversation.pop();
+      bubble.remove();
+      appendError("(no content returned — try a different model or retry)");
+    }
+  } catch (e) {
+    bubble.remove();
+    const msg = String(e && e.message ? e.message : e);
+    if (msg.includes("aborted")) {
+      appendError("(generation stopped)");
+    } else {
+      appendError(msg);
+    }
+    conversation.pop();
+  } finally {
+    setStreaming(false);
+    promptEl.focus();
+  }
+}
+
+// renderAssistant rewrites the assistant bubble with markdown-rendered
+// content. Reasoning is shown above content with a dashed divider.
+function renderAssistant(bubble, reason, content) {
+  let html = "";
+  if (reason) {
+    html += `<span class="reason">${reason.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;")}</span>`;
+  }
+  html += renderMarkdown(content);
+  bubble.innerHTML = html;
+}
+
+// ---- Abort button --------------------------------------------------------
+abortBtn.addEventListener("click", () => {
+  if (typeof dockerAgent !== "undefined" && dockerAgent.abort) {
+    dockerAgent.abort();
+  }
+});
+
+// ---- Send / keyboard shortcuts -------------------------------------------
+sendBtn.addEventListener("click", run);
+promptEl.addEventListener("keydown", (e) => {
+  if (e.key === "Enter" && !e.shiftKey && !e.isComposing) {
+    e.preventDefault();
+    if (!isStreaming) run();
+  }
+});
+
+// ---- YAML change -> refresh agent picker + live validation --------------
+// Since CM6 doesn't easily support adding updateListeners after construction
+// without a full reconfigure, we use a MutationObserver on the CM content.
+const yamlContainer = document.getElementById("yaml");
+const yamlStatusEl = document.getElementById("yaml-status");
+let validateTimer = null;
+
+function validateYaml() {
+  if (typeof globalThis.dockerAgent === "undefined") return;
+  const yaml = getYaml();
+  if (!yaml.trim()) {
+    yamlStatusEl.className = "";
+    yamlStatusEl.innerHTML = "";
+    yamlStatusEl.title = "";
+    return;
+  }
+  try {
+    dockerAgent.parseConfig(yaml);
+    yamlStatusEl.className = "valid";
+    yamlStatusEl.innerHTML = "✓";
+    yamlStatusEl.title = "Config is valid";
+  } catch (e) {
+    const msg = e.message || String(e);
+    // Strip the "parseConfig: " prefix for cleaner display
+    const clean = msg.replace(/^parseConfig:\s*/, "");
+    const short = clean.length > 60 ? clean.slice(0, 57) + "…" : clean;
+    yamlStatusEl.className = "invalid";
+    yamlStatusEl.innerHTML = `✗ <span class="error-text">${short.replace(/</g,"&lt;")}</span>`;
+    yamlStatusEl.title = clean;
+  }
+}
+
+const observer = new MutationObserver(() => {
+  clearTimeout(agentRefreshTimer);
+  agentRefreshTimer = setTimeout(refreshAgentPicker, 600);
+  clearTimeout(validateTimer);
+  validateTimer = setTimeout(validateYaml, 300);
+});
+observer.observe(yamlContainer, { childList: true, subtree: true, characterData: true });
+</script>
+
+</body>
+</html>

--- a/pkg/cache/lock_js.go
+++ b/pkg/cache/lock_js.go
@@ -1,0 +1,17 @@
+//go:build js && wasm
+
+package cache
+
+import "os"
+
+// lockExclusive is a no-op under js/wasm. The runtime is single-threaded and
+// the cache file lives in either an in-memory FS or a host-mediated FS, so
+// there is no second writer to coordinate with.
+func lockExclusive(_ *os.File) error {
+	return nil
+}
+
+// unlockFile mirrors lockExclusive: there is nothing to release.
+func unlockFile(_ *os.File) error {
+	return nil
+}

--- a/pkg/desktop/connection_js.go
+++ b/pkg/desktop/connection_js.go
@@ -1,0 +1,23 @@
+//go:build js && wasm
+
+package desktop
+
+import (
+	"context"
+	"errors"
+	"net"
+)
+
+// errNoDesktopUnderWasm is returned by every desktop-socket dial under
+// js/wasm. The browser cannot dial Unix sockets or Windows named pipes, so
+// any code path that tries to talk to Docker Desktop simply returns this
+// error and lets the caller skip the Desktop-integration path.
+var errNoDesktopUnderWasm = errors.New("docker desktop integration is not available under js/wasm")
+
+func dialBackend(_ context.Context) (net.Conn, error) {
+	return nil, errNoDesktopUnderWasm
+}
+
+func dial(_ context.Context, _ string) (net.Conn, error) {
+	return nil, errNoDesktopUnderWasm
+}

--- a/pkg/desktop/connection_other.go
+++ b/pkg/desktop/connection_other.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !js
 
 package desktop
 

--- a/pkg/desktop/sockets_js.go
+++ b/pkg/desktop/sockets_js.go
@@ -1,0 +1,15 @@
+//go:build js && wasm
+
+package desktop
+
+// getDockerDesktopPaths returns empty paths under js/wasm: the Docker Desktop
+// backend speaks over Unix domain sockets / named pipes, neither of which is
+// reachable from a browser. The runtime falls back to no Desktop integration.
+func getDockerDesktopPaths() (DockerDesktopPaths, error) {
+	return DockerDesktopPaths{}, nil
+}
+
+// IsWSL is always false under js/wasm.
+func IsWSL() bool {
+	return false
+}

--- a/pkg/model/provider/factory.go
+++ b/pkg/model/provider/factory.go
@@ -1,3 +1,5 @@
+//go:build !js
+
 package provider
 
 import (

--- a/pkg/model/provider/factory_js.go
+++ b/pkg/model/provider/factory_js.go
@@ -1,0 +1,84 @@
+//go:build js && wasm
+
+// Package provider's js/wasm factory.
+//
+// The non-js factory.go pulls in every provider — including dmr (os/exec),
+// rulebased (bleve, mmap), bedrock and vertexai (cloud SDKs). None of those
+// can be cross-compiled to js/wasm, so this file replaces factory.go under
+// js/wasm with a slim variant that only knows about the providers that work
+// over plain net/http (which the Go runtime maps to fetch in the browser):
+//
+//   - openai / openai_chatcompletions / openai_responses
+//   - anthropic
+//   - google (Gemini API; Vertex AI is unsupported under wasm)
+//
+// Routing rules and Docker Model Runner are unsupported and return an error.
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/environment"
+	"github.com/docker/docker-agent/pkg/model/provider/anthropic"
+	"github.com/docker/docker-agent/pkg/model/provider/gemini"
+	"github.com/docker/docker-agent/pkg/model/provider/openai"
+	"github.com/docker/docker-agent/pkg/model/provider/options"
+)
+
+// errRoutingUnsupported is returned by createRuleBasedRouter under js/wasm:
+// the rulebased provider depends on bleve which cannot be cross-compiled to
+// wasm (mmap, file locking).
+var errRoutingUnsupported = errors.New("rule-based model routing is not supported under js/wasm")
+
+// createRuleBasedRouter is a stub that always returns an error under wasm.
+func createRuleBasedRouter(_ context.Context, _ *latest.ModelConfig, _ map[string]latest.ModelConfig, _ environment.Provider, _ ...options.Opt) (Provider, error) {
+	return nil, errRoutingUnsupported
+}
+
+// createDirectProvider mirrors the non-wasm version but only dispatches to
+// providers that are reachable from a browser.
+func createDirectProvider(ctx context.Context, cfg *latest.ModelConfig, env environment.Provider, opts ...options.Opt) (Provider, error) {
+	var globalOptions options.ModelOptions
+	for _, opt := range opts {
+		opt(&globalOptions)
+	}
+
+	enhancedCfg := applyProviderDefaults(cfg, globalOptions.Providers())
+
+	providerType := resolveProviderType(enhancedCfg)
+
+	factory, ok := providerFactories[providerType]
+	if !ok {
+		slog.Error("Unknown or unsupported provider type under js/wasm", "type", providerType)
+		return nil, fmt.Errorf("provider type %q is not supported under js/wasm (only openai/anthropic/google work in the browser)", providerType)
+	}
+	return factory(ctx, enhancedCfg, env, opts...)
+}
+
+type providerFactory func(ctx context.Context, cfg *latest.ModelConfig, env environment.Provider, opts ...options.Opt) (Provider, error)
+
+// providerFactories: js/wasm-only subset. dmr (os/exec), amazon-bedrock and
+// vertex AI (cloud SDKs that don't compile to wasm) are deliberately absent.
+var providerFactories = map[string]providerFactory{
+	"openai":                 openaiFactory,
+	"openai_chatcompletions": openaiFactory,
+	"openai_responses":       openaiFactory,
+	"anthropic":              anthropicFactory,
+	"google":                 googleFactory,
+}
+
+func openaiFactory(ctx context.Context, cfg *latest.ModelConfig, env environment.Provider, opts ...options.Opt) (Provider, error) {
+	return openai.NewClient(ctx, cfg, env, opts...)
+}
+
+func anthropicFactory(ctx context.Context, cfg *latest.ModelConfig, env environment.Provider, opts ...options.Opt) (Provider, error) {
+	return anthropic.NewClient(ctx, cfg, env, opts...)
+}
+
+func googleFactory(ctx context.Context, cfg *latest.ModelConfig, env environment.Provider, opts ...options.Opt) (Provider, error) {
+	return gemini.NewClient(ctx, cfg, env, opts...)
+}

--- a/pkg/tools/builtin/shell/cmd_js.go
+++ b/pkg/tools/builtin/shell/cmd_js.go
@@ -1,0 +1,25 @@
+//go:build js
+
+package shell
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+// processGroup is a no-op under js/wasm: there are no processes to track,
+// because os/exec cannot actually spawn subprocesses in the browser.
+type processGroup struct{}
+
+func platformSpecificSysProcAttr() *syscall.SysProcAttr {
+	return nil
+}
+
+func createProcessGroup(_ *os.Process) (*processGroup, error) {
+	return &processGroup{}, nil
+}
+
+func kill(_ *os.Process, _ *processGroup) error {
+	return errors.New("shell: process termination not supported on js/wasm")
+}

--- a/pkg/tools/builtin/shell/cmd_unix.go
+++ b/pkg/tools/builtin/shell/cmd_unix.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !js
 
 package shell
 


### PR DESCRIPTION
## What this is

A `GOOS=js GOARCH=wasm` entry point under `cmd/wasm` that exposes a slice of docker-agent — config parsing plus a streaming agentic loop with tool calling — to a JavaScript host (browser or Node). It is a proof-of-concept, not a port of the full agent (see *Limits* below).

The static demo at `cmd/wasm/web/index.html` runs against OpenRouter via the [PKCE OAuth flow](https://openrouter.ai/docs/use-cases/oauth-pkce).

See `cmd/wasm/README.md` for full build / run instructions and architecture notes.

## What it does

- **Config parsing** (any version → latest via `pkg/config`)
- **Agent enumeration** (lists agents, models, instructions)
- **Full agentic loop**: streaming chat with tool calling, multi-agent handoffs, fallback models with retry + backoff, hooks (`session_start`, `turn_start`, `pre_tool_use`, `post_tool_use`)
- **Remote MCP tools** (HTTP/SSE transport — no stdio)
- **Request cancellation** via `dockerAgent.abort()`

A JS API is registered on `globalThis.dockerAgent`:

```js
dockerAgent.parseConfig(yamlString)
dockerAgent.listAgents(yamlString)
dockerAgent.chat({yaml, agentName?, env?, messages}, onEvent)
dockerAgent.abort()
```

## What it intentionally does NOT do

- Run shell commands (no `os/exec` under js/wasm)
- Open files or listen on sockets
- Persist sessions to sqlite
- Render a TUI
- Use `pkg/runtime` or `pkg/teamloader` directly (both are blocked by sqlite under wasm) — instead `cmd/wasm/runtime_wasm.go` builds agents from config using `pkg/agent` directly and runs a simplified streaming loop

## Build & test

```sh
# Compile (~94 MB unoptimised .wasm).
GOOS=js GOARCH=wasm go build -o cmd/wasm/web/docker-agent.wasm ./cmd/wasm

# Copy the matching shim from the Go toolchain.
cp "\$(go env GOROOT)/lib/wasm/wasm_exec.js" cmd/wasm/web/wasm_exec.js

# Node smoke test (proves runtime + parseConfig + listAgents + abort work).
node cmd/wasm/smoke_test.js
```

The generated artifacts (`cmd/wasm/web/docker-agent.wasm`, `cmd/wasm/web/wasm_exec.js`, and a `wasm` debug binary) are in `.gitignore` — they are built locally.

## Cross-platform plumbing this required

Several packages had unix-only files that incidentally matched `GOOS=js`. To make the wasm target compile, a small set of `_js.go` stubs was added alongside the existing `_unix.go` / `_windows.go` files:

- `pkg/cache/lock_js.go` — file-lock no-op (single-process under wasm)
- `pkg/desktop/connection_js.go` + `sockets_js.go` — Docker Desktop connection stubs
- `pkg/desktop/connection_other.go` — tightened build tag to `!windows && !js`
- `pkg/model/provider/factory_js.go` — provider factory without OS-specific deps
- `pkg/tools/builtin/shell/cmd_js.go` — process-group stubs
- `pkg/tools/builtin/shell/cmd_unix.go` — tightened build tag to `!windows && !js` (it was using \`syscall.SysProcAttr.Setpgid\` which doesn't exist under js/wasm)

## Validation

- \`go build ./...\` — ok
- \`GOOS=js GOARCH=wasm go build -o cmd/wasm/web/docker-agent.wasm ./cmd/wasm\` — ok
- \`GOOS=windows go build ./...\` — ok
- \`task test\` — all packages pass
- \`task lint\` — 0 issues
- \`node cmd/wasm/smoke_test.js\` — *OK — all smoke tests pass (parseConfig, listAgents, abort)*

Assisted-By: docker-agent