### PR TITLE
docs: add --theme launch example to TUI quickstart

### DIFF
--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -30,6 +30,9 @@ $ docker agent run agent.yaml --debug
 # Override the application name shown in the status bar and window title
 $ docker agent run agent.yaml --app-name "My Project"
 
+# Preselect a color theme
+$ docker agent run agent.yaml --theme dracula
+
 # Hide the sidebar (cannot be re-enabled via Ctrl+B)
 $ docker agent run agent.yaml --sidebar=false
 


### PR DESCRIPTION
## Summary

Adds a missing `--theme` launch example to the "Launching the TUI" quickstart code block in `docs/features/tui/index.md`.

The "Applying Themes" section and the CLI reference (`docs/features/cli/index.md`) both correctly document the `--theme` flag (added in #2933 and documented in #2936), but the quickstart block that lists other launch-time flags (`--app-name`, `--sidebar`, `--disable-commands`) omitted `--theme`, leaving the page internally inconsistent.

## Documentation changes

| File | Change |
|------|--------|
| `docs/features/tui/index.md` | Added `--theme dracula` example to the "Launching the TUI" quickstart code block |

## Commits

| Commit | Scope | Source PR |
|--------|-------|-----------|
| `79f16572` | Add `--theme` launch example to TUI quickstart | #2933 |

## PRs audited

| Source PR | Title | Doc status |
|-----------|-------|------------|
| #2933 | feat: add --theme flag to preselect TUI theme | ✅ Gap fixed (this PR) |
| #2932 | docs: document --auth-token flag, OAuth callback security note, and TUI notification UX | ✅ Already accurate and complete |
| #2936 | docs: document --theme flag for docker agent run | ✅ Already accurate and complete |