### PR TITLE
fix: use available Kimi-K2.5 model in nebius example

### DIFF
--- a/examples/nebius.yaml
+++ b/examples/nebius.yaml
@@ -12,6 +12,6 @@ agents:
 models:
   grok-model:
     provider: nebius
-    model: moonshotai/Kimi-K2-Instruct
+    model: moonshotai/Kimi-K2.5
     max_tokens: 110000
     temperature: 0.7


### PR DESCRIPTION
The `moonshotai/Kimi-K2-Instruct` model is no longer listed in the nebius provider catalog on models.dev, which caused `TestParseExamples/../../examples/nebius.yaml` to fail. Switch the example to `moonshotai/Kimi-K2.5`, which is the current Moonshot model offered by nebius.