### PR TITLE
feat(skills): run `context: fork` slash commands as sub-sessions

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -28,6 +28,7 @@ import (
 	"github.com/docker/docker-agent/pkg/shellpath"
 	"github.com/docker/docker-agent/pkg/skills"
 	"github.com/docker/docker-agent/pkg/tools"
+	skillstool "github.com/docker/docker-agent/pkg/tools/builtin/skills"
 	mcptools "github.com/docker/docker-agent/pkg/tools/mcp"
 	"github.com/docker/docker-agent/pkg/tui/messages"
 )
@@ -227,6 +228,9 @@ func (a *App) CurrentAgentSkills() []skills.Skill {
 
 // ResolveSkillCommand checks if the input matches a skill slash command (e.g. /skill-name args).
 // If matched, it reads the skill content and returns the resolved prompt. Otherwise returns "".
+//
+// Fork-mode skills are NOT resolved here; chat dispatches them via
+// SkillCommandFork + RunSkillFork to keep the parent transcript clean.
 func (a *App) ResolveSkillCommand(ctx context.Context, input string) (string, error) {
 	if !strings.HasPrefix(input, "/") {
 		return "", nil
@@ -245,6 +249,13 @@ func (a *App) ResolveSkillCommand(ctx context.Context, input string) (string, er
 			continue
 		}
 
+		if skill.IsFork() {
+			// Fall through to ResolveCommand for non-chat callers; the
+			// chat layer already routed fork-mode skills via
+			// SkillCommandFork before reaching this point.
+			return "", nil
+		}
+
 		content, err := st.ReadSkillContent(ctx, skill.Name)
 		if err != nil {
 			return "", fmt.Errorf("reading skill %q: %w", skill.Name, err)
@@ -258,6 +269,81 @@ func (a *App) ResolveSkillCommand(ctx context.Context, input string) (string, er
 
 	return "", nil
 }
+
+// SkillCommandFork returns (skillName, task, true) when input is a slash
+// command for a `context: fork` skill, otherwise (_, _, false). Chat layers
+// must call this before ResolveInput and route to RunSkillFork on a hit.
+func (a *App) SkillCommandFork(_ context.Context, input string) (skillName, task string, ok bool) {
+	if !strings.HasPrefix(input, "/") {
+		return "", "", false
+	}
+
+	st := a.runtime.CurrentAgentSkillsToolset()
+	if st == nil {
+		return "", "", false
+	}
+
+	cmd, arg, _ := strings.Cut(input[1:], " ")
+	arg = strings.TrimSpace(arg)
+
+	for _, skill := range st.Skills() {
+		if skill.Name != cmd {
+			continue
+		}
+		if !skill.IsFork() {
+			return "", "", false
+		}
+		return skill.Name, arg, true
+	}
+
+	return "", "", false
+}
+
+// RunSkillFork dispatches a fork-mode skill in an isolated sub-session of
+// the current parent. The parent gains a SubSession item once the runtime
+// opens the child; the sub-session's first user message is the expanded
+// SKILL.md body. Companion of SkillCommandFork.
+func (a *App) RunSkillFork(ctx context.Context, cancel context.CancelFunc, skillName, task string, _ []messages.Attachment) {
+	a.cancel = cancel
+
+	// Mirrors App.Run's drain loop: forward events to the App bus and
+	// always let StreamStoppedEvent through, even after ctx cancellation,
+	// so the supervisor marks the session idle.
+	go func() { //nolint:gosec // background processing intentionally continues after request ctx ends; uses context.Background() only to forward StreamStoppedEvent
+		events := make(chan runtime.Event, defaultRuntimeEventBuffer)
+		go func() {
+			defer close(events)
+			result, err := a.runtime.RunSkillFork(ctx, a.session, skillstool.RunSkillArgs{
+				Name: skillName,
+				Task: task,
+			}, runtime.NewChannelSink(events))
+			switch {
+			case errors.Is(err, runtime.ErrUnsupported):
+				slog.WarnContext(ctx, "Runtime does not support fork-mode skills; skill not executed", "skill", skillName)
+				a.sendEvent(ctx, runtime.Error(fmt.Sprintf("Skill %q cannot run: this runtime does not support fork-mode skills.", skillName)))
+			case err != nil:
+				slog.ErrorContext(ctx, "Failed to run fork-mode skill", "skill", skillName, "error", err)
+				a.sendEvent(ctx, runtime.Error(fmt.Sprintf("Skill %q failed: %v", skillName, err)))
+			case result != nil && result.IsError:
+				a.sendEvent(ctx, runtime.Error(result.Output))
+			}
+		}()
+
+		for event := range events {
+			if ctx.Err() != nil {
+				if _, ok := event.(*runtime.StreamStoppedEvent); ok {
+					a.sendEvent(context.Background(), event)
+				}
+				continue
+			}
+			a.sendEvent(ctx, event)
+		}
+	}()
+}
+
+// defaultRuntimeEventBuffer matches Summarize and Runtime.RunStream;
+// wide enough that a fork-skill sub-session won't block the producer.
+const defaultRuntimeEventBuffer = 100
 
 // ResolveInput resolves the user input by trying skill commands first,
 // then agent commands. Returns the resolved content ready to send to the agent.

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -64,6 +64,10 @@ func (m *mockRuntime) CurrentAgentSkillsToolset() *skillstool.ToolSet {
 	return nil
 }
 
+func (m *mockRuntime) RunSkillFork(context.Context, *session.Session, skillstool.RunSkillArgs, runtime.EventSink) (*tools.ToolCallResult, error) {
+	return nil, nil
+}
+
 func (m *mockRuntime) CurrentMCPPrompts(context.Context) map[string]mcptools.PromptInfo {
 	return make(map[string]mcptools.PromptInfo)
 }

--- a/pkg/app/skills_fork_test.go
+++ b/pkg/app/skills_fork_test.go
@@ -1,0 +1,247 @@
+package app
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/skills"
+	"github.com/docker/docker-agent/pkg/tools"
+	skillstool "github.com/docker/docker-agent/pkg/tools/builtin/skills"
+)
+
+// skillFakeRuntime extends mockRuntime with a real *skillstool.ToolSet so
+// the App can detect fork-mode slash commands. RunSkillFork is recorded
+// (no real sub-agent) since the contract under test is observable on the
+// parent session alone.
+type skillFakeRuntime struct {
+	*mockRuntime
+
+	skillset *skillstool.ToolSet
+
+	mu       sync.Mutex
+	calls    []skillstool.RunSkillArgs
+	emitted  []runtime.Event
+	stopCall atomic.Bool
+}
+
+func (f *skillFakeRuntime) CurrentAgentSkillsToolset() *skillstool.ToolSet {
+	return f.skillset
+}
+
+func (f *skillFakeRuntime) RunSkillFork(_ context.Context, sess *session.Session, args skillstool.RunSkillArgs, sink runtime.EventSink) (*tools.ToolCallResult, error) {
+	f.mu.Lock()
+	f.calls = append(f.calls, args)
+	emitted := f.emitted
+	f.mu.Unlock()
+
+	for _, ev := range emitted {
+		sink.Emit(ev)
+	}
+	// Always emit StreamStoppedEvent so the App's drain loop terminates.
+	sink.Emit(runtime.StreamStopped(sess.ID, "", ""))
+	f.stopCall.Store(true)
+	return tools.ResultSuccess("done"), nil
+}
+
+func (f *skillFakeRuntime) recordedCalls() []skillstool.RunSkillArgs {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]skillstool.RunSkillArgs, len(f.calls))
+	copy(out, f.calls)
+	return out
+}
+
+// writeSkill creates a SKILL.md in a temp dir and returns a Local skill
+// pointing at it so ReadSkillContent expands `!`shell“ placeholders.
+func writeSkill(t *testing.T, name string, fork bool, body string) skills.Skill {
+	t.Helper()
+
+	dir := t.TempDir()
+	skillFile := filepath.Join(dir, "SKILL.md")
+	require.NoError(t, os.WriteFile(skillFile, []byte(body), 0o644))
+
+	skill := skills.Skill{
+		Name:        name,
+		Description: "Test skill " + name,
+		FilePath:    skillFile,
+		BaseDir:     dir,
+		Local:       true,
+	}
+	if fork {
+		skill.Context = "fork"
+	}
+	return skill
+}
+
+// TestApp_SlashSkill_ForkContext_DispatchesToRunSkillFork verifies that a
+// `/<skill>` slash command for a fork-mode skill is routed to
+// Runtime.RunSkillFork and never inlines the skill body in the parent
+// session as a regular user message.
+func TestApp_SlashSkill_ForkContext_DispatchesToRunSkillFork(t *testing.T) {
+	t.Parallel()
+
+	const skillBody = "" +
+		"# Commit\n" +
+		"\n" +
+		"Greeting: !`echo HELLO_FROM_SKILL`\n" +
+		"\n" +
+		"Please commit the staged changes.\n"
+
+	skill := writeSkill(t, "commit", true /* fork */, skillBody)
+	st := skillstool.New([]skills.Skill{skill}, filepath.Dir(skill.FilePath))
+
+	rt := &skillFakeRuntime{
+		mockRuntime: &mockRuntime{},
+		skillset:    st,
+	}
+
+	ctx := t.Context()
+	// Pre-populate so the slash command is invoked mid-conversation.
+	sess := session.New(session.WithUserMessage("hi there"))
+	require.Equal(t, 1, sess.MessageCount())
+
+	a := New(ctx, rt, sess)
+
+	// Detection.
+	skillName, task, ok := a.SkillCommandFork(ctx, "/commit please commit")
+	require.True(t, ok, "fork-mode skill slash command must be detected")
+	assert.Equal(t, "commit", skillName)
+	assert.Equal(t, "please commit", task)
+
+	// ResolveInput must NOT inline a fork-mode skill: that would cause
+	// chat.processMessage to add it to the parent before fork dispatch runs.
+	resolved := a.ResolveInput(ctx, "/commit please commit")
+	assert.NotContains(t, resolved, "HELLO_FROM_SKILL")
+	assert.NotContains(t, resolved, "<skill name=")
+	assert.Equal(t, "/commit please commit", resolved, "raw input passes through; chat will take a different branch")
+
+	// Dispatch.
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	a.RunSkillFork(runCtx, cancel, skillName, task, nil)
+
+	require.Eventually(t, func() bool { return rt.stopCall.Load() }, time.Second, 10*time.Millisecond,
+		"RunSkillFork goroutine should drain its event channel and finish")
+
+	calls := rt.recordedCalls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, "commit", calls[0].Name)
+	assert.Equal(t, "please commit", calls[0].Task)
+
+	// Parent session must be unchanged.
+	require.Equal(t, 1, sess.MessageCount(), "parent session must not gain a user message from a fork-mode slash command")
+	for _, item := range sess.GetAllMessages() {
+		content := item.Message.Content
+		assert.NotContains(t, content, "/commit")
+		assert.NotContains(t, content, "HELLO_FROM_SKILL")
+		assert.NotContains(t, content, "<skill name=")
+	}
+
+	assert.Same(t, sess, a.Session(), "App.Session() must still point at the parent")
+}
+
+// TestApp_SlashSkill_InlineContext_StillInlines covers the
+// backwards-compatible path: skills without `context: fork` keep being
+// inlined into the parent transcript via the <skill> envelope.
+func TestApp_SlashSkill_InlineContext_StillInlines(t *testing.T) {
+	t.Parallel()
+
+	skill := writeSkill(t, "review", false /* not fork */, "# Review\nPlease review.\n")
+	st := skillstool.New([]skills.Skill{skill}, filepath.Dir(skill.FilePath))
+
+	rt := &skillFakeRuntime{
+		mockRuntime: &mockRuntime{},
+		skillset:    st,
+	}
+
+	ctx := t.Context()
+	a := New(ctx, rt, session.New())
+
+	_, _, ok := a.SkillCommandFork(ctx, "/review the diff")
+	assert.False(t, ok)
+
+	resolved := a.ResolveInput(ctx, "/review the diff")
+	assert.Contains(t, resolved, "<skill name=\"review\">")
+	assert.Contains(t, resolved, "Please review.")
+	assert.Contains(t, resolved, "the diff")
+}
+
+// TestApp_SlashSkill_NonFork_E2E exercises the full chat dispatch path for
+// a non-fork skill: SkillCommandFork returns false, App.Run inlines the
+// resolved body as a user message in the parent session, and
+// Runtime.RunSkillFork is never called. Pairs with the fork-mode test to
+// pin both halves of the dispatcher contract.
+func TestApp_SlashSkill_NonFork_E2E(t *testing.T) {
+	t.Parallel()
+
+	const skillBody = "" +
+		"---\n" +
+		"name: review\n" +
+		"description: Review staged changes\n" +
+		"---\n" +
+		"\n" +
+		"# Review\n" +
+		"\n" +
+		"Greeting: !`echo HELLO_FROM_SKILL`\n" +
+		"\n" +
+		"Please review the staged changes.\n"
+
+	skill := writeSkill(t, "review", false /* not fork */, skillBody)
+	st := skillstool.New([]skills.Skill{skill}, filepath.Dir(skill.FilePath))
+
+	rt := &skillFakeRuntime{
+		mockRuntime: &mockRuntime{},
+		skillset:    st,
+	}
+
+	ctx := t.Context()
+	// Pre-populate so the slash command is invoked mid-conversation.
+	sess := session.New(session.WithUserMessage("hi there"))
+	require.Equal(t, 1, sess.MessageCount())
+
+	a := New(ctx, rt, sess)
+
+	// Same dispatch as chat.processMessage.
+	input := "/review carefully"
+	_, _, ok := a.SkillCommandFork(ctx, input)
+	require.False(t, ok)
+
+	resolved := a.ResolveInput(ctx, input)
+	require.Contains(t, resolved, `<skill name="review">`)
+	require.Contains(t, resolved, "User's request: carefully")
+	require.Contains(t, resolved, "HELLO_FROM_SKILL", "local skill placeholders must be expanded")
+	require.Contains(t, resolved, "Please review the staged changes.")
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	a.Run(runCtx, cancel, resolved, nil)
+
+	// App.Run is async; MessageCount holds session.mu so the race detector
+	// sees a synchronised read against AddMessage.
+	require.Eventually(t, func() bool {
+		return sess.MessageCount() == 2
+	}, time.Second, 10*time.Millisecond, "App.Run must append the resolved skill content")
+
+	messages := sess.GetAllMessages()
+	require.Len(t, messages, 2)
+	last := messages[len(messages)-1]
+	assert.Equal(t, chat.MessageRoleUser, last.Message.Role)
+	assert.Contains(t, last.Message.Content, `<skill name="review">`)
+	assert.Contains(t, last.Message.Content, "Please review the staged changes.")
+	assert.Contains(t, last.Message.Content, "HELLO_FROM_SKILL")
+	assert.Contains(t, last.Message.Content, "User's request: carefully")
+
+	assert.Empty(t, rt.recordedCalls(), "Runtime.RunSkillFork must not be called for non-fork skills")
+	assert.False(t, rt.stopCall.Load())
+}

