### PR TITLE
feat: add title_model for delegating session-title generation

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -1527,6 +1527,14 @@
               "dmr/ai/qwen3"
             ]
           ]
+        },
+        "title_model": {
+          "type": "string",
+          "description": "Model used to generate session titles when an agent runs with this model. Lets a heavyweight primary model delegate the cheap title-generation call to a smaller/faster model. Value can be a model name from the models section or an inline 'provider/model' spec. When omitted, title generation reuses the agent's own model.",
+          "examples": [
+            "openai/gpt-4o-mini",
+            "title_model"
+          ]
         }
       },
       "additionalProperties": false

--- a/agent-schema.json
+++ b/agent-schema.json
@@ -1533,7 +1533,7 @@
           "description": "Model used to generate session titles when an agent runs with this model. Lets a heavyweight primary model delegate the cheap title-generation call to a smaller/faster model. Value can be a model name from the models section or an inline 'provider/model' spec. When omitted, title generation reuses the agent's own model.",
           "examples": [
             "openai/gpt-4o-mini",
-            "title_model"
+            "fast"
           ]
         }
       },

--- a/cmd/root/debug.go
+++ b/cmd/root/debug.go
@@ -215,13 +215,13 @@ func (f *debugFlags) runDebugTitleCommand(cmd *cobra.Command, args []string) (co
 		return err
 	}
 
