### PR TITLE
docs: document coding harnesses and fill P0/P1/P2 documentation gaps

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -94,6 +94,8 @@
       url: /features/cli/
     - title: MCP Mode
       url: /features/mcp-mode/
+    - title: Coding Harnesses
+      url: /features/harnesses/
     - title: A2A Protocol
       url: /features/a2a/
     - title: ACP

--- a/docs/concepts/multi-agent/index.md
+++ b/docs/concepts/multi-agent/index.md
@@ -21,7 +21,7 @@ Each agent has its own model, tools, and instructions — optimized for its spec
 
 ## Two Patterns: Delegation vs. Handoffs
 
-docker-agent supports two multi-agent patterns:
+Docker Agent supports two multi-agent patterns:
 
 | | **Delegation** (`sub_agents`) | **Handoffs** (`handoffs`) |
 |---|---|---|
@@ -232,22 +232,22 @@ agents:
     instruction: |
       Break down coding tasks and delegate to the coding agents.
     sub_agents:
-      - claude_coder
-      - codex_coder
+      - claude-coder
+      - codex-coder
 
-  claude_coder:
+  claude-coder:
     description: Claude Code specialist
     harness:
       type: claude-code
       effort: high
 
-  codex_coder:
+  codex-coder:
     description: Codex specialist
     harness:
       type: codex
 ```
 
-The orchestrator uses `transfer_task` to send work to a harness sub-agent just like any other sub-agent. docker-agent handles the orchestration and hooks; the external CLI drives the coding loop.
+The orchestrator uses `transfer_task` to send work to a harness sub-agent just like any other sub-agent. Docker Agent handles the orchestration and hooks; the external CLI drives the coding loop.
 
 <div class="callout callout-tip" markdown="1">
 <div class="callout-title">Learn more
@@ -383,8 +383,8 @@ toolsets:
 - **Choose the right pattern** — Use `sub_agents` for hierarchical task delegation, `handoffs` for pipeline workflows and conversational routing
 
 <div class="callout callout-info" markdown="1">
-<div class="callout-title">Beyond docker-agent
+<div class="callout-title">Beyond Docker Agent
 </div>
-  <p>For interoperability with other agent frameworks, docker-agent supports the <a href="{{ '/features/a2a/' | relative_url }}">A2A protocol</a> and can expose agents via <a href="{{ '/features/mcp-mode/' | relative_url }}">MCP Mode</a>.</p>
+  <p>For interoperability with other agent frameworks, Docker Agent supports the <a href="{{ '/features/a2a/' | relative_url }}">A2A protocol</a> and can expose agents via <a href="{{ '/features/mcp-mode/' | relative_url }}">MCP Mode</a>.</p>
 
 </div>

--- a/docs/concepts/multi-agent/index.md
+++ b/docs/concepts/multi-agent/index.md
@@ -216,10 +216,47 @@ External sub-agents are automatically named after their last path segment — fo
 <div class="callout-title">Tip
 </div>
   <p>External sub-agents work with any OCI-compatible registry, not just the Docker Agent Catalog. See <a href="{{ '/concepts/distribution/' | relative_url }}">Agent Distribution</a> for more on registry references.</p>
+  <p>See <a href="https://github.com/docker/docker-agent/blob/main/examples/sub-agents-from-catalog.yaml"><code>examples/sub-agents-from-catalog.yaml</code></a> for a complete example mixing local and catalog sub-agents.</p>
 
 </div>
 
+## Harness-Backed Sub-Agents
+
+Sub-agents can be backed by external coding CLIs — Claude Code, Codex, opencode, or pi — instead of a model API. Add a `harness:` block in place of a `model:` field to create a harness sub-agent:
+
+```yaml
+agents:
+  root:
+    model: anthropic/claude-sonnet-4-5
+    description: Orchestrator that plans and delegates
+    instruction: |
+      Break down coding tasks and delegate to the coding agents.
+    sub_agents:
+      - claude_coder
+      - codex_coder
+
+  claude_coder:
+    description: Claude Code specialist
+    harness:
+      type: claude-code
+      effort: high
+
+  codex_coder:
+    description: Codex specialist
+    harness:
+      type: codex
+```
+
+The orchestrator uses `transfer_task` to send work to a harness sub-agent just like any other sub-agent. docker-agent handles the orchestration and hooks; the external CLI drives the coding loop.
+
+<div class="callout callout-tip" markdown="1">
+<div class="callout-title">Learn more
+</div>
+  <p>See <a href="{{ '/features/harnesses/' | relative_url }}">Coding Harnesses</a> for the full field reference, parallel dispatch patterns, and what does not work inside harness agents.</p>
+</div>
+
 ## Example: Development Team
+
 
 ```yaml
 agents:

