### PR TITLE
server: load initial source asynchronously so /api/ping is responsive immediately

### DIFF
--- a/pkg/server/source_loader.go
+++ b/pkg/server/source_loader.go
@@ -13,12 +13,19 @@ type sourceLoader struct {
 	inner           config.Source
 	refreshInterval time.Duration
 
+	// ready is closed when the first load attempt has completed (whether it
+	// produced data, an error, or was cancelled). Read blocks on this so
+	// callers never observe the pre-load (nil, nil) state, preserving the
+	// contract of the previous synchronous-constructor implementation.
+	ready chan struct{}
+
 	mu   sync.RWMutex
 	data []byte
 	err  error
 }
 
 // NewSourceLoader creates a new source loader that caches and periodically refreshes a config source.
+// The initial load runs in a goroutine; callers of Read block until the first load completes.
 func NewSourceLoader(ctx context.Context, inner config.Source, refreshInterval time.Duration) *sourceLoader {
 	return newSourceLoader(ctx, inner, refreshInterval)
 }
@@ -27,9 +34,19 @@ func newSourceLoader(ctx context.Context, inner config.Source, refreshInterval t
 	sl := &sourceLoader{
 		inner:           inner,
 		refreshInterval: refreshInterval,
+		ready:           make(chan struct{}),
 	}
 
-	sl.load(ctx)
+	// Run the initial load asynchronously so the constructor returns
+	// immediately. This lets the HTTP server start serving non-source
+	// endpoints (e.g. /api/ping, /health) while a potentially slow OCI
+	// pull or HTTPS GET is still in flight. Endpoints that need the
+	// source content (getAgents, createSession, ...) block in Read
+	// until this load finishes.
+	go func() {
+		defer close(sl.ready)
+		sl.load(ctx)
+	}()
 
 	if refreshInterval > 0 {
 		go sl.refreshLoop(ctx)
@@ -46,7 +63,16 @@ func (sl *sourceLoader) ParentDir() string {
 	return sl.inner.ParentDir()
 }
 
-func (sl *sourceLoader) Read(_ context.Context) ([]byte, error) {
+// Read returns the latest cached data, blocking until the first load attempt
+// has completed or ctx is cancelled. Once the first load has finished, Read
+// returns the cached data/err snapshot without further blocking; the
+// background refreshLoop is responsible for keeping the snapshot fresh.
+func (sl *sourceLoader) Read(ctx context.Context) ([]byte, error) {
+	select {
+	case <-sl.ready:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 	sl.mu.RLock()
 	defer sl.mu.RUnlock()
 	return sl.data, sl.err

--- a/pkg/server/source_loader_test.go
+++ b/pkg/server/source_loader_test.go
@@ -68,7 +68,8 @@ func TestSourceLoader_Read_WithRefreshInterval_BeforeExpiry(t *testing.T) {
 		refreshInterval := 100 * time.Millisecond
 		sl := newSourceLoader(ctx, inner, refreshInterval)
 
-		// Read should return cached data immediately
+		// Read blocks until the asynchronous initial load completes, then
+		// returns the cached data.
 		data, err := sl.Read(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, []byte("test data"), data)
@@ -115,14 +116,12 @@ func TestSourceLoader_Read_Error(t *testing.T) {
 	ctx := t.Context()
 	sl := newSourceLoader(ctx, inner, 0)
 
-	// Initial load failed
-	assert.Equal(t, 1, inner.getReadCount())
-
-	// Read should return the error from initial load
+	// Read blocks on the initial load and returns its error.
 	data, err := sl.Read(ctx)
 	require.Error(t, err)
 	assert.Equal(t, expectedErr, err)
 	assert.Nil(t, data)
+	assert.Equal(t, 1, inner.getReadCount())
 }
 
 func TestSourceLoader_Read_DataChanges(t *testing.T) {
@@ -169,17 +168,19 @@ func TestSourceLoader_Read_ZeroRefreshInterval(t *testing.T) {
 	ctx := t.Context()
 	sl := newSourceLoader(ctx, inner, 0)
 
-	initialReadCount := inner.getReadCount()
+	// First Read blocks on and then drives the single initial load.
+	data, err := sl.Read(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("test data"), data)
+	require.Equal(t, 1, inner.getReadCount())
 
-	// Multiple reads with zero refresh interval
+	// Subsequent reads must not trigger any further Source.Read calls.
 	for range 10 {
 		data, err := sl.Read(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, []byte("test data"), data)
 	}
-
-	// All reads should return cached data from startup
-	assert.Equal(t, initialReadCount, inner.getReadCount())
+	assert.Equal(t, 1, inner.getReadCount())
 }
 
 func TestSourceLoader_SuccessThenError(t *testing.T) {
@@ -210,4 +211,108 @@ func TestSourceLoader_SuccessThenError(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, []byte("initial data"), data)
 	})
+}
+
+// slowSource blocks Read until the test releases it. It models a slow OCI
+// pull or HTTPS GET that would previously have blocked NewSessionManager.
+type slowSource struct {
+	name    string
+	release chan struct{}
+	data    []byte
+}
+
+func (s *slowSource) Name() string      { return s.name }
+func (s *slowSource) ParentDir() string { return "" }
+
+func (s *slowSource) Read(ctx context.Context) ([]byte, error) {
+	select {
+	case <-s.release:
+		return s.data, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// TestSourceLoader_ConstructorReturnsBeforeInitialLoad is the regression test
+// for the docker-agent-as-AI-backend startup hang: NewSourceLoader (and
+// therefore NewSessionManager and server.New) must return immediately, even
+// if the underlying Source.Read is slow. Endpoints that don't need source
+// data (notably /api/ping) can then start serving while the load is still
+// in flight.
+func TestSourceLoader_ConstructorReturnsBeforeInitialLoad(t *testing.T) {
+	t.Parallel()
+	inner := &slowSource{
+		name:    "slow.yaml",
+		release: make(chan struct{}),
+		data:    []byte("loaded data"),
+	}
+	ctx := t.Context()
+
+	constructorDone := make(chan struct{})
+	var sl *sourceLoader
+	go func() {
+		sl = newSourceLoader(ctx, inner, 0)
+		close(constructorDone)
+	}()
+
+	select {
+	case <-constructorDone:
+	case <-time.After(time.Second):
+		t.Fatal("newSourceLoader did not return while the source was still loading")
+	}
+
+	// Read should block until we release the underlying source.
+	readDone := make(chan struct {
+		data []byte
+		err  error
+	})
+	go func() {
+		data, err := sl.Read(ctx)
+		readDone <- struct {
+			data []byte
+			err  error
+		}{data, err}
+	}()
+
+	select {
+	case <-readDone:
+		t.Fatal("Read returned before the initial load completed")
+	case <-time.After(50 * time.Millisecond):
+		// Expected: Read is waiting on sl.ready
+	}
+
+	close(inner.release)
+
+	select {
+	case result := <-readDone:
+		require.NoError(t, result.err)
+		assert.Equal(t, []byte("loaded data"), result.data)
+	case <-time.After(time.Second):
+		t.Fatal("Read did not unblock after the initial load completed")
+	}
+}
+
+// TestSourceLoader_ReadCancelledByContext verifies that a caller of Read
+// can give up if the initial load is taking too long, without leaking the
+// loader's background goroutine.
+func TestSourceLoader_ReadCancelledByContext(t *testing.T) {
+	t.Parallel()
+	inner := &slowSource{
+		name:    "slow.yaml",
+		release: make(chan struct{}),
+		data:    []byte("loaded data"),
+	}
+	loaderCtx, cancelLoader := context.WithCancel(t.Context())
+	defer cancelLoader()
+	sl := newSourceLoader(loaderCtx, inner, 0)
+
+	readCtx, cancelRead := context.WithCancel(t.Context())
+	cancelRead()
+
+	data, err := sl.Read(readCtx)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, data)
+
+	// Let the loader's goroutine finish so we don't leak it across tests.
+	close(inner.release)
 }


### PR DESCRIPTION
### What this PR does

`newSourceLoader` calls `sl.load(ctx)` **synchronously** in the constructor. `NewSessionManager` waits on every source's constructor, and `cmd/root/api.go:runAPICommand` waits on `NewSessionManager` before calling `s.Serve(ctx, ln)`. So if `Source.Read` does network I/O — an OCI pull, an HTTPS fetch, a slow registry, etc. — nothing else in the agent runs until that finishes, including the `Accept()` loop that would answer `/api/ping` or `/health`.

That means an embedding client which probes `/api/ping` with a bounded timeout after spawning `docker-agent serve api …` may give up and kill the process even though the binary is perfectly healthy — it just hasn't reached `s.Serve` yet because the initial source load is still in flight.

```
   BEFORE                                       AFTER
   ──────                                       ─────
   newListener()       ◄── listener visible     newListener()
   NewSessionManager                            NewSessionManager
     newSourceLoader                              newSourceLoader
       sl.load(ctx)    ◄── 🛑 blocks here          go sl.load(ctx)   ◄── async
                          (network I/O,             return immediately
                           cold cache, etc.)
                                               s.Serve(ctx, ln)   ◄── Accept()
   s.Serve(ctx, ln)    ◄── Accept() starts                              starts NOW
                          here, possibly                                /api/ping is
                          after the client's                            answerable in ms
                          probe timeout

   /api/ping → timeout                          /api/ping → 200 OK
   /api/agents → ready immediately              /api/agents → blocks in Read
                                                  until first load completes
                                                  (or ctx is cancelled)
```

### Implementation

- `sourceLoader` gains a `ready chan struct{}` that is closed once the first load completes (whether it succeeded, failed, or was cancelled).
- The initial load runs in a goroutine inside `newSourceLoader`, so the constructor returns immediately.
- `Read(ctx)` now blocks on `<-sl.ready` or `<-ctx.Done()` before returning the cached snapshot. Callers that don't want to wait can pass a short-deadline context.

This preserves the previous Read contract — when `Read` returns, the data is either valid or there's an error — so existing consumers (`getAgents`, `getAgentConfig`, `createSession`, etc.) do not need any changes.

