### PR TITLE
docs: sync CLI flags and hook payload docs with recent changes

### DIFF
--- a/docs/configuration/hooks/index.md
+++ b/docs/configuration/hooks/index.md
@@ -256,7 +256,7 @@ In addition to the common fields, each event ships its own payload:
 | `turn_start`                | _none_ (just the common fields)                                                                                       |
 | `turn_end`                  | `agent_name`, `reason` — one of `normal`, `continue`, `steered`, `error`, `canceled`, `hook_blocked`, `loop_detected` |
 | `before_llm_call`           | `iteration` — 1-based run-loop iteration counter (the model call this hook is gating)                                |
-| `after_llm_call`            | `agent_name`, `stop_response`, `last_user_message`                                                                    |
+| `after_llm_call`            | `agent_name`, `stop_response`, `last_user_message`, `model_id`                                                       |
 | `session_end`               | `reason` — one of `clear`, `logout`, `prompt_input_exit`, `other`                                                     |
 | `pre_compact`               | `source` — one of `manual`, `auto`, `overflow`, `tool_overflow`                                                       |
 | `before_compaction`         | `input_tokens`, `output_tokens`, `context_limit`, `compaction_reason` (one of `threshold`/`overflow`/`manual`)        |
@@ -276,6 +276,7 @@ Notes:
 - `tool_response` for `post_tool_use` carries the tool's result; `tool_error` is `true` when the tool failed (the failure detail is surfaced inside `tool_response`).
 - `prompt` is only populated for `user_prompt_submit`. Sub-sessions (transferred tasks, background agents, skills) do **not** fire this event because their kick-off message is synthesised by the runtime, not authored by the user.
 - `stop_response` carries the model's final assistant text for `stop`, `after_llm_call`, and `subagent_stop`. `last_user_message` carries the latest user message at dispatch time.
+- `model_id` is populated for `after_llm_call` (and `before_llm_call`) in the canonical `<provider>/<model>` form (e.g. `anthropic/claude-sonnet-4-5`). For harness agents the value is the harness label rather than the canonical form.
 - `context_limit` is `0` when the model definition is unavailable (treat `0` as "unknown", not as a real limit).
 - `approval_decision` is one of `allow`, `deny`, `canceled`. `approval_source` is a stable classifier of which step decided (e.g. `yolo`, `session_permissions_allow`, `session_permissions_deny`, `team_permissions_allow`, `team_permissions_deny`, `pre_tool_use_hook_allow`, `pre_tool_use_hook_deny`, `readonly_hint`, `user_approved`, `user_approved_session`, `user_approved_tool`, `user_rejected`, `context_canceled`).
 

--- a/docs/configuration/hooks/index.md
+++ b/docs/configuration/hooks/index.md
@@ -255,7 +255,7 @@ In addition to the common fields, each event ships its own payload:
 | `user_prompt_submit`        | `prompt` — the text the user just submitted                                                                           |
 | `turn_start`                | _none_ (just the common fields)                                                                                       |
 | `turn_end`                  | `agent_name`, `reason` — one of `normal`, `continue`, `steered`, `error`, `canceled`, `hook_blocked`, `loop_detected` |
-| `before_llm_call`           | `iteration` — 1-based run-loop iteration counter (the model call this hook is gating)                                |
+| `before_llm_call`           | `iteration` — 1-based run-loop iteration counter (the model call this hook is gating), `model_id`                    |
 | `after_llm_call`            | `agent_name`, `stop_response`, `last_user_message`, `model_id`                                                       |
 | `session_end`               | `reason` — one of `clear`, `logout`, `prompt_input_exit`, `other`                                                     |
 | `pre_compact`               | `source` — one of `manual`, `auto`, `overflow`, `tool_overflow`                                                       |

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -37,6 +37,9 @@ $ docker agent run [config] [message...] [flags]
 | `--dry-run`                             | Initialize the agent without executing anything (useful for validating a config)                                                          |
 | `--remote <addr>`                       | Use a remote runtime at the given address instead of running the agent locally                                                            |
 | `--lean`                                | Use a simplified TUI with minimal chrome                                                                                                  |
