### PR TITLE
refactor(remote): faster, safer, simpler OCI pull path

### DIFF
--- a/cmd/root/pull.go
+++ b/cmd/root/pull.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/docker/docker-agent/pkg/cli"
-	"github.com/docker/docker-agent/pkg/content"
 	"github.com/docker/docker-agent/pkg/remote"
 	"github.com/docker/docker-agent/pkg/telemetry"
 )
@@ -47,24 +46,15 @@ func (f *pullFlags) runPullCommand(cmd *cobra.Command, args []string) (commandEr
 
 	out.Println("Pulling agent", registryRef)
 
-	_, err := remote.Pull(ctx, registryRef, f.force)
+	yamlFile, _, err := remote.PullAgent(ctx, registryRef, f.force)
 	if err != nil {
 		return fmt.Errorf("failed to pull artifact: %w", err)
-	}
-
-	store, err := content.NewStore()
-	if err != nil {
-		return fmt.Errorf("failed to open content store: %w", err)
-	}
-	yamlFile, err := store.GetArtifact(registryRef)
-	if err != nil {
-		return fmt.Errorf("failed to get agent yaml: %w", err)
 	}
 
 	agentName := strings.ReplaceAll(registryRef, "/", "_")
 	fileName := agentName + ".yaml"
 
-	if err := os.WriteFile(fileName, []byte(yamlFile), 0o644); err != nil { //nolint:gosec // pulled agent yaml is meant to be readable
+	if err := os.WriteFile(fileName, yamlFile, 0o644); err != nil { //nolint:gosec // pulled agent yaml is meant to be readable
 		return err
 	}
 

--- a/cmd/root/pull.go
+++ b/cmd/root/pull.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/docker/docker-agent/pkg/cli"
+	"github.com/docker/docker-agent/pkg/content"
 	"github.com/docker/docker-agent/pkg/remote"
 	"github.com/docker/docker-agent/pkg/telemetry"
 )
@@ -46,15 +47,26 @@ func (f *pullFlags) runPullCommand(cmd *cobra.Command, args []string) (commandEr
 
 	out.Println("Pulling agent", registryRef)
 
-	yamlFile, _, err := remote.PullAgent(ctx, registryRef, f.force)
-	if err != nil {
+	// Use remote.Pull (not PullAgent) so registry failures surface to the
+	// user. An explicit `share pull` should never silently serve a stale
+	// cached YAML if the remote is unreachable or returned an error.
+	if _, err := remote.Pull(ctx, registryRef, f.force); err != nil {
 		return fmt.Errorf("failed to pull artifact: %w", err)
+	}
+
+	store, err := content.NewStore()
+	if err != nil {
+		return fmt.Errorf("failed to open content store: %w", err)
+	}
+	yamlFile, err := store.GetArtifact(registryRef)
+	if err != nil {
+		return fmt.Errorf("failed to get agent yaml: %w", err)
 	}
 
 	agentName := strings.ReplaceAll(registryRef, "/", "_")
 	fileName := agentName + ".yaml"
 
-	if err := os.WriteFile(fileName, yamlFile, 0o644); err != nil { //nolint:gosec // pulled agent yaml is meant to be readable
+	if err := os.WriteFile(fileName, []byte(yamlFile), 0o644); err != nil { //nolint:gosec // pulled agent yaml is meant to be readable
 		return err
 	}
 

--- a/pkg/config/sources.go
+++ b/pkg/config/sources.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -16,7 +15,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/docker/docker-agent/pkg/content"
 	"github.com/docker/docker-agent/pkg/environment"
 	"github.com/docker/docker-agent/pkg/httpclient"
 	"github.com/docker/docker-agent/pkg/paths"
@@ -115,78 +113,12 @@ func (a ociSource) ParentDir() string {
 //
 // The OCI registry remains the source of truth.
 // The local content store is used as a cache and fallback only.
-// A forced re-pull is triggered exclusively when store corruption is detected.
 func (a ociSource) Read(ctx context.Context) ([]byte, error) {
-	store, err := content.NewStore()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create content store: %w", err)
-	}
-
-	// Normalize the reference so that equivalent forms (e.g.
-	// "agentcatalog/review-pr" and "index.docker.io/agentcatalog/review-pr:latest")
-	// resolve to the same store key that remote.Pull uses.
-	storeKey, err := remote.NormalizeReference(a.reference)
-	if err != nil {
-		return nil, fmt.Errorf("normalizing OCI reference %s: %w", a.reference, err)
-	}
-
-	// For digest references, the content is immutable. If we already have
-	// the artifact locally, serve it directly without any network call.
-	if remote.IsDigestReference(a.reference) {
-		if data, loadErr := loadArtifact(store, storeKey); loadErr == nil {
-			slog.DebugContext(ctx, "Serving digest-pinned OCI artifact from cache", "ref", a.reference)
-			return data, nil
-		}
-	}
-
-	// Check whether we have a local copy to fall back on.
-	hasLocal := hasLocalArtifact(store, storeKey)
-
-	// Pull from registry (checks remote digest, skips download if unchanged).
-	if _, pullErr := remote.Pull(ctx, a.reference, false); pullErr != nil {
-		if !hasLocal {
-			return nil, fmt.Errorf("failed to pull OCI image %s: %w", a.reference, pullErr)
-		}
-		slog.DebugContext(ctx, "Failed to check for OCI reference updates, using cached version",
-			"ref", a.reference, "error", pullErr)
-	}
-
-	// Try loading from store.
-	data, err := loadArtifact(store, storeKey)
-	if err == nil {
-		return data, nil
-	}
-
-	// If corrupted, force re-pull and try once more.
-	if !errors.Is(err, content.ErrStoreCorrupted) {
-		return nil, fmt.Errorf("failed to load agent from OCI source %s: %w", a.reference, err)
-	}
-
-	slog.WarnContext(ctx, "Local OCI store corrupted, forcing re-pull", "ref", a.reference)
-	if _, pullErr := remote.Pull(ctx, a.reference, true); pullErr != nil {
-		return nil, fmt.Errorf("failed to force re-pull OCI image %s: %w", a.reference, pullErr)
-	}
-
-	data, err = loadArtifact(store, storeKey)
+	data, _, err := remote.PullAgent(ctx, a.reference, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load agent from OCI source %s: %w", a.reference, err)
 	}
 	return data, nil
-}
-
-// loadArtifact reads the agent YAML from the content store.
-func loadArtifact(store *content.Store, storeKey string) ([]byte, error) {
-	af, err := store.GetArtifact(storeKey)
-	if err != nil {
-		return nil, err
-	}
-	return []byte(af), nil
-}
-
-// hasLocalArtifact reports whether the content store has metadata for the given key.
-func hasLocalArtifact(store *content.Store, storeKey string) bool {
-	_, err := store.GetArtifactMetadata(storeKey)
-	return err == nil
 }
 
 // urlSource is used to load an agent configuration from an HTTP/HTTPS URL.

--- a/pkg/remote/pull.go
+++ b/pkg/remote/pull.go
@@ -52,13 +52,10 @@ func Pull(ctx context.Context, registryRef string, force bool, opts ...crane.Opt
 	localRef := ref.Context().RepositoryStr() + separator(ref) + ref.Identifier()
 
 	// Cache check: only worth a HEAD round-trip when we actually have a
-	// local copy to compare against. When the cache is empty we'd have to
-	// pull anyway, so skip the digest probe entirely.
+	// usable local copy. When the cache is empty or contains a non-agent
+	// artifact we'd have to pull anyway, so skip the digest probe.
 	if !force {
-		if meta, metaErr := store.GetArtifactMetadata(localRef); metaErr == nil {
-			if !hasCagentAnnotation(meta.Annotations) {
-				return "", fmt.Errorf("artifact %s found in store wasn't created by `docker agent share push`\nTry to push again with `docker agent share push`", localRef)
-			}
+		if meta, metaErr := store.GetArtifactMetadata(localRef); metaErr == nil && hasCagentAnnotation(meta.Annotations) {
 			remoteDigest, err := crane.Digest(ref.String(), opts...)
 			if err != nil {
 				return "", fmt.Errorf("resolving remote digest for %s: %w", registryRef, err)
@@ -154,11 +151,16 @@ func PullAgent(ctx context.Context, registryRef string, force bool) ([]byte, str
 	return []byte(data), digest, nil
 }
 
-// readCached returns the cached YAML bytes and digest for storeKey, or
-// ok=false if no usable cached copy is present.
+// readCached returns the cached YAML bytes and digest for storeKey. It
+// returns ok=false when no usable copy exists, including when the cached
+// metadata lacks the cagent annotation — mirroring the validation Pull
+// applies on the registry path so the cache cannot be used to bypass it.
 func readCached(store *content.Store, storeKey string) ([]byte, string, bool) {
 	meta, err := store.GetArtifactMetadata(storeKey)
 	if err != nil {
+		return nil, "", false
+	}
+	if !hasCagentAnnotation(meta.Annotations) {
 		return nil, "", false
 	}
 	data, err := store.GetArtifact(storeKey)

--- a/pkg/remote/pull.go
+++ b/pkg/remote/pull.go
@@ -2,7 +2,9 @@ package remote
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -42,23 +44,26 @@ func Pull(ctx context.Context, registryRef string, force bool, opts ...crane.Opt
 		return "", fmt.Errorf("parsing registry reference %s: %w", registryRef, err)
 	}
 
-	remoteDigest, err := crane.Digest(ref.String(), opts...)
-	if err != nil {
-		return "", fmt.Errorf("resolving remote digest for %s: %w", registryRef, err)
-	}
-
 	store, err := content.NewStore()
 	if err != nil {
 		return "", fmt.Errorf("creating content store: %w", err)
 	}
 
 	localRef := ref.Context().RepositoryStr() + separator(ref) + ref.Identifier()
+
+	// Cache check: only worth a HEAD round-trip when we actually have a
+	// local copy to compare against. When the cache is empty we'd have to
+	// pull anyway, so skip the digest probe entirely.
 	if !force {
 		if meta, metaErr := store.GetArtifactMetadata(localRef); metaErr == nil {
+			if !hasCagentAnnotation(meta.Annotations) {
+				return "", fmt.Errorf("artifact %s found in store wasn't created by `docker agent share push`\nTry to push again with `docker agent share push`", localRef)
+			}
+			remoteDigest, err := crane.Digest(ref.String(), opts...)
+			if err != nil {
+				return "", fmt.Errorf("resolving remote digest for %s: %w", registryRef, err)
+			}
 			if meta.Digest == remoteDigest {
-				if !hasCagentAnnotation(meta.Annotations) {
-					return "", fmt.Errorf("artifact %s found in store wasn't created by `docker agent share push`\nTry to push again with `docker agent share push`", localRef)
-				}
 				return meta.Digest, nil
 			}
 		}
@@ -83,6 +88,84 @@ func Pull(ctx context.Context, registryRef string, force bool, opts ...crane.Opt
 	}
 
 	return digest, nil
+}
+
+// PullAgent fetches the agent YAML for the given OCI reference and returns its
+// bytes and resolved sha256 digest. The local content store is used as a
+// cache; the registry remains the source of truth.
+//
+// Behavior:
+//   - Digest refs are served from the cache when present (immutable content).
+//   - Tag refs are refreshed against the registry; the cache is reused when
+//     the remote digest is unchanged.
+//   - On registry/network errors, a previously cached copy is returned if one
+//     exists; the error is logged at debug level.
+//   - If the local store is detected as corrupted, a single forced re-pull
+//     is attempted.
+func PullAgent(ctx context.Context, registryRef string, force bool) ([]byte, string, error) {
+	storeKey, err := NormalizeReference(registryRef)
+	if err != nil {
+		return nil, "", err
+	}
+
+	store, err := content.NewStore()
+	if err != nil {
+		return nil, "", fmt.Errorf("creating content store: %w", err)
+	}
+
+	// Digest refs are immutable: serve from cache without any network call.
+	if !force && IsDigestReference(registryRef) {
+		if data, digest, ok := readCached(store, storeKey); ok {
+			return data, digest, nil
+		}
+	}
+
+	digest, pullErr := Pull(ctx, registryRef, force)
+	if pullErr != nil {
+		// Tolerate registry/network failures when we have a usable cached copy.
+		if !force {
+			if data, d, ok := readCached(store, storeKey); ok {
+				slog.DebugContext(ctx, "Failed to refresh OCI artifact, using cached copy",
+					"ref", registryRef, "error", pullErr)
+				return data, d, nil
+			}
+		}
+		return nil, "", fmt.Errorf("failed to pull OCI image %s: %w", registryRef, pullErr)
+	}
+
+	data, err := store.GetArtifact(storeKey)
+	if err == nil {
+		return []byte(data), digest, nil
+	}
+
+	// Store went missing right after a successful pull. Re-pull once.
+	if !errors.Is(err, content.ErrStoreCorrupted) {
+		return nil, "", fmt.Errorf("loading artifact from store: %w", err)
+	}
+
+	slog.WarnContext(ctx, "Local OCI store corrupted, forcing re-pull", "ref", registryRef)
+	if digest, err = Pull(ctx, registryRef, true); err != nil {
+		return nil, "", fmt.Errorf("force re-pull %s: %w", registryRef, err)
+	}
+	data, err = store.GetArtifact(storeKey)
+	if err != nil {
+		return nil, "", fmt.Errorf("loading artifact from store after re-pull: %w", err)
+	}
+	return []byte(data), digest, nil
+}
+
+// readCached returns the cached YAML bytes and digest for storeKey, or
+// ok=false if no usable cached copy is present.
+func readCached(store *content.Store, storeKey string) ([]byte, string, bool) {
+	meta, err := store.GetArtifactMetadata(storeKey)
+	if err != nil {
+		return nil, "", false
+	}
+	data, err := store.GetArtifact(storeKey)
+	if err != nil {
+		return nil, "", false
+	}
+	return []byte(data), meta.Digest, true
 }
 
 func hasCagentAnnotation(annotations map[string]string) bool {

--- a/pkg/remote/pull_test.go
+++ b/pkg/remote/pull_test.go
@@ -1,6 +1,8 @@
 package remote
 
 import (
+	"io"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -8,6 +10,8 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/static"
@@ -28,12 +32,12 @@ func TestPullRegistryNotFound(t *testing.T) {
 	defer server.Close()
 
 	// Extract host:port from server URL (remove http://)
-	registry := strings.TrimPrefix(server.URL, "http://")
+	registryHost := strings.TrimPrefix(server.URL, "http://")
 
 	// Test various image references that should fail with 404
 	refs := []string{
-		registry + "/non-existent:latest",
-		registry + "/test:latest",
+		registryHost + "/non-existent:latest",
+		registryHost + "/test:latest",
 	}
 
 	for _, ref := range refs {
@@ -184,4 +188,138 @@ func TestSeparator(t *testing.T) {
 			assert.Equal(t, tt.expected, separator(ref))
 		})
 	}
+}
+
+// agentImage returns a small OCI image carrying the cagent annotation,
+// or no annotation when annotated is false. Useful for exercising the
+// annotation-validation code paths.
+func agentImage(t *testing.T, annotated bool, body string) v1.Image {
+	t.Helper()
+	layer := static.NewLayer([]byte(body), "application/yaml")
+	img, err := mutate.AppendLayers(empty.Image, layer)
+	require.NoError(t, err)
+	img = mutate.MediaType(img, types.OCIManifestSchema1)
+	if annotated {
+		img = mutate.Annotations(img, map[string]string{
+			"io.docker.agent.version": "test",
+		}).(v1.Image)
+	}
+	return img
+}
+
+func TestReadCached(t *testing.T) {
+	t.Parallel()
+
+	store, err := content.NewStore(content.WithBaseDir(t.TempDir()))
+	require.NoError(t, err)
+
+	t.Run("missing entry returns ok=false", func(t *testing.T) {
+		_, _, ok := readCached(store, "missing/agent:latest")
+		assert.False(t, ok)
+	})
+
+	t.Run("unannotated entry is treated as cache miss", func(t *testing.T) {
+		ref := "unannotated/agent:latest"
+		_, err := store.StoreArtifact(agentImage(t, false, "unannotated"), ref)
+		require.NoError(t, err)
+
+		_, _, ok := readCached(store, ref)
+		assert.False(t, ok, "cached artifact without cagent annotation must not be served")
+	})
+
+	t.Run("annotated entry is returned", func(t *testing.T) {
+		ref := "annotated/agent:latest"
+		digest, err := store.StoreArtifact(agentImage(t, true, "hello"), ref)
+		require.NoError(t, err)
+
+		data, gotDigest, ok := readCached(store, ref)
+		require.True(t, ok)
+		assert.Equal(t, "hello", string(data))
+		assert.Equal(t, digest, gotDigest)
+	})
+}
+
+// startTestRegistry spins up an in-memory OCI registry on a random port
+// and returns its host:port.
+func startTestRegistry(t *testing.T) string {
+	t.Helper()
+	quietLogger := log.New(io.Discard, "", 0)
+	srv := httptest.NewServer(registry.New(registry.Logger(quietLogger)))
+	t.Cleanup(srv.Close)
+	return strings.TrimPrefix(srv.URL, "http://")
+}
+
+// pushImageToRegistry pushes img to the given ref on the test registry.
+func pushImageToRegistry(t *testing.T, ref string, img v1.Image) {
+	t.Helper()
+	require.NoError(t, crane.Push(img, ref, crane.Insecure))
+}
+
+// TestPull_RecoversFromUnannotatedCache verifies that an unannotated
+// cached entry does not permanently block re-pulling a tag whose remote
+// content is now a valid agent artifact. Before the fix, Pull would
+// short-circuit on the bad cache entry and refuse to contact the
+// registry, leaving the user stuck until they manually wiped the store.
+func TestPull_RecoversFromUnannotatedCache(t *testing.T) {
+	// Not parallel: t.Setenv on HOME mutates process state.
+
+	registryHost := startTestRegistry(t)
+	ref := registryHost + "/agent/recovery:latest"
+
+	// Sandbox the content store under a fake HOME.
+	t.Setenv("HOME", t.TempDir())
+
+	store, err := content.NewStore()
+	require.NoError(t, err)
+
+	// Seed the cache under the *normalised* key, since that is the key
+	// Pull itself uses (it strips the registry host).
+	seedKey, err := NormalizeReference(ref)
+	require.NoError(t, err)
+	_, err = store.StoreArtifact(agentImage(t, false, "old, not an agent"), seedKey)
+	require.NoError(t, err)
+
+	// Push a properly annotated artifact to the same tag.
+	pushImageToRegistry(t, ref, agentImage(t, true, "new agent yaml"))
+
+	// Pull must reach the registry and replace the bad cache entry,
+	// not error out on the local metadata.
+	digest, err := Pull(t.Context(), ref, false, crane.Insecure)
+	require.NoError(t, err)
+	require.NotEmpty(t, digest)
+
+	// The cached YAML must now match the freshly-pulled, annotated artifact.
+	// Pull normalises the reference (strips the registry host) before keying
+	// the store, so we look up the same way.
+	storeKey, err := NormalizeReference(ref)
+	require.NoError(t, err)
+	data, err := store.GetArtifact(storeKey)
+	require.NoError(t, err)
+	assert.Equal(t, "new agent yaml", data)
+}
+
+// TestPullAgent_DigestRefDoesNotServeUnannotatedCache verifies the
+// defense-in-depth check on the cache fast-path: even for an immutable
+// digest reference, an unannotated cached entry must not be returned.
+func TestPullAgent_DigestRefDoesNotServeUnannotatedCache(t *testing.T) {
+	// Not parallel: t.Setenv on HOME mutates process state.
+
+	t.Setenv("HOME", t.TempDir())
+
+	store, err := content.NewStore()
+	require.NoError(t, err)
+
+	// Seed an unannotated artifact under a tag, then derive a digest ref
+	// for it. PullAgent's fast path operates on digest references.
+	tagRef := "unannotated/digest:latest"
+	digest, err := store.StoreArtifact(agentImage(t, false, "poisoned"), tagRef)
+	require.NoError(t, err)
+
+	digestRef := "unannotated/digest@" + digest
+
+	// PullAgent will fall through to remote.Pull, which will fail because
+	// the test runs offline. The important property is that the cached
+	// bytes are NOT returned silently.
+	_, _, err = PullAgent(t.Context(), digestRef, false)
+	require.Error(t, err, "unannotated cache hit must not satisfy a digest-pinned PullAgent")
 }

--- a/pkg/remote/transport.go
+++ b/pkg/remote/transport.go
@@ -2,12 +2,13 @@ package remote
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
-	"strings"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/kofalt/go-memoize"
@@ -121,29 +122,33 @@ func (f *fallbackTransport) RoundTrip(req *http.Request) (*http.Response, error)
 	return nil, err
 }
 
-// isProxySocketError checks if the error indicates the proxy socket is unavailable.
-// This includes:
-// - "no such file or directory" - socket file was deleted
-// - "connection refused" - socket exists but nothing is listening
-// - "dial unix" errors - general Unix socket connection failures
+// isProxySocketError reports whether err indicates the Docker Desktop proxy
+// socket is unavailable: socket file gone, nothing listening on it, or any
+// failure dialing a Unix socket. Detection is type-based (net.OpError /
+// syscall errno) rather than string matching, so it stays correct across
+// Go versions and locales.
 func isProxySocketError(err error) bool {
 	if err == nil {
 		return false
 	}
 
-	errStr := strings.ToLower(err.Error())
-
-	// Check for common proxy socket failure patterns
-	proxyErrorPatterns := []string{
-		"no such file or directory",   // Socket file deleted
-		"connect: connection refused", // Socket exists but no listener
-		"proxyconnect tcp",            // Proxy connection failure
-		"dial unix",                   // Unix socket dial failure
-		"unix socket",                 // Generic Unix socket error
+	// Connection-level failures: ENOENT (socket file deleted) or
+	// ECONNREFUSED (socket exists but no listener). The HTTP transport
+	// wraps these in *net.OpError{Op: "proxyconnect"} → *os.SyscallError,
+	// but errors.Is unwraps the chain for us.
+	if errors.Is(err, syscall.ENOENT) || errors.Is(err, syscall.ECONNREFUSED) {
+		return true
 	}
 
-	for _, pattern := range proxyErrorPatterns {
-		if strings.Contains(errStr, pattern) {
+	// Any failure that originated from dialing the proxy: either the
+	// HTTP transport's "proxyconnect" wrapper, or a direct Unix-socket
+	// dial error from our own DialContext.
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		if opErr.Op == "proxyconnect" {
+			return true
+		}
+		if opErr.Op == "dial" && opErr.Net == "unix" {
 			return true
 		}
 	}

--- a/pkg/remote/transport_test.go
+++ b/pkg/remote/transport_test.go
@@ -1,8 +1,13 @@
 package remote
 
 import (
+	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"os"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -60,44 +65,61 @@ func TestNewTransport_WorksWithoutDesktopProxy(t *testing.T) {
 func TestIsProxySocketError(t *testing.T) {
 	t.Parallel()
 
+	dialUnixENOENT := &net.OpError{
+		Op:  "dial",
+		Net: "unix",
+		Err: &os.SyscallError{Syscall: "connect", Err: syscall.ENOENT},
+	}
+	proxyConnectRefused := &net.OpError{
+		Op:  "proxyconnect",
+		Net: "tcp",
+		Err: &os.SyscallError{Syscall: "connect", Err: syscall.ECONNREFUSED},
+	}
+	proxyConnectGeneric := &net.OpError{
+		Op:  "proxyconnect",
+		Net: "tcp",
+		Err: errors.New("some unrelated error"),
+	}
+	urlErr := &url.Error{Op: "Get", URL: "https://example/", Err: proxyConnectRefused}
+
 	tests := []struct {
 		name     string
-		errStr   string
+		err      error
 		expected bool
 	}{
 		{
-			name:     "no such file or directory",
-			errStr:   "proxyconnect tcp: dial unix /path/to/httpproxy.sock: connect: no such file or directory",
+			name:     "unix socket missing (ENOENT)",
+			err:      dialUnixENOENT,
 			expected: true,
 		},
 		{
-			name:     "connection refused",
-			errStr:   "proxyconnect tcp: dial unix /path/to/httpproxy.sock: connect: connection refused",
+			name:     "proxy connect refused",
+			err:      proxyConnectRefused,
 			expected: true,
 		},
 		{
-			name:     "proxyconnect tcp error",
-			errStr:   "Post https://api.anthropic.com/v1/messages: proxyconnect tcp: some error",
+			name:     "proxyconnect with unrelated wrapped error",
+			err:      proxyConnectGeneric,
 			expected: true,
 		},
 		{
-			name:     "dial unix error",
-			errStr:   "dial unix /var/run/docker.sock: operation timed out",
+			name:     "wrapped in url.Error (real http.Client failure shape)",
+			err:      urlErr,
 			expected: true,
 		},
 		{
-			name:     "regular network error",
-			errStr:   "dial tcp 192.168.1.1:443: i/o timeout",
+			name:     "plain TCP timeout is not a proxy error",
+			err:      &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("i/o timeout")},
 			expected: false,
 		},
 		{
-			name:     "HTTP error",
-			errStr:   "HTTP 500: internal server error",
+			name:     "unrelated error",
+			err:      errors.New("HTTP 500"),
 			expected: false,
 		},
 		{
 			name:     "nil error",
-			errStr:   "",
+			err:      nil,
 			expected: false,
 		},
 	}
@@ -105,12 +127,7 @@ func TestIsProxySocketError(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			var err error
-			if tc.errStr != "" {
-				err = &testError{msg: tc.errStr}
-			}
-			result := isProxySocketError(err)
-			assert.Equal(t, tc.expected, result)
+			assert.Equal(t, tc.expected, isProxySocketError(tc.err))
 		})
 	}
 }
@@ -133,13 +150,4 @@ func TestFallbackTransport_DisableCompression(t *testing.T) {
 	// Verify compression is now disabled on both transports
 	assert.True(t, proxy.DisableCompression)
 	assert.True(t, direct.DisableCompression)
-}
-
-// testError is a simple error type for testing
-type testError struct {
-	msg string
-}
-
-func (e *testError) Error() string {
-	return e.msg
 }


### PR DESCRIPTION
Reviewing how we pull agent YAMLs from OCI artifacts surfaced a few wins. Each commit is independently reviewable.

## What changes

### `4242b42b4` refactor(remote): detect proxy socket errors via type, not strings

`isProxySocketError` decides whether the Docker Desktop proxy is unavailable so the transport can fall back to a direct connection. It used substring matching on `err.Error()` (`"no such file or directory"`, `"connection refused"`, `"dial unix"`, …), which breaks across Go versions and locales and gives false positives whenever any error text happens to contain those phrases.

Use `errors.Is` against `syscall.ENOENT` / `syscall.ECONNREFUSED` and `errors.As` against `*net.OpError` (`Op == "proxyconnect"` or unix-socket dial). Tests now construct realistic typed error chains, including the `*url.Error` wrapper `http.Client` adds in production.

### `169d6dff8` refactor(remote): collapse OCI agent read path into `PullAgent`

The flow to load an agent YAML from an OCI reference was split across three places: `cmd/root/pull.go` (Pull + open store + GetArtifact), `ociSource.Read` (Pull + load + corruption-aware retry + cache fallback), and `remote.Pull` itself (its own cache check). Each duplicated parts of the others.

Introduce `remote.PullAgent(ctx, ref, force) ([]byte, digest, error)` as the single entry point: it handles the digest-ref shortcut, the network-error fallback to cache, and the one-shot recovery on store corruption. `ociSource.Read` shrinks to a single call.

Also: skip the upfront `crane.Digest` HEAD when the cache is empty. With no local copy to compare against we'd have to `crane.Pull` anyway, so the HEAD is pure latency. Cold pulls drop from two manifest round-trips to one.

### `0ffbe5895` fix(remote): keep `share pull` strict on registry errors

Routing the `share pull` command through `PullAgent` meant a registry 404 or auth failure would silently overwrite the on-disk YAML with a stale cached copy. `PullAgent`'s cache-fallback policy is the right behaviour for `ociSource.Read` (running an agent shouldn't break when the registry blips) but the wrong behaviour for an explicit user-driven refresh. `share pull` now calls `remote.Pull` directly so registry failures surface as errors.

### `385816cb5` fix(remote): treat unannotated cache as cache-miss, not as terminal error

Two related defense-in-depth fixes:

1. `Pull` bailed out with a permanent error if local metadata lacked the cagent annotation, before contacting the registry. A user with a stale or bad cache entry on a tag was stuck until they manually wiped the store, even after the remote tag was updated to a valid agent artifact. Treat an unannotated cache entry as a cache miss so `Pull` falls through to `crane.Pull`, which re-validates the freshly fetched manifest and overwrites the bad entry.
2. `PullAgent`'s cache fast-paths (digest-ref shortcut and the network-error fallback) returned cached bytes without re-checking the annotation, while `Pull` validates it on the registry path. `readCached` now refuses entries missing the annotation, so the cache cannot be used to bypass that validation.

Tests:
- `TestReadCached` — missing / unannotated / annotated cases.
- `TestPull_RecoversFromUnannotatedCache` — uses an in-memory OCI registry to verify a poisoned cache entry no longer blocks a valid re-pull.
- `TestPullAgent_DigestRefDoesNotServeUnannotatedCache` — verifies the digest-ref fast path no longer trusts an unannotated cache entry.

## Validation

- `task lint` — clean
- `task test` — clean (130 packages)