### PR TITLE
Propagate user-initiated cancellation across the WithoutCancel boundary

### DIFF
--- a/cmd/root/flags.go
+++ b/cmd/root/flags.go
@@ -36,6 +36,12 @@ func addRuntimeConfigFlags(cmd *cobra.Command, runConfig *config.RuntimeConfig) 
 	cmd.PersistentFlags().StringArrayVar(&runConfig.HookSessionEnd, "hook-session-end", nil, "Add a session-end hook command (repeatable)")
 	cmd.PersistentFlags().StringArrayVar(&runConfig.HookOnUserInput, "hook-on-user-input", nil, "Add an on-user-input hook command (repeatable)")
 	cmd.PersistentFlags().StringArrayVar(&runConfig.HookStop, "hook-stop", nil, "Add a stop hook command, fired when the model finishes responding (repeatable)")
+	cmd.PersistentFlags().StringVar(&runConfig.MCPOAuthRedirectURI, "mcp-oauth-redirect-uri", "",
+		"Public HTTPS URL to advertise as the OAuth `redirect_uri` for MCP servers "+
+			"running in unmanaged OAuth mode. When set, docker-agent drives the OAuth flow "+
+			"itself (PKCE + DCR + token exchange) and expects clients to return `{code, state}` "+
+			"via ResumeElicitation. When empty, the client is expected to perform the OAuth "+
+			"flow and return an access token (legacy behavior).")
 }
 
 func setupWorkingDirectory(workingDir string) error {

--- a/docs/features/remote-mcp/index.md
+++ b/docs/features/remote-mcp/index.md
@@ -106,6 +106,30 @@ The local callback server still listens on the loopback interface on `callbackPo
 - Only `http` and `https` schemes are accepted.
 - `http` is only allowed when the host is a loopback address (`127.0.0.1`, `::1`, `localhost`); any other host must use `https` to avoid exposing the authorization `code` on the wire (RFC 8252 §7.3).
 
+### Unmanaged OAuth flow (server mode)
+
+When running `docker-agent serve api` (no local browser, no callback server), the runtime delegates the OAuth dance to the connected client via an MCP elicitation. There are two sub-behaviors, selected by the `--mcp-oauth-redirect-uri` flag:
+
+- **`--mcp-oauth-redirect-uri=<URL>` set** (recommended for hosts like Docker Desktop): the runtime generates `state` + PKCE + (optional) Dynamic Client Registration in-process, builds the full authorize URL, and emits an elicitation whose `Meta` includes:
+
+  | Key                          | Value                                                            |
+  | ---------------------------- | ---------------------------------------------------------------- |
+  | `cagent/type`                | `"oauth_flow"`                                                   |
+  | `cagent/server_url`          | The MCP server URL (for display / favicon)                       |
+  | `cagent/authorize_url`       | The full URL the client should open in the user's browser        |
+  | `cagent/state`               | The `state` value the client must echo back when replying        |
+  | `auth_server`                | Issuer of the authorization server                               |
+  | `auth_server_metadata`       | RFC 8414 authorization-server metadata document                  |
+  | `resource_metadata`          | RFC 9728 protected-resource metadata document                    |
+
+  The client opens the browser at `cagent/authorize_url`, receives the OAuth callback at whatever endpoint the configured `redirect_uri` resolves to (typically a host-controlled bouncer that 302s into a deeplink), and replies to the elicitation with `accept` and `Content = {"code": "...", "state": "..."}`. The runtime verifies the `state`, exchanges the `code` at the token endpoint (using the same `redirect_uri` for RFC 6749 §4.1.3 binding), stores the token, and replays the original MCP request with `Authorization: Bearer ...`.
+
+- **Flag not set** (legacy): the runtime emits only `auth_server_metadata` + `resource_metadata`; the client is expected to drive the OAuth flow itself (PKCE, DCR, token exchange) and reply with `Content = {"access_token": "...", "refresh_token": "...", ...}`.
+
+The legacy `{access_token, ...}` reply shape is still accepted on the `--mcp-oauth-redirect-uri` path too: a client that prefers to do the exchange itself can ignore the `cagent/authorize_url`/`cagent/state` keys.
+
+A per-toolset `callbackRedirectURL` (in the YAML) overrides the runtime-wide `--mcp-oauth-redirect-uri` for that toolset.
+
 ## Project Management &amp; Collaboration
 
 | Service    | URL                                | Transport | Description                           |

--- a/pkg/config/runtime.go
+++ b/pkg/config/runtime.go
@@ -44,6 +44,27 @@ type Config struct {
 
 	MCPToolName  string
 	MCPKeepAlive time.Duration
+
+	// MCPOAuthRedirectURI is an opaque public HTTPS URL the runtime advertises
+	// as the OAuth `redirect_uri` when running an MCP server OAuth flow in
+	// unmanaged mode (see WithManagedOAuth(false)). When set, docker-agent
+	// generates state + PKCE + DCR in-process and emits an elicitation
+	// carrying the `authorize_url` + `state`; the client is then a thin
+	// relay that opens the browser, receives the callback (typically via a
+	// host-controlled bouncer + deeplink), and returns {code, state} via
+	// ResumeElicitation. docker-agent then exchanges the code for the
+	// token using this same URI as redirect_uri (RFC 6749 §4.1.3 requires
+	// the value to match the one sent at the /authorize step).
+	//
+	// When empty, the unmanaged flow keeps its original contract: the
+	// client is expected to drive the OAuth dance end-to-end and return
+	// {access_token, refresh_token, …}. This preserves backward compat
+	// with existing CLI-mirror clients.
+	//
+	// The URI itself is opaque to docker-agent — what it points at and how
+	// the browser eventually lands back in the host application is the
+	// caller's concern.
+	MCPOAuthRedirectURI string
 }
 
 func (runConfig *RuntimeConfig) Clone() *RuntimeConfig {

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -841,6 +841,7 @@ func (r *LocalRuntime) configureToolsetHandlers(a *agent.Agent, events EventSink
 			r.samplingHandler,
 			func() { events.Emit(Authorization(tools.ElicitationActionAccept, a.Name())) },
 			r.managedOAuth,
+			r.unmanagedOAuthRedirectURI,
 		)
 
 		// Wire RAG event forwarding so the TUI shows indexing progress.

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -177,22 +177,23 @@ type ModelStore interface {
 
 // LocalRuntime manages the execution of agents
 type LocalRuntime struct {
-	toolMap              map[string]ToolHandlerFunc
-	team                 *team.Team
-	agents               *agentRouter
-	resumeChan           chan ResumeRequest
-	tracer               trace.Tracer
-	modelsStore          ModelStore
-	sessionCompaction    bool
-	managedOAuth         bool
-	nonInteractive       bool
-	startupInfoEmitted   bool                   // Track if startup info has been emitted to avoid unnecessary duplication
-	elicitationRequestCh chan ElicitationResult // Channel for receiving elicitation responses
-	elicitation          elicitationBridge      // Owns the per-stream events channel for outbound elicitation requests
-	sessionStore         session.Store
-	workingDir           string   // Working directory for hooks execution
-	env                  []string // Environment variables for hooks execution
-	modelSwitcherCfg     *ModelSwitcherConfig
+	toolMap                   map[string]ToolHandlerFunc
+	team                      *team.Team
+	agents                    *agentRouter
+	resumeChan                chan ResumeRequest
+	tracer                    trace.Tracer
+	modelsStore               ModelStore
+	sessionCompaction         bool
+	managedOAuth              bool
+	unmanagedOAuthRedirectURI string
+	nonInteractive            bool
+	startupInfoEmitted        bool                   // Track if startup info has been emitted to avoid unnecessary duplication
+	elicitationRequestCh      chan ElicitationResult // Channel for receiving elicitation responses
+	elicitation               elicitationBridge      // Owns the per-stream events channel for outbound elicitation requests
+	sessionStore              session.Store
+	workingDir                string   // Working directory for hooks execution
+	env                       []string // Environment variables for hooks execution
+	modelSwitcherCfg          *ModelSwitcherConfig
 
 	// hooksRegistry is the runtime-private hooks.Registry used to build
 	// every Executor. It carries the runtime-owned builtin hooks
@@ -288,6 +289,20 @@ func WithCurrentAgent(agentName string) Opt {
 func WithManagedOAuth(managed bool) Opt {
 	return func(r *LocalRuntime) {
 		r.managedOAuth = managed
+	}
+}
+
+// WithUnmanagedOAuthRedirectURI configures the redirect_uri the runtime
+// advertises when running MCP server OAuth flows in unmanaged mode (i.e.
+// when WithManagedOAuth(false) is set). When set, docker-agent generates
+// state + PKCE + DCR in-process and emits an elicitation carrying the
+// `authorize_url` + `state`; the client returns `{code, state}` via
+// ResumeElicitation and docker-agent does the token exchange itself.
+// When empty, the runtime falls back to the legacy unmanaged contract
+// where the client performs the OAuth flow and returns an access token.
+func WithUnmanagedOAuthRedirectURI(uri string) Opt {
+	return func(r *LocalRuntime) {
+		r.unmanagedOAuthRedirectURI = uri
 	}
 }
 

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -963,6 +963,8 @@ func (s *oauthAwareToolSet) SetManagedOAuth(managed bool) {
 	s.managedOAuthSet = true
 }
 
+func (s *oauthAwareToolSet) SetUnmanagedOAuthRedirectURI(string) {}
+
 // TestEmitStartupInfo_DoesNotBlockOnInteractiveOAuth verifies that the
 // startup path does NOT trigger interactive flows on toolsets. In particular:
 //

--- a/pkg/server/mcp_oauth_test.go
+++ b/pkg/server/mcp_oauth_test.go
@@ -15,9 +15,10 @@ import (
 	"github.com/docker/docker-agent/pkg/config"
 )
 
-// httpDoWithStatus is a slim variant of httpDo that exposes the response
-// status code. The standard helper assumes 2xx and only returns the body.
-func httpDoWithStatus(t *testing.T, ctx context.Context, method, socketPath, path string) (int, []byte) {
+// httpDoStatus is a slim variant of httpDo that exposes the response
+// status code. The standard helper assumes 2xx and only returns the body;
+// these tests assert on 4xx, so they need direct access to the status.
+func httpDoStatus(t *testing.T, ctx context.Context, method, socketPath, path string) int {
 	t.Helper()
 	req, err := http.NewRequestWithContext(ctx, method, "http://_"+path, http.NoBody)
 	require.NoError(t, err)
@@ -32,9 +33,9 @@ func httpDoWithStatus(t *testing.T, ctx context.Context, method, socketPath, pat
 	resp, err := client.Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
+	_, err = io.Copy(io.Discard, resp.Body)
 	require.NoError(t, err)
-	return resp.StatusCode, body
+	return resp.StatusCode
 }
 
 func startServerBare(t *testing.T, ctx context.Context) string {
@@ -67,7 +68,7 @@ func TestMcpOAuthCb_Unknown(t *testing.T) {
 	ctx := t.Context()
 	lnPath := startServerBare(t, ctx)
 
-	status, _ := httpDoWithStatus(t, ctx, http.MethodPost, lnPath,
+	status := httpDoStatus(t, ctx, http.MethodPost, lnPath,
 		"/api/mcp-oauth/callback?state=unknown-state&code=abc")
 	assert.Equal(t, http.StatusNotFound, status)
 }
@@ -76,7 +77,7 @@ func TestMcpOAuthCb_NoState(t *testing.T) {
 	ctx := t.Context()
 	lnPath := startServerBare(t, ctx)
 
-	status, _ := httpDoWithStatus(t, ctx, http.MethodPost, lnPath,
+	status := httpDoStatus(t, ctx, http.MethodPost, lnPath,
 		"/api/mcp-oauth/callback?code=abc")
 	assert.Equal(t, http.StatusBadRequest, status)
 }
@@ -85,7 +86,7 @@ func TestMcpOAuthCb_NoCode(t *testing.T) {
 	ctx := t.Context()
 	lnPath := startServerBare(t, ctx)
 
-	status, _ := httpDoWithStatus(t, ctx, http.MethodPost, lnPath,
+	status := httpDoStatus(t, ctx, http.MethodPost, lnPath,
 		"/api/mcp-oauth/callback?state=some-state")
 	assert.Equal(t, http.StatusBadRequest, status)
 }

--- a/pkg/server/mcp_oauth_test.go
+++ b/pkg/server/mcp_oauth_test.go
@@ -1,0 +1,91 @@
+package server
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/config"
+)
+
+// httpDoWithStatus is a slim variant of httpDo that exposes the response
+// status code. The standard helper assumes 2xx and only returns the body.
+func httpDoWithStatus(t *testing.T, ctx context.Context, method, socketPath, path string) (int, []byte) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(ctx, method, "http://_"+path, http.NoBody)
+	require.NoError(t, err)
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, "unix", strings.TrimPrefix(socketPath, "unix://"))
+			},
+		},
+	}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, body
+}
+
+func startServerBare(t *testing.T, ctx context.Context) string {
+	t.Helper()
+	var store mockStore
+	runConfig := config.RuntimeConfig{}
+	sources, err := config.ResolveSources(t.TempDir(), nil)
+	require.NoError(t, err)
+	srv, err := New(ctx, store, &runConfig, 0, sources, "")
+	require.NoError(t, err)
+
+	socketPath := "unix://" + filepath.Join(t.TempDir(), "sock")
+	ln, err := Listen(ctx, socketPath)
+	require.NoError(t, err)
+	go func() { <-ctx.Done(); _ = ln.Close() }()
+	go func() { _ = srv.Serve(ctx, ln) }()
+	return socketPath
+}
+
+// The happy path (waiter registered, callback delivered) is covered end
+// to end in TestUnmanagedOAuthFlow_DriveFlow_AcceptsDirectCallback in
+// pkg/tools/mcp. The server-side tests here focus on the input
+// validation and the 404 response shape so the embedder's HTTP client
+// can rely on it.
+
+// Short test names because the macOS unix-socket path limit (104 bytes)
+// includes t.TempDir() which embeds the test name.
+
+func TestMcpOAuthCb_Unknown(t *testing.T) {
+	ctx := t.Context()
+	lnPath := startServerBare(t, ctx)
+
+	status, _ := httpDoWithStatus(t, ctx, http.MethodPost, lnPath,
+		"/api/mcp-oauth/callback?state=unknown-state&code=abc")
+	assert.Equal(t, http.StatusNotFound, status)
+}
+
+func TestMcpOAuthCb_NoState(t *testing.T) {
+	ctx := t.Context()
+	lnPath := startServerBare(t, ctx)
+
+	status, _ := httpDoWithStatus(t, ctx, http.MethodPost, lnPath,
+		"/api/mcp-oauth/callback?code=abc")
+	assert.Equal(t, http.StatusBadRequest, status)
+}
+
+func TestMcpOAuthCb_NoCode(t *testing.T) {
+	ctx := t.Context()
+	lnPath := startServerBare(t, ctx)
+
+	status, _ := httpDoWithStatus(t, ctx, http.MethodPost, lnPath,
+		"/api/mcp-oauth/callback?state=some-state")
+	assert.Equal(t, http.StatusBadRequest, status)
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/docker/docker-agent/pkg/echolog"
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/tools/mcp"
 	"github.com/docker/docker-agent/pkg/upstream"
 )
 
@@ -89,6 +90,8 @@ func (s *Server) registerRoutes() {
 	group.POST("/sessions/batch/export", s.batchExportSessions)
 
 	group.GET("/agents/:id/:agent_name/tools/count", s.getAgentToolCount)
+
+	group.POST("/mcp-oauth/callback", s.mcpOAuthCallback)
 
 	group.GET("/ping", func(c echo.Context) error {
 		return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
@@ -403,6 +406,52 @@ func (s *Server) elicitation(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to resume elicitation: %v", err))
 	}
 
+	return c.JSON(http.StatusOK, nil)
+}
+
+// mcpOAuthCallback is the out-of-band entry point used by embedders
+// that receive an OAuth deeplink (e.g. a system-wide URL-scheme handler
+// or an OS-integrated launcher) and want to forward the resulting
+// {code, state} to docker-agent without going through the session-keyed
+// ResumeElicitation path.
+//
+// The state value is opaque, high-entropy and was generated in-process by
+// docker-agent's unmanaged OAuth flow (see GenerateState in
+// pkg/tools/mcp). Looking it up in the pending-oauth registry IS the
+// authentication: docker-agent only accepts callbacks for states it is
+// currently awaiting. An unknown state returns 404 (which is the
+// expected outcome for replays and any state value the agent did not
+// itself generate).
+//
+// The handler never blocks: it hands the callback to the buffered
+// channel of the waiting flow and returns immediately. The token
+// exchange and storage happen inside that flow's goroutine, which then
+// emits the existing authorization_event on the session SSE stream.
+func (s *Server) mcpOAuthCallback(c echo.Context) error {
+	q := c.QueryParams()
+	state := q.Get("state")
+	if state == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "missing state query parameter")
+	}
+	code := q.Get("code")
+	errStr := q.Get("error")
+	errDesc := q.Get("error_description")
+	if code == "" && errStr == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "missing both code and error query parameters")
+	}
+
+	err := mcp.DeliverPendingOAuthCallback(state, mcp.PendingOAuthCallback{
+		Code:    code,
+		Error:   errStr,
+		ErrDesc: errDesc,
+	})
+	if errors.Is(err, mcp.ErrPendingOAuthNoWaiter) {
+		return echo.NewHTTPError(http.StatusNotFound, "no pending OAuth flow for the given state")
+	}
+	if err != nil {
+		slog.WarnContext(c.Request().Context(), "Failed to deliver pending oauth callback", "error", err)
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to deliver pending oauth callback: %v", err))
+	}
 	return c.JSON(http.StatusOK, nil)
 }
 

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -665,6 +665,7 @@ func (sm *SessionManager) runtimeForSession(ctx context.Context, sess *session.S
 	opts := []runtime.Opt{
 		runtime.WithCurrentAgent(currentAgent),
 		runtime.WithManagedOAuth(false),
+		runtime.WithUnmanagedOAuthRedirectURI(rc.MCPOAuthRedirectURI),
 		runtime.WithSessionStore(sm.sessionStore),
 		runtime.WithTracer(otel.Tracer("cagent")),
 		runtime.WithModelSwitcherConfig(modelSwitcherCfg),

--- a/pkg/tools/builtin/mcpcatalog/mcpcatalog.go
+++ b/pkg/tools/builtin/mcpcatalog/mcpcatalog.go
@@ -84,11 +84,12 @@ type Toolset struct {
 	// OAuth-success refreshes, the managed-vs-unmanaged flag and
 	// tool-list change notifications behave identically to a YAML-
 	// declared `mcp.remote` toolset.
-	elicitationHandler  tools.ElicitationHandler
-	oauthSuccessHandler func()
-	toolsChangedHandler func()
-	managedOAuth        bool
-	managedOAuthSet     bool // distinguishes "default" from "explicitly false"
+	elicitationHandler        tools.ElicitationHandler
+	oauthSuccessHandler       func()
+	toolsChangedHandler       func()
+	managedOAuth              bool
+	managedOAuthSet           bool // distinguishes "default" from "explicitly false"
+	unmanagedOAuthRedirectURI string
 
 	// removeOAuthToken drops a persisted OAuth token by resource URL.
 	// Defaults to mcp.RemoveOAuthToken; tests inject a stub to avoid
@@ -222,6 +223,20 @@ func (t *Toolset) SetManagedOAuth(managed bool) {
 	for _, ts := range enabled {
 		if o, ok := tools.As[tools.OAuthCapable](ts); ok {
 			o.SetManagedOAuth(managed)
+		}
+	}
+}
+
+// SetUnmanagedOAuthRedirectURI forwards the unmanaged-OAuth redirect URI
+// to every enabled toolset; new toolsets pick it up at enable time.
+func (t *Toolset) SetUnmanagedOAuthRedirectURI(uri string) {
+	t.mu.Lock()
+	t.unmanagedOAuthRedirectURI = uri
+	enabled := t.snapshotEnabled()
+	t.mu.Unlock()
+	for _, ts := range enabled {
+		if o, ok := tools.As[tools.OAuthCapable](ts); ok {
+			o.SetUnmanagedOAuthRedirectURI(uri)
 		}
 	}
 }
@@ -562,6 +577,9 @@ func (t *Toolset) handleEnable(ctx context.Context, args EnableArgs) (*tools.Too
 	}
 	if t.managedOAuthSet {
 		mcpToolset.SetManagedOAuth(t.managedOAuth)
+	}
+	if t.unmanagedOAuthRedirectURI != "" {
+		mcpToolset.SetUnmanagedOAuthRedirectURI(t.unmanagedOAuthRedirectURI)
 	}
 
 	wrapped := tools.NewStartable(mcpToolset)

--- a/pkg/tools/capabilities.go
+++ b/pkg/tools/capabilities.go
@@ -57,6 +57,12 @@ type Sampleable interface {
 type OAuthCapable interface {
 	SetOAuthSuccessHandler(handler func())
 	SetManagedOAuth(managed bool)
+	// SetUnmanagedOAuthRedirectURI sets the `redirect_uri` that docker-agent
+	// advertises when running an MCP server OAuth flow in unmanaged mode.
+	// When non-empty, docker-agent drives PKCE + DCR + token exchange itself
+	// and expects the client to return {code, state} (in addition to the
+	// existing {access_token, …} reply shape). Ignored in managed mode.
+	SetUnmanagedOAuthRedirectURI(uri string)
 }
 
 // GetInstructions returns instructions if the toolset implements Instructable.
@@ -78,7 +84,7 @@ type ChangeNotifier interface {
 // It checks for Elicitable, Sampleable and OAuthCapable interfaces and
 // configures them. This is a convenience function that handles the capability
 // checking internally.
-func ConfigureHandlers(ts ToolSet, elicitHandler ElicitationHandler, samplingHandler SamplingHandler, oauthHandler func(), managedOAuth bool) {
+func ConfigureHandlers(ts ToolSet, elicitHandler ElicitationHandler, samplingHandler SamplingHandler, oauthHandler func(), managedOAuth bool, unmanagedOAuthRedirectURI string) {
 	if e, ok := As[Elicitable](ts); ok {
 		e.SetElicitationHandler(elicitHandler)
 	}
@@ -88,5 +94,6 @@ func ConfigureHandlers(ts ToolSet, elicitHandler ElicitationHandler, samplingHan
 	if o, ok := As[OAuthCapable](ts); ok {
 		o.SetOAuthSuccessHandler(oauthHandler)
 		o.SetManagedOAuth(managedOAuth)
+		o.SetUnmanagedOAuthRedirectURI(unmanagedOAuthRedirectURI)
 	}
 }

--- a/pkg/tools/mcp/cancellable_parent.go
+++ b/pkg/tools/mcp/cancellable_parent.go
@@ -1,0 +1,72 @@
+package mcp
+
+import "context"
+
+// cancellableParentCtxKey is the private context key under which
+// clientConnector.Connect stashes the caller's original ctx before
+// detaching it with context.WithoutCancel.
+//
+// We use a struct{} key (the standard Go idiom for ctx keys) so it's
+// not addressable from other packages and can't collide with anything
+// else.
+type cancellableParentCtxKey struct{}
+
+// withCancellableParent attaches `parent` to `ctx` so that downstream
+// code paths that explicitly opt in can observe the parent's
+// cancellation signal.
+//
+// Why this exists
+// ---------------
+//
+// clientConnector.Connect (see mcp.go) deliberately detaches its
+// caller's ctx with context.WithoutCancel before sending the MCP
+// initialize handshake. The rationale is correct: an MCP toolset's
+// session must outlive any single request -- otherwise, when the
+// inbound HTTP request that first caused toolset.Start to be invoked
+// finishes, the underlying SSE/stdio connection would tear down, and
+// subsequent agent requests would have to re-initialize from scratch.
+// Worse, an OAuth flow that succeeded would still die at the moment
+// its triggering request returned.
+//
+// But that detachment also severs a signal we actually do want to
+// observe in some operations: user-initiated cancellation. In
+// particular, the unmanaged OAuth flow (handleUnmanagedOAuthFlow)
+// blocks on a select waiting for either the user's elicitation reply
+// or an out-of-band callback. If the user aborts the in-progress
+// agent run via the host's Stop affordance, the streamCtx that the
+// SessionManager derived from the request ctx gets cancelled -- and
+// every ctx in the chain BELOW Connect's WithoutCancel boundary
+// stays alive. The OAuth select then blocks forever, the per-session
+// streaming lock is never released, and the next user message
+// returns 409 Conflict from RunSession.ErrSessionBusy.
+//
+// We resolve this without giving up the connection-longevity
+// invariant by stashing the caller's original ctx as a value on the
+// detached ctx. The detached ctx remains the primary driver of the
+// connection's lifetime (so the WithoutCancel rationale holds), and
+// any operation that wants to observe user-initiated cancellation
+// can opt in by calling cancellableParentFromContext and selecting
+// on its Done channel alongside the local ctx.
+//
+// Carrying ctx-as-value is unusual but appropriate here: the parent
+// is genuinely metadata about how the detached ctx was constructed,
+// not data that the request is operating on.
+func withCancellableParent(ctx, parent context.Context) context.Context {
+	if parent == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, cancellableParentCtxKey{}, parent)
+}
+
+// cancellableParentFromContext returns the parent ctx previously
+// attached via withCancellableParent, or nil if none is set.
+//
+// Callers should treat a nil return as "no user-cancellation signal
+// available on this code path" -- not as an error. The most common
+// reason for nil is that the operation is running outside an
+// MCP-toolset call site (e.g. unit tests, CLI invocations), in
+// which case there is no useful user-cancellation signal to observe.
+func cancellableParentFromContext(ctx context.Context) context.Context {
+	parent, _ := ctx.Value(cancellableParentCtxKey{}).(context.Context)
+	return parent
+}

--- a/pkg/tools/mcp/cancellable_parent_test.go
+++ b/pkg/tools/mcp/cancellable_parent_test.go
@@ -1,0 +1,65 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCancellableParent_RoundTrip(t *testing.T) {
+	parent, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	ctx := withCancellableParent(context.WithoutCancel(parent), parent)
+	got := cancellableParentFromContext(ctx)
+	assert.Same(t, parent, got)
+}
+
+func TestCancellableParent_AbsentReturnsNil(t *testing.T) {
+	got := cancellableParentFromContext(t.Context())
+	assert.Nil(t, got)
+}
+
+func TestCancellableParent_NilParentIsNoOp(t *testing.T) {
+	base := t.Context()
+	got := withCancellableParent(base, nil)
+	// No key attached, so cancellableParentFromContext returns nil --
+	// the helper is a no-op when handed a nil parent.
+	assert.Nil(t, cancellableParentFromContext(got))
+}
+
+// TestCancellableParent_DetachedCtxStaysIndependent verifies the
+// invariant the helper preserves: even though the parent is reachable
+// via the returned ctx as a value, the returned ctx itself does NOT
+// inherit the parent's cancellation. That's exactly what makes the
+// helper useful in clientConnector.Connect -- code that just calls
+// ctx.Done() sees the detached ctx, code that opts in by reading
+// cancellableParentFromContext can additionally observe the parent.
+func TestCancellableParent_DetachedCtxStaysIndependent(t *testing.T) {
+	parent, parentCancel := context.WithCancel(t.Context())
+	defer parentCancel()
+
+	detached := context.WithoutCancel(parent)
+	ctx := withCancellableParent(detached, parent)
+
+	parentCancel()
+
+	// Local ctx is unaffected by parent cancellation (because of
+	// WithoutCancel applied before withCancellableParent).
+	select {
+	case <-ctx.Done():
+		t.Fatal("detached ctx must not be cancelled when its parent-by-value is cancelled")
+	default:
+	}
+
+	// Parent reachable via value IS cancelled.
+	got := cancellableParentFromContext(ctx)
+	assert.NotNil(t, got)
+	select {
+	case <-got.Done():
+		// expected
+	default:
+		t.Fatal("parent ctx retrieved from value should be cancelled")
+	}
+}

--- a/pkg/tools/mcp/mcp.go
+++ b/pkg/tools/mcp/mcp.go
@@ -137,6 +137,7 @@ type mcpClient interface {
 	SetSamplingHandler(handler tools.SamplingHandler)
 	SetOAuthSuccessHandler(handler func())
 	SetManagedOAuth(managed bool)
+	SetUnmanagedOAuthRedirectURI(uri string)
 	SetToolListChangedHandler(handler func())
 	SetPromptListChangedHandler(handler func())
 	// Wait blocks until the underlying connection is closed by the server.
@@ -783,6 +784,10 @@ func (ts *Toolset) SetOAuthSuccessHandler(handler func()) {
 
 func (ts *Toolset) SetManagedOAuth(managed bool) {
 	ts.mcpClient.SetManagedOAuth(managed)
+}
+
+func (ts *Toolset) SetUnmanagedOAuthRedirectURI(uri string) {
+	ts.mcpClient.SetUnmanagedOAuthRedirectURI(uri)
 }
 
 func (ts *Toolset) SetToolsChangedHandler(handler func()) {

--- a/pkg/tools/mcp/mcp.go
+++ b/pkg/tools/mcp/mcp.go
@@ -455,7 +455,17 @@ func (c *clientConnector) Connect(ctx context.Context) (lifecycle.Session, error
 	// But if the connection's underlying context is tied to the first HTTP
 	// request, it gets cancelled when that request completes, killing the
 	// connection even though OAuth succeeded.
+	//
+	// The detachment is the right default for the *connection's* lifetime,
+	// but it also hides user-initiated cancellation from operations that
+	// run inside Connect and need to react to it -- most importantly, the
+	// OAuth flow's wait for an elicitation reply or out-of-band callback.
+	// We stash the caller's original ctx on the detached one (as a value)
+	// so handleUnmanagedOAuthFlow can opt into observing it; see
+	// cancellable_parent.go for the full rationale.
+	parentCtx := ctx
 	ctx = context.WithoutCancel(ctx)
+	ctx = withCancellableParent(ctx, parentCtx)
 
 	slog.DebugContext(ctx, "Starting MCP toolset", "server", ts.logID)
 

--- a/pkg/tools/mcp/mcp_test.go
+++ b/pkg/tools/mcp/mcp_test.go
@@ -48,6 +48,8 @@ func (m *mockMCPClient) SetOAuthSuccessHandler(func()) {}
 
 func (m *mockMCPClient) SetManagedOAuth(bool) {}
 
+func (m *mockMCPClient) SetUnmanagedOAuthRedirectURI(string) {}
+
 func (m *mockMCPClient) SetToolListChangedHandler(func()) {}
 
 func (m *mockMCPClient) SetPromptListChangedHandler(func()) {}

--- a/pkg/tools/mcp/oauth.go
+++ b/pkg/tools/mcp/oauth.go
@@ -1072,7 +1072,7 @@ func (t *oauthTransport) handleUnmanagedOAuthFlow(ctx context.Context, authServe
 			return fmt.Errorf("failed to send elicitation request: %w", er.err)
 		}
 		slog.DebugContext(ctx, "Received elicitation response from client", "action", er.result.Action)
-		if tools.ElicitationAction(er.result.Action) != tools.ElicitationActionAccept {
+		if er.result.Action != tools.ElicitationActionAccept {
 			return errors.New("OAuth flow declined or cancelled by client")
 		}
 		if er.result.Content == nil {

--- a/pkg/tools/mcp/oauth.go
+++ b/pkg/tools/mcp/oauth.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"cmp"
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -265,13 +266,14 @@ func callbackRedirectURLFrom(c *latest.RemoteOAuthConfig) string {
 type oauthTransport struct {
 	base http.RoundTripper
 	// TODO(rumpl): remove client reference, we need to find a better way to send elicitation requests
-	client          *remoteMCPClient
-	tokenStore      OAuthTokenStore
-	baseURL         string
-	managed         bool
-	oauthConfig     *latest.RemoteOAuthConfig
-	oauthHTTPClient *http.Client
-	oauthFlowMu     sync.Mutex
+	client                    *remoteMCPClient
+	tokenStore                OAuthTokenStore
+	baseURL                   string
+	managed                   bool
+	unmanagedOAuthRedirectURI string
+	oauthConfig               *latest.RemoteOAuthConfig
+	oauthHTTPClient           *http.Client
+	oauthFlowMu               sync.Mutex
 
 	// mu protects refreshFailedAt and lastErr* from concurrent access.
 	mu sync.Mutex
@@ -728,34 +730,9 @@ func (t *oauthTransport) handleManagedOAuthFlow(ctx context.Context, authServer,
 	redirectURI := callbackServer.resolveRedirectURI(callbackRedirectURLFrom(t.oauthConfig))
 	slog.DebugContext(ctx, "Using redirect URI", "uri", redirectURI)
 
-	var clientID string
-	var clientSecret string
-	var scopes []string
-
-	switch {
-	case t.oauthConfig != nil && t.oauthConfig.ClientID != "":
-		// Use explicit credentials from config
-		slog.DebugContext(ctx, "Using explicit OAuth credentials from config")
-		clientID = t.oauthConfig.ClientID
-		clientSecret = t.oauthConfig.ClientSecret
-		scopes = t.oauthConfig.Scopes
-	case authServerMetadata.RegistrationEndpoint != "":
-		slog.DebugContext(ctx, "Attempting dynamic client registration")
-		clientID, clientSecret, err = registerClient(
-			ctx,
-			t.oauthClient(),
-			authServerMetadata,
-			redirectURI,
-			nil,
-		)
-		if err != nil {
-			slog.DebugContext(ctx, "Dynamic registration failed", "error", err)
-			// TODO(rumpl): fall back to requesting client ID from user
-			return err
-		}
-	default:
-		// TODO(rumpl): fall back to requesting client ID from user
-		return errors.New("authorization server does not support dynamic client registration and no explicit OAuth credentials configured")
+	clientID, clientSecret, scopes, err := t.resolveClientCredentials(ctx, authServerMetadata, redirectURI)
+	if err != nil {
+		return err
 	}
 
 	state, err := GenerateState()
@@ -838,8 +815,73 @@ func (t *oauthTransport) handleManagedOAuthFlow(ctx context.Context, authServer,
 	return nil
 }
 
-// handleUnmanagedOAuthFlow performs the OAuth flow for remote/unmanaged scenarios
-// where the client handles the OAuth interaction instead of us
+// resolveClientCredentials picks the OAuth client_id (and optional secret +
+// scopes) used for both the authorize URL and the token exchange. Explicit
+// credentials from the per-toolset config take precedence; otherwise we
+// attempt RFC 7591 Dynamic Client Registration against the authorization
+// server. Returns an error if neither path is available.
+func (t *oauthTransport) resolveClientCredentials(ctx context.Context, authServerMetadata *AuthorizationServerMetadata, redirectURI string) (clientID, clientSecret string, scopes []string, err error) {
+	switch {
+	case t.oauthConfig != nil && t.oauthConfig.ClientID != "":
+		// Use explicit credentials from config
+		slog.DebugContext(ctx, "Using explicit OAuth credentials from config")
+		return t.oauthConfig.ClientID, t.oauthConfig.ClientSecret, t.oauthConfig.Scopes, nil
+	case authServerMetadata.RegistrationEndpoint != "":
+		slog.DebugContext(ctx, "Attempting dynamic client registration")
+		clientID, clientSecret, err = registerClient(
+			ctx,
+			t.oauthClient(),
+			authServerMetadata,
+			redirectURI,
+			nil,
+		)
+		if err != nil {
+			slog.DebugContext(ctx, "Dynamic registration failed", "error", err)
+			// TODO(rumpl): fall back to requesting client ID from user
+			return "", "", nil, err
+		}
+		return clientID, clientSecret, nil, nil
+	default:
+		// TODO(rumpl): fall back to requesting client ID from user
+		return "", "", nil, errors.New("authorization server does not support dynamic client registration and no explicit OAuth credentials configured")
+	}
+}
+
+// unmanagedRedirectURI returns the redirect_uri docker-agent should use when
+// driving the unmanaged OAuth flow itself. Per-toolset config takes
+// precedence (RemoteOAuthConfig.CallbackRedirectURL) over the runtime-wide
+// default (--mcp-oauth-redirect-uri).
+//
+// Returns the empty string when neither is set, in which case the unmanaged
+// flow falls back to the legacy client-driven behavior (client returns
+// {access_token, …} via ResumeElicitation).
+func (t *oauthTransport) unmanagedRedirectURI() string {
+	if t.oauthConfig != nil && t.oauthConfig.CallbackRedirectURL != "" {
+		return t.oauthConfig.CallbackRedirectURL
+	}
+	return t.unmanagedOAuthRedirectURI
+}
+
+// handleUnmanagedOAuthFlow runs the OAuth flow when the runtime is not
+// managing the browser/callback machinery itself. Two sub-behaviors:
+//
+//   - If a redirect URI is configured (either via per-toolset
+//     CallbackRedirectURL or the runtime-wide --mcp-oauth-redirect-uri),
+//     docker-agent drives the OAuth flow: generates state + PKCE, runs DCR
+//     if needed, builds the authorize URL, emits an elicitation carrying
+//     authorize_url + state, and expects the client to return {code, state}
+//     via ResumeElicitation. docker-agent then exchanges the code for the
+//     token. The client never touches the OAuth endpoints — it just opens
+//     the browser and forwards the deeplink payload back.
+//
+//   - Otherwise the client is expected to drive the OAuth flow end-to-end
+//     and return {access_token, refresh_token, …} via ResumeElicitation
+//     (the legacy contract).
+//
+// Both reply shapes are accepted by the elicitation-result handling below
+// regardless of which sub-behavior emitted the request, so a client that
+// receives an authorize_url but still wants to do the exchange itself is
+// free to return an access token.
 func (t *oauthTransport) handleUnmanagedOAuthFlow(ctx context.Context, authServer, wwwAuth string) error {
 	slog.DebugContext(ctx, "Starting unmanaged OAuth flow for server", "url", t.baseURL)
 
@@ -878,18 +920,66 @@ func (t *oauthTransport) handleUnmanagedOAuthFlow(ctx context.Context, authServe
 		return fmt.Errorf("failed to fetch authorization server metadata: %w", err)
 	}
 
-	slog.DebugContext(ctx, "Sending OAuth elicitation request to client")
+	// Decide which sub-behavior to run based on whether a redirect URI is
+	// configured. When set, docker-agent does the OAuth dance itself and
+	// emits authorize_url + state in the elicitation; otherwise it emits
+	// only metadata and waits for the client to return a ready token.
+	redirectURI := t.unmanagedRedirectURI()
+	driveFlow := redirectURI != ""
+
+	meta := map[string]any{
+		"cagent/type":          "oauth_flow",
+		"cagent/server_url":    t.baseURL,
+		"auth_server":          resourceMetadata.AuthorizationServers[0],
+		"auth_server_metadata": authServerMetadata,
+		"resource_metadata":    resourceMetadata,
+	}
+
+	// Variables populated only on the docker-agent-driven path; needed
+	// after the elicitation if the client returns {code, state}.
+	var (
+		clientID          string
+		clientSecret      string
+		scopes            []string
+		expectedState     string
+		pkceVerifier      string
+		resourceIndicator string
+	)
+
+	if driveFlow {
+		clientID, clientSecret, scopes, err = t.resolveClientCredentials(ctx, authServerMetadata, redirectURI)
+		if err != nil {
+			return err
+		}
+
+		expectedState, err = GenerateState()
+		if err != nil {
+			return fmt.Errorf("failed to generate state: %w", err)
+		}
+		pkceVerifier = GeneratePKCEVerifier()
+		resourceIndicator = cmp.Or(resourceMetadata.Resource, t.baseURL)
+
+		authURL := BuildAuthorizationURL(
+			authServerMetadata.AuthorizationEndpoint,
+			clientID,
+			redirectURI,
+			expectedState,
+			oauth2.S256ChallengeFromVerifier(pkceVerifier),
+			resourceIndicator,
+			scopes,
+		)
+		// Forward the values the client needs to open the browser and
+		// later correlate the deeplink callback back to this flow.
+		meta["cagent/authorize_url"] = authURL
+		meta["cagent/state"] = expectedState
+	}
+
+	slog.DebugContext(ctx, "Sending OAuth elicitation request to client", "drive_flow", driveFlow)
 
 	result, err := t.client.requestElicitation(ctx, &mcpsdk.ElicitParams{
 		Message:         "OAuth authorization required for " + t.baseURL,
 		RequestedSchema: nil,
-		Meta: map[string]any{
-			"cagent/type":          "oauth_flow",
-			"cagent/server_url":    t.baseURL,
-			"auth_server":          resourceMetadata.AuthorizationServers[0],
-			"auth_server_metadata": authServerMetadata,
-			"resource_metadata":    resourceMetadata,
-		},
+		Meta:            meta,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to send elicitation request: %w", err)
@@ -901,35 +991,37 @@ func (t *oauthTransport) handleUnmanagedOAuthFlow(ctx context.Context, authServe
 		return errors.New("OAuth flow declined or cancelled by client")
 	}
 	if result.Content == nil {
-		return errors.New("no token received from client")
+		return errors.New("no payload received from client")
 	}
 
-	tokenData := result.Content
-
-	token := &OAuthToken{}
-
-	if accessToken, ok := tokenData["access_token"].(string); ok {
-		token.AccessToken = accessToken
-	} else {
-		return errors.New("access_token missing or invalid in client response")
+	token, err := t.consumeUnmanagedElicitationReply(
+		ctx,
+		result.Content,
+		authServerMetadata,
+		resourceMetadata,
+		driveFlow,
+		expectedState,
+		pkceVerifier,
+		clientID,
+		clientSecret,
+		redirectURI,
+		resourceIndicator,
+	)
+	if err != nil {
+		return err
 	}
 
-	if tokenType, ok := tokenData["token_type"].(string); ok {
-		token.TokenType = tokenType
-	}
-
-	if expiresIn, ok := tokenData["expires_in"].(float64); ok {
-		token.ExpiresIn = int(expiresIn)
-		token.ExpiresAt = time.Now().Add(time.Duration(token.ExpiresIn) * time.Second)
+	if driveFlow {
+		// On the docker-agent-driven path we generated the credentials, so
+		// stamp them onto the token for silent refresh later.
+		token.ClientID = clientID
+		token.ClientSecret = clientSecret
+		token.RequestedScopes = scopes
+	} else if t.oauthConfig != nil {
+		token.RequestedScopes = t.oauthConfig.Scopes
 	}
 	token.AuthServer = resourceMetadata.AuthorizationServers[0]
 
-	if refreshToken, ok := tokenData["refresh_token"].(string); ok {
-		token.RefreshToken = refreshToken
-	}
-	if t.oauthConfig != nil {
-		token.RequestedScopes = t.oauthConfig.Scopes
-	}
 	if err := t.tokenStore.StoreToken(t.baseURL, token); err != nil {
 		return fmt.Errorf("failed to store token: %w", err)
 	}
@@ -937,6 +1029,76 @@ func (t *oauthTransport) handleUnmanagedOAuthFlow(ctx context.Context, authServe
 	// Notify the runtime that the OAuth flow was successful
 	t.client.oauthSuccess()
 
-	slog.DebugContext(ctx, "Managed OAuth flow completed successfully")
+	slog.DebugContext(ctx, "Unmanaged OAuth flow completed successfully")
 	return nil
+}
+
+// consumeUnmanagedElicitationReply turns the ResumeElicitation payload into
+// an OAuthToken. It accepts two shapes:
+//
+//   - {access_token, token_type?, expires_in?, refresh_token?, scope?}
+//     The client did the OAuth dance itself; we just record the token.
+//
+//   - {code, state}
+//     The client received the deeplink callback; docker-agent verifies the
+//     state, exchanges the code at the token endpoint, and returns the
+//     resulting token. Only valid on the docker-agent-driven path (we need
+//     the stored PKCE verifier + client credentials to make the exchange).
+//
+// If the client mixes shapes (e.g. supplies both access_token and code), the
+// access_token wins to preserve the legacy behavior.
+func (t *oauthTransport) consumeUnmanagedElicitationReply(
+	ctx context.Context,
+	content map[string]any,
+	authServerMetadata *AuthorizationServerMetadata,
+	resourceMetadata protectedResourceMetadata,
+	driveFlow bool,
+	expectedState, pkceVerifier, clientID, clientSecret, redirectURI, resourceIndicator string,
+) (*OAuthToken, error) {
+	if accessToken, ok := content["access_token"].(string); ok && accessToken != "" {
+		token := &OAuthToken{AccessToken: accessToken}
+		if tokenType, ok := content["token_type"].(string); ok {
+			token.TokenType = tokenType
+		}
+		if expiresIn, ok := content["expires_in"].(float64); ok {
+			token.ExpiresIn = int(expiresIn)
+			token.ExpiresAt = time.Now().Add(time.Duration(token.ExpiresIn) * time.Second)
+		}
+		if refreshToken, ok := content["refresh_token"].(string); ok {
+			token.RefreshToken = refreshToken
+		}
+		return token, nil
+	}
+
+	code, hasCode := content["code"].(string)
+	state, hasState := content["state"].(string)
+	if !hasCode || code == "" || !hasState || state == "" {
+		return nil, errors.New("elicitation reply must include either access_token or {code, state}")
+	}
+	if !driveFlow {
+		// We never sent an authorize_url; receiving {code, state} means the
+		// client is confused about which contract is in effect.
+		return nil, errors.New("received {code, state} in elicitation reply but no redirect URI was configured for unmanaged OAuth flow")
+	}
+	if subtle.ConstantTimeCompare([]byte(state), []byte(expectedState)) != 1 {
+		return nil, errors.New("state mismatch in elicitation reply")
+	}
+
+	slog.DebugContext(ctx, "Exchanging authorization code received from client")
+	token, err := exchangeCodeForToken(
+		ctx,
+		t.oauthClient(),
+		authServerMetadata.TokenEndpoint,
+		code,
+		pkceVerifier,
+		clientID,
+		clientSecret,
+		redirectURI,
+		resourceIndicator,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to exchange code for token: %w", err)
+	}
+	_ = resourceMetadata // captured for future audit logging; intentionally unused here
+	return token, nil
 }

--- a/pkg/tools/mcp/oauth.go
+++ b/pkg/tools/mcp/oauth.go
@@ -974,29 +974,83 @@ func (t *oauthTransport) handleUnmanagedOAuthFlow(ctx context.Context, authServe
 		meta["cagent/state"] = expectedState
 	}
 
+	// On the docker-agent-driven path, register a waiter for an
+	// out-of-band callback. This lets an embedder POST the deeplink
+	// payload to /api/mcp-oauth/callback without going through the
+	// client's ResumeElicitation path -- the bearer never enters the
+	// embedder UI. Both delivery paths (elicitation result, direct
+	// callback) race; the first to arrive wins and the other is
+	// cancelled.
+	var callbackCh chan PendingOAuthCallback
+	if driveFlow {
+		callbackCh = make(chan PendingOAuthCallback, 1)
+		if err := defaultPendingOAuth.register(expectedState, callbackCh); err != nil {
+			return fmt.Errorf("failed to register pending oauth callback: %w", err)
+		}
+		defer defaultPendingOAuth.unregister(expectedState)
+	}
+
 	slog.DebugContext(ctx, "Sending OAuth elicitation request to client", "drive_flow", driveFlow)
 
-	result, err := t.client.requestElicitation(ctx, &mcpsdk.ElicitParams{
-		Message:         "OAuth authorization required for " + t.baseURL,
-		RequestedSchema: nil,
-		Meta:            meta,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to send elicitation request: %w", err)
+	// Run the elicitation request in a goroutine so we can also wait on
+	// the direct-callback channel. The elicitation goroutine is scoped to
+	// `elicCtx` -- when the direct callback wins we cancel elicCtx to
+	// release the goroutine, but the surrounding ctx (used for the token
+	// exchange below) stays alive.
+	type elicResult struct {
+		result tools.ElicitationResult
+		err    error
 	}
+	elicCh := make(chan elicResult, 1)
+	elicCtx, elicCancel := context.WithCancel(ctx)
+	defer elicCancel()
+	go func() {
+		r, e := t.client.requestElicitation(elicCtx, &mcpsdk.ElicitParams{
+			Message:         "OAuth authorization required for " + t.baseURL,
+			RequestedSchema: nil,
+			Meta:            meta,
+		})
+		elicCh <- elicResult{r, e}
+	}()
 
-	slog.DebugContext(ctx, "Received elicitation response from client", "action", result.Action)
-
-	if result.Action != tools.ElicitationActionAccept {
-		return errors.New("OAuth flow declined or cancelled by client")
-	}
-	if result.Content == nil {
-		return errors.New("no payload received from client")
+	var content map[string]any
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case cb := <-callbackCh:
+		// Direct deeplink callback won. Release the in-flight
+		// elicitation goroutine; any UI the embedder showed for this
+		// flow will be brought up to date by the authorization_event
+		// emitted via oauthSuccess() below.
+		elicCancel()
+		if cb.Error != "" {
+			msg := cb.Error
+			if cb.ErrDesc != "" {
+				msg = cb.Error + ": " + cb.ErrDesc
+			}
+			return fmt.Errorf("OAuth flow declined by provider: %s", msg)
+		}
+		slog.DebugContext(ctx, "OAuth callback received via deeplink, exchanging code for token")
+		// Synthesize the {code, state} payload that
+		// consumeUnmanagedElicitationReply expects.
+		content = map[string]any{"code": cb.Code, "state": expectedState}
+	case er := <-elicCh:
+		if er.err != nil {
+			return fmt.Errorf("failed to send elicitation request: %w", er.err)
+		}
+		slog.DebugContext(ctx, "Received elicitation response from client", "action", er.result.Action)
+		if tools.ElicitationAction(er.result.Action) != tools.ElicitationActionAccept {
+			return errors.New("OAuth flow declined or cancelled by client")
+		}
+		if er.result.Content == nil {
+			return errors.New("no payload received from client")
+		}
+		content = er.result.Content
 	}
 
 	token, err := t.consumeUnmanagedElicitationReply(
 		ctx,
-		result.Content,
+		content,
 		authServerMetadata,
 		resourceMetadata,
 		driveFlow,

--- a/pkg/tools/mcp/oauth.go
+++ b/pkg/tools/mcp/oauth.go
@@ -1013,10 +1013,43 @@ func (t *oauthTransport) handleUnmanagedOAuthFlow(ctx context.Context, authServe
 		elicCh <- elicResult{r, e}
 	}()
 
+	// Observe the caller's original ctx for user-initiated cancellation.
+	//
+	// `ctx` here is the detached ctx that clientConnector.Connect set up
+	// via context.WithoutCancel, so that the MCP toolset's session can
+	// outlive any single request (see mcp.go for the longevity
+	// rationale). But the user-initiated cancellation signal -- the
+	// embedder's "Stop" affordance on an in-progress agent run --
+	// arrives via the ORIGINAL caller's ctx, which has been stashed as a
+	// value at the Connect boundary. Without observing it here, this
+	// select would block until the user clicks the elicitation dialog's
+	// Cancel button, even when the embedder has already given up on the
+	// turn; the per-session streaming lock at the SessionManager level
+	// would then stay held, and the next user message would return
+	// 409 Conflict / ErrSessionBusy.
+	//
+	// userCancelCh is the Done channel of the parent ctx, or a nil
+	// channel if no parent was attached (in which case the select case
+	// is silently never selected, preserving back-compat for callers
+	// that don't go through clientConnector.Connect, e.g. unit tests).
+	var userCancelCh <-chan struct{}
+	parentCtx := cancellableParentFromContext(ctx)
+	if parentCtx != nil {
+		userCancelCh = parentCtx.Done()
+	}
+
 	var content map[string]any
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
+	case <-userCancelCh:
+		// The host aborted the in-progress agent run. Return its ctx
+		// error so the agent loop sees a cancellable error (it
+		// propagates up through the MCP tool-call boundary, the
+		// runtime's iteration check then exits cleanly, and the
+		// per-session streaming lock is released by the SessionManager
+		// goroutine's deferred Unlock).
+		return parentCtx.Err()
 	case cb := <-callbackCh:
 		// Direct deeplink callback won. Release the in-flight
 		// elicitation goroutine; any UI the embedder showed for this

--- a/pkg/tools/mcp/oauth_test.go
+++ b/pkg/tools/mcp/oauth_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1236,4 +1237,329 @@ func TestGetAuthorizationServerMetadata_All404FallsBackToDefaults(t *testing.T) 
 	require.NoError(t, err)
 	assert.Equal(t, srv.URL+"/tenant/authorize", md.AuthorizationEndpoint,
 		"defaults must be derived from the issuer URL")
+}
+
+// --------- Unmanaged flow with docker-agent-driven OAuth ---------
+
+// unmanagedOAuthTestServer stands up an httptest.Server that emulates both
+// the MCP server (returns 401 + WWW-Authenticate) and the authorization
+// server (metadata + DCR + token endpoint) at known paths.
+type unmanagedOAuthTestServer struct {
+	*httptest.Server
+
+	tokenCalls atomic.Int32
+	lastForm   url.Values
+}
+
+func newUnmanagedOAuthTestServer(t *testing.T) *unmanagedOAuthTestServer {
+	t.Helper()
+	srv := &unmanagedOAuthTestServer{}
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/.well-known/oauth-protected-resource", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(protectedResourceMetadata{
+			Resource:             srv.URL,
+			AuthorizationServers: []string{srv.URL},
+		})
+	})
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(AuthorizationServerMetadata{
+			Issuer:                srv.URL,
+			AuthorizationEndpoint: srv.URL + "/authorize",
+			TokenEndpoint:         srv.URL + "/token",
+			RegistrationEndpoint:  srv.URL + "/register",
+		})
+	})
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+	mux.HandleFunc("/register", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"client_id":"registered-client-id","client_secret":"registered-secret"}`))
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		srv.tokenCalls.Add(1)
+		_ = r.ParseForm()
+		srv.lastForm = r.Form
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"exchanged-at","token_type":"Bearer","expires_in":3600,"refresh_token":"refresh-tok"}`))
+	})
+	// The MCP endpoint at "/" returns 401 until a Bearer header is present.
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.Header().Set("WWW-Authenticate", `Bearer resource="`+srv.URL+`/.well-known/oauth-protected-resource"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+
+	srv.Server = httptest.NewServer(mux)
+	return srv
+}
+
+// elicitCaptured records the elicitation request that the OAuth transport
+// sent and lets the test reply with a chosen payload, mirroring what a
+// real client (e.g. Docker Desktop) would do.
+type elicitCaptured struct {
+	mu      sync.Mutex
+	req     *gomcp.ElicitParams
+	reply   tools.ElicitationResult
+	replyFn func(req *gomcp.ElicitParams) tools.ElicitationResult
+}
+
+func (e *elicitCaptured) handler(_ context.Context, req *gomcp.ElicitParams) (tools.ElicitationResult, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.req = req
+	if e.replyFn != nil {
+		return e.replyFn(req), nil
+	}
+	return e.reply, nil
+}
+
+// newUnmanagedTestTransport builds an oauthTransport configured for the
+// unmanaged flow and wires the supplied elicitation handler.
+func newUnmanagedTestTransport(t *testing.T, baseURL, redirectURI string, capture *elicitCaptured) (*oauthTransport, *remoteMCPClient) {
+	t.Helper()
+	client := newRemoteClient(baseURL, "streamable", nil, NewInMemoryTokenStore(), nil, false)
+	client.unmanagedOAuthRedirectURI = redirectURI
+	client.SetElicitationHandler(capture.handler)
+	// Allow private-IP destinations so the httptest server's 127.0.0.1 URLs
+	// aren't blocked by the SSRF guard the production OAuth helper uses.
+	client.allowPrivateIPs = true
+	transport := &oauthTransport{
+		base:                      http.DefaultTransport,
+		client:                    client,
+		tokenStore:                client.tokenStore,
+		baseURL:                   baseURL,
+		managed:                   false,
+		unmanagedOAuthRedirectURI: redirectURI,
+		oauthHTTPClient:           oauthHTTPClientForAllowPrivateIPs(true),
+	}
+	return transport, client
+}
+
+// TestUnmanagedOAuthFlow_DriveFlow_ExchangesCodeForToken verifies the new
+// docker-agent-driven branch end-to-end: docker-agent emits the elicitation
+// with authorize_url + state, the client (test stub) replies with
+// {code, state}, and docker-agent exchanges the code at the token endpoint.
+func TestUnmanagedOAuthFlow_DriveFlow_ExchangesCodeForToken(t *testing.T) {
+	srv := newUnmanagedOAuthTestServer(t)
+	defer srv.Close()
+
+	const redirectURI = "https://example.test/oauth/cb"
+	capture := &elicitCaptured{}
+	capture.replyFn = func(req *gomcp.ElicitParams) tools.ElicitationResult {
+		// Echo the state docker-agent sent us, simulating a real OAuth
+		// callback round-trip.
+		state, _ := req.Meta["cagent/state"].(string)
+		return tools.ElicitationResult{
+			Action: tools.ElicitationActionAccept,
+			Content: map[string]any{
+				"code":  "abc",
+				"state": state,
+			},
+		}
+	}
+	transport, client := newUnmanagedTestTransport(t, srv.URL, redirectURI, capture)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL, strings.NewReader("{}"))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Verify the elicitation carried the new fields.
+	require.NotNil(t, capture.req)
+	assert.Equal(t, "oauth_flow", capture.req.Meta["cagent/type"])
+	assert.Equal(t, srv.URL, capture.req.Meta["cagent/server_url"])
+	authorizeURL, _ := capture.req.Meta["cagent/authorize_url"].(string)
+	assert.NotEmpty(t, authorizeURL, "drive-flow elicitation must include cagent/authorize_url")
+	assert.Contains(t, authorizeURL, "redirect_uri="+url.QueryEscape(redirectURI))
+	state, _ := capture.req.Meta["cagent/state"].(string)
+	assert.NotEmpty(t, state, "drive-flow elicitation must include cagent/state")
+
+	// Verify docker-agent exchanged the code (not the client).
+	require.Equal(t, int32(1), srv.tokenCalls.Load(), "token endpoint must be hit exactly once")
+	assert.Equal(t, "authorization_code", srv.lastForm.Get("grant_type"))
+	assert.Equal(t, "abc", srv.lastForm.Get("code"))
+	assert.Equal(t, redirectURI, srv.lastForm.Get("redirect_uri"),
+		"redirect_uri sent at /token must match the one used at /authorize per RFC 6749 §4.1.3")
+	assert.Equal(t, "registered-client-id", srv.lastForm.Get("client_id"))
+	assert.NotEmpty(t, srv.lastForm.Get("code_verifier"), "PKCE verifier must be sent at exchange")
+
+	// Verify the token landed in the store with the credentials stamped on
+	// (for silent refresh later).
+	tok, err := client.tokenStore.GetToken(srv.URL)
+	require.NoError(t, err)
+	require.NotNil(t, tok)
+	assert.Equal(t, "exchanged-at", tok.AccessToken)
+	assert.Equal(t, "refresh-tok", tok.RefreshToken)
+	assert.Equal(t, "registered-client-id", tok.ClientID)
+	assert.Equal(t, "registered-secret", tok.ClientSecret)
+	assert.Equal(t, srv.URL, tok.AuthServer)
+}
+
+// TestUnmanagedOAuthFlow_DriveFlow_RejectsStateMismatch verifies the CSRF
+// check: if the client returns a `state` value that doesn't match what
+// docker-agent generated and embedded in the authorize URL, the flow
+// aborts WITHOUT calling the token endpoint.
+func TestUnmanagedOAuthFlow_DriveFlow_RejectsStateMismatch(t *testing.T) {
+	srv := newUnmanagedOAuthTestServer(t)
+	defer srv.Close()
+
+	capture := &elicitCaptured{
+		reply: tools.ElicitationResult{
+			Action: tools.ElicitationActionAccept,
+			Content: map[string]any{
+				"code":  "abc",
+				"state": "i-made-this-up",
+			},
+		},
+	}
+	transport, _ := newUnmanagedTestTransport(t, srv.URL, "https://example.test/oauth/cb", capture)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL, strings.NewReader("{}"))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := transport.RoundTrip(req)
+	if resp != nil {
+		resp.Body.Close()
+	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "state mismatch")
+	assert.Equal(t, int32(0), srv.tokenCalls.Load(), "token endpoint must not be hit on state mismatch")
+}
+
+// TestUnmanagedOAuthFlow_DriveFlow_AcceptsLegacyAccessTokenReply verifies
+// that when docker-agent is driving the flow but the client decides to do
+// the exchange itself anyway (returning {access_token, …}), the legacy
+// reply shape is still honored — no error, token stored verbatim, no
+// /token request from docker-agent.
+func TestUnmanagedOAuthFlow_DriveFlow_AcceptsLegacyAccessTokenReply(t *testing.T) {
+	srv := newUnmanagedOAuthTestServer(t)
+	defer srv.Close()
+
+	capture := &elicitCaptured{
+		reply: tools.ElicitationResult{
+			Action: tools.ElicitationActionAccept,
+			Content: map[string]any{
+				"access_token":  "client-provided-at",
+				"token_type":    "Bearer",
+				"refresh_token": "client-provided-refresh",
+			},
+		},
+	}
+	transport, client := newUnmanagedTestTransport(t, srv.URL, "https://example.test/oauth/cb", capture)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL, strings.NewReader("{}"))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int32(0), srv.tokenCalls.Load(),
+		"docker-agent must not exchange when the client supplied a ready token")
+
+	tok, err := client.tokenStore.GetToken(srv.URL)
+	require.NoError(t, err)
+	assert.Equal(t, "client-provided-at", tok.AccessToken)
+	assert.Equal(t, "client-provided-refresh", tok.RefreshToken)
+}
+
+// TestUnmanagedOAuthFlow_LegacyMode_NoAuthorizeURLInElicitation verifies the
+// back-compat path: with no redirect URI configured, the elicitation does
+// NOT include authorize_url/state, the client returns an access token, and
+// docker-agent stores it directly.
+func TestUnmanagedOAuthFlow_LegacyMode_NoAuthorizeURLInElicitation(t *testing.T) {
+	srv := newUnmanagedOAuthTestServer(t)
+	defer srv.Close()
+
+	capture := &elicitCaptured{
+		reply: tools.ElicitationResult{
+			Action: tools.ElicitationActionAccept,
+			Content: map[string]any{
+				"access_token": "legacy-at",
+				"token_type":   "Bearer",
+			},
+		},
+	}
+	// Empty redirect URI → legacy client-driven mode.
+	transport, _ := newUnmanagedTestTransport(t, srv.URL, "", capture)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL, strings.NewReader("{}"))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	require.NotNil(t, capture.req)
+	_, hasAuthorizeURL := capture.req.Meta["cagent/authorize_url"]
+	assert.False(t, hasAuthorizeURL, "legacy unmanaged flow must not include cagent/authorize_url")
+	_, hasState := capture.req.Meta["cagent/state"]
+	assert.False(t, hasState, "legacy unmanaged flow must not include cagent/state")
+	// resource_metadata is still surfaced so the client can do its own DCR
+	// if desired.
+	assert.NotNil(t, capture.req.Meta["resource_metadata"])
+}
+
+// TestUnmanagedOAuthFlow_LegacyMode_RejectsCodeStateReply verifies that a
+// client which sends {code, state} despite docker-agent not emitting an
+// authorize_url is rejected — there is no stored PKCE verifier to exchange
+// the code with, so the flow cannot complete.
+func TestUnmanagedOAuthFlow_LegacyMode_RejectsCodeStateReply(t *testing.T) {
+	srv := newUnmanagedOAuthTestServer(t)
+	defer srv.Close()
+
+	capture := &elicitCaptured{
+		reply: tools.ElicitationResult{
+			Action: tools.ElicitationActionAccept,
+			Content: map[string]any{
+				"code":  "abc",
+				"state": "xyz",
+			},
+		},
+	}
+	transport, _ := newUnmanagedTestTransport(t, srv.URL, "", capture)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL, strings.NewReader("{}"))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := transport.RoundTrip(req)
+	if resp != nil {
+		resp.Body.Close()
+	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no redirect URI was configured")
+}
+
+// TestUnmanagedRedirectURI_PerToolsetTakesPrecedence verifies the precedence
+// order: per-toolset RemoteOAuthConfig.CallbackRedirectURL overrides the
+// runtime-wide --mcp-oauth-redirect-uri.
+func TestUnmanagedRedirectURI_PerToolsetTakesPrecedence(t *testing.T) {
+	transport := &oauthTransport{
+		unmanagedOAuthRedirectURI: "https://global.example/cb",
+		oauthConfig: &latest.RemoteOAuthConfig{
+			CallbackRedirectURL: "https://per-toolset.example/cb",
+		},
+	}
+	assert.Equal(t, "https://per-toolset.example/cb", transport.unmanagedRedirectURI())
+
+	transport.oauthConfig = nil
+	assert.Equal(t, "https://global.example/cb", transport.unmanagedRedirectURI())
+
+	transport.unmanagedOAuthRedirectURI = ""
+	assert.Empty(t, transport.unmanagedRedirectURI())
 }

