### PR TITLE
toolinstall: verify asset checksums and support aqua version_overrides

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/docker/go-units v0.5.0
 	github.com/docker/portcullis v0.0.0-20260602141607-f40f36dfd646
 	github.com/dop251/goja v0.0.0-20260607120635-348e6bea910d
+	github.com/expr-lang/expr v1.17.8
 	github.com/fatih/color v1.19.0
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-git/go-git/v5 v5.19.1

--- a/go.sum
+++ b/go.sum
@@ -232,6 +232,8 @@ github.com/envoyproxy/go-control-plane/envoy v1.37.0 h1:u3riX6BoYRfF4Dr7dwSOroNf
 github.com/envoyproxy/go-control-plane/envoy v1.37.0/go.mod h1:DReE9MMrmecPy+YvQOAOHNYMALuowAnbjjEMkkWOi6A=
 github.com/envoyproxy/protoc-gen-validate v1.3.3 h1:MVQghNeW+LZcmXe7SY1V36Z+WFMDjpqGAGacLe2T0ds=
 github.com/envoyproxy/protoc-gen-validate v1.3.3/go.mod h1:TsndJ/ngyIdQRhMcVVGDDHINPLWB7C82oDArY51KfB0=
+github.com/expr-lang/expr v1.17.8 h1:W1loDTT+0PQf5YteHSTpju2qfUfNoBt4yw9+wOEU9VM=
+github.com/expr-lang/expr v1.17.8/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
 github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
 github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=

--- a/pkg/toolinstall/checksum.go
+++ b/pkg/toolinstall/checksum.go
@@ -1,0 +1,194 @@
+package toolinstall
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// maxChecksumFileSize bounds the checksum file download. Real checksum
+// manifests are a few KiB at most; the limit guards against an
+// attacker-controlled release streaming an unbounded body.
+const maxChecksumFileSize = 1 << 20 // 1 MiB
+
+// Checksum mirrors the aqua registry "checksum" schema describing how to
+// verify the integrity of a downloaded release asset.
+type Checksum struct {
+	Type      string `yaml:"type"`
+	Asset     string `yaml:"asset"`
+	URL       string `yaml:"url"`
+	Algorithm string `yaml:"algorithm"`
+	Enabled   *bool  `yaml:"enabled"`
+}
+
+// isEnabled reports whether checksum verification should be attempted. A
+// checksum block defaults to enabled when present unless explicitly disabled
+// (e.g. an aqua platform override setting "enabled: false").
+func (c *Checksum) isEnabled() bool {
+	if c == nil {
+		return false
+	}
+	return c.Enabled == nil || *c.Enabled
+}
+
+// mergeChecksum overlays the non-empty fields of override onto base. It mirrors
+// how aqua platform overrides amend a package's checksum config — most commonly
+// to disable verification on a specific OS via "enabled: false".
+func mergeChecksum(base, override *Checksum) *Checksum {
+	if base == nil {
+		return override
+	}
+	if override == nil {
+		return base
+	}
+
+	merged := *base
+	if override.Type != "" {
+		merged.Type = override.Type
+	}
+	if override.Asset != "" {
+		merged.Asset = override.Asset
+	}
+	if override.URL != "" {
+		merged.URL = override.URL
+	}
+	if override.Algorithm != "" {
+		merged.Algorithm = override.Algorithm
+	}
+	if override.Enabled != nil {
+		merged.Enabled = override.Enabled
+	}
+	return &merged
+}
+
+// newHasher returns a hash for the given algorithm. Only strong algorithms are
+// supported; weaker ones (md5/sha1) provide little integrity guarantee and are
+// reported as unsupported so verification is skipped rather than giving a false
+// sense of security.
+func newHasher(algorithm string) (hash.Hash, error) {
+	switch strings.ToLower(algorithm) {
+	case "", "sha256":
+		return sha256.New(), nil
+	case "sha512":
+		return sha512.New(), nil
+	default:
+		return nil, fmt.Errorf("unsupported checksum algorithm %q", algorithm)
+	}
+}
+
+// verifyAssetChecksum downloads the checksum manifest advertised by the package,
+// extracts the expected digest for assetName, and compares it against the digest
+// of the asset stored at assetPath.
+//
+// It fails closed: once a package advertises an (enabled, supported) checksum,
+// any failure to download, parse, or match the digest aborts the installation.
+// Unsupported checksum types or algorithms are skipped with a warning rather
+// than failing, to avoid breaking installs the registry can't help us verify.
+//
+// Threat model: the manifest is fetched from the same GitHub release as the
+// asset, so this primarily guards against in-transit corruption and a tampered
+// download CDN. It does NOT defend against a fully compromised release or repo
+// (where an attacker controls both files) — that requires pinned digests or
+// cosign/SLSA provenance, which the registry also exposes and is future work.
+func (r *Registry) verifyAssetChecksum(ctx context.Context, pkg *Package, version, assetName, assetPath string, c *Checksum, data templateData) error {
+	pkgName := pkg.RepoOwner + "/" + pkg.RepoName
+
+	if c.Type != "" && c.Type != "github_release" {
+		slog.WarnContext(ctx, "Skipping checksum verification: unsupported checksum type",
+			"type", c.Type, "package", pkgName)
+		return nil
+	}
+
+	hasher, err := newHasher(c.Algorithm)
+	if err != nil {
+		slog.WarnContext(ctx, "Skipping checksum verification", "reason", err, "package", pkgName)
+		return nil
+	}
+
+	checksumAsset, err := renderTemplate(c.Asset, data)
+	if err != nil {
+		return fmt.Errorf("rendering checksum asset template: %w", err)
+	}
+	if checksumAsset == "" {
+		slog.WarnContext(ctx, "Skipping checksum verification: no checksum asset", "package", pkgName)
+		return nil
+	}
+
+	url := fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/%s",
+		pkg.RepoOwner, pkg.RepoName, version, checksumAsset)
+
+	body, err := r.download(ctx, url)
+	if err != nil {
+		return fmt.Errorf("downloading checksum file %s: %w", checksumAsset, err)
+	}
+	defer body.Close()
+
+	manifest, err := io.ReadAll(io.LimitReader(body, maxChecksumFileSize))
+	if err != nil {
+		return fmt.Errorf("reading checksum file %s: %w", checksumAsset, err)
+	}
+
+	expected, err := parseChecksumFile(manifest, assetName)
+	if err != nil {
+		return fmt.Errorf("checksum file %s: %w", checksumAsset, err)
+	}
+
+	f, err := os.Open(assetPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := io.Copy(hasher, f); err != nil {
+		return fmt.Errorf("hashing asset %s: %w", assetName, err)
+	}
+	actual := hex.EncodeToString(hasher.Sum(nil))
+
+	if !strings.EqualFold(actual, expected) {
+		return fmt.Errorf("checksum mismatch for %s: expected %s, got %s", assetName, expected, actual)
+	}
+
+	slog.InfoContext(ctx, "Verified asset checksum",
+		"package", pkgName, "asset", assetName, "algorithm", c.Algorithm)
+	return nil
+}
+
+// parseChecksumFile extracts the hex digest for assetName from a checksum
+// manifest. It supports both multi-entry "<digest>  <file>" manifests (e.g.
+// checksums.txt) and single-line files containing only a digest. The "*"
+// binary-mode marker some tools prepend to filenames is tolerated.
+func parseChecksumFile(data []byte, assetName string) (string, error) {
+	var lines []string
+	for l := range strings.SplitSeq(string(data), "\n") {
+		if strings.TrimSpace(l) != "" {
+			lines = append(lines, l)
+		}
+	}
+
+	if len(lines) == 1 {
+		if fields := strings.Fields(lines[0]); len(fields) == 1 {
+			return fields[0], nil
+		}
+	}
+
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		name := strings.TrimPrefix(fields[len(fields)-1], "*")
+		if name == assetName || filepath.Base(name) == assetName {
+			return fields[0], nil
+		}
+	}
+
+	return "", fmt.Errorf("no checksum entry found for asset %q", assetName)
+}

