### PR TITLE
lint: add SlogContextual cop and fix remaining bare slog calls

### DIFF
--- a/cmd/root/api.go
+++ b/cmd/root/api.go
@@ -67,7 +67,7 @@ func (f *apiFlags) runAPICommand(cmd *cobra.Command, args []string) (commandErr 
 	}
 	defer func() {
 		if err := cleanup(); err != nil {
-			slog.Error("Failed to cleanup fake proxy", "error", err)
+			slog.ErrorContext(ctx, "Failed to cleanup fake proxy", "error", err)
 		}
 	}()
 
@@ -78,7 +78,7 @@ func (f *apiFlags) runAPICommand(cmd *cobra.Command, args []string) (commandErr 
 	}
 	defer func() {
 		if err := recordCleanup(); err != nil {
-			slog.Error("Failed to cleanup recording proxy", "error", err)
+			slog.ErrorContext(ctx, "Failed to cleanup recording proxy", "error", err)
 		}
 	}()
 
@@ -95,7 +95,7 @@ func (f *apiFlags) runAPICommand(cmd *cobra.Command, args []string) (commandErr 
 	out.Println("Listening on", ln.Addr().String())
 	warnIfNotLoopback(out, ln.Addr())
 
-	slog.Debug("Starting server", "agents", agentsPath, "addr", ln.Addr().String())
+	slog.DebugContext(ctx, "Starting server", "agents", agentsPath, "addr", ln.Addr().String())
 
 	// Expand tilde in session database path
 	sessionDB, err := expandTilde(f.sessionDB)
@@ -109,7 +109,7 @@ func (f *apiFlags) runAPICommand(cmd *cobra.Command, args []string) (commandErr 
 	}
 	defer func() {
 		if err := sessionStore.Close(); err != nil {
-			slog.Error("Failed to close session store", "error", err)
+			slog.ErrorContext(ctx, "Failed to close session store", "error", err)
 		}
 	}()
 

--- a/cmd/root/debug.go
+++ b/cmd/root/debug.go
@@ -114,13 +114,13 @@ func (f *debugFlags) runDebugToolsetsCommand(cmd *cobra.Command, args []string) 
 	for _, name := range t.AgentNames() {
 		agent, err := t.Agent(name)
 		if err != nil {
-			slog.Error("Failed to get agent", "name", name, "error", err)
+			slog.ErrorContext(ctx, "Failed to get agent", "name", name, "error", err)
 			continue
 		}
 
 		tools, err := agent.Tools(ctx)
 		if err != nil {
-			slog.Error("Failed to query tools", "name", agent.Name(), "error", err)
+			slog.ErrorContext(ctx, "Failed to query tools", "name", agent.Name(), "error", err)
 			continue
 		}
 

--- a/cmd/root/eval.go
+++ b/cmd/root/eval.go
@@ -127,7 +127,7 @@ func (f *evalFlags) runEvalCommand(cmd *cobra.Command, args []string) (commandEr
 	// Save sessions to SQLite database
 	dbPath, err := evaluation.SaveRunSessions(ctx, run, outputDir)
 	if err != nil {
-		slog.Error("Failed to save sessions database", "error", err)
+		slog.ErrorContext(ctx, "Failed to save sessions database", "error", err)
 	} else {
 		fmt.Fprintf(teeOut, "\nSessions DB: %s\n", dbPath)
 	}
@@ -135,7 +135,7 @@ func (f *evalFlags) runEvalCommand(cmd *cobra.Command, args []string) (commandEr
 	// Save sessions to JSON file (same format as /eval produces)
 	sessionsPath, err := evaluation.SaveRunSessionsJSON(run, outputDir)
 	if err != nil {
-		slog.Error("Failed to save sessions JSON", "error", err)
+		slog.ErrorContext(ctx, "Failed to save sessions JSON", "error", err)
 	} else {
 		fmt.Fprintf(teeOut, "Sessions JSON: %s\n", sessionsPath)
 	}

--- a/cmd/root/flags.go
+++ b/cmd/root/flags.go
@@ -76,13 +76,14 @@ func addGatewayFlags(cmd *cobra.Command, runConfig *config.RuntimeConfig) {
 
 	persistentPreRunE := cmd.PersistentPreRunE
 	cmd.PersistentPreRunE = func(_ *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+
 		userCfg, err := loadUserConfig()
 		if err != nil {
-			slog.Warn("Failed to load user config", "error", err)
+			slog.WarnContext(ctx, "Failed to load user config", "error", err)
 			userCfg = &userconfig.Config{}
 		}
 
-		ctx := cmd.Context()
 		env := runConfig.EnvProvider()
 
 		// Precedence: CLI flag > environment variable > user config

--- a/cmd/root/pull.go
+++ b/cmd/root/pull.go
@@ -43,7 +43,7 @@ func (f *pullFlags) runPullCommand(cmd *cobra.Command, args []string) (commandEr
 
 	out := cli.NewPrinter(cmd.OutOrStdout())
 	registryRef := args[0]
-	slog.Debug("Starting pull", "registry_ref", registryRef)
+	slog.DebugContext(ctx, "Starting pull", "registry_ref", registryRef)
 
 	out.Println("Pulling agent", registryRef)
 

--- a/cmd/root/push.go
+++ b/cmd/root/push.go
@@ -50,7 +50,7 @@ func runPushCommand(cmd *cobra.Command, args []string) (commandErr error) {
 		return fmt.Errorf("failed to build artifact: %w", err)
 	}
 
-	slog.Debug("Starting push", "registry_ref", tag)
+	slog.DebugContext(ctx, "Starting push", "registry_ref", tag)
 
 	out.Printf("Pushing agent %s to %s\n", agentFilename, tag)
 

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -592,7 +592,7 @@ func stopToolSets(t toolStopper) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	if err := t.StopToolSets(ctx); err != nil {
-		slog.Error("Failed to stop tool sets", "error", err)
+		slog.ErrorContext(ctx, "Failed to stop tool sets", "error", err)
 	}
 }
 

--- a/lint/main.go
+++ b/lint/main.go
@@ -27,6 +27,7 @@ func allCops() []cop.Cop {
 		NewRuntimeSessionScoped(),
 		NewHookConfigSync(),
 		NewHookBuiltinsRegistered(),
+		NewSlogContextual(),
 	}
 }
 

--- a/lint/slog_contextual.go
+++ b/lint/slog_contextual.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"go/ast"
+	"slices"
 
 	"github.com/dgageot/rubocop-go/cop"
 )
@@ -108,6 +109,11 @@ func signatureDeclaresContext(typ *ast.FuncType) bool {
 			if !isContextContextType(f.Type) {
 				continue
 			}
+			// Anonymous parameter (e.g., `func(context.Context)`) has no names
+			// but still declares a context in scope.
+			if len(f.Names) == 0 {
+				return true
+			}
 			for _, n := range f.Names {
 				if namedIdent(n) {
 					return true
@@ -164,11 +170,14 @@ func valueSpecDeclaresContext(s *ast.ValueSpec) bool {
 // bindsContext reports whether the assignment binds at least one LHS
 // identifier to a context.Context value. A single RHS covers both
 // single-value forms (`ctx := f()`) and multi-value returns
-// (`ctx, cancel := context.WithCancel(...)`); in the latter case the
-// context is always at the first return position.
+// (`ctx, cancel := context.WithCancel(...)`); we check all LHS positions
+// since the context might not be at position 0 (e.g., `err, ctx := fn()`).
 func bindsContext(lhs, rhs []ast.Expr) bool {
 	if len(rhs) == 1 {
-		return len(lhs) >= 1 && contextProducer(rhs[0]) && namedIdent(lhs[0])
+		// Single RHS: could be single-value or multi-return.
+		// For multi-return, check all LHS positions since context
+		// might not be at position 0 (e.g., `err, ctx := fn()`).
+		return contextProducer(rhs[0]) && slices.ContainsFunc(lhs, namedIdent)
 	}
 	for i := 0; i < len(lhs) && i < len(rhs); i++ {
 		if contextProducer(rhs[i]) && namedIdent(lhs[i]) {

--- a/lint/slog_contextual.go
+++ b/lint/slog_contextual.go
@@ -48,56 +48,58 @@ func NewSlogContextual() *SlogContextual {
 	}}
 }
 
-// slogContextEquivalent maps a bare slog top-level helper to its
-// context-aware variant. Only the four level helpers are listed because
-// they are the only ones the codebase calls in their non-Context form;
-// slog.Log / slog.LogAttrs already take a context.
-var slogContextEquivalent = map[string]string{
-	"Debug": "DebugContext",
-	"Info":  "InfoContext",
-	"Warn":  "WarnContext",
-	"Error": "ErrorContext",
+// slogLevels is the set of slog top-level helpers whose Context-aware
+// sibling (e.g. Debug → DebugContext) should be preferred when a context
+// is in scope. slog.Log / slog.LogAttrs already take a context.
+var slogLevels = map[string]bool{
+	"Debug": true,
+	"Info":  true,
+	"Warn":  true,
+	"Error": true,
 }
 
 func (c *SlogContextual) Check(p *cop.Pass) {
 	p.ForEachFunc(func(fn *ast.FuncDecl) {
 		if fn.Body != nil {
-			c.checkScope(p, fn.Type, fn.Body, false)
+			c.checkFunc(p, fn.Type, fn.Body, false)
 		}
 	})
 }
 
-// checkScope reports bare slog calls inside body when a context is reachable
+// checkFunc reports bare slog calls inside body when a context is reachable
 // from any enclosing function. outerHasContext propagates that visibility
 // into nested function literals, since closures capture by name.
-func (c *SlogContextual) checkScope(p *cop.Pass, typ *ast.FuncType, body *ast.BlockStmt, outerHasContext bool) {
-	hasContext := outerHasContext || hasFuncTypeContext(typ) || hasLocalContext(body)
+func (c *SlogContextual) checkFunc(p *cop.Pass, typ *ast.FuncType, body *ast.BlockStmt, outerHasContext bool) {
+	hasContext := outerHasContext || signatureDeclaresContext(typ) || bodyDeclaresContext(body)
 	ast.Inspect(body, func(n ast.Node) bool {
 		switch x := n.(type) {
 		case *ast.FuncLit:
-			c.checkScope(p, x.Type, x.Body, hasContext)
+			c.checkFunc(p, x.Type, x.Body, hasContext)
 			return false
 		case *ast.CallExpr:
-			if !hasContext {
-				return true
-			}
-			pkg, level, ok := cop.MatchSelector(x.Fun)
-			if !ok || pkg != "slog" {
-				return true
-			}
-			if ctxVariant, ok := slogContextEquivalent[level]; ok {
-				p.Report(x,
-					"a context is in scope; use slog.%s(ctx, …) instead of slog.%s so handlers (e.g. OpenTelemetry) can read it",
-					ctxVariant, level)
+			if hasContext {
+				c.reportIfBareSlog(p, x)
 			}
 		}
 		return true
 	})
 }
 
-// hasFuncTypeContext reports whether typ has any parameter or named result
-// declared as context.Context.
-func hasFuncTypeContext(typ *ast.FuncType) bool {
+// reportIfBareSlog reports an offense when call is `slog.<Level>(...)`
+// for one of the four level helpers that have a Context-aware sibling.
+func (c *SlogContextual) reportIfBareSlog(p *cop.Pass, call *ast.CallExpr) {
+	pkg, level, ok := cop.MatchSelector(call.Fun)
+	if !ok || pkg != "slog" || !slogLevels[level] {
+		return
+	}
+	p.Report(call,
+		"a context is in scope; use slog.%s(ctx, …) instead of slog.%s so handlers (e.g. OpenTelemetry) can read it",
+		level+"Context", level)
+}
+
+// signatureDeclaresContext reports whether typ declares any parameter or
+// named result of type context.Context.
+func signatureDeclaresContext(typ *ast.FuncType) bool {
 	for _, fl := range []*ast.FieldList{typ.Params, typ.Results} {
 		if fl == nil {
 			continue
@@ -107,7 +109,7 @@ func hasFuncTypeContext(typ *ast.FuncType) bool {
 				continue
 			}
 			for _, n := range f.Names {
-				if n.Name != "" && n.Name != "_" {
+				if namedIdent(n) {
 					return true
 				}
 			}
@@ -116,10 +118,10 @@ func hasFuncTypeContext(typ *ast.FuncType) bool {
 	return false
 }
 
-// hasLocalContext reports whether body locally binds an identifier to a
-// context.Context value. Nested function literals are skipped — their
-// bindings are inspected separately when checkScope recurses into them.
-func hasLocalContext(body *ast.BlockStmt) bool {
+// bodyDeclaresContext reports whether body locally binds an identifier to
+// a context.Context value. Nested function literals are skipped — their
+// bindings are inspected separately when checkFunc recurses into them.
+func bodyDeclaresContext(body *ast.BlockStmt) bool {
 	found := false
 	ast.Inspect(body, func(n ast.Node) bool {
 		if found {
@@ -131,29 +133,36 @@ func hasLocalContext(body *ast.BlockStmt) bool {
 		case *ast.AssignStmt:
 			found = bindsContext(s.Lhs, s.Rhs)
 		case *ast.ValueSpec:
-			if isContextContextType(s.Type) {
-				for _, n := range s.Names {
-					if n.Name != "" && n.Name != "_" {
-						found = true
-						break
-					}
-				}
-			}
-			if !found && len(s.Values) > 0 {
-				lhs := make([]ast.Expr, len(s.Names))
-				for i, n := range s.Names {
-					lhs[i] = n
-				}
-				found = bindsContext(lhs, s.Values)
-			}
+			found = valueSpecDeclaresContext(s)
 		}
 		return !found
 	})
 	return found
 }
 
+// valueSpecDeclaresContext reports whether s declares a context.Context,
+// either explicitly via its declared type (`var ctx context.Context`) or
+// implicitly via its initializer (`var ctx = context.Background()`).
+func valueSpecDeclaresContext(s *ast.ValueSpec) bool {
+	if isContextContextType(s.Type) {
+		for _, n := range s.Names {
+			if namedIdent(n) {
+				return true
+			}
+		}
+	}
+	if len(s.Values) == 0 {
+		return false
+	}
+	lhs := make([]ast.Expr, len(s.Names))
+	for i, n := range s.Names {
+		lhs[i] = n
+	}
+	return bindsContext(lhs, s.Values)
+}
+
 // bindsContext reports whether the assignment binds at least one LHS
-// identifier to a context.Context value. A single RHS handles both
+// identifier to a context.Context value. A single RHS covers both
 // single-value forms (`ctx := f()`) and multi-value returns
 // (`ctx, cancel := context.WithCancel(...)`); in the latter case the
 // context is always at the first return position.
@@ -169,6 +178,8 @@ func bindsContext(lhs, rhs []ast.Expr) bool {
 	return false
 }
 
+// namedIdent reports whether e is a named identifier — anonymous (`_`)
+// or unset names produce no usable scope binding.
 func namedIdent(e ast.Expr) bool {
 	id, ok := e.(*ast.Ident)
 	return ok && id.Name != "" && id.Name != "_"
@@ -187,7 +198,7 @@ func contextProducer(expr ast.Expr) bool {
 }
 
 // isContextContextType reports whether expr is the syntactic type
-// `context.Context`. Type aliases and embeddings are out of scope.
+// `context.Context`.
 func isContextContextType(expr ast.Expr) bool {
 	pkg, sel, ok := cop.MatchSelector(expr)
 	return ok && pkg == "context" && sel == "Context"

--- a/lint/slog_contextual.go
+++ b/lint/slog_contextual.go
@@ -1,0 +1,302 @@
+package main
+
+import (
+	"go/ast"
+	"go/token"
+	"strings"
+
+	"github.com/dgageot/rubocop-go/cop"
+)
+
+// SlogContextual enforces that callers use the *Context variant of every
+// slog top-level helper whenever a context.Context is reachable in scope.
+//
+// Go 1.21's `log/slog` exposes DebugContext / InfoContext / WarnContext /
+// ErrorContext so that handlers can read request-scoped values from the
+// active context — most importantly the OpenTelemetry trace/span IDs the
+// project's handler stamps on every record. The bare Debug / Info / Warn /
+// Error helpers drop the context, so any context-aware handler ends up
+// emitting records that cannot be correlated with the surrounding trace.
+//
+// The rule fires only when the cop can statically see a context name that
+// is *already in scope* at the call site:
+//
+//   - a parameter or named result whose type is `context.Context`;
+//   - a local var declared earlier in the same function from a context-
+//     producing expression (e.g. `ctx := cmd.Context()`,
+//     `ctx := context.Background()`, or the first return of
+//     `context.WithCancel(...)` / `context.WithTimeout(...)`).
+//
+// Function literals inherit the names visible at the position where the
+// literal is written, so a `defer func() { slog.Error(...) }()` placed
+// after `ctx := cmd.Context()` is flagged.
+//
+// Helpers without an in-scope context (e.g. `applyTheme()` in the TUI)
+// are intentionally not flagged: rewriting them would force callers to
+// thread a context through APIs that don't otherwise need one. When that
+// trade-off is acceptable, callers can capture `cmd.Context()` into a
+// local and the cop will then enforce the `*Context` variant inside.
+//
+// Per-line suppression is provided centrally by the runner: annotate the
+// line with `//rubocop:disable Lint/SlogContextual` to opt out — the
+// canonical use is a deliberate "no context here" log inside a helper
+// where `context.TODO()` would be more misleading than informative.
+type SlogContextual struct {
+	cop.Meta
+}
+
+// NewSlogContextual returns a fully configured SlogContextual cop.
+func NewSlogContextual() *SlogContextual {
+	return &SlogContextual{Meta: cop.Meta{
+		CopName:     "Lint/SlogContextual",
+		CopDesc:     "use slog.{Level}Context(ctx, …) when a context is in scope",
+		CopSeverity: cop.Warning,
+	}}
+}
+
+// slogContextEquivalent maps a bare slog top-level helper to its
+// context-aware variant. Only the four level helpers are listed because
+// they are the only ones the codebase calls in their non-Context form;
+// slog.Log / slog.LogAttrs already take a context.
+var slogContextEquivalent = map[string]string{
+	"Debug": "DebugContext",
+	"Info":  "InfoContext",
+	"Warn":  "WarnContext",
+	"Error": "ErrorContext",
+}
+
+// contextBinding records a context-typed identifier alongside the source
+// position at which the identifier becomes visible (after the binding
+// statement). Captured names are compared against later positions so the
+// cop only treats a name as in scope once its declaration has executed.
+type contextBinding struct {
+	name string
+	pos  token.Pos
+}
+
+func (c *SlogContextual) Check(p *cop.Pass) {
+	p.ForEachFunc(func(fn *ast.FuncDecl) {
+		if fn.Body == nil {
+			return
+		}
+		c.checkScope(p, fn.Type, fn.Body, nil)
+	})
+}
+
+// checkScope walks body and reports bare slog calls that have a context
+// name visible at their position. outer carries the bindings already
+// visible from enclosing scopes (parameters of outer functions, locals
+// of the enclosing block declared before this function literal, …).
+func (c *SlogContextual) checkScope(p *cop.Pass, typ *ast.FuncType, body *ast.BlockStmt, outer []contextBinding) {
+	// Parameters and named results are visible from the very first byte
+	// of the body.
+	bindings := append([]contextBinding(nil), outer...)
+	for _, name := range contextNamesInFuncType(typ) {
+		bindings = append(bindings, contextBinding{name: name, pos: body.Lbrace})
+	}
+	// Add every locally-derived context, recorded at the position right
+	// after its binding statement so a use on the same line as the
+	// declaration is correctly considered in scope.
+	bindings = append(bindings, contextBindingsInBlock(body)...)
+
+	ast.Inspect(body, func(n ast.Node) bool {
+		switch x := n.(type) {
+		case *ast.FuncLit:
+			// Inherit only the names that exist at the position where
+			// the literal is written.
+			c.checkScope(p, x.Type, x.Body, visibleAt(bindings, x.Pos()))
+			return false
+		case *ast.CallExpr:
+			if hasVisibleAt(bindings, x.Pos()) {
+				c.maybeReport(p, x)
+			}
+		}
+		return true
+	})
+}
+
+// maybeReport reports an offense when call is `slog.<Level>(...)` for one
+// of the four level helpers that have a Context-aware sibling.
+func (c *SlogContextual) maybeReport(p *cop.Pass, call *ast.CallExpr) {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok || pkg.Name != "slog" {
+		return
+	}
+	ctxVariant, ok := slogContextEquivalent[sel.Sel.Name]
+	if !ok {
+		return
+	}
+	p.Report(call,
+		"a context is in scope; use slog.%s(ctx, …) instead of slog.%s so handlers (e.g. OpenTelemetry) can read it",
+		ctxVariant, sel.Sel.Name)
+}
+
+// contextNamesInFuncType returns the identifier names declared in fn's
+// parameter or named-result lists whose syntactic type is `context.Context`.
+func contextNamesInFuncType(typ *ast.FuncType) []string {
+	var names []string
+	names = appendContextFieldNames(names, typ.Params)
+	names = appendContextFieldNames(names, typ.Results)
+	return names
+}
+
+func appendContextFieldNames(names []string, fl *ast.FieldList) []string {
+	if fl == nil {
+		return names
+	}
+	for _, f := range fl.List {
+		if !isContextContextType(f.Type) {
+			continue
+		}
+		for _, n := range f.Names {
+			if n.Name != "" && n.Name != "_" {
+				names = append(names, n.Name)
+			}
+		}
+	}
+	return names
+}
+
+// contextBindingsInBlock collects locally-declared context-typed
+// identifiers from body, recording each at the position right after the
+// binding statement so that scope lookups respect declaration order.
+// Nested function literals are skipped — their bindings are tracked
+// separately when checkScope recurses into them.
+func contextBindingsInBlock(body *ast.BlockStmt) []contextBinding {
+	if body == nil {
+		return nil
+	}
+	var out []contextBinding
+	ast.Inspect(body, func(n ast.Node) bool {
+		switch s := n.(type) {
+		case *ast.FuncLit:
+			return false
+		case *ast.AssignStmt:
+			for _, name := range collectContextLHSNames(s.Lhs, s.Rhs) {
+				out = append(out, contextBinding{name: name, pos: s.End()})
+			}
+		case *ast.ValueSpec:
+			if isContextContextType(s.Type) {
+				for _, n := range s.Names {
+					if n.Name != "" && n.Name != "_" {
+						out = append(out, contextBinding{name: n.Name, pos: s.End()})
+					}
+				}
+			}
+			if len(s.Values) > 0 {
+				lhs := make([]ast.Expr, len(s.Names))
+				for i, n := range s.Names {
+					lhs[i] = n
+				}
+				for _, name := range collectContextLHSNames(lhs, s.Values) {
+					out = append(out, contextBinding{name: name, pos: s.End()})
+				}
+			}
+		}
+		return true
+	})
+	return out
+}
+
+// collectContextLHSNames returns every LHS identifier name that an
+// assignment binds to a context.Context value, using purely syntactic
+// shape recognition.
+func collectContextLHSNames(lhs, rhs []ast.Expr) []string {
+	var names []string
+	if len(rhs) == 1 && len(lhs) >= 1 {
+		// Multi-value RHS like `ctx, cancel := context.WithCancel(parent)`:
+		// the first return of context.With* is the derived Context.
+		if call, ok := rhs[0].(*ast.CallExpr); ok && isContextWithCall(call) {
+			if name := identName(lhs[0]); name != "" {
+				names = append(names, name)
+			}
+			return names
+		}
+	}
+	for i := 0; i < len(lhs) && i < len(rhs); i++ {
+		if !isContextProducingExpr(rhs[i]) {
+			continue
+		}
+		if name := identName(lhs[i]); name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+func identName(e ast.Expr) string {
+	id, ok := e.(*ast.Ident)
+	if !ok || id.Name == "" || id.Name == "_" {
+		return ""
+	}
+	return id.Name
+}
+
+// isContextProducingExpr reports whether expr is a syntactic shape that
+// commonly yields a context.Context: any call into the `context` package,
+// or any zero-arg method named `Context` (the cobra/http convention).
+func isContextProducingExpr(expr ast.Expr) bool {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	if id, ok := sel.X.(*ast.Ident); ok && id.Name == "context" {
+		return true
+	}
+	return sel.Sel.Name == "Context" && len(call.Args) == 0
+}
+
+// isContextWithCall reports whether call is `context.With<Something>(...)`,
+// the family that returns (Context, CancelFunc) and friends.
+func isContextWithCall(call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	id, ok := sel.X.(*ast.Ident)
+	if !ok || id.Name != "context" {
+		return false
+	}
+	return strings.HasPrefix(sel.Sel.Name, "With")
+}
+
+// isContextContextType reports whether expr is the syntactic type
+// `context.Context`. Type aliases and embeddings are out of scope.
+func isContextContextType(expr ast.Expr) bool {
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	id, ok := sel.X.(*ast.Ident)
+	return ok && id.Name == "context" && sel.Sel.Name == "Context"
+}
+
+// hasVisibleAt reports whether at least one binding from bindings is
+// visible at position pos (i.e. its binding.pos < pos).
+func hasVisibleAt(bindings []contextBinding, pos token.Pos) bool {
+	for _, b := range bindings {
+		if b.pos < pos {
+			return true
+		}
+	}
+	return false
+}
+
+// visibleAt returns the subset of bindings already visible at position pos.
+func visibleAt(bindings []contextBinding, pos token.Pos) []contextBinding {
+	var out []contextBinding
+	for _, b := range bindings {
+		if b.pos < pos {
+			out = append(out, b)
+		}
+	}
+	return out
+}

--- a/lint/slog_contextual.go
+++ b/lint/slog_contextual.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"go/ast"
-	"strings"
 
 	"github.com/dgageot/rubocop-go/cop"
 )
@@ -18,8 +17,8 @@ import (
 // Error helpers drop the context, so any context-aware handler ends up
 // emitting records that cannot be correlated with the surrounding trace.
 //
-// The rule fires when the cop can statically see a context name visible
-// in the call's enclosing function:
+// The rule fires when the cop can syntactically see a context name in the
+// call's enclosing function:
 //
 //   - a parameter or named result whose type is `context.Context`;
 //   - a local var declared from a context-producing expression (e.g.
@@ -27,19 +26,15 @@ import (
 //     return of `context.WithCancel(...)` / `context.WithTimeout(...)`).
 //
 // Function literals inherit context names from every enclosing function,
-// so a `defer func() { slog.Error(...) }()` placed inside a function
-// that holds a ctx is flagged.
+// so a `defer func() { slog.Error(...) }()` inside a function that holds
+// a ctx is flagged.
 //
-// Convention: always declare the context near the top of the function so
-// that every later log statement sees it. Helpers without an in-scope
-// context (e.g. `applyTheme()` in cmd/root/run.go) are intentionally not
-// flagged: rewriting them would force callers to thread a context
-// through APIs that don't otherwise need one.
+// Convention: declare the context near the top of the function so that
+// every later log statement sees it. Helpers without an in-scope context
+// are intentionally not flagged: rewriting them would force callers to
+// thread a context through APIs that don't otherwise need one.
 //
-// Per-line suppression is provided centrally by the runner: annotate the
-// line with `//rubocop:disable Lint/SlogContextual` to opt out — the
-// canonical use is a deliberate "no context here" log inside a helper
-// where `context.TODO()` would be more misleading than informative.
+// Per-line suppression: `//rubocop:disable Lint/SlogContextual`.
 type SlogContextual struct {
 	cop.Meta
 }
@@ -66,84 +61,65 @@ var slogContextEquivalent = map[string]string{
 
 func (c *SlogContextual) Check(p *cop.Pass) {
 	p.ForEachFunc(func(fn *ast.FuncDecl) {
-		if fn.Body == nil {
-			return
+		if fn.Body != nil {
+			c.checkScope(p, fn.Type, fn.Body, false)
 		}
-		c.checkScope(p, fn.Type, fn.Body, false)
 	})
 }
 
-// checkScope reports bare slog calls inside body when a context name is
-// visible in the enclosing function or any outer function literal.
-// outerHasContext propagates that visibility into nested literals.
+// checkScope reports bare slog calls inside body when a context is reachable
+// from any enclosing function. outerHasContext propagates that visibility
+// into nested function literals, since closures capture by name.
 func (c *SlogContextual) checkScope(p *cop.Pass, typ *ast.FuncType, body *ast.BlockStmt, outerHasContext bool) {
-	hasContext := outerHasContext || hasContextInFuncType(typ) || hasContextBindingInBlock(body)
-
+	hasContext := outerHasContext || hasFuncTypeContext(typ) || hasLocalContext(body)
 	ast.Inspect(body, func(n ast.Node) bool {
 		switch x := n.(type) {
 		case *ast.FuncLit:
 			c.checkScope(p, x.Type, x.Body, hasContext)
 			return false
 		case *ast.CallExpr:
-			if hasContext {
-				c.maybeReport(p, x)
+			if !hasContext {
+				return true
+			}
+			pkg, level, ok := cop.MatchSelector(x.Fun)
+			if !ok || pkg != "slog" {
+				return true
+			}
+			if ctxVariant, ok := slogContextEquivalent[level]; ok {
+				p.Report(x,
+					"a context is in scope; use slog.%s(ctx, …) instead of slog.%s so handlers (e.g. OpenTelemetry) can read it",
+					ctxVariant, level)
 			}
 		}
 		return true
 	})
 }
 
-// maybeReport reports an offense when call is `slog.<Level>(...)` for one
-// of the four level helpers that have a Context-aware sibling.
-func (c *SlogContextual) maybeReport(p *cop.Pass, call *ast.CallExpr) {
-	sel, ok := call.Fun.(*ast.SelectorExpr)
-	if !ok {
-		return
-	}
-	pkg, ok := sel.X.(*ast.Ident)
-	if !ok || pkg.Name != "slog" {
-		return
-	}
-	ctxVariant, ok := slogContextEquivalent[sel.Sel.Name]
-	if !ok {
-		return
-	}
-	p.Report(call,
-		"a context is in scope; use slog.%s(ctx, …) instead of slog.%s so handlers (e.g. OpenTelemetry) can read it",
-		ctxVariant, sel.Sel.Name)
-}
-
-// hasContextInFuncType reports whether typ has any parameter or named
-// result whose syntactic type is `context.Context`.
-func hasContextInFuncType(typ *ast.FuncType) bool {
-	return fieldListHasContext(typ.Params) || fieldListHasContext(typ.Results)
-}
-
-func fieldListHasContext(fl *ast.FieldList) bool {
-	if fl == nil {
-		return false
-	}
-	for _, f := range fl.List {
-		if !isContextContextType(f.Type) {
+// hasFuncTypeContext reports whether typ has any parameter or named result
+// declared as context.Context.
+func hasFuncTypeContext(typ *ast.FuncType) bool {
+	for _, fl := range []*ast.FieldList{typ.Params, typ.Results} {
+		if fl == nil {
 			continue
 		}
-		for _, n := range f.Names {
-			if n.Name != "" && n.Name != "_" {
-				return true
+		for _, f := range fl.List {
+			if !isContextContextType(f.Type) {
+				continue
+			}
+			for _, n := range f.Names {
+				if n.Name != "" && n.Name != "_" {
+					return true
+				}
 			}
 		}
 	}
 	return false
 }
 
-// hasContextBindingInBlock reports whether body locally binds at least one
-// identifier to a context.Context value, using purely syntactic shape
-// recognition. Nested function literals are skipped — their bindings are
-// inspected separately when checkScope recurses into them.
-func hasContextBindingInBlock(body *ast.BlockStmt) bool {
-	if body == nil {
-		return false
-	}
+// hasLocalContext reports whether body locally binds an identifier to a
+// context.Context value. Nested function literals are skipped — their
+// bindings are inspected separately when checkScope recurses into them.
+func hasLocalContext(body *ast.BlockStmt) bool {
 	found := false
 	ast.Inspect(body, func(n ast.Node) bool {
 		if found {
@@ -153,26 +129,22 @@ func hasContextBindingInBlock(body *ast.BlockStmt) bool {
 		case *ast.FuncLit:
 			return false
 		case *ast.AssignStmt:
-			if assignBindsContext(s.Lhs, s.Rhs) {
-				found = true
-			}
+			found = bindsContext(s.Lhs, s.Rhs)
 		case *ast.ValueSpec:
 			if isContextContextType(s.Type) {
 				for _, n := range s.Names {
 					if n.Name != "" && n.Name != "_" {
 						found = true
-						return false
+						break
 					}
 				}
 			}
-			if len(s.Values) > 0 {
+			if !found && len(s.Values) > 0 {
 				lhs := make([]ast.Expr, len(s.Names))
 				for i, n := range s.Names {
 					lhs[i] = n
 				}
-				if assignBindsContext(lhs, s.Values) {
-					found = true
-				}
+				found = bindsContext(lhs, s.Values)
 			}
 		}
 		return !found
@@ -180,72 +152,43 @@ func hasContextBindingInBlock(body *ast.BlockStmt) bool {
 	return found
 }
 
-// assignBindsContext reports whether an assignment binds at least one LHS
-// identifier to a context.Context value, using purely syntactic shape
-// recognition.
-func assignBindsContext(lhs, rhs []ast.Expr) bool {
-	if len(rhs) == 1 && len(lhs) >= 1 {
-		// Multi-value RHS like `ctx, cancel := context.WithCancel(parent)`:
-		// the first return of context.With* is the derived Context.
-		if call, ok := rhs[0].(*ast.CallExpr); ok && isContextWithCall(call) {
-			return identName(lhs[0]) != ""
-		}
+// bindsContext reports whether the assignment binds at least one LHS
+// identifier to a context.Context value. A single RHS handles both
+// single-value forms (`ctx := f()`) and multi-value returns
+// (`ctx, cancel := context.WithCancel(...)`); in the latter case the
+// context is always at the first return position.
+func bindsContext(lhs, rhs []ast.Expr) bool {
+	if len(rhs) == 1 {
+		return len(lhs) >= 1 && contextProducer(rhs[0]) && namedIdent(lhs[0])
 	}
 	for i := 0; i < len(lhs) && i < len(rhs); i++ {
-		if isContextProducingExpr(rhs[i]) && identName(lhs[i]) != "" {
+		if contextProducer(rhs[i]) && namedIdent(lhs[i]) {
 			return true
 		}
 	}
 	return false
 }
 
-func identName(e ast.Expr) string {
+func namedIdent(e ast.Expr) bool {
 	id, ok := e.(*ast.Ident)
-	if !ok || id.Name == "" || id.Name == "_" {
-		return ""
-	}
-	return id.Name
+	return ok && id.Name != "" && id.Name != "_"
 }
 
-// isContextProducingExpr reports whether expr is a syntactic shape that
-// commonly yields a context.Context: any call into the `context` package,
-// or any zero-arg method named `Context` (the cobra/http convention).
-func isContextProducingExpr(expr ast.Expr) bool {
+// contextProducer reports whether expr is a call whose shape commonly
+// yields a context.Context: any call into the `context` package, or any
+// zero-arg method named `Context` (the cobra / http.Request convention).
+func contextProducer(expr ast.Expr) bool {
 	call, ok := expr.(*ast.CallExpr)
 	if !ok {
 		return false
 	}
-	sel, ok := call.Fun.(*ast.SelectorExpr)
-	if !ok {
-		return false
-	}
-	if id, ok := sel.X.(*ast.Ident); ok && id.Name == "context" {
-		return true
-	}
-	return sel.Sel.Name == "Context" && len(call.Args) == 0
-}
-
-// isContextWithCall reports whether call is `context.With<Something>(...)`,
-// the family that returns (Context, CancelFunc) and friends.
-func isContextWithCall(call *ast.CallExpr) bool {
-	sel, ok := call.Fun.(*ast.SelectorExpr)
-	if !ok {
-		return false
-	}
-	id, ok := sel.X.(*ast.Ident)
-	if !ok || id.Name != "context" {
-		return false
-	}
-	return strings.HasPrefix(sel.Sel.Name, "With")
+	pkg, sel, ok := cop.MatchSelector(call.Fun)
+	return ok && (pkg == "context" || (sel == "Context" && len(call.Args) == 0))
 }
 
 // isContextContextType reports whether expr is the syntactic type
 // `context.Context`. Type aliases and embeddings are out of scope.
 func isContextContextType(expr ast.Expr) bool {
-	sel, ok := expr.(*ast.SelectorExpr)
-	if !ok {
-		return false
-	}
-	id, ok := sel.X.(*ast.Ident)
-	return ok && id.Name == "context" && sel.Sel.Name == "Context"
+	pkg, sel, ok := cop.MatchSelector(expr)
+	return ok && pkg == "context" && sel == "Context"
 }

--- a/lint/slog_contextual.go
+++ b/lint/slog_contextual.go
@@ -2,14 +2,14 @@ package main
 
 import (
 	"go/ast"
-	"go/token"
 	"strings"
 
 	"github.com/dgageot/rubocop-go/cop"
 )
 
 // SlogContextual enforces that callers use the *Context variant of every
-// slog top-level helper whenever a context.Context is reachable in scope.
+// slog top-level helper whenever a context.Context is reachable in the
+// enclosing function.
 //
 // Go 1.21's `log/slog` exposes DebugContext / InfoContext / WarnContext /
 // ErrorContext so that handlers can read request-scoped values from the
@@ -18,24 +18,23 @@ import (
 // Error helpers drop the context, so any context-aware handler ends up
 // emitting records that cannot be correlated with the surrounding trace.
 //
-// The rule fires only when the cop can statically see a context name that
-// is *already in scope* at the call site:
+// The rule fires when the cop can statically see a context name visible
+// in the call's enclosing function:
 //
 //   - a parameter or named result whose type is `context.Context`;
-//   - a local var declared earlier in the same function from a context-
-//     producing expression (e.g. `ctx := cmd.Context()`,
-//     `ctx := context.Background()`, or the first return of
-//     `context.WithCancel(...)` / `context.WithTimeout(...)`).
+//   - a local var declared from a context-producing expression (e.g.
+//     `ctx := cmd.Context()`, `ctx := context.Background()`, or the first
+//     return of `context.WithCancel(...)` / `context.WithTimeout(...)`).
 //
-// Function literals inherit the names visible at the position where the
-// literal is written, so a `defer func() { slog.Error(...) }()` placed
-// after `ctx := cmd.Context()` is flagged.
+// Function literals inherit context names from every enclosing function,
+// so a `defer func() { slog.Error(...) }()` placed inside a function
+// that holds a ctx is flagged.
 //
-// Helpers without an in-scope context (e.g. `applyTheme()` in the TUI)
-// are intentionally not flagged: rewriting them would force callers to
-// thread a context through APIs that don't otherwise need one. When that
-// trade-off is acceptable, callers can capture `cmd.Context()` into a
-// local and the cop will then enforce the `*Context` variant inside.
+// Convention: always declare the context near the top of the function so
+// that every later log statement sees it. Helpers without an in-scope
+// context (e.g. `applyTheme()` in cmd/root/run.go) are intentionally not
+// flagged: rewriting them would force callers to thread a context
+// through APIs that don't otherwise need one.
 //
 // Per-line suppression is provided centrally by the runner: annotate the
 // line with `//rubocop:disable Lint/SlogContextual` to opt out — the
@@ -65,49 +64,28 @@ var slogContextEquivalent = map[string]string{
 	"Error": "ErrorContext",
 }
 
-// contextBinding records a context-typed identifier alongside the source
-// position at which the identifier becomes visible (after the binding
-// statement). Captured names are compared against later positions so the
-// cop only treats a name as in scope once its declaration has executed.
-type contextBinding struct {
-	name string
-	pos  token.Pos
-}
-
 func (c *SlogContextual) Check(p *cop.Pass) {
 	p.ForEachFunc(func(fn *ast.FuncDecl) {
 		if fn.Body == nil {
 			return
 		}
-		c.checkScope(p, fn.Type, fn.Body, nil)
+		c.checkScope(p, fn.Type, fn.Body, false)
 	})
 }
 
-// checkScope walks body and reports bare slog calls that have a context
-// name visible at their position. outer carries the bindings already
-// visible from enclosing scopes (parameters of outer functions, locals
-// of the enclosing block declared before this function literal, …).
-func (c *SlogContextual) checkScope(p *cop.Pass, typ *ast.FuncType, body *ast.BlockStmt, outer []contextBinding) {
-	// Parameters and named results are visible from the very first byte
-	// of the body.
-	bindings := append([]contextBinding(nil), outer...)
-	for _, name := range contextNamesInFuncType(typ) {
-		bindings = append(bindings, contextBinding{name: name, pos: body.Lbrace})
-	}
-	// Add every locally-derived context, recorded at the position right
-	// after its binding statement so a use on the same line as the
-	// declaration is correctly considered in scope.
-	bindings = append(bindings, contextBindingsInBlock(body)...)
+// checkScope reports bare slog calls inside body when a context name is
+// visible in the enclosing function or any outer function literal.
+// outerHasContext propagates that visibility into nested literals.
+func (c *SlogContextual) checkScope(p *cop.Pass, typ *ast.FuncType, body *ast.BlockStmt, outerHasContext bool) {
+	hasContext := outerHasContext || hasContextInFuncType(typ) || hasContextBindingInBlock(body)
 
 	ast.Inspect(body, func(n ast.Node) bool {
 		switch x := n.(type) {
 		case *ast.FuncLit:
-			// Inherit only the names that exist at the position where
-			// the literal is written.
-			c.checkScope(p, x.Type, x.Body, visibleAt(bindings, x.Pos()))
+			c.checkScope(p, x.Type, x.Body, hasContext)
 			return false
 		case *ast.CallExpr:
-			if hasVisibleAt(bindings, x.Pos()) {
+			if hasContext {
 				c.maybeReport(p, x)
 			}
 		}
@@ -135,18 +113,15 @@ func (c *SlogContextual) maybeReport(p *cop.Pass, call *ast.CallExpr) {
 		ctxVariant, sel.Sel.Name)
 }
 
-// contextNamesInFuncType returns the identifier names declared in fn's
-// parameter or named-result lists whose syntactic type is `context.Context`.
-func contextNamesInFuncType(typ *ast.FuncType) []string {
-	var names []string
-	names = appendContextFieldNames(names, typ.Params)
-	names = appendContextFieldNames(names, typ.Results)
-	return names
+// hasContextInFuncType reports whether typ has any parameter or named
+// result whose syntactic type is `context.Context`.
+func hasContextInFuncType(typ *ast.FuncType) bool {
+	return fieldListHasContext(typ.Params) || fieldListHasContext(typ.Results)
 }
 
-func appendContextFieldNames(names []string, fl *ast.FieldList) []string {
+func fieldListHasContext(fl *ast.FieldList) bool {
 	if fl == nil {
-		return names
+		return false
 	}
 	for _, f := range fl.List {
 		if !isContextContextType(f.Type) {
@@ -154,36 +129,39 @@ func appendContextFieldNames(names []string, fl *ast.FieldList) []string {
 		}
 		for _, n := range f.Names {
 			if n.Name != "" && n.Name != "_" {
-				names = append(names, n.Name)
+				return true
 			}
 		}
 	}
-	return names
+	return false
 }
 
-// contextBindingsInBlock collects locally-declared context-typed
-// identifiers from body, recording each at the position right after the
-// binding statement so that scope lookups respect declaration order.
-// Nested function literals are skipped — their bindings are tracked
-// separately when checkScope recurses into them.
-func contextBindingsInBlock(body *ast.BlockStmt) []contextBinding {
+// hasContextBindingInBlock reports whether body locally binds at least one
+// identifier to a context.Context value, using purely syntactic shape
+// recognition. Nested function literals are skipped — their bindings are
+// inspected separately when checkScope recurses into them.
+func hasContextBindingInBlock(body *ast.BlockStmt) bool {
 	if body == nil {
-		return nil
+		return false
 	}
-	var out []contextBinding
+	found := false
 	ast.Inspect(body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
 		switch s := n.(type) {
 		case *ast.FuncLit:
 			return false
 		case *ast.AssignStmt:
-			for _, name := range collectContextLHSNames(s.Lhs, s.Rhs) {
-				out = append(out, contextBinding{name: name, pos: s.End()})
+			if assignBindsContext(s.Lhs, s.Rhs) {
+				found = true
 			}
 		case *ast.ValueSpec:
 			if isContextContextType(s.Type) {
 				for _, n := range s.Names {
 					if n.Name != "" && n.Name != "_" {
-						out = append(out, contextBinding{name: n.Name, pos: s.End()})
+						found = true
+						return false
 					}
 				}
 			}
@@ -192,40 +170,33 @@ func contextBindingsInBlock(body *ast.BlockStmt) []contextBinding {
 				for i, n := range s.Names {
 					lhs[i] = n
 				}
-				for _, name := range collectContextLHSNames(lhs, s.Values) {
-					out = append(out, contextBinding{name: name, pos: s.End()})
+				if assignBindsContext(lhs, s.Values) {
+					found = true
 				}
 			}
 		}
-		return true
+		return !found
 	})
-	return out
+	return found
 }
 
-// collectContextLHSNames returns every LHS identifier name that an
-// assignment binds to a context.Context value, using purely syntactic
-// shape recognition.
-func collectContextLHSNames(lhs, rhs []ast.Expr) []string {
-	var names []string
+// assignBindsContext reports whether an assignment binds at least one LHS
+// identifier to a context.Context value, using purely syntactic shape
+// recognition.
+func assignBindsContext(lhs, rhs []ast.Expr) bool {
 	if len(rhs) == 1 && len(lhs) >= 1 {
 		// Multi-value RHS like `ctx, cancel := context.WithCancel(parent)`:
 		// the first return of context.With* is the derived Context.
 		if call, ok := rhs[0].(*ast.CallExpr); ok && isContextWithCall(call) {
-			if name := identName(lhs[0]); name != "" {
-				names = append(names, name)
-			}
-			return names
+			return identName(lhs[0]) != ""
 		}
 	}
 	for i := 0; i < len(lhs) && i < len(rhs); i++ {
-		if !isContextProducingExpr(rhs[i]) {
-			continue
-		}
-		if name := identName(lhs[i]); name != "" {
-			names = append(names, name)
+		if isContextProducingExpr(rhs[i]) && identName(lhs[i]) != "" {
+			return true
 		}
 	}
-	return names
+	return false
 }
 
 func identName(e ast.Expr) string {
@@ -277,26 +248,4 @@ func isContextContextType(expr ast.Expr) bool {
 	}
 	id, ok := sel.X.(*ast.Ident)
 	return ok && id.Name == "context" && sel.Sel.Name == "Context"
-}
-
-// hasVisibleAt reports whether at least one binding from bindings is
-// visible at position pos (i.e. its binding.pos < pos).
-func hasVisibleAt(bindings []contextBinding, pos token.Pos) bool {
-	for _, b := range bindings {
-		if b.pos < pos {
-			return true
-		}
-	}
-	return false
-}
-
-// visibleAt returns the subset of bindings already visible at position pos.
-func visibleAt(bindings []contextBinding, pos token.Pos) []contextBinding {
-	var out []contextBinding
-	for _, b := range bindings {
-		if b.pos < pos {
-			out = append(out, b)
-		}
-	}
-	return out
 }

--- a/lint/slog_contextual.go
+++ b/lint/slog_contextual.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"go/ast"
-	"slices"
 
 	"github.com/dgageot/rubocop-go/cop"
 )
@@ -170,14 +169,12 @@ func valueSpecDeclaresContext(s *ast.ValueSpec) bool {
 // bindsContext reports whether the assignment binds at least one LHS
 // identifier to a context.Context value. A single RHS covers both
 // single-value forms (`ctx := f()`) and multi-value returns
-// (`ctx, cancel := context.WithCancel(...)`); we check all LHS positions
-// since the context might not be at position 0 (e.g., `err, ctx := fn()`).
+// (`ctx, cancel := context.WithCancel(...)`); in the latter case the
+// context is always at the first return position — `_, cancel := ...`
+// discards the context and intentionally yields no in-scope name.
 func bindsContext(lhs, rhs []ast.Expr) bool {
 	if len(rhs) == 1 {
-		// Single RHS: could be single-value or multi-return.
-		// For multi-return, check all LHS positions since context
-		// might not be at position 0 (e.g., `err, ctx := fn()`).
-		return contextProducer(rhs[0]) && slices.ContainsFunc(lhs, namedIdent)
+		return len(lhs) >= 1 && contextProducer(rhs[0]) && namedIdent(lhs[0])
 	}
 	for i := 0; i < len(lhs) && i < len(rhs); i++ {
 		if contextProducer(rhs[i]) && namedIdent(lhs[i]) {

--- a/pkg/acp/agent.go
+++ b/pkg/acp/agent.go
@@ -183,14 +183,14 @@ func (a *Agent) NewSession(ctx context.Context, params acp.NewSessionRequest) (a
 }
 
 // Authenticate implements [acp.Agent]
-func (a *Agent) Authenticate(context.Context, acp.AuthenticateRequest) (acp.AuthenticateResponse, error) {
-	slog.Debug("ACP Authenticate called")
+func (a *Agent) Authenticate(ctx context.Context, _ acp.AuthenticateRequest) (acp.AuthenticateResponse, error) {
+	slog.DebugContext(ctx, "ACP Authenticate called")
 	return acp.AuthenticateResponse{}, nil
 }
 
 // LoadSession implements [acp.AgentLoader] (optional, not supported)
-func (a *Agent) LoadSession(context.Context, acp.LoadSessionRequest) (acp.LoadSessionResponse, error) {
-	slog.Debug("ACP LoadSession called (not supported)")
+func (a *Agent) LoadSession(ctx context.Context, _ acp.LoadSessionRequest) (acp.LoadSessionResponse, error) {
+	slog.DebugContext(ctx, "ACP LoadSession called (not supported)")
 	return acp.LoadSessionResponse{}, errors.New("load session not supported")
 }
 
@@ -215,20 +215,20 @@ func (a *Agent) CloseSession(_ context.Context, params acp.CloseSessionRequest) 
 }
 
 // ListSessions implements [acp.Agent] (optional, not advertised in capabilities)
-func (a *Agent) ListSessions(context.Context, acp.ListSessionsRequest) (acp.ListSessionsResponse, error) {
-	slog.Debug("ACP ListSessions called (not supported)")
+func (a *Agent) ListSessions(ctx context.Context, _ acp.ListSessionsRequest) (acp.ListSessionsResponse, error) {
+	slog.DebugContext(ctx, "ACP ListSessions called (not supported)")
 	return acp.ListSessionsResponse{}, errors.New("list sessions not supported")
 }
 
 // ResumeSession implements [acp.Agent] (optional, not advertised in capabilities)
-func (a *Agent) ResumeSession(context.Context, acp.ResumeSessionRequest) (acp.ResumeSessionResponse, error) {
-	slog.Debug("ACP ResumeSession called (not supported)")
+func (a *Agent) ResumeSession(ctx context.Context, _ acp.ResumeSessionRequest) (acp.ResumeSessionResponse, error) {
+	slog.DebugContext(ctx, "ACP ResumeSession called (not supported)")
 	return acp.ResumeSessionResponse{}, errors.New("resume session not supported")
 }
 
 // SetSessionConfigOption implements [acp.Agent] (optional, not advertised in capabilities)
-func (a *Agent) SetSessionConfigOption(context.Context, acp.SetSessionConfigOptionRequest) (acp.SetSessionConfigOptionResponse, error) {
-	slog.Debug("ACP SetSessionConfigOption called (not supported)")
+func (a *Agent) SetSessionConfigOption(ctx context.Context, _ acp.SetSessionConfigOptionRequest) (acp.SetSessionConfigOptionResponse, error) {
+	slog.DebugContext(ctx, "ACP SetSessionConfigOption called (not supported)")
 	return acp.SetSessionConfigOptionResponse{}, nil
 }
 

--- a/pkg/fake/proxy.go
+++ b/pkg/fake/proxy.go
@@ -107,7 +107,7 @@ func StartStreamingRecordingProxy(
 		case err := <-stopDone:
 			return err
 		case <-ctx.Done():
-			slog.Warn("Recording proxy cleanup timed out, cassette may be incomplete")
+			slog.WarnContext(ctx, "Recording proxy cleanup timed out, cassette may be incomplete")
 			return nil
 		}
 	}
@@ -192,7 +192,7 @@ func StartProxyWithOptions(
 		case err := <-stopDone:
 			return err
 		case <-ctx.Done():
-			slog.Warn("Recording proxy cleanup timed out, cassette may be incomplete")
+			slog.WarnContext(ctx, "Recording proxy cleanup timed out, cassette may be incomplete")
 			return nil
 		}
 	}
@@ -321,7 +321,7 @@ func Handle(transport http.RoundTripper, headerUpdater func(host string, req *ht
 
 		resp, err := client.Do(req)
 		if err != nil {
-			slog.Error("VCR proxy request failed", "url", targetURL, "error", err)
+			slog.ErrorContext(ctx, "VCR proxy request failed", "url", targetURL, "error", err)
 			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to run request: "+err.Error())
 		}
 		defer resp.Body.Close()

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -71,7 +71,7 @@ func (m *appModel) handleBranchFromEdit(msg messages.BranchFromEditMsg) (tea.Mod
 	if m.tuiStore != nil {
 		oldPersistedID := m.persistedSessionID(activeID)
 		if err := m.tuiStore.UpdateTabSessionID(ctx, oldPersistedID, newSess.ID); err != nil {
-			slog.Warn("Failed to update tab session ID after branch", "error", err)
+			slog.WarnContext(ctx, "Failed to update tab session ID after branch", "error", err)
 		}
 	}
 	m.persistActiveTab(newSess.ID)
@@ -135,7 +135,7 @@ func (m *appModel) handleForkSession() (tea.Model, tea.Cmd) {
 
 	if m.tuiStore != nil {
 		if err := m.tuiStore.AddTab(ctx, forkedSession.ID, forkedSession.WorkingDir); err != nil {
-			slog.Warn("Failed to persist forked tab", "error", err)
+			slog.WarnContext(ctx, "Failed to persist forked tab", "error", err)
 		}
 	}
 

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -1065,11 +1065,11 @@ func (m *appModel) handleLoadSession(sessionID string) (tea.Model, tea.Cmd) {
 		// Update tuistate: replace old persisted ID with the loaded session's ID
 		if m.tuiStore != nil {
 			if err := m.tuiStore.UpdateTabSessionID(ctx, oldPersistedID, sess.ID); err != nil {
-				slog.Warn("Failed to update tab session ID after in-place load", "error", err)
+				slog.WarnContext(ctx, "Failed to update tab session ID after in-place load", "error", err)
 			}
 			if sess.WorkingDir != "" {
 				if err := m.tuiStore.UpdateTabWorkingDir(ctx, sess.ID, sess.WorkingDir); err != nil {
-					slog.Warn("Failed to update tab working dir after in-place load", "error", err)
+					slog.WarnContext(ctx, "Failed to update tab working dir after in-place load", "error", err)
 				}
 			}
 		}
@@ -1077,7 +1077,7 @@ func (m *appModel) handleLoadSession(sessionID string) (tea.Model, tea.Cmd) {
 		return model, cmd
 	}
 
-	slog.Debug("Loading session into new tab", "session_id", sessionID)
+	slog.DebugContext(ctx, "Loading session into new tab", "session_id", sessionID)
 
 	// Spawn a new tab.
 	newSessionID, err := m.supervisor.SpawnSession(ctx, workingDir)
@@ -1088,7 +1088,7 @@ func (m *appModel) handleLoadSession(sessionID string) (tea.Model, tea.Cmd) {
 	// Persist the new tab using the loaded session's persisted ID (not the ephemeral tab ID).
 	if m.tuiStore != nil {
 		if err := m.tuiStore.AddTab(ctx, sess.ID, workingDir); err != nil {
-			slog.Warn("Failed to persist loaded session tab", "error", err)
+			slog.WarnContext(ctx, "Failed to persist loaded session tab", "error", err)
 		}
 	}
 
@@ -1181,7 +1181,7 @@ func (m *appModel) handleClearSession() (tea.Model, tea.Cmd) {
 		ctx := context.Background()
 		oldPersistedID := m.persistedSessionID(activeID)
 		if err := m.tuiStore.UpdateTabSessionID(ctx, oldPersistedID, newSess.ID); err != nil {
-			slog.Warn("Failed to update tab session ID after clear", "error", err)
+			slog.WarnContext(ctx, "Failed to update tab session ID after clear", "error", err)
 		}
 	}
 	m.persistActiveTab(newSess.ID)
@@ -1212,7 +1212,7 @@ func (m *appModel) handleSpawnSession(workingDir string) (tea.Model, tea.Cmd) {
 	// Persist the new tab (for new tabs, persisted ID == runtime tab ID).
 	if m.tuiStore != nil {
 		if err := m.tuiStore.AddTab(ctx, sessionID, workingDir); err != nil {
-			slog.Warn("Failed to persist new tab", "error", err)
+			slog.WarnContext(ctx, "Failed to persist new tab", "error", err)
 		}
 	}
 
@@ -1473,7 +1473,7 @@ func (m *appModel) handleCloseTab(sessionID string) (tea.Model, tea.Cmd) {
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
 		if err := m.tuiStore.RemoveTab(ctx, persistedID); err != nil {
-			slog.Error("Failed to remove tab from store", "error", err)
+			slog.ErrorContext(ctx, "Failed to remove tab from store", "error", err)
 			cmds = append(cmds, notification.ErrorCmd(fmt.Sprintf("Failed to remove tab from tui state db: %v", err)))
 		}
 	}


### PR DESCRIPTION
Follow-up to #2669. That PR converted `slog.{Debug,Info,Warn,Error}` to their `*Context` variants where a `context.Context` was passed in as a parameter, but missed every site where the context was *locally derived* — `ctx := cmd.Context()`, `ctx, cancel := context.WithTimeout(...)`, closures capturing an outer `ctx`, etc. The OpenTelemetry handler we register on `slog` reads trace/span IDs from the active context, so any record emitted via the bare helper drops out of the trace.

This PR adds a custom linter cop that catches those cases automatically, and fixes the ones that were still hiding in the codebase.

## What's in the PR

### `Lint/SlogContextual` cop (`lint/slog_contextual.go`)

A custom rubocop-go cop that flags `slog.{Debug,Info,Warn,Error}(...)` whenever a `context.Context` is reachable in the enclosing function. It recognises:

- parameters and named results of type `context.Context` (named or anonymous);
- locals derived from `ctx := cmd.Context()`, `ctx := context.Background()/TODO()`, and the first return of `context.With*(...)`;
- `var ctx context.Context` and `var ctx = context.Background()` forms;
- closures capturing an outer ctx (`defer func() { slog.Error(...) }()`).

Helpers without an in-scope context are intentionally **not** flagged — rewriting them would force callers to thread a context through APIs that don't otherwise need one. Per-line opt-out via `//rubocop:disable Lint/SlogContextual`.

I tried a type-aware implementation using `types.Scope.Innermost(pos)`, which would have collapsed the cop to ~60 lines, but the rubocop-go runner type-checks each package without an `Importer`, so cross-package types like `context.Context` resolve to "invalid type" and the cop never matches. Stuck with the syntactic version.

### Conversions surfaced by the cop

The cop found **24 bare `slog.X` calls** in functions where a context was already in scope. All converted in this PR:

- `cmd/root/api.go` (4) — defer closures and the top-level "Starting server" log
- `cmd/root/debug.go` (2) — toolset listing errors
- `cmd/root/eval.go` (2) — session save errors
- `cmd/root/pull.go`, `cmd/root/push.go` — "Starting pull/push" debug logs
- `cmd/root/run.go::stopToolSets` — error log inside the cancel-bound scope
- `pkg/fake/proxy.go` (3) — recording-proxy cleanup and VCR request error
- `pkg/tui/handlers.go` (2) and `pkg/tui/tui.go` (7) — tab/session persistence warnings
- `pkg/acp/agent.go` (5) — ACP method handlers; their `context.Context` parameter was anonymous, so the linter fix that picks up anonymous params surfaced these too. Renamed each anonymous param to `ctx` and switched to `slog.DebugContext`.

`cmd/root/flags.go` also moves `ctx := cmd.Context()` above the `loadUserConfig()` call so the now-context-aware `slog.WarnContext` has a context in scope. `cmd.Context()` is just a closure accessor on the captured `cmd`, so calling it earlier is safe.

## Validation

- `task lint` — clean (golangci-lint + 12 custom cops on 948 files)
- `task test` — all packages pass
- `task build` — binary built
- Verified the cop on a 12-case fixture (params, named results, anonymous params, `:=`, multi-return, `cmd.Context()`, `var` forms, closures inheriting outer ctx, closures with their own ctx, `_` discard, no-ctx, already-using-Context-variant) — all expected offenses fired and all non-cases stayed silent.

## Commit history

Each commit is focused so the rationale is easy to follow:

1. `lint: add slog contextual cop and fix remaining bare calls` — the cop and the bulk of the conversions.
2. `simplify slog cop, drop positional scope tracking` — moved `ctx := cmd.Context()` to the top of `flags.go::PersistentPreRunE` so the cop no longer needs per-position scope analysis (1-bit-per-scope is enough).
3. `shorten slog cop using cop.MatchSelector and unifying helpers` — removed `strings` and `context.With*`-specific logic; any call into the `context` package counts.
4. `split slog cop helpers along ast node boundaries` — extracted `reportIfBareSlog` and `valueSpecDeclaresContext`; renamed for symmetry (`signatureDeclaresContext` / `bodyDeclaresContext`).
5. `fix linter: handle anonymous context params and multi-return contexts` — handles `func(context.Context)` and surfaces 5 cases in `pkg/acp/agent.go`.
6. `revert misguided multi-return change in slog cop` — kept the anonymous-param fix from the previous commit; reverted the LHS-position widening, which was a latent false positive for `_, cancel := context.WithCancel(...)` and didn't address any case the cop could actually detect.