### PR TITLE
docs: update remaining gpt-5-mini → gpt-5 examples across docs

### DIFF
--- a/docs/community/troubleshooting/index.md
+++ b/docs/community/troubleshooting/index.md
@@ -149,7 +149,7 @@ docker-agent validates config at startup and reports errors with line numbers. C
 ### Missing references
 
 - Local agents in `sub_agents` must be defined in the `agents` section (external OCI references like `agentcatalog/pirate` are resolved from registries automatically)
-- Named model references must exist in the `models` section (or use inline format like `openai/gpt-5-mini`)
+- Named model references must exist in the `models` section (or use inline format like `openai/gpt-5`)
 - RAG source names referenced by agents must be defined in the `rag` section
 
 ### Toolset validation

--- a/docs/concepts/agents/index.md
+++ b/docs/concepts/agents/index.md
@@ -47,7 +47,7 @@ Every docker-agent configuration has a **root agent** — the entry point that r
 
 | Property               | Type    | Required | Description                                                    |
 | ---------------------- | ------- | -------- | -------------------------------------------------------------- |
-| `model`                | string  | ✓        | Model reference (inline like `openai/gpt-5-mini` or a named model) |
+| `model`                | string  | ✓        | Model reference (inline like `openai/gpt-5` or a named model) |
 | `description`          | string  | ✓        | What the agent does — used by other agents for delegation      |
 | `instruction`          | string  | ✓        | System prompt defining behavior                                |
 | `toolsets`             | array   | ✗        | List of tool configurations                                    |
@@ -69,7 +69,7 @@ agents:
     model: anthropic/claude-sonnet-4-5
     fallback:
       models:
-        - openai/gpt-5-mini
+        - openai/gpt-5
         - google/gemini-2.5-flash
       retries: 2 # retries per model for 5xx errors
       cooldown: 1m # stick with fallback after 429
@@ -82,7 +82,7 @@ Define reusable prompts that can be invoked as commands:
 ```yaml
 agents:
   root:
-    model: openai/gpt-5-mini
+    model: openai/gpt-5
     instruction: You are a helpful assistant.
     commands:
       df: "Check how much free space I have on my disk"

--- a/docs/concepts/agents/index.md
+++ b/docs/concepts/agents/index.md
@@ -70,7 +70,7 @@ agents:
     fallback:
       models:
         - openai/gpt-5
-        - google/gemini-2.5-flash
+        - google/gemini-3.5-flash
       retries: 2 # retries per model for 5xx errors
       cooldown: 1m # stick with fallback after 429
 ```

--- a/docs/concepts/distribution/index.md
+++ b/docs/concepts/distribution/index.md
@@ -73,7 +73,7 @@ Registry agents can be used directly as sub-agents in a multi-agent configuratio
 ```yaml
 agents:
   root:
-    model: openai/gpt-5-mini
+    model: openai/gpt-5
     description: Coordinator
     instruction: Delegate tasks to the right sub-agent.
     sub_agents:

--- a/docs/concepts/models/index.md
+++ b/docs/concepts/models/index.md
@@ -19,7 +19,7 @@ Use the `provider/model` shorthand directly in the agent definition:
 ```yaml
 agents:
   root:
-    model: openai/gpt-5-mini
+    model: openai/gpt-5
     instruction: You are a helpful assistant.
 ```
 
@@ -125,7 +125,7 @@ models:
 
   fast-responder:
     provider: openai
-    model: gpt-5-mini
+    model: gpt-5
     thinking_budget: none # disable thinking
 ```
 
@@ -143,7 +143,7 @@ models:
 ```yaml
 agents:
   root:
-    model: anthropic/claude-sonnet-4-5,openai/gpt-5-mini
+    model: anthropic/claude-sonnet-4-5,openai/gpt-5
     instruction: You are a helpful assistant.
 ```
 

--- a/docs/concepts/models/index.md
+++ b/docs/concepts/models/index.md
@@ -74,7 +74,7 @@ for details.
 | ------------------- | ---------------- | ------------------------------------ | ----------------------------------- |
 | OpenAI              | `openai`         | gpt-5, gpt-5-mini, gpt-4o            | `OPENAI_API_KEY`                    |
 | Anthropic           | `anthropic`      | claude-sonnet-4-5, claude-opus-4-7   | `ANTHROPIC_API_KEY`                 |
