### PR TITLE
feat(tui): expose read access to transcript messages

### DIFF
--- a/pkg/tui/components/transcript/transcript.go
+++ b/pkg/tui/components/transcript/transcript.go
@@ -264,3 +264,12 @@ func (t *Transcript) StopAnimations() {
 		animation.StopView(v)
 	}
 }
+
+// Messages returns the transcript's messages, oldest first. The slice is
+// the transcript's own backing store: callers must treat it as read-only
+// (mutating entries would desync them from their rendered views). It gives
+// embedders observability — host tests asserting on conversation structure,
+// or persistence of the chat — without growing the mutation surface.
+func (t *Transcript) Messages() []*types.Message {
+	return t.msgs
+}

--- a/pkg/tui/components/transcript/transcript_test.go
+++ b/pkg/tui/components/transcript/transcript_test.go
@@ -233,3 +233,17 @@ func TestTransferTaskGetsSeparator(t *testing.T) {
 	// Unlike other consecutive tool calls, a handoff stands apart.
 	assert.Contains(t, tr.Render(80), "\n\n")
 }
+
+func TestMessages(t *testing.T) {
+	tr := newTestTranscript()
+
+	assert.Empty(t, tr.Messages())
+
+	_ = tr.Append(types.User("hello"))
+	_ = tr.AppendToLastMessage(testAgent, "hi")
+
+	msgs := tr.Messages()
+	require.Len(t, msgs, 2)
+	assert.Equal(t, types.MessageTypeUser, msgs[0].Type)
+	assert.Equal(t, "hi", msgs[1].Content)
+}


### PR DESCRIPTION
Follow-up to #3080 (TUI embedding seams for Gordon). The embedded transcript component now exposes a read-only `Messages()` accessor so embedders can observe conversation structure — host-side tests asserting on chat history, persistence layers reading state — without accessing private fields.

The accessor returns the backing slice as-is and the comment makes clear it must be treated as read-only: mutating entries would desync them from their rendered views, bloating the mutation surface. This keeps the component's contract clean while giving embedders the introspection they need.

Includes a unit test covering the empty case and the ordering of appended messages.