### PR TITLE
fix(runtime): populate ModelID in after_llm_call hook payload

### DIFF
--- a/pkg/runtime/after_llm_call_test.go
+++ b/pkg/runtime/after_llm_call_test.go
@@ -1,0 +1,76 @@
+package runtime
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/hooks"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/team"
+)
+
+// TestAfterLLMCallHook_PopulatesModelID is a regression test for the
+// doc/impl mismatch where [hooks.Input.ModelID] is documented as
+// populated for after_llm_call but executeAfterLLMCallHooks never
+// actually set it — handlers reading model_id always saw an empty
+// string. A single successful turn must dispatch after_llm_call with
+// ModelID equal to the provider's canonical "<provider>/<model>" id.
+func TestAfterLLMCallHook_PopulatesModelID(t *testing.T) {
+	t.Parallel()
+
+	const (
+		hookName = "test-after-llm-model-id"
+		modelID  = "test/mock-model"
+	)
+
+	var captured atomic.Pointer[hooks.Input]
+
+	stream := newStreamBuilder().
+		AddContent("ok").
+		AddStopWithUsage(1, 1).
+		Build()
+	prov := &mockProvider{id: modelID, stream: stream}
+
+	root := agent.New("root", "test agent",
+		agent.WithModel(prov),
+		agent.WithHooks(&latest.HooksConfig{
+			AfterLLMCall: []latest.HookDefinition{
+				{Type: "builtin", Command: hookName},
+			},
+		}),
+	)
+	tm := team.New(team.WithAgents(root))
+
+	rt, err := NewLocalRuntime(tm,
+		WithSessionCompaction(false),
+		WithModelStore(mockModelStore{}),
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, rt.hooksRegistry.RegisterBuiltin(
+		hookName,
+		func(_ context.Context, in *hooks.Input, _ []string) (*hooks.Output, error) {
+			snap := *in
+			captured.Store(&snap)
+			return nil, nil
+		},
+	))
+
+	sess := session.New(session.WithUserMessage("hi"))
+	sess.Title = "Unit Test"
+
+	for range rt.RunStream(t.Context(), sess) {
+	}
+
+	got := captured.Load()
+	require.NotNil(t, got, "after_llm_call hook must fire on a successful turn")
+	assert.Equal(t, modelID, got.ModelID,
+		"after_llm_call payload must include the canonical model id; "+
+			"see pkg/hooks/types.go:177-186 for the documented contract")
+}

--- a/pkg/runtime/harness.go
+++ b/pkg/runtime/harness.go
@@ -189,7 +189,7 @@ func (r *LocalRuntime) runHarnessAgent(ctx context.Context, sess *session.Sessio
 		content = strings.TrimSpace(finalResult)
 	}
 
-	r.executeAfterLLMCallHooks(ctx, sess, a, content)
+	r.executeAfterLLMCallHooks(ctx, sess, a, modelID, content)
 	r.recordHarnessAssistantMessage(sess, a, content, modelID, usage, cost, events)
 	r.executeStopHooks(ctx, sess, a, content, events)
 

