### PR TITLE
feat(tui): add per-code-block copy affordance

### DIFF
--- a/pkg/tui/components/markdown/codeblock.go
+++ b/pkg/tui/components/markdown/codeblock.go
@@ -1,0 +1,18 @@
+package markdown
+
+// CodeBlockCopyLabel is the unicode glyph rendered at the top-right corner of
+// every fenced code block. Clicking on it copies the block's raw content to
+// the clipboard. It matches the glyph used for the message-level copy
+// affordance so the visual language stays consistent; the two are
+// disambiguated by line index, not by glyph.
+const CodeBlockCopyLabel = "\u2398"
+
+// CodeBlock describes a fenced code block emitted by the renderer.
+//
+// Line is the 0-indexed line, within the renderer's output, where the copy
+// label is rendered on the code block's top padding row. Content holds the
+// raw code (without ANSI styling) so callers can place it on the clipboard.
+type CodeBlock struct {
+	Content string
+	Line    int
+}

--- a/pkg/tui/components/markdown/codeblock.go
+++ b/pkg/tui/components/markdown/codeblock.go
@@ -1,16 +1,16 @@
 package markdown
 
-// CodeBlockCopyLabel is the unicode glyph rendered at the top-right corner of
+// CodeBlockCopyIcon is the unicode glyph rendered at the top-right corner of
 // every fenced code block. Clicking on it copies the block's raw content to
 // the clipboard. It matches the glyph used for the message-level copy
 // affordance so the visual language stays consistent; the two are
 // disambiguated by line index, not by glyph.
-const CodeBlockCopyLabel = "\u2398"
+const CodeBlockCopyIcon = "\u2398"
 
 // CodeBlock describes a fenced code block emitted by the renderer.
 //
 // Line is the 0-indexed line, within the renderer's output, where the copy
