### PR TITLE
docs: sync /docs with changes merged 2026-05-28 – 2026-05-29

### DIFF
--- a/docs/features/api-server/index.md
+++ b/docs/features/api-server/index.md
@@ -96,6 +96,12 @@ curl -N -X POST http://localhost:8080/api/sessions/$SID/agent/team/reviewer \
 | ------ | ----------- | ----------------------------------------- |
 | `GET`  | `/api/ping` | Health check — returns `{"status": "ok"}` |
 
+### OAuth
+
+| Method | Path                     | Description                                                                                                                                                                                                                                          |
+| ------ | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `POST` | `/api/mcp-oauth/callback` | Deliver an OAuth deeplink callback (`?state=<state>&code=<code>`) to a pending unmanaged OAuth flow. Returns 400 if `state` or `code` is missing, 404 if no flow is awaiting that `state`. See [Remote MCP OAuth]({{ '/features/remote-mcp/' | relative_url }}) for details. |
+
 ## Streaming Responses
 
 The agent execution endpoints (`POST /api/sessions/:id/agent/:agent`) return **Server-Sent Events (SSE)**. The request body is a JSON object with a `messages` array and an optional `model` field. Setting `model` applies a persistent per-agent override on the session before the turn starts (subsequent turns reuse it). An empty or omitted `model` leaves the existing override untouched. (Each event is a JSON object representing a runtime event — remember that `:agent` is the config filename without the `.yaml` extension.):
@@ -167,6 +173,7 @@ docker agent serve api <agent-file>|<agents-dir> [flags]
 | `--pull-interval`  | `0` (disabled)   | Auto-pull OCI reference every N minutes          |
 | `--fake`           | (none)           | Replay AI responses from cassette file (testing) |
 | `--record`         | (none)           | Record AI API interactions to cassette file      |
+| `--mcp-oauth-redirect-uri` | (none)   | Public HTTPS URL advertised as the OAuth `redirect_uri` for unmanaged MCP OAuth flows. When set, docker-agent drives PKCE and code exchange in-process. See [Remote MCP]({{ '/features/remote-mcp/' | relative_url }}) for details. |
 
 <div class="callout callout-tip" markdown="1">
 <div class="callout-title">Multi-agent configs

--- a/docs/features/api-server/index.md
+++ b/docs/features/api-server/index.md
@@ -100,7 +100,7 @@ curl -N -X POST http://localhost:8080/api/sessions/$SID/agent/team/reviewer \
 
 | Method | Path                     | Description                                                                                                                                                                                                                                          |
 | ------ | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `POST` | `/api/mcp-oauth/callback` | Deliver an OAuth deeplink callback (`?state=<state>&code=<code>`) to a pending unmanaged OAuth flow. Returns 400 if `state` or `code` is missing, 404 if no flow is awaiting that `state`. See [Remote MCP OAuth]({{ '/features/remote-mcp/' | relative_url }}) for details. |
+| `POST` | `/api/mcp-oauth/callback` | Deliver an OAuth deeplink callback to a pending unmanaged OAuth flow. Success path: `?state=<state>&code=<code>`; authorization-server error path: `?state=<state>&error=<error>&error_description=<desc>`. Returns 400 if `state` is missing or neither `code` nor `error` is provided; 404 if no flow is awaiting that `state`. See [Remote MCP OAuth]({{ '/features/remote-mcp/' | relative_url }}) for details. |
 
 ## Streaming Responses
 
@@ -173,7 +173,7 @@ docker agent serve api <agent-file>|<agents-dir> [flags]
 | `--pull-interval`  | `0` (disabled)   | Auto-pull OCI reference every N minutes          |
 | `--fake`           | (none)           | Replay AI responses from cassette file (testing) |
 | `--record`         | (none)           | Record AI API interactions to cassette file      |
