### PR TITLE
docs+config: surface the two env-variable expansion syntaxes (#2615)

### DIFF
--- a/docs/configuration/agents/index.md
+++ b/docs/configuration/agents/index.md
@@ -301,9 +301,11 @@ $ docker agent run agent.yaml /greet
 $ PROJECT_NAME=myapp ENV=production docker agent run agent.yaml /deploy
 ```
 
-Commands use JavaScript template literal syntax for environment variable interpolation. Undefined variables expand to empty strings.
+Commands use JavaScript template literal syntax (`${env.VAR}`) for environment variable interpolation. Undefined variables expand to empty strings.
 
-The same syntax is also expanded in agent and toolset instructions: `agents.<name>.instruction` and `toolsets[*].instruction` now support `${env.X}` placeholders (with optional `||` defaults and ternary expressions). Note that `agents.<name>.description` and `agents.<name>.welcome_message` already supported this syntax.
+The same syntax is also expanded in agent and toolset instructions: `agents.<name>.instruction` and `toolsets[*].instruction` support `${env.X}` placeholders (with optional `||` defaults and ternary expressions). `agents.<name>.description` and `agents.<name>.welcome_message` also support it.
+
+Note that path-like fields (`working_dir`, `path`) use a different, shell-style syntax (`$VAR`, `${VAR}`, `~`) and do **not** recognize `${env.X}`. See [Variable Expansion in Config Fields]({{ '/configuration/overview/#variable-expansion-in-config-fields' | relative_url }}) for the full table.
 
 ## Complete Example
 

--- a/docs/configuration/overview/index.md
+++ b/docs/configuration/overview/index.md
@@ -205,6 +205,75 @@ API keys and secrets are read from environment variables — never stored in con
 
 </div>
 
+## Variable Expansion in Config Fields
+
+docker-agent uses **two different expansion syntaxes** depending on the field. They are not interchangeable: using the wrong syntax in a field is currently a silent no-op, so the literal string is passed through. Tracking issue: [#2615](https://github.com/docker/docker-agent/issues/2615).
+
+### JavaScript template literals — `${env.VAR}`
+
+Used wherever the agent prompt or HTTP traffic is templated. Backed by a JS evaluator, so you also get `||` defaults, ternaries, and tool calls (`${tool({...})}`).
+
+Applies to:
+
+- `agents.<name>.description`
+- `agents.<name>.welcome_message`
+- `agents.<name>.instruction`
+- `agents.<name>.commands.*` (string form and `instruction:` field)
+- `toolsets[*].instruction`
+- `toolsets[*].headers` and `toolsets[*].remote.headers` (MCP, A2A, OpenAPI, fetch, API)
+- `toolsets[*].env` values (MCP, shell, script, LSP)
+
+```yaml
+agents:
+  root:
+    description: "Assistant for ${env.USER || 'guest'}"
+    commands:
+      deploy: "Deploy ${env.PROJECT_NAME || 'app'} to ${env.ENV || 'staging'}"
+    toolsets:
+      - type: openapi
+        url: https://api.example.com
+        headers:
+          Authorization: "Bearer ${env.INTERNAL_TOKEN}"
+```
+
+Undefined variables expand to the empty string.
+
+### Shell-style — `$VAR`, `${VAR}`, `~`
+
+Used only for filesystem paths. Backed by `os.ExpandEnv` plus tilde expansion against the current user's home directory.
+
+Applies to:
+
+- `agents.<name>.toolsets[*].working_dir` (MCP, LSP)
+- `agents.<name>.toolsets[*].path` (memory, tasks)
+- The `~` prefix is also accepted in any path-like field documented as such.
+
+```yaml
+agents:
+  root:
+    toolsets:
+      - type: memory
+        path: "~/notes/${PROJECT}/memory.db"
+      - type: mcp
+        command: my-server
+        working_dir: "$HOME/work"
+```
+
+The `${env.VAR}` form is **not** recognized in these path fields today.
+
+### Quick reference
+
+| Field                                         | `${env.X}` | `$X` / `${X}` | `~` |
+| --------------------------------------------- | :--------: | :-----------: | :-: |
+| `description`, `welcome_message`              |     ✓      |       ✗       |  ✗  |
+| `instruction` (agent and toolset)             |     ✓      |       ✗       |  ✗  |
+| `commands.*`                                  |     ✓      |       ✗       |  ✗  |
+| `headers`, `remote.headers`                   |     ✓      |       ✗       |  ✗  |
+| `env` values                                  |     ✓      |       ✗       |  ✗  |
+| `working_dir`, `path`                         |     ✗      |       ✓       |  ✓  |
+
+When in doubt, prefer `${env.X}` for prompts and headers, and `${X}` (or `$X`) for paths.
+
 ## Validation
 
 docker-agent validates your configuration at startup:

--- a/docs/configuration/overview/index.md
+++ b/docs/configuration/overview/index.md
@@ -221,7 +221,8 @@ Applies to:
 - `agents.<name>.commands.*` (string form and `instruction:` field)
 - `toolsets[*].instruction`
 - `toolsets[*].headers` and `toolsets[*].remote.headers` (MCP, A2A, OpenAPI, fetch, API)
-- `toolsets[*].env` values (MCP, shell, script, LSP)
+
+For `api` toolsets, `api_config.endpoint` and `api_config.headers` are also rendered through the JS expander (the same syntax applies).
 
 ```yaml
 agents:
@@ -246,6 +247,7 @@ Applies to:
 
 - `agents.<name>.toolsets[*].working_dir` (MCP, LSP)
 - `agents.<name>.toolsets[*].path` (memory, tasks)
+- `agents.<name>.toolsets[*].env` values (MCP, shell, script, LSP) — these go through `os.Expand`, not the JS evaluator, so `${env.X}` is **not** recognized here either.
 - The `~` prefix is also accepted in any path-like field documented as such.
 
 ```yaml
@@ -268,9 +270,9 @@ The `${env.VAR}` form is **not** recognized in these path fields today.
 | `description`, `welcome_message`              |     ✓      |       ✗       |  ✗  |
 | `instruction` (agent and toolset)             |     ✓      |       ✗       |  ✗  |
 | `commands.*`                                  |     ✓      |       ✗       |  ✗  |
-| `headers`, `remote.headers`                   |     ✓      |       ✗       |  ✗  |
-| `env` values                                  |     ✓      |       ✗       |  ✗  |
+| `headers`, `remote.headers`, `api_config.headers` |     ✓      |       ✗       |  ✗  |
 | `working_dir`, `path`                         |     ✗      |       ✓       |  ✓  |
+| `env` values                                  |     ✗      |       ✓       |  ✗  |
 
 When in doubt, prefer `${env.X}` for prompts and headers, and `${X}` (or `$X`) for paths.
 

--- a/docs/configuration/tools/index.md
+++ b/docs/configuration/tools/index.md
@@ -75,7 +75,7 @@ Browse available tools at the [Docker MCP Catalog](https://hub.docker.com/search
 | `tools`       | array  | Optional: only expose these tools                                |
 | `instruction` | string | Custom instructions injected into the agent's context            |
 | `config`      | any    | MCP server-specific configuration (passed during initialization) |
-| `working_dir` | string | Working directory for the MCP gateway subprocess. Only applies when the catalog entry runs as a local process (not remote). Relative paths are resolved against the agent's working directory. |
+| `working_dir` | string | Working directory for the MCP gateway subprocess. Only applies when the catalog entry runs as a local process (not remote). Relative paths are resolved against the agent's working directory. Supports `~` and shell-style `$VAR`/`${VAR}` expansion ([details]({{ '/configuration/overview/#variable-expansion-in-config-fields' | relative_url }})). |
 
 ### Local MCP (stdio)
 
@@ -97,7 +97,7 @@ toolsets:
 | `args` | array | Command arguments |
 | `tools` | array | Optional: only expose these tools |
 | `env` | object | Environment variables (key-value pairs) |
-| `working_dir` | string | Working directory for the MCP server process. Relative paths are resolved against the agent's working directory. Defaults to the agent's working directory when omitted. |
+| `working_dir` | string | Working directory for the MCP server process. Relative paths are resolved against the agent's working directory. Defaults to the agent's working directory when omitted. Supports `~` and shell-style `$VAR`/`${VAR}` expansion ([details]({{ '/configuration/overview/#variable-expansion-in-config-fields' | relative_url }})). |
 | `instruction` | string | Custom instructions injected into the agent's context |
 | `version` | string | Package reference for [auto-installing](#auto-installing-tools) the command binary |
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -60,7 +60,7 @@ func Load(ctx context.Context, source Source) (*latest.Config, error) {
 		return nil, err
 	}
 
-	warnExpansionMismatches(ctx, &config)
+	warnExpansionMismatches(ctx, slog.Default(), &config)
 
 	return &config, nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -60,6 +60,8 @@ func Load(ctx context.Context, source Source) (*latest.Config, error) {
 		return nil, err
 	}
 
+	warnExpansionMismatches(ctx, &config)
+
 	return &config, nil
 }
 

--- a/pkg/config/expansion_warnings.go
+++ b/pkg/config/expansion_warnings.go
@@ -10,51 +10,164 @@ import (
 	"github.com/docker/docker-agent/pkg/config/latest"
 )
 
-// shellEnvVarRef matches a `${IDENT}` where IDENT looks like a shell environment
-// variable name (uppercase letters, digits, underscores, leading non-digit).
-// Used to flag shell-style references that appear in JS-template fields, where
-// they will be silently passed through as literals instead of expanded.
-var shellEnvVarRef = regexp.MustCompile(`\$\{([A-Z_][A-Z0-9_]*)\}`)
+// shellEnvVarRef matches a `${IDENT}` where IDENT looks like an environment
+// variable name accepted by os.Expand (letters, digits, underscores; leading
+// non-digit). Used to flag shell-style references that appear in JS-template
+// fields, where they will be silently passed through as literals instead of
+// expanded.
+var shellEnvVarRef = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)\}`)
 
