### PR TITLE
docs: document --session-read-only flag for TUI read-only mode

### DIFF
--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -32,6 +32,7 @@ $ docker agent run [config] [message...] [flags]
 | `--model <ref>`                         | Override model(s). Use `provider/model` for all agents, or `agent=provider/model` for specific agents. Comma-separate multiple overrides. |
 | `--session <id>`                        | Resume a previous session. Supports relative refs (`-1` = last, `-2` = second to last)                                                    |
 | `-s, --session-db <path>`               | Path to the SQLite session database (default: `~/.cagent/session.db`)                                                                     |
+| `--session-read-only`                   | Open the TUI in read-only mode: conversation history is displayed but no new messages can be sent to the LLM. Cannot be used with `--exec`. |
 | `--prompt-file <path>`                  | Include file contents as additional system context (repeatable)                                                                           |
 | `--attach <path>`                       | Attach an image file to the initial message                                                                                               |
 | `--dry-run`                             | Initialize the agent without executing anything (useful for validating a config)                                                          |
@@ -75,6 +76,7 @@ $ docker agent run agent.yaml -a developer --yolo
 $ docker agent run agent.yaml --model anthropic/claude-sonnet-4-5
 $ docker agent run agent.yaml --model "dev=openai/gpt-4o,reviewer=anthropic/claude-sonnet-4-5"
 $ docker agent run agent.yaml --session -1  # resume last session
+$ docker agent run agent.yaml --session -1 --session-read-only  # review last session without sending messages
 $ docker agent run agent.yaml --prompt-file ./context.md  # include file as context
 
 # Add hooks from the command line

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -38,6 +38,9 @@ $ docker agent run agent.yaml --sidebar=false
 
 # Disable specific slash commands
 $ docker agent run agent.yaml --disable-commands="/cost,/eval,/model"
+
+# Open in read-only mode to review a past session without sending new messages
+$ docker agent run agent.yaml --session -1 --session-read-only
 ```
 
 ## Slash Commands


### PR DESCRIPTION
## Documentation updates

This PR documents the `--session-read-only` flag introduced by [#3026](https://github.com/docker/docker-agent/pull/3026).

### Changes

| Commit | Source PR | What changed |
|--------|-----------|-------------|
| `9092b7d8` | [#3026](https://github.com/docker/docker-agent/pull/3026) | Add `--session-read-only` to CLI reference flags table; add usage examples in CLI and TUI docs |

### Details

**`docs/features/cli/index.md`** — Added `--session-read-only` row to the `docker agent run` flags table (after `--session-db`), and added a combined `--session -1 --session-read-only` example to the Examples block.

**`docs/features/tui/index.md`** — Added a commented example to the "Launching the TUI" code block showing how to open a past session in read-only mode.

### Behavior documented

- Opens the TUI in read-only mode: conversation history is displayed but no new messages can be sent to the LLM
- Editor shows a "Session is read-only" placeholder
- Attempting to send a message shows a warning notification
- Slash commands (e.g. `/exit`, `/compact`) still work in read-only mode
- File attachments are also blocked
- Cannot be used with `--exec` (returns an error)
- Most useful when combined with `--session` to review past conversations without accidentally sending new messages

### PRs reviewed and found up to date

| Source PR | Reason |
|-----------|--------|
| [#3025](https://github.com/docker/docker-agent/pull/3025) | Docs-only PR — all changes applied within the PR itself |
| [#3012](https://github.com/docker/docker-agent/pull/3012) | Docs-only PR — all changes applied within the PR itself |
| [#3007](https://github.com/docker/docker-agent/pull/3007) | Bug fix only (preserve agent field during command expansion) — docs already correctly describe intended behavior |
| [#3006](https://github.com/docker/docker-agent/pull/3006) | Internal implementation detail (skip binary files in content search) — no user-facing behavior change |