### PR TITLE
feat(mcp_catalog): block enable_remote_mcp_server until the server is connected

### DIFF
--- a/docs/tools/mcp-catalog/index.md
+++ b/docs/tools/mcp-catalog/index.md
@@ -56,7 +56,7 @@ Up to five tools are exposed to the model. The disable / reset-auth pair only ap
 | Tool                            | When visible            | Description                                                                                                                                          |
 | ------------------------------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `search_remote_mcp_servers`     | Always                  | Case-insensitive fuzzy search over id, title, description, category and tags. Returns id, auth requirements (`oauth` / `api_key` / `none`) and URL. |
-| `enable_remote_mcp_server`      | Always                  | Activate a server by id. The actual MCP handshake (and any OAuth flow) is deferred until the host next enumerates tools.                            |
+| `enable_remote_mcp_server`      | Always                  | Activate a server by id. **Blocks** until the connection (and any required OAuth handshake) completes; on success the server's tools are immediately live and the model continues with the user's original request in the same turn. |
 | `list_remote_mcp_servers`       | Always                  | Show currently enabled servers and their connection state.                                                                                           |
 | `disable_remote_mcp_server`     | After first enable      | Stop a server and remove its tools from the active set.                                                                                              |
 | `reset_remote_mcp_server_auth`  | After first enable      | Drop persisted OAuth credentials so the next enable triggers a fresh authorization flow. No-op for `api_key` / `none` servers.                       |
@@ -64,7 +64,9 @@ Up to five tools are exposed to the model. The disable / reset-auth pair only ap
 ### Workflow
 
 1. The agent calls `search_remote_mcp_servers` with a keyword matching the user's intent (`"notion"`, `"stripe"`, `"docs"`, `"browser"`, …).
-2. It picks a matching server id and calls `enable_remote_mcp_server`. The server's tools become available on the **next turn**.
+2. It picks a matching server id and calls `enable_remote_mcp_server`. **`enable` blocks** until the MCP handshake (and any required OAuth flow) completes:
+   - on success the server's tools are available **in the same turn** — the agent goes straight to the user's original request, no re-ask required;
+   - on failure (user dismissed the authorization dialog, missing env var, server refused) the tool returns an error result naming the specific reason so the agent can recover instead of pretending the server is connected.
 3. It uses the newly activated tools as it would any other.
 4. When done, it calls `disable_remote_mcp_server` to remove the server from the active set.
 
@@ -72,8 +74,8 @@ Up to five tools are exposed to the model. The disable / reset-auth pair only ap
 
 The catalog distinguishes three auth flavours:
 
-- **`oauth`** — On the first turn that enumerates the server's tools, an authorization URL is surfaced through the elicitation pipeline (the same one used by YAML-declared remote MCP toolsets). Once the user authorizes, tokens are persisted in the OS keyring and re-used on subsequent runs. Use `reset_remote_mcp_server_auth` to wipe them.
-- **`api_key`** — The server expects one or more env vars to be set in the agent's environment (e.g. `APIFY_API_KEY`, `BRAVE_API_KEY`). `enable_remote_mcp_server` warns if any required variable is missing — set it, then re-enable the server.
+- **`oauth`** — `enable_remote_mcp_server` surfaces an authorization URL through the elicitation pipeline (the same one used by YAML-declared remote MCP toolsets) and blocks until the user either authorizes or cancels. Once the user authorizes, tokens are persisted in the OS keyring and re-used on subsequent runs. Use `reset_remote_mcp_server_auth` to wipe them. If the user dismisses the dialog, `enable` returns an error result naming the decline so the agent can ask whether to retry.
+- **`api_key`** — The server expects one or more env vars to be set in the agent's environment (e.g. `APIFY_API_KEY`, `BRAVE_API_KEY`). `enable_remote_mcp_server` returns an error result if any required variable is missing — set it, then call `enable` again.
 - **`none`** — No authentication. The server is reachable as soon as it is enabled.
 
 Search results only carry the auth flavour (`oauth` / `api_key` / `none`); the specific env-var names are surfaced by `enable_remote_mcp_server` when it detects an unset variable, so you may need to enable an `api_key` server once just to learn which variable to set.
