### PR TITLE
feat(mcp): forward embedded resources to model providers

### DIFF
--- a/cmd/wasm/runtime_wasm.go
+++ b/cmd/wasm/runtime_wasm.go
@@ -638,11 +638,15 @@ func (rt *wasmRuntime) processToolCalls(ctx context.Context, calls []tools.ToolC
 			ToolError:    err != nil,
 		})
 
-		resultMessages = append(resultMessages, chat.Message{
+		msg := chat.Message{
 			Role:       chat.MessageRoleTool,
 			ToolCallID: tc.ID,
 			Content:    output,
-		})
+		}
+		if toolResult != nil && (len(toolResult.Images) > 0 || len(toolResult.Documents) > 0) {
+			msg.MultiContent = chat.BuildToolResultMultiContent(output, toolResult.Images, toolResult.Documents)
+		}
+		resultMessages = append(resultMessages, msg)
 	}
 
 	return resultMessages, handoffAgent, nil

--- a/pkg/chat/tool_result.go
+++ b/pkg/chat/tool_result.go
@@ -1,0 +1,66 @@
+package chat
+
+import (
+	"cmp"
+	"encoding/base64"
+	"log/slog"
+
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+// BuildToolResultMultiContent attaches inline media and documents to a tool
+// response as a MultiContent payload that providers can convert to native
+// multimodal tool-result content where supported.
+func BuildToolResultMultiContent(text string, images []tools.MediaContent, documents []tools.DocumentContent) []MessagePart {
+	parts := make([]MessagePart, 0, 1+len(documents)+len(images))
+	parts = append(parts, MessagePart{Type: MessagePartTypeText, Text: text})
+	for _, doc := range documents {
+		part, ok := ToolDocumentPart(doc)
+		if ok {
+			parts = append(parts, part)
+		}
+	}
+	for _, img := range images {
+		parts = append(parts, MessagePart{
+			Type: MessagePartTypeImageURL,
+			ImageURL: &MessageImageURL{
+				URL:    "data:" + img.MimeType + ";base64," + img.Data,
+				Detail: ImageURLDetailAuto,
+			},
+		})
+	}
+	return parts
+}
+
+// ToolDocumentPart converts a tool-returned document payload into a chat
+// document part. It returns false when the payload is empty or malformed.
+func ToolDocumentPart(content tools.DocumentContent) (MessagePart, bool) {
+	doc := Document{
+		Name:     cmp.Or(content.Name, "document"),
+		MimeType: content.MimeType,
+	}
+
+	switch {
+	case content.Text != "":
+		doc.Size = int64(len(content.Text))
+		doc.Source = DocumentSource{InlineText: content.Text}
+		if doc.MimeType == "" {
+			doc.MimeType = "text/plain"
+		}
+	case content.Data != "":
+		data, err := base64.StdEncoding.DecodeString(content.Data)
+		if err != nil {
+			slog.Warn("Dropping tool document with invalid base64 payload", "name", content.Name, "mime", content.MimeType, "error", err)
+			return MessagePart{}, false
+		}
+		doc.Size = int64(len(data))
+		doc.Source = DocumentSource{InlineData: data}
+		if doc.MimeType == "" {
+			doc.MimeType = DetectMimeTypeByContent(data)
+		}
+	default:
+		return MessagePart{}, false
+	}
+
+	return MessagePart{Type: MessagePartTypeDocument, Document: &doc}, true
+}

--- a/pkg/model/provider/anthropic/attachments.go
+++ b/pkg/model/provider/anthropic/attachments.go
@@ -25,6 +25,9 @@ import (
 //   - unsupported / no content → nil (logged as warning)
 func convertDocument(ctx context.Context, doc chat.Document, id modelsdev.ID, store *modelsdev.Store) ([]anthropic.ContentBlockParamUnion, error) {
 	mc := modelinfo.LoadCaps(store, id)
+	if !mc.Supports(doc.MimeType) && modelinfo.IsClaude(ctx, store, id) {
+		mc = modelinfo.CapsWith(true, true)
+	}
 	return convertDocumentWithCaps(ctx, doc, mc)
 }
 

--- a/pkg/model/provider/anthropic/beta_converter.go
+++ b/pkg/model/provider/anthropic/beta_converter.go
@@ -103,14 +103,20 @@ func (c *Client) convertBetaMessages(ctx context.Context, messages []chat.Messag
 			// Collect consecutive tool messages and merge them into a single user message
 			// This is required by Anthropic API: all tool_result blocks for tool_use blocks
 			// from the same assistant message must be in the same user message
-			toolResultBlocks := []anthropic.BetaContentBlockParamUnion{
-				convertBetaToolResultBlock(msg),
+			firstBlock, err := c.convertBetaToolResultBlock(ctx, msg)
+			if err != nil {
+				return nil, err
 			}
+			toolResultBlocks := []anthropic.BetaContentBlockParamUnion{firstBlock}
 
 			// Look ahead for consecutive tool messages and merge them
 			j := i + 1
 			for j < len(messages) && messages[j].Role == chat.MessageRoleTool {
-				toolResultBlocks = append(toolResultBlocks, convertBetaToolResultBlock(&messages[j]))
+				block, err := c.convertBetaToolResultBlock(ctx, &messages[j])
+				if err != nil {
+					return nil, err
+				}
+				toolResultBlocks = append(toolResultBlocks, block)
 				j++
 			}
 
@@ -135,62 +141,111 @@ func (c *Client) convertBetaMessages(ctx context.Context, messages []chat.Messag
 // convertBetaUserMultiContent converts user message multi-content parts to Beta API content blocks.
 // It handles text, images (base64 and URL), and file uploads via the Files API.
 // convertBetaToolResultBlock converts a tool message to a Beta API tool_result block,
-// including any image content from MultiContent.
-func convertBetaToolResultBlock(msg *chat.Message) anthropic.BetaContentBlockParamUnion {
-	if !hasImageMultiContent(msg.MultiContent) {
-		// tool_result must be present for every preceding tool_use; we cannot skip
-		// it. Normalize whitespace-only content to empty string rather than skipping.
-		content := msg.Content
-		if strings.TrimSpace(content) == "" {
-			content = ""
-		}
+// including inline image and document content from MultiContent.
+func (c *Client) convertBetaToolResultBlock(ctx context.Context, msg *chat.Message) (anthropic.BetaContentBlockParamUnion, error) {
+	if !hasRichToolResultMultiContent(msg.MultiContent) {
 		return anthropic.BetaContentBlockParamUnion{
 			OfToolResult: &anthropic.BetaToolResultBlockParam{
 				ToolUseID: msg.ToolCallID,
+				IsError:   anthropic.Bool(msg.IsError),
 				Content: []anthropic.BetaToolResultBlockParamContentUnion{
-					{OfText: &anthropic.BetaTextBlockParam{Text: content}},
+					{OfText: &anthropic.BetaTextBlockParam{Text: toolResultText(msg.Content)}},
 				},
 			},
-		}
+		}, nil
 	}
 
 	var content []anthropic.BetaToolResultBlockParamContentUnion
 	for _, part := range msg.MultiContent {
 		switch part.Type {
 		case chat.MessagePartTypeText:
+			if strings.TrimSpace(part.Text) == "" {
+				continue
+			}
 			content = append(content, anthropic.BetaToolResultBlockParamContentUnion{
 				OfText: &anthropic.BetaTextBlockParam{Text: part.Text},
 			})
 		case chat.MessagePartTypeImageURL:
-			// Note: superseded by MessagePartTypeDocument.
-			if part.ImageURL == nil {
+			content = append(content, betaToolResultImageContent(part)...)
+		case chat.MessagePartTypeDocument:
+			if part.Document == nil {
 				continue
 			}
-			if strings.HasPrefix(part.ImageURL.URL, "data:") {
-				urlParts := strings.SplitN(part.ImageURL.URL, ",", 2)
-				if len(urlParts) == 2 {
-					mediaType := extractMediaType(urlParts[0])
-					content = append(content, anthropic.BetaToolResultBlockParamContentUnion{
-						OfImage: &anthropic.BetaImageBlockParam{
-							Source: anthropic.BetaImageBlockParamSourceUnion{
-								OfBase64: &anthropic.BetaBase64ImageSourceParam{
-									Data:      urlParts[1],
-									MediaType: anthropic.BetaBase64ImageSourceMediaType(mediaType),
-								},
-							},
-						},
-					})
-				}
+			docBlocks, err := c.convertDoc(ctx, *part.Document)
+			if err != nil {
+				return anthropic.BetaContentBlockParamUnion{}, fmt.Errorf("failed to convert tool result document %q: %w", part.Document.Name, err)
 			}
+			content = append(content, stdBlocksToBetaToolResultContent(docBlocks)...)
 		}
+	}
+	if len(content) == 0 {
+		content = append(content, anthropic.BetaToolResultBlockParamContentUnion{
+			OfText: &anthropic.BetaTextBlockParam{Text: toolResultText(msg.Content)},
+		})
 	}
 
 	return anthropic.BetaContentBlockParamUnion{
 		OfToolResult: &anthropic.BetaToolResultBlockParam{
 			ToolUseID: msg.ToolCallID,
 			Content:   content,
+			IsError:   anthropic.Bool(msg.IsError),
 		},
+	}, nil
+}
+
+func betaToolResultImageContent(part chat.MessagePart) []anthropic.BetaToolResultBlockParamContentUnion {
+	if part.ImageURL == nil || !strings.HasPrefix(part.ImageURL.URL, "data:") {
+		return nil
 	}
+	urlParts := strings.SplitN(part.ImageURL.URL, ",", 2)
+	if len(urlParts) != 2 {
+		return nil
+	}
+	mediaType := extractMediaType(urlParts[0])
+	return []anthropic.BetaToolResultBlockParamContentUnion{{
+		OfImage: &anthropic.BetaImageBlockParam{
+			Source: anthropic.BetaImageBlockParamSourceUnion{
+				OfBase64: &anthropic.BetaBase64ImageSourceParam{
+					Data:      urlParts[1],
+					MediaType: anthropic.BetaBase64ImageSourceMediaType(mediaType),
+				},
+			},
+		},
+	}}
+}
+
+func stdBlocksToBetaToolResultContent(blocks []anthropic.ContentBlockParamUnion) []anthropic.BetaToolResultBlockParamContentUnion {
+	out := make([]anthropic.BetaToolResultBlockParamContentUnion, 0, len(blocks))
+	for _, b := range blocks {
+		switch {
+		case b.OfText != nil:
+			out = append(out, anthropic.BetaToolResultBlockParamContentUnion{
+				OfText: &anthropic.BetaTextBlockParam{Text: b.OfText.Text},
+			})
+		case b.OfImage != nil && b.OfImage.Source.OfBase64 != nil:
+			out = append(out, anthropic.BetaToolResultBlockParamContentUnion{
+				OfImage: &anthropic.BetaImageBlockParam{
+					Source: anthropic.BetaImageBlockParamSourceUnion{
+						OfBase64: &anthropic.BetaBase64ImageSourceParam{
+							Data:      b.OfImage.Source.OfBase64.Data,
+							MediaType: anthropic.BetaBase64ImageSourceMediaType(b.OfImage.Source.OfBase64.MediaType),
+						},
+					},
+				},
+			})
+		case b.OfDocument != nil && b.OfDocument.Source.OfBase64 != nil:
+			out = append(out, anthropic.BetaToolResultBlockParamContentUnion{
+				OfDocument: &anthropic.BetaRequestDocumentBlockParam{
+					Source: anthropic.BetaRequestDocumentBlockSourceUnionParam{
+						OfBase64: &anthropic.BetaBase64PDFSourceParam{
+							Data: b.OfDocument.Source.OfBase64.Data,
+						},
+					},
+				},
+			})
+		}
+	}
+	return out
 }
 
 func (c *Client) convertBetaUserMultiContent(ctx context.Context, parts []chat.MessagePart) ([]anthropic.BetaContentBlockParamUnion, error) {

--- a/pkg/model/provider/anthropic/client.go
+++ b/pkg/model/provider/anthropic/client.go
@@ -407,7 +407,10 @@ func (c *Client) convertMessages(ctx context.Context, messages []chat.Message) (
 			var blocks []anthropic.ContentBlockParamUnion
 			j := i
 			for j < len(messages) && messages[j].Role == chat.MessageRoleTool {
-				tr := convertToolResultBlock(&messages[j])
+				tr, err := c.convertToolResultBlock(ctx, &messages[j])
+				if err != nil {
+					return nil, err
+				}
 				blocks = append(blocks, tr)
 				j++
 			}
@@ -433,49 +436,39 @@ func (c *Client) convertMessages(ctx context.Context, messages []chat.Message) (
 }
 
 // convertToolResultBlock converts a tool message to an Anthropic tool_result block.
-// If the message contains image content in MultiContent, the images are included
-// as image blocks within the tool_result.
-func convertToolResultBlock(msg *chat.Message) anthropic.ContentBlockParamUnion {
-	// If there are no images in MultiContent, use the simple text-only format.
-	if !hasImageMultiContent(msg.MultiContent) {
-		// tool_result must be present for every preceding tool_use; we cannot skip
-		// it. Normalize whitespace-only content to empty string rather than skipping.
-		content := msg.Content
-		if strings.TrimSpace(content) == "" {
-			content = ""
-		}
-		return anthropic.NewToolResultBlock(msg.ToolCallID, content, msg.IsError)
+// Inline images and documents are included as native blocks within the tool_result.
+func (c *Client) convertToolResultBlock(ctx context.Context, msg *chat.Message) (anthropic.ContentBlockParamUnion, error) {
+	if !hasRichToolResultMultiContent(msg.MultiContent) {
+		return anthropic.NewToolResultBlock(msg.ToolCallID, toolResultText(msg.Content), msg.IsError), nil
 	}
 
-	// Build content blocks with text + images for the tool result.
 	var content []anthropic.ToolResultBlockParamContentUnion
 	for _, part := range msg.MultiContent {
 		switch part.Type {
 		case chat.MessagePartTypeText:
+			if strings.TrimSpace(part.Text) == "" {
+				continue
+			}
 			content = append(content, anthropic.ToolResultBlockParamContentUnion{
 				OfText: &anthropic.TextBlockParam{Text: part.Text},
 			})
 		case chat.MessagePartTypeImageURL:
-			if part.ImageURL == nil {
+			content = append(content, toolResultImageContent(part)...)
+		case chat.MessagePartTypeDocument:
+			if part.Document == nil {
 				continue
 			}
-			if strings.HasPrefix(part.ImageURL.URL, "data:") {
-				urlParts := strings.SplitN(part.ImageURL.URL, ",", 2)
-				if len(urlParts) == 2 {
-					mediaType := extractMediaType(urlParts[0])
-					content = append(content, anthropic.ToolResultBlockParamContentUnion{
-						OfImage: &anthropic.ImageBlockParam{
-							Source: anthropic.ImageBlockParamSourceUnion{
-								OfBase64: &anthropic.Base64ImageSourceParam{
-									Data:      urlParts[1],
-									MediaType: anthropic.Base64ImageSourceMediaType(mediaType),
-								},
-							},
-						},
-					})
-				}
+			docBlocks, err := c.convertDoc(ctx, *part.Document)
+			if err != nil {
+				return anthropic.ContentBlockParamUnion{}, fmt.Errorf("failed to convert tool result document %q: %w", part.Document.Name, err)
 			}
+			content = append(content, stdBlocksToToolResultContent(docBlocks)...)
 		}
+	}
+	if len(content) == 0 {
+		content = append(content, anthropic.ToolResultBlockParamContentUnion{
+			OfText: &anthropic.TextBlockParam{Text: toolResultText(msg.Content)},
+		})
 	}
 
 	toolBlock := anthropic.ToolResultBlockParam{
@@ -483,14 +476,65 @@ func convertToolResultBlock(msg *chat.Message) anthropic.ContentBlockParamUnion 
 		Content:   content,
 		IsError:   anthropic.Bool(msg.IsError),
 	}
-	return anthropic.ContentBlockParamUnion{OfToolResult: &toolBlock}
+	return anthropic.ContentBlockParamUnion{OfToolResult: &toolBlock}, nil
 }
 
-// hasImageMultiContent returns true if the multi-content parts contain any image content.
-func hasImageMultiContent(parts []chat.MessagePart) bool {
+func toolResultText(text string) string {
+	if strings.TrimSpace(text) == "" {
+		return "(no output)"
+	}
+	return text
+}
+
+func toolResultImageContent(part chat.MessagePart) []anthropic.ToolResultBlockParamContentUnion {
+	if part.ImageURL == nil || !strings.HasPrefix(part.ImageURL.URL, "data:") {
+		return nil
+	}
+	urlParts := strings.SplitN(part.ImageURL.URL, ",", 2)
+	if len(urlParts) != 2 {
+		return nil
+	}
+	mediaType := extractMediaType(urlParts[0])
+	return []anthropic.ToolResultBlockParamContentUnion{{
+		OfImage: &anthropic.ImageBlockParam{
+			Source: anthropic.ImageBlockParamSourceUnion{
+				OfBase64: &anthropic.Base64ImageSourceParam{
+					Data:      urlParts[1],
+					MediaType: anthropic.Base64ImageSourceMediaType(mediaType),
+				},
+			},
+		},
+	}}
+}
+
+func stdBlocksToToolResultContent(blocks []anthropic.ContentBlockParamUnion) []anthropic.ToolResultBlockParamContentUnion {
+	out := make([]anthropic.ToolResultBlockParamContentUnion, 0, len(blocks))
+	for _, block := range blocks {
+		switch {
+		case block.OfText != nil:
+			out = append(out, anthropic.ToolResultBlockParamContentUnion{OfText: block.OfText})
+		case block.OfImage != nil:
+			out = append(out, anthropic.ToolResultBlockParamContentUnion{OfImage: block.OfImage})
+		case block.OfDocument != nil:
+			out = append(out, anthropic.ToolResultBlockParamContentUnion{OfDocument: block.OfDocument})
+		}
+	}
+	return out
+}
+
+// hasRichToolResultMultiContent returns true if multi-content contains blocks
+// that need Anthropic's array-shaped tool_result content.
+func hasRichToolResultMultiContent(parts []chat.MessagePart) bool {
 	for _, part := range parts {
-		if part.Type == chat.MessagePartTypeImageURL && part.ImageURL != nil {
-			return true
+		switch part.Type {
+		case chat.MessagePartTypeImageURL:
+			if part.ImageURL != nil {
+				return true
+			}
+		case chat.MessagePartTypeDocument:
+			if part.Document != nil {
+				return true
+			}
 		}
 	}
 	return false

--- a/pkg/model/provider/anthropic/tool_result_attachments_test.go
+++ b/pkg/model/provider/anthropic/tool_result_attachments_test.go
@@ -1,0 +1,149 @@
+package anthropic
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/model/provider/base"
+	"github.com/docker/docker-agent/pkg/model/provider/options"
+	"github.com/docker/docker-agent/pkg/modelsdev"
+)
+
+func TestConvertToolResultBlockUsesClaudeCapabilityFallback(t *testing.T) {
+	client := testAttachmentClientWithStore(nil)
+	pdf := []byte("%PDF")
+	msg := &chat.Message{
+		Role:       chat.MessageRoleTool,
+		ToolCallID: "toolu_1",
+		Content:    "created report",
+		MultiContent: []chat.MessagePart{
+			{Type: chat.MessagePartTypeText, Text: "created report"},
+			{
+				Type: chat.MessagePartTypeDocument,
+				Document: &chat.Document{
+					Name:     "report.pdf",
+					MimeType: "application/pdf",
+					Source:   chat.DocumentSource{InlineData: pdf},
+				},
+			},
+		},
+	}
+
+	block, err := client.convertToolResultBlock(t.Context(), msg)
+	require.NoError(t, err)
+	require.NotNil(t, block.OfToolResult)
+	require.Len(t, block.OfToolResult.Content, 2)
+	require.NotNil(t, block.OfToolResult.Content[1].OfDocument)
+}
+
+func TestConvertToolResultBlockIncludesDocumentAttachments(t *testing.T) {
+	client := testAttachmentClient()
+	pdf := []byte("%PDF")
+	msg := &chat.Message{
+		Role:       chat.MessageRoleTool,
+		ToolCallID: "toolu_1",
+		Content:    "created report",
+		MultiContent: []chat.MessagePart{
+			{Type: chat.MessagePartTypeText, Text: "created report"},
+			{
+				Type: chat.MessagePartTypeDocument,
+				Document: &chat.Document{
+					Name:     "report.pdf",
+					MimeType: "application/pdf",
+					Source:   chat.DocumentSource{InlineData: pdf},
+				},
+			},
+		},
+	}
+
+	block, err := client.convertToolResultBlock(t.Context(), msg)
+	require.NoError(t, err)
+	require.NotNil(t, block.OfToolResult)
+	require.Len(t, block.OfToolResult.Content, 2)
+	assert.NotNil(t, block.OfToolResult.Content[0].OfText)
+	require.NotNil(t, block.OfToolResult.Content[1].OfDocument)
+	require.NotNil(t, block.OfToolResult.Content[1].OfDocument.Source.OfBase64)
+	assert.Equal(t, base64.StdEncoding.EncodeToString(pdf), block.OfToolResult.Content[1].OfDocument.Source.OfBase64.Data)
+}
+
+func TestConvertToolResultBlockNeverSendsEmptyContent(t *testing.T) {
+	client := testAttachmentClient()
+	msg := &chat.Message{
+		Role:       chat.MessageRoleTool,
+		ToolCallID: "toolu_1",
+		Content:    "   ",
+	}
+
+	block, err := client.convertToolResultBlock(t.Context(), msg)
+	require.NoError(t, err)
+	require.NotNil(t, block.OfToolResult)
+	require.Len(t, block.OfToolResult.Content, 1)
+	require.NotNil(t, block.OfToolResult.Content[0].OfText)
+	assert.Equal(t, "(no output)", block.OfToolResult.Content[0].OfText.Text)
+}
+
+func TestConvertToolResultBlockIncludesImageDocumentAttachments(t *testing.T) {
+	client := testAttachmentClient()
+	image := []byte("PNG")
+	msg := &chat.Message{
+		Role:       chat.MessageRoleTool,
+		ToolCallID: "toolu_1",
+		Content:    "screenshot",
+		MultiContent: []chat.MessagePart{
+			{Type: chat.MessagePartTypeText, Text: "screenshot"},
+			{
+				Type: chat.MessagePartTypeDocument,
+				Document: &chat.Document{
+					Name:     "screenshot.png",
+					MimeType: "image/png",
+					Source:   chat.DocumentSource{InlineData: image},
+				},
+			},
+		},
+	}
+
+	block, err := client.convertToolResultBlock(t.Context(), msg)
+	require.NoError(t, err)
+	require.NotNil(t, block.OfToolResult)
+	require.Len(t, block.OfToolResult.Content, 2)
+	require.NotNil(t, block.OfToolResult.Content[1].OfImage)
+	require.NotNil(t, block.OfToolResult.Content[1].OfImage.Source.OfBase64)
+	assert.Equal(t, base64.StdEncoding.EncodeToString(image), block.OfToolResult.Content[1].OfImage.Source.OfBase64.Data)
+	assert.Equal(t, "image/png", string(block.OfToolResult.Content[1].OfImage.Source.OfBase64.MediaType))
+}
+
+func testAttachmentClient() *Client {
+	store := modelsdev.NewDatabaseStore(&modelsdev.Database{
+		Providers: map[string]modelsdev.Provider{
+			"anthropic": {
+				Models: map[string]modelsdev.Model{
+					"claude-test": {
+						Modalities: modelsdev.Modalities{Input: []string{"text", "image", "pdf"}},
+					},
+				},
+			},
+		},
+	})
+
+	return testAttachmentClientWithStore(store)
+}
+
+func testAttachmentClientWithStore(store *modelsdev.Store) *Client {
+	var modelOptions options.ModelOptions
+	if store != nil {
+		options.WithModelsDevStore(store)(&modelOptions)
+	}
+
+	return &Client{Config: base.Config{
+		ModelConfig: latest.ModelConfig{
+			Provider: "anthropic",
+			Model:    "claude-test",
+		},
+		ModelOptions: modelOptions,
+	}}
+}

--- a/pkg/model/provider/bedrock/convert.go
+++ b/pkg/model/provider/bedrock/convert.go
@@ -72,11 +72,7 @@ func convertMessages(ctx context.Context, messages []chat.Message, id modelsdev.
 					toolResultBlocks = append(toolResultBlocks, &types.ContentBlockMemberToolResult{
 						Value: types.ToolResultBlock{
 							ToolUseId: aws.String(messages[j].ToolCallID),
-							Content: []types.ToolResultContentBlock{
-								&types.ToolResultContentBlockMemberText{
-									Value: messages[j].Content,
-								},
-							},
+							Content:   convertToolResultContent(ctx, &messages[j], id, store),
 						},
 					})
 				}
@@ -155,6 +151,57 @@ func convertUserContent(ctx context.Context, msg *chat.Message, id modelsdev.ID,
 		})
 	}
 
+	return blocks
+}
+
+func convertToolResultContent(ctx context.Context, msg *chat.Message, id modelsdev.ID, store *modelsdev.Store) []types.ToolResultContentBlock {
+	if len(msg.MultiContent) == 0 {
+		return []types.ToolResultContentBlock{&types.ToolResultContentBlockMemberText{Value: msg.Content}}
+	}
+
+	var blocks []types.ToolResultContentBlock
+	for _, part := range msg.MultiContent {
+		switch part.Type {
+		case chat.MessagePartTypeText:
+			blocks = append(blocks, &types.ToolResultContentBlockMemberText{Value: part.Text})
+		case chat.MessagePartTypeImageURL:
+			if part.ImageURL != nil {
+				if imageBlock := convertImageURL(part.ImageURL); imageBlock != nil {
+					if image, ok := imageBlock.(*types.ContentBlockMemberImage); ok {
+						blocks = append(blocks, &types.ToolResultContentBlockMemberImage{Value: image.Value})
+					}
+				}
+			}
+		case chat.MessagePartTypeDocument:
+			if part.Document == nil {
+				continue
+			}
+			docBlocks, err := convertDocument(ctx, *part.Document, id, store)
+			if err != nil {
+				slog.WarnContext(ctx, "failed to convert tool result document attachment", "error", err, "doc", part.Document.Name)
+				continue
+			}
+			blocks = append(blocks, contentBlocksToToolResultBlocks(docBlocks)...)
+		}
+	}
+	if len(blocks) == 0 {
+		blocks = append(blocks, &types.ToolResultContentBlockMemberText{Value: msg.Content})
+	}
+	return blocks
+}
+
+func contentBlocksToToolResultBlocks(contentBlocks []types.ContentBlock) []types.ToolResultContentBlock {
+	blocks := make([]types.ToolResultContentBlock, 0, len(contentBlocks))
+	for _, block := range contentBlocks {
+		switch block := block.(type) {
+		case *types.ContentBlockMemberText:
+			blocks = append(blocks, &types.ToolResultContentBlockMemberText{Value: block.Value})
+		case *types.ContentBlockMemberImage:
+			blocks = append(blocks, &types.ToolResultContentBlockMemberImage{Value: block.Value})
+		case *types.ContentBlockMemberDocument:
+			blocks = append(blocks, &types.ToolResultContentBlockMemberDocument{Value: block.Value})
+		}
+	}
 	return blocks
 }
 

--- a/pkg/model/provider/gemini/client.go
+++ b/pkg/model/provider/gemini/client.go
@@ -210,24 +210,11 @@ func convertMessagesToGemini(ctx context.Context, messages []chat.Message, id mo
 		if msg.Role == chat.MessageRoleTool && msg.ToolCallID != "" {
 			response := map[string]any{"result": msg.Content}
 
-			// Check for image content in MultiContent
-			var imageParts []*genai.FunctionResponsePart
-			for _, mc := range msg.MultiContent {
-				if mc.Type == chat.MessagePartTypeImageURL && mc.ImageURL != nil && strings.HasPrefix(mc.ImageURL.URL, "data:") {
-					urlParts := strings.SplitN(mc.ImageURL.URL, ",", 2)
-					if len(urlParts) == 2 {
-						mimeType := extractMimeType(urlParts[0])
-						data, err := base64.StdEncoding.DecodeString(urlParts[1])
-						if err == nil {
-							imageParts = append(imageParts, genai.NewFunctionResponsePartFromBytes(data, mimeType))
-						}
-					}
-				}
-			}
+			attachmentParts := functionResponsePartsFromMultiContent(ctx, msg.MultiContent, id, store)
 
 			var part *genai.Part
-			if len(imageParts) > 0 {
-				part = genai.NewPartFromFunctionResponseWithParts(msg.ToolCallID, response, imageParts)
+			if len(attachmentParts) > 0 {
+				part = genai.NewPartFromFunctionResponseWithParts(msg.ToolCallID, response, attachmentParts)
 			} else {
 				part = genai.NewPartFromFunctionResponse(msg.ToolCallID, response)
 			}
@@ -269,6 +256,45 @@ func convertMessagesToGemini(ctx context.Context, messages []chat.Message, id mo
 		}
 	}
 	return contents
+}
+
+func functionResponsePartsFromMultiContent(ctx context.Context, multiContent []chat.MessagePart, id modelsdev.ID, store *modelsdev.Store) []*genai.FunctionResponsePart {
+	var parts []*genai.FunctionResponsePart
+	for _, part := range multiContent {
+		switch part.Type {
+		case chat.MessagePartTypeImageURL:
+			if part.ImageURL == nil || !strings.HasPrefix(part.ImageURL.URL, "data:") {
+				continue
+			}
+			urlParts := strings.SplitN(part.ImageURL.URL, ",", 2)
+			if len(urlParts) != 2 {
+				continue
+			}
+			mimeType := extractMimeType(urlParts[0])
+			data, err := base64.StdEncoding.DecodeString(urlParts[1])
+			if err == nil {
+				parts = append(parts, genai.NewFunctionResponsePartFromBytes(data, mimeType))
+			}
+		case chat.MessagePartTypeDocument:
+			if part.Document == nil {
+				continue
+			}
+			docPart, err := convertDocument(ctx, *part.Document, id, store)
+			if err != nil {
+				slog.WarnContext(ctx, "failed to convert tool result document attachment", "error", err, "doc", part.Document.Name)
+				continue
+			}
+			if docPart == nil {
+				continue
+			}
+			if docPart.InlineData != nil {
+				parts = append(parts, genai.NewFunctionResponsePartFromBytes(docPart.InlineData.Data, docPart.InlineData.MIMEType))
+			} else if docPart.Text != "" {
+				parts = append(parts, genai.NewFunctionResponsePartFromBytes([]byte(docPart.Text), part.Document.MimeType))
+			}
+		}
+	}
+	return parts
 }
 
 // messageRoleToGemini converts chat.MessageRole to genai.Role

--- a/pkg/model/provider/oaistream/messages.go
+++ b/pkg/model/provider/oaistream/messages.go
@@ -174,22 +174,33 @@ func convertMessagesWithStore(ctx context.Context, messages []chat.Message, id m
 
 		openaiMessages = append(openaiMessages, openaiMessage)
 
-		// For tool messages with image content, inject a follow-up user message
-		// with the images since OpenAI tool messages only support text.
+		// For tool messages with attachments, inject a follow-up user message
+		// since OpenAI tool messages only support text.
 		if msg.Role == chat.MessageRoleTool && len(msg.MultiContent) > 0 {
-			var imageParts []openai.ChatCompletionContentPartUnionParam
+			var attachmentParts []openai.ChatCompletionContentPartUnionParam
 			for _, part := range msg.MultiContent {
-				if part.Type == chat.MessagePartTypeImageURL && part.ImageURL != nil {
-					imageParts = append(imageParts, openai.ImageContentPart(openai.ChatCompletionContentPartImageImageURLParam{
-						URL:    part.ImageURL.URL,
-						Detail: string(part.ImageURL.Detail),
-					}))
+				switch part.Type {
+				case chat.MessagePartTypeImageURL:
+					if part.ImageURL != nil {
+						attachmentParts = append(attachmentParts, openai.ImageContentPart(openai.ChatCompletionContentPartImageImageURLParam{
+							URL:    part.ImageURL.URL,
+							Detail: string(part.ImageURL.Detail),
+						}))
+					}
+				case chat.MessagePartTypeDocument:
+					if part.Document != nil {
+						docParts, err := convertDocument(ctx, *part.Document, id, store)
+						if err != nil {
+							slog.WarnContext(ctx, "failed to convert tool result document attachment", "error", err, "doc", part.Document.Name)
+							continue
+						}
+						attachmentParts = append(attachmentParts, docParts...)
+					}
 				}
 			}
-			if len(imageParts) > 0 {
-				// Prepend a text label so the model knows these images came from a tool result
-				label := openai.TextContentPart("Attached image(s) from tool result:")
-				allParts := append([]openai.ChatCompletionContentPartUnionParam{label}, imageParts...)
+			if len(attachmentParts) > 0 {
+				label := openai.TextContentPart("Attached content from tool result:")
+				allParts := append([]openai.ChatCompletionContentPartUnionParam{label}, attachmentParts...)
 				openaiMessages = append(openaiMessages, openai.UserMessage(allParts))
 			}
 		}

--- a/pkg/model/provider/openai/attachments.go
+++ b/pkg/model/provider/openai/attachments.go
@@ -22,7 +22,7 @@ import (
 //
 // Routing:
 //   - image/* with InlineData → OfInputImage with a data URI
-//   - application/pdf with InlineData → OfInputFile (base64)
+//   - application/pdf with InlineData → OfInputFile with a data URI
 //   - text MIMEs with InlineText → OfInputText with TXTEnvelope
 //   - unsupported / no content → nil (logged as warning)
 func convertDocumentToResponseInput(ctx context.Context, doc chat.Document, id modelsdev.ID, store *modelsdev.Store) ([]responses.ResponseInputContentUnionParam, error) {
@@ -56,14 +56,13 @@ func convertDocumentToResponseInputWithCaps(ctx context.Context, doc chat.Docume
 		}
 
 		if mime == "application/pdf" {
-			// The Responses API file block expects raw base64-encoded bytes in FileData
-			// (not a data URI). See ResponseInputFileParam.FileData godoc:
-			// "The base64-encoded data of the file to be sent to the model."
-			b64Data := base64.StdEncoding.EncodeToString(doc.Source.InlineData)
+			dataURI := fmt.Sprintf("data:%s;base64,%s",
+				doc.MimeType,
+				base64.StdEncoding.EncodeToString(doc.Source.InlineData))
 			return []responses.ResponseInputContentUnionParam{
 				{
 					OfInputFile: &responses.ResponseInputFileParam{
-						FileData: param.NewOpt(b64Data),
+						FileData: param.NewOpt(dataURI),
 						Filename: param.NewOpt(doc.Name),
 					},
 				},

--- a/pkg/model/provider/openai/attachments_test.go
+++ b/pkg/model/provider/openai/attachments_test.go
@@ -40,6 +40,21 @@ func TestConvertDocumentResponseInput_StrategyB64_Image(t *testing.T) {
 
 // TestConvertDocumentResponseInput_StrategyB64_ImageDropped verifies that an
 // image is dropped for a text-only model.
+func TestConvertDocumentResponseInput_StrategyB64_PDF(t *testing.T) {
+	doc := chat.Document{
+		Name:     "report.pdf",
+		MimeType: "application/pdf",
+		Source:   chat.DocumentSource{InlineData: []byte("%PDF")},
+	}
+
+	parts, err := convertDocumentToResponseInputWithCaps(t.Context(), doc, modelinfo.CapsWith(false, true))
+	require.NoError(t, err)
+	require.Len(t, parts, 1)
+	require.NotNil(t, parts[0].OfInputFile)
+	assert.Equal(t, "report.pdf", parts[0].OfInputFile.Filename.Value)
+	assert.Equal(t, "data:application/pdf;base64,JVBERg==", parts[0].OfInputFile.FileData.Value)
+}
+
 func TestConvertDocumentResponseInput_StrategyB64_ImageDropped(t *testing.T) {
 	doc := chat.Document{
 		Name:     "photo.jpg",

--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -728,35 +728,46 @@ func (c *Client) convertMessagesToResponseInput(ctx context.Context, messages []
 			input = append(input, item)
 		}
 
-		// For tool messages with image content, inject a follow-up user message
-		// with the images since OpenAI function call outputs only support text.
+		// For tool messages with attachments, inject a follow-up user message
+		// since OpenAI function call outputs only support text.
 		if msg.Role == chat.MessageRoleTool && len(msg.MultiContent) > 0 {
-			var imageParts []responses.ResponseInputContentUnionParam
+			var attachmentParts []responses.ResponseInputContentUnionParam
 			for _, part := range msg.MultiContent {
-				if part.Type == chat.MessagePartTypeImageURL && part.ImageURL != nil {
-					detail := responses.ResponseInputImageContentDetailAuto
-					switch part.ImageURL.Detail {
-					case chat.ImageURLDetailHigh:
-						detail = responses.ResponseInputImageContentDetailHigh
-					case chat.ImageURLDetailLow:
-						detail = responses.ResponseInputImageContentDetailLow
+				switch part.Type {
+				case chat.MessagePartTypeImageURL:
+					if part.ImageURL != nil {
+						detail := responses.ResponseInputImageContentDetailAuto
+						switch part.ImageURL.Detail {
+						case chat.ImageURLDetailHigh:
+							detail = responses.ResponseInputImageContentDetailHigh
+						case chat.ImageURLDetailLow:
+							detail = responses.ResponseInputImageContentDetailLow
+						}
+						attachmentParts = append(attachmentParts, responses.ResponseInputContentUnionParam{
+							OfInputImage: &responses.ResponseInputImageParam{
+								ImageURL: param.NewOpt(part.ImageURL.URL),
+								Detail:   responses.ResponseInputImageDetail(detail),
+							},
+						})
 					}
-					imageParts = append(imageParts, responses.ResponseInputContentUnionParam{
-						OfInputImage: &responses.ResponseInputImageParam{
-							ImageURL: param.NewOpt(part.ImageURL.URL),
-							Detail:   responses.ResponseInputImageDetail(detail),
-						},
-					})
+				case chat.MessagePartTypeDocument:
+					if part.Document != nil {
+						docParts, err := convertDocumentToResponseInput(ctx, *part.Document, c.ID(), c.ModelOptions.ModelsDevStore())
+						if err != nil {
+							slog.WarnContext(ctx, "failed to convert tool result document attachment", "error", err, "doc", part.Document.Name)
+							continue
+						}
+						attachmentParts = append(attachmentParts, docParts...)
+					}
 				}
 			}
-			if len(imageParts) > 0 {
-				// Prepend a text label so the model knows these images came from a tool result
+			if len(attachmentParts) > 0 {
 				label := responses.ResponseInputContentUnionParam{
 					OfInputText: &responses.ResponseInputTextParam{
-						Text: "Attached image(s) from tool result:",
+						Text: "Attached content from tool result:",
 					},
 				}
-				allParts := append([]responses.ResponseInputContentUnionParam{label}, imageParts...)
+				allParts := append([]responses.ResponseInputContentUnionParam{label}, attachmentParts...)
 				input = append(input, responses.ResponseInputItemUnionParam{
 					OfInputMessage: &responses.ResponseInputItemMessageParam{
 						Role:    "user",

--- a/pkg/runtime/toolexec/dispatcher.go
+++ b/pkg/runtime/toolexec/dispatcher.go
@@ -710,29 +710,11 @@ func (c *call) recordToolResponse(res *tools.ToolCallResult) {
 		CreatedAt:  time.Now().Format(time.RFC3339),
 	}
 
-	if len(res.Images) > 0 {
-		msg.MultiContent = buildMultiContent(content, res.Images)
+	if len(res.Images) > 0 || len(res.Documents) > 0 {
+		msg.MultiContent = chat.BuildToolResultMultiContent(content, res.Images, res.Documents)
 	}
 
 	c.addMessage(&msg)
-}
-
-// buildMultiContent attaches inline images to a tool response as a
-// MultiContent payload, following the data-URL convention expected by
-// chat clients.
-func buildMultiContent(text string, images []tools.MediaContent) []chat.MessagePart {
-	parts := make([]chat.MessagePart, 0, 1+len(images))
-	parts = append(parts, chat.MessagePart{Type: chat.MessagePartTypeText, Text: text})
-	for _, img := range images {
-		parts = append(parts, chat.MessagePart{
-			Type: chat.MessagePartTypeImageURL,
-			ImageURL: &chat.MessageImageURL{
-				URL:    "data:" + img.MimeType + ";base64," + img.Data,
-				Detail: chat.ImageURLDetailAuto,
-			},
-		})
-	}
-	return parts
 }
 
 // postHook fires the post-tool-use hook. SystemMessage emission is the

--- a/pkg/runtime/toolexec/dispatcher_test.go
+++ b/pkg/runtime/toolexec/dispatcher_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/hooks"
 	"github.com/docker/docker-agent/pkg/runtime/toolexec"
 	"github.com/docker/docker-agent/pkg/session"
@@ -102,6 +103,44 @@ func TestDispatcher_RoutesToToolsetHandler(t *testing.T) {
 	require.Len(t, em.responses, 1)
 	assert.Equal(t, `hello {"x":1}`, em.responses[0].Output)
 	assert.False(t, em.responses[0].IsError)
+}
+
+func TestDispatcher_RecordsDocumentToolResult(t *testing.T) {
+	a := newAgent()
+	sess := session.New()
+	sess.ToolsApproved = true
+
+	tool := tools.Tool{
+		Name: "report",
+		Handler: func(context.Context, tools.ToolCall) (*tools.ToolCallResult, error) {
+			return &tools.ToolCallResult{
+				Output: "created report",
+				Documents: []tools.DocumentContent{{
+					Name:     "report.pdf",
+					URI:      "file:///report.pdf",
+					MimeType: "application/pdf",
+					Data:     "UERG",
+				}},
+			}, nil
+		},
+	}
+
+	d := &toolexec.Dispatcher{AgentFor: func(*session.Session) *agent.Agent { return a }}
+	d.Process(t.Context(), sess, []tools.ToolCall{{
+		ID:       "call_report",
+		Function: tools.FunctionCall{Name: "report", Arguments: `{}`},
+	}}, []tools.Tool{tool}, &captureEmitter{})
+
+	require.Len(t, sess.Messages, 1)
+	msg := sess.Messages[0].Message.Message
+	require.Len(t, msg.MultiContent, 2)
+	assert.Equal(t, chat.MessagePartTypeText, msg.MultiContent[0].Type)
+	assert.Equal(t, "created report", msg.MultiContent[0].Text)
+	require.NotNil(t, msg.MultiContent[1].Document)
+	assert.Equal(t, chat.MessagePartTypeDocument, msg.MultiContent[1].Type)
+	assert.Equal(t, "report.pdf", msg.MultiContent[1].Document.Name)
+	assert.Equal(t, "application/pdf", msg.MultiContent[1].Document.MimeType)
+	assert.Equal(t, []byte("PDF"), msg.MultiContent[1].Document.Source.InlineData)
 }
 
 func TestDispatcher_RoutesToRuntimeHandler(t *testing.T) {

--- a/pkg/session/branch_test.go
+++ b/pkg/session/branch_test.go
@@ -142,10 +142,8 @@ func TestBranchSession(t *testing.T) {
 	})
 
 	t.Run("deep-copies pointer fields in MultiContent", func(t *testing.T) {
-		// Regression test: the previous branch.go cloneChatMessage forgot to
-		// duplicate MessagePart.File, leaving branched sessions sharing the
-		// pointer with the parent. Mutating either side now must NOT affect
-		// the other.
+		// Regression test: MultiContent pointer fields must not be shared
+		// between branched sessions and their parents.
 		parent := &Session{
 			Messages: []Item{NewMessageItem(&Message{
 				Message: chat.Message{
@@ -159,6 +157,14 @@ func TestBranchSession(t *testing.T) {
 							Type: chat.MessagePartTypeFile,
 							File: &chat.MessageFile{Path: "/tmp/parent.txt", MimeType: "text/plain"},
 						},
+						{
+							Type: chat.MessagePartTypeDocument,
+							Document: &chat.Document{
+								Name:     "parent.pdf",
+								MimeType: "application/pdf",
+								Source:   chat.DocumentSource{InlineData: []byte("parent")},
+							},
+						},
 					},
 				},
 			})},
@@ -169,14 +175,18 @@ func TestBranchSession(t *testing.T) {
 		require.Len(t, branched.Messages, 1)
 
 		parts := branched.Messages[0].Message.Message.MultiContent
-		require.Len(t, parts, 2)
+		require.Len(t, parts, 3)
 
 		// Mutate branched copies; parent must be unaffected.
 		parts[0].ImageURL.URL = "http://branched"
 		parts[1].File.Path = "/tmp/branched.txt"
+		parts[2].Document.Name = "branched.pdf"
+		parts[2].Document.Source.InlineData[0] = 'B'
 
 		parentParts := parent.Messages[0].Message.Message.MultiContent
 		assert.Equal(t, "http://parent", parentParts[0].ImageURL.URL, "ImageURL must be deep-copied")
 		assert.Equal(t, "/tmp/parent.txt", parentParts[1].File.Path, "File must be deep-copied")
+		assert.Equal(t, "parent.pdf", parentParts[2].Document.Name, "Document must be deep-copied")
+		assert.Equal(t, []byte("parent"), parentParts[2].Document.Source.InlineData, "Document InlineData must be deep-copied")
 	})
 }

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -374,6 +374,13 @@ func cloneChatMessage(m chat.Message) chat.Message {
 				fileCopy := *part.File
 				part.File = &fileCopy
 			}
+			if part.Document != nil {
+				docCopy := *part.Document
+				if part.Document.Source.InlineData != nil {
+					docCopy.Source.InlineData = slices.Clone(part.Document.Source.InlineData)
+				}
+				part.Document = &docCopy
+			}
 			m.MultiContent[i] = part
 		}
 	}

--- a/pkg/tools/mcp/mcp.go
+++ b/pkg/tools/mcp/mcp.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"net/url"
 	"os"
+	"path"
 	"strings"
 	"sync"
 	"time"
@@ -729,6 +730,7 @@ func isInitNotificationSendError(err error) bool {
 func processMCPContent(toolResult *mcp.CallToolResult) *tools.ToolCallResult {
 	var text strings.Builder
 	var images, audios []tools.MediaContent
+	var documents []tools.DocumentContent
 
 	for _, c := range toolResult.Content {
 		switch c := c.(type) {
@@ -756,9 +758,17 @@ func processMCPContent(toolResult *mcp.CallToolResult) *tools.ToolCallResult {
 				continue
 			}
 			if len(c.Resource.Blob) > 0 {
-				// Binary blobs can't be inlined as text; surface a marker the model can reason about.
-				fmt.Fprintf(&text, "[embedded resource %s (%s, %d bytes)]",
-					c.Resource.URI, c.Resource.MIMEType, len(c.Resource.Blob))
+				switch {
+				case strings.HasPrefix(c.Resource.MIMEType, "image/"), c.Resource.MIMEType == "application/pdf":
+					documents = append(documents, encodeDocument(c.Resource.Blob, c.Resource.MIMEType, c.Resource.URI))
+				case strings.HasPrefix(c.Resource.MIMEType, "text/"):
+					documents = append(documents, encodeTextDocument(string(c.Resource.Blob), c.Resource.MIMEType, c.Resource.URI))
+				case strings.HasPrefix(c.Resource.MIMEType, "audio/"):
+					audios = append(audios, encodeMedia(c.Resource.Blob, c.Resource.MIMEType))
+				default:
+					fmt.Fprintf(&text, "[embedded resource %s (%s, %d bytes)]",
+						c.Resource.URI, c.Resource.MIMEType, len(c.Resource.Blob))
+				}
 			}
 		}
 	}
@@ -768,6 +778,7 @@ func processMCPContent(toolResult *mcp.CallToolResult) *tools.ToolCallResult {
 		IsError:           toolResult.IsError,
 		Images:            images,
 		Audios:            audios,
+		Documents:         documents,
 		StructuredContent: toolResult.StructuredContent,
 	}
 }
@@ -778,6 +789,51 @@ func encodeMedia(data []byte, mimeType string) tools.MediaContent {
 	return tools.MediaContent{
 		Data:     base64.StdEncoding.EncodeToString(data),
 		MimeType: mimeType,
+	}
+}
+
+func encodeDocument(data []byte, mimeType, uri string) tools.DocumentContent {
+	return tools.DocumentContent{
+		Name:     embeddedResourceName(uri, mimeType),
+		URI:      uri,
+		Data:     base64.StdEncoding.EncodeToString(data),
+		MimeType: mimeType,
+	}
+}
+
+func encodeTextDocument(text, mimeType, uri string) tools.DocumentContent {
+	return tools.DocumentContent{
+		Name:     embeddedResourceName(uri, mimeType),
+		URI:      uri,
+		Text:     text,
+		MimeType: mimeType,
+	}
+}
+
+func embeddedResourceName(uri, mimeType string) string {
+	if uri != "" {
+		namePath := uri
+		if parsed, err := url.Parse(uri); err == nil && parsed.Path != "" {
+			namePath = parsed.Path
+		}
+		if base := path.Base(namePath); base != "." && base != "/" && base != "" {
+			return base
+		}
+	}
+
+	switch mimeType {
+	case "application/pdf":
+		return "resource.pdf"
+	case "image/jpeg":
+		return "resource.jpg"
+	case "image/png":
+		return "resource.png"
+	case "image/gif":
+		return "resource.gif"
+	case "image/webp":
+		return "resource.webp"
+	default:
+		return "resource"
 	}
 }
 

--- a/pkg/tools/mcp/mcp_test.go
+++ b/pkg/tools/mcp/mcp_test.go
@@ -328,6 +328,7 @@ func TestProcessMCPContent(t *testing.T) {
 		wantIsError    bool
 		wantImages     []tools.MediaContent
 		wantAudios     []tools.MediaContent
+		wantDocuments  []tools.DocumentContent
 		wantStructured any
 	}{
 		// --- text ---
@@ -438,7 +439,7 @@ func TestProcessMCPContent(t *testing.T) {
 			wantOutput: "downloaded hello world",
 		},
 		{
-			name: "embedded blob resource emits a marker",
+			name: "embedded image resource routes to documents",
 			input: callToolResult(&mcp.EmbeddedResource{
 				Resource: &mcp.ResourceContents{
 					URI:      "file:///image.png",
@@ -446,7 +447,70 @@ func TestProcessMCPContent(t *testing.T) {
 					Blob:     []byte("PNGBYTES"),
 				},
 			}),
-			wantOutput: "[embedded resource file:///image.png (image/png, 8 bytes)]",
+			wantOutput:    "no output",
+			wantDocuments: []tools.DocumentContent{{Name: "image.png", URI: "file:///image.png", Data: "UE5HQllURVM=", MimeType: "image/png"}},
+		},
+		{
+			name: "embedded text blob resource routes to documents",
+			input: callToolResult(&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "file:///notes.md",
+					MIMEType: "text/markdown",
+					Blob:     []byte("# Notes"),
+				},
+			}),
+			wantOutput:    "no output",
+			wantDocuments: []tools.DocumentContent{{Name: "notes.md", URI: "file:///notes.md", Text: "# Notes", MimeType: "text/markdown"}},
+		},
+		{
+			name: "embedded audio resource routes to audios",
+			input: callToolResult(&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "file:///clip.wav",
+					MIMEType: "audio/wav",
+					Blob:     []byte("WAVBYTES"),
+				},
+			}),
+			wantOutput: "no output",
+			wantAudios: []tools.MediaContent{{Data: "V0FWQllURVM=", MimeType: "audio/wav"}},
+		},
+		{
+			name: "text ack and embedded image resource",
+			input: callToolResult(
+				&mcp.TextContent{Text: "here you go"},
+				&mcp.EmbeddedResource{
+					Resource: &mcp.ResourceContents{
+						URI:      "file:///image.jpg",
+						MIMEType: "image/jpeg",
+						Blob:     []byte("JPGBYTES"),
+					},
+				},
+			),
+			wantOutput:    "here you go",
+			wantDocuments: []tools.DocumentContent{{Name: "image.jpg", URI: "file:///image.jpg", Data: "SlBHQllURVM=", MimeType: "image/jpeg"}},
+		},
+		{
+			name: "embedded pdf resource routes to documents",
+			input: callToolResult(&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "file:///doc.pdf",
+					MIMEType: "application/pdf",
+					Blob:     []byte("PDFBYTES"),
+				},
+			}),
+			wantOutput:    "no output",
+			wantDocuments: []tools.DocumentContent{{Name: "doc.pdf", URI: "file:///doc.pdf", Data: "UERGQllURVM=", MimeType: "application/pdf"}},
+		},
+		{
+			name: "embedded unsupported blob still emits a marker",
+			input: callToolResult(&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "file:///archive.zip",
+					MIMEType: "application/zip",
+					Blob:     []byte("ZIPBYTES"),
+				},
+			}),
+			wantOutput: "[embedded resource file:///archive.zip (application/zip, 8 bytes)]",
 		},
 		{
 			name: "embedded resource with nil contents is no-op",
@@ -494,6 +558,11 @@ func TestProcessMCPContent(t *testing.T) {
 				assert.Equal(t, tt.wantAudios, result.Audios)
 			} else {
 				assert.Empty(t, result.Audios)
+			}
+			if tt.wantDocuments != nil {
+				assert.Equal(t, tt.wantDocuments, result.Documents)
+			} else {
+				assert.Empty(t, result.Documents)
 			}
 			assert.Equal(t, tt.wantStructured, result.StructuredContent)
 		})

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -71,6 +71,16 @@ type ImageContent = MediaContent
 // AudioContent is an alias kept for readability at call sites.
 type AudioContent = MediaContent
 
+// DocumentContent represents inline document-like content returned by a tool.
+// Exactly one of Data or Text should be set. Data is base64-encoded.
+type DocumentContent struct {
+	Name     string `json:"name,omitempty"`
+	URI      string `json:"uri,omitempty"`
+	MimeType string `json:"mimeType"`
+	Data     string `json:"data,omitempty"`
+	Text     string `json:"text,omitempty"`
+}
+
 type ToolCallResult struct {
 	Output  string `json:"output"`
 	IsError bool   `json:"isError,omitempty"`
@@ -79,6 +89,8 @@ type ToolCallResult struct {
 	Images []MediaContent `json:"images,omitempty"`
 	// Audios contains optional audio attachments returned by the tool.
 	Audios []MediaContent `json:"audios,omitempty"`
+	// Documents contains optional inline document attachments returned by the tool.
+	Documents []DocumentContent `json:"documents,omitempty"`
 	// StructuredContent holds optional structured output returned by an MCP
 	// tool whose definition includes an OutputSchema. When non-nil it is the
 	// JSON-decoded structured result from the server.

--- a/pkg/tools/tools_test.go
+++ b/pkg/tools/tools_test.go
@@ -175,6 +175,7 @@ func TestToolCallResultWithoutPayload(t *testing.T) {
 		Meta:              "metadata",
 		Images:            []MediaContent{{Data: "image", MimeType: "image/png"}},
 		Audios:            []MediaContent{{Data: "audio", MimeType: "audio/wav"}},
+		Documents:         []DocumentContent{{Name: "report.pdf", MimeType: "application/pdf", Data: "pdf"}},
 		StructuredContent: map[string]any{"key": "value"},
 	}
 
@@ -186,5 +187,6 @@ func TestToolCallResultWithoutPayload(t *testing.T) {
 	assert.Equal(t, "metadata", slim.Meta)
 	assert.Nil(t, slim.Images)
 	assert.Nil(t, slim.Audios)
+	assert.Nil(t, slim.Documents)
 	assert.Nil(t, slim.StructuredContent)
 }


### PR DESCRIPTION
Preserve MCP embedded image, PDF, and text resources as tool-result attachments instead of reducing them to text markers. Convert those attachments into provider-native content blocks for Anthropic, OpenAI, Bedrock, and Gemini, including Anthropic image/document tool_result blocks and OpenAI Responses input_file data URIs. Also ensure tool-result content is never empty and deep-copy document attachments in session branches.