### PR TITLE
feat: add X-Docker-Agent-Version and X-Docker-Desktop-Version headers to built-in tools

### DIFF
--- a/pkg/desktop/version.go
+++ b/pkg/desktop/version.go
@@ -7,51 +7,32 @@ import (
 	"github.com/kofalt/go-memoize"
 )
 
-// updateInfo is the subset of Docker Desktop's `/update` endpoint payload
-// we care about. The endpoint exposes the running app's version and build
-// number; the full body also contains appcast and update-status fields
-// that are irrelevant here.
-type updateInfo struct {
-	CurrentVersion string `json:"currentVersion"`
-	CurrentBuild   string `json:"currentBuild"`
-}
-
-// versionTTL bounds how long a previous lookup result (success or failure)
-// is reused. A TTL — rather than the lifetime of the process — means:
+// versionMemoizer caches the Docker Desktop version lookup with a TTL so:
 //   - if docker-agent starts before Desktop is ready, version detection
 //     recovers automatically once Desktop comes up;
 //   - if Desktop is upgraded mid-session, the new version is picked up
-//     within at most this interval.
-//
-// 5 minutes is generous enough to keep the per-request overhead negligible
-// (the Unix socket call only happens once per window) while still giving
-// quick recovery in the failure case.
-const versionTTL = 5 * time.Minute
-
-var versionMemoizer = memoize.NewMemoizer(versionTTL, 2*versionTTL)
+//     within at most one TTL.
+var versionMemoizer = memoize.NewMemoizer(5*time.Minute, 10*time.Minute)
 
 // GetVersion returns the running Docker Desktop version (e.g. "4.74.0") or
 // an empty string if Docker Desktop is not running or the call fails.
 //
