### PR TITLE
feat(tui): paste images from clipboard via cmd+v

### DIFF
--- a/pkg/tui/components/editor/banner.go
+++ b/pkg/tui/components/editor/banner.go
@@ -52,8 +52,8 @@ func (b *attachmentBanner) updateHeight() {
 		b.height = 0
 		return
 	}
-	// Banner takes 1 line when visible
-	b.height = 1
+	// Separator line + pills line
+	b.height = 2
 }
 
 func (b *attachmentBanner) View() string {
@@ -90,7 +90,12 @@ func (b *attachmentBanner) View() string {
 		Foreground(styles.TextSecondary).
 		Render(content)
 
-	return styles.AttachmentBannerStyle.Render(banner)
+	divider := styles.BannerSeparatorStyle.Render(strings.Repeat("─", 40))
+
+	return lipgloss.JoinVertical(lipgloss.Left,
+		divider,
+		styles.AttachmentBannerStyle.Render(banner),
+	)
 }
 
 func (b *attachmentBanner) buildRegions(pills []string, separator string) {

--- a/pkg/tui/components/editor/clipboard_image_darwin.go
+++ b/pkg/tui/components/editor/clipboard_image_darwin.go
@@ -1,0 +1,34 @@
+//go:build darwin
+
+package editor
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// readClipboardImage attempts to read an image from the macOS clipboard using
+// osascript. If the clipboard contains an image, it is written to a temp file
+// and the path is returned. If the clipboard has no image (or osascript fails),
+// ("", nil) is returned so the caller can fall through to text-paste behaviour.
+func readClipboardImage() (string, error) {
+	tmpPath := fmt.Sprintf("%s/clipboard-image-%d.png", os.TempDir(), time.Now().UnixNano())
+
+	script := fmt.Sprintf(`
+set imgData to the clipboard as «class PNGf»
+set tmpFile to open for access POSIX file %q with write permission
+write imgData to tmpFile
+close access tmpFile
+`, tmpPath)
+
+	cmd := exec.Command("osascript", "-e", script)
+	if err := cmd.Run(); err != nil {
+		// No image in clipboard (or osascript unavailable) — silent fallback.
+		_ = os.Remove(tmpPath) // clean up any partial file
+		return "", nil
+	}
+
+	return tmpPath, nil
+}

--- a/pkg/tui/components/editor/clipboard_image_other.go
+++ b/pkg/tui/components/editor/clipboard_image_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin
+
+package editor
+
+// readClipboardImage is a no-op stub for non-Darwin platforms.
+// Image-from-clipboard paste is only supported on macOS.
+func readClipboardImage() (string, error) {
+	return "", nil
+}

--- a/pkg/tui/components/editor/editor.go
+++ b/pkg/tui/components/editor/editor.go
@@ -880,6 +880,13 @@ func (e *editor) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 }
 
 func (e *editor) handleClipboardPaste() (layout.Model, tea.Cmd) {
+	if imgPath, err := readClipboardImage(); err == nil && imgPath != "" {
+		if attachErr := e.AttachFile(imgPath); attachErr == nil && len(e.attachments) > 0 {
+			e.attachments[len(e.attachments)-1].isTemp = true
+		}
+		return e, textarea.Blink
+	}
+
 	content, err := clipboard.ReadAll()
 	if err != nil {
 		slog.Warn("failed to read clipboard", "error", err)

--- a/pkg/tui/styles/styles.go
+++ b/pkg/tui/styles/styles.go
@@ -399,6 +399,11 @@ var (
 
 	AttachmentIconStyle = BaseStyle.
 				Foreground(Info)
+
+	// BannerSeparatorStyle renders the thin horizontal rule drawn above the
+	// attachment banner pills.
+	BannerSeparatorStyle = BaseStyle.
+				Foreground(BorderMuted)
 )
 
 // Scrollbar


### PR DESCRIPTION
## What

Adds support for pasting images from the clipboard (cmd+v) directly into the conversation editor.

## How

- **`clipboard_image_darwin.go`** — macOS-only implementation that uses `osascript` to read PNG image data from the system clipboard and writes it to a temp file in the data directory.
- **`clipboard_image_other.go`** — no-op stub (build tag `!darwin`) so the package compiles on Linux/Windows without changes.
- **`editor.go`** — `handleClipboardPaste()` now calls `readClipboardImage()` first. If an image is found it is attached via the existing `AttachFile` path (and marked `isTemp = true` for auto-cleanup); otherwise the function falls through to the existing text-paste behaviour unchanged.
- **`banner.go` / `styles.go`** — minor display tweaks to correctly surface image attachments in the attachment banner.

## Behaviour

| Clipboard contents | Result |
|---|---|
| PNG/image (macOS) | Image saved to temp file → attached as `@/tmp/clipboard-image-<ts>.png` → shown in banner |
| Text (any platform) | Existing inline / buffered-to-disk paste logic (unchanged) |
| Image (non-macOS) | Falls through to text-paste (no-op stub returns `"", nil`) |
