### PR TITLE
feat: add docs preview workflow for PRs

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,0 +1,59 @@
+name: Docs Preview
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+  pull-requests: write
+
+concurrency:
+  group: docs-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build-preview:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@e5517072e87f198d9533967ae13d97c11b604005 # v1.99.0
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: docs
+
+      - name: Build Jekyll site
+        run: |
+          cd docs
+          bundle exec jekyll build --baseurl "/docker-agent/pr-${{ github.event.pull_request.number }}"
+        env:
+          JEKYLL_ENV: production
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        with:
+          path: docs/_site
+
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+
+      - name: Comment preview URL
+        if: success()
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: docs-preview
+          message: |
+            📖 **Docs preview**: ${{ steps.deploy.outputs.page_url }}

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -4,18 +4,20 @@ on:
   pull_request:
     paths:
       - "docs/**"
-
-permissions:
-  contents: write
-  pull-requests: write
+    types: [opened, synchronize, reopened, closed]
 
 concurrency:
   group: docs-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
-  build-preview:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+  build-and-deploy:
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository
+      && github.event.action != 'closed'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     environment:
       name: github-pages
       url: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}/
@@ -34,7 +36,7 @@ jobs:
         working-directory: docs
 
       - name: Build Jekyll site
-        run: bundle exec jekyll build --baseurl "/docker-agent/pr-${{ github.event.pull_request.number }}"
+        run: bundle exec jekyll build --baseurl "/${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}"
         working-directory: docs
         env:
           JEKYLL_ENV: production
@@ -46,10 +48,42 @@ jobs:
           publish_dir: docs/_site
           destination_dir: pr-${{ github.event.pull_request.number }}
 
+  comment:
+    needs: build-and-deploy
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository
+      && github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
       - name: Comment preview URL
-        if: success()
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: docs-preview
           message: |
             📖 **Docs preview**: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}/
+
+  cleanup:
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository
+      && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: gh-pages
+
+      - name: Remove preview directory
+        run: |
+          PR_DIR="pr-${{ github.event.pull_request.number }}"
+          if [ -d "$PR_DIR" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git rm -rf "$PR_DIR"
+            git commit -m "chore: remove docs preview for PR #${{ github.event.pull_request.number }}"
+            git push
+          fi

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -6,23 +6,19 @@ on:
       - "docs/**"
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
   pull-requests: write
 
 concurrency:
   group: docs-preview-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
 
 jobs:
   build-preview:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-      pull-requests: write
+    environment:
+      name: github-pages
+      url: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}/
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -31,24 +27,24 @@ jobs:
         uses: ruby/setup-ruby@e5517072e87f198d9533967ae13d97c11b604005 # v1.99.0
         with:
           ruby-version: "3.3"
-          bundler-cache: true
           working-directory: docs
 
+      - name: Install dependencies
+        run: bundle install
+        working-directory: docs
+
       - name: Build Jekyll site
-        run: |
-          cd docs
-          bundle exec jekyll build --baseurl "/docker-agent/pr-${{ github.event.pull_request.number }}"
+        run: bundle exec jekyll build --baseurl "/docker-agent/pr-${{ github.event.pull_request.number }}"
+        working-directory: docs
         env:
           JEKYLL_ENV: production
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
-        with:
-          path: docs/_site
-
       - name: Deploy to GitHub Pages
-        id: deploy
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/_site
+          destination_dir: pr-${{ github.event.pull_request.number }}
 
       - name: Comment preview URL
         if: success()
@@ -56,4 +52,4 @@ jobs:
         with:
           header: docs-preview
           message: |
-            📖 **Docs preview**: ${{ steps.deploy.outputs.page_url }}
+            📖 **Docs preview**: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}/


### PR DESCRIPTION
Add a GitHub Actions workflow that builds and deploys a preview of the docs site on PRs that touch `docs/**`.

**What it does:**
- Builds the Jekyll site with a PR-specific base URL
- Deploys to GitHub Pages
- Posts a sticky comment with the preview link

All actions are SHA-pinned per project conventions.