### PR TITLE
feat: wire TUI/CLI to emit Document parts and render attachments

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -3,7 +3,6 @@ package app
 import (
 	"cmp"
 	"context"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -437,43 +436,27 @@ func (a *App) processFileAttachment(ctx context.Context, att messages.Attachment
 		textBuilder.WriteString(content)
 
 	case chat.IsSupportedMimeType(mimeType):
-		if chat.IsImageMimeType(mimeType) {
-			// Read, resize if needed, and inline as base64 data URL.
-			// This works across all providers (not just Anthropic's File API).
-			imgData, readErr := os.ReadFile(absPath)
-			if readErr != nil {
-				slog.WarnContext(ctx, "skipping attachment: failed to read image", "path", absPath, "error", readErr)
-				a.sendEvent(ctx, runtime.Warning(fmt.Sprintf("Skipped attachment %s: failed to read image", att.Name), ""))
-				return true
-			}
-			resized, resizeErr := chat.ResizeImage(imgData, mimeType)
-			if resizeErr != nil {
-				// Don't bypass security checks - reject the file if resize failed
-				slog.WarnContext(ctx, "skipping attachment: image resize failed", "path", absPath, "error", resizeErr)
-				a.sendEvent(ctx, runtime.Warning(fmt.Sprintf("Skipped attachment %s: %s", att.Name, resizeErr), ""))
-				return true
-			}
-			dataURL := fmt.Sprintf("data:%s;base64,%s", resized.MimeType, base64.StdEncoding.EncodeToString(resized.Data))
-			*binaryParts = append(*binaryParts, chat.MessagePart{
-				Type: chat.MessagePartTypeImageURL,
-				ImageURL: &chat.MessageImageURL{
-					URL:    dataURL,
-					Detail: chat.ImageURLDetailAuto,
-				},
-			})
-			if note := chat.FormatDimensionNote(resized); note != "" {
+		// Route through ProcessAttachmentWithMetadata for normalised Document output.
+		// For images this also returns resize metadata used to emit a dimension note.
+		doc, resizeMeta, procErr := chat.ProcessAttachmentWithMetadata(chat.MessagePart{
+			Type: chat.MessagePartTypeFile,
+			File: &chat.MessageFile{Path: absPath, MimeType: mimeType},
+		})
+		if procErr != nil {
+			slog.WarnContext(ctx, "skipping attachment: processing failed", "path", absPath, "error", procErr)
+			a.sendEvent(ctx, runtime.Warning(fmt.Sprintf("Skipped attachment %s: %s", att.Name, procErr), ""))
+			return true
+		}
+		// For images, emit a dimension note so the model can map coordinates back to the original.
+		if resizeMeta != nil {
+			if note := chat.FormatDimensionNote(resizeMeta); note != "" {
 				textBuilder.WriteString("\n" + note)
 			}
-		} else {
-			// Non-image supported types (e.g. PDF) use the file upload path.
-			*binaryParts = append(*binaryParts, chat.MessagePart{
-				Type: chat.MessagePartTypeFile,
-				File: &chat.MessageFile{
-					Path:     absPath,
-					MimeType: mimeType,
-				},
-			})
 		}
+		*binaryParts = append(*binaryParts, chat.MessagePart{
+			Type:     chat.MessagePartTypeDocument,
+			Document: &doc,
+		})
 
 	default:
 		slog.WarnContext(ctx, "skipping attachment: unsupported file type", "path", absPath, "mime_type", mimeType)

--- a/pkg/app/transcript/testdata/user_message_image_document.golden
+++ b/pkg/app/transcript/testdata/user_message_image_document.golden
@@ -1,0 +1,5 @@
+## User
+
+Check this image
+
+[image: photo.jpg (image/jpeg, 41.0 KB)]

--- a/pkg/app/transcript/testdata/user_message_pdf_document.golden
+++ b/pkg/app/transcript/testdata/user_message_pdf_document.golden
@@ -1,0 +1,5 @@
+## User
+
+Summarise this PDF
+
+[attachment: report.pdf (application/pdf, 245.8 KB)]

--- a/pkg/app/transcript/testdata/user_message_text_document.golden
+++ b/pkg/app/transcript/testdata/user_message_text_document.golden
@@ -1,0 +1,5 @@
+## User
+
+Review this file
+
+[attachment: readme.md (text/markdown)]

--- a/pkg/app/transcript/transcript.go
+++ b/pkg/app/transcript/transcript.go
@@ -37,6 +37,12 @@ func writeUserMessage(builder *strings.Builder, msg session.Message) {
 	builder.WriteString("\n## User\n")
 
 	// When MultiContent is present, render text and attachment chips.
+	// The text part reflects what was actually sent to the model (the user's
+	// original typed text, plus any dimension notes from image resizing and
+	// inlined file headers from ReadFileForInline). This is intentional: a
+	// transcript should show what the model received, not just what the user
+	// typed into the prompt box. Callers wanting just the raw typed text
+	// should read msg.Message.Content directly.
 	if len(msg.Message.MultiContent) > 0 {
 		for _, part := range msg.Message.MultiContent {
 			switch part.Type {

--- a/pkg/app/transcript/transcript.go
+++ b/pkg/app/transcript/transcript.go
@@ -34,7 +34,64 @@ func PlainText(sess *session.Session) string {
 }
 
 func writeUserMessage(builder *strings.Builder, msg session.Message) {
-	fmt.Fprintf(builder, "\n## User\n\n%s\n", msg.Message.Content)
+	builder.WriteString("\n## User\n")
+
+	// When MultiContent is present, render text and attachment chips.
+	if len(msg.Message.MultiContent) > 0 {
+		for _, part := range msg.Message.MultiContent {
+			switch part.Type {
+			case chat.MessagePartTypeText:
+				if part.Text != "" {
+					fmt.Fprintf(builder, "\n%s\n", part.Text)
+				}
+			case chat.MessagePartTypeDocument:
+				if part.Document != nil {
+					doc := part.Document
+					switch {
+					case chat.IsImageMimeType(doc.MimeType):
+						size := doc.Size
+						if size == 0 {
+							size = int64(len(doc.Source.InlineData))
+						}
+						fmt.Fprintf(builder, "\n[image: %s (%s, %s)]\n", doc.Name, doc.MimeType, formatBytes(size))
+					case doc.Source.InlineText != "":
+						fmt.Fprintf(builder, "\n[attachment: %s (%s)]\n", doc.Name, doc.MimeType)
+					default:
+						size := doc.Size
+						if size == 0 {
+							size = int64(len(doc.Source.InlineData))
+						}
+						fmt.Fprintf(builder, "\n[attachment: %s (%s, %s)]\n", doc.Name, doc.MimeType, formatBytes(size))
+					}
+				}
+			// Note: superseded types kept for backward-compat with stored sessions.
+			case chat.MessagePartTypeImageURL:
+				if part.ImageURL != nil {
+					fmt.Fprintf(builder, "\n[image: %s]\n", part.ImageURL.URL[:min(len(part.ImageURL.URL), 60)])
+				}
+			case chat.MessagePartTypeFile:
+				if part.File != nil {
+					fmt.Fprintf(builder, "\n[file: %s]\n", part.File.Path)
+				}
+			}
+		}
+		return
+	}
+	fmt.Fprintf(builder, "\n%s\n", msg.Message.Content)
+}
+
+// formatBytes returns a human-readable byte size string (e.g. "1.2 MB").
+func formatBytes(b int64) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), "KMGTPE"[exp])
 }
 
 func writeAssistantMessage(builder *strings.Builder, msg session.Message) {

--- a/pkg/app/transcript/transcript_test.go
+++ b/pkg/app/transcript/transcript_test.go
@@ -75,3 +75,87 @@ func TestToolCalls(t *testing.T) {
 
 	golden.Assert(t, content, "tool_calls.golden")
 }
+
+// ─── Document attachment rendering ───────────────────────────────────────────
+
+func TestUserMessageWithImageDocument(t *testing.T) {
+	msg := session.UserMessage(
+		"Check this image",
+		chat.MessagePart{Type: chat.MessagePartTypeText, Text: "Check this image"},
+		chat.MessagePart{
+			Type: chat.MessagePartTypeDocument,
+			Document: &chat.Document{
+				Name:     "photo.jpg",
+				MimeType: "image/jpeg",
+				Size:     42000,
+				Source:   chat.DocumentSource{InlineData: []byte{0xFF, 0xD8}},
+			},
+		},
+	)
+	sess := session.New()
+	sess.AddMessage(msg)
+	content := PlainText(sess)
+	golden.Assert(t, content, "user_message_image_document.golden")
+}
+
+func TestUserMessageWithPDFDocument(t *testing.T) {
+	msg := session.UserMessage(
+		"Summarise this PDF",
+		chat.MessagePart{Type: chat.MessagePartTypeText, Text: "Summarise this PDF"},
+		chat.MessagePart{
+			Type: chat.MessagePartTypeDocument,
+			Document: &chat.Document{
+				Name:     "report.pdf",
+				MimeType: "application/pdf",
+				Size:     251658, // ~245 KB
+				Source:   chat.DocumentSource{InlineData: []byte{0x25, 0x50, 0x44, 0x46}},
+			},
+		},
+	)
+	sess := session.New()
+	sess.AddMessage(msg)
+	content := PlainText(sess)
+	golden.Assert(t, content, "user_message_pdf_document.golden")
+}
+
+func TestUserMessageWithTextDocument(t *testing.T) {
+	msg := session.UserMessage(
+		"Review this file",
+		chat.MessagePart{Type: chat.MessagePartTypeText, Text: "Review this file"},
+		chat.MessagePart{
+			Type: chat.MessagePartTypeDocument,
+			Document: &chat.Document{
+				Name:     "readme.md",
+				MimeType: "text/markdown",
+				Source:   chat.DocumentSource{InlineText: "# Hello World"},
+			},
+		},
+	)
+	sess := session.New()
+	sess.AddMessage(msg)
+	content := PlainText(sess)
+	golden.Assert(t, content, "user_message_text_document.golden")
+}
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		input int64
+		want  string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1023, "1023 B"},
+		{1536, "1.5 KB"},
+		{1024 * 1024, "1.0 MB"},
+		{2 * 1024 * 1024, "2.0 MB"},
+		{1536 * 1024, "1.5 MB"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := formatBytes(tt.input)
+			if got != tt.want {
+				t.Errorf("formatBytes(%d) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"cmp"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -336,7 +335,7 @@ func PrepareUserMessage(ctx context.Context, rt runtime.Runtime, userInput, glob
 	// Use either the per-message attachment or the global one
 	finalAttachPath := cmp.Or(attachPath, globalAttachPath)
 
-	return CreateUserMessageWithAttachment(messageText, finalAttachPath)
+	return CreateUserMessageWithAttachment(ctx, messageText, finalAttachPath)
 }
 
 // ParseAttachCommand parses user input for /attach commands
@@ -394,19 +393,16 @@ func ParseAttachCommand(userInput string) (messageText, attachPath string) {
 }
 
 // CreateUserMessageWithAttachment creates a user message with optional file attachment.
-// Text files are inlined directly as text content for cross-provider compatibility.
-// Binary files (images, PDFs) are stored as file references for provider-specific upload.
+// All attachment processing (MIME detection, image resize, text inlining) is delegated
+// to [chat.ProcessAttachment], which runs once at message-assembly time.
 //
 // Returns the prepared session.Message and the absolute path of the file that
 // was actually attached. The returned path is empty when no attachment was
 // produced (no path supplied, file unreadable, type unsupported, file too
 // large to inline, etc.). Callers should record successful attachments via
 // session.Session.AddAttachedFile so sub-agents inherit the file context.
-func CreateUserMessageWithAttachment(userContent, attachmentPath string) (*session.Message, string) {
-	// noAttachment returns the message without any attachment. It's used both
-	// when the caller didn't supply a path and as the fallback for every
-	// best-effort failure below (unreadable file, unsupported type, etc.) so
-	// the user always gets at least a plain text message.
+func CreateUserMessageWithAttachment(ctx context.Context, userContent, attachmentPath string) (*session.Message, string) {
+	// noAttachment returns the message without any attachment.
 	noAttachment := func() (*session.Message, string) {
 		return session.UserMessage(userContent), ""
 	}
@@ -427,26 +423,23 @@ func CreateUserMessageWithAttachment(userContent, attachmentPath string) (*sessi
 		return noAttachment()
 	}
 
-	// Ensure we have some text content when attaching a file
+	// Ensure we have some text content when attaching a file.
 	textContent := cmp.Or(strings.TrimSpace(userContent), "Please analyze this attached file.")
 
 	multiContent := []chat.MessagePart{
-		{
-			Type: chat.MessagePartTypeText,
-			Text: textContent,
-		},
+		{Type: chat.MessagePartTypeText, Text: textContent},
 	}
 
 	switch {
 	case chat.IsTextFile(absPath):
 		// Text files are inlined directly as text content.
 		if fi.Size() > chat.MaxInlineFileSize {
-			slog.Warn("Attachment text file too large to inline", "path", absPath, "size", fi.Size())
+			slog.WarnContext(ctx, "Attachment text file too large to inline", "path", absPath, "size", fi.Size())
 			return noAttachment()
 		}
 		content, err := chat.ReadFileForInline(absPath)
 		if err != nil {
-			slog.Warn("Failed to read attachment file", "path", absPath, "error", err)
+			slog.WarnContext(ctx, "Failed to read attachment file", "path", absPath, "error", err)
 			return noAttachment()
 		}
 		multiContent = append(multiContent, chat.MessagePart{
@@ -455,44 +448,23 @@ func CreateUserMessageWithAttachment(userContent, attachmentPath string) (*sessi
 		})
 
 	default:
-		// Binary files (images, PDFs) are handled based on type.
-		mimeType := chat.DetectMimeType(absPath)
-		if !chat.IsSupportedMimeType(mimeType) {
-			slog.Warn("Unsupported attachment file type", "path", absPath, "mime_type", mimeType)
+		// Binary files (images, PDFs, etc.) — delegate to ProcessAttachment.
+		if !chat.IsSupportedMimeType(chat.DetectMimeType(absPath)) {
+			slog.WarnContext(ctx, "Unsupported attachment file type", "path", absPath)
 			return noAttachment()
 		}
-		if chat.IsImageMimeType(mimeType) {
-			// Read, resize if needed, and inline as base64 data URL.
-			// This ensures cross-provider compatibility (not all providers
-			// support file references).
-			imgData, readErr := os.ReadFile(absPath)
-			if readErr != nil {
-				slog.Warn("Failed to read image attachment", "path", absPath, "error", readErr)
-				return noAttachment()
-			}
-			resized, resizeErr := chat.ResizeImage(imgData, mimeType)
-			if resizeErr != nil {
-				slog.Warn("Image resize failed for attachment", "path", absPath, "error", resizeErr)
-				return noAttachment()
-			}
-			dataURL := fmt.Sprintf("data:%s;base64,%s", resized.MimeType, base64.StdEncoding.EncodeToString(resized.Data))
-			multiContent = append(multiContent, chat.MessagePart{
-				Type: chat.MessagePartTypeImageURL,
-				ImageURL: &chat.MessageImageURL{
-					URL:    dataURL,
-					Detail: chat.ImageURLDetailAuto,
-				},
-			})
-		} else {
-			// Non-image binary files (e.g. PDFs) are kept as file references.
-			multiContent = append(multiContent, chat.MessagePart{
-				Type: chat.MessagePartTypeFile,
-				File: &chat.MessageFile{
-					Path:     absPath,
-					MimeType: mimeType,
-				},
-			})
+		doc, _, procErr := chat.ProcessAttachmentWithMetadata(chat.MessagePart{
+			Type: chat.MessagePartTypeFile,
+			File: &chat.MessageFile{Path: absPath},
+		})
+		if procErr != nil {
+			slog.WarnContext(ctx, "Failed to process attachment", "path", absPath, "error", procErr)
+			return noAttachment()
 		}
+		multiContent = append(multiContent, chat.MessagePart{
+			Type:     chat.MessagePartTypeDocument,
+			Document: &doc,
+		})
 	}
 
 	return session.UserMessage(textContent, multiContent...), absPath

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -2078,7 +2078,89 @@ func TestStripImageContent(t *testing.T) {
 			},
 		},
 		{
-			name: "mixed messages only strips images",
+			name: "strips document parts with image MIME type",
+			messages: []chat.Message{
+				{
+					Role: chat.MessageRoleUser,
+					MultiContent: []chat.MessagePart{
+						{Type: chat.MessagePartTypeText, Text: "look at this"},
+						{
+							Type: chat.MessagePartTypeDocument,
+							Document: &chat.Document{
+								Name:     "photo.png",
+								MimeType: "image/png",
+								Source:   chat.DocumentSource{InlineData: []byte{0x89, 0x50}},
+							},
+						},
+					},
+				},
+			},
+			want: []chat.Message{
+				{
+					Role: chat.MessageRoleUser,
+					MultiContent: []chat.MessagePart{
+						{Type: chat.MessagePartTypeText, Text: "look at this"},
+					},
+				},
+			},
+		},
+		{
+			name: "preserves document parts with non-image MIME type",
+			messages: []chat.Message{
+				{
+					Role: chat.MessageRoleUser,
+					MultiContent: []chat.MessagePart{
+						{Type: chat.MessagePartTypeText, Text: "here is the doc"},
+						{
+							Type: chat.MessagePartTypeDocument,
+							Document: &chat.Document{
+								Name:     "report.pdf",
+								MimeType: "application/pdf",
+								Source:   chat.DocumentSource{InlineData: []byte{0x25, 0x50}},
+							},
+						},
+					},
+				},
+			},
+			want: []chat.Message{
+				{
+					Role: chat.MessageRoleUser,
+					MultiContent: []chat.MessagePart{
+						{Type: chat.MessagePartTypeText, Text: "here is the doc"},
+						{
+							Type: chat.MessagePartTypeDocument,
+							Document: &chat.Document{
+								Name:     "report.pdf",
+								MimeType: "application/pdf",
+								Source:   chat.DocumentSource{InlineData: []byte{0x25, 0x50}},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "preserves document part with nil Document pointer (defensive)",
+			messages: []chat.Message{
+				{
+					Role: chat.MessageRoleUser,
+					MultiContent: []chat.MessagePart{
+						{Type: chat.MessagePartTypeText, Text: "text"},
+						{Type: chat.MessagePartTypeDocument, Document: nil},
+					},
+				},
+			},
+			want: []chat.Message{
+				{
+					Role: chat.MessageRoleUser,
+					MultiContent: []chat.MessagePart{
+						{Type: chat.MessagePartTypeText, Text: "text"},
+						{Type: chat.MessagePartTypeDocument, Document: nil},
+					},
+				},
+			},
+		},
+		{
 			messages: []chat.Message{
 				{Role: chat.MessageRoleUser, Content: "plain text"},
 				{

--- a/pkg/runtime/strip_modalities.go
+++ b/pkg/runtime/strip_modalities.go
@@ -99,6 +99,11 @@ func stripImageContent(messages []chat.Message) []chat.Message {
 				if part.File != nil && chat.IsImageMimeType(part.File.MimeType) {
 					continue
 				}
+			case chat.MessagePartTypeDocument:
+				// Drop Document parts that carry image InlineData.
+				if part.Document != nil && chat.IsImageMimeType(part.Document.MimeType) {
+					continue
+				}
 			}
 			filtered = append(filtered, part)
 		}


### PR DESCRIPTION
## Summary

Final Phase 1 wiring: routes all binary attachments through `chat.ProcessAttachmentWithMetadata` and emits `MessagePartTypeDocument` parts instead of the legacy `MessagePartTypeImageURL` and `MessagePartTypeFile` parts. Part of #2595.

## Changes

### `pkg/app/app.go` — TUI attachment wiring

`processFileAttachment` previously had two separate branches for images (read→resize→base64 data URL → `MessagePartTypeImageURL`) and non-image binaries (path-ref → `MessagePartTypeFile`). Both are replaced with a single `chat.ProcessAttachmentWithMetadata` call that produces a `MessagePartTypeDocument`. The dimension note for resized images is still emitted via the returned `*ImageResizeResult`. Removes `encoding/base64` import.

### `pkg/cli/runner.go` — CLI attachment wiring

`CreateUserMessageWithAttachment` gains a `ctx context.Context` parameter (threaded through to `slog.WarnContext`). The separate image-resize and PDF-ref branches are replaced with `ProcessAttachmentWithMetadata` → `MessagePartTypeDocument`. Removes `encoding/base64` import.

### `pkg/runtime/strip_modalities.go` — Document stripping

Added `MessagePartTypeDocument` case: when stripping image modalities, drop document parts whose `MimeType` is an image type. Consistent with existing handling for `MessagePartTypeImageURL` and `MessagePartTypeFile`.

### `pkg/app/transcript/transcript.go` — Transcript rendering

`writeUserMessage` now:
- Always emits the `## User` heading once before rendering parts (fixes a regression where heading was omitted for attachment-only messages)
- Renders `MessagePartTypeDocument` parts as chips:
  - Image: `[image: name.jpg (image/jpeg, 42.3 KB)]`
  - Binary/PDF: `[attachment: report.pdf (application/pdf, 245.0 KB)]`
  - Text: `[attachment: readme.md (text/markdown)]`
- Backward-compat rendering for legacy `MessagePartTypeImageURL` and `MessagePartTypeFile` parts in stored sessions
- New `formatBytes` helper

## What's NOT changed
- The `MessagePartTypeFile` and `MessagePartTypeImageURL` types remain in `pkg/chat` for backward-compat with serialized sessions
- Provider packages are untouched — they already handle `MessagePartTypeDocument` via `convertDocument` from #2639
- `pkg/chatserver`, `pkg/runtime/toolexec` image paths are intentionally unchanged (they produce parts from already-processed data)

Part of #2595