### PR TITLE
feat(effort): cycle thinking levels from per-model capabilities

### DIFF
--- a/pkg/effort/effort.go
+++ b/pkg/effort/effort.go
@@ -3,7 +3,10 @@
 // this package instead of hard-coding effort strings.
 package effort
 
-import "strings"
+import (
+	"slices"
+	"strings"
+)
 
 // Level represents a thinking effort level.
 type Level string
@@ -75,63 +78,89 @@ func ValidNames() string {
 }
 
 // ---------------------------------------------------------------------------
-// Thinking-level cycling (TUI shift+tab)
+// Capability-driven level selection (TUI shift+tab cycling)
 // ---------------------------------------------------------------------------
 
-// thinkingCycles maps a normalised provider bucket to the ordered list of
-// thinking-effort levels the TUI cycles through with shift+tab. Each cycle
-// starts with None (thinking off) and otherwise spans the full range of
-// effort levels the provider's API accepts (see the per-provider mapping
-// helpers below). Not every model supports the highest tiers (xhigh, max);
-// cycling onto an unsupported tier is recoverable by cycling again.
-var thinkingCycles = map[string][]Level{
-	"openai":    {None, Minimal, Low, Medium, High, XHigh},
-	"anthropic": {None, Low, Medium, High, XHigh, Max},
-	"google":    {None, Minimal, Low, Medium, High},
-}
+// orderedLevels is the canonical low-to-high ordering of selectable
+// thinking-effort levels. None (thinking off) always sorts first.
+var orderedLevels = []Level{None, Minimal, Low, Medium, High, XHigh, Max}
 
-// defaultThinkingCycle is used for providers without a dedicated cycle.
-var defaultThinkingCycle = []Level{None, Low, Medium, High}
+// explicitOnlyLevels are the top-tier levels that only a few models accept;
+// they are offered only when a [LevelMap] explicitly declares support, so
+// models without capability data never cycle onto a tier their API rejects.
+var explicitOnlyLevels = map[Level]bool{XHigh: true, Max: true}
 
