### PR TITLE
docs: document --auth-token flag, OAuth callback security note, and TUI notification UX

### DIFF
--- a/docs/features/api-server/index.md
+++ b/docs/features/api-server/index.md
@@ -169,6 +169,7 @@ docker agent serve api <agent-file>|<agents-dir> [flags]
 | Flag               | Default          | Description                                      |
 | ------------------ | ---------------- | ------------------------------------------------ |
 | `-l, --listen`     | `127.0.0.1:8080` | Address to listen on                             |
+| `--auth-token`     | (none)           | Bearer token required for all API requests. Leave empty to disable authentication (safe when listening on loopback interfaces only). Recommended when `--listen` binds to a network-reachable interface. |
 | `-s, --session-db` | `session.db`     | Path to the SQLite session database              |
 | `--pull-interval`  | `0` (disabled)   | Auto-pull OCI reference every N minutes          |
 | `--fake`           | (none)           | Replay AI responses from cassette file (testing) |

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -152,6 +152,7 @@ $ docker agent serve api <agent-file>|<agents-dir>|<registry-ref> [flags]
 | Flag                       | Default            | Description                                                                                                |
 | -------------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------- |
 | `-l, --listen <addr>`      | `127.0.0.1:8080`   | Address to listen on.                                                                                      |
+| `--auth-token <token>`     | (none)             | Bearer token required for all API requests. When set, every request must include `Authorization: Bearer <token>`. Leave empty to disable authentication (safe when listening on loopback interfaces only). |
 | `-s, --session-db <path>`  | `session.db`       | Path to the SQLite session database (relative paths resolve against the working directory).                |
 | `--pull-interval <minutes>`| `0`                | Periodically re-pull OCI/URL references and refresh the agent definition. `0` disables auto-pull.          |
 | `--fake <path>`             | (none)             | Replay AI responses from a cassette file (for testing). Mutually exclusive with `--record`.               |

--- a/docs/features/remote-mcp/index.md
+++ b/docs/features/remote-mcp/index.md
@@ -138,6 +138,13 @@ The client-driven `{access_token, ...}` reply shape is still accepted on the `--
 
 A per-toolset `callbackRedirectURL` (in the YAML) overrides the runtime-wide `--mcp-oauth-redirect-uri` for that toolset.
 
+<div class="callout callout-warning" markdown="1">
+<div class="callout-title">Security note
+</div>
+  <p>The <code>POST /api/mcp-oauth/callback</code> route is open by default (no auth required) when <code>--auth-token</code> is unset. State values are 128-bit opaque tokens, so brute-force is infeasible, but a state value that leaks (e.g. via debug logs or a compromised host) could be exploited by an attacker to inject a code. Set <code>--auth-token</code> when <code>docker agent serve api</code> listens on a network-reachable interface. When set, <code>--auth-token</code> enforces Bearer-token authentication on all API routes including this callback endpoint.</p>
+
+</div>
+
 ## Project Management &amp; Collaboration
 
 | Service    | URL                                | Transport | Description                           |

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -293,3 +293,15 @@ When an agent calls a tool, docker-agent shows a confirmation dialog by default.
   <p>Use <code>--yolo</code> or the <code>/yolo</code> command to auto-approve all tool calls. You can also toggle this mid-session. For aliases, set <code>--yolo</code> when creating the alias: <code>docker agent alias add fast agentcatalog/coder --yolo</code>.</p>
 
 </div>
+
+## Notifications
+
+The TUI displays transient notification banners for agent warnings, errors, and other runtime events. Notifications auto-dismiss after a short delay unless the mouse is hovering over them — hovering pauses the timer so you have time to read the message.
+
+| Interaction | Behaviour |
+| ----------- | --------- |
+| Hover       | Pauses auto-dismiss; the notification stays visible until the mouse moves away |
+| Click       | Copies the notification text to the clipboard |
+| × (close)   | Dismisses immediately; the glyph turns red when hovered |
+
+Hint text in the top-left corner of the notification border shows the available actions at a glance.


### PR DESCRIPTION
## Summary

Catch-up documentation updates for code changes merged in the last 36 hours.

---

## Commits

### `docs: document --auth-token flag and add OAuth callback security note` (refs #2921)

**Files:** `docs/features/api-server/index.md`, `docs/features/cli/index.md`, `docs/features/remote-mcp/index.md`

- Added `--auth-token` to the `docker agent serve api` flags table in both the CLI reference and API server docs.
- Added a security callout in the Remote MCP OAuth section recommending `--auth-token` when `docker agent serve api` listens on a non-localhost interface, explaining the threat model for `POST /api/mcp-oauth/callback`.

### `docs: document TUI notification UX improvements` (refs #2931)

**File:** `docs/features/tui/index.md`

Added a **`## Notifications`** section documenting the updated notification behaviour:
- Notifications auto-dismiss unless the mouse hovers (hover pauses the timer)
- Clicking a notification copies its text to the clipboard
- The × close glyph turns red when hovered
- Hint text in the notification border shows available actions at a glance

---

## PRs covered

| Source PR | Title | Doc impact |
|-----------|-------|------------|
| #2921 | Address review feedback on #2896 | `--auth-token` flag documented in API server + CLI reference; OAuth callback security callout added to Remote MCP docs |
| #2931 | TUI - Improve notifications | New Notifications section in TUI docs |

## PRs with no additional doc gaps

| Source PR | Title | Reason |
|-----------|-------|--------|
| #2928 | feat: add allow/block-list of servers to the mcp_catalog tool | Docs included in the PR itself (`docs/tools/mcp-catalog/index.md`) |
| #2925 | fix(mcpcatalog): tell the model to proceed after enabling an OAuth server | Prompt-only fix, no user-facing feature to document |
| #2930 | docs: update CHANGELOG.md for v1.70.0 | Automated CHANGELOG update |
| #2918, #2926 | chore: bump direct Go dependencies | Dependency bumps, no docs needed |