--- a/pkg/toolinstall/checksum_test.go
+++ b/pkg/toolinstall/checksum_test.go
@@ -1,0 +1,284 @@
+package toolinstall
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChecksum_IsEnabled(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, (*Checksum)(nil).isEnabled())
+	assert.True(t, (&Checksum{}).isEnabled())
+	assert.True(t, (&Checksum{Enabled: new(true)}).isEnabled())
+	assert.False(t, (&Checksum{Enabled: new(false)}).isEnabled())
+}
+
+func TestMergeChecksum(t *testing.T) {
+	t.Parallel()
+
+	base := &Checksum{Type: "github_release", Asset: "checksums.txt", Algorithm: "sha256"}
+
+	// Override only disables verification (common aqua per-OS pattern).
+	merged := mergeChecksum(base, &Checksum{Enabled: new(false)})
+	assert.Equal(t, "github_release", merged.Type)
+	assert.Equal(t, "checksums.txt", merged.Asset)
+	assert.False(t, merged.isEnabled())
+
+	// Base unchanged.
+	assert.True(t, base.isEnabled())
+
+	// Nil base returns override.
+	assert.Equal(t, base, mergeChecksum(nil, base))
+	// Nil override returns base.
+	assert.Equal(t, base, mergeChecksum(base, nil))
+
+	// Override replaces non-empty fields.
+	merged = mergeChecksum(base, &Checksum{Asset: "other.txt", Algorithm: "sha512"})
+	assert.Equal(t, "other.txt", merged.Asset)
+	assert.Equal(t, "sha512", merged.Algorithm)
+}
+
+func TestNewHasher(t *testing.T) {
+	t.Parallel()
+
+	for _, algo := range []string{"", "sha256", "SHA256"} {
+		h, err := newHasher(algo)
+		require.NoError(t, err)
+		assert.Equal(t, sha256.New().Size(), h.Size())
+	}
+
+	h, err := newHasher("sha512")
+	require.NoError(t, err)
+	assert.Equal(t, sha512.New().Size(), h.Size())
+
+	for _, weak := range []string{"md5", "sha1", "bogus"} {
+		_, err := newHasher(weak)
+		require.Error(t, err)
+	}
+}
+
+func TestParseChecksumFile(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		data    string
+		asset   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "multi-entry checksums.txt",
+			data:  "abc123  tool_linux_amd64.tar.gz\ndef456  tool_darwin_arm64.tar.gz\n",
+			asset: "tool_darwin_arm64.tar.gz",
+			want:  "def456",
+		},
+		{
+			name:  "binary-mode marker",
+			data:  "abc123 *tool_linux_amd64.tar.gz\n",
+			asset: "tool_linux_amd64.tar.gz",
+			want:  "abc123",
+		},
+		{
+			name:  "match by basename",
+			data:  "abc123  ./dist/tool_linux_amd64.tar.gz\n",
+			asset: "tool_linux_amd64.tar.gz",
+			want:  "abc123",
+		},
+		{
+			name:  "single bare digest",
+			data:  "deadbeef\n",
+			asset: "anything",
+			want:  "deadbeef",
+		},
+		{
+			name:    "asset not found",
+			data:    "abc123  other.tar.gz\n",
+			asset:   "missing.tar.gz",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseChecksumFile([]byte(tt.data), tt.asset)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// urlRegistry builds a Registry whose HTTP client serves bodies keyed by the
+// trailing path segment of the request URL, so an asset and its checksum file
+// can be served distinctly.
+func urlRegistry(responses map[string][]byte) *Registry {
+	return &Registry{
+		httpClient: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) *http.Response {
+				for name, body := range responses {
+					if strings.HasSuffix(req.URL.Path, "/"+name) {
+						return &http.Response{
+							StatusCode: http.StatusOK,
+							Body:       io.NopCloser(bytes.NewReader(body)),
+						}
+					}
+				}
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader("not found")),
+				}
+			}),
+		},
+	}
+}
+
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+func TestInstallE2E_ChecksumVerified(t *testing.T) {
+	t.Setenv("DOCKER_AGENT_TOOLS_DIR", t.TempDir())
+
+	binaryContent := []byte("#!/bin/sh\necho verified")
+	manifest := sha256Hex(binaryContent) + "  rawtool\n"
+
+	pkg := &Package{
+		RepoOwner: "acme",
+		RepoName:  "rawtool",
+		Format:    "raw",
+		Asset:     "rawtool",
+		Files:     []PackageFile{{Name: "rawtool"}},
+		Checksum:  &Checksum{Type: "github_release", Asset: "checksums.txt", Algorithm: "sha256"},
+	}
+
+	registry := urlRegistry(map[string][]byte{
+		"rawtool":       binaryContent,
+		"checksums.txt": []byte(manifest),
+	})
+
+	result, err := registry.Install(t.Context(), pkg, "v1.0.0")
+	require.NoError(t, err)
+	assertInstalledBinary(t, result, string(binaryContent), "rawtool")
+}
+
+func TestInstallE2E_ChecksumMismatch(t *testing.T) {
+	t.Setenv("DOCKER_AGENT_TOOLS_DIR", t.TempDir())
+
+	binaryContent := []byte("#!/bin/sh\necho tampered")
+	// Manifest advertises a digest for different content.
+	manifest := sha256Hex([]byte("original")) + "  rawtool\n"
+
+	pkg := &Package{
+		RepoOwner: "acme",
+		RepoName:  "rawtool",
+		Format:    "raw",
+		Asset:     "rawtool",
+		Files:     []PackageFile{{Name: "rawtool"}},
+		Checksum:  &Checksum{Type: "github_release", Asset: "checksums.txt", Algorithm: "sha256"},
+	}
+
+	registry := urlRegistry(map[string][]byte{
+		"rawtool":       binaryContent,
+		"checksums.txt": []byte(manifest),
+	})
+
+	_, err := registry.Install(t.Context(), pkg, "v1.0.0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "checksum mismatch")
+
+	// Nothing should have been linked into BinDir on a failed verification.
+	_, statErr := os.Stat(filepath.Join(BinDir(), "rawtool"))
+	assert.True(t, os.IsNotExist(statErr), "binary must not be installed on checksum failure")
+}
+
+func TestInstallE2E_ChecksumDisabled(t *testing.T) {
+	// A package whose checksum is explicitly disabled installs without
+	// requiring a checksum file to be present.
+	t.Setenv("DOCKER_AGENT_TOOLS_DIR", t.TempDir())
+
+	binaryContent := []byte("#!/bin/sh\necho nocheck")
+
+	pkg := &Package{
+		RepoOwner: "acme",
+		RepoName:  "rawtool",
+		Format:    "raw",
+		Asset:     "rawtool",
+		Files:     []PackageFile{{Name: "rawtool"}},
+		Checksum:  &Checksum{Type: "github_release", Asset: "checksums.txt", Enabled: new(false)},
+	}
+
+	registry := urlRegistry(map[string][]byte{
+		"rawtool": binaryContent,
+	})
+
+	result, err := registry.Install(t.Context(), pkg, "v1.0.0")
+	require.NoError(t, err)
+	assertInstalledBinary(t, result, string(binaryContent), "rawtool")
+}
+
+func TestInstallE2E_ChecksumFileMissing_FailsClosed(t *testing.T) {
+	t.Setenv("DOCKER_AGENT_TOOLS_DIR", t.TempDir())
+
+	binaryContent := []byte("#!/bin/sh\necho x")
+
+	pkg := &Package{
+		RepoOwner: "acme",
+		RepoName:  "rawtool",
+		Format:    "raw",
+		Asset:     "rawtool",
+		Files:     []PackageFile{{Name: "rawtool"}},
+		Checksum:  &Checksum{Type: "github_release", Asset: "checksums.txt", Algorithm: "sha256"},
+	}
+
+	// Checksum file not served -> 404.
+	registry := urlRegistry(map[string][]byte{
+		"rawtool": binaryContent,
+	})
+
+	_, err := registry.Install(t.Context(), pkg, "v1.0.0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "downloading checksum file")
+}
+
+func TestInstallE2E_UnsupportedChecksumType_Skips(t *testing.T) {
+	// Unsupported checksum types are skipped (not enforced) so installs that
+	// the registry can't help us verify still succeed.
+	t.Setenv("DOCKER_AGENT_TOOLS_DIR", t.TempDir())
+
+	binaryContent := []byte("#!/bin/sh\necho skip")
+
+	pkg := &Package{
+		RepoOwner: "acme",
+		RepoName:  "rawtool",
+		Format:    "raw",
+		Asset:     "rawtool",
+		Files:     []PackageFile{{Name: "rawtool"}},
+		Checksum:  &Checksum{Type: "http", URL: "https://example.com/sum", Algorithm: "sha256"},
+	}
+
+	registry := urlRegistry(map[string][]byte{
+		"rawtool": binaryContent,
+	})
+
+	result, err := registry.Install(t.Context(), pkg, "v1.0.0")
+	require.NoError(t, err)
+	assertInstalledBinary(t, result, string(binaryContent), "rawtool")
+}

--- a/pkg/toolinstall/installer.go
+++ b/pkg/toolinstall/installer.go
@@ -3,6 +3,7 @@ package toolinstall
 import (
 	"context"
 	"fmt"
+	"io"
 	"maps"
 	"os"
 	"os/exec"
@@ -15,6 +16,11 @@ import (
 // Install downloads and installs a package at the specified version.
 // Returns the path to the installed binary.
 func (r *Registry) Install(ctx context.Context, pkg *Package, version string) (string, error) {
+	// Apply the aqua version_override matching this version before deciding
+	// how to install (asset, format, checksum, and even type can differ
+	// between versions).
+	pkg = resolveVersionOverride(pkg, version)
+
 	if pkg.IsGoPackage() {
 		return installGoPackage(ctx, pkg, version)
 	}
@@ -78,6 +84,10 @@ func installGoPackage(ctx context.Context, pkg *Package, version string) (string
 
 // installGitHubRelease downloads and installs a package from GitHub releases.
 func (r *Registry) installGitHubRelease(ctx context.Context, pkg *Package, version string) (string, error) {
+	if pkg.NoAsset {
+		return "", fmt.Errorf("%s/%s has no downloadable asset for version %s", pkg.RepoOwner, pkg.RepoName, version)
+	}
+
 	binaryName := pkg.BinaryName()
 	if binaryName == "" {
 		return "", fmt.Errorf("cannot determine binary name for %s/%s", pkg.RepoOwner, pkg.RepoName)
@@ -100,6 +110,9 @@ func (r *Registry) installGitHubRelease(ctx context.Context, pkg *Package, versi
 	if err != nil {
 		return "", fmt.Errorf("rendering asset template: %w", err)
 	}
+	if assetName == "" {
+		return "", fmt.Errorf("%s/%s has no asset configured for version %s", pkg.RepoOwner, pkg.RepoName, version)
+	}
 
 	downloadURL := fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/%s",
 		pkg.RepoOwner, pkg.RepoName, version, assetName)
@@ -110,18 +123,35 @@ func (r *Registry) installGitHubRelease(ctx context.Context, pkg *Package, versi
 	}
 	defer body.Close()
 
+	// Spool the asset to disk so its checksum can be verified before any of
+	// its bytes are extracted and made executable.
+	asset, err := spoolToTemp(body)
+	if err != nil {
+		return "", fmt.Errorf("downloading %s: %w", downloadURL, err)
+	}
+	defer func() {
+		asset.Close()
+		_ = os.Remove(asset.Name())
+	}()
+
+	if pc.Checksum.isEnabled() {
+		if err := r.verifyAssetChecksum(ctx, pkg, version, assetName, asset.Name(), pc.Checksum, pc.TemplateData); err != nil {
+			return "", err
+		}
+	}
+
 	if err := os.MkdirAll(pkgDir, 0o755); err != nil { //nolint:gosec // package dir holds installed tool binaries; needs traversal/exec
 		return "", fmt.Errorf("creating package directory: %w", err)
 	}
 
 	switch pc.Format {
 	case "raw", "":
-		// Single-binary download — write the body directly to binaryPath.
-		if err := writeRawBinary(body, binaryPath); err != nil {
+		// Single-binary download — write the asset directly to binaryPath.
+		if err := writeRawBinary(asset, binaryPath); err != nil {
 			return "", err
 		}
 	default:
-		if err := extractRelease(body, pkgDir, pc.Format, pc.Files, pc.TemplateData); err != nil {
+		if err := extractRelease(asset, pkgDir, pc.Format, pc.Files, pc.TemplateData); err != nil {
 			return "", err
 		}
 	}
@@ -138,11 +168,12 @@ func (r *Registry) installGitHubRelease(ctx context.Context, pkg *Package, versi
 }
 
 // platformConfig holds all platform-resolved package fields needed for
-// downloading and extracting a release asset.
+// downloading, verifying, and extracting a release asset.
 type platformConfig struct {
 	Format       string
 	Asset        string
 	Files        []PackageFile
+	Checksum     *Checksum
 	TemplateData templateData
 }
 
@@ -153,6 +184,8 @@ func resolveForPlatform(pkg *Package, version string) platformConfig {
 	asset := pkg.Asset
 	files := pkg.Files
 	replacements := pkg.Replacements
+	replacementsOwned := false
+	checksum := pkg.Checksum
 
 	for _, o := range pkg.Overrides {
 		if o.GOOS != "" && o.GOOS != runtime.GOOS {
@@ -170,9 +203,17 @@ func resolveForPlatform(pkg *Package, version string) platformConfig {
 		if len(o.Files) > 0 {
 			files = o.Files
 		}
+		if o.Checksum != nil {
+			checksum = mergeChecksum(checksum, o.Checksum)
+		}
 		if len(o.Replacements) > 0 {
-			if replacements == nil {
-				replacements = make(map[string]string)
+			// Copy-on-write so we never mutate the package's shared
+			// Replacements map.
+			if !replacementsOwned {
+				cp := make(map[string]string, len(replacements)+len(o.Replacements))
+				maps.Copy(cp, replacements)
+				replacements = cp
+				replacementsOwned = true
 			}
 			maps.Copy(replacements, o.Replacements)
 		}
@@ -193,9 +234,10 @@ func resolveForPlatform(pkg *Package, version string) platformConfig {
 	}
 
 	return platformConfig{
-		Format: format,
-		Asset:  asset,
-		Files:  files,
+		Format:   format,
+		Asset:    asset,
+		Files:    files,
+		Checksum: checksum,
 		TemplateData: templateData{
 			Version: templateVersion,
 			OS:      osName,
@@ -203,6 +245,40 @@ func resolveForPlatform(pkg *Package, version string) platformConfig {
 			Format:  format,
 		},
 	}
+}
+
+// spoolToTemp copies an asset stream to a temporary file so it can be
+// checksum-verified before extraction. The returned file is positioned at the
+// start; the caller must close and remove it. The copy is bounded by
+// maxArchiveCompressed to defend against an attacker-controlled release
+// streaming an unbounded body.
+func spoolToTemp(r io.Reader) (*os.File, error) {
+	f, err := os.CreateTemp("", "cagent-asset-*")
+	if err != nil {
+		return nil, fmt.Errorf("creating temp file: %w", err)
+	}
+
+	cleanup := func() {
+		f.Close()
+		_ = os.Remove(f.Name())
+	}
+
+	n, err := io.Copy(f, io.LimitReader(r, maxArchiveCompressed+1))
+	if err != nil {
+		cleanup()
+		return nil, fmt.Errorf("buffering asset: %w", err)
+	}
+	if n > maxArchiveCompressed {
+		cleanup()
+		return nil, errExtractTooLarge
+	}
+
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		cleanup()
+		return nil, err
+	}
+
+	return f, nil
 }
 
 // ensureSymlink atomically creates a symlink in BinDir() pointing to the binary.

--- a/pkg/toolinstall/installer_test.go
+++ b/pkg/toolinstall/installer_test.go
@@ -60,6 +60,27 @@ func TestResolveForPlatform_Defaults(t *testing.T) {
 	assert.NotEmpty(t, pc.TemplateData.Arch)
 }
 
+// resolveForPlatform must never mutate the package's shared Replacements map
+// when a matching platform override adds replacements.
+func TestResolveForPlatform_DoesNotMutateSharedReplacements(t *testing.T) {
+	t.Parallel()
+
+	pkg := &Package{
+		Format:       "tar.gz",
+		Asset:        "tool_{{.OS}}_{{.Arch}}.tar.gz",
+		Replacements: map[string]string{"amd64": "x86_64"},
+		Overrides: []Override{{
+			GOOS:         runtime.GOOS,
+			Replacements: map[string]string{"linux": "unknown-linux-gnu"},
+		}},
+	}
+
+	_ = resolveForPlatform(pkg, "v1.0.0")
+
+	assert.Equal(t, map[string]string{"amd64": "x86_64"}, pkg.Replacements,
+		"base Replacements map must remain unmodified")
+}
+
 func TestEnsureSymlink(t *testing.T) {
 	t.Setenv("DOCKER_AGENT_TOOLS_DIR", t.TempDir())
 

--- a/pkg/toolinstall/registry.go
+++ b/pkg/toolinstall/registry.go
@@ -58,10 +58,38 @@ type Package struct {
 	VersionFilter string            `yaml:"version_filter"`
 	VersionPrefix string            `yaml:"version_prefix"`
 	Name          string            `yaml:"name"`
+	Checksum      *Checksum         `yaml:"checksum"`
+	NoAsset       bool              `yaml:"no_asset"`
+
+	// VersionConstraint and VersionOverrides implement aqua's per-version
+	// configuration: the base fields apply when VersionConstraint matches
+	// (commonly "false" so it never does), otherwise the first matching
+	// override is layered on top.
+	VersionConstraint string            `yaml:"version_constraint"`
+	VersionOverrides  []VersionOverride `yaml:"version_overrides"`
 
 	// GoInstallPath is the Go module path for go_install/go_build packages.
 	// Example: "golang.org/x/tools/gopls"
 	GoInstallPath string `yaml:"path"`
+}
+
+// VersionOverride is a partial package definition applied when its
+// VersionConstraint matches the version being installed. It mirrors the aqua
+// registry "version_overrides" schema; only the fields relevant to resolving
+// and downloading an asset are parsed.
+type VersionOverride struct {
+	VersionConstraint string            `yaml:"version_constraint"`
+	Type              string            `yaml:"type"`
+	Asset             string            `yaml:"asset"`
+	Format            string            `yaml:"format"`
+	Files             []PackageFile     `yaml:"files"`
+	Overrides         []Override        `yaml:"overrides"`
+	Replacements      map[string]string `yaml:"replacements"`
+	Checksum          *Checksum         `yaml:"checksum"`
+	VersionPrefix     string            `yaml:"version_prefix"`
+	SupportedEnvs     []string          `yaml:"supported_envs"`
+	GoInstallPath     string            `yaml:"path"`
+	NoAsset           *bool             `yaml:"no_asset"`
 }
 
 // IsGoPackage returns true if this package is installed via "go install".
@@ -96,6 +124,7 @@ type Override struct {
 	Format       string            `yaml:"format"`
 	Files        []PackageFile     `yaml:"files"`
 	Replacements map[string]string `yaml:"replacements"`
+	Checksum     *Checksum         `yaml:"checksum"`
 }
 
 // registryIndex represents the top-level registry.yaml containing full package definitions.

--- a/pkg/toolinstall/versionoverride.go
+++ b/pkg/toolinstall/versionoverride.go
@@ -1,0 +1,137 @@
+package toolinstall
+
+import (
+	"log/slog"
+	"maps"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/expr-lang/expr"
+)
+
+// resolveVersionOverride returns a package view for a specific version with the
+// first matching aqua "version_override" applied. Packages without
+// version_overrides are returned unchanged.
+//
+// aqua evaluates the base package's own constraint first (commonly "false" so
+// it never matches on its own), then each override top-to-bottom; the first
+// match wins and its fields are layered over the base.
+func resolveVersionOverride(pkg *Package, version string) *Package {
+	if len(pkg.VersionOverrides) == 0 {
+		return pkg
+	}
+
+	if pkg.VersionConstraint != "" && evalVersionConstraint(pkg.VersionConstraint, version) {
+		return pkg
+	}
+
+	for i := range pkg.VersionOverrides {
+		vo := &pkg.VersionOverrides[i]
+		if evalVersionConstraint(vo.VersionConstraint, version) {
+			return applyVersionOverride(pkg, vo)
+		}
+	}
+
+	return pkg
+}
+
+// applyVersionOverride layers a matched override's non-empty fields onto a copy
+// of the base package. Replacements and checksum are merged; everything else
+// replaces the base value when set.
+func applyVersionOverride(base *Package, vo *VersionOverride) *Package {
+	resolved := *base
+	resolved.VersionOverrides = nil
+
+	if vo.Type != "" {
+		resolved.Type = vo.Type
+	}
+	if vo.Asset != "" {
+		resolved.Asset = vo.Asset
+	}
+	if vo.Format != "" {
+		resolved.Format = vo.Format
+	}
+	if len(vo.Files) > 0 {
+		resolved.Files = vo.Files
+	}
+	if len(vo.Overrides) > 0 {
+		resolved.Overrides = vo.Overrides
+	}
+	if vo.GoInstallPath != "" {
+		resolved.GoInstallPath = vo.GoInstallPath
+	}
+	if vo.VersionPrefix != "" {
+		resolved.VersionPrefix = vo.VersionPrefix
+	}
+	if len(vo.SupportedEnvs) > 0 {
+		resolved.SupportedEnvs = vo.SupportedEnvs
+	}
+	if vo.Checksum != nil {
+		resolved.Checksum = mergeChecksum(resolved.Checksum, vo.Checksum)
+	}
+	if len(vo.Replacements) > 0 {
+		merged := make(map[string]string, len(resolved.Replacements)+len(vo.Replacements))
+		maps.Copy(merged, resolved.Replacements)
+		maps.Copy(merged, vo.Replacements)
+		resolved.Replacements = merged
+	}
+	if vo.NoAsset != nil {
+		resolved.NoAsset = *vo.NoAsset
+	}
+
+	return &resolved
+}
+
+// evalVersionConstraint evaluates an aqua version_constraint expression against
+// a version. An empty constraint matches. Compilation or evaluation errors are
+// treated as "no match" (logged) so a single malformed registry entry cannot
+// abort resolution.
+//
+// The expression language is aqua's: the variable "Version" plus the functions
+// semver/semverWithVersion/trimPrefix; string operators like startsWith,
+// matches, and in are provided natively by expr-lang.
+func evalVersionConstraint(constraint, version string) bool {
+	constraint = strings.TrimSpace(constraint)
+	if constraint == "" {
+		return true
+	}
+
+	out, err := expr.Eval(constraint, constraintEnv(version))
+	if err != nil {
+		slog.Warn("Failed to evaluate aqua version_constraint",
+			"constraint", constraint, "version", version, "error", err)
+		return false
+	}
+
+	matched, ok := out.(bool)
+	return ok && matched
+}
+
+func constraintEnv(version string) map[string]any {
+	return map[string]any{
+		"Version": version,
+		"semver": func(constraint string) bool {
+			return semverSatisfies(version, constraint)
+		},
+		"semverWithVersion": func(constraint, v string) bool {
+			return semverSatisfies(v, constraint)
+		},
+		"trimPrefix": strings.TrimPrefix,
+	}
+}
+
+// semverSatisfies reports whether version satisfies the semver constraint range.
+// Invalid versions or constraints yield false so a malformed entry can never
+// accidentally match. Matches aqua's range semantics via Masterminds/semver,
+// which (like npm/cargo) excludes pre-releases unless the range names one.
+func semverSatisfies(version, constraint string) bool {
+	c, err := semver.NewConstraint(constraint)
+	if err != nil {
+		return false
+	}
+	v, err := semver.NewVersion(version)
+	if err != nil {
+		return false
+	}
+	return c.Check(v)
+}

--- a/pkg/toolinstall/versionoverride_test.go
+++ b/pkg/toolinstall/versionoverride_test.go
@@ -1,0 +1,261 @@
+package toolinstall
+
+import (
+	"testing"
+
+	"github.com/goccy/go-yaml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEvalVersionConstraint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		constraint string
+		version    string
+		want       bool
+	}{
+		{"empty matches", "", "v1.0.0", true},
+		{"literal true", "true", "v1.0.0", true},
+		{"literal false", "false", "v1.0.0", false},
+		{"semver in range", `semver("<= 0.25.1")`, "v0.20.0", true},
+		{"semver out of range", `semver("<= 0.25.1")`, "v0.30.0", false},
+		{"semver with v prefix", `semver(">= 1.0.0")`, "v1.2.3", true},
+		{"equality match", `Version == "0.26.0"`, "0.26.0", true},
+		{"equality no match", `Version == "0.26.0"`, "0.27.0", false},
+		{"startsWith", `Version startsWith "v1."`, "v1.4.0", true},
+		{"in list", `Version in ["v1.0.0", "v1.1.0"]`, "v1.1.0", true},
+		{"or expression", `Version == "1.0.0" or semver(">= 2.0.0")`, "v2.5.0", true},
+		{"caret range excludes next major", `semver("^1.2.0")`, "v2.0.0", false},
+		{"invalid constraint is no match", `this is not valid (`, "v1.0.0", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, evalVersionConstraint(tt.constraint, tt.version))
+		})
+	}
+}
+
+func TestSemverSatisfies(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, semverSatisfies("v1.2.3", ">= 1.0.0"))
+	assert.True(t, semverSatisfies("1.2", "< 2.0.0")) // coerced to 1.2.0
+	assert.False(t, semverSatisfies("v2.0.0", "<= 1.5.0"))
+	// Pre-releases are excluded from plain ranges (npm/cargo semantics).
+	assert.False(t, semverSatisfies("v1.0.0-rc1", ">= 0.1.0"))
+	assert.False(t, semverSatisfies("not-a-version", ">= 0.1.0"))
+	assert.False(t, semverSatisfies("v1.0.0", "not-a-constraint ("))
+}
+
+// fzfRegistry mirrors the real aqua junegunn/fzf shape: an empty base with a
+// "false" constraint and version_overrides whose asset/format/checksum change
+// across versions, ending in a "true" catch-all for the newest releases.
+const fzfRegistryYAML = `
+type: github_release
+repo_owner: junegunn
+repo_name: fzf
+version_constraint: "false"
+version_overrides:
+  - version_constraint: semver("<= 0.25.1")
+    asset: fzf-{{.Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    checksum:
+      type: github_release
+      asset: fzf_{{.Version}}_checksums.txt
+      algorithm: sha256
+    overrides:
+      - goos: windows
+        format: zip
+  - version_constraint: "true"
+    asset: fzf-{{trimV .Version}}-{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    checksum:
+      type: github_release
+      asset: fzf_{{trimV .Version}}_checksums.txt
+      algorithm: sha256
+`
+
+func parsePackage(t *testing.T, y string) *Package {
+	t.Helper()
+	var pkg Package
+	require.NoError(t, yaml.Unmarshal([]byte(y), &pkg))
+	return &pkg
+}
+
+func TestResolveVersionOverride_FZF_Newest(t *testing.T) {
+	t.Parallel()
+
+	pkg := parsePackage(t, fzfRegistryYAML)
+	resolved := resolveVersionOverride(pkg, "v0.65.0")
+
+	// The "true" catch-all override supplies the asset/checksum.
+	assert.Equal(t, "fzf-{{trimV .Version}}-{{.OS}}_{{.Arch}}.{{.Format}}", resolved.Asset)
+	assert.Equal(t, "tar.gz", resolved.Format)
+	require.NotNil(t, resolved.Checksum)
+	assert.Equal(t, "fzf_{{trimV .Version}}_checksums.txt", resolved.Checksum.Asset)
+	assert.Equal(t, "sha256", resolved.Checksum.Algorithm)
+	// Base identity is preserved.
+	assert.Equal(t, "junegunn", resolved.RepoOwner)
+	assert.Equal(t, "github_release", resolved.Type)
+}
+
+func TestResolveVersionOverride_FZF_Old(t *testing.T) {
+	t.Parallel()
+
+	pkg := parsePackage(t, fzfRegistryYAML)
+	resolved := resolveVersionOverride(pkg, "v0.20.0")
+
+	// The "<= 0.25.1" override wins; its asset template lacks trimV.
+	assert.Equal(t, "fzf-{{.Version}}-{{.OS}}_{{.Arch}}.{{.Format}}", resolved.Asset)
+	require.NotNil(t, resolved.Checksum)
+	assert.Equal(t, "fzf_{{.Version}}_checksums.txt", resolved.Checksum.Asset)
+}
+
+func TestResolveVersionOverride_NoOverrides(t *testing.T) {
+	t.Parallel()
+
+	pkg := &Package{RepoOwner: "acme", RepoName: "tool", Asset: "tool.tar.gz"}
+	assert.Same(t, pkg, resolveVersionOverride(pkg, "v1.0.0"))
+}
+
+func TestResolveVersionOverride_ChecksumDisabledPerOS(t *testing.T) {
+	t.Parallel()
+
+	// An override that matches but disables checksum should merge enabled:false
+	// onto the base checksum.
+	y := `
+type: github_release
+repo_owner: acme
+repo_name: tool
+checksum:
+  type: github_release
+  asset: checksums.txt
+  algorithm: sha256
+version_constraint: "false"
+version_overrides:
+  - version_constraint: "true"
+    asset: tool-{{.Version}}.tar.gz
+    format: tar.gz
+    checksum:
+      enabled: false
+`
+	pkg := parsePackage(t, y)
+	resolved := resolveVersionOverride(pkg, "v1.0.0")
+	require.NotNil(t, resolved.Checksum)
+	assert.False(t, resolved.Checksum.isEnabled())
+	// Base fields preserved through the merge.
+	assert.Equal(t, "checksums.txt", resolved.Checksum.Asset)
+}
+
+func TestResolveVersionOverride_NoAsset(t *testing.T) {
+	t.Parallel()
+
+	y := `
+type: github_release
+repo_owner: acme
+repo_name: tool
+version_constraint: "false"
+version_overrides:
+  - version_constraint: Version == "v1.0.0"
+    no_asset: true
+  - version_constraint: "true"
+    asset: tool-{{.Version}}.tar.gz
+    format: tar.gz
+`
+	pkg := parsePackage(t, y)
+
+	yanked := resolveVersionOverride(pkg, "v1.0.0")
+	assert.True(t, yanked.NoAsset)
+
+	ok := resolveVersionOverride(pkg, "v2.0.0")
+	assert.False(t, ok.NoAsset)
+	assert.Equal(t, "tool-{{.Version}}.tar.gz", ok.Asset)
+}
+
+func TestResolveVersionOverride_TypeChangePerVersion(t *testing.T) {
+	t.Parallel()
+
+	// Older versions installed via go_build, newer via github_release.
+	y := `
+type: github_release
+repo_owner: acme
+repo_name: tool
+version_constraint: "false"
+version_overrides:
+  - version_constraint: semver("< 1.0.0")
+    type: go_build
+    path: github.com/acme/tool
+  - version_constraint: "true"
+    asset: tool-{{.Version}}.tar.gz
+    format: tar.gz
+`
+	pkg := parsePackage(t, y)
+
+	old := resolveVersionOverride(pkg, "v0.5.0")
+	assert.True(t, old.IsGoPackage())
+	assert.Equal(t, "github.com/acme/tool", old.GoInstallPath)
+
+	current := resolveVersionOverride(pkg, "v1.2.0")
+	assert.False(t, current.IsGoPackage())
+}
+
+func TestInstallE2E_VersionOverride_SelectsAsset(t *testing.T) {
+	t.Setenv("DOCKER_AGENT_TOOLS_DIR", t.TempDir())
+
+	binaryContent := []byte("#!/bin/sh\necho overridden")
+	manifest := sha256Hex(binaryContent) + "  tool\n"
+
+	y := `
+type: github_release
+repo_owner: acme
+repo_name: tool
+version_constraint: "false"
+version_overrides:
+  - version_constraint: "true"
+    asset: tool
+    format: raw
+    files:
+      - name: tool
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      algorithm: sha256
+`
+	pkg := parsePackage(t, y)
+
+	registry := urlRegistry(map[string][]byte{
+		"tool":          binaryContent,
+		"checksums.txt": []byte(manifest),
+	})
+
+	result, err := registry.Install(t.Context(), pkg, "v1.0.0")
+	require.NoError(t, err)
+	assertInstalledBinary(t, result, string(binaryContent), "tool")
+}
+
+func TestInstallE2E_VersionOverride_NoAssetFails(t *testing.T) {
+	t.Setenv("DOCKER_AGENT_TOOLS_DIR", t.TempDir())
+
+	y := `
+type: github_release
+repo_owner: acme
+repo_name: tool
+version_constraint: "false"
+version_overrides:
+  - version_constraint: "true"
+    no_asset: true
+`
+	pkg := parsePackage(t, y)
+
+	_, err := urlRegistry(nil).Install(t.Context(), pkg, "v1.0.0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no downloadable asset")
+}


### PR DESCRIPTION
## What

Make tool auto-install both **more reliable** and **safer** by leveraging the aqua registry more fully:

1. **Checksum verification** of downloaded tool binaries before they are extracted, made executable, or linked onto the agent's PATH.
2. **`version_overrides` support**, so per-version package configuration is resolved correctly.

## Why

- The installer previously only understood **top-level** aqua package fields, so the ~80% of registry packages that keep their config under `version_overrides` (e.g. `fzf`) resolved an **empty asset and failed to install**.
- Downloaded release assets were installed with **no integrity check** — a corrupted or tampered download would be extracted and run.

## How

- Parse the aqua `checksum` schema on `Package` / `Override` / `VersionOverride`. Spool the asset to disk, fetch the release's checksum manifest, hash the asset, and verify **before** extraction/chmod/symlink.
  - **Fails closed** when an enabled, supported checksum is advertised.
  - Skips unsupported checksum types and weak (md5/sha1) algorithms with a warning (no false assurance), so installs without usable metadata still succeed.
- Resolve `version_overrides` / `version_constraint` using `expr-lang/expr` (aqua's own engine) + `Masterminds/semver` (already a dependency). The first matching override is layered onto the base package (asset/format/files/checksum/type/...).
- Harden `resolveForPlatform` to never mutate the package's shared `Replacements` map (copy-on-write).

## Threat model / limitation

The checksum manifest is fetched from the **same** GitHub release as the asset, so this guards against in-transit / CDN tampering but **not** a fully compromised release (attacker controls both files). Stronger supply-chain guarantees — pinned digests or cosign/SLSA provenance — remain follow-up work.

## Tests

- Checksum parsing & end-to-end verification (success, mismatch aborts with nothing installed, disabled, fail-closed on missing manifest, unsupported-type skip).
- Constraint evaluation (semver / equality / startsWith / in / or / caret / invalid).
- `version_overrides` resolution against real registry shapes (`fzf` old vs newest, per-OS checksum disable, `no_asset`, per-version type change).
- Regression test that `resolveForPlatform` does not mutate shared state.

`task build`, `task lint` (0 issues), and `task test` all pass.

## User impact

- Common CLI tools that previously failed to auto-install now work.
- Auto-installed binaries are integrity-checked before use.
- No new configuration or commands — fully automatic.
