### PR TITLE
Add Docker Desktop JWT when pulling agent from a .docker.com URL

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -69,7 +69,7 @@ func Load(ctx context.Context, source Source) (*latest.Config, error) {
 //
 // This allows exiting early with a proper error message instead of failing later when trying to use a model or tool.
 func CheckRequiredEnvVars(ctx context.Context, cfg *latest.Config, modelsGateway string, env environment.Provider) error {
-	if modelsGateway != "" && environment.IsDockerURL(modelsGateway) {
+	if modelsGateway != "" && environment.IsTrustedDockerURL(modelsGateway) {
 		if jwt, _ := env.Get(ctx, environment.DockerDesktopTokenEnv); jwt == "" {
 			return errors.New("sorry, you first need to sign in Docker Desktop to use the Docker AI Gateway")
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -69,7 +69,7 @@ func Load(ctx context.Context, source Source) (*latest.Config, error) {
 //
 // This allows exiting early with a proper error message instead of failing later when trying to use a model or tool.
 func CheckRequiredEnvVars(ctx context.Context, cfg *latest.Config, modelsGateway string, env environment.Provider) error {
-	if modelsGateway != "" {
+	if modelsGateway != "" && environment.IsDockerURL(modelsGateway) {
 		if jwt, _ := env.Get(ctx, environment.DockerDesktopTokenEnv); jwt == "" {
 			return errors.New("sorry, you first need to sign in Docker Desktop to use the Docker AI Gateway")
 		}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -324,6 +324,30 @@ func TestCheckRequiredEnvVarsWithModelGateway(t *testing.T) {
 		err = CheckRequiredEnvVars(t.Context(), cfg, "https://my-gateway.example.com", &noEnvProvider{})
 		require.NoError(t, err)
 	})
+
+	t.Run("localhost gateway without token", func(t *testing.T) {
+		t.Parallel()
+
+		cfg, err := Load(t.Context(), NewFileSource("testdata/env/all.yaml"))
+		require.NoError(t, err)
+
+		err = CheckRequiredEnvVars(t.Context(), cfg, "http://localhost:8080", &noEnvProvider{})
+		require.ErrorContains(t, err, "sign in Docker Desktop")
+	})
+
+	t.Run("localhost gateway with token", func(t *testing.T) {
+		t.Parallel()
+
+		cfg, err := Load(t.Context(), NewFileSource("testdata/env/all.yaml"))
+		require.NoError(t, err)
+
+		env := &fakeEnvProvider{vars: map[string]string{
+			environment.DockerDesktopTokenEnv: "some-jwt-token",
+		}}
+
+		err = CheckRequiredEnvVars(t.Context(), cfg, "http://localhost:8080", env)
+		require.NoError(t, err)
+	})
 }
 
 func TestApplyModelOverrides(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -301,7 +301,7 @@ func TestCheckRequiredEnvVarsWithModelGateway(t *testing.T) {
 			environment.DockerDesktopTokenEnv: "some-jwt-token",
 		}}
 
-		err = CheckRequiredEnvVars(t.Context(), cfg, "gateway:8080", env)
+		err = CheckRequiredEnvVars(t.Context(), cfg, "https://models.docker.com", env)
 		require.NoError(t, err)
 	})
 
@@ -311,8 +311,18 @@ func TestCheckRequiredEnvVarsWithModelGateway(t *testing.T) {
 		cfg, err := Load(t.Context(), NewFileSource("testdata/env/all.yaml"))
 		require.NoError(t, err)
 
-		err = CheckRequiredEnvVars(t.Context(), cfg, "gateway:8080", &noEnvProvider{})
+		err = CheckRequiredEnvVars(t.Context(), cfg, "https://models.docker.com", &noEnvProvider{})
 		require.ErrorContains(t, err, "sign in Docker Desktop")
+	})
+
+	t.Run("non-docker gateway without token", func(t *testing.T) {
+		t.Parallel()
+
+		cfg, err := Load(t.Context(), NewFileSource("testdata/env/all.yaml"))
+		require.NoError(t, err)
+
+		err = CheckRequiredEnvVars(t.Context(), cfg, "https://my-gateway.example.com", &noEnvProvider{})
+		require.NoError(t, err)
 	})
 }
 

--- a/pkg/config/sources.go
+++ b/pkg/config/sources.go
@@ -340,8 +340,8 @@ func isGitHubURL(urlStr string) bool {
 	return slices.Contains(githubHosts, u.Host)
 }
 
-// isDockerURL is an alias for [environment.IsDockerURL] for local readability.
-var isDockerURL = environment.IsDockerURL
+// isTrustedDockerURL is an alias for [environment.IsTrustedDockerURL] for local readability.
+var isTrustedDockerURL = environment.IsTrustedDockerURL
 
 // addGitHubAuth adds GitHub token authorization to the request if:
 // - The URL is a GitHub URL
@@ -374,7 +374,7 @@ func (a urlSource) addDockerAuth(ctx context.Context, req *http.Request) {
 		return
 	}
 
-	if !isDockerURL(a.url) {
+	if !isTrustedDockerURL(a.url) {
 		return
 	}
 

--- a/pkg/config/sources.go
+++ b/pkg/config/sources.go
@@ -340,18 +340,8 @@ func isGitHubURL(urlStr string) bool {
 	return slices.Contains(githubHosts, u.Host)
 }
 
-// isDockerURL checks if the URL targets a .docker.com domain that should
-// receive the Docker Desktop JWT. The check matches the exact host
-// "docker.com" as well as any subdomain (e.g. "desktop.docker.com").
-// It performs strict hostname validation to prevent token leakage.
-func isDockerURL(urlStr string) bool {
-	u, err := url.Parse(urlStr)
-	if err != nil {
-		return false
-	}
-	host := u.Hostname()
-	return host == "docker.com" || strings.HasSuffix(host, ".docker.com")
-}
+// isDockerURL is an alias for [environment.IsDockerURL] for local readability.
+var isDockerURL = environment.IsDockerURL
 
 // addGitHubAuth adds GitHub token authorization to the request if:
 // - The URL is a GitHub URL

--- a/pkg/config/sources.go
+++ b/pkg/config/sources.go
@@ -250,8 +250,8 @@ func (a urlSource) Read(ctx context.Context) ([]byte, error) {
 		req.Header.Set("If-None-Match", cachedETag)
 	}
 
-	// Add GitHub token authorization for GitHub URLs
 	a.addGitHubAuth(ctx, req)
+	a.addDockerAuth(ctx, req)
 
 	client := httpclient.NewHTTPClient(ctx)
 	if !a.unsafe {
@@ -340,6 +340,19 @@ func isGitHubURL(urlStr string) bool {
 	return slices.Contains(githubHosts, u.Host)
 }
 
+// isDockerURL checks if the URL targets a .docker.com domain that should
+// receive the Docker Desktop JWT. The check matches the exact host
+// "docker.com" as well as any subdomain (e.g. "desktop.docker.com").
+// It performs strict hostname validation to prevent token leakage.
+func isDockerURL(urlStr string) bool {
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		return false
+	}
+	host := u.Hostname()
+	return host == "docker.com" || strings.HasSuffix(host, ".docker.com")
+}
+
 // addGitHubAuth adds GitHub token authorization to the request if:
 // - The URL is a GitHub URL
 // - An environment provider is configured
@@ -360,6 +373,28 @@ func (a urlSource) addGitHubAuth(ctx context.Context, req *http.Request) {
 
 	req.Header.Set("Authorization", "Bearer "+token)
 	slog.DebugContext(ctx, "Added GitHub token authorization to request", "url", a.url)
+}
+
+// addDockerAuth adds the Docker Desktop JWT to the request if:
+// - The URL targets a .docker.com domain
+// - An environment provider is configured
+// - DOCKER_TOKEN is available in the environment
+func (a urlSource) addDockerAuth(ctx context.Context, req *http.Request) {
+	if a.envProvider == nil {
+		return
+	}
+
+	if !isDockerURL(a.url) {
+		return
+	}
+
+	token, ok := a.envProvider.Get(ctx, environment.DockerDesktopTokenEnv)
+	if !ok || token == "" {
+		return
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+	slog.DebugContext(ctx, "Added Docker token authorization to request", "url", a.url)
 }
 
 // hashURL creates a safe filename from a URL.

--- a/pkg/config/sources.go
+++ b/pkg/config/sources.go
@@ -366,7 +366,7 @@ func (a urlSource) addGitHubAuth(ctx context.Context, req *http.Request) {
 }
 
 // addDockerAuth adds the Docker Desktop JWT to the request if:
-// - The URL targets a .docker.com domain
+// - The URL targets a .docker.com domain or localhost
 // - An environment provider is configured
 // - DOCKER_TOKEN is available in the environment
 func (a urlSource) addDockerAuth(ctx context.Context, req *http.Request) {

--- a/pkg/config/sources_test.go
+++ b/pkg/config/sources_test.go
@@ -618,7 +618,7 @@ func TestIsGitHubURL(t *testing.T) {
 	}
 }
 
-func TestIsDockerURL(t *testing.T) {
+func TestIsTrustedDockerURL(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -634,10 +634,15 @@ func TestIsDockerURL(t *testing.T) {
 		{"https://sub.sub.docker.com/path", true},
 		{"http://docker.com/path", true},
 
+		// Localhost URLs (local development)
+		{"http://localhost:8080/agent.yaml", true},
+		{"https://localhost/agent.yaml", true},
+		{"http://127.0.0.1:8080/agent.yaml", true},
+		{"http://[::1]:8080/agent.yaml", true},
+
 		// Non-Docker URLs
 		{"https://example.com/agent.yaml", false},
 		{"https://github.com/docker/repo", false},
-		{"http://localhost:8080/agent.yaml", false},
 		{"", false},
 
 		// Security: malicious URLs that should NOT be treated as Docker URLs
@@ -653,7 +658,7 @@ func TestIsDockerURL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.url, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.expected, isDockerURL(tt.url))
+			assert.Equal(t, tt.expected, isTrustedDockerURL(tt.url))
 		})
 	}
 }
@@ -672,17 +677,29 @@ func TestURLSource_Read_WithDockerAuth_NonDockerURL(t *testing.T) {
 		environment.DockerDesktopTokenEnv: "docker-jwt-token",
 	})
 
-	source := newURLSourceForTest(server.URL, envProvider)
-	_, err := source.Read(t.Context())
+	// Use a non-Docker, non-localhost URL as the source URL so
+	// isTrustedDockerURL returns false. The actual HTTP request still goes to
+	// the local test server via the unsafe flag.
+	src := &urlSource{
+		url:         "https://example.com/agent.yaml",
+		envProvider: envProvider,
+		unsafe:      true,
+	}
+	// Override the url to point at our test server for the actual fetch,
+	// but addDockerAuth checks the url field which is example.com.
+	// We need to actually fetch from the test server though, so we
+	// manually test addDockerAuth in isolation instead.
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL, http.NoBody)
 	require.NoError(t, err)
+	src.addDockerAuth(t.Context(), req)
 	assert.Empty(t, receivedAuth, "non-Docker URLs should not receive Docker auth header")
 }
 
