### PR TITLE
perf(tui): skip sidebar scrollbar-probe pass on animation frames

### DIFF
--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -156,6 +156,7 @@ type model struct {
 	cachedWidth          int      // Width used for cached render
 	cachedNeedsScrollbar bool     // Whether scrollbar is needed for cached render
 	cacheDirty           bool     // True when cache needs rebuild
+	layoutDirty          bool     // True when a change may alter line count/scrollbar visibility (not just an animation frame)
 
 	// Agent click zones: maps content line index to agent name for click detection
 	agentClickZones map[int]string // content line -> agent name
@@ -189,6 +190,7 @@ func New(sessionState *service.SessionState) Model {
 		preferredWidth:   DefaultWidth,
 		titleInput:       ti,
 		cacheDirty:       true, // Initial render needed
+		layoutDirty:      true, // First render must probe scrollbar visibility
 	}
 	return m
 }
@@ -225,8 +227,20 @@ func (m *model) stopSpinner() {
 	m.spinner.Stop()
 }
 
-// invalidateCache marks the sidebar render cache as dirty so it will be rebuilt on the next View().
+// invalidateCache marks the sidebar render cache as dirty so it will be rebuilt
+// on the next View(). Use this for changes that may alter the rendered content
+// AND its line layout (todos, sizing, agents, theme, …): the next View()
+// re-probes scrollbar visibility via the two-pass render.
 func (m *model) invalidateCache() {
+	m.cacheDirty = true
+	m.layoutDirty = true
+}
+
+// invalidateAnimation marks the cache dirty for an animation-only change, i.e. a
+// spinner advancing one frame. Spinner glyphs are fixed (single-cell) width, so
+// the line count and scrollbar visibility cannot change; the next View() can
+// therefore skip the scrollbar-probe pass and render the sections only once.
+func (m *model) invalidateAnimation() {
 	m.cacheDirty = true
 }
 
@@ -827,9 +841,10 @@ func (m *model) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 			needsInvalidate = true
 		}
 
-		// Invalidate cache when spinners update to show new animation frames
+		// Invalidate cache when spinners update to show new animation frames.
+		// This is animation-only (fixed-width glyph swap), so the cheaper path is used.
 		if needsInvalidate {
-			m.invalidateCache()
+			m.invalidateAnimation()
 		}
 
 		return m, tea.Batch(cmds...)
@@ -926,6 +941,19 @@ func (m *model) verticalView() string {
 		return m.renderFromCache()
 	}
 
+	// Animation-only fast path: when only a spinner frame changed, the line count
+	// and scrollbar visibility are unchanged, so reuse the cached scrollbar
+	// decision and render the sections a single time instead of the two-pass probe.
+	if !m.layoutDirty && len(m.cachedLines) > 0 && m.cachedWidth == contentWidthNoScroll {
+		width := contentWidthNoScroll
+		if m.cachedNeedsScrollbar {
+			width = m.contentWidth(true)
+		}
+		m.cachedLines = m.renderSections(width)
+		m.cacheDirty = false
+		return m.renderFromCache()
+	}
+
 	// Two-pass rendering: first check if scrollbar is needed
 	// Pass 1: render without scrollbar to count lines
 	lines := m.renderSections(contentWidthNoScroll)
@@ -943,6 +971,7 @@ func (m *model) verticalView() string {
 	m.cachedWidth = contentWidthNoScroll
 	m.cachedNeedsScrollbar = needsScrollbar
 	m.cacheDirty = false
+	m.layoutDirty = false
 
 	return m.renderFromCache()
 }

