### PR TITLE
refactor: restrict mcp_catalog to oauth and none auth only

### DIFF
--- a/docs/tools/mcp-catalog/index.md
+++ b/docs/tools/mcp-catalog/index.md
@@ -55,30 +55,29 @@ Up to five tools are exposed to the model. The disable / reset-auth pair only ap
 
 | Tool                            | When visible            | Description                                                                                                                                          |
 | ------------------------------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `search_remote_mcp_servers`     | Always                  | Case-insensitive fuzzy search over id, title, description, category and tags. Returns id, auth requirements (`oauth` / `api_key` / `none`) and URL. |
+| `search_remote_mcp_servers`     | Always                  | Case-insensitive fuzzy search over id, title, description, category and tags. Returns id, auth requirements (`oauth` / `none`) and URL. |
 | `enable_remote_mcp_server`      | Always                  | Activate a server by id. **Blocks** until the connection (and any required OAuth handshake) completes; on success the server's tools are immediately live and the model continues with the user's original request in the same turn. |
 | `list_remote_mcp_servers`       | Always                  | Show currently enabled servers and their connection state.                                                                                           |
 | `disable_remote_mcp_server`     | After first enable      | Stop a server and remove its tools from the active set.                                                                                              |
-| `reset_remote_mcp_server_auth`  | After first enable      | Drop persisted OAuth credentials so the next enable triggers a fresh authorization flow. No-op for `api_key` / `none` servers.                       |
+| `reset_remote_mcp_server_auth`  | After first enable      | Drop persisted OAuth credentials so the next enable triggers a fresh authorization flow. No-op for `none` servers.                       |
 
 ### Workflow
 
 1. The agent calls `search_remote_mcp_servers` with a keyword matching the user's intent (`"notion"`, `"stripe"`, `"docs"`, `"browser"`, …).
 2. It picks a matching server id and calls `enable_remote_mcp_server`. **`enable` blocks** until the MCP handshake (and any required OAuth flow) completes:
    - on success the server's tools are available **in the same turn** — the agent goes straight to the user's original request, no re-ask required;
-   - on failure (user dismissed the authorization dialog, missing env var, server refused) the tool returns an error result naming the specific reason so the agent can recover instead of pretending the server is connected.
+   - on failure (user dismissed the authorization dialog, server refused) the tool returns an error result naming the specific reason so the agent can recover instead of pretending the server is connected.
 3. It uses the newly activated tools as it would any other.
 4. When done, it calls `disable_remote_mcp_server` to remove the server from the active set.
 
 ## Authentication
 
-The catalog distinguishes three auth flavours:
+The catalog only includes servers docker-agent can authenticate itself, so there are two auth flavours:
 
 - **`oauth`** — `enable_remote_mcp_server` surfaces an authorization URL through the elicitation pipeline (the same one used by YAML-declared remote MCP toolsets) and blocks until the user either authorizes or cancels. Once the user authorizes, tokens are persisted in the OS keyring and re-used on subsequent runs. Use `reset_remote_mcp_server_auth` to wipe them. If the user dismisses the dialog, `enable` returns an error result naming the decline so the agent can ask whether to retry.
-- **`api_key`** — The server expects one or more env vars to be set in the agent's environment (e.g. `APIFY_API_KEY`, `BRAVE_API_KEY`). `enable_remote_mcp_server` returns an error result if any required variable is missing — set it, then call `enable` again.
 - **`none`** — No authentication. The server is reachable as soon as it is enabled.
 
-Search results only carry the auth flavour (`oauth` / `api_key` / `none`); the specific env-var names are surfaced by `enable_remote_mcp_server` when it detects an unset variable, so you may need to enable an `api_key` server once just to learn which variable to set.
+Servers that require a caller-provided API key are intentionally excluded from the catalog. To use one, declare it explicitly with [`type: mcp`]({{ '/configuration/tools/#mcp-tools' | relative_url }}) and supply the key via an environment variable.
 
 ## Example
 

--- a/examples/mcp_catalog.yaml
+++ b/examples/mcp_catalog.yaml
@@ -4,22 +4,26 @@
 # How it works:
 #   - The mcp_catalog toolset adds up to 5 meta-tools:
 #       * search_remote_mcp_servers   — find servers by keyword
-#       * enable_remote_mcp_server    — activate one (no network yet)
+#       * enable_remote_mcp_server    — activate one (connects now,
+#         blocking on any required OAuth handshake)
 #       * list_remote_mcp_servers     — show what's currently active
 #       * disable_remote_mcp_server   — turn one off again
 #       * reset_remote_mcp_server_auth — wipe persisted OAuth credentials
 #         for a server so the next enable triggers a fresh authorization
 #         flow. Useful when a token was revoked, scopes changed, or you
 #         signed in to the wrong account. Only exposed once at least one
-#         server is enabled; no-op for api_key/none servers.
+#         server is enabled; no-op for servers with no persisted
+#         credentials.
 #   - Tools from servers that have not been enabled stay hidden, so the
 #     prompt is not flooded with hundreds of tool definitions.
-#   - When the model first calls a tool from an enabled server, the
-#     underlying connection is established and any required OAuth
-#     authorization URL is surfaced via the elicitation pipeline.
-#   - For api_key servers (e.g. Apify, Brave Search, Tavily, …), make
-#     sure the documented env var is exported before enabling the
-#     server. The catalog tells you exactly which one to set.
+#   - When the model enables a server, the underlying connection is
+#     established synchronously and any required OAuth authorization URL
+#     is surfaced via the elicitation pipeline, blocking until the user
+#     authorizes or cancels.
+#   - The catalog only includes servers docker-agent can authenticate
+#     itself: those needing no credentials ("none") or an OAuth flow
+#     ("oauth"). Servers requiring a caller-provided API key are
+#     intentionally excluded — declare those explicitly with `type: mcp`.
 
 agents:
   root:

--- a/pkg/teamloader/registry.go
+++ b/pkg/teamloader/registry.go
@@ -74,7 +74,7 @@ func NewDefaultToolsetRegistry() ToolsetRegistry {
 				if len(toolset.BlockedServers) > 0 {
 					opts = append(opts, mcpcatalog.WithBlockedServers(toolset.BlockedServers))
 				}
-				return mcpcatalog.New(runConfig.EnvProvider(), opts...), nil
+				return mcpcatalog.New(opts...), nil
 			},
 			"api": func(_ context.Context, toolset latest.Toolset, _ string, runConfig *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
 				return api.CreateToolSet(toolset, runConfig)

--- a/pkg/tools/builtin/mcpcatalog/mcpcatalog.go
+++ b/pkg/tools/builtin/mcpcatalog/mcpcatalog.go
@@ -49,13 +49,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"regexp"
-	"slices"
 	"sort"
 	"strings"
 	"sync"
 
-	"github.com/docker/docker-agent/pkg/environment"
 	"github.com/docker/docker-agent/pkg/tools"
 	"github.com/docker/docker-agent/pkg/tools/mcp"
 )
