### PR TITLE
fix: retry transient Vertex AI 'function response parts' 400 errors

### DIFF
--- a/pkg/modelerrors/modelerrors.go
+++ b/pkg/modelerrors/modelerrors.go
@@ -217,6 +217,38 @@ func isRetryableStatusCode(statusCode int) bool {
 	}
 }
 
+// transientStatusCodePatterns contains error message substrings that indicate
+// a transient failure even when the HTTP status code would otherwise classify
+// the error as non-retryable (e.g. 4xx). Patterns are matched
+// case-insensitively against the full formatted error.
+//
+// Currently:
+//   - Vertex AI / Gemini intermittently returns 400 INVALID_ARGUMENT with the
+//     message "Please ensure that the number of function response parts is
+//     equal to the number of function call parts of the function call turn."
+//     even for well-formed requests; the same payload succeeds on retry.
+//     Without this override the run would surface a fatal error to the user
+//     and exit non-zero, see https://github.com/docker/docker-agent/issues/2683.
+var transientStatusCodePatterns = []string{
+	"number of function response parts",
+}
+
+// matchesTransientPattern reports whether the error's message matches one of
+// [transientStatusCodePatterns]. Used to override an otherwise non-retryable
+// HTTP status classification.
+func matchesTransientPattern(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, p := range transientStatusCodePatterns {
+		if strings.Contains(msg, p) {
+			return true
+		}
+	}
+	return false
+}
+
 // retryablePatterns contains error message substrings that indicate a
 // transient/retryable failure. Numeric status codes (500, 502, etc.) are
 // handled separately by extractHTTPStatusCode + isRetryableStatusCode.
