### PR TITLE
feat(tui): show user pasted content

### DIFF
--- a/pkg/tui/components/editor/editor.go
+++ b/pkg/tui/components/editor/editor.go
@@ -566,10 +566,26 @@ func (e *editor) resetAndSend(content string) tea.Cmd {
 	e.tryAddFileRef(e.pendingFileRef)
 	e.pendingFileRef = ""
 	attachments := e.collectAttachments(content)
+
+	// Sort attachments by name length descending to avoid partial matches
+	// e.g., replacing @paste-1 before @paste-10 would corrupt @paste-10.
+	slices.SortFunc(attachments, func(a, b messages.Attachment) int {
+		return len(b.Name) - len(a.Name)
+	})
+
+	var finalAttachments []messages.Attachment
+	for _, att := range attachments {
+		if att.Content != "" && strings.HasPrefix(att.Name, "paste-") {
+			content = strings.ReplaceAll(content, "@"+att.Name, att.Content)
+		} else {
+			finalAttachments = append(finalAttachments, att)
+		}
+	}
+
 	e.textarea.Reset()
 	e.userTyped = false
 	e.clearSuggestion()
-	return core.CmdHandler(messages.SendMsg{Content: content, Attachments: attachments})
+	return core.CmdHandler(messages.SendMsg{Content: content, Attachments: finalAttachments})
 }
 
 // configureNewlineKeybinding sets up the appropriate newline keybinding

