### PR TITLE
docs: update default model examples to gpt-5 and gemini-3.5-flash

### DIFF
--- a/docs/configuration/overview/index.md
+++ b/docs/configuration/overview/index.md
@@ -194,7 +194,7 @@ API keys and secrets are read from environment variables — never stored in con
 
 | Variable                            | Description                                                                                          |
 | ----------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `DOCKER_AGENT_DEFAULT_MODEL`        | Default model used when none is specified, in `provider/model` form (e.g. `openai/gpt-5-mini`).      |
+| `DOCKER_AGENT_DEFAULT_MODEL`        | Default model used when none is specified, in `provider/model` form (e.g. `openai/gpt-5`).      |
 | `DOCKER_AGENT_MODELS_GATEWAY`       | Route model traffic through a gateway. Equivalent to the `--models-gateway` flag.                    |
 | `DOCKER_AGENT_HIDE_TELEMETRY_BANNER`| Set to `1` to suppress the first-run telemetry notice.                                               |
 | `DOCKER_AGENT_AUTO_UPDATE`          | Set to a truthy value (`1`, `true`, `yes`, `on`) to let standalone release binaries self-update before running. See [Optional Self-Updates]({{ '/getting-started/installation/#optional-self-updates' | relative_url }}). |

--- a/docs/providers/google/index.md
+++ b/docs/providers/google/index.md
@@ -38,7 +38,7 @@ export GOOGLE_CLOUD_LOCATION="us-central1"
 ```yaml
 agents:
   root:
-    model: google/gemini-2.5-flash
+    model: google/gemini-3.5-flash
 ```
 
 ### Named Model
@@ -47,7 +47,7 @@ agents:
 models:
   gemini:
     provider: google
-    model: gemini-2.5-flash
+    model: gemini-3.5-flash
     temperature: 0.5
 ```
 

--- a/docs/providers/openai/index.md
+++ b/docs/providers/openai/index.md
@@ -22,7 +22,7 @@ export OPENAI_API_KEY="sk-..."
 ```yaml
 agents:
   root:
-    model: openai/gpt-5-mini
+    model: openai/gpt-5
 ```
 
 ### Named Model
@@ -31,7 +31,7 @@ agents:
 models:
   gpt:
     provider: openai
-    model: gpt-5-mini
+    model: gpt-5
     temperature: 0.7
     max_tokens: 4000
 ```


### PR DESCRIPTION
## Documentation updates for recently merged features

This PR brings the `/docs` content in sync with changes merged into `main` in the last 36 hours.

### Changes

| Commit | Source PR | What changed |
|--------|-----------|-------------|
| 57b6f53a | [#2997](https://github.com/docker/docker-agent/pull/2997) | Update default model examples: `gpt-5-mini` → `gpt-5`, `gemini-2.5-flash` → `gemini-3.5-flash` |

### Details

**`docs/configuration/overview/index.md`** — Updates the `DOCKER_AGENT_DEFAULT_MODEL` environment variable example value from `openai/gpt-5-mini` to `openai/gpt-5`, reflecting the bumped default in PR #2997.

**`docs/providers/openai/index.md`** — Updates the primary inline and named model examples from `gpt-5-mini` to `gpt-5`. The Available Models table is left intact — `gpt-5-mini` remains a valid model and is correctly listed there.

**`docs/providers/google/index.md`** — Updates the primary inline and named model examples from `gemini-2.5-flash` to `gemini-3.5-flash`. The Available Models table is left intact — `gemini-2.5-flash` remains a valid model and is correctly listed there.

### PRs reviewed but no doc changes needed

| Source PR | Reason |
|-----------|--------|
| [#3000](https://github.com/docker/docker-agent/pull/3000) | Hooks docs (`docs/configuration/hooks/index.md`) were updated as part of the PR itself |
| [#2999](https://github.com/docker/docker-agent/pull/2999) | Already a docs-only PR |
| [#2996](https://github.com/docker/docker-agent/pull/2996) | Coder agent model rename (`haiku` → `fast`) has no doc references — only `claude-haiku-4-5` (a real model name) appears in docs, not the internal config alias |
| [#2995](https://github.com/docker/docker-agent/pull/2995) | Dependency bump — no user-facing changes |
| [#2993](https://github.com/docker/docker-agent/pull/2993) | Self-update docs were included in the PR itself |