### PR TITLE
expose embeddable tui components

### DIFF
--- a/pkg/tui/animation/stopper.go
+++ b/pkg/tui/animation/stopper.go
@@ -1,0 +1,17 @@
+package animation
+
+// Stopper is implemented by views that register with the animation
+// coordinator. When such a view is removed from the UI, StopAnimation must
+// be called to unregister its subscription; a leaked subscription keeps the
+// tick stream alive forever.
+type Stopper interface {
+	StopAnimation()
+}
+
+// StopView stops the animation subscription of a view being removed, when
+// it has one. Safe to call on any view.
+func StopView(view any) {
+	if stopper, ok := view.(Stopper); ok {
+		stopper.StopAnimation()
+	}
+}

--- a/pkg/tui/components/messages/messages.go
+++ b/pkg/tui/components/messages/messages.go
@@ -1712,22 +1712,6 @@ func (m *model) RemoveSpinner() {
 	m.removeSpinner()
 }
 
-// animationStopper is implemented by views that register with the animation coordinator.
-// When a view is removed from the UI, StopAnimation must be called to unregister
-// its animation subscription and prevent leaked ticks.
-type animationStopper interface {
-	StopAnimation()
-}
-
-// stopViewAnimation stops animation subscriptions for a view being removed.
-// This prevents animation tick leaks when views with active spinners are
-// removed from the message list (e.g., on stream cancellation via ESC).
-func stopViewAnimation(view layout.Model) {
-	if stopper, ok := view.(animationStopper); ok {
-		stopper.StopAnimation()
-	}
-}
-
 func (m *model) removeSpinner() {
 	if len(m.messages) == 0 {
 		return
@@ -1737,7 +1721,7 @@ func (m *model) removeSpinner() {
 	if m.messages[lastIdx].Type == types.MessageTypeSpinner {
 		// Stop any animation subscriptions before removing the view
 		if lastIdx < len(m.views) {
-			stopViewAnimation(m.views[lastIdx])
+			animation.StopView(m.views[lastIdx])
 			m.views = m.views[:lastIdx]
 		}
 		m.messages = m.messages[:lastIdx]
@@ -1767,7 +1751,7 @@ func (m *model) removePendingToolCallMessages() {
 			(msg.ToolStatus == types.ToolStatusPending || msg.ToolStatus == types.ToolStatusRunning) {
 			// Stop any animation subscriptions before removing the view
 			if i < len(m.views) {
-				stopViewAnimation(m.views[i])
+				animation.StopView(m.views[i])
 			}
 			continue
 		}

--- a/pkg/tui/components/reasoningblock/reasoningblock.go
+++ b/pkg/tui/components/reasoningblock/reasoningblock.go
@@ -728,18 +728,7 @@ func (m *Model) StopAnimation() {
 	}
 	// Stop spinners in all tool entries
 	for _, entry := range m.toolEntries {
-		stopViewAnimation(entry.view)
-	}
-}
-
-// stopViewAnimation stops animation subscriptions for a view being removed.
-type animationStopper interface {
-	StopAnimation()
-}
-
-func stopViewAnimation(view layout.Model) {
-	if stopper, ok := view.(animationStopper); ok {
-		stopper.StopAnimation()
+		animation.StopView(entry.view)
 	}
 }
 

--- a/pkg/tui/components/toolconfirm/toolconfirm.go
+++ b/pkg/tui/components/toolconfirm/toolconfirm.go
@@ -1,0 +1,167 @@
+// Package toolconfirm centralizes the tool-confirmation policy shared by
+// docker-agent's own confirmation dialog and embedders that bring their own
+// dialog framework (e.g. the Gordon assistant embedded in Docker Sandboxes):
+// the decision set and its runtime resume semantics, the "always allow"
+// permission-pattern construction, key bindings, and the user-facing strings.
+//
+// Keeping this policy in one runtime-agnostic place matters most for
+// BuildPermissionPattern: the pattern shown to the user ("always allow ls*")
+// and the pattern granted to the runtime must come from the same code, in
+// every UI that hosts a confirmation.
+package toolconfirm
+
+import (
+	"encoding/json"
+	"strings"
+
+	"charm.land/bubbles/v2/key"
+
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+// User-facing strings of the confirmation prompt.
+const (
+	Title    = "Tool Confirmation"
+	Question = "Do you want to allow this tool call?"
+)
+
+// Decision is the user's answer to a tool confirmation.
+type Decision int
+
+const (
+	// Approve runs this one call.
+	Approve Decision = iota
+	// ApproveTool runs the call and always allows the tool, scoped by the
+	// permission pattern from BuildPermissionPattern.
+	ApproveTool
+	// ApproveSession runs the call and approves all tools for the rest of
+	// the session.
+	ApproveSession
+	// Reject rejects the call with an optional reason shown to the model.
+	Reject
+)
+
+// Resume translates the decision into the runtime resume request. pattern
+// is the permission pattern for ApproveTool (from BuildPermissionPattern);
+// reason is the optional rejection reason for Reject. Each is ignored by
+// the other decisions.
+func (d Decision) Resume(pattern, reason string) runtime.ResumeRequest {
+	switch d {
+	case ApproveTool:
+		return runtime.ResumeApproveTool(pattern)
+	case ApproveSession:
+		return runtime.ResumeApproveSession()
+	case Reject:
+		return runtime.ResumeReject(reason)
+	default:
+		return runtime.ResumeApprove()
+	}
+}
+
+// BuildPermissionPattern creates the permission pattern granted by the
+// "always allow" decision. For shell commands it extracts the first word of
+// the command and creates a pattern like "shell:cmd=ls*" matching all
+// invocations of that command; for other tools it returns the tool name.
+func BuildPermissionPattern(toolCall tools.ToolCall) string {
+	toolName := toolCall.Function.Name
+
+	if toolName == "shell" {
+		var args struct {
+			Cmd string `json:"cmd"`
+		}
+		if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &args); err == nil {
+			// First word of the command ("ls -la /tmp" -> "ls"); the
+			// trailing * matches any arguments.
+			if fields := strings.Fields(args.Cmd); len(fields) > 0 {
+				return toolName + ":cmd=" + fields[0] + "*"
+			}
+		}
+	}
+
+	return toolName
+}
+
+// AlwaysAllowLabel is the descriptive label of the "always allow" option
+// for a pattern from BuildPermissionPattern: the command pattern for shell
+// ("always allow ls*"), the tool name otherwise.
+func AlwaysAllowLabel(pattern string) string {
+	if _, cmdPattern, ok := strings.Cut(pattern, ":cmd="); ok {
+		return "always allow " + cmdPattern
+	}
+	return "always allow " + pattern
+}
+
+// OptionsHelp returns the key/label pairs of the decision row, in display
+// order, ready for a help-keys renderer (e.g. dialog.RenderHelpKeys).
+func OptionsHelp(pattern string) []string {
+	return []string{
+		"Y", "yes",
+		"N", "no",
+		"T", AlwaysAllowLabel(pattern),
+		"A", "all tools",
+	}
+}
+
+// KeyMap defines the confirmation key bindings.
+type KeyMap struct {
+	Yes      key.Binding
+	No       key.Binding
+	All      key.Binding
+	ThisTool key.Binding
+}
+
+// DefaultKeyMap returns the standard confirmation key bindings.
+func DefaultKeyMap() KeyMap {
+	return KeyMap{
+		Yes: key.NewBinding(
+			key.WithKeys("y", "Y"),
+			key.WithHelp("Y", "approve"),
+		),
+		No: key.NewBinding(
+			key.WithKeys("n", "N"),
+			key.WithHelp("N", "reject"),
+		),
+		All: key.NewBinding(
+			key.WithKeys("a", "A"),
+			key.WithHelp("A", "approve all"),
+		),
+		ThisTool: key.NewBinding(
+			key.WithKeys("t", "T"),
+			key.WithHelp("T", "always allow this tool"),
+		),
+	}
+}
+
+// RejectionReason is one preset answer to "Why reject this tool call?".
+type RejectionReason struct {
+	ID    string // stable identifier
+	Label string // short label shown to the user
+	Value string // model-friendly sentence sent as the rejection reason
+}
+
+// RejectionReasons returns the preset rejection reasons, in display order.
+func RejectionReasons() []RejectionReason {
+	return []RejectionReason{
+		{
+			ID:    "bad_args",
+			Label: "Bad arguments",
+			Value: "The arguments provided are incorrect or invalid.",
+		},
+		{
+			ID:    "wrong_tool",
+			Label: "Wrong tool",
+			Value: "This is the wrong tool for this task.",
+		},
+		{
+			ID:    "unsafe",
+			Label: "Unsafe",
+			Value: "This action could be unsafe or destructive.",
+		},
+		{
+			ID:    "clarify",
+			Label: "Clarify first",
+			Value: "Please clarify what you're trying to accomplish.",
+		},
+	}
+}

--- a/pkg/tui/components/toolconfirm/toolconfirm_test.go
+++ b/pkg/tui/components/toolconfirm/toolconfirm_test.go
@@ -1,0 +1,98 @@
+package toolconfirm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+func shellCall(cmd string) tools.ToolCall {
+	return tools.ToolCall{
+		Function: tools.FunctionCall{
+			Name:      "shell",
+			Arguments: `{"cmd":` + jsonString(cmd) + `}`,
+		},
+	}
+}
+
+func jsonString(s string) string {
+	return `"` + s + `"`
+}
+
+func TestBuildPermissionPattern(t *testing.T) {
+	tests := []struct {
+		name string
+		call tools.ToolCall
+		want string
+	}{
+		{
+			name: "shell extracts the command",
+			call: shellCall("ls -la /tmp"),
+			want: "shell:cmd=ls*",
+		},
+		{
+			name: "shell with single word",
+			call: shellCall("ls"),
+			want: "shell:cmd=ls*",
+		},
+		{
+			name: "shell with leading whitespace and newlines",
+			call: shellCall(`\tgit\nstatus`), // decodes to "\tgit\nstatus"
+			want: "shell:cmd=git*",
+		},
+		{
+			name: "shell with empty command falls back to tool name",
+			call: shellCall(""),
+			want: "shell",
+		},
+		{
+			name: "shell with invalid arguments falls back to tool name",
+			call: tools.ToolCall{Function: tools.FunctionCall{Name: "shell", Arguments: "not json"}},
+			want: "shell",
+		},
+		{
+			name: "other tools use the tool name",
+			call: tools.ToolCall{Function: tools.FunctionCall{Name: "write_file", Arguments: `{"path":"/x"}`}},
+			want: "write_file",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, BuildPermissionPattern(tt.call))
+		})
+	}
+}
+
+func TestAlwaysAllowLabel(t *testing.T) {
+	assert.Equal(t, "always allow ls*", AlwaysAllowLabel("shell:cmd=ls*"))
+	assert.Equal(t, "always allow write_file", AlwaysAllowLabel("write_file"))
+}
+
+func TestOptionsHelpUsesThePattern(t *testing.T) {
+	opts := OptionsHelp("shell:cmd=rm*")
+	require.Len(t, opts, 8)
+	assert.Equal(t, []string{"Y", "yes", "N", "no", "T", "always allow rm*", "A", "all tools"}, opts)
+}
+
+func TestDecisionResume(t *testing.T) {
+	assert.Equal(t, runtime.ResumeApprove(), Approve.Resume("", ""))
+	assert.Equal(t, runtime.ResumeApproveTool("shell:cmd=ls*"), ApproveTool.Resume("shell:cmd=ls*", ""))
+	assert.Equal(t, runtime.ResumeApproveSession(), ApproveSession.Resume("", ""))
+	assert.Equal(t, runtime.ResumeReject("too risky"), Reject.Resume("", "too risky"))
+}
+
+func TestRejectionReasonsAreStable(t *testing.T) {
+	reasons := RejectionReasons()
+	require.Len(t, reasons, 4)
+	ids := make([]string, 0, len(reasons))
+	for _, r := range reasons {
+		require.NotEmpty(t, r.Label)
+		require.NotEmpty(t, r.Value)
+		ids = append(ids, r.ID)
+	}
+	assert.Equal(t, []string{"bad_args", "wrong_tool", "unsafe", "clarify"}, ids)
+}

--- a/pkg/tui/dialog/tool_confirmation.go
+++ b/pkg/tui/dialog/tool_confirmation.go
@@ -1,7 +1,6 @@
 package dialog
 
 import (
-	"encoding/json"
 	"strings"
 
 	"charm.land/bubbles/v2/key"
@@ -10,8 +9,8 @@ import (
 	"github.com/charmbracelet/x/ansi"
 
 	"github.com/docker/docker-agent/pkg/runtime"
-	"github.com/docker/docker-agent/pkg/tools"
 	"github.com/docker/docker-agent/pkg/tui/components/messages"
+	"github.com/docker/docker-agent/pkg/tui/components/toolconfirm"
 	"github.com/docker/docker-agent/pkg/tui/core"
 	"github.com/docker/docker-agent/pkg/tui/core/layout"
 	tuimessages "github.com/docker/docker-agent/pkg/tui/messages"
@@ -44,7 +43,7 @@ type toolConfirmationDialog struct {
 	BaseDialog
 
 	msg               *runtime.ToolCallConfirmationEvent
-	keyMap            toolConfirmationKeyMap
+	keyMap            toolconfirm.KeyMap
 	sessionState      *service.SessionState
 	scrollView        messages.Model
 	permissionPattern string // cached permission pattern for this tool call
@@ -67,16 +66,16 @@ func (d *toolConfirmationDialog) SetSize(width, height int) tea.Cmd {
 
 	// Measure fixed UI elements using the same rendering as View()
 	titleStyle := styles.DialogTitleStyle.Width(contentWidth)
-	title := titleStyle.Render("Tool Confirmation")
+	title := titleStyle.Render(toolconfirm.Title)
 	titleHeight := lipgloss.Height(title)
 
 	separator := d.renderSeparator(contentWidth)
 	separatorHeight := lipgloss.Height(separator)
 
-	question := styles.DialogQuestionStyle.Width(contentWidth).Render("Do you want to allow this tool call?")
+	question := styles.DialogQuestionStyle.Width(contentWidth).Render(toolconfirm.Question)
 	questionHeight := lipgloss.Height(question)
 
-	options := RenderHelpKeys(contentWidth, "Y", "yes", "N", "no", "T", d.alwaysAllowHelpText(), "A", "all tools")
+	options := d.renderOptions(contentWidth)
 	optionsHeight := lipgloss.Height(options)
 
 	// Calculate available height for scroll view
@@ -93,79 +92,9 @@ func (d *toolConfirmationDialog) renderSeparator(contentWidth int) string {
 	return RenderSeparator(contentWidth)
 }
 
-// alwaysAllowHelpText returns a descriptive help text for the "always allow" option.
-// For shell commands, it shows the command pattern (e.g., "always allow ls*").
-// For other tools, it shows "always allow <toolname>".
-func (d *toolConfirmationDialog) alwaysAllowHelpText() string {
-	pattern := d.permissionPattern
-	toolName := d.msg.ToolCall.Function.Name
-
-	// For shell with a command pattern, show a more descriptive label
-	if toolName == "shell" {
-		if _, cmdPattern, ok := strings.Cut(pattern, ":cmd="); ok {
-			return "always allow " + cmdPattern
-		}
-	}
-
-	return "always allow " + toolName
-}
-
-// toolConfirmationKeyMap defines key bindings for tool confirmation dialog
-type toolConfirmationKeyMap struct {
-	Yes      key.Binding
-	No       key.Binding
-	All      key.Binding
-	ThisTool key.Binding
-}
-
-// defaultToolConfirmationKeyMap returns default key bindings
-func defaultToolConfirmationKeyMap() toolConfirmationKeyMap {
-	return toolConfirmationKeyMap{
-		Yes: key.NewBinding(
-			key.WithKeys("y", "Y"),
-			key.WithHelp("Y", "approve"),
-		),
-		No: key.NewBinding(
-			key.WithKeys("n", "N"),
-			key.WithHelp("N", "reject"),
-		),
-		All: key.NewBinding(
-			key.WithKeys("a", "A"),
-			key.WithHelp("A", "approve all"),
-		),
-		ThisTool: key.NewBinding(
-			key.WithKeys("t", "T"),
-			key.WithHelp("T", "always allow this tool"),
-		),
-	}
-}
-
-// buildPermissionPattern creates a permission pattern for the tool call.
-// For shell commands, it extracts the first word of the command and creates
-// a pattern like "shell:cmd=ls*" to match all invocations of that command.
-// For other tools, it returns just the tool name.
-func buildPermissionPattern(toolCall tools.ToolCall) string {
-	toolName := toolCall.Function.Name
-
-	// For shell tool, extract the command and create a pattern
-	if toolName == "shell" {
-		var args struct {
-			Cmd string `json:"cmd"`
-		}
-		if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &args); err == nil {
-			// Extract the first word (the command) from the full command string
-			// e.g., "ls -la /tmp" -> "ls"
-			// strings.Fields handles all whitespace (space, tab, newline)
-			if fields := strings.Fields(args.Cmd); len(fields) > 0 {
-				// Create pattern: shell:cmd=<command>*
-				// The trailing * allows matching with any arguments
-				return toolName + ":cmd=" + fields[0] + "*"
-			}
-		}
-	}
-
-	// For other tools, just return the tool name
-	return toolName
+// renderOptions renders the Y/N/T/A decision row.
+func (d *toolConfirmationDialog) renderOptions(contentWidth int) string {
+	return RenderHelpKeys(contentWidth, toolconfirm.OptionsHelp(d.permissionPattern)...)
 }
 
 // NewToolConfirmationDialog creates a new tool confirmation dialog
@@ -182,12 +111,12 @@ func NewToolConfirmationDialog(msg *runtime.ToolCallConfirmationEvent, sessionSt
 	)
 
 	// Build and cache the permission pattern for display and use
-	pattern := buildPermissionPattern(msg.ToolCall)
+	pattern := toolconfirm.BuildPermissionPattern(msg.ToolCall)
 
 	return &toolConfirmationDialog{
 		msg:               msg,
 		sessionState:      sessionState,
-		keyMap:            defaultToolConfirmationKeyMap(),
+		keyMap:            toolconfirm.DefaultKeyMap(),
 		scrollView:        scrollView,
 		permissionPattern: pattern,
 	}
@@ -204,7 +133,7 @@ func (d *toolConfirmationDialog) executeAction(action string) (layout.Model, tea
 	case "Y":
 		return d, tea.Sequence(
 			core.CmdHandler(CloseDialogMsg{}),
-			core.CmdHandler(RuntimeResumeMsg{Request: runtime.ResumeApprove()}),
+			core.CmdHandler(RuntimeResumeMsg{Request: toolconfirm.Approve.Resume("", "")}),
 		)
 	case "N":
 		return d, core.CmdHandler(OpenDialogMsg{
@@ -213,13 +142,13 @@ func (d *toolConfirmationDialog) executeAction(action string) (layout.Model, tea
 	case "T":
 		return d, tea.Sequence(
 			core.CmdHandler(CloseDialogMsg{}),
-			core.CmdHandler(RuntimeResumeMsg{Request: runtime.ResumeApproveTool(d.permissionPattern)}),
+			core.CmdHandler(RuntimeResumeMsg{Request: toolconfirm.ApproveTool.Resume(d.permissionPattern, "")}),
 		)
 	case "A":
 		d.sessionState.SetYoloMode(true)
 		return d, tea.Sequence(
 			core.CmdHandler(CloseDialogMsg{}),
-			core.CmdHandler(RuntimeResumeMsg{Request: runtime.ResumeApproveSession()}),
+			core.CmdHandler(RuntimeResumeMsg{Request: toolconfirm.ApproveSession.Resume("", "")}),
 		)
 	}
 	return d, nil
@@ -283,7 +212,7 @@ func (d *toolConfirmationDialog) handleMouseClick(msg tea.MouseClickMsg) (layout
 
 	// Render the help keys and strip ANSI to get plain text for hit-testing.
 	_, contentWidth := d.dialogDimensions()
-	options := RenderHelpKeys(contentWidth, "Y", "yes", "N", "no", "T", d.alwaysAllowHelpText(), "A", "all tools")
+	options := d.renderOptions(contentWidth)
 	optionsPlain := ansi.Strip(options)
 
 	// Content starts after left border + padding.
@@ -317,7 +246,7 @@ func (d *toolConfirmationDialog) View() string {
 	dialogStyle := styles.DialogStyle.Width(dialogWidth)
 
 	titleStyle := styles.DialogTitleStyle.Width(contentWidth)
-	title := titleStyle.Render("Tool Confirmation")
+	title := titleStyle.Render(toolconfirm.Title)
 
 	// Separator
 	separator := d.renderSeparator(contentWidth)
@@ -333,8 +262,8 @@ func (d *toolConfirmationDialog) View() string {
 	}
 
 	// Confirmation prompt
-	question := styles.DialogQuestionStyle.Width(contentWidth).Render("Do you want to allow this tool call?")
-	options := RenderHelpKeys(contentWidth, "Y", "yes", "N", "no", "T", d.alwaysAllowHelpText(), "A", "all tools")
+	question := styles.DialogQuestionStyle.Width(contentWidth).Render(toolconfirm.Question)
+	options := d.renderOptions(contentWidth)
 
 	parts = append(parts, "", question, "", options)
 

--- a/pkg/tui/dialog/tool_rejection_reason.go
+++ b/pkg/tui/dialog/tool_rejection_reason.go
@@ -1,35 +1,21 @@
 package dialog
 
 import (
-	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/tui/components/toolconfirm"
 )
 
 // ToolRejectionDialogID is the unique identifier for the tool rejection reason dialog.
 const ToolRejectionDialogID = "tool-rejection-reason"
 
-// toolRejectionOptions defines the preset rejection reasons.
-// These match the original presets from tool_confirmation.go.
-var toolRejectionOptions = []MultiChoiceOption{
-	{
-		ID:    "bad_args",
-		Label: "Bad arguments",
-		Value: "The arguments provided are incorrect or invalid.",
-	},
-	{
-		ID:    "wrong_tool",
-		Label: "Wrong tool",
-		Value: "This is the wrong tool for this task.",
-	},
-	{
-		ID:    "unsafe",
-		Label: "Unsafe",
-		Value: "This action could be unsafe or destructive.",
-	},
-	{
-		ID:    "clarify",
-		Label: "Clarify first",
-		Value: "Please clarify what you're trying to accomplish.",
-	},
+// toolRejectionOptions adapts the shared preset rejection reasons to the
+// multi-choice dialog options.
+func toolRejectionOptions() []MultiChoiceOption {
+	reasons := toolconfirm.RejectionReasons()
+	options := make([]MultiChoiceOption, 0, len(reasons))
+	for _, r := range reasons {
+		options = append(options, MultiChoiceOption{ID: r.ID, Label: r.Label, Value: r.Value})
+	}
+	return options
 }
 
 // NewToolRejectionReasonDialog creates a multi-choice dialog for selecting
@@ -38,7 +24,7 @@ func NewToolRejectionReasonDialog() Dialog {
 	return NewMultiChoiceDialog(MultiChoiceConfig{
 		DialogID:          ToolRejectionDialogID,
 		Title:             "Why reject this tool call?",
-		Options:           toolRejectionOptions,
+		Options:           toolRejectionOptions(),
 		AllowCustom:       true,
 		AllowSecondary:    true,
 		SecondaryLabel:    "Skip",
@@ -63,6 +49,6 @@ func HandleToolRejectionResult(result MultiChoiceResult) *RuntimeResumeMsg {
 	}
 
 	return &RuntimeResumeMsg{
-		Request: runtime.ResumeReject(reason),
+		Request: toolconfirm.Reject.Resume("", reason),
 	}
 }

--- a/pkg/tui/service/staticsessionstate.go
+++ b/pkg/tui/service/staticsessionstate.go
@@ -1,0 +1,31 @@
+package service
+
+import (
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/tui/types"
+)
+
+// StaticSessionState is a SessionStateReader with fixed, conservative
+// values for embedders that render message and tool views outside the
+// full TUI application: unified (non-split) diff view, collapsed thinking,
+// tool results shown, no yolo mode. Embed or use it directly instead of
+// hand-rolling a stub, so views keep working with sensible defaults when
+// the reader interface grows.
+type StaticSessionState struct {
+	// AgentName is returned by CurrentAgentName.
+	AgentName string
+	// Title is returned by SessionTitle.
+	Title string
+}
+
+var _ SessionStateReader = StaticSessionState{}
+
+func (s StaticSessionState) SplitDiffView() bool                     { return false }
+func (s StaticSessionState) ExpandThinking() bool                    { return false }
+func (s StaticSessionState) YoloMode() bool                          { return false }
+func (s StaticSessionState) HideToolResults() bool                   { return false }
+func (s StaticSessionState) CurrentAgentName() string                { return s.AgentName }
+func (s StaticSessionState) PreviousMessage() *types.Message         { return nil }
+func (s StaticSessionState) SessionTitle() string                    { return s.Title }
+func (s StaticSessionState) AvailableAgents() []runtime.AgentDetails { return nil }
+func (s StaticSessionState) GetCurrentAgent() runtime.AgentDetails   { return runtime.AgentDetails{} }


### PR DESCRIPTION
# refactor(tui): expose embeddable TUI components for downstream embedders

## What

Docker Sandboxes embeds a Gordon assistant inside its own TUI (`sbx` →
ctrl+k). It reuses docker-agent's runtime (teamloader/runtime/session) and
its runtime-agnostic TUI components (message, tool, markdown, editor,
animation), but it had to **duplicate** three pieces that were private or
implicit. This PR exposes them so embedders share the code instead of
porting it:

1. **`pkg/tui/components/toolconfirm`** (new package): the tool-confirmation
   *policy*, extracted from `pkg/tui/dialog/tool_confirmation.go`:
   - `Decision` enum + `Decision.Resume()` mapping to `runtime.ResumeRequest`
   - `BuildPermissionPattern` / `AlwaysAllowLabel` / `OptionsHelp`
   - `KeyMap` / `DefaultKeyMap`, `Title` / `Question` constants
   - `RejectionReasons()` presets (shared with the rejection-reason dialog)

   The permission pattern is the security-sensitive part: the pattern
   *shown* to the user ("always allow ls*") and the pattern *granted* to the
   runtime must come from the same code, in every UI that hosts a
   confirmation. Until now the embedder carried a verbatim copy.

2. **`service.StaticSessionState`**: a `SessionStateReader` with fixed,
   conservative values for rendering message/tool views outside the full
   TUI app. Replaces hand-rolled nine-method stubs that silently rot when
   the interface grows.

3. **`animation.Stopper` / `animation.StopView`**: the "views removed from
   the UI must have StopAnimation called or they leak tick subscriptions"
   contract, previously duplicated as private helpers in the `messages` and
   `reasoningblock` components (and again by embedders).

The last commit refactors `dialog/tool_confirmation.go` and
`dialog/tool_rejection_reason.go` onto the new package.

## Behavior

Strictly behavior-preserving for docker-agent's own TUI:
- `executeAction` emits byte-identical resume requests.
- `AlwaysAllowLabel` is equivalent to the old `alwaysAllowHelpText` for all
  reachable inputs (for non-shell tools the pattern is the tool name, which
  cannot contain `:cmd=`).
- Rejection presets unchanged in content and order; title, question, key
  bindings, and option ordering preserved.

