### PR TITLE
security: five defense-in-depth fixes (secrets, archives, oauth, shell tool, request logs)

### DIFF
--- a/pkg/chatserver/server.go
+++ b/pkg/chatserver/server.go
@@ -38,6 +38,7 @@ import (
 	"github.com/openai/openai-go/v3"
 
 	"github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/echolog"
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/team"
@@ -202,7 +203,7 @@ func newRouter(s *server, opts Options) http.Handler {
 		timeout = defaultRequestTimeout
 	}
 
-	e.Use(middleware.RequestLogger())
+	e.Use(echolog.RedactedRequestLogger())
 	e.Use(middleware.BodyLimit(strconv.FormatInt(maxBytes, 10)))
 	e.Use(requestTimeoutMiddleware(timeout))
 

--- a/pkg/echolog/echolog.go
+++ b/pkg/echolog/echolog.go
@@ -6,7 +6,6 @@
 package echolog
 
 import (
-	"context"
 	"log/slog"
 
 	"github.com/labstack/echo/v4"
@@ -36,7 +35,7 @@ func RedactedRequestLogger() echo.MiddlewareFunc {
 		LogContentLength: true,
 		LogResponseSize:  true,
 		HandleError:      true,
-		LogValuesFunc: func(_ echo.Context, v middleware.RequestLoggerValues) error {
+		LogValuesFunc: func(c echo.Context, v middleware.RequestLoggerValues) error {
 			level := slog.LevelInfo
 			msg := "REQUEST"
 			attrs := []slog.Attr{
@@ -56,7 +55,7 @@ func RedactedRequestLogger() echo.MiddlewareFunc {
 				msg = "REQUEST_ERROR"
 				attrs = append(attrs, slog.String("error", v.Error.Error()))
 			}
-			slog.LogAttrs(context.Background(), level, msg, attrs...)
+			slog.LogAttrs(c.Request().Context(), level, msg, attrs...)
 			return nil
 		},
 	})

--- a/pkg/echolog/echolog.go
+++ b/pkg/echolog/echolog.go
@@ -1,0 +1,63 @@
+// Package echolog provides Echo middleware tailored for docker-agent's
+// HTTP servers. It currently exposes a single helper, RedactedRequestLogger,
+// that mirrors the default echo middleware.RequestLogger() but never
+// records request bodies, raw query strings, or other places that may
+// carry secrets.
+package echolog
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+)
+
+// RedactedRequestLogger returns an Echo request-logging middleware that
+// matches middleware.RequestLogger() in spirit (one structured slog line
+// per request) but logs the URL path only, not the full request URI.
+//
+// Echo's default logger emits v.URI, which includes the query string.
+// Some clients pass authentication material through query parameters,
+// which would otherwise be persisted to whichever sink slog points at.
+// We therefore log v.URIPath (req.URL.Path) and explicitly drop the
+// query.
+func RedactedRequestLogger() echo.MiddlewareFunc {
+	return middleware.RequestLoggerWithConfig(middleware.RequestLoggerConfig{
+		LogLatency:       true,
+		LogRemoteIP:      true,
+		LogHost:          true,
+		LogMethod:        true,
+		LogURIPath:       true,
+		LogRequestID:     true,
+		LogUserAgent:     true,
+		LogStatus:        true,
+		LogError:         true,
+		LogContentLength: true,
+		LogResponseSize:  true,
+		HandleError:      true,
+		LogValuesFunc: func(_ echo.Context, v middleware.RequestLoggerValues) error {
+			level := slog.LevelInfo
+			msg := "REQUEST"
+			attrs := []slog.Attr{
+				slog.String("method", v.Method),
+				slog.String("path", v.URIPath),
+				slog.Int("status", v.Status),
+				slog.Duration("latency", v.Latency),
+				slog.String("host", v.Host),
+				slog.String("bytes_in", v.ContentLength),
+				slog.Int64("bytes_out", v.ResponseSize),
+				slog.String("user_agent", v.UserAgent),
+				slog.String("remote_ip", v.RemoteIP),
+				slog.String("request_id", v.RequestID),
+			}
+			if v.Error != nil {
+				level = slog.LevelError
+				msg = "REQUEST_ERROR"
+				attrs = append(attrs, slog.String("error", v.Error.Error()))
+			}
+			slog.LogAttrs(context.Background(), level, msg, attrs...)
+			return nil
+		},
+	})
+}

--- a/pkg/echolog/echolog_test.go
+++ b/pkg/echolog/echolog_test.go
@@ -2,6 +2,7 @@ package echolog
 
 import (
 	"bytes"
+	"context"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -44,4 +45,63 @@ func TestRedactedRequestLogger_DropsQueryString(t *testing.T) {
 	assert.NotContains(t, logged, "token=", "query parameter names+values must not leak")
 	// Sanity: the path key should be present, not "uri".
 	assert.Contains(t, logged, "path=", "expected path= attribute, got: %s", logged)
+}
+
+// ctxCapturingHandler is a slog.Handler that records a value extracted
+// from the context passed to Handle, so tests can assert that per-request
+// context values reach slog.
+type ctxCapturingHandler struct {
+	inner slog.Handler
+	key   any
+	value any
+}
+
+func (h *ctxCapturingHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.inner.Enabled(ctx, level)
+}
+
+func (h *ctxCapturingHandler) Handle(ctx context.Context, r slog.Record) error {
+	if v := ctx.Value(h.key); v != nil {
+		h.value = v
+	}
+	return h.inner.Handle(ctx, r)
+}
+
+func (h *ctxCapturingHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &ctxCapturingHandler{inner: h.inner.WithAttrs(attrs), key: h.key}
+}
+
+func (h *ctxCapturingHandler) WithGroup(name string) slog.Handler {
+	return &ctxCapturingHandler{inner: h.inner.WithGroup(name), key: h.key}
+}
+
+type ctxKey struct{}
+
+// TestRedactedRequestLogger_PropagatesRequestContext verifies that the
+// per-request context (carrying trace spans, correlation IDs, etc.) is
+// passed through to slog instead of being replaced by context.Background().
+func TestRedactedRequestLogger_PropagatesRequestContext(t *testing.T) {
+	var buf bytes.Buffer
+	capturing := &ctxCapturingHandler{
+		inner: slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}),
+		key:   ctxKey{},
+	}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(capturing))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	e := echo.New()
+	e.Use(RedactedRequestLogger())
+	e.GET("/ping", func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	ctx := context.WithValue(t.Context(), ctxKey{}, "trace-42")
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/ping", http.NoBody)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	assert.Equal(t, "trace-42", capturing.value,
+		"request context values must be propagated to slog (not replaced by context.Background())")
 }

