### PR TITLE
feat: add first_available model selection

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -1496,6 +1496,23 @@
         "auth": {
           "$ref": "#/definitions/AuthConfig",
           "description": "Non-API-key authentication scheme for this model. When set, takes precedence over both the provider's API-key path and any auth defined on the referenced ProviderConfig."
+        },
+        "first_available": {
+          "type": "array",
+          "minItems": 1,
+          "description": "Candidate model references in priority order. At load time docker-agent selects the first candidate whose credentials are configured. Candidates may be named models or inline 'provider/model' specs. Local providers (dmr, ollama) need no credentials and make reliable final fallbacks. Mutually exclusive with other model configuration fields.",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S"
+          },
+          "examples": [
+            [
+              "anthropic/claude-sonnet-4-5",
+              "openai/gpt-5",
+              "dmr/ai/qwen3"
+            ]
+          ]
         }
       },
       "additionalProperties": false

--- a/docs/concepts/models/index.md
+++ b/docs/concepts/models/index.md
@@ -43,6 +43,31 @@ agents:
 
 Named models let you configure temperature, token limits, thinking budgets, and other parameters. They're also reusable across multiple agents.
 
+## First Available Models
+
+A named model can also select the first usable model from a priority list. This
+is useful for shared configs that should prefer paid cloud models when their API
+keys are present, but still work with a local fallback:
+
+```yaml
+models:
+  smart:
+    first_available:
+      - anthropic/claude-sonnet-4-5
+      - openai/gpt-5
+      - dmr/ai/qwen3
+
+agents:
+  root:
+    model: smart
+    instruction: You are a helpful assistant.
+```
+
+At load time, docker-agent selects the first candidate whose credentials are
+configured. You only need credentials for one candidate. See
+[Model Configuration]({{ '/configuration/models/#first-available-models' | relative_url }})
+for details.
+
 ## Supported Providers
 
 | Provider            | Key              | Example Models                       | API Key Env Var                     |

