### PR TITLE
docs: Docker-branded redesign with dark-mode-first theme and improved homepage

### DIFF
--- a/docs/404.md
+++ b/docs/404.md
@@ -6,6 +6,6 @@ permalink: /404.html
 
 # Page not found
 
-The page you're looking for doesn't exist.
+The page you're looking for doesn't exist or has been moved.
 
-<a href="{{ '/' | relative_url }}" class="btn btn-primary" style="background:var(--accent);color:white;display:inline-block;margin-top:1rem;">Go Home</a>
+<a href="{{ '/' | relative_url }}" class="btn btn-primary" style="background:var(--accent);color:white;display:inline-block;margin-top:1rem;">← Back to Docs</a>

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -1,25 +1,23 @@
 <!-- Header -->
 <header class="header" role="banner">
   <div class="header-inner">
-    <a href="{{ '/' | relative_url }}" class="header-logo" aria-label="docker agent docs home">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-        <rect x="3" y="11" width="18" height="10" rx="2"/>
-        <circle cx="9" cy="16" r="1.5" fill="currentColor"/>
-        <circle cx="15" cy="16" r="1.5" fill="currentColor"/>
-        <path d="M8 11V7a4 4 0 0 1 8 0v4"/>
-        <path d="M5 11V9"/>
-        <path d="M19 11V9"/>
+    <a href="{{ '/' | relative_url }}" class="header-logo" aria-label="Docker Agent docs home">
+      <!-- Docker whale logo -->
+      <svg viewBox="0 0 50 36" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <path d="M48.3 16.5c-.3-.2-2.6-1.3-5.1-1.3-.5 0-1 0-1.5.1-.6-2.2-2.6-3.2-2.7-3.3l-.5-.3-.3.5c-.4.8-.7 1.7-.8 2.6-.3 1.8.1 3.5 1.2 4.9-1.8 1-4.7 1.3-5.3 1.3H1.2c-.7 0-1.2.5-1.2 1.2 0 4.4 1.8 8.8 5.2 12C8.5 37.2 13.2 39 19 39c12.5 0 21.7-7.3 26-20.4 1.7 0 3.3-.5 4.1-2.1l.2-.4-.3-.2zM5.3 19.8H9c.2 0 .3-.1.3-.3v-3.8c0-.2-.1-.3-.3-.3H5.3c-.2 0-.3.1-.3.3v3.8c0 .1.1.3.3.3zm5 0h3.8c.2 0 .3-.1.3-.3v-3.8c0-.2-.1-.3-.3-.3h-3.8c-.2 0-.3.1-.3.3v3.8c0 .1.1.3.3.3zm5.1 0h3.8c.2 0 .3-.1.3-.3v-3.8c0-.2-.1-.3-.3-.3h-3.8c-.2 0-.3.1-.3.3v3.8c0 .1.1.3.3.3zm5.1 0h3.8c.2 0 .3-.1.3-.3v-3.8c0-.2-.1-.3-.3-.3h-3.8c-.2 0-.3.1-.3.3v3.8c0 .1.1.3.3.3zm-10.2-5h3.8c.2 0 .3-.1.3-.3v-3.8c0-.2-.1-.3-.3-.3h-3.8c-.2 0-.3.1-.3.3v3.8c0 .2.1.3.3.3zm5.1 0h3.8c.2 0 .3-.1.3-.3v-3.8c0-.2-.1-.3-.3-.3h-3.8c-.2 0-.3.1-.3.3v3.8c0 .2.1.3.3.3zm5.1 0h3.8c.2 0 .3-.1.3-.3v-3.8c0-.2-.1-.3-.3-.3h-3.8c-.2 0-.3.1-.3.3v3.8c0 .2.1.3.3.3zm0-5h3.8c.2 0 .3-.1.3-.3V5.7c0-.2-.1-.3-.3-.3h-3.8c-.2 0-.3.1-.3.3v3.8c0 .2.1.3.3.3zm5.1 5h3.8c.2 0 .3-.1.3-.3v-3.8c0-.2-.1-.3-.3-.3h-3.8c-.2 0-.3.1-.3.3v3.8c0 .2.1.3.3.3z" fill="#1D63ED"/>
       </svg>
-      <span>Docker Agent <span style="font-weight:400;color:var(--text-muted);font-size:0.85rem;">docs</span></span>
+      <span>Docker Agent</span>
+      <span class="logo-divider"></span>
+      <span class="logo-label">Docs</span>
     </a>
 
     <div class="header-actions">
       <div class="header-search">
         <svg class="search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
-        <input type="text" id="search-input" placeholder="Search docs… ⌘K" readonly aria-label="Search documentation">
+        <input type="text" id="search-input" placeholder="Search… ⌘K" readonly aria-label="Search documentation">
       </div>
 
-      <button class="btn-icon" onclick="toggleTheme()" title="Toggle theme" aria-label="Toggle dark/light theme">
+      <button class="btn-icon" id="theme-toggle" title="Toggle theme" aria-label="Toggle dark/light theme">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
       </button>
 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -3,10 +3,10 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{% if page.title %}{{ page.title }} – Docker Agent docs{% else %}Docker Agent – Documentation{% endif %}</title>
+  <title>{% if page.title %}{{ page.title }} – Docker Agent Docs{% else %}Docker Agent – Documentation{% endif %}</title>
   <meta name="description" content="{{ page.description | default: site.description }}">
 
-  <meta property="og:title" content="{% if page.title %}{{ page.title }} – Docker Agent docs{% else %}Docker Agent – Documentation{% endif %}">
+  <meta property="og:title" content="{% if page.title %}{{ page.title }} – Docker Agent Docs{% else %}Docker Agent – Documentation{% endif %}">
   <meta property="og:description" content="{{ page.description | default: site.description }}">
   <meta property="og:type" content="{% if page.url == '/' %}website{% else %}article{% endif %}">
   <meta property="og:url" content="{{ page.url | absolute_url }}">
@@ -15,7 +15,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{{ '/css/style.css' | relative_url }}">
-  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100' fill='none'%3E%3Crect x='15' y='35' width='70' height='45' rx='10' fill='%231a56db'/%3E%3Ccircle cx='37' cy='57' r='7' fill='white'/%3E%3Ccircle cx='63' cy='57' r='7' fill='white'/%3E%3Ccircle cx='37' cy='57' r='3' fill='%231a56db'/%3E%3Ccircle cx='63' cy='57' r='3' fill='%231a56db'/%3E%3Crect x='30' y='20' width='8' height='20' rx='4' fill='%231a56db'/%3E%3Crect x='62' y='20' width='8' height='20' rx='4' fill='%231a56db'/%3E%3C/svg%3E">
+  <!-- Docker whale favicon -->
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 50 36' fill='none'%3E%3Cpath d='M48.3 16.5c-.3-.2-2.6-1.3-5.1-1.3-.5 0-1 0-1.5.1-.6-2.2-2.6-3.2-2.7-3.3l-.5-.3-.3.5c-.4.8-.7 1.7-.8 2.6-.3 1.8.1 3.5 1.2 4.9-1.8 1-4.7 1.3-5.3 1.3H1.2c-.7 0-1.2.5-1.2 1.2 0 4.4 1.8 8.8 5.2 12C8.5 37.2 13.2 39 19 39c12.5 0 21.7-7.3 26-20.4 1.7 0 3.3-.5 4.1-2.1l.2-.4-.3-.2zM5.3 19.8H9c.2 0 .3-.1.3-.3v-3.8c0-.2-.1-.3-.3-.3H5.3c-.2 0-.3.1-.3.3v3.8c0 .1.1.3.3.3zm5 0h3.8c.2 0 .3-.1.3-.3v-3.8c0-.2-.1-.3-.3-.3h-3.8c-.2 0-.3.1-.3.3v3.8c0 .1.1.3.3.3zm5.1 0h3.8c.2 0 .3-.1.3-.3v-3.8c0-.2-.1-.3-.3-.3h-3.8c-.2 0-.3.1-.3.3v3.8c0 .1.1.3.3.3zm5.1 0h3.8c.2 0 .3-.1.3-.3v-3.8c0-.2-.1-.3-.3-.3h-3.8c-.2 0-.3.1-.3.3v3.8c0 .1.1.3.3.3zm-10.2-5h3.8c.2 0 .3-.1.3-.3v-3.8c0-.2-.1-.3-.3-.3h-3.8c-.2 0-.3.1-.3.3v3.8c0 .2.1.3.3.3zm5.1 0h3.8c.2 0 .3-.1.3-.3v-3.8c0-.2-.1-.3-.3-.3h-3.8c-.2 0-.3.1-.3.3v3.8c0 .2.1.3.3.3zm5.1 0h3.8c.2 0 .3-.1.3-.3v-3.8c0-.2-.1-.3-.3-.3h-3.8c-.2 0-.3.1-.3.3v3.8c0 .2.1.3.3.3zm0-5h3.8c.2 0 .3-.1.3-.3V5.7c0-.2-.1-.3-.3-.3h-3.8c-.2 0-.3.1-.3.3v3.8c0 .2.1.3.3.3zm5.1 5h3.8c.2 0 .3-.1.3-.3v-3.8c0-.2-.1-.3-.3-.3h-3.8c-.2 0-.3.1-.3.3v3.8c0 .2.1.3.3.3z' fill='%231D63ED'/%3E%3C/svg%3E">
 </head>
 <body>
   <a href="#page-content" class="skip-link">Skip to content</a>
