### PR TITLE
perf(tui): only render visible session rows in /sessions dialog

### DIFF
--- a/pkg/tui/dialog/session_browser.go
+++ b/pkg/tui/dialog/session_browser.go
@@ -253,6 +253,9 @@ func (d *sessionBrowserDialog) filterSessions() {
 	if d.selected >= len(d.filtered) {
 		d.selected = max(0, len(d.filtered)-1)
 	}
+	// Keep the scrollview's totalHeight in sync so EnsureLineVisible and the
+	// scrollbar clamp correctly even before View() runs.
+	d.scrollview.SetContent(nil, len(d.filtered))
 	d.scrollview.SetScrollOffset(0)
 }
 
@@ -285,13 +288,6 @@ func (d *sessionBrowserDialog) View() string {
 	dialogWidth, _, contentWidth := d.dialogSize()
 	d.textInput.SetWidth(contentWidth)
 
-	// Build all session lines
-	var allLines []string
-	for i, sess := range d.filtered {
-		allLines = append(allLines, d.renderSession(sess, i == d.selected, contentWidth))
-	}
-
-	// Configure scrollview and let it handle slicing + rendering
 	regionWidth := contentWidth + d.scrollview.ReservedCols()
 	visibleLines := d.scrollview.VisibleHeight()
 
@@ -299,10 +295,16 @@ func (d *sessionBrowserDialog) View() string {
 	dialogRow, dialogCol := d.Position()
 	d.scrollview.SetPosition(dialogCol+3, dialogRow+sessionBrowserListStartY)
 
-	d.scrollview.SetContent(allLines, len(allLines))
+	// Tell the scrollview the total content height and re-clamp the offset
+	// against it. Pass nil for lines because we render only the visible
+	// window below — rendering every row on every keystroke is the dominant
+	// cost when there are many sessions.
+	total := len(d.filtered)
+	d.scrollview.SetContent(nil, total)
+	d.scrollview.SetScrollOffset(d.scrollview.ScrollOffset())
 
 	var scrollableContent string
-	if len(d.filtered) == 0 {
+	if total == 0 {
 		// Empty state: render manually so "No sessions found" is centered
 		emptyLines := []string{"", styles.DialogContentStyle.
 			Italic(true).Align(lipgloss.Center).Width(contentWidth).
@@ -312,7 +314,13 @@ func (d *sessionBrowserDialog) View() string {
 		}
 		scrollableContent = d.scrollview.ViewWithLines(emptyLines)
 	} else {
-		scrollableContent = d.scrollview.View()
+		offset := d.scrollview.ScrollOffset()
+		end := min(offset+visibleLines, total)
+		windowLines := make([]string, 0, end-offset)
+		for i := offset; i < end; i++ {
+			windowLines = append(windowLines, d.renderSession(d.filtered[i], i == d.selected, contentWidth))
+		}
+		scrollableContent = d.scrollview.ViewWithLines(windowLines)
 	}
 
 	// Build title with session count and optional star-filter indicator.

--- a/pkg/tui/dialog/session_browser.go
+++ b/pkg/tui/dialog/session_browser.go
@@ -295,10 +295,11 @@ func (d *sessionBrowserDialog) View() string {
 	dialogRow, dialogCol := d.Position()
 	d.scrollview.SetPosition(dialogCol+3, dialogRow+sessionBrowserListStartY)
 
-	// Tell the scrollview the total content height and re-clamp the offset
-	// against it. Pass nil for lines because we render only the visible
-	// window below — rendering every row on every keystroke is the dominant
-	// cost when there are many sessions.
+	// Tell the scrollview the total content height; pass nil for lines
+	// because we render only the visible window below. Rendering every row
+	// on every keystroke is the dominant cost when there are many sessions.
+	// The follow-up SetScrollOffset call re-clamps the offset against the
+	// (possibly shrunk) total — it is intentionally not a no-op.
 	total := len(d.filtered)
 	d.scrollview.SetContent(nil, total)
 	d.scrollview.SetScrollOffset(d.scrollview.ScrollOffset())


### PR DESCRIPTION
The `/sessions` dialog was visibly slow when scrolling or moving the
selection with arrow keys, especially with a large session history.

Every render of `sessionBrowserDialog.View()` was pre-rendering **all**
filtered session rows into styled lines (two `lipgloss.Style.Render`
calls plus string concatenation per row), even though the scrollview
only displays a small visible window. With hundreds of sessions, every
keystroke and scroll tick incurred hundreds of style renders before
the scrollview sliced the result down to the viewport.

The scrollview already exposes `ViewWithLines(visible)` for the
virtualised case (used by `picker.go` and `working_dir_picker.go`).
This change uses it to render only `[offset, offset+visibleHeight)`,
making render cost O(visible rows) (~10–20) instead of O(total
sessions).

`filterSessions` also now calls `SetContent(nil, len(filtered))` so
the scrollview's `totalHeight` is always in sync — this fixes a
latent bug where `EnsureLineVisible` (called on Up/Down keypress)
could clamp against a stale `totalHeight` between a filter change and
the next `View()`.