### PR TITLE
refactor: reuse registry session for OCI pulls

### DIFF
--- a/pkg/remote/pull.go
+++ b/pkg/remote/pull.go
@@ -2,10 +2,17 @@ package remote
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
+	"slices"
 
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 
 	"github.com/docker/docker-agent/pkg/content"
 )
@@ -33,16 +40,27 @@ func IsDigestReference(registryRef string) bool {
 	return ok
 }
 
-// Pull pulls an artifact from a registry and stores it in the content store
+// Pull pulls an artifact from a registry and stores it in the content store.
+//
+// The digest check, manifest read, and layer downloads all reuse a single
+// authenticated registry session (a remote.Puller) so the token exchange and
+// underlying connection are established only once, rather than re-doing
+// authentication for each step.
 func Pull(ctx context.Context, registryRef string, force bool, opts ...crane.Option) (string, error) {
 	opts = append(opts, crane.WithContext(ctx), crane.WithTransport(NewTransport(ctx)))
+	o := crane.GetOptions(opts...)
 
-	ref, err := name.ParseReference(registryRef)
+	ref, err := name.ParseReference(registryRef, o.Name...)
 	if err != nil {
 		return "", fmt.Errorf("parsing registry reference %s: %w", registryRef, err)
 	}
 
-	remoteDigest, err := crane.Digest(ref.String(), opts...)
+	s, err := newSession(o)
+	if err != nil {
+		return "", fmt.Errorf("creating registry session: %w", err)
+	}
+
+	remoteDigest, err := s.digest(ctx, ref)
 	if err != nil {
 		return "", fmt.Errorf("resolving remote digest for %s: %w", registryRef, err)
 	}
@@ -64,7 +82,7 @@ func Pull(ctx context.Context, registryRef string, force bool, opts ...crane.Opt
 		}
 	}
 
-	img, err := crane.Pull(ref.String(), opts...)
+	img, err := s.image(ctx, ref)
 	if err != nil {
 		return "", fmt.Errorf("pulling image from registry %s: %w", registryRef, err)
 	}
@@ -77,12 +95,178 @@ func Pull(ctx context.Context, registryRef string, force bool, opts ...crane.Opt
 		return "", fmt.Errorf("artifact %s wasn't created by `docker agent share push`\nTry to push again with `docker agent share push`", localRef)
 	}
 
-	digest, err := store.StoreArtifact(img, localRef)
+	digest, err := storeArtifact(ctx, store, s, ref, localRef, img)
 	if err != nil {
 		return "", fmt.Errorf("storing artifact in content store: %w", err)
 	}
 
 	return digest, nil
