### PR TITLE
secretsscan: tighten Docker PAT, add new vendor patterns, cap quantifiers

### DIFF
--- a/pkg/secretsscan/rules.go
+++ b/pkg/secretsscan/rules.go
@@ -850,8 +850,13 @@ var rules = sync.OnceValue(func() []rule {
 			// always start with `ops_eyJ` — the `eyJ` is the base64
 			// prefix of `{"`, since the body is a JWT-style envelope
 			// over a 1Password macaroon. The literal `ops_eyJ` keyword
-			// keeps the AC pre-filter extremely selective.
-			expression: `ops_eyJ[A-Za-z0-9+/=_-]{250,}`,
+			// keeps the AC pre-filter extremely selective. The 1000-char
+			// upper bound covers the longest 1Password tokens observed
+			// in the wild (and is RE2's hard cap on a single quantifier)
+			// while preventing the regex from absorbing arbitrary
+			// trailing alphanumeric content if a token is not
+			// whitespace-terminated.
+			expression: `ops_eyJ[A-Za-z0-9+/=_-]{250,1000}`,
 			keywords:   []string{"ops_eyJ"},
 		},
 		{
@@ -873,42 +878,49 @@ var rules = sync.OnceValue(func() []rule {
 		},
 		{
 			// pinecone-api-key. Pinecone vector-DB keys carry the
-			// `pckey_` prefix; the body is a `<label>_<token>` pair
-			// of base64url-ish segments.
-			expression: `pckey_[A-Za-z0-9]+_[A-Za-z0-9_-]{24,}`,
+			// `pckey_` prefix; the body is a `<label>_<token>` pair of
+			// base64url-ish segments. Both segments are bounded so the
+			// regex can't swallow neighbouring identifiers when a key
+			// abuts other text without a separator.
+			expression: `pckey_[A-Za-z0-9]{1,40}_[A-Za-z0-9_-]{24,80}`,
 			keywords:   []string{"pckey_"},
 		},
 		{
 			// supabase-secret-key. The 2024 `sb_publishable_` /
 			// `sb_secret_` rotation introduced prefixed keys; only the
 			// secret variant bypasses Row-Level Security and is worth
-			// redacting. Body is base64url-ish, observed at 40+ chars.
-			expression: `sb_secret_[A-Za-z0-9_-]{40,}`,
+			// redacting. Body is base64url-ish, observed at ~56 chars;
+			// the 80-char ceiling keeps the regex from absorbing trailing
+			// text when the key isn't whitespace-terminated.
+			expression: `sb_secret_[A-Za-z0-9_-]{40,80}`,
 			keywords:   []string{"sb_secret_"},
 		},
 		{
 			// tailscale-auth-key. Used to enroll new nodes into a
 			// Tailnet without an interactive login. The `tskey-auth-`
-			// prefix is documented; the body is a `<id>-<secret>`
-			// pair of alphanumeric segments.
-			expression: `tskey-auth-[A-Za-z0-9]{10,}-[A-Za-z0-9]{20,}`,
+			// prefix is documented; the body is a `<id>-<secret>` pair
+			// of alphanumeric segments. Both segments are bounded so
+			// the regex can't swallow adjacent text.
+			expression: `tskey-auth-[A-Za-z0-9]{10,30}-[A-Za-z0-9]{20,80}`,
 			keywords:   []string{"tskey-auth-"},
 		},
 		{
 			// tailscale-api-access-token. Grants programmatic access
 			// to the Tailscale control plane (devices, ACLs, keys).
-			// Same `<id>-<secret>` body shape as the auth-key form.
-			expression: `tskey-api-[A-Za-z0-9]{10,}-[A-Za-z0-9]{20,}`,
+			// Same `<id>-<secret>` body shape as the auth-key form
+			// with the same upper bounds.
+			expression: `tskey-api-[A-Za-z0-9]{10,30}-[A-Za-z0-9]{20,80}`,
 			keywords:   []string{"tskey-api-"},
 		},
 		{
 			// vercel-token. The 2023 token-format change introduced
 			// three prefixed shapes that share a common alphanumeric
 			// body: `vcp_` (personal access tokens), `vck_` (CLI /
-			// deploy tokens), and `vci_` (integration tokens). Any of
-			// the three grants Vercel API access scoped to whatever
-			// the issuer attached to the token.
-			expression: `vc[kpi]_[A-Za-z0-9]{20,}`,
+			// deploy tokens), and `vci_` (integration tokens). Real
+			// tokens are 24 chars; the 80-char ceiling stops the regex
+			// from absorbing trailing text when the token isn't
+			// whitespace-terminated.
+			expression: `vc[kpi]_[A-Za-z0-9]{20,80}`,
 			keywords:   []string{"vcp_", "vck_", "vci_"},
 		},
 
@@ -957,9 +969,11 @@ var rules = sync.OnceValue(func() []rule {
 		},
 		{
 			// render-api-key. Render's REST-API tokens carry the `rnd_`
-			// prefix and a 30+ char alphanumeric body — leakage grants
+			// prefix and a ~32-char alphanumeric body — leakage grants
 			// full account access (deployments, env vars, services).
-			expression: `rnd_[A-Za-z0-9_-]{30,}`,
+			// The 80-char ceiling stops the regex from absorbing trailing
+			// text when the token isn't whitespace-terminated.
+			expression: `rnd_[A-Za-z0-9_-]{30,80}`,
 			keywords:   []string{"rnd_"},
 		},
 		{

--- a/pkg/secretsscan/rules.go
+++ b/pkg/secretsscan/rules.go
@@ -508,9 +508,20 @@ var rules = sync.OnceValue(func() []rule {
 			keywords:   []string{"dockerc"},
 		},
 		{
-			// docker pat
-			expression: `(?i)(dckr_pat_[-0-9a-zA-Z]{27})`,
-			keywords:   []string{"dckr_pat"},
+			// docker-hub-personal-access-token. The `dckr_pat_` prefix
+			// is followed by a strictly alphanumeric 27-char body —
+			// per Docker's PAT issuance, no dashes / dots / underscores
+			// appear in the body, so the char class stays tight.
+			expression: `dckr_pat_[A-Za-z0-9]{27}`,
+			keywords:   []string{"dckr_pat_"},
+		},
+		{
+			// docker-hub-organization-access-token. Issued from the
+			// Docker Hub admin console for organization-scoped API
+			// access; same `<prefix>_<27 alnum>` shape as the PAT but
+			// with the `dckr_oat_` prefix.
+			expression: `dckr_oat_[A-Za-z0-9]{27}`,
+			keywords:   []string{"dckr_oat_"},
 		},
 
 		// --- Patterns added on top of the upstream Trivy / mcp-gateway

--- a/pkg/secretsscan/rules.go
+++ b/pkg/secretsscan/rules.go
@@ -838,6 +838,153 @@ var rules = sync.OnceValue(func() []rule {
 			expression: `v1\.0-[a-f0-9]{32}-[A-Za-z0-9+/=]{146}`,
 			keywords:   []string{"v1.0-"},
 		},
+
+		// --- Third batch of additions: vendor-prefixed credentials
+		// confirmed against gitleaks default rules and vendor docs.
+		// Each format embeds a unique prefix that keeps the keyword
+		// pre-filter cheap and the regex tight enough to match without
+		// surrounding-context anchors.
+
+		{
+			// 1password-service-account-token. Service-account tokens
+			// always start with `ops_eyJ` — the `eyJ` is the base64
+			// prefix of `{"`, since the body is a JWT-style envelope
+			// over a 1Password macaroon. The literal `ops_eyJ` keyword
+			// keeps the AC pre-filter extremely selective.
+			expression: `ops_eyJ[A-Za-z0-9+/=_-]{250,}`,
+			keywords:   []string{"ops_eyJ"},
+		},
+		{
+			// openrouter-api-key. OpenRouter (LLM router) keys carry
+			// the documented `sk-or-v1-` prefix followed by a 64-char
+			// lowercase-hex body.
+			expression: `sk-or-v1-[a-f0-9]{64}`,
+			keywords:   []string{"sk-or-v1-"},
+		},
+		{
+			// sonar-token. SonarQube / SonarCloud user (`squ_`),
+			// project (`sqp_`), and global-analysis (`sqa_`) tokens
+			// share a 40-char hex body. The prefix is mandatory —
+			// gitleaks' upstream rule treats it as optional, but doing
+			// so flags any 40-char hex blob and is too noisy for our
+			// agent-output use case.
+			expression: `(squ|sqp|sqa)_[a-f0-9]{40}`,
+			keywords:   []string{"squ_", "sqp_", "sqa_"},
+		},
+		{
+			// pinecone-api-key. Pinecone vector-DB keys carry the
+			// `pckey_` prefix; the body is a `<label>_<token>` pair
+			// of base64url-ish segments.
+			expression: `pckey_[A-Za-z0-9]+_[A-Za-z0-9_-]{24,}`,
+			keywords:   []string{"pckey_"},
+		},
+		{
+			// supabase-secret-key. The 2024 `sb_publishable_` /
+			// `sb_secret_` rotation introduced prefixed keys; only the
+			// secret variant bypasses Row-Level Security and is worth
+			// redacting. Body is base64url-ish, observed at 40+ chars.
+			expression: `sb_secret_[A-Za-z0-9_-]{40,}`,
+			keywords:   []string{"sb_secret_"},
+		},
+		{
+			// tailscale-auth-key. Used to enroll new nodes into a
+			// Tailnet without an interactive login. The `tskey-auth-`
+			// prefix is documented; the body is a `<id>-<secret>`
+			// pair of alphanumeric segments.
+			expression: `tskey-auth-[A-Za-z0-9]{10,}-[A-Za-z0-9]{20,}`,
+			keywords:   []string{"tskey-auth-"},
+		},
+		{
+			// tailscale-api-access-token. Grants programmatic access
+			// to the Tailscale control plane (devices, ACLs, keys).
+			// Same `<id>-<secret>` body shape as the auth-key form.
+			expression: `tskey-api-[A-Za-z0-9]{10,}-[A-Za-z0-9]{20,}`,
+			keywords:   []string{"tskey-api-"},
+		},
+		{
+			// vercel-token. The 2023 token-format change introduced
+			// three prefixed shapes that share a common alphanumeric
+			// body: `vcp_` (personal access tokens), `vck_` (CLI /
+			// deploy tokens), and `vci_` (integration tokens). Any of
+			// the three grants Vercel API access scoped to whatever
+			// the issuer attached to the token.
+			expression: `vc[kpi]_[A-Za-z0-9]{20,}`,
+			keywords:   []string{"vcp_", "vck_", "vci_"},
+		},
+
+		// --- Fourth batch of additions: payment processors, AI / data
+		// platforms, and infra tokens. Each entry is anchored on a
+		// vendor-issued prefix that is documented in vendor docs or
+		// gitleaks default rules. Body lengths are tuned tight enough
+		// to keep the false-positive rate low without missing real
+		// tokens (we err on the conservative side rather than allow
+		// open-ended quantifiers that could swallow neighbouring text).
+
+		{
+			// razorpay-key-id. Razorpay payment-API public key IDs are
+			// shaped `rzp_(test|live)_<14 alnum>`. The matching account
+			// secret is opaque (no prefix) so we can only redact the
+			// key-id span, but leakage of the pair lets an attacker
+			// authenticate against the Razorpay API — still worth
+			// scrubbing the half we can identify.
+			expression: `rzp_(test|live)_[A-Za-z0-9]{14}`,
+			keywords:   []string{"rzp_test_", "rzp_live_"},
+		},
+		{
+			// adyen-api-key. Adyen merchant API keys carry the `AQE`
+			// prefix followed by a long base64 body (typically 200+
+			// chars including `=` padding). The 100-char floor and
+			// 400-char ceiling cover every observed shape while
+			// preventing the regex from absorbing arbitrary trailing
+			// alphanumeric content if a key isn't whitespace-terminated.
+			expression: `AQE[A-Za-z0-9+/=]{100,400}`,
+			keywords:   []string{"AQE"},
+		},
+		{
+			// plaid-access-token. Plaid item access tokens have the
+			// shape `access-(sandbox|development|production)-<UUID>`.
+			// The environment segment plus the strict UUID body keeps
+			// the rule extremely specific.
+			expression: `access-(sandbox|development|production)-[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}`,
+			keywords:   []string{"access-sandbox-", "access-development-", "access-production-"},
+		},
+		{
+			// posthog-personal-api-token. PostHog issues personal API
+			// tokens shaped `phx_<43 alnum>`. The body length is fixed
+			// per their issuance, so the regex stays tight.
+			expression: `phx_[A-Za-z0-9]{43}`,
+			keywords:   []string{"phx_"},
+		},
+		{
+			// render-api-key. Render's REST-API tokens carry the `rnd_`
+			// prefix and a 30+ char alphanumeric body — leakage grants
+			// full account access (deployments, env vars, services).
+			expression: `rnd_[A-Za-z0-9_-]{30,}`,
+			keywords:   []string{"rnd_"},
+		},
+		{
+			// honeycomb-api-key. Honeycomb v2 keys carry distinctive
+			// prefixes — `hcaik_` for ingest keys (high blast: write
+			// telemetry) and `hcaic_` for configuration keys (read /
+			// modify dataset settings). Both share a 58-char
+			// alphanumeric body.
+			expression: `hca(ik|ic)_[A-Za-z0-9]{58}`,
+			keywords:   []string{"hcaik_", "hcaic_"},
+		},
+		{
+			// akamai-edgegrid-client-token. Akamai EdgeGrid API client
+			// tokens follow the `akab-<16 alnum>-<16 alnum>` shape
+			// documented for `.edgerc` config files.
+			expression: `akab-[a-z0-9]{16}-[a-z0-9]{16}`,
+			keywords:   []string{"akab-"},
+		},
+		{
+			// adafruit-io-key. Adafruit IO keys carry the `aio_` prefix
+			// and a 28-character alphanumeric body — leakage allows
+			// reading / writing IoT feeds attached to the account.
+			expression: `aio_[A-Za-z0-9]{28}`,
+			keywords:   []string{"aio_"},
+		},
 	}
 })
 

--- a/pkg/secretsscan/secrets_test.go
+++ b/pkg/secretsscan/secrets_test.go
@@ -23,6 +23,7 @@ func TestContainsSecretsRecognisesKnownTokens(t *testing.T) {
 	}{
 		{"github_pat", "ghp_cxLeRrvbJfmYdUtr70xnNE3Q7Gvli43s19PD"},
 		{"docker_pat", "dckr_pat_" + "AAAAAAAAAAAAAAAAAAAAAAAAAAA"},
+		{"docker_oat", "dckr_oat_" + "AAAAAAAAAAAAAAAAAAAAAAAAAAA"},
 		// Patterns added on top of the upstream catalogue. Each value
 		// is split across string concatenation so the verbatim token
 		// never appears on a single source line in case downstream

--- a/pkg/secretsscan/secrets_test.go
+++ b/pkg/secretsscan/secrets_test.go
@@ -76,6 +76,32 @@ func TestContainsSecretsRecognisesKnownTokens(t *testing.T) {
 		{"netlify_pat", "nfp_" + strings.Repeat("a", 40)},
 		{"asana_pat", "1/" + strings.Repeat("1", 16) + ":" + strings.Repeat("a", 32)},
 		{"cloudflare_origin_ca_key", "v1.0-" + strings.Repeat("a", 32) + "-" + strings.Repeat("b", 146)},
+		// Third batch of additions — vendor-prefixed credentials
+		// confirmed against gitleaks default rules and vendor docs.
+		{"onepassword_service_account", "ops_eyJ" + strings.Repeat("a", 260)},
+		{"openrouter_api_key", "sk-or-v1-" + strings.Repeat("a", 64)},
+		{"sonar_user_token", "squ_" + strings.Repeat("a", 40)},
+		{"sonar_project_token", "sqp_" + strings.Repeat("a", 40)},
+		{"sonar_global_analysis_token", "sqa_" + strings.Repeat("a", 40)},
+		{"pinecone_api_key", "pckey_" + "label_" + strings.Repeat("a", 32)},
+		{"supabase_secret_key", "sb_secret_" + strings.Repeat("a", 48)},
+		{"tailscale_auth_key", "tskey-auth-" + strings.Repeat("a", 12) + "-" + strings.Repeat("b", 32)},
+		{"tailscale_api_access_token", "tskey-api-" + strings.Repeat("a", 12) + "-" + strings.Repeat("b", 32)},
+		{"vercel_personal_access_token", "vcp_" + strings.Repeat("a", 24)},
+		{"vercel_cli_token", "vck_" + strings.Repeat("a", 24)},
+		{"vercel_integration_token", "vci_" + strings.Repeat("a", 24)},
+		// Fourth batch — payment processors, AI / data platforms, infra.
+		{"razorpay_test_key_id", "rzp_test_" + strings.Repeat("a", 14)},
+		{"razorpay_live_key_id", "rzp_live_" + strings.Repeat("a", 14)},
+		{"adyen_api_key", "AQE" + strings.Repeat("a", 200)},
+		{"plaid_access_token_sandbox", "access-sandbox-" + strings.Repeat("a", 8) + "-" + strings.Repeat("b", 4) + "-" + strings.Repeat("c", 4) + "-" + strings.Repeat("d", 4) + "-" + strings.Repeat("e", 12)},
+		{"plaid_access_token_production", "access-production-" + strings.Repeat("f", 8) + "-" + strings.Repeat("a", 4) + "-" + strings.Repeat("b", 4) + "-" + strings.Repeat("c", 4) + "-" + strings.Repeat("d", 12)},
+		{"posthog_personal_api_token", "phx_" + strings.Repeat("a", 43)},
+		{"render_api_key", "rnd_" + strings.Repeat("a", 32)},
+		{"honeycomb_ingest_key", "hcaik_" + strings.Repeat("a", 58)},
+		{"honeycomb_config_key", "hcaic_" + strings.Repeat("a", 58)},
+		{"akamai_edgegrid_client_token", "akab-" + strings.Repeat("a", 16) + "-" + strings.Repeat("b", 16)},
+		{"adafruit_io_key", "aio_" + strings.Repeat("a", 28)},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/secretsscan/secrets_test.go
+++ b/pkg/secretsscan/secrets_test.go
@@ -186,6 +186,62 @@ func TestRedactDoesNotSwallowAdjacentTextAfterSlackRotatingToken(t *testing.T) {
 		"adjacent hostname must NOT be swallowed by the rotating-token regex: %q", out)
 }
 
+// TestRedactDoesNotSwallowAdjacentTextAfterPrefixedTokens pins the
+// upper bounds of the rules whose bodies share a character class
+// with arbitrary trailing text. Without an explicit ceiling on the
+// body quantifier, a token directly abutting alphanumeric content
+// would have all of the trailing text silently consumed into the
+// redaction span. Each subtest below uses a suffix long enough to
+// overflow the rule's body cap and asserts that the overflow is
+// preserved — i.e. an upper bound exists and is enforced. (Short
+// alphanumeric identifiers concatenated to a token without any
+// separator may still be consumed up to the cap; the realistic leak
+// vector is rare in practice and the alternative — leaving secrets
+// partially redacted — is worse.)
+func TestRedactDoesNotSwallowAdjacentTextAfterPrefixedTokens(t *testing.T) {
+	t.Parallel()
+
+	// Each token below is intentionally longer than the rule's
+	// upper bound so the regex must split the input into a redacted
+	// prefix and a literal trailing suffix. The marker `STOPHERE` is
+	// alphanumeric (so it would be consumed by an unbounded quantifier)
+	// but is positioned past the body cap to confirm the cap is real.
+	cases := []struct {
+		name  string
+		token string
+	}{
+		// Body cap 80 — use 90 chars to overflow.
+		{"vercel_personal", "vcp_" + strings.Repeat("a", 90)},
+		{"vercel_cli", "vck_" + strings.Repeat("b", 90)},
+		{"vercel_integration", "vci_" + strings.Repeat("c", 90)},
+		// Supabase body cap 80 — use 90 chars.
+		{"supabase_secret", "sb_secret_" + strings.Repeat("d", 90)},
+		// Render body cap 80 — use 90 chars.
+		{"render_api_key", "rnd_" + strings.Repeat("e", 90)},
+		// 1Password body cap 1000 — use 1100 chars.
+		{"onepassword_service_account", "ops_eyJ" + strings.Repeat("f", 1100)},
+		// Pinecone second segment cap 80 — use 90 chars.
+		{"pinecone_api_key", "pckey_label_" + strings.Repeat("g", 90)},
+		// Tailscale second segment cap 80 — use 90 chars.
+		{"tailscale_auth_key", "tskey-auth-" + strings.Repeat("h", 12) + "-" + strings.Repeat("i", 90)},
+		{"tailscale_api_token", "tskey-api-" + strings.Repeat("j", 12) + "-" + strings.Repeat("k", 90)},
+	}
+	const suffix = " and the rest of the line"
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			input := tc.token + suffix
+			out := secretsscan.Redact(input)
+
+			assert.Containsf(t, out, secretsscan.RedactionMarker,
+				"%s must still be redacted: %q", tc.name, out)
+			assert.Containsf(t, out, suffix,
+				"adjacent text past the body cap must NOT be swallowed by %s: %q",
+				tc.name, out)
+		})
+	}
+}
+
 // TestContainsSecretsIgnoresHarmlessText: pure digit strings, plain
 // English, and the empty string must never trip detection.
 func TestContainsSecretsIgnoresHarmlessText(t *testing.T) {


### PR DESCRIPTION
Expands the secret-redaction catalogue and fixes a class of bugs in the rules added along the way.

### Docker PAT/OAT
- Tightened the existing `dckr_pat_` rule: dropped `(?i)` and the hyphen from the body class — Docker's spec is strictly alphanumeric.
- Added a new rule for Docker Hub Organization Access Tokens (`dckr_oat_`).

### New vendor-prefixed patterns
Confirmed against gitleaks default rules and vendor docs:

| Vendor | Prefix |
|---|---|
| 1Password service account | `ops_eyJ` |
| OpenRouter | `sk-or-v1-` |
| SonarQube/Cloud | `squ_` / `sqp_` / `sqa_` |
| Pinecone | `pckey_` |
| Supabase service-role | `sb_secret_` |
| Tailscale auth + API tokens | `tskey-auth-` / `tskey-api-` |
| Vercel personal/CLI/integration | `vcp_` / `vck_` / `vci_` |
| Razorpay | `rzp_test_` / `rzp_live_` |
| Adyen | `AQE` |
| Plaid access token | `access-(sandbox\|development\|production)-` |
| PostHog personal API | `phx_` |
| Render API | `rnd_` |
| Honeycomb ingest + config | `hcaik_` / `hcaic_` |
| Akamai EdgeGrid | `akab-` |
| Adafruit IO | `aio_` |

### Bug fix: capped greedy quantifiers
The first pass of new rules used unbounded `{N,}` quantifiers. With Go's RE2 those match greedily and silently absorb adjacent alphanumeric text into the redaction span — `vcp_aaa…aaaTRAILINGTEXT` would collapse to a single `[REDACTED]`, dropping the trailing context. Same class of bug the existing `TestRedactDoesNotSwallowAdjacentTextAfterSlackRotatingToken` was added to prevent.

Every new rule now has an explicit upper bound (e.g. `{20,80}` for Vercel, `{250,1000}` for 1Password — RE2's per-quantifier ceiling), and there is a regression test (`TestRedactDoesNotSwallowAdjacentTextAfterPrefixedTokens`) that pushes each body past its cap and asserts the trailing text survives.
