### PR TITLE
xml fallback for llama.cpp models

### DIFF
--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -452,6 +452,71 @@ func TestToolCallSequence(t *testing.T) {
 	require.True(t, hasEventType(t, events, &StreamStoppedEvent{}), "Expected StreamStoppedEvent")
 }
 
+// TestXMLToolCallFallback verifies that <tool_call> blocks in text content
+// are extracted as tool calls and not leaked as AgentChoice events.
+func TestXMLToolCallFallback(t *testing.T) {
+	xmlPayload := `<tool_call>
+{"name": "shell_exec", "arguments": {"cmd": "ls -la"}}
+</tool_call>`
+
+	stream := newStreamBuilder().
+		AddContent(xmlPayload).
+		AddStopWithUsage(10, 15).
+		Build()
+
+	sess := session.New(session.WithUserMessage("list files"))
+	events := runSession(t, sess, stream)
+
+	// The XML should be promoted to a PartialToolCall, not remain as plain text.
+	require.True(t, hasEventType(t, events, &PartialToolCallEvent{}), "Expected PartialToolCallEvent from XML extraction")
+
+	// No raw XML should have been emitted as an AgentChoice event.
+	for _, ev := range events {
+		if choice, ok := ev.(*AgentChoiceEvent); ok {
+			require.NotContains(t, choice.Content, "<tool_call>", "XML tool call block must not appear in AgentChoice events")
+		}
+	}
+
+	// Verify the extracted tool call fields.
+	for _, ev := range events {
+		if partial, ok := ev.(*PartialToolCallEvent); ok {
+			require.Equal(t, "shell_exec", partial.ToolCall.Function.Name)
+			require.JSONEq(t, `{"cmd": "ls -la"}`, partial.ToolCall.Function.Arguments)
+		}
+	}
+}
+
+// TestXMLToolCallFallback_WithPreamble verifies that preamble text before a
+// <tool_call> block is emitted as AgentChoice while the XML is suppressed.
+func TestXMLToolCallFallback_WithPreamble(t *testing.T) {
+	stream := newStreamBuilder().
+		AddContent("I'll list the files for you.\n").
+		AddContent(`<tool_call>{"name": "ls", "arguments": {"path": "/tmp"}}</tool_call>`).
+		AddStopWithUsage(12, 18).
+		Build()
+
+	sess := session.New(session.WithUserMessage("list /tmp"))
+	events := runSession(t, sess, stream)
+
+	// Preamble text must have been emitted as AgentChoice.
+	var choiceContents []string
+	for _, ev := range events {
+		if choice, ok := ev.(*AgentChoiceEvent); ok {
+			choiceContents = append(choiceContents, choice.Content)
+		}
+	}
+	require.NotEmpty(t, choiceContents, "Expected AgentChoice events for preamble")
+	require.Contains(t, strings.Join(choiceContents, ""), "I'll list the files for you.")
+
+	// XML itself must not leak into AgentChoice.
+	for _, c := range choiceContents {
+		require.NotContains(t, c, "<tool_call>")
+	}
+
+	// Tool must still be extracted.
+	require.True(t, hasEventType(t, events, &PartialToolCallEvent{}))
+}
+
 func TestErrorEvent(t *testing.T) {
 	prov := &mockProviderWithError{id: "test/error-model"}
 	root := agent.New("root", "You are a test agent", agent.WithModel(prov))

--- a/pkg/runtime/streaming.go
+++ b/pkg/runtime/streaming.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"strings"
 
 	"github.com/docker/docker-agent/pkg/agent"
@@ -52,8 +53,36 @@ func handleStream(ctx context.Context, stream chat.MessageStream, a *agent.Agent
 	toolCallIndex := make(map[string]int)   // toolCallID -> index in toolCalls slice
 	emittedPartial := make(map[string]bool) // toolCallID -> whether we've emitted a partial event
 	toolDefMap := make(map[string]tools.Tool, len(agentTools))
+
+	// xmlToolCallGate suppresses AgentChoice events once a <tool_call> tag is
+	// seen, preventing raw XML from rendering in the TUI.
+	xmlToolCallGate := false
 	for _, t := range agentTools {
 		toolDefMap[t.Name] = t
+	}
+
+	// applyXMLFallback extracts <tool_call> blocks from accumulated content when
+	// no structured tool calls were received. Called from both the early-return
+	// and EOF paths.
+	applyXMLFallback := func() {
+		if len(toolCalls) > 0 {
+			return
+		}
+		extracted, textBefore, found := extractXMLToolCalls(fullContent.String())
+		if !found {
+			return
+		}
+		slog.DebugContext(ctx, "XML tool call fallback triggered",
+			"agent", a.Name(),
+			"tool_calls", len(extracted),
+		)
+		toolCalls = extracted
+		fullContent.Reset()
+		fullContent.WriteString(textBefore)
+		for _, tc := range toolCalls {
+			toolDef := toolDefMap[tc.Function.Name]
+			events <- PartialToolCall(tc, toolDef, a.Name())
+		}
 	}
 
 	// recordUsage persists the final token counts and emits telemetry exactly
@@ -102,14 +131,19 @@ func handleStream(ctx context.Context, stream chat.MessageStream, a *agent.Agent
 
 		if choice.FinishReason == chat.FinishReasonStop || choice.FinishReason == chat.FinishReasonLength {
 			recordUsage()
+			applyXMLFallback()
+			finishReason := choice.FinishReason
+			if finishReason == chat.FinishReasonStop && len(toolCalls) > 0 {
+				finishReason = chat.FinishReasonToolCalls
+			}
 			return streamResult{
 				Calls:             toolCalls,
 				Content:           fullContent.String(),
 				ReasoningContent:  fullReasoningContent.String(),
 				ThinkingSignature: thinkingSignature,
 				ThoughtSignature:  thoughtSignature,
-				Stopped:           true,
-				FinishReason:      choice.FinishReason,
+				Stopped:           len(toolCalls) == 0, // stop only when there are no tool calls to execute
+				FinishReason:      finishReason,
 				Usage:             messageUsage,
 			}, nil
 		}
@@ -188,12 +222,24 @@ func handleStream(ctx context.Context, stream chat.MessageStream, a *agent.Agent
 		}
 
 		if choice.Delta.Content != "" {
-			events <- AgentChoice(a.Name(), sess.ID, choice.Delta.Content)
+			if !xmlToolCallGate {
+				tagIdx := strings.Index(choice.Delta.Content, "<tool_call>")
+				if tagIdx < 0 {
+					events <- AgentChoice(a.Name(), sess.ID, choice.Delta.Content)
+				} else {
+					xmlToolCallGate = true
+					if tagIdx > 0 {
+						events <- AgentChoice(a.Name(), sess.ID, choice.Delta.Content[:tagIdx])
+					}
+				}
+			}
 			fullContent.WriteString(choice.Delta.Content)
 		}
 	}
 
 	recordUsage()
+
+	applyXMLFallback()
 
 	// If the stream completed without producing any content or tool calls, likely because of a token limit, stop to avoid breaking the request loop
 	// NOTE(krissetto): this can likely be removed once compaction works properly with all providers (aka dmr)

--- a/pkg/runtime/xml_tool_calls.go
+++ b/pkg/runtime/xml_tool_calls.go
@@ -1,0 +1,63 @@
+package runtime
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+// xmlToolCallRe matches <tool_call>…</tool_call> blocks emitted by some
+// llama.cpp-backed models (e.g. Qwen3-coder, Hermes) instead of the OpenAI
+// function-calling API.
+var xmlToolCallRe = regexp.MustCompile(`(?s)<tool_call>\s*(.*?)\s*</tool_call>`)
+
+// xmlToolCallPayload is the JSON structure emitted inside a <tool_call> block.
+type xmlToolCallPayload struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+// extractXMLToolCalls scans content for <tool_call>…</tool_call> blocks and
+// returns parsed tool calls plus any text preceding the first block. Trailing
+// text after the last block is discarded. ok is false when no valid blocks
+// are found.
+func extractXMLToolCalls(content string) (calls []tools.ToolCall, textBefore string, ok bool) {
+	locs := xmlToolCallRe.FindAllStringIndex(content, -1)
+	if len(locs) == 0 {
+		return nil, "", false
+	}
+
+	textBefore = strings.TrimRight(content[:locs[0][0]], "\n")
+
+	for i, loc := range locs {
+		sub := xmlToolCallRe.FindStringSubmatch(content[loc[0]:loc[1]])
+		if len(sub) < 2 {
+			continue
+		}
+
+		var payload xmlToolCallPayload
+		if err := json.Unmarshal([]byte(sub[1]), &payload); err != nil || payload.Name == "" {
+			continue
+		}
+
+		// absent or null arguments → "{}"
+		args := "{}"
+		if len(payload.Arguments) > 0 && string(payload.Arguments) != "null" {
+			args = string(payload.Arguments)
+		}
+
+		calls = append(calls, tools.ToolCall{
+			ID:   fmt.Sprintf("call_%d", i),
+			Type: "function",
+			Function: tools.FunctionCall{
+				Name:      payload.Name,
+				Arguments: args,
+			},
+		})
+	}
+
+	return calls, textBefore, len(calls) > 0
+}

--- a/pkg/runtime/xml_tool_calls_test.go
+++ b/pkg/runtime/xml_tool_calls_test.go
@@ -1,0 +1,125 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+func TestExtractXMLToolCalls_NoBlocks(t *testing.T) {
+	calls, textBefore, ok := extractXMLToolCalls("Hello, how can I help?")
+	assert.False(t, ok)
+	assert.Empty(t, calls)
+	assert.Empty(t, textBefore)
+}
+
+func TestExtractXMLToolCalls_SingleCall(t *testing.T) {
+	content := `<tool_call>
+{"name": "get_time", "arguments": {}}
+</tool_call>`
+
+	calls, textBefore, ok := extractXMLToolCalls(content)
+	require.True(t, ok)
+	require.Len(t, calls, 1)
+	assert.Equal(t, "get_time", calls[0].Function.Name)
+	assert.Equal(t, "{}", calls[0].Function.Arguments)
+	assert.Equal(t, "call_0", calls[0].ID)
+	assert.Equal(t, tools.ToolType("function"), calls[0].Type)
+	assert.Empty(t, textBefore)
+}
+
+func TestExtractXMLToolCalls_WithArguments(t *testing.T) {
+	content := `<tool_call>
+{"name": "search", "arguments": {"query": "docker agent"}}
+</tool_call>`
+
+	calls, _, ok := extractXMLToolCalls(content)
+	require.True(t, ok)
+	require.Len(t, calls, 1)
+	assert.Equal(t, "search", calls[0].Function.Name)
+	assert.JSONEq(t, `{"query": "docker agent"}`, calls[0].Function.Arguments)
+}
+
+func TestExtractXMLToolCalls_TextBefore(t *testing.T) {
+	content := "I'll search for that.\n<tool_call>\n{\"name\": \"search\", \"arguments\": {\"q\": \"go\"}}\n</tool_call>"
+
+	calls, textBefore, ok := extractXMLToolCalls(content)
+	require.True(t, ok)
+	assert.Equal(t, "I'll search for that.", textBefore)
+	require.Len(t, calls, 1)
+	assert.Equal(t, "search", calls[0].Function.Name)
+}
+
+func TestExtractXMLToolCalls_MultipleCalls(t *testing.T) {
+	content := `<tool_call>
+{"name": "tool_one", "arguments": {"a": 1}}
+</tool_call>
+<tool_call>
+{"name": "tool_two", "arguments": {"b": "hello"}}
+</tool_call>`
+
+	calls, textBefore, ok := extractXMLToolCalls(content)
+	require.True(t, ok)
+	require.Len(t, calls, 2)
+	assert.Empty(t, textBefore)
+	assert.Equal(t, "tool_one", calls[0].Function.Name)
+	assert.Equal(t, "call_0", calls[0].ID)
+	assert.Equal(t, "tool_two", calls[1].Function.Name)
+	assert.Equal(t, "call_1", calls[1].ID)
+}
+
+func TestExtractXMLToolCalls_NullArguments(t *testing.T) {
+	content := `<tool_call>{"name": "ping", "arguments": null}</tool_call>`
+
+	calls, _, ok := extractXMLToolCalls(content)
+	require.True(t, ok)
+	require.Len(t, calls, 1)
+	assert.Equal(t, "{}", calls[0].Function.Arguments)
+}
+
+func TestExtractXMLToolCalls_MissingArguments(t *testing.T) {
+	content := `<tool_call>{"name": "ping"}</tool_call>`
+
+	calls, _, ok := extractXMLToolCalls(content)
+	require.True(t, ok)
+	require.Len(t, calls, 1)
+	assert.Equal(t, "{}", calls[0].Function.Arguments)
+}
+
+func TestExtractXMLToolCalls_InvalidJSON(t *testing.T) {
+	content := `<tool_call>not-valid-json</tool_call>`
+
+	calls, _, ok := extractXMLToolCalls(content)
+	assert.False(t, ok)
+	assert.Empty(t, calls)
+}
+
+func TestExtractXMLToolCalls_MissingName(t *testing.T) {
+	content := `<tool_call>{"arguments": {"x": 1}}</tool_call>`
+
+	calls, _, ok := extractXMLToolCalls(content)
+	assert.False(t, ok)
+	assert.Empty(t, calls)
+}
+
+func TestExtractXMLToolCalls_InlineNoWhitespace(t *testing.T) {
+	content := `<tool_call>{"name":"ls","arguments":{"path":"/tmp"}}</tool_call>`
+
+	calls, _, ok := extractXMLToolCalls(content)
+	require.True(t, ok)
+	require.Len(t, calls, 1)
+	assert.Equal(t, "ls", calls[0].Function.Name)
+	assert.JSONEq(t, `{"path": "/tmp"}`, calls[0].Function.Arguments)
+}
+
+func TestExtractXMLToolCalls_TextAfterCallDiscarded(t *testing.T) {
+	content := "Preamble\n<tool_call>\n{\"name\": \"run\", \"arguments\": {}}\n</tool_call>\nSome trailing text."
+
+	calls, textBefore, ok := extractXMLToolCalls(content)
+	require.True(t, ok)
+	require.Len(t, calls, 1)
+	assert.Equal(t, "Preamble", textBefore)
+}


### PR DESCRIPTION
## summary

closes #2263

* some models served via docker model runner (like qwen3-coder and hermes) ignore the openai function-calling api and instead return tool calls as `<tool_call>...</tool_call>` text, which caused tools to never execute
* added a fallback to detect and extract these xml blocks after streaming completes and convert them into actual tool calls
* suppressed raw xml blocks from showing up in the tui while streaming so they never appear as visible chat output

## ai model disclosure

used vscode copilot (claude sonnet 4.6) to understand the issue context and help generate a fix. changes were self-reviewed and verified via:

```bash
task build
task test
task lint
```