### PR TITLE
fix(runtime): finalize event channel on runStreamLoop early returns

### DIFF
--- a/pkg/runtime/elicitation_test.go
+++ b/pkg/runtime/elicitation_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -9,6 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/hooks"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/team"
 )
@@ -231,6 +234,72 @@ func TestLocalRuntime_FinalizeEventChannelDoesNotDeadlockWhenBufferFullAndConsum
 		}
 	}
 	assert.Zero(t, stopped, "StreamStopped should be dropped instead of blocking when the buffer is full")
+}
+
+// TestRunStreamClosesChannelAndRestoresElicitationOnEarlyReturn is the
+// regression test for issue #3073: runStreamLoop swapped this stream's
+// events channel into the elicitation bridge before registering the
+// finalize defer, so the early-return paths (tool setup failure, a
+// user_prompt_submit hook signalling termination) exited without closing
+// the events channel or restoring the bridge. A `for range RunStream(...)`
+// consumer then hung forever and the bridge kept pointing at the dead
+// stream's channel.
+//
+// We drive the reachable early return — a user_prompt_submit hook that
+// stops the run — and assert the consumer's range terminates and the
+// previously-swapped elicitation channel is restored.
+func TestRunStreamClosesChannelAndRestoresElicitationOnEarlyReturn(t *testing.T) {
+	t.Parallel()
+
+	const hookName = "test-stop-user-prompt-submit"
+	dontContinue := false
+
+	root := agent.New("root", "test agent",
+		agent.WithModel(&mockProvider{id: "test/mock-model"}),
+		agent.WithHooks(&latest.HooksConfig{
+			UserPromptSubmit: []latest.HookDefinition{
+				{Type: "builtin", Command: hookName},
+			},
+		}),
+	)
+	rt, err := NewLocalRuntime(team.New(team.WithAgents(root)),
+		WithSessionCompaction(false),
+		WithModelStore(mockModelStore{}),
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, rt.hooksRegistry.RegisterBuiltin(
+		hookName,
+		func(_ context.Context, _ *hooks.Input, _ []string) (*hooks.Output, error) {
+			return &hooks.Output{Continue: &dontContinue, StopReason: "stop the run"}, nil
+		},
+	))
+
+	// Seed a sentinel "parent" elicitation channel. After the stream tears
+	// down, the bridge must be restored to this channel — not left pointing
+	// at the stream's own (now closed) events channel.
+	parent := make(chan Event, 1)
+	rt.elicitation.swap(parent)
+
+	sess := session.New(session.WithUserMessage("hi"))
+	sess.Title = "Unit Test"
+
+	drained := make(chan struct{})
+	go func() {
+		defer close(drained)
+		for range rt.RunStream(t.Context(), sess) { //nolint:revive // draining the stream is the point
+		}
+	}()
+
+	select {
+	case <-drained:
+	case <-time.After(5 * time.Second):
+		t.Fatal("RunStream consumer hung: events channel was never closed on the hook-driven early return")
+	}
+
+	restored := rt.elicitation.swap(nil)
+	assert.Equal(t, parent, restored,
+		"the previous elicitation channel must be restored on the early-return path")
 }
 
 func newElicitationTestRuntime(t *testing.T) *LocalRuntime {

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -227,6 +227,22 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 	// parent's channel.
 	prevElicitationCh := r.elicitation.swap(events)
 
+	// streamReason records the exit reason from the final turn so
+	// finalizeEventChannel can surface it in the StreamStoppedEvent.
+	// It is updated by each turn via runTurn (passed by pointer).
+	//
+	// Register the cleanup defer immediately after the swap so every exit
+	// path finalizes, including the early returns below (tool setup
+	// failure, a user_prompt_submit hook signalling termination). Without
+	// this, those early returns leak the events channel: observe's
+	// forwarder goroutine never exits, a `for range RunStream(...)`
+	// consumer hangs forever, and the elicitation bridge is left pointing
+	// at this dead stream's channel.
+	var streamReason string
+	defer func() {
+		r.finalizeEventChannel(ctx, sess, streamReason, prevElicitationCh, events)
+	}()
+
 	a := r.resolveSessionAgent(sess)
 
 	// session_start fires once per RunStream. Its AdditionalContext
@@ -280,14 +296,6 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 	}
 
 	sink.Emit(StreamStarted(sess.ID, a.Name()))
-
-	// streamReason records the exit reason from the final turn so
-	// finalizeEventChannel can surface it in the StreamStoppedEvent.
-	// It is updated by each turn via runTurn (passed by pointer).
-	var streamReason string
-	defer func() {
-		r.finalizeEventChannel(ctx, sess, streamReason, prevElicitationCh, events)
-	}()
 
 	if a.HasHarness() {
 		streamReason = r.runHarnessAgent(ctx, sess, a, slices.Concat(ls.sessionStartMsgs, ls.userPromptMsgs), sink)


### PR DESCRIPTION
Fixes #3073

## Problem

`runStreamLoop` swaps this stream's events channel into the elicitation bridge **before** the `finalizeEventChannel` cleanup defer is registered. Two early-return paths sit in that gap:

- `getTools` failure
- a `user_prompt_submit` hook signalling termination

On those paths the stream exits without closing the events channel or restoring the bridge:

- `observe`'s forwarder goroutine (`for event := range inner`) never exits, so a `for range RunStream(...)` consumer hangs forever
- the elicitation bridge stays pointing at the dead stream's channel
- for nested streams, the parent's elicitation channel is never restored

## Fix

Register the cleanup defer immediately after the swap, so every exit path finalizes. `finalizeEventChannel` is already safe on these early paths (it emits `StreamStopped` non-blockingly and closes last, since #3070). The `streamReason` declaration just moves up with the defer.

## Test

Added a regression test (`TestRunStreamClosesChannelAndRestoresElicitationOnEarlyReturn`) that drives the reachable early return (a `user_prompt_submit` hook that stops the run) and asserts the consumer's range terminates and the previous elicitation channel is restored. Confirmed it hangs/fails without the fix.

Note: the `getTools` early return is not easily reachable today since `collectTools` swallows toolset listing errors, so the test exercises the hook-stop path. The same defer covers both.

## Checks

- `go build ./...`
- `go test -race ./pkg/runtime/ ./pkg/app/ ./pkg/a2a/ ./pkg/tui/...` all pass
- verified consumers of `StreamStopped` (sidebar, chat page, supervisor, a2a adapter) handle a stop without a preceding `StreamStarted` safely