### PR TITLE
fix: github-copilot Responses API auto-selection and error preservation

### DIFF
--- a/docs/providers/github-copilot/index.md
+++ b/docs/providers/github-copilot/index.md
@@ -97,6 +97,25 @@ models:
 Header names are matched case-insensitively, so `copilot-integration-id`
 works too.
 
+## Chat Completions vs. Responses API
+
+GitHub Copilot proxies OpenAI models behind two endpoints: the legacy
+`/chat/completions` and the newer `/responses`. Newer models (the `gpt-5`
+family, Codex variants, etc.) are only served via `/responses` and reject
+`/chat/completions` with a `400 Bad Request`. docker-agent auto-selects the
+right endpoint per model, so no configuration is needed in the common case.
+
+If you ever need to force one or the other, set `api_type` explicitly:
+
+```yaml
+models:
+  copilot:
+    provider: github-copilot
+    model: gpt-5
+    provider_opts:
+      api_type: openai_responses # or openai_chatcompletions
+```
+
 ## Custom HTTP Headers
 
 `provider_opts.http_headers` is a generic escape hatch that works for any

--- a/examples/github-copilot.yaml
+++ b/examples/github-copilot.yaml
@@ -4,7 +4,12 @@
 # but you can override it (or add any other custom header) via
 # `provider_opts.http_headers`.
 #
+# Newer Copilot models (gpt-5, Codex, ...) are only served via the Responses
+# API; docker-agent auto-selects the right endpoint per model, so no extra
+# config is needed. You can still force it with `provider_opts.api_type`.
+#
 # See https://github.com/docker/docker-agent/issues/2471
+#      https://github.com/docker/docker-agent/issues/2885
 
 agents:
   root:

--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -97,6 +97,11 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 		// required Copilot-Integration-Id) and any provider-specific defaults.
 		clientOptions = append(clientOptions, buildHeaderOptions(cfg)...)
 
+		// Preserve full error details from non-OpenAI providers (e.g. GitHub
+		// Copilot returns a bare "400 Bad Request" whose body explains the
+		// actual cause); without this the SDK discards it.
+		clientOptions = append(clientOptions, option.WithMiddleware(oaistream.ErrorBodyMiddleware()))
+
 		httpClient := httpclient.NewHTTPClient(ctx)
 		clientOptions = append(clientOptions, option.WithHTTPClient(httpClient))
 
