### PR TITLE
fix: don't drop tool call when finish_reason shares the chunk

### DIFF
--- a/pkg/runtime/streaming.go
+++ b/pkg/runtime/streaming.go
@@ -129,33 +129,12 @@ func handleStream(ctx context.Context, stream chat.MessageStream, a *agent.Agent
 			thoughtSignature = choice.Delta.ThoughtSignature
 		}
 
-		if choice.FinishReason == chat.FinishReasonStop || choice.FinishReason == chat.FinishReasonLength {
-			recordUsage()
-			applyXMLFallback()
-			finishReason := choice.FinishReason
-			if finishReason == chat.FinishReasonStop && len(toolCalls) > 0 {
-				finishReason = chat.FinishReasonToolCalls
-			}
-			return streamResult{
-				Calls:             toolCalls,
-				Content:           fullContent.String(),
-				ReasoningContent:  fullReasoningContent.String(),
-				ThinkingSignature: thinkingSignature,
-				ThoughtSignature:  thoughtSignature,
-				Stopped:           len(toolCalls) == 0, // stop only when there are no tool calls to execute
-				FinishReason:      finishReason,
-				Usage:             messageUsage,
-			}, nil
-		}
-
-		// Track the provider's explicit finish reason (e.g. tool_calls) so we
-		// can prefer it over inference after the loop.  stop/length are already
-		// handled by the early return above.
-		if choice.FinishReason != "" {
-			providerFinishReason = choice.FinishReason
-		}
-
-		// Handle tool calls
+		// Accumulate tool call deltas from this chunk *before* evaluating the
+		// finish reason below. Some OpenAI-compatible providers (e.g. LiteLLM
+		// in front of Gemini) pack a complete tool call and a terminal
+		// finish_reason ("stop") into the same chunk; handling the finish
+		// reason first would drop the call and the turn would end with an
+		// empty assistant message ("No response from agent").
 		if len(choice.Delta.ToolCalls) > 0 {
 			// Process each tool call delta
 			for _, delta := range choice.Delta.ToolCalls {
@@ -208,7 +187,38 @@ func handleStream(ctx context.Context, stream chat.MessageStream, a *agent.Agent
 					}
 				}
 			}
