### PR TITLE
fix(tui): user_prompt dialog opens scrolled to top and respects user scrolling

### DIFF
--- a/pkg/tui/dialog/elicitation.go
+++ b/pkg/tui/dialog/elicitation.go
@@ -164,6 +164,7 @@ func (d *ElicitationDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		if d.isTextInputField() {
 			var cmd tea.Cmd
 			d.inputs[d.currentField], cmd = d.inputs[d.currentField].Update(msg)
+			d.ensureFocusVisible()
 			return d, cmd
 		}
 		return d, nil
@@ -263,6 +264,10 @@ func (d *ElicitationDialog) updateCurrentInput(msg tea.KeyPressMsg) (layout.Mode
 		delete(d.fieldErrors, d.currentField)
 		var cmd tea.Cmd
 		d.inputs[d.currentField], cmd = d.inputs[d.currentField].Update(msg)
+		// If the field was below the fold (e.g. the dialog opened scrolled to
+		// the top with a tall message), reveal it as soon as the user starts
+		// typing so they can see what they're entering.
+		d.ensureFocusVisible()
 		return d, cmd
 	}
 	return d, nil

--- a/pkg/tui/dialog/elicitation.go
+++ b/pkg/tui/dialog/elicitation.go
@@ -514,11 +514,15 @@ func (d *ElicitationDialog) View() string {
 	// layout, so we accept the mutation as a render-cache compromise.
 	d.fieldStarts = l.fieldStarts //rubocop:disable Lint/TUIViewPurity // click-zone cache consumed by Update()
 
-	// Configure the scrollview viewport, give it the body, and scroll so the
-	// focused field stays visible.
+	// Configure the scrollview viewport and give it the body. Scroll position
+	// is intentionally not adjusted here: the dialog opens scrolled to the top
+	// (so the user can read the full question/message from the start), and
+	// only changes when the user interacts (focus moves, selection changes,
+	// or scroll keys/wheel). Auto-scrolling on every render would prevent the
+	// user from scrolling back up to see the question header above the
+	// initially focused option/field.
 	d.scrollview.SetSize(l.contentWidth, l.viewport)
 	d.scrollview.SetContent(l.bodyLines, len(l.bodyLines))
-	d.ensureFocusVisible()
 
 	// Tell the scrollview where it lives on screen (for scrollbar drag) and
 	// remember the body's top row for our own mouse click hit-testing.

--- a/pkg/tui/dialog/elicitation_test.go
+++ b/pkg/tui/dialog/elicitation_test.go
@@ -667,6 +667,45 @@ func TestElicitationDialog_SmallContent_NoScrollbar(t *testing.T) {
 // opened elicitation dialog (e.g. user_prompt) starts scrolled all the way
 // up so the user can read the question/message from the start, even when
 // the focused option/field would otherwise pull the viewport down.
+// TestElicitationDialog_TypingRevealsBelowFoldField pins that when the user
+// starts typing into a text field that lives below the fold (because the
+// dialog opens scrolled to the top with a long message), the input is
+// scrolled into view so the user can see what they are entering.
+func TestElicitationDialog_TypingRevealsBelowFoldField(t *testing.T) {
+	t.Parallel()
+
+	longMessage := strings.Repeat("Long question line. ", 30)
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"name": map[string]any{"type": "string", "title": "Name"},
+		},
+		"required": []any{"name"},
+	}
+
+	dialog := NewElicitationDialog(longMessage, schema, nil).(*ElicitationDialog)
+	_, _ = dialog.Update(tea.WindowSizeMsg{Width: 80, Height: 16})
+	_ = dialog.View()
+
+	require.True(t, dialog.scrollview.NeedsScrollbar(), "long message + field must require scrolling")
+	require.Equal(t, 0, dialog.scrollview.ScrollOffset(), "dialog must open scrolled to the top")
+	require.Len(t, dialog.fieldStarts, 1)
+
+	// The text field's input line lives below the initial viewport.
+	inputLine := dialog.fieldStarts[0] + 1
+	require.Greater(t, inputLine, dialog.scrollview.VisibleHeight()-1,
+		"test setup: the text field must initially be below the fold")
+
+	// User types a character — this must scroll the input into view.
+	_, _ = dialog.Update(tea.KeyPressMsg(tea.Key{Code: 'a', Text: "a"}))
+	_ = dialog.View()
+
+	offset := dialog.scrollview.ScrollOffset()
+	visEnd := offset + dialog.scrollview.VisibleHeight() - 1
+	assert.GreaterOrEqual(t, inputLine, offset, "input line must be at or below scroll offset after typing")
+	assert.LessOrEqual(t, inputLine, visEnd, "input line must be visible after typing")
+}
+
 func TestElicitationDialog_OpensScrolledToTop(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tui/dialog/elicitation_test.go
+++ b/pkg/tui/dialog/elicitation_test.go
@@ -662,3 +662,69 @@ func TestElicitationDialog_SmallContent_NoScrollbar(t *testing.T) {
 
 	assert.False(t, dialog.scrollview.NeedsScrollbar(), "small dialogs should not need a scrollbar")
 }
+
+// TestElicitationDialog_OpensScrolledToTop pins the contract that a freshly
+// opened elicitation dialog (e.g. user_prompt) starts scrolled all the way
+// up so the user can read the question/message from the start, even when
+// the focused option/field would otherwise pull the viewport down.
+func TestElicitationDialog_OpensScrolledToTop(t *testing.T) {
+	t.Parallel()
+
+	// Long question that, combined with many options, forces a scrollbar.
+	longMessage := strings.Repeat("This is a long question that takes several lines. ", 20)
+
+	enumValues := make([]any, 0, 12)
+	for i := range 12 {
+		enumValues = append(enumValues, "option-"+string(rune('A'+i)))
+	}
+
+	schema := map[string]any{
+		"type":  "string",
+		"title": "Pick one",
+		"enum":  enumValues,
+	}
+
+	dialog := NewElicitationDialog(longMessage, schema, nil).(*ElicitationDialog)
+	_, _ = dialog.Update(tea.WindowSizeMsg{Width: 80, Height: 18})
+	_ = dialog.View()
+
+	require.True(t, dialog.scrollview.NeedsScrollbar(), "long question + many options must require scrolling")
+	assert.Equal(t, 0, dialog.scrollview.ScrollOffset(),
+		"dialog must open scrolled to the top so the user can read the question first")
+}
+
+// TestElicitationDialog_UserScrollUp_NotSnappedBack pins the contract that
+// once the user scrolls up (e.g. via wheel/PgUp) to read the question, the
+// next render must not snap the viewport back down to the focused option.
+func TestElicitationDialog_UserScrollUp_NotSnappedBack(t *testing.T) {
+	t.Parallel()
+
+	longMessage := strings.Repeat("Long question line. ", 30)
+	enumValues := make([]any, 0, 12)
+	for i := range 12 {
+		enumValues = append(enumValues, "option-"+string(rune('A'+i)))
+	}
+	schema := map[string]any{"type": "string", "title": "Pick one", "enum": enumValues}
+
+	dialog := NewElicitationDialog(longMessage, schema, nil).(*ElicitationDialog)
+	_, _ = dialog.Update(tea.WindowSizeMsg{Width: 80, Height: 16})
+	_ = dialog.View()
+
+	require.True(t, dialog.scrollview.NeedsScrollbar())
+
+	// Scroll all the way down (e.g. user pressed End).
+	dialog.scrollview.ScrollToBottom()
+	offsetAfterScroll := dialog.scrollview.ScrollOffset()
+	require.Positive(t, offsetAfterScroll, "scrollview should accept a non-zero offset")
+
+	// Re-render: must NOT snap back to keep the focused option visible.
+	_ = dialog.View()
+	assert.Equal(t, offsetAfterScroll, dialog.scrollview.ScrollOffset(),
+		"re-rendering must not auto-scroll; the user's scroll position must be preserved")
+
+	// Now scroll back to the top (to re-read the question).
+	dialog.scrollview.ScrollToTop()
+	_ = dialog.View()
+	assert.Equal(t, 0, dialog.scrollview.ScrollOffset(),
+		"re-rendering must not auto-scroll back down to the focused option")
+}


### PR DESCRIPTION
## Problem

When the `user_prompt` dialog showed a long question with many multiple-choice options, a scrollbar appeared (as expected) but the user could not scroll all the way up to read the beginning of the question — the viewport kept snapping back down to keep the focused option on screen.

## Cause

`ElicitationDialog.View()` was calling `d.ensureFocusVisible()` on every render. So whenever the user scrolled up (wheel, PgUp, scrollbar drag, …), the next render snapped the scroll position back down to keep the focused field/option visible.

## Fix

Auto-scroll is now triggered only on actual user interactions that change focus or selection:

- `moveFocus` / `focusField` (Tab, Shift-Tab, validation jump-to-error)
- `moveSelection` (Up/Down/Space inside an enum/boolean field)
- Typing or pasting into a text input (so a text field below the fold gets revealed once the user starts editing it)

Render-time auto-scroll has been removed from `View()`. As a result:

- The dialog now opens scrolled all the way to the top, so the question/message is visible from the start.
- The user can freely scroll up/down (wheel, PgUp/PgDn, Home/End, scrollbar drag) without the viewport snapping back.

## Tests

Added regression tests in `pkg/tui/dialog/elicitation_test.go`:

- `TestElicitationDialog_OpensScrolledToTop` — verifies the dialog opens with `ScrollOffset == 0`.
- `TestElicitationDialog_UserScrollUp_NotSnappedBack` — verifies that re-rendering after a manual scroll does not override the user's position.
- `TestElicitationDialog_TypingRevealsBelowFoldField` — verifies that typing into a text field below the fold scrolls it into view.

Existing scroll-related tests (`TestElicitationDialog_LongEnumScrolls`, `TestElicitationDialog_FieldsBelowFold_AreReachable`, `TestElicitationDialog_SmallContent_NoScrollbar`) still pass.
