### PR TITLE
refactor(lint): adopt new rubocop-go DSL across all cops

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -154,7 +154,7 @@ require (
 	github.com/containerd/stargz-snapshotter/estargz v0.18.2 // indirect
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/dgageot/rubocop-go v0.0.0-20260429125723-198995cc80c9
+	github.com/dgageot/rubocop-go v0.0.0-20260507084512-2695e6771458
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/dlclark/regexp2 v1.12.0 // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -193,8 +193,8 @@ github.com/danieljoos/wincred v1.2.2/go.mod h1:w7w4Utbrz8lqeMbDAK0lkNJUv5sAOkFi7
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgageot/rubocop-go v0.0.0-20260429125723-198995cc80c9 h1:LwBQXSuGbtHC3rzVOBQIsSofzTc7k9QWRqoQdfPbG+s=
-github.com/dgageot/rubocop-go v0.0.0-20260429125723-198995cc80c9/go.mod h1:r8YOJV5+/30NZ8HW/2NbWUObBGDXGvfHrjgury5YlFI=
+github.com/dgageot/rubocop-go v0.0.0-20260507084512-2695e6771458 h1:qLFMffgwEigJvNG9kNGVlgfpVmLz92dy92Nr1sPJt4M=
+github.com/dgageot/rubocop-go v0.0.0-20260507084512-2695e6771458/go.mod h1:r8YOJV5+/30NZ8HW/2NbWUObBGDXGvfHrjgury5YlFI=
 github.com/dgageot/ultraviolet v0.0.0-20260313154905-9451997d56b6 h1:88fWkkjwzuI4tRTqadbJIbA9O+gO67oyu+2OpHHuuT8=
 github.com/dgageot/ultraviolet v0.0.0-20260313154905-9451997d56b6/go.mod h1:SQpCTRNBtzJkwku5ye4S3HEuthAlGy2n9VXZnWkEW98=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=

--- a/lint/config_latest_tag_consistency.go
+++ b/lint/config_latest_tag_consistency.go
@@ -3,7 +3,6 @@ package main
 import (
 	"go/ast"
 	"reflect"
-	"strings"
 
 	"github.com/dgageot/rubocop-go/cop"
 )
@@ -31,89 +30,57 @@ import (
 //
 // Fields without a `yaml` tag are skipped — yaml.v3 derives a default name
 // from the field, which is a separate concern handled elsewhere.
-type ConfigLatestTagConsistency struct {
-	cop.Meta
-}
+var ConfigLatestTagConsistency = &cop.Func{
+	Meta: cop.Meta{
+		Name:        "Lint/ConfigLatestTagConsistency",
+		Description: "json and yaml tags in pkg/config/latest must agree on omitempty/omitzero",
+		Severity:    cop.Error,
+	},
+	Scope: cop.And(
+		cop.InPathSegment("pkg/config", func(seg string) bool { return seg == "latest" }),
+		// Black-box test files don't ship struct definitions for the wire format.
+		cop.NotBlackBoxTest(),
+	),
+	Run: func(p *cop.Pass) {
+		p.ForEachStructField(func(_ *ast.TypeSpec, field *ast.Field, tag reflect.StructTag) {
+			if field.Tag == nil {
+				return
+			}
+			j, hasJSON := cop.ParseTagOptions(tag, "json")
+			y, hasYAML := cop.ParseTagOptions(tag, "yaml")
+			if !hasJSON || !hasYAML {
+				return
+			}
+			// Embedded fields use ",inline" on both sides; nothing to compare.
+			if j.Has("inline") || y.Has("inline") {
+				return
+			}
 
-// NewConfigLatestTagConsistency returns a fully configured
-// ConfigLatestTagConsistency cop.
-func NewConfigLatestTagConsistency() *ConfigLatestTagConsistency {
-	return &ConfigLatestTagConsistency{Meta: cop.Meta{
-		CopName:     "Lint/ConfigLatestTagConsistency",
-		CopDesc:     "json and yaml tags in pkg/config/latest must agree on omitempty/omitzero",
-		CopSeverity: cop.Error,
-	}}
-}
+			jsonOmit, jsonMod := jsonOmitModifier(j)
+			yamlOmit := y.Has("omitempty")
 
-func (c *ConfigLatestTagConsistency) Check(p *cop.Pass) {
-	dir, _ := p.PathSegment("pkg/config")
-	if dir != "latest" {
-		return
-	}
-	// Black-box test files don't ship struct definitions for the wire format.
-	if p.IsBlackBoxTest() {
-		return
-	}
-
-	p.ForEachStructField(func(_ *ast.TypeSpec, field *ast.Field, tag reflect.StructTag) {
-		if field.Tag == nil {
-			return
-		}
-		jsonTag, hasJSON := tag.Lookup("json")
-		yamlTag, hasYAML := tag.Lookup("yaml")
-		if !hasJSON || !hasYAML {
-			return
-		}
-		// Embedded fields use ",inline" on both sides; nothing to compare.
-		if isInline(jsonTag) || isInline(yamlTag) {
-			return
-		}
-
-		jsonOmit, jsonMod := jsonOmitModifier(jsonTag)
-		yamlOmit := hasOption(yamlTag, "omitempty")
-
-		if jsonOmit != yamlOmit {
-			p.Report(field.Tag,
-				"json and yaml tags disagree on omit-when-empty: json has %q, yaml has %q (field %s)",
-				modifierLabel(jsonOmit, jsonMod), modifierLabel(yamlOmit, "omitempty"),
-				fieldNames(field))
-		}
-	})
+			if jsonOmit != yamlOmit {
+				p.Reportf(field.Tag,
+					"json and yaml tags disagree on omit-when-empty: json has %q, yaml has %q (field %s)",
+					modifierLabel(jsonOmit, jsonMod), modifierLabel(yamlOmit, "omitempty"),
+					cop.FieldNames(field))
+			}
+		})
+	},
 }
 
 // jsonOmitModifier reports whether the json tag opts out of empty values,
 // returning the specific modifier that triggered the match (omitempty or
 // omitzero). When neither is present, it returns false and "".
-func jsonOmitModifier(tag string) (bool, string) {
+func jsonOmitModifier(opts cop.TagOptions) (bool, string) {
 	switch {
-	case hasOption(tag, "omitempty"):
+	case opts.Has("omitempty"):
 		return true, "omitempty"
-	case hasOption(tag, "omitzero"):
+	case opts.Has("omitzero"):
 		return true, "omitzero"
 	default:
 		return false, ""
 	}
-}
-
-// hasOption reports whether the comma-separated options on tag include opt.
-// The first comma-separated entry is the field name; only later entries are
-// modifiers (`omitempty`, `omitzero`, `inline`, …).
-func hasOption(tag, opt string) bool {
-	for i, part := range strings.Split(tag, ",") {
-		if i == 0 {
-			continue
-		}
-		if part == opt {
-			return true
-		}
-	}
-	return false
-}
-
-// isInline reports whether the tag carries a ",inline" option, which is used
-// by both json/yaml libraries to flatten an embedded struct into the parent.
-func isInline(tag string) bool {
-	return hasOption(tag, "inline")
 }
 
 // modifierLabel renders a human-readable description of the modifier for an
@@ -123,17 +90,4 @@ func modifierLabel(present bool, name string) string {
 		return "<none>"
 	}
 	return name
-}
-
-// fieldNames returns the comma-separated list of field identifiers for use in
-// diagnostic messages. Anonymous (embedded) fields fall back to "<embedded>".
-func fieldNames(field *ast.Field) string {
-	if len(field.Names) == 0 {
-		return "<embedded>"
-	}
-	names := make([]string, 0, len(field.Names))
-	for _, n := range field.Names {
-		names = append(names, n.Name)
-	}
-	return strings.Join(names, ", ")
 }

--- a/lint/config_package_name.go
+++ b/lint/config_package_name.go
@@ -15,35 +15,25 @@ import (
 // is frozen into a numbered vN directory: the package clause is easy to
 // forget, and the broken state remains compilable as long as importers use
 // an explicit alias.
-type ConfigPackageName struct {
-	cop.Meta
-}
-
-// NewConfigPackageName returns a fully configured ConfigPackageName cop.
-func NewConfigPackageName() *ConfigPackageName {
-	return &ConfigPackageName{Meta: cop.Meta{
-		CopName:     "Lint/ConfigPackageName",
-		CopDesc:     "Files under pkg/config/<dir>/ must declare package <dir>",
-		CopSeverity: cop.Error,
-	}}
-}
-
-func (c *ConfigPackageName) Check(p *cop.Pass) {
-	dir, ok := p.PathSegment("pkg/config")
-	if !ok {
-		return
-	}
-
-	got := p.PackageName()
-	switch got {
-	case dir:
-		return
-	case dir + "_test":
-		// Black-box test packages are a legitimate Go convention.
-		if p.IsTestFile() {
+var ConfigPackageName = &cop.Func{
+	Meta: cop.Meta{
+		Name:        "Lint/ConfigPackageName",
+		Description: "Files under pkg/config/<dir>/ must declare package <dir>",
+		Severity:    cop.Error,
+	},
+	Scope: cop.InPathSegment("pkg/config", nil),
+	Run: func(p *cop.Pass) {
+		dir, _ := p.PathSegment("pkg/config")
+		got := p.PackageName()
+		switch got {
+		case dir:
 			return
+		case dir + "_test":
+			// Black-box test packages are a legitimate Go convention.
+			if p.IsTestFile() {
+				return
+			}
 		}
-	}
-
-	p.Report(p.File.Name, "file in pkg/config/%s/ must declare package %s, got %s", dir, dir, got)
+		p.Reportf(p.File.Name, "file in pkg/config/%s/ must declare package %s, got %s", dir, dir, got)
+	},
 }

--- a/lint/config_version_constant.go
+++ b/lint/config_version_constant.go
@@ -17,34 +17,29 @@ import (
 //
 // Files under pkg/config/latest/ are intentionally exempt: their `Version`
 // is the next, work-in-progress value (one greater than the highest vN).
-type ConfigVersionConstant struct {
-	cop.Meta
-}
+var ConfigVersionConstant = &cop.Func{
+	Meta: cop.Meta{
+		Name:        "Lint/ConfigVersionConstant",
+		Description: `Version constant in pkg/config/vN/ must equal "N"`,
+		Severity:    cop.Error,
+	},
+	Scope: cop.InPathSegment("pkg/config", func(seg string) bool {
+		_, ok := versionFromDir(seg)
+		return ok
+	}),
+	Run: func(p *cop.Pass) {
+		dir, _ := p.PathSegment("pkg/config")
+		dirVersion, _ := versionFromDir(dir)
+		expected := strconv.Itoa(dirVersion)
 
-// NewConfigVersionConstant returns a fully configured ConfigVersionConstant cop.
-func NewConfigVersionConstant() *ConfigVersionConstant {
-	return &ConfigVersionConstant{Meta: cop.Meta{
-		CopName:     "Lint/ConfigVersionConstant",
-		CopDesc:     "Version constant in pkg/config/vN/ must equal \"N\"",
-		CopSeverity: cop.Error,
-	}}
-}
-
-func (c *ConfigVersionConstant) Check(p *cop.Pass) {
-	dir, _ := p.PathSegment("pkg/config")
-	dirVersion, ok := versionFromDir(dir)
-	if !ok {
-		return
-	}
-	expected := strconv.Itoa(dirVersion)
-
-	lit, ok := p.StringConstNodes()["Version"]
-	if !ok {
-		return
-	}
-	got, err := strconv.Unquote(lit.Value)
-	if err != nil || got == expected {
-		return
-	}
-	p.Report(lit, "Version in pkg/config/v%s/ must be %q, got %q", expected, expected, got)
+		lit, ok := p.StringConstNodes()["Version"]
+		if !ok {
+			return
+		}
+		got, err := strconv.Unquote(lit.Value)
+		if err != nil || got == expected {
+			return
+		}
+		p.Reportf(lit, "Version in pkg/config/v%s/ must be %q, got %q", expected, expected, got)
+	},
 }

--- a/lint/config_version_import.go
+++ b/lint/config_version_import.go
@@ -11,55 +11,50 @@ import (
 // and pkg/config/latest) only import their immediate predecessor and the
 // shared types package, preserving the strict migration chain:
 // v0 → v1 → v2 → … → latest.
-type ConfigVersionImport struct {
-	cop.Meta
-}
-
-// NewConfigVersionImport returns a fully configured ConfigVersionImport cop.
-func NewConfigVersionImport() *ConfigVersionImport {
-	return &ConfigVersionImport{Meta: cop.Meta{
-		CopName:     "Lint/ConfigVersionImport",
-		CopDesc:     "Config version packages must only import their immediate predecessor",
-		CopSeverity: cop.Error,
-	}}
-}
-
-func (c *ConfigVersionImport) Check(p *cop.Pass) {
-	if len(p.File.Imports) == 0 {
-		return
-	}
-	// Black-box test files (package <dir>_test) are external to the package
-	// and may import what they please.
-	if p.IsBlackBoxTest() {
-		return
-	}
-
-	dir, ok := p.PathSegment("pkg/config")
-	if !ok {
-		return
-	}
-	dirVersion, isVersioned := versionFromDir(dir)
-	isLatest := dir == "latest"
-	if !isVersioned && !isLatest {
-		return
-	}
-
-	for _, imp := range p.File.Imports {
-		path := cop.ImportPath(imp)
-
-		if !strings.Contains(path, "pkg/config/") || strings.HasSuffix(path, "pkg/config/types") {
-			continue
+var ConfigVersionImport = &cop.Func{
+	Meta: cop.Meta{
+		Name:        "Lint/ConfigVersionImport",
+		Description: "Config version packages must only import their immediate predecessor",
+		Severity:    cop.Error,
+	},
+	Scope: cop.And(
+		cop.InPathSegment("pkg/config", func(seg string) bool {
+			if seg == "latest" {
+				return true
+			}
+			_, ok := versionFromDir(seg)
+			return ok
+		}),
+		// Black-box test files (package <dir>_test) are external to the
+		// package and may import what they please.
+		cop.NotBlackBoxTest(),
+	),
+	Run: func(p *cop.Pass) {
+		if len(p.File.Imports) == 0 {
+			return
 		}
-		if msg := importViolation(path, dirVersion, isLatest); msg != "" {
-			p.Report(imp.Path, "%s", msg)
+
+		dir, _ := p.PathSegment("pkg/config")
+		dirVersion, isVersioned := versionFromDir(dir)
+		isLatest := dir == "latest"
+
+		for _, imp := range p.File.Imports {
+			path := cop.ImportPath(imp)
+
+			if !strings.Contains(path, "pkg/config/") || strings.HasSuffix(path, "pkg/config/types") {
+				continue
+			}
+			if msg := importViolation(path, dirVersion, isVersioned, isLatest); msg != "" {
+				p.Reportf(imp.Path, "%s", msg)
+			}
 		}
-	}
+	},
 }
 
 // importViolation returns a non-empty error message if the given import path
 // is forbidden inside a config-version package, or "" if the import is fine.
-// dirVersion is the importing package's N (only meaningful when !isLatest).
-func importViolation(path string, dirVersion int, isLatest bool) string {
+// dirVersion is the importing package's N (only meaningful when isVersioned).
+func importViolation(path string, dirVersion int, isVersioned, isLatest bool) string {
 	if isLatest {
 		// pkg/config/latest may only import other config-version packages.
 		// (The "must be the immediate predecessor" rule lives in the
@@ -68,6 +63,10 @@ func importViolation(path string, dirVersion int, isLatest bool) string {
 			return ""
 		}
 		return "pkg/config/latest must only import config version or types packages, not " + path
+	}
+
+	if !isVersioned {
+		return ""
 	}
 
 	// Versioned package (vN).

--- a/lint/config_versions_registered.go
+++ b/lint/config_versions_registered.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"strings"
 
 	"github.com/dgageot/rubocop-go/cop"
 )
@@ -27,46 +26,36 @@ import (
 //
 // The cop only inspects pkg/config/versions.go and reports any package that
 // exists under pkg/config/ but is not registered.
-type ConfigVersionsRegistered struct {
-	cop.Meta
-}
-
-// NewConfigVersionsRegistered returns a fully configured
-// ConfigVersionsRegistered cop.
-func NewConfigVersionsRegistered() *ConfigVersionsRegistered {
-	return &ConfigVersionsRegistered{Meta: cop.Meta{
-		CopName:     "Lint/ConfigVersionsRegistered",
-		CopDesc:     "pkg/config/versions.go must register every pkg/config/vN and pkg/config/latest package",
-		CopSeverity: cop.Error,
-	}}
-}
-
-func (c *ConfigVersionsRegistered) Check(p *cop.Pass) {
-	if !p.FileMatches("pkg/config/versions.go") {
-		return
-	}
-
-	want, err := versionPackagesOnDisk(filepath.Dir(p.Filename()))
-	if err != nil || len(want) == 0 {
-		return
-	}
-	got := p.SelectorReceivers("Register")
-
-	var missing []string
-	for _, name := range want {
-		if !got[name] {
-			missing = append(missing, name)
+var ConfigVersionsRegistered = &cop.Func{
+	Meta: cop.Meta{
+		Name:        "Lint/ConfigVersionsRegistered",
+		Description: "pkg/config/versions.go must register every pkg/config/vN and pkg/config/latest package",
+		Severity:    cop.Error,
+	},
+	Scope: cop.OnlyFile("pkg/config/versions.go"),
+	Run: func(p *cop.Pass) {
+		want, err := versionPackagesOnDisk(filepath.Dir(p.Filename()))
+		if err != nil || len(want) == 0 {
+			return
 		}
-	}
-	if len(missing) == 0 {
-		return
-	}
-	slices.Sort(missing)
+		got := p.SelectorReceivers("Register")
 
-	// Anchor the diagnostic on the function declaration so the message points
-	// at the registry rather than at the package clause.
-	p.Report(registryAnchor(p),
-		"pkg/config/versions.go is missing Register call(s) for: %s", strings.Join(missing, ", "))
+		var missing []string
+		for _, name := range want {
+			if !got[name] {
+				missing = append(missing, name)
+			}
+		}
+
+		// Anchor the diagnostic on the function declaration so the message
+		// points at the registry rather than at the package clause.
+		anchor := ast.Node(p.File.Name)
+		if fn := p.FuncDecl("versions"); fn != nil {
+			anchor = fn.Name
+		}
+		p.ReportMissing(anchor,
+			"pkg/config/versions.go is missing Register call(s) for: %s", missing)
+	},
 }
 
 // versionPackagesOnDisk lists the package directories under pkg/config/ that
@@ -92,18 +81,4 @@ func versionPackagesOnDisk(dir string) ([]string, error) {
 	}
 	slices.Sort(names)
 	return names, nil
-}
-
-// registryAnchor picks the AST node used to position the offense. Preferring
-// the `versions` function declaration keeps the diagnostic close to the
-// dispatch table; if that function is absent (unexpected), the file's
-// package clause is used as a fallback.
-func registryAnchor(p *cop.Pass) ast.Node {
-	var anchor ast.Node = p.File.Name
-	p.ForEachFunc(func(fn *ast.FuncDecl) {
-		if fn.Name.Name == "versions" {
-			anchor = fn.Name
-		}
-	})
-	return anchor
 }

--- a/lint/configpath.go
+++ b/lint/configpath.go
@@ -3,8 +3,8 @@ package main
 import (
 	"os"
 	"path/filepath"
-	"regexp"
 	"strconv"
+	"strings"
 	"sync"
 )
 
@@ -25,22 +25,16 @@ func versionFromDir(dir string) (int, bool) {
 	return n, true
 }
 
-// versionedImportRe matches a versioned config import path of the form
-// ".../pkg/config/vN" at the end of an import path.
-var versionedImportRe = regexp.MustCompile(`pkg/config/v(\d+)$`)
-
 // versionFromImport returns N if importPath ends with "pkg/config/vN".
+// Re-uses [versionFromDir] for the vN suffix, so the two helpers cannot
+// drift apart.
 func versionFromImport(importPath string) (int, bool) {
-	m := versionedImportRe.FindStringSubmatch(importPath)
-	if m == nil {
+	const marker = "pkg/config/"
+	idx := strings.LastIndex(importPath, marker)
+	if idx < 0 {
 		return 0, false
 	}
-	n, err := strconv.Atoi(m[1])
-	if err != nil {
-		// Should never happen since regex only captures digits.
-		return 0, false
-	}
-	return n, true
+	return versionFromDir(importPath[idx+len(marker):])
 }
 
 // highestSiblingVersion returns the largest N such that pkg/config/vN/

--- a/lint/hook_builtins_registered.go
+++ b/lint/hook_builtins_registered.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"go/ast"
-	"slices"
-	"strings"
 
 	"github.com/dgageot/rubocop-go/cop"
 )
@@ -39,54 +37,37 @@ import (
 // Files named builtins.go itself, *_test.go, and testhelpers_test.go are
 // excluded from the constant scan because they are not where new
 // builtins land.
-type HookBuiltinsRegistered struct {
-	cop.Meta
-}
+var HookBuiltinsRegistered = &cop.Func{
+	Meta: cop.Meta{
+		Name:        "Lint/HookBuiltinsRegistered",
+		Description: "every builtin name constant under pkg/hooks/builtins/ must appear in a RegisterBuiltin call",
+		Severity:    cop.Error,
+	},
+	Scope: cop.OnlyFile("pkg/hooks/builtins/builtins.go"),
+	Run: func(p *cop.Pass) {
+		declared, err := exportedBuiltinNames(p)
+		if err != nil || len(declared) == 0 {
+			return
+		}
 
-// NewHookBuiltinsRegistered returns a fully configured
-// HookBuiltinsRegistered cop.
-func NewHookBuiltinsRegistered() *HookBuiltinsRegistered {
-	return &HookBuiltinsRegistered{Meta: cop.Meta{
-		CopName:     "Lint/HookBuiltinsRegistered",
-		CopDesc:     "every builtin name constant under pkg/hooks/builtins/ must appear in a RegisterBuiltin call",
-		CopSeverity: cop.Error,
-	}}
-}
+		registered := p.IdentSetFromCalls("RegisterBuiltin", 0)
 
-func (c *HookBuiltinsRegistered) Check(p *cop.Pass) {
-	if !p.FileMatches("pkg/hooks/builtins/builtins.go") {
-		return
-	}
+		var missing []string
+		for _, name := range declared {
+			if !registered[name] {
+				missing = append(missing, name)
+			}
+		}
 
-	declared, err := exportedBuiltinNames(p)
-	if err != nil || len(declared) == 0 {
-		return
-	}
-
-	registered := p.IdentSetFromCalls("RegisterBuiltin", 0)
-
-	// Anchor on the first RegisterBuiltin call, falling back to the package
-	// clause if the function was reshaped beyond recognition.
-	var anchor ast.Node = p.File.Name
-	p.ForEachMethodCall("RegisterBuiltin", func(call *ast.CallExpr) {
-		if anchor == p.File.Name {
+		// Anchor on the first RegisterBuiltin call, falling back to the
+		// package clause if the function was reshaped beyond recognition.
+		var anchor ast.Node = p.File.Name
+		if call := p.FirstMethodCall("RegisterBuiltin"); call != nil {
 			anchor = call
 		}
-	})
-
-	var missing []string
-	for _, name := range declared {
-		if !registered[name] {
-			missing = append(missing, name)
-		}
-	}
-	if len(missing) == 0 {
-		return
-	}
-	slices.Sort(missing)
-	p.Report(anchor,
-		"pkg/hooks/builtins/builtins.go is missing RegisterBuiltin call(s) for: %s",
-		strings.Join(missing, ", "))
+		p.ReportMissing(anchor,
+			"pkg/hooks/builtins/builtins.go is missing RegisterBuiltin call(s) for: %s", missing)
+	},
 }
 
 // exportedBuiltinNames returns the identifiers of every exported `const Name = "..."`
@@ -110,6 +91,5 @@ func exportedBuiltinNames(p *cop.Pass) ([]string, error) {
 	for n := range seen {
 		names = append(names, n)
 	}
-	slices.Sort(names)
 	return names, nil
 }

--- a/lint/hook_config_sync.go
+++ b/lint/hook_config_sync.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"go/ast"
-	"reflect"
-	"slices"
 	"strconv"
 	"strings"
 
@@ -34,103 +31,72 @@ import (
 // cop runs on pkg/config/latest/types.go (where the diagnostic anchors
 // on the HooksConfig type spec) and parses pkg/hooks/types.go from disk
 // for the source of truth.
-type HookConfigSync struct {
-	cop.Meta
-}
-
-// NewHookConfigSync returns a fully configured HookConfigSync cop.
-func NewHookConfigSync() *HookConfigSync {
-	return &HookConfigSync{Meta: cop.Meta{
-		CopName:     "Lint/HookConfigSync",
-		CopDesc:     "EventXxx constants in pkg/hooks/types.go must match HooksConfig fields in pkg/config/latest",
-		CopSeverity: cop.Error,
-	}}
-}
-
-func (c *HookConfigSync) Check(p *cop.Pass) {
-	if !p.FileMatches("pkg/config/latest/types.go") {
-		return
-	}
-
-	// pkg/config/latest/types.go ↔ ../../hooks/types.go
-	hookFile, err := p.ParseSibling("../../hooks/types.go")
-	if err != nil {
-		return
-	}
-	hookEvents := cop.StringConstsIn(hookFile, func(name string) bool {
-		return strings.HasPrefix(name, "Event")
-	})
-	if len(hookEvents) == 0 {
-		return
-	}
-
-	cfgFields, hooksConfigSpec := readHooksConfigFields(p)
-	if hooksConfigSpec == nil {
-		// Schema didn't ship HooksConfig (or this isn't the right
-		// types.go) — nothing meaningful the cop can say.
-		return
-	}
-
-	// Build reverse map for diagnostics.
-	cfgByJSON := map[string]string{} // wire-string -> Go field name
-	for goName, jsonName := range cfgFields {
-		cfgByJSON[jsonName] = goName
-	}
-
-	// Direction 1: every event must have a config field.
-	var missingFields []string
-	for constName, wire := range hookEvents {
-		if _, ok := cfgByJSON[wire]; !ok {
-			missingFields = append(missingFields, constName+"="+strconv.Quote(wire))
+var HookConfigSync = &cop.Func{
+	Meta: cop.Meta{
+		Name:        "Lint/HookConfigSync",
+		Description: "EventXxx constants in pkg/hooks/types.go must match HooksConfig fields in pkg/config/latest",
+		Severity:    cop.Error,
+	},
+	Scope: cop.OnlyFile("pkg/config/latest/types.go"),
+	Run: func(p *cop.Pass) {
+		// pkg/config/latest/types.go ↔ ../../hooks/types.go
+		hookFile, err := p.ParseSibling("../../hooks/types.go")
+		if err != nil {
+			return
 		}
-	}
-	if len(missingFields) > 0 {
-		slices.Sort(missingFields)
-		p.Report(hooksConfigSpec.Name,
-			"HooksConfig is missing field(s) for hook event(s): %s", strings.Join(missingFields, ", "))
-	}
-
-	// Direction 2: every config field must have an event constant.
-	wireSet := map[string]string{} // wire -> const name
-	for n, w := range hookEvents {
-		wireSet[w] = n
-	}
-	var orphanFields []string
-	for goName, jsonName := range cfgFields {
-		if _, ok := wireSet[jsonName]; !ok {
-			orphanFields = append(orphanFields, goName+" json:"+strconv.Quote(jsonName))
+		hookEvents := cop.StringConstsIn(hookFile, func(name string) bool {
+			return strings.HasPrefix(name, "Event")
+		})
+		if len(hookEvents) == 0 {
+			return
 		}
-	}
-	if len(orphanFields) > 0 {
-		slices.Sort(orphanFields)
-		p.Report(hooksConfigSpec.Name,
+
+		ts, st := p.StructType("HooksConfig")
+		if ts == nil {
+			// Schema didn't ship HooksConfig (or this isn't the right
+			// types.go) — nothing meaningful the cop can say.
+			return
+		}
+
+		// Build Go-name -> wire-name and the reverse, to diff in both directions.
+		cfgFields := map[string]string{}
+		for _, fld := range st.Fields.List {
+			opts, ok := cop.ParseTagOptions(cop.FieldTag(fld), "json")
+			if !ok || !opts.HasName() {
+				continue
+			}
+			for _, n := range fld.Names {
+				cfgFields[n.Name] = opts.Name
+			}
+		}
+		cfgByJSON := map[string]string{}
+		for goName, jsonName := range cfgFields {
+			cfgByJSON[jsonName] = goName
+		}
+
+		// Direction 1: every event must have a config field.
+		var missingFields []string
+		for constName, wire := range hookEvents {
+			if _, ok := cfgByJSON[wire]; !ok {
+				missingFields = append(missingFields, constName+"="+strconv.Quote(wire))
+			}
+		}
+		p.ReportMissing(ts.Name,
+			"HooksConfig is missing field(s) for hook event(s): %s", missingFields)
+
+		// Direction 2: every config field must have an event constant.
+		wireSet := map[string]string{}
+		for n, w := range hookEvents {
+			wireSet[w] = n
+		}
+		var orphanFields []string
+		for goName, jsonName := range cfgFields {
+			if _, ok := wireSet[jsonName]; !ok {
+				orphanFields = append(orphanFields, goName+" json:"+strconv.Quote(jsonName))
+			}
+		}
+		p.ReportMissing(ts.Name,
 			"HooksConfig field(s) without a matching EventXxx constant in pkg/hooks/types.go: %s",
-			strings.Join(orphanFields, ", "))
-	}
-}
-
-// readHooksConfigFields scans the file in p for the HooksConfig type and
-// returns the field-name -> json-tag-name map together with the type spec
-// itself (so the caller can anchor diagnostics on it).
-func readHooksConfigFields(p *cop.Pass) (map[string]string, *ast.TypeSpec) {
-	fields := map[string]string{}
-	var spec *ast.TypeSpec
-	p.ForEachStructField(func(ts *ast.TypeSpec, fld *ast.Field, tag reflect.StructTag) {
-		if ts.Name.Name != "HooksConfig" {
-			return
-		}
-		spec = ts
-		jsonTag, ok := tag.Lookup("json")
-		if !ok {
-			return
-		}
-		name, _, _ := strings.Cut(jsonTag, ",")
-		if name == "" || name == "-" {
-			return
-		}
-		for _, n := range fld.Names {
-			fields[n.Name] = name
-		}
-	})
-	return fields, spec
+			orphanFields)
+	},
 }

--- a/lint/latest_imports_predecessor.go
+++ b/lint/latest_imports_predecessor.go
@@ -13,41 +13,33 @@ import (
 // This cop closes that gap so pkg/config/latest also obeys the chain
 // (latest imports the highest vN, never an older version), which is required
 // for the upgrade pipeline to reach the latest schema in a single hop.
-type LatestImportsPredecessor struct {
-	cop.Meta
-}
-
-// NewLatestImportsPredecessor returns a fully configured LatestImportsPredecessor cop.
-func NewLatestImportsPredecessor() *LatestImportsPredecessor {
-	return &LatestImportsPredecessor{Meta: cop.Meta{
-		CopName:     "Lint/LatestImportsPredecessor",
-		CopDesc:     "pkg/config/latest must only import its immediate predecessor (highest vN)",
-		CopSeverity: cop.Error,
-	}}
-}
-
-func (c *LatestImportsPredecessor) Check(p *cop.Pass) {
-	if len(p.File.Imports) == 0 {
-		return
-	}
-	// Black-box test files (package latest_test) are external to the package
-	// and may import what they please.
-	if p.IsBlackBoxTest() {
-		return
-	}
-	if dir, _ := p.PathSegment("pkg/config"); dir != "latest" {
-		return
-	}
-	highest, ok := highestSiblingVersion(p.Filename())
-	if !ok {
-		return
-	}
-
-	for _, imp := range p.File.Imports {
-		got, ok := versionFromImport(cop.ImportPath(imp))
-		if !ok || got == highest {
-			continue
+var LatestImportsPredecessor = &cop.Func{
+	Meta: cop.Meta{
+		Name:        "Lint/LatestImportsPredecessor",
+		Description: "pkg/config/latest must only import its immediate predecessor (highest vN)",
+		Severity:    cop.Error,
+	},
+	Scope: cop.And(
+		cop.InPathSegment("pkg/config", func(seg string) bool { return seg == "latest" }),
+		// Black-box test files (package latest_test) are external to the
+		// package and may import what they please.
+		cop.NotBlackBoxTest(),
+	),
+	Run: func(p *cop.Pass) {
+		if len(p.File.Imports) == 0 {
+			return
 		}
-		p.Report(imp.Path, "pkg/config/latest must import its predecessor v%d, not v%d", highest, got)
-	}
+		highest, ok := highestSiblingVersion(p.Filename())
+		if !ok {
+			return
+		}
+
+		for _, imp := range p.File.Imports {
+			got, ok := versionFromImport(cop.ImportPath(imp))
+			if !ok || got == highest {
+				continue
+			}
+			p.Reportf(imp.Path, "pkg/config/latest must import its predecessor v%d, not v%d", highest, got)
+		}
+	},
 }

--- a/lint/main.go
+++ b/lint/main.go
@@ -12,23 +12,23 @@ import (
 	"github.com/dgageot/rubocop-go/runner"
 )
 
-// allCops returns the project-specific cops, in declaration order.
-// To add a cop: implement cop.Cop and append it here.
-func allCops() []cop.Cop {
-	return []cop.Cop{
-		NewConfigVersionImport(),
-		NewConfigPackageName(),
-		NewConfigVersionConstant(),
-		NewLatestImportsPredecessor(),
-		NewConfigLatestTagConsistency(),
-		NewConfigVersionsRegistered(),
-		NewTUIViewPurity(),
-		NewRuntimeEventRegistry(),
-		NewRuntimeSessionScoped(),
-		NewHookConfigSync(),
-		NewHookBuiltinsRegistered(),
-		NewSlogContextual(),
-	}
+// cops lists every project-specific cop, in declaration order.
+//
+// To add a cop: declare it as a var in its own file using cop.New (or a
+// cop.Func literal when it needs Scope/Types) and append it here.
+var cops = []cop.Cop{
+	ConfigVersionImport,
+	ConfigPackageName,
+	ConfigVersionConstant,
+	LatestImportsPredecessor,
+	ConfigLatestTagConsistency,
+	ConfigVersionsRegistered,
+	TUIViewPurity,
+	RuntimeEventRegistry,
+	RuntimeSessionScoped,
+	HookConfigSync,
+	HookBuiltinsRegistered,
+	SlogContextual,
 }
 
 func main() {
@@ -37,7 +37,7 @@ func main() {
 		paths = []string{"."}
 	}
 
-	r := runner.New(allCops(), config.DefaultConfig(), os.Stdout)
+	r := runner.New(cops, config.DefaultConfig(), os.Stdout)
 	offenseCount, err := r.Run(paths)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)

--- a/lint/runtime_event_registry.go
+++ b/lint/runtime_event_registry.go
@@ -3,7 +3,6 @@ package main
 import (
 	"go/ast"
 	"go/token"
-	"slices"
 	"strconv"
 	"strings"
 
@@ -34,59 +33,46 @@ import (
 // finds in pkg/runtime/event.go. Each event type whose Type-string is
 // missing from the registry is reported with a diagnostic anchored on
 // the registry map literal, where the fix lives.
-type RuntimeEventRegistry struct {
-	cop.Meta
-}
-
-// NewRuntimeEventRegistry returns a fully configured RuntimeEventRegistry cop.
-func NewRuntimeEventRegistry() *RuntimeEventRegistry {
-	return &RuntimeEventRegistry{Meta: cop.Meta{
-		CopName:     "Lint/RuntimeEventRegistry",
-		CopDesc:     "pkg/runtime/client.go must register every runtime event type",
-		CopSeverity: cop.Error,
-	}}
-}
-
-func (c *RuntimeEventRegistry) Check(p *cop.Pass) {
-	if !p.FileMatches("pkg/runtime/client.go") {
-		return
-	}
-
-	// Sibling event.go is the source of truth for the set of emitted events.
-	eventFile, err := p.ParseSibling("event.go")
-	if err != nil {
-		return
-	}
-	emitted := emittedEventTypes(eventFile)
-	if len(emitted) == 0 {
-		return
-	}
-
-	registryNode, registered := registryEntries(p)
-	if registryNode == nil {
-		return
-	}
-
-	var missing []string
-	for typeName, typeStr := range emitted {
-		if got, ok := registered[typeStr]; !ok {
-			missing = append(missing, typeName+" (Type: "+strconv.Quote(typeStr)+")")
-		} else if got != typeName {
-			// The registry key is correct but it constructs the wrong
-			// concrete type. That is a different bug from "missing entry"
-			// so we keep it as a separate diagnostic anchored on the
-			// registry map for clarity.
-			p.Report(registryNode,
-				"registry key %q constructs %s but %s emits Type=%q",
-				typeStr, got, typeName, typeStr)
+var RuntimeEventRegistry = &cop.Func{
+	Meta: cop.Meta{
+		Name:        "Lint/RuntimeEventRegistry",
+		Description: "pkg/runtime/client.go must register every runtime event type",
+		Severity:    cop.Error,
+	},
+	Scope: cop.OnlyFile("pkg/runtime/client.go"),
+	Run: func(p *cop.Pass) {
+		// Sibling event.go is the source of truth for the set of emitted events.
+		eventFile, err := p.ParseSibling("event.go")
+		if err != nil {
+			return
 		}
-	}
-	if len(missing) == 0 {
-		return
-	}
-	slices.Sort(missing)
-	p.Report(registryNode,
-		"pkg/runtime/client.go is missing registry entries for: %s", strings.Join(missing, ", "))
+		emitted := emittedEventTypes(eventFile)
+		if len(emitted) == 0 {
+			return
+		}
+
+		registryNode, registered := registryEntries(p)
+		if registryNode == nil {
+			return
+		}
+
+		var missing []string
+		for typeName, typeStr := range emitted {
+			if got, ok := registered[typeStr]; !ok {
+				missing = append(missing, typeName+" (Type: "+strconv.Quote(typeStr)+")")
+			} else if got != typeName {
+				// The registry key is correct but it constructs the wrong
+				// concrete type. That is a different bug from "missing entry"
+				// so we keep it as a separate diagnostic anchored on the
+				// registry map for clarity.
+				p.Reportf(registryNode,
+					"registry key %q constructs %s but %s emits Type=%q",
+					typeStr, got, typeName, typeStr)
+			}
+		}
+		p.ReportMissing(registryNode,
+			"pkg/runtime/client.go is missing registry entries for: %s", missing)
+	},
 }
 
 // emittedEventTypes returns a map of EventTypeName -> wire-format Type
@@ -104,23 +90,7 @@ func emittedEventTypes(file *ast.File) map[string]string {
 		if !ok || !strings.HasSuffix(id.Name, "Event") {
 			return true
 		}
-		for _, elt := range cl.Elts {
-			kv, ok := elt.(*ast.KeyValueExpr)
-			if !ok {
-				continue
-			}
-			k, ok := kv.Key.(*ast.Ident)
-			if !ok || k.Name != "Type" {
-				continue
-			}
-			lit, ok := kv.Value.(*ast.BasicLit)
-			if !ok || lit.Kind != token.STRING {
-				continue
-			}
-			val, err := strconv.Unquote(lit.Value)
-			if err != nil {
-				continue
-			}
+		if val, ok := cop.StringField(cl, "Type"); ok {
 			emitted[id.Name] = val
 		}
 		return true
@@ -140,10 +110,7 @@ func registryEntries(p *cop.Pass) (ast.Node, map[string]string) {
 	registered := map[string]string{}
 	ast.Inspect(p.File, func(n ast.Node) bool {
 		cl, ok := n.(*ast.CompositeLit)
-		if !ok {
-			return true
-		}
-		if !isEventRegistryType(cl.Type) {
+		if !ok || !isEventRegistryType(cl.Type) {
 			return true
 		}
 		found = cl
@@ -180,22 +147,14 @@ func isEventRegistryType(expr ast.Expr) bool {
 	if !ok {
 		return false
 	}
-	keyID, ok := mt.Key.(*ast.Ident)
-	if !ok || keyID.Name != "string" {
+	if k, ok := mt.Key.(*ast.Ident); !ok || k.Name != "string" {
 		return false
 	}
 	ft, ok := mt.Value.(*ast.FuncType)
 	if !ok {
 		return false
 	}
-	if ft.Params != nil && len(ft.Params.List) != 0 {
-		return false
-	}
-	if ft.Results == nil || len(ft.Results.List) != 1 {
-		return false
-	}
-	rid, ok := ft.Results.List[0].Type.(*ast.Ident)
-	return ok && rid.Name == "Event"
+	return cop.IsNullarySig(ft, "Event")
 }
 
 // returnedEventType pulls "FooEvent" out of a `func() Event { return &FooEvent{} }`
@@ -213,18 +172,16 @@ func returnedEventType(expr ast.Expr) (string, bool) {
 			continue
 		}
 		ue, ok := ret.Results[0].(*ast.UnaryExpr)
-		if !ok || ue.Op != token.AND {
+		if !ok {
 			continue
 		}
 		cl, ok := ue.X.(*ast.CompositeLit)
 		if !ok {
 			continue
 		}
-		id, ok := cl.Type.(*ast.Ident)
-		if !ok {
-			continue
+		if id, ok := cl.Type.(*ast.Ident); ok {
+			return id.Name, true
 		}
-		return id.Name, true
 	}
 	return "", false
 }

--- a/lint/runtime_session_scoped.go
+++ b/lint/runtime_session_scoped.go
@@ -27,38 +27,29 @@ import (
 //
 // The cop runs on pkg/runtime/event.go and reports any *Event struct with
 // a SessionID field whose pointer type lacks GetSessionID().
-type RuntimeSessionScoped struct {
-	cop.Meta
-}
-
-// NewRuntimeSessionScoped returns a fully configured RuntimeSessionScoped cop.
-func NewRuntimeSessionScoped() *RuntimeSessionScoped {
-	return &RuntimeSessionScoped{Meta: cop.Meta{
-		CopName:     "Lint/RuntimeSessionScoped",
-		CopDesc:     "runtime events with a SessionID field must implement GetSessionID() (SessionScoped)",
-		CopSeverity: cop.Error,
-	}}
-}
-
-func (c *RuntimeSessionScoped) Check(p *cop.Pass) {
-	if !p.FileMatches("pkg/runtime/event.go") {
-		return
-	}
-
-	withSessionID := eventStructsWithSessionID(p)
-	if len(withSessionID) == 0 {
-		return
-	}
-	implementsScoped := pointerReceiversWithMethod(p, "GetSessionID")
-
-	for typeName, typeSpec := range withSessionID {
-		if !implementsScoped[typeName] {
-			p.Report(typeSpec.Name,
-				"%s carries a SessionID field but does not implement GetSessionID() (SessionScoped); "+
-					"sub-agent events of this type would bypass the persistence-observer session filter",
-				typeName)
+var RuntimeSessionScoped = &cop.Func{
+	Meta: cop.Meta{
+		Name:        "Lint/RuntimeSessionScoped",
+		Description: "runtime events with a SessionID field must implement GetSessionID() (SessionScoped)",
+		Severity:    cop.Error,
+	},
+	Scope: cop.OnlyFile("pkg/runtime/event.go"),
+	Run: func(p *cop.Pass) {
+		withSessionID := eventStructsWithSessionID(p)
+		if len(withSessionID) == 0 {
+			return
 		}
-	}
+		implementsScoped := p.PointerReceiverMethods("GetSessionID")
+
+		for typeName, typeSpec := range withSessionID {
+			if !implementsScoped[typeName] {
+				p.Reportf(typeSpec.Name,
+					"%s carries a SessionID field but does not implement GetSessionID() (SessionScoped); "+
+						"sub-agent events of this type would bypass the persistence-observer session filter",
+					typeName)
+			}
+		}
+	},
 }
 
 // eventStructsWithSessionID maps EventTypeName -> its declaring *ast.TypeSpec
@@ -79,20 +70,4 @@ func eventStructsWithSessionID(p *cop.Pass) map[string]*ast.TypeSpec {
 		}
 	})
 	return out
-}
-
-// pointerReceiversWithMethod returns the set of type names T for which the
-// file declares `func (* T) <method>(...)`. Used to detect interface
-// satisfaction without invoking the type checker.
-func pointerReceiversWithMethod(p *cop.Pass, method string) map[string]bool {
-	with := map[string]bool{}
-	p.ForEachFunc(func(fn *ast.FuncDecl) {
-		if fn.Name.Name != method {
-			return
-		}
-		if r, ok := cop.Receiver(fn); ok && r.IsPointer {
-			with[r.TypeName] = true
-		}
-	})
-	return with
 }

--- a/lint/slog_contextual.go
+++ b/lint/slog_contextual.go
@@ -35,177 +35,34 @@ import (
 // thread a context through APIs that don't otherwise need one.
 //
 // Per-line suppression: `//rubocop:disable Lint/SlogContextual`.
-type SlogContextual struct {
-	cop.Meta
-}
-
-// NewSlogContextual returns a fully configured SlogContextual cop.
-func NewSlogContextual() *SlogContextual {
-	return &SlogContextual{Meta: cop.Meta{
-		CopName:     "Lint/SlogContextual",
-		CopDesc:     "use slog.{Level}Context(ctx, …) when a context is in scope",
-		CopSeverity: cop.Warning,
-	}}
-}
-
-// slogLevels is the set of slog top-level helpers whose Context-aware
-// sibling (e.g. Debug → DebugContext) should be preferred when a context
-// is in scope. slog.Log / slog.LogAttrs already take a context.
-var slogLevels = map[string]bool{
-	"Debug": true,
-	"Info":  true,
-	"Warn":  true,
-	"Error": true,
-}
-
-func (c *SlogContextual) Check(p *cop.Pass) {
-	p.ForEachFunc(func(fn *ast.FuncDecl) {
-		if fn.Body != nil {
-			c.checkFunc(p, fn.Type, fn.Body, false)
-		}
-	})
-}
-
-// checkFunc reports bare slog calls inside body when a context is reachable
-// from any enclosing function. outerHasContext propagates that visibility
-// into nested function literals, since closures capture by name.
-func (c *SlogContextual) checkFunc(p *cop.Pass, typ *ast.FuncType, body *ast.BlockStmt, outerHasContext bool) {
-	hasContext := outerHasContext || signatureDeclaresContext(typ) || bodyDeclaresContext(body)
-	ast.Inspect(body, func(n ast.Node) bool {
-		switch x := n.(type) {
-		case *ast.FuncLit:
-			c.checkFunc(p, x.Type, x.Body, hasContext)
-			return false
-		case *ast.CallExpr:
-			if hasContext {
-				c.reportIfBareSlog(p, x)
-			}
-		}
-		return true
-	})
-}
-
-// reportIfBareSlog reports an offense when call is `slog.<Level>(...)`
-// for one of the four level helpers that have a Context-aware sibling.
-func (c *SlogContextual) reportIfBareSlog(p *cop.Pass, call *ast.CallExpr) {
-	pkg, level, ok := cop.MatchSelector(call.Fun)
-	if !ok || pkg != "slog" || !slogLevels[level] {
-		return
-	}
-	p.Report(call,
-		"a context is in scope; use slog.%s(ctx, …) instead of slog.%s so handlers (e.g. OpenTelemetry) can read it",
-		level+"Context", level)
-}
-
-// signatureDeclaresContext reports whether typ declares any parameter or
-// named result of type context.Context.
-func signatureDeclaresContext(typ *ast.FuncType) bool {
-	for _, fl := range []*ast.FieldList{typ.Params, typ.Results} {
-		if fl == nil {
-			continue
-		}
-		for _, f := range fl.List {
-			if !isContextContextType(f.Type) {
-				continue
-			}
-			// Anonymous parameter (e.g., `func(context.Context)`) has no names
-			// but still declares a context in scope.
-			if len(f.Names) == 0 {
-				return true
-			}
-			for _, n := range f.Names {
-				if namedIdent(n) {
+var SlogContextual = &cop.Func{
+	Meta: cop.Meta{
+		Name:        "Lint/SlogContextual",
+		Description: "use slog.{Level}Context(ctx, …) when a context is in scope",
+		Severity:    cop.Warning,
+	},
+	Run: func(p *cop.Pass) {
+		p.ForEachFunc(func(fn *ast.FuncDecl) {
+			cop.WalkFuncWithContextScope(fn.Type, fn.Body, false, func(n ast.Node, hasContext bool) bool {
+				if !hasContext {
 					return true
 				}
-			}
-		}
-	}
-	return false
-}
-
-// bodyDeclaresContext reports whether body locally binds an identifier to
-// a context.Context value. Nested function literals are skipped — their
-// bindings are inspected separately when checkFunc recurses into them.
-func bodyDeclaresContext(body *ast.BlockStmt) bool {
-	found := false
-	ast.Inspect(body, func(n ast.Node) bool {
-		if found {
-			return false
-		}
-		switch s := n.(type) {
-		case *ast.FuncLit:
-			return false
-		case *ast.AssignStmt:
-			found = bindsContext(s.Lhs, s.Rhs)
-		case *ast.ValueSpec:
-			found = valueSpecDeclaresContext(s)
-		}
-		return !found
-	})
-	return found
-}
-
-// valueSpecDeclaresContext reports whether s declares a context.Context,
-// either explicitly via its declared type (`var ctx context.Context`) or
-// implicitly via its initializer (`var ctx = context.Background()`).
-func valueSpecDeclaresContext(s *ast.ValueSpec) bool {
-	if isContextContextType(s.Type) {
-		for _, n := range s.Names {
-			if namedIdent(n) {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				// slog.Log / slog.LogAttrs already take a context; only the
+				// four bare level helpers below have a *Context sibling.
+				level, ok := cop.CallTo(call, "slog", "Debug", "Info", "Warn", "Error")
+				if !ok {
+					return true
+				}
+				p.Reportf(call,
+					"a context is in scope; use slog.%sContext(ctx, …) instead of slog.%s "+
+						"so handlers (e.g. OpenTelemetry) can read it",
+					level, level)
 				return true
-			}
-		}
-	}
-	if len(s.Values) == 0 {
-		return false
-	}
-	lhs := make([]ast.Expr, len(s.Names))
-	for i, n := range s.Names {
-		lhs[i] = n
-	}
-	return bindsContext(lhs, s.Values)
-}
-
-// bindsContext reports whether the assignment binds at least one LHS
-// identifier to a context.Context value. A single RHS covers both
-// single-value forms (`ctx := f()`) and multi-value returns
-// (`ctx, cancel := context.WithCancel(...)`); in the latter case the
-// context is always at the first return position — `_, cancel := ...`
-// discards the context and intentionally yields no in-scope name.
-func bindsContext(lhs, rhs []ast.Expr) bool {
-	if len(rhs) == 1 {
-		return len(lhs) >= 1 && contextProducer(rhs[0]) && namedIdent(lhs[0])
-	}
-	for i := 0; i < len(lhs) && i < len(rhs); i++ {
-		if contextProducer(rhs[i]) && namedIdent(lhs[i]) {
-			return true
-		}
-	}
-	return false
-}
-
-// namedIdent reports whether e is a named identifier — anonymous (`_`)
-// or unset names produce no usable scope binding.
-func namedIdent(e ast.Expr) bool {
-	id, ok := e.(*ast.Ident)
-	return ok && id.Name != "" && id.Name != "_"
-}
-
-// contextProducer reports whether expr is a call whose shape commonly
-// yields a context.Context: any call into the `context` package, or any
-// zero-arg method named `Context` (the cobra / http.Request convention).
-func contextProducer(expr ast.Expr) bool {
-	call, ok := expr.(*ast.CallExpr)
-	if !ok {
-		return false
-	}
-	pkg, sel, ok := cop.MatchSelector(call.Fun)
-	return ok && (pkg == "context" || (sel == "Context" && len(call.Args) == 0))
-}
-
-// isContextContextType reports whether expr is the syntactic type
-// `context.Context`.
-func isContextContextType(expr ast.Expr) bool {
-	pkg, sel, ok := cop.MatchSelector(expr)
-	return ok && pkg == "context" && sel == "Context"
+			})
+		})
+	},
 }

--- a/lint/tui_view_purity.go
+++ b/lint/tui_view_purity.go
@@ -29,36 +29,30 @@ import (
 //
 // Per-line suppression is provided centrally by the runner: annotate the
 // line with `//rubocop:disable Lint/TUIViewPurity` to opt out.
-type TUIViewPurity struct {
-	cop.Meta
+var TUIViewPurity = &cop.Func{
+	Meta: cop.Meta{
+		Name:        "Lint/TUIViewPurity",
+		Description: "View() methods on TUI models must not mutate the receiver",
+		Severity:    cop.Warning,
+	},
+	Scope: cop.UnderDir("pkg/tui"),
+	Run: func(p *cop.Pass) {
+		p.ForEachFunc(func(fn *ast.FuncDecl) {
+			recv, ok := cop.Receiver(fn)
+			if !ok || !recv.IsPointer || recv.Name == "" {
+				return
+			}
+			if fn.Name.Name != "View" || !cop.IsNullaryFunc(fn, "string") {
+				return
+			}
+			checkViewBody(p, fn.Body, recv.Name)
+		})
+	},
 }
 
-// NewTUIViewPurity returns a fully configured TUIViewPurity cop.
-func NewTUIViewPurity() *TUIViewPurity {
-	return &TUIViewPurity{Meta: cop.Meta{
-		CopName:     "Lint/TUIViewPurity",
-		CopDesc:     "View() methods on TUI models must not mutate the receiver",
-		CopSeverity: cop.Warning,
-	}}
-}
-
-func (c *TUIViewPurity) Check(p *cop.Pass) {
-	if !p.FileUnder("pkg/tui") {
-		return
-	}
-
-	p.ForEachFunc(func(fn *ast.FuncDecl) {
-		recv, ok := cop.Receiver(fn)
-		if !ok || !recv.IsPointer || recv.Name == "" || !isViewMethod(fn) {
-			return
-		}
-		c.checkBody(p, fn.Body, recv.Name)
-	})
-}
-
-// checkBody walks fn body and reports an offense for every assignment to a
+// checkViewBody walks fn body and reports an offense for every assignment to a
 // receiver field that is not part of the slice-cache exemption set.
-func (c *TUIViewPurity) checkBody(p *cop.Pass, body *ast.BlockStmt, recv string) {
+func checkViewBody(p *cop.Pass, body *ast.BlockStmt, recv string) {
 	if body == nil {
 		return
 	}
@@ -75,30 +69,13 @@ func (c *TUIViewPurity) checkBody(p *cop.Pass, body *ast.BlockStmt, recv string)
 			if i < len(assign.Rhs) && isSliceCachePattern(assign.Rhs[i], recv, field) {
 				continue
 			}
-			p.Report(assign,
+			p.Reportf(assign,
 				"View() must not mutate %s.%s; move the side effect to Update or compute it in a local variable"+
 					" (or annotate the line with //rubocop:disable Lint/TUIViewPurity if it is an intentional click-zone cache)",
 				recv, field)
 		}
 		return true
 	})
-}
-
-// isViewMethod reports whether fn is exactly `func (...) View() string`.
-// The cop intentionally ignores helpers that happen to be called View*
-// because they are not part of the Bubble Tea contract.
-func isViewMethod(fn *ast.FuncDecl) bool {
-	if fn.Name.Name != "View" {
-		return false
-	}
-	if fn.Type.Params != nil && len(fn.Type.Params.List) > 0 {
-		return false
-	}
-	if fn.Type.Results == nil || len(fn.Type.Results.List) != 1 {
-		return false
-	}
-	id, ok := fn.Type.Results.List[0].Type.(*ast.Ident)
-	return ok && id.Name == "string"
 }
 
 // isSliceCachePattern reports whether rhs is one of the recognised


### PR DESCRIPTION
Adopts the new `rubocop-go` DSL across all 12 custom cops in `lint/`. Behaviour is unchanged — same offenses, same anchors, same severities — but the cops read better and a lot of plumbing moved into the library.

## What changed

- **`cop.Func` literal style everywhere.** Each cop is now a single `&cop.Func{Meta, Scope, Run}` value. The `type CopX struct { cop.Meta }` + `NewCopX()` constructor + `Check` method triplet is gone.
- **Declarative scope.** File-scope guards (`if !p.FileMatches(...) { return }`) are gone from `Check` bodies; cops declare their scope as data and the runner skips out-of-scope files entirely:

  ```go
  Scope: cop.UnderDir("pkg/tui"),
  Scope: cop.OnlyFile("pkg/runtime/event.go"),
  Scope: cop.And(cop.InPathSegment("pkg/config", isLatest), cop.NotBlackBoxTest()),
  ```

- **Library helpers absorbed boilerplate.** Cops now use:
  - `Pass.ReportMissing(anchor, fmt, names)` — replaces the sort + join + empty-check pattern in 5 dispatch-table cops
  - `Pass.PointerReceiverMethods(name)`, `Pass.StructType(name)`, `Pass.FirstMethodCall(name)`, `Pass.FuncDecl(name)` — direct lookups instead of hand-rolled `ForEach...` filter loops
  - `cop.WalkFuncWithContextScope` — the ~120 LOC of context-scope analysis from `slog_contextual.go` lifted into the library
  - `cop.StringField`, `cop.ParseTagOptions`, `cop.FieldNames`, `cop.FieldTag`, `cop.IsNullaryFunc`, `cop.CallTo` — small helpers for shapes that recurred across cops
- **Dropped the regex in `configpath.go`** in favour of a one-line `LastIndex` + delegation to `versionFromDir`, removing a drift point between the two helpers.
- **`main.go`'s registry** is now a flat `var cops = []cop.Cop{...}` of literal vars instead of a `[]cop.Cop{NewX(), ...}` builder.

## Numbers

|                                     |  Before |              After |
| ----------------------------------- | ------: | -----------------: |
| `lint/` LOC                         |    1390 |      1151 (−17%)   |
| Project-private helper functions    |     ~20 | ~12 (8 absorbed into the library) |

## Validation

- `task build`, `task test`, `task lint` — all green
- Negative-tested `TUIViewPurity`, `SlogContextual` (parameter-declared / nested funclit / discarded multi-return), and `RuntimeSessionScoped` — same offenses, same anchors, same wording as before

## Note for reviewers

The cops report 4 pre-existing offenses on current `main` (in `pkg/attachment/modelcaps/modelcaps.go`, `pkg/model/provider/anthropic/federation/federation.go`, `pkg/model/provider/openai/client.go`). They exist on `main` with the original cops too — verified by checking out the pre-refactor `lint/` and re-running. They are real `Lint/SlogContextual` violations that landed during the time this branch was stale and are not introduced by this refactor; happy to fix in a separate PR.
