### PR TITLE
fix: update github-copilot model from gpt-4o to gpt-4.1

### DIFF
--- a/examples/github-copilot.yaml
+++ b/examples/github-copilot.yaml
@@ -13,16 +13,16 @@
 
 agents:
   root:
-    model: github-copilot/gpt-4o
+    model: github-copilot/gpt-4.1
     description: A helpful AI assistant powered by GitHub Copilot
     instruction: |
       You are a helpful AI assistant.
       Be helpful, accurate, and concise in your responses.
 
 models:
-  github-copilot/gpt-4o:
+  github-copilot/gpt-4.1:
     provider: github-copilot
-    model: gpt-4o
+    model: gpt-4.1
     # Optional: override the default Copilot-Integration-Id header or add
     # any other custom HTTP headers. Header names are matched
     # case-insensitively against the default.


### PR DESCRIPTION
The GitHub Copilot provider removed `gpt-4o` from models.dev, causing `TestParseExamples` in `pkg/config` to fail. This test validates every example config's model against the live models.dev catalog. CI fetches fresh data and fails; locally it passed due to a stale 24h cache that still contained `gpt-4o`.

Updated `examples/github-copilot.yaml` to use `gpt-4.1` (a currently-available Copilot model) for both the agent's model reference and the models entry. Verified `go test ./pkg/config/...` passes against freshly-fetched models.dev data.