### PR TITLE
feat(secretsscan): add 20 more secret patterns

### DIFF
--- a/pkg/secretsscan/aho.go
+++ b/pkg/secretsscan/aho.go
@@ -3,13 +3,15 @@ package secretsscan
 // kwMask is a fixed-size bitset over keyword indices, used to record
 // which patterns occurred in a scanned input and which keywords each
 // rule subscribes to. Storing it as a small array keeps every test
-// branch-free; the cap of 128 indices accommodates today's catalogue
-// of ~108 unique keywords with comfortable headroom.
-type kwMask [2]uint64
+// branch-free; the cap of 256 indices accommodates today's catalogue
+// of ~150 unique keywords with comfortable headroom for future rules.
+type kwMask [4]uint64
 
-func (m *kwMask) empty() bool                { return m[0]|m[1] == 0 }
-func (m *kwMask) overlaps(other kwMask) bool { return m[0]&other[0]|m[1]&other[1] != 0 }
-func (m *kwMask) set(idx int)                { m[idx>>6] |= 1 << uint(idx&63) }
+func (m *kwMask) empty() bool { return m[0]|m[1]|m[2]|m[3] == 0 }
+func (m *kwMask) overlaps(other kwMask) bool {
+	return m[0]&other[0]|m[1]&other[1]|m[2]&other[2]|m[3]&other[3] != 0
+}
+func (m *kwMask) set(idx int) { m[idx>>6] |= 1 << uint(idx&63) }
 
 // acAutomaton is an Aho–Corasick keyword pre-filter for [Redact] and
 // [ContainsSecrets]. A single linear pass over the input yields a