@@ -33,7 +34,7 @@
     {% endfor %}
   </nav>
 
-  <button class="sidebar-toggle" onclick="document.getElementById('sidebar').classList.toggle('open')" aria-label="Toggle navigation menu">
+  <button class="sidebar-toggle" aria-label="Toggle navigation menu">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
   </button>
 

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -2,73 +2,78 @@
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 :root {
-  /* Colors – light theme */
-  --bg: #ffffff;
-  --bg-sidebar: #f8f9fb;
-  --bg-code: #f4f5f7;
-  --bg-code-block: #1e1e2e;
-  --bg-hero: linear-gradient(135deg, #1a56db 0%, #7c3aed 100%);
-  --bg-card: #ffffff;
-  --bg-hover: #eef1f6;
+  /* Docker brand palette */
+  --docker-blue: #1D63ED;
+  --docker-blue-hover: #1854D1;
+  --docker-blue-light: #4A8AF4;
+  --docker-navy: #09101F;
+  --docker-navy-light: #111827;
 
-  --text: #1a1a2e;
-  --text-secondary: #4a5568;
-  --text-muted: #718096;
-  --text-sidebar: #374151;
-  --text-sidebar-active: #1a56db;
-  --text-code: #e06c75;
-  --text-on-dark: #f1f5f9;
+  /* Colors – dark theme (default, docker-branded) */
+  --bg: #09101F;
+  --bg-sidebar: #0D1525;
+  --bg-code: rgba(255,255,255,0.05);
+  --bg-code-block: #0B1120;
+  --bg-card: rgba(255,255,255,0.03);
+  --bg-hover: rgba(255,255,255,0.06);
+
+  --text: #E8ECF2;
+  --text-secondary: #94A3B8;
+  --text-muted: #64748B;
+  --text-sidebar: #94A3B8;
+  --text-sidebar-active: #E8ECF2;
+  --text-code: #7DD3FC;
   --text-on-hero: #ffffff;
 
-  --border: #e2e8f0;
-  --border-light: #f0f0f5;
+  --border: rgba(255,255,255,0.08);
+  --border-light: rgba(255,255,255,0.05);
 
-  --accent: #1a56db;
-  --accent-hover: #1648b8;
-  --accent-light: #e8efff;
+  --accent: #1D63ED;
+  --accent-hover: #4A8AF4;
+  --accent-light: rgba(29,99,237,0.12);
 
-  --success: #10b981;
-  --warning: #f59e0b;
-  --error: #ef4444;
-  --info: #3b82f6;
+  --success: #34D399;
+  --warning: #FBBF24;
+  --error: #F87171;
+  --info: #60A5FA;
 
-  --shadow-sm: 0 1px 2px rgba(0,0,0,0.04);
-  --shadow-md: 0 4px 12px rgba(0,0,0,0.07);
-  --shadow-lg: 0 8px 30px rgba(0,0,0,0.1);
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.3);
+  --shadow-md: 0 4px 16px rgba(0,0,0,0.4);
+  --shadow-lg: 0 12px 40px rgba(0,0,0,0.5);
 
   --radius: 8px;
   --radius-lg: 12px;
 
-  --sidebar-width: 280px;
-  --header-height: 60px;
+  --sidebar-width: 260px;
+  --header-height: 56px;
   --toc-width: 220px;
 
   --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
 }
 
-/* Dark theme */
-[data-theme="dark"] {
-  --bg: #0f1117;
-  --bg-sidebar: #161822;
-  --bg-code: #1e2030;
-  --bg-code-block: #1e2030;
-  --bg-card: #1a1c2a;
-  --bg-hover: #252840;
+/* Light theme override */
+[data-theme="light"] {
+  --bg: #FAFBFC;
+  --bg-sidebar: #F3F4F6;
+  --bg-code: #F1F5F9;
+  --bg-code-block: #0F172A;
+  --bg-card: #FFFFFF;
+  --bg-hover: #E5E7EB;
 
-  --text: #e2e8f0;
-  --text-secondary: #a0aec0;
-  --text-muted: #718096;
-  --text-sidebar: #cbd5e0;
-  --text-sidebar-active: #63b3ed;
-  --text-code: #f78c6c;
+  --text: #0F172A;
+  --text-secondary: #475569;
+  --text-muted: #94A3B8;
+  --text-sidebar: #475569;
+  --text-sidebar-active: #0F172A;
+  --text-code: #1D63ED;
 
-  --border: #2d3148;
-  --border-light: #252840;
+  --border: #E2E8F0;
+  --border-light: #F1F5F9;
 
-  --accent: #63b3ed;
-  --accent-hover: #4299e1;
-  --accent-light: #1e2a4a;
+  --accent: #1D63ED;
+  --accent-hover: #1854D1;
+  --accent-light: #EFF6FF;
 }
 
 /* ===== Skip link (accessibility) ===== */
@@ -82,7 +87,7 @@
   border-radius: var(--radius);
   z-index: 9999;
   font-weight: 600;
-  font-size: 0.9rem;
+  font-size: 0.875rem;
   text-decoration: none;
   transition: top 0.2s;
 }
