### PR TITLE
docs: document WithHTTPTransportWrapper and RAG permanent error behavior

### DIFF
--- a/docs/guides/go-sdk/index.md
+++ b/docs/guides/go-sdk/index.md
@@ -317,7 +317,10 @@ wrapper := options.WithHTTPTransportWrapper(
     },
 )
 
-client, err := openai.NewClient(ctx, modelCfg, env, wrapper)
+client, err := openai.NewClient(ctx, &latest.ModelConfig{
+    Provider: "openai",
+    Model:    "gpt-4o",
+}, env, wrapper)
 ```
 
 The wrapper receives the already-instrumented transport (OpenTelemetry, SSE decompression, Desktop proxy support) as its `base` argument, so wrapping it preserves all built-in behaviour.
@@ -331,7 +334,7 @@ The wrapper receives the already-instrumented transport (OpenTelemetry, SSE deco
 
 </div>
 
-In **gateway mode** the wrapper is called on every LLM request because gateway clients are rebuilt each call for short-lived auth tokens. In **direct mode** it is called once at client construction.
+In **gateway mode** the wrapper is called on every LLM request because gateway clients are rebuilt each call for short-lived auth tokens. In **direct mode** it is called once at client construction. Rate-limit responses (HTTP 429) are classified as non-retryable by the runtime and cause the model chain to skip to the next fallback, so wrappers that track per-request outcomes will observe these as failures rather than retried calls.
 
 Returning `nil` from your wrapper function is treated as a bug: docker-agent logs a warning and preserves the original transport instead.
 

--- a/docs/guides/go-sdk/index.md
+++ b/docs/guides/go-sdk/index.md
@@ -325,18 +325,18 @@ client, err := openai.NewClient(ctx, &latest.ModelConfig{
 
 The wrapper receives the already-instrumented transport (OpenTelemetry, SSE decompression, Desktop proxy support) as its `base` argument, so wrapping it preserves all built-in behaviour.
 
-**Supported providers:** Anthropic, OpenAI, Gemini (GeminiAPI backend). Works in both direct and gateway/proxy mode.
+**Supported providers:** Anthropic, OpenAI, Gemini (GeminiAPI backend), Bedrock. Works in both direct and gateway/proxy mode.
 
 <div class="callout callout-warning" markdown="1">
-<div class="callout-title">Bedrock and Vertex AI not supported
+<div class="callout-title">Vertex AI not supported
 </div>
-  <p>Bedrock and Vertex AI use SDK-managed transports that docker-agent cannot intercept. Passing <code>WithHTTPTransportWrapper</code> when targeting these providers has no effect; a warning is logged at startup.</p>
+  <p>Vertex AI uses an ADC-managed HTTP client that docker-agent cannot intercept. When a transport wrapper is set, docker-agent falls back to the GeminiAPI backend instead of Vertex AI — a debug message is logged.</p>
 
 </div>
 
 In **gateway mode** the wrapper is called on every LLM request because gateway clients are rebuilt each call for short-lived auth tokens. In **direct mode** it is called once at client construction. Rate-limit responses (HTTP 429) are classified as non-retryable by the runtime and cause the model chain to skip to the next fallback, so wrappers that track per-request outcomes will observe these as failures rather than retried calls.
 
-Returning `nil` from your wrapper function is treated as a bug: docker-agent logs a warning and preserves the original transport instead.
+Returning `nil` from your wrapper function is not allowed; docker-agent logs a warning and keeps the original transport instead.
 
 ## Using Different Providers
 

--- a/docs/guides/go-sdk/index.md
+++ b/docs/guides/go-sdk/index.md
@@ -312,8 +312,8 @@ func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 // Example: add a custom header to every outbound LLM request
 wrapper := options.WithHTTPTransportWrapper(
-    func(base http.RoundTripper) (http.RoundTripper, error) {
-        return &headerTransport{base: base}, nil
+    func(base http.RoundTripper) http.RoundTripper {
+        return &headerTransport{base: base}
     },
 )
 

--- a/docs/guides/go-sdk/index.md
+++ b/docs/guides/go-sdk/index.md
@@ -300,14 +300,20 @@ import (
     "github.com/docker/docker-agent/pkg/model/provider/options"
 )
 
+type headerTransport struct {
+    base http.RoundTripper
+}
+
+func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+    req = req.Clone(req.Context())
+    req.Header.Set("X-Request-Source", "my-app")
+    return t.base.RoundTrip(req)
+}
+
 // Example: add a custom header to every outbound LLM request
 wrapper := options.WithHTTPTransportWrapper(
-    func(base http.RoundTripper) http.RoundTripper {
-        return roundTripperFunc(func(req *http.Request) (*http.Response, error) {
-            req = req.Clone(req.Context())
-            req.Header.Set("X-Request-Source", "my-app")
-            return base.RoundTrip(req)
-        })
+    func(base http.RoundTripper) (http.RoundTripper, error) {
+        return &headerTransport{base: base}, nil
     },
 )
 

--- a/docs/guides/go-sdk/index.md
+++ b/docs/guides/go-sdk/index.md
@@ -289,6 +289,46 @@ func createAgentWithBuiltinTools(llm provider.Provider) *agent.Agent {
 }
 ```
 
