### PR TITLE
feat: improve TUI control plane API for external consumers

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -258,3 +258,15 @@ type QueueDepthResponse struct {
 		Capacity int `json:"capacity"`
 	} `json:"followup"`
 }
+
+// SessionStatusResponse represents the current runtime state of a session.
+// Designed for late-joining SSE consumers that need a state snapshot on connect.
+type SessionStatusResponse struct {
+	ID           string `json:"id"`
+	Title        string `json:"title"`
+	Streaming    bool   `json:"streaming"`
+	Agent        string `json:"agent,omitempty"`
+	InputTokens  int64  `json:"input_tokens"`
+	OutputTokens int64  `json:"output_tokens"`
+	NumMessages  int    `json:"num_messages"`
+}

--- a/pkg/runtime/event.go
+++ b/pkg/runtime/event.go
@@ -198,17 +198,37 @@ func AgentChoiceReasoning(agentName, sessionID, content string) Event {
 	}
 }
 
+// ErrorCode constants classify errors so external consumers (boards,
+// dashboards) can react programmatically without parsing free-form messages.
+const (
+	ErrorCodeModelError      = "model_error"
+	ErrorCodeRateLimited     = "rate_limited"
+	ErrorCodeContextExceeded = "context_exceeded"
+	ErrorCodeToolFailed      = "tool_failed"
+	ErrorCodeHookBlocked     = "hook_blocked"
+	ErrorCodeLoopDetected    = "loop_detected"
+)
+
 type ErrorEvent struct {
 	AgentContext
 
 	Type  string `json:"type"`
 	Error string `json:"error"`
+	Code  string `json:"code,omitempty"`
 }
 
 func Error(msg string) Event {
 	return &ErrorEvent{
 		Type:  "error",
 		Error: msg,
+	}
+}
+
+func ErrorWithCode(code, msg string) Event {
+	return &ErrorEvent{
+		Type:  "error",
+		Error: msg,
+		Code:  code,
 	}
 }
 

--- a/pkg/runtime/event.go
+++ b/pkg/runtime/event.go
@@ -387,13 +387,15 @@ type StreamStoppedEvent struct {
 
 	Type      string `json:"type"`
 	SessionID string `json:"session_id,omitempty"`
+	Reason    string `json:"reason,omitempty"`
 }
 
-func StreamStopped(sessionID, agentName string) Event {
+func StreamStopped(sessionID, agentName, reason string) Event {
 	return &StreamStoppedEvent{
 		Type:         "stream_stopped",
 		SessionID:    sessionID,
 		AgentContext: newAgentContext(agentName),
+		Reason:       reason,
 	}
 }
 

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -127,7 +127,7 @@ func (r *LocalRuntime) emitHookDrivenShutdown(
 		// block without a reason.
 		message = "Agent terminated by a hook."
 	}
-	events <- Error(message)
+	events <- ErrorWithCode(ErrorCodeHookBlocked, message)
 	r.notifyError(ctx, a, sess.ID, message)
 }
 
@@ -224,7 +224,7 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 
 	agentTools, err := r.getTools(ctx, a, sessionSpan, events, true)
 	if err != nil {
-		events <- Error(fmt.Sprintf("failed to get tools: %v", err))
+		events <- ErrorWithCode(ErrorCodeToolFailed, fmt.Sprintf("failed to get tools: %v", err))
 		return
 	}
 	agentTools = filterExcludedTools(agentTools, sess.ExcludedTools)
@@ -307,7 +307,7 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 
 		agentTools, err := r.getTools(ctx, a, sessionSpan, events, true)
 		if err != nil {
-			events <- Error(fmt.Sprintf("failed to get tools: %v", err))
+			events <- ErrorWithCode(ErrorCodeToolFailed, fmt.Sprintf("failed to get tools: %v", err))
 			return
 		}
 		agentTools = filterExcludedTools(agentTools, sess.ExcludedTools)
@@ -614,7 +614,7 @@ func (r *LocalRuntime) runTurn(
 			"Agent terminated: detected %d consecutive identical calls to %s. "+
 				"This indicates a degenerate loop where the model is not making progress.",
 			consecutive, toolName)
