### PR TITLE
perf(tui): make streaming chunk rendering linear

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1016,88 +1016,149 @@ func (a *App) shouldThrottle(msg tea.Msg) bool {
 	}
 }
 
-// mergeEvents merges consecutive similar events to reduce UI updates
+// mergeEvents merges consecutive similar events to reduce UI updates.
+//
+// Each merge group is built with a single strings.Builder so concatenating N
+// chunks costs O(N) instead of the O(N^2) the naive `merged.Content + next.Content`
+// pattern produces. This matters during fast LLM streams where dozens of
+// chunks land per throttle window.
 func (a *App) mergeEvents(events []tea.Msg) []tea.Msg {
 	if len(events) == 0 {
 		return events
 	}
 
-	var result []tea.Msg
+	result := make([]tea.Msg, 0, len(events))
 
-	// Group events by type and merge
 	for i := 0; i < len(events); i++ {
-		current := events[i]
-
-		switch ev := current.(type) {
+		switch ev := events[i].(type) {
 		case *runtime.AgentChoiceEvent:
-			// Merge consecutive AgentChoiceEvents with same agent
-			merged := ev
-			for i+1 < len(events) {
-				if next, ok := events[i+1].(*runtime.AgentChoiceEvent); ok && next.AgentName == ev.AgentName {
-					// Concatenate content
-					merged = &runtime.AgentChoiceEvent{
-						Type:         ev.Type,
-						Content:      merged.Content + next.Content,
-						AgentContext: ev.AgentContext,
-					}
-					i++
-				} else {
-					break
-				}
-			}
+			merged, consumed := mergeAgentChoiceRun(ev, events[i+1:])
 			result = append(result, merged)
+			i += consumed
 
 		case *runtime.AgentChoiceReasoningEvent:
-			// Merge consecutive AgentChoiceReasoningEvents with same agent
-			merged := ev
-			for i+1 < len(events) {
-				if next, ok := events[i+1].(*runtime.AgentChoiceReasoningEvent); ok && next.AgentName == ev.AgentName {
-					// Concatenate content
-					merged = &runtime.AgentChoiceReasoningEvent{
-						Type:         ev.Type,
-						Content:      merged.Content + next.Content,
-						AgentContext: ev.AgentContext,
-					}
-					i++
-				} else {
-					break
-				}
-			}
+			merged, consumed := mergeAgentChoiceReasoningRun(ev, events[i+1:])
 			result = append(result, merged)
+			i += consumed
 
 		case *runtime.PartialToolCallEvent:
-			// For PartialToolCallEvent, merge consecutive events with the same tool call ID
-			// by concatenating argument deltas
-			latest := ev
-			for i+1 < len(events) {
-				if next, ok := events[i+1].(*runtime.PartialToolCallEvent); ok && next.ToolCall.ID == ev.ToolCall.ID {
-					latest = &runtime.PartialToolCallEvent{
-						Type: ev.Type,
-						ToolCall: tools.ToolCall{
-							ID:   ev.ToolCall.ID,
-							Type: ev.ToolCall.Type,
-							Function: tools.FunctionCall{
-								Name:      cmp.Or(next.ToolCall.Function.Name, latest.ToolCall.Function.Name),
-								Arguments: latest.ToolCall.Function.Arguments + next.ToolCall.Function.Arguments,
-							},
-						},
-						ToolDefinition: cmp.Or(latest.ToolDefinition, next.ToolDefinition),
-						AgentContext:   ev.AgentContext,
-					}
-					i++
-				} else {
-					break
-				}
-			}
-			result = append(result, latest)
+			merged, consumed := mergePartialToolCallRun(ev, events[i+1:])
+			result = append(result, merged)
+			i += consumed
 
 		default:
-			// Pass through other events as-is
-			result = append(result, current)
+			result = append(result, events[i])
 		}
 	}
 
 	return result
+}
+
+// mergeAgentChoiceRun merges first with any directly-following AgentChoiceEvents
+// for the same agent. It returns the merged event and the number of follow-up
+// events that were consumed.
+func mergeAgentChoiceRun(first *runtime.AgentChoiceEvent, rest []tea.Msg) (*runtime.AgentChoiceEvent, int) {
+	n := 0
+	total := len(first.Content)
+	for _, msg := range rest {
+		next, ok := msg.(*runtime.AgentChoiceEvent)
+		if !ok || next.AgentName != first.AgentName {
+			break
+		}
+		total += len(next.Content)
+		n++
+	}
+	if n == 0 {
+		return first, 0
+	}
+
+	var b strings.Builder
+	b.Grow(total)
+	b.WriteString(first.Content)
+	for _, msg := range rest[:n] {
+		b.WriteString(msg.(*runtime.AgentChoiceEvent).Content)
+	}
+	return &runtime.AgentChoiceEvent{
+		Type:         first.Type,
+		Content:      b.String(),
+		AgentContext: first.AgentContext,
+	}, n
+}
+
+// mergeAgentChoiceReasoningRun is the AgentChoiceReasoningEvent counterpart of
+// mergeAgentChoiceRun.
+func mergeAgentChoiceReasoningRun(first *runtime.AgentChoiceReasoningEvent, rest []tea.Msg) (*runtime.AgentChoiceReasoningEvent, int) {
+	n := 0
+	total := len(first.Content)
+	for _, msg := range rest {
+		next, ok := msg.(*runtime.AgentChoiceReasoningEvent)
+		if !ok || next.AgentName != first.AgentName {
+			break
+		}
+		total += len(next.Content)
+		n++
+	}
+	if n == 0 {
+		return first, 0
+	}
+
+	var b strings.Builder
+	b.Grow(total)
+	b.WriteString(first.Content)
+	for _, msg := range rest[:n] {
+		b.WriteString(msg.(*runtime.AgentChoiceReasoningEvent).Content)
+	}
+	return &runtime.AgentChoiceReasoningEvent{
+		Type:         first.Type,
+		Content:      b.String(),
+		AgentContext: first.AgentContext,
+	}, n
+}
+
+// mergePartialToolCallRun merges argument deltas across consecutive
+// PartialToolCallEvents that share the same tool call ID.
+func mergePartialToolCallRun(first *runtime.PartialToolCallEvent, rest []tea.Msg) (*runtime.PartialToolCallEvent, int) {
+	n := 0
+	total := len(first.ToolCall.Function.Arguments)
+	for _, msg := range rest {
+		next, ok := msg.(*runtime.PartialToolCallEvent)
+		if !ok || next.ToolCall.ID != first.ToolCall.ID {
+			break
+		}
+		total += len(next.ToolCall.Function.Arguments)
+		n++
+	}
+	if n == 0 {
+		return first, 0
+	}
+
+	var b strings.Builder
+	b.Grow(total)
+	b.WriteString(first.ToolCall.Function.Arguments)
+
+	name := first.ToolCall.Function.Name
+	toolDef := first.ToolDefinition
+	for _, msg := range rest[:n] {
+		next := msg.(*runtime.PartialToolCallEvent)
+		b.WriteString(next.ToolCall.Function.Arguments)
+		// The function name is sometimes only present on later deltas; keep the
+		// first non-empty value we observe across the run.
+		name = cmp.Or(name, next.ToolCall.Function.Name)
+		toolDef = cmp.Or(toolDef, next.ToolDefinition)
+	}
+	return &runtime.PartialToolCallEvent{
+		Type: first.Type,
+		ToolCall: tools.ToolCall{
+			ID:   first.ToolCall.ID,
+			Type: first.ToolCall.Type,
+			Function: tools.FunctionCall{
+				Name:      name,
+				Arguments: b.String(),
+			},
+		},
+		ToolDefinition: toolDef,
+		AgentContext:   first.AgentContext,
+	}, n
 }
 
 // ExportHTML exports the current session as a standalone HTML file.

--- a/pkg/app/merge_events_test.go
+++ b/pkg/app/merge_events_test.go
@@ -1,0 +1,147 @@
+package app
+
+import (
+	"strconv"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+func TestMergeEventsConcatenatesAgentChoiceContent(t *testing.T) {
+	t.Parallel()
+
+	a := &App{}
+	chunks := []string{"Hello ", "streaming ", "world", "!"}
+	events := make([]tea.Msg, 0, len(chunks))
+	for _, c := range chunks {
+		events = append(events, &runtime.AgentChoiceEvent{
+			Content:      c,
+			AgentContext: runtime.AgentContext{AgentName: "agent-a"},
+		})
+	}
+
+	merged := a.mergeEvents(events)
+
+	assert.Len(t, merged, 1)
+	got, ok := merged[0].(*runtime.AgentChoiceEvent)
+	assert.True(t, ok)
+	assert.Equal(t, "Hello streaming world!", got.Content)
+}
+
+func TestMergeEventsKeepsBoundaryBetweenAgents(t *testing.T) {
+	t.Parallel()
+
+	a := &App{}
+	events := []tea.Msg{
+		&runtime.AgentChoiceEvent{Content: "a1", AgentContext: runtime.AgentContext{AgentName: "agent-a"}},
+		&runtime.AgentChoiceEvent{Content: "a2", AgentContext: runtime.AgentContext{AgentName: "agent-a"}},
+		&runtime.AgentChoiceEvent{Content: "b1", AgentContext: runtime.AgentContext{AgentName: "agent-b"}},
+		&runtime.AgentChoiceEvent{Content: "a3", AgentContext: runtime.AgentContext{AgentName: "agent-a"}},
+	}
+
+	merged := a.mergeEvents(events)
+
+	assert.Len(t, merged, 3)
+	assert.Equal(t, "a1a2", merged[0].(*runtime.AgentChoiceEvent).Content)
+	assert.Equal(t, "b1", merged[1].(*runtime.AgentChoiceEvent).Content)
+	assert.Equal(t, "a3", merged[2].(*runtime.AgentChoiceEvent).Content)
+}
+
+func TestMergeEventsConcatenatesPartialToolCallArguments(t *testing.T) {
+	t.Parallel()
+
+	a := &App{}
+	events := []tea.Msg{
+		&runtime.PartialToolCallEvent{
+			ToolCall: tools.ToolCall{
+				ID:       "call-1",
+				Function: tools.FunctionCall{Arguments: `{"a"`},
+			},
+		},
+		&runtime.PartialToolCallEvent{
+			ToolCall: tools.ToolCall{
+				ID:       "call-1",
+				Function: tools.FunctionCall{Name: "shell", Arguments: `:1`},
+			},
+		},
+		&runtime.PartialToolCallEvent{
+			ToolCall: tools.ToolCall{
+				ID:       "call-1",
+				Function: tools.FunctionCall{Arguments: `}`},
+			},
+		},
+	}
+
+	merged := a.mergeEvents(events)
+
+	assert.Len(t, merged, 1)
+	got := merged[0].(*runtime.PartialToolCallEvent)
+	assert.Equal(t, `{"a":1}`, got.ToolCall.Function.Arguments)
+	assert.Equal(t, "shell", got.ToolCall.Function.Name)
+}
+
+// BenchmarkMergeEventsAgentChoice measures the cost of merging a typical
+// throttle-window's worth of streaming chunks. The pre-fix implementation did
+// `merged.Content + next.Content` repeatedly, which is O(N^2) in chunk count;
+// the strings.Builder version is O(N).
+func BenchmarkMergeEventsAgentChoice(b *testing.B) {
+	for _, n := range []int{16, 64, 256} {
+		b.Run("chunks="+strconv.Itoa(n), func(b *testing.B) {
+			events := buildAgentChoiceEvents(n)
+			a := &App{}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				_ = a.mergeEvents(events)
+			}
+		})
+	}
+}
+
+// BenchmarkMergeEventsPartialToolCall measures the same thing for tool-call
+// argument deltas, which use a structurally similar concatenation pattern.
+func BenchmarkMergeEventsPartialToolCall(b *testing.B) {
+	for _, n := range []int{16, 64, 256} {
+		b.Run("chunks="+strconv.Itoa(n), func(b *testing.B) {
+			events := buildPartialToolCallEvents(n)
+			a := &App{}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				_ = a.mergeEvents(events)
+			}
+		})
+	}
+}
+
+func buildAgentChoiceEvents(n int) []tea.Msg {
+	const chunk = "the quick brown fox jumps over the lazy dog. "
+	events := make([]tea.Msg, 0, n)
+	for range n {
+		events = append(events, &runtime.AgentChoiceEvent{
+			Content:      chunk,
+			AgentContext: runtime.AgentContext{AgentName: "agent"},
+		})
+	}
+	return events
+}
+
+func buildPartialToolCallEvents(n int) []tea.Msg {
+	const chunk = `,"key":"value"`
+	events := make([]tea.Msg, 0, n)
+	for range n {
+		events = append(events, &runtime.PartialToolCallEvent{
+			ToolCall: tools.ToolCall{
+				ID:       "call-1",
+				Function: tools.FunctionCall{Arguments: chunk},
+			},
+		})
+	}
+	return events
+}

