### PR TITLE
feat: add --disable-commands flag to hide and disable slash commands in TUI

### DIFF
--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -62,11 +62,12 @@ type runExecFlags struct {
 	outputJSON    bool
 
 	// Run only
-	hideToolResults bool
-	lean            bool
-	appName         string
-	listenAddr      string
-	onEventSpecs    []string
+	hideToolResults  bool
+	lean             bool
+	appName          string
+	listenAddr       string
+	onEventSpecs     []string
+	disabledCommands []string
 
 	// globalPermissions holds the user-level global permission checker built
 	// from user config settings. Nil when no global permissions are configured.
@@ -140,6 +141,7 @@ func addRunOrExecFlags(cmd *cobra.Command, flags *runExecFlags) {
 	_ = cmd.PersistentFlags().MarkHidden("force-tui")
 	cmd.PersistentFlags().BoolVar(&flags.lean, "lean", false, "Use a simplified TUI with minimal chrome")
 	cmd.PersistentFlags().StringVar(&flags.appName, "app-name", "", "Application name shown in the TUI in place of \"docker agent\"")
+	cmd.PersistentFlags().StringSliceVar(&flags.disabledCommands, "disable-commands", nil, "Comma-separated list of slash commands to hide and disable in the TUI (e.g. /cost,/eval,/model)")
 	cmd.PersistentFlags().BoolVar(&flags.sandbox, "sandbox", false, "Run the agent inside a Docker sandbox (requires Docker Desktop with sandbox support)")
 	cmd.PersistentFlags().StringVar(&flags.sandboxTemplate, "template", "docker/sandbox-templates:docker-agent", "Template image for the sandbox (passed to docker sandbox create -t)")
 	cmd.PersistentFlags().BoolVar(&flags.sbx, "sbx", true, "Prefer the sbx CLI backend when available (set --sbx=false to force docker sandbox)")
@@ -502,6 +504,9 @@ func (f *runExecFlags) tuiOpts() []tui.Option {
 	}
 	if f.appName != "" {
 		opts = append(opts, tui.WithAppName(f.appName))
+	}
+	if len(f.disabledCommands) > 0 {
+		opts = append(opts, tui.WithDisabledCommands(f.disabledCommands))
 	}
 	return opts
 }

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -188,6 +188,10 @@ type appModel struct {
 
 	appName    string
 	appVersion string
+
+	// disabledCommands holds slash commands to hide and disable.
+	// Normalized to start with "/".
+	disabledCommands map[string]bool
 }
 
 // Transcriber is the speech-to-text interface used by the TUI. It is an
@@ -227,6 +231,32 @@ func WithAppName(name string) Option {
 func WithVersion(v string) Option {
 	return func(m *appModel) {
 		m.appVersion = v
+	}
+}
+
+// WithDisabledCommands hides and disables the given slash commands so they
+// are stripped from the command palette, the slash-command parser, and
+// completion. Each entry is normalized to start with "/" (so "cost" and
+// "/cost" are equivalent) and lower-cased to match the registered slash
+// command names (so "/Cost" and "/cost" are equivalent).
+func WithDisabledCommands(slashCommands []string) Option {
+	return func(m *appModel) {
+		if len(slashCommands) == 0 {
+			return
+		}
+		if m.disabledCommands == nil {
+			m.disabledCommands = make(map[string]bool, len(slashCommands))
+		}
+		for _, c := range slashCommands {
+			c = strings.ToLower(strings.TrimSpace(c))
+			if c == "" {
+				continue
+			}
+			if !strings.HasPrefix(c, "/") {
+				c = "/" + c
+			}
+			m.disabledCommands[c] = true
+		}
 	}
 }
 
@@ -392,7 +422,26 @@ func (m *appModel) reapplyKeyboardEnhancements() {
 }
 
 func (m *appModel) commandCategories() []commands.Category {
-	return m.buildCommandCategories(context.Background(), m)
+	categories := m.buildCommandCategories(context.Background(), m)
+	if len(m.disabledCommands) == 0 {
+		return categories
+	}
+	filtered := make([]commands.Category, 0, len(categories))
+	for _, cat := range categories {
+		items := make([]commands.Item, 0, len(cat.Commands))
+		for _, item := range cat.Commands {
+			if m.disabledCommands[item.SlashCommand] {
+				continue
+			}
+			items = append(items, item)
+		}
+		if len(items) == 0 {
+			continue
+		}
+		cat.Commands = items
+		filtered = append(filtered, cat)
+	}
+	return filtered
 }
 
 // chatPageOpts returns the chat.PageOption slice derived from the current

--- a/pkg/tui/tui_helpers_test.go
+++ b/pkg/tui/tui_helpers_test.go
@@ -1,11 +1,13 @@
 package tui
 
 import (
+	"context"
 	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/docker/docker-agent/pkg/tui/commands"
 	"github.com/docker/docker-agent/pkg/tui/components/statusbar"
 	"github.com/docker/docker-agent/pkg/tui/components/tabbar"
 )
@@ -262,4 +264,79 @@ func TestFormatWindowTitle(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCommandCategories_DisabledCommandsFilter(t *testing.T) {
+	t.Parallel()
+
+	build := func(context.Context, tea.Model) []commands.Category {
+		return []commands.Category{
+			{
+				Name: "Session",
+				Commands: []commands.Item{
+					{ID: "a", SlashCommand: "/cost"},
+					{ID: "b", SlashCommand: "/eval"},
+					{ID: "c", SlashCommand: "/exit"},
+				},
+			},
+			{
+				Name: "Settings",
+				Commands: []commands.Item{
+					{ID: "d", SlashCommand: "/theme"},
+				},
+			},
+		}
+	}
+
+	t.Run("no filter keeps everything", func(t *testing.T) {
+		t.Parallel()
+		m := &appModel{buildCommandCategories: build}
+		got := m.commandCategories()
+		if len(got) != 2 {
+			t.Fatalf("len(categories) = %d, want 2", len(got))
+		}
+	})
+
+	t.Run("filters slash commands and drops empty categories", func(t *testing.T) {
+		t.Parallel()
+		m := &appModel{buildCommandCategories: build}
+		WithDisabledCommands([]string{"/cost", "eval", "/theme"})(m)
+
+		got := m.commandCategories()
+		if len(got) != 1 {
+			t.Fatalf("len(categories) = %d, want 1 (Settings dropped, Session kept)", len(got))
+		}
+		if got[0].Name != "Session" {
+			t.Fatalf("category = %q, want Session", got[0].Name)
+		}
+		if len(got[0].Commands) != 1 || got[0].Commands[0].SlashCommand != "/exit" {
+			t.Fatalf("session commands = %+v, want only /exit", got[0].Commands)
+		}
+	})
+
+	t.Run("blank entries are ignored", func(t *testing.T) {
+		t.Parallel()
+		m := &appModel{buildCommandCategories: build}
+		WithDisabledCommands([]string{"", "  "})(m)
+		got := m.commandCategories()
+		if len(got) != 2 {
+			t.Fatalf("len(categories) = %d, want 2", len(got))
+		}
+	})
+
+	t.Run("matching is case-insensitive", func(t *testing.T) {
+		t.Parallel()
+		m := &appModel{buildCommandCategories: build}
+		WithDisabledCommands([]string{"/Cost", "EVAL", "/Theme"})(m)
+		got := m.commandCategories()
+		if len(got) != 1 {
+			t.Fatalf("len(categories) = %d, want 1 (Settings dropped, Session kept)", len(got))
+		}
+		if got[0].Name != "Session" {
+			t.Fatalf("category = %q, want Session", got[0].Name)
+		}
+		if len(got[0].Commands) != 1 || got[0].Commands[0].SlashCommand != "/exit" {
+			t.Fatalf("session commands = %+v, want only /exit", got[0].Commands)
+		}
+	})
 }


### PR DESCRIPTION
Users sometimes want to limit which slash commands are available in the TUI—for example, to hide commands that shouldn't be used in a particular environment or workflow. This change adds a `--disable-commands` flag to `docker agent run` and `docker agent exec` that lets you specify which commands to hide.

The flag accepts a comma-separated list of slash command names, like `--disable-commands="/cost,/eval,/model"`. Leading slashes are optional and matching is case-insensitive (`/Cost`, `cost`, `/cost` all disable `/cost`). When set, the specified commands are completely hidden and disabled: they're stripped from the command palette (Ctrl+K), the slash-command parser, and the editor completion popup. The filtering happens in a single `commandCategories()` chokepoint, so all three surfaces inherit the behavior consistently.