-// jsEnvRef matches the JS-template form `${env.X}`.
+// jsEnvRef matches the JS-template form `${env.X}`. The leading `\$\{` is
+// followed by optional whitespace and then `env.IDENT`; we deliberately do
+// not anchor the closing brace so the match also fires for expressions like
+// `${env.X || 'fallback'}`.
 var jsEnvRef = regexp.MustCompile(`\$\{\s*env\.[A-Za-z_][A-Za-z0-9_]*`)
+
+// jsEnvRefStrict matches a `${env.X}` reference with no extra JS expression
+// trailing the identifier. Used to flag occurrences in shell-style fields,
+// where ScriptShellToolConfig and other path-like targets only call
+// os.Expand (no JS evaluator), so the literal `${env.X}` is passed through.
+var jsEnvRefStrict = regexp.MustCompile(`\$\{\s*env\.([A-Za-z_][A-Za-z0-9_]*)\s*\}`)
 
 // warnExpansionMismatches scans a loaded config for fields whose contents use
 // the wrong variable-expansion syntax for that field. Two incompatible
-// syntaxes coexist today (issue #2615): JS template literals (`${env.X}`) for
-// prompt/header fields and shell-style (`$VAR`/`${VAR}`) for path fields.
+// syntaxes coexist today (issue #2615):
+//
+//   - JS template literals (`${env.X}`) for prompt/instruction/header/command
+//     fields rendered through pkg/js.
+//   - Shell-style (`$VAR` / `${VAR}` / `~`) for path fields and toolset env
+//     values, processed by os.Expand and pkg/path.
+//
 // Mixing them up currently fails silently; we emit warnings to make the
 // problem visible without changing runtime behavior.
