### PR TITLE
fix(mcpcatalog): mark semgrep server as oauth

### DIFF
--- a/pkg/tools/builtin/mcpcatalog/servers.json
+++ b/pkg/tools/builtin/mcpcatalog/servers.json
@@ -695,7 +695,7 @@
       "readme": "http://desktop.docker.com/mcp/catalog/v3/readme/semgrep.md",
       "headers": {},
       "auth": {
-        "type": "none"
+        "type": "oauth"
       }
     },
     {


### PR DESCRIPTION
The semgrep MCP server in the catalog was marked as `auth: none`, but the upstream server actually requires OAuth.