### PR TITLE
feat: add --session-read-only flag to view sessions without sending messages

### DIFF
--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -69,6 +69,7 @@ type runExecFlags struct {
 	worktree          bool
 	worktreeName      string
 	worktreePR        string
+	sessionReadOnly   bool
 
 	// Exec only
 	exec          bool
@@ -170,6 +171,7 @@ func addRunOrExecFlags(cmd *cobra.Command, flags *runExecFlags) {
 	cmd.PersistentFlags().StringVarP(&flags.worktreeName, "worktree", "w", "", "Run the agent in a fresh git worktree of the working directory (isolates changes from your checkout). Optionally name it: --worktree=my-name")
 	cmd.PersistentFlags().Lookup("worktree").NoOptDefVal = worktreeAutoName
 	cmd.PersistentFlags().StringVar(&flags.worktreePR, "worktree-pr", "", "Run the agent in a git worktree checked out on an existing GitHub pull request (number or URL). Continues the PR's branch; requires the GitHub CLI (gh).")
+	cmd.PersistentFlags().BoolVar(&flags.sessionReadOnly, "session-read-only", false, "Open the session in read-only mode (view conversation history but prevent new messages)")
 	cmd.MarkFlagsMutuallyExclusive("fake", "record")
 	cmd.MarkFlagsMutuallyExclusive("remote", "sandbox")
 	cmd.MarkFlagsMutuallyExclusive("remote", "session-db")
@@ -724,6 +726,10 @@ func (f *runExecFlags) createLocalRuntimeAndSession(ctx context.Context, loadRes
 }
 
 func (f *runExecFlags) handleExecMode(ctx context.Context, out *cli.Printer, rt runtime.Runtime, sess *session.Session, args []string) error {
+	if f.sessionReadOnly {
+		return errors.New("--session-read-only cannot be used with --exec: there is nothing to display without a TUI")
+	}
+
 	// args[0] is the agent file; args[1:] are user messages for multi-turn conversation
 	var userMessages []string
 	if len(args) > 1 {
@@ -804,6 +810,9 @@ func (f *runExecFlags) buildAppOpts(args []string) ([]app.Opt, error) {
 	}
 	if f.snapshotController != nil {
 		opts = append(opts, app.WithSnapshotController(f.snapshotController))
+	}
+	if f.sessionReadOnly {
+		opts = append(opts, app.WithReadOnly())
 	}
 	return opts, nil
 }

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -44,6 +44,7 @@ type App struct {
 	cancel                 context.CancelFunc
 	currentAgentModel      string                      // Tracks the current agent's model ID from AgentInfoEvent
 	exitAfterFirstResponse bool                        // Exit TUI after first assistant response completes
+	readOnly               bool                        // When true, no new messages can be sent to the LLM
 	titleGenerating        atomic.Bool                 // True when title generation is in progress
 	titleGen               *sessiontitle.Generator     // Title generator for local runtime (nil for remote)
 	snapshotController     builtins.SnapshotController // Drives /undo, /snapshots, /reset; nil for runtimes that don't capture snapshots
@@ -91,6 +92,14 @@ func WithQueuedMessages(msgs []string) Opt {
 func WithTitleGenerator(gen *sessiontitle.Generator) Opt {
 	return func(a *App) {
 		a.titleGen = gen
+	}
+}
+
+// WithReadOnly marks the session as read-only: the conversation history
+// is displayed but no new messages can be sent to the LLM.
+func WithReadOnly() Opt {
+	return func(a *App) {
+		a.readOnly = true
 	}
 }
 
@@ -915,6 +924,12 @@ func (a *App) SupportsModelSwitching() bool {
 // after the first assistant response completes.
 func (a *App) ShouldExitAfterFirstResponse() bool {
 	return a.exitAfterFirstResponse
+}
+
+// IsReadOnly returns true when the session is in read-only mode and no new
+// messages should be sent to the LLM.
+func (a *App) IsReadOnly() bool {
+	return a.readOnly
 }
 
 func (a *App) CompactSession(ctx context.Context, additionalPrompt string) {

--- a/pkg/tui/components/editor/editor.go
+++ b/pkg/tui/components/editor/editor.go
@@ -168,6 +168,14 @@ func WithCompletions(comps ...completions.Completion) Option {
 	}
 }
 
+// WithReadOnly disables the editor so no new messages can be composed.
+func WithReadOnly() Option {
+	return func(e *editor) {
+		e.textarea.Placeholder = "Session is read-only"
+		e.textarea.KeyMap.InsertNewline.SetEnabled(false)
+	}
+}
+
 // New creates a new editor component
 func New(hist *history.History, opts ...Option) Editor {
 	ta := textarea.New()

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -649,12 +649,17 @@ func (p *chatPage) handleSendMsg(msg msgtypes.SendMsg) (layout.Model, tea.Cmd) {
 		return p, core.CmdHandler(msgtypes.ExitSessionMsg{})
 	}
 
-	if msg.BypassQueue || isBangCommand(msg.Content) {
-		cmd := p.processMessage(msg)
+	// Allow immediate slash commands (e.g. /exit, /compact) even in read-only mode
+	if cmd := p.parseImmediateCommand(msg.Content); cmd != nil {
 		return p, cmd
 	}
 
-	if cmd := p.parseImmediateCommand(msg.Content); cmd != nil {
+	if p.app != nil && p.app.IsReadOnly() {
+		return p, notification.WarningCmd("Session is read-only. No new messages can be sent.")
+	}
+
+	if msg.BypassQueue || isBangCommand(msg.Content) {
+		cmd := p.processMessage(msg)
 		return p, cmd
 	}
 

--- a/pkg/tui/page/chat/queue_test.go
+++ b/pkg/tui/page/chat/queue_test.go
@@ -263,3 +263,44 @@ func TestQueueFlow_ClearQueue(t *testing.T) {
 	assert.Empty(t, p.messageQueue)
 	assert.NotNil(t, cmd) // Info notification
 }
+
+func TestReadOnly_RejectsMessages(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	a := app.New(t.Context(), queueTestRuntime{}, sess, app.WithReadOnly())
+	require.True(t, a.IsReadOnly())
+
+	p := New(a, service.NewSessionState(sess)).(*chatPage)
+
+	_, cmd := p.handleSendMsg(messages.SendMsg{Content: "hello"})
+
+	assert.Empty(t, p.messageQueue)
+	assert.NotNil(t, cmd)
+}
+
+func TestReadOnly_AllowsSlashCommands(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	a := app.New(t.Context(), queueTestRuntime{}, sess, app.WithReadOnly())
+	p := New(a, service.NewSessionState(sess)).(*chatPage)
+	p.commandParser = commands.NewParser(commands.Category{
+		Name: "Test",
+		Commands: []commands.Item{
+			{
+				SlashCommand: "/now",
+				Immediate:    true,
+				Execute: func(arg string) tea.Cmd {
+					return func() tea.Msg { return immediateCommandMsg{arg: arg} }
+				},
+			},
+		},
+	})
+
+	// Slash commands should still work in read-only mode
+	_, cmd := p.handleSendMsg(messages.SendMsg{Content: "/now please"})
+
+	require.NotNil(t, cmd)
+	assert.Equal(t, immediateCommandMsg{arg: "please"}, cmd())
+}

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -474,12 +474,16 @@ func (m *appModel) chatPageOpts() []chat.PageOption {
 
 // editorOpts returns the editor.Option slice derived from the current appModel.
 func (m *appModel) editorOpts() []editor.Option {
-	return []editor.Option{
+	opts := []editor.Option{
 		editor.WithCompletions(
 			completions.NewCommandCompletion(m.commandCategories()),
 			completions.NewFileCompletion(),
 		),
 	}
+	if m.application.IsReadOnly() {
+		opts = append(opts, editor.WithReadOnly())
+	}
+	return opts
 }
 
 // initSessionComponents creates a new chat page, session state, and editor for
@@ -1020,6 +1024,9 @@ func (m *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleAttachFile(msg.FilePath)
 
 	case messages.SendAttachmentMsg:
+		if m.application.IsReadOnly() {
+			return m, notification.WarningCmd("Session is read-only. No new messages can be sent.")
+		}
 		m.application.RunWithMessage(context.Background(), nil, msg.Content)
 		return m, nil
 


### PR DESCRIPTION


When running with --session-read-only, the TUI opens in read-only mode:
- The editor shows a "Session is read-only" placeholder
- Attempting to send a message shows a warning notification
- Slash commands (e.g. /exit, /compact) still work
- File attachments are also blocked
- Using --exec with --session-read-only returns an error

This is useful for reviewing past session conversations loaded from --session-db without accidentally sending new messages to the LLM.