### PR TITLE
feat: add --sidebar flag to control sidebar visibility

### DIFF
--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -65,6 +65,7 @@ type runExecFlags struct {
 	hideToolResults  bool
 	lean             bool
 	appName          string
+	sidebar          bool
 	listenAddr       string
 	onEventSpecs     []string
 	disabledCommands []string
@@ -142,6 +143,7 @@ func addRunOrExecFlags(cmd *cobra.Command, flags *runExecFlags) {
 	cmd.PersistentFlags().BoolVar(&flags.lean, "lean", false, "Use a simplified TUI with minimal chrome")
 	cmd.PersistentFlags().StringVar(&flags.appName, "app-name", "", "Application name shown in the TUI in place of \"docker agent\"")
 	cmd.PersistentFlags().StringSliceVar(&flags.disabledCommands, "disable-commands", nil, "Comma-separated list of slash commands to hide and disable in the TUI (e.g. /cost,/eval,/model)")
+	cmd.PersistentFlags().BoolVar(&flags.sidebar, "sidebar", true, "Show the sidebar in the TUI (set --sidebar=false to hide it)")
 	cmd.PersistentFlags().BoolVar(&flags.sandbox, "sandbox", false, "Run the agent inside a Docker sandbox (requires Docker Desktop with sandbox support)")
 	cmd.PersistentFlags().StringVar(&flags.sandboxTemplate, "template", "docker/sandbox-templates:docker-agent", "Template image for the sandbox (passed to docker sandbox create -t)")
 	cmd.PersistentFlags().BoolVar(&flags.sbx, "sbx", true, "Prefer the sbx CLI backend when available (set --sbx=false to force docker sandbox)")
@@ -507,6 +509,9 @@ func (f *runExecFlags) tuiOpts() []tui.Option {
 	}
 	if len(f.disabledCommands) > 0 {
 		opts = append(opts, tui.WithDisabledCommands(f.disabledCommands))
+	}
+	if !f.sidebar {
+		opts = append(opts, tui.WithHideSidebar())
 	}
 	return opts
 }

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -136,8 +136,9 @@ type chatPage struct {
 	sessionState *service.SessionState
 
 	// State
-	working  bool
-	leanMode bool
+	working     bool
+	leanMode    bool
+	hideSidebar bool
 
 	msgCancel       context.CancelFunc
 	streamCancelled bool
@@ -171,12 +172,18 @@ type chatPage struct {
 	sidebarDragMoved      bool // True if mouse moved beyond threshold during drag
 }
 
+// sidebarHidden reports whether the sidebar should be omitted entirely from
+// layout and rendering (lean mode or explicit --sidebar=false).
+func (p *chatPage) sidebarHidden() bool {
+	return p.leanMode || p.hideSidebar
+}
+
 // computeSidebarLayout calculates the layout based on current state.
 func (p *chatPage) computeSidebarLayout() sidebarLayout {
 	innerWidth := p.width - appPaddingHorizontal
 
-	// Lean mode: no sidebar at all
-	if p.leanMode {
+	// No sidebar at all (lean mode or hideSidebar): chat fills the area.
+	if p.sidebarHidden() {
 		return sidebarLayout{
 			mode:       sidebarCollapsedNarrow,
 			innerWidth: innerWidth,
@@ -280,6 +287,15 @@ type PageOption func(*chatPage)
 func WithLeanMode() PageOption {
 	return func(p *chatPage) {
 		p.leanMode = true
+	}
+}
+
+// WithHideSidebar hides the sidebar without enabling lean mode.
+// The sidebar cannot be re-shown via the TUI.
+func WithHideSidebar() PageOption {
+	return func(p *chatPage) {
+		p.hideSidebar = true
+		p.keyMap.ToggleSidebar.SetEnabled(false)
 	}
 }
 
@@ -496,12 +512,19 @@ func (p *chatPage) View() string {
 		bodyContent = lipgloss.JoinHorizontal(lipgloss.Left, chatView, toggleCol, sidebarView)
 
 	case sidebarCollapsed, sidebarCollapsedNarrow:
-		if p.leanMode {
+		switch {
+		case p.leanMode:
 			// Lean mode: no sidebar header, no fixed height
 			bodyContent = styles.ChatStyle.
 				Width(sl.innerWidth).
 				Render(messagesView)
-		} else {
+		case p.hideSidebar:
+			// Sidebar hidden: chat fills the full height, no sidebar header.
+			bodyContent = styles.ChatStyle.
+				Height(sl.chatHeight).
+				Width(sl.innerWidth).
+				Render(messagesView)
+		default:
 			sidebarRendered := p.renderCollapsedSidebar(sl)
 			chatView := styles.ChatStyle.
 				Height(sl.chatHeight).

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -183,6 +183,9 @@ type appModel struct {
 	// leanMode enables a simplified TUI with minimal chrome.
 	leanMode bool
 
+	// hideSidebar hides the sidebar and disables the ctrl+b toggle.
+	hideSidebar bool
+
 	// buildCommandCategories is a function that returns the list of command categories.
 	buildCommandCategories func(context.Context, tea.Model) []commands.Category
 
@@ -213,6 +216,15 @@ type Option func(*appModel)
 func WithLeanMode() Option {
 	return func(m *appModel) {
 		m.leanMode = true
+	}
+}
+
+// WithHideSidebar hides the chat sidebar. Unlike lean mode, the rest of
+// the chrome (tab bar, status bar, dialogs) remains visible. The user
+// cannot bring the sidebar back via the TUI.
+func WithHideSidebar() Option {
+	return func(m *appModel) {
+		m.hideSidebar = true
 	}
 }
 
@@ -454,6 +466,9 @@ func (m *appModel) chatPageOpts() []chat.PageOption {
 	if m.leanMode {
 		opts = append(opts, chat.WithLeanMode())
 	}
+	if m.hideSidebar {
+		opts = append(opts, chat.WithHideSidebar())
+	}
 	return opts
 }
 
@@ -608,6 +623,9 @@ func (m *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleReorderTab(msg)
 
 	case messages.ToggleSidebarMsg:
+		if m.hideSidebar {
+			return m, nil
+		}
 		if m.tuiStore != nil {
 			persistedID := m.persistedSessionID(m.supervisor.ActiveID())
 			if err := m.tuiStore.ToggleSidebarCollapsed(context.Background(), persistedID); err != nil {
@@ -1747,7 +1765,7 @@ func (m *appModel) AllBindings() []key.Binding {
 		),
 	)
 
-	if !m.leanMode {
+	if !m.leanMode && !m.hideSidebar {
 		bindings = append(bindings, key.NewBinding(
 			key.WithKeys("ctrl+b"),
 			key.WithHelp("Ctrl+b", "toggle sidebar"),
@@ -1942,7 +1960,7 @@ func (m *appModel) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 	// Toggle sidebar (propagates to content view regardless of focus)
 	case key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+b"))):
-		if m.leanMode {
+		if m.leanMode || m.hideSidebar {
 			return m, nil
 		}
 		return m.forwardChat(msg)

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -1765,7 +1765,8 @@ func (m *appModel) AllBindings() []key.Binding {
 		),
 	)
 
-	if !m.leanMode && !m.hideSidebar {
+	// leanMode already returned above, so only hideSidebar matters here.
+	if !m.hideSidebar {
 		bindings = append(bindings, key.NewBinding(
 			key.WithKeys("ctrl+b"),
 			key.WithHelp("Ctrl+b", "toggle sidebar"),


### PR DESCRIPTION
Closes #2912

Adds a `--sidebar` flag to control sidebar visibility in the TUI. When set to `--sidebar=false`, the sidebar is hidden and the user cannot re-enable it via keyboard shortcut or mouse interaction. The flag defaults to `true`, preserving existing behavior.

This complements the existing `--lean` flag, which hides the entire UI chrome. The `--sidebar=false` option is lighter—it keeps the tab bar, status bar, and dialogs intact while hiding only the sidebar. The implementation gates the Ctrl+B keybinding and sidebar toggle behavior when the sidebar is disabled, and adjusts the chat layout to fill the full width when the sidebar is absent.

Build, lint, and tests all pass. (Unrelated pre-existing failures in `pkg/snapshot` on macOS stem from `/private/var` symlink handling and are out of scope.)