### PR TITLE
fix: avoid sub-agent terminology in skill instructions to prevent transfer_task confusion

### DIFF
--- a/pkg/tools/builtin/skills/skills.go
+++ b/pkg/tools/builtin/skills/skills.go
@@ -181,9 +181,9 @@ func (s *Toolset) Instructions() string {
 
 	hasFork := s.hasForkSkills()
 	if hasFork {
-		sb.WriteString("Some skills are configured to run as isolated sub-agents (context: fork). ")
-		sb.WriteString("For those skills use run_skill instead of read_skill so they execute in a dedicated context ")
-		sb.WriteString("with their own conversation history.\n\n")
+		sb.WriteString("Some skills are configured to run in a forked context with their own conversation history. ")
+		sb.WriteString("For those skills, you MUST use the run_skill tool (not transfer_task or read_skill). ")
+		sb.WriteString("The run_skill tool handles the isolated execution automatically.\n\n")
 	}
 
 	if s.hasFiles() {
@@ -201,7 +201,7 @@ func (s *Toolset) Instructions() string {
 		sb.WriteString(skill.Description)
 		sb.WriteString("</description>\n")
 		if skill.IsFork() {
-			sb.WriteString("    <mode>sub-agent</mode>\n")
+			sb.WriteString("    <mode>forked</mode>\n")
 		}
 		if len(skill.Files) > 1 {
 			sb.WriteString("    <files>")
@@ -228,8 +228,8 @@ func (s *Toolset) Instructions() string {
 
 // RunSkillArgs specifies the parameters for the run_skill tool.
 type RunSkillArgs struct {
-	Name string `json:"name" jsonschema:"The name of the skill to run as a sub-agent"`
-	Task string `json:"task" jsonschema:"A clear description of the task the skill sub-agent should achieve"`
+	Name string `json:"name" jsonschema:"The name of the skill to run in a forked context"`
+	Task string `json:"task" jsonschema:"A clear description of the task the skill should achieve"`
 }
 
 // PreparedSkillFork carries the validated and expanded data needed to launch a
@@ -266,7 +266,7 @@ func (s *Toolset) PrepareForkSubSession(ctx context.Context, args RunSkillArgs) 
 
 	if !skill.IsFork() {
 		return nil, tools.ResultError(fmt.Sprintf(
-			"skill %q is not configured for sub-agent execution (missing context: fork in SKILL.md frontmatter); use read_skill instead",
+			"skill %q is not configured for forked execution (missing context: fork in SKILL.md frontmatter); use read_skill instead",
 			args.Name,
 		))
 	}
@@ -325,7 +325,7 @@ func (s *Toolset) Tools(context.Context) ([]tools.Tool, error) {
 		result = append(result, tools.Tool{
 			Name:         ToolNameRunSkill,
 			Category:     "skills",
-			Description:  "Run a skill as an isolated sub-agent with its own conversation context. Use this for skills marked with sub-agent mode.",
+			Description:  "Run a skill in a forked context with its own conversation history. Use this for skills marked with forked mode — never use transfer_task for skills.",
 			Parameters:   tools.MustSchemaFor[RunSkillArgs](),
 			OutputSchema: tools.MustSchemaFor[string](),
 			Annotations: tools.ToolAnnotations{

--- a/pkg/tools/builtin/skills/skills_test.go
+++ b/pkg/tools/builtin/skills/skills_test.go
@@ -308,11 +308,10 @@ func TestSkillsToolset_Instructions_ForkSkills(t *testing.T) {
 
 	// Should mention run_skill for fork skills
 	assert.Contains(t, instructions, "run_skill")
-	assert.Contains(t, instructions, "context: fork")
-	assert.Contains(t, instructions, "isolated sub-agents")
+	assert.Contains(t, instructions, "forked context")
 
-	// Fork skill should have sub-agent mode tag
-	assert.Contains(t, instructions, "<mode>sub-agent</mode>")
+	// Fork skill should have forked mode tag
+	assert.Contains(t, instructions, "<mode>forked</mode>")
 
 	// Inline skill should NOT have the mode tag
 	// We check that inline-skill's entry does not contain <mode>
@@ -327,10 +326,10 @@ func TestSkillsToolset_Instructions_NoForkSkills(t *testing.T) {
 
 	instructions := st.Instructions()
 
-	// Should NOT mention run_skill or sub-agent
+	// Should NOT mention run_skill or forked mode
 	assert.NotContains(t, instructions, "run_skill")
-	assert.NotContains(t, instructions, "<mode>sub-agent</mode>")
-	assert.NotContains(t, instructions, "context: fork")
+	assert.NotContains(t, instructions, "<mode>forked</mode>")
+	assert.NotContains(t, instructions, "forked context")
 }
 
 func TestSkillsToolset_Tools_WithForkSkills(t *testing.T) {
@@ -421,7 +420,7 @@ func TestSkillsToolset_PrepareForkSubSession_NotFork(t *testing.T) {
 	assert.Nil(t, prepared)
 	require.NotNil(t, errResult)
 	assert.True(t, errResult.IsError)
-	assert.Contains(t, errResult.Output, "not configured for sub-agent execution")
+	assert.Contains(t, errResult.Output, "not configured for forked execution")
 	assert.Contains(t, errResult.Output, "use read_skill instead")
 }
 


### PR DESCRIPTION
When forked skills (context: fork) were present, the instructions and tool schema used the term "sub-agent" extensively. This caused models to confuse `run_skill` with `transfer_task` (which handles actual sub-agent delegation), leading to failed attempts to transfer to a non-existent agent instead of invoking the skill correctly.

### Changes

- Replace "sub-agent" with "forked context" in skill instructions, tool description, parameter schema, and error messages
- Change `<mode>sub-agent</mode>` tag to `<mode>forked</mode>` in the available_skills XML
- Add explicit guidance: "you MUST use the run_skill tool (not transfer_task or read_skill)"
- Update tests to match new wording