### PR TITLE
fix: prevent memory explosion in search_files_content

### DIFF
--- a/pkg/tools/builtin/filesystem/filesystem.go
+++ b/pkg/tools/builtin/filesystem/filesystem.go
@@ -1126,12 +1126,18 @@ func (t *ToolSet) handleSearchFilesContent(_ context.Context, args SearchFilesCo
 		}
 	}
 
-	var results []string
+	var out strings.Builder
 	filesWithMatches := make(map[string]struct{})
+	matchCount := 0
+	truncated := false
 
 	err = filepath.WalkDir(resolvedPath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return nil
+		}
+
+		if truncated {
+			return fs.SkipAll
 		}
 
 		// Check VCS ignore rules
@@ -1159,6 +1165,13 @@ func (t *ToolSet) handleSearchFilesContent(_ context.Context, args SearchFilesCo
 
 		// Only process files, not directories
 		if d.IsDir() {
+			return nil
+		}
+
+		// Skip files too large to scan safely. Reading them whole would
+		// spike memory (content + string copy + line split) for what is
+		// almost always a binary or data dump.
+		if info, statErr := d.Info(); statErr == nil && info.Size() > maxSearchFileSize {
 			return nil
 		}
 
@@ -1208,8 +1221,19 @@ func (t *ToolSet) handleSearchFilesContent(_ context.Context, args SearchFilesCo
 					preview = preview[start:end]
 				}
 
-				result := fmt.Sprintf("%s:%d:%d: %s", path, lineNum+1, matchStart+1, preview)
-				results = append(results, result)
+				// Write matches straight into the builder rather than
+				// collecting them in a slice and joining at the end: that
+				// would hold every match twice (slice + joined copy). The
+				// builder's running length doubles as the output budget.
+				if matchCount > 0 {
+					out.WriteByte('\n')
+				}
+				fmt.Fprintf(&out, "%s:%d:%d: %s", path, lineNum+1, matchStart+1, preview)
+				matchCount++
+				if out.Len() >= maxSearchOutputBytes {
+					truncated = true
+					return fs.SkipAll
+				}
 			}
 		}
 
@@ -1220,19 +1244,24 @@ func (t *ToolSet) handleSearchFilesContent(_ context.Context, args SearchFilesCo
 	}
 
 	meta := SearchFilesContentMeta{
-		MatchCount: len(results),
+		MatchCount: matchCount,
 		FileCount:  len(filesWithMatches),
 	}
 
-	if len(results) == 0 {
+	if matchCount == 0 {
 		return &tools.ToolCallResult{
 			Output: "No results found",
 			Meta:   meta,
 		}, nil
 	}
 
+	output := out.String()
+	if truncated {
+		output += "\n\n[Output truncated: exceeded 1 MiB limit. Narrow the search with a more specific query, path, or exclude patterns.]"
+	}
+
 	return &tools.ToolCallResult{
-		Output: strings.Join(results, "\n"),
+		Output: output,
 		Meta:   meta,
 	}, nil
 }

--- a/pkg/tools/builtin/filesystem/filesystem.go
+++ b/pkg/tools/builtin/filesystem/filesystem.go
@@ -1136,10 +1136,6 @@ func (t *ToolSet) handleSearchFilesContent(_ context.Context, args SearchFilesCo
 			return nil
 		}
 
