### PR TITLE
openai: handle newer Responses stream event shapes

### DIFF
--- a/pkg/model/provider/openai/response_stream.go
+++ b/pkg/model/provider/openai/response_stream.go
@@ -23,6 +23,7 @@ type ResponseStreamAdapter struct {
 	trackUsage     bool
 	itemCallIDMap  map[string]string
 	itemHasContent map[string]bool
+	pendingArgs    map[string]string
 }
 
 func newResponseStreamAdapter(stream responseEventStream, trackUsage bool) *ResponseStreamAdapter {
@@ -31,7 +32,12 @@ func newResponseStreamAdapter(stream responseEventStream, trackUsage bool) *Resp
 		trackUsage:     trackUsage,
 		itemCallIDMap:  make(map[string]string),
 		itemHasContent: make(map[string]bool),
+		pendingArgs:    make(map[string]string),
 	}
+}
+
+func isTextContentPart(partType string) bool {
+	return partType == "text" || partType == "output_text"
 }
 
 // Recv gets the next completion chunk
@@ -63,22 +69,17 @@ func (a *ResponseStreamAdapter) Recv() (chat.MessageStreamResponse, error) {
 		}
 	case "response.output_text.done":
 		slog.Debug("Output text done", "item_id", event.ItemID)
+	case "response.created", "response.in_progress", "response.content_part.done":
+		slog.Debug("Ignoring structural response stream event", "type", event.Type, "item_id", event.ItemID)
 	case "response.content_part.added":