--- a/pkg/tui/components/markdown/incremental.go
+++ b/pkg/tui/components/markdown/incremental.go
@@ -1,0 +1,327 @@
+package markdown
+
+import "strings"
+
+// IncrementalRenderer is a markdown renderer specialized for streaming use:
+// it remembers the most recently rendered "stable prefix" of the input and,
+// when the next call extends that prefix, re-renders only the new trailing
+// region instead of the whole document.
+//
+// A "stable prefix" here is the portion of the input ending at the last block
+// boundary that the underlying FastRenderer is guaranteed to render the same
+// way regardless of what comes after it: a blank line that lies outside any
+// fenced code block and is not flanked by list or blockquote lines (those
+// constructs absorb blank lines into a single block, so the surrounding
+// content is not yet "frozen").
+//
+// The optimization is correct because the FastRenderer (and CommonMark in
+// general) treats such blank lines as hard breaks between top-level blocks:
+// rendering the document up to a stable boundary and rendering the rest
+// independently produces the same output as rendering the full document,
+// modulo the blank-line separator that joinPrefixAndTail re-inserts.
+//
+// IncrementalRenderer is not safe for concurrent use.
+type IncrementalRenderer struct {
+	width int
+
+	// inputPrefix is the longest stable prefix of the most recent input that
+	// ends at a block boundary. outputPrefix is its rendered counterpart.
+	// Both are empty until the first successful incremental render.
+	inputPrefix  string
+	outputPrefix string
+
+	// fallback is used for the actual rendering work; it is reused across calls
+	// so its parser pool (and chroma caches) stay warm.
+	fallback *FastRenderer
+}
+
+// NewIncrementalRenderer creates a new incremental renderer with the given
+// terminal width.
+func NewIncrementalRenderer(width int) *IncrementalRenderer {
+	return &IncrementalRenderer{
+		width:    width,
+		fallback: NewFastRenderer(width),
+	}
+}
+
+// Render produces styled terminal output for input. When successive calls pass
+// inputs that share a long common prefix (the streaming case), only the suffix
+// is parsed and rendered; the rest is served from the cached output.
+func (r *IncrementalRenderer) Render(input string) (string, error) {
+	if input == "" {
+		r.inputPrefix = ""
+		r.outputPrefix = ""
+		return "", nil
+	}
+
+	// If the new input no longer starts with our cached prefix, the user (or a
+	// retry) replaced earlier content; fall back to a full render.
+	if r.inputPrefix == "" || !strings.HasPrefix(input, r.inputPrefix) {
+		return r.fullRender(input)
+	}
+
+	// Locate a fresh stable boundary anywhere up to the end of the current
+	// input. We always re-render from the previous boundary onward to keep the
+	// implementation simple and correctness-preserving: the previously emitted
+	// tail may have been an unfinished paragraph that should now be part of a
+	// completed block.
+	tail := input[len(r.inputPrefix):]
+	boundary := stableBoundary(tail)
+	if boundary <= 0 {
+		// No new block boundary in the tail yet — render only the tail and
+		// concatenate. Cached prefix is unchanged.
+		renderedTail, err := r.fallback.Render(tail)
+		if err != nil {
+			return r.fullRender(input)
+		}
+		return r.joinPrefixAndTail(r.outputPrefix, renderedTail), nil
+	}
+
+	// We have a new boundary inside the tail. Render the new stable region
+	// (inputPrefix + tail[:boundary]) once, append it to the cache, then render
+	// the new tail.
+	newStableTail := tail[:boundary]
+	renderedStableTail, err := r.fallback.Render(newStableTail)
+	if err != nil {
+		return r.fullRender(input)
+	}
+	r.inputPrefix += newStableTail
+	r.outputPrefix = r.joinPrefixAndTail(r.outputPrefix, renderedStableTail)
+
+	rest := tail[boundary:]
+	if rest == "" {
+		return r.outputPrefix, nil
+	}
+	renderedRest, err := r.fallback.Render(rest)
+	if err != nil {
+		return r.fullRender(input)
+	}
+	return r.joinPrefixAndTail(r.outputPrefix, renderedRest), nil
+}
+
+// SetWidth updates the renderer width. Width changes invalidate the cache
+// because the rendered output is width-dependent.
+func (r *IncrementalRenderer) SetWidth(width int) {
+	if width == r.width {
+		return
+	}
+	r.width = width
+	r.fallback = NewFastRenderer(width)
+	r.inputPrefix = ""
+	r.outputPrefix = ""
+}
+
+// Reset drops the cached prefix without changing the width. Use when the
+// underlying message is replaced by an unrelated new one.
+func (r *IncrementalRenderer) Reset() {
+	r.inputPrefix = ""
+	r.outputPrefix = ""
+}
+
+// fullRender renders input from scratch, refreshes the cache, and returns the
+// result. To avoid rendering input twice (once whole, once for the cached
+// prefix), we split input at its longest stable boundary and render the two
+// pieces separately, then join. The two render calls on smaller inputs are
+// faster than one big render plus a separate prefix render, and the prefix
+// piece can be reused as outputPrefix.
+func (r *IncrementalRenderer) fullRender(input string) (string, error) {
+	boundary := stableBoundary(input)
+	if boundary <= 0 {
+		out, err := r.fallback.Render(input)
+		if err != nil {
+			return "", err
+		}
+		r.inputPrefix = ""
+		r.outputPrefix = ""
+		return out, nil
+	}
+
+	prefix := input[:boundary]
+	rest := input[boundary:]
+	renderedPrefix, err := r.fallback.Render(prefix)
+	if err != nil {
+		return "", err
+	}
+	if rest == "" {
+		r.inputPrefix = prefix
+		r.outputPrefix = renderedPrefix
+		return renderedPrefix, nil
+	}
+	renderedRest, err := r.fallback.Render(rest)
+	if err != nil {
+		return "", err
+	}
+	r.inputPrefix = prefix
+	r.outputPrefix = renderedPrefix
+	return r.joinPrefixAndTail(renderedPrefix, renderedRest), nil
+}
+
+// joinPrefixAndTail concatenates a previously rendered prefix and a freshly
+// rendered tail to form the equivalent of a single-shot render of
+// prefix-content + "\n\n" + tail-content.
+//
+// Two FastRenderer details drive the body of this function:
+//
+//  1. FastRenderer trims trailing newlines from its output, so each piece
+//     ends mid-line and we have to reintroduce a separator newline.
+//  2. FastRenderer's finalizeOutput pads every line (including blank ones) to
+//     `width` with spaces. The blank line we insert between the two pieces
+//     therefore needs the same padding to be byte-identical to a full render.
+//
+// If either of those FastRenderer behaviours changes in the future, the
+// IncrementalRendererMatchesFullRender* tests will fail and pinpoint this
+// function as the place to update.
+func (r *IncrementalRenderer) joinPrefixAndTail(prefix, tail string) string {
+	if prefix == "" {
+		return tail
+	}
+	if tail == "" {
+		return prefix
+	}
+	if r.width <= 0 {
+		return prefix + "\n\n" + tail
+	}
+	var b strings.Builder
+	b.Grow(len(prefix) + len(tail) + r.width + 2)
+	b.WriteString(prefix)
+	b.WriteByte('\n')
+	for range r.width {
+		b.WriteByte(' ')
+	}
+	b.WriteByte('\n')
+	b.WriteString(tail)
+	return b.String()
+}
+
+// stableBoundary returns the byte index just after the last "safe" block
+// boundary in input, or 0 if no safe boundary exists. A safe boundary is a
+// blank line that the FastRenderer treats as a hard break between top-level
+// blocks: it must lie outside any fenced code block AND the lines immediately
+// surrounding it must not be "blank-line tolerant" constructs (lists,
+// blockquotes) where the parser keeps absorbing lines across the blank.
+//
+// The returned index satisfies input[:boundary] ends with a newline and a
+// blank line, and input[boundary:] starts a fresh top-level block.
+func stableBoundary(input string) int {
+	if input == "" {
+		return 0
+	}
+
+	// classifyFenceLines and classifyListLikeLines emit one entry per logical
+	// line, including a final trailing line if input does not end with '\n'.
+	// They therefore have either len(lineEnds) or len(lineEnds)+1 entries; the
+	// loop below only indexes positions in [0, len(lineEnds)+1), which is
+	// always within bounds, but we still guard each access defensively to keep
+	// the function robust against future refactors of the helpers.
+	inFence := classifyFenceLines(input)
+	isListLike := classifyListLikeLines(input, inFence)
+
+	lineEnds := make([]int, 0, 64)
+	for i := range len(input) {
+		if input[i] == '\n' {
+			lineEnds = append(lineEnds, i)
+		}
+	}
+
+	// Walk newlines from the end backwards looking for a blank line (two
+	// consecutive '\n' bytes) that isn't inside a fence and whose neighbours
+	// are not list/blockquote lines (which would absorb the blank).
+	for k := len(lineEnds) - 1; k > 0; k-- {
+		i := lineEnds[k]
+		if input[i-1] != '\n' {
+			continue
+		}
+		if inFenceAt(inFence, k) {
+			continue
+		}
+		boundary := i + 1
+		if boundary >= len(input) {
+			continue
+		}
+		if inFenceAt(inFence, k+1) {
+			continue
+		}
+		if listLikeAt(isListLike, k-1) || listLikeAt(isListLike, k+1) {
+			continue
+		}
+		return boundary
+	}
+	return 0
+}
+
+func inFenceAt(inFence []bool, k int) bool {
+	return k >= 0 && k < len(inFence) && inFence[k]
+}
+
+func listLikeAt(isListLike []bool, k int) bool {
+	return k >= 0 && k < len(isListLike) && isListLike[k]
+}
+
+// classifyListLikeLines marks every line that looks like the start of a list
+// item, an ordered-list continuation, an indented continuation of a list
+// item, or a blockquote. The FastRenderer absorbs blank lines between such
+// lines into a single block, so they are not safe split points.
+func classifyListLikeLines(input string, inFence []bool) []bool {
+	var lines []bool
+	lineStart := 0
+	idx := 0
+	for i := 0; i <= len(input); i++ {
+		if i < len(input) && input[i] != '\n' {
+			continue
+		}
+		line := input[lineStart:i]
+		listLike := false
+		if idx < len(inFence) && !inFence[idx] {
+			trimmed := strings.TrimLeft(line, " \t")
+			switch {
+			case strings.HasPrefix(trimmed, ">"):
+				listLike = true
+			case isListStart(trimmed):
+				listLike = true
+			case line != "" && (line[0] == ' ' || line[0] == '\t'):
+				// Indented non-empty line: could be a list-item continuation. We
+				// can't be sure without the surrounding context, so treat it as
+				// list-like to stay on the safe side.
+				listLike = trimmed != ""
+			}
+		}
+		lines = append(lines, listLike)
+		lineStart = i + 1
+		idx++
+	}
+	return lines
+}
+
+// classifyFenceLines returns a slice indexed by line number where each entry
+// is true when that line lies inside a fenced code block. The opening and
+// closing fence lines themselves are marked true so a boundary cannot land
+// directly on them.
+func classifyFenceLines(input string) []bool {
+	var lines []bool
+	openFence := ""
+	lineStart := 0
+	for i := 0; i <= len(input); i++ {
+		if i < len(input) && input[i] != '\n' {
+			continue
+		}
+		line := input[lineStart:i]
+		trimmed := strings.TrimLeft(line, " \t")
+		switch {
+		case openFence != "":
+			lines = append(lines, true)
+			if strings.HasPrefix(strings.TrimSpace(trimmed), openFence) {
+				openFence = ""
+			}
+		case strings.HasPrefix(trimmed, "```"):
+			lines = append(lines, true)
+			openFence = "```"
+		case strings.HasPrefix(trimmed, "~~~"):
+			lines = append(lines, true)
+			openFence = "~~~"
+		default:
+			lines = append(lines, false)
+		}
+		lineStart = i + 1
+	}
+	return lines
+}