-		if truncated {
-			return fs.SkipAll
-		}
-
 		// Check VCS ignore rules
 		if t.shouldIgnorePath(path) {
 			if d.IsDir() {
@@ -1168,17 +1164,20 @@ func (t *ToolSet) handleSearchFilesContent(_ context.Context, args SearchFilesCo
 			return nil
 		}
 
-		// Skip files too large to scan safely. Reading them whole would
-		// spike memory (content + string copy + line split) for what is
-		// almost always a binary or data dump.
-		if info, statErr := d.Info(); statErr == nil && info.Size() > maxSearchFileSize {
-			return nil
-		}
-
 		// Check this file against allow/deny lists before reading.
 		// This prevents symlinks inside the allowed root from escaping the sandbox.
 		if _, checkErr := t.resolveAndCheckPath(path); checkErr != nil {
 			// Skip files outside the sandbox silently (don't fail the whole search).
+			return nil
+		}
+
+		// Only scan regular files within the size limit. We stat (following
+		// symlinks) rather than trust d.Info()'s lstat: t.readFile follows
+		// symlinks, so measuring the link itself would let a symlink to a
+		// huge file slip past the guard. Skipping non-regular files also
+		// avoids reading forever from a device or FIFO such as /dev/zero.
+		info, statErr := t.stat(path)
+		if statErr != nil || !info.Mode().IsRegular() || info.Size() > maxSearchFileSize {
 			return nil
 		}
 

--- a/pkg/tools/builtin/filesystem/filesystem_test.go
+++ b/pkg/tools/builtin/filesystem/filesystem_test.go
@@ -9,6 +9,7 @@ import (
 	"image/png"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -486,6 +487,57 @@ func TestFilesystemTool_SearchFilesContent(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Contains(t, result.Output, "Invalid regex pattern")
+}
+
+// TestFilesystemTool_SearchFilesContent_OutputCap verifies that a search
+// producing more matches than the output budget is truncated instead of
+// returning an unbounded string that would cascade into the message list,
+// the session store, and every subsequent model request.
+func TestFilesystemTool_SearchFilesContent_OutputCap(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	tool := New(tmpDir)
+
+	// One file with many matching lines, comfortably exceeding the cap.
+	var b strings.Builder
+	for range 200_000 {
+		b.WriteString("needle here\n")
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "big.txt"), []byte(b.String()), 0o644))
+
+	result, err := tool.handleSearchFilesContent(t.Context(), SearchFilesContentArgs{
+		Path:  ".",
+		Query: "needle",
+	})
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, "Output truncated")
+	assert.Less(t, len(result.Output), maxSearchOutputBytes+1024,
+		"output must stay close to the cap, not grow unbounded")
+}
+
+// TestFilesystemTool_SearchFilesContent_SkipsLargeFiles verifies that files
+// larger than maxSearchFileSize are skipped so a recursive search can't be
+// made to read a multi-gigabyte file (or a binary/log) into memory.
+func TestFilesystemTool_SearchFilesContent_SkipsLargeFiles(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	tool := New(tmpDir)
+
+	// A small file that should match.
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "small.txt"), []byte("findme\n"), 0o644))
+
+	// A file just over the size limit containing the same term: must be skipped.
+	big := make([]byte, maxSearchFileSize+1)
+	copy(big, "findme\n")
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "big.bin"), big, 0o644))
+
+	result, err := tool.handleSearchFilesContent(t.Context(), SearchFilesContentArgs{
+		Path:  ".",
+		Query: "findme",
+	})
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, "small.txt")
+	assert.NotContains(t, result.Output, "big.bin")
 }
 
 func TestFilesystemTool_PostEditCommands(t *testing.T) {

--- a/pkg/tools/builtin/filesystem/filesystem_test.go
+++ b/pkg/tools/builtin/filesystem/filesystem_test.go
@@ -540,6 +540,33 @@ func TestFilesystemTool_SearchFilesContent_SkipsLargeFiles(t *testing.T) {
 	assert.NotContains(t, result.Output, "big.bin")
 }
 
+// TestFilesystemTool_SearchFilesContent_SkipsSymlinkToLargeFile is a
+// regression test for the size guard: a symlink reports its own tiny size
+// via lstat, but readFile follows it. The guard must stat the target so a
+// symlink pointing at an over-limit file is skipped rather than read whole.
+func TestFilesystemTool_SearchFilesContent_SkipsSymlinkToLargeFile(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	tool := New(tmpDir)
+
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "small.txt"), []byte("findme\n"), 0o644))
+
+	bigTarget := filepath.Join(tmpDir, "target.bin")
+	big := make([]byte, maxSearchFileSize+1)
+	copy(big, "findme\n")
+	require.NoError(t, os.WriteFile(bigTarget, big, 0o644))
+	require.NoError(t, os.Symlink(bigTarget, filepath.Join(tmpDir, "link.txt")))
+
+	result, err := tool.handleSearchFilesContent(t.Context(), SearchFilesContentArgs{
+		Path:  ".",
+		Query: "findme",
+	})
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, "small.txt")
+	assert.NotContains(t, result.Output, "link.txt")
+	assert.NotContains(t, result.Output, "target.bin")
+}
+
 func TestFilesystemTool_PostEditCommands(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()

--- a/pkg/tools/builtin/filesystem/limit.go
+++ b/pkg/tools/builtin/filesystem/limit.go
@@ -1,3 +1,17 @@
 package filesystem
 
 const maxFiles = 100
+
+// maxSearchFileSize bounds how large a single file may be before
+// search_files_content skips it. Files above this size are almost always
+// binaries, logs or data dumps that blow up memory when read whole
+// (os.ReadFile + string(...) + strings.Split triples the footprint).
+// Skipping them keeps a recursive search over a large tree bounded.
+const maxSearchFileSize = 10 << 20 // 10 MiB
+
+// maxSearchOutputBytes caps the total size of the joined match output.
+// Without it a broad search (e.g. across the home directory) produces a
+// multi-megabyte result that is then copied into the in-memory message
+// list, written to the session store, and re-serialised into every
+// subsequent model request for the rest of the session.
+const maxSearchOutputBytes = 1 << 20 // 1 MiB


### PR DESCRIPTION
The `search_files_content` filesystem tool can produce massive results when searching across large directory trees, causing unbounded memory growth as the output cascades through multiple layers: tool output buffer → in-memory message list → session store/WAL → re-serialization into every subsequent model request for the rest of the session.

This change caps the total output at 1 MiB with a truncation notice and skips files larger than 10 MiB. Output is now built incrementally with `strings.Builder` instead of accumulating a slice and joining at the end. The file-size check now stats the target (following symlinks, not the symlink itself) and only scans regular files, which also prevents reading forever from device files or FIFOs like `/dev/zero`.

Tests cover output-cap truncation, large-file skipping, and the symlink-to-large-file case.