-func TestURLSource_Read_WithDockerAuth_DockerURL(t *testing.T) {
+func TestURLSource_Read_WithDockerAuth_LocalhostURL(t *testing.T) {
 	t.Parallel()
 
-	// We cannot test with real docker.com URLs, but we verify that URLs with
-	// docker.com in the path (not hostname) don't receive the token.
+	// httptest.NewServer binds to 127.0.0.1 which is treated as localhost.
+	// Verify that the Docker JWT is included for localhost URLs.
 	var receivedAuth string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedAuth = r.Header.Get("Authorization")
@@ -694,11 +711,10 @@ func TestURLSource_Read_WithDockerAuth_DockerURL(t *testing.T) {
 		environment.DockerDesktopTokenEnv: "docker-jwt-token",
 	})
 
-	maliciousURL := server.URL + "/desktop.docker.com/agent.yaml"
-	source := newURLSourceForTest(maliciousURL, envProvider)
+	source := newURLSourceForTest(server.URL, envProvider)
 	_, err := source.Read(t.Context())
 	require.NoError(t, err)
-	assert.Empty(t, receivedAuth, "should not add Docker auth header when docker.com host is only in path")
+	assert.Equal(t, "Bearer docker-jwt-token", receivedAuth, "localhost URLs should receive Docker auth header")
 }
 
 func TestURLSource_Read_WithDockerAuth_NoToken(t *testing.T) {
@@ -764,6 +780,30 @@ func TestURLSource_addDockerAuth(t *testing.T) {
 			wantAuth: "Bearer my-jwt",
 		},
 		{
+			name: "localhost with token",
+			url:  "http://localhost:8080/v1/models",
+			envProvider: environment.NewMapEnvProvider(map[string]string{
+				environment.DockerDesktopTokenEnv: "my-jwt",
+			}),
+			wantAuth: "Bearer my-jwt",
+		},
+		{
+			name: "127.0.0.1 with token",
+			url:  "http://127.0.0.1:9090/agent.yaml",
+			envProvider: environment.NewMapEnvProvider(map[string]string{
+				environment.DockerDesktopTokenEnv: "my-jwt",
+			}),
+			wantAuth: "Bearer my-jwt",
+		},
+		{
+			name: "IPv6 loopback with token",
+			url:  "http://[::1]:9090/agent.yaml",
+			envProvider: environment.NewMapEnvProvider(map[string]string{
+				environment.DockerDesktopTokenEnv: "my-jwt",
+			}),
+			wantAuth: "Bearer my-jwt",
+		},
+		{
 			name: "non-docker URL with token",
 			url:  "https://example.com/agent.yaml",
 			envProvider: environment.NewMapEnvProvider(map[string]string{
@@ -774,6 +814,12 @@ func TestURLSource_addDockerAuth(t *testing.T) {
 		{
 			name:        "docker.com URL without token",
 			url:         "https://desktop.docker.com/agent.yaml",
+			envProvider: environment.NewNoEnvProvider(),
+			wantAuth:    "",
+		},
+		{
+			name:        "localhost without token",
+			url:         "http://localhost:8080/agent.yaml",
 			envProvider: environment.NewNoEnvProvider(),
 			wantAuth:    "",
 		},

--- a/pkg/config/sources_test.go
+++ b/pkg/config/sources_test.go
@@ -618,6 +618,199 @@ func TestIsGitHubURL(t *testing.T) {
 	}
 }
 
+func TestIsDockerURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		url      string
+		expected bool
+	}{
+		// Valid Docker URLs
+		{"https://docker.com/some/path", true},
+		{"https://desktop.docker.com/mcp/catalog/v3/catalog.yaml", true},
+		{"https://api.docker.com/events/v1/track", true},
+		{"https://api-stage.docker.com/events/v1/track", true},
+		{"https://hub.docker.com/mcp/server", true},
+		{"https://sub.sub.docker.com/path", true},
+		{"http://docker.com/path", true},
+
+		// Non-Docker URLs
+		{"https://example.com/agent.yaml", false},
+		{"https://github.com/docker/repo", false},
+		{"http://localhost:8080/agent.yaml", false},
+		{"", false},
+
+		// Security: malicious URLs that should NOT be treated as Docker URLs
+		{"https://evil.com/docker.com/file.yaml", false},     // docker.com in path
+		{"https://notdocker.com/file.yaml", false},           // similar domain name
+		{"https://docker.com.attacker.com/file.yaml", false}, // docker.com as subdomain of attacker
+		{"https://fakedocker.com/agent.yaml", false},         // contains "docker.com" substring
+		{"https://attacker.com?redirect=docker.com", false},  // docker.com in query string
+		{"https://my-docker.com/agent.yaml", false},          // hyphenated similar domain
+		{"https://xdocker.com/agent.yaml", false},            // prefixed similar domain
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, isDockerURL(tt.url))
+		})
+	}
+}
+
+func TestURLSource_Read_WithDockerAuth_NonDockerURL(t *testing.T) {
+	t.Parallel()
+
+	var receivedAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte("test content"))
+	}))
+	t.Cleanup(server.Close)
+
+	envProvider := environment.NewMapEnvProvider(map[string]string{
+		environment.DockerDesktopTokenEnv: "docker-jwt-token",
+	})
+
+	source := newURLSourceForTest(server.URL, envProvider)
+	_, err := source.Read(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, receivedAuth, "non-Docker URLs should not receive Docker auth header")
+}
+
+func TestURLSource_Read_WithDockerAuth_DockerURL(t *testing.T) {
+	t.Parallel()
+
+	// We cannot test with real docker.com URLs, but we verify that URLs with
+	// docker.com in the path (not hostname) don't receive the token.
+	var receivedAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte("test content"))
+	}))
+	t.Cleanup(server.Close)
+
+	envProvider := environment.NewMapEnvProvider(map[string]string{
+		environment.DockerDesktopTokenEnv: "docker-jwt-token",
+	})
+
+	maliciousURL := server.URL + "/desktop.docker.com/agent.yaml"
+	source := newURLSourceForTest(maliciousURL, envProvider)
+	_, err := source.Read(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, receivedAuth, "should not add Docker auth header when docker.com host is only in path")
+}
+
+func TestURLSource_Read_WithDockerAuth_NoToken(t *testing.T) {
+	t.Parallel()
+
+	var receivedAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte("test content"))
+	}))
+	t.Cleanup(server.Close)
+
+	envProvider := environment.NewNoEnvProvider()
+
+	// Even if we construct a source with a Docker URL hostname, the
+	// addDockerAuth method checks the url field, not the request URL.
+	// We use the test server URL here, which is NOT a docker.com URL.
+	source := newURLSourceForTest(server.URL, envProvider)
+	_, err := source.Read(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, receivedAuth, "should not add auth header when token is missing")
+}
+
+func TestURLSource_Read_WithDockerAuth_NoEnvProvider(t *testing.T) {
+	t.Parallel()
+
+	var receivedAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte("test content"))
+	}))
+	t.Cleanup(server.Close)
+
+	source := newURLSourceForTest(server.URL, nil)
+	_, err := source.Read(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, receivedAuth, "should not add auth header without env provider")
+}
+
+func TestURLSource_addDockerAuth(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		url         string
+		envProvider environment.Provider
+		wantAuth    string
+	}{
+		{
+			name: "docker.com URL with token",
+			url:  "https://docker.com/agent.yaml",
+			envProvider: environment.NewMapEnvProvider(map[string]string{
+				environment.DockerDesktopTokenEnv: "my-jwt",
+			}),
+			wantAuth: "Bearer my-jwt",
+		},
+		{
+			name: "subdomain of docker.com with token",
+			url:  "https://desktop.docker.com/mcp/catalog.yaml",
+			envProvider: environment.NewMapEnvProvider(map[string]string{
+				environment.DockerDesktopTokenEnv: "my-jwt",
+			}),
+			wantAuth: "Bearer my-jwt",
+		},
+		{
+			name: "non-docker URL with token",
+			url:  "https://example.com/agent.yaml",
+			envProvider: environment.NewMapEnvProvider(map[string]string{
+				environment.DockerDesktopTokenEnv: "my-jwt",
+			}),
+			wantAuth: "",
+		},
+		{
+			name:        "docker.com URL without token",
+			url:         "https://desktop.docker.com/agent.yaml",
+			envProvider: environment.NewNoEnvProvider(),
+			wantAuth:    "",
+		},
+		{
+			name:        "docker.com URL without env provider",
+			url:         "https://desktop.docker.com/agent.yaml",
+			envProvider: nil,
+			wantAuth:    "",
+		},
+		{
+			name: "docker.com as subdomain of attacker",
+			url:  "https://docker.com.attacker.com/agent.yaml",
+			envProvider: environment.NewMapEnvProvider(map[string]string{
+				environment.DockerDesktopTokenEnv: "my-jwt",
+			}),
+			wantAuth: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			src := &urlSource{
+				url:         tt.url,
+				envProvider: tt.envProvider,
+			}
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, tt.url, http.NoBody)
+			require.NoError(t, err)
+
+			src.addDockerAuth(t.Context(), req)
+
+			assert.Equal(t, tt.wantAuth, req.Header.Get("Authorization"))
+		})
+	}
+}
+
 func TestResolve_URLReference_WithEnvProvider(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/config/sources_test.go
+++ b/pkg/config/sources_test.go
@@ -625,16 +625,15 @@ func TestIsTrustedDockerURL(t *testing.T) {
 		url      string
 		expected bool
 	}{
-		// Valid Docker URLs
+		// Valid Docker URLs (HTTPS only for remote)
 		{"https://docker.com/some/path", true},
 		{"https://desktop.docker.com/mcp/catalog/v3/catalog.yaml", true},
 		{"https://api.docker.com/events/v1/track", true},
 		{"https://api-stage.docker.com/events/v1/track", true},
 		{"https://hub.docker.com/mcp/server", true},
 		{"https://sub.sub.docker.com/path", true},
-		{"http://docker.com/path", true},
 
-		// Localhost URLs (local development)
+		// Localhost URLs (local development, HTTP or HTTPS)
 		{"http://localhost:8080/agent.yaml", true},
 		{"https://localhost/agent.yaml", true},
 		{"http://127.0.0.1:8080/agent.yaml", true},
@@ -644,6 +643,14 @@ func TestIsTrustedDockerURL(t *testing.T) {
 		{"https://example.com/agent.yaml", false},
 		{"https://github.com/docker/repo", false},
 		{"", false},
+
+		// Scheme enforcement: plain HTTP to remote .docker.com is rejected
+		{"http://docker.com/path", false},
+		{"http://desktop.docker.com/agent.yaml", false},
+
+		// Non-HTTP(S) schemes are rejected
+		{"ftp://docker.com/file.yaml", false},
+		{"ftp://localhost/file.yaml", false},
 
 		// Security: malicious URLs that should NOT be treated as Docker URLs
 		{"https://evil.com/docker.com/file.yaml", false},     // docker.com in path
@@ -832,6 +839,14 @@ func TestURLSource_addDockerAuth(t *testing.T) {
 		{
 			name: "docker.com as subdomain of attacker",
 			url:  "https://docker.com.attacker.com/agent.yaml",
+			envProvider: environment.NewMapEnvProvider(map[string]string{
+				environment.DockerDesktopTokenEnv: "my-jwt",
+			}),
+			wantAuth: "",
+		},
+		{
+			name: "plain HTTP to docker.com is rejected",
+			url:  "http://docker.com/agent.yaml",
 			envProvider: environment.NewMapEnvProvider(map[string]string{
 				environment.DockerDesktopTokenEnv: "my-jwt",
 			}),

--- a/pkg/environment/docker-desktop.go
+++ b/pkg/environment/docker-desktop.go
@@ -14,17 +14,20 @@ const (
 	DockerDesktopTokenEnv = "DOCKER_TOKEN"
 )
 
-// IsDockerURL checks if the URL targets a .docker.com domain that should
-// receive the Docker Desktop JWT. The check matches the exact host
-// "docker.com" as well as any subdomain (e.g. "desktop.docker.com").
+// IsTrustedDockerURL checks if the URL targets a domain trusted to receive
+// the Docker Desktop JWT. It matches:
+//   - "docker.com" and any subdomain (e.g. "desktop.docker.com")
+//   - localhost addresses ("localhost", "127.0.0.1", "::1") for local development
+//
 // It performs strict hostname validation to prevent token leakage.
-func IsDockerURL(rawURL string) bool {
+func IsTrustedDockerURL(rawURL string) bool {
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return false
 	}
 	host := u.Hostname()
-	return host == "docker.com" || strings.HasSuffix(host, ".docker.com")
+	return host == "docker.com" || strings.HasSuffix(host, ".docker.com") ||
+		host == "localhost" || host == "127.0.0.1" || host == "::1"
 }
 
 type DockerDesktopProvider struct{}

--- a/pkg/environment/docker-desktop.go
+++ b/pkg/environment/docker-desktop.go
@@ -2,6 +2,8 @@ package environment
 
 import (
 	"context"
+	"net/url"
+	"strings"
 
 	"github.com/docker/docker-agent/pkg/desktop"
 )
@@ -11,6 +13,19 @@ const (
 	DockerDesktopUsername = "DOCKER_USERNAME"
 	DockerDesktopTokenEnv = "DOCKER_TOKEN"
 )
+
+// IsDockerURL checks if the URL targets a .docker.com domain that should
+// receive the Docker Desktop JWT. The check matches the exact host
+// "docker.com" as well as any subdomain (e.g. "desktop.docker.com").
+// It performs strict hostname validation to prevent token leakage.
+func IsDockerURL(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	host := u.Hostname()
+	return host == "docker.com" || strings.HasSuffix(host, ".docker.com")
+}
 
 type DockerDesktopProvider struct{}
 

--- a/pkg/environment/docker-desktop.go
+++ b/pkg/environment/docker-desktop.go
@@ -16,18 +16,26 @@ const (
 
 // IsTrustedDockerURL checks if the URL targets a domain trusted to receive
 // the Docker Desktop JWT. It matches:
-//   - "docker.com" and any subdomain (e.g. "desktop.docker.com")
-//   - localhost addresses ("localhost", "127.0.0.1", "::1") for local development
+//   - "docker.com" and any subdomain (e.g. "desktop.docker.com") over HTTPS only
+//   - localhost addresses ("localhost", "127.0.0.1", "::1") over HTTP or HTTPS
 //
-// It performs strict hostname validation to prevent token leakage.
+// It performs strict hostname and scheme validation to prevent token leakage.
 func IsTrustedDockerURL(rawURL string) bool {
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return false
 	}
+	if u.Scheme != "https" && u.Scheme != "http" {
+		return false
+	}
 	host := u.Hostname()
-	return host == "docker.com" || strings.HasSuffix(host, ".docker.com") ||
-		host == "localhost" || host == "127.0.0.1" || host == "::1"
+	if host == "localhost" || host == "127.0.0.1" || host == "::1" {
+		return true
+	}
+	if u.Scheme != "https" {
+		return false
+	}
+	return host == "docker.com" || strings.HasSuffix(host, ".docker.com")
 }
 
 type DockerDesktopProvider struct{}

--- a/pkg/environment/docker_desktop_test.go
+++ b/pkg/environment/docker_desktop_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/docker/docker-agent/pkg/environment"
 )
 
-func TestIsDockerURL(t *testing.T) {
+func TestIsTrustedDockerURL(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -24,10 +24,18 @@ func TestIsDockerURL(t *testing.T) {
 		{"https://sub.sub.docker.com/path", true},
 		{"http://docker.com/path", true},
 
+		// Localhost URLs (local development)
+		{"http://localhost:8080/agent.yaml", true},
+		{"https://localhost/agent.yaml", true},
+		{"http://localhost/v1/models", true},
+		{"http://127.0.0.1:8080/agent.yaml", true},
+		{"http://127.0.0.1/path", true},
+		{"http://[::1]:8080/agent.yaml", true},
+		{"http://[::1]/path", true},
+
 		// Non-Docker URLs
 		{"https://example.com/agent.yaml", false},
 		{"https://github.com/docker/repo", false},
-		{"http://localhost:8080/agent.yaml", false},
 		{"", false},
 
 		// Security: malicious URLs that should NOT be treated as Docker URLs
@@ -43,7 +51,7 @@ func TestIsDockerURL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.url, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.expected, environment.IsDockerURL(tt.url))
+			assert.Equal(t, tt.expected, environment.IsTrustedDockerURL(tt.url))
 		})
 	}
 }

--- a/pkg/environment/docker_desktop_test.go
+++ b/pkg/environment/docker_desktop_test.go
@@ -1,0 +1,49 @@
+package environment_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/docker/docker-agent/pkg/environment"
+)
+
+func TestIsDockerURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		url      string
+		expected bool
+	}{
+		// Valid Docker URLs
+		{"https://docker.com/some/path", true},
+		{"https://desktop.docker.com/mcp/catalog/v3/catalog.yaml", true},
+		{"https://api.docker.com/events/v1/track", true},
+		{"https://api-stage.docker.com/events/v1/track", true},
+		{"https://hub.docker.com/mcp/server", true},
+		{"https://sub.sub.docker.com/path", true},
+		{"http://docker.com/path", true},
+
+		// Non-Docker URLs
+		{"https://example.com/agent.yaml", false},
+		{"https://github.com/docker/repo", false},
+		{"http://localhost:8080/agent.yaml", false},
+		{"", false},
+
+		// Security: malicious URLs that should NOT be treated as Docker URLs
+		{"https://evil.com/docker.com/file.yaml", false},     // docker.com in path
+		{"https://notdocker.com/file.yaml", false},           // similar domain name
+		{"https://docker.com.attacker.com/file.yaml", false}, // docker.com as subdomain of attacker
+		{"https://fakedocker.com/agent.yaml", false},         // contains "docker.com" substring
+		{"https://attacker.com?redirect=docker.com", false},  // docker.com in query string
+		{"https://my-docker.com/agent.yaml", false},          // hyphenated similar domain
+		{"https://xdocker.com/agent.yaml", false},            // prefixed similar domain
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, environment.IsDockerURL(tt.url))
+		})
+	}
+}