-// ThinkingCycle returns the ordered list of selectable thinking-effort
-// levels for the given provider type. The provider type is matched
-// case-insensitively and tolerant of aliases (e.g. "amazon-bedrock" maps
-// onto the underlying Anthropic family).
-func ThinkingCycle(providerType string) []Level {
-	if c, ok := thinkingCycles[providerBucket(providerType)]; ok {
-		return c
+// LevelMap describes per-model thinking-level support. A level mapped to
+// true is supported, a level mapped to false is explicitly unsupported, and
+// an absent level is unspecified: supported by default, except for the
+// explicit-only top tiers.
+type LevelMap map[Level]bool
+
+// SupportedLevels returns the ordered subset of thinking-effort levels a
+// model supports, derived from its reasoning capability and level map.
+// Models that cannot reason only support None. A nil map is valid and
+// yields every level except the explicit-only top tiers.
+func SupportedLevels(reasoning bool, m LevelMap) []Level {
+	if !reasoning {
+		return []Level{None}
 	}
-	return defaultThinkingCycle
+	supported := make([]Level, 0, len(orderedLevels))
+	for _, l := range orderedLevels {
+		v, present := m[l]
+		if present && !v {
+			continue
+		}
+		if !present && explicitOnlyLevels[l] {
+			continue
+		}
+		supported = append(supported, l)
+	}
+	return supported
 }
 
-// NextThinkingLevel returns the level following current in the provider's
-// thinking cycle, wrapping back to the first level. When current is not in
-// the cycle the first level is returned.
-func NextThinkingLevel(providerType string, current Level) Level {
-	cycle := ThinkingCycle(providerType)
-	for i, l := range cycle {
-		if l == current {
-			return cycle[(i+1)%len(cycle)]
+// Clamp maps requested onto the nearest level in supported. When requested
+// is already supported it is returned unchanged. Otherwise the canonical
+// ordering is scanned upward (toward higher effort) first and then downward,
+// so a too-precise request degrades to the closest tier the model accepts.
+// Falls back to the first supported level, or None when supported is empty.
+func Clamp(supported []Level, requested Level) Level {
+	if slices.Contains(supported, requested) {
+		return requested
+	}
+	first := None
+	if len(supported) > 0 {
+		first = supported[0]
+	}
+	idx := slices.Index(orderedLevels, requested)
+	if idx == -1 {
+		return first
+	}
+	for i := idx + 1; i < len(orderedLevels); i++ {
+		if slices.Contains(supported, orderedLevels[i]) {
+			return orderedLevels[i]
 		}
 	}
-	return cycle[0]
+	for i := idx - 1; i >= 0; i-- {
+		if slices.Contains(supported, orderedLevels[i]) {
+			return orderedLevels[i]
+		}
+	}
+	return first
 }
 
-// providerBucket normalises a provider type to one of the buckets used by
-// thinkingCycles. Returns the lowercased provider type unchanged when no
-// alias matches (callers fall back to the default cycle).
-func providerBucket(providerType string) string {
-	p := strings.ToLower(strings.TrimSpace(providerType))
-	switch {
-	case strings.Contains(p, "anthropic"), strings.Contains(p, "claude"), strings.Contains(p, "bedrock"):
-		return "anthropic"
-	case strings.Contains(p, "google"), strings.Contains(p, "gemini"), strings.Contains(p, "vertex"):
-		return "google"
-	case strings.Contains(p, "openai"), strings.Contains(p, "azure"):
-		return "openai"
-	default:
-		return p
+// NextSupportedLevel returns the level following current within supported,
+// wrapping back to the first level. When current is not in supported (or
+// supported is empty) the first supported level (or None) is returned.
+func NextSupportedLevel(supported []Level, current Level) Level {
+	if len(supported) == 0 {
+		return None
 	}
+	for i, l := range supported {
+		if l == current {
+			return supported[(i+1)%len(supported)]
+		}
+	}
+	return supported[0]
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/effort/effort_test.go
+++ b/pkg/effort/effort_test.go
@@ -185,80 +185,130 @@ func TestIsValidAdaptive(t *testing.T) {
 	}
 }
 
-func TestThinkingCycle(t *testing.T) {
+func TestSupportedLevels(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		provider string
-		want     []Level
+		name      string
+		reasoning bool
+		levelMap  LevelMap
+		want      []Level
 	}{
-		{"openai", []Level{None, Minimal, Low, Medium, High, XHigh}},
-		{"openai_responses", []Level{None, Minimal, Low, Medium, High, XHigh}},
-		{"azure", []Level{None, Minimal, Low, Medium, High, XHigh}},
-		{"anthropic", []Level{None, Low, Medium, High, XHigh, Max}},
-		{"amazon-bedrock", []Level{None, Low, Medium, High, XHigh, Max}},
-		{"google", []Level{None, Minimal, Low, Medium, High}},
-		{"gemini", []Level{None, Minimal, Low, Medium, High}},
-		{"vertexai", []Level{None, Minimal, Low, Medium, High}},
-		{"dmr", []Level{None, Low, Medium, High}},
-		{"unknown", []Level{None, Low, Medium, High}},
-		{"  OpenAI  ", []Level{None, Minimal, Low, Medium, High, XHigh}},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.provider, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tt.want, ThinkingCycle(tt.provider))
-		})
-	}
-}
-
-func TestNextThinkingLevel(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		provider string
-		current  Level
-		want     Level
-	}{
-		{"openai none to minimal", "openai", None, Minimal},
-		{"openai high to xhigh", "openai", High, XHigh},
-		{"openai xhigh wraps to none", "openai", XHigh, None},
-		{"openai unknown level resets to first", "openai", Max, None},
-		{"anthropic none to low", "anthropic", None, Low},
-		{"anthropic high to xhigh", "anthropic", High, XHigh},
-		{"anthropic xhigh to max", "anthropic", XHigh, Max},
-		{"anthropic max wraps to none", "anthropic", Max, None},
-		{"anthropic minimal not in cycle resets to none", "anthropic", Minimal, None},
-		{"default medium to high", "dmr", Medium, High},
-		{"default high wraps to none", "dmr", High, None},
+		{
+			name:      "non-reasoning model only supports none",
+			reasoning: false,
+			levelMap:  LevelMap{XHigh: true},
+			want:      []Level{None},
+		},
+		{
+			name:      "nil map yields defaults without top tiers",
+			reasoning: true,
+			levelMap:  nil,
+			want:      []Level{None, Minimal, Low, Medium, High},
+		},
+		{
+			name:      "false entry excludes level",
+			reasoning: true,
+			levelMap:  LevelMap{Minimal: false},
+			want:      []Level{None, Low, Medium, High},
+		},
+		{
+			name:      "xhigh requires explicit support",
+			reasoning: true,
+			levelMap:  LevelMap{XHigh: true},
+			want:      []Level{None, Minimal, Low, Medium, High, XHigh},
+		},
+		{
+			name:      "max requires explicit support",
+			reasoning: true,
+			levelMap:  LevelMap{Max: true},
+			want:      []Level{None, Minimal, Low, Medium, High, Max},
+		},
+		{
+			name:      "explicit false top tier stays excluded",
+			reasoning: true,
+			levelMap:  LevelMap{XHigh: false, Max: false},
+			want:      []Level{None, Minimal, Low, Medium, High},
+		},
+		{
+			name:      "anthropic-style map without minimal",
+			reasoning: true,
+			levelMap:  LevelMap{Minimal: false, XHigh: true, Max: true},
+			want:      []Level{None, Low, Medium, High, XHigh, Max},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.want, NextThinkingLevel(tt.provider, tt.current))
+			assert.Equal(t, tt.want, SupportedLevels(tt.reasoning, tt.levelMap))
 		})
 	}
 }
 
-// TestNextThinkingLevel_FullCycle walks every provider cycle end-to-end and
-// asserts that repeatedly advancing returns to the starting level.
-func TestNextThinkingLevel_FullCycle(t *testing.T) {
+func TestClamp(t *testing.T) {
 	t.Parallel()
 
-	for _, provider := range []string{"openai", "anthropic", "google", "dmr"} {
-		t.Run(provider, func(t *testing.T) {
+	tests := []struct {
+		name      string
+		supported []Level
+		requested Level
+		want      Level
+	}{
+		{"supported level returned unchanged", []Level{None, Low, Medium, High}, Medium, Medium},
+		{"clamps upward first", []Level{None, Low, High}, Medium, High},
+		{"clamps downward when nothing above", []Level{None, Low, Medium, High}, Max, High},
+		{"minimal clamps up to low", []Level{None, Low, Medium}, Minimal, Low},
+		{"unknown level falls back to first", []Level{None, Low}, Level("bogus"), None},
+		{"empty supported falls back to none", nil, High, None},
+		{"none clamps up when unsupported", []Level{Low, Medium}, None, Low},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			cycle := ThinkingCycle(provider)
-			cur := cycle[0]
-			for range cycle {
-				cur = NextThinkingLevel(provider, cur)
-			}
-			assert.Equal(t, cycle[0], cur, "advancing len(cycle) times returns to start")
+			assert.Equal(t, tt.want, Clamp(tt.supported, tt.requested))
 		})
 	}
+}
+
+func TestNextSupportedLevel(t *testing.T) {
+	t.Parallel()
+
+	supported := []Level{None, Low, Medium, High}
+
+	tests := []struct {
+		name    string
+		levels  []Level
+		current Level
+		want    Level
+	}{
+		{"advances to next", supported, Low, Medium},
+		{"wraps to first", supported, High, None},
+		{"unknown current resets to first", supported, XHigh, None},
+		{"empty supported returns none", nil, High, None},
+		{"single level cycles onto itself", []Level{None}, None, None},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, NextSupportedLevel(tt.levels, tt.current))
+		})
+	}
+}
+
+// TestNextSupportedLevel_FullCycle advances through a capability-derived
+// level list end-to-end and asserts it returns to the starting level.
+func TestNextSupportedLevel_FullCycle(t *testing.T) {
+	t.Parallel()
+
+	supported := SupportedLevels(true, LevelMap{Minimal: false, XHigh: true, Max: true})
+	cur := supported[0]
+	for range supported {
+		cur = NextSupportedLevel(supported, cur)
+	}
+	assert.Equal(t, supported[0], cur, "advancing len(supported) times returns to start")
 }
 
 func TestString(t *testing.T) {

--- a/pkg/modelinfo/thinking_levels.go
+++ b/pkg/modelinfo/thinking_levels.go
@@ -1,0 +1,125 @@
+package modelinfo
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/docker/docker-agent/pkg/effort"
+)
+
+// SupportedThinkingLevels returns the ordered thinking-effort levels a
+// reasoning-capable model accepts for user-selectable cycling. It combines
+// the provider API's effort vocabulary with per-model gating of the optional
+// top tiers: not every model accepts xhigh or max, and offering them blindly
+// makes the API reject the request. Callers are expected to have already
+// established that the model reasons at all.
+func SupportedThinkingLevels(provider, modelID string) []effort.Level {
+	return effort.SupportedLevels(true, thinkingLevelMap(provider, modelID))
+}
+
+// thinkingLevelMap builds the per-model capability map consumed by
+// [effort.SupportedLevels].
+func thinkingLevelMap(provider, modelID string) effort.LevelMap {
+	switch providerFamily(provider) {
+	case "anthropic":
+		// The Anthropic effort scale starts at low ([effort.ForAnthropic]
+		// maps minimal onto low), so offering minimal would duplicate low.
+		m := effort.LevelMap{effort.Minimal: false}
+		if top := anthropicTopEffort(modelID); top != "" {
+			m[top] = true
+		}
+		return m
+	case "openai":
+		if openAISupportsXHighEffort(modelID) {
+			return effort.LevelMap{effort.XHigh: true}
+		}
+		return nil
+	case "google":
+		return nil
+	default:
+		// Unknown providers (e.g. dmr) get the conservative low/medium/high
+		// scale; minimal is far from universally accepted.
+		return effort.LevelMap{effort.Minimal: false}
+	}
+}
+
+// providerFamily normalises a provider type onto the model family whose API
+// defines the thinking-level vocabulary, tolerating aliases such as
+// "amazon-bedrock" (hosting Anthropic models) or "vertexai" (Gemini).
+func providerFamily(providerType string) string {
+	p := normalize(providerType)
+	switch {
+	case strings.Contains(p, "anthropic"), strings.Contains(p, "claude"), strings.Contains(p, "bedrock"):
+		return "anthropic"
+	case strings.Contains(p, "google"), strings.Contains(p, "gemini"), strings.Contains(p, "vertex"):
+		return "google"
+	case strings.Contains(p, "openai"), strings.Contains(p, "azure"):
+		return "openai"
+	default:
+		return p
+	}
+}
+
+// anthropicTopEffort returns the highest selectable effort above high for a
+// Claude model: Max for Opus 4.6 (the only model accepting effort "max"),
+// XHigh for Opus 4.7+ and the Fable family, and "" for every other Claude
+// model, which tops out at high.
+//
+// Works on bare Anthropic IDs ("claude-opus-4-7", "claude-opus-4.7") as well
+// as Bedrock-style IDs with regional prefixes ("us.anthropic.claude-opus-4-7").
+func anthropicTopEffort(modelID string) effort.Level {
+	m := normalize(modelID)
+	if strings.Contains(m, "fable") {
+		return effort.XHigh
+	}
+	_, rest, found := strings.Cut(m, "opus-4")
+	if !found {
+		return ""
+	}
+	if rest == "" || (rest[0] != '-' && rest[0] != '.') {
+		return ""
+	}
+	minor, width := leadingInt(rest[1:])
+	// Long digit runs are date stamps (claude-opus-4-20250514 is Opus 4.0),
+	// not minor versions.
+	if width == 0 || width > 2 {
+		return ""
+	}
+	switch {
+	case minor >= 7:
+		return effort.XHigh
+	case minor == 6:
+		return effort.Max
+	default:
+		return ""
+	}
+}
+
+// openAISupportsXHighEffort reports whether an OpenAI model accepts
+// reasoning effort "xhigh". Only gpt-5.2 and later minor versions do; the
+// o-series and earlier gpt-5 releases top out at high.
+func openAISupportsXHighEffort(modelID string) bool {
+	m := normalize(modelID)
+	const prefix = "gpt-5."
+	if !strings.HasPrefix(m, prefix) {
+		return false
+	}
+	minor, width := leadingInt(m[len(prefix):])
+	return width > 0 && minor >= 2
+}
+
+// leadingInt parses the run of decimal digits at the start of s, returning
+// its value and width. A zero width means s does not start with a digit.
+func leadingInt(s string) (value, width int) {
+	for width < len(s) && s[width] >= '0' && s[width] <= '9' {
+		width++
+	}
+	if width == 0 {
+		return 0, 0
+	}
+	n, err := strconv.Atoi(s[:width])
+	if err != nil {
+		return 0, 0
+	}
+	return n, width
+}