--- a/pkg/echolog/echolog_test.go
+++ b/pkg/echolog/echolog_test.go
@@ -1,0 +1,47 @@
+package echolog
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRedactedRequestLogger_DropsQueryString verifies that secrets passed
+// through query parameters never reach slog. Echo's default RequestLogger
+// emits v.URI (which includes "?token=..."); RedactedRequestLogger must
+// log v.URIPath instead.
+func TestRedactedRequestLogger_DropsQueryString(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	e := echo.New()
+	e.Use(RedactedRequestLogger())
+	e.GET("/api/things", func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequestWithContext(
+		t.Context(),
+		http.MethodGet,
+		"/api/things?token=swordfish&user=alice",
+		http.NoBody,
+	)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	logged := buf.String()
+	assert.Contains(t, logged, "/api/things", "the path itself should be logged")
+	assert.NotContains(t, logged, "swordfish", "query parameter values must not leak into logs")
+	assert.NotContains(t, logged, "token=", "query parameter names+values must not leak")
+	// Sanity: the path key should be present, not "uri".
+	assert.Contains(t, logged, "path=", "expected path= attribute, got: %s", logged)
+}

--- a/pkg/environment/secrets.go
+++ b/pkg/environment/secrets.go
@@ -2,10 +2,10 @@ package environment
 
 import (
 	"context"
+	"errors"
+	"io/fs"
 	"log/slog"
 	"os"
-
-	"github.com/docker/docker-agent/pkg/path"
 )
 
 type RunSecretsProvider struct {
@@ -18,24 +18,29 @@ func NewRunSecretsProvider() *RunSecretsProvider {
 	}
 }
 
+// Get reads the named secret file from the provider's root directory.
+//
+// Lookups are anchored to root via os.OpenRoot: name components that
+// escape via ".." segments, absolute paths, or symbolic links pointing
+// outside the root are rejected by the kernel and surface as a missed
+// lookup. An attacker who can plant a symlink under root therefore
+// cannot coerce the agent into reading files elsewhere on the host.
 func (p *RunSecretsProvider) Get(_ context.Context, name string) (string, bool) {
-	// Validate the secret name to prevent path traversal
-	validatedPath, err := path.ValidatePathInDirectory(name, p.root)
+	root, err := os.OpenRoot(p.root)
 	if err != nil {
-		slog.Debug("Invalid secret name", "name", name, "error", err)
-		return "", false
-	}
-
-	buf, err := os.ReadFile(validatedPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return "", false
+		if !errors.Is(err, fs.ErrNotExist) {
+			slog.Debug("Failed to open secrets root", "root", p.root, "error", err)
 		}
-
-		// Ignore error
-		slog.Debug("Failed to find secret in /run/secrets", "error", err)
 		return "", false
 	}
+	defer root.Close()
 
+	buf, err := root.ReadFile(name)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			slog.Debug("Failed to read secret", "name", name, "error", err)
+		}
+		return "", false
+	}
 	return string(buf), true
 }

