### PR TITLE
chore: bump direct go dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/natefinch/atomic v1.0.1
 	github.com/openai/openai-go/v3 v3.37.0
-	github.com/pb33f/libopenapi v0.36.6
+	github.com/pb33f/libopenapi v0.37.1
 	github.com/rivo/uniseg v0.4.7
 	github.com/rumpl/harness v0.0.0-20260519225334-1d956be4fff1
 	github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/docker/aijson v0.1.0
 	github.com/docker/cli v29.5.2+incompatible
 	github.com/docker/go-units v0.5.0
-	github.com/docker/portcullis v0.0.0-20260526131538-fc97bf12bbdb
+	github.com/docker/portcullis v0.0.0-20260526171634-3105c185ace7
 	github.com/dop251/goja v0.0.0-20260311135729-065cd970411c
 	github.com/fatih/color v1.19.0
 	github.com/fsnotify/fsnotify v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -421,8 +421,8 @@ github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaR
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pb33f/jsonpath v0.8.2 h1:Ou4C7zjYClBm97dfZjDCjdZGusJoynv/vrtiEKNfj2Y=
 github.com/pb33f/jsonpath v0.8.2/go.mod h1:zBV5LJW4OQOPatmQE2QdKpGQJvhDTlE5IEj6ASaRNTo=
-github.com/pb33f/libopenapi v0.36.6 h1:DRqWcgnMn8wiknMBKETIRZiY+GL05xEFtWwnK/Q+WOs=
-github.com/pb33f/libopenapi v0.36.6/go.mod h1:MsDdUlQ1CdrIDO5v26JfgBxQs7kcaOUEpMP3EqU6bI4=
+github.com/pb33f/libopenapi v0.37.1 h1:CUtDEN8WHVkfVqauGdHOi6ZPrcXT9PJ9phA4rrRAUcI=
+github.com/pb33f/libopenapi v0.37.1/go.mod h1:MsDdUlQ1CdrIDO5v26JfgBxQs7kcaOUEpMP3EqU6bI4=
 github.com/pb33f/ordered-map/v2 v2.3.1 h1:5319HDO0aw4DA4gzi+zv4FXU9UlSs3xGZ40wcP1nBjY=
 github.com/pb33f/ordered-map/v2 v2.3.1/go.mod h1:qxFQgd0PkVUtOMCkTapqotNgzRhMPL7VvaHKbd1HnmQ=
 github.com/pjbgf/sha1cd v0.6.0 h1:3WJ8Wz8gvDz29quX1OcEmkAlUg9diU4GxJHqs0/XiwU=

--- a/go.sum
+++ b/go.sum
@@ -217,8 +217,8 @@ github.com/docker/go-metrics v0.0.1 h1:AgB/0SvBxihN0X8OR4SjsblXkbMvalQ8cjmtKQ2rQ
 github.com/docker/go-metrics v0.0.1/go.mod h1:cG1hvH2utMXtqgqqYE9plW6lDxS3/5ayHzueweSI3Vw=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/docker/portcullis v0.0.0-20260526131538-fc97bf12bbdb h1:0Juktp2Xn6Nxs0fqaCeuTSM01i6Pe1+7aKLsBhMfp2I=
-github.com/docker/portcullis v0.0.0-20260526131538-fc97bf12bbdb/go.mod h1:FBCDtWLlYquonR/uesgN9HhLvbaDIX3PEC6lgHCnL24=
+github.com/docker/portcullis v0.0.0-20260526171634-3105c185ace7 h1:VypPQlgr9tfJl0hyVaF8PSFVZD3qikwK8eixcqv9Qo8=
+github.com/docker/portcullis v0.0.0-20260526171634-3105c185ace7/go.mod h1:FBCDtWLlYquonR/uesgN9HhLvbaDIX3PEC6lgHCnL24=
 github.com/dop251/goja v0.0.0-20260311135729-065cd970411c h1:OcLmPfx1T1RmZVHHFwWMPaZDdRf0DBMZOFMVWJa7Pdk=
 github.com/dop251/goja v0.0.0-20260311135729-065cd970411c/go.mod h1:MxLav0peU43GgvwVgNbLAj1s/bSGboKkhuULvq/7hx4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=


### PR DESCRIPTION
This PR updates two direct dependencies to incorporate bug fixes and improvements.

The bumps are straightforward upgrades with no code changes required. Both dependencies pass linting and tests on the current version of the codebase.

A third dependency, `google.golang.org/adk`, was evaluated but not bumped. Version v1.3.0 deprecates the `server/adka2a` package in favor of `server/adka2a/v2`, which would require a separate migration and is being deferred to a follow-up effort.

| Module | From | To | Status |
|--------|------|----|--------|
| github.com/docker/portcullis | v0.0.0-20260526131538-fc97bf12bbdb | v0.0.0-20260526171634-3105c185ace7 | bumped |
| github.com/pb33f/libopenapi | v0.36.6 | v0.37.1 | bumped |
| google.golang.org/adk | v1.2.0 | v1.3.0 | skipped — lint failure (adka2a deprecated, requires migration to adka2a/v2) |