--- a/pkg/environment/docker_desktop_test.go
+++ b/pkg/environment/docker_desktop_test.go
@@ -15,16 +15,15 @@ func TestIsTrustedDockerURL(t *testing.T) {
 		url      string
 		expected bool
 	}{
-		// Valid Docker URLs
+		// Valid Docker URLs (HTTPS only for remote)
 		{"https://docker.com/some/path", true},
 		{"https://desktop.docker.com/mcp/catalog/v3/catalog.yaml", true},
 		{"https://api.docker.com/events/v1/track", true},
 		{"https://api-stage.docker.com/events/v1/track", true},
 		{"https://hub.docker.com/mcp/server", true},
 		{"https://sub.sub.docker.com/path", true},
-		{"http://docker.com/path", true},
 
-		// Localhost URLs (local development)
+		// Localhost URLs (local development, HTTP or HTTPS)
 		{"http://localhost:8080/agent.yaml", true},
 		{"https://localhost/agent.yaml", true},
 		{"http://localhost/v1/models", true},
@@ -37,6 +36,14 @@ func TestIsTrustedDockerURL(t *testing.T) {
 		{"https://example.com/agent.yaml", false},
 		{"https://github.com/docker/repo", false},
 		{"", false},
+
+		// Scheme enforcement: plain HTTP to remote .docker.com is rejected
+		{"http://docker.com/path", false},
+		{"http://desktop.docker.com/agent.yaml", false},
+
+		// Non-HTTP(S) schemes are rejected
+		{"ftp://docker.com/file.yaml", false},
+		{"ftp://localhost/file.yaml", false},
 
 		// Security: malicious URLs that should NOT be treated as Docker URLs
 		{"https://evil.com/docker.com/file.yaml", false},     // docker.com in path

--- a/pkg/model/provider/anthropic/client.go
+++ b/pkg/model/provider/anthropic/client.go
@@ -90,7 +90,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 		}
 		// When using a Gateway targeting a Docker domain, tokens are short-lived.
 		// Only require and inject the Docker JWT if the gateway is a .docker.com URL.
-		if environment.IsDockerURL(gateway) {
+		if environment.IsTrustedDockerURL(gateway) {
 			// Fail fast if Docker Desktop's auth token isn't available
 			if token, _ := env.Get(ctx, environment.DockerDesktopTokenEnv); token == "" {
 				slog.ErrorContext(ctx, "Anthropic client creation failed", "error", "failed to get Docker Desktop's authentication token")
@@ -101,7 +101,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 		// When using a Gateway, tokens are short-lived.
 		anthropicClient.clientFn = func(ctx context.Context) (anthropic.Client, error) {
 			var authToken string
-			if environment.IsDockerURL(gateway) {
+			if environment.IsTrustedDockerURL(gateway) {
 				// Query a fresh auth token each time the client is used
 				authToken, _ = env.Get(ctx, environment.DockerDesktopTokenEnv)
 				if authToken == "" {

--- a/pkg/model/provider/anthropic/client.go
+++ b/pkg/model/provider/anthropic/client.go
@@ -88,18 +88,25 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 		if cfg.Auth != nil {
 			return nil, errors.New("anthropic: auth and Docker AI Gateway are mutually exclusive")
 		}
-		// Fail fast if Docker Desktop's auth token isn't available
-		if token, _ := env.Get(ctx, environment.DockerDesktopTokenEnv); token == "" {
-			slog.ErrorContext(ctx, "Anthropic client creation failed", "error", "failed to get Docker Desktop's authentication token")
-			return nil, errors.New("sorry, you first need to sign in Docker Desktop to use the Docker AI Gateway")
+		// When using a Gateway targeting a Docker domain, tokens are short-lived.
+		// Only require and inject the Docker JWT if the gateway is a .docker.com URL.
+		if environment.IsDockerURL(gateway) {
+			// Fail fast if Docker Desktop's auth token isn't available
+			if token, _ := env.Get(ctx, environment.DockerDesktopTokenEnv); token == "" {
+				slog.ErrorContext(ctx, "Anthropic client creation failed", "error", "failed to get Docker Desktop's authentication token")
+				return nil, errors.New("sorry, you first need to sign in Docker Desktop to use the Docker AI Gateway")
+			}
 		}
 
 		// When using a Gateway, tokens are short-lived.
 		anthropicClient.clientFn = func(ctx context.Context) (anthropic.Client, error) {
-			// Query a fresh auth token each time the client is used
-			authToken, _ := env.Get(ctx, environment.DockerDesktopTokenEnv)
-			if authToken == "" {
-				return anthropic.Client{}, errors.New(base.NoDesktopTokenErrorMessage)
+			var authToken string
+			if environment.IsDockerURL(gateway) {
+				// Query a fresh auth token each time the client is used
+				authToken, _ = env.Get(ctx, environment.DockerDesktopTokenEnv)
+				if authToken == "" {
+					return anthropic.Client{}, errors.New(base.NoDesktopTokenErrorMessage)
+				}
 			}
 
 			url, err := url.Parse(gateway)
@@ -120,12 +127,14 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 				httpOptions = append(httpOptions, httpclient.WithHeader("X-Cagent-GeneratingTitle", "1"))
 			}
 
-			client := anthropic.NewClient(
-				option.WithAuthToken(authToken),
-				option.WithAPIKey(authToken),
+			clientOptions := []option.RequestOption{
 				option.WithBaseURL(baseURL),
 				option.WithHTTPClient(httpclient.NewHTTPClient(ctx, httpOptions...)),
-			)
+			}
+			if authToken != "" {
+				clientOptions = append(clientOptions, option.WithAuthToken(authToken), option.WithAPIKey(authToken))
+			}
+			client := anthropic.NewClient(clientOptions...)
 
 			return client, nil
 		}

--- a/pkg/model/provider/gemini/client.go
+++ b/pkg/model/provider/gemini/client.go
@@ -123,7 +123,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 	} else {
 		// When using a Gateway targeting a Docker domain, tokens are short-lived.
 		// Only require and inject the Docker JWT if the gateway is a .docker.com URL.
-		if environment.IsDockerURL(gateway) {
+		if environment.IsTrustedDockerURL(gateway) {
 			// Fail fast if Docker Desktop's auth token isn't available
 			if token, _ := env.Get(ctx, environment.DockerDesktopTokenEnv); token == "" {
 				slog.ErrorContext(ctx, "Gemini client creation failed", "error", "failed to get Docker Desktop's authentication token")
@@ -134,7 +134,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 		// When using a Gateway, tokens are short-lived.
 		clientFn = func(ctx context.Context) (*genai.Client, error) {
 			var authToken string
-			if environment.IsDockerURL(gateway) {
+			if environment.IsTrustedDockerURL(gateway) {
 				// Query a fresh auth token each time the client is used
 				authToken, _ = env.Get(ctx, environment.DockerDesktopTokenEnv)
 				if authToken == "" {

--- a/pkg/model/provider/gemini/client.go
+++ b/pkg/model/provider/gemini/client.go
@@ -121,18 +121,25 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 			return client, nil
 		}
 	} else {
-		// Fail fast if Docker Desktop's auth token isn't available
-		if token, _ := env.Get(ctx, environment.DockerDesktopTokenEnv); token == "" {
-			slog.ErrorContext(ctx, "Gemini client creation failed", "error", "failed to get Docker Desktop's authentication token")
-			return nil, errors.New("sorry, you first need to sign in Docker Desktop to use the Docker AI Gateway")
+		// When using a Gateway targeting a Docker domain, tokens are short-lived.
+		// Only require and inject the Docker JWT if the gateway is a .docker.com URL.
+		if environment.IsDockerURL(gateway) {
+			// Fail fast if Docker Desktop's auth token isn't available
+			if token, _ := env.Get(ctx, environment.DockerDesktopTokenEnv); token == "" {
+				slog.ErrorContext(ctx, "Gemini client creation failed", "error", "failed to get Docker Desktop's authentication token")
+				return nil, errors.New("sorry, you first need to sign in Docker Desktop to use the Docker AI Gateway")
+			}
 		}
 
 		// When using a Gateway, tokens are short-lived.
 		clientFn = func(ctx context.Context) (*genai.Client, error) {
-			// Query a fresh auth token each time the client is used
-			authToken, _ := env.Get(ctx, environment.DockerDesktopTokenEnv)
-			if authToken == "" {
-				return nil, errors.New(base.NoDesktopTokenErrorMessage)
+			var authToken string
+			if environment.IsDockerURL(gateway) {
+				// Query a fresh auth token each time the client is used
+				authToken, _ = env.Get(ctx, environment.DockerDesktopTokenEnv)
+				if authToken == "" {
+					return nil, errors.New(base.NoDesktopTokenErrorMessage)
+				}
 			}
 
 			url, err := url.Parse(gateway)
@@ -152,16 +159,20 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 				httpOptions = append(httpOptions, httpclient.WithHeader("X-Cagent-GeneratingTitle", "1"))
 			}
 
+			httpOpts := genai.HTTPOptions{
+				BaseURL: baseURL,
+			}
+			if authToken != "" {
+				httpOpts.Headers = http.Header{
+					"Authorization": []string{"Bearer " + authToken},
+				}
+			}
+
 			return genai.NewClient(ctx, &genai.ClientConfig{
-				APIKey:     authToken,
-				Backend:    genai.BackendGeminiAPI,
-				HTTPClient: httpclient.NewHTTPClient(ctx, httpOptions...),
-				HTTPOptions: genai.HTTPOptions{
-					BaseURL: baseURL,
-					Headers: http.Header{
-						"Authorization": []string{"Bearer " + authToken},
-					},
-				},
+				APIKey:      authToken,
+				Backend:     genai.BackendGeminiAPI,
+				HTTPClient:  httpclient.NewHTTPClient(ctx, httpOptions...),
+				HTTPOptions: httpOpts,
 			})
 		}
 	}

--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -112,7 +112,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 	} else {
 		// When using a Gateway targeting a Docker domain, tokens are short-lived.
 		// Only require and inject the Docker JWT if the gateway is a .docker.com URL.
-		if environment.IsDockerURL(gateway) {
+		if environment.IsTrustedDockerURL(gateway) {
 			// Fail fast if Docker Desktop's auth token isn't available
 			if token, _ := env.Get(ctx, environment.DockerDesktopTokenEnv); token == "" {
 				slog.ErrorContext(ctx, "OpenAI client creation failed", "error", "failed to get Docker Desktop's authentication token")
@@ -123,7 +123,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 		// When using a Gateway, tokens are short-lived.
 		clientFn = func(ctx context.Context) (*openai.Client, error) {
 			var authToken string
-			if environment.IsDockerURL(gateway) {
+			if environment.IsTrustedDockerURL(gateway) {
 				// Query a fresh auth token each time the client is used
 				authToken, _ = env.Get(ctx, environment.DockerDesktopTokenEnv)
 				if authToken == "" {

--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -110,18 +110,25 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 			return &client, nil
 		}
 	} else {
-		// Fail fast if Docker Desktop's auth token isn't available
-		if token, _ := env.Get(ctx, environment.DockerDesktopTokenEnv); token == "" {
-			slog.ErrorContext(ctx, "OpenAI client creation failed", "error", "failed to get Docker Desktop's authentication token")
-			return nil, errors.New("sorry, you first need to sign in Docker Desktop to use the Docker AI Gateway")
+		// When using a Gateway targeting a Docker domain, tokens are short-lived.
+		// Only require and inject the Docker JWT if the gateway is a .docker.com URL.
+		if environment.IsDockerURL(gateway) {
+			// Fail fast if Docker Desktop's auth token isn't available
+			if token, _ := env.Get(ctx, environment.DockerDesktopTokenEnv); token == "" {
+				slog.ErrorContext(ctx, "OpenAI client creation failed", "error", "failed to get Docker Desktop's authentication token")
+				return nil, errors.New("sorry, you first need to sign in Docker Desktop to use the Docker AI Gateway")
+			}
 		}
 
 		// When using a Gateway, tokens are short-lived.
 		clientFn = func(ctx context.Context) (*openai.Client, error) {
-			// Query a fresh auth token each time the client is used
-			authToken, _ := env.Get(ctx, environment.DockerDesktopTokenEnv)
-			if authToken == "" {
-				return nil, errors.New(base.NoDesktopTokenErrorMessage)
+			var authToken string
+			if environment.IsDockerURL(gateway) {
+				// Query a fresh auth token each time the client is used
+				authToken, _ = env.Get(ctx, environment.DockerDesktopTokenEnv)
+				if authToken == "" {
+					return nil, errors.New(base.NoDesktopTokenErrorMessage)
+				}
 			}
 
 			url, err := url.Parse(gateway)
@@ -142,12 +149,15 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 				httpOptions = append(httpOptions, httpclient.WithHeader("X-Cagent-GeneratingTitle", "1"))
 			}
 
-			client := openai.NewClient(
-				option.WithAPIKey(authToken),
+			clientOptions := []option.RequestOption{
 				option.WithBaseURL(baseURL),
 				option.WithHTTPClient(httpclient.NewHTTPClient(ctx, httpOptions...)),
 				option.WithMiddleware(oaistream.ErrorBodyMiddleware()),
-			)
+			}
+			if authToken != "" {
+				clientOptions = append(clientOptions, option.WithAPIKey(authToken))
+			}
+			client := openai.NewClient(clientOptions...)
 
 			return &client, nil
 		}


### PR DESCRIPTION
Also, don't send desktop JWT to model gateway if it's not a .docker.com URL, or localhost (for dev purposes)

Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>