### PR TITLE
fix: expand ~ in filesystem tool paths

### DIFF
--- a/pkg/tools/builtin/filesystem/filesystem.go
+++ b/pkg/tools/builtin/filesystem/filesystem.go
@@ -490,18 +490,42 @@ func (t *Tool) executePostEditCommands(ctx context.Context, filePath string) err
 }
 
 // resolvePath resolves a path relative to the working directory.
-// Relative paths (including ".") are joined with the working directory.
-// Absolute paths and paths starting with ".." are used as-is.
+// A leading "~" or "~/" is expanded to the user's home directory so that
+// LLM-supplied paths like "~/file.txt" work without the agent having to
+// know the user's home directory upfront. Relative paths (including ".")
+// are joined with the working directory. Absolute paths and paths
+// starting with ".." are used as-is.
 //
 // resolvePath does NOT enforce the allow- or deny-lists; callers should use
 // [resolveAndCheckPath] when those checks are required (i.e. for any path
 // that originates from a tool argument).
 func (t *Tool) resolvePath(path string) string {
+	path = expandHomeDir(path)
 	if filepath.IsAbs(path) {
 		return filepath.Clean(path)
 	}
 
 	return filepath.Clean(filepath.Join(t.workingDir, path))
+}
+
+// expandHomeDir replaces a leading "~" or "~/" (or "~\\" on Windows) with
+// the user's home directory. Returns the path unchanged when it isn't a
+// home-relative reference or when the home directory cannot be determined;
+// the caller will then resolve it as a literal name and likely surface a
+// "not found" error, which is preferable to a hard failure inside path
+// resolution.
+func expandHomeDir(path string) string {
+	if path != "~" && !strings.HasPrefix(path, "~/") && !strings.HasPrefix(path, "~"+string(filepath.Separator)) {
+		return path
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+	if path == "~" {
+		return home
+	}
+	return filepath.Join(home, path[2:])
 }
 
 // resolveAndCheckPath is the canonical entry point used by every filesystem

--- a/pkg/tools/builtin/filesystem/filesystem_test.go
+++ b/pkg/tools/builtin/filesystem/filesystem_test.go
@@ -67,6 +67,45 @@ func TestFilesystemTool_ResolvePath(t *testing.T) {
 	assert.Equal(t, "/etc/hosts", resolvedPath)
 }
 
+// TestFilesystemTool_ResolvePath_ExpandsTilde is a regression test for
+// issue #2696: paths starting with "~" or "~/" must be expanded to the
+// user's home directory before being used, otherwise read_file (and every
+// other filesystem handler) treats them as a literal subdirectory of the
+// working directory and fails with "not found".
+func TestFilesystemTool_ResolvePath_ExpandsTilde(t *testing.T) {
+	homeDir := t.TempDir()
+	resetHomeDir(t, homeDir)
+	wd := t.TempDir()
+	tool := NewFilesystemTool(wd)
+
+	assert.Equal(t, homeDir, tool.resolvePath("~"))
+	assert.Equal(t, filepath.Join(homeDir, "file.txt"), tool.resolvePath("~/file.txt"))
+	assert.Equal(t, filepath.Join(homeDir, "a", "b", "c.txt"), tool.resolvePath("~/a/b/c.txt"))
+
+	// A bare "~name" (no separator) is not the home dir: keep it as a
+	// literal subdirectory of the working dir so the user can still
+	// reference a file/dir whose name happens to start with "~".
+	assert.Equal(t, filepath.Join(wd, "~name"), tool.resolvePath("~name"))
+}
+
+// TestFilesystemTool_ReadFile_TildePath verifies the end-to-end behaviour:
+// read_file with a "~/..." path must succeed and return the file's
+// contents. This is the user-visible bug from issue #2696.
+func TestFilesystemTool_ReadFile_TildePath(t *testing.T) {
+	homeDir := t.TempDir()
+	resetHomeDir(t, homeDir)
+	wd := t.TempDir()
+	tool := NewFilesystemTool(wd)
+
+	content := "hello from home"
+	require.NoError(t, os.WriteFile(filepath.Join(homeDir, "note.txt"), []byte(content), 0o644))
+
+	result, err := tool.handleReadFile(t.Context(), ReadFileArgs{Path: "~/note.txt"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Equal(t, content, result.Output)
+}
+
 func TestFilesystemTool_WriteFile(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()


### PR DESCRIPTION
Fixes #2696.

`Tool.resolvePath` joined LLM-supplied paths with the working directory without expanding a leading `~`, so calls like `read_file("~/file.txt")` looked up `<workingDir>/~/file.txt` and failed with "not found". The allow/deny list config already expanded `~` (via `expandPathToken`); this brings runtime path resolution in line.

- Added a small `expandHomeDir` helper that replaces a leading `~` or `~/` (or `~\` on Windows) with `os.UserHomeDir()`, leaving everything else (including bare `~name`) untouched.
- `resolvePath` calls it before its absolute/relative branching, so every filesystem handler benefits (read, write, edit, list, search, mkdir, rmdir, tree, read_multiple).
- Regression tests cover `~`, `~/file`, `~/a/b/c`, the literal `~name` case, and an end-to-end `read_file("~/note.txt")`.