### PR TITLE
fix(tui): preserve user_prompt input across tab switches

### DIFF
--- a/pkg/tui/dialog/dialog.go
+++ b/pkg/tui/dialog/dialog.go
@@ -47,6 +47,12 @@ type Manager interface {
 	// background dialog, or nil if the top dialog is not a background dialog
 	// or the dialog stack is empty.
 	TopBackgroundEvent() tea.Msg
+	// TopDialog returns the topmost dialog instance, or nil if the dialog
+	// stack is empty. Used by the app model to stash a background dialog's
+	// live state when the user navigates away from the tab that opened it,
+	// so the same instance (with any in-progress input) can be re-opened on
+	// return.
+	TopDialog() Dialog
 }
 
 // dialogEntry pairs a dialog with its drag offset so the two stay in sync.
@@ -321,6 +327,15 @@ func (d *manager) TopBackgroundEvent() tea.Msg {
 		return nil
 	}
 	return d.stack[len(d.stack)-1].originatingEvent
+}
+
+// TopDialog returns the topmost dialog instance, or nil if the dialog stack
+// is empty.
+func (d *manager) TopDialog() Dialog {
+	if len(d.stack) == 0 {
+		return nil
+	}
+	return d.stack[len(d.stack)-1].dialog
 }
 
 func (d *manager) SetSize(width, height int) tea.Cmd {

--- a/pkg/tui/dialog/manager_test.go
+++ b/pkg/tui/dialog/manager_test.go
@@ -17,34 +17,41 @@ func TestManagerBackgroundDialog(t *testing.T) {
 	assert.False(t, mgr.Open(), "manager starts empty")
 	assert.False(t, mgr.TopIsBackground(), "empty manager has no background dialog")
 	assert.Nil(t, mgr.TopBackgroundEvent())
+	assert.Nil(t, mgr.TopDialog(), "empty manager has no top dialog")
 
 	// Open a regular (modal) dialog without an event.
+	modal := NewExitConfirmationDialog()
 	mgr.handleOpen(OpenDialogMsg{
-		Model: NewExitConfirmationDialog(),
+		Model: modal,
 	})
 	assert.True(t, mgr.Open())
 	assert.False(t, mgr.TopIsBackground(), "dialog opened without OriginatingEvent must NOT be background")
 	assert.Nil(t, mgr.TopBackgroundEvent())
+	assert.Same(t, modal, mgr.TopDialog(), "TopDialog returns the modal instance")
 
 	// Stack a background dialog (i.e. one carrying an originating event) on top.
 	type fakeEvent struct{ id int }
 	event := &fakeEvent{id: 42}
+	bg := NewElicitationDialog("Pick a value", nil, nil)
 	mgr.handleOpen(OpenDialogMsg{
-		Model:            NewElicitationDialog("Pick a value", nil, nil),
+		Model:            bg,
 		OriginatingEvent: event,
 	})
 	assert.True(t, mgr.TopIsBackground(), "dialog opened with OriginatingEvent IS background")
 	assert.Same(t, event, mgr.TopBackgroundEvent(), "TopBackgroundEvent returns the originating event")
+	assert.Same(t, bg, mgr.TopDialog(), "TopDialog returns the background instance")
 
 	// Closing the top reveals the modal dialog underneath.
 	mgr.handleClose()
 	assert.True(t, mgr.Open(), "manager still has the modal dialog underneath")
 	assert.False(t, mgr.TopIsBackground(), "underneath is the modal dialog, not background")
 	assert.Nil(t, mgr.TopBackgroundEvent())
+	assert.Same(t, modal, mgr.TopDialog())
 
 	// Closing again empties the stack.
 	mgr.handleClose()
 	assert.False(t, mgr.Open())
 	assert.False(t, mgr.TopIsBackground())
 	assert.Nil(t, mgr.TopBackgroundEvent())
+	assert.Nil(t, mgr.TopDialog())
 }

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -161,6 +161,17 @@ type appModel struct {
 	// restored tab (in handleSwitchTab) and then removed from the map.
 	pendingSidebarCollapsed map[string]bool
 
+	// stashedDialogs holds background dialog instances that were on screen
+	// when the user navigated away from a tab. The dialog instance preserves
+	// in-progress input (e.g. text typed into a user_prompt elicitation) so
+	// that returning to the tab restores the same dialog rather than
+	// rebuilding a fresh one from the originating runtime event.
+	//
+	// The stored event is matched against the supervisor's pending event on
+	// return: if they no longer match (because the agent superseded the
+	// prompt) the stashed dialog is discarded and a fresh one is built.
+	stashedDialogs map[string]stashedDialog
+
 	// pendingActiveTab is the tab ID to switch to on Init(). Set when the
 	// previously focused tab differs from the initial tab.
 	pendingActiveTab string
@@ -287,6 +298,7 @@ func New(ctx context.Context, spawner SessionSpawner, initialApp *app.App, initi
 		history:                 historyStore,
 		pendingRestores:         make(map[string]string),
 		pendingSidebarCollapsed: make(map[string]bool),
+		stashedDialogs:          make(map[string]stashedDialog),
 		notification:            notification.New(),
 		dialogMgr:               dialog.New(),
 		completions:             completion.New(),
@@ -1249,21 +1261,39 @@ func (m *appModel) openWorkingDirPicker() (tea.Model, tea.Cmd) {
 	})
 }
 
+// stashedDialog holds a background dialog instance that was on screen when
+// the user navigated away from a tab, paired with the runtime event that
+// caused it to open. The event is used as an identity check on return: if
+// the supervisor's pending event for the tab no longer matches, the agent
+// has superseded the prompt and we discard the stash in favour of building
+// a fresh dialog from the new event.
+type stashedDialog struct {
+	dialog dialog.Dialog
+	event  tea.Msg
+}
+
 // handleSwitchTab switches to a different session.
 // Existing chat pages and editors are preserved (not recreated) so that in-flight streaming
 // content and draft text are retained when switching back to a tab.
 func (m *appModel) handleSwitchTab(sessionID string) (tea.Model, tea.Cmd) {
 	// If a background dialog (e.g. pending elicitation) is open on the
-	// outgoing tab, capture its originating event and the outgoing tab ID
-	// before the supervisor flips activeID. We only commit the re-stash
-	// after SwitchTo succeeds — otherwise a failed switch would leave the
-	// supervisor with a stale pending event and the dialog still on screen.
+	// outgoing tab, capture both its originating event and the live dialog
+	// instance before the supervisor flips activeID. We only commit the
+	// re-stash after SwitchTo succeeds — otherwise a failed switch would
+	// leave the supervisor with a stale pending event and the dialog still
+	// on screen.
+	//
+	// Stashing the dialog instance (rather than rebuilding it from the event
+	// on return) preserves any in-progress input the user typed — e.g. text
+	// already entered into a user_prompt elicitation. See issue #2770.
 	var (
-		backgroundEvent tea.Msg
-		outgoingTabID   string
+		backgroundEvent  tea.Msg
+		backgroundDialog dialog.Dialog
+		outgoingTabID    string
 	)
 	if m.dialogMgr.Open() && m.dialogMgr.TopIsBackground() {
 		backgroundEvent = m.dialogMgr.TopBackgroundEvent()
+		backgroundDialog = m.dialogMgr.TopDialog()
 		outgoingTabID = m.supervisor.ActiveID()
 	}
 
@@ -1276,6 +1306,12 @@ func (m *appModel) handleSwitchTab(sessionID string) (tea.Model, tea.Cmd) {
 	var closeBackgroundDialogCmd tea.Cmd
 	if backgroundEvent != nil && outgoingTabID != "" && outgoingTabID != sessionID {
 		m.supervisor.SetPendingEvent(outgoingTabID, backgroundEvent)
+		if backgroundDialog != nil {
+			m.stashedDialogs[outgoingTabID] = stashedDialog{
+				dialog: backgroundDialog,
+				event:  backgroundEvent,
+			}
+		}
 		closeBackgroundDialogCmd = core.CmdHandler(dialog.CloseDialogMsg{})
 	}
 
@@ -1372,15 +1408,36 @@ func (m *appModel) applySidebarCollapsed(sessionID string) tea.Cmd {
 // max iterations, elicitation) that was received while the tab was inactive.
 // If found, it opens the appropriate dialog. The event was already processed by the chat page
 // (updating the message list), but the dialog command was discarded for inactive sessions.
+//
+// If a stashed dialog instance is available for this session and its
+// associated event still matches the pending one, the same instance is
+// re-opened so any in-progress input survives the round trip (issue #2770).
+// Otherwise the stash is discarded and a fresh dialog is built.
 func (m *appModel) replayPendingEvent(sessionID string) tea.Cmd {
 	pendingEvent := m.supervisor.ConsumePendingEvent(sessionID)
 	if pendingEvent == nil {
+		// No pending event: any stash is stale (e.g. the agent finished).
+		delete(m.stashedDialogs, sessionID)
 		return nil
 	}
 
 	sessionState, ok := m.sessionStates[sessionID]
 	if !ok {
+		delete(m.stashedDialogs, sessionID)
 		return nil
+	}
+
+	// If we stashed the live dialog instance when leaving this tab and the
+	// pending event hasn't changed, re-open the same instance so the user's
+	// in-progress input is preserved.
+	if stash, ok := m.stashedDialogs[sessionID]; ok {
+		delete(m.stashedDialogs, sessionID)
+		if stash.event == pendingEvent && stash.dialog != nil {
+			return core.CmdHandler(dialog.OpenDialogMsg{
+				Model:            stash.dialog,
+				OriginatingEvent: pendingEvent,
+			})
+		}
 	}
 
 	switch ev := pendingEvent.(type) {
@@ -1475,6 +1532,7 @@ func (m *appModel) handleCloseTab(sessionID string) (tea.Model, tea.Cmd) {
 	delete(m.sessionStates, sessionID)
 	delete(m.pendingRestores, sessionID)
 	delete(m.pendingSidebarCollapsed, sessionID)
+	delete(m.stashedDialogs, sessionID)
 
 	var cmds []tea.Cmd
 	// Remove from persistent store using the persisted session-store ID.

--- a/pkg/tui/tui_exit_test.go
+++ b/pkg/tui/tui_exit_test.go
@@ -136,6 +136,7 @@ func newTestModel() (*appModel, *mockEditor) {
 		editors:                 map[string]editor.Editor{"test": ed},
 		pendingRestores:         map[string]string{},
 		pendingSidebarCollapsed: map[string]bool{},
+		stashedDialogs:          map[string]stashedDialog{},
 		chatPage:                page,
 		editor:                  ed,
 		transcriber:             &fakeTranscriber{},

--- a/pkg/tui/tui_stash_dialog_test.go
+++ b/pkg/tui/tui_stash_dialog_test.go
@@ -1,0 +1,172 @@
+package tui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/tui/core/layout"
+	"github.com/docker/docker-agent/pkg/tui/dialog"
+	"github.com/docker/docker-agent/pkg/tui/service"
+	"github.com/docker/docker-agent/pkg/tui/service/supervisor"
+)
+
+// stubDialog is a minimal dialog.Dialog that records when its size is set.
+// We rely on the fact that the dialog.Manager calls SetSize on opening so
+// that re-using the same instance is observable from the layer count.
+type stubDialog struct {
+	dialog.BaseDialog
+
+	id string
+}
+
+func (s *stubDialog) Init() tea.Cmd { return nil }
+func (s *stubDialog) Update(tea.Msg) (layout.Model, tea.Cmd) {
+	return s, nil
+}
+func (s *stubDialog) View() string             { return "stub:" + s.id }
+func (s *stubDialog) SetSize(w, h int) tea.Cmd { return s.BaseDialog.SetSize(w, h) }
+func (s *stubDialog) Position() (row, col int) { return 0, 0 }
+
+// TestReplayPendingEvent_RestoresStashedDialog verifies that when the user
+// switches back to a tab whose background dialog was on screen, the *same*
+// dialog instance is re-opened (not a freshly built one). This guards
+// against the regression in #2770 where typed-but-not-submitted user_prompt
+// answers were lost on tab switch.
+func TestReplayPendingEvent_RestoresStashedDialog(t *testing.T) {
+	t.Parallel()
+
+	const sessionID = "session-A"
+
+	// Build a model with a single-session supervisor so ConsumePendingEvent
+	// has a real runner to read from.
+	m, _ := newTestModel()
+	m.supervisor = supervisor.New(nil)
+	require.NotEmpty(t, m.supervisor.AddSession(
+		t.Context(),
+		nil,
+		&session.Session{ID: sessionID},
+		"/tmp",
+		nil,
+	))
+	m.sessionStates[sessionID] = service.NewSessionState(&session.Session{ID: sessionID})
+
+	// Simulate the pre-conditions of a tab-switch-while-dialog-open:
+	//   - the supervisor has a pending event for this tab
+	//   - the appModel has stashed the live dialog instance keyed by tab.
+	event := &runtime.ElicitationRequestEvent{Message: "ask the user"}
+	m.supervisor.SetPendingEvent(sessionID, event)
+
+	stashed := &stubDialog{id: "stashed"}
+	m.stashedDialogs[sessionID] = stashedDialog{
+		dialog: stashed,
+		event:  event,
+	}
+
+	cmd := m.replayPendingEvent(sessionID)
+	require.NotNil(t, cmd, "replayPendingEvent must return an Open command")
+
+	msg := cmd()
+	openMsg, ok := msg.(dialog.OpenDialogMsg)
+	require.True(t, ok, "expected dialog.OpenDialogMsg, got %T", msg)
+
+	// The crucial property: the SAME dialog instance is re-used so any
+	// in-progress input survives the round trip.
+	assert.Same(t, stashed, openMsg.Model,
+		"stashed dialog instance must be re-opened to preserve in-progress input")
+	assert.Same(t, event, openMsg.OriginatingEvent,
+		"the open command must carry the matching originating event")
+
+	// Stash entry is consumed exactly once.
+	_, stillStashed := m.stashedDialogs[sessionID]
+	assert.False(t, stillStashed, "stash entry must be removed after consumption")
+}
+
+// TestReplayPendingEvent_DiscardsStaleStash covers the case where the agent
+// superseded the original prompt while the user was on a different tab. The
+// stashed dialog no longer matches the new pending event, so it must be
+// discarded and a fresh dialog built from the current event.
+func TestReplayPendingEvent_DiscardsStaleStash(t *testing.T) {
+	t.Parallel()
+
+	const sessionID = "session-A"
+
+	m, _ := newTestModel()
+	m.supervisor = supervisor.New(nil)
+	m.supervisor.AddSession(
+		t.Context(),
+		nil,
+		&session.Session{ID: sessionID},
+		"/tmp",
+		nil,
+	)
+	m.sessionStates[sessionID] = service.NewSessionState(&session.Session{ID: sessionID})
+
+	// Original event the user was answering when they left the tab.
+	originalEvent := &runtime.ElicitationRequestEvent{Message: "first prompt"}
+	stashed := &stubDialog{id: "stashed"}
+	m.stashedDialogs[sessionID] = stashedDialog{
+		dialog: stashed,
+		event:  originalEvent,
+	}
+
+	// While the user was away the agent superseded the prompt with a new
+	// elicitation. The supervisor's pending event no longer matches the
+	// stashed one.
+	newEvent := &runtime.ElicitationRequestEvent{Message: "replacement prompt"}
+	m.supervisor.SetPendingEvent(sessionID, newEvent)
+
+	cmd := m.replayPendingEvent(sessionID)
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	openMsg, ok := msg.(dialog.OpenDialogMsg)
+	require.True(t, ok)
+
+	// A fresh dialog is built — it must NOT be the stale stashed instance.
+	assert.NotSame(t, stashed, openMsg.Model,
+		"stale stash must be discarded; a fresh dialog must be built")
+	assert.Same(t, newEvent, openMsg.OriginatingEvent,
+		"the open command must carry the *new* event")
+
+	// The stale stash must not linger after this call.
+	_, stillStashed := m.stashedDialogs[sessionID]
+	assert.False(t, stillStashed, "stale stash entry must be removed")
+}
+
+// TestReplayPendingEvent_NoPendingEvent_ClearsStash verifies that when a tab
+// has no pending event (e.g. the agent finished while the user was away on
+// another tab), any leftover stash is cleared so a stale dialog isn't
+// re-opened on a future switch.
+func TestReplayPendingEvent_NoPendingEvent_ClearsStash(t *testing.T) {
+	t.Parallel()
+
+	const sessionID = "session-A"
+
+	m, _ := newTestModel()
+	m.supervisor = supervisor.New(nil)
+	m.supervisor.AddSession(
+		t.Context(),
+		nil,
+		&session.Session{ID: sessionID},
+		"/tmp",
+		nil,
+	)
+	m.sessionStates[sessionID] = service.NewSessionState(&session.Session{ID: sessionID})
+
+	// Stash exists but the supervisor has no pending event (e.g. the stream
+	// stopped while the user was on another tab).
+	m.stashedDialogs[sessionID] = stashedDialog{
+		dialog: &stubDialog{id: "orphan"},
+		event:  &runtime.ElicitationRequestEvent{Message: "obsolete"},
+	}
+
+	cmd := m.replayPendingEvent(sessionID)
+	assert.Nil(t, cmd, "no pending event ⇒ no command to run")
+	_, stillStashed := m.stashedDialogs[sessionID]
+	assert.False(t, stillStashed, "orphaned stash must be cleared")
+}


### PR DESCRIPTION
Closes #2770.

When the user switched tabs while a background `user_prompt` (MCP elicitation) dialog was open, `handleSwitchTab` re-stashed only the originating runtime event in the supervisor and closed the dialog. On return, `replayPendingEvent` built a brand-new dialog from that event — discarding any text the user had typed.

This change stashes the live dialog instance (along with its event) per-tab when leaving, and re-opens the same instance on return so its in-progress input survives the round trip. If the agent supersedes the prompt while the user is away, the stale stash is discarded and a fresh dialog is built from the new event.

## Changes

- `pkg/tui/dialog/dialog.go` — add `Manager.TopDialog()` accessor.
- `pkg/tui/tui.go` — add `appModel.stashedDialogs` map + `stashedDialog` type; capture the dialog instance in `handleSwitchTab`; reuse it in `replayPendingEvent` when the event still matches; clear it in `handleCloseTab` and on stale/empty pending events.
- `pkg/tui/tui_stash_dialog_test.go` — three regression tests covering: stashed dialog reopened on match, stale stash discarded after supersession, orphaned stash cleared when no event is pending.
- `pkg/tui/dialog/manager_test.go` and `pkg/tui/tui_exit_test.go` — extend existing tests to cover the new accessor and map.