### PR TITLE
fix(tui): resolve skill slash commands instead of looping dispatch

### DIFF
--- a/pkg/tui/commands/commands.go
+++ b/pkg/tui/commands/commands.go
@@ -36,6 +36,11 @@ type Item struct {
 	// Immediate marks commands that should run as soon as they are submitted
 	// instead of being treated as ordinary queued chat input.
 	Immediate bool
+	// SkipImmediateParse excludes this item from Parser.Parse so the slash
+	// command falls through to the chat page's processMessage path. Skill
+	// items use this because their palette Execute re-emits the same SendMsg,
+	// which would otherwise be parsed again instead of resolved by the app.
+	SkipImmediateParse bool
 }
 
 func builtInSessionCommands() []Item {
@@ -557,12 +562,13 @@ func BuildCommandCategories(ctx context.Context, application *app.App) []Categor
 			description := toolcommon.TruncateText(skill.Description, 55)
 
 			skillCommands = append(skillCommands, Item{
-				ID:           "skill." + skillName,
-				Label:        skillName,
-				Description:  description,
-				Category:     "Skills",
-				SlashCommand: "/" + skillName,
-				Immediate:    true,
+				ID:                 "skill." + skillName,
+				Label:              skillName,
+				Description:        description,
+				Category:           "Skills",
+				SlashCommand:       "/" + skillName,
+				Immediate:          true,
+				SkipImmediateParse: true,
 				Execute: func(arg string) tea.Cmd {
 					input := "/" + skillName
 					if arg = strings.TrimSpace(arg); arg != "" {
@@ -620,7 +626,7 @@ func (p *Parser) Parse(input string) tea.Cmd {
 	// Search through all categories and commands
 	for _, category := range p.categories {
 		for _, item := range category.Commands {
-			if item.SlashCommand == cmd && item.Immediate {
+			if item.SlashCommand == cmd && item.Immediate && !item.SkipImmediateParse {
 				return item.Execute(arg)
 			}
 		}

--- a/pkg/tui/commands/commands_test.go
+++ b/pkg/tui/commands/commands_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -200,4 +201,52 @@ func TestRemoveByIDsDropsSnapshotCommands(t *testing.T) {
 	assert.Nil(t, parser.Parse("/undo"))
 	assert.Nil(t, parser.Parse("/snapshots"))
 	require.NotNil(t, parser.Parse("/exit"))
+}
+
+func TestParseSkipsItemsMarkedSkipImmediateParse(t *testing.T) {
+	t.Parallel()
+
+	parser := NewParser(Category{
+		Name: "Skills",
+		Commands: []Item{
+			{
+				SlashCommand:       "/services",
+				Immediate:          true,
+				SkipImmediateParse: true,
+				Execute: func(string) tea.Cmd {
+					return func() tea.Msg {
+						return messages.SendMsg{Content: "/services", BypassQueue: true}
+					}
+				},
+			},
+		},
+	})
+
+	assert.Nil(t, parser.Parse("/services"))
+	assert.Nil(t, parser.Parse("/services report"))
+}
+
+func TestParseStillMatchesImmediateItems(t *testing.T) {
+	t.Parallel()
+
+	parser := NewParser(Category{
+		Name: "Agent Commands",
+		Commands: []Item{
+			{
+				SlashCommand: "/review",
+				Immediate:    true,
+				Execute: func(arg string) tea.Cmd {
+					return func() tea.Msg {
+						return messages.AgentCommandMsg{Command: "/review " + arg}
+					}
+				},
+			},
+		},
+	})
+
+	cmd := parser.Parse("/review the diff")
+	require.NotNil(t, cmd)
+	msg, ok := cmd().(messages.AgentCommandMsg)
+	require.True(t, ok)
+	assert.Equal(t, "/review the diff", msg.Command)
 }

--- a/pkg/tui/page/chat/queue_test.go
+++ b/pkg/tui/page/chat/queue_test.go
@@ -2,7 +2,9 @@ package chat
 
 import (
 	"context"
+	"sync"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/stretchr/testify/assert"
@@ -12,6 +14,7 @@ import (
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/sessiontitle"
+	"github.com/docker/docker-agent/pkg/skills"
 	"github.com/docker/docker-agent/pkg/tools"
 	skillstool "github.com/docker/docker-agent/pkg/tools/builtin/skills"
 	mcptools "github.com/docker/docker-agent/pkg/tools/mcp"
@@ -98,6 +101,76 @@ func (queueTestRuntime) TogglePause(context.Context) (bool, error)             {
 func (queueTestRuntime) Close() error                                          { return nil }
 
 var _ runtime.Runtime = queueTestRuntime{}
+
+type skillDispatchRuntime struct {
+	queueTestRuntime
+
+	skillset *skillstool.ToolSet
+
+	mu            sync.Mutex
+	forkCalls     []skillstool.RunSkillArgs
+	runStreamRuns int
+	lastRun       string
+}
+
+func (r *skillDispatchRuntime) CurrentAgentSkillsToolset() *skillstool.ToolSet {
+	return r.skillset
+}
+
+func (r *skillDispatchRuntime) RunSkillFork(_ context.Context, sess *session.Session, args skillstool.RunSkillArgs, sink runtime.EventSink) (*tools.ToolCallResult, error) {
+	r.mu.Lock()
+	r.forkCalls = append(r.forkCalls, args)
+	r.lastRun = "/" + args.Name
+	if args.Task != "" {
+		r.lastRun += " " + args.Task
+	}
+	r.mu.Unlock()
+
+	sink.Emit(runtime.StreamStopped(sess.ID, "", ""))
+	return tools.ResultSuccess("done"), nil
+}
+
+func (r *skillDispatchRuntime) RunStream(_ context.Context, sess *session.Session) <-chan runtime.Event {
+	r.mu.Lock()
+	r.runStreamRuns++
+	items := sess.GetAllMessages()
+	if len(items) > 0 {
+		r.lastRun = items[len(items)-1].Message.Content
+	}
+	r.mu.Unlock()
+
+	ch := make(chan runtime.Event, 1)
+	ch <- runtime.StreamStopped(sess.ID, "", "")
+	close(ch)
+	return ch
+}
+
+func (r *skillDispatchRuntime) forkCallCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.forkCalls)
+}
+
+func (r *skillDispatchRuntime) lastForkArgs() skillstool.RunSkillArgs {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.forkCalls) == 0 {
+		return skillstool.RunSkillArgs{}
+	}
+	return r.forkCalls[len(r.forkCalls)-1]
+}
+
+func (r *skillDispatchRuntime) runStreamCallCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.runStreamRuns
+}
+
+func (r *skillDispatchRuntime) lastRunMessage() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.lastRun
+}
 
 func TestQueueFlow_BusyAgent_ImmediateSlashCommandBypassesQueue(t *testing.T) {
 	t.Parallel()
@@ -303,4 +376,81 @@ func TestReadOnly_AllowsSlashCommands(t *testing.T) {
 
 	require.NotNil(t, cmd)
 	assert.Equal(t, immediateCommandMsg{arg: "please"}, cmd())
+}
+
+func skillCommandParser(name string) *commands.Parser {
+	return commands.NewParser(commands.Category{
+		Name: "Skills",
+		Commands: []commands.Item{
+			{
+				SlashCommand:       "/" + name,
+				Immediate:          true,
+				SkipImmediateParse: true,
+				Execute: func(arg string) tea.Cmd {
+					input := "/" + name
+					if arg != "" {
+						input += " " + arg
+					}
+					return func() tea.Msg { return messages.SendMsg{Content: input, BypassQueue: true} }
+				},
+			},
+		},
+	})
+}
+
+func TestHandleSendMsg_ForkSkillFallsThroughToRunSkillFork(t *testing.T) {
+	t.Parallel()
+
+	skillSet := skillstool.New([]skills.Skill{{
+		Name:          "services",
+		Description:   "List services",
+		Context:       "fork",
+		InlineContent: "# Services\nList repository services.",
+	}}, t.TempDir())
+	rt := &skillDispatchRuntime{skillset: skillSet}
+	sess := session.New()
+	p := New(app.New(t.Context(), rt, sess), service.NewSessionState(sess)).(*chatPage)
+	p.commandParser = skillCommandParser("services")
+	p.working = false
+
+	_, cmd := p.handleSendMsg(messages.SendMsg{Content: "/services please", BypassQueue: true})
+
+	require.NotNil(t, cmd)
+	msg := cmd()
+	_, loops := msg.(messages.SendMsg)
+	assert.False(t, loops, "skill SendMsg must not be re-emitted by the parser")
+	require.Eventually(t, func() bool { return rt.forkCallCount() == 1 }, time.Second, 10*time.Millisecond)
+	assert.Equal(t, "/services please", rt.lastRunMessage())
+	assert.Equal(t, "services", rt.lastForkArgs().Name)
+	assert.Equal(t, "please", rt.lastForkArgs().Task)
+	assert.Zero(t, rt.runStreamCallCount(), "fork skills should not use inline RunStream path")
+	assert.Zero(t, sess.MessageCount(), "fork skill dispatch must not append inline user message")
+}
+
+func TestHandleSendMsg_InlineSkillFallsThroughToResolveInput(t *testing.T) {
+	t.Parallel()
+
+	skillSet := skillstool.New([]skills.Skill{{
+		Name:          "services",
+		Description:   "List services",
+		InlineContent: "# Services\nList repository services.",
+	}}, t.TempDir())
+	rt := &skillDispatchRuntime{skillset: skillSet}
+	sess := session.New()
+	p := New(app.New(t.Context(), rt, sess), service.NewSessionState(sess)).(*chatPage)
+	p.commandParser = skillCommandParser("services")
+	p.working = false
+
+	_, cmd := p.handleSendMsg(messages.SendMsg{Content: "/services please", BypassQueue: true})
+
+	require.NotNil(t, cmd)
+	msg := cmd()
+	_, loops := msg.(messages.SendMsg)
+	assert.False(t, loops, "skill SendMsg must not be re-emitted by the parser")
+	require.Eventually(t, func() bool { return sess.MessageCount() == 1 }, time.Second, 10*time.Millisecond)
+	assert.Zero(t, rt.forkCallCount(), "inline skills must not use fork dispatch")
+	require.Equal(t, 1, rt.runStreamCallCount())
+	assert.Contains(t, rt.lastRunMessage(), `<skill name="services">`)
+	assert.Contains(t, rt.lastRunMessage(), "List repository services.")
+	assert.Contains(t, rt.lastRunMessage(), "User's request: please")
 }


### PR DESCRIPTION
## Summary
Fixes #3054 — skill slash commands (e.g. `/services`, `/but`) appeared in the command palette and as `/` commands but did nothing: pressing Enter just cleared the editor and the skill never resolved or executed.

## Root cause
Skill palette items were registered as `Immediate` slash commands whose `Execute` re-emitted a `SendMsg` carrying the **same** slash text. `chatPage.handleSendMsg` runs the immediate-command parser (`parseImmediateCommand`) on every inbound `SendMsg` *before* reaching `processMessage`, so a skill command re-matched its own palette item and re-sent the identical `SendMsg` — an infinite self-referential dispatch loop. The message therefore never reached `processMessage` → `SkillCommandFork` / `ResolveInput`, so the skill was never resolved.

Built-in commands (`/clear`, `/compact`, …) and agent commands do **not** loop because their `Execute` emits dedicated message types (`ClearSessionMsg`, `AgentCommandMsg`, …) that resolve to non-slash content. Only skills re-sent their own slash text.

## Fix
Add an explicit `Item.SkipImmediateParse` flag, set it on skill items, and have `Parser.Parse` skip flagged items. The skill `SendMsg` then falls through `handleSendMsg` to `processMessage`, which routes `context: fork` skills to `SkillCommandFork`/`RunSkillFork` and inline skills to `ResolveInput`. The palette `Execute` is unchanged (still invoked directly), so this fixes both the palette and typed-slash invocation paths. Change is contained to `pkg/tui/commands/commands.go` (one struct field, one item literal, one parser condition).

## Tests
- `pkg/tui/commands/commands_test.go`: `TestParseSkipsItemsMarkedSkipImmediateParse` (skill items return nil from the parser → no self-resend), `TestParseStillMatchesImmediateItems` (agent commands still match).
- `pkg/tui/page/chat/queue_test.go`: `TestHandleSendMsg_ForkSkillFallsThroughToRunSkillFork` and `TestHandleSendMsg_InlineSkillFallsThroughToResolveInput` (the skill `SendMsg` is not re-emitted and reaches the correct resolution path).

## Validation
- `task build` ✓
- targeted `go test ./pkg/tui/commands/... ./pkg/tui/page/chat/... ./pkg/app/...` ✓ (incl. the 4 new tests)
- `task lint` ✓ (0 issues, go.mod tidy)
- Full `task test` deferred to CI.

Assisted-By: docker-agent
