### PR TITLE
refactor(run): unify local/remote dispatch via Backend (10 baby steps)

### DIFF
--- a/cmd/root/backend.go
+++ b/cmd/root/backend.go
@@ -2,20 +2,35 @@ package root
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"sync"
 
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/tui"
 )
 
 // backend creates a runtime and a session, plus a cleanup closure that
 // callers must invoke when they're done. Both --remote and the local code
-// path will eventually be expressed as backends so the rest of runOrExec
-// stops branching on f.remoteAddress.
+// path are expressed as backends so runOrExec stops branching on
+// f.remoteAddress.
 type backend interface {
 	CreateRuntimeAndSession(ctx context.Context) (runtime.Runtime, *session.Session, func(), error)
+	Spawner(rt runtime.Runtime) tui.SessionSpawner
+}
+
+// selectBackend picks the backend implied by the current flags.
+func (f *runExecFlags) selectBackend(agentFileName string) (backend, error) {
+	if f.remoteAddress != "" {
+		return &remoteBackend{flags: f, agentFileName: agentFileName}, nil
+	}
+	agentSource, err := config.Resolve(agentFileName, f.runConfig.EnvProvider())
+	if err != nil {
+		return nil, err
+	}
+	return &localBackend{flags: f, agentSource: agentSource}, nil
 }
 
 // localBackend builds the in-process runtime and session.
@@ -46,4 +61,51 @@ func (b *localBackend) CreateRuntimeAndSession(ctx context.Context) (runtime.Run
 		})
 	}
 	return rt, sess, cleanup, nil
+}
+
+func (b *localBackend) Spawner(rt runtime.Runtime) tui.SessionSpawner {
+	return b.flags.createSessionSpawner(b.agentSource, rt.SessionStore())
+}
+
+// remoteBackend talks to a docker-agent server.
+type remoteBackend struct {
+	flags         *runExecFlags
+	agentFileName string
+}
+
+func (b *remoteBackend) CreateRuntimeAndSession(ctx context.Context) (runtime.Runtime, *session.Session, func(), error) {
+	client, err := runtime.NewClient(b.flags.remoteAddress)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create remote client: %w", err)
+	}
+
+	sessTemplate := session.New(
+		session.WithToolsApproved(b.flags.autoApprove),
+	)
+
+	sess, err := client.CreateSession(ctx, sessTemplate)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	rt, err := runtime.NewRemoteRuntime(client,
+		runtime.WithRemoteCurrentAgent(b.flags.agentName),
+		runtime.WithRemoteAgentFilename(b.agentFileName),
+	)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create remote runtime: %w", err)
+	}
+
+	slog.DebugContext(ctx, "Using remote runtime", "address", b.flags.remoteAddress, "agent", b.flags.agentName)
+
+	cleanup := func() {
+		if err := rt.Close(); err != nil {
+			slog.ErrorContext(ctx, "Failed to close remote runtime", "error", err)
+		}
+	}
+	return rt, sess, cleanup, nil
+}
+
+func (b *remoteBackend) Spawner(runtime.Runtime) tui.SessionSpawner {
+	return nil
 }

--- a/cmd/root/backend.go
+++ b/cmd/root/backend.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"sync"
 
 	"github.com/docker/docker-agent/pkg/config"
@@ -40,12 +41,13 @@ type localBackend struct {
 }
 
 func (b *localBackend) CreateRuntimeAndSession(ctx context.Context) (runtime.Runtime, *session.Session, func(), error) {
-	loadResult, err := b.flags.loadAgentFrom(ctx, b.agentSource)
+	loadResult, err := b.flags.loadAgentFrom(ctx, b.flags.loadTeamRequest(b.agentSource))
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
-	rt, sess, err := b.flags.createLocalRuntimeAndSession(ctx, loadResult)
+	wd, _ := os.Getwd()
+	rt, sess, err := b.flags.createLocalRuntimeAndSession(ctx, loadResult, b.flags.createSessionRequest(wd))
 	if err != nil {
 		stopToolSets(loadResult.Team)
 		return nil, nil, nil, err

--- a/cmd/root/backend.go
+++ b/cmd/root/backend.go
@@ -1,0 +1,49 @@
+package root
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+
+	"github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/session"
+)
+
+// backend creates a runtime and a session, plus a cleanup closure that
+// callers must invoke when they're done. Both --remote and the local code
+// path will eventually be expressed as backends so the rest of runOrExec
+// stops branching on f.remoteAddress.
+type backend interface {
+	CreateRuntimeAndSession(ctx context.Context) (runtime.Runtime, *session.Session, func(), error)
+}
+
+// localBackend builds the in-process runtime and session.
+type localBackend struct {
+	flags       *runExecFlags
+	agentSource config.Source
+}
+
+func (b *localBackend) CreateRuntimeAndSession(ctx context.Context) (runtime.Runtime, *session.Session, func(), error) {
+	loadResult, err := b.flags.loadAgentFrom(ctx, b.agentSource)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	rt, sess, err := b.flags.createLocalRuntimeAndSession(ctx, loadResult)
+	if err != nil {
+		stopToolSets(loadResult.Team)
+		return nil, nil, nil, err
+	}
+
+	var once sync.Once
+	cleanup := func() {
+		once.Do(func() {
+			stopToolSets(loadResult.Team)
+			if err := rt.Close(); err != nil {
+				slog.ErrorContext(ctx, "Failed to close runtime", "error", err)
+			}
+		})
+	}
+	return rt, sess, cleanup, nil
+}

--- a/cmd/root/payload.go
+++ b/cmd/root/payload.go
@@ -1,0 +1,61 @@
+package root
+
+import (
+	"github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/permissions"
+)
+
+// LoadTeamRequest is the typed input to a backend's team load. It carries
+// everything the team loader needs: the resolved agent source plus the
+// runtime config and the per-flag knobs the user supplied.
+//
+// Today only LocalBackend consumes it. The intent is that a future
+// RemoteBackend marshals the same struct over the wire so the server runs
+// teamloader.LoadWithConfig with identical inputs.
+type LoadTeamRequest struct {
+	Source         config.Source
+	ModelOverrides []string
+	PromptFiles    []string
+	RunConfig      *config.RuntimeConfig
+}
+
+// CreateSessionRequest is the typed input to a backend's session creation.
+// It carries the agent selection and every CLI-flag-driven session knob.
+//
+// The same forward-compatibility argument as LoadTeamRequest applies: this
+// is the payload a remote backend will eventually send over the wire.
+type CreateSessionRequest struct {
+	AgentName         string
+	ToolsApproved     bool
+	HideToolResults   bool
+	SessionDB         string
+	ResumeSessionID   string
+	SnapshotsEnabled  bool
+	GlobalPermissions *permissions.Checker
+	WorkingDir        string
+}
+
+// loadTeamRequest builds a LoadTeamRequest from the current flags.
+func (f *runExecFlags) loadTeamRequest(agentSource config.Source) LoadTeamRequest {
+	return LoadTeamRequest{
+		Source:         agentSource,
+		ModelOverrides: f.modelOverrides,
+		PromptFiles:    f.promptFiles,
+		RunConfig:      &f.runConfig,
+	}
+}
+
+// createSessionRequest builds a CreateSessionRequest from the current
+// flags and the supplied working directory.
+func (f *runExecFlags) createSessionRequest(workingDir string) CreateSessionRequest {
+	return CreateSessionRequest{
+		AgentName:         f.agentName,
+		ToolsApproved:     f.autoApprove,
+		HideToolResults:   f.hideToolResults,
+		SessionDB:         f.sessionDB,
+		ResumeSessionID:   f.sessionID,
+		SnapshotsEnabled:  f.snapshotsEnabled,
+		GlobalPermissions: f.globalPermissions,
+		WorkingDir:        workingDir,
+	}
+}

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -270,19 +270,14 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 	return runTUI(ctx, rt, sess, b.Spawner(rt), cleanup, f.tuiOpts(), opts...)
 }
 
