### PR TITLE
refactor: remove empty query truncation from MCP server search

### DIFF
--- a/pkg/tools/builtin/mcpcatalog/mcpcatalog.go
+++ b/pkg/tools/builtin/mcpcatalog/mcpcatalog.go
@@ -626,12 +626,6 @@ type SearchResult struct {
 	Enabled     bool     `json:"enabled"`
 }
 
-// emptyQuerySearchLimit caps the result set for an empty query so the
-// catalog (currently 45+ servers) doesn't bloat the LLM's context window.
-// A model exploring "is there anything here?" gets a representative
-// sample with a hint to refine; concrete keywords still return every match.
-const emptyQuerySearchLimit = 25
-
 func (t *Toolset) handleSearch(_ context.Context, args SearchArgs) (*tools.ToolCallResult, error) {
 	q := strings.ToLower(strings.TrimSpace(args.Query))
 
@@ -662,21 +656,11 @@ func (t *Toolset) handleSearch(_ context.Context, args SearchArgs) (*tools.ToolC
 
 	sort.Slice(matches, func(i, j int) bool { return matches[i].ID < matches[j].ID })
 
-	total := len(matches)
-	truncated := q == "" && total > emptyQuerySearchLimit
-	if truncated {
-		matches = matches[:emptyQuerySearchLimit]
-	}
-
 	out, err := json.Marshal(matches)
 	if err != nil {
 		return nil, err
 	}
-	if truncated {
-		return tools.ResultSuccess(fmt.Sprintf("showing %d of %d server(s) (catalog truncated for empty query — refine with a keyword to see more):\n%s",
-			len(matches), total, string(out))), nil
-	}
-	return tools.ResultSuccess(fmt.Sprintf("found %d server(s):\n%s", total, string(out))), nil
+	return tools.ResultSuccess(fmt.Sprintf("found %d server(s):\n%s", len(matches), string(out))), nil
 }
 
 // matchesQuery returns true if any of the searchable string fields contains q.

--- a/pkg/tools/builtin/mcpcatalog/mcpcatalog_test.go
+++ b/pkg/tools/builtin/mcpcatalog/mcpcatalog_test.go
@@ -79,20 +79,18 @@ func TestSearchTool(t *testing.T) {
 	require.False(t, res.IsError)
 	assert.Contains(t, strings.ToLower(res.Output), "stripe")
 
-	// Empty query returns the catalog truncated to emptyQuerySearchLimit
-	// so we don't dump the full catalog into the LLM context window.
+	// Empty query returns the full catalog so the model can list every
+	// matching server.
 	res, err = ts.handleSearch(ctx, SearchArgs{Query: ""})
 	require.NoError(t, err)
 	require.False(t, res.IsError)
 	first := strings.SplitN(res.Output, "\n", 2)[0]
-	assert.Contains(t, first, "showing ")
-	assert.Contains(t, first, "refine with a keyword")
+	assert.Contains(t, first, "found ")
 	body := strings.SplitN(res.Output, "\n", 2)[1]
 	var parsed []SearchResult
 	require.NoError(t, json.Unmarshal([]byte(body), &parsed))
-	assert.Len(t, parsed, emptyQuerySearchLimit)
-	require.Greater(t, ts.catalog.Count, emptyQuerySearchLimit,
-		"test fixture: catalog should be larger than the empty-query cap")
+	assert.Len(t, parsed, ts.catalog.Count,
+		"empty query must return every catalog server")
 
 	// Unknown query returns an error result (not a Go error).
 	res, err = ts.handleSearch(ctx, SearchArgs{Query: "xxxxxx_no_such_server_xxxxxx"})


### PR DESCRIPTION
The `search_remote_mcp_servers` tool truncated results for empty queries to 25 servers, ostensibly to avoid bloating the LLM's context window. In practice, this hides relevant servers and requires users to already know keywords to discover them.

This change removes the truncation logic entirely. An empty query now returns all matching servers from the catalog. Models can still make intelligent choices about how many results to present to a user, and they're not artificially blinded by the tool's limits.

The test expectations were updated accordingly.