### PR TITLE
Disable old tool-call truncation by default

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -603,7 +603,7 @@
         },
         "max_old_tool_call_tokens": {
           "type": "integer",
-          "description": "Maximum number of tokens to keep from old tool call arguments and results. Older tool calls beyond this budget will have their content replaced with a placeholder. Tokens are approximated as len/4. Set to -1 to disable truncation (unlimited tool content). Default: 40000.",
+          "description": "Maximum number of tokens to keep from old tool call arguments and results. Older tool calls beyond this budget will have their content replaced with a placeholder. Tokens are approximated as len/4. Truncation is disabled by default; set a positive value to enable it. Set to -1 to disable truncation (unlimited tool content).",
           "minimum": -1
         },
         "num_history_items": {

--- a/docs/configuration/agents/index.md
+++ b/docs/configuration/agents/index.md
@@ -31,7 +31,7 @@ agents:
     code_mode_tools: boolean # Optional: enable code mode tool format
     max_iterations: int # Optional: max tool-calling loops
     max_consecutive_tool_calls: int # Optional: max identical consecutive tool calls
-    max_old_tool_call_tokens: int # Optional: token budget for old tool call content
+    max_old_tool_call_tokens: int # Optional: token budget for old tool call content (disabled unless positive)
     num_history_items: int # Optional: limit conversation history
     skills: boolean | [list] # Optional: enable skill discovery (true/false or list of names and/or sources)
     use_commands: [list] # Optional: names of top-level commands groups to merge into this agent
@@ -91,7 +91,7 @@ agents:
 | `code_mode_tools`           | boolean | ✗        | When `true`, formats tool responses in a code-optimized format with structured output schemas. Useful for MCP gateway and programmatic access.                                |
 | `max_iterations`            | int     | ✗        | Maximum number of tool-calling loops. Default: unlimited (0). Set this to prevent infinite loops.                                                                             |
 | `max_consecutive_tool_calls` | int     | ✗        | Maximum consecutive identical tool calls before the agent is terminated, preventing degenerate loops. Default: `5`.                                                          |
-| `max_old_tool_call_tokens`  | int     | ✗        | Maximum number of tokens to keep from old tool call arguments and results. Older tool calls beyond this budget have their content replaced with a placeholder, saving context space. Tokens are approximated as `len/4`. Set to `-1` to disable truncation (unlimited). Default: `40000`. |
+| `max_old_tool_call_tokens`  | int     | ✗        | Maximum number of tokens to keep from old tool call arguments and results. Older tool calls beyond this budget have their content replaced with a placeholder, saving context space. Tokens are approximated as `len/4`. Truncation is disabled by default; set a positive value to enable it. Set to `-1` to disable truncation (unlimited). |
 | `num_history_items`         | int     | ✗        | Limit the number of conversation history messages sent to the model. Useful for managing context window size with long conversations. Default: unlimited (all messages sent). |
 | `skills`                    | bool/array | ✗     | Enable automatic skill discovery. `true` loads all discovered local skills, `false` disables them. A list can mix skill sources (`local` or `https://…` URLs) and skill names to include — see [Skills]({{ '/features/skills/' | relative_url }}).                                                     |
 | `commands`                  | object  | ✗        | Named prompts that can be run with `docker agent run config.yaml /command_name`. Can be simple strings or objects with `instruction` and/or `agent` fields for agent switching. See [Named Commands](#named-commands) below. |

--- a/pkg/agent/opts.go
+++ b/pkg/agent/opts.go
@@ -167,8 +167,7 @@ func WithMaxConsecutiveToolCalls(n int) Opt {
 }
 
 // WithMaxOldToolCallTokens sets the maximum token budget for old tool call content.
-// Set to -1 to disable truncation (unlimited tool content).
-// Set to 0 to use the default (40000).
+// Positive values enable truncation; 0 and -1 disable truncation (unlimited tool content).
 func WithMaxOldToolCallTokens(n int) Opt {
 	return func(a *Agent) {
 		a.maxOldToolCallTokens = n

--- a/pkg/session/get_messages_tool_truncation_test.go
+++ b/pkg/session/get_messages_tool_truncation_test.go
@@ -1,0 +1,75 @@
+package session
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+func TestGetMessagesMaxOldToolCallTokensDefaultDoesNotTruncate(t *testing.T) {
+	oldResult := strings.Repeat("old-result-", 15000)
+	newResult := "new result"
+
+	s := New()
+	addToolExchange(s, "old", oldResult)
+	addToolExchange(s, "new", newResult)
+
+	messages := s.GetMessages(agent.New("test-agent", "test instruction"))
+
+	assert.Equal(t, oldResult, toolResultContent(t, messages, "old"))
+	assert.Equal(t, newResult, toolResultContent(t, messages, "new"))
+}
+
+func TestGetMessagesMaxOldToolCallTokensPositiveTruncatesOldContent(t *testing.T) {
+	oldResult := strings.Repeat("old-result-", 15000)
+	newResult := "new result"
+
+	s := New(WithMaxOldToolCallTokens(10))
+	addToolExchange(s, "old", oldResult)
+	addToolExchange(s, "new", newResult)
+
+	messages := s.GetMessages(agent.New("test-agent", "test instruction"))
+
+	assert.Equal(t, toolContentPlaceholder, toolResultContent(t, messages, "old"))
+	assert.Equal(t, newResult, toolResultContent(t, messages, "new"))
+}
+
+func addToolExchange(s *Session, toolCallID, result string) {
+	s.AddMessage(UserMessage("run " + toolCallID))
+	s.AddMessage(NewAgentMessage("test-agent", &chat.Message{
+		Role: chat.MessageRoleAssistant,
+		ToolCalls: []tools.ToolCall{
+			{
+				ID: toolCallID,
+				Function: tools.FunctionCall{
+					Name:      "test_tool",
+					Arguments: `{"input":"` + toolCallID + `"}`,
+				},
+			},
+		},
+	}))
+	s.AddMessage(NewAgentMessage("test-agent", &chat.Message{
+		Role:       chat.MessageRoleTool,
+		ToolCallID: toolCallID,
+		Content:    result,
+	}))
+}
+
+func toolResultContent(t *testing.T, messages []chat.Message, toolCallID string) string {
+	t.Helper()
+
+	for _, msg := range messages {
+		if msg.Role == chat.MessageRoleTool && msg.ToolCallID == toolCallID {
+			return msg.Content
+		}
+	}
+
+	require.Failf(t, "tool result not found", "tool_call_id=%s", toolCallID)
+	return ""
+}

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -27,12 +27,6 @@ var nowFn = time.Now
 var newIDFn = func() string { return uuid.New().String() }
 
 const (
-	// DefaultMaxOldToolCallTokens is the default maximum number of tokens to keep from tool call
-	// arguments and results. Older tool calls beyond this budget will have their
-	// content replaced with a placeholder. Tokens are approximated by
-	// approximateTokens (len/4).
-	DefaultMaxOldToolCallTokens = 40000
-
 	// toolContentPlaceholder is the text used to replace truncated tool content
 	toolContentPlaceholder = "[content truncated]"
 )
@@ -128,9 +122,8 @@ type Session struct {
 	// MaxOldToolCallTokens is the maximum number of tokens to keep from old tool call
 	// arguments and results. Older tool calls beyond this budget will have their
 	// content replaced with a placeholder. Tokens are approximated by
-	// approximateTokens (len/4).
-	// Set to -1 to disable truncation (unlimited tool content).
-	// Default: 40000 (when not configured or set to 0).
+	// approximateTokens (len/4). Truncation is enabled only when this is positive;
+	// 0 (unset) and -1 both disable truncation (unlimited tool content).
 	MaxOldToolCallTokens int `json:"max_old_tool_call_tokens,omitempty"`
 
 	// Starred indicates if this session has been starred by the user
@@ -686,8 +679,7 @@ func WithMaxConsecutiveToolCalls(n int) Opt {
 }
 
 // WithMaxOldToolCallTokens sets the maximum token budget for old tool call content.
-// Set to -1 to disable truncation (unlimited tool content).
-// Set to 0 to use the default (40000).
+// Positive values enable truncation; 0 and -1 disable truncation (unlimited tool content).
 func WithMaxOldToolCallTokens(n int) Opt {
 	return func(s *Session) {
 		s.MaxOldToolCallTokens = n
@@ -1108,14 +1100,10 @@ func (s *Session) GetMessages(a *agent.Agent, extraSystemMessages ...chat.Messag
 		messages = trimMessages(messages, maxItems)
 	}
 
-	// Use configured max tokens or fall back to default constant if zero or unset.
-	// -1 means unlimited (no truncation).
-	maxOldToolCallTokens := s.MaxOldToolCallTokens
-	if maxOldToolCallTokens == 0 {
-		maxOldToolCallTokens = DefaultMaxOldToolCallTokens
-	}
-	if maxOldToolCallTokens > 0 { // If maxOldToolCallTokens is -1, skip truncation (unlimited)
-		messages = truncateOldToolContent(messages, maxOldToolCallTokens)
+	// Truncation of old tool-call content is opt-in: only a positive token
+	// budget truncates. 0 (unset/omitted) and -1 both disable truncation.
+	if s.MaxOldToolCallTokens > 0 {
+		messages = truncateOldToolContent(messages, s.MaxOldToolCallTokens)
 	}
 
 	messages = normalizeMessageContent(messages)


### PR DESCRIPTION
- Changes old tool-call truncation to opt-in: `0`/omitted now disables truncation, `-1` remains disabled, positive values still truncate.
- Removes the unused `DefaultMaxOldToolCallTokens` constant and updates comments, schema, and docs to match the new semantics.
- Adds a `Session.GetMessages` regression test covering the default no-truncation path and positive-budget truncation.
- Behavior change: agents relying on the implicit 40000-token cap will now keep full tool history unless they configure `max_old_tool_call_tokens`.

Validation:
- `task build`
- `task test`
- `task lint`
