### PR TITLE
feat: support inline skills in agent YAML config

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -706,7 +706,7 @@
           "description": "Optional response cache: when the same user question is asked again, replay the previous answer instead of calling the model."
         },
         "skills": {
-          "description": "Enable skills discovery for this agent. Set to true to load all discovered skills from local filesystem sources; false disables skills. A list can mix sources (\"local\" or an HTTP/HTTPS URL) and/or skill names to include. If only names are given, local sources are loaded and filtered to just those skills.",
+          "description": "Enable skills discovery for this agent. Set to true to load all discovered skills from local filesystem sources; false disables skills. A list can mix sources (\"local\" or an HTTP/HTTPS URL), skill names to include, and inline skill definitions (objects). If only names are given, local sources are loaded and filtered to just those skills.",
           "oneOf": [
             {
               "type": "boolean",
@@ -714,9 +714,16 @@
             },
             {
               "type": "array",
-              "description": "List combining skill sources and/or skill names to include. Items equal to \"local\" or starting with http:// or https:// are treated as sources; any other string is treated as a skill name filter.",
+              "description": "List combining skill sources, skill names to include, and/or inline skill definitions. String items equal to \"local\" or starting with http:// or https:// are treated as sources; any other string is treated as a skill name filter; object items are inline skill definitions.",
               "items": {
-                "type": "string"
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/definitions/InlineSkill"
+                  }
+                ]
               },
               "examples": [
                 [
@@ -739,6 +746,48 @@
           ]
         }
       },
+      "additionalProperties": false
+    },
+    "InlineSkill": {
+      "type": "object",
+      "description": "A skill defined directly in the agent config instead of a SKILL.md file or remote URL. Supports the subset of the skill format that can be expressed in YAML.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Skill identifier used by read_skill / run_skill and the /<name> slash command."
+        },
+        "description": {
+          "type": "string",
+          "description": "Short description injected into the system prompt so the model knows when the skill applies."
+        },
+        "instructions": {
+          "type": "string",
+          "description": "The skill body (equivalent to the Markdown content below the SKILL.md frontmatter)."
+        },
+        "context": {
+          "type": "string",
+          "enum": [
+            "fork"
+          ],
+          "description": "When set to \"fork\", the skill runs as an isolated sub-agent (exposed via run_skill) instead of inlining into the conversation."
+        },
+        "model": {
+          "type": "string",
+          "description": "Optional model override applied while a fork-mode skill runs. Ignored for non-fork skills."
+        },
+        "allowed_tools": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Tools the skill expects to use (mirrors the SKILL.md allowed-tools field)."
+        }
+      },
+      "required": [
+        "name",
+        "description",
+        "instructions"
+      ],
       "additionalProperties": false
     },
     "CommandConfig": {

--- a/docs/features/skills/index.md
+++ b/docs/features/skills/index.md
@@ -68,6 +68,57 @@ agents:
 
 A name that doesn't match any discovered skill is logged as a warning at startup but is otherwise ignored.
 
+## Inline Skills
+
+Instead of (or alongside) loading skills from files and URLs, you can define skills directly in the agent config. An inline skill is a mapping item in the `skills` list, freely mixed with the string items above:
+
+```yaml
+agents:
+  root:
+    model: openai/gpt-4o
+    instruction: You are a helpful assistant.
+    skills:
+      - name: changelog
+        description: Write a concise changelog entry from a diff or description.
+        instructions: |
+          Produce a single changelog entry in Keep a Changelog style.
+          Pick the right category (Added, Changed, Fixed, Removed) and write
+          one imperative sentence summarising the user-visible change.
+
+      # A fork-mode inline skill runs in an isolated sub-agent.
+      - name: triage
+        description: Triage a bug report in an isolated context.
+        context: fork
+        instructions: |
+          Restate the problem, list likely root causes most-probable-first,
+          and propose the smallest reproduction and next concrete action.
+
+      # Inline skills mix freely with sources and name filters.
+      - local
+    toolsets:
+      - type: filesystem
+```
+
+Inline skills carry their body in the config itself, so they need no `SKILL.md` file and require no filesystem source. They are **always exposed** — the name filter only applies to file- and URL-based skills. Because inline skills travel inside the agent YAML, they also work in `--sandbox` mode without any kit staging, and they can be shared with the agent via `share push`.
+
+### Inline Skill Fields
+
+| Field           | Required | Description                                                                |
+| --------------- | -------- | -------------------------------------------------------------------------- |
+| `name`          | Yes      | Skill identifier used by `read_skill` / `run_skill` and the `/<name>` command |
+| `description`   | Yes      | Short description shown to the agent for skill matching                    |
+| `instructions`  | Yes      | The skill body (what a `SKILL.md` would contain below its frontmatter)     |
+| `context`       | No       | Set to `fork` to run the skill as an isolated sub-agent                    |
+| `model`         | No       | Override the model used while running a fork-mode skill                    |
+| `allowed_tools` | No       | Tools the skill expects to use                                             |
+
+<div class="callout callout-info" markdown="1">
+<div class="callout-title">Inline vs. file-based skills
+</div>
+  <p>Inline skills support the subset of the SKILL.md format that fits in YAML. They cannot bundle supporting files (no <code>read_skill_file</code>) or use <code>!`command`</code> expansion. For skills that need bundled resources or executable helpers, use a <code>SKILL.md</code> directory instead.</p>
+
+</div>
+
 ## SKILL.md Format
 
 <!-- yaml-lint:skip -->

--- a/examples/skills_inline.yaml
+++ b/examples/skills_inline.yaml
@@ -1,0 +1,50 @@
+#!yaml
+# Inline skills example.
+#
+# Besides loading skills from the local filesystem or remote URLs, the `skills`
+# field can also define skills directly in the agent config. An inline skill is
+# a mapping (object) item in the `skills` list, freely mixed with string items
+# (sources and name filters).
+#
+# Inline skills support the subset of the SKILL.md format that fits in YAML:
+#   - name         (required) identifier used by read_skill / the /<name> command
+#   - description  (required) shown to the model so it knows when the skill applies
+#   - instructions (required) the skill body (what a SKILL.md would contain)
+#   - context      optional; set to "fork" to run the skill as an isolated sub-agent
+#   - model        optional; model override for fork-mode skills
+#   - allowed_tools optional; tools the skill expects to use
+#
+# Inline skills are always exposed and are never affected by name filters.
+agents:
+  root:
+    model: openai/gpt-4o-mini
+    description: An agent that demonstrates inline skill definitions.
+    instruction: |
+      You are a helpful assistant. Use the available skills when the user's
+      request matches one.
+    skills:
+      # A regular, inlined skill: its body is injected when the model reads it.
+      - name: changelog
+        description: Write a concise, well-structured changelog entry from a diff or description.
+        instructions: |
+          Produce a single changelog entry in Keep a Changelog style.
+
+          1. Pick the right category: Added, Changed, Fixed, Removed.
+          2. Write one imperative sentence summarising the user-visible change.
+          3. Avoid implementation detail; focus on what changed for users.
+
+      # A fork-mode skill: runs in an isolated sub-session via run_skill.
+      - name: triage
+        description: Triage a bug report and propose next steps in an isolated context.
+        context: fork
+        instructions: |
+          You are triaging a bug report.
+
+          - Restate the problem in one sentence.
+          - List the most likely root causes, most probable first.
+          - Propose the smallest reproduction and the next concrete action.
+
+      # Inline skills mix freely with sources and name filters.
+      - local
+    toolsets:
+      - type: filesystem

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -277,5 +277,25 @@ func validateSkillsConfiguration(_ string, agent *latest.AgentConfig) error {
 			return fmt.Errorf("agent '%s' has an empty skills entry", agent.Name)
 		}
 	}