+## HTTP Middleware / Transport Wrappers
+
+Use `options.WithHTTPTransportWrapper` to inject HTTP middleware into the transport chain of all provider clients built by docker-agent. This is useful for request tracing, injecting custom headers, collecting metrics, or any other cross-cutting concern at the HTTP layer.
+
+```go
+import (
+    "net/http"
+
+    "github.com/docker/docker-agent/pkg/model/provider/options"
+)
+
+// Example: add a custom header to every outbound LLM request
+wrapper := options.WithHTTPTransportWrapper(
+    func(base http.RoundTripper) http.RoundTripper {
+        return roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+            req = req.Clone(req.Context())
+            req.Header.Set("X-Request-Source", "my-app")
+            return base.RoundTrip(req)
+        })
+    },
+)
+
+client, err := openai.NewClient(ctx, modelCfg, env, wrapper)
+```
+
+The wrapper receives the already-instrumented transport (OpenTelemetry, SSE decompression, Desktop proxy support) as its `base` argument, so wrapping it preserves all built-in behaviour.
+
+**Supported providers:** Anthropic, OpenAI, Gemini (GeminiAPI backend). Works in both direct and gateway/proxy mode.
+
+<div class="callout callout-warning" markdown="1">
+<div class="callout-title">Bedrock and Vertex AI not supported
+</div>
+  <p>Bedrock and Vertex AI use SDK-managed transports that docker-agent cannot intercept. Passing <code>WithHTTPTransportWrapper</code> when targeting these providers has no effect; a warning is logged at startup.</p>
+
+</div>
+
+In **gateway mode** the wrapper is called on every LLM request because gateway clients are rebuilt each call for short-lived auth tokens. In **direct mode** it is called once at client construction.
+
+Returning `nil` from your wrapper function is treated as a bug: docker-agent logs a warning and preserves the original transport instead.
+
 ## Using Different Providers
 
 ```go

--- a/docs/tools/rag/index.md
+++ b/docs/tools/rag/index.md
@@ -183,10 +183,10 @@ $ docker agent run config.yaml --debug --log-file debug.log
 
 Look for log tags: `[RAG Manager]`, `[Chunked-Embeddings Strategy]`, `[BM25 Strategy]`, `[RRF Fusion]`, `[Reranker]`.
 
-**Permanent model errors abort early.** If the embedding model, semantic-LLM model, or reranking model returns a permanent error (HTTP 400, 401, 404, or 429), docker-agent treats the model configuration as invalid and stops immediately rather than retrying doomed requests:
+**Permanent model errors abort early.** If the embedding model, semantic-LLM model, or reranking model returns a permanent error (HTTP 400, 401, or 404 — invalid config, bad auth, or unknown model), docker-agent treats the model configuration as invalid and stops immediately rather than retrying doomed requests:
 
 - **Indexing** — the entire indexing run is aborted after the first permanent failure. The error is surfaced in the logs so you know immediately if a model name or API key is wrong, rather than silently producing incomplete results.
-- **Reranking** — a permanent error permanently disables the reranker for the lifetime of the manager. Subsequent queries fall back to un-reranked results. Transient errors (5xx, timeouts) still fall back and retry on the next query.
+- **Reranking** — a permanent error permanently disables the reranker for the lifetime of the manager. Subsequent queries fall back to un-reranked results. Transient errors (5xx, timeouts) and rate limits (429) still fall back and retry on the next query.
 
 <div class="callout callout-tip" markdown="1">
 <div class="callout-title">Examples

--- a/docs/tools/rag/index.md
+++ b/docs/tools/rag/index.md
@@ -183,6 +183,11 @@ $ docker agent run config.yaml --debug --log-file debug.log
 
 Look for log tags: `[RAG Manager]`, `[Chunked-Embeddings Strategy]`, `[BM25 Strategy]`, `[RRF Fusion]`, `[Reranker]`.
 
+**Permanent model errors abort early.** If the embedding model, semantic-LLM model, or reranking model returns a permanent error (HTTP 400, 401, 404, or 429), docker-agent treats the model configuration as invalid and stops immediately rather than retrying doomed requests:
+
+- **Indexing** — the entire indexing run is aborted after the first permanent failure. The error is surfaced in the logs so you know immediately if a model name or API key is wrong, rather than silently producing incomplete results.
+- **Reranking** — a permanent error permanently disables the reranker for the lifetime of the manager. Subsequent queries fall back to un-reranked results. Transient errors (5xx, timeouts) still fall back and retry on the next query.
+
 <div class="callout callout-tip" markdown="1">
 <div class="callout-title">Examples
 </div>

--- a/docs/tools/rag/index.md
+++ b/docs/tools/rag/index.md
@@ -183,10 +183,10 @@ $ docker agent run config.yaml --debug --log-file debug.log
 
 Look for log tags: `[RAG Manager]`, `[Chunked-Embeddings Strategy]`, `[BM25 Strategy]`, `[RRF Fusion]`, `[Reranker]`.
 
-**Permanent model errors abort early.** If the embedding model, semantic-LLM model, or reranking model returns a permanent error (HTTP 400, 401, or 404 — invalid config, bad auth, or unknown model), docker-agent treats the model configuration as invalid and stops immediately rather than retrying doomed requests:
+**Permanent model errors abort early.** If the embedding model, semantic-LLM model, or reranking model returns a permanent error (HTTP 400, 401, 404, or 429 — invalid config, bad auth, unknown model, or rate limit), docker-agent treats the model configuration as invalid and stops immediately rather than retrying doomed requests:
 
-- **Indexing** — the entire indexing run is aborted after the first permanent failure. The error is surfaced in the logs so you know immediately if a model name or API key is wrong, rather than silently producing incomplete results.
-- **Reranking** — a permanent error permanently disables the reranker for the lifetime of the manager. Subsequent queries fall back to un-reranked results. Transient errors (5xx, timeouts) and rate limits (429) still fall back and retry on the next query.
+- **Indexing** — the entire indexing run is aborted after the first permanent failure (including 429). The error is surfaced in the logs so you know immediately if a model name or API key is wrong, rather than silently producing incomplete results.
+- **Reranking** — a permanent error (including 429) permanently disables the reranker for the lifetime of the manager. Subsequent queries fall back to un-reranked results. Only transient errors (5xx, timeouts) fall back and retry on the next query.
 
 <div class="callout callout-tip" markdown="1">
 <div class="callout-title">Examples


### PR DESCRIPTION
## Documentation updates

This PR documents two code changes merged into \`main\` in the last 36 hours that were not reflected in the \`/docs\`.

| Commit | Source PR | What changed |
|--------|-----------|--------------|
| \`8c28e215\` | [#3090](https://github.com/docker/docker-agent/pull/3090) | Document \`options.WithHTTPTransportWrapper\` for HTTP middleware injection in Go SDK |
| \`64889754\` | [#3091](https://github.com/docker/docker-agent/pull/3091) | Document permanent error behavior in RAG indexing and reranking |

## Details

### Go SDK HTTP Middleware / Transport Wrappers ([#3090](https://github.com/docker/docker-agent/pull/3090))

PR #3090 added \`options.WithHTTPTransportWrapper\` — a new \`Opt\` that lets Go SDK embedders inject an HTTP middleware (e.g. tracing, custom auth headers, metrics) into the transport chain of all provider clients. No documentation existed for this API.

Added a new **"HTTP Middleware / Transport Wrappers"** section to \`docs/guides/go-sdk/index.md\` covering:
- Full Go code example (custom header injection pattern)
- The fact that \`base\` already carries OTel/SSE/proxy instrumentation
- Supported providers: Anthropic, OpenAI, Gemini (GeminiAPI backend)
- Warning callout for Bedrock and Vertex AI (unsupported; warning is logged)
- Gateway vs. direct mode lifecycle difference (wrapper called once vs. per-request)
- Nil-return-is-a-bug note

### RAG permanent error behavior ([#3091](https://github.com/docker/docker-agent/pull/3091))

PR #3091 fixed a bug where a misconfigured embedding or reranking model (e.g. a typo in the model name) caused a flood of doomed requests. The new behavior — aborting indexing on the first permanent failure and permanently disabling the reranker on permanent errors — was not documented.

Added a paragraph to the **"Debugging RAG"** section of \`docs/tools/rag/index.md\` explaining:
- What counts as a permanent error (400, 401, 404, 429)
- Indexing: aborts on first permanent failure and surfaces the error immediately
- Reranking: permanently disabled for the manager lifetime; transient errors (5xx/timeouts) still fall back and retry

## PRs reviewed and found up to date

| Source PR | Reason |
|-----------|--------|
| [#3095](https://github.com/docker/docker-agent/pull/3095) | \`force_handoff\` — docs included in the PR (multi-agent concepts, agent config ref, hooks ref) |
| [#3086](https://github.com/docker/docker-agent/pull/3086) | Gateway model discovery — TUI docs updated in the PR |
| [#3092](https://github.com/docker/docker-agent/pull/3092) | CHANGELOG v1.79.0 — automated release update |
| [#3087](https://github.com/docker/docker-agent/pull/3087) | Require GPG/SSH commit signing — AGENTS.md only (contributor guide) |
| [#3085](https://github.com/docker/docker-agent/pull/3085) | Semgrep MCP catalog auth fix — internal catalog metadata, no user docs |
| [#3084](https://github.com/docker/docker-agent/pull/3084) | Previous docs update PR |