### PR TITLE
docs: update docs for --sidebar, --app-name, --disable-commands flags, OAuth meta keys rename, and hooks model_id gap

### DIFF
--- a/docs/configuration/hooks/index.md
+++ b/docs/configuration/hooks/index.md
@@ -255,8 +255,8 @@ In addition to the common fields, each event ships its own payload:
 | `user_prompt_submit`        | `prompt` — the text the user just submitted                                                                           |
 | `turn_start`                | _none_ (just the common fields)                                                                                       |
 | `turn_end`                  | `agent_name`, `reason` — one of `normal`, `continue`, `steered`, `error`, `canceled`, `hook_blocked`, `loop_detected` |
-| `before_llm_call`           | `iteration` — 1-based run-loop iteration counter (the model call this hook is gating)                                |
-| `after_llm_call`            | `agent_name`, `stop_response`, `last_user_message`                                                                    |
+| `before_llm_call`           | `model_id`, `iteration` — 1-based run-loop iteration counter (the model call this hook is gating)                                |
+| `after_llm_call`            | `model_id`, `agent_name`, `stop_response`, `last_user_message`                                                                    |
 | `session_end`               | `reason` — one of `clear`, `logout`, `prompt_input_exit`, `other`                                                     |
 | `pre_compact`               | `source` — one of `manual`, `auto`, `overflow`, `tool_overflow`                                                       |
 | `before_compaction`         | `input_tokens`, `output_tokens`, `context_limit`, `compaction_reason` (one of `threshold`/`overflow`/`manual`)        |
@@ -275,6 +275,7 @@ Notes:
 
 - `tool_response` for `post_tool_use` carries the tool's result; `tool_error` is `true` when the tool failed (the failure detail is surfaced inside `tool_response`).
 - `prompt` is only populated for `user_prompt_submit`. Sub-sessions (transferred tasks, background agents, skills) do **not** fire this event because their kick-off message is synthesised by the runtime, not authored by the user.
+- `model_id` is in `provider/model` form and reflects per-tool model overrides and alloy-mode selection. It is populated for `before_llm_call` and `after_llm_call` only.
 - `stop_response` carries the model's final assistant text for `stop`, `after_llm_call`, and `subagent_stop`. `last_user_message` carries the latest user message at dispatch time.
 - `context_limit` is `0` when the model definition is unavailable (treat `0` as "unknown", not as a real limit).
 - `approval_decision` is one of `allow`, `deny`, `canceled`. `approval_source` is a stable classifier of which step decided (e.g. `yolo`, `session_permissions_allow`, `session_permissions_deny`, `team_permissions_allow`, `team_permissions_deny`, `pre_tool_use_hook_allow`, `pre_tool_use_hook_deny`, `readonly_hint`, `user_approved`, `user_approved_session`, `user_approved_tool`, `user_rejected`, `context_canceled`).

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -37,6 +37,9 @@ $ docker agent run [config] [message...] [flags]
 | `--dry-run`                             | Initialize the agent without executing anything (useful for validating a config)                                                          |
 | `--remote <addr>`                       | Use a remote runtime at the given address instead of running the agent locally                                                            |
 | `--lean`                                | Use a simplified TUI with minimal chrome                                                                                                  |
+| `--sidebar`                             | Show the sidebar in the TUI (default `true`; set `--sidebar=false` to hide it permanently — Ctrl+B and mouse toggle are both disabled)    |
+| `--app-name <name>`                     | Override the application name shown in the TUI status bar and terminal title (default: `docker agent`)                                    |
+| `--disable-commands <list>`             | Comma-separated slash commands to hide and disable in the TUI, command palette, and completion (e.g. `--disable-commands="/cost,/eval,/model"`). Leading slashes are optional; values are case-insensitive. |
 | `--json`                                | Output results as newline-delimited JSON (use with `--exec`)                                                                              |
 | `--hide-tool-calls`                     | Hide tool calls in the output                                                                                                             |
 | `--hide-tool-results`                   | Hide tool call results in the output                                                                                                      |

--- a/docs/features/remote-mcp/index.md
+++ b/docs/features/remote-mcp/index.md
@@ -112,21 +112,21 @@ When running `docker-agent serve api` (no local browser, no callback server), th
 
 - **`--mcp-oauth-redirect-uri=<URL>` set** (recommended for hosts like Docker Desktop): the runtime generates `state` + PKCE + (optional) Dynamic Client Registration in-process, builds the full authorize URL, and emits an elicitation whose `Meta` includes:
 
