### PR TITLE
refactor(api): fold model override into runAgent request body

### DIFF
--- a/docs/features/api-server/index.md
+++ b/docs/features/api-server/index.md
@@ -53,8 +53,6 @@ All endpoints are under the `/api` prefix.
 | `POST`   | `/api/sessions/:id/steer`           | Inject messages into a running turn (pre-empts current) |
 | `POST`   | `/api/sessions/:id/followup`        | Enqueue messages to run after the current turn finishes |
 | `GET`    | `/api/sessions/:id/models`          | List available models for the session's current agent   |
-| `PATCH`  | `/api/sessions/:id/model`           | Set or clear the agent's model override                 |
-| `POST`   | `/api/sessions/:id/model`           | Set or clear the agent's model override (backward compat with RemoteRuntime) |
 
 ### Agent Execution
 
@@ -77,19 +75,19 @@ All endpoints are under the `/api` prefix.
 # Run the root agent:
 curl -N -X POST http://localhost:8080/api/sessions/$SID/agent/my-assistant \
   -H "Content-Type: application/json" \
-  -d '[{"role": "user", "content": "Hello!"}]'
+  -d '{"messages":[{"role": "user", "content": "Hello!"}]}'
 
 # Multi-agent config: team.yaml (defines agents: root, coder, reviewer)
 # Start: docker agent serve api team.yaml
 # Run the root agent:
 curl -N -X POST http://localhost:8080/api/sessions/$SID/agent/team \
   -H "Content-Type: application/json" \
-  -d '[{"role": "user", "content": "Review this PR"}]'
+  -d '{"messages":[{"role": "user", "content": "Review this PR"}]}'
 
 # Run a specific sub-agent (reviewer):
 curl -N -X POST http://localhost:8080/api/sessions/$SID/agent/team/reviewer \
   -H "Content-Type: application/json" \
-  -d '[{"role": "user", "content": "Review this PR"}]'
+  -d '{"messages":[{"role": "user", "content": "Review this PR"}]}'
 ```
 
 ### Health
@@ -100,14 +98,19 @@ curl -N -X POST http://localhost:8080/api/sessions/$SID/agent/team/reviewer \
 
 ## Streaming Responses
 
-The agent execution endpoints (`POST /api/sessions/:id/agent/:agent`) return **Server-Sent Events (SSE)**. Each event is a JSON object representing a runtime event (remember that `:agent` is the config filename without the `.yaml` extension):
+The agent execution endpoints (`POST /api/sessions/:id/agent/:agent`) return **Server-Sent Events (SSE)**. The request body is a JSON object with a `messages` array and an optional `model` field. Setting `model` applies a persistent per-agent override on the session before the turn starts (subsequent turns reuse it). An empty or omitted `model` leaves the existing override untouched. (Each event is a JSON object representing a runtime event — remember that `:agent` is the config filename without the `.yaml` extension.):
 
 ```bash
 # Send a message and stream the response
 # (assuming the server was started with: docker agent serve api my-agent.yaml)
 $ curl -N -X POST http://localhost:8080/api/sessions/$SID/agent/my-agent \
   -H "Content-Type: application/json" \
-  -d '[{"role": "user", "content": "Hello!"}]'
+  -d '{"messages":[{"role": "user", "content": "Hello!"}]}'
+
+# Same call, but switch the agent's model for this turn (and persist it):
+$ curl -N -X POST http://localhost:8080/api/sessions/$SID/agent/my-agent \
+  -H "Content-Type: application/json" \
+  -d '{"messages":[{"role":"user","content":"Hello!"}],"model":"openai/gpt-4o"}'
 
 # Response (SSE stream):
 data: {"type":"stream_started","session_id":"...","agent":"root"}
@@ -148,7 +151,7 @@ $ curl -X POST http://localhost:8080/api/sessions \
 # 3. Run the agent with a message
 $ curl -N -X POST http://localhost:8080/api/sessions/abc-123/agent/my-agent \
   -H "Content-Type: application/json" \