@@ -32,7 +34,7 @@ type acAutomaton struct {
 // buildAhoCorasick compiles patterns into an automaton. Patterns
 // must be lower-cased ASCII.
 func buildAhoCorasick(patterns []string) *acAutomaton {
-	if len(patterns) > 128 {
+	if len(patterns) > 256 {
 		panic("secretsscan: too many AC patterns for kwMask")
 	}
 
@@ -83,6 +85,8 @@ func buildAhoCorasick(patterns []string) *acAutomaton {
 		accept[s] = trie[s].terms
 		accept[s][0] |= accept[fs][0]
 		accept[s][1] |= accept[fs][1]
+		accept[s][2] |= accept[fs][2]
+		accept[s][3] |= accept[fs][3]
 
 		base, fbase := int(s)*256, int(fs)*256
 		copy(next[base:base+256], next[fbase:fbase+256])
@@ -110,6 +114,8 @@ func (a *acAutomaton) scan(text string) (mask kwMask) {
 		s = a.next[int(s)*256+int(c)]
 		mask[0] |= a.accept[s][0]
 		mask[1] |= a.accept[s][1]
+		mask[2] |= a.accept[s][2]
+		mask[3] |= a.accept[s][3]
 	}
 	return mask
 }

--- a/pkg/secretsscan/aho_test.go
+++ b/pkg/secretsscan/aho_test.go
@@ -84,14 +84,19 @@ func TestAhoCorasickOverlappingPatterns(t *testing.T) {
 }
 
 // TestAhoCorasickPanicOnTooManyPatterns verifies that buildAhoCorasick
-// panics when given more than 128 patterns, which would overflow the
+// panics when given more than 256 patterns, which would overflow the
 // kwMask bitset.
 func TestAhoCorasickPanicOnTooManyPatterns(t *testing.T) {
 	t.Parallel()
 
-	patterns := make([]string, 129)
+	patterns := make([]string, 257)
 	for i := range patterns {
-		patterns[i] = string(rune('a' + i%26))
+		// Each pattern must be unique to avoid trie conflicts; encode
+		// the index as a 3-letter base-26 string.
+		a := byte('a' + (i/26/26)%26)
+		b := byte('a' + (i/26)%26)
+		c := byte('a' + i%26)
+		patterns[i] = string([]byte{a, b, c})
 	}
 
 	assert.PanicsWithValue(t, "secretsscan: too many AC patterns for kwMask",
@@ -118,11 +123,20 @@ func TestKwMaskOperations(t *testing.T) {
 	m.set(127)
 	assert.Equal(t, uint64(1<<63|1), m[1], "bit 127 should be set in second word")
 
+	m.set(128)
+	assert.Equal(t, uint64(1), m[2], "bit 128 should be set in third word")
+
+	m.set(192)
+	assert.Equal(t, uint64(1), m[3], "bit 192 should be set in fourth word")
+
+	m.set(255)
+	assert.Equal(t, uint64(1<<63|1), m[3], "bit 255 should be set in fourth word")
+
 	var other kwMask
 	other.set(0)
 	assert.True(t, m.overlaps(other), "masks with shared bit should overlap")
 
 	other = kwMask{}
-	other.set(100)
+	other.set(200)
 	assert.False(t, m.overlaps(other), "masks with no shared bits should not overlap")
 }

--- a/pkg/secretsscan/edge_cases_test.go
+++ b/pkg/secretsscan/edge_cases_test.go
@@ -1,0 +1,115 @@
+package secretsscan_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/docker/docker-agent/pkg/secretsscan"
+)
+
+// TestNoisyKeywordsFalsePositives verifies that common text patterns
+// containing the noisy keywords don't trigger false positives.
+func TestNoisyKeywordsFalsePositives(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		text string
+	}{
+		// :AA keyword - should NOT match times or other contexts
+		{"time_with_AA", "Meeting at 12:00 AA tomorrow"},
+		{"AA_abbreviation", "The AA battery is dead"},
+		{"AA_in_text", "AA is a common abbreviation"},
+
+		// sk. keyword - should NOT match common English words
+		{"ask_sentence", "I ask. Can you help?"},
+		{"disk_sentence", "The disk. is full"},
+		{"risk_sentence", "The risk. is high"},
+
+		// 1/ keyword - should NOT match simple fractions or paths
+		{"simple_fraction", "1/2 cup of sugar"},
+		{"short_path", "1/home/user"},
+		{"date_like", "1/1/2024"},
+
+		// v1.0- keyword - should NOT match version strings without the full pattern
+		{"version_string", "v1.0-beta"},
+		{"version_release", "v1.0-rc1"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result := secretsscan.ContainsSecrets(tc.text)
+			assert.Falsef(t, result, "should not detect secret in: %q", tc.text)
+		})
+	}
+}
+
+// TestDiscordTokenPrefixes verifies all documented Discord bot token prefixes.
+func TestDiscordTokenPrefixes(t *testing.T) {
+	t.Parallel()
+
+	// Test all documented prefixes
+	prefixes := []string{"MT", "Mz", "ND", "NT", "Nz", "OD"}
+
+	for _, prefix := range prefixes {
+		t.Run("prefix_"+prefix, func(t *testing.T) {
+			t.Parallel()
+			token := prefix + strings.Repeat("A", 22) + "." + strings.Repeat("B", 6) + "." + strings.Repeat("C", 30)
+			assert.Truef(t, secretsscan.ContainsSecrets(token),
+				"should detect Discord token with prefix %s", prefix)
+		})
+	}
+}
+
+// TestConnectionStringContextPreservation verifies that MongoDB, Postgres,
+// and Azure Storage connection strings only redact the password/key portion.
+func TestConnectionStringContextPreservation(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		input       string
+		mustHave    []string
+		mustNotHave string
+	}{
+		{
+			name:        "mongodb_preserves_user_and_host",
+			input:       "mongodb://myuser:secretpassword123@cluster.mongodb.net/mydb",
+			mustHave:    []string{"mongodb://", "myuser", "@cluster.mongodb.net"},
+			mustNotHave: "secretpassword123",
+		},
+		{
+			name:        "postgres_preserves_user_and_host",
+			input:       "postgresql://dbuser:secretpass456@db.example.com:5432/mydb",
+			mustHave:    []string{"postgresql://", "dbuser", "@db.example.com"},
+			mustNotHave: "secretpass456",
+		},
+		{
+			name:        "azure_storage_preserves_account_name",
+			input:       "DefaultEndpointsProtocol=https;AccountName=mystorage;AccountKey=" + strings.Repeat("a", 86) + "==",
+			mustHave:    []string{"DefaultEndpointsProtocol=https", "AccountName=mystorage", "AccountKey="},
+			mustNotHave: strings.Repeat("a", 86) + "==",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.True(t, secretsscan.ContainsSecrets(tc.input), "should detect secret")
+
+			redacted := secretsscan.Redact(tc.input)
+
+			for _, must := range tc.mustHave {
+				assert.Containsf(t, redacted, must,
+					"redacted output should preserve: %s", must)
+			}
+
+			assert.NotContainsf(t, redacted, tc.mustNotHave,
+				"redacted output must not contain secret: %s", tc.mustNotHave)
+		})
+	}
+}

