### PR TITLE
refactor: use strings.Builder for message merging in oaistream

### DIFF
--- a/pkg/model/provider/oaistream/messages.go
+++ b/pkg/model/provider/oaistream/messages.go
@@ -270,7 +270,7 @@ func MergeConsecutiveMessages(openaiMessages []openai.ChatCompletionMessageParam
 
 		// Only merge system or user messages
 		if currentRole == "system" || currentRole == "user" {
-			var mergedContent string
+			var mergedContent strings.Builder
 			var mergedMultiContent []openai.ChatCompletionContentPartUnionParam
 			j := i
 
@@ -284,10 +284,10 @@ func MergeConsecutiveMessages(openaiMessages []openai.ChatCompletionMessageParam
 
 				// Extract content
 				if str, ok := getStringContent(msgToMerge); ok {
-					if mergedContent != "" {
-						mergedContent += "\n"
+					if mergedContent.Len() > 0 {
+						mergedContent.WriteString("\n")
 					}
-					mergedContent += str
+					mergedContent.WriteString(str)
 				} else if parts := getMultiContent(msgToMerge); parts != nil {
 					mergedMultiContent = append(mergedMultiContent, parts...)
 				} else if textParts := getSystemTextParts(msgToMerge); textParts != nil {
@@ -307,7 +307,7 @@ func MergeConsecutiveMessages(openaiMessages []openai.ChatCompletionMessageParam
 			var mergedMessage openai.ChatCompletionMessageParamUnion
 			if currentRole == "system" {
 				if len(mergedMultiContent) == 0 {
-					mergedMessage = openai.SystemMessage(mergedContent)
+					mergedMessage = openai.SystemMessage(mergedContent.String())
 				} else {
 					textParts := make([]openai.ChatCompletionContentPartTextParam, 0)
 					for _, part := range mergedMultiContent {
@@ -319,7 +319,7 @@ func MergeConsecutiveMessages(openaiMessages []openai.ChatCompletionMessageParam
 				}
 			} else {
 				if len(mergedMultiContent) == 0 {
-					mergedMessage = openai.UserMessage(mergedContent)
+					mergedMessage = openai.UserMessage(mergedContent.String())
 				} else {
 					mergedMessage = openai.UserMessage(mergedMultiContent)
 				}


### PR DESCRIPTION
Consecutive same-role messages in the OpenAI stream handler were being merged by concatenating strings with `+=` in a loop. This causes repeated allocations and copying as the accumulated content grows.

The `MergeConsecutiveMessages` function now uses `strings.Builder` instead, which buffers the concatenation and reduces allocations to a single final operation. The change is strictly behavior-preserving: the condition `mergedContent.Len() > 0` replaces `mergedContent != ""`, and `mergedContent.String()` yields the same accumulated value.

Testing confirmed the change passes `go build ./...`, unit tests in `pkg/model/provider/oaistream/`, and golangci-lint with zero issues.