### PR TITLE
refactor(coder): use first_available model selection with multi-provider fallbacks

### DIFF
--- a/pkg/config/builtin-agents/coder.yaml
+++ b/pkg/config/builtin-agents/coder.yaml
@@ -1,10 +1,16 @@
 models:
   default:
-    provider: anthropic
-    model: claude-opus-4-6
-  haiku:
-    provider: anthropic
-    model: claude-haiku-4-5
+    first_available:
+      - anthropic/claude-opus-4-8
+      - openai/gpt-5.5
+      - google/gemini-3.5-flash
+      - dmr/ai/qwen3
+  fast:
+    first_available:
+      - anthropic/claude-haiku-4-5
+      - openai/gpt-5.4-mini
+      - google/gemini-3.1-flash-lite
+      - dmr/ai/qwen3
 
 agents:
   root:
@@ -185,7 +191,7 @@ agents:
         agent: root
 
   librarian:
-    model: haiku
+    model: fast
     description: Web Researcher
     instruction: |
       You search the web for documentation, articles, and technical references.


### PR DESCRIPTION
The builtin coder agent previously hardcoded Anthropic models, which meant users without Anthropic credentials had to manually configure alternative providers. This change leverages the new `first_available` model selection feature to work seamlessly with any configured provider.

The coder agent's `default` and `fast` models now each list candidate provider/model combinations across Anthropic, OpenAI, and Google, with a fallback to the local `dmr` model. The agent automatically selects the first available option based on the user's configured credentials, eliminating the need for manual configuration in most cases.

The `fast` model was renamed from `haiku` for consistency, and the librarian sub-agent reference was updated accordingly.