-			continue
+			// Short-circuit only when the chunk carried nothing but tool call
+			// deltas. If it also carries a terminal finish reason, fall through
+			// so the early return below sees the freshly accumulated call.
+			if choice.FinishReason == "" {
+				continue
+			}
+		}
+
+		if choice.FinishReason == chat.FinishReasonStop || choice.FinishReason == chat.FinishReasonLength {
+			recordUsage()
+			applyXMLFallback()
+			finishReason := choice.FinishReason
+			if finishReason == chat.FinishReasonStop && len(toolCalls) > 0 {
+				finishReason = chat.FinishReasonToolCalls
+			}
+			return streamResult{
+				Calls:             toolCalls,
+				Content:           fullContent.String(),
+				ReasoningContent:  fullReasoningContent.String(),
+				ThinkingSignature: thinkingSignature,
+				ThoughtSignature:  thoughtSignature,
+				Stopped:           len(toolCalls) == 0, // stop only when there are no tool calls to execute
+				FinishReason:      finishReason,
+				Usage:             messageUsage,
+			}, nil
+		}
+
+		// Track the provider's explicit finish reason (e.g. tool_calls) so we
+		// can prefer it over inference after the loop.  stop/length are already
+		// handled by the early return above.
+		if choice.FinishReason != "" {
+			providerFinishReason = choice.FinishReason
 		}
 
 		if choice.Delta.ReasoningContent != "" {

--- a/pkg/runtime/streaming_test.go
+++ b/pkg/runtime/streaming_test.go
@@ -1,0 +1,89 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+// AddToolCallWithStop appends a single chunk that carries BOTH a complete tool
+// call AND a terminal finish_reason ("stop"), the way LiteLLM/Gemini emit a
+// function call atomically. The OpenAI-native streaming protocol never does
+// this (the tool call deltas and the terminal finish_reason live in separate
+// chunks), which is why this case was never exercised before.
+func (b *streamBuilder) AddToolCallWithStop(id, name, args string) *streamBuilder {
+	b.responses = append(b.responses, chat.MessageStreamResponse{
+		Choices: []chat.MessageStreamChoice{{
+			Index:        0,
+			FinishReason: chat.FinishReasonStop,
+			Delta: chat.MessageDelta{ToolCalls: []tools.ToolCall{{
+				ID:       id,
+				Type:     "function",
+				Function: tools.FunctionCall{Name: name, Arguments: args},
+			}}},
+		}},
+		Usage: &chat.Usage{InputTokens: 1, OutputTokens: 1},
+	})
+	return b
+}
+
+// TestHandleStream_ToolCallAndStopInSameChunk reproduces the LiteLLM/Gemini bug
+// where a subagent's tool call is silently dropped because the provider packs
+// the tool call and finish_reason:"stop" into the same streaming chunk. The
+// dropped tool call leaves the assistant message empty, which surfaces upstream
+// as "No response from agent".
+func TestHandleStream_ToolCallAndStopInSameChunk(t *testing.T) {
+	stream := newStreamBuilder().
+		AddToolCallWithStop("call_1", "company_search", `{"query":"x"}`).
+		Build()
+
+	a := agent.New("root", "test", agent.WithModel(&mockProvider{id: "test/mock-model", stream: stream}))
+	sess := session.New(session.WithUserMessage("go"))
+
+	evCh := make(chan Event, 64) // buffered so handleStream never blocks on Emit
+	res, err := handleStream(
+		t.Context(), stream, a, nil, sess, nil,
+		defaultTelemetry{}, NewChannelSink(evCh),
+	)
+	require.NoError(t, err)
+
+	require.Len(t, res.Calls, 1, "the tool call from the terminal chunk must not be dropped")
+	assert.Equal(t, "company_search", res.Calls[0].Function.Name)
+	assert.JSONEq(t, `{"query":"x"}`, res.Calls[0].Function.Arguments)
+	assert.Equal(t, chat.FinishReasonToolCalls, res.FinishReason)
+	assert.False(t, res.Stopped, "must not stop: a tool call is pending execution")
+}
+
+// TestHandleStream_ToolCallThenSeparateStop is the OpenAI-native shape: the tool
+// call deltas arrive first, then a separate terminal chunk carries the finish
+// reason. This already works today and guards against a regression when fixing
+// the same-chunk case above.
+func TestHandleStream_ToolCallThenSeparateStop(t *testing.T) {
+	stream := newStreamBuilder().
+		AddToolCallName("call_1", "company_search").
+		AddToolCallArguments("call_1", `{"query":"x"}`).
+		AddStopWithUsage(1, 1).
+		Build()
+
+	a := agent.New("root", "test", agent.WithModel(&mockProvider{id: "test/mock-model", stream: stream}))
+	sess := session.New(session.WithUserMessage("go"))
+
+	evCh := make(chan Event, 64)
+	res, err := handleStream(
+		t.Context(), stream, a, nil, sess, nil,
+		defaultTelemetry{}, NewChannelSink(evCh),
+	)
+	require.NoError(t, err)
+
+	require.Len(t, res.Calls, 1)
+	assert.Equal(t, "company_search", res.Calls[0].Function.Name)
+	assert.JSONEq(t, `{"query":"x"}`, res.Calls[0].Function.Arguments)
+	assert.Equal(t, chat.FinishReasonToolCalls, res.FinishReason)
+	assert.False(t, res.Stopped)
+}


### PR DESCRIPTION
Fixes #1544

## Problem
With OpenAI-compatible proxies like LiteLLM (e.g. in front of Gemini), a subagent's valid `tool_calls` response is dropped and the host agent reports "no response from subagent" without executing the tool.

## Root cause
`handleStream` (pkg/runtime/streaming.go) checked the terminal `finish_reason` **before** accumulating the current chunk's tool call deltas. The OpenAI-native protocol sends them in separate chunks, but LiteLLM/Gemini packs the tool call and the terminal `finish_reason` into a single chunk. The early return then saw `len(toolCalls) == 0` and dropped the call, leaving an empty assistant message.

## Fix
Accumulate tool call deltas before evaluating the finish reason; only short-circuit the iteration when the chunk has no terminal finish reason.

## Tests
- `TestHandleStream_ToolCallAndStopInSameChunk` — regression test (red before, green after).
- `TestHandleStream_ToolCallThenSeparateStop` — guards the OpenAI-native path.