### PR TITLE
feat: add fd:// scheme support to server.Listen

### DIFF
--- a/pkg/server/listen.go
+++ b/pkg/server/listen.go
@@ -2,9 +2,11 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -17,7 +19,31 @@ func Listen(ctx context.Context, addr string) (net.Listener, error) {
 		return listenNamedPipe(path)
 	}
 
+	if raw, ok := strings.CutPrefix(addr, "fd://"); ok {
+		return listenFD(raw)
+	}
+
 	return listenTCP(ctx, addr)
+}
+
+func listenFD(raw string) (net.Listener, error) {
+	fd, err := strconv.Atoi(raw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid file descriptor %q: %w", raw, err)
+	}
+	if fd < 3 {
+		return nil, fmt.Errorf("invalid file descriptor %d: must be > 2 (0-2 are stdin/stdout/stderr)", fd)
+	}
+
+	f := os.NewFile(uintptr(fd), "fd://"+raw)
+	defer f.Close() // net.FileListener duplicates the fd; close our copy
+
+	ln, err := net.FileListener(f)
+	if err != nil {
+		return nil, fmt.Errorf("file descriptor %d is not a listener: %w", fd, err)
+	}
+
+	return ln, nil
 }
 
 func listenUnix(ctx context.Context, path string) (net.Listener, error) {

--- a/pkg/server/listen_test.go
+++ b/pkg/server/listen_test.go
@@ -1,0 +1,64 @@
+package server
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListen_FD(t *testing.T) {
+	t.Parallel()
+
+	var lc net.ListenConfig
+	orig, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer orig.Close()
+
+	file, err := orig.(*net.TCPListener).File()
+	require.NoError(t, err)
+	defer file.Close()
+
+	ln, err := Listen(t.Context(), fmt.Sprintf("fd://%d", file.Fd()))
+	require.NoError(t, err)
+	defer ln.Close()
+
+	assert.NotNil(t, ln.Addr())
+}
+
+func TestListen_FD_InvalidNumber(t *testing.T) {
+	t.Parallel()
+
+	_, err := Listen(t.Context(), "fd://notanumber")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid file descriptor")
+}
+
+func TestListen_FD_NegativeNumber(t *testing.T) {
+	t.Parallel()
+
+	_, err := Listen(t.Context(), "fd://-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be > 2")
+}
+
+func TestListen_FD_ReservedDescriptors(t *testing.T) {
+	t.Parallel()
+
+	for _, fd := range []string{"0", "1", "2"} {
+		_, err := Listen(t.Context(), "fd://"+fd)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be > 2")
+	}
+}
+
+func TestListen_FD_InvalidDescriptor(t *testing.T) {
+	t.Parallel()
+
+	// Use a very high fd number that's unlikely to exist
+	_, err := Listen(t.Context(), "fd://999999")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "file descriptor 999999")
+}


### PR DESCRIPTION
## Summary

Add `fd://` scheme support to `server.Listen()` so a parent process can pass a pre-opened listening socket via a file descriptor. This eliminates the need for polling when a client creates the listener before spawning the server.

## Motivation

When the server is a child process, the parent can create the listening socket first and pass the file descriptor via `cmd.ExtraFiles`. The server then uses `fd://3` (or whichever FD) to adopt the listener immediately — no race, no polling.

This is the same mechanism used by Docker Desktop when spawning vpnkit.

## Changes

- **`pkg/server/listen.go`**: Added `fd://` prefix handling in `Listen()` and a new `listenFD()` helper that parses the FD number, wraps it with `os.NewFile` + `net.FileListener`, and returns the listener. Validates against non-numeric and negative FD values.
- **`pkg/server/listen_test.go`** (new): Tests for valid FD, invalid (non-numeric) FD, negative FD, and bogus FD number.

## Supported address schemes

| Scheme | Transport |
|---|---|
| `fd://3` | Inherited file descriptor |
| `unix:///path/to/sock` | Unix domain socket |
| `npipe://\\.\pipe\name` | Windows named pipe |
| `:8080` (anything else) | TCP |
