### PR TITLE
fix: remove todo strikethrough

### DIFF
--- a/pkg/tui/components/tool/todotool/todotool.go
+++ b/pkg/tui/components/tool/todotool/todotool.go
@@ -13,7 +13,7 @@ func renderTodoIcon(status string) (string, lipgloss.Style) {
 	case "in-progress":
 		return "◔", styles.InProgressStyle
 	case "completed":
-		return "✓", styles.CompletedStyle.Strikethrough(true)
+		return "✓", styles.CompletedStyle
 	default:
 		return "?", styles.ToBeDoneStyle
 	}


### PR DESCRIPTION
- Remove strikethrough styling from completed todo items.
- Keep the completed checkmark and existing completed style color.

Testing: not run (opened immediately per request).