--- a/pkg/tools/mcp/oauth_test.go
+++ b/pkg/tools/mcp/oauth_test.go
@@ -1300,9 +1300,9 @@ func newUnmanagedOAuthTestServer(t *testing.T) *unmanagedOAuthTestServer {
 	return srv
 }
 
-// elicitCaptured records the elicitation request that the OAuth transport
-// sent and lets the test reply with a chosen payload, mirroring what a
-// real client (e.g. Docker Desktop) would do.
+// elicitCaptured records the elicitation request that the OAuth
+// transport sent and lets the test reply with a chosen payload,
+// mirroring what a real client would do.
 type elicitCaptured struct {
 	mu      sync.Mutex
 	req     *gomcp.ElicitParams
@@ -1543,6 +1543,147 @@ func TestUnmanagedOAuthFlow_LegacyMode_RejectsCodeStateReply(t *testing.T) {
 	}
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no redirect URI was configured")
+}
+
+// TestUnmanagedOAuthFlow_DriveFlow_AcceptsDirectCallback verifies the new
+// out-of-band path: the elicitation never replies (the client is a thin
+// courier that opens the browser and forwards the deeplink via
+// /api/mcp-oauth/callback). docker-agent's pending-OAuth registry
+// delivers {code, state} directly into the waiting flow, which then
+// exchanges the code at the token endpoint as on the regular drive-flow.
+func TestUnmanagedOAuthFlow_DriveFlow_AcceptsDirectCallback(t *testing.T) {
+	srv := newUnmanagedOAuthTestServer(t)
+	defer srv.Close()
+
+	const redirectURI = "https://example.test/oauth/cb"
+	// Block the elicitation handler indefinitely (until the test
+	// goroutine closes the channel below). This simulates an embedder
+	// that never sends a `ResumeElicitation` -- the deeplink relay goes
+	// straight to /api/mcp-oauth/callback instead.
+	elicitationCanReturn := make(chan struct{})
+	defer close(elicitationCanReturn)
+	capture := &elicitCaptured{}
+	stateSent := make(chan string, 1)
+	capture.replyFn = func(req *gomcp.ElicitParams) tools.ElicitationResult {
+		state, _ := req.Meta["cagent/state"].(string)
+		stateSent <- state
+		<-elicitationCanReturn
+		// This return value should be unreachable because the direct
+		// callback wins first and cancels the elicitation context. The
+		// real-world client's elicitation request returns ctx.Err() in
+		// that case; we mirror that with a decline so a bug that would
+		// otherwise consume this reply path is obvious in tests.
+		return tools.ElicitationResult{Action: tools.ElicitationActionDecline}
+	}
+	transport, client := newUnmanagedTestTransport(t, srv.URL, redirectURI, capture)
+
+	// Run the OAuth flow on a separate goroutine; the main test goroutine
+	// will deliver the callback once the elicitation has been observed.
+	type roundTripResult struct {
+		resp *http.Response
+		err  error
+	}
+	rtCh := make(chan roundTripResult, 1)
+	go func() {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL, strings.NewReader("{}"))
+		if err != nil {
+			rtCh <- roundTripResult{nil, err}
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := transport.RoundTrip(req)
+		rtCh <- roundTripResult{resp, err}
+	}()
+
+	// Wait for the elicitation to be sent (so we know the registry has a
+	// waiter), then deliver the callback out of band.
+	var state string
+	select {
+	case state = <-stateSent:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for elicitation to be sent")
+	}
+	require.NotEmpty(t, state)
+	require.NoError(t, DeliverPendingOAuthCallback(state, PendingOAuthCallback{Code: "abc"}))
+
+	// The RoundTrip goroutine should now complete.
+	var rt roundTripResult
+	select {
+	case rt = <-rtCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for OAuth flow to complete after direct callback")
+	}
+	require.NoError(t, rt.err)
+	require.NotNil(t, rt.resp)
+	rt.resp.Body.Close()
+	assert.Equal(t, http.StatusOK, rt.resp.StatusCode)
+
+	// Verify the same token-endpoint contract as the regular drive-flow.
+	require.Equal(t, int32(1), srv.tokenCalls.Load(), "token endpoint must be hit exactly once")
+	assert.Equal(t, "abc", srv.lastForm.Get("code"))
+	assert.Equal(t, redirectURI, srv.lastForm.Get("redirect_uri"))
+	assert.NotEmpty(t, srv.lastForm.Get("code_verifier"))
+
+	tok, err := client.tokenStore.GetToken(srv.URL)
+	require.NoError(t, err)
+	require.NotNil(t, tok)
+	assert.Equal(t, "exchanged-at", tok.AccessToken)
+}
+
+// TestUnmanagedOAuthFlow_DriveFlow_DirectCallbackError relays an OAuth
+// error (e.g. user denied consent) via the direct-callback path. The
+// flow must abort cleanly without hitting the token endpoint.
+func TestUnmanagedOAuthFlow_DriveFlow_DirectCallbackError(t *testing.T) {
+	srv := newUnmanagedOAuthTestServer(t)
+	defer srv.Close()
+
+	const redirectURI = "https://example.test/oauth/cb"
+	elicitationCanReturn := make(chan struct{})
+	defer close(elicitationCanReturn)
+	capture := &elicitCaptured{}
+	stateSent := make(chan string, 1)
+	capture.replyFn = func(req *gomcp.ElicitParams) tools.ElicitationResult {
+		state, _ := req.Meta["cagent/state"].(string)
+		stateSent <- state
+		<-elicitationCanReturn
+		return tools.ElicitationResult{Action: tools.ElicitationActionDecline}
+	}
+	transport, _ := newUnmanagedTestTransport(t, srv.URL, redirectURI, capture)
+
+	rtErrCh := make(chan error, 1)
+	go func() {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL, strings.NewReader("{}"))
+		if err != nil {
+			rtErrCh <- err
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+		_, err = transport.RoundTrip(req)
+		rtErrCh <- err
+	}()
+
+	var state string
+	select {
+	case state = <-stateSent:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for elicitation to be sent")
+	}
+	require.NoError(t, DeliverPendingOAuthCallback(state, PendingOAuthCallback{
+		Error:   "access_denied",
+		ErrDesc: "user declined",
+	}))
+
+	var rtErr error
+	select {
+	case rtErr = <-rtErrCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for OAuth flow to abort after direct callback error")
+	}
+	require.Error(t, rtErr)
+	assert.Contains(t, rtErr.Error(), "access_denied")
+	assert.Contains(t, rtErr.Error(), "user declined")
+	assert.Equal(t, int32(0), srv.tokenCalls.Load(),
+		"token endpoint must NOT be hit when the callback carries an error")
 }
 
 // TestUnmanagedRedirectURI_PerToolsetTakesPrecedence verifies the precedence

