### PR TITLE
docs: document mcp_catalog toolset and reorganize RAG reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ More examples in the [`examples/`](examples/README.md) directory.
 - [Installation](https://docker.github.io/docker-agent/getting-started/installation) · [Quick Start](https://docker.github.io/docker-agent/getting-started/quickstart)
 - [Agents](https://docker.github.io/docker-agent/concepts/agents) · [Models](https://docker.github.io/docker-agent/concepts/models) · [Tools](https://docker.github.io/docker-agent/concepts/tools) · [Multi-Agent](https://docker.github.io/docker-agent/concepts/multi-agent)
 - [Configuration Reference](https://docker.github.io/docker-agent/configuration/overview)
-- [TUI](https://docker.github.io/docker-agent/features/tui) · [CLI](https://docker.github.io/docker-agent/features/cli) · [MCP Mode](https://docker.github.io/docker-agent/features/mcp-mode) · [RAG](https://docker.github.io/docker-agent/features/rag)
+- [TUI](https://docker.github.io/docker-agent/features/tui) · [CLI](https://docker.github.io/docker-agent/features/cli) · [MCP Mode](https://docker.github.io/docker-agent/features/mcp-mode) · [RAG](https://docker.github.io/docker-agent/tools/rag)
 - [Model Providers](https://docker.github.io/docker-agent/providers/overview) · [Docker Model Runner](https://docker.github.io/docker-agent/providers/dmr)
 
 ## Contributing

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -79,6 +79,10 @@
       url: /tools/openapi/
     - title: A2A
       url: /tools/a2a/
+    - title: RAG
+      url: /tools/rag/
+    - title: MCP Catalog
+      url: /tools/mcp-catalog/
 
 - section: Features
   items:

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -102,8 +102,6 @@
       url: /features/chat-server/
     - title: Evaluation
       url: /features/evaluation/
-    - title: RAG
-      url: /features/rag/
     - title: Skills
       url: /features/skills/
     - title: Remote MCP Servers

--- a/docs/concepts/tools/index.md
+++ b/docs/concepts/tools/index.md
@@ -68,5 +68,5 @@ See [Tool Config]({{ '/configuration/tools/#mcp-tools' | relative_url }}) for fu
 <div class="callout callout-tip" markdown="1">
 <div class="callout-title">See also
 </div>
-  <p>For full configuration reference, see <a href="{{ '/configuration/tools/' | relative_url }}">Tool Config</a>. For RAG (document retrieval), see <a href="{{ '/tools/rag/' | relative_url }}">RAG</a>.</p>
+  <p>For full configuration reference, see <a href="{{ '/configuration/tools/' | relative_url }}">Tool Config</a>.</p>
 </div>

--- a/docs/concepts/tools/index.md
+++ b/docs/concepts/tools/index.md
@@ -40,13 +40,14 @@ docker-agent ships with several built-in tools that require no external dependen
 | [LSP]({{ '/tools/lsp/' | relative_url }}) | Connect to Language Server Protocol servers for code intelligence |
 | [API]({{ '/tools/api/' | relative_url }}) | Create custom tools that call HTTP APIs without writing code |
 | [OpenAPI]({{ '/tools/openapi/' | relative_url }}) | Generate tools from an OpenAPI 3.x document |
-| [RAG]({{ '/features/rag/' | relative_url }}) | Retrieval-augmented generation over indexed sources |
+| [RAG]({{ '/tools/rag/' | relative_url }}) | Retrieval-augmented generation over indexed sources |
 | [Model Picker]({{ '/tools/model-picker/' | relative_url }}) | Let the agent pick between several models per turn |
 | [User Prompt]({{ '/tools/user-prompt/' | relative_url }}) | Ask users questions and collect interactive input |
 | [Transfer Task]({{ '/tools/transfer-task/' | relative_url }}) | Delegate tasks to sub-agents (auto-enabled with `sub_agents`) |
 | [Background Agents]({{ '/tools/background-agents/' | relative_url }}) | Dispatch work to sub-agents concurrently |
 | [Handoff]({{ '/tools/handoff/' | relative_url }}) | Hand the conversation off to another local agent in the same config (auto-enabled with `handoffs:`) |
 | [A2A]({{ '/tools/a2a/' | relative_url }}) | Connect to remote agents via the Agent-to-Agent protocol |
+| [MCP Catalog]({{ '/tools/mcp-catalog/' | relative_url }}) | Discover and activate remote MCP servers from the Docker MCP Catalog on demand |
 
 ## MCP Tools
 

--- a/docs/concepts/tools/index.md
+++ b/docs/concepts/tools/index.md
@@ -68,5 +68,5 @@ See [Tool Config]({{ '/configuration/tools/#mcp-tools' | relative_url }}) for fu
 <div class="callout callout-tip" markdown="1">
 <div class="callout-title">See also
 </div>
-  <p>For full configuration reference, see <a href="{{ '/configuration/tools/' | relative_url }}">Tool Config</a>. For RAG (document retrieval), see <a href="{{ '/features/rag/' | relative_url }}">RAG</a>.</p>
+  <p>For full configuration reference, see <a href="{{ '/configuration/tools/' | relative_url }}">Tool Config</a>. For RAG (document retrieval), see <a href="{{ '/tools/rag/' | relative_url }}">RAG</a>.</p>
 </div>

--- a/docs/configuration/tools/index.md
+++ b/docs/configuration/tools/index.md
@@ -25,13 +25,14 @@ Built-in tools are included with docker-agent and require no external dependenci
 | `lsp` | Language Server Protocol integration | [LSP]({{ '/tools/lsp/' | relative_url }}) |
 | `api` | Custom HTTP API tools | [API]({{ '/tools/api/' | relative_url }}) |
 | `openapi` | Import every operation of an OpenAPI 3.x document as tools | [OpenAPI]({{ '/tools/openapi/' | relative_url }}) |
-| `rag` | Retrieval-augmented generation over indexed sources | [RAG]({{ '/features/rag/' | relative_url }}) |
+| `rag` | Retrieval-augmented generation over indexed sources | [RAG]({{ '/tools/rag/' | relative_url }}) |
 | `model_picker` | Let the agent pick between several models per turn | [Model Picker]({{ '/tools/model-picker/' | relative_url }}) |
 | `user_prompt` | Interactive user input | [User Prompt]({{ '/tools/user-prompt/' | relative_url }}) |
 | `transfer_task` | Delegate to sub-agents (auto-enabled) | [Transfer Task]({{ '/tools/transfer-task/' | relative_url }}) |
 | `background_agents` | Parallel sub-agent dispatch | [Background Agents]({{ '/tools/background-agents/' | relative_url }}) |
 | `handoff` | Local conversation handoff to another agent in the same config (auto-enabled by `handoffs:`) | [Handoff]({{ '/tools/handoff/' | relative_url }}) |
 | `a2a` | A2A remote agent connection | [A2A]({{ '/tools/a2a/' | relative_url }}) |
+| `mcp_catalog` | Discover and activate remote MCP servers from the Docker MCP Catalog on demand | [MCP Catalog]({{ '/tools/mcp-catalog/' | relative_url }}) |
 
 **Example:**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -221,7 +221,7 @@ What people build with Docker Agent today:
     </div>
     <h3>Data &amp; research</h3>
     <p>Persistent memory, web fetch, RAG over local docs, structured output for downstream pipelines.</p>
-    <a href="{{ '/features/rag/' | relative_url }}">RAG guide →</a>
+    <a href="{{ '/tools/rag/' | relative_url }}">RAG guide →</a>
   </div>
   <div class="usecase">
     <div class="usecase-icon">

--- a/docs/tools/mcp-catalog/index.md
+++ b/docs/tools/mcp-catalog/index.md
@@ -56,7 +56,7 @@ The catalog distinguishes three auth flavours:
 - **`api_key`** — The server expects one or more env vars to be set in the agent's environment (e.g. `APIFY_API_KEY`, `BRAVE_API_KEY`). `enable_remote_mcp_server` warns if any required variable is missing — set it, then re-enable the server.
 - **`none`** — No authentication. The server is reachable as soon as it is enabled.
 
-The catalog tells the model which env vars each `api_key` server expects, so it can ask the user up front.
+Search results only carry the auth flavour (`oauth` / `api_key` / `none`); the specific env-var names are surfaced by `enable_remote_mcp_server` when it detects an unset variable, so you may need to enable an `api_key` server once just to learn which variable to set.
 
 ## Example
 

--- a/docs/tools/mcp-catalog/index.md
+++ b/docs/tools/mcp-catalog/index.md
@@ -1,0 +1,92 @@
+---
+title: "MCP Catalog Tool"
+description: "Let the agent discover and activate remote MCP servers from the Docker MCP Catalog on demand."
+permalink: /tools/mcp-catalog/
+---
+
+# MCP Catalog Tool
+
+_Let the agent discover and activate remote MCP servers from the Docker MCP Catalog on demand._
+
+## Overview
+
+The `mcp_catalog` toolset gives an agent access to a curated subset of the [Docker MCP Catalog](https://hub.docker.com/search?q=&type=mcp) — every server in this subset is reachable over the **streamable-http** transport, so docker-agent can talk to it directly without the MCP gateway or a local subprocess.
+
+Servers are **not** active by default. Instead, the toolset exposes a small set of meta-tools the agent uses to search, enable, and disable servers as a turn unfolds. Tools from un-enabled servers stay hidden, so the prompt is not flooded with hundreds of tool definitions the agent will never use.
+
+<div class="callout callout-info" markdown="1">
+<div class="callout-title">When to use it
+</div>
+  <p>Use <code>mcp_catalog</code> when you want the agent to <em>decide at runtime</em> which third-party services it needs (Notion, Stripe, Brave Search, …) instead of pinning that decision in YAML up front. For a fixed set of servers, declare each one with <a href="{{ '/configuration/tools/#mcp-tools' | relative_url }}"><code>type: mcp</code></a> directly — the catalog adds an extra layer of meta-tools that pure <code>type: mcp</code> entries do not need.</p>
+</div>
+
+## Configuration
+
+```yaml
+toolsets:
+  - type: mcp_catalog
+```
+
+The toolset takes no options: the catalog is embedded in the docker-agent binary and refreshed with each release.
+
+## Meta-Tools
+
+Up to five tools are exposed to the model. The disable / reset-auth pair only appears once at least one server is enabled, so the meta-tool surface stays minimal until the agent activates something.
+
+| Tool                            | When visible            | Description                                                                                                                                          |
+| ------------------------------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `search_remote_mcp_servers`     | Always                  | Case-insensitive fuzzy search over id, title, description, category and tags. Returns id, auth requirements (`oauth` / `api_key` / `none`) and URL. |
+| `enable_remote_mcp_server`      | Always                  | Activate a server by id. The actual MCP handshake (and any OAuth flow) is deferred until the host next enumerates tools.                            |
+| `list_remote_mcp_servers`       | Always                  | Show currently enabled servers and their connection state.                                                                                           |
+| `disable_remote_mcp_server`     | After first enable      | Stop a server and remove its tools from the active set.                                                                                              |
+| `reset_remote_mcp_server_auth`  | After first enable      | Drop persisted OAuth credentials so the next enable triggers a fresh authorization flow. No-op for `api_key` / `none` servers.                       |
+
+### Workflow
+
+1. The agent calls `search_remote_mcp_servers` with a keyword matching the user's intent (`"notion"`, `"stripe"`, `"docs"`, `"browser"`, …).
+2. It picks a matching server id and calls `enable_remote_mcp_server`. The server's tools become available on the **next turn**.
+3. It uses the newly activated tools as it would any other.
+4. When done, it calls `disable_remote_mcp_server` to remove the server from the active set.
+
+## Authentication
+
+The catalog distinguishes three auth flavours:
+
+- **`oauth`** — On the first turn that enumerates the server's tools, an authorization URL is surfaced through the elicitation pipeline (the same one used by YAML-declared remote MCP toolsets). Once the user authorizes, tokens are persisted in the OS keyring and re-used on subsequent runs. Use `reset_remote_mcp_server_auth` to wipe them.
+- **`api_key`** — The server expects one or more env vars to be set in the agent's environment (e.g. `APIFY_API_KEY`, `BRAVE_API_KEY`). `enable_remote_mcp_server` warns if any required variable is missing — set it, then re-enable the server.
+- **`none`** — No authentication. The server is reachable as soon as it is enabled.
+
+The catalog tells the model which env vars each `api_key` server expects, so it can ask the user up front.
+
+## Example
+
+```yaml
+agents:
+  root:
+    model: anthropic/claude-sonnet-4-5
+    description: Agent that can on-demand connect to remote MCP servers from the Docker MCP Catalog.
+    instruction: |
+      You can discover and activate remote MCP servers on demand.
+      Use search_remote_mcp_servers to find a server matching the
+      user's intent, then enable_remote_mcp_server to activate it.
+      Be conservative: enable only the servers you actually need for
+      the task at hand. Disable a server with disable_remote_mcp_server
+      once you are done with it.
+    toolsets:
+      - type: mcp_catalog
+```
+
+A complete, runnable configuration lives in [`examples/mcp_catalog.yaml`](https://github.com/docker/docker-agent/blob/main/examples/mcp_catalog.yaml).
+
+## Notes and Limitations
+
+- **Streamable-http only.** The catalog deliberately excludes servers that require a local subprocess or the MCP gateway — declare those with [`type: mcp`]({{ '/configuration/tools/#mcp-tools' | relative_url }}) instead.
+- **Lazy connect.** DNS, TCP, MCP handshake and OAuth flow happen the first time the host enumerates tools for a freshly enabled server. On startup the runtime probes tools non-interactively, so OAuth-pending servers fail fast and are silently deferred to the next interactive turn.
+- **No prompt discovery.** MCP prompt lookups (`/prompts`) walk YAML-declared `mcp` toolsets directly; prompts exposed by servers activated through the catalog are not surfaced. Tools — the primary interface — work fine.
+- **Frozen at build time.** The list of servers is embedded in the binary. New entries land with each docker-agent release.
+
+<div class="callout callout-tip" markdown="1">
+<div class="callout-title">Pair with permissions
+</div>
+  <p>Because the agent decides which third-party services to talk to, this toolset works best with explicit <a href="{{ '/configuration/permissions/' | relative_url }}">permissions</a> on the surrounding tools (filesystem writes, shell commands) so a misrouted server cannot exfiltrate data unnoticed.</p>
+</div>

--- a/docs/tools/rag/index.md
+++ b/docs/tools/rag/index.md
@@ -1,16 +1,16 @@
 ---
-title: "RAG (Retrieval-Augmented Generation)"
+title: "RAG Tool"
 description: "Give your agents access to document knowledge bases with background indexing, multiple retrieval strategies, and hybrid search."
-permalink: /features/rag/
+permalink: /tools/rag/
 ---
 
-# RAG (Retrieval-Augmented Generation)
+# RAG Tool
 
 _Give your agents access to document knowledge bases with background indexing, multiple retrieval strategies, and hybrid search._
 
 ## Overview
 
-RAG lets agents search through your documents to find relevant information before responding. docker-agent supports:
+The `rag` toolset lets agents search through your documents to find relevant information before responding. Knowledge bases are declared once at the top of the config under `rag:` and then referenced from any agent via `type: rag, ref: <name>`. docker-agent supports:
 
 - **Background indexing** — Files are indexed automatically and re-indexed on change
 - **Multiple strategies** — Semantic embeddings, BM25 keyword search, and LLM-enhanced search


### PR DESCRIPTION
The built-in toolsets reference had two gaps: `mcp_catalog` was completely undocumented, and RAG was filed under features instead of tools despite being declared as a toolset via `type: rag`.

This PR adds comprehensive documentation for `mcp_catalog` and moves RAG under the tools section where it belongs. The `mcp_catalog` documentation covers the meta-tools (`search_remote_mcp_servers`, `enable_remote_mcp_server`, `list_remote_mcp_servers`, `disable_remote_mcp_server`, `reset_remote_mcp_server_auth`), auth flavors (`oauth`, `api_key`, `none`), lazy-connect behavior, and relevant limitations. Both toolsets are now wired into the built-in tools reference tables and navigation.

Docs-only change; no runtime code modifications.