### PR TITLE
fix: reconnect remote MCP toolsets after clean idle SSE close

### DIFF
--- a/examples/remote_mcp_reconnect.yaml
+++ b/examples/remote_mcp_reconnect.yaml
@@ -1,0 +1,20 @@
+# Remote MCP streams reconnect after clean idle closes by default.
+# Set lifecycle.restart: never to opt out for a server that should not reconnect.
+
+agents:
+  root:
+    model: openai/gpt-4o
+    description: Demonstrates remote MCP reconnect defaults.
+    instruction: Use the remote MCP tools when helpful.
+    toolsets:
+      - type: mcp
+        remote:
+          url: https://mcp.notion.com/sse
+          transport_type: sse
+
+      - type: mcp
+        remote:
+          url: https://example.com/mcp/sse
+          transport_type: sse
+        lifecycle:
+          restart: never

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -75,6 +75,49 @@ func (f *flappyToolSet) Tools(_ context.Context) ([]tools.Tool, error) {
 	return f.stubs, nil
 }
 
+type reconnectingToolSet struct {
+	started      bool
+	startCalls   int
+	restartCalls int
+	listCalls    int
+	stubs        []tools.Tool
+}
+
+var (
+	_ tools.ToolSet   = (*reconnectingToolSet)(nil)
+	_ tools.Startable = (*reconnectingToolSet)(nil)
+)
+
+func (r *reconnectingToolSet) Start(context.Context) error {
+	r.startCalls++
+	r.started = true
+	return nil
+}
+
+func (r *reconnectingToolSet) Stop(context.Context) error {
+	r.started = false
+	return nil
+}
+
+func (r *reconnectingToolSet) Restart(context.Context) error {
+	r.restartCalls++
+	r.started = true
+	return nil
+}
+
+func (r *reconnectingToolSet) IsStarted() bool { return r.started }
+
+func (r *reconnectingToolSet) Tools(context.Context) ([]tools.Tool, error) {
+	if !r.started {
+		return nil, errors.New("toolset not started")
+	}
+	r.listCalls++
+	if r.listCalls == 1 {
+		r.started = false
+	}
+	return r.stubs, nil
+}
+
 func TestAgentTools(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -495,4 +538,28 @@ func TestAgentWarningsConcurrentAccess(t *testing.T) {
 	// A successful run means no data race and no panic; we don't assert a
 	// specific number of warnings drained because drainers run concurrently
 	// with writers.
+}
+
+func TestAgentToolsRecoversWhenUnderlyingToolsetDies(t *testing.T) {
+	t.Parallel()
+
+	stub := &reconnectingToolSet{
+		stubs: []tools.Tool{{Name: "mcp_ping", Parameters: map[string]any{}}},
+	}
+	a := New("root", "test", WithToolSets(stub))
+
+	got, err := a.Tools(t.Context())
+	require.NoError(t, err)
+	assert.Len(t, got, 1, "turn 1: tool should be available after initial start")
+	assert.Empty(t, a.DrainWarnings())
+	assert.Equal(t, 1, stub.startCalls)
+	assert.Equal(t, 0, stub.restartCalls)
+	assert.False(t, stub.IsStarted(), "test fixture simulates an underlying session death after turn 1")
+
+	got, err = a.Tools(t.Context())
+	require.NoError(t, err)
+	assert.Len(t, got, 1, "turn 2: tool should be available after Startable-triggered recovery")
+	assert.Empty(t, a.DrainWarnings(), "silent recovery must not emit a warning")
+	assert.Equal(t, 1, stub.startCalls)
+	assert.Equal(t, 1, stub.restartCalls)
 }

--- a/pkg/tools/lifecycle/supervisor.go
+++ b/pkg/tools/lifecycle/supervisor.go
@@ -418,6 +418,9 @@ func (s *Supervisor) shouldRestart(err error, forced bool) bool {
 	case RestartAlways:
 		return true
 	default: // RestartOnFailure
+		// Clean exits are not failures for stdio MCP and LSP child processes.
+		// Remote MCP streams that should reconnect after an idle clean close opt
+		// into RestartAlways when their supervisor policy is constructed.
 		return err != nil && !IsPermanent(err)
 	}
 }

--- a/pkg/tools/lifecycle/supervisor_test.go
+++ b/pkg/tools/lifecycle/supervisor_test.go
@@ -451,6 +451,120 @@ func TestSupervisor_PermanentErrorsDontRestart(t *testing.T) {
 	assert.Check(t, is.Equal(c.Calls(), 1), "must not retry on permanent error")
 }
 