--- a/pkg/cli/runner_test.go
+++ b/pkg/cli/runner_test.go
@@ -76,6 +76,10 @@ func (m *mockRuntime) SessionStore() session.Store                              
 func (m *mockRuntime) Summarize(context.Context, *session.Session, string, runtime.EventSink) {}
 func (m *mockRuntime) PermissionsInfo() *runtime.PermissionsInfo                              { return nil }
 func (m *mockRuntime) CurrentAgentSkillsToolset() *skillstool.ToolSet                         { return nil }
+func (m *mockRuntime) RunSkillFork(context.Context, *session.Session, skillstool.RunSkillArgs, runtime.EventSink) (*tools.ToolCallResult, error) {
+	return nil, nil
+}
+
 func (m *mockRuntime) CurrentMCPPrompts(context.Context) map[string]mcptools.PromptInfo {
 	return nil
 }

--- a/pkg/runtime/commands_test.go
+++ b/pkg/runtime/commands_test.go
@@ -58,6 +58,10 @@ func (m *mockRuntime) CurrentAgentSkillsToolset() *skillstool.ToolSet {
 	return nil
 }
 
+func (m *mockRuntime) RunSkillFork(context.Context, *session.Session, skillstool.RunSkillArgs, EventSink) (*tools.ToolCallResult, error) {
+	return nil, nil
+}
+
 func (m *mockRuntime) CurrentMCPPrompts(context.Context) map[string]mcptools.PromptInfo {
 	return make(map[string]mcptools.PromptInfo)
 }

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -571,6 +571,12 @@ func (r *RemoteRuntime) CurrentAgentSkillsToolset() *skills.ToolSet {
 	return nil
 }
 
