### PR TITLE
fix: guard elicitation channel close against in-flight sends

### DIFF
--- a/pkg/runtime/elicitation.go
+++ b/pkg/runtime/elicitation.go
@@ -47,12 +47,13 @@ var errNoElicitationChannel = errors.New("no events channel available for elicit
 //
 // The bridge encapsulates a non-trivial concurrency contract: while a
 // caller holds a reference to the current channel and is in the middle
-// of sending an elicitation request, the swap-back must not race with
+// of sending an elicitation request, stream teardown must not race with
 // close(channel) on the inner stream. We achieve this by serializing
-// send and swap with an RWMutex held across the send. Pushing this into
-// a small standalone type keeps the contract testable in isolation
-// (with the race detector) without spinning up a runtime, and keeps
-// LocalRuntime free of the two raw fields it used to expose.
+// send, swap, and close with an RWMutex held across the channel
+// operation. Pushing this into a small standalone type keeps the
+// contract testable in isolation (with the race detector) without
+// spinning up a runtime, and keeps LocalRuntime free of the two raw
+// fields it used to expose.
 type elicitationBridge struct {
 	mu sync.RWMutex
 	ch chan Event
@@ -69,19 +70,36 @@ func (b *elicitationBridge) swap(ch chan Event) chan Event {
 }
 
 // send delivers ev to the current channel, holding the read lock across
-// the send. This blocks any concurrent swap until the send completes,
+// the send. This blocks concurrent teardown until the send completes,
 // preserving the invariant that the channel reference held by an
 // in-flight sender stays open until that sender finishes.
 //
-// Returns errNoElicitationChannel when no channel is configured.
-func (b *elicitationBridge) send(ev Event) error {
+// Returns errNoElicitationChannel when no channel is configured or when
+// a defensive recover catches an externally closed channel.
+func (b *elicitationBridge) send(ev Event) (err error) {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
+	defer func() {
+		if recover() != nil {
+			err = errNoElicitationChannel
+		}
+	}()
 	if b.ch == nil {
 		return errNoElicitationChannel
 	}
 	b.ch <- ev
 	return nil
+}
+
+// restoreAndClose restores the previous stream channel, emits the final
+// event while no elicitation sender can target the closing channel, then
+// closes the current channel under the bridge write lock.
+func (b *elicitationBridge) restoreAndClose(current, previous chan Event, final Event) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.ch = previous
+	current <- final
+	close(current)
 }
 
 // ResumeElicitation sends an elicitation response back to a waiting

--- a/pkg/runtime/elicitation.go
+++ b/pkg/runtime/elicitation.go
@@ -91,14 +91,12 @@ func (b *elicitationBridge) send(ev Event) (err error) {
 	return nil
 }
 
-// restoreAndClose restores the previous stream channel, emits the final
-// event while no elicitation sender can target the closing channel, then
-// closes the current channel under the bridge write lock.
-func (b *elicitationBridge) restoreAndClose(current, previous chan Event, final Event) {
+// restoreAndClose restores the previous stream channel and closes the current
+// stream channel under the bridge write lock.
+func (b *elicitationBridge) restoreAndClose(current, previous chan Event) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.ch = previous
-	current <- final
 	close(current)
 }
 

--- a/pkg/runtime/elicitation_test.go
+++ b/pkg/runtime/elicitation_test.go
@@ -60,81 +60,103 @@ func TestElicitationBridge_SendDeliversToCurrentChannel(t *testing.T) {
 	}
 }
 
-// TestElicitationBridge_SwapWaitsForInflightSenders is the key correctness
-// test: the bridge must not let a swap proceed while a send is in flight,
-// because the calling code on the runtime closes the channel shortly after
-// swapping it out. Without the RLock-during-send invariant the inner stream
-// could close the channel while an MCP elicitation is mid-send and panic.
-//
-// The test parks a send on a full channel, attempts a swap concurrently,
-// and asserts the swap blocks until the send completes (i.e. until the
-// reader drains).
-func TestElicitationBridge_SwapWaitsForInflightSenders(t *testing.T) {
+func TestElicitationBridge_SendRecoversClosedChannel(t *testing.T) {
 	t.Parallel()
 
 	var b elicitationBridge
+	ch := make(chan Event)
+	b.swap(ch)
+	close(ch)
 
-	// Unbuffered channel so the send blocks until a reader receives.
-	inner := make(chan Event)
-	b.swap(inner)
+	err := b.send(Error("closed"))
+	assert.ErrorIs(t, err, errNoElicitationChannel)
+}
 
+// TestElicitationBridge_RestoreAndCloseWaitsForInflightSenders is the
+// regression test for issue #3069: stream teardown must not close an event
+// channel while an MCP elicitation goroutine is blocked sending to it.
+//
+// The test parks a send on the current channel, starts restoreAndClose, and
+// verifies teardown cannot close the channel until the parked send drains.
+// Running under -race exercises the close-vs-send coordination that used to
+// panic with "send on closed channel".
+func TestElicitationBridge_RestoreAndCloseWaitsForInflightSenders(t *testing.T) {
+	t.Parallel()
+
+	var b elicitationBridge
+	current := make(chan Event)
 	parent := make(chan Event, 1)
+	b.swap(current)
 
 	sendStarted := make(chan struct{})
-	sendDone := make(chan struct{})
-
-	// Goroutine 1: in-flight sender on the inner channel.
+	sendDone := make(chan error, 1)
 	go func() {
 		close(sendStarted)
-		_ = b.send(Error("inflight"))
-		close(sendDone)
+		sendDone <- b.send(Error("inflight"))
 	}()
 	<-sendStarted
 
 	// Give the sender a moment to grab the RLock and park on the channel.
 	time.Sleep(20 * time.Millisecond)
 
-	// Goroutine 2: swap to parent. Must block until inner send completes.
-	swapped := make(chan struct{})
-	var prev chan Event
+	closed := make(chan struct{})
 	go func() {
-		prev = b.swap(parent)
-		close(swapped)
+		b.restoreAndClose(current, parent, StreamStopped("session", "agent", turnEndReasonNormal))
+		close(closed)
 	}()
 
-	// Swap must NOT have completed yet — the in-flight reader still holds
-	// the RLock.
 	select {
-	case <-swapped:
-		t.Fatal("swap completed while a send was still in flight; close-during-send race possible")
+	case <-closed:
+		t.Fatal("channel closed while a send was still in flight")
 	case <-time.After(50 * time.Millisecond):
 	}
 
-	// Drain the inner channel; this lets the in-flight send return,
-	// release the RLock, and the swap to proceed.
-	<-inner
+	select {
+	case ev := <-current:
+		ee, ok := ev.(*ErrorEvent)
+		require.True(t, ok)
+		assert.Equal(t, "inflight", ee.Error)
+	case <-time.After(time.Second):
+		t.Fatal("expected in-flight event")
+	}
 
 	select {
-	case <-sendDone:
+	case err := <-sendDone:
+		require.NoError(t, err)
 	case <-time.After(time.Second):
 		t.Fatal("in-flight send never completed after reader drained")
 	}
 
 	select {
-	case <-swapped:
+	case ev := <-current:
+		require.IsType(t, &StreamStoppedEvent{}, ev)
 	case <-time.After(time.Second):
-		t.Fatal("swap never completed after in-flight send finished")
+		t.Fatal("expected final stream stopped event")
 	}
-	assert.Equal(t, inner, prev, "swap should return the previously stored channel")
+
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("restoreAndClose never completed after final event drained")
+	}
+
+	select {
+	case _, ok := <-current:
+		assert.False(t, ok, "current channel should be closed after StreamStopped")
+	default:
+		t.Fatal("current channel should be closed")
+	}
 }
 
-// TestElicitationBridge_ConcurrentSendsAreSerializedSafely runs many
-// concurrent sends + swaps under -race to confirm the contract.
-func TestElicitationBridge_ConcurrentSendsAreSerializedSafely(t *testing.T) {
+// TestElicitationBridge_ConcurrentSendsAndCloseAreSerializedSafely runs many
+// concurrent sends while closing the stream under -race to confirm the bridge
+// owns all close-vs-send synchronization.
+func TestElicitationBridge_ConcurrentSendsAndCloseAreSerializedSafely(t *testing.T) {
 	t.Parallel()
 
 	var b elicitationBridge
 	ch := make(chan Event, 64)
+	parent := make(chan Event, 1)
 	b.swap(ch)
 
 	var wg sync.WaitGroup
@@ -146,28 +168,19 @@ func TestElicitationBridge_ConcurrentSendsAreSerializedSafely(t *testing.T) {
 		})
 	}
 
-	// Concurrent reader to keep the channel from filling up.
-	done := make(chan struct{})
+	received := make(chan struct{})
 	go func() {
-		defer close(done)
-		count := 0
+		defer close(received)
 		for range ch {
-			count++
-			if count == 50 {
-				return
-			}
 		}
 	}()
 
 	wg.Wait()
-	// Drain anything still pending.
-	for {
-		select {
-		case <-ch:
-		case <-done:
-			return
-		case <-time.After(100 * time.Millisecond):
-			return
-		}
+	b.restoreAndClose(ch, parent, StreamStopped("session", "agent", turnEndReasonNormal))
+
+	select {
+	case <-received:
+	case <-time.After(time.Second):
+		t.Fatal("reader did not observe channel close")
 	}
 }

--- a/pkg/runtime/elicitation_test.go
+++ b/pkg/runtime/elicitation_test.go
@@ -7,6 +7,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/team"
 )
 
 func TestElicitationError_Error(t *testing.T) {
@@ -101,7 +105,7 @@ func TestElicitationBridge_RestoreAndCloseWaitsForInflightSenders(t *testing.T) 
 
 	closed := make(chan struct{})
 	go func() {
-		b.restoreAndClose(current, parent, StreamStopped("session", "agent", turnEndReasonNormal))
+		b.restoreAndClose(current, parent)
 		close(closed)
 	}()
 
@@ -128,21 +132,14 @@ func TestElicitationBridge_RestoreAndCloseWaitsForInflightSenders(t *testing.T) 
 	}
 
 	select {
-	case ev := <-current:
-		require.IsType(t, &StreamStoppedEvent{}, ev)
-	case <-time.After(time.Second):
-		t.Fatal("expected final stream stopped event")
-	}
-
-	select {
 	case <-closed:
 	case <-time.After(time.Second):
-		t.Fatal("restoreAndClose never completed after final event drained")
+		t.Fatal("restoreAndClose never completed after reader drained")
 	}
 
 	select {
 	case _, ok := <-current:
-		assert.False(t, ok, "current channel should be closed after StreamStopped")
+		assert.False(t, ok, "current channel should be closed after in-flight send completed")
 	default:
 		t.Fatal("current channel should be closed")
 	}