+func TestSupervisor_CleanClosePolicyBoundary(t *testing.T) {
+	t.Parallel()
+
+	sess1 := newFakeSession()
+	c := newScriptedConnector(scriptStep{session: sess1})
+
+	failedCh := make(chan error, 1)
+	s := lifecycle.New("test", c, lifecycle.Policy{
+		Restart: lifecycle.RestartOnFailure,
+		Backoff: fastBackoff,
+		OnFailed: func(err error) {
+			select {
+			case failedCh <- err:
+			default:
+			}
+		},
+	})
+
+	assert.NilError(t, s.Start(t.Context()))
+	sess1.fail(nil)
+
+	select {
+	case err := <-failedCh:
+		assert.Check(t, err == nil)
+	case <-time.After(2 * time.Second):
+		t.Fatal("supervisor did not transition to Failed after clean close")
+	}
+	assert.Check(t, is.Equal(s.State().State, lifecycle.StateFailed))
+	assert.Check(t, is.Equal(c.Calls(), 1), "RestartOnFailure must not reconnect clean closes")
+}
+
+func TestSupervisor_RestartAlwaysReconnectsCleanCloseAndResetsBudget(t *testing.T) {
+	t.Parallel()
+
+	sess1 := newFakeSession()
+	sess2 := newFakeSession()
+	sess3 := newFakeSession()
+	c := newScriptedConnector(
+		scriptStep{session: sess1},
+		scriptStep{session: sess2},
+		scriptStep{session: sess3},
+	)
+
+	restarted := make(chan struct{}, 2)
+	s := lifecycle.New("test", c, lifecycle.Policy{
+		Restart:     lifecycle.RestartAlways,
+		MaxAttempts: 1,
+		Backoff:     fastBackoff,
+		OnRestart: func() {
+			select {
+			case restarted <- struct{}{}:
+			default:
+			}
+		},
+	})
+
+	assert.NilError(t, s.Start(t.Context()))
+	sess1.fail(nil)
+
+	select {
+	case <-restarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("supervisor did not reconnect after first clean close")
+	}
+	assert.Check(t, is.Equal(s.State().State, lifecycle.StateReady))
+	assert.Check(t, is.Equal(c.Calls(), 2))
+
+	sess2.fail(nil)
+	select {
+	case <-restarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("supervisor did not reconnect after second clean close")
+	}
+	assert.Check(t, is.Equal(s.State().State, lifecycle.StateReady))
+	assert.Check(t, is.Equal(c.Calls(), 3), "successful reconnect must reset the budget")
+
+	assert.NilError(t, s.Stop(t.Context()))
+}
+
+func TestSupervisor_RestartAlwaysCleanCloseStillHonorsFailedReconnectBudget(t *testing.T) {
+	t.Parallel()
+
+	sess1 := newFakeSession()
+	c := newScriptedConnector(
+		scriptStep{session: sess1},
+		scriptStep{err: errors.New("fail-1")},
+		scriptStep{err: errors.New("fail-2")},
+	)
+
+	failedCh := make(chan error, 1)
+	s := lifecycle.New("test", c, lifecycle.Policy{
+		Restart:     lifecycle.RestartAlways,
+		MaxAttempts: 2,
+		Backoff:     fastBackoff,
+		OnFailed: func(err error) {
+			select {
+			case failedCh <- err:
+			default:
+			}
+		},
+	})
+
+	assert.NilError(t, s.Start(t.Context()))
+	sess1.fail(nil)
+
+	select {
+	case <-failedCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("supervisor did not give up after failed reconnect budget")
+	}
+	assert.Check(t, is.Equal(s.State().State, lifecycle.StateFailed))
+	assert.Check(t, is.Equal(c.Calls(), 3))
+}
+
 func TestBackoff_Defaults(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tools/mcp/mcp.go
+++ b/pkg/tools/mcp/mcp.go
@@ -267,8 +267,19 @@ func newRemoteToolset(
 		logID:       urlString,
 		description: desc,
 	}
-	ts.supervisor = newSupervisor(ts, firstOrZero(policy))
+	ts.supervisor = newSupervisor(ts, remotePolicy(firstOrZero(policy)))
 	return ts
+}
+
+func remotePolicy(base lifecycle.Policy) lifecycle.Policy {
+	if base.Restart == lifecycle.RestartOnFailure {
+		// Remote MCP servers commonly close idle SSE/streaming connections
+		// cleanly even though the server remains available. Treat on_failure as
+		// always for this transport so those clean closes reconnect, while
+		// preserving RestartNever opt-outs and stdio child-process semantics.
+		base.Restart = lifecycle.RestartAlways
+	}
+	return base
 }
 
 // firstOrZero returns the first element of s or the zero value of T if

--- a/pkg/tools/mcp/mcp_test.go
+++ b/pkg/tools/mcp/mcp_test.go
@@ -7,12 +7,14 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/tools/lifecycle"
 )
 
 // mockMCPClient is a test double for the mcpClient interface.
