### PR TITLE
docs: update agent config reference, custom provider api_type, and slash command behavior

### DIFF
--- a/docs/configuration/agents/index.md
+++ b/docs/configuration/agents/index.md
@@ -264,7 +264,7 @@ agents:
 
 Define reusable prompt shortcuts that can send prompts to the current agent or switch to a different sub-agent:
 
-> **Note:** Named slash commands execute immediately, even while the agent is processing another message. Unlike regular chat messages (which are queued), slash commands interrupt the current operation and run right away.
+> **Note:** Named slash commands execute immediately, even while the agent is processing another message. Unlike regular chat messages (which are queued), slash commands interrupt or direct the agent even while it is mid-response.
 
 ```yaml
 agents:

--- a/docs/configuration/agents/index.md
+++ b/docs/configuration/agents/index.md
@@ -264,6 +264,8 @@ agents:
 
 Define reusable prompt shortcuts that can send prompts to the current agent or switch to a different sub-agent:
 
+> **Note:** Named slash commands execute immediately, even while the agent is processing another message. Unlike regular chat messages (which are queued), slash commands interrupt the current operation and run right away.
+
 ```yaml
 agents:
   root:

--- a/docs/configuration/agents/index.md
+++ b/docs/configuration/agents/index.md
@@ -34,6 +34,8 @@ agents:
     max_old_tool_call_tokens: int # Optional: token budget for old tool call content
     num_history_items: int # Optional: limit conversation history
     skills: boolean | [list] # Optional: enable skill discovery (true/false or list of names and/or sources)
+    use_commands: [list] # Optional: names of top-level commands groups to merge into this agent
+    use_skills: [list] # Optional: names of top-level skills groups to merge into this agent
     commands: # Optional: named prompts
       name: "prompt text" # or {instruction: "prompt", agent: "sub_agent_name"}
     welcome_message: string # Optional: message shown at session start
