### PR TITLE
feat: add ContextLimit helper to modelinfo

### DIFF
--- a/pkg/model/provider/anthropic/attachments.go
+++ b/pkg/model/provider/anthropic/attachments.go
@@ -24,7 +24,7 @@ import (
 //   - text with InlineText → TextBlockParam with TXTEnvelope
 //   - unsupported / no content → nil (logged as warning)
 func convertDocument(ctx context.Context, doc chat.Document, id modelsdev.ID, store *modelsdev.Store) ([]anthropic.ContentBlockParamUnion, error) {
-	mc := modelinfo.LoadCaps(store, id)
+	mc := modelinfo.LoadCaps(ctx, store, id)
 	if !mc.Supports(doc.MimeType) && modelinfo.IsClaude(ctx, store, id) {
 		mc = modelinfo.CapsWith(true, true)
 	}

--- a/pkg/model/provider/anthropic/beta_client.go
+++ b/pkg/model/provider/anthropic/beta_client.go
@@ -123,7 +123,7 @@ func (c *Client) createBetaStream(
 			slog.WarnContext(ctx, "Failed to count tokens for retry, skipping", "error", err)
 			return nil
 		}
-		newMaxTokens := clampMaxTokens(anthropicContextLimit(c.ModelConfig.Model), used, maxTokens)
+		newMaxTokens := clampMaxTokens(c.contextLimit(ctx), used, maxTokens)
 		if newMaxTokens >= maxTokens {
 			slog.WarnContext(ctx, "Token count does not require clamping, not retrying")
 			return nil

--- a/pkg/model/provider/anthropic/beta_client_test.go
+++ b/pkg/model/provider/anthropic/beta_client_test.go
@@ -12,7 +12,19 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/model/provider/base"
+	"github.com/docker/docker-agent/pkg/model/provider/options"
+	"github.com/docker/docker-agent/pkg/modelinfo"
+	"github.com/docker/docker-agent/pkg/modelsdev"
 )
+
+// optionsFromStore builds ModelOptions carrying the given models.dev store.
+func optionsFromStore(store *modelsdev.Store) options.ModelOptions {
+	var mo options.ModelOptions
+	options.WithModelsDevStore(store)(&mo)
+	return mo
+}
 
 // TestCountAnthropicTokensBeta_Success tests successful token counting for beta API
 func TestCountAnthropicTokensBeta_Success(t *testing.T) {
@@ -170,10 +182,37 @@ func TestClampMaxTokens_ExactlyAtLimit(t *testing.T) {
 	assert.Equal(t, int64(1), result)
 }
 
-// TestAnthropicContextLimit_ReturnsCorrectLimit tests context limit function
-func TestAnthropicContextLimit_ReturnsCorrectLimit(t *testing.T) {
-	limit := anthropicContextLimit("claude-3-5-sonnet-20241022")
-	assert.Equal(t, int64(200000), limit)
+// TestContextLimit_FromModelsDev verifies the client prefers the models.dev
+// context window and falls back to the Claude 200k default otherwise.
+func TestContextLimit_FromModelsDev(t *testing.T) {
+	store := modelsdev.NewDatabaseStore(&modelsdev.Database{
+		Providers: map[string]modelsdev.Provider{
+			"anthropic": {
+				Models: map[string]modelsdev.Model{
+					"claude-sonnet-4-5": {Limit: modelsdev.Limit{Context: 1000000}},
+				},
+			},
+		},
+	})
+
+	withStore := &Client{Config: base.Config{
+		ModelConfig:  latest.ModelConfig{Provider: "anthropic", Model: "claude-sonnet-4-5"},
+		ModelOptions: optionsFromStore(store),
+	}}
+	assert.Equal(t, int64(1000000), withStore.contextLimit(t.Context()))
+
+	// Unknown model falls back to the default Claude window.
+	unknown := &Client{Config: base.Config{
+		ModelConfig:  latest.ModelConfig{Provider: "anthropic", Model: "claude-future"},
+		ModelOptions: optionsFromStore(store),
+	}}
+	assert.Equal(t, int64(modelinfo.DefaultAnthropicContextLimit), unknown.contextLimit(t.Context()))
+
+	// No store configured: default Claude window.
+	noStore := &Client{Config: base.Config{
+		ModelConfig: latest.ModelConfig{Provider: "anthropic", Model: "claude-sonnet-4-5"},
+	}}
+	assert.Equal(t, int64(modelinfo.DefaultAnthropicContextLimit), noStore.contextLimit(t.Context()))
 }
 
 // TestExtractBetaSystemBlocks_SingleSystemMessage tests extracting system messages

--- a/pkg/model/provider/anthropic/client.go
+++ b/pkg/model/provider/anthropic/client.go
@@ -23,6 +23,7 @@ import (
 	"github.com/docker/docker-agent/pkg/model/provider/base"
 	"github.com/docker/docker-agent/pkg/model/provider/options"
 	"github.com/docker/docker-agent/pkg/model/provider/providerutil"
+	"github.com/docker/docker-agent/pkg/modelinfo"
 	"github.com/docker/docker-agent/pkg/tools"
 )
 
@@ -298,7 +299,7 @@ func (c *Client) CreateChatCompletionStream(
 			slog.WarnContext(ctx, "Failed to count tokens for retry, skipping", "error", err)
 			return nil
 		}
-		newMaxTokens := clampMaxTokens(anthropicContextLimit(c.ModelConfig.Model), used, maxTokens)
+		newMaxTokens := clampMaxTokens(c.contextLimit(ctx), used, maxTokens)
 		if newMaxTokens >= maxTokens {
 			slog.WarnContext(ctx, "Token count does not require clamping, not retrying")
 			return nil
@@ -757,11 +758,11 @@ func contentArray(m map[string]any) []any {
 	return nil
 }
 
-// anthropicContextLimit returns a reasonable default context window for Anthropic models.
-// We default to 200k tokens, which is what 3.5-4.5 models support; adjust as needed over time.
-func anthropicContextLimit(model string) int64 {
-	_ = model
-	return 200000
+// contextLimit returns the context window for this client's model, sourced
+// from models.dev when available and falling back to the standard Claude
+// 200k window otherwise.
+func (c *Client) contextLimit(ctx context.Context) int64 {
+	return modelinfo.ContextLimit(ctx, c.ModelOptions.ModelsDevStore(), c.ID(), modelinfo.DefaultAnthropicContextLimit)
 }
 
 // clampMaxTokens returns the effective max_tokens value after capping to the

--- a/pkg/model/provider/bedrock/attachments.go
+++ b/pkg/model/provider/bedrock/attachments.go
@@ -42,7 +42,7 @@ func imageFormatFromMIME(mimeType string) (types.ImageFormat, bool) {
 //   - text/* with InlineText → ContentBlockMemberText with TXTEnvelope
 //   - unsupported / no content → nil (logged as warning)
 func convertDocument(ctx context.Context, doc chat.Document, id modelsdev.ID, store *modelsdev.Store) ([]types.ContentBlock, error) {
-	mc := modelinfo.LoadCaps(store, id)
+	mc := modelinfo.LoadCaps(ctx, store, id)
 	return convertDocumentWithCaps(ctx, doc, mc)
 }
 

--- a/pkg/model/provider/gemini/attachments.go
+++ b/pkg/model/provider/gemini/attachments.go
@@ -21,7 +21,7 @@ import (
 //   - text MIMEs with InlineText → genai.Text part with TXTEnvelope
 //   - unsupported / no content → nil (logged as warning)
 func convertDocument(ctx context.Context, doc chat.Document, id modelsdev.ID, store *modelsdev.Store) (*genai.Part, error) {
-	mc := modelinfo.LoadCaps(store, id)
+	mc := modelinfo.LoadCaps(ctx, store, id)
 	return convertDocumentWithCaps(ctx, doc, mc)
 }
 

--- a/pkg/model/provider/oaistream/attachments.go
+++ b/pkg/model/provider/oaistream/attachments.go
@@ -25,7 +25,7 @@ import (
 //   - text MIMEs with InlineText → text part with TXTEnvelope
 //   - unsupported / no content → nil (logged as warning)
 func convertDocument(ctx context.Context, doc chat.Document, id modelsdev.ID, store *modelsdev.Store) ([]openai.ChatCompletionContentPartUnionParam, error) {
-	mc := modelinfo.LoadCaps(store, id)
+	mc := modelinfo.LoadCaps(ctx, store, id)
 	return convertDocumentWithCaps(ctx, doc, mc)
 }
 

--- a/pkg/model/provider/openai/attachments.go
+++ b/pkg/model/provider/openai/attachments.go
@@ -26,7 +26,7 @@ import (
 //   - text MIMEs with InlineText → OfInputText with TXTEnvelope
 //   - unsupported / no content → nil (logged as warning)
 func convertDocumentToResponseInput(ctx context.Context, doc chat.Document, id modelsdev.ID, store *modelsdev.Store) ([]responses.ResponseInputContentUnionParam, error) {
-	mc := modelinfo.LoadCaps(store, id)
+	mc := modelinfo.LoadCaps(ctx, store, id)
 	return convertDocumentToResponseInputWithCaps(ctx, doc, mc)
 }
 

--- a/pkg/modelinfo/modelinfo.go
+++ b/pkg/modelinfo/modelinfo.go
@@ -255,8 +255,10 @@ const DefaultAnthropicContextLimit = 200000
 // back to fallback. Callers that have no sensible fallback should pass 0 and
 // treat a 0 result as "unknown".
 //
-// The supplied ctx is wrapped with loadCapsTimeout so the lookup is both
-// cancellable with the caller and bounded on its own.
+// The supplied ctx is wrapped with loadCapsTimeout so the lookup stays
+// cancellable with the caller and the underlying models.dev load is bounded.
+// Note that the first lookup may serialize behind a shared store load: the
+// timeout bounds the load itself, not time spent waiting for the store lock.
 func ContextLimit(ctx context.Context, store *modelsdev.Store, id modelsdev.ID, fallback int64) int64 {
 	if store == nil {
 		return fallback
@@ -278,8 +280,10 @@ func ContextLimit(ctx context.Context, store *modelsdev.Store, id modelsdev.ID, 
 // When the store is nil or the model is not found, LoadCaps returns a
 // conservative capability set that only allows text MIME types.
 //
-// The supplied ctx is wrapped with loadCapsTimeout so the lookup is both
-// cancellable with the caller and bounded on its own.
+// The supplied ctx is wrapped with loadCapsTimeout so the lookup stays
+// cancellable with the caller and the underlying models.dev load is bounded.
+// Note that the first lookup may serialize behind a shared store load: the
+// timeout bounds the load itself, not time spent waiting for the store lock.
 func LoadCaps(ctx context.Context, store *modelsdev.Store, id modelsdev.ID) ModelCapabilities {
 	if store == nil {
 		return ModelCapabilities{}

--- a/pkg/modelinfo/modelinfo.go
+++ b/pkg/modelinfo/modelinfo.go
@@ -243,17 +243,49 @@ func (mc ModelCapabilities) Supports(mimeType string) bool {
 // loadCapsTimeout is the maximum time allowed for a models.dev capability lookup.
 const loadCapsTimeout = 10 * time.Second
 
+// DefaultAnthropicContextLimit is the context window assumed for Claude models
+// when models.dev has no entry for them. Claude 3.5 through 4.x all expose a
+// 200k-token window, so it is a safe floor for clamping retries.
+const DefaultAnthropicContextLimit = 200000
+
+// ContextLimit returns the context-window size (in tokens) for a model.
+//
+// It prefers the models.dev catalogue entry for id; when the store is nil,
+// the model is unknown, or the catalogue reports no context limit, it falls
+// back to fallback. Callers that have no sensible fallback should pass 0 and
+// treat a 0 result as "unknown".
+//
+// The supplied ctx is wrapped with loadCapsTimeout so the lookup is both
+// cancellable with the caller and bounded on its own.
+func ContextLimit(ctx context.Context, store *modelsdev.Store, id modelsdev.ID, fallback int64) int64 {
+	if store == nil {
+		return fallback
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, loadCapsTimeout)
+	defer cancel()
+
+	model, err := store.GetModel(ctx, id)
+	if err != nil || model == nil || model.Limit.Context <= 0 {
+		return fallback
+	}
+	return int64(model.Limit.Context)
+}
+
 // LoadCaps fetches (or returns from cache) the capability record for the given
 // model ID using the provided store.
 //
 // When the store is nil or the model is not found, LoadCaps returns a
 // conservative capability set that only allows text MIME types.
-func LoadCaps(store *modelsdev.Store, id modelsdev.ID) ModelCapabilities {
+//
+// The supplied ctx is wrapped with loadCapsTimeout so the lookup is both
+// cancellable with the caller and bounded on its own.
+func LoadCaps(ctx context.Context, store *modelsdev.Store, id modelsdev.ID) ModelCapabilities {
 	if store == nil {
 		return ModelCapabilities{}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), loadCapsTimeout)
+	ctx, cancel := context.WithTimeout(ctx, loadCapsTimeout)
 	defer cancel()
 
 	model, err := store.GetModel(ctx, id)

--- a/pkg/modelinfo/modelinfo_test.go
+++ b/pkg/modelinfo/modelinfo_test.go
@@ -350,7 +350,7 @@ func TestLoadCaps_QualifiedIDRequired(t *testing.T) {
 
 	// Bare model name: must fall back to conservative text-only caps.
 	bareID := modelsdev.NewID("", "claude-sonnet-4-6")
-	mcBare := LoadCaps(store, bareID)
+	mcBare := LoadCaps(t.Context(), store, bareID)
 	assert.False(t, mcBare.Supports("image/jpeg"),
 		"bare model name %q must NOT resolve to vision caps", bareID.String())
 	assert.False(t, mcBare.Supports("application/pdf"),
@@ -358,7 +358,7 @@ func TestLoadCaps_QualifiedIDRequired(t *testing.T) {
 
 	// Fully-qualified ID: must resolve to vision+pdf caps.
 	qualifiedID := modelsdev.NewID("anthropic", "claude-sonnet-4-6")
-	mcQualified := LoadCaps(store, qualifiedID)
+	mcQualified := LoadCaps(t.Context(), store, qualifiedID)
 	assert.True(t, mcQualified.Supports("image/jpeg"),
 		"qualified ID %q must resolve to vision caps", qualifiedID.String())
 	assert.True(t, mcQualified.Supports("application/pdf"),
@@ -380,7 +380,7 @@ func TestLoadCaps_VisionModel(t *testing.T) {
 		},
 	}})
 
-	mc := LoadCaps(store, modelsdev.NewID("anthropic", "claude-3-5-sonnet"))
+	mc := LoadCaps(t.Context(), store, modelsdev.NewID("anthropic", "claude-3-5-sonnet"))
 
 	assert.True(t, mc.Supports("image/jpeg"))
 	assert.True(t, mc.Supports("image/png"))
@@ -403,7 +403,7 @@ func TestLoadCaps_TextOnlyModel(t *testing.T) {
 		},
 	}})
 
-	mc := LoadCaps(store, modelsdev.NewID("openai", "gpt-3.5-turbo"))
+	mc := LoadCaps(t.Context(), store, modelsdev.NewID("openai", "gpt-3.5-turbo"))
 
 	assert.False(t, mc.Supports("image/jpeg"))
 	assert.False(t, mc.Supports("application/pdf"))
@@ -414,7 +414,7 @@ func TestLoadCaps_TextOnlyModel(t *testing.T) {
 func TestLoadCaps_ModelNotFound(t *testing.T) {
 	store := modelsdev.NewDatabaseStore(&modelsdev.Database{Providers: map[string]modelsdev.Provider{}})
 
-	mc := LoadCaps(store, modelsdev.NewID("unknown", "nonexistent-model"))
+	mc := LoadCaps(t.Context(), store, modelsdev.NewID("unknown", "nonexistent-model"))
 
 	assert.False(t, mc.Supports("image/jpeg"))
 	assert.False(t, mc.Supports("application/pdf"))
@@ -436,7 +436,7 @@ func TestLoadCaps_OfficeDocsNotAllowed(t *testing.T) {
 		},
 	}})
 
-	mc := LoadCaps(store, modelsdev.NewID("openai", "gpt-4o"))
+	mc := LoadCaps(t.Context(), store, modelsdev.NewID("openai", "gpt-4o"))
 
 	for _, officeMIME := range []string{
 		"application/vnd.openxmlformats-officedocument.wordprocessingml.document",


### PR DESCRIPTION
Model context-window handling was scattered across providers. Each provider either hardcoded a limit (Anthropic had `anthropicContextLimit` embedded in its package) or lacked a fallback when the models.dev store was unavailable, risking silent failures or degraded behavior in production environments.

This change centralizes context-window logic into a new `ContextLimit(ctx, store, id, fallback)` helper in `pkg/modelinfo`. It first attempts to source the window from the models.dev store with a bounded timeout, then falls back to a provided default. A new `DefaultAnthropicContextLimit` constant (200000) replaces Anthropic's hardcoded function, and all five provider packages now use `modelinfo.ContextLimit` consistently.

Additionally, `LoadCaps` now accepts a `context.Context` as its first parameter so callers can implement proper timeout behavior. This is wrapped internally with `loadCapsTimeout` to bound the underlying models.dev load operation, though callers should understand that the timeout does not cover contention from the shared store lock.