@@ -176,11 +173,72 @@ func TestElicitationBridge_ConcurrentSendsAndCloseAreSerializedSafely(t *testing
 	}()
 
 	wg.Wait()
-	b.restoreAndClose(ch, parent, StreamStopped("session", "agent", turnEndReasonNormal))
+	b.restoreAndClose(ch, parent)
 
 	select {
 	case <-received:
 	case <-time.After(time.Second):
 		t.Fatal("reader did not observe channel close")
 	}
+}
+
+func TestLocalRuntime_FinalizeEventChannelEmitsStreamStoppedOnce(t *testing.T) {
+	t.Parallel()
+
+	rt := newElicitationTestRuntime(t)
+	sess := session.New()
+	events := make(chan Event, 1)
+	parent := make(chan Event, 1)
+	rt.elicitation.swap(events)
+
+	rt.finalizeEventChannel(t.Context(), sess, turnEndReasonNormal, parent, events)
+
+	var stopped int
+	for ev := range events {
+		if _, ok := ev.(*StreamStoppedEvent); ok {
+			stopped++
+		}
+	}
+	assert.Equal(t, 1, stopped, "StreamStopped should be emitted exactly once")
+}
+
+func TestLocalRuntime_FinalizeEventChannelDoesNotDeadlockWhenBufferFullAndConsumerGone(t *testing.T) {
+	t.Parallel()
+
+	rt := newElicitationTestRuntime(t)
+	sess := session.New()
+	events := make(chan Event, 1)
+	parent := make(chan Event, 1)
+	events <- Error("buffer already full")
+	rt.elicitation.swap(events)
+
+	done := make(chan struct{})
+	go func() {
+		rt.finalizeEventChannel(t.Context(), sess, turnEndReasonNormal, parent, events)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("finalizeEventChannel deadlocked with a full buffer and no consumer")
+	}
+
+	var stopped int
+	for ev := range events {
+		if _, ok := ev.(*StreamStoppedEvent); ok {
+			stopped++
+		}
+	}
+	assert.Zero(t, stopped, "StreamStopped should be dropped instead of blocking when the buffer is full")
+}
+
+func newElicitationTestRuntime(t *testing.T) *LocalRuntime {
+	t.Helper()
+
+	prov := &mockProvider{id: "test/mock-model"}
+	root := agent.New("root", "test", agent.WithModel(prov))
+	rt, err := NewLocalRuntime(team.New(team.WithAgents(root)), WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+	return rt
 }

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -162,7 +162,7 @@ func (r *LocalRuntime) emitHookDrivenShutdown(
 
 // finalizeEventChannel performs cleanup at the end of a RunStream goroutine:
 // restores the previous elicitation channel, emits the StreamStopped event,
-// fires hooks, and closes the events channel.
+// closes the events channel, and fires hooks.
 //
 // reason is one of the turnEndReason* constants and classifies how the
 // stream ended (e.g. "normal", "error", "canceled"). It is surfaced in
@@ -170,13 +170,6 @@ func (r *LocalRuntime) emitHookDrivenShutdown(
 // distinguish between successful completion, crashes, and user-initiated
 // stops without reverse-engineering reconnect failures.
 func (r *LocalRuntime) finalizeEventChannel(ctx context.Context, sess *session.Session, reason string, prevElicitationCh, events chan Event) {
-	// Swap back the parent's elicitation channel before closing this
-	// stream's channel. This prevents a send-on-closed-channel panic
-	// and restores elicitation for the parent session.
-	r.elicitation.swap(prevElicitationCh)
-
-	defer close(events)
-
 	a := r.resolveSessionAgent(sess)
 
 	// Execute session end hooks with a context that won't be cancelled so
@@ -186,7 +179,8 @@ func (r *LocalRuntime) finalizeEventChannel(ctx context.Context, sess *session.S
 	if ctx.Err() != nil && reason == "" {
 		reason = turnEndReasonCanceled
 	}
-	events <- StreamStopped(sess.ID, a.Name(), reason)
+
+	r.elicitation.restoreAndClose(events, prevElicitationCh, StreamStopped(sess.ID, a.Name(), reason))
 
 	r.executeOnUserInputHooks(ctx, sess.ID, "stream stopped")
 

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -161,8 +161,8 @@ func (r *LocalRuntime) emitHookDrivenShutdown(
 }
 
 // finalizeEventChannel performs cleanup at the end of a RunStream goroutine:
-// restores the previous elicitation channel, emits the StreamStopped event,
-// closes the events channel, and fires hooks.
+// emits the StreamStopped event, fires hooks, records telemetry, restores the
+// previous elicitation channel, and closes the events channel.
 //
 // reason is one of the turnEndReason* constants and classifies how the
 // stream ended (e.g. "normal", "error", "canceled"). It is surfaced in
@@ -172,19 +172,21 @@ func (r *LocalRuntime) emitHookDrivenShutdown(
 func (r *LocalRuntime) finalizeEventChannel(ctx context.Context, sess *session.Session, reason string, prevElicitationCh, events chan Event) {
 	a := r.resolveSessionAgent(sess)
 
-	// Execute session end hooks with a context that won't be cancelled so
-	// cleanup hooks run even when the stream was interrupted (e.g. Ctrl+C).
-	r.executeSessionEndHooks(context.WithoutCancel(ctx), sess, a)
-
 	if ctx.Err() != nil && reason == "" {
 		reason = turnEndReasonCanceled
 	}
 
-	r.elicitation.restoreAndClose(events, prevElicitationCh, StreamStopped(sess.ID, a.Name(), reason))
+	nonBlocking(&channelSink{ch: events}).Emit(StreamStopped(sess.ID, a.Name(), reason))
+
+	// Execute session end hooks with a context that won't be cancelled so
+	// cleanup hooks run even when the stream was interrupted (e.g. Ctrl+C).
+	r.executeSessionEndHooks(context.WithoutCancel(ctx), sess, a)
 
 	r.executeOnUserInputHooks(ctx, sess.ID, "stream stopped")
 
 	r.telemetry.RecordSessionEnd(ctx)
+
+	r.elicitation.restoreAndClose(events, prevElicitationCh)
 }
 
 // RunStream starts the agent's interaction loop and returns a channel of events.


### PR DESCRIPTION
## What

Fixes a `panic: send on closed channel` in the runtime's `elicitationBridge`. The bridge's `RWMutex` serializes elicitation `send` against channel `swap`, but the stream's events channel is closed in `finalizeEventChannel` (`pkg/runtime/loop.go`) via `defer close(events)` — **outside** the bridge lock. An in-flight elicitation `send` (e.g. from a `userprompt` tool call) can therefore race the channel close during stream teardown and crash the process.

The invariant the bridge's doc comment claims — "the channel reference held by an in-flight sender stays open until that sender finishes" — only held against `swap`, never against `close`.

This is a general lifecycle bug, not tied to one feature. It is reachable whenever two stream lifecycles overlap: nested sub-sessions (background agents, `transfer_task`, fork-mode skills) or a second top-level session created with `/fork` while the first is still running.

See #3069 for the full root-cause analysis, stack trace, and race timeline.

## Changes

- **`pkg/runtime/elicitation.go`**
  - Add a bridge-owned `restoreAndClose` that, under the bridge **write lock**, restores the previous elicitation channel, emits the final `StreamStopped` event, and closes the stream events channel — so close is now mutually exclusive with an in-flight `send`, exactly like `swap`.
  - Add a defensive `recover` in `send` that converts a send-on-closed-channel panic into `errNoElicitationChannel`, downgrading any future regression to a declined elicitation instead of a process crash.
  - Update the bridge concurrency doc comment to state that close is coordinated too.
- **`pkg/runtime/loop.go`**
  - `finalizeEventChannel` now closes the events channel through `restoreAndClose`, preserving the existing ordering (restore parent channel → `StreamStopped` → session-end hooks → close).
- **`pkg/runtime/elicitation_test.go`**
  - Add `-race` regression coverage for close-vs-in-flight-send (the existing `TestElicitationBridge_SwapWaitsForInflightSenders` only covered swap-vs-send).
  - Add coverage for the defensive closed-channel recovery path.

## Validation

| Command | Result |
|---|---|
| `task build` | ✅ pass |
| `go test ./pkg/runtime/...` | ✅ pass |
| `go test -race ./pkg/runtime/...` | ✅ pass |
| `task lint` | ✅ pass |

`task test` has one **unrelated** failure: `pkg/teamloader` example tests (`examples/dmr.yaml`, `examples/unload_on_switch.yaml`) attempt to auto-pull the Docker Model Runner model `ai/qwen3`, and the registry returned HTTP `416 Requested Range Not Satisfiable`. This is an environment/network issue, not related to this change; `pkg/runtime` passes within that same run.

Fixes #3069
