### PR TITLE
feat: add force_handoff for deterministic agent routing on natural stop

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -574,6 +574,10 @@
             "type": "string"
           }
         },
+        "force_handoff": {
+          "type": "string",
+          "description": "Name of an agent that unconditionally receives the conversation whenever this agent produces a final response, bypassing the LLM's tool-calling entirely. Guarantees deterministic routing for strict pipelines (e.g. extractor -> summarizer). Can be the name of an agent defined in this config or an external reference. Must not reference the agent itself, and force_handoff chains must not form a cycle."
+        },
         "add_date": {
           "type": "boolean",
           "description": "Whether to add date information"

--- a/docs/concepts/multi-agent/index.md
+++ b/docs/concepts/multi-agent/index.md
@@ -147,6 +147,34 @@ agents:
 
 </div>
 
+### Forced Handoffs
+
+With `handoffs`, the **model decides** whether to call the `handoff` tool — which means it can forget to, breaking pipelines that depend on a strict order. `force_handoff` removes that uncertainty: whenever the agent produces a final response, the **runtime itself** routes the conversation to the named agent, bypassing the LLM's tool-calling entirely. The full conversation context carries over.
+
+```yaml
+agents:
+  root:
+    model: anthropic/claude-sonnet-4-5
+    description: Extracts key facts from the input
+    instruction: |
+      Extract the key facts from the user's input as a bullet list.
+    force_handoff: summarizer
+
+  summarizer:
+    model: anthropic/claude-sonnet-4-5
+    description: Produces the final summary
+    instruction: |
+      Summarize the extracted facts for the user.
+```
+
+Rules enforced at config load time:
+
+- The target must be an agent defined in the config (or an external reference)
+- An agent cannot `force_handoff` to itself
+- Chains of `force_handoff` edges must not form a cycle (A → B → A is rejected)
+
+See <a href="https://github.com/docker/docker-agent/blob/main/examples/force_handoff.yaml"><code>examples/force_handoff.yaml</code></a> for a runnable example.
+
 ## Parallel Delegation with Background Agents
 
 `transfer_task` is **sequential** — the coordinator waits for the sub-agent to finish before continuing. When you need to fan out work to multiple agents at the same time, use the `background_agents` toolset instead.

--- a/docs/configuration/agents/index.md
+++ b/docs/configuration/agents/index.md
@@ -40,6 +40,7 @@ agents:
       name: "prompt text" # or {instruction: "prompt", agent: "sub_agent_name"}
     welcome_message: string # Optional: message shown at session start
     handoffs: [list] # Optional: agent names this agent can hand off to
+    force_handoff: string # Optional: agent that always receives the conversation when this agent stops
     hooks: # Optional: lifecycle hooks
       pre_tool_use: [list]
       tool_response_transform: [list]
@@ -98,6 +99,7 @@ agents:
 | `use_skills`                | list of string | ✗   | Names of top-level `skills` groups to merge into this agent. Inline skills are deduplicated by name against merged entries. Default: `[]`. |
 | `welcome_message`           | string  | ✗        | Message displayed to the user when a session starts. Rendered as Markdown in the TUI. **Not sent to the model** — it exists purely for the user's benefit. Useful for telling users what the agent can do and what commands are available. |
 | `handoffs`                  | array   | ✗        | List of agent names this agent can hand off the conversation to. Enables the `handoff` tool. See [Handoffs Routing]({{ '/concepts/multi-agent/#handoffs-routing' | relative_url }}).                  |
+| `force_handoff`             | string  | ✗        | Name of an agent that unconditionally receives the conversation whenever this agent produces a final response. The runtime performs the switch itself, bypassing the LLM's tool-calling, guaranteeing deterministic pipelines. Must not reference the agent itself, and chains must not form a cycle. See [Forced Handoffs]({{ '/concepts/multi-agent/#forced-handoffs' | relative_url }}). |
 | `hooks`                     | object  | ✗        | Lifecycle hooks for running commands at various points. See [Hooks]({{ '/configuration/hooks/' | relative_url }}).                                                                                   |
 | `structured_output`         | object  | ✗        | Constrain agent output to match a JSON schema. See [Structured Output]({{ '/configuration/structured-output/' | relative_url }}).                                                                    |
 | `cache`                     | object  | ✗        | Response cache. When the same user question is asked again, the previous answer is replayed verbatim and the model is not called. See [Response Cache](#response-cache) below.                  |

--- a/docs/configuration/hooks/index.md
+++ b/docs/configuration/hooks/index.md
@@ -274,7 +274,7 @@ In addition to the common fields, each event ships its own payload:
 | `notification`              | `notification_level` (`error` or `warning`), `notification_message`                                                   |
 | `on_error`                  | `notification_level` (always `error`), `notification_message`                                                         |
 | `on_max_iterations`         | `notification_level` (always `warning`), `notification_message`                                                       |
-| `on_agent_switch`           | `from_agent`, `to_agent`, `agent_switch_kind` (`transfer_task`, `transfer_task_return`, or `handoff`)                 |
+| `on_agent_switch`           | `from_agent`, `to_agent`, `agent_switch_kind` (`transfer_task`, `transfer_task_return`, `handoff`, or `force_handoff`)                 |
 | `on_session_resume`         | `previous_max_iterations`, `new_max_iterations`                                                                       |
 | `on_tool_approval_decision` | `tool_name`, `tool_use_id`, `tool_input`, `approval_decision`, `approval_source`                                      |
 | `worktree_create`           | `worktree_path`, `worktree_branch`, `worktree_source_dir` (`cwd` is also set to the new worktree)                     |
@@ -571,7 +571,7 @@ The `reason` field classifies the exit:
 
 ### Agent-Switch and Session-Resume: observability for multi-agent and long runs
 
-`on_agent_switch` fires whenever the runtime moves the active agent to a new one — `transfer_task`, `handoff`, or the return after a transferred task completes. The cause is in `agent_switch_kind`, the source and destination in `from_agent` and `to_agent`. Use it for audit, transcript, and metrics pipelines that track which agent ran which tools.
+`on_agent_switch` fires whenever the runtime moves the active agent to a new one — `transfer_task`, `handoff`, `force_handoff`, or the return after a transferred task completes. The cause is in `agent_switch_kind`, the source and destination in `from_agent` and `to_agent`. Use it for audit, transcript, and metrics pipelines that track which agent ran which tools.
 
 The built-in [`unload`](#available-built-ins) hooks into this event to release the resources held by the previous agent's models. It's the canonical way to run two heavy local models on a GPU that can only fit one at a time:
 

--- a/examples/force_handoff.yaml
+++ b/examples/force_handoff.yaml
@@ -1,0 +1,30 @@
+#!/usr/bin/env cagent run
+# Deterministic pipeline using force_handoff:
+#
+#   extractor ──(always)──> summarizer
+#
+# Unlike `handoffs` (where the LLM decides whether to call the handoff
+# tool), `force_handoff` is enforced by the runtime: whenever the agent
+# produces a final response, the conversation is unconditionally routed
+# to the named agent, carrying over the full context. This guarantees
+# the pipeline order even when the model would otherwise "forget" to
+# hand off.
+
+agents:
+  root:
+    model: anthropic/claude-sonnet-4-5
+    description: Extracts the key facts and entities from the user's input
+    instruction: |
+      You are the first stage of a two-stage pipeline.
+      Extract the key facts, entities, and figures from the user's input
+      as a concise bullet list. Do not summarize or editorialize - the
+      next agent in the pipeline will do that.
+    force_handoff: summarizer
+
+  summarizer:
+    model: anthropic/claude-sonnet-4-5
+    description: Produces the final summary from the extracted facts
+    instruction: |
+      You are the final stage of a two-stage pipeline.
+      Using the extracted facts from the conversation history, write a
+      short, well-structured summary for the user.

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -32,6 +32,7 @@ type Agent struct {
 	modelOverrides          atomic.Pointer[[]provider.Provider] // Optional model override(s) set at runtime (supports alloy)
 	subAgents               []*Agent
 	handoffs                []*Agent
+	forceHandoff            *Agent
 	parents                 []*Agent
 	addDate                 bool
 	addEnvironmentInfo      bool
@@ -136,6 +137,13 @@ func (a *Agent) SubAgents() []*Agent {
 // Handoffs returns the list of handoff agents
 func (a *Agent) Handoffs() []*Agent {
 	return a.handoffs
+}
+
+// ForceHandoff returns the agent that unconditionally receives the
+// conversation when this agent produces a final response, or nil when
+// no forced handoff is configured.
+func (a *Agent) ForceHandoff() *Agent {
+	return a.forceHandoff
 }
 
 // Parents returns the list of parent agent names

--- a/pkg/agent/opts.go
+++ b/pkg/agent/opts.go
@@ -106,6 +106,15 @@ func WithHandoffs(handoffs ...*Agent) Opt {
 	}
 }
 
+// WithForceHandoff sets the agent that unconditionally receives the
+// conversation when this agent produces a final response. The runtime
+// performs the switch itself, bypassing the LLM's tool-calling.
+func WithForceHandoff(target *Agent) Opt {
+	return func(a *Agent) {
+		a.forceHandoff = target
+	}
+}
+
 func WithAddDate(addDate bool) Opt {
 	return func(a *Agent) {
 		a.addDate = addDate

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -186,6 +186,59 @@ func validateConfig(cfg *latest.Config) error {
 		}
 	}
 
+	if err := validateForceHandoffs(cfg, allNames); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateForceHandoffs checks every agent's force_handoff reference:
+// the target must exist (or be an external reference), an agent cannot
+// force-hand off to itself, and chains of force_handoff edges between
+// local agents must not form a cycle — a cycle would make the run loop
+// bounce between agents until max_iterations trips, which is never what
+// the user intended.
+func validateForceHandoffs(cfg *latest.Config, allNames map[string]bool) error {
+	for _, agent := range cfg.Agents {
+		ref := agent.ForceHandoff
+		if ref == "" {
+			continue
+		}
+		if ref == agent.Name {
+			return fmt.Errorf("agent '%s' cannot force_handoff to itself", agent.Name)
+		}
+		if _, exists := allNames[ref]; !exists && !IsExternalReference(ref) {
+			return fmt.Errorf("agent '%s' references non-existent force_handoff agent '%s'", agent.Name, ref)
+		}
+		if IsExternalReference(ref) {
+			name, _ := ParseExternalAgentRef(ref)
+			if allNames[name] {
+				return fmt.Errorf("agent '%s': external force_handoff '%s' resolves to name '%s' which conflicts with a locally-defined agent", agent.Name, ref, name)
+			}
+		}
+	}
+
+	// Cycle detection: each agent has at most one outgoing force_handoff
+	// edge, so walking the chain from every agent with a visited set is
+	// linear overall. External references are leaves — they can't point
+	// back into this config.
+	edges := make(map[string]string, len(cfg.Agents))
+	for _, agent := range cfg.Agents {
+		if agent.ForceHandoff != "" && !IsExternalReference(agent.ForceHandoff) {
+			edges[agent.Name] = agent.ForceHandoff
+		}
+	}
+	for start := range edges {
+		visited := map[string]bool{start: true}
+		for cur, ok := edges[start], true; ok; cur, ok = edges[cur] {
+			if visited[cur] {
+				return fmt.Errorf("force_handoff cycle detected involving agent '%s'", cur)
+			}
+			visited[cur] = true
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -673,6 +673,82 @@ func TestValidateConfig_ExternalSubAgentReferences(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "force_handoff to another local agent passes",
+			cfg: &latest.Config{
+				Agents: []latest.AgentConfig{
+					{Name: "root", Model: "openai/gpt-4o", ForceHandoff: "helper"},
+					{Name: "helper", Model: "openai/gpt-4o"},
+				},
+			},
+		},
+		{
+			name: "force_handoff chain passes",
+			cfg: &latest.Config{
+				Agents: []latest.AgentConfig{
+					{Name: "a", Model: "openai/gpt-4o", ForceHandoff: "b"},
+					{Name: "b", Model: "openai/gpt-4o", ForceHandoff: "c"},
+					{Name: "c", Model: "openai/gpt-4o"},
+				},
+			},
+		},
+		{
+			name: "force_handoff to non-existent agent fails",
+			cfg: &latest.Config{
+				Agents: []latest.AgentConfig{
+					{Name: "root", Model: "openai/gpt-4o", ForceHandoff: "does_not_exist"},
+				},
+			},
+			wantErr: "non-existent force_handoff agent 'does_not_exist'",
+		},
+		{
+			name: "force_handoff to self fails",
+			cfg: &latest.Config{
+				Agents: []latest.AgentConfig{
+					{Name: "root", Model: "openai/gpt-4o", ForceHandoff: "root"},
+				},
+			},
+			wantErr: "cannot force_handoff to itself",
+		},
+		{
+			name: "force_handoff cycle fails",
+			cfg: &latest.Config{
+				Agents: []latest.AgentConfig{
+					{Name: "a", Model: "openai/gpt-4o", ForceHandoff: "b"},
+					{Name: "b", Model: "openai/gpt-4o", ForceHandoff: "a"},
+				},
+			},
+			wantErr: "force_handoff cycle detected",
+		},
+		{
+			name: "force_handoff three-agent cycle fails",
+			cfg: &latest.Config{
+				Agents: []latest.AgentConfig{
+					{Name: "a", Model: "openai/gpt-4o", ForceHandoff: "b"},
+					{Name: "b", Model: "openai/gpt-4o", ForceHandoff: "c"},
+					{Name: "c", Model: "openai/gpt-4o", ForceHandoff: "a"},
+				},
+			},
+			wantErr: "force_handoff cycle detected",
+		},
+		{
+			name: "external force_handoff reference is allowed",
+			cfg: &latest.Config{
+				Agents: []latest.AgentConfig{
+					{Name: "root", Model: "openai/gpt-4o", ForceHandoff: "agentcatalog/pirate"},
+				},
+			},
+		},
+		{
+			name: "external force_handoff name collides with local agent",
+			cfg: &latest.Config{
+				Agents: []latest.AgentConfig{
+					{Name: "root", Model: "openai/gpt-4o", ForceHandoff: "agentcatalog/pirate"},
+					{Name: "pirate", Model: "openai/gpt-4o"},
+				},
+			},
+			wantErr: "conflicts with a locally-defined agent",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -430,6 +430,14 @@ type AgentConfig struct {
 	Harness        *HarnessConfig  `json:"harness,omitempty"`
 	SubAgents      []string        `json:"sub_agents,omitempty"`
 	Handoffs       []string        `json:"handoffs,omitempty"`
+	// ForceHandoff names an agent that unconditionally receives the
+	// conversation whenever this agent produces a final response,
+	// bypassing the LLM's tool-calling entirely. Unlike Handoffs (which
+	// rely on the model choosing to call the handoff tool), the runtime
+	// intercepts the natural stop and routes deterministically, making
+	// strict pipelines reliable. The full conversation context carries
+	// over to the target agent.
+	ForceHandoff string `json:"force_handoff,omitempty" yaml:"force_handoff,omitempty"`
 
 	AddDate            bool `json:"add_date,omitempty"`
 	AddEnvironmentInfo bool `json:"add_environment_info,omitempty"`
@@ -2063,9 +2071,9 @@ type HooksConfig struct {
 	OnMaxIterations []HookDefinition `json:"on_max_iterations,omitempty" yaml:"on_max_iterations,omitempty"`
 
 	// OnAgentSwitch hooks run whenever the runtime moves the active
-	// agent to a new one — transfer_task, handoff, or the return
-	// after a transferred task completes. Observational; useful for
-	// audit, transcript, and metrics pipelines.
+	// agent to a new one — transfer_task, handoff, force_handoff, or
+	// the return after a transferred task completes. Observational;
+	// useful for audit, transcript, and metrics pipelines.
 	OnAgentSwitch []HookDefinition `json:"on_agent_switch,omitempty" yaml:"on_agent_switch,omitempty"`
 
 	// OnSessionResume hooks run when the user explicitly approves the

--- a/pkg/hooks/types.go
+++ b/pkg/hooks/types.go
@@ -117,11 +117,11 @@ const (
 	EventOnMaxIterations EventType = "on_max_iterations"
 	// EventOnAgentSwitch fires whenever the runtime moves the active
 	// agent to a new one — either delegating a task (transfer_task),
-	// handing off the conversation (handoff), or returning to the
-	// caller after a transferred task completes. Observational; useful
-	// for audit, transcript, and metrics pipelines that track which
-	// agent ran which tools without subscribing to the runtime event
-	// channel.
+	// handing off the conversation (handoff), routing a configured
+	// forced handoff (force_handoff), or returning to the caller after
+	// a transferred task completes. Observational; useful for audit,
+	// transcript, and metrics pipelines that track which agent ran
+	// which tools without subscribing to the runtime event channel.
 	EventOnAgentSwitch EventType = "on_agent_switch"
 	// EventOnSessionResume fires when the user explicitly approves the
 	// runtime to continue past its configured max_iterations limit.
@@ -286,8 +286,8 @@ type Input struct {
 	// OnAgentSwitch specific: the agent the runtime is moving away
 	// from (FromAgent) and the one it's switching to (ToAgent), plus
 	// the cause of the transition ("transfer_task", "handoff",
-	// "transfer_task_return"). Empty FromAgent is valid for the
-	// initial switch into the team's default agent.
+	// "force_handoff", "transfer_task_return"). Empty FromAgent is
+	// valid for the initial switch into the team's default agent.
 	FromAgent       string `json:"from_agent,omitempty"`
 	ToAgent         string `json:"to_agent,omitempty"`
 	AgentSwitchKind string `json:"agent_switch_kind,omitempty"`

--- a/pkg/runtime/agent_delegation.go
+++ b/pkg/runtime/agent_delegation.go
@@ -461,3 +461,27 @@ func (r *LocalRuntime) handleHandoff(ctx context.Context, sess *session.Session,
 		"(if any are available to you), or respond directly to the user if you are the final agent."
 	return tools.ResultSuccess(handoffMessage), nil
 }
+
+// applyForceHandoff routes the conversation to the agent's configured
+// force_handoff target after a natural stop, bypassing the LLM's
+// tool-calling entirely. The conversation context carries over because
+// the same session keeps running; an implicit user message tells the
+// target agent what happened so the next model call doesn't start on a
+// dangling assistant message. The caller (runTurn) is responsible for
+// continuing the run loop, where the next iteration re-resolves the
+// current agent and emits the AgentInfo event.
+func (r *LocalRuntime) applyForceHandoff(ctx context.Context, sess *session.Session, from, to *agent.Agent) {
+	slog.InfoContext(ctx, "Forced handoff", "from_agent", from.Name(), "to_agent", to.Name(), "session_id", sess.ID)
+
+	r.executeOnAgentSwitchHooks(ctx, from, sess.ID, from.Name(), to.Name(), agentSwitchKindForceHandoff)
+	r.setCurrentAgent(to.Name())
+
+	sess.AddMessage(session.ImplicitUserMessage(
+		"The agent " + from.Name() + " finished its response and the conversation was automatically " +
+			"handed off to you. Your available handoff agents and tools are specified in the system " +
+			"messages that follow. Only use those capabilities - do not attempt to use tools or hand " +
+			"off to agents that you see in the conversation history from previous agents, as those were " +
+			"available to different agents with different capabilities. Look at the conversation history " +
+			"for context, continue the work from where the previous agent stopped, and complete your " +
+			"part of the task."))
+}

--- a/pkg/runtime/force_handoff_test.go
+++ b/pkg/runtime/force_handoff_test.go
@@ -1,0 +1,145 @@
+package runtime
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/team"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+// handoffRecordingProvider wraps mockProvider to count model invocations and
+// capture the messages of the most recent call, so tests can assert
+// whether and with what context a forced-handoff target was invoked.
+type handoffRecordingProvider struct {
+	mockProvider
+
+	mu       sync.Mutex
+	calls    int
+	lastMsgs []chat.Message
+}
+
+func (p *handoffRecordingProvider) CreateChatCompletionStream(ctx context.Context, msgs []chat.Message, t []tools.Tool) (chat.MessageStream, error) {
+	p.mu.Lock()
+	p.calls++
+	p.lastMsgs = append([]chat.Message(nil), msgs...)
+	p.mu.Unlock()
+	return p.mockProvider.CreateChatCompletionStream(ctx, msgs, t)
+}
+
+func (p *handoffRecordingProvider) handoffCallCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.calls
+}
+
+func (p *handoffRecordingProvider) lastMessages() []chat.Message {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]chat.Message(nil), p.lastMsgs...)
+}
+
+// forceHandoffTeam builds a two-agent team where root force-hands off to
+// summarizer, plus a runtime wired with the usual test doubles.
+func forceHandoffTeam(t *testing.T, rootStream, summarizerStream *mockStream) (*LocalRuntime, *handoffRecordingProvider) {
+	t.Helper()
+
+	rootProv := &mockProvider{id: "test/mock-model", stream: rootStream}
+	sumProv := &handoffRecordingProvider{mockProvider: mockProvider{id: "test/mock-model", stream: summarizerStream}}
+
+	summarizer := agent.New("summarizer", "You summarize", agent.WithModel(sumProv))
+	root := agent.New("root", "You extract", agent.WithModel(rootProv), agent.WithForceHandoff(summarizer))
+	tm := team.New(team.WithAgents(root, summarizer))
+
+	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+	return rt, sumProv
+}
+
+// TestForceHandoff_RoutesToTargetOnNaturalStop pins the core contract of
+// force_handoff: when the first agent produces a final response, the
+// runtime deterministically routes the conversation to the configured
+// target — no LLM tool call involved — and the target runs in the same
+// session with the carried-over context.
+func TestForceHandoff_RoutesToTargetOnNaturalStop(t *testing.T) {
+	t.Parallel()
+
+	rt, sumProv := forceHandoffTeam(t,
+		newStreamBuilder().AddContent("extracted facts").AddStopWithUsage(10, 5).Build(),
+		newStreamBuilder().AddContent("final summary").AddStopWithUsage(10, 5).Build(),
+	)
+
+	sess := session.New(session.WithUserMessage("Summarize this article"))
+	sess.Title = "Unit Test"
+
+	var events []Event
+	for ev := range rt.RunStream(t.Context(), sess) {
+		events = append(events, ev)
+	}
+
+	for _, ev := range events {
+		errEv, isErr := ev.(*ErrorEvent)
+		require.False(t, isErr, "unexpected error event: %+v", errEv)
+	}
+
+	assert.Equal(t, "summarizer", rt.CurrentAgentName(), "current agent must be the force_handoff target after the run")
+	assert.Equal(t, 1, sumProv.handoffCallCount(), "target agent's model must be invoked exactly once")
+	assert.Equal(t, "final summary", sess.GetLastAssistantMessageContent())
+
+	// The runtime injects an implicit user message so the target's model
+	// call doesn't start on a dangling assistant message.
+	var implicitHandoffMsg bool
+	for _, m := range sess.GetAllMessages() {
+		if m.Implicit && m.Message.Role == chat.MessageRoleUser && strings.Contains(m.Message.Content, "automatically handed off") {
+			implicitHandoffMsg = true
+		}
+	}
+	assert.True(t, implicitHandoffMsg, "implicit handoff user message must be recorded in the session")
+
+	// The target agent must see the previous agent's output (carried-over
+	// context) and the handoff notice in its prompt.
+	prompt := sumProv.lastMessages()
+	var sawExtracted, sawNotice bool
+	for _, m := range prompt {
+		if m.Role == chat.MessageRoleAssistant && strings.Contains(m.Content, "extracted facts") {
+			sawExtracted = true
+		}
+		if m.Role == chat.MessageRoleUser && strings.Contains(m.Content, "automatically handed off") {
+			sawNotice = true
+		}
+	}
+	assert.True(t, sawExtracted, "target agent must see the previous agent's final response")
+	assert.True(t, sawNotice, "target agent must see the handoff notice")
+}
+
+// TestForceHandoff_SkippedForPinnedSession documents the guard for pinned
+// sessions (background agents): resolveSessionAgent always returns the
+// pinned agent, so honouring force_handoff there would loop forever. The
+// runtime must finish the run on the pinned agent without ever invoking
+// the target.
+func TestForceHandoff_SkippedForPinnedSession(t *testing.T) {
+	t.Parallel()
+
+	rt, sumProv := forceHandoffTeam(t,
+		newStreamBuilder().AddContent("done").AddStopWithUsage(10, 5).Build(),
+		newStreamBuilder().AddContent("should never run").AddStopWithUsage(10, 5).Build(),
+	)
+
+	sess := session.New(session.WithUserMessage("hi"), session.WithAgentName("root"))
+	sess.Title = "Unit Test"
+
+	for range rt.RunStream(t.Context(), sess) {
+	}
+
+	assert.Equal(t, 0, sumProv.handoffCallCount(), "force_handoff target must not run for pinned sessions")
+	assert.Equal(t, "root", rt.CurrentAgentName())
+	assert.Equal(t, "done", sess.GetLastAssistantMessageContent())
+}

--- a/pkg/runtime/hooks.go
+++ b/pkg/runtime/hooks.go
@@ -185,6 +185,10 @@ const (
 	// turnEndReasonLoopDetected — the consecutive-tool-call loop
 	// detector terminated the turn.
 	turnEndReasonLoopDetected = "loop_detected"
+	// turnEndReasonForceHandoff — the turn finished cleanly and the
+	// runtime routed the conversation to the agent's configured
+	// force_handoff target, prompting a new iteration.
+	turnEndReasonForceHandoff = "force_handoff"
 )
 
 // executeTurnEndHooks fires turn_end once per turn — symmetric to
@@ -273,6 +277,7 @@ const (
 	agentSwitchKindTransferTask       = "transfer_task"
 	agentSwitchKindTransferTaskReturn = "transfer_task_return"
 	agentSwitchKindHandoff            = "handoff"
+	agentSwitchKindForceHandoff       = "force_handoff"
 )
 
 // executeOnAgentSwitchHooks fires on_agent_switch when the runtime

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -705,6 +705,19 @@ func (r *LocalRuntime) runTurn(
 		slog.DebugContext(ctx, "Conversation stopped", "agent", a.Name())
 		r.executeStopHooks(ctx, sess, a, res.Content, events)
 
+		// --- FORCED HANDOFF: deterministic routing on natural stop ---
+		// When the agent's config names a force_handoff target, the
+		// runtime intercepts the finish state and routes the conversation
+		// to that agent without involving the LLM. Skipped for pinned
+		// sessions (background agents): resolveSessionAgent would keep
+		// returning the pinned agent, turning the forced switch into an
+		// infinite stop/handoff loop.
+		if next := a.ForceHandoff(); next != nil && sess.AgentName == "" {
+			r.applyForceHandoff(ctx, sess, a, next)
+			endReason = turnEndReasonForceHandoff
+			return turnContinue
+		}
+
 		// Re-check steer queue: closes the race between the mid-loop drain and this stop.
 		if sr := r.drainAndEmitSteered(ctx, sess, a, events); sr.drained {
 			if sr.stop {

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -289,6 +289,17 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 		if len(handoffs) > 0 {
 			agent.WithHandoffs(handoffs...)(a)
 		}
+
+		if agentConfig.ForceHandoff != "" {
+			targets, err := resolveAgentRefs(ctx, []string{agentConfig.ForceHandoff}, agentsByName, externalAgents, &agents, runConfig, &loadOpts)
+			if err != nil {
+				return nil, fmt.Errorf("agent '%s': resolving force_handoff: %w", agentConfig.Name, err)
+			}
+			if len(targets) == 0 {
+				return nil, fmt.Errorf("agent '%s': force_handoff '%s' did not resolve to an agent", agentConfig.Name, agentConfig.ForceHandoff)
+			}
+			agent.WithForceHandoff(targets[0])(a)
+		}
 	}
 
 	// Create permissions checker from config


### PR DESCRIPTION
## What

Adds a `force_handoff` config parameter on agents. When set, the runtime intercepts the agent's natural stop (final text response) and **deterministically routes the conversation to the target agent**, bypassing the LLM's tool-calling entirely. The full conversation context carries over (same session, same handoff semantics as the `handoff` tool).

Closes #3078

## Why

With `handoffs`, the model *chooses* whether to call the `handoff` tool — and can simply forget to, silently breaking pipelines that depend on a strict order (e.g. extractor → summarizer). `force_handoff` makes such pipelines reliable by moving the routing decision from the model to the runtime.

## How

- **Config (latest schema only)**: new `force_handoff: <agent>` field on `AgentConfig`; frozen `vN` packages untouched. `agent-schema.json` updated (`TestSchemaMatchesGoTypes` passes).
- **Validation** (config load time):
  - target must exist locally or be an external reference (same rules as `handoffs`, incl. external-name collision check)
  - an agent cannot `force_handoff` to itself
  - `force_handoff` chains must not form a cycle (each agent has at most one outgoing edge, so detection is a linear walk)
- **Runtime**: in `runTurn`, on `res.Stopped`, if the agent has a `force_handoff` target the runtime fires `on_agent_switch` (new kind `force_handoff`), switches the current agent, injects an implicit user message (mirroring the `handoff` tool's notice, so the next model call doesn't start on a dangling assistant message) and continues the loop. `turn_end` reports the new reason `force_handoff`.
  - **Guard**: skipped for pinned sessions (background agents) — `resolveSessionAgent` would keep returning the pinned agent, turning the forced switch into an infinite stop/handoff loop.
- **Teamloader**: resolves the reference via the existing `resolveAgentRefs` (supports local + external agents).
- **Docs**: agents config reference, new *Forced Handoffs* section in multi-agent concepts, hooks reference (`agent_switch_kind`).
- **Example**: `examples/force_handoff.yaml` (two-stage extractor → summarizer pipeline).

## Tests

- `pkg/config`: validation table tests (missing target, self-reference, 2- and 3-agent cycles, valid chains, external refs, external-name collision)
- `pkg/runtime/force_handoff_test.go`:
  - `TestForceHandoff_RoutesToTargetOnNaturalStop` — target agent runs exactly once in the same session, sees the previous agent's output and the handoff notice, current agent ends up on the target
  - `TestForceHandoff_SkippedForPinnedSession` — pinned sessions never trigger the forced switch
- `examples/force_handoff.yaml` covered by `TestLoadExamples`

## Validation

- [x] `task build`
- [x] `task test` (only pre-existing, environment-dependent failures: `dmr.yaml` / `unload_on_switch.yaml` pull DMR models; they fail identically on a clean tree)
- [x] `task lint` — 0 issues