### PR TITLE
test(server): make TestAttachedServer_DeleteSessionStopsEventStream more robust

### DIFF
--- a/pkg/server/server_attached_test.go
+++ b/pkg/server/server_attached_test.go
@@ -122,8 +122,10 @@ func TestAttachedServer_DeleteSessionStopsEventStream(t *testing.T) {
 	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
 	sm.AttachRuntime(sess.ID, &fakeRuntime{}, sess)
 
+	sourceStarted := make(chan struct{})
 	sourceCtxDone := make(chan struct{})
 	sm.RegisterEventSource(sess.ID, func(ctx context.Context, _ func(any)) {
+		close(sourceStarted)
 		<-ctx.Done()
 		close(sourceCtxDone)
 	})
@@ -140,11 +142,20 @@ func TestAttachedServer_DeleteSessionStopsEventStream(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = resp.Body.Close() })
 
+	// Wait for the SSE handler to actually invoke the registered source.
+	// Otherwise DeleteSession may remove the source from the registry before
+	// StreamEvents picks it up, leaving sourceCtxDone unclosed.
+	select {
+	case <-sourceStarted:
+	case <-time.After(10 * time.Second):
+		t.Fatal("event source was never invoked by the SSE handler")
+	}
+
 	require.NoError(t, sm.DeleteSession(ctx, sess.ID))
 
 	select {
 	case <-sourceCtxDone:
-	case <-time.After(2 * time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatal("event source ctx was not cancelled when session was deleted")
 	}
 


### PR DESCRIPTION
## Problem

`TestAttachedServer_DeleteSessionStopsEventStream` was occasionally failing on CI with:

```
event source ctx was not cancelled when session was deleted
```

(timing out at exactly 2.00s on the `select` at `server_attached_test.go:148`.)

## Root cause

The test was racing against the SSE handler:

1. The test issues `GET /api/sessions/:id/events`.
2. `http.Client.Do` returns as soon as the server flushes the SSE response headers in `Server.sessionEvents` — **before** that handler reaches `sm.StreamEvents` → `eventSources.Load(...)`.
3. The test then immediately calls `sm.DeleteSession`, which removes the entry from `eventSources`.
4. If `DeleteSession` won the race, `StreamEvents` returned `false` without ever invoking the registered source closure, so its `<-ctx.Done(); close(sourceCtxDone)` body never ran and the 2 s timeout fired.

## Fix

`pkg/server/server_attached_test.go`:

- Add a `sourceStarted` channel that is closed at the top of the registered `EventSource` closure.
- Wait on `<-sourceStarted` *before* calling `sm.DeleteSession`, guaranteeing the SSE handler has actually invoked the source.
- Bump the two cancellation/wait timeouts from 2 s to 10 s for slow CI runners.

## Validation

- `go test -race -run TestAttachedServer_DeleteSessionStopsEventStream -count=50 ./pkg/server/...` — pass
- `go test -race -run TestAttachedServer_DeleteSessionStopsEventStream -count=200 ./pkg/server/...` — pass
- `go test -race -count=1 ./pkg/server/...` — pass
- `task lint` — 0 issues