### PR TITLE
fix: use SSRF-safe HTTP client for MCP OAuth authorization server metadata fetch

### DIFF
--- a/pkg/tools/mcp/oauth_login.go
+++ b/pkg/tools/mcp/oauth_login.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"golang.org/x/oauth2"
+
+	"github.com/docker/docker-agent/pkg/httpclient"
 )
 
 // PerformOAuthLogin performs a standalone OAuth flow for the given MCP server URL.
@@ -19,7 +21,7 @@ import (
 func PerformOAuthLogin(ctx context.Context, serverURL string) error {
 	tokenStore := NewKeyringTokenStore()
 
-	o := &oauth{metadataClient: &http.Client{Timeout: 5 * time.Second}}
+	o := &oauth{metadataClient: httpclient.NewSafeClient(5*time.Second, false)}
 
 	// Derive the base origin (scheme + host) from the server URL.
 	// The well-known endpoints live at the origin, not under the SSE/path.

--- a/pkg/tools/mcp/oauth_login.go
+++ b/pkg/tools/mcp/oauth_login.go
@@ -37,7 +37,7 @@ func PerformOAuthLogin(ctx context.Context, serverURL string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create resource metadata request: %w", err)
 	}
-	resp, err := http.DefaultClient.Do(resourceReq)
+	resp, err := o.metadataClient.Do(resourceReq)
 	if err != nil {
 		return fmt.Errorf("failed to fetch protected resource metadata: %w", err)
 	}


### PR DESCRIPTION
## What

Replaces the unguarded `&http.Client{Timeout: 5s}` used as
`oauth.metadataClient` in `PerformOAuthLogin` with
`httpclient.NewSafeClient(5s, false)`, preserving the original timeout
while adding the SSRF-safe transport and redirect cap.

## Why

`PerformOAuthLogin` fetches `/.well-known/oauth-protected-resource` from
the configured MCP server, then follows the `authorization_servers` URL
returned in that response. That second URL is attacker-controlled -- a
malicious MCP server can point it at an internal host (e.g.
`http://169.254.169.254/`). The unguarded `metadataClient` would fetch
it unconditionally.

Closes #3034.

## References

- Issue #3034
- PR #3031 -- fixed `IsPublicIP` for IPv6 / CGNAT gaps (same audit)
- GHSA-r48c-v28r-pf6v -- upstream SSRF advisory