### PR TITLE
feat: add allow/block-list of servers to the mcp_catalog tool

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -1873,6 +1873,31 @@
             "type": "string"
           }
         },
+        "allowed_servers": {
+          "type": "array",
+          "description": "Allow-list of MCP catalog server ids offered by default (only valid for type 'mcp_catalog'). When non-empty, only these servers are searchable and enableable; every other catalog entry is hidden. Combine with 'blocked_servers' to subtract individual ids (block takes precedence). An empty or omitted list offers the full catalog.",
+          "items": {
+            "type": "string"
+          },
+          "examples": [
+            [
+              "duckduckgo",
+              "fetch"
+            ]
+          ]
+        },
+        "blocked_servers": {
+          "type": "array",
+          "description": "Block-list of MCP catalog server ids removed from the offered set (only valid for type 'mcp_catalog'). Applied after 'allowed_servers', so a server listed in both is blocked. An empty or omitted list disables the block-list.",
+          "items": {
+            "type": "string"
+          },
+          "examples": [
+            [
+              "shell"
+            ]
+          ]
+        },
         "models": {
           "type": "array",
           "description": "List of allowed models for the model_picker tool.",

--- a/agent-schema.json
+++ b/agent-schema.json
@@ -1881,8 +1881,8 @@
           },
           "examples": [
             [
-              "duckduckgo",
-              "fetch"
+              "docker-docs",
+              "microsoft-learn"
             ]
           ]
         },
@@ -1894,7 +1894,7 @@
           },
           "examples": [
             [
-              "shell"
+              "gitmcp"
             ]
           ]
         },

--- a/docs/tools/mcp-catalog/index.md
+++ b/docs/tools/mcp-catalog/index.md
@@ -27,7 +27,27 @@ toolsets:
   - type: mcp_catalog
 ```
 
-The toolset takes no options: the catalog is embedded in the docker-agent binary and refreshed with each release.
+The catalog is embedded in the docker-agent binary and refreshed with each release. By default every server in the embedded subset is offered.
+
+### Restricting the offered servers
+
+Two optional lists narrow what the toolset offers, so an agent sees a focused, predictable menu instead of the full catalog:
+
+- **`allowed_servers`** — when non-empty, **only** these catalog server ids are searchable and enableable; every other entry is hidden.
+- **`blocked_servers`** — removes individual ids from the offered set. It is applied **after** `allowed_servers`, so a server listed in both is blocked (block wins over allow).
+
+Both take server ids (the `id` field returned by `search_remote_mcp_servers`). An empty or omitted list disables that filter.
+
+```yaml
+toolsets:
+  - type: mcp_catalog
+    allowed_servers:
+      - docker-docs
+      - microsoft-learn
+      - hugging-face
+    blocked_servers:
+      - gitmcp
+```
 
 ## Meta-Tools
 
@@ -76,7 +96,7 @@ agents:
       - type: mcp_catalog
 ```
 