-| Google              | `google`         | gemini-2.5-flash, gemini-3-pro       | `GOOGLE_API_KEY` / `GEMINI_API_KEY` |
+| Google              | `google`         | gemini-3.5-flash, gemini-3-pro       | `GOOGLE_API_KEY` / `GEMINI_API_KEY` |
 | AWS Bedrock         | `amazon-bedrock` | Claude, Nova, Llama models           | AWS credentials                     |
 | Docker Model Runner | `dmr`            | ai/qwen3, ai/llama3.2                | None (local)                        |
 | Mistral             | `mistral`        | Mistral models                       | `MISTRAL_API_KEY`                   |

--- a/docs/concepts/multi-agent/index.md
+++ b/docs/concepts/multi-agent/index.md
@@ -120,7 +120,7 @@ agents:
       - researcher
 
   researcher:
-    model: openai/gpt-5-mini
+    model: openai/gpt-5
     description: Web researcher
     instruction: |
       Search the web, then hand off to the summarizer.
@@ -131,7 +131,7 @@ agents:
       - summarizer
 
   summarizer:
-    model: openai/gpt-5-mini
+    model: openai/gpt-5
     description: Summarizes findings
     instruction: |
       Summarize the research results, then hand off
@@ -190,7 +190,7 @@ Sub-agents don't have to be defined locally — you can reference agents from OC
 ```yaml
 agents:
   root:
-    model: openai/gpt-5-mini
+    model: openai/gpt-5
     description: Coordinator that delegates to local and catalog sub-agents
     instruction: |
       Delegate tasks to the most appropriate sub-agent.
@@ -199,7 +199,7 @@ agents:
       - agentcatalog/pirate # pulled from registry automatically
 
   local_helper:
-    model: openai/gpt-5-mini
+    model: openai/gpt-5
     description: A local helper agent for simple tasks
     instruction: You are a helpful assistant.
 ```
@@ -283,7 +283,7 @@ agents:
       - type: think
 
   reviewer:
-    model: openai/gpt-5-mini
+    model: openai/gpt-5
     description: Code review specialist
     instruction: |
       You review code for quality, security, and maintainability.
@@ -292,7 +292,7 @@ agents:
       - type: filesystem
 
   tester:
-    model: openai/gpt-5-mini
+    model: openai/gpt-5
     description: Quality assurance engineer
     instruction: |
       You write tests and ensure software quality. Run tests
@@ -317,7 +317,7 @@ agents:
       - type: think
 
   researcher:
-    model: openai/gpt-5-mini
+    model: openai/gpt-5
     description: Web researcher
     instruction: Search the web and gather information.
     toolsets:
@@ -342,7 +342,7 @@ A key advantage of multi-agent systems is using different models for different r
 models:
   fast:
     provider: openai
-    model: gpt-5-mini
+    model: gpt-5
     temperature: 0.2 # precise
 
   creative:

--- a/docs/concepts/multi-agent/index.md
+++ b/docs/concepts/multi-agent/index.md
@@ -342,7 +342,7 @@ A key advantage of multi-agent systems is using different models for different r
 models:
   fast:
     provider: openai
-    model: gpt-5
+    model: gpt-5-mini
     temperature: 0.2 # precise
 
   creative:

--- a/docs/configuration/agents/index.md
+++ b/docs/configuration/agents/index.md
@@ -76,7 +76,7 @@ agents:
 
 | Property                    | Type    | Required | Description                                                                                                                                                                   |
 | --------------------------- | ------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `model`                     | string  | ✓        | Model reference. Either inline (`openai/gpt-5-mini`) or a named model from the `models` section.                                                                              |
+| `model`                     | string  | ✓        | Model reference. Either inline (`openai/gpt-5`) or a named model from the `models` section.                                                                              |
 | `description`               | string  | ✓        | Brief description of the agent's purpose. Used by coordinators to decide delegation.                                                                                          |
 | `instruction`               | string  | ✓        | System prompt that defines the agent's behavior, personality, and constraints.                                                                                                |
 | `sub_agents`                | array   | ✗        | List of agent names or external OCI references this agent can delegate to. Supports local agents, registry references (e.g., `agentcatalog/pirate`), and named references (`name:reference`). Automatically enables the `transfer_task` tool. See [External Sub-Agents]({{ '/concepts/multi-agent/#external-sub-agents-from-registries' | relative_url }}). |
@@ -117,7 +117,7 @@ The response cache short-circuits the model when the same user question is asked
 ```yaml
 agents:
   root:
-    model: openai/gpt-5-mini
+    model: openai/gpt-5
     description: Cached assistant
     instruction: You are a helpful assistant.
     cache:
@@ -162,7 +162,7 @@ The `redact_secrets` flag is a single agent-level switch that scrubs accidentall
 ```yaml
 agents:
   root:
-    model: openai/gpt-5-mini
+    model: openai/gpt-5
     description: A helpful assistant that scrubs secrets before they leak
     instruction: |
       You are a helpful assistant. If the user accidentally pastes a token,
