### PR TITLE
fix: stop sidebar token usage panel flickering during sub-agent transfers

### DIFF
--- a/pkg/tui/components/sidebar/context_percent_test.go
+++ b/pkg/tui/components/sidebar/context_percent_test.go
@@ -13,83 +13,39 @@ import (
 func TestContextPercent_SingleSession(t *testing.T) {
 	t.Parallel()
 
-	sess := session.New()
-	sessionState := service.NewSessionState(sess)
-	m := New(sessionState).(*model)
-
-	m.SetTokenUsage(&runtime.TokenUsageEvent{
-		SessionID:    "session-1",
-		AgentContext: runtime.AgentContext{AgentName: "root"},
-		Usage: &runtime.Usage{
-			InputTokens:   5000,
-			OutputTokens:  5000,
-			ContextLength: 10000,
-			ContextLimit:  100000,
-		},
-	})
+	m := newTestSidebar()
+	m.startStream("session-1", "root")
+	m.recordUsage("session-1", "root", 10000, 100000)
 
 	assert.Equal(t, "10%", m.contextPercent())
 }
 
-func TestContextPercent_MultipleSessionsWithCurrentAgent(t *testing.T) {
+// TestContextPercent_TracksActiveSession verifies the percentage follows the
+// active session: the sub-agent's context while it runs, the parent's once it
+// returns.
+func TestContextPercent_TracksActiveSession(t *testing.T) {
 	t.Parallel()
 
-	sess := session.New()
-	sessionState := service.NewSessionState(sess)
-	m := New(sessionState).(*model)
+	m := newTestSidebar()
 
-	// Root agent session
-	m.SetTokenUsage(&runtime.TokenUsageEvent{
-		SessionID:    "session-root",
-		AgentContext: runtime.AgentContext{AgentName: "root"},
-		Usage: &runtime.Usage{
-			InputTokens:   20000,
-			OutputTokens:  10000,
-			ContextLength: 30000,
-			ContextLimit:  100000,
-		},
-	})
+	m.startStream("session-root", "root")
+	m.recordUsage("session-root", "root", 30000, 100000)
 
-	// Child agent session (from transfer_task)
-	m.SetTokenUsage(&runtime.TokenUsageEvent{
-		SessionID:    "session-child",
-		AgentContext: runtime.AgentContext{AgentName: "developer"},
-		Usage: &runtime.Usage{
-			InputTokens:   8000,
-			OutputTokens:  2000,
-			ContextLength: 10000,
-			ContextLimit:  200000,
-		},
-	})
+	m.startStream("session-child", "developer")
+	m.recordUsage("session-child", "developer", 10000, 200000)
+	assert.Equal(t, "5%", m.contextPercent(), "sub-agent context while it runs")
 
-	// Current agent is the child — should show child's percentage
-	m.currentAgent = "developer"
-	assert.Equal(t, "5%", m.contextPercent())
-
-	// Switch back to root agent — should show root's percentage
-	m.currentAgent = "root"
-	assert.Equal(t, "30%", m.contextPercent())
+	m.stopStream()
+	assert.Equal(t, "30%", m.contextPercent(), "parent context after the sub-agent returns")
 }
 
 func TestContextPercent_NoContextLimit(t *testing.T) {
 	t.Parallel()
 
-	sess := session.New()
-	sessionState := service.NewSessionState(sess)
-	m := New(sessionState).(*model)
+	m := newTestSidebar()
+	m.startStream("session-1", "root")
+	m.recordUsage("session-1", "root", 10000, 0) // No context limit
 
-	m.SetTokenUsage(&runtime.TokenUsageEvent{
-		SessionID:    "session-1",
-		AgentContext: runtime.AgentContext{AgentName: "root"},
-		Usage: &runtime.Usage{
-			InputTokens:   5000,
-			OutputTokens:  5000,
-			ContextLength: 10000,
-			ContextLimit:  0, // No context limit
-		},
-	})
-
-	m.currentAgent = "root"
 	assert.Empty(t, m.contextPercent())
 }
 
@@ -110,65 +66,72 @@ func TestContextPercent_FallbackToSingleSession(t *testing.T) {
 	sessionState := service.NewSessionState(sess)
 	m := New(sessionState).(*model)
 
-	// Session with no agent mapping (e.g., restored from persistence)
+	// Session with no active stream (e.g., restored from persistence)
 	m.sessionUsage["session-1"] = &runtime.Usage{
 		InputTokens:   5000,
 		OutputTokens:  5000,
 		ContextLength: 10000,
 		ContextLimit:  100000,
 	}
-	// No sessionAgent entry, no currentAgent set
 
 	assert.Equal(t, "10%", m.contextPercent())
 }
 
-// TestContextPercent_StaleSessionIDAfterSubAgent verifies that contextPercent()
-// returns the correct value throughout a transfer_task round-trip.
-//
-// After a sub-agent's stream stops, the parent's AgentInfo event restores
-// currentAgent to the parent while currentSessionID still references the child
-// session. The sidebar must detect this stale ID and fall back to an
-// agent-name lookup so the displayed context % matches the parent.
-func TestContextPercent_StaleSessionIDAfterSubAgent(t *testing.T) {
+// TestContextPercent_StableDuringSubAgent verifies the percentage does not
+// flicker while a sub-agent is active: it consistently reflects the
+// sub-session, independent of which agent last emitted an event.
+func TestContextPercent_StableDuringSubAgent(t *testing.T) {
+	t.Parallel()
+
+	m := newTestSidebar()
+
+	m.startStream("session-root", "root")
+	m.recordUsage("session-root", "root", 30000, 100000)
+
+	m.startStream("session-child", "developer")
+	m.recordUsage("session-child", "developer", 50000, 100000)
+
+	m.currentAgent = "root"
+	for range 100 {
+		assert.Equal(t, "50%", m.contextPercent(), "contextPercent() flickered while a sub-agent was running")
+	}
+}
+
+// TestContextPercent_RoundTripDelegations replays two transfer_task round-trips
+// and asserts the percentage tracks the active session at every step.
+func TestContextPercent_RoundTripDelegations(t *testing.T) {
 	t.Parallel()
 
 	m := newTestSidebar()
 
 	// Parent starts.
-	m.setAgent("root")
 	m.startStream("parent-session", "root")
 	m.recordUsage("parent-session", "root", 30000, 100000)
 	assert.Equal(t, "30%", m.contextPercent(), "parent at 30%%")
 
-	// --- transfer_task to "developer" ---
-	m.setAgent("developer")
+	// --- transfer_task to "developer" (nested stream) ---
 	m.startStream("child-session-1", "developer")
 	m.recordUsage("child-session-1", "developer", 10000, 200000)
 	assert.Equal(t, "5%", m.contextPercent(), "developer sub-agent at 5%%")
 
 	m.stopStream()
-	m.setAgent("root") // parent restored
-
-	// Key assertion: stale currentSessionID must not cause a wrong lookup.
-	assert.Equal(t, "30%", m.contextPercent(),
-		"after sub-agent returns, context %% must reflect the parent (30%%), not the child (5%%)")
+	assert.Equal(t, "30%", m.contextPercent(), "after sub-agent returns, back to the parent (30%%)")
 
 	// --- transfer_task to "researcher" (second round-trip) ---
-	m.setAgent("researcher")
 	m.startStream("child-session-2", "researcher")
 	m.recordUsage("child-session-2", "researcher", 80000, 100000)
 	assert.Equal(t, "80%", m.contextPercent(), "researcher sub-agent at 80%%")
 
 	m.stopStream()
-	m.setAgent("root") // parent restored again
+	assert.Equal(t, "30%", m.contextPercent(), "after second sub-agent returns, back to the parent (30%%)")
 
-	assert.Equal(t, "30%", m.contextPercent(),
-		"after second sub-agent returns, context %% must still reflect the parent (30%%)")
-
-	// Parent resumes with a new stream iteration.
-	m.startStream("parent-session", "root")
+	// Parent resumes with more usage on the main session.
 	m.recordUsage("parent-session", "root", 40000, 100000)
 	assert.Equal(t, "40%", m.contextPercent(), "parent resumes at 40%%")
+
+	// Parent's outermost stream stops; the main session remains the fallback.
+	m.stopStream()
+	assert.Equal(t, "40%", m.contextPercent(), "idle: still the main session")
 }
 
 // testSidebar wraps *model with helpers that mirror the sidebar field mutations
@@ -185,17 +148,20 @@ func newTestSidebar() *testSidebar {
 	}
 }
 
-func (s *testSidebar) setAgent(name string) {
-	s.currentAgent = name
-}
-
 func (s *testSidebar) startStream(sessionID, agentName string) {
+	s.currentAgent = agentName
 	s.workingAgent = agentName
-	s.currentSessionID = sessionID
+	if len(s.sessionStack) == 0 {
+		s.rootSessionID = sessionID
+	}
+	s.sessionStack = append(s.sessionStack, sessionID)
 }
 
 func (s *testSidebar) stopStream() {
 	s.workingAgent = ""
+	if n := len(s.sessionStack); n > 0 {
+		s.sessionStack = s.sessionStack[:n-1]
+	}
 }
 
 func (s *testSidebar) recordUsage(sessionID, agentName string, contextLen, contextLimit int64) {
@@ -207,6 +173,17 @@ func (s *testSidebar) recordUsage(sessionID, agentName string, contextLen, conte
 			OutputTokens:  contextLen / 2,
 			ContextLength: contextLen,
 			ContextLimit:  contextLimit,
+		},
+	})
+}
+
+func (s *testSidebar) recordUsageTokens(sessionID, agentName string, input, output int64) {
+	s.SetTokenUsage(&runtime.TokenUsageEvent{
+		SessionID:    sessionID,
+		AgentContext: runtime.AgentContext{AgentName: agentName},
+		Usage: &runtime.Usage{
+			InputTokens:  input,
+			OutputTokens: output,
 		},
 	})
 }

