### PR TITLE
fix: stop matching category in command palette filter

### DIFF
--- a/pkg/tui/dialog/command_palette.go
+++ b/pkg/tui/dialog/command_palette.go
@@ -139,11 +139,14 @@ func (d *commandPaletteDialog) filterCommands() {
 }
 
 // matchesCommandQuery reports whether the given command matches the lowercase
-// query string by searching label, description, category, or slash command.
+// query string by searching label, description, or slash command. The
+// category is intentionally excluded: category names act as section headers
+// and matching them would surface every command in a category, drowning out
+// targeted queries (e.g. typing "session" would otherwise match every
+// command in the Session category).
 func matchesCommandQuery(cmd commands.Item, query string) bool {
 	return strings.Contains(strings.ToLower(cmd.Label), query) ||
 		strings.Contains(strings.ToLower(cmd.Description), query) ||
-		strings.Contains(strings.ToLower(cmd.Category), query) ||
 		strings.Contains(strings.ToLower(cmd.SlashCommand), query)
 }
 

--- a/pkg/tui/dialog/command_palette_test.go
+++ b/pkg/tui/dialog/command_palette_test.go
@@ -58,6 +58,34 @@ var multiCategoryCommands = []commands.Category{
 	},
 }
 
+// TestCommandPaletteFilteringIgnoresCategory ensures that typing the name of
+// a category does not match every command in that category. Regression test
+// for the case where typing "session" would surface every Session-category
+// command, defeating the purpose of filtering.
+func TestCommandPaletteFilteringIgnoresCategory(t *testing.T) {
+	cats := []commands.Category{
+		{
+			Name: "Session",
+			Commands: []commands.Item{
+				{ID: "session.attach", Label: "Attach", SlashCommand: "/attach", Description: "Attach a file to your message", Category: "Session"},
+				{ID: "session.history", Label: "Sessions", SlashCommand: "/sessions", Description: "Browse and load past sessions", Category: "Session"},
+			},
+		},
+	}
+	dialog := NewCommandPaletteDialog(cats)
+	d := dialog.(*commandPaletteDialog)
+
+	d.textInput.SetValue("session")
+	d.filterCommands()
+
+	var ids []string
+	for _, c := range d.filtered {
+		ids = append(ids, c.ID)
+	}
+	require.Equal(t, []string{"session.history"}, ids,
+		"typing 'session' must not surface unrelated commands like 'Attach' just because they share the Session category")
+}
+
 func TestCommandPaletteFiltering(t *testing.T) {
 	dialog := NewCommandPaletteDialog(categories)
 	d := dialog.(*commandPaletteDialog)


### PR DESCRIPTION
## Problem

In the command palette (Ctrl-K), typing a category name like `session` did not narrow down the list — every command in the `Session` category stayed visible. Only typing `/session` produced useful filtering.

## Cause

`matchesCommandQuery` was matching the query against the `Category` field. Since all 24 session commands share `Category: "Session"`, typing "session" matched every single one of them, defeating the filter.

## Fix

Drop `Category` from the search fields. Filtering now only considers user-visible content: `Label`, `Description`, and `SlashCommand`. Categories remain as visual section headers, which is their actual purpose.

## Result

Typing `session` now narrows the list from 24 → 8 commands that actually mention sessions in their label or description (Sessions, Cost, Export, Fork, Star, Title, Permissions, Clear).

Includes a regression test.