### PR TITLE
test(mcp): fix staticcheck SA5011 nil-pointer errors in oauth_test

### DIFF
--- a/pkg/tools/mcp/oauth_test.go
+++ b/pkg/tools/mcp/oauth_test.go
@@ -159,9 +159,7 @@ func TestGetValidToken_UsesStoredCredentialsForRefresh(t *testing.T) {
 	}
 
 	got := transport.getValidToken(t.Context())
-	if got == nil {
-		t.Fatal("getValidToken returned nil, expected refreshed token")
-	}
+	require.NotNil(t, got, "getValidToken returned nil, expected refreshed token")
 	if got.AccessToken != "fresh-at" {
 		t.Errorf("AccessToken = %q, want %q", got.AccessToken, "fresh-at")
 	}
@@ -245,9 +243,7 @@ func TestGetValidToken_UsesStoredAuthServerForRefresh(t *testing.T) {
 	}
 
 	got := transport.getValidToken(t.Context())
-	if got == nil {
-		t.Fatal("getValidToken returned nil, expected refreshed token")
-	}
+	require.NotNil(t, got, "getValidToken returned nil, expected refreshed token")
 	if got.AccessToken != "fresh-at" {
 		t.Fatalf("AccessToken = %q, want %q", got.AccessToken, "fresh-at")
 	}
@@ -870,9 +866,7 @@ func TestOAuthTransportAllowPrivateIPsControlsOAuthClient(t *testing.T) {
 
 	allowPrivateIPsTransport := newTransport(oauthHTTPClientForAllowPrivateIPs(true))
 	got := allowPrivateIPsTransport.getValidToken(t.Context())
-	if got == nil {
-		t.Fatal("getValidToken with allow_private_ips OAuth client returned nil, want refreshed token")
-	}
+	require.NotNil(t, got, "getValidToken with allow_private_ips OAuth client returned nil, want refreshed token")
 	if got.AccessToken != "fresh-at" {
 		t.Fatalf("AccessToken = %q, want fresh-at", got.AccessToken)
 	}


### PR DESCRIPTION
The main branch CI was failing with 6 golangci-lint staticcheck SA5011 ("possible nil pointer dereference") errors in oauth_test. These were triggered by three `if got == nil { t.Fatal(...) }` guards that staticcheck did not recognize as terminating the execution path, so it flagged subsequent `got.AccessToken` accesses as potentially accessing a nil pointer.

Replacing these three guards with `require.NotNil(t, got, ...)` from testify removes the explicit nil comparison that trips staticcheck, while preserving the same fail-fast behavior and readability. The require helper is already in use throughout the test file.

Tests and linter pass locally.