### PR TITLE
fix(evals): build /run.sh with printf so legacy builder works

### DIFF
--- a/pkg/evaluation/Dockerfile.template
+++ b/pkg/evaluation/Dockerfile.template
@@ -3,12 +3,7 @@
 FROM alpine:latest
 LABEL "io.docker.agent.evals.image"="default"
 COPY --from=docker/docker-agent:edge /docker-agent /
-RUN cat <<-'EOF' >/run.sh
-#!/usr/bin/env sh
-set -euo pipefail
-exec "$@"
-EOF
-RUN chmod +x /run.sh
+RUN printf '#!/usr/bin/env sh\nset -euo pipefail\nexec "$@"\n' > /run.sh && chmod +x /run.sh
 WORKDIR /working_dir
 ENV TELEMETRY_ENABLED=false
 ENV DOCKER_AGENT_HIDE_TELEMETRY_BANNER=1


### PR DESCRIPTION
## Summary

`pkg/evaluation/Dockerfile.template` used a BuildKit heredoc to write `/run.sh`:

```dockerfile
RUN cat <<-'EOF' >/run.sh
#!/usr/bin/env sh
set -euo pipefail
exec "$@"
EOF
```

Heredocs require BuildKit. When the build runs against the **legacy builder**, this is parsed as just `RUN cat >/run.sh` — `cat` reads from empty stdin and produces a **zero-byte `/run.sh`**. The subsequent heredoc body lines are treated as standalone Dockerfile instructions; Docker is lenient and the build "succeeds" with `/run.sh` empty but executable.

Replaced with a single `printf` that works on both legacy and BuildKit builders:

```dockerfile
RUN printf '#!/usr/bin/env sh\nset -euo pipefail\nexec "$@"\n' > /run.sh && chmod +x /run.sh
```

Resulting `/run.sh` is byte-identical to what the heredoc produces under BuildKit.

```
exec /run.sh: exec format error
```