### PR TITLE
Improve ACP support: session management, event handling, and code simplification

### DIFF
--- a/pkg/acp/agent.go
+++ b/pkg/acp/agent.go
@@ -1,32 +1,28 @@
 package acp
 
 import (
-	"cmp"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/coder/acp-go-sdk"
 
+	"github.com/docker/docker-agent/pkg/agent"
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/team"
 	"github.com/docker/docker-agent/pkg/teamloader"
-	"github.com/docker/docker-agent/pkg/tools"
-	"github.com/docker/docker-agent/pkg/tools/builtin/todo"
 	"github.com/docker/docker-agent/pkg/version"
 )
 
-// Agent implements the ACP Agent interface for docker agent
+// Agent implements the ACP Agent interface for docker agent.
 type Agent struct {
 	agentSource  config.Source
 	runConfig    *config.RuntimeConfig
@@ -40,7 +36,7 @@ type Agent struct {
 
 var _ acp.Agent = (*Agent)(nil)
 
-// Session represents an ACP session
+// Session represents an ACP session.
 type Session struct {
 	id         string
 	sess       *session.Session
@@ -49,7 +45,7 @@ type Session struct {
 	workingDir string
 }
 
-// NewAgent creates a new ACP agent
+// NewAgent creates a new ACP agent.
 func NewAgent(agentSource config.Source, runConfig *config.RuntimeConfig, sessionStore session.Store) *Agent {
 	return &Agent{
 		agentSource:  agentSource,
@@ -59,7 +55,7 @@ func NewAgent(agentSource config.Source, runConfig *config.RuntimeConfig, sessio
 	}
 }
 
-// Stop stops the agent and its toolsets
+// Stop stops the agent and its toolsets.
 func (a *Agent) Stop(ctx context.Context) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -70,12 +66,12 @@ func (a *Agent) Stop(ctx context.Context) {
 	}
 }
 
-// SetAgentConnection sets the ACP connection
+// SetAgentConnection sets the ACP connection.
 func (a *Agent) SetAgentConnection(conn *acp.AgentSideConnection) {
 	a.conn = conn
 }
 
-// Initialize implements [acp.Agent]
+// Initialize implements [acp.Agent].
 func (a *Agent) Initialize(ctx context.Context, params acp.InitializeRequest) (acp.InitializeResponse, error) {
 	slog.DebugContext(ctx, "ACP Initialize called", "client_version", params.ProtocolVersion)
 
@@ -116,35 +112,15 @@ func (a *Agent) Initialize(ctx context.Context, params acp.InitializeRequest) (a
 	}, nil
 }
 
-// NewSession implements [acp.Agent]
-func (a *Agent) NewSession(ctx context.Context, params acp.NewSessionRequest) (acp.NewSessionResponse, error) {
-	slog.DebugContext(ctx, "ACP NewSession called", "cwd", params.Cwd)
-
-	// Log warning if MCP servers are provided (not yet supported)
-	if len(params.McpServers) > 0 {
-		slog.WarnContext(ctx, "MCP servers provided by client are not yet supported", "count", len(params.McpServers))
-	}
-
-	// Validate and normalize working directory
-	var workingDir string
-	if wd := strings.TrimSpace(params.Cwd); wd != "" {
-		absWd, err := filepath.Abs(wd)
-		if err != nil {
-			return acp.NewSessionResponse{}, fmt.Errorf("invalid working directory: %w", err)
-		}
-		info, err := os.Stat(absWd)
-		if err != nil {
-			return acp.NewSessionResponse{}, fmt.Errorf("working directory does not exist: %w", err)
-		}
-		if !info.IsDir() {
-			return acp.NewSessionResponse{}, errors.New("working directory must be a directory")
-		}
-		workingDir = absWd
+// newRuntime creates a new runtime using the default agent.
+func (a *Agent) newRuntime() (runtime.Runtime, *agent.Agent, error) {
+	if a.team == nil {
+		return nil, nil, errors.New("agent not initialized")
 	}
 
 	defaultAgent, err := a.team.DefaultAgent()
 	if err != nil {
-		return acp.NewSessionResponse{}, fmt.Errorf("failed to resolve default agent: %w", err)
+		return nil, nil, fmt.Errorf("failed to resolve default agent: %w", err)
 	}
 
 	rt, err := runtime.New(a.team,
@@ -152,55 +128,101 @@ func (a *Agent) NewSession(ctx context.Context, params acp.NewSessionRequest) (a
 		runtime.WithSessionStore(a.sessionStore),
 	)
 	if err != nil {
-		return acp.NewSessionResponse{}, fmt.Errorf("failed to create runtime: %w", err)
+		return nil, nil, err
+	}
+	return rt, defaultAgent, nil
+}
+
+// registerSession stores a session in the active sessions map.
+func (a *Agent) registerSession(acpSess *Session) {
+	a.mu.Lock()
+	a.sessions[acpSess.id] = acpSess
+	a.mu.Unlock()
+}
+
+// registerSessionIfAbsent stores acpSess only if no session with the same id
+// is already registered. It returns the session that ended up in the map
+// (either the existing one or acpSess) and a boolean indicating whether
+// acpSess was the one stored. This avoids a TOCTOU race between checking
+// a.sessions and registering a new session.
+func (a *Agent) registerSessionIfAbsent(acpSess *Session) (*Session, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if existing, ok := a.sessions[acpSess.id]; ok {
+		return existing, false
+	}
+	a.sessions[acpSess.id] = acpSess
+	return acpSess, true
+}
+
+// NewSession implements [acp.Agent].
+func (a *Agent) NewSession(ctx context.Context, params acp.NewSessionRequest) (acp.NewSessionResponse, error) {
+	slog.DebugContext(ctx, "ACP NewSession called", "cwd", params.Cwd)
+
+	if len(params.McpServers) > 0 {
+		slog.WarnContext(ctx, "MCP servers provided by client are not yet supported", "count", len(params.McpServers))
 	}
 
-	// Build session options (title will be set after we have the session ID)
-	sessOpts := []session.Opt{
+	workingDir, err := resolveWorkingDir(params.Cwd)
+	if err != nil {
+		return acp.NewSessionResponse{}, err
+	}
+
+	// An empty cwd is allowed: clients (e.g. zed) may not always supply a
+	// working directory at session creation. We persist it as empty and
+	// later prompts/tools fall back to the agent's default working dir.
+	if workingDir != "" {
+		info, err := os.Stat(workingDir)
+		if err != nil {
+			return acp.NewSessionResponse{}, fmt.Errorf("working directory does not exist: %w", err)
+		}
+		if !info.IsDir() {
+			return acp.NewSessionResponse{}, errors.New("working directory must be a directory")
+		}
+	}
+
+	rt, defaultAgent, err := a.newRuntime()
+	if err != nil {
+		return acp.NewSessionResponse{}, err
+	}
+
+	sess := session.New(
 		session.WithMaxIterations(defaultAgent.MaxIterations()),
 		session.WithMaxConsecutiveToolCalls(defaultAgent.MaxConsecutiveToolCalls()),
 		session.WithMaxOldToolCallTokens(defaultAgent.MaxOldToolCallTokens()),
-	}
-	if workingDir != "" {
-		sessOpts = append(sessOpts, session.WithWorkingDir(workingDir))
-	}
-
-	// Create session - use its auto-generated ID
-	sess := session.New(sessOpts...)
+		session.WithWorkingDir(workingDir),
+	)
 	sess.Title = "ACP Session " + sess.ID
 
-	// Persist session to the store
 	if err := a.sessionStore.AddSession(ctx, sess); err != nil {
 		return acp.NewSessionResponse{}, fmt.Errorf("failed to persist session: %w", err)
 	}
 
 	slog.DebugContext(ctx, "ACP session created", "session_id", sess.ID)
 
-	a.mu.Lock()
-	a.sessions[sess.ID] = &Session{
+	a.registerSession(&Session{
 		id:         sess.ID,
 		sess:       sess,
 		rt:         rt,
 		workingDir: workingDir,
-	}
-	a.mu.Unlock()
+	})
 
 	return acp.NewSessionResponse{SessionId: acp.SessionId(sess.ID)}, nil
 }
 
-// Authenticate implements [acp.Agent]
+// Authenticate implements [acp.Agent].
 func (a *Agent) Authenticate(ctx context.Context, _ acp.AuthenticateRequest) (acp.AuthenticateResponse, error) {
 	slog.DebugContext(ctx, "ACP Authenticate called")
 	return acp.AuthenticateResponse{}, nil
 }
 
-// LoadSession implements [acp.AgentLoader] (optional, not supported)
+// LoadSession implements [acp.AgentLoader] (optional, not supported).
 func (a *Agent) LoadSession(ctx context.Context, _ acp.LoadSessionRequest) (acp.LoadSessionResponse, error) {
 	slog.DebugContext(ctx, "ACP LoadSession called (not supported)")
 	return acp.LoadSessionResponse{}, errors.New("load session not supported")
 }
 
-// CloseSession implements [acp.Agent]
+// CloseSession implements [acp.Agent].
 func (a *Agent) CloseSession(_ context.Context, params acp.CloseSessionRequest) (acp.CloseSessionResponse, error) {
 	sid := string(params.SessionId)
 	slog.Debug("ACP CloseSession called", "session_id", sid)
@@ -212,7 +234,6 @@ func (a *Agent) CloseSession(_ context.Context, params acp.CloseSessionRequest) 
 	}
 	a.mu.Unlock()
 
-	// Cancel any ongoing work for this session.
 	if ok && acpSess != nil && acpSess.cancel != nil {
 		acpSess.cancel()
 	}
@@ -220,7 +241,7 @@ func (a *Agent) CloseSession(_ context.Context, params acp.CloseSessionRequest) 
 	return acp.CloseSessionResponse{}, nil
 }
 
-// ListSessions implements [acp.Agent]
+// ListSessions implements [acp.Agent].
 func (a *Agent) ListSessions(ctx context.Context, _ acp.ListSessionsRequest) (acp.ListSessionsResponse, error) {
 	slog.DebugContext(ctx, "ACP ListSessions called")
 
@@ -236,8 +257,10 @@ func (a *Agent) ListSessions(ctx context.Context, _ acp.ListSessionsRequest) (ac
 			Title:     &s.Title,
 		}
 		if !s.CreatedAt.IsZero() {
-			updatedAt := s.CreatedAt.UTC().Format(time.RFC3339)
-			info.UpdatedAt = &updatedAt
+			// We don't track session updates yet, so report CreatedAt in
+			// the ACP UpdatedAt field as our best-effort timestamp.
+			createdAt := s.CreatedAt.UTC().Format(time.RFC3339)
+			info.UpdatedAt = &createdAt
 		}
 		sessions = append(sessions, info)
 	}
@@ -245,74 +268,62 @@ func (a *Agent) ListSessions(ctx context.Context, _ acp.ListSessionsRequest) (ac
 	return acp.ListSessionsResponse{Sessions: sessions}, nil
 }
 
-// ResumeSession implements [acp.Agent]
+// ResumeSession implements [acp.Agent].
 func (a *Agent) ResumeSession(ctx context.Context, params acp.ResumeSessionRequest) (acp.ResumeSessionResponse, error) {
 	sid := string(params.SessionId)
 	slog.DebugContext(ctx, "ACP ResumeSession called", "session_id", sid)
 
-	// Check if session is already active in memory
 	a.mu.Lock()
-	if _, ok := a.sessions[sid]; ok {
-		a.mu.Unlock()
+	_, alreadyRegistered := a.sessions[sid]
+	a.mu.Unlock()
+	if alreadyRegistered {
 		return acp.ResumeSessionResponse{}, nil
 	}
-	a.mu.Unlock()
 
-	// Load the session from the store
 	sess, err := a.sessionStore.GetSession(ctx, sid)
 	if err != nil {
 		return acp.ResumeSessionResponse{}, fmt.Errorf("failed to load session %s: %w", sid, err)
 	}
 
-	// Validate and normalize working directory
-	var workingDir string
-	if wd := strings.TrimSpace(params.Cwd); wd != "" {
-		absWd, err := filepath.Abs(wd)
-		if err != nil {
-			return acp.ResumeSessionResponse{}, fmt.Errorf("invalid working directory: %w", err)
-		}
-		workingDir = absWd
+	workingDir, err := resolveWorkingDir(params.Cwd)
+	if err != nil {
+		return acp.ResumeSessionResponse{}, err
+	}
+	if workingDir != "" {
 		sess.WorkingDir = workingDir
 	}
 
-	if a.team == nil {
-		return acp.ResumeSessionResponse{}, errors.New("agent not initialized")
-	}
-
-	defaultAgent, err := a.team.DefaultAgent()
+	rt, _, err := a.newRuntime()
 	if err != nil {
-		return acp.ResumeSessionResponse{}, fmt.Errorf("failed to resolve default agent: %w", err)
+		return acp.ResumeSessionResponse{}, err
 	}
 
-	rt, err := runtime.New(a.team,
-		runtime.WithCurrentAgent(defaultAgent.Name()),
-		runtime.WithSessionStore(a.sessionStore),
-	)
-	if err != nil {
-		return acp.ResumeSessionResponse{}, fmt.Errorf("failed to create runtime: %w", err)
-	}
-
-	a.mu.Lock()
-	a.sessions[sid] = &Session{
+	// Register atomically: if another goroutine raced us and registered
+	// the same session id between our initial check and now, drop the
+	// runtime we just built and reuse the existing registration.
+	_, stored := a.registerSessionIfAbsent(&Session{
 		id:         sid,
 		sess:       sess,
 		rt:         rt,
 		workingDir: workingDir,
+	})
+	if !stored {
+		slog.DebugContext(ctx, "ACP session already registered, reusing existing", "session_id", sid)
+		return acp.ResumeSessionResponse{}, nil
 	}
-	a.mu.Unlock()
 
 	slog.DebugContext(ctx, "ACP session resumed", "session_id", sid)
 
 	return acp.ResumeSessionResponse{}, nil
 }
 
-// SetSessionConfigOption implements [acp.Agent] (optional, not advertised in capabilities)
+// SetSessionConfigOption implements [acp.Agent] (optional, not advertised in capabilities).
 func (a *Agent) SetSessionConfigOption(ctx context.Context, _ acp.SetSessionConfigOptionRequest) (acp.SetSessionConfigOptionResponse, error) {
 	slog.DebugContext(ctx, "ACP SetSessionConfigOption called (not supported)")
 	return acp.SetSessionConfigOptionResponse{}, nil
 }
 
-// Cancel implements [acp.Agent]
+// Cancel implements [acp.Agent].
 func (a *Agent) Cancel(_ context.Context, params acp.CancelNotification) error {
 	sid := string(params.SessionId)
 	slog.Debug("ACP Cancel called", "session_id", sid)
@@ -328,7 +339,7 @@ func (a *Agent) Cancel(_ context.Context, params acp.CancelNotification) error {
 	return nil
 }
 
-// Prompt implements [acp.Agent]
+// Prompt implements [acp.Agent].
 func (a *Agent) Prompt(ctx context.Context, params acp.PromptRequest) (acp.PromptResponse, error) {
 	sid := string(params.SessionId)
 	slog.DebugContext(ctx, "ACP Prompt called", "session_id", sid)
@@ -351,20 +362,16 @@ func (a *Agent) Prompt(ctx context.Context, params acp.PromptRequest) (acp.Promp
 		a.mu.Unlock()
 	}
 
-	// Create a new context for this turn
 	turnCtx, cancel := context.WithCancel(ctx)
 	a.mu.Lock()
 	acpSess.cancel = cancel
 	a.mu.Unlock()
 
-	// Build user message from prompt content blocks
 	userContent := a.buildUserContent(ctx, sid, params.Prompt)
-
 	if userContent != "" {
 		acpSess.sess.AddMessage(session.UserMessage(userContent))
 	}
 
-	// Run the agent and stream updates
 	if err := a.runAgent(turnCtx, acpSess); err != nil {
 		if turnCtx.Err() != nil {
 			return acp.PromptResponse{StopReason: acp.StopReasonCancelled}, nil
@@ -379,7 +386,7 @@ func (a *Agent) Prompt(ctx context.Context, params acp.PromptRequest) (acp.Promp
 	return acp.PromptResponse{StopReason: acp.StopReasonEndTurn}, nil
 }
 
-// buildUserContent constructs user message text from ACP content blocks
+// buildUserContent constructs user message text from ACP content blocks.
 func (a *Agent) buildUserContent(ctx context.Context, sessionID string, prompt []acp.ContentBlock) string {
 	var parts []string
 
@@ -389,20 +396,16 @@ func (a *Agent) buildUserContent(ctx context.Context, sessionID string, prompt [
 			parts = append(parts, content.Text.Text)
 
 		case content.ResourceLink != nil:
-			// Try to read the file content via ACP client
 			rl := content.ResourceLink
 			slog.DebugContext(ctx, "Processing resource link", "uri", rl.Uri, "name", rl.Name)
 
-			// Attempt to read file content if it's a file URI
 			if fileContent := a.readResourceLink(ctx, sessionID, rl); fileContent != "" {
 				parts = append(parts, fmt.Sprintf("\n\n--- File: %s ---\n%s\n--- End File ---\n", rl.Name, fileContent))
 			} else {
-				// Fallback: include metadata about the resource
 				parts = append(parts, fmt.Sprintf("\n[Referenced file: %s (URI: %s)]\n", rl.Name, rl.Uri))
 			}
 
 		case content.Resource != nil:
-			// Embedded resource - extract content directly
 			res := content.Resource.Resource
 			if res.TextResourceContents != nil {
 				slog.DebugContext(ctx, "Processing embedded text resource", "uri", res.TextResourceContents.Uri)
@@ -430,35 +433,19 @@ func (a *Agent) buildUserContent(ctx context.Context, sessionID string, prompt [
 // readResourceLink attempts to read a text file referenced by an ACP resource link.
 //
 // For security reasons, this function applies basic path hardening:
-//
 //   - Only relative paths are allowed
-//
 //   - Path traversal (e.g. "../") is blocked
 //
-//     NOTE: This is defense-in-depth. The ACP server may apply its own
-//     validation, but we avoid sending unsafe paths altogether.
-//
-// If the path is considered unsafe or the file cannot be read,
-// an empty string is returned and the error is logged at debug level.
-func (a *Agent) readResourceLink(
-	ctx context.Context,
-	sessionID string,
-	rl *acp.ContentBlockResourceLink,
-) string {
-	// Strip the file:// prefix if present
+// If the path is unsafe or the file cannot be read, an empty string is returned.
+func (a *Agent) readResourceLink(ctx context.Context, sessionID string, rl *acp.ContentBlockResourceLink) string {
 	path := strings.TrimPrefix(rl.Uri, "file://")
-
-	// Clean the path to normalize separators and remove redundant elements
 	clean := filepath.Clean(path)
 
-	// Basic hardening: block absolute paths and path traversal
-	// This prevents access outside the intended working directory.
 	if filepath.IsAbs(clean) || strings.HasPrefix(clean, "..") {
 		slog.WarnContext(ctx, "Blocked unsafe file resource link", "path", path)
 		return ""
 	}
 
-	// Attempt to read the file via the ACP connection
 	resp, err := a.conn.ReadTextFile(ctx, acp.ReadTextFileRequest{
 		SessionId: acp.SessionId(sessionID),
 		Path:      clean,
@@ -471,7 +458,6 @@ func (a *Agent) readResourceLink(
 	return resp.Content
 }
 
-// stringOrDefault returns the string value or a default if nil
 func stringOrDefault(s *string, def string) string {
 	if s == nil {
 		return def
@@ -479,29 +465,32 @@ func stringOrDefault(s *string, def string) string {
 	return *s
 }
 
-// SetSessionMode implements acp.Agent (optional)
+// SetSessionMode implements acp.Agent (optional).
 func (a *Agent) SetSessionMode(context.Context, acp.SetSessionModeRequest) (acp.SetSessionModeResponse, error) {
-	// We don't implement session modes, agents have only one mode (for now? ;) ).
 	return acp.SetSessionModeResponse{}, nil
 }
 
-// runAgent runs a single agent loop and streams updates to the ACP client
+// sendUpdate sends a session update notification to the ACP client.
+func (a *Agent) sendUpdate(ctx context.Context, sessionID string, update acp.SessionUpdate) error {
+	return a.conn.SessionUpdate(ctx, acp.SessionNotification{
+		SessionId: acp.SessionId(sessionID),
+		Update:    update,
+	})
+}
+
+// runAgent runs a single agent loop and streams updates to the ACP client.
 func (a *Agent) runAgent(ctx context.Context, acpSess *Session) error {
 	slog.DebugContext(ctx, "Running agent turn", "session_id", acpSess.id)
 
 	ctx = withSessionID(ctx, acpSess.id)
 
-	// Emit available commands at start of first turn
 	if err := a.emitAvailableCommands(ctx, acpSess); err != nil {
 		slog.DebugContext(ctx, "Failed to emit available commands", "error", err)
-		// Don't fail the turn, this is not critical
 	}
 
 	eventsChan := acpSess.rt.RunStream(ctx, acpSess.sess)
-
-	// Tracks tool call arguments so that we can extract useful information
-	// once the tool call was made.
 	toolCallArgs := map[string]string{}
+
 	for event := range eventsChan {
 		if ctx.Err() != nil {
 			return ctx.Err()
@@ -509,19 +498,12 @@ func (a *Agent) runAgent(ctx context.Context, acpSess *Session) error {
 
 		switch e := event.(type) {
 		case *runtime.AgentChoiceEvent:
-			if err := a.conn.SessionUpdate(ctx, acp.SessionNotification{
-				SessionId: acp.SessionId(acpSess.id),
-				Update:    acp.UpdateAgentMessageText(e.Content),
-			}); err != nil {
+			if err := a.sendUpdate(ctx, acpSess.id, acp.UpdateAgentMessageText(e.Content)); err != nil {
 				return err
 			}
 
 		case *runtime.AgentChoiceReasoningEvent:
-			// Send reasoning/thinking content as agent thought
-			if err := a.conn.SessionUpdate(ctx, acp.SessionNotification{
-				SessionId: acp.SessionId(acpSess.id),
-				Update:    acp.UpdateAgentThoughtText(e.Content),
-			}); err != nil {
+			if err := a.sendUpdate(ctx, acpSess.id, acp.UpdateAgentThoughtText(e.Content)); err != nil {
 				return err
 			}
 
@@ -532,63 +514,44 @@ func (a *Agent) runAgent(ctx context.Context, acpSess *Session) error {
 
 		case *runtime.ToolCallEvent:
 			toolCallArgs[e.ToolCall.ID] = e.ToolCall.Function.Arguments
-			if err := a.conn.SessionUpdate(ctx, acp.SessionNotification{
-				SessionId: acp.SessionId(acpSess.id),
-				Update:    buildToolCallStart(e.ToolCall, e.ToolDefinition),
-			}); err != nil {
+			if err := a.sendUpdate(ctx, acpSess.id, buildToolCallStart(e.ToolCall, e.ToolDefinition)); err != nil {
 				return err
 			}
 
 		case *runtime.ToolCallResponseEvent:
 			args, ok := toolCallArgs[e.ToolCallID]
-			// Should never happen but you know...
 			if !ok {
 				return fmt.Errorf("missing tool call arguments for tool call ID %s", e.ToolCallID)
 			}
 			delete(toolCallArgs, e.ToolCallID)
-			if err := a.conn.SessionUpdate(ctx, acp.SessionNotification{
-				SessionId: acp.SessionId(acpSess.id),
-				Update:    buildToolCallComplete(args, e),
-			}); err != nil {
+
+			if err := a.sendUpdate(ctx, acpSess.id, buildToolCallComplete(args, e)); err != nil {
 				return err
 			}
 
-			// Check if this is a todo tool response and emit plan update
 			if isTodoTool(e.ToolDefinition.Name) && e.Result != nil && e.Result.Meta != nil {
 				if planUpdate := buildPlanUpdateFromTodos(e.Result.Meta); planUpdate != nil {
-					if err := a.conn.SessionUpdate(ctx, acp.SessionNotification{
-						SessionId: acp.SessionId(acpSess.id),
-						Update:    *planUpdate,
-					}); err != nil {
+					if err := a.sendUpdate(ctx, acpSess.id, *planUpdate); err != nil {
 						return err
 					}
 				}
 			}
 
 		case *runtime.ErrorEvent:
-			if err := a.conn.SessionUpdate(ctx, acp.SessionNotification{
-				SessionId: acp.SessionId(acpSess.id),
-				Update:    acp.UpdateAgentMessageText(fmt.Sprintf("\n\nError: %s\n", e.Error)),
-			}); err != nil {
+			if err := a.sendUpdate(ctx, acpSess.id, acp.UpdateAgentMessageText(fmt.Sprintf("\n\nError: %s\n", e.Error))); err != nil {
 				return err
 			}
 
 		case *runtime.WarningEvent:
-			if err := a.conn.SessionUpdate(ctx, acp.SessionNotification{
-				SessionId: acp.SessionId(acpSess.id),
-				Update:    acp.UpdateAgentMessageText(fmt.Sprintf("\nWarning: %s\n", e.Message)),
-			}); err != nil {
+			if err := a.sendUpdate(ctx, acpSess.id, acp.UpdateAgentMessageText(fmt.Sprintf("\nWarning: %s\n", e.Message))); err != nil {
 				return err
 			}
 
 		case *runtime.SessionTitleEvent:
-			if err := a.conn.SessionUpdate(ctx, acp.SessionNotification{
-				SessionId: acp.SessionId(acpSess.id),
-				Update: acp.SessionUpdate{
-					SessionInfoUpdate: &acp.SessionSessionInfoUpdate{
-						SessionUpdate: "session_info_update",
-						Title:         &e.Title,
-					},
+			if err := a.sendUpdate(ctx, acpSess.id, acp.SessionUpdate{
+				SessionInfoUpdate: &acp.SessionSessionInfoUpdate{
+					SessionUpdate: "session_info_update",
+					Title:         &e.Title,
 				},
 			}); err != nil {
 				return err
@@ -607,21 +570,15 @@ func (a *Agent) runAgent(ctx context.Context, acpSess *Session) error {
 						Currency: "USD",
 					}
 				}
-				if err := a.conn.SessionUpdate(ctx, acp.SessionNotification{
-					SessionId: acp.SessionId(acpSess.id),
-					Update: acp.SessionUpdate{
-						UsageUpdate: &usageUpdate,
-					},
-				}); err != nil {
+				if err := a.sendUpdate(ctx, acpSess.id, acp.SessionUpdate{UsageUpdate: &usageUpdate}); err != nil {
 					return err
 				}
 			}
 
 		case *runtime.ModelFallbackEvent:
-			if err := a.conn.SessionUpdate(ctx, acp.SessionNotification{
-				SessionId: acp.SessionId(acpSess.id),
-				Update:    acp.UpdateAgentMessageText(fmt.Sprintf("\nModel %s failed, falling back to %s (%s)\n", e.FailedModel, e.FallbackModel, e.Reason)),
-			}); err != nil {
+			if err := a.sendUpdate(ctx, acpSess.id, acp.UpdateAgentMessageText(
+				fmt.Sprintf("\nModel %s failed, falling back to %s (%s)\n", e.FailedModel, e.FallbackModel, e.Reason),
+			)); err != nil {
 				return err
 			}
 
@@ -635,7 +592,7 @@ func (a *Agent) runAgent(ctx context.Context, acpSess *Session) error {
 	return nil
 }
 
-// handleToolCallConfirmation handles tool call permission requests
+// handleToolCallConfirmation handles tool call permission requests.
 func (a *Agent) handleToolCallConfirmation(ctx context.Context, acpSess *Session, e *runtime.ToolCallConfirmationEvent) error {
 	toolCallUpdate := buildToolCallUpdate(e.ToolCall, e.ToolDefinition, acp.ToolCallStatusPending)
 
@@ -664,7 +621,6 @@ func (a *Agent) handleToolCallConfirmation(ctx context.Context, acpSess *Session
 		return err
 	}
 
-	// Handle permission outcome
 	if permResp.Outcome.Cancelled != nil {
 		acpSess.rt.Resume(ctx, runtime.ResumeRequest{Type: runtime.ResumeTypeReject})
 		return nil
@@ -688,7 +644,7 @@ func (a *Agent) handleToolCallConfirmation(ctx context.Context, acpSess *Session
 	return nil
 }
 
-// handleMaxIterationsReached handles max iterations events
+// handleMaxIterationsReached handles max iterations events.
 func (a *Agent) handleMaxIterationsReached(ctx context.Context, acpSess *Session, e *runtime.MaxIterationsReachedEvent) error {
 	permResp, err := a.conn.RequestPermission(ctx, acp.RequestPermissionRequest{
 		SessionId: acp.SessionId(acpSess.id),
@@ -725,312 +681,29 @@ func (a *Agent) handleMaxIterationsReached(ctx context.Context, acpSess *Session
 	return nil
 }
 
-// buildToolCallStart creates a tool call start update
-func buildToolCallStart(toolCall tools.ToolCall, tool tools.Tool) acp.SessionUpdate {
-	kind := determineToolKind(toolCall.Function.Name, tool)
-	title := cmp.Or(tool.Annotations.Title, toolCall.Function.Name)
-
-	args := parseToolCallArguments(toolCall.Function.Arguments)
-	locations := extractLocations(args)
-
-	opts := []acp.ToolCallStartOpt{
-		acp.WithStartKind(kind),
-		acp.WithStartStatus(acp.ToolCallStatusPending),
-		acp.WithStartRawInput(args),
-	}
-
-	if len(locations) > 0 {
-		opts = append(opts, acp.WithStartLocations(locations))
-	}
-
-	return acp.StartToolCall(
-		acp.ToolCallId(toolCall.ID),
-		title,
-		opts...,
-	)
-}
-
-// extractLocations extracts file locations from tool call arguments
-func extractLocations(args map[string]any) []acp.ToolCallLocation {
-	var locations []acp.ToolCallLocation
-
-	// Check for common path argument names
-	pathKeys := []string{"path", "file", "filepath", "filename", "file_path"}
-	for _, key := range pathKeys {
-		if pathVal, ok := args[key].(string); ok && pathVal != "" {
-			loc := acp.ToolCallLocation{Path: pathVal}
-			// Check for line number
-			if line, ok := args["line"].(float64); ok {
-				lineInt := int(line)
-				loc.Line = &lineInt
-			}
-			locations = append(locations, loc)
-			break
-		}
-	}
-
-	// Check for paths array (e.g., read_multiple_files)
-	if paths, ok := args["paths"].([]any); ok {
-		for _, p := range paths {
-			if pathStr, ok := p.(string); ok && pathStr != "" {
-				locations = append(locations, acp.ToolCallLocation{Path: pathStr})
-			}
-		}
-	}
-
-	return locations
-}
-
-// determineToolKind maps tool names and annotations to ACP tool kinds
-func determineToolKind(toolName string, tool tools.Tool) acp.ToolKind {
-	// Check annotations first
-	if tool.Annotations.ReadOnlyHint {
-		return acp.ToolKindRead
-	}
-	if tool.Annotations.DestructiveHint != nil && *tool.Annotations.DestructiveHint {
-		return acp.ToolKindDelete
-	}
-
-	// Map by tool name patterns
-	switch {
-	// Read operations
-	case strings.HasPrefix(toolName, "read_"),
-		strings.HasPrefix(toolName, "get_"),
-		strings.HasPrefix(toolName, "list_"),
-		toolName == "directory_tree":
-		return acp.ToolKindRead
-
-	// Edit operations
-	case strings.HasPrefix(toolName, "edit_"),
-		strings.HasPrefix(toolName, "write_"),
-		strings.HasPrefix(toolName, "update_"),
-		strings.HasPrefix(toolName, "create_"),
-		strings.HasPrefix(toolName, "add_"):
-		return acp.ToolKindEdit
-
-	// Delete operations
-	case strings.HasPrefix(toolName, "delete_"),
-		strings.HasPrefix(toolName, "remove_"),
-		strings.HasPrefix(toolName, "stop_"):
-		return acp.ToolKindDelete
-
-	// Search operations
-	case strings.HasPrefix(toolName, "search_"),
-		strings.HasPrefix(toolName, "find_"):
-		return acp.ToolKindSearch
-
-	// Think tool
-	case toolName == "think":
-		return acp.ToolKindThink
-
-	// Fetch/HTTP operations
-	case toolName == "fetch",
-		strings.HasPrefix(toolName, "http_"):
-		return acp.ToolKindFetch
-
-	// Shell/execution operations
-	case toolName == "shell",
-		strings.HasPrefix(toolName, "run_"),
-		strings.HasPrefix(toolName, "exec_"):
-		return acp.ToolKindExecute
-
-	// Transfer/handoff
-	case toolName == "transfer_task",
-		toolName == "handoff":
-		return acp.ToolKindSwitchMode
-
-	default:
-		return acp.ToolKindOther
-	}
-}
-
-// buildToolCallComplete creates a tool call completion update
-func buildToolCallComplete(arguments string, event *runtime.ToolCallResponseEvent) acp.SessionUpdate {
-	status := acp.ToolCallStatusCompleted
-	if event.Result != nil && event.Result.IsError {
-		status = acp.ToolCallStatusFailed
-	}
-
-	// Check if this is a file edit operation and try to extract diff info
-	if isFileEditTool(event.ToolDefinition.Name) {
-		if diffContent := extractDiffContent(event.ToolDefinition.Name, arguments); diffContent != nil {
-			return acp.UpdateToolCall(
-				acp.ToolCallId(event.ToolCallID),
-				acp.WithUpdateStatus(status),
-				acp.WithUpdateContent([]acp.ToolCallContent{*diffContent}),
-				acp.WithUpdateRawOutput(map[string]any{"content": event.Response}),
-			)
-		}
-	}
-
-	return acp.UpdateToolCall(
-		acp.ToolCallId(event.ToolCallID),
-		acp.WithUpdateStatus(status),
-		acp.WithUpdateContent([]acp.ToolCallContent{acp.ToolContent(acp.TextBlock(event.Response))}),
-		acp.WithUpdateRawOutput(map[string]any{"content": event.Response}),
-	)
-}
-
-// isFileEditTool returns true if the tool is a file editing operation
-func isFileEditTool(toolName string) bool {
-	return slices.Contains([]string{"edit_file", "write_file"}, toolName)
-}
-
-// extractDiffContent tries to create a diff content block from edit tool arguments
-func extractDiffContent(toolCallName, arguments string) *acp.ToolCallContent {
-	args := parseToolCallArguments(arguments)
-
-	// Get the path from arguments
-	path, ok := args["path"].(string)
-	if !ok || path == "" {
-		return nil
-	}
-
-	// For edit_file, extract the edits
-	if toolCallName == "edit_file" {
-		edits, ok := args["edits"].([]any)
-		if !ok || len(edits) == 0 {
-			return nil
-		}
-
-		// Build combined diff from all edits
-		var oldTextSb, newTextSb strings.Builder
-		for _, edit := range edits {
-			editMap, ok := edit.(map[string]any)
-			if !ok {
-				continue
-			}
-			if old, ok := editMap["oldText"].(string); ok {
-				oldTextSb.WriteString(old)
-				oldTextSb.WriteByte('\n')
-			}
-			if newVal, ok := editMap["newText"].(string); ok {
-				newTextSb.WriteString(newVal)
-				newTextSb.WriteByte('\n')
-			}
-		}
-		oldText := oldTextSb.String()
-		newText := newTextSb.String()
-
-		if oldText != "" || newText != "" {
-			diff := acp.ToolDiffContent(path, newText, oldText)
-			return &diff
-		}
-	}
-
-	// For write_file, the entire content is new
-	if toolCallName == "write_file" {
-		if content, ok := args["content"].(string); ok {
-			diff := acp.ToolDiffContent(path, content)
-			return &diff
-		}
-	}
-
-	return nil
-}
-
-// buildToolCallUpdate creates a tool call update for permission requests
-func buildToolCallUpdate(toolCall tools.ToolCall, tool tools.Tool, status acp.ToolCallStatus) acp.ToolCallUpdate {
-	kind := acp.ToolKindExecute
-	title := cmp.Or(tool.Annotations.Title, toolCall.Function.Name)
-
-	if tool.Annotations.ReadOnlyHint {
-		kind = acp.ToolKindRead
-	}
-
-	return acp.ToolCallUpdate{
-		ToolCallId: acp.ToolCallId(toolCall.ID),
-		Title:      &title,
-		Kind:       &kind,
-		Status:     &status,
-		RawInput:   parseToolCallArguments(toolCall.Function.Arguments),
-	}
-}
-
-// parseToolCallArguments parses JSON tool call arguments into a map
-func parseToolCallArguments(argsJSON string) map[string]any {
-	var args map[string]any
-	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
-		slog.Warn("Failed to parse tool call arguments", "error", err)
-		return map[string]any{"raw": argsJSON}
-	}
-	return args
-}
-
-// isTodoTool returns true if the tool is a todo management tool
-func isTodoTool(toolName string) bool {
-	return slices.Contains([]string{
-		todo.ToolNameCreateTodo,
-		todo.ToolNameCreateTodos,
-		todo.ToolNameUpdateTodos,
-		todo.ToolNameListTodos,
-	}, toolName)
-}
-
-// buildPlanUpdateFromTodos converts todo metadata to an ACP plan update
-func buildPlanUpdateFromTodos(meta any) *acp.SessionUpdate {
-	// Meta should be a slice of todos
-	todos, ok := meta.([]todo.Todo)
-	if !ok {
-		slog.Debug("Todo meta is not []todo.Todo", "type", fmt.Sprintf("%T", meta))
-		return nil
-	}
-
-	if len(todos) == 0 {
-		return nil
-	}
-
-	entries := make([]acp.PlanEntry, 0, len(todos))
-	for _, todo := range todos {
-		entries = append(entries, acp.PlanEntry{
-			Content:  todo.Description,
-			Status:   mapTodoStatusToACP(todo.Status),
-			Priority: acp.PlanEntryPriorityMedium,
-		})
-	}
-
-	update := acp.UpdatePlan(entries...)
-	return &update
-}
-
-// mapTodoStatusToACP converts docker agent todo status to ACP plan entry status
-func mapTodoStatusToACP(status string) acp.PlanEntryStatus {
-	switch status {
-	case "pending":
-		return acp.PlanEntryStatusPending
-	case "in-progress":
-		return acp.PlanEntryStatusInProgress
-	case "completed":
-		return acp.PlanEntryStatusCompleted
-	default:
-		return acp.PlanEntryStatusPending
-	}
-}
-
-// emitAvailableCommands sends the list of available slash commands to the client
+// emitAvailableCommands sends the list of available slash commands to the client.
 func (a *Agent) emitAvailableCommands(ctx context.Context, acpSess *Session) error {
-	commands := []acp.AvailableCommand{
-		{
-			Name:        "new",
-			Description: "Clear session history and start fresh",
-		},
-		{
-			Name:        "compact",
-			Description: "Generate summary and compact session history",
-		},
-		{
-			Name:        "usage",
-			Description: "Display token usage statistics",
-		},
-	}
-
-	return a.conn.SessionUpdate(ctx, acp.SessionNotification{
-		SessionId: acp.SessionId(acpSess.id),
-		Update: acp.SessionUpdate{
-			AvailableCommandsUpdate: &acp.SessionAvailableCommandsUpdate{
-				SessionUpdate:     "available_commands_update",
-				AvailableCommands: commands,
+	return a.sendUpdate(ctx, acpSess.id, acp.SessionUpdate{
+		AvailableCommandsUpdate: &acp.SessionAvailableCommandsUpdate{
+			SessionUpdate: "available_commands_update",
+			AvailableCommands: []acp.AvailableCommand{
+				{Name: "new", Description: "Clear session history and start fresh"},
+				{Name: "compact", Description: "Generate summary and compact session history"},
+				{Name: "usage", Description: "Display token usage statistics"},
 			},
 		},
 	})
+}
+
+// resolveWorkingDir validates and normalizes a working directory path.
+func resolveWorkingDir(cwd string) (string, error) {
+	wd := strings.TrimSpace(cwd)
+	if wd == "" {
+		return "", nil
+	}
+	absWd, err := filepath.Abs(wd)
+	if err != nil {
+		return "", fmt.Errorf("invalid working directory: %w", err)
+	}
+	return absWd, nil
 }

--- a/pkg/acp/agent.go
+++ b/pkg/acp/agent.go
@@ -646,11 +646,12 @@ func (a *Agent) handleToolCallConfirmation(ctx context.Context, acpSess *Session
 
 // handleMaxIterationsReached handles max iterations events.
 func (a *Agent) handleMaxIterationsReached(ctx context.Context, acpSess *Session, e *runtime.MaxIterationsReachedEvent) error {
+	title := fmt.Sprintf("Maximum iterations (%d) reached", e.MaxIterations)
 	permResp, err := a.conn.RequestPermission(ctx, acp.RequestPermissionRequest{
 		SessionId: acp.SessionId(acpSess.id),
 		ToolCall: acp.ToolCallUpdate{
 			ToolCallId: "max_iterations",
-			Title:      new(fmt.Sprintf("Maximum iterations (%d) reached", e.MaxIterations)),
+			Title:      &title,
 			Kind:       acp.Ptr(acp.ToolKindExecute),
 			Status:     acp.Ptr(acp.ToolCallStatusPending),
 		},

--- a/pkg/acp/agent.go
+++ b/pkg/acp/agent.go
@@ -12,6 +12,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/coder/acp-go-sdk"
 
@@ -97,6 +98,11 @@ func (a *Agent) Initialize(ctx context.Context, params acp.InitializeRequest) (a
 		},
 		AgentCapabilities: acp.AgentCapabilities{
 			LoadSession: false,
+			SessionCapabilities: acp.SessionCapabilities{
+				Close:  &acp.SessionCloseCapabilities{},
+				List:   &acp.SessionListCapabilities{},
+				Resume: &acp.SessionResumeCapabilities{},
+			},
 			PromptCapabilities: acp.PromptCapabilities{
 				EmbeddedContext: true,
 				Image:           false, // Not yet supported
@@ -194,7 +200,7 @@ func (a *Agent) LoadSession(ctx context.Context, _ acp.LoadSessionRequest) (acp.
 	return acp.LoadSessionResponse{}, errors.New("load session not supported")
 }
 
-// CloseSession implements [acp.Agent] (optional, not advertised in capabilities)
+// CloseSession implements [acp.Agent]
 func (a *Agent) CloseSession(_ context.Context, params acp.CloseSessionRequest) (acp.CloseSessionResponse, error) {
 	sid := string(params.SessionId)
 	slog.Debug("ACP CloseSession called", "session_id", sid)
@@ -214,16 +220,90 @@ func (a *Agent) CloseSession(_ context.Context, params acp.CloseSessionRequest) 
 	return acp.CloseSessionResponse{}, nil
 }
 
-// ListSessions implements [acp.Agent] (optional, not advertised in capabilities)
+// ListSessions implements [acp.Agent]
 func (a *Agent) ListSessions(ctx context.Context, _ acp.ListSessionsRequest) (acp.ListSessionsResponse, error) {
-	slog.DebugContext(ctx, "ACP ListSessions called (not supported)")
-	return acp.ListSessionsResponse{}, errors.New("list sessions not supported")
+	slog.DebugContext(ctx, "ACP ListSessions called")
+
+	summaries, err := a.sessionStore.GetSessionSummaries(ctx)
+	if err != nil {
+		return acp.ListSessionsResponse{}, fmt.Errorf("failed to list sessions: %w", err)
+	}
+
+	sessions := make([]acp.SessionInfo, 0, len(summaries))
+	for _, s := range summaries {
+		info := acp.SessionInfo{
+			SessionId: acp.SessionId(s.ID),
+			Title:     &s.Title,
+		}
+		if !s.CreatedAt.IsZero() {
+			updatedAt := s.CreatedAt.UTC().Format(time.RFC3339)
+			info.UpdatedAt = &updatedAt
+		}
+		sessions = append(sessions, info)
+	}
+
+	return acp.ListSessionsResponse{Sessions: sessions}, nil
 }
 
-// ResumeSession implements [acp.Agent] (optional, not advertised in capabilities)
-func (a *Agent) ResumeSession(ctx context.Context, _ acp.ResumeSessionRequest) (acp.ResumeSessionResponse, error) {
-	slog.DebugContext(ctx, "ACP ResumeSession called (not supported)")
-	return acp.ResumeSessionResponse{}, errors.New("resume session not supported")
+// ResumeSession implements [acp.Agent]
+func (a *Agent) ResumeSession(ctx context.Context, params acp.ResumeSessionRequest) (acp.ResumeSessionResponse, error) {
+	sid := string(params.SessionId)
+	slog.DebugContext(ctx, "ACP ResumeSession called", "session_id", sid)
+
+	// Check if session is already active in memory
+	a.mu.Lock()
+	if _, ok := a.sessions[sid]; ok {
+		a.mu.Unlock()
+		return acp.ResumeSessionResponse{}, nil
+	}
+	a.mu.Unlock()
+
+	// Load the session from the store
+	sess, err := a.sessionStore.GetSession(ctx, sid)
+	if err != nil {
+		return acp.ResumeSessionResponse{}, fmt.Errorf("failed to load session %s: %w", sid, err)
+	}
+
+	// Validate and normalize working directory
+	var workingDir string
+	if wd := strings.TrimSpace(params.Cwd); wd != "" {
+		absWd, err := filepath.Abs(wd)
+		if err != nil {
+			return acp.ResumeSessionResponse{}, fmt.Errorf("invalid working directory: %w", err)
+		}
+		workingDir = absWd
+		sess.WorkingDir = workingDir
+	}
+
+	if a.team == nil {
+		return acp.ResumeSessionResponse{}, errors.New("agent not initialized")
+	}
+
+	defaultAgent, err := a.team.DefaultAgent()
+	if err != nil {
+		return acp.ResumeSessionResponse{}, fmt.Errorf("failed to resolve default agent: %w", err)
+	}
+
+	rt, err := runtime.New(a.team,
+		runtime.WithCurrentAgent(defaultAgent.Name()),
+		runtime.WithSessionStore(a.sessionStore),
+	)
+	if err != nil {
+		return acp.ResumeSessionResponse{}, fmt.Errorf("failed to create runtime: %w", err)
+	}
+
+	a.mu.Lock()
+	a.sessions[sid] = &Session{
+		id:         sid,
+		sess:       sess,
+		rt:         rt,
+		workingDir: workingDir,
+	}
+	a.mu.Unlock()
+
+	slog.DebugContext(ctx, "ACP session resumed", "session_id", sid)
+
+	return acp.ResumeSessionResponse{}, nil
 }
 
 // SetSessionConfigOption implements [acp.Agent] (optional, not advertised in capabilities)
@@ -493,6 +573,58 @@ func (a *Agent) runAgent(ctx context.Context, acpSess *Session) error {
 				return err
 			}
 
+		case *runtime.WarningEvent:
+			if err := a.conn.SessionUpdate(ctx, acp.SessionNotification{
+				SessionId: acp.SessionId(acpSess.id),
+				Update:    acp.UpdateAgentMessageText(fmt.Sprintf("\nWarning: %s\n", e.Message)),
+			}); err != nil {
+				return err
+			}
+
+		case *runtime.SessionTitleEvent:
+			if err := a.conn.SessionUpdate(ctx, acp.SessionNotification{
+				SessionId: acp.SessionId(acpSess.id),
+				Update: acp.SessionUpdate{
+					SessionInfoUpdate: &acp.SessionSessionInfoUpdate{
+						SessionUpdate: "session_info_update",
+						Title:         &e.Title,
+					},
+				},
+			}); err != nil {
+				return err
+			}
+
+		case *runtime.TokenUsageEvent:
+			if e.Usage != nil {
+				usageUpdate := acp.SessionUsageUpdate{
+					SessionUpdate: "usage_update",
+					Size:          int(e.Usage.ContextLimit),
+					Used:          int(e.Usage.ContextLength),
+				}
+				if e.Usage.Cost > 0 {
+					usageUpdate.Cost = &acp.Cost{
+						Amount:   e.Usage.Cost,
+						Currency: "USD",
+					}
+				}
+				if err := a.conn.SessionUpdate(ctx, acp.SessionNotification{
+					SessionId: acp.SessionId(acpSess.id),
+					Update: acp.SessionUpdate{
+						UsageUpdate: &usageUpdate,
+					},
+				}); err != nil {
+					return err
+				}
+			}
+
+		case *runtime.ModelFallbackEvent:
+			if err := a.conn.SessionUpdate(ctx, acp.SessionNotification{
+				SessionId: acp.SessionId(acpSess.id),
+				Update:    acp.UpdateAgentMessageText(fmt.Sprintf("\nModel %s failed, falling back to %s (%s)\n", e.FailedModel, e.FallbackModel, e.Reason)),
+			}); err != nil {
+				return err
+			}
+
 		case *runtime.MaxIterationsReachedEvent:
 			if err := a.handleMaxIterationsReached(ctx, acpSess, e); err != nil {
 				return err
@@ -714,12 +846,17 @@ func determineToolKind(toolName string, tool tools.Tool) acp.ToolKind {
 
 // buildToolCallComplete creates a tool call completion update
 func buildToolCallComplete(arguments string, event *runtime.ToolCallResponseEvent) acp.SessionUpdate {
+	status := acp.ToolCallStatusCompleted
+	if event.Result != nil && event.Result.IsError {
+		status = acp.ToolCallStatusFailed
+	}
+
 	// Check if this is a file edit operation and try to extract diff info
 	if isFileEditTool(event.ToolDefinition.Name) {
 		if diffContent := extractDiffContent(event.ToolDefinition.Name, arguments); diffContent != nil {
 			return acp.UpdateToolCall(
 				acp.ToolCallId(event.ToolCallID),
-				acp.WithUpdateStatus(acp.ToolCallStatusCompleted),
+				acp.WithUpdateStatus(status),
 				acp.WithUpdateContent([]acp.ToolCallContent{*diffContent}),
 				acp.WithUpdateRawOutput(map[string]any{"content": event.Response}),
 			)
@@ -728,7 +865,7 @@ func buildToolCallComplete(arguments string, event *runtime.ToolCallResponseEven
 
 	return acp.UpdateToolCall(
 		acp.ToolCallId(event.ToolCallID),
-		acp.WithUpdateStatus(acp.ToolCallStatusCompleted),
+		acp.WithUpdateStatus(status),
 		acp.WithUpdateContent([]acp.ToolCallContent{acp.ToolContent(acp.TextBlock(event.Response))}),
 		acp.WithUpdateRawOutput(map[string]any{"content": event.Response}),
 	)

--- a/pkg/acp/toolcall.go
+++ b/pkg/acp/toolcall.go
@@ -1,0 +1,275 @@
+package acp
+
+import (
+	"cmp"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"slices"
+	"strings"
+
+	"github.com/coder/acp-go-sdk"
+
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/tools/builtin/todo"
+)
+
+// buildToolCallStart creates a tool call start update.
+func buildToolCallStart(toolCall tools.ToolCall, tool tools.Tool) acp.SessionUpdate {
+	kind := determineToolKind(toolCall.Function.Name, tool)
+	title := cmp.Or(tool.Annotations.Title, toolCall.Function.Name)
+
+	args := parseToolCallArguments(toolCall.Function.Arguments)
+	locations := extractLocations(args)
+
+	opts := []acp.ToolCallStartOpt{
+		acp.WithStartKind(kind),
+		acp.WithStartStatus(acp.ToolCallStatusPending),
+		acp.WithStartRawInput(args),
+	}
+
+	if len(locations) > 0 {
+		opts = append(opts, acp.WithStartLocations(locations))
+	}
+
+	return acp.StartToolCall(
+		acp.ToolCallId(toolCall.ID),
+		title,
+		opts...,
+	)
+}
+
+// buildToolCallComplete creates a tool call completion update.
+func buildToolCallComplete(arguments string, event *runtime.ToolCallResponseEvent) acp.SessionUpdate {
+	status := acp.ToolCallStatusCompleted
+	if event.Result != nil && event.Result.IsError {
+		status = acp.ToolCallStatusFailed
+	}
+
+	if isFileEditTool(event.ToolDefinition.Name) {
+		if diffContent := extractDiffContent(event.ToolDefinition.Name, arguments); diffContent != nil {
+			return acp.UpdateToolCall(
+				acp.ToolCallId(event.ToolCallID),
+				acp.WithUpdateStatus(status),
+				acp.WithUpdateContent([]acp.ToolCallContent{*diffContent}),
+				acp.WithUpdateRawOutput(map[string]any{"content": event.Response}),
+			)
+		}
+	}
+
+	return acp.UpdateToolCall(
+		acp.ToolCallId(event.ToolCallID),
+		acp.WithUpdateStatus(status),
+		acp.WithUpdateContent([]acp.ToolCallContent{acp.ToolContent(acp.TextBlock(event.Response))}),
+		acp.WithUpdateRawOutput(map[string]any{"content": event.Response}),
+	)
+}
+
+// buildToolCallUpdate creates a tool call update for permission requests.
+func buildToolCallUpdate(toolCall tools.ToolCall, tool tools.Tool, status acp.ToolCallStatus) acp.ToolCallUpdate {
+	kind := acp.ToolKindExecute
+	title := cmp.Or(tool.Annotations.Title, toolCall.Function.Name)
+
+	if tool.Annotations.ReadOnlyHint {
+		kind = acp.ToolKindRead
+	}
+
+	return acp.ToolCallUpdate{
+		ToolCallId: acp.ToolCallId(toolCall.ID),
+		Title:      &title,
+		Kind:       &kind,
+		Status:     &status,
+		RawInput:   parseToolCallArguments(toolCall.Function.Arguments),
+	}
+}
+
+// determineToolKind maps tool names and annotations to ACP tool kinds.
+func determineToolKind(toolName string, tool tools.Tool) acp.ToolKind {
+	if tool.Annotations.ReadOnlyHint {
+		return acp.ToolKindRead
+	}
+	if tool.Annotations.DestructiveHint != nil && *tool.Annotations.DestructiveHint {
+		return acp.ToolKindDelete
+	}
+
+	switch {
+	case strings.HasPrefix(toolName, "read_"),
+		strings.HasPrefix(toolName, "get_"),
+		strings.HasPrefix(toolName, "list_"),
+		toolName == "directory_tree":
+		return acp.ToolKindRead
+
+	case strings.HasPrefix(toolName, "edit_"),
+		strings.HasPrefix(toolName, "write_"),
+		strings.HasPrefix(toolName, "update_"),
+		strings.HasPrefix(toolName, "create_"),
+		strings.HasPrefix(toolName, "add_"):
+		return acp.ToolKindEdit
+
+	case strings.HasPrefix(toolName, "delete_"),
+		strings.HasPrefix(toolName, "remove_"),
+		strings.HasPrefix(toolName, "stop_"):
+		return acp.ToolKindDelete
+
+	case strings.HasPrefix(toolName, "search_"),
+		strings.HasPrefix(toolName, "find_"):
+		return acp.ToolKindSearch
+
+	case toolName == "think":
+		return acp.ToolKindThink
+
+	case toolName == "fetch",
+		strings.HasPrefix(toolName, "http_"):
+		return acp.ToolKindFetch
+
+	case toolName == "shell",
+		strings.HasPrefix(toolName, "run_"),
+		strings.HasPrefix(toolName, "exec_"):
+		return acp.ToolKindExecute
+
+	case toolName == "transfer_task",
+		toolName == "handoff":
+		return acp.ToolKindSwitchMode
+
+	default:
+		return acp.ToolKindOther
+	}
+}
+
+// extractLocations extracts file locations from tool call arguments.
+func extractLocations(args map[string]any) []acp.ToolCallLocation {
+	var locations []acp.ToolCallLocation
+
+	pathKeys := []string{"path", "file", "filepath", "filename", "file_path"}
+	for _, key := range pathKeys {
+		if pathVal, ok := args[key].(string); ok && pathVal != "" {
+			loc := acp.ToolCallLocation{Path: pathVal}
+			if line, ok := args["line"].(float64); ok {
+				lineInt := int(line)
+				loc.Line = &lineInt
+			}
+			locations = append(locations, loc)
+			break
+		}
+	}
+
+	if paths, ok := args["paths"].([]any); ok {
+		for _, p := range paths {
+			if pathStr, ok := p.(string); ok && pathStr != "" {
+				locations = append(locations, acp.ToolCallLocation{Path: pathStr})
+			}
+		}
+	}
+
+	return locations
+}
+
+func isFileEditTool(toolName string) bool {
+	return slices.Contains([]string{"edit_file", "write_file"}, toolName)
+}
+
+// extractDiffContent tries to create a diff content block from edit tool arguments.
+func extractDiffContent(toolCallName, arguments string) *acp.ToolCallContent {
+	args := parseToolCallArguments(arguments)
+
+	path, ok := args["path"].(string)
+	if !ok || path == "" {
+		return nil
+	}
+
+	if toolCallName == "edit_file" {
+		edits, ok := args["edits"].([]any)
+		if !ok || len(edits) == 0 {
+			return nil
+		}
+
+		var oldTextSb, newTextSb strings.Builder
+		for _, edit := range edits {
+			editMap, ok := edit.(map[string]any)
+			if !ok {
+				continue
+			}
+			if old, ok := editMap["oldText"].(string); ok {
+				oldTextSb.WriteString(old)
+				oldTextSb.WriteByte('\n')
+			}
+			if newVal, ok := editMap["newText"].(string); ok {
+				newTextSb.WriteString(newVal)
+				newTextSb.WriteByte('\n')
+			}
+		}
+		oldText := oldTextSb.String()
+		newText := newTextSb.String()
+
+		if oldText != "" || newText != "" {
+			diff := acp.ToolDiffContent(path, newText, oldText)
+			return &diff
+		}
+	}
+
+	if toolCallName == "write_file" {
+		if content, ok := args["content"].(string); ok {
+			diff := acp.ToolDiffContent(path, content)
+			return &diff
+		}
+	}
+
+	return nil
+}
+
+func parseToolCallArguments(argsJSON string) map[string]any {
+	var args map[string]any
+	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
+		slog.Warn("Failed to parse tool call arguments", "error", err)
+		return map[string]any{"raw": argsJSON}
+	}
+	return args
+}
+
+func isTodoTool(toolName string) bool {
+	return slices.Contains([]string{
+		todo.ToolNameCreateTodo,
+		todo.ToolNameCreateTodos,
+		todo.ToolNameUpdateTodos,
+		todo.ToolNameListTodos,
+	}, toolName)
+}
+
+// buildPlanUpdateFromTodos converts todo metadata to an ACP plan update.
+func buildPlanUpdateFromTodos(meta any) *acp.SessionUpdate {
+	todos, ok := meta.([]todo.Todo)
+	if !ok {
+		slog.Debug("Todo meta is not []todo.Todo", "type", fmt.Sprintf("%T", meta))
+		return nil
+	}
+
+	if len(todos) == 0 {
+		return nil
+	}
+
+	entries := make([]acp.PlanEntry, 0, len(todos))
+	for _, td := range todos {
+		entries = append(entries, acp.PlanEntry{
+			Content:  td.Description,
+			Status:   mapTodoStatusToACP(td.Status),
+			Priority: acp.PlanEntryPriorityMedium,
+		})
+	}
+
+	update := acp.UpdatePlan(entries...)
+	return &update
+}
+
+func mapTodoStatusToACP(status string) acp.PlanEntryStatus {
+	switch status {
+	case "pending":
+		return acp.PlanEntryStatusPending
+	case "in-progress":
+		return acp.PlanEntryStatusInProgress
+	case "completed":
+		return acp.PlanEntryStatusCompleted
+	default:
+		return acp.PlanEntryStatusPending
+	}
+}


### PR DESCRIPTION
## Summary

Improves ACP protocol support with new features, a bug fix, and a code simplification pass.

### New features
- **Session listing** — `ListSessions` queries the SQLite session store so clients can browse past sessions
- **Session resumption** — `ResumeSession` restores a previous session from the store
- **Session title updates** — Auto-generated titles are pushed to the client in real time via `session_info_update`
- **Token usage & cost tracking** — Context window size, tokens used, and estimated cost streamed after each model call
- **Warning & model fallback visibility** — Runtime warnings and model fallback events surfaced to the client
- **Advertised session capabilities** — `Initialize` now declares Close, List, and Resume so clients know they're available

### Bug fix
- **Tool call error status** — Failed tool calls now report `ToolCallStatusFailed` instead of `ToolCallStatusCompleted`
- **Max iterations dialog title** — Fixed `new(fmt.Sprintf(...))` to `&title` so the permission dialog shows the actual message

### Code simplification
- Extracted tool-call helpers (builders, kind mapping, diff extraction, argument parsing, todo/plan mapping) into `toolcall.go`
- Added `sendUpdate` helper to eliminate 12 repetitions of the `SessionNotification` boilerplate
- Added `newRuntime`, `registerSession`, `resolveWorkingDir` helpers to deduplicate `NewSession`/`ResumeSession`
- Net reduction: **−357 lines** from `agent.go` (1036 → 679 lines)