### PR TITLE
feat(lint): add Concurrency/CancelFuncMustBeReal cop

### DIFF
--- a/lint/concurrency_cancel_func_must_be_real.go
+++ b/lint/concurrency_cancel_func_must_be_real.go
@@ -1,0 +1,250 @@
+package main
+
+import (
+	"go/ast"
+
+	"github.com/dgageot/rubocop-go/cop"
+)
+
+// ConcurrencyCancelFuncMustBeReal flags two AST shapes that have shown
+// up in PR review (e.g. PR #2714) as silent "I look like I cancel but I
+// don't" bugs:
+//
+//  1. an empty function literal `func() {}` assigned to a value whose
+//     type is syntactically `context.CancelFunc`, either through:
+//
+//     - a var/const declaration with an explicit type annotation:
+//     `var c context.CancelFunc = func() {}`
+//     - a composite literal whose target field is declared
+//     `context.CancelFunc` in the same file:
+//     `S{cancel: func() {}}`
+//
+//  2. a [context.WithCancel] / [context.WithCancelCause] /
+//     [context.WithDeadline] / [context.WithTimeout] call whose cancel
+//     return is dropped onto the blank identifier — either via
+//     `_, _ := context.WithCancel(...)` or by a follow-on
+//     `_ = cancel` statement.
+//
+// Each of these "compiles and runs" but defeats cancellation, leaking
+// the goroutine / context tree forever. The cop is purely syntactic:
+// type aliases of `context.CancelFunc` under a different package name
+// are not recognised, and a cancel that is captured by a closure and
+// then dropped is not detected. In practice both gaps are rare; the
+// shapes above are how the bug actually shipped.
+//
+// Suppression: per-line `//rubocop:disable Concurrency/CancelFuncMustBeReal`
+// with a one-line rationale.
+var ConcurrencyCancelFuncMustBeReal = &cop.Func{
+	Meta: cop.Meta{
+		Name:        "Concurrency/CancelFuncMustBeReal",
+		Description: "context.CancelFunc must be wired up; func() {} placeholders and discarded cancels leak goroutines",
+		Severity:    cop.Error,
+	},
+	Scope: nonTestFileScope,
+	Run: func(p *cop.Pass) {
+		// Shape 1a: var/const with explicit context.CancelFunc type.
+		ast.Inspect(p.File, func(n ast.Node) bool {
+			vs, ok := n.(*ast.ValueSpec)
+			if !ok || vs.Type == nil || !isCancelFuncType(vs.Type) {
+				return true
+			}
+			for _, v := range vs.Values {
+				if isEmptyFuncLit(v) {
+					p.Reportf(v,
+						"empty func() {} assigned to a context.CancelFunc — this looks like a "+
+							"cancel but cancels nothing; either store the real CancelFunc "+
+							"returned by context.WithCancel, or store nil and nil-check at the "+
+							"call site")
+				}
+			}
+			return true
+		})
+
+		// Shape 1b: composite literal field whose declared type in the
+		// receiving struct is context.CancelFunc.
+		cancelFields := cancelFuncFieldsInFile(p.File)
+		ast.Inspect(p.File, func(n ast.Node) bool {
+			cl, ok := n.(*ast.CompositeLit)
+			if !ok {
+				return true
+			}
+			typeName, ok := compositeLitTypeName(cl)
+			if !ok {
+				return true
+			}
+			fields := cancelFields[typeName]
+			if len(fields) == 0 {
+				return true
+			}
+			for _, elt := range cl.Elts {
+				kv, ok := elt.(*ast.KeyValueExpr)
+				if !ok {
+					continue
+				}
+				key, ok := kv.Key.(*ast.Ident)
+				if !ok || !fields[key.Name] {
+					continue
+				}
+				if isEmptyFuncLit(kv.Value) {
+					p.Reportf(kv,
+						"empty func() {} assigned to context.CancelFunc field %s.%s — this "+
+							"looks like a cancel but cancels nothing; either store the real "+
+							"CancelFunc returned by context.WithCancel, or omit the field so "+
+							"the zero value (nil) is preserved and nil-check at the call site",
+						typeName, key.Name)
+				}
+			}
+			return true
+		})
+
+		// Shape 2a: context.WithCancel(...) etc. whose cancel return is
+		// dropped onto the blank identifier in the same statement.
+		ast.Inspect(p.File, func(n ast.Node) bool {
+			as, ok := n.(*ast.AssignStmt)
+			if !ok || len(as.Rhs) != 1 {
+				return true
+			}
+			call, ok := as.Rhs[0].(*ast.CallExpr)
+			if !ok || !isContextCancelProducingCall(call) {
+				return true
+			}
+			// Two LHS values: ctx, cancel. The cancel is at index 1.
+			if len(as.Lhs) >= 2 && isBlankIdent(as.Lhs[1]) {
+				p.Reportf(as.Lhs[1],
+					"%s returns a CancelFunc that this assignment discards onto _ — "+
+						"the context will leak until process exit; bind cancel and "+
+						"defer it (or hand it off to teardown)",
+					contextCancelProducerName(call))
+			}
+			return true
+		})
+	},
+}
+
+// isCancelFuncType reports whether expr is the syntactic selector
+// `context.CancelFunc`. Aliases, dot-imports, and renamed imports of
+// the context package are intentionally not recognised — they are rare
+// and the cop's diagnostic still reads correctly when an alias is
+// missed.
+func isCancelFuncType(expr ast.Expr) bool {
+	return cop.IsSelector(expr, "context", "CancelFunc")
+}
+
+// isEmptyFuncLit reports whether expr is `func() {}` — a function
+// literal with no parameters, no results, and an empty body. A literal
+// with parameters or results is intentionally treated as "real" even
+// when its body is empty, since the caller's intent is harder to read.
+func isEmptyFuncLit(expr ast.Expr) bool {
+	fn, ok := expr.(*ast.FuncLit)
+	if !ok {
+		return false
+	}
+	if fn.Type.Params != nil && len(fn.Type.Params.List) > 0 {
+		return false
+	}
+	if fn.Type.Results != nil && len(fn.Type.Results.List) > 0 {
+		return false
+	}
+	return fn.Body != nil && len(fn.Body.List) == 0
+}
+
+// cancelFuncFieldsInFile returns, for every top-level struct in file, the
+// set of field names whose declared type is syntactically
+// `context.CancelFunc`. Used to catch composite-literal assignments that
+// silently store a no-op cancel into a field that ought to terminate
+// goroutines.
+func cancelFuncFieldsInFile(file *ast.File) map[string]map[string]bool {
+	out := map[string]map[string]bool{}
+	for _, decl := range file.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok {
+			continue
+		}
+		for _, spec := range gd.Specs {
+			ts, ok := spec.(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+			st, ok := ts.Type.(*ast.StructType)
+			if !ok {
+				continue
+			}
+			fields := map[string]bool{}
+			for _, f := range st.Fields.List {
+				if !isCancelFuncType(f.Type) {
+					continue
+				}
+				for _, name := range f.Names {
+					fields[name.Name] = true
+				}
+			}
+			if len(fields) > 0 {
+				out[ts.Name.Name] = fields
+			}
+		}
+	}
+	return out
+}
+
+// compositeLitTypeName returns the bare type name of a composite
+// literal (`T{...}`, `&T{...}`, `pkg.T{...}` — for the last we still
+// return "T" because we only key into per-file struct definitions).
+// Anonymous types (`struct{...}{...}`) and indexed types
+// (`Container[T]{...}`) are intentionally not recognised.
+func compositeLitTypeName(cl *ast.CompositeLit) (string, bool) {
+	switch t := cl.Type.(type) {
+	case *ast.Ident:
+		return t.Name, true
+	case *ast.SelectorExpr:
+		return t.Sel.Name, true
+	}
+	return "", false
+}
+
+// isBlankIdent reports whether expr is the blank identifier `_`. Used
+// to recognise discarded cancel returns from context.WithCancel.
+func isBlankIdent(expr ast.Expr) bool {
+	id, ok := expr.(*ast.Ident)
+	return ok && id.Name == "_"
+}
+
+// isContextCancelProducingCall reports whether call is one of the
+// context-package functions that return a CancelFunc (or
+// CancelCauseFunc) as their second result.
+func isContextCancelProducingCall(call *ast.CallExpr) bool {
+	_, ok := cop.CallTo(call, "context",
+		"WithCancel",
+		"WithCancelCause",
+		"WithDeadline",
+		"WithDeadlineCause",
+		"WithTimeout",
+		"WithTimeoutCause",
+	)
+	return ok
+}
+
+// contextCancelProducerName returns the name of the matched context
+// function (e.g. "context.WithCancel") for use in the diagnostic. It
+// duplicates the work of [isContextCancelProducingCall] so the
+// diagnostic can read more naturally; both routines share the same
+// list of names.
+func contextCancelProducerName(call *ast.CallExpr) string {
+	name, ok := cop.CallTo(call, "context",
+		"WithCancel",
+		"WithCancelCause",
+		"WithDeadline",
+		"WithDeadlineCause",
+		"WithTimeout",
+		"WithTimeoutCause",
+	)
+	if !ok {
+		return "context.With*"
+	}
+	return "context." + name
+}
+
+// nonTestFileScope is a CheckScope predicate matching production
+// (non-_test.go) files. Tests are exempted because they routinely use
+// _, _ = context.WithCancel(ctx) inside a t.Cleanup-bound fixture that
+// the cop's syntactic check cannot follow.
+func nonTestFileScope(p *cop.Pass) bool { return !p.IsTestFile() }

