### PR TITLE
feat(config): accept ${env.X} in path fields (steps 2-4 of #2615)

### DIFF
--- a/docs/configuration/agents/index.md
+++ b/docs/configuration/agents/index.md
@@ -305,7 +305,7 @@ Commands use JavaScript template literal syntax (`${env.VAR}`) for environment v
 
 The same syntax is also expanded in agent and toolset instructions: `agents.<name>.instruction` and `toolsets[*].instruction` support `${env.X}` placeholders (with optional `||` defaults and ternary expressions). `agents.<name>.description` and `agents.<name>.welcome_message` also support it.
 
-Note that path-like fields (`working_dir`, `path`) use a different, shell-style syntax (`$VAR`, `${VAR}`, `~`) and do **not** recognize `${env.X}`. See [Variable Expansion in Config Fields]({{ '/configuration/overview/#variable-expansion-in-config-fields' | relative_url }}) for the full table.
+Note that path-like fields (`working_dir`, `path`) primarily use a shell-style syntax (`$VAR`, `${VAR}`, `~`), and also accept `${env.X}` as an alias (though not richer JS expressions). See [Variable Expansion in Config Fields]({{ '/configuration/overview/#variable-expansion-in-config-fields' | relative_url }}) for the full table.
 
 ## Complete Example
 

--- a/docs/configuration/overview/index.md
+++ b/docs/configuration/overview/index.md
@@ -241,13 +241,13 @@ Undefined variables expand to the empty string.
 
 ### Shell-style — `$VAR`, `${VAR}`, `~`
 
-Used only for filesystem paths. Backed by `os.ExpandEnv` plus tilde expansion against the current user's home directory.
+Used for filesystem paths. Backed by `os.ExpandEnv` plus tilde expansion against the current user's home directory.
 
 Applies to:
 
 - `agents.<name>.toolsets[*].working_dir` (MCP, LSP)
 - `agents.<name>.toolsets[*].path` (memory, tasks)
-- `agents.<name>.toolsets[*].env` values (MCP, shell, script, LSP) — these go through `os.Expand`, not the JS evaluator, so `${env.X}` is **not** recognized here either.
+- `agents.<name>.toolsets[*].env` values (MCP, shell, script, LSP) — these go through `os.Expand`, not the JS evaluator, so `${env.X}` is **not** recognized here.
 - The `~` prefix is also accepted in any path-like field documented as such.
 
 ```yaml
@@ -261,7 +261,7 @@ agents:
         working_dir: "$HOME/work"
 ```
 
-The `${env.VAR}` form is **not** recognized in these path fields today.
+The `working_dir` and `path` fields additionally accept the `${env.VAR}` form as an alias for `${VAR}`, so the JS-style syntax works there too. Richer JS expressions (e.g. `${env.VAR || 'default'}`) are still **not** evaluated in path fields. The `env` values fields remain shell-only.
 
 ### Quick reference
 
@@ -271,7 +271,7 @@ The `${env.VAR}` form is **not** recognized in these path fields today.
 | `instruction` (agent and toolset)             |     ✓      |       ✗       |  ✗  |
 | `commands.*`                                  |     ✓      |       ✗       |  ✗  |
 | `headers`, `remote.headers`, `api_config.headers` |     ✓      |       ✗       |  ✗  |
-| `working_dir`, `path`                         |     ✗      |       ✓       |  ✓  |
+| `working_dir`, `path`                         |     ✓      |       ✓       |  ✓  |
 | `env` values                                  |     ✗      |       ✓       |  ✗  |
 
 When in doubt, prefer `${env.X}` for prompts and headers, and `${X}` (or `$X`) for paths.

--- a/pkg/config/expansion_warnings.go
+++ b/pkg/config/expansion_warnings.go
@@ -27,6 +27,10 @@ var jsEnvRef = regexp.MustCompile(`\$\{\s*env\.[A-Za-z_][A-Za-z0-9_]*`)
 // trailing the identifier. Used to flag occurrences in shell-style fields,
 // where ScriptShellToolConfig and other path-like targets only call
 // os.Expand (no JS evaluator), so the literal `${env.X}` is passed through.
+//
+// Kept in sync with jsEnvRef in pkg/path/expand.go, which uses the same
+// pattern to normalize `${env.X}` to `${X}` in path fields. The pattern is
+// duplicated rather than shared to avoid an import cycle.
 var jsEnvRefStrict = regexp.MustCompile(`\$\{\s*env\.([A-Za-z_][A-Za-z0-9_]*)\s*\}`)
 
 // warnExpansionMismatches scans a loaded config for fields whose contents use

--- a/pkg/config/expansion_warnings.go
+++ b/pkg/config/expansion_warnings.go
@@ -35,8 +35,11 @@ var jsEnvRefStrict = regexp.MustCompile(`\$\{\s*env\.([A-Za-z_][A-Za-z0-9_]*)\s*
 //
 //   - JS template literals (`${env.X}`) for prompt/instruction/header/command
 //     fields rendered through pkg/js.
-//   - Shell-style (`$VAR` / `${VAR}` / `~`) for path fields and toolset env
-//     values, processed by os.Expand and pkg/path.
+//   - Shell-style (`$VAR` / `${VAR}` / `~`) for toolset env values and the
+//     ScriptShell/hook fields that are forwarded verbatim to exec.Cmd.
+//
+// Toolset path fields (working_dir, path) are not checked here: they flow
+// through pkg/path.ExpandPath, which now accepts both syntaxes (#2615).
 //
 // Mixing them up currently fails silently; we emit warnings to make the
 // problem visible without changing runtime behavior.
@@ -82,13 +85,11 @@ func warnExpansionMismatches(ctx context.Context, logger *slog.Logger, cfg *late
 
 			// Toolset env values are expanded with os.Expand (shell-style),
 			// not the JS evaluator, so a stray `${env.X}` is the silent-failure
-			// case here.
+			// case here. working_dir and path are not checked: they flow through
+			// pkg/path.ExpandPath, which accepts both ${env.X} and ${X} (#2615).
 			for k, v := range t.Env {
 				warnPathField(ctx, logger, loc, "env."+k, v)
 			}
-
-			warnPathField(ctx, logger, loc, "working_dir", t.WorkingDir)
-			warnPathField(ctx, logger, loc, "path", t.Path)
 
 			for name, sh := range t.Shell {
 				shellLoc := loc + " shell[" + name + "]"

--- a/pkg/config/expansion_warnings_test.go
+++ b/pkg/config/expansion_warnings_test.go
@@ -66,9 +66,11 @@ func TestWarnExpansionMismatches_LowerCaseShellIdent(t *testing.T) {
 	assert.Contains(t, out, "shell-style")
 }
 
-func TestWarnExpansionMismatches_JSEnvInPathField(t *testing.T) {
+func TestWarnExpansionMismatches_JSEnvInPathFieldNoLongerWarns(t *testing.T) {
 	t.Parallel()
 
+	// working_dir and path flow through pkg/path.ExpandPath, which now accepts
+	// ${env.X}, so these must not warn anymore (#2615).
 	cfg := &latest.Config{
 		Agents: []latest.AgentConfig{{
 			Name: "root",
@@ -87,10 +89,32 @@ func TestWarnExpansionMismatches_JSEnvInPathField(t *testing.T) {
 		warnExpansionMismatches(ctx, logger, cfg)
 	})
 
+	assert.NotContains(t, out, "WARN")
+}
+
+func TestWarnExpansionMismatches_JSEnvInToolsetEnv(t *testing.T) {
+	t.Parallel()
+
+	// Toolset env values are still expanded with os.Expand, so ${env.X} there
+	// remains a silent no-op we must warn about.
+	cfg := &latest.Config{
+		Agents: []latest.AgentConfig{{
+			Name: "root",
+			Toolsets: []latest.Toolset{{
+				Type:    "mcp",
+				Command: "x",
+				Env: map[string]string{
+					"MEM_DIR": "${env.MEM_DIR}/db",
+				},
+			}},
+		}},
+	}
+
+	out := captureWarnings(t, func(ctx context.Context, logger *slog.Logger) {
+		warnExpansionMismatches(ctx, logger, cfg)
+	})
+
 	assert.Contains(t, out, "JS-style")
-	assert.Contains(t, out, "working_dir")
-	assert.Contains(t, out, "path")
-	assert.Contains(t, out, "HOME")
 	assert.Contains(t, out, "MEM_DIR")
 }
 
@@ -102,11 +126,15 @@ func TestWarnExpansionMismatches_DoesNotLeakValueInPathField(t *testing.T) {
 		Agents: []latest.AgentConfig{{
 			Name: "root",
 			Toolsets: []latest.Toolset{{
-				Type: "memory",
+				Type:    "mcp",
+				Command: "x",
 				// Realistic shape: secret prefix followed by an unsupported
-				// JS-style expansion. We must surface the variable name so
-				// users can fix the typo, but we must not echo the secret.
-				Path: secretToken + "/${env.MEM_DIR}/db",
+				// JS-style expansion in a shell-expanded env value. We must
+				// surface the variable name so users can fix the typo, but we
+				// must not echo the secret.
+				Env: map[string]string{
+					"TOKEN": secretToken + "/${env.MEM_DIR}/db",
+				},
 			}},
 		}},
 	}

--- a/pkg/path/expand.go
+++ b/pkg/path/expand.go
@@ -13,6 +13,11 @@ import (
 // Only the plain `${env.VAR}` reference is recognized; richer JS expressions
 // such as `${env.VAR || 'default'}` are not evaluated in path fields (that
 // would require the goja engine, which pkg/path cannot import).
+//
+// Kept in sync with jsEnvRefStrict in pkg/config/expansion_warnings.go: that
+// helper warns about the same `${env.VAR}` form in fields that, unlike paths,
+// cannot resolve it. The pattern is duplicated rather than shared to avoid an
+// import cycle (pkg/environment already imports pkg/path).
 var jsEnvRef = regexp.MustCompile(`\$\{\s*env\.([A-Za-z_][A-Za-z0-9_]*)\s*\}`)
 
 // ExpandPath expands shell-like patterns in a file path:

--- a/pkg/path/expand.go
+++ b/pkg/path/expand.go
@@ -1,14 +1,32 @@
 package path
 
-import "os"
+import (
+	"os"
+	"regexp"
+)
+
+// jsEnvRef matches the JS-template form `${env.VAR}` (optional surrounding
+// whitespace). Path fields historically only understood shell-style
+// expansion via os.ExpandEnv, so the JS form was passed through as a literal.
+// We normalize it to `${VAR}` so both syntaxes resolve identically here.
+//
+// Only the plain `${env.VAR}` reference is recognized; richer JS expressions
+// such as `${env.VAR || 'default'}` are not evaluated in path fields (that
+// would require the goja engine, which pkg/path cannot import).
+var jsEnvRef = regexp.MustCompile(`\$\{\s*env\.([A-Za-z_][A-Za-z0-9_]*)\s*\}`)
 
 // ExpandPath expands shell-like patterns in a file path:
 //   - ~ or ~/ at the start is replaced with the user's home directory
 //   - Environment variables like ${HOME} or $HOME are expanded
+//   - The JS-template form ${env.HOME} is accepted as an alias for ${HOME}
 func ExpandPath(p string) string {
 	if p == "" {
 		return p
 	}
+
+	// Normalize ${env.VAR} to ${VAR} so the JS-template syntax used elsewhere
+	// in the config also works in path fields (issue #2615).
+	p = jsEnvRef.ReplaceAllString(p, "${$1}")
 
 	// Expand environment variables
 	p = os.ExpandEnv(p)

--- a/pkg/path/expand_test.go
+++ b/pkg/path/expand_test.go
@@ -60,6 +60,40 @@ func TestExpandPath(t *testing.T) {
 			envSetup: map[string]string{"MY_TEST_SUBDIR": "data"},
 			expected: filepath.Join(home, "data", "memory.db"),
 		},
+		{
+			name:     "js env ref",
+			input:    "${env.HOME}/.data/memory.db",
+			expected: filepath.Join(home, ".data", "memory.db"),
+		},
+		{
+			name:     "js env ref custom var",
+			input:    "${env.MY_TEST_DATA_DIR}/memory.db",
+			envSetup: map[string]string{"MY_TEST_DATA_DIR": "/tmp/testdata"},
+			expected: "/tmp/testdata/memory.db",
+		},
+		{
+			name:     "js env ref with surrounding whitespace",
+			input:    "${ env.MY_TEST_DATA_DIR }/memory.db",
+			envSetup: map[string]string{"MY_TEST_DATA_DIR": "/tmp/testdata"},
+			expected: "/tmp/testdata/memory.db",
+		},
+		{
+			name:     "tilde and js env ref combined",
+			input:    "~/${env.MY_TEST_SUBDIR}/memory.db",
+			envSetup: map[string]string{"MY_TEST_SUBDIR": "data"},
+			expected: filepath.Join(home, "data", "memory.db"),
+		},
+		{
+			name:     "shell and js env refs mixed",
+			input:    "${MY_TEST_DATA_DIR}/${env.MY_TEST_SUBDIR}/memory.db",
+			envSetup: map[string]string{"MY_TEST_DATA_DIR": "/tmp/testdata", "MY_TEST_SUBDIR": "data"},
+			expected: "/tmp/testdata/data/memory.db",
+		},
+		{
+			name:     "undefined js env ref expands to empty",
+			input:    "/base/${env.MY_TEST_UNDEFINED}/memory.db",
+			expected: "/base//memory.db",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
docker-agent has two incompatible environment variable expansion syntaxes: JavaScript template literals (`${env.X}`) for prompt, header, and command fields, and shell-style (`$VAR`, `${VAR}`, `~`) for path fields. Using the wrong syntax in a path field was silently ignored, tracked in #2615.

This PR makes path fields accept both syntaxes. `pkg/path.ExpandPath` now normalizes the JavaScript form `${env.VAR}` to `${VAR}` before calling `os.ExpandEnv`, so toolset `working_dir`, path fields (memory and tasks path, mcp and lsp `working_dir`), and related fields accept either syntax. The change is fully backward-compatible — existing `$VAR`/`${VAR}`/`~` configurations are unchanged.

Only plain `${env.VAR}` references are supported in paths; richer expressions like `${env.X || 'default'}` are not evaluated (would require importing the goja engine, creating a circular dependency). Resolution uses the OS environment, matching the existing `${X}` behavior. The now-obsolete mismatch warnings for `working_dir` and path fields have been removed from `pkg/config/expansion_warnings.go`. Warnings remain for truly shell-only fields: toolset env values, `ScriptShell` `working_dir`/env, and hook `working_dir`/env.

This is a partial fix for #2615; a follow-up will address the remaining shell-only fields in step 5. Documentation has been updated with a new variable-expansion matrix and cross-reference comments on the duplicated regex.

Refs #2615