-| `--mcp-oauth-redirect-uri` | (none)   | Public HTTPS URL advertised as the OAuth `redirect_uri` for unmanaged MCP OAuth flows. When set, docker-agent drives PKCE and code exchange in-process. See [Remote MCP]({{ '/features/remote-mcp/' | relative_url }}) for details. |
+| `--mcp-oauth-redirect-uri` | (none)   | Public HTTPS URL advertised as the OAuth `redirect_uri` for unmanaged MCP OAuth flows. When set, docker-agent drives PKCE and code exchange in-process and sends the full authorize URL to the client via elicitation. See [Remote MCP]({{ '/features/remote-mcp/' | relative_url }}) for details. |
 
 <div class="callout callout-tip" markdown="1">
 <div class="callout-title">Multi-agent configs

--- a/docs/features/remote-mcp/index.md
+++ b/docs/features/remote-mcp/index.md
@@ -122,7 +122,7 @@ When running `docker-agent serve api` (no local browser, no callback server), th
   | `auth_server_metadata`       | RFC 8414 authorization-server metadata document                  |
   | `resource_metadata`          | RFC 9728 protected-resource metadata document                    |
 
-  The client opens the browser at `docker-agent/authorize_url`, receives the OAuth callback at whatever endpoint the configured `redirect_uri` resolves to (typically a host-controlled bouncer that 302s into a deeplink), and replies to the elicitation with `accept` and `Content = {"code": "...", "state": "..."}`. The runtime verifies the `state`, exchanges the `code` at the token endpoint (using the same `redirect_uri` for RFC 6749 §4.1.3 binding), stores the token, and replays the original MCP request with `Authorization: Bearer ...`.
+  The client opens the browser at the URL provided in the `docker-agent/authorize_url` meta field, receives the OAuth callback at whatever endpoint the configured `redirect_uri` resolves to (typically a host-controlled bouncer that 302s into a deeplink), and replies to the elicitation with `accept` and `Content = {"code": "...", "state": "..."}`. The runtime verifies the `state`, exchanges the `code` at the token endpoint (using the same `redirect_uri` for RFC 6749 §4.1.3 binding), stores the token, and replays the original MCP request with `Authorization: Bearer ...`.
 
 - **Flag not set** (client-driven): the runtime emits only `auth_server_metadata` + `resource_metadata`; the client is expected to drive the OAuth flow itself (PKCE, DCR, token exchange) and reply with `Content = {"access_token": "...", "refresh_token": "...", ...}`.
 

--- a/docs/features/remote-mcp/index.md
+++ b/docs/features/remote-mcp/index.md
@@ -124,7 +124,15 @@ When running `docker-agent serve api` (no local browser, no callback server), th
 
   The client opens the browser at the URL provided in the `docker-agent/authorize_url` meta field, receives the OAuth callback at whatever endpoint the configured `redirect_uri` resolves to (typically a host-controlled bouncer that 302s into a deeplink), and replies to the elicitation with `accept` and `Content = {"code": "...", "state": "..."}`. The runtime verifies the `state`, exchanges the `code` at the token endpoint (using the same `redirect_uri` for RFC 6749 §4.1.3 binding), stores the token, and replays the original MCP request with `Authorization: Bearer ...`.
 
-- **Flag not set** (client-driven): the runtime emits only `auth_server_metadata` + `resource_metadata`; the client is expected to drive the OAuth flow itself (PKCE, DCR, token exchange) and reply with `Content = {"access_token": "...", "refresh_token": "...", ...}`.
+- **Flag not set** (client-driven): the runtime emits the elicitation meta below and expects the client to drive the OAuth flow itself (PKCE, DCR, token exchange) and reply with `Content = {"access_token": "...", "refresh_token": "...", ...}`:
+
+  | Key                          | Value                                                            |
+  | ---------------------------- | ---------------------------------------------------------------- |
+  | `docker-agent/type`          | `"oauth_flow"`                                                   |
+  | `docker-agent/server_url`    | The MCP server URL (for display / favicon)                       |
+  | `auth_server`                | Issuer of the authorization server                               |
+  | `auth_server_metadata`       | RFC 8414 authorization-server metadata document                  |
+  | `resource_metadata`          | RFC 9728 protected-resource metadata document                    |
 
 The client-driven `{access_token, ...}` reply shape is still accepted on the `--mcp-oauth-redirect-uri` path too: a client that prefers to do the exchange itself can ignore the `docker-agent/authorize_url`/`docker-agent/state` keys.
 

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -27,6 +27,9 @@ $ docker agent run agent.yaml --yolo
 # Enable debug logging
 $ docker agent run agent.yaml --debug
 
