### PR TITLE
docs: align CLI/serve flag docs with source and bump schema to v9

### DIFF
--- a/docs/configuration/overview/index.md
+++ b/docs/configuration/overview/index.md
@@ -16,7 +16,7 @@ A docker-agent config has these main sections:
 
 ```bash
 # 1. Version — configuration schema version (optional but recommended)
-version: 8
+version: 9
 
 # 2. Metadata — optional agent metadata for distribution
 metadata:
@@ -225,10 +225,10 @@ For YAML editor autocompletion and validation, use the [Docker Agent JSON Schema
 
 ## Config Versioning
 
-docker-agent configs are versioned. The current version is `8`. Add the version at the top of your config:
+docker-agent configs are versioned. The current version is `9`. Add the version at the top of your config:
 
 ```yaml
-version: 8
+version: 9
 
 agents:
   root:
@@ -236,7 +236,7 @@ agents:
     # ...
 ```
 
-When you load an older config, docker-agent automatically migrates it to the latest schema. It's recommended to include the version to ensure consistent behavior.
+When you load an older config, docker-agent automatically migrates it to the latest schema. Frozen parsers exist for every previous version (`v0` through `v8`) under `pkg/config/`, so older configs keep working unchanged. It is still recommended to pin the version explicitly to ensure consistent behavior.
 
 ## Metadata Section
 

--- a/docs/features/a2a/index.md
+++ b/docs/features/a2a/index.md
@@ -34,20 +34,21 @@ $ docker agent serve a2a agentcatalog/pirate
 
 ## Flags
 
-| Flag                              | Default          | Description                                                                                                          |
-| --------------------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `-l, --listen <addr>`             | `127.0.0.1:8082` | Address to listen on.                                                                                                |
-| `-a, --agent <name>`              | `root`           | Name of the agent to expose when the config contains multiple agents.                                                |
-| `--working-dir <path>`            | current dir      | Working directory the agent runs in.                                                                                 |
-| `--env-from-file <file>`          | (none)           | Load additional environment variables from a `.env` file (repeatable).                                               |
-| `--models-gateway <url>`          | (none)           | Route all provider traffic through a models gateway URL.                                                             |
-| `--code-mode-tools`               | `false`          | Expose tools as a single "code" toolset that accepts a JavaScript snippet to run.                                    |
-| `--hook-pre-tool-use <cmd>`       | (none)           | Add a pre-tool-use hook (repeatable). See [Hooks]({{ '/configuration/hooks/' | relative_url }}).                     |
-| `--hook-post-tool-use <cmd>`      | (none)           | Add a post-tool-use hook (repeatable).                                                                               |
-| `--hook-session-start <cmd>`      | (none)           | Add a session-start hook (repeatable).                                                                               |
-| `--hook-session-end <cmd>`        | (none)           | Add a session-end hook (repeatable).                                                                                 |
-| `--hook-on-user-input <cmd>`      | (none)           | Add an on-user-input hook (repeatable).                                                                              |
-| `--hook-stop <cmd>`               | (none)           | Add a stop hook, fired when the model finishes responding (repeatable).                                              |
+| Flag                              | Default                | Description                                                                                                          |
+| --------------------------------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `-l, --listen <addr>`             | `127.0.0.1:8082`       | Address to listen on.                                                                                                |
+| `-a, --agent <name>`              | (team default)         | Name of the agent to expose. Defaults to the team's first agent if the config contains multiple.                     |
+| `-s, --session-db <path>`         | `~/.cagent/session.db` | Path to the SQLite session database.                                                                                 |
+| `--working-dir <path>`            | current dir            | Working directory the agent runs in.                                                                                 |
+| `--env-from-file <file>`          | (none)                 | Load additional environment variables from a `.env` file (repeatable).                                               |
+| `--models-gateway <url>`          | (none)                 | Route all provider traffic through a models gateway URL.                                                             |
+| `--code-mode-tools`               | `false`                | Expose tools as a single "code" toolset that accepts a JavaScript snippet to run.                                    |
+| `--hook-pre-tool-use <cmd>`       | (none)                 | Add a pre-tool-use hook (repeatable). See [Hooks]({{ '/configuration/hooks/' | relative_url }}).                     |
+| `--hook-post-tool-use <cmd>`      | (none)                 | Add a post-tool-use hook (repeatable).                                                                               |
+| `--hook-session-start <cmd>`      | (none)                 | Add a session-start hook (repeatable).                                                                               |
+| `--hook-session-end <cmd>`        | (none)                 | Add a session-end hook (repeatable).                                                                                 |
+| `--hook-on-user-input <cmd>`      | (none)                 | Add an on-user-input hook (repeatable).                                                                              |
+| `--hook-stop <cmd>`               | (none)                 | Add a stop hook, fired when the model finishes responding (repeatable).                                              |
 
 ## Features
 

--- a/docs/features/api-server/index.md
+++ b/docs/features/api-server/index.md
@@ -162,6 +162,7 @@ docker agent serve api <agent-file>|<agents-dir> [flags]
 | `-l, --listen`     | `127.0.0.1:8080` | Address to listen on                             |
 | `-s, --session-db` | `session.db`     | Path to the SQLite session database              |
 | `--pull-interval`  | `0` (disabled)   | Auto-pull OCI reference every N minutes          |
+| `--auth-token`     | (none)           | Bearer token clients must present in the `Authorization: Bearer <token>` header. Empty disables authentication. |
 | `--fake`           | (none)           | Replay AI responses from cassette file (testing) |
 | `--record`         | (none)           | Record AI API interactions to cassette file      |
 

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -29,6 +29,7 @@ $ docker agent run [config] [message...] [flags]
 | --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
 | `-a, --agent <name>`                    | Run a specific agent from the config                                                                                                      |
 | `--yolo`                                | Auto-approve all tool calls                                                                                                               |
+| `--exec`                                | Run without a TUI (headless mode). See [`docker agent run --exec`](#docker-agent-run---exec) below.                                       |
 | `--model <ref>`                         | Override model(s). Use `provider/model` for all agents, or `agent=provider/model` for specific agents. Comma-separate multiple overrides. |
 | `--session <id>`                        | Resume a previous session. Supports relative refs (`-1` = last, `-2` = second to last)                                                    |
 | `-s, --session-db <path>`               | Path to the SQLite session database (default: `~/.cagent/session.db`)                                                                     |
@@ -46,6 +47,7 @@ $ docker agent run [config] [message...] [flags]
 | `--working-dir <path>`                  | Set the working directory for the session (applies to tools and relative paths)                                                           |
 | `--env-from-file <path>`                | Load environment variables from file (repeatable)                                                                                         |
 | `--code-mode-tools`                     | Provide a single tool to call other tools via JavaScript (forces code-mode tools globally)                                                |
+| `--on-event <type>=<cmd>`               | Run a shell command when an event fires (e.g. `--on-event tool_call=./log.sh`, or `*=<cmd>` for any). Repeatable.                          |
 | `--models-gateway <addr>`               | Route model traffic through a gateway. Also reads `DOCKER_AGENT_MODELS_GATEWAY` (legacy `CAGENT_MODELS_GATEWAY`) env var.                  |
 | `--hook-pre-tool-use <cmd>`             | Add a pre-tool-use hook command (repeatable). See [Hooks]({{ '/configuration/hooks/' | relative_url }}).                                  |
 | `--hook-post-tool-use <cmd>`            | Add a post-tool-use hook command (repeatable)                                                                                             |
@@ -99,13 +101,23 @@ $ docker agent run --exec agent.yaml "question 1" "question 2" "question 3"
 
 ### `docker agent new`
 
-Interactively generate a new agent configuration file.
+Interactively generate a new agent configuration file. Optionally pass a free-text description as a positional argument to skip the initial prompt.
 
 ```bash
