### PR TITLE
docs: update remote MCP reconnect, thinking runtime cycling, distribution, and Go SDK docs

### DIFF
--- a/docs/concepts/distribution/index.md
+++ b/docs/concepts/distribution/index.md
@@ -125,3 +125,18 @@ $ docker agent run docker.io/myorg/private-agent:latest
   <p>Having issues with push/pull? See <a href="{{ '/community/troubleshooting/' | relative_url }}">Troubleshooting</a> for common registry issues.</p>
 
 </div>
+
+## Local Development
+
+For local development and testing, you can run an agent directly from a local HTTP server without a registry:
+
+```bash
+# Serve an agent config locally
+$ python3 -m http.server 8080
+
+# Run it directly via HTTP
+$ docker agent run http://localhost:8080/agent.yaml
+$ docker agent run http://127.0.0.1:8080/agent.yaml
+```
+
+This is useful for iterating on agent configs served from a local dev server before pushing to a registry. Both `localhost` and `127.0.0.1` addresses are supported with plain `http://` URLs.

--- a/docs/concepts/distribution/index.md
+++ b/docs/concepts/distribution/index.md
@@ -120,6 +120,12 @@ $ docker agent run docker.io/myorg/private-agent:latest
 ```
 
 <div class="callout callout-info" markdown="1">
+<div class="callout-title">Docker Desktop credentials
+</div>
+  <p>When pulling or running an agent from a <code>.docker.com</code> URL (e.g. <code>hub.docker.com</code>, <code>registry-1.docker.com</code>), docker-agent automatically forwards your Docker Desktop JWT for authentication — no <code>docker login</code> required as long as Docker Desktop is running and signed in.</p>
+</div>
+
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">Troubleshooting
 </div>
   <p>Having issues with push/pull? See <a href="{{ '/community/troubleshooting/' | relative_url }}">Troubleshooting</a> for common registry issues.</p>

--- a/docs/concepts/distribution/index.md
+++ b/docs/concepts/distribution/index.md
@@ -122,7 +122,8 @@ $ docker agent run docker.io/myorg/private-agent:latest
 <div class="callout callout-info" markdown="1">
 <div class="callout-title">Docker Desktop credentials
 </div>
-  <p>When pulling or running an agent from a <code>.docker.com</code> URL (e.g. <code>hub.docker.com</code>, <code>registry-1.docker.com</code>), docker-agent automatically forwards your Docker Desktop JWT for authentication — no <code>docker login</code> required as long as Docker Desktop is running and signed in.</p>
+  <p>When pulling or running an agent from a <code>docker.com</code> or <code>*.docker.com</code> HTTPS URL (e.g. <code>desktop.docker.com</code>), docker-agent automatically forwards your Docker Desktop JWT for authentication — no explicit login required when Docker Desktop is running and signed in.</p>
+  <p>Note: <code>docker.io</code> (the standard Docker Hub registry domain) is a separate domain and is <strong>not</strong> covered by automatic JWT forwarding. Agents pulled from <code>docker.io</code> or <code>registry-1.docker.io</code> still require <code>docker login docker.io</code> for private repositories.</p>
 </div>
 
 <div class="callout callout-info" markdown="1">

--- a/docs/configuration/tools/index.md
+++ b/docs/configuration/tools/index.md
@@ -262,7 +262,7 @@ toolsets:
 | Property | Type | Description |
 | --- | --- | --- |
 | `profile` | string | One of `resilient` (default), `strict`, `best-effort`. Picks defaults for every other field. |
-| `restart` | string | When the supervisor should reconnect after a disconnect: `never`, `on_failure` (default), or `always`. |
+| `restart` | string | When the supervisor should reconnect after a disconnect: `never`, `on_failure` (default), or `always`. For **remote** MCP toolsets (Streamable HTTP / SSE), `on_failure` is automatically promoted to `always` so idle-timeout closes reconnect gracefully — `never` is still honored. |
 | `max_restarts` | int | Maximum consecutive restart attempts before the toolset is marked `Failed`. `0` uses the profile default (5); `-1` means unlimited. |
 | `backoff.initial` | duration | First wait between attempts (Go duration: `500ms`, `1s`, …). Default: `1s`. |
 | `backoff.max` | duration | Cap on the wait between attempts. Default: `32s`. |

--- a/docs/features/remote-mcp/index.md
+++ b/docs/features/remote-mcp/index.md
@@ -52,6 +52,12 @@ For full configuration details, see the [Tool Config]({{ '/configuration/tools/'
 
 Set `allow_private_ips: true` on a remote MCP toolset only when the MCP server or its OAuth registration/token endpoints intentionally resolve to private, loopback, or link-local addresses. The default blocks those OAuth helper requests to reduce SSRF risk.
 
+<div class="callout callout-info" markdown="1">
+<div class="callout-title">Automatic reconnection after idle timeouts
+</div>
+  <p>Remote MCP connections (Streamable HTTP / SSE) automatically reconnect after the server closes an idle connection — no configuration needed. Services like Notion and Linear close idle connections periodically; docker-agent detects the clean close and reconnects with exponential backoff. To tune reconnect behaviour or disable reconnection entirely, use the <a href="{{ '/configuration/tools/#toolset-lifecycle' | relative_url }}"><code>lifecycle</code> block</a>.</p>
+</div>
+
 ### OAuth for servers without Dynamic Client Registration
 
 Most remote MCP servers that require OAuth support [Dynamic Client Registration (RFC 7591)]({{ 'https://datatracker.ietf.org/doc/html/rfc7591' }}) — no configuration is needed, docker-agent handles the flow for you.

--- a/docs/guides/go-sdk/index.md
+++ b/docs/guides/go-sdk/index.md
@@ -38,7 +38,7 @@ docker-agent can be used as a Go library, allowing you to build AI agents direct
 
 ## Embedding TUI Components
 
-When building custom UIs on top of docker-agent's TUI primitives, three packages define the contracts that keep the runtime and the UI in sync:
+When building custom UIs on top of docker-agent's TUI primitives, four packages define the contracts that keep the runtime and the UI in sync:
 
 - **`pkg/tui/components/toolconfirm`** — import this package for the permission-decision policy rather than copying the pattern-building logic. The `Decision` enum, `BuildPermissionPattern` helper, and rejection-reason presets are the canonical source of truth: whatever pattern is shown to the user in the confirmation dialog is exactly the pattern granted to the runtime.
 - **`pkg/tui/service`** — use `StaticSessionState` as a stub `SessionStateReader` when rendering individual message or tool views outside the full TUI app. It returns conservative fixed values for all nine interface methods, eliminating the need for hand-rolled stubs.

--- a/docs/guides/go-sdk/index.md
+++ b/docs/guides/go-sdk/index.md
@@ -34,6 +34,7 @@ docker-agent can be used as a Go library, allowing you to build AI agents direct
 | `pkg/tui/components/toolconfirm` | Tool-confirmation policy: `Decision` enum, `BuildPermissionPattern`, key bindings, and rejection-reason presets. Share this instead of copying the permission-pattern logic. |
 | `pkg/tui/service`      | `StaticSessionState` — a `SessionStateReader` with conservative fixed values, for rendering message/tool views outside the full TUI app. Replaces hand-rolled nine-method stubs. |
 | `pkg/tui/animation`    | `Stopper` / `StopView` — animation lifecycle contract. Call `StopAnimation` on views removed from the UI to prevent leaked tick subscriptions. |
+| `pkg/tui/components/transcript` | Embedded transcript view with read-only `Messages()` accessor for observing conversation structure in host tests and persistence layers. |
 
 ## Embedding TUI Components
 
@@ -42,6 +43,7 @@ When building custom UIs on top of docker-agent's TUI primitives, three packages
 - **`pkg/tui/components/toolconfirm`** — import this package for the permission-decision policy rather than copying the pattern-building logic. The `Decision` enum, `BuildPermissionPattern` helper, and rejection-reason presets are the canonical source of truth: whatever pattern is shown to the user in the confirmation dialog is exactly the pattern granted to the runtime.
 - **`pkg/tui/service`** — use `StaticSessionState` as a stub `SessionStateReader` when rendering individual message or tool views outside the full TUI app. It returns conservative fixed values for all nine interface methods, eliminating the need for hand-rolled stubs.
 - **`pkg/tui/animation`** — implement `animation.Stopper` on any view that owns a tick-based animation. Call `StopAnimation` whenever a view is removed from the UI hierarchy to prevent leaked `time.Tick` subscriptions from firing against a dead view.
+- **`pkg/tui/components/transcript`** — embed the transcript view for displaying conversation history. Use the `Messages()` method to read the current slice of transcript messages (treat as read-only — mutations desync renders). This is useful for host-side tests asserting on chat history, and for persistence layers that need to snapshot conversation state.
 
 ## Basic Example
 

--- a/docs/guides/thinking/index.md
+++ b/docs/guides/thinking/index.md
@@ -308,7 +308,7 @@ models:
 
 While running in the TUI, press **Shift+Tab** to cycle the thinking effort level for the current model without editing your YAML config:
 
-- The level steps through the model's supported range (provider-specific), wrapping around — for example `off → minimal → low → medium → high → xhigh → off` on OpenAI.
+- The level steps through the model's supported range (provider-specific), wrapping around — for example `none → minimal → low → medium → high → xhigh → none` on OpenAI.
 - The current level is shown in the sidebar next to the model name (e.g. `openai/gpt-5 • high`).
 - This applies as a session override — it is **not** saved to the config file. The next session starts from the level defined in your YAML.
 - For models that don't support reasoning, and for remote runtimes, Shift+Tab is a no-op and an informational message is displayed.

--- a/docs/guides/thinking/index.md
+++ b/docs/guides/thinking/index.md
@@ -304,6 +304,15 @@ models:
 | Research, difficult math/logic   | `xhigh` / `max`         |
 | Long agentic tasks (Anthropic)   | `adaptive`              |
 
+## Changing Thinking Level at Runtime
+
+While running in the TUI, press **Shift+Tab** to cycle the thinking effort level for the current model without editing your YAML config:
+
+- The level steps through the model's supported range (provider-specific), wrapping around — for example `off → minimal → low → medium → high → xhigh → off` on OpenAI.
+- The current level is shown in the sidebar next to the model name (e.g. `openai/gpt-5 • high`).
+- This applies as a session override — it is **not** saved to the config file. The next session starts from the level defined in your YAML.
+- For models that don't support reasoning, and for remote runtimes, Shift+Tab is a no-op and an informational message is displayed.
+
 ## Sharing Thinking Config Across Models
 
 Define a provider with a default `thinking_budget` and all models that reference it inherit it:

--- a/docs/tools/mcp/index.md
+++ b/docs/tools/mcp/index.md
@@ -217,7 +217,7 @@ See [Per-Toolset Model Routing]({{ '/configuration/tools/#per-toolset-model-rout
 
 ### Lifecycle (auto-restart, profiles)
 
-Local stdio and remote MCP servers are supervised: crashed servers reconnect automatically with exponential backoff. Tune the policy with the `lifecycle` block:
+Local stdio and remote MCP servers are supervised: crashed servers reconnect automatically with exponential backoff. **Remote** MCP servers (Streamable HTTP / SSE) also reconnect after idle/clean connection closes — services like Notion and Linear periodically close idle connections, and docker-agent reconnects transparently. Tune the policy with the `lifecycle` block:
 
 ```yaml
 toolsets:


