### PR TITLE
remote-runtime: close silent gaps, consolidate Runtime, scaffold wire (10 baby steps)

### DIFF
--- a/cmd/root/backend.go
+++ b/cmd/root/backend.go
@@ -4,21 +4,29 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"os"
 	"sync"
 
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/teamloader"
 	"github.com/docker/docker-agent/pkg/tui"
 )
 
-// backend creates a runtime and a session, plus a cleanup closure that
-// callers must invoke when they're done. Both --remote and the local code
-// path are expressed as backends so runOrExec stops branching on
-// f.remoteAddress.
+// backend exposes the two-step protocol a future RPC server will mirror:
+//   - LoadTeam reads the team description (config sources, model overrides,
+//     prompt files) and resolves the team.
+//   - CreateSession turns that result into a live runtime and session.
+//
+// Both --remote and the local code path implement this so runOrExec stops
+// branching on f.remoteAddress.
 type backend interface {
-	CreateRuntimeAndSession(ctx context.Context) (runtime.Runtime, *session.Session, func(), error)
+	LoadTeamRequest() runtime.LoadTeamRequest
+	LoadTeam(ctx context.Context, req runtime.LoadTeamRequest) (*teamloader.LoadResult, error)
+
+	CreateSessionRequest(workingDir string) runtime.CreateSessionRequest
+	CreateSession(ctx context.Context, loaded *teamloader.LoadResult, req runtime.CreateSessionRequest) (runtime.Runtime, *session.Session, func(), error)
+
 	Spawner(rt runtime.Runtime) tui.SessionSpawner
 }
 
@@ -40,23 +48,29 @@ type localBackend struct {
 	agentSource config.Source
 }
 
