### PR TITLE
ci: skip image push in forked repositories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
           cache-to: type=gha,mode=min,scope=buildx
 
   build-and-push-image:
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && github.repository == 'docker/docker-agent'
     needs: [lint, build-and-test, license-check]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
           cache-to: type=gha,mode=min,scope=buildx
 
   build-and-push-image:
-    if: github.event_name != 'pull_request' && github.repository == 'docker/docker-agent'
+    if: github.event_name != 'pull_request' && !github.event.repository.fork
     needs: [lint, build-and-test, license-check]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
got notification about failing build job in my forked repo

<img width="978" height="110" alt="image" src="https://github.com/user-attachments/assets/d0e5a693-f7ce-40fd-abc0-43e1ac913d6a" />

<img width="548" height="290" alt="image" src="https://github.com/user-attachments/assets/94fcbb63-9b41-4c21-9b62-69804278fc27" />

this should be skipped while other jobs run as normal