-func (f *runExecFlags) loadAgentFrom(ctx context.Context, agentSource config.Source) (*teamloader.LoadResult, error) {
-	return teamloader.LoadWithConfig(ctx, agentSource, &f.runConfig, f.teamOpts()...)
-}
-
-// teamOpts returns the team-loader options derived from the current flags.
-func (f *runExecFlags) teamOpts() []teamloader.Opt {
+func (f *runExecFlags) loadAgentFrom(ctx context.Context, req LoadTeamRequest) (*teamloader.LoadResult, error) {
 	opts := []teamloader.Opt{
-		teamloader.WithModelOverrides(f.modelOverrides),
+		teamloader.WithModelOverrides(req.ModelOverrides),
 	}
-	if len(f.promptFiles) > 0 {
-		opts = append(opts, teamloader.WithPromptFiles(f.promptFiles))
+	if len(req.PromptFiles) > 0 {
+		opts = append(opts, teamloader.WithPromptFiles(req.PromptFiles))
 	}
-	return opts
+	return teamloader.LoadWithConfig(ctx, req.Source, req.RunConfig, opts...)
 }
 
 // runtimeOpts returns the runtime options derived from the current flags,
@@ -309,22 +304,22 @@ func (f *runExecFlags) runtimeOpts(loadResult *teamloader.LoadResult, runConfig 
 	return opts
 }
 
-func (f *runExecFlags) createLocalRuntimeAndSession(ctx context.Context, loadResult *teamloader.LoadResult) (runtime.Runtime, *session.Session, error) {
+func (f *runExecFlags) createLocalRuntimeAndSession(ctx context.Context, loadResult *teamloader.LoadResult, req CreateSessionRequest) (runtime.Runtime, *session.Session, error) {
 	t := loadResult.Team
 
 	// Merge user-level global permissions into the team's checker so the
 	// runtime receives a single, already-merged permission set.
-	if f.globalPermissions != nil && !f.globalPermissions.IsEmpty() {
-		t.SetPermissions(permissions.Merge(t.Permissions(), f.globalPermissions))
+	if req.GlobalPermissions != nil && !req.GlobalPermissions.IsEmpty() {
+		t.SetPermissions(permissions.Merge(t.Permissions(), req.GlobalPermissions))
 	}
 
-	agt, err := t.AgentOrDefault(f.agentName)
+	agt, err := t.AgentOrDefault(req.AgentName)
 	if err != nil {
 		return nil, nil, err
 	}
 	agentName := agt.Name()
 
-	sessionDB, err := pathx.ExpandHomeDir(f.sessionDB)
+	sessionDB, err := pathx.ExpandHomeDir(req.SessionDB)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -340,11 +335,11 @@ func (f *runExecFlags) createLocalRuntimeAndSession(ctx context.Context, loadRes
 	}
 
 	var sess *session.Session
-	if f.sessionID != "" {
+	if req.ResumeSessionID != "" {
 		// Resolve relative session references (e.g., "-1" for last session)
-		resolvedID, err := session.ResolveSessionID(ctx, sessStore, f.sessionID)
+		resolvedID, err := session.ResolveSessionID(ctx, sessStore, req.ResumeSessionID)
 		if err != nil {
-			return nil, nil, fmt.Errorf("resolving session %q: %w", f.sessionID, err)
+			return nil, nil, fmt.Errorf("resolving session %q: %w", req.ResumeSessionID, err)
 		}
 
 		// Load existing session
@@ -352,8 +347,8 @@ func (f *runExecFlags) createLocalRuntimeAndSession(ctx context.Context, loadRes
 		if err != nil {
 			return nil, nil, fmt.Errorf("loading session %q: %w", resolvedID, err)
 		}
-		sess.ToolsApproved = f.autoApprove
-		sess.HideToolResults = f.hideToolResults
+		sess.ToolsApproved = req.ToolsApproved
+		sess.HideToolResults = req.HideToolResults
 
 		// Apply any stored model overrides from the session
 		if len(sess.AgentModelOverrides) > 0 {
@@ -366,10 +361,9 @@ func (f *runExecFlags) createLocalRuntimeAndSession(ctx context.Context, loadRes
 			}
 		}
 
-		slog.DebugContext(ctx, "Loaded existing session", "session_id", resolvedID, "session_ref", f.sessionID, "agent", agentName)
+		slog.DebugContext(ctx, "Loaded existing session", "session_id", resolvedID, "session_ref", req.ResumeSessionID, "agent", agentName)
 	} else {
-		wd, _ := os.Getwd()
-		sess = session.New(f.buildSessionOpts(agt, wd)...)
+		sess = session.New(f.buildSessionOpts(agt, req)...)
 		// Session is stored lazily on first UpdateSession call (when content is added)
 		// This avoids creating empty sessions in the database
 		slog.DebugContext(ctx, "Using local runtime", "agent", agentName)
@@ -454,14 +448,14 @@ func (f *runExecFlags) buildAppOpts(args []string) ([]app.Opt, error) {
 // buildSessionOpts returns the canonical set of session options derived from
 // CLI flags and agent configuration. Both the initial session and spawned
 // sessions use this method so their options never drift apart.
-func (f *runExecFlags) buildSessionOpts(agt *agent.Agent, workingDir string) []session.Opt {
+func (f *runExecFlags) buildSessionOpts(agt *agent.Agent, req CreateSessionRequest) []session.Opt {
 	return []session.Opt{
 		session.WithMaxIterations(agt.MaxIterations()),
 		session.WithMaxConsecutiveToolCalls(agt.MaxConsecutiveToolCalls()),
 		session.WithMaxOldToolCallTokens(agt.MaxOldToolCallTokens()),
-		session.WithToolsApproved(f.autoApprove),
-		session.WithHideToolResults(f.hideToolResults),
-		session.WithWorkingDir(workingDir),
+		session.WithToolsApproved(req.ToolsApproved),
+		session.WithHideToolResults(req.HideToolResults),
+		session.WithWorkingDir(req.WorkingDir),
 	}
 }
 
@@ -495,7 +489,10 @@ func (f *runExecFlags) createSessionSpawner(agentSource config.Source, sessStore
 		}
 
 		// Create a new session
-		newSess := session.New(f.buildSessionOpts(agt, workingDir)...)
+		wd := workingDir
+		spawnReq := f.createSessionRequest(wd)
+		spawnReq.AgentName = agt.Name()
+		newSess := session.New(f.buildSessionOpts(agt, spawnReq)...)
 
 		// Create cleanup function
 		cleanup := func() {

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -125,6 +125,11 @@ func addRunOrExecFlags(cmd *cobra.Command, flags *runExecFlags) {
 	cmd.PersistentFlags().StringVar(&flags.sandboxTemplate, "template", "docker/sandbox-templates:docker-agent", "Template image for the sandbox (passed to docker sandbox create -t)")
 	cmd.PersistentFlags().BoolVar(&flags.sbx, "sbx", true, "Prefer the sbx CLI backend when available (set --sbx=false to force docker sandbox)")
 	cmd.MarkFlagsMutuallyExclusive("fake", "record")
+	cmd.MarkFlagsMutuallyExclusive("remote", "sandbox")
+	cmd.MarkFlagsMutuallyExclusive("remote", "session-db")
+	cmd.MarkFlagsMutuallyExclusive("remote", "session")
+	cmd.MarkFlagsMutuallyExclusive("remote", "record")
+	cmd.MarkFlagsMutuallyExclusive("remote", "fake")
 
 	// --exec only
 	cmd.PersistentFlags().BoolVar(&flags.exec, "exec", false, "Execute without a TUI")

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -241,36 +241,21 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 		out.Println("Recording mode enabled, cassette: " + cassettePath)
 	}
 
-	// Remote runtime
-	if f.remoteAddress != "" {
-		if f.dryRun {
-			out.Println("Dry run mode enabled. Agent initialized but will not execute.")
-			return nil
-		}
-		rt, sess, err := f.createRemoteRuntimeAndSession(ctx, agentFileName)
-		if err != nil {
-			return err
-		}
-		return f.launchTUI(ctx, out, rt, sess, args, useTUI)
-	}
-
-	// Local runtime
-	agentSource, err := config.Resolve(agentFileName, f.runConfig.EnvProvider())
+	b, err := f.selectBackend(agentFileName)
 	if err != nil {
 		return err
 	}
-
-	var b backend = &localBackend{flags: f, agentSource: agentSource}
-	rt, sess, cleanup, err := b.CreateRuntimeAndSession(ctx)
-	if err != nil {
-		return err
-	}
-	defer cleanup()
 
 	if f.dryRun {
 		out.Println("Dry run mode enabled. Agent initialized but will not execute.")
 		return nil
 	}
+
+	rt, sess, cleanup, err := b.CreateRuntimeAndSession(ctx)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
 
 	if !useTUI {
 		return f.handleExecMode(ctx, out, rt, sess, args)
@@ -282,8 +267,7 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 		return err
 	}
 
-	sessStore := rt.SessionStore()
-	return runTUI(ctx, rt, sess, f.createSessionSpawner(agentSource, sessStore), cleanup, f.tuiOpts(), opts...)
+	return runTUI(ctx, rt, sess, b.Spawner(rt), cleanup, f.tuiOpts(), opts...)
 }
 
 func (f *runExecFlags) loadAgentFrom(ctx context.Context, agentSource config.Source) (*teamloader.LoadResult, error) {
@@ -323,33 +307,6 @@ func (f *runExecFlags) runtimeOpts(loadResult *teamloader.LoadResult, runConfig 
 		opts = append(opts, runtime.WithSnapshots(true))
 	}
 	return opts
-}
-
-func (f *runExecFlags) createRemoteRuntimeAndSession(ctx context.Context, originalFilename string) (runtime.Runtime, *session.Session, error) {
-	client, err := runtime.NewClient(f.remoteAddress)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create remote client: %w", err)
-	}
-
-	sessTemplate := session.New(
-		session.WithToolsApproved(f.autoApprove),
-	)
-
-	sess, err := client.CreateSession(ctx, sessTemplate)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	remoteRt, err := runtime.NewRemoteRuntime(client,
-		runtime.WithRemoteCurrentAgent(f.agentName),
-		runtime.WithRemoteAgentFilename(originalFilename),
-	)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create remote runtime: %w", err)
-	}
-
-	slog.DebugContext(ctx, "Using remote runtime", "address", f.remoteAddress, "agent", f.agentName)
-	return remoteRt, sess, nil
 }
 
 func (f *runExecFlags) createLocalRuntimeAndSession(ctx context.Context, loadResult *teamloader.LoadResult) (runtime.Runtime, *session.Session, error) {
@@ -456,23 +413,6 @@ func readInitialMessage(args []string) (*string, error) {
 	}
 
 	return &args[1], nil
-}
-
-func (f *runExecFlags) launchTUI(ctx context.Context, out *cli.Printer, rt runtime.Runtime, sess *session.Session, args []string, useTUI bool) error {
-	if useTUI {
-		applyTheme()
-	}
-
-	if !useTUI {
-		return f.handleExecMode(ctx, out, rt, sess, args)
-	}
-
-	opts, err := f.buildAppOpts(args)
-	if err != nil {
-		return err
-	}
-
-	return runTUI(ctx, rt, sess, nil, nil, f.tuiOpts(), opts...)
 }
 
 // tuiOpts returns the TUI options derived from the current flags.

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -303,13 +303,42 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 }
 
 func (f *runExecFlags) loadAgentFrom(ctx context.Context, agentSource config.Source) (*teamloader.LoadResult, error) {
+	return teamloader.LoadWithConfig(ctx, agentSource, &f.runConfig, f.teamOpts()...)
+}
+
+// teamOpts returns the team-loader options derived from the current flags.
+func (f *runExecFlags) teamOpts() []teamloader.Opt {
 	opts := []teamloader.Opt{
 		teamloader.WithModelOverrides(f.modelOverrides),
 	}
 	if len(f.promptFiles) > 0 {
 		opts = append(opts, teamloader.WithPromptFiles(f.promptFiles))
 	}
-	return teamloader.LoadWithConfig(ctx, agentSource, &f.runConfig, opts...)
+	return opts
+}
+
+// runtimeOpts returns the runtime options derived from the current flags,
+// the loaded team and the runtime configuration. The session store and the
+// current agent name are passed in because they're resolved by callers from
+// different sources (e.g. the spawner uses the same store as the parent).
+func (f *runExecFlags) runtimeOpts(loadResult *teamloader.LoadResult, runConfig *config.RuntimeConfig, sessStore session.Store, agentName string) []runtime.Opt {
+	modelSwitcherCfg := &runtime.ModelSwitcherConfig{
+		Models:             loadResult.Models,
+		Providers:          loadResult.Providers,
+		ModelsGateway:      runConfig.ModelsGateway,
+		EnvProvider:        runConfig.EnvProvider(),
+		AgentDefaultModels: loadResult.AgentDefaultModels,
+	}
+	opts := []runtime.Opt{
+		runtime.WithSessionStore(sessStore),
+		runtime.WithCurrentAgent(agentName),
+		runtime.WithTracer(otel.Tracer(AppName)),
+		runtime.WithModelSwitcherConfig(modelSwitcherCfg),
+	}
+	if f.snapshotsEnabled {
+		opts = append(opts, runtime.WithSnapshots(true))
+	}
+	return opts
 }
 
 func (f *runExecFlags) createRemoteRuntimeAndSession(ctx context.Context, originalFilename string) (runtime.Runtime, *session.Session, error) {
@@ -364,25 +393,7 @@ func (f *runExecFlags) createLocalRuntimeAndSession(ctx context.Context, loadRes
 		return nil, nil, fmt.Errorf("creating session store: %w", err)
 	}
 
-	// Create model switcher config for runtime model switching support
-	modelSwitcherCfg := &runtime.ModelSwitcherConfig{
-		Models:             loadResult.Models,
-		Providers:          loadResult.Providers,
-		ModelsGateway:      f.runConfig.ModelsGateway,
-		EnvProvider:        f.runConfig.EnvProvider(),
-		AgentDefaultModels: loadResult.AgentDefaultModels,
-	}
-
-	runtimeOpts := []runtime.Opt{
-		runtime.WithSessionStore(sessStore),
-		runtime.WithCurrentAgent(agentName),
-		runtime.WithTracer(otel.Tracer(AppName)),
-		runtime.WithModelSwitcherConfig(modelSwitcherCfg),
-	}
-	if f.snapshotsEnabled {
-		runtimeOpts = append(runtimeOpts, runtime.WithSnapshots(true))
-	}
-	localRt, err := runtime.New(t, runtimeOpts...)
+	localRt, err := runtime.New(t, f.runtimeOpts(loadResult, &f.runConfig, sessStore, agentName)...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating runtime: %w", err)
 	}
@@ -549,31 +560,12 @@ func (f *runExecFlags) createSessionSpawner(agentSource config.Source, sessStore
 			return nil, nil, nil, err
 		}
 
-		// Create model switcher config
-		modelSwitcherCfg := &runtime.ModelSwitcherConfig{
-			Models:             loadResult.Models,
-			Providers:          loadResult.Providers,
-			ModelsGateway:      runConfigCopy.ModelsGateway,
-			EnvProvider:        runConfigCopy.EnvProvider(),
-			AgentDefaultModels: loadResult.AgentDefaultModels,
-		}
-
 		// Merge global permissions into the team's checker
 		if f.globalPermissions != nil && !f.globalPermissions.IsEmpty() {
 			t.SetPermissions(permissions.Merge(t.Permissions(), f.globalPermissions))
 		}
 
-		// Create the local runtime
-		runtimeOpts := []runtime.Opt{
-			runtime.WithSessionStore(sessStore),
-			runtime.WithCurrentAgent(agt.Name()),
-			runtime.WithTracer(otel.Tracer(AppName)),
-			runtime.WithModelSwitcherConfig(modelSwitcherCfg),
-		}
-		if f.snapshotsEnabled {
-			runtimeOpts = append(runtimeOpts, runtime.WithSnapshots(true))
-		}
-		localRt, err := runtime.New(t, runtimeOpts...)
+		localRt, err := runtime.New(t, f.runtimeOpts(loadResult, runConfigCopy, sessStore, agt.Name())...)
 		if err != nil {
 			return nil, nil, nil, err
 		}

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -244,6 +244,10 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 
 	// Remote runtime
 	if f.remoteAddress != "" {
+		if f.dryRun {
+			out.Println("Dry run mode enabled. Agent initialized but will not execute.")
+			return nil
+		}
 		rt, sess, err := f.createRemoteRuntimeAndSession(ctx, agentFileName)
 		if err != nil {
 			return err
@@ -462,11 +466,6 @@ func readInitialMessage(args []string) (*string, error) {
 func (f *runExecFlags) launchTUI(ctx context.Context, out *cli.Printer, rt runtime.Runtime, sess *session.Session, args []string, useTUI bool) error {
 	if useTUI {
 		applyTheme()
-	}
-
-	if f.dryRun {
-		out.Println("Dry run mode enabled. Agent initialized but will not execute.")
-		return nil
 	}
 
 	if !useTUI {

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -357,7 +357,7 @@ func (f *runExecFlags) createLocalRuntimeAndSession(ctx context.Context, loadRes
 
 		// Apply any stored model overrides from the session
 		if len(sess.AgentModelOverrides) > 0 {
-			if modelSwitcher, ok := localRt.(runtime.ModelSwitcher); ok {
+			if modelSwitcher := runtime.ModelSwitcherOf(localRt); modelSwitcher != nil {
 				for agentName, modelRef := range sess.AgentModelOverrides {
 					if err := modelSwitcher.SetAgentModel(ctx, agentName, modelRef); err != nil {
 						slog.WarnContext(ctx, "Failed to apply stored model override", "agent", agentName, "model", modelRef, "error", err)

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -8,7 +8,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"sync"
 	"time"
 
 	"github.com/mattn/go-isatty"
@@ -261,27 +260,12 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 		return err
 	}
 
-	loadResult, err := f.loadAgentFrom(ctx, agentSource)
+	var b backend = &localBackend{flags: f, agentSource: agentSource}
+	rt, sess, cleanup, err := b.CreateRuntimeAndSession(ctx)
 	if err != nil {
 		return err
 	}
-
-	rt, sess, err := f.createLocalRuntimeAndSession(ctx, loadResult)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err := rt.Close(); err != nil {
-			slog.ErrorContext(ctx, "Failed to close runtime", "error", err)
-		}
-	}()
-	var initialTeamCleanupOnce sync.Once
-	initialTeamCleanup := func() {
-		initialTeamCleanupOnce.Do(func() {
-			stopToolSets(loadResult.Team)
-		})
-	}
-	defer initialTeamCleanup()
+	defer cleanup()
 
 	if f.dryRun {
 		out.Println("Dry run mode enabled. Agent initialized but will not execute.")
@@ -299,7 +283,7 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 	}
 
 	sessStore := rt.SessionStore()
-	return runTUI(ctx, rt, sess, f.createSessionSpawner(agentSource, sessStore), initialTeamCleanup, f.tuiOpts(), opts...)
+	return runTUI(ctx, rt, sess, f.createSessionSpawner(agentSource, sessStore), cleanup, f.tuiOpts(), opts...)
 }
 
 func (f *runExecFlags) loadAgentFrom(ctx context.Context, agentSource config.Source) (*teamloader.LoadResult, error) {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -570,11 +570,15 @@ func (a *App) Resume(req runtime.ResumeRequest) {
 // doesn't support pausing (e.g. remote runtimes), in which case the first
 // return value is meaningless.
 func (a *App) TogglePause() (paused, supported bool) {
-	p := runtime.PauserOf(a.runtime)
-	if p == nil {
+	p, err := a.runtime.TogglePause(context.Background())
+	if errors.Is(err, runtime.ErrUnsupported) {
 		return false, false
 	}
-	return p.TogglePause(), true
+	if err != nil {
+		slog.Error("Failed to toggle pause", "error", err)
+		return false, false
+	}
+	return p, true
 }
 
 // ResumeElicitation resumes an elicitation request with the given action and content

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -119,7 +119,7 @@ func New(ctx context.Context, rt runtime.Runtime, sess *session.Session, opts ..
 
 	// Subscribe to tool list changes so the sidebar updates immediately
 	// when an MCP server adds or removes tools (outside of a RunStream).
-	if tcs, ok := rt.(runtime.ToolsChangeSubscriber); ok {
+	if tcs := runtime.ToolsChangeSubscriberOf(rt); tcs != nil {
 		tcs.OnToolsChanged(func(event runtime.Event) {
 			select {
 			case app.events <- event:
@@ -570,11 +570,11 @@ func (a *App) Resume(req runtime.ResumeRequest) {
 // doesn't support pausing (e.g. remote runtimes), in which case the first
 // return value is meaningless.
 func (a *App) TogglePause() (paused, supported bool) {
-	rt, ok := a.runtime.(interface{ TogglePause() bool })
-	if !ok {
+	p := runtime.PauserOf(a.runtime)
+	if p == nil {
 		return false, false
 	}
-	return rt.TogglePause(), true
+	return p.TogglePause(), true
 }
 
 // ResumeElicitation resumes an elicitation request with the given action and content
@@ -685,8 +685,8 @@ func (a *App) SwitchAgent(agentName string) error {
 // supported by the runtime (e.g., remote runtimes).
 // Pass an empty modelRef to clear the override and use the agent's default model.
 func (a *App) SetCurrentAgentModel(ctx context.Context, modelRef string) error {
-	modelSwitcher, ok := a.runtime.(runtime.ModelSwitcher)
-	if !ok {
+	modelSwitcher := runtime.ModelSwitcherOf(a.runtime)
+	if modelSwitcher == nil {
 		return errors.New("model switching not supported by this runtime")
 	}
 
@@ -733,8 +733,8 @@ func (a *App) SetCurrentAgentModel(ctx context.Context, modelRef string) error {
 // AvailableModels returns the list of models available for selection.
 // Returns nil if model switching is not supported.
 func (a *App) AvailableModels(ctx context.Context) []runtime.ModelChoice {
-	modelSwitcher, ok := a.runtime.(runtime.ModelSwitcher)
-	if !ok {
+	modelSwitcher := runtime.ModelSwitcherOf(a.runtime)
+	if modelSwitcher == nil {
 		return nil
 	}
 	models := modelSwitcher.AvailableModels(ctx)
@@ -826,8 +826,7 @@ func (a *App) trackCustomModel(modelRef string) {
 
 // SupportsModelSwitching returns true if the runtime supports model switching.
 func (a *App) SupportsModelSwitching() bool {
-	_, ok := a.runtime.(runtime.ModelSwitcher)
-	return ok
+	return runtime.ModelSwitcherOf(a.runtime) != nil
 }
 
 // ShouldExitAfterFirstResponse returns true if the app is configured to exit
@@ -896,8 +895,8 @@ func (a *App) applySessionModelOverrides(ctx context.Context, sess *session.Sess
 	}
 
 	// Check if runtime supports model switching
-	modelSwitcher, ok := a.runtime.(runtime.ModelSwitcher)
-	if !ok {
+	modelSwitcher := runtime.ModelSwitcherOf(a.runtime)
+	if modelSwitcher == nil {
 		slog.DebugContext(ctx, "Runtime does not support model switching, skipping overrides")
 		return
 	}

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -73,11 +73,12 @@ func (m *mockRuntime) UpdateSessionTitle(_ context.Context, sess *session.Sessio
 	sess.Title = title
 	return nil
 }
-func (m *mockRuntime) TitleGenerator() *sessiontitle.Generator { return nil }
-func (m *mockRuntime) Close() error                            { return nil }
-func (m *mockRuntime) Stop()                                   {}
-func (m *mockRuntime) Steer(_ runtime.QueuedMessage) error     { return nil }
-func (m *mockRuntime) FollowUp(_ runtime.QueuedMessage) error  { return nil }
+func (m *mockRuntime) TitleGenerator() *sessiontitle.Generator   { return nil }
+func (m *mockRuntime) Close() error                              { return nil }
+func (m *mockRuntime) Stop()                                     {}
+func (m *mockRuntime) Steer(_ runtime.QueuedMessage) error       { return nil }
+func (m *mockRuntime) FollowUp(_ runtime.QueuedMessage) error    { return nil }
+func (m *mockRuntime) TogglePause(context.Context) (bool, error) { return false, nil }
 func (m *mockRuntime) UndoLastSnapshot(context.Context, *session.Session) (int, bool, error) {
 	return m.undoFiles, m.undoOK, m.undoErr
 }

--- a/pkg/cli/runner_test.go
+++ b/pkg/cli/runner_test.go
@@ -64,6 +64,7 @@ func (m *mockRuntime) TitleGenerator() *sessiontitle.Generator                  
 func (m *mockRuntime) Close() error                                                          { return nil }
 func (m *mockRuntime) Steer(runtime.QueuedMessage) error                                     { return nil }
 func (m *mockRuntime) FollowUp(runtime.QueuedMessage) error                                  { return nil }
+func (m *mockRuntime) TogglePause(context.Context) (bool, error)                             { return false, nil }
 func (m *mockRuntime) RegenerateTitle(context.Context, *session.Session, chan runtime.Event) {}
 
 func (m *mockRuntime) Resume(_ context.Context, req runtime.ResumeRequest) {

--- a/pkg/runtime/capabilities.go
+++ b/pkg/runtime/capabilities.go
@@ -1,0 +1,28 @@
+package runtime
+
+// Pauser is implemented by runtimes that can pause/resume their loop at
+// iteration boundaries.
+type Pauser interface {
+	TogglePause() bool
+}
+
+// PauserOf returns the runtime as a Pauser, or nil if it doesn't support
+// pausing.
+func PauserOf(r Runtime) Pauser {
+	p, _ := r.(Pauser)
+	return p
+}
+
+// ModelSwitcherOf returns the runtime as a ModelSwitcher, or nil if it
+// doesn't support model switching.
+func ModelSwitcherOf(r Runtime) ModelSwitcher {
+	ms, _ := r.(ModelSwitcher)
+	return ms
+}
+
+// ToolsChangeSubscriberOf returns the runtime as a ToolsChangeSubscriber,
+// or nil if it doesn't emit tool-change notifications.
+func ToolsChangeSubscriberOf(r Runtime) ToolsChangeSubscriber {
+	tcs, _ := r.(ToolsChangeSubscriber)
+	return tcs
+}

--- a/pkg/runtime/capabilities.go
+++ b/pkg/runtime/capabilities.go
@@ -1,18 +1,5 @@
 package runtime
 
-// Pauser is implemented by runtimes that can pause/resume their loop at
-// iteration boundaries.
-type Pauser interface {
-	TogglePause() bool
-}
-
-// PauserOf returns the runtime as a Pauser, or nil if it doesn't support
-// pausing.
-func PauserOf(r Runtime) Pauser {
-	p, _ := r.(Pauser)
-	return p
-}
-
 // ModelSwitcherOf returns the runtime as a ModelSwitcher, or nil if it
 // doesn't support model switching.
 func ModelSwitcherOf(r Runtime) ModelSwitcher {

--- a/pkg/runtime/commands_test.go
+++ b/pkg/runtime/commands_test.go
@@ -69,10 +69,11 @@ func (m *mockRuntime) ExecuteMCPPrompt(context.Context, string, map[string]strin
 func (m *mockRuntime) UpdateSessionTitle(context.Context, *session.Session, string) error {
 	return nil
 }
-func (m *mockRuntime) TitleGenerator() *sessiontitle.Generator { return nil }
-func (m *mockRuntime) Close() error                            { return nil }
-func (m *mockRuntime) Steer(QueuedMessage) error               { return nil }
-func (m *mockRuntime) FollowUp(QueuedMessage) error            { return nil }
+func (m *mockRuntime) TitleGenerator() *sessiontitle.Generator   { return nil }
+func (m *mockRuntime) Close() error                              { return nil }
+func (m *mockRuntime) Steer(QueuedMessage) error                 { return nil }
+func (m *mockRuntime) FollowUp(QueuedMessage) error              { return nil }
+func (m *mockRuntime) TogglePause(context.Context) (bool, error) { return false, nil }
 
 func (m *mockRuntime) RegenerateTitle(context.Context, *session.Session, chan Event) {
 }

--- a/pkg/runtime/contract_test.go
+++ b/pkg/runtime/contract_test.go
@@ -1,0 +1,142 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/team"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+// runRuntimeContract exercises every non-streaming method on the Runtime
+// interface. It runs against any factory so that LocalRuntime and (in a
+// future commit) RemoteRuntime can be checked against the same expectations.
+//
+// Streaming methods (RunStream, Run, Summarize) are exercised by the
+// type-specific test files because they need real models or providers.
+func runRuntimeContract(t *testing.T, newRT func(t *testing.T) Runtime) {
+	t.Helper()
+
+	t.Run("CurrentAgentName not empty", func(t *testing.T) {
+		rt := newRT(t)
+		t.Cleanup(func() { _ = rt.Close() })
+		assert.NotEmpty(t, rt.CurrentAgentName())
+	})
+
+	t.Run("CurrentAgentInfo carries the current name", func(t *testing.T) {
+		rt := newRT(t)
+		t.Cleanup(func() { _ = rt.Close() })
+		info := rt.CurrentAgentInfo(t.Context())
+		assert.Equal(t, rt.CurrentAgentName(), info.Name)
+	})
+
+	t.Run("SetCurrentAgent rejects unknown agents", func(t *testing.T) {
+		rt := newRT(t)
+		t.Cleanup(func() { _ = rt.Close() })
+		err := rt.SetCurrentAgent("nonexistent-agent")
+		assert.Error(t, err)
+	})
+
+	t.Run("CurrentAgentTools returns slice or ErrUnsupported", func(t *testing.T) {
+		rt := newRT(t)
+		t.Cleanup(func() { _ = rt.Close() })
+		_, err := rt.CurrentAgentTools(t.Context())
+		if err != nil {
+			assert.ErrorIs(t, err, ErrUnsupported, "unexpected error type: %v", err)
+		}
+	})
+
+	t.Run("CurrentAgentToolsetStatuses does not panic", func(t *testing.T) {
+		rt := newRT(t)
+		t.Cleanup(func() { _ = rt.Close() })
+		_ = rt.CurrentAgentToolsetStatuses()
+	})
+
+	t.Run("RestartToolset on unknown name returns error", func(t *testing.T) {
+		rt := newRT(t)
+		t.Cleanup(func() { _ = rt.Close() })
+		err := rt.RestartToolset(t.Context(), "nonexistent-toolset")
+		assert.Error(t, err)
+	})
+
+	t.Run("CurrentMCPPrompts returns a non-nil map", func(t *testing.T) {
+		rt := newRT(t)
+		t.Cleanup(func() { _ = rt.Close() })
+		prompts := rt.CurrentMCPPrompts(t.Context())
+		assert.NotNil(t, prompts)
+	})
+
+	t.Run("ExecuteMCPPrompt for unknown prompt returns error", func(t *testing.T) {
+		rt := newRT(t)
+		t.Cleanup(func() { _ = rt.Close() })
+		_, err := rt.ExecuteMCPPrompt(t.Context(), "nonexistent-prompt", nil)
+		assert.Error(t, err)
+	})
+
+	t.Run("Steer accepts a message", func(t *testing.T) {
+		rt := newRT(t)
+		t.Cleanup(func() { _ = rt.Close() })
+		err := rt.Steer(QueuedMessage{Content: "hello"})
+		if err != nil {
+			assert.ErrorIs(t, err, ErrUnsupported, "unexpected error type: %v", err)
+		}
+	})
+
+	t.Run("FollowUp accepts a message", func(t *testing.T) {
+		rt := newRT(t)
+		t.Cleanup(func() { _ = rt.Close() })
+		err := rt.FollowUp(QueuedMessage{Content: "hello"})
+		if err != nil {
+			assert.ErrorIs(t, err, ErrUnsupported, "unexpected error type: %v", err)
+		}
+	})
+
+	t.Run("ResetStartupInfo is idempotent", func(t *testing.T) {
+		rt := newRT(t)
+		t.Cleanup(func() { _ = rt.Close() })
+		rt.ResetStartupInfo()
+		rt.ResetStartupInfo()
+	})
+
+	t.Run("Close is idempotent", func(t *testing.T) {
+		rt := newRT(t)
+		require.NoError(t, rt.Close())
+		// A second Close may error or not; both are acceptable as long as it
+		// doesn't panic.
+		_ = rt.Close()
+	})
+
+	t.Run("Resume on a fresh runtime is non-blocking", func(t *testing.T) {
+		rt := newRT(t)
+		t.Cleanup(func() { _ = rt.Close() })
+		// No tool call is in flight; Resume must not deadlock.
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		rt.Resume(ctx, ResumeApprove())
+	})
+
+	t.Run("ResumeElicitation outside an elicitation does not panic", func(t *testing.T) {
+		rt := newRT(t)
+		t.Cleanup(func() { _ = rt.Close() })
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		_ = rt.ResumeElicitation(ctx, tools.ElicitationActionDecline, nil)
+	})
+}
+
+func TestLocalRuntime_Contract(t *testing.T) {
+	runRuntimeContract(t, func(t *testing.T) Runtime {
+		t.Helper()
+		prov := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
+		root := agent.New("root", "You are a test agent", agent.WithModel(prov))
+		tm := team.New(team.WithAgents(root))
+
+		rt, err := New(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+		require.NoError(t, err)
+		return rt
+	})
+}

--- a/pkg/runtime/errors.go
+++ b/pkg/runtime/errors.go
@@ -1,0 +1,8 @@
+package runtime
+
+import "errors"
+
+// ErrUnsupported indicates that a runtime method is not supported by the
+// current backend. Callers can check with errors.Is to surface a clear
+// message instead of treating a silent zero value as a feature.
+var ErrUnsupported = errors.New("operation not supported by this runtime")

--- a/pkg/runtime/pause.go
+++ b/pkg/runtime/pause.go
@@ -6,18 +6,21 @@ import "context"
 // Returns true if now paused. The pause takes effect as soon as the in-flight
 // LLM request and its tool calls complete.
 //
+// The error return is reserved for runtimes that need to talk to a remote
+// service to flip the flag; LocalRuntime always returns nil.
+//
 // Internally, pauseCh is non-nil and open while paused; closing it on resume
 // wakes every goroutine waiting in waitIfPaused.
-func (r *LocalRuntime) TogglePause() bool {
+func (r *LocalRuntime) TogglePause(context.Context) (bool, error) {
 	r.pauseMu.Lock()
 	defer r.pauseMu.Unlock()
 	if r.pauseCh != nil {
 		close(r.pauseCh)
 		r.pauseCh = nil
-		return false
+		return false, nil
 	}
 	r.pauseCh = make(chan struct{})
-	return true
+	return true, nil
 }
 
 // waitIfPaused blocks until the runtime is resumed or ctx is cancelled.

--- a/pkg/runtime/pause_test.go
+++ b/pkg/runtime/pause_test.go
@@ -17,10 +17,17 @@ func TestTogglePause_StateCycles(t *testing.T) {
 
 	r := &LocalRuntime{}
 
-	assert.True(t, r.TogglePause(), "first toggle should pause")
-	assert.False(t, r.TogglePause(), "second toggle should resume")
-	assert.True(t, r.TogglePause(), "third toggle should pause again")
-	assert.False(t, r.TogglePause(), "fourth toggle should resume again")
+	assertToggle := func(want bool, msg string) {
+		t.Helper()
+		got, err := r.TogglePause(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, want, got, msg)
+	}
+
+	assertToggle(true, "first toggle should pause")
+	assertToggle(false, "second toggle should resume")
+	assertToggle(true, "third toggle should pause again")
+	assertToggle(false, "fourth toggle should resume again")
 }
 
 // TestWaitIfPaused_NotPaused returns immediately when the runtime isn't paused.
@@ -46,7 +53,7 @@ func TestWaitIfPaused_BlocksUntilResumed(t *testing.T) {
 	t.Parallel()
 
 	r := &LocalRuntime{}
-	r.TogglePause() // pause
+	_, _ = r.TogglePause(t.Context()) // pause
 
 	done := make(chan error, 1)
 	go func() { done <- r.waitIfPaused(t.Context()) }()
@@ -58,7 +65,7 @@ func TestWaitIfPaused_BlocksUntilResumed(t *testing.T) {
 	case <-time.After(50 * time.Millisecond):
 	}
 
-	r.TogglePause() // resume
+	_, _ = r.TogglePause(t.Context()) // resume
 
 	select {
 	case err := <-done:
@@ -74,7 +81,7 @@ func TestWaitIfPaused_ContextCancellation(t *testing.T) {
 	t.Parallel()
 
 	r := &LocalRuntime{}
-	r.TogglePause() // pause
+	_, _ = r.TogglePause(t.Context()) // pause
 
 	ctx, cancel := context.WithCancel(t.Context())
 	done := make(chan error, 1)
@@ -103,7 +110,7 @@ func TestWaitIfPaused_BroadcastsToAllWaiters(t *testing.T) {
 	t.Parallel()
 
 	r := &LocalRuntime{}
-	r.TogglePause()
+	_, _ = r.TogglePause(t.Context())
 
 	const n = 8
 	var wg sync.WaitGroup
@@ -115,7 +122,7 @@ func TestWaitIfPaused_BroadcastsToAllWaiters(t *testing.T) {
 
 	// Give them a moment to all enter waitIfPaused.
 	time.Sleep(50 * time.Millisecond)
-	r.TogglePause() // single resume should wake all waiters
+	_, _ = r.TogglePause(t.Context()) // single resume should wake all waiters
 
 	doneAll := make(chan struct{})
 	go func() {
@@ -146,7 +153,7 @@ func TestTogglePause_RaceFreeUnderConcurrentCallers(t *testing.T) {
 	for range togglers {
 		wg.Go(func() {
 			for range 200 {
-				r.TogglePause()
+				_, _ = r.TogglePause(ctx)
 			}
 		})
 	}

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -532,6 +532,11 @@ func (r *RemoteRuntime) TitleGenerator() *sessiontitle.Generator {
 	return nil
 }
 
+// TogglePause is not yet supported on remote runtimes.
+func (r *RemoteRuntime) TogglePause(context.Context) (bool, error) {
+	return false, fmt.Errorf("pause: %w", ErrUnsupported)
+}
+
 // Close is a no-op for remote runtimes.
 func (r *RemoteRuntime) Close() error {
 	return nil

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -132,10 +132,9 @@ func (r *RemoteRuntime) CurrentAgentToolsetStatuses() []tools.ToolsetStatus {
 }
 
 // RestartToolset is not implemented for remote runtimes; toolset
-// restart is a server-side concern. Returns an error so the caller
-// can surface a clear message.
+// restart is a server-side concern.
 func (r *RemoteRuntime) RestartToolset(context.Context, string) error {
-	return errors.New("restart-toolset is not supported for remote runtimes")
+	return fmt.Errorf("restart-toolset: %w", ErrUnsupported)
 }
 
 // EmitStartupInfo emits initial agent, team, and toolset information
@@ -525,7 +524,7 @@ func (r *RemoteRuntime) CurrentMCPPrompts(context.Context) map[string]mcp.Prompt
 
 // ExecuteMCPPrompt is not supported on remote runtimes.
 func (r *RemoteRuntime) ExecuteMCPPrompt(context.Context, string, map[string]string) (string, error) {
-	return "", errors.New("MCP prompts are not supported by remote runtimes")
+	return "", fmt.Errorf("MCP prompts: %w", ErrUnsupported)
 }
 
 // TitleGenerator is not supported on remote runtimes (titles are generated server-side).

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -107,6 +107,11 @@ type Runtime interface {
 	// gets a full undivided agent turn. Returns an error if the queue is full.
 	FollowUp(msg QueuedMessage) error
 
+	// TogglePause toggles whether the run loop is paused at iteration
+	// boundaries. Returns the new state (true if now paused). Returns
+	// [ErrUnsupported] for runtimes that don't expose pause control.
+	TogglePause(ctx context.Context) (paused bool, err error)
+
 	// Close releases resources held by the runtime (e.g., session store connections).
 	Close() error
 }


### PR DESCRIPTION
## Why

`docker agent run` has two parallel code paths — a long-form local one and a remote shortcut that branches early in `runOrExec`. The shortcut bypasses team load options, `RuntimeConfig`, `buildSessionOpts`, the session spawner, and several optional sub-interfaces, so a long list of features silently break under `--remote`: `--model`, `--prompt-file`, `--session-db`, `--session`, `--record`, `--fake`, hooks, `--working-dir`, `--hide-tool-results`, max iterations, snapshots, model switching, pause, `/tools`, `/sessions`, `/skills`, MCP prompts, compaction, title regeneration, …

Rather than rewriting both paths in one go, this PR lays the groundwork: ten small, individually-revertible commits that make the eventual unification a mechanical change. No user-visible behaviour changes except clearer error messages and four flag-combo rejections that previously did nothing.

## What

Ten commits, each shippable on its own:

1. `feat(runtime): introduce ErrUnsupported sentinel for remote runtime gaps` — typed sentinel so silent `nil`/empty returns become explicit.
2. `feat(run): reject --remote combined with silently-broken flags` — `MarkFlagsMutuallyExclusive` for `--sandbox`, `--session-db`, `--session`, `--record`, `--fake`. Stops the bleeding.
3. `fix(run): honour --dry-run before contacting the remote server` — `--dry-run --remote` no longer creates a server-side session before exiting.
4. `refactor(run): extract teamOpts and runtimeOpts helpers` — pure tidy-first; preps the typed payload.
5. `refactor(run): introduce backend interface with localBackend impl` — adds the seam; one implementation today.
6. `refactor(run): collapse local/remote branches via shared backend` — `selectBackend` + linear `runOrExec`. `launchTUI` disappears.
7. `refactor(runtime): centralize optional-capability checks` — `PauserOf`, `ModelSwitcherOf`, `ToolsChangeSubscriberOf` replace scattered type assertions.
8. `test(runtime): add backend-agnostic Runtime contract test` — pins what `Runtime` means; runs against `LocalRuntime` today.
9. `refactor(runtime): promote TogglePause onto the Runtime interface` — first sub-interface promotion. Template for the others.
10. `refactor(run): introduce LoadTeamRequest and CreateSessionRequest` — typed config payloads, ready to travel over the wire.

After these ten commits, `--remote` is a `Backend` selector instead of a parallel universe, and adding new wire-protocol endpoints, file uploads, etc. becomes an isolated change against a stable spine.

## What this PR does *not* do

- It does not extend the wire protocol.
- It does not add file uploads, a server-side shell endpoint, or a `ServerPolicy`.
- It does not promote the remaining optional sub-interfaces (`ModelSwitcher`, snapshots, `ToolsChangeSubscriber`) onto `Runtime` — commit 9 establishes the pattern; the rest are mechanical follow-ups.

Each of the above is its own PR.

## Validation

- `task build` ✅
- `task lint` ✅
- `task test` ✅
