### PR TITLE
fix(toolinstall): route the registry client through httpclient.NewSafeClient

### DIFF
--- a/pkg/toolinstall/registry.go
+++ b/pkg/toolinstall/registry.go
@@ -11,10 +11,12 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/goccy/go-yaml"
 
 	"github.com/docker/docker-agent/pkg/atomicfile"
+	"github.com/docker/docker-agent/pkg/httpclient"
 )
 
 // githubToken returns a GitHub personal access token from the environment,
@@ -116,7 +118,13 @@ var (
 // NewRegistry creates a new Registry with default settings.
 func NewRegistry() *Registry {
 	return &Registry{
-		httpClient: http.DefaultClient,
+		// httpclient.NewSafeClient enforces dial-time SSRF protection
+		// even though baseURL is hard-coded — a hostname that today
+		// resolves to a public IP can be DNS-rebound to 127.0.0.1 or
+		// 169.254.169.254 and we want the request to fail at dial,
+		// not after exfiltration. The 30s timeout matches the de-facto
+		// upper bound the request context already enforces.
+		httpClient: httpclient.NewSafeClient(30*time.Second, false),
 		baseURL:    registryBaseURL,
 		cacheDir:   RegistryDir(),
 	}


### PR DESCRIPTION
The tool-install `Registry` talks to a hard-coded URL
(`registryBaseURL`) but does so via `http.DefaultClient` — so no
dial-time SSRF protection, no redirect filter, no timeout (relying
on the request context for liveness).

A hard-coded hostname is not by itself a defence: today's resolution
to a public IP can become tomorrow's resolution to `127.0.0.1` or
`169.254.169.254` under DNS rebinding (or under a future operator
override of the registry URL), at which point the registry client
silently follows along.

`httpclient.NewSafeClient` enforces an IP allow-list at dial time,
bounds the redirect chain at 10 hops, and we pin a 30s timeout here
to match the de-facto bound the request context already enforces.

### Behaviour

No change for the happy path — the public registry URL resolves to
a public IP, dial proceeds, the same JSON comes back. This is a
defence-in-depth fix that closes a gap before someone moves the
registry to a hostname an attacker can influence (internal mirror,
CDN with a wider TTL, env-overridable URL, etc.).