@@ -73,7 +70,6 @@ const (
 type Toolset struct {
 	catalog *Catalog
 	byID    map[string]Server
-	env     environment.Provider
 
 	mu sync.RWMutex
 	// enabled holds the per-server StartableToolSet wrapper. Wrapping the
@@ -150,14 +146,14 @@ func WithBlockedServers(ids []string) Option {
 	return func(o *options) { o.blockedServers = ids }
 }
 
-// New returns a Toolset backed by the embedded catalog. envProvider is used
-// to resolve ${ENV_VAR} placeholders in catalog headers (e.g. the Apify
-// `Authorization: Bearer ${APIFY_API_KEY}` header) at enable time, mirroring
-// how a YAML-declared `mcp.remote` toolset works.
+// New returns a Toolset backed by the embedded catalog. Every catalog server
+// is reachable over streamable-http and authenticates with either no
+// credentials ("none") or an OAuth flow ("oauth") driven by the underlying
+// mcp.Toolset.
 //
 // Optional WithAllowedServers / WithBlockedServers options narrow the set of
 // servers the toolset offers by default.
-func New(envProvider environment.Provider, opts ...Option) *Toolset {
+func New(opts ...Option) *Toolset {
 	var cfg options
 	for _, opt := range opts {
 		opt(&cfg)
@@ -165,7 +161,6 @@ func New(envProvider environment.Provider, opts ...Option) *Toolset {
 
 	t := &Toolset{
 		catalog:          MustLoad(),
-		env:              envProvider,
 		enabled:          make(map[string]*tools.StartableToolSet),
 		removeOAuthToken: mcp.RemoveOAuthToken,
 		startToolset: func(ctx context.Context, ts *tools.StartableToolSet) error {
@@ -282,13 +277,9 @@ Workflow:
          setup. Enabling a server is a means to an end, not a stopping
          point.
        - ERROR — the result text tells you exactly why (user declined
-         the authorization dialog, missing env var, server refused).
-         Act on that specific reason; do NOT pretend the server is
-         connected and do NOT call any "<id>_..." tools (there are
-         none).
-     For api_key servers, make sure the listed env var(s) are set in
-     the user's shell BEFORE enabling, otherwise the enable will fail
-     with a missing-env warning.
+         the authorization dialog, server refused). Act on that
+         specific reason; do NOT pretend the server is connected and do
+         NOT call any "<id>_..." tools (there are none).
   3. Call ` + ToolNameDisable + ` to remove a server when no longer needed.
      This tool only appears once at least one server is enabled.
   4. If a previously enabled server starts rejecting requests
@@ -691,33 +682,6 @@ func (t *Toolset) handleEnable(ctx context.Context, args EnableArgs) (*tools.Too
 		return tools.ResultError(fmt.Sprintf("unknown server id %q (use %s first to discover available ids)", id, ToolNameSearch)), nil
 	}
 
-	// Pre-flight: block if an api_key server is missing its env var. The
-	// catalog promises enable returns a deterministic answer in the same
-	// turn, so we cannot register a toolset we already know will be
-	// rejected on the first request. The model is told to ask the user to
-	// set the variable and retry.
-	// Perform these slow external calls BEFORE acquiring the lock — server
-	// data is immutable (from t.byID), no mutex protection needed here.
-	missing := t.missingAPIKeyEnv(ctx, server)
-	headers := t.expandHeaders(ctx, server.Headers)
-
-	// Belt-and-braces: also surface any ${VAR} placeholders left in the
-	// expanded headers. This catches future catalog entries whose headers
-	// reference an env var that is not declared under Auth.Secrets — the
-	// missingAPIKeyEnv check above wouldn't see those.
-	for _, env := range unresolvedHeaderEnvs(headers) {
-		if !slices.Contains(missing, env) {
-			missing = append(missing, env)
-		}
-	}
-	if len(missing) > 0 {
-		return tools.ResultError(fmt.Sprintf(
-			"cannot enable %q: the following env var(s) are NOT set: %s. "+
-				"Ask the user to set them in their shell, then call %s for this id again. "+
-				"Do NOT pretend the server is connected — no tools were activated.",
-			id, strings.Join(missing, ", "), ToolNameEnable)), nil
-	}
-
 	// Two paths land here: a fresh enable (no entry yet) and a re-enable
 	// of an existing entry whose previous Start did not complete (deferred
 	// auth-required fallback, cancellation, or any other transient
@@ -736,14 +700,14 @@ func (t *Toolset) handleEnable(ctx context.Context, args EnableArgs) (*tools.Too
 
 	var notify func()
 	if !alreadyEnabled {
-		// Create the MCP toolset with the pre-computed headers.
-		// The nil third arg (*latest.RemoteOAuthConfig) is intentional:
-		// every server currently in the catalog works with default
-		// Dynamic Client Registration and the runtime's default callback.
-		// If a future entry needs custom scopes / a fixed client_id / a
-		// non-default callback, extend Auth in servers.go and plumb the
-		// resulting *RemoteOAuthConfig through here.
-		mcpToolset := mcp.NewRemoteToolset(id, server.URL, server.Transport, headers, nil)
+		// Create the MCP toolset. The nil headers and nil
+		// *latest.RemoteOAuthConfig are intentional: every catalog server
+		// authenticates with either no credentials or an OAuth flow that
+		// works with default Dynamic Client Registration and the runtime's
+		// default callback. If a future entry needs custom scopes / a fixed
+		// client_id / a non-default callback, extend Auth in servers.go and
+		// plumb the resulting *RemoteOAuthConfig through here.
+		mcpToolset := mcp.NewRemoteToolset(id, server.URL, server.Transport, nil, nil)
 
 		// Re-attach the captured handlers so OAuth flows behave
 		// identically to a YAML-declared mcp.remote toolset. Apply
@@ -872,79 +836,6 @@ func (t *Toolset) handleEnableStartError(ctx context.Context, id string, server 
 			"failed to connect to %q (%s): %v. No tools were activated — do NOT claim the server is connected. Report the failure to the user; they may need to fix their network or, if the server's credentials changed, call %s for %q before re-enabling.",
 			id, server.Title, err, ToolNameResetAuth, id))
 	}
-}
-
-// expandHeaders resolves ${VAR} placeholders in catalog headers against the
-// configured env provider. The catalog uses the bare ${VAR} form (e.g.
-// `Authorization: Bearer ${APIFY_API_KEY}`), so we route through the env
-// provider directly rather than the JavaScript expander — the latter
-// expects the ${env.VAR} form used in YAML configs. Headers that don't
-// contain any placeholder pass through unchanged.
-func (t *Toolset) expandHeaders(ctx context.Context, in map[string]string) map[string]string {
-	if len(in) == 0 {
-		return nil
-	}
-	out := make(map[string]string, len(in))
-	for k, v := range in {
-		out[k] = unresolvedHeaderEnv.ReplaceAllStringFunc(v, func(match string) string {
-			name := match[2 : len(match)-1] // strip ${ and }
-			if t.env == nil {
-				return match
-			}
-			if val, ok := t.env.Get(ctx, name); ok && val != "" {
-				return val
-			}
-			return match // leave the placeholder in place so unresolvedHeaderEnvs picks it up
-		})
-	}
-	return out
-}
-
-// missingAPIKeyEnv returns the names of api_key env vars that are not
-// available from the toolset's env provider. Empty result means "all good".
-// Returns nil for non api_key servers.
-func (t *Toolset) missingAPIKeyEnv(ctx context.Context, s Server) []string {
-	if s.Auth.Type != "api_key" || t.env == nil {
-		return nil
-	}
-	var missing []string
-	for _, sec := range s.Auth.Secrets {
-		if sec.Env == "" {
-			continue
-		}
-		if v, ok := t.env.Get(ctx, sec.Env); !ok || v == "" {
-			missing = append(missing, sec.Env)
-		}
-	}
-	return missing
-}
-
-// unresolvedHeaderEnv matches any ${VAR}-style placeholder still present
-// in a header value after expansion — i.e. an env var the expander could
-// not resolve. We scan post-expansion so headers that resolved correctly
-// are silently accepted.
-var unresolvedHeaderEnv = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)\}`)
-
-// unresolvedHeaderEnvs returns the names of every ${VAR} placeholder
-// that survived header expansion. Defends against catalog entries whose
-// headers reference env vars not declared under Auth.Secrets.
-func unresolvedHeaderEnvs(headers map[string]string) []string {
-	if len(headers) == 0 {
-		return nil
-	}
-	seen := make(map[string]struct{})
-	var out []string
-	for _, v := range headers {
-		for _, m := range unresolvedHeaderEnv.FindAllStringSubmatch(v, -1) {
-			if _, ok := seen[m[1]]; ok {
-				continue
-			}
-			seen[m[1]] = struct{}{}
-			out = append(out, m[1])
-		}
-	}
-	sort.Strings(out)
-	return out
 }
 
 // DisableArgs is the input schema for disable_remote_mcp_server.

--- a/pkg/tools/builtin/mcpcatalog/mcpcatalog_test.go
+++ b/pkg/tools/builtin/mcpcatalog/mcpcatalog_test.go
@@ -24,13 +24,6 @@ import (
 	mcptools "github.com/docker/docker-agent/pkg/tools/mcp"
 )
 
-type stubEnv struct{ vars map[string]string }
-
-func (s stubEnv) Get(_ context.Context, name string) (string, bool) {
-	v, ok := s.vars[name]
-	return v, ok
-}
-
 // stubStartOK swaps the Toolset's synchronous-Start seam for a no-op so
 // handleEnable returns the success branch without dialling out. Use it on
 // tests that only need handleEnable to register the bookkeeping (the
@@ -61,9 +54,9 @@ func TestLoadCatalog(t *testing.T) {
 		assert.NotEmpty(t, s.ID, "server id must not be empty")
 		assert.Equal(t, "streamable-http", s.Transport, "server %s has unexpected transport", s.ID)
 		assert.NotEmpty(t, s.URL, "server %s has no URL", s.ID)
-		// auth.type must be one of the three documented values.
+		// auth.type must be one of the two documented values.
 		switch s.Auth.Type {
-		case "oauth", "api_key", "none":
+		case "oauth", "none":
 		default:
 			t.Fatalf("server %s has invalid auth.type %q", s.ID, s.Auth.Type)
 		}
@@ -71,7 +64,7 @@ func TestLoadCatalog(t *testing.T) {
 }
 
 func TestSearchTool(t *testing.T) {
-	ts := New(stubEnv{vars: map[string]string{}})
+	ts := New()
 	ctx := t.Context()
 
 	res, err := ts.handleSearch(ctx, SearchArgs{Query: "stripe"})
@@ -99,7 +92,7 @@ func TestSearchTool(t *testing.T) {
 }
 
 func TestEnableDisableLifecycle(t *testing.T) {
-	ts := New(stubEnv{vars: map[string]string{}})
+	ts := New()
 	// Synchronous-Start is short-circuited so the success branch of
 	// handleEnable is exercised without dialling out to the real OAuth
 	// server. The dedicated failure-path tests below cover declined /
@@ -206,61 +199,6 @@ func TestEnableDisableLifecycle(t *testing.T) {
 	assert.Equal(t, int32(2), changes.Load())
 }
 
-func TestEnableUnresolvedHeaderEnvSurfacesWarning(t *testing.T) {
-	ts := New(stubEnv{vars: map[string]string{}})
-
-	// Synthetic catalog entry: auth.type="none" so neither missingAPIKeyEnv
-	// nor the api_key path fires; the only signal is the post-expansion
-	// scan over Headers.
-	const id = "unresolved-headers"
-	server := Server{
-		ID:        id,
-		Title:     "Unresolved Headers Server",
-		URL:       "https://example.invalid/mcp",
-		Transport: "streamable-http",
-		Auth:      Auth{Type: "none"},
-		Headers: map[string]string{
-			"Authorization": "Bearer ${UNDECLARED_TOKEN}",
-		},
-	}
-	ts.catalog.Servers = append(ts.catalog.Servers, server)
-	ts.byID[id] = server
-
-	// Missing env vars BLOCK the enable now (rather than attaching a
-	// warning to a success result): the catalog promises a deterministic
-	// answer in the same turn, and we already know the server will reject
-	// the connection. The model is told to ask the user to set the
-	// variable and call enable again.
-	res, err := ts.handleEnable(t.Context(), EnableArgs{ID: id})
-	require.NoError(t, err)
-	assert.True(t, res.IsError,
-		"missing env vars must be returned as an error result so the model does not pretend the server is connected")
-	assert.Contains(t, res.Output, "UNDECLARED_TOKEN",
-		"the post-expansion scan must surface env vars referenced from headers but not declared under Auth.Secrets")
-	assert.Contains(t, res.Output, ToolNameEnable,
-		"the error must point the model at the recovery call to make once the env var is set")
-	// And the server must NOT have been registered — we returned before
-	// even constructing the inner toolset.
-	ts.mu.RLock()
-	_, exists := ts.enabled[id]
-	ts.mu.RUnlock()
-	assert.False(t, exists,
-		"a missing-env enable must not leave a half-registered entry behind")
-}
-
-func TestUnresolvedHeaderEnvsHelper(t *testing.T) {
-	assert.Empty(t, unresolvedHeaderEnvs(nil))
-	assert.Empty(t, unresolvedHeaderEnvs(map[string]string{"X": "plain-value"}))
-
-	got := unresolvedHeaderEnvs(map[string]string{
-		"A": "Bearer ${TOKEN_ONE}",
-		"B": "prefix-${TOKEN_TWO}-${TOKEN_ONE}-suffix",
-		"C": "resolved-already",
-	})
-	assert.Equal(t, []string{"TOKEN_ONE", "TOKEN_TWO"}, got,
-		"placeholders must be deduplicated and returned in sorted order")
-}
-
 // TestLoadCatalogIsCachedButReturnsCopies verifies the sync.OnceValues
 // optimization: subsequent Load() calls don't re-decode the JSON, but
 // each one returns an independently mutable Servers slice so test
@@ -281,7 +219,7 @@ func TestLoadCatalogIsCachedButReturnsCopies(t *testing.T) {
 // by id so model-side prompt caches and TUI rendering don't reshuffle on
 // every turn.
 func TestToolsUsesStableIterationOrder(t *testing.T) {
-	ts := New(stubEnv{vars: map[string]string{}})
+	ts := New()
 	// We only care about the order of the t.enabled map after a sequence
 	// of handleEnable calls. Stub out the synchronous Start so we don't
 	// dial out to real catalog endpoints.
@@ -324,12 +262,12 @@ func TestToolsUsesStableIterationOrder(t *testing.T) {
 // TestServerFilters covers the allow/block-list narrowing applied at
 // construction time via WithAllowedServers / WithBlockedServers.
 func TestServerFilters(t *testing.T) {
-	full := New(stubEnv{vars: map[string]string{}})
+	full := New()
 	require.GreaterOrEqual(t, len(full.catalog.Servers), 3, "need 3+ servers in fixture")
 	ids := []string{full.catalog.Servers[0].ID, full.catalog.Servers[1].ID, full.catalog.Servers[2].ID}
 
 	t.Run("allow list restricts to the named servers", func(t *testing.T) {
-		ts := New(stubEnv{vars: map[string]string{}}, WithAllowedServers(ids[:2]))
+		ts := New(WithAllowedServers(ids[:2]))
 		assert.Equal(t, len(ts.catalog.Servers), ts.catalog.Count)
 		assert.Len(t, ts.catalog.Servers, 2)
 		assert.Contains(t, ts.byID, ids[0])
@@ -338,36 +276,32 @@ func TestServerFilters(t *testing.T) {
 	})
 
 	t.Run("block list removes the named servers", func(t *testing.T) {
-		ts := New(stubEnv{vars: map[string]string{}}, WithBlockedServers(ids[:1]))
+		ts := New(WithBlockedServers(ids[:1]))
 		assert.Len(t, ts.catalog.Servers, len(full.catalog.Servers)-1)
 		assert.NotContains(t, ts.byID, ids[0])
 		assert.Contains(t, ts.byID, ids[1])
 	})
 
 	t.Run("block takes precedence over allow", func(t *testing.T) {
-		ts := New(stubEnv{vars: map[string]string{}},
-			WithAllowedServers(ids[:2]), WithBlockedServers([]string{ids[0]}))
+		ts := New(WithAllowedServers(ids[:2]), WithBlockedServers([]string{ids[0]}))
 		assert.Len(t, ts.catalog.Servers, 1)
 		assert.NotContains(t, ts.byID, ids[0])
 		assert.Contains(t, ts.byID, ids[1])
 	})
 
 	t.Run("unknown ids are ignored", func(t *testing.T) {
-		ts := New(stubEnv{vars: map[string]string{}},
-			WithAllowedServers([]string{ids[0], "definitely-not-a-server"}))
+		ts := New(WithAllowedServers([]string{ids[0], "definitely-not-a-server"}))
 		assert.Len(t, ts.catalog.Servers, 1)
 		assert.Contains(t, ts.byID, ids[0])
 	})
 
 	t.Run("blank entries are ignored", func(t *testing.T) {
-		ts := New(stubEnv{vars: map[string]string{}},
-			WithAllowedServers([]string{ids[0], "  ", ""}))
+		ts := New(WithAllowedServers([]string{ids[0], "  ", ""}))
 		assert.Len(t, ts.catalog.Servers, 1)
 	})
 
 	t.Run("empty lists offer the full catalog", func(t *testing.T) {
-		ts := New(stubEnv{vars: map[string]string{}},
-			WithAllowedServers(nil), WithBlockedServers([]string{}))
+		ts := New(WithAllowedServers(nil), WithBlockedServers([]string{}))
 		assert.Len(t, ts.catalog.Servers, len(full.catalog.Servers))
 	})
 }
@@ -375,12 +309,12 @@ func TestServerFilters(t *testing.T) {
 // TestSearchRespectsAllowList ensures filtered-out servers are not
 // reachable through the search meta-tool.
 func TestSearchRespectsAllowList(t *testing.T) {
-	full := New(stubEnv{vars: map[string]string{}})
+	full := New()
 	require.GreaterOrEqual(t, len(full.catalog.Servers), 2)
 	keep := full.catalog.Servers[0].ID
 	drop := full.catalog.Servers[1].ID
 
-	ts := New(stubEnv{vars: map[string]string{}}, WithAllowedServers([]string{keep}))
+	ts := New(WithAllowedServers([]string{keep}))
 
 	res, err := ts.handleSearch(t.Context(), SearchArgs{Query: drop})
 	require.NoError(t, err)
@@ -388,75 +322,11 @@ func TestSearchRespectsAllowList(t *testing.T) {
 }
 
 func TestEnableUnknownServer(t *testing.T) {
-	ts := New(stubEnv{vars: map[string]string{}})
+	ts := New()
 	res, err := ts.handleEnable(t.Context(), EnableArgs{ID: "definitely-not-a-server"})
 	require.NoError(t, err)
 	assert.True(t, res.IsError)
 	assert.Contains(t, res.Output, "unknown server id")
-}
-
-func TestEnableAPIKeyMissingEnv(t *testing.T) {
-	ts := New(stubEnv{vars: map[string]string{}})
-
-	var apiKeyID, expectedEnv string
-	for _, s := range ts.catalog.Servers {
-		if s.Auth.Type == "api_key" && len(s.Auth.Secrets) > 0 && s.Auth.Secrets[0].Env != "" {
-			apiKeyID = s.ID
-			expectedEnv = s.Auth.Secrets[0].Env
-			break
-		}
-	}
-	require.NotEmpty(t, apiKeyID, "test fixture: catalog should contain at least one api_key server with an env var")
-
-	res, err := ts.handleEnable(t.Context(), EnableArgs{ID: apiKeyID})
-	require.NoError(t, err)
-	assert.True(t, res.IsError,
-		"missing api_key env vars must block enable so the model does not pretend the server is connected")
-	assert.Contains(t, res.Output, expectedEnv,
-		"the error must name the specific env var(s) the user needs to set")
-	assert.Contains(t, res.Output, ToolNameEnable,
-		"the error must point the model at the recovery call once the env var is set")
-	// No half-registered entry: we returned before constructing the inner
-	// toolset, so a follow-up enable (after the user sets the variable)
-	// goes through the full success path with no stale state.
-	ts.mu.RLock()
-	_, exists := ts.enabled[apiKeyID]
-	ts.mu.RUnlock()
-	assert.False(t, exists)
-}
-
-func TestEnableAPIKeyEnvPresent(t *testing.T) {
-	// Find an api_key server with a declared env var first so we know what
-	// to populate.
-	ts := New(stubEnv{vars: map[string]string{}})
-	var apiKeyID string
-	vars := map[string]string{}
-	for _, s := range ts.catalog.Servers {
-		if s.Auth.Type == "api_key" {
-			apiKeyID = s.ID
-			for _, sec := range s.Auth.Secrets {
-				if sec.Env != "" {
-					vars[sec.Env] = "sentinel-value"
-				}
-			}
-			break
-		}
-	}
-	require.NotEmpty(t, apiKeyID)
-
-	// Re-instantiate with the populated env so missingAPIKeyEnv and the
-	// unresolved-header scan both come back empty. Stub out the synchronous
-	// Start so we don't dial the real catalog endpoint.
-	ts = New(stubEnv{vars: vars})
-	stubStartOK(ts)
-
-	res, err := ts.handleEnable(t.Context(), EnableArgs{ID: apiKeyID})
-	require.NoError(t, err)
-	require.False(t, res.IsError, "enable failed: %s", res.Output)
-	assert.Contains(t, res.Output, "enabled",
-		"the success branch must state plainly that the server is enabled")
-	assert.Contains(t, res.Output, apiKeyID+"_",
-		"the success branch must reference the tool-name prefix")
 }
 
 // TestEnableSyncStartSuccess asserts that handleEnable, on the happy path,
@@ -464,7 +334,7 @@ func TestEnableAPIKeyEnvPresent(t *testing.T) {
 // to continue with the user's ORIGINAL request in the SAME turn — not on
 // the next one. This is the property that makes a re-ask unnecessary.
 func TestEnableSyncStartSuccess(t *testing.T) {
-	ts := New(stubEnv{vars: map[string]string{}})
+	ts := New()
 	stubStartOK(ts)
 
 	id := firstOAuthServerID(t, ts)
@@ -493,7 +363,7 @@ func TestEnableSyncStartSuccess(t *testing.T) {
 // does not re-pop the dialog, and tells the model how to retry on user
 // request — all in the SAME turn.
 func TestEnableSyncStartOAuthDeclined(t *testing.T) {
-	ts := New(stubEnv{vars: map[string]string{}})
+	ts := New()
 
 	var changes atomic.Int32
 	ts.SetToolsChangedHandler(func() { changes.Add(1) })
@@ -531,7 +401,7 @@ func TestEnableSyncStartOAuthDeclined(t *testing.T) {
 // Tools() call retries; the tool result falls back to the legacy
 // "tools appear next turn" wording so the model knows to verify.
 func TestEnableSyncStartAuthorizationRequiredDefers(t *testing.T) {
-	ts := New(stubEnv{vars: map[string]string{}})
+	ts := New()
 
 	id := firstOAuthServerID(t, ts)
 	stubStartErr(ts, &mcptools.AuthorizationRequiredError{URL: ts.byID[id].URL})
@@ -560,7 +430,7 @@ func TestEnableSyncStartAuthorizationRequiredDefers(t *testing.T) {
 // must be rolled back so the next Tools() call doesn't replay the failed
 // handshake.
 func TestEnableSyncStartTransportError(t *testing.T) {
-	ts := New(stubEnv{vars: map[string]string{}})
+	ts := New()
 
 	id := firstOAuthServerID(t, ts)
 	stubStartErr(ts, errors.New("dial tcp: connection refused"))
@@ -614,7 +484,7 @@ func (f *flakyStartToolSet) Stop(context.Context) error { return nil }
 // without invoking the seam, so the OAuth dialog never re-surfaced and
 // the only escape was disable+enable.
 func TestEnableRetriesStartOnExistingUnstartedEntry(t *testing.T) {
-	ts := New(stubEnv{vars: map[string]string{}})
+	ts := New()
 
 	id := firstOAuthServerID(t, ts)
 	fake := &flakyStartToolSet{
@@ -680,7 +550,7 @@ func TestEnableRetriesStartOnExistingUnstartedEntry(t *testing.T) {
 // fresh wrapper (not on the cancelled one) and drives Start again — which
 // is what makes the "user asked to retry" path work.
 func TestEnableSyncStartCancelledRollsBack(t *testing.T) {
-	ts := New(stubEnv{vars: map[string]string{}})
+	ts := New()
 
 	id := firstOAuthServerID(t, ts)
 	fake := &flakyStartToolSet{failures: 1, failWith: context.Canceled}
@@ -741,7 +611,7 @@ func TestEnableSyncStartCancelledRollsBack(t *testing.T) {
 // the user did not ask for. This test pins the post-fix behaviour:
 // Turn-2's Tools() must not touch the cancelled wrapper at all.
 func TestToolsAfterCancelledEnableDoesNotReFireOAuth(t *testing.T) {
-	ts := New(stubEnv{vars: map[string]string{}})
+	ts := New()
 
 	id := firstOAuthServerID(t, ts)
 	// Stop-during-OAuth is modelled as a Start that returns
@@ -774,7 +644,7 @@ func TestToolsAfterCancelledEnableDoesNotReFireOAuth(t *testing.T) {
 }
 
 func TestListEnabled(t *testing.T) {
-	ts := New(stubEnv{vars: map[string]string{}})
+	ts := New()
 	stubStartOK(ts)
 	ctx := t.Context()
 
@@ -793,7 +663,7 @@ func TestListEnabled(t *testing.T) {
 }
 
 func TestStopReleasesEverything(t *testing.T) {
-	ts := New(stubEnv{vars: map[string]string{}})
+	ts := New()
 	stubStartOK(ts)
 	ctx := t.Context()
 
@@ -817,9 +687,7 @@ func toolNames(list []tools.Tool) []string {
 }
 
 // firstOAuthServerID picks an arbitrary OAuth catalog server for tests that
-// only need *some* server id to feed into handleEnable. OAuth servers are
-// preferred over api_key ones so the missing-env-var guard doesn't trip and
-// turn the call into an unintended ResultError.
+// only need *some* server id to feed into handleEnable.
 func firstOAuthServerID(t *testing.T, ts *Toolset) string {
 	t.Helper()
 	for _, s := range ts.catalog.Servers {
@@ -832,7 +700,7 @@ func firstOAuthServerID(t *testing.T, ts *Toolset) string {
 }
 
 func TestSetManagedOAuthPersistence(t *testing.T) {
-	ts := New(stubEnv{vars: map[string]string{}})
+	ts := New()
 	stubStartOK(ts)
 	ctx := t.Context()
 
@@ -857,7 +725,7 @@ func TestSetManagedOAuthPersistence(t *testing.T) {
 }
 
 func TestConcurrentEnableDisable(t *testing.T) {
-	ts := New(stubEnv{vars: map[string]string{}})
+	ts := New()
 	stubStartOK(ts)
 	ctx := t.Context()
 
@@ -935,7 +803,7 @@ func TestConcurrentEnableDisable(t *testing.T) {
 }
 
 func TestToolsContextCancellation(t *testing.T) {
-	ts := New(stubEnv{vars: map[string]string{}})
+	ts := New()
 	stubStartOK(ts)
 
 	id := firstOAuthServerID(t, ts)
@@ -960,7 +828,7 @@ func TestToolsExposesEnabledServerTools(t *testing.T) {
 	srv := newFakeMCPServer(t)
 	defer srv.Close()
 
-	ts := New(stubEnv{vars: map[string]string{}})
+	ts := New()
 
 	// Inject a synthetic catalog entry that points at the test server.
 	const id = "test-server"
@@ -1005,7 +873,7 @@ func TestToolsExposesEnabledServerTools(t *testing.T) {
 // TestResetAuthForwardsToTokenStore verifies that reset_remote_mcp_server_auth
 // places the right call with the right URL.
 func TestResetAuthForwardsToTokenStore(t *testing.T) {
-	ts := New(stubEnv{vars: map[string]string{}})
+	ts := New()
 
 	var removedURLs []string
 	ts.removeOAuthToken = func(url string) error {
@@ -1033,7 +901,7 @@ func TestResetAuthForwardsToTokenStore(t *testing.T) {
 // TestResetAuthUnknownServer confirms unknown ids surface a friendly error
 // without touching the token store.
 func TestResetAuthUnknownServer(t *testing.T) {
-	ts := New(stubEnv{vars: map[string]string{}})
+	ts := New()
 	called := 0
 	ts.removeOAuthToken = func(string) error { called++; return nil }
 
@@ -1044,34 +912,38 @@ func TestResetAuthUnknownServer(t *testing.T) {
 	assert.Zero(t, called, "token store must not be touched for unknown ids")
 }
 
-// TestResetAuthNoOpForNonOAuth confirms that resetting auth for an
-// api_key/none server is a no-op that doesn't reach the token store.
+// TestResetAuthNoOpForNonOAuth confirms that resetting auth for a
+// non-OAuth ("none") server is a no-op that doesn't reach the token store.
 func TestResetAuthNoOpForNonOAuth(t *testing.T) {
-	ts := New(stubEnv{vars: map[string]string{}})
+	ts := New()
 	called := 0
 	ts.removeOAuthToken = func(string) error { called++; return nil }
 
-	var apiKeyID string
-	for _, s := range ts.catalog.Servers {
-		if s.Auth.Type == "api_key" {
-			apiKeyID = s.ID
-			break
-		}
+	// Inject a synthetic auth.type="none" entry to confirm reset is a
+	// no-op for non-OAuth auth.
+	const noneID = "synthetic-none"
+	server := Server{
+		ID:        noneID,
+		Title:     "Synthetic None",
+		URL:       "https://example.invalid/mcp",
+		Transport: "streamable-http",
+		Auth:      Auth{Type: "none"},
 	}
-	require.NotEmpty(t, apiKeyID)
+	ts.catalog.Servers = append(ts.catalog.Servers, server)
+	ts.byID[noneID] = server
 
-	res, err := ts.handleResetAuth(t.Context(), ResetAuthArgs{ID: apiKeyID})
+	res, err := ts.handleResetAuth(t.Context(), ResetAuthArgs{ID: noneID})
 	require.NoError(t, err)
 	require.False(t, res.IsError)
 	assert.Contains(t, res.Output, "no persisted credentials")
-	assert.Zero(t, called, "api_key servers must not touch the OAuth token store")
+	assert.Zero(t, called, "non-OAuth servers must not touch the OAuth token store")
 }
 
 // TestResetAuthDisablesEnabledServer makes sure resetting auth for a
 // currently-enabled server stops its toolset (so the next enable does a
 // fresh handshake) AND fires the tools-changed handler.
 func TestResetAuthDisablesEnabledServer(t *testing.T) {
-	ts := New(stubEnv{vars: map[string]string{}})
+	ts := New()
 	stubStartOK(ts)
 	ts.removeOAuthToken = func(string) error { return nil }
 
@@ -1107,7 +979,7 @@ func TestResetAuthDisablesEnabledServer(t *testing.T) {
 // TestResetAuthSurfacesStoreErrors confirms that errors from the token
 // store are surfaced to the caller as IsError results (not panics).
 func TestResetAuthSurfacesStoreErrors(t *testing.T) {
-	ts := New(stubEnv{vars: map[string]string{}})
+	ts := New()
 	ts.removeOAuthToken = func(string) error { return errors.New("keyring on fire") }
 
 	var oauthID string
@@ -1131,7 +1003,7 @@ func TestResetAuthSurfacesStoreErrors(t *testing.T) {
 // the keyring; the runtime's tool list has therefore changed regardless of
 // whether the keyring removal eventually succeeds. Notify must fire.
 func TestResetAuthNotifiesEvenWhenKeyringFails(t *testing.T) {
-	ts := New(stubEnv{vars: map[string]string{}})
+	ts := New()
 	stubStartOK(ts)
 	ts.removeOAuthToken = func(string) error { return errors.New("keyring on fire") }
 
@@ -1176,7 +1048,7 @@ func TestDisableAndResetAuthGatedOnEnabledServers(t *testing.T) {
 	srv := newAuthRequiredMCPServer(t)
 	defer srv.Close()
 
-	ts := New(stubEnv{vars: map[string]string{}})
+	ts := New()
 	// Stub the synchronous Start to surface AuthorizationRequired so
 	// handleEnable takes the defensive "keep the server enabled, defer to
 	// next interactive Tools()" branch — that is what previously happened
@@ -1248,7 +1120,7 @@ func (d *declineOnStartToolSet) Stop(context.Context) error {
 // second time on the next Tools() iteration — which is what previously
 // caused the dialog to re-appear in the host on every agent loop turn.
 func TestToolsOAuthDeclineRemovesServer(t *testing.T) {
-	ts := New(stubEnv{vars: map[string]string{}})
+	ts := New()
 	const id = "decline-server"
 	server := Server{
 		ID:        id,
@@ -1353,7 +1225,7 @@ func (c *cancelOnStartToolSet) Stop(context.Context) error {
 // entry so the next Tools() iteration does not silently re-fire the
 // OAuth dialog on an unrelated user message.
 func TestToolsCancelledStartRemovesServer(t *testing.T) {
-	ts := New(stubEnv{vars: map[string]string{}})
+	ts := New()
 	const id = "cancel-server"
 	server := Server{
 		ID:        id,
@@ -1417,7 +1289,7 @@ func TestToolsCancelledStartRemovesServer(t *testing.T) {
 // case the entry has already been removed and notify() has already fired;
 // disableAfterDecline must not double-notify.
 func TestToolsOAuthDeclineNoNotifyWhenAlreadyDisabled(t *testing.T) {
-	ts := New(stubEnv{vars: map[string]string{}})
+	ts := New()
 	const id = "decline-server-concurrent"
 	server := Server{
 		ID:        id,
@@ -1474,7 +1346,7 @@ func TestToolsAuthRequiredIsDeferred(t *testing.T) {
 	srv := newAuthRequiredMCPServer(t)
 	defer srv.Close()
 
-	ts := New(stubEnv{vars: map[string]string{}})
+	ts := New()
 	// Defensive fallback: when handleEnable's synchronous Start surfaces
 	// AuthorizationRequired (e.g. because the elicitation bridge isn't
 	// wired up yet), the catalog must keep the server in t.enabled so the

--- a/pkg/tools/builtin/mcpcatalog/servers.go
+++ b/pkg/tools/builtin/mcpcatalog/servers.go
@@ -25,46 +25,36 @@ type Catalog struct {
 
 // Server is a curated, on-demand-activatable remote MCP server description.
 //
-// Headers may contain ${ENV_VAR} placeholders that are resolved at request
-// time against the agent's env provider — exactly like a YAML-declared
-// `mcp` toolset with `remote.headers`. This lets API-key servers like
-// Apify pull APIFY_API_KEY from the user's shell at activation time.
+// The catalog only carries servers reachable over streamable-http with an
+// auth model docker-agent can drive itself: either no credentials at all
+// ("none") or an OAuth flow ("oauth") handled by the underlying mcp.Toolset.
 type Server struct {
-	ID          string            `json:"id"`
-	Title       string            `json:"title"`
-	Description string            `json:"description"`
-	URL         string            `json:"url"`
-	Transport   string            `json:"transport"`
-	Category    string            `json:"category,omitempty"`
-	Tags        []string          `json:"tags,omitempty"`
-	Icon        string            `json:"icon,omitempty"`
-	Readme      string            `json:"readme,omitempty"`
-	Headers     map[string]string `json:"headers,omitempty"`
-	Auth        Auth              `json:"auth"`
+	ID          string   `json:"id"`
+	Title       string   `json:"title"`
+	Description string   `json:"description"`
+	URL         string   `json:"url"`
+	Transport   string   `json:"transport"`
+	Category    string   `json:"category,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+	Icon        string   `json:"icon,omitempty"`
+	Readme      string   `json:"readme,omitempty"`
+	Auth        Auth     `json:"auth"`
 }
 
 // Auth describes how to authenticate against a remote MCP server.
 //
 // Type is one of:
-//   - "none"     — no credentials required
-//   - "oauth"    — OAuth flow handled by the underlying mcp.Toolset
-//   - "api_key"  — caller-provided secret(s) (env vars listed in Secrets)
+//   - "none"  — no credentials required
+//   - "oauth" — OAuth flow handled by the underlying mcp.Toolset
 type Auth struct {
 	Type      string          `json:"type"`
 	Providers []OAuthProvider `json:"providers,omitempty"`
-	Secrets   []SecretSpec    `json:"secrets,omitempty"`
 }
 
 type OAuthProvider struct {
 	Provider string `json:"provider"`
 	Env      string `json:"env"`
 	Secret   string `json:"secret"`
-}
-
-type SecretSpec struct {
-	Name    string `json:"name"`
-	Env     string `json:"env"`
-	Example string `json:"example,omitempty"`
 }
 
 // loadOnce caches the parsed catalog. The embedded JSON is immutable for

--- a/pkg/tools/builtin/mcpcatalog/servers.json
+++ b/pkg/tools/builtin/mcpcatalog/servers.json
@@ -3,37 +3,8 @@
   "source_url": "https://desktop.docker.com/mcp/catalog/v3/catalog.json",
   "schema_version": 3,
   "filter": "type=remote AND remote.transport_type=streamable-http",
-  "count": 51,
+  "count": 39,
   "servers": [
-    {
-      "id": "apify",
-      "title": "Apify Remote",
-      "description": "Apify is the world's largest marketplace of tools for web scraping, data extraction, and web automation. You can extract structured data from social media, e-commerce, search engines, maps, travel sites, or any other website.",
-      "url": "https://mcp.apify.com",
-      "transport": "streamable-http",
-      "category": "automation",
-      "tags": [
-        "automation",
-        "web-scraping",
-        "data-extraction",
-        "remote"
-      ],
-      "icon": "https://www.google.com/s2/favicons?domain=apify.com&sz=64",
-      "readme": "http://desktop.docker.com/mcp/catalog/v3/readme/apify.md",
-      "headers": {
-        "Authorization": "Bearer ${APIFY_API_KEY}"
-      },
-      "auth": {
-        "type": "api_key",
-        "secrets": [
-          {
-            "name": "apify.api_key",
-            "env": "APIFY_API_KEY",
-            "example": "<YOUR_API_KEY>"
-          }
-        ]
-      }
-    },
     {
       "id": "astro-docs",
       "title": "Astro Docs",
@@ -110,33 +81,6 @@
       }
     },
     {
-      "id": "brightdata",
-      "title": "Bright Data",
-      "description": "One MCP for the Web. Easily search, crawl, navigate, and extract websites without getting blocked. Ideal for discovering and retrieving structured insights from any public source - effortlessly and ethically.  The Web MCP is your gateway to giving AI assistants true web capabilities. No more outdated responses, no more \"I can't access real-time information\" - just seamless, reliable web access that actually works.  Built by Bright Data, the world's #1 web data platform, this MCP server ensures your AI never gets blocked, rate-limited, or served CAPTCHAs.",
-      "url": "https://mcp.brightdata.com/mcp",
-      "transport": "streamable-http",
-      "category": "web-scraping",
-      "tags": [
-        "web-scraping",
-        "data",
-        "search",
-        "remote"
-      ],
-      "icon": "https://www.google.com/s2/favicons?domain=brightdata.com&sz=128",
-      "readme": "http://desktop.docker.com/mcp/catalog/v3/readme/brightdata.md",
-      "headers": {},
-      "auth": {
-        "type": "api_key",
-        "secrets": [
-          {
-            "name": "brightdata.api_token",
-            "env": "BRIGHTDATA_API_TOKEN",
-            "example": "<YOUR_API_TOKEN>"
-          }
-        ]
-      }
-    },
-    {
       "id": "carbon-voice",
       "title": "Carbon Voice",
       "description": "Communicate asynchronously with voice messages featuring AI transcription, summaries, and automated action item extraction.",
@@ -164,35 +108,6 @@
       }
     },
     {
-      "id": "close",
-      "title": "Close",
-      "description": "Streamline sales processes with integrated calling, email, SMS, and automated workflows for small and scaling businesses.",
-      "url": "https://mcp.close.com/mcp",
-      "transport": "streamable-http",
-      "category": "crm",
-      "tags": [
-        "crm",
-        "sales",
-        "customer-management",
-        "remote"
-      ],
-      "icon": "https://www.google.com/s2/favicons?domain=close.com&sz=64",
-      "readme": "http://desktop.docker.com/mcp/catalog/v3/readme/close.md",
-      "headers": {
-        "Authorization": "Bearer ${CLOSE_API_KEY}"
-      },
-      "auth": {
-        "type": "api_key",
-        "secrets": [
-          {
-            "name": "close.api_key",
-            "env": "CLOSE_API_KEY",
-            "example": "<YOUR_API_KEY>"
-          }
-        ]
-      }
-    },
-    {
       "id": "cloudflare",
       "title": "Cloudflare",
       "description": "Manage Cloudflare workers, DNS, security and platform resources via the Cloudflare API.",
@@ -210,35 +125,6 @@
       "headers": {},
       "auth": {
         "type": "oauth"
-      }
-    },
-    {
-      "id": "dappier-remote",
-      "title": "Dappier Remote",
-      "description": "Enable fast, free real-time web search and access premium data from trusted media brands—news, financial markets, sports, entertainment, weather, and more. Build powerful AI agents with Dappier.",
-      "url": "https://mcp.dappier.com/mcp",
-      "transport": "streamable-http",
-      "category": "ai",
-      "tags": [
-        "ai",
-        "rag",
-        "knowledge-base",
-        "remote"
-      ],
-      "icon": "https://avatars.githubusercontent.com/u/152645347?s=200&v=4",
-      "readme": "http://desktop.docker.com/mcp/catalog/v3/readme/dappier-remote.md",
-      "headers": {
-        "Authorization": "Bearer ${DAPPIER_REMOTE_API_KEY}"
-      },
-      "auth": {
-        "type": "api_key",
-        "secrets": [
-          {
-            "name": "dappier-remote.api_key",
-            "env": "DAPPIER_REMOTE_API_KEY",
-            "example": "<YOUR_API_KEY>"
-          }
-        ]
       }
     },
     {
@@ -395,35 +281,6 @@
       }
     },
     {
-      "id": "hubspot",
-      "title": "HubSpot",
-      "description": "Unite marketing, sales, and customer service with AI-powered automation, lead management, and comprehensive analytics.",
-      "url": "https://app.hubspot.com/mcp/v1/http",
-      "transport": "streamable-http",
-      "category": "crm",
-      "tags": [
-        "crm",
-        "marketing",
-        "sales",
-        "remote"
-      ],
-      "icon": "https://www.google.com/s2/favicons?domain=hubspot.com&sz=64",
-      "readme": "http://desktop.docker.com/mcp/catalog/v3/readme/hubspot.md",
-      "headers": {
-        "Authorization": "Bearer ${HUBSPOT_API_KEY}"
-      },
-      "auth": {
-        "type": "api_key",
-        "secrets": [
-          {
-            "name": "hubspot.api_key",
-            "env": "HUBSPOT_API_KEY",
-            "example": "<YOUR_API_KEY>"
-          }
-        ]
-      }
-    },
-    {
       "id": "hugging-face",
       "title": "Hugging Face",
       "description": "Tools for interacting with Hugging Face models, datasets, research papers, and more.",
@@ -565,64 +422,6 @@
       }
     },
     {
-      "id": "mercado-libre",
-      "title": "Mercado Libre",
-      "description": "Provides access to Mercado Libre E-Commerce API.",
-      "url": "https://mcp.mercadolibre.com",
-      "transport": "streamable-http",
-      "category": "commerce",
-      "tags": [
-        "commerce",
-        "marketplace",
-        "latin-america",
-        "remote"
-      ],
-      "icon": "https://www.google.com/s2/favicons?domain=mercadolibre.com&sz=64",
-      "readme": "http://desktop.docker.com/mcp/catalog/v3/readme/mercado-libre.md",
-      "headers": {
-        "Authorization": "Bearer ${MERCADO_LIBRE_API_KEY}"
-      },
-      "auth": {
-        "type": "api_key",
-        "secrets": [
-          {
-            "name": "mercado-libre.api_key",
-            "env": "MERCADO_LIBRE_API_KEY",
-            "example": "<YOUR_API_KEY>"
-          }
-        ]
-      }
-    },
-    {
-      "id": "mercado-pago",
-      "title": "Mercado Pago",
-      "description": "Provides access to Mercado Pago Marketplace API.",
-      "url": "https://mcp.mercadopago.com",
-      "transport": "streamable-http",
-      "category": "payments",
-      "tags": [
-        "payments",
-        "finance",
-        "latin-america",
-        "remote"
-      ],
-      "icon": "https://www.google.com/s2/favicons?domain=mercadopago.com&sz=64",
-      "readme": "http://desktop.docker.com/mcp/catalog/v3/readme/mercado-pago.md",
-      "headers": {
-        "Authorization": "Bearer ${MERCADO_PAGO_API_KEY}"
-      },
-      "auth": {
-        "type": "api_key",
-        "secrets": [
-          {
-            "name": "mercado-pago.api_key",
-            "env": "MERCADO_PAGO_API_KEY",
-            "example": "<YOUR_API_KEY>"
-          }
-        ]
-      }
-    },
-    {
       "id": "microchip",
       "title": "Microchip",
       "description": "Look up Microchip semiconductor product specifications, datasheets and inventory data.",
@@ -709,35 +508,6 @@
             "provider": "morningstar-mcp-server",
             "env": "MORNINGSTAR_MCP_SERVER_PERSONAL_ACCESS_TOKEN",
             "secret": "morningstar-mcp-server.personal_access_token"
-          }
-        ]
-      }
-    },
-    {
-      "id": "needle",
-      "title": "Needle Remote",
-      "description": "Production-ready RAG service to search and retrieve data from your documents.",
-      "url": "https://mcp.needle.app/mcp",
-      "transport": "streamable-http",
-      "category": "ai",
-      "tags": [
-        "ai",
-        "rag",
-        "knowledge-base",
-        "remote"
-      ],
-      "icon": "https://www.google.com/s2/favicons?domain=needle.app&sz=64",
-      "readme": "http://desktop.docker.com/mcp/catalog/v3/readme/needle.md",
-      "headers": {
-        "Authorization": "Bearer ${NEEDLE_API_KEY}"
-      },
-      "auth": {
-        "type": "api_key",
-        "secrets": [
-          {
-            "name": "needle.api_key",
-            "env": "NEEDLE_API_KEY",
-            "example": "<YOUR_API_KEY>"
           }
         ]
       }
@@ -935,35 +705,6 @@
       }
     },
     {
-      "id": "polar-signals",
-      "title": "Polar Signals",
-      "description": "MCP server for Polar Signals Cloud continuous profiling platform, enabling AI assistants to analyze CPU performance, memory usage, and identify optimization opportunities in production systems.",
-      "url": "https://api.polarsignals.com/api/mcp/",
-      "transport": "streamable-http",
-      "category": "devops",
-      "tags": [
-        "devops",
-        "profiling",
-        "performance",
-        "remote"
-      ],
-      "icon": "https://www.google.com/s2/favicons?domain=polarsignals.com&sz=64",
-      "readme": "http://desktop.docker.com/mcp/catalog/v3/readme/polar-signals.md",
-      "headers": {
-        "Authorization": "Bearer ${POLAR_SIGNALS_API_KEY}"
-      },
-      "auth": {
-        "type": "api_key",
-        "secrets": [
-          {
-            "name": "polar-signals.api_key",
-            "env": "POLAR_SIGNALS_API_KEY",
-            "example": "<YOUR_API_KEY>"
-          }
-        ]
-      }
-    },
-    {
       "id": "prisma-postgres",
       "title": "Prisma Postgres",
       "description": "Access PostgreSQL databases through Prisma's type-safe ORM with automated migrations and intuitive query building.",
@@ -1036,34 +777,6 @@
       }
     },
     {
-      "id": "rube",
-      "title": "Rube",
-      "description": "Access to Rube's catalog of remote MCP servers.",
-      "url": "https://rube.app/mcp",
-      "transport": "streamable-http",
-      "category": "tools",
-      "tags": [
-        "tools",
-        "automation",
-        "remote"
-      ],
-      "icon": "https://www.google.com/s2/favicons?domain=composio.dev&sz=64",
-      "readme": "http://desktop.docker.com/mcp/catalog/v3/readme/rube.md",
-      "headers": {
-        "Authorization": "Bearer ${RUBE_API_KEY}"
-      },
-      "auth": {
-        "type": "api_key",
-        "secrets": [
-          {
-            "name": "rube.api_key",
-            "env": "RUBE_API_KEY",
-            "example": "<YOUR_API_KEY>"
-          }
-        ]
-      }
-    },
-    {
       "id": "semgrep",
       "title": "Semgrep",
       "description": "MCP server for using Semgrep to scan code for security vulnerabilities.",
@@ -1081,35 +794,6 @@
       "headers": {},
       "auth": {
         "type": "none"
-      }
-    },
-    {
-      "id": "short-io",
-      "title": "Short.io",
-      "description": "Access to Short.io's link shortener and analytics tools.",
-      "url": "https://ai-assistant.short.io/mcp",
-      "transport": "streamable-http",
-      "category": "tools",
-      "tags": [
-        "tools",
-        "url-shortener",
-        "analytics",
-        "remote"
-      ],
-      "icon": "https://www.google.com/s2/favicons?domain=short.io&sz=64",
-      "readme": "http://desktop.docker.com/mcp/catalog/v3/readme/short-io.md",
-      "headers": {
-        "Authorization": "Bearer ${SHORT_IO_API_KEY}"
-      },
-      "auth": {
-        "type": "api_key",
-        "secrets": [
-          {
-            "name": "short-io.api_key",
-            "env": "SHORT_IO_API_KEY",
-            "example": "<YOUR_API_KEY>"
-          }
-        ]
       }
     },
     {
@@ -1177,35 +861,6 @@
       "headers": {},
       "auth": {
         "type": "oauth"
-      }
-    },
-    {
-      "id": "telnyx",
-      "title": "Telnyx",
-      "description": "Enables interaction with powerful telephony, messaging, and AI assistant APIs.",
-      "url": "https://api.telnyx.com/v2/mcp",
-      "transport": "streamable-http",
-      "category": "communication",
-      "tags": [
-        "communication",
-        "telephony",
-        "sms",
-        "remote"
-      ],
-      "icon": "https://www.google.com/s2/favicons?domain=telnyx.com&sz=64",
-      "readme": "http://desktop.docker.com/mcp/catalog/v3/readme/telnyx.md",
-      "headers": {
-        "Authorization": "Bearer ${TELNYX_API_KEY}"
-      },
-      "auth": {
-        "type": "api_key",
-        "secrets": [
-          {
-            "name": "telnyx.api_key",
-            "env": "TELNYX_API_KEY",
-            "example": "<YOUR_API_KEY>"
-          }
-        ]
       }
     },
     {


### PR DESCRIPTION
The MCP catalog feature currently requires manual API key management for 12 of its 51 servers. Most users don't need these, and their configuration overhead adds unnecessary complexity. This change simplifies the catalog by supporting only OAuth and anonymous-access servers, which can be fully managed by the framework.

The refactor removes all API key machinery from the MCP catalog code, drops 12 rarely-used servers from the built-in registry, and updates callers and tests accordingly. The catalog shrinks from 51 to 39 servers but becomes much simpler to use and maintain. Users who need the removed servers can still set them up manually as custom MCP servers.

The change is backwards-incompatible for anyone explicitly using the removed servers in their config, but as an internal feature not yet documented in release notes, this is acceptable.