+| `--app-name <name>`                     | Override the application name label shown in the TUI (status bar, window title, "/exit" notifications).                                   |
+| `--sidebar`                             | Control sidebar visibility. Set to `--sidebar=false` to hide the sidebar and disable the Ctrl+B toggle (default: `true`).                 |
+| `--disable-commands <list>`             | Hide and disable specific slash commands in the TUI. Accepts a comma-separated list of command names (leading slash optional, case-insensitive). E.g. `--disable-commands="/cost,/eval,/model"`. |
 | `--json`                                | Output results as newline-delimited JSON (use with `--exec`)                                                                              |
 | `--hide-tool-calls`                     | Hide tool calls in the output                                                                                                             |
 | `--hide-tool-results`                   | Hide tool call results in the output                                                                                                      |
@@ -77,6 +80,11 @@ $ docker agent run agent.yaml --hook-pre-tool-use "./scripts/validate.sh" --hook
 
 # Queue multiple messages (processed in sequence)
 $ docker agent run agent.yaml "question 1" "question 2" "question 3"
+
+# Customize TUI display
+$ docker agent run agent.yaml --app-name "My Project"
+$ docker agent run agent.yaml --sidebar=false
+$ docker agent run agent.yaml --disable-commands="/cost,/eval,/model"
 ```
 
 ### `docker agent run --exec`

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -156,6 +156,7 @@ $ docker agent serve api <agent-file>|<agents-dir>|<registry-ref> [flags]
 | `--pull-interval <minutes>`| `0`                | Periodically re-pull OCI/URL references and refresh the agent definition. `0` disables auto-pull.          |
 | `--fake <path>`             | (none)             | Replay AI responses from a cassette file (for testing). Mutually exclusive with `--record`.               |
 | `--record [path]`           | (none)             | Record AI API interactions to a cassette file.                                                            |
+| `--mcp-oauth-redirect-uri <url>` | (none)        | OAuth redirect URI for the unmanaged MCP OAuth flow in server mode. When set, the runtime drives PKCE and code exchange in-process and sends the full authorize URL to the client via elicitation. See [Remote MCP]({{ '/features/remote-mcp/' | relative_url }}) for details. |
 
 All [runtime configuration flags](#runtime-configuration-flags) (`--working-dir`, `--env-from-file`, `--models-gateway`, `--hook-*`, …) are also accepted.
 

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -26,6 +26,9 @@ $ docker agent run agent.yaml --yolo
 
 # Enable debug logging
 $ docker agent run agent.yaml --debug
+
+# Hide the sidebar (cannot be re-enabled via Ctrl+B)
+$ docker agent run agent.yaml --sidebar=false
 ```
 
 ## Slash Commands
@@ -173,7 +176,7 @@ Customize session titles to make them more meaningful and easier to find. By def
 | Ctrl+W     | Close the current tab                           |
 | Ctrl+N     | Next tab                                        |
 | Ctrl+P     | Previous tab                                    |
-| Ctrl+B     | Toggle the sidebar (full-UI mode only)          |
+| Ctrl+B     | Toggle the sidebar (full-UI mode only; disabled when --sidebar=false) |
 | Ctrl+Y     | Toggle YOLO mode (auto-approve tool calls)      |
 | Ctrl+O     | Toggle hide tool results                        |
 | Ctrl+Z     | Suspend TUI to background (resume with `fg`)    |

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -29,6 +29,9 @@ $ docker agent run agent.yaml --debug
 
 # Hide the sidebar (cannot be re-enabled via Ctrl+B)
 $ docker agent run agent.yaml --sidebar=false
+
+# Disable specific slash commands
+$ docker agent run agent.yaml --disable-commands="/cost,/eval,/model"
 ```
 
 ## Slash Commands


### PR DESCRIPTION
- Add `--app-name` flag to `docker agent run` table (PR #2914): overrides the application name label in the TUI status bar, window title, and "/exit" notifications
- Add `--sidebar` flag to `docker agent run` table (PR #2917): controls sidebar visibility; `--sidebar=false` hides it and disables Ctrl+B toggle
- Add `--disable-commands` flag to `docker agent run` table (PR #2913): hides/disables specific slash commands via comma-separated list
- Add usage examples for `--app-name`, `--sidebar`, and `--disable-commands` to the examples block
- Update `docs/features/tui/index.md`: add `--sidebar=false` launch example; note Ctrl+B is disabled when `--sidebar=false`
- Update `docs/configuration/hooks/index.md` (PR #2911): add `model_id` to `after_llm_call` extra fields; add note explaining `model_id` format for `after_llm_call` and `before_llm_call`