### PR TITLE
fix(examples): use xai/grok-2-latest in grok.yaml

### DIFF
--- a/examples/grok.yaml
+++ b/examples/grok.yaml
@@ -2,7 +2,7 @@
 
 agents:
   root:
-    model: xai/grok-3-mini
+    model: xai/grok-2-latest
     description: A helpful AI assistant powered by Grok
     instruction: |
       You are Grok, a helpful and maximally truthful AI built by xAI.
@@ -12,6 +12,6 @@ agents:
 models:
   grok-model:
     provider: xai
-    model: grok-3-mini
+    model: grok-2-latest
     max_tokens: 131072
     temperature: 0.7


### PR DESCRIPTION
The example previously referenced `xai/grok-3-mini`, which is no longer present in the models.dev catalog (xAI now lists `grok-2*`, `grok-beta`, `grok-vision-beta`, `grok-4.*`, and `grok-imagine-*`). This caused `TestParseExamples` in `pkg/config` to fail.

Switch the example to `xai/grok-2-latest`, which is in the catalog.