--- a/pkg/tui/components/markdown/incremental_test.go
+++ b/pkg/tui/components/markdown/incremental_test.go
@@ -1,0 +1,190 @@
+package markdown
+
+import (
+	_ "embed"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestIncrementalRendererMatchesFullRender feeds a representative streaming
+// document chunk by chunk through the incremental renderer and checks that the
+// final output matches a single full render. This is the correctness contract
+// the optimization must preserve.
+func TestIncrementalRendererMatchesFullRender(t *testing.T) {
+	t.Parallel()
+
+	chunks := splitIntoStreamingChunks(streamingBenchmarkContent)
+
+	full := NewFastRenderer(80)
+	expected, err := full.Render(streamingBenchmarkContent)
+	require.NoError(t, err)
+
+	inc := NewIncrementalRenderer(80)
+	var accumulated strings.Builder
+	var got string
+	for _, c := range chunks {
+		accumulated.WriteString(c)
+		got, err = inc.Render(accumulated.String())
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, expected, got, "incremental render diverged from full render")
+}
+
+// TestIncrementalRendererMatchesFullRenderForEachStep verifies that *every*
+// intermediate output matches what a full render would produce for the same
+// accumulated input. This catches per-chunk divergences (not just the final
+// output).
+func TestIncrementalRendererMatchesFullRenderForEachStep(t *testing.T) {
+	t.Parallel()
+
+	chunks := splitIntoStreamingChunks(streamingBenchmarkContent)
+
+	full := NewFastRenderer(80)
+	inc := NewIncrementalRenderer(80)
+	var accumulated strings.Builder
+	for i, c := range chunks {
+		accumulated.WriteString(c)
+		expected, err := full.Render(accumulated.String())
+		require.NoError(t, err)
+		got, err := inc.Render(accumulated.String())
+		require.NoError(t, err)
+		require.Equal(t, expected, got, "step %d (len=%d) diverged", i, accumulated.Len())
+	}
+}
+
+// TestIncrementalRendererCorrectnessForVariousInputs runs the same equivalence
+// check on a battery of small markdown samples that exercise different block
+// types and tricky boundaries.
+func TestIncrementalRendererCorrectnessForVariousInputs(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"empty", ""},
+		{"plain paragraph", "Hello there, this is a single paragraph."},
+		{"two paragraphs", "First paragraph.\n\nSecond paragraph."},
+		{"heading then paragraph", "# Title\n\nBody text follows."},
+		{
+			name:  "code fence then paragraph",
+			input: "Intro.\n\n```go\nfunc main() {}\n```\n\nOutro.",
+		},
+		{
+			name:  "open code fence at end",
+			input: "Intro.\n\n```go\nfunc main() {",
+		},
+		{
+			name:  "list followed by code",
+			input: "- one\n- two\n\n```\ncode\n```",
+		},
+		{
+			name:  "blank line inside fence",
+			input: "```\nline 1\n\nline 3\n```\n\nafter",
+		},
+		{
+			name:  "trailing blank line",
+			input: "Paragraph one.\n\n",
+		},
+		{
+			name:  "no trailing newline",
+			input: "First paragraph.\n\nSecond without trailing newline",
+		},
+		{
+			name:  "open fence no trailing newline",
+			input: "Intro.\n\n```go\nfunc main",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			full := NewFastRenderer(80)
+			expected, err := full.Render(tc.input)
+			require.NoError(t, err)
+
+			inc := NewIncrementalRenderer(80)
+			got, err := inc.Render(tc.input)
+			require.NoError(t, err)
+			require.Equal(t, expected, got)
+
+			// Also check chunked feeding (every byte) preserves correctness.
+			inc2 := NewIncrementalRenderer(80)
+			var acc strings.Builder
+			for i := range len(tc.input) {
+				acc.WriteByte(tc.input[i])
+				_, err := inc2.Render(acc.String())
+				require.NoError(t, err)
+			}
+			finalGot, err := inc2.Render(tc.input)
+			require.NoError(t, err)
+			require.Equal(t, expected, finalGot, "byte-by-byte streaming diverged from full render")
+		})
+	}
+}
+
+// TestIncrementalRendererHandlesWidthChanges checks that SetWidth invalidates
+// the cache and subsequent renders match the full-render output at the new
+// width.
+func TestIncrementalRendererHandlesWidthChanges(t *testing.T) {
+	t.Parallel()
+
+	const sample = "# Title\n\nA paragraph that should wrap nicely at narrow widths.\n\n- one\n- two"
+
+	inc := NewIncrementalRenderer(80)
+	_, err := inc.Render(sample)
+	require.NoError(t, err)
+
+	inc.SetWidth(40)
+	got, err := inc.Render(sample)
+	require.NoError(t, err)
+
+	full := NewFastRenderer(40)
+	expected, err := full.Render(sample)
+	require.NoError(t, err)
+
+	require.Equal(t, expected, got)
+}
+
+// TestIncrementalRendererHandlesContentReplacement verifies that an unrelated
+// new content (one that does not extend the cached prefix) triggers a full
+// render and produces the correct output.
+func TestIncrementalRendererHandlesContentReplacement(t *testing.T) {
+	t.Parallel()
+
+	inc := NewIncrementalRenderer(80)
+	_, err := inc.Render("Hello there.\n\nMore text.\n\n")
+	require.NoError(t, err)
+
+	const next = "# Different\n\nCompletely unrelated content."
+	got, err := inc.Render(next)
+	require.NoError(t, err)
+
+	full := NewFastRenderer(80)
+	expected, err := full.Render(next)
+	require.NoError(t, err)
+
+	require.Equal(t, expected, got)
+}
+
+// BenchmarkStreamingIncrementalRenderer measures the streaming workload using
+// the incremental renderer. Compare with BenchmarkStreamingFastRenderer (the
+// full-render baseline) to see the speedup.
+func BenchmarkStreamingIncrementalRenderer(b *testing.B) {
+	chunks := splitIntoStreamingChunks(streamingBenchmarkContent)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		inc := NewIncrementalRenderer(80)
+		var accumulated strings.Builder
+		for _, c := range chunks {
+			accumulated.WriteString(c)
+			_, _ = inc.Render(accumulated.String())
+		}
+	}
+}