--- a/pkg/tui/components/editor/editor.go
+++ b/pkg/tui/components/editor/editor.go
@@ -567,19 +567,25 @@ func (e *editor) resetAndSend(content string) tea.Cmd {
 	e.pendingFileRef = ""
 	attachments := e.collectAttachments(content)
 
-	// Sort attachments by name length descending to avoid partial matches
-	// e.g., replacing @paste-1 before @paste-10 would corrupt @paste-10.
-	slices.SortFunc(attachments, func(a, b messages.Attachment) int {
-		return len(b.Name) - len(a.Name)
-	})
-
 	var finalAttachments []messages.Attachment
+	var pastes []messages.Attachment
+
 	for _, att := range attachments {
 		if att.Content != "" && strings.HasPrefix(att.Name, "paste-") {
-			content = strings.ReplaceAll(content, "@"+att.Name, att.Content)
+			pastes = append(pastes, att)
 		} else {
 			finalAttachments = append(finalAttachments, att)
 		}
+	}
+
+	// Sort pastes by name length descending to avoid partial matches
+	// e.g., replacing @paste-1 before @paste-10 would corrupt @paste-10.
+	slices.SortFunc(pastes, func(a, b messages.Attachment) int {
+		return len(b.Name) - len(a.Name)
+	})
+
+	for _, att := range pastes {
+		content = strings.ReplaceAll(content, "@"+att.Name, att.Content)
 	}
 
 	e.textarea.Reset()

--- a/pkg/tui/components/message/message.go
+++ b/pkg/tui/components/message/message.go
@@ -14,6 +14,11 @@ import (
 	"github.com/docker/docker-agent/pkg/tui/types"
 )
 
+const (
+	maxUserMessageLines       = 30
+	collapsedUserMessageLines = 5
+)
+
 // Model represents a view that can render a message
 type Model interface {
 	layout.Model
@@ -34,6 +39,7 @@ type messageModel struct {
 	focused  bool
 	selected bool
 	hovered  bool
+	expanded bool
 	spinner  spinner.Spinner
 
 	// renderCache memoizes the output of Render(width) keyed by the inputs
@@ -65,6 +71,7 @@ type renderCache struct {
 	width     int
 	selected  bool
 	hovered   bool
+	expanded  bool
 	sameAgent bool
 	result    string
 }
@@ -128,6 +135,33 @@ func (mv *messageModel) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 	return mv, nil
 }
 
+// Toggle switches between expanded and collapsed state.
+func (mv *messageModel) Toggle() {
+	mv.expanded = !mv.expanded
+	mv.renderCache.valid = false
+}
+
+// IsToggleLine returns true if the line contains the expand/collapse affordance.
+func (mv *messageModel) IsToggleLine(lineIdx int) bool {
+	if mv.message == nil || mv.message.Type != types.MessageTypeUser {
+		return false
+	}
+	content := strings.TrimRight(mv.message.Content, "\n\r\t ")
+	if strings.Count(content, "\n")+1 <= maxUserMessageLines {
+		return false
+	}
+
+	// The indicator is placed at the end of the message view with a leading \n\n.
+	// Depending on edit state, the view has 0 or 1 lines of top padding,
+	// and 1 line of bottom padding.
+	// height-1 is the bottom padding.
+	// height-2 is the text of the indicator ("[-] click to collapse").
+	// height-3 is the empty line above it.
+	// By checking >= height-3, we provide a generous clickable area exactly on the toggle.
+	height := mv.Height(mv.width)
+	return lineIdx >= height-3
+}
+
 // View renders the message view
 func (mv *messageModel) View() string {
 	return mv.Render(mv.width)
@@ -151,6 +185,7 @@ func (mv *messageModel) Render(width int) string {
 			c.msgType == msg.Type &&
 			c.selected == mv.selected &&
 			c.hovered == mv.hovered &&
+			c.expanded == mv.expanded &&
 			c.content == msg.Content &&
 			c.sameAgent == mv.sameAgentAsPrevious(msg) {
 			return c.result
@@ -167,6 +202,7 @@ func (mv *messageModel) Render(width int) string {
 			width:     width,
 			selected:  mv.selected,
 			hovered:   mv.hovered,
+			expanded:  mv.expanded,
 			sameAgent: mv.sameAgentAsPrevious(msg),
 			result:    result,
 		}
@@ -199,16 +235,34 @@ func (mv *messageModel) render(width int) string {
 			messageStyle = styles.SelectedUserMessageStyle
 		}
 
+		formatUserContent := func(c string) string {
+			c = strings.TrimRight(c, "\n\r\t ")
+			if c == "" {
+				return msg.Content
+			}
+
+			totalLines := strings.Count(c, "\n") + 1
+			if totalLines > maxUserMessageLines {
+				if !mv.expanded {
+					parts := strings.SplitN(c, "\n", collapsedUserMessageLines+1)
+					visibleLines := strings.Join(parts[:collapsedUserMessageLines], "\n")
+					hiddenCount := totalLines - collapsedUserMessageLines
+					indicator := "\n\n" + styles.MutedStyle.Render(fmt.Sprintf("[+] expand %d more lines", hiddenCount))
+					return visibleLines + indicator
+				}
+				indicator := "\n\n" + styles.MutedStyle.Render("[-] collapse")
+				return c + indicator
+			}
+			return c
+		}
+
 		if msg.SessionPosition == nil {
-			return messageStyle.Width(width).Render(msg.Content)
+			return messageStyle.Width(width).Render(formatUserContent(msg.Content))
 		}
 
 		// For editable messages, place the pencil icon in the top padding row
 		innerWidth := width - messageStyle.GetHorizontalFrameSize()
-		content := strings.TrimRight(msg.Content, "\n\r\t ")
-		if content == "" {
-			content = msg.Content
-		}
+		content := formatUserContent(msg.Content)
 
 		// Create the edit icon for the top row
 		editIcon := styles.MutedStyle.Render(types.UserMessageEditLabel)

--- a/pkg/tui/components/message/message_test.go
+++ b/pkg/tui/components/message/message_test.go
@@ -1,6 +1,7 @@
 package message
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 	"testing"
@@ -219,4 +220,76 @@ func TestWelcomeMessagePreservesLineBreaks(t *testing.T) {
 	// Verify indentation is preserved in the output
 	plainRendered := stripANSI(rendered)
 	assert.Contains(t, plainRendered, "indented")
+}
+
+func TestUserMessageCollapsible(t *testing.T) {
+	t.Parallel()
+
+	// Create a user message with > 30 lines
+	lines := make([]string, 35)
+	for i := range 35 {
+		lines[i] = fmt.Sprintf("Line %d", i+1)
+	}
+	content := strings.Join(lines, "\n")
+
+	msg := &types.Message{
+		Type:    types.MessageTypeUser,
+		Content: content,
+	}
+	mv := New(msg, nil)
+	mv.SetSize(80, 0)
+
+	// Initially, it should not be expanded.
+	// It should render 5 lines + indicator
+	rendered := mv.View()
+	renderedPlain := stripANSI(rendered)
+
+	assert.Contains(t, renderedPlain, "Line 1")
+	assert.Contains(t, renderedPlain, "Line 5")
+	assert.NotContains(t, renderedPlain, "Line 6")
+	assert.Contains(t, renderedPlain, "[+] expand 30 more lines")
+
+	// Test IsToggleLine
+	// The height calculation inside IsToggleLine relies on mv.Height(80)
+	height := mv.Height(80)
+	assert.True(t, mv.IsToggleLine(height-1), "Bottom padding line should be toggleable")
+	assert.True(t, mv.IsToggleLine(height-2), "Indicator text line should be toggleable")
+	assert.True(t, mv.IsToggleLine(height-3), "Empty line above indicator should be toggleable")
+	assert.False(t, mv.IsToggleLine(height-4), "Text content lines should not be toggleable")
+
+	// Toggle it
+	mv.Toggle()
+
+	// Render again, should be expanded
+	renderedExpanded := mv.View()
+	renderedExpandedPlain := stripANSI(renderedExpanded)
+
+	assert.Contains(t, renderedExpandedPlain, "Line 1")
+	assert.Contains(t, renderedExpandedPlain, "Line 35")
+	assert.Contains(t, renderedExpandedPlain, "[-] collapse")
+}
+
+func TestUserMessageNotCollapsible(t *testing.T) {
+	t.Parallel()
+
+	// Create a user message with <= 30 lines
+	lines := make([]string, 10)
+	for i := range 10 {
+		lines[i] = fmt.Sprintf("Line %d", i+1)
+	}
+	msg := &types.Message{
+		Type:    types.MessageTypeUser,
+		Content: strings.Join(lines, "\n"),
+	}
+	mv := New(msg, nil)
+	mv.SetSize(80, 0)
+
+	renderedPlain := stripANSI(mv.View())
+
+	assert.Contains(t, renderedPlain, "Line 10")
+	assert.NotContains(t, renderedPlain, "[+] expand")
+	assert.NotContains(t, renderedPlain, "[-] collapse")
+
+	height := mv.Height(80)
+	assert.False(t, mv.IsToggleLine(height-1))
 }

--- a/pkg/tui/components/messages/messages.go
+++ b/pkg/tui/components/messages/messages.go
@@ -37,6 +37,11 @@ import (
 // ToggleHideToolResultsMsg triggers hiding/showing tool results
 type ToggleHideToolResultsMsg struct{}
 
+type toggleableView interface {
+	IsToggleLine(lineIdx int) bool
+	Toggle()
+}
+
 // Model represents a chat message list component
 type Model interface {
 	layout.Model
@@ -296,11 +301,11 @@ func (m *model) handleMouseClick(msg tea.MouseClickMsg) (layout.Model, tea.Cmd) 
 
 	line, col := m.mouseToLineCol(msg.X, msg.Y)
 
-	// Check for reasoning block header toggle
 	if msgIdx, localLine := m.globalLineToMessageLine(line); msgIdx >= 0 {
-		if block, ok := m.views[msgIdx].(*reasoningblock.Model); ok {
-			if block.IsToggleLine(localLine) {
-				block.Toggle()
+		// Check for toggleable blocks (e.g. reasoning block, collapsed long messages)
+		if t, ok := m.views[msgIdx].(toggleableView); ok {
+			if t.IsToggleLine(localLine) {
+				t.Toggle()
 				m.bottomSlack = 0
 				m.invalidateItem(msgIdx)
 				return m, nil


### PR DESCRIPTION
## Summary
This PR enhances the TUI to render pasted content back to the user - automatically collapsing large pasted file contents (exceeding 30 lines) into a toggleable view, improving overall chat readability and scrolling performance.

## Key Changes
* **Show User Pasted Content:** Currently pasting multiple lines into docker agent TUI renders as `@paste-1` for example. This shows the pasted content back to the user to allow for better readability.
* **Collapsible User Messages:** Added expand/collapse functionality to user messages exceeding 30 lines (rendered via `messages.go` and `message.go`).
* **Interactive Toggles:** Implemented a generic `toggleableView` interface in `messages.go` to handle click-to-toggle interactions on message views (now supporting both reasoning blocks and long user messages).
* **Robust File Replacements:** Modified `editor.go` to sort paste attachments by length descending before inline string replacement (`@paste-1` vs `@paste-10`), preventing partial match corruption, while fully retaining proper order of standard metadata file attachments.
* **Performance Enhancements:** Prevented memory allocation spikes by utilizing zero-allocation string ops (`strings.Count` and `strings.SplitN`) instead of heavy array allocations (`strings.Split`) during truncation calculations.
* **Coverage:** Added comprehensive `TestUserMessageCollapsible` and `TestUserMessageNotCollapsible` unit tests to secure boundary math and UI layout mechanics.