### PR TITLE
docs: document reset_remote_mcp_server_auth meta-tool

### DIFF
--- a/examples/mcp_catalog.yaml
+++ b/examples/mcp_catalog.yaml
@@ -2,11 +2,16 @@
 # MCP server from the Docker MCP Catalog on demand.
 #
 # How it works:
-#   - The mcp_catalog toolset adds 4 meta-tools:
-#       * search_remote_mcp_servers — find servers by keyword
-#       * enable_remote_mcp_server  — activate one (no network yet)
-#       * list_remote_mcp_servers   — show what's currently active
-#       * disable_remote_mcp_server — turn one off again
+#   - The mcp_catalog toolset adds up to 5 meta-tools:
+#       * search_remote_mcp_servers   — find servers by keyword
+#       * enable_remote_mcp_server    — activate one (no network yet)
+#       * list_remote_mcp_servers     — show what's currently active
+#       * disable_remote_mcp_server   — turn one off again
+#       * reset_remote_mcp_server_auth — wipe persisted OAuth credentials
+#         for a server so the next enable triggers a fresh authorization
+#         flow. Useful when a token was revoked, scopes changed, or you
+#         signed in to the wrong account. Only exposed once at least one
+#         server is enabled; no-op for api_key/none servers.
 #   - Tools from servers that have not been enabled stay hidden, so the
 #     prompt is not flooded with hundreds of tool definitions.
 #   - When the model first calls a tool from an enabled server, the


### PR DESCRIPTION
The `mcp_catalog` toolset now exposes a fifth meta-tool, `reset_remote_mcp_server_auth`, that allows users to clear persisted OAuth credentials for a remote MCP server. This is useful when an access token was revoked, authorization scopes changed, or the user needs to sign in with a different account.

This change updates the example configuration to document the new meta-tool and clarify when it becomes available. The implementation already supports the feature; this is purely a documentation update to keep the example in sync with the actual toolset behavior.

The meta-tool is only exposed once at least one server is enabled and is a no-op for servers using `api_key` or `none` authentication.