### PR TITLE
perf: TUI rendering performance improvements

### DIFF
--- a/pkg/tui/components/messages/messages.go
+++ b/pkg/tui/components/messages/messages.go
@@ -2,6 +2,7 @@ package messages
 
 import (
 	"slices"
+	"sort"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -106,6 +107,7 @@ type model struct {
 	renderedLines     []string               // Cached rendered content as lines (avoids split/join per frame)
 	renderedItems     map[int]renderedItem   // Cache of rendered items with positions
 	urlSpans          *urlSpanCache          // Cached URL spans per rendered line
+	lineOffsets       []int                  // Prefix-sum: lineOffsets[i] = starting global line of view i
 	totalHeight       int                    // Total height of all content in lines
 	renderDirty       bool                   // True when rendered content needs rebuild
 
@@ -342,24 +344,26 @@ func (m *model) handleMouseClick(msg tea.MouseClickMsg) (layout.Model, tea.Cmd) 
 func (m *model) globalLineToMessageLine(globalLine int) (msgIdx, localLine int) {
 	m.ensureAllItemsRendered()
 
-	currentLine := 0
-	for i, view := range m.views {
-		item := m.renderItem(i, view)
-		if item.height == 0 {
-			continue
-		}
-
-		endLine := currentLine + item.height
-		if globalLine >= currentLine && globalLine < endLine {
-			return i, globalLine - currentLine
-		}
-
-		currentLine = endLine
-		if m.needsSeparator(i) {
-			currentLine++ // Account for separator line
-		}
+	if len(m.lineOffsets) == 0 || globalLine < 0 || globalLine >= m.totalHeight {
+		return -1, -1
 	}
 
+	// Binary search: find the last view whose offset <= globalLine
+	i := sort.Search(len(m.lineOffsets), func(i int) bool {
+		return m.lineOffsets[i] > globalLine
+	}) - 1
+
+	if i < 0 || i >= len(m.views) {
+		return -1, -1
+	}
+
+	item := m.renderItem(i, m.views[i])
+	local := globalLine - m.lineOffsets[i]
+	if local < item.height {
+		return i, local
+	}
+
+	// globalLine falls in a separator gap between messages
 	return -1, -1
 }
 
@@ -953,20 +957,14 @@ func (m *model) scrollToSelectedMessage() {
 		return
 	}
 
-	// Ensure all items are rendered so totalHeight is accurate
+	// Ensure all items are rendered so lineOffsets and totalHeight are accurate
 	m.ensureAllItemsRendered()
 
-	// Calculate the line range for the selected message
-	startLine := 0
-	for i := range m.selectedMessageIndex {
-		if i < len(m.views) {
-			item := m.renderItem(i, m.views[i])
-			startLine += item.height
-			if m.needsSeparator(i) {
-				startLine++
-			}
-		}
+	if m.selectedMessageIndex >= len(m.lineOffsets) {
+		return
 	}
+
+	startLine := m.lineOffsets[m.selectedMessageIndex]
 
 	var selectedHeight int
 	if m.selectedMessageIndex < len(m.views) {
@@ -1124,8 +1122,10 @@ func (m *model) ensureAllItemsRendered() {
 	}
 
 	var allLines []string
+	offsets := make([]int, len(m.views))
 
 	for i, view := range m.views {
+		offsets[i] = len(allLines)
 		item := m.renderItem(i, view)
 		if len(item.lines) == 0 {
 			continue
@@ -1140,6 +1140,7 @@ func (m *model) ensureAllItemsRendered() {
 
 	// Store lines directly - avoid join/split on every View() call
 	m.renderedLines = allLines
+	m.lineOffsets = offsets
 	m.totalHeight = len(allLines)
 	m.urlSpans.clear()
 	m.renderDirty = false
@@ -1155,6 +1156,7 @@ func (m *model) invalidateItem(index int) {
 func (m *model) invalidateAllItems() {
 	m.renderedItems = make(map[int]renderedItem)
 	m.renderedLines = nil
+	m.lineOffsets = nil
 	m.totalHeight = 0
 	m.urlSpans.clear()
 	m.renderDirty = true

--- a/pkg/tui/components/messages/messages.go
+++ b/pkg/tui/components/messages/messages.go
@@ -105,6 +105,7 @@ type model struct {
 	slackAnimationSub animation.Subscription // Subscription to animation ticks while slack > 0
 	renderedLines     []string               // Cached rendered content as lines (avoids split/join per frame)
 	renderedItems     map[int]renderedItem   // Cache of rendered items with positions
+	urlSpans          *urlSpanCache          // Cached URL spans per rendered line
 	totalHeight       int                    // Total height of all content in lines
 	renderDirty       bool                   // True when rendered content needs rebuild
 
@@ -156,6 +157,7 @@ func newModel(width, height int, sessionState *service.SessionState) *model {
 		width:                width,
 		height:               height,
 		renderedItems:        make(map[int]renderedItem),
+		urlSpans:             newURLSpanCache(),
 		sessionState:         sessionState,
 		scrollview:           sv,
 		selectedMessageIndex: -1,
@@ -1139,6 +1141,7 @@ func (m *model) ensureAllItemsRendered() {
 	// Store lines directly - avoid join/split on every View() call
 	m.renderedLines = allLines
 	m.totalHeight = len(allLines)
+	m.urlSpans.clear()
 	m.renderDirty = false
 }
 
@@ -1153,6 +1156,7 @@ func (m *model) invalidateAllItems() {
 	m.renderedItems = make(map[int]renderedItem)
 	m.renderedLines = nil
 	m.totalHeight = 0
+	m.urlSpans.clear()
 	m.renderDirty = true
 }
 

--- a/pkg/tui/components/messages/messages.go
+++ b/pkg/tui/components/messages/messages.go
@@ -666,18 +666,23 @@ func (m *model) Focus() tea.Cmd {
 		// Fall back to last selectable if no assistant messages
 		m.selectedMessageIndex = m.findLastSelectableMessage()
 	}
-	// Invalidate render cache so selection highlight is shown
-	m.invalidateAllItems()
+	// Only invalidate the newly selected message
+	if m.selectedMessageIndex >= 0 {
+		m.invalidateItem(m.selectedMessageIndex)
+	}
 	m.renderDirty = true
 	return nil
 }
 
 // Blur removes focus from the component
 func (m *model) Blur() tea.Cmd {
+	oldIndex := m.selectedMessageIndex
 	m.focused = false
 	m.selectedMessageIndex = -1
-	// Invalidate render cache so selection highlight is cleared
-	m.invalidateAllItems()
+	// Only invalidate the previously selected message
+	if oldIndex >= 0 {
+		m.invalidateItem(oldIndex)
+	}
 	m.renderDirty = true
 	return nil
 }
@@ -698,7 +703,13 @@ func (m *model) FocusAt(x, y int) tea.Cmd {
 		}
 	}
 
-	m.invalidateAllItems()
+	// Only invalidate the old and new selected messages
+	if oldIndex >= 0 {
+		m.invalidateItem(oldIndex)
+	}
+	if m.selectedMessageIndex >= 0 && m.selectedMessageIndex != oldIndex {
+		m.invalidateItem(m.selectedMessageIndex)
+	}
 	m.renderDirty = true
 
 	if m.messageTypeChanged(oldIndex, m.selectedMessageIndex) {
@@ -892,7 +903,11 @@ func (m *model) selectPreviousMessage() tea.Cmd {
 	if prevIndex := m.findPreviousSelectableMessage(m.selectedMessageIndex); prevIndex >= 0 {
 		oldIndex := m.selectedMessageIndex
 		m.selectedMessageIndex = prevIndex
-		m.invalidateAllItems()
+		if oldIndex >= 0 {
+			m.invalidateItem(oldIndex)
+		}
+		m.invalidateItem(prevIndex)
+		m.renderDirty = true
 		m.scrollToSelectedMessage()
 		if m.messageTypeChanged(oldIndex, prevIndex) {
 			return core.CmdHandler(messages.InvalidateStatusBarMsg{})
@@ -908,7 +923,11 @@ func (m *model) selectNextMessage() tea.Cmd {
 	if nextIndex := m.findNextSelectableMessage(m.selectedMessageIndex); nextIndex >= 0 {
 		oldIndex := m.selectedMessageIndex
 		m.selectedMessageIndex = nextIndex
-		m.invalidateAllItems()
+		if oldIndex >= 0 {
+			m.invalidateItem(oldIndex)
+		}
+		m.invalidateItem(nextIndex)
+		m.renderDirty = true
 		m.scrollToSelectedMessage()
 		if m.messageTypeChanged(oldIndex, nextIndex) {
 			return core.CmdHandler(messages.InvalidateStatusBarMsg{})

--- a/pkg/tui/components/messages/messages.go
+++ b/pkg/tui/components/messages/messages.go
@@ -11,7 +11,6 @@ import (
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/textarea"
 	tea "charm.land/bubbletea/v2"
-	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
 
 	"github.com/docker/docker-agent/pkg/chat"
@@ -80,8 +79,9 @@ type Model interface {
 
 // renderedItem represents a cached rendered message with position information
 type renderedItem struct {
-	view   string // Cached rendered content
-	height int    // Height in lines
+	view   string   // Cached rendered content
+	lines  []string // Pre-split lines (avoids re-splitting on every rebuild)
+	height int      // Height in lines
 }
 
 // blockIDCounter generates unique IDs for reasoning blocks.
@@ -992,8 +992,11 @@ func (m *model) renderItem(index int, view layout.Model) renderedItem {
 	// If this message is being inline edited, render the textarea instead
 	if index == m.inlineEditMsgIndex {
 		rendered := m.renderInlineEditTextarea()
-		height := lipgloss.Height(rendered)
-		return renderedItem{view: rendered, height: height}
+		var lines []string
+		if rendered != "" {
+			lines = strings.Split(strings.TrimSuffix(rendered, "\n"), "\n")
+		}
+		return renderedItem{view: rendered, lines: lines, height: len(lines)}
 	}
 
 	isSelected := m.focused && index == m.selectedMessageIndex
@@ -1015,12 +1018,12 @@ func (m *model) renderItem(index int, view layout.Model) renderedItem {
 	}
 
 	rendered := view.View()
-	height := lipgloss.Height(rendered)
-	if rendered == "" {
-		height = 0
+	var lines []string
+	if rendered != "" {
+		lines = strings.Split(strings.TrimSuffix(rendered, "\n"), "\n")
 	}
 
-	item := renderedItem{view: rendered, height: height}
+	item := renderedItem{view: rendered, lines: lines, height: len(lines)}
 
 	if shouldCache {
 		m.renderedItems[index] = item
@@ -1103,13 +1106,11 @@ func (m *model) ensureAllItemsRendered() {
 
 	for i, view := range m.views {
 		item := m.renderItem(i, view)
-		if item.view == "" {
+		if len(item.lines) == 0 {
 			continue
 		}
 
-		viewContent := strings.TrimSuffix(item.view, "\n")
-		lines := strings.Split(viewContent, "\n")
-		allLines = append(allLines, lines...)
+		allLines = append(allLines, item.lines...)
 
 		if m.needsSeparator(i) {
 			allLines = append(allLines, "")
@@ -1683,12 +1684,11 @@ func (m *model) isEditLabelClick(msgIdx, localLine, col int) (bool, *types.Messa
 	}
 
 	item := m.renderItem(msgIdx, m.views[msgIdx])
-	lines := strings.Split(item.view, "\n")
-	if localLine < 0 || localLine >= len(lines) {
+	if localLine < 0 || localLine >= len(item.lines) {
 		return false, nil
 	}
 
-	plainLine := ansi.Strip(lines[localLine])
+	plainLine := ansi.Strip(item.lines[localLine])
 	before, _, ok := strings.Cut(plainLine, types.UserMessageEditLabel)
 	if !ok {
 		return false, nil
@@ -1721,12 +1721,11 @@ func (m *model) isCopyLabelClick(msgIdx, localLine, col int) bool {
 	}
 
 	item := m.renderItem(msgIdx, m.views[msgIdx])
-	lines := strings.Split(item.view, "\n")
-	if localLine < 0 || localLine >= len(lines) {
+	if localLine < 0 || localLine >= len(item.lines) {
 		return false
 	}
 
-	plainLine := ansi.Strip(lines[localLine])
+	plainLine := ansi.Strip(item.lines[localLine])
 	before, _, ok := strings.Cut(plainLine, types.AssistantMessageCopyLabel)
 	if !ok {
 		return false

--- a/pkg/tui/components/messages/urldetect.go
+++ b/pkg/tui/components/messages/urldetect.go
@@ -18,6 +18,31 @@ type hoveredURL struct {
 	endCol   int // display column where URL ends (exclusive)
 }
 
+// urlSpanCache caches parsed URL spans per rendered line index.
+// Cleared when renderedLines changes (renderDirty rebuild).
+type urlSpanCache struct {
+	spans map[int][]urlSpan
+}
+
+func newURLSpanCache() *urlSpanCache {
+	return &urlSpanCache{spans: make(map[int][]urlSpan)}
+}
+
+// get returns the cached URL spans for the given line, parsing on first access.
+func (c *urlSpanCache) get(line int, renderedLine string) []urlSpan {
+	if spans, ok := c.spans[line]; ok {
+		return spans
+	}
+	spans := findAllURLSpans(renderedLine)
+	c.spans[line] = spans
+	return spans
+}
+
+// clear resets the cache (called when rendered lines change).
+func (c *urlSpanCache) clear() {
+	c.spans = make(map[int][]urlSpan)
+}
+
 // urlAtPosition extracts a URL from the rendered line at the given display column.
 // Returns the URL string if found, or empty string if the click position is not on a URL.
 func urlAtPosition(renderedLine string, col int) string {
@@ -310,7 +335,12 @@ func (m *model) urlAt(line, col int) string {
 	if line < 0 || line >= len(m.renderedLines) {
 		return ""
 	}
-	return urlAtPosition(m.renderedLines[line], col)
+	for _, span := range m.urlSpans.get(line, m.renderedLines[line]) {
+		if col >= span.startCol && col < span.endCol {
+			return span.url
+		}
+	}
+	return ""
 }
 
 // updateHoveredURL updates the hovered URL state based on mouse position.
@@ -318,7 +348,7 @@ func (m *model) updateHoveredURL(line, col int) {
 	m.ensureAllItemsRendered()
 
 	if line >= 0 && line < len(m.renderedLines) {
-		for _, span := range findAllURLSpans(m.renderedLines[line]) {
+		for _, span := range m.urlSpans.get(line, m.renderedLines[line]) {
 			if col >= span.startCol && col < span.endCol {
 				newHover := &hoveredURL{line: line, startCol: span.startCol, endCol: span.endCol}
 				if m.hoveredURL == nil || *m.hoveredURL != *newHover {

--- a/pkg/tui/components/reasoningblock/reasoningblock.go
+++ b/pkg/tui/components/reasoningblock/reasoningblock.go
@@ -2,10 +2,10 @@ package reasoningblock
 
 import (
 	"fmt"
-	"image/color"
 	"math"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -30,19 +30,35 @@ const (
 	completedToolVisibleDuration = 1500 * time.Millisecond
 	// completedToolFadeDuration is how long the fade-out effect lasts before hiding.
 	completedToolFadeDuration = 1000 * time.Millisecond
+	// fadeSteps is the number of discrete quantized fade levels.
+	fadeSteps = 20
 )
 
-// fadeColor returns an interpolated color for the given fade progress (0.0 to 1.0).
-// Progress 0.0 is normal color, 1.0 is very faded (close to background).
-func fadeColor(progress float64) color.Color {
-	// Interpolate from #808080 (normal muted) to #303038 (very faded)
-	// RGB: (128,128,128) -> (48,48,56)
-	startR, startG, startB := 128, 128, 128
-	endR, endG, endB := 48, 48, 56
-	r := int(float64(startR) + progress*float64(endR-startR))
-	g := int(float64(startG) + progress*float64(endG-startG))
-	b := int(float64(startB) + progress*float64(endB-startB))
-	return lipgloss.Color(fmt.Sprintf("#%02X%02X%02X", r, g, b))
+// fadeStyles is a pre-computed table of lipgloss styles for discrete fade levels.
+// Index 0 = no fade (normal), index fadeSteps = fully faded.
+var (
+	fadeStyles     [fadeSteps + 1]lipgloss.Style
+	fadeStylesOnce sync.Once
+)
+
+func initFadeStyles() {
+	for i := range fadeSteps + 1 {
+		progress := float64(i) / float64(fadeSteps)
+		startR, startG, startB := 128, 128, 128
+		endR, endG, endB := 48, 48, 56
+		r := int(float64(startR) + progress*float64(endR-startR))
+		g := int(float64(startG) + progress*float64(endG-startG))
+		b := int(float64(startB) + progress*float64(endB-startB))
+		c := lipgloss.Color(fmt.Sprintf("#%02X%02X%02X", r, g, b))
+		fadeStyles[i] = lipgloss.NewStyle().Foreground(c)
+	}
+}
+
+// fadeStyleForProgress returns the pre-computed style for the given fade progress.
+func fadeStyleForProgress(progress float64) lipgloss.Style {
+	fadeStylesOnce.Do(initFadeStyles)
+	idx := min(max(int(progress*fadeSteps), 0), fadeSteps)
+	return fadeStyles[idx]
 }
 
 // nowFunc is the time function used to get the current time.
@@ -55,6 +71,7 @@ type toolEntry struct {
 	view                  layout.Model
 	collapsedVisibleUntil time.Time // Zero means no grace period (hide immediately when completed)
 	fadeProgress          float64   // 0.0 = not fading, 0.0-1.0 = fading (higher = more faded)
+	strippedCollapsed     string    // Cached ANSI-stripped collapsed view (set once on completion)
 }
 
 // contentItemKind identifies the type of content item.
@@ -241,6 +258,15 @@ func (m *Model) UpdateToolResult(toolCallID, content string, status types.ToolSt
 		view.SetSize(m.contentWidth(), 0)
 		m.toolEntries[i] = entry
 		m.toolEntries[i].view = view
+
+		// Pre-cache the ANSI-stripped collapsed view for fade rendering
+		if wasInProgress && isCompleted {
+			if cv, ok := view.(layout.CollapsedViewer); ok {
+				m.toolEntries[i].strippedCollapsed = ansi.Strip(cv.CollapsedView())
+			} else {
+				m.toolEntries[i].strippedCollapsed = ansi.Strip(view.View())
+			}
+		}
 
 		initCmd := view.Init()
 		if animCmd != nil {
@@ -530,7 +556,7 @@ func (m *Model) renderCollapsed() string {
 	visibleTools := m.getVisibleToolsCollapsed()
 	if len(visibleTools) > 0 {
 		parts = append(parts, "") // blank line before tools
-		for _, entry := range visibleTools {
+		for i, entry := range visibleTools {
 			// Prefer CollapsedView() for simplified rendering in collapsed state
 			var toolView string
 			if cv, ok := entry.view.(layout.CollapsedViewer); ok {
@@ -539,11 +565,12 @@ func (m *Model) renderCollapsed() string {
 				toolView = entry.view.View()
 			}
 			if entry.fadeProgress > 0 {
-				// Strip existing ANSI codes and apply faded color based on progress
-				// (wrapping styled content doesn't override inner colors)
-				stripped := ansi.Strip(toolView)
-				fadeStyle := lipgloss.NewStyle().Foreground(fadeColor(entry.fadeProgress))
-				toolView = fadeStyle.Render(stripped)
+				// Use cached stripped text (populated once on tool completion)
+				stripped := visibleTools[i].strippedCollapsed
+				if stripped == "" {
+					stripped = ansi.Strip(toolView)
+				}
+				toolView = fadeStyleForProgress(entry.fadeProgress).Render(stripped)
 			}
 			parts = append(parts, toolView)
 		}


### PR DESCRIPTION
Five focused performance optimizations for the TUI rendering pipeline:

1. **Store pre-split lines in renderedItem** — `ensureAllItemsRendered()` was re-splitting every cached item's view string on every dirty rebuild. Lines are now split once in `renderItem()` and reused. O(n×m) → O(n).

2. **Targeted invalidation on selection changes** — `Focus()`, `Blur()`, `FocusAt()`, `selectPreviousMessage()`, and `selectNextMessage()` all called `invalidateAllItems()`, wiping the entire render cache. Now only the old/new selected items are invalidated. O(n) → O(1).

3. **Cache URL spans per rendered line** — `updateHoveredURL()` re-parsed URL spans (OSC 8 + plain-text) on every mouse motion event (~60 Hz). Spans are now cached per line index and cleared when rendered lines change. O(m) → O(1) for repeated motions on the same line.

4. **Prefix-sum + binary search for globalLineToMessageLine** — Replaces a linear scan through all views on every mouse event with a pre-computed offset array and `sort.Search`. O(n) → O(log n). Also optimizes `scrollToSelectedMessage()`.

5. **Pre-computed fade styles and cached stripped text in reasoning block** — The fade animation was creating a new color string (`fmt.Sprintf`), `lipgloss.NewStyle()`, and `ansi.Strip()` per tool per tick. Fade styles are now a pre-computed 21-element lookup table (`sync.Once`), and the stripped collapsed view is cached once on tool completion. O(m) → O(1) per frame.