@@ -606,4 +608,66 @@ func TestCallToolRecoversFromErrSessionMissing(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "recovered", result.Output)
 	assert.Equal(t, int32(2), callCount.Load(), "expected exactly 2 CallTool invocations (1 failed + 1 retry)")
+}
+
+func TestRemoteToolsetDefaultsRestartAlways(t *testing.T) {
+	t.Parallel()
+
+	policy := remotePolicy(lifecycle.Policy{Restart: lifecycle.RestartOnFailure})
+
+	assert.Equal(t, lifecycle.RestartAlways, policy.Restart)
+}
+
+func TestRemoteToolsetPreservesRestartNever(t *testing.T) {
+	t.Parallel()
+
+	policy := remotePolicy(lifecycle.Policy{Restart: lifecycle.RestartNever})
+
+	assert.Equal(t, lifecycle.RestartNever, policy.Restart)
+}
+
+func TestRemotePolicyPreservesRestartAlways(t *testing.T) {
+	t.Parallel()
+
+	policy := remotePolicy(lifecycle.Policy{Restart: lifecycle.RestartAlways})
+
+	assert.Equal(t, lifecycle.RestartAlways, policy.Restart)
+}
+
+func TestRemoteToolsetReconnectsAfterCleanClose(t *testing.T) {
+	t.Parallel()
+
+	pingTool := &mcp.Tool{Name: "ping"}
+	mock := &failingInitClient{
+		toolsToList: []*mcp.Tool{pingTool},
+		waitCh:      make(chan struct{}),
+	}
+
+	ts := newTestToolset("test-remote", "remote-server", mock)
+	ts.supervisor = newSupervisor(ts, lifecycle.Policy{
+		Restart: lifecycle.RestartAlways,
+		Backoff: lifecycle.Backoff{
+			Initial:    time.Millisecond,
+			Max:        2 * time.Millisecond,
+			Multiplier: 2,
+		},
+	})
+
+	require.NoError(t, ts.Start(t.Context()))
+	require.True(t, ts.IsStarted())
+
+	require.NoError(t, mock.Close(t.Context()))
+	require.Eventually(t, func() bool {
+		mock.mu.Lock()
+		initCalls := mock.initCalls
+		mock.mu.Unlock()
+		return initCalls >= 2 && ts.IsStarted()
+	}, 2*time.Second, 10*time.Millisecond, "remote toolset did not reconnect after clean close")
+
+	toolList, err := ts.Tools(t.Context())
+	require.NoError(t, err)
+	require.Len(t, toolList, 1)
+	assert.Equal(t, "test-remote_ping", toolList[0].Name)
+
+	_ = ts.Stop(t.Context())
 }

--- a/pkg/tools/startable.go
+++ b/pkg/tools/startable.go
@@ -40,6 +40,12 @@ type failureStreak struct {
 	pending bool // true if the current streak's first failure is unreported
 }
 