+}
+
+func storeArtifact(ctx context.Context, store *content.Store, s *session, ref name.Reference, localRef string, img v1.Image) (string, error) {
+	digest, err := store.StoreArtifact(img, localRef)
+	if err == nil {
+		return digest, nil
+	}
+	if s.fellBack || !shouldRetryWithCredentials(err) {
+		return "", err
+	}
+	if perr := s.retryWithCredentials(); perr != nil {
+		return "", perr
+	}
+
+	img, err = s.image(ctx, ref)
+	if err != nil {
+		return "", err
+	}
+	manifest, err := img.Manifest()
+	if err != nil {
+		return "", fmt.Errorf("getting manifest from pulled image: %w", err)
+	}
+	if !hasCagentAnnotation(manifest.Annotations) {
+		return "", fmt.Errorf("artifact %s wasn't created by `docker agent share push`\nTry to push again with `docker agent share push`", localRef)
+	}
+	return store.StoreArtifact(img, localRef)
+}
+
+// session reuses a single remote.Puller across the digest check, manifest read,
+// and layer downloads of a pull. It starts anonymous and transparently falls
+// back to credentials from the keychain when the registry denies anonymous
+// access or rate-limits the request.
+type session struct {
+	opts     crane.Options
+	puller   *remote.Puller
+	fellBack bool
+}
+
+func newSession(o crane.Options) (*session, error) {
+	s := &session{opts: o}
+	puller, err := remote.NewPuller(s.remoteOptions(authn.Anonymous)...)
+	if err != nil {
+		return nil, err
+	}
+	s.puller = puller
+	return s, nil
+}
+
+// digest resolves the remote digest, matching crane.Digest behavior. When a
+// platform is set, it resolves indexes to the platform-specific image digest;
+// otherwise it uses a cheap HEAD request and falls back to GET if HEAD fails.
+func (s *session) digest(ctx context.Context, ref name.Reference) (string, error) {
+	if s.opts.Platform != nil {
+		d, err := s.get(ctx, ref)
+		if err != nil {
+			return "", err
+		}
+		if !d.MediaType.IsIndex() {
+			return d.Digest.String(), nil
+		}
+		img, err := d.Image()
+		if err != nil {
+			return "", err
+		}
+		digest, err := img.Digest()
+		if err != nil {
+			return "", err
+		}
+		return digest.String(), nil
+	}
+
+	var desc *v1.Descriptor
+	err := s.withFallback(func(p *remote.Puller) error {
+		var headErr error
+		desc, headErr = p.Head(ctx, ref)
+		return headErr
+	})
+	if err == nil {
+		return desc.Digest.String(), nil
+	}
+
+	// HEAD failed (e.g. registry doesn't support it); fall back to GET.
+	d, getErr := s.get(ctx, ref)
+	if getErr != nil {
+		return "", getErr
+	}
+	return d.Digest.String(), nil
+}
+
+// image fetches the manifest and returns a lazy v1.Image whose layer reads
+// reuse this session's authenticated fetcher.
+func (s *session) image(ctx context.Context, ref name.Reference) (v1.Image, error) {
+	desc, err := s.get(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+	return desc.Image()
+}
+
+func (s *session) get(ctx context.Context, ref name.Reference) (*remote.Descriptor, error) {
+	var desc *remote.Descriptor
+	err := s.withFallback(func(p *remote.Puller) error {
+		var getErr error
+		desc, getErr = p.Get(ctx, ref)
+		return getErr
+	})
+	return desc, err
+}
+
+// withFallback runs op against the current puller and, if an anonymous request
+// is denied or rate-limited, rebuilds the puller with keychain credentials and
+// retries once. Subsequent calls reuse the credentialed puller (and its cached
+// token).
+func (s *session) withFallback(op func(*remote.Puller) error) error {
+	err := op(s.puller)
+	if s.fellBack || !shouldRetryWithCredentials(err) {
+		return err
+	}
+
+	if err := s.retryWithCredentials(); err != nil {
+		return err
+	}
+	return op(s.puller)
+}
+
+func (s *session) retryWithCredentials() error {
+	if s.fellBack {
+		return nil
+	}
+	puller, err := remote.NewPuller(s.remoteOptions(nil)...)
+	if err != nil {
+		return err
+	}
+	s.puller = puller
+	s.fellBack = true
+	return nil
+}
+
+// remoteOptions builds the options for a puller, reusing the exact remote.Option
+// slice crane assembled (transport, context, platform, user-agent, jobs, ...).
+// crane keeps the authenticator at index 0, so we only override that entry:
+// authn.Anonymous for the first attempt, or the keychain (crane's original
+// option) for the credentialed fallback.
+func (s *session) remoteOptions(auth authn.Authenticator) []remote.Option {
+	opts := slices.Clone(s.opts.Remote)
+	if auth != nil && len(opts) > 0 {
+		opts[0] = remote.WithAuth(auth)
+	}
+	return opts
+}
+
+// shouldRetryWithCredentials reports whether an anonymous registry request
+// failed in a way that authenticating might fix: the registry denied access
+// (401 Unauthorized or 403 Forbidden) or rate-limited the anonymous request
+// (429 Too Many Requests, since authenticated accounts get higher limits).
+func shouldRetryWithCredentials(err error) bool {
+	var terr *transport.Error
+	if !errors.As(err, &terr) {
+		return false
+	}
+	switch terr.StatusCode {
+	case http.StatusUnauthorized, http.StatusForbidden, http.StatusTooManyRequests:
+		return true
+	default:
+		return false
+	}
 }
 
 func hasCagentAnnotation(annotations map[string]string) bool {

--- a/pkg/remote/pull_test.go
+++ b/pkg/remote/pull_test.go
@@ -1,15 +1,24 @@
 package remote
 
 import (
+	"errors"
+	"io"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
+	testregistry "github.com/google/go-containerregistry/pkg/registry"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	v1remote "github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/google/go-containerregistry/pkg/v1/static"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/stretchr/testify/assert"
@@ -17,6 +26,377 @@ import (
 
 	"github.com/docker/docker-agent/pkg/content"
 )
+
+type staticKeychain struct {
+	auth authn.Authenticator
+}
+
+func (k staticKeychain) Resolve(authn.Resource) (authn.Authenticator, error) {
+	return k.auth, nil
+}
+
+func TestShouldRetryWithCredentials(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{"nil error", nil, false},
+		{"generic error", errors.New("boom"), false},
+		{"unauthorized", &transport.Error{StatusCode: http.StatusUnauthorized}, true},
+		{"forbidden", &transport.Error{StatusCode: http.StatusForbidden}, true},
+		{"too many requests", &transport.Error{StatusCode: http.StatusTooManyRequests}, true},
+		{"not found", &transport.Error{StatusCode: http.StatusNotFound}, false},
+		{"server error", &transport.Error{StatusCode: http.StatusInternalServerError}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, shouldRetryWithCredentials(tt.err))
+		})
+	}
+}
+
+// testRegistry is a minimal in-memory OCI registry for exercising session
+// behavior. It serves one image's manifest and layers and can be configured to
+// reject anonymous requests, forcing a credential fallback.
+type testRegistry struct {
+	img        v1.Image
+	manifest   []byte
+	mediaType  types.MediaType
+	digest     string
+	anonReject int // status returned to anonymous manifest/blob requests; 0 allows anonymous
+	user, pass string
+
+	pingHits atomic.Int64 // requests to /v2/
+	anonHits atomic.Int64 // anonymous manifest/blob requests served
+	authHits atomic.Int64 // credentialed manifest/blob requests served
+	reqHits  atomic.Int64 // all HTTP requests received
+}
+
+func newTestRegistry(t *testing.T) *testRegistry {
+	t.Helper()
+
+	layer := static.NewLayer([]byte("test layer"), types.OCIUncompressedLayer)
+	img, err := mutate.AppendLayers(empty.Image, layer)
+	require.NoError(t, err)
+	img = mutate.Annotations(img, map[string]string{"io.docker.agent.version": "test"}).(v1.Image)
+	manifest, err := img.RawManifest()
+	require.NoError(t, err)
+	dig, err := img.Digest()
+	require.NoError(t, err)
+	mt, err := img.MediaType()
+	require.NoError(t, err)
+
+	return &testRegistry{
+		img:       img,
+		manifest:  manifest,
+		mediaType: mt,
+		digest:    dig.String(),
+	}
+}
+
+func (reg *testRegistry) start(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reg.reqHits.Add(1)
+		if r.URL.Path == "/v2/" {
+			reg.pingHits.Add(1)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		rejectStatus := reg.anonReject
+
+		_, _, hasAuth := r.BasicAuth()
+		if rejectStatus != 0 {
+			if !hasAuth {
+				reg.anonHits.Add(1)
+				if rejectStatus == http.StatusUnauthorized {
+					w.Header().Set("WWW-Authenticate", `Basic realm="test"`)
+				}
+				w.WriteHeader(rejectStatus)
+				return
+			}
+			u, p, _ := r.BasicAuth()
+			if u != reg.user || p != reg.pass {
+				w.WriteHeader(http.StatusForbidden)
+				return
+			}
+			reg.authHits.Add(1)
+		} else {
+			reg.anonHits.Add(1)
+		}
+
+		switch {
+		case strings.Contains(r.URL.Path, "/manifests/"):
+			w.Header().Set("Docker-Content-Digest", reg.digest)
+			w.Header().Set("Content-Type", string(reg.mediaType))
+			if r.Method == http.MethodGet {
+				_, _ = w.Write(reg.manifest)
+			}
+		case strings.Contains(r.URL.Path, "/blobs/"):
+			layers, _ := reg.img.Layers()
+			if len(layers) == 0 {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			rc, err := layers[0].Compressed()
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			defer rc.Close()
+			_, _ = io.Copy(w, rc)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	return server
+}
+
+func newTestSession(t *testing.T, opts ...crane.Option) *session {
+	t.Helper()
+	opts = append(opts, crane.Insecure)
+	s, err := newSession(crane.GetOptions(opts...))
+	require.NoError(t, err)
+	return s
+}
+
+func TestSessionDigestAnonymousFirst(t *testing.T) {
+	t.Parallel()
+
+	reg := newTestRegistry(t)
+	server := reg.start(t)
+
+	registry := strings.TrimPrefix(server.URL, "http://")
+	ref, err := name.ParseReference(registry + "/anon:latest")
+	require.NoError(t, err)
+
+	// A keychain that would fail if used, ensuring anonymous access is preferred.
+	keychain := staticKeychain{auth: &authn.Basic{Username: "bad", Password: "creds"}}
+	s := newTestSession(t, crane.WithAuthFromKeychain(keychain))
+
+	dig, err := s.digest(t.Context(), ref)
+	require.NoError(t, err)
+	assert.Equal(t, reg.digest, dig)
+	assert.Positive(t, reg.anonHits.Load(), "expected an anonymous request")
+	assert.Zero(t, reg.authHits.Load(), "did not expect a credentialed request")
+}
+
+func TestSessionCredentialFallback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		anonReject int
+	}{
+		{"unauthorized", http.StatusUnauthorized},
+		{"rate limited", http.StatusTooManyRequests},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			reg := newTestRegistry(t)
+			reg.anonReject = tt.anonReject
+			reg.user, reg.pass = "user", "pass"
+			server := reg.start(t)
+
+			registry := strings.TrimPrefix(server.URL, "http://")
+			ref, err := name.ParseReference(registry + "/private:latest")
+			require.NoError(t, err)
+
+			keychain := staticKeychain{auth: &authn.Basic{Username: "user", Password: "pass"}}
+			s := newTestSession(t, crane.WithAuthFromKeychain(keychain))
+
+			dig, err := s.digest(t.Context(), ref)
+			require.NoError(t, err)
+			assert.Equal(t, reg.digest, dig)
+			assert.Positive(t, reg.anonHits.Load(), "expected an initial anonymous attempt")
+			assert.Positive(t, reg.authHits.Load(), "expected a credentialed retry")
+		})
+	}
+}
+
+func TestStoreArtifactCredentialFallbackOnLayerDownload(t *testing.T) {
+	t.Parallel()
+
+	var requireBlobAuth atomic.Bool
+	var anonHits atomic.Int64
+	var authHits atomic.Int64
+	registryHandler := testregistry.New(testregistry.Logger(log.New(io.Discard, "", 0)))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requireBlobAuth.Load() && r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/blobs/") {
+			u, p, ok := r.BasicAuth()
+			if !ok {
+				anonHits.Add(1)
+				w.Header().Set("WWW-Authenticate", `Basic realm="test"`)
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			if u != "user" || p != "pass" {
+				w.WriteHeader(http.StatusForbidden)
+				return
+			}
+			authHits.Add(1)
+		}
+		registryHandler.ServeHTTP(w, r)
+	}))
+	defer server.Close()
+
+	img := mutate.Annotations(testImage(t, "layer-auth"), map[string]string{"io.docker.agent.version": "test"}).(v1.Image)
+	registryRef := strings.TrimPrefix(server.URL, "http://") + "/layer-auth:latest"
+	require.NoError(t, crane.Push(img, registryRef, crane.Insecure))
+	requireBlobAuth.Store(true)
+
+	ref, err := name.ParseReference(registryRef, name.Insecure)
+	require.NoError(t, err)
+
+	keychain := staticKeychain{auth: &authn.Basic{Username: "user", Password: "pass"}}
+	s := newTestSession(t, crane.WithAuthFromKeychain(keychain))
+	img, err = s.image(t.Context(), ref)
+	require.NoError(t, err)
+
+	store, err := content.NewStore(content.WithBaseDir(t.TempDir()))
+	require.NoError(t, err)
+
+	dig, err := storeArtifact(t.Context(), store, s, ref, "layer-auth:latest", img)
+	require.NoError(t, err)
+	assert.NotEmpty(t, dig)
+	assert.Positive(t, anonHits.Load(), "expected an anonymous layer attempt")
+	assert.Positive(t, authHits.Load(), "expected a credentialed retry for the layer")
+}
+
+func TestSessionReusesAuthAcrossDigestAndImage(t *testing.T) {
+	t.Parallel()
+
+	reg := newTestRegistry(t)
+	server := reg.start(t)
+
+	registry := strings.TrimPrefix(server.URL, "http://")
+	ref, err := name.ParseReference(registry + "/reuse:latest")
+	require.NoError(t, err)
+
+	s := newTestSession(t)
+
+	dig, err := s.digest(t.Context(), ref)
+	require.NoError(t, err)
+	assert.Equal(t, reg.digest, dig)
+
+	img, err := s.image(t.Context(), ref)
+	require.NoError(t, err)
+	_, err = img.Manifest()
+	require.NoError(t, err)
+
+	// digest (HEAD) and image (GET) should share one puller, so the registry
+	// is pinged only once rather than once per crane call.
+	assert.Equal(t, int64(1), reg.pingHits.Load(), "expected a single registry ping for the shared session")
+}
+
+// TestSessionFewerRequestsThanCraneCalls is a head-to-head proof of the
+// optimization: it runs the digest + manifest steps once through the shared
+// session and once through the previous approach (crane.Digest then crane.Pull)
+// against identical registries, and asserts the session makes strictly fewer
+// HTTP requests by avoiding the redundant ping/token round trips.
+func TestSessionFewerRequestsThanCraneCalls(t *testing.T) {
+	t.Parallel()
+
+	// Shared-session approach.
+	sessReg := newTestRegistry(t)
+	sessServer := sessReg.start(t)
+	sessRef, err := name.ParseReference(strings.TrimPrefix(sessServer.URL, "http://") + "/repo:latest")
+	require.NoError(t, err)
+
+	s := newTestSession(t)
+	_, err = s.digest(t.Context(), sessRef)
+	require.NoError(t, err)
+	img, err := s.image(t.Context(), sessRef)
+	require.NoError(t, err)
+	_, err = img.Manifest()
+	require.NoError(t, err)
+
+	// Previous approach: two independent crane calls, each re-pinging and
+	// re-authenticating from scratch.
+	craneReg := newTestRegistry(t)
+	craneServer := craneReg.start(t)
+	craneRef := strings.TrimPrefix(craneServer.URL, "http://") + "/repo:latest"
+
+	_, err = crane.Digest(craneRef, crane.Insecure)
+	require.NoError(t, err)
+	craneImg, err := crane.Pull(craneRef, crane.Insecure)
+	require.NoError(t, err)
+	_, err = craneImg.Manifest()
+	require.NoError(t, err)
+
+	t.Logf("requests: shared session=%d, two crane calls=%d", sessReg.reqHits.Load(), craneReg.reqHits.Load())
+	assert.Less(t, sessReg.reqHits.Load(), craneReg.reqHits.Load(),
+		"shared session should make fewer HTTP requests than two independent crane calls")
+	assert.Equal(t, int64(1), sessReg.pingHits.Load(), "shared session should ping the registry once")
+	assert.Greater(t, craneReg.pingHits.Load(), int64(1), "independent crane calls re-ping per call")
+}
+
+func TestSessionDigestResolvesPlatformIndex(t *testing.T) {
+	t.Parallel()
+
+	amd64Image := testImage(t, "amd64")
+	arm64Image := testImage(t, "arm64")
+	amd64Digest, err := amd64Image.Digest()
+	require.NoError(t, err)
+	arm64Digest, err := arm64Image.Digest()
+	require.NoError(t, err)
+	require.NotEqual(t, amd64Digest, arm64Digest)
+
+	idx := mutate.AppendManifests(empty.Index,
+		mutate.IndexAddendum{
+			Add: amd64Image,
+			Descriptor: v1.Descriptor{Platform: &v1.Platform{
+				OS:           "linux",
+				Architecture: "amd64",
+			}},
+		},
+		mutate.IndexAddendum{
+			Add: arm64Image,
+			Descriptor: v1.Descriptor{Platform: &v1.Platform{
+				OS:           "linux",
+				Architecture: "arm64",
+			}},
+		},
+	)
+
+	server := httptest.NewServer(testregistry.New(testregistry.Logger(log.New(io.Discard, "", 0))))
+	defer server.Close()
+
+	registryRef := strings.TrimPrefix(server.URL, "http://") + "/platform:latest"
+	ref, err := name.ParseReference(registryRef, name.Insecure)
+	require.NoError(t, err)
+	require.NoError(t, v1remote.WriteIndex(ref, idx))
+
+	platform := &v1.Platform{OS: "linux", Architecture: "arm64"}
+	s, err := newSession(crane.GetOptions(crane.Insecure, crane.WithPlatform(platform)))
+	require.NoError(t, err)
+
+	dig, err := s.digest(t.Context(), ref)
+	require.NoError(t, err)
+	assert.Equal(t, arm64Digest.String(), dig)
+}
+
+func testImage(t *testing.T, contents string) v1.Image {
+	t.Helper()
+
+	layer := static.NewLayer([]byte(contents), types.OCIUncompressedLayer)
+	img, err := mutate.AppendLayers(empty.Image, layer)
+	require.NoError(t, err)
+	return img
+}
 
 func TestPullRegistryNotFound(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Anonymous-first pull with credential fallback on 401/403/429. This change reuses a single `remote.Puller` across digest, manifest, and layer downloads to avoid duplicate authentication attempts and improve performance.

The refactored implementation preserves platform digest behavior and retries credentialed storage on lazy layer authentication and rate-limit failures. By maintaining one session state, we eliminate redundant auth flows while keeping the same error recovery semantics.

Validation: `task lint`, `go test -race ./pkg/remote/...`, `task build`, `task test`.