### PR TITLE
docs: sync config examples with updated default models (gpt-5, gemini-3.5-flash)

### DIFF
--- a/docs/configuration/models/index.md
+++ b/docs/configuration/models/index.md
@@ -66,9 +66,9 @@ Use `first_available` when the same agent should work with whichever provider cr
 models:
   smart:
     first_available:
-      - anthropic/claude-sonnet-4-5
+      - anthropic/claude-sonnet-4-6
       - openai/gpt-5
-      - google/gemini-2.5-flash
+      - google/gemini-3.5-flash
       - dmr/ai/qwen3 # local fallback; no API key required
 
 agents:
@@ -87,7 +87,7 @@ A `first_available` model is only a selector. It cannot be combined with `provid
 models:
   claude:
     provider: anthropic
-    model: claude-sonnet-4-5
+    model: claude-sonnet-4-6
     max_tokens: 64000
 
   gpt:

--- a/docs/configuration/overview/index.md
+++ b/docs/configuration/overview/index.md
@@ -83,7 +83,7 @@ The simplest possible configuration — a single agent with an inline model:
 ```yaml
 agents:
   root:
-    model: openai/gpt-5-mini
+    model: openai/gpt-5
     description: A helpful assistant
     instruction: You are a helpful assistant.
 ```
@@ -92,7 +92,7 @@ The same config in HCL:
 
 ```hcl
 agent "root" {
-  model       = "openai/gpt-5-mini"
+  model       = "openai/gpt-5"
   description = "A helpful assistant"
   instruction = "You are a helpful assistant."
 }
@@ -106,7 +106,7 @@ Models can be referenced inline or defined in the `models` section:
   <div class="card" style="cursor:default;">
     <h3>Inline</h3>
     <p>Quick and simple. Use <code>provider/model</code> syntax directly.</p>
-    <pre style="margin-top:12px"><code class="language-yaml">model: openai/gpt-5-mini</code></pre>
+    <pre style="margin-top:12px"><code class="language-yaml">model: openai/gpt-5</code></pre>
   </div>
   <div class="card" style="cursor:default;">
     <h3>Named</h3>
@@ -311,7 +311,7 @@ version: 8
 
 agents:
   root:
-    model: openai/gpt-5-mini
+    model: openai/gpt-5
     # ...
 ```
 
@@ -357,7 +357,7 @@ mcps:
 
 agents:
   root:
-    model: openai/gpt-5-mini
+    model: openai/gpt-5
     toolsets:
       - type: mcp
         ref: github        # reuse the definition above
@@ -383,13 +383,13 @@ skills:
 
 agents:
   root:
-    model: openai/gpt-5-mini
+    model: openai/gpt-5
     use_commands: [ci]        # reuse the "ci" command group
     use_skills: [base]        # reuse the "base" skill group
     commands:
       lint: "Run the linter"  # inline command, merged in (wins on conflict)
   reviewer:
-    model: openai/gpt-5-mini
+    model: openai/gpt-5
     use_commands: [ci]        # same group, reused without duplication
 ```
 


### PR DESCRIPTION
## Documentation updates for recently merged features

This PR brings the `/docs` content in sync with changes merged into `main` in the last 36 hours.

### Changes

| Commit | Source PR | What changed |
|--------|-----------|-------------|
| `5dbd717c` | [#2997](https://github.com/docker/docker-agent/pull/2997) | Update 7 code examples in config overview: `gpt-5-mini` → `gpt-5` |
| `79b0a736` | [#2997](https://github.com/docker/docker-agent/pull/2997) | Update `first_available` example: `claude-sonnet-4-5` → `claude-sonnet-4-6`, `gemini-2.5-flash` → `gemini-3.5-flash` |

### Details

**`docs/configuration/overview/index.md`** — PR #3003 (merged 2026-06-05) updated the `DOCKER_AGENT_DEFAULT_MODEL` env var description but left 7 YAML/HCL code examples still showing `openai/gpt-5-mini`. These are the "Minimal Config", "Inline model card", "Config Versioning", "Reusable MCPs", and "Reusable Commands & Skills" examples — all generic how-to snippets that should use the current default model. The case-sensitivity callout (`openai/gpt-5-mini is not the same as openai/GPT-5-mini`) is intentionally left unchanged since it references a real valid model.

**`docs/configuration/models/index.md`** — The `first_available` section example used `claude-sonnet-4-5` and `gemini-2.5-flash` as candidates, reflecting the old defaults. Updated to `claude-sonnet-4-6` and `gemini-3.5-flash` to match the current defaults from PR #2997. The Available Models table listing `gemini-2.5-flash` as a valid model is unchanged.

### PRs reviewed and found up to date

| Source PR | Reason |
|-----------|--------|
| [#3004](https://github.com/docker/docker-agent/pull/3004) | Docs-only PR — all changes applied within the PR itself |
| [#3003](https://github.com/docker/docker-agent/pull/3003) | Docs-only PR — partially applied; remaining gaps fixed in this PR |
| [#3001](https://github.com/docker/docker-agent/pull/3001) | Internal bugfix (drop orphaned tool results on session resume) — no user-facing documentation impact |