-// The lookup is memoized for [versionTTL] and is bounded by a short
-// internal timeout so a stale or missing backend socket cannot stall
-// callers on hot paths (it is queried on every outbound built-in tool
-// HTTP request). The HTTP call uses [context.Background] rather than a
-// caller-supplied context: the result is shared across all callers, so
-// we don't want the first caller's deadline or cancellation to bleed
-// into other callers' view of the world.
+// The lookup is bounded by a short internal timeout so a stale or missing
+// backend socket cannot stall callers on hot paths (it is queried on every
+// outbound built-in tool HTTP request). The HTTP call uses
+// [context.Background] rather than a caller-supplied context: the result
+// is shared across all callers, so we don't want the first caller's
+// deadline or cancellation to bleed into other callers' view of the world.
 func GetVersion() string {
-	v, _, _ := versionMemoizer.Memoize("desktopVersion", func() (any, error) {
+	v, _, _ := memoize.Call(versionMemoizer, "desktopVersion", func() (string, error) {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
 
-		var info updateInfo
+		var info struct {
+			CurrentVersion string `json:"currentVersion"`
+		}
 		_ = ClientBackend.Get(ctx, "/update", &info)
 		return info.CurrentVersion, nil
 	})
-	s, ok := v.(string)
-	if !ok {
-		return ""
-	}
-	return s
+	return v
 }

--- a/pkg/desktop/version.go
+++ b/pkg/desktop/version.go
@@ -1,0 +1,40 @@
+package desktop
+
+import (
+	"context"
+	"time"
+
+	"github.com/kofalt/go-memoize"
+	"github.com/patrickmn/go-cache"
+)
+
+// updateInfo is the subset of Docker Desktop's `/update` endpoint payload
+// we care about. The endpoint exposes the running app's version and build
+// number; the full body also contains appcast and update-status fields
+// that are irrelevant here.
+type updateInfo struct {
+	CurrentVersion string `json:"currentVersion"`
+	CurrentBuild   string `json:"currentBuild"`
+}
+
+var versionMemoizer = memoize.NewMemoizer(cache.NoExpiration, cache.NoExpiration)
+
+// GetVersion returns the running Docker Desktop version (e.g. "4.74.0") or
+// an empty string if Docker Desktop is not running or the call fails.
+//
+// The lookup is memoized for the lifetime of the process — Desktop's
+// version cannot change without a restart that would also tear down our
+// process — and is bounded by a short internal timeout so a stale or
+// missing backend socket cannot stall callers on hot paths (it is
+// queried on every outbound built-in tool HTTP request).
+func GetVersion(ctx context.Context) string {
+	v, _, _ := versionMemoizer.Memoize("desktopVersion", func() (any, error) {
+		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		defer cancel()
+
+		var info updateInfo
+		_ = ClientBackend.Get(ctx, "/update", &info)
+		return info.CurrentVersion, nil
+	})
+	return v.(string)
+}

--- a/pkg/desktop/version.go
+++ b/pkg/desktop/version.go
@@ -19,13 +19,12 @@ var versionMemoizer = memoize.NewMemoizer(5*time.Minute, 10*time.Minute)
 //
 // The lookup is bounded by a short internal timeout so a stale or missing
 // backend socket cannot stall callers on hot paths (it is queried on every
-// outbound built-in tool HTTP request). The HTTP call uses
-// [context.Background] rather than a caller-supplied context: the result
-// is shared across all callers, so we don't want the first caller's
-// deadline or cancellation to bleed into other callers' view of the world.
-func GetVersion() string {
+// outbound built-in tool HTTP request). ctx is used for the underlying
+// HTTP call on a cache miss; on a cache hit the cached value is returned
+// without consulting ctx.
+func GetVersion(ctx context.Context) string {
 	v, _, _ := memoize.Call(versionMemoizer, "desktopVersion", func() (string, error) {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		defer cancel()
 
 		var info struct {

--- a/pkg/desktop/version.go
+++ b/pkg/desktop/version.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/kofalt/go-memoize"
-	"github.com/patrickmn/go-cache"
 )
 
 // updateInfo is the subset of Docker Desktop's `/update` endpoint payload
@@ -17,24 +16,42 @@ type updateInfo struct {
 	CurrentBuild   string `json:"currentBuild"`
 }
 
-var versionMemoizer = memoize.NewMemoizer(cache.NoExpiration, cache.NoExpiration)
+// versionTTL bounds how long a previous lookup result (success or failure)
+// is reused. A TTL — rather than the lifetime of the process — means:
+//   - if docker-agent starts before Desktop is ready, version detection
+//     recovers automatically once Desktop comes up;
+//   - if Desktop is upgraded mid-session, the new version is picked up
+//     within at most this interval.
+//
+// 5 minutes is generous enough to keep the per-request overhead negligible
+// (the Unix socket call only happens once per window) while still giving
+// quick recovery in the failure case.
+const versionTTL = 5 * time.Minute
+
+var versionMemoizer = memoize.NewMemoizer(versionTTL, 2*versionTTL)
 
 // GetVersion returns the running Docker Desktop version (e.g. "4.74.0") or
 // an empty string if Docker Desktop is not running or the call fails.
 //
-// The lookup is memoized for the lifetime of the process — Desktop's
-// version cannot change without a restart that would also tear down our
-// process — and is bounded by a short internal timeout so a stale or
-// missing backend socket cannot stall callers on hot paths (it is
-// queried on every outbound built-in tool HTTP request).
-func GetVersion(ctx context.Context) string {
+// The lookup is memoized for [versionTTL] and is bounded by a short
+// internal timeout so a stale or missing backend socket cannot stall
+// callers on hot paths (it is queried on every outbound built-in tool
+// HTTP request). The HTTP call uses [context.Background] rather than a
+// caller-supplied context: the result is shared across all callers, so
+// we don't want the first caller's deadline or cancellation to bleed
+// into other callers' view of the world.
+func GetVersion() string {
 	v, _, _ := versionMemoizer.Memoize("desktopVersion", func() (any, error) {
-		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
 
 		var info updateInfo
 		_ = ClientBackend.Get(ctx, "/update", &info)
 		return info.CurrentVersion, nil
 	})
-	return v.(string)
+	s, ok := v.(string)
+	if !ok {
+		return ""
+	}
+	return s
 }

--- a/pkg/tools/builtin/api/api.go
+++ b/pkg/tools/builtin/api/api.go
@@ -149,7 +149,7 @@ func (t *Tool) Tools(context.Context) ([]tools.Tool, error) {
 }
 
 func setHeaders(req *http.Request, headers map[string]string) {
-	req.Header.Set("User-Agent", useragent.Header)
+	useragent.SetIdentity(req.Context(), req)
 	for k, v := range upstream.ResolveHeaders(req.Context(), headers) {
 		req.Header.Set(k, v)
 	}

--- a/pkg/tools/builtin/api/api.go
+++ b/pkg/tools/builtin/api/api.go
@@ -149,7 +149,7 @@ func (t *Tool) Tools(context.Context) ([]tools.Tool, error) {
 }
 
 func setHeaders(req *http.Request, headers map[string]string) {
-	useragent.SetIdentity(req.Context(), req)
+	useragent.SetIdentity(req)
 	for k, v := range upstream.ResolveHeaders(req.Context(), headers) {
 		req.Header.Set(k, v)
 	}

--- a/pkg/tools/builtin/api/api_test.go
+++ b/pkg/tools/builtin/api/api_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/js"
 	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/useragent"
+	"github.com/docker/docker-agent/pkg/version"
 )
 
 // newAPIToolForTest constructs an APITool that bypasses SSRF dial-time
@@ -131,6 +133,26 @@ func TestAPITool_Headers(t *testing.T) {
 	assert.Equal(t, "custom-value", ts.receivedHeaders.Get("X-Custom-Header"))
 	assert.Equal(t, "secret-key", ts.receivedHeaders.Get("X-API-Key"))
 	assert.Equal(t, "another-value", ts.receivedHeaders.Get("X-Another-Header"))
+}
+
+// TestAPITool_IdentityHeaders pins the docker-agent identity headers that
+// every built-in tool sends so backends can attribute traffic to a specific
+// docker-agent install. X-Docker-Desktop-Version is only present when
+// Docker Desktop is reachable, so we accept its absence.
+func TestAPITool_IdentityHeaders(t *testing.T) {
+	t.Parallel()
+	ts := getTestServer(t)
+
+	tool := newAPIToolForTest(latest.APIToolConfig{
+		Method:   http.MethodGet,
+		Endpoint: ts.serverURL,
+	}, testExpander())
+
+	_, err := tool.callTool(t.Context(), tools.ToolCall{})
+	require.NoError(t, err)
+
+	assert.Equal(t, useragent.Header, ts.receivedHeaders.Get("User-Agent"))
+	assert.Equal(t, version.Version, ts.receivedHeaders.Get(useragent.HeaderAgentVersion))
 }
 
 func TestAPITool_DefaultOutputSchema(t *testing.T) {

--- a/pkg/tools/builtin/fetch/fetch.go
+++ b/pkg/tools/builtin/fetch/fetch.go
@@ -163,7 +163,7 @@ func (h *fetchHandler) fetchURL(ctx context.Context, client *http.Client, urlStr
 	robots, cached := robotsCache[host]
 	if !cached {
 		var err error
-		robots, err = h.fetchRobots(ctx, client, parsedURL, useragent.Header)
+		robots, err = h.fetchRobots(ctx, client, parsedURL)
 		if err != nil {
 			result.Error = fmt.Sprintf("robots.txt check failed: %v", err)
 			return result
@@ -183,8 +183,8 @@ func (h *fetchHandler) fetchURL(ctx context.Context, client *http.Client, urlStr
 		result.Error = fmt.Sprintf("failed to create request: %v", err)
 		return result
 	}
-	req.Header.Set("User-Agent", useragent.Header)
 	req.Header.Set("Accept", fmtHandler.accept)
+	useragent.SetIdentity(ctx, req)
 	// Apply caller-configured headers last so an operator-supplied
 	// Authorization, User-Agent, Accept, ... wins over the defaults set above.
 	for k, v := range h.headers {
@@ -233,7 +233,7 @@ func (h *fetchHandler) fetchURL(ctx context.Context, client *http.Client, urlStr
 //   - caller-supplied headers (Authorization, X-Api-Key, ...) are stripped
 //     when crossing host boundaries, so credentials never leak to a
 //     third-party host that handles a robots.txt redirect.
-func (h *fetchHandler) fetchRobots(ctx context.Context, client *http.Client, targetURL *url.URL, userAgent string) (*robotstxt.RobotsData, error) {
+func (h *fetchHandler) fetchRobots(ctx context.Context, client *http.Client, targetURL *url.URL) (*robotstxt.RobotsData, error) {
 	// Build robots.txt URL
 	robotsURL := &url.URL{
 		Scheme: targetURL.Scheme,
@@ -248,7 +248,7 @@ func (h *fetchHandler) fetchRobots(ctx context.Context, client *http.Client, tar
 		return nil, nil
 	}
 
-	req.Header.Set("User-Agent", userAgent)
+	useragent.SetIdentity(ctx, req)
 	// Apply custom headers to robots.txt requests too, so authenticated
 	// endpoints that also protect robots.txt work correctly. Cross-host
 	// leaks are prevented by the shared client's CheckRedirect.

--- a/pkg/tools/builtin/fetch/fetch.go
+++ b/pkg/tools/builtin/fetch/fetch.go
@@ -184,7 +184,7 @@ func (h *fetchHandler) fetchURL(ctx context.Context, client *http.Client, urlStr
 		return result
 	}
 	req.Header.Set("Accept", fmtHandler.accept)
-	useragent.SetIdentity(ctx, req)
+	useragent.SetIdentity(req)
 	// Apply caller-configured headers last so an operator-supplied
 	// Authorization, User-Agent, Accept, ... wins over the defaults set above.
 	for k, v := range h.headers {
@@ -248,7 +248,7 @@ func (h *fetchHandler) fetchRobots(ctx context.Context, client *http.Client, tar
 		return nil, nil
 	}
 
-	useragent.SetIdentity(ctx, req)
+	useragent.SetIdentity(req)
 	// Apply custom headers to robots.txt requests too, so authenticated
 	// endpoints that also protect robots.txt work correctly. Cross-host
 	// leaks are prevented by the shared client's CheckRedirect.

--- a/pkg/tools/builtin/fetch/fetch_test.go
+++ b/pkg/tools/builtin/fetch/fetch_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/useragent"
+	"github.com/docker/docker-agent/pkg/version"
 )
 
 // newFetchToolForTest constructs a FetchTool that bypasses SSRF dial-time
@@ -438,7 +440,7 @@ func TestFetchTool_WithHeadersOption(t *testing.T) {
 }
 
 func TestFetch_Headers_SentOnRequest(t *testing.T) {
-	var gotAuthorization, gotAPIKey string
+	var gotAuthorization, gotAPIKey, gotUserAgent, gotAgentVersion string
 	url := runHTTPServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/robots.txt" {
 			http.NotFound(w, r)
@@ -446,6 +448,8 @@ func TestFetch_Headers_SentOnRequest(t *testing.T) {
 		}
 		gotAuthorization = r.Header.Get("Authorization")
 		gotAPIKey = r.Header.Get("X-Api-Key")
+		gotUserAgent = r.Header.Get("User-Agent")
+		gotAgentVersion = r.Header.Get(useragent.HeaderAgentVersion)
 		w.Header().Set("Content-Type", "text/plain")
 		fmt.Fprint(w, "ok")
 	})
@@ -463,6 +467,8 @@ func TestFetch_Headers_SentOnRequest(t *testing.T) {
 	assert.Contains(t, result.Output, "Successfully fetched")
 	assert.Equal(t, "Bearer secret-token", gotAuthorization)
 	assert.Equal(t, "key-123", gotAPIKey)
+	assert.Equal(t, useragent.Header, gotUserAgent)
+	assert.Equal(t, version.Version, gotAgentVersion)
 }
 
 // TestFetch_Headers_OverrideDefaults pins the precedence rule: caller-supplied

--- a/pkg/tools/builtin/openapi/openapi.go
+++ b/pkg/tools/builtin/openapi/openapi.go
@@ -387,7 +387,7 @@ func sanitizeToolName(name string) string {
 // an HTTP request. Header values may contain ${headers.NAME} placeholders
 // that are resolved from upstream headers stored in the request context.
 func setHeaders(req *http.Request, headers map[string]string) {
-	useragent.SetIdentity(req.Context(), req)
+	useragent.SetIdentity(req)
 	for k, v := range upstream.ResolveHeaders(req.Context(), headers) {
 		req.Header.Set(k, v)
 	}

--- a/pkg/tools/builtin/openapi/openapi.go
+++ b/pkg/tools/builtin/openapi/openapi.go
@@ -382,11 +382,12 @@ func sanitizeToolName(name string) string {
 	return name
 }
 
-// setHeaders sets the User-Agent and custom headers on an HTTP request.
-// Header values may contain ${headers.NAME} placeholders that are resolved
-// from upstream headers stored in the request context.
+// setHeaders sets identity headers (User-Agent, X-Docker-Agent-Version,
+// X-Docker-Desktop-Version) plus any operator-supplied custom headers on
+// an HTTP request. Header values may contain ${headers.NAME} placeholders
+// that are resolved from upstream headers stored in the request context.
 func setHeaders(req *http.Request, headers map[string]string) {
-	req.Header.Set("User-Agent", useragent.Header)
+	useragent.SetIdentity(req.Context(), req)
 	for k, v := range upstream.ResolveHeaders(req.Context(), headers) {
 		req.Header.Set(k, v)
 	}

--- a/pkg/tools/builtin/openapi/openapi_test.go
+++ b/pkg/tools/builtin/openapi/openapi_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/useragent"
+	"github.com/docker/docker-agent/pkg/version"
 )
 
 // newOpenAPIToolForTest constructs an OpenAPITool that bypasses SSRF
@@ -342,6 +344,8 @@ func TestOpenAPITool_CustomHeaders(t *testing.T) {
 
 	assert.Equal(t, "Bearer test-token", receivedHeaders.Get("Authorization"))
 	assert.Equal(t, "custom-value", receivedHeaders.Get("X-Custom"))
+	assert.Equal(t, useragent.Header, receivedHeaders.Get("User-Agent"))
+	assert.Equal(t, version.Version, receivedHeaders.Get(useragent.HeaderAgentVersion))
 }
 
 func TestOpenAPITool_ErrorResponse(t *testing.T) {

--- a/pkg/useragent/useragent.go
+++ b/pkg/useragent/useragent.go
@@ -1,10 +1,55 @@
+// Package useragent centralizes the HTTP identity headers that built-in
+// tools (api, fetch, openapi, ...) attach to every outbound request.
+//
+// All built-in tools call [SetIdentity] before sending the HTTP request so
+// the wire format is uniform across tool kinds and easy to evolve from a
+// single place.
 package useragent
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 	"runtime"
 
+	"github.com/docker/docker-agent/pkg/desktop"
 	"github.com/docker/docker-agent/pkg/version"
 )
 
+// Header is the User-Agent value sent by built-in HTTP tools. It also
+// doubles as the agent name fed to robotstxt.RobotsData.TestAgent so
+// site operators see the same identity in both places.
 var Header = fmt.Sprintf("Cagent/%s (%s; %s)", version.Version, runtime.GOOS, runtime.GOARCH)
+
+// HTTP header names emitted by [SetIdentity] in addition to User-Agent.
+// They surface the docker-agent and Docker Desktop versions so backends
+// can correlate built-in tool calls with the rest of Docker's traffic
+// for the same install.
+const (
+	HeaderAgentVersion   = "X-Docker-Agent-Version"
+	HeaderDesktopVersion = "X-Docker-Desktop-Version"
+)
+
+// SetIdentity stamps the outgoing request with a consistent set of
+// identity headers:
+//
+//   - User-Agent: see [Header].
+//   - X-Docker-Agent-Version: the docker-agent version (always sent —
+//     the literal "dev" used in dev builds is still useful to
+//     disambiguate from non-cagent traffic).
+//   - X-Docker-Desktop-Version: the running Docker Desktop version, only
+//     when Desktop is reachable on this machine. Looked up once per
+//     process via [desktop.GetVersion]; absent on hosts that don't run
+//     Desktop, so its presence is itself a signal.
+//
+// SetIdentity uses [http.Header.Set] semantics, so callers that want to
+// honour an operator-supplied override should apply those headers AFTER
+// calling SetIdentity. This matches the precedence rule already used in
+// the fetch tool for User-Agent and Accept.
+func SetIdentity(ctx context.Context, req *http.Request) {
+	req.Header.Set("User-Agent", Header)
+	req.Header.Set(HeaderAgentVersion, version.Version)
+	if v := desktop.GetVersion(ctx); v != "" {
+		req.Header.Set(HeaderDesktopVersion, v)
+	}
+}

--- a/pkg/useragent/useragent.go
+++ b/pkg/useragent/useragent.go
@@ -1,9 +1,5 @@
 // Package useragent centralizes the HTTP identity headers that built-in
 // tools (api, fetch, openapi, ...) attach to every outbound request.
-//
-// All built-in tools call [SetIdentity] before sending the HTTP request so
-// the wire format is uniform across tool kinds and easy to evolve from a
-// single place.
 package useragent
 
 import (
@@ -21,30 +17,15 @@ import (
 var Header = fmt.Sprintf("Cagent/%s (%s; %s)", version.Version, runtime.GOOS, runtime.GOARCH)
 
 // HTTP header names emitted by [SetIdentity] in addition to User-Agent.
-// They surface the docker-agent and Docker Desktop versions so backends
-// can correlate built-in tool calls with the rest of Docker's traffic
-// for the same install.
 const (
 	HeaderAgentVersion   = "X-Docker-Agent-Version"
 	HeaderDesktopVersion = "X-Docker-Desktop-Version"
 )
 
-// SetIdentity stamps the outgoing request with a consistent set of
-// identity headers:
-//
-//   - User-Agent: see [Header].
-//   - X-Docker-Agent-Version: the docker-agent version (always sent —
-//     the literal "dev" used in dev builds is still useful to
-//     disambiguate from non-cagent traffic).
-//   - X-Docker-Desktop-Version: the running Docker Desktop version, only
-//     when Desktop is reachable on this machine. Looked up once per
-//     process via [desktop.GetVersion]; absent on hosts that don't run
-//     Desktop, so its presence is itself a signal.
-//
-// SetIdentity uses [http.Header.Set] semantics, so callers that want to
-// honour an operator-supplied override should apply those headers AFTER
-// calling SetIdentity. This matches the precedence rule already used in
-// the fetch tool for User-Agent and Accept.
+// SetIdentity stamps the request with User-Agent, X-Docker-Agent-Version,
+// and (when Docker Desktop is reachable) X-Docker-Desktop-Version. Callers
+// that want operator-supplied overrides should apply those headers AFTER
+// calling SetIdentity.
 func SetIdentity(req *http.Request) {
 	req.Header.Set("User-Agent", Header)
 	req.Header.Set(HeaderAgentVersion, version.Version)

--- a/pkg/useragent/useragent.go
+++ b/pkg/useragent/useragent.go
@@ -7,7 +7,6 @@
 package useragent
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"runtime"
@@ -46,10 +45,10 @@ const (
 // honour an operator-supplied override should apply those headers AFTER
 // calling SetIdentity. This matches the precedence rule already used in
 // the fetch tool for User-Agent and Accept.
-func SetIdentity(ctx context.Context, req *http.Request) {
+func SetIdentity(req *http.Request) {
 	req.Header.Set("User-Agent", Header)
 	req.Header.Set(HeaderAgentVersion, version.Version)
-	if v := desktop.GetVersion(ctx); v != "" {
+	if v := desktop.GetVersion(); v != "" {
 		req.Header.Set(HeaderDesktopVersion, v)
 	}
 }

--- a/pkg/useragent/useragent.go
+++ b/pkg/useragent/useragent.go
@@ -29,7 +29,7 @@ const (
 func SetIdentity(req *http.Request) {
 	req.Header.Set("User-Agent", Header)
 	req.Header.Set(HeaderAgentVersion, version.Version)
-	if v := desktop.GetVersion(); v != "" {
+	if v := desktop.GetVersion(req.Context()); v != "" {
 		req.Header.Set(HeaderDesktopVersion, v)
 	}
 }

--- a/pkg/useragent/useragent_test.go
+++ b/pkg/useragent/useragent_test.go
@@ -1,0 +1,38 @@
+package useragent
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/version"
+)
+
+func TestSetIdentity_StampsAgentVersionAndUserAgent(t *testing.T) {
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com/", http.NoBody)
+	require.NoError(t, err)
+
+	SetIdentity(req.Context(), req)
+
+	assert.Equal(t, Header, req.Header.Get("User-Agent"))
+	assert.Equal(t, version.Version, req.Header.Get(HeaderAgentVersion))
+	assert.True(t, strings.HasPrefix(req.Header.Get("User-Agent"), "Cagent/"),
+		"User-Agent should start with Cagent/")
+}
+
+// Docker Desktop is not running in CI, so [HeaderDesktopVersion] must not be
+// emitted when the backend socket cannot be reached. Tests pinned to the
+// affirmative case live in pkg/desktop where we can fake the backend client.
+func TestSetIdentity_OmitsDesktopVersionWhenAbsent(t *testing.T) {
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com/", http.NoBody)
+	require.NoError(t, err)
+
+	SetIdentity(req.Context(), req)
+
+	if got := req.Header.Get(HeaderDesktopVersion); got != "" {
+		t.Logf("Docker Desktop reachable in this environment; skipping absence assertion (got %q)", got)
+	}
+}

--- a/pkg/useragent/useragent_test.go
+++ b/pkg/useragent/useragent_test.go
@@ -2,7 +2,6 @@ package useragent
 
 import (
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,7 +10,7 @@ import (
 	"github.com/docker/docker-agent/pkg/version"
 )
 
-func TestSetIdentity_StampsAgentVersionAndUserAgent(t *testing.T) {
+func TestSetIdentity(t *testing.T) {
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com/", http.NoBody)
 	require.NoError(t, err)
 
@@ -19,20 +18,4 @@ func TestSetIdentity_StampsAgentVersionAndUserAgent(t *testing.T) {
 
 	assert.Equal(t, Header, req.Header.Get("User-Agent"))
 	assert.Equal(t, version.Version, req.Header.Get(HeaderAgentVersion))
-	assert.True(t, strings.HasPrefix(req.Header.Get("User-Agent"), "Cagent/"),
-		"User-Agent should start with Cagent/")
-}
-
-// Docker Desktop is not running in CI, so [HeaderDesktopVersion] must not be
-// emitted when the backend socket cannot be reached. Tests pinned to the
-// affirmative case live in pkg/desktop where we can fake the backend client.
-func TestSetIdentity_OmitsDesktopVersionWhenAbsent(t *testing.T) {
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com/", http.NoBody)
-	require.NoError(t, err)
-
-	SetIdentity(req)
-
-	if got := req.Header.Get(HeaderDesktopVersion); got != "" {
-		t.Logf("Docker Desktop reachable in this environment; skipping absence assertion (got %q)", got)
-	}
 }

--- a/pkg/useragent/useragent_test.go
+++ b/pkg/useragent/useragent_test.go
@@ -15,7 +15,7 @@ func TestSetIdentity_StampsAgentVersionAndUserAgent(t *testing.T) {
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com/", http.NoBody)
 	require.NoError(t, err)
 
-	SetIdentity(req.Context(), req)
+	SetIdentity(req)
 
 	assert.Equal(t, Header, req.Header.Get("User-Agent"))
 	assert.Equal(t, version.Version, req.Header.Get(HeaderAgentVersion))
@@ -30,7 +30,7 @@ func TestSetIdentity_OmitsDesktopVersionWhenAbsent(t *testing.T) {
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com/", http.NoBody)
 	require.NoError(t, err)
 
-	SetIdentity(req.Context(), req)
+	SetIdentity(req)
 
 	if got := req.Header.Get(HeaderDesktopVersion); got != "" {
 		t.Logf("Docker Desktop reachable in this environment; skipping absence assertion (got %q)", got)


### PR DESCRIPTION
## What

Adds two HTTP identity headers to every outbound request made by the `api`, `fetch`, and `openapi` built-in tools, on top of the existing `User-Agent`:

| Header | Value | When |
|---|---|---|
| `User-Agent` | `Cagent/<version> (<goos>; <goarch>)` | Always (unchanged) |
| `X-Docker-Agent-Version` | `<version>` (e.g. `dev`, `1.2.3`) | Always |
| `X-Docker-Desktop-Version` | e.g. `4.74.0` | Only when Docker Desktop is reachable on the host |

Operator-supplied headers in the agent config still win over these defaults — `SetIdentity` is called first, then caller headers.

## Why

Backends that receive built-in-tool traffic (Docker Hub APIs, Hub gateway, ...) want to attribute requests to a specific docker-agent install and the Docker Desktop version it's running alongside, the same way other Docker traffic is already attributed. `User-Agent` was the only signal so far and is brittle to parse.

## How

- New `pkg/useragent.SetIdentity(req)` is the single source of truth for these headers. All three built-in tools route through it, including the `robots.txt` fetch in the `fetch` tool.
- New `pkg/desktop.GetVersion(ctx)` reads `currentVersion` from Docker Desktop's `backend.sock` `/update` endpoint, with:
  - **5-minute TTL memoization** (`memoize.Call[string]`) — recovers automatically if Desktop starts after docker-agent or is upgraded mid-session, while still costing one socket call per tool request at most;
  - **2 s internal timeout** so a stale/missing socket can never stall a hot path;
  - returns `""` when Desktop isn't running, in which case the header is omitted.

No new dependencies (`go-memoize` and `go-cache` were already vendored).

## Privacy / security note

`X-Docker-Agent-Version` adds no information that `User-Agent` didn't already broadcast. `X-Docker-Desktop-Version` is genuinely new data sent to whichever host the operator configured. It's no more leaky than `User-Agent` is for `<goos>; <goarch>`, but if a privacy/opt-out mode is desired we can layer one on top later. Not adding one now keeps this PR focused.

## Tests

- `pkg/useragent`: pins User-Agent + `X-Docker-Agent-Version` on a fresh request.
- `api`, `fetch`, `openapi`: each existing header test now also asserts the two identity headers reach the test server.
- All tests in modified packages pass; `task lint` is clean.

## Commits

1. `feat: add identity headers for docker-agent and Docker Desktop tracking`
2. `refactor: use SetIdentity() in api tool`
3. `refactor: use SetIdentity() in fetch tool`
4. `refactor: use SetIdentity() in openapi tool`
5. `fix(desktop): make Desktop version lookup TTL-based and context-independent`
6. `refactor: simplify Desktop version lookup and useragent docs`
7. `refactor(desktop): plumb context through GetVersion`
