### PR TITLE
fix(examples): update grok example to use grok-4.3

### DIFF
--- a/examples/grok.yaml
+++ b/examples/grok.yaml
@@ -1,6 +1,6 @@
 agents:
   root:
-    model: xai/grok-2-latest
+    model: xai/grok-4.3
     description: A helpful AI assistant powered by Grok
     instruction: |
       You are Grok, a helpful and maximally truthful AI built by xAI.
@@ -10,6 +10,6 @@ agents:
 models:
   grok-model:
     provider: xai
-    model: grok-2-latest
-    max_tokens: 131072
+    model: grok-4.3
+    max_tokens: 30000
     temperature: 0.7


### PR DESCRIPTION
## Problem

`TestParseExamples/../../examples/grok.yaml` fails in CI:

```
model "grok-2-latest" not found in provider "xai"
```

The `xai/grok-2-latest` model is no longer published in the [models.dev](https://models.dev/api.json) API — the `xai` provider now only exposes the `grok-4.x` family. The failure is masked locally for anyone whose `~/.cagent/models_dev.json` cache still contains the old `grok-2-*` entries (the cache is valid for 24h before refresh).

## Fix

Switch `examples/grok.yaml` to `xai/grok-4.3`, which is currently published, and adjust `max_tokens` to match the model's 30k output limit.

## Validation

```
rm ~/.cagent/models_dev.json
go test ./pkg/config/...
```

Now passes.