@@ -99,12 +104,7 @@ body {
   background: var(--bg);
   line-height: 1.7;
   -webkit-font-smoothing: antialiased;
-}
-
-/* ===== Layout ===== */
-.layout {
-  display: flex;
-  min-height: 100vh;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 /* ===== Header ===== */
@@ -119,11 +119,11 @@ body {
   align-items: center;
   padding: 0 24px;
   z-index: 100;
-  backdrop-filter: blur(12px);
-  background: rgba(255,255,255,0.85);
+  backdrop-filter: blur(16px) saturate(180%);
+  background: rgba(9,16,31,0.8);
 }
-[data-theme="dark"] .header {
-  background: rgba(15,17,23,0.85);
+[data-theme="light"] .header {
+  background: rgba(250,251,252,0.85);
 }
 
 .header-inner {
@@ -141,37 +141,54 @@ body {
   gap: 10px;
   text-decoration: none;
   font-weight: 700;
-  font-size: 1.2rem;
+  font-size: 1.05rem;
   color: var(--text);
+  letter-spacing: -0.01em;
+}
+.header-logo:hover {
+  text-decoration: none;
 }
 .header-logo svg {
-  width: 28px;
-  height: 28px;
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+}
+.header-logo .logo-divider {
+  width: 1px;
+  height: 20px;
+  background: var(--border);
+  margin: 0 2px;
+}
+.header-logo .logo-label {
+  font-weight: 400;
+  color: var(--text-muted);
+  font-size: 0.9rem;
 }
 
 .header-actions {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 8px;
 }
 
 .header-search {
   position: relative;
 }
 .header-search input {
-  width: 240px;
-  padding: 8px 12px 8px 36px;
+  width: 220px;
+  padding: 7px 12px 7px 34px;
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  background: var(--bg);
+  background: var(--bg-hover);
   color: var(--text);
-  font-size: 0.875rem;
+  font-size: 0.8rem;
   outline: none;
-  transition: border-color 0.2s, box-shadow 0.2s;
+  transition: border-color 0.2s, box-shadow 0.2s, width 0.2s;
 }
 .header-search input:focus {
   border-color: var(--accent);
   box-shadow: 0 0 0 3px var(--accent-light);
+  width: 280px;
 }
 .header-search .search-icon {
   position: absolute;
@@ -179,17 +196,17 @@ body {
   top: 50%;
   transform: translateY(-50%);
   color: var(--text-muted);
-  width: 16px;
-  height: 16px;
+  width: 15px;
+  height: 15px;
 }
 
 .btn-icon {
   background: none;
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  padding: 8px;
+  padding: 7px;
   cursor: pointer;
-  color: var(--text-secondary);
+  color: var(--text-muted);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -198,20 +215,26 @@ body {
 .btn-icon:hover {
   background: var(--bg-hover);
   color: var(--text);
+  border-color: var(--text-muted);
 }
-.btn-icon svg { width: 18px; height: 18px; }
+.btn-icon svg { width: 16px; height: 16px; }
 
 .github-link {
   text-decoration: none;
-  color: var(--text-secondary);
+  color: var(--text-muted);
   display: flex;
   align-items: center;
-  padding: 8px;
+  padding: 7px;
   border-radius: var(--radius);
-  transition: color 0.2s;
+  border: 1px solid var(--border);
+  transition: all 0.2s;
 }
-.github-link:hover { color: var(--text); }
-.github-link svg { width: 22px; height: 22px; }
+.github-link:hover {
+  color: var(--text);
+  background: var(--bg-hover);
+  border-color: var(--text-muted);
+}
+.github-link svg { width: 16px; height: 16px; }
 
 /* ===== Sidebar ===== */
 .sidebar {
@@ -223,7 +246,7 @@ body {
   background: var(--bg-sidebar);
   border-right: 1px solid var(--border);
   overflow-y: auto;
-  padding: 20px 0;
+  padding: 16px 0;
   z-index: 50;
   scrollbar-width: thin;
   scrollbar-color: var(--border) transparent;
@@ -231,15 +254,15 @@ body {
 }
 
 .sidebar-section {
-  margin-bottom: 8px;
+  margin-bottom: 4px;
 }
 
 .sidebar-heading {
-  padding: 8px 24px;
-  font-size: 0.7rem;
+  padding: 10px 20px 6px;
+  font-size: 0.65rem;
   font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.1em;
   color: var(--text-muted);
   user-select: none;
 }
@@ -247,12 +270,12 @@ body {
 .sidebar-link {
   display: flex;
   align-items: center;
-  padding: 7px 24px 7px 28px;
-  font-size: 0.875rem;
+  padding: 5px 20px 5px 24px;
+  font-size: 0.825rem;
   color: var(--text-sidebar);
   text-decoration: none;
-  transition: all 0.15s;
-  border-left: 3px solid transparent;
+  transition: all 0.12s;
+  border-left: 2px solid transparent;
   cursor: pointer;
 }
 .sidebar-link:hover {
@@ -281,14 +304,14 @@ body {
   color: white;
   border: none;
   border-radius: 50%;
-  width: 48px;
-  height: 48px;
+  width: 44px;
+  height: 44px;
   cursor: pointer;
   box-shadow: var(--shadow-lg);
   align-items: center;
   justify-content: center;
 }
-.sidebar-toggle svg { width: 24px; height: 24px; }
+.sidebar-toggle svg { width: 20px; height: 20px; }
 
 /* ===== Main Content ===== */
 .main {
@@ -300,7 +323,7 @@ body {
 }
 
 .content {
-  max-width: 820px;
+  max-width: 800px;
   margin: 0 auto;
   padding: 40px 48px 80px;
 }
@@ -319,15 +342,15 @@ body {
 }
 
 .toc-inner {
-  border-left: 1px solid var(--border-light);
+  border-left: 1px solid var(--border);
   padding-left: 16px;
 }
 
 .toc-title {
-  font-size: 0.7rem;
+  font-size: 0.65rem;
   font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.1em;
   color: var(--text-muted);
   margin-bottom: 12px;
 }
@@ -338,12 +361,12 @@ body {
 }
 
 .toc-link {
-  font-size: 0.8rem;
+  font-size: 0.78rem;
   color: var(--text-muted);
   text-decoration: none;
-  padding: 4px 0;
+  padding: 3px 0;
   line-height: 1.4;
-  transition: color 0.15s;
+  transition: color 0.12s;
   border-left: 2px solid transparent;
   margin-left: -17px;
   padding-left: 15px;
@@ -361,10 +384,9 @@ body {
 }
 .toc-link.toc-h3 {
   padding-left: 27px;
-  font-size: 0.75rem;
+  font-size: 0.72rem;
 }
 
-/* When TOC is visible, adjust content max-width */
 @media (min-width: 1280px) {
   .content {
     margin-left: 48px;
@@ -376,30 +398,30 @@ body {
 .content h1 {
   font-size: 2.25rem;
   font-weight: 800;
-  line-height: 1.2;
+  line-height: 1.15;
   margin-bottom: 12px;
-  letter-spacing: -0.02em;
+  letter-spacing: -0.03em;
   color: var(--text);
 }
 .content h2 {
-  font-size: 1.5rem;
+  font-size: 1.4rem;
   font-weight: 700;
   margin-top: 48px;
   margin-bottom: 16px;
   padding-bottom: 8px;
-  border-bottom: 1px solid var(--border-light);
-  letter-spacing: -0.01em;
+  border-bottom: 1px solid var(--border);
+  letter-spacing: -0.02em;
   scroll-margin-top: calc(var(--header-height) + 16px);
 }
 .content h3 {
-  font-size: 1.2rem;
+  font-size: 1.15rem;
   font-weight: 600;
   margin-top: 32px;
   margin-bottom: 12px;
   scroll-margin-top: calc(var(--header-height) + 16px);
 }
 .content h4 {
-  font-size: 1.05rem;
+  font-size: 1rem;
   font-weight: 600;
   margin-top: 24px;
   margin-bottom: 8px;
@@ -411,13 +433,16 @@ body {
 }
 
 .content a {
-  color: var(--accent);
+  color: var(--accent-hover);
   text-decoration: none;
   font-weight: 500;
-  transition: color 0.15s;
+  transition: color 0.12s;
+}
+[data-theme="light"] .content a {
+  color: var(--accent);
 }
 .content a:hover {
-  color: var(--accent-hover);
+  color: var(--docker-blue-light);
   text-decoration: underline;
 }
 .content a:focus-visible {
@@ -438,7 +463,7 @@ body {
 }
 
 .content > .subtitle {
-  font-size: 1.15rem;
+  font-size: 1.1rem;
   color: var(--text-muted);
   margin-bottom: 32px;
   line-height: 1.6;
@@ -447,11 +472,12 @@ body {
 /* Inline code */
 .content code {
   font-family: var(--font-mono);
-  font-size: 0.875em;
+  font-size: 0.85em;
   background: var(--bg-code);
   color: var(--text-code);
-  padding: 2px 6px;
+  padding: 2px 7px;
   border-radius: 4px;
+  border: 1px solid var(--border);
 }
 
 /* Code blocks */
@@ -466,13 +492,11 @@ body {
 }
 .content pre code {
   background: none;
-  color: #abb2bf;
+  color: #CBD5E1;
   padding: 0;
-  font-size: 0.85rem;
-  line-height: 1.6;
-}
-[data-theme="dark"] .content pre {
-  border-color: var(--border);
+  font-size: 0.84rem;
+  line-height: 1.65;
+  border: none;
 }
 
 /* Rouge / highlighter-rouge overrides */
@@ -481,11 +505,10 @@ body {
 .content .highlighter-rouge pre.highlight,
 .content .highlighter-rouge pre.highlight code {
   background: var(--bg-code-block);
-  color: #abb2bf;
+  color: #CBD5E1;
   text-shadow: none;
 }
 
-/* Ensure rouge wrapper div doesn't add margins */
 .content .highlighter-rouge {
   margin-bottom: 20px;
 }
@@ -502,51 +525,51 @@ body {
 }
 .content .highlighter-rouge pre.highlight code {
   padding: 0;
-  font-size: 0.85rem;
-  line-height: 1.6;
+  font-size: 0.84rem;
+  line-height: 1.65;
   background: none;
+  border: none;
 }
 
-/* Don't style inline code inside code blocks */
 .content .highlighter-rouge code {
   background: none;
-  color: #abb2bf;
+  color: #CBD5E1;
   padding: 0;
+  border: none;
 }
 
-/* Rouge syntax token colors (monokai-inspired, matches dark blocks) */
-.highlight .c, .highlight .c1, .highlight .cm, .highlight .cs { color: #5c6370; font-style: italic; } /* comments */
-.highlight .k, .highlight .kd, .highlight .kn, .highlight .kp, .highlight .kr { color: #c678dd; } /* keywords */
-.highlight .kc { color: #d19a66; } /* keyword constant */
-.highlight .kt { color: #e5c07b; } /* keyword type */
-.highlight .s, .highlight .s1, .highlight .s2, .highlight .sb, .highlight .sc, .highlight .sh { color: #98c379; } /* strings */
-.highlight .na { color: #e06c75; } /* name attribute (yaml keys) */
-.highlight .nb, .highlight .bp { color: #61afef; } /* builtin */
-.highlight .nc, .highlight .nn { color: #e5c07b; } /* class/namespace */
-.highlight .nf, .highlight .fm { color: #61afef; } /* function */
-.highlight .no { color: #d19a66; } /* constant */
-.highlight .ni { color: #abb2bf; } /* entity */
-.highlight .ne { color: #e06c75; } /* exception */
-.highlight .nv, .highlight .vi, .highlight .vc, .highlight .vg { color: #e06c75; } /* variables */
-.highlight .o, .highlight .ow { color: #56b6c2; } /* operator */
-.highlight .p, .highlight .pi { color: #abb2bf; } /* punctuation */
-.highlight .m, .highlight .mi, .highlight .mf, .highlight .mh, .highlight .il { color: #d19a66; } /* numbers */
-.highlight .sr { color: #98c379; } /* regex */
-.highlight .ss { color: #56b6c2; } /* symbol */
-.highlight .nt { color: #e06c75; } /* tag */
-.highlight .err { color: #e06c75; } /* error */
-.highlight .gh { color: #abb2bf; font-weight: bold; } /* heading */
-.highlight .gd { color: #e06c75; } /* diff deleted */
-.highlight .gi { color: #98c379; } /* diff inserted */
-.highlight .w { color: #abb2bf; } /* whitespace */
-
+/* Rouge syntax token colors – Docker-blue-tinted dark theme */
+.highlight .c, .highlight .c1, .highlight .cm, .highlight .cs { color: #4A5568; font-style: italic; }
+.highlight .k, .highlight .kd, .highlight .kn, .highlight .kp, .highlight .kr { color: #A78BFA; }
+.highlight .kc { color: #F59E0B; }
+.highlight .kt { color: #FBBF24; }
+.highlight .s, .highlight .s1, .highlight .s2, .highlight .sb, .highlight .sc, .highlight .sh { color: #34D399; }
+.highlight .na { color: #7DD3FC; }
+.highlight .nb, .highlight .bp { color: #60A5FA; }
+.highlight .nc, .highlight .nn { color: #FBBF24; }
+.highlight .nf, .highlight .fm { color: #60A5FA; }
+.highlight .no { color: #F59E0B; }
+.highlight .ni { color: #CBD5E1; }
+.highlight .ne { color: #F87171; }
+.highlight .nv, .highlight .vi, .highlight .vc, .highlight .vg { color: #F87171; }
+.highlight .o, .highlight .ow { color: #22D3EE; }
+.highlight .p, .highlight .pi { color: #CBD5E1; }
+.highlight .m, .highlight .mi, .highlight .mf, .highlight .mh, .highlight .il { color: #F59E0B; }
+.highlight .sr { color: #34D399; }
+.highlight .ss { color: #22D3EE; }
+.highlight .nt { color: #F87171; }
+.highlight .err { color: #F87171; }
+.highlight .gh { color: #CBD5E1; font-weight: bold; }
+.highlight .gd { color: #F87171; }
+.highlight .gi { color: #34D399; }
+.highlight .w { color: #CBD5E1; }
 
 /* ===== Tables ===== */
 .content table {
   width: 100%;
   border-collapse: collapse;
   margin-bottom: 24px;
-  font-size: 0.9rem;
+  font-size: 0.875rem;
 }
 .content th {
   text-align: left;
@@ -554,7 +577,7 @@ body {
   background: var(--bg-code);
   border: 1px solid var(--border);
   font-weight: 600;
-  font-size: 0.85rem;
+  font-size: 0.825rem;
   color: var(--text);
 }
 .content td {
@@ -568,53 +591,61 @@ body {
   padding: 16px 20px;
   border-radius: var(--radius);
   margin-bottom: 20px;
-  border-left: 4px solid;
-  font-size: 0.9rem;
+  border-left: 3px solid;
+  font-size: 0.875rem;
+  background: var(--bg-card);
 }
 .callout p { margin-bottom: 0; }
 .callout-title {
   font-weight: 700;
-  font-size: 0.8rem;
+  font-size: 0.75rem;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.06em;
   margin-bottom: 6px;
 }
 
 .callout-info {
-  background: #eff6ff;
   border-color: var(--info);
-  color: #1e40af;
+  color: var(--info);
 }
-[data-theme="dark"] .callout-info {
-  background: #172554;
-  color: #93c5fd;
-}
+.callout-info p { color: var(--text-secondary); }
 
 .callout-tip {
-  background: #ecfdf5;
   border-color: var(--success);
-  color: #065f46;
+  color: var(--success);
 }
-[data-theme="dark"] .callout-tip {
-  background: #052e16;
-  color: #6ee7b7;
-}
+.callout-tip p { color: var(--text-secondary); }
 
 .callout-warning {
-  background: #fffbeb;
   border-color: var(--warning);
-  color: #92400e;
+  color: var(--warning);
 }
-[data-theme="dark"] .callout-warning {
-  background: #451a03;
-  color: #fcd34d;
+.callout-warning p { color: var(--text-secondary); }
+
+[data-theme="light"] .callout-info {
+  background: #EFF6FF;
+  border-color: var(--accent);
+  color: #1E40AF;
 }
+[data-theme="light"] .callout-info p { color: #1E40AF; }
+[data-theme="light"] .callout-tip {
+  background: #ECFDF5;
+  border-color: #10B981;
+  color: #065F46;
+}
+[data-theme="light"] .callout-tip p { color: #065F46; }
+[data-theme="light"] .callout-warning {
+  background: #FFFBEB;
+  border-color: #F59E0B;
+  color: #92400E;
+}
+[data-theme="light"] .callout-warning p { color: #92400E; }
 
 /* ===== Cards Grid ===== */
 .cards {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-  gap: 16px;
+  gap: 12px;
   margin-bottom: 24px;
 }
 .card {
@@ -629,7 +660,7 @@ body {
 }
 .card:hover {
   border-color: var(--accent);
-  box-shadow: var(--shadow-md);
+  box-shadow: 0 0 20px rgba(29,99,237,0.1);
   transform: translateY(-2px);
   text-decoration: none;
 }
@@ -638,57 +669,78 @@ body {
   outline-offset: 2px;
 }
 .card-icon {
-  font-size: 1.5rem;
-  margin-bottom: 12px;
+  font-size: 1.4rem;
+  margin-bottom: 10px;
 }
 .card h3 {
-  font-size: 1rem;
+  font-size: 0.95rem;
   margin-top: 0;
-  margin-bottom: 8px;
+  margin-bottom: 6px;
   font-weight: 600;
 }
 .card p {
-  font-size: 0.875rem;
+  font-size: 0.825rem;
   margin-bottom: 0;
   color: var(--text-muted);
 }
 
 /* ===== Hero section (home page) ===== */
 .hero {
-  background: var(--bg-hero);
+  background: linear-gradient(145deg, #09101F 0%, #0D1D3A 40%, #1D63ED 100%);
   color: var(--text-on-hero);
   padding: 64px 48px;
   border-radius: var(--radius-lg);
   margin-bottom: 48px;
   text-align: center;
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgba(29,99,237,0.2);
+}
+[data-theme="light"] .hero {
+  background: linear-gradient(145deg, #0F172A 0%, #1E3A5F 40%, #1D63ED 100%);
+}
+.hero::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: radial-gradient(ellipse at 70% 20%, rgba(29,99,237,0.3) 0%, transparent 60%);
+  pointer-events: none;
 }
 .hero h1 {
   font-size: 2.75rem;
   font-weight: 800;
   margin-bottom: 16px;
   color: white;
+  letter-spacing: -0.03em;
+  position: relative;
 }
 .hero p {
-  font-size: 1.15rem;
-  opacity: 0.9;
-  max-width: 640px;
-  margin: 0 auto 28px;
-  color: rgba(255,255,255,0.9);
+  font-size: 1.1rem;
+  opacity: 0.85;
+  max-width: 600px;
+  margin: 0 auto 32px;
+  color: rgba(255,255,255,0.85);
+  position: relative;
+  line-height: 1.6;
 }
 .hero-buttons {
   display: flex;
   gap: 12px;
   justify-content: center;
   flex-wrap: wrap;
+  position: relative;
 }
 .btn {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  padding: 12px 24px;
+  padding: 10px 22px;
   border-radius: var(--radius);
   font-weight: 600;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   text-decoration: none;
   transition: all 0.2s;
   cursor: pointer;
@@ -696,49 +748,56 @@ body {
 }
 .btn-primary {
   background: white;
-  color: #1a56db;
+  color: #1D63ED;
 }
 .btn-primary:hover {
-  background: #f0f4ff;
+  background: #F0F4FF;
   text-decoration: none;
   transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.2);
 }
 .btn-secondary {
-  background: rgba(255,255,255,0.15);
+  background: rgba(255,255,255,0.1);
   color: white;
-  border: 1px solid rgba(255,255,255,0.3);
+  border: 1px solid rgba(255,255,255,0.2);
+  backdrop-filter: blur(8px);
 }
 .btn-secondary:hover {
-  background: rgba(255,255,255,0.25);
+  background: rgba(255,255,255,0.18);
   text-decoration: none;
 }
 
-/* Feature pills on home */
+/* Feature grid on home */
 .features-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 20px;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 16px;
   margin-bottom: 40px;
 }
 .feature {
-  padding: 28px;
+  padding: 24px;
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   background: var(--bg-card);
+  transition: border-color 0.2s;
+}
+.feature:hover {
+  border-color: rgba(29,99,237,0.3);
 }
 .feature-icon {
-  font-size: 1.75rem;
-  margin-bottom: 12px;
+  font-size: 1.5rem;
+  margin-bottom: 10px;
 }
 .feature h3 {
-  font-size: 1.05rem;
+  font-size: 1rem;
   margin-top: 0;
   margin-bottom: 8px;
 }
 .feature p {
-  font-size: 0.9rem;
+  font-size: 0.85rem;
   color: var(--text-muted);
   margin: 0;
+  line-height: 1.55;
 }
 
 /* ===== Demo GIF ===== */
@@ -767,7 +826,7 @@ body {
 .page-nav a {
   display: flex;
   flex-direction: column;
-  padding: 16px 20px;
+  padding: 14px 18px;
   border: 1px solid var(--border);
   border-radius: var(--radius);
   text-decoration: none;
@@ -777,19 +836,20 @@ body {
 }
 .page-nav a:hover {
   border-color: var(--accent);
-  box-shadow: var(--shadow-sm);
+  box-shadow: 0 0 16px rgba(29,99,237,0.08);
   text-decoration: none;
 }
 .page-nav .nav-label {
-  font-size: 0.75rem;
+  font-size: 0.7rem;
   color: var(--text-muted);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.06em;
   margin-bottom: 4px;
 }
 .page-nav .nav-title {
   font-weight: 600;
   color: var(--accent);
+  font-size: 0.9rem;
 }
 .page-nav .next { text-align: right; margin-left: auto; }
 
@@ -798,7 +858,8 @@ body {
   display: none;
   position: fixed;
   inset: 0;
-  background: rgba(0,0,0,0.5);
+  background: rgba(0,0,0,0.6);
+  backdrop-filter: blur(4px);
   z-index: 1000;
   align-items: flex-start;
   justify-content: center;
@@ -806,10 +867,10 @@ body {
 }
 .search-overlay.active { display: flex; }
 .search-modal {
-  background: var(--bg);
+  background: var(--bg-sidebar);
   border-radius: var(--radius-lg);
   width: 90%;
-  max-width: 600px;
+  max-width: 560px;
   max-height: 70vh;
   overflow: hidden;
   box-shadow: var(--shadow-lg);
@@ -817,25 +878,26 @@ body {
 }
 .search-modal input {
   width: 100%;
-  padding: 16px 20px;
+  padding: 14px 20px;
   border: none;
   border-bottom: 1px solid var(--border);
-  background: var(--bg);
+  background: transparent;
   color: var(--text);
-  font-size: 1rem;
+  font-size: 0.95rem;
   outline: none;
+  font-family: var(--font-sans);
 }
 .search-results {
   overflow-y: auto;
-  max-height: calc(70vh - 60px);
+  max-height: calc(70vh - 56px);
   padding: 8px;
 }
 .search-result {
   display: block;
-  padding: 10px 16px;
+  padding: 8px 14px;
   border-radius: var(--radius);
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background 0.12s;
   text-decoration: none;
   color: var(--text);
 }
@@ -847,25 +909,25 @@ body {
 }
 .search-result-title {
   font-weight: 500;
-  font-size: 0.9rem;
+  font-size: 0.85rem;
   color: var(--text);
 }
 .search-result-group {
-  padding: 12px 16px 4px;
-  font-size: 0.7rem;
+  padding: 10px 14px 4px;
+  font-size: 0.65rem;
   font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.1em;
   color: var(--text-muted);
   user-select: none;
 }
 .search-result-group:not(:first-child) {
   margin-top: 4px;
-  border-top: 1px solid var(--border-light);
-  padding-top: 12px;
+  border-top: 1px solid var(--border);
+  padding-top: 10px;
 }
 .search-result-match {
-  font-size: 0.78rem;
+  font-size: 0.75rem;
   color: var(--text-muted);
   margin-top: 2px;
   font-style: italic;
@@ -877,7 +939,7 @@ body {
   padding: 24px;
   text-align: center;
   color: var(--text-muted);
-  font-size: 0.9rem;
+  font-size: 0.875rem;
 }
 
 /* ===== Responsive ===== */
@@ -908,7 +970,7 @@ body {
 }
 
 @media (max-width: 640px) {
-  .header-search input { width: 160px; }
+  .header-search input { width: 140px; }
   .content h1 { font-size: 1.75rem; }
   .cards { grid-template-columns: 1fr; }
   .features-grid { grid-template-columns: 1fr; }
@@ -923,9 +985,9 @@ body {
 ::-webkit-scrollbar-thumb:hover { background: var(--text-muted); }
 
 /* ===== Transitions ===== */
-.content { animation: fadeIn 0.2s ease; }
+.content { animation: fadeIn 0.15s ease; }
 @keyframes fadeIn {
-  from { opacity: 0; transform: translateY(8px); }
+  from { opacity: 0; transform: translateY(6px); }
   to { opacity: 1; transform: translateY(0); }
 }
 
@@ -934,7 +996,7 @@ kbd {
   display: inline-block;
   padding: 2px 6px;
   font-family: var(--font-mono);
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   color: var(--text-muted);
   background: var(--bg-code);
   border: 1px solid var(--border);
@@ -947,20 +1009,20 @@ kbd {
   position: absolute;
   top: 8px;
   right: 8px;
-  background: rgba(255,255,255,0.1);
-  border: none;
+  background: rgba(255,255,255,0.06);
+  border: 1px solid rgba(255,255,255,0.1);
   border-radius: 4px;
-  color: #718096;
+  color: #64748B;
   cursor: pointer;
-  padding: 4px 8px;
-  font-size: 0.75rem;
+  padding: 3px 8px;
+  font-size: 0.7rem;
   font-family: var(--font-mono);
   opacity: 0;
-  transition: opacity 0.2s;
+  transition: opacity 0.2s, background 0.2s;
 }
 pre:hover .copy-btn { opacity: 1; }
-.copy-btn:hover { background: rgba(255,255,255,0.2); color: #a0aec0; }
-.copy-btn.copied { color: var(--success); }
+.copy-btn:hover { background: rgba(255,255,255,0.12); color: #94A3B8; }
+.copy-btn.copied { color: var(--success); border-color: var(--success); }
 
 /* ===== Print stylesheet ===== */
 @media print {

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,7 @@ That's it. Your agent can now read and write files, run shell commands, and reas
 ## See It in Action
 
 <div class="demo-container">
-  <img src="demo.gif" alt="Docker Agent TUI demo showing an interactive agent session" loading="lazy">
+  <img src="{{ '/demo.gif' | relative_url }}" alt="Docker Agent TUI demo showing an interactive agent session" loading="lazy">
 </div>
 
 ## Why Docker Agent?

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,124 +1,199 @@
 ---
 layout: default
-title: "docker-agent"
-description: "Build, run, and share powerful AI agents with a declarative YAML or HCL config, rich tool ecosystem, and multi-agent orchestration — by Docker."
+title: "Docker Agent"
+description: "An open-source runtime for AI agents. Define agents in YAML — not code — with tools, multi-agent teams, and any LLM. Package and share them like container images."
 permalink: /
 ---
 
 <div class="hero">
-  <h1>docker-agent</h1>
-  <p>Build, run, and share powerful AI agents with a declarative YAML or HCL config, rich tool ecosystem, and multi-agent orchestration — by Docker.</p>
+  <h1>Docker Agent</h1>
+  <p>An open-source runtime for AI agents. Define agents in YAML, give them tools, wire up multi-agent teams — and run them anywhere. No framework code required.</p>
   <div class="hero-buttons">
-    <a href="{{ '/getting-started/introduction/' | relative_url }}" class="btn btn-primary">Get Started</a>
-    <a href="https://github.com/docker/docker-agent" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">GitHub →</a>
+    <a href="{{ '/getting-started/quickstart/' | relative_url }}" class="btn btn-primary">Quick Start →</a>
+    <a href="https://github.com/docker/docker-agent" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">View on GitHub</a>
   </div>
 </div>
 
-<div class="features-grid">
-  <div class="feature">
-    <div class="feature-icon">🤖</div>
-    <h3>Declarative Agents</h3>
-    <p>Define agents in simple YAML or HCL — their model, tools, behavior, and relationships. No framework code required.</p>
-  </div>
-  <div class="feature">
-    <div class="feature-icon">🔧</div>
-    <h3>Rich Tool Ecosystem</h3>
-    <p>Built-in tools for filesystem, shell, memory, and more. Extend with any MCP server — local, remote, or Docker-based.</p>
-  </div>
-  <div class="feature">
-    <div class="feature-icon">👥</div>
-    <h3>Multi-Agent Orchestration</h3>
-    <p>Create teams of specialized agents that delegate tasks to each other automatically via a coordinator.</p>
-  </div>
-  <div class="feature">
-    <div class="feature-icon">🧠</div>
-    <h3>Multi-Model Support</h3>
-    <p>Use OpenAI, Anthropic, Google Gemini, AWS Bedrock, Docker Model Runner, or bring your own provider.</p>
-  </div>
-  <div class="feature">
-    <div class="feature-icon">📦</div>
-    <h3>Package &amp; Share</h3>
-    <p>Push agents to any OCI-compatible registry. Pull and run them anywhere — just like container images.</p>
-  </div>
-  <div class="feature">
-    <div class="feature-icon">🖥️</div>
-    <h3>Multiple Interfaces</h3>
-    <p>Beautiful TUI for interactive sessions, CLI for scripting, HTTP API for integrations, and MCP mode for interop.</p>
-  </div>
-</div>
+## What Is Docker Agent?
 
-## See It in Action
+Docker Agent is an open-source tool from Docker that lets you **build, run, and share AI agents using simple configuration files** instead of writing application code.
 
-<div class="demo-container">
-  <img src="demo.gif" alt="docker agent TUI demo showing an interactive agent session" loading="lazy">
-</div>
-
-## Quick Example
-
-Create a file called `agent.yaml`:
+You describe what your agent does — its model, personality, tools, and teammates — in a YAML file. Docker Agent handles the LLM orchestration loop, tool execution, multi-agent delegation, and streaming output. You focus on *what* the agent should do, not *how* to wire it up.
 
 ```yaml
+# agent.yaml — this is all you need
 agents:
   root:
     model: anthropic/claude-sonnet-4-5
-    description: A helpful coding assistant
+    description: A coding assistant
     instruction: |
       You are an expert developer. Help users write clean,
-      efficient code and follow best practices.
+      efficient code. Explain your reasoning step by step.
     toolsets:
       - type: filesystem
       - type: shell
       - type: think
 ```
 
-Then run it:
+```bash
+$ docker agent run agent.yaml
+```
+
+That's it. Your agent can now read and write files, run shell commands, and reason through problems — all through an interactive terminal UI.
+
+## See It in Action
+
+<div class="demo-container">
+  <img src="demo.gif" alt="Docker Agent TUI demo showing an interactive agent session" loading="lazy">
+</div>
+
+## Why Docker Agent?
+
+Most AI agent frameworks ask you to write Python or TypeScript to glue together models, tools, and workflows. Docker Agent takes a different approach: **declare everything in config, run it with a single command.**
+
+<div class="features-grid">
+  <div class="feature">
+    <div class="feature-icon">📝</div>
+    <h3>Config, Not Code</h3>
+    <p>Define agents in YAML or HCL. Swap models, add tools, or change behavior without touching application code.</p>
+  </div>
+  <div class="feature">
+    <div class="feature-icon">🔧</div>
+    <h3>Built-in Tools + MCP</h3>
+    <p>Comes with tools for filesystem, shell, memory, web fetch, and more. Extend with any MCP server — over 1,000 are available.</p>
+  </div>
+  <div class="feature">
+    <div class="feature-icon">👥</div>
+    <h3>Multi-Agent Teams</h3>
+    <p>Build teams of specialized agents that delegate work to each other. A coordinator routes tasks to the right specialist.</p>
+  </div>
+  <div class="feature">
+    <div class="feature-icon">🧠</div>
+    <h3>Any Model</h3>
+    <p>OpenAI, Anthropic, Google Gemini, AWS Bedrock, local models via Docker Model Runner or Ollama — bring your own provider.</p>
+  </div>
+  <div class="feature">
+    <div class="feature-icon">📦</div>
+    <h3>Package &amp; Share Like Images</h3>
+    <p>Push agents to any OCI registry. Pull and run them anywhere with one command — the same workflow you use for containers.</p>
+  </div>
+  <div class="feature">
+    <div class="feature-icon">🖥️</div>
+    <h3>Run Anywhere</h3>
+    <p>Interactive TUI, headless CLI, HTTP API server, OpenAI-compatible chat endpoint, MCP server, or A2A protocol.</p>
+  </div>
+</div>
+
+## How It Works
+
+Docker Agent follows a simple loop:
+
+1. **You define an agent** in YAML — its model, instructions, tools, and sub-agents
+2. **You run it** with `docker agent run` via TUI, CLI, or API
+3. **The agent processes your request** — calling tools, delegating to sub-agents, reasoning step by step
+4. **Results stream back** in real time
+
+### Zero Config
+
+The fastest way to try it — no config file needed:
 
 ```bash
-# Launch the interactive TUI
-docker agent run agent.yaml
+# Run the built-in default agent
+$ docker agent run
+```
 
-# Or run a one-shot command
-docker agent run --exec agent.yaml "Explain the code in main.go"
+### From the Registry
+
+Run pre-built agents from the [agent catalog](https://hub.docker.com/u/agentcatalog) — just like pulling a Docker image:
+
+```bash
+# A pirate-themed assistant
+$ docker agent run agentcatalog/pirate
+
+# A coding agent
+$ docker agent run agentcatalog/coder
+```
+
+### Multi-Agent Teams
+
+Build a team where a coordinator delegates tasks to specialists:
+
+```yaml
+agents:
+  root:
+    model: openai/gpt-5
+    description: Team coordinator
+    instruction: Route tasks to the best specialist.
+    sub_agents: [coder, reviewer]
+
+  coder:
+    model: anthropic/claude-sonnet-4-5
+    description: Writes and modifies code
+    instruction: Write clean, tested code.
+    toolsets:
+      - type: filesystem
+      - type: shell
+
+  reviewer:
+    model: anthropic/claude-sonnet-4-5
+    description: Reviews code for quality
+    instruction: Review code for bugs, style, and best practices.
+    toolsets:
+      - type: filesystem
+```
+
+### Non-Interactive Mode
+
+Use `--exec` for scripting and automation:
+
+```bash
+# One-shot task
+$ docker agent run --exec agent.yaml "Create a Dockerfile for a Node.js app"
+
+# Pipe input
+$ cat error.log | docker agent run --exec agent.yaml "What's wrong in this log?"
+
+# Serve as an API
+$ docker agent serve api agent.yaml --listen :8080
 ```
 
 <div class="callout callout-tip" markdown="1">
 <div class="callout-title">💡 Prefer HCL?
 </div>
-  <p>You can also write agents as <code>.hcl</code> files. See <a href="{{ '/configuration/hcl/' | relative_url }}">HCL Configuration</a> for the block-based syntax.</p>
+  <p>You can also write agent configs in HCL using labeled blocks and heredocs. See <a href="{{ '/configuration/hcl/' | relative_url }}">HCL Configuration</a>.</p>
 </div>
 
 ## Explore the Docs
 
 <div class="cards">
-<a class="card" href="{{ '/getting-started/introduction/' | relative_url }}">
-    <div class="card-icon">🚀
-</div>
-    <h3>Getting Started</h3>
-    <p>Learn what docker agent is and get your first agent running in minutes.</p>
+  <a class="card" href="{{ '/getting-started/introduction/' | relative_url }}">
+    <div class="card-icon">🚀</div>
+    <h3>Introduction</h3>
+    <p>The full story: what Docker Agent is, why it exists, and how it works.</p>
+  </a>
+  <a class="card" href="{{ '/getting-started/quickstart/' | relative_url }}">
+    <div class="card-icon">⚡</div>
+    <h3>Quick Start</h3>
+    <p>Get your first agent running in under 5 minutes.</p>
   </a>
   <a class="card" href="{{ '/concepts/agents/' | relative_url }}">
     <div class="card-icon">💡</div>
     <h3>Core Concepts</h3>
-    <p>Understand agents, models, tools, and multi-agent orchestration.</p>
+    <p>Agents, models, tools, and multi-agent orchestration explained.</p>
   </a>
   <a class="card" href="{{ '/configuration/overview/' | relative_url }}">
     <div class="card-icon">⚙️</div>
     <h3>Configuration</h3>
-    <p>Complete reference for agent, model, and tool configuration.</p>
-  </a>
-  <a class="card" href="{{ '/features/tui/' | relative_url }}">
-    <div class="card-icon">✨</div>
-    <h3>Features</h3>
-    <p>TUI, CLI, MCP mode, RAG, Skills, and distribution.</p>
+    <p>Full reference for every YAML and HCL option.</p>
   </a>
   <a class="card" href="{{ '/providers/overview/' | relative_url }}">
     <div class="card-icon">🧠</div>
     <h3>Model Providers</h3>
-    <p>OpenAI, Anthropic, Gemini, AWS Bedrock, Docker Model Runner, and custom providers.</p>
+    <p>OpenAI, Anthropic, Gemini, Bedrock, Docker Model Runner, and more.</p>
   </a>
-  <a class="card" href="{{ '/community/contributing/' | relative_url }}">
-    <div class="card-icon">🤝</div>
-    <h3>Community</h3>
-    <p>Contributing guidelines, troubleshooting, and more.</p>
+  <a class="card" href="{{ '/features/tui/' | relative_url }}">
+    <div class="card-icon">✨</div>
+    <h3>Features</h3>
+    <p>TUI, CLI, API server, MCP mode, A2A, RAG, Skills, and distribution.</p>
   </a>
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ permalink: /
 
 <div class="hero">
   <h1>Docker Agent</h1>
-  <p>An open-source runtime for AI agents. Define agents in YAML, give them tools, wire up multi-agent teams — and run them anywhere. No framework code required.</p>
+  <p>An open-source runtime for AI agents. Define agents in YAML, give them tools, wire up multi-agent teams — and run them anywhere.</p>
   <div class="hero-buttons">
     <a href="{{ '/getting-started/quickstart/' | relative_url }}" class="btn btn-primary">Quick Start →</a>
     <a href="https://github.com/docker/docker-agent" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">View on GitHub</a>

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -69,16 +69,30 @@ function buildTOC() {
 
 function setupScrollSpy(headings, aside) {
   let currentActive = null;
-  const observer = new IntersectionObserver((entries) => {
-    const intersecting = entries
-      .filter(e => e.isIntersecting)
-      .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+  const visibleIds = new Set();
+  const tocLinks = aside.querySelectorAll('.toc-link');
 
-    const topmost = intersecting[0];
-    if (topmost && topmost.target.id !== currentActive) {
-      currentActive = topmost.target.id;
-      aside.querySelectorAll('.toc-link').forEach(l => l.classList.remove('active'));
-      aside.querySelector(`.toc-link[data-id="${currentActive}"]`)?.classList.add('active');
+  const observer = new IntersectionObserver((entries) => {
+    for (const entry of entries) {
+      if (entry.isIntersecting) {
+        visibleIds.add(entry.target.id);
+      } else {
+        visibleIds.delete(entry.target.id);
+      }
+    }
+
+    // Pick the first heading (in DOM order) that is currently visible
+    let nextActive = null;
+    for (const h of headings) {
+      if (visibleIds.has(h.id)) { nextActive = h.id; break; }
+    }
+
+    if (nextActive !== currentActive) {
+      currentActive = nextActive;
+      tocLinks.forEach(l => l.classList.remove('active'));
+      if (currentActive) {
+        aside.querySelector(`.toc-link[data-id="${currentActive}"]`)?.classList.add('active');
+      }
     }
   }, { rootMargin: '-80px 0px -70% 0px', threshold: 0 });
 
@@ -101,10 +115,14 @@ function addCopyButtons() {
     btn.textContent = 'Copy';
     btn.setAttribute('aria-label', 'Copy code to clipboard');
     btn.addEventListener('click', async () => {
-      const text = pre.querySelector('code')?.textContent ?? pre.textContent;
-      await navigator.clipboard.writeText(text);
-      btn.textContent = 'Copied!';
-      btn.classList.add('copied');
+      try {
+        const text = pre.querySelector('code')?.textContent ?? pre.textContent;
+        await navigator.clipboard.writeText(text);
+        btn.textContent = 'Copied!';
+        btn.classList.add('copied');
+      } catch {
+        btn.textContent = 'Failed';
+      }
       setTimeout(() => { btn.textContent = 'Copy'; btn.classList.remove('copied'); }, 2000);
     });
     pre.style.position = 'relative';

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -12,26 +12,27 @@ const $searchResults = document.getElementById('search-results');
 
 // ---------- Theme ----------
 function initTheme() {
-  const saved = localStorage.getItem('cagent-docs-theme');
-  const theme = saved || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : null);
-  if (theme) document.documentElement.setAttribute('data-theme', theme);
+  const saved = localStorage.getItem('docker-agent-docs-theme');
+  if (saved === 'light') {
+    document.documentElement.setAttribute('data-theme', 'light');
+  } else if (!saved && window.matchMedia?.('(prefers-color-scheme: light)').matches) {
+    document.documentElement.setAttribute('data-theme', 'light');
+  }
+  // Dark is the default — no attribute needed (CSS :root is dark)
 }
 
 function toggleTheme() {
-  const next = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
-  document.documentElement.setAttribute('data-theme', next);
-  localStorage.setItem('cagent-docs-theme', next);
+  const isLight = document.documentElement.getAttribute('data-theme') === 'light';
+  if (isLight) {
+    document.documentElement.removeAttribute('data-theme');
+    localStorage.setItem('docker-agent-docs-theme', 'dark');
+  } else {
+    document.documentElement.setAttribute('data-theme', 'light');
+    localStorage.setItem('docker-agent-docs-theme', 'light');
+  }
 }
 
 // ---------- Table of Contents ----------
-function slugify(text) {
-  return text.toLowerCase()
-    .replace(/[^a-z0-9\s-]/g, '')
-    .replace(/\s+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '');
-}
-
 function buildTOC() {
   if (!$content) return;
 
@@ -67,12 +68,17 @@ function buildTOC() {
 }
 
 function setupScrollSpy(headings, aside) {
+  let currentActive = null;
   const observer = new IntersectionObserver((entries) => {
-    for (const entry of entries) {
-      if (entry.isIntersecting) {
-        aside.querySelectorAll('.toc-link').forEach(l => l.classList.remove('active'));
-        aside.querySelector(`.toc-link[data-id="${entry.target.id}"]`)?.classList.add('active');
-      }
+    const intersecting = entries
+      .filter(e => e.isIntersecting)
+      .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+
+    const topmost = intersecting[0];
+    if (topmost && topmost.target.id !== currentActive) {
+      currentActive = topmost.target.id;
+      aside.querySelectorAll('.toc-link').forEach(l => l.classList.remove('active'));
+      aside.querySelector(`.toc-link[data-id="${currentActive}"]`)?.classList.add('active');
     }
   }, { rootMargin: '-80px 0px -70% 0px', threshold: 0 });
 
@@ -82,17 +88,21 @@ function setupScrollSpy(headings, aside) {
 // ---------- Copy buttons ----------
 function addCopyButtons() {
   if (!$content) return;
-  // Target both direct <pre> and Rouge-generated pre.highlight
+  const seen = new WeakSet();
   $content.querySelectorAll('pre, pre.highlight').forEach(pre => {
+    if (seen.has(pre)) return;
     if (pre.querySelector('.copy-btn')) return;
-    // Skip if this pre is inside a .highlight div that already has a button
-    if (pre.closest('.highlight')?.querySelector('.copy-btn')) return;
+    const parent = pre.parentElement;
+    if (parent?.classList.contains('highlight') && parent.querySelector('.copy-btn')) return;
+    seen.add(pre);
+
     const btn = document.createElement('button');
     btn.className = 'copy-btn';
     btn.textContent = 'Copy';
     btn.setAttribute('aria-label', 'Copy code to clipboard');
     btn.addEventListener('click', async () => {
-      await navigator.clipboard.writeText(pre.querySelector('code')?.textContent || pre.textContent);
+      const text = pre.querySelector('code')?.textContent ?? pre.textContent;
+      await navigator.clipboard.writeText(text);
       btn.textContent = 'Copied!';
       btn.classList.add('copied');
       setTimeout(() => { btn.textContent = 'Copy'; btn.classList.remove('copied'); }, 2000);
@@ -103,27 +113,27 @@ function addCopyButtons() {
 }
 
 // ---------- Search ----------
-// Build a search index from sidebar links and page content
 const searchIndex = [];
 
 function buildSearchIndex() {
-  // Index from sidebar navigation
-  document.querySelectorAll('.sidebar-link').forEach(link => {
+  const sidebarLinks = document.querySelectorAll('.sidebar-link');
+  sidebarLinks.forEach(link => {
+    const href = link.getAttribute('href');
+    if (!href) return;
     const section = link.closest('.sidebar-section')?.querySelector('.sidebar-heading')?.textContent || '';
     searchIndex.push({
       title: link.textContent.trim(),
-      url: link.getAttribute('href'),
+      url: href,
       section: section,
       searchText: `${link.textContent} ${section}`.toLowerCase(),
     });
   });
 
-  // Also index current page content for richer results
   if ($content) {
-    const currentEntry = searchIndex.find(e => {
-      const currentPath = window.location.pathname;
-      return currentPath.endsWith(e.url) || currentPath.endsWith(e.url.replace(/\/$/, ''));
-    });
+    const currentPath = window.location.pathname;
+    const currentEntry = searchIndex.find(e =>
+      currentPath.endsWith(e.url) || currentPath.endsWith(e.url.replace(/\/$/, ''))
+    );
     if (currentEntry) {
       currentEntry.searchText += ' ' + $content.textContent.replace(/\s+/g, ' ').toLowerCase();
     }
@@ -169,7 +179,6 @@ function renderSearchResults(query) {
     return;
   }
 
-  // Group results by section to avoid repeating section names
   let html = '';
   let lastSection = '';
   for (const r of results) {
@@ -212,11 +221,18 @@ function restoreSidebarScroll() {
     sidebar.scrollTop = parseInt(saved, 10);
   }
 
-  // Before navigating away, save the current scroll position
   sidebar.querySelectorAll('a').forEach(link => {
     link.addEventListener('click', () => {
       sessionStorage.setItem('sidebar-scroll', sidebar.scrollTop);
     });
+  });
+}
+
+// ---------- Bind buttons (no inline handlers) ----------
+function bindButtons() {
+  document.getElementById('theme-toggle')?.addEventListener('click', toggleTheme);
+  document.querySelector('.sidebar-toggle')?.addEventListener('click', () => {
+    document.getElementById('sidebar')?.classList.toggle('open');
   });
 }
 
@@ -226,3 +242,4 @@ restoreSidebarScroll();
 buildSearchIndex();
 buildTOC();
 addCopyButtons();
+bindButtons();


### PR DESCRIPTION
## Summary

Redesigns the docs site to be more Docker-branded and better at explaining what Docker Agent is.

### Visual redesign
- **Dark-mode-first**: Default theme is Docker navy (`#09101F`) with Docker Blue (`#1D63ED`) accents; respects `prefers-color-scheme` system preference
- **Docker whale logo** in header and favicon (replaces generic robot icon)
- Hero gradient from Docker navy to Docker Blue with radial glow
- Refined typography, spacing, and syntax highlighting with Docker-blue-tinted token colors
- Light mode available as opt-in alternate theme

### Homepage rewrite
- New **"What Is Docker Agent?"** section explains the product in plain English before listing features
- Shows the minimal YAML + `docker agent run` example immediately so readers see the full experience in seconds
- Features reframed as differentiators ("Config, Not Code", "Package & Share Like Images")
- **"How It Works"** walks through the usage progression: zero-config → registry pull → multi-agent teams → API mode
- Inline multi-agent team example demonstrates the most differentiating capability
- Removed "no framework code" claim since Docker Agent can also be used as a Go library

### Code quality
- No inline `onclick` handlers — all event listeners bound in JS (CSP-compatible)
- `demo.gif` uses `relative_url` filter so it resolves under `baseurl: /docker-agent`
- TOC scroll-spy tracks visible headings in a `Set` and clears active state when scrolling above all headings
- `navigator.clipboard.writeText()` wrapped in try/catch with user feedback on failure
- Copy button uses `WeakSet` to prevent duplicates
- Search index skips sidebar links with no `href`

### Files changed
- `docs/css/style.css` — Full visual overhaul
- `docs/_includes/header.html` — Docker whale logo, cleaner branding
- `docs/_layouts/default.html` — Favicon, meta tags, removed inline handlers
- `docs/index.md` — Rewritten homepage
- `docs/js/app.js` — Dark-mode-first logic, CSP fixes, scroll spy optimization
- `docs/404.md` — Minor copy update