--- a/pkg/tui/components/message/bench_test.go
+++ b/pkg/tui/components/message/bench_test.go
@@ -1,0 +1,116 @@
+package message
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/docker/docker-agent/pkg/tui/types"
+)
+
+// streamingMarkdownContent is a representative assistant reply: a few
+// paragraphs of prose, bullets, inline code and a fenced block. Long enough
+// that re-parsing it on every chunk is measurable.
+const streamingMarkdownContent = `# Streaming response
+
+This is a representative assistant reply that uses a mix of **bold**,
+*italic* and ` + "`inline code`" + ` so the markdown parser actually has to do
+some work. We also throw in a [link](https://example.com) and an autolink
+https://docker.com to exercise the URL detection paths.
+
+Here is a short list:
+
+- First bullet with some prose attached.
+- Second bullet with ` + "`code`" + ` inside.
+- Third bullet that mentions another https://example.org URL.
+
+And a fenced code block:
+
+` + "```go" + `
+package main
+
+import "fmt"
+
+func main() {
+    fmt.Println("hello, world")
+}
+` + "```" + `
+
+Another paragraph after the code block to make sure the parser does not
+short-circuit. We want this benchmark to reflect real assistant traffic.
+`
+
+// BenchmarkRenderRepeated measures the cost of calling Render twice in a row
+// on the same content (View() + Height() pattern). With the cache this should
+// be roughly half the cost of two uncached renders.
+func BenchmarkRenderRepeated(b *testing.B) {
+	msg := types.Agent(types.MessageTypeAssistant, "agent", streamingMarkdownContent)
+	mv := New(msg, nil)
+	mv.SetSize(100, 0)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_ = mv.Render(100)
+		_ = mv.Render(100)
+	}
+}
+
+// BenchmarkRenderRepeatedUncached is the baseline that bypasses the cache by
+// calling the unmemoized core. Comparing it with BenchmarkRenderRepeated shows
+// how much work the cache eliminates when View()/Height() pairs render the
+// same content.
+func BenchmarkRenderRepeatedUncached(b *testing.B) {
+	msg := types.Agent(types.MessageTypeAssistant, "agent", streamingMarkdownContent)
+	mv := New(msg, nil)
+	mv.SetSize(100, 0)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_ = mv.render(100)
+		_ = mv.render(100)
+	}
+}
+
+// BenchmarkStreamingChunks simulates a streaming reply where each new token
+// triggers a Render of the entire accumulated content. With chunkCount chunks
+// the work is O(N^2) in chunkCount because the markdown parse processes the
+// full prefix every time. The cache here only helps when the same content is
+// rendered twice (e.g. View() then Height()), which is the common case.
+func BenchmarkStreamingChunks(b *testing.B) {
+	msg := types.Agent(types.MessageTypeAssistant, "agent", "")
+	mv := New(msg, nil)
+	mv.SetSize(100, 0)
+
+	const chunkCount = 64
+	chunks := splitIntoChunks(streamingMarkdownContent, chunkCount)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		var accumulated strings.Builder
+		msg.Content = ""
+		mv.SetMessage(msg)
+		for _, c := range chunks {
+			accumulated.WriteString(c)
+			msg.Content = accumulated.String()
+			mv.SetMessage(msg)
+			// Each chunk typically triggers View() and (transitively) Height().
+			_ = mv.Render(100)
+			_ = mv.Render(100)
+		}
+	}
+}
+
+func splitIntoChunks(s string, n int) []string {
+	if n <= 0 {
+		return []string{s}
+	}
+	chunkSize := max(1, len(s)/n)
+	chunks := make([]string, 0, n)
+	for i := 0; i < len(s); i += chunkSize {
+		end := min(i+chunkSize, len(s))
+		chunks = append(chunks, s[i:end])
+	}
+	return chunks
+}

