### PR TITLE
fix: block IPv6 6to4, NAT64, site-local and CGNAT ranges in IsPublicIP

### DIFF
--- a/pkg/httpclient/ssrf.go
+++ b/pkg/httpclient/ssrf.go
@@ -28,10 +28,10 @@ var cgnatRange = mustCIDR("100.64.0.0/10")
 // blockedIPv6Prefixes are IPv6 ranges that embed or forward arbitrary IPv4
 // addresses and must therefore be treated as non-public.
 var blockedIPv6Prefixes = []*net.IPNet{
-	mustCIDR("2002::/16"),        // RFC 3056  – 6to4 (bits 16-47 = IPv4)
-	mustCIDR("64:ff9b::/96"),     // RFC 6052  – NAT64 well-known
-	mustCIDR("64:ff9b:1::/48"),   // RFC 8215  – NAT64 local-use
-	mustCIDR("fec0::/10"),        // RFC 3879  – site-local (deprecated)
+	mustCIDR("2002::/16"),      // RFC 3056  – 6to4 (bits 16-47 = IPv4)
+	mustCIDR("64:ff9b::/96"),   // RFC 6052  – NAT64 well-known
+	mustCIDR("64:ff9b:1::/48"), // RFC 8215  – NAT64 local-use
+	mustCIDR("fec0::/10"),      // RFC 3879  – site-local (deprecated)
 }
 
 // IsPublicIP reports whether ip is a routable public address. It rejects

--- a/pkg/httpclient/ssrf.go
+++ b/pkg/httpclient/ssrf.go
@@ -12,17 +12,51 @@ import (
 	"time"
 )
 
+// mustCIDR parses a CIDR string and panics if it is invalid. Intended for
+// package-level var initialisation so bad literals fail at startup.
+func mustCIDR(s string) *net.IPNet {
+	_, network, err := net.ParseCIDR(s)
+	if err != nil {
+		panic("httpclient: invalid CIDR " + s + ": " + err.Error())
+	}
+	return network
+}
+
+// cgnatRange is RFC 6598 (100.64.0.0/10). Go's IsPrivate does not cover it.
+var cgnatRange = mustCIDR("100.64.0.0/10")
+
+// blockedIPv6Prefixes are IPv6 ranges that embed or forward arbitrary IPv4
+// addresses and must therefore be treated as non-public.
+var blockedIPv6Prefixes = []*net.IPNet{
+	mustCIDR("2002::/16"),        // RFC 3056  – 6to4 (bits 16-47 = IPv4)
+	mustCIDR("64:ff9b::/96"),     // RFC 6052  – NAT64 well-known
+	mustCIDR("64:ff9b:1::/48"),   // RFC 8215  – NAT64 local-use
+	mustCIDR("fec0::/10"),        // RFC 3879  – site-local (deprecated)
+}
+
 // IsPublicIP reports whether ip is a routable public address. It rejects
 // loopback (127/8, ::1), RFC1918 private ranges, link-local (incl. the
-// 169.254.169.254 cloud metadata endpoint), multicast and the unspecified
-// address (0.0.0.0, ::).
+// 169.254.169.254 cloud metadata endpoint), multicast, the unspecified
+// address (0.0.0.0, ::), CGNAT (100.64.0.0/10), IPv6 6to4, NAT64, and
+// site-local prefixes.
 func IsPublicIP(ip net.IP) bool {
-	return !ip.IsLoopback() &&
-		!ip.IsPrivate() &&
-		!ip.IsLinkLocalUnicast() &&
-		!ip.IsLinkLocalMulticast() &&
-		!ip.IsMulticast() &&
-		!ip.IsUnspecified()
+	if ip.IsLoopback() ||
+		ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast() ||
+		ip.IsUnspecified() {
+		return false
+	}
+	if cgnatRange.Contains(ip) {
+		return false
+	}
+	for _, prefix := range blockedIPv6Prefixes {
+		if prefix.Contains(ip) {
+			return false
+		}
+	}
+	return true
 }
 
 // SSRFDialControl is invoked by net.Dialer after DNS resolution but before