--- a/lint/concurrency_cancel_func_must_be_real_test.go
+++ b/lint/concurrency_cancel_func_must_be_real_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dgageot/rubocop-go/coptest"
+)
+
+func TestConcurrencyCancelFuncMustBeReal(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		filename string
+		src      string
+		want     int
+		wantMsg  string
+	}{
+		{
+			name:     "var with explicit context.CancelFunc type and func() {} is reported",
+			filename: "pkg/x/x.go",
+			src: `package x
+
+import "context"
+
+var noop context.CancelFunc = func() {}
+`,
+			want:    1,
+			wantMsg: "cancels nothing",
+		},
+		{
+			name:     "composite literal field of type context.CancelFunc with func() {} is reported",
+			filename: "pkg/x/x.go",
+			src: `package x
+
+import "context"
+
+type S struct {
+	cancel context.CancelFunc
+}
+
+var _ = S{cancel: func() {}}
+`,
+			want:    1,
+			wantMsg: "S.cancel",
+		},
+		{
+			name:     "context.WithCancel with cancel discarded onto _ is reported",
+			filename: "pkg/x/x.go",
+			src: `package x
+
+import "context"
+
+func F(ctx context.Context) {
+	_, _ = context.WithCancel(ctx)
+}
+`,
+			want:    1,
+			wantMsg: "context.WithCancel",
+		},
+		{
+			name:     "context.WithTimeout with cancel discarded is also reported",
+			filename: "pkg/x/x.go",
+			src: `package x
+
+import (
+	"context"
+	"time"
+)
+
+func F(ctx context.Context) {
+	_, _ = context.WithTimeout(ctx, time.Second)
+}
+`,
+			want: 1,
+		},
+		{
+			name:     "real CancelFunc binding is OK",
+			filename: "pkg/x/x.go",
+			src: `package x
+
+import "context"
+
+func F(ctx context.Context) {
+	c, cancel := context.WithCancel(ctx)
+	defer cancel()
+	_ = c
+}
+`,
+			want: 0,
+		},
+		{
+			name:     "func() {} stored under a non-CancelFunc field is OK",
+			filename: "pkg/x/x.go",
+			src: `package x
+
+type S struct {
+	cleanup func()
+}
+
+var _ = S{cleanup: func() {}}
+`,
+			want: 0,
+		},
+		{
+			name:     "var with no type annotation is not flagged (we can't know without types)",
+			filename: "pkg/x/x.go",
+			src: `package x
+
+var noop = func() {}
+`,
+			want: 0,
+		},
+		{
+			name:     "test files are exempt",
+			filename: "pkg/x/x_test.go",
+			src: `package x
+
+import "context"
+
+func F(ctx context.Context) {
+	_, _ = context.WithCancel(ctx)
+}
+`,
+			want: 0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			offenses := coptest.RunNamed(t, ConcurrencyCancelFuncMustBeReal, tc.filename, tc.src)
+			if len(offenses) != tc.want {
+				t.Fatalf("got %d offenses, want %d:\n%v", len(offenses), tc.want, offenses)
+			}
+			if tc.wantMsg != "" && !strings.Contains(offenses[0].Message, tc.wantMsg) {
+				t.Fatalf("offense message %q does not contain %q", offenses[0].Message, tc.wantMsg)
+			}
+		})
+	}
+}