--- a/docs/configuration/agents/index.md
+++ b/docs/configuration/agents/index.md
@@ -97,7 +97,7 @@ agents:
 | `hooks`                     | object  | ✗        | Lifecycle hooks for running commands at various points. See [Hooks]({{ '/configuration/hooks/' | relative_url }}).                                                                                   |
 | `structured_output`         | object  | ✗        | Constrain agent output to match a JSON schema. See [Structured Output]({{ '/configuration/structured-output/' | relative_url }}).                                                                    |
 | `cache`                     | object  | ✗        | Response cache. When the same user question is asked again, the previous answer is replayed verbatim and the model is not called. See [Response Cache](#response-cache) below.                  |
-| `harness`                   | object  | ✗        | Run this agent through an external coding CLI instead of a model. See [Coding Harnesses]({{ '/features/harnesses/' | relative_url }}). |
+| `harness`                   | object  | ✗        | Run this agent through an external coding CLI instead of a model. **Note:** Any `toolsets:` defined on the same agent are silently ignored when `harness:` is set — the external CLI brings its own tools. See [Coding Harnesses]({{ '/features/harnesses/' | relative_url }}). |
 
 <div class="callout callout-warning" markdown="1">
 <div class="callout-title">max_iterations

--- a/docs/configuration/agents/index.md
+++ b/docs/configuration/agents/index.md
@@ -55,6 +55,12 @@ agents:
       case_sensitive: boolean
       trim_spaces: boolean
       path: string
+    harness: # Optional: delegate to an external coding CLI (Claude Code, Codex, opencode, pi)
+      type: string # Required: claude-code | codex | opencode | pi
+      model: string # Optional: model override forwarded to the CLI
+      effort: string # claude-code only: low | medium | high | max
+      agent: string # opencode only: agent profile name
+      thinking: boolean # opencode only: enable extended thinking
 ```
 
 <div class="callout callout-tip" markdown="1">
@@ -86,11 +92,12 @@ agents:
 | `num_history_items`         | int     | ✗        | Limit the number of conversation history messages sent to the model. Useful for managing context window size with long conversations. Default: unlimited (all messages sent). |
 | `skills`                    | bool/array | ✗     | Enable automatic skill discovery. `true` loads all discovered local skills, `false` disables them. A list can mix skill sources (`local` or `https://…` URLs) and skill names to include — see [Skills]({{ '/features/skills/' | relative_url }}).                                                     |
 | `commands`                  | object  | ✗        | Named prompts that can be run with `docker agent run config.yaml /command_name`. Can be simple strings or objects with `instruction` and/or `agent` fields for agent switching. See [Named Commands](#named-commands) below. |
-| `welcome_message`           | string  | ✗        | Message displayed to the user when a session starts. Useful for providing context or instructions.                                                                            |
+| `welcome_message`           | string  | ✗        | Message displayed to the user when a session starts. Rendered as Markdown in the TUI. **Not sent to the model** — it exists purely for the user's benefit. Useful for telling users what the agent can do and what commands are available. |
 | `handoffs`                  | array   | ✗        | List of agent names this agent can hand off the conversation to. Enables the `handoff` tool. See [Handoffs Routing]({{ '/concepts/multi-agent/#handoffs-routing' | relative_url }}).                  |
 | `hooks`                     | object  | ✗        | Lifecycle hooks for running commands at various points. See [Hooks]({{ '/configuration/hooks/' | relative_url }}).                                                                                   |
 | `structured_output`         | object  | ✗        | Constrain agent output to match a JSON schema. See [Structured Output]({{ '/configuration/structured-output/' | relative_url }}).                                                                    |
 | `cache`                     | object  | ✗        | Response cache. When the same user question is asked again, the previous answer is replayed verbatim and the model is not called. See [Response Cache](#response-cache) below.                  |
+| `harness`                   | object  | ✗        | Run this agent through an external coding CLI instead of a model. See [Coding Harnesses]({{ '/features/harnesses/' | relative_url }}). |
 
 <div class="callout callout-warning" markdown="1">
 <div class="callout-title">max_iterations
@@ -293,6 +300,54 @@ Commands support two formats:
    ```
 
 When `agent` is set without `instruction`, any text typed after the slash command (e.g., `/plan build a web app`) is forwarded as a prompt to the target agent. The target agent must be listed in the current agent's `sub_agents` array.
+
+### Agent-Switching Commands
+
+Commands with an `agent` field switch the active agent for that command's scope. This is useful for building workflow shortcuts where `/plan`, `/review`, `/deploy` each route the user to the appropriate specialist.
+
+```yaml
+agents:
+  root:
+    model: openai/gpt-5-mini
+    description: Main assistant
+    instruction: You are a project coordinator.
+    sub_agents: [planner, reviewer]
+    commands:
+      # Switch to planner with a pre-filled prompt
+      plan:
+        agent: planner
+        instruction: "Create a detailed plan for: $1"
+      # Switch to reviewer; any text after /review is forwarded
+      review:
+        agent: reviewer
+      # Simple prompt command (no switching)
+      status: "Summarize what we have accomplished so far"
+
+  planner:
+    model: openai/gpt-5-mini
+    description: Planning specialist
+    instruction: You create detailed project plans.
+
+  reviewer:
+    model: anthropic/claude-sonnet-4-5
+    description: Code review specialist
+    instruction: You review code and suggest improvements.
+```
+
+**Agent-switching vs. `handoff`**
+
+| | Agent-switching command | `handoff` tool |
+| --- | --- | --- |
+| **Trigger** | User runs `/command` | Model calls `handoff()` |
+| **Session** | Stays in the same session | Stays in the same session |
+| **History** | Target agent sees full conversation | Target agent sees full conversation |
+| **Return** | User must explicitly switch back | Target agent can chain to another agent |
+
+**Agent-switching vs. `transfer_task`**
+
+`transfer_task` launches a **sub-session**: the root agent sends a task, the child runs in isolation, and the result is returned to the root. The root agent stays in control and the child's work is never in the main conversation. Use `transfer_task` (via `sub_agents`) when you want delegation with a clean result; use agent-switching commands when you want to *become* a different agent for the rest of the conversation.
+
+See [`examples/agent_switching_commands.yaml`](https://github.com/docker/docker-agent/blob/main/examples/agent_switching_commands.yaml) for a complete example.
 
 ```bash
 # Run commands from the CLI

--- a/docs/configuration/hooks/index.md
+++ b/docs/configuration/hooks/index.md
@@ -197,6 +197,8 @@ settings:
 
 Omit `snapshot` or set it to `false` to leave automatic snapshots off; manually configured snapshot hooks still run.
 
+See [`examples/snapshot_hooks.yaml`](https://github.com/docker/docker-agent/blob/main/examples/snapshot_hooks.yaml) for a complete snapshot hook configuration.
+
 <div class="callout callout-warning" markdown="1">
 <div class="callout-title">Two flavors of <code>max_iterations</code>
 </div>
@@ -278,7 +280,7 @@ Notes:
 - `tool_response` for `post_tool_use` carries the tool's result; `tool_error` is `true` when the tool failed (the failure detail is surfaced inside `tool_response`).
 - `prompt` is only populated for `user_prompt_submit`. Sub-sessions (transferred tasks, background agents, skills) do **not** fire this event because their kick-off message is synthesised by the runtime, not authored by the user.
 - `stop_response` carries the model's final assistant text for `stop`, `after_llm_call`, and `subagent_stop`. `last_user_message` carries the latest user message at dispatch time.
-- `model_id` is populated for `after_llm_call` (and `before_llm_call`) in the canonical `<provider>/<model>` form (e.g. `anthropic/claude-sonnet-4-5`). For harness agents the value is the harness label rather than the canonical form.
+- `model_id` is populated for `after_llm_call` (and `before_llm_call`) in the canonical `<provider>/<model>` form (e.g. `anthropic/claude-sonnet-4-5`). For harness agents, `model_id` is the harness label (e.g. `claude-code`) rather than a canonical model name — see [Coding Harnesses]({{ '/features/harnesses/' | relative_url }}).
 - `context_limit` is `0` when the model definition is unavailable (treat `0` as "unknown", not as a real limit).
 - `approval_decision` is one of `allow`, `deny`, `canceled`. `approval_source` is a stable classifier of which step decided (e.g. `yolo`, `session_permissions_allow`, `session_permissions_deny`, `team_permissions_allow`, `team_permissions_deny`, `pre_tool_use_hook_allow`, `pre_tool_use_hook_deny`, `readonly_hint`, `user_approved`, `user_approved_session`, `user_approved_tool`, `user_rejected`, `context_canceled`).
 

--- a/docs/configuration/models/index.md
+++ b/docs/configuration/models/index.md
@@ -167,6 +167,8 @@ Like other inheritable model settings, `task_budget` can also be declared on a
 [provider definition]({{ '/providers/custom/' | relative_url }}) and is
 inherited by every model that references that provider.
 
+See [`examples/task_budget.yaml`](https://github.com/docker/docker-agent/blob/main/examples/task_budget.yaml) for a complete example.
+
 ## Interleaved Thinking
 
 For Anthropic and Bedrock Claude models, interleaved thinking allows tool calls during model reasoning. This is enabled by default:

--- a/docs/configuration/tools/index.md
+++ b/docs/configuration/tools/index.md
@@ -275,6 +275,8 @@ The TUI exposes the supervisor through two slash commands:
 
 See the [TUI reference]({{ '/features/tui/' | relative_url }}) for the full list of slash commands.
 
+See [`examples/lifecycle.yaml`](https://github.com/docker/docker-agent/blob/main/examples/lifecycle.yaml) for a complete lifecycle configuration example.
+
 ## TOON-Encoded Tool Outputs
 
 Many MCP servers return verbose JSON responses that consume a lot of context budget. The `toon` field on a toolset transparently re-encodes matching tools' JSON output as [TOON](https://github.com/alpkeskin/gotoon) — a compact, model-friendly key/value format — before the result is shown to the model.
@@ -368,9 +370,45 @@ toolsets:
       Label new issues with 'triage' by default.
 ```
 
+By default, the `instruction:` field **replaces** the toolset's built-in instructions (if any). To keep the built-in guidance and add your own rules on top, include the `{ORIGINAL_INSTRUCTIONS}` placeholder anywhere in your instruction text. At runtime it expands to the toolset's default instructions:
+
+```yaml
+toolsets:
+  # Enrich: keep built-in instructions, then add your own rules
+  - type: filesystem
+    instruction: |
+      {ORIGINAL_INSTRUCTIONS}
+
+      ## Project-specific rules
+      - Never modify files outside the `src/` directory.
+      - Always create a backup before overwriting a file.
+
+  # Enrich: prepend your rules before the built-in instructions
+  - type: shell
+    instruction: |
+      Important: only run commands inside the project root.
+      {ORIGINAL_INSTRUCTIONS}
+
+  # Replace: omit the placeholder to discard built-in instructions entirely
+  - type: mcp
+    ref: docker:github-official
+    instruction: |
+      Only read GitHub issues. Never create, edit, or close anything.
+```
+
+Three patterns at a glance:
+
+| Pattern | Description |
+| --- | --- |
+| `{ORIGINAL_INSTRUCTIONS}` then your text | Append your rules after the defaults |
+| Your text then `{ORIGINAL_INSTRUCTIONS}` | Prepend your rules before the defaults |
+| No placeholder | Replace the defaults entirely |
+
+See [`examples/toolset_instructions.yaml`](https://github.com/docker/docker-agent/blob/main/examples/toolset_instructions.yaml) for a complete example.
+
 ## Deferred Tool Loading
 
-Load tools on-demand to speed up agent startup:
+Load tools on-demand to speed up agent startup. When a toolset is deferred, its tools are registered lazily — the tool server process is not started until the agent first calls one of its tools. This is useful for large toolsets (e.g., an MCP server with hundreds of tools) where startup time matters.
 
 ```yaml
 toolsets:
@@ -393,6 +431,10 @@ toolsets:
       - "list_issues"
       - "search_repos"
 ```
+
+When `defer` is a list of tool names, only those specific tools are deferred; all other tools in the toolset load eagerly. Setting `defer: true` defers the entire toolset.
+
+See [`examples/deferred.yaml`](https://github.com/docker/docker-agent/blob/main/examples/deferred.yaml) for a complete example.
 
 ## Combined Example
 

--- a/docs/features/harnesses/index.md
+++ b/docs/features/harnesses/index.md
@@ -10,31 +10,31 @@ _Delegate coding tasks to external AI coding CLIs (Claude Code, Codex, opencode)
 
 ## Overview
 
-A **harness** agent delegates its work to an external coding CLI — `claude` (Claude Code), `codex` (OpenAI Codex), `opencode`, or `pi` — instead of calling a model API directly. The external CLI drives the coding loop while docker-agent provides orchestration, hooks, permissions, and distribution.
+A **harness** agent delegates its work to an external coding CLI — `claude` (Claude Code), `codex` (OpenAI Codex), `opencode`, or `pi` — instead of calling a model API directly. The external CLI drives the coding loop while Docker Agent provides orchestration, hooks, permissions, and distribution.
 
 This pattern gives you the best of both worlds:
 
 - **External CLI strengths** — deep IDE integration, specialized coding workflows, CLI-native tool access
-- **docker-agent strengths** — multi-agent coordination, hook-based auditing and policy enforcement, permission controls, OCI distribution, and the full agent config schema
+- **Docker Agent strengths** — multi-agent coordination, hook-based auditing and policy enforcement, permission controls, OCI distribution, and the full agent config schema
 
 <div class="callout callout-info" markdown="1">
 <div class="callout-title">When to use harnesses
 </div>
-  <p>Use a harness when you want a Claude Code / Codex / opencode session to act as a sub-agent inside a larger docker-agent workflow — for example, an orchestrator that plans work and delegates coding tasks to specialized harness agents.</p>
+  <p>Use a harness when you want a Claude Code / Codex / opencode session to act as a sub-agent inside a larger Docker Agent workflow — for example, an orchestrator that plans work and delegates coding tasks to specialized harness agents.</p>
 </div>
 
 ## Prerequisites
 
-The external CLI must be installed and available on `PATH` before starting docker-agent:
+The external CLI must be installed and available on `PATH` before starting Docker Agent:
 
 | Harness type | Required binary | Install |
 | --- | --- | --- |
 | `claude-code` | `claude` | [docs.anthropic.com/en/docs/claude-code](https://docs.anthropic.com/en/docs/claude-code) |
 | `codex` | `codex` | [github.com/openai/codex](https://github.com/openai/codex) |
 | `opencode` | `opencode` | [opencode.ai](https://opencode.ai) |
-| `pi` | `pi` | [pi.ai/talk](https://pi.ai/talk) |
+| `pi` | `pi` | Refer to the `pi` CLI documentation for installation instructions. |
 
-docker-agent will report an error at session start if the required binary is not found.
+Docker Agent will report an error at session start if the required binary is not found.
 
 ## Configuration
 
@@ -96,21 +96,21 @@ agents:
 
 ## What Does NOT Work
 
-Harness agents bypass the docker-agent model pipeline entirely. As a result:
+Harness agents bypass the Docker Agent model pipeline entirely. As a result:
 
-- **docker-agent toolsets are inactive.** The external CLI provides its own tools — filesystem, shell, etc. Any `toolsets:` defined on a harness agent are ignored.
-- **`model:` routing is unavailable.** The harness CLI manages model selection; docker-agent's `models:` configuration and routing rules do not apply to harness agents.
-- **Token usage tracking is unavailable.** The CLI drives the loop, so docker-agent cannot count tokens.
+- **Docker Agent toolsets are inactive.** The external CLI provides its own tools — filesystem, shell, etc. Any `toolsets:` defined on a harness agent are silently ignored.
+- **`model:` routing is unavailable.** The harness CLI manages model selection; Docker Agent's `models:` configuration and routing rules do not apply to harness agents.
+- **Token usage tracking depends on the external CLI.** Docker Agent records usage when the CLI reports it (Claude Code and Codex both report usage data). If the CLI does not emit usage data, the session will show zero token usage.
 
 <div class="callout callout-warning" markdown="1">
-<div class="callout-title">No docker-agent toolsets inside a harness
+<div class="callout-title">No Docker Agent toolsets inside a harness
 </div>
-  <p>Do not configure <code>toolsets:</code> on a harness agent — they are silently ignored. If you need docker-agent toolsets alongside external coding capabilities, use a standard sub-agent with <code>transfer_task</code> rather than a harness.</p>
+  <p>Do not configure <code>toolsets:</code> on a harness agent — they are silently ignored. If you need Docker Agent toolsets alongside external coding capabilities, use a standard sub-agent with <code>transfer_task</code> rather than a harness.</p>
 </div>
 
 ## Hook Behavior
 
-Hooks work normally on harness agents. However, events that depend on the model pipeline (such as `before_llm_call` or `after_llm_call`) will not fire because the external CLI owns the model calls.
+Hooks work normally on harness agents, including `before_llm_call` and `after_llm_call`. `before_llm_call` runs before the prompt is forwarded to the external CLI and can block or rewrite the run; `after_llm_call` fires after the CLI returns its final response.
 
 The `model_id` field in hook payloads is set to the harness label (e.g. `claude-code`) rather than a canonical `provider/model` string. This applies to `before_llm_call`, `after_llm_call`, and any other event that carries `model_id`.
 
@@ -137,16 +137,16 @@ agents:
       focused tasks and delegate each task to the most appropriate
       coding agent. Collect results and synthesize a final summary.
     sub_agents:
-      - claude_coder
-      - codex_coder
+      - claude-coder
+      - codex-coder
 
-  claude_coder:
+  claude-coder:
     description: Claude Code specialist for complex refactors
     harness:
       type: claude-code
       effort: high
 
-  codex_coder:
+  codex-coder:
     description: Codex specialist for code generation
     harness:
       type: codex
@@ -174,18 +174,18 @@ agents:
       Use background agents to run multiple coding tasks at once.
       Dispatch all tasks, then collect results when each finishes.
     sub_agents:
-      - frontend_coder
-      - backend_coder
+      - claude-coder
+      - codex-coder
     toolsets:
       - type: background_agents
 
-  frontend_coder:
+  claude-coder:
     description: Frontend specialist (Claude Code)
     harness:
       type: claude-code
       effort: medium
 
-  backend_coder:
+  codex-coder:
     description: Backend specialist (Codex)
     harness:
       type: codex

--- a/docs/features/harnesses/index.md
+++ b/docs/features/harnesses/index.md
@@ -1,0 +1,203 @@
+---
+title: "Coding Harnesses"
+description: "Delegate coding tasks to external AI coding CLIs (Claude Code, Codex, opencode) as sub-agents."
+permalink: /features/harnesses/
+---
+
+# Coding Harnesses
+
+_Delegate coding tasks to external AI coding CLIs (Claude Code, Codex, opencode) as sub-agents._
+
+## Overview
+
+A **harness** agent delegates its work to an external coding CLI — `claude` (Claude Code), `codex` (OpenAI Codex), `opencode`, or `pi` — instead of calling a model API directly. The external CLI drives the coding loop while docker-agent provides orchestration, hooks, permissions, and distribution.
+
+This pattern gives you the best of both worlds:
+
+- **External CLI strengths** — deep IDE integration, specialized coding workflows, CLI-native tool access
+- **docker-agent strengths** — multi-agent coordination, hook-based auditing and policy enforcement, permission controls, OCI distribution, and the full agent config schema
+
+<div class="callout callout-info" markdown="1">
+<div class="callout-title">When to use harnesses
+</div>
+  <p>Use a harness when you want a Claude Code / Codex / opencode session to act as a sub-agent inside a larger docker-agent workflow — for example, an orchestrator that plans work and delegates coding tasks to specialized harness agents.</p>
+</div>
+
+## Prerequisites
+
+The external CLI must be installed and available on `PATH` before starting docker-agent:
+
+| Harness type | Required binary | Install |
+| --- | --- | --- |
+| `claude-code` | `claude` | [docs.anthropic.com/en/docs/claude-code](https://docs.anthropic.com/en/docs/claude-code) |
+| `codex` | `codex` | [github.com/openai/codex](https://github.com/openai/codex) |
+| `opencode` | `opencode` | [opencode.ai](https://opencode.ai) |
+| `pi` | `pi` | [pi.ai/talk](https://pi.ai/talk) |
+
+docker-agent will report an error at session start if the required binary is not found.
+
+## Configuration
+
+Add a `harness:` block to any agent definition to make it harness-backed:
+
+```yaml
+agents:
+  coder:
+    description: A Claude Code harness agent
+    harness:
+      type: claude-code
+```
+
+Harness agents do **not** need a `model:` field — the external CLI manages its own model selection.
+
+### Field Reference
+
+| Field | Applies to | Type | Description |
+| --- | --- | --- | --- |
+| `type` | all | string | **Required.** One of `claude-code`, `codex`, `opencode`, `pi` |
+| `model` | all | string | Optional model override forwarded to the CLI |
+| `effort` | `claude-code` | string | Reasoning effort: `low` \| `medium` \| `high` \| `max` — forwarded as `--effort` |
+| `agent` | `opencode` | string | opencode agent profile name |
+| `thinking` | `opencode` | boolean | Enable extended thinking — forwarded as `--thinking` |
+
+### Claude Code
+
+```yaml
+agents:
+  coder:
+    description: Claude Code coding agent
+    harness:
+      type: claude-code
+      effort: high       # low | medium | high | max
+```
+
+### Codex
+
+```yaml
+agents:
+  coder:
+    description: Codex coding agent
+    harness:
+      type: codex
+      model: o4-mini     # optional model override
+```
+
+### opencode
+
+```yaml
+agents:
+  coder:
+    description: opencode coding agent
+    harness:
+      type: opencode
+      agent: my-profile  # optional agent profile
+      thinking: true     # enable extended thinking
+```
+
+## What Does NOT Work
+
+Harness agents bypass the docker-agent model pipeline entirely. As a result:
+
+- **docker-agent toolsets are inactive.** The external CLI provides its own tools — filesystem, shell, etc. Any `toolsets:` defined on a harness agent are ignored.
+- **`model:` routing is unavailable.** The harness CLI manages model selection; docker-agent's `models:` configuration and routing rules do not apply to harness agents.
+- **Token usage tracking is unavailable.** The CLI drives the loop, so docker-agent cannot count tokens.
+
+<div class="callout callout-warning" markdown="1">
+<div class="callout-title">No docker-agent toolsets inside a harness
+</div>
+  <p>Do not configure <code>toolsets:</code> on a harness agent — they are silently ignored. If you need docker-agent toolsets alongside external coding capabilities, use a standard sub-agent with <code>transfer_task</code> rather than a harness.</p>
+</div>
+
+## Hook Behavior
+
+Hooks work normally on harness agents. However, events that depend on the model pipeline (such as `before_llm_call` or `after_llm_call`) will not fire because the external CLI owns the model calls.
+
+The `model_id` field in hook payloads is set to the harness label (e.g. `claude-code`) rather than a canonical `provider/model` string. This applies to `before_llm_call`, `after_llm_call`, and any other event that carries `model_id`.
+
+See [Hooks]({{ '/configuration/hooks/' | relative_url }}) for the full hook reference.
+
+## Recipe: Orchestrator + Harness Sub-Agents (Sequential)
+
+An orchestrator plans the work and delegates to specialized harness agents one at a time. Each coding agent runs in its own sub-session and reports results back.
+
+```yaml
+# examples/coding_harnesses.yaml
+
+models:
+  claude:
+    provider: anthropic
+    model: claude-sonnet-4-5
+
+agents:
+  root:
+    model: claude
+    description: Orchestrator that plans and delegates coding tasks
+    instruction: |
+      You are a project orchestrator. Break down coding requests into
+      focused tasks and delegate each task to the most appropriate
+      coding agent. Collect results and synthesize a final summary.
+    sub_agents:
+      - claude_coder
+      - codex_coder
+
+  claude_coder:
+    description: Claude Code specialist for complex refactors
+    harness:
+      type: claude-code
+      effort: high
+
+  codex_coder:
+    description: Codex specialist for code generation
+    harness:
+      type: codex
+```
+
+The root agent calls `transfer_task` to send work to a harness sub-agent, waits for the result, and continues. See the [full example on GitHub](https://github.com/docker/docker-agent/blob/main/examples/coding_harnesses.yaml).
+
+## Recipe: Parallel Harness Dispatch
+
+Combine the `background_agents` toolset with harness sub-agents to dispatch multiple coding tasks simultaneously:
+
+```yaml
+# examples/coding_harness_background_agents.yaml
+
+models:
+  claude:
+    provider: anthropic
+    model: claude-sonnet-4-5
+
+agents:
+  root:
+    model: claude
+    description: Orchestrator that fans out coding tasks in parallel
+    instruction: |
+      Use background agents to run multiple coding tasks at once.
+      Dispatch all tasks, then collect results when each finishes.
+    sub_agents:
+      - frontend_coder
+      - backend_coder
+    toolsets:
+      - type: background_agents
+
+  frontend_coder:
+    description: Frontend specialist (Claude Code)
+    harness:
+      type: claude-code
+      effort: medium
+
+  backend_coder:
+    description: Backend specialist (Codex)
+    harness:
+      type: codex
+```
+
+The orchestrator calls `run_background_agent` for each task, monitors progress with `list_background_agents`, and collects results with `view_background_agent`. See the [full example on GitHub](https://github.com/docker/docker-agent/blob/main/examples/coding_harness_background_agents.yaml).
+
+For the general background agents reference, see [Background Agents]({{ '/tools/background-agents/' | relative_url }}).
+
+## See Also
+
+- [Multi-Agent Systems]({{ '/concepts/multi-agent/' | relative_url }}) — orchestration patterns
+- [Background Agents]({{ '/tools/background-agents/' | relative_url }}) — parallel task dispatch
+- [Hooks]({{ '/configuration/hooks/' | relative_url }}) — auditing and policy enforcement
+- [Agent Configuration]({{ '/configuration/agents/' | relative_url }}) — full agent schema reference

--- a/docs/features/skills/index.md
+++ b/docs/features/skills/index.md
@@ -306,5 +306,6 @@ The skill will automatically be available to any agent with skills enabled (`ski
 <div class="callout-title">See also
 </div>
   <p>Skills are enabled in the <a href="{{ '/configuration/agents/' | relative_url }}">Agent Config</a> with the <code>skills</code> property (boolean or list). For tool-based capabilities, see <a href="{{ '/concepts/tools/' | relative_url }}">Tools</a>.</p>
+  <p>Example configs: <a href="https://github.com/docker/docker-agent/blob/main/examples/skills_inline.yaml"><code>examples/skills_inline.yaml</code></a> (inline skill definition), <a href="https://github.com/docker/docker-agent/blob/main/examples/skills_filter.yaml"><code>examples/skills_filter.yaml</code></a> (filtering which skills load).</p>
 
 </div>

--- a/docs/tools/background-agents/index.md
+++ b/docs/tools/background-agents/index.md
@@ -89,18 +89,18 @@ agents:
       Dispatch the frontend and backend tasks in parallel,
       then collect results and produce a summary.
     sub_agents:
-      - frontend_coder
-      - backend_coder
+      - claude-coder
+      - codex-coder
     toolsets:
       - type: background_agents
 
-  frontend_coder:
+  claude-coder:
     description: Frontend specialist (Claude Code)
     harness:
       type: claude-code
       effort: medium
 
-  backend_coder:
+  codex-coder:
     description: Backend specialist (Codex)
     harness:
       type: codex

--- a/docs/tools/background-agents/index.md
+++ b/docs/tools/background-agents/index.md
@@ -75,3 +75,43 @@ agents:
 </div>
   <p>Use <code>background_agents</code> when your orchestrator needs to fan out work to multiple specialists in parallel — for example, researching several topics simultaneously or running independent code analyses side by side.</p>
 </div>
+
+## Using Harness Sub-Agents
+
+Background agents work equally well with [harness-backed sub-agents]({{ '/features/harnesses/' | relative_url }}) — sub-agents driven by external coding CLIs such as Claude Code or Codex. This lets you dispatch multiple independent coding tasks in parallel:
+
+```yaml
+agents:
+  root:
+    model: anthropic/claude-sonnet-4-5
+    description: Orchestrator that fans out coding tasks
+    instruction: |
+      Dispatch the frontend and backend tasks in parallel,
+      then collect results and produce a summary.
+    sub_agents:
+      - frontend_coder
+      - backend_coder
+    toolsets:
+      - type: background_agents
+
+  frontend_coder:
+    description: Frontend specialist (Claude Code)
+    harness:
+      type: claude-code
+      effort: medium
+
+  backend_coder:
+    description: Backend specialist (Codex)
+    harness:
+      type: codex
+```
+
+The orchestrator calls `run_background_agent` for each coding task, then uses `list_background_agents` and `view_background_agent` to collect results when they finish.
+
+<div class="callout callout-info" markdown="1">
+<div class="callout-title">Harness toolsets are ignored
+</div>
+  <p>Harness agents use the external CLI's own tools — any <code>toolsets:</code> configured on the harness agent are silently ignored. See <a href="{{ '/features/harnesses/' | relative_url }}">Coding Harnesses</a> for details and caveats.</p>
+</div>
+
+See [`examples/coding_harness_background_agents.yaml`](https://github.com/docker/docker-agent/blob/main/examples/coding_harness_background_agents.yaml) for a complete configuration.

--- a/docs/tools/fetch/index.md
+++ b/docs/tools/fetch/index.md
@@ -171,8 +171,8 @@ The `allowed_domains`, `blocked_domains`, and `allow_private_ips` options let yo
 **Key points:**
 
 - `allowed_domains` — allow-list; only listed hosts (and their subdomains for bare-domain entries) are reachable
-- `blocked_domains` — deny-list; takes priority over allowed; cannot be combined with `allowed_domains`
+- `blocked_domains` — deny-list; mutually exclusive with `allowed_domains` (a config error is thrown if both are set)
 - `allow_private_ips` — defaults to `false`; set to `true` to reach loopback / RFC-1918 / link-local addresses
-- The same `allow_private_ips` flag applies to [remote MCP toolsets]({{ '/tools/mcp/' | relative_url }}) when their OAuth helper needs to reach internal servers
+- The same `allow_private_ips` flag is also supported on `api`, `openapi`, `a2a`, and remote `mcp` toolsets
 
 See [`examples/fetch_domain_filtering.yaml`](https://github.com/docker/docker-agent/blob/main/examples/fetch_domain_filtering.yaml) for a complete filtering example, and [`examples/remote_mcp_allow_private_ips.yaml`](https://github.com/docker/docker-agent/blob/main/examples/remote_mcp_allow_private_ips.yaml) for the equivalent pattern on remote MCP toolsets.

--- a/docs/tools/fetch/index.md
+++ b/docs/tools/fetch/index.md
@@ -163,3 +163,16 @@ Responses are capped at **1 MB** per URL. Hosts that disallow the agent's user-a
 </div>
   <p>Use <code>fetch</code> when the agent needs to read arbitrary public URLs at runtime. Use the <a href="{{ '/tools/api/' | relative_url }}">API tool</a> to expose specific, structured HTTP endpoints (including non-<code>GET</code> verbs) as named tools.</p>
 </div>
+
+## Domain Filtering
+
+The `allowed_domains`, `blocked_domains`, and `allow_private_ips` options let you control which hosts the fetch tool may reach. The complete reference is in the [Options](#options) table and [Domain matching](#domain-matching) section above.
+
+**Key points:**
+
+- `allowed_domains` — allow-list; only listed hosts (and their subdomains for bare-domain entries) are reachable
+- `blocked_domains` — deny-list; takes priority over allowed; cannot be combined with `allowed_domains`
+- `allow_private_ips` — defaults to `false`; set to `true` to reach loopback / RFC-1918 / link-local addresses
+- The same `allow_private_ips` flag applies to [remote MCP toolsets]({{ '/tools/mcp/' | relative_url }}) when their OAuth helper needs to reach internal servers
+
+See [`examples/fetch_domain_filtering.yaml`](https://github.com/docker/docker-agent/blob/main/examples/fetch_domain_filtering.yaml) for a complete filtering example, and [`examples/remote_mcp_allow_private_ips.yaml`](https://github.com/docker/docker-agent/blob/main/examples/remote_mcp_allow_private_ips.yaml) for the equivalent pattern on remote MCP toolsets.

--- a/docs/tools/filesystem/index.md
+++ b/docs/tools/filesystem/index.md
@@ -84,7 +84,7 @@ restriction visible to the model so it can adjust its plan.
 
 ### Post-Edit Hooks
 
-Automatically run formatting or other commands after file edits:
+Automatically run formatting, linting, or other commands after the agent edits a file. The command fires once per file after each edit operation (including `write_file`, `patch_file`, and similar mutations). Use `${file}` as a placeholder for the absolute path of the edited file.
 
 ```yaml
 toolsets:
@@ -95,7 +95,18 @@ toolsets:
         cmd: "gofmt -w ${file}"
       - path: "*.ts"
         cmd: "prettier --write ${file}"
+      - path: "src/**/*.py"
+        cmd: "black ${file}"
 ```
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `path` | string | Glob pattern matched against the file path. `*.go` matches any `.go` file; `src/**/*.ts` matches `.ts` files anywhere under `src/`. |
+| `cmd` | string | Shell command to run. `${file}` expands to the absolute path of the just-edited file. |
+
+Post-edit commands run with the same working directory as the agent. If a command exits non-zero, the error is logged and surfaced to the model as a warning, but the edit is not rolled back.
+
+See [`examples/post_edit.yaml`](https://github.com/docker/docker-agent/blob/main/examples/post_edit.yaml) for a complete example.
 
 <div class="callout callout-tip" markdown="1">
 <div class="callout-title">Tip

--- a/docs/tools/mcp/index.md
+++ b/docs/tools/mcp/index.md
@@ -174,7 +174,9 @@ toolsets:
 
 ### TOON-encoded outputs
 
-Re-encode verbose JSON outputs as the compact [TOON](https://github.com/alpkeskin/gotoon) format to save context budget. Typically yields 30–60% smaller payloads on list/search tools:
+Re-encode verbose JSON outputs as the compact [TOON](https://github.com/alpkeskin/gotoon) format to save context budget. Typically yields 30–60% smaller payloads on list/search tools.
+
+`toon` is a regex string that is matched against tool names. Any tool whose name matches the pattern has its JSON output transparently re-encoded as TOON before it is shown to the model. The re-encoding reduces schema verbosity, which is especially useful when a model struggles with large or repetitive tool output.
 
 ```yaml
 toolsets:
@@ -185,6 +187,10 @@ toolsets:
     command: my-server
     toon: "list_.*,get_.*" # only toonify list_/get_ tools
 ```
+
+The value is a comma-separated list of regexes (or a single regex). A tool name must match at least one pattern to be re-encoded. Setting `toon: ".*"` re-encodes all tools from that toolset.
+
+See [`examples/github-toon.yaml`](https://github.com/docker/docker-agent/blob/main/examples/github-toon.yaml) for a practical example using the GitHub MCP server.
 
 ### Per-toolset model routing
 


### PR DESCRIPTION
Addresses the gap analysis (artifact d7dff17d-15d5-49b4-966e-ee6ee006f5f6).

**New pages**
- `docs/features/harnesses/index.md` — Coding Harnesses (P0): full reference for `harness:` field, claude-code/codex/opencode/pi types, sequential and parallel recipes, limitations, hook behavior

**Pages updated**
- `docs/_data/nav.yml` — added Coding Harnesses to Features nav
- `docs/configuration/agents/index.md` — harness field in schema + table; agent-switching commands subsection; welcome_message description expanded
- `docs/configuration/hooks/index.md` — model_id note links to harnesses page; snapshot_hooks.yaml example link
- `docs/configuration/models/index.md` — task_budget.yaml example link
- `docs/configuration/tools/index.md` — ORIGINAL_INSTRUCTIONS placeholder docs; Deferred Tool Loading expanded; lifecycle.yaml and deferred.yaml links
- `docs/concepts/multi-agent/index.md` — Harness-Backed Sub-Agents section; sub-agents-from-catalog.yaml link
- `docs/tools/background-agents/index.md` — Using Harness Sub-Agents section
- `docs/tools/fetch/index.md` — Domain Filtering summary section with example links
- `docs/tools/filesystem/index.md` — Post-Edit Hooks section expanded with field table and post_edit.yaml link
- `docs/tools/mcp/index.md` — TOON section expanded with regex semantics and github-toon.yaml link
- `docs/features/skills/index.md` — skills_inline.yaml and skills_filter.yaml example links

Validated: `golangci-lint run` (0 issues), `task build` (builds cleanly).