+// startReporter is implemented by toolsets whose live lifecycle state can be
+// queried independently of the StartableToolSet wrapper's latched state.
+type startReporter interface {
+	IsStarted() bool
+}
+
 func (f *failureStreak) fail() {
 	if !f.active {
 		f.active = true
@@ -101,11 +107,21 @@ func (s *StartableToolSet) Start(ctx context.Context) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	recovering := false
 	if s.started {
-		return nil
+		if reporter, ok := As[startReporter](s.ToolSet); !ok || reporter.IsStarted() {
+			return nil
+		}
+		s.started = false
+		recovering = true
 	}
 
-	if startable, ok := As[Startable](s.ToolSet); ok {
+	if restarter, ok := As[Restartable](s.ToolSet); recovering && ok {
+		if err := restarter.Restart(ctx); err != nil {
+			s.startStreak.fail()
+			return err
+		}
+	} else if startable, ok := As[Startable](s.ToolSet); ok {
 		if err := startable.Start(ctx); err != nil {
 			s.startStreak.fail()
 			return err

--- a/pkg/tools/startable_test.go
+++ b/pkg/tools/startable_test.go
@@ -226,3 +226,98 @@ func TestStartableToolSet_ListFailureRecoveryResetsStreak(t *testing.T) {
 	assert.Check(t, err != nil)
 	assert.Check(t, is.Equal(s.ShouldReportListFailure(), true), "fresh failure after recovery must warn")
 }
+
+type reportingToolSet struct {
+	started      bool
+	startCalls   int
+	restartCalls int
+}
+
+func (r *reportingToolSet) Tools(context.Context) ([]tools.Tool, error) {
+	return []tools.Tool{{Name: "reporting_tool"}}, nil
+}
+
+func (r *reportingToolSet) Start(context.Context) error {
+	r.startCalls++
+	r.started = true
+	return nil
+}
+
+func (r *reportingToolSet) Stop(context.Context) error {
+	r.started = false
+	return nil
+}
+
+func (r *reportingToolSet) IsStarted() bool { return r.started }
+
+func (r *reportingToolSet) Restart(context.Context) error {
+	r.restartCalls++
+	r.started = true
+	return nil
+}
+
+type reportingStartOnlyToolSet struct {
+	started    bool
+	startCalls int
+}
+
+func (r *reportingStartOnlyToolSet) Tools(context.Context) ([]tools.Tool, error) {
+	return []tools.Tool{{Name: "start_only_tool"}}, nil
+}
+
+func (r *reportingStartOnlyToolSet) Start(context.Context) error {
+	r.startCalls++
+	r.started = true
+	return nil
+}
+
+func (r *reportingStartOnlyToolSet) Stop(context.Context) error {
+	r.started = false
+	return nil
+}
+
+func (r *reportingStartOnlyToolSet) IsStarted() bool { return r.started }
+
+func TestStartableToolSet_RecoversDeadUnderlyingWithRestart(t *testing.T) {
+	t.Parallel()
+
+	inner := &reportingToolSet{}
+	s := tools.NewStartable(inner)
+
+	assert.NilError(t, s.Start(t.Context()))
+	assert.Check(t, is.Equal(s.IsStarted(), true))
+	assert.Check(t, is.Equal(inner.startCalls, 1))
+	assert.Check(t, is.Equal(inner.restartCalls, 0))
+
+	inner.started = false
+	assert.NilError(t, s.Start(t.Context()))
+	assert.Check(t, is.Equal(s.IsStarted(), true))
+	assert.Check(t, is.Equal(inner.startCalls, 1), "recovery should prefer Restart over Start")
+	assert.Check(t, is.Equal(inner.restartCalls, 1))
+}
+
+func TestStartableToolSet_RecoversDeadUnderlyingWithStartFallback(t *testing.T) {
+	t.Parallel()
+
+	inner := &reportingStartOnlyToolSet{}
+	s := tools.NewStartable(inner)
+
+	assert.NilError(t, s.Start(t.Context()))
+	assert.Check(t, is.Equal(inner.startCalls, 1))
+
+	inner.started = false
+	assert.NilError(t, s.Start(t.Context()))
+	assert.Check(t, is.Equal(s.IsStarted(), true))
+	assert.Check(t, is.Equal(inner.startCalls, 2))
+}
+
+func TestStartableToolSet_NoStartReporterPreservesLatchedStart(t *testing.T) {
+	t.Parallel()
+
+	inner := &flappyToolSet{}
+	s := tools.NewStartable(inner)
+
+	assert.NilError(t, s.Start(t.Context()))
+	assert.NilError(t, s.Start(t.Context()))
+	assert.Check(t, is.Equal(inner.startups, 1))
+}


### PR DESCRIPTION
Fixes #3063

## Problem
Remote MCP servers (observed with Notion at mcp.notion.com/sse) close idle SSE connections cleanly. The lifecycle supervisor's default `RestartOnFailure` policy only restarts when `Wait()` returns a non-nil error, so a clean close transitioned the toolset to `StateFailed` with no reconnect. On top of that, `StartableToolSet` latched `started=true` forever, making the per-turn `Start()` retry a no-op — the agent then failed every `Tools()` call with `toolset not started` until process restart, and ran without any of its MCP tools.

## Fix
- **Remote MCP policy normalization** (`pkg/tools/mcp/mcp.go`): remote toolsets resolved to `RestartOnFailure` are normalized to `RestartAlways`, so clean idle closes reconnect with the existing 1s..32s backoff. `RestartNever` is preserved; stdio MCP and LSP semantics are unchanged (a cleanly-exited child process still does not restart-loop).
- **Honest started state + recovery** (`pkg/tools/startable.go`): `StartableToolSet` detects when the underlying toolset reports not-started despite the latched flag, clears it, and recovers — preferring the underlying `Restart()` (the documented recovery path for Failed/Stopped supervisors) over a bare `Start()`.
- **Restart budget preserved**: `MaxAttempts` stays at 5; successful reconnects reset the budget, repeated failures still terminate in `StateFailed`.

## Tests
- Supervisor: clean close under `RestartOnFailure` still terminates (boundary), clean close under `RestartAlways` reconnects, budget exhaustion still terminates, success resets budget.
- MCP: remote policy normalization; clean-close reconnect with successful `Tools()` afterwards.
- Startable: stale-latch detection, `Restart()` preference, `Start()` fallback, latch-once behavior preserved for plain toolsets.
- Agent-level regression reproducing the original "toolset not started forever" bug and proving recovery on the next turn.

## Validation
- `task build` ✅
- `task test` ✅
- `task lint` ✅

Reviewed locally (verdict: ready, no findings).