@@ -202,7 +202,7 @@ Display a message when users start a session:
 ```yaml
 agents:
   assistant:
-    model: openai/gpt-5-mini
+    model: openai/gpt-5
     description: Development assistant
     instruction: You are a helpful coding assistant.
     welcome_message: |
@@ -254,7 +254,7 @@ agents:
     model: anthropic/claude-sonnet-4-5
     fallback:
       models:
-        - openai/gpt-5-mini
+        - openai/gpt-5
         - google/gemini-2.5-flash
       retries: 2
       cooldown: 1m
@@ -269,7 +269,7 @@ Define reusable prompt shortcuts that can send prompts to the current agent or s
 ```yaml
 agents:
   root:
-    model: openai/gpt-5-mini
+    model: openai/gpt-5
     instruction: You are a system administrator.
     commands:
       df: "Check how much free space I have on my disk"
@@ -314,7 +314,7 @@ Commands with an `agent` field switch the active agent for that command's scope.
 ```yaml
 agents:
   root:
-    model: openai/gpt-5-mini
+    model: openai/gpt-5
     description: Main assistant
     instruction: You are a project coordinator.
     sub_agents: [planner, reviewer]
@@ -330,7 +330,7 @@ agents:
       status: "Summarize what we have accomplished so far"
 
   planner:
-    model: openai/gpt-5-mini
+    model: openai/gpt-5
     description: Planning specialist
     instruction: You create detailed project plans.
 
@@ -389,7 +389,7 @@ agents:
     add_date: true
     add_environment_info: true
     fallback:
-      models: [openai/gpt-5-mini]
+      models: [openai/gpt-5]
     toolsets:
       - type: think
     commands:
@@ -411,7 +411,7 @@ agents:
       - type: todo
 
   researcher:
-    model: openai/gpt-5-mini
+    model: openai/gpt-5
     description: Web researcher with memory
     instruction: Search for information and remember findings.
     toolsets:

--- a/docs/configuration/agents/index.md
+++ b/docs/configuration/agents/index.md
@@ -255,7 +255,7 @@ agents:
     fallback:
       models:
         - openai/gpt-5
-        - google/gemini-2.5-flash
+        - google/gemini-3.5-flash
       retries: 2
       cooldown: 1m
 ```