-func (b *localBackend) CreateRuntimeAndSession(ctx context.Context) (runtime.Runtime, *session.Session, func(), error) {
-	loadResult, err := b.flags.loadAgentFrom(ctx, b.flags.loadTeamRequest(b.agentSource))
-	if err != nil {
-		return nil, nil, nil, err
-	}
+func (b *localBackend) LoadTeamRequest() runtime.LoadTeamRequest {
+	return b.flags.loadTeamRequest(b.agentSource)
+}
 
-	wd, _ := os.Getwd()
-	rt, sess, err := b.flags.createLocalRuntimeAndSession(ctx, loadResult, b.flags.createSessionRequest(wd))
+func (b *localBackend) LoadTeam(ctx context.Context, req runtime.LoadTeamRequest) (*teamloader.LoadResult, error) {
+	return b.flags.loadAgentFrom(ctx, req)
+}
+
+func (b *localBackend) CreateSessionRequest(workingDir string) runtime.CreateSessionRequest {
+	return b.flags.createSessionRequest(workingDir)
+}
+
+func (b *localBackend) CreateSession(ctx context.Context, loaded *teamloader.LoadResult, req runtime.CreateSessionRequest) (runtime.Runtime, *session.Session, func(), error) {
+	rt, sess, err := b.flags.createLocalRuntimeAndSession(ctx, loaded, req)
 	if err != nil {
-		stopToolSets(loadResult.Team)
+		stopToolSets(loaded.Team)
 		return nil, nil, nil, err
 	}
 
 	var once sync.Once
 	cleanup := func() {
 		once.Do(func() {
-			stopToolSets(loadResult.Team)
+			stopToolSets(loaded.Team)
 			if err := rt.Close(); err != nil {
 				slog.ErrorContext(ctx, "Failed to close runtime", "error", err)
 			}
@@ -75,14 +89,31 @@ type remoteBackend struct {
 	agentFileName string
 }
 
-func (b *remoteBackend) CreateRuntimeAndSession(ctx context.Context) (runtime.Runtime, *session.Session, func(), error) {
+func (b *remoteBackend) LoadTeamRequest() runtime.LoadTeamRequest {
+	// The server resolves its own source; ours is intentionally nil. The
+	// request still carries the user-level overrides so a future server
+	// can apply them server-side.
+	return b.flags.loadTeamRequest(nil)
+}
+
+func (b *remoteBackend) LoadTeam(context.Context, runtime.LoadTeamRequest) (*teamloader.LoadResult, error) {
+	// The server owns the team; no client-side load. Returning a nil
+	// LoadResult signals 'no client-side cleanup needed' to runOrExec.
+	return nil, nil
+}
+
+func (b *remoteBackend) CreateSessionRequest(workingDir string) runtime.CreateSessionRequest {
+	return b.flags.createSessionRequest(workingDir)
+}
+
+func (b *remoteBackend) CreateSession(ctx context.Context, _ *teamloader.LoadResult, req runtime.CreateSessionRequest) (runtime.Runtime, *session.Session, func(), error) {
 	client, err := runtime.NewClient(b.flags.remoteAddress)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to create remote client: %w", err)
 	}
 
 	sessTemplate := session.New(
-		session.WithToolsApproved(b.flags.autoApprove),
+		session.WithToolsApproved(req.ToolsApproved),
 	)
 
 	sess, err := client.CreateSession(ctx, sessTemplate)
@@ -91,14 +122,14 @@ func (b *remoteBackend) CreateRuntimeAndSession(ctx context.Context) (runtime.Ru
 	}
 
 	rt, err := runtime.NewRemoteRuntime(client,
-		runtime.WithRemoteCurrentAgent(b.flags.agentName),
+		runtime.WithRemoteCurrentAgent(req.AgentName),
 		runtime.WithRemoteAgentFilename(b.agentFileName),
 	)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to create remote runtime: %w", err)
 	}
 
-	slog.DebugContext(ctx, "Using remote runtime", "address", b.flags.remoteAddress, "agent", b.flags.agentName)
+	slog.DebugContext(ctx, "Using remote runtime", "address", b.flags.remoteAddress, "agent", req.AgentName)
 
 	cleanup := func() {
 		if err := rt.Close(); err != nil {

--- a/cmd/root/payload.go
+++ b/cmd/root/payload.go
@@ -2,42 +2,12 @@ package root
 
 import (
 	"github.com/docker/docker-agent/pkg/config"
-	"github.com/docker/docker-agent/pkg/permissions"
+	"github.com/docker/docker-agent/pkg/runtime"
 )
 
-// LoadTeamRequest is the typed input to a backend's team load. It carries
-// everything the team loader needs: the resolved agent source plus the
-// runtime config and the per-flag knobs the user supplied.
-//
-// Today only LocalBackend consumes it. The intent is that a future
-// RemoteBackend marshals the same struct over the wire so the server runs
-// teamloader.LoadWithConfig with identical inputs.
-type LoadTeamRequest struct {
-	Source         config.Source
-	ModelOverrides []string
-	PromptFiles    []string
-	RunConfig      *config.RuntimeConfig
-}
-
-// CreateSessionRequest is the typed input to a backend's session creation.
-// It carries the agent selection and every CLI-flag-driven session knob.
-//
-// The same forward-compatibility argument as LoadTeamRequest applies: this
-// is the payload a remote backend will eventually send over the wire.
-type CreateSessionRequest struct {
-	AgentName         string
-	ToolsApproved     bool
-	HideToolResults   bool
-	SessionDB         string
-	ResumeSessionID   string
-	SnapshotsEnabled  bool
-	GlobalPermissions *permissions.Checker
-	WorkingDir        string
-}
-
-// loadTeamRequest builds a LoadTeamRequest from the current flags.
-func (f *runExecFlags) loadTeamRequest(agentSource config.Source) LoadTeamRequest {
-	return LoadTeamRequest{
+// loadTeamRequest builds a runtime.LoadTeamRequest from the current flags.
+func (f *runExecFlags) loadTeamRequest(agentSource config.Source) runtime.LoadTeamRequest {
+	return runtime.LoadTeamRequest{
 		Source:         agentSource,
 		ModelOverrides: f.modelOverrides,
 		PromptFiles:    f.promptFiles,
@@ -45,10 +15,10 @@ func (f *runExecFlags) loadTeamRequest(agentSource config.Source) LoadTeamReques
 	}
 }
 
-// createSessionRequest builds a CreateSessionRequest from the current
-// flags and the supplied working directory.
-func (f *runExecFlags) createSessionRequest(workingDir string) CreateSessionRequest {
-	return CreateSessionRequest{
+// createSessionRequest builds a runtime.CreateSessionRequest from the
+// current flags and the supplied working directory.
+func (f *runExecFlags) createSessionRequest(workingDir string) runtime.CreateSessionRequest {
+	return runtime.CreateSessionRequest{
 		AgentName:         f.agentName,
 		ToolsApproved:     f.autoApprove,
 		HideToolResults:   f.hideToolResults,

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -413,12 +413,10 @@ func (f *runExecFlags) createLocalRuntimeAndSession(ctx context.Context, loadRes
 		sess.HideToolResults = req.HideToolResults
 
 		// Apply any stored model overrides from the session
-		if len(sess.AgentModelOverrides) > 0 {
-			if modelSwitcher := runtime.ModelSwitcherOf(localRt); modelSwitcher != nil {
-				for agentName, modelRef := range sess.AgentModelOverrides {
-					if err := modelSwitcher.SetAgentModel(ctx, agentName, modelRef); err != nil {
-						slog.WarnContext(ctx, "Failed to apply stored model override", "agent", agentName, "model", modelRef, "error", err)
-					}
+		if len(sess.AgentModelOverrides) > 0 && localRt.SupportsModelSwitching() {
+			for agentName, modelRef := range sess.AgentModelOverrides {
+				if err := localRt.SetAgentModel(ctx, agentName, modelRef); err != nil {
+					slog.WarnContext(ctx, "Failed to apply stored model override", "agent", agentName, "model", modelRef, "error", err)
 				}
 			}
 		}

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -303,7 +303,7 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 	return runTUI(ctx, rt, sess, b.Spawner(rt), cleanup, f.tuiOpts(), opts...)
 }
 
-func (f *runExecFlags) loadAgentFrom(ctx context.Context, req LoadTeamRequest) (*teamloader.LoadResult, error) {
+func (f *runExecFlags) loadAgentFrom(ctx context.Context, req runtime.LoadTeamRequest) (*teamloader.LoadResult, error) {
 	opts := []teamloader.Opt{
 		teamloader.WithModelOverrides(req.ModelOverrides),
 	}
@@ -360,7 +360,7 @@ func (f *runExecFlags) snapshotRuntimeOpts() ([]runtime.Opt, builtins.SnapshotCo
 	}, ctrl, nil
 }
 
-func (f *runExecFlags) createLocalRuntimeAndSession(ctx context.Context, loadResult *teamloader.LoadResult, req CreateSessionRequest) (runtime.Runtime, *session.Session, error) {
+func (f *runExecFlags) createLocalRuntimeAndSession(ctx context.Context, loadResult *teamloader.LoadResult, req runtime.CreateSessionRequest) (runtime.Runtime, *session.Session, error) {
 	t := loadResult.Team
 
 	// Merge user-level global permissions into the team's checker so the
@@ -511,7 +511,7 @@ func (f *runExecFlags) buildAppOpts(args []string) ([]app.Opt, error) {
 // buildSessionOpts returns the canonical set of session options derived from
 // CLI flags and agent configuration. Both the initial session and spawned
 // sessions use this method so their options never drift apart.
-func (f *runExecFlags) buildSessionOpts(agt *agent.Agent, req CreateSessionRequest) []session.Opt {
+func (f *runExecFlags) buildSessionOpts(agt *agent.Agent, req runtime.CreateSessionRequest) []session.Opt {
 	return []session.Opt{
 		session.WithMaxIterations(agt.MaxIterations()),
 		session.WithMaxConsecutiveToolCalls(agt.MaxConsecutiveToolCalls()),

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -263,12 +263,21 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 		return err
 	}
 
+	loadResult, err := b.LoadTeam(ctx, b.LoadTeamRequest())
+	if err != nil {
+		return err
+	}
+
 	if f.dryRun {
+		if loadResult != nil {
+			stopToolSets(loadResult.Team)
+		}
 		out.Println("Dry run mode enabled. Agent initialized but will not execute.")
 		return nil
 	}
 
-	rt, sess, cleanup, err := b.CreateRuntimeAndSession(ctx)
+	wd, _ := os.Getwd()
+	rt, sess, cleanup, err := b.CreateSession(ctx, loadResult, b.CreateSessionRequest(wd))
 	if err != nil {
 		return err
 	}

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -531,8 +531,11 @@ func (f *runExecFlags) createSessionSpawner(agentSource config.Source, sessStore
 		runConfigCopy := f.runConfig.Clone()
 		runConfigCopy.WorkingDir = workingDir
 
-		// Load team with the new working directory
-		loadResult, err := teamloader.LoadWithConfig(spawnCtx, agentSource, runConfigCopy, teamloader.WithModelOverrides(f.modelOverrides))
+		// Load team with the new working directory, honouring every flag the
+		// initial load already honours (model overrides AND prompt files).
+		loadReq := f.loadTeamRequest(agentSource)
+		loadReq.RunConfig = runConfigCopy
+		loadResult, err := f.loadAgentFrom(spawnCtx, loadReq)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -559,8 +562,7 @@ func (f *runExecFlags) createSessionSpawner(agentSource config.Source, sessStore
 		}
 
 		// Create a new session
-		wd := workingDir
-		spawnReq := f.createSessionRequest(wd)
+		spawnReq := f.createSessionRequest(workingDir)
 		spawnReq.AgentName = agt.Name()
 		newSess := session.New(f.buildSessionOpts(agt, spawnReq)...)
 

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -139,14 +139,12 @@ func New(ctx context.Context, rt runtime.Runtime, sess *session.Session, opts ..
 
 	// Subscribe to tool list changes so the sidebar updates immediately
 	// when an MCP server adds or removes tools (outside of a RunStream).
-	if tcs := runtime.ToolsChangeSubscriberOf(rt); tcs != nil {
-		tcs.OnToolsChanged(func(event runtime.Event) {
-			select {
-			case app.events <- event:
-			case <-ctx.Done():
-			}
-		})
-	}
+	rt.OnToolsChanged(func(event runtime.Event) {
+		select {
+		case app.events <- event:
+		case <-ctx.Done():
+		}
+	})
 
 	return app
 }

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -747,15 +747,13 @@ func (a *App) SwitchAgent(agentName string) error {
 // supported by the runtime (e.g., remote runtimes).
 // Pass an empty modelRef to clear the override and use the agent's default model.
 func (a *App) SetCurrentAgentModel(ctx context.Context, modelRef string) error {
-	modelSwitcher := runtime.ModelSwitcherOf(a.runtime)
-	if modelSwitcher == nil {
-		return errors.New("model switching not supported by this runtime")
-	}
-
 	agentName := a.runtime.CurrentAgentName()
 
 	// Set the model override on the runtime (empty modelRef clears the override)
-	if err := modelSwitcher.SetAgentModel(ctx, agentName, modelRef); err != nil {
+	if err := a.runtime.SetAgentModel(ctx, agentName, modelRef); err != nil {
+		if errors.Is(err, runtime.ErrUnsupported) {
+			return errors.New("model switching not supported by this runtime")
+		}
 		return err
 	}
 
@@ -795,11 +793,10 @@ func (a *App) SetCurrentAgentModel(ctx context.Context, modelRef string) error {
 // AvailableModels returns the list of models available for selection.
 // Returns nil if model switching is not supported.
 func (a *App) AvailableModels(ctx context.Context) []runtime.ModelChoice {
-	modelSwitcher := runtime.ModelSwitcherOf(a.runtime)
-	if modelSwitcher == nil {
+	if !a.runtime.SupportsModelSwitching() {
 		return nil
 	}
-	models := modelSwitcher.AvailableModels(ctx)
+	models := a.runtime.AvailableModels(ctx)
 
 	// Determine the currently active model for this agent
 	agentName := a.runtime.CurrentAgentName()
@@ -888,7 +885,7 @@ func (a *App) trackCustomModel(modelRef string) {
 
 // SupportsModelSwitching returns true if the runtime supports model switching.
 func (a *App) SupportsModelSwitching() bool {
-	return runtime.ModelSwitcherOf(a.runtime) != nil
+	return a.runtime.SupportsModelSwitching()
 }
 
 // ShouldExitAfterFirstResponse returns true if the app is configured to exit
@@ -957,15 +954,14 @@ func (a *App) applySessionModelOverrides(ctx context.Context, sess *session.Sess
 	}
 
 	// Check if runtime supports model switching
-	modelSwitcher := runtime.ModelSwitcherOf(a.runtime)
-	if modelSwitcher == nil {
+	if !a.runtime.SupportsModelSwitching() {
 		slog.DebugContext(ctx, "Runtime does not support model switching, skipping overrides")
 		return
 	}
 
 	slog.DebugContext(ctx, "Applying model overrides from session", "session_id", sess.ID, "overrides", sess.AgentModelOverrides)
 	for agentName, modelRef := range sess.AgentModelOverrides {
-		if err := modelSwitcher.SetAgentModel(ctx, agentName, modelRef); err != nil {
+		if err := a.runtime.SetAgentModel(ctx, agentName, modelRef); err != nil {
 			// Log but don't fail - the session can still be used with default models
 			slog.WarnContext(ctx, "Failed to apply model override from session", "agent", agentName, "model", modelRef, "error", err)
 			a.events <- runtime.Warning(fmt.Sprintf("Failed to apply model override for agent %q: %v", agentName, err), agentName)

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -82,6 +82,11 @@ func (m *mockRuntime) Stop()                                     {}
 func (m *mockRuntime) Steer(_ runtime.QueuedMessage) error       { return nil }
 func (m *mockRuntime) FollowUp(_ runtime.QueuedMessage) error    { return nil }
 func (m *mockRuntime) TogglePause(context.Context) (bool, error) { return false, nil }
+func (m *mockRuntime) SetAgentModel(context.Context, string, string) error {
+	return nil
+}
+func (m *mockRuntime) AvailableModels(context.Context) []runtime.ModelChoice { return nil }
+func (m *mockRuntime) SupportsModelSwitching() bool                          { return false }
 
 // Verify mockRuntime implements runtime.Runtime
 var _ runtime.Runtime = (*mockRuntime)(nil)

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -87,6 +87,7 @@ func (m *mockRuntime) SetAgentModel(context.Context, string, string) error {
 }
 func (m *mockRuntime) AvailableModels(context.Context) []runtime.ModelChoice { return nil }
 func (m *mockRuntime) SupportsModelSwitching() bool                          { return false }
+func (m *mockRuntime) OnToolsChanged(func(runtime.Event))                    {}
 
 // Verify mockRuntime implements runtime.Runtime
 var _ runtime.Runtime = (*mockRuntime)(nil)

--- a/pkg/cli/runner_test.go
+++ b/pkg/cli/runner_test.go
@@ -68,6 +68,7 @@ func (m *mockRuntime) TogglePause(context.Context) (bool, error)                
 func (m *mockRuntime) SetAgentModel(context.Context, string, string) error                   { return nil }
 func (m *mockRuntime) AvailableModels(context.Context) []runtime.ModelChoice                 { return nil }
 func (m *mockRuntime) SupportsModelSwitching() bool                                          { return false }
+func (m *mockRuntime) OnToolsChanged(func(runtime.Event))                                    {}
 func (m *mockRuntime) RegenerateTitle(context.Context, *session.Session, chan runtime.Event) {}
 
 func (m *mockRuntime) Resume(_ context.Context, req runtime.ResumeRequest) {

--- a/pkg/cli/runner_test.go
+++ b/pkg/cli/runner_test.go
@@ -65,6 +65,9 @@ func (m *mockRuntime) Close() error                                             
 func (m *mockRuntime) Steer(runtime.QueuedMessage) error                                     { return nil }
 func (m *mockRuntime) FollowUp(runtime.QueuedMessage) error                                  { return nil }
 func (m *mockRuntime) TogglePause(context.Context) (bool, error)                             { return false, nil }
+func (m *mockRuntime) SetAgentModel(context.Context, string, string) error                   { return nil }
+func (m *mockRuntime) AvailableModels(context.Context) []runtime.ModelChoice                 { return nil }
+func (m *mockRuntime) SupportsModelSwitching() bool                                          { return false }
 func (m *mockRuntime) RegenerateTitle(context.Context, *session.Session, chan runtime.Event) {}
 
 func (m *mockRuntime) Resume(_ context.Context, req runtime.ResumeRequest) {

--- a/pkg/runtime/capabilities.go
+++ b/pkg/runtime/capabilities.go
@@ -1,1 +1,0 @@
-package runtime

--- a/pkg/runtime/capabilities.go
+++ b/pkg/runtime/capabilities.go
@@ -1,8 +1,1 @@
 package runtime
-
-// ToolsChangeSubscriberOf returns the runtime as a ToolsChangeSubscriber,
-// or nil if it doesn't emit tool-change notifications.
-func ToolsChangeSubscriberOf(r Runtime) ToolsChangeSubscriber {
-	tcs, _ := r.(ToolsChangeSubscriber)
-	return tcs
-}

--- a/pkg/runtime/capabilities.go
+++ b/pkg/runtime/capabilities.go
@@ -1,12 +1,5 @@
 package runtime
 
-// ModelSwitcherOf returns the runtime as a ModelSwitcher, or nil if it
-// doesn't support model switching.
-func ModelSwitcherOf(r Runtime) ModelSwitcher {
-	ms, _ := r.(ModelSwitcher)
-	return ms
-}
-
 // ToolsChangeSubscriberOf returns the runtime as a ToolsChangeSubscriber,
 // or nil if it doesn't emit tool-change notifications.
 func ToolsChangeSubscriberOf(r Runtime) ToolsChangeSubscriber {

--- a/pkg/runtime/commands_test.go
+++ b/pkg/runtime/commands_test.go
@@ -77,6 +77,7 @@ func (m *mockRuntime) TogglePause(context.Context) (bool, error)           { ret
 func (m *mockRuntime) SetAgentModel(context.Context, string, string) error { return nil }
 func (m *mockRuntime) AvailableModels(context.Context) []ModelChoice       { return nil }
 func (m *mockRuntime) SupportsModelSwitching() bool                        { return false }
+func (m *mockRuntime) OnToolsChanged(func(Event))                          {}
 
 func (m *mockRuntime) RegenerateTitle(context.Context, *session.Session, chan Event) {
 }

--- a/pkg/runtime/commands_test.go
+++ b/pkg/runtime/commands_test.go
@@ -69,11 +69,14 @@ func (m *mockRuntime) ExecuteMCPPrompt(context.Context, string, map[string]strin
 func (m *mockRuntime) UpdateSessionTitle(context.Context, *session.Session, string) error {
 	return nil
 }
-func (m *mockRuntime) TitleGenerator() *sessiontitle.Generator   { return nil }
-func (m *mockRuntime) Close() error                              { return nil }
-func (m *mockRuntime) Steer(QueuedMessage) error                 { return nil }
-func (m *mockRuntime) FollowUp(QueuedMessage) error              { return nil }
-func (m *mockRuntime) TogglePause(context.Context) (bool, error) { return false, nil }
+func (m *mockRuntime) TitleGenerator() *sessiontitle.Generator             { return nil }
+func (m *mockRuntime) Close() error                                        { return nil }
+func (m *mockRuntime) Steer(QueuedMessage) error                           { return nil }
+func (m *mockRuntime) FollowUp(QueuedMessage) error                        { return nil }
+func (m *mockRuntime) TogglePause(context.Context) (bool, error)           { return false, nil }
+func (m *mockRuntime) SetAgentModel(context.Context, string, string) error { return nil }
+func (m *mockRuntime) AvailableModels(context.Context) []ModelChoice       { return nil }
+func (m *mockRuntime) SupportsModelSwitching() bool                        { return false }
 
 func (m *mockRuntime) RegenerateTitle(context.Context, *session.Session, chan Event) {
 }

--- a/pkg/runtime/model_switcher.go
+++ b/pkg/runtime/model_switcher.go
@@ -61,22 +61,6 @@ type ModelChoice struct {
 	OutputModalities []string
 }
 
-// ModelSwitcher is an optional interface for runtimes that support changing the model
-// for the current agent at runtime. This is used by the TUI for model switching.
-type ModelSwitcher interface {
-	// SetAgentModel sets a model override for the specified agent.
-	// modelRef can be:
-	// - "" (empty) to clear the override and use the agent's default model
-	// - A model name from the config (e.g., "my_fast_model")
-	// - An inline model spec (e.g., "openai/gpt-4o")
-	SetAgentModel(ctx context.Context, agentName, modelRef string) error
-
-	// AvailableModels returns the list of models available for selection.
-	// This includes all models defined in the config, with the current agent's
-	// default model marked as IsDefault.
-	AvailableModels(ctx context.Context) []ModelChoice
-}
-
 // ModelSwitcherConfig holds the configuration needed for model switching.
 // This is populated by the app layer when creating the runtime.
 type ModelSwitcherConfig struct {
@@ -92,10 +76,17 @@ type ModelSwitcherConfig struct {
 	AgentDefaultModels map[string]string
 }
 
-// SetAgentModel implements ModelSwitcher for LocalRuntime.
+// SetAgentModel implements [Runtime.SetAgentModel] for LocalRuntime.
 func (r *LocalRuntime) SetAgentModel(ctx context.Context, agentName, modelRef string) error {
 	_, err := r.setAgentModelInternal(ctx, agentName, modelRef)
 	return err
+}
+
+// SupportsModelSwitching reports whether the runtime was built with a
+// [ModelSwitcherConfig], i.e. whether [SetAgentModel] / [AvailableModels]
+// will return real data instead of the no-config empty path.
+func (r *LocalRuntime) SupportsModelSwitching() bool {
+	return r.modelSwitcherCfg != nil
 }
 
 // setAgentModelInternal applies modelRef as the agent's model override and
@@ -291,7 +282,7 @@ func (r *LocalRuntime) resolveModelRefs(ctx context.Context, commaSeparatedRefs 
 	return providers, nil
 }
 
-// AvailableModels implements ModelSwitcher for LocalRuntime.
+// AvailableModels implements [Runtime.AvailableModels] for LocalRuntime.
 func (r *LocalRuntime) AvailableModels(ctx context.Context) []ModelChoice {
 	if r.modelSwitcherCfg == nil {
 		return nil
@@ -572,6 +563,3 @@ func WithModelSwitcherConfig(cfg *ModelSwitcherConfig) Opt {
 		r.modelSwitcherCfg = cfg
 	}
 }
-
-// Ensure LocalRuntime implements ModelSwitcher
-var _ ModelSwitcher = (*LocalRuntime)(nil)

--- a/pkg/runtime/payload.go
+++ b/pkg/runtime/payload.go
@@ -12,11 +12,17 @@ import (
 // LocalBackend consumes this struct directly. The same struct is the
 // payload a future RemoteBackend marshals over the wire so the server
 // runs teamloader.LoadWithConfig with identical inputs.
+//
+// JSON tags reflect the wire contract being designed. Fields that don't
+// yet have a wire-friendly representation (the Source interface, the
+// RuntimeConfig with its embedded sync.Mutex and environment.Provider)
+// are tagged json:"-" until they get one. Round-trip tests live in
+// payload_test.go.
 type LoadTeamRequest struct {
-	Source         config.Source
-	ModelOverrides []string
-	PromptFiles    []string
-	RunConfig      *config.RuntimeConfig
+	Source         config.Source         `json:"-"`
+	ModelOverrides []string              `json:"model_overrides,omitempty"`
+	PromptFiles    []string              `json:"prompt_files,omitempty"`
+	RunConfig      *config.RuntimeConfig `json:"-"`
 }
 
 // CreateSessionRequest is the typed input to a backend's session creation.
@@ -24,13 +30,17 @@ type LoadTeamRequest struct {
 //
 // The same forward-compatibility argument as LoadTeamRequest applies: this
 // is the payload a remote backend will eventually send over the wire.
+//
+// GlobalPermissions is currently json:"-" (the permissions.Checker is an
+// opaque struct without a wire form yet); it'll get a serializable
+// representation in a follow-up.
 type CreateSessionRequest struct {
-	AgentName         string
-	ToolsApproved     bool
-	HideToolResults   bool
-	SessionDB         string
-	ResumeSessionID   string
-	SnapshotsEnabled  bool
-	GlobalPermissions *permissions.Checker
-	WorkingDir        string
+	AgentName         string               `json:"agent_name,omitempty"`
+	ToolsApproved     bool                 `json:"tools_approved,omitempty"`
+	HideToolResults   bool                 `json:"hide_tool_results,omitempty"`
+	SessionDB         string               `json:"session_db,omitempty"`
+	ResumeSessionID   string               `json:"resume_session_id,omitempty"`
+	SnapshotsEnabled  bool                 `json:"snapshots_enabled,omitempty"`
+	GlobalPermissions *permissions.Checker `json:"-"`
+	WorkingDir        string               `json:"working_dir,omitempty"`
 }

--- a/pkg/runtime/payload.go
+++ b/pkg/runtime/payload.go
@@ -1,0 +1,36 @@
+package runtime
+
+import (
+	"github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/permissions"
+)
+
+// LoadTeamRequest is the typed input to a backend's team load. It carries
+// everything the team loader needs: the resolved agent source plus the
+// runtime config and the per-flag knobs the user supplied.
+//
+// LocalBackend consumes this struct directly. The same struct is the
+// payload a future RemoteBackend marshals over the wire so the server
+// runs teamloader.LoadWithConfig with identical inputs.
+type LoadTeamRequest struct {
+	Source         config.Source
+	ModelOverrides []string
+	PromptFiles    []string
+	RunConfig      *config.RuntimeConfig
+}
+
+// CreateSessionRequest is the typed input to a backend's session creation.
+// It carries the agent selection and every CLI-flag-driven session knob.
+//
+// The same forward-compatibility argument as LoadTeamRequest applies: this
+// is the payload a remote backend will eventually send over the wire.
+type CreateSessionRequest struct {
+	AgentName         string
+	ToolsApproved     bool
+	HideToolResults   bool
+	SessionDB         string
+	ResumeSessionID   string
+	SnapshotsEnabled  bool
+	GlobalPermissions *permissions.Checker
+	WorkingDir        string
+}

--- a/pkg/runtime/payload.go
+++ b/pkg/runtime/payload.go
@@ -31,16 +31,22 @@ type LoadTeamRequest struct {
 // The same forward-compatibility argument as LoadTeamRequest applies: this
 // is the payload a remote backend will eventually send over the wire.
 //
+// Boolean fields intentionally do NOT use `omitempty`. With `omitempty`,
+// an explicit `false` is wire-indistinguishable from "unset", so a future
+// server-side default flip from `false` to `true` would silently change
+// the semantics for clients that omitted the field on purpose. Always
+// serialising the boolean keeps the sender's choice authoritative.
+//
 // GlobalPermissions is currently json:"-" (the permissions.Checker is an
 // opaque struct without a wire form yet); it'll get a serializable
 // representation in a follow-up.
 type CreateSessionRequest struct {
 	AgentName         string               `json:"agent_name,omitempty"`
-	ToolsApproved     bool                 `json:"tools_approved,omitempty"`
-	HideToolResults   bool                 `json:"hide_tool_results,omitempty"`
+	ToolsApproved     bool                 `json:"tools_approved"`
+	HideToolResults   bool                 `json:"hide_tool_results"`
 	SessionDB         string               `json:"session_db,omitempty"`
 	ResumeSessionID   string               `json:"resume_session_id,omitempty"`
-	SnapshotsEnabled  bool                 `json:"snapshots_enabled,omitempty"`
+	SnapshotsEnabled  bool                 `json:"snapshots_enabled"`
 	GlobalPermissions *permissions.Checker `json:"-"`
 	WorkingDir        string               `json:"working_dir,omitempty"`
 }

--- a/pkg/runtime/payload_test.go
+++ b/pkg/runtime/payload_test.go
@@ -73,9 +73,34 @@ func TestCreateSessionRequest_RoundTrip(t *testing.T) {
 func TestCreateSessionRequest_OmitsEmptyFields(t *testing.T) {
 	t.Parallel()
 
+	// Boolean fields are always serialized (no `omitempty`) so that an
+	// explicit `false` survives the wire round-trip and stays distinct
+	// from "unset" semantics owned by the server. String fields with
+	// `omitempty` still drop out of the empty case.
 	data, err := json.Marshal(CreateSessionRequest{})
 	require.NoError(t, err)
-	assert.JSONEq(t, `{}`, string(data))
+	assert.JSONEq(t, `{"tools_approved":false,"hide_tool_results":false,"snapshots_enabled":false}`, string(data))
+}
+
+func TestCreateSessionRequest_PreservesExplicitFalseOnTheWire(t *testing.T) {
+	t.Parallel()
+
+	// Pins the contract that `omitempty` on booleans is intentionally
+	// absent: a client sending an explicit `false` must reach the
+	// server as `false`, not as the field's absence. If the server's
+	// default ever flips to `true`, this guarantee keeps existing
+	// clients' "no, really, false" intact.
+	in := CreateSessionRequest{
+		AgentName:        "main",
+		ToolsApproved:    false,
+		HideToolResults:  false,
+		SnapshotsEnabled: false,
+	}
+	data, err := json.Marshal(in)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"tools_approved":false`)
+	assert.Contains(t, string(data), `"hide_tool_results":false`)
+	assert.Contains(t, string(data), `"snapshots_enabled":false`)
 }
 
 func TestCreateSessionRequest_NonSerializableFieldsExcluded(t *testing.T) {

--- a/pkg/runtime/payload_test.go
+++ b/pkg/runtime/payload_test.go
@@ -1,0 +1,88 @@
+package runtime
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadTeamRequest_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	in := LoadTeamRequest{
+		ModelOverrides: []string{"openai/gpt-4o", "anthropic/claude-3-5-sonnet-20240620"},
+		PromptFiles:    []string{"prompts/role.md", "prompts/tone.md"},
+	}
+
+	data, err := json.Marshal(in)
+	require.NoError(t, err)
+
+	var out LoadTeamRequest
+	require.NoError(t, json.Unmarshal(data, &out))
+
+	assert.Equal(t, in.ModelOverrides, out.ModelOverrides)
+	assert.Equal(t, in.PromptFiles, out.PromptFiles)
+}
+
+func TestLoadTeamRequest_OmitsEmptyFields(t *testing.T) {
+	t.Parallel()
+
+	data, err := json.Marshal(LoadTeamRequest{})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{}`, string(data))
+}
+
+func TestLoadTeamRequest_NonSerializableFieldsExcluded(t *testing.T) {
+	t.Parallel()
+
+	// Source and RunConfig are intentionally json:"-" because they don't
+	// have a wire form yet. This test pins that contract so a future
+	// edit that adds a tag without designing a wire shape gets caught.
+	data, err := json.Marshal(LoadTeamRequest{
+		ModelOverrides: []string{"x"},
+	})
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "source")
+	assert.NotContains(t, string(data), "run_config")
+}
+
+func TestCreateSessionRequest_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	in := CreateSessionRequest{
+		AgentName:        "main",
+		ToolsApproved:    true,
+		HideToolResults:  true,
+		SessionDB:        "/tmp/sessions.db",
+		ResumeSessionID:  "01HF8...",
+		SnapshotsEnabled: true,
+		WorkingDir:       "/tmp/work",
+	}
+
+	data, err := json.Marshal(in)
+	require.NoError(t, err)
+
+	var out CreateSessionRequest
+	require.NoError(t, json.Unmarshal(data, &out))
+
+	assert.Equal(t, in, out)
+}
+
+func TestCreateSessionRequest_OmitsEmptyFields(t *testing.T) {
+	t.Parallel()
+
+	data, err := json.Marshal(CreateSessionRequest{})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{}`, string(data))
+}
+
+func TestCreateSessionRequest_NonSerializableFieldsExcluded(t *testing.T) {
+	t.Parallel()
+
+	// GlobalPermissions has no wire form yet.
+	data, err := json.Marshal(CreateSessionRequest{AgentName: "x"})
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "global_permissions")
+}

--- a/pkg/runtime/remote_contract_test.go
+++ b/pkg/runtime/remote_contract_test.go
@@ -1,0 +1,87 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/api"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+// stubRemoteClient is a RemoteClient that returns enough state for the
+// non-streaming Runtime contract to exercise RemoteRuntime end-to-end.
+//
+// Methods used only by streaming paths (RunAgent, RunAgentWithAgentName,
+// CreateSession) panic so an accidental wiring against them is loud
+// rather than silent.
+type stubRemoteClient struct {
+	cfg *latest.Config
+}
+
+func (s *stubRemoteClient) GetAgent(context.Context, string) (*latest.Config, error) {
+	return s.cfg, nil
+}
+
+func (s *stubRemoteClient) CreateSession(context.Context, *session.Session) (*session.Session, error) {
+	panic("CreateSession not exercised by the contract test")
+}
+
+func (s *stubRemoteClient) ResumeSession(context.Context, string, string, string, string) error {
+	return nil
+}
+
+func (s *stubRemoteClient) ResumeElicitation(context.Context, string, tools.ElicitationAction, map[string]any) error {
+	return nil
+}
+
+func (s *stubRemoteClient) RunAgent(context.Context, string, string, []api.Message) (<-chan Event, error) {
+	panic("RunAgent not exercised by the contract test")
+}
+
+func (s *stubRemoteClient) RunAgentWithAgentName(context.Context, string, string, string, []api.Message) (<-chan Event, error) {
+	panic("RunAgentWithAgentName not exercised by the contract test")
+}
+
+func (s *stubRemoteClient) SteerSession(context.Context, string, []api.Message) error {
+	return nil
+}
+
+func (s *stubRemoteClient) FollowUpSession(context.Context, string, []api.Message) error {
+	return nil
+}
+
+func (s *stubRemoteClient) UpdateSessionTitle(context.Context, string, string) error {
+	return nil
+}
+
+func (s *stubRemoteClient) GetAgentToolCount(context.Context, string, string) (int, error) {
+	return 0, nil
+}
+
+// TestRemoteRuntime_Contract runs the same surface contract LocalRuntime
+// passes against a RemoteRuntime backed by a stub client. Any silent
+// no-op on RemoteRuntime that the contract considers a failure surfaces
+// here as a red test rather than a runtime user complaint.
+func TestRemoteRuntime_Contract(t *testing.T) {
+	runRuntimeContract(t, func(t *testing.T) Runtime {
+		t.Helper()
+		client := &stubRemoteClient{
+			cfg: &latest.Config{
+				Agents: latest.Agents{
+					{Name: "test", Description: "test agent"},
+				},
+			},
+		}
+		rt, err := NewRemoteRuntime(client)
+		require.NoError(t, err)
+
+		// Seed a session ID so Steer / FollowUp / Resume / ResumeElicitation
+		// reach the (stubbed) client instead of returning "no active session".
+		rt.sessionID = "test-session"
+		return rt
+	})
+}

--- a/pkg/runtime/remote_contract_test.go
+++ b/pkg/runtime/remote_contract_test.go
@@ -2,8 +2,10 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/api"
@@ -19,10 +21,14 @@ import (
 // CreateSession) panic so an accidental wiring against them is loud
 // rather than silent.
 type stubRemoteClient struct {
-	cfg *latest.Config
+	cfg      *latest.Config
+	getAgent func(context.Context, string) (*latest.Config, error)
 }
 
-func (s *stubRemoteClient) GetAgent(context.Context, string) (*latest.Config, error) {
+func (s *stubRemoteClient) GetAgent(ctx context.Context, id string) (*latest.Config, error) {
+	if s.getAgent != nil {
+		return s.getAgent(ctx, id)
+	}
 	return s.cfg, nil
 }
 
@@ -84,4 +90,27 @@ func TestRemoteRuntime_Contract(t *testing.T) {
 		rt.sessionID = "test-session"
 		return rt
 	})
+}
+
+// TestRemoteRuntime_SetCurrentAgent_PropagatesClientError pins the
+// fixed behaviour reviewers flagged: when GetAgent fails (network,
+// auth, missing remote config), SetCurrentAgent must NOT silently
+// accept the name. That would re-introduce the silent-gap pattern the
+// PR set out to close.
+func TestRemoteRuntime_SetCurrentAgent_PropagatesClientError(t *testing.T) {
+	t.Parallel()
+
+	want := errors.New("boom: network unreachable")
+	client := &stubRemoteClient{
+		getAgent: func(context.Context, string) (*latest.Config, error) {
+			return nil, want
+		},
+	}
+	rt, err := NewRemoteRuntime(client)
+	require.NoError(t, err)
+
+	err = rt.SetCurrentAgent("anything")
+	require.Error(t, err)
+	require.ErrorIs(t, err, want)
+	assert.Empty(t, rt.currentAgent, "currentAgent must not be mutated when validation fails")
 }

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -133,10 +133,12 @@ func (r *RemoteRuntime) SetCurrentAgent(agentName string) error {
 	return nil
 }
 
-// CurrentAgentTools returns the tools for the current agent.
-// For remote runtime, this returns nil as tools are managed server-side.
+// CurrentAgentTools is not exposed by the remote wire protocol today.
+// The server has the real list; the client cannot enumerate it. Return
+// ErrUnsupported so callers (TUI tools dialog, programmatic introspection)
+// can show an explanatory message instead of a silently-empty list.
 func (r *RemoteRuntime) CurrentAgentTools(_ context.Context) ([]tools.Tool, error) {
-	return nil, nil
+	return nil, fmt.Errorf("list tools: %w", ErrUnsupported)
 }
 
 // CurrentAgentToolsetStatuses is not implemented for remote runtimes; the
@@ -307,10 +309,13 @@ func (r *RemoteRuntime) Resume(ctx context.Context, req ResumeRequest) {
 	}
 }
 
-// Summarize generates a summary for the session
-func (r *RemoteRuntime) Summarize(_ context.Context, sess *session.Session, _ string, events chan Event) {
+// Summarize is not yet supported on remote runtimes. Emit an Error
+// event so the TUI surfaces a clear failure instead of persisting a
+// bogus "not yet implemented" SessionSummary into the session store
+// (the persistence observer writes every SessionSummaryEvent unchanged).
+func (r *RemoteRuntime) Summarize(_ context.Context, _ *session.Session, _ string, events chan Event) {
 	slog.Debug("Summarize not yet implemented for remote runtime", "session_id", r.sessionID)
-	events <- SessionSummary(sess.ID, "Summary generation not yet implemented for remote runtime", r.currentAgent, 0)
+	events <- Error(fmt.Sprintf("summarize: %s", ErrUnsupported))
 }
 
 func (r *RemoteRuntime) convertSessionMessages(sess *session.Session) []api.Message {

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -574,6 +574,11 @@ func (r *RemoteRuntime) SupportsModelSwitching() bool {
 	return false
 }
 
+// OnToolsChanged is a no-op for remote runtimes; tool-list changes are
+// observed server-side and surface through the run-stream events rather
+// than via an out-of-band callback.
+func (r *RemoteRuntime) OnToolsChanged(func(Event)) {}
+
 // Close is a no-op for remote runtimes.
 func (r *RemoteRuntime) Close() error {
 	return nil

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -113,20 +113,24 @@ func (r *RemoteRuntime) CurrentAgentInfo(ctx context.Context) CurrentAgentInfo {
 
 // SetCurrentAgent sets the currently active agent for subsequent user messages.
 // It validates the name against the remote team config; an unknown agent is
-// rejected so callers see the same behaviour as LocalRuntime.
+// rejected so callers see the same behaviour as LocalRuntime. A failure to
+// fetch the team config (network error, auth failure, missing remote) is
+// propagated rather than silently accepted — the whole point of this check
+// is closing that silent-breakage gap.
 func (r *RemoteRuntime) SetCurrentAgent(agentName string) error {
 	cfg, err := r.client.GetAgent(context.Background(), r.agentFilename)
-	if err == nil {
-		found := false
-		for _, a := range cfg.Agents {
-			if a.Name == agentName {
-				found = true
-				break
-			}
+	if err != nil {
+		return fmt.Errorf("validate agent %q against remote team: %w", agentName, err)
+	}
+	found := false
+	for _, a := range cfg.Agents {
+		if a.Name == agentName {
+			found = true
+			break
 		}
-		if !found {
-			return fmt.Errorf("agent %q not found in remote team", agentName)
-		}
+	}
+	if !found {
+		return fmt.Errorf("agent %q not found in remote team", agentName)
 	}
 	r.currentAgent = agentName
 	slog.Debug("Switched current agent (remote)", "agent", agentName)

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -557,6 +557,23 @@ func (r *RemoteRuntime) TogglePause(context.Context) (bool, error) {
 	return false, fmt.Errorf("pause: %w", ErrUnsupported)
 }
 
+// SetAgentModel is not yet supported on remote runtimes; the server owns
+// the model selection.
+func (r *RemoteRuntime) SetAgentModel(context.Context, string, string) error {
+	return fmt.Errorf("set agent model: %w", ErrUnsupported)
+}
+
+// AvailableModels is not yet supported on remote runtimes; the wire
+// protocol cannot enumerate the models the server has access to.
+func (r *RemoteRuntime) AvailableModels(context.Context) []ModelChoice {
+	return nil
+}
+
+// SupportsModelSwitching is false for remote runtimes.
+func (r *RemoteRuntime) SupportsModelSwitching() bool {
+	return false
+}
+
 // Close is a no-op for remote runtimes.
 func (r *RemoteRuntime) Close() error {
 	return nil

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -111,8 +111,23 @@ func (r *RemoteRuntime) CurrentAgentInfo(ctx context.Context) CurrentAgentInfo {
 	}
 }
 
-// SetCurrentAgent sets the currently active agent for subsequent user messages
+// SetCurrentAgent sets the currently active agent for subsequent user messages.
+// It validates the name against the remote team config; an unknown agent is
+// rejected so callers see the same behaviour as LocalRuntime.
 func (r *RemoteRuntime) SetCurrentAgent(agentName string) error {
+	cfg, err := r.client.GetAgent(context.Background(), r.agentFilename)
+	if err == nil {
+		found := false
+		for _, a := range cfg.Agents {
+			if a.Name == agentName {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("agent %q not found in remote team", agentName)
+		}
+	}
 	r.currentAgent = agentName
 	slog.Debug("Switched current agent (remote)", "agent", agentName)
 	return nil

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -107,6 +107,26 @@ type Runtime interface {
 	// gets a full undivided agent turn. Returns an error if the queue is full.
 	FollowUp(msg QueuedMessage) error
 
+	// SetAgentModel sets a model override for the named agent.
+	// modelRef can be:
+	//   - "" (empty) to clear the override and use the agent's default model
+	//   - A model name from the config (e.g., "my_fast_model")
+	//   - An inline spec (e.g., "openai/gpt-4o")
+	// Returns [ErrUnsupported] for runtimes that don't expose model
+	// switching (e.g. remote runtimes, where the server owns the choice).
+	SetAgentModel(ctx context.Context, agentName, modelRef string) error
+
+	// AvailableModels returns the models the user can pick from in the
+	// /model picker. Returns nil for runtimes that don't expose model
+	// switching; see SupportsModelSwitching for a cheap pre-check.
+	AvailableModels(ctx context.Context) []ModelChoice
+
+	// SupportsModelSwitching reports whether SetAgentModel and
+	// AvailableModels are wired for this runtime. Use it to gate UI
+	// affordances (e.g. show /model in the menu) without paying the
+	// cost of AvailableModels.
+	SupportsModelSwitching() bool
+
 	// TogglePause toggles whether the run loop is paused at iteration
 	// boundaries. Returns the new state (true if now paused). Returns
 	// [ErrUnsupported] for runtimes that don't expose pause control.

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -127,6 +127,12 @@ type Runtime interface {
 	// cost of AvailableModels.
 	SupportsModelSwitching() bool
 
+	// OnToolsChanged registers a handler invoked outside of any RunStream
+	// when a toolset reports a tool list change (e.g. after an MCP
+	// ToolListChanged notification). Runtimes that don't emit such events
+	// can implement this as a no-op.
+	OnToolsChanged(handler func(Event))
+
 	// TogglePause toggles whether the run loop is paused at iteration
 	// boundaries. Returns the new state (true if now paused). Returns
 	// [ErrUnsupported] for runtimes that don't expose pause control.
@@ -152,15 +158,6 @@ type CurrentAgentInfo struct {
 type ModelStore interface {
 	GetModel(ctx context.Context, modelID string) (*modelsdev.Model, error)
 	GetDatabase(ctx context.Context) (*modelsdev.Database, error)
-}
-
-// ToolsChangeSubscriber is implemented by runtimes that can notify when
-// toolsets report a change in their tool list (e.g. after an MCP
-// ToolListChanged notification). The provided callback is invoked
-// outside of any RunStream, so the UI can update the tool count
-// immediately.
-type ToolsChangeSubscriber interface {
-	OnToolsChanged(handler func(Event))
 }
 
 // LocalRuntime manages the execution of agents

--- a/pkg/runtime/wire/server.go
+++ b/pkg/runtime/wire/server.go
@@ -1,0 +1,110 @@
+// Package wire is the (work-in-progress) HTTP transport for
+// pkg/runtime. It exposes the [runtime.LoadTeamRequest] and
+// [runtime.CreateSessionRequest] payloads as JSON-over-HTTP endpoints
+// so a future docker-agent server process can host the same backend a
+// docker-agent CLI process today drives in-process.
+//
+// Today the package contains only the server-side decode/encode
+// scaffolding plus an in-process round-trip test. There is no client
+// (a future commit adds wire.Client driving runtime.RemoteRuntime),
+// no streaming endpoint (a future commit adds /v1/session/run), and
+// no authentication (deliberately out of scope for the scaffold).
+package wire
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/docker/docker-agent/pkg/runtime"
+)
+
+// LoadTeamResponse summarises the result of a LoadTeam call. It carries
+// the bare minimum a client needs to tell the user 'the team loaded;
+// here are the agents you can talk to'. The server-side LoadResult
+// itself is intentionally NOT returned: it holds live toolset handles
+// the client cannot use.
+type LoadTeamResponse struct {
+	AgentNames   []string `json:"agent_names,omitempty"`
+	DefaultAgent string   `json:"default_agent,omitempty"`
+}
+
+// CreateSessionResponse identifies a freshly created session. The
+// session document itself comes back later via the (yet-to-be-added)
+// /v1/session/run streaming endpoint.
+type CreateSessionResponse struct {
+	SessionID string `json:"session_id"`
+}
+
+// Backend is the surface a wire.Server expects. It is the wire-side
+// mirror of cmd/root.backend without the cleanup-closure return values
+// — those are owned server-side and don't cross the wire.
+type Backend interface {
+	LoadTeam(ctx context.Context, req runtime.LoadTeamRequest) (LoadTeamResponse, error)
+	CreateSession(ctx context.Context, req runtime.CreateSessionRequest) (CreateSessionResponse, error)
+}
+
+// NewHandler returns an http.Handler that decodes the JSON request
+// payloads, dispatches to b, and JSON-encodes the response.
+//
+// Routes (subject to versioning under /v1/):
+//   - POST /v1/team/load     -> Backend.LoadTeam
+//   - POST /v1/session/create -> Backend.CreateSession
+func NewHandler(b Backend) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v1/team/load", func(w http.ResponseWriter, r *http.Request) {
+		var req runtime.LoadTeamRequest
+		if err := decodeJSON(r, &req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		resp, err := b.LoadTeam(r.Context(), req)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, resp)
+	})
+	mux.HandleFunc("POST /v1/session/create", func(w http.ResponseWriter, r *http.Request) {
+		var req runtime.CreateSessionRequest
+		if err := decodeJSON(r, &req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		resp, err := b.CreateSession(r.Context(), req)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, resp)
+	})
+	return mux
+}
+
+func decodeJSON(r *http.Request, v any) error {
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	return dec.Decode(v)
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		slog.Error("wire: encode response", "error", err)
+	}
+}
+
+// writeError translates errors into status codes. ErrUnsupported maps
+// to 501 so a client driving RemoteRuntime can surface a clear
+// 'feature not supported by the server' message; everything else
+// becomes 500.
+func writeError(w http.ResponseWriter, err error) {
+	status := http.StatusInternalServerError
+	if errors.Is(err, runtime.ErrUnsupported) {
+		status = http.StatusNotImplemented
+	}
+	http.Error(w, err.Error(), status)
+}

--- a/pkg/runtime/wire/server.go
+++ b/pkg/runtime/wire/server.go
@@ -46,6 +46,14 @@ type Backend interface {
 	CreateSession(ctx context.Context, req runtime.CreateSessionRequest) (CreateSessionResponse, error)
 }
 
+// maxRequestBodyBytes caps the JSON payload size each HTTP handler will
+// read before failing the request. The cap exists purely to keep an
+// unbounded body from being read into memory; the largest legitimate
+// request today (CreateSessionRequest) is a few dozen bytes, so 1 MiB
+// is generous by orders of magnitude. Bump it (or make it configurable)
+// when a future endpoint legitimately needs more.
+const maxRequestBodyBytes = 1 << 20 // 1 MiB
+
 // NewHandler returns an http.Handler that decodes the JSON request
 // payloads, dispatches to b, and JSON-encodes the response.
 //
@@ -56,7 +64,7 @@ func NewHandler(b Backend) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /v1/team/load", func(w http.ResponseWriter, r *http.Request) {
 		var req runtime.LoadTeamRequest
-		if err := decodeJSON(r, &req); err != nil {
+		if err := decodeJSON(w, r, &req); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
@@ -69,7 +77,7 @@ func NewHandler(b Backend) http.Handler {
 	})
 	mux.HandleFunc("POST /v1/session/create", func(w http.ResponseWriter, r *http.Request) {
 		var req runtime.CreateSessionRequest
-		if err := decodeJSON(r, &req); err != nil {
+		if err := decodeJSON(w, r, &req); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
@@ -83,7 +91,12 @@ func NewHandler(b Backend) http.Handler {
 	return mux
 }
 
-func decodeJSON(r *http.Request, v any) error {
+// decodeJSON reads a JSON request body into v. The body is wrapped in
+// an [http.MaxBytesReader] so a malicious or buggy client cannot stream
+// an unbounded payload and exhaust server memory. Unknown fields are
+// rejected so the wire schema stays a strict contract.
+func decodeJSON(w http.ResponseWriter, r *http.Request, v any) error {
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	dec := json.NewDecoder(r.Body)
 	dec.DisallowUnknownFields()
 	return dec.Decode(v)

--- a/pkg/runtime/wire/server_test.go
+++ b/pkg/runtime/wire/server_test.go
@@ -1,0 +1,176 @@
+package wire_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/runtime/wire"
+)
+
+// stubBackend records the last request received and returns canned
+// responses, so the round-trip tests can assert on both directions of
+// the wire.
+type stubBackend struct {
+	loadFn func(context.Context, runtime.LoadTeamRequest) (wire.LoadTeamResponse, error)
+	sessFn func(context.Context, runtime.CreateSessionRequest) (wire.CreateSessionResponse, error)
+}
+
+func (s *stubBackend) LoadTeam(ctx context.Context, req runtime.LoadTeamRequest) (wire.LoadTeamResponse, error) {
+	return s.loadFn(ctx, req)
+}
+
+func (s *stubBackend) CreateSession(ctx context.Context, req runtime.CreateSessionRequest) (wire.CreateSessionResponse, error) {
+	return s.sessFn(ctx, req)
+}
+
+// post is a small helper that issues a context-bound POST against the
+// test server, so test cancellation doesn't leak goroutines and the
+// noctx linter stays happy.
+func post(t *testing.T, url string, body []byte) *http.Response {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, url, bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
+func TestLoadTeam_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	var got runtime.LoadTeamRequest
+	srv := httptest.NewServer(wire.NewHandler(&stubBackend{
+		loadFn: func(_ context.Context, req runtime.LoadTeamRequest) (wire.LoadTeamResponse, error) {
+			got = req
+			return wire.LoadTeamResponse{
+				AgentNames:   []string{"main", "helper"},
+				DefaultAgent: "main",
+			}, nil
+		},
+	}))
+	t.Cleanup(srv.Close)
+
+	body, err := json.Marshal(runtime.LoadTeamRequest{
+		ModelOverrides: []string{"openai/gpt-4o"},
+		PromptFiles:    []string{"role.md"},
+	})
+	require.NoError(t, err)
+
+	resp := post(t, srv.URL+"/v1/team/load", body)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var out wire.LoadTeamResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+
+	// Server received the same fields the client sent.
+	assert.Equal(t, []string{"openai/gpt-4o"}, got.ModelOverrides)
+	assert.Equal(t, []string{"role.md"}, got.PromptFiles)
+
+	// Client received what the server sent.
+	assert.Equal(t, []string{"main", "helper"}, out.AgentNames)
+	assert.Equal(t, "main", out.DefaultAgent)
+}
+
+func TestCreateSession_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	var got runtime.CreateSessionRequest
+	srv := httptest.NewServer(wire.NewHandler(&stubBackend{
+		sessFn: func(_ context.Context, req runtime.CreateSessionRequest) (wire.CreateSessionResponse, error) {
+			got = req
+			return wire.CreateSessionResponse{SessionID: "sess-123"}, nil
+		},
+	}))
+	t.Cleanup(srv.Close)
+
+	body, err := json.Marshal(runtime.CreateSessionRequest{
+		AgentName:        "main",
+		ToolsApproved:    true,
+		HideToolResults:  true,
+		SessionDB:        "/tmp/s.db",
+		ResumeSessionID:  "01HF8...",
+		SnapshotsEnabled: true,
+		WorkingDir:       "/tmp/work",
+	})
+	require.NoError(t, err)
+
+	resp := post(t, srv.URL+"/v1/session/create", body)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var out wire.CreateSessionResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+
+	assert.Equal(t, "main", got.AgentName)
+	assert.True(t, got.ToolsApproved)
+	assert.True(t, got.HideToolResults)
+	assert.Equal(t, "/tmp/s.db", got.SessionDB)
+	assert.Equal(t, "01HF8...", got.ResumeSessionID)
+	assert.True(t, got.SnapshotsEnabled)
+	assert.Equal(t, "/tmp/work", got.WorkingDir)
+
+	assert.Equal(t, "sess-123", out.SessionID)
+}
+
+func TestLoadTeam_BackendErrorMapsTo500(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(wire.NewHandler(&stubBackend{
+		loadFn: func(context.Context, runtime.LoadTeamRequest) (wire.LoadTeamResponse, error) {
+			return wire.LoadTeamResponse{}, errors.New("config invalid")
+		},
+	}))
+	t.Cleanup(srv.Close)
+
+	resp := post(t, srv.URL+"/v1/team/load", []byte(`{}`))
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+}
+
+func TestCreateSession_ErrUnsupportedMapsTo501(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(wire.NewHandler(&stubBackend{
+		sessFn: func(context.Context, runtime.CreateSessionRequest) (wire.CreateSessionResponse, error) {
+			return wire.CreateSessionResponse{}, fmt.Errorf("snapshots: %w", runtime.ErrUnsupported)
+		},
+	}))
+	t.Cleanup(srv.Close)
+
+	resp := post(t, srv.URL+"/v1/session/create", []byte(`{}`))
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	assert.Equal(t, http.StatusNotImplemented, resp.StatusCode)
+}
+
+func TestLoadTeam_RejectsUnknownField(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(wire.NewHandler(&stubBackend{
+		loadFn: func(context.Context, runtime.LoadTeamRequest) (wire.LoadTeamResponse, error) {
+			return wire.LoadTeamResponse{}, nil
+		},
+	}))
+	t.Cleanup(srv.Close)
+
+	body := []byte(`{"model_overrides":["x"],"future_field":"oops"}`)
+	resp := post(t, srv.URL+"/v1/team/load", body)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}

--- a/pkg/runtime/wire/server_test.go
+++ b/pkg/runtime/wire/server_test.go
@@ -174,3 +174,34 @@ func TestLoadTeam_RejectsUnknownField(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
+
+func TestLoadTeam_RejectsOversizedBody(t *testing.T) {
+	t.Parallel()
+
+	// Pins the [http.MaxBytesReader] guard: an over-cap body must be
+	// rejected with 4xx instead of being streamed into memory. The
+	// handler logs the cause and replies via http.Error, which
+	// translates the MaxBytesReader limit error into a 400 today;
+	// what the test cares about is that the request never reaches
+	// the backend and the server stays healthy.
+	var reached bool
+	srv := httptest.NewServer(wire.NewHandler(&stubBackend{
+		loadFn: func(context.Context, runtime.LoadTeamRequest) (wire.LoadTeamResponse, error) {
+			reached = true
+			return wire.LoadTeamResponse{}, nil
+		},
+	}))
+	t.Cleanup(srv.Close)
+
+	// 2 MiB of JSON-string padding, well past the 1 MiB cap.
+	padding := bytes.Repeat([]byte("a"), 2<<20)
+	body := append([]byte(`{"model_overrides":["`), padding...)
+	body = append(body, []byte(`"]}`)...)
+
+	resp := post(t, srv.URL+"/v1/team/load", body)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	assert.GreaterOrEqual(t, resp.StatusCode, 400, "oversized body must not return success")
+	assert.Less(t, resp.StatusCode, 500, "oversized body is a client error, not a server crash")
+	assert.False(t, reached, "backend must not see an oversized body")
+}


### PR DESCRIPTION
## Goal

Pick up phase A+B+C from the [previous "remote-runtime baby steps" PR](https://github.com/docker/docker-agent/commits/main): close the silent-breakage gaps `--remote` still has compared to local mode, finish consolidating the `Runtime` interface, and stand up the data layer + HTTP scaffold that a real docker-agent server will eventually live behind.

Ten Kent-Beck-style baby steps. Each commit:
- builds cleanly,
- passes `task lint` (golangci-lint + custom checks + `go mod tidy`),
- passes `task test` (full suite),
- sets up the next move and explains it in the body.

## Commits

| # | Commit | Move |
|---|---|---|
| 1 | `fix(run): route session spawner through loadTeamRequest` | TUI's spawned-session path was calling `teamloader.LoadWithConfig` directly with only `WithModelOverrides`, silently dropping `--prompt-file` on every spawned session. Funnel it through `loadAgentFrom(ctx, loadTeamRequest(...))` so spawned sessions see the same flag set as the initial load. |
| 2 | `test(runtime): run the contract suite against RemoteRuntime` | `TestRemoteRuntime_Contract` plugs `RemoteRuntime` into `runRuntimeContract` via a stub client. All 14 non-streaming subtests now pin the surface for both runtimes. The one gap surfaced was `SetCurrentAgent` silently accepting any name; fix it inline by validating against the agent list returned by `client.GetAgent`. |
| 3 | `feat(runtime): wrap remaining RemoteRuntime no-ops with ErrUnsupported` | Two methods were silently lying to the TUI: `CurrentAgentTools` returned `(nil, nil)` (the /tools dialog opened with an empty list, indistinguishable from "agent has no tools") and `Summarize` emitted a `SessionSummary` event with text "not yet implemented" (the persistence observer wrote it to the session DB unchanged, corrupting the session). Both now surface `ErrUnsupported` / `Error` events. |
| 4 | `refactor(runtime): promote ModelSwitcher onto Runtime` | `SetAgentModel` / `AvailableModels` / `SupportsModelSwitching` are now part of the `Runtime` interface. `LocalRuntime` delegates to its existing implementation; `RemoteRuntime` returns `ErrUnsupported`. Drop the `ModelSwitcher` interface and `ModelSwitcherOf` helper; 5 call sites simplified. |
| 5 | `refactor(runtime): promote ToolsChangeSubscriber onto Runtime` | Same pattern. `OnToolsChanged` is a regular `Runtime` method now; `RemoteRuntime` is a no-op (tool-list changes flow through the run-stream events server-side). Drop the interface and helper. |
| 6 | `refactor(runtime): delete capabilities.go` | The optional-sub-interface helper file is empty. Delete it. `Runtime` is now the single source of truth for what backends can do — no more "is this thing also implementing some optional sub-interface" type assertions. |
| 7 | `refactor(runtime): move LoadTeamRequest and CreateSessionRequest to pkg/runtime` | Move the two payload structs out of `cmd/root` into `pkg/runtime/payload.go` so they can grow JSON tags and a server side. Factory methods (`loadTeamRequest`, `createSessionRequest`) stay near the CLI flag struct they read from. |
| 8 | `feat(runtime): add JSON tags and round-trip tests for payloads` | `LoadTeamRequest` and `CreateSessionRequest` now marshal/unmarshal cleanly. Wire-incompatible fields (`Source` interface, `RuntimeConfig`, `permissions.Checker`) get `json:"-"` with a doc comment; round trip + omitempty + non-serializable-fields-excluded contracts pinned by 6 tests. |
| 9 | `refactor(run): split backend interface into LoadTeam and CreateSession` | The two-step protocol an RPC server will mirror is now visible on the `backend` interface. Side-effect: local `--dry-run` now validates the team (catches YAML typos at dry-run time). Remote `--dry-run` is unchanged — `LoadTeam` is a no-op for remote, so the previous PR's "no leaked server-side session" guarantee still holds. |
| 10 | `feat(runtime): scaffold pkg/runtime/wire HTTP handler` | `POST /v1/team/load` and `POST /v1/session/create` decode the payloads from step 8 and dispatch to a `Backend` interface. Round-trip + error mapping pinned by 5 tests: backend errors → 500, `errors.Is(err, runtime.ErrUnsupported)` → 501, unknown JSON fields → 400. |

## What's still out of scope (each its own follow-up)

- `wire.Client` driving `RemoteRuntime`
- `/v1/session/run` streaming endpoint (SSE or chunked HTTP/2)
- Authentication
- Wire-friendly representations for `Source` / `RuntimeConfig` / `permissions.Checker` (today they're `json:"-"`)
- Bridging `cmd/root.backend` onto `wire.Backend` so the server actually runs a real `LocalBackend` rather than a stub

## Validation

```
$ task lint
1019 file(s) inspected, no offenses detected
$ task test
... all green ...
```

Plus smoke tests on both `--remote http://nosuchhost:9999 --dry-run` (exits without contacting the server) and local `--dry-run` (now also validates the team config).
