### PR TITLE
fix(skills): discover .agents/skills in non-git grouping parents

### DIFF
--- a/pkg/runtime/elicitation_test.go
+++ b/pkg/runtime/elicitation_test.go
@@ -287,7 +287,7 @@ func TestRunStreamClosesChannelAndRestoresElicitationOnEarlyReturn(t *testing.T)
 	drained := make(chan struct{})
 	go func() {
 		defer close(drained)
-		for range rt.RunStream(t.Context(), sess) { //nolint:revive // draining the stream is the point
+		for range rt.RunStream(t.Context(), sess) {
 		}
 	}()
 

--- a/pkg/skills/local.go
+++ b/pkg/skills/local.go
@@ -43,7 +43,8 @@ type localSearchPath struct {
 //
 //  1. Global directories (under $HOME).
 //  2. .claude/skills under cwd (Claude project format, flat).
-//  3. .agents/skills from the git root down to cwd (closest wins).
+//  3. .agents/skills in each ancestor of cwd up to $HOME — or the enclosing
+//     git root when cwd is outside $HOME — down to cwd (closest wins).
 func localSearchPaths() []localSearchPath {
 	if kit := os.Getenv(KitDirEnv); kit != "" {
 		return []localSearchPath{{filepath.Join(kit, KitSkillsSubdir), true}}
@@ -101,42 +102,62 @@ func homeSkillSearchPaths(home string) []localSearchPath {
 	}
 }
 
-// projectSearchDirs returns directories from the enclosing git root down to
-// cwd (inclusive), ordered from root to cwd. If cwd is not inside a git
-// repository, it returns just cwd.
+// projectSearchDirs returns the directories to scan for repo-local
+// .agents/skills, ordered from the topmost ancestor down to cwd (inclusive).
+// Ordering matters: later (deeper) entries override skills from parents, so a
+// project subdirectory can shadow a skill defined higher up.
 //
-// The ordering matters: later (deeper) entries override skills from parents,
-// so a project subdirectory can shadow a skill defined at the repo root.
+// When cwd is inside $HOME the walk climbs all the way up to (but not
+// including) $HOME. This makes a .agents/skills placed in a non-git "grouping"
+// directory — e.g. ~/work/org holding several independent repos — reachable
+// from inside any sub-repo, instead of being hidden by the sub-repo's own
+// .git. $HOME itself is excluded because ~/.agents/skills is already scanned
+// as a global path.
+//
+// When cwd is outside $HOME (or is $HOME itself) the walk is anchored at the
+// enclosing git root, so discovery never climbs into system directories.
 func projectSearchDirs(cwd string) []string {
 	abs, err := filepath.Abs(cwd)
 	if err != nil {
 		return []string{cwd}
 	}
 
-	// Walk up from cwd, recording each dir, until we either hit a git
-	// marker or run out of parents. This collects findGitRoot's result
-	// and the dir list in a single traversal.
+	// Walk up to $HOME only when cwd is inside it (and not $HOME itself, which
+	// is already covered by the global ~/.agents/skills scan).
+	if home := paths.GetHomeDir(); home != "" && abs != home && pathx.IsWithin(abs, home) {
+		var dirs []string
+		for current := abs; current != home; {
+			dirs = append(dirs, current)
+			parent := filepath.Dir(current)
+			if parent == current {
+				break
+			}
+			current = parent
+		}
+		slices.Reverse(dirs)
+		return dirs
+	}
+
+	return gitAnchoredDirs(abs)
+}
+
+// gitAnchoredDirs returns the directories from the enclosing git root down to
+// abs (inclusive), ordered root-to-abs, or just abs when it is not inside a git
+// repository.
+func gitAnchoredDirs(abs string) []string {
 	var dirs []string
-	var gitRoot string
 	for current := abs; ; {
 		dirs = append(dirs, current)
 		if hasGitMarker(current) {
-			gitRoot = current
-			break
+			slices.Reverse(dirs)
+			return dirs
 		}
 		parent := filepath.Dir(current)
 		if parent == current {
-			break
+			return []string{abs}
 		}
 		current = parent
 	}
-
-	if gitRoot == "" {
-		return []string{abs}
-	}
-
-	slices.Reverse(dirs)
-	return dirs
 }
 
 // hasGitMarker reports whether dir contains a .git directory or .git file

--- a/pkg/skills/skills.go
+++ b/pkg/skills/skills.go
@@ -60,7 +60,8 @@ func (s Skill) IsFork() bool {
 //
 // Project locations (under cwd, closest wins):
 //   - .claude/skills/ (flat, only at cwd)
-//   - .agents/skills/ (flat, scanned from git root to cwd)
+//   - .agents/skills/ (flat, scanned from each ancestor up to $HOME — or the
+//     enclosing git root outside $HOME — down to cwd)
 //
 // The returned slice is sorted by skill name for deterministic ordering.
 func Load(sources []string) []Skill {

--- a/pkg/skills/skills_test.go
+++ b/pkg/skills/skills_test.go
@@ -579,6 +579,95 @@ description: A skill from repo root
 	assert.True(t, found, "Expected to find repo-skill from .agents/skills at git root")
 }
 
+func TestLoad_AgentsSkillsFromNonGitGroupingParent(t *testing.T) {
+	// Reproduces #3056: several independent repos grouped under a non-git
+	// parent, with a shared skill at the grouping root's .agents/skills. It
+	// must be discoverable from inside any sub-repo, not just from the
+	// grouping root itself.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Grouping root (~/org) is NOT a git repo and holds a cross-repo skill.
+	groupingSkillDir := filepath.Join(home, "org", ".agents", "skills", "services")
+	require.NoError(t, os.MkdirAll(groupingSkillDir, 0o755))
+	groupingContent := `---
+name: services
+description: Cross-repo helper skill
+---
+
+# Services
+`
+	require.NoError(t, os.WriteFile(filepath.Join(groupingSkillDir, "SKILL.md"), []byte(groupingContent), 0o644))
+
+	// An independent sub-repo where work actually happens.
+	repo := filepath.Join(home, "org", "docker-agent")
+	workdir := filepath.Join(repo, "pkg", "skills")
+	require.NoError(t, os.MkdirAll(workdir, 0o755))
+	require.NoError(t, os.Mkdir(filepath.Join(repo, ".git"), 0o755))
+	t.Chdir(workdir)
+
+	skills := Load([]string{"local"})
+
+	found := false
+	for _, s := range skills {
+		if s.Name == "services" {
+			found = true
+			assert.Equal(t, "Cross-repo helper skill", s.Description)
+			assert.Equal(t, filepath.Join(groupingSkillDir, "SKILL.md"), s.FilePath)
+			break
+		}
+	}
+	assert.True(t, found, "grouping-level skill must be discoverable from inside a sub-repo")
+}
+
+func TestLoad_AgentsSkillsPrecedence_GroupingOverridesGlobal(t *testing.T) {
+	// Same skill name in ~/.agents/skills (global) and in a non-git grouping
+	// parent. From inside a sub-repo the grouping version is closer to cwd and
+	// must win over the global one.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	globalSkillDir := filepath.Join(home, ".agents", "skills", "shared-skill")
+	require.NoError(t, os.MkdirAll(globalSkillDir, 0o755))
+	globalContent := `---
+name: shared-skill
+description: Global version
+---
+
+# Global
+`
+	require.NoError(t, os.WriteFile(filepath.Join(globalSkillDir, "SKILL.md"), []byte(globalContent), 0o644))
+
+	groupingSkillDir := filepath.Join(home, "org", ".agents", "skills", "shared-skill")
+	require.NoError(t, os.MkdirAll(groupingSkillDir, 0o755))
+	groupingContent := `---
+name: shared-skill
+description: Grouping version
+---
+
+# Grouping
+`
+	require.NoError(t, os.WriteFile(filepath.Join(groupingSkillDir, "SKILL.md"), []byte(groupingContent), 0o644))
+
+	repo := filepath.Join(home, "org", "repo")
+	require.NoError(t, os.MkdirAll(repo, 0o755))
+	require.NoError(t, os.Mkdir(filepath.Join(repo, ".git"), 0o755))
+	t.Chdir(repo)
+
+	skills := Load([]string{"local"})
+
+	found := false
+	for _, s := range skills {
+		if s.Name == "shared-skill" {
+			found = true
+			assert.Equal(t, "Grouping version", s.Description)
+			assert.Equal(t, filepath.Join(groupingSkillDir, "SKILL.md"), s.FilePath)
+			break
+		}
+	}
+	assert.True(t, found, "grouping-parent skill must override the global one")
+}
+
 func TestLoad_AgentsSkillsPrecedence_ProjectOverridesGlobal(t *testing.T) {
 	// Create a temp home directory with a global skill
 	tmpHome := t.TempDir()
@@ -808,5 +897,28 @@ func TestProjectSearchDirs(t *testing.T) {
 
 		require.Len(t, dirs, 1)
 		assert.Equal(t, tmpRepo, dirs[0])
+	})
+
+	t.Run("under home walks past git root up to but not including home", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+
+		// A sub-repo (its own .git) inside a non-git grouping parent.
+		repo := filepath.Join(home, "org", "repo")
+		require.NoError(t, os.MkdirAll(filepath.Join(repo, ".git"), 0o755))
+		nested := filepath.Join(repo, "pkg", "skills")
+		require.NoError(t, os.MkdirAll(nested, 0o755))
+
+		dirs := projectSearchDirs(nested)
+
+		// The git boundary is ignored: every dir from the child of $HOME
+		// down to cwd is included, so the grouping parent (org) is reachable.
+		assert.Equal(t, []string{
+			filepath.Join(home, "org"),
+			repo,
+			filepath.Join(repo, "pkg"),
+			nested,
+		}, dirs)
+		assert.NotContains(t, dirs, home, "$HOME itself must be excluded")
 	})
 }


### PR DESCRIPTION
## What

`projectSearchDirs` stopped at the nearest `.git` when walking up from cwd, so a `.agents/skills` placed in a non-git "grouping" parent (e.g. `~/work/org` holding several independent repos) was invisible from inside any sub-repo. See #3056.

When cwd is inside `$HOME`, the search now walks up to (but not including) `$HOME` instead of stopping at the git root, so grouping-level skills are reachable from any sub-repo. `$HOME` itself is excluded because `~/.agents/skills` is already scanned as a global path.

## Design choice

The issue lists three options for maintainers to weigh. This PR takes option 1 (walk past the git root, with `$HOME` as the ceiling) plus the documentation fix. Reasoning for picking it over the others:

- Option 3 (document only) does not fix discovery, it just records the blind spot. The issue's intent is that a shared skill be available from any repo, and documentation alone does not make that true.
- Option 2 (env var / config search root) does fix it, but requires manual configuration of an extra root and introduces a new config surface (variable naming, plumbing, docs) that does not exist yet.
- Option 1 fits what the code already does: it extends the existing "closest wins" walk from root to cwd rather than adding a new mechanism. The `$HOME` ceiling is natural because `~/.agents/skills` is already the global path, so option 1 slots cleanly between global home skills and repo skills. It is also the smallest change for the value (one function, no new API or config).

If option 2 seems more appropriate, it can always be changed.

Precedence is unchanged for existing skills: ancestors are lower priority than deeper dirs, so a repo-level skill still wins (closest-to-cwd wins).

## Known boundary

When cwd is outside `$HOME` (e.g. `/opt/work/org/repo`), discovery stays anchored at the git root so it never climbs into system dirs like `/opt` or `/`. The issue only describes layouts under `$HOME`, so this is intentional rather than a gap.

## Tests

- `TestProjectSearchDirs/under_home_walks_past_git_root...`
- `TestLoad_AgentsSkillsFromNonGitGroupingParent` (reproduces the issue end to end)
- `TestLoad_AgentsSkillsPrecedence_GroupingOverridesGlobal`

All existing skills tests still pass.

Closes #3056