### PR TITLE
fix(toolinstall): recover from panics during auto-install

### DIFF
--- a/pkg/toolinstall/resolver.go
+++ b/pkg/toolinstall/resolver.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 
 	"golang.org/x/sync/singleflight"
@@ -60,7 +61,7 @@ func resolve(ctx context.Context, command, version string) (string, error) {
 
 	// Use singleflight to deduplicate concurrent installs of the same command.
 	result, err, _ := installGroup.Do(command, func() (any, error) {
-		return doInstall(ctx, command, version)
+		return safeInstall(ctx, command, version)
 	})
 	if err != nil {
 		return "", err
@@ -68,6 +69,27 @@ func resolve(ctx context.Context, command, version string) (string, error) {
 
 	return result.(string), nil
 }
+
+// safeInstall wraps doInstall with panic recovery. Without this,
+// singleflight wraps any panic in *panicError and re-raises it via
+// `go panic(...)` (see golang.org/x/sync/singleflight), which is
+// unrecoverable by callers and crashes the process. Issue #2765.
+func safeInstall(ctx context.Context, command, version string) (path string, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.ErrorContext(ctx, "Panic during tool auto-install",
+				"command", command, "panic", r, "stack", string(debug.Stack()))
+			path = ""
+			err = fmt.Errorf("auto-install for %q panicked: %v", command, r)
+		}
+	}()
+	return doInstallFn(ctx, command, version)
+}
+
+// doInstallFn is the install function safeInstall delegates to. Indirected
+// through a var so tests can swap in a panicking implementation to verify
+// the recover path. Production code never reassigns this.
+var doInstallFn = doInstall
 
 // doInstall performs the actual package resolution and installation.
 func doInstall(ctx context.Context, command, versionRef string) (string, error) {

--- a/pkg/toolinstall/resolver_panic_test.go
+++ b/pkg/toolinstall/resolver_panic_test.go
@@ -1,0 +1,80 @@
+package toolinstall
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withPanickingInstaller swaps doInstallFn for a panicking stub for the
+// duration of the test, restoring the original on cleanup.
+func withPanickingInstaller(t *testing.T, panicValue any) {
+	t.Helper()
+	original := doInstallFn
+	doInstallFn = func(context.Context, string, string) (string, error) {
+		panic(panicValue)
+	}
+	t.Cleanup(func() { doInstallFn = original })
+}
+
+// TestSafeInstall_RecoversFromStringPanic verifies that a string panic
+// inside doInstall is converted to an error rather than crashing the
+// process via singleflight's re-panic.
+func TestSafeInstall_RecoversFromStringPanic(t *testing.T) {
+	withPanickingInstaller(t, "boom")
+
+	path, err := safeInstall(t.Context(), "fake-tool", "")
+
+	require.Error(t, err)
+	assert.Empty(t, path)
+	assert.Contains(t, err.Error(), "fake-tool")
+	assert.Contains(t, err.Error(), "panicked")
+	assert.Contains(t, err.Error(), "boom")
+}
+
+// TestSafeInstall_RecoversFromNilDeref verifies recovery from a runtime
+// nil-pointer dereference, which is the failure mode described in the
+// original issue (downstream HTTP/YAML code dereferencing a nil result).
+func TestSafeInstall_RecoversFromNilDeref(t *testing.T) {
+	original := doInstallFn
+	doInstallFn = func(context.Context, string, string) (string, error) {
+		var p *struct{ X int }
+		_ = p.X // forces a runtime panic
+		return "", nil
+	}
+	t.Cleanup(func() { doInstallFn = original })
+
+	path, err := safeInstall(t.Context(), "fake-tool", "")
+
+	require.Error(t, err)
+	assert.Empty(t, path)
+	assert.Contains(t, err.Error(), "panicked")
+}
+
+// TestResolve_ConcurrentPanic_DoesNotCrash exercises the full resolve()
+// path: multiple goroutines hit singleflight at once, the underlying
+// install panics, and every caller must observe an error rather than the
+// process crashing via singleflight's `go panic(...)` re-raise.
+func TestResolve_ConcurrentPanic_DoesNotCrash(t *testing.T) {
+	t.Setenv("DOCKER_AGENT_TOOLS_DIR", t.TempDir())
+	withPanickingInstaller(t, "simulated network failure")
+
+	const numGoroutines = 10
+	var wg sync.WaitGroup
+	errs := make([]error, numGoroutines)
+
+	for i := range numGoroutines {
+		wg.Go(func() {
+			_, errs[i] = resolve(t.Context(), "concurrent-panic-tool", "")
+		})
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		require.Errorf(t, err, "goroutine %d should observe an error, not crash", i)
+		assert.Contains(t, err.Error(), "panicked")
+	}
+}


### PR DESCRIPTION
Closes #2765.

`toolinstall.EnsureCommand` could crash the process when the aqua registry HTTP fetch failed in network-restricted environments. The panic (e.g. a nil-pointer deref deep in the HTTP/YAML stack) was wrapped by `singleflight` into a `*panicError` and re-raised via `go panic(...)`, which is unrecoverable by callers.

This change wraps `doInstall` in a `safeInstall` helper that uses `defer/recover` to convert any panic into a normal error before it ever reaches singleflight. The existing call sites (`createLSPTool`, `createMCPTool`) already handle errors from `EnsureCommand` gracefully.

Logs the panic value and stack trace at ERROR level so the underlying issue is still diagnosable.

### Tests

Three new tests in `resolver_panic_test.go`, all exercising the real `safeInstall`/`resolve` code paths through a small `doInstallFn` test seam:

- `TestSafeInstall_RecoversFromStringPanic` — explicit `panic("boom")`
- `TestSafeInstall_RecoversFromNilDeref` — runtime nil-pointer dereference (the failure mode reported in the issue)
- `TestResolve_ConcurrentPanic_DoesNotCrash` — 10 concurrent goroutines hit the same singleflight key while installation panics; all must observe an error rather than the process crashing

Verified the regression test fails without the fix (panic propagates) and passes with it.