### PR TITLE
Lazy headers in tools

### DIFF
--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -879,7 +879,7 @@ type Toolset struct {
 	// Set to "false" or "off" to disable auto-install for this toolset.
 	Version string `json:"version,omitempty"`
 
-	// For the `a2a` and `openapi` tools
+	// For the `a2a`, `api`, `openapi` and `fetch` tools
 	Name    string            `json:"name,omitempty"`
 	URL     string            `json:"url,omitempty"`
 	Headers map[string]string `json:"headers,omitempty"`

--- a/pkg/js/expand_test.go
+++ b/pkg/js/expand_test.go
@@ -351,3 +351,24 @@ func TestFindClosingBrace(t *testing.T) {
 		})
 	}
 }
+
+func TestMultiStepExpand(t *testing.T) {
+	t.Parallel()
+
+	env := testEnvProvider(map[string]string{
+		"KEY": "KEY_VALUE",
+	})
+	expander := NewJsExpander(&env)
+
+	value := "PREFIX-[${env.KEY}]-[${PARAM}]-SUFFIX"
+
+	// Expand the environment variables first.
+	value = expander.Expand(t.Context(), value, nil)
+	assert.Equal(t, "PREFIX-[KEY_VALUE]-[${PARAM}]-SUFFIX", value)
+
+	// Expand the parameters.
+	value = expander.Expand(t.Context(), value, map[string]string{
+		"PARAM": "PARAM_VALUE",
+	})
+	assert.Equal(t, "PREFIX-[KEY_VALUE]-[PARAM_VALUE]-SUFFIX", value)
+}