+	seenInline := make(map[string]bool, len(agent.Skills.Inline))
+	for i := range agent.Skills.Inline {
+		inline := &agent.Skills.Inline[i]
+		if strings.TrimSpace(inline.Name) == "" {
+			return fmt.Errorf("agent '%s' has an inline skill with no name", agent.Name)
+		}
+		if strings.TrimSpace(inline.Description) == "" {
+			return fmt.Errorf("agent '%s' inline skill '%s' is missing a description", agent.Name, inline.Name)
+		}
+		if strings.TrimSpace(inline.Instructions) == "" {
+			return fmt.Errorf("agent '%s' inline skill '%s' is missing instructions", agent.Name, inline.Name)
+		}
+		if inline.Context != "" && inline.Context != "fork" {
+			return fmt.Errorf("agent '%s' inline skill '%s' has invalid context '%s' (only 'fork' is supported)", agent.Name, inline.Name, inline.Context)
+		}
+		if seenInline[inline.Name] {
+			return fmt.Errorf("agent '%s' has duplicate inline skill '%s'", agent.Name, inline.Name)
+		}
+		seenInline[inline.Name] = true
+	}
 	return nil
 }

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -477,22 +477,53 @@ type CacheConfig struct {
 const SkillSourceLocal = "local"
 
 // errSkillsFormat is returned when the `skills` value is neither a boolean nor
-// a list of strings.
-var errSkillsFormat = errors.New("skills must be a boolean or a list of skill sources and/or names")
+// a list of strings and/or inline skill definitions.
+var errSkillsFormat = errors.New("skills must be a boolean or a list of skill sources, names, and/or inline skill definitions")
 
-// SkillsConfig controls skill discovery sources and filtering for an agent.
-// Supports three YAML formats:
+// InlineSkill is a skill defined directly in the agent config rather than
+// loaded from the filesystem or a remote URL. It supports the subset of the
+// SKILL.md format that can be expressed in YAML; the skill body lives in
+// Instructions instead of a Markdown file.
+type InlineSkill struct {
+	// Name is the skill identifier used by read_skill / run_skill and the
+	// /<name> slash command. Required.
+	Name string `json:"name" yaml:"name"`
+	// Description is injected into the system prompt so the model knows when
+	// the skill applies. Required.
+	Description string `json:"description" yaml:"description"`
+	// Instructions is the skill body (equivalent to the Markdown content
+	// below the SKILL.md frontmatter). Required.
+	Instructions string `json:"instructions" yaml:"instructions"`
+	// Context, when set to "fork", runs the skill as an isolated sub-agent
+	// (exposed via run_skill) instead of inlining it in the conversation.
+	Context string `json:"context,omitempty" yaml:"context,omitempty"`
+	// Model optionally overrides the model used while a fork-mode skill runs.
+	// Ignored for non-fork skills.
+	Model string `json:"model,omitempty" yaml:"model,omitempty"`
+	// AllowedTools optionally records the tools the skill expects. It mirrors
+	// the SKILL.md `allowed-tools` field.
+	AllowedTools []string `json:"allowed_tools,omitempty" yaml:"allowed_tools,omitempty"`
+}
+
+// SkillsConfig controls skill discovery sources, filtering, and inline
+// definitions for an agent. Supports these YAML formats:
 //   - Boolean: `skills: true` (equivalent to ["local"]) or `skills: false` (disabled)
 //   - List:    `skills: ["local", "http://example.com"]` — sources to load from
 //   - List:    `skills: ["git", "docker"]`               — names of skills to include
 //   - List:    `skills: ["local", "git"]`                — mix of sources and names
+//   - List:    a list may also contain mapping items, each an inline skill
+//     definition (see InlineSkill), freely mixed with the string items above.
 //
-// Items in the list are classified automatically:
+// String items in the list are classified automatically:
 //   - "local" or any HTTP/HTTPS URL → a skill source (added to Sources)
 //   - any other string             → a skill name filter (added to Include)
 //
+// Mapping items are decoded as inline skills (added to Inline).
+//
 // When Include is non-empty but no explicit sources are provided, Sources defaults
 // to ["local"] so that `skills: ["git"]` loads local skills and keeps only "git".
+// Inline skills on their own do not pull in any sources: a list containing only
+// inline definitions enables skills without loading local or remote ones.
 //
 // The special source "local" loads skills from the filesystem (standard locations).
 // HTTP/HTTPS URLs load skills from remote servers per the well-known skills discovery spec.
@@ -502,10 +533,14 @@ type SkillsConfig struct { //nolint:recvcheck // MarshalYAML/MarshalJSON must us
 	// Include optionally filters loaded skills by name. When non-empty, only
 	// skills whose Name matches an entry in this list are exposed to the agent.
 	Include []string
+	// Inline holds skills defined directly in the agent config. They are
+	// always exposed (never subject to the Include filter) and are not
+	// affected by Sources.
+	Inline []InlineSkill
 }
 
 func (s SkillsConfig) Enabled() bool {
-	return len(s.Sources) > 0
+	return len(s.Sources) > 0 || len(s.Inline) > 0
 }
 
 func (s SkillsConfig) HasLocal() bool {
@@ -533,10 +568,47 @@ func isSkillSource(item string) bool {
 	return item == SkillSourceLocal || isRemoteURL(item)
 }
 
+// skillListItem is one entry of the `skills` list, which may be either a
+// plain string (a source or a name filter) or a mapping (an inline skill
+// definition). Exactly one of str/inline is populated after unmarshaling.
+type skillListItem struct {
+	str    string
+	inline *InlineSkill
+}
+
+func (i *skillListItem) UnmarshalYAML(unmarshal func(any) error) error {
+	var s string
+	if err := unmarshal(&s); err == nil {
+		i.str = s
+		return nil
+	}
+	var inline InlineSkill
+	if err := unmarshal(&inline); err != nil {
+		return errSkillsFormat
+	}
+	i.inline = &inline
+	return nil
+}
+
+func (i *skillListItem) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		i.str = s
+		return nil
+	}
+	var inline InlineSkill
+	if err := json.Unmarshal(data, &inline); err != nil {
+		return errSkillsFormat
+	}
+	i.inline = &inline
+	return nil
+}
+
 // setFromBool is the shared "boolean shorthand" logic for YAML and JSON
 // unmarshaling: `true` means load local skills, `false` disables skills.
 func (s *SkillsConfig) setFromBool(b bool) {
 	s.Include = nil
+	s.Inline = nil
 	if b {
 		s.Sources = []string{SkillSourceLocal}
 	} else {
@@ -544,18 +616,23 @@ func (s *SkillsConfig) setFromBool(b bool) {
 	}
 }
 
-// setFromList splits items into Sources ("local" + URLs) and Include (skill
-// name filters). When Include is non-empty and Sources is empty, Sources
-// defaults to ["local"] so that `skills: ["git"]` filters local skills
-// without requiring the user to spell out the source.
-func (s *SkillsConfig) setFromList(items []string) {
+// setFromList splits items into Sources ("local" + URLs), Include (skill name
+// filters), and Inline (mapping items). When Include is non-empty and Sources
+// is empty, Sources defaults to ["local"] so that `skills: ["git"]` filters
+// local skills without requiring the user to spell out the source. Inline
+// skills do not, on their own, pull in any source.
+func (s *SkillsConfig) setFromList(items []skillListItem) {
 	s.Sources = nil
 	s.Include = nil
+	s.Inline = nil
 	for _, item := range items {
-		if isSkillSource(item) {
-			s.Sources = append(s.Sources, item)
-		} else {
-			s.Include = append(s.Include, item)
+		switch {
+		case item.inline != nil:
+			s.Inline = append(s.Inline, *item.inline)
+		case isSkillSource(item.str):
+			s.Sources = append(s.Sources, item.str)
+		default:
+			s.Include = append(s.Include, item.str)
 		}
 	}
 	if len(s.Sources) == 0 && len(s.Include) > 0 {
@@ -565,14 +642,14 @@ func (s *SkillsConfig) setFromList(items []string) {
 
 // marshalValue returns the canonical encoded representation: `false` when
 // disabled, `true` when only the default local source is set, otherwise a
-// flat []string combining Sources and Include. The default local source is
+// list combining Sources, Include, and Inline. The default local source is
 // omitted from the list when Include is non-empty so the output round-trips
 // back through setFromList.
 func (s SkillsConfig) marshalValue() any {
 	switch {
-	case len(s.Sources) == 0 && len(s.Include) == 0:
+	case len(s.Sources) == 0 && len(s.Include) == 0 && len(s.Inline) == 0:
 		return false
-	case len(s.Include) == 0 && len(s.Sources) == 1 && s.Sources[0] == SkillSourceLocal:
+	case len(s.Include) == 0 && len(s.Inline) == 0 && len(s.Sources) == 1 && s.Sources[0] == SkillSourceLocal:
 		return true
 	}
 
@@ -580,9 +657,16 @@ func (s SkillsConfig) marshalValue() any {
 	if len(s.Include) > 0 && len(sources) == 1 && sources[0] == SkillSourceLocal {
 		sources = nil
 	}
-	out := make([]string, 0, len(sources)+len(s.Include))
-	out = append(out, sources...)
-	out = append(out, s.Include...)
+	out := make([]any, 0, len(sources)+len(s.Include)+len(s.Inline))
+	for _, src := range sources {
+		out = append(out, src)
+	}
+	for _, name := range s.Include {
+		out = append(out, name)
+	}
+	for _, inline := range s.Inline {
+		out = append(out, inline)
+	}
 	return out
 }
 
@@ -592,7 +676,7 @@ func (s *SkillsConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		s.setFromBool(b)
 		return nil
 	}
-	var items []string
+	var items []skillListItem
 	if err := unmarshal(&items); err != nil {
 		return errSkillsFormat
 	}
@@ -610,7 +694,7 @@ func (s *SkillsConfig) UnmarshalJSON(data []byte) error {
 		s.setFromBool(b)
 		return nil
 	}
-	var items []string
+	var items []skillListItem
 	if err := json.Unmarshal(data, &items); err != nil {
 		return errSkillsFormat
 	}

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -480,6 +480,17 @@ const SkillSourceLocal = "local"
 // a list of strings and/or inline skill definitions.
 var errSkillsFormat = errors.New("skills must be a boolean or a list of skill sources, names, and/or inline skill definitions")
 
+// skillsFormatError maps a list-decode failure to a user-facing error. When the
+// failure carries a specific inline-skill diagnostic (an unknown/misspelled
+// field surfaced by skillListItem), that detail is preserved; otherwise the
+// generic shape hint is returned.
+func skillsFormatError(err error) error {
+	if err != nil && strings.Contains(err.Error(), "invalid inline skill") {
+		return err
+	}
+	return errSkillsFormat
+}
+
 // InlineSkill is a skill defined directly in the agent config rather than
 // loaded from the filesystem or a remote URL. It supports the subset of the
 // SKILL.md format that can be expressed in YAML; the skill body lives in
@@ -582,9 +593,12 @@ func (i *skillListItem) UnmarshalYAML(unmarshal func(any) error) error {
 		i.str = s
 		return nil
 	}
+	// Not a scalar: the item must be an inline skill definition. Surface the
+	// decode error (e.g. an unknown/misspelled field under strict mode) rather
+	// than the generic errSkillsFormat so the user can see what's wrong.
 	var inline InlineSkill
 	if err := unmarshal(&inline); err != nil {
-		return errSkillsFormat
+		return fmt.Errorf("invalid inline skill: %w", err)
 	}
 	i.inline = &inline
 	return nil
@@ -598,7 +612,7 @@ func (i *skillListItem) UnmarshalJSON(data []byte) error {
 	}
 	var inline InlineSkill
 	if err := json.Unmarshal(data, &inline); err != nil {
-		return errSkillsFormat
+		return fmt.Errorf("invalid inline skill: %w", err)
 	}
 	i.inline = &inline
 	return nil
@@ -678,7 +692,7 @@ func (s *SkillsConfig) UnmarshalYAML(unmarshal func(any) error) error {
 	}
 	var items []skillListItem
 	if err := unmarshal(&items); err != nil {
-		return errSkillsFormat
+		return skillsFormatError(err)
 	}
 	s.setFromList(items)
 	return nil
@@ -696,7 +710,7 @@ func (s *SkillsConfig) UnmarshalJSON(data []byte) error {
 	}
 	var items []skillListItem
 	if err := json.Unmarshal(data, &items); err != nil {
-		return errSkillsFormat
+		return skillsFormatError(err)
 	}
 	s.setFromList(items)
 	return nil

--- a/pkg/config/skills_config_test.go
+++ b/pkg/config/skills_config_test.go
@@ -378,6 +378,81 @@ skills: []
 	assert.False(t, agent.Skills.HasLocal())
 }
 
+func TestSkillsConfig_InlineSkills(t *testing.T) {
+	yamlInput := `
+model: openai/gpt-4o
+instruction: test
+skills:
+  - local
+  - changelog
+  - name: triage
+    description: Triage a bug report.
+    context: fork
+    model: openai/gpt-4o-mini
+    instructions: |
+      Restate the problem and propose next steps.
+    allowed_tools:
+      - read_file
+  - name: summary
+    description: Summarize a diff.
+    instructions: Write a concise summary.
+`
+	var agent latest.AgentConfig
+	err := yaml.Unmarshal([]byte(yamlInput), &agent)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"local"}, agent.Skills.Sources)
+	assert.Equal(t, []string{"changelog"}, agent.Skills.Include)
+	require.Len(t, agent.Skills.Inline, 2)
+
+	assert.Equal(t, "triage", agent.Skills.Inline[0].Name)
+	assert.Equal(t, "Triage a bug report.", agent.Skills.Inline[0].Description)
+	assert.Equal(t, "fork", agent.Skills.Inline[0].Context)
+	assert.Equal(t, "openai/gpt-4o-mini", agent.Skills.Inline[0].Model)
+	assert.Equal(t, []string{"read_file"}, agent.Skills.Inline[0].AllowedTools)
+	assert.Contains(t, agent.Skills.Inline[0].Instructions, "Restate the problem")
+
+	assert.Equal(t, "summary", agent.Skills.Inline[1].Name)
+	assert.True(t, agent.Skills.Enabled())
+}
+
+func TestSkillsConfig_InlineOnlyEnabledWithoutSources(t *testing.T) {
+	yamlInput := `
+model: openai/gpt-4o
+instruction: test
+skills:
+  - name: only
+    description: The only skill.
+    instructions: Do the thing.
+`
+	var agent latest.AgentConfig
+	err := yaml.Unmarshal([]byte(yamlInput), &agent)
+	require.NoError(t, err)
+
+	assert.True(t, agent.Skills.Enabled())
+	assert.Empty(t, agent.Skills.Sources)
+	assert.Empty(t, agent.Skills.Include)
+	require.Len(t, agent.Skills.Inline, 1)
+	assert.Equal(t, "only", agent.Skills.Inline[0].Name)
+}
+
+func TestSkillsConfig_InlineJSONRoundTrip(t *testing.T) {
+	input := latest.SkillsConfig{
+		Sources: []string{"local"},
+		Include: []string{"changelog"},
+		Inline: []latest.InlineSkill{
+			{Name: "triage", Description: "d", Instructions: "i", Context: "fork"},
+		},
+	}
+
+	data, err := json.Marshal(input)
+	require.NoError(t, err)
+
+	var result latest.SkillsConfig
+	require.NoError(t, json.Unmarshal(data, &result))
+	assert.Equal(t, input, result)
+}
+
 func TestSkillsConfig_UnmarshalResetsReceiver(t *testing.T) {
 	skills := latest.SkillsConfig{Sources: []string{"local", "https://old.example.com"}}
 

--- a/pkg/config/skills_config_test.go
+++ b/pkg/config/skills_config_test.go
@@ -453,6 +453,26 @@ func TestSkillsConfig_InlineJSONRoundTrip(t *testing.T) {
 	assert.Equal(t, input, result)
 }
 
+func TestSkillsConfig_InlineInvalidFieldError(t *testing.T) {
+	// A misspelled inline-skill field should surface the specific decode
+	// error (which names the unknown field) rather than the generic
+	// "must be a boolean or a list" hint. Strict unknown-field checking
+	// runs on the real Load path, so exercise that.
+	cfgStr := `version: "` + latest.Version + `"
+agents:
+  root:
+    model: openai/gpt-4o
+    instruction: test
+    skills:
+      - name: foo
+        description: bar
+        instructionz: oops
+`
+	_, err := Load(t.Context(), NewBytesSource("test", []byte(cfgStr)))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "instructionz")
+}
+
 func TestSkillsConfig_UnmarshalResetsReceiver(t *testing.T) {
 	skills := latest.SkillsConfig{Sources: []string{"local", "https://old.example.com"}}
 

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/config/latest"
 )
 
 func TestLoadConfig_InvalidPath(t *testing.T) {
@@ -138,6 +140,75 @@ agents:
 	_, err := Load(t.Context(), NewBytesSource("test", []byte(cfgStr)))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty skills entry")
+}
+
+func TestInlineSkillsValid(t *testing.T) {
+	t.Parallel()
+
+	cfgStr := `version: "` + latest.Version + `"
+agents:
+  root:
+    model: openai/gpt-4o
+    instruction: test
+    skills:
+      - local
+      - name: changelog
+        description: Write a changelog entry.
+        instructions: Do the thing.
+      - name: triage
+        description: Triage a bug.
+        context: fork
+        instructions: Triage it.
+`
+	cfg, err := Load(t.Context(), NewBytesSource("test", []byte(cfgStr)))
+	require.NoError(t, err)
+	agent, ok := cfg.Agents.Lookup("root")
+	require.True(t, ok)
+	require.Len(t, agent.Skills.Inline, 2)
+	assert.Equal(t, "changelog", agent.Skills.Inline[0].Name)
+	assert.Equal(t, "fork", agent.Skills.Inline[1].Context)
+}
+
+func TestInlineSkillsValidationErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		skills  string
+		wantErr string
+	}{
+		{
+			name:    "missing description",
+			skills:  "      - name: foo\n        instructions: do it\n",
+			wantErr: "missing a description",
+		},
+		{
+			name:    "missing instructions",
+			skills:  "      - name: foo\n        description: a foo\n",
+			wantErr: "missing instructions",
+		},
+		{
+			name:    "invalid context",
+			skills:  "      - name: foo\n        description: a foo\n        instructions: do it\n        context: nope\n",
+			wantErr: "invalid context",
+		},
+		{
+			name:    "duplicate inline skill",
+			skills:  "      - name: foo\n        description: a foo\n        instructions: do it\n      - name: foo\n        description: another foo\n        instructions: do it again\n",
+			wantErr: "duplicate inline skill",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfgStr := "version: \"" + latest.Version + "\"\nagents:\n  root:\n    model: openai/gpt-4o\n    instruction: test\n    skills:\n" + tt.skills
+			_, err := Load(t.Context(), NewBytesSource("test", []byte(cfgStr)))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
 }
 
 func TestSkillsNameFilter(t *testing.T) {

--- a/pkg/skills/skills.go
+++ b/pkg/skills/skills.go
@@ -28,6 +28,16 @@ type Skill struct {
 	// agent config or an inline "provider/model" reference (e.g.
 	// "openai/gpt-4o-mini"). It is ignored for non-fork skills.
 	Model string
+	// InlineContent holds the skill body for skills defined directly in the
+	// agent config rather than loaded from a file or URL. When set, the
+	// skill has no FilePath/BaseDir and its content is served from memory.
+	InlineContent string
+}
+
+// IsInline reports whether the skill is defined inline in the agent config
+// (its body lives in InlineContent rather than on disk or behind a URL).
+func (s Skill) IsInline() bool {
+	return s.InlineContent != ""
 }
 
 // IsFork returns true when the skill should be executed in an isolated

--- a/pkg/teamloader/skills_filter_test.go
+++ b/pkg/teamloader/skills_filter_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/skills"
 )
 
@@ -63,6 +65,39 @@ func TestFilterSkillsByName_IgnoresUnknownNames(t *testing.T) {
 func TestFilterSkillsByName_EmptyLoaded(t *testing.T) {
 	result := filterSkillsByName(nil, []string{"git"})
 	assert.Empty(t, result)
+}
+
+func TestInlineSkills_Conversion(t *testing.T) {
+	defs := []latest.InlineSkill{
+		{
+			Name:         "triage",
+			Description:  "Triage a bug.",
+			Instructions: "Do the triage.",
+			Context:      "fork",
+			Model:        "openai/gpt-4o-mini",
+			AllowedTools: []string{"read_file"},
+		},
+	}
+
+	result := inlineSkills(defs)
+	require.Len(t, result, 1)
+
+	skill := result[0]
+	assert.Equal(t, "triage", skill.Name)
+	assert.Equal(t, "Triage a bug.", skill.Description)
+	assert.Equal(t, "Do the triage.", skill.InlineContent)
+	assert.True(t, skill.IsInline())
+	assert.True(t, skill.IsFork())
+	assert.Equal(t, "openai/gpt-4o-mini", skill.Model)
+	assert.Equal(t, []string{"read_file"}, skill.AllowedTools)
+	// Inline skills have no filesystem footprint.
+	assert.Empty(t, skill.FilePath)
+	assert.Empty(t, skill.BaseDir)
+	assert.False(t, skill.Local)
+}
+
+func TestInlineSkills_Empty(t *testing.T) {
+	assert.Nil(t, inlineSkills(nil))
 }
 
 func TestFilterSkillsByName_KeepsAllDuplicateNameMatches(t *testing.T) {

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -228,6 +228,9 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 		if agentConfig.Skills.Enabled() {
 			loadedSkills := skills.Load(agentConfig.Skills.Sources)
 			loadedSkills = filterSkillsByName(loadedSkills, agentConfig.Skills.Include)
+			// Inline skills are defined in the agent config itself; they are
+			// always exposed and never subject to the include filter.
+			loadedSkills = append(loadedSkills, inlineSkills(agentConfig.Skills.Inline)...)
 			if len(loadedSkills) > 0 {
 				agentTools = append(agentTools, skillstool.New(loadedSkills, runConfig.WorkingDir))
 			}
@@ -494,6 +497,27 @@ func getToolsForAgent(ctx context.Context, a *latest.AgentConfig, parentDir stri
 	}
 
 	return toolSets, warnings
+}
+
+// inlineSkills converts inline skill definitions from the agent config into
+// runtime skills. Their body is carried in memory (InlineContent) so the
+// toolset serves it without touching the filesystem.
+func inlineSkills(defs []latest.InlineSkill) []skills.Skill {
+	if len(defs) == 0 {
+		return nil
+	}
+	out := make([]skills.Skill, 0, len(defs))
+	for _, d := range defs {
+		out = append(out, skills.Skill{
+			Name:          d.Name,
+			Description:   d.Description,
+			InlineContent: d.Instructions,
+			Context:       d.Context,
+			Model:         d.Model,
+			AllowedTools:  d.AllowedTools,
+		})
+	}
+	return out
 }
 
 // filterSkillsByName returns the subset of skills whose Name matches one of

--- a/pkg/tools/builtin/skills/skills.go
+++ b/pkg/tools/builtin/skills/skills.go
@@ -142,6 +142,14 @@ func (s *ToolSet) ReadSkillFile(skillName, relativePath string) (string, error) 
 		return "", fmt.Errorf("skill %q not found", skillName)
 	}
 
+	// Inline skills live in the agent config and have no backing directory,
+	// so there are no supporting files to read. Reject explicitly rather than
+	// joining against an empty BaseDir (which would resolve against the
+	// process working directory).
+	if skill.IsInline() {
+		return "", fmt.Errorf("skill %q is defined inline and has no supporting files", skillName)
+	}
+
 	if !isValidRelativePath(relativePath) {
 		return "", fmt.Errorf("invalid file path %q", relativePath)
 	}
@@ -322,7 +330,7 @@ func (s *ToolSet) PrepareForkSubSession(ctx context.Context, args RunSkillArgs) 
 
 	if !skill.IsFork() {
 		return nil, tools.ResultError(fmt.Sprintf(
-			"skill %q is not configured for forked execution (missing context: fork in SKILL.md frontmatter); use read_skill instead",
+			"skill %q is not configured for forked execution (set context: fork); use read_skill instead",
 			args.Name,
 		))
 	}

--- a/pkg/tools/builtin/skills/skills.go
+++ b/pkg/tools/builtin/skills/skills.go
@@ -107,11 +107,19 @@ func (s *ToolSet) FindSkill(name string) *skills.Skill {
 // ReadSkillContent returns the content of a skill's SKILL.md by name.
 // For local skills, it expands any !`command` patterns in the content by
 // executing the commands and replacing the patterns with their stdout output.
-// Command expansion is disabled for remote skills to prevent arbitrary code execution.
+// Command expansion is disabled for remote and inline skills to prevent
+// arbitrary code execution.
 func (s *ToolSet) ReadSkillContent(ctx context.Context, name string) (string, error) {
 	skill := s.findSkill(name)
 	if skill == nil {
 		return "", fmt.Errorf("skill %q not found", name)
+	}
+
+	// Inline skills carry their body in memory; there is no file to read and
+	// no command expansion (their content comes from the trusted agent config
+	// author, but we keep behaviour identical to remote skills for safety).
+	if skill.IsInline() {
+		return skill.InlineContent, nil
 	}
 
 	content, err := readFileContent(skill.FilePath)

--- a/pkg/tools/builtin/skills/skills_test.go
+++ b/pkg/tools/builtin/skills/skills_test.go
@@ -281,6 +281,41 @@ func TestSkillsToolset_ReadSkillContent_RemoteSkillSkipsExpansion(t *testing.T) 
 	assert.Equal(t, content, result, "commands in remote skills must not be expanded")
 }
 
+func TestSkillsToolset_ReadSkillContent_Inline(t *testing.T) {
+	st := New([]skills.Skill{
+		{Name: "inline", Description: "Inline skill", InlineContent: "# Inline\nDo it."},
+	}, "")
+
+	content, err := st.ReadSkillContent(t.Context(), "inline")
+	require.NoError(t, err)
+	assert.Equal(t, "# Inline\nDo it.", content)
+}
+
+func TestSkillsToolset_ReadSkillContent_InlineSkipsExpansion(t *testing.T) {
+	// Inline content must never be shell-expanded, even when a working dir is set.
+	st := New([]skills.Skill{
+		{Name: "inline", Description: "Inline", InlineContent: "Info: !`echo should-not-run`"},
+	}, t.TempDir())
+
+	content, err := st.ReadSkillContent(t.Context(), "inline")
+	require.NoError(t, err)
+	assert.Equal(t, "Info: !`echo should-not-run`", content)
+}
+
+func TestSkillsToolset_ReadSkillFile_InlineRejected(t *testing.T) {
+	// An inline skill has no backing directory. read_skill_file must reject it
+	// rather than resolving against an empty BaseDir (the process working dir).
+	st := New([]skills.Skill{
+		{Name: "inline", Description: "Inline", InlineContent: "body"},
+	}, "")
+
+	for _, p := range []string{"references/FORMS.md", ".", "SKILL.md"} {
+		_, err := st.ReadSkillFile("inline", p)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "defined inline")
+	}
+}
+
 func TestSkillsToolset_FindSkill(t *testing.T) {
 	st := New([]skills.Skill{
 		{Name: "alpha", Description: "Alpha skill"},

--- a/pkg/tui/dialog/skills.go
+++ b/pkg/tui/dialog/skills.go
@@ -83,6 +83,10 @@ func formatSkill(s *skills.Skill, contentWidth int) []string {
 }
 
 func skillLoadedFrom(s *skills.Skill) string {
+	if s.IsInline() {
+		return ""
+	}
+
 	path := s.BaseDir
 	if path == "" {
 		path = s.FilePath
@@ -103,8 +107,12 @@ func skillLoadedFrom(s *skills.Skill) string {
 }
 
 func skillSourceBadge(s *skills.Skill) string {
-	if s.Local {
+	switch {
+	case s.IsInline():
+		return styles.MutedStyle.Render("[inline]")
+	case s.Local:
 		return styles.SuccessStyle.Render("[local]")
+	default:
+		return styles.WarningStyle.Render("[remote]")
 	}
-	return styles.WarningStyle.Render("[remote]")
 }

--- a/pkg/worktree/worktree_test.go
+++ b/pkg/worktree/worktree_test.go
@@ -218,6 +218,10 @@ func bootstrapRepo(t *testing.T) string {
 	runGit(t, dir, "init")
 	runGit(t, dir, "config", "user.email", "test@example.com")
 	runGit(t, dir, "config", "user.name", "Test User")
+	// Keep the test hermetic: never sign commits with the developer's
+	// global signing setup (e.g. a 1Password SSH agent), which is
+	// unavailable/flaky in test environments and breaks `git commit`.
+	runGit(t, dir, "config", "commit.gpgsign", "false")
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("A"), 0o644))
 	runGit(t, dir, "add", ".")
 	runGit(t, dir, "commit", "-m", "init")


### PR DESCRIPTION
Adds support for defining "inline skills" directly in the agent YAML `skills:` field, enabling users to express skills without maintaining separate files or requiring external sources. Inline skills are defined as YAML mappings mixed with existing string sources and name filters, and support the YAML-expressible subset of the skill definition format.

An inline skill specifies a name, description, and instructions (all required), plus optional fields for context (only "fork" allowed), model, and allowed_tools. They cannot bundle files or use command expansion. Inline skills are always exposed to the agent, work in sandbox mode since they travel inside the agent YAML, and enable skills independently without needing to pull in local sources.

The implementation includes schema updates, validation (required fields, duplicate-name detection, context restrictions), a new InlineSkill type with mixed YAML/JSON parsing, and updates to the skills toolset and TUI to handle inline skill retrieval and display.

Also includes a fix for test hermeticity: `pkg/worktree/worktree_test.go` now disables commit signing in the test bootstrap repo to prevent leakage from the developer's global 1Password SSH commit-signing config, which was flaky in tests.