### PR TITLE
Allow models.dev in sandbox proxy for model catalog resolution

### DIFF
--- a/cmd/root/sandbox.go
+++ b/cmd/root/sandbox.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/docker-agent/pkg/config"
 	latestcfg "github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/environment"
+	"github.com/docker/docker-agent/pkg/modelsdev"
 	"github.com/docker/docker-agent/pkg/paths"
 	"github.com/docker/docker-agent/pkg/sandbox"
 	"github.com/docker/docker-agent/pkg/sandbox/kit"
@@ -175,6 +176,7 @@ func runInSandbox(ctx context.Context, cmd *cobra.Command, args []string, runCon
 	userHosts := userSandboxAllowlist(ctx)
 
 	printModelsGateway(cmd.OutOrStdout(), runConfig.ModelsGateway)
+	printModelsDevAllowance(cmd.OutOrStdout())
 	printToolInstallAllowance(cmd.OutOrStdout(), kitResult)
 	printAgentNetworkAllowlist(cmd.OutOrStdout(), agentHosts)
 	printUserSandboxAllowlist(cmd.OutOrStdout(), userHosts)
@@ -272,15 +274,18 @@ func dockerAgentArgs(cmd *cobra.Command, args []string, configDir string) []stri
 }
 
 // allowSandboxHosts adds per-sandbox allow-network rules for every
-// host the in-sandbox runtime is known to need: the configured
-// models gateway (when set), the package hosts the auto-installer
-// reaches for (when the kit build identified at least one
-// auto-installable toolset), and any extra hosts the agent author
-// declared in runtime.network_allowlist. The default sandbox proxy
-// denies all of them; without this, the inner agent's first request
-// returns a misleading "403 Blocked by network policy".
+// host the in-sandbox runtime is known to need: the models.dev
+// catalog API (always), the configured models gateway (when set), the
+// package hosts the auto-installer reaches for (when the kit build
+// identified at least one auto-installable toolset), and any extra
+// hosts the agent author declared in runtime.network_allowlist. The
+// default sandbox proxy denies all of them; without this, the inner
+// agent's first request returns a misleading "403 Blocked by network
+// policy".
 //
 // Holes are punched only when the corresponding feature is in play:
+//   - models.dev is always opened — every run resolves model
+//     metadata (limits, pricing, capabilities) against the catalog;
 //   - the gateway host is added only when gatewayURL is non-empty;
 //   - the per-agent install hosts come from the kit build, which
 //     looks each toolset up against the aqua registry and contributes
@@ -300,6 +305,7 @@ func dockerAgentArgs(cmd *cobra.Command, args []string, configDir string) []stri
 // inner and we surface that diagnostic verbatim.
 func allowSandboxHosts(ctx context.Context, backend *sandbox.Backend, name, gatewayURL string, toolInstallHosts, agentHosts, userHosts []string) {
 	var hosts []string
+	hosts = append(hosts, modelsdev.APIHost)
 	hosts = append(hosts, toolInstallHosts...)
 	hosts = append(hosts, agentHosts...)
 	hosts = append(hosts, userHosts...)
@@ -478,6 +484,13 @@ func printModelsGateway(w io.Writer, gateway string) {
 		return
 	}
 	fmt.Fprintf(w, "Models gateway: %s (allowlisting %s in the sandbox proxy)\n", display, host)
+}
+
+// printModelsDevAllowance prints that the models.dev catalog host is
+// always allowlisted in the sandbox proxy, since every run resolves
+// model metadata against it.
+func printModelsDevAllowance(w io.Writer) {
+	fmt.Fprintf(w, "Models catalog: allowlisting %s in the sandbox proxy\n", modelsdev.APIHost)
 }
 
 // printToolInstallAllowance prints a multi-line description of the

--- a/cmd/root/sandbox_test.go
+++ b/cmd/root/sandbox_test.go
@@ -194,6 +194,14 @@ func TestPrintModelsGateway(t *testing.T) {
 	}
 }
 
+func TestPrintModelsDevAllowance(t *testing.T) {
+	t.Parallel()
+
+	var buf strings.Builder
+	printModelsDevAllowance(&buf)
+	assert.Equal(t, "Models catalog: allowlisting models.dev in the sandbox proxy\n", buf.String())
+}
+
 func TestPrintToolInstallAllowance(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/modelsdev/store.go
+++ b/pkg/modelsdev/store.go
@@ -19,6 +19,9 @@ import (
 
 const (
 	ModelsDevAPIURL = "https://models.dev/api.json"
+	// APIHost is the host portion of ModelsDevAPIURL, allowlisted by
+	// sandbox callers so the in-sandbox agent can reach the catalog.
+	APIHost         = "models.dev"
 	CacheFileName   = "models_dev.json"
 	refreshInterval = 24 * time.Hour
 )

--- a/pkg/modelsdev/store.go
+++ b/pkg/modelsdev/store.go
@@ -18,10 +18,12 @@ import (
 )
 
 const (
-	ModelsDevAPIURL = "https://models.dev/api.json"
-	// APIHost is the host portion of ModelsDevAPIURL, allowlisted by
-	// sandbox callers so the in-sandbox agent can reach the catalog.
-	APIHost         = "models.dev"
+	// APIHost is the models.dev catalog host. Sandbox callers allowlist
+	// it so the in-sandbox agent can reach the catalog through the
+	// default-deny network proxy.
+	APIHost = "models.dev"
+	// ModelsDevAPIURL is derived from APIHost so the two can't drift.
+	ModelsDevAPIURL = "https://" + APIHost + "/api.json"
 	CacheFileName   = "models_dev.json"
 	refreshInterval = 24 * time.Hour
 )


### PR DESCRIPTION
## What

`docker agent run --sandbox` now always allowlists the `models.dev`
catalog host in the sandbox's default-deny network proxy, so the
in-sandbox agent can fetch the model list and resolve model metadata
(context limits, pricing, capabilities).

## Why

Every agent run resolves model metadata against `models.dev`, but the
sandbox proxy denies it by default. Without an explicit allow rule the
inner agent's first catalog lookup fails with a misleading
`403 Blocked by network policy`. This wires `models.dev` into the same
auto-allowlist machinery that already opens the models gateway and the
auto-installer's package hosts.

## Changes

- `pkg/modelsdev`: export `APIHost = "models.dev"` and derive
  `ModelsDevAPIURL` from it so the host and URL can't drift.
- `cmd/root/sandbox.go`: always include `modelsdev.APIHost` in
  `allowSandboxHosts`, and surface it via a new `printModelsDevAllowance`
  line alongside the gateway/tool-install output.
- `cmd/root/sandbox_test.go`: add `TestPrintModelsDevAllowance`.

## Validation

- `go build ./...`
- `go test ./cmd/root/ ./pkg/modelsdev/`
- `golangci-lint run` (0 issues)