--- a/pkg/environment/secrets_test.go
+++ b/pkg/environment/secrets_test.go
@@ -125,3 +125,25 @@ func TestRunSecretsProvider_PathTraversal(t *testing.T) {
 	assert.Equal(t, "SUB_VALUE", result, "Subdirectory access should work")
 	assert.True(t, found)
 }
+
+func TestRunSecretsProvider_SymlinkEscape(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	secretsDir := filepath.Join(tmpDir, "secrets")
+	require.NoError(t, os.Mkdir(secretsDir, 0o755))
+
+	// A sensitive file living outside the secrets directory.
+	sensitive := filepath.Join(tmpDir, "sensitive.txt")
+	require.NoError(t, os.WriteFile(sensitive, []byte("SENSITIVE_DATA"), 0o644))
+
+	// Plant a symlink inside the secrets directory pointing at it.
+	require.NoError(t, os.Symlink(sensitive, filepath.Join(secretsDir, "escape")))
+
+	provider := &RunSecretsProvider{root: secretsDir}
+
+	result, found := provider.Get(t.Context(), "escape")
+	assert.Empty(t, result, "Symlink escaping the secrets root must not resolve")
+	assert.False(t, found)
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -13,10 +13,10 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
-	"github.com/labstack/echo/v4/middleware"
 
 	"github.com/docker/docker-agent/pkg/api"
 	"github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/echolog"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/upstream"
 )
