### PR TITLE
fix: add max_tokens floor for Anthropic when thinking is disabled

### DIFF
--- a/pkg/model/provider/anthropic/client.go
+++ b/pkg/model/provider/anthropic/client.go
@@ -202,6 +202,10 @@ func (c *Client) CreateChatCompletionStream(
 	if err != nil {
 		return nil, err
 	}
+	// Leave headroom for visible output when thinking is disabled with a tiny
+	// cap (e.g. title generation): adaptive-thinking models still reason and
+	// would otherwise consume the whole budget, returning empty text.
+	maxTokens = c.floorMaxTokensForNoThinking(maxTokens)
 
 	client, err := c.clientFn(ctx)
 	if err != nil {

--- a/pkg/model/provider/anthropic/thinking.go
+++ b/pkg/model/provider/anthropic/thinking.go
@@ -19,6 +19,26 @@ const (
 	thinkingDisplayDisplay    = "display"
 )
 
+// noThinkingMinOutputTokens is the minimum output-token budget enforced when
+// thinking is disabled but the caller imposed a tiny max_tokens cap. Anthropic
+// adaptive-thinking models (e.g. Claude Opus 4.6+) always reason internally,
+// and those hidden thinking tokens count against max_tokens. A small cap (title
+// generation uses 20) can be entirely consumed by reasoning, leaving no visible
+// output and producing an empty title. This mirrors the OpenAI provider's floor
+// for reasoning models.
+const noThinkingMinOutputTokens int64 = 256
+
+// floorMaxTokensForNoThinking raises a tiny max_tokens cap to
+// noThinkingMinOutputTokens when the caller disabled thinking (e.g. title or
+// summary generation). The floor is scoped to the NoThinking path so it never
+// overrides an explicit user-set cap during normal completions.
+func (c *Client) floorMaxTokensForNoThinking(maxTokens int64) int64 {
+	if c.ModelOptions.NoThinking() && maxTokens < noThinkingMinOutputTokens {
+		return noThinkingMinOutputTokens
+	}
+	return maxTokens
+}
+
 // adjustMaxTokensForThinking checks if max_tokens needs adjustment for thinking_budget.
 // Anthropic's max_tokens represents the combined budget for thinking + output tokens.
 // Returns the adjusted maxTokens value and an error if user-set max_tokens is too low.

--- a/pkg/model/provider/anthropic/thinking_test.go
+++ b/pkg/model/provider/anthropic/thinking_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/model/provider/base"
+	"github.com/docker/docker-agent/pkg/model/provider/options"
 )
 
 func TestAnthropicThinkingDisplay(t *testing.T) {
@@ -466,6 +467,55 @@ func TestCoerceAdaptiveThinking(t *testing.T) {
 		t.Run("opus-4-7 "+name+" passes through", func(t *testing.T) {
 			c := clientWithModel("claude-opus-4-7", in, nil)
 			assert.Same(t, in, c.coerceAdaptiveThinking())
+		})
+	}
+}
+
+func TestFloorMaxTokensForNoThinking(t *testing.T) {
+	buildOpts := func(opts ...options.Opt) options.ModelOptions {
+		var mo options.ModelOptions
+		for _, opt := range opts {
+			opt(&mo)
+		}
+		return mo
+	}
+
+	tests := []struct {
+		name      string
+		opts      options.ModelOptions
+		maxTokens int64
+		want      int64
+	}{
+		{
+			name:      "no-thinking tiny cap is raised to floor",
+			opts:      buildOpts(options.WithNoThinking(), options.WithMaxTokens(20)),
+			maxTokens: 20,
+			want:      noThinkingMinOutputTokens,
+		},
+		{
+			name:      "no-thinking cap already above floor is unchanged",
+			opts:      buildOpts(options.WithNoThinking()),
+			maxTokens: 8192,
+			want:      8192,
+		},
+		{
+			name:      "no-thinking cap equal to floor is unchanged",
+			opts:      buildOpts(options.WithNoThinking()),
+			maxTokens: noThinkingMinOutputTokens,
+			want:      noThinkingMinOutputTokens,
+		},
+		{
+			name:      "thinking enabled leaves tiny cap untouched",
+			opts:      buildOpts(options.WithMaxTokens(20)),
+			maxTokens: 20,
+			want:      20,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{Config: base.Config{ModelOptions: tt.opts}}
+			assert.Equal(t, tt.want, c.floorMaxTokensForNoThinking(tt.maxTokens))
 		})
 	}
 }


### PR DESCRIPTION
Newer adaptive-thinking Claude models (such as claude-fable-5) reason internally even when thinking is nominally disabled. With a 20-token budget from title generation's `WithNoThinking()` call, this internal reasoning consumes the entire allocation, leaving no tokens for visible output. The model returns empty text, causing title generation to fail.

The OpenAI provider already handles this by enforcing a 256-token output floor for reasoning models when thinking is disabled. This ensures hidden reasoning tokens can't starve visible output. Anthropic had no equivalent protection.

This fix adds `noThinkingMinOutputTokens = 256` and a `floorMaxTokensForNoThinking` helper in `pkg/model/provider/anthropic/thinking.go`, wired into `CreateChatCompletionStream` right after `adjustMaxTokensForThinking`. The floor applies only when thinking is disabled, ensuring it never overrides an explicit user-set cap during normal completions. It's intentionally gated on `NoThinking` rather than a model-name allowlist, so it covers new and unknown reasoning models automatically.

Test coverage includes scenarios for raising tiny caps to the floor, no-op above the floor, equal-to-floor, and thinking-enabled paths remaining untouched.