### PR TITLE
feat: add shadow snapshots and undo

### DIFF
--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -65,6 +65,7 @@ type runExecFlags struct {
 	// globalPermissions holds the user-level global permission checker built
 	// from user config settings. Nil when no global permissions are configured.
 	globalPermissions *permissions.Checker
+	snapshotsEnabled  bool
 }
 
 func newRunCmd() *cobra.Command {
@@ -184,6 +185,10 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 	if userSettings.YOLO && !f.autoApprove {
 		f.autoApprove = true
 		slog.DebugContext(ctx, "Applying user settings", "YOLO", true)
+	}
+	if userSettings.SnapshotsEnabled() {
+		f.snapshotsEnabled = true
+		slog.DebugContext(ctx, "Applying user settings", "snapshot", true)
 	}
 
 	// Apply alias options if this is an alias reference
@@ -359,12 +364,16 @@ func (f *runExecFlags) createLocalRuntimeAndSession(ctx context.Context, loadRes
 		AgentDefaultModels: loadResult.AgentDefaultModels,
 	}
 
-	localRt, err := runtime.New(t,
+	runtimeOpts := []runtime.Opt{
 		runtime.WithSessionStore(sessStore),
 		runtime.WithCurrentAgent(agentName),
 		runtime.WithTracer(otel.Tracer(AppName)),
 		runtime.WithModelSwitcherConfig(modelSwitcherCfg),
-	)
+	}
+	if f.snapshotsEnabled {
+		runtimeOpts = append(runtimeOpts, runtime.WithSnapshots(true))
+	}
+	localRt, err := runtime.New(t, runtimeOpts...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating runtime: %w", err)
 	}
@@ -551,12 +560,16 @@ func (f *runExecFlags) createSessionSpawner(agentSource config.Source, sessStore
 		}
 
 		// Create the local runtime
-		localRt, err := runtime.New(t,
+		runtimeOpts := []runtime.Opt{
 			runtime.WithSessionStore(sessStore),
 			runtime.WithCurrentAgent(agt.Name()),
 			runtime.WithTracer(otel.Tracer(AppName)),
 			runtime.WithModelSwitcherConfig(modelSwitcherCfg),
-		)
+		}
+		if f.snapshotsEnabled {
+			runtimeOpts = append(runtimeOpts, runtime.WithSnapshots(true))
+		}
+		localRt, err := runtime.New(t, runtimeOpts...)
 		if err != nil {
 			return nil, nil, nil, err
 		}

--- a/docs/configuration/hooks/index.md
+++ b/docs/configuration/hooks/index.md
@@ -34,31 +34,31 @@ Hooks allow you to execute shell commands or scripts at key points in an agent's
 
 docker-agent dispatches the following hook events:
 
-| Event                       | When it fires                                                                       | Can block? |
-| --------------------------- | ----------------------------------------------------------------------------------- | ---------- |
-| `pre_tool_use`              | Before a tool call executes                                                         | Yes        |
-| `tool_response_transform`   | Between a tool's execution and the runtime's emission/record of the response        | No         |
-| `post_tool_use`             | After a tool completes — fires for both success and failure                         | Yes        |
-| `permission_request`        | Just before the runtime would prompt the user to approve a tool                     | Yes        |
-| `session_start`             | When a session begins or resumes                                                    | No         |
-| `user_prompt_submit`        | Once per user message, after submission and before the model runs                   | Yes        |
-| `turn_start`                | At the start of every agent turn (each model call)                                  | No         |
-| `turn_end`                  | At the end of every agent turn — fires no matter why the turn ended                 | No         |
-| `before_llm_call`           | Just before every model call (after `turn_start`)                                   | Yes        |
-| `after_llm_call`            | After every successful model call, before the response is recorded                  | No         |
-| `session_end`               | When a session terminates                                                           | No         |
-| `pre_compact`               | Just before the runtime compacts the session transcript                             | Yes        |
-| `before_compaction`         | Just before a compaction runs — can veto or supply a custom summary                 | Yes        |
-| `after_compaction`          | After a successful compaction (summary applied to the session)                      | No         |
-| `subagent_stop`             | When a sub-agent (transferred task / background / skill sub-session) finishes       | No         |
-| `on_user_input`             | When the agent is waiting for user input                                            | No         |
-| `stop`                      | When the model finishes responding                                                  | No         |
-| `notification`              | When the agent emits a notification (error or warning)                              | No         |
-| `on_error`                  | When the runtime hits an error during a turn (fires alongside `notification`)       | No         |
-| `on_max_iterations`         | When the runtime reaches its configured `max_iterations` limit                      | No         |
-| `on_agent_switch`           | When the runtime moves the active agent (transfer_task, handoff, return)            | No         |
-| `on_session_resume`         | When the user explicitly approves continuation past `max_iterations`                | No         |
-| `on_tool_approval_decision` | After the runtime's approval chain (yolo / permissions / readonly / ask) resolves   | No         |
+| Event                       | When it fires                                                                     | Can block? |
+| --------------------------- | --------------------------------------------------------------------------------- | ---------- |
+| `pre_tool_use`              | Before a tool call executes                                                       | Yes        |
+| `tool_response_transform`   | Between a tool's execution and the runtime's emission/record of the response      | No         |
+| `post_tool_use`             | After a tool completes — fires for both success and failure                       | Yes        |
+| `permission_request`        | Just before the runtime would prompt the user to approve a tool                   | Yes        |
+| `session_start`             | When a session begins or resumes                                                  | No         |
+| `user_prompt_submit`        | Once per user message, after submission and before the model runs                 | Yes        |
+| `turn_start`                | At the start of every agent turn (each model call)                                | No         |
+| `turn_end`                  | At the end of every agent turn — fires no matter why the turn ended               | No         |
+| `before_llm_call`           | Just before every model call (after `turn_start`)                                 | Yes        |
+| `after_llm_call`            | After every successful model call, before the response is recorded                | No         |
+| `session_end`               | When a session terminates                                                         | No         |
+| `pre_compact`               | Just before the runtime compacts the session transcript                           | Yes        |
+| `before_compaction`         | Just before a compaction runs — can veto or supply a custom summary               | Yes        |
+| `after_compaction`          | After a successful compaction (summary applied to the session)                    | No         |
+| `subagent_stop`             | When a sub-agent (transferred task / background / skill sub-session) finishes     | No         |
+| `on_user_input`             | When the agent is waiting for user input                                          | No         |
+| `stop`                      | When the model finishes responding                                                | No         |
+| `notification`              | When the agent emits a notification (error or warning)                            | No         |
+| `on_error`                  | When the runtime hits an error during a turn (fires alongside `notification`)     | No         |
+| `on_max_iterations`         | When the runtime reaches its configured `max_iterations` limit                    | No         |
+| `on_agent_switch`           | When the runtime moves the active agent (transfer_task, handoff, return)          | No         |
+| `on_session_resume`         | When the user explicitly approves continuation past `max_iterations`              | No         |
+| `on_tool_approval_decision` | After the runtime's approval chain (yolo / permissions / readonly / ask) resolves | No         |
 
 <div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ Two compaction events
@@ -143,18 +143,19 @@ Built-ins are typically zero-config and faster than equivalent shell hooks becau
 
 ### Available built-ins
 
-| Builtin                 | Event             | Args                   | What it does                                                                                                          |
-| ----------------------- | ----------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `add_date`              | `turn_start`      | _none_                 | Prepends `Today's date: YYYY-MM-DD` so the model always knows the current date.                                       |
-| `add_environment_info`  | `session_start`   | _none_                 | Adds the working directory, git-repo status, OS, and CPU architecture.                                                |
-| `add_prompt_files`      | `turn_start`      | `[file1, file2, ...]`  | Reads each named file from the workdir hierarchy (walking up) and the home directory, and appends their contents.     |
-| `add_git_status`        | `turn_start`      | _none_                 | Adds the output of `git status --short --branch` (no-op outside a git repo or when git isn't installed).              |
-| `add_git_diff`          | `turn_start`      | _none_, or `["full"]`  | Adds `git diff --stat` by default. Pass `args: ["full"]` to emit the full unified diff. Output is capped to 4 KB.     |
-| `add_directory_listing` | `session_start`   | _none_                 | Adds an alphabetical listing of the cwd's top-level entries (skips dot-files, capped at 100 with a "... and N more"). |
-| `add_user_info`         | `session_start`   | _none_                 | Adds the current OS user (username and full name) and the hostname.                                                   |
-| `add_recent_commits`    | `session_start`   | _none_, or `["<N>"]`   | Adds `git log --oneline -n N`. `N` defaults to 10; pass a positive integer to override.                               |
-| `max_iterations`        | `before_llm_call` | `["<N>"]` (required)   | Hard-stops the agent after `N` model calls. State is per-session and reset at `session_end`.                          |
-| `redact_secrets`        | `pre_tool_use`, `before_llm_call`, `tool_response_transform` | _none_ | Scrubs detected secrets (API keys, tokens, private keys, …) out of tool call arguments, outgoing chat content, and tool output. The same builtin handles all three events and dispatches on the event name. Auto-registered on all three events by `redact_secrets: true` on the agent — see [`examples/redact_secrets_hooks.yaml`](https://github.com/docker/docker-agent/blob/main/examples/redact_secrets_hooks.yaml) for the manual wiring. |
+| Builtin                 | Event                                                                                     | Args                  | What it does                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| ----------------------- | ----------------------------------------------------------------------------------------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `add_date`              | `turn_start`                                                                              | _none_                | Prepends `Today's date: YYYY-MM-DD` so the model always knows the current date.                                                                                                                                                                                                                                                                                                                                                                 |
+| `add_environment_info`  | `session_start`                                                                           | _none_                | Adds the working directory, git-repo status, OS, and CPU architecture.                                                                                                                                                                                                                                                                                                                                                                          |
+| `add_prompt_files`      | `turn_start`                                                                              | `[file1, file2, ...]` | Reads each named file from the workdir hierarchy (walking up) and the home directory, and appends their contents.                                                                                                                                                                                                                                                                                                                               |
+| `add_git_status`        | `turn_start`                                                                              | _none_                | Adds the output of `git status --short --branch` (no-op outside a git repo or when git isn't installed).                                                                                                                                                                                                                                                                                                                                        |
+| `add_git_diff`          | `turn_start`                                                                              | _none_, or `["full"]` | Adds `git diff --stat` by default. Pass `args: ["full"]` to emit the full unified diff. Output is capped to 4 KB.                                                                                                                                                                                                                                                                                                                               |
+| `add_directory_listing` | `session_start`                                                                           | _none_                | Adds an alphabetical listing of the cwd's top-level entries (skips dot-files, capped at 100 with a "... and N more").                                                                                                                                                                                                                                                                                                                           |
+| `add_user_info`         | `session_start`                                                                           | _none_                | Adds the current OS user (username and full name) and the hostname.                                                                                                                                                                                                                                                                                                                                                                             |
+| `add_recent_commits`    | `session_start`                                                                           | _none_, or `["<N>"]`  | Adds `git log --oneline -n N`. `N` defaults to 10; pass a positive integer to override.                                                                                                                                                                                                                                                                                                                                                         |
+| `max_iterations`        | `before_llm_call`                                                                         | `["<N>"]` (required)  | Hard-stops the agent after `N` model calls. State is per-session and reset at `session_end`.                                                                                                                                                                                                                                                                                                                                                    |
+| `snapshot`              | `session_start`, `turn_start`, `turn_end`, `pre_tool_use`, `post_tool_use`, `session_end` | _none_                | Records filesystem snapshots in a shadow git repo under the docker-agent data directory. No-op outside git repos; respects the source repo's ignore rules and skips newly-added files larger than 2 MiB.                                                                                                                                                                                                                                        |
+| `redact_secrets`        | `pre_tool_use`, `before_llm_call`, `tool_response_transform`                              | _none_                | Scrubs detected secrets (API keys, tokens, private keys, …) out of tool call arguments, outgoing chat content, and tool output. The same builtin handles all three events and dispatches on the event name. Auto-registered on all three events by `redact_secrets: true` on the agent — see [`examples/redact_secrets_hooks.yaml`](https://github.com/docker/docker-agent/blob/main/examples/redact_secrets_hooks.yaml) for the manual wiring. |
 
 <div class="callout callout-info" markdown="1">
 <div class="callout-title">ℹ️ Per-turn vs. per-session
@@ -167,6 +168,32 @@ Built-ins are typically zero-config and faster than equivalent shell hooks becau
 </div>
   <p>The agent flags <code>add_date: true</code>, <code>add_environment_info: true</code>, <code>add_prompt_files: [...]</code>, and <code>redact_secrets: true</code> are shorthands that auto-register the matching built-in hook. You don't need to repeat them under <code>hooks:</code> — set the flag <em>or</em> the hook entry(ies), not both. <code>redact_secrets: true</code> auto-registers the same builtin on all three of <code>pre_tool_use</code>, <code>before_llm_call</code>, and <code>tool_response_transform</code>; you can also wire any subset of them by hand for finer-grained control (per-tool matchers, ordering with other rewriters, …).</p>
 </div>
+
+A minimal snapshot wiring looks like this:
+
+```yaml
+hooks:
+  turn_start:
+    - type: builtin
+      command: snapshot
+  turn_end:
+    - type: builtin
+      command: snapshot
+  session_end:
+    - type: builtin
+      command: snapshot
+```
+
+The shadow repository stores tree objects only; it never writes commits or touches the source repository's `.git` directory. The source repository's `.gitignore` and `info/exclude` rules are mirrored before each capture so ignored files do not appear in snapshots. The built-in only records undo checkpoints when files changed, so a final no-op model response does not hide the last changed snapshot.
+
+You can also enable snapshots globally for every agent with user config:
+
+```yaml
+settings:
+  snapshot: true
+```
+
+Omit `snapshot` or set it to `false` to leave automatic snapshots off; manually configured snapshot hooks still run.
 
 <div class="callout callout-warning" markdown="1">
 <div class="callout-title">⚠️ Two flavors of <code>max_iterations</code>
@@ -207,41 +234,41 @@ Hooks receive JSON input via stdin with context about the event:
 
 Every hook event carries:
 
-| Field             | Description                                      |
-| ----------------- | ------------------------------------------------ |
-| `session_id`      | The current session's ID.                        |
-| `cwd`             | The runtime's working directory.                 |
-| `hook_event_name` | The event name (e.g. `pre_tool_use`).            |
+| Field             | Description                           |
+| ----------------- | ------------------------------------- |
+| `session_id`      | The current session's ID.             |
+| `cwd`             | The runtime's working directory.      |
+| `hook_event_name` | The event name (e.g. `pre_tool_use`). |
 
 ### Per-Event Extra Fields
 
 In addition to the common fields, each event ships its own payload:
 
-| Event                       | Extra fields                                                                                                  |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `pre_tool_use`              | `tool_name`, `tool_use_id`, `tool_input`                                                                      |
-| `tool_response_transform`   | `tool_name`, `tool_use_id`, `tool_input`, `tool_response`                                                     |
-| `post_tool_use`             | `tool_name`, `tool_use_id`, `tool_input`, `tool_response`, `tool_error`                                       |
-| `permission_request`        | `tool_name`, `tool_use_id`, `tool_input`                                                                      |
-| `session_start`             | `source` — one of `startup`, `resume`, `clear`, `compact`                                                     |
-| `user_prompt_submit`        | `prompt` — the text the user just submitted                                                                   |
-| `turn_start`                | _none_ (just the common fields)                                                                               |
+| Event                       | Extra fields                                                                                                          |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `pre_tool_use`              | `tool_name`, `tool_use_id`, `tool_input`                                                                              |
+| `tool_response_transform`   | `tool_name`, `tool_use_id`, `tool_input`, `tool_response`                                                             |
+| `post_tool_use`             | `tool_name`, `tool_use_id`, `tool_input`, `tool_response`, `tool_error`                                               |
+| `permission_request`        | `tool_name`, `tool_use_id`, `tool_input`                                                                              |
+| `session_start`             | `source` — one of `startup`, `resume`, `clear`, `compact`                                                             |
+| `user_prompt_submit`        | `prompt` — the text the user just submitted                                                                           |
+| `turn_start`                | _none_ (just the common fields)                                                                                       |
 | `turn_end`                  | `agent_name`, `reason` — one of `normal`, `continue`, `steered`, `error`, `canceled`, `hook_blocked`, `loop_detected` |
-| `before_llm_call`           | _none_                                                                                                        |
-| `after_llm_call`            | `agent_name`, `stop_response`, `last_user_message`                                                            |
-| `session_end`               | `reason` — one of `clear`, `logout`, `prompt_input_exit`, `other`                                             |
-| `pre_compact`               | `source` — one of `manual`, `auto`, `overflow`, `tool_overflow`                                               |
-| `before_compaction`         | `input_tokens`, `output_tokens`, `context_limit`, `compaction_reason` (one of `threshold`/`overflow`/`manual`)|
-| `after_compaction`          | `input_tokens`, `output_tokens`, `context_limit`, `compaction_reason`, `summary`                              |
-| `subagent_stop`             | `agent_name` (the sub-agent), `parent_session_id`, `stop_response`                                            |
-| `on_user_input`             | _none_                                                                                                        |
-| `stop`                      | `agent_name`, `stop_response`, `last_user_message`                                                            |
-| `notification`              | `notification_level` (`error` or `warning`), `notification_message`                                           |
-| `on_error`                  | `notification_level` (always `error`), `notification_message`                                                 |
-| `on_max_iterations`         | `notification_level` (always `warning`), `notification_message`                                               |
-| `on_agent_switch`           | `from_agent`, `to_agent`, `agent_switch_kind` (`transfer_task`, `transfer_task_return`, or `handoff`)         |
-| `on_session_resume`         | `previous_max_iterations`, `new_max_iterations`                                                               |
-| `on_tool_approval_decision` | `tool_name`, `tool_use_id`, `tool_input`, `approval_decision`, `approval_source`                              |
+| `before_llm_call`           | _none_                                                                                                                |
+| `after_llm_call`            | `agent_name`, `stop_response`, `last_user_message`                                                                    |
+| `session_end`               | `reason` — one of `clear`, `logout`, `prompt_input_exit`, `other`                                                     |
+| `pre_compact`               | `source` — one of `manual`, `auto`, `overflow`, `tool_overflow`                                                       |
+| `before_compaction`         | `input_tokens`, `output_tokens`, `context_limit`, `compaction_reason` (one of `threshold`/`overflow`/`manual`)        |
+| `after_compaction`          | `input_tokens`, `output_tokens`, `context_limit`, `compaction_reason`, `summary`                                      |
+| `subagent_stop`             | `agent_name` (the sub-agent), `parent_session_id`, `stop_response`                                                    |
+| `on_user_input`             | _none_                                                                                                                |
+| `stop`                      | `agent_name`, `stop_response`, `last_user_message`                                                                    |
+| `notification`              | `notification_level` (`error` or `warning`), `notification_message`                                                   |
+| `on_error`                  | `notification_level` (always `error`), `notification_message`                                                         |
+| `on_max_iterations`         | `notification_level` (always `warning`), `notification_message`                                                       |
+| `on_agent_switch`           | `from_agent`, `to_agent`, `agent_switch_kind` (`transfer_task`, `transfer_task_return`, or `handoff`)                 |
+| `on_session_resume`         | `previous_max_iterations`, `new_max_iterations`                                                                       |
+| `on_tool_approval_decision` | `tool_name`, `tool_use_id`, `tool_input`, `approval_decision`, `approval_source`                                      |
 
 Notes:
 
@@ -299,9 +326,9 @@ The `hook_specific_output` for `pre_tool_use` (and `permission_request`) support
 
 The `hook_specific_output` for `tool_response_transform` supports:
 
-| Field                    | Type   | Description                                       |
-| ------------------------ | ------ | ------------------------------------------------- |
-| `updated_tool_response`  | string | Rewritten tool output (replaces the original)     |
+| Field                   | Type   | Description                                   |
+| ----------------------- | ------ | --------------------------------------------- |
+| `updated_tool_response` | string | Rewritten tool output (replaces the original) |
 
 This is the symmetric counterpart of `pre_tool_use`'s `updated_input`, applied to tool **results** instead of tool **arguments**. The rewrite reaches every downstream consumer — event subscribers, the persisted session file, the `post_tool_use` hook input, and the next LLM call. Use it to truncate excessive output, scrub PII, or normalise tool dialects. The built-in `redact_secrets` registers itself on this event as the third leg of the redact_secrets feature.
 
@@ -503,15 +530,15 @@ Use `on_error` and `on_max_iterations` instead of `notification` when you want a
 
 The `reason` field classifies the exit:
 
-| `reason`        | When |
-| --------------- | ---- |
-| `normal`        | Model finished cleanly with no follow-up |
+| `reason`        | When                                                         |
+| --------------- | ------------------------------------------------------------ |
+| `normal`        | Model finished cleanly with no follow-up                     |
 | `continue`      | More iterations to come (e.g. tool calls, follow-up message) |
-| `steered`       | Drained steered messages prompted a re-entry |
-| `error`         | Model call failed (`handleStreamError` exited the loop) |
-| `canceled`      | Context was cancelled (e.g. Ctrl+C) |
-| `hook_blocked`  | `before_llm_call` or `post_tool_use` denied the call |
-| `loop_detected` | The consecutive-tool-call loop detector terminated the turn |
+| `steered`       | Drained steered messages prompted a re-entry                 |
+| `error`         | Model call failed (`handleStreamError` exited the loop)      |
+| `canceled`      | Context was cancelled (e.g. Ctrl+C)                          |
+| `hook_blocked`  | `before_llm_call` or `post_tool_use` denied the call         |
+| `loop_detected` | The consecutive-tool-call loop detector terminated the turn  |
 
 `turn_end` is observational — the result is ignored. Use it to time turns, accumulate per-turn metrics (token usage, tool counts), or notify external observability pipelines symmetrically with `turn_start`.
 
@@ -614,12 +641,12 @@ hooks:
             - Writes to ~/.ssh / ~/.aws / ~/.docker are deny.
 ```
 
-| Field    | Required          | Description                                                                                                                                                                |
-| -------- | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `model`  | yes               | Model spec (`provider/model`, e.g. `openai/gpt-4o-mini`). The judge model — small/cheap is recommended.                                                                    |
-| `prompt` | yes               | Go [`text/template`](https://pkg.go.dev/text/template) body. Sees the hook [Input](#hook-input) as data, plus the `toJSON` and `truncate <n>` helpers.                     |
-| `schema` | no                | Well-known response interpretation. `pre_tool_use_decision` produces a `permission_decision` verdict; omit for free-form text injected as `additional_context`.            |
-| `timeout`| no (default 60s)  | Per-call timeout. **Timeouts fail closed (deny) for `pre_tool_use`** regardless of any other setting. Match it to your judge model's typical latency plus a small buffer. |
+| Field     | Required         | Description                                                                                                                                                               |
+| --------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `model`   | yes              | Model spec (`provider/model`, e.g. `openai/gpt-4o-mini`). The judge model — small/cheap is recommended.                                                                   |
+| `prompt`  | yes              | Go [`text/template`](https://pkg.go.dev/text/template) body. Sees the hook [Input](#hook-input) as data, plus the `toJSON` and `truncate <n>` helpers.                    |
+| `schema`  | no               | Well-known response interpretation. `pre_tool_use_decision` produces a `permission_decision` verdict; omit for free-form text injected as `additional_context`.           |
+| `timeout` | no (default 60s) | Per-call timeout. **Timeouts fail closed (deny) for `pre_tool_use`** regardless of any other setting. Match it to your judge model's typical latency plus a small buffer. |
 
 The `pre_tool_use_decision` schema constrains the judge to reply with
 strict `{decision, reason}` JSON. Providers that honor structured
@@ -649,14 +676,14 @@ for a complete configuration.
 
 You can add hooks from the command line without modifying the agent's YAML file. This is useful for one-off debugging, audit logging, or layering hooks onto an existing agent.
 
-| Flag                    | Description                             |
-| ----------------------- | --------------------------------------- |
-| `--hook-pre-tool-use`   | Run a command before every tool call    |
-| `--hook-post-tool-use`  | Run a command after every tool call     |
-| `--hook-session-start`  | Run a command when a session starts     |
-| `--hook-session-end`    | Run a command when a session ends       |
-| `--hook-on-user-input`  | Run a command when waiting for input    |
-| `--hook-stop`           | Run a command when the model finishes responding |
+| Flag                   | Description                                      |
+| ---------------------- | ------------------------------------------------ |
+| `--hook-pre-tool-use`  | Run a command before every tool call             |
+| `--hook-post-tool-use` | Run a command after every tool call              |
+| `--hook-session-start` | Run a command when a session starts              |
+| `--hook-session-end`   | Run a command when a session ends                |
+| `--hook-on-user-input` | Run a command when waiting for input             |
+| `--hook-stop`          | Run a command when the model finishes responding |
 
 All flags are repeatable — pass multiple to register multiple hooks.
 

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -40,6 +40,7 @@ Type `/` during a session to see available commands, or press <kbd>Ctrl</kbd>+<k
 | `/fork`            | Fork the current session into a new branch                                           |
 | `/copy`            | Copy the entire conversation to clipboard                                            |
 | `/copy-last`       | Copy only the last assistant message to clipboard                                    |
+| `/undo`            | Restore file changes from the latest snapshot                                       |
 | `/export`          | Export the session as HTML                                                           |
 | `/sessions`        | Browse and load past sessions                                                        |
 | `/model`           | Change the model for the current agent                                               |
@@ -58,6 +59,17 @@ Type `/` during a session to see available commands, or press <kbd>Ctrl</kbd>+<k
 | `/split-diff`      | Toggle split-diff view for file edits                                                |
 | `/speak`           | Voice input via system speech-to-text (macOS only)                                   |
 | `/exit`            | Exit the application (aliases: `/quit`, `/q`)                                        |
+
+### Snapshots and `/undo`
+
+Enable shadow-git snapshots globally in `~/.config/cagent/config.yaml`:
+
+```yaml
+settings:
+  snapshot: true
+```
+
+When enabled, docker-agent records filesystem snapshots at turn boundaries. `/undo` restores files from the most recent changed snapshot; it does **not** remove messages from the session transcript. Omit `snapshot` or set it to `false` to leave automatic snapshots off; agents can still configure snapshot hooks manually.
 
 ## File Attachments
 

--- a/examples/hooks.yaml
+++ b/examples/hooks.yaml
@@ -46,6 +46,9 @@
 #               add_user_info         (session_start)
 #               add_recent_commits    (session_start; args = ["<N>"], default 10)
 #               max_iterations        (before_llm_call; args = ["<N>"], hard stop)
+#               snapshot              (session_start / turn_start / turn_end /
+#                                      pre_tool_use / post_tool_use / session_end;
+#                                      shadow-git filesystem snapshots)
 #
 # Requirements: the command-style hooks below pipe stdin through `jq` for
 # convenient JSON access. If you don't have jq installed (`brew install jq`

--- a/examples/snapshot_hooks.yaml
+++ b/examples/snapshot_hooks.yaml
@@ -1,0 +1,41 @@
+#!/usr/bin/env docker agent run
+#
+# Shadow-git snapshot hook
+# ------------------------
+# Records filesystem snapshots under the docker-agent data
+# directory (`~/.cagent/snapshot/...` by default) without touching the
+# source repository's `.git` directory.
+#
+# The builtin is a no-op outside git repositories. It mirrors the source
+# repo's ignore rules and skips newly-added files larger than 2 MiB.
+#
+# To enable the same turn-level snapshots for every agent, set this in
+# ~/.config/cagent/config.yaml instead of wiring hooks manually:
+#
+# settings:
+#   snapshot: true
+
+agents:
+  root:
+    model: openai/gpt-5-mini
+    description: Coder with shadow-git snapshots enabled
+    instruction: |
+      You are a coding assistant. Make focused changes and explain what you changed.
+    toolsets:
+      - type: shell
+      - type: filesystem
+    hooks:
+      # Per-turn snapshots: capture before the model call and after the
+      # resulting tool batch finishes.
+      turn_start:
+        - type: builtin
+          command: snapshot
+      turn_end:
+        - type: builtin
+          command: snapshot
+
+      # Runs git gc on the shadow repo. Undo checkpoints stay available after
+      # the response stops so `/undo` can restore the latest changed snapshot.
+      session_end:
+        - type: builtin
+          command: snapshot

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -17,7 +17,12 @@ import (
 )
 
 // mockRuntime is a minimal mock for testing App without a real runtime
-type mockRuntime struct{}
+type mockRuntime struct {
+	store     session.Store
+	undoFiles int
+	undoOK    bool
+	undoErr   error
+}
 
 func (m *mockRuntime) CurrentAgentInfo(ctx context.Context) runtime.CurrentAgentInfo {
 	return runtime.CurrentAgentInfo{}
@@ -47,7 +52,7 @@ func (m *mockRuntime) Resume(ctx context.Context, req runtime.ResumeRequest) {}
 func (m *mockRuntime) ResumeElicitation(ctx context.Context, action tools.ElicitationAction, content map[string]any) error {
 	return nil
 }
-func (m *mockRuntime) SessionStore() session.Store { return nil }
+func (m *mockRuntime) SessionStore() session.Store { return m.store }
 func (m *mockRuntime) Summarize(ctx context.Context, sess *session.Session, additionalPrompt string, events chan runtime.Event) {
 }
 func (m *mockRuntime) PermissionsInfo() *runtime.PermissionsInfo { return nil }
@@ -72,6 +77,9 @@ func (m *mockRuntime) Close() error                            { return nil }
 func (m *mockRuntime) Stop()                                   {}
 func (m *mockRuntime) Steer(_ runtime.QueuedMessage) error     { return nil }
 func (m *mockRuntime) FollowUp(_ runtime.QueuedMessage) error  { return nil }
+func (m *mockRuntime) UndoLastSnapshot(context.Context, *session.Session) (int, bool, error) {
+	return m.undoFiles, m.undoOK, m.undoErr
+}
 
 // Verify mockRuntime implements runtime.Runtime
 var _ runtime.Runtime = (*mockRuntime)(nil)
@@ -225,6 +233,25 @@ func TestApp_ResolveSkillCommand_NotSlashCommand(t *testing.T) {
 	resolved, err := app.ResolveSkillCommand(ctx, "not a slash command")
 	require.NoError(t, err)
 	assert.Empty(t, resolved)
+}
+
+func TestApp_UndoLastSnapshot(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	app := New(ctx, &mockRuntime{undoFiles: 2, undoOK: true}, session.New())
+	result, err := app.UndoLastSnapshot(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.RestoredFiles)
+}
+
+func TestApp_UndoLastSnapshot_NoSnapshot(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	app := New(ctx, &mockRuntime{}, session.New())
+	_, err := app.UndoLastSnapshot(ctx)
+	assert.ErrorIs(t, err, ErrNothingToUndo)
 }
 
 func TestApp_RegenerateSessionTitle(t *testing.T) {

--- a/pkg/app/undo.go
+++ b/pkg/app/undo.go
@@ -1,0 +1,37 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/docker/docker-agent/pkg/session"
+)
+
+var ErrNothingToUndo = errors.New("nothing to undo")
+
+type UndoSnapshotResult struct {
+	RestoredFiles int
+}
+
+type snapshotUndoer interface {
+	UndoLastSnapshot(ctx context.Context, sess *session.Session) (files int, ok bool, err error)
+}
+
+func (a *App) UndoLastSnapshot(ctx context.Context) (UndoSnapshotResult, error) {
+	if a.session == nil {
+		return UndoSnapshotResult{}, ErrNothingToUndo
+	}
+	undoer, ok := a.runtime.(snapshotUndoer)
+	if !ok {
+		return UndoSnapshotResult{}, ErrNothingToUndo
+	}
+	files, ok, err := undoer.UndoLastSnapshot(ctx, a.session)
+	if err != nil {
+		return UndoSnapshotResult{}, fmt.Errorf("restoring snapshot: %w", err)
+	}
+	if !ok {
+		return UndoSnapshotResult{}, ErrNothingToUndo
+	}
+	return UndoSnapshotResult{RestoredFiles: files}, nil
+}

--- a/pkg/hooks/builtins/builtins.go
+++ b/pkg/hooks/builtins/builtins.go
@@ -12,6 +12,10 @@
 //   - add_user_info         (session_start)   — current OS user and host
 //   - add_recent_commits    (session_start)   — `git log --oneline -n N`
 //   - max_iterations        (before_llm_call) — hard stop after N model calls
+//   - snapshot              (session_start,
+//     turn_start, turn_end,
+//     pre_tool_use, post_tool_use,
+//     session_end) — shadow-git snapshots
 //   - redact_secrets        (pre_tool_use,
 //     before_llm_call,
 //     tool_response_transform) — scrub secrets
@@ -23,8 +27,9 @@
 // Reference any of them from a hook YAML entry as
 // `{type: builtin, command: "<name>"}`. The runtime additionally
 // auto-injects add_date / add_environment_info / add_prompt_files /
-// redact_secrets from the matching agent flags. Setting
-// redact_secrets at the agent level is exactly equivalent to writing
+// redact_secrets from the matching agent flags, and snapshot from
+// global user config. Setting redact_secrets at the agent level is
+// exactly equivalent to writing
 // the three matching hook entries by hand —
 // [ApplyAgentDefaults] performs the auto-injection.
 //
@@ -33,6 +38,10 @@
 // stable for its duration. max_iterations is stateful: its
 // per-session counter lives on the [State] returned by [Register];
 // the runtime clears it via [State.ClearSession] from session_end.
+// snapshot is also stateful: it keeps per-session turn/tool snapshot
+// hashes and undo checkpoints in memory while the shadow git objects live
+// under the data directory. Undo checkpoints intentionally survive the
+// RunStream session_end cleanup so /undo can run after the response stops.
 //
 // LLM-as-a-judge hooks are NOT shipped here: write `type: model` with
 // `schema: pre_tool_use_decision` instead — see
@@ -40,6 +49,7 @@
 package builtins
 
 import (
+	"context"
 	"errors"
 
 	"github.com/docker/docker-agent/pkg/hooks"
@@ -50,9 +60,10 @@ import (
 // entries on session_end. Stateless builtins don't appear here.
 type State struct {
 	maxIterations *maxIterationsBuiltin
+	snapshot      *snapshotBuiltin
 }
 
-// ClearSession drops per-session state from every stateful builtin.
+// ClearSession drops per-RunStream state that should not survive stream teardown.
 // A nil receiver is a no-op.
 func (s *State) ClearSession(sessionID string) {
 	if s == nil || sessionID == "" {
@@ -61,11 +72,20 @@ func (s *State) ClearSession(sessionID string) {
 	s.maxIterations.clearSession(sessionID)
 }
 
+// UndoLastSnapshot restores files from the latest completed snapshot checkpoint.
+func (s *State) UndoLastSnapshot(ctx context.Context, sessionID, cwd string) (files int, ok bool, err error) {
+	if s == nil || s.snapshot == nil || sessionID == "" || cwd == "" {
+		return 0, false, nil
+	}
+	return s.snapshot.undoLast(ctx, sessionID, cwd)
+}
+
 // Register installs the stock builtin hooks on r and returns a [State]
-// handle the caller must use to clear per-session state on session_end.
+// handle the caller can use for stateful builtin operations.
 func Register(r *hooks.Registry) (*State, error) {
 	state := &State{
 		maxIterations: newMaxIterations(),
+		snapshot:      newSnapshotBuiltin(),
 	}
 	if err := errors.Join(
 		r.RegisterBuiltin(AddDate, addDate),
@@ -77,6 +97,7 @@ func Register(r *hooks.Registry) (*State, error) {
 		r.RegisterBuiltin(AddUserInfo, addUserInfo),
 		r.RegisterBuiltin(AddRecentCommits, addRecentCommits),
 		r.RegisterBuiltin(MaxIterations, state.maxIterations.hook),
+		r.RegisterBuiltin(Snapshot, state.snapshot.hook),
 		r.RegisterBuiltin(RedactSecrets, redactSecrets),
 	); err != nil {
 		return nil, err
@@ -84,8 +105,8 @@ func Register(r *hooks.Registry) (*State, error) {
 	return state, nil
 }
 
-// AgentDefaults captures the agent-level flags that map onto stock
-// builtin hook entries. Pass each AgentConfig.AddXxx flag as-is.
+// AgentDefaults captures defaults that map onto stock builtin hook entries.
+// Pass each AgentConfig.AddXxx flag as-is; Snapshot comes from runtime/global config.
 type AgentDefaults struct {
 	AddDate            bool
 	AddEnvironmentInfo bool
@@ -97,6 +118,10 @@ type AgentDefaults struct {
 	// makes the auto-injection idempotent against an explicit YAML
 	// entry that already names the same builtin.
 	RedactSecrets bool
+	// Snapshot auto-injects shadow-git snapshots at
+	// turn boundaries. session_end is included to garbage-collect the
+	// shadow repository; undo history remains available after a response stops.
+	Snapshot bool
 }
 
 // ApplyAgentDefaults appends the stock builtin hook entries implied by
@@ -114,6 +139,12 @@ func ApplyAgentDefaults(cfg *hooks.Config, d AgentDefaults) *hooks.Config {
 	}
 	if d.AddEnvironmentInfo {
 		cfg.SessionStart = append(cfg.SessionStart, builtinHook(AddEnvironmentInfo))
+	}
+	if d.Snapshot {
+		cfg.SessionStart = append(cfg.SessionStart, builtinHook(Snapshot))
+		cfg.TurnStart = append(cfg.TurnStart, builtinHook(Snapshot))
+		cfg.TurnEnd = append(cfg.TurnEnd, builtinHook(Snapshot))
+		cfg.SessionEnd = append(cfg.SessionEnd, builtinHook(Snapshot))
 	}
 	if d.RedactSecrets {
 		// Wire all three legs at once. The same builtin handles each

--- a/pkg/hooks/builtins/builtins_test.go
+++ b/pkg/hooks/builtins/builtins_test.go
@@ -34,6 +34,7 @@ func TestRegisterInstallsAllBuiltins(t *testing.T) {
 		builtins.AddUserInfo,
 		builtins.AddRecentCommits,
 		builtins.MaxIterations,
+		builtins.Snapshot,
 		builtins.RedactSecrets,
 	} {
 		fn, ok := r.LookupBuiltin(name)
@@ -219,10 +220,23 @@ func TestApplyAgentDefaultsInjectsExpectedEvents(t *testing.T) {
 	assert.Equal(t, builtins.AddEnvironmentInfo, cfg.SessionStart[0].Command)
 }
 
-// TestApplyAgentDefaultsAppendsToUserHooks documents that auto-injected
-// builtins coexist with user-authored entries — they're appended, not
-// replaced. The executor's dedup logic then collapses any overlap so
-// a user-authored `add_date` plus `addDate=true` runs exactly once.
+// TestApplyAgentDefaultsInjectsSnapshotHooks verifies the global snapshot
+// default wires turn-boundary capture plus session_end shadow-repo cleanup.
+func TestApplyAgentDefaultsInjectsSnapshotHooks(t *testing.T) {
+	t.Parallel()
+
+	cfg := builtins.ApplyAgentDefaults(nil, builtins.AgentDefaults{Snapshot: true})
+	require.NotNil(t, cfg)
+	require.Len(t, cfg.SessionStart, 1)
+	require.Len(t, cfg.TurnStart, 1)
+	require.Len(t, cfg.TurnEnd, 1)
+	require.Len(t, cfg.SessionEnd, 1)
+	assert.Equal(t, builtins.Snapshot, cfg.SessionStart[0].Command)
+	assert.Equal(t, builtins.Snapshot, cfg.TurnStart[0].Command)
+	assert.Equal(t, builtins.Snapshot, cfg.TurnEnd[0].Command)
+	assert.Equal(t, builtins.Snapshot, cfg.SessionEnd[0].Command)
+}
+
 func TestApplyAgentDefaultsAppendsToUserHooks(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/hooks/builtins/snapshot.go
+++ b/pkg/hooks/builtins/snapshot.go
@@ -1,0 +1,219 @@
+package builtins
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+
+	"github.com/docker/docker-agent/pkg/hooks"
+	"github.com/docker/docker-agent/pkg/snapshot"
+)
+
+// Snapshot is the registered name of the snapshot builtin.
+const Snapshot = "snapshot"
+
+type snapshotBuiltin struct {
+	manager *snapshot.Manager
+	mu      sync.Mutex
+	session map[string]*snapshotSession
+}
+
+type snapshotSession struct {
+	turn    string
+	tools   map[string]string
+	history []snapshotCheckpoint
+}
+
+type snapshotCheckpoint struct {
+	hash  string
+	files []string
+}
+
+func newSnapshotBuiltin() *snapshotBuiltin {
+	return &snapshotBuiltin{
+		manager: snapshot.NewManager(""),
+		session: map[string]*snapshotSession{},
+	}
+}
+
+func (b *snapshotBuiltin) hook(ctx context.Context, in *hooks.Input, _ []string) (*hooks.Output, error) {
+	if in == nil || in.Cwd == "" || in.SessionID == "" {
+		return nil, nil
+	}
+	repo, err := b.manager.Open(ctx, in.Cwd)
+	if err != nil {
+		if errors.Is(err, snapshot.ErrNotGitRepository) {
+			return nil, nil
+		}
+		slog.DebugContext(ctx, "snapshot hook: open repository failed; skipping", "cwd", in.Cwd, "error", err)
+		return nil, nil
+	}
+
+	track := func() (string, bool) {
+		hash, err := repo.Track(ctx)
+		if err != nil {
+			slog.DebugContext(ctx, "snapshot hook: track failed", "cwd", in.Cwd, "error", err)
+			return "", false
+		}
+		return hash, true
+	}
+	patchFrom := func(hash string) (snapshot.Patch, string, bool) {
+		after, ok := track()
+		if !ok {
+			return snapshot.Patch{}, "", false
+		}
+		patch, err := repo.Patch(ctx, hash)
+		if err != nil {
+			slog.DebugContext(ctx, "snapshot hook: patch failed", "cwd", in.Cwd, "hash", hash, "error", err)
+			return snapshot.Patch{}, "", false
+		}
+		return patch, after, true
+	}
+
+	switch in.HookEventName {
+	case hooks.EventSessionStart:
+		track()
+	case hooks.EventTurnStart:
+		if hash, ok := track(); ok {
+			b.setTurn(in.SessionID, hash)
+		}
+	case hooks.EventPreToolUse:
+		if hash, ok := track(); ok {
+			b.setTool(in.SessionID, in.ToolUseID, hash)
+		}
+	case hooks.EventPostToolUse:
+		hash := b.popTool(in.SessionID, in.ToolUseID)
+		if hash == "" {
+			return nil, nil
+		}
+		if patch, after, ok := patchFrom(hash); ok {
+			b.pushCheckpoint(in.SessionID, snapshotCheckpoint{hash: hash, files: patch.Files})
+			logPatch(ctx, "tool", in.SessionID, in.ToolName, patch, after)
+		}
+	case hooks.EventTurnEnd:
+		hash := b.popTurn(in.SessionID)
+		if hash == "" {
+			return nil, nil
+		}
+		if patch, after, ok := patchFrom(hash); ok {
+			b.pushCheckpoint(in.SessionID, snapshotCheckpoint{hash: hash, files: patch.Files})
+			logPatch(ctx, "turn", in.SessionID, in.Reason, patch, after)
+		}
+	case hooks.EventSessionEnd:
+		if err := repo.Cleanup(ctx); err != nil {
+			slog.DebugContext(ctx, "snapshot hook: cleanup failed", "cwd", in.Cwd, "error", err)
+		}
+	default:
+		slog.DebugContext(ctx, "snapshot hook configured on unsupported event; skipping", "event", in.HookEventName)
+	}
+	return nil, nil
+}
+
+func (b *snapshotBuiltin) getSession(sessionID string) *snapshotSession {
+	s := b.session[sessionID]
+	if s == nil {
+		s = &snapshotSession{tools: map[string]string{}}
+		b.session[sessionID] = s
+	}
+	return s
+}
+
+func (b *snapshotBuiltin) setTurn(sessionID, hash string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.getSession(sessionID).turn = hash
+}
+
+func (b *snapshotBuiltin) popTurn(sessionID string) string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	s := b.session[sessionID]
+	if s == nil {
+		return ""
+	}
+	hash := s.turn
+	s.turn = ""
+	return hash
+}
+
+func (b *snapshotBuiltin) setTool(sessionID, toolUseID, hash string) {
+	if toolUseID == "" {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.getSession(sessionID).tools[toolUseID] = hash
+}
+
+func (b *snapshotBuiltin) popTool(sessionID, toolUseID string) string {
+	if toolUseID == "" {
+		return ""
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	s := b.session[sessionID]
+	if s == nil {
+		return ""
+	}
+	hash := s.tools[toolUseID]
+	delete(s.tools, toolUseID)
+	return hash
+}
+
+func (b *snapshotBuiltin) pushCheckpoint(sessionID string, checkpoint snapshotCheckpoint) {
+	if len(checkpoint.files) == 0 {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	s := b.getSession(sessionID)
+	s.history = append(s.history, checkpoint)
+}
+
+func (b *snapshotBuiltin) popCheckpoint(sessionID string) (snapshotCheckpoint, bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	s := b.session[sessionID]
+	if s == nil || len(s.history) == 0 {
+		return snapshotCheckpoint{}, false
+	}
+	last := len(s.history) - 1
+	checkpoint := s.history[last]
+	s.history[last] = snapshotCheckpoint{}
+	s.history = s.history[:last]
+	return checkpoint, true
+}
+
+func (b *snapshotBuiltin) undoLast(ctx context.Context, sessionID, cwd string) (files int, ok bool, err error) {
+	checkpoint, ok := b.popCheckpoint(sessionID)
+	if !ok {
+		return 0, false, nil
+	}
+	if len(checkpoint.files) == 0 {
+		return 0, true, nil
+	}
+	repo, err := b.manager.Open(ctx, cwd)
+	if err != nil {
+		return 0, true, err
+	}
+	patch := snapshot.Patch{Hash: checkpoint.hash, Files: checkpoint.files}
+	if err := repo.Revert(ctx, []snapshot.Patch{patch}); err != nil {
+		return 0, true, err
+	}
+	return len(checkpoint.files), true, nil
+}
+
+func logPatch(ctx context.Context, scope, sessionID, label string, patch snapshot.Patch, after string) {
+	if len(patch.Files) == 0 {
+		return
+	}
+	slog.DebugContext(ctx, "snapshot captured changes",
+		"scope", scope,
+		"session_id", sessionID,
+		"label", label,
+		"hash", patch.Hash,
+		"after", after,
+		"files", len(patch.Files),
+	)
+}

--- a/pkg/hooks/builtins/snapshot_test.go
+++ b/pkg/hooks/builtins/snapshot_test.go
@@ -1,0 +1,102 @@
+package builtins_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/hooks"
+	"github.com/docker/docker-agent/pkg/hooks/builtins"
+	"github.com/docker/docker-agent/pkg/paths"
+)
+
+func TestSnapshotBuiltinUndoSurvivesStreamEnd(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	paths.SetDataDir(t.TempDir())
+	t.Cleanup(func() { paths.SetDataDir("") })
+
+	r := hooks.NewRegistry()
+	state, err := builtins.Register(r)
+	require.NoError(t, err)
+	fn, ok := r.LookupBuiltin(builtins.Snapshot)
+	require.True(t, ok)
+
+	dir := snapshotBuiltinRepo(t)
+	_, err = fn(t.Context(), &hooks.Input{
+		SessionID:     "s",
+		Cwd:           dir,
+		HookEventName: hooks.EventTurnStart,
+	}, nil)
+	require.NoError(t, err)
+
+	changedPath := filepath.Join(dir, "changed.txt")
+	require.NoError(t, os.WriteFile(changedPath, []byte("changed"), 0o644))
+
+	_, err = fn(t.Context(), &hooks.Input{
+		SessionID:     "s",
+		Cwd:           dir,
+		HookEventName: hooks.EventTurnEnd,
+		Reason:        "continue",
+	}, nil)
+	require.NoError(t, err)
+
+	_, err = fn(t.Context(), &hooks.Input{
+		SessionID:     "s",
+		Cwd:           dir,
+		HookEventName: hooks.EventTurnStart,
+	}, nil)
+	require.NoError(t, err)
+
+	_, err = fn(t.Context(), &hooks.Input{
+		SessionID:     "s",
+		Cwd:           dir,
+		HookEventName: hooks.EventTurnEnd,
+		Reason:        "normal",
+	}, nil)
+	require.NoError(t, err)
+
+	_, err = fn(t.Context(), &hooks.Input{
+		SessionID:     "s",
+		Cwd:           dir,
+		HookEventName: hooks.EventSessionEnd,
+		Reason:        "stream_ended",
+	}, nil)
+	require.NoError(t, err)
+	state.ClearSession("s")
+
+	entries, err := os.ReadDir(filepath.Join(paths.GetDataDir(), "snapshot"))
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.DirExists(t, filepath.Join(paths.GetDataDir(), "snapshot", entries[0].Name()))
+
+	files, restored, err := state.UndoLastSnapshot(t.Context(), "s", dir)
+	require.NoError(t, err)
+	assert.True(t, restored)
+	assert.Equal(t, 1, files)
+	assert.NoFileExists(t, changedPath)
+}
+
+func snapshotBuiltinRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGitForSnapshotBuiltin(t, dir, "init")
+	runGitForSnapshotBuiltin(t, dir, "config", "user.email", "test@example.com")
+	runGitForSnapshotBuiltin(t, dir, "config", "user.name", "Test User")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "base.txt"), []byte("base"), 0o644))
+	runGitForSnapshotBuiltin(t, dir, "add", ".")
+	runGitForSnapshotBuiltin(t, dir, "commit", "-m", "init")
+	return dir
+}
+
+func runGitForSnapshotBuiltin(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), "git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+}

--- a/pkg/runtime/hooks.go
+++ b/pkg/runtime/hooks.go
@@ -15,10 +15,10 @@ import (
 )
 
 // buildHooksExecutors builds a [hooks.Executor] for every agent in the
-// team that has user-configured hooks, an agent-flag that maps to a
-// builtin (AddDate / AddEnvironmentInfo / AddPromptFiles), or a
-// configured response cache (which auto-injects a cache_response stop
-// hook). Agents with no hooks have no entry; lookups fall through to
+// team that has user-configured hooks, an agent-flag or runtime setting
+// that maps to a builtin (AddDate / AddEnvironmentInfo / AddPromptFiles /
+// Snapshot), or a configured response cache (which auto-injects a
+// cache_response stop hook). Agents with no hooks have no entry; lookups fall through to
 // nil so callers can short-circuit cheaply.
 //
 // Called once from [NewLocalRuntime] after r.workingDir, r.env and
@@ -37,6 +37,7 @@ func (r *LocalRuntime) buildHooksExecutors() {
 			AddEnvironmentInfo: a.AddEnvironmentInfo(),
 			AddPromptFiles:     a.AddPromptFiles(),
 			RedactSecrets:      a.RedactSecrets(),
+			Snapshot:           r.snapshotsEnabled,
 		})
 		cfg = applyCacheDefault(cfg, a)
 		if cfg == nil {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -156,6 +156,7 @@ type LocalRuntime struct {
 	workingDir           string   // Working directory for hooks execution
 	env                  []string // Environment variables for hooks execution
 	modelSwitcherCfg     *ModelSwitcherConfig
+	snapshotsEnabled     bool
 
 	// hooksRegistry is the runtime-private hooks.Registry used to build
 	// every Executor. It carries the runtime-owned builtin hooks

--- a/pkg/runtime/snapshot.go
+++ b/pkg/runtime/snapshot.go
@@ -1,0 +1,30 @@
+package runtime
+
+import (
+	"context"
+	"os"
+
+	"github.com/docker/docker-agent/pkg/session"
+)
+
+// WithSnapshots configures whether snapshot hooks are auto-injected for every agent.
+func WithSnapshots(enabled bool) Opt {
+	return func(r *LocalRuntime) {
+		r.snapshotsEnabled = enabled
+	}
+}
+
+// UndoLastSnapshot restores files recorded for the latest completed snapshot hook checkpoint.
+func (r *LocalRuntime) UndoLastSnapshot(ctx context.Context, sess *session.Session) (files int, ok bool, err error) {
+	if r == nil || sess == nil {
+		return 0, false, nil
+	}
+	cwd := sess.WorkingDir
+	if cwd == "" {
+		cwd = r.workingDir
+	}
+	if cwd == "" {
+		cwd, _ = os.Getwd()
+	}
+	return r.builtinsState.UndoLastSnapshot(ctx, sess.ID, cwd)
+}

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -1,0 +1,794 @@
+// Package snapshot records workspace states in a shadow git repository.
+package snapshot
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/docker/docker-agent/pkg/paths"
+)
+
+const (
+	pruneAfter     = "7.days"
+	largeFileLimit = 2 * 1024 * 1024
+)
+
+// ErrNotGitRepository means the requested directory is not inside a git worktree.
+var ErrNotGitRepository = errors.New("not a git repository")
+
+// Patch describes files changed since a snapshot tree hash.
+type Patch struct {
+	Hash  string   `json:"hash"`
+	Files []string `json:"files"`
+}
+
+// FileDiff describes one file in a diff between two snapshot tree hashes.
+type FileDiff struct {
+	File      string `json:"file"`
+	Patch     string `json:"patch"`
+	Additions int    `json:"additions"`
+	Deletions int    `json:"deletions"`
+	Status    string `json:"status,omitempty"`
+}
+
+type revertOp struct {
+	hash string
+	file string
+	rel  string
+}
+
+// Manager opens per-worktree shadow repositories under a data directory.
+type Manager struct {
+	dataDir string
+	mu      sync.Mutex
+	locks   map[string]*sync.Mutex
+}
+
+// NewManager creates a snapshot manager rooted at dataDir.
+func NewManager(dataDir string) *Manager {
+	if dataDir == "" {
+		dataDir = paths.GetDataDir()
+	}
+	return &Manager{dataDir: dataDir, locks: map[string]*sync.Mutex{}}
+}
+
+// Open returns the shadow repository for the git worktree containing dir.
+func (m *Manager) Open(ctx context.Context, dir string) (*Repo, error) {
+	if dir == "" {
+		return nil, ErrNotGitRepository
+	}
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, err
+	}
+	worktree, err := gitWorktree(ctx, abs)
+	if err != nil {
+		return nil, err
+	}
+	gitdir := filepath.Join(m.dataDir, "snapshot", hashPath(worktree))
+	return &Repo{
+		directory: abs,
+		worktree:  worktree,
+		gitdir:    gitdir,
+		lock:      m.lock(gitdir),
+	}, nil
+}
+
+// Cleanup runs garbage collection for the shadow repository containing dir.
+func (m *Manager) Cleanup(ctx context.Context, dir string) error {
+	repo, err := m.Open(ctx, dir)
+	if err != nil {
+		return err
+	}
+	return repo.Cleanup(ctx)
+}
+
+func (m *Manager) lock(key string) *sync.Mutex {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if l := m.locks[key]; l != nil {
+		return l
+	}
+	l := &sync.Mutex{}
+	m.locks[key] = l
+	return l
+}
+
+// Repo is a shadow git repository paired with a source worktree.
+type Repo struct {
+	directory string
+	worktree  string
+	gitdir    string
+	lock      *sync.Mutex
+}
+
+// Directory returns the directory used to scope pathspecs for this repo.
+func (r *Repo) Directory() string { return r.directory }
+
+// Worktree returns the source git worktree root.
+func (r *Repo) Worktree() string { return r.worktree }
+
+// GitDir returns the shadow git directory.
+func (r *Repo) GitDir() string { return r.gitdir }
+
+// Track stages the current source worktree state and returns its tree hash.
+func (r *Repo) Track(ctx context.Context) (string, error) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	if err := r.ensure(ctx); err != nil {
+		return "", err
+	}
+	if err := r.add(ctx); err != nil {
+		return "", err
+	}
+	result := r.git(ctx, r.args("write-tree"), gitOpts{cwd: r.directory})
+	if result.err != nil {
+		return "", result.err
+	}
+	if result.code != 0 {
+		return "", fmt.Errorf("git write-tree failed: %s", strings.TrimSpace(result.stderr))
+	}
+	hash := strings.TrimSpace(result.stdout)
+	slog.DebugContext(ctx, "snapshot tracking", "hash", hash, "cwd", r.directory, "gitdir", r.gitdir)
+	return hash, nil
+}
+
+// Patch reports files that changed between hash and the current source state.
+func (r *Repo) Patch(ctx context.Context, hash string) (Patch, error) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	if err := r.ensure(ctx); err != nil {
+		return Patch{Hash: hash}, err
+	}
+	if err := r.add(ctx); err != nil {
+		return Patch{Hash: hash}, err
+	}
+	result := r.git(ctx, append(quoteArgs(), r.args("diff", "--cached", "--no-ext-diff", "--name-only", hash, "--", ".")...), gitOpts{cwd: r.directory})
+	if result.err != nil {
+		return Patch{Hash: hash}, result.err
+	}
+	if result.code != 0 {
+		slog.WarnContext(ctx, "failed to get snapshot diff", "hash", hash, "exit_code", result.code, "stderr", result.stderr)
+		return Patch{Hash: hash, Files: []string{}}, nil
+	}
+	files := lines(result.stdout)
+	ignored := r.ignore(ctx, files)
+	out := make([]string, 0, len(files))
+	for _, file := range files {
+		if ignored[file] {
+			continue
+		}
+		out = append(out, filepath.ToSlash(filepath.Join(r.worktree, filepath.FromSlash(file))))
+	}
+	return Patch{Hash: hash, Files: out}, nil
+}
+
+// Diff returns a unified diff between hash and the current source state.
+func (r *Repo) Diff(ctx context.Context, hash string) (string, error) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	if err := r.ensure(ctx); err != nil {
+		return "", err
+	}
+	if err := r.add(ctx); err != nil {
+		return "", err
+	}
+	result := r.git(ctx, append(quoteArgs(), r.args("diff", "--cached", "--no-ext-diff", hash, "--", ".")...), gitOpts{cwd: r.directory})
+	if result.err != nil {
+		return "", result.err
+	}
+	if result.code != 0 {
+		slog.WarnContext(ctx, "failed to get snapshot diff", "hash", hash, "exit_code", result.code, "stderr", result.stderr)
+		return "", nil
+	}
+	return strings.TrimSpace(result.stdout), nil
+}
+
+// Restore checks out all files from hash into the source worktree.
+func (r *Repo) Restore(ctx context.Context, hash string) error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	if err := r.ensure(ctx); err != nil {
+		return err
+	}
+	result := r.git(ctx, append(coreArgs(), r.args("read-tree", hash)...), gitOpts{cwd: r.worktree})
+	if result.err != nil {
+		return result.err
+	}
+	if result.code != 0 {
+		return fmt.Errorf("restore snapshot %s: git read-tree failed: %s", hash, strings.TrimSpace(result.stderr))
+	}
+	checkout := r.git(ctx, append(coreArgs(), r.args("checkout-index", "-a", "-f")...), gitOpts{cwd: r.worktree})
+	if checkout.err != nil {
+		return checkout.err
+	}
+	if checkout.code != 0 {
+		return fmt.Errorf("restore snapshot %s: git checkout-index failed: %s", hash, strings.TrimSpace(checkout.stderr))
+	}
+	return nil
+}
+
+// Revert restores or removes the files listed in patches.
+func (r *Repo) Revert(ctx context.Context, patches []Patch) error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	if err := r.ensure(ctx); err != nil {
+		return err
+	}
+	ops := make([]revertOp, 0)
+	seen := map[string]bool{}
+	for _, patch := range patches {
+		for _, file := range patch.Files {
+			abs, err := filepath.Abs(file)
+			if err != nil {
+				continue
+			}
+			if seen[abs] {
+				continue
+			}
+			rel, err := filepath.Rel(r.worktree, abs)
+			if err != nil || rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+				continue
+			}
+			seen[abs] = true
+			ops = append(ops, revertOp{hash: patch.Hash, file: abs, rel: filepath.ToSlash(rel)})
+		}
+	}
+
+	single := func(op revertOp) error {
+		slog.DebugContext(ctx, "reverting snapshot file", "file", op.file, "hash", op.hash)
+		checkout := r.git(ctx, append(coreArgs(), r.args("checkout", op.hash, "--", op.rel)...), gitOpts{cwd: r.worktree})
+		if checkout.err != nil {
+			return checkout.err
+		}
+		if checkout.code == 0 {
+			return nil
+		}
+		tree := r.git(ctx, append(coreArgs(), r.args("ls-tree", op.hash, "--", op.rel)...), gitOpts{cwd: r.worktree})
+		if tree.err != nil {
+			return tree.err
+		}
+		if tree.code == 0 && strings.TrimSpace(tree.stdout) != "" {
+			slog.DebugContext(ctx, "snapshot file existed but checkout failed; keeping", "file", op.file, "hash", op.hash)
+			return nil
+		}
+		slog.DebugContext(ctx, "snapshot file did not exist; deleting", "file", op.file, "hash", op.hash)
+		return removeFile(op.file)
+	}
+
+	for i := 0; i < len(ops); {
+		first := ops[i]
+		run := []revertOp{first}
+		j := i + 1
+		for j < len(ops) && len(run) < 100 {
+			next := ops[j]
+			if next.hash != first.hash || anyClash(run, next.rel) {
+				break
+			}
+			run = append(run, next)
+			j++
+		}
+		if len(run) == 1 {
+			if err := single(first); err != nil {
+				return err
+			}
+			i = j
+			continue
+		}
+
+		rels := make([]string, 0, len(run))
+		for _, op := range run {
+			rels = append(rels, op.rel)
+		}
+		tree := r.git(ctx, append(coreArgs(), r.args(append([]string{"ls-tree", "--name-only", first.hash, "--"}, rels...)...)...), gitOpts{cwd: r.worktree})
+		if tree.err != nil {
+			return tree.err
+		}
+		if tree.code != 0 {
+			for _, op := range run {
+				if err := single(op); err != nil {
+					return err
+				}
+			}
+			i = j
+			continue
+		}
+		have := map[string]bool{}
+		for _, item := range lines(tree.stdout) {
+			have[item] = true
+		}
+		var checkoutRels []string
+		for _, op := range run {
+			if have[op.rel] {
+				checkoutRels = append(checkoutRels, op.rel)
+			}
+		}
+		if len(checkoutRels) > 0 {
+			checkout := r.git(ctx, append(coreArgs(), r.args(append([]string{"checkout", first.hash, "--"}, checkoutRels...)...)...), gitOpts{cwd: r.worktree})
+			if checkout.err != nil {
+				return checkout.err
+			}
+			if checkout.code != 0 {
+				for _, op := range run {
+					if err := single(op); err != nil {
+						return err
+					}
+				}
+				i = j
+				continue
+			}
+		}
+		for _, op := range run {
+			if have[op.rel] {
+				continue
+			}
+			if err := removeFile(op.file); err != nil {
+				return err
+			}
+		}
+		i = j
+	}
+	return nil
+}
+
+// Cleanup runs git gc for this shadow repository.
+func (r *Repo) Cleanup(ctx context.Context) error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	if _, err := os.Stat(r.gitdir); errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	result := r.git(ctx, r.args("gc", "--prune="+pruneAfter), gitOpts{cwd: r.directory})
+	if result.err != nil {
+		return result.err
+	}
+	if result.code != 0 {
+		return fmt.Errorf("snapshot cleanup failed: %s", strings.TrimSpace(result.stderr))
+	}
+	return nil
+}
+
+// DiffFull returns file-level diff metadata between two snapshot tree hashes.
+func (r *Repo) DiffFull(ctx context.Context, from, to string) ([]FileDiff, error) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	if err := r.ensure(ctx); err != nil {
+		return nil, err
+	}
+	statuses := r.git(ctx, append(quoteArgs(), r.args("diff", "--no-ext-diff", "--name-status", "--no-renames", from, to, "--", ".")...), gitOpts{cwd: r.directory})
+	if statuses.err != nil {
+		return nil, statuses.err
+	}
+	if statuses.code != 0 {
+		return nil, fmt.Errorf("snapshot diff status failed: %s", strings.TrimSpace(statuses.stderr))
+	}
+	statusByFile := map[string]string{}
+	for _, line := range lines(statuses.stdout) {
+		code, file, ok := strings.Cut(line, "\t")
+		if !ok || file == "" {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(code, "A"):
+			statusByFile[file] = "added"
+		case strings.HasPrefix(code, "D"):
+			statusByFile[file] = "deleted"
+		default:
+			statusByFile[file] = "modified"
+		}
+	}
+
+	numstat := r.git(ctx, append(quoteArgs(), r.args("diff", "--no-ext-diff", "--no-renames", "--numstat", from, to, "--", ".")...), gitOpts{cwd: r.directory})
+	if numstat.err != nil {
+		return nil, numstat.err
+	}
+	if numstat.code != 0 {
+		return nil, fmt.Errorf("snapshot diff numstat failed: %s", strings.TrimSpace(numstat.stderr))
+	}
+	type row struct {
+		file      string
+		binary    bool
+		additions int
+		deletions int
+	}
+	rows := make([]row, 0)
+	for _, line := range lines(numstat.stdout) {
+		parts := strings.Split(line, "\t")
+		if len(parts) < 3 {
+			continue
+		}
+		rows = append(rows, row{
+			file:      parts[2],
+			binary:    parts[0] == "-" && parts[1] == "-",
+			additions: parseNumstat(parts[0]),
+			deletions: parseNumstat(parts[1]),
+		})
+	}
+	ignored := r.ignore(ctx, func() []string {
+		files := make([]string, 0, len(rows))
+		for _, row := range rows {
+			files = append(files, row.file)
+		}
+		return files
+	}())
+	out := make([]FileDiff, 0, len(rows))
+	for _, row := range rows {
+		if ignored[row.file] {
+			continue
+		}
+		patch := ""
+		if !row.binary {
+			p := r.git(ctx, append(quoteArgs(), r.args("diff", "--no-ext-diff", "--no-renames", from, to, "--", row.file)...), gitOpts{cwd: r.directory})
+			if p.err != nil {
+				return nil, p.err
+			}
+			if p.code == 0 {
+				patch = p.stdout
+			}
+		}
+		out = append(out, FileDiff{
+			File:      row.file,
+			Patch:     patch,
+			Additions: row.additions,
+			Deletions: row.deletions,
+			Status:    statusByFile[row.file],
+		})
+	}
+	return out, nil
+}
+
+func (r *Repo) ensure(ctx context.Context) error {
+	if err := os.MkdirAll(r.gitdir, 0o755); err != nil {
+		return err
+	}
+	if _, err := os.Stat(filepath.Join(r.gitdir, "HEAD")); err == nil {
+		return nil
+	}
+	result := r.git(ctx, []string{"init"}, gitOpts{env: map[string]string{
+		"GIT_DIR":       r.gitdir,
+		"GIT_WORK_TREE": r.worktree,
+	}})
+	if result.err != nil {
+		return result.err
+	}
+	if result.code != 0 {
+		return fmt.Errorf("snapshot git init failed: %s", strings.TrimSpace(result.stderr))
+	}
+	for _, args := range [][]string{
+		{"config", "core.autocrlf", "false"},
+		{"config", "core.longpaths", "true"},
+		{"config", "core.symlinks", "true"},
+		{"config", "core.fsmonitor", "false"},
+	} {
+		cfg := r.git(ctx, append([]string{"--git-dir", r.gitdir}, args...), gitOpts{})
+		if cfg.err != nil {
+			return cfg.err
+		}
+		if cfg.code != 0 {
+			return fmt.Errorf("snapshot git config failed: %s", strings.TrimSpace(cfg.stderr))
+		}
+	}
+	slog.DebugContext(ctx, "initialized snapshot repository", "gitdir", r.gitdir, "worktree", r.worktree)
+	return nil
+}
+
+func (r *Repo) add(ctx context.Context) error {
+	if err := r.syncExcludes(ctx, nil); err != nil {
+		return err
+	}
+	diff := r.git(ctx, append(quoteArgs(), r.args("diff-files", "--name-only", "-z", "--", ".")...), gitOpts{cwd: r.directory})
+	other := r.git(ctx, append(quoteArgs(), r.args("ls-files", "--others", "--exclude-standard", "-z", "--", ".")...), gitOpts{cwd: r.directory})
+	if diff.err != nil {
+		return diff.err
+	}
+	if other.err != nil {
+		return other.err
+	}
+	if diff.code != 0 || other.code != 0 {
+		return fmt.Errorf("list snapshot files failed: diff=%d %s other=%d %s", diff.code, strings.TrimSpace(diff.stderr), other.code, strings.TrimSpace(other.stderr))
+	}
+	tracked := splitNUL(diff.stdout)
+	untracked := splitNUL(other.stdout)
+	all := unique(append(tracked, untracked...))
+	if len(all) == 0 {
+		return nil
+	}
+	ignored := r.ignore(ctx, all)
+	if len(ignored) > 0 {
+		ignoredFiles := keys(ignored)
+		slog.DebugContext(ctx, "removing gitignored files from snapshot", "count", len(ignoredFiles))
+		if err := r.drop(ctx, ignoredFiles); err != nil {
+			return err
+		}
+	}
+	allow := make([]string, 0, len(all))
+	for _, item := range all {
+		if !ignored[item] {
+			allow = append(allow, item)
+		}
+	}
+	if len(allow) == 0 {
+		return nil
+	}
+	large := map[string]bool{}
+	for _, item := range allow {
+		info, err := os.Lstat(filepath.Join(r.worktree, filepath.FromSlash(item)))
+		if err != nil || !info.Mode().IsRegular() {
+			continue
+		}
+		if info.Size() > largeFileLimit {
+			large[item] = true
+		}
+	}
+	block := make([]string, 0)
+	for _, item := range untracked {
+		if large[item] {
+			block = append(block, item)
+		}
+	}
+	if err := r.syncExcludes(ctx, block); err != nil {
+		return err
+	}
+	stage := make([]string, 0, len(allow))
+	for _, item := range allow {
+		if !slices.Contains(block, item) {
+			stage = append(stage, item)
+		}
+	}
+	return r.stage(ctx, stage)
+}
+
+func (r *Repo) ignore(ctx context.Context, files []string) map[string]bool {
+	out := map[string]bool{}
+	if len(files) == 0 {
+		return out
+	}
+	result := command(ctx, []string{"-C", r.worktree, "-c", "core.quotepath=false", "check-ignore", "--no-index", "--stdin", "-z"}, gitOpts{cwd: r.directory, stdin: []byte(strings.Join(files, "\x00") + "\x00")})
+	if result.err != nil || (result.code != 0 && result.code != 1) {
+		return out
+	}
+	for _, item := range splitNUL(result.stdout) {
+		out[item] = true
+	}
+	return out
+}
+
+func (r *Repo) drop(ctx context.Context, files []string) error {
+	if len(files) == 0 {
+		return nil
+	}
+	result := r.git(ctx, append(cfgArgs(), r.args("rm", "--cached", "-f", "--ignore-unmatch", "--pathspec-from-file=-", "--pathspec-file-nul")...), gitOpts{cwd: r.directory, stdin: nulList(files)})
+	if result.err != nil {
+		return result.err
+	}
+	if result.code != 0 {
+		return fmt.Errorf("snapshot git rm failed: %s", strings.TrimSpace(result.stderr))
+	}
+	return nil
+}
+
+func (r *Repo) stage(ctx context.Context, files []string) error {
+	if len(files) == 0 {
+		return nil
+	}
+	result := r.git(ctx, append(cfgArgs(), r.args("add", "--all", "--sparse", "--pathspec-from-file=-", "--pathspec-file-nul")...), gitOpts{cwd: r.directory, stdin: nulList(files)})
+	if result.err != nil {
+		return result.err
+	}
+	if result.code != 0 {
+		slog.WarnContext(ctx, "failed to add snapshot files", "exit_code", result.code, "stderr", result.stderr)
+	}
+	return nil
+}
+
+func (r *Repo) syncExcludes(ctx context.Context, list []string) error {
+	source := ""
+	result := command(ctx, []string{"-C", r.worktree, "rev-parse", "--path-format=absolute", "--git-path", "info/exclude"}, gitOpts{})
+	if result.err == nil && result.code == 0 {
+		file := strings.TrimSpace(result.stdout)
+		if file != "" {
+			if data, err := os.ReadFile(file); err == nil {
+				source = strings.TrimRight(string(data), "\r\n")
+			}
+		}
+	}
+	parts := make([]string, 0, 1+len(list))
+	if source != "" {
+		parts = append(parts, source)
+	}
+	for _, item := range list {
+		parts = append(parts, "/"+filepath.ToSlash(item))
+	}
+	text := strings.Join(parts, "\n")
+	if text != "" {
+		text += "\n"
+	}
+	target := filepath.Join(r.gitdir, "info", "exclude")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(target, []byte(text), 0o644)
+}
+
+func (r *Repo) args(cmd ...string) []string {
+	out := make([]string, 0, 4+len(cmd))
+	out = append(out, "--git-dir", r.gitdir, "--work-tree", r.worktree)
+	out = append(out, cmd...)
+	return out
+}
+
+func (r *Repo) git(ctx context.Context, args []string, opts gitOpts) gitResult {
+	return command(ctx, args, opts)
+}
+
+type gitOpts struct {
+	cwd   string
+	env   map[string]string
+	stdin []byte
+}
+
+type gitResult struct {
+	code   int
+	stdout string
+	stderr string
+	err    error
+}
+
+func command(ctx context.Context, args []string, opts gitOpts) gitResult {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = opts.cwd
+	if len(opts.env) > 0 {
+		cmd.Env = os.Environ()
+		for key, value := range opts.env {
+			cmd.Env = append(cmd.Env, key+"="+value)
+		}
+	}
+	if opts.stdin != nil {
+		cmd.Stdin = bytes.NewReader(opts.stdin)
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	res := gitResult{stdout: stdout.String(), stderr: stderr.String()}
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			res.code = exitErr.ExitCode()
+			return res
+		}
+		res.code = -1
+		res.err = err
+		return res
+	}
+	return res
+}
+
+func gitWorktree(ctx context.Context, dir string) (string, error) {
+	inside := command(ctx, []string{"-C", dir, "rev-parse", "--is-inside-work-tree"}, gitOpts{})
+	if inside.err != nil {
+		return "", inside.err
+	}
+	if inside.code != 0 || strings.TrimSpace(inside.stdout) != "true" {
+		return "", ErrNotGitRepository
+	}
+	root := command(ctx, []string{"-C", dir, "rev-parse", "--show-toplevel"}, gitOpts{})
+	if root.err != nil {
+		return "", root.err
+	}
+	if root.code != 0 {
+		return "", ErrNotGitRepository
+	}
+	return filepath.Clean(strings.TrimSpace(root.stdout)), nil
+}
+
+func hashPath(path string) string {
+	sum := sha256.Sum256([]byte(filepath.Clean(path)))
+	return hex.EncodeToString(sum[:16])
+}
+
+func coreArgs() []string {
+	return []string{"-c", "core.longpaths=true", "-c", "core.symlinks=true"}
+}
+
+func cfgArgs() []string {
+	return append([]string{"-c", "core.autocrlf=false"}, coreArgs()...)
+}
+
+func quoteArgs() []string {
+	return append(cfgArgs(), "-c", "core.quotepath=false")
+}
+
+func splitNUL(s string) []string {
+	parts := strings.Split(s, "\x00")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+func lines(s string) []string {
+	parts := strings.Split(strings.TrimSpace(s), "\n")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+func unique(items []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		if item == "" || seen[item] {
+			continue
+		}
+		seen[item] = true
+		out = append(out, item)
+	}
+	return out
+}
+
+func keys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for key := range m {
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func nulList(items []string) []byte {
+	if len(items) == 0 {
+		return nil
+	}
+	return []byte(strings.Join(items, "\x00") + "\x00")
+}
+
+func clash(a, b string) bool {
+	return a == b || strings.HasPrefix(a, b+"/") || strings.HasPrefix(b, a+"/")
+}
+
+func anyClash(ops []revertOp, rel string) bool {
+	for _, op := range ops {
+		if clash(op.rel, rel) {
+			return true
+		}
+	}
+	return false
+}
+
+func removeFile(file string) error {
+	err := os.Remove(file)
+	if err == nil || errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
+}
+
+func parseNumstat(s string) int {
+	if s == "-" || s == "" {
+		return 0
+	}
+	var n int
+	_, _ = fmt.Sscanf(s, "%d", &n)
+	return n
+}

--- a/pkg/snapshot/snapshot_test.go
+++ b/pkg/snapshot/snapshot_test.go
@@ -1,0 +1,160 @@
+package snapshot
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrackPatchAndRevert(t *testing.T) {
+	dir := bootstrapRepo(t)
+	repo := openRepo(t, dir)
+
+	before, err := repo.Track(t.Context())
+	require.NoError(t, err)
+	require.NotEmpty(t, before)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("modified"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "new.txt"), []byte("new"), 0o644))
+	require.NoError(t, os.Remove(filepath.Join(dir, "b.txt")))
+
+	patch, err := repo.Patch(t.Context(), before)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{
+		filepath.ToSlash(filepath.Join(repo.Worktree(), "a.txt")),
+		filepath.ToSlash(filepath.Join(repo.Worktree(), "b.txt")),
+		filepath.ToSlash(filepath.Join(repo.Worktree(), "new.txt")),
+	}, patch.Files)
+
+	require.NoError(t, repo.Revert(t.Context(), []Patch{patch}))
+	assertFile(t, filepath.Join(dir, "a.txt"), "A")
+	assertFile(t, filepath.Join(dir, "b.txt"), "B")
+	assert.NoFileExists(t, filepath.Join(dir, "new.txt"))
+}
+
+func TestGitignoreAndLargeFilesAreNotSnapshotted(t *testing.T) {
+	dir := bootstrapRepo(t)
+	repo := openRepo(t, dir)
+
+	before, err := repo.Track(t.Context())
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("*.ignored\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "skip.ignored"), []byte("ignored"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "huge.bin"), make([]byte, largeFileLimit+1), 0o644))
+
+	patch, err := repo.Patch(t.Context(), before)
+	require.NoError(t, err)
+	assert.Contains(t, patch.Files, filepath.ToSlash(filepath.Join(repo.Worktree(), ".gitignore")))
+	assert.NotContains(t, patch.Files, filepath.ToSlash(filepath.Join(repo.Worktree(), "skip.ignored")))
+	assert.NotContains(t, patch.Files, filepath.ToSlash(filepath.Join(repo.Worktree(), "huge.bin")))
+
+	after, err := repo.Track(t.Context())
+	require.NoError(t, err)
+	diffs, err := repo.DiffFull(t.Context(), before, after)
+	require.NoError(t, err)
+	for _, diff := range diffs {
+		assert.NotEqual(t, "skip.ignored", diff.File)
+		assert.NotEqual(t, "huge.bin", diff.File)
+	}
+}
+
+func TestDiffFullReportsFileMetadata(t *testing.T) {
+	dir := bootstrapRepo(t)
+	repo := openRepo(t, dir)
+
+	before, err := repo.Track(t.Context())
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("A\nchanged\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "new.txt"), []byte("new\n"), 0o644))
+	require.NoError(t, os.Remove(filepath.Join(dir, "b.txt")))
+
+	after, err := repo.Track(t.Context())
+	require.NoError(t, err)
+
+	diffs, err := repo.DiffFull(t.Context(), before, after)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"a.txt", "b.txt", "new.txt"}, diffFiles(diffs))
+	assert.Equal(t, "modified", diffByFile(diffs, "a.txt").Status)
+	assert.Equal(t, "deleted", diffByFile(diffs, "b.txt").Status)
+	assert.Equal(t, "added", diffByFile(diffs, "new.txt").Status)
+	assert.Contains(t, diffByFile(diffs, "a.txt").Patch, "changed")
+}
+
+func TestInvalidHashPatchIsEmpty(t *testing.T) {
+	dir := bootstrapRepo(t)
+	repo := openRepo(t, dir)
+
+	_, err := repo.Track(t.Context())
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "changed.txt"), []byte("changed"), 0o644))
+
+	patch, err := repo.Patch(t.Context(), "not-a-real-hash")
+	require.NoError(t, err)
+	assert.Equal(t, "not-a-real-hash", patch.Hash)
+	assert.Empty(t, patch.Files)
+}
+
+func TestOpenOutsideGitRepo(t *testing.T) {
+	_, err := NewManager(t.TempDir()).Open(t.Context(), t.TempDir())
+	assert.ErrorIs(t, err, ErrNotGitRepository)
+}
+
+func bootstrapRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "Test User")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("A"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.txt"), []byte("B"), 0o644))
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "init")
+	return dir
+}
+
+func openRepo(t *testing.T, dir string) *Repo {
+	t.Helper()
+	repo, err := NewManager(t.TempDir()).Open(t.Context(), dir)
+	require.NoError(t, err)
+	return repo
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), "git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+}
+
+func diffFiles(diffs []FileDiff) []string {
+	files := make([]string, 0, len(diffs))
+	for _, diff := range diffs {
+		files = append(files, diff.File)
+	}
+	return files
+}
+
+func diffByFile(diffs []FileDiff, file string) FileDiff {
+	for _, diff := range diffs {
+		if diff.File == file {
+			return diff
+		}
+	}
+	return FileDiff{}
+}
+
+func assertFile(t *testing.T, path, want string) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, want, string(got))
+}

--- a/pkg/tui/commands/commands.go
+++ b/pkg/tui/commands/commands.go
@@ -96,6 +96,17 @@ func builtInSessionCommands() []Item {
 			},
 		},
 		{
+			ID:           "session.undo",
+			Label:        "Undo",
+			SlashCommand: "/undo",
+			Description:  "Restore file changes from the latest snapshot",
+			Category:     "Session",
+			Immediate:    true,
+			Execute: func(string) tea.Cmd {
+				return core.CmdHandler(messages.UndoSnapshotMsg{})
+			},
+		},
+		{
 			ID:           "session.cost",
 			Label:        "Cost",
 			SlashCommand: "/cost",

--- a/pkg/tui/commands/commands_test.go
+++ b/pkg/tui/commands/commands_test.go
@@ -98,6 +98,15 @@ func TestParseSlashCommand_OtherCommands(t *testing.T) {
 		assert.True(t, ok)
 	})
 
+	t.Run("undo command", func(t *testing.T) {
+		t.Parallel()
+		cmd := parser.Parse("/undo")
+		require.NotNil(t, cmd)
+		msg := cmd()
+		_, ok := msg.(messages.UndoSnapshotMsg)
+		assert.True(t, ok)
+	})
+
 	t.Run("unknown command returns nil", func(t *testing.T) {
 		t.Parallel()
 		cmd := parser.Parse("/unknown")

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -247,6 +247,29 @@ func (m *appModel) handleCopyLastResponseToClipboard() (tea.Model, tea.Cmd) {
 	return m, copyToClipboard(lastResponse, "Last response copied to clipboard.")
 }
 
+func (m *appModel) handleUndoSnapshot() (tea.Model, tea.Cmd) {
+	if m.chatPage.IsWorking() {
+		return m, notification.WarningCmd("Wait for the current response to finish before undoing")
+	}
+	result, err := m.application.UndoLastSnapshot(context.Background())
+	if err != nil {
+		if errors.Is(err, app.ErrNothingToUndo) {
+			return m, notification.InfoCmd("No snapshot to undo")
+		}
+		return m, notification.ErrorCmd(fmt.Sprintf("Failed to undo snapshot: %v", err))
+	}
+
+	text := fmt.Sprintf("Restored %d file%s from the last snapshot", result.RestoredFiles, plural(result.RestoredFiles))
+	return m, notification.SuccessCmd(text)
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
 // copyToClipboard returns a sequenced command that copies text to the system
 // clipboard using both the OSC 52 escape sequence (for SSH/tmux compatibility)
 // and the platform-native clipboard API, then shows a success notification.

--- a/pkg/tui/messages/session.go
+++ b/pkg/tui/messages/session.go
@@ -47,6 +47,9 @@ type (
 	// CopyLastResponseToClipboardMsg copies the last assistant response to clipboard.
 	CopyLastResponseToClipboardMsg struct{}
 
+	// UndoSnapshotMsg restores files from the latest snapshot.
+	UndoSnapshotMsg struct{}
+
 	// ExportSessionMsg exports the session to the specified file.
 	ExportSessionMsg struct{ Filename string }
 

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -820,6 +820,9 @@ func (m *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case messages.CopyLastResponseToClipboardMsg:
 		return m.handleCopyLastResponseToClipboard()
 
+	case messages.UndoSnapshotMsg:
+		return m.handleUndoSnapshot()
+
 	case messages.EvalSessionMsg:
 		return m.handleEvalSession(msg.Filename)
 

--- a/pkg/userconfig/userconfig.go
+++ b/pkg/userconfig/userconfig.go
@@ -61,6 +61,8 @@ type Settings struct {
 	// SoundThreshold is the minimum duration in seconds a task must run
 	// before a success sound is played. Defaults to 5 seconds.
 	SoundThreshold int `yaml:"sound_threshold,omitempty"`
+	// Snapshot enables automatic shadow-git snapshots globally when true.
+	Snapshot *bool `yaml:"snapshot,omitempty"`
 	// Permissions defines global permission patterns applied across all sessions
 	// and agents. These act as user-wide defaults; session-level and agent-level
 	// permissions override them.
@@ -103,6 +105,11 @@ func (s *Settings) GetSplitDiffView() bool {
 		return true
 	}
 	return *s.SplitDiffView
+}
+
+// SnapshotsEnabled returns whether global snapshot auto-injection is enabled.
+func (s *Settings) SnapshotsEnabled() bool {
+	return s != nil && s.Snapshot != nil && *s.Snapshot
 }
 
 // CredentialHelper contains configuration for a credential helper command

--- a/pkg/userconfig/userconfig_test.go
+++ b/pkg/userconfig/userconfig_test.go
@@ -833,6 +833,26 @@ func TestSettings_GetSound(t *testing.T) {
 	}
 }
 
+func TestSettings_SnapshotsEnabled(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name     string
+		settings *Settings
+		want     bool
+	}{
+		{"nil settings", nil, false},
+		{"empty settings", &Settings{}, false},
+		{"explicitly enabled", &Settings{Snapshot: new(true)}, true},
+		{"explicitly disabled", &Settings{Snapshot: new(false)}, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.settings.SnapshotsEnabled())
+		})
+	}
+}
+
 func TestSettings_RestoreTabs(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Add a git snapshot manager and register it as a builtin hook. Wire user config so snapshots can be auto-enabled for every local runtime.

Add a TUI /undo command that restores file changes from the latest changed snapshot without modifying the session transcript. Keep undo checkpoints available after a response stops so the command works once the agent is idle.

Document snapshot hooks and add an example agent configuration.