--- a/pkg/modelinfo/thinking_levels_test.go
+++ b/pkg/modelinfo/thinking_levels_test.go
@@ -1,0 +1,171 @@
+package modelinfo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/docker/docker-agent/pkg/effort"
+)
+
+func TestSupportedThinkingLevels(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		provider string
+		modelID  string
+		want     []effort.Level
+	}{
+		{
+			name:     "claude sonnet tops out at high",
+			provider: "anthropic",
+			modelID:  "claude-sonnet-4-5",
+			want:     []effort.Level{effort.None, effort.Low, effort.Medium, effort.High},
+		},
+		{
+			name:     "claude haiku tops out at high",
+			provider: "anthropic",
+			modelID:  "claude-haiku-4-5-20251001",
+			want:     []effort.Level{effort.None, effort.Low, effort.Medium, effort.High},
+		},
+		{
+			name:     "claude opus 4.5 tops out at high",
+			provider: "anthropic",
+			modelID:  "claude-opus-4-5",
+			want:     []effort.Level{effort.None, effort.Low, effort.Medium, effort.High},
+		},
+		{
+			name:     "date-stamped opus 4.0 tops out at high",
+			provider: "anthropic",
+			modelID:  "claude-opus-4-20250514",
+			want:     []effort.Level{effort.None, effort.Low, effort.Medium, effort.High},
+		},
+		{
+			name:     "claude opus 4.6 gets max but not xhigh",
+			provider: "anthropic",
+			modelID:  "claude-opus-4-6",
+			want:     []effort.Level{effort.None, effort.Low, effort.Medium, effort.High, effort.Max},
+		},
+		{
+			name:     "claude opus 4.7 gets xhigh but not max",
+			provider: "anthropic",
+			modelID:  "claude-opus-4-7",
+			want:     []effort.Level{effort.None, effort.Low, effort.Medium, effort.High, effort.XHigh},
+		},
+		{
+			name:     "claude opus 4.8 gets xhigh",
+			provider: "anthropic",
+			modelID:  "claude-opus-4-8",
+			want:     []effort.Level{effort.None, effort.Low, effort.Medium, effort.High, effort.XHigh},
+		},
+		{
+			name:     "dotted opus version",
+			provider: "anthropic",
+			modelID:  "claude-opus-4.6",
+			want:     []effort.Level{effort.None, effort.Low, effort.Medium, effort.High, effort.Max},
+		},
+		{
+			name:     "bedrock regional opus 4.7",
+			provider: "amazon-bedrock",
+			modelID:  "us.anthropic.claude-opus-4-7",
+			want:     []effort.Level{effort.None, effort.Low, effort.Medium, effort.High, effort.XHigh},
+		},
+		{
+			name:     "bedrock sonnet tops out at high",
+			provider: "amazon-bedrock",
+			modelID:  "anthropic.claude-sonnet-4-5-20250929-v1:0",
+			want:     []effort.Level{effort.None, effort.Low, effort.Medium, effort.High},
+		},
+		{
+			name:     "claude fable gets xhigh",
+			provider: "anthropic",
+			modelID:  "claude-fable-5",
+			want:     []effort.Level{effort.None, effort.Low, effort.Medium, effort.High, effort.XHigh},
+		},
+		{
+			name:     "gpt-5 tops out at high",
+			provider: "openai",
+			modelID:  "gpt-5",
+			want:     []effort.Level{effort.None, effort.Minimal, effort.Low, effort.Medium, effort.High},
+		},
+		{
+			name:     "gpt-5.1 tops out at high",
+			provider: "openai",
+			modelID:  "gpt-5.1-codex",
+			want:     []effort.Level{effort.None, effort.Minimal, effort.Low, effort.Medium, effort.High},
+		},
+		{
+			name:     "gpt-5.2 gets xhigh",
+			provider: "openai",
+			modelID:  "gpt-5.2",
+			want:     []effort.Level{effort.None, effort.Minimal, effort.Low, effort.Medium, effort.High, effort.XHigh},
+		},
+		{
+			name:     "gpt-5.4 variant gets xhigh",
+			provider: "openai_responses",
+			modelID:  "gpt-5.4-mini",
+			want:     []effort.Level{effort.None, effort.Minimal, effort.Low, effort.Medium, effort.High, effort.XHigh},
+		},
+		{
+			name:     "o-series tops out at high",
+			provider: "openai",
+			modelID:  "o3",
+			want:     []effort.Level{effort.None, effort.Minimal, effort.Low, effort.Medium, effort.High},
+		},
+		{
+			name:     "gemini 3 pro has no xhigh",
+			provider: "google",
+			modelID:  "gemini-3-pro-preview",
+			want:     []effort.Level{effort.None, effort.Minimal, effort.Low, effort.Medium, effort.High},
+		},
+		{
+			name:     "vertex alias maps to gemini scale",
+			provider: "vertexai",
+			modelID:  "gemini-3-flash-preview",
+			want:     []effort.Level{effort.None, effort.Minimal, effort.Low, effort.Medium, effort.High},
+		},
+		{
+			name:     "unknown provider gets conservative scale",
+			provider: "dmr",
+			modelID:  "deepseek-r1",
+			want:     []effort.Level{effort.None, effort.Low, effort.Medium, effort.High},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, SupportedThinkingLevels(tt.provider, tt.modelID))
+		})
+	}
+}
+
+func TestAnthropicTopEffort(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		modelID string
+		want    effort.Level
+	}{
+		{"claude-sonnet-4-5", ""},
+		{"claude-opus-4-1-20250805", ""},
+		{"claude-opus-4-20250514", ""},
+		{"claude-opus-4-6", effort.Max},
+		{"claude-opus-4-6-v1", effort.Max},
+		{"claude-opus-4.6", effort.Max},
+		{"claude-opus-4-7", effort.XHigh},
+		{"claude-opus-4-8", effort.XHigh},
+		{"global.anthropic.claude-opus-4-6-v1", effort.Max},
+		{"us.anthropic.claude-opus-4-7", effort.XHigh},
+		{"claude-fable-5", effort.XHigh},
+		{"CLAUDE-OPUS-4-7", effort.XHigh},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.modelID, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, anthropicTopEffort(tt.modelID))
+		})
+	}
+}