--- a/pkg/tools/mcp/oauth_test.go
+++ b/pkg/tools/mcp/oauth_test.go
@@ -1686,6 +1686,76 @@ func TestUnmanagedOAuthFlow_DriveFlow_DirectCallbackError(t *testing.T) {
 		"token endpoint must NOT be hit when the callback carries an error")
 }
 
+// TestUnmanagedOAuthFlow_DriveFlow_AbortsOnParentCtxCancellation verifies
+// that user-initiated cancellation of the in-progress agent run
+// propagates through the OAuth select even though the local ctx has been
+// detached from its parent by clientConnector.Connect's
+// context.WithoutCancel.
+//
+// The select watches two cancellation signals: the local (detached) ctx
+// and the parent ctx attached via withCancellableParent. Only the
+// second one is expected to fire on user-initiated cancellation; this
+// test asserts it does, and that the OAuth flow returns the parent's
+// ctx error so the agent loop can complete cleanly and the
+// per-session streaming lock can be released.
+func TestUnmanagedOAuthFlow_DriveFlow_AbortsOnParentCtxCancellation(t *testing.T) {
+	srv := newUnmanagedOAuthTestServer(t)
+	defer srv.Close()
+
+	const redirectURI = "https://example.test/oauth/cb"
+	elicitationCanReturn := make(chan struct{})
+	defer close(elicitationCanReturn)
+	capture := &elicitCaptured{}
+	elicitationSent := make(chan struct{}, 1)
+	capture.replyFn = func(req *gomcp.ElicitParams) tools.ElicitationResult {
+		elicitationSent <- struct{}{}
+		<-elicitationCanReturn
+		return tools.ElicitationResult{Action: tools.ElicitationActionDecline}
+	}
+	transport, _ := newUnmanagedTestTransport(t, srv.URL, redirectURI, capture)
+
+	// Mirror what clientConnector.Connect sets up: a cancellable parent
+	// ctx, then a detached ctx that carries the parent as a value.
+	parentCtx, parentCancel := context.WithCancel(t.Context())
+	defer parentCancel()
+	requestCtx := withCancellableParent(context.WithoutCancel(parentCtx), parentCtx)
+
+	rtErrCh := make(chan error, 1)
+	go func() {
+		req, err := http.NewRequestWithContext(requestCtx, http.MethodPost, srv.URL, strings.NewReader("{}"))
+		if err != nil {
+			rtErrCh <- err
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+		_, err = transport.RoundTrip(req)
+		rtErrCh <- err
+	}()
+
+	// Wait for the OAuth flow to enter its blocking select (i.e. the
+	// elicitation has been sent and the goroutine is waiting on a
+	// reply). Cancel the parent ctx; the local ctx remains live, so
+	// without the user-cancel branch in the select, this would hang.
+	select {
+	case <-elicitationSent:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for elicitation to be sent")
+	}
+	parentCancel()
+
+	var rtErr error
+	select {
+	case rtErr = <-rtErrCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("OAuth flow did not abort after parent ctx cancellation")
+	}
+	require.Error(t, rtErr)
+	require.ErrorIs(t, rtErr, context.Canceled,
+		"OAuth flow must return the parent's ctx error so the agent loop sees a cancellable error")
+	assert.Equal(t, int32(0), srv.tokenCalls.Load(),
+		"token endpoint must NOT be hit when the parent ctx is cancelled before any callback")
+}
+
 // TestUnmanagedRedirectURI_PerToolsetTakesPrecedence verifies the precedence
 // order: per-toolset RemoteOAuthConfig.CallbackRedirectURL overrides the
 // runtime-wide --mcp-oauth-redirect-uri.

--- a/pkg/tools/mcp/oauth_test.go
+++ b/pkg/tools/mcp/oauth_test.go
@@ -1592,6 +1592,9 @@ func TestUnmanagedOAuthFlow_DriveFlow_AcceptsDirectCallback(t *testing.T) {
 		}
 		req.Header.Set("Content-Type", "application/json")
 		resp, err := transport.RoundTrip(req)
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
 		rtCh <- roundTripResult{resp, err}
 	}()
 
