### PR TITLE
fix(tui): cache sidebar todo render to stop scroll lag while streaming

### DIFF
--- a/pkg/tui/components/sidebar/bench_test.go
+++ b/pkg/tui/components/sidebar/bench_test.go
@@ -1,0 +1,54 @@
+package sidebar
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/tools/builtin/todo"
+	"github.com/docker/docker-agent/pkg/tui/service"
+)
+
+// makeTodos builds n todo items whose descriptions are long enough to exercise
+// the word-wrap path in the sidebar's narrow content column.
+func makeTodos(n int) *tools.ToolCallResult {
+	statuses := []string{"completed", "in-progress", "pending"}
+	items := make([]todo.Todo, n)
+	for i := range items {
+		items[i] = todo.Todo{
+			ID:          fmt.Sprintf("t%d", i),
+			Status:      statuses[i%len(statuses)],
+			Description: fmt.Sprintf("Task %d: refactor the rendering pipeline and add coverage for the new code path", i),
+		}
+	}
+	return &tools.ToolCallResult{Meta: items}
+}
+
+// BenchmarkSidebarStreamingTodos reproduces issue #3123: while the agent is
+// working, the sidebar invalidates its whole render cache on every 14 FPS
+// spinner tick and rebuilds all sections — including the full todo list, twice
+// when it overflows (two-pass scrollbar layout). This benchmark measures that
+// per-frame rebuild cost across todo-list sizes; the cost should stay flat, not
+// grow with the list length.
+func BenchmarkSidebarStreamingTodos(b *testing.B) {
+	for _, n := range []int{10, 50, 150} {
+		b.Run(fmt.Sprintf("todos=%d", n), func(b *testing.B) {
+			m := New(service.NewSessionState(session.New())).(*model)
+			m.SetMode(ModeVertical)
+			m.SetSize(40, 40) // small height so the long list overflows (two-pass)
+			m.workingAgent = "root"
+			if err := m.SetTodos(makeTodos(n)); err != nil {
+				b.Fatal(err)
+			}
+			_ = m.verticalView() // warm any caches
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for range b.N {
+				m.invalidateCache() // a spinner tick invalidates the sidebar cache
+				_ = m.verticalView()
+			}
+		})
+	}
+}

--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -805,7 +805,8 @@ func (m *model) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 			cmds = append(cmds, state.spinner.Init())
 		}
 
-		m.invalidateCache() // Theme affects all styling
+		m.todoComp.InvalidateCache() // Cached todo lines embed theme styling
+		m.invalidateCache()          // Theme affects all styling
 		return m, tea.Batch(cmds...)
 	default:
 		var cmds []tea.Cmd

--- a/pkg/tui/components/tool/todotool/sidebar.go
+++ b/pkg/tui/components/tool/todotool/sidebar.go
@@ -12,10 +12,24 @@ import (
 	"github.com/docker/docker-agent/pkg/tui/styles"
 )
 
