### PR TITLE
feat(api): expose agent_model_overrides on GET /sessions/:id

### DIFF
--- a/docs/features/api-server/index.md
+++ b/docs/features/api-server/index.md
@@ -43,7 +43,7 @@ All endpoints are under the `/api` prefix.
 | -------- | ----------------------------------- | ------------------------------------------------------- |
 | `GET`    | `/api/sessions`                     | List all sessions                                       |
 | `POST`   | `/api/sessions`                     | Create a new session                                    |
-| `GET`    | `/api/sessions/:id`                 | Get a session by ID (messages, tokens, permissions)     |
+| `GET`    | `/api/sessions/:id`                 | Get a session by ID (messages, tokens, permissions, per-agent model overrides) |
 | `DELETE` | `/api/sessions/:id`                 | Delete a session                                        |
 | `PATCH`  | `/api/sessions/:id/title`           | Update session title                                    |
 | `PATCH`  | `/api/sessions/:id/permissions`     | Update session permissions                              |

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -135,6 +135,16 @@ type SessionResponse struct {
 	OutputTokens  int64                      `json:"output_tokens"`
 	WorkingDir    string                     `json:"working_dir,omitempty"`
 	Permissions   *session.PermissionsConfig `json:"permissions,omitempty"`
+	// AgentModelOverrides maps an agent name to the model ref currently
+	// applied as a per-agent override for that agent in this session
+	// (set on prior turns via the `model` field of POST /sessions/:id/agent/:agent).
+	// Empty/omitted when no override is active for any agent — in that
+	// case the agent's YAML-declared default applies. Surfaced here so
+	// clients can rehydrate their UI's model picker after a restart
+	// without having to attach the session's runtime first (the
+	// /models endpoint requires an active runtime, which GET /sessions/:id
+	// deliberately does not).
+	AgentModelOverrides map[string]string `json:"agent_model_overrides,omitempty"`
 }
 
 // UpdateSessionPermissionsRequest represents a request to update session permissions.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -235,15 +235,16 @@ func (s *Server) getSession(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, api.SessionResponse{
-		ID:            sess.ID,
-		Title:         sess.Title,
-		CreatedAt:     sess.CreatedAt,
-		Messages:      sess.GetAllMessages(),
-		ToolsApproved: sess.ToolsApproved,
-		InputTokens:   sess.InputTokens,
-		OutputTokens:  sess.OutputTokens,
-		WorkingDir:    sess.WorkingDir,
-		Permissions:   sess.Permissions,
+		ID:                  sess.ID,
+		Title:               sess.Title,
+		CreatedAt:           sess.CreatedAt,
+		Messages:            sess.GetAllMessages(),
+		ToolsApproved:       sess.ToolsApproved,
+		InputTokens:         sess.InputTokens,
+		OutputTokens:        sess.OutputTokens,
+		WorkingDir:          sess.WorkingDir,
+		Permissions:         sess.Permissions,
+		AgentModelOverrides: sess.AgentModelOverrides,
 	})
 }
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -199,6 +199,59 @@ func TestServer_UpdateSessionTitle(t *testing.T) {
 	assert.Equal(t, newTitle, sessionResp.Title)
 }
 
+// TestGetSession_ModelOverrides pins the behavior that
+// GET /api/sessions/:id surfaces any per-agent model overrides persisted
+// on the session, so clients can rehydrate their model picker after a
+// restart without having to attach the session's runtime first.
+//
+// The /sessions/:id/models endpoint cannot serve this need on its own
+// because it requires an active runtime (see [SessionManager.AvailableSessionModels]);
+// a session loaded purely from the store after a restart has no runtime
+// attached until the user sends the next message.
+func TestGetSession_ModelOverrides(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := session.NewInMemorySessionStore()
+
+	// Seed a session directly in the store with a per-agent override —
+	// this models what's left over on disk after a restart, without
+	// having to spin up a runtime to set it the "real" way.
+	sess := session.New()
+	sess.AgentModelOverrides = map[string]string{
+		"root":       "anthropic/claude-sonnet-4-0",
+		"researcher": "openai/gpt-4o",
+	}
+	require.NoError(t, store.AddSession(ctx, sess))
+
+	lnPath := startServerWithStore(t, ctx, prepareAgentsDir(t), store)
+
+	getResp := httpGET(t, ctx, lnPath, "/api/sessions/"+sess.ID)
+	var got api.SessionResponse
+	unmarshal(t, getResp, &got)
+
+	assert.Equal(t, sess.AgentModelOverrides, got.AgentModelOverrides)
+}
+
+// TestGetSession_NoOverrides guards the `omitempty` tag on
+// AgentModelOverrides: a session without any overrides must not carry
+// an `agent_model_overrides` key in the wire response, so clients can
+// distinguish "no override picked" from "override is the empty map"
+// (which is a wire-level corner case but shows up in tests).
+func TestGetSession_NoOverrides(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := session.NewInMemorySessionStore()
+	sess := session.New()
+	require.NoError(t, store.AddSession(ctx, sess))
+
+	lnPath := startServerWithStore(t, ctx, prepareAgentsDir(t), store)
+
+	getResp := httpGET(t, ctx, lnPath, "/api/sessions/"+sess.ID)
+	assert.NotContains(t, string(getResp), "agent_model_overrides")
+}
+
 func startServerWithStore(t *testing.T, ctx context.Context, agentsDir string, store session.Store) string {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

Surfaces the session's persisted per-agent model overrides on
`GET /api/sessions/:id` so HTTP clients can rehydrate a model picker
after a restart from a single round trip.

## Background

#2852 (released in v1.62.0) made `model` part of the
`POST /api/sessions/:id/agent/:agent` body and removed the dedicated
`PATCH /api/sessions/:id/model` endpoint. A non-empty `model` is
persisted on the session as a per-agent override
(`session.AgentModelOverrides[agentName]`), survives restarts, and is
reused on subsequent turns.

Today the only HTTP-accessible way for a client to read that
persisted state back is `GET /api/sessions/:id/models`, which
requires an active runtime (see
`SessionManager.AvailableSessionModels`). A session loaded purely
from the store after a restart has no attached runtime until the
user sends the next message, so a client UI that needs to show "what
model is this session using?" can't answer the question without
forcing a runtime attach.

## Wire-level change

- `SessionResponse` gains an `agent_model_overrides` field
  (`map[string]string`, `omitempty`), populated from the existing
  `session.AgentModelOverrides` field. The map mirrors the storage
  shape: `agent_name -> provider/model_ref`.
- Omitted entirely when no overrides are active so clients can
  distinguish "no override picked" from "override is the empty map"
  on the wire.
- Pure addition — no existing fields change shape and no endpoints
  are removed.

## Concrete client use case (Docker Desktop / Gordon)

Gordon's chat UI in Docker Desktop has a model picker per session
(behind a feature flag). With #2852 the user's selection is
persisted server-side, but after a Desktop restart the picker had
no way to know what was selected without speculatively starting the
session's runtime. This change lets the picker hydrate from
`getSession` like it already does for `permissions`, `working_dir`
and `tools_approved`.

## Validation

- `task build` ✅
- `go test ./pkg/server/... ./pkg/api/... ./pkg/session/... -count=1` ✅
- New tests in `pkg/server/server_test.go`:
  - `TestGetSession_ModelOverrides` — exposes overrides
  - `TestGetSession_NoOverrides` — `omitempty` is respected on the wire
- `task lint` blocked locally on a golangci-lint/Go version skew, but
  `go vet ./pkg/server/... ./pkg/api/...` and `gofmt -l` are clean.