### PR TITLE
fix(evals): copy docker-agent binary + entrypoint in custom-base-image template

### DIFF
--- a/pkg/evaluation/Dockerfile.custom.template
+++ b/pkg/evaluation/Dockerfile.custom.template
@@ -1,6 +1,12 @@
 # syntax=docker/dockerfile:1
 
 FROM {{.BaseImage}}
+LABEL "io.docker.agent.evals.image"="custom"
+COPY --from=docker/docker-agent:edge /docker-agent /
+RUN printf '#!/usr/bin/env sh\nset -euo pipefail\nexec "$@"\n' > /run.sh && chmod +x /run.sh
 WORKDIR /working_dir
+ENV TELEMETRY_ENABLED=false
+ENV DOCKER_AGENT_HIDE_TELEMETRY_BANNER=1
+ENTRYPOINT ["/run.sh", "/docker-agent", "run", "--exec", "--yolo", "--json"]
 {{if .CopyWorkingDir}}COPY . ./
 {{end}}

--- a/pkg/evaluation/dockerfile_template_test.go
+++ b/pkg/evaluation/dockerfile_template_test.go
@@ -1,0 +1,71 @@
+package evaluation
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// renderTemplate is a small helper to render the embedded Dockerfile
+// templates with the same fields buildEvalImage populates.
+func renderTemplate(t *testing.T, custom, copyWorkingDir bool, baseImage string) string {
+	t.Helper()
+
+	var data struct {
+		CopyWorkingDir bool
+		BaseImage      string
+	}
+	data.CopyWorkingDir = copyWorkingDir
+	data.BaseImage = baseImage
+
+	tmpl := dockerfileTemplate
+	if custom {
+		tmpl = dockerfileCustomTemplate
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, tmpl.Execute(&buf, data))
+	return buf.String()
+}
+
+// TestDockerfileCustomTemplateParity guards against the regression in
+// https://github.com/docker/docker-agent/issues/796: the custom-base-image
+// template must copy the docker-agent binary and wrap it with the /run.sh
+// entrypoint, exactly like the default template. Without these, the eval
+// container inherits the base image's `ENTRYPOINT ["/docker-agent"]` and the
+// agent YAML path is passed as a bare subcommand, producing
+// `unknown command "/configs/<agent>.yaml"`.
+func TestDockerfileCustomTemplateParity(t *testing.T) {
+	t.Parallel()
+
+	out := renderTemplate(t, true /* custom */, true /* copyWorkingDir */, "python:3.12")
+
+	assert.Contains(t, out, "FROM python:3.12",
+		"custom template must use the provided base image")
+	assert.Contains(t, out, "COPY --from=docker/docker-agent:edge /docker-agent /",
+		"custom template must copy the docker-agent binary into the eval image")
+	assert.Contains(t, out, `ENTRYPOINT ["/run.sh", "/docker-agent", "run", "--exec", "--yolo", "--json"]`,
+		"custom template must set the /run.sh docker-agent run entrypoint")
+	assert.Contains(t, out, "/run.sh",
+		"custom template must create the /run.sh entrypoint wrapper")
+}
+
+// TestDockerfileTemplatesRender ensures both templates render with and without
+// a working directory copy for the fields buildEvalImage supplies.
+func TestDockerfileTemplatesRender(t *testing.T) {
+	t.Parallel()
+
+	for _, custom := range []bool{false, true} {
+		for _, copyWorkingDir := range []bool{false, true} {
+			out := renderTemplate(t, custom, copyWorkingDir, "alpine:latest")
+			assert.Contains(t, out, "ENTRYPOINT [")
+			if copyWorkingDir {
+				assert.Contains(t, out, "COPY . ./")
+			} else {
+				assert.NotContains(t, out, "COPY . ./")
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #796.

`docker-agent eval` runs each eval case in a freshly built container. `pkg/evaluation/build.go` picks one of two embedded templates:

- `Dockerfile.template` (default — used when the eval has no `image:`)
- `Dockerfile.custom.template` (used when the eval sets `evals.image:`)

The **custom** template was missing the two things the default template provides: it never copied the `docker-agent` binary into the image and never set the `/run.sh … docker-agent run …` entrypoint wrapper. As a result the eval container inherited the base image's `ENTRYPOINT ["/docker-agent"]`, and `eval.go` appended the agent YAML path as CMD, producing:

```
running docker agent in container: container failed: exit status 1
(stderr: Error: unknown command "/configs/<agent>.yaml" for "docker-agent")
```

This broke **every** custom-base-image eval (e.g. task-style evals that set a base image), while plain evals (no `image:`) kept working. Note that PR #2779 only fixed the `/run.sh` `printf` generation in the *default* template, so it did not address this.

## Fix

Bring `Dockerfile.custom.template` to parity with the default template:
- `COPY --from=docker/docker-agent:edge /docker-agent /`
- create the `/run.sh` exec wrapper
- `ENTRYPOINT ["/run.sh", "/docker-agent", "run", "--exec", "--yolo", "--json"]`
- add the same telemetry-suppression env vars and a `custom` image label

`FROM {{.BaseImage}}` and the `CopyWorkingDir` conditional are preserved, so the change is fully data-compatible with `build.go` (no Go changes needed).

## Tests

Added `pkg/evaluation/dockerfile_template_test.go`:
- `TestDockerfileCustomTemplateParity` — asserts the custom template copies the binary and sets the `/run.sh` entrypoint (guards against this exact regression).
- `TestDockerfileTemplatesRender` — renders both templates across the `CopyWorkingDir` matrix.

`go test ./pkg/evaluation/` passes. The full `go test ./...` suite passes except one pre-existing, host-specific `pkg/sandbox` test failure unrelated to this change.

## Scope

Eval harness only. The published `docker/docker-agent` image, `docker-agent run`/`serve`, and the TUI are unaffected — `Dockerfile.custom.template` is referenced solely by `pkg/evaluation/build.go`.