### PR TITLE
fix(gemini): coalesce parallel tool responses into a single Content

### DIFF
--- a/pkg/model/provider/gemini/client.go
+++ b/pkg/model/provider/gemini/client.go
@@ -196,6 +196,19 @@ func thoughtSignatureOrDefault(sig []byte) []byte {
 // convertMessagesToGemini converts chat.Messages into Gemini Contents
 func convertMessagesToGemini(ctx context.Context, messages []chat.Message, id modelsdev.ID, store *modelsdev.Store) []*genai.Content {
 	contents := make([]*genai.Content, 0, len(messages))
+
+	// Vertex Gemini rejects a request unless the turn answering an N-function-call turn
+	// carries exactly N function-response parts, so consecutive tool responses are
+	// coalesced into a single Content instead of one Content per response.
+	var pendingToolParts []*genai.Part
+	var pendingToolRole genai.Role
+	flushToolParts := func() {
+		if len(pendingToolParts) > 0 {
+			contents = append(contents, genai.NewContentFromParts(pendingToolParts, pendingToolRole))
+			pendingToolParts = nil
+		}
+	}
+
 	for i := range messages {
 		msg := &messages[i]
 
@@ -206,7 +219,7 @@ func convertMessagesToGemini(ctx context.Context, messages []chat.Message, id mo
 
 		role := messageRoleToGemini(msg.Role)
 
-		// Handle tool responses
+		// Handle tool responses (accumulated, then flushed as one Content)
 		if msg.Role == chat.MessageRoleTool && msg.ToolCallID != "" {
 			response := map[string]any{"result": msg.Content}
 
@@ -218,9 +231,12 @@ func convertMessagesToGemini(ctx context.Context, messages []chat.Message, id mo
 			} else {
 				part = genai.NewPartFromFunctionResponse(msg.ToolCallID, response)
 			}
-			contents = append(contents, genai.NewContentFromParts([]*genai.Part{part}, role))
+			pendingToolParts = append(pendingToolParts, part)
+			pendingToolRole = role
 			continue
 		}
+
+		flushToolParts()
 
 		// Handle assistant messages with tool calls
 		if msg.Role == chat.MessageRoleAssistant && len(msg.ToolCalls) > 0 {
@@ -255,6 +271,9 @@ func convertMessagesToGemini(ctx context.Context, messages []chat.Message, id mo
 			contents = append(contents, genai.NewContentFromParts([]*genai.Part{part}, role))
 		}
 	}
+
+	flushToolParts()
+
 	return contents
 }
 

--- a/pkg/model/provider/gemini/client_test.go
+++ b/pkg/model/provider/gemini/client_test.go
@@ -493,3 +493,41 @@ func TestBuildConfig_ThinkingFromBudget(t *testing.T) {
 	assert.True(t, config.ThinkingConfig.IncludeThoughts, "IncludeThoughts should be true")
 	assert.Equal(t, genai.ThinkingLevelHigh, config.ThinkingConfig.ThinkingLevel, "ThinkingLevel should match ThinkingBudget")
 }
+
+func TestConvertMessagesToGemini_ParallelToolResponsesCoalesced(t *testing.T) {
+	t.Parallel()
+
+	// An assistant turn emits two parallel function calls, followed by the two tool
+	// responses. Vertex Gemini requires those responses to be delivered as a single
+	// Content with two FunctionResponse parts (matching the two FunctionCall parts of
+	// the preceding turn). Regression test for the "number of function response parts is
+	// equal to the number of function call parts" INVALID_ARGUMENT error.
+	messages := []chat.Message{
+		{Role: chat.MessageRoleUser, Content: "go"},
+		{
+			Role: chat.MessageRoleAssistant,
+			ToolCalls: []tools.ToolCall{
+				{ID: "call-1", Function: tools.FunctionCall{Name: "tool_a", Arguments: `{}`}},
+				{ID: "call-2", Function: tools.FunctionCall{Name: "tool_b", Arguments: `{"x":1}`}},
+			},
+		},
+		{Role: chat.MessageRoleTool, ToolCallID: "call-1", Content: "result-a"},
+		{Role: chat.MessageRoleTool, ToolCallID: "call-2", Content: "result-b"},
+	}
+
+	contents := convertMessagesToGemini(t.Context(), messages, modelsdev.ID{}, modelsdev.NewDatabaseStore(&modelsdev.Database{}))
+
+	// user + assistant(2 function calls) + ONE coalesced tool-response content.
+	require.Len(t, contents, 3)
+
+	assistant := contents[1]
+	assert.Equal(t, genai.RoleModel, assistant.Role)
+	require.Len(t, assistant.Parts, 2)
+
+	toolResp := contents[2]
+	require.Len(t, toolResp.Parts, 2,
+		"two parallel tool responses must be coalesced into one Content with two FunctionResponse parts")
+	for i, p := range toolResp.Parts {
+		require.NotNil(t, p.FunctionResponse, "part %d should be a FunctionResponse", i)
+	}
+}


### PR DESCRIPTION
Fixes #2958.

## Problem

When a Gemini model (via Vertex AI) returns parallel function calls (multiple `functionCall` parts in one assistant turn), `convertMessagesToGemini` returned each tool result as its **own** `genai.Content` (one `functionResponse` part per `Content`). Vertex AI requires the response turn to carry the same number of `functionResponse` parts as the preceding turn's `functionCall` parts, so the request fails with:

```
Error 400 ... Please ensure that the number of function response parts is equal to the number of function call parts of the function call turn. INVALID_ARGUMENT
```

This is deterministic for a given turn, so retries reproduce it and the run eventually aborts. There is no opt-out: Vertex Gemini exposes no parameter to disable parallel function calling (`go-genai` `FunctionCallingConfig` only has `Mode`).

## Change

`convertMessagesToGemini` now **coalesces consecutive tool-response messages into a single `Content` (role `user`) with N `functionResponse` parts**, flushing on the next non-tool message and at the end of the loop — instead of emitting one `Content` per response. Single (non-parallel) tool calls are unaffected (one response → one Content).

Added regression test `TestConvertMessagesToGemini_ParallelToolResponsesCoalesced` (fails on `main`, passes with this change).

## Reference

Per the Vertex AI function-calling docs, parallel results are returned together as one `Content(role="user", parts=function_response_parts)` with the part count matching the calls:
- https://docs.cloud.google.com/vertex-ai/generative-ai/docs/multimodal/function-calling
- https://docs.cloud.google.com/vertex-ai/generative-ai/docs/samples/generativeaionvertexai-function-calling-generate-parallel-calls

## Verification

- `go build ./...` — ok
- `go vet ./pkg/model/provider/gemini/...` — ok
- `go test ./pkg/model/provider/...` — ok
- `golangci-lint run` (repo `.golangci.yml`, v2.12.2) — 0 issues
