### PR TITLE
fix(openai): support Notion and Jira MCP tools with gpt-5 strict mode

### DIFF
--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -258,7 +258,7 @@ func (c *Client) CreateChatCompletionStream(
 		slog.DebugContext(ctx, "Adding tools to OpenAI request", "tool_count", len(requestTools))
 		toolsParam := make([]openai.ChatCompletionToolUnionParam, len(requestTools))
 		for i, tool := range requestTools {
-			parameters, err := ConvertParametersToSchema(tool.Parameters)
+			parameters, _, err := ConvertParametersToSchema(tool.Parameters)
 			if err != nil {
 				slog.DebugContext(ctx, "Failed to convert tool parameters to OpenAI schema", "tool_name", tool.Name, "error", err)
 				return nil, err
@@ -397,7 +397,7 @@ func (c *Client) CreateResponseStream(
 		slog.DebugContext(ctx, "Adding tools to OpenAI responses request", "tool_count", len(requestTools))
 		toolsParam := make([]responses.ToolUnionParam, len(requestTools))
 		for i, tool := range requestTools {
-			parameters, err := ConvertParametersToSchema(tool.Parameters)
+			parameters, strict, err := ConvertParametersToSchema(tool.Parameters)
 			if err != nil {
 				slog.DebugContext(ctx, "Failed to convert tool parameters to OpenAI schema", "tool_name", tool.Name, "error", err)
 				return nil, err
@@ -408,8 +408,12 @@ func (c *Client) CreateResponseStream(
 					Name:        tool.Name,
 					Description: param.NewOpt(tool.Description),
 					Parameters:  parameters,
-					Strict:      param.NewOpt(true),
+					Strict:      param.NewOpt(strict),
 				},
+			}
+
+			if !strict {
+				slog.DebugContext(ctx, "Tool not compatible with OpenAI strict mode, falling back", "tool_name", tool.Name)
 			}
 
 			slog.DebugContext(ctx, "Added tool to OpenAI responses request", "tool_name", tool.Name)

--- a/pkg/model/provider/openai/schema.go
+++ b/pkg/model/provider/openai/schema.go
@@ -9,12 +9,14 @@ import (
 	"github.com/docker/docker-agent/pkg/tools"
 )
 
-// ConvertParametersToSchema converts parameters to OpenAI Schema format.
-// It also returns whether the schema is compatible with strict mode.
-// Schemas that declare schema-form additionalProperties (e.g. Notion MCP)
-// are not strict-compatible: rewriting them to additionalProperties: false
-// would lose the dictionary value shape the model needs. The caller should
-// set Strict=false on the tool definition in that case.
+// ConvertParametersToSchema converts parameters to OpenAI Schema format and
+// reports whether the resulting schema is compatible with OpenAI strict mode.
+//
+// The same normalization pipeline runs in both cases — strict-incompatible
+// schemas (e.g. Notion MCP tools that declare schema-form additionalProperties)
+// still need fully-populated `required` arrays for the Chat Completions API,
+// which has no per-tool strict flag. The strict flag is only consumed by the
+// Responses API caller.
 func ConvertParametersToSchema(params any) (shared.FunctionParameters, bool, error) {
 	p, err := tools.SchemaToMap(params)
 	if err != nil {
@@ -22,37 +24,56 @@ func ConvertParametersToSchema(params any) (shared.FunctionParameters, bool, err
 	}
 
 	strict := isStrictCompatible(p)
-
-	if strict {
-		return fixSchemaArrayItems(removeFormatFields(ensureTypeFields(makeAllRequired(p)))), true, nil
-	}
-	return fixSchemaArrayItems(removeFormatFields(ensureTypeFields(p))), false, nil
+	return fixSchemaArrayItems(removeFormatFields(ensureTypeFields(makeAllRequired(p)))), strict, nil
 }
 
 // isStrictCompatible reports whether the schema can use OpenAI strict mode.
 // Strict mode requires every object node to have additionalProperties: false.
 // Schema-form additionalProperties (a map) and additionalProperties: true are
-// both incompatible.
+// both incompatible. The walk stops at the first incompatible node.
 func isStrictCompatible(schema map[string]any) bool {
-	compatible := true
-	walkSchema(schema, func(node map[string]any) {
-		if !compatible {
-			return
-		}
-		v, ok := node["additionalProperties"]
-		if !ok {
-			return
-		}
+	return !hasIncompatibleNode(schema)
+}
+
+func hasIncompatibleNode(node map[string]any) bool {
+	if v, ok := node["additionalProperties"]; ok {
 		switch t := v.(type) {
 		case map[string]any:
-			compatible = false
+			return true
 		case bool:
 			if t {
-				compatible = false
+				return true
 			}
 		}
-	})
-	return compatible
+	}
+
+	if properties, ok := node["properties"].(map[string]any); ok {
+		for _, v := range properties {
+			if sub, ok := v.(map[string]any); ok && hasIncompatibleNode(sub) {
+				return true
+			}
+		}
+	}
+
+	for _, keyword := range []string{"anyOf", "oneOf", "allOf"} {
+		if variants, ok := node[keyword].([]any); ok {
+			for _, v := range variants {
+				if sub, ok := v.(map[string]any); ok && hasIncompatibleNode(sub) {
+					return true
+				}
+			}
+		}
+	}
+
+	if items, ok := node["items"].(map[string]any); ok && hasIncompatibleNode(items) {
+		return true
+	}
+
+	if additionalProps, ok := node["additionalProperties"].(map[string]any); ok && hasIncompatibleNode(additionalProps) {
+		return true
+	}
+
+	return false
 }
 
 // walkSchema calls fn on the given schema node, then recursively walks into
@@ -88,9 +109,11 @@ func walkSchema(schema map[string]any, fn func(map[string]any)) {
 	}
 }
 
-// makeAllRequired enforces OpenAI strict mode: every object property is
-// listed in `required` (newly-required ones are made nullable) and every
-// object node has `additionalProperties: false`.
+// makeAllRequired makes every object property `required` (newly-required ones
+// are made nullable) and ensures every object node has `additionalProperties`
+// set. It runs on every schema regardless of strict-mode compatibility, so
+// schema-form additionalProperties (e.g. Notion's dictionary value shape) is
+// preserved — only missing/true/nil values are forced to `false`.
 func makeAllRequired(schema shared.FunctionParameters) shared.FunctionParameters {
 	if schema == nil {
 		schema = map[string]any{"type": "object", "properties": map[string]any{}}
@@ -114,8 +137,13 @@ func makeAllRequired(schema shared.FunctionParameters) shared.FunctionParameters
 			}
 		}
 
+		// Only force additionalProperties: false when it isn't already a
+		// schema. Schema-form additionalProperties carries information the
+		// model needs (Notion-style dictionaries) and would be lost otherwise.
 		if isObject {
-			node["additionalProperties"] = false
+			if addProps, exists := node["additionalProperties"]; !exists || addProps == nil || addProps == true {
+				node["additionalProperties"] = false
+			}
 		}
 
 		properties, ok := node["properties"].(map[string]any)

--- a/pkg/model/provider/openai/schema.go
+++ b/pkg/model/provider/openai/schema.go
@@ -30,7 +30,11 @@ func ConvertParametersToSchema(params any) (shared.FunctionParameters, bool, err
 // isStrictCompatible reports whether the schema can use OpenAI strict mode.
 // Strict mode requires every object node to have additionalProperties: false.
 // Schema-form additionalProperties (a map) and additionalProperties: true are
-// both incompatible. The walk stops at the first incompatible node.
+// both incompatible.
+//
+// The decision is per-tool and all-or-nothing: a single non-compliant node
+// anywhere in the schema disables strict mode for the whole tool. The walk
+// stops at the first incompatible node.
 func isStrictCompatible(schema map[string]any) bool {
 	return !hasIncompatibleNode(schema)
 }

--- a/pkg/model/provider/openai/schema.go
+++ b/pkg/model/provider/openai/schema.go
@@ -73,8 +73,12 @@ func hasIncompatibleNode(node map[string]any) bool {
 		return true
 	}
 
-	if additionalProps, ok := node["additionalProperties"].(map[string]any); ok && hasIncompatibleNode(additionalProps) {
-		return true
+	if prefixItems, ok := node["prefixItems"].([]any); ok {
+		for _, v := range prefixItems {
+			if sub, ok := v.(map[string]any); ok && hasIncompatibleNode(sub) {
+				return true
+			}
+		}
 	}
 
 	return false
@@ -105,6 +109,14 @@ func walkSchema(schema map[string]any, fn func(map[string]any)) {
 
 	if items, ok := schema["items"].(map[string]any); ok {
 		walkSchema(items, fn)
+	}
+
+	if prefixItems, ok := schema["prefixItems"].([]any); ok {
+		for _, v := range prefixItems {
+			if sub, ok := v.(map[string]any); ok {
+				walkSchema(sub, fn)
+			}
+		}
 	}
 
 	// additionalProperties can be a boolean or an object schema

--- a/pkg/model/provider/openai/schema.go
+++ b/pkg/model/provider/openai/schema.go
@@ -9,14 +9,50 @@ import (
 	"github.com/docker/docker-agent/pkg/tools"
 )
 
-// ConvertParametersToSchema converts parameters to OpenAI Schema format
-func ConvertParametersToSchema(params any) (shared.FunctionParameters, error) {
+// ConvertParametersToSchema converts parameters to OpenAI Schema format.
+// It also returns whether the schema is compatible with strict mode.
+// Schemas that declare schema-form additionalProperties (e.g. Notion MCP)
+// are not strict-compatible: rewriting them to additionalProperties: false
+// would lose the dictionary value shape the model needs. The caller should
+// set Strict=false on the tool definition in that case.
+func ConvertParametersToSchema(params any) (shared.FunctionParameters, bool, error) {
 	p, err := tools.SchemaToMap(params)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
-	return fixSchemaArrayItems(removeFormatFields(ensureTypeFields(makeAllRequired(p)))), nil
+	strict := isStrictCompatible(p)
+
+	if strict {
+		return fixSchemaArrayItems(removeFormatFields(ensureTypeFields(makeAllRequired(p)))), true, nil
+	}
+	return fixSchemaArrayItems(removeFormatFields(ensureTypeFields(p))), false, nil
+}
+
+// isStrictCompatible reports whether the schema can use OpenAI strict mode.
+// Strict mode requires every object node to have additionalProperties: false.
+// Schema-form additionalProperties (a map) and additionalProperties: true are
+// both incompatible.
+func isStrictCompatible(schema map[string]any) bool {
+	compatible := true
+	walkSchema(schema, func(node map[string]any) {
+		if !compatible {
+			return
+		}
+		v, ok := node["additionalProperties"]
+		if !ok {
+			return
+		}
+		switch t := v.(type) {
+		case map[string]any:
+			compatible = false
+		case bool:
+			if t {
+				compatible = false
+			}
+		}
+	})
+	return compatible
 }
 
 // walkSchema calls fn on the given schema node, then recursively walks into
@@ -52,17 +88,15 @@ func walkSchema(schema map[string]any, fn func(map[string]any)) {
 	}
 }
 
-// makeAllRequired makes all object properties "required" throughout the schema,
-// because that's what the OpenAI Response API demands.
-// Properties that were not originally required are made nullable.
-// Also ensures all object-type schemas have additionalProperties: false.
+// makeAllRequired enforces OpenAI strict mode: every object property is
+// listed in `required` (newly-required ones are made nullable) and every
+// object node has `additionalProperties: false`.
 func makeAllRequired(schema shared.FunctionParameters) shared.FunctionParameters {
 	if schema == nil {
 		schema = map[string]any{"type": "object", "properties": map[string]any{}}
 	}
 
 	walkSchema(schema, func(node map[string]any) {
-		// Check if this node is an object type (either "object" or ["object", ...])
 		isObject := false
 		if typeVal, ok := node["type"]; ok {
 			switch t := typeVal.(type) {
@@ -80,17 +114,10 @@ func makeAllRequired(schema shared.FunctionParameters) shared.FunctionParameters
 			}
 		}
 
-		// All object types must have additionalProperties: false for OpenAI Responses API strict mode
-		// But only set it if additionalProperties is not already defined as an object schema
 		if isObject {
-			if addProps, exists := node["additionalProperties"]; !exists || addProps == nil || addProps == true {
-				node["additionalProperties"] = false
-			}
-			// If additionalProperties is already set to false or is an object schema (map[string]any),
-			// leave it as is - the object schema case will be walked separately
+			node["additionalProperties"] = false
 		}
 
-		// If the node has explicit properties, make them all required
 		properties, ok := node["properties"].(map[string]any)
 		if !ok {
 			return
@@ -106,8 +133,6 @@ func makeAllRequired(schema shared.FunctionParameters) shared.FunctionParameters
 		newRequired := []any{}
 		for _, propName := range slices.Sorted(maps.Keys(properties)) {
 			newRequired = append(newRequired, propName)
-
-			// Make newly-required properties nullable
 			if !originallyRequired[propName] {
 				if propMap, ok := properties[propName].(map[string]any); ok {
 					if t, ok := propMap["type"].(string); ok {

--- a/pkg/model/provider/openai/schema_test.go
+++ b/pkg/model/provider/openai/schema_test.go
@@ -168,7 +168,10 @@ func TestMakeAllRequired_ArrayItems(t *testing.T) {
 }
 
 func TestMakeAllRequired_AdditionalProperties(t *testing.T) {
-	// Schema-form additionalProperties must be replaced with false.
+	// Schema-form additionalProperties (Notion-style) must be preserved so the
+	// model knows what dictionary values look like. The inner schema is still
+	// normalized: all its properties become required, newly-required ones are
+	// nullable, and inner object nodes get additionalProperties: false.
 	schema := shared.FunctionParameters{
 		"type": "object",
 		"properties": map[string]any{
@@ -189,9 +192,25 @@ func TestMakeAllRequired_AdditionalProperties(t *testing.T) {
 
 	updated := makeAllRequired(schema)
 
+	// Outer object: no additionalProperties was set, so it is forced to false.
 	assert.Equal(t, false, updated["additionalProperties"])
+
+	// `children` declares schema-form additionalProperties — left as-is.
 	children := updated["properties"].(map[string]any)["children"].(map[string]any)
-	assert.Equal(t, false, children["additionalProperties"])
+	additionalProps, ok := children["additionalProperties"].(map[string]any)
+	require.True(t, ok, "schema-form additionalProperties must be preserved")
+
+	// The inner schema is still normalized.
+	additionalRequired := additionalProps["required"].([]any)
+	assert.Len(t, additionalRequired, 2)
+	assert.Contains(t, additionalRequired, "bulleted_list_item")
+	assert.Contains(t, additionalRequired, "numbered_list_item")
+
+	numberedListItem := additionalProps["properties"].(map[string]any)["numbered_list_item"].(map[string]any)
+	assert.Equal(t, []string{"string", "null"}, numberedListItem["type"])
+
+	bulletedListItem := additionalProps["properties"].(map[string]any)["bulleted_list_item"].(map[string]any)
+	assert.Equal(t, "string", bulletedListItem["type"])
 }
 
 func TestMakeAllRequired_JiraEditIssueFields(t *testing.T) {
@@ -464,7 +483,9 @@ func TestIsStrictCompatible(t *testing.T) {
 func TestConvertParametersToSchema_NotionStylePreservesShape(t *testing.T) {
 	// Notion MCP tools declare schema-form additionalProperties so the model
 	// knows what dictionary values look like. We must not strip that, even
-	// though it forces non-strict mode.
+	// though it forces non-strict mode. The inner schema is still normalized
+	// (all properties become required) so the Chat Completions API receives a
+	// fully-populated schema.
 	schema := map[string]any{
 		"type": "object",
 		"properties": map[string]any{
@@ -493,6 +514,13 @@ func TestConvertParametersToSchema_NotionStylePreservesShape(t *testing.T) {
 	props := inner["properties"].(map[string]any)
 	assert.Contains(t, props, "bulleted_list_item")
 	assert.Contains(t, props, "numbered_list_item")
+
+	// makeAllRequired still runs: every inner property is required so the
+	// Chat Completions API gets a fully-populated schema.
+	innerRequired := inner["required"].([]any)
+	assert.Len(t, innerRequired, 2)
+	assert.Contains(t, innerRequired, "bulleted_list_item")
+	assert.Contains(t, innerRequired, "numbered_list_item")
 }
 
 func TestConvertParametersToSchema_AdditionalPropertiesMissingType(t *testing.T) {

--- a/pkg/model/provider/openai/schema_test.go
+++ b/pkg/model/provider/openai/schema_test.go
@@ -213,7 +213,7 @@ func TestMakeAllRequired_AdditionalProperties(t *testing.T) {
 	assert.Equal(t, "string", bulletedListItem["type"])
 }
 
-func TestMakeAllRequired_JiraEditIssueFields(t *testing.T) {
+func TestConvertParametersToSchema_JiraEditIssueFields(t *testing.T) {
 	// Regression for the Atlassian remote MCP `editJiraIssue` tool, whose
 	// `fields` property declared additionalProperties as an object schema.
 	schema := shared.FunctionParameters{

--- a/pkg/model/provider/openai/schema_test.go
+++ b/pkg/model/provider/openai/schema_test.go
@@ -168,10 +168,7 @@ func TestMakeAllRequired_ArrayItems(t *testing.T) {
 }
 
 func TestMakeAllRequired_AdditionalProperties(t *testing.T) {
-	// Reproduces the Notion MCP tool schema where additionalProperties
-	// contains an object schema with its own properties (like bulleted_list_item).
-	// OpenAI requires all properties in additionalProperties schemas to also
-	// be listed in the required array.
+	// Schema-form additionalProperties must be replaced with false.
 	schema := shared.FunctionParameters{
 		"type": "object",
 		"properties": map[string]any{
@@ -192,21 +189,35 @@ func TestMakeAllRequired_AdditionalProperties(t *testing.T) {
 
 	updated := makeAllRequired(schema)
 
-	// additionalProperties object: all properties must be required
+	assert.Equal(t, false, updated["additionalProperties"])
 	children := updated["properties"].(map[string]any)["children"].(map[string]any)
-	additionalProps := children["additionalProperties"].(map[string]any)
-	additionalRequired := additionalProps["required"].([]any)
-	assert.Len(t, additionalRequired, 2)
-	assert.Contains(t, additionalRequired, "bulleted_list_item")
-	assert.Contains(t, additionalRequired, "numbered_list_item")
+	assert.Equal(t, false, children["additionalProperties"])
+}
 
-	// numbered_list_item was not originally required, so its type should be nullable
-	numberedListItem := additionalProps["properties"].(map[string]any)["numbered_list_item"].(map[string]any)
-	assert.Equal(t, []string{"string", "null"}, numberedListItem["type"])
+func TestMakeAllRequired_JiraEditIssueFields(t *testing.T) {
+	// Regression for the Atlassian remote MCP `editJiraIssue` tool, whose
+	// `fields` property declared additionalProperties as an object schema.
+	schema := shared.FunctionParameters{
+		"type": "object",
+		"properties": map[string]any{
+			"issueIdOrKey": map[string]any{"type": "string"},
+			"fields": map[string]any{
+				"type":                 "object",
+				"description":          "Jira issue fields to update",
+				"additionalProperties": map[string]any{},
+			},
+		},
+		"required": []any{"issueIdOrKey", "fields"},
+	}
 
-	// bulleted_list_item was originally required, so its type should be unchanged
-	bulletedListItem := additionalProps["properties"].(map[string]any)["bulleted_list_item"].(map[string]any)
-	assert.Equal(t, "string", bulletedListItem["type"])
+	result, strict, err := ConvertParametersToSchema(schema)
+	require.NoError(t, err)
+
+	// Schema-form additionalProperties => non-strict, schema preserved as-is.
+	assert.False(t, strict)
+	fields := result["properties"].(map[string]any)["fields"].(map[string]any)
+	_, isMap := fields["additionalProperties"].(map[string]any)
+	assert.True(t, isMap, "non-strict path must preserve schema-form additionalProperties")
 }
 
 func TestRemoveFormatFields(t *testing.T) {
@@ -399,8 +410,92 @@ func TestEnsureTypeFields_AdditionalPropertiesMissingType(t *testing.T) {
 	assert.Equal(t, "object", additionalProps["type"], "additionalProperties should have type added")
 }
 
+func TestIsStrictCompatible(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		schema map[string]any
+		want   bool
+	}{
+		{
+			name:   "empty schema",
+			schema: map[string]any{"type": "object"},
+			want:   true,
+		},
+		{
+			name: "explicit additionalProperties: false",
+			schema: map[string]any{
+				"type":                 "object",
+				"additionalProperties": false,
+			},
+			want: true,
+		},
+		{
+			name: "additionalProperties: true is incompatible",
+			schema: map[string]any{
+				"type":                 "object",
+				"additionalProperties": true,
+			},
+			want: false,
+		},
+		{
+			name: "schema-form additionalProperties is incompatible",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"children": map[string]any{
+						"type":                 "object",
+						"additionalProperties": map[string]any{"type": "string"},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isStrictCompatible(tc.schema))
+		})
+	}
+}
+
+func TestConvertParametersToSchema_NotionStylePreservesShape(t *testing.T) {
+	// Notion MCP tools declare schema-form additionalProperties so the model
+	// knows what dictionary values look like. We must not strip that, even
+	// though it forces non-strict mode.
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"children": map[string]any{
+				"type": "object",
+				"additionalProperties": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"bulleted_list_item": map[string]any{"type": "string"},
+						"numbered_list_item": map[string]any{"type": "string"},
+					},
+					"required": []any{"bulleted_list_item"},
+				},
+			},
+		},
+		"required": []any{"children"},
+	}
+
+	result, strict, err := ConvertParametersToSchema(schema)
+	require.NoError(t, err)
+	require.False(t, strict)
+
+	children := result["properties"].(map[string]any)["children"].(map[string]any)
+	inner, ok := children["additionalProperties"].(map[string]any)
+	require.True(t, ok, "non-strict path must preserve schema-form additionalProperties")
+	props := inner["properties"].(map[string]any)
+	assert.Contains(t, props, "bulleted_list_item")
+	assert.Contains(t, props, "numbered_list_item")
+}
+
 func TestConvertParametersToSchema_AdditionalPropertiesMissingType(t *testing.T) {
-	// End-to-end test: the full pipeline should produce a valid schema
 	schema := map[string]any{
 		"type": "object",
 		"properties": map[string]any{
@@ -416,11 +511,15 @@ func TestConvertParametersToSchema_AdditionalPropertiesMissingType(t *testing.T)
 		"required": []any{"filters"},
 	}
 
-	result, err := ConvertParametersToSchema(schema)
+	result, strict, err := ConvertParametersToSchema(schema)
 	require.NoError(t, err)
 
+	// Schema-form additionalProperties => non-strict; the inner schema is
+	// preserved (and ensureTypeFields adds the missing "type").
+	assert.False(t, strict)
 	filters := result["properties"].(map[string]any)["filters"].(map[string]any)
-	additionalProps := filters["additionalProperties"].(map[string]any)
+	additionalProps, ok := filters["additionalProperties"].(map[string]any)
+	require.True(t, ok)
 	assert.Equal(t, "object", additionalProps["type"])
 }
 

--- a/pkg/model/provider/openai/schema_test.go
+++ b/pkg/model/provider/openai/schema_test.go
@@ -471,6 +471,24 @@ func TestIsStrictCompatible(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "schema-form additionalProperties nested in prefixItems is incompatible",
+			schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"tuple": map[string]any{
+						"type": "array",
+						"prefixItems": []any{
+							map[string]any{
+								"type":                 "object",
+								"additionalProperties": map[string]any{"type": "string"},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/model/provider/schema_test.go
+++ b/pkg/model/provider/schema_test.go
@@ -188,7 +188,7 @@ func TestSchemaForAnthropic(t *testing.T) {
 // OpenAI and LM Studio accept.
 // See https://github.com/docker/docker-agent/issues/278
 func TestEmptyMapSchemaForOpenai(t *testing.T) {
-	schema, err := openai.ConvertParametersToSchema(map[string]any{})
+	schema, _, err := openai.ConvertParametersToSchema(map[string]any{})
 	require.NoError(t, err)
 
 	schemaJSON, err := json.Marshal(schema)
@@ -197,7 +197,7 @@ func TestEmptyMapSchemaForOpenai(t *testing.T) {
 }
 
 func TestNilSchemaForOpenai(t *testing.T) {
-	schema, err := openai.ConvertParametersToSchema(nil)
+	schema, _, err := openai.ConvertParametersToSchema(nil)
 	require.NoError(t, err)
 
 	schemaJSON, err := json.Marshal(schema)
@@ -208,7 +208,7 @@ func TestNilSchemaForOpenai(t *testing.T) {
 func TestSchemaForOpenai(t *testing.T) {
 	parameters := parseFunctionParameters(t, schemaJSON)
 
-	schema, err := openai.ConvertParametersToSchema(parameters)
+	schema, _, err := openai.ConvertParametersToSchema(parameters)
 	require.NoError(t, err)
 
 	schemaJSON, err := json.Marshal(schema)


### PR DESCRIPTION
## Problem

OpenAI's Responses API in strict mode (used by gpt-5/gpt-5.5 with `Strict: true`) requires `additionalProperties` to be literally `false` on every object schema. Some MCP servers ship tool schemas that violate this:

- **Atlassian remote MCP** (`editJiraIssue`): declares `fields.additionalProperties: {}` (or a richer schema). The request fails with:

  ```
  HTTP 400: Invalid schema for function 'atlassian-remote_editJiraIssue':
  In context=('properties', 'fields', 'additionalProperties'),
  'additionalProperties' is required to be supplied and to be false.
  ```

- **Notion MCP** (e.g. block-creation tools): declares `additionalProperties` as a *schema* (a map describing the dictionary value shape, like `bulleted_list_item`/`numbered_list_item`). Rewriting that to `false` would strip information the model relies on to call the tool correctly.

A previous fix overwrote schema-form `additionalProperties` with `false` everywhere — that fixed Jira but degraded Notion's tool calls.

## Fix

Decide strict mode per tool:

1. `ConvertParametersToSchema` now returns `(schema, strict, err)`.
2. A schema is **strict-incompatible** if any node has `additionalProperties` set to a map (schema form) or to `true`. We detect that with a read-only walk before any normalization.
3. **Strict-compatible** schemas go through the existing pipeline (`makeAllRequired` → forces `additionalProperties: false`, all properties required, nullables, etc.).
4. **Strict-incompatible** schemas are preserved (only cosmetic fixups: `ensureTypeFields`, `removeFormatFields`, `fixSchemaArrayItems`).
5. The Responses API tool definition uses `Strict: param.NewOpt(strict)` per tool.

Result:
- Jira's `editJiraIssue` works because we no longer claim strict mode on it.
- Notion's tools work because the inner dictionary schema survives the conversion.
- All other tools keep the existing strict-mode benefits.

## Tests

- `TestIsStrictCompatible` covers strict, `additionalProperties: true`, and schema-form cases.
- `TestConvertParametersToSchema_NotionStylePreservesShape` proves Notion's inner schema is preserved end-to-end.
- `TestMakeAllRequired_JiraEditIssueFields` is a regression for the original Atlassian failure.
- All existing schema/conversion tests updated to the new 3-return signature.

## Validation

- \`go build ./...\` ✅
- \`go vet ./...\` ✅
- \`go test -race -count=1 ./pkg/model/provider/...\` ✅
- \`task lint\` ✅ (0 issues)
- \`go mod tidy --diff\` clean ✅