### PR TITLE
Rename OAuth elicitation meta keys from cagent/ to docker-agent/

### DIFF
--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -230,7 +230,7 @@ func Run(ctx context.Context, out *Printer, cfg Config, rt runtime.Runtime, sess
 					}
 				}
 			case *runtime.ElicitationRequestEvent:
-				serverURL, ok := e.Meta["cagent/server_url"].(string)
+				serverURL, ok := e.Meta["docker-agent/server_url"].(string)
 				if !ok || serverURL == "" {
 					slog.WarnContext(ctx, "Skipping elicitation: missing or invalid server_url (non-interactive session?)")
 					_ = rt.ResumeElicitation(ctx, "decline", nil)

--- a/pkg/cli/runner_test.go
+++ b/pkg/cli/runner_test.go
@@ -230,7 +230,7 @@ func TestElicitationAutoDeclineInJSONMode(t *testing.T) {
 			&runtime.ElicitationRequestEvent{
 				Type:    "elicitation_request",
 				Message: "Please authorize",
-				Meta:    map[string]any{"cagent/server_url": "https://example.com"},
+				Meta:    map[string]any{"docker-agent/server_url": "https://example.com"},
 			},
 		},
 	}

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -398,9 +398,9 @@ func (r *RemoteRuntime) handleOAuthElicitation(ctx context.Context, req *Elicita
 		return nil
 	}
 
-	slog.DebugContext(ctx, "Handling OAuth elicitation request", "server_url", req.Meta["cagent/server_url"])
+	slog.DebugContext(ctx, "Handling OAuth elicitation request", "server_url", req.Meta["docker-agent/server_url"])
 
-	serverURL, ok := req.Meta["cagent/server_url"].(string)
+	serverURL, ok := req.Meta["docker-agent/server_url"].(string)
 	if !ok {
 		err := errors.New("server_url missing from elicitation metadata")
 		slog.ErrorContext(ctx, "Failed to extract server_url", "error", err)

--- a/pkg/tools/mcp/oauth.go
+++ b/pkg/tools/mcp/oauth.go
@@ -781,8 +781,8 @@ func (t *oauthTransport) handleManagedOAuthFlow(ctx context.Context, authServer,
 		Message:         fmt.Sprintf("The MCP server at %s requires OAuth authorization. Do you want to proceed?", t.baseURL),
 		RequestedSchema: nil,
 		Meta: map[string]any{
-			"cagent/type":       "oauth_flow",
-			"cagent/server_url": t.baseURL,
+			"docker-agent/type":       "oauth_flow",
+			"docker-agent/server_url": t.baseURL,
 		},
 	})
 	if err != nil {
@@ -884,11 +884,11 @@ func (t *oauthTransport) handleUnmanagedOAuthFlow(ctx context.Context, authServe
 		Message:         "OAuth authorization required for " + t.baseURL,
 		RequestedSchema: nil,
 		Meta: map[string]any{
-			"cagent/type":          "oauth_flow",
-			"cagent/server_url":    t.baseURL,
-			"auth_server":          resourceMetadata.AuthorizationServers[0],
-			"auth_server_metadata": authServerMetadata,
-			"resource_metadata":    resourceMetadata,
+			"docker-agent/type":       "oauth_flow",
+			"docker-agent/server_url": t.baseURL,
+			"auth_server":             resourceMetadata.AuthorizationServers[0],
+			"auth_server_metadata":    authServerMetadata,
+			"resource_metadata":       resourceMetadata,
 		},
 	})
 	if err != nil {

--- a/pkg/tui/page/chat/runtime_events.go
+++ b/pkg/tui/page/chat/runtime_events.go
@@ -337,10 +337,10 @@ func (p *chatPage) handleElicitationRequest(msg *runtime.ElicitationRequestEvent
 	// Check if this is an OAuth flow by looking at the meta type
 	// Guard against nil Meta map to prevent panic
 	if msg.Meta != nil {
-		if elicitationType, ok := msg.Meta["cagent/type"].(string); ok && elicitationType == "oauth_flow" {
+		if elicitationType, ok := msg.Meta["docker-agent/type"].(string); ok && elicitationType == "oauth_flow" {
 			// OAuth flow - show the OAuth authorization dialog
 			var serverURL string
-			if url, ok := msg.Meta["cagent/server_url"].(string); ok {
+			if url, ok := msg.Meta["docker-agent/server_url"].(string); ok {
 				serverURL = url
 			}
 			dialogCmd := core.CmdHandler(dialog.OpenDialogMsg{

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -1470,9 +1470,9 @@ func (m *appModel) replayPendingEvent(sessionID string) tea.Cmd {
 func (m *appModel) replayElicitationEvent(ev *runtime.ElicitationRequestEvent) tea.Cmd {
 	// Check if this is an OAuth flow
 	if ev.Meta != nil {
-		if elicitationType, ok := ev.Meta["cagent/type"].(string); ok && elicitationType == "oauth_flow" {
+		if elicitationType, ok := ev.Meta["docker-agent/type"].(string); ok && elicitationType == "oauth_flow" {
 			var serverURL string
-			if url, ok := ev.Meta["cagent/server_url"].(string); ok {
+			if url, ok := ev.Meta["docker-agent/server_url"].(string); ok {
 				serverURL = url
 			}
 			return core.CmdHandler(dialog.OpenDialogMsg{


### PR DESCRIPTION
## Summary

The OAuth elicitation `Meta` map keys still carry the legacy product name (`cagent/type`, `cagent/server_url`). The runtime was renamed to `docker-agent` some time ago; align the meta keys with it so the contract clients see matches the project name they're integrating against.

Renamed:

| Before | After |
|---|---|
| `cagent/type` | `docker-agent/type` |
| `cagent/server_url` | `docker-agent/server_url` |

Both writer sites (`handleManagedOAuthFlow`, `handleUnmanagedOAuthFlow`) and every in-tree reader (CLI runner, `RemoteRuntime` OAuth mirror, TUI elicitation handling) are updated together.