### PR DESCRIPTION
## Documentation updates

This PR updates five areas of the docs to reflect code changes merged into `main` in the last 36 hours.

| Commit | Source PR | What changed |
|--------|-----------|--------------|
| `dc84089` | [#3064](https://github.com/docker/docker-agent/pull/3064) | Document automatic idle-reconnect for remote MCP toolsets |
| `774ebef` | [#3067](https://github.com/docker/docker-agent/pull/3067) | Document Shift+Tab runtime thinking-level cycling |
| `ec033c7` | [#3075](https://github.com/docker/docker-agent/pull/3075) | Document `http://localhost` URL support for local agent dev |
| `5ea48dc` | [#3077](https://github.com/docker/docker-agent/pull/3077) | Document automatic Docker Desktop JWT for `.docker.com` registries |
| `b145dae` | [#3081](https://github.com/docker/docker-agent/pull/3081) | Add `pkg/tui/components/transcript` to Go SDK core packages |

## Details

### Remote MCP idle reconnection ([#3064](https://github.com/docker/docker-agent/pull/3064))
Remote MCP servers (Streamable HTTP / SSE) now reconnect automatically after idle connection closes, not just after failures. Updated three files:
- `docs/configuration/tools/index.md` — extended the `restart` table row to note that `on_failure` is auto-promoted to `always` for remote MCP; `never` still honored.
- `docs/features/remote-mcp/index.md` — added a callout explaining automatic reconnection after idle timeouts, with a link to lifecycle tuning.
- `docs/tools/mcp/index.md` — updated the Lifecycle section to call out idle/clean closes alongside crashes.

### Shift+Tab thinking-level cycling ([#3067](https://github.com/docker/docker-agent/pull/3067))
The keyboard shortcut was already listed in the TUI shortcuts table but had no prose explanation. Added a **"Changing Thinking Level at Runtime"** section to `docs/guides/thinking/index.md` covering: cycling with Shift+Tab, provider-specific ranges with wrap-around, sidebar display, session-only scope (not saved to config), and no-op behaviour on unsupported models/remote runtimes.

### Localhost HTTP URL for local dev ([#3075](https://github.com/docker/docker-agent/pull/3075))
Added a **"Local Development"** section to `docs/concepts/distribution/index.md` showing `docker agent run http://localhost:PORT/agent.yaml` for testing against locally-served agent configs.

### Docker Desktop JWT for `.docker.com` registries ([#3077](https://github.com/docker/docker-agent/pull/3077))
Added a callout inside the **"Private Repositories"** section of `docs/concepts/distribution/index.md` noting that docker-agent auto-forwards the Docker Desktop JWT when pulling from `.docker.com` URLs — no explicit `docker login` needed when Docker Desktop is running.

### `pkg/tui/components/transcript` in Go SDK docs ([#3081](https://github.com/docker/docker-agent/pull/3081))
Added a row for `pkg/tui/components/transcript` to the Core Packages table in `docs/guides/go-sdk/index.md`, and a bullet in the "Embedding TUI Components" section describing `Messages()` as a read-only accessor for host-side tests and persistence layers.

## PRs reviewed and found up to date

| Source PR | Reason |
|-----------|--------|
| [#3080](https://github.com/docker/docker-agent/pull/3080) | TUI embedding helpers — covered by previous docs PR [#3068](https://github.com/docker/docker-agent/pull/3068) |
| [#3079](https://github.com/docker/docker-agent/pull/3079) | CHANGELOG v1.78.0 — automated release update |
| [#3076](https://github.com/docker/docker-agent/pull/3076) | Dependency bumps — no user-facing API or behaviour change |
| [#3072](https://github.com/docker/docker-agent/pull/3072) | Internal bug fix (ScriptToolSet panic guard) — no config/API change |
| [#3070](https://github.com/docker/docker-agent/pull/3070) | Internal bug fix (elicitation channel race) — no user-facing behaviour change |
| [#3068](https://github.com/docker/docker-agent/pull/3068) | Docs PR itself |
| [#3065](https://github.com/docker/docker-agent/pull/3065) | Docs PR itself (remote MCP transport migration) |
| [#3061](https://github.com/docker/docker-agent/pull/3061) | CHANGELOG v1.76.0 — automated release update |