### PR TITLE
fix: run /shell in the active session's working directory

### DIFF
--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -785,6 +785,12 @@ func (m *appModel) startShell() (tea.Model, tea.Cmd) {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	// Run the shell in the active session's working directory so it matches
+	// where the tools operate (e.g. the worktree created by --worktree),
+	// rather than inheriting the process CWD.
+	if runner := m.supervisor.GetRunner(m.supervisor.ActiveID()); runner != nil && runner.WorkingDir != "" {
+		cmd.Dir = runner.WorkingDir
+	}
 	return m, tea.ExecProcess(cmd, nil)
 }
 


### PR DESCRIPTION
When running with `--worktree`, the current directory is changed for tools but the `/shell` slash command was still inheriting the process CWD. This meant launching an interactive shell via `/shell` would start in the original directory rather than the working directory where tools operate.

This fix updates the `startShell` handler in `pkg/tui/handlers.go` to set `cmd.Dir` to the active session's working directory (`runner.WorkingDir`). Now the interactive shell launched by `/shell` starts in the same directory as the tools, such as a worktree created by `--worktree`.