@@ -1615,7 +1618,6 @@ func TestUnmanagedOAuthFlow_DriveFlow_AcceptsDirectCallback(t *testing.T) {
 	}
 	require.NoError(t, rt.err)
 	require.NotNil(t, rt.resp)
-	rt.resp.Body.Close()
 	assert.Equal(t, http.StatusOK, rt.resp.StatusCode)
 
 	// Verify the same token-endpoint contract as the regular drive-flow.
@@ -1658,7 +1660,10 @@ func TestUnmanagedOAuthFlow_DriveFlow_DirectCallbackError(t *testing.T) {
 			return
 		}
 		req.Header.Set("Content-Type", "application/json")
-		_, err = transport.RoundTrip(req)
+		resp, err := transport.RoundTrip(req)
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
 		rtErrCh <- err
 	}()
 
@@ -1728,7 +1733,10 @@ func TestUnmanagedOAuthFlow_DriveFlow_AbortsOnParentCtxCancellation(t *testing.T
 			return
 		}
 		req.Header.Set("Content-Type", "application/json")
-		_, err = transport.RoundTrip(req)
+		resp, err := transport.RoundTrip(req)
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
 		rtErrCh <- err
 	}()
 

--- a/pkg/tools/mcp/pending_oauth.go
+++ b/pkg/tools/mcp/pending_oauth.go
@@ -33,10 +33,10 @@ type pendingOAuthRegistry struct {
 }
 
 var (
-	errEmptyState       = errors.New("pending oauth: empty state")
-	errStateRegistered  = errors.New("pending oauth: state already registered")
-	errNoWaiter         = errors.New("pending oauth: no waiter for state")
-	errChannelFull      = errors.New("pending oauth: callback channel is full")
+	errEmptyState      = errors.New("pending oauth: empty state")
+	errStateRegistered = errors.New("pending oauth: state already registered")
+	errNoWaiter        = errors.New("pending oauth: no waiter for state")
+	errChannelFull     = errors.New("pending oauth: callback channel is full")
 )
 
 func (p *pendingOAuthRegistry) register(state string, ch chan<- PendingOAuthCallback) error {

--- a/pkg/tools/mcp/pending_oauth.go
+++ b/pkg/tools/mcp/pending_oauth.go
@@ -1,0 +1,104 @@
+package mcp
+
+import (
+	"errors"
+	"sync"
+)
+
+// PendingOAuthCallback is the payload delivered out-of-band to a
+// pending unmanaged OAuth flow, by an embedder that received the
+// deeplink callback (e.g. a system-wide URL-scheme handler or an
+// OS-integrated launcher) and POSTs the payload to docker-agent's
+// /api/mcp-oauth/callback route.
+//
+// Exactly one of Code (success) or Error (failure) is set.
+type PendingOAuthCallback struct {
+	Code    string
+	Error   string
+	ErrDesc string
+}
+
+// pendingOAuthRegistry is a process-wide map: OAuth state -> channel into
+// which the deeplink-handler HTTP route delivers the callback. The
+// channel is buffered so Deliver never blocks; entries are one-shot
+// (Deliver removes them on the way through).
+//
+// State values are opaque, high-entropy (>=128 bits) strings generated
+// by GenerateState. Looking them up in this registry IS the
+// authentication: docker-agent only accepts callbacks for state values
+// that are currently being awaited. An unknown state -> 404.
+type pendingOAuthRegistry struct {
+	mu      sync.Mutex
+	waiters map[string]chan<- PendingOAuthCallback
+}
+
+var (
+	errEmptyState       = errors.New("pending oauth: empty state")
+	errStateRegistered  = errors.New("pending oauth: state already registered")
+	errNoWaiter         = errors.New("pending oauth: no waiter for state")
+	errChannelFull      = errors.New("pending oauth: callback channel is full")
+)
+
+func (p *pendingOAuthRegistry) register(state string, ch chan<- PendingOAuthCallback) error {
+	if state == "" {
+		return errEmptyState
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if _, exists := p.waiters[state]; exists {
+		return errStateRegistered
+	}
+	p.waiters[state] = ch
+	return nil
+}
+
+func (p *pendingOAuthRegistry) unregister(state string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.waiters, state)
+}
+
+// deliver hands cb to the waiter registered for state and removes the
+// entry. Returns errNoWaiter if no flow is waiting on this state.
+func (p *pendingOAuthRegistry) deliver(state string, cb PendingOAuthCallback) error {
+	p.mu.Lock()
+	ch, ok := p.waiters[state]
+	if ok {
+		delete(p.waiters, state)
+	}
+	p.mu.Unlock()
+	if !ok {
+		return errNoWaiter
+	}
+	// Channel is buffered (size 1) by the caller, so this should never
+	// block; using a non-blocking send is purely defensive.
+	select {
+	case ch <- cb:
+		return nil
+	default:
+		return errChannelFull
+	}
+}
+
+var defaultPendingOAuth = &pendingOAuthRegistry{
+	waiters: map[string]chan<- PendingOAuthCallback{},
+}
+
+// DeliverPendingOAuthCallback hands a deeplink-relayed callback to the
+// in-process unmanaged-OAuth flow that's currently waiting on `state`.
+//
+// Returns nil on success. ErrPendingOAuthNoWaiter signals that no flow
+// is currently awaiting this state -- which is the expected behavior
+// for replays, stale callbacks, and any state value the agent did not
+// itself generate, and which the HTTP route surfaces as 404. Any other
+// error is internal.
+//
+// Exposed for the embedder's HTTP handler at POST /api/mcp-oauth/callback.
+func DeliverPendingOAuthCallback(state string, cb PendingOAuthCallback) error {
+	return defaultPendingOAuth.deliver(state, cb)
+}
+
+// ErrPendingOAuthNoWaiter is returned by DeliverPendingOAuthCallback
+// when no flow is currently awaiting the given state. The HTTP handler
+// surfaces this as 404.
+var ErrPendingOAuthNoWaiter = errNoWaiter

--- a/pkg/tools/mcp/pending_oauth_test.go
+++ b/pkg/tools/mcp/pending_oauth_test.go
@@ -1,7 +1,6 @@
 package mcp
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,14 +27,14 @@ func TestPendingOAuthRegistry_DeliverUnknownState(t *testing.T) {
 	r := newTestRegistry()
 	err := r.deliver("state-nope", PendingOAuthCallback{Code: "abc"})
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, errNoWaiter))
+	assert.ErrorIs(t, err, errNoWaiter)
 }
 
 func TestPendingOAuthRegistry_RegisterEmptyState(t *testing.T) {
 	r := newTestRegistry()
 	err := r.register("", make(chan PendingOAuthCallback, 1))
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, errEmptyState))
+	assert.ErrorIs(t, err, errEmptyState)
 }
 
 func TestPendingOAuthRegistry_RegisterDuplicate(t *testing.T) {
@@ -43,7 +42,7 @@ func TestPendingOAuthRegistry_RegisterDuplicate(t *testing.T) {
 	require.NoError(t, r.register("state-1", make(chan PendingOAuthCallback, 1)))
 	err := r.register("state-1", make(chan PendingOAuthCallback, 1))
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, errStateRegistered))
+	assert.ErrorIs(t, err, errStateRegistered)
 }
 
 func TestPendingOAuthRegistry_DeliverIsOneShot(t *testing.T) {
@@ -55,7 +54,7 @@ func TestPendingOAuthRegistry_DeliverIsOneShot(t *testing.T) {
 	// Second deliver returns errNoWaiter because the entry was consumed.
 	err := r.deliver("state-1", PendingOAuthCallback{Code: "second"})
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, errNoWaiter))
+	assert.ErrorIs(t, err, errNoWaiter)
 }
 
 func TestPendingOAuthRegistry_UnregisterRemovesEntry(t *testing.T) {
@@ -64,5 +63,5 @@ func TestPendingOAuthRegistry_UnregisterRemovesEntry(t *testing.T) {
 	r.unregister("state-1")
 	err := r.deliver("state-1", PendingOAuthCallback{Code: "abc"})
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, errNoWaiter))
+	assert.ErrorIs(t, err, errNoWaiter)
 }