--- a/pkg/tui/components/message/message.go
+++ b/pkg/tui/components/message/message.go
@@ -34,6 +34,27 @@ type messageModel struct {
 	selected bool
 	hovered  bool
 	spinner  spinner.Spinner
+
+	// renderCache memoizes the output of Render(width) keyed by the inputs
+	// that affect its output. During streaming, View() and Height() are called
+	// in pairs for each new chunk, and the chat list also re-renders for hover
+	// tracking and scroll updates; without this cache each call would re-parse
+	// the entire accumulated markdown from scratch.
+	renderCache renderCache
+}
+
+// renderCache stores the most recent Render result keyed by the inputs that
+// can change its output. The key is small enough (a string and a few flags)
+// that comparing it is much cheaper than rendering markdown.
+type renderCache struct {
+	valid     bool
+	content   string
+	msgType   types.MessageType
+	width     int
+	selected  bool
+	hovered   bool
+	sameAgent bool
+	result    string
 }
 
 // New creates a new message view
@@ -60,14 +81,21 @@ func (mv *messageModel) Init() tea.Cmd {
 
 func (mv *messageModel) SetMessage(msg *types.Message) {
 	mv.message = msg
+	mv.renderCache.valid = false
 }
 
 func (mv *messageModel) SetSelected(selected bool) {
-	mv.selected = selected
+	if mv.selected != selected {
+		mv.selected = selected
+		mv.renderCache.valid = false
+	}
 }
 
 func (mv *messageModel) SetHovered(hovered bool) {
-	mv.hovered = hovered
+	if mv.hovered != hovered {
+		mv.hovered = hovered
+		mv.renderCache.valid = false
+	}
 }
 
 // Update handles messages and updates the message view state
@@ -85,8 +113,61 @@ func (mv *messageModel) View() string {
 	return mv.Render(mv.width)
 }
 
-// Render renders the message view content
+// Render renders the message view content. Results are memoized so repeated
+// calls with the same inputs (very common during streaming, hover tracking,
+// and from Height()) skip the expensive markdown parse.
 func (mv *messageModel) Render(width int) string {
+	msg := mv.message
+
+	// Spinner-driven types (MessageTypeSpinner, MessageTypeLoading, and an empty
+	// MessageTypeAssistant placeholder) animate on every tick, so the result is
+	// not cacheable. Everything else is a pure function of the inputs tracked in
+	// renderCache below.
+	cacheable := !mv.isSpinnerDriven()
+	if cacheable {
+		c := &mv.renderCache
+		if c.valid &&
+			c.width == width &&
+			c.msgType == msg.Type &&
+			c.selected == mv.selected &&
+			c.hovered == mv.hovered &&
+			c.content == msg.Content &&
+			c.sameAgent == mv.sameAgentAsPrevious(msg) {
+			return c.result
+		}
+	}
+
+	result := mv.render(width)
+
+	if cacheable {
+		mv.renderCache = renderCache{
+			valid:     true,
+			content:   msg.Content,
+			msgType:   msg.Type,
+			width:     width,
+			selected:  mv.selected,
+			hovered:   mv.hovered,
+			sameAgent: mv.sameAgentAsPrevious(msg),
+			result:    result,
+		}
+	}
+	return result
+}
+
+// isSpinnerDriven reports whether the rendered output animates on every tick
+// and therefore cannot be cached across renders.
+func (mv *messageModel) isSpinnerDriven() bool {
+	switch mv.message.Type {
+	case types.MessageTypeSpinner, types.MessageTypeLoading:
+		return true
+	case types.MessageTypeAssistant:
+		return mv.message.Content == ""
+	}
+	return false
+}
+
+// render is the uncached rendering core. Render() wraps it with memoization.
+func (mv *messageModel) render(width int) string {
 	msg := mv.message
 	switch msg.Type {
 	case types.MessageTypeSpinner:
@@ -215,7 +296,9 @@ func (mv *messageModel) sameAgentAsPrevious(msg *types.Message) bool {
 	}
 }
 
-// Height calculates the height needed for this message view
+// Height calculates the height needed for this message view. Render() is
+// memoized, so calling it from here does not duplicate work when View() is
+// invoked for the same inputs.
 func (mv *messageModel) Height(width int) int {
 	content := mv.Render(width)
 	return strings.Count(content, "\n") + 1
@@ -238,6 +321,9 @@ func (mv *messageModel) StopAnimation() {
 
 // SetSize sets the dimensions of the message view
 func (mv *messageModel) SetSize(width, height int) tea.Cmd {
+	if mv.width != width {
+		mv.renderCache.valid = false
+	}
 	mv.width = width
 	mv.height = height
 	return nil

--- a/pkg/tui/components/message/message.go
+++ b/pkg/tui/components/message/message.go
@@ -41,6 +41,11 @@ type messageModel struct {
 	// tracking and scroll updates; without this cache each call would re-parse
 	// the entire accumulated markdown from scratch.
 	renderCache renderCache
+
+	// mdRenderer is reused across renders of an assistant message so that
+	// streamed-in chunks only re-render the trailing block instead of the whole
+	// accumulated markdown each time.
+	mdRenderer *markdown.IncrementalRenderer
 }
 
 // renderCache stores the most recent Render result keyed by the inputs that
@@ -80,6 +85,14 @@ func (mv *messageModel) Init() tea.Cmd {
 }
 
 func (mv *messageModel) SetMessage(msg *types.Message) {
+	// If the new content is not an extension of the previous one (different
+	// message, or the message was edited), drop the IncrementalRenderer's
+	// cached prefix so its memory is released immediately rather than on the
+	// next render. The renderer detects mismatches on its own and falls back
+	// to a full render either way, so this is purely an optimization.
+	if mv.mdRenderer != nil && mv.message != nil && msg != nil && !strings.HasPrefix(msg.Content, mv.message.Content) {
+		mv.mdRenderer.Reset()
+	}
 	mv.message = msg
 	mv.renderCache.valid = false
 }
@@ -215,7 +228,8 @@ func (mv *messageModel) render(width int) string {
 			messageStyle = styles.SelectedMessageStyle
 		}
 
-		rendered, err := markdown.NewRenderer(width - messageStyle.GetHorizontalFrameSize()).Render(msg.Content)
+		innerRenderWidth := width - messageStyle.GetHorizontalFrameSize()
+		rendered, err := mv.renderAssistantMarkdown(msg.Content, innerRenderWidth)
 		if err != nil {
 			rendered = msg.Content
 		}
@@ -271,6 +285,19 @@ func (mv *messageModel) render(width int) string {
 	default:
 		return msg.Content
 	}
+}
+
+// renderAssistantMarkdown renders streamed assistant content using a per-message
+// IncrementalRenderer. The renderer remembers the last rendered stable prefix
+// so each new chunk only re-parses the trailing region. The first render at a
+// given width is equivalent to a fresh full render.
+func (mv *messageModel) renderAssistantMarkdown(content string, width int) (string, error) {
+	if mv.mdRenderer == nil {
+		mv.mdRenderer = markdown.NewIncrementalRenderer(width)
+	} else {
+		mv.mdRenderer.SetWidth(width)
+	}
+	return mv.mdRenderer.Render(content)
 }
 
 func (mv *messageModel) senderPrefix(sender string) string {


### PR DESCRIPTION
Three independent perf wins for the TUI streaming path. Each commit is self-contained, ships its own benchmark, and passes `task test` + `task lint`.

The shared theme: when the LLM streams a long message in many small chunks, we used to do quadratic work per chunk. Each commit removes one of those quadratic factors.

## 1. `perf(tui/message): cache Render output to avoid redundant markdown parses`

`messageModel.Render(width)` was called by both `View()` and `Height()` (and again by hover/scroll updates). Each call re-parsed the entire accumulated assistant message. Memoize the result against `(content, msgType, width, selected, hovered, sameAgent)`.

| | ns/op | B/op | allocs/op |
|---|---:|---:|---:|
| uncached | 555,272 | 419,392 | 9,956 |
| cached | **4.5** | **0** | **0** |

Cache invalidates correctly on content/state changes, so streaming still re-renders new chunks; only redundant calls are skipped.

## 2. `perf(app): use strings.Builder when merging streamed events`

`mergeEvents` coalesces consecutive same-kind streaming events (`AgentChoiceEvent`, `AgentChoiceReasoningEvent`, `PartialToolCallEvent`) per throttle window. The original code did `merged.Content = merged.Content + next.Content` inside the loop — O(N²) in the run length. Refactored each merge into a helper that scans ahead, sums lengths, and builds with a single pre-sized `strings.Builder`.

256-chunk merge group:
| | ns/op | B/op | allocs/op |
|---|---:|---:|---:|
| before | 173,834 | 1,595,323 | 511 |
| after | **2,239** | **17,248** | **3** |

Includes correctness tests covering same-agent merging, agent-boundary preservation, and tool-call argument-delta concatenation.

## 3. `perf(tui/markdown): incremental renderer for streaming chunks`

New `markdown.IncrementalRenderer` caches the rendered output up to the last "safe" block boundary — a blank line that lies outside any fenced code block and is not flanked by list/blockquote lines (constructs that absorb blank lines into a single block). On each subsequent call only the trailing tail is re-rendered. Wired into `messageModel` so streamed assistant replies benefit transparently.

8.5 KB streaming-benchmark document, fed in 3–5 byte chunks:
| | ns/op | B/op | allocs/op |
|---|---:|---:|---:|
| `BenchmarkStreamingFastRenderer` | 519,361,000 | 917,394,140 | 3,434,638 |
| `BenchmarkStreamingIncrementalRenderer` | **293,493,521** | **312,866,876** | **2,280,702** |

That's ~1.75× faster and ~3× less memory per pass through the document. Correctness is pinned by a per-step equivalence test (`TestIncrementalRendererMatchesFullRenderForEachStep`) that asserts every intermediate output matches what a single full render would produce, plus targeted cases for tricky inputs (open code fences, lists, no trailing newline, width changes, content replacement).

## Validation

- [x] `task test` — green
- [x] `task lint` — 0 issues
- [x] All three commits compile and pass tests independently
- [x] Benchmarks numbers above were re-measured on the rebased branch