-		if event.Part.Type == "text" {
-			content := event.Part.Text
-			if content != "" {
-				a.itemHasContent[event.ItemID] = true
-				response.Choices = []chat.MessageStreamChoice{
-					{
-						Delta: chat.MessageDelta{
-							Content: content,
-							Role:    "assistant",
-						},
-					},
-				}
-			}
-		} else {
-			slog.Warn("Received function_call_arguments.delta for unknown item_id", "item_id", event.ItemID, "known_items", len(a.itemCallIDMap))
+		// This event announces that a content part exists. For output_text
+		// parts, the text itself is streamed separately via
+		// response.output_text.delta and finalized by content_part.done /
+		// output_item.done. Do not emit Part.Text here: newer Responses API
+		// models can include a snapshot in the added event, and emitting it
+		// duplicates the subsequent deltas.
+		if !isTextContentPart(event.Part.Type) {
+			slog.Debug("Ignoring non-text response content part", "item_id", event.ItemID, "part_type", event.Part.Type)
 		}
 	case "response.content_part.delta":
 		content := cmp.Or(event.Delta, event.Text, event.Code, event.Part.Text)
@@ -112,8 +113,15 @@ func (a *ResponseStreamAdapter) Recv() (chat.MessageStreamResponse, error) {
 				slog.Debug("Extracted name from Item.Name field", "name", funcName)
 			}
 
-			// Only emit the tool call with name, arguments will come in delta events
+			// Only emit the tool call with name. Arguments normally arrive in
+			// delta events, but some transports/models can deliver an arguments
+			// delta before the output_item.added event. Flush any such buffered
+			// bytes with the first named tool-call delta so the runtime can still
+			// reconstruct the call.
 			if funcName != "" {
+				args := a.pendingArgs[itemID]
+				delete(a.pendingArgs, itemID)
+
 				slog.Debug("Emitting tool call with name", "item_id", event.ItemID, "call_id", callID, "name", funcName)
 				response.Choices = []chat.MessageStreamChoice{
 					{
@@ -124,7 +132,7 @@ func (a *ResponseStreamAdapter) Recv() (chat.MessageStreamResponse, error) {
 									Type: "function",
 									Function: tools.FunctionCall{
 										Name:      funcName,
-										Arguments: "", // Arguments come in delta events
+										Arguments: args,
 									},
 								},
 							},
@@ -159,7 +167,11 @@ func (a *ResponseStreamAdapter) Recv() (chat.MessageStreamResponse, error) {
 				}
 			}
 		} else {
-			slog.Error("Unknown item_id for arguments delta", "item_id", event.ItemID, "known_items", a.itemCallIDMap)
+			args := cmp.Or(event.Delta, event.Arguments)
+			if args != "" {
+				a.pendingArgs[event.ItemID] += args
+				slog.Debug("Buffered function call arguments delta before output item", "item_id", event.ItemID, "delta_length", len(args))
+			}
 		}
 	case "response.function_call_arguments.done":
 		// Function call arguments are complete - we already streamed them
@@ -203,19 +215,22 @@ func (a *ResponseStreamAdapter) Recv() (chat.MessageStreamResponse, error) {
 
 	case "response.output_item.done":
 		// Tool call or message item is complete
-		slog.Debug("Output item done", "item_id", event.ItemID, "type", event.Item.Type)
-		// Don't set finish reason here - wait for response.completed
-		// Just handle any missed content
-		if event.Item.Type == "message" && !a.itemHasContent[event.ItemID] {
+		itemID := cmp.Or(event.ItemID, event.Item.ID)
+		slog.Debug("Output item done", "item_id", itemID, "type", event.Item.Type)
+		// Don't set finish reason here - wait for response.completed.
+		// Just handle any missed content. Some Responses API transports omit
+		// the top-level item_id on output_item.done while still providing
+		// item.id, so use the resolved itemID for deduplication.
+		if event.Item.Type == "message" && !a.itemHasContent[itemID] {
 			for _, content := range event.Item.Content {
-				if content.Type == "text" && content.Text != "" {
+				if isTextContentPart(content.Type) && content.Text != "" {
 					response.Choices = append(response.Choices, chat.MessageStreamChoice{
 						Delta: chat.MessageDelta{
 							Content: content.Text,
 							Role:    "assistant",
 						},
 					})
-					a.itemHasContent[event.ItemID] = true
+					a.itemHasContent[itemID] = true
 				}
 			}
 		}

--- a/pkg/model/provider/openai/ws_stream_test.go
+++ b/pkg/model/provider/openai/ws_stream_test.go
@@ -134,6 +134,221 @@ func TestWSStream_TextDelta(t *testing.T) {
 	assert.ErrorIs(t, err, io.EOF)
 }
 
+func TestWSStream_ContentPartAddedOutputTextIsStructural(t *testing.T) {
+	t.Parallel()
+
+	events := []map[string]any{
+		{
+			"type":          "response.content_part.added",
+			"item_id":       "msg_123",
+			"output_index":  0,
+			"content_index": 0,
+			"part": map[string]any{
+				"type": "output_text",
+				"text": "Hello",
+			},
+		},
+		{
+			"type":    "response.output_text.delta",
+			"item_id": "msg_123",
+			"delta":   "Hello",
+		},
+		{
+			"type": "response.output_item.done",
+			"item": map[string]any{
+				"id":   "msg_123",
+				"type": "message",
+				"content": []any{
+					map[string]any{"type": "output_text", "text": "Hello"},
+				},
+				"role": "assistant",
+			},
+		},
+		{
+			"type": "response.completed",
+			"response": map[string]any{
+				"id":     "resp_content_part",
+				"output": []any{},
+				"usage": map[string]any{
+					"input_tokens":          4,
+					"output_tokens":         4,
+					"total_tokens":          8,
+					"input_tokens_details":  map[string]any{"cached_tokens": 0},
+					"output_tokens_details": map[string]any{"reasoning_tokens": 0},
+				},
+			},
+		},
+	}
+
+	srv := testWSServer(t, events)
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	stream, err := dialWebSocket(t.Context(), wsURL, http.Header{}, defaultTestParams())
+	require.NoError(t, err)
+	defer stream.Close()
+
+	adapter := newResponseStreamAdapter(stream, true)
+
+	// content_part.added is structural. Even if it carries a text snapshot,
+	// output_text.delta is the event that should produce streamed content.
+	resp, err := adapter.Recv()
+	require.NoError(t, err)
+	assert.Empty(t, resp.Choices)
+
+	resp, err = adapter.Recv()
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+	assert.Equal(t, "Hello", resp.Choices[0].Delta.Content)
+
+	// output_item.done contains the complete text snapshot, but the delta
+	// above already streamed it. It must not be emitted a second time.
+	resp, err = adapter.Recv()
+	require.NoError(t, err)
+	assert.Empty(t, resp.Choices)
+
+	resp, err = adapter.Recv()
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+	assert.Equal(t, chat.FinishReasonStop, resp.Choices[0].FinishReason)
+
+	_, err = adapter.Recv()
+	assert.ErrorIs(t, err, io.EOF)
+}
+
+func TestWSStream_OutputItemDoneRecoversMissedOutputText(t *testing.T) {
+	t.Parallel()
+
+	events := []map[string]any{
+		{
+			"type": "response.output_item.done",
+			"item": map[string]any{
+				"id":   "msg_recovered",
+				"type": "message",
+				"content": []any{
+					map[string]any{"type": "output_text", "text": "Recovered"},
+				},
+				"role": "assistant",
+			},
+		},
+		{
+			"type": "response.completed",
+			"response": map[string]any{
+				"id":     "resp_recovered",
+				"output": []any{},
+				"usage": map[string]any{
+					"input_tokens":          4,
+					"output_tokens":         4,
+					"total_tokens":          8,
+					"input_tokens_details":  map[string]any{"cached_tokens": 0},
+					"output_tokens_details": map[string]any{"reasoning_tokens": 0},
+				},
+			},
+		},
+	}
+
+	srv := testWSServer(t, events)
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	stream, err := dialWebSocket(t.Context(), wsURL, http.Header{}, defaultTestParams())
+	require.NoError(t, err)
+	defer stream.Close()
+
+	adapter := newResponseStreamAdapter(stream, true)
+
+	resp, err := adapter.Recv()
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+	assert.Equal(t, "Recovered", resp.Choices[0].Delta.Content)
+
+	resp, err = adapter.Recv()
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+	assert.Equal(t, chat.FinishReasonStop, resp.Choices[0].FinishReason)
+
+	_, err = adapter.Recv()
+	assert.ErrorIs(t, err, io.EOF)
+}
+
+func TestWSStream_BuffersArgumentsDeltaBeforeOutputItemAdded(t *testing.T) {
+	t.Parallel()
+
+	events := []map[string]any{
+		{
+			"type":    "response.function_call_arguments.delta",
+			"item_id": "item_early",
+			"delta":   `{"city":"Paris"}`,
+		},
+		{
+			"type":    "response.output_item.added",
+			"item_id": "item_early",
+			"item": map[string]any{
+				"type":    "function_call",
+				"id":      "item_early",
+				"call_id": "call_early",
+				"name":    "get_weather",
+			},
+		},
+		{
+			"type":    "response.function_call_arguments.done",
+			"item_id": "item_early",
+		},
+		{
+			"type": "response.completed",
+			"response": map[string]any{
+				"id": "resp_early_tool_args",
+				"output": []any{
+					map[string]any{"type": "function_call"},
+				},
+				"usage": map[string]any{
+					"input_tokens":          8,
+					"output_tokens":         12,
+					"total_tokens":          20,
+					"input_tokens_details":  map[string]any{"cached_tokens": 0},
+					"output_tokens_details": map[string]any{"reasoning_tokens": 0},
+				},
+			},
+		},
+	}
+
+	srv := testWSServer(t, events)
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	stream, err := dialWebSocket(t.Context(), wsURL, http.Header{}, defaultTestParams())
+	require.NoError(t, err)
+	defer stream.Close()
+
+	adapter := newResponseStreamAdapter(stream, true)
+
+	// Early arguments are buffered until the corresponding function item arrives.
+	resp, err := adapter.Recv()
+	require.NoError(t, err)
+	assert.Empty(t, resp.Choices)
+
+	resp, err = adapter.Recv()
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+	require.Len(t, resp.Choices[0].Delta.ToolCalls, 1)
+	call := resp.Choices[0].Delta.ToolCalls[0]
+	assert.Equal(t, "call_early", call.ID)
+	assert.Equal(t, "get_weather", call.Function.Name)
+	assert.JSONEq(t, `{"city":"Paris"}`, call.Function.Arguments)
+
+	resp, err = adapter.Recv()
+	require.NoError(t, err)
+	assert.Empty(t, resp.Choices)
+
+	resp, err = adapter.Recv()
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+	assert.Equal(t, chat.FinishReasonToolCalls, resp.Choices[0].FinishReason)
+
+	_, err = adapter.Recv()
+	assert.ErrorIs(t, err, io.EOF)
+}
+
 func TestWSStream_IgnoresEmptyFrames(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Newer Responses API models can announce assistant text with response.content_part.added using part.type=output_text. The adapter only recognized text, so those msg_* items fell into a misleading tool-call warning path even though no function call was involved.

Keep response.content_part.added structural. Text is streamed by response.output_text.delta, and output_item.done carries a final snapshot. Emitting both snapshots and deltas duplicates assistant text.

Use output_item.done only as a fallback for missed text. Some streams omit the top-level item_id there while still setting item.id, so resolve that ID before checking whether content was already streamed.

Also tolerate function_call_arguments.delta arriving before the matching output_item.added event by buffering the argument bytes until the tool item is registered. This avoids dropping tool arguments when stream events are delivered in that order.

Add coverage for output_text content parts, output_item.done fallback and early function-call argument deltas.