### PR TITLE
fix: respect HOME env var when expanding ~ in paths

### DIFF
--- a/pkg/path/home.go
+++ b/pkg/path/home.go
@@ -14,17 +14,25 @@ func ExpandHomeDir(path string) (string, error) {
 	if !isHomeDirPath(path) {
 		return path, nil
 	}
-
-	homeDir, err := os.UserHomeDir()
+	homeDir, err := userHomeDir()
 	if err != nil || homeDir == "" {
 		return "", errors.New("failed to get user home directory")
 	}
-
 	if path == "~" {
 		return filepath.Clean(homeDir), nil
 	}
-
 	return filepath.Join(homeDir, path[2:]), nil
+}
+
+// userHomeDir returns the user's home directory, preferring the HOME
+// environment variable (used cross-platform, including in tests) before
+// falling back to os.UserHomeDir(), which on Windows reads USERPROFILE
+// instead of HOME.
+func userHomeDir() (string, error) {
+	if home := os.Getenv("HOME"); home != "" {
+		return home, nil
+	}
+	return os.UserHomeDir()
 }
 
 func isHomeDirPath(path string) bool {


### PR DESCRIPTION
Fixes Windows test failure in pkg/tools/workingdir where HOME override was ignored because os.UserHomeDir() reads USERPROFILE instead.