### PR TITLE
route mouse-wheel events to background dialogs

### DIFF
--- a/pkg/tui/dialog/dialog.go
+++ b/pkg/tui/dialog/dialog.go
@@ -11,11 +11,12 @@ import (
 // OpenDialogMsg is sent to open a new dialog.
 //
 // OriginatingEvent is an optional runtime event whose presence marks the
-// dialog as a background dialog. Background dialogs do not block the rest of
-// the UI: tab navigation, tab-bar mouse clicks and chat scroll-wheel events
-// keep working. When the user switches away from the tab that opened the
-// dialog, the dialog is closed and OriginatingEvent is re-stashed in the
-// supervisor so the same prompt is re-displayed when the user returns.
+// dialog as a background dialog. Background dialogs do not block tab
+// navigation: tab-switch keys and tab-bar mouse clicks keep working. When
+// the user switches away from the tab that opened the dialog, the dialog is
+// closed and OriginatingEvent is re-stashed in the supervisor so the same
+// prompt is re-displayed when the user returns. Other input (including
+// mouse-wheel events) is still routed to the dialog while it is on screen.
 type OpenDialogMsg struct {
 	Model            Dialog
 	OriginatingEvent tea.Msg
@@ -41,7 +42,7 @@ type Manager interface {
 	Open() bool
 	TopIsExitConfirmation() bool
 	// TopIsBackground reports whether the topmost dialog is a background
-	// dialog (i.e. it should not block tab navigation or chat scrolling).
+	// dialog (i.e. it should not block tab navigation).
 	TopIsBackground() bool
 	// TopBackgroundEvent returns the originating event of the topmost
 	// background dialog, or nil if the top dialog is not a background dialog

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -2093,12 +2093,6 @@ func (m *appModel) handleWheelCoalesced(msg messages.WheelCoalescedMsg) (tea.Mod
 	}
 
 	if m.dialogMgr.Open() {
-		// Background dialogs (e.g. pending elicitations) let chat-area scroll
-		// wheel events fall through so the user can review the conversation
-		// behind the dialog while the prompt waits.
-		if m.dialogMgr.TopIsBackground() && m.hitTestRegion(msg.Y) == regionContent {
-			return m.forwardChat(msg)
-		}
 		return m.forwardDialog(msg)
 	}
 


### PR DESCRIPTION
When a background dialog (e.g. a pending elicitation) is open, mouse-wheel events were falling through to the chat area so the user could scroll the conversation behind the dialog. They now go to the dialog itself, like every other open dialog. Tab navigation still works as before, so the wheel naturally only ever reaches the dialog of the current tab.