### PR TITLE
bump github.com/dgageot/rubocop-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -154,7 +154,7 @@ require (
 	github.com/containerd/stargz-snapshotter/estargz v0.18.2 // indirect
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/dgageot/rubocop-go v0.0.0-20260429125723-198995cc80c9
+	github.com/dgageot/rubocop-go v0.0.0-20260507084512-2695e6771458
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/dlclark/regexp2 v1.12.0 // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -193,8 +193,8 @@ github.com/danieljoos/wincred v1.2.2/go.mod h1:w7w4Utbrz8lqeMbDAK0lkNJUv5sAOkFi7
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgageot/rubocop-go v0.0.0-20260429125723-198995cc80c9 h1:LwBQXSuGbtHC3rzVOBQIsSofzTc7k9QWRqoQdfPbG+s=
-github.com/dgageot/rubocop-go v0.0.0-20260429125723-198995cc80c9/go.mod h1:r8YOJV5+/30NZ8HW/2NbWUObBGDXGvfHrjgury5YlFI=
+github.com/dgageot/rubocop-go v0.0.0-20260507084512-2695e6771458 h1:qLFMffgwEigJvNG9kNGVlgfpVmLz92dy92Nr1sPJt4M=
+github.com/dgageot/rubocop-go v0.0.0-20260507084512-2695e6771458/go.mod h1:r8YOJV5+/30NZ8HW/2NbWUObBGDXGvfHrjgury5YlFI=
 github.com/dgageot/ultraviolet v0.0.0-20260313154905-9451997d56b6 h1:88fWkkjwzuI4tRTqadbJIbA9O+gO67oyu+2OpHHuuT8=
 github.com/dgageot/ultraviolet v0.0.0-20260313154905-9451997d56b6/go.mod h1:SQpCTRNBtzJkwku5ye4S3HEuthAlGy2n9VXZnWkEW98=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=

--- a/lint/config_latest_tag_consistency.go
+++ b/lint/config_latest_tag_consistency.go
@@ -3,12 +3,11 @@ package main
 import (
 	"go/ast"
 	"reflect"
-	"strings"
 
 	"github.com/dgageot/rubocop-go/cop"
 )
 
-// ConfigLatestTagConsistency enforces that struct fields under
+// NewConfigLatestTagConsistency enforces that struct fields under
 // pkg/config/latest/ keep their `json` and `yaml` struct tags in sync with
 // respect to the omit-when-empty modifier:
 //
@@ -31,89 +30,58 @@ import (
 //
 // Fields without a `yaml` tag are skipped — yaml.v3 derives a default name
 // from the field, which is a separate concern handled elsewhere.
-type ConfigLatestTagConsistency struct {
-	cop.Meta
-}
+func NewConfigLatestTagConsistency() cop.Cop {
+	return &cop.Func{
+		Meta: cop.Meta{
+			Name:        "Lint/ConfigLatestTagConsistency",
+			Description: "json and yaml tags in pkg/config/latest must agree on omitempty/omitzero",
+			Severity:    cop.Error,
+		},
+		Scope: cop.And(
+			cop.InPathSegment("pkg/config", func(s string) bool { return s == "latest" }),
+			cop.NotBlackBoxTest(),
+		),
+		Run: func(p *cop.Pass) {
+			p.ForEachStructField(func(_ *ast.TypeSpec, field *ast.Field, tag reflect.StructTag) {
+				if field.Tag == nil {
+					return
+				}
+				jsonOpts, hasJSON := cop.ParseTagOptions(tag, "json")
+				yamlOpts, hasYAML := cop.ParseTagOptions(tag, "yaml")
+				if !hasJSON || !hasYAML {
+					return
+				}
+				// Embedded fields use ",inline" on both sides; nothing to compare.
+				if jsonOpts.Has("inline") || yamlOpts.Has("inline") {
+					return
+				}
 
-// NewConfigLatestTagConsistency returns a fully configured
-// ConfigLatestTagConsistency cop.
-func NewConfigLatestTagConsistency() *ConfigLatestTagConsistency {
-	return &ConfigLatestTagConsistency{Meta: cop.Meta{
-		CopName:     "Lint/ConfigLatestTagConsistency",
-		CopDesc:     "json and yaml tags in pkg/config/latest must agree on omitempty/omitzero",
-		CopSeverity: cop.Error,
-	}}
-}
+				jsonOmit, jsonMod := jsonOmitModifier(jsonOpts)
+				yamlOmit := yamlOpts.Has("omitempty")
 
-func (c *ConfigLatestTagConsistency) Check(p *cop.Pass) {
-	dir, _ := p.PathSegment("pkg/config")
-	if dir != "latest" {
-		return
+				if jsonOmit != yamlOmit {
+					p.Reportf(field.Tag,
+						"json and yaml tags disagree on omit-when-empty: json has %q, yaml has %q (field %s)",
+						modifierLabel(jsonOmit, jsonMod), modifierLabel(yamlOmit, "omitempty"),
+						cop.FieldNames(field))
+				}
+			})
+		},
 	}
-	// Black-box test files don't ship struct definitions for the wire format.
-	if p.IsBlackBoxTest() {
-		return
-	}
-
-	p.ForEachStructField(func(_ *ast.TypeSpec, field *ast.Field, tag reflect.StructTag) {
-		if field.Tag == nil {
-			return
-		}
-		jsonTag, hasJSON := tag.Lookup("json")
-		yamlTag, hasYAML := tag.Lookup("yaml")
-		if !hasJSON || !hasYAML {
-			return
-		}
-		// Embedded fields use ",inline" on both sides; nothing to compare.
-		if isInline(jsonTag) || isInline(yamlTag) {
-			return
-		}
-
-		jsonOmit, jsonMod := jsonOmitModifier(jsonTag)
-		yamlOmit := hasOption(yamlTag, "omitempty")
-
-		if jsonOmit != yamlOmit {
-			p.Report(field.Tag,
-				"json and yaml tags disagree on omit-when-empty: json has %q, yaml has %q (field %s)",
-				modifierLabel(jsonOmit, jsonMod), modifierLabel(yamlOmit, "omitempty"),
-				fieldNames(field))
-		}
-	})
 }
 
 // jsonOmitModifier reports whether the json tag opts out of empty values,
 // returning the specific modifier that triggered the match (omitempty or
 // omitzero). When neither is present, it returns false and "".
-func jsonOmitModifier(tag string) (bool, string) {
+func jsonOmitModifier(opts cop.TagOptions) (bool, string) {
 	switch {
-	case hasOption(tag, "omitempty"):
+	case opts.Has("omitempty"):
 		return true, "omitempty"
-	case hasOption(tag, "omitzero"):
+	case opts.Has("omitzero"):
 		return true, "omitzero"
 	default:
 		return false, ""
 	}
-}
-
-// hasOption reports whether the comma-separated options on tag include opt.
-// The first comma-separated entry is the field name; only later entries are
-// modifiers (`omitempty`, `omitzero`, `inline`, …).
-func hasOption(tag, opt string) bool {
-	for i, part := range strings.Split(tag, ",") {
-		if i == 0 {
-			continue
-		}
-		if part == opt {
-			return true
-		}
-	}
-	return false
-}
-
-// isInline reports whether the tag carries a ",inline" option, which is used
-// by both json/yaml libraries to flatten an embedded struct into the parent.
-func isInline(tag string) bool {
-	return hasOption(tag, "inline")
 }
 
 // modifierLabel renders a human-readable description of the modifier for an
@@ -123,17 +91,4 @@ func modifierLabel(present bool, name string) string {
 		return "<none>"
 	}
 	return name
-}
-
-// fieldNames returns the comma-separated list of field identifiers for use in
-// diagnostic messages. Anonymous (embedded) fields fall back to "<embedded>".
-func fieldNames(field *ast.Field) string {
-	if len(field.Names) == 0 {
-		return "<embedded>"
-	}
-	names := make([]string, 0, len(field.Names))
-	for _, n := range field.Names {
-		names = append(names, n.Name)
-	}
-	return strings.Join(names, ", ")
 }

--- a/lint/config_package_name.go
+++ b/lint/config_package_name.go
@@ -4,7 +4,7 @@ import (
 	"github.com/dgageot/rubocop-go/cop"
 )
 
-// ConfigPackageName enforces that files under pkg/config/<dir>/ declare a
+// NewConfigPackageName enforces that files under pkg/config/<dir>/ declare a
 // package name that matches their directory:
 //
 //   - pkg/config/vN/      → package vN
@@ -15,35 +15,28 @@ import (
 // is frozen into a numbered vN directory: the package clause is easy to
 // forget, and the broken state remains compilable as long as importers use
 // an explicit alias.
-type ConfigPackageName struct {
-	cop.Meta
-}
-
-// NewConfigPackageName returns a fully configured ConfigPackageName cop.
-func NewConfigPackageName() *ConfigPackageName {
-	return &ConfigPackageName{Meta: cop.Meta{
-		CopName:     "Lint/ConfigPackageName",
-		CopDesc:     "Files under pkg/config/<dir>/ must declare package <dir>",
-		CopSeverity: cop.Error,
-	}}
-}
-
-func (c *ConfigPackageName) Check(p *cop.Pass) {
-	dir, ok := p.PathSegment("pkg/config")
-	if !ok {
-		return
-	}
-
-	got := p.PackageName()
-	switch got {
-	case dir:
-		return
-	case dir + "_test":
-		// Black-box test packages are a legitimate Go convention.
-		if p.IsTestFile() {
+func NewConfigPackageName() cop.Cop {
+	return cop.New(cop.Meta{
+		Name:        "Lint/ConfigPackageName",
+		Description: "Files under pkg/config/<dir>/ must declare package <dir>",
+		Severity:    cop.Error,
+	}, func(p *cop.Pass) {
+		dir, ok := p.PathSegment("pkg/config")
+		if !ok {
 			return
 		}
-	}
 
-	p.Report(p.File.Name, "file in pkg/config/%s/ must declare package %s, got %s", dir, dir, got)
+		got := p.PackageName()
+		switch got {
+		case dir:
+			return
+		case dir + "_test":
+			// Black-box test packages are a legitimate Go convention.
+			if p.IsTestFile() {
+				return
+			}
+		}
+
+		p.Reportf(p.File.Name, "file in pkg/config/%s/ must declare package %s, got %s", dir, dir, got)
+	})
 }

--- a/lint/config_version_constant.go
+++ b/lint/config_version_constant.go
@@ -6,8 +6,8 @@ import (
 	"github.com/dgageot/rubocop-go/cop"
 )
 
-// ConfigVersionConstant enforces that a file under pkg/config/vN/ declaring a
-// `const Version = "<value>"` uses "<N>" as its value.
+// NewConfigVersionConstant enforces that a file under pkg/config/vN/
+// declaring a `const Version = "<value>"` uses "<N>" as its value.
 //
 // This guards against the common mistake of bumping the directory name
 // without bumping the constant (or vice versa) when freezing the
@@ -17,34 +17,27 @@ import (
 //
 // Files under pkg/config/latest/ are intentionally exempt: their `Version`
 // is the next, work-in-progress value (one greater than the highest vN).
-type ConfigVersionConstant struct {
-	cop.Meta
-}
+func NewConfigVersionConstant() cop.Cop {
+	return cop.New(cop.Meta{
+		Name:        "Lint/ConfigVersionConstant",
+		Description: "Version constant in pkg/config/vN/ must equal \"N\"",
+		Severity:    cop.Error,
+	}, func(p *cop.Pass) {
+		dir, _ := p.PathSegment("pkg/config")
+		dirVersion, ok := versionFromDir(dir)
+		if !ok {
+			return
+		}
+		expected := strconv.Itoa(dirVersion)
 
-// NewConfigVersionConstant returns a fully configured ConfigVersionConstant cop.
-func NewConfigVersionConstant() *ConfigVersionConstant {
-	return &ConfigVersionConstant{Meta: cop.Meta{
-		CopName:     "Lint/ConfigVersionConstant",
-		CopDesc:     "Version constant in pkg/config/vN/ must equal \"N\"",
-		CopSeverity: cop.Error,
-	}}
-}
-
-func (c *ConfigVersionConstant) Check(p *cop.Pass) {
-	dir, _ := p.PathSegment("pkg/config")
-	dirVersion, ok := versionFromDir(dir)
-	if !ok {
-		return
-	}
-	expected := strconv.Itoa(dirVersion)
-
-	lit, ok := p.StringConstNodes()["Version"]
-	if !ok {
-		return
-	}
-	got, err := strconv.Unquote(lit.Value)
-	if err != nil || got == expected {
-		return
-	}
-	p.Report(lit, "Version in pkg/config/v%s/ must be %q, got %q", expected, expected, got)
+		lit, ok := p.StringConstNodes()["Version"]
+		if !ok {
+			return
+		}
+		got, err := strconv.Unquote(lit.Value)
+		if err != nil || got == expected {
+			return
+		}
+		p.Reportf(lit, "Version in pkg/config/v%s/ must be %q, got %q", expected, expected, got)
+	})
 }

--- a/lint/config_version_import.go
+++ b/lint/config_version_import.go
@@ -7,53 +7,46 @@ import (
 	"github.com/dgageot/rubocop-go/cop"
 )
 
-// ConfigVersionImport enforces that config version packages (pkg/config/vN
-// and pkg/config/latest) only import their immediate predecessor and the
-// shared types package, preserving the strict migration chain:
-// v0 → v1 → v2 → … → latest.
-type ConfigVersionImport struct {
-	cop.Meta
-}
-
-// NewConfigVersionImport returns a fully configured ConfigVersionImport cop.
-func NewConfigVersionImport() *ConfigVersionImport {
-	return &ConfigVersionImport{Meta: cop.Meta{
-		CopName:     "Lint/ConfigVersionImport",
-		CopDesc:     "Config version packages must only import their immediate predecessor",
-		CopSeverity: cop.Error,
-	}}
-}
-
-func (c *ConfigVersionImport) Check(p *cop.Pass) {
-	if len(p.File.Imports) == 0 {
-		return
-	}
-	// Black-box test files (package <dir>_test) are external to the package
-	// and may import what they please.
-	if p.IsBlackBoxTest() {
-		return
-	}
-
-	dir, ok := p.PathSegment("pkg/config")
-	if !ok {
-		return
-	}
-	dirVersion, isVersioned := versionFromDir(dir)
-	isLatest := dir == "latest"
-	if !isVersioned && !isLatest {
-		return
-	}
-
-	for _, imp := range p.File.Imports {
-		path := cop.ImportPath(imp)
-
-		if !strings.Contains(path, "pkg/config/") || strings.HasSuffix(path, "pkg/config/types") {
-			continue
+// NewConfigVersionImport enforces that config version packages
+// (pkg/config/vN and pkg/config/latest) only import their immediate
+// predecessor and the shared types package, preserving the strict
+// migration chain: v0 → v1 → v2 → … → latest.
+func NewConfigVersionImport() cop.Cop {
+	return cop.New(cop.Meta{
+		Name:        "Lint/ConfigVersionImport",
+		Description: "Config version packages must only import their immediate predecessor",
+		Severity:    cop.Error,
+	}, func(p *cop.Pass) {
+		if len(p.File.Imports) == 0 {
+			return
 		}
-		if msg := importViolation(path, dirVersion, isLatest); msg != "" {
-			p.Report(imp.Path, "%s", msg)
+		// Black-box test files (package <dir>_test) are external to the
+		// package and may import what they please.
+		if p.IsBlackBoxTest() {
+			return
 		}
-	}
+
+		dir, ok := p.PathSegment("pkg/config")
+		if !ok {
+			return
+		}
+		dirVersion, isVersioned := versionFromDir(dir)
+		isLatest := dir == "latest"
+		if !isVersioned && !isLatest {
+			return
+		}
+
+		for _, imp := range p.File.Imports {
+			path := cop.ImportPath(imp)
+
+			if !strings.Contains(path, "pkg/config/") || strings.HasSuffix(path, "pkg/config/types") {
+				continue
+			}
+			if msg := importViolation(path, dirVersion, isLatest); msg != "" {
+				p.Reportf(imp.Path, "%s", msg)
+			}
+		}
+	})
 }
 
 // importViolation returns a non-empty error message if the given import path

--- a/lint/config_versions_registered.go
+++ b/lint/config_versions_registered.go
@@ -1,16 +1,14 @@
 package main
 
 import (
-	"go/ast"
 	"os"
 	"path/filepath"
 	"slices"
-	"strings"
 
 	"github.com/dgageot/rubocop-go/cop"
 )
 
-// ConfigVersionsRegistered enforces that pkg/config/versions.go registers
+// NewConfigVersionsRegistered enforces that pkg/config/versions.go registers
 // every config-version package that exists on disk.
 //
 // pkg/config/versions.go is the dispatch table for parsing and upgrading: it
@@ -27,46 +25,39 @@ import (
 //
 // The cop only inspects pkg/config/versions.go and reports any package that
 // exists under pkg/config/ but is not registered.
-type ConfigVersionsRegistered struct {
-	cop.Meta
-}
+func NewConfigVersionsRegistered() cop.Cop {
+	return &cop.Func{
+		Meta: cop.Meta{
+			Name:        "Lint/ConfigVersionsRegistered",
+			Description: "pkg/config/versions.go must register every pkg/config/vN and pkg/config/latest package",
+			Severity:    cop.Error,
+		},
+		Scope: cop.OnlyFile("pkg/config/versions.go"),
+		Run: func(p *cop.Pass) {
+			want, err := versionPackagesOnDisk(filepath.Dir(p.Filename()))
+			if err != nil || len(want) == 0 {
+				return
+			}
+			got := p.SelectorReceivers("Register")
 
-// NewConfigVersionsRegistered returns a fully configured
-// ConfigVersionsRegistered cop.
-func NewConfigVersionsRegistered() *ConfigVersionsRegistered {
-	return &ConfigVersionsRegistered{Meta: cop.Meta{
-		CopName:     "Lint/ConfigVersionsRegistered",
-		CopDesc:     "pkg/config/versions.go must register every pkg/config/vN and pkg/config/latest package",
-		CopSeverity: cop.Error,
-	}}
-}
+			var missing []string
+			for _, name := range want {
+				if !got[name] {
+					missing = append(missing, name)
+				}
+			}
 
-func (c *ConfigVersionsRegistered) Check(p *cop.Pass) {
-	if !p.FileMatches("pkg/config/versions.go") {
-		return
+			// Anchor on the `versions` function declaration so the message
+			// points at the registry rather than the package clause; fall
+			// back to the package clause if it has been renamed.
+			anchor := p.File.Name
+			if fn := p.FuncDecl("versions"); fn != nil {
+				anchor = fn.Name
+			}
+			p.ReportMissing(anchor,
+				"pkg/config/versions.go is missing Register call(s) for: %s", missing)
+		},
 	}
-
-	want, err := versionPackagesOnDisk(filepath.Dir(p.Filename()))
-	if err != nil || len(want) == 0 {
-		return
-	}
-	got := p.SelectorReceivers("Register")
-
-	var missing []string
-	for _, name := range want {
-		if !got[name] {
-			missing = append(missing, name)
-		}
-	}
-	if len(missing) == 0 {
-		return
-	}
-	slices.Sort(missing)
-
-	// Anchor the diagnostic on the function declaration so the message points
-	// at the registry rather than at the package clause.
-	p.Report(registryAnchor(p),
-		"pkg/config/versions.go is missing Register call(s) for: %s", strings.Join(missing, ", "))
 }
 
 // versionPackagesOnDisk lists the package directories under pkg/config/ that
@@ -92,18 +83,4 @@ func versionPackagesOnDisk(dir string) ([]string, error) {
 	}
 	slices.Sort(names)
 	return names, nil
-}
-
-// registryAnchor picks the AST node used to position the offense. Preferring
-// the `versions` function declaration keeps the diagnostic close to the
-// dispatch table; if that function is absent (unexpected), the file's
-// package clause is used as a fallback.
-func registryAnchor(p *cop.Pass) ast.Node {
-	var anchor ast.Node = p.File.Name
-	p.ForEachFunc(func(fn *ast.FuncDecl) {
-		if fn.Name.Name == "versions" {
-			anchor = fn.Name
-		}
-	})
-	return anchor
 }

--- a/lint/hook_builtins_registered.go
+++ b/lint/hook_builtins_registered.go
@@ -2,15 +2,13 @@ package main
 
 import (
 	"go/ast"
-	"slices"
-	"strings"
 
 	"github.com/dgageot/rubocop-go/cop"
 )
 
-// HookBuiltinsRegistered enforces that every builtin-name constant declared
-// under pkg/hooks/builtins/ is wired into the package's Register() function
-// in pkg/hooks/builtins/builtins.go.
+// NewHookBuiltinsRegistered enforces that every builtin-name constant
+// declared under pkg/hooks/builtins/ is wired into the package's Register()
+// function in pkg/hooks/builtins/builtins.go.
 //
 // Each in-process builtin lives in its own file with a name constant and an
 // implementation:
@@ -39,60 +37,46 @@ import (
 // Files named builtins.go itself, *_test.go, and testhelpers_test.go are
 // excluded from the constant scan because they are not where new
 // builtins land.
-type HookBuiltinsRegistered struct {
-	cop.Meta
+func NewHookBuiltinsRegistered() cop.Cop {
+	return &cop.Func{
+		Meta: cop.Meta{
+			Name:        "Lint/HookBuiltinsRegistered",
+			Description: "every builtin name constant under pkg/hooks/builtins/ must appear in a RegisterBuiltin call",
+			Severity:    cop.Error,
+		},
+		Scope: cop.OnlyFile("pkg/hooks/builtins/builtins.go"),
+		Run: func(p *cop.Pass) {
+			declared, err := exportedBuiltinNames(p)
+			if err != nil || len(declared) == 0 {
+				return
+			}
+
+			registered := p.IdentSetFromCalls("RegisterBuiltin", 0)
+
+			// Anchor on the first RegisterBuiltin call, falling back to the
+			// package clause if the function was reshaped beyond recognition.
+			var anchor ast.Node = p.File.Name
+			if call := p.FirstMethodCall("RegisterBuiltin"); call != nil {
+				anchor = call
+			}
+
+			var missing []string
+			for name := range declared {
+				if !registered[name] {
+					missing = append(missing, name)
+				}
+			}
+			p.ReportMissing(anchor,
+				"pkg/hooks/builtins/builtins.go is missing RegisterBuiltin call(s) for: %s", missing)
+		},
+	}
 }
 
-// NewHookBuiltinsRegistered returns a fully configured
-// HookBuiltinsRegistered cop.
-func NewHookBuiltinsRegistered() *HookBuiltinsRegistered {
-	return &HookBuiltinsRegistered{Meta: cop.Meta{
-		CopName:     "Lint/HookBuiltinsRegistered",
-		CopDesc:     "every builtin name constant under pkg/hooks/builtins/ must appear in a RegisterBuiltin call",
-		CopSeverity: cop.Error,
-	}}
-}
-
-func (c *HookBuiltinsRegistered) Check(p *cop.Pass) {
-	if !p.FileMatches("pkg/hooks/builtins/builtins.go") {
-		return
-	}
-
-	declared, err := exportedBuiltinNames(p)
-	if err != nil || len(declared) == 0 {
-		return
-	}
-
-	registered := p.IdentSetFromCalls("RegisterBuiltin", 0)
-
-	// Anchor on the first RegisterBuiltin call, falling back to the package
-	// clause if the function was reshaped beyond recognition.
-	var anchor ast.Node = p.File.Name
-	p.ForEachMethodCall("RegisterBuiltin", func(call *ast.CallExpr) {
-		if anchor == p.File.Name {
-			anchor = call
-		}
-	})
-
-	var missing []string
-	for _, name := range declared {
-		if !registered[name] {
-			missing = append(missing, name)
-		}
-	}
-	if len(missing) == 0 {
-		return
-	}
-	slices.Sort(missing)
-	p.Report(anchor,
-		"pkg/hooks/builtins/builtins.go is missing RegisterBuiltin call(s) for: %s",
-		strings.Join(missing, ", "))
-}
-
-// exportedBuiltinNames returns the identifiers of every exported `const Name = "..."`
-// declaration in pkg/hooks/builtins/, excluding builtins.go itself and any
-// test files (which is not where new builtins land).
-func exportedBuiltinNames(p *cop.Pass) ([]string, error) {
+// exportedBuiltinNames returns the set of identifiers of every exported
+// `const Name = "..."` declaration in pkg/hooks/builtins/, excluding
+// builtins.go itself and any test files (which is not where new builtins
+// land).
+func exportedBuiltinNames(p *cop.Pass) (map[string]struct{}, error) {
 	files, err := p.ParseDir(".", cop.ParseDirOptions{
 		SkipTests: true,
 		SkipFiles: []string{"builtins.go"},
@@ -106,10 +90,5 @@ func exportedBuiltinNames(p *cop.Pass) ([]string, error) {
 			seen[name] = struct{}{}
 		}
 	}
-	names := make([]string, 0, len(seen))
-	for n := range seen {
-		names = append(names, n)
-	}
-	slices.Sort(names)
-	return names, nil
+	return seen, nil
 }

--- a/lint/hook_config_sync.go
+++ b/lint/hook_config_sync.go
@@ -3,15 +3,15 @@ package main
 import (
 	"go/ast"
 	"reflect"
-	"slices"
 	"strconv"
 	"strings"
 
 	"github.com/dgageot/rubocop-go/cop"
 )
 
-// HookConfigSync enforces that the EventXxx constants in pkg/hooks/types.go
-// stay in lock-step with the HooksConfig fields in pkg/config/latest/types.go.
+// NewHookConfigSync enforces that the EventXxx constants in
+// pkg/hooks/types.go stay in lock-step with the HooksConfig fields in
+// pkg/config/latest/types.go.
 //
 // The two are coupled: every hook event the runtime knows how to dispatch
 // has to be configurable in the agent YAML, and every YAML field has to
@@ -34,78 +34,65 @@ import (
 // cop runs on pkg/config/latest/types.go (where the diagnostic anchors
 // on the HooksConfig type spec) and parses pkg/hooks/types.go from disk
 // for the source of truth.
-type HookConfigSync struct {
-	cop.Meta
-}
+func NewHookConfigSync() cop.Cop {
+	return &cop.Func{
+		Meta: cop.Meta{
+			Name:        "Lint/HookConfigSync",
+			Description: "EventXxx constants in pkg/hooks/types.go must match HooksConfig fields in pkg/config/latest",
+			Severity:    cop.Error,
+		},
+		Scope: cop.OnlyFile("pkg/config/latest/types.go"),
+		Run: func(p *cop.Pass) {
+			// pkg/config/latest/types.go ↔ ../../hooks/types.go
+			hookFile, err := p.ParseSibling("../../hooks/types.go")
+			if err != nil {
+				return
+			}
+			hookEvents := cop.StringConstsIn(hookFile, func(name string) bool {
+				return strings.HasPrefix(name, "Event")
+			})
+			if len(hookEvents) == 0 {
+				return
+			}
 
-// NewHookConfigSync returns a fully configured HookConfigSync cop.
-func NewHookConfigSync() *HookConfigSync {
-	return &HookConfigSync{Meta: cop.Meta{
-		CopName:     "Lint/HookConfigSync",
-		CopDesc:     "EventXxx constants in pkg/hooks/types.go must match HooksConfig fields in pkg/config/latest",
-		CopSeverity: cop.Error,
-	}}
-}
+			cfgFields, hooksConfigSpec := readHooksConfigFields(p)
+			if hooksConfigSpec == nil {
+				// Schema didn't ship HooksConfig (or this isn't the right
+				// types.go) — nothing meaningful the cop can say.
+				return
+			}
 
-func (c *HookConfigSync) Check(p *cop.Pass) {
-	if !p.FileMatches("pkg/config/latest/types.go") {
-		return
-	}
+			// Build reverse map for diagnostics.
+			cfgByJSON := map[string]string{} // wire-string -> Go field name
+			for goName, jsonName := range cfgFields {
+				cfgByJSON[jsonName] = goName
+			}
 
-	// pkg/config/latest/types.go ↔ ../../hooks/types.go
-	hookFile, err := p.ParseSibling("../../hooks/types.go")
-	if err != nil {
-		return
-	}
-	hookEvents := cop.StringConstsIn(hookFile, func(name string) bool {
-		return strings.HasPrefix(name, "Event")
-	})
-	if len(hookEvents) == 0 {
-		return
-	}
+			// Direction 1: every event must have a config field.
+			var missingFields []string
+			for constName, wire := range hookEvents {
+				if _, ok := cfgByJSON[wire]; !ok {
+					missingFields = append(missingFields, constName+"="+strconv.Quote(wire))
+				}
+			}
+			p.ReportMissing(hooksConfigSpec.Name,
+				"HooksConfig is missing field(s) for hook event(s): %s", missingFields)
 
-	cfgFields, hooksConfigSpec := readHooksConfigFields(p)
-	if hooksConfigSpec == nil {
-		// Schema didn't ship HooksConfig (or this isn't the right
-		// types.go) — nothing meaningful the cop can say.
-		return
-	}
-
-	// Build reverse map for diagnostics.
-	cfgByJSON := map[string]string{} // wire-string -> Go field name
-	for goName, jsonName := range cfgFields {
-		cfgByJSON[jsonName] = goName
-	}
-
-	// Direction 1: every event must have a config field.
-	var missingFields []string
-	for constName, wire := range hookEvents {
-		if _, ok := cfgByJSON[wire]; !ok {
-			missingFields = append(missingFields, constName+"="+strconv.Quote(wire))
-		}
-	}
-	if len(missingFields) > 0 {
-		slices.Sort(missingFields)
-		p.Report(hooksConfigSpec.Name,
-			"HooksConfig is missing field(s) for hook event(s): %s", strings.Join(missingFields, ", "))
-	}
-
-	// Direction 2: every config field must have an event constant.
-	wireSet := map[string]string{} // wire -> const name
-	for n, w := range hookEvents {
-		wireSet[w] = n
-	}
-	var orphanFields []string
-	for goName, jsonName := range cfgFields {
-		if _, ok := wireSet[jsonName]; !ok {
-			orphanFields = append(orphanFields, goName+" json:"+strconv.Quote(jsonName))
-		}
-	}
-	if len(orphanFields) > 0 {
-		slices.Sort(orphanFields)
-		p.Report(hooksConfigSpec.Name,
-			"HooksConfig field(s) without a matching EventXxx constant in pkg/hooks/types.go: %s",
-			strings.Join(orphanFields, ", "))
+			// Direction 2: every config field must have an event constant.
+			wireSet := map[string]string{} // wire -> const name
+			for n, w := range hookEvents {
+				wireSet[w] = n
+			}
+			var orphanFields []string
+			for goName, jsonName := range cfgFields {
+				if _, ok := wireSet[jsonName]; !ok {
+					orphanFields = append(orphanFields, goName+" json:"+strconv.Quote(jsonName))
+				}
+			}
+			p.ReportMissing(hooksConfigSpec.Name,
+				"HooksConfig field(s) without a matching EventXxx constant in pkg/hooks/types.go: %s",
+				orphanFields)
+		},
 	}
 }
 
@@ -120,16 +107,12 @@ func readHooksConfigFields(p *cop.Pass) (map[string]string, *ast.TypeSpec) {
 			return
 		}
 		spec = ts
-		jsonTag, ok := tag.Lookup("json")
-		if !ok {
-			return
-		}
-		name, _, _ := strings.Cut(jsonTag, ",")
-		if name == "" || name == "-" {
+		opts, ok := cop.ParseTagOptions(tag, "json")
+		if !ok || !opts.HasName() {
 			return
 		}
 		for _, n := range fld.Names {
-			fields[n.Name] = name
+			fields[n.Name] = opts.Name
 		}
 	})
 	return fields, spec

--- a/lint/latest_imports_predecessor.go
+++ b/lint/latest_imports_predecessor.go
@@ -4,8 +4,8 @@ import (
 	"github.com/dgageot/rubocop-go/cop"
 )
 
-// LatestImportsPredecessor enforces that files under pkg/config/latest/ that
-// import a historical config version package (pkg/config/vN) only ever
+// NewLatestImportsPredecessor enforces that files under pkg/config/latest/
+// that import a historical config version package (pkg/config/vN) only ever
 // import the immediate predecessor: the highest vN under pkg/config/.
 //
 // The Lint/ConfigVersionImport cop verifies that *numbered* versions follow
@@ -13,41 +13,33 @@ import (
 // This cop closes that gap so pkg/config/latest also obeys the chain
 // (latest imports the highest vN, never an older version), which is required
 // for the upgrade pipeline to reach the latest schema in a single hop.
-type LatestImportsPredecessor struct {
-	cop.Meta
-}
+func NewLatestImportsPredecessor() cop.Cop {
+	return &cop.Func{
+		Meta: cop.Meta{
+			Name:        "Lint/LatestImportsPredecessor",
+			Description: "pkg/config/latest must only import its immediate predecessor (highest vN)",
+			Severity:    cop.Error,
+		},
+		Scope: cop.And(
+			cop.InPathSegment("pkg/config", func(s string) bool { return s == "latest" }),
+			cop.NotBlackBoxTest(),
+		),
+		Run: func(p *cop.Pass) {
+			if len(p.File.Imports) == 0 {
+				return
+			}
+			highest, ok := highestSiblingVersion(p.Filename())
+			if !ok {
+				return
+			}
 
-// NewLatestImportsPredecessor returns a fully configured LatestImportsPredecessor cop.
-func NewLatestImportsPredecessor() *LatestImportsPredecessor {
-	return &LatestImportsPredecessor{Meta: cop.Meta{
-		CopName:     "Lint/LatestImportsPredecessor",
-		CopDesc:     "pkg/config/latest must only import its immediate predecessor (highest vN)",
-		CopSeverity: cop.Error,
-	}}
-}
-
-func (c *LatestImportsPredecessor) Check(p *cop.Pass) {
-	if len(p.File.Imports) == 0 {
-		return
-	}
-	// Black-box test files (package latest_test) are external to the package
-	// and may import what they please.
-	if p.IsBlackBoxTest() {
-		return
-	}
-	if dir, _ := p.PathSegment("pkg/config"); dir != "latest" {
-		return
-	}
-	highest, ok := highestSiblingVersion(p.Filename())
-	if !ok {
-		return
-	}
-
-	for _, imp := range p.File.Imports {
-		got, ok := versionFromImport(cop.ImportPath(imp))
-		if !ok || got == highest {
-			continue
-		}
-		p.Report(imp.Path, "pkg/config/latest must import its predecessor v%d, not v%d", highest, got)
+			for _, imp := range p.File.Imports {
+				got, ok := versionFromImport(cop.ImportPath(imp))
+				if !ok || got == highest {
+					continue
+				}
+				p.Reportf(imp.Path, "pkg/config/latest must import its predecessor v%d, not v%d", highest, got)
+			}
+		},
 	}
 }

--- a/lint/runtime_event_registry.go
+++ b/lint/runtime_event_registry.go
@@ -3,15 +3,14 @@ package main
 import (
 	"go/ast"
 	"go/token"
-	"slices"
 	"strconv"
 	"strings"
 
 	"github.com/dgageot/rubocop-go/cop"
 )
 
-// RuntimeEventRegistry enforces that pkg/runtime/client.go registers every
-// runtime event type defined in pkg/runtime/event.go.
+// NewRuntimeEventRegistry enforces that pkg/runtime/client.go registers
+// every runtime event type defined in pkg/runtime/event.go.
 //
 // The remote-runtime client decodes incoming JSON events by reading the
 // "type" discriminator and looking it up in a static registry built in
@@ -34,59 +33,49 @@ import (
 // finds in pkg/runtime/event.go. Each event type whose Type-string is
 // missing from the registry is reported with a diagnostic anchored on
 // the registry map literal, where the fix lives.
-type RuntimeEventRegistry struct {
-	cop.Meta
-}
+func NewRuntimeEventRegistry() cop.Cop {
+	return &cop.Func{
+		Meta: cop.Meta{
+			Name:        "Lint/RuntimeEventRegistry",
+			Description: "pkg/runtime/client.go must register every runtime event type",
+			Severity:    cop.Error,
+		},
+		Scope: cop.OnlyFile("pkg/runtime/client.go"),
+		Run: func(p *cop.Pass) {
+			// Sibling event.go is the source of truth for the set of
+			// emitted events.
+			eventFile, err := p.ParseSibling("event.go")
+			if err != nil {
+				return
+			}
+			emitted := emittedEventTypes(eventFile)
+			if len(emitted) == 0 {
+				return
+			}
 
-// NewRuntimeEventRegistry returns a fully configured RuntimeEventRegistry cop.
-func NewRuntimeEventRegistry() *RuntimeEventRegistry {
-	return &RuntimeEventRegistry{Meta: cop.Meta{
-		CopName:     "Lint/RuntimeEventRegistry",
-		CopDesc:     "pkg/runtime/client.go must register every runtime event type",
-		CopSeverity: cop.Error,
-	}}
-}
+			registryNode, registered := registryEntries(p)
+			if registryNode == nil {
+				return
+			}
 
-func (c *RuntimeEventRegistry) Check(p *cop.Pass) {
-	if !p.FileMatches("pkg/runtime/client.go") {
-		return
+			var missing []string
+			for typeName, typeStr := range emitted {
+				if got, ok := registered[typeStr]; !ok {
+					missing = append(missing, typeName+" (Type: "+strconv.Quote(typeStr)+")")
+				} else if got != typeName {
+					// The registry key is correct but it constructs the
+					// wrong concrete type. That is a different bug from
+					// "missing entry" so we keep it as a separate
+					// diagnostic anchored on the registry map for clarity.
+					p.Reportf(registryNode,
+						"registry key %q constructs %s but %s emits Type=%q",
+						typeStr, got, typeName, typeStr)
+				}
+			}
+			p.ReportMissing(registryNode,
+				"pkg/runtime/client.go is missing registry entries for: %s", missing)
+		},
 	}
-
-	// Sibling event.go is the source of truth for the set of emitted events.
-	eventFile, err := p.ParseSibling("event.go")
-	if err != nil {
-		return
-	}
-	emitted := emittedEventTypes(eventFile)
-	if len(emitted) == 0 {
-		return
-	}
-
-	registryNode, registered := registryEntries(p)
-	if registryNode == nil {
-		return
-	}
-
-	var missing []string
-	for typeName, typeStr := range emitted {
-		if got, ok := registered[typeStr]; !ok {
-			missing = append(missing, typeName+" (Type: "+strconv.Quote(typeStr)+")")
-		} else if got != typeName {
-			// The registry key is correct but it constructs the wrong
-			// concrete type. That is a different bug from "missing entry"
-			// so we keep it as a separate diagnostic anchored on the
-			// registry map for clarity.
-			p.Report(registryNode,
-				"registry key %q constructs %s but %s emits Type=%q",
-				typeStr, got, typeName, typeStr)
-		}
-	}
-	if len(missing) == 0 {
-		return
-	}
-	slices.Sort(missing)
-	p.Report(registryNode,
-		"pkg/runtime/client.go is missing registry entries for: %s", strings.Join(missing, ", "))
 }
 
 // emittedEventTypes returns a map of EventTypeName -> wire-format Type
@@ -104,23 +93,7 @@ func emittedEventTypes(file *ast.File) map[string]string {
 		if !ok || !strings.HasSuffix(id.Name, "Event") {
 			return true
 		}
-		for _, elt := range cl.Elts {
-			kv, ok := elt.(*ast.KeyValueExpr)
-			if !ok {
-				continue
-			}
-			k, ok := kv.Key.(*ast.Ident)
-			if !ok || k.Name != "Type" {
-				continue
-			}
-			lit, ok := kv.Value.(*ast.BasicLit)
-			if !ok || lit.Kind != token.STRING {
-				continue
-			}
-			val, err := strconv.Unquote(lit.Value)
-			if err != nil {
-				continue
-			}
+		if val, ok := cop.StringField(cl, "Type"); ok {
 			emitted[id.Name] = val
 		}
 		return true
@@ -188,14 +161,7 @@ func isEventRegistryType(expr ast.Expr) bool {
 	if !ok {
 		return false
 	}
-	if ft.Params != nil && len(ft.Params.List) != 0 {
-		return false
-	}
-	if ft.Results == nil || len(ft.Results.List) != 1 {
-		return false
-	}
-	rid, ok := ft.Results.List[0].Type.(*ast.Ident)
-	return ok && rid.Name == "Event"
+	return cop.IsNullarySig(ft, "Event")
 }
 
 // returnedEventType pulls "FooEvent" out of a `func() Event { return &FooEvent{} }`

--- a/lint/runtime_session_scoped.go
+++ b/lint/runtime_session_scoped.go
@@ -7,9 +7,9 @@ import (
 	"github.com/dgageot/rubocop-go/cop"
 )
 
-// RuntimeSessionScoped enforces that every runtime event struct carrying a
-// SessionID field also implements the SessionScoped interface, i.e. exposes
-// a `GetSessionID() string` method on its pointer receiver.
+// NewRuntimeSessionScoped enforces that every runtime event struct carrying
+// a SessionID field also implements the SessionScoped interface, i.e.
+// exposes a `GetSessionID() string` method on its pointer receiver.
 //
 // SessionScoped is the discriminator the persistence pipeline uses to keep
 // sub-agent events out of the parent session's transcript:
@@ -27,37 +27,30 @@ import (
 //
 // The cop runs on pkg/runtime/event.go and reports any *Event struct with
 // a SessionID field whose pointer type lacks GetSessionID().
-type RuntimeSessionScoped struct {
-	cop.Meta
-}
+func NewRuntimeSessionScoped() cop.Cop {
+	return &cop.Func{
+		Meta: cop.Meta{
+			Name:        "Lint/RuntimeSessionScoped",
+			Description: "runtime events with a SessionID field must implement GetSessionID() (SessionScoped)",
+			Severity:    cop.Error,
+		},
+		Scope: cop.OnlyFile("pkg/runtime/event.go"),
+		Run: func(p *cop.Pass) {
+			withSessionID := eventStructsWithSessionID(p)
+			if len(withSessionID) == 0 {
+				return
+			}
+			implementsScoped := p.PointerReceiverMethods("GetSessionID")
 
-// NewRuntimeSessionScoped returns a fully configured RuntimeSessionScoped cop.
-func NewRuntimeSessionScoped() *RuntimeSessionScoped {
-	return &RuntimeSessionScoped{Meta: cop.Meta{
-		CopName:     "Lint/RuntimeSessionScoped",
-		CopDesc:     "runtime events with a SessionID field must implement GetSessionID() (SessionScoped)",
-		CopSeverity: cop.Error,
-	}}
-}
-
-func (c *RuntimeSessionScoped) Check(p *cop.Pass) {
-	if !p.FileMatches("pkg/runtime/event.go") {
-		return
-	}
-
-	withSessionID := eventStructsWithSessionID(p)
-	if len(withSessionID) == 0 {
-		return
-	}
-	implementsScoped := pointerReceiversWithMethod(p, "GetSessionID")
-
-	for typeName, typeSpec := range withSessionID {
-		if !implementsScoped[typeName] {
-			p.Report(typeSpec.Name,
-				"%s carries a SessionID field but does not implement GetSessionID() (SessionScoped); "+
-					"sub-agent events of this type would bypass the persistence-observer session filter",
-				typeName)
-		}
+			for typeName, typeSpec := range withSessionID {
+				if !implementsScoped[typeName] {
+					p.Reportf(typeSpec.Name,
+						"%s carries a SessionID field but does not implement GetSessionID() (SessionScoped); "+
+							"sub-agent events of this type would bypass the persistence-observer session filter",
+						typeName)
+				}
+			}
+		},
 	}
 }
 
@@ -79,20 +72,4 @@ func eventStructsWithSessionID(p *cop.Pass) map[string]*ast.TypeSpec {
 		}
 	})
 	return out
-}
-
-// pointerReceiversWithMethod returns the set of type names T for which the
-// file declares `func (* T) <method>(...)`. Used to detect interface
-// satisfaction without invoking the type checker.
-func pointerReceiversWithMethod(p *cop.Pass, method string) map[string]bool {
-	with := map[string]bool{}
-	p.ForEachFunc(func(fn *ast.FuncDecl) {
-		if fn.Name.Name != method {
-			return
-		}
-		if r, ok := cop.Receiver(fn); ok && r.IsPointer {
-			with[r.TypeName] = true
-		}
-	})
-	return with
 }

--- a/lint/slog_contextual.go
+++ b/lint/slog_contextual.go
@@ -6,7 +6,7 @@ import (
 	"github.com/dgageot/rubocop-go/cop"
 )
 
-// SlogContextual enforces that callers use the *Context variant of every
+// NewSlogContextual enforces that callers use the *Context variant of every
 // slog top-level helper whenever a context.Context is reachable in the
 // enclosing function.
 //
@@ -35,177 +35,33 @@ import (
 // thread a context through APIs that don't otherwise need one.
 //
 // Per-line suppression: `//rubocop:disable Lint/SlogContextual`.
-type SlogContextual struct {
-	cop.Meta
-}
-
-// NewSlogContextual returns a fully configured SlogContextual cop.
-func NewSlogContextual() *SlogContextual {
-	return &SlogContextual{Meta: cop.Meta{
-		CopName:     "Lint/SlogContextual",
-		CopDesc:     "use slog.{Level}Context(ctx, …) when a context is in scope",
-		CopSeverity: cop.Warning,
-	}}
-}
-
-// slogLevels is the set of slog top-level helpers whose Context-aware
-// sibling (e.g. Debug → DebugContext) should be preferred when a context
-// is in scope. slog.Log / slog.LogAttrs already take a context.
-var slogLevels = map[string]bool{
-	"Debug": true,
-	"Info":  true,
-	"Warn":  true,
-	"Error": true,
-}
-
-func (c *SlogContextual) Check(p *cop.Pass) {
-	p.ForEachFunc(func(fn *ast.FuncDecl) {
-		if fn.Body != nil {
-			c.checkFunc(p, fn.Type, fn.Body, false)
-		}
-	})
-}
-
-// checkFunc reports bare slog calls inside body when a context is reachable
-// from any enclosing function. outerHasContext propagates that visibility
-// into nested function literals, since closures capture by name.
-func (c *SlogContextual) checkFunc(p *cop.Pass, typ *ast.FuncType, body *ast.BlockStmt, outerHasContext bool) {
-	hasContext := outerHasContext || signatureDeclaresContext(typ) || bodyDeclaresContext(body)
-	ast.Inspect(body, func(n ast.Node) bool {
-		switch x := n.(type) {
-		case *ast.FuncLit:
-			c.checkFunc(p, x.Type, x.Body, hasContext)
-			return false
-		case *ast.CallExpr:
-			if hasContext {
-				c.reportIfBareSlog(p, x)
+func NewSlogContextual() cop.Cop {
+	return cop.New(cop.Meta{
+		Name:        "Lint/SlogContextual",
+		Description: "use slog.{Level}Context(ctx, …) when a context is in scope",
+		Severity:    cop.Warning,
+	}, func(p *cop.Pass) {
+		p.ForEachFunc(func(fn *ast.FuncDecl) {
+			if fn.Body == nil {
+				return
 			}
-		}
-		return true
-	})
-}
-
-// reportIfBareSlog reports an offense when call is `slog.<Level>(...)`
-// for one of the four level helpers that have a Context-aware sibling.
-func (c *SlogContextual) reportIfBareSlog(p *cop.Pass, call *ast.CallExpr) {
-	pkg, level, ok := cop.MatchSelector(call.Fun)
-	if !ok || pkg != "slog" || !slogLevels[level] {
-		return
-	}
-	p.Report(call,
-		"a context is in scope; use slog.%s(ctx, …) instead of slog.%s so handlers (e.g. OpenTelemetry) can read it",
-		level+"Context", level)
-}
-
-// signatureDeclaresContext reports whether typ declares any parameter or
-// named result of type context.Context.
-func signatureDeclaresContext(typ *ast.FuncType) bool {
-	for _, fl := range []*ast.FieldList{typ.Params, typ.Results} {
-		if fl == nil {
-			continue
-		}
-		for _, f := range fl.List {
-			if !isContextContextType(f.Type) {
-				continue
-			}
-			// Anonymous parameter (e.g., `func(context.Context)`) has no names
-			// but still declares a context in scope.
-			if len(f.Names) == 0 {
-				return true
-			}
-			for _, n := range f.Names {
-				if namedIdent(n) {
+			cop.WalkFuncWithContextScope(fn.Type, fn.Body, false, func(n ast.Node, hasContext bool) bool {
+				if !hasContext {
 					return true
 				}
-			}
-		}
-	}
-	return false
-}
-
-// bodyDeclaresContext reports whether body locally binds an identifier to
-// a context.Context value. Nested function literals are skipped — their
-// bindings are inspected separately when checkFunc recurses into them.
-func bodyDeclaresContext(body *ast.BlockStmt) bool {
-	found := false
-	ast.Inspect(body, func(n ast.Node) bool {
-		if found {
-			return false
-		}
-		switch s := n.(type) {
-		case *ast.FuncLit:
-			return false
-		case *ast.AssignStmt:
-			found = bindsContext(s.Lhs, s.Rhs)
-		case *ast.ValueSpec:
-			found = valueSpecDeclaresContext(s)
-		}
-		return !found
-	})
-	return found
-}
-
-// valueSpecDeclaresContext reports whether s declares a context.Context,
-// either explicitly via its declared type (`var ctx context.Context`) or
-// implicitly via its initializer (`var ctx = context.Background()`).
-func valueSpecDeclaresContext(s *ast.ValueSpec) bool {
-	if isContextContextType(s.Type) {
-		for _, n := range s.Names {
-			if namedIdent(n) {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				name, ok := cop.CallTo(call, "slog", "Debug", "Info", "Warn", "Error")
+				if !ok {
+					return true
+				}
+				p.Reportf(call,
+					"a context is in scope; use slog.%s(ctx, …) instead of slog.%s so handlers (e.g. OpenTelemetry) can read it",
+					name+"Context", name)
 				return true
-			}
-		}
-	}
-	if len(s.Values) == 0 {
-		return false
-	}
-	lhs := make([]ast.Expr, len(s.Names))
-	for i, n := range s.Names {
-		lhs[i] = n
-	}
-	return bindsContext(lhs, s.Values)
-}
-
-// bindsContext reports whether the assignment binds at least one LHS
-// identifier to a context.Context value. A single RHS covers both
-// single-value forms (`ctx := f()`) and multi-value returns
-// (`ctx, cancel := context.WithCancel(...)`); in the latter case the
-// context is always at the first return position — `_, cancel := ...`
-// discards the context and intentionally yields no in-scope name.
-func bindsContext(lhs, rhs []ast.Expr) bool {
-	if len(rhs) == 1 {
-		return len(lhs) >= 1 && contextProducer(rhs[0]) && namedIdent(lhs[0])
-	}
-	for i := 0; i < len(lhs) && i < len(rhs); i++ {
-		if contextProducer(rhs[i]) && namedIdent(lhs[i]) {
-			return true
-		}
-	}
-	return false
-}
-
-// namedIdent reports whether e is a named identifier — anonymous (`_`)
-// or unset names produce no usable scope binding.
-func namedIdent(e ast.Expr) bool {
-	id, ok := e.(*ast.Ident)
-	return ok && id.Name != "" && id.Name != "_"
-}
-
-// contextProducer reports whether expr is a call whose shape commonly
-// yields a context.Context: any call into the `context` package, or any
-// zero-arg method named `Context` (the cobra / http.Request convention).
-func contextProducer(expr ast.Expr) bool {
-	call, ok := expr.(*ast.CallExpr)
-	if !ok {
-		return false
-	}
-	pkg, sel, ok := cop.MatchSelector(call.Fun)
-	return ok && (pkg == "context" || (sel == "Context" && len(call.Args) == 0))
-}
-
-// isContextContextType reports whether expr is the syntactic type
-// `context.Context`.
-func isContextContextType(expr ast.Expr) bool {
-	pkg, sel, ok := cop.MatchSelector(expr)
-	return ok && pkg == "context" && sel == "Context"
+			})
+		})
+	})
 }

--- a/lint/tui_view_purity.go
+++ b/lint/tui_view_purity.go
@@ -7,8 +7,8 @@ import (
 	"github.com/dgageot/rubocop-go/cop"
 )
 
-// TUIViewPurity enforces that `View() string` methods on TUI models do not
-// mutate the receiver's fields. This is the Bubble Tea / Elm-Architecture
+// NewTUIViewPurity enforces that `View() string` methods on TUI models do
+// not mutate the receiver's fields. This is the Bubble Tea / Elm-Architecture
 // purity contract: rendering must be a pure function of state, otherwise
 // rendering twice in a row can produce different output and the runtime is
 // free to do exactly that (e.g. on resize, on a missed alt-screen redraw).
@@ -29,36 +29,30 @@ import (
 //
 // Per-line suppression is provided centrally by the runner: annotate the
 // line with `//rubocop:disable Lint/TUIViewPurity` to opt out.
-type TUIViewPurity struct {
-	cop.Meta
-}
-
-// NewTUIViewPurity returns a fully configured TUIViewPurity cop.
-func NewTUIViewPurity() *TUIViewPurity {
-	return &TUIViewPurity{Meta: cop.Meta{
-		CopName:     "Lint/TUIViewPurity",
-		CopDesc:     "View() methods on TUI models must not mutate the receiver",
-		CopSeverity: cop.Warning,
-	}}
-}
-
-func (c *TUIViewPurity) Check(p *cop.Pass) {
-	if !p.FileUnder("pkg/tui") {
-		return
+func NewTUIViewPurity() cop.Cop {
+	return &cop.Func{
+		Meta: cop.Meta{
+			Name:        "Lint/TUIViewPurity",
+			Description: "View() methods on TUI models must not mutate the receiver",
+			Severity:    cop.Warning,
+		},
+		Scope: cop.UnderDir("pkg/tui"),
+		Run: func(p *cop.Pass) {
+			p.ForEachFunc(func(fn *ast.FuncDecl) {
+				recv, ok := cop.Receiver(fn)
+				if !ok || !recv.IsPointer || recv.Name == "" || !cop.IsNullaryFunc(fn, "string") || fn.Name.Name != "View" {
+					return
+				}
+				checkViewBody(p, fn.Body, recv.Name)
+			})
+		},
 	}
-
-	p.ForEachFunc(func(fn *ast.FuncDecl) {
-		recv, ok := cop.Receiver(fn)
-		if !ok || !recv.IsPointer || recv.Name == "" || !isViewMethod(fn) {
-			return
-		}
-		c.checkBody(p, fn.Body, recv.Name)
-	})
 }
 
-// checkBody walks fn body and reports an offense for every assignment to a
-// receiver field that is not part of the slice-cache exemption set.
-func (c *TUIViewPurity) checkBody(p *cop.Pass, body *ast.BlockStmt, recv string) {
+// checkViewBody walks the View body and reports an offense for every
+// assignment to a receiver field that is not part of the slice-cache
+// exemption set.
+func checkViewBody(p *cop.Pass, body *ast.BlockStmt, recv string) {
 	if body == nil {
 		return
 	}
@@ -75,30 +69,13 @@ func (c *TUIViewPurity) checkBody(p *cop.Pass, body *ast.BlockStmt, recv string)
 			if i < len(assign.Rhs) && isSliceCachePattern(assign.Rhs[i], recv, field) {
 				continue
 			}
-			p.Report(assign,
+			p.Reportf(assign,
 				"View() must not mutate %s.%s; move the side effect to Update or compute it in a local variable"+
 					" (or annotate the line with //rubocop:disable Lint/TUIViewPurity if it is an intentional click-zone cache)",
 				recv, field)
 		}
 		return true
 	})
-}
-
-// isViewMethod reports whether fn is exactly `func (...) View() string`.
-// The cop intentionally ignores helpers that happen to be called View*
-// because they are not part of the Bubble Tea contract.
-func isViewMethod(fn *ast.FuncDecl) bool {
-	if fn.Name.Name != "View" {
-		return false
-	}
-	if fn.Type.Params != nil && len(fn.Type.Params.List) > 0 {
-		return false
-	}
-	if fn.Type.Results == nil || len(fn.Type.Results.List) != 1 {
-		return false
-	}
-	id, ok := fn.Type.Results.List[0].Type.(*ast.Ident)
-	return ok && id.Name == "string"
 }
 
 // isSliceCachePattern reports whether rhs is one of the recognised


### PR DESCRIPTION
Bumps `github.com/dgageot/rubocop-go` from `v0.0.0-20260429125723-198995cc80c9` to `v0.0.0-20260507084512-2695e6771458` and migrates the project cops in `lint/` to the new API:

- `cop.Meta` field renames: `CopName`/`CopDesc`/`CopSeverity` → `Name`/`Description`/`Severity`.
- `Pass.Report` → `Pass.Reportf`.
- Cops are now built with `cop.New` / `*cop.Func`, with file/dir guards expressed as `Scope:` filters (`OnlyFile`, `UnderDir`, `InPathSegment`, `NotBlackBoxTest`, `And`).
- Several locally-duplicated helpers were dropped in favour of the new built-ins:
  - `SlogContextual` now uses `cop.WalkFuncWithContextScope` + `cop.CallTo` (~150 lines removed).
  - `ConfigLatestTagConsistency` uses `cop.ParseTagOptions` + `cop.FieldNames`.
  - `RuntimeEventRegistry` uses `cop.StringField` + `cop.IsNullarySig`.
  - `RuntimeSessionScoped` uses `Pass.PointerReceiverMethods`.
  - `ConfigVersionsRegistered`, `HookBuiltinsRegistered`, `RuntimeEventRegistry`, `HookConfigSync` use `Pass.ReportMissing` for the recurring "missing entries for: …" diagnostics.
  - `TUIViewPurity` uses `cop.IsNullaryFunc`.
  - `HookBuiltinsRegistered` uses `Pass.FuncDecl` / `Pass.FirstMethodCall` for anchor lookup.

Net: −359 lines across `lint/`. Validated with `task lint`, `task test`, and `task build`. Spot-tested several cops by injecting deliberate violations to confirm they still fire.