-$ docker agent new [flags]
+$ docker agent new [description] [flags]
+```
 
+| Flag                   | Default | Description                                                                                                                                          |
+| ---------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--model <ref>`        | (auto)  | Model to use, optionally as `provider/model` where provider is `anthropic`, `openai`, `google`, or `dmr`. If omitted, picks based on available credentials or gateway. |
+| `--max-iterations <n>` | `0`     | Maximum number of agentic loop iterations to prevent infinite loops. `0` means use the default (20 for DMR, unlimited for other providers).          |
+
+All [runtime configuration flags](#runtime-configuration-flags) are also accepted.
+
+```bash
 # Examples
 $ docker agent new
+$ docker agent new "a web scraper that extracts product prices"
 $ docker agent new --model openai/gpt-5-mini
 $ docker agent new --model dmr/ai/gemma3-qat:12B --max-iterations 15
 ```
@@ -145,6 +157,7 @@ $ docker agent serve api <agent-file>|<agents-dir>|<registry-ref> [flags]
 | `-l, --listen <addr>`      | `127.0.0.1:8080`   | Address to listen on.                                                                                      |
 | `-s, --session-db <path>`  | `session.db`       | Path to the SQLite session database (relative paths resolve against the working directory).                |
 | `--pull-interval <minutes>`| `0`                | Periodically re-pull OCI/URL references and refresh the agent definition. `0` disables auto-pull.          |
+| `--auth-token <token>`     | (none)             | Bearer token clients must present in the `Authorization: Bearer <token>` header. Empty disables auth.      |
 | `--fake <path>`             | (none)             | Replay AI responses from a cassette file (for testing). Mutually exclusive with `--record`.               |
 | `--record [path]`           | (none)             | Record AI API interactions to a cassette file.                                                            |
 
@@ -173,6 +186,9 @@ $ docker agent serve mcp <config> [flags]
 | `-a, --agent <name>`   | (all agents)       | Name of the agent to expose. If omitted, every agent in the config is exposed as a separate tool. |
 | `--http`               | `false`            | Use streaming HTTP transport instead of stdio.                                                    |
 | `-l, --listen <addr>`  | `127.0.0.1:8081`   | Address to listen on (only used with `--http`).                                                   |
+| `--attach [target]`    | (none)             | Attach to a running TUI run by pid, address, or session id. Pass without a value to attach to the most recent run. When set, the agent file argument can be omitted. |
+| `--tool-name <name>`   | (agent name)       | Override the MCP tool identifier clients call. Only valid when exposing a single agent.           |
+| `--mcp-keepalive <dur>`| `0` (disabled)     | Interval between MCP keep-alive pings (e.g. `30s`).                                              |
 
 All [runtime configuration flags](#runtime-configuration-flags) are also accepted.
 
@@ -194,10 +210,11 @@ Start an A2A (Agent-to-Agent) protocol server.
 $ docker agent serve a2a <config> [flags]
 ```
 
-| Flag                   | Default            | Description                                                                                |
-| ---------------------- | ------------------ | ------------------------------------------------------------------------------------------ |
-| `-a, --agent <name>`   | (team default)     | Name of the agent to run. Defaults to the team's first agent if not specified.             |
-| `-l, --listen <addr>`  | `127.0.0.1:8082`   | Address to listen on.                                                                       |
+| Flag                      | Default                | Description                                                                                |
+| ------------------------- | ---------------------- | ------------------------------------------------------------------------------------------ |
+| `-a, --agent <name>`      | (team default)         | Name of the agent to run. Defaults to the team's first agent if not specified.             |
+| `-l, --listen <addr>`     | `127.0.0.1:8082`       | Address to listen on.                                                                       |
+| `-s, --session-db <path>` | `~/.cagent/session.db` | Path to the SQLite session database.                                                        |
 
 All [runtime configuration flags](#runtime-configuration-flags) are also accepted.
 

--- a/docs/features/evaluation/index.md
+++ b/docs/features/evaluation/index.md
@@ -170,6 +170,8 @@ $ docker agent eval <agent-file>|<registry-ref> [<eval-dir>|./evals]
 | `-e, --env`         | (none)                      | Environment variables to pass to container (`KEY` or `KEY=VALUE`) |
 | `--repeat`          | `1`                         | Number of times to repeat each evaluation (useful for computing baselines) |
 
+All [runtime configuration flags]({{ '/features/cli/#runtime-configuration-flags' | relative_url }}) (`--working-dir`, `--env-from-file`, `--models-gateway`, `--hook-*`, …) are also accepted.
+
 ## Output
 
 After a run completes, docker-agent produces:

--- a/docs/features/mcp-mode/index.md
+++ b/docs/features/mcp-mode/index.md
@@ -56,6 +56,7 @@ $ docker agent serve mcp ./agent.yaml --http --listen 0.0.0.0:9090
 | `--http`               | `false`            | Use streaming HTTP transport instead of stdio.                                                               |
 | `-l`, `--listen`       | `127.0.0.1:8081`   | Address to listen on when `--http` is enabled.                                                               |
 | `-a`, `--agent`        | all agents         | Expose a single named agent instead of every agent in the config.                                            |
+| `--attach [target]`    | (none)             | Attach to a running TUI run by pid, address, or session id. Pass without a value to attach to the most recent run. When set, the agent file argument can be omitted. |
 | `--tool-name`          | (none)             | Override the MCP tool identifier clients call (defaults to agent name); only valid when exposing one agent.  |
 | `--mcp-keepalive`      | `0`                | Interval between MCP keep-alive pings (e.g. `30s`); `0` disables keep-alive.                                 |
 

--- a/docs/getting-started/installation/index.md
+++ b/docs/getting-started/installation/index.md
@@ -37,10 +37,10 @@ Install docker-agent using [Homebrew](https://brew.sh/):
 $ brew install docker-agent
 
 # Verify
-$ docker-agent version
+$ docker agent version
 ```
 
-You can also install docker-agent as a docker CLI plugin, by copying `docker-agent` binary in `~/.docker/cli-plugins`. You can then run `docker agent version`.
+Homebrew installs docker-agent as a Docker CLI plugin (under `~/.docker/cli-plugins/`), so the canonical invocation is `docker agent`. If you prefer the standalone command, the binary is also exposed on your `PATH` as `docker-agent`.
 
 ## Download Binary Releases
 
@@ -55,7 +55,7 @@ ARCH=$(uname -m); case "$ARCH" in x86_64) ARCH=amd64;; aarch64) ARCH=arm64;; esa
 curl -L "https://github.com/docker/docker-agent/releases/latest/download/docker-agent-${OS}-${ARCH}" -o docker-agent
 chmod +x docker-agent
 sudo mv docker-agent /usr/local/bin/