@@ -28,7 +28,7 @@ type Server struct {
 
 func New(ctx context.Context, sessionStore session.Store, runConfig *config.RuntimeConfig, refreshInterval time.Duration, agentSources config.Sources) (*Server, error) {
 	e := echo.New()
-	e.Use(middleware.RequestLogger())
+	e.Use(echolog.RedactedRequestLogger())
 	e.Use(echo.WrapMiddleware(upstream.Handler))
 
 	s := &Server{

--- a/pkg/toolinstall/archive.go
+++ b/pkg/toolinstall/archive.go
@@ -26,6 +26,23 @@ var templateFuncs = template.FuncMap{
 	"trimV": func(s string) string { return strings.TrimPrefix(s, "v") },
 }
 
+// Conservative bounds preventing zip-bomb / tar-bomb attacks from
+// adversaries that control a GitHub release referenced by a tool
+// resolver. The limits are deliberately generous for legitimate CLI
+// releases, which typically weigh single-digit MB compressed. They
+// are vars rather than consts so tests can lower them.
+var (
+	maxArchiveCompressed   int64 = 1 << 30   // 1 GiB
+	maxArchiveUncompressed int64 = 2 << 30   // 2 GiB
+	maxFileUncompressed    int64 = 500 << 20 // 500 MiB
+	maxArchiveEntries            = 100_000
+)
+
+// errExtractTooLarge is returned when an archive (or a single entry
+// within it) exceeds the configured extraction size or entry-count
+// limit. It is the sentinel for zip-bomb / tar-bomb defenses.
+var errExtractTooLarge = errors.New("archive exceeds extraction size limit")
+
 // renderTemplate renders a Go template string with the given data.
 func renderTemplate(tmplStr string, data templateData) (string, error) {
 	tmpl, err := template.New("asset").Funcs(templateFuncs).Parse(tmplStr)
@@ -57,14 +74,18 @@ func extractRelease(body io.ReadCloser, destDir, format string, files []PackageF
 }
 
 // writeRawBinary writes a raw (non-archived) binary stream directly to destPath
-// with executable permissions.
+// with executable permissions. The body is bounded by maxFileUncompressed
+// to avoid an attacker-controlled release asset from filling the disk.
 func writeRawBinary(r io.Reader, destPath string) error {
 	f, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
 	if err != nil {
 		return fmt.Errorf("creating raw binary %s: %w", destPath, err)
 	}
 
-	_, copyErr := io.Copy(f, r) //nolint:gosec // binary size bounded by GitHub release asset limits
+	n, copyErr := io.Copy(f, io.LimitReader(r, maxFileUncompressed+1))
+	if copyErr == nil && n > maxFileUncompressed {
+		copyErr = errExtractTooLarge
+	}
 	closeErr := f.Close()
 
 	if copyErr != nil {
@@ -94,6 +115,8 @@ func extractTarGz(r io.Reader, destDir string, files []PackageFile, tmplData tem
 		return err
 	}
 
+	var totalBytes int64
+	var entries int
 	for {
 		header, err := tarReader.Next()
 		if errors.Is(err, io.EOF) {
@@ -103,6 +126,11 @@ func extractTarGz(r io.Reader, destDir string, files []PackageFile, tmplData tem
 			return fmt.Errorf("extracting tar.gz: %w", err)
 		}
 
+		entries++
+		if entries > maxArchiveEntries {
+			return errExtractTooLarge
+		}
+
 		if header.Typeflag != tar.TypeReg {
 			continue
 		}
@@ -110,6 +138,14 @@ func extractTarGz(r io.Reader, destDir string, files []PackageFile, tmplData tem
 		destName, ok := matchFile(header.Name, fileMap)
 		if !ok {
 			continue
+		}
+
+		// header.Size is attacker-controlled, but a header that
+		// already advertises a too-large size lets us fail without
+		// spending CPU on decompression. The LimitReader below
+		// guards against headers that lie.
+		if header.Size > maxFileUncompressed {
+			return errExtractTooLarge
 		}
 
 		destPath, err := safePath(destDir, destName)
@@ -125,10 +161,17 @@ func extractTarGz(r io.Reader, destDir string, files []PackageFile, tmplData tem
 			return err
 		}
 
-		_, copyErr := io.Copy(f, tarReader) //nolint:gosec // archive size bounded by GitHub release asset limits
+		n, copyErr := io.Copy(f, io.LimitReader(tarReader, maxFileUncompressed+1))
 		f.Close()
 		if copyErr != nil {
 			return copyErr
+		}
+		if n > maxFileUncompressed {
+			return errExtractTooLarge
+		}
+		totalBytes += n
+		if totalBytes > maxArchiveUncompressed {
+			return errExtractTooLarge
 		}
 	}
 
@@ -144,11 +187,16 @@ func extractZip(ra io.ReaderAt, size int64, destDir string, files []PackageFile,
 		return fmt.Errorf("extracting zip: %w", err)
 	}
 
+	if len(reader.File) > maxArchiveEntries {
+		return errExtractTooLarge
+	}
+
 	fileMap, err := buildFileMap(files, tmplData)
 	if err != nil {
 		return err
 	}
 
+	var totalBytes int64
 	for _, f := range reader.File {
 		if f.FileInfo().IsDir() {
 			continue
@@ -159,38 +207,56 @@ func extractZip(ra io.ReaderAt, size int64, destDir string, files []PackageFile,
 			continue
 		}
 
+		// UncompressedSize64 comes from the central directory and
+		// is attacker-controlled, but lets us reject obvious bombs
+		// without spending CPU on decompression first.
+		if f.UncompressedSize64 > uint64(maxFileUncompressed) {
+			return errExtractTooLarge
+		}
+
 		destPath, err := safePath(destDir, destName)
 		if err != nil {
 			return err
 		}
 
-		if err := extractZipFile(f, destPath); err != nil {
+		n, err := extractZipFile(f, destPath)
+		if err != nil {
 			return err
+		}
+		totalBytes += n
+		if totalBytes > maxArchiveUncompressed {
+			return errExtractTooLarge
 		}
 	}
 
 	return nil
 }
 
-func extractZipFile(f *zip.File, destPath string) error {
+func extractZipFile(f *zip.File, destPath string) (int64, error) {
 	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
-		return err
+		return 0, err
 	}
 
 	rc, err := f.Open()
 	if err != nil {
-		return err
+		return 0, err
 	}
 	defer rc.Close()
 
 	outFile, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	defer outFile.Close()
 
-	_, err = io.Copy(outFile, rc) //nolint:gosec // archive size bounded by GitHub release asset limits
-	return err
+	n, err := io.Copy(outFile, io.LimitReader(rc, maxFileUncompressed+1))
+	if err != nil {
+		return n, err
+	}
+	if n > maxFileUncompressed {
+		return n, errExtractTooLarge
+	}
+	return n, nil
 }
 
 // extractZipFromStream spools an io.Reader to a temporary file and then
@@ -204,9 +270,12 @@ func extractZipFromStream(r io.Reader, destDir string, files []PackageFile, tmpl
 	defer os.Remove(tmpFile.Name())
 	defer tmpFile.Close()
 
-	size, err := io.Copy(tmpFile, r) //nolint:gosec // archive size bounded by GitHub release asset limits
+	size, err := io.Copy(tmpFile, io.LimitReader(r, maxArchiveCompressed+1))
 	if err != nil {
 		return fmt.Errorf("spooling zip to temp file: %w", err)
+	}
+	if size > maxArchiveCompressed {
+		return errExtractTooLarge
 	}
 
 	if _, err := tmpFile.Seek(0, io.SeekStart); err != nil {

--- a/pkg/toolinstall/archive_test.go
+++ b/pkg/toolinstall/archive_test.go
@@ -266,3 +266,64 @@ func TestExtractZip_PathTraversal(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errPathTraversal)
 }
+
+// withFileLimit lowers the per-file extraction cap for the duration of
+// a test, restoring it on cleanup.
+func withFileLimit(t *testing.T, n int64) {
+	t.Helper()
+	prev := maxFileUncompressed
+	maxFileUncompressed = n
+	t.Cleanup(func() { maxFileUncompressed = prev })
+}
+
+func TestExtractTarGz_TooLarge(t *testing.T) {
+	withFileLimit(t, 32)
+
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	// Header advertises a small size but the body is larger; the
+	// LimitReader-based check must catch the overflow regardless.
+	content := bytes.Repeat([]byte("A"), 1024)
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name: "tool/bin/mytool",
+		Mode: 0o755,
+		Size: int64(len(content)),
+	}))
+	_, err := tw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+
+	files := []PackageFile{{Name: "mytool", Src: "tool/bin/mytool"}}
+	err = extractTarGz(&buf, t.TempDir(), files, templateData{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errExtractTooLarge)
+}
+
+func TestExtractZip_TooLarge(t *testing.T) {
+	withFileLimit(t, 32)
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	fw, err := zw.Create("tool/bin/mytool")
+	require.NoError(t, err)
+	_, err = fw.Write(bytes.Repeat([]byte("A"), 1024))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+
+	files := []PackageFile{{Name: "mytool", Src: "tool/bin/mytool"}}
+	err = extractZip(bytes.NewReader(buf.Bytes()), int64(buf.Len()), t.TempDir(), files, templateData{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errExtractTooLarge)
+}
+
+func TestWriteRawBinary_TooLarge(t *testing.T) {
+	withFileLimit(t, 32)
+
+	dest := filepath.Join(t.TempDir(), "big")
+	err := writeRawBinary(strings.NewReader(strings.Repeat("A", 1024)), dest)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errExtractTooLarge)
+}

--- a/pkg/tools/builtin/shell/script_shell.go
+++ b/pkg/tools/builtin/shell/script_shell.go
@@ -150,12 +150,27 @@ func (t *ScriptShellTool) execute(ctx context.Context, toolConfig *latest.Script
 	if base == nil {
 		base = os.Environ()
 	}
-	envCopy := make([]string, len(base), len(base)+len(params))
+	envCopy := make([]string, len(base), len(base)+len(toolConfig.Args))
 	copy(envCopy, base)
 	for key, value := range params {
-		if value != nil {
-			envCopy = append(envCopy, fmt.Sprintf("%s=%v", key, value))
+		if value == nil {
+			continue
 		}
+		// Only forward arguments declared in the tool's schema. The
+		// LLM may hallucinate extra keys (e.g. LD_PRELOAD, PATH);
+		// without this filter they would land verbatim in the
+		// spawned process's environment.
+		if _, declared := toolConfig.Args[key]; !declared {
+			continue
+		}
+		valueStr := fmt.Sprintf("%v", value)
+		// A NUL byte mid-string silently truncates env entries at the
+		// execve boundary; refuse rather than spawn a process with a
+		// surprising env.
+		if strings.ContainsRune(valueStr, 0) {
+			return tools.ResultError(fmt.Sprintf("argument %q contains a NUL byte", key)), nil
+		}
+		envCopy = append(envCopy, key+"="+valueStr)
 	}
 	cmd.Env = envCopy
 

--- a/pkg/tools/builtin/shell/script_shell_test.go
+++ b/pkg/tools/builtin/shell/script_shell_test.go
@@ -155,6 +155,74 @@ func TestNewScriptShellTool_NumberArg(t *testing.T) {
 	assert.Equal(t, "hello\nhello\nhello\n", result.Output)
 }
 
+func TestScriptShellTool_DropsUndeclaredArgs(t *testing.T) {
+	// `env` lists the spawned process's full environment. With base env
+	// set to an empty slice, the only entries should be those forwarded
+	// from declared args.
+	shellTools := map[string]latest.ScriptShellToolConfig{
+		"echo_name": {
+			Cmd: "env",
+			Args: map[string]any{
+				"name": map[string]any{
+					"description": "who to greet",
+					"type":        "string",
+				},
+			},
+			Required: []string{"name"},
+		},
+	}
+
+	tool, err := NewScriptShellTool(shellTools, []string{})
+	require.NoError(t, err)
+
+	allTools, err := tool.Tools(t.Context())
+	require.NoError(t, err)
+	require.Len(t, allTools, 1)
+
+	// The LLM hallucinates LD_PRELOAD alongside the declared `name`.
+	// Only `name` should reach execve; LD_PRELOAD must be dropped.
+	result, err := allTools[0].Handler(t.Context(), tools.ToolCall{
+		Function: tools.FunctionCall{
+			Arguments: `{"name": "alice", "LD_PRELOAD": "/tmp/evil.so"}`,
+		},
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError, "unexpected error: %s", result.Output)
+	assert.Contains(t, result.Output, "name=alice")
+	assert.NotContains(t, result.Output, "LD_PRELOAD")
+}
+
+func TestScriptShellTool_RejectsNULInValue(t *testing.T) {
+	shellTools := map[string]latest.ScriptShellToolConfig{
+		"echo_name": {
+			Cmd: "echo $name",
+			Args: map[string]any{
+				"name": map[string]any{
+					"description": "who to greet",
+					"type":        "string",
+				},
+			},
+			Required: []string{"name"},
+		},
+	}
+
+	tool, err := NewScriptShellTool(shellTools, []string{})
+	require.NoError(t, err)
+
+	allTools, err := tool.Tools(t.Context())
+	require.NoError(t, err)
+	require.Len(t, allTools, 1)
+
+	result, err := allTools[0].Handler(t.Context(), tools.ToolCall{
+		Function: tools.FunctionCall{
+			Arguments: "{\"name\": \"alice\\u0000extra\"}",
+		},
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Output, "NUL byte")
+}
+
 func TestNewScriptShellTool_ArgWithoutType(t *testing.T) {
 	shellTools := map[string]latest.ScriptShellToolConfig{
 		"greet": {

--- a/pkg/tools/mcp/main_test.go
+++ b/pkg/tools/mcp/main_test.go
@@ -1,0 +1,17 @@
+package mcp
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/docker/docker-agent/pkg/httpclient"
+)
+
+// TestMain swaps the OAuth helpers' SSRF-safe HTTP client for the
+// loopback-allowing variant so tests can hit httptest.NewServer (which
+// binds to 127.0.0.1). Production code keeps the safe client.
+func TestMain(m *testing.M) {
+	oauthHTTPClient = httpclient.NewSafeClient(30*time.Second, true)
+	os.Exit(m.Run())
+}

--- a/pkg/tools/mcp/oauth_helpers.go
+++ b/pkg/tools/mcp/oauth_helpers.go
@@ -17,7 +17,21 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/docker/docker-agent/pkg/browser"
+	"github.com/docker/docker-agent/pkg/httpclient"
 )
+
+// oauthHTTPClient is the *http.Client used for outbound OAuth requests
+// (token exchange, refresh, dynamic client registration). The endpoint
+// URLs come from MCP server metadata, i.e. effectively the remote
+// server's choice — so a hostile MCP server could otherwise redirect us
+// at, or hold a connection open to, an internal address. The dialer
+// rejects non-public IPs (defeating SSRF and DNS rebinding to loopback /
+// link-local / RFC1918 / cloud metadata), and the wall-clock timeout
+// puts an upper bound on a slow-loris token endpoint.
+//
+// Tests in this package replace the var via TestMain (see main_test.go)
+// because httptest.NewServer binds to 127.0.0.1.
+var oauthHTTPClient = httpclient.NewSafeClient(30*time.Second, false)
 
 // GenerateState generates a random state parameter for OAuth CSRF protection
 func GenerateState() (string, error) {
@@ -63,7 +77,7 @@ func ExchangeCodeForToken(ctx context.Context, tokenEndpoint, code, codeVerifier
 
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := oauthHTTPClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to exchange code for token: %w", err)
 	}
@@ -233,7 +247,7 @@ func RegisterClient(ctx context.Context, authMetadata *AuthorizationServerMetada
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := oauthHTTPClient.Do(req)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to register client: %w", err)
 	}
@@ -281,7 +295,7 @@ func RefreshAccessToken(ctx context.Context, tokenEndpoint, refreshToken, client
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := oauthHTTPClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to refresh token: %w", err)
 	}


### PR DESCRIPTION
Five small, focused, security-hardening commits surfaced while reading
the codebase like a security researcher. None of them changes a public
API, removes a feature, or alters a default the user explicitly
requested — they're defense-in-depth fixes that close concrete attack
paths.

Each commit passes `task lint` and `task test` independently.

| # | Commit | Summary |
|---|---|---|
| 1 | `fix(environment): make RunSecretsProvider symlink/TOCTOU-safe` | `/run/secrets/<name>` lookups now go through `os.OpenRoot` + `Root.ReadFile` so symbolic links escaping the secrets root are rejected by the kernel instead of silently followed. Adds a planted-symlink regression test. |
| 2 | `fix(toolinstall): bound archive extraction to defeat zip/tar bombs` | Per-entry, per-archive, and per-binary uncompressed caps via `io.LimitReader`; entry-count cap; bounded compressed-spool. Drops the `//nolint:gosec` band-aids that papered over unbounded `io.Copy`s. |
| 3 | `fix(mcp/oauth): harden the HTTP client used for token endpoints` | OAuth token-exchange / refresh / dynamic-registration calls go through `httpclient.NewSafeClient` (SSRF-safe transport, 30 s timeout, bounded redirects) instead of `http.DefaultClient`. A package-local `TestMain` swaps in the loopback-allowing variant so `httptest.NewServer`-driven tests keep working. |
| 4 | `fix(shell): drop undeclared script_shell args and reject NUL bytes` | `ScriptShellTool.execute` now only forwards JSON keys declared in the tool's `args` schema, so an LLM that hallucinates `LD_PRELOAD` / `PATH` cannot inject arbitrary env entries into the spawned process. Values containing NUL are rejected (would otherwise truncate at `execve`). |
| 5 | `fix(server,chatserver): redact query strings in request logs` | New `pkg/echolog.RedactedRequestLogger` is wired into both servers in place of `middleware.RequestLogger()`. Logs `req.URL.Path`, never the full URI, so `?token=...` query parameters cannot leak into structured logs. Includes a regression test. |

These are derived from a longer security review of the codebase. The
remaining items (auth on `/api/*`, slowloris timeouts on the REST API
server, Unix-socket permissions, OAuth state width, CORS regex
anchoring) are intentionally left for follow-up so each PR stays
reviewable.
