### PR TITLE
docs: document --theme flag for docker agent run

### DIFF
--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -37,6 +37,7 @@ $ docker agent run [config] [message...] [flags]
 | `--dry-run`                             | Initialize the agent without executing anything (useful for validating a config)                                                          |
 | `--remote <addr>`                       | Use a remote runtime at the given address instead of running the agent locally                                                            |
 | `--lean`                                | Use a simplified TUI with minimal chrome                                                                                                  |
+| `--theme <name>`                        | Preselect a TUI theme by name at launch (overrides `settings.theme` in user config; ignored in `--exec` mode). Run `/theme` to browse available names. |
 | `--app-name <name>`                     | Override the application name label shown in the TUI (status bar, window title, "/exit" notifications).                                   |
 | `--sidebar`                             | Control sidebar visibility. Set to `--sidebar=false` to hide the sidebar and disable the Ctrl+B toggle (default: `true`).                 |
 | `--disable-commands <list>`             | Hide and disable specific slash commands in the TUI. Accepts a comma-separated list of command names (leading slash optional, case-insensitive). E.g. `--disable-commands="/cost,/eval,/model"`. |
@@ -82,6 +83,7 @@ $ docker agent run agent.yaml --hook-pre-tool-use "./scripts/validate.sh" --hook
 $ docker agent run agent.yaml "question 1" "question 2" "question 3"
 
 # Customize TUI display
+$ docker agent run agent.yaml --theme dracula
 $ docker agent run agent.yaml --app-name "My Project"
 $ docker agent run agent.yaml --sidebar=false
 $ docker agent run agent.yaml --disable-commands="/cost,/eval,/model"

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -261,6 +261,8 @@ settings:
   theme: my-theme # References ~/.cagent/themes/my-theme.yaml
 ```
 
+**At launch:** Pass `--theme <name>` to `docker agent run` to preselect a theme for that session. This overrides `settings.theme` in your config but is not saved. Invalid theme names print an error at startup listing the available options. Has no effect in `--exec` mode.
+
 **At runtime:** Use the `/theme` command to open the theme picker and select from available themes. Your selection is saved globally in `~/.config/cagent/config.yaml` under `settings.theme` and persists across sessions.
 
 <div class="callout callout-tip" markdown="1">


### PR DESCRIPTION
## Summary

Catch-up documentation update for a code change merged in the last 36 hours.

---

## Commits

### `docs: document --theme flag for docker agent run` (refs #2933)

**Files:** `docs/features/cli/index.md`, `docs/features/tui/index.md`

- Added `--theme <name>` row to the `docker agent run` flags table in the CLI reference, inserted after `--lean` (before `--app-name`). Describes that it preselects a TUI theme by name at launch, overrides `settings.theme` in user config, is ignored in `--exec` mode, and suggests `/theme` to browse available names.
- Added `$ docker agent run agent.yaml --theme dracula` example to the "Customize TUI display" examples block.
- Added an **At launch** bullet to the "Applying Themes" section in the TUI docs, before the existing "At runtime" bullet, describing that `--theme` overrides the config value for the session without saving it, and that invalid names print an error listing available options.

---

## PRs covered

| Source PR | Title | Doc impact |
|-----------|-------|------------|
| #2933 | feat: add --theme flag to preselect TUI theme | `--theme` flag documented in CLI reference and TUI "Applying Themes" section |

## PRs with no additional doc gaps

| Source PR | Title | Reason |
|-----------|-------|--------|
| #2928 | feat: add allow/block-list of servers to the mcp_catalog tool | Docs included in the PR itself (`docs/tools/mcp-catalog/index.md`) |
| #2931 | TUI - Improve notifications | Covered by #2932 |
| #2932 | docs: document --auth-token flag, OAuth callback security note, and TUI notification UX | Docs-only PR |
| #2929 | docs: sync /docs with changes merged 2026-05-28 – 2026-05-29 | Docs-only PR |
| #2927 | docs: sync CLI flags and hook payload docs with recent changes | Docs-only PR |
| #2930, #2919 | docs: update CHANGELOG.md for v1.70.0 / v1.69.0 | Automated CHANGELOG updates |
| #2926, #2918 | chore: bump direct Go dependencies | Dependency bumps, no docs needed |
| #2925 | fix(mcpcatalog): tell the model to proceed after enabling an OAuth server | Prompt-only fix, no user-facing feature to document |
| #2921 | Address review feedback on #2896 | Doc gaps covered by #2929 and #2932 |
| #2920 | fix: rune-safe truncation and dead-code cleanup | Internal only — no user-facing doc changes needed |
| #2917 | feat: add --sidebar flag | Covered by #2927 |
| #2911 | fix(runtime): populate ModelID in after_llm_call hook payload | Covered by #2927 |