### PR TITLE
docs(memory): fix incorrect default database path placeholder

### DIFF
--- a/docs/tools/memory/index.md
+++ b/docs/tools/memory/index.md
@@ -12,7 +12,7 @@ _Persistent key-value storage backed by SQLite for cross-session recall._
 
 The memory tool provides persistent key-value storage backed by SQLite. Data survives across sessions, allowing agents to remember facts, user preferences, project context, and past decisions. Memories can be organized with categories and searched by keyword.
 
-Each agent gets its own database at `~/.cagent/memory/<agent-name>/memory.db` by default.
+By default, the database is stored at `~/.cagent/memory/<config-name>/memory.db`, where `<config-name>` is derived from the loaded configuration (typically the YAML file name) and falls back to `default` when unavailable. Agents declared in the same configuration share this database by default; set an explicit `path` per toolset to isolate them.
 
 ## Available Tools
 
@@ -35,7 +35,7 @@ toolsets:
 
 | Property | Type   | Default                                   | Description                      |
 | -------- | ------ | ----------------------------------------- | -------------------------------- |
-| `path`   | string | `~/.cagent/memory/<agent-name>/memory.db` | Path to the SQLite database file |
+| `path`   | string | `~/.cagent/memory/<config-name>/memory.db` | Path to the SQLite database file |
 
 ### Custom Database Path
 


### PR DESCRIPTION
## What

Fixes two occurrences of the default database path in `docs/tools/memory/index.md`. The documentation currently states that the default path is
`~/.cagent/memory/<agent-name>/memory.db`, but the actual implementation uses the **config name**, not the agent name.

## Why

In `pkg/tools/builtin/memory/memory.go`:

```go
if configName == "" {
    configName = "default"
}
validatedMemoryPath = filepath.Join(paths.GetDataDir(), "memory", configName, "memory.db")
```

`configName` is passed into `CreateToolSet` and corresponds to the loaded
configuration (typically the YAML file name), not the individual agent's
`name` field. As a result, multiple agents declared in the same YAML
configuration share the same SQLite database by default — which contradicts
the current wording "Each agent gets its own database".

This can be surprising for users who expect per-agent isolation and may
explain unexpected memory leakage between agents in the same config.

## Changes

- Replace `<agent-name>` with `<config-name>` in both the prose and the
  options table.
- Clarify that agents in the same configuration share the database by
  default, and that an explicit `path` is required to isolate them.

## How to verify

- Run an agent declared in `myconfig.yaml` with the memory toolset and no
  explicit `path`. The created DB is at
  `~/.cagent/memory/myconfig/memory.db` (not `~/.cagent/memory/<agent>/...`).
- Code references:
  - `pkg/tools/builtin/memory/memory.go` (`CreateToolSet`)
  - `pkg/paths/paths.go` (`GetDataDir`)