### PR TITLE
fix(markdown): avoid infinite loop on hash-prefixed paragraphs; simplify renderer

### DIFF
--- a/pkg/tui/components/markdown/fast_renderer.go
+++ b/pkg/tui/components/markdown/fast_renderer.go
@@ -1492,15 +1492,21 @@ func (p *parser) renderParagraph() {
 			p.lineIdx++
 			break
 		}
-		// Check if next line starts a block element
-		trimmed := strings.TrimLeft(line, " \t")
-		if strings.HasPrefix(trimmed, "#") ||
-			strings.HasPrefix(trimmed, "```") ||
-			strings.HasPrefix(trimmed, "~~~") ||
-			strings.HasPrefix(trimmed, ">") ||
-			isListStart(trimmed) ||
-			isHorizontalRule(trimmed) {
-			break
+		// On subsequent lines, stop the paragraph when a new block element starts.
+		// The first iteration always consumes the current line: parse() has already
+		// determined it isn't a block, so the prefix-based check below would otherwise
+		// loop forever on inputs like "####### foo" or "#nospace" that look like a
+		// heading prefix but were rejected by tryHeading.
+		if len(paraLines) > 0 {
+			trimmed := strings.TrimLeft(line, " \t")
+			if strings.HasPrefix(trimmed, "#") ||
+				strings.HasPrefix(trimmed, "```") ||
+				strings.HasPrefix(trimmed, "~~~") ||
+				strings.HasPrefix(trimmed, ">") ||
+				isListStart(trimmed) ||
+				isHorizontalRule(trimmed) {
+				break
+			}
 		}
 		paraLines = append(paraLines, line)
 		p.lineIdx++

--- a/pkg/tui/components/markdown/fast_renderer.go
+++ b/pkg/tui/components/markdown/fast_renderer.go
@@ -49,66 +49,49 @@ func (s ansiStyle) renderTo(b *strings.Builder, text string) {
 	b.WriteString(s.suffix)
 }
 
-// withBold returns a new style with bold formatting added
-// Bold is applied first, then the parent color, to prevent "bright bold" terminals
-// from overriding the color when bold is enabled.
+// withAttribute returns a new style with the given ANSI attribute layered on
+// top of s while preserving s's color/background. on is the SGR sequence that
+// turns the attribute on (e.g. "\x1b[1m" for bold); off is the matching off
+// sequence (e.g. "\x1b[22m"). When s has no styling the off sequence is
+// replaced with a full reset, matching the behaviour of a fresh style.
+//
+// Format attributes are written before the parent's color/background so that
+// terminals which auto-brighten bold colors do not override our color choice.
+func (s ansiStyle) withAttribute(on, off string) ansiStyle {
+	r := s
+	if s.prefix == "" {
+		r.prefix = on
+		r.suffix = "\x1b[m"
+	} else {
+		r.prefix = on + s.prefix
+		r.suffix = off + s.prefix
+	}
+	return r
+}
+
 func (s ansiStyle) withBold() ansiStyle {
-	if s.prefix == "" {
-		return ansiStyle{prefix: "\x1b[1m", suffix: "\x1b[m", hasBold: true}
-	}
-	return ansiStyle{
-		prefix:    "\x1b[1m" + s.prefix,  // Bold first, then color (prevents bright-bold color override)
-		suffix:    "\x1b[22m" + s.prefix, // Turn off bold, re-apply parent style
-		hasBold:   true,
-		hasStrike: s.hasStrike,
-		hasItalic: s.hasItalic,
-	}
+	r := s.withAttribute("\x1b[1m", "\x1b[22m")
+	r.hasBold = true
+	return r
 }
 
-// withItalic returns a new style with italic formatting added
-// Format attribute applied first, then color, for consistency with withBold.
 func (s ansiStyle) withItalic() ansiStyle {
-	if s.prefix == "" {
-		return ansiStyle{prefix: "\x1b[3m", suffix: "\x1b[m", hasItalic: true}
-	}
-	return ansiStyle{
-		prefix:    "\x1b[3m" + s.prefix,  // Italic first, then color
-		suffix:    "\x1b[23m" + s.prefix, // Turn off italic, re-apply parent style
-		hasBold:   s.hasBold,
-		hasStrike: s.hasStrike,
-		hasItalic: true,
-	}
+	r := s.withAttribute("\x1b[3m", "\x1b[23m")
+	r.hasItalic = true
+	return r
 }
 
-// withBoldItalic returns a new style with bold and italic formatting added
-// Format attributes applied first, then color, to prevent "bright bold" terminals
-// from overriding the color when bold is enabled.
 func (s ansiStyle) withBoldItalic() ansiStyle {
-	if s.prefix == "" {
-		return ansiStyle{prefix: "\x1b[1;3m", suffix: "\x1b[m", hasBold: true, hasItalic: true}
-	}
-	return ansiStyle{
-		prefix:    "\x1b[1;3m" + s.prefix,   // Bold+italic first, then color
-		suffix:    "\x1b[22;23m" + s.prefix, // Turn off bold and italic, re-apply parent style
-		hasBold:   true,
-		hasStrike: s.hasStrike,
-		hasItalic: true,
-	}
+	r := s.withAttribute("\x1b[1;3m", "\x1b[22;23m")
+	r.hasBold = true
+	r.hasItalic = true
+	return r
 }
 
-// withStrikethrough returns a new style with strikethrough formatting added
-// Format attribute applied first, then color, for consistency with withBold.
 func (s ansiStyle) withStrikethrough() ansiStyle {
-	if s.prefix == "" {
-		return ansiStyle{prefix: "\x1b[9m", suffix: "\x1b[m", hasStrike: true}
-	}
-	return ansiStyle{
-		prefix:    "\x1b[9m" + s.prefix,  // Strikethrough first, then color
-		suffix:    "\x1b[29m" + s.prefix, // Turn off strikethrough, re-apply parent style
-		hasBold:   s.hasBold,
-		hasStrike: true,
-		hasItalic: s.hasItalic,
-	}
+	r := s.withAttribute("\x1b[9m", "\x1b[29m")
+	r.hasStrike = true
+	return r
 }
 
 // buildAnsiStyle extracts ANSI codes from a lipgloss style by rendering an empty marker.
@@ -374,35 +357,41 @@ func (p *parser) tryCodeBlock(line string) bool {
 	return true
 }
 
+// headingLevel returns the ATX heading level (1-6) for line, or 0 if line is
+// not a valid ATX heading. A valid heading has 1-6 '#' characters followed by
+// a space, tab, or end of line.
+func headingLevel(line string) int {
+	level := 0
+	for level < len(line) && line[level] == '#' {
+		level++
+	}
+	if level == 0 || level > 6 {
+		return 0
+	}
+	if level == len(line) {
+		return level
+	}
+	if c := line[level]; c == ' ' || c == '\t' {
+		return level
+	}
+	return 0
+}
+
 // tryHeading checks for ATX-style headings (# through ######)
 func (p *parser) tryHeading(line string) bool {
 	trimmed := strings.TrimLeft(line, " \t")
-	if !strings.HasPrefix(trimmed, "#") {
+	level := headingLevel(trimmed)
+	if level == 0 {
 		return false
 	}
 
-	// Count heading level
-	level := 0
-	for i := 0; i < len(trimmed) && trimmed[i] == '#'; i++ {
-		level++
-	}
-	if level > 6 || level == 0 {
-		return false
-	}
-
-	// Must have space after #s or be empty
-	rest := trimmed[level:]
-	if rest != "" && rest[0] != ' ' && rest[0] != '\t' {
-		return false
-	}
-
-	content := strings.TrimSpace(rest)
+	content := strings.TrimSpace(trimmed[level:])
 	// Remove trailing #s
 	content = strings.TrimRight(content, "# \t")
 
-	style := p.headingStyle(level)
-	ansiStyle := p.headingAnsiStyle(level)
-	prefix := p.headingPrefix(level)
+	style := p.styles.headingStyles[level-1]
+	ansiStyle := p.styles.ansiHeadings[level-1]
+	prefix := p.styles.headingPrefixes[level-1]
 
 	// Headings are bold by default. If the entire heading is wrapped in emphasis,
 	// strip the wrapper and only apply italics when requested.
@@ -463,27 +452,6 @@ func (p *parser) tryHeading(line string) bool {
 	p.out.WriteByte('\n')
 	p.lineIdx++
 	return true
-}
-
-func (p *parser) headingStyle(level int) lipgloss.Style {
-	if level >= 1 && level <= 6 {
-		return p.styles.headingStyles[level-1]
-	}
-	return p.styles.headingStyles[0]
-}
-
-func (p *parser) headingAnsiStyle(level int) ansiStyle {
-	if level >= 1 && level <= 6 {
-		return p.styles.ansiHeadings[level-1]
-	}
-	return p.styles.ansiHeadings[0]
-}
-
-func (p *parser) headingPrefix(level int) string {
-	if level >= 1 && level <= 6 {
-		return p.styles.headingPrefixes[level-1]
-	}
-	return ""
 }
 
 // tryHorizontalRule checks for horizontal rules (---, ***, ___)
@@ -1484,6 +1452,9 @@ func (p *parser) renderListBlockquoteCodeBlock(code, lang, indent string, availa
 }
 
 // renderParagraph collects consecutive non-empty lines and renders them as a paragraph.
+// The first line is always consumed: parse() has already verified it isn't a block,
+// so without that guarantee an approximate isBlockStart check could loop forever on
+// inputs like "####### foo" or "#nospace".
 func (p *parser) renderParagraph() {
 	var paraLines []string
 	for p.lineIdx < len(p.lines) {
@@ -1492,21 +1463,8 @@ func (p *parser) renderParagraph() {
 			p.lineIdx++
 			break
 		}
-		// On subsequent lines, stop the paragraph when a new block element starts.
-		// The first iteration always consumes the current line: parse() has already
-		// determined it isn't a block, so the prefix-based check below would otherwise
-		// loop forever on inputs like "####### foo" or "#nospace" that look like a
-		// heading prefix but were rejected by tryHeading.
-		if len(paraLines) > 0 {
-			trimmed := strings.TrimLeft(line, " \t")
-			if strings.HasPrefix(trimmed, "#") ||
-				strings.HasPrefix(trimmed, "```") ||
-				strings.HasPrefix(trimmed, "~~~") ||
-				strings.HasPrefix(trimmed, ">") ||
-				isListStart(trimmed) ||
-				isHorizontalRule(trimmed) {
-				break
-			}
+		if len(paraLines) > 0 && isBlockStart(line) {
+			break
 		}
 		paraLines = append(paraLines, line)
 		p.lineIdx++
@@ -1516,11 +1474,30 @@ func (p *parser) renderParagraph() {
 		return
 	}
 
-	// Join lines and render inline elements
 	text := strings.Join(paraLines, " ")
 	rendered := p.renderInline(text)
 	wrapped := p.wrapText(rendered, p.width)
 	p.out.WriteString(wrapped + "\n\n")
+}
+
+// isBlockStart reports whether line could begin a new block element when
+// encountered inside a paragraph. It mirrors the prefix tests in parse() so a
+// paragraph terminates correctly at the start of the next block.
+func isBlockStart(line string) bool {
+	trimmed := strings.TrimLeft(line, " \t")
+	switch {
+	case headingLevel(trimmed) > 0:
+		return true
+	case strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~"):
+		return true
+	case strings.HasPrefix(trimmed, ">"):
+		return true
+	case isListStart(trimmed):
+		return true
+	case isHorizontalRule(trimmed):
+		return true
+	}
+	return false
 }
 
 func isHorizontalRule(line string) bool {

--- a/pkg/tui/components/markdown/fast_renderer_test.go
+++ b/pkg/tui/components/markdown/fast_renderer_test.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"charm.land/glamour/v2"
 	"github.com/charmbracelet/x/ansi"
@@ -77,6 +78,51 @@ func TestFastRendererHeadings(t *testing.T) {
 			result, err := r.Render(tt.input)
 			require.NoError(t, err)
 			assert.Contains(t, result, tt.contains)
+		})
+	}
+}
+
+// TestFastRendererHashLikeParagraphs ensures the renderer terminates on lines
+// that look like ATX headings but are rejected by tryHeading (7+ hashes, or '#'
+// not followed by whitespace). Previously these caused an infinite loop in
+// parser.parse() because tryHeading returned false without advancing lineIdx,
+// and renderParagraph also bailed out without consuming the line.
+func TestFastRendererHashLikeParagraphs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		contains string
+	}{
+		{"seven hashes", "####### foo", "####### foo"},
+		{"eight hashes", "######## bar", "######## bar"},
+		{"hash without space", "#nospace", "#nospace"},
+		{"double hash without space", "##nospace", "##nospace"},
+		{"hash followed by punctuation", "#tag:value", "#tag:value"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			done := make(chan struct{})
+			var result string
+			var err error
+			go func() {
+				defer close(done)
+				r := NewFastRenderer(80)
+				result, err = r.Render(tt.input)
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+				t.Fatalf("renderer hung on input %q (infinite loop)", tt.input)
+			}
+
+			require.NoError(t, err)
+			assert.Contains(t, stripANSI(result), tt.contains)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Fixes an infinite loop in the custom fast markdown renderer and simplifies the surrounding code.

## Bug

In `pkg/tui/components/markdown/fast_renderer.go`, the top-level `parser.parse()` loop hung on any line that started with `#` but was rejected by `tryHeading`:

- 7 or more leading `#` (e.g. `####### foo`)
- a `#` not followed by space/tab (e.g. `#nospace`)

`tryHeading` returned `false` without advancing `lineIdx`, then `renderParagraph` saw the leading `#` in its block-element prefix check and bailed out before consuming the line, so `lineIdx` never advanced.

## Fix

`renderParagraph` now always consumes the first line — by the time `parse()` calls it, the line has already been rejected by every `try*` parser, so it is unconditionally a paragraph line. The block-boundary check is only applied to subsequent lines.

## Simplifications

- New `headingLevel(line) int` helper replaces the duplicated heading-level parsing inside `tryHeading`. Returns 0 if the line is not a valid ATX heading (1–6 `#` followed by space, tab, or end-of-line).
- New `isBlockStart(line) bool` predicate centralises paragraph-termination detection, and uses `headingLevel` so `####### foo` is no longer mis-classified as a block start.
- Removed three trivial wrapper methods (`headingStyle`, `headingAnsiStyle`, `headingPrefix`) that just indexed a fixed-size array; the call site now indexes directly.
- Replaced ~80 lines of near-duplicated `ansiStyle.withBold` / `withItalic` / `withBoldItalic` / `withStrikethrough` with one shared `withAttribute(on, off)` primitive plus four 4-line wrappers. Behaviour is preserved exactly.

## Tests

Added `TestFastRendererHashLikeParagraphs` covering `####### foo`, `######## bar`, `#nospace`, `##nospace`, and `#tag:value`. Each case is rendered in a goroutine with a 2 s watchdog so a regression fails the test rather than hanging the suite. Verified (by stashing the fix) that the test catches the original infinite loop on all five inputs.

Existing markdown tests continue to pass.