### PR TITLE
fix(agent): deduplicate tool names before dispatch

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -377,11 +377,37 @@ func (a *Agent) collectTools(ctx context.Context) ([]tools.Tool, error) {
 
 	agentTools = append(agentTools, a.tools...)
 
+	// Collapse duplicate tool names to their first occurrence. Two toolsets of
+	// the same type, two unnamed MCP servers, or an MCP server whose tool name
+	// shadows a built-in can all surface the same name; providers such as
+	// Anthropic reject a request whose tool list contains duplicates ("tools:
+	// Tool names must be unique."). This is the single point where every tool
+	// converges before being handed to any provider. See #2251.
+	agentTools = a.dedupeToolsByName(ctx, agentTools)
+
 	if a.addDescriptionParameter {
 		agentTools = tools.AddDescriptionParameter(agentTools)
 	}
 
 	return agentTools, nil
+}
+
+// dedupeToolsByName keeps the first tool seen for each name and drops any later
+// collision, logging a warning per dropped tool. Deduplication happens in place
+// (the input slice is local to collectTools), so a collision-free list is
+// returned unchanged.
+func (a *Agent) dedupeToolsByName(ctx context.Context, agentTools []tools.Tool) []tools.Tool {
+	seen := make(map[string]struct{}, len(agentTools))
+	deduped := agentTools[:0]
+	for _, tool := range agentTools {
+		if _, ok := seen[tool.Name]; ok {
+			slog.WarnContext(ctx, "Dropping duplicate tool name from agent tool set", "agent", a.Name(), "tool", tool.Name)
+			continue
+		}
+		seen[tool.Name] = struct{}{}
+		deduped = append(deduped, tool)
+	}
+	return deduped
 }
 
 func (a *Agent) ToolSets() []tools.ToolSet {

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -149,6 +149,19 @@ func TestAgentTools(t *testing.T) {
 			wantToolCount: 0,
 			wantWarnings:  0,
 		},
+		{
+			// #2251: two toolsets emitting the same names (e.g. the same
+			// built-in type configured twice) must collapse to a unique set,
+			// otherwise Anthropic rejects the request with "Tool names must be
+			// unique." Deduplication is silent (slog only), so no warnings.
+			name: "duplicate names across toolsets are deduped",
+			toolsets: []tools.ToolSet{
+				newStubToolSet(nil, []tools.Tool{{Name: "read_file", Parameters: map[string]any{}}, {Name: "write_file", Parameters: map[string]any{}}}, nil),
+				newStubToolSet(nil, []tools.Tool{{Name: "read_file", Parameters: map[string]any{}}, {Name: "write_file", Parameters: map[string]any{}}}, nil),
+			},
+			wantToolCount: 2,
+			wantWarnings:  0,
+		},
 	}
 
 	for _, tt := range tests {
@@ -167,6 +180,38 @@ func TestAgentTools(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestAgentToolsDedupeKeepsFirstInOrder verifies the deduplication contract
+// from #2251: when several toolsets emit the same tool name, Tools() keeps the
+// first occurrence (so the earliest toolset wins), preserves the original
+// order of distinct names, and never emits a duplicate to the provider.
+func TestAgentToolsDedupeKeepsFirstInOrder(t *testing.T) {
+	t.Parallel()
+
+	first := newStubToolSet(nil, []tools.Tool{
+		{Name: "read_file", Description: "from first", Parameters: map[string]any{}},
+		{Name: "fetch", Description: "from first", Parameters: map[string]any{}},
+	}, nil)
+	second := newStubToolSet(nil, []tools.Tool{
+		{Name: "read_file", Description: "from second", Parameters: map[string]any{}},
+		{Name: "write_file", Description: "from second", Parameters: map[string]any{}},
+	}, nil)
+
+	a := New("root", "test", WithToolSets(first, second))
+	got, err := a.Tools(t.Context())
+	require.NoError(t, err)
+
+	names := make([]string, len(got))
+	for i, tool := range got {
+		names[i] = tool.Name
+	}
+	assert.Equal(t, []string{"read_file", "fetch", "write_file"}, names,
+		"distinct names in first-seen order, no duplicates")
+
+	require.Len(t, got, 3)
+	assert.Equal(t, "from first", got[0].Description,
+		"the first occurrence of read_file must win")
 }
 
 // TestAgentNoDuplicateListWarnings verifies that a toolset that starts


### PR DESCRIPTION
## What

Deduplicate tool names in `Agent.Tools()` so an agent never sends duplicate tool names to a provider.

Fixes #2251.

## Why

When an agent has multiple toolsets that emit the same tool name, `Agent.Tools()` (via `collectTools`) returned every copy verbatim — there was no dedup anywhere in the collection pipeline. The Anthropic API rejects such a request:

```
HTTP 400: {"type":"error","error":{"type":"invalid_request_error",
"message":"tools: Tool names must be unique."}}
```

Collisions happen in several real configs:
- the same built-in toolset type configured twice (e.g. two `filesystem` toolsets → `read_file`, `write_file`, …);
- two unnamed MCP servers exposing the same tool names;
- an MCP server whose tool name shadows a built-in (e.g. `fetch`).

#1969 fixed only the specific multi-LSP case via the LSP multiplexer; the general problem remained.

## How

`collectTools()` is the single point where tools from every toolset plus static tools converge before being handed to any provider, so dedup lives there. `dedupeToolsByName` keeps the **first** occurrence of each name, drops later collisions, and logs a `slog.Warn` per dropped tool. Deduplication is done in place on the locally-built slice, so a collision-free list is returned unchanged (and an empty list stays `nil`).

Warnings go through `slog.Warn` rather than the user-facing `AddToolWarning`: `collectTools()` runs every turn and warnings are drained per turn, so surfacing this to the user would repeat on every message.

## Tests

- `TestAgentTools`: new table case — two toolsets emitting the same names collapse to a unique set with no user-facing warnings.
- `TestAgentToolsDedupeKeepsFirstInOrder`: asserts the first occurrence wins and distinct names keep their first-seen order.

## Verification

Reproduced the root cause with a config of two `filesystem` toolsets:

- before: `Agent.Tools()` returned 18 tools / 9 distinct names (all duplicated);
- after: 9 tools / 9 distinct names, with a logged warning per dropped duplicate.