### PR TITLE
feat: add --app-name flag and fix macOS test symlink issue

### DIFF
--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -64,6 +64,7 @@ type runExecFlags struct {
 	// Run only
 	hideToolResults bool
 	lean            bool
+	appName         string
 	listenAddr      string
 	onEventSpecs    []string
 
@@ -138,6 +139,7 @@ func addRunOrExecFlags(cmd *cobra.Command, flags *runExecFlags) {
 	cmd.PersistentFlags().BoolVar(&flags.forceTUI, "force-tui", false, "Force TUI mode even when not in a terminal")
 	_ = cmd.PersistentFlags().MarkHidden("force-tui")
 	cmd.PersistentFlags().BoolVar(&flags.lean, "lean", false, "Use a simplified TUI with minimal chrome")
+	cmd.PersistentFlags().StringVar(&flags.appName, "app-name", "", "Application name shown in the TUI in place of \"docker agent\"")
 	cmd.PersistentFlags().BoolVar(&flags.sandbox, "sandbox", false, "Run the agent inside a Docker sandbox (requires Docker Desktop with sandbox support)")
 	cmd.PersistentFlags().StringVar(&flags.sandboxTemplate, "template", "docker/sandbox-templates:docker-agent", "Template image for the sandbox (passed to docker sandbox create -t)")
 	cmd.PersistentFlags().BoolVar(&flags.sbx, "sbx", true, "Prefer the sbx CLI backend when available (set --sbx=false to force docker sandbox)")
@@ -497,6 +499,9 @@ func (f *runExecFlags) tuiOpts() []tui.Option {
 	var opts []tui.Option
 	if f.lean {
 		opts = append(opts, tui.WithLeanMode())
+	}
+	if f.appName != "" {
+		opts = append(opts, tui.WithAppName(f.appName))
 	}
 	return opts
 }

--- a/pkg/snapshot/snapshot_test.go
+++ b/pkg/snapshot/snapshot_test.go
@@ -210,7 +210,10 @@ func bootstrapRepo(t *testing.T) string {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
-	dir := t.TempDir()
+	// Canonicalize so paths match git rev-parse --show-toplevel, which
+	// resolves symlinks (e.g. /var/folders -> /private/var/folders on macOS).
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
 	runGit(t, dir, "init")
 	runGit(t, dir, "config", "user.email", "test@example.com")
 	runGit(t, dir, "config", "user.name", "Test User")


### PR DESCRIPTION
The `docker agent run` command now accepts an `--app-name` flag to override the default "docker agent" label shown in the TUI. This string is passed to the existing `tui.WithAppName` option, affecting the status bar, terminal window title, and "/exit" notifications.

We also fixed an unrelated test issue in `pkg/snapshot/snapshot_test.go`. The `bootstrapRepo` helper now resolves symlinks via `filepath.EvalSymlinks` on its temporary directory. This ensures test assertions pass on macOS, where `t.TempDir()` returns `/var/folders/...` (a symlink to `/private/var/folders/...`), while `git rev-parse --show-toplevel` returns the canonical resolved path. This unblocks `TestTrackPatchFromSubfolder` and `TestOpenCanonicalizesSymlinkedDirectory`.