-		events <- Error(errMsg)
+		events <- ErrorWithCode(ErrorCodeLoopDetected, errMsg)
 		r.notifyError(ctx, a, sess.ID, errMsg)
 		ls.loopDetector.Reset()
 		endReason = turnEndReasonLoopDetected

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -134,7 +134,13 @@ func (r *LocalRuntime) emitHookDrivenShutdown(
 // finalizeEventChannel performs cleanup at the end of a RunStream goroutine:
 // restores the previous elicitation channel, emits the StreamStopped event,
 // fires hooks, and closes the events channel.
-func (r *LocalRuntime) finalizeEventChannel(ctx context.Context, sess *session.Session, prevElicitationCh, events chan Event) {
+//
+// reason is one of the turnEndReason* constants and classifies how the
+// stream ended (e.g. "normal", "error", "canceled"). It is surfaced in
+// the StreamStoppedEvent so external consumers (boards, dashboards) can
+// distinguish between successful completion, crashes, and user-initiated
+// stops without reverse-engineering reconnect failures.
+func (r *LocalRuntime) finalizeEventChannel(ctx context.Context, sess *session.Session, reason *string, prevElicitationCh, events chan Event) {
 	// Swap back the parent's elicitation channel before closing this
 	// stream's channel. This prevents a send-on-closed-channel panic
 	// and restores elicitation for the parent session.
@@ -148,7 +154,14 @@ func (r *LocalRuntime) finalizeEventChannel(ctx context.Context, sess *session.S
 	// cleanup hooks run even when the stream was interrupted (e.g. Ctrl+C).
 	r.executeSessionEndHooks(context.WithoutCancel(ctx), sess, a)
 
-	events <- StreamStopped(sess.ID, a.Name())
+	stopReason := ""
+	if reason != nil {
+		stopReason = *reason
+	}
+	if ctx.Err() != nil && stopReason == "" {
+		stopReason = turnEndReasonCanceled
+	}
+	events <- StreamStopped(sess.ID, a.Name(), stopReason)
 
 	r.executeOnUserInputHooks(ctx, sess.ID, "stream stopped")
 
@@ -245,7 +258,11 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 
 	events <- StreamStarted(sess.ID, a.Name())
 
-	defer r.finalizeEventChannel(ctx, sess, prevElicitationCh, events)
+	// streamReason records the exit reason from the final turn so
+	// finalizeEventChannel can surface it in the StreamStoppedEvent.
+	// It is updated by each turn via runTurn's returned reason.
+	var streamReason string
+	defer r.finalizeEventChannel(ctx, sess, &streamReason, prevElicitationCh, events)
 
 	// Response cache lookup. On a hit, replay the stored answer and
 	// skip the model entirely. The matching storage half is
@@ -370,7 +387,8 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 		// AFTER the closure body has assigned both, so callers see the same
 		// reason the runtime took. ctrl drives the outer for-loop's
 		// continue-or-exit decision.
-		ctrl := r.runTurn(ctx, sess, a, m, model, modelID, contextLimit, sessionSpan, agentTools, ls, events)
+		ctrl, reason := r.runTurn(ctx, sess, a, m, model, modelID, contextLimit, sessionSpan, agentTools, ls, events)
+		streamReason = reason
 		switch ctrl {
 		case turnContinue:
 			continue
@@ -439,7 +457,7 @@ func (r *LocalRuntime) runTurn(
 	agentTools []tools.Tool,
 	ls *loopState,
 	events chan Event,
-) (ctrl turnControl) {
+) (ctrl turnControl, exitReason string) {
 	streamCtx, streamSpan := r.startSpan(ctx, "runtime.stream", trace.WithAttributes(
 		attribute.String("agent", a.Name()),
 		attribute.String("session.id", sess.ID),
@@ -476,6 +494,7 @@ func (r *LocalRuntime) runTurn(
 		// matching the same guarantee session_end has at the
 		// finalizeEventChannel level.
 		r.executeTurnEndHooks(context.WithoutCancel(ctx), sess, a, endReason, events)
+		exitReason = endReason
 	}()
 
 	// Run turn_start hooks BEFORE building messages so their
@@ -506,7 +525,7 @@ func (r *LocalRuntime) runTurn(
 		r.emitHookDrivenShutdown(ctx, a, sess, msg, events)
 		endStreamSpan()
 		endReason = turnEndReasonHookBlocked
-		return turnExit
+		return turnExit, ""
 	}
 	if rewritten != nil {
 		messages = rewritten
@@ -529,9 +548,9 @@ func (r *LocalRuntime) runTurn(
 		endStreamSpan()
 		endReason = turnEndReasonError
 		if outcome == streamErrorRetry {
-			return turnContinue
+			return turnContinue, ""
 		}
-		return turnExit
+		return turnExit, ""
 	}
 
 	// A successful model call resets the overflow compaction counter.
@@ -599,7 +618,7 @@ func (r *LocalRuntime) runTurn(
 		r.notifyError(ctx, a, sess.ID, errMsg)
 		ls.loopDetector.Reset()
 		endReason = turnEndReasonLoopDetected
-		return turnExit
+		return turnExit, ""
 	}
 
 	// post_tool_use hook signalled run termination via a deny
@@ -612,7 +631,7 @@ func (r *LocalRuntime) runTurn(
 			"agent", a.Name(), "session_id", sess.ID, "reason", stopMsg)
 		r.emitHookDrivenShutdown(ctx, a, sess, stopMsg, events)
 		endReason = turnEndReasonHookBlocked
-		return turnExit
+		return turnExit, ""
 	}
 
 	// Record per-toolset model override for the next LLM turn.
@@ -622,7 +641,7 @@ func (r *LocalRuntime) runTurn(
 	if drained, _ := r.drainAndEmitSteered(ctx, sess, events); drained {
 		r.compactIfNeeded(ctx, sess, a, m, contextLimit, messageCountBeforeTools, events)
 		endReason = turnEndReasonSteered
-		return turnContinue
+		return turnContinue, ""
 	}
 
 	if res.Stopped {
@@ -633,7 +652,7 @@ func (r *LocalRuntime) runTurn(
 		if drained, _ := r.drainAndEmitSteered(ctx, sess, events); drained {
 			r.compactIfNeeded(ctx, sess, a, m, contextLimit, messageCountBeforeTools, events)
 			endReason = turnEndReasonSteered
-			return turnContinue
+			return turnContinue, ""
 		}
 
 		// --- FOLLOW-UP: end-of-turn injection ---
@@ -648,16 +667,16 @@ func (r *LocalRuntime) runTurn(
 			events <- UserMessage(followUp.Content, sess.ID, followUp.MultiContent, len(sess.Messages)-1)
 			r.compactIfNeeded(ctx, sess, a, m, contextLimit, messageCountBeforeTools, events)
 			endReason = turnEndReasonContinue
-			return turnContinue // re-enter the loop for a new turn
+			return turnContinue, "" // re-enter the loop for a new turn
 		}
 
 		endReason = turnEndReasonNormal
-		return turnExit
+		return turnExit, ""
 	}
 
 	r.compactIfNeeded(ctx, sess, a, m, contextLimit, messageCountBeforeTools, events)
 	endReason = turnEndReasonContinue
-	return turnContinue
+	return turnContinue, ""
 }
 
 // Run executes the agent loop synchronously and returns the final session

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -140,7 +140,7 @@ func (r *LocalRuntime) emitHookDrivenShutdown(
 // the StreamStoppedEvent so external consumers (boards, dashboards) can
 // distinguish between successful completion, crashes, and user-initiated
 // stops without reverse-engineering reconnect failures.
-func (r *LocalRuntime) finalizeEventChannel(ctx context.Context, sess *session.Session, reason *string, prevElicitationCh, events chan Event) {
+func (r *LocalRuntime) finalizeEventChannel(ctx context.Context, sess *session.Session, reason string, prevElicitationCh, events chan Event) {
 	// Swap back the parent's elicitation channel before closing this
 	// stream's channel. This prevents a send-on-closed-channel panic
 	// and restores elicitation for the parent session.
@@ -154,14 +154,10 @@ func (r *LocalRuntime) finalizeEventChannel(ctx context.Context, sess *session.S
 	// cleanup hooks run even when the stream was interrupted (e.g. Ctrl+C).
 	r.executeSessionEndHooks(context.WithoutCancel(ctx), sess, a)
 
-	stopReason := ""
-	if reason != nil {
-		stopReason = *reason
+	if ctx.Err() != nil && reason == "" {
+		reason = turnEndReasonCanceled
 	}
-	if ctx.Err() != nil && stopReason == "" {
-		stopReason = turnEndReasonCanceled
-	}
-	events <- StreamStopped(sess.ID, a.Name(), stopReason)
+	events <- StreamStopped(sess.ID, a.Name(), reason)
 
 	r.executeOnUserInputHooks(ctx, sess.ID, "stream stopped")
 
@@ -260,9 +256,11 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 
 	// streamReason records the exit reason from the final turn so
 	// finalizeEventChannel can surface it in the StreamStoppedEvent.
-	// It is updated by each turn via runTurn's returned reason.
+	// It is updated by each turn via runTurn (passed by pointer).
 	var streamReason string
-	defer r.finalizeEventChannel(ctx, sess, &streamReason, prevElicitationCh, events)
+	defer func() {
+		r.finalizeEventChannel(ctx, sess, streamReason, prevElicitationCh, events)
+	}()
 
 	// Response cache lookup. On a hit, replay the stored answer and
 	// skip the model entirely. The matching storage half is
@@ -387,8 +385,8 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 		// AFTER the closure body has assigned both, so callers see the same
 		// reason the runtime took. ctrl drives the outer for-loop's
 		// continue-or-exit decision.
-		ctrl, reason := r.runTurn(ctx, sess, a, m, model, modelID, contextLimit, sessionSpan, agentTools, ls, events)
-		streamReason = reason
+		ctrl := r.runTurn(ctx, sess, a, m, model, modelID, contextLimit, sessionSpan, agentTools, ls, events)
+		streamReason = ls.exitReason
 		switch ctrl {
 		case turnContinue:
 			continue
@@ -429,6 +427,7 @@ type loopState struct {
 	loopDetector        *toolexec.LoopDetector
 	sessionStartMsgs    []chat.Message
 	userPromptMsgs      []chat.Message
+	exitReason          string
 }
 
 // runTurn performs one iteration of the run-stream loop, from
@@ -457,7 +456,7 @@ func (r *LocalRuntime) runTurn(
 	agentTools []tools.Tool,
 	ls *loopState,
 	events chan Event,
-) (ctrl turnControl, exitReason string) {
+) turnControl {
 	streamCtx, streamSpan := r.startSpan(ctx, "runtime.stream", trace.WithAttributes(
 		attribute.String("agent", a.Name()),
 		attribute.String("session.id", sess.ID),
@@ -494,7 +493,7 @@ func (r *LocalRuntime) runTurn(
 		// matching the same guarantee session_end has at the
 		// finalizeEventChannel level.
 		r.executeTurnEndHooks(context.WithoutCancel(ctx), sess, a, endReason, events)
-		exitReason = endReason
+		ls.exitReason = endReason
 	}()
 
 	// Run turn_start hooks BEFORE building messages so their
@@ -525,7 +524,7 @@ func (r *LocalRuntime) runTurn(
 		r.emitHookDrivenShutdown(ctx, a, sess, msg, events)
 		endStreamSpan()
 		endReason = turnEndReasonHookBlocked
-		return turnExit, ""
+		return turnExit
 	}
 	if rewritten != nil {
 		messages = rewritten
@@ -548,9 +547,9 @@ func (r *LocalRuntime) runTurn(
 		endStreamSpan()
 		endReason = turnEndReasonError
 		if outcome == streamErrorRetry {
-			return turnContinue, ""
+			return turnContinue
 		}
-		return turnExit, ""
+		return turnExit
 	}
 
 	// A successful model call resets the overflow compaction counter.
@@ -618,7 +617,7 @@ func (r *LocalRuntime) runTurn(
 		r.notifyError(ctx, a, sess.ID, errMsg)
 		ls.loopDetector.Reset()
 		endReason = turnEndReasonLoopDetected
-		return turnExit, ""
+		return turnExit
 	}
 
 	// post_tool_use hook signalled run termination via a deny
@@ -631,7 +630,7 @@ func (r *LocalRuntime) runTurn(
 			"agent", a.Name(), "session_id", sess.ID, "reason", stopMsg)
 		r.emitHookDrivenShutdown(ctx, a, sess, stopMsg, events)
 		endReason = turnEndReasonHookBlocked
-		return turnExit, ""
+		return turnExit
 	}
 
 	// Record per-toolset model override for the next LLM turn.
@@ -641,7 +640,7 @@ func (r *LocalRuntime) runTurn(
 	if drained, _ := r.drainAndEmitSteered(ctx, sess, events); drained {
 		r.compactIfNeeded(ctx, sess, a, m, contextLimit, messageCountBeforeTools, events)
 		endReason = turnEndReasonSteered
-		return turnContinue, ""
+		return turnContinue
 	}
 
 	if res.Stopped {
@@ -652,7 +651,7 @@ func (r *LocalRuntime) runTurn(
 		if drained, _ := r.drainAndEmitSteered(ctx, sess, events); drained {
 			r.compactIfNeeded(ctx, sess, a, m, contextLimit, messageCountBeforeTools, events)
 			endReason = turnEndReasonSteered
-			return turnContinue, ""
+			return turnContinue
 		}
 
 		// --- FOLLOW-UP: end-of-turn injection ---
@@ -667,16 +666,16 @@ func (r *LocalRuntime) runTurn(
 			events <- UserMessage(followUp.Content, sess.ID, followUp.MultiContent, len(sess.Messages)-1)
 			r.compactIfNeeded(ctx, sess, a, m, contextLimit, messageCountBeforeTools, events)
 			endReason = turnEndReasonContinue
-			return turnContinue, "" // re-enter the loop for a new turn
+			return turnContinue // re-enter the loop for a new turn
 		}
 
 		endReason = turnEndReasonNormal
-		return turnExit, ""
+		return turnExit
 	}
 
 	r.compactIfNeeded(ctx, sess, a, m, contextLimit, messageCountBeforeTools, events)
 	endReason = turnEndReasonContinue
-	return turnContinue, ""
+	return turnContinue
 }
 
 // Run executes the agent loop synchronously and returns the final session

--- a/pkg/runtime/loop_steps.go
+++ b/pkg/runtime/loop_steps.go
@@ -184,7 +184,22 @@ func (r *LocalRuntime) handleStreamError(
 	slog.ErrorContext(ctx, "All models failed", "agent", a.Name(), "error", err)
 	r.telemetry.RecordError(ctx, err.Error())
 	errMsg := modelerrors.FormatError(err)
-	events <- Error(errMsg)
+	events <- ErrorWithCode(classifyErrorCode(err), errMsg)
 	r.notifyError(ctx, a, sess.ID, errMsg)
 	return streamErrorFatal
+}
+
+// classifyErrorCode maps a model error to an ErrorCode constant for
+// structured error events. The classification mirrors [modelerrors]
+// but reduces the granularity to a small set of codes that external
+// consumers can act on.
+func classifyErrorCode(err error) string {
+	if modelerrors.IsContextOverflowError(err) {
+		return ErrorCodeContextExceeded
+	}
+	_, rateLimited, _ := modelerrors.ClassifyModelError(err)
+	if rateLimited {
+		return ErrorCodeRateLimited
+	}
+	return ErrorCodeModelError
 }

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -302,7 +302,7 @@ func TestSimple(t *testing.T) {
 			Model:        "test/mock-model",
 			FinishReason: chat.FinishReasonStop,
 		}}),
-		StreamStopped(sess.ID, "root"),
+		StreamStopped(sess.ID, "root", "normal"),
 	}
 
 	assertEventsEqual(t, expectedEvents, events)
@@ -346,7 +346,7 @@ func TestMultipleContentChunks(t *testing.T) {
 			Model:        "test/mock-model",
 			FinishReason: chat.FinishReasonStop,
 		}}),
-		StreamStopped(sess.ID, "root"),
+		StreamStopped(sess.ID, "root", "normal"),
 	}
 
 	assertEventsEqual(t, expectedEvents, events)
@@ -386,7 +386,7 @@ func TestWithReasoning(t *testing.T) {
 			Model:        "test/mock-model",
 			FinishReason: chat.FinishReasonStop,
 		}}),
-		StreamStopped(sess.ID, "root"),
+		StreamStopped(sess.ID, "root", "normal"),
 	}
 
 	assertEventsEqual(t, expectedEvents, events)
@@ -428,7 +428,7 @@ func TestMixedContentAndReasoning(t *testing.T) {
 			Model:        "test/mock-model",
 			FinishReason: chat.FinishReasonStop,
 		}}),
-		StreamStopped(sess.ID, "root"),
+		StreamStopped(sess.ID, "root", "normal"),
 	}
 
 	assertEventsEqual(t, expectedEvents, events)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -417,7 +417,8 @@ func (s *Server) followUpSession(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "at least one message is required")
 	}
 
-	if err := s.sm.FollowUpSession(c.Request().Context(), sessionID, req.Messages); err != nil {
+	streaming, err := s.sm.FollowUpSession(c.Request().Context(), sessionID, req.Messages)
+	if err != nil {
 		if strings.Contains(err.Error(), "queue full") {
 			c.Response().Header().Set("Retry-After", "1")
 			return echo.NewHTTPError(http.StatusTooManyRequests, "follow-up queue full")
@@ -425,7 +426,11 @@ func (s *Server) followUpSession(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusConflict, fmt.Sprintf("failed to enqueue follow-up: %v", err))
 	}
 
-	return c.JSON(http.StatusAccepted, map[string]string{"status": "queued"})
+	status := "queued_streaming"
+	if !streaming {
+		status = "queued_idle"
+	}
+	return c.JSON(http.StatusAccepted, map[string]string{"status": status})
 }
 
 func (s *Server) addMessage(c echo.Context) error {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -314,8 +314,25 @@ func (s *Server) updateSessionTitle(c echo.Context) error {
 func (s *Server) deleteSession(c echo.Context) error {
 	sessionID := c.Param("id")
 
+	timeout := 10 * time.Second
+	if v := c.QueryParam("timeout"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid timeout: %v", err))
+		}
+		timeout = d
+	}
+
 	if err := s.sm.DeleteSession(c.Request().Context(), sessionID); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to delete session: %v", err))
+	}
+
+	// When ?wait=true, block until the runtime's stream goroutine has
+	// fully exited (the streaming mutex is released) or the timeout fires.
+	if c.QueryParam("wait") == "true" {
+		if err := s.sm.WaitStopped(c.Request().Context(), sessionID, timeout); err != nil {
+			return c.JSON(http.StatusAccepted, map[string]string{"message": "session deleted, stop still in progress"})
+		}
 	}
 
 	return c.JSON(http.StatusOK, map[string]string{"message": "session deleted"})

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -91,7 +91,7 @@ func (s *Server) registerRoutes() {
 	group.GET("/ping", func(c echo.Context) error {
 		return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
 	})
-	group.GET("/ready", s.ready)
+	group.GET("/ready", s.sessionsReady)
 }
 
 func (s *Server) Serve(ctx context.Context, ln net.Listener) error {
@@ -112,7 +112,7 @@ const maxAPITimeout = 5 * time.Minute
 
 // ready blocks until at least one session is registered. The caller
 // may supply a ?timeout=<duration> query parameter (default 30s, max 5m).
-func (s *Server) ready(c echo.Context) error {
+func (s *Server) sessionsReady(c echo.Context) error {
 	timeout := 30 * time.Second
 	if v := c.QueryParam("timeout"); v != "" {
 		d, err := time.ParseDuration(v)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -91,6 +91,7 @@ func (s *Server) registerRoutes() {
 	group.GET("/ping", func(c echo.Context) error {
 		return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
 	})
+	group.GET("/ready", s.ready)
 }
 
 func (s *Server) Serve(ctx context.Context, ln net.Listener) error {
@@ -105,6 +106,27 @@ func (s *Server) Serve(ctx context.Context, ln net.Listener) error {
 	}
 
 	return nil
+}
+
+// ready blocks until at least one session is registered. The caller
+// may supply a ?timeout=<duration> query parameter (default 30s).
+func (s *Server) ready(c echo.Context) error {
+	timeout := 30 * time.Second
+	if v := c.QueryParam("timeout"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid timeout: %v", err))
+		}
+		timeout = d
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request().Context(), timeout)
+	defer cancel()
+
+	if err := s.sm.WaitReady(ctx); err != nil {
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "no sessions registered within timeout")
+	}
+	return c.JSON(http.StatusOK, map[string]string{"status": "ready"})
 }
 
 func (s *Server) getAgents(c echo.Context) error {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -63,6 +63,7 @@ func (s *Server) registerRoutes() {
 
 	group.GET("/sessions", s.getSessions)
 	group.GET("/sessions/:id", s.getSession)
+	group.GET("/sessions/:id/status", s.getSessionStatus)
 	group.POST("/sessions/:id/resume", s.resumeSession)
 	group.POST("/sessions/:id/tools/toggle", s.toggleSessionYolo)
 	group.PATCH("/sessions/:id/permissions", s.updateSessionPermissions)
@@ -218,6 +219,14 @@ func (s *Server) getSession(c echo.Context) error {
 		WorkingDir:    sess.WorkingDir,
 		Permissions:   sess.Permissions,
 	})
+}
+
+func (s *Server) getSessionStatus(c echo.Context) error {
+	status, err := s.sm.GetSessionStatus(c.Request().Context(), c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("session not found: %v", err))
+	}
+	return c.JSON(http.StatusOK, status)
 }
 
 func (s *Server) resumeSession(c echo.Context) error {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -108,8 +108,10 @@ func (s *Server) Serve(ctx context.Context, ln net.Listener) error {
 	return nil
 }
 
+const maxAPITimeout = 5 * time.Minute
+
 // ready blocks until at least one session is registered. The caller
-// may supply a ?timeout=<duration> query parameter (default 30s).
+// may supply a ?timeout=<duration> query parameter (default 30s, max 5m).
 func (s *Server) ready(c echo.Context) error {
 	timeout := 30 * time.Second
 	if v := c.QueryParam("timeout"); v != "" {
@@ -117,7 +119,7 @@ func (s *Server) ready(c echo.Context) error {
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid timeout: %v", err))
 		}
-		timeout = d
+		timeout = min(d, maxAPITimeout)
 	}
 
 	ctx, cancel := context.WithTimeout(c.Request().Context(), timeout)
@@ -320,7 +322,7 @@ func (s *Server) deleteSession(c echo.Context) error {
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid timeout: %v", err))
 		}
-		timeout = d
+		timeout = min(d, maxAPITimeout)
 	}
 
 	if err := s.sm.DeleteSession(c.Request().Context(), sessionID); err != nil {

--- a/pkg/server/server_attached_test.go
+++ b/pkg/server/server_attached_test.go
@@ -268,3 +268,40 @@ func TestAttachedServer_ReadyEndpointTimesOut(t *testing.T) {
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
 }
+
+// TestAttachedServer_DeleteWithWaitBlocksUntilStreamStops verifies that
+// DELETE /api/sessions/:id?wait=true blocks until the stream goroutine exits.
+func TestAttachedServer_DeleteWithWaitBlocksUntilStreamStops(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	store := session.NewInMemorySessionStore()
+	sess := session.New()
+	require.NoError(t, store.AddSession(ctx, sess))
+
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+	fake := &fakeRuntime{streamDelay: 200 * time.Millisecond}
+	sm.AttachRuntime(sess.ID, fake, sess)
+
+	srv := NewWithManager(sm)
+
+	ln, err := Listen(ctx, "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() { _ = srv.Serve(ctx, ln) }()
+
+	addr := "http://" + ln.Addr().String()
+
+	// Start a stream so the streaming lock is held.
+	ch, err := sm.RunSession(ctx, sess.ID, "agent", "root", []api.Message{{Content: "hello"}})
+	require.NoError(t, err)
+
+	// DELETE with wait should block until stream finishes (200ms).
+	resp := httpDoTCP(t, ctx, http.MethodDelete, addr+"/api/sessions/"+sess.ID+"?wait=true&timeout=5s", nil)
+	assert.Contains(t, string(resp), "deleted")
+
+	// Stream channel should be drained by now.
+	for range ch {
+	}
+}

--- a/pkg/server/server_attached_test.go
+++ b/pkg/server/server_attached_test.go
@@ -219,3 +219,52 @@ func TestAttachedServer_FollowUpWhileIdleReturnsQueuedIdle(t *testing.T) {
 
 	assert.Contains(t, string(resp), "queued_idle")
 }
+
+// TestAttachedServer_ReadyEndpointReturnsImmediatelyWithSession verifies
+// that GET /api/ready returns immediately when a session is already attached.
+func TestAttachedServer_ReadyEndpointReturnsImmediately(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	store := session.NewInMemorySessionStore()
+	sess := session.New()
+	require.NoError(t, store.AddSession(ctx, sess))
+
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+	sm.AttachRuntime(sess.ID, &fakeRuntime{}, sess)
+
+	srv := NewWithManager(sm)
+
+	ln, err := Listen(ctx, "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() { _ = srv.Serve(ctx, ln) }()
+
+	addr := "http://" + ln.Addr().String()
+	resp := httpDoTCP(t, ctx, http.MethodGet, addr+"/api/ready", nil)
+	assert.Contains(t, string(resp), "ready")
+}
+
+// TestAttachedServer_ReadyEndpointTimesOutWithoutSession verifies
+// that GET /api/ready returns 503 when no session is registered within the timeout.
+func TestAttachedServer_ReadyEndpointTimesOut(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := session.NewInMemorySessionStore()
+
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+	srv := NewWithManager(sm)
+
+	ln, err := Listen(ctx, "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() { _ = srv.Serve(ctx, ln) }()
+
+	addr := "http://" + ln.Addr().String()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, addr+"/api/ready?timeout=100ms", http.NoBody)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+}

--- a/pkg/server/server_attached_test.go
+++ b/pkg/server/server_attached_test.go
@@ -158,3 +158,36 @@ func TestAttachedServer_DeleteSessionStopsEventStream(t *testing.T) {
 	defer resp2.Body.Close()
 	assert.Equal(t, http.StatusNotFound, resp2.StatusCode)
 }
+
+// TestAttachedServer_StatusEndpointReturnsCurrentState verifies that
+// GET /api/sessions/:id/status returns the current runtime state snapshot.
+func TestAttachedServer_StatusEndpointReturnsCurrentState(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	store := session.NewInMemorySessionStore()
+	sess := session.New()
+	sess.Title = "Test Session"
+	require.NoError(t, store.AddSession(ctx, sess))
+
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+	fake := &fakeRuntime{}
+	sm.AttachRuntime(sess.ID, fake, sess)
+
+	srv := NewWithManager(sm)
+
+	ln, err := Listen(ctx, "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() { _ = srv.Serve(ctx, ln) }()
+
+	addr := "http://" + ln.Addr().String()
+	resp := httpDoTCP(t, ctx, http.MethodGet, addr+"/api/sessions/"+sess.ID+"/status", nil)
+
+	var status api.SessionStatusResponse
+	require.NoError(t, json.Unmarshal(resp, &status))
+
+	assert.Equal(t, sess.ID, status.ID)
+	assert.Equal(t, "Test Session", status.Title)
+	assert.False(t, status.Streaming)
+}

--- a/pkg/server/server_attached_test.go
+++ b/pkg/server/server_attached_test.go
@@ -175,7 +175,7 @@ func TestAttachedServer_StatusEndpointReturnsCurrentState(t *testing.T) {
 	fake := &fakeRuntime{}
 	sm.AttachRuntime(sess.ID, fake, sess)
 
-	srv := NewWithManager(sm)
+	srv := NewWithManager(sm, "")
 
 	ln, err := Listen(ctx, "127.0.0.1:0")
 	require.NoError(t, err)
@@ -207,7 +207,7 @@ func TestAttachedServer_FollowUpWhileIdleReturnsQueuedIdle(t *testing.T) {
 	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
 	sm.AttachRuntime(sess.ID, &fakeRuntime{}, sess)
 
-	srv := NewWithManager(sm)
+	srv := NewWithManager(sm, "")
 
 	ln, err := Listen(ctx, "127.0.0.1:0")
 	require.NoError(t, err)
@@ -234,7 +234,7 @@ func TestAttachedServer_ReadyEndpointReturnsImmediately(t *testing.T) {
 	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
 	sm.AttachRuntime(sess.ID, &fakeRuntime{}, sess)
 
-	srv := NewWithManager(sm)
+	srv := NewWithManager(sm, "")
 
 	ln, err := Listen(ctx, "127.0.0.1:0")
 	require.NoError(t, err)
@@ -254,7 +254,7 @@ func TestAttachedServer_ReadyEndpointTimesOut(t *testing.T) {
 	store := session.NewInMemorySessionStore()
 
 	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
-	srv := NewWithManager(sm)
+	srv := NewWithManager(sm, "")
 
 	ln, err := Listen(ctx, "127.0.0.1:0")
 	require.NoError(t, err)
@@ -285,7 +285,7 @@ func TestAttachedServer_DeleteWithWaitBlocksUntilStreamStops(t *testing.T) {
 	fake := &fakeRuntime{streamDelay: 200 * time.Millisecond}
 	sm.AttachRuntime(sess.ID, fake, sess)
 
-	srv := NewWithManager(sm)
+	srv := NewWithManager(sm, "")
 
 	ln, err := Listen(ctx, "127.0.0.1:0")
 	require.NoError(t, err)

--- a/pkg/server/server_attached_test.go
+++ b/pkg/server/server_attached_test.go
@@ -191,3 +191,31 @@ func TestAttachedServer_StatusEndpointReturnsCurrentState(t *testing.T) {
 	assert.Equal(t, "Test Session", status.Title)
 	assert.False(t, status.Streaming)
 }
+
+// TestAttachedServer_FollowUpWhileIdleReturnsQueuedIdle verifies that
+// POST /api/sessions/:id/followup returns status "queued_idle" when the
+// agent is not currently streaming.
+func TestAttachedServer_FollowUpWhileIdleReturnsQueuedIdle(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	store := session.NewInMemorySessionStore()
+	sess := session.New()
+	require.NoError(t, store.AddSession(ctx, sess))
+
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+	sm.AttachRuntime(sess.ID, &fakeRuntime{}, sess)
+
+	srv := NewWithManager(sm)
+
+	ln, err := Listen(ctx, "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() { _ = srv.Serve(ctx, ln) }()
+
+	addr := "http://" + ln.Addr().String()
+	resp := httpDoTCP(t, ctx, http.MethodPost, addr+"/api/sessions/"+sess.ID+"/followup",
+		api.SteerSessionRequest{Messages: []api.Message{{Content: "hello"}}})
+
+	assert.Contains(t, string(resp), "queued_idle")
+}

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -357,8 +357,11 @@ func (sm *SessionManager) RunSession(ctx context.Context, sessionID, agentFilena
 
 	streamChan := make(chan runtime.Event)
 
-	// Check if we need to generate a title
-	needsTitle := sess.Title == "" && len(userMessages) > 0 && titleGen != nil
+	// Snapshot the title under sm.mux before launching the goroutine to
+	// avoid a data race with UpdateSessionTitle, which takes sm.mux and
+	// writes to sess.Title concurrently with the goroutine's read.
+	titleToEmit := sess.Title
+	needsTitle := titleToEmit == "" && len(userMessages) > 0 && titleGen != nil
 
 	go func() {
 		// Defers run LIFO: close(streamChan) last, so by the time the
@@ -373,6 +376,10 @@ func (sm *SessionManager) RunSession(ctx context.Context, sessionID, agentFilena
 		// Start title generation in parallel if needed
 		if needsTitle {
 			go sm.generateTitle(ctx, sess, titleGen, userMessages, streamChan)
+		} else if titleToEmit != "" {
+			// Re-emit the existing title so late-joining SSE consumers
+			// and boards can pick it up without an extra API call.
+			streamChan <- runtime.SessionTitle(sess.ID, titleToEmit)
 		}
 
 		stream := runtimeSession.runtime.RunStream(streamCtx, sess)

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -140,6 +140,35 @@ func (sm *SessionManager) GetSession(ctx context.Context, id string) (*session.S
 	return sess, nil
 }
 
+// GetSessionStatus returns a lightweight snapshot of the session's current
+// runtime state. Designed for late-joining SSE consumers that need to know
+// the session's state without waiting for the next event transition.
+func (sm *SessionManager) GetSessionStatus(_ context.Context, id string) (*api.SessionStatusResponse, error) {
+	rs, ok := sm.runtimeSessions.Load(id)
+	if !ok {
+		return nil, fmt.Errorf("session %s not found", id)
+	}
+
+	sess := rs.session
+
+	// Probe streaming state: TryLock succeeds only when no RunStream is
+	// in progress. Immediately unlock so we don't interfere.
+	streaming := !rs.streaming.TryLock()
+	if !streaming {
+		rs.streaming.Unlock()
+	}
+
+	return &api.SessionStatusResponse{
+		ID:           sess.ID,
+		Title:        sess.Title,
+		Streaming:    streaming,
+		Agent:        rs.runtime.CurrentAgentName(),
+		InputTokens:  sess.InputTokens,
+		OutputTokens: sess.OutputTokens,
+		NumMessages:  len(sess.GetAllMessages()),
+	}, nil
+}
+
 // CreateSession creates a new session from a template.
 func (sm *SessionManager) CreateSession(ctx context.Context, sessionTemplate *session.Session) (*session.Session, error) {
 	var opts []session.Opt

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -48,6 +48,11 @@ type SessionManager struct {
 	refreshInterval time.Duration
 
 	mux sync.Mutex
+
+	// sessionReady is closed once the first session is attached or created,
+	// signalling that the server is ready to accept session-scoped requests.
+	sessionReady     chan struct{}
+	sessionReadyOnce sync.Once
 }
 
 // EventSource pushes session events to send for the lifetime of ctx. The
@@ -69,9 +74,25 @@ func NewSessionManager(ctx context.Context, sources config.Sources, sessionStore
 		Sources:         loaders,
 		refreshInterval: refreshInterval,
 		runConfig:       runConfig,
+		sessionReady:    make(chan struct{}),
 	}
 
 	return sm
+}
+
+func (sm *SessionManager) markReady() {
+	sm.sessionReadyOnce.Do(func() { close(sm.sessionReady) })
+}
+
+// WaitReady blocks until at least one session has been attached or created,
+// or ctx is cancelled. Returns nil when ready, ctx.Err() on timeout.
+func (sm *SessionManager) WaitReady(ctx context.Context) error {
+	select {
+	case <-sm.sessionReady:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // RegisterEventSource attaches an event source for sessionID. It is used by
@@ -129,6 +150,7 @@ func (sm *SessionManager) AttachRuntime(sessionID string, rt runtime.Runtime, se
 		cancel:  cancel,
 		session: sess,
 	})
+	sm.markReady()
 }
 
 // GetSession retrieves a session by ID.
@@ -266,6 +288,7 @@ func (sm *SessionManager) RunSession(ctx context.Context, sessionID, agentFilena
 			titleGen: titleGen,
 		}
 		sm.runtimeSessions.Store(sessionID, runtimeSession)
+		sm.markReady()
 	} else {
 		titleGen = runtimeSession.titleGen
 	}

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -378,10 +378,14 @@ func (sm *SessionManager) SteerSession(_ context.Context, sessionID string, mess
 // FollowUpSession enqueues user messages for end-of-turn processing in a
 // running session. Each message is popped one at a time after the current
 // turn finishes, giving each follow-up a full undivided agent turn.
-func (sm *SessionManager) FollowUpSession(_ context.Context, sessionID string, messages []api.Message) error {
+//
+// If no stream is currently running (agent is idle), the messages are still
+// enqueued but will not be consumed until the next RunSession starts a new
+// stream. The returned boolean indicates whether a stream is active.
+func (sm *SessionManager) FollowUpSession(_ context.Context, sessionID string, messages []api.Message) (streaming bool, err error) {
 	rt, exists := sm.runtimeSessions.Load(sessionID)
 	if !exists {
-		return errors.New("session not found or not running")
+		return false, errors.New("session not found or not running")
 	}
 
 	for _, msg := range messages {
@@ -389,11 +393,18 @@ func (sm *SessionManager) FollowUpSession(_ context.Context, sessionID string, m
 			Content:      msg.Content,
 			MultiContent: msg.MultiContent,
 		}); err != nil {
-			return err
+			return false, err
 		}
 	}
 
-	return nil
+	// Probe streaming state so the caller knows whether the follow-up
+	// will be consumed by the current turn or sit idle until the next.
+	streaming = !rt.streaming.TryLock()
+	if !streaming {
+		rt.streaming.Unlock()
+	}
+
+	return streaming, nil
 }
 
 // ResumeElicitation resumes an elicitation request.

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -256,6 +256,28 @@ func (sm *SessionManager) DeleteSession(ctx context.Context, sessionID string) e
 		// streaming mutex after the runtime is deregistered.
 		sm.deletedSessions.Store(sess.ID, sessionRuntime)
 		sm.runtimeSessions.Delete(sess.ID)
+
+		// Background cleanup: remove the deletedSessions entry once the
+		// stream goroutine has exited. This prevents a memory leak when
+		// the caller does not use ?wait=true.
+		go func() {
+			ticker := time.NewTicker(100 * time.Millisecond)
+			defer ticker.Stop()
+			deadline := time.After(5 * time.Minute)
+			for {
+				if sessionRuntime.streaming.TryLock() {
+					sessionRuntime.streaming.Unlock()
+					sm.deletedSessions.Delete(sess.ID)
+					return
+				}
+				select {
+				case <-deadline:
+					sm.deletedSessions.Delete(sess.ID)
+					return
+				case <-ticker.C:
+				}
+			}
+		}()
 	}
 	sm.eventSources.Delete(sess.ID)
 
@@ -263,9 +285,10 @@ func (sm *SessionManager) DeleteSession(ctx context.Context, sessionID string) e
 }
 
 // WaitStopped blocks until the session's runtime stream goroutine has fully
-// exited (streaming mutex released) or the timeout fires. It should be called
-// after DeleteSession. Returns nil when the stream has stopped.
-func (sm *SessionManager) WaitStopped(_ context.Context, sessionID string, timeout time.Duration) error {
+// exited (streaming mutex released), the timeout fires, or ctx is cancelled
+// (e.g. client disconnect). It should be called after DeleteSession.
+// Returns nil when the stream has stopped.
+func (sm *SessionManager) WaitStopped(ctx context.Context, sessionID string, timeout time.Duration) error {
 	rs, ok := sm.deletedSessions.Load(sessionID)
 	if !ok {
 		return nil // already cleaned up
@@ -282,6 +305,8 @@ func (sm *SessionManager) WaitStopped(_ context.Context, sessionID string, timeo
 			return nil
 		}
 		select {
+		case <-ctx.Done():
+			return ctx.Err()
 		case <-deadline:
 			return fmt.Errorf("timeout waiting for session %s to stop", sessionID)
 		case <-ticker.C:

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -37,6 +37,7 @@ type activeRuntimes struct {
 // SessionManager manages sessions for HTTP and Connect-RPC servers.
 type SessionManager struct {
 	runtimeSessions *concurrent.Map[string, *activeRuntimes]
+	deletedSessions *concurrent.Map[string, *activeRuntimes]
 	eventSources    *concurrent.Map[string, EventSource]
 	sessionStore    session.Store
 	Sources         config.Sources
@@ -69,6 +70,7 @@ func NewSessionManager(ctx context.Context, sources config.Sources, sessionStore
 
 	sm := &SessionManager{
 		runtimeSessions: concurrent.NewMap[string, *activeRuntimes](),
+		deletedSessions: concurrent.NewMap[string, *activeRuntimes](),
 		eventSources:    concurrent.NewMap[string, EventSource](),
 		sessionStore:    sessionStore,
 		Sources:         loaders,
@@ -233,7 +235,9 @@ func (sm *SessionManager) GetSessions(ctx context.Context) ([]*session.Session, 
 	return sessions, nil
 }
 
-// DeleteSession deletes a session by ID.
+// DeleteSession deletes a session by ID. It cancels the runtime context and
+// removes the session from all registries. Callers that need to wait for
+// the stream to fully stop should call WaitStopped afterwards.
 func (sm *SessionManager) DeleteSession(ctx context.Context, sessionID string) error {
 	sm.mux.Lock()
 	defer sm.mux.Unlock()
@@ -248,11 +252,41 @@ func (sm *SessionManager) DeleteSession(ctx context.Context, sessionID string) e
 
 	if sessionRuntime, ok := sm.runtimeSessions.Load(sess.ID); ok {
 		sessionRuntime.cancel()
+		// Keep the entry in deletedSessions so WaitStopped can probe the
+		// streaming mutex after the runtime is deregistered.
+		sm.deletedSessions.Store(sess.ID, sessionRuntime)
 		sm.runtimeSessions.Delete(sess.ID)
 	}
 	sm.eventSources.Delete(sess.ID)
 
 	return nil
+}
+
+// WaitStopped blocks until the session's runtime stream goroutine has fully
+// exited (streaming mutex released) or the timeout fires. It should be called
+// after DeleteSession. Returns nil when the stream has stopped.
+func (sm *SessionManager) WaitStopped(_ context.Context, sessionID string, timeout time.Duration) error {
+	rs, ok := sm.deletedSessions.Load(sessionID)
+	if !ok {
+		return nil // already cleaned up
+	}
+
+	deadline := time.After(timeout)
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		if rs.streaming.TryLock() {
+			rs.streaming.Unlock()
+			sm.deletedSessions.Delete(sessionID)
+			return nil
+		}
+		select {
+		case <-deadline:
+			return fmt.Errorf("timeout waiting for session %s to stop", sessionID)
+		case <-ticker.C:
+		}
+	}
 }
 
 // ErrSessionBusy is returned when a session is already processing a request.

--- a/pkg/server/session_manager_test.go
+++ b/pkg/server/session_manager_test.go
@@ -67,6 +67,7 @@ func newTestSessionManager(t *testing.T, sess *session.Session, fake *fakeRuntim
 
 	sm := &SessionManager{
 		runtimeSessions: concurrent.NewMap[string, *activeRuntimes](),
+		deletedSessions: concurrent.NewMap[string, *activeRuntimes](),
 		sessionStore:    store,
 		Sources:         config.Sources{},
 		runConfig:       &config.RuntimeConfig{},
@@ -211,6 +212,7 @@ func TestRunSession_DifferentSessionsConcurrently(t *testing.T) {
 
 	sm := &SessionManager{
 		runtimeSessions: concurrent.NewMap[string, *activeRuntimes](),
+		deletedSessions: concurrent.NewMap[string, *activeRuntimes](),
 		sessionStore:    store,
 		Sources:         config.Sources{},
 		runConfig:       &config.RuntimeConfig{},

--- a/pkg/server/session_manager_test.go
+++ b/pkg/server/session_manager_test.go
@@ -70,6 +70,7 @@ func newTestSessionManager(t *testing.T, sess *session.Session, fake *fakeRuntim
 		sessionStore:    store,
 		Sources:         config.Sources{},
 		runConfig:       &config.RuntimeConfig{},
+		sessionReady:    make(chan struct{}),
 	}
 
 	// Pre-register a runtime for this session so RunSession skips agent loading.
@@ -213,6 +214,7 @@ func TestRunSession_DifferentSessionsConcurrently(t *testing.T) {
 		sessionStore:    store,
 		Sources:         config.Sources{},
 		runConfig:       &config.RuntimeConfig{},
+		sessionReady:    make(chan struct{}),
 	}
 
 	sm.runtimeSessions.Store(sess1.ID, &activeRuntimes{

--- a/pkg/server/session_manager_test.go
+++ b/pkg/server/session_manager_test.go
@@ -56,6 +56,8 @@ func (f *fakeRuntime) ResumeElicitation(_ context.Context, _ tools.ElicitationAc
 	return nil
 }
 
+func (f *fakeRuntime) CurrentAgentName() string { return "root" }
+
 func newTestSessionManager(t *testing.T, sess *session.Session, fake *fakeRuntime) *SessionManager {
 	t.Helper()
 

--- a/pkg/tui/page/chat/runtime_events.go
+++ b/pkg/tui/page/chat/runtime_events.go
@@ -226,6 +226,7 @@ func (p *chatPage) handleStreamStopped(msg *runtime.StreamStoppedEvent) tea.Cmd 
 	slog.Debug("handleStreamStopped called",
 		"agent", msg.AgentName,
 		"session_id", msg.SessionID,
+		"reason", msg.Reason,
 		"should_exit", p.app.ShouldExitAfterFirstResponse(),
 		"has_content", p.hasReceivedAssistantContent,
 		"stream_depth", p.streamDepth)
@@ -245,7 +246,10 @@ func (p *chatPage) handleStreamStopped(msg *runtime.StreamStoppedEvent) tea.Cmd 
 	}
 
 	// Outermost stream stopped — fully clean up.
-	if userconfig.Get().GetSound() {
+	// Only play the success sound when the stream completed normally.
+	// Errors already trigger a failure sound via ErrorEvent, and
+	// user-initiated cancels don't warrant a chime.
+	if userconfig.Get().GetSound() && isSuccessfulStop(msg.Reason) {
 		duration := time.Since(p.streamStartTime)
 		threshold := time.Duration(userconfig.Get().GetSoundThreshold()) * time.Second
 		if duration >= threshold {
@@ -364,5 +368,18 @@ func (p *chatPage) handleElicitationRequest(msg *runtime.ElicitationRequestEvent
 			OriginatingEvent: msg,
 		})
 		return tea.Batch(spinnerCmd, dialogCmd)
+	}
+}
+
+// isSuccessfulStop returns true when the stream reason indicates a
+// normal completion that warrants the success sound. Empty reason
+// (e.g. cache hits, early exits before a turn runs) is treated as
+// success to preserve backward compatibility.
+func isSuccessfulStop(reason string) bool {
+	switch reason {
+	case "", "normal", "continue", "steered":
+		return true
+	default:
+		return false
 	}
 }


### PR DESCRIPTION
## What

Seven improvements to the control plane API, motivated by building an external board integration that drives docker-agent over HTTP + SSE.

### API changes

| Change | Description |
|--------|-------------|
| **StreamStoppedEvent.Reason** | Carries the exit reason (`normal`, `error`, `canceled`, `hook_blocked`, `loop_detected`) so consumers can distinguish completion from crashes. |
| **ErrorEvent.Code** | Machine-readable error classification (`rate_limited`, `context_exceeded`, `model_error`, `tool_failed`, `hook_blocked`, `loop_detected`). |
| **GET /api/sessions/:id/status** | Lightweight state snapshot (title, streaming flag, agent, tokens, message count) for late-joining SSE consumers. |
| **POST /followup response** | Returns `queued_streaming` or `queued_idle` so callers know if the message will be processed immediately. |
| **GET /api/ready** | Blocks until the first session is registered, replacing the poll-every-100ms pattern. Supports `?timeout=`. |
| **DELETE /api/sessions/:id ?wait=true** | Optionally blocks until the stream goroutine fully exits, enabling graceful shutdown without SIGKILL. |
| **Re-emit SessionTitle on stream start** | Existing titles are re-emitted so late joiners get them without an extra API call. |

### Bug fixes found during review

- **WaitStopped ignored context** — client disconnect left the polling loop spinning until timeout.
- **deletedSessions memory leak** — entries were never cleaned up without `?wait=true`.
- **Unbounded `?timeout`** — capped at 5 minutes to prevent goroutine pinning.
- **Reason threading** — simplified from `*string` + named return to pointer param + closure defer.

### TUI fix

- **Success sound on error/cancel** — the chime now only plays on normal completion, not after errors (which already play the failure sound) or user cancels.