--- a/docs/configuration/models/index.md
+++ b/docs/configuration/models/index.md
@@ -14,7 +14,9 @@ _Complete reference for defining models with providers, parameters, and reasonin
 ```yaml
 models:
   model_name:
-    provider: string # Required. One of: openai, anthropic, google, amazon-bedrock,
+    first_available: [list] # Optional: candidate model refs, tried in order by available credentials.
+                            # Mutually exclusive with other model settings.
+    provider: string # Required unless using first_available. One of: openai, anthropic, google, amazon-bedrock,
                      # dmr, mistral, xai, nebius, minimax, requesty, azure, ollama,
                      # github-copilot, or a named provider defined under the top-level
                      # `providers:` section.
@@ -39,8 +41,9 @@ models:
 
 | Property              | Type       | Required | Description                                                                           |
 | --------------------- | ---------- | -------- | ------------------------------------------------------------------------------------- |
-| `provider`            | string     | ✓        | Provider: `openai`, `anthropic`, `google`, `amazon-bedrock`, `dmr`, `mistral`, `xai`, `nebius`, `minimax`, `requesty`, `azure`, `ollama`, `github-copilot`, or any [named provider]({{ '/providers/custom/' | relative_url }}). |
-| `model`               | string     | ✓        | Model name (e.g., `gpt-4o`, `claude-sonnet-4-5`, `gemini-2.5-flash`)                  |
+| `first_available`     | array      | ✗        | Candidate model references tried in order; selects the first whose credentials are configured. Mutually exclusive with other model settings. |
+| `provider`            | string     | ✓/✗      | Required for regular model definitions; omitted for `first_available` selectors. Provider: `openai`, `anthropic`, `google`, `amazon-bedrock`, `dmr`, `mistral`, `xai`, `nebius`, `minimax`, `requesty`, `azure`, `ollama`, `github-copilot`, or any [named provider]({{ '/providers/custom/' | relative_url }}). |
+| `model`               | string     | ✓/✗      | Required for regular model definitions; omitted for `first_available` selectors. Model name (e.g., `gpt-4o`, `claude-sonnet-4-5`, `gemini-2.5-flash`) |
 | `temperature`         | float      | ✗        | Sampling randomness. Range is provider-dependent — typically `0.0–2.0` (Anthropic caps at `1.0`). `0.0` is deterministic. |
 | `max_tokens`          | int        | ✗        | Maximum response length in tokens                                                     |
 | `top_p`               | float      | ✗        | Nucleus sampling threshold (`0.0–1.0`)                                                |
@@ -54,6 +57,52 @@ models:
 | `track_usage`         | boolean    | ✗        | Track and report token usage for this model                                           |
 | `routing`             | array      | ✗        | Rule-based routing to different models. See [Model Routing]({{ '/configuration/routing/' | relative_url }}). |
 | `provider_opts`       | object     | ✗        | Provider-specific options (see provider pages)                                        |
+
+## First Available Models
+
+Use `first_available` when the same agent should work with whichever provider credentials are available in the current environment. docker-agent checks the candidates in order at load time and replaces the selector with the first candidate whose required environment variables are configured.
+
+```yaml
+models:
+  smart:
+    first_available:
+      - anthropic/claude-sonnet-4-5
+      - openai/gpt-5
+      - google/gemini-2.5-flash
+      - dmr/ai/qwen3 # local fallback; no API key required
+
+agents:
+  root:
+    model: smart
+    instruction: You are a helpful assistant.
+```
+
+Candidates can be inline `provider/model` references or names from the same `models:` section. Local providers such as `dmr` and `ollama` do not require credentials, so they are useful as final fallbacks.
+
+If none of the candidates has credentials configured, docker-agent reports the missing environment variables grouped by candidate. You only need to configure one group of credentials, not every provider in the list.
+
+A `first_available` model is only a selector. It cannot be combined with `provider`, `model`, `routing`, `token_key`, budgets, sampling options, or other model settings. Put those settings on named candidate models instead:
+
+```yaml
+models:
+  claude:
+    provider: anthropic
+    model: claude-sonnet-4-5
+    max_tokens: 64000
+
+  gpt:
+    provider: openai
+    model: gpt-5
+    thinking_budget: low
+
+  smart:
+    first_available:
+      - claude
+      - gpt
+      - dmr/ai/qwen3
+```
+
+See [`examples/first_available.yaml`](https://github.com/docker/docker-agent/blob/main/examples/first_available.yaml) for a complete example.
 
 ## Thinking Budget
 

--- a/examples/first_available.yaml
+++ b/examples/first_available.yaml
@@ -1,0 +1,17 @@
+agents:
+  root:
+    model: smart
+    description: An agent that uses the first model with configured credentials
+    instruction: |
+      You are a helpful assistant.
+
+models:
+  # `smart` resolves at load time to the first candidate whose credentials are
+  # configured. Candidates are tried top to bottom. The local dmr provider
+  # needs no API key, so it acts as a guaranteed final fallback.
+  smart:
+    first_available:
+      - anthropic/claude-sonnet-4-6
+      - openai/gpt-5
+      - google/gemini-2.5-flash
+      - dmr/ai/qwen3

--- a/pkg/config/examples_test.go
+++ b/pkg/config/examples_test.go
@@ -60,6 +60,11 @@ func TestParseExamples(t *testing.T) {
 			}
 
 			for _, model := range cfg.Models {
+				// Skip first_available selectors - their provider/model is
+				// resolved at load time from the environment's credentials.
+				if model.IsFirstAvailable() {
+					continue
+				}
 				require.NotEmpty(t, model.Provider)
 				require.NotEmpty(t, model.Model)
 				// Skip providers that don't have entries in models.dev

--- a/pkg/config/first_available.go
+++ b/pkg/config/first_available.go
@@ -1,0 +1,282 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/environment"
+	modelprovider "github.com/docker/docker-agent/pkg/model/provider"
+)
+
+// ResolveFirstAvailableModels resolves reachable `first_available` models in the
+// config into concrete provider/model definitions by selecting the first
+// candidate whose credentials are configured. The config is mutated in place so
+// the rest of the pipeline (env-var gathering, model instantiation, runtime
+// switching) sees regular model definitions for models that can be reached from
+// agents, fallbacks, tool model overrides, skills, RAG reranking, or routing.
+//
+// Candidates are tried in order. A candidate is considered available when all
+// the environment variables it requires are set; local providers (dmr, ollama)
+// require none and therefore make reliable final fallbacks. When a models
+// gateway is configured, the first candidate is selected since the gateway
+// supplies the credentials.
+func ResolveFirstAvailableModels(ctx context.Context, cfg *latest.Config, modelsGateway string, env environment.Provider) error {
+	// Snapshot which models are selectors before mutating the map, so the
+	// nested-selector check is independent of map iteration order.
+	selectors := map[string]bool{}
+	for name, m := range cfg.Models {
+		if m.IsFirstAvailable() {
+			selectors[name] = true
+		}
+	}
+	if len(selectors) == 0 {
+		return nil
+	}
+
+	reachable := reachableFirstAvailableModels(cfg, selectors)
+	for _, name := range sortedKeys(reachable) {
+		if err := resolveFirstAvailableModel(ctx, cfg, name, selectors, modelsGateway, env); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func resolveFirstAvailableModel(ctx context.Context, cfg *latest.Config, name string, selectors map[string]bool, modelsGateway string, env environment.Provider) error {
+	m := cfg.Models[name]
+	chosen, ref, err := selectFirstAvailable(ctx, cfg, m.FirstAvailable, selectors, modelsGateway, env)
+	if err != nil {
+		var missingErr *firstAvailableMissingEnvError
+		if errors.As(err, &missingErr) {
+			return missingErr
+		}
+		return fmt.Errorf("model '%s': %w", name, err)
+	}
+
+	slog.DebugContext(ctx, "Resolved first_available model",
+		"model_name", name, "selected", ref, "provider", chosen.Provider, "model", chosen.Model)
+	cfg.Models[name] = chosen
+	return nil
+}
+
+func reachableFirstAvailableModels(cfg *latest.Config, selectors map[string]bool) map[string]bool {
+	reachable := map[string]bool{}
+	seen := map[string]bool{}
+
+	hasRootReference := false
+
+	var visit func(string)
+	visit = func(ref string) {
+		ref = strings.TrimSpace(ref)
+		if ref == "" || seen[ref] {
+			return
+		}
+		hasRootReference = true
+		seen[ref] = true
+
+		model, exists := cfg.Models[ref]
+		if !exists {
+			return
+		}
+		if selectors[ref] {
+			reachable[ref] = true
+			return
+		}
+		for _, rule := range model.Routing {
+			visit(rule.Model)
+		}
+	}
+
+	for _, agent := range cfg.Agents {
+		if agent.Harness == nil {
+			for ref := range strings.SplitSeq(agent.Model, ",") {
+				visit(ref)
+			}
+			for _, ref := range agent.GetFallbackModels() {
+				visit(ref)
+			}
+		}
+
+		for _, toolset := range agent.Toolsets {
+			visit(toolset.Model)
+			if toolset.RAGConfig != nil && toolset.RAGConfig.Results.Reranking != nil {
+				visit(toolset.RAGConfig.Results.Reranking.Model)
+			}
+		}
+
+		for _, skill := range agent.Skills.Inline {
+			if skill.Context == "fork" {
+				visit(skill.Model)
+			}
+		}
+	}
+
+	if !hasRootReference {
+		return selectors
+	}
+
+	return reachable
+}
+
+// selectFirstAvailable returns the config of the first candidate that has
+// credentials configured, along with the reference that was selected.
+func selectFirstAvailable(ctx context.Context, cfg *latest.Config, refs []string, selectors map[string]bool, modelsGateway string, env environment.Provider) (latest.ModelConfig, string, error) {
+	var missingByCandidate []firstAvailableMissingCandidate
+
+	for _, ref := range refs {
+		ref = strings.TrimSpace(ref)
+		if ref == "" {
+			continue
+		}
+
+		candidate, err := resolveCandidate(cfg, ref, selectors)
+		if err != nil {
+			return latest.ModelConfig{}, "", err
+		}
+
+		missing, err := modelMissingCredentials(ctx, cfg, &candidate, modelsGateway, env)
+		if err != nil {
+			return latest.ModelConfig{}, "", err
+		}
+		if len(missing) == 0 {
+			return candidate, ref, nil
+		}
+		missingByCandidate = append(missingByCandidate, firstAvailableMissingCandidate{
+			Ref:     ref,
+			Missing: missing,
+		})
+	}
+
+	if len(missingByCandidate) > 0 {
+		return latest.ModelConfig{}, "", &firstAvailableMissingEnvError{Candidates: missingByCandidate}
+	}
+	return latest.ModelConfig{}, "", fmt.Errorf("no first_available candidate has credentials configured (tried: %s)", strings.Join(refs, ", "))
+}
+
+type firstAvailableMissingCandidate struct {
+	Ref     string
+	Missing []string
+}
+
+type firstAvailableMissingEnvError struct {
+	Candidates []firstAvailableMissingCandidate
+}
+
+var _ error = &firstAvailableMissingEnvError{}
+
+func (e *firstAvailableMissingEnvError) Error() string {
+	var msg strings.Builder
+
+	fmt.Fprintln(&msg, "No 'first_available' candidate has credentials configured.")
+	fmt.Fprintln(&msg, "Set the environment variables for at least one candidate:")
+	for _, candidate := range e.Candidates {
+		fmt.Fprintf(&msg, " - %s: %s\n", candidate.Ref, strings.Join(candidate.Missing, ", "))
+	}
+	fmt.Fprintln(&msg, "\nEither:\n - Set one of those groups of environment variables before running docker agent\n - Run docker agent with --env-from-file\n - Store those secrets using one of the built-in environment variable providers.")
+
+	return msg.String()
+}
+
+// resolveCandidate turns a candidate reference into a ModelConfig. The
+// reference is first looked up as a named model; otherwise it is parsed as an
+// inline "provider/model" spec. A candidate that is itself a first_available
+// selector is rejected to avoid recursive selectors.
+func resolveCandidate(cfg *latest.Config, ref string, selectors map[string]bool) (latest.ModelConfig, error) {
+	if selectors[ref] {
+		return latest.ModelConfig{}, fmt.Errorf("first_available candidate '%s' is itself a first_available selector", ref)
+	}
+	if mc, exists := cfg.Models[ref]; exists {
+		if err := validateCandidateProvider(cfg, ref, mc.Provider); err != nil {
+			return latest.ModelConfig{}, err
+		}
+		return mc, nil
+	}
+
+	parsed, err := latest.ParseModelRef(ref)
+	if err != nil {
+		return latest.ModelConfig{}, fmt.Errorf("first_available candidate '%s' is not a known model nor a valid 'provider/model' spec", ref)
+	}
+	if err := validateCandidateProvider(cfg, ref, parsed.Provider); err != nil {
+		return latest.ModelConfig{}, err
+	}
+	return parsed, nil
+}
+
+func validateCandidateProvider(cfg *latest.Config, ref, provider string) error {
+	if provider == "" || modelprovider.IsKnownProvider(provider) {
+		return nil
+	}
+	if _, exists := cfg.Providers[provider]; exists {
+		return nil
+	}
+	return fmt.Errorf("first_available candidate '%s' uses unknown provider '%s'", ref, provider)
+}
+
+// modelMissingCredentials returns the credentials required by a model that are
+// not configured in the environment. Models that require no env vars (e.g.
+// local dmr/ollama providers) have no missing credentials and are considered
+// available. When a gateway is configured, credentials are supplied by the
+// gateway.
+func modelMissingCredentials(ctx context.Context, cfg *latest.Config, model *latest.ModelConfig, modelsGateway string, env environment.Provider) ([]string, error) {
+	if modelsGateway != "" {
+		return nil, nil
+	}
+
+	required, err := requiredEnvVarsForModelConfig(ctx, model, cfg, env)
+	if err != nil {
+		return nil, err
+	}
+
+	var missing []string
+	for _, name := range sortedKeys(required) {
+		if v, _ := env.Get(ctx, name); v == "" {
+			slog.DebugContext(ctx, "First-available candidate missing credentials", "env", name, "provider", model.Provider, "model", model.Model)
+			missing = append(missing, name)
+		}
+	}
+	return missing, nil
+}
+
+func requiredEnvVarsForModelConfig(ctx context.Context, model *latest.ModelConfig, cfg *latest.Config, env environment.Provider) (map[string]bool, error) {
+	required := map[string]bool{}
+	addEnvVarsForModelConfig(ctx, model, cfg.Providers, required, env)
+
+	for _, rule := range model.Routing {
+		ruleModel, err := resolveRoutingRuleModel(cfg, rule.Model)
+		if err != nil {
+			return nil, err
+		}
+		addEnvVarsForModelConfig(ctx, &ruleModel, cfg.Providers, required, env)
+	}
+
+	return required, nil
+}
+
+func resolveRoutingRuleModel(cfg *latest.Config, ref string) (latest.ModelConfig, error) {
+	if model, exists := cfg.Models[ref]; exists {
+		if model.IsFirstAvailable() {
+			return latest.ModelConfig{}, fmt.Errorf("routing target '%s' is a first_available selector and cannot be used as a first_available candidate dependency", ref)
+		}
+		if len(model.Routing) > 0 {
+			return latest.ModelConfig{}, fmt.Errorf("routing target '%s' has routing rules and cannot be used as a first_available candidate dependency", ref)
+		}
+		if err := validateCandidateProvider(cfg, ref, model.Provider); err != nil {
+			return latest.ModelConfig{}, err
+		}
+		return model, nil
+	}
+
+	parsed, err := latest.ParseModelRef(ref)
+	if err != nil {
+		return latest.ModelConfig{}, fmt.Errorf("routing target '%s' is not a known model nor a valid 'provider/model' spec", ref)
+	}
+	if err := validateCandidateProvider(cfg, ref, parsed.Provider); err != nil {
+		return latest.ModelConfig{}, err
+	}
+	return parsed, nil
+}

--- a/pkg/config/first_available_test.go
+++ b/pkg/config/first_available_test.go
@@ -1,0 +1,394 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/environment"
+)
+
+func TestResolveFirstAvailableModels_SelectsFirstWithCredentials(t *testing.T) {
+	t.Parallel()
+
+	cfg := &latest.Config{
+		Models: map[string]latest.ModelConfig{
+			"smart": {
+				FirstAvailable: []string{
+					"anthropic/claude-sonnet-4-6",
+					"openai/gpt-5",
+					"dmr/ai/qwen3",
+				},
+			},
+		},
+	}
+
+	env := environment.NewMapEnvProvider(map[string]string{
+		"OPENAI_API_KEY": "test-key",
+	})
+
+	require.NoError(t, ResolveFirstAvailableModels(t.Context(), cfg, "", env))
+
+	got := cfg.Models["smart"]
+	assert.Equal(t, "openai", got.Provider)
+	assert.Equal(t, "gpt-5", got.Model)
+	assert.Empty(t, got.FirstAvailable)
+}
+
+func TestResolveFirstAvailableModels_FallsBackToLocalProvider(t *testing.T) {
+	t.Parallel()
+
+	cfg := &latest.Config{
+		Models: map[string]latest.ModelConfig{
+			"smart": {
+				FirstAvailable: []string{
+					"anthropic/claude-sonnet-4-6",
+					"openai/gpt-5",
+					"dmr/ai/qwen3",
+				},
+			},
+		},
+	}
+
+	// No API keys: dmr needs none, so it is selected.
+	require.NoError(t, ResolveFirstAvailableModels(t.Context(), cfg, "", environment.NewNoEnvProvider()))
+
+	got := cfg.Models["smart"]
+	assert.Equal(t, "dmr", got.Provider)
+	assert.Equal(t, "ai/qwen3", got.Model)
+}
+
+func TestResolveFirstAvailableModels_NamedCandidate(t *testing.T) {
+	t.Parallel()
+
+	cfg := &latest.Config{
+		Models: map[string]latest.ModelConfig{
+			"claude": {Provider: "anthropic", Model: "claude-sonnet-4-6"},
+			"gpt":    {Provider: "openai", Model: "gpt-5"},
+			"smart":  {FirstAvailable: []string{"claude", "gpt"}},
+		},
+	}
+
+	env := environment.NewMapEnvProvider(map[string]string{
+		"ANTHROPIC_API_KEY": "test-key",
+	})
+
+	require.NoError(t, ResolveFirstAvailableModels(t.Context(), cfg, "", env))
+
+	got := cfg.Models["smart"]
+	assert.Equal(t, "anthropic", got.Provider)
+	assert.Equal(t, "claude-sonnet-4-6", got.Model)
+}
+
+func TestResolveFirstAvailableModels_SkipsRoutingCandidateWithMissingCredentials(t *testing.T) {
+	t.Parallel()
+
+	cfg := &latest.Config{
+		Models: map[string]latest.ModelConfig{
+			"router": {
+				Provider: "openai",
+				Model:    "gpt-5",
+				Routing: []latest.RoutingRule{
+					{Model: "anthropic/claude-sonnet-4-6", Examples: []string{"reasoning"}},
+				},
+			},
+			"smart": {FirstAvailable: []string{"router", "dmr/ai/qwen3"}},
+		},
+	}
+
+	env := environment.NewMapEnvProvider(map[string]string{
+		"OPENAI_API_KEY": "test-key",
+	})
+
+	require.NoError(t, ResolveFirstAvailableModels(t.Context(), cfg, "", env))
+
+	got := cfg.Models["smart"]
+	assert.Equal(t, "dmr", got.Provider)
+	assert.Equal(t, "ai/qwen3", got.Model)
+}
+
+func TestResolveFirstAvailableModels_RejectsRoutingCandidateWithNestedRouter(t *testing.T) {
+	t.Parallel()
+
+	cfg := &latest.Config{
+		Models: map[string]latest.ModelConfig{
+			"inner_router": {
+				Provider: "openai",
+				Model:    "gpt-5",
+				Routing: []latest.RoutingRule{
+					{Model: "anthropic/claude-sonnet-4-6", Examples: []string{"reasoning"}},
+				},
+			},
+			"outer_router": {
+				Provider: "openai",
+				Model:    "gpt-5",
+				Routing: []latest.RoutingRule{
+					{Model: "inner_router", Examples: []string{"reasoning"}},
+				},
+			},
+			"smart": {FirstAvailable: []string{"outer_router", "dmr/ai/qwen3"}},
+		},
+	}
+
+	err := ResolveFirstAvailableModels(t.Context(), cfg, "", environment.NewMapEnvProvider(map[string]string{
+		"OPENAI_API_KEY": "test-key",
+	}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot be used as a first_available candidate dependency")
+}
+
+func TestResolveFirstAvailableModels_GatewaySelectsFirst(t *testing.T) {
+	t.Parallel()
+
+	cfg := &latest.Config{
+		Models: map[string]latest.ModelConfig{
+			"smart": {
+				FirstAvailable: []string{
+					"anthropic/claude-sonnet-4-6",
+					"openai/gpt-5",
+				},
+			},
+		},
+	}
+
+	require.NoError(t, ResolveFirstAvailableModels(t.Context(), cfg, "gateway:8080", environment.NewNoEnvProvider()))
+
+	got := cfg.Models["smart"]
+	assert.Equal(t, "anthropic", got.Provider)
+	assert.Equal(t, "claude-sonnet-4-6", got.Model)
+}
+
+func TestResolveFirstAvailableModels_NoCandidateAvailable(t *testing.T) {
+	t.Parallel()
+
+	cfg := &latest.Config{
+		Models: map[string]latest.ModelConfig{
+			"smart": {
+				FirstAvailable: []string{
+					"anthropic/claude-sonnet-4-6",
+					"openai/gpt-5",
+				},
+			},
+		},
+	}
+
+	err := ResolveFirstAvailableModels(t.Context(), cfg, "", environment.NewNoEnvProvider())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "No 'first_available' candidate has credentials configured.")
+	assert.Contains(t, err.Error(), "Set the environment variables for at least one candidate:")
+	assert.Contains(t, err.Error(), " - anthropic/claude-sonnet-4-6: ANTHROPIC_API_KEY")
+	assert.Contains(t, err.Error(), " - openai/gpt-5: OPENAI_API_KEY")
+	assert.Contains(t, err.Error(), "Set one of those groups of environment variables")
+	assert.Contains(t, err.Error(), "Run docker agent with --env-from-file")
+}
+
+func TestResolveFirstAvailableModels_InvalidCandidate(t *testing.T) {
+	t.Parallel()
+
+	cfg := &latest.Config{
+		Models: map[string]latest.ModelConfig{
+			"smart": {FirstAvailable: []string{"not-a-valid-ref"}},
+		},
+	}
+
+	err := ResolveFirstAvailableModels(t.Context(), cfg, "", environment.NewNoEnvProvider())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a known model")
+}
+
+func TestResolveFirstAvailableModels_UnknownProvider(t *testing.T) {
+	t.Parallel()
+
+	cfg := &latest.Config{
+		Models: map[string]latest.ModelConfig{
+			"smart": {FirstAvailable: []string{"unknown/model", "dmr/ai/qwen3"}},
+		},
+	}
+
+	err := ResolveFirstAvailableModels(t.Context(), cfg, "", environment.NewNoEnvProvider())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "uses unknown provider 'unknown'")
+}
+
+func TestResolveFirstAvailableModels_RejectsNestedSelector(t *testing.T) {
+	t.Parallel()
+
+	cfg := &latest.Config{
+		Models: map[string]latest.ModelConfig{
+			"inner": {FirstAvailable: []string{"dmr/ai/qwen3"}},
+			"smart": {FirstAvailable: []string{"inner"}},
+		},
+	}
+
+	err := ResolveFirstAvailableModels(t.Context(), cfg, "", environment.NewNoEnvProvider())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "itself a first_available selector")
+}
+
+func TestValidateFirstAvailable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		model   latest.ModelConfig
+		wantErr string
+	}{
+		{
+			name:  "valid",
+			model: latest.ModelConfig{FirstAvailable: []string{"openai/gpt-5"}},
+		},
+		{
+			name:    "empty list",
+			model:   latest.ModelConfig{FirstAvailable: []string{}},
+			wantErr: "must contain at least one candidate",
+		},
+		{
+			name:    "combined with provider/model",
+			model:   latest.ModelConfig{Provider: "openai", Model: "gpt-5", FirstAvailable: []string{"openai/gpt-5"}},
+			wantErr: "cannot be combined with provider/model",
+		},
+		{
+			name: "combined with routing",
+			model: latest.ModelConfig{
+				FirstAvailable: []string{"openai/gpt-5"},
+				Routing:        []latest.RoutingRule{{Model: "openai/gpt-5", Examples: []string{"x"}}},
+			},
+			wantErr: "cannot be combined with routing",
+		},
+		{
+			name:    "combined with token key",
+			model:   latest.ModelConfig{FirstAvailable: []string{"openai/gpt-5"}, TokenKey: "CUSTOM_API_KEY"},
+			wantErr: "cannot be combined with token_key",
+		},
+		{
+			name:    "combined with model options",
+			model:   latest.ModelConfig{FirstAvailable: []string{"openai/gpt-5"}, ProviderOpts: map[string]any{"project": "p"}},
+			wantErr: "cannot be combined with provider_opts",
+		},
+		{
+			name:    "combined with auth",
+			model:   latest.ModelConfig{FirstAvailable: []string{"anthropic/claude-sonnet-4-6"}, Auth: &latest.AuthConfig{Type: "anthropic_wif"}},
+			wantErr: "cannot be combined with auth",
+		},
+		{
+			name:    "empty candidate",
+			model:   latest.ModelConfig{FirstAvailable: []string{"  "}},
+			wantErr: "must not be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := latest.Config{Models: map[string]latest.ModelConfig{"smart": tt.model}}
+			err := cfg.Validate()
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestResolveFirstAvailableModels_IgnoresUnusedUnavailableSelector(t *testing.T) {
+	t.Parallel()
+
+	cfg := &latest.Config{
+		Agents: []latest.AgentConfig{{Name: "agent", Model: "used"}},
+		Models: map[string]latest.ModelConfig{
+			"used":   {FirstAvailable: []string{"dmr/ai/qwen3"}},
+			"unused": {FirstAvailable: []string{"anthropic/claude-sonnet-4-6"}},
+		},
+	}
+
+	require.NoError(t, ResolveFirstAvailableModels(t.Context(), cfg, "", environment.NewNoEnvProvider()))
+
+	assert.Equal(t, "dmr", cfg.Models["used"].Provider)
+	unused := cfg.Models["unused"]
+	assert.True(t, unused.IsFirstAvailable())
+}
+
+func TestResolveFirstAvailableModels_GeminiCredentialsFromEnvProvider(t *testing.T) {
+	t.Parallel()
+
+	cfg := &latest.Config{
+		Agents: []latest.AgentConfig{{Name: "agent", Model: "smart"}},
+		Models: map[string]latest.ModelConfig{
+			"smart": {FirstAvailable: []string{"google/gemini-2.5-pro", "dmr/ai/qwen3"}},
+		},
+	}
+	env := environment.NewMapEnvProvider(map[string]string{"GEMINI_API_KEY": "test-key"})
+
+	require.NoError(t, ResolveFirstAvailableModels(t.Context(), cfg, "", env))
+
+	got := cfg.Models["smart"]
+	assert.Equal(t, "google", got.Provider)
+	assert.Equal(t, "gemini-2.5-pro", got.Model)
+}
+
+func TestResolveFirstAvailableModels_ProcessEnvDoesNotAffectGeminiSelection(t *testing.T) {
+	t.Setenv("GEMINI_API_KEY", "process-key")
+
+	cfg := &latest.Config{
+		Agents: []latest.AgentConfig{{Name: "agent", Model: "smart"}},
+		Models: map[string]latest.ModelConfig{
+			"smart": {FirstAvailable: []string{"google/gemini-2.5-pro", "dmr/ai/qwen3"}},
+		},
+	}
+
+	require.NoError(t, ResolveFirstAvailableModels(t.Context(), cfg, "", environment.NewNoEnvProvider()))
+
+	got := cfg.Models["smart"]
+	assert.Equal(t, "dmr", got.Provider)
+	assert.Equal(t, "ai/qwen3", got.Model)
+}
+
+func TestResolveFirstAvailableModels_RejectsRoutingTargetFirstAvailableSelector(t *testing.T) {
+	t.Parallel()
+
+	cfg := &latest.Config{
+		Agents: []latest.AgentConfig{{Name: "agent", Model: "smart"}},
+		Models: map[string]latest.ModelConfig{
+			"nested": {FirstAvailable: []string{"anthropic/claude-sonnet-4-6"}},
+			"router": {
+				Provider: "openai",
+				Model:    "gpt-5",
+				Routing: []latest.RoutingRule{
+					{Model: "nested", Examples: []string{"reasoning"}},
+				},
+			},
+			"smart": {FirstAvailable: []string{"router", "dmr/ai/qwen3"}},
+		},
+	}
+
+	err := ResolveFirstAvailableModels(t.Context(), cfg, "", environment.NewMapEnvProvider(map[string]string{
+		"OPENAI_API_KEY": "test-key",
+	}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "routing target 'nested' is a first_available selector")
+}
+
+func TestResolveFirstAvailableModels_SelectsUnauthenticatedCustomProvider(t *testing.T) {
+	t.Parallel()
+
+	cfg := &latest.Config{
+		Agents: []latest.AgentConfig{{Name: "agent", Model: "smart"}},
+		Providers: map[string]latest.ProviderConfig{
+			"local_openai": {BaseURL: "http://localhost:1234/v1"},
+		},
+		Models: map[string]latest.ModelConfig{
+			"smart": {FirstAvailable: []string{"local_openai/qwen3", "dmr/ai/qwen3"}},
+		},
+	}
+
+	require.NoError(t, ResolveFirstAvailableModels(t.Context(), cfg, "", environment.NewNoEnvProvider()))
+
+	got := cfg.Models["smart"]
+	assert.Equal(t, "local_openai", got.Provider)
+	assert.Equal(t, "qwen3", got.Model)
+}

--- a/pkg/config/gather.go
+++ b/pkg/config/gather.go
@@ -22,7 +22,7 @@ func gatherMissingEnvVars(ctx context.Context, cfg *latest.Config, modelsGateway
 
 	// Models
 	if modelsGateway == "" {
-		names := GatherEnvVarsForModels(cfg)
+		names := GatherEnvVarsForModels(ctx, cfg, env)
 		for _, e := range names {
 			requiredEnv[e] = true
 		}
@@ -50,7 +50,7 @@ func gatherMissingEnvVars(ctx context.Context, cfg *latest.Config, modelsGateway
 	return missing, toolErr
 }
 
-func GatherEnvVarsForModels(cfg *latest.Config) []string {
+func GatherEnvVarsForModels(ctx context.Context, cfg *latest.Config, env environment.Provider) []string {
 	requiredEnv := map[string]bool{}
 
 	// Inspect only the models that are actually used by docker-agent model-backed agents.
@@ -61,7 +61,7 @@ func GatherEnvVarsForModels(cfg *latest.Config) []string {
 		modelNames := strings.SplitSeq(agent.Model, ",")
 		for modelName := range modelNames {
 			modelName = strings.TrimSpace(modelName)
-			gatherEnvVarsForModel(cfg, modelName, requiredEnv)
+			gatherEnvVarsForModel(ctx, cfg, modelName, requiredEnv, env)
 		}
 	}
 
@@ -70,29 +70,29 @@ func GatherEnvVarsForModels(cfg *latest.Config) []string {
 
 // gatherEnvVarsForModel collects required environment variables for a single model,
 // including any models referenced in its routing rules.
-func gatherEnvVarsForModel(cfg *latest.Config, modelName string, requiredEnv map[string]bool) {
+func gatherEnvVarsForModel(ctx context.Context, cfg *latest.Config, modelName string, requiredEnv map[string]bool, env environment.Provider) {
 	model := cfg.Models[modelName]
 
 	// Add env vars for the model itself
-	addEnvVarsForModelConfig(&model, cfg.Providers, requiredEnv)
+	addEnvVarsForModelConfig(ctx, &model, cfg.Providers, requiredEnv, env)
 
 	// If the model has routing rules, also check all referenced models
 	for _, rule := range model.Routing {
 		ruleModelName := rule.Model
 		if ruleModel, exists := cfg.Models[ruleModelName]; exists {
 			// Model reference - add its env vars
-			addEnvVarsForModelConfig(&ruleModel, cfg.Providers, requiredEnv)
+			addEnvVarsForModelConfig(ctx, &ruleModel, cfg.Providers, requiredEnv, env)
 		} else if providerName, _, ok := strings.Cut(ruleModelName, "/"); ok {
 			// Inline spec (e.g., "openai/gpt-4o") - infer env vars from provider
 			inlineModel := latest.ModelConfig{Provider: providerName}
-			addEnvVarsForModelConfig(&inlineModel, cfg.Providers, requiredEnv)
+			addEnvVarsForModelConfig(ctx, &inlineModel, cfg.Providers, requiredEnv, env)
 		}
 	}
 }
 
 // addEnvVarsForModelConfig adds required environment variables for a model config.
 // It checks custom providers first, then built-in aliases, then hardcoded fallbacks.
-func addEnvVarsForModelConfig(model *latest.ModelConfig, customProviders map[string]latest.ProviderConfig, requiredEnv map[string]bool) {
+func addEnvVarsForModelConfig(ctx context.Context, model *latest.ModelConfig, customProviders map[string]latest.ProviderConfig, requiredEnv map[string]bool, env environment.Provider) {
 	// A model with non-API-key auth (e.g. Workload Identity Federation) does
 	// not require a TokenKey or the hardcoded API-key env var. Instead, the
 	// env vars referenced by its identity-token source are required.
@@ -105,32 +105,41 @@ func addEnvVarsForModelConfig(model *latest.ModelConfig, customProviders map[str
 
 	if model.TokenKey != "" {
 		requiredEnv[model.TokenKey] = true
-	} else if customProviders != nil {
+		return
+	}
+	if model.BaseURL != "" {
+		return
+	}
+	if customProviders != nil {
 		// Check custom providers from config
 		if provCfg, exists := customProviders[model.Provider]; exists {
 			if provCfg.TokenKey != "" {
 				requiredEnv[provCfg.TokenKey] = true
-			} else {
-				// Fall through to check the effective provider type
+			} else if provCfg.BaseURL == "" {
+				// Custom providers with a base_url and no token_key are intentionally
+				// unauthenticated; native provider aliases without a base_url use the
+				// effective provider's default credentials.
 				effective := provCfg.Provider
 				if effective == "" {
 					effective = "openai"
 				}
-				addEnvVarsForCoreProvider(effective, model, requiredEnv)
+				addEnvVarsForCoreProvider(ctx, effective, model, requiredEnv, env)
 			}
+			return
 		}
-	} else if alias, exists := provider.LookupAlias(model.Provider); exists {
+	}
+	if alias, exists := provider.LookupAlias(model.Provider); exists {
 		// Check built-in aliases
 		if alias.TokenEnvVar != "" {
 			requiredEnv[alias.TokenEnvVar] = true
 		}
 	} else {
-		addEnvVarsForCoreProvider(model.Provider, model, requiredEnv)
+		addEnvVarsForCoreProvider(ctx, model.Provider, model, requiredEnv, env)
 	}
 }
 
 // addEnvVarsForCoreProvider adds the required env vars for a core provider type.
-func addEnvVarsForCoreProvider(providerType string, model *latest.ModelConfig, requiredEnv map[string]bool) {
+func addEnvVarsForCoreProvider(ctx context.Context, providerType string, model *latest.ModelConfig, requiredEnv map[string]bool, env environment.Provider) {
 	switch providerType {
 	case "openai":
 		requiredEnv["OPENAI_API_KEY"] = true
@@ -138,10 +147,10 @@ func addEnvVarsForCoreProvider(providerType string, model *latest.ModelConfig, r
 		requiredEnv["ANTHROPIC_API_KEY"] = true
 	case "google":
 		if model.ProviderOpts["project"] == nil && model.ProviderOpts["location"] == nil {
-			if os.Getenv("GOOGLE_GENAI_USE_VERTEXAI") != "" {
+			if value, _ := env.Get(ctx, "GOOGLE_GENAI_USE_VERTEXAI"); value != "" {
 				requiredEnv["GOOGLE_CLOUD_PROJECT"] = true
 				requiredEnv["GOOGLE_CLOUD_LOCATION"] = true
-			} else if _, exist := os.LookupEnv("GEMINI_API_KEY"); !exist {
+			} else if value, _ := env.Get(ctx, "GEMINI_API_KEY"); value == "" {
 				requiredEnv["GOOGLE_API_KEY"] = true
 			}
 		}

--- a/pkg/config/gather_auth_test.go
+++ b/pkg/config/gather_auth_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/environment"
 )
 
 func TestGatherEnvVarsForModels_WIFAuth(t *testing.T) {
@@ -127,7 +128,7 @@ func TestGatherEnvVarsForModels_WIFAuth(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GatherEnvVarsForModels(tt.cfg)
+			got := GatherEnvVarsForModels(t.Context(), tt.cfg, environment.NewNoEnvProvider())
 			for _, want := range tt.wantPresent {
 				assert.Contains(t, got, want, "expected %q in %v", want, got)
 			}

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -813,6 +813,18 @@ type ModelConfig struct {
 	// - The provider/model fields define the fallback model
 	// - Each routing rule maps to a different model based on examples
 	Routing []RoutingRule `json:"routing,omitempty"`
+	// FirstAvailable lists candidate model references, in priority order.
+	// At load time docker-agent selects the first candidate whose credentials
+	// are configured. Candidates may be named models or inline "provider/model"
+	// specs. Local providers (dmr, ollama) need no credentials and make reliable
+	// final fallbacks. When set, other model configuration fields must be empty.
+	FirstAvailable []string `json:"first_available,omitempty"`
+}
+
+// IsFirstAvailable reports whether this model is a first-available selector
+// (i.e. it picks the first candidate with configured credentials).
+func (m *ModelConfig) IsFirstAvailable() bool {
+	return m != nil && m.FirstAvailable != nil
 }
 
 // Clone returns a deep copy of the ModelConfig.
@@ -895,7 +907,8 @@ func (f *FlexibleModelConfig) isShorthandOnly() bool {
 		f.TrackUsage == nil &&
 		f.ThinkingBudget == nil &&
 		f.TaskBudget == nil &&
-		len(f.Routing) == 0
+		len(f.Routing) == 0 &&
+		f.FirstAvailable == nil
 }
 
 // RoutingRule defines a single routing rule for model selection.

--- a/pkg/config/latest/validate.go
+++ b/pkg/config/latest/validate.go
@@ -25,6 +25,9 @@ func (t *Config) Validate() error {
 		}
 	}
 	for name, m := range t.Models {
+		if err := m.validateFirstAvailable(); err != nil {
+			return fmt.Errorf("models.%s: %w", name, err)
+		}
 		if err := m.Auth.Validate(EffectiveProviderType(m, t.Providers)); err != nil {
 			return fmt.Errorf("models.%s: %w", name, err)
 		}
@@ -53,6 +56,66 @@ func (t *Config) Validate() error {
 		}
 	}
 
+	return nil
+}
+
+// validateFirstAvailable validates a model's first_available selector. The
+// selector is mutually exclusive with other model configuration fields, and
+// every candidate reference must be non-empty.
+func (m *ModelConfig) validateFirstAvailable() error {
+	if m.FirstAvailable == nil {
+		return nil
+	}
+	if len(m.FirstAvailable) == 0 {
+		return errors.New("first_available must contain at least one candidate")
+	}
+	if m.Provider != "" || m.Model != "" {
+		return errors.New("first_available cannot be combined with provider/model")
+	}
+	if m.Temperature != nil {
+		return errors.New("first_available cannot be combined with temperature")
+	}
+	if m.MaxTokens != nil {
+		return errors.New("first_available cannot be combined with max_tokens")
+	}
+	if m.TopP != nil {
+		return errors.New("first_available cannot be combined with top_p")
+	}
+	if m.FrequencyPenalty != nil {
+		return errors.New("first_available cannot be combined with frequency_penalty")
+	}
+	if m.PresencePenalty != nil {
+		return errors.New("first_available cannot be combined with presence_penalty")
+	}
+	if m.BaseURL != "" {
+		return errors.New("first_available cannot be combined with base_url")
+	}
+	if m.TokenKey != "" {
+		return errors.New("first_available cannot be combined with token_key")
+	}
+	if len(m.ProviderOpts) > 0 {
+		return errors.New("first_available cannot be combined with provider_opts")
+	}
+	if m.TrackUsage != nil {
+		return errors.New("first_available cannot be combined with track_usage")
+	}
+	if m.ThinkingBudget != nil {
+		return errors.New("first_available cannot be combined with thinking_budget")
+	}
+	if m.TaskBudget != nil {
+		return errors.New("first_available cannot be combined with task_budget")
+	}
+	if m.Auth != nil {
+		return errors.New("first_available cannot be combined with auth")
+	}
+	if len(m.Routing) > 0 {
+		return errors.New("first_available cannot be combined with routing")
+	}
+	for i, ref := range m.FirstAvailable {
+		if strings.TrimSpace(ref) == "" {
+			return fmt.Errorf("first_available[%d] must not be empty", i)
+		}
+	}
 	return nil
 }
 

--- a/pkg/config/model_alias.go
+++ b/pkg/config/model_alias.go
@@ -20,6 +20,10 @@ import (
 func ResolveModelAliases(ctx context.Context, cfg *latest.Config, store *modelsdev.Store) {
 	// Resolve model aliases in the models section
 	for name, modelCfg := range cfg.Models {
+		if modelCfg.IsFirstAvailable() || isInlineModelEntry(name, modelCfg) {
+			continue
+		}
+
 		// Skip alias resolution for models with custom base_url (direct or via provider)
 		// Custom endpoints like Azure Foundry use alias names as deployment names
 		if hasCustomBaseURL(&modelCfg, cfg.Providers) {
@@ -44,6 +48,10 @@ func ResolveModelAliases(ctx context.Context, cfg *latest.Config, store *modelsd
 		}
 		cfg.Models[name] = modelCfg
 	}
+}
+
+func isInlineModelEntry(name string, modelCfg latest.ModelConfig) bool {
+	return name == modelCfg.Provider+"/"+modelCfg.Model
 }
 
 // hasCustomBaseURL checks if a model config has a custom base_url, either directly

--- a/pkg/config/model_alias_test.go
+++ b/pkg/config/model_alias_test.go
@@ -122,6 +122,19 @@ func TestResolveModelAliases(t *testing.T) {
 			},
 		},
 		{
+			name: "does not resolve inline model entries added for CLI overrides",
+			cfg: &latest.Config{
+				Models: map[string]latest.ModelConfig{
+					"anthropic/claude-sonnet-4-5": {Provider: "anthropic", Model: "claude-sonnet-4-5"},
+				},
+			},
+			expected: &latest.Config{
+				Models: map[string]latest.ModelConfig{
+					"anthropic/claude-sonnet-4-5": {Provider: "anthropic", Model: "claude-sonnet-4-5"},
+				},
+			},
+		},
+		{
 			name: "resolves routing rules",
 			cfg: &latest.Config{
 				Models: map[string]latest.ModelConfig{
@@ -229,6 +242,19 @@ func TestResolveModelAliases(t *testing.T) {
 						Provider: "my_anthropic",
 						Model:    "claude-sonnet-4-5", // NOT resolved - custom provider name
 					},
+				},
+			},
+		},
+		{
+			name: "skips first_available selector",
+			cfg: &latest.Config{
+				Models: map[string]latest.ModelConfig{
+					"smart": {FirstAvailable: []string{"anthropic/claude-sonnet-4-5"}},
+				},
+			},
+			expected: &latest.Config{
+				Models: map[string]latest.ModelConfig{
+					"smart": {FirstAvailable: []string{"anthropic/claude-sonnet-4-5"}},
 				},
 			},
 		},

--- a/pkg/sandbox/sandbox.go
+++ b/pkg/sandbox/sandbox.go
@@ -350,7 +350,7 @@ func gatherAgentEnvVars(ctx context.Context, agentRef string, env environment.Pr
 	}
 
 	var names []string
-	names = append(names, config.GatherEnvVarsForModels(cfg)...)
+	names = append(names, config.GatherEnvVarsForModels(ctx, cfg, env)...)
 
 	toolNames, err := config.GatherEnvVarsForTools(ctx, cfg)
 	if err != nil {

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -110,8 +110,6 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 	modelsStore, err := runConfig.ModelsDevStore()
 	if err != nil {
 		slog.DebugContext(ctx, "Failed to create modelsdev store for alias resolution", "error", err)
-	} else {
-		config.ResolveModelAliases(ctx, cfg, modelsStore)
 	}
 
 	// Apply model overrides from CLI flags before checking required env vars
@@ -121,6 +119,18 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 
 	// Early check for required env vars before loading models and tools.
 	env := runConfig.EnvProvider()
+
+	// Resolve `first_available` model selectors into concrete provider/model
+	// definitions now that the environment is available, so the rest of the
+	// pipeline sees regular model definitions.
+	if err := config.ResolveFirstAvailableModels(ctx, cfg, runConfig.ModelsGateway, env); err != nil {
+		return nil, err
+	}
+
+	if modelsStore != nil {
+		config.ResolveModelAliases(ctx, cfg, modelsStore)
+	}
+
 	if err := config.CheckRequiredEnvVars(ctx, cfg, runConfig.ModelsGateway, env); err != nil {
 		return nil, err
 	}

--- a/pkg/teamloader/teamloader_test.go
+++ b/pkg/teamloader/teamloader_test.go
@@ -131,7 +131,7 @@ func gatherExampleEnvVars(t *testing.T, examples []string) map[string]bool {
 		cfg, err := config.Load(t.Context(), agentSource)
 		require.NoError(t, err)
 
-		for _, env := range config.GatherEnvVarsForModels(cfg) {
+		for _, env := range config.GatherEnvVarsForModels(t.Context(), cfg, environment.NewOsEnvProvider()) {
 			envs[env] = true
 		}
 		toolEnvs, _ := config.GatherEnvVarsForTools(t.Context(), cfg)


### PR DESCRIPTION
This adds a `first_available` model selector to the config schema. It enables automatic fallback across multiple model candidates by resolving the first reachable one with configured credentials, including support for local dmr and ollama fallbacks.

The implementation automatically tries each candidate in order until one succeeds based on available credentials. If no candidates can be resolved, it reports grouped missing-credential errors indicating that at least one candidate group is needed. During alias resolution, unresolved selectors are skipped, allowing other aliases to proceed.

The change includes an example configuration, comprehensive tests, and all necessary schema updates.

## Validation

```bash
go test ./pkg/config/... ./pkg/teamloader/... ./pkg/runtime/...
task build
task lint
```