--- a/pkg/secretsscan/rules.go
+++ b/pkg/secretsscan/rules.go
@@ -656,6 +656,177 @@ var rules = sync.OnceValue(func() []rule {
 			expression: `ATATT3xFfGF0[A-Za-z0-9_=-]{180,250}`,
 			keywords:   []string{"ATATT3xFfGF0"},
 		},
+
+		// --- Second batch of additions, focused on credentials whose
+		// shapes are documented by the issuing vendor and whose
+		// prefixes (or framing structure) are unique enough to keep
+		// the keyword pre-filter useful and the false-positive rate
+		// low. Each rule cites the format it targets in its comment.
+
+		{
+			// discord-bot-token. Three-part dotted format issued for bot
+			// applications: `<base64 snowflake>.<6-char timestamp>.<27+
+			// char HMAC>`. The first segment is the bot's user-ID base64
+			// encoded; current Discord IDs (2018 onwards) base64 to a
+			// leading `MT`/`Mz`/`ND`/`NT`/`Nz`/`OD` byte pair, which we
+			// list as keywords so the AC pre-filter still skips inputs
+			// without a plausible token prefix. The structural shape
+			// (M-or-N-or-O-prefixed body, two literal dots, fixed segment
+			// widths) keeps the regex itself specific.
+			expression: `[MNO][A-Za-z\d_-]{23,25}\.[\w-]{6,7}\.[\w-]{27,38}`,
+			keywords:   []string{"MT", "Mz", "ND", "NT", "Nz", "OD"},
+		},
+		{
+			// discord-webhook-url. The URL itself is a bearer credential:
+			// anyone holding it can post arbitrary content to the channel.
+			// `discord.com/api/webhooks/<channel id>/<token>` (and the
+			// `discordapp.com` legacy alias plus the `canary.`/`ptb.`
+			// release-channel hosts) is the documented shape.
+			expression: `https://(?:canary\.|ptb\.)?discord(?:app)?\.com/api/webhooks/\d+/[\w-]+`,
+			keywords:   []string{"discord.com/api/webhooks", "discordapp.com/api/webhooks"},
+		},
+		{
+			// telegram-bot-token. BotFather issues tokens shaped
+			// `<8-10 digit bot id>:AA<33 char base64url>`; the literal
+			// `:AA` byte pair starts the second segment for every token
+			// the BotFather has ever issued.
+			expression: `\d{8,10}:AA[A-Za-z0-9_-]{33}`,
+			keywords:   []string{":AA"},
+		},
+		{
+			// flyio-macaroon. Fly.io API tokens are macaroons whose
+			// printable form always starts with the literal `FlyV1 fm2_`
+			// prefix followed by a long base64url body. The space inside
+			// the prefix is part of the token (Fly's CLI emits it
+			// verbatim). Capping the body at 400 chars stops the regex
+			// from swallowing arbitrary trailing text when the token is
+			// not separated from following content by whitespace.
+			expression: `FlyV1 fm2_[A-Za-z0-9_=-]{40,400}`,
+			keywords:   []string{"FlyV1 fm2_"},
+		},
+		{
+			// groq-api-key. Groq Cloud API keys carry the `gsk_` prefix
+			// followed by a fixed 52-character alphanumeric body.
+			expression: `gsk_[A-Za-z0-9]{52}`,
+			keywords:   []string{"gsk_"},
+		},
+		{
+			// perplexity-api-key. Perplexity API keys carry the `pplx-`
+			// prefix followed by a 48-56 char alphanumeric body (length
+			// has shifted slightly between issuance epochs).
+			expression: `pplx-[A-Za-z0-9]{48,56}`,
+			keywords:   []string{"pplx-"},
+		},
+		{
+			// xai-api-key. xAI / Grok API keys carry the `xai-` prefix
+			// followed by an 80-character alphanumeric body.
+			expression: `xai-[A-Za-z0-9]{80}`,
+			keywords:   []string{"xai-"},
+		},
+		{
+			// cohere-api-key. Cohere's modern API keys carry the `co_`
+			// prefix and a 40-char alphanumeric body. Older trial keys
+			// without the prefix are unfortunately too generic to
+			// match without a `cohere` keyword anchor.
+			expression: `co_[A-Za-z0-9]{40}`,
+			keywords:   []string{"co_"},
+		},
+		{
+			// buildkite-agent-token. Agent registration tokens carry the
+			// `bkua_` prefix and a 40-character alphanumeric body. Leakage
+			// lets attackers register fake agents in a Buildkite cluster.
+			expression: `bkua_[a-zA-Z0-9]{40}`,
+			keywords:   []string{"bkua_"},
+		},
+		{
+			// circleci-project-token. Project-scoped CircleCI API tokens
+			// carry the `CCIPRJ_` prefix followed by `<vcs-org>_<token>`.
+			// User-scoped personal tokens are 40-char hex without a
+			// prefix and are too generic to match safely on their own.
+			expression: `CCIPRJ_[A-Za-z0-9_-]+_[A-Za-z0-9_-]{32,}`,
+			keywords:   []string{"CCIPRJ_"},
+		},
+		{
+			// cloudinary-url. Cloudinary SDK credentials are passed as a
+			// single URL whose userinfo segment carries the API key and
+			// secret. The `cloudinary://` scheme is unique to this
+			// product so we redact the whole URL.
+			expression: `cloudinary://\d+:[A-Za-z0-9_-]+@[A-Za-z0-9_-]+`,
+			keywords:   []string{"cloudinary://"},
+		},
+		{
+			// mongodb-connection-string. The userinfo of a `mongodb://` /
+			// `mongodb+srv://` URI carries the database password. We
+			// preserve the scheme + username + host so log readers can
+			// still tell which cluster was being addressed, and only
+			// scrub the password span. The 200-char upper bound stops
+			// the regex from consuming arbitrary trailing content if a
+			// connection string is missing the `@` terminator.
+			expression: `mongodb(?:\+srv)?://[^\s:/?#@]+:(?P<secret>[^\s@]{1,200})@`,
+			keywords:   []string{"mongodb://", "mongodb+srv://"},
+		},
+		{
+			// postgres-connection-string. Same shape as the MongoDB rule:
+			// only the URI password is redacted so the surrounding
+			// `postgresql://user@host/db` framing stays readable.
+			expression: `postgres(?:ql)?://[^\s:/?#@]+:(?P<secret>[^\s@]{1,200})@`,
+			keywords:   []string{"postgres://", "postgresql://"},
+		},
+		{
+			// azure-storage-connection-string. The `AccountKey=` field is
+			// the actual secret; the surrounding `DefaultEndpointsProtocol`
+			// / `AccountName` framing is only metadata. The base64 value
+			// is typically 88 chars (44-byte key) but we accept anything
+			// from 20 chars upwards to cover shorter SAS-signing keys.
+			expression: `DefaultEndpointsProtocol=https?;AccountName=[^;]+;AccountKey=(?P<secret>[A-Za-z0-9+/=]{20,})`,
+			keywords:   []string{"DefaultEndpointsProtocol="},
+		},
+		{
+			// mapbox-secret-key. Mapbox publishable keys (`pk.<60>.<22>`)
+			// are already covered; secret keys share the same shape with
+			// the `sk.` prefix and grant write access to the Mapbox
+			// account.
+			expression: `(?i)sk\.[a-z0-9]{60}\.[a-z0-9]{22}`,
+			keywords:   []string{"sk."},
+		},
+		{
+			// vault-batch-token. HashiCorp Vault batch tokens follow the
+			// same `<prefix>.<base64url body>` shape as service tokens
+			// but use the `hvb.` prefix.
+			expression: `hvb\.[A-Za-z0-9_-]{90,200}`,
+			keywords:   []string{"hvb."},
+		},
+		{
+			// vault-recovery-token. Recovery tokens are issued during
+			// initialisation of an auto-unsealed Vault and carry the
+			// `hvr.` prefix; full root-equivalent if leaked.
+			expression: `hvr\.[A-Za-z0-9_-]{90,200}`,
+			keywords:   []string{"hvr."},
+		},
+		{
+			// netlify-pat. Netlify personal access tokens carry the
+			// `nfp_` prefix and a 40-character alphanumeric body.
+			expression: `nfp_[A-Za-z0-9]{40}`,
+			keywords:   []string{"nfp_"},
+		},
+		{
+			// asana-pat. Asana personal access tokens are shaped
+			// `1/<numeric workspace id>:<32 hex>`. The numeric workspace
+			// id is at least 14 digits in practice, which keeps the rule
+			// from firing on innocuous `1/<short>` substrings (page
+			// numbers, fractions, paths). The existing `asana-*` rules
+			// only fire when the literal word `asana` appears nearby; this
+			// rule fills the gap for bare leakage in CLI output / logs.
+			expression: `1/\d{14,}:[a-f0-9]{32}`,
+			keywords:   []string{"1/"},
+		},
+		{
+			// cloudflare-origin-ca-key. Cloudflare's Origin CA keys are
+			// printed as `v1.0-<32 hex>-<146 base64>` and grant the
+			// ability to issue certificates for any zone in the account.
+			expression: `v1\.0-[a-f0-9]{32}-[A-Za-z0-9+/=]{146}`,
+			keywords:   []string{"v1.0-"},
+		},
 	}
 })
 

