### PR TITLE
docs: update remote MCP examples to prefer Streamable HTTP over SSE

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -1693,7 +1693,7 @@
         },
         "remote": {
           "$ref": "#/definitions/Remote",
-          "description": "Remote MCP server configuration (SSE/streamable-http transport)"
+          "description": "Remote MCP server configuration (streamable-http/SSE transport)"
         },
         "config": {
           "description": "MCP server configuration (for docker refs)"

--- a/docs/community/troubleshooting/index.md
+++ b/docs/community/troubleshooting/index.md
@@ -155,7 +155,7 @@ docker-agent validates config at startup and reports errors with line numbers. C
 ### Toolset validation
 
 - The `path` field is valid for `memory` and `tasks` toolsets, and for the agent-level `cache` block
-- MCP toolsets need either `command` (stdio), `remote` (SSE/HTTP), or `ref` (Docker)
+- MCP toolsets need either `command` (stdio), `remote` (Streamable HTTP/SSE), or `ref` (Docker)
 - Provider names must be one of: `openai`, `anthropic`, `google`, `amazon-bedrock`, `dmr`, etc.
 
 <div class="callout callout-info" markdown="1">
@@ -184,8 +184,8 @@ $ docker agent serve api config.yaml --listen :9090
 For remote MCP servers, verify the endpoint is reachable:
 
 ```bash
-# Test SSE endpoint
-$ curl -v https://mcp-server.example.com/sse
+# Test streamable HTTP endpoint
+$ curl -v https://mcp-server.example.com/mcp
 ```
 
 ### Session isolation

--- a/docs/concepts/tools/index.md
+++ b/docs/concepts/tools/index.md
@@ -55,7 +55,7 @@ docker-agent supports the [Model Context Protocol (MCP)](https://modelcontextpro
 
 - **Docker MCP** (recommended) — Run MCP servers in Docker containers via the [MCP Gateway](https://github.com/docker/mcp-gateway). Browse the [Docker MCP Catalog](https://hub.docker.com/search?q=&type=mcp).
 - **Local MCP (stdio)** — Run MCP servers as local processes communicating over stdin/stdout.
-- **Remote MCP (SSE / HTTP)** — Connect to MCP servers running on a network. See [Remote MCP Servers]({{ '/features/remote-mcp/' | relative_url }}).
+- **Remote MCP (Streamable HTTP / SSE)** — Connect to MCP servers running on a network. See [Remote MCP Servers]({{ '/features/remote-mcp/' | relative_url }}).
 
 ```yaml
 toolsets:

--- a/docs/configuration/overview/index.md
+++ b/docs/configuration/overview/index.md
@@ -53,7 +53,7 @@ mcps:
   github:
     remote:
       url: https://api.githubcopilot.com/mcp
-      transport_type: streamable
+      transport_type: sse
 
 # 7. Providers — optional reusable provider definitions
 providers:
@@ -350,7 +350,7 @@ mcps:
   github:
     remote:
       url: https://api.githubcopilot.com/mcp
-      transport_type: streamable
+      transport_type: sse
   playwright:
     command: npx
     args: ["-y", "@modelcontextprotocol/server-playwright"]

--- a/docs/configuration/overview/index.md
+++ b/docs/configuration/overview/index.md
@@ -53,7 +53,7 @@ mcps:
   github:
     remote:
       url: https://api.githubcopilot.com/mcp
-      transport_type: sse
+      transport_type: streamable
 
 # 7. Providers — optional reusable provider definitions
 providers:
@@ -350,7 +350,7 @@ mcps:
   github:
     remote:
       url: https://api.githubcopilot.com/mcp
-      transport_type: sse
+      transport_type: streamable
   playwright:
     command: npx
     args: ["-y", "@modelcontextprotocol/server-playwright"]

--- a/docs/configuration/tools/index.md
+++ b/docs/configuration/tools/index.md
@@ -102,7 +102,7 @@ toolsets:
 | `instruction` | string | Custom instructions injected into the agent's context |
 | `version` | string | Package reference for [auto-installing](#auto-installing-tools) the command binary |
 
-### Remote MCP (SSE / Streamable HTTP)
+### Remote MCP (Streamable HTTP / SSE)
 
 Connect to MCP servers over the network:
 
@@ -111,7 +111,7 @@ toolsets:
   - type: mcp
     remote:
       url: "https://mcp-server.example.com"
-      transport_type: "sse"
+      transport_type: "streamable"
       headers:
         Authorization: "Bearer your-token"
     # Optional: allow OAuth helper requests to reach private/internal IPs.
@@ -122,7 +122,7 @@ toolsets:
 | Property                | Type    | Description                                                                                                           |
 | ----------------------- | ------- | --------------------------------------------------------------------------------------------------------------------- |
 | `remote.url`            | string  | Base URL of the MCP server                                                                                            |
-| `remote.transport_type` | string  | `sse` or `streamable`                                                                                                 |
+| `remote.transport_type` | string  | `streamable` or `sse`                                                                                                 |
 | `remote.headers`        | object  | HTTP headers (typically for auth)                                                                                     |
 | `allow_private_ips`     | boolean | Permit remote MCP OAuth helper requests to dial non-public IP addresses. Use only for trusted internal servers.        |
 
@@ -200,7 +200,7 @@ Installed binaries are placed in `~/.cagent/tools/bin/` and cached so they are o
 
 ## Toolset Lifecycle
 
-Long-running toolsets — local MCP servers (stdio), remote MCP servers (SSE / streamable HTTP), and LSP servers — are managed by a single supervisor that can auto-reconnect them when they crash, time out, or drop their session. The `lifecycle` block on the toolset lets you tune that supervisor per toolset. It applies to every `type: mcp` and `type: lsp` toolset.
+Long-running toolsets — local MCP servers (stdio), remote MCP servers (Streamable HTTP / SSE), and LSP servers — are managed by a single supervisor that can auto-reconnect them when they crash, time out, or drop their session. The `lifecycle` block on the toolset lets you tune that supervisor per toolset. It applies to every `type: mcp` and `type: lsp` toolset.
 
 The simplest knob is `profile`, which picks a preset:
 
@@ -483,7 +483,7 @@ agents:
       - type: mcp
         remote:
           url: "https://internal-api.example.com/mcp"
-          transport_type: "sse"
+          transport_type: "streamable"
           headers:
             Authorization: "Bearer ${INTERNAL_TOKEN}"
 ```

--- a/docs/features/remote-mcp/index.md
+++ b/docs/features/remote-mcp/index.md
@@ -10,14 +10,14 @@ _Connect docker-agent to cloud services via remote MCP servers with built-in OAu
 
 ## Overview
 
-Docker Agent supports connecting to remote MCP servers over **SSE** (Server-Sent Events) and **Streamable HTTP** transports. Many popular services offer MCP endpoints with OAuth — docker-agent handles the authentication flow automatically.
+Docker Agent supports connecting to remote MCP servers over **Streamable HTTP** and **SSE** (Server-Sent Events) transports. Streamable HTTP is the current recommended transport for most hosted MCP servers. Many popular services offer MCP endpoints with OAuth — docker-agent handles the authentication flow automatically.
 
 ```yaml
 toolsets:
   - type: mcp
     remote:
-      url: "https://mcp.linear.app/sse"
-      transport_type: "sse"
+      url: "https://mcp.linear.app/mcp"
+      transport_type: "streamable"
 ```
 
 <div class="callout callout-tip" markdown="1">
@@ -40,8 +40,8 @@ toolsets:
 toolsets:
   - type: mcp
     remote:
-      url: "https://mcp.example.com/sse"
-      transport_type: "sse" # or "streamable"
+      url: "https://mcp.example.com/mcp"
+      transport_type: "streamable" # or "sse" for legacy servers
       headers:
         Authorization: "Bearer token" # optional: static auth
     # Optional: use only for trusted internal/private MCP or OAuth endpoints.
@@ -157,8 +157,8 @@ A per-toolset `callbackRedirectURL` (in the YAML) overrides the runtime-wide `--
 | Service    | URL                                | Transport | Description                           |
 | ---------- | ---------------------------------- | --------- | ------------------------------------- |
 | Asana      | `https://mcp.asana.com/sse`        | sse       | Task and project management           |
-| Atlassian  | `https://mcp.atlassian.com/v1/sse` | sse       | Jira, Confluence integration          |
-| Linear     | `https://mcp.linear.app/sse`       | sse       | Issue tracking and project management |
+| Atlassian  | `https://mcp.atlassian.com/v1/mcp/authv2` | streamable | Jira, Confluence integration          |
+| Linear     | `https://mcp.linear.app/mcp`       | streamable | Issue tracking and project management |
 | Monday.com | `https://mcp.monday.com/sse`       | sse       | Work management platform              |
 | Intercom   | `https://mcp.intercom.com/sse`     | sse       | Customer communication platform       |
 
@@ -186,7 +186,7 @@ A per-toolset `callbackRedirectURL` (in the YAML) overrides the runtime-wide `--
 | InVideo    | `https://mcp.invideo.io/sse`                      | sse        | Video creation platform           |
 | Webflow    | `https://mcp.webflow.com/sse`                     | sse        | Website builder and CMS           |
 | Wix        | `https://mcp.wix.com/sse`                         | sse        | Website builder platform          |
-| Notion     | `https://mcp.notion.com/sse`                      | sse        | Documentation and knowledge base  |
+| Notion     | `https://mcp.notion.com/mcp`                      | streamable | Documentation and knowledge base  |
 
 ## Communication &amp; Voice
 
@@ -244,8 +244,8 @@ agents:
     toolsets:
       - type: mcp
         remote:
-          url: "https://mcp.linear.app/sse"
-          transport_type: "sse"
+          url: "https://mcp.linear.app/mcp"
+          transport_type: "streamable"
         instruction: Use Linear for issue tracking.
       - type: mcp
         remote:

--- a/docs/tools/mcp/index.md
+++ b/docs/tools/mcp/index.md
@@ -16,7 +16,7 @@ The `mcp` toolset connects your agent to any MCP server — a process or remote 
 | --- | --- | --- |
 | **Docker MCP** | Container via the [MCP Gateway](https://github.com/docker/mcp-gateway) | Curated, sandboxed servers from the [Docker MCP Catalog](https://hub.docker.com/u/mcp) |
 | **Local stdio** | Subprocess over stdin/stdout | Custom or community MCP servers run from a binary or `npx`/`pip` package |
-| **Remote** | SSE or Streamable HTTP | Cloud services with hosted MCP endpoints (Linear, GitHub, Vercel, …) |
+| **Remote** | Streamable HTTP or SSE | Cloud services with hosted MCP endpoints (Linear, Notion, Atlassian, …) |
 
 <div class="callout callout-info" markdown="1">
 <div class="callout-title">What is MCP?
@@ -77,7 +77,7 @@ toolsets:
   <p>If the <code>command</code> is not in your <code>PATH</code>, docker-agent looks it up in the <a href="https://github.com/aquaproj/aqua-registry">aqua registry</a> and installs it for you. Use <code>version: "false"</code> to opt out, or set <code>DOCKER_AGENT_AUTO_INSTALL=false</code> globally. See <a href="{{ '/configuration/tools/#auto-installing-tools' | relative_url }}">Auto-Installing Tools</a>.</p>
 </div>
 
-## Remote MCP (SSE / Streamable HTTP)
+## Remote MCP (Streamable HTTP / SSE)
 
 Connect to MCP servers over the network. OAuth flows (including [Dynamic Client Registration](https://datatracker.ietf.org/doc/html/rfc7591)) are handled automatically — docker-agent opens your browser when authentication is required and caches tokens for subsequent sessions.
 
@@ -85,8 +85,8 @@ Connect to MCP servers over the network. OAuth flows (including [Dynamic Client 
 toolsets:
   - type: mcp
     remote:
-      url: "https://mcp.linear.app/sse"
-      transport_type: "sse"               # or "streamable"
+      url: "https://mcp.linear.app/mcp"
+      transport_type: "streamable"               # or "sse" for legacy servers
       headers:
         Authorization: "Bearer ${LINEAR_TOKEN}"
     # Optional: allow OAuth helper requests to reach private/internal IPs.
@@ -97,7 +97,7 @@ toolsets:
 | Property                | Type    | Description |
 | ----------------------- | ------- | ----------- |
 | `remote.url`            | string  | Base URL of the MCP server. |
-| `remote.transport_type` | string  | `sse` or `streamable`. |
+| `remote.transport_type` | string  | `streamable` or `sse`. |
 | `remote.headers`        | object  | HTTP headers (typically for static auth tokens). |
 | `remote.oauth`          | object  | Explicit OAuth client credentials for servers that don't support DCR. See [Remote MCP Servers]({{ '/features/remote-mcp/' | relative_url }}#oauth-for-servers-without-dynamic-client-registration). |
 | `allow_private_ips`     | boolean | Permit remote MCP OAuth helper requests to dial non-public IP addresses. Use only for trusted internal servers. |
@@ -268,8 +268,8 @@ agents:
       # Remote MCP with OAuth (handled automatically)
       - type: mcp
         remote:
-          url: "https://mcp.linear.app/sse"
-          transport_type: "sse"
+          url: "https://mcp.linear.app/mcp"
+          transport_type: "streamable"
         instruction: Use Linear for issue tracking.
 ```
 

--- a/examples/notion-expert.yaml
+++ b/examples/notion-expert.yaml
@@ -6,5 +6,5 @@ agents:
     toolsets:
       - type: mcp
         remote:
-          url: https://mcp.notion.com/sse
-          transport_type: sse
+          url: https://mcp.notion.com/mcp
+          transport_type: streamable

--- a/examples/remote_mcp_oauth.yaml
+++ b/examples/remote_mcp_oauth.yaml
@@ -10,8 +10,8 @@ agents:
     toolsets:
       - type: mcp
         remote:
-          url: "https://mcp.example.com/sse"
-          transport_type: sse
+          url: "https://mcp.example.com/mcp"
+          transport_type: streamable
           oauth:
             clientId: "your-client-id"
             clientSecret: "your-client-secret"

--- a/pkg/config/mcps_test.go
+++ b/pkg/config/mcps_test.go
@@ -89,7 +89,7 @@ func TestMCPDefinitions_Remote(t *testing.T) {
 	require.Len(t, root.Toolsets, 1)
 
 	ts := root.Toolsets[0]
-	assert.Equal(t, "https://mcp.example.com/sse", ts.Remote.URL)
+	assert.Equal(t, "https://mcp.example.com/mcp", ts.Remote.URL)
 	assert.Equal(t, "Bearer token123", ts.Remote.Headers["Authorization"])
 	assert.True(t, ts.AllowPrivateIPsEnabled())
 	assert.Empty(t, ts.Ref)

--- a/pkg/config/testdata/mcp_definitions_remote.yaml
+++ b/pkg/config/testdata/mcp_definitions_remote.yaml
@@ -6,7 +6,7 @@ models:
 mcps:
   my_server:
     remote:
-      url: https://mcp.example.com/sse
+      url: https://mcp.example.com/mcp
       headers:
         Authorization: "Bearer token123"
     allow_private_ips: true


### PR DESCRIPTION
Notion (`/mcp`), Linear (`/mcp`), and Atlassian (already updated) have all migrated their hosted MCP servers from SSE to Streamable HTTP transport. This updates all docs, examples, config, and test fixtures to reflect that.

**URL and transport changes:**

| Provider | Old URL | New URL | Old transport | New transport |
|---|---|---|---|---|
| Notion | `mcp.notion.com/sse` | `mcp.notion.com/mcp` | `sse` | `streamable` |
| Linear | `mcp.linear.app/sse` | `mcp.linear.app/mcp` | `sse` | `streamable` |
| Atlassian | already correct | `mcp.atlassian.com/v1/mcp/authv2` | — | `streamable` |
| Generic placeholder | `mcp.example.com/sse` | `mcp.example.com/mcp` | `sse` | `streamable` |

**Files changed:**
- `examples/notion-expert.yaml` — updated URL and transport
- `examples/remote_mcp_oauth.yaml` — updated placeholder URL and transport
- `pkg/config/testdata/mcp_definitions_remote.yaml` — updated placeholder URL
- `docs/features/remote-mcp/index.md` — updated overview prose, first example, config example, Atlassian/Linear/Notion table rows, and multi-service example
- `docs/tools/mcp/index.md` — updated overview table, section heading, inline examples, parameter table
- `docs/configuration/tools/index.md` — updated section heading, YAML example, parameter table, lifecycle prose, combined example
- `docs/configuration/overview/index.md` — updated both `mcps:` examples to `streamable`
- `docs/community/troubleshooting/index.md` — updated toolset validation note and diagnostic curl example
- `docs/concepts/tools/index.md` — updated Remote MCP flavour description
- `agent-schema.json` — reordered Remote MCP description to lead with streamable-http