### PR TITLE
feat: let external processes drive a running TUI

### DIFF
--- a/cmd/root/mcp.go
+++ b/cmd/root/mcp.go
@@ -1,6 +1,9 @@
 package root
 
 import (
+	"context"
+	"errors"
+
 	"github.com/spf13/cobra"
 
 	"github.com/docker/docker-agent/pkg/config"
@@ -12,6 +15,7 @@ type mcpFlags struct {
 	agentName  string
 	http       bool
 	listenAddr string
+	attach     string
 	runConfig  config.RuntimeConfig
 }
 
@@ -21,18 +25,21 @@ func newMCPCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "mcp <agent-file>|<registry-ref>",
 		Short: "Start an agent as an MCP (Model Context Protocol) server",
-		Long:  "Start an MCP server that exposes the agent via the Model Context Protocol. By default, uses stdio transport. Use --http to start a streaming HTTP server instead.",
+		Long:  "Start an MCP server that exposes the agent via the Model Context Protocol. By default, uses stdio transport. Use --http to start a streaming HTTP server instead. Use --attach to expose a running TUI's session instead of an agent file.",
 		Example: `  docker-agent serve mcp ./agent.yaml
   docker-agent serve mcp ./team.yaml
   docker-agent serve mcp agentcatalog/pirate
-  docker-agent serve mcp ./agent.yaml --http --listen 127.0.0.1:9090`,
-		Args: cobra.ExactArgs(1),
+  docker-agent serve mcp ./agent.yaml --http --listen 127.0.0.1:9090
+  docker-agent serve mcp --attach`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: flags.runMCPCommand,
 	}
 
 	cmd.PersistentFlags().StringVarP(&flags.agentName, "agent", "a", "", "Name of the agent to run (all agents if not specified)")
 	cmd.PersistentFlags().BoolVar(&flags.http, "http", false, "Use streaming HTTP transport instead of stdio")
 	cmd.PersistentFlags().StringVarP(&flags.listenAddr, "listen", "l", "127.0.0.1:8081", "Address to listen on")
+	cmd.PersistentFlags().StringVar(&flags.attach, "attach", "", "Attach to a running TUI run by pid (or empty for the most recent)")
+	cmd.PersistentFlags().Lookup("attach").NoOptDefVal = "latest"
 	cmd.PersistentFlags().StringVar(&flags.runConfig.MCPToolName, "tool-name", "", "Override the MCP tool identifier clients call (defaults to agent name); only valid when exposing a single agent")
 	cmd.PersistentFlags().DurationVar(&flags.runConfig.MCPKeepAlive, "mcp-keepalive", 0, "Interval between MCP keep-alive pings (e.g. 30s); 0 disables keep-alive")
 	addRuntimeConfigFlags(cmd, &flags.runConfig)
@@ -47,6 +54,13 @@ func (f *mcpFlags) runMCPCommand(cmd *cobra.Command, args []string) (commandErr 
 		telemetry.TrackCommandError(ctx, "serve", append([]string{"mcp"}, args...), commandErr)
 	}()
 
+	if f.attach != "" {
+		return f.runAttach(ctx)
+	}
+
+	if len(args) == 0 {
+		return errors.New("agent file is required (or use --attach)")
+	}
 	agentFilename := args[0]
 
 	if !f.http {
@@ -60,4 +74,16 @@ func (f *mcpFlags) runMCPCommand(cmd *cobra.Command, args []string) (commandErr 
 	defer cleanup()
 
 	return mcp.StartHTTPServer(ctx, agentFilename, f.agentName, &f.runConfig, ln)
+}
+
+func (f *mcpFlags) runAttach(ctx context.Context) error {
+	target := f.attach
+	if target == "latest" {
+		target = ""
+	}
+	rec, err := resolveTarget(target)
+	if err != nil {
+		return err
+	}
+	return mcp.StartAttachStdio(ctx, rec.Addr, rec.SessionID)
 }

--- a/cmd/root/proto.go
+++ b/cmd/root/proto.go
@@ -1,0 +1,190 @@
+package root
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+
+	"github.com/spf13/cobra"
+
+	"github.com/docker/docker-agent/pkg/api"
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/telemetry"
+)
+
+type protoFlags struct {
+	target string
+}
+
+func newProtoCmd() *cobra.Command {
+	var flags protoFlags
+
+	cmd := &cobra.Command{
+		Use:   "proto",
+		Short: "Drive a running docker-agent TUI over stdio JSON-RPC",
+		Long: `Read newline-delimited JSON requests from stdin and write events and
+responses to stdout. Designed for editor integrations and orchestrators
+that want a single-process channel to a live run started with --listen.
+
+Each input line is a JSON object with at least:
+  {"id": "1", "type": "send", "message": "hello"}
+
+Supported types: send, followup, resume, transcript, interrupt.
+Output objects always carry a "type" field.`,
+		GroupID: "advanced",
+		Args:    cobra.NoArgs,
+		RunE:    flags.run,
+	}
+
+	cmd.Flags().StringVar(&flags.target, "to", "", "Target run pid (defaults to the most recent live run)")
+	return cmd
+}
+
+func (f *protoFlags) run(cmd *cobra.Command, args []string) (commandErr error) {
+	ctx, cancel := context.WithCancel(cmd.Context())
+	defer cancel()
+	telemetry.TrackCommand(ctx, "proto", args)
+	defer func() { telemetry.TrackCommandError(ctx, "proto", args, commandErr) }()
+
+	rec, err := resolveTarget(f.target)
+	if err != nil {
+		return err
+	}
+	client, err := runtime.NewClient(rec.Addr)
+	if err != nil {
+		return err
+	}
+
+	w := newProtoWriter(cmd.OutOrStdout())
+	w.send(map[string]any{
+		"type":       "ready",
+		"addr":       rec.Addr,
+		"session_id": rec.SessionID,
+	})
+
+	go streamEvents(ctx, rec.Addr, rec.SessionID, w)
+	return readCommands(ctx, cmd.InOrStdin(), client, rec.SessionID, w)
+}
+
+type protoWriter struct {
+	mu  sync.Mutex
+	out io.Writer
+}
+
+func newProtoWriter(out io.Writer) *protoWriter { return &protoWriter{out: out} }
+
+func (w *protoWriter) send(obj any) {
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	_, _ = w.out.Write(append(data, '\n'))
+}
+
+type protoRequest struct {
+	ID       string `json:"id,omitempty"`
+	Type     string `json:"type"`
+	Message  string `json:"message,omitempty"`
+	Reason   string `json:"reason,omitempty"`
+	ToolName string `json:"tool_name,omitempty"`
+	Decision string `json:"decision,omitempty"` // "approve" | "reject"
+	Limit    int    `json:"limit,omitempty"`
+}
+
+func readCommands(ctx context.Context, in io.Reader, client *runtime.Client, sessionID string, w *protoWriter) error {
+	scanner := bufio.NewScanner(in)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		if ctx.Err() != nil {
+			return nil
+		}
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+
+		var req protoRequest
+		if err := json.Unmarshal(line, &req); err != nil {
+			w.send(map[string]any{"type": "error", "message": "invalid json: " + err.Error()})
+			continue
+		}
+
+		if err := dispatchProto(ctx, client, sessionID, req, w); err != nil {
+			w.send(map[string]any{"id": req.ID, "type": "error", "message": err.Error()})
+			continue
+		}
+		w.send(map[string]any{"id": req.ID, "type": "ack"})
+	}
+	return scanner.Err()
+}
+
+func dispatchProto(ctx context.Context, client *runtime.Client, sessionID string, req protoRequest, w *protoWriter) error {
+	switch req.Type {
+	case "send":
+		return client.SteerSession(ctx, sessionID, []api.Message{{Content: req.Message}})
+	case "followup":
+		return client.FollowUpSession(ctx, sessionID, []api.Message{{Content: req.Message}})
+	case "resume":
+		decision := req.Decision
+		if decision == "" {
+			decision = "approve"
+		}
+		return client.ResumeSession(ctx, sessionID, decision, req.Reason, req.ToolName)
+	case "interrupt":
+		return client.ResumeSession(ctx, sessionID, "reject", req.Reason, req.ToolName)
+	case "transcript":
+		sess, err := client.GetSession(ctx, sessionID)
+		if err != nil {
+			return err
+		}
+		messages := sess.Messages
+		if req.Limit > 0 && len(messages) > req.Limit {
+			messages = messages[len(messages)-req.Limit:]
+		}
+		w.send(map[string]any{"id": req.ID, "type": "transcript", "title": sess.Title, "messages": messages})
+		return nil
+	default:
+		return fmt.Errorf("unknown request type %q", req.Type)
+	}
+}
+
+func streamEvents(ctx context.Context, addr, sessionID string, w *protoWriter) {
+	url := addr + "/api/sessions/" + sessionID + "/events"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil || resp.StatusCode >= 400 {
+		if resp != nil {
+			resp.Body.Close()
+		}
+		return
+	}
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		if ctx.Err() != nil {
+			return
+		}
+		line := scanner.Bytes()
+		after, ok := bytes.CutPrefix(line, []byte("data: "))
+		if !ok {
+			continue
+		}
+		var event any
+		if err := json.Unmarshal(after, &event); err != nil {
+			continue
+		}
+		w.send(map[string]any{"type": "event", "event": event})
+	}
+}

--- a/cmd/root/proto_test.go
+++ b/cmd/root/proto_test.go
@@ -1,0 +1,87 @@
+package root
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/runtime"
+)
+
+// recorder mimics enough of the docker-agent control plane to verify the
+// proto dispatcher routes requests to the right HTTP endpoints.
+type recorder struct {
+	mu    sync.Mutex
+	calls []string
+}
+
+func (r *recorder) record(path string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, path)
+}
+
+func TestProtoDispatch_RoutesRequestsToHTTPClient(t *testing.T) {
+	rec := &recorder{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.record(r.Method + " " + r.URL.Path)
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/steer"),
+			strings.HasSuffix(r.URL.Path, "/followup"),
+			strings.HasSuffix(r.URL.Path, "/resume"):
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+		default:
+			_, _ = w.Write([]byte(`{"id":"s1","title":"T","messages":[]}`))
+		}
+	}))
+	defer srv.Close()
+
+	client, err := runtime.NewClient(srv.URL)
+	require.NoError(t, err)
+
+	out := &bytes.Buffer{}
+	w := newProtoWriter(out)
+	ctx := t.Context()
+
+	cases := []struct {
+		req  protoRequest
+		want string
+	}{
+		{protoRequest{Type: "send", Message: "hi"}, "POST /api/sessions/s1/steer"},
+		{protoRequest{Type: "followup", Message: "later"}, "POST /api/sessions/s1/followup"},
+		{protoRequest{Type: "resume", Decision: "approve"}, "POST /api/sessions/s1/resume"},
+		{protoRequest{Type: "interrupt"}, "POST /api/sessions/s1/resume"},
+		{protoRequest{Type: "transcript"}, "GET /api/sessions/s1"},
+	}
+	for _, c := range cases {
+		require.NoError(t, dispatchProto(ctx, client, "s1", c.req, w))
+	}
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	for _, want := range []string{
+		"POST /api/sessions/s1/steer",
+		"POST /api/sessions/s1/followup",
+		"POST /api/sessions/s1/resume",
+		"POST /api/sessions/s1/resume",
+		"GET /api/sessions/s1",
+	} {
+		assert.Contains(t, rec.calls, want)
+	}
+}
+
+func TestProtoDispatch_UnknownType(t *testing.T) {
+	out := &bytes.Buffer{}
+	w := newProtoWriter(out)
+
+	err := dispatchProto(t.Context(), nil, "s1", protoRequest{Type: "nope"}, w)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown request type")
+}

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -156,6 +156,7 @@ We collect anonymous usage data to help improve docker agent. To disable:
 		newRunCmd(),
 		newSendCmd(),
 		newWatchCmd(),
+		newProtoCmd(),
 		newNewCmd(),
 		newEvalCmd(),
 		newShareCmd(),

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -154,6 +154,7 @@ We collect anonymous usage data to help improve docker agent. To disable:
 	cmd.AddCommand(
 		newVersionCmd(),
 		newRunCmd(),
+		newSendCmd(),
 		newNewCmd(),
 		newEvalCmd(),
 		newShareCmd(),

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -155,6 +155,7 @@ We collect anonymous usage data to help improve docker agent. To disable:
 		newVersionCmd(),
 		newRunCmd(),
 		newSendCmd(),
+		newWatchCmd(),
 		newNewCmd(),
 		newEvalCmd(),
 		newShareCmd(),

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -62,6 +62,7 @@ type runExecFlags struct {
 	hideToolResults bool
 	lean            bool
 	listenAddr      string
+	onEventSpecs    []string
 
 	// globalPermissions holds the user-level global permission checker built
 	// from user config settings. Nil when no global permissions are configured.
@@ -116,6 +117,7 @@ func addRunOrExecFlags(cmd *cobra.Command, flags *runExecFlags) {
 	_ = cmd.PersistentFlags().MarkHidden("exit-after-response")
 	cmd.PersistentFlags().StringVar(&flags.listenAddr, "listen", "", "Expose this run's control plane on the given address (e.g. 127.0.0.1:0)")
 	_ = cmd.PersistentFlags().MarkHidden("listen")
+	cmd.PersistentFlags().StringArrayVar(&flags.onEventSpecs, "on-event", nil, "Run shell command on event: --on-event <type>=<cmd> (or *=<cmd> for any). Repeatable.")
 	cmd.PersistentFlags().StringVar(&flags.cpuProfile, "cpuprofile", "", "Write CPU profile to file")
 	_ = cmd.PersistentFlags().MarkHidden("cpuprofile")
 	cmd.PersistentFlags().StringVar(&flags.memProfile, "memprofile", "", "Write memory profile to file")
@@ -297,6 +299,14 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 	}
 	if listenOpt != nil {
 		opts = append(opts, listenOpt)
+	}
+
+	eventHooks, err := parseOnEventFlags(f.onEventSpecs)
+	if err != nil {
+		return err
+	}
+	if hookOpt := withEventHooks(eventHooks); hookOpt != nil {
+		opts = append(opts, hookOpt)
 	}
 
 	sessStore := rt.SessionStore()

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -61,6 +61,7 @@ type runExecFlags struct {
 	// Run only
 	hideToolResults bool
 	lean            bool
+	listenAddr      string
 
 	// globalPermissions holds the user-level global permission checker built
 	// from user config settings. Nil when no global permissions are configured.
@@ -113,6 +114,8 @@ func addRunOrExecFlags(cmd *cobra.Command, flags *runExecFlags) {
 	cmd.PersistentFlags().Lookup("record").NoOptDefVal = "true"
 	cmd.PersistentFlags().BoolVar(&flags.exitAfterResponse, "exit-after-response", false, "Exit TUI after first assistant response completes")
 	_ = cmd.PersistentFlags().MarkHidden("exit-after-response")
+	cmd.PersistentFlags().StringVar(&flags.listenAddr, "listen", "", "Expose this run's control plane on the given address (e.g. 127.0.0.1:0)")
+	_ = cmd.PersistentFlags().MarkHidden("listen")
 	cmd.PersistentFlags().StringVar(&flags.cpuProfile, "cpuprofile", "", "Write CPU profile to file")
 	_ = cmd.PersistentFlags().MarkHidden("cpuprofile")
 	cmd.PersistentFlags().StringVar(&flags.memProfile, "memprofile", "", "Write memory profile to file")
@@ -280,6 +283,10 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 
 	if !useTUI {
 		return f.handleExecMode(ctx, out, rt, sess, args)
+	}
+
+	if err := f.startAttachedServer(ctx, out, rt, sess); err != nil {
+		return err
 	}
 
 	applyTheme()

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -285,7 +285,8 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 		return f.handleExecMode(ctx, out, rt, sess, args)
 	}
 
-	if err := f.startAttachedServer(ctx, out, rt, sess); err != nil {
+	listenOpt, err := f.startAttachedServer(ctx, out, rt, sess)
+	if err != nil {
 		return err
 	}
 
@@ -293,6 +294,9 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 	opts, err := f.buildAppOpts(args)
 	if err != nil {
 		return err
+	}
+	if listenOpt != nil {
+		opts = append(opts, listenOpt)
 	}
 
 	sessStore := rt.SessionStore()

--- a/cmd/root/run_event_hooks.go
+++ b/cmd/root/run_event_hooks.go
@@ -1,0 +1,75 @@
+package root
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/docker/docker-agent/pkg/app"
+	"github.com/docker/docker-agent/pkg/runtime"
+)
+
+type onEventHook struct {
+	eventType string
+	command   string
+}
+
+func parseOnEventFlags(specs []string) ([]onEventHook, error) {
+	hooks := make([]onEventHook, 0, len(specs))
+	for _, s := range specs {
+		i := strings.Index(s, "=")
+		if i < 1 {
+			return nil, fmt.Errorf("--on-event expects <event-type>=<command>, got %q", s)
+		}
+		hooks = append(hooks, onEventHook{eventType: s[:i], command: s[i+1:]})
+	}
+	return hooks, nil
+}
+
+// withEventHooks returns an app.Opt that runs each configured shell command
+// for matching events on the App fan-out. The event JSON is piped to the
+// command's stdin. Commands run asynchronously and their failures are logged
+// but never block the event bus.
+func withEventHooks(hooks []onEventHook) app.Opt {
+	if len(hooks) == 0 {
+		return nil
+	}
+	return func(a *app.App) {
+		go a.SubscribeWith(context.Background(), func(msg tea.Msg) {
+			ev, ok := msg.(runtime.Event)
+			if !ok {
+				return
+			}
+			data, err := json.Marshal(ev)
+			if err != nil {
+				return
+			}
+			var head struct {
+				Type string `json:"type"`
+			}
+			if err := json.Unmarshal(data, &head); err != nil {
+				return
+			}
+			for _, h := range hooks {
+				if h.eventType != "*" && h.eventType != head.Type {
+					continue
+				}
+				go runEventHook(h.command, data)
+			}
+		})
+	}
+}
+
+func runEventHook(command string, payload []byte) {
+	cmd := exec.CommandContext(context.Background(), "sh", "-c", command)
+	cmd.Stdin = bytes.NewReader(payload)
+	if err := cmd.Run(); err != nil {
+		slog.Warn("on-event hook failed", "command", command, "error", err)
+	}
+}

--- a/cmd/root/run_event_hooks_test.go
+++ b/cmd/root/run_event_hooks_test.go
@@ -1,0 +1,29 @@
+package root
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseOnEventFlags(t *testing.T) {
+	hooks, err := parseOnEventFlags([]string{
+		"stream_stopped=say done",
+		"*=tee /tmp/events.log",
+	})
+	require.NoError(t, err)
+	require.Len(t, hooks, 2)
+	assert.Equal(t, "stream_stopped", hooks[0].eventType)
+	assert.Equal(t, "say done", hooks[0].command)
+	assert.Equal(t, "*", hooks[1].eventType)
+	assert.Equal(t, "tee /tmp/events.log", hooks[1].command)
+}
+
+func TestParseOnEventFlags_BadFormat(t *testing.T) {
+	cases := []string{"no-equals", "=missing-type"}
+	for _, s := range cases {
+		_, err := parseOnEventFlags([]string{s})
+		assert.Error(t, err, "expected error for %q", s)
+	}
+}

--- a/cmd/root/run_listen.go
+++ b/cmd/root/run_listen.go
@@ -1,0 +1,42 @@
+package root
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/docker/docker-agent/pkg/cli"
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/server"
+	"github.com/docker/docker-agent/pkg/session"
+)
+
+// startAttachedServer exposes the in-process runtime over HTTP so external
+// processes can drive the running TUI (steer, followup, resume, ...). The
+// listener is closed when ctx is cancelled. No-op when --listen is empty.
+func (f *runExecFlags) startAttachedServer(ctx context.Context, out *cli.Printer, rt runtime.Runtime, sess *session.Session) error {
+	if f.listenAddr == "" {
+		return nil
+	}
+
+	sm := server.NewSessionManager(ctx, nil, rt.SessionStore(), 0, &f.runConfig)
+	sm.AttachRuntime(sess.ID, rt, sess)
+
+	ln, err := server.Listen(ctx, f.listenAddr)
+	if err != nil {
+		return fmt.Errorf("listen %s: %w", f.listenAddr, err)
+	}
+	context.AfterFunc(ctx, func() { _ = ln.Close() })
+
+	out.Println("Control plane listening on", ln.Addr().String())
+	warnIfNotLoopback(out, ln.Addr())
+
+	srv := server.NewWithManager(sm)
+	go func() {
+		if err := srv.Serve(ctx, ln); err != nil {
+			slog.ErrorContext(ctx, "Control plane server stopped", "error", err)
+		}
+	}()
+
+	return nil
+}

--- a/cmd/root/run_listen.go
+++ b/cmd/root/run_listen.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
+	"time"
 
 	"github.com/docker/docker-agent/pkg/cli"
+	"github.com/docker/docker-agent/pkg/runregistry"
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/server"
 	"github.com/docker/docker-agent/pkg/session"
@@ -27,6 +30,19 @@ func (f *runExecFlags) startAttachedServer(ctx context.Context, out *cli.Printer
 		return fmt.Errorf("listen %s: %w", f.listenAddr, err)
 	}
 	context.AfterFunc(ctx, func() { _ = ln.Close() })
+
+	cleanup, err := runregistry.Write(runregistry.Record{
+		PID:       os.Getpid(),
+		Addr:      "http://" + ln.Addr().String(),
+		SessionID: sess.ID,
+		Agent:     f.agentName,
+		StartedAt: time.Now(),
+	})
+	if err != nil {
+		slog.WarnContext(ctx, "Could not write run registry record", "error", err)
+	} else {
+		context.AfterFunc(ctx, cleanup)
+	}
 
 	out.Println("Control plane listening on", ln.Addr().String())
 	warnIfNotLoopback(out, ln.Addr())

--- a/cmd/root/run_listen.go
+++ b/cmd/root/run_listen.go
@@ -7,6 +7,9 @@ import (
 	"os"
 	"time"
 
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/docker/docker-agent/pkg/app"
 	"github.com/docker/docker-agent/pkg/cli"
 	"github.com/docker/docker-agent/pkg/runregistry"
 	"github.com/docker/docker-agent/pkg/runtime"
@@ -15,11 +18,13 @@ import (
 )
 
 // startAttachedServer exposes the in-process runtime over HTTP so external
-// processes can drive the running TUI (steer, followup, resume, ...). The
-// listener is closed when ctx is cancelled. No-op when --listen is empty.
-func (f *runExecFlags) startAttachedServer(ctx context.Context, out *cli.Printer, rt runtime.Runtime, sess *session.Session) error {
+// processes can drive the running TUI (steer, followup, resume, ...). It
+// returns an app.Opt that, once the App is constructed, registers the App's
+// event stream as the session's event source so /events SSE works. No-op
+// when --listen is empty.
+func (f *runExecFlags) startAttachedServer(ctx context.Context, out *cli.Printer, rt runtime.Runtime, sess *session.Session) (app.Opt, error) {
 	if f.listenAddr == "" {
-		return nil
+		return nil, nil
 	}
 
 	sm := server.NewSessionManager(ctx, nil, rt.SessionStore(), 0, &f.runConfig)
@@ -27,7 +32,7 @@ func (f *runExecFlags) startAttachedServer(ctx context.Context, out *cli.Printer
 
 	ln, err := server.Listen(ctx, f.listenAddr)
 	if err != nil {
-		return fmt.Errorf("listen %s: %w", f.listenAddr, err)
+		return nil, fmt.Errorf("listen %s: %w", f.listenAddr, err)
 	}
 	context.AfterFunc(ctx, func() { _ = ln.Close() })
 
@@ -54,5 +59,13 @@ func (f *runExecFlags) startAttachedServer(ctx context.Context, out *cli.Printer
 		}
 	}()
 
-	return nil
+	return func(a *app.App) {
+		sm.RegisterEventSource(sess.ID, func(ctx context.Context, send func(any)) {
+			a.SubscribeWith(ctx, func(msg tea.Msg) {
+				if ev, ok := msg.(runtime.Event); ok {
+					send(ev)
+				}
+			})
+		})
+	}, nil
 }

--- a/cmd/root/send.go
+++ b/cmd/root/send.go
@@ -1,0 +1,123 @@
+package root
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/docker/docker-agent/pkg/api"
+	"github.com/docker/docker-agent/pkg/cli"
+	"github.com/docker/docker-agent/pkg/runregistry"
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/telemetry"
+)
+
+type sendFlags struct {
+	target   string
+	followUp bool
+}
+
+func newSendCmd() *cobra.Command {
+	var flags sendFlags
+
+	cmd := &cobra.Command{
+		Use:   "send [message]",
+		Short: "Send a message to a running docker-agent TUI",
+		Long: `Send a message to the most recent docker-agent run that exposes a control
+plane (started with run --listen). Use - to read the message from stdin.
+
+The target can be selected explicitly with --to <addr|pid>; otherwise the
+most recent live run is used.`,
+		Example: `  docker-agent send "summarize the diff"
+  echo "and now write tests" | docker-agent send -
+  docker-agent send --to 12345 "hello"`,
+		GroupID: "advanced",
+		Args:    cobra.ExactArgs(1),
+		RunE:    flags.run,
+	}
+
+	cmd.Flags().StringVar(&flags.target, "to", "", "Target run pid (defaults to the most recent live run)")
+	cmd.Flags().BoolVar(&flags.followUp, "followup", false, "Queue as an end-of-turn follow-up instead of mid-turn steering")
+	return cmd
+}
+
+func (f *sendFlags) run(cmd *cobra.Command, args []string) (commandErr error) {
+	ctx := cmd.Context()
+	telemetry.TrackCommand(ctx, "send", args)
+	defer func() { telemetry.TrackCommandError(ctx, "send", args, commandErr) }()
+
+	message, err := readMessage(cmd.InOrStdin(), args[0])
+	if err != nil {
+		return err
+	}
+
+	rec, err := resolveTarget(f.target)
+	if err != nil {
+		return err
+	}
+
+	client, err := runtime.NewClient(rec.Addr)
+	if err != nil {
+		return fmt.Errorf("creating client: %w", err)
+	}
+
+	msgs := []api.Message{{Content: message}}
+	if f.followUp {
+		err = client.FollowUpSession(ctx, rec.SessionID, msgs)
+	} else {
+		err = client.SteerSession(ctx, rec.SessionID, msgs)
+	}
+	if err != nil {
+		return err
+	}
+
+	out := cli.NewPrinter(cmd.OutOrStdout())
+	out.Println("Sent to", rec.Addr, "(session", rec.SessionID+")")
+	return nil
+}
+
+func readMessage(stdin io.Reader, arg string) (string, error) {
+	if arg != "-" {
+		return arg, nil
+	}
+	buf, err := io.ReadAll(stdin)
+	if err != nil {
+		return "", fmt.Errorf("reading stdin: %w", err)
+	}
+	return strings.TrimRight(string(buf), "\n"), nil
+}
+
+// resolveTarget returns the registry record matching --to. An empty target
+// resolves to the most recent live run; a numeric target is matched by pid.
+func resolveTarget(target string) (runregistry.Record, error) {
+	if target == "" {
+		rec, ok, err := runregistry.Latest()
+		if err != nil {
+			return runregistry.Record{}, err
+		}
+		if !ok {
+			return runregistry.Record{}, errors.New("no live docker-agent run found; start one with: docker-agent run --listen 127.0.0.1:0")
+		}
+		return rec, nil
+	}
+
+	pid, err := strconv.Atoi(target)
+	if err != nil {
+		return runregistry.Record{}, fmt.Errorf("--to must be a pid, got %q", target)
+	}
+
+	records, err := runregistry.List()
+	if err != nil {
+		return runregistry.Record{}, err
+	}
+	for _, r := range records {
+		if r.PID == pid {
+			return r, nil
+		}
+	}
+	return runregistry.Record{}, fmt.Errorf("no live run with pid %d", pid)
+}

--- a/cmd/root/send_test.go
+++ b/cmd/root/send_test.go
@@ -1,0 +1,59 @@
+package root
+
+import (
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/paths"
+	"github.com/docker/docker-agent/pkg/runregistry"
+)
+
+func TestResolveTarget_NoLiveRun(t *testing.T) {
+	paths.SetDataDir(t.TempDir())
+	t.Cleanup(func() { paths.SetDataDir("") })
+
+	_, err := resolveTarget("")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no live docker-agent run")
+}
+
+func TestResolveTarget_LatestWhenEmpty(t *testing.T) {
+	paths.SetDataDir(t.TempDir())
+	t.Cleanup(func() { paths.SetDataDir("") })
+
+	cleanup, err := runregistry.Write(runregistry.Record{
+		PID: os.Getpid(), Addr: "http://1", SessionID: "s1", StartedAt: time.Now(),
+	})
+	require.NoError(t, err)
+	defer cleanup()
+
+	rec, err := resolveTarget("")
+	require.NoError(t, err)
+	assert.Equal(t, "s1", rec.SessionID)
+}
+
+func TestResolveTarget_ByPID(t *testing.T) {
+	paths.SetDataDir(t.TempDir())
+	t.Cleanup(func() { paths.SetDataDir("") })
+
+	cleanup, err := runregistry.Write(runregistry.Record{
+		PID: os.Getpid(), Addr: "http://x", SessionID: "matched", StartedAt: time.Now(),
+	})
+	require.NoError(t, err)
+	defer cleanup()
+
+	rec, err := resolveTarget(strconv.Itoa(os.Getpid()))
+	require.NoError(t, err)
+	assert.Equal(t, "matched", rec.SessionID)
+}
+
+func TestResolveTarget_NonNumericTo(t *testing.T) {
+	_, err := resolveTarget("not-a-pid")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a pid")
+}

--- a/cmd/root/watch.go
+++ b/cmd/root/watch.go
@@ -1,0 +1,92 @@
+package root
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/spf13/cobra"
+
+	"github.com/docker/docker-agent/pkg/cli"
+	"github.com/docker/docker-agent/pkg/telemetry"
+)
+
+type watchFlags struct {
+	target string
+}
+
+func newWatchCmd() *cobra.Command {
+	var flags watchFlags
+
+	cmd := &cobra.Command{
+		Use:   "watch",
+		Short: "Stream events from a running docker-agent TUI",
+		Long: `Connect to the SSE event stream of the most recent docker-agent run that
+exposes a control plane (started with run --listen) and print each event
+as one JSON line on stdout.`,
+		Example: `  docker-agent watch
+  docker-agent watch --to 12345 | jq`,
+		GroupID: "advanced",
+		Args:    cobra.NoArgs,
+		RunE:    flags.run,
+	}
+
+	cmd.Flags().StringVar(&flags.target, "to", "", "Target run pid (defaults to the most recent live run)")
+	return cmd
+}
+
+func (f *watchFlags) run(cmd *cobra.Command, args []string) (commandErr error) {
+	ctx := cmd.Context()
+	telemetry.TrackCommand(ctx, "watch", args)
+	defer func() { telemetry.TrackCommandError(ctx, "watch", args, commandErr) }()
+
+	rec, err := resolveTarget(f.target)
+	if err != nil {
+		return err
+	}
+
+	url := rec.Addr + "/api/sessions/" + rec.SessionID + "/events"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("connecting to %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("server returned %s: %s", resp.Status, string(body))
+	}
+
+	out := cli.NewPrinter(cmd.OutOrStdout())
+	out.Println("Watching", rec.Addr, "(session", rec.SessionID+")")
+
+	return printSSE(ctx, resp.Body, cmd.OutOrStdout())
+}
+
+func printSSE(ctx context.Context, body io.Reader, out io.Writer) error {
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		if ctx.Err() != nil {
+			return nil
+		}
+		line := scanner.Bytes()
+		after, ok := bytes.CutPrefix(line, []byte("data: "))
+		if !ok {
+			continue
+		}
+		if _, err := fmt.Fprintln(out, string(after)); err != nil {
+			return err
+		}
+	}
+	return scanner.Err()
+}

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"slices"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -44,6 +45,10 @@ type App struct {
 	exitAfterFirstResponse bool                    // Exit TUI after first assistant response completes
 	titleGenerating        atomic.Bool             // True when title generation is in progress
 	titleGen               *sessiontitle.Generator // Title generator for local runtime (nil for remote)
+
+	subsMu     sync.Mutex
+	subs       []chan tea.Msg
+	fanoutOnce sync.Once
 }
 
 // Opt is an option for creating a new App.
@@ -542,22 +547,60 @@ func (a *App) RunBangCommand(ctx context.Context, command string) {
 }
 
 // SubscribeWith subscribes to app events using a custom send function.
-// This allows callers to wrap or transform messages before sending them
-// to the Bubble Tea program (e.g. to tag events with a session ID for routing).
+// Multiple concurrent subscribers are supported: a single fan-out goroutine
+// drains the throttled event stream and dispatches a copy to each one.
+// Slow subscribers drop events rather than block the bus.
 func (a *App) SubscribeWith(ctx context.Context, send func(tea.Msg)) {
-	throttledChan := a.throttleEvents(ctx, a.events)
+	ch := make(chan tea.Msg, subscriberBufferSize)
+	a.addSubscriber(ch)
+	defer a.removeSubscriber(ch)
+
+	a.fanoutOnce.Do(a.startFanOut)
+
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case msg, ok := <-throttledChan:
-			if !ok {
-				return
-			}
-
+		case msg := <-ch:
 			send(msg)
 		}
 	}
+}
+
+const subscriberBufferSize = 1024
+
+func (a *App) addSubscriber(ch chan tea.Msg) {
+	a.subsMu.Lock()
+	defer a.subsMu.Unlock()
+	a.subs = append(a.subs, ch)
+}
+
+func (a *App) removeSubscriber(ch chan tea.Msg) {
+	a.subsMu.Lock()
+	defer a.subsMu.Unlock()
+	a.subs = slices.DeleteFunc(a.subs, func(c chan tea.Msg) bool { return c == ch })
+}
+
+// startFanOut runs once per App. It throttles the raw events channel and
+// scatters every message to all currently-registered subscribers. Sends are
+// non-blocking; if a subscriber's buffer is full the event is dropped for
+// that subscriber so one slow consumer cannot stall the others.
+func (a *App) startFanOut() {
+	throttled := a.throttleEvents(context.Background(), a.events)
+	go func() {
+		for msg := range throttled {
+			a.subsMu.Lock()
+			subs := slices.Clone(a.subs)
+			a.subsMu.Unlock()
+			for _, ch := range subs {
+				select {
+				case ch <- msg:
+				default:
+					slog.Warn("app: subscriber buffer full, dropping event")
+				}
+			}
+		}
+	}()
 }
 
 // Resume resumes the runtime with the given confirmation request

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/stretchr/testify/assert"
@@ -267,6 +268,48 @@ func TestApp_SnapshotsEnabled_DoesNotRequireSession(t *testing.T) {
 	// silently return false just because no session is attached.
 	app := &App{runtime: &mockRuntime{}, session: nil}
 	assert.True(t, app.SnapshotsEnabled())
+}
+
+func TestApp_SubscribeWith_FanOutToMultipleSubscribers(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	rt := &mockRuntime{}
+	app := New(ctx, rt, session.New())
+
+	recv := func() (chan tea.Msg, context.CancelFunc) {
+		subCtx, subCancel := context.WithCancel(ctx)
+		ch := make(chan tea.Msg, 16)
+		go app.SubscribeWith(subCtx, func(m tea.Msg) { ch <- m })
+		return ch, subCancel
+	}
+
+	a, cancelA := recv()
+	b, cancelB := recv()
+	defer cancelA()
+	defer cancelB()
+
+	// Wait until both subscribers are registered before publishing.
+	require.Eventually(t, func() bool {
+		app.subsMu.Lock()
+		defer app.subsMu.Unlock()
+		return len(app.subs) == 2
+	}, time.Second, 5*time.Millisecond)
+
+	app.events <- runtime.SessionTitle("sess", "hello")
+
+	for _, ch := range []chan tea.Msg{a, b} {
+		select {
+		case msg := <-ch:
+			ev, ok := msg.(*runtime.SessionTitleEvent)
+			require.True(t, ok)
+			assert.Equal(t, "hello", ev.Title)
+		case <-time.After(time.Second):
+			t.Fatal("subscriber did not receive event")
+		}
+	}
 }
 
 func TestApp_RegenerateSessionTitle(t *testing.T) {

--- a/pkg/mcp/attach.go
+++ b/pkg/mcp/attach.go
@@ -1,0 +1,108 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/docker/docker-agent/pkg/api"
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/version"
+)
+
+type SendInput struct {
+	Message  string `json:"message" jsonschema:"the message to send"`
+	FollowUp bool   `json:"followup,omitempty" jsonschema:"queue as end-of-turn follow-up instead of mid-turn steer"`
+}
+
+type SendOutput struct {
+	Status string `json:"status"`
+}
+
+type TranscriptInput struct {
+	Limit int `json:"limit,omitempty" jsonschema:"max number of recent messages to return (0 = all)"`
+}
+
+type TranscriptOutput struct {
+	Title    string        `json:"title"`
+	Messages []TranscriptM `json:"messages"`
+}
+
+type TranscriptM struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// AttachServer wires an MCP server to a running docker-agent run accessible
+// via its HTTP control plane. It exposes a small toolset (send, transcript)
+// that other agents can use to drive the live session.
+func AttachServer(ctx context.Context, addr, sessionID string) (*mcp.Server, error) {
+	if addr == "" || sessionID == "" {
+		return nil, errors.New("attach: addr and sessionID are required")
+	}
+
+	client, err := runtime.NewClient(addr)
+	if err != nil {
+		return nil, fmt.Errorf("client for %s: %w", addr, err)
+	}
+
+	server := mcp.NewServer(&mcp.Implementation{
+		Name:    "docker-agent (attached)",
+		Version: version.Version,
+	}, nil)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "send",
+		Description: fmt.Sprintf("Send a message to the running docker-agent session %s.", sessionID),
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in SendInput) (*mcp.CallToolResult, SendOutput, error) {
+		msgs := []api.Message{{Content: in.Message}}
+		var err error
+		if in.FollowUp {
+			err = client.FollowUpSession(ctx, sessionID, msgs)
+		} else {
+			err = client.SteerSession(ctx, sessionID, msgs)
+		}
+		if err != nil {
+			return nil, SendOutput{}, err
+		}
+		return nil, SendOutput{Status: "queued"}, nil
+	})
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "transcript",
+		Description: fmt.Sprintf("Read the transcript of the running docker-agent session %s.", sessionID),
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in TranscriptInput) (*mcp.CallToolResult, TranscriptOutput, error) {
+		sess, err := client.GetSession(ctx, sessionID)
+		if err != nil {
+			return nil, TranscriptOutput{}, err
+		}
+
+		out := TranscriptOutput{Title: sess.Title}
+		messages := sess.Messages
+		if in.Limit > 0 && len(messages) > in.Limit {
+			messages = messages[len(messages)-in.Limit:]
+		}
+		for _, m := range messages {
+			out.Messages = append(out.Messages, TranscriptM{
+				Role:    string(m.Message.Role),
+				Content: m.Message.Content,
+			})
+		}
+		return nil, out, nil
+	})
+
+	slog.DebugContext(ctx, "MCP attach server ready", "addr", addr, "session_id", sessionID)
+	return server, nil
+}
+
+// StartAttachStdio runs the attach MCP server over stdio.
+func StartAttachStdio(ctx context.Context, addr, sessionID string) error {
+	server, err := AttachServer(ctx, addr, sessionID)
+	if err != nil {
+		return err
+	}
+	return server.Run(ctx, &mcp.StdioTransport{})
+}

--- a/pkg/mcp/attach_test.go
+++ b/pkg/mcp/attach_test.go
@@ -1,0 +1,28 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAttachServer_RequiresArgs(t *testing.T) {
+	ctx := t.Context()
+
+	_, err := AttachServer(ctx, "", "session-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "addr and sessionID")
+
+	_, err = AttachServer(ctx, "http://127.0.0.1:1234", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "addr and sessionID")
+}
+
+func TestAttachServer_BuildsWithValidArgs(t *testing.T) {
+	ctx := t.Context()
+
+	srv, err := AttachServer(ctx, "http://127.0.0.1:1234", "session-1")
+	require.NoError(t, err)
+	assert.NotNil(t, srv)
+}

--- a/pkg/runregistry/registry.go
+++ b/pkg/runregistry/registry.go
@@ -1,0 +1,115 @@
+// Package runregistry persists discovery records for running docker-agent
+// processes that expose a control plane (see run --listen). Records live as
+// per-pid JSON files under <data dir>/runs so external tools can enumerate
+// live runs and connect to them.
+package runregistry
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/docker/docker-agent/pkg/paths"
+)
+
+// Record describes a running docker-agent that exposes a control plane.
+type Record struct {
+	PID       int       `json:"pid"`
+	Addr      string    `json:"addr"`
+	SessionID string    `json:"session_id"`
+	Agent     string    `json:"agent,omitempty"`
+	StartedAt time.Time `json:"started_at"`
+}
+
+// Dir is the directory holding run records.
+func Dir() string {
+	return filepath.Join(paths.GetDataDir(), "runs")
+}
+
+// Write atomically persists a record for the current process and returns a
+// cleanup func that removes it. Cleanup is safe to call more than once.
+func Write(rec Record) (func(), error) {
+	if err := os.MkdirAll(Dir(), 0o755); err != nil {
+		return nil, fmt.Errorf("creating run registry dir: %w", err)
+	}
+
+	path := filepath.Join(Dir(), strconv.Itoa(rec.PID)+".json")
+	buf, err := json.MarshalIndent(rec, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(path, buf, 0o600); err != nil {
+		return nil, err
+	}
+
+	return func() { _ = os.Remove(path) }, nil
+}
+
+// List returns every record currently registered. Stale records (whose pid is
+// no longer alive) are skipped and best-effort removed.
+func List() ([]Record, error) {
+	entries, err := os.ReadDir(Dir())
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var out []Record
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		path := filepath.Join(Dir(), e.Name())
+		buf, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var rec Record
+		if err := json.Unmarshal(buf, &rec); err != nil {
+			continue
+		}
+		if !pidAlive(rec.PID) {
+			_ = os.Remove(path)
+			continue
+		}
+		out = append(out, rec)
+	}
+	return out, nil
+}
+
+// Latest returns the most recently started live record, or false when none.
+func Latest() (Record, bool, error) {
+	records, err := List()
+	if err != nil || len(records) == 0 {
+		return Record{}, false, err
+	}
+	latest := records[0]
+	for _, r := range records[1:] {
+		if r.StartedAt.After(latest.StartedAt) {
+			latest = r
+		}
+	}
+	return latest, true, nil
+}
+
+// pidAlive reports whether the given pid corresponds to a live process.
+// Uses os.FindProcess + signal 0, the cross-platform idiom for liveness.
+func pidAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return p.Signal(syscall.Signal(0)) == nil
+}

--- a/pkg/runregistry/registry.go
+++ b/pkg/runregistry/registry.go
@@ -35,8 +35,12 @@ func Dir() string {
 
 // Write atomically persists a record for the current process and returns a
 // cleanup func that removes it. Cleanup is safe to call more than once.
+//
+// The registry directory is created with 0o700 so other local users cannot
+// enumerate live PIDs/addresses by listing it. Individual records are still
+// written with 0o600 for the same reason.
 func Write(rec Record) (func(), error) {
-	if err := os.MkdirAll(Dir(), 0o755); err != nil {
+	if err := os.MkdirAll(Dir(), 0o700); err != nil {
 		return nil, fmt.Errorf("creating run registry dir: %w", err)
 	}
 

--- a/pkg/runregistry/registry_test.go
+++ b/pkg/runregistry/registry_test.go
@@ -1,0 +1,84 @@
+package runregistry
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/paths"
+)
+
+func TestWriteAndList_RoundTrip(t *testing.T) {
+	withTempDataDir(t)
+
+	rec := Record{
+		PID:       os.Getpid(),
+		Addr:      "http://127.0.0.1:1234",
+		SessionID: "sess-1",
+		Agent:     "root",
+		StartedAt: time.Now(),
+	}
+	cleanup, err := Write(rec)
+	require.NoError(t, err)
+
+	records, err := List()
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	assert.Equal(t, rec.SessionID, records[0].SessionID)
+	assert.Equal(t, rec.Addr, records[0].Addr)
+
+	cleanup()
+	cleanup() // safe to call twice
+
+	records, err = List()
+	require.NoError(t, err)
+	assert.Empty(t, records)
+}
+
+func TestList_DropsStaleRecords(t *testing.T) {
+	withTempDataDir(t)
+
+	writeRecord(t, "999999.json", Record{
+		PID: 999999, Addr: "x", SessionID: "y",
+		StartedAt: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+
+	records, err := List()
+	require.NoError(t, err)
+	assert.Empty(t, records)
+
+	_, err = os.Stat(filepath.Join(Dir(), "999999.json"))
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestLatest_PicksMostRecent(t *testing.T) {
+	withTempDataDir(t)
+
+	pid := os.Getpid()
+	writeRecord(t, "1.json", Record{PID: pid, Addr: "http://a", SessionID: "old", StartedAt: time.Now().Add(-time.Hour)})
+	writeRecord(t, "2.json", Record{PID: pid, Addr: "http://b", SessionID: "new", StartedAt: time.Now()})
+
+	rec, ok, err := Latest()
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "new", rec.SessionID)
+}
+
+func withTempDataDir(t *testing.T) {
+	t.Helper()
+	paths.SetDataDir(t.TempDir())
+	t.Cleanup(func() { paths.SetDataDir("") })
+}
+
+func writeRecord(t *testing.T, name string, rec Record) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(Dir(), 0o755))
+	buf, err := json.Marshal(rec)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(Dir(), name), buf, 0o600))
+}

--- a/pkg/runregistry/registry_test.go
+++ b/pkg/runregistry/registry_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -38,6 +39,29 @@ func TestWriteAndList_RoundTrip(t *testing.T) {
 	records, err = List()
 	require.NoError(t, err)
 	assert.Empty(t, records)
+}
+
+// TestWrite_RestrictsDirectoryPermissions verifies that the registry
+// directory is created with 0o700 so other local users cannot enumerate
+// running PIDs/addresses by listing it.
+func TestWrite_RestrictsDirectoryPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix mode bits are not enforced on Windows")
+	}
+	withTempDataDir(t)
+
+	cleanup, err := Write(Record{
+		PID:       os.Getpid(),
+		Addr:      "http://127.0.0.1:1",
+		SessionID: "s",
+		StartedAt: time.Now(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(cleanup)
+
+	info, err := os.Stat(Dir())
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o700), info.Mode().Perm(), "registry dir must not be world- or group-readable")
 }
 
 func TestList_DropsStaleRecords(t *testing.T) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -343,8 +343,7 @@ func (s *Server) steerSession(c echo.Context) error {
 // sessionEvents streams events for a session as Server-Sent Events. The
 // stream lasts until the client disconnects or the session ends.
 func (s *Server) sessionEvents(c echo.Context) error {
-	source, ok := s.sm.GetEventSource(c.Param("id"))
-	if !ok {
+	if _, ok := s.sm.GetEventSource(c.Param("id")); !ok {
 		return echo.NewHTTPError(http.StatusNotFound, "no event source for session")
 	}
 
@@ -354,7 +353,7 @@ func (s *Server) sessionEvents(c echo.Context) error {
 	c.Response().WriteHeader(http.StatusOK)
 	c.Response().Flush()
 
-	source(c.Request().Context(), func(event any) {
+	s.sm.StreamEvents(c.Request().Context(), c.Param("id"), func(event any) {
 		data, err := json.Marshal(event)
 		if err != nil {
 			return

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -62,6 +62,7 @@ func (s *Server) registerRoutes() {
 	group.POST("/sessions/:id/elicitation", s.elicitation)
 	group.POST("/sessions/:id/steer", s.steerSession)
 	group.POST("/sessions/:id/followup", s.followUpSession)
+	group.GET("/sessions/:id/events", s.sessionEvents)
 
 	group.GET("/agents/:id/:agent_name/tools/count", s.getAgentToolCount)
 
@@ -337,6 +338,31 @@ func (s *Server) steerSession(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusAccepted, map[string]string{"status": "queued"})
+}
+
+// sessionEvents streams events for a session as Server-Sent Events. The
+// stream lasts until the client disconnects or the session ends.
+func (s *Server) sessionEvents(c echo.Context) error {
+	source, ok := s.sm.GetEventSource(c.Param("id"))
+	if !ok {
+		return echo.NewHTTPError(http.StatusNotFound, "no event source for session")
+	}
+
+	c.Response().Header().Set("Content-Type", "text/event-stream")
+	c.Response().Header().Set("Cache-Control", "no-cache")
+	c.Response().Header().Set("Connection", "keep-alive")
+	c.Response().WriteHeader(http.StatusOK)
+	c.Response().Flush()
+
+	source(c.Request().Context(), func(event any) {
+		data, err := json.Marshal(event)
+		if err != nil {
+			return
+		}
+		fmt.Fprintf(c.Response(), "data: %s\n\n", data)
+		c.Response().Flush()
+	})
+	return nil
 }
 
 func (s *Server) followUpSession(c echo.Context) error {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -27,56 +27,47 @@ type Server struct {
 }
 
 func New(ctx context.Context, sessionStore session.Store, runConfig *config.RuntimeConfig, refreshInterval time.Duration, agentSources config.Sources) (*Server, error) {
+	return NewWithManager(NewSessionManager(ctx, agentSources, sessionStore, refreshInterval, runConfig)), nil
+}
+
+// NewWithManager builds a Server around an already-constructed SessionManager.
+// Useful when the runtime is owned by another component (e.g. the TUI) and
+// only needs to be exposed over HTTP.
+func NewWithManager(sm *SessionManager) *Server {
 	e := echo.New()
 	e.Use(middleware.RequestLogger())
 	e.Use(echo.WrapMiddleware(upstream.Handler))
 
-	s := &Server{
-		e:  e,
-		sm: NewSessionManager(ctx, agentSources, sessionStore, refreshInterval, runConfig),
-	}
+	s := &Server{e: e, sm: sm}
+	s.registerRoutes()
+	return s
+}
 
-	group := e.Group("/api")
+func (s *Server) registerRoutes() {
+	group := s.e.Group("/api")
 
-	// List all available agents
 	group.GET("/agents", s.getAgents)
-	// Get an agent by id
 	group.GET("/agents/:id", s.getAgentConfig)
 
-	// List all sessions
 	group.GET("/sessions", s.getSessions)
-	// Get a session by id
 	group.GET("/sessions/:id", s.getSession)
-	// Resume a session by id
 	group.POST("/sessions/:id/resume", s.resumeSession)
-	// Toggle YOLO mode for a session
 	group.POST("/sessions/:id/tools/toggle", s.toggleSessionYolo)
-	// Update session permissions
 	group.PATCH("/sessions/:id/permissions", s.updateSessionPermissions)
-	// Update session title
 	group.PATCH("/sessions/:id/title", s.updateSessionTitle)
-	// Create a new session
 	group.POST("/sessions", s.createSession)
-	// Delete a session
 	group.DELETE("/sessions/:id", s.deleteSession)
-	// Run an agent loop
 	group.POST("/sessions/:id/agent/:agent", s.runAgent)
 	group.POST("/sessions/:id/agent/:agent/:agent_name", s.runAgent)
 	group.POST("/sessions/:id/elicitation", s.elicitation)
-	// Steer: inject user messages into a running agent session mid-turn
 	group.POST("/sessions/:id/steer", s.steerSession)
-	// Follow-up: queue messages for end-of-turn processing
 	group.POST("/sessions/:id/followup", s.followUpSession)
 
-	// Agent tool count
 	group.GET("/agents/:id/:agent_name/tools/count", s.getAgentToolCount)
 
-	// Health check endpoint
 	group.GET("/ping", func(c echo.Context) error {
 		return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
 	})
-
-	return s, nil
 }
 
 func (s *Server) Serve(ctx context.Context, ln net.Listener) error {

--- a/pkg/server/server_attached_test.go
+++ b/pkg/server/server_attached_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -103,4 +104,57 @@ func httpDoTCP(t *testing.T, ctx context.Context, method, url string, payload an
 	require.NoError(t, err)
 	require.Less(t, resp.StatusCode, 400, string(out))
 	return out
+}
+
+// TestAttachedServer_DeleteSessionStopsEventStream verifies that calling
+// DeleteSession on an attached session cancels in-flight SSE event streams
+// and removes the registered event source so a subsequent GET /events 404s.
+func TestAttachedServer_DeleteSessionStopsEventStream(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	store := session.NewInMemorySessionStore()
+	sess := session.New()
+	require.NoError(t, store.AddSession(ctx, sess))
+
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+	sm.AttachRuntime(sess.ID, &fakeRuntime{}, sess)
+
+	sourceCtxDone := make(chan struct{})
+	sm.RegisterEventSource(sess.ID, func(ctx context.Context, _ func(any)) {
+		<-ctx.Done()
+		close(sourceCtxDone)
+	})
+
+	srv := NewWithManager(sm)
+	ln, err := Listen(ctx, "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() { _ = srv.Serve(ctx, ln) }()
+
+	addr := "http://" + ln.Addr().String()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, addr+"/api/sessions/"+sess.ID+"/events", http.NoBody)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	require.NoError(t, sm.DeleteSession(ctx, sess.ID))
+
+	select {
+	case <-sourceCtxDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("event source ctx was not cancelled when session was deleted")
+	}
+
+	_, ok := sm.GetEventSource(sess.ID)
+	assert.False(t, ok, "event source must be removed from the registry on delete")
+
+	req2, err := http.NewRequestWithContext(ctx, http.MethodGet, addr+"/api/sessions/"+sess.ID+"/events", http.NoBody)
+	require.NoError(t, err)
+	resp2, err := http.DefaultClient.Do(req2)
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp2.StatusCode)
 }

--- a/pkg/server/server_attached_test.go
+++ b/pkg/server/server_attached_test.go
@@ -1,0 +1,61 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/api"
+	"github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/session"
+)
+
+func TestAttachedServer_SteerReachesAttachedRuntime(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := session.NewInMemorySessionStore()
+	sess := session.New()
+	require.NoError(t, store.AddSession(ctx, sess))
+
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+	fake := &fakeRuntime{}
+	sm.AttachRuntime(sess.ID, fake, sess)
+
+	srv := NewWithManager(sm)
+
+	ln, err := Listen(ctx, "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() { _ = srv.Serve(ctx, ln) }()
+
+	addr := "http://" + ln.Addr().String()
+	resp := httpDoTCP(t, ctx, http.MethodPost, addr+"/api/sessions/"+sess.ID+"/steer",
+		api.SteerSessionRequest{Messages: []api.Message{{Content: "hello"}}})
+	assert.Contains(t, string(resp), "queued")
+}
+
+func httpDoTCP(t *testing.T, ctx context.Context, method, url string, payload any) []byte {
+	t.Helper()
+
+	buf, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(buf))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	out, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Less(t, resp.StatusCode, 400, string(out))
+	return out
+}

--- a/pkg/server/server_attached_test.go
+++ b/pkg/server/server_attached_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -38,6 +39,50 @@ func TestAttachedServer_SteerReachesAttachedRuntime(t *testing.T) {
 	resp := httpDoTCP(t, ctx, http.MethodPost, addr+"/api/sessions/"+sess.ID+"/steer",
 		api.SteerSessionRequest{Messages: []api.Message{{Content: "hello"}}})
 	assert.Contains(t, string(resp), "queued")
+}
+
+func TestAttachedServer_EventStreamEmitsRegisteredEvents(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	store := session.NewInMemorySessionStore()
+	sess := session.New()
+	require.NoError(t, store.AddSession(ctx, sess))
+
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+	sm.AttachRuntime(sess.ID, &fakeRuntime{}, sess)
+
+	events := make(chan any, 4)
+	sm.RegisterEventSource(sess.ID, func(ctx context.Context, send func(any)) {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case ev := <-events:
+				send(ev)
+			}
+		}
+	})
+
+	srv := NewWithManager(sm)
+	ln, err := Listen(ctx, "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() { _ = srv.Serve(ctx, ln) }()
+
+	addr := "http://" + ln.Addr().String()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, addr+"/api/sessions/"+sess.ID+"/events", http.NoBody)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	events <- map[string]string{"type": "hello", "msg": "world"}
+
+	line, err := bufio.NewReader(resp.Body).ReadString('\n')
+	require.NoError(t, err)
+	assert.Contains(t, line, `"type":"hello"`)
 }
 
 func httpDoTCP(t *testing.T, ctx context.Context, method, url string, payload any) []byte {

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -66,6 +66,18 @@ func NewSessionManager(ctx context.Context, sources config.Sources, sessionStore
 	return sm
 }
 
+// AttachRuntime registers a pre-built runtime + session under sessionID so
+// that subsequent calls (RunSession, Steer, Resume...) reuse it instead of
+// building one from agentFilename. This is what lets a single in-process
+// runtime be shared between the TUI and an HTTP control plane.
+func (sm *SessionManager) AttachRuntime(sessionID string, rt runtime.Runtime, sess *session.Session) {
+	sm.runtimeSessions.Store(sessionID, &activeRuntimes{
+		runtime: rt,
+		cancel:  func() {},
+		session: sess,
+	})
+}
+
 // GetSession retrieves a session by ID.
 func (sm *SessionManager) GetSession(ctx context.Context, id string) (*session.Session, error) {
 	sess, err := sm.sessionStore.GetSession(ctx, id)

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -26,6 +26,7 @@ import (
 
 type activeRuntimes struct {
 	runtime  runtime.Runtime
+	done     <-chan struct{} // Closed when the session is deleted/detached. Nil for sessions without lifetime tracking.
 	cancel   context.CancelFunc
 	session  *session.Session        // The actual session object used by the runtime
 	titleGen *sessiontitle.Generator // Title generator (includes fallback models)
@@ -85,14 +86,47 @@ func (sm *SessionManager) GetEventSource(sessionID string) (EventSource, bool) {
 	return sm.eventSources.Load(sessionID)
 }
 
+// StreamEvents drives the EventSource registered for sessionID, sending each
+// event through send. It blocks until the source returns, the caller's ctx is
+// cancelled, or the session is detached via [SessionManager.DeleteSession].
+// Returns false when no source is registered.
+func (sm *SessionManager) StreamEvents(ctx context.Context, sessionID string, send func(any)) bool {
+	src, ok := sm.eventSources.Load(sessionID)
+	if !ok {
+		return false
+	}
+
+	if rs, ok := sm.runtimeSessions.Load(sessionID); ok && rs.done != nil {
+		derived, cancel := context.WithCancel(ctx)
+		defer cancel()
+		go func() {
+			select {
+			case <-rs.done:
+				cancel()
+			case <-derived.Done():
+			}
+		}()
+		ctx = derived
+	}
+
+	src(ctx, send)
+	return true
+}
+
 // AttachRuntime registers a pre-built runtime + session under sessionID so
 // that subsequent calls (RunSession, Steer, Resume...) reuse it instead of
 // building one from agentFilename. This is what lets a single in-process
 // runtime be shared between the TUI and an HTTP control plane.
+//
+// The internal cancellation signal is fired by [SessionManager.DeleteSession];
+// SSE streams and other lifetime-bound consumers use it (via
+// [SessionManager.StreamEvents]) to terminate when the session is detached.
 func (sm *SessionManager) AttachRuntime(sessionID string, rt runtime.Runtime, sess *session.Session) {
+	ctx, cancel := context.WithCancel(context.Background())
 	sm.runtimeSessions.Store(sessionID, &activeRuntimes{
 		runtime: rt,
-		cancel:  func() {},
+		done:    ctx.Done(),
+		cancel:  cancel,
 		session: sess,
 	})
 }
@@ -165,6 +199,7 @@ func (sm *SessionManager) DeleteSession(ctx context.Context, sessionID string) e
 		sessionRuntime.cancel()
 		sm.runtimeSessions.Delete(sess.ID)
 	}
+	sm.eventSources.Delete(sess.ID)
 
 	return nil
 }

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -36,6 +36,7 @@ type activeRuntimes struct {
 // SessionManager manages sessions for HTTP and Connect-RPC servers.
 type SessionManager struct {
 	runtimeSessions *concurrent.Map[string, *activeRuntimes]
+	eventSources    *concurrent.Map[string, EventSource]
 	sessionStore    session.Store
 	Sources         config.Sources
 
@@ -48,6 +49,11 @@ type SessionManager struct {
 	mux sync.Mutex
 }
 
+// EventSource pushes session events to send for the lifetime of ctx. The
+// callback is invoked from request goroutines (e.g. an SSE handler), so it
+// must be safe to call concurrently across requests.
+type EventSource func(ctx context.Context, send func(any))
+
 // NewSessionManager creates a new session manager.
 func NewSessionManager(ctx context.Context, sources config.Sources, sessionStore session.Store, refreshInterval time.Duration, runConfig *config.RuntimeConfig) *SessionManager {
 	loaders := make(config.Sources)
@@ -57,6 +63,7 @@ func NewSessionManager(ctx context.Context, sources config.Sources, sessionStore
 
 	sm := &SessionManager{
 		runtimeSessions: concurrent.NewMap[string, *activeRuntimes](),
+		eventSources:    concurrent.NewMap[string, EventSource](),
 		sessionStore:    sessionStore,
 		Sources:         loaders,
 		refreshInterval: refreshInterval,
@@ -64,6 +71,18 @@ func NewSessionManager(ctx context.Context, sources config.Sources, sessionStore
 	}
 
 	return sm
+}
+
+// RegisterEventSource attaches an event source for sessionID. It is used by
+// callers that own a runtime out-of-band (e.g. the TUI) so that HTTP clients
+// can subscribe to events via GET /api/sessions/:id/events.
+func (sm *SessionManager) RegisterEventSource(sessionID string, src EventSource) {
+	sm.eventSources.Store(sessionID, src)
+}
+
+// GetEventSource returns the registered event source for sessionID.
+func (sm *SessionManager) GetEventSource(sessionID string) (EventSource, bool) {
+	return sm.eventSources.Load(sessionID)
 }
 
 // AttachRuntime registers a pre-built runtime + session under sessionID so

--- a/pkg/server/session_manager_test.go
+++ b/pkg/server/session_manager_test.go
@@ -48,6 +48,10 @@ func (f *fakeRuntime) RunStream(_ context.Context, _ *session.Session) <-chan ru
 
 func (f *fakeRuntime) Resume(_ context.Context, _ runtime.ResumeRequest) {}
 
+func (f *fakeRuntime) Steer(_ runtime.QueuedMessage) error { return nil }
+
+func (f *fakeRuntime) FollowUp(_ runtime.QueuedMessage) error { return nil }
+
 func (f *fakeRuntime) ResumeElicitation(_ context.Context, _ tools.ElicitationAction, _ map[string]any) error {
 	return nil
 }
@@ -74,6 +78,25 @@ func newTestSessionManager(t *testing.T, sess *session.Session, fake *fakeRuntim
 	})
 
 	return sm
+}
+
+// TestAttachRuntime_RegistersRuntimeForExternalDriver verifies that a
+// pre-built runtime is reachable through the manager API after AttachRuntime.
+// This is what lets the TUI hand its in-process runtime to an HTTP server.
+func TestAttachRuntime_RegistersRuntimeForExternalDriver(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := session.NewInMemorySessionStore()
+	sess := session.New()
+	require.NoError(t, store.AddSession(ctx, sess))
+
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+	fake := &fakeRuntime{streamDelay: 10 * time.Millisecond}
+	sm.AttachRuntime(sess.ID, fake, sess)
+
+	// Steer routes through the attached runtime, not a freshly built one.
+	require.NoError(t, sm.SteerSession(ctx, sess.ID, []api.Message{{Content: "hi"}}))
 }
 
 // TestRunSession_ConcurrentRequestReturnsErrSessionBusy verifies that a


### PR DESCRIPTION
External processes can now drive a running docker-agent TUI. Implemented as 9 small, additive commits in the spirit of *"make the change easy, then make the easy change"* — the first two are pure refactors that unlock everything else.

## Why

Tools like opencode, Claude Code, Codex, and Gemini CLI all expose some way for an external process (editor, script, another agent) to drive a running session. We had `docker-agent serve api` (full HTTP control plane) and `docker-agent run` (TUI), but the two were mutually exclusive — the running TUI was a black box.

The goal: **let one process be both**, with no architectural change.

## What's new

| Capability | How |
|---|---|
| Drive a live TUI over HTTP | `docker-agent run --listen 127.0.0.1:0` exposes the existing API against the same in-process runtime |
| Auto-discovery | `<data dir>/runs/<pid>.json` records every live run; pruned on exit and on stale-pid `List()` |
| Send a prompt from another shell | `docker-agent send "summarize the diff"` (or `--followup`, `--to <pid>`) |
| Tail events as JSON | `docker-agent watch \| jq` |
| Claude Code-style observability hooks | `--on-event stream_stopped="say done" --on-event "*=tee /tmp/events.log"` |
| MCP attach for agent-to-agent control | `docker-agent serve mcp --attach` (exposes `send` + `transcript` MCP tools) |
| Stdio JSON protocol (Codex `proto` style) | `docker-agent proto` — newline-delimited JSON-RPC for editor integrations |

## The 9 commits

| # | Commit | Type |
|---|---|---|
| 1 | `refactor(server): allow attaching a pre-built runtime` | Tidy |
| 2 | `refactor(app): turn SubscribeWith into a fan-out` | Tidy |
| 3 | `feat(run): add hidden --listen flag to expose the running TUI` | Feature |
| 4 | `feat(runregistry): publish discovery files for live runs` | Feature |
| 5 | `feat(send): new subcommand to drive a live TUI` | Feature |
| 6 | `feat(watch): stream events from a running TUI` | Feature |
| 7 | `feat(run): --on-event hooks observe arbitrary events` | Feature |
| 8 | `feat(serve mcp): --attach exposes a running TUI via MCP` | Feature |
| 9 | `feat(proto): newline-delimited JSON protocol over stdio` | Feature |

Each commit is small, reversible, opt-in, and unobservable to users who don't ask for it. Steps 1 and 2 are pure refactors:

- **Step 1** factors `Server.New` so a pre-built `SessionManager` (with `AttachRuntime`) can back it. No behavior change to `serve api`.
- **Step 2** turns `App.SubscribeWith` into a fan-out: one drain goroutine, many subscribers. The TUI keeps its single subscriber; HTTP/SSE, hooks, MCP, and stdio all become extra subscribers.

Steps 3–9 are then composition over the existing API surface — almost no new domain logic.

## Architecture

```
                   ┌─────────────┐
                   │  TUI (App)  │ ◄── subscriber #1
                   └──────┬──────┘
                          │  fan-out (step 2)
                          ▼
        ┌─────────────────────────────────────┐
        │            App events bus           │
        └────┬─────────┬─────────┬────────────┘
             │         │         │
             ▼         ▼         ▼
        ┌────────┐ ┌────────┐ ┌────────────┐
        │ HTTP   │ │ on-    │ │ MCP / proto│
        │ /events│ │ event  │ │ (via HTTP) │
        │ (SSE)  │ │ shell  │ └────────────┘
        └────────┘ └────────┘
             ▲
             │  (drives steer/followup/resume/...)
        ┌────┴──────────────────────────────┐
        │  send / watch / proto subcommands │
        │  (auto-discover via runregistry)  │
        └───────────────────────────────────┘
```

The `runtime.Runtime` is the API. The TUI is already a client of it (via `--remote`). This PR just lets the same in-process `Runtime` simultaneously serve the TUI **and** the HTTP control plane. Everything else is composition.

## Validation

- `golangci-lint run ./...` → **0 issues**
- `go run ./lint .` → **1006 file(s) inspected, no offenses detected**
- `go test ./...` → **123 packages OK, 0 failed**
- `go test -race -count=1 ./pkg/server/... ./pkg/app/... ./pkg/runregistry/... ./pkg/mcp/... ./cmd/root/...` → all pass, no data races

## Try it

```bash
# Terminal 1: start a TUI that exposes its control plane
docker-agent run ./agent.yaml --listen 127.0.0.1:0

# Terminal 2: drive it
docker-agent send "what files changed?"
docker-agent watch | jq 'select(.type=="agent_choice").content'

# Terminal 3: editor / agent integration
docker-agent proto                # stdio JSON-RPC
docker-agent serve mcp --attach   # expose as MCP tools to another agent
```

## Notes

- `--listen` is **hidden** for now (opt-in / experimental).
- `--on-event` complements (does **not** replace) the existing `pkg/hooks` system — it's purely observational, for events that don't have formal hook points.
- `pkg/server.NewWithManager` is a public sibling of `New`; existing callers are untouched.
- The `runregistry` package handles stale-pid cleanup automatically on `List()`.