-// label is rendered on the code block's top padding row. Content holds the
+// icon is rendered on the code block's top padding row. Content holds the
 // raw code (without ANSI styling) so callers can place it on the clipboard.
 type CodeBlock struct {
 	Content string

--- a/pkg/tui/components/markdown/fast_renderer.go
+++ b/pkg/tui/components/markdown/fast_renderer.go
@@ -117,18 +117,19 @@ type cachedStyles struct {
 	styleCodeBg lipgloss.Style // kept only because chroma styles inherit its bg color
 
 	// ANSI styles (for fast inline rendering)
-	ansiBold       ansiStyle
-	ansiItalic     ansiStyle
-	ansiBoldItal   ansiStyle
-	ansiStrike     ansiStyle
-	ansiCode       ansiStyle
-	ansiLink       ansiStyle
-	ansiLinkText   ansiStyle
-	ansiText       ansiStyle    // base document text style
-	ansiHeadings   [6]ansiStyle // heading styles for inline restoration
-	ansiBlockquote ansiStyle    // blockquote style for inline restoration
-	ansiFootnote   ansiStyle    // footnote reference style
-	ansiCodeBg     ansiStyle    // code block background (cached to avoid repeated buildAnsiStyle)
+	ansiBold        ansiStyle
+	ansiItalic      ansiStyle
+	ansiBoldItal    ansiStyle
+	ansiStrike      ansiStyle
+	ansiCode        ansiStyle
+	ansiLink        ansiStyle
+	ansiLinkText    ansiStyle
+	ansiText        ansiStyle    // base document text style
+	ansiHeadings    [6]ansiStyle // heading styles for inline restoration
+	ansiBlockquote  ansiStyle    // blockquote style for inline restoration
+	ansiFootnote    ansiStyle    // footnote reference style
+	ansiCodeBg      ansiStyle    // code block background (cached to avoid repeated buildAnsiStyle)
+	ansiCodeBgMuted ansiStyle    // muted foreground on code block background (for code-block chrome like copy label)
 
 	// Pre-rendered chrome (computed once, reused across renders)
 	headingPrefixes         [6]string // raw prefix strings (e.g. "## ") for width math
@@ -242,6 +243,7 @@ func getGlobalStyles() *cachedStyles {
 			ansiBlockquote:          buildAnsiStyle(blockquoteLipStyle),
 			ansiFootnote:            buildAnsiStyle(lipgloss.NewStyle().Foreground(styles.TextSecondary).Italic(true)),
 			ansiCodeBg:              buildAnsiStyle(codeBg),
+			ansiCodeBgMuted:         buildAnsiStyle(codeBg.Foreground(styles.TextMutedGray)),
 			headingPrefixes:         headingPrefixes,
 			styledHeadingPrefixes:   styledPrefixes,
 			styledHeadingContIndent: styledContIndents,
@@ -278,8 +280,17 @@ var parserPool = sync.Pool{
 
 // Render parses and renders markdown content to styled terminal output.
 func (r *FastRenderer) Render(input string) (string, error) {
+	out, _, err := r.RenderWithCodeBlocks(input)
+	return out, err
+}
+
+// RenderWithCodeBlocks renders markdown content and returns both the styled
+// terminal output and the list of fenced code blocks emitted, in document
+// order. Each entry's Line points at the rendered line that carries the
+// clickable copy label for that block.
+func (r *FastRenderer) RenderWithCodeBlocks(input string) (string, []CodeBlock, error) {
 	if input == "" {
-		return "", nil
+		return "", nil, nil
 	}
 
 	input = sanitizeForTerminal(input)
@@ -287,18 +298,24 @@ func (r *FastRenderer) Render(input string) (string, error) {
 	p := parserPool.Get().(*parser)
 	p.reset(input, r.width)
 	result := p.parse()
+	var blocks []CodeBlock
+	if len(p.codeBlocks) > 0 {
+		blocks = make([]CodeBlock, len(p.codeBlocks))
+		copy(blocks, p.codeBlocks)
+	}
 	parserPool.Put(p)
-	return finalizeOutput(result, r.width), nil
+	return finalizeOutput(result, r.width), blocks, nil
 }
 
 // parser holds the state for parsing markdown.
 type parser struct {
-	input   string
-	width   int
-	styles  *cachedStyles
-	out     strings.Builder
-	lines   []string
-	lineIdx int
+	input      string
+	width      int
+	styles     *cachedStyles
+	out        strings.Builder
+	lines      []string
+	lineIdx    int
+	codeBlocks []CodeBlock
 }
 
 func (p *parser) reset(input string, width int) {
@@ -311,6 +328,7 @@ func (p *parser) reset(input string, width int) {
 		p.lines = append(p.lines, line)
 	}
 	p.lineIdx = 0
+	p.codeBlocks = p.codeBlocks[:0]
 	p.out.Reset()
 	p.out.Grow(len(input) * 2) // Pre-allocate for styled output
 }
@@ -1913,10 +1931,25 @@ func (p *parser) renderCodeBlockWithIndent(code, lang, indent string, availableW
 	// Use cached background style
 	bgStyle := p.styles.ansiCodeBg
 
-	// Render empty line at the top (use sequential writes instead of concat)
+	// Render empty line at the top with a copy affordance pushed to the right
+	// edge. Record the rendered line index so click handlers can map a click
+	// back to this block's raw content.
+	topLine := strings.Count(p.out.String(), "\n")
 	p.out.WriteString(indent)
-	bgStyle.renderTo(&p.out, fullWidthPad)
+	labelWidth := runewidth.StringWidth(CodeBlockCopyLabel)
+	leftFill := max(availableWidth-paddingRight-labelWidth, 0)
+	if availableWidth >= labelWidth+paddingRight {
+		bgStyle.renderTo(&p.out, spaces(leftFill))
+		p.styles.ansiCodeBgMuted.renderTo(&p.out, CodeBlockCopyLabel)
+		if paddingRight > 0 {
+			bgStyle.renderTo(&p.out, spaces(paddingRight))
+		}
+	} else {
+		// Too narrow for the label; fall back to a plain top padding row.
+		bgStyle.renderTo(&p.out, fullWidthPad)
+	}
 	p.out.WriteByte('\n')
+	p.codeBlocks = append(p.codeBlocks, CodeBlock{Content: code, Line: topLine})
 
 	// Process tokens line by line for better performance
 	var lineBuilder strings.Builder

--- a/pkg/tui/components/markdown/fast_renderer.go
+++ b/pkg/tui/components/markdown/fast_renderer.go
@@ -117,19 +117,19 @@ type cachedStyles struct {
 	styleCodeBg lipgloss.Style // kept only because chroma styles inherit its bg color
 
 	// ANSI styles (for fast inline rendering)
-	ansiBold        ansiStyle
-	ansiItalic      ansiStyle
-	ansiBoldItal    ansiStyle
-	ansiStrike      ansiStyle
-	ansiCode        ansiStyle
-	ansiLink        ansiStyle
-	ansiLinkText    ansiStyle
-	ansiText        ansiStyle    // base document text style
-	ansiHeadings    [6]ansiStyle // heading styles for inline restoration
-	ansiBlockquote  ansiStyle    // blockquote style for inline restoration
-	ansiFootnote    ansiStyle    // footnote reference style
-	ansiCodeBg      ansiStyle    // code block background (cached to avoid repeated buildAnsiStyle)
-	ansiCodeBgMuted ansiStyle    // muted foreground on code block background (for code-block chrome like copy label)
+	ansiBold              ansiStyle
+	ansiItalic            ansiStyle
+	ansiBoldItal          ansiStyle
+	ansiStrike            ansiStyle
+	ansiCode              ansiStyle
+	ansiLink              ansiStyle
+	ansiLinkText          ansiStyle
+	ansiText              ansiStyle    // base document text style
+	ansiHeadings          [6]ansiStyle // heading styles for inline restoration
+	ansiBlockquote        ansiStyle    // blockquote style for inline restoration
+	ansiFootnote          ansiStyle    // footnote reference style
+	ansiCodeBg            ansiStyle    // code block background (cached to avoid repeated buildAnsiStyle)
+	ansiCodeBlockCopyIcon ansiStyle    // muted foreground on code block background, used for the per-block copy icon
 
 	// Pre-rendered chrome (computed once, reused across renders)
 	headingPrefixes         [6]string // raw prefix strings (e.g. "## ") for width math
@@ -243,7 +243,7 @@ func getGlobalStyles() *cachedStyles {
 			ansiBlockquote:          buildAnsiStyle(blockquoteLipStyle),
 			ansiFootnote:            buildAnsiStyle(lipgloss.NewStyle().Foreground(styles.TextSecondary).Italic(true)),
 			ansiCodeBg:              buildAnsiStyle(codeBg),
-			ansiCodeBgMuted:         buildAnsiStyle(codeBg.Foreground(styles.TextMutedGray)),
+			ansiCodeBlockCopyIcon:   buildAnsiStyle(codeBg.Foreground(styles.TextMutedGray)),
 			headingPrefixes:         headingPrefixes,
 			styledHeadingPrefixes:   styledPrefixes,
 			styledHeadingContIndent: styledContIndents,
@@ -1936,16 +1936,16 @@ func (p *parser) renderCodeBlockWithIndent(code, lang, indent string, availableW
 	// back to this block's raw content.
 	topLine := strings.Count(p.out.String(), "\n")
 	p.out.WriteString(indent)
-	labelWidth := runewidth.StringWidth(CodeBlockCopyLabel)
-	leftFill := max(availableWidth-paddingRight-labelWidth, 0)
-	if availableWidth >= labelWidth+paddingRight {
+	iconWidth := runewidth.StringWidth(CodeBlockCopyIcon)
+	leftFill := max(availableWidth-paddingRight-iconWidth, 0)
+	if availableWidth >= iconWidth+paddingRight {
 		bgStyle.renderTo(&p.out, spaces(leftFill))
-		p.styles.ansiCodeBgMuted.renderTo(&p.out, CodeBlockCopyLabel)
+		p.styles.ansiCodeBlockCopyIcon.renderTo(&p.out, CodeBlockCopyIcon)
 		if paddingRight > 0 {
 			bgStyle.renderTo(&p.out, spaces(paddingRight))
 		}
 	} else {
-		// Too narrow for the label; fall back to a plain top padding row.
+		// Too narrow for the icon; fall back to a plain top padding row.
 		bgStyle.renderTo(&p.out, fullWidthPad)
 	}
 	p.out.WriteByte('\n')

--- a/pkg/tui/components/markdown/fast_renderer_test.go
+++ b/pkg/tui/components/markdown/fast_renderer_test.go
@@ -2045,7 +2045,7 @@ func TestFastRendererCodeBlocksReturnsRawContent(t *testing.T) {
 	lines := strings.Split(out, "\n")
 	for _, b := range blocks {
 		require.Less(t, b.Line, len(lines), "code block line index out of range")
-		assert.Contains(t, stripANSI(lines[b.Line]), CodeBlockCopyLabel,
+		assert.Contains(t, stripANSI(lines[b.Line]), CodeBlockCopyIcon,
 			"line %d should contain the code block copy label", b.Line)
 	}
 
@@ -2076,6 +2076,6 @@ func TestIncrementalRendererCodeBlocksAggregate(t *testing.T) {
 	lines := strings.Split(out, "\n")
 	for _, b := range blocks2 {
 		require.Less(t, b.Line, len(lines))
-		assert.Contains(t, stripANSI(lines[b.Line]), CodeBlockCopyLabel)
+		assert.Contains(t, stripANSI(lines[b.Line]), CodeBlockCopyIcon)
 	}
 }

--- a/pkg/tui/components/markdown/fast_renderer_test.go
+++ b/pkg/tui/components/markdown/fast_renderer_test.go
@@ -2028,3 +2028,54 @@ func BenchmarkStreamingGlamourRenderer(b *testing.B) {
 		}
 	}
 }
+
+func TestFastRendererCodeBlocksReturnsRawContent(t *testing.T) {
+	t.Parallel()
+
+	input := "Some intro.\n\n```go\npackage main\n\nfunc main() {}\n```\n\nMid.\n\n```\nhello\nworld\n```\n"
+	r := NewFastRenderer(80)
+	out, blocks, err := r.RenderWithCodeBlocks(input)
+	require.NoError(t, err)
+
+	require.Len(t, blocks, 2)
+	assert.Equal(t, "package main\n\nfunc main() {}", blocks[0].Content)
+	assert.Equal(t, "hello\nworld", blocks[1].Content)
+
+	// Each block's recorded line must contain the copy-affordance glyph.
+	lines := strings.Split(out, "\n")
+	for _, b := range blocks {
+		require.Less(t, b.Line, len(lines), "code block line index out of range")
+		assert.Contains(t, stripANSI(lines[b.Line]), CodeBlockCopyLabel,
+			"line %d should contain the code block copy label", b.Line)
+	}
+
+	// The two code blocks must land on different lines.
+	assert.NotEqual(t, blocks[0].Line, blocks[1].Line)
+}
+
+func TestIncrementalRendererCodeBlocksAggregate(t *testing.T) {
+	t.Parallel()
+
+	// Render in two streamed chunks; the second extends the first.
+	chunk1 := "Intro paragraph.\n\n```go\nfunc a() {}\n```\n\n"
+	chunk2 := chunk1 + "Middle.\n\n```\nplain\ncode\n```\n"
+
+	r := NewIncrementalRenderer(80)
+	_, blocks1, err := r.RenderWithCodeBlocks(chunk1)
+	require.NoError(t, err)
+	require.Len(t, blocks1, 1)
+	assert.Equal(t, "func a() {}", blocks1[0].Content)
+
+	out, blocks2, err := r.RenderWithCodeBlocks(chunk2)
+	require.NoError(t, err)
+	require.Len(t, blocks2, 2)
+	assert.Equal(t, "func a() {}", blocks2[0].Content)
+	assert.Equal(t, "plain\ncode", blocks2[1].Content)
+
+	// Each block's reported line must carry the copy label in the final output.
+	lines := strings.Split(out, "\n")
+	for _, b := range blocks2 {
+		require.Less(t, b.Line, len(lines))
+		assert.Contains(t, stripANSI(lines[b.Line]), CodeBlockCopyLabel)
+	}
+}

--- a/pkg/tui/components/markdown/incremental.go
+++ b/pkg/tui/components/markdown/incremental.go
@@ -30,6 +30,10 @@ type IncrementalRenderer struct {
 	inputPrefix  string
 	outputPrefix string
 
+	// codeBlocksPrefix is the list of code blocks emitted while rendering the
+	// cached prefix, with Line indices relative to outputPrefix.
+	codeBlocksPrefix []CodeBlock
+
 	// fallback is used for the actual rendering work; it is reused across calls
 	// so its parser pool (and chroma caches) stay warm.
 	fallback *FastRenderer
@@ -48,10 +52,20 @@ func NewIncrementalRenderer(width int) *IncrementalRenderer {
 // inputs that share a long common prefix (the streaming case), only the suffix
 // is parsed and rendered; the rest is served from the cached output.
 func (r *IncrementalRenderer) Render(input string) (string, error) {
+	out, _, err := r.RenderWithCodeBlocks(input)
+	return out, err
+}
+
+// RenderWithCodeBlocks behaves like Render but additionally returns the list
+// of fenced code blocks in the rendered output. Each entry's Line is the
+// 0-indexed line within the returned string where the block's copy label is
+// drawn.
+func (r *IncrementalRenderer) RenderWithCodeBlocks(input string) (string, []CodeBlock, error) {
 	if input == "" {
 		r.inputPrefix = ""
 		r.outputPrefix = ""
-		return "", nil
+		r.codeBlocksPrefix = nil
+		return "", nil, nil
 	}
 
 	// If the new input no longer starts with our cached prefix, the user (or a
@@ -70,33 +84,37 @@ func (r *IncrementalRenderer) Render(input string) (string, error) {
 	if boundary <= 0 {
 		// No new block boundary in the tail yet — render only the tail and
 		// concatenate. Cached prefix is unchanged.
-		renderedTail, err := r.fallback.Render(tail)
+		renderedTail, tailBlocks, err := r.fallback.RenderWithCodeBlocks(tail)
 		if err != nil {
 			return r.fullRender(input)
 		}
-		return r.joinPrefixAndTail(r.outputPrefix, renderedTail), nil
+		out := r.joinPrefixAndTail(r.outputPrefix, renderedTail)
+		return out, r.mergeCodeBlocks(r.outputPrefix, r.codeBlocksPrefix, tailBlocks), nil
 	}
 
 	// We have a new boundary inside the tail. Render the new stable region
 	// (inputPrefix + tail[:boundary]) once, append it to the cache, then render
 	// the new tail.
 	newStableTail := tail[:boundary]
-	renderedStableTail, err := r.fallback.Render(newStableTail)
+	renderedStableTail, stableBlocks, err := r.fallback.RenderWithCodeBlocks(newStableTail)
 	if err != nil {
 		return r.fullRender(input)
 	}
+	newBlocks := r.mergeCodeBlocks(r.outputPrefix, r.codeBlocksPrefix, stableBlocks)
 	r.inputPrefix += newStableTail
 	r.outputPrefix = r.joinPrefixAndTail(r.outputPrefix, renderedStableTail)
+	r.codeBlocksPrefix = newBlocks
 
 	rest := tail[boundary:]
 	if rest == "" {
-		return r.outputPrefix, nil
+		return r.outputPrefix, cloneCodeBlocks(r.codeBlocksPrefix), nil
 	}
-	renderedRest, err := r.fallback.Render(rest)
+	renderedRest, restBlocks, err := r.fallback.RenderWithCodeBlocks(rest)
 	if err != nil {
 		return r.fullRender(input)
 	}
-	return r.joinPrefixAndTail(r.outputPrefix, renderedRest), nil
+	out := r.joinPrefixAndTail(r.outputPrefix, renderedRest)
+	return out, r.mergeCodeBlocks(r.outputPrefix, r.codeBlocksPrefix, restBlocks), nil
 }
 
 // SetWidth updates the renderer width. Width changes invalidate the cache
@@ -109,6 +127,7 @@ func (r *IncrementalRenderer) SetWidth(width int) {
 	r.fallback = NewFastRenderer(width)
 	r.inputPrefix = ""
 	r.outputPrefix = ""
+	r.codeBlocksPrefix = nil
 }
 
 // Reset drops the cached prefix without changing the width. Use when the
@@ -116,6 +135,7 @@ func (r *IncrementalRenderer) SetWidth(width int) {
 func (r *IncrementalRenderer) Reset() {
 	r.inputPrefix = ""
 	r.outputPrefix = ""
+	r.codeBlocksPrefix = nil
 }
 
 // fullRender renders input from scratch, refreshes the cache, and returns the
@@ -124,36 +144,40 @@ func (r *IncrementalRenderer) Reset() {
 // pieces separately, then join. The two render calls on smaller inputs are
 // faster than one big render plus a separate prefix render, and the prefix
 // piece can be reused as outputPrefix.
-func (r *IncrementalRenderer) fullRender(input string) (string, error) {
+func (r *IncrementalRenderer) fullRender(input string) (string, []CodeBlock, error) {
 	boundary := stableBoundary(input)
 	if boundary <= 0 {
-		out, err := r.fallback.Render(input)
+		out, blocks, err := r.fallback.RenderWithCodeBlocks(input)
 		if err != nil {
-			return "", err
+			return "", nil, err
 		}
 		r.inputPrefix = ""
 		r.outputPrefix = ""
-		return out, nil
+		r.codeBlocksPrefix = nil
+		return out, blocks, nil
 	}
 
 	prefix := input[:boundary]
 	rest := input[boundary:]
-	renderedPrefix, err := r.fallback.Render(prefix)
+	renderedPrefix, prefixBlocks, err := r.fallback.RenderWithCodeBlocks(prefix)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 	if rest == "" {
 		r.inputPrefix = prefix
 		r.outputPrefix = renderedPrefix
-		return renderedPrefix, nil
+		r.codeBlocksPrefix = prefixBlocks
+		return renderedPrefix, cloneCodeBlocks(prefixBlocks), nil
 	}
-	renderedRest, err := r.fallback.Render(rest)
+	renderedRest, restBlocks, err := r.fallback.RenderWithCodeBlocks(rest)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 	r.inputPrefix = prefix
 	r.outputPrefix = renderedPrefix
-	return r.joinPrefixAndTail(renderedPrefix, renderedRest), nil
+	r.codeBlocksPrefix = prefixBlocks
+	out := r.joinPrefixAndTail(renderedPrefix, renderedRest)
+	return out, r.mergeCodeBlocks(renderedPrefix, prefixBlocks, restBlocks), nil
 }
 
 // joinPrefixAndTail concatenates a previously rendered prefix and a freshly
@@ -191,6 +215,41 @@ func (r *IncrementalRenderer) joinPrefixAndTail(prefix, tail string) string {
 	b.WriteByte('\n')
 	b.WriteString(tail)
 	return b.String()
+}
+
+// mergeCodeBlocks returns the union of code blocks from a cached prefix output
+// and a freshly rendered tail. Tail block line indices are shifted by the
+// number of lines in the prefix plus one for the blank separator inserted by
+// joinPrefixAndTail.
+func (r *IncrementalRenderer) mergeCodeBlocks(prefixOut string, prefixBlocks, tailBlocks []CodeBlock) []CodeBlock {
+	if len(prefixBlocks) == 0 && len(tailBlocks) == 0 {
+		return nil
+	}
+	out := make([]CodeBlock, 0, len(prefixBlocks)+len(tailBlocks))
+	out = append(out, prefixBlocks...)
+	if len(tailBlocks) == 0 {
+		return out
+	}
+	offset := 0
+	if prefixOut != "" {
+		// Number of lines in prefix (FastRenderer trims its trailing newline so
+		// the count is newlines + 1) plus one for the blank separator inserted
+		// by joinPrefixAndTail.
+		offset = strings.Count(prefixOut, "\n") + 2
+	}
+	for _, b := range tailBlocks {
+		out = append(out, CodeBlock{Content: b.Content, Line: b.Line + offset})
+	}
+	return out
+}
+
+func cloneCodeBlocks(in []CodeBlock) []CodeBlock {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]CodeBlock, len(in))
+	copy(out, in)
+	return out
 }
 
 // stableBoundary returns the byte index just after the last "safe" block

--- a/pkg/tui/components/markdown/incremental.go
+++ b/pkg/tui/components/markdown/incremental.go
@@ -217,10 +217,15 @@ func (r *IncrementalRenderer) joinPrefixAndTail(prefix, tail string) string {
 	return b.String()
 }
 
+// joinSeparatorLines is the number of extra rendered lines that
+// joinPrefixAndTail inserts between the prefix output and the tail output:
+// one to terminate the prefix's final (untrailing-newlined) line, and one
+// blank-padded separator line. Keep this in sync with joinPrefixAndTail.
+const joinSeparatorLines = 2
+
 // mergeCodeBlocks returns the union of code blocks from a cached prefix output
-// and a freshly rendered tail. Tail block line indices are shifted by the
-// number of lines in the prefix plus one for the blank separator inserted by
-// joinPrefixAndTail.
+// and a freshly rendered tail. Tail block line indices are shifted past the
+// prefix's lines and the separator that joinPrefixAndTail inserts.
 func (r *IncrementalRenderer) mergeCodeBlocks(prefixOut string, prefixBlocks, tailBlocks []CodeBlock) []CodeBlock {
 	if len(prefixBlocks) == 0 && len(tailBlocks) == 0 {
 		return nil
@@ -232,10 +237,7 @@ func (r *IncrementalRenderer) mergeCodeBlocks(prefixOut string, prefixBlocks, ta
 	}
 	offset := 0
 	if prefixOut != "" {
-		// Number of lines in prefix (FastRenderer trims its trailing newline so
-		// the count is newlines + 1) plus one for the blank separator inserted
-		// by joinPrefixAndTail.
-		offset = strings.Count(prefixOut, "\n") + 2
+		offset = strings.Count(prefixOut, "\n") + joinSeparatorLines
 	}
 	for _, b := range tailBlocks {
 		out = append(out, CodeBlock{Content: b.Content, Line: b.Line + offset})

--- a/pkg/tui/components/message/message.go
+++ b/pkg/tui/components/message/message.go
@@ -21,6 +21,7 @@ type Model interface {
 	SetMessage(msg *types.Message)
 	SetSelected(selected bool)
 	SetHovered(hovered bool)
+	CodeBlocks() []markdown.CodeBlock
 }
 
 // messageModel implements Model
@@ -41,6 +42,12 @@ type messageModel struct {
 	// tracking and scroll updates; without this cache each call would re-parse
 	// the entire accumulated markdown from scratch.
 	renderCache renderCache
+
+	// codeBlocks holds the fenced code blocks emitted by the last call to
+	// render() for assistant messages, with Line indices translated into the
+	// messageModel's own View() output coordinate system (i.e. zero-indexed
+	// from the first line of View()).
+	codeBlocks []markdown.CodeBlock
 
 	// mdRenderer is reused across renders of an assistant message so that
 	// streamed-in chunks only re-render the trailing block instead of the whole
@@ -229,9 +236,10 @@ func (mv *messageModel) render(width int) string {
 		}
 
 		innerRenderWidth := width - messageStyle.GetHorizontalFrameSize()
-		rendered, err := mv.renderAssistantMarkdown(msg.Content, innerRenderWidth)
+		rendered, codeBlocks, err := mv.renderAssistantMarkdown(msg.Content, innerRenderWidth)
 		if err != nil {
 			rendered = msg.Content
+			codeBlocks = nil
 		}
 
 		var prefix string
@@ -251,6 +259,28 @@ func (mv *messageModel) render(width int) string {
 			padding := max(innerWidth-iconWidth, 0)
 			topRow = strings.Repeat(" ", padding) + copyIcon
 		}
+
+		// Translate the markdown-relative line indices into messageModel View()
+		// coordinates. The rendered markdown is preceded by the sender prefix
+		// (when shown) and the always-present topRow line inside the styled
+		// envelope, so the first line of `rendered` lands at this offset.
+		prefixLines := 0
+		if prefix != "" {
+			prefixLines = strings.Count(prefix, "\n")
+		}
+		lineOffset := prefixLines + 1 // +1 for topRow
+		if len(codeBlocks) > 0 {
+			mv.codeBlocks = make([]markdown.CodeBlock, len(codeBlocks))
+			for i, cb := range codeBlocks {
+				mv.codeBlocks[i] = markdown.CodeBlock{
+					Content: cb.Content,
+					Line:    cb.Line + lineOffset,
+				}
+			}
+		} else {
+			mv.codeBlocks = nil
+		}
+
 		return prefix + messageStyle.Width(width).Render(topRow+"\n"+rendered)
 	case types.MessageTypeShellOutput:
 		if rendered, err := markdown.NewRenderer(width).Render(fmt.Sprintf("```console\n%s\n```", msg.Content)); err == nil {
@@ -291,13 +321,17 @@ func (mv *messageModel) render(width int) string {
 // IncrementalRenderer. The renderer remembers the last rendered stable prefix
 // so each new chunk only re-parses the trailing region. The first render at a
 // given width is equivalent to a fresh full render.
-func (mv *messageModel) renderAssistantMarkdown(content string, width int) (string, error) {
+//
+// It also returns the list of fenced code blocks emitted by the renderer so
+// that callers can map clicks on the per-block copy affordance back to the
+// underlying raw code.
+func (mv *messageModel) renderAssistantMarkdown(content string, width int) (string, []markdown.CodeBlock, error) {
 	if mv.mdRenderer == nil {
 		mv.mdRenderer = markdown.NewIncrementalRenderer(width)
 	} else {
 		mv.mdRenderer.SetWidth(width)
 	}
-	return mv.mdRenderer.Render(content)
+	return mv.mdRenderer.RenderWithCodeBlocks(content)
 }
 
 func (mv *messageModel) senderPrefix(sender string) string {
@@ -334,6 +368,14 @@ func (mv *messageModel) Height(width int) int {
 // Message returns the underlying message
 func (mv *messageModel) Message() *types.Message {
 	return mv.message
+}
+
+// CodeBlocks returns the fenced code blocks emitted by the most recent render
+// of this message, with Line indices expressed in View() output coordinates.
+// Returns nil when the message has no code blocks or has not been rendered
+// yet (e.g. non-assistant messages).
+func (mv *messageModel) CodeBlocks() []markdown.CodeBlock {
+	return mv.codeBlocks
 }
 
 // Layout.Sizeable methods

--- a/pkg/tui/components/messages/messages.go
+++ b/pkg/tui/components/messages/messages.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/docker-agent/pkg/tools"
 	"github.com/docker/docker-agent/pkg/tools/builtin/transfertask"
 	"github.com/docker/docker-agent/pkg/tui/animation"
+	"github.com/docker/docker-agent/pkg/tui/components/markdown"
 	"github.com/docker/docker-agent/pkg/tui/components/message"
 	"github.com/docker/docker-agent/pkg/tui/components/reasoningblock"
 	"github.com/docker/docker-agent/pkg/tui/components/scrollview"
@@ -312,6 +313,10 @@ func (m *model) handleMouseClick(msg tea.MouseClickMsg) (layout.Model, tea.Cmd) 
 				SessionPosition: *msg.SessionPosition,
 				OriginalContent: msg.Content,
 			})
+		}
+
+		if content, ok := m.codeBlockAt(msgIdx, localLine, col); ok {
+			return m, copyTextToClipboard(content)
 		}
 
 		if m.isCopyLabelClick(msgIdx, localLine, col) {
@@ -1726,6 +1731,51 @@ func (m *model) isEditLabelClick(msgIdx, localLine, col int) (bool, *types.Messa
 	}
 
 	return false, nil
+}
+
+// codeBlockAt returns the raw code of the fenced code block whose copy label
+// is at the given click position, if any.
+func (m *model) codeBlockAt(msgIdx, localLine, col int) (string, bool) {
+	if msgIdx < 0 || msgIdx >= len(m.messages) {
+		return "", false
+	}
+	if msgIdx >= len(m.views) {
+		return "", false
+	}
+	mv, ok := m.views[msgIdx].(message.Model)
+	if !ok {
+		return "", false
+	}
+	blocks := mv.CodeBlocks()
+	if len(blocks) == 0 {
+		return "", false
+	}
+	var target *markdown.CodeBlock
+	for i := range blocks {
+		if blocks[i].Line == localLine {
+			target = &blocks[i]
+			break
+		}
+	}
+	if target == nil {
+		return "", false
+	}
+
+	item := m.renderItem(msgIdx, m.views[msgIdx])
+	if localLine < 0 || localLine >= len(item.lines) {
+		return "", false
+	}
+	plainLine := ansi.Strip(item.lines[localLine])
+	before, _, found := strings.Cut(plainLine, markdown.CodeBlockCopyLabel)
+	if !found {
+		return "", false
+	}
+	labelStart := ansi.StringWidth(before)
+	labelEnd := labelStart + ansi.StringWidth(markdown.CodeBlockCopyLabel)
+	if col < labelStart || col >= labelEnd {
+		return "", false
+	}
+	return target.Content, true
 }
 
 // isCopyLabelClick checks if the click is on the copy label of an assistant message.

--- a/pkg/tui/components/messages/messages.go
+++ b/pkg/tui/components/messages/messages.go
@@ -1766,13 +1766,13 @@ func (m *model) codeBlockAt(msgIdx, localLine, col int) (string, bool) {
 		return "", false
 	}
 	plainLine := ansi.Strip(item.lines[localLine])
-	before, _, found := strings.Cut(plainLine, markdown.CodeBlockCopyLabel)
+	before, _, found := strings.Cut(plainLine, markdown.CodeBlockCopyIcon)
 	if !found {
 		return "", false
 	}
-	labelStart := ansi.StringWidth(before)
-	labelEnd := labelStart + ansi.StringWidth(markdown.CodeBlockCopyLabel)
-	if col < labelStart || col >= labelEnd {
+	iconStart := ansi.StringWidth(before)
+	iconEnd := iconStart + ansi.StringWidth(markdown.CodeBlockCopyIcon)
+	if col < iconStart || col >= iconEnd {
 		return "", false
 	}
 	return target.Content, true


### PR DESCRIPTION
Each fenced code block now renders a copy glyph in its top-right corner. Clicking the glyph copies the block's raw content (preserving original whitespace and line breaks) instead of the whole assistant message.

The renderer returns the list of code blocks alongside the styled output, and the message click handler maps a click on the glyph back to the corresponding raw code.

Closes #2776