### PR TITLE
refactor: simplify RuntimeConfig by removing dead field and caching env provider

### DIFF
--- a/pkg/config/runtime.go
+++ b/pkg/config/runtime.go
@@ -16,8 +16,8 @@ type RuntimeConfig struct {
 	Config
 
 	EnvProviderForTests environment.Provider
-	envProvider         environment.Provider
-	envProviderLock     sync.Mutex
+	envProviderCached   environment.Provider
+	envProviderOnce     sync.Once
 
 	ModelsDevStoreOverride *modelsdev.Store
 	modelsDevStore         *modelsdev.Store
@@ -48,12 +48,16 @@ type Config struct {
 
 func (runConfig *RuntimeConfig) Clone() *RuntimeConfig {
 	store, storeErr := runConfig.ModelsDevStore()
+	env := runConfig.EnvProvider()
 	clone := &RuntimeConfig{
 		Config:                 runConfig.Config,
+		EnvProviderForTests:    runConfig.EnvProviderForTests,
+		envProviderCached:      env,
 		ModelsDevStoreOverride: runConfig.ModelsDevStoreOverride,
 		modelsDevStore:         store,
 		modelsDevStoreErr:      storeErr,
 	}
+	clone.envProviderOnce.Do(func() {})    // mark as resolved
 	clone.modelsDevStoreOnce.Do(func() {}) // mark as resolved
 	clone.EnvFiles = slices.Clone(runConfig.EnvFiles)
 	clone.Models = maps.Clone(runConfig.Models)
@@ -86,12 +90,10 @@ func (runConfig *RuntimeConfig) EnvProvider() environment.Provider {
 		return runConfig.EnvProviderForTests
 	}
 
-	runConfig.envProviderLock.Lock()
-	defer runConfig.envProviderLock.Unlock()
-
-	env := runConfig.computedEnvProvider()
-	runConfig.envProvider = env
-	return env
+	runConfig.envProviderOnce.Do(func() {
+		runConfig.envProviderCached = runConfig.computedEnvProvider()
+	})
+	return runConfig.envProviderCached
 }
 
 func (runConfig *RuntimeConfig) computedEnvProvider() environment.Provider {


### PR DESCRIPTION
## Summary

- Remove the dead `envProvider` field (written but never read)
- Replace `envProviderLock sync.Mutex` with `sync.Once` caching, matching the existing `ModelsDevStore()` pattern
- Propagate the cached env provider through `Clone()`

This eliminates redundant recomputation on every `EnvProvider()` call and makes the two lazy-init patterns in `RuntimeConfig` consistent.