+// RunSkillFork is unsupported on remote runtimes; the server owns skill
+// execution.
+func (r *RemoteRuntime) RunSkillFork(context.Context, *session.Session, skills.RunSkillArgs, EventSink) (*tools.ToolCallResult, error) {
+	return nil, fmt.Errorf("run skill fork: %w", ErrUnsupported)
+}
+
 // UpdateSessionTitle updates the title of the current session on the remote server.
 func (r *RemoteRuntime) UpdateSessionTitle(ctx context.Context, sess *session.Session, title string) error {
 	sess.Title = title

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -85,6 +85,13 @@ type Runtime interface {
 	// CurrentAgentSkillsToolset returns the skills toolset for the current agent, or nil if skills are not enabled.
 	CurrentAgentSkillsToolset() *skills.ToolSet
 
+	// RunSkillFork executes a `context: fork` skill as an isolated
+	// sub-session of sess. Used by the run_skill tool and the App's
+	// slash-command path. Returns a ToolCallResult carrying the sub-agent's
+	// last assistant message, or a user-facing error reason; err is non-nil
+	// only for unexpected runtime failures.
+	RunSkillFork(ctx context.Context, sess *session.Session, args skills.RunSkillArgs, events EventSink) (*tools.ToolCallResult, error)
+
 	// CurrentMCPPrompts returns MCP prompts available from the current agent's toolsets.
 	// Returns an empty map if no MCP prompts are available.
 	CurrentMCPPrompts(ctx context.Context) map[string]mcptools.PromptInfo

--- a/pkg/runtime/skill_runner.go
+++ b/pkg/runtime/skill_runner.go
@@ -14,26 +14,21 @@ import (
 	"github.com/docker/docker-agent/pkg/tools/builtin/skills"
 )
 
-// handleRunSkill executes a skill as an isolated sub-agent. The skill's
-// SKILL.md content (with command expansions) becomes the system prompt, and
-// the caller-provided task becomes the implicit user message. The sub-agent
-// runs in a child session using the current agent's model and tools, and
-// its final response is returned as the tool result.
-//
-// All skill-specific business rules (lookup, fork-mode validation, content
-// expansion) live in (*skills.ToolSet).PrepareForkSubSession; this
-// handler keeps only the runtime-private orchestration that runForwarding
-// can't generalise — namely the optional model override that applies for
-// the sub-session's lifetime.
-//
-// This implements the `context: fork` behaviour from the SKILL.md frontmatter,
-// following the same convention as Claude Code.
+// handleRunSkill unmarshals the run_skill tool arguments and delegates
+// to RunSkillFork.
 func (r *LocalRuntime) handleRunSkill(ctx context.Context, sess *session.Session, toolCall tools.ToolCall, evts EventSink) (*tools.ToolCallResult, error) {
 	var args skills.RunSkillArgs
 	if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &args); err != nil {
 		return nil, fmt.Errorf("invalid arguments: %w", err)
 	}
+	return r.RunSkillFork(ctx, sess, args, evts)
+}
 
+// RunSkillFork executes a `context: fork` skill as an isolated sub-session.
+// The expanded SKILL.md body becomes the child's first user message; the
+// agent's own system prompt is preserved. Shared by the run_skill tool
+// and the App's slash-command path.
+func (r *LocalRuntime) RunSkillFork(ctx context.Context, sess *session.Session, args skills.RunSkillArgs, evts EventSink) (*tools.ToolCallResult, error) {
 	st := r.CurrentAgentSkillsToolset()
 	if st == nil {
 		return tools.ResultError("no skills are available for the current agent"), nil
@@ -46,9 +41,8 @@ func (r *LocalRuntime) handleRunSkill(ctx context.Context, sess *session.Session
 
 	ca := r.CurrentAgentName()
 
-	// Open the span before any pre-delegation work so model resolution
-	// (inside WithAgentModel) is recorded under runtime.run_skill rather
-	// than the parent session span.
+	// Open the span before model resolution so it's recorded under
+	// runtime.run_skill rather than the parent session span.
 	ctx, span := r.startSpan(ctx, "runtime.run_skill", trace.WithAttributes(
 		attribute.String("agent", ca),
 		attribute.String("skill", prepared.SkillName),
@@ -62,11 +56,9 @@ func (r *LocalRuntime) handleRunSkill(ctx context.Context, sess *session.Session
 		"task", prepared.Task,
 	)
 
-	// If the skill declares a model override, apply it for the duration of
-	// the sub-session. WithAgentModel handles every accepted form (named
-	// model, alloy, inline provider/model, inline alloy) and returns a
-	// CAS-safe restore func that is always non-nil; on failure we log a
-	// warning and fall back to the agent's currently-active model.
+	// Apply the skill's optional model override for the sub-session.
+	// On failure we log and fall back to the agent's current model;
+	// restore is CAS-safe and always non-nil.
 	if prepared.Model != "" {
 		restore, err := r.WithAgentModel(ctx, ca, prepared.Model)
 		defer restore()
@@ -80,14 +72,13 @@ func (r *LocalRuntime) handleRunSkill(ctx context.Context, sess *session.Session
 		}
 	}
 
-	// run_skill keeps the same agent (skills are sub-sessions of the
-	// caller, not delegations to another agent), so we never swap the
-	// runtime's currentAgent here.
+	// Skills are sub-sessions of the caller, not delegations, so the
+	// runtime's currentAgent stays put.
 	return r.runForwarding(ctx, sess, evts, delegationRequest{
 		SubSessionConfig: SubSessionConfig{
 			Task:                prepared.Task,
-			SystemMessage:       prepared.Content,
-			ImplicitUserMessage: prepared.Task,
+			SystemMessage:       skills.BuildSkillSystemMessage(prepared, sess.AttachedFilesSnapshot()),
+			ImplicitUserMessage: skills.BuildSkillUserMessage(prepared),
 			AgentName:           ca,
 			Title:               "Skill: " + prepared.SkillName,
 			ToolsApproved:       sess.ToolsApproved,

--- a/pkg/tools/builtin/skills/build_user_message_test.go
+++ b/pkg/tools/builtin/skills/build_user_message_test.go
@@ -1,0 +1,109 @@
+package skills
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestBuildSkillSystemMessage pins the skill-fork system prompt: skill
+// name present, next-user-message directive present, attached files
+// listed when provided, no task-delegation boilerplate.
+func TestBuildSkillSystemMessage(t *testing.T) {
+	t.Run("no attachments", func(t *testing.T) {
+		prepared := &PreparedSkillFork{SkillName: "commit"}
+		msg := BuildSkillSystemMessage(prepared, nil)
+		assert.Contains(t, msg, `"commit" skill`)
+		assert.Contains(t, msg, "next user message")
+		assert.NotContains(t, msg, "<attached_files>")
+		assert.NotContains(t, msg, "<task>", "must not reuse buildTaskSystemMessage boilerplate")
+		assert.NotContains(t, msg, "team of agents", "must not impersonate transfer_task")
+	})
+
+	t.Run("with attached files", func(t *testing.T) {
+		prepared := &PreparedSkillFork{SkillName: "review"}
+		msg := BuildSkillSystemMessage(prepared, []string{"/abs/foo.go", "/abs/bar.md"})
+		assert.Contains(t, msg, "<attached_files>")
+		assert.Contains(t, msg, "- /abs/foo.go")
+		assert.Contains(t, msg, "- /abs/bar.md")
+		assert.Contains(t, msg, "</attached_files>")
+	})
+}
+
+// TestBuildSkillUserMessage_StripsFrontmatter pins the user message
+// shape: <skill> envelope, frontmatter stripped, body verbatim,
+// User's request: header for non-empty Task.
+func TestBuildSkillUserMessage_StripsFrontmatter(t *testing.T) {
+	prepared := &PreparedSkillFork{
+		SkillName: "commit",
+		Task:      "fix the typo",
+		Content: "---\n" +
+			"name: commit\n" +
+			"description: Commit local changes\n" +
+			"context: fork\n" +
+			"---\n" +
+			"\n" +
+			"# Commit\n" +
+			"Use `git commit -q -m \"<subject>\"` for the common single-line case.\n",
+	}
+
+	msg := BuildSkillUserMessage(prepared)
+
+	assert.True(t, strings.HasPrefix(msg, "Use the following skill."))
+	assert.Contains(t, msg, "User's request: fix the typo")
+	assert.Contains(t, msg, `<skill name="commit">`)
+	assert.Contains(t, msg, "# Commit")
+	assert.Contains(t, msg, `git commit -q -m "<subject>"`, "backtick markdown passes through untouched")
+	assert.NotContains(t, msg, "context: fork", "frontmatter must not leak")
+	assert.NotContains(t, msg, "name: commit\n", "frontmatter must not leak")
+}
+
+// TestBuildSkillUserMessage_NoTask: empty Task drops the User's request: header.
+func TestBuildSkillUserMessage_NoTask(t *testing.T) {
+	prepared := &PreparedSkillFork{
+		SkillName: "review",
+		Content:   "---\nname: review\ndescription: x\n---\nReview the code.\n",
+	}
+
+	msg := BuildSkillUserMessage(prepared)
+
+	assert.NotContains(t, msg, "User's request:")
+	assert.Contains(t, msg, "Review the code.")
+}
+
+// TestStripFrontmatter covers no-fence, well-formed, unterminated, and
+// leading-blank-line cases.
+func TestStripFrontmatter(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "no frontmatter",
+			in:   "# Skill\nbody\n",
+			want: "# Skill\nbody\n",
+		},
+		{
+			name: "well-formed frontmatter",
+			in:   "---\nname: x\n---\nbody\n",
+			want: "body\n",
+		},
+		{
+			name: "unterminated frontmatter is left alone",
+			in:   "---\nname: x\nbody without closing fence\n",
+			want: "---\nname: x\nbody without closing fence\n",
+		},
+		{
+			name: "frontmatter with leading newline preserved",
+			in:   "---\nname: x\n---\n\n# Heading\n",
+			want: "\n# Heading\n",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, stripFrontmatter(tc.in))
+		})
+	}
+}

--- a/pkg/tools/builtin/skills/skills.go
+++ b/pkg/tools/builtin/skills/skills.go
@@ -22,6 +22,54 @@ var (
 	_ tools.Instructable = (*ToolSet)(nil)
 )
 
+// BuildSkillUserMessage formats a PreparedSkillFork as the implicit user
+// message of a forked sub-session. It mirrors the inline `<skill name=...>`
+// envelope used by ResolveSkillCommand for non-fork skills, strips the YAML
+// frontmatter (already consumed by the runtime), and surfaces a non-empty
+// Task as a "User's request:" header.
+func BuildSkillUserMessage(prepared *PreparedSkillFork) string {
+	body := stripFrontmatter(prepared.Content)
+	if prepared.Task != "" {
+		return fmt.Sprintf("Use the following skill.\n\nUser's request: %s\n\n<skill name=%q>\n%s\n</skill>", prepared.Task, prepared.SkillName, body)
+	}
+	return fmt.Sprintf("Use the following skill.\n\n<skill name=%q>\n%s\n</skill>", prepared.SkillName, body)
+}
+
+// BuildSkillSystemMessage returns the system prompt of a forked skill
+// sub-session. It avoids the task-delegation boilerplate from
+// buildTaskSystemMessage (which references <task> / "team of agents")
+// since skills aren't delegations. attachedFiles, when non-empty, exposes
+// parent-attached files by absolute path.
+func BuildSkillSystemMessage(prepared *PreparedSkillFork, attachedFiles []string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "You are running the %q skill in an isolated sub-session. ", prepared.SkillName)
+	b.WriteString("The next user message contains the full skill instructions. Follow them; ")
+	b.WriteString("do not improvise around them or mix in unrelated tasks from prior conversations.")
+	if len(attachedFiles) > 0 {
+		b.WriteString("\n\nThe user attached these files in the parent conversation. Prefer them over any bare filenames in the skill body:\n<attached_files>")
+		for _, p := range attachedFiles {
+			fmt.Fprintf(&b, "\n- %s", p)
+		}
+		b.WriteString("\n</attached_files>")
+	}
+	return b.String()
+}
+
+// stripFrontmatter removes a leading YAML `---`-delimited frontmatter
+// block from a SKILL.md payload. Returns the input unchanged if no
+// leading fence or no closing fence is found.
+func stripFrontmatter(content string) string {
+	if !strings.HasPrefix(content, "---") {
+		return content
+	}
+	rest := content[3:]
+	_, after, found := strings.Cut(rest, "\n---")
+	if !found {
+		return content
+	}
+	return strings.TrimPrefix(after, "\n")
+}
+
 // ToolSet provides the read_skill and read_skill_file tools that let an
 // agent load skill content and supporting resources by name. It hides whether
 // a skill is local or remote — the agent just sees a name and description.
@@ -244,8 +292,8 @@ type PreparedSkillFork struct {
 	// Task is the caller-supplied task description, intended to be used as
 	// the implicit user message of the child session.
 	Task string
-	// Content is the expanded SKILL.md content, intended to be used as the
-	// system message of the child session.
+	// Content is the expanded SKILL.md content. Wrap with
+	// BuildSkillUserMessage to use as the child's first user message.
 	Content string
 	// Model is the optional model override declared in the SKILL.md
 	// frontmatter. Empty means "use the parent agent's current model".

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -860,6 +860,11 @@ func (p *chatPage) processMessage(msg msgtypes.SendMsg) tea.Cmd {
 	// Run command resolution and agent execution in a goroutine
 	// so the UI stays responsive while skill/agent commands are resolved.
 	go func() {
+		if skillName, task, ok := p.app.SkillCommandFork(ctx, msg.Content); ok {
+			// Fork-mode skill: run in an isolated sub-session.
+			p.app.RunSkillFork(ctx, p.msgCancel, skillName, task, msg.Attachments)
+			return
+		}
 		p.app.Run(ctx, p.msgCancel, p.app.ResolveInput(ctx, msg.Content), msg.Attachments)
 	}()
 


### PR DESCRIPTION
## Problem

Typing `/<skill-name>` in the TUI for a skill declared with `context: fork` used to inline the SKILL.md body into the parent conversation as a regular user message and let the parent agent answer it directly. The fork flag was silently ignored on this path: no sub-session was created, the parent transcript was polluted with a giant `<skill name="…">…</skill>` block, and the skill's own `allowed-tools` / `description` had no effect.

## Solution

Route fork-mode slash commands through the same machinery the `run_skill` tool uses, so the skill runs in an isolated child session and control returns to the parent when it ends:

- `Runtime.RunSkillFork` is now a public entry point shared by the `run_skill` tool and the new App-level slash dispatcher; it handles lookup, fork-mode validation, content + placeholder expansion, optional model override, and `runForwarding`.
- `App.SkillCommandFork` classifies user input as a fork-skill invocation; `App.RunSkillFork` drives the runtime and forwards events through the App's bus with the same context/cancellation discipline as `App.Run`.
- `App.ResolveSkillCommand` short-circuits for fork-mode skills so `ResolveInput` never returns the inlined body for them.
- The chat page calls `SkillCommandFork` first and falls back to the existing inline path for non-fork skills, agent commands and plain messages.

## Prompt shape

The skill body is now framed as the **first user message** of the sub-session (matching the inline `<skill name="…">` envelope), not as an extra system message — otherwise the agent's invariant system prompt would drown it out and the model would ignore the instructions. The YAML frontmatter is stripped because the runtime has already consumed it; passing it through just adds noise. `` !`shell` `` placeholders continue to be expanded by the existing `ReadSkillContent` path, while plain backtick markdown such as `` `git commit -q -m "<subject>"` `` passes through verbatim.

## Tests

- `pkg/app/skills_fork_test.go` — slash-command detection, fork dispatch contract (parent session not mutated, args forwarded), preserved inline path for non-fork skills, and a full-flow non-fork e2e test.
- `pkg/tools/builtin/skills/build_user_message_test.go` — user-message envelope, frontmatter stripping, system-message contract (no `transfer_task` boilerplate), and the markdown pass-through.

`task lint` clean, `task test` green, `-race` clean across the touched packages.