-docker-agent version
+docker-agent version  # standalone binary on PATH
 
 # or alternatively, instead of moving to /usr/local/bin:
 mkdir -p ~/.docker/cli-plugins

--- a/docs/guides/tips/index.md
+++ b/docs/guides/tips/index.md
@@ -229,7 +229,7 @@ permissions:
 
 ```bash
 # Run with sandbox enabled
-docker-agent run --sandbox agent.yaml
+docker agent run --sandbox agent.yaml
 ```
 
 ### Set Global Permission Guardrails


### PR DESCRIPTION
## Summary

Documentation-only changes. Aligns the docs with the actual implementation in `cmd/root/*.go` and `pkg/config/`. No source code is touched.

### Schema version
- `docs/configuration/overview/index.md` bumped from `version: 8` to `version: 9` (matches `pkg/config/latest/types.go`).
- Refreshed the versioning paragraph to mention the frozen `v0`–`v8` parsers.

### Canonical CLI invocation
- Picked `docker agent` (with space) as the canonical user-facing form across docs (matches the README and Cobra plugin behaviour).
- `docs/getting-started/installation/index.md`: clarified that Homebrew installs as a CLI plugin (`docker agent`) while the standalone binary on `PATH` is invoked as `docker-agent`.
- `docs/guides/tips/index.md`: replaced `docker-agent run` with `docker agent run` in the sandbox example.
- The legacy `cagent` filesystem paths (`~/.cagent/`, `~/.config/cagent/`, `CAGENT_*` env vars) were intentionally left untouched — those are still real on-disk identifiers in the binary.

