### PR TITLE
use slices.Backward in CompactionInput

### DIFF
--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -941,7 +941,7 @@ func (s *Session) CompactionInput() ([]chat.Message, []int) {
 	items := s.snapshotItems()
 
 	lastSummaryIndex := -1
-	for i := len(items) - 1; i >= 0; i-- {
+	for i := range slices.Backward(items) {
 		if items[i].Summary != "" {
 			lastSummaryIndex = i
 			break


### PR DESCRIPTION
Replaces the manual reverse-index loop in `(*Session).CompactionInput` with `slices.Backward`, matching the style already used in `buildSessionSummaryMessages` in the same file. Fixes the lone `modernize/slicesbackward` lint warning.