### PR TITLE
update PR reviewer to 1.5.1

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -14,7 +14,7 @@ jobs:
     if: |
       github.event_name == 'issue_comment' ||
       github.event.workflow_run.conclusion == 'success'
-    uses: docker/cagent-action/.github/workflows/review-pr.yml@c22076b8856ee12d9b4c4685bb49cf26eb974079 # v1.5.0
+    uses: docker/cagent-action/.github/workflows/review-pr.yml@0498757af1c50b084f763d626f571918cf317509 # v1.5.1
     # Scoped to the job so other jobs in this workflow aren't over-permissioned
     permissions:
       contents: read # Read repository files and PR diffs


### PR DESCRIPTION
## Summary

Updates the `cagent-action` workflow dependency from v1.5.0 to v1.5.1 to pick up the latest bug fixes and improvements.

## Changes

- Updated `docker/cagent-action` workflow reference to v1.5.1 in the PR review workflow

Closes: https://github.com/docker/gordon/issues/566