### PR TITLE
docs: sync documentation with recent code changes

### DIFF
--- a/docs/configuration/hooks/index.md
+++ b/docs/configuration/hooks/index.md
@@ -256,7 +256,7 @@ In addition to the common fields, each event ships its own payload:
 | `turn_start`                | _none_ (just the common fields)                                                                                       |
 | `turn_end`                  | `agent_name`, `reason` — one of `normal`, `continue`, `steered`, `error`, `canceled`, `hook_blocked`, `loop_detected` |
 | `before_llm_call`           | `iteration` — 1-based run-loop iteration counter (the model call this hook is gating)                                |
-| `after_llm_call`            | `agent_name`, `stop_response`, `last_user_message`                                                                    |
+| `after_llm_call`            | `agent_name`, `model_id`, `stop_response`, `last_user_message`                                                        |
 | `session_end`               | `reason` — one of `clear`, `logout`, `prompt_input_exit`, `other`                                                     |
 | `pre_compact`               | `source` — one of `manual`, `auto`, `overflow`, `tool_overflow`                                                       |
 | `before_compaction`         | `input_tokens`, `output_tokens`, `context_limit`, `compaction_reason` (one of `threshold`/`overflow`/`manual`)        |
@@ -547,7 +547,7 @@ The `reason` field classifies the exit:
 
 `before_llm_call` fires immediately before every model call (after `turn_start` has assembled the messages). It cannot contribute context — use `turn_start` for that — but it can **stop the run** by returning `decision: block` (or exit code 2). The built-in `max_iterations` hook implements a hard cap on top of this event.
 
-`after_llm_call` fires immediately after each successful model call, before the response is recorded into the session and tool calls are dispatched. The assistant text is in `stop_response`. Use it for response auditing, redaction logging, or quality metrics. Failed model calls fire `on_error` instead.
+`after_llm_call` fires immediately after each successful model call, before the response is recorded into the session and tool calls are dispatched. The assistant text is in `stop_response`. The model used for the call is in `model_id` (e.g. `anthropic/claude-sonnet-4-5`). Use it for response auditing, redaction logging, or quality metrics. Failed model calls fire `on_error` instead.
 
 ### Before/After-Compaction: structured compaction control
 

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -38,7 +38,7 @@ $ docker agent run [config] [message...] [flags]
 | `--remote <addr>`                       | Use a remote runtime at the given address instead of running the agent locally                                                            |
 | `--lean`                                | Use a simplified TUI with minimal chrome                                                                                                  |
 | `--app-name <name>`                     | Application name shown in the TUI in place of "docker agent"                                                                             |
-| `--sidebar`                             | Show the sidebar in the TUI (set `--sidebar=false` to hide it)                                                                            |
+| `--sidebar`                             | Show the sidebar in the TUI; enabled by default (pass `--sidebar=false` to hide it)                                                       |
 | `--disable-commands <list>`             | Comma-separated list of slash commands to hide and disable in the TUI (e.g. `/cost,/eval,/model`)                                         |
 | `--json`                                | Output results as newline-delimited JSON (use with `--exec`)                                                                              |
 | `--hide-tool-calls`                     | Hide tool calls in the output                                                                                                             |

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -37,6 +37,9 @@ $ docker agent run [config] [message...] [flags]
 | `--dry-run`                             | Initialize the agent without executing anything (useful for validating a config)                                                          |
 | `--remote <addr>`                       | Use a remote runtime at the given address instead of running the agent locally                                                            |
 | `--lean`                                | Use a simplified TUI with minimal chrome                                                                                                  |
+| `--app-name <name>`                     | Application name shown in the TUI in place of "docker agent"                                                                             |
+| `--sidebar`                             | Show the sidebar in the TUI (set `--sidebar=false` to hide it)                                                                            |
+| `--disable-commands <list>`             | Comma-separated list of slash commands to hide and disable in the TUI (e.g. `/cost,/eval,/model`)                                         |
 | `--json`                                | Output results as newline-delimited JSON (use with `--exec`)                                                                              |
 | `--hide-tool-calls`                     | Hide tool calls in the output                                                                                                             |
 | `--hide-tool-results`                   | Hide tool call results in the output                                                                                                      |

