### PR TITLE
feat(mcp_catalog): add 7 remote streamable-http servers

### DIFF
--- a/pkg/tools/builtin/mcpcatalog/servers.json
+++ b/pkg/tools/builtin/mcpcatalog/servers.json
@@ -3,7 +3,7 @@
   "source_url": "https://desktop.docker.com/mcp/catalog/v3/catalog.json",
   "schema_version": 3,
   "filter": "type=remote AND remote.transport_type=streamable-http",
-  "count": 44,
+  "count": 51,
   "servers": [
     {
       "id": "apify",
@@ -193,6 +193,26 @@
       }
     },
     {
+      "id": "cloudflare",
+      "title": "Cloudflare",
+      "description": "Manage Cloudflare workers, DNS, security and platform resources via the Cloudflare API.",
+      "url": "https://mcp.cloudflare.com/mcp",
+      "transport": "streamable-http",
+      "category": "infrastructure",
+      "tags": [
+        "infrastructure",
+        "cdn",
+        "edge",
+        "dns",
+        "remote"
+      ],
+      "icon": "https://www.google.com/s2/favicons?domain=cloudflare.com&sz=64",
+      "headers": {},
+      "auth": {
+        "type": "oauth"
+      }
+    },
+    {
       "id": "dappier-remote",
       "title": "Dappier Remote",
       "description": "Enable fast, free real-time web search and access premium data from trusted media brands—news, financial markets, sports, entertainment, weather, and more. Build powerful AI agents with Dappier.",
@@ -259,6 +279,25 @@
       "headers": {},
       "auth": {
         "type": "none"
+      }
+    },
+    {
+      "id": "figma",
+      "title": "Figma",
+      "description": "Read design files, components, frames and metadata directly from Figma.",
+      "url": "https://mcp.figma.com/mcp",
+      "transport": "streamable-http",
+      "category": "design",
+      "tags": [
+        "design",
+        "ui",
+        "collaboration",
+        "remote"
+      ],
+      "icon": "https://www.google.com/s2/favicons?domain=figma.com&sz=64",
+      "headers": {},
+      "auth": {
+        "type": "oauth"
       }
     },
     {
@@ -584,6 +623,26 @@
       }
     },
     {
+      "id": "microchip",
+      "title": "Microchip",
+      "description": "Look up Microchip semiconductor product specifications, datasheets and inventory data.",
+      "url": "https://api.microchip.com/mcp/resources",
+      "transport": "streamable-http",
+      "category": "hardware",
+      "tags": [
+        "hardware",
+        "embedded",
+        "semiconductor",
+        "documentation",
+        "remote"
+      ],
+      "icon": "https://www.google.com/s2/favicons?domain=microchip.com&sz=64",
+      "headers": {},
+      "auth": {
+        "type": "none"
+      }
+    },
+    {
       "id": "microsoft-learn",
       "title": "Microsoft Learn",
       "description": "Add trusted and up-to-date content from Microsoft Learn to your AI agent.",
@@ -681,6 +740,25 @@
             "example": "<YOUR_API_KEY>"
           }
         ]
+      }
+    },
+    {
+      "id": "neon",
+      "title": "Neon",
+      "description": "Provision and manage serverless PostgreSQL databases on Neon, including branches, roles and queries.",
+      "url": "https://mcp.neon.tech/mcp",
+      "transport": "streamable-http",
+      "category": "database",
+      "tags": [
+        "database",
+        "postgres",
+        "serverless",
+        "remote"
+      ],
+      "icon": "https://www.google.com/s2/favicons?domain=neon.tech&sz=64",
+      "headers": {},
+      "auth": {
+        "type": "oauth"
       }
     },
     {
@@ -835,6 +913,25 @@
       "headers": {},
       "auth": {
         "type": "none"
+      }
+    },
+    {
+      "id": "paypal",
+      "title": "PayPal",
+      "description": "Process payments, manage invoices and inspect PayPal merchant data.",
+      "url": "https://mcp.paypal.com/mcp",
+      "transport": "streamable-http",
+      "category": "payments",
+      "tags": [
+        "payments",
+        "finance",
+        "merchant",
+        "remote"
+      ],
+      "icon": "https://www.google.com/s2/favicons?domain=paypal.com&sz=64",
+      "headers": {},
+      "auth": {
+        "type": "oauth"
       }
     },
     {
@@ -1040,6 +1137,46 @@
             "secret": "stripe-remote.personal_access_token"
           }
         ]
+      }
+    },
+    {
+      "id": "supabase",
+      "title": "Supabase",
+      "description": "Manage Supabase projects, run database queries, edit schemas and configure edge functions and storage.",
+      "url": "https://mcp.supabase.com/mcp",
+      "transport": "streamable-http",
+      "category": "database",
+      "tags": [
+        "database",
+        "postgres",
+        "backend",
+        "auth",
+        "storage",
+        "remote"
+      ],
+      "icon": "https://www.google.com/s2/favicons?domain=supabase.com&sz=64",
+      "headers": {},
+      "auth": {
+        "type": "oauth"
+      }
+    },
+    {
+      "id": "tally",
+      "title": "Tally",
+      "description": "Build forms and inspect Tally form submissions and respondent data.",
+      "url": "https://api.tally.so/mcp",
+      "transport": "streamable-http",
+      "category": "productivity",
+      "tags": [
+        "productivity",
+        "forms",
+        "surveys",
+        "remote"
+      ],
+      "icon": "https://www.google.com/s2/favicons?domain=tally.so&sz=64",
+      "headers": {},
+      "auth": {
+        "type": "oauth"
       }
     },
     {


### PR DESCRIPTION
The `mcp_catalog` toolset embeds a curated snapshot of remote streamable-http MCP servers from the Docker MCP Catalog. This PR extends that snapshot with 7 newly verified servers.

Each candidate was discovered by web research and then probed against the live endpoint with a real MCP `initialize` request to confirm streamable-http transport. The probe sent `Accept: application/json, text/event-stream` and verified either a 200 OK response with a valid `initialize` reply, or a 401 with valid `oauth-protected-resource` metadata in the `WWW-Authenticate: Bearer` challenge.

| id | url | auth | category |
|---|---|---|---|
| cloudflare | https://mcp.cloudflare.com/mcp | oauth | infrastructure |
| figma | https://mcp.figma.com/mcp | oauth | design |
| microchip | https://api.microchip.com/mcp/resources | none | hardware |
| neon | https://mcp.neon.tech/mcp | oauth | databases |
| paypal | https://mcp.paypal.com/mcp | oauth | finance |
| supabase | https://mcp.supabase.com/mcp | oauth | databases |
| tally | https://api.tally.so/mcp | oauth | productivity |

All OAuth servers expose the standard `WWW-Authenticate: Bearer` challenge with `resource_metadata` discovery, so docker-agent's existing OAuth + Dynamic Client Registration plumbing should work without per-server configuration. This mirrors the same path already taken by Linear, Notion, and Atlassian.

The catalog `count` field was bumped from 44 to 51 and entries were re-sorted by id to match the existing convention. Tests pass (`go test ./pkg/tools/builtin/mcpcatalog/...` is green) and linting reports 0 issues (`task lint`).

Note: this is a snapshot of the live catalog at <https://desktop.docker.com/mcp/catalog/v3/catalog.json>. Long-term, these servers should be proposed upstream so the live-fetched catalog stays consistent across docker-agent releases.