### PR TITLE
docs: document alias list --json flag and failure-safe conversation caching

### DIFF
--- a/docs/features/chat-server/index.md
+++ b/docs/features/chat-server/index.md
@@ -147,6 +147,14 @@ Cached conversations are evicted after `--conversation-ttl` of inactivity, or
 when the cache hits `--conversations-max` items (oldest entries are evicted
 first).
 
+### Failure-safe caching
+
+When a request fails — for example because the model returns an error or the `--request-timeout` expires — the conversation cache is **not updated**. The server clones the cached session before processing each request and only commits the updated session when the turn completes successfully. This means:
+
+- A failed turn leaves the conversation in the same state it was before the request.
+- Clients can safely retry with the same `X-Conversation-Id` after a failure.
+- Transient errors do not corrupt the conversation history.
+
 ## Authentication
 
 The chat server has **no authentication by default**. To require a Bearer

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -386,6 +386,9 @@ Manage agent aliases for quick access.
 # List aliases
 $ docker agent alias ls
 
+# List aliases as JSON
+$ docker agent alias list --json
+
 # Add an alias
 $ docker agent alias add pirate /path/to/pirate.yaml
 $ docker agent alias add other ociReference
@@ -420,6 +423,32 @@ Registered aliases (3):
 
 Run an alias with: docker agent run <alias>
 ```
+
+Pass `--json` to output aliases as a JSON array instead of the formatted table. Each entry includes the alias `name` and its options:
+
+```bash
+$ docker agent alias list --json
+[
+  {
+    "name": "fast-coder",
+    "path": "agentcatalog/coder",
+    "model": "openai/gpt-4o-mini"
+  },
+  {
+    "name": "turbo",
+    "path": "agentcatalog/coder",
+    "yolo": true,
+    "model": "anthropic/claude-sonnet-4-5"
+  },
+  {
+    "name": "yolo-coder",
+    "path": "agentcatalog/coder",
+    "yolo": true
+  }
+]
+```
+
+JSON output is sorted by name and omits false/zero-valued fields. This is useful for scripting and automation.
 
 <div class="callout callout-tip" markdown="1">
 <div class="callout-title">Override alias options


### PR DESCRIPTION
## Summary

This PR updates the documentation to reflect two features merged into `main` in the last 36 hours.

### Changes

- **`docs/features/cli/index.md`** — Document the `--json` flag added to `docker agent alias list` in [#2966](https://github.com/docker/docker-agent/pull/2966). Added a `--json` usage example in the alias usage block, a full JSON output example showing the `name`/`path`/options fields, and a note that output is sorted by name and omits false/zero-valued fields.

- **`docs/features/chat-server/index.md`** — Document the failure-safe conversation caching behavior fixed in [#2947](https://github.com/docker/docker-agent/pull/2947). Added a new "Failure-safe caching" subsection explaining that failed requests (model error, timeout) leave the cached conversation unchanged, clients can safely retry with the same `X-Conversation-Id`, and transient errors do not corrupt conversation history.

### Source PRs covered

| Commit | Source PR | What changed |
|--------|-----------|-------------|
| d2de0e19 | [#2966](https://github.com/docker/docker-agent/pull/2966) | `alias list --json` machine-readable output flag |
| 73f37cfb | [#2947](https://github.com/docker/docker-agent/pull/2947) | Failure-safe conversation cache (failed turns do not corrupt cache) |