+# Override the application name shown in the status bar and window title
+$ docker agent run agent.yaml --app-name "My Project"
+
 # Hide the sidebar (cannot be re-enabled via Ctrl+B)
 $ docker agent run agent.yaml --sidebar=false
 


### PR DESCRIPTION
## Summary

Catch-up documentation updates for code changes merged in the last 36 hours.

> Most doc updates for the same batch of PRs were already landed in #2927 ("docs: sync CLI flags and hook payload docs with recent changes"). This PR covers the remaining gaps.

---

## Commits

### `docs: document /api/mcp-oauth/callback endpoint and --mcp-oauth-redirect-uri flag` (refs #2896, #2921)

**File:** `docs/features/api-server/index.md`

Added a new **`### OAuth`** subsection documenting `POST /api/mcp-oauth/callback` (query parameters, error responses 400/404) and added `--mcp-oauth-redirect-uri` to the API-server CLI flags table.

---

### `docs: clarify docker-agent/authorize_url prose in unmanaged OAuth section` (refs #2921)

**File:** `docs/features/remote-mcp/index.md`

Fixed ambiguous prose: "opens the browser at `docker-agent/authorize_url`" → "at the URL provided in the `docker-agent/authorize_url` meta field".

---

### `docs: document full elicitation meta for client-driven unmanaged OAuth flow` (refs #2896)

**File:** `docs/features/remote-mcp/index.md`

The client-driven (flag-not-set) case previously said it "emits only `auth_server_metadata` + `resource_metadata`", which was inaccurate. The code emits five keys for both sub-behaviors. Replaced the prose description with a proper table showing all five keys (`docker-agent/type`, `docker-agent/server_url`, `auth_server`, `auth_server_metadata`, `resource_metadata`).

---

### `docs: add --app-name example to TUI launch section` (refs #2914)

**File:** `docs/features/tui/index.md`

`--app-name` was added to the CLI flags table by #2927 but was absent from the TUI launch examples block. Added the example.

---

### `docs: fix /api/mcp-oauth/callback 400 condition and add error-path params` (refs #2896)

**File:** `docs/features/api-server/index.md`

The original endpoint description said "Returns 400 if `state` or `code` is missing" — incorrect per the handler (`mcpOAuthCallback` in `pkg/server/server.go`). The handler accepts `?error=<error>` as a valid alternative to `?code`, per the OAuth error-response path (RFC 6749 §4.1.2.1), and returns 400 only if **both** `code` and `error` are absent. Fixed the 400 condition and documented the full query-string contract including `?error` and `?error_description`. Also aligned the `--mcp-oauth-redirect-uri` flag description with the fuller version in `docs/features/cli/index.md` (adds "and sends the full authorize URL to the client via elicitation").

---

## PRs covered

| Source PR | Title | Doc impact |
|-----------|-------|------------|
| #2896 | Extend unmanaged OAuth flow to drive code exchange in-process | `POST /api/mcp-oauth/callback` endpoint docs (accurate 400 condition, full query params); full elicitation meta table for client-driven path; `--mcp-oauth-redirect-uri` flag description aligned |
| #2914 | Add `--app-name` flag | `--app-name` example added to TUI launch docs |
| #2915 | Rename OAuth elicitation meta keys from `cagent/` to `docker-agent/` | All `cagent/*` meta key refs removed (verified complete) |
| #2917 | Add `--sidebar` flag | Already covered by #2927 — no further gaps |
| #2913 | Add `--disable-commands` flag | Already covered by #2927 — no further gaps |
| #2911 | Populate ModelID in `after_llm_call` hook payload | Already covered by #2927 — both hooks have `model_id` documented |
| #2921 | Address review feedback on #2896 | Prose clarification (this PR) |
| #2920 | fix: rune-safe truncation and dead-code cleanup | Internal only — no user-facing doc changes needed |
| #2926, #2918 | Dependency bumps | No docs needed |
| #2905 | Test cleanup | No docs needed |
| #2919 | CHANGELOG update | Already done |