--- a/docs/features/remote-mcp/index.md
+++ b/docs/features/remote-mcp/index.md
@@ -114,19 +114,19 @@ When running `docker-agent serve api` (no local browser, no callback server), th
 
   | Key                          | Value                                                            |
   | ---------------------------- | ---------------------------------------------------------------- |
-  | `cagent/type`                | `"oauth_flow"`                                                   |
-  | `cagent/server_url`          | The MCP server URL (for display / favicon)                       |
-  | `cagent/authorize_url`       | The full URL the client should open in the user's browser        |
-  | `cagent/state`               | The `state` value the client must echo back when replying        |
+  | `docker-agent/type`          | `"oauth_flow"`                                                   |
+  | `docker-agent/server_url`    | The MCP server URL (for display / favicon)                       |
+  | `docker-agent/authorize_url` | The full URL the client should open in the user's browser        |
+  | `docker-agent/state`         | The `state` value the client must echo back when replying        |
   | `auth_server`                | Issuer of the authorization server                               |
   | `auth_server_metadata`       | RFC 8414 authorization-server metadata document                  |
   | `resource_metadata`          | RFC 9728 protected-resource metadata document                    |
 
-  The client opens the browser at `cagent/authorize_url`, receives the OAuth callback at whatever endpoint the configured `redirect_uri` resolves to (typically a host-controlled bouncer that 302s into a deeplink), and replies to the elicitation with `accept` and `Content = {"code": "...", "state": "..."}`. The runtime verifies the `state`, exchanges the `code` at the token endpoint (using the same `redirect_uri` for RFC 6749 §4.1.3 binding), stores the token, and replays the original MCP request with `Authorization: Bearer ...`.
+  The client opens the browser at `docker-agent/authorize_url`, receives the OAuth callback at whatever endpoint the configured `redirect_uri` resolves to (typically a host-controlled bouncer that 302s into a deeplink), and replies to the elicitation with `accept` and `Content = {"code": "...", "state": "..."}`. The runtime verifies the `state`, exchanges the `code` at the token endpoint (using the same `redirect_uri` for RFC 6749 §4.1.3 binding), stores the token, and replays the original MCP request with `Authorization: Bearer ...`.
 
 - **Flag not set** (legacy): the runtime emits only `auth_server_metadata` + `resource_metadata`; the client is expected to drive the OAuth flow itself (PKCE, DCR, token exchange) and reply with `Content = {"access_token": "...", "refresh_token": "...", ...}`.
 
-The legacy `{access_token, ...}` reply shape is still accepted on the `--mcp-oauth-redirect-uri` path too: a client that prefers to do the exchange itself can ignore the `cagent/authorize_url`/`cagent/state` keys.
+The legacy `{access_token, ...}` reply shape is still accepted on the `--mcp-oauth-redirect-uri` path too: a client that prefers to do the exchange itself can ignore the `docker-agent/authorize_url`/`docker-agent/state` keys.
 
 A per-toolset `callbackRedirectURL` (in the YAML) overrides the runtime-wide `--mcp-oauth-redirect-uri` for that toolset.
 


### PR DESCRIPTION
Three doc fixes to sync with recent code changes:

- **CLI flags** (`docs/features/cli/index.md`): add `--app-name`, `--sidebar`, and `--disable-commands` to the `docker agent run` flag table, grouped with the other TUI-related flags.
- **Hooks payload** (`docs/configuration/hooks/index.md`): add `model_id` to the `after_llm_call` event table and prose description (PR #2911).
- **Remote MCP OAuth meta keys** (`docs/features/remote-mcp/index.md`): rename `cagent/type`, `cagent/server_url`, `cagent/authorize_url`, `cagent/state` → `docker-agent/*` in the unmanaged OAuth flow section (commits dfca23c7, 6dd7608d).