### PR TITLE
TUI - Improve notifications

### DIFF
--- a/pkg/tui/components/notification/notification.go
+++ b/pkg/tui/components/notification/notification.go
@@ -5,22 +5,29 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+	"unicode/utf8"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/mattn/go-runewidth"
 
-	"github.com/docker/docker-agent/pkg/tui/core"
 	"github.com/docker/docker-agent/pkg/tui/styles"
 )
 
 const (
-	closeButton          = " [x]"
-	defaultDuration      = 3 * time.Second
+	defaultDuration      = 10 * time.Second
 	notificationPadding  = 2
 	maxNotificationWidth = 80 // Maximum width to prevent covering too much screen
+	closeGlyph           = "✕"
+	closeInset           = 1
+	hoverLabel           = "click to copy"
+	copiedLabel          = "copied!"
+	closeLabel           = "dismiss"
 )
 
 var nextID atomic.Uint64
+
+var timerDuration = defaultDuration
 
 // Type represents the type of notification
 type Type int
@@ -32,9 +39,8 @@ const (
 	TypeError
 )
 
-// persistent returns true for notification types that stay until manually dismissed.
-func (t Type) persistent() bool {
-	return t == TypeWarning || t == TypeError
+func (t Type) autoHideDuration() time.Duration {
+	return timerDuration
 }
 
 // style returns the lipgloss style for this notification type.
@@ -60,60 +66,96 @@ type HideMsg struct {
 	ID uint64 // If 0, hides all notifications (backward compatibility)
 }
 
+// DismissMsg is sent when the user explicitly dismisses a notification.
+type DismissMsg struct {
+	ID uint64
+}
+
+// AutoHideMsg is sent by a notification timer. The generation field prevents
+// stale timers from hiding notifications after hover pause/restart.
+type AutoHideMsg struct {
+	ID         uint64
+	Generation uint64
+}
+
+func cmd(msg tea.Msg) tea.Cmd {
+	return func() tea.Msg { return msg }
+}
+
 func SuccessCmd(text string) tea.Cmd {
-	return core.CmdHandler(ShowMsg{Text: text, Type: TypeSuccess})
+	return cmd(ShowMsg{Text: text, Type: TypeSuccess})
 }
 
 func WarningCmd(text string) tea.Cmd {
-	return core.CmdHandler(ShowMsg{Text: text, Type: TypeWarning})
+	return cmd(ShowMsg{Text: text, Type: TypeWarning})
 }
 
 func InfoCmd(text string) tea.Cmd {
-	return core.CmdHandler(ShowMsg{Text: text, Type: TypeInfo})
+	return cmd(ShowMsg{Text: text, Type: TypeInfo})
 }
 
 func ErrorCmd(text string) tea.Cmd {
-	return core.CmdHandler(ShowMsg{Text: text, Type: TypeError})
+	return cmd(ShowMsg{Text: text, Type: TypeError})
 }
 
 // notificationItem represents a single notification
 type notificationItem struct {
-	ID   uint64
-	Text string
-	Type Type
+	ID       uint64
+	Text     string
+	Type     Type
+	timerGen uint64
 }
 
-// render returns the styled view string for this notification item,
-// including a close button for persistent notifications.
-func (item notificationItem) render(maxWidth int) string {
+// render returns the styled view string for this notification item.
+func (item notificationItem) render(maxWidth int, closeHovered, bodyHovered, copied bool) string {
 	text := item.Text
-	if item.Type.persistent() {
-		text += closeButton
-	}
-
 	style := item.Type.style()
+
+	var rendered string
 	if lipgloss.Width(text) > maxWidth {
-		return style.Width(maxWidth).Render(text)
+		rendered = style.Width(maxWidth).Render(text)
+	} else {
+		rendered = style.Render(text)
 	}
-	return style.Render(text)
+
+	rendered = overlayCloseButton(rendered, style, closeHovered)
+
+	if bodyHovered || copied || closeHovered {
+		label := hoverLabel
+		switch {
+		case closeHovered:
+			label = closeLabel
+		case copied:
+			label = copiedLabel
+		}
+		rendered = overlayTopBorderText(rendered, style, label)
+	}
+
+	return rendered
 }
 
-// Manager represents a notification manager that displays
-// multiple stacked messages in the bottom right corner of the screen
+// Manager represents a notification manager that displays multiple stacked
+// messages in the bottom right corner of the screen.
 type Manager struct {
-	width, height int
-	items         []notificationItem
+	width, height  int
+	items          []notificationItem
+	hoveredID      uint64
+	closeHoveredID uint64
+	copiedID       uint64
 }
 
-func New() Manager {
-	return Manager{
-		items: make([]notificationItem, 0),
-	}
-}
+func New() Manager { return Manager{} }
 
+// SetSize records the screen size used to position notifications.
 func (n *Manager) SetSize(width, height int) {
 	n.width = width
 	n.height = height
+}
+
+func makeTimerCmd(id, gen uint64, duration time.Duration) tea.Cmd {
+	return tea.Tick(duration, func(time.Time) tea.Msg {
+		return AutoHideMsg{ID: id, Generation: gen}
+	})
 }
 
 func (n *Manager) Update(msg tea.Msg) (Manager, tea.Cmd) {
@@ -124,44 +166,93 @@ func (n *Manager) Update(msg tea.Msg) (Manager, tea.Cmd) {
 		return *n, nil
 
 	case ShowMsg:
-		id := nextID.Add(1)
-		notifType := msg.Type
-		// Auto-detect error type for backward compatibility when Type is not set
-		if notifType == TypeSuccess && msg.Text != "" {
-			textLower := strings.ToLower(msg.Text)
-			if strings.Contains(textLower, "failed") || strings.Contains(textLower, "error") {
-				notifType = TypeError
-			}
-		}
+		return n.handleShow(msg)
 
-		item := notificationItem{ID: id, Text: msg.Text, Type: notifType}
-		n.items = append([]notificationItem{item}, n.items...)
-
-		var cmd tea.Cmd
-		if !notifType.persistent() {
-			cmd = tea.Tick(defaultDuration, func(t time.Time) tea.Msg {
-				return HideMsg{ID: id}
-			})
-		}
-		return *n, cmd
+	case AutoHideMsg:
+		return n.handleAutoHide(msg)
 
 	case HideMsg:
-		if msg.ID == 0 {
-			n.items = nil
-			return *n, nil
-		}
+		return n.handleHide(msg)
 
-		newItems := make([]notificationItem, 0, len(n.items))
-		for _, item := range n.items {
-			if item.ID != msg.ID {
-				newItems = append(newItems, item)
-			}
-		}
-		n.items = newItems
-		return *n, nil
+	case DismissMsg:
+		return n.removeByID(msg.ID)
 	}
 
 	return *n, nil
+}
+
+func (n *Manager) handleShow(msg ShowMsg) (Manager, tea.Cmd) {
+	id := nextID.Add(1)
+	notifType := msg.Type
+	// Auto-detect error type for backward compatibility when Type is not set.
+	if notifType == TypeSuccess && msg.Text != "" {
+		textLower := strings.ToLower(msg.Text)
+		if strings.Contains(textLower, "failed") || strings.Contains(textLower, "error") {
+			notifType = TypeError
+		}
+	}
+
+	item := notificationItem{ID: id, Text: msg.Text, Type: notifType}
+	n.items = append([]notificationItem{item}, n.items...)
+
+	return *n, makeTimerCmd(id, item.timerGen, notifType.autoHideDuration())
+}
+
+func (n *Manager) handleAutoHide(msg AutoHideMsg) (Manager, tea.Cmd) {
+	id := msg.ID
+	gen := msg.Generation
+	newItems := make([]notificationItem, 0, len(n.items))
+	for _, item := range n.items {
+		if item.ID == id && item.timerGen == gen {
+			n.clearItemState(item.ID)
+			continue
+		}
+		newItems = append(newItems, item)
+	}
+	n.items = newItems
+	return *n, nil
+}
+
+func (n *Manager) handleHide(msg HideMsg) (Manager, tea.Cmd) {
+	if msg.ID == 0 {
+		n.items = nil
+		n.clearAllState()
+		return *n, nil
+	}
+
+	return n.removeByID(msg.ID)
+}
+
+func (n *Manager) removeByID(id uint64) (Manager, tea.Cmd) {
+	if i := n.findItemIndex(id); i >= 0 {
+		n.clearItemState(id)
+		n.items = slices.Delete(n.items, i, i+1)
+	}
+	return *n, nil
+}
+
+func (n *Manager) clearAllState() {
+	n.hoveredID, n.closeHoveredID, n.copiedID = 0, 0, 0
+}
+
+func (n *Manager) clearItemState(id uint64) {
+	if n.hoveredID == id {
+		n.hoveredID = 0
+	}
+	if n.closeHoveredID == id {
+		n.closeHoveredID = 0
+	}
+	if n.copiedID == id {
+		n.copiedID = 0
+	}
+}
+
+// MarkCopied records that the given notification was copied so View can show a
+// transient copied label. The state is cleared when hover moves away or the item
+// is removed.
+func (n *Manager) MarkCopied(id uint64) Manager {
+	n.copiedID = id
+	return *n
 }
 
 // maxWidth returns the effective maximum width for notification text.
@@ -180,7 +271,12 @@ func (n *Manager) View() string {
 	mw := n.maxWidth()
 	views := make([]string, 0, len(n.items))
 	for _, item := range slices.Backward(n.items) {
-		views = append(views, item.render(mw))
+		views = append(views, item.render(
+			mw,
+			n.closeHoveredID == item.ID,
+			n.hoveredID == item.ID,
+			n.copiedID == item.ID,
+		))
 	}
 	return lipgloss.JoinVertical(lipgloss.Right, views...)
 }
@@ -197,14 +293,18 @@ func (n *Manager) GetLayer() *lipgloss.Layer {
 }
 
 func (n *Manager) position() (row, col int) {
-	notificationView := n.View()
-	viewHeight := lipgloss.Height(notificationView)
-	viewWidth := lipgloss.Width(notificationView)
+	bounds := n.itemBounds()
+	if len(bounds) == 0 {
+		return max(0, n.height-notificationPadding), max(0, n.width-notificationPadding)
+	}
 
-	// Position in bottom right corner with padding
-	row = max(0, n.height-viewHeight-notificationPadding)
+	viewWidth := 0
+	for _, b := range bounds {
+		viewWidth = max(viewWidth, b.width)
+	}
+
+	row = bounds[0].row
 	col = max(0, n.width-viewWidth-notificationPadding)
-
 	return row, col
 }
 
@@ -212,32 +312,226 @@ func (n *Manager) Open() bool {
 	return len(n.items) > 0
 }
 
-// HandleClick checks if the given screen coordinates hit a persistent
-// notification and dismisses it. Returns a command if a notification
-// was dismissed, nil otherwise.
-func (n *Manager) HandleClick(x, y int) tea.Cmd {
-	if len(n.items) == 0 {
+type notifBounds struct {
+	id     uint64
+	row    int
+	col    int
+	width  int
+	height int
+	text   string
+	style  lipgloss.Style
+}
+
+// itemBounds computes screen-space bounds in the same order notifications render.
+func (n *Manager) itemBounds() []notifBounds {
+	if len(n.items) == 0 || n.width == 0 {
 		return nil
 	}
 
-	row, col := n.position()
 	mw := n.maxWidth()
-	notifY := row
+	totalHeight := 0
+	for _, item := range n.items {
+		totalHeight += lipgloss.Height(item.render(mw, false, false, false))
+	}
 
-	// Walk items bottom-to-top (same render order as View)
+	row := max(0, n.height-totalHeight-notificationPadding)
+	bounds := make([]notifBounds, 0, len(n.items))
 	for _, item := range slices.Backward(n.items) {
-		view := item.render(mw)
-		viewHeight := lipgloss.Height(view)
+		view := item.render(mw, false, false, false)
+		w := lipgloss.Width(view)
+		bounds = append(bounds, notifBounds{
+			id:     item.ID,
+			row:    row,
+			col:    max(0, n.width-w-notificationPadding),
+			width:  w,
+			height: lipgloss.Height(view),
+			text:   item.Text,
+			style:  item.Type.style(),
+		})
+		row += lipgloss.Height(view)
+	}
+	return bounds
+}
 
-		if item.Type.persistent() {
-			viewWidth := lipgloss.Width(view)
-			if y >= notifY && y < notifY+viewHeight && x >= col && x < col+viewWidth {
-				return core.CmdHandler(HideMsg{ID: item.ID})
+func closeButtonPosition(b notifBounds) (x, y int) {
+	return b.col + max(0, b.width-b.style.GetBorderRightSize()-1-closeInset), b.row + b.style.GetBorderTopSize()
+}
+
+// CloseButtonHit checks if the given screen coordinates hit a notification close glyph.
+func (n *Manager) CloseButtonHit(x, y int) (uint64, bool) {
+	for _, b := range n.itemBounds() {
+		closeX, closeY := closeButtonPosition(b)
+		if x == closeX && y == closeY {
+			return b.id, true
+		}
+	}
+	return 0, false
+}
+
+// BodyHit checks whether the coordinates hit the body of a notification and
+// returns its ID and text. The close button is excluded so dismiss priority can
+// stay separate from click-to-copy behavior.
+func (n *Manager) BodyHit(x, y int) (uint64, string, bool) {
+	for _, b := range n.itemBounds() {
+		if x < b.col || x >= b.col+b.width || y < b.row || y >= b.row+b.height {
+			continue
+		}
+		closeX, closeY := closeButtonPosition(b)
+		if x == closeX && y == closeY {
+			return 0, "", false
+		}
+		return b.id, b.text, true
+	}
+	return 0, "", false
+}
+
+// CopyHit checks whether the coordinates hit the currently-hovered notification
+// body and returns its ID and text. The close button is excluded so dismiss
+// priority stays separate from click-to-copy behavior.
+func (n *Manager) CopyHit(x, y int) (uint64, string, bool) {
+	id, text, ok := n.BodyHit(x, y)
+	if !ok || id != n.hoveredID || id == n.closeHoveredID {
+		return 0, "", false
+	}
+	return id, text, true
+}
+
+// HandleClick checks if the given screen coordinates hit a notification close
+// button and returns a dismiss command when they do. Body clicks do not dismiss;
+// callers can use CopyHit for additional behavior such as click-to-copy.
+func (n *Manager) HandleClick(x, y int) tea.Cmd {
+	id, ok := n.CloseButtonHit(x, y)
+	if !ok {
+		return nil
+	}
+	return cmd(DismissMsg{ID: id})
+}
+
+func (n *Manager) hitTestNotification(x, y int) uint64 {
+	for _, b := range n.itemBounds() {
+		if x >= b.col && x < b.col+b.width && y >= b.row && y < b.row+b.height {
+			return b.id
+		}
+	}
+	return 0
+}
+
+func (n *Manager) findItemIndex(id uint64) int {
+	for i := range n.items {
+		if n.items[i].ID == id {
+			return i
+		}
+	}
+	return -1
+}
+
+// HandleMouseMotion updates hover state. Entering an auto-hide notification
+// invalidates its pending timer; leaving restarts a generation-safe timer.
+func (n *Manager) HandleMouseMotion(x, y int) (Manager, tea.Cmd) {
+	newHoveredID := n.hitTestNotification(x, y)
+	newCloseHoveredID, _ := n.CloseButtonHit(x, y)
+
+	var cmd tea.Cmd
+	if newHoveredID != n.hoveredID {
+		// Clear copied state when the pointer leaves or enters another notification.
+		n.copiedID = 0
+
+		if n.hoveredID != 0 {
+			if idx := n.findItemIndex(n.hoveredID); idx >= 0 {
+				cmd = makeTimerCmd(n.items[idx].ID, n.items[idx].timerGen, n.items[idx].Type.autoHideDuration())
 			}
 		}
 
-		notifY += viewHeight
+		if newHoveredID != 0 {
+			if idx := n.findItemIndex(newHoveredID); idx >= 0 {
+				n.items[idx].timerGen++
+			}
+		}
+
+		n.hoveredID = newHoveredID
 	}
 
-	return nil
+	n.closeHoveredID = newCloseHoveredID
+	return *n, cmd
+}
+
+// overlayCloseButton places a close glyph in the top-right area of a rendered notification.
+func overlayCloseButton(rendered string, style lipgloss.Style, hovered bool) string {
+	lines := strings.Split(rendered, "\n")
+	lineIndex := style.GetBorderTopSize()
+	if lineIndex < 0 || lineIndex >= len(lines) {
+		return rendered
+	}
+
+	glyph := styles.NoStyle.Foreground(styles.TextSecondary).Render(closeGlyph)
+	if hovered {
+		glyph = styles.NoStyle.Foreground(styles.Error).Bold(true).Render(closeGlyph)
+	}
+
+	targetCol := lipgloss.Width(lines[lineIndex]) - style.GetBorderRightSize() - 1 - closeInset
+	idx := visibleColumnByteIndex(lines[lineIndex], targetCol)
+	if idx < 0 {
+		return rendered
+	}
+	_, size := utf8.DecodeRuneInString(lines[lineIndex][idx:])
+	lines[lineIndex] = lines[lineIndex][:idx] + glyph + lines[lineIndex][idx+size:]
+	return strings.Join(lines, "\n")
+}
+
+// overlayTopBorderText injects a label into the top border line of a rendered
+// notification.
+func overlayTopBorderText(rendered string, style lipgloss.Style, label string) string {
+	lines := strings.Split(rendered, "\n")
+	if len(lines) == 0 {
+		return rendered
+	}
+
+	paddedLabel := " " + label + " "
+	labelWidth := lipgloss.Width(paddedLabel)
+	totalWidth := lipgloss.Width(lines[0])
+
+	// Need room for: left corner, one dash, label, one dash, right corner.
+	if totalWidth < labelWidth+4 {
+		return rendered
+	}
+
+	bdr := styles.NoStyle.Foreground(style.GetBorderTopForeground())
+	lbl := styles.NoStyle.Foreground(styles.TextMutedGray)
+	lines[0] = bdr.Render("╭─") +
+		lbl.Render(paddedLabel) +
+		bdr.Render(strings.Repeat("─", totalWidth-3-labelWidth)) +
+		bdr.Render("╮")
+
+	return strings.Join(lines, "\n")
+}
+
+func visibleColumnByteIndex(s string, targetCol int) int {
+	if targetCol < 0 {
+		return -1
+	}
+	col := 0
+	for i := 0; i < len(s); {
+		if s[i] == '\x1b' {
+			end := i + 1
+			for end < len(s) && s[end] != 'm' {
+				end++
+			}
+			if end < len(s) {
+				end++
+			}
+			i = end
+			continue
+		}
+		if col == targetCol {
+			return i
+		}
+		r, size := utf8.DecodeRuneInString(s[i:])
+		i += size
+		w := runewidth.RuneWidth(r)
+		if w <= 0 {
+			w = 1
+		}
+		col += w
+	}
+	return -1
 }

--- a/pkg/tui/components/notification/notification_test.go
+++ b/pkg/tui/components/notification/notification_test.go
@@ -1,9 +1,16 @@
 package notification
 
 import (
+	"strings"
 	"testing"
+	"time"
 
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/tui/styles"
 )
 
 func TestNotification_InitialState(t *testing.T) {
@@ -13,15 +20,24 @@ func TestNotification_InitialState(t *testing.T) {
 	require.False(t, n.Open())
 }
 
+func TestNotification_AutoHideDurations(t *testing.T) {
+	require.Equal(t, defaultDuration, TypeSuccess.autoHideDuration())
+	require.Equal(t, defaultDuration, TypeInfo.autoHideDuration())
+	require.Equal(t, defaultDuration, TypeError.autoHideDuration())
+	require.Equal(t, defaultDuration, TypeWarning.autoHideDuration())
+}
+
 func TestNotification_Show(t *testing.T) {
 	n := New()
 
-	updated, _ := n.Update(ShowMsg{Text: "Test notification"})
+	updated, cmd := n.Update(ShowMsg{Text: "Test notification"})
 
 	require.Len(t, updated.items, 1)
 	require.Equal(t, "Test notification", updated.items[0].Text)
+	require.Equal(t, TypeSuccess, updated.items[0].Type)
 	require.True(t, updated.Open())
 	require.NotEmpty(t, updated.View())
+	require.NotNil(t, cmd)
 }
 
 func TestNotification_Hide(t *testing.T) {
@@ -37,14 +53,39 @@ func TestNotification_Hide(t *testing.T) {
 	require.Empty(t, updated.View())
 }
 
+func TestNotification_HideByID(t *testing.T) {
+	n := New()
+	updated, _ := n.Update(ShowMsg{Text: "first"})
+	updated, _ = updated.Update(ShowMsg{Text: "second"})
+	require.Len(t, updated.items, 2)
+
+	firstID := updated.items[1].ID
+	updated, _ = updated.Update(HideMsg{ID: firstID})
+
+	require.Len(t, updated.items, 1)
+	require.Equal(t, "second", updated.items[0].Text)
+}
+
+func TestNotification_DismissByID(t *testing.T) {
+	n := New()
+	updated, _ := n.Update(ShowMsg{Text: "dismiss me", Type: TypeWarning})
+	id := updated.items[0].ID
+
+	updated, _ = updated.Update(DismissMsg{ID: id})
+
+	require.Empty(t, updated.items)
+	require.False(t, updated.Open())
+}
+
 func TestNotification_Position(t *testing.T) {
 	n := New()
 	n.SetSize(100, 50)
 	updated, _ := n.Update(ShowMsg{Text: "Test"})
 	row, col := updated.position()
 
-	require.Equal(t, 45, row)
-	require.Equal(t, 90, col)
+	view := updated.View()
+	require.Equal(t, 50-lipgloss.Height(view)-notificationPadding, row)
+	require.Equal(t, 100-lipgloss.Width(view)-notificationPadding, col)
 }
 
 func TestNotification_GetLayer(t *testing.T) {
@@ -55,3 +96,356 @@ func TestNotification_GetLayer(t *testing.T) {
 	updated, _ := n.Update(ShowMsg{Text: "Test"})
 	require.NotNil(t, updated.GetLayer())
 }
+
+func TestNotification_AutoHideGeneration(t *testing.T) {
+	n := New()
+	updated, _ := n.Update(ShowMsg{Text: "auto", Type: TypeInfo})
+	id := updated.items[0].ID
+	require.Equal(t, uint64(0), updated.items[0].timerGen)
+
+	updated, _ = updated.Update(AutoHideMsg{ID: id, Generation: 0})
+
+	require.Empty(t, updated.items)
+}
+
+func TestNotification_StaleTimerIgnored(t *testing.T) {
+	n := New()
+	n.SetSize(100, 50)
+	updated, _ := n.Update(ShowMsg{Text: "hover me", Type: TypeInfo})
+	id := updated.items[0].ID
+	row, col := updated.position()
+
+	updated, cmd := updated.HandleMouseMotion(col+1, row+1)
+	require.Nil(t, cmd)
+	require.Equal(t, uint64(1), updated.items[0].timerGen)
+
+	updated, _ = updated.Update(AutoHideMsg{ID: id, Generation: 0})
+
+	require.Len(t, updated.items, 1)
+	require.Equal(t, id, updated.items[0].ID)
+}
+
+func TestNotification_HoverEnterLeaveRestartsTimer(t *testing.T) {
+	t.Cleanup(func(previous time.Duration) func() {
+		timerDuration = 0
+		return func() { timerDuration = previous }
+	}(timerDuration))
+
+	n := New()
+	n.SetSize(100, 50)
+	updated, _ := n.Update(ShowMsg{Text: "hover", Type: TypeInfo})
+	id := updated.items[0].ID
+	row, col := updated.position()
+
+	updated, cmd := updated.HandleMouseMotion(col+1, row+1)
+	require.Nil(t, cmd)
+	require.Equal(t, id, updated.hoveredID)
+	require.Equal(t, uint64(1), updated.items[0].timerGen)
+
+	updated, cmd = updated.HandleMouseMotion(0, 0)
+	require.NotNil(t, cmd)
+	require.Zero(t, updated.hoveredID)
+
+	msg := cmd()
+	auto, ok := msg.(AutoHideMsg)
+	require.True(t, ok)
+	require.Equal(t, id, auto.ID)
+	require.Equal(t, uint64(1), auto.Generation)
+}
+
+func TestNotification_WarningHoverEnterLeaveRestartsTimer(t *testing.T) {
+	t.Cleanup(func(previous time.Duration) func() {
+		timerDuration = 0
+		return func() { timerDuration = previous }
+	}(timerDuration))
+
+	n := New()
+	n.SetSize(100, 50)
+	updated, showCmd := n.Update(ShowMsg{Text: "warning", Type: TypeWarning})
+	require.NotNil(t, showCmd)
+	id := updated.items[0].ID
+	row, col := updated.position()
+
+	updated, cmd := updated.HandleMouseMotion(col+1, row+1)
+	require.Nil(t, cmd)
+	require.Equal(t, id, updated.hoveredID)
+	require.Equal(t, uint64(1), updated.items[0].timerGen)
+
+	updated, cmd = updated.HandleMouseMotion(0, 0)
+	require.NotNil(t, cmd)
+	require.Zero(t, updated.hoveredID)
+
+	msg := cmd()
+	auto, ok := msg.(AutoHideMsg)
+	require.True(t, ok)
+	require.Equal(t, id, auto.ID)
+	require.Equal(t, uint64(1), auto.Generation)
+}
+
+func TestNotification_CloseButtonHit(t *testing.T) {
+	n := New()
+	n.SetSize(100, 50)
+	updated, _ := n.Update(ShowMsg{Text: "close", Type: TypeWarning})
+	id := updated.items[0].ID
+	x, y := closeButtonCoords(t, updated, id)
+
+	hitID, ok := updated.CloseButtonHit(x, y)
+	require.True(t, ok)
+	require.Equal(t, id, hitID)
+}
+
+func TestNotification_CloseButtonHitWithWideText(t *testing.T) {
+	n := New()
+	n.SetSize(100, 50)
+	updated, _ := n.Update(ShowMsg{Text: "wide 🚀 漢字", Type: TypeInfo})
+	id := updated.items[0].ID
+	x, y := closeButtonCoords(t, updated, id)
+
+	hitID, ok := updated.CloseButtonHit(x, y)
+	require.True(t, ok)
+	require.Equal(t, id, hitID)
+	plainLine := strings.Split(ansi.Strip(updated.View()), "\n")[1]
+	require.Contains(t, plainLine, closeGlyph)
+}
+
+func TestNotification_HandleClickDismissesOnlyCloseButton(t *testing.T) {
+	n := New()
+	n.SetSize(100, 50)
+	updated, _ := n.Update(ShowMsg{Text: "click", Type: TypeWarning})
+	id := updated.items[0].ID
+	x, y := closeButtonCoords(t, updated, id)
+
+	bodyCmd := updated.HandleClick(x-2, y)
+	require.Nil(t, bodyCmd)
+
+	cmd := updated.HandleClick(x, y)
+	require.NotNil(t, cmd)
+	msg := cmd()
+	dismiss, ok := msg.(DismissMsg)
+	require.True(t, ok)
+	require.Equal(t, id, dismiss.ID)
+
+	updated, _ = updated.Update(dismiss)
+	require.Empty(t, updated.items)
+}
+
+func TestNotification_StackingLayerBasics(t *testing.T) {
+	n := New()
+	n.SetSize(100, 50)
+	updated, _ := n.Update(ShowMsg{Text: "old"})
+	updated, _ = updated.Update(ShowMsg{Text: "new"})
+
+	view := ansi.Strip(updated.View())
+	require.Contains(t, view, "old")
+	require.Contains(t, view, "new")
+	require.Less(t, stringsIndex(t, view, "old"), stringsIndex(t, view, "new"))
+	require.NotNil(t, updated.GetLayer())
+	require.Len(t, updated.itemBounds(), 2)
+	bounds := updated.itemBounds()
+	require.Equal(t, 50-lipgloss.Height(updated.View())-notificationPadding, bounds[0].row)
+	require.Less(t, bounds[0].row, bounds[1].row)
+}
+
+func TestNotification_CloseGlyphAndPaddingRegression(t *testing.T) {
+	n := New()
+	updated, _ := n.Update(ShowMsg{Text: "glyph"})
+	plain := ansi.Strip(updated.View())
+
+	require.Contains(t, plain, closeGlyph)
+	require.NotContains(t, plain, "[x]")
+	require.Equal(t, 3, styles.NotificationStyle.GetPaddingRight())
+	require.Equal(t, 3, styles.NotificationInfoStyle.GetPaddingRight())
+	require.Equal(t, 3, styles.NotificationWarningStyle.GetPaddingRight())
+	require.Equal(t, 3, styles.NotificationErrorStyle.GetPaddingRight())
+}
+
+func TestNotification_WarningsAutoHide(t *testing.T) {
+	t.Cleanup(func(previous time.Duration) func() {
+		timerDuration = 0
+		return func() { timerDuration = previous }
+	}(timerDuration))
+
+	n := New()
+	updated, cmd := n.Update(ShowMsg{Text: "warn", Type: TypeWarning})
+	require.NotNil(t, cmd)
+	require.Len(t, updated.items, 1)
+
+	warnID := updated.items[0].ID
+	msg := cmd()
+	auto, ok := msg.(AutoHideMsg)
+	require.True(t, ok)
+	require.Equal(t, warnID, auto.ID)
+	require.Equal(t, uint64(0), auto.Generation)
+
+	updated, _ = updated.Update(auto)
+	require.Empty(t, updated.items)
+}
+
+func TestNotification_ErrorAutoHides(t *testing.T) {
+	t.Cleanup(func(previous time.Duration) func() {
+		timerDuration = 0
+		return func() { timerDuration = previous }
+	}(timerDuration))
+
+	n := New()
+	updated, cmd := n.Update(ShowMsg{Text: "err", Type: TypeError})
+	require.NotNil(t, cmd)
+	require.Len(t, updated.items, 1)
+
+	errID := updated.items[0].ID
+	msg := cmd()
+	auto, ok := msg.(AutoHideMsg)
+	require.True(t, ok)
+	require.Equal(t, errID, auto.ID)
+	require.Equal(t, uint64(0), auto.Generation)
+
+	updated, _ = updated.Update(auto)
+	require.Empty(t, updated.items)
+}
+
+func TestNotification_ErrorHoverEnterLeaveRestartsTimer(t *testing.T) {
+	t.Cleanup(func(previous time.Duration) func() {
+		timerDuration = 0
+		return func() { timerDuration = previous }
+	}(timerDuration))
+
+	n := New()
+	n.SetSize(100, 50)
+	updated, _ := n.Update(ShowMsg{Text: "err", Type: TypeError})
+	id := updated.items[0].ID
+	row, col := updated.position()
+
+	updated, cmd := updated.HandleMouseMotion(col+1, row+1)
+	require.Nil(t, cmd)
+	require.Equal(t, id, updated.hoveredID)
+	require.Equal(t, uint64(1), updated.items[0].timerGen)
+
+	updated, _ = updated.Update(AutoHideMsg{ID: id, Generation: 0})
+	require.Len(t, updated.items, 1)
+
+	updated, cmd = updated.HandleMouseMotion(0, 0)
+	require.NotNil(t, cmd)
+	require.Zero(t, updated.hoveredID)
+
+	msg := cmd()
+	auto, ok := msg.(AutoHideMsg)
+	require.True(t, ok)
+	require.Equal(t, id, auto.ID)
+	require.Equal(t, uint64(1), auto.Generation)
+}
+
+func TestNotification_ErrorAutodetectAutoHides(t *testing.T) {
+	t.Cleanup(func(previous time.Duration) func() {
+		timerDuration = 0
+		return func() { timerDuration = previous }
+	}(timerDuration))
+
+	n := New()
+	updated, cmd := n.Update(ShowMsg{Text: "operation failed"})
+
+	require.NotNil(t, cmd)
+	require.Equal(t, TypeError, updated.items[0].Type)
+}
+
+func TestNotification_BodyHit(t *testing.T) {
+	n := New()
+	n.SetSize(100, 50)
+	updated, _ := n.Update(ShowMsg{Text: "copy this", Type: TypeInfo})
+	id := updated.items[0].ID
+	bounds := updated.itemBounds()[0]
+
+	hitID, text, ok := updated.BodyHit(bounds.col+1, bounds.row+1)
+	require.True(t, ok)
+	require.Equal(t, id, hitID)
+	require.Equal(t, "copy this", text)
+
+	closeX, closeY := closeButtonCoords(t, updated, id)
+	hitID, text, ok = updated.BodyHit(closeX, closeY)
+	require.False(t, ok)
+	require.Zero(t, hitID)
+	require.Empty(t, text)
+}
+
+func TestNotification_CopyHitRequiresHoveredBody(t *testing.T) {
+	n := New()
+	n.SetSize(120, 50)
+	updated, _ := n.Update(ShowMsg{Text: "copy this", Type: TypeInfo})
+	id := updated.items[0].ID
+	bounds := updated.itemBounds()[0]
+	bodyX, bodyY := bounds.col+1, bounds.row+1
+
+	hitID, text, ok := updated.CopyHit(bodyX, bodyY)
+	require.False(t, ok)
+	require.Zero(t, hitID)
+	require.Empty(t, text)
+
+	updated, _ = updated.HandleMouseMotion(bodyX, bodyY)
+	hitID, text, ok = updated.CopyHit(bodyX, bodyY)
+	require.True(t, ok)
+	require.Equal(t, id, hitID)
+	require.Equal(t, "copy this", text)
+
+	closeX, closeY := closeButtonCoords(t, updated, id)
+	updated, _ = updated.HandleMouseMotion(closeX, closeY)
+	hitID, text, ok = updated.CopyHit(closeX, closeY)
+	require.False(t, ok)
+	require.Zero(t, hitID)
+	require.Empty(t, text)
+}
+
+func TestNotification_HoverAndCopiedLabels(t *testing.T) {
+	n := New()
+	n.SetSize(120, 50)
+	updated, _ := n.Update(ShowMsg{Text: "copyable notification with enough width", Type: TypeInfo})
+	id := updated.items[0].ID
+	bounds := updated.itemBounds()[0]
+
+	updated, _ = updated.HandleMouseMotion(bounds.col+1, bounds.row+1)
+	require.Contains(t, ansi.Strip(updated.View()), hoverLabel)
+
+	updated = updated.MarkCopied(id)
+	require.Contains(t, ansi.Strip(updated.View()), copiedLabel)
+
+	closeX, closeY := closeButtonCoords(t, updated, id)
+	updated, _ = updated.HandleMouseMotion(closeX, closeY)
+	require.Contains(t, ansi.Strip(updated.View()), closeLabel)
+
+	updated, _ = updated.HandleMouseMotion(0, 20)
+	require.NotContains(t, ansi.Strip(updated.View()), copiedLabel)
+}
+
+func TestNotification_HideAllClearsCopiedState(t *testing.T) {
+	n := New()
+	n.SetSize(100, 50)
+	updated, _ := n.Update(ShowMsg{Text: "copy", Type: TypeInfo})
+	id := updated.items[0].ID
+	updated = updated.MarkCopied(id)
+	require.Equal(t, id, updated.copiedID)
+
+	updated, _ = updated.Update(HideMsg{})
+	require.Empty(t, updated.items)
+	require.Zero(t, updated.hoveredID)
+	require.Zero(t, updated.closeHoveredID)
+	require.Zero(t, updated.copiedID)
+}
+
+func closeButtonCoords(t *testing.T, n Manager, id uint64) (int, int) {
+	t.Helper()
+	for _, b := range n.itemBounds() {
+		if b.id != id {
+			continue
+		}
+		return closeButtonPosition(b)
+	}
+	t.Fatalf("notification %d not found", id)
+	return 0, 0
+}
+
+func stringsIndex(t *testing.T, s, substr string) int {
+	t.Helper()
+	idx := strings.Index(s, substr)
+	require.NotEqual(t, -1, idx)
+	return idx
+}
+
+var _ tea.Msg = AutoHideMsg{}

--- a/pkg/tui/notification_clipboard.go
+++ b/pkg/tui/notification_clipboard.go
@@ -1,0 +1,24 @@
+package tui
+
+import (
+	tea "charm.land/bubbletea/v2"
+	"github.com/atotto/clipboard"
+)
+
+// notificationCopiedMsg marks an existing notification as copied after its text
+// has been written to the clipboard.
+type notificationCopiedMsg struct {
+	ID uint64
+}
+
+// copyNotificationToClipboard copies notification text using the same OSC 52 +
+// best-effort platform clipboard pattern as the conversation copy handlers.
+func copyNotificationToClipboard(id uint64, text string) tea.Cmd {
+	return tea.Sequence(
+		tea.SetClipboard(text),
+		func() tea.Msg {
+			_ = clipboard.WriteAll(text)
+			return notificationCopiedMsg{ID: id}
+		},
+	)
+}

--- a/pkg/tui/styles/styles.go
+++ b/pkg/tui/styles/styles.go
@@ -427,22 +427,22 @@ var (
 	NotificationStyle = BaseStyle.
 				Border(lipgloss.RoundedBorder()).
 				BorderForeground(Success).
-				Padding(0, 1)
+				Padding(0, 3, 0, 1)
 
 	NotificationInfoStyle = BaseStyle.
 				Border(lipgloss.RoundedBorder()).
 				BorderForeground(Info).
-				Padding(0, 1)
+				Padding(0, 3, 0, 1)
 
 	NotificationWarningStyle = BaseStyle.
 					Border(lipgloss.RoundedBorder()).
 					BorderForeground(Warning).
-					Padding(0, 1)
+					Padding(0, 3, 0, 1)
 
 	NotificationErrorStyle = BaseStyle.
 				Border(lipgloss.RoundedBorder()).
 				BorderForeground(Error).
-				Padding(0, 1)
+				Padding(0, 3, 0, 1)
 )
 
 // Completion Styles

--- a/pkg/tui/styles/theme.go
+++ b/pkg/tui/styles/theme.go
@@ -1173,22 +1173,22 @@ func rebuildStyles() {
 	NotificationStyle = BaseStyle.
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(Success).
-		Padding(0, 1)
+		Padding(0, 3, 0, 1)
 
 	NotificationInfoStyle = BaseStyle.
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(Info).
-		Padding(0, 1)
+		Padding(0, 3, 0, 1)
 
 	NotificationWarningStyle = BaseStyle.
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(Warning).
-		Padding(0, 1)
+		Padding(0, 3, 0, 1)
 
 	NotificationErrorStyle = BaseStyle.
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(Error).
-		Padding(0, 1)
+		Padding(0, 3, 0, 1)
 
 	// Completion styles
 	CompletionBoxStyle = BaseStyle.

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -726,7 +726,11 @@ func (m *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	// --- Notifications ---
 
-	case notification.ShowMsg, notification.HideMsg:
+	case notificationCopiedMsg:
+		m.notification = m.notification.MarkCopied(msg.ID)
+		return m, nil
+
+	case notification.ShowMsg, notification.HideMsg, notification.DismissMsg, notification.AutoHideMsg:
 		updated, cmd := m.notification.Update(msg)
 		m.notification = updated
 		return m, cmd
@@ -1957,9 +1961,12 @@ func (m *appModel) switchFocus() (tea.Model, tea.Cmd) {
 
 // handleMouseClick routes mouse clicks to the appropriate component based on Y coordinate.
 func (m *appModel) handleMouseClick(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) {
-	// Check if click hits a notification close button
+	// Check if click hits a notification close button before handling body clicks.
 	if cmd := m.notification.HandleClick(msg.X, msg.Y); cmd != nil {
 		return m, cmd
+	}
+	if id, text, ok := m.notification.CopyHit(msg.X, msg.Y); ok {
+		return m, copyNotificationToClipboard(id, text)
 	}
 
 	// Dialogs use full-window coordinates (they're positioned over the entire screen)
@@ -2024,21 +2031,40 @@ func (m *appModel) handleMouseClick(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) 
 
 // handleMouseMotion routes mouse motion events with adjusted coordinates.
 func (m *appModel) handleMouseMotion(msg tea.MouseMotionMsg) (tea.Model, tea.Cmd) {
+	var cmds []tea.Cmd
+	batchWith := func(cmd tea.Cmd) tea.Cmd {
+		if cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+		return tea.Batch(cmds...)
+	}
+
+	if !m.leanMode {
+		updated, cmd := m.notification.HandleMouseMotion(msg.X, msg.Y)
+		m.notification = updated
+		if cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	}
+
 	if m.isDragging {
 		cmd := m.handleEditorResize(msg.Y)
-		return m, cmd
+		return m, batchWith(cmd)
 	}
 
 	// Forward drag motion to tab bar when a tab drag is active.
 	if m.tabBar.IsDragging() {
 		adjustedMsg := msg
 		adjustedMsg.X = msg.X - styles.AppPadding
-		m.tabBar.Update(adjustedMsg)
-		return m, nil
+		if cmd := m.tabBar.Update(adjustedMsg); cmd != nil {
+			return m, batchWith(cmd)
+		}
+		return m, tea.Batch(cmds...)
 	}
 
 	if m.dialogMgr.Open() {
-		return m.forwardDialog(msg)
+		model, cmd := m.forwardDialog(msg)
+		return model, batchWith(cmd)
 	}
 
 	// Update hover state for resize handle
@@ -2046,15 +2072,17 @@ func (m *appModel) handleMouseMotion(msg tea.MouseMotionMsg) (tea.Model, tea.Cmd
 	m.isHoveringHandle = region == regionResizeHandle
 	switch region {
 	case regionContent:
-		return m.forwardChat(msg)
+		model, cmd := m.forwardChat(msg)
+		return model, batchWith(cmd)
 	case regionEditor:
 		adjustedMsg := msg
 		adjustedMsg.X = msg.X - styles.AppPadding
 		adjustedMsg.Y = msg.Y - m.editorTop()
-		return m.forwardEditor(adjustedMsg)
+		model, cmd := m.forwardEditor(adjustedMsg)
+		return model, batchWith(cmd)
 	}
 
-	return m, nil
+	return m, tea.Batch(cmds...)
 }
 
 // handleMouseRelease routes mouse release events with adjusted coordinates.


### PR DESCRIPTION
Misc improvements to the TUI notifications:

- don't auto remove notifications if the mouse is hovering them
- clicking the notification will copy its contents
- use a glyph for the `x` to close, and make it red when hovered
- show action hint text in the top left of the notification border

Screenshots:

<img width="642" height="229" alt="Screenshot From 2026-05-29 14-45-53" src="https://github.com/user-attachments/assets/5e1cda82-0ae8-472c-ba25-9271d52ba6ba" />

---

<img width="642" height="229" alt="Screenshot From 2026-05-29 14-46-25" src="https://github.com/user-attachments/assets/8051f2b5-b189-43a2-9b38-fdd916fddbdd" />


---

<img width="642" height="229" alt="Screenshot From 2026-05-29 14-46-13" src="https://github.com/user-attachments/assets/ffec1158-9615-425d-9413-01c16f088f12" />

---

<img width="642" height="229" alt="Screenshot From 2026-05-29 14-46-18" src="https://github.com/user-attachments/assets/38d43c1a-1470-4bc5-a22b-197c8ab6c15a" />