-func warnExpansionMismatches(ctx context.Context, cfg *latest.Config) {
+//
+// The logger is injected (rather than read from slog.Default()) so tests can
+// capture warnings without racing with other goroutines that share the
+// global default logger.
+func warnExpansionMismatches(ctx context.Context, logger *slog.Logger, cfg *latest.Config) {
+	if logger == nil {
+		logger = slog.Default()
+	}
 	for i := range cfg.Agents {
 		a := &cfg.Agents[i]
-		warnJSField(ctx, a.Name, "description", a.Description)
-		warnJSField(ctx, a.Name, "welcome_message", a.WelcomeMessage)
-		warnJSField(ctx, a.Name, "instruction", a.Instruction)
+		warnJSField(ctx, logger, a.Name, "description", a.Description)
+		warnJSField(ctx, logger, a.Name, "welcome_message", a.WelcomeMessage)
+		warnJSField(ctx, logger, a.Name, "instruction", a.Instruction)
 
 		for name, cmd := range a.Commands {
-			warnJSField(ctx, a.Name, "commands."+name+".instruction", cmd.Instruction)
-			warnJSField(ctx, a.Name, "commands."+name+".description", cmd.Description)
+			warnJSField(ctx, logger, a.Name, "commands."+name+".instruction", cmd.Instruction)
+			warnJSField(ctx, logger, a.Name, "commands."+name+".description", cmd.Description)
 		}
 
 		for j := range a.Toolsets {
 			t := &a.Toolsets[j]
 			loc := agentToolsetLocation(a.Name, t, j)
 
-			warnJSField(ctx, loc, "instruction", t.Instruction)
+			warnJSField(ctx, logger, loc, "instruction", t.Instruction)
 			for k, v := range t.Headers {
-				warnJSField(ctx, loc, "headers."+k, v)
+				warnJSField(ctx, logger, loc, "headers."+k, v)
 			}
 			for k, v := range t.Remote.Headers {
-				warnJSField(ctx, loc, "remote.headers."+k, v)
-			}
-			for k, v := range t.Env {
-				warnJSField(ctx, loc, "env."+k, v)
+				warnJSField(ctx, logger, loc, "remote.headers."+k, v)
 			}
 
-			warnPathField(ctx, loc, "working_dir", t.WorkingDir)
-			warnPathField(ctx, loc, "path", t.Path)
+			// APIConfig fields (api toolset): endpoint and headers go through
+			// the JS expander; instruction is rendered as plain text but the
+			// agent still sees it, so a `${VAR}` typo there is silently broken.
+			warnJSField(ctx, logger, loc, "api_config.endpoint", t.APIConfig.Endpoint)
+			warnJSField(ctx, logger, loc, "api_config.instruction", t.APIConfig.Instruction)
+			for k, v := range t.APIConfig.Headers {
+				warnJSField(ctx, logger, loc, "api_config.headers."+k, v)
+			}
+
+			// Toolset env values are expanded with os.Expand (shell-style),
+			// not the JS evaluator, so a stray `${env.X}` is the silent-failure
+			// case here.
+			for k, v := range t.Env {
+				warnPathField(ctx, logger, loc, "env."+k, v)
+			}
+
+			warnPathField(ctx, logger, loc, "working_dir", t.WorkingDir)
+			warnPathField(ctx, logger, loc, "path", t.Path)
+
+			for name, sh := range t.Shell {
+				shellLoc := loc + " shell[" + name + "]"
+				// ScriptShellToolConfig env and working_dir are forwarded
+				// directly to exec.Cmd without expansion, so neither syntax
+				// works there. Flag the JS form because that's the
+				// surprising silent failure (it looks template-y).
+				warnPathField(ctx, logger, shellLoc, "working_dir", sh.WorkingDir)
+				for k, v := range sh.Env {
+					warnPathField(ctx, logger, shellLoc, "env."+k, v)
+				}
+			}
 		}
+
+		warnHooksConfig(ctx, logger, a.Name, a.Hooks)
+	}
+}
+
+// warnHooksConfig walks every hook list on HooksConfig and warns about
+// silently-broken expansions in fields the runtime forwards verbatim
+// (`env`, `working_dir`).
+func warnHooksConfig(ctx context.Context, logger *slog.Logger, agentName string, h *latest.HooksConfig) {
+	if h == nil {
+		return
+	}
+	flat := []struct {
+		name  string
+		hooks []latest.HookDefinition
+	}{
+		{"session_start", h.SessionStart},
+		{"user_prompt_submit", h.UserPromptSubmit},
+		{"turn_start", h.TurnStart},
+		{"turn_end", h.TurnEnd},
+		{"before_llm_call", h.BeforeLLMCall},
+		{"after_llm_call", h.AfterLLMCall},
+		{"session_end", h.SessionEnd},
+		{"pre_compact", h.PreCompact},
+		{"subagent_stop", h.SubagentStop},
+		{"on_user_input", h.OnUserInput},
+		{"stop", h.Stop},
+		{"notification", h.Notification},
+		{"on_error", h.OnError},
+		{"on_max_iterations", h.OnMaxIterations},
+		{"on_agent_switch", h.OnAgentSwitch},
+		{"on_session_resume", h.OnSessionResume},
+		{"on_tool_approval_decision", h.OnToolApprovalDecision},
+		{"before_compaction", h.BeforeCompaction},
+		{"after_compaction", h.AfterCompaction},
+	}
+	for _, g := range flat {
+		for i := range g.hooks {
+			warnHookDefinition(ctx, logger, agentName, g.name, i, &g.hooks[i])
+		}
+	}
+
+	matched := []struct {
+		name     string
+		matchers []latest.HookMatcherConfig
+	}{
+		{"pre_tool_use", h.PreToolUse},
+		{"post_tool_use", h.PostToolUse},
+		{"permission_request", h.PermissionRequest},
+		{"tool_response_transform", h.ToolResponseTransform},
+	}
+	for _, g := range matched {
+		for mi := range g.matchers {
+			for i := range g.matchers[mi].Hooks {
+				name := g.name + "[" + strconv.Itoa(mi) + "]"
+				warnHookDefinition(ctx, logger, agentName, name, i, &g.matchers[mi].Hooks[i])
+			}
+		}
+	}
+}
+
+func warnHookDefinition(ctx context.Context, logger *slog.Logger, agentName, group string, idx int, hook *latest.HookDefinition) {
+	loc := "agent " + agentName + " hooks." + group + "[" + strconv.Itoa(idx) + "]"
+	warnPathField(ctx, logger, loc, "working_dir", hook.WorkingDir)
+	for k, v := range hook.Env {
+		warnPathField(ctx, logger, loc, "env."+k, v)
 	}
 }
 
@@ -66,12 +179,12 @@ func agentToolsetLocation(agentName string, t *latest.Toolset, idx int) string {
 	return "agent " + agentName + " toolset[" + strconv.Itoa(idx) + "] (" + kind + ")"
 }
 
-// warnJSField warns when a JS-template field contains a `${VAR}` reference
-// that looks like a shell variable name (uppercase identifier) and no
-// `${env.X}` appears in the same value. Such references are kept literal at
-// runtime instead of being expanded.
-func warnJSField(ctx context.Context, loc, field, value string) {
-	if value == "" {
+// warnJSField warns when a JS-template field contains a `${IDENT}` reference
+// that isn't a `${env.X}` expression and no `${env.X}` appears elsewhere in
+// the same value. Such references are kept literal at runtime instead of
+// being expanded.
+func warnJSField(ctx context.Context, logger *slog.Logger, loc, field, value string) {
+	if value == "" || !strings.Contains(value, "${") {
 		return
 	}
 	if jsEnvRef.MatchString(value) {
@@ -79,7 +192,7 @@ func warnJSField(ctx context.Context, loc, field, value string) {
 		return
 	}
 	for _, m := range shellEnvVarRef.FindAllStringSubmatch(value, -1) {
-		slog.WarnContext(ctx,
+		logger.WarnContext(ctx,
 			"shell-style ${VAR} in JS-expanded field will not be substituted; use ${env.VAR}",
 			"location", loc,
 			"field", field,
@@ -89,21 +202,21 @@ func warnJSField(ctx context.Context, loc, field, value string) {
 	}
 }
 
-// warnPathField warns when a path field contains a `${env.X}` reference,
-// which is JS-template syntax that path expansion (os.ExpandEnv + ~) does not
-// recognize.
-func warnPathField(ctx context.Context, loc, field, value string) {
-	if value == "" {
+// warnPathField warns when a shell-style field contains a `${env.X}`
+// reference, which is JS-template syntax that os.Expand / path.ExpandPath
+// does not recognize. The variable name is captured but the surrounding
+// value is not, since path/env values frequently contain credentials.
+func warnPathField(ctx context.Context, logger *slog.Logger, loc, field, value string) {
+	if value == "" || !strings.Contains(value, "${env.") {
 		return
 	}
-	if !strings.Contains(value, "${env.") {
-		return
+	for _, m := range jsEnvRefStrict.FindAllStringSubmatch(value, -1) {
+		logger.WarnContext(ctx,
+			"JS-style ${env.X} in shell-expanded field will not be substituted; use ${X} or $X",
+			"location", loc,
+			"field", field,
+			"variable", m[1],
+			"see", "https://github.com/docker/docker-agent/issues/2615",
+		)
 	}
-	slog.WarnContext(ctx,
-		"JS-style ${env.X} in path field will not be substituted; use ${X} or $X",
-		"location", loc,
-		"field", field,
-		"value", value,
-		"see", "https://github.com/docker/docker-agent/issues/2615",
-	)
 }

--- a/pkg/config/expansion_warnings.go
+++ b/pkg/config/expansion_warnings.go
@@ -1,0 +1,109 @@
+package config
+
+import (
+	"context"
+	"log/slog"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/docker/docker-agent/pkg/config/latest"
+)
+
+// shellEnvVarRef matches a `${IDENT}` where IDENT looks like a shell environment
+// variable name (uppercase letters, digits, underscores, leading non-digit).
+// Used to flag shell-style references that appear in JS-template fields, where
+// they will be silently passed through as literals instead of expanded.
+var shellEnvVarRef = regexp.MustCompile(`\$\{([A-Z_][A-Z0-9_]*)\}`)
+
+// jsEnvRef matches the JS-template form `${env.X}`.
+var jsEnvRef = regexp.MustCompile(`\$\{\s*env\.[A-Za-z_][A-Za-z0-9_]*`)
+
+// warnExpansionMismatches scans a loaded config for fields whose contents use
+// the wrong variable-expansion syntax for that field. Two incompatible
+// syntaxes coexist today (issue #2615): JS template literals (`${env.X}`) for
+// prompt/header fields and shell-style (`$VAR`/`${VAR}`) for path fields.
+// Mixing them up currently fails silently; we emit warnings to make the
+// problem visible without changing runtime behavior.
+func warnExpansionMismatches(ctx context.Context, cfg *latest.Config) {
+	for i := range cfg.Agents {
+		a := &cfg.Agents[i]
+		warnJSField(ctx, a.Name, "description", a.Description)
+		warnJSField(ctx, a.Name, "welcome_message", a.WelcomeMessage)
+		warnJSField(ctx, a.Name, "instruction", a.Instruction)
+
+		for name, cmd := range a.Commands {
+			warnJSField(ctx, a.Name, "commands."+name+".instruction", cmd.Instruction)
+			warnJSField(ctx, a.Name, "commands."+name+".description", cmd.Description)
+		}
+
+		for j := range a.Toolsets {
+			t := &a.Toolsets[j]
+			loc := agentToolsetLocation(a.Name, t, j)
+
+			warnJSField(ctx, loc, "instruction", t.Instruction)
+			for k, v := range t.Headers {
+				warnJSField(ctx, loc, "headers."+k, v)
+			}
+			for k, v := range t.Remote.Headers {
+				warnJSField(ctx, loc, "remote.headers."+k, v)
+			}
+			for k, v := range t.Env {
+				warnJSField(ctx, loc, "env."+k, v)
+			}
+
+			warnPathField(ctx, loc, "working_dir", t.WorkingDir)
+			warnPathField(ctx, loc, "path", t.Path)
+		}
+	}
+}
+
+func agentToolsetLocation(agentName string, t *latest.Toolset, idx int) string {
+	kind := t.Type
+	if kind == "" {
+		kind = "?"
+	}
+	return "agent " + agentName + " toolset[" + strconv.Itoa(idx) + "] (" + kind + ")"
+}
+
+// warnJSField warns when a JS-template field contains a `${VAR}` reference
+// that looks like a shell variable name (uppercase identifier) and no
+// `${env.X}` appears in the same value. Such references are kept literal at
+// runtime instead of being expanded.
+func warnJSField(ctx context.Context, loc, field, value string) {
+	if value == "" {
+		return
+	}
+	if jsEnvRef.MatchString(value) {
+		// Has a real ${env.X}; assume any other ${...} is intentional JS.
+		return
+	}
+	for _, m := range shellEnvVarRef.FindAllStringSubmatch(value, -1) {
+		slog.WarnContext(ctx,
+			"shell-style ${VAR} in JS-expanded field will not be substituted; use ${env.VAR}",
+			"location", loc,
+			"field", field,
+			"variable", m[1],
+			"see", "https://github.com/docker/docker-agent/issues/2615",
+		)
+	}
+}
+
+// warnPathField warns when a path field contains a `${env.X}` reference,
+// which is JS-template syntax that path expansion (os.ExpandEnv + ~) does not
+// recognize.
+func warnPathField(ctx context.Context, loc, field, value string) {
+	if value == "" {
+		return
+	}
+	if !strings.Contains(value, "${env.") {
+		return
+	}
+	slog.WarnContext(ctx,
+		"JS-style ${env.X} in path field will not be substituted; use ${X} or $X",
+		"location", loc,
+		"field", field,
+		"value", value,
+		"see", "https://github.com/docker/docker-agent/issues/2615",
+	)
+}

--- a/pkg/config/expansion_warnings_test.go
+++ b/pkg/config/expansion_warnings_test.go
@@ -13,18 +13,20 @@ import (
 	"github.com/docker/docker-agent/pkg/config/types"
 )
 
-func captureWarnings(t *testing.T, fn func(ctx context.Context)) string {
+// captureWarnings runs fn with an isolated *slog.Logger and returns the
+// emitted text. The logger is not registered as the process default, so
+// parallel tests sharing slog.Default() are unaffected.
+func captureWarnings(t *testing.T, fn func(ctx context.Context, logger *slog.Logger)) string {
 	t.Helper()
 	var buf bytes.Buffer
-	prev := slog.Default()
-	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
-	t.Cleanup(func() { slog.SetDefault(prev) })
-
-	fn(t.Context())
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	fn(t.Context(), logger)
 	return buf.String()
 }
 
 func TestWarnExpansionMismatches_ShellSyntaxInJSField(t *testing.T) {
+	t.Parallel()
+
 	cfg := &latest.Config{
 		Agents: []latest.AgentConfig{{
 			Name:           "root",
@@ -36,8 +38,8 @@ func TestWarnExpansionMismatches_ShellSyntaxInJSField(t *testing.T) {
 		}},
 	}
 
-	out := captureWarnings(t, func(ctx context.Context) {
-		warnExpansionMismatches(ctx, cfg)
+	out := captureWarnings(t, func(ctx context.Context, logger *slog.Logger) {
+		warnExpansionMismatches(ctx, logger, cfg)
 	})
 
 	assert.Contains(t, out, "USER")
@@ -46,7 +48,27 @@ func TestWarnExpansionMismatches_ShellSyntaxInJSField(t *testing.T) {
 	assert.Contains(t, out, "shell-style")
 }
 
+func TestWarnExpansionMismatches_LowerCaseShellIdent(t *testing.T) {
+	t.Parallel()
+
+	cfg := &latest.Config{
+		Agents: []latest.AgentConfig{{
+			Name:        "root",
+			Description: "Hi ${user}",
+		}},
+	}
+
+	out := captureWarnings(t, func(ctx context.Context, logger *slog.Logger) {
+		warnExpansionMismatches(ctx, logger, cfg)
+	})
+
+	assert.Contains(t, out, "user")
+	assert.Contains(t, out, "shell-style")
+}
+
 func TestWarnExpansionMismatches_JSEnvInPathField(t *testing.T) {
+	t.Parallel()
+
 	cfg := &latest.Config{
 		Agents: []latest.AgentConfig{{
 			Name: "root",
@@ -61,16 +83,45 @@ func TestWarnExpansionMismatches_JSEnvInPathField(t *testing.T) {
 		}},
 	}
 
-	out := captureWarnings(t, func(ctx context.Context) {
-		warnExpansionMismatches(ctx, cfg)
+	out := captureWarnings(t, func(ctx context.Context, logger *slog.Logger) {
+		warnExpansionMismatches(ctx, logger, cfg)
 	})
 
 	assert.Contains(t, out, "JS-style")
 	assert.Contains(t, out, "working_dir")
 	assert.Contains(t, out, "path")
+	assert.Contains(t, out, "HOME")
+	assert.Contains(t, out, "MEM_DIR")
+}
+
+func TestWarnExpansionMismatches_DoesNotLeakValueInPathField(t *testing.T) {
+	t.Parallel()
+
+	const secretToken = "supers3cret-token-DO-NOT-LOG"
+	cfg := &latest.Config{
+		Agents: []latest.AgentConfig{{
+			Name: "root",
+			Toolsets: []latest.Toolset{{
+				Type: "memory",
+				// Realistic shape: secret prefix followed by an unsupported
+				// JS-style expansion. We must surface the variable name so
+				// users can fix the typo, but we must not echo the secret.
+				Path: secretToken + "/${env.MEM_DIR}/db",
+			}},
+		}},
+	}
+
+	out := captureWarnings(t, func(ctx context.Context, logger *slog.Logger) {
+		warnExpansionMismatches(ctx, logger, cfg)
+	})
+
+	assert.Contains(t, out, "MEM_DIR")
+	assert.NotContains(t, out, secretToken, "warning must not include the field's full value")
 }
 
 func TestWarnExpansionMismatches_NoFalsePositives(t *testing.T) {
+	t.Parallel()
+
 	cfg := &latest.Config{
 		Agents: []latest.AgentConfig{{
 			Name:           "root",
@@ -88,7 +139,7 @@ func TestWarnExpansionMismatches_NoFalsePositives(t *testing.T) {
 					"Authorization": "Bearer ${env.TOKEN}",
 				},
 				Env: map[string]string{
-					"FOO": "${env.BAR}",
+					"FOO": "${BAR}",
 				},
 			}, {
 				Type: "memory",
@@ -97,8 +148,8 @@ func TestWarnExpansionMismatches_NoFalsePositives(t *testing.T) {
 		}},
 	}
 
-	out := captureWarnings(t, func(ctx context.Context) {
-		warnExpansionMismatches(ctx, cfg)
+	out := captureWarnings(t, func(ctx context.Context, logger *slog.Logger) {
+		warnExpansionMismatches(ctx, logger, cfg)
 	})
 
 	if strings.Contains(out, "WARN") {
@@ -107,6 +158,8 @@ func TestWarnExpansionMismatches_NoFalsePositives(t *testing.T) {
 }
 
 func TestWarnExpansionMismatches_HeaderMixedWithEnv(t *testing.T) {
+	t.Parallel()
+
 	// When a value already references ${env.X}, we treat any other ${...} as
 	// intentional JS so we don't second-guess legitimate template literals.
 	cfg := &latest.Config{
@@ -122,9 +175,120 @@ func TestWarnExpansionMismatches_HeaderMixedWithEnv(t *testing.T) {
 		}},
 	}
 
-	out := captureWarnings(t, func(ctx context.Context) {
-		warnExpansionMismatches(ctx, cfg)
+	out := captureWarnings(t, func(ctx context.Context, logger *slog.Logger) {
+		warnExpansionMismatches(ctx, logger, cfg)
 	})
 
 	assert.NotContains(t, out, "WARN")
+}
+
+func TestWarnExpansionMismatches_APIConfigHeaders(t *testing.T) {
+	t.Parallel()
+
+	cfg := &latest.Config{
+		Agents: []latest.AgentConfig{{
+			Name: "root",
+			Toolsets: []latest.Toolset{{
+				Type: "api",
+				APIConfig: latest.APIToolConfig{
+					Endpoint: "https://api.example.com/${USER_ID}",
+					Headers: map[string]string{
+						"Authorization": "Bearer ${TOKEN}",
+					},
+				},
+			}},
+		}},
+	}
+
+	out := captureWarnings(t, func(ctx context.Context, logger *slog.Logger) {
+		warnExpansionMismatches(ctx, logger, cfg)
+	})
+
+	assert.Contains(t, out, "USER_ID")
+	assert.Contains(t, out, "TOKEN")
+	assert.Contains(t, out, "shell-style")
+}
+
+func TestWarnExpansionMismatches_ToolsetEnvJSStyle(t *testing.T) {
+	t.Parallel()
+
+	cfg := &latest.Config{
+		Agents: []latest.AgentConfig{{
+			Name: "root",
+			Toolsets: []latest.Toolset{{
+				Type:    "mcp",
+				Command: "x",
+				Env: map[string]string{
+					"TOKEN": "${env.GH_TOKEN}",
+				},
+			}},
+		}},
+	}
+
+	out := captureWarnings(t, func(ctx context.Context, logger *slog.Logger) {
+		warnExpansionMismatches(ctx, logger, cfg)
+	})
+
+	assert.Contains(t, out, "GH_TOKEN")
+	assert.Contains(t, out, "JS-style")
+}
+
+func TestWarnExpansionMismatches_ScriptShellTool(t *testing.T) {
+	t.Parallel()
+
+	cfg := &latest.Config{
+		Agents: []latest.AgentConfig{{
+			Name: "root",
+			Toolsets: []latest.Toolset{{
+				Type: "script",
+				Shell: map[string]latest.ScriptShellToolConfig{
+					"build": {
+						Cmd:        "make",
+						WorkingDir: "${env.WORK}/repo",
+						Env: map[string]string{
+							"FOO": "${env.BAR}",
+						},
+					},
+				},
+			}},
+		}},
+	}
+
+	out := captureWarnings(t, func(ctx context.Context, logger *slog.Logger) {
+		warnExpansionMismatches(ctx, logger, cfg)
+	})
+
+	assert.Contains(t, out, "WORK")
+	assert.Contains(t, out, "BAR")
+	assert.Contains(t, out, "shell[build]")
+}
+
+func TestWarnExpansionMismatches_Hooks(t *testing.T) {
+	t.Parallel()
+
+	cfg := &latest.Config{
+		Agents: []latest.AgentConfig{{
+			Name: "root",
+			Hooks: &latest.HooksConfig{
+				PreToolUse: []latest.HookMatcherConfig{{
+					Matcher: "*",
+					Hooks: []latest.HookDefinition{{
+						Type:       "command",
+						Command:    "echo",
+						WorkingDir: "${env.HOME}/hooks",
+						Env: map[string]string{
+							"X": "${env.Y}",
+						},
+					}},
+				}},
+			},
+		}},
+	}
+
+	out := captureWarnings(t, func(ctx context.Context, logger *slog.Logger) {
+		warnExpansionMismatches(ctx, logger, cfg)
+	})
+
+	assert.Contains(t, out, "HOME")
+	assert.Contains(t, out, "hooks.")
 }

--- a/pkg/config/expansion_warnings_test.go
+++ b/pkg/config/expansion_warnings_test.go
@@ -1,0 +1,130 @@
+package config
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/config/types"
+)
+
+func captureWarnings(t *testing.T, fn func(ctx context.Context)) string {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	fn(t.Context())
+	return buf.String()
+}
+
+func TestWarnExpansionMismatches_ShellSyntaxInJSField(t *testing.T) {
+	cfg := &latest.Config{
+		Agents: []latest.AgentConfig{{
+			Name:           "root",
+			Description:    "Hi ${USER}",
+			WelcomeMessage: "Welcome ${HOME}",
+			Commands: types.Commands{
+				"deploy": types.Command{Instruction: "Deploy ${PROJECT}"},
+			},
+		}},
+	}
+
+	out := captureWarnings(t, func(ctx context.Context) {
+		warnExpansionMismatches(ctx, cfg)
+	})
+
+	assert.Contains(t, out, "USER")
+	assert.Contains(t, out, "HOME")
+	assert.Contains(t, out, "PROJECT")
+	assert.Contains(t, out, "shell-style")
+}
+
+func TestWarnExpansionMismatches_JSEnvInPathField(t *testing.T) {
+	cfg := &latest.Config{
+		Agents: []latest.AgentConfig{{
+			Name: "root",
+			Toolsets: []latest.Toolset{{
+				Type:       "mcp",
+				Command:    "x",
+				WorkingDir: "${env.HOME}/work",
+			}, {
+				Type: "memory",
+				Path: "${env.MEM_DIR}/db",
+			}},
+		}},
+	}
+
+	out := captureWarnings(t, func(ctx context.Context) {
+		warnExpansionMismatches(ctx, cfg)
+	})
+
+	assert.Contains(t, out, "JS-style")
+	assert.Contains(t, out, "working_dir")
+	assert.Contains(t, out, "path")
+}
+
+func TestWarnExpansionMismatches_NoFalsePositives(t *testing.T) {
+	cfg := &latest.Config{
+		Agents: []latest.AgentConfig{{
+			Name:           "root",
+			Description:    "Hello ${env.USER || 'guest'}",
+			WelcomeMessage: "",
+			Instruction:    "Use ${env.PROJECT} carefully",
+			Commands: types.Commands{
+				"greet": types.Command{Instruction: "Hello ${env.USER}"},
+			},
+			Toolsets: []latest.Toolset{{
+				Type:       "mcp",
+				Command:    "x",
+				WorkingDir: "~/work/${PROJECT}",
+				Headers: map[string]string{
+					"Authorization": "Bearer ${env.TOKEN}",
+				},
+				Env: map[string]string{
+					"FOO": "${env.BAR}",
+				},
+			}, {
+				Type: "memory",
+				Path: "$HOME/db",
+			}},
+		}},
+	}
+
+	out := captureWarnings(t, func(ctx context.Context) {
+		warnExpansionMismatches(ctx, cfg)
+	})
+
+	if strings.Contains(out, "WARN") {
+		t.Errorf("unexpected warnings emitted: %s", out)
+	}
+}
+
+func TestWarnExpansionMismatches_HeaderMixedWithEnv(t *testing.T) {
+	// When a value already references ${env.X}, we treat any other ${...} as
+	// intentional JS so we don't second-guess legitimate template literals.
+	cfg := &latest.Config{
+		Agents: []latest.AgentConfig{{
+			Name: "root",
+			Toolsets: []latest.Toolset{{
+				Type: "openapi",
+				URL:  "https://x",
+				Headers: map[string]string{
+					"X": "${env.A} ${B}",
+				},
+			}},
+		}},
+	}
+
+	out := captureWarnings(t, func(ctx context.Context) {
+		warnExpansionMismatches(ctx, cfg)
+	})
+
+	assert.NotContains(t, out, "WARN")
+}


### PR DESCRIPTION
Stop-gap for #2615 — surfaces the silently-failing variable-expansion mismatch in agent YAML without changing runtime behavior.

## Background

Agent YAML uses two incompatible expansion syntaxes:

- **JS template literals** — `${env.X}` (with `||` defaults, ternaries, tool calls). Used in `description`, `welcome_message`, `instruction`, `commands`, headers, and `api_config`. Backed by `pkg/js`.
- **Shell-style** — `$VAR`, `${VAR}`, `~`. Used in path-like fields (`working_dir`, toolset `path`) and toolset/hook `env` values. Backed by `os.Expand` / `pkg/path`.

Mixing them up (e.g. `${USER}` in a `description`, or `${env.HOME}` in a `working_dir`) is a silent no-op: the literal string is passed through. This bites users every few weeks.

PR #2710 attempts a runtime unification but is blocked on design (reflection-based walker, breaking `Source` interface). This PR takes the smaller steps the issue explicitly invited:

1. **Document the rules.**
2. **Warn at config-load time** so the silent failure becomes visible.

Runtime behavior is unchanged.

## What's in this PR

### Documentation

`docs/configuration/overview/index.md` gets a new "Variable Expansion in Config Fields" section with a quick-reference table:

| Field                            | `${env.X}` | `$X` / `${X}` | `~` |
| -------------------------------- | :--------: | :-----------: | :-: |
| `description`, `welcome_message` |     ✓      |       ✗       |  ✗  |
| `instruction` (agent + toolset)  |     ✓      |       ✗       |  ✗  |
| `commands.*`                     |     ✓      |       ✗       |  ✗  |
| `headers`, `remote.headers`      |     ✓      |       ✗       |  ✗  |
| `api_config.endpoint`/`headers`  |     ✓      |       ✗       |  ✗  |
| `working_dir`, `path`            |     ✗      |       ✓       |  ✓  |
| `env` values (toolset/hook)      |     ✗      |       ✓       |  ✗  |

Cross-links added from `docs/configuration/agents/index.md` and `docs/configuration/tools/index.md`.

### Warnings at config-load

`pkg/config/expansion_warnings.go` adds `warnExpansionMismatches`, called at the end of `config.Load`. It walks every agent + toolset + hook and emits a single `slog.Warn` per offending occurrence with `location`, `field`, `variable`, and a link to #2615.

Two cases:

- **Shell-style in JS field**: `${IDENT}` in `description`, `welcome_message`, `instruction`, `commands`, headers (`headers`, `remote.headers`, `api_config.headers`), `api_config.endpoint`, `api_config.instruction`. Suppressed when the same value also contains a real `${env.X}` so legitimate JS templates with non-env interpolations don't false-positive.
- **JS-style in shell field**: `${env.X}` in `working_dir`, toolset `path`, toolset `env`, `script` shell `working_dir`/`env`, all hook `working_dir`/`env`.

The warning logs the **variable name and location only** — never the full field value, since `path:`/`env:` values often contain credentials.

### Tests

10 table tests in `pkg/config/expansion_warnings_test.go` cover both directions, false-positive avoidance, secret non-leakage, lowercase identifiers, mixed JS+shell headers, `APIConfig`, `ScriptShellToolConfig`, and hooks. All run with `t.Parallel()` because the logger is dependency-injected (no global `slog.Default()` mutation).

## Validation

- `task build` ✓
- `task test` ✓ (all packages pass with `-race`)
- `task lint` ✓ (0 issues, custom lint clean, `go.mod` tidy)

## Commits

```text
docs: clarify which env-variable expansion syntax applies per field
feat(config): warn on mismatched env-variable expansion syntax
docs: correct env-value expansion syntax
fix(config): harden expansion mismatch warnings
```

The two `fix:`/`docs:` follow-ups came out of self-review; happy to squash on merge.

## Out of scope

- Runtime unification of the two syntaxes (#2710).
- Threading the agent's `EnvProvider` through `pkg/path/expand.go` so secrets / env files reach `working_dir`. Tracked as a follow-up — it's a small, contained change once this lands.

Closes part of #2615 (documentation + visibility); leaves it open for the runtime unification.