--- a/pkg/tools/mcp/pending_oauth_test.go
+++ b/pkg/tools/mcp/pending_oauth_test.go
@@ -1,0 +1,68 @@
+package mcp
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestRegistry() *pendingOAuthRegistry {
+	return &pendingOAuthRegistry{waiters: map[string]chan<- PendingOAuthCallback{}}
+}
+
+func TestPendingOAuthRegistry_RegisterAndDeliver(t *testing.T) {
+	r := newTestRegistry()
+	ch := make(chan PendingOAuthCallback, 1)
+
+	require.NoError(t, r.register("state-1", ch))
+
+	require.NoError(t, r.deliver("state-1", PendingOAuthCallback{Code: "abc"}))
+
+	got := <-ch
+	assert.Equal(t, "abc", got.Code)
+}
+
+func TestPendingOAuthRegistry_DeliverUnknownState(t *testing.T) {
+	r := newTestRegistry()
+	err := r.deliver("state-nope", PendingOAuthCallback{Code: "abc"})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errNoWaiter))
+}
+
+func TestPendingOAuthRegistry_RegisterEmptyState(t *testing.T) {
+	r := newTestRegistry()
+	err := r.register("", make(chan PendingOAuthCallback, 1))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errEmptyState))
+}
+
+func TestPendingOAuthRegistry_RegisterDuplicate(t *testing.T) {
+	r := newTestRegistry()
+	require.NoError(t, r.register("state-1", make(chan PendingOAuthCallback, 1)))
+	err := r.register("state-1", make(chan PendingOAuthCallback, 1))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errStateRegistered))
+}
+
+func TestPendingOAuthRegistry_DeliverIsOneShot(t *testing.T) {
+	r := newTestRegistry()
+	ch := make(chan PendingOAuthCallback, 1)
+	require.NoError(t, r.register("state-1", ch))
+
+	require.NoError(t, r.deliver("state-1", PendingOAuthCallback{Code: "first"}))
+	// Second deliver returns errNoWaiter because the entry was consumed.
+	err := r.deliver("state-1", PendingOAuthCallback{Code: "second"})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errNoWaiter))
+}
+
+func TestPendingOAuthRegistry_UnregisterRemovesEntry(t *testing.T) {
+	r := newTestRegistry()
+	require.NoError(t, r.register("state-1", make(chan PendingOAuthCallback, 1)))
+	r.unregister("state-1")
+	err := r.deliver("state-1", PendingOAuthCallback{Code: "abc"})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errNoWaiter))
+}

