### PR TITLE
fix: use cmd.Context() instead of context.Background()

### DIFF
--- a/cmd/root/completion.go
+++ b/cmd/root/completion.go
@@ -1,7 +1,6 @@
 package root
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -65,7 +64,7 @@ func completeMessage(cmd *cobra.Command, args []string, toComplete string) ([]st
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	cfg, err := config.Load(context.Background(), agentSource)
+	cfg, err := config.Load(cmd.Context(), agentSource)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}


### PR DESCRIPTION
During an audit of `context.Background()` usage in the codebase, this was identified as the one genuinely suspicious instance. The shell-completion handler for `completeMessage` was passing `context.Background()` to `config.Load()`, which meant completion operations ignored the cobra command's own context and could not be cancelled or respect deadline constraints.

This change passes `cmd.Context()` instead, ensuring that shell completion respects cancellation and any deadlines set by the caller. The now-unused `context` import was removed.

All other `context.Background()` occurrences in the codebase were reviewed and deemed intentional (detached long-lived resources, `sync.Once` caches, fire-and-forget calls), so no further changes are needed.