### PR TITLE
docs: update evaluation and compaction documentation

### DIFF
--- a/docs/features/evaluation/index.md
+++ b/docs/features/evaluation/index.md
@@ -165,10 +165,19 @@ $ docker agent eval <agent-file>|<registry-ref> [<eval-dir>|./evals]
 | `--judge-model`     | `anthropic/claude-opus-4-5-20251101` | Model for LLM-as-a-judge relevance scoring                        |
 | `--output`          | `&lt;eval-dir&gt;/results`  | Directory for results, logs, and session databases                |
 | `--only`            | (all)                       | Only run evals with file names matching these patterns            |
-| `--base-image`      | (default)                   | Custom base Docker image for eval containers                      |
+| `--base-image`      | (default)                   | Custom base Docker image for eval containers (see [Custom Base Images](#custom-base-images)) |
 | `--keep-containers` | `false`                     | Keep containers after evaluation (don't remove with `--rm`)       |
 | `-e, --env`         | (none)                      | Environment variables to pass to container (`KEY` or `KEY=VALUE`) |
 | `--repeat`          | `1`                         | Number of times to repeat each evaluation (useful for computing baselines) |
+
+### Custom Base Images
+
+When `--base-image` is set, the eval harness builds a derived image on top of your base image at evaluation time. Two things happen automatically:
+
+1. **The docker-agent binary is injected** — it is copied from `docker/docker-agent:edge` into the derived image at build time, so you don't need to include it in your base image.
+2. **The entrypoint is overridden** — docker-agent replaces your base image's entrypoint with its own `/run.sh` wrapper.
+
+Your base image therefore only needs to provide the runtime environment: language runtimes, installed dependencies, test fixtures, the appropriate working directory, and so on. Any `ENTRYPOINT` or `CMD` defined in your base image is ignored.
 
 ## Output
 

--- a/docs/providers/dmr/index.md
+++ b/docs/providers/dmr/index.md
@@ -92,6 +92,8 @@ models:
 
 If `context_size` is omitted, Model Runner uses its default. `max_tokens` is **not** used as the context window.
 
+docker-agent's auto-compaction scales its summary and keep-tail token budgets proportionally to `context_size`. This ensures compaction works correctly even for small context windows — for example, an 8k-token local model will not have its session history wiped during compaction.
+
 ## Thinking / reasoning budget
 
 When using the **llama.cpp** backend, `thinking_budget` is sent as structured `llamacpp.reasoning-budget` on `_configure` (maps to `--reasoning-budget`). String efforts use the same token mapping as other providers; `adaptive` maps to unlimited (`-1`).


### PR DESCRIPTION
## Documentation updates

This PR updates documentation to reflect two recently merged code changes.

### Changes

| Commit | Source PR | What changed |
|--------|-----------|--------------|
| First commit | [#3029](https://github.com/docker/docker-agent/pull/3029) | Document custom base image behavior for `--base-image` eval flag |
| Second commit | [#3042](https://github.com/docker/docker-agent/pull/3042) | Note that compaction budgets scale with `context_size` for small windows |

### Details

**`docs/features/evaluation/index.md`** — Added explanation of how the eval harness handles custom base images: the docker-agent binary is injected from `docker/docker-agent:edge` at build time and the base image's entrypoint is overridden. Users should provide only the runtime environment in their base image.

**`docs/providers/dmr/index.md`** (or troubleshooting doc) — Added note that auto-compaction scales summary and keep-tail budgets proportionally to `provider_opts.context_size`, so small context windows (e.g. 8k local models) no longer lose session history during compaction.

### PRs reviewed and found up to date

| Source PR | Reason |
|-----------|--------|
| [#3036](https://github.com/docker/docker-agent/pull/3036) | Docs shipped in the same PR (secrets guide updated) |
| [#3032](https://github.com/docker/docker-agent/pull/3032) | Removed catalog server IDs not referenced in docs |
| [#3035](https://github.com/docker/docker-agent/pull/3035) | Internal security fix, no user-facing behavior change |
| [#3031](https://github.com/docker/docker-agent/pull/3031) | Internal SSRF hardening, `allow_private_ips` semantics unchanged |
| [#3033](https://github.com/docker/docker-agent/pull/3033) | Go dependency bumps |
| [#3039](https://github.com/docker/docker-agent/pull/3039) | Go dependency bump |
| [#3005](https://github.com/docker/docker-agent/pull/3005) | Go dependency bumps |
| [#3038](https://github.com/docker/docker-agent/pull/3038) | Already a docs PR (CHANGELOG) |
| [#3028](https://github.com/docker/docker-agent/pull/3028) | Already a docs PR (`--session-read-only`) |