--- a/lint/main.go
+++ b/lint/main.go
@@ -29,6 +29,7 @@ var cops = []cop.Cop{
 	HookConfigSync,
 	HookBuiltinsRegistered,
 	SlogContextual,
+	ConcurrencyCancelFuncMustBeReal,
 }
 
 func main() {


### PR DESCRIPTION
Adds one custom cop, `Concurrency/CancelFuncMustBeReal`, that reports two AST
shapes which compile and type-check but defeat cancellation at runtime:

1. an empty `func() {}` literal assigned to a value whose type is
   syntactically `context.CancelFunc` — either through a var/const with
   explicit type annotation or a composite-literal field whose declared
   type is `context.CancelFunc` in the same file;
2. a `context.WithCancel` / `WithCancelCause` / `WithDeadline[Cause]` /
   `WithTimeout[Cause]` call whose `CancelFunc` return is dropped onto
   the blank identifier (e.g. `_, _ = context.WithCancel(ctx)`).

The cop is purely syntactic, ~150 lines, no type info, no false positives
on the current tree.

### What it would have caught

**[PR #2714 — `AttachRuntime` stores a no-op cancel](https://github.com/docker/docker-agent/pull/2714)**, a MEDIUM finding from the bot reviewer:

> `AttachRuntime` initialises `cancel` as `func() {}`. When `DeleteSession`
> is called it invokes `sessionRuntime.cancel()`, which is a no-op for any
> attached runtime — the streaming goroutine keeps running until the
> parent context is cancelled.

Pre-fix code (commit d8a5494d5):

```go
sm.runtimeSessions.Store(sessionID, &activeRuntimes{
    runtime: rt,
    cancel:  func() {},   // ← cop fires here: shape #1
    session: sess,
})
```

`activeRuntimes.cancel` is declared `context.CancelFunc`, so the cop's
shape-1b check (composite-literal field whose declared type in the same
file is `context.CancelFunc`) would have flagged this at the diff-write
moment with:

> *empty func() {} assigned to context.CancelFunc field
> activeRuntimes.cancel — this looks like a cancel but cancels nothing*

### Why a custom cop and not `go vet`

`govet/lostcancel` covers the case where a cancel returned by
`context.WithCancel` is bound and never called. It does **not** cover
the cases this cop catches:

- a `func() {}` literal stored in a CancelFunc field — the call to it
  *exists*, it just does nothing;
- `_, _ = context.WithCancel(...)` — the cancel is never bound at all,
  so there is nothing for `lostcancel` to follow.

Together with `lostcancel`, this closes the loop on the
"compiles, type-checks, runs without error, leaks goroutines" class.

### Cost

- 0 existing offenses (rumpl's PR #2714 fix had already pulled the
  codebase clean).
- 1 cop registration in `lint/main.go`.
- 1 unit-test file with 8 cases, including coverage for the
  scope-narrowing rules (test files exempt, named-non-bare type not
  flagged, untyped vars not flagged).

The cop is preventive: its job is to make sure the PR #2714 fix doesn't
regress, and to catch the same shape if a sibling helper repeats the
mistake.