--- a/docs/configuration/hcl/index.md
+++ b/docs/configuration/hcl/index.md
@@ -22,7 +22,7 @@ _Write docker-agent configs in HCL instead of YAML. It maps to the same docker-a
 #!/usr/bin/env docker agent run
 
 agent "root" {
-  model       = "openai/gpt-5-mini"
+  model       = "openai/gpt-5"
   description = "A helpful assistant"
   instruction = <<-EOT
   You are a helpful assistant.
@@ -133,7 +133,7 @@ Instead of writing list entries with `type: ...`, HCL uses a `toolset` block who
 
 ```hcl
 agent "root" {
-  model       = "openai/gpt-5-mini"
+  model       = "openai/gpt-5"
   description = "Dev assistant"
   instruction = "You can inspect and modify code."
 
@@ -151,7 +151,7 @@ Agent commands are often nicer to write in HCL because each command gets its own
 
 ```hcl
 agent "root" {
-  model       = "openai/gpt-5-mini"
+  model       = "openai/gpt-5"
   description = "Build helper"
   instruction = "You help with builds."
 
@@ -168,7 +168,7 @@ Use quoted strings for short values and heredocs for long prompts, welcome messa
 
 ```hcl
 agent "root" {
-  model       = "openai/gpt-5-mini"
+  model       = "openai/gpt-5"
   description = "Friendly assistant"
 
   instruction = <<-EOT
@@ -206,7 +206,7 @@ For example, model routing rules become repeated `routing { ... }` blocks:
 ```hcl
 model "smart_router" {
   provider = "openai"
-  model    = "gpt-5-mini"
+  model    = "gpt-5"
 
   routing {
     model    = "anthropic/claude-sonnet-4-5"

--- a/docs/configuration/models/index.md
+++ b/docs/configuration/models/index.md
@@ -116,7 +116,7 @@ Uses effort levels as strings:
 models:
   gpt:
     provider: openai
-    model: gpt-5-mini
+    model: gpt-5
     thinking_budget: low # minimal | low | medium | high | xhigh | max | adaptive/<level>
 ```
 
@@ -278,7 +278,7 @@ models:
   # OpenAI
   gpt:
     provider: openai
-    model: gpt-5-mini
+    model: gpt-5
 
   # Anthropic
   claude:

--- a/docs/configuration/models/index.md
+++ b/docs/configuration/models/index.md
@@ -43,7 +43,7 @@ models:
 | --------------------- | ---------- | -------- | ------------------------------------------------------------------------------------- |
 | `first_available`     | array      | ✗        | Candidate model references tried in order; selects the first whose credentials are configured. Mutually exclusive with other model settings. |
 | `provider`            | string     | ✓/✗      | Required for regular model definitions; omitted for `first_available` selectors. Provider: `openai`, `anthropic`, `google`, `amazon-bedrock`, `dmr`, `mistral`, `xai`, `nebius`, `minimax`, `requesty`, `azure`, `ollama`, `github-copilot`, or any [named provider]({{ '/providers/custom/' | relative_url }}). |
-| `model`               | string     | ✓/✗      | Required for regular model definitions; omitted for `first_available` selectors. Model name (e.g., `gpt-4o`, `claude-sonnet-4-5`, `gemini-2.5-flash`) |
+| `model`               | string     | ✓/✗      | Required for regular model definitions; omitted for `first_available` selectors. Model name (e.g., `gpt-4o`, `claude-sonnet-4-5`, `gemini-3.5-flash`) |
 | `temperature`         | float      | ✗        | Sampling randomness. Range is provider-dependent — typically `0.0–2.0` (Anthropic caps at `1.0`). `0.0` is deterministic. |
 | `max_tokens`          | int        | ✗        | Maximum response length in tokens                                                     |
 | `top_p`               | float      | ✗        | Nucleus sampling threshold (`0.0–1.0`)                                                |
@@ -140,7 +140,7 @@ Uses an integer token budget. `0` disables, `-1` lets the model decide:
 models:
   gemini:
     provider: google
-    model: gemini-2.5-flash
+    model: gemini-3.5-flash
     thinking_budget: -1 # dynamic (default)
 ```
 
@@ -289,7 +289,7 @@ models:
   # Google Gemini
   gemini:
     provider: google
-    model: gemini-2.5-flash
+    model: gemini-3.5-flash
     temperature: 0.5
 
   # AWS Bedrock

--- a/docs/configuration/overview/index.md
+++ b/docs/configuration/overview/index.md
@@ -209,7 +209,7 @@ API keys and secrets are read from environment variables — never stored in con
 <div class="callout callout-warning" markdown="1">
 <div class="callout-title">Important
 </div>
-  <p>Model references are case-sensitive: <code>openai/gpt-5-mini</code> is not the same as <code>openai/GPT-5-mini</code>.</p>
+  <p>Model references are case-sensitive: <code>openai/gpt-5</code> is not the same as <code>openai/GPT-5</code>.</p>
 
 </div>
 

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -151,7 +151,7 @@ $ docker agent new [flags]
 
 # Examples
 $ docker agent new
-$ docker agent new --model openai/gpt-5-mini
+$ docker agent new --model openai/gpt-5
 $ docker agent new --model dmr/ai/gemma3-qat:12B --max-iterations 15
 ```
 

--- a/docs/features/mcp-mode/index.md
+++ b/docs/features/mcp-mode/index.md
@@ -112,7 +112,7 @@ agents:
     description: Main coordinator
     sub_agents: [designer, engineer]
   designer:
-    model: openai/gpt-5-mini
+    model: openai/gpt-5
     description: UI/UX design specialist
   engineer:
     model: anthropic/claude-sonnet-4-5

--- a/docs/features/mcp-mode/index.md
+++ b/docs/features/mcp-mode/index.md
@@ -112,7 +112,7 @@ agents:
     description: Main coordinator
     sub_agents: [designer, engineer]
   designer:
-    model: openai/gpt-5
+    model: openai/gpt-5-mini
     description: UI/UX design specialist
   engineer:
     model: anthropic/claude-sonnet-4-5

--- a/docs/getting-started/introduction/index.md
+++ b/docs/getting-started/introduction/index.md
@@ -85,7 +85,7 @@ At its core, Docker Agent follows a simple loop:
 # A minimal agent definition
 agents:
   root:
-    model: openai/gpt-5-mini
+    model: openai/gpt-5
     description: A helpful assistant
     instruction: You are a helpful assistant.
     toolsets:

--- a/docs/getting-started/quickstart/index.md
+++ b/docs/getting-started/quickstart/index.md
@@ -40,7 +40,7 @@ Use the `docker agent new` command to scaffold a config file through prompts:
 $ docker agent new
 
 # Or specify options directly
-$ docker agent new --model openai/gpt-5-mini
+$ docker agent new --model openai/gpt-5
 
 # Override iteration limits
 $ docker agent new --model dmr/ai/gemma3-qat:12B --max-iterations 15

--- a/docs/guides/go-sdk/index.md
+++ b/docs/guides/go-sdk/index.md
@@ -300,7 +300,7 @@ anthropicClient, _ := anthropic.NewClient(ctx, &latest.ModelConfig{
 // Google Gemini
 geminiClient, _ := gemini.NewClient(ctx, &latest.ModelConfig{
     Provider: "google",
-    Model:    "gemini-2.5-flash",
+    Model:    "gemini-3.5-flash",
 }, env)
 ```
 

--- a/docs/guides/secrets/index.md
+++ b/docs/guides/secrets/index.md
@@ -241,7 +241,7 @@ For that defense-in-depth case, set `redact_secrets: true` on an agent. It scrub
 ```yaml
 agents:
   root:
-    model: openai/gpt-5-mini
+    model: openai/gpt-5
     description: A helpful assistant
     instruction: You are a helpful assistant.
     redact_secrets: true

--- a/docs/providers/overview/index.md
+++ b/docs/providers/overview/index.md
@@ -94,7 +94,7 @@ models:
     max_tokens: 64000
   gpt:
     provider: openai
-    model: gpt-5-mini
+    model: gpt-5
   local:
     provider: dmr
     model: ai/qwen3
@@ -104,7 +104,7 @@ agents:
     model: claude # coordinator uses Claude
     sub_agents: [coder, helper]
   coder:
-    model: gpt # coder uses GPT-5-mini
+    model: gpt # coder uses GPT-5
   helper:
     model: local # helper runs locally for free
 ```

--- a/docs/tools/mcp/index.md
+++ b/docs/tools/mcp/index.md
@@ -130,7 +130,7 @@ mcps:
 
 agents:
   root:
-    model: openai/gpt-5-mini
+    model: openai/gpt-5
     toolsets:
       - type: mcp
         ref: github


### PR DESCRIPTION
## Documentation updates

This PR completes the documentation sync for PR #2997 and PR #3012, updating the remaining `gpt-5-mini` → `gpt-5` and `gemini-2.5-flash` → `gemini-3.5-flash` references in generic how-to examples across the docs.

### Source PRs
- [#2997](https://github.com/docker/docker-agent/pull/2997) — updated OpenAI default from `gpt-5-mini` to `gpt-5`, Google default from `gemini-2.5-flash` to `gemini-3.5-flash`
- [#3012](https://github.com/docker/docker-agent/pull/3012) — partial doc sync (covered `configuration/overview` and `configuration/models`)

### Commits

**Commit 1** — `gpt-5-mini` → `gpt-5` in generic how-to examples:
- `docs/configuration/hcl/index.md`
- `docs/configuration/agents/index.md`
- `docs/configuration/models/index.md`
- `docs/concepts/multi-agent/index.md`
- `docs/concepts/models/index.md`
- `docs/concepts/agents/index.md`
- `docs/concepts/distribution/index.md`
- `docs/features/mcp-mode/index.md`
- `docs/features/cli/index.md`
- `docs/getting-started/introduction/index.md`
- `docs/getting-started/quickstart/index.md`
- `docs/guides/secrets/index.md`
- `docs/tools/mcp/index.md`
- `docs/community/troubleshooting/index.md`
- `docs/providers/overview/index.md`

**Commit 2** — `gemini-2.5-flash` → `gemini-3.5-flash` in generic how-to examples:
- `docs/configuration/agents/index.md`
- `docs/concepts/agents/index.md`
- `docs/configuration/models/index.md`
- `docs/guides/go-sdk/index.md`
- `docs/concepts/models/index.md`

**Commit 3** — revert contrast-example model names back to `gpt-5-mini`:
- `docs/concepts/multi-agent/index.md` (Multi-Model Teams `fast` model)
- `docs/features/mcp-mode/index.md` (`designer` agent alongside `claude-sonnet-4-5` engineer)

### Not changed

Provider-specific pages (`docs/providers/google/`, `docs/providers/openai/`), examples specifically demonstrating model parameters (`guides/thinking/`), model-picker tool docs, routing cheap-fallback contrast examples (`docs/configuration/routing/index.md`), `docs/providers/custom/index.md`, and within-file contrast/tiering examples (`docs/concepts/multi-agent/index.md` Multi-Model Teams section, `docs/features/mcp-mode/index.md` designer/engineer example) are intentionally unchanged.

### PR #3007 review

PR #3007 (fix: preserve agent field during command expansion) — bug fix only. The docs already correctly document the intended behavior of the `agent:` field in commands. No documentation update needed.