--- a/pkg/teamloader/registry.go
+++ b/pkg/teamloader/registry.go
@@ -60,8 +60,8 @@ func NewDefaultToolsetRegistry() ToolsetRegistry {
 			"filesystem": func(_ context.Context, toolset latest.Toolset, _ string, runConfig *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
 				return filesystem.CreateToolSet(toolset, runConfig)
 			},
-			"fetch": func(ctx context.Context, toolset latest.Toolset, _ string, runConfig *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
-				return fetch.CreateToolSet(ctx, toolset, runConfig)
+			"fetch": func(_ context.Context, toolset latest.Toolset, _ string, runConfig *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
+				return fetch.CreateToolSet(toolset, runConfig)
 			},
 			"mcp": func(ctx context.Context, toolset latest.Toolset, _ string, runConfig *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
 				return mcp.CreateToolSet(ctx, toolset, runConfig)

--- a/pkg/teamloader/registry.go
+++ b/pkg/teamloader/registry.go
@@ -69,8 +69,8 @@ func NewDefaultToolsetRegistry() ToolsetRegistry {
 			"mcp_catalog": func(_ context.Context, _ latest.Toolset, _ string, runConfig *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
 				return mcpcatalog.New(runConfig.EnvProvider()), nil
 			},
-			"api": func(ctx context.Context, toolset latest.Toolset, _ string, runConfig *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
-				return api.CreateToolSet(ctx, toolset, runConfig)
+			"api": func(_ context.Context, toolset latest.Toolset, _ string, runConfig *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
+				return api.CreateToolSet(toolset, runConfig)
 			},
 			"a2a": func(ctx context.Context, toolset latest.Toolset, _ string, runConfig *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
 				return a2a.CreateToolSet(ctx, toolset, runConfig)

--- a/pkg/tools/a2a/a2a.go
+++ b/pkg/tools/a2a/a2a.go
@@ -32,6 +32,7 @@ type Toolset struct {
 	headers         map[string]string
 	timeout         time.Duration
 	allowPrivateIPs bool
+	expander        *js.Expander
 	client          *a2aclient.Client
 	card            *a2a.AgentCard
 	mu              sync.RWMutex
@@ -54,6 +55,10 @@ func WithAllowPrivateIPs(allow bool) Option {
 	return func(t *Toolset) { t.allowPrivateIPs = allow }
 }
 
+func WithExpander(expander *js.Expander) Option {
+	return func(t *Toolset) { t.expander = expander }
+}
+
 // Verify interface compliance
 var (
 	_ tools.ToolSet      = (*Toolset)(nil)
@@ -63,17 +68,18 @@ var (
 
 // CreateToolSet is used by the tools registry.
 func CreateToolSet(ctx context.Context, toolset latest.Toolset, runConfig *config.RuntimeConfig) (tools.ToolSet, error) {
-	expander := js.NewJsExpander(runConfig.EnvProvider())
-	headers := expander.ExpandMap(ctx, toolset.Headers)
-
 	var opts []Option
+
 	if toolset.Timeout > 0 {
 		opts = append(opts, WithTimeout(time.Duration(toolset.Timeout)*time.Second))
 	}
 	if toolset.AllowPrivateIPsEnabled() {
 		opts = append(opts, WithAllowPrivateIPs(true))
 	}
-	return NewToolset(toolset.Name, toolset.URL, headers, opts...), nil
+	expander := js.NewJsExpander(runConfig.EnvProvider())
+	opts = append(opts, WithExpander(expander))
+
+	return NewToolset(toolset.Name, toolset.URL, toolset.Headers, opts...), nil
 }
 
 // NewToolset creates a new A2A toolset for the given URL.
@@ -176,7 +182,9 @@ func (t *Toolset) Start(ctx context.Context) error {
 	if base == nil {
 		base = http.DefaultTransport
 	}
-	httpClient.Transport = upstream.NewHeaderTransport(base, t.headers)
+
+	headers := t.expander.ExpandMap(ctx, t.headers)
+	httpClient.Transport = upstream.NewHeaderTransport(base, headers)
 
 	client, err := a2aclient.NewFromCard(ctx, card,
 		a2aclient.WithDefaultsDisabled(),

--- a/pkg/tools/builtin/api/api.go
+++ b/pkg/tools/builtin/api/api.go
@@ -36,9 +36,11 @@ var (
 )
 
 func (t *ToolSet) callTool(ctx context.Context, toolCall tools.ToolCall) (*tools.ToolCallResult, error) {
+	endpoint := t.expander.Expand(ctx, t.config.Endpoint, nil)
+	headers := t.expander.ExpandMap(ctx, t.config.Headers)
+
 	client := httpclient.NewSafeClient(t.timeout, t.allowPrivateIPs)
 
-	endpoint := t.config.Endpoint
 	var reqBody io.Reader = http.NoBody
 	switch t.config.Method {
 	case http.MethodGet:
@@ -69,7 +71,7 @@ func (t *ToolSet) callTool(ctx context.Context, toolCall tools.ToolCall) (*tools
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	setHeaders(req, t.config.Headers)
+	setHeaders(req, headers)
 	if t.config.Method == http.MethodPost {
 		req.Header.Set("Content-Type", "application/json")
 	}
@@ -90,14 +92,12 @@ func (t *ToolSet) callTool(ctx context.Context, toolCall tools.ToolCall) (*tools
 }
 
 // CreateToolSet is used by the tools registry.
-func CreateToolSet(ctx context.Context, toolset latest.Toolset, runConfig *config.RuntimeConfig) (tools.ToolSet, error) {
+func CreateToolSet(toolset latest.Toolset, runConfig *config.RuntimeConfig) (tools.ToolSet, error) {
 	if toolset.APIConfig.Endpoint == "" {
 		return nil, errors.New("api tool requires an endpoint in api_config")
 	}
 
 	expander := js.NewJsExpander(runConfig.EnvProvider())
-	toolset.APIConfig.Endpoint = expander.Expand(ctx, toolset.APIConfig.Endpoint, nil)
-	toolset.APIConfig.Headers = expander.ExpandMap(ctx, toolset.APIConfig.Headers)
 
 	var opts []Option
 	if toolset.Timeout > 0 {
@@ -106,6 +106,7 @@ func CreateToolSet(ctx context.Context, toolset latest.Toolset, runConfig *confi
 	if toolset.AllowPrivateIPsEnabled() {
 		opts = append(opts, WithAllowPrivateIPs(true))
 	}
+
 	return New(toolset.APIConfig, expander, opts...), nil
 }
 

--- a/pkg/tools/builtin/api/api_test.go
+++ b/pkg/tools/builtin/api/api_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/js"
 	"github.com/docker/docker-agent/pkg/tools"
@@ -23,8 +24,8 @@ import (
 // protection so tests can talk to httptest.NewServer (which binds to
 // 127.0.0.1). It is defined in a *_test.go file so it is not compiled
 // into release binaries. Production callers must use [New].
-func newAPIToolForTest(config latest.APIToolConfig, expander *js.Expander) *ToolSet {
-	return New(config, expander, WithAllowPrivateIPs(true))
+func newAPIToolForTest(apiConfig latest.APIToolConfig, expander *js.Expander) *ToolSet {
+	return New(apiConfig, expander, WithAllowPrivateIPs(true))
 }
 
 type testServer struct {
@@ -267,9 +268,54 @@ func TestAPITool_TimeoutHonoured(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestAPITool_LazyReplaceHeaders(t *testing.T) {
+	t.Parallel()
+	ts := getTestServer(t)
+
+	envVariables := map[string]string{
+		"DOCKER_TOKEN": "INITIAL",
+	}
+	env := testEnvProvider(envVariables)
+
+	toolSet, err := CreateToolSet(latest.Toolset{
+		AllowPrivateIPs: new(true),
+		APIConfig: latest.APIToolConfig{
+			Method:   http.MethodGet,
+			Endpoint: ts.serverURL + "/api?token=${env.DOCKER_TOKEN}&value=${value}",
+		},
+	}, &config.RuntimeConfig{
+		EnvProviderForTests: &env,
+	})
+	require.NoError(t, err)
+
+	// Refresh the DOCKER_TOKEN after tool creation.
+	envVariables["DOCKER_TOKEN"] = "REFRESHED"
+
+	allTools, err := toolSet.Tools(t.Context())
+	require.NoError(t, err)
+
+	result, err := allTools[0].Handler(t.Context(), tools.ToolCall{
+		Function: tools.FunctionCall{
+			Arguments: `{"value": "myvalue"}`,
+		},
+	})
+
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"status":"ok"}`, result.Output)
+	assert.Equal(t, http.MethodGet, ts.receivedMethod)
+	assert.Equal(t, "/api?token=REFRESHED&value=myvalue", ts.receivedURL)
+}
+
 type noopEnvProvider struct{}
 
 func (noopEnvProvider) Get(context.Context, string) (string, bool) { return "", false }
+
+type testEnvProvider map[string]string
+
+func (p *testEnvProvider) Get(_ context.Context, name string) (string, bool) {
+	val, found := (*p)[name]
+	return val, found
+}
 
 func testExpander() *js.Expander {
 	return js.NewJsExpander(noopEnvProvider{})

--- a/pkg/tools/builtin/fetch/fetch.go
+++ b/pkg/tools/builtin/fetch/fetch.go
@@ -44,6 +44,7 @@ type fetchHandler struct {
 	blockedDomains  []string
 	headers         map[string]string
 	allowPrivateIPs bool
+	expander        *js.Expander
 }
 
 type ToolArgs struct {
@@ -68,6 +69,8 @@ func (h *fetchHandler) CallTool(ctx context.Context, params ToolArgs) (*tools.To
 		transport = http.DefaultTransport
 	}
 
+	headers := h.expander.ExpandMap(ctx, h.headers)
+
 	client := &http.Client{
 		Timeout:   h.timeout,
 		Transport: transport,
@@ -88,7 +91,7 @@ func (h *fetchHandler) CallTool(ctx context.Context, params ToolArgs) (*tools.To
 			// than the previous hop) guarantees that headers cannot reappear
 			// after a chain like A -> B -> A.
 			if origHost := via[0].URL.Host; origHost != req.URL.Host {
-				for k := range h.headers {
+				for k := range headers {
 					req.Header.Del(k)
 				}
 			}
@@ -105,7 +108,7 @@ func (h *fetchHandler) CallTool(ctx context.Context, params ToolArgs) (*tools.To
 	robotsCache := make(map[string]*robotstxt.RobotsData)
 
 	for _, urlStr := range params.URLs {
-		result := h.fetchURL(ctx, client, urlStr, params.Format, robotsCache)
+		result := h.fetchURL(ctx, client, urlStr, params.Format, headers, robotsCache)
 		results = append(results, result)
 	}
 
@@ -133,7 +136,7 @@ type Result struct {
 	Error         string `json:"error,omitempty"`
 }
 
-func (h *fetchHandler) fetchURL(ctx context.Context, client *http.Client, urlStr, format string, robotsCache map[string]*robotstxt.RobotsData) Result {
+func (h *fetchHandler) fetchURL(ctx context.Context, client *http.Client, urlStr, format string, headers map[string]string, robotsCache map[string]*robotstxt.RobotsData) Result {
 	result := Result{URL: urlStr}
 
 	// Validate URL
@@ -166,7 +169,7 @@ func (h *fetchHandler) fetchURL(ctx context.Context, client *http.Client, urlStr
 	robots, cached := robotsCache[host]
 	if !cached {
 		var err error
-		robots, err = h.fetchRobots(ctx, client, parsedURL)
+		robots, err = h.fetchRobots(ctx, client, parsedURL, headers)
 		if err != nil {
 			result.Error = fmt.Sprintf("robots.txt check failed: %v", err)
 			return result
@@ -190,7 +193,7 @@ func (h *fetchHandler) fetchURL(ctx context.Context, client *http.Client, urlStr
 	useragent.SetIdentity(req)
 	// Apply caller-configured headers last so an operator-supplied
 	// Authorization, User-Agent, Accept, ... wins over the defaults set above.
-	for k, v := range h.headers {
+	for k, v := range headers {
 		req.Header.Set(k, v)
 	}
 
@@ -236,7 +239,7 @@ func (h *fetchHandler) fetchURL(ctx context.Context, client *http.Client, urlStr
 //   - caller-supplied headers (Authorization, X-Api-Key, ...) are stripped
 //     when crossing host boundaries, so credentials never leak to a
 //     third-party host that handles a robots.txt redirect.
-func (h *fetchHandler) fetchRobots(ctx context.Context, client *http.Client, targetURL *url.URL) (*robotstxt.RobotsData, error) {
+func (h *fetchHandler) fetchRobots(ctx context.Context, client *http.Client, targetURL *url.URL, headers map[string]string) (*robotstxt.RobotsData, error) {
 	// Build robots.txt URL
 	robotsURL := &url.URL{
 		Scheme: targetURL.Scheme,
@@ -255,7 +258,7 @@ func (h *fetchHandler) fetchRobots(ctx context.Context, client *http.Client, tar
 	// Apply custom headers to robots.txt requests too, so authenticated
 	// endpoints that also protect robots.txt work correctly. Cross-host
 	// leaks are prevented by the shared client's CheckRedirect.
-	for k, v := range h.headers {
+	for k, v := range headers {
 		req.Header.Set(k, v)
 	}
 
@@ -456,10 +459,9 @@ func htmlToText(html string) string {
 }
 
 // CreateToolSet is used by the tools registry.
-func CreateToolSet(ctx context.Context, toolset latest.Toolset, runConfig *config.RuntimeConfig) (tools.ToolSet, error) {
-	expander := js.NewJsExpander(runConfig.EnvProvider())
-
+func CreateToolSet(toolset latest.Toolset, runConfig *config.RuntimeConfig) (tools.ToolSet, error) {
 	var opts []ToolOption
+
 	if toolset.Timeout > 0 {
 		timeout := time.Duration(toolset.Timeout) * time.Second
 		opts = append(opts, WithTimeout(timeout))
@@ -473,7 +475,10 @@ func CreateToolSet(ctx context.Context, toolset latest.Toolset, runConfig *confi
 	if toolset.AllowPrivateIPsEnabled() {
 		opts = append(opts, WithAllowPrivateIPs(true))
 	}
-	opts = append(opts, WithHeaders(expander.ExpandMap(ctx, toolset.Headers)))
+	opts = append(opts, WithHeaders(toolset.Headers))
+	expander := js.NewJsExpander(runConfig.EnvProvider())
+	opts = append(opts, WithExpander(expander))
+
 	return New(opts...), nil
 }
 
@@ -536,6 +541,12 @@ func WithAllowPrivateIPs(allow bool) ToolOption {
 func WithHeaders(headers map[string]string) ToolOption {
 	return func(t *ToolSet) {
 		t.handler.headers = headers
+	}
+}
+
+func WithExpander(expander *js.Expander) ToolOption {
+	return func(t *ToolSet) {
+		t.handler.expander = expander
 	}
 }
 

--- a/pkg/tools/builtin/fetch/fetch_test.go
+++ b/pkg/tools/builtin/fetch/fetch_test.go
@@ -1,6 +1,7 @@
 package fetch
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -12,6 +13,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/js"
 	"github.com/docker/docker-agent/pkg/tools"
 	"github.com/docker/docker-agent/pkg/useragent"
 	"github.com/docker/docker-agent/pkg/version"
@@ -27,7 +31,7 @@ import (
 // caller options still take precedence (a later option overrides an
 // earlier one).
 func newFetchToolForTest(opts ...ToolOption) *ToolSet {
-	return New(append([]ToolOption{WithAllowPrivateIPs(true)}, opts...)...)
+	return New(append([]ToolOption{WithAllowPrivateIPs(true), WithExpander(js.NewJsExpander(&testEnvProvider{}))}, opts...)...)
 }
 
 func TestFetchToolWithOptions(t *testing.T) {
@@ -910,4 +914,51 @@ func TestFetch_AllowPrivateIPsRestoresLegacyBehaviour(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, result.Output, "internal service response",
 		"WithAllowPrivateIPs(true) must permit dialling 127.0.0.1")
+}
+
+func TestFetch_LazyReplaceHeaders(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		fmt.Fprintf(w, `header value: "%s"`, r.Header.Get("Docker-Token"))
+	}))
+	t.Cleanup(server.Close)
+
+	envVariables := map[string]string{
+		"DOCKER_TOKEN": "INITIAL",
+	}
+	env := testEnvProvider(envVariables)
+
+	toolSet, err := CreateToolSet(latest.Toolset{
+		AllowPrivateIPs: new(true),
+		Headers: map[string]string{
+			"Docker-Token": "${env.DOCKER_TOKEN}",
+		},
+	}, &config.RuntimeConfig{
+		EnvProviderForTests: &env,
+	})
+	require.NoError(t, err)
+
+	// Refresh the DOCKER_TOKEN after tool creation.
+	envVariables["DOCKER_TOKEN"] = "REFRESHED"
+
+	allTools, err := toolSet.Tools(t.Context())
+	require.NoError(t, err)
+
+	result, err := allTools[0].Handler(t.Context(), tools.ToolCall{
+		Function: tools.FunctionCall{
+			Arguments: fmt.Sprintf(`{"urls": [%q], "format": "text"}`, server.URL),
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, `header value: "REFRESHED"`)
+}
+
+type testEnvProvider map[string]string
+
+func (p *testEnvProvider) Get(_ context.Context, name string) (string, bool) {
+	val, found := (*p)[name]
+	return val, found
 }

--- a/pkg/tools/builtin/openapi/openapi.go
+++ b/pkg/tools/builtin/openapi/openapi.go
@@ -30,9 +30,7 @@ import (
 // CreateToolSet is used by the tools registry.
 func CreateToolSet(ctx context.Context, toolset latest.Toolset, runConfig *config.RuntimeConfig) (tools.ToolSet, error) {
 	expander := js.NewJsExpander(runConfig.EnvProvider())
-
 	specURL := expander.Expand(ctx, toolset.URL, nil)
-	headers := expander.ExpandMap(ctx, toolset.Headers)
 
 	var opts []Option
 	if toolset.Timeout > 0 {
@@ -41,7 +39,9 @@ func CreateToolSet(ctx context.Context, toolset latest.Toolset, runConfig *confi
 	if toolset.AllowPrivateIPsEnabled() {
 		opts = append(opts, WithAllowPrivateIPs(true))
 	}
-	return New(specURL, headers, opts...), nil
+	opts = append(opts, WithExpander(expander))
+
+	return New(specURL, toolset.Headers, opts...), nil
 }
 
 // ToolSet generates HTTP tools from an OpenAPI specification.
@@ -51,6 +51,7 @@ type ToolSet struct {
 
 	timeout         time.Duration
 	allowPrivateIPs bool
+	expander        *js.Expander
 }
 
 // Verify interface compliance.
@@ -75,6 +76,10 @@ func WithTimeout(d time.Duration) Option {
 // target internal services. Tests use this to talk to httptest.NewServer.
 func WithAllowPrivateIPs(allow bool) Option {
 	return func(t *ToolSet) { t.allowPrivateIPs = allow }
+}
+
+func WithExpander(expander *js.Expander) Option {
+	return func(t *ToolSet) { t.expander = expander }
 }
 
 // New creates a new OpenAPI toolset from the given spec URL.
@@ -251,6 +256,7 @@ func (t *ToolSet) operationToTool(baseURL, path, method string, op *v3.Operation
 			headers:         t.headers,
 			timeout:         t.timeout,
 			allowPrivateIPs: t.allowPrivateIPs,
+			expander:        t.expander,
 		}).callTool),
 		Annotations: tools.ToolAnnotations{
 			ReadOnlyHint: readOnly,
@@ -441,6 +447,7 @@ type openAPIHandler struct {
 
 	timeout         time.Duration
 	allowPrivateIPs bool
+	expander        *js.Expander
 }
 
 type openAPICallArgs map[string]any
@@ -471,7 +478,9 @@ func (h *openAPIHandler) callTool(ctx context.Context, params openAPICallArgs) (
 		req.Header.Set("Content-Type", "application/json")
 	}
 	req.Header.Set("Accept", "application/json")
-	setHeaders(req, h.headers)
+
+	headers := h.expander.ExpandMap(ctx, h.headers)
+	setHeaders(req, headers)
 
 	resp, err := httpclient.NewSafeClient(h.timeout, h.allowPrivateIPs).Do(req)
 	if err != nil {

--- a/pkg/tools/builtin/openapi/openapi_test.go
+++ b/pkg/tools/builtin/openapi/openapi_test.go
@@ -1,6 +1,7 @@
 package openapi
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/docker/docker-agent/pkg/js"
 	"github.com/docker/docker-agent/pkg/tools"
 	"github.com/docker/docker-agent/pkg/useragent"
 	"github.com/docker/docker-agent/pkg/version"
@@ -22,7 +24,7 @@ import (
 // compiled into release binaries. Production callers must use
 // [New].
 func newOpenAPIToolForTest(specURL string, headers map[string]string) *ToolSet {
-	return New(specURL, headers, WithAllowPrivateIPs(true))
+	return New(specURL, headers, WithAllowPrivateIPs(true), WithExpander(js.NewJsExpander(&testEnvProvider{})))
 }
 
 const petStoreSpec = `{
@@ -622,4 +624,11 @@ func TestOpenAPITool_EnumAndDefaultTypes(t *testing.T) {
 	limitProp := props["limit"].(map[string]any)
 	assert.Equal(t, []any{10, 25, 50, 100}, limitProp["enum"])
 	assert.Equal(t, 25, limitProp["default"])
+}
+
+type testEnvProvider map[string]string
+
+func (p *testEnvProvider) Get(_ context.Context, name string) (string, bool) {
+	val, found := (*p)[name]
+	return val, found
 }

--- a/pkg/tools/mcp/mcp.go
+++ b/pkg/tools/mcp/mcp.go
@@ -109,6 +109,7 @@ func CreateToolSet(ctx context.Context, toolset latest.Toolset, runConfig *confi
 	case toolset.Remote.URL != "":
 		expander := js.NewJsExpander(envProvider)
 
+		// TODO: expand headers on each request, not at creation time.
 		headers := expander.ExpandMap(ctx, toolset.Remote.Headers)
 		remoteURL := expander.Expand(ctx, toolset.Remote.URL, nil)
 


### PR DESCRIPTION
Builtin tools with custom headers should expand them on each http query, not at toolset creation.
This allows for example DOCKER_TOKEN based headers to use a fresh token each time.