@@ -101,7 +103,7 @@ A complete, runnable configuration lives in [`examples/mcp_catalog.yaml`](https:
 ## Notes and Limitations
 
 - **Streamable-http only.** The catalog deliberately excludes servers that require a local subprocess or the MCP gateway — declare those with [`type: mcp`]({{ '/configuration/tools/#mcp-tools' | relative_url }}) instead.
-- **Lazy connect.** DNS, TCP, MCP handshake and OAuth flow happen the first time the host enumerates tools for a freshly enabled server. On startup the runtime probes tools non-interactively, so OAuth-pending servers fail fast and are silently deferred to the next interactive turn.
+- **Blocking enable.** DNS, TCP, MCP handshake and any OAuth flow happen synchronously inside `enable_remote_mcp_server` so the agent gets a deterministic result in the same turn. On startup, however, the runtime probes tools non-interactively (`mcp.WithoutInteractivePrompts`); OAuth-pending servers fail fast there and are silently deferred to the next interactive turn — including the sidebar-only tool-count pass, where a dialog would be impossible.
 - **No prompt discovery.** MCP prompt lookups (`/prompts`) walk YAML-declared `mcp` toolsets directly; prompts exposed by servers activated through the catalog are not surfaced. Tools — the primary interface — work fine.
 - **Frozen at build time.** The list of servers is embedded in the binary. New entries land with each docker-agent release.
 

--- a/pkg/tools/builtin/mcpcatalog/mcpcatalog.go
+++ b/pkg/tools/builtin/mcpcatalog/mcpcatalog.go
@@ -8,8 +8,9 @@
 //     curated catalog (id / title / description / category / tags).
 //   - list_remote_mcp_servers   — show currently enabled servers.
 //   - enable_remote_mcp_server  — instantiate an *mcp.Toolset for a server
-//     (defers the actual TCP connect / OAuth handshake until Tools() is
-//     next enumerated).
+//     and synchronously drive its connect (including any required OAuth
+//     handshake) so the model gets a deterministic success / declined /
+//     transport-error result in the same turn.
 //   - disable_remote_mcp_server — stop the toolset and remove its tools.
 //     Only exposed once at least one server is enabled.
 //   - reset_remote_mcp_server_auth — drop persisted OAuth credentials so
@@ -26,11 +27,20 @@
 // (the primary interface) work fine; the prompt feature would need a
 // separate plumb-through interface to walk into container toolsets.
 //
-// On-demand semantics: the expensive parts — DNS, TCP, MCP handshake,
-// OAuth flow — happen the first time Tools() is called for a freshly
-// enabled server. The handshake runs through the same lifecycle.Supervisor
-// the YAML-declared `mcp.remote` toolset uses, so OAuth elicitation and
-// tool-list-change notifications behave identically.
+// On-demand semantics: DNS, TCP, MCP handshake and any OAuth flow happen
+// synchronously inside enable_remote_mcp_server's handler. Tool calls run
+// with an interactive context, so OAuth elicitation surfaces a dialog and
+// blocks until the user responds; the handshake runs through the same
+// lifecycle.Supervisor the YAML-declared `mcp.remote` toolset uses, so
+// elicitation and tool-list-change notifications behave identically. The
+// handler returns a deterministic success / declined / auth-required /
+// transport-error result so the model can continue with the user's
+// original request in the *same* turn (success) or recover appropriately
+// (failure) — no second user message required. Tools() additionally
+// retries any toolset left in the "deferred — auth required" state, which
+// keeps the startup non-interactive probe (mcp.WithoutInteractivePrompts)
+// from hanging while still surfacing OAuth dialogs on the first
+// interactive turn.
 package mcpcatalog
 
 import (
@@ -95,6 +105,14 @@ type Toolset struct {
 	// Defaults to mcp.RemoveOAuthToken; tests inject a stub to avoid
 	// touching the OS keyring.
 	removeOAuthToken func(resourceURL string) error
+
+	// startToolset drives the inner mcp.Toolset connect (including any
+	// OAuth handshake) synchronously from handleEnable so the model
+	// gets a deterministic success/decline/error result in the same
+	// turn. Defaults to (*tools.StartableToolSet).Start; tests inject a
+	// stub to exercise the success / declined / auth-required / errored
+	// branches without standing up a real MCP server.
+	startToolset func(ctx context.Context, ts *tools.StartableToolSet) error
 }
 
 var (
@@ -150,6 +168,9 @@ func New(envProvider environment.Provider, opts ...Option) *Toolset {
 		env:              envProvider,
 		enabled:          make(map[string]*tools.StartableToolSet),
 		removeOAuthToken: mcp.RemoveOAuthToken,
+		startToolset: func(ctx context.Context, ts *tools.StartableToolSet) error {
+			return ts.Start(ctx)
+		},
 	}
 	t.filterCatalog(cfg.allowedServers, cfg.blockedServers)
 	return t
@@ -251,18 +272,26 @@ Workflow:
      Use any term related to the user's intent ("notion", "stripe",
      "docs", "search", "browser", …).
   2. Call ` + ToolNameEnable + ` with the server's "id" to activate it.
-     The server's tools appear in your set on the *next* turn; the host
-     handles any required connection setup. For api_key servers, make
-     sure the listed env var(s) are set in the user's shell BEFORE
-     enabling, otherwise the server will refuse the connection.
-  3. On your NEXT turn (once the activated server's tools appear in
-     your set), go straight to the user's ORIGINAL request using those
-     tools. Do NOT stop and ask the user to repeat themselves; do NOT
-     narrate connection setup. Enabling a server is a means to an end,
-     not a stopping point.
-  4. Call ` + ToolNameDisable + ` to remove a server when no longer needed.
+     This call BLOCKS until the connection (and any required OAuth
+     handshake) completes, so by the time it returns you have a
+     deterministic answer:
+       - SUCCESS — the server's tools (names prefixed with the server's
+         id and an underscore) are live. Continue with the user's
+         ORIGINAL request using them right away. Do NOT stop, do NOT
+         ask the user to repeat themselves, do NOT narrate connection
+         setup. Enabling a server is a means to an end, not a stopping
+         point.
+       - ERROR — the result text tells you exactly why (user declined
+         the authorization dialog, missing env var, server refused).
+         Act on that specific reason; do NOT pretend the server is
+         connected and do NOT call any "<id>_..." tools (there are
+         none).
+     For api_key servers, make sure the listed env var(s) are set in
+     the user's shell BEFORE enabling, otherwise the enable will fail
+     with a missing-env warning.
+  3. Call ` + ToolNameDisable + ` to remove a server when no longer needed.
      This tool only appears once at least one server is enabled.
-  5. If a previously enabled server starts rejecting requests
+  4. If a previously enabled server starts rejecting requests
      (credentials revoked, scopes changed, signed in to the wrong
      account), call ` + ToolNameResetAuth + ` to clear any persisted
      credentials so the next enable starts fresh. This tool also only
@@ -418,7 +447,7 @@ func (t *Toolset) Tools(ctx context.Context) ([]tools.Tool, error) {
 		{
 			Name:         ToolNameEnable,
 			Category:     "mcp_catalog",
-			Description:  "Activate a remote MCP server from the catalog by id. Connection setup is deferred until the host next enumerates tools; the server's tools become available on the next turn.",
+			Description:  "Activate a remote MCP server from the catalog by id. Blocks until the connection (and any required OAuth handshake) completes; on success the server's tools are immediately available and you should continue with the user's original request using them.",
 			Parameters:   tools.MustSchemaFor[EnableArgs](),
 			OutputSchema: tools.MustSchemaFor[string](),
 			Handler:      tools.NewHandler(t.handleEnable),
@@ -660,11 +689,13 @@ func (t *Toolset) handleEnable(ctx context.Context, args EnableArgs) (*tools.Too
 		return tools.ResultError(fmt.Sprintf("unknown server id %q (use %s first to discover available ids)", id, ToolNameSearch)), nil
 	}
 
-	// Pre-flight: warn (don't block) if an api_key server is missing its env var.
-	// We do not block because the user may set the variable later, or rely on
-	// the model to surface the error from the first tool call.
-	// Perform these slow external calls BEFORE acquiring the lock — server data
-	// is immutable (from t.byID), no mutex protection needed here.
+	// Pre-flight: block if an api_key server is missing its env var. The
+	// catalog promises enable returns a deterministic answer in the same
+	// turn, so we cannot register a toolset we already know will be
+	// rejected on the first request. The model is told to ask the user to
+	// set the variable and retry.
+	// Perform these slow external calls BEFORE acquiring the lock — server
+	// data is immutable (from t.byID), no mutex protection needed here.
 	missing := t.missingAPIKeyEnv(ctx, server)
 	headers := t.expandHeaders(ctx, server.Headers)
 
@@ -677,11 +708,29 @@ func (t *Toolset) handleEnable(ctx context.Context, args EnableArgs) (*tools.Too
 			missing = append(missing, env)
 		}
 	}
+	if len(missing) > 0 {
+		return tools.ResultError(fmt.Sprintf(
+			"cannot enable %q: the following env var(s) are NOT set: %s. "+
+				"Ask the user to set them in their shell, then call %s for this id again. "+
+				"Do NOT pretend the server is connected — no tools were activated.",
+			id, strings.Join(missing, ", "), ToolNameEnable)), nil
+	}
 
 	t.mu.Lock()
-	if _, exists := t.enabled[id]; exists {
+	if existing, exists := t.enabled[id]; exists {
+		started := existing.IsStarted()
 		t.mu.Unlock()
-		return tools.ResultSuccess(fmt.Sprintf("server %q is already enabled", id)), nil
+		// Idempotent re-enable. If the toolset is already started, its
+		// tools are live; otherwise the previous enable hit a deferred-
+		// auth fallback and the user can retry via disable+enable.
+		if started {
+			return tools.ResultSuccess(fmt.Sprintf(
+				"server %q is already enabled and connected. Its tools (names starting with %q) are live; proceed with the user's original request using them.",
+				id, id+"_")), nil
+		}
+		return tools.ResultSuccess(fmt.Sprintf(
+			"server %q is already enabled but not yet connected (likely waiting on user authorization). If the user has just authorized, retry their original request; otherwise tell them the connection still needs authorization.",
+			id)), nil
 	}
 
 	// Create the MCP toolset with the pre-computed headers.
@@ -717,27 +766,73 @@ func (t *Toolset) handleEnable(ctx context.Context, args EnableArgs) (*tools.Too
 	notify := t.toolsChangedHandler
 	t.mu.Unlock()
 
-	// Notify the runtime that the meta-tool surface itself changed.
+	// Notify the runtime that the meta-tool surface changed (disable /
+	// reset_auth become visible the moment the entry lands in t.enabled).
+	// Done BEFORE the synchronous Start so the TUI can reflect the
+	// pending server while the (potentially slow) OAuth dialog is open.
 	if notify != nil {
 		notify()
 	}
 
-	msg := strings.Builder{}
-	fmt.Fprintf(&msg, "enable requested for %q (%s). The host will surface any required authorization dialog. On your next turn:\n", id, server.Title)
-	fmt.Fprintf(&msg, "  - if tools whose names start with %q appear in your available tools, proceed with the user's original request using them.\n", id+"_")
-	fmt.Fprintf(&msg, "  - if NO such tools appear, the user dismissed the authorization dialog. Do NOT claim the server is connected and do NOT ask the user for workspace details to use \"the available tools\" (there are none). Tell the user the request needs them to authorize the connection. If the user then re-asks for the same thing (or says \"yes\", \"retry\", \"try again\", etc.), call %s for this id again to surface a fresh authorization dialog.\n", ToolNameEnable)
-	fmt.Fprintf(&msg, "endpoint: %s\n", server.URL)
-	// Only surface unresolved env vars — the model can act on those by
-	// asking the user to set the variable and retrying. Every other auth
-	// detail (OAuth flow type, redirect URI, token persistence) is the
-	// host's concern and is intentionally not exposed to the model; the
-	// previous wording leaked "auth: OAuth — elicited on the next turn"
-	// and led the model to stop and ask the user to repeat themselves.
-	if len(missing) > 0 {
-		fmt.Fprintf(&msg, "WARNING: the following env var(s) are NOT set: %s. Ask the user to set them, then call %s and %s for this id again, otherwise tool calls will fail.\n",
-			strings.Join(missing, ", "), ToolNameDisable, ToolNameEnable)
+	// Drive the inner toolset's connect (and any OAuth handshake)
+	// synchronously so the model gets a deterministic answer in the same
+	// turn. Tool handlers run with an interactive context, so OAuth
+	// elicitation surfaces a dialog and blocks until the user responds.
+	//
+	// This is what makes a freshly-enabled server's tools usable on the
+	// VERY NEXT model response within the same RunStream: by the time
+	// handleEnable returns, the toolset is started, the runtime's next
+	// getTools() picks up its tools, and the model can call them in its
+	// follow-up turn — no second user message required.
+	if err := t.startToolset(ctx, wrapped); err != nil {
+		return t.handleEnableStartError(ctx, id, server, wrapped, err), nil
 	}
-	return tools.ResultSuccess(msg.String()), nil
+
+	return tools.ResultSuccess(fmt.Sprintf(
+		"enabled %q (%s). Its tools (names starting with %q) are now active. Proceed with the user's original request using them right away; do not stop to ask for confirmation.",
+		id, server.Title, id+"_")), nil
+}
+
+// handleEnableStartError translates a failed Start() into a model-facing
+// result and, where appropriate, rolls back the t.enabled bookkeeping so
+// the next Tools() enumeration doesn't replay the same failing handshake.
+// The three branches mirror the cases the model needs to distinguish:
+//
+//   - OAuthDeclined → user actively dismissed the dialog. Drop the entry
+//     (mirrors the existing Tools() handling) and tell the model to ask
+//     before retrying.
+//   - AuthorizationRequired → defensive fallback for the (rare) case where
+//     the elicitation bridge isn't wired up yet. Keep the entry so the
+//     next interactive Tools() call can surface the OAuth dialog, and
+//     fall back to the legacy "tools appear next turn" wording.
+//   - any other error (transport, server refused, context cancelled) →
+//     drop the entry and surface the underlying message so the model can
+//     decide what to tell the user.
+func (t *Toolset) handleEnableStartError(ctx context.Context, id string, server Server, wrapped *tools.StartableToolSet, err error) *tools.ToolCallResult {
+	switch {
+	case mcp.IsOAuthDeclined(err):
+		t.disableAfterDecline(ctx, id, wrapped)
+		return tools.ResultError(fmt.Sprintf(
+			"user declined the authorization dialog for %q (%s). No tools were activated — do NOT claim the server is connected and do NOT call any %q tools. Tell the user the request needs them to authorize the connection. If the user then says \"yes\", \"retry\", or re-asks for the same thing, call %s for %q again to surface a fresh authorization dialog.",
+			id, server.Title, id+"_", ToolNameEnable, id))
+	case mcp.IsAuthorizationRequired(err):
+		slog.DebugContext(ctx, "Remote MCP server enable deferred: authorization required, leaving in enabled set for next interactive Tools() to retry",
+			"id", id, "error", err)
+		return tools.ResultSuccess(fmt.Sprintf(
+			"enable requested for %q (%s); authorization is required and the host will surface the dialog. On your next turn, if tools whose names start with %q appear in your available tools, proceed with the user's original request using them. If NO such tools appear, the user dismissed the dialog — tell them the request needs them to authorize, and call %s for %q again if they want to retry.",
+			id, server.Title, id+"_", ToolNameEnable, id))
+	case errors.Is(err, context.Canceled):
+		// Don't roll back: cancellation is the runtime tearing down the
+		// turn (Ctrl+C, parent cancellation). The cleanup paths upstream
+		// (Toolset.Stop) own the lifecycle here.
+		return tools.ResultError(fmt.Sprintf(
+			"enable cancelled for %q before the connection completed.", id))
+	default:
+		t.disableAfterDecline(ctx, id, wrapped)
+		return tools.ResultError(fmt.Sprintf(
+			"failed to connect to %q (%s): %v. No tools were activated — do NOT claim the server is connected. Report the failure to the user; they may need to fix their network or, if the server's credentials changed, call %s for %q before re-enabling.",
+			id, server.Title, err, ToolNameResetAuth, id))
+	}
 }
 
 // expandHeaders resolves ${VAR} placeholders in catalog headers against the

--- a/pkg/tools/builtin/mcpcatalog/mcpcatalog.go
+++ b/pkg/tools/builtin/mcpcatalog/mcpcatalog.go
@@ -716,60 +716,65 @@ func (t *Toolset) handleEnable(ctx context.Context, args EnableArgs) (*tools.Too
 			id, strings.Join(missing, ", "), ToolNameEnable)), nil
 	}
 
+	// Two paths land here: a fresh enable (no entry yet) and a re-enable
+	// of an existing entry whose previous Start did not complete (deferred
+	// auth-required fallback, cancellation, or any other transient
+	// failure). Both must converge on a Start attempt, otherwise the
+	// model-facing retry instructions in the failure branches dead-end at
+	// the guard.
 	t.mu.Lock()
-	if existing, exists := t.enabled[id]; exists {
-		started := existing.IsStarted()
+	wrapped, alreadyEnabled := t.enabled[id]
+	if alreadyEnabled && wrapped.IsStarted() {
 		t.mu.Unlock()
-		// Idempotent re-enable. If the toolset is already started, its
-		// tools are live; otherwise the previous enable hit a deferred-
-		// auth fallback and the user can retry via disable+enable.
-		if started {
-			return tools.ResultSuccess(fmt.Sprintf(
-				"server %q is already enabled and connected. Its tools (names starting with %q) are live; proceed with the user's original request using them.",
-				id, id+"_")), nil
-		}
+		// Live entry — nothing to do.
 		return tools.ResultSuccess(fmt.Sprintf(
-			"server %q is already enabled but not yet connected (likely waiting on user authorization). If the user has just authorized, retry their original request; otherwise tell them the connection still needs authorization.",
-			id)), nil
+			"server %q is already enabled and connected. Its tools (names starting with %q) are live; proceed with the user's original request using them.",
+			id, id+"_")), nil
 	}
 
-	// Create the MCP toolset with the pre-computed headers.
-	// The nil third arg (*latest.RemoteOAuthConfig) is intentional: every
-	// server currently in the catalog works with default Dynamic Client
-	// Registration and the runtime's default callback. If a future entry
-	// needs custom scopes / a fixed client_id / a non-default callback,
-	// extend Auth in servers.go and plumb the resulting *RemoteOAuthConfig
-	// through here.
-	mcpToolset := mcp.NewRemoteToolset(id, server.URL, server.Transport, headers, nil)
+	var notify func()
+	if !alreadyEnabled {
+		// Create the MCP toolset with the pre-computed headers.
+		// The nil third arg (*latest.RemoteOAuthConfig) is intentional:
+		// every server currently in the catalog works with default
+		// Dynamic Client Registration and the runtime's default callback.
+		// If a future entry needs custom scopes / a fixed client_id / a
+		// non-default callback, extend Auth in servers.go and plumb the
+		// resulting *RemoteOAuthConfig through here.
+		mcpToolset := mcp.NewRemoteToolset(id, server.URL, server.Transport, headers, nil)
 
-	// Re-attach the captured handlers so OAuth flows behave identically to
-	// a YAML-declared mcp.remote toolset. Apply BEFORE wrapping so we hit
-	// the *mcp.Toolset's typed setters directly without a tools.As walk.
-	if t.elicitationHandler != nil {
-		mcpToolset.SetElicitationHandler(t.elicitationHandler)
-	}
-	if t.oauthSuccessHandler != nil {
-		mcpToolset.SetOAuthSuccessHandler(t.oauthSuccessHandler)
-	}
-	if t.toolsChangedHandler != nil {
-		mcpToolset.SetToolsChangedHandler(t.toolsChangedHandler)
-	}
-	if t.managedOAuthSet {
-		mcpToolset.SetManagedOAuth(t.managedOAuth)
-	}
-	if t.unmanagedOAuthRedirectURI != "" {
-		mcpToolset.SetUnmanagedOAuthRedirectURI(t.unmanagedOAuthRedirectURI)
-	}
+		// Re-attach the captured handlers so OAuth flows behave
+		// identically to a YAML-declared mcp.remote toolset. Apply
+		// BEFORE wrapping so we hit the *mcp.Toolset's typed setters
+		// directly without a tools.As walk.
+		if t.elicitationHandler != nil {
+			mcpToolset.SetElicitationHandler(t.elicitationHandler)
+		}
+		if t.oauthSuccessHandler != nil {
+			mcpToolset.SetOAuthSuccessHandler(t.oauthSuccessHandler)
+		}
+		if t.toolsChangedHandler != nil {
+			mcpToolset.SetToolsChangedHandler(t.toolsChangedHandler)
+		}
+		if t.managedOAuthSet {
+			mcpToolset.SetManagedOAuth(t.managedOAuth)
+		}
+		if t.unmanagedOAuthRedirectURI != "" {
+			mcpToolset.SetUnmanagedOAuthRedirectURI(t.unmanagedOAuthRedirectURI)
+		}
 
-	wrapped := tools.NewStartable(mcpToolset)
-	t.enabled[id] = wrapped
-	notify := t.toolsChangedHandler
+		wrapped = tools.NewStartable(mcpToolset)
+		t.enabled[id] = wrapped
+		notify = t.toolsChangedHandler
+	}
 	t.mu.Unlock()
 
 	// Notify the runtime that the meta-tool surface changed (disable /
 	// reset_auth become visible the moment the entry lands in t.enabled).
 	// Done BEFORE the synchronous Start so the TUI can reflect the
 	// pending server while the (potentially slow) OAuth dialog is open.
+	// Only the first-time enable notifies; a retry on an existing entry
+	// has no surface change to report.
 	if notify != nil {
 		notify()
 	}
@@ -784,6 +789,10 @@ func (t *Toolset) handleEnable(ctx context.Context, args EnableArgs) (*tools.Too
 	// handleEnable returns, the toolset is started, the runtime's next
 	// getTools() picks up its tools, and the model can call them in its
 	// follow-up turn — no second user message required.
+	//
+	// StartableToolSet.Start is idempotent and single-flight: on a retry
+	// path it re-invokes the inner Start when the previous attempt left
+	// the wrapper in the not-started state.
 	if err := t.startToolset(ctx, wrapped); err != nil {
 		return t.handleEnableStartError(ctx, id, server, wrapped, err), nil
 	}
@@ -796,18 +805,26 @@ func (t *Toolset) handleEnable(ctx context.Context, args EnableArgs) (*tools.Too
 // handleEnableStartError translates a failed Start() into a model-facing
 // result and, where appropriate, rolls back the t.enabled bookkeeping so
 // the next Tools() enumeration doesn't replay the same failing handshake.
-// The three branches mirror the cases the model needs to distinguish:
+// The four branches mirror the cases the model needs to distinguish:
 //
 //   - OAuthDeclined → user actively dismissed the dialog. Drop the entry
 //     (mirrors the existing Tools() handling) and tell the model to ask
-//     before retrying.
+//     before retrying. A subsequent enable for the same id will land on
+//     a fresh entry and run a fresh OAuth flow.
 //   - AuthorizationRequired → defensive fallback for the (rare) case where
 //     the elicitation bridge isn't wired up yet. Keep the entry so the
-//     next interactive Tools() call can surface the OAuth dialog, and
-//     fall back to the legacy "tools appear next turn" wording.
-//   - any other error (transport, server refused, context cancelled) →
-//     drop the entry and surface the underlying message so the model can
-//     decide what to tell the user.
+//     next interactive Tools() call can surface the OAuth dialog. A
+//     subsequent enable for the same id is funnelled through
+//     handleEnable's top-of-function guard, which sees an unstarted
+//     entry and re-attempts Start — that is what makes the model-facing
+//     "call enable again" instruction below actually work.
+//   - context.Canceled → leave the entry. If the cancellation tore down
+//     the whole session, Toolset.Stop will clean it up; if it was a
+//     softer per-turn cancellation, the next enable's top-of-function
+//     guard re-attempts Start on the existing wrapper.
+//   - any other error (transport, server refused, …) → drop the entry
+//     and surface the underlying message so the model can decide what to
+//     tell the user. A subsequent enable lands on a fresh entry.
 func (t *Toolset) handleEnableStartError(ctx context.Context, id string, server Server, wrapped *tools.StartableToolSet, err error) *tools.ToolCallResult {
 	switch {
 	case mcp.IsOAuthDeclined(err):
@@ -816,17 +833,21 @@ func (t *Toolset) handleEnableStartError(ctx context.Context, id string, server 
 			"user declined the authorization dialog for %q (%s). No tools were activated — do NOT claim the server is connected and do NOT call any %q tools. Tell the user the request needs them to authorize the connection. If the user then says \"yes\", \"retry\", or re-asks for the same thing, call %s for %q again to surface a fresh authorization dialog.",
 			id, server.Title, id+"_", ToolNameEnable, id))
 	case mcp.IsAuthorizationRequired(err):
-		slog.DebugContext(ctx, "Remote MCP server enable deferred: authorization required, leaving in enabled set for next interactive Tools() to retry",
+		slog.DebugContext(ctx, "Remote MCP server enable deferred: authorization required, leaving in enabled set for next interactive Tools() / enable to retry",
 			"id", id, "error", err)
 		return tools.ResultSuccess(fmt.Sprintf(
 			"enable requested for %q (%s); authorization is required and the host will surface the dialog. On your next turn, if tools whose names start with %q appear in your available tools, proceed with the user's original request using them. If NO such tools appear, the user dismissed the dialog — tell them the request needs them to authorize, and call %s for %q again if they want to retry.",
 			id, server.Title, id+"_", ToolNameEnable, id))
 	case errors.Is(err, context.Canceled):
-		// Don't roll back: cancellation is the runtime tearing down the
-		// turn (Ctrl+C, parent cancellation). The cleanup paths upstream
-		// (Toolset.Stop) own the lifecycle here.
+		// Don't roll back. If this is full-session cancellation (Ctrl+C,
+		// parent shutdown), Toolset.Stop will tear the entry down with
+		// the rest of the session; if it's softer (per-turn cancel /
+		// timeout), the next enable's top-of-function guard re-attempts
+		// Start on the existing unstarted wrapper, so the model's retry
+		// instruction still has somewhere to land.
 		return tools.ResultError(fmt.Sprintf(
-			"enable cancelled for %q before the connection completed.", id))
+			"enable cancelled for %q before the connection completed. Call %s for %q again to retry once the user is ready.",
+			id, ToolNameEnable, id))
 	default:
 		t.disableAfterDecline(ctx, id, wrapped)
 		return tools.ResultError(fmt.Sprintf(

--- a/pkg/tools/builtin/mcpcatalog/mcpcatalog.go
+++ b/pkg/tools/builtin/mcpcatalog/mcpcatalog.go
@@ -818,10 +818,12 @@ func (t *Toolset) handleEnable(ctx context.Context, args EnableArgs) (*tools.Too
 //     handleEnable's top-of-function guard, which sees an unstarted
 //     entry and re-attempts Start — that is what makes the model-facing
 //     "call enable again" instruction below actually work.
-//   - context.Canceled → leave the entry. If the cancellation tore down
-//     the whole session, Toolset.Stop will clean it up; if it was a
-//     softer per-turn cancellation, the next enable's top-of-function
-//     guard re-attempts Start on the existing wrapper.
+//   - context.Canceled → leave the entry. In a tool handler the only
+//     thing that cancels ctx is the RunStream shutting down (Ctrl+C,
+//     parent cancellation); Toolset.Stop tears the entry down with the
+//     rest of the session. The top-of-function guard would also re-Start
+//     the wrapper if a follow-up enable somehow ran on the same id
+//     before Stop, so neither path leaks.
 //   - any other error (transport, server refused, …) → drop the entry
 //     and surface the underlying message so the model can decide what to
 //     tell the user. A subsequent enable lands on a fresh entry.
@@ -839,12 +841,12 @@ func (t *Toolset) handleEnableStartError(ctx context.Context, id string, server 
 			"enable requested for %q (%s); authorization is required and the host will surface the dialog. On your next turn, if tools whose names start with %q appear in your available tools, proceed with the user's original request using them. If NO such tools appear, the user dismissed the dialog — tell them the request needs them to authorize, and call %s for %q again if they want to retry.",
 			id, server.Title, id+"_", ToolNameEnable, id))
 	case errors.Is(err, context.Canceled):
-		// Don't roll back. If this is full-session cancellation (Ctrl+C,
-		// parent shutdown), Toolset.Stop will tear the entry down with
-		// the rest of the session; if it's softer (per-turn cancel /
-		// timeout), the next enable's top-of-function guard re-attempts
-		// Start on the existing unstarted wrapper, so the model's retry
-		// instruction still has somewhere to land.
+		// Don't roll back. ctx in a tool handler is the RunStream's
+		// context, which only cancels when the whole RunStream is going
+		// away (Ctrl+C, parent shutdown). Toolset.Stop will tear the
+		// entry down with the rest of the session. The top-of-function
+		// guard above also re-Starts unstarted wrappers, so a hypothetical
+		// follow-up enable on the same id wouldn't dead-end either.
 		return tools.ResultError(fmt.Sprintf(
 			"enable cancelled for %q before the connection completed. Call %s for %q again to retry once the user is ready.",
 			id, ToolNameEnable, id))

--- a/pkg/tools/builtin/mcpcatalog/mcpcatalog.go
+++ b/pkg/tools/builtin/mcpcatalog/mcpcatalog.go
@@ -539,6 +539,24 @@ func (t *Toolset) Tools(ctx context.Context) ([]tools.Tool, error) {
 					t.disableAfterDecline(ctx, e.id, e.ts)
 					continue
 				}
+				// User stopped the in-progress turn while OAuth was
+				// parked (browser-side flow failed externally, or the
+				// user simply gave up). Same lifecycle reasoning as
+				// the declined branch above: the catalog Toolset is
+				// owned by the RuntimeSession and outlives the
+				// RunStream, so leaving the entry behind would let
+				// the next user message's Tools() iteration silently
+				// re-Start the wrapper and re-pop the same dialog the
+				// user just abandoned — on a question that may have
+				// nothing to do with this server. The outer ctx.Err()
+				// check at the top of the next iteration will then
+				// propagate the cancellation up.
+				if errors.Is(err, context.Canceled) {
+					slog.InfoContext(ctx, "Remote MCP server start cancelled by user; removing from enabled set",
+						"id", e.id)
+					t.disableAfterDecline(ctx, e.id, e.ts)
+					continue
+				}
 				// Real failure: log once per streak (StartableToolSet
 				// dedupes) so a misbehaving server doesn't flood logs.
 				if e.ts.ShouldReportFailure() {

--- a/pkg/tools/builtin/mcpcatalog/mcpcatalog.go
+++ b/pkg/tools/builtin/mcpcatalog/mcpcatalog.go
@@ -818,12 +818,20 @@ func (t *Toolset) handleEnable(ctx context.Context, args EnableArgs) (*tools.Too
 //     handleEnable's top-of-function guard, which sees an unstarted
 //     entry and re-attempts Start — that is what makes the model-facing
 //     "call enable again" instruction below actually work.
-//   - context.Canceled → leave the entry. In a tool handler the only
-//     thing that cancels ctx is the RunStream shutting down (Ctrl+C,
-//     parent cancellation); Toolset.Stop tears the entry down with the
-//     rest of the session. The top-of-function guard would also re-Start
-//     the wrapper if a follow-up enable somehow ran on the same id
-//     before Stop, so neither path leaks.
+//   - context.Canceled → drop the entry. The caller's ctx here is the
+//     RunStream's ctx (observed via the cancellable-parent stash in
+//     clientConnector.Connect), which cancels when the host aborts the
+//     in-progress turn — typically because the user clicked Stop while
+//     the OAuth dialog was parked waiting for a callback that never
+//     arrived (browser flow failed externally, user gave up). The
+//     catalog Toolset is owned by the RuntimeSession and survives many
+//     RunStreams, so Toolset.Stop will NOT run between this turn and
+//     the user's next message. If we left the entry behind, Tools() at
+//     the start of the next turn would silently re-Start the wrapper,
+//     re-fire the same 401, and re-pop the dialog the user just abandoned
+//     — without any model decision to do so. Roll back so the next
+//     enable on the same id lands on a fresh wrapper; the model is told
+//     to re-issue enable only if the user asks again.
 //   - any other error (transport, server refused, …) → drop the entry
 //     and surface the underlying message so the model can decide what to
 //     tell the user. A subsequent enable lands on a fresh entry.
@@ -841,14 +849,20 @@ func (t *Toolset) handleEnableStartError(ctx context.Context, id string, server 
 			"enable requested for %q (%s); authorization is required and the host will surface the dialog. On your next turn, if tools whose names start with %q appear in your available tools, proceed with the user's original request using them. If NO such tools appear, the user dismissed the dialog — tell them the request needs them to authorize, and call %s for %q again if they want to retry.",
 			id, server.Title, id+"_", ToolNameEnable, id))
 	case errors.Is(err, context.Canceled):
-		// Don't roll back. ctx in a tool handler is the RunStream's
-		// context, which only cancels when the whole RunStream is going
-		// away (Ctrl+C, parent shutdown). Toolset.Stop will tear the
-		// entry down with the rest of the session. The top-of-function
-		// guard above also re-Starts unstarted wrappers, so a hypothetical
-		// follow-up enable on the same id wouldn't dead-end either.
+		// Roll back. The cancellation reaches us via the parent-ctx
+		// stash that handleUnmanagedOAuthFlow observes (oauth.go's
+		// userCancelCh case), which means the host aborted the current
+		// turn — almost always the user clicking Stop while the OAuth
+		// dialog was parked. The mcp-catalog Toolset is owned by the
+		// RuntimeSession, not the RunStream, so leaving the entry
+		// behind would let Tools() silently re-Start it on the very
+		// next user message and re-pop the dialog the user just
+		// abandoned (including on questions that have nothing to do
+		// with this server). Drop the entry; if the user re-asks, the
+		// model will re-issue enable and land on a fresh wrapper.
+		t.disableAfterDecline(ctx, id, wrapped)
 		return tools.ResultError(fmt.Sprintf(
-			"enable cancelled for %q before the connection completed. Call %s for %q again to retry once the user is ready.",
+			"enable cancelled for %q before the connection completed — the user stopped the turn while authorization was pending. No tools were activated. Tell the user the request needs them to authorize the connection. Only call %s for %q again if the user asks to retry.",
 			id, ToolNameEnable, id))
 	default:
 		t.disableAfterDecline(ctx, id, wrapped)

--- a/pkg/tools/builtin/mcpcatalog/mcpcatalog_test.go
+++ b/pkg/tools/builtin/mcpcatalog/mcpcatalog_test.go
@@ -31,6 +31,23 @@ func (s stubEnv) Get(_ context.Context, name string) (string, bool) {
 	return v, ok
 }
 
+// stubStartOK swaps the Toolset's synchronous-Start seam for a no-op so
+// handleEnable returns the success branch without dialling out. Use it on
+// tests that only need handleEnable to register the bookkeeping (the
+// majority); tests that call Tools() afterwards should use stubStartErr
+// with mcptools.AuthorizationRequiredError instead so the catalog's
+// deferred-auth path is the one that runs against the (unreachable) URL.
+func stubStartOK(ts *Toolset) {
+	ts.startToolset = func(context.Context, *tools.StartableToolSet) error { return nil }
+}
+
+// stubStartErr swaps the seam to return a fixed error. Used to exercise
+// the OAuth-declined / authorization-required / transport-error branches
+// of handleEnable without standing up a real MCP server.
+func stubStartErr(ts *Toolset, err error) {
+	ts.startToolset = func(context.Context, *tools.StartableToolSet) error { return err }
+}
+
 func TestLoadCatalog(t *testing.T) {
 	cat, err := Load()
 	require.NoError(t, err)
@@ -85,6 +102,11 @@ func TestSearchTool(t *testing.T) {
 
 func TestEnableDisableLifecycle(t *testing.T) {
 	ts := New(stubEnv{vars: map[string]string{}})
+	// Synchronous-Start is short-circuited so the success branch of
+	// handleEnable is exercised without dialling out to the real OAuth
+	// server. The dedicated failure-path tests below cover declined /
+	// auth-required / transport-error.
+	stubStartOK(ts)
 	ctx := t.Context()
 
 	// Pick the first OAuth-style server in the catalog as a known good fixture.
@@ -115,27 +137,23 @@ func TestEnableDisableLifecycle(t *testing.T) {
 	assert.NotContains(t, names, ToolNameResetAuth,
 		"reset_auth must not be exposed when no server is enabled")
 
-	// Enable: a callback should fire and the underlying mcp.Toolset should
-	// be present in t.enabled. We deliberately do NOT exercise the network
-	// path — Tools(ctx) on the lazily-instantiated toolset would attempt a
-	// connection. Just check the bookkeeping.
+	// Enable on the success path: handleEnable blocks until the inner
+	// toolset is connected, then reports the tools as live so the model
+	// proceeds to the user's original request in the SAME turn without
+	// asking them to retry.
 	res, err := ts.handleEnable(ctx, EnableArgs{ID: oauthID})
 	require.NoError(t, err)
 	require.False(t, res.IsError, "enable failed: %s", res.Output)
-	assert.Contains(t, res.Output, "enable requested",
-		"tool result must record the enable request so the model has something to ground its next turn on")
-	// The tool result MUST set up a self-check for the next turn: if no
-	// `<id>_` tools appear, the user dismissed the authorization dialog
-	// and the model must NOT pretend the server is connected. This was
-	// the regression that motivated the wording change — the previous
-	// "the server's tools will appear on your next turn. Proceed with
-	// the user's original request" was a flat promise the runtime cannot
-	// actually keep when OAuth is required, and the model parroted it
-	// even after the user clicked Cancel.
+	assert.Contains(t, res.Output, "enabled",
+		"the success branch must state plainly that the server is enabled — not 'enable requested'")
 	assert.Contains(t, res.Output, oauthID+"_",
-		"tool result must reference the tool-name prefix so the model can verify whether the server actually came online")
-	assert.Contains(t, res.Output, "dismissed",
-		"tool result must explicitly cover the user-dismissed-the-dialog branch so the model does not hallucinate access")
+		"tool result must reference the tool-name prefix so the model knows which tools to call")
+	assert.Contains(t, res.Output, "Proceed with the user's original request",
+		"the success branch must instruct the model to continue in the same turn — the whole point of blocking on Start")
+	assert.NotContains(t, res.Output, "next turn",
+		"the success branch must NOT defer to a next turn — tools are live now")
+	assert.NotContains(t, res.Output, "dismissed",
+		"the success branch must NOT mention the user-dismissed-the-dialog fallback — that is the OAuthDeclined branch")
 	assert.Equal(t, int32(1), changes.Load(), "enable should fire tools-changed handler exactly once")
 
 	ts.mu.RLock()
@@ -143,7 +161,9 @@ func TestEnableDisableLifecycle(t *testing.T) {
 	ts.mu.RUnlock()
 	assert.True(t, exists)
 
-	// Re-enable: idempotent, no extra change notification.
+	// Re-enable: idempotent, no extra change notification. The success
+	// re-enable must tell the model the tools are still live so it does
+	// not stop to "set up" the connection again.
 	res, err = ts.handleEnable(ctx, EnableArgs{ID: oauthID})
 	require.NoError(t, err)
 	assert.Contains(t, res.Output, "already enabled")
@@ -203,14 +223,26 @@ func TestEnableUnresolvedHeaderEnvSurfacesWarning(t *testing.T) {
 	ts.catalog.Servers = append(ts.catalog.Servers, server)
 	ts.byID[id] = server
 
+	// Missing env vars BLOCK the enable now (rather than attaching a
+	// warning to a success result): the catalog promises a deterministic
+	// answer in the same turn, and we already know the server will reject
+	// the connection. The model is told to ask the user to set the
+	// variable and call enable again.
 	res, err := ts.handleEnable(t.Context(), EnableArgs{ID: id})
 	require.NoError(t, err)
-	require.False(t, res.IsError)
-	assert.Contains(t, res.Output, "WARNING")
+	assert.True(t, res.IsError,
+		"missing env vars must be returned as an error result so the model does not pretend the server is connected")
 	assert.Contains(t, res.Output, "UNDECLARED_TOKEN",
 		"the post-expansion scan must surface env vars referenced from headers but not declared under Auth.Secrets")
-	assert.Contains(t, res.Output, ToolNameDisable)
-	assert.Contains(t, res.Output, ToolNameEnable)
+	assert.Contains(t, res.Output, ToolNameEnable,
+		"the error must point the model at the recovery call to make once the env var is set")
+	// And the server must NOT have been registered — we returned before
+	// even constructing the inner toolset.
+	ts.mu.RLock()
+	_, exists := ts.enabled[id]
+	ts.mu.RUnlock()
+	assert.False(t, exists,
+		"a missing-env enable must not leave a half-registered entry behind")
 }
 
 func TestUnresolvedHeaderEnvsHelper(t *testing.T) {
@@ -247,14 +279,24 @@ func TestLoadCatalogIsCachedButReturnsCopies(t *testing.T) {
 // every turn.
 func TestToolsUsesStableIterationOrder(t *testing.T) {
 	ts := New(stubEnv{vars: map[string]string{}})
+	// We only care about the order of the t.enabled map after a sequence
+	// of handleEnable calls. Stub out the synchronous Start so we don't
+	// dial out to real catalog endpoints.
+	stubStartOK(ts)
 
-	// Pick the first OAuth server so handleEnable doesn't try to expand
-	// missing api_key headers; the inner toolset never starts because
-	// IsStarted() is false and Start() will fail — but we don't actually
-	// call Tools() through to the network here, we only assert the
-	// meta-tool prefix is stable.
+	// Pick the first OAuth servers so the missing-env-var guard doesn't
+	// trip — we only assert the meta-tool iteration order is stable.
 	require.GreaterOrEqual(t, len(ts.catalog.Servers), 3, "need 3+ servers")
-	ids := []string{ts.catalog.Servers[0].ID, ts.catalog.Servers[1].ID, ts.catalog.Servers[2].ID}
+	var ids []string
+	for _, s := range ts.catalog.Servers {
+		if s.Auth.Type == "oauth" {
+			ids = append(ids, s.ID)
+		}
+		if len(ids) == 3 {
+			break
+		}
+	}
+	require.Len(t, ids, 3, "test fixture: catalog should contain at least 3 OAuth servers")
 
 	ctx := t.Context()
 	for _, id := range ids {
@@ -365,14 +407,19 @@ func TestEnableAPIKeyMissingEnv(t *testing.T) {
 
 	res, err := ts.handleEnable(t.Context(), EnableArgs{ID: apiKeyID})
 	require.NoError(t, err)
-	require.False(t, res.IsError)
-	assert.Contains(t, res.Output, "WARNING")
-	assert.Contains(t, res.Output, expectedEnv)
-	// The recovery instructions must mention the disable+enable sequence,
-	// not the misleading "re-enable" wording (the early-return at the top
-	// of handleEnable would otherwise short-circuit a plain second enable).
-	assert.Contains(t, res.Output, ToolNameDisable)
-	assert.Contains(t, res.Output, ToolNameEnable)
+	assert.True(t, res.IsError,
+		"missing api_key env vars must block enable so the model does not pretend the server is connected")
+	assert.Contains(t, res.Output, expectedEnv,
+		"the error must name the specific env var(s) the user needs to set")
+	assert.Contains(t, res.Output, ToolNameEnable,
+		"the error must point the model at the recovery call once the env var is set")
+	// No half-registered entry: we returned before constructing the inner
+	// toolset, so a follow-up enable (after the user sets the variable)
+	// goes through the full success path with no stale state.
+	ts.mu.RLock()
+	_, exists := ts.enabled[apiKeyID]
+	ts.mu.RUnlock()
+	assert.False(t, exists)
 }
 
 func TestEnableAPIKeyEnvPresent(t *testing.T) {
@@ -395,28 +442,153 @@ func TestEnableAPIKeyEnvPresent(t *testing.T) {
 	require.NotEmpty(t, apiKeyID)
 
 	// Re-instantiate with the populated env so missingAPIKeyEnv and the
-	// unresolved-header scan both come back empty.
+	// unresolved-header scan both come back empty. Stub out the synchronous
+	// Start so we don't dial the real catalog endpoint.
 	ts = New(stubEnv{vars: vars})
+	stubStartOK(ts)
 
 	res, err := ts.handleEnable(t.Context(), EnableArgs{ID: apiKeyID})
 	require.NoError(t, err)
-	require.False(t, res.IsError)
-	assert.Contains(t, res.Output, "enable requested")
-	// With every required env var present, no WARNING line is emitted —
-	// the tool result is intentionally terse so the model proceeds to the
-	// user's original request rather than narrating setup.
-	assert.NotContains(t, res.Output, "WARNING")
+	require.False(t, res.IsError, "enable failed: %s", res.Output)
+	assert.Contains(t, res.Output, "enabled",
+		"the success branch must state plainly that the server is enabled")
+	assert.Contains(t, res.Output, apiKeyID+"_",
+		"the success branch must reference the tool-name prefix")
+}
+
+// TestEnableSyncStartSuccess asserts that handleEnable, on the happy path,
+// returns a "tools are live now" result whose wording instructs the model
+// to continue with the user's ORIGINAL request in the SAME turn — not on
+// the next one. This is the property that makes a re-ask unnecessary.
+func TestEnableSyncStartSuccess(t *testing.T) {
+	ts := New(stubEnv{vars: map[string]string{}})
+	stubStartOK(ts)
+
+	id := firstOAuthServerID(t, ts)
+	res, err := ts.handleEnable(t.Context(), EnableArgs{ID: id})
+	require.NoError(t, err)
+	require.False(t, res.IsError, "enable: %s", res.Output)
+
+	assert.Contains(t, res.Output, "enabled",
+		"the success branch must state the server is enabled in past tense")
+	assert.Contains(t, res.Output, id+"_",
+		"the success branch must reference the tool-name prefix")
+	assert.Contains(t, res.Output, "Proceed with the user's original request",
+		"the success branch must tell the model to continue in the same turn")
+	assert.NotContains(t, res.Output, "next turn",
+		"the success branch must NOT defer to the next turn")
+
+	ts.mu.RLock()
+	_, present := ts.enabled[id]
+	ts.mu.RUnlock()
+	assert.True(t, present, "successful enable must leave the entry in t.enabled")
+}
+
+// TestEnableSyncStartOAuthDeclined asserts that an OAuth dismissal during
+// the synchronous Start is surfaced as an ERROR result (not a soft "tools
+// might appear" message), rolls back t.enabled so the next Tools() call
+// does not re-pop the dialog, and tells the model how to retry on user
+// request — all in the SAME turn.
+func TestEnableSyncStartOAuthDeclined(t *testing.T) {
+	ts := New(stubEnv{vars: map[string]string{}})
+
+	var changes atomic.Int32
+	ts.SetToolsChangedHandler(func() { changes.Add(1) })
+
+	id := firstOAuthServerID(t, ts)
+	stubStartErr(ts, &mcptools.OAuthDeclinedError{URL: ts.byID[id].URL})
+
+	res, err := ts.handleEnable(t.Context(), EnableArgs{ID: id})
+	require.NoError(t, err)
+	require.True(t, res.IsError,
+		"a user-declined authorization must be returned as a tool ERROR so the model does not hallucinate a connection")
+
+	assert.Contains(t, res.Output, "declined",
+		"the error must name the user-declined branch explicitly")
+	assert.Contains(t, res.Output, ToolNameEnable,
+		"the error must point the model at the retry path so it knows how to honour a 'try again' from the user")
+
+	ts.mu.RLock()
+	_, stillEnabled := ts.enabled[id]
+	ts.mu.RUnlock()
+	assert.False(t, stillEnabled,
+		"the declined server must be removed from t.enabled so the next Tools() call does not re-trigger OAuth")
+
+	// Two notifications: one when the entry was registered, one when
+	// disableAfterDecline removed it. Both are visible to the runtime so
+	// the TUI's tool count stays correct.
+	assert.Equal(t, int32(2), changes.Load(),
+		"enable+decline must fire tools-changed exactly twice — register, then rollback")
+}
+
+// TestEnableSyncStartAuthorizationRequiredDefers covers the defensive
+// fallback for the (rare) case where the elicitation bridge isn't wired
+// up yet and Start returns AuthorizationRequiredError instead of blocking
+// on a dialog. The server must STAY in t.enabled so the next interactive
+// Tools() call retries; the tool result falls back to the legacy
+// "tools appear next turn" wording so the model knows to verify.
+func TestEnableSyncStartAuthorizationRequiredDefers(t *testing.T) {
+	ts := New(stubEnv{vars: map[string]string{}})
+
+	id := firstOAuthServerID(t, ts)
+	stubStartErr(ts, &mcptools.AuthorizationRequiredError{URL: ts.byID[id].URL})
+
+	res, err := ts.handleEnable(t.Context(), EnableArgs{ID: id})
+	require.NoError(t, err)
+	require.False(t, res.IsError,
+		"a deferred-auth start must not be returned as a tool error — the runtime will retry on the next interactive turn")
+
+	assert.Contains(t, res.Output, "next turn",
+		"the deferred-auth fallback must explicitly tell the model to wait one turn for the tools to appear")
+	assert.Contains(t, res.Output, id+"_",
+		"the fallback must reference the tool-name prefix so the model can verify on the next turn")
+
+	ts.mu.RLock()
+	_, stillEnabled := ts.enabled[id]
+	ts.mu.RUnlock()
+	assert.True(t, stillEnabled,
+		"a deferred-auth start must leave the entry in t.enabled so the next Tools() call can retry")
+}
+
+// TestEnableSyncStartTransportError covers the generic-failure branch:
+// the inner toolset's Start returned something that isn't OAuth-related
+// (DNS, TCP refused, server returned a 5xx during handshake, …). The
+// result must be a tool ERROR with the underlying message, and the entry
+// must be rolled back so the next Tools() call doesn't replay the failed
+// handshake.
+func TestEnableSyncStartTransportError(t *testing.T) {
+	ts := New(stubEnv{vars: map[string]string{}})
+
+	id := firstOAuthServerID(t, ts)
+	stubStartErr(ts, errors.New("dial tcp: connection refused"))
+
+	res, err := ts.handleEnable(t.Context(), EnableArgs{ID: id})
+	require.NoError(t, err)
+	require.True(t, res.IsError,
+		"a transport failure during synchronous Start must surface as a tool error")
+
+	assert.Contains(t, res.Output, "connection refused",
+		"the error must include the underlying transport error so the model can report it to the user")
+	assert.Contains(t, res.Output, ToolNameResetAuth,
+		"the error must mention reset_auth as a recovery hint for the credentials-changed case")
+
+	ts.mu.RLock()
+	_, stillEnabled := ts.enabled[id]
+	ts.mu.RUnlock()
+	assert.False(t, stillEnabled,
+		"a failed enable must roll back t.enabled so the next Tools() call does not replay the failure")
 }
 
 func TestListEnabled(t *testing.T) {
 	ts := New(stubEnv{vars: map[string]string{}})
+	stubStartOK(ts)
 	ctx := t.Context()
 
 	res, err := ts.handleList(ctx, ListArgs{})
 	require.NoError(t, err)
 	assert.Contains(t, res.Output, "0 enabled")
 
-	id := ts.catalog.Servers[0].ID
+	id := firstOAuthServerID(t, ts)
 	_, err = ts.handleEnable(ctx, EnableArgs{ID: id})
 	require.NoError(t, err)
 
@@ -428,9 +600,10 @@ func TestListEnabled(t *testing.T) {
 
 func TestStopReleasesEverything(t *testing.T) {
 	ts := New(stubEnv{vars: map[string]string{}})
+	stubStartOK(ts)
 	ctx := t.Context()
 
-	id := ts.catalog.Servers[0].ID
+	id := firstOAuthServerID(t, ts)
 	_, err := ts.handleEnable(ctx, EnableArgs{ID: id})
 	require.NoError(t, err)
 
@@ -449,8 +622,24 @@ func toolNames(list []tools.Tool) []string {
 	return out
 }
 
+// firstOAuthServerID picks an arbitrary OAuth catalog server for tests that
+// only need *some* server id to feed into handleEnable. OAuth servers are
+// preferred over api_key ones so the missing-env-var guard doesn't trip and
+// turn the call into an unintended ResultError.
+func firstOAuthServerID(t *testing.T, ts *Toolset) string {
+	t.Helper()
+	for _, s := range ts.catalog.Servers {
+		if s.Auth.Type == "oauth" {
+			return s.ID
+		}
+	}
+	t.Fatalf("test fixture: catalog should contain at least one OAuth server")
+	return ""
+}
+
 func TestSetManagedOAuthPersistence(t *testing.T) {
 	ts := New(stubEnv{vars: map[string]string{}})
+	stubStartOK(ts)
 	ctx := t.Context()
 
 	// Setting before any server is enabled must persist so that the next
@@ -462,7 +651,7 @@ func TestSetManagedOAuthPersistence(t *testing.T) {
 	assert.True(t, ts.managedOAuthSet)
 	ts.mu.RUnlock()
 
-	id := ts.catalog.Servers[0].ID
+	id := firstOAuthServerID(t, ts)
 	_, err := ts.handleEnable(ctx, EnableArgs{ID: id})
 	require.NoError(t, err)
 
@@ -475,11 +664,20 @@ func TestSetManagedOAuthPersistence(t *testing.T) {
 
 func TestConcurrentEnableDisable(t *testing.T) {
 	ts := New(stubEnv{vars: map[string]string{}})
+	stubStartOK(ts)
 	ctx := t.Context()
 
-	require.GreaterOrEqual(t, len(ts.catalog.Servers), 2, "need at least 2 servers for concurrency test")
-	id1 := ts.catalog.Servers[0].ID
-	id2 := ts.catalog.Servers[1].ID
+	var oauthIDs []string
+	for _, s := range ts.catalog.Servers {
+		if s.Auth.Type == "oauth" {
+			oauthIDs = append(oauthIDs, s.ID)
+		}
+		if len(oauthIDs) == 2 {
+			break
+		}
+	}
+	require.Len(t, oauthIDs, 2, "need at least 2 OAuth servers for concurrency test")
+	id1, id2 := oauthIDs[0], oauthIDs[1]
 
 	var wg sync.WaitGroup
 	enableErrs := make(chan error, 2)
@@ -544,8 +742,9 @@ func TestConcurrentEnableDisable(t *testing.T) {
 
 func TestToolsContextCancellation(t *testing.T) {
 	ts := New(stubEnv{vars: map[string]string{}})
+	stubStartOK(ts)
 
-	id := ts.catalog.Servers[0].ID
+	id := firstOAuthServerID(t, ts)
 	_, err := ts.handleEnable(t.Context(), EnableArgs{ID: id})
 	require.NoError(t, err)
 
@@ -679,19 +878,13 @@ func TestResetAuthNoOpForNonOAuth(t *testing.T) {
 // fresh handshake) AND fires the tools-changed handler.
 func TestResetAuthDisablesEnabledServer(t *testing.T) {
 	ts := New(stubEnv{vars: map[string]string{}})
+	stubStartOK(ts)
 	ts.removeOAuthToken = func(string) error { return nil }
 
 	var changes atomic.Int32
 	ts.SetToolsChangedHandler(func() { changes.Add(1) })
 
-	var oauthID string
-	for _, s := range ts.catalog.Servers {
-		if s.Auth.Type == "oauth" {
-			oauthID = s.ID
-			break
-		}
-	}
-	require.NotEmpty(t, oauthID)
+	oauthID := firstOAuthServerID(t, ts)
 
 	ctx := t.Context()
 	_, err := ts.handleEnable(ctx, EnableArgs{ID: oauthID})
@@ -745,19 +938,13 @@ func TestResetAuthSurfacesStoreErrors(t *testing.T) {
 // whether the keyring removal eventually succeeds. Notify must fire.
 func TestResetAuthNotifiesEvenWhenKeyringFails(t *testing.T) {
 	ts := New(stubEnv{vars: map[string]string{}})
+	stubStartOK(ts)
 	ts.removeOAuthToken = func(string) error { return errors.New("keyring on fire") }
 
 	var changes atomic.Int32
 	ts.SetToolsChangedHandler(func() { changes.Add(1) })
 
-	var oauthID string
-	for _, s := range ts.catalog.Servers {
-		if s.Auth.Type == "oauth" {
-			oauthID = s.ID
-			break
-		}
-	}
-	require.NotEmpty(t, oauthID)
+	oauthID := firstOAuthServerID(t, ts)
 
 	ctx := t.Context()
 	_, err := ts.handleEnable(ctx, EnableArgs{ID: oauthID})
@@ -789,14 +976,18 @@ func TestResetAuthNotifiesEvenWhenKeyringFails(t *testing.T) {
 // and hidden again after the last server is disabled.
 func TestDisableAndResetAuthGatedOnEnabledServers(t *testing.T) {
 	// Use a local auth-required fake server so the test never touches the
-	// network and is independent of catalog data. The OAuth path makes
-	// Tools() swallow the AuthorizationRequired error while keeping the
-	// entry in t.enabled, which is exactly the state we want to assert
-	// against.
+	// network and is independent of catalog data. The OAuth path keeps the
+	// entry in t.enabled (handleEnable's defensive deferred-auth fallback),
+	// which is exactly the state we want to assert against.
 	srv := newAuthRequiredMCPServer(t)
 	defer srv.Close()
 
 	ts := New(stubEnv{vars: map[string]string{}})
+	// Stub the synchronous Start to surface AuthorizationRequired so
+	// handleEnable takes the defensive "keep the server enabled, defer to
+	// next interactive Tools()" branch — that is what previously happened
+	// implicitly when handleEnable did no Start at all.
+	stubStartErr(ts, &mcptools.AuthorizationRequiredError{URL: srv.URL})
 
 	const id = "gated-meta-server"
 	ts.catalog.Servers = append(ts.catalog.Servers, Server{
@@ -999,6 +1190,14 @@ func TestToolsAuthRequiredIsDeferred(t *testing.T) {
 	defer srv.Close()
 
 	ts := New(stubEnv{vars: map[string]string{}})
+	// Defensive fallback: when handleEnable's synchronous Start surfaces
+	// AuthorizationRequired (e.g. because the elicitation bridge isn't
+	// wired up yet), the catalog must keep the server in t.enabled so the
+	// next interactive Tools() call can retry against the live server.
+	// That's exactly the path this test asserts: a probe with
+	// WithoutInteractivePrompts must still defer cleanly.
+	stubStartErr(ts, &mcptools.AuthorizationRequiredError{URL: srv.URL})
+
 	const id = "auth-required-server"
 	server := Server{
 		ID:        id,

--- a/pkg/tools/builtin/mcpcatalog/mcpcatalog_test.go
+++ b/pkg/tools/builtin/mcpcatalog/mcpcatalog_test.go
@@ -161,13 +161,18 @@ func TestEnableDisableLifecycle(t *testing.T) {
 	ts.mu.RUnlock()
 	assert.True(t, exists)
 
-	// Re-enable: idempotent, no extra change notification. The success
-	// re-enable must tell the model the tools are still live so it does
-	// not stop to "set up" the connection again.
+	// Re-enable on a registered-but-still-unstarted entry: the guard at
+	// the top of handleEnable falls through to the Start retry path
+	// (otherwise the retry instructions emitted by the AuthorizationRequired
+	// / Canceled branches would dead-end at the guard). No extra
+	// tools_changed notification: the entry was already in t.enabled.
 	res, err = ts.handleEnable(ctx, EnableArgs{ID: oauthID})
 	require.NoError(t, err)
-	assert.Contains(t, res.Output, "already enabled")
-	assert.Equal(t, int32(1), changes.Load())
+	require.False(t, res.IsError, "re-enable: %s", res.Output)
+	assert.Contains(t, res.Output, "enabled",
+		"re-enable must report success — the Start retry succeeded under stubStartOK")
+	assert.Equal(t, int32(1), changes.Load(),
+		"re-enable of an existing entry must not fire tools-changed again")
 
 	// Search now reports it as enabled.
 	res, err = ts.handleSearch(ctx, SearchArgs{Query: oauthID})
@@ -577,6 +582,127 @@ func TestEnableSyncStartTransportError(t *testing.T) {
 	ts.mu.RUnlock()
 	assert.False(t, stillEnabled,
 		"a failed enable must roll back t.enabled so the next Tools() call does not replay the failure")
+}
+
+// flakyStartToolSet is a Startable test fake whose Start fails N times
+// before returning nil. It exists so the retry-on-second-enable regression
+// tests can assert that the model's retry instructions actually drive a
+// fresh Start attempt instead of dead-ending at the idempotent guard.
+type flakyStartToolSet struct {
+	startCalls atomic.Int32
+	failures   int   // number of times Start should fail before succeeding
+	failWith   error // sentinel returned on each failure
+}
+
+func (f *flakyStartToolSet) Tools(context.Context) ([]tools.Tool, error) {
+	return nil, nil
+}
+
+func (f *flakyStartToolSet) Start(context.Context) error {
+	n := f.startCalls.Add(1)
+	if int(n) <= f.failures {
+		return f.failWith
+	}
+	return nil
+}
+
+func (f *flakyStartToolSet) Stop(context.Context) error { return nil }
+
+// TestEnableRetriesStartOnExistingUnstartedEntry is the regression test
+// for the AuthorizationRequired-branch dead-end the reviewer flagged: the
+// model-facing retry instruction must actually drive a second Start
+// attempt. Before the fix, the top-of-handleEnable guard short-circuited
+// every retry into the "already enabled but not yet connected" message
+// without invoking the seam, so the OAuth dialog never re-surfaced and
+// the only escape was disable+enable.
+func TestEnableRetriesStartOnExistingUnstartedEntry(t *testing.T) {
+	ts := New(stubEnv{vars: map[string]string{}})
+
+	id := firstOAuthServerID(t, ts)
+	fake := &flakyStartToolSet{
+		failures: 1,
+		failWith: &mcptools.AuthorizationRequiredError{URL: ts.byID[id].URL},
+	}
+	ts.startToolset = func(ctx context.Context, _ *tools.StartableToolSet) error {
+		return fake.Start(ctx)
+	}
+
+	var changes atomic.Int32
+	ts.SetToolsChangedHandler(func() { changes.Add(1) })
+
+	// First enable: defensive AuthorizationRequired fallback. Entry stays
+	// in t.enabled, message tells the model to call enable again.
+	res, err := ts.handleEnable(t.Context(), EnableArgs{ID: id})
+	require.NoError(t, err)
+	require.False(t, res.IsError, "deferred-auth must not be returned as an error: %s", res.Output)
+	assert.Contains(t, res.Output, "next turn",
+		"the AuthRequired branch must surface its deferred-auth wording on first failure")
+
+	ts.mu.RLock()
+	_, stillEnabled := ts.enabled[id]
+	ts.mu.RUnlock()
+	require.True(t, stillEnabled, "AuthRequired must leave the entry in t.enabled for retry")
+
+	// Second enable on the same id: the guard must NOT short-circuit on
+	// the existing unstarted entry. It must invoke Start again so the
+	// model's "call enable again" instruction actually drives a retry.
+	res, err = ts.handleEnable(t.Context(), EnableArgs{ID: id})
+	require.NoError(t, err)
+	require.False(t, res.IsError, "retry: %s", res.Output)
+	assert.Contains(t, res.Output, "enabled",
+		"re-enable must report success once the underlying Start succeeds")
+	assert.Contains(t, res.Output, id+"_",
+		"re-enable must reference the tool-name prefix so the model knows the tools are live")
+
+	assert.Equal(t, int32(2), fake.startCalls.Load(),
+		"re-enable must invoke Start a second time — the AuthRequired fallback's retry instruction depends on it")
+	// Only the first enable registers the entry; the retry reuses it, so
+	// the tools-changed notification fires exactly once across both calls.
+	assert.Equal(t, int32(1), changes.Load(),
+		"re-enable of an existing entry must NOT re-fire tools-changed — it would falsely signal a tool-surface change")
+}
+
+// TestEnableRetriesStartAfterCancellation is the regression test for the
+// context.Canceled branch the reviewer flagged: when Start is cancelled,
+// the entry stays in t.enabled, and a subsequent enable must drive Start
+// again rather than dead-ending at the guard. This covers the soft
+// per-turn cancellation case where Toolset.Stop has not (and will not)
+// run between the cancelled enable and the retry.
+func TestEnableRetriesStartAfterCancellation(t *testing.T) {
+	ts := New(stubEnv{vars: map[string]string{}})
+
+	id := firstOAuthServerID(t, ts)
+	fake := &flakyStartToolSet{failures: 1, failWith: context.Canceled}
+	ts.startToolset = func(ctx context.Context, _ *tools.StartableToolSet) error {
+		return fake.Start(ctx)
+	}
+
+	// First enable: Start returns context.Canceled. The handler must
+	// surface a tool error AND leave the entry behind so a retry has
+	// somewhere to land.
+	res, err := ts.handleEnable(t.Context(), EnableArgs{ID: id})
+	require.NoError(t, err)
+	require.True(t, res.IsError, "cancelled Start must surface a tool error: %s", res.Output)
+	assert.Contains(t, res.Output, "cancelled",
+		"the error must name cancellation so the model can explain to the user")
+	assert.Contains(t, res.Output, ToolNameEnable,
+		"the error must instruct the model how to retry")
+
+	ts.mu.RLock()
+	_, stillEnabled := ts.enabled[id]
+	ts.mu.RUnlock()
+	require.True(t, stillEnabled,
+		"context.Canceled must leave the entry so the next enable can retry — the alternative would be relying on Toolset.Stop firing between turns, which is a fragile invariant")
+
+	// Second enable: must drive Start again, not short-circuit at the
+	// guard with a "still not connected" message. Otherwise the user is
+	// stuck and the only escape is disable+enable.
+	res, err = ts.handleEnable(t.Context(), EnableArgs{ID: id})
+	require.NoError(t, err)
+	require.False(t, res.IsError, "retry after cancel: %s", res.Output)
+	assert.Contains(t, res.Output, "enabled")
+	assert.Equal(t, int32(2), fake.startCalls.Load(),
+		"the retry must invoke Start a second time — the post-cancel recovery depends on it")
 }
 
 func TestListEnabled(t *testing.T) {

--- a/pkg/tools/builtin/mcpcatalog/mcpcatalog_test.go
+++ b/pkg/tools/builtin/mcpcatalog/mcpcatalog_test.go
@@ -1322,6 +1322,97 @@ func TestToolsOAuthDeclineRemovesServer(t *testing.T) {
 		"reset_auth must be hidden once the declined server has been removed from the enabled set")
 }
 
+// cancelOnStartToolSet is a minimal ToolSet+Startable whose Start returns
+// context.Canceled on every call. It exists so the catalog's Tools()
+// iteration can be tested for "user stopped the turn while OAuth was
+// parked -> server is removed from the enabled set, no further retries"
+// without driving a real OAuth handshake.
+type cancelOnStartToolSet struct {
+	startCalls atomic.Int32
+	stopCalls  atomic.Int32
+}
+
+func (c *cancelOnStartToolSet) Tools(context.Context) ([]tools.Tool, error) {
+	return nil, errors.New("cancelOnStartToolSet.Tools should never be called")
+}
+
+func (c *cancelOnStartToolSet) Start(context.Context) error {
+	c.startCalls.Add(1)
+	return context.Canceled
+}
+
+func (c *cancelOnStartToolSet) Stop(context.Context) error {
+	c.stopCalls.Add(1)
+	return nil
+}
+
+// TestToolsCancelledStartRemovesServer is the Tools()-path counterpart of
+// TestToolsOAuthDeclineRemovesServer. It pins the user-stop-mid-OAuth
+// scenario reachable when the synchronous handleEnable path didn't drive
+// OAuth itself (e.g. the elicitation bridge wasn't ready and the
+// AuthorizationRequired fallback left the entry to be Started by the
+// next Tools() call). A Start returning context.Canceled must drop the
+// entry so the next Tools() iteration does not silently re-fire the
+// OAuth dialog on an unrelated user message.
+func TestToolsCancelledStartRemovesServer(t *testing.T) {
+	ts := New(stubEnv{vars: map[string]string{}})
+	const id = "cancel-server"
+	server := Server{
+		ID:        id,
+		Title:     "Cancel",
+		URL:       "https://example.test/mcp",
+		Transport: "streamable-http",
+		Auth:      Auth{Type: "oauth"},
+	}
+	ts.catalog.Servers = append(ts.catalog.Servers, server)
+	ts.byID[id] = server
+
+	fake := &cancelOnStartToolSet{}
+	wrapped := tools.NewStartable(fake)
+
+	var changes atomic.Int32
+	ts.SetToolsChangedHandler(func() { changes.Add(1) })
+
+	ts.mu.Lock()
+	ts.enabled[id] = wrapped
+	ts.mu.Unlock()
+
+	ctx := t.Context()
+
+	// First Tools() call: Start() returns context.Canceled. The catalog
+	// must swallow it cleanly (no error to the runtime) and drop the
+	// entry — leaving it would let the next Tools() call silently
+	// re-Start the wrapper and re-pop the dialog the user just abandoned.
+	list, err := ts.Tools(ctx)
+	require.NoError(t, err, "Tools() must not propagate a user-stop as an error")
+
+	names := toolNames(list)
+	for _, meta := range []string{ToolNameSearch, ToolNameList, ToolNameEnable} {
+		assert.Contains(t, names, meta, "meta tools must still be present after a stop-mid-OAuth")
+	}
+
+	ts.mu.RLock()
+	_, stillEnabled := ts.enabled[id]
+	ts.mu.RUnlock()
+	assert.False(t, stillEnabled,
+		"cancelled server must be removed from t.enabled — leaving it would let Tools() re-fire OAuth on the next user message")
+
+	assert.Equal(t, int32(1), fake.startCalls.Load(),
+		"Start() must be called exactly once before the cancellation removes the entry")
+	assert.Equal(t, int32(1), fake.stopCalls.Load(),
+		"the cancelled toolset must be Stop()'d so any partially-initialised session is cleaned up")
+	assert.Equal(t, int32(1), changes.Load(),
+		"tools-changed must fire so the runtime / UI sees the server is no longer enabled")
+
+	// Second Tools() call: the entry is gone, so the fake must not be
+	// touched again. This is the property that breaks the
+	// "dialog re-appears on every user message" loop reported by the user.
+	_, err = ts.Tools(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), fake.startCalls.Load(),
+		"Start() must NOT be called again after the cancellation: the server is no longer enabled")
+}
+
 // TestToolsOAuthDeclineNoNotifyWhenAlreadyDisabled covers the race where
 // the model called disable_remote_mcp_server (or reset_remote_mcp_server_auth)
 // between the OAuth flow being initiated and the user declining it. In that

--- a/pkg/tools/builtin/mcpcatalog/mcpcatalog_test.go
+++ b/pkg/tools/builtin/mcpcatalog/mcpcatalog_test.go
@@ -662,13 +662,26 @@ func TestEnableRetriesStartOnExistingUnstartedEntry(t *testing.T) {
 		"re-enable of an existing entry must NOT re-fire tools-changed — it would falsely signal a tool-surface change")
 }
 
-// TestEnableRetriesStartAfterCancellation is the regression test for the
-// context.Canceled branch the reviewer flagged: when Start is cancelled,
-// the entry stays in t.enabled, and a subsequent enable must drive Start
-// again rather than dead-ending at the guard. This covers the soft
-// per-turn cancellation case where Toolset.Stop has not (and will not)
-// run between the cancelled enable and the retry.
-func TestEnableRetriesStartAfterCancellation(t *testing.T) {
+// TestEnableSyncStartCancelledRollsBack is the regression test for the
+// "stopped turn re-pops the OAuth dialog on the next message" bug. When
+// the user clicks Stop while the OAuth dialog is parked (e.g. the
+// browser-side OAuth flow failed externally and the elicitation goroutine
+// never gets a reply), the inner Start returns context.Canceled. handleEnable
+// must:
+//
+//  1. Surface a tool error with a recognisable wording so the model can
+//     explain to the user.
+//  2. Remove the entry from t.enabled so the next RunStream's Tools()
+//     does NOT silently re-Start the wrapper and re-pop the dialog on
+//     an unrelated user message — the catalog Toolset is owned by the
+//     RuntimeSession and survives many RunStreams, so Toolset.Stop will
+//     NOT run between this turn and the user's next message.
+//  3. Notify the runtime that the tool surface changed (register + drop).
+//
+// A subsequent enable_remote_mcp_server for the same id then lands on a
+// fresh wrapper (not on the cancelled one) and drives Start again — which
+// is what makes the "user asked to retry" path work.
+func TestEnableSyncStartCancelledRollsBack(t *testing.T) {
 	ts := New(stubEnv{vars: map[string]string{}})
 
 	id := firstOAuthServerID(t, ts)
@@ -677,32 +690,89 @@ func TestEnableRetriesStartAfterCancellation(t *testing.T) {
 		return fake.Start(ctx)
 	}
 
+	var changes atomic.Int32
+	ts.SetToolsChangedHandler(func() { changes.Add(1) })
+
 	// First enable: Start returns context.Canceled. The handler must
-	// surface a tool error AND leave the entry behind so a retry has
-	// somewhere to land.
+	// surface a tool error AND drop the entry so Tools() on the next
+	// RunStream does not silently re-fire the OAuth dialog.
 	res, err := ts.handleEnable(t.Context(), EnableArgs{ID: id})
 	require.NoError(t, err)
 	require.True(t, res.IsError, "cancelled Start must surface a tool error: %s", res.Output)
 	assert.Contains(t, res.Output, "cancelled",
 		"the error must name cancellation so the model can explain to the user")
 	assert.Contains(t, res.Output, ToolNameEnable,
-		"the error must instruct the model how to retry")
+		"the error must instruct the model how to retry on user request")
 
 	ts.mu.RLock()
 	_, stillEnabled := ts.enabled[id]
 	ts.mu.RUnlock()
-	require.True(t, stillEnabled,
-		"context.Canceled must leave the entry so the next enable can retry — the alternative would be relying on Toolset.Stop firing between turns, which is a fragile invariant")
+	require.False(t, stillEnabled,
+		"context.Canceled must roll back t.enabled — leaving the entry would let the next RunStream's Tools() silently re-Start it and re-pop the OAuth dialog on an unrelated user message")
 
-	// Second enable: must drive Start again, not short-circuit at the
-	// guard with a "still not connected" message. Otherwise the user is
-	// stuck and the only escape is disable+enable.
+	// Two notifications: one when the entry was registered, one when
+	// the cancellation rollback removed it. Mirrors the OAuthDeclined
+	// branch — both are visible to the runtime so the TUI's tool count
+	// stays correct.
+	assert.Equal(t, int32(2), changes.Load(),
+		"enable+cancel must fire tools-changed exactly twice — register, then rollback")
+
+	// Second enable: must land on a fresh wrapper (the previous one
+	// was rolled back) and drive Start again. The model's "if the user
+	// asks to retry" instruction depends on this path actually firing.
 	res, err = ts.handleEnable(t.Context(), EnableArgs{ID: id})
 	require.NoError(t, err)
 	require.False(t, res.IsError, "retry after cancel: %s", res.Output)
 	assert.Contains(t, res.Output, "enabled")
 	assert.Equal(t, int32(2), fake.startCalls.Load(),
 		"the retry must invoke Start a second time — the post-cancel recovery depends on it")
+}
+
+// TestToolsAfterCancelledEnableDoesNotReFireOAuth reproduces the user-
+// reported scenario at the catalog layer:
+//
+//   - Turn 1: model calls enable_remote_mcp_server; the OAuth dialog
+//     opens, the browser-side flow fails externally, the user clicks
+//     Stop. The inner Start returns context.Canceled.
+//   - Turn 2: a fresh, UNRELATED user message arrives; the runtime
+//     calls Tools() to enumerate the available tools for the new turn.
+//
+// Before the fix the Turn-1 cancellation left the entry in t.enabled,
+// so Turn-2's Tools() iteration silently re-Started the same wrapper,
+// hit 401, and re-popped the Authentication Request dialog on a turn
+// the user did not ask for. This test pins the post-fix behaviour:
+// Turn-2's Tools() must not touch the cancelled wrapper at all.
+func TestToolsAfterCancelledEnableDoesNotReFireOAuth(t *testing.T) {
+	ts := New(stubEnv{vars: map[string]string{}})
+
+	id := firstOAuthServerID(t, ts)
+	// Stop-during-OAuth is modelled as a Start that returns
+	// context.Canceled every time; if Tools() ever re-Starts the same
+	// wrapper, startCalls will go to 2 and the assertion below fails.
+	fake := &flakyStartToolSet{failures: 999, failWith: context.Canceled}
+	ts.startToolset = func(ctx context.Context, _ *tools.StartableToolSet) error {
+		return fake.Start(ctx)
+	}
+
+	res, err := ts.handleEnable(t.Context(), EnableArgs{ID: id})
+	require.NoError(t, err)
+	require.True(t, res.IsError, "stop-during-OAuth must surface as a tool error: %s", res.Output)
+
+	ts.mu.RLock()
+	_, stillEnabled := ts.enabled[id]
+	ts.mu.RUnlock()
+	require.False(t, stillEnabled,
+		"the cancelled entry must be rolled back so the next Tools() does not see it")
+
+	// Mimic the next RunStream's tool enumeration. The runtime calls
+	// Tools() at the start of every turn; if the rollback didn't take,
+	// this would re-Start the wrapper and the dialog would re-pop.
+	for range 3 {
+		_, err := ts.Tools(t.Context())
+		require.NoError(t, err)
+	}
+	assert.Equal(t, int32(1), fake.startCalls.Load(),
+		"Tools() on the next RunStream must NOT re-Start the cancelled wrapper — that is what re-pops the OAuth dialog on an unrelated user message")
 }
 
 func TestListEnabled(t *testing.T) {


### PR DESCRIPTION
## Issues on main this PR fixes

### 1. The user has to re-ask their original question after enabling a server

`enable_remote_mcp_server`'s handler defers the MCP connect (and any OAuth handshake) to the next `Tools()` enumeration. The tool's result text and the catalog Instructions block both tell the model "tools appear on your **next turn**". Every model reading that ends its turn after enable with a "please try again" message; the user then has to **re-send their original question** for the activated server's tools to actually be invoked.

```
User : List all Notion posts by David
Model: <calls search → calls enable("notion")>
       Notion is being set up. Please try again on your next message.
User : List all Notion posts by David          ← forced re-ask
Model: <now actually uses notion_* tools>
```

This was never a runtime constraint — `getTools` rebuilds the tool list at the top of every iteration of the run loop, and `reprobe` (with its regression test `TestReprobe_NewToolsAvailableAfterToolCall`) explicitly supports new tools appearing mid-stream. The deferred-Start design was an artifact: registering the toolset was cheap, but the prompt then had to admit the runtime couldn't guarantee tools would actually be available, since OAuth might be declined or the server might refuse the connection.

After this PR `handleEnable` drives Start synchronously inside the tool call. OAuth elicitation surfaces a dialog and blocks until the user responds; the success / failure result reaches the model at the point of the call, in the same RunStream. The Instructions block and the tool description are rewritten to match (no more "appears on your next turn" wording on the happy path).

### 2. OAuth is still required on the next question even if the previous OAuth failed

If the user stops a turn while the OAuth dialog is parked (the browser-side flow failed externally, the user gave up, etc.), Start returns `context.Canceled`. On main this falls into a generic warning-log branch and the entry stays in `t.enabled` in an unstarted state. The next user message — typically unrelated to the abandoned server — calls `Tools()`, which silently re-Starts the wrapper, hits 401, and re-pops the same dialog the user just abandoned.

The root cause is a lifetime mismatch: the catalog `Toolset` is owned by the `RuntimeSession`, not the `RunStream`, so `Toolset.Stop` does NOT run between a stopped turn and the user's next message.

```
                  RuntimeSession  (lives across many user messages)
┌─────────────────────────────────────────────────────────────┐
│  RunStream #1   │   RunStream #2   │   RunStream #3         │
│   Stop here─┘                                               │
│                                                             │
│  mcpcatalog.Tools()        runs at the start of every       │
│                            RunStream — iterates t.enabled   │
│                            and Start()s any unstarted entry │
│                                                             │
│  mcpcatalog.Toolset.Stop() runs ONCE, at session teardown   │
└─────────────────────────────────────────────────────────────┘
```

`context.Canceled` is now routed through `disableAfterDecline` (the same path that already handles an explicit `OAuthDeclined`) in both code paths that can Start a catalog server — the synchronous handleEnable and the per-turn Tools() iteration. The model-facing result tells the model the user stopped the turn while authorization was pending and to only retry if the user asks.

Public docs at `docs/tools/mcp-catalog/index.md` are updated for the new contract.