@@ -293,7 +325,7 @@ func isRetryableModelError(err error) bool {
 
 	// First, try to extract HTTP status code from known SDK error types
 	if statusCode := extractHTTPStatusCode(err); statusCode != 0 {
-		retryable := isRetryableStatusCode(statusCode)
+		retryable := isRetryableStatusCode(statusCode) || matchesTransientPattern(err)
 		slog.Debug("Classified error by status code",
 			"status_code", statusCode,
 			"retryable", retryable)
@@ -387,7 +419,7 @@ func ClassifyModelError(err error) (retryable, rateLimited bool, retryAfter time
 		if statusErr.StatusCode == http.StatusTooManyRequests {
 			return false, true, statusErr.RetryAfter
 		}
-		return isRetryableStatusCode(statusErr.StatusCode), false, 0
+		return isRetryableStatusCode(statusErr.StatusCode) || matchesTransientPattern(err), false, 0
 	}
 
 	// Fallback: providers that don't yet wrap (e.g. Bedrock), or non-provider
@@ -397,7 +429,7 @@ func ClassifyModelError(err error) (retryable, rateLimited bool, retryAfter time
 		return false, true, 0 // No Retry-After without StatusError
 	}
 	if statusCode != 0 {
-		return isRetryableStatusCode(statusCode), false, 0
+		return isRetryableStatusCode(statusCode) || matchesTransientPattern(err), false, 0
 	}
 	return isRetryableModelError(err), false, 0
 }

--- a/pkg/modelerrors/modelerrors.go
+++ b/pkg/modelerrors/modelerrors.go
@@ -219,8 +219,8 @@ func isRetryableStatusCode(statusCode int) bool {
 
 // transientStatusCodePatterns contains error message substrings that indicate
 // a transient failure even when the HTTP status code would otherwise classify
-// the error as non-retryable (e.g. 4xx). Patterns are matched
-// case-insensitively against the full formatted error.
+// the error as non-retryable (e.g. 4xx). Patterns MUST be lowercase: they are
+// compared against a lowercased error message (see [matchesTransientPattern]).
 //
 // Currently:
 //   - Vertex AI / Gemini intermittently returns 400 INVALID_ARGUMENT with the
@@ -235,14 +235,16 @@ var transientStatusCodePatterns = []string{
 
 // matchesTransientPattern reports whether the error's message matches one of
 // [transientStatusCodePatterns]. Used to override an otherwise non-retryable
-// HTTP status classification.
+// HTTP status classification. Patterns are pre-lowercased (enforced by
+// declaration convention) and additionally lowercased here for defence in
+// depth, so a mixed-case pattern slipping into the list will still match.
 func matchesTransientPattern(err error) bool {
 	if err == nil {
 		return false
 	}
 	msg := strings.ToLower(err.Error())
 	for _, p := range transientStatusCodePatterns {
-		if strings.Contains(msg, p) {
+		if strings.Contains(msg, strings.ToLower(p)) {
 			return true
 		}
 	}

--- a/pkg/modelerrors/modelerrors_test.go
+++ b/pkg/modelerrors/modelerrors_test.go
@@ -61,6 +61,8 @@ func TestIsRetryableModelError(t *testing.T) {
 		{name: "context overflow - thinking budget", err: errors.New("max_tokens must be greater than thinking.budget_tokens"), expected: false},
 		{name: "context overflow - wrapped", err: &ContextOverflowError{Underlying: errors.New("test")}, expected: false},
 		{name: "unknown error", err: errors.New("something weird happened"), expected: false},
+		// Vertex AI / Gemini transient 400 (issue #2683)
+		{name: "vertex function response parts 400", err: errors.New("400 Bad Request: please ensure that the number of function response parts is equal to the number of function call parts"), expected: true},
 	}
 
 	for _, tt := range tests {
@@ -498,6 +500,10 @@ func TestClassifyModelError(t *testing.T) {
 		{name: "403 StatusError", err: &StatusError{StatusCode: 403, Err: errors.New("forbidden")}, wantRetryable: false, wantRateLimited: false},
 		// Non-retryable fallback
 		{name: "401 message fallback", err: errors.New("401 unauthorized"), wantRetryable: false, wantRateLimited: false},
+		// 400 with Vertex AI "function response parts" message is treated as transient (issue #2683)
+		{name: "vertex transient 400 StatusError", err: &StatusError{StatusCode: 400, Err: errors.New("Error 400, Message: Please ensure that the number of function response parts is equal to the number of function call parts of the function call turn., Status: INVALID_ARGUMENT, Details: []")}, wantRetryable: true, wantRateLimited: false},
+		{name: "vertex transient 400 wrapped in stream error", err: fmt.Errorf("error receiving from stream: %w", &StatusError{StatusCode: 400, Err: errors.New("number of function response parts")}), wantRetryable: true, wantRateLimited: false},
+		{name: "vertex transient 400 message fallback (no StatusError)", err: errors.New("400 Bad Request: Please ensure that the number of function response parts is equal to the number of function call parts"), wantRetryable: true, wantRateLimited: false},
 		// Network errors
 		{name: "network timeout", err: &mockTimeoutError{}, wantRetryable: true, wantRateLimited: false},
 	}

--- a/pkg/modelerrors/modelerrors_test.go
+++ b/pkg/modelerrors/modelerrors_test.go
@@ -211,6 +211,31 @@ func TestIsRetryableModelError_ContextOverflow(t *testing.T) {
 	}
 }
 
+func TestMatchesTransientPattern(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{name: "nil error", err: nil, expected: false},
+		{name: "unrelated error", err: errors.New("connection refused"), expected: false},
+		{name: "exact lowercase match", err: errors.New("number of function response parts"), expected: true},
+		// Defence-in-depth: the message is lowercased before comparison so
+		// mixed-case provider errors still match the lowercase pattern.
+		{name: "mixed-case message", err: errors.New("Please ensure that the Number Of Function Response Parts is equal"), expected: true},
+		{name: "wrapped error", err: fmt.Errorf("error receiving from stream: %w", errors.New("NUMBER OF FUNCTION RESPONSE PARTS")), expected: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, matchesTransientPattern(tt.err), "matchesTransientPattern(%v)", tt.err)
+		})
+	}
+}
+
 func TestFormatError(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #2683.

Vertex AI / Gemini intermittently returns HTTP 400 `INVALID_ARGUMENT` with the message _"Please ensure that the number of function response parts is equal to the number of function call parts of the function call turn."_ even for well-formed requests. The same payload always succeeds on retry — it's a server-side transient.

Today `ClassifyModelError` treats every 400 as non-retryable. Mid-session occurrences look like they auto-recover only because the error happens inside a `transfer_task` child session, gets translated to a tool error, and the orchestrator's LLM decides to re-issue the call against a fresh sub-session. End-of-session, there's no surrounding tool dispatch, so the same error becomes fatal and the run exits non-zero — breaking CI.

This change adds a small `transientStatusCodePatterns` list and a `matchesTransientPattern` helper. `ClassifyModelError` and `isRetryableModelError` consult it whenever the HTTP status code would otherwise classify the error as non-retryable, so the existing retry-with-backoff loop in `fallbackExecutor.execute` handles the 400 the same way it handles 5xx — uniformly in mid-session and end-of-session contexts. Bounded by `DefaultRetries=2` (3 attempts total) with exponential backoff.

The pattern is intentionally narrow (`"number of function response parts"`) so unrelated 400s remain non-retryable.

### Validation
- `go test ./pkg/modelerrors/...` — new cases cover the typed `*StatusError` path, the wrapped `error receiving from stream: %w` path, and the message-fallback path.
- `task test` — full suite green (128 packages).
- `golangci-lint run ./pkg/modelerrors/...` — 0 issues.