-  | Key                          | Value                                                            |
-  | ---------------------------- | ---------------------------------------------------------------- |
-  | `cagent/type`                | `"oauth_flow"`                                                   |
-  | `cagent/server_url`          | The MCP server URL (for display / favicon)                       |
-  | `cagent/authorize_url`       | The full URL the client should open in the user's browser        |
-  | `cagent/state`               | The `state` value the client must echo back when replying        |
-  | `auth_server`                | Issuer of the authorization server                               |
-  | `auth_server_metadata`       | RFC 8414 authorization-server metadata document                  |
-  | `resource_metadata`          | RFC 9728 protected-resource metadata document                    |
+  | Key                               | Value                                                            |
+  | --------------------------------- | ---------------------------------------------------------------- |
+  | `docker-agent/type`               | `"oauth_flow"`                                                   |
+  | `docker-agent/server_url`         | The MCP server URL (for display / favicon)                       |
+  | `docker-agent/authorize_url`      | The full URL the client should open in the user's browser        |
+  | `docker-agent/state`              | The `state` value the client must echo back when replying        |
+  | `auth_server`                     | Issuer of the authorization server                               |
+  | `auth_server_metadata`            | RFC 8414 authorization-server metadata document                  |
+  | `resource_metadata`               | RFC 9728 protected-resource metadata document                    |
 
-  The client opens the browser at `cagent/authorize_url`, receives the OAuth callback at whatever endpoint the configured `redirect_uri` resolves to (typically a host-controlled bouncer that 302s into a deeplink), and replies to the elicitation with `accept` and `Content = {"code": "...", "state": "..."}`. The runtime verifies the `state`, exchanges the `code` at the token endpoint (using the same `redirect_uri` for RFC 6749 §4.1.3 binding), stores the token, and replays the original MCP request with `Authorization: Bearer ...`.
+  The client opens the browser at `docker-agent/authorize_url`, receives the OAuth callback at whatever endpoint the configured `redirect_uri` resolves to (typically a host-controlled bouncer that 302s into a deeplink), and replies to the elicitation with `accept` and `Content = {"code": "...", "state": "..."}`. The runtime verifies the `state`, exchanges the `code` at the token endpoint (using the same `redirect_uri` for RFC 6749 §4.1.3 binding), stores the token, and replays the original MCP request with `Authorization: Bearer ...`.
 
 - **Flag not set** (legacy): the runtime emits only `auth_server_metadata` + `resource_metadata`; the client is expected to drive the OAuth flow itself (PKCE, DCR, token exchange) and reply with `Content = {"access_token": "...", "refresh_token": "...", ...}`.
 
-The legacy `{access_token, ...}` reply shape is still accepted on the `--mcp-oauth-redirect-uri` path too: a client that prefers to do the exchange itself can ignore the `cagent/authorize_url`/`cagent/state` keys.
+The legacy `{access_token, ...}` reply shape is still accepted on the `--mcp-oauth-redirect-uri` path too: a client that prefers to do the exchange itself can ignore the `docker-agent/authorize_url`/`docker-agent/state` keys.
 
 A per-toolset `callbackRedirectURL` (in the YAML) overrides the runtime-wide `--mcp-oauth-redirect-uri` for that toolset.
 


### PR DESCRIPTION
## Summary

Catches up `/docs` with user-facing changes merged in the last 36 hours.

## Changes

### `docs/features/cli/index.md` — 3 new flags documented
Added to the `docker agent run` flags table (alongside `--lean` which they complement):

| Flag | Description |
|---|---|
| `--sidebar` | Show the sidebar in the TUI (default `true`; `--sidebar=false` hides it permanently, disabling Ctrl+B and mouse toggle) |
| `--app-name <name>` | Override the application name shown in the TUI status bar, terminal title, and `/exit` notifications |
| `--disable-commands <list>` | Comma-separated slash commands to hide from TUI, command palette, and editor completion. Leading slashes optional, case-insensitive. |

Refs: #2917, #2914, #2913

### `docs/features/remote-mcp/index.md` — OAuth elicitation meta key prefix corrected
The unmanaged OAuth section referenced the old `cagent/` key prefix. Updated all four keys to the renamed `docker-agent/` prefix per #2915:
- `cagent/type` → `docker-agent/type`
- `cagent/server_url` → `docker-agent/server_url`
- `cagent/authorize_url` → `docker-agent/authorize_url`
- `cagent/state` → `docker-agent/state`

Refs: #2915

### `docs/configuration/hooks/index.md` — `model_id` added to hook payload tables
The per-event extra fields table was missing `model_id` for both `before_llm_call` and `after_llm_call`. Added the field and a note explaining its `provider/model` canonical form. This closes the docs gap explicitly flagged in #2911.

Refs: #2911

## No changes needed
- `docs/features/tui/index.md` — does not enumerate CLI flags; no update needed.
- `docs/features/mcp-mode/index.md` — no stale OAuth meta key references found.
- `docs/features/remote-mcp/index.md` OAuth drive-flow section — already written by #2896 itself; only the key-name rename was stale.