--- a/pkg/tools/mcp/reconnect_test.go
+++ b/pkg/tools/mcp/reconnect_test.go
@@ -71,6 +71,7 @@ func (m *failingInitClient) SetElicitationHandler(tools.ElicitationHandler) {}
 func (m *failingInitClient) SetSamplingHandler(tools.SamplingHandler)       {}
 func (m *failingInitClient) SetOAuthSuccessHandler(func())                  {}
 func (m *failingInitClient) SetManagedOAuth(bool)                           {}
+func (m *failingInitClient) SetUnmanagedOAuthRedirectURI(string)            {}
 func (m *failingInitClient) SetToolListChangedHandler(func())               {}
 func (m *failingInitClient) SetPromptListChangedHandler(func())             {}
 

--- a/pkg/tools/mcp/remote.go
+++ b/pkg/tools/mcp/remote.go
@@ -15,13 +15,14 @@ import (
 type remoteMCPClient struct {
 	sessionClient
 
-	url             string
-	transportType   string
-	headers         map[string]string
-	tokenStore      OAuthTokenStore
-	managed         bool
-	oauthConfig     *latest.RemoteOAuthConfig
-	allowPrivateIPs bool
+	url                       string
+	transportType             string
+	headers                   map[string]string
+	tokenStore                OAuthTokenStore
+	managed                   bool
+	unmanagedOAuthRedirectURI string
+	oauthConfig               *latest.RemoteOAuthConfig
+	allowPrivateIPs           bool
 }
 
 func newRemoteClient(
@@ -139,6 +140,15 @@ func (c *remoteMCPClient) SetManagedOAuth(managed bool) {
 	c.mu.Unlock()
 }
 
+// SetUnmanagedOAuthRedirectURI sets the redirect URI docker-agent advertises
+// when running the OAuth flow in unmanaged mode. See OAuthCapable for full
+// semantics.
+func (c *remoteMCPClient) SetUnmanagedOAuthRedirectURI(uri string) {
+	c.mu.Lock()
+	c.unmanagedOAuthRedirectURI = uri
+	c.mu.Unlock()
+}
+
 // createHTTPClient creates an HTTP client with custom headers and OAuth support.
 // Header values may contain ${headers.NAME} placeholders that are resolved
 // at request time from upstream headers stored in the request context.
@@ -151,13 +161,14 @@ func (c *remoteMCPClient) createHTTPClient() (*http.Client, *oauthTransport) {
 
 	// Then wrap with OAuth support
 	oauthT := &oauthTransport{
-		base:            base,
-		client:          c,
-		tokenStore:      c.tokenStore,
-		baseURL:         c.url,
-		managed:         c.managed,
-		oauthConfig:     c.oauthConfig,
-		oauthHTTPClient: oauthHTTPClientForAllowPrivateIPs(c.allowPrivateIPs),
+		base:                      base,
+		client:                    c,
+		tokenStore:                c.tokenStore,
+		baseURL:                   c.url,
+		managed:                   c.managed,
+		unmanagedOAuthRedirectURI: c.unmanagedOAuthRedirectURI,
+		oauthConfig:               c.oauthConfig,
+		oauthHTTPClient:           oauthHTTPClientForAllowPrivateIPs(c.allowPrivateIPs),
 	}
 
 	return &http.Client{Transport: oauthT}, oauthT

--- a/pkg/tools/mcp/session_client.go
+++ b/pkg/tools/mcp/session_client.go
@@ -235,3 +235,9 @@ func (c *sessionClient) oauthSuccess() {
 // SetManagedOAuth is a no-op at the session level. The remoteMCPClient
 // overrides this to store the managed flag for its OAuth transport.
 func (c *sessionClient) SetManagedOAuth(bool) {}
+
+// SetUnmanagedOAuthRedirectURI is a no-op at the session level. The
+// remoteMCPClient overrides this to store the URI for its OAuth transport.
+// Stdio MCP clients never run OAuth (they have no HTTP transport to
+// authenticate), so the URI is ignored there too.
+func (c *sessionClient) SetUnmanagedOAuthRedirectURI(string) {}


### PR DESCRIPTION
## Depends on

This PR is stacked on top of #2896 (`extend-unmanaged-oauth-flow`). The two predecessor commits (`c97124d0f`, `a93ae4d3c`) shown in the diff belong to #2896; review only the last commit in this PR. Will be rebased onto a clean main after #2896 (or its replacement) merges.

## Problem

`clientConnector.Connect` detaches the caller's `ctx` with `context.WithoutCancel` before sending the MCP `initialize` handshake. The rationale is correct: an MCP toolset's session must outlive any single request — otherwise the underlying SSE/stdio connection tears down when the request that triggered `toolset.Start` returns, and a successful OAuth flow gets killed the moment its triggering request completes.

But that detachment also severs **user-initiated cancellation**, which the OAuth flow inside `Connect` DOES need to observe. Concretely:

`handleUnmanagedOAuthFlow` blocks on a select waiting for an elicitation reply or an out-of-band callback. If the embedder aborts the in-progress agent run while the user is in the OAuth dialog, the `streamCtx` the `SessionManager` derived from the request `ctx` gets cancelled — but every ctx in the chain BELOW `Connect`'s `WithoutCancel` boundary stays alive. The OAuth select then blocks forever, the per-session streaming lock is never released, and the next user message returns 409 Conflict from `RunSession.ErrSessionBusy`.

## Fix

Preserve the connection-longevity invariant **and** restore user-initiated cancellation by stashing the caller's original ctx as a value on the detached ctx. The detached ctx remains the primary driver of the connection's lifetime; operations that want to observe user-initiated cancellation can opt in by reading the parent back out and selecting on its `Done` channel alongside the local ctx.

Carrying ctx-as-value is unusual but appropriate here: the parent is **metadata about how the detached ctx was constructed**, not data the request is operating on. The helpers (`withCancellableParent` / `cancellableParentFromContext`) live next to the connector that creates the relationship so the rationale stays close to the code.

`handleUnmanagedOAuthFlow` now extends its select with a `userCancelCh` case keyed on the parent's `Done` channel. When the parent is nil (e.g. unit tests, CLI invocations that don't go through `clientConnector.Connect`), `userCancelCh` stays nil and the select silently never picks it — preserving back-compat.

## Plumbing

- `pkg/tools/mcp/cancellable_parent.go` — new helper file with `withCancellableParent` + `cancellableParentFromContext`, extensively commented because ctx-as-value is unusual.
- `pkg/tools/mcp/mcp.go` — `clientConnector.Connect` captures the caller's ctx before `WithoutCancel` and attaches it via `withCancellableParent`.
- `pkg/tools/mcp/oauth.go` — `handleUnmanagedOAuthFlow` extracts the parent and adds a fourth select case watching its `Done` channel; returns `parent.Err()` so the agent loop sees a cancellable error and the `SessionManager` goroutine's deferred `Unlock` fires.

## Tests

- `cancellable_parent_test.go` — round-trip, absent-returns-nil, nil-parent-no-op, and the key invariant that the local ctx stays independent of the parent's cancellation (only opt-in callers see it).
- `oauth_test.go` — `TestUnmanagedOAuthFlow_DriveFlow_AbortsOnParentCtxCancellation` asserts the new branch fires under the exact boundary `clientConnector.Connect` sets up, returns the parent's ctx error, and skips the token exchange.