--- a/pkg/runtime/hooks.go
+++ b/pkg/runtime/hooks.go
@@ -443,10 +443,11 @@ func (r *LocalRuntime) executeBeforeLLMCallHooks(
 // stop_response (matching the stop event), so handlers can reuse the
 // same parsing logic. Failed model calls fire on_error instead and
 // skip this event.
-func (r *LocalRuntime) executeAfterLLMCallHooks(ctx context.Context, sess *session.Session, a *agent.Agent, responseContent string) {
+func (r *LocalRuntime) executeAfterLLMCallHooks(ctx context.Context, sess *session.Session, a *agent.Agent, modelID, responseContent string) {
 	r.dispatchHook(ctx, a, hooks.EventAfterLLMCall, &hooks.Input{
 		SessionID:       sess.ID,
 		AgentName:       a.Name(),
+		ModelID:         modelID,
 		StopResponse:    responseContent,
 		LastUserMessage: sess.GetLastUserMessageContent(),
 	}, nil)

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -569,7 +569,7 @@ func (r *LocalRuntime) runTurn(
 	// fire on_error above. The assistant text content is passed
 	// via stop_response, matching the stop event's payload, so
 	// handlers can reuse the same parsing.
-	r.executeAfterLLMCallHooks(ctx, sess, a, res.Content)
+	r.executeAfterLLMCallHooks(ctx, sess, a, modelID.String(), res.Content)
 
 	if usedModel != nil && usedModel.ID() != model.ID() {
 		slog.InfoContext(ctx, "Used fallback model", "agent", a.Name(), "primary", model.ID().String(), "used", usedModel.ID().String())


### PR DESCRIPTION
## Problem

Hook handlers wired to `after_llm_call` read `model_id` and always observed
the empty string, even though `pkg/hooks/types.go:177-186` documents `ModelID`
as populated for this event:

```go
// ModelID identifies the model the runtime is about to call (for
// before_llm_call) or just called (for after_llm_call), in the
// canonical "<provider>/<model>" form...
ModelID string `json:"model_id,omitempty"`
```

Anyone writing a cost/audit/telemetry sidecar that trusts the doc and keys off
`model_id` ends up with no way to distinguish responses across models in the
same session.

## Root cause

`executeAfterLLMCallHooks` (`pkg/runtime/hooks.go:446-453`) never set the field
on the dispatched `hooks.Input`:

```go
func (r *LocalRuntime) executeAfterLLMCallHooks(
    ctx context.Context, sess *session.Session,
    a *agent.Agent, responseContent string,
) {
    r.dispatchHook(ctx, a, hooks.EventAfterLLMCall, &hooks.Input{
        SessionID:       sess.ID,
        AgentName:       a.Name(),
        StopResponse:    responseContent,
        LastUserMessage: sess.GetLastUserMessageContent(),
        // ModelID was missing — `json:"model_id,omitempty"` then elided it
    }, nil)
}
```

`json:"model_id,omitempty"` on the zero-string then elides the key from the
wire payload entirely, so handlers can't even branch on "is the field present".

The sibling `executeBeforeLLMCallHooks` already populates `ModelID` from a
parameter (`pkg/runtime/loop.go:530`), so this is an after-only impl gap, not a
runtime-wide one.

## Fix

Thread the model identifier into the dispatch so the payload matches the
documented contract. Both callsites already have the identifier in scope:

- `pkg/runtime/hooks.go`: add `modelID` parameter to `executeAfterLLMCallHooks`
  and set `Input.ModelID` on the dispatch.
- `pkg/runtime/harness.go:192`: pass the existing local `modelID`.
- `pkg/runtime/loop.go:572`: pass `modelID.String()` from the resolved
  `modelsdev.ID`.

No public API or wire-format addition — the field has been on `hooks.Input` and
documented all along; this PR just stops eliding it.

For harness agents, `modelID` is the harness label (e.g. `claude-code`) rather
than the `<provider>/<model>` canonical form the types.go doc describes. That's
pre-existing: the sibling `executeBeforeLLMCallHooks` in the harness path is
dispatched with the same `modelID` (`pkg/runtime/harness.go:50`). This PR
preserves the before/after symmetry and introduces no new asymmetry.

## Tests

`pkg/runtime/after_llm_call_test.go` adds `TestAfterLLMCallHook_PopulatesModelID`,
which registers a builtin `after_llm_call` hook against a fixed-id `mockProvider`,
runs one turn, and asserts the captured `Input.ModelID` equals the provider's
canonical id. Verified the test fails on the unfixed tree
(`expected "test/mock-model" / actual ""`) and passes with the fix.

## Verification

- `go vet ./pkg/runtime/` — clean
- `golangci-lint run ./pkg/runtime/...` — 0 issues
- `go test ./pkg/runtime/ ./pkg/hooks/...` — all green

## Out of scope

`docs/configuration/hooks/index.md:258-259` lists per-event payload fields but
doesn't mention `model_id` for either `before_llm_call` (already populated in
code) or `after_llm_call` (this PR). That's a pre-existing docs gap covering
both events; a follow-up docs PR (matching the spirit of #2569) is a better
venue for catching them up together than fixing only the after-side here.