--- a/pkg/runtime/model_switcher.go
+++ b/pkg/runtime/model_switcher.go
@@ -180,7 +180,8 @@ func (r *LocalRuntime) SupportsModelSwitching() bool {
 
 // CycleAgentThinkingLevel implements [Runtime.CycleAgentThinkingLevel] for
 // LocalRuntime. It reads the agent's current effective model, advances the
-// thinking-effort level by one step in that provider's cycle, re-creates the
+// thinking-effort level by one step through the levels that specific model
+// supports (see [modelinfo.SupportedThinkingLevels]), re-creates the
 // provider(s) with the new level, and installs them as a runtime override.
 func (r *LocalRuntime) CycleAgentThinkingLevel(ctx context.Context, agentName string) (effort.Level, error) {
 	if r.modelSwitcherCfg == nil {
@@ -202,7 +203,11 @@ func (r *LocalRuntime) CycleAgentThinkingLevel(ctx context.Context, agentName st
 		return "", fmt.Errorf("model %q does not support thinking levels: %w", baseCfg.DisplayOrModel(), ErrUnsupported)
 	}
 
-	next := effort.NextThinkingLevel(baseCfg.Provider, currentThinkingLevel(&baseCfg))
+	supported := modelinfo.SupportedThinkingLevels(baseCfg.Provider, baseCfg.Model)
+	// Clamp first so a configured level the model does not support re-enters
+	// the cycle at the nearest supported tier instead of resetting it.
+	current := effort.Clamp(supported, currentThinkingLevel(&baseCfg))
+	next := effort.NextSupportedLevel(supported, current)
 
 	// Re-create each effective provider (alloy models can have several) with
 	// the new thinking level so the override preserves the existing pool.

--- a/pkg/runtime/model_switcher_test.go
+++ b/pkg/runtime/model_switcher_test.go
@@ -200,6 +200,58 @@ func TestCycleAgentThinkingLevel_AdvancesAndOverrides(t *testing.T) {
 	assert.Equal(t, effort.Low, level)
 }
 
+// TestCycleAgentThinkingLevel_PerModelTopTier verifies that cycling only
+// offers the top effort tiers to the Claude models whose API accepts them.
+func TestCycleAgentThinkingLevel_PerModelTopTier(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		modelID   string
+		wantCycle []effort.Level
+	}{
+		{
+			name:      "sonnet never reaches xhigh or max",
+			modelID:   "claude-sonnet-4-5",
+			wantCycle: []effort.Level{effort.Low, effort.Medium, effort.High, effort.None},
+		},
+		{
+			name:      "opus 4.6 tops out at max",
+			modelID:   "claude-opus-4-6",
+			wantCycle: []effort.Level{effort.Low, effort.Medium, effort.High, effort.Max, effort.None},
+		},
+		{
+			name:      "opus 4.7 tops out at xhigh",
+			modelID:   "claude-opus-4-7",
+			wantCycle: []effort.Level{effort.Low, effort.Medium, effort.High, effort.XHigh, effort.None},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			model := newConfigProvider(latest.ModelConfig{Provider: "anthropic", Model: tt.modelID})
+			root := agent.New("root", "test", agent.WithModel(model))
+			r := &LocalRuntime{
+				team: team.New(team.WithAgents(root)),
+				modelSwitcherCfg: &ModelSwitcherConfig{
+					EnvProvider: environment.NewMapEnvProvider(map[string]string{"ANTHROPIC_API_KEY": "sk-test"}),
+				},
+			}
+
+			// Walk one full cycle starting from None and record every level.
+			var got []effort.Level
+			for range tt.wantCycle {
+				level, err := r.CycleAgentThinkingLevel(t.Context(), "root")
+				require.NoError(t, err)
+				got = append(got, level)
+			}
+			assert.Equal(t, tt.wantCycle, got)
+		})
+	}
+}
+
 func TestIsInlineAlloySpec(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Replace the per-provider thinking-level cycles with capability-driven selection. pkg/effort now exposes the generic level algebra: a three-state LevelMap, SupportedLevels (explicit-only top tiers xhigh and max), Clamp (nearest supported level, searching upward first), and NextSupportedLevel (wraparound cycling).

pkg/modelinfo builds the per-model level set: Claude models top out at high except Opus 4.6 (max) and Opus 4.7+/Fable (xhigh); OpenAI gets xhigh from gpt-5.2 on; Gemini and unknown providers keep their previous scales. CycleAgentThinkingLevel now advances through the levels the specific model accepts, so e.g. claude-sonnet is never offered xhigh.