### PR TITLE
chore: add clean task to remove generated binary

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -33,6 +33,11 @@ tasks:
     cmds:
       - ./scripts/build.sh
 
+  clean:
+    desc: Remove the generated binary
+    cmds:
+      - rm -rf ./bin
+
   deploy-local:
     desc: Deploy the cli-plugin
     aliases: [install]


### PR DESCRIPTION
Adds a `clean` task to `Taskfile.yml` that removes the `./bin` directory containing the generated binary.

Usage:
```
task clean
```