### PR TITLE
fix(gemini): forward stream chunks that carry only UsageMetadata

### DIFF
--- a/pkg/model/provider/gemini/adapter.go
+++ b/pkg/model/provider/gemini/adapter.go
@@ -110,9 +110,12 @@ func NewStreamAdapter(iter func(func(*genai.GenerateContentResponse, error) bool
 
 				// Check for function calls
 				hasFuncs := len(resp.FunctionCalls()) > 0
+				// Gemini 3 can emit usage metadata on chunks without text/tool
+				// calls. Forward such chunks so downstream can capture token usage.
+				hasUsage := resp.UsageMetadata != nil
 
-				// Send response if it has content or function calls
-				if hasText || hasFuncs {
+				// Send response if it has content, function calls, or usage metadata
+				if hasText || hasFuncs || hasUsage {
 					hasContent = hasContent || hasText
 					hasToolCalls = hasToolCalls || hasFuncs
 					lastResponse = resp // Store for final message
@@ -152,6 +155,22 @@ func (g *StreamAdapter) Recv() (chat.MessageStreamResponse, error) {
 		Choices: []chat.MessageStreamChoice{{}},
 	}
 
+	// Extract usage metadata before branching on done state so that the final
+	// "done" event also surfaces usage if the last upstream chunk carried it
+	// (Gemini 3 emits usage on chunks without text/tool calls).
+	if res.resp != nil {
+		resp.ID = res.resp.ResponseID
+
+		if res.resp.UsageMetadata != nil && g.trackUsage {
+			resp.Usage = &chat.Usage{
+				InputTokens:       int64(res.resp.UsageMetadata.PromptTokenCount - res.resp.UsageMetadata.CachedContentTokenCount),
+				OutputTokens:      int64(res.resp.UsageMetadata.CandidatesTokenCount + res.resp.UsageMetadata.ThoughtsTokenCount),
+				CachedInputTokens: int64(res.resp.UsageMetadata.CachedContentTokenCount),
+				ReasoningTokens:   int64(res.resp.UsageMetadata.ThoughtsTokenCount),
+			}
+		}
+	}
+
 	if res.done {
 		// Set finish reason and role
 		resp.Choices[0].Delta.Role = string(chat.MessageRoleAssistant)
@@ -165,18 +184,6 @@ func (g *StreamAdapter) Recv() (chat.MessageStreamResponse, error) {
 			resp.Choices[0].FinishReason = chat.FinishReasonStop
 		}
 	} else if res.resp != nil {
-		resp.ID = res.resp.ResponseID
-
-		// Handle token usage if present
-		if res.resp.UsageMetadata != nil && g.trackUsage {
-			resp.Usage = &chat.Usage{
-				InputTokens:       int64(res.resp.UsageMetadata.PromptTokenCount - res.resp.UsageMetadata.CachedContentTokenCount),
-				OutputTokens:      int64(res.resp.UsageMetadata.CandidatesTokenCount + res.resp.UsageMetadata.ThoughtsTokenCount),
-				CachedInputTokens: int64(res.resp.UsageMetadata.CachedContentTokenCount),
-				ReasoningTokens:   int64(res.resp.UsageMetadata.ThoughtsTokenCount),
-			}
-		}
-
 		// Handle text and thoughts separately so TUI can render them distinctly
 		var reasoningTextSb strings.Builder
 		var textContentSb strings.Builder

--- a/pkg/model/provider/gemini/adapter_test.go
+++ b/pkg/model/provider/gemini/adapter_test.go
@@ -9,6 +9,118 @@ import (
 	"github.com/docker/docker-agent/pkg/chat"
 )
 
+func TestStreamAdapter_GeminiUsageMetadata(t *testing.T) {
+	// Gemini 3 (and any future model that emits usage metadata on its own chunk
+	// without accompanying text/tool calls) was previously losing token counts
+	// because the stream adapter dropped chunks that lacked text/function calls.
+	// These tests pin the fixed behaviour.
+
+	t.Run("forwards chunks containing only UsageMetadata", func(t *testing.T) {
+		textChunk := &genai.GenerateContentResponse{
+			Candidates: []*genai.Candidate{
+				{
+					Content: &genai.Content{
+						Parts: []*genai.Part{{Text: "Hello"}},
+					},
+				},
+			},
+		}
+		usageOnlyChunk := &genai.GenerateContentResponse{
+			UsageMetadata: &genai.GenerateContentResponseUsageMetadata{
+				PromptTokenCount:     14,
+				CandidatesTokenCount: 5,
+				ThoughtsTokenCount:   3,
+			},
+		}
+
+		iter := func(fn func(*genai.GenerateContentResponse, error) bool) {
+			if !fn(textChunk, nil) {
+				return
+			}
+			fn(usageOnlyChunk, nil)
+		}
+
+		adapter := NewStreamAdapter(iter, "test-model", true)
+
+		// First Recv: text chunk, no usage.
+		r1, err := adapter.Recv()
+		require.NoError(t, err)
+		require.Equal(t, "Hello", r1.Choices[0].Delta.Content)
+		require.Nil(t, r1.Usage)
+
+		// Second Recv: the usage-only chunk must be forwarded (regression guard).
+		r2, err := adapter.Recv()
+		require.NoError(t, err)
+		require.NotNil(t, r2.Usage, "usage-only chunk must surface token counts")
+		require.Equal(t, int64(14), r2.Usage.InputTokens)
+		require.Equal(t, int64(8), r2.Usage.OutputTokens) // candidates + thoughts
+		require.Equal(t, int64(3), r2.Usage.ReasoningTokens)
+
+		// Final done event closes the stream.
+		rdone, err := adapter.Recv()
+		require.NoError(t, err)
+		require.Equal(t, chat.FinishReasonStop, rdone.Choices[0].FinishReason)
+	})
+
+	t.Run("done event carries usage from last response", func(t *testing.T) {
+		// When the upstream stream ends with a chunk that carries usage,
+		// the synthesised "done" event must propagate that usage so downstream
+		// observers receive the final tally.
+		chunk := &genai.GenerateContentResponse{
+			Candidates: []*genai.Candidate{
+				{
+					Content: &genai.Content{
+						Parts: []*genai.Part{{Text: "ok"}},
+					},
+				},
+			},
+			UsageMetadata: &genai.GenerateContentResponseUsageMetadata{
+				PromptTokenCount:     10,
+				CandidatesTokenCount: 2,
+			},
+		}
+
+		iter := func(fn func(*genai.GenerateContentResponse, error) bool) {
+			fn(chunk, nil)
+		}
+
+		adapter := NewStreamAdapter(iter, "test-model", true)
+
+		// Forwarded chunk carries usage.
+		r1, err := adapter.Recv()
+		require.NoError(t, err)
+		require.NotNil(t, r1.Usage)
+		require.Equal(t, int64(10), r1.Usage.InputTokens)
+
+		// Done event also exposes the usage from the last response.
+		rdone, err := adapter.Recv()
+		require.NoError(t, err)
+		require.Equal(t, chat.FinishReasonStop, rdone.Choices[0].FinishReason)
+		require.NotNil(t, rdone.Usage, "done event should expose usage from last response")
+		require.Equal(t, int64(10), rdone.Usage.InputTokens)
+		require.Equal(t, int64(2), rdone.Usage.OutputTokens)
+	})
+
+	t.Run("trackUsage=false suppresses usage extraction", func(t *testing.T) {
+		// When trackUsage is disabled the adapter must not populate Usage even
+		// if upstream returns UsageMetadata.
+		chunk := &genai.GenerateContentResponse{
+			UsageMetadata: &genai.GenerateContentResponseUsageMetadata{
+				PromptTokenCount:     10,
+				CandidatesTokenCount: 2,
+			},
+		}
+		iter := func(fn func(*genai.GenerateContentResponse, error) bool) {
+			fn(chunk, nil)
+		}
+		adapter := NewStreamAdapter(iter, "test-model", false)
+
+		r1, err := adapter.Recv()
+		require.NoError(t, err)
+		require.Nil(t, r1.Usage)
+	})
+}
+
 func TestStreamAdapter_FunctionCalls(t *testing.T) {
 	t.Run("function calls in final message", func(t *testing.T) {
 		mockResp := &genai.GenerateContentResponse{


### PR DESCRIPTION
## Summary

Gemini 3 family models (e.g. `gemini-3-flash-preview`,
`gemini-3.1-flash-lite-preview`) emit `usageMetadata` on stream chunks that
contain no text and no function calls. The current `gemini.StreamAdapter`
drops those chunks before they reach the runtime, so all token counts and
costs come back as zero. Gemini 2.5 happens to fit its `usageMetadata` into
the same chunk as the final text, which is why it has worked so far.

## Root cause

Two places in `pkg/model/provider/gemini/adapter.go`:

1. `NewStreamAdapter` forwarded only chunks with `hasText || hasFuncs`.
   Usage-only chunks were silently discarded before reaching the channel.
2. `Recv()` extracted `UsageMetadata` only in the `else if res.resp != nil`
   branch, so even when the synthesised "done" event carried the last
   response, the usage was not surfaced.

## Fix

- Forward chunks that have `UsageMetadata` even when text and tool calls are
  absent (`hasUsage` check added to the OR).
- Move `Usage` extraction out of the `else if` branch so the done event
  also exposes the usage of the last response.

## Reproduction

`gemini-3-flash-preview` Vertex AI response contains `usageMetadata` (verified
with a direct curl against `:generateContent` and `:streamGenerateContent`),
but `docker agent run --exec --yolo` records `usage = {input:0, output:0}`
in `session_items.message_json` and `sessions.cost = 0` in the SQLite store.

After the fix the same run records non-zero tokens and the cost computed by
the runtime against the `models.dev` catalog.

| model | before | after |
| --- | --- | --- |
| `gemini-3-flash-preview` | usage = all zero, cost = 0 | usage populated, cost > 0 |
| `gemini-2.5-flash` | already worked | still works (regression test) |

## Tests

`pkg/model/provider/gemini/adapter_test.go` gains three sub-tests under
`TestStreamAdapter_GeminiUsageMetadata`:

- `forwards chunks containing only UsageMetadata` — directly guards the
  dropped-chunk regression.
- `done event carries usage from last response` — guards the second fix
  (extracting usage on the done branch).
- `trackUsage=false suppresses usage extraction` — confirms the existing
  opt-out still works.

The existing `TestStreamAdapter_FunctionCalls` continues to pass.
