### PR TITLE
fix: prevent fork-mode skill commands from looping in TUI

### DIFF
--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -649,11 +649,19 @@ func (p *chatPage) handleSendMsg(msg msgtypes.SendMsg) (layout.Model, tea.Cmd) {
 		return p, core.CmdHandler(msgtypes.ExitSessionMsg{})
 	}
 
-	// Allow immediate slash commands (e.g. /exit, /compact) even in read-only mode
-	if cmd := p.parseImmediateCommand(msg.Content); cmd != nil {
-		return p, cmd
+	// Immediate UI slash commands (e.g. /exit, /compact) run even in read-only
+	// mode. A BypassQueue message has already been resolved (e.g. an agent
+	// command or fork-mode skill re-dispatching itself) and must skip parsing:
+	// re-parsing would match the same command again and loop forever.
+	if !msg.BypassQueue {
+		if cmd := p.parseImmediateCommand(msg.Content); cmd != nil {
+			return p, cmd
+		}
 	}
 
+	// Everything below hands work to the model, which read-only sessions must
+	// reject: normal input, bang commands, and resolved agent/skill commands
+	// flagged BypassQueue.
 	if p.app != nil && p.app.IsReadOnly() {
 		return p, notification.WarningCmd("Session is read-only. No new messages can be sent.")
 	}

--- a/pkg/tui/page/chat/queue_test.go
+++ b/pkg/tui/page/chat/queue_test.go
@@ -17,6 +17,7 @@ import (
 	mcptools "github.com/docker/docker-agent/pkg/tools/mcp"
 	"github.com/docker/docker-agent/pkg/tui/commands"
 	"github.com/docker/docker-agent/pkg/tui/components/sidebar"
+	"github.com/docker/docker-agent/pkg/tui/core"
 	"github.com/docker/docker-agent/pkg/tui/messages"
 	"github.com/docker/docker-agent/pkg/tui/service"
 )
@@ -142,6 +143,56 @@ func TestQueueFlow_BusyAgent_BangCommandBypassesQueue(t *testing.T) {
 		t.Fatal("bang command should not cancel the running stream")
 	default:
 	}
+}
+
+// TestQueueFlow_SkillCommand_DispatchesOnceWithoutLooping guards against a
+// regression (introduced by reordering the checks in handleSendMsg for the
+// --session-read-only feature) where fork-mode skill slash commands looped
+// forever. Such commands resolve by re-dispatching themselves as
+// SendMsg{BypassQueue: true}; if handleSendMsg re-parses that bypass message
+// it matches the same command again, re-runs Execute, and never reaches
+// processMessage (so the skill never actually runs).
+//
+// The test reproduces the real two-hop flow: the user-typed "/myskill" is
+// parsed into an Execute that emits a BypassQueue SendMsg, which is then fed
+// back through handleSendMsg. Execute must run exactly once.
+func TestQueueFlow_SkillCommand_DispatchesOnceWithoutLooping(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	p := New(app.New(t.Context(), queueTestRuntime{}, sess), service.NewSessionState(sess)).(*chatPage)
+
+	calls := 0
+	p.commandParser = commands.NewParser(commands.Category{
+		Name: "Skills",
+		Commands: []commands.Item{
+			{
+				SlashCommand: "/myskill",
+				Immediate:    true,
+				Execute: func(string) tea.Cmd {
+					calls++
+					return core.CmdHandler(messages.SendMsg{Content: "/myskill", BypassQueue: true})
+				},
+			},
+		},
+	})
+
+	// Hop 1: the user types "/myskill". It is parsed and Execute emits a
+	// BypassQueue re-dispatch of the same command.
+	_, cmd := p.handleSendMsg(messages.SendMsg{Content: "/myskill"})
+	require.NotNil(t, cmd)
+	require.Equal(t, 1, calls)
+
+	redispatch, ok := cmd().(messages.SendMsg)
+	require.True(t, ok, "skill Execute should re-dispatch a SendMsg")
+	require.True(t, redispatch.BypassQueue, "re-dispatch must bypass the queue")
+
+	// Hop 2: the BypassQueue message must be processed directly, not re-parsed
+	// back into the command (which would invoke Execute again and loop).
+	_, cmd = p.handleSendMsg(redispatch)
+	require.NotNil(t, cmd)
+	assert.Empty(t, p.messageQueue)
+	assert.Equal(t, 1, calls, "BypassQueue message must not be re-parsed into the command again")
 }
 
 func TestQueueFlow_BusyAgent_QueuesMessage(t *testing.T) {
@@ -303,4 +354,23 @@ func TestReadOnly_AllowsSlashCommands(t *testing.T) {
 
 	require.NotNil(t, cmd)
 	assert.Equal(t, immediateCommandMsg{arg: "please"}, cmd())
+}
+
+// TestReadOnly_RejectsBypassQueueCommands ensures resolved skill/agent
+// commands (re-dispatched as SendMsg{BypassQueue: true}) are still blocked in
+// read-only mode. BypassQueue only skips re-parsing to avoid the command loop;
+// it must not let model-bound work slip past the read-only guard.
+func TestReadOnly_RejectsBypassQueueCommands(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	a := app.New(t.Context(), queueTestRuntime{}, sess, app.WithReadOnly())
+	p := New(a, service.NewSessionState(sess)).(*chatPage)
+
+	_, cmd := p.handleSendMsg(messages.SendMsg{Content: "/myskill", BypassQueue: true})
+
+	require.NotNil(t, cmd)
+	assert.Empty(t, p.messageQueue)
+	assert.False(t, p.working, "read-only must not start processing a BypassQueue message")
+	assert.Nil(t, p.msgCancel, "read-only must not start a stream for a BypassQueue message")
 }

--- a/pkg/tui/page/chat/queue_test.go
+++ b/pkg/tui/page/chat/queue_test.go
@@ -2,7 +2,10 @@ package chat
 
 import (
 	"context"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/stretchr/testify/assert"
@@ -12,6 +15,7 @@ import (
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/sessiontitle"
+	"github.com/docker/docker-agent/pkg/skills"
 	"github.com/docker/docker-agent/pkg/tools"
 	skillstool "github.com/docker/docker-agent/pkg/tools/builtin/skills"
 	mcptools "github.com/docker/docker-agent/pkg/tools/mcp"
@@ -99,6 +103,74 @@ func (queueTestRuntime) TogglePause(context.Context) (bool, error)             {
 func (queueTestRuntime) Close() error                                          { return nil }
 
 var _ runtime.Runtime = queueTestRuntime{}
+
+// skillDispatchRuntime records how a skill slash command is ultimately
+// executed so tests can assert it reaches the right resolution path:
+// fork skills via RunSkillFork, inline skills via the regular RunStream path.
+type skillDispatchRuntime struct {
+	queueTestRuntime
+
+	skillset *skillstool.ToolSet
+
+	mu            sync.Mutex
+	forkCalls     []skillstool.RunSkillArgs
+	runStreamRuns int
+	lastRun       string
+}
+
+func (r *skillDispatchRuntime) CurrentAgentSkillsToolset() *skillstool.ToolSet {
+	return r.skillset
+}
+
+func (r *skillDispatchRuntime) RunSkillFork(_ context.Context, sess *session.Session, args skillstool.RunSkillArgs, sink runtime.EventSink) (*tools.ToolCallResult, error) {
+	r.mu.Lock()
+	r.forkCalls = append(r.forkCalls, args)
+	r.mu.Unlock()
+
+	sink.Emit(runtime.StreamStopped(sess.ID, "", ""))
+	return tools.ResultSuccess("done"), nil
+}
+
+func (r *skillDispatchRuntime) RunStream(_ context.Context, sess *session.Session) <-chan runtime.Event {
+	r.mu.Lock()
+	r.runStreamRuns++
+	if items := sess.GetAllMessages(); len(items) > 0 {
+		r.lastRun = items[len(items)-1].Message.Content
+	}
+	r.mu.Unlock()
+
+	ch := make(chan runtime.Event, 1)
+	ch <- runtime.StreamStopped(sess.ID, "", "")
+	close(ch)
+	return ch
+}
+
+func (r *skillDispatchRuntime) forkCallCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.forkCalls)
+}
+
+func (r *skillDispatchRuntime) lastForkArgs() skillstool.RunSkillArgs {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.forkCalls) == 0 {
+		return skillstool.RunSkillArgs{}
+	}
+	return r.forkCalls[len(r.forkCalls)-1]
+}
+
+func (r *skillDispatchRuntime) runStreamCallCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.runStreamRuns
+}
+
+func (r *skillDispatchRuntime) lastRunMessage() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.lastRun
+}
 
 func TestQueueFlow_BusyAgent_ImmediateSlashCommandBypassesQueue(t *testing.T) {
 	t.Parallel()
@@ -354,6 +426,100 @@ func TestReadOnly_AllowsSlashCommands(t *testing.T) {
 
 	require.NotNil(t, cmd)
 	assert.Equal(t, immediateCommandMsg{arg: "please"}, cmd())
+}
+
+// skillCommandParser mirrors the real skill palette item built in
+// BuildCommandCategories: an Immediate slash command whose Execute re-emits
+// the same slash text as a BypassQueue SendMsg.
+func skillCommandParser(name string) *commands.Parser {
+	return commands.NewParser(commands.Category{
+		Name: "Skills",
+		Commands: []commands.Item{
+			{
+				SlashCommand: "/" + name,
+				Immediate:    true,
+				Execute: func(arg string) tea.Cmd {
+					input := "/" + name
+					if arg = strings.TrimSpace(arg); arg != "" {
+						input += " " + arg
+					}
+					return core.CmdHandler(messages.SendMsg{Content: input, BypassQueue: true})
+				},
+			},
+		},
+	})
+}
+
+// dispatchTypedSkill reproduces typing a skill slash command in the editor.
+// Hop 1: handleSendMsg parses it and Execute re-emits a BypassQueue SendMsg.
+// Hop 2: that message is fed back through handleSendMsg, which must route it
+// to processMessage instead of re-parsing it into another SendMsg (the loop).
+func dispatchTypedSkill(t *testing.T, p *chatPage, content string) {
+	t.Helper()
+
+	_, cmd := p.handleSendMsg(messages.SendMsg{Content: content})
+	require.NotNil(t, cmd)
+
+	redispatch, ok := cmd().(messages.SendMsg)
+	require.True(t, ok, "typed skill should resolve to a re-dispatched SendMsg")
+	require.True(t, redispatch.BypassQueue, "re-dispatch must bypass the queue")
+
+	_, cmd = p.handleSendMsg(redispatch)
+	require.NotNil(t, cmd)
+	if _, loops := cmd().(messages.SendMsg); loops {
+		t.Fatal("skill SendMsg was re-emitted: dispatch is looping")
+	}
+}
+
+// TestHandleSendMsg_ForkSkillRunsViaFork proves a fork-mode skill slash
+// command reaches RunSkillFork with the parsed name/task and never loops.
+func TestHandleSendMsg_ForkSkillRunsViaFork(t *testing.T) {
+	t.Parallel()
+
+	skillSet := skillstool.New([]skills.Skill{{
+		Name:          "services",
+		Description:   "List services",
+		Context:       "fork",
+		InlineContent: "# Services\nList repository services.",
+	}}, t.TempDir())
+	rt := &skillDispatchRuntime{skillset: skillSet}
+	sess := session.New()
+	p := New(app.New(t.Context(), rt, sess), service.NewSessionState(sess)).(*chatPage)
+	p.commandParser = skillCommandParser("services")
+
+	dispatchTypedSkill(t, p, "/services please")
+
+	require.Eventually(t, func() bool { return rt.forkCallCount() == 1 }, time.Second, 10*time.Millisecond)
+	assert.Equal(t, "services", rt.lastForkArgs().Name)
+	assert.Equal(t, "please", rt.lastForkArgs().Task)
+	assert.Zero(t, rt.runStreamCallCount(), "fork skills must not use the inline RunStream path")
+	assert.Zero(t, sess.MessageCount(), "fork skill dispatch must not append an inline user message")
+}
+
+// TestHandleSendMsg_InlineSkillRunsViaResolveInput proves an inline skill
+// slash command is expanded and sent through the regular RunStream path
+// (not the fork path) and never loops.
+func TestHandleSendMsg_InlineSkillRunsViaResolveInput(t *testing.T) {
+	t.Parallel()
+
+	skillSet := skillstool.New([]skills.Skill{{
+		Name:          "services",
+		Description:   "List services",
+		InlineContent: "# Services\nList repository services.",
+	}}, t.TempDir())
+	rt := &skillDispatchRuntime{skillset: skillSet}
+	sess := session.New()
+	p := New(app.New(t.Context(), rt, sess), service.NewSessionState(sess)).(*chatPage)
+	p.commandParser = skillCommandParser("services")
+
+	dispatchTypedSkill(t, p, "/services please")
+
+	require.Eventually(t, func() bool { return sess.MessageCount() == 1 }, time.Second, 10*time.Millisecond)
+	assert.Zero(t, rt.forkCallCount(), "inline skills must not use fork dispatch")
+	require.Equal(t, 1, rt.runStreamCallCount())
+	assert.Contains(t, rt.lastRunMessage(), `<skill name="services">`)
+	assert.Contains(t, rt.lastRunMessage(), "List repository services.")
+	assert.Contains(t, rt.lastRunMessage(), "User's request: please")
 }
 
 // TestReadOnly_RejectsBypassQueueCommands ensures resolved skill/agent


### PR DESCRIPTION
## Summary

Typing a skill slash command (`/skillname`) in the TUI did nothing — the editor cleared and the skill never ran. The `--session-read-only` change had reordered `chatPage.handleSendMsg` so that `parseImmediateCommand` ran **before** the `BypassQueue` check.

Skill palette items are `Immediate` slash commands whose `Execute` re-emits a `SendMsg` carrying the **same** slash text (with `BypassQueue: true`). With the new ordering, that re-dispatched message was parsed again, re-matched its own palette item, and re-emitted itself — an infinite self-referential dispatch loop that never reached `processMessage` → `SkillCommandFork` / `ResolveInput`. (Built-in and agent commands don't loop because their `Execute` emits dedicated, non-slash message types.)

## Fix

Only skip re-parsing for `BypassQueue` messages, while still letting the read-only guard reject the resolved, model-bound work:

```go
if !msg.BypassQueue {
    if cmd := p.parseImmediateCommand(msg.Content); cmd != nil {
        return p, cmd
    }
}

if p.app != nil && p.app.IsReadOnly() {
    return p, notification.WarningCmd("Session is read-only. No new messages can be sent.")
}

if msg.BypassQueue || isBangCommand(msg.Content) {
    return p, p.processMessage(msg)
}
```

This mirrors the `if !msg.BypassQueue` guard that already exists in `processMessage`, so both dispatch paths now treat already-resolved messages consistently — rather than introducing a separate flag. It also fixes the read-only interaction: skill/agent commands are still correctly blocked in `--session-read-only` sessions instead of slipping past the guard.

> Note: #3058 fixes the same loop in `pkg/tui/commands` via a new `Item.SkipImmediateParse` flag on skill items. Both fixes are correct; this PR keeps the fix in `handleSendMsg` because it aligns with the existing `!msg.BypassQueue` guard in `processMessage` and generalizes to any re-dispatched message without a flag that would be redundant with `Immediate`. The strong end-to-end runtime tests below are adapted from the good ideas in that PR.

## Tests

- `TestQueueFlow_SkillCommand_DispatchesOnceWithoutLooping` — fast unit check that `Execute` runs exactly once across the two-hop dispatch.
- `TestReadOnly_RejectsBypassQueueCommands` — a resolved `BypassQueue` skill/agent command is still rejected in read-only mode (does not start a stream).
- `TestHandleSendMsg_ForkSkillRunsViaFork` / `TestHandleSendMsg_InlineSkillRunsViaResolveInput` — drive the real typed two-hop flow through `handleSendMsg` against a `skillDispatchRuntime` and assert the skill actually executes via the correct path: fork skills reach `RunSkillFork` with the parsed name/task; inline skills reach `ResolveInput`/`RunStream` with the `<skill name="...">` envelope and user request — and neither loops.

Each test was verified to fail against the buggy ordering and pass with the fix.

## Validation

- `go build ./...` ✓
- `go test ./pkg/tui/...` ✓ (incl. the new tests)
- `golangci-lint run ./pkg/tui/page/chat/` ✓ (0 issues)