+// renderCacheCap bounds the per-width render cache. Only a couple of widths are
+// ever live at once (the two-pass scrollbar layout renders at two widths), so a
+// small cap soaks up a window resize without letting the cache grow unbounded
+// between todo updates.
+const renderCacheCap = 8
+
 // SidebarComponent represents the todo display component for the sidebar
 type SidebarComponent struct {
 	todos []todo.Todo
 	width int
+
+	// renderCache memoizes the rendered todo list keyed by content width.
+	// Render() is called on every animation frame while the agent works (the
+	// sidebar rebuilds its whole cache on each spinner tick) and the two-pass
+	// scrollbar layout renders at two widths, so without this the O(todos)
+	// word-wrap+style work runs many times per second on long lists. Cleared
+	// when the todos change (SetTodos) or the theme changes (InvalidateCache).
+	renderCache map[int]string
 }
 
 func NewSidebarComponent() *SidebarComponent {
@@ -39,7 +53,14 @@ func (c *SidebarComponent) SetTodos(result *tools.ToolCallResult) error {
 	}
 
 	c.todos = todos
+	c.renderCache = nil // todos changed — drop the stale render cache
 	return nil
+}
+
+// InvalidateCache drops the memoized render. The sidebar calls this when the
+// theme changes, since the cached lines embed theme-dependent styling.
+func (c *SidebarComponent) InvalidateCache() {
+	c.renderCache = nil
 }
 
 func (c *SidebarComponent) Render() string {
@@ -47,12 +68,21 @@ func (c *SidebarComponent) Render() string {
 		return ""
 	}
 
+	if cached, ok := c.renderCache[c.width]; ok {
+		return cached
+	}
+
 	var lines []string
 	for _, todo := range c.todos {
 		lines = append(lines, c.renderTodoLine(todo))
 	}
+	rendered := c.renderTab("TO-DO", strings.Join(lines, "\n"))
 
-	return c.renderTab("TO-DO", strings.Join(lines, "\n"))
+	if c.renderCache == nil || len(c.renderCache) >= renderCacheCap {
+		c.renderCache = make(map[int]string, 2)
+	}
+	c.renderCache[c.width] = rendered
+	return rendered
 }
 
 func (c *SidebarComponent) renderTodoLine(todoItem todo.Todo) string {

--- a/pkg/tui/components/tool/todotool/sidebar_test.go
+++ b/pkg/tui/components/tool/todotool/sidebar_test.go
@@ -1,0 +1,89 @@
+package todotool
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/tools/builtin/todo"
+)
+
+func todoResult(descriptions ...string) *tools.ToolCallResult {
+	items := make([]todo.Todo, len(descriptions))
+	for i, d := range descriptions {
+		items[i] = todo.Todo{ID: d, Description: d, Status: "pending"}
+	}
+	return &tools.ToolCallResult{Meta: items}
+}
+
+// TestRenderCacheReflectsTodoChanges guards the render cache added for issue
+// #3123: a cache hit must never serve a render from a previous todo list.
+func TestRenderCacheReflectsTodoChanges(t *testing.T) {
+	t.Parallel()
+
+	c := NewSidebarComponent()
+	c.SetSize(40)
+
+	require.NoError(t, c.SetTodos(todoResult("alpha task")))
+	first := c.Render()
+	assert.Contains(t, first, "alpha")
+	assert.Equal(t, first, c.Render(), "same todos + width should hit the cache and return an identical render")
+
+	require.NoError(t, c.SetTodos(todoResult("beta task")))
+	second := c.Render()
+	assert.Contains(t, second, "beta")
+	assert.NotContains(t, second, "alpha", "render must reflect the new todos, not a stale cache")
+}
+
+// TestRenderCacheKeyedByWidth verifies the cache distinguishes widths so the
+// two-pass scrollbar layout (which renders at two widths) stays correct.
+func TestRenderCacheKeyedByWidth(t *testing.T) {
+	t.Parallel()
+
+	c := NewSidebarComponent()
+	require.NoError(t, c.SetTodos(todoResult("a task with a fairly long description that wraps")))
+
+	c.SetSize(50)
+	wide := c.Render()
+	c.SetSize(20)
+	narrow := c.Render()
+	c.SetSize(50)
+	wideAgain := c.Render()
+
+	assert.NotEqual(t, wide, narrow, "different widths should produce different renders")
+	assert.Equal(t, wide, wideAgain, "returning to a seen width should reuse its cached render")
+	// A narrower column wraps into more lines.
+	assert.Greater(t, strings.Count(narrow, "\n"), strings.Count(wide, "\n"))
+}
+
+// TestInvalidateCacheForcesRecompute verifies theme-change invalidation drops
+// the memoized render.
+func TestInvalidateCacheForcesRecompute(t *testing.T) {
+	t.Parallel()
+
+	c := NewSidebarComponent()
+	c.SetSize(40)
+	require.NoError(t, c.SetTodos(todoResult("a task")))
+
+	_ = c.Render()
+	require.NotEmpty(t, c.renderCache, "render should populate the cache")
+	c.InvalidateCache()
+	assert.Empty(t, c.renderCache, "InvalidateCache should drop the memoized render")
+}
+
+// TestRenderCacheBounded verifies a flood of distinct widths (e.g. a window
+// resize drag) cannot grow the cache without bound.
+func TestRenderCacheBounded(t *testing.T) {
+	t.Parallel()
+
+	c := NewSidebarComponent()
+	require.NoError(t, c.SetTodos(todoResult("a task")))
+	for w := 20; w < 200; w++ {
+		c.SetSize(w)
+		_ = c.Render()
+	}
+	assert.LessOrEqual(t, len(c.renderCache), renderCacheCap)
+}


### PR DESCRIPTION
## What
The right-hand sidebar (todo list) scrolls laggily while the left chat panel is streaming, and the longer the todo list the worse it gets (#3123). It's smooth again once the turn ends.

## Why
While the agent works, the sidebar invalidates its whole render cache on every 14 FPS spinner tick and rebuilds every section, including the entire todo list, twice when it overflows (two-pass scrollbar layout). The todo render does O(n) word-wrap + styling per item with no memoization, so the per-frame cost scales with the list length and contends with scroll handling on the single render goroutine. The left (messages) panel already caches/virtualizes its build stage; the sidebar didn't.

## Fix
Memoize the todo render in the todo sidebar component, keyed by content width so it survives the two-pass width toggle, cleared when the todos change or the theme changes. Bounded to a few widths so a window resize can't grow it unbounded. Small, contained change in `todotool/sidebar.go` plus a one-line theme invalidation hook in `sidebar.go`.

## Before / after
Per-frame sidebar rebuild while streaming (`BenchmarkSidebarStreamingTodos`):

| todos | before (ms/frame) | after (ms/frame) | speedup |
|------:|------------------:|-----------------:|--------:|
| 10    | 1.05              | 0.36             | ~3x     |
| 50    | 3.65              | 0.36             | ~10x    |
| 150   | 10.19             | 0.36             | ~28x    |

At 150 todos, allocations drop too, and the cost stops scaling with the list:

| metric (150 todos) | before  | after  |
|--------------------|--------:|-------:|
| time / frame       | 10.19ms | 0.36ms |
| bytes / frame      | 7.5 MB  | 159 KB |
| allocs / frame     | 140855  | 2252   |
| scaling 150-vs-10  | ~10x    | ~1x (flat) |

## Tests
- new `BenchmarkSidebarStreamingTodos` (sidebar pkg) measuring the per-frame rebuild across todo counts
- new unit tests for the cache (todotool pkg): reflects todo changes, keyed by width, invalidates on theme, stays bounded
- full `pkg/tui/...` suite is green, gofmt clean