@@ -208,10 +213,12 @@ func (c *Client) CreateChatCompletionStream(
 	case "openai_chatcompletions":
 		slog.DebugContext(ctx, "Using Chat Completions API", "api_type", apiType, "model", c.ModelConfig.Model)
 	default:
-		// Auto-detect based on model name for OpenAI provider
-		// Use Responses API for newer models that support it (gpt-4.1+, o-series, gpt-5)
-		if c.ModelConfig.Provider == "openai" && modelinfo.SupportsResponsesAPI(c.ModelConfig.Model) {
-			slog.DebugContext(ctx, "Auto-selecting Responses API", "model", c.ModelConfig.Model)
+		// Auto-detect based on model name. Use the Responses API for newer
+		// models that require it (gpt-4.1+, o-series, gpt-5, Codex). This
+		// applies to both OpenAI and GitHub Copilot, which proxies the same
+		// models and rejects them on /chat/completions with a 400.
+		if autoSelectsResponsesAPI(c.ModelConfig.Provider) && modelinfo.SupportsResponsesAPI(c.ModelConfig.Model) {
+			slog.DebugContext(ctx, "Auto-selecting Responses API", "provider", c.ModelConfig.Provider, "model", c.ModelConfig.Model)
 			return c.CreateResponseStream(ctx, messages, requestTools)
 		}
 	}
@@ -1111,6 +1118,22 @@ func getAPIType(cfg *latest.ModelConfig) string {
 // (defined in the providers: section). Custom providers have api_type set in ProviderOpts.
 func isCustomProvider(cfg *latest.ModelConfig) bool {
 	return getAPIType(cfg) != ""
+}
+
+// autoSelectsResponsesAPI reports whether, absent an explicit api_type, the
+// provider should auto-select the Responses API for models that require it.
+//
+// This covers OpenAI directly and GitHub Copilot, which proxies the same
+// OpenAI models and rejects newer ones (gpt-5, Codex, ...) on the legacy
+// /chat/completions endpoint with a 400. Detection is driven by
+// modelinfo.SupportsResponsesAPI so new models are picked up by naming
+// convention rather than a hardcoded allow-list.
+func autoSelectsResponsesAPI(provider string) bool {
+	switch provider {
+	case "openai", "github-copilot":
+		return true
+	}
+	return false
 }
 
 // noThinkingMinOutputTokens is the minimum output-token budget we enforce for

--- a/pkg/model/provider/openai/copilot_endpoint_test.go
+++ b/pkg/model/provider/openai/copilot_endpoint_test.go
@@ -1,0 +1,218 @@
+package openai
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/environment"
+)
+
+// TestCopilotEndpointSelection verifies that the GitHub Copilot provider
+// auto-selects the Responses API for models that require it (gpt-5, Codex,
+// ...), while keeping older / chat-only models on /chat/completions.
+//
+// GitHub Copilot proxies the same OpenAI models and rejects the newer ones on
+// /chat/completions with a 400 — see
+// https://github.com/docker/docker-agent/issues/2885.
+func TestCopilotEndpointSelection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		provider string
+		model    string
+		wantPath string
+	}{
+		{
+			name:     "copilot gpt-5 routes to responses",
+			provider: "github-copilot",
+			model:    "gpt-5",
+			wantPath: "/responses",
+		},
+		{
+			name:     "copilot codex routes to responses",
+			provider: "github-copilot",
+			model:    "gpt-5.3-codex",
+			wantPath: "/responses",
+		},
+		{
+			name:     "copilot gpt-4o stays on chat completions",
+			provider: "github-copilot",
+			model:    "gpt-4o",
+			wantPath: "/chat/completions",
+		},
+		{
+			name:     "copilot gemini chat model stays on chat completions",
+			provider: "github-copilot",
+			model:    "gemini-3.1-pro-preview",
+			wantPath: "/chat/completions",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				gotPath string
+				mu      sync.Mutex
+			)
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				gotPath = r.URL.Path
+				mu.Unlock()
+				if r.URL.Path == "/responses" {
+					writeResponsesSSEResponse(w)
+				} else {
+					writeSSEResponse(w)
+				}
+			}))
+			defer server.Close()
+
+			cfg := &latest.ModelConfig{
+				Provider: tt.provider,
+				Model:    tt.model,
+				BaseURL:  server.URL,
+				TokenKey: "GITHUB_TOKEN",
+			}
+
+			env := environment.NewMapEnvProvider(map[string]string{
+				"GITHUB_TOKEN": "ghp_secret",
+			})
+
+			client, err := NewClient(t.Context(), cfg, env)
+			require.NoError(t, err)
+
+			stream, err := client.CreateChatCompletionStream(
+				t.Context(),
+				[]chat.Message{{Role: chat.MessageRoleUser, Content: "hi"}},
+				nil,
+			)
+			require.NoError(t, err)
+			defer stream.Close()
+
+			for {
+				if _, err := stream.Recv(); err != nil {
+					break
+				}
+			}
+
+			mu.Lock()
+			defer mu.Unlock()
+			assert.Equal(t, tt.wantPath, gotPath)
+		})
+	}
+}
+
+// TestCopilotExplicitAPITypeWins verifies that an explicit api_type in
+// provider_opts overrides the auto-selection.
+func TestCopilotExplicitAPITypeWins(t *testing.T) {
+	t.Parallel()
+
+	var (
+		gotPath string
+		mu      sync.Mutex
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		gotPath = r.URL.Path
+		mu.Unlock()
+		writeSSEResponse(w)
+	}))
+	defer server.Close()
+
+	// gpt-5 would normally auto-select responses, but the explicit
+	// chat-completions api_type must take precedence.
+	cfg := &latest.ModelConfig{
+		Provider: "github-copilot",
+		Model:    "gpt-5",
+		BaseURL:  server.URL,
+		TokenKey: "GITHUB_TOKEN",
+		ProviderOpts: map[string]any{
+			"api_type": "openai_chatcompletions",
+		},
+	}
+
+	env := environment.NewMapEnvProvider(map[string]string{
+		"GITHUB_TOKEN": "ghp_secret",
+	})
+
+	client, err := NewClient(t.Context(), cfg, env)
+	require.NoError(t, err)
+
+	stream, err := client.CreateChatCompletionStream(
+		t.Context(),
+		[]chat.Message{{Role: chat.MessageRoleUser, Content: "hi"}},
+		nil,
+	)
+	require.NoError(t, err)
+	defer stream.Close()
+
+	for {
+		if _, err := stream.Recv(); err != nil {
+			break
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, "/chat/completions", gotPath)
+}
+
+// TestDirectClientPreservesErrorBody verifies that a non-OpenAI error body
+// (e.g. GitHub Copilot's bare 400) is surfaced to the caller instead of being
+// discarded, so failures are diagnosable. See
+// https://github.com/docker/docker-agent/issues/2885.
+func TestDirectClientPreservesErrorBody(t *testing.T) {
+	t.Parallel()
+
+	const detail = "model is not supported by this endpoint"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(detail))
+	}))
+	defer server.Close()
+
+	cfg := &latest.ModelConfig{
+		Provider: "github-copilot",
+		Model:    "gpt-4o",
+		BaseURL:  server.URL,
+		TokenKey: "GITHUB_TOKEN",
+	}
+
+	env := environment.NewMapEnvProvider(map[string]string{
+		"GITHUB_TOKEN": "ghp_secret",
+	})
+
+	client, err := NewClient(t.Context(), cfg, env)
+	require.NoError(t, err)
+
+	stream, err := client.CreateChatCompletionStream(
+		t.Context(),
+		[]chat.Message{{Role: chat.MessageRoleUser, Content: "hi"}},
+		nil,
+	)
+	require.NoError(t, err)
+	defer stream.Close()
+
+	var streamErr error
+	for {
+		if _, err := stream.Recv(); err != nil {
+			streamErr = err
+			break
+		}
+	}
+
+	require.Error(t, streamErr)
+	assert.Contains(t, streamErr.Error(), detail, "the underlying provider error body must be preserved")
+}


### PR DESCRIPTION
GitHub Copilot returns HTTP 400 Bad Request when newer models like gpt-5 and Codex are sent to the legacy `/chat/completions` endpoint, since Copilot proxies the same OpenAI models but has a different set of supported endpoints. This change extends the Responses API auto-selection logic to the github-copilot provider so that models are routed to the correct endpoint based on their capabilities, not a hardcoded allow-list.

The fix extends the OpenAI client's endpoint auto-selection to the github-copilot provider, driven by `modelinfo.SupportsResponsesAPI` so new models are picked up by naming convention. It also wires `oaistream.ErrorBodyMiddleware` into the direct OpenAI client path to preserve provider error bodies—like Copilot's bare "400 Bad Request"—instead of discarding them, so users see meaningful error messages.

Comprehensive tests verify endpoint selection for different model families, explicit `api_type` override behavior, and error-body preservation. This relates to the earlier Copilot header fix #2471.

Fixes #2885