### PR TITLE
test: disable git commit signing in test helpers

### DIFF
--- a/cmd/root/run_worktree_test.go
+++ b/cmd/root/run_worktree_test.go
@@ -87,6 +87,7 @@ func createTestWorktree(t *testing.T) *worktree.Worktree {
 		{"init"},
 		{"config", "user.email", "test@example.com"},
 		{"config", "user.name", "Test User"},
+		{"config", "commit.gpgsign", "false"},
 	} {
 		cmd := exec.CommandContext(t.Context(), "git", append([]string{"-C", dir}, args...)...)
 		out, err := cmd.CombinedOutput()

--- a/pkg/hooks/builtins/snapshot_test.go
+++ b/pkg/hooks/builtins/snapshot_test.go
@@ -203,6 +203,7 @@ func snapshotBuiltinRepo(t *testing.T) string {
 	runGitForSnapshotBuiltin(t, dir, "init")
 	runGitForSnapshotBuiltin(t, dir, "config", "user.email", "test@example.com")
 	runGitForSnapshotBuiltin(t, dir, "config", "user.name", "Test User")
+	runGitForSnapshotBuiltin(t, dir, "config", "commit.gpgsign", "false")
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "base.txt"), []byte("base"), 0o644))
 	runGitForSnapshotBuiltin(t, dir, "add", ".")
 	runGitForSnapshotBuiltin(t, dir, "commit", "-m", "init")

--- a/pkg/snapshot/snapshot_test.go
+++ b/pkg/snapshot/snapshot_test.go
@@ -217,6 +217,7 @@ func bootstrapRepo(t *testing.T) string {
 	runGit(t, dir, "init")
 	runGit(t, dir, "config", "user.email", "test@example.com")
 	runGit(t, dir, "config", "user.name", "Test User")
+	runGit(t, dir, "config", "commit.gpgsign", "false")
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("A"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.txt"), []byte("B"), 0o644))
 	runGit(t, dir, "add", ".")


### PR DESCRIPTION
Tests that bootstrap throwaway git repos and run `git commit` failed on hosts whose global git config enables commit signing (commit.gpgsign=true) without an available GPG secret key. This change disables commit signing in three test helpers, making the test suite deterministic regardless of the host's global git config.

The fix adds `git config commit.gpgsign false` to the test repository initialization in `pkg/snapshot/snapshot_test.go` (bootstrapRepo), `cmd/root/run_worktree_test.go` (createTestWorktree), and `pkg/hooks/builtins/snapshot_test.go` (snapshotBuiltinRepo). This pattern is already used elsewhere in the repo for similar purposes. The full test suite passes with `go test -count=1 ./...`.