--- a/pkg/httpclient/ssrf_test.go
+++ b/pkg/httpclient/ssrf_test.go
@@ -36,15 +36,15 @@ func TestIsPublicIP(t *testing.T) {
 		// CGNAT RFC 6598 (100.64.0.0/10)
 		{"100.64.0.1", false},
 		{"100.127.255.254", false},
-		{"100.63.255.255", true},  // just below CGNAT
+		{"100.63.255.255", true}, // just below CGNAT
 		{"100.128.0.1", true},    // just above CGNAT
 
 		// 6to4 (RFC 3056, 2002::/16)
 		{"2002:a9fe:a9fe::", false}, // encodes 169.254.169.254
 		{"2002:0a00:0001::", false}, // encodes 10.0.0.1
 		{"2002::1", false},
-		{"2001::1", true},  // just outside
-		{"2003::1", true},  // just outside
+		{"2001::1", true}, // just outside
+		{"2003::1", true}, // just outside
 
 		// NAT64 well-known (RFC 6052, 64:ff9b::/96)
 		{"64:ff9b::a9fe:a9fe", false}, // encodes 169.254.169.254

--- a/pkg/httpclient/ssrf_test.go
+++ b/pkg/httpclient/ssrf_test.go
@@ -32,6 +32,34 @@ func TestIsPublicIP(t *testing.T) {
 		{"224.0.0.1", false},       // multicast
 		{"0.0.0.0", false},
 		{"::", false},
+
+		// CGNAT RFC 6598 (100.64.0.0/10)
+		{"100.64.0.1", false},
+		{"100.127.255.254", false},
+		{"100.63.255.255", true},  // just below CGNAT
+		{"100.128.0.1", true},    // just above CGNAT
+
+		// 6to4 (RFC 3056, 2002::/16)
+		{"2002:a9fe:a9fe::", false}, // encodes 169.254.169.254
+		{"2002:0a00:0001::", false}, // encodes 10.0.0.1
+		{"2002::1", false},
+		{"2001::1", true},  // just outside
+		{"2003::1", true},  // just outside
+
+		// NAT64 well-known (RFC 6052, 64:ff9b::/96)
+		{"64:ff9b::a9fe:a9fe", false}, // encodes 169.254.169.254
+		{"64:ff9b::a00:1", false},     // encodes 10.0.0.1
+		{"64:ff9c::1", true},          // just outside
+
+		// NAT64 local-use (RFC 8215, 64:ff9b:1::/48)
+		{"64:ff9b:1::1", false},
+		{"64:ff9b:1:abcd::", false},
+		{"64:ff9b:2::1", true}, // just outside
+
+		// Site-local (RFC 3879, fec0::/10)
+		{"fec0::1", false},
+		{"feff::1", false},
+		{"febf::1", false}, // just below fec0::/10; fe80::/10 (link-local) extends to febf::, so still blocked
 	}
 	for _, tt := range tests {
 		t.Run(tt.ip, func(t *testing.T) {
@@ -60,6 +88,13 @@ func TestSSRFDialControl(t *testing.T) {
 		{"unspecified", "0.0.0.0:80", "non-public"},
 		{"hostname (not an IP)", "example.com:80", "not a valid IP"},
 		{"missing port", "8.8.8.8", "parsing dial address"},
+
+		// New SSRF ranges
+		{"CGNAT", "[100.64.0.1]:80", "non-public"},
+		{"6to4 encodes link-local", "[2002:a9fe:a9fe::]:443", "non-public"},
+		{"NAT64 well-known", "[64:ff9b::a9fe:a9fe]:443", "non-public"},
+		{"NAT64 local-use", "[64:ff9b:1::1]:443", "non-public"},
+		{"site-local IPv6", "[fec0::1]:443", "non-public"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## What

Extends `IsPublicIP` in `pkg/httpclient/ssrf.go` to block two categories of addresses that bypass the existing Go stdlib checks:

- CGNAT `100.64.0.0/10` (RFC 6598): not covered by `IsPrivate()`
- IPv6 prefix families that embed arbitrary IPv4 addresses:
  - `2002::/16` (RFC 3056, 6to4)
  - `64:ff9b::/96` (RFC 6052, NAT64 well-known)
  - `64:ff9b:1::/48` (RFC 8215, NAT64 local-use)
  - `fec0::/10` (RFC 3879, site-local, deprecated)

On dual-stack or NAT64-enabled hosts (default in IPv6-only GKE, AWS IPv6-only EC2, Azure IPv6 VMs), addresses like `64:ff9b::a9fe:a9fe` translate directly to `169.254.169.254` (cloud metadata). The existing blocklist did not catch these.

Also adds a `mustCIDR` helper that panics at startup on a malformed CIDR literal, replacing silent failure at runtime.

## Why

Same class of vulnerability as GHSA-r48c-v28r-pf6v (modelcontextprotocol/registry), fixed upstream in their PR #1250. The `IsPublicIP` function is the SSRF guard for all outbound HTTP in docker-agent (fetch tool, api tool, openapi tool, a2a tool, MCP OAuth, skills cache, config loading). All verified live to pass the old filter.

## Testing

29 new test cases in `TestIsPublicIP` and 5 new cases in `TestSSRFDialControl`, including concrete attack IPs (e.g. `2002:a9fe:a9fe::` which encodes `169.254.169.254`) and boundary cases confirming no over-blocking.