-	model := agent.Model(ctx)
-	if model == nil {
+	// Use the same title generation code path as the TUI (see runTUI in new.go),
+	// including any dedicated title_model configured for the agent's model.
+	models := agent.TitleModels(ctx)
+	if len(models) == 0 {
 		return fmt.Errorf("agent %q has no model configured", agent.Name())
 	}
-
-	// Use the same title generation code path as the TUI (see runTUI in new.go)
-	gen := sessiontitle.New(model, agent.FallbackModels()...)
+	gen := sessiontitle.New(models[0], models[1:]...)
 
 	title, err := gen.Generate(ctx, "debug", []string{args[1]})
 	if err != nil {

--- a/examples/title_model.yaml
+++ b/examples/title_model.yaml
@@ -1,0 +1,27 @@
+# Title Model Example
+#
+# This example demonstrates how a model can delegate session-title
+# generation to another, cheaper/faster model via the `title_model` field.
+#
+# Session titles are short summaries generated from the first user message.
+# There is no need to spend a heavyweight reasoning model on that: point the
+# primary model's `title_model` at a small model and docker-agent will use it
+# for the title-generation call only. Everything else still runs on the
+# primary model. When `title_model` is omitted, title generation reuses the
+# agent's own model.
+
+models:
+  primary:
+    provider: anthropic
+    model: claude-sonnet-4-5
+    # Generate session titles with the cheaper Haiku model instead of Sonnet.
+    title_model: fast
+  fast:
+    provider: anthropic
+    model: claude-haiku-4-5
+
+agents:
+  root:
+    model: primary
+    description: An assistant that generates session titles with a cheaper model.
+    instruction: You are a helpful assistant.

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -27,6 +27,7 @@ type Agent struct {
 	fallbackModels          []provider.Provider                 // Fallback models to try if primary fails
 	fallbackRetries         int                                 // Number of retries per fallback model with exponential backoff
 	fallbackCooldown        time.Duration                       // Duration to stick with fallback after non-retryable error
+	titleModel              provider.Provider                   // Optional dedicated model for session-title generation
 	modelOverrides          atomic.Pointer[[]provider.Provider] // Optional model override(s) set at runtime (supports alloy)
 	subAgents               []*Agent
 	handoffs                []*Agent
@@ -265,6 +266,29 @@ func (a *Agent) FallbackRetries() int {
 // model before retrying the primary. Returns 0 if not configured.
 func (a *Agent) FallbackCooldown() time.Duration {
 	return a.fallbackCooldown
+}
+
+// TitleModel returns the dedicated model configured for session-title
+// generation, or nil when none was configured (in which case title
+// generation reuses the agent's own model).
+func (a *Agent) TitleModel() provider.Provider {
+	return a.titleModel
+}
+
+// TitleModels returns the ordered list of providers to use for session-title
+// generation. The dedicated title model (when configured) comes first,
+// followed by the agent's current model and its fallbacks so title
+// generation still succeeds if the dedicated model is unavailable. The
+// result never contains nil entries.
+func (a *Agent) TitleModels(ctx context.Context) []provider.Provider {
+	var models []provider.Provider
+	if a.titleModel != nil {
+		models = append(models, a.titleModel)
+	}
+	if m := a.Model(ctx); m != nil {
+		models = append(models, m)
+	}
+	return append(models, a.fallbackModels...)
 }
 
 // Commands returns the named commands configured for this agent.

--- a/pkg/agent/opts.go
+++ b/pkg/agent/opts.go
@@ -83,6 +83,14 @@ func WithFallbackCooldown(cooldown time.Duration) Opt {
 	}
 }
 
+// WithTitleModel sets a dedicated model for session-title generation, letting
+// a heavyweight primary model delegate the cheap title call to a smaller one.
+func WithTitleModel(model provider.Provider) Opt {
+	return func(a *Agent) {
+		a.titleModel = model
+	}
+}
+
 func WithSubAgents(subAgents ...*Agent) Opt {
 	return func(a *Agent) {
 		a.subAgents = subAgents

--- a/pkg/config/first_available_test.go
+++ b/pkg/config/first_available_test.go
@@ -258,6 +258,11 @@ func TestValidateFirstAvailable(t *testing.T) {
 			wantErr: "cannot be combined with routing",
 		},
 		{
+			name:    "combined with title_model",
+			model:   latest.ModelConfig{FirstAvailable: []string{"openai/gpt-5"}, TitleModel: "openai/gpt-4o-mini"},
+			wantErr: "cannot be combined with title_model",
+		},
+		{
 			name:    "combined with token key",
 			model:   latest.ModelConfig{FirstAvailable: []string{"openai/gpt-5"}, TokenKey: "CUSTOM_API_KEY"},
 			wantErr: "cannot be combined with token_key",

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -819,6 +819,12 @@ type ModelConfig struct {
 	// specs. Local providers (dmr, ollama) need no credentials and make reliable
 	// final fallbacks. When set, other model configuration fields must be empty.
 	FirstAvailable []string `json:"first_available,omitempty"`
+	// TitleModel names the model used to generate session titles when an agent
+	// runs with this model. It lets a heavyweight primary model delegate the
+	// cheap title-generation call to a smaller/faster model. The value can be a
+	// model name from the models section or an inline "provider/model" spec.
+	// When empty, title generation reuses the agent's own model.
+	TitleModel string `json:"title_model,omitempty"`
 }
 
 // IsFirstAvailable reports whether this model is a first-available selector
@@ -908,7 +914,8 @@ func (f *FlexibleModelConfig) isShorthandOnly() bool {
 		f.ThinkingBudget == nil &&
 		f.TaskBudget == nil &&
 		len(f.Routing) == 0 &&
-		f.FirstAvailable == nil
+		f.FirstAvailable == nil &&
+		f.TitleModel == ""
 }
 
 // RoutingRule defines a single routing rule for model selection.

--- a/pkg/config/latest/validate.go
+++ b/pkg/config/latest/validate.go
@@ -111,6 +111,9 @@ func (m *ModelConfig) validateFirstAvailable() error {
 	if len(m.Routing) > 0 {
 		return errors.New("first_available cannot be combined with routing")
 	}
+	if m.TitleModel != "" {
+		return errors.New("first_available cannot be combined with title_model")
+	}
 	for i, ref := range m.FirstAvailable {
 		if strings.TrimSpace(ref) == "" {
 			return fmt.Errorf("first_available[%d] must not be empty", i)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -872,11 +872,11 @@ func (r *LocalRuntime) TitleGenerator() *sessiontitle.Generator {
 	// Title-gen setup happens before any session ctx exists; the resulting
 	// generator carries its own ctx when actually invoked. context.TODO is
 	// the right marker here.
-	model := a.Model(context.TODO())
-	if model == nil {
+	models := a.TitleModels(context.TODO())
+	if len(models) == 0 {
 		return nil
 	}
-	return sessiontitle.New(model, a.FallbackModels()...)
+	return sessiontitle.New(models[0], models[1:]...)
 }
 
 // getAgentModelID returns the model ID for an agent. The zero ID is

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -680,7 +680,11 @@ func (sm *SessionManager) runtimeForSession(ctx context.Context, sess *session.S
 	// the requested models instead of the agent's defaults.
 	applyStoredOverrides(ctx, sess.ID, run, sess.AgentModelOverrides)
 
-	titleGen := sessiontitle.New(agt.Model(ctx), agt.FallbackModels()...)
+	titleModels := agt.TitleModels(ctx)
+	var titleGen *sessiontitle.Generator
+	if len(titleModels) > 0 {
+		titleGen = sessiontitle.New(titleModels[0], titleModels[1:]...)
+	}
 
 	slog.DebugContext(ctx, "Runtime created for session", "session_id", sess.ID)
 

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -227,6 +227,15 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 					agent.WithFallbackCooldown(agentConfig.GetFallbackCooldown()),
 				)
 			}
+
+			// A model may delegate session-title generation to another model.
+			titleModel, err := getTitleModelForAgent(ctx, cfg, &agentConfig, runConfig)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get title model: %w", err)
+			}
+			if titleModel != nil {
+				opts = append(opts, agent.WithTitleModel(titleModel))
+			}
 		}
 
 		agentTools, warnings := getToolsForAgent(ctx, &agentConfig, parentDir, runConfig, loadOpts.toolsetRegistry, configName, expander)
@@ -423,6 +432,62 @@ func getFallbackModelsForAgent(ctx context.Context, cfg *latest.Config, a *lates
 	}
 
 	return fallbackModels, nil
+}
+
+// getTitleModelForAgent resolves the dedicated title-generation model for an
+// agent, if any. It returns the model named by the `title_model` field of the
+// first of the agent's configured models that sets it, or nil when none do.
+func getTitleModelForAgent(ctx context.Context, cfg *latest.Config, a *latest.AgentConfig, runConfig *config.RuntimeConfig) (provider.Provider, error) {
+	var titleRef string
+	for name := range strings.SplitSeq(a.Model, ",") {
+		if modelCfg, ok := cfg.Models[name]; ok && modelCfg.TitleModel != "" {
+			titleRef = modelCfg.TitleModel
+			break
+		}
+	}
+	if titleRef == "" {
+		return nil, nil
+	}
+
+	modelsStore, modelsStoreErr := runConfig.ModelsDevStore()
+
+	modelCfg, exists := cfg.Models[titleRef]
+	if !exists {
+		parsed, err := latest.ParseModelRef(titleRef)
+		if err != nil {
+			return nil, fmt.Errorf("title model '%s' not found in configuration and is not a valid provider/model format", titleRef)
+		}
+		modelCfg = parsed
+	}
+	modelCfg.Name = titleRef
+
+	maxTokens := &defaultMaxTokens
+	if modelCfg.MaxTokens != nil {
+		maxTokens = modelCfg.MaxTokens
+	} else if modelsStoreErr == nil {
+		m, err := modelsStore.GetModel(ctx, modelsdev.NewID(modelCfg.Provider, modelCfg.Model))
+		if err == nil {
+			maxTokens = &m.Limit.Output
+		}
+	}
+
+	opts := []options.Opt{
+		options.WithGateway(runConfig.ModelsGateway),
+		options.WithStructuredOutput(a.StructuredOutput),
+		options.WithProviders(cfg.Providers),
+	}
+	if maxTokens != nil {
+		opts = append(opts, options.WithMaxTokens(*maxTokens))
+	}
+	if modelsStoreErr == nil {
+		opts = append(opts, options.WithModelsDevStore(modelsStore))
+	}
+
+	model, err := provider.NewWithModels(ctx, &modelCfg, cfg.Models, runConfig.EnvProvider(), opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create title model '%s': %w", titleRef, err)
+	}
+	return model, nil
 }
 
 // getToolsForAgent returns the tool definitions for an agent based on its

--- a/pkg/teamloader/teamloader_test.go
+++ b/pkg/teamloader/teamloader_test.go
@@ -202,6 +202,87 @@ func TestOverrideModel(t *testing.T) {
 	}
 }
 
+func TestTitleModelResolution(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "dummy")
+	t.Setenv("ANTHROPIC_API_KEY", "dummy")
+
+	t.Run("named title model", func(t *testing.T) {
+		data := []byte(`models:
+  primary:
+    provider: anthropic
+    model: claude-sonnet-4-5
+    title_model: fast
+  fast:
+    provider: openai
+    model: gpt-4o-mini
+agents:
+  root:
+    model: primary
+    instruction: test
+`)
+
+		team, err := Load(t.Context(), config.NewBytesSource("title.yaml", data), &config.RuntimeConfig{})
+		require.NoError(t, err)
+
+		root, err := team.Agent("root")
+		require.NoError(t, err)
+
+		require.NotNil(t, root.TitleModel())
+		assert.Equal(t, "openai/gpt-4o-mini", root.TitleModel().ID().String())
+
+		// The dedicated title model comes first, the agent's own model follows
+		// as a fallback so title generation still works if it is unavailable.
+		models := root.TitleModels(t.Context())
+		require.Len(t, models, 2)
+		assert.Equal(t, "openai/gpt-4o-mini", models[0].ID().String())
+		assert.Equal(t, "anthropic/claude-sonnet-4-5", models[1].ID().String())
+	})
+
+	t.Run("inline title model", func(t *testing.T) {
+		data := []byte(`models:
+  primary:
+    provider: anthropic
+    model: claude-sonnet-4-5
+    title_model: openai/gpt-4o-mini
+agents:
+  root:
+    model: primary
+    instruction: test
+`)
+
+		team, err := Load(t.Context(), config.NewBytesSource("title.yaml", data), &config.RuntimeConfig{})
+		require.NoError(t, err)
+
+		root, err := team.Agent("root")
+		require.NoError(t, err)
+
+		require.NotNil(t, root.TitleModel())
+		assert.Equal(t, "openai/gpt-4o-mini", root.TitleModel().ID().String())
+	})
+
+	t.Run("no title model", func(t *testing.T) {
+		data := []byte(`agents:
+  root:
+    model: openai/gpt-4o
+    instruction: test
+`)
+
+		team, err := Load(t.Context(), config.NewBytesSource("title.yaml", data), &config.RuntimeConfig{})
+		require.NoError(t, err)
+
+		root, err := team.Agent("root")
+		require.NoError(t, err)
+
+		assert.Nil(t, root.TitleModel())
+
+		// Without a dedicated title model, generation falls back to the
+		// agent's own model.
+		models := root.TitleModels(t.Context())
+		require.Len(t, models, 1)
+		assert.Equal(t, "openai/gpt-4o", models[0].ID().String())
+	})
+}
+
 func TestLoadHarnessAgentWithoutModel(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "dummy")
 


### PR DESCRIPTION
Adds a new `title_model` field to the agent configuration, allowing a model to declare which other model should be used for generating session titles. This lets a heavyweight primary model delegate the cheap title-generation call to a smaller or faster model. The value can be a named model from the `models` section or an inline `provider/model` spec; when omitted, title generation reuses the agent's own model.

The change touches the config schema (`pkg/config/latest`), agent initialization with a new `WithTitleModel` option and `TitleModel()` getter, title-model resolution in `pkg/teamloader`, and the title generators in `pkg/runtime` and `pkg/server/session_manager.go`. The `debug title` command now respects the `title_model` setting. A validation guard ensures `first_available` cannot be combined with `title_model`, since that resolution would otherwise silently drop the delegation.

Schema documentation and an example configuration have been added, along with test coverage for title-model resolution and the new validation constraint.