### Flag-table fixes (cross-checked against `cmd/root/*.go`)
- `docker agent run`: added `--exec`, `--on-event`.
- `docker agent new`: added a flag table (`--model`, `--max-iterations`); positional `[description]` arg now documented.
- `docker agent serve api`: added `--auth-token` (both in the CLI reference and the dedicated API server page).
- `docker agent serve mcp`: added `--attach`, `--tool-name`, `--mcp-keepalive` (CLI reference + MCP feature page).
- `docker agent serve a2a`: added `-s, --session-db`; corrected `-a, --agent` description (defaults to the team's default agent, not literally `root`).
- `docker agent eval`: added a note that all runtime configuration flags (`--working-dir`, `--env-from-file`, `--models-gateway`, `--hook-*`) are accepted (these are inherited via `addRuntimeConfigFlags`).

### Validation
- `task lint` — clean (0 issues, no offenses, go.mod tidy).
- `task test` — all packages pass.
- All modified Markdown files parse cleanly with kramdown+GFM (the engine GitHub Pages uses); no broken in-page anchors.

### Files changed (8)
```
docs/configuration/overview/index.md       |  8 ++++----
docs/features/a2a/index.md                 | 29 +++++++++++++++--------------
docs/features/api-server/index.md          |  1 +
docs/features/cli/index.md                 | 29 +++++++++++++++++++++++------
docs/features/evaluation/index.md          |  2 ++
docs/features/mcp-mode/index.md            |  1 +
docs/getting-started/installation/index.md |  6 +++---
docs/guides/tips/index.md                  |  2 +-
```