### PR TITLE
docs: require GPG/SSH commit signing in Git Practices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,3 +107,4 @@ Before marking work as complete:
 - Group related changes together; avoid mixing unrelated changes
 - Keep branches focused on single features or fixes
 - Ensure your branch is up-to-date before submitting
+- Sign commits with a GPG or SSH key (`git commit -S`)


### PR DESCRIPTION
Add a bullet point to the `# Git Practices` section of `AGENTS.md` requiring contributors to sign commits with a GPG or SSH key (`git commit -S`).

- No changes to `README.md` — its Contributing section only links to an external guide with no git practices content.