### PR TITLE
build: compress linux binary with UPX in builder-linux stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ FROM crazymax/osxcross:15.5-debian AS osxcross
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS builder-base
 COPY --from=xx / /
-RUN apk add --no-cache clang zig
+RUN apk add --no-cache clang zig upx
 WORKDIR /src
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=bind,source=go.mod,target=go.mod \
@@ -37,6 +37,8 @@ RUN --mount=type=cache,target=/root/.cache/go-build,id=go-build-$TARGETPLATFORM 
     xx-go build -trimpath -tags no_audio -ldflags "-s -w -linkmode=external -X 'github.com/docker/docker-agent/pkg/version.Version=$GIT_TAG' -X 'github.com/docker/docker-agent/pkg/version.Commit=$GIT_COMMIT'" -o /binaries/docker-agent-$TARGETOS-$TARGETARCH .
     xx-verify --static /binaries/docker-agent-$TARGETOS-$TARGETARCH
 EOT
+RUN upx /binaries/docker-agent-$TARGETOS-$TARGETARCH && \
+    upx -t /binaries/docker-agent-$TARGETOS-$TARGETARCH
 
 FROM builder-base AS builder-cross
 ARG TARGETPLATFORM


### PR DESCRIPTION
## Summary

- Adds UPX compression to the `builder-linux` stage, reducing the production binary from **~110 MB to ~28.7 MB** (73.8% reduction)
- UPX installed in `builder-base` alongside `clang` and `zig` (all host-arch build tools), so it is cached once and inherited — no per-variant re-fetch
- Compression runs in its own `RUN` layer after the Go build layer for correct BuildKit cache separation
- `upx -t` validates packed binary integrity at build time before the image is finalized
- `builder-cross` (macOS/Windows release binaries) intentionally unchanged — UPX on macOS requires re-signing and triggers AV on Windows

## Test plan

- [x] UPX default compression (level 7) verified: 114,874,072 → 30,089,008 bytes (26.19%) in ~30s
- [x] Compressed binary tested inside Alpine container: `version` and `--help` both work correctly after UPX decompression
- [x] `upx -t` integrity check passes on the packed binary

## Deferred findings (accepted tradeoffs)

- **RSS at runtime**: The binary decompresses to ~110 MB in anonymous memory at startup — on-disk size is 28.7 MB but runtime footprint is unchanged. Containers with memory limits below ~200 MB may OOM during decompression.
- **Startup latency**: ~300–800 ms decompression on cold invocations before the Go runtime initialises. Acceptable for a long-lived interactive agent; noticeable for very short-lived invocations.
- **AV/EDR false positives**: UPX-packed binaries are flagged heuristically by some AV/EDR products. Teams deploying in regulated environments may need to pre-allowlist the binary.
- **Seccomp**: UPX's decompression stub requires `mmap` and `mprotect(PROT_EXEC)` on anonymous mappings. Docker's default seccomp profile allows both; custom hardened profiles may need to be updated.

> *Comment drafted by Claude Code.*