@@ -92,6 +94,8 @@ agents:
 | `num_history_items`         | int     | ✗        | Limit the number of conversation history messages sent to the model. Useful for managing context window size with long conversations. Default: unlimited (all messages sent). |
 | `skills`                    | bool/array | ✗     | Enable automatic skill discovery. `true` loads all discovered local skills, `false` disables them. A list can mix skill sources (`local` or `https://…` URLs) and skill names to include — see [Skills]({{ '/features/skills/' | relative_url }}).                                                     |
 | `commands`                  | object  | ✗        | Named prompts that can be run with `docker agent run config.yaml /command_name`. Can be simple strings or objects with `instruction` and/or `agent` fields for agent switching. See [Named Commands](#named-commands) below. |
+| `use_commands`              | list of string | ✗   | Names of top-level `commands` groups to merge into this agent. Inline `commands` entries take precedence on name conflicts. Default: `[]`. |
+| `use_skills`                | list of string | ✗   | Names of top-level `skills` groups to merge into this agent. Inline skills are deduplicated by name against merged entries. Default: `[]`. |
 | `welcome_message`           | string  | ✗        | Message displayed to the user when a session starts. Rendered as Markdown in the TUI. **Not sent to the model** — it exists purely for the user's benefit. Useful for telling users what the agent can do and what commands are available. |
 | `handoffs`                  | array   | ✗        | List of agent names this agent can hand off the conversation to. Enables the `handoff` tool. See [Handoffs Routing]({{ '/concepts/multi-agent/#handoffs-routing' | relative_url }}).                  |
 | `hooks`                     | object  | ✗        | Lifecycle hooks for running commands at various points. See [Hooks]({{ '/configuration/hooks/' | relative_url }}).                                                                                   |

--- a/docs/configuration/overview/index.md
+++ b/docs/configuration/overview/index.md
@@ -393,7 +393,7 @@ agents:
     use_commands: [ci]        # same group, reused without duplication
 ```
 
-See [`examples/shared-commands-skills.yaml`](https://github.com/docker/cagent/blob/main/examples/shared-commands-skills.yaml) for a complete example.
+See [`examples/shared-commands-skills.yaml`](https://github.com/docker/docker-agent/blob/main/examples/shared-commands-skills.yaml) for a complete example.
 
 ## Custom Providers Section
 

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -73,6 +73,8 @@ Type `/` during a session to see available commands, or press <kbd>Ctrl</kbd>+<k
 | `/speak`           | Voice input via system speech-to-text (macOS only)                                   |
 | `/exit`            | Exit the application (aliases: `/quit`, `/q`)                                        |
 
+Slash commands (both built-in and named) execute immediately when entered. Regular chat messages are queued and processed in order. This means you can invoke a slash command to interrupt or direct the agent even while it is mid-response.
+
 ### Thinking and Tool Details
 
 Reasoning/thinking blocks are collapsed by default. When collapsed, the TUI shows a short preview and compact tool summaries. Expand a block to see the full thinking content and the real tool renderers, including detailed tool output such as file edit diffs.

--- a/docs/providers/custom/index.md
+++ b/docs/providers/custom/index.md
@@ -97,7 +97,7 @@ agents:
 | Property              | Type       | Description                                                                           | Default                  |
 | --------------------- | ---------- | ------------------------------------------------------------------------------------- | ------------------------ |
 | `provider`            | string     | Underlying provider type: `openai`, `anthropic`, `google`, `amazon-bedrock`, `dmr`, etc. | `openai`                 |
-| `api_type`            | string     | API schema: `openai_chatcompletions` or `openai_responses`. Only for OpenAI-compatible providers. | `openai_chatcompletions` |
+| `api_type`            | string     | API schema: `openai_chatcompletions` or `openai_responses`. Only for OpenAI-compatible providers. When omitted, the API type is selected automatically based on the model name: newer models (gpt-4.1, o-series, gpt-5, Codex) default to `openai_responses`; all others default to `openai_chatcompletions`. | `auto (model-dependent)` |
 | `base_url`            | string     | Base URL for the API endpoint. Required for OpenAI-compatible providers, optional for native providers. | —                        |
 | `token_key`           | string     | Environment variable name containing the API token.                                   | —                        |
 | `unload_api`          | string     | Optional path (or absolute URL) to the provider's model-unload endpoint. Used by the [`unload`]({{ '/configuration/hooks/#available-built-ins' | relative_url }}) built-in hook to release model resources between agent switches. Relative paths resolve against `base_url`'s scheme + host; absolute URLs are used verbatim. Today only Docker Model Runner ships a provider that calls this endpoint; cloud providers don't implement the underlying interface and the hook silently skips them. | —                        |
@@ -157,6 +157,8 @@ Only applicable for OpenAI-compatible providers (when `provider` is `openai` or 
 
 - **`openai_chatcompletions`** — Standard OpenAI Chat Completions API. Works with most OpenAI-compatible endpoints.
 - **`openai_responses`** — OpenAI Responses API. For newer models that require the Responses API format.
+
+> If `api_type` is not set, docker-agent automatically selects the API type based on the model name. You only need to set `api_type` explicitly to override the detected default.
 
 ## Examples
 


### PR DESCRIPTION
## Documentation updates for recently merged features

This PR brings the `/docs` content in sync with three features merged into `main`.

### Changes

| Commit | Source PR | What changed |
|--------|-----------|-------------|
| 67170bb | [#2971](https://github.com/docker/docker-agent/pull/2971) | Add `use_commands`/`use_skills` to agent reference; fix broken example link |
| 06b3dac | [#2985](https://github.com/docker/docker-agent/pull/2985) | Document `api_type` auto-detection for custom OpenAI providers |
| 372ef2a | [#2979](https://github.com/docker/docker-agent/pull/2979) | Clarify that named slash commands execute immediately, not queued |

### Details

**`docs/configuration/agents/index.md`** — Adds `use_commands` and `use_skills` to the Full Schema YAML example and Properties Reference table (from #2971). Also adds a note that named slash commands execute immediately (from #2979).

**`docs/configuration/overview/index.md`** — Fixes broken link pointing to wrong repo (`cagent` → `docker-agent`) in the shared skills/commands example (from #2971).

**`docs/providers/custom/index.md`** — Updates `api_type` default from hardcoded `openai_chatcompletions` to `auto (model-dependent)` and documents the auto-detection logic for newer OpenAI models (from #2985).

**`docs/features/tui/index.md`** — Adds note about immediate slash command execution vs queued chat messages (from #2979).