### PR TITLE
feat(hooks): populate agent_name on tool-use hook events

### DIFF
--- a/pkg/runtime/hooks.go
+++ b/pkg/runtime/hooks.go
@@ -104,6 +104,13 @@ func (r *LocalRuntime) dispatchHook(
 		return nil
 	}
 
+	// Auto-fill AgentName for events whose Input builder omits it (tool
+	// events via toolexec.NewHooksInput), mirroring Cwd auto-fill in
+	// Executor.Dispatch. Caller-set values win.
+	if input != nil && input.AgentName == "" {
+		input.AgentName = a.Name()
+	}
+
 	started := time.Now()
 	if events != nil {
 		events.Emit(HookStarted(event, input.SessionID, a.Name()))

--- a/pkg/runtime/pre_tool_use_approval_test.go
+++ b/pkg/runtime/pre_tool_use_approval_test.go
@@ -260,3 +260,41 @@ func TestPreToolUseHook_PermissionsAllowShortCircuitsHook(t *testing.T) {
 	assert.True(t, *executed,
 		"deterministic Allow must short-circuit the hook (cost / latency win)")
 }
+
+// TestPreToolUseHook_ReceivesAgentName verifies dispatchHook auto-fills
+// Input.AgentName for tool events, whose toolexec.NewHooksInput builder
+// can't set it — matching every other event type.
+func TestPreToolUseHook_ReceivesAgentName(t *testing.T) {
+	t.Parallel()
+
+	executed := new(bool)
+	agentTools := recordingTool("the_tool", executed)
+	hookName := "test_agentname_" + t.Name()
+
+	prov := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
+	root := agent.New("root", "instr",
+		agent.WithModel(prov),
+		agent.WithToolSets(newStubToolSet(nil, agentTools, nil)),
+		agent.WithHooks(preToolUseHooksConfig(hookName)),
+	)
+	rt, err := NewLocalRuntime(team.New(team.WithAgents(root)),
+		WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+
+	var gotAgentName string
+	require.NoError(t, rt.hooksRegistry.RegisterBuiltin(hookName, func(_ context.Context, in *hooks.Input, _ []string) (*hooks.Output, error) {
+		if in != nil && in.HookEventName == hooks.EventPreToolUse {
+			gotAgentName = in.AgentName
+		}
+		return &hooks.Output{HookSpecificOutput: &hooks.HookSpecificOutput{
+			HookEventName:      hooks.EventPreToolUse,
+			PermissionDecision: hooks.DecisionAllow,
+		}}, nil
+	}))
+
+	sess := session.New(session.WithUserMessage("test"))
+	_ = runJudgedToolCall(t, rt, sess, agentTools)
+
+	assert.Equal(t, "root", gotAgentName,
+		"pre_tool_use hook Input must carry the dispatching agent's name")
+}


### PR DESCRIPTION
## What

Tool-use hook events (`pre_tool_use` / `post_tool_use`) now carry
`agent_name` in their `hooks.Input`, matching every other event type.

Fixes #3109.

## Why

`hooks.Input.AgentName` exists and is documented as "identifies the agent
dispatching the event", and session / turn / `before|after_llm_call` /
`on_agent_switch` events all set it. But tool events build their Input via
`toolexec.NewHooksInput`, which receives no agent, so `agent_name` shipped
empty — even though the shared `dispatchHook` path already has the agent.
This blocks any `pre_tool_use` consumer (auditing, per-agent rate limits,
external policy engines) from knowing which agent issued a tool call.

## How

Auto-fill `AgentName` in `dispatchHook` (the shared path that already
receives the agent), only when it is empty so explicit caller values win,
mirroring how `Executor.Dispatch` auto-fills `Cwd`. The field is `omitempty`,
so this is backward compatible, and it covers both `pre_tool_use` and
`post_tool_use` (both flow through the same path).

Semantics: `agent_name` = the agent that directly issues the tool call
(`a.Name()`); on transfer/handoff it follows the active sub-agent.

## Testing

- `go test ./pkg/runtime/...` — added `TestPreToolUseHook_ReceivesAgentName`;
  all pre_tool_use hook tests pass.
- `go build ./...`, `go vet ./pkg/runtime/...`, `gofmt` — clean.
- End-to-end on a real agent run with a `pre_tool_use` hook dumping its stdin:
  - single agent: `{"agent_name":"root","tool_name":"think"}`
  - multi-agent (root delegates to a sub-agent via `transfer_task`):
    ```
    {"agent_name":"root",   "tool_name":"think"}
    {"agent_name":"root",   "tool_name":"transfer_task"}
    {"agent_name":"worker", "tool_name":"think"}
    ```
    confirming `agent_name` follows the active agent across delegation.
