### PR TITLE
chore: bump github.com/pb33f/libopenapi to v0.36.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.6.0
 	github.com/natefinch/atomic v1.0.1
 	github.com/openai/openai-go/v3 v3.36.0
-	github.com/pb33f/libopenapi v0.36.4
+	github.com/pb33f/libopenapi v0.36.5
 	github.com/rivo/uniseg v0.4.7
 	github.com/rumpl/harness v0.0.0-20260519225334-1d956be4fff1
 	github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82

--- a/go.sum
+++ b/go.sum
@@ -417,8 +417,8 @@ github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaR
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pb33f/jsonpath v0.8.2 h1:Ou4C7zjYClBm97dfZjDCjdZGusJoynv/vrtiEKNfj2Y=
 github.com/pb33f/jsonpath v0.8.2/go.mod h1:zBV5LJW4OQOPatmQE2QdKpGQJvhDTlE5IEj6ASaRNTo=
-github.com/pb33f/libopenapi v0.36.4 h1:oGDGjHpCyaj55RG0i0TLB3N3MEGIsGsM1aD7iInfZ8A=
-github.com/pb33f/libopenapi v0.36.4/go.mod h1:MsDdUlQ1CdrIDO5v26JfgBxQs7kcaOUEpMP3EqU6bI4=
+github.com/pb33f/libopenapi v0.36.5 h1:Y1FNJ99E+1OW65ijfx447HezNc7vfi9AHYtaPmtj34c=
+github.com/pb33f/libopenapi v0.36.5/go.mod h1:MsDdUlQ1CdrIDO5v26JfgBxQs7kcaOUEpMP3EqU6bI4=
 github.com/pb33f/ordered-map/v2 v2.3.1 h1:5319HDO0aw4DA4gzi+zv4FXU9UlSs3xGZ40wcP1nBjY=
 github.com/pb33f/ordered-map/v2 v2.3.1/go.mod h1:qxFQgd0PkVUtOMCkTapqotNgzRhMPL7VvaHKbd1HnmQ=
 github.com/pjbgf/sha1cd v0.6.0 h1:3WJ8Wz8gvDz29quX1OcEmkAlUg9diU4GxJHqs0/XiwU=


### PR DESCRIPTION
Updates `github.com/pb33f/libopenapi` from v0.36.4 to v0.36.5. This dependency provides OpenAPI parsing and validation; the bump pulls in upstream improvements and fixes.

A second dependency, `google.golang.org/adk`, was evaluated for a bump from v1.2.0 to v1.3.0 but deferred. The new version deprecates `google.golang.org/adk/server/adka2a` in favor of `adka2a/v2`, which would require a separate migration beyond a simple dependency bump.

| Module | From | To | Status |
|--------|------|----|--------|
| github.com/pb33f/libopenapi | v0.36.4 | v0.36.5 | bumped |
| google.golang.org/adk | v1.2.0 | v1.3.0 | skipped — adka2a deprecated in favor of adka2a/v2 (separate migration needed) |