### PR TITLE
fix: rune-safe truncation and dead-code cleanup

### DIFF
--- a/cmd/wasm/runtime_wasm.go
+++ b/cmd/wasm/runtime_wasm.go
@@ -788,8 +788,8 @@ func parseToolArgs(args string) map[string]any {
 
 // truncateOutput truncates a string to maxLen characters, appending "…" if truncated.
 func truncateOutput(s string, maxLen int) string {
-	if len(s) <= maxLen {
-		return s
+	if r := []rune(s); len(r) > maxLen {
+		return string(r[:maxLen]) + "…"
 	}
-	return s[:maxLen] + "…"
+	return s
 }

--- a/cmd/wasm/runtime_wasm.go
+++ b/cmd/wasm/runtime_wasm.go
@@ -250,11 +250,7 @@ func (rt *wasmRuntime) agentInstruction(name string) string {
 // maxIterations.
 func (rt *wasmRuntime) runAgentLoop(ctx context.Context, agentName string, messages []chat.Message) (map[string]any, error) {
 	if agentName == "" {
-		if len(rt.cfg.Agents) == 1 {
-			agentName = rt.cfg.Agents[0].Name
-		} else {
-			agentName = rt.cfg.Agents[0].Name
-		}
+		agentName = rt.cfg.Agents[0].Name
 	}
 	rt.currentAgent = agentName
 

--- a/pkg/evaluation/progress.go
+++ b/pkg/evaluation/progress.go
@@ -216,8 +216,8 @@ func (p *progressBar) render(final bool) {
 		// Calculate available space for running task name
 		availableForName := max(termWidth-len(status)-10, 5)
 		name := firstName
-		if len(name) > availableForName {
-			name = name[:availableForName-1] + "…"
+		if r := []rune(name); len(r) > availableForName {
+			name = string(r[:availableForName-1]) + "…"
 		}
 		if runningCount == 1 {
 			status += " | " + name

--- a/pkg/evaluation/progress.go
+++ b/pkg/evaluation/progress.go
@@ -166,7 +166,7 @@ func (p *progressBar) render(final bool) {
 
 	// Calculate bar width based on terminal size
 	// Reserve space for: "[" + "]" + " 100% (999/999) " + counts (~20) + running info (~30)
-	barWidth := min(max(termWidth-80, 10), 10)
+	barWidth := min(max(termWidth-80, 10), 30)
 
 	filledWidth := 0
 	if p.total > 0 {

--- a/pkg/rag/strategy/semantic_embeddings.go
+++ b/pkg/rag/strategy/semantic_embeddings.go
@@ -312,7 +312,7 @@ func (b *llmSemanticEmbeddingBuilder) BuildEmbeddingInput(ctx context.Context, s
 
 		fallback := ch.Content
 		if len(fallback) > maxEmbeddingInputLength {
-			fallback = fallback[:maxEmbeddingInputLength] + "..."
+			fallback = strings.ToValidUTF8(fallback[:maxEmbeddingInputLength], "") + "..."
 			slog.DebugContext(ctx, "Truncated fallback content to fit embedding model limits",
 				"original_length", len(ch.Content),
 				"truncated_length", len(fallback))
@@ -332,7 +332,7 @@ func (b *llmSemanticEmbeddingBuilder) BuildEmbeddingInput(ctx context.Context, s
 			"chunk_index", ch.Index,
 			"original_length", len(embeddingInput),
 			"truncated_length", maxEmbeddingInputLength)
-		embeddingInput = embeddingInput[:maxEmbeddingInputLength] + "..."
+		embeddingInput = strings.ToValidUTF8(embeddingInput[:maxEmbeddingInputLength], "") + "..."
 	}
 
 	slog.DebugContext(ctx, "Generated semantic embedding input for chunk",

--- a/pkg/tools/builtin/filesystem/filesystem.go
+++ b/pkg/tools/builtin/filesystem/filesystem.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"unicode/utf8"
 
 	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/config"
@@ -1195,8 +1196,15 @@ func (t *ToolSet) handleSearchFilesContent(_ context.Context, args SearchFilesCo
 				preview := line
 				if len(preview) > 100 {
 					start := max(matchStart-20, 0)
-					end := matchEnd + 20
-					end = min(end, len(preview))
+					end := min(matchEnd+20, len(preview))
+					// Snap to rune boundaries so we never split a multi-byte
+					// UTF-8 sequence in the preview.
+					for start > 0 && !utf8.RuneStart(preview[start]) {
+						start--
+					}
+					for end < len(preview) && !utf8.RuneStart(preview[end]) {
+						end++
+					}
 					preview = preview[start:end]
 				}
 

--- a/pkg/tools/builtin/openapi/openapi.go
+++ b/pkg/tools/builtin/openapi/openapi.go
@@ -281,8 +281,8 @@ func operationDescription(path, method string, op *v3.Operation) string {
 	}
 
 	if op.Description != "" {
-		if len(op.Description) > 200 {
-			return op.Description[:200] + "..."
+		if r := []rune(op.Description); len(r) > 200 {
+			return string(r[:200]) + "..."
 		}
 		return op.Description
 	}

--- a/pkg/tui/components/tabbar/tab.go
+++ b/pkg/tui/components/tabbar/tab.go
@@ -88,8 +88,8 @@ func renderTab(info messages.TabInfo, maxTitleLen, animFrame int, role dragRole)
 	if title == "" {
 		title = defaultTabTitle
 	}
-	if len(title) > maxTitleLen {
-		title = title[:maxTitleLen-1] + "…"
+	if r := []rune(title); len(r) > maxTitleLen {
+		title = string(r[:maxTitleLen-1]) + "…"
 	}
 
 	// Pick colors based on focus state.

--- a/pkg/tui/components/tool/searchfilescontent/searchfilescontent.go
+++ b/pkg/tui/components/tool/searchfilescontent/searchfilescontent.go
@@ -26,8 +26,8 @@ func extractArgs(args string) string {
 
 	path := pathx.ShortenHome(parsed.Path)
 	query := parsed.Query
-	if len(query) > 30 {
-		query = query[:27] + "..."
+	if r := []rune(query); len(r) > 30 {
+		query = string(r[:27]) + "..."
 	}
 
 	if parsed.IsRegex {

--- a/pkg/tui/dialog/file_picker.go
+++ b/pkg/tui/dialog/file_picker.go
@@ -340,8 +340,8 @@ func (d *filePickerDialog) renderEntry(entry fileEntry, selected bool, maxWidth 
 
 	name := entry.name
 	maxNameLen := max(1, maxWidth-20)
-	if len(name) > maxNameLen {
-		name = name[:maxNameLen-1] + "…"
+	if r := []rune(name); len(r) > maxNameLen {
+		name = string(r[:maxNameLen-1]) + "…"
 	}
 
 	line := nameStyle.Render(icon + name)

--- a/pkg/tui/dialog/session_browser.go
+++ b/pkg/tui/dialog/session_browser.go
@@ -396,8 +396,8 @@ func (d *sessionBrowserDialog) renderSession(sess session.Summary, selected bool
 
 	starWidth := 3
 	maxTitleLen := max(1, maxWidth-len(suffix)-starWidth)
-	if len(title) > maxTitleLen {
-		title = title[:maxTitleLen-1] + "…"
+	if r := []rune(title); len(r) > maxTitleLen {
+		title = string(r[:maxTitleLen-1]) + "…"
 	}
 
 	return styles.StarIndicator(sess.Starred) + titleStyle.Render(title) + timeStyle.Render(suffix)

--- a/pkg/tui/dialog/working_dir_picker.go
+++ b/pkg/tui/dialog/working_dir_picker.go
@@ -897,8 +897,8 @@ func (d *workingDirPickerDialog) renderBrowseEntry(entry dirEntry, selected bool
 		icon := "📁 "
 		name := entry.name
 		nameLimit := availableWidth - dirPickerFolderIconWidth
-		if len(name) > nameLimit {
-			name = name[:nameLimit-1] + "…"
+		if r := []rune(name); len(r) > nameLimit {
+			name = string(r[:nameLimit-1]) + "…"
 		}
 		return prefix + nameStyle.Render(icon+name)
 	}


### PR DESCRIPTION
## Summary

A focused pass of small, high-confidence bug fixes found while reviewing the codebase. Two categories:

### Logic / dead code
- **`evaluation`: progress bar width was always `10`** — `min(max(termWidth-80, 10), 10)` made the `max` dead, so the bar never scaled with the terminal. Restored a sensible upper clamp.
- **`wasm`: removed an `if/else` with identical branches** in `runAgentLoop`'s default-agent selection (the `len(Agents)==1` check was meaningless).

### UTF-8 truncation (byte-index slicing could split a multi-byte rune → `�` / invalid bytes)
The project already standardizes on rune-aware truncation (`[]rune`, `ansi.Truncate`, `truncateRunes`), but several spots still sliced by byte. Fixed in:
- `evaluation` running-task name
- TUI file picker, session browser, working-dir picker, tab titles, search-query preview
- OpenAPI operation descriptions
- `wasm` tool-output preview
- `filesystem` grep search-result preview window (snap to rune boundaries)
- `rag` semantic-embedding input — could feed invalid UTF-8 (encoded as U+FFFD) to the embedding API; now clamped to valid UTF-8 while preserving the byte budget

## Validation
- `go build ./...` and `GOOS=js GOARCH=wasm go build ./cmd/wasm/`
- `go vet` + `golangci-lint`: clean on all touched packages
- Tests pass for every touched package

All changes are behavior-preserving for ASCII input and consistent with existing conventions. Each fix is an individual commit.