-A complete, runnable configuration lives in [`examples/mcp_catalog.yaml`](https://github.com/docker/docker-agent/blob/main/examples/mcp_catalog.yaml).
+A complete, runnable configuration lives in [`examples/mcp_catalog.yaml`](https://github.com/docker/docker-agent/blob/main/examples/mcp_catalog.yaml). A curated, allow/block-listed variant lives in [`examples/mcp_catalog_filtered.yaml`](https://github.com/docker/docker-agent/blob/main/examples/mcp_catalog_filtered.yaml).
 
 ## Notes and Limitations
 

--- a/examples/mcp_catalog_filtered.yaml
+++ b/examples/mcp_catalog_filtered.yaml
@@ -1,0 +1,31 @@
+# An agent that exposes only a curated subset of the Docker MCP Catalog.
+#
+# The mcp_catalog toolset can be narrowed with two optional lists:
+#   - allowed_servers: when non-empty, ONLY these catalog server ids are
+#     searchable and enableable. Every other entry is hidden.
+#   - blocked_servers: removes individual ids from the offered set. It is
+#     applied after allowed_servers, so a server present in both is blocked.
+#
+# Use these to give an agent a focused, predictable menu of servers instead
+# of the full catalog (which contains hundreds of entries).
+
+agents:
+  root:
+    model: anthropic/claude-sonnet-4-6
+    description: Agent restricted to a curated set of remote MCP servers.
+    instruction: |
+      You can discover and activate remote MCP servers on demand, but only
+      a curated subset of the catalog is available to you. Use
+      search_remote_mcp_servers to find one, then enable_remote_mcp_server
+      to activate it.
+    toolsets:
+      - type: mcp_catalog
+        # Only these servers are offered by default.
+        allowed_servers:
+          - docker-docs
+          - microsoft-learn
+          - hugging-face
+          - gitmcp
+        # ...minus any explicitly blocked one (block wins over allow).
+        blocked_servers:
+          - gitmcp

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -921,6 +921,20 @@ type Toolset struct {
 	// both is rejected. An empty or omitted list disables the deny-list.
 	DenyList []string `json:"deny_list,omitempty" yaml:"deny_list,omitempty"`
 
+	// For the `mcp_catalog` tool - allow-list of catalog server ids that
+	// are offered by default. When non-empty, only these servers are
+	// searchable and enableable; every other catalog entry is hidden. An
+	// empty or omitted list offers the full catalog. Combine with
+	// `blocked_servers` to subtract individual ids from the allowed set
+	// (block takes precedence).
+	AllowedServers []string `json:"allowed_servers,omitempty" yaml:"allowed_servers,omitempty"`
+
+	// For the `mcp_catalog` tool - block-list of catalog server ids that
+	// are removed from the offered set. Applied after `allowed_servers`,
+	// so a server listed in both is blocked. An empty or omitted list
+	// disables the block-list.
+	BlockedServers []string `json:"blocked_servers,omitempty" yaml:"blocked_servers,omitempty"`
+
 	// For the `lsp` tool
 	FileTypes []string `json:"file_types,omitempty"`
 

--- a/pkg/config/latest/validate.go
+++ b/pkg/config/latest/validate.go
@@ -139,6 +139,18 @@ func (t *Toolset) validate() error {
 	if len(t.FileTypes) > 0 && t.Type != "lsp" {
 		return errors.New("file_types can only be used with type 'lsp'")
 	}
+	if len(t.AllowedServers) > 0 && t.Type != "mcp_catalog" {
+		return errors.New("allowed_servers can only be used with type 'mcp_catalog'")
+	}
+	if len(t.BlockedServers) > 0 && t.Type != "mcp_catalog" {
+		return errors.New("blocked_servers can only be used with type 'mcp_catalog'")
+	}
+	if err := validateNonEmptyEntries("allowed_servers", t.AllowedServers); err != nil {
+		return err
+	}
+	if err := validateNonEmptyEntries("blocked_servers", t.BlockedServers); err != nil {
+		return err
+	}
 	if len(t.AllowedDomains) > 0 && t.Type != "fetch" {
 		return errors.New("allowed_domains can only be used with type 'fetch'")
 	}
@@ -278,6 +290,18 @@ func (t *Toolset) validate() error {
 		// no additional validation needed
 	}
 
+	return nil
+}
+
+// validateNonEmptyEntries rejects empty / whitespace-only entries in a
+// generic string list (e.g. the mcp_catalog allow/block server lists). An
+// empty id would never match a catalog server but signals a config typo.
+func validateNonEmptyEntries(field string, entries []string) error {
+	for i, e := range entries {
+		if strings.TrimSpace(e) == "" {
+			return fmt.Errorf("%s[%d] must not be empty", field, i)
+		}
+	}
 	return nil
 }
 

--- a/pkg/config/toolset_validate_test.go
+++ b/pkg/config/toolset_validate_test.go
@@ -595,6 +595,129 @@ agents:
 	}
 }
 
+func TestToolset_Validate_MCPCatalog_ServerLists(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		config  string
+		wantErr string
+	}{
+		{
+			name: "mcp_catalog with allowed_servers",
+			config: `
+agents:
+  root:
+    model: "openai/gpt-4"
+    toolsets:
+      - type: mcp_catalog
+        allowed_servers:
+          - docker-docs
+          - microsoft-learn
+`,
+			wantErr: "",
+		},
+		{
+			name: "mcp_catalog with blocked_servers",
+			config: `
+agents:
+  root:
+    model: "openai/gpt-4"
+    toolsets:
+      - type: mcp_catalog
+        blocked_servers:
+          - gitmcp
+`,
+			wantErr: "",
+		},
+		{
+			name: "mcp_catalog with both lists is accepted",
+			config: `
+agents:
+  root:
+    model: "openai/gpt-4"
+    toolsets:
+      - type: mcp_catalog
+        allowed_servers:
+          - docker-docs
+          - gitmcp
+        blocked_servers:
+          - gitmcp
+`,
+			wantErr: "",
+		},
+		{
+			name: "allowed_servers on non-mcp_catalog toolset is rejected",
+			config: `
+agents:
+  root:
+    model: "openai/gpt-4"
+    toolsets:
+      - type: shell
+        allowed_servers:
+          - docker-docs
+`,
+			wantErr: "allowed_servers can only be used with type 'mcp_catalog'",
+		},
+		{
+			name: "blocked_servers on non-mcp_catalog toolset is rejected",
+			config: `
+agents:
+  root:
+    model: "openai/gpt-4"
+    toolsets:
+      - type: shell
+        blocked_servers:
+          - docker-docs
+`,
+			wantErr: "blocked_servers can only be used with type 'mcp_catalog'",
+		},
+		{
+			name: "empty allowed_servers entry is rejected",
+			config: `
+agents:
+  root:
+    model: "openai/gpt-4"
+    toolsets:
+      - type: mcp_catalog
+        allowed_servers:
+          - ""
+          - docker-docs
+`,
+			wantErr: "allowed_servers[0] must not be empty",
+		},
+		{
+			name: "whitespace-only blocked_servers entry is rejected",
+			config: `
+agents:
+  root:
+    model: "openai/gpt-4"
+    toolsets:
+      - type: mcp_catalog
+        blocked_servers:
+          - "   "
+`,
+			wantErr: "blocked_servers[0] must not be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var cfg latest.Config
+			err := yaml.Unmarshal([]byte(tt.config), &cfg)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestToolset_Validate_MCP_RemoteOAuth_CallbackRedirectURL(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/teamloader/registry.go
+++ b/pkg/teamloader/registry.go
@@ -66,8 +66,15 @@ func NewDefaultToolsetRegistry() ToolsetRegistry {
 			"mcp": func(ctx context.Context, toolset latest.Toolset, _ string, runConfig *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
 				return mcp.CreateToolSet(ctx, toolset, runConfig)
 			},
-			"mcp_catalog": func(_ context.Context, _ latest.Toolset, _ string, runConfig *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
-				return mcpcatalog.New(runConfig.EnvProvider()), nil
+			"mcp_catalog": func(_ context.Context, toolset latest.Toolset, _ string, runConfig *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
+				var opts []mcpcatalog.Option
+				if len(toolset.AllowedServers) > 0 {
+					opts = append(opts, mcpcatalog.WithAllowedServers(toolset.AllowedServers))
+				}
+				if len(toolset.BlockedServers) > 0 {
+					opts = append(opts, mcpcatalog.WithBlockedServers(toolset.BlockedServers))
+				}
+				return mcpcatalog.New(runConfig.EnvProvider(), opts...), nil
 			},
 			"api": func(_ context.Context, toolset latest.Toolset, _ string, runConfig *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
 				return api.CreateToolSet(toolset, runConfig)

--- a/pkg/tools/builtin/mcpcatalog/mcpcatalog.go
+++ b/pkg/tools/builtin/mcpcatalog/mcpcatalog.go
@@ -65,6 +65,12 @@ type Toolset struct {
 	byID    map[string]Server
 	env     environment.Provider
 
+	// allowedServers / blockedServers capture the optional offer filters
+	// applied at construction time. They are retained only for reference;
+	// the actual filtering happens once in New via filterCatalog.
+	allowedServers []string
+	blockedServers []string
+
 	mu sync.RWMutex
 	// enabled holds the per-server StartableToolSet wrapper. Wrapping the
 	// inner *mcp.Toolset in a StartableToolSet gives us:
@@ -107,23 +113,91 @@ var (
 	_ tools.OAuthCapable   = (*Toolset)(nil)
 )
 
+// Option customizes a Toolset at construction time.
+type Option func(*Toolset)
+
+// WithAllowedServers restricts the offered catalog to the given server ids.
+// When the list is non-empty, only these servers are searchable and
+// enableable; every other entry is hidden. An empty or nil list leaves the
+// full catalog in place.
+func WithAllowedServers(ids []string) Option {
+	return func(t *Toolset) { t.allowedServers = ids }
+}
+
+// WithBlockedServers removes the given server ids from the offered catalog.
+// Block takes precedence over allow: a server present in both lists is
+// blocked.
+func WithBlockedServers(ids []string) Option {
+	return func(t *Toolset) { t.blockedServers = ids }
+}
+
 // New returns a Toolset backed by the embedded catalog. envProvider is used
 // to resolve ${ENV_VAR} placeholders in catalog headers (e.g. the Apify
 // `Authorization: Bearer ${APIFY_API_KEY}` header) at enable time, mirroring
 // how a YAML-declared `mcp.remote` toolset works.
-func New(envProvider environment.Provider) *Toolset {
+//
+// Optional WithAllowedServers / WithBlockedServers options narrow the set of
+// servers the toolset offers by default.
+func New(envProvider environment.Provider, opts ...Option) *Toolset {
 	cat := MustLoad()
-	byID := make(map[string]Server, len(cat.Servers))
-	for _, s := range cat.Servers {
-		byID[s.ID] = s
-	}
-	return &Toolset{
+	t := &Toolset{
 		catalog:          cat,
-		byID:             byID,
 		env:              envProvider,
 		enabled:          make(map[string]*tools.StartableToolSet),
 		removeOAuthToken: mcp.RemoveOAuthToken,
 	}
+	for _, opt := range opts {
+		opt(t)
+	}
+	t.filterCatalog()
+	return t
+}
+
+// filterCatalog applies the allow/block lists to the embedded catalog,
+// rebuilding Servers, Count and the id index so the rest of the toolset only
+// ever sees the offered subset. Block takes precedence over allow. It always
+// runs (even with no filters) to populate byID.
+func (t *Toolset) filterCatalog() {
+	allow := toIDSet(t.allowedServers)
+	block := toIDSet(t.blockedServers)
+
+	if len(allow) > 0 || len(block) > 0 {
+		filtered := make([]Server, 0, len(t.catalog.Servers))
+		for _, s := range t.catalog.Servers {
+			if len(allow) > 0 {
+				if _, ok := allow[s.ID]; !ok {
+					continue
+				}
+			}
+			if _, ok := block[s.ID]; ok {
+				continue
+			}
+			filtered = append(filtered, s)
+		}
+		t.catalog.Servers = filtered
+		t.catalog.Count = len(filtered)
+	}
+
+	t.byID = make(map[string]Server, len(t.catalog.Servers))
+	for _, s := range t.catalog.Servers {
+		t.byID[s.ID] = s
+	}
+}
+
+// toIDSet builds a lookup set from a list of server ids, dropping empty /
+// whitespace-only entries. Returns nil for an empty input so callers can
+// cheaply test len() == 0.
+func toIDSet(ids []string) map[string]struct{} {
+	if len(ids) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if id = strings.TrimSpace(id); id != "" {
+			set[id] = struct{}{}
+		}
+	}
+	return set
 }
 
 // Describe returns a short, user-visible label for the /tools dialog.

--- a/pkg/tools/builtin/mcpcatalog/mcpcatalog.go
+++ b/pkg/tools/builtin/mcpcatalog/mcpcatalog.go
@@ -162,6 +162,17 @@ func (t *Toolset) filterCatalog() {
 	block := toIDSet(t.blockedServers)
 
 	if len(allow) > 0 || len(block) > 0 {
+		known := make(map[string]struct{}, len(t.catalog.Servers))
+		for _, s := range t.catalog.Servers {
+			known[s.ID] = struct{}{}
+		}
+		if unknown := unknownIDs(known, allow, block); len(unknown) > 0 {
+			// A typo in allowed_servers can silently leave an agent with an
+			// over-restricted (even empty) catalog, so surface it loudly.
+			slog.Warn("mcp_catalog allow/block list references unknown server id(s); they will be ignored",
+				"ids", unknown)
+		}
+
 		filtered := make([]Server, 0, len(t.catalog.Servers))
 		for _, s := range t.catalog.Servers {
 			if len(allow) > 0 {
@@ -182,6 +193,27 @@ func (t *Toolset) filterCatalog() {
 	for _, s := range t.catalog.Servers {
 		t.byID[s.ID] = s
 	}
+}
+
+// unknownIDs returns the sorted, de-duplicated ids present in the allow/block
+// sets but absent from the catalog (known). Used to warn about config typos.
+func unknownIDs(known map[string]struct{}, sets ...map[string]struct{}) []string {
+	seen := make(map[string]struct{})
+	var out []string
+	for _, set := range sets {
+		for id := range set {
+			if _, ok := known[id]; ok {
+				continue
+			}
+			if _, dup := seen[id]; dup {
+				continue
+			}
+			seen[id] = struct{}{}
+			out = append(out, id)
+		}
+	}
+	sort.Strings(out)
+	return out
 }
 
 // toIDSet builds a lookup set from a list of server ids, dropping empty /

--- a/pkg/tools/builtin/mcpcatalog/mcpcatalog.go
+++ b/pkg/tools/builtin/mcpcatalog/mcpcatalog.go
@@ -65,12 +65,6 @@ type Toolset struct {
 	byID    map[string]Server
 	env     environment.Provider
 
-	// allowedServers / blockedServers capture the optional offer filters
-	// applied at construction time. They are retained only for reference;
-	// the actual filtering happens once in New via filterCatalog.
-	allowedServers []string
-	blockedServers []string
-
 	mu sync.RWMutex
 	// enabled holds the per-server StartableToolSet wrapper. Wrapping the
 	// inner *mcp.Toolset in a StartableToolSet gives us:
@@ -114,21 +108,28 @@ var (
 )
 
 // Option customizes a Toolset at construction time.
-type Option func(*Toolset)
+type Option func(*options)
+
+// options collects the construction-time settings supplied via Option. It is
+// consumed entirely within New, so nothing leaks onto the long-lived Toolset.
+type options struct {
+	allowedServers []string
+	blockedServers []string
+}
 
 // WithAllowedServers restricts the offered catalog to the given server ids.
 // When the list is non-empty, only these servers are searchable and
 // enableable; every other entry is hidden. An empty or nil list leaves the
 // full catalog in place.
 func WithAllowedServers(ids []string) Option {
-	return func(t *Toolset) { t.allowedServers = ids }
+	return func(o *options) { o.allowedServers = ids }
 }
 
 // WithBlockedServers removes the given server ids from the offered catalog.
 // Block takes precedence over allow: a server present in both lists is
 // blocked.
 func WithBlockedServers(ids []string) Option {
-	return func(t *Toolset) { t.blockedServers = ids }
+	return func(o *options) { o.blockedServers = ids }
 }
 
 // New returns a Toolset backed by the embedded catalog. envProvider is used
@@ -139,17 +140,18 @@ func WithBlockedServers(ids []string) Option {
 // Optional WithAllowedServers / WithBlockedServers options narrow the set of
 // servers the toolset offers by default.
 func New(envProvider environment.Provider, opts ...Option) *Toolset {
-	cat := MustLoad()
+	var cfg options
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
 	t := &Toolset{
-		catalog:          cat,
+		catalog:          MustLoad(),
 		env:              envProvider,
 		enabled:          make(map[string]*tools.StartableToolSet),
 		removeOAuthToken: mcp.RemoveOAuthToken,
 	}
-	for _, opt := range opts {
-		opt(t)
-	}
-	t.filterCatalog()
+	t.filterCatalog(cfg.allowedServers, cfg.blockedServers)
 	return t
 }
 
@@ -157,9 +159,9 @@ func New(envProvider environment.Provider, opts ...Option) *Toolset {
 // rebuilding Servers, Count and the id index so the rest of the toolset only
 // ever sees the offered subset. Block takes precedence over allow. It always
 // runs (even with no filters) to populate byID.
-func (t *Toolset) filterCatalog() {
-	allow := toIDSet(t.allowedServers)
-	block := toIDSet(t.blockedServers)
+func (t *Toolset) filterCatalog(allowedServers, blockedServers []string) {
+	allow := toIDSet(allowedServers)
+	block := toIDSet(blockedServers)
 
 	if len(allow) > 0 || len(block) > 0 {
 		known := make(map[string]struct{}, len(t.catalog.Servers))

--- a/pkg/tools/builtin/mcpcatalog/mcpcatalog_test.go
+++ b/pkg/tools/builtin/mcpcatalog/mcpcatalog_test.go
@@ -263,6 +263,72 @@ func TestToolsUsesStableIterationOrder(t *testing.T) {
 	assert.Equal(t, want, got)
 }
 
+// TestServerFilters covers the allow/block-list narrowing applied at
+// construction time via WithAllowedServers / WithBlockedServers.
+func TestServerFilters(t *testing.T) {
+	full := New(stubEnv{vars: map[string]string{}})
+	require.GreaterOrEqual(t, len(full.catalog.Servers), 3, "need 3+ servers in fixture")
+	ids := []string{full.catalog.Servers[0].ID, full.catalog.Servers[1].ID, full.catalog.Servers[2].ID}
+
+	t.Run("allow list restricts to the named servers", func(t *testing.T) {
+		ts := New(stubEnv{vars: map[string]string{}}, WithAllowedServers(ids[:2]))
+		assert.Equal(t, len(ts.catalog.Servers), ts.catalog.Count)
+		assert.Len(t, ts.catalog.Servers, 2)
+		assert.Contains(t, ts.byID, ids[0])
+		assert.Contains(t, ts.byID, ids[1])
+		assert.NotContains(t, ts.byID, ids[2])
+	})
+
+	t.Run("block list removes the named servers", func(t *testing.T) {
+		ts := New(stubEnv{vars: map[string]string{}}, WithBlockedServers(ids[:1]))
+		assert.Len(t, ts.catalog.Servers, len(full.catalog.Servers)-1)
+		assert.NotContains(t, ts.byID, ids[0])
+		assert.Contains(t, ts.byID, ids[1])
+	})
+
+	t.Run("block takes precedence over allow", func(t *testing.T) {
+		ts := New(stubEnv{vars: map[string]string{}},
+			WithAllowedServers(ids[:2]), WithBlockedServers([]string{ids[0]}))
+		assert.Len(t, ts.catalog.Servers, 1)
+		assert.NotContains(t, ts.byID, ids[0])
+		assert.Contains(t, ts.byID, ids[1])
+	})
+
+	t.Run("unknown ids are ignored", func(t *testing.T) {
+		ts := New(stubEnv{vars: map[string]string{}},
+			WithAllowedServers([]string{ids[0], "definitely-not-a-server"}))
+		assert.Len(t, ts.catalog.Servers, 1)
+		assert.Contains(t, ts.byID, ids[0])
+	})
+
+	t.Run("blank entries are ignored", func(t *testing.T) {
+		ts := New(stubEnv{vars: map[string]string{}},
+			WithAllowedServers([]string{ids[0], "  ", ""}))
+		assert.Len(t, ts.catalog.Servers, 1)
+	})
+
+	t.Run("empty lists offer the full catalog", func(t *testing.T) {
+		ts := New(stubEnv{vars: map[string]string{}},
+			WithAllowedServers(nil), WithBlockedServers([]string{}))
+		assert.Len(t, ts.catalog.Servers, len(full.catalog.Servers))
+	})
+}
+
+// TestSearchRespectsAllowList ensures filtered-out servers are not
+// reachable through the search meta-tool.
+func TestSearchRespectsAllowList(t *testing.T) {
+	full := New(stubEnv{vars: map[string]string{}})
+	require.GreaterOrEqual(t, len(full.catalog.Servers), 2)
+	keep := full.catalog.Servers[0].ID
+	drop := full.catalog.Servers[1].ID
+
+	ts := New(stubEnv{vars: map[string]string{}}, WithAllowedServers([]string{keep}))
+
+	res, err := ts.handleSearch(t.Context(), SearchArgs{Query: drop})
+	require.NoError(t, err)
+	assert.True(t, res.IsError, "a blocked/hidden server must not be searchable")
+}
+
 func TestEnableUnknownServer(t *testing.T) {
 	ts := New(stubEnv{vars: map[string]string{}})
 	res, err := ts.handleEnable(t.Context(), EnableArgs{ID: "definitely-not-a-server"})


### PR DESCRIPTION
The `mcp_catalog` builtin tool now supports allow-listing and block-listing of MCP servers. This lets agents enforce a curated set of available integrations and prevent access to specific servers—useful for compliance, security policies, or ensuring a focused set of tools in multi-agent deployments.

Configuration is straightforward: set `allowed_servers` (optional) to whitelist specific catalog server IDs, and `blocked_servers` (optional) to exclude them. Block-list takes precedence if a server appears in both. Filtering applies to all catalog operations: search, enable, and `reset_auth`. Empty or whitespace-only entries are rejected at validation time, and a warning is logged if a configuration references unknown server IDs, helping catch typos early.

An example configuration can be found in `examples/mcp_catalog_filtered.yaml`. All changes are backward compatible—existing configurations without these fields work unchanged.