--- a/pkg/tui/components/sidebar/streaming_perf_test.go
+++ b/pkg/tui/components/sidebar/streaming_perf_test.go
@@ -1,0 +1,138 @@
+package sidebar
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/tools/builtin/todo"
+	"github.com/docker/docker-agent/pkg/tui/animation"
+	"github.com/docker/docker-agent/pkg/tui/components/spinner"
+	"github.com/docker/docker-agent/pkg/tui/service"
+)
+
+func makeStreamingTodos(n int) []todo.Todo {
+	out := make([]todo.Todo, n)
+	statuses := []string{"pending", "in-progress", "completed"}
+	for i := range out {
+		out[i] = todo.Todo{
+			ID:          fmt.Sprintf("todo_%d", i+1),
+			Description: fmt.Sprintf("Step %d: migrate and validate component %d of the legacy system and document the rollback plan", i+1, i+1),
+			Status:      statuses[i%len(statuses)],
+		}
+	}
+	return out
+}
+
+// buildStreamingSidebar returns a sidebar in a realistic "agent is streaming"
+// state (working agent set, spinner active, token usage, two agents, a todo
+// list) with its render cache warmed.
+func buildStreamingSidebar(tb testing.TB, nTodos int) *model {
+	tb.Helper()
+	sess := session.New()
+	ss := service.NewSessionState(sess)
+	ss.SetCurrentAgentName("root")
+	m := New(ss).(*model)
+	m.SetSize(40, 30)
+	m.SetTeamInfo([]runtime.AgentDetails{
+		{Name: "root", Provider: "openai", Model: "gpt-4o", Description: "Expert developer that plans and executes migrations"},
+		{Name: "helper", Provider: "anthropic", Model: "claude-sonnet-4-0", Description: "Helper sub-agent"},
+	})
+	m.SetToolsetInfo(12, false)
+	ev := runtime.NewTokenUsageEvent(sess.ID, "root", &runtime.Usage{
+		InputTokens: 12000, OutputTokens: 8000, ContextLength: 20000, ContextLimit: 128000, Cost: 0.42,
+	})
+	m.SetTokenUsage(ev.(*runtime.TokenUsageEvent))
+	if nTodos > 0 {
+		require.NoError(tb, m.SetTodos(&tools.ToolCallResult{Meta: makeStreamingTodos(nTodos)}))
+	}
+	m.workingAgent = "root"
+	m.spinnerActive = true
+	_ = m.View() // warm cache
+	return m
+}
+
+// TestAnimationFastPathMatchesFullRebuild guarantees the animation-only render
+// fast path (single pass, reusing the cached scrollbar decision) produces byte
+// identical output to a full two-pass rebuild for the same state. The spinner
+// frame is not advanced between the two renders, so any difference would be a
+// rendering bug introduced by the optimization rather than animation.
+func TestAnimationFastPathMatchesFullRebuild(t *testing.T) {
+	t.Parallel()
+	for _, n := range []int{0, 1, 5, 50, 120, 300} {
+		t.Run(fmt.Sprintf("todos=%d", n), func(t *testing.T) {
+			t.Parallel()
+			m := buildStreamingSidebar(t, n)
+
+			// Full two-pass rebuild (hard invalidation).
+			m.invalidateCache()
+			want := m.View()
+			require.False(t, m.layoutDirty)
+
+			// Animation-only invalidation must take the single-pass fast path
+			// and yield identical output.
+			m.invalidateAnimation()
+			require.False(t, m.layoutDirty, "animation invalidation must not mark layout dirty")
+			got := m.View()
+
+			require.Equal(t, want, got)
+		})
+	}
+}
+
+// TestAnimationFastPathTracksSpinnerFrame ensures the fast path still reflects a
+// new spinner frame (it re-renders the sections, it does not freeze them).
+func TestAnimationFastPathTracksSpinnerFrame(t *testing.T) {
+	t.Parallel()
+	m := buildStreamingSidebar(t, 120)
+
+	m.invalidateCache()
+	first := m.View()
+
+	// Advance the spinner until its frame changes, as the 14 FPS tick does.
+	prev := m.spinner.RawFrame()
+	for i := 1; i <= 20 && m.spinner.RawFrame() == prev; i++ {
+		model, _ := m.spinner.Update(animation.TickMsg{Frame: i})
+		m.spinner = model.(spinner.Spinner)
+	}
+	require.NotEqual(t, prev, m.spinner.RawFrame(), "spinner should advance to a new frame")
+
+	// The animation fast path must reflect the advanced frame, not freeze it.
+	m.invalidateAnimation()
+	second := m.View()
+	require.NotEqual(t, first, second, "fast path must re-render the advanced spinner frame")
+}
+
+// BenchmarkStreamingViewAnimationFrame measures the per-frame sidebar cost with
+// the animation fast path: cache invalidated by a spinner tick every frame.
+func BenchmarkStreamingViewAnimationFrame(b *testing.B) {
+	for _, n := range []int{0, 50, 120, 300} {
+		m := buildStreamingSidebar(b, n)
+		b.Run(fmt.Sprintf("todos=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				m.invalidateAnimation()
+				_ = m.View()
+			}
+		})
+	}
+}
+
+// BenchmarkStreamingViewFullRebuild measures the previous behavior, where every
+// spinner tick forced a full two-pass rebuild.
+func BenchmarkStreamingViewFullRebuild(b *testing.B) {
+	for _, n := range []int{0, 50, 120, 300} {
+		m := buildStreamingSidebar(b, n)
+		b.Run(fmt.Sprintf("todos=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				m.invalidateCache()
+				_ = m.View()
+			}
+		})
+	}
+}


### PR DESCRIPTION
While the agent is streaming, the 14 FPS spinner tick invalidates the sidebar render cache every frame. `verticalView()` then rebuilds all sidebar sections twice — the scrollbar "two-pass" (render without scrollbar to count lines, then re-render narrower if a scrollbar is needed) — even though the only thing that changed is a single fixed-width spinner glyph.

This splits cache invalidation in two: `invalidateCache()` for changes that can alter line count or scrollbar visibility (todos, sizing, agents, theme, …), which keeps the full two-pass render, and `invalidateAnimation()` (new) for the spinner-tick path. Because spinner glyphs are fixed single-cell width, the line count and scrollbar visibility cannot change, so `verticalView()` renders the sections once, reusing the cached scrollbar decision.

Profiling the real sidebar `View()` in a streaming state showed ~60% of per-frame CPU in `lipgloss.Style.Render` and ~45% in `ansi.stringWidth`, and the cost was doubled by the redundant second pass whenever a scrollbar is present. Per-frame sidebar render cost and allocations roughly halve while streaming (Apple M4 Max): at 50 todos, 4.35 ms → 2.15 ms and 51k → 25k allocations; at 120 todos, 9.49 ms → 4.67 ms and 116k → 58k allocations; at 300 todos, 22.2 ms → 11.2 ms and 282k → 141k allocations. This stacks with caching the todo render independently.

Output is unchanged. New `TestAnimationFastPathMatchesFullRebuild` asserts the fast path is byte-identical to a full two-pass rebuild across 0–300 todos; `TestAnimationFastPathTracksSpinnerFrame` asserts the fast path still reflects the advancing spinner. New before/after benchmarks included.

Relates to #3123.