### PR TITLE
runtime: skip auto-compaction for non-token overflow

### DIFF
--- a/pkg/runtime/loop_steps.go
+++ b/pkg/runtime/loop_steps.go
@@ -161,22 +161,42 @@ func (r *LocalRuntime) handleStreamError(
 	// request instead of surfacing raw errors. We allow at most
 	// r.maxOverflowCompactions consecutive attempts to avoid an infinite
 	// loop when compaction cannot reduce the context enough.
+	//
+	// Compaction only helps for token-count overflow ([OverflowKindTokens]):
+	// summarising older turns reduces the input token count.
+	//
+	// For wire-level overflow ([OverflowKindWire]) the request body itself
+	// is over the provider's cap; the latest turn alone is too large and
+	// would still have to be sent during compaction. For media overflow
+	// ([OverflowKindMedia]) we have no media-stripping path today, so a
+	// retry would resend the same oversized attachment. In both cases the
+	// recovery attempt always fails, so we skip it and surface the error
+	// directly — the user can act on it (smaller paste, smaller file)
+	// faster, without burning a second provider call.
 	if _, ok := errors.AsType[*modelerrors.ContextOverflowError](err); ok && r.sessionCompaction && *overflowCompactions < r.maxOverflowCompactions {
-		*overflowCompactions++
-		slog.WarnContext(ctx, "Context window overflow detected, attempting auto-compaction",
+		kind := modelerrors.OverflowKindOf(err)
+		if kind == modelerrors.OverflowKindTokens {
+			*overflowCompactions++
+			slog.WarnContext(ctx, "Context window overflow detected, attempting auto-compaction",
+				"agent", a.Name(),
+				"session_id", sess.ID,
+				"input_tokens", sess.InputTokens,
+				"output_tokens", sess.OutputTokens,
+				"context_limit", contextLimit,
+				"attempt", *overflowCompactions,
+			)
+			events.Emit(Warning(
+				"The conversation has exceeded the model's context window. Automatically compacting the conversation history...",
+				a.Name(),
+			))
+			r.compactWithReason(ctx, sess, "", compactionReasonOverflow, events)
+			return streamErrorRetry
+		}
+		slog.InfoContext(ctx, "Skipping auto-compaction for non-token overflow",
 			"agent", a.Name(),
 			"session_id", sess.ID,
-			"input_tokens", sess.InputTokens,
-			"output_tokens", sess.OutputTokens,
-			"context_limit", contextLimit,
-			"attempt", *overflowCompactions,
+			"overflow_kind", string(kind),
 		)
-		events.Emit(Warning(
-			"The conversation has exceeded the model's context window. Automatically compacting the conversation history...",
-			a.Name(),
-		))
-		r.compactWithReason(ctx, sess, "", compactionReasonOverflow, events)
-		return streamErrorRetry
 	}
 
 	streamSpan.RecordError(err)

--- a/pkg/runtime/loop_steps_test.go
+++ b/pkg/runtime/loop_steps_test.go
@@ -292,3 +292,75 @@ func TestHandleStreamError_GenericError_FatalAndEmitsError(t *testing.T) {
 	}
 	assert.True(t, sawError, "generic error should emit ErrorEvent")
 }
+
+// TestHandleStreamError_WireOverflowSkipsCompaction verifies that wire-level
+// overflow does not trigger auto-compaction. Compaction would resend the same
+// oversized request that just got rejected, so it is guaranteed to fail; we
+// surface the error directly instead.
+func TestHandleStreamError_WireOverflowSkipsCompaction(t *testing.T) {
+	t.Parallel()
+
+	rt, a := newTestRuntime(t)
+	sess := session.New()
+	events := make(chan Event, 16)
+	_, sp := noop.NewTracerProvider().Tracer("t").Start(t.Context(), "x")
+
+	overflow := &modelerrors.ContextOverflowError{
+		Underlying: errors.New("HTTP 413: Payload Too Large"),
+		Kind:       modelerrors.OverflowKindWire,
+	}
+	overflowCount := 0
+
+	outcome := rt.handleStreamError(t.Context(), sess, a, overflow, 1000, &overflowCount, sp, NewChannelSink(events))
+
+	assert.Equal(t, streamErrorFatal, outcome, "wire overflow must not trigger compaction retry")
+	assert.Equal(t, 0, overflowCount, "wire overflow must not bump the compaction counter")
+
+	got := drainEvents(events)
+	var sawError bool
+	var sawWarning bool
+	var errCode string
+	for _, ev := range got {
+		switch e := ev.(type) {
+		case *ErrorEvent:
+			sawError = true
+			errCode = e.Code
+		case *WarningEvent:
+			sawWarning = true
+		}
+	}
+	assert.True(t, sawError, "wire overflow should emit an ErrorEvent")
+	assert.False(t, sawWarning, "wire overflow should not emit the compaction warning")
+	assert.Equal(t, ErrorCodeRequestTooLarge, errCode, "ErrorEvent.Code should distinguish wire overflow")
+}
+
+// TestHandleStreamError_MediaOverflowSkipsCompaction verifies the same skip
+// behaviour for media-size rejections. Without media-stripping during
+// compaction, the offending attachment would be resent and fail again.
+func TestHandleStreamError_MediaOverflowSkipsCompaction(t *testing.T) {
+	t.Parallel()
+
+	rt, a := newTestRuntime(t)
+	sess := session.New()
+	events := make(chan Event, 16)
+	_, sp := noop.NewTracerProvider().Tracer("t").Start(t.Context(), "x")
+
+	overflow := &modelerrors.ContextOverflowError{
+		Underlying: errors.New("image exceeds 5 MB maximum"),
+		Kind:       modelerrors.OverflowKindMedia,
+	}
+	overflowCount := 0
+
+	outcome := rt.handleStreamError(t.Context(), sess, a, overflow, 1000, &overflowCount, sp, NewChannelSink(events))
+
+	assert.Equal(t, streamErrorFatal, outcome, "media overflow must not trigger compaction retry")
+	assert.Equal(t, 0, overflowCount, "media overflow must not bump the compaction counter")
+
+	var errCode string
+	for _, ev := range drainEvents(events) {
+		if e, ok := ev.(*ErrorEvent); ok {
+			errCode = e.Code
+		}
+	}
+	assert.Equal(t, ErrorCodeMediaTooLarge, errCode, "ErrorEvent.Code should distinguish media overflow")
+}


### PR DESCRIPTION
Stacked on #2818. Review after that one merges.


When a request is rejected because the **whole request body** is too big to send (e.g. HTTP 413, large paste, oversized attachment), the runtime today reacts the same way it reacts to a token-count overflow: it tries to recover by compacting the conversation.

Compaction is itself a model call. It has to send the same conversation history that just got rejected, including the oversized turn. So that call is rejected too. Then the runtime gives up — but only after burning a second provider call and several seconds of wall-clock latency, and the user sees a *"context window exceeded — try /compact"* message that is actively wrong (compaction is exactly what just failed, and starting a new session is the only thing that helps).

The same trap applies to media-size rejections: there is no media-stripping path during compaction yet, so the offending attachment gets resent and the compaction call fails the same way.


```
Today                                       After this change
─────                                       ─────────────────
User sends an oversized message             User sends an oversized message
   │                                           │
   ▼                                           ▼
Provider → wire-level rejection             Provider → wire-level rejection
   │                                           │
   ▼                                           ▼
"context overflow" → start compaction       Recognise: compaction cannot help
   │                                           │
   ▼                                           ▼
Compaction model call                       Skip compaction entirely
   │   (with same oversized history)           │
   ▼                                           ▼
Rejected again, same reason                 Emit a specific, actionable error
   │                                           │
   ▼                                           ▼
Give up; show "context window exceeded"     User sees the right message

```

## What this change achieves

- A wire-level overflow (request body too large) is surfaced immediately with the structured error code introduced in #2818, instead of being routed through a compaction attempt that is guaranteed to fail.
- A media-size overflow is treated the same way, because the current compaction path cannot remove the offending attachment.
- Token-count overflow — the case compaction actually helps — is unchanged. Auto-compaction still fires there, with the same limits and the same retry semantics as before.

