### PR TITLE
fix: surface useful errors when session title generation fails

### DIFF
--- a/cmd/root/debug.go
+++ b/cmd/root/debug.go
@@ -225,7 +225,7 @@ func (f *debugFlags) runDebugTitleCommand(cmd *cobra.Command, args []string) (co
 
 	title, err := gen.Generate(ctx, "debug", []string{args[1]})
 	if err != nil {
-		return fmt.Errorf("generating title: %w", err)
+		return fmt.Errorf("generating title with agent %q: %w", agent.Name(), err)
 	}
 
 	fmt.Fprintln(cmd.OutOrStdout(), title)

--- a/pkg/sessiontitle/generator.go
+++ b/pkg/sessiontitle/generator.go
@@ -75,7 +75,7 @@ func (g *Generator) Generate(ctx context.Context, sessionID string, userMessages
 
 	messages := buildPrompt(userMessages)
 
-	var lastErr error
+	var errs []error
 	for idx, baseModel := range g.models {
 		if err := ctx.Err(); err != nil {
 			return "", err
@@ -87,9 +87,10 @@ func (g *Generator) Generate(ctx context.Context, sessionID string, userMessages
 			return title, nil
 		}
 
-		lastErr = err
+		errs = append(errs, err)
 		// Per-attempt failures are logged at Debug because we still have
-		// fallbacks; the final error is what callers log/wrap.
+		// fallbacks; the final error joins every attempt so callers see
+		// which model failed and why instead of just the last one.
 		slog.DebugContext(ctx, "Title generation attempt failed",
 			"session_id", sessionID,
 			"model", baseModel.ID(),
@@ -97,7 +98,7 @@ func (g *Generator) Generate(ctx context.Context, sessionID string, userMessages
 			"error", err)
 	}
 
-	return "", fmt.Errorf("generating title failed: %w", lastErr)
+	return "", fmt.Errorf("all %d title model(s) failed: %w", len(g.models), errors.Join(errs...))
 }
 
 // generateOnce performs a single one-shot title generation call against
@@ -118,12 +119,12 @@ func generateOnce(ctx context.Context, baseModel provider.Provider, messages []c
 
 	stream, err := titleModel.CreateChatCompletionStream(ctx, messages, nil)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("model %q: %w", baseModel.ID(), err)
 	}
 
 	raw, err := drainStream(stream)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("model %q: %w", baseModel.ID(), err)
 	}
 
 	title := sanitizeTitle(raw)

--- a/pkg/sessiontitle/generator_test.go
+++ b/pkg/sessiontitle/generator_test.go
@@ -135,6 +135,37 @@ func TestGenerator_Generate_FallsBackOnRecvError(t *testing.T) {
 	assert.Equal(t, 1, fallback.calls)
 }
 
+func TestGenerator_Generate_AllModelsFail_ReportsEachModel(t *testing.T) {
+	t.Parallel()
+
+	primary := &mockProvider{
+		id: modelsdev.NewID("primary", "boom"),
+		createFn: func() (chat.MessageStream, error) {
+			return nil, errors.New("exit status 1")
+		},
+	}
+	fallback := &mockProvider{
+		id: modelsdev.NewID("fallback", "nope"),
+		createFn: func() (chat.MessageStream, error) {
+			return nil, errors.New("connection refused")
+		},
+	}
+
+	gen := New(primary, fallback)
+	title, err := gen.Generate(t.Context(), "sess-1", []string{"hello"})
+	require.Error(t, err)
+	assert.Empty(t, title)
+
+	// Every attempt is surfaced, each tagged with the model that failed,
+	// so a bare leaf like "exit status 1" is no longer the whole message.
+	msg := err.Error()
+	assert.Contains(t, msg, "all 2 title model(s) failed")
+	assert.Contains(t, msg, `model "primary/boom"`)
+	assert.Contains(t, msg, "exit status 1")
+	assert.Contains(t, msg, `model "fallback/nope"`)
+	assert.Contains(t, msg, "connection refused")
+}
+
 func TestGenerator_Generate_FallsBackOnEmptyOutput(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
When session title generation failed, the error message was unhelpful — users would see something like `docker agent debug title: exit status 1` with no indication of what actually went wrong.

The fix improves error reporting in two ways. The `pkg/sessiontitle` generator now tags each failing model attempt with its model ID and aggregates all attempts via `errors.Join`, instead of keeping only the last error. The error message now reads like `all N title model(s) failed: model "X": <cause>`. The `docker agent debug title` command no longer double-wraps the error and includes the agent name for context.

A unit test asserts that the failure message lists every model and its cause. Changes validated with `task lint` (0 issues) and `task test` (all pass).