### PR TITLE
fix(providers): route Responses-only models on custom OpenAI providers

### DIFF
--- a/pkg/model/provider/custom_provider_test.go
+++ b/pkg/model/provider/custom_provider_test.go
@@ -428,6 +428,62 @@ func TestApplyProviderDefaults_DefaultsAPIType(t *testing.T) {
 	assert.Equal(t, "openai_chatcompletions", result.ProviderOpts["api_type"])
 }
 
+// TestApplyProviderDefaults_DefaultsResponsesAPIForNewerModels verifies that a
+// custom OpenAI-compatible provider with no explicit api_type defaults to the
+// Responses API for models that require it (gpt-5, Codex, o-series), while
+// older chat models stay on Chat Completions. Without this, a provider pointed
+// at the OpenAI/GitHub Copilot API rejects newer models on /chat/completions
+// with a 400. See https://github.com/docker/docker-agent/issues/2303.
+func TestApplyProviderDefaults_DefaultsResponsesAPIForNewerModels(t *testing.T) {
+	t.Parallel()
+
+	customProviders := map[string]latest.ProviderConfig{
+		// OpenAI-compatible provider (e.g. a github-copilot endpoint defined in
+		// the providers: section) without an explicit api_type.
+		"copilot": {
+			BaseURL:  "https://api.githubcopilot.com",
+			TokenKey: "GITHUB_TOKEN",
+		},
+	}
+
+	tests := []struct {
+		name            string
+		model           string
+		expectedAPIType string
+	}{
+		{name: "codex routes to responses", model: "gpt-5.3-codex", expectedAPIType: "openai_responses"},
+		{name: "gpt-5 routes to responses", model: "gpt-5", expectedAPIType: "openai_responses"},
+		{name: "o-series routes to responses", model: "o3-mini", expectedAPIType: "openai_responses"},
+		{name: "gpt-4o stays on chat completions", model: "gpt-4o", expectedAPIType: "openai_chatcompletions"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := applyProviderDefaults(&latest.ModelConfig{Provider: "copilot", Model: tt.model}, customProviders)
+			assert.Equal(t, tt.expectedAPIType, result.ProviderOpts["api_type"])
+		})
+	}
+}
+
+// TestApplyProviderDefaults_ExplicitAPITypeWinsOverModel verifies that an
+// explicit provider-level api_type is honored even for a model that would
+// otherwise default to the Responses API.
+func TestApplyProviderDefaults_ExplicitAPITypeWinsOverModel(t *testing.T) {
+	t.Parallel()
+
+	customProviders := map[string]latest.ProviderConfig{
+		"pinned": {
+			APIType:  "openai_chatcompletions",
+			BaseURL:  "https://api.example.com/v1",
+			TokenKey: "KEY",
+		},
+	}
+
+	result := applyProviderDefaults(&latest.ModelConfig{Provider: "pinned", Model: "gpt-5.3-codex"}, customProviders)
+	assert.Equal(t, "openai_chatcompletions", result.ProviderOpts["api_type"])
+}
+
 // TestResolveProviderTypeFromConfig tests the provider type resolution logic
 func TestResolveProviderTypeFromConfig(t *testing.T) {
 	t.Parallel()

--- a/pkg/model/provider/defaults.go
+++ b/pkg/model/provider/defaults.go
@@ -32,6 +32,25 @@ func resolveEffectiveProvider(cfg latest.ProviderConfig) string {
 	return cmp.Or(cfg.Provider, "openai")
 }
 
+// defaultOpenAIAPIType returns the api_type to default to for an
+// OpenAI-compatible provider that did not specify one explicitly.
+//
+// Newer OpenAI models (gpt-4.1, the o-series, gpt-5 and Codex) are only
+// served via the Responses API; the legacy Chat Completions endpoint rejects
+// them with a 400 ("unsupported_api_for_model"). Built-in providers (openai,
+// github-copilot) get this routing for free via the client's per-request
+// auto-detection, but custom providers in the providers: section bypass that
+// path because an explicit api_type pins the endpoint. Defaulting on the same
+// modelinfo.SupportsResponsesAPI predicate keeps both paths consistent so a
+// provider pointed at the OpenAI/Copilot API works without a manual
+// api_type override. See https://github.com/docker/docker-agent/issues/2303.
+func defaultOpenAIAPIType(model string) string {
+	if modelinfo.SupportsResponsesAPI(model) {
+		return "openai_responses"
+	}
+	return "openai_chatcompletions"
+}
+
 // isOpenAICompatibleProvider returns true if the provider type uses the OpenAI API protocol.
 func isOpenAICompatibleProvider(providerType string) bool {
 	switch providerType {
@@ -123,13 +142,13 @@ func mergeFromProviderConfig(dst *latest.ModelConfig, src latest.ProviderConfig)
 	}
 
 	// Set api_type in ProviderOpts if not already set.
-	// Prefer the explicit APIType from the provider config; otherwise default to
-	// openai_chatcompletions for OpenAI-compatible providers.
+	// Prefer the explicit APIType from the provider config; otherwise pick a
+	// default for OpenAI-compatible providers based on the model.
 	switch {
 	case src.APIType != "":
 		setProviderOptIfAbsent(dst, "api_type", src.APIType)
 	case isOpenAICompatibleProvider(resolveEffectiveProvider(src)):
-		setProviderOptIfAbsent(dst, "api_type", "openai_chatcompletions")
+		setProviderOptIfAbsent(dst, "api_type", defaultOpenAIAPIType(dst.Model))
 	}
 }
 


### PR DESCRIPTION
## Problem

Custom OpenAI-compatible providers declared in the `providers:` section without
an explicit `api_type` were hard-defaulted to `openai_chatcompletions`. Models
that are only served via the Responses API (gpt-4.1, the o-series, gpt-5, Codex)
were therefore sent to `/chat/completions` and rejected with
`400 unsupported_api_for_model` — e.g. a github-copilot endpoint declared as a
custom provider running `gpt-5.3-codex`.

Fixes #2303

## Fix

`pkg/model/provider/defaults.go`

- Added `defaultOpenAIAPIType(model)`: returns `openai_responses` when
  `modelinfo.SupportsResponsesAPI(model)` is true, otherwise
  `openai_chatcompletions`.
- `mergeFromProviderConfig` now uses `defaultOpenAIAPIType(dst.Model)` for the
  OpenAI-compatible fallback instead of always setting `openai_chatcompletions`,
  reusing the same predicate as the built-in routing.

## Tests

`pkg/model/provider/custom_provider_test.go`

- `TestApplyProviderDefaults_DefaultsResponsesAPIForNewerModels`: a custom
  provider with no `api_type` routes `gpt-5.3-codex`, `gpt-5`, `o3-mini` to
  `openai_responses`, while `gpt-4o` stays on `openai_chatcompletions`.
- `TestApplyProviderDefaults_ExplicitAPITypeWinsOverModel`: an explicit
  provider-level `api_type` is honored even for a Responses-default model.