### PR TITLE
fix: guard type assertions in ScriptToolSet.Instructions() against missing description

### DIFF
--- a/pkg/tools/builtin/shell/script_shell.go
+++ b/pkg/tools/builtin/shell/script_shell.go
@@ -101,12 +101,21 @@ func (t *ScriptToolSet) Instructions() string {
 		}
 
 		for argName, argDef := range tool.Args {
-			description := argDef.(map[string]any)["description"].(string)
+			description := ""
+			if m, ok := argDef.(map[string]any); ok {
+				if d, ok := m["description"].(string); ok {
+					description = d
+				}
+			}
 			required := ""
 			if slices.Contains(tool.Required, argName) {
 				required = " (required)"
 			}
-			fmt.Fprintf(&sb, "- `%s`: %s%s\n", argName, description, required)
+			if description != "" {
+				fmt.Fprintf(&sb, "- `%s`: %s%s\n", argName, description, required)
+			} else {
+				fmt.Fprintf(&sb, "- `%s`%s\n", argName, required)
+			}
 		}
 		sb.WriteString("\n")
 	}

--- a/pkg/tools/builtin/shell/script_shell_test.go
+++ b/pkg/tools/builtin/shell/script_shell_test.go
@@ -223,6 +223,66 @@ func TestScriptShellTool_RejectsNULInValue(t *testing.T) {
 	assert.Contains(t, result.Output, "NUL byte")
 }
 
+func TestScriptToolSet_InstructionsNoDescription(t *testing.T) {
+	shellTools := map[string]latest.ScriptShellToolConfig{
+		"greet": {
+			Cmd: "echo hello ${name}",
+			Args: map[string]any{
+				"name": map[string]any{
+					"type": "string",
+					// no "description" key — this must not panic
+				},
+			},
+			Required: []string{"name"},
+		},
+	}
+
+	tool, err := NewScript(shellTools, nil)
+	require.NoError(t, err)
+
+	// Must not panic even though description is absent.
+	instructions := tool.Instructions()
+	assert.Contains(t, instructions, "greet")
+	assert.Contains(t, instructions, "`name`")
+	assert.Contains(t, instructions, "(required)")
+	// No trailing colon-space artefact when description is empty.
+	assert.NotContains(t, instructions, "`name`: ")
+}
+
+func TestScriptToolSet_InstructionsNilArgDef(t *testing.T) {
+	// argDef is nil — must not panic.
+	shellTools := map[string]latest.ScriptShellToolConfig{
+		"greet": {
+			Cmd:      "echo hello ${name}",
+			Args:     map[string]any{"name": nil},
+			Required: []string{"name"},
+		},
+	}
+
+	tool, err := NewScript(shellTools, nil)
+	require.NoError(t, err)
+
+	instructions := tool.Instructions()
+	assert.Contains(t, instructions, "`name`")
+}
+
+func TestScriptToolSet_InstructionsNonMapArgDef(t *testing.T) {
+	// argDef is a bare string (not a map) — must not panic.
+	shellTools := map[string]latest.ScriptShellToolConfig{
+		"greet": {
+			Cmd:      "echo hello ${name}",
+			Args:     map[string]any{"name": "string"},
+			Required: []string{"name"},
+		},
+	}
+
+	tool, err := NewScript(shellTools, nil)
+	require.NoError(t, err)
+
+	instructions := tool.Instructions()
+	assert.Contains(t, instructions, "`name`")
+}
+
 func TestNewScript_ArgWithoutType(t *testing.T) {
 	shellTools := map[string]latest.ScriptShellToolConfig{
 		"greet": {


### PR DESCRIPTION
Fixes #3071.

`Instructions()` panicked with `interface conversion: interface {} is nil, not string` when a `script` toolset defined a shell tool whose arg omitted `description`.

**Root cause:** two chained unguarded type assertions:
```go
description := argDef.(map[string]any)["description"].(string)
```

**Fix:** replace both with comma-ok guards; fall back to empty string when `description` is absent or `argDef` is not a map. When description is empty the colon-space separator is also omitted to avoid cosmetic artefacts.

**Tests added:**
- `TestScriptToolSet_InstructionsNoDescription` — map argDef, missing description key
- `TestScriptToolSet_InstructionsNilArgDef` — nil argDef
- `TestScriptToolSet_InstructionsNonMapArgDef` — non-map argDef (bare string)