-  -d '[{"role":"user","content":"What files are in the current directory?"}]'
+  -d '{"messages":[{"role":"user","content":"What files are in the current directory?"}]}'
 ```
 
 ## CLI Flags

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -271,14 +271,13 @@ type SessionStatusResponse struct {
 	NumMessages  int    `json:"num_messages"`
 }
 
-// SetSessionModelRequest is the body of PATCH /api/sessions/:id/model.
-// An empty Model clears the override and reverts to the agent's default.
-type SetSessionModelRequest struct {
-	Model string `json:"model"`
-}
-
-// SetSessionModelResponse is the response from PATCH /api/sessions/:id/model.
-type SetSessionModelResponse struct {
-	Agent string `json:"agent"`
-	Model string `json:"model,omitempty"`
+// RunAgentRequest is the body of POST /api/sessions/:id/agent/:agent[/:agent_name].
+// It carries the user messages to enqueue plus an optional Model override
+// applied to the session's current agent before the turn starts. The
+// override is persistent (mirrors what setting a model on the session
+// would do) so subsequent turns reuse it. An empty Model leaves the
+// current override untouched.
+type RunAgentRequest struct {
+	Messages []Message `json:"messages"`
+	Model    string    `json:"model,omitempty"`
 }

--- a/pkg/runtime/client.go
+++ b/pkg/runtime/client.go
@@ -329,23 +329,28 @@ func (c *Client) GetDesktopToken(ctx context.Context) (*api.DesktopTokenResponse
 	return &resp, err
 }
 
-// RunAgent executes an agent and returns a channel of streaming events
-func (c *Client) RunAgent(ctx context.Context, sessionID, agent string, messages []api.Message) (<-chan Event, error) {
-	return c.runAgentWithAgentName(ctx, sessionID, agent, "", messages)
+// RunAgent executes an agent and returns a channel of streaming events. The
+// optional model override is persisted on the session's current agent before
+// the user messages are appended; pass an empty string to leave the existing
+// override (if any) untouched.
+func (c *Client) RunAgent(ctx context.Context, sessionID, agent string, messages []api.Message, model string) (<-chan Event, error) {
+	return c.runAgentWithAgentName(ctx, sessionID, agent, "", messages, model)
 }
 
-// RunAgentWithAgentName executes an agent with a specific agent name and returns a channel of streaming events
-func (c *Client) RunAgentWithAgentName(ctx context.Context, sessionID, agent, agentName string, messages []api.Message) (<-chan Event, error) {
-	return c.runAgentWithAgentName(ctx, sessionID, agent, agentName, messages)
+// RunAgentWithAgentName executes an agent with a specific agent name and
+// returns a channel of streaming events. See [Client.RunAgent] for the
+// semantics of model.
+func (c *Client) RunAgentWithAgentName(ctx context.Context, sessionID, agent, agentName string, messages []api.Message, model string) (<-chan Event, error) {
+	return c.runAgentWithAgentName(ctx, sessionID, agent, agentName, messages, model)
 }
 
-func (c *Client) runAgentWithAgentName(ctx context.Context, sessionID, agent, agentName string, messages []api.Message) (<-chan Event, error) {
+func (c *Client) runAgentWithAgentName(ctx context.Context, sessionID, agent, agentName string, messages []api.Message, model string) (<-chan Event, error) {
 	endpoint := "/api/sessions/" + sessionID + "/agent/" + agent
 	if agentName != "" {
 		endpoint += "/" + agentName
 	}
 
-	jsonBody, err := json.Marshal(messages)
+	jsonBody, err := json.Marshal(api.RunAgentRequest{Messages: messages, Model: model})
 	if err != nil {
 		return nil, fmt.Errorf("marshaling messages: %w", err)
 	}
@@ -592,12 +597,6 @@ func (c *Client) GetAvailableModels(ctx context.Context) ([]string, error) {
 	var models []string
 	err := c.doRequest(ctx, http.MethodGet, "/api/models", nil, &models)
 	return models, err
-}
-
-// SetAgentModel sets the model for the agent in a session.
-func (c *Client) SetAgentModel(ctx context.Context, sessionID, model string) error {
-	req := map[string]string{"model": model}
-	return c.doRequest(ctx, http.MethodPost, "/api/sessions/"+sessionID+"/model", req, nil)
 }
 
 // GetSessionMCPPrompts returns available MCP prompts for a session.

--- a/pkg/runtime/remote_client.go
+++ b/pkg/runtime/remote_client.go
@@ -25,11 +25,13 @@ type RemoteClient interface {
 	// ResumeElicitation sends an elicitation response
 	ResumeElicitation(ctx context.Context, sessionID string, action tools.ElicitationAction, content map[string]any) error
 
-	// RunAgent executes an agent and returns a channel of streaming events
-	RunAgent(ctx context.Context, sessionID, agent string, messages []api.Message) (<-chan Event, error)
+	// RunAgent executes an agent and returns a channel of streaming events.
+	// model, when non-empty, is applied as a persistent override on the
+	// session's current agent before the turn starts.
+	RunAgent(ctx context.Context, sessionID, agent string, messages []api.Message, model string) (<-chan Event, error)
 
-	// RunAgentWithAgentName executes an agent with a specific agent name
-	RunAgentWithAgentName(ctx context.Context, sessionID, agent, agentName string, messages []api.Message) (<-chan Event, error)
+	// RunAgentWithAgentName executes an agent with a specific agent name. See RunAgent for the meaning of model.
+	RunAgentWithAgentName(ctx context.Context, sessionID, agent, agentName string, messages []api.Message, model string) (<-chan Event, error)
 
 	// SteerSession injects user messages into a running session mid-turn
 	SteerSession(ctx context.Context, sessionID string, messages []api.Message) error
@@ -57,9 +59,6 @@ type RemoteClient interface {
 
 	// GetAvailableModels returns available models for the agent
 	GetAvailableModels(ctx context.Context) ([]string, error)
-
-	// SetAgentModel sets the model for the agent in a session
-	SetAgentModel(ctx context.Context, sessionID, model string) error
 
 	// GetSessionMCPPrompts returns available MCP prompts for a session
 	GetSessionMCPPrompts(ctx context.Context, sessionID string) (map[string]any, error)

--- a/pkg/runtime/remote_contract_test.go
+++ b/pkg/runtime/remote_contract_test.go
@@ -45,11 +45,11 @@ func (s *stubRemoteClient) ResumeElicitation(context.Context, string, tools.Elic
 	return nil
 }
 
-func (s *stubRemoteClient) RunAgent(context.Context, string, string, []api.Message) (<-chan Event, error) {
+func (s *stubRemoteClient) RunAgent(context.Context, string, string, []api.Message, string) (<-chan Event, error) {
 	panic("RunAgent not exercised by the contract test")
 }
 
-func (s *stubRemoteClient) RunAgentWithAgentName(context.Context, string, string, string, []api.Message) (<-chan Event, error) {
+func (s *stubRemoteClient) RunAgentWithAgentName(context.Context, string, string, string, []api.Message, string) (<-chan Event, error) {
 	panic("RunAgentWithAgentName not exercised by the contract test")
 }
 
@@ -87,10 +87,6 @@ func (s *stubRemoteClient) GetSessionTools(context.Context, string) ([]tools.Too
 
 func (s *stubRemoteClient) GetAvailableModels(context.Context) ([]string, error) {
 	return nil, nil
-}
-
-func (s *stubRemoteClient) SetAgentModel(context.Context, string, string) error {
-	return nil
 }
 
 func (s *stubRemoteClient) GetSessionMCPPrompts(context.Context, string) (map[string]any, error) {

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -35,6 +35,14 @@ type RemoteRuntime struct {
 	team                    *team.Team
 	pendingOAuthElicitation *ElicitationRequestEvent
 
+	// pendingModelOverride is the model ref to apply to the current agent
+	// on the next [RemoteRuntime.RunStream] call. It is set by
+	// [RemoteRuntime.SetAgentModel] and consumed once the override has
+	// been forwarded to the server, which persists it server-side as the
+	// session's per-agent override.
+	pendingMu            sync.Mutex
+	pendingModelOverride string
+
 	// resolvedDefault caches the team's default agent name fetched from the
 	// server, so [CurrentAgentName] stays an O(1) field read after the first
 	// call when no specific agent has been selected.
@@ -242,13 +250,18 @@ func (r *RemoteRuntime) RunStream(ctx context.Context, sess *session.Session) <-
 		messages := r.convertSessionMessages(sess)
 		r.sessionID = sess.ID
 
+		r.pendingMu.Lock()
+		model := r.pendingModelOverride
+		r.pendingModelOverride = ""
+		r.pendingMu.Unlock()
+
 		var streamChan <-chan Event
 		var err error
 
 		if r.currentAgent != "" {
-			streamChan, err = r.client.RunAgentWithAgentName(ctx, r.sessionID, r.agentFilename, r.currentAgent, messages)
+			streamChan, err = r.client.RunAgentWithAgentName(ctx, r.sessionID, r.agentFilename, r.currentAgent, messages, model)
 		} else {
-			streamChan, err = r.client.RunAgent(ctx, r.sessionID, r.agentFilename, messages)
+			streamChan, err = r.client.RunAgent(ctx, r.sessionID, r.agentFilename, messages, model)
 		}
 
 		if err != nil {
@@ -544,12 +557,17 @@ func (r *RemoteRuntime) AvailableModels(ctx context.Context) []ModelChoice {
 	return choices
 }
 
-// SetAgentModel sets the model for the agent.
-func (r *RemoteRuntime) SetAgentModel(ctx context.Context, _, modelRef string) error {
-	if r.sessionID == "" {
-		return errors.New("no active session")
-	}
-	return r.client.SetAgentModel(ctx, r.sessionID, modelRef)
+// SetAgentModel queues modelRef as the override to apply on the session's
+// current agent. The override is forwarded to the server on the next
+// [RemoteRuntime.RunStream] call, where the server persists it as the
+// per-agent model override (same effect as the historic dedicated endpoint,
+// just without the extra round trip). A subsequent call before the next
+// turn replaces the queued ref; an empty string clears it.
+func (r *RemoteRuntime) SetAgentModel(_ context.Context, _, modelRef string) error {
+	r.pendingMu.Lock()
+	r.pendingModelOverride = modelRef
+	r.pendingMu.Unlock()
+	return nil
 }
 
 // SupportsModelSwitching returns true for remote runtimes (model switching is handled server-side).

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -250,9 +250,12 @@ func (r *RemoteRuntime) RunStream(ctx context.Context, sess *session.Session) <-
 		messages := r.convertSessionMessages(sess)
 		r.sessionID = sess.ID
 
+		// Snapshot the queued override but do NOT clear it yet: if the
+		// request fails before the server can persist it, clearing here
+		// would silently drop the user's switch. We only clear after the
+		// server has accepted the request (i.e. RunAgent returned a stream).
 		r.pendingMu.Lock()
 		model := r.pendingModelOverride
-		r.pendingModelOverride = ""
 		r.pendingMu.Unlock()
 
 		var streamChan <-chan Event
@@ -267,6 +270,17 @@ func (r *RemoteRuntime) RunStream(ctx context.Context, sess *session.Session) <-
 		if err != nil {
 			events <- Error(fmt.Sprintf("failed to start remote agent: %v", err))
 			return
+		}
+
+		// Server accepted the request, so the override (if any) has been
+		// forwarded; clear it but only if no concurrent SetAgentModel
+		// queued a newer ref while we were dispatching.
+		if model != "" {
+			r.pendingMu.Lock()
+			if r.pendingModelOverride == model {
+				r.pendingModelOverride = ""
+			}
+			r.pendingMu.Unlock()
 		}
 
 		// Consume events from the agent stream

--- a/pkg/runtime/remote_runtime_test.go
+++ b/pkg/runtime/remote_runtime_test.go
@@ -1,0 +1,105 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/api"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/session"
+)
+
+// runStreamRecordingClient is a stubRemoteClient variant that records the
+// model ref forwarded to RunAgent / RunAgentWithAgentName and lets the test
+// inject a synthetic dispatch error so the early-error path is exercised.
+type runStreamRecordingClient struct {
+	stubRemoteClient
+
+	runErr        error
+	gotModel      string
+	gotInvocation int
+}
+
+func (c *runStreamRecordingClient) RunAgent(_ context.Context, _, _ string, _ []api.Message, model string) (<-chan Event, error) {
+	c.gotInvocation++
+	c.gotModel = model
+	if c.runErr != nil {
+		return nil, c.runErr
+	}
+	ch := make(chan Event)
+	close(ch)
+	return ch, nil
+}
+
+func (c *runStreamRecordingClient) RunAgentWithAgentName(ctx context.Context, sessionID, agent, _ string, msgs []api.Message, model string) (<-chan Event, error) {
+	return c.RunAgent(ctx, sessionID, agent, msgs, model)
+}
+
+// TestRemoteRuntime_SetAgentModel_RetainsOverrideOnDispatchError pins the
+// fix for the silent-drop bug: when the next RunStream's HTTP dispatch
+// fails (network, auth, server unavailable), the queued override MUST
+// remain queued so the next attempt still applies the user's chosen
+// model. Clearing it eagerly would silently swallow the request.
+func TestRemoteRuntime_SetAgentModel_RetainsOverrideOnDispatchError(t *testing.T) {
+	t.Parallel()
+
+	client := &runStreamRecordingClient{
+		stubRemoteClient: stubRemoteClient{
+			cfg: &latest.Config{Agents: latest.Agents{{Name: "test"}}},
+		},
+		runErr: errors.New("dial tcp: connection refused"),
+	}
+	rt, err := NewRemoteRuntime(client)
+	require.NoError(t, err)
+
+	require.NoError(t, rt.SetAgentModel(t.Context(), "test", "openai/gpt-4o"))
+
+	// First RunStream fails to dispatch — drain the error event.
+	sess := &session.Session{ID: "s1"}
+	for range rt.RunStream(t.Context(), sess) {
+	}
+	require.Equal(t, 1, client.gotInvocation)
+	require.Equal(t, "openai/gpt-4o", client.gotModel)
+
+	// Second RunStream must re-forward the override since the first
+	// attempt never reached the server.
+	client.runErr = nil
+	for range rt.RunStream(t.Context(), sess) {
+	}
+	require.Equal(t, 2, client.gotInvocation)
+	assert.Equal(t, "openai/gpt-4o", client.gotModel, "override must persist after dispatch error")
+
+	// Once successfully forwarded, a subsequent call without a new
+	// SetAgentModel must NOT re-send the same override (it is now
+	// owned by the server-side session state).
+	client.gotModel = "sentinel"
+	for range rt.RunStream(t.Context(), sess) {
+	}
+	require.Equal(t, 3, client.gotInvocation)
+	assert.Empty(t, client.gotModel, "override must clear after successful dispatch")
+}
+
+// TestRemoteRuntime_SetAgentModel_LatestQueuedWins guards the
+// concurrent-update path: if SetAgentModel is called between the
+// snapshot and the post-dispatch clear, the newer ref must NOT be
+// silently overwritten.
+func TestRemoteRuntime_SetAgentModel_LatestQueuedWins(t *testing.T) {
+	t.Parallel()
+
+	rt, err := NewRemoteRuntime(&stubRemoteClient{
+		cfg: &latest.Config{Agents: latest.Agents{{Name: "test"}}},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, rt.SetAgentModel(t.Context(), "test", "first"))
+	require.NoError(t, rt.SetAgentModel(t.Context(), "test", "second"))
+
+	rt.pendingMu.Lock()
+	got := rt.pendingModelOverride
+	rt.pendingMu.Unlock()
+	assert.Equal(t, "second", got)
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -72,12 +72,6 @@ func (s *Server) registerRoutes() {
 	group.PATCH("/sessions/:id/tokens", s.updateSessionTokens)
 	group.PATCH("/sessions/:id/starred", s.setSessionStarred)
 	group.GET("/sessions/:id/models", s.getSessionModels)
-	// PATCH is the canonical verb for updating the agent's model. POST is
-	// also accepted because pkg/runtime Client.SetAgentModel (used by
-	// RemoteRuntime) was historically a POST; keep both so a client
-	// upgrade is not required.
-	group.PATCH("/sessions/:id/model", s.setSessionModel)
-	group.POST("/sessions/:id/model", s.setSessionModel)
 	group.POST("/sessions", s.createSession)
 	group.DELETE("/sessions/:id", s.deleteSession)
 	group.POST("/sessions/:id/agent/:agent", s.runAgent)
@@ -359,15 +353,18 @@ func (s *Server) runAgent(c echo.Context) error {
 
 	slog.Debug("Running agent", "agent_filename", agentFilename, "session_id", sessionID, "current_agent", currentAgent)
 
-	var messages []api.Message
-	if err := json.NewDecoder(c.Request().Body).Decode(&messages); err != nil {
+	var req api.RunAgentRequest
+	if err := json.NewDecoder(c.Request().Body).Decode(&req); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid request body: %v", err))
 	}
 
-	streamChan, err := s.sm.RunSession(c.Request().Context(), sessionID, agentFilename, currentAgent, messages)
+	streamChan, err := s.sm.RunSession(c.Request().Context(), sessionID, agentFilename, currentAgent, req.Messages, req.Model)
 	if err != nil {
 		if errors.Is(err, ErrSessionBusy) {
 			return echo.NewHTTPError(http.StatusConflict, err.Error())
+		}
+		if errors.Is(err, ErrModelSwitchingNotSupported) {
+			return echo.NewHTTPError(http.StatusUnprocessableEntity, err.Error())
 		}
 		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to run session: %v", err))
 	}
@@ -588,40 +585,6 @@ func (s *Server) getSessionModels(c echo.Context) error {
 		Agent:           agentName,
 		CurrentModelRef: current,
 		Models:          choices,
-	})
-}
-
-// setSessionModel applies a model override on the session's current agent
-// and persists it. An empty `model` clears the override and reverts the
-// agent to its configured default.
-func (s *Server) setSessionModel(c echo.Context) error {
-	sessionID := c.Param("id")
-
-	var req api.SetSessionModelRequest
-	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid request body: %v", err))
-	}
-
-	agentName, modelRef, err := s.sm.SetSessionAgentModel(c.Request().Context(), sessionID, req.Model)
-	if err != nil {
-		switch {
-		case errors.Is(err, ErrModelSwitchingNotSupported):
-			return echo.NewHTTPError(http.StatusUnprocessableEntity, err.Error())
-		case errors.Is(err, ErrSessionNotRunning):
-			return echo.NewHTTPError(http.StatusNotFound, err.Error())
-		default:
-			// Unknown errors come from the runtime (e.g. an inline model
-			// ref that fails provider creation) or from the session store
-			// (e.g. a write failure). Both are server-side concerns, not
-			// client mistakes, so map to 500. Validation of the request
-			// body itself is handled above by Bind which returns 400.
-			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
-		}
-	}
-
-	return c.JSON(http.StatusOK, api.SetSessionModelResponse{
-		Agent: agentName,
-		Model: modelRef,
 	})
 }
 

--- a/pkg/server/server_attached_test.go
+++ b/pkg/server/server_attached_test.go
@@ -305,7 +305,7 @@ func TestAttachedServer_DeleteWithWaitBlocksUntilStreamStops(t *testing.T) {
 	addr := "http://" + ln.Addr().String()
 
 	// Start a stream so the streaming lock is held.
-	ch, err := sm.RunSession(ctx, sess.ID, "agent", "root", []api.Message{{Content: "hello"}})
+	ch, err := sm.RunSession(ctx, sess.ID, "agent", "root", []api.Message{{Content: "hello"}}, "")
 	require.NoError(t, err)
 
 	// DELETE with wait should block until stream finishes (200ms).

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -34,13 +34,6 @@ type activeRuntimes struct {
 	titleGen *sessiontitle.Generator // Title generator (includes fallback models)
 
 	streaming sync.Mutex // Held while a RunStream is in progress; serialises concurrent requests
-
-	// modelSwitch serialises concurrent SetSessionAgentModel calls on the
-	// same session. It is held across the (potentially slow) runtime I/O
-	// so we never overlap a SetAgentModel + rollback pair with another
-	// switch on the same session, while still allowing other sessions to
-	// make progress.
-	modelSwitch sync.Mutex
 }
 
 // SessionManager manages sessions for HTTP and Connect-RPC servers.
@@ -340,7 +333,14 @@ func (sm *SessionManager) WaitStopped(ctx context.Context, sessionID string, tim
 var ErrSessionBusy = errors.New("session is already processing a request")
 
 // RunSession runs a session with the given messages.
-func (sm *SessionManager) RunSession(ctx context.Context, sessionID, agentFilename, currentAgent string, messages []api.Message) (<-chan runtime.Event, error) {
+//
+// When modelOverride is non-empty, it is applied to the session's current
+// agent before any user messages are appended (and persisted via
+// SetSessionAgentModel) so the override is in effect for this turn and
+// every subsequent one. Validation happens before the messages are
+// recorded so a bad ref does not leave an orphaned user message in the
+// history.
+func (sm *SessionManager) RunSession(ctx context.Context, sessionID, agentFilename, currentAgent string, messages []api.Message, modelOverride string) (<-chan runtime.Event, error) {
 	sm.mux.Lock()
 	defer sm.mux.Unlock()
 	sess, err := sm.sessionStore.GetSession(ctx, sessionID)
@@ -383,6 +383,18 @@ func (sm *SessionManager) RunSession(ctx context.Context, sessionID, agentFilena
 		return nil, ErrSessionBusy
 	}
 
+	// Apply the model override (if any) before persisting the user
+	// messages so that an invalid ref does not leave an orphaned user
+	// message in the history. We hold both sm.mux and streaming, so we
+	// can mutate session fields directly; on store-write failure below
+	// we roll the runtime back to its previous override.
+	prevOverride, hadPrevOverride, undoModelOverride, err := sm.applyRunModelOverride(ctx, runtimeSession, modelOverride)
+	if err != nil {
+		runtimeSession.streaming.Unlock()
+		cancel()
+		return nil, err
+	}
+
 	// Now that we hold the streaming lock, it is safe to mutate the session.
 	// Collect user messages for potential title generation
 	var userMessages []string
@@ -394,6 +406,7 @@ func (sm *SessionManager) RunSession(ctx context.Context, sessionID, agentFilena
 	}
 
 	if err := sm.sessionStore.UpdateSession(ctx, sess); err != nil {
+		undoModelOverride(ctx, prevOverride, hadPrevOverride)
 		runtimeSession.streaming.Unlock()
 		cancel()
 		return nil, err
@@ -693,6 +706,72 @@ func (sm *SessionManager) loadTeamWithConfig(ctx context.Context, agentFilename 
 	return teamloader.LoadWithConfig(ctx, agentSource, runConfig)
 }
 
+// applyRunModelOverride applies modelRef as the per-agent model override
+// on the session backing rs. It mirrors the in-memory mutations that
+// SetSessionAgentModel performs, but without acquiring sm.mux (the
+// caller already holds it) and without an explicit store write — the
+// caller's pending UpdateSession persists the override alongside any
+// user messages in a single round trip.
+//
+// Returns the previous override value (and whether one existed) plus an
+// undo function. If the subsequent store write fails the caller must
+// invoke undo to roll the runtime override back; the in-memory session
+// fields are owned by the caller and rolled back inline.
+func (sm *SessionManager) applyRunModelOverride(ctx context.Context, rs *activeRuntimes, modelRef string) (prevOverride string, hadPrev bool, undo func(context.Context, string, bool), err error) {
+	noop := func(context.Context, string, bool) {}
+	if modelRef == "" {
+		return "", false, noop, nil
+	}
+	if !rs.runtime.SupportsModelSwitching() {
+		return "", false, noop, ErrModelSwitchingNotSupported
+	}
+
+	agentName := rs.runtime.CurrentAgentName()
+	sess := rs.session
+
+	if sess != nil && sess.AgentModelOverrides != nil {
+		prevOverride, hadPrev = sess.AgentModelOverrides[agentName]
+	}
+
+	if err := rs.runtime.SetAgentModel(ctx, agentName, modelRef); err != nil {
+		return "", false, noop, err
+	}
+
+	var appendedCustom bool
+	if sess != nil {
+		if sess.AgentModelOverrides == nil {
+			sess.AgentModelOverrides = make(map[string]string)
+		}
+		sess.AgentModelOverrides[agentName] = modelRef
+		if strings.Contains(modelRef, "/") && !slices.Contains(sess.CustomModelsUsed, modelRef) {
+			sess.CustomModelsUsed = append(sess.CustomModelsUsed, modelRef)
+			appendedCustom = true
+		}
+	}
+
+	undo = func(ctx context.Context, prev string, had bool) {
+		rollback := prev
+		if !had {
+			rollback = ""
+		}
+		if rbErr := rs.runtime.SetAgentModel(ctx, agentName, rollback); rbErr != nil {
+			slog.ErrorContext(ctx, "Failed to roll back runtime model override", "agent", agentName, "error", rbErr)
+		}
+		if sess == nil {
+			return
+		}
+		if had {
+			sess.AgentModelOverrides[agentName] = prev
+		} else {
+			delete(sess.AgentModelOverrides, agentName)
+		}
+		if appendedCustom {
+			sess.CustomModelsUsed = sess.CustomModelsUsed[:len(sess.CustomModelsUsed)-1]
+		}
+	}
+	return prevOverride, hadPrev, undo, nil
+}
+
 // applyStoredOverrides applies the persisted per-agent model overrides on
 // the freshly created runtime. Failures are logged at WARN and otherwise
 // ignored: a stored override that no longer resolves (e.g. because the
@@ -852,18 +931,16 @@ func (sm *SessionManager) AvailableSessionModels(ctx context.Context, sessionID 
 }
 
 // SetSessionAgentModel applies modelRef as the model override for the
-// current agent of the session, persists it to the session store, and
-// tracks custom models for later re-selection. Pass an empty modelRef
+// current agent of the session and persists it. Pass an empty modelRef
 // to clear the override and revert to the agent's default model.
 //
 // On store-write failure the in-memory session state and the runtime
 // override are rolled back so the next call observes a consistent state.
 //
-// Concurrent SetSessionAgentModel calls on the same session are
-// serialised via the session-scoped modelSwitch lock so the runtime,
-// session and store never observe interleaved updates. The manager-wide
-// sm.mux is only held briefly while reading or mutating session fields,
-// never while calling into the runtime or the store.
+// The HTTP server no longer exposes this directly: model overrides are
+// folded into the runAgent request body. The method is kept so in-process
+// callers (notably the TUI's App) can switch models without going through
+// HTTP.
 func (sm *SessionManager) SetSessionAgentModel(ctx context.Context, sessionID, modelRef string) (string, string, error) {
 	rs, ok := sm.runtimeSessions.Load(sessionID)
 	if !ok {
@@ -873,9 +950,6 @@ func (sm *SessionManager) SetSessionAgentModel(ctx context.Context, sessionID, m
 	if !rs.runtime.SupportsModelSwitching() {
 		return "", "", ErrModelSwitchingNotSupported
 	}
-
-	rs.modelSwitch.Lock()
-	defer rs.modelSwitch.Unlock()
 
 	agentName := rs.runtime.CurrentAgentName()
 	sess := rs.session

--- a/pkg/server/session_manager_test.go
+++ b/pkg/server/session_manager_test.go
@@ -121,7 +121,7 @@ func TestRunSession_ConcurrentRequestReturnsErrSessionBusy(t *testing.T) {
 	// Start the first stream.
 	ch1, err := sm.RunSession(ctx, sess.ID, "agent", "root", []api.Message{
 		{Content: "first"},
-	})
+	}, "")
 	require.NoError(t, err)
 
 	// Give the goroutine a moment to acquire the streaming lock.
@@ -130,7 +130,7 @@ func TestRunSession_ConcurrentRequestReturnsErrSessionBusy(t *testing.T) {
 	// The second request should fail immediately with ErrSessionBusy.
 	_, err = sm.RunSession(ctx, sess.ID, "agent", "root", []api.Message{
 		{Content: "second"},
-	})
+	}, "")
 	require.ErrorIs(t, err, ErrSessionBusy)
 
 	// Drain first stream to let it complete.
@@ -140,7 +140,7 @@ func TestRunSession_ConcurrentRequestReturnsErrSessionBusy(t *testing.T) {
 	// After the first stream finishes, a new request should succeed.
 	ch3, err := sm.RunSession(ctx, sess.ID, "agent", "root", []api.Message{
 		{Content: "third"},
-	})
+	}, "")
 	require.NoError(t, err)
 	for range ch3 {
 	}
@@ -158,7 +158,7 @@ func TestRunSession_MessagesNotAddedWhenBusy(t *testing.T) {
 
 	ch1, err := sm.RunSession(ctx, sess.ID, "agent", "root", []api.Message{
 		{Content: "first"},
-	})
+	}, "")
 	require.NoError(t, err)
 
 	time.Sleep(50 * time.Millisecond)
@@ -167,7 +167,7 @@ func TestRunSession_MessagesNotAddedWhenBusy(t *testing.T) {
 
 	_, err = sm.RunSession(ctx, sess.ID, "agent", "root", []api.Message{
 		{Content: "should not be added"},
-	})
+	}, "")
 	require.ErrorIs(t, err, ErrSessionBusy)
 
 	// Messages should not have been added.
@@ -190,7 +190,7 @@ func TestRunSession_SequentialRequestsSucceed(t *testing.T) {
 	for range 3 {
 		ch, err := sm.RunSession(ctx, sess.ID, "agent", "root", []api.Message{
 			{Content: "hello"},
-		})
+		}, "")
 		require.NoError(t, err)
 		for range ch {
 		}
@@ -235,7 +235,7 @@ func TestRunSession_DifferentSessionsConcurrently(t *testing.T) {
 
 	go func() {
 		defer wg.Done()
-		ch, err := sm.RunSession(ctx, sess1.ID, "agent", "root", []api.Message{{Content: "a"}})
+		ch, err := sm.RunSession(ctx, sess1.ID, "agent", "root", []api.Message{{Content: "a"}}, "")
 		assert.NoError(t, err)
 		for range ch {
 		}
@@ -243,7 +243,7 @@ func TestRunSession_DifferentSessionsConcurrently(t *testing.T) {
 
 	go func() {
 		defer wg.Done()
-		ch, err := sm.RunSession(ctx, sess2.ID, "agent", "root", []api.Message{{Content: "b"}})
+		ch, err := sm.RunSession(ctx, sess2.ID, "agent", "root", []api.Message{{Content: "b"}}, "")
 		assert.NoError(t, err)
 		for range ch {
 		}

--- a/pkg/server/session_models_test.go
+++ b/pkg/server/session_models_test.go
@@ -254,7 +254,12 @@ func TestAttachedServer_GetSessionModels_AppendsCustomModels(t *testing.T) {
 	assert.True(t, got.Models[1].IsCustom)
 }
 
-func TestAttachedServer_SetSessionModel_PersistsOverride(t *testing.T) {
+func TestAttachedServer_SetSessionModel_PersistsViaRunAgent(t *testing.T) {
+	// The PATCH /sessions/:id/model endpoint was removed in favour of
+	// folding the model override into POST /sessions/:id/agent/:agent.
+	// This test pins the new path: a runAgent body carrying a model
+	// must apply the override on the runtime AND persist it on the
+	// session as a per-agent override (so the next turn reuses it).
 	t.Parallel()
 
 	ctx := t.Context()
@@ -269,28 +274,32 @@ func TestAttachedServer_SetSessionModel_PersistsOverride(t *testing.T) {
 	sm.AttachRuntime(sess.ID, fake, sess)
 
 	addr := startAttachedServer(t, ctx, sm)
-	resp := httpDoTCP(t, ctx, http.MethodPatch, addr+"/api/sessions/"+sess.ID+"/model",
-		api.SetSessionModelRequest{Model: "anthropic/claude-sonnet-4-0"})
+	resp := httpDoTCP(t, ctx, http.MethodPost,
+		addr+"/api/sessions/"+sess.ID+"/agent/agent.yaml/root",
+		api.RunAgentRequest{
+			Messages: []api.Message{{Content: "hi"}},
+			Model:    "anthropic/claude-sonnet-4-0",
+		})
+	// The body is an SSE stream; we just need confirmation the request
+	// was accepted (no 4xx/5xx) before checking side effects.
+	_ = resp
 
-	var got api.SetSessionModelResponse
-	require.NoError(t, json.Unmarshal(resp, &got))
-	assert.Equal(t, "root", got.Agent)
-	assert.Equal(t, "anthropic/claude-sonnet-4-0", got.Model)
+	require.Eventually(t, func() bool {
+		fake.mu.Lock()
+		defer fake.mu.Unlock()
+		return fake.overrides["root"] == "anthropic/claude-sonnet-4-0"
+	}, 2*time.Second, 10*time.Millisecond, "runtime override was not applied")
 
-	// The runtime must have received the override.
-	fake.mu.Lock()
-	assert.Equal(t, "anthropic/claude-sonnet-4-0", fake.overrides["root"])
-	fake.mu.Unlock()
-
-	// The session in the store must reflect the override and track the
-	// custom model for future picks.
 	stored, err := store.GetSession(ctx, sess.ID)
 	require.NoError(t, err)
 	assert.Equal(t, "anthropic/claude-sonnet-4-0", stored.AgentModelOverrides["root"])
 	assert.Contains(t, stored.CustomModelsUsed, "anthropic/claude-sonnet-4-0")
 }
 
-func TestAttachedServer_SetSessionModel_EmptyClearsOverride(t *testing.T) {
+func TestAttachedServer_RunAgent_EmptyModelLeavesOverrideUntouched(t *testing.T) {
+	// An empty model field on the runAgent body must be a no-op for the
+	// override (it is not a request to clear it). The TUI relies on this
+	// when it sends a regular user turn after a previous /model PATCH.
 	t.Parallel()
 
 	ctx := t.Context()
@@ -301,44 +310,25 @@ func TestAttachedServer_SetSessionModel_EmptyClearsOverride(t *testing.T) {
 	require.NoError(t, store.AddSession(ctx, sess))
 
 	fake := newModelSwitchingRuntime(nil)
+	fake.overrides["root"] = "openai/gpt-4o"
 
 	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
 	sm.AttachRuntime(sess.ID, fake, sess)
 
 	addr := startAttachedServer(t, ctx, sm)
-	_ = httpDoTCP(t, ctx, http.MethodPatch, addr+"/api/sessions/"+sess.ID+"/model",
-		api.SetSessionModelRequest{Model: ""})
-
-	stored, err := store.GetSession(ctx, sess.ID)
-	require.NoError(t, err)
-	_, exists := stored.AgentModelOverrides["root"]
-	assert.False(t, exists, "override should be cleared")
-}
-
-func TestAttachedServer_SetSessionModel_PostVerbAlsoWorks(t *testing.T) {
-	// The pre-existing pkg/runtime Client.SetAgentModel POSTs to
-	// /api/sessions/:id/model. The server must accept POST as well as
-	// PATCH so RemoteRuntime keeps working without a coordinated bump.
-	t.Parallel()
-
-	ctx := t.Context()
-
-	store := session.NewInMemorySessionStore()
-	sess := session.New()
-	require.NoError(t, store.AddSession(ctx, sess))
-
-	fake := newModelSwitchingRuntime(nil)
-
-	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
-	sm.AttachRuntime(sess.ID, fake, sess)
-
-	addr := startAttachedServer(t, ctx, sm)
-	_ = httpDoTCP(t, ctx, http.MethodPost, addr+"/api/sessions/"+sess.ID+"/model",
-		api.SetSessionModelRequest{Model: "openai/gpt-4o"})
+	_ = httpDoTCP(t, ctx, http.MethodPost,
+		addr+"/api/sessions/"+sess.ID+"/agent/agent.yaml/root",
+		api.RunAgentRequest{
+			Messages: []api.Message{{Content: "hi"}},
+		})
 
 	fake.mu.Lock()
 	assert.Equal(t, "openai/gpt-4o", fake.overrides["root"])
 	fake.mu.Unlock()
+
+	stored, err := store.GetSession(ctx, sess.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "openai/gpt-4o", stored.AgentModelOverrides["root"])
 }
 
 func TestAttachedServer_GetSessionModels_NotSupported(t *testing.T) {
@@ -445,7 +435,7 @@ func TestSessionManager_SetSessionAgentModel_RuntimeFailureLeavesStateUntouched(
 // Server-side errors (store-write failures, runtime errors that aren't
 // the well-known sentinels) must be reported as 500, not 400. 400 is
 // reserved for client-side mistakes like an invalid request body.
-func TestAttachedServer_SetSessionModel_StoreFailureReturns500(t *testing.T) {
+func TestAttachedServer_RunAgent_StoreFailureReturns500(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -463,8 +453,8 @@ func TestAttachedServer_SetSessionModel_StoreFailureReturns500(t *testing.T) {
 	store.mu.Unlock()
 
 	addr := startAttachedServer(t, ctx, sm)
-	body := bytes.NewReader([]byte(`{"model":"openai/gpt-4o"}`))
-	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, addr+"/api/sessions/"+sess.ID+"/model", body)
+	body := bytes.NewReader([]byte(`{"messages":[{"role":"user","content":"hi"}],"model":"openai/gpt-4o"}`))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, addr+"/api/sessions/"+sess.ID+"/agent/agent.yaml/root", body)
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
@@ -496,17 +486,6 @@ func TestAttachedServer_ModelEndpoints_404WhenNotRunning(t *testing.T) {
 	t.Run("GET", func(t *testing.T) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, addr+"/api/sessions/"+sess.ID+"/models", http.NoBody)
 		require.NoError(t, err)
-		resp, err := http.DefaultClient.Do(req)
-		require.NoError(t, err)
-		defer resp.Body.Close()
-		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
-	})
-
-	t.Run("PATCH", func(t *testing.T) {
-		body := bytes.NewReader([]byte(`{"model":"openai/gpt-4o"}`))
-		req, err := http.NewRequestWithContext(ctx, http.MethodPatch, addr+"/api/sessions/"+sess.ID+"/model", body)
-		require.NoError(t, err)
-		req.Header.Set("Content-Type", "application/json")
 		resp, err := http.DefaultClient.Do(req)
 		require.NoError(t, err)
 		defer resp.Body.Close()


### PR DESCRIPTION
## Summary

Folds the per-agent model override into the SSE turn-runner endpoint
`POST /api/sessions/:id/agent/:agent[/:agent_name]` and removes the
dedicated `PATCH/POST /api/sessions/:id/model` routes.

The dedicated routes were confusing: clients had to PATCH the model and
then POST the messages in two separate calls, with a race window in
between. This change makes model selection an atomic part of starting
the next turn.

## Wire-level changes

- **`POST /api/sessions/:id/agent/:agent[/:agent_name]`** body changes
  from a bare ` + "`[]Message`" + ` to ` + "`{ \"messages\": [...], \"model\": \"optional/ref\" }`" + `.
  A non-empty ` + "`model`" + ` is applied as a **persistent** per-agent override
  on the session before the user message is appended; empty leaves the
  current override untouched. Validation happens before the message is
  recorded so a bad ref does not leave an orphaned user message in
  history.
- **` + "`PATCH /api/sessions/:id/model`" + `** and **` + "`POST /api/sessions/:id/model`" + `**
  removed (along with ` + "`api.SetSessionModelRequest`" + `/` + "`Response`" + `).
- **` + "`GET /api/sessions/:id/models`" + `** unchanged.

This is a **breaking** change for HTTP clients of ` + "`docker agent serve api`" + `:
- the bare-array body is no longer accepted, and
- the dedicated model endpoint is gone.

The TUI and other in-process callers are unaffected.

## Internal changes

- ` + "`SessionManager.RunSession`" + ` gained a ` + "`modelOverride string`" + ` parameter.
  When set, it is applied via the new ` + "`applyRunModelOverride`" + ` helper
  (validates with the runtime, mutates in-memory session fields, returns
  an ` + "`undo`" + ` closure that rolls the runtime override back if the subsequent
  ` + "`UpdateSession`" + ` store-write fails).
- ` + "`SessionManager.SetSessionAgentModel`" + ` is kept for in-process callers.
  The unused ` + "`activeRuntimes.modelSwitch`" + ` mutex was removed.
- ` + "`runtime.Client.RunAgent`" + `/` + "`RunAgentWithAgentName`" + ` gained a ` + "`model string`" + `
  parameter; ` + "`Client.SetAgentModel`" + ` was removed; the ` + "`RemoteClient`" + `
  interface was updated to match.
- ` + "`RemoteRuntime.SetAgentModel`" + ` now buffers the ref locally
  (` + "`pendingModelOverride`" + ` guarded by ` + "`pendingMu`" + `) and forwards it on the
  next ` + "`RunStream`" + ` rather than calling a separate endpoint. The buffer
  is only cleared **after** the server accepts the request, so a
  transient HTTP failure no longer silently drops the user's switch
  (with a CAS-style guard so a concurrent ` + "`SetAgentModel`" + ` queued mid-dispatch
  is not overwritten).

## Docs

` + "`docs/features/api-server/index.md`" + ` updated with the new request shape and
new ` + "`curl`" + ` examples.

## Validation

- ` + "`task build`" + ` ✅
- ` + "`task test`" + ` ✅
- ` + "`task lint`" + ` ✅ (golangci-lint, custom lint checker, ` + "`go mod tidy`" + `)

## Commits

1. ` + "`refactor: fold model override into runAgent request body`" + ` — main refactor.
2. ` + "`fix(runtime): retain pending model override when RunStream dispatch fails`" + ` —
   addresses a race uncovered during self-review where the ` + "`RemoteRuntime`" + `
   buffer was cleared before the HTTP dispatch could fail, silently
   swallowing the user's model switch on a transient error.