### PR TITLE
fix(mcp): harden managed OAuth flow (decline sentinel + bounded wait)

### DIFF
--- a/pkg/tools/mcp/oauth.go
+++ b/pkg/tools/mcp/oauth.go
@@ -849,7 +849,12 @@ func (t *oauthTransport) handleManagedOAuthFlow(ctx context.Context, authServer,
 	slog.DebugContext(ctx, "Elicitation response received", "result", result)
 
 	if result.Action != tools.ElicitationActionAccept {
-		return errors.New("user declined OAuth authorization")
+		// Surface the recognisable sentinel (mirroring the unmanaged
+		// path) so authorizeOnce can latch the decline and queued
+		// initialize-stage goroutines don't re-pop the dialog the user
+		// just dismissed, and so enrichConnectError / mcpcatalog's
+		// IsOAuthDeclined short-circuit can break the retry loop.
+		return &OAuthDeclinedError{URL: t.baseURL}
 	}
 
 	slog.DebugContext(ctx, "Requesting authorization code", "url", authURL)

--- a/pkg/tools/mcp/oauth.go
+++ b/pkg/tools/mcp/oauth.go
@@ -27,13 +27,13 @@ import (
 // resourceMetadataFromWWWAuth extracts resource metadata URL from WWW-Authenticate header
 var re = regexp.MustCompile(`resource="([^"]+)"`)
 
-// unmanagedOAuthWaitTimeout is the upper bound on how long the unmanaged
-// OAuth flow blocks waiting for a reply (elicitation result or
-// out-of-band callback). Generous enough to accommodate a user clicking
-// through an IdP consent screen and any IdP-side prompts; small enough
-// that a silently-disconnected MCP client can't hold the per-session
-// streaming lock indefinitely.
-var unmanagedOAuthWaitTimeout = 10 * time.Minute
+// oauthInteractiveWaitTimeout is the upper bound on how long an interactive
+// OAuth flow (managed or unmanaged) blocks waiting for a reply (elicitation
+// result, browser callback, or out-of-band callback). Generous enough to
+// accommodate a user clicking through an IdP consent screen and any IdP-side
+// prompts; small enough that a silently-disconnected MCP client can't hold
+// the per-session streaming lock indefinitely.
+var oauthInteractiveWaitTimeout = 10 * time.Minute
 
 // oauth is a simple struct for compatibility with existing code
 type oauth struct {
@@ -843,7 +843,7 @@ func (t *oauthTransport) handleManagedOAuthFlow(ctx context.Context, authServer,
 	// ErrSessionBusy. We also wire up user-initiated cancellation, which
 	// arrives via the original caller's ctx stashed at the Connect
 	// boundary (see cancellable_parent.go). Mirrors handleUnmanagedOAuthFlow.
-	waitCtx, cancelWait := context.WithTimeout(ctx, unmanagedOAuthWaitTimeout)
+	waitCtx, cancelWait := context.WithTimeout(ctx, oauthInteractiveWaitTimeout)
 	defer cancelWait()
 	if parentCtx := cancellableParentFromContext(ctx); parentCtx != nil {
 		defer context.AfterFunc(parentCtx, cancelWait)()
@@ -1105,14 +1105,14 @@ func (t *oauthTransport) handleUnmanagedOAuthFlow(ctx context.Context, authServe
 	// `requestElicitation` blocked forever, holding the per-session
 	// streaming lock at the SessionManager level. Subsequent user
 	// messages would then all return 409 / ErrSessionBusy until a
-	// process restart. unmanagedOAuthWaitTimeout caps that window;
+	// process restart. oauthInteractiveWaitTimeout caps that window;
 	// user-initiated cancellation still wins instantly via userCancelCh.
 	type elicResult struct {
 		result tools.ElicitationResult
 		err    error
 	}
 	elicCh := make(chan elicResult, 1)
-	elicCtx, elicCancel := context.WithTimeout(ctx, unmanagedOAuthWaitTimeout)
+	elicCtx, elicCancel := context.WithTimeout(ctx, oauthInteractiveWaitTimeout)
 	defer elicCancel()
 	go func() {
 		r, e := t.client.requestElicitation(elicCtx, &mcpsdk.ElicitParams{
@@ -1170,7 +1170,7 @@ func (t *oauthTransport) handleUnmanagedOAuthFlow(ctx context.Context, authServe
 		// lock from being held indefinitely. In practice the elicCh
 		// case below usually fires first with a deadline-exceeded
 		// error wrapped from requestElicitation.
-		return fmt.Errorf("OAuth flow timed out waiting for a reply after %s", unmanagedOAuthWaitTimeout)
+		return fmt.Errorf("OAuth flow timed out waiting for a reply after %s", oauthInteractiveWaitTimeout)
 	case cb := <-callbackCh:
 		// Direct deeplink callback won. Release the in-flight
 		// elicitation goroutine; any UI the embedder showed for this

--- a/pkg/tools/mcp/oauth.go
+++ b/pkg/tools/mcp/oauth.go
@@ -834,7 +834,22 @@ func (t *oauthTransport) handleManagedOAuthFlow(ctx context.Context, authServer,
 		scopes,
 	)
 
-	result, err := t.client.requestElicitation(ctx, &mcpsdk.ElicitParams{
+	// Bound the interactive wait. `ctx` here is the detached ctx from
+	// clientConnector.Connect (context.WithoutCancel), whose Done channel
+	// never fires on its own. Without this, an abandoned browser tab or a
+	// silent MCP-client disconnect would leave the elicitation and the
+	// callback wait blocked forever, holding the per-session streaming
+	// lock and turning every subsequent user message into a 409 /
+	// ErrSessionBusy. We also wire up user-initiated cancellation, which
+	// arrives via the original caller's ctx stashed at the Connect
+	// boundary (see cancellable_parent.go). Mirrors handleUnmanagedOAuthFlow.
+	waitCtx, cancelWait := context.WithTimeout(ctx, unmanagedOAuthWaitTimeout)
+	defer cancelWait()
+	if parentCtx := cancellableParentFromContext(ctx); parentCtx != nil {
+		defer context.AfterFunc(parentCtx, cancelWait)()
+	}
+
+	result, err := t.client.requestElicitation(waitCtx, &mcpsdk.ElicitParams{
 		Message:         fmt.Sprintf("The MCP server at %s requires OAuth authorization. Do you want to proceed?", t.baseURL),
 		RequestedSchema: nil,
 		Meta: map[string]any{
@@ -859,7 +874,7 @@ func (t *oauthTransport) handleManagedOAuthFlow(ctx context.Context, authServer,
 
 	slog.DebugContext(ctx, "Requesting authorization code", "url", authURL)
 
-	code, receivedState, err := RequestAuthorizationCode(ctx, authURL, callbackServer, state)
+	code, receivedState, err := RequestAuthorizationCode(waitCtx, authURL, callbackServer, state)
 	if err != nil {
 		return fmt.Errorf("failed to get authorization code: %w", err)
 	}

--- a/pkg/tools/mcp/oauth_test.go
+++ b/pkg/tools/mcp/oauth_test.go
@@ -1873,14 +1873,14 @@ func TestUnmanagedOAuthFlow_DriveFlow_AbortsOnParentCtxCancellation(t *testing.T
 // per-flow deadline releases the streaming lock even when the MCP client
 // disconnects silently and never produces an elicitation reply.
 //
-// Without unmanagedOAuthWaitTimeout, requestElicitation would block on a
+// Without oauthInteractiveWaitTimeout, requestElicitation would block on a
 // dead session indefinitely, the per-session lock at the SessionManager
 // level would stay held, and every subsequent message from that session
 // would return 409 / ErrSessionBusy until a process restart.
 func TestUnmanagedOAuthFlow_DriveFlow_TimesOutWhenNoReplyArrives(t *testing.T) {
-	original := unmanagedOAuthWaitTimeout
-	unmanagedOAuthWaitTimeout = 200 * time.Millisecond
-	t.Cleanup(func() { unmanagedOAuthWaitTimeout = original })
+	original := oauthInteractiveWaitTimeout
+	oauthInteractiveWaitTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { oauthInteractiveWaitTimeout = original })
 
 	srv := newUnmanagedOAuthTestServer(t)
 	defer srv.Close()
@@ -1912,6 +1912,101 @@ func TestUnmanagedOAuthFlow_DriveFlow_TimesOutWhenNoReplyArrives(t *testing.T) {
 			strings.Contains(rtErr.Error(), "context deadline exceeded"),
 		"expected timeout error, got: %v", rtErr,
 	)
+	assert.Equal(t, int32(0), srv.tokenCalls.Load(),
+		"token endpoint must NOT be hit on timeout")
+}
+
+// newManagedTestTransport builds an oauthTransport configured for the
+// managed flow (docker-agent opens the browser itself) and wires the
+// supplied elicitation handler. It reuses newUnmanagedOAuthTestServer's
+// endpoints, which are identical for both flows.
+func newManagedTestTransport(t *testing.T, baseURL string, capture *elicitCaptured) (*oauthTransport, *remoteMCPClient) {
+	t.Helper()
+	client := newRemoteClient(baseURL, "streamable", nil, NewInMemoryTokenStore(), nil, false)
+	client.SetElicitationHandler(capture.handler)
+	client.allowPrivateIPs = true
+	transport := &oauthTransport{
+		base:            http.DefaultTransport,
+		client:          client,
+		tokenStore:      client.tokenStore,
+		baseURL:         baseURL,
+		managed:         true,
+		oauthHTTPClient: oauthHTTPClientForAllowPrivateIPs(true),
+	}
+	return transport, client
+}
+
+// TestManagedOAuthFlow_ElicitationDeclineReturnsSentinel verifies that a
+// declined approval prompt in the managed flow surfaces a recognisable
+// *OAuthDeclinedError, mirroring the unmanaged path. A generic error here
+// would defeat the catalog's IsOAuthDeclined short-circuit and re-pop the
+// dialog the user just dismissed.
+func TestManagedOAuthFlow_ElicitationDeclineReturnsSentinel(t *testing.T) {
+	srv := newUnmanagedOAuthTestServer(t)
+	defer srv.Close()
+
+	capture := &elicitCaptured{}
+	capture.replyFn = func(_ *gomcp.ElicitParams) tools.ElicitationResult {
+		return tools.ElicitationResult{Action: tools.ElicitationActionDecline}
+	}
+	transport, _ := newManagedTestTransport(t, srv.URL, capture)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL, strings.NewReader("{}"))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, rtErr := transport.RoundTrip(req)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	require.Error(t, rtErr)
+	assert.True(t, IsOAuthDeclined(rtErr),
+		"declined managed approval must surface as IsOAuthDeclined; got: %v", rtErr)
+
+	var declined *OAuthDeclinedError
+	require.ErrorAs(t, rtErr, &declined)
+	assert.Equal(t, srv.URL, declined.URL)
+
+	assert.Equal(t, int32(0), srv.tokenCalls.Load(),
+		"token endpoint must NOT be hit when the user declined")
+}
+
+// TestManagedOAuthFlow_TimesOutWhenNoReplyArrives ensures the managed flow
+// is bounded by oauthInteractiveWaitTimeout when the elicitation never
+// returns. The flow runs on the detached Connect ctx (WithoutCancel), so
+// without the deadline the per-session streaming lock would be held
+// forever, turning every subsequent message into 409 / ErrSessionBusy.
+func TestManagedOAuthFlow_TimesOutWhenNoReplyArrives(t *testing.T) {
+	original := oauthInteractiveWaitTimeout
+	oauthInteractiveWaitTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { oauthInteractiveWaitTimeout = original })
+
+	srv := newUnmanagedOAuthTestServer(t)
+	defer srv.Close()
+
+	capture := &elicitCaptured{}
+	transport, client := newManagedTestTransport(t, srv.URL, capture)
+	// Replace the handler with one that blocks until its context is
+	// cancelled, mirroring LocalRuntime.elicitationHandler waiting on a
+	// reply that never arrives (silent client disconnect). The managed
+	// flow calls requestElicitation synchronously, so the only thing that
+	// can unblock it is oauthInteractiveWaitTimeout cancelling waitCtx.
+	client.SetElicitationHandler(func(ctx context.Context, _ *gomcp.ElicitParams) (tools.ElicitationResult, error) {
+		<-ctx.Done()
+		return tools.ElicitationResult{}, ctx.Err()
+	})
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL, strings.NewReader("{}"))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, rtErr := transport.RoundTrip(req)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	require.Error(t, rtErr)
+	assert.Contains(t, rtErr.Error(), "context deadline exceeded",
+		"managed flow must abort on oauthInteractiveWaitTimeout; got: %v", rtErr)
 	assert.Equal(t, int32(0), srv.tokenCalls.Load(),
 		"token endpoint must NOT be hit on timeout")
 }


### PR DESCRIPTION
## What

Fixes two correctness bugs in the **managed** MCP OAuth flow (`pkg/tools/mcp/oauth.go`), which had not received the hardening the unmanaged path already has.

## Why

While scanning the MCP code for bugs, leaks, and context-handling issues, the managed OAuth path stood out as missing two protections the unmanaged path implements:

1. **Unbounded interactive wait → pinned session lock.** `handleManagedOAuthFlow` waited on the detached `clientConnector.Connect` context (`context.WithoutCancel`), whose `Done()` never fires. An abandoned browser tab or a silent MCP-client disconnect would block the elicitation/callback wait forever, holding the per-session streaming lock and turning every subsequent user message into a `409 / ErrSessionBusy` until a process restart.

2. **Decline returned a generic error.** On user decline the flow returned `errors.New("user declined OAuth authorization")`, so the sticky-decline latch (`authorizeOnce`), `enrichConnectError`, and mcpcatalog's `IsOAuthDeclined` short-circuit could not recognise it — re-popping the dialog the user just dismissed and re-entering the `Tools() → Start() → elicitation` retry loop the sentinel exists to prevent.

## What changed

- **`fix(mcp): return OAuthDeclinedError when managed OAuth is declined`** — return the recognisable `*OAuthDeclinedError{URL: ...}` sentinel on decline, matching the unmanaged path.
- **`fix(mcp): bound managed OAuth interactive wait and observe cancellation`** — derive a `waitCtx` with `oauthInteractiveWaitTimeout` and tie it to the caller's original ctx via `context.AfterFunc`, so the timeout and user-initiated "Stop" both unblock the flow. Mirrors `handleUnmanagedOAuthFlow`.
- **`test(mcp): cover managed OAuth decline/timeout; rename shared wait timeout`** — renamed `unmanagedOAuthWaitTimeout` → `oauthInteractiveWaitTimeout` (it is now shared by both flows) and added `TestManagedOAuthFlow_ElicitationDeclineReturnsSentinel` and `TestManagedOAuthFlow_TimesOutWhenNoReplyArrives` (the managed flow previously had no test coverage).

## Testing

- `task test` — all packages pass.
- `task lint` — 0 issues (golangci-lint + custom cops + `go mod tidy`).
