### PR TITLE
Remove MCP non-working servers 

### DIFF
--- a/pkg/tools/builtin/mcpcatalog/servers.json
+++ b/pkg/tools/builtin/mcpcatalog/servers.json
@@ -726,46 +726,6 @@
       }
     },
     {
-      "id": "supabase",
-      "title": "Supabase",
-      "description": "Manage Supabase projects, run database queries, edit schemas and configure edge functions and storage.",
-      "url": "https://mcp.supabase.com/mcp",
-      "transport": "streamable-http",
-      "category": "database",
-      "tags": [
-        "database",
-        "postgres",
-        "backend",
-        "auth",
-        "storage",
-        "remote"
-      ],
-      "icon": "https://www.google.com/s2/favicons?domain=supabase.com&sz=64",
-      "headers": {},
-      "auth": {
-        "type": "oauth"
-      }
-    },
-    {
-      "id": "tally",
-      "title": "Tally",
-      "description": "Build forms and inspect Tally form submissions and respondent data.",
-      "url": "https://api.tally.so/mcp",
-      "transport": "streamable-http",
-      "category": "productivity",
-      "tags": [
-        "productivity",
-        "forms",
-        "surveys",
-        "remote"
-      ],
-      "icon": "https://www.google.com/s2/favicons?domain=tally.so&sz=64",
-      "headers": {},
-      "auth": {
-        "type": "oauth"
-      }
-    },
-    {
       "id": "waystation",
       "title": "WayStation",
       "description": "Connect AI to your productivity ecosystem with integrations across Notion, Slack, Asana, Monday.com, and 50+ other business tools.",

--- a/pkg/tools/builtin/mcpcatalog/servers.json
+++ b/pkg/tools/builtin/mcpcatalog/servers.json
@@ -3,7 +3,7 @@
   "source_url": "https://desktop.docker.com/mcp/catalog/v3/catalog.json",
   "schema_version": 3,
   "filter": "type=remote AND remote.transport_type=streamable-http",
-  "count": 35,
+  "count": 33,
   "servers": [
     {
       "id": "astro-docs",


### PR DESCRIPTION
The Supabase and Tally entries in the MCP catalog do not work reliably through the OAuth flow. Until their OAuth integration is fixed, exposing them in the catalog leads users into a broken first-run experience, so drop them for now.