--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -58,6 +58,10 @@ type Model interface {
 	SetQueuedMessages(messages ...string)
 	GetSize() (width, height int)
 	LoadFromSession(sess *session.Session)
+	// ResetStreamTracking clears the active-stream stack so a new top-level run
+	// starts from a clean slate, even if a previous run's stream events were
+	// left unbalanced (e.g. cancelled without a StreamCancelledMsg).
+	ResetStreamTracking()
 	// HandleClick checks if click is on the star or title and returns true if handled
 	HandleClick(x, y int) bool
 	// HandleClickType returns the type of click (star, title, agent, or none).
@@ -455,8 +459,10 @@ func (m *model) LoadFromSession(sess *session.Session) {
 		}
 	}
 
-	// The restored session is the main session until a stream starts.
+	// The restored session is the main session until a stream starts. A freshly
+	// loaded session has no in-flight streams, so clear any stale stack entries.
 	m.rootSessionID = sess.ID
+	m.sessionStack = nil
 
 	// Load session title
 	if sess.Title != "" {
@@ -475,6 +481,20 @@ func (m *model) LoadFromSession(sess *session.Session) {
 	// Session has content if it has messages or token usage
 	m.sessionHasContent = len(sess.Messages) > 0 || sess.InputTokens > 0 || sess.OutputTokens > 0
 
+	m.invalidateCache()
+}
+
+// ResetStreamTracking clears the active-stream stack. It is called when a new
+// top-level run begins so leaked entries from a previous run that ended without
+// a balanced StreamStoppedEvent (e.g. a context cancel without a
+// StreamCancelledMsg) cannot pile up and pin the panel to a stale sub-session.
+// rootSessionID is preserved so the idle display stays valid until the next
+// stream starts.
+func (m *model) ResetStreamTracking() {
+	if len(m.sessionStack) == 0 {
+		return
+	}
+	m.sessionStack = nil
 	m.invalidateCache()
 }
 

--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -113,7 +113,6 @@ type model struct {
 	yPos               int                       // absolute y position on screen
 	layoutCfg          LayoutConfig              // layout configuration for spacing
 	sessionUsage       map[string]*runtime.Usage // sessionID -> latest usage snapshot
-	sessionAgent       map[string]string         // sessionID -> agent name
 	todoComp           *todotool.SidebarComponent
 	mcpInit            bool
 	ragIndexing        map[string]*ragIndexingState // strategy name -> indexing state
@@ -132,8 +131,9 @@ type model struct {
 	availableSkills    int
 	toolsLoading       bool // true when more tools may still be loading
 	sessionState       *service.SessionState
-	workingAgent       string // Name of the agent currently working (empty if none)
-	currentSessionID   string // Session ID of the currently active stream
+	workingAgent       string   // Name of the agent currently working (empty if none)
+	sessionStack       []string // Active stream session IDs; the top is the active (deepest) session
+	rootSessionID      string   // Main (top-level) session, shown when no stream is active
 	scrollview         *scrollview.Model
 	workingDirectory   string
 	gitBranchName      string   // current git branch, empty if not in a repo
@@ -171,7 +171,6 @@ func New(sessionState *service.SessionState) Model {
 		layoutCfg:    DefaultLayoutConfig(),
 		height:       24,
 		sessionUsage: make(map[string]*runtime.Usage),
-		sessionAgent: make(map[string]string),
 		todoComp:     todotool.NewSidebarComponent(),
 		spinner:      spinner.New(spinner.ModeSpinnerOnly, styles.SpinnerDotsHighlightStyle),
 		sessionTitle: "New session",
@@ -235,7 +234,6 @@ func (m *model) SetTokenUsage(event *runtime.TokenUsageEvent) {
 	// Store/replace by session ID (each event has cumulative totals for that session)
 	usage := *event.Usage
 	m.sessionUsage[event.SessionID] = &usage
-	m.sessionAgent[event.SessionID] = event.AgentName
 
 	// Mark session as having content once we receive token usage
 	m.sessionHasContent = true
@@ -457,6 +455,9 @@ func (m *model) LoadFromSession(sess *session.Session) {
 		}
 	}
 
+	// The restored session is the main session until a stream starts.
+	m.rootSessionID = sess.ID
+
 	// Load session title
 	if sess.Title != "" {
 		m.sessionTitle = sess.Title
@@ -491,34 +492,28 @@ func formatCost(cost float64) string {
 	return fmt.Sprintf("%.2f", cost)
 }
 
-// currentSessionUsage returns the usage snapshot for the current agent's session.
-// It uses a 3-tier lookup: session ID → agent name → single-session fallback.
-func (m *model) currentSessionUsage() (*runtime.Usage, bool) {
-	// Direct lookup by current session ID, skipping when the session belongs
-	// to a different agent (stale after a sub-agent's stream stops while
-	// currentAgent has already been restored to the parent).
-	if m.currentSessionID != "" {
-		owner := m.sessionAgent[m.currentSessionID]
-		stale := owner != "" && m.currentAgent != "" && owner != m.currentAgent
-		if !stale {
-			if usage, ok := m.sessionUsage[m.currentSessionID]; ok {
-				return usage, true
-			}
+// activeSessionID returns the session whose usage the sidebar should display:
+// the deepest currently-running stream, or the main session when idle. It is
+// derived from the stream stack rather than the (rapidly toggling) current
+// agent, so the displayed totals stay stable while a sub-agent runs instead of
+// flickering between the parent and sub-session.
+func (m *model) activeSessionID() string {
+	if n := len(m.sessionStack); n > 0 {
+		return m.sessionStack[n-1]
+	}
+	return m.rootSessionID
+}
+
+// activeSessionUsage returns the usage snapshot for the active session.
+func (m *model) activeSessionUsage() (*runtime.Usage, bool) {
+	if id := m.activeSessionID(); id != "" {
+		if usage, ok := m.sessionUsage[id]; ok {
+			return usage, true
 		}
 	}
 
-	// Fallback: search by current agent name.
-	if m.currentAgent != "" {
-		for sessionID, agentName := range m.sessionAgent {
-			if agentName == m.currentAgent {
-				if usage, ok := m.sessionUsage[sessionID]; ok {
-					return usage, true
-				}
-			}
-		}
-	}
-
-	// Fallback: if there's exactly one session, use it.
+	// Fallback: if there's exactly one session, use it (e.g. restored from
+	// persistence before any stream has started).
 	if len(m.sessionUsage) == 1 {
 		for _, usage := range m.sessionUsage {
 			return usage, true
@@ -527,17 +522,17 @@ func (m *model) currentSessionUsage() (*runtime.Usage, bool) {
 	return nil, false
 }
 
-// currentSessionTokens returns the token count for the current agent's session.
-func (m *model) currentSessionTokens() (tokens int64, found bool) {
-	if usage, ok := m.currentSessionUsage(); ok {
+// activeSessionTokens returns the token count for the active session.
+func (m *model) activeSessionTokens() (tokens int64, found bool) {
+	if usage, ok := m.activeSessionUsage(); ok {
 		return usage.InputTokens + usage.OutputTokens, true
 	}
 	return 0, false
 }
 
-// contextPercent returns a context usage percentage string for the current agent's session.
+// contextPercent returns a context usage percentage string for the active session.
 func (m *model) contextPercent() string {
-	if usage, ok := m.currentSessionUsage(); ok && usage.ContextLimit > 0 {
+	if usage, ok := m.activeSessionUsage(); ok && usage.ContextLimit > 0 {
 		percent := (float64(usage.ContextLength) / float64(usage.ContextLimit)) * 100
 		return fmt.Sprintf("%.0f%%", percent)
 	}
@@ -700,7 +695,13 @@ func (m *model) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		// New stream starting - reset cancelled flag and enable spinner
 		m.streamCancelled = false
 		m.workingAgent = msg.AgentName
-		m.currentSessionID = msg.SessionID
+		// Track the active session via a stack: the outermost stream owns the
+		// main session; nested sub-agent streams are pushed on top so their
+		// usage is shown while they run, then popped when they stop.
+		if len(m.sessionStack) == 0 {
+			m.rootSessionID = msg.SessionID
+		}
+		m.sessionStack = append(m.sessionStack, msg.SessionID)
 		// If title hasn't been generated yet, show the title generation spinner
 		if !m.titleGenerated {
 			m.titleRegenerating = true
@@ -710,6 +711,9 @@ func (m *model) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		return m, cmd
 	case *runtime.StreamStoppedEvent:
 		m.workingAgent = ""
+		if n := len(m.sessionStack); n > 0 {
+			m.sessionStack = m.sessionStack[:n-1]
+		}
 		m.invalidateCache()
 		m.stopSpinner() // Will only stop if no other state needs it
 		return m, nil
@@ -738,6 +742,7 @@ func (m *model) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		// Clear all spinner-driving state when stream is cancelled via ESC
 		m.streamCancelled = true
 		m.workingAgent = ""
+		m.sessionStack = nil
 		m.toolsLoading = false
 		m.mcpInit = false
 		m.titleRegenerating = false
@@ -1077,7 +1082,7 @@ func (m *model) computeUsageStats() usageStats {
 		s.totalCost += usage.Cost
 		s.sessionCount++
 	}
-	s.tokens, _ = m.currentSessionTokens()
+	s.tokens, _ = m.activeSessionTokens()
 	s.contextPct = m.contextPercent()
 	return s
 }

--- a/pkg/tui/components/sidebar/token_usage_test.go
+++ b/pkg/tui/components/sidebar/token_usage_test.go
@@ -101,6 +101,32 @@ func TestActiveSessionTokens_StableDuringSubAgent(t *testing.T) {
 	}
 }
 
+// TestActiveSessionTokens_RecoversFromImbalancedStreams verifies that a new
+// top-level run starting with a reset is not pinned to a leaked sub-session
+// from a previous run whose stream events were left unbalanced.
+func TestActiveSessionTokens_RecoversFromImbalancedStreams(t *testing.T) {
+	t.Parallel()
+
+	m := newTestSidebar()
+
+	// Turn 1: a sub-agent stream is left unbalanced (no matching stop).
+	m.startStream("session-root", "root")
+	m.recordUsageTokens("session-root", "root", 20000, 10000) // 30000
+	m.startStream("session-child", "developer")
+	m.recordUsageTokens("session-child", "developer", 8000, 2000) // 10000
+
+	// Turn 2: a new top-level run resets tracking, runs, and completes.
+	m.ResetStreamTracking()
+	m.startStream("session-root", "root")
+	m.recordUsageTokens("session-root", "root", 25000, 10000) // 35000
+	m.stopStream()
+
+	// Idle after the turn: must show the main session, not the leaked child.
+	tokens, found := m.activeSessionTokens()
+	assert.True(t, found)
+	assert.Equal(t, int64(35000), tokens)
+}
+
 func TestTokenUsageSummary_SingleSession(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tui/components/sidebar/token_usage_test.go
+++ b/pkg/tui/components/sidebar/token_usage_test.go
@@ -10,69 +10,45 @@ import (
 	"github.com/docker/docker-agent/pkg/tui/service"
 )
 
-func TestCurrentSessionTokens_SingleSession(t *testing.T) {
+func TestActiveSessionTokens_SingleSession(t *testing.T) {
 	t.Parallel()
 
-	sess := session.New()
-	sessionState := service.NewSessionState(sess)
-	m := New(sessionState).(*model)
+	m := newTestSidebar()
+	m.startStream("session-1", "root")
+	m.recordUsageTokens("session-1", "root", 5000, 3000)
 
-	m.SetTokenUsage(&runtime.TokenUsageEvent{
-		SessionID:    "session-1",
-		AgentContext: runtime.AgentContext{AgentName: "root"},
-		Usage: &runtime.Usage{
-			InputTokens:  5000,
-			OutputTokens: 3000,
-		},
-	})
-
-	m.currentAgent = "root"
-	tokens, found := m.currentSessionTokens()
+	tokens, found := m.activeSessionTokens()
 	assert.True(t, found)
 	assert.Equal(t, int64(8000), tokens)
 }
 
-func TestCurrentSessionTokens_MultipleSessions(t *testing.T) {
+// TestActiveSessionTokens_TracksActiveSubSession verifies the panel shows the
+// running sub-session's tokens while it is active, then the parent's again once
+// the sub-session stops.
+func TestActiveSessionTokens_TracksActiveSubSession(t *testing.T) {
 	t.Parallel()
 
-	sess := session.New()
-	sessionState := service.NewSessionState(sess)
-	m := New(sessionState).(*model)
+	m := newTestSidebar()
 
-	m.SetTokenUsage(&runtime.TokenUsageEvent{
-		SessionID:    "session-root",
-		AgentContext: runtime.AgentContext{AgentName: "root"},
-		Usage: &runtime.Usage{
-			InputTokens:  20000,
-			OutputTokens: 10000,
-		},
-	})
+	m.startStream("session-root", "root")
+	m.recordUsageTokens("session-root", "root", 20000, 10000)
 
-	m.SetTokenUsage(&runtime.TokenUsageEvent{
-		SessionID:    "session-child",
-		AgentContext: runtime.AgentContext{AgentName: "developer"},
-		Usage: &runtime.Usage{
-			InputTokens:  8000,
-			OutputTokens: 2000,
-		},
-	})
+	// Sub-agent runs as a nested stream.
+	m.startStream("session-child", "developer")
+	m.recordUsageTokens("session-child", "developer", 8000, 2000)
 
-	// Current agent is developer — should return developer's tokens
-	m.currentAgent = "developer"
-	m.currentSessionID = "session-child"
-	tokens, found := m.currentSessionTokens()
+	tokens, found := m.activeSessionTokens()
 	assert.True(t, found)
-	assert.Equal(t, int64(10000), tokens)
+	assert.Equal(t, int64(10000), tokens, "while the sub-agent runs, show its tokens")
 
-	// Switch to root — should return root's tokens
-	m.currentAgent = "root"
-	m.currentSessionID = "session-root"
-	tokens, found = m.currentSessionTokens()
+	// Sub-agent done — back to the parent's tokens.
+	m.stopStream()
+	tokens, found = m.activeSessionTokens()
 	assert.True(t, found)
-	assert.Equal(t, int64(30000), tokens)
+	assert.Equal(t, int64(30000), tokens, "after the sub-agent returns, show the parent's tokens")
 }
 
-func TestCurrentSessionTokens_FallbackToSingleSession(t *testing.T) {
+func TestActiveSessionTokens_FallbackToSingleSession(t *testing.T) {
 	t.Parallel()
 
 	sess := session.New()
@@ -84,74 +60,52 @@ func TestCurrentSessionTokens_FallbackToSingleSession(t *testing.T) {
 		OutputTokens: 5000,
 	}
 
-	tokens, found := m.currentSessionTokens()
+	tokens, found := m.activeSessionTokens()
 	assert.True(t, found)
 	assert.Equal(t, int64(10000), tokens)
 }
 
-func TestCurrentSessionTokens_Empty(t *testing.T) {
+func TestActiveSessionTokens_Empty(t *testing.T) {
 	t.Parallel()
 
 	sess := session.New()
 	sessionState := service.NewSessionState(sess)
 	m := New(sessionState).(*model)
 
-	tokens, found := m.currentSessionTokens()
+	tokens, found := m.activeSessionTokens()
 	assert.False(t, found)
 	assert.Equal(t, int64(0), tokens)
 }
 
-func TestCurrentSessionTokens_SessionIDTakesPrecedence(t *testing.T) {
+// TestActiveSessionTokens_StableDuringSubAgent verifies the reported count does
+// not flicker while a sub-agent is the active session: it consistently reports
+// the sub-session's tokens regardless of which agent last emitted an event.
+func TestActiveSessionTokens_StableDuringSubAgent(t *testing.T) {
 	t.Parallel()
 
-	// This test verifies the fix for the flickering bug.
-	// When the same agent runs multiple sessions (e.g., transfer_task called
-	// twice to the same sub-agent, or new_session for the same agent), the
-	// agent name lookup in sessionAgent is ambiguous because Go map iteration
-	// order is non-deterministic. Using currentSessionID for direct lookup
-	// eliminates this ambiguity.
+	m := newTestSidebar()
 
-	sess := session.New()
-	sessionState := service.NewSessionState(sess)
-	m := New(sessionState).(*model)
+	m.startStream("session-root", "root")
+	m.recordUsageTokens("session-root", "root", 20000, 10000)
 
-	// Same agent "developer" has two sessions (e.g., transfer_task called twice)
-	m.SetTokenUsage(&runtime.TokenUsageEvent{
-		SessionID:    "child-session-1",
-		AgentContext: runtime.AgentContext{AgentName: "developer"},
-		Usage: &runtime.Usage{
-			InputTokens:  5000,
-			OutputTokens: 5000,
-		},
-	})
+	m.startStream("session-child", "developer")
+	m.recordUsageTokens("session-child", "developer", 8000, 2000)
 
-	m.SetTokenUsage(&runtime.TokenUsageEvent{
-		SessionID:    "child-session-2",
-		AgentContext: runtime.AgentContext{AgentName: "developer"},
-		Usage: &runtime.Usage{
-			InputTokens:  20000,
-			OutputTokens: 10000,
-		},
-	})
-
-	m.currentAgent = "developer"
-	m.currentSessionID = "child-session-2"
-
-	// Must consistently return session-2's tokens, not randomly pick between them
+	// Even if the parent agent name lingers in currentAgent, the active
+	// session is the sub-session and must be reported consistently.
+	m.currentAgent = "root"
 	for range 100 {
-		tokens, found := m.currentSessionTokens()
+		tokens, found := m.activeSessionTokens()
 		assert.True(t, found)
-		assert.Equal(t, int64(30000), tokens, "currentSessionTokens() returned inconsistent value — the flickering bug is back")
+		assert.Equal(t, int64(10000), tokens, "activeSessionTokens() flickered while a sub-agent was running")
 	}
 }
 
 func TestTokenUsageSummary_SingleSession(t *testing.T) {
 	t.Parallel()
 
-	sess := session.New()
-	sessionState := service.NewSessionState(sess)
-	m := New(sessionState).(*model)
-
+	m := newTestSidebar()
+	m.startStream("session-1", "root")
 	m.SetTokenUsage(&runtime.TokenUsageEvent{
 		SessionID:    "session-1",
 		AgentContext: runtime.AgentContext{AgentName: "root"},
@@ -164,8 +118,6 @@ func TestTokenUsageSummary_SingleSession(t *testing.T) {
 		},
 	})
 
-	m.currentAgent = "root"
-	m.currentSessionID = "session-1"
 	summary := m.tokenUsageSummary()
 	// Single session: shows total tokens, cost, and context
 	assert.Contains(t, summary, "Tokens: 8.0K")
@@ -174,14 +126,13 @@ func TestTokenUsageSummary_SingleSession(t *testing.T) {
 	assert.NotContains(t, summary, "sub-sessions")
 }
 
-func TestTokenUsageSummary_MultipleSessions_ShowsCurrentSessionTokens(t *testing.T) {
+func TestTokenUsageSummary_MultipleSessions_ShowsActiveSessionTokens(t *testing.T) {
 	t.Parallel()
 
-	sess := session.New()
-	sessionState := service.NewSessionState(sess)
-	m := New(sessionState).(*model)
+	m := newTestSidebar()
 
 	// Root agent session: 30K tokens, $0.10
+	m.startStream("session-root", "root")
 	m.SetTokenUsage(&runtime.TokenUsageEvent{
 		SessionID:    "session-root",
 		AgentContext: runtime.AgentContext{AgentName: "root"},
@@ -195,6 +146,7 @@ func TestTokenUsageSummary_MultipleSessions_ShowsCurrentSessionTokens(t *testing
 	})
 
 	// Child agent session: 10K tokens, $0.05
+	m.startStream("session-child", "developer")
 	m.SetTokenUsage(&runtime.TokenUsageEvent{
 		SessionID:    "session-child",
 		AgentContext: runtime.AgentContext{AgentName: "developer"},
@@ -207,28 +159,20 @@ func TestTokenUsageSummary_MultipleSessions_ShowsCurrentSessionTokens(t *testing
 		},
 	})
 
-	m.currentAgent = "root"
-	m.currentSessionID = "session-root"
+	// While the sub-agent runs, show its tokens and context, with the
+	// aggregated cost and sub-session count.
 	summary := m.tokenUsageSummary()
-	// Should show current session (root) tokens, not total
-	assert.Contains(t, summary, "Tokens: 30.0K")
-	// Should show total cost ($0.10 + $0.05)
+	assert.Contains(t, summary, "Tokens: 10.0K")
 	assert.Contains(t, summary, "Cost: $0.15")
-	// Should show context % for root session
-	assert.Contains(t, summary, "Context: 30%")
-	// Should show sub-session count
+	assert.Contains(t, summary, "Context: 5%")
 	assert.Contains(t, summary, "1 sub-sessions")
 
-	// Switch to developer
-	m.currentAgent = "developer"
-	m.currentSessionID = "session-child"
+	// Once it returns, the parent's tokens and context are shown again.
+	m.stopStream()
 	summary = m.tokenUsageSummary()
-	// Should show current session (developer) tokens
-	assert.Contains(t, summary, "Tokens: 10.0K")
-	// Should still show total cost
+	assert.Contains(t, summary, "Tokens: 30.0K")
 	assert.Contains(t, summary, "Cost: $0.15")
-	// Should show context % for developer session
-	assert.Contains(t, summary, "Context: 5%")
+	assert.Contains(t, summary, "Context: 30%")
 }
 
 func TestTokenUsageSummary_Empty(t *testing.T) {
@@ -239,40 +183,4 @@ func TestTokenUsageSummary_Empty(t *testing.T) {
 	m := New(sessionState).(*model)
 
 	assert.Empty(t, m.tokenUsageSummary())
-}
-
-func TestContextPercent_SessionIDTakesPrecedence(t *testing.T) {
-	t.Parallel()
-
-	// Same flickering bug applies to contextPercent — verify session ID lookup
-	// takes precedence over non-deterministic agent name map iteration.
-
-	sess := session.New()
-	sessionState := service.NewSessionState(sess)
-	m := New(sessionState).(*model)
-
-	m.SetTokenUsage(&runtime.TokenUsageEvent{
-		SessionID:    "child-session-1",
-		AgentContext: runtime.AgentContext{AgentName: "developer"},
-		Usage: &runtime.Usage{
-			ContextLength: 10000,
-			ContextLimit:  100000,
-		},
-	})
-
-	m.SetTokenUsage(&runtime.TokenUsageEvent{
-		SessionID:    "child-session-2",
-		AgentContext: runtime.AgentContext{AgentName: "developer"},
-		Usage: &runtime.Usage{
-			ContextLength: 50000,
-			ContextLimit:  100000,
-		},
-	})
-
-	m.currentAgent = "developer"
-	m.currentSessionID = "child-session-2"
-
-	for range 100 {
-		assert.Equal(t, "50%", m.contextPercent(), "contextPercent() returned inconsistent value — the flickering bug is back")
-	}
 }

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -882,6 +882,7 @@ func (p *chatPage) processMessage(msg msgtypes.SendMsg) tea.Cmd {
 	}
 
 	p.streamDepth = 0
+	p.sidebar.ResetStreamTracking()
 
 	var ctx context.Context
 	ctx, p.msgCancel = context.WithCancel(context.Background())


### PR DESCRIPTION
The sidebar's Token Usage panel flickered between two different numbers while a sub-agent ran. This happened because the panel picked which session to display using the `currentAgent` heuristic, which toggles rapidly as sub-agents are spawned and cleaned up. The fix tracks the active session via a stream stack instead: we push on `StreamStarted` and pop on `StreamStopped`, so the panel stably shows the active (sub-)session's tokens and context, then reverts to the parent once the sub-agent returns.

The second commit hardens this against drift: a new `ResetStreamTracking()` method (called from the chat page's `processMessage`, mirroring its existing `streamDepth=0` reset) plus clearing the stack on `LoadFromSession` prevents leaked entries from pinning the panel to a stale sub-session or growing unbounded when a stream ends without a balanced `StreamStoppedEvent` (for example, when a context cancel occurs without a corresponding `StreamCancelledMsg`).

All changes are confined to `pkg/tui/components/sidebar/` and `pkg/tui/page/chat/chat.go`, with updated and added unit tests. Linter and the full test suite both pass.