### PR TITLE
docs: update documentation for agent-picker, MCP embedded resources, and remote MCP OAuth cancel

### DIFF
--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -47,6 +47,7 @@ $ docker agent run [config] [message...] [flags]
 | `--template <image>`                    | Template image for the sandbox (default: `docker/sandbox-templates:docker-agent`)                                                         |
 | `--sbx`                                 | Prefer the `sbx` CLI backend when available (default `true`; set `--sbx=false` to force `docker sandbox`)                                 |
 | `--no-kit`                              | Disable the [auto-kit]({{ '/configuration/sandbox/' | relative_url }}#auto-kit): do not stage skills or prompt files into the sandbox    |
+| `--agent-picker [refs]`                 | Show a full-screen interactive picker before launching, letting you browse and select an agent. Accepts an optional comma-separated list of agent references to show (defaults to `default,coder`). Arrow keys navigate; `?` toggles the YAML preview panel; Enter confirms. Not available in `--exec` or non-TTY modes. |
 | `-w, --worktree [name]`                 | Run the agent in a fresh git worktree of the working directory, isolating its changes from your checkout. Optionally name it (`--worktree=my-feature`); otherwise a name is generated. Requires the working directory to be inside a git repository. Cannot be combined with `--remote` or `--sandbox`. When the session ends, a clean worktree is removed automatically; one with work prompts to keep or remove (never in `--exec`). |
 | `--worktree-pr <number\|url>`            | Run the agent in a git worktree checked out on an existing GitHub pull request (PR number, `#123`, or PR URL). Continues the PR's branch so commits push back to it. Requires the [GitHub CLI](https://cli.github.com/) (`gh`). Cannot be combined with `--worktree`, `--remote`, or `--sandbox`. |
 | `--working-dir <path>`                  | Set the working directory for the session (applies to tools and relative paths)                                                           |
@@ -87,6 +88,10 @@ $ docker agent run agent.yaml "question 1" "question 2" "question 3"
 $ docker agent run agent.yaml --app-name "My Project"
 $ docker agent run agent.yaml --sidebar=false
 $ docker agent run agent.yaml --disable-commands="/cost,/eval,/model"
+
+# Browse and pick an agent interactively
+$ docker agent run --agent-picker
+$ docker agent run --agent-picker=agentcatalog/coder,agentcatalog/researcher
 ```
 
 <div class="callout callout-tip" markdown="1">

--- a/docs/features/remote-mcp/index.md
+++ b/docs/features/remote-mcp/index.md
@@ -30,7 +30,7 @@ toolsets:
 <div class="callout callout-tip" markdown="1">
 <div class="callout-title">Cancelling the authorization dialog
 </div>
-  <p>If you dismiss the OAuth authorization dialog, the request is cancelled cleanly — no repeated prompts appear. The agent will report that authorization was declined and offer to retry. To try again, simply re-enable the server or repeat the request that triggered the flow.</p>
+  <p>If you dismiss the OAuth authorization dialog, the request is cancelled cleanly — no repeated prompts appear. The agent will report that authorization was declined. To try again, simply re-enable the server or repeat the request that triggered the flow.</p>
 
 </div>
 

--- a/docs/features/remote-mcp/index.md
+++ b/docs/features/remote-mcp/index.md
@@ -27,6 +27,13 @@ toolsets:
 
 </div>
 
+<div class="callout callout-tip" markdown="1">
+<div class="callout-title">Cancelling the authorization dialog
+</div>
+  <p>If you dismiss the OAuth authorization dialog, the request is cancelled cleanly — no repeated prompts appear. The agent will report that authorization was declined and offer to retry. To try again, simply re-enable the server or repeat the request that triggered the flow.</p>
+
+</div>
+
 ## Configuration
 
 ```yaml

--- a/docs/tools/mcp/index.md
+++ b/docs/tools/mcp/index.md
@@ -109,7 +109,7 @@ For a curated list of public remote MCP endpoints (Linear, GitHub, Vercel, Notio
 MCP tool results can include embedded resources — images, PDFs, and text files returned directly in the tool response. Docker Agent preserves these as attachments and forwards them to the model as native content blocks:
 
 - **Anthropic** — images become `image` blocks in the `tool_result`; PDFs and other documents become `document` blocks.
-- **OpenAI** — images and PDFs are forwarded as `input_file` data URIs in the tool result content.
+- **OpenAI** — images are forwarded as `input_image` data URIs; PDFs as `input_file` data URIs in the tool result content.
 - **Bedrock** and **Gemini** — receive equivalent provider-native representations.
 
 No configuration is required. When an MCP server returns an embedded resource alongside its text output, the resource is automatically attached and sent to the model on the next turn. This is useful for MCP servers that generate charts, export PDFs, or return binary data as part of their responses.

--- a/docs/tools/mcp/index.md
+++ b/docs/tools/mcp/index.md
@@ -104,6 +104,16 @@ toolsets:
 
 For a curated list of public remote MCP endpoints (Linear, GitHub, Vercel, Notion, …) and full OAuth configuration details, see [Remote MCP Servers]({{ '/features/remote-mcp/' | relative_url }}).
 
+## Embedded Resources
+
+MCP tool results can include embedded resources — images, PDFs, and text files returned directly in the tool response. Docker Agent preserves these as attachments and forwards them to the model as native content blocks:
+
+- **Anthropic** — images become `image` blocks in the `tool_result`; PDFs and other documents become `document` blocks.
+- **OpenAI** — images and PDFs are forwarded as `input_file` data URIs in the tool result content.
+- **Bedrock** and **Gemini** — receive equivalent provider-native representations.
+
+No configuration is required. When an MCP server returns an embedded resource alongside its text output, the resource is automatically attached and sent to the model on the next turn. This is useful for MCP servers that generate charts, export PDFs, or return binary data as part of their responses.
+
 ## Reusable Definitions (`mcps:`)
 
 Repeated MCP server configurations can be hoisted into the top-level `mcps:` section and referenced by name with `{type: mcp, ref: <name>}`:


### PR DESCRIPTION
## Summary

This PR updates the documentation to reflect three features and fixes merged into `main` in the last 36 hours.

### Changes

- **`docs/features/cli/index.md`** — Document the `--agent-picker` flag added in #2937. The flag was missing from the CLI reference table entirely. Added the flag row and two usage examples showing bare and ref-list invocations.

- **`docs/tools/mcp/index.md`** — Document MCP embedded resource forwarding added in #2935. MCP tool results can now include embedded images, PDFs, and text resources that are forwarded to model providers as native content blocks (Anthropic image/document blocks, OpenAI input_file data URIs, Bedrock/Gemini equivalents). Added a new "Embedded Resources" section explaining the behavior and noting that no configuration is required.

- **`docs/features/remote-mcp/index.md`** — Document the OAuth authorization cancel behavior fixed in #2949. Dismissing the OAuth dialog now cancels cleanly without repeated prompts, and the agent reports authorization declined instead of claiming success. Added a callout explaining this behavior and how to retry.

### Source PRs covered

| Commit | Source PR | What changed |
|--------|-----------|-------------|
| 6a47819b | #2937 | `--agent-picker` interactive agent selection flag |
| 918ad504 | #2935 | MCP embedded image/PDF/text resource forwarding |
| 1569209f | #2949 | Remote MCP OAuth cancel behavior fix |