--- a/pkg/secretsscan/secrets_test.go
+++ b/pkg/secretsscan/secrets_test.go
@@ -51,6 +51,30 @@ func TestContainsSecretsRecognisesKnownTokens(t *testing.T) {
 		{"atlassian_cloud_api_token", "ATATT3xFfGF0" + strings.Repeat("a", 200)},
 		{"digitalocean_oauth_token", "doo_v1_" + strings.Repeat("a", 64)},
 		{"digitalocean_oauth_refresh", "dor_v1_" + strings.Repeat("a", 64)},
+		// Second batch of additions (Discord / Telegram / Fly.io / LLM
+		// providers / data-store URIs / Cloudflare Origin CA / etc.).
+		{"discord_bot_token", "MTI" + strings.Repeat("a", 22) + "." + strings.Repeat("b", 6) + "." + strings.Repeat("c", 30)},
+		{"discord_bot_token_n_prefix", "NDQ" + strings.Repeat("a", 22) + "." + strings.Repeat("b", 6) + "." + strings.Repeat("c", 30)},
+		{"discord_webhook_url", "https://discord.com/api/webhooks/" + strings.Repeat("1", 18) + "/" + strings.Repeat("a", 60)},
+		{"discord_webhook_legacy", "https://discordapp.com/api/webhooks/" + strings.Repeat("1", 18) + "/" + strings.Repeat("a", 60)},
+		{"telegram_bot_token", strings.Repeat("1", 10) + ":AA" + strings.Repeat("a", 33)},
+		{"flyio_macaroon", "FlyV1 " + "fm2_" + strings.Repeat("a", 80)},
+		{"groq_api_key", "gsk_" + strings.Repeat("a", 52)},
+		{"perplexity_api_key", "pplx-" + strings.Repeat("a", 48)},
+		{"xai_api_key", "xai-" + strings.Repeat("a", 80)},
+		{"cohere_api_key", "co_" + strings.Repeat("a", 40)},
+		{"buildkite_agent_token", "bkua_" + strings.Repeat("a", 40)},
+		{"circleci_project_token", "CCIPRJ_someorg_" + strings.Repeat("a", 40)},
+		{"cloudinary_url", "cloudinary://" + strings.Repeat("1", 15) + ":" + strings.Repeat("a", 27) + "@" + strings.Repeat("b", 10)},
+		{"mongodb_conn_string", "mongodb+srv://user:" + strings.Repeat("p", 24) + "@cluster.mongodb.net"},
+		{"postgres_conn_string", "postgresql://user:" + strings.Repeat("p", 24) + "@db.example.com"},
+		{"azure_storage_conn", "DefaultEndpointsProtocol=https;AccountName=mystorage;AccountKey=" + strings.Repeat("a", 86) + "=="},
+		{"mapbox_secret_key", "sk." + strings.Repeat("a", 60) + "." + strings.Repeat("b", 22)},
+		{"vault_batch_token", "hvb." + strings.Repeat("a", 100)},
+		{"vault_recovery_token", "hvr." + strings.Repeat("a", 100)},
+		{"netlify_pat", "nfp_" + strings.Repeat("a", 40)},
+		{"asana_pat", "1/" + strings.Repeat("1", 16) + ":" + strings.Repeat("a", 32)},
+		{"cloudflare_origin_ca_key", "v1.0-" + strings.Repeat("a", 32) + "-" + strings.Repeat("b", 146)},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Adds 20 new detection rules to `pkg/secretsscan`, on top of the existing upstream-derived catalogue:

| # | Provider | Shape |
|---|---|---|
| 1 | Discord bot token | `[MNO]<24>.<6>.<27+>` (3-part dotted) |
| 2 | Discord webhook URL | `https://discord(?:app)?.com/api/webhooks/<id>/<token>` |
| 3 | Telegram bot token | `<8-10 digits>:AA<33 base64url>` |
| 4 | Fly.io macaroon | `FlyV1 fm2_…` |
| 5 | Groq API key | `gsk_<52>` |
| 6 | Perplexity API key | `pplx-<48-56>` |
| 7 | xAI / Grok API key | `xai-<80>` |
| 8 | Cohere API key | `co_<40>` |
| 9 | Buildkite agent token | `bkua_<40>` |
| 10 | CircleCI project token | `CCIPRJ_<org>_<token>` |
| 11 | Cloudinary URL | `cloudinary://<key>:<secret>@<cloud>` |
| 12 | MongoDB connection string | `mongodb(?:+srv)?://user:<pwd>@…` (only the password is redacted) |
| 13 | PostgreSQL connection string | `postgres(?:ql)?://user:<pwd>@…` (only the password is redacted) |
| 14 | Azure storage connection string | `DefaultEndpointsProtocol=…;AccountKey=<base64>` (only the key is redacted) |
| 15 | Mapbox secret key | `sk.<60>.<22>` |
| 16 | Vault batch token | `hvb.<90-200>` |
| 17 | Vault recovery token | `hvr.<90-200>` |
| 18 | Netlify PAT | `nfp_<40>` |
| 19 | Asana PAT | `1/<≥14 digits>:<32 hex>` |
| 20 | Cloudflare Origin CA key | `v1.0-<32 hex>-<146 base64>` |

Each rule has a documented vendor prefix or framing structure unique enough to keep the keyword pre-filter useful and the false-positive rate low; the in-source comments cite the format they target.

### Supporting changes
- `pkg/secretsscan/aho.go`: `kwMask` grown from `[2]uint64` (128-bit) to `[4]uint64` (256-bit). The catalogue went from 121 → 149 unique keywords, exceeding the previous 128 cap. `empty`, `overlaps`, `scan`, `buildAhoCorasick`'s panic limit, and the BFS merge are updated accordingly.
- `pkg/secretsscan/aho_test.go`: `TestAhoCorasickPanicOnTooManyPatterns` now exercises the 257-pattern boundary; `TestKwMaskOperations` covers bits in words 3 and 4.
- `pkg/secretsscan/secrets_test.go`: 21 new detection cases in `TestContainsSecretsRecognisesKnownTokens` (Discord gets two, one per first-segment letter class).
- `pkg/secretsscan/edge_cases_test.go` (new): three suites pinning the new behaviour:
  - `TestNoisyKeywordsFalsePositives` — common noise (`12:00 AA`, `1/2 cup`, `v1.0-beta`, `disk.`, …) does not trip detection.
  - `TestDiscordTokenPrefixes` — every documented Discord token first-segment prefix (MT/Mz/ND/NT/Nz/OD) is detected; this caught a regex/keyword skew during review and now guards against future drift.
  - `TestConnectionStringContextPreservation` — the new MongoDB / Postgres / Azure-storage rules redact only the `(?P<secret>…)` span and keep scheme + username + host visible.

### Validation
- `go test ./pkg/secretsscan/... ./pkg/hooks/...` — all pass
- `golangci-lint run ./...` — 0 issues
- Idempotency, redaction-marker safety, slack-rotating-token bounding, and linear-scaling tests still pass
- Benchmarks on Apple M4 Max:
  - `BenchmarkRedactCleanInput`: 19.1 µs/op (was 18.6 µs)
  - `BenchmarkRedactWithSecret`: 4.3 µs/op (unchanged)