### PR TITLE
fix(acp): respect workspace roots for Zed paths

### DIFF
--- a/pkg/acp/agent.go
+++ b/pkg/acp/agent.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,6 +15,7 @@ import (
 	"github.com/coder/acp-go-sdk"
 
 	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/session"
@@ -29,20 +31,22 @@ type Agent struct {
 	sessionStore session.Store
 	sessions     map[string]*Session
 
-	conn *acp.AgentSideConnection
-	team *team.Team
-	mu   sync.Mutex
+	conn     *acp.AgentSideConnection
+	clientFS acp.FileSystemCapabilities
+	team     *team.Team
+	mu       sync.Mutex
 }
 
 var _ acp.Agent = (*Agent)(nil)
 
 // Session represents an ACP session.
 type Session struct {
-	id         string
-	sess       *session.Session
-	rt         runtime.Runtime
-	cancel     context.CancelFunc
-	workingDir string
+	id             string
+	sess           *session.Session
+	rt             runtime.Runtime
+	cancel         context.CancelFunc
+	workingDir     string
+	additionalDirs []string
 }
 
 // NewAgent creates a new ACP agent.
@@ -76,6 +80,7 @@ func (a *Agent) Initialize(ctx context.Context, params acp.InitializeRequest) (a
 	slog.DebugContext(ctx, "ACP Initialize called", "client_version", params.ProtocolVersion)
 
 	a.mu.Lock()
+	a.clientFS = params.ClientCapabilities.Fs
 	defer a.mu.Unlock()
 	t, err := teamloader.Load(ctx, a.agentSource, a.runConfig, teamloader.WithToolsetRegistry(createToolsetRegistry(a)))
 	if err != nil {
@@ -95,13 +100,14 @@ func (a *Agent) Initialize(ctx context.Context, params acp.InitializeRequest) (a
 		AgentCapabilities: acp.AgentCapabilities{
 			LoadSession: false,
 			SessionCapabilities: acp.SessionCapabilities{
-				Close:  &acp.SessionCloseCapabilities{},
-				List:   &acp.SessionListCapabilities{},
-				Resume: &acp.SessionResumeCapabilities{},
+				AdditionalDirectories: &acp.SessionAdditionalDirectoriesCapabilities{},
+				Close:                 &acp.SessionCloseCapabilities{},
+				List:                  &acp.SessionListCapabilities{},
+				Resume:                &acp.SessionResumeCapabilities{},
 			},
 			PromptCapabilities: acp.PromptCapabilities{
 				EmbeddedContext: true,
-				Image:           false, // Not yet supported
+				Image:           true,
 				Audio:           false, // Not yet supported
 			},
 			McpCapabilities: acp.McpCapabilities{
@@ -113,7 +119,7 @@ func (a *Agent) Initialize(ctx context.Context, params acp.InitializeRequest) (a
 }
 
 // newRuntime creates a new runtime using the default agent.
-func (a *Agent) newRuntime() (runtime.Runtime, *agent.Agent, error) {
+func (a *Agent) newRuntime(workingDir string) (runtime.Runtime, *agent.Agent, error) {
 	if a.team == nil {
 		return nil, nil, errors.New("agent not initialized")
 	}
@@ -123,10 +129,15 @@ func (a *Agent) newRuntime() (runtime.Runtime, *agent.Agent, error) {
 		return nil, nil, fmt.Errorf("failed to resolve default agent: %w", err)
 	}
 
-	rt, err := runtime.New(a.team,
+	opts := []runtime.Opt{
 		runtime.WithCurrentAgent(defaultAgent.Name()),
 		runtime.WithSessionStore(a.sessionStore),
-	)
+	}
+	if workingDir != "" {
+		opts = append(opts, runtime.WithWorkingDir(workingDir))
+	}
+
+	rt, err := runtime.New(a.team, opts...)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -171,17 +182,16 @@ func (a *Agent) NewSession(ctx context.Context, params acp.NewSessionRequest) (a
 	// An empty cwd is allowed: clients (e.g. zed) may not always supply a
 	// working directory at session creation. We persist it as empty and
 	// later prompts/tools fall back to the agent's default working dir.
-	if workingDir != "" {
-		info, err := os.Stat(workingDir)
-		if err != nil {
-			return acp.NewSessionResponse{}, fmt.Errorf("working directory does not exist: %w", err)
-		}
-		if !info.IsDir() {
-			return acp.NewSessionResponse{}, errors.New("working directory must be a directory")
-		}
+	if err := validateWorkingDir(workingDir); err != nil {
+		return acp.NewSessionResponse{}, err
 	}
 
-	rt, defaultAgent, err := a.newRuntime()
+	additionalDirs, err := resolveAdditionalDirectories(params.AdditionalDirectories)
+	if err != nil {
+		return acp.NewSessionResponse{}, err
+	}
+
+	rt, defaultAgent, err := a.newRuntime(workingDir)
 	if err != nil {
 		return acp.NewSessionResponse{}, err
 	}
@@ -201,10 +211,11 @@ func (a *Agent) NewSession(ctx context.Context, params acp.NewSessionRequest) (a
 	slog.DebugContext(ctx, "ACP session created", "session_id", sess.ID)
 
 	a.registerSession(&Session{
-		id:         sess.ID,
-		sess:       sess,
-		rt:         rt,
-		workingDir: workingDir,
+		id:             sess.ID,
+		sess:           sess,
+		rt:             rt,
+		workingDir:     workingDir,
+		additionalDirs: additionalDirs,
 	})
 
 	return acp.NewSessionResponse{SessionId: acp.SessionId(sess.ID)}, nil
@@ -225,7 +236,7 @@ func (a *Agent) Logout(ctx context.Context, _ acp.LogoutRequest) (acp.LogoutResp
 // LoadSession implements [acp.AgentLoader] (optional, not supported).
 func (a *Agent) LoadSession(ctx context.Context, _ acp.LoadSessionRequest) (acp.LoadSessionResponse, error) {
 	slog.DebugContext(ctx, "ACP LoadSession called (not supported)")
-	return acp.LoadSessionResponse{}, errors.New("load session not supported")
+	return acp.LoadSessionResponse{}, acp.NewMethodNotFound(acp.AgentMethodSessionLoad)
 }
 
 // CloseSession implements [acp.Agent].
@@ -258,9 +269,12 @@ func (a *Agent) ListSessions(ctx context.Context, _ acp.ListSessionsRequest) (ac
 
 	sessions := make([]acp.SessionInfo, 0, len(summaries))
 	for _, s := range summaries {
+		cwd, additionalDirs := a.sessionListPaths(ctx, s.ID)
 		info := acp.SessionInfo{
-			SessionId: acp.SessionId(s.ID),
-			Title:     &s.Title,
+			SessionId:             acp.SessionId(s.ID),
+			Title:                 &s.Title,
+			Cwd:                   cwd,
+			AdditionalDirectories: additionalDirs,
 		}
 		if !s.CreatedAt.IsZero() {
 			// We don't track session updates yet, so report CreatedAt in
@@ -295,11 +309,19 @@ func (a *Agent) ResumeSession(ctx context.Context, params acp.ResumeSessionReque
 	if err != nil {
 		return acp.ResumeSessionResponse{}, err
 	}
+	if err := validateWorkingDir(workingDir); err != nil {
+		return acp.ResumeSessionResponse{}, err
+	}
 	if workingDir != "" {
 		sess.WorkingDir = workingDir
 	}
 
-	rt, _, err := a.newRuntime()
+	additionalDirs, err := resolveAdditionalDirectories(params.AdditionalDirectories)
+	if err != nil {
+		return acp.ResumeSessionResponse{}, err
+	}
+
+	rt, _, err := a.newRuntime(sess.WorkingDir)
 	if err != nil {
 		return acp.ResumeSessionResponse{}, err
 	}
@@ -308,10 +330,11 @@ func (a *Agent) ResumeSession(ctx context.Context, params acp.ResumeSessionReque
 	// the same session id between our initial check and now, drop the
 	// runtime we just built and reuse the existing registration.
 	_, stored := a.registerSessionIfAbsent(&Session{
-		id:         sid,
-		sess:       sess,
-		rt:         rt,
-		workingDir: workingDir,
+		id:             sid,
+		sess:           sess,
+		rt:             rt,
+		workingDir:     sess.WorkingDir,
+		additionalDirs: additionalDirs,
 	})
 	if !stored {
 		slog.DebugContext(ctx, "ACP session already registered, reusing existing", "session_id", sid)
@@ -326,7 +349,7 @@ func (a *Agent) ResumeSession(ctx context.Context, params acp.ResumeSessionReque
 // SetSessionConfigOption implements [acp.Agent] (optional, not advertised in capabilities).
 func (a *Agent) SetSessionConfigOption(ctx context.Context, _ acp.SetSessionConfigOptionRequest) (acp.SetSessionConfigOptionResponse, error) {
 	slog.DebugContext(ctx, "ACP SetSessionConfigOption called (not supported)")
-	return acp.SetSessionConfigOptionResponse{}, nil
+	return acp.SetSessionConfigOptionResponse{}, acp.NewMethodNotFound(acp.AgentMethodSessionSetConfigOption)
 }
 
 // Cancel implements [acp.Agent].
@@ -373,9 +396,9 @@ func (a *Agent) Prompt(ctx context.Context, params acp.PromptRequest) (acp.Promp
 	acpSess.cancel = cancel
 	a.mu.Unlock()
 
-	userContent := a.buildUserContent(ctx, sid, params.Prompt)
-	if userContent != "" {
-		acpSess.sess.AddMessage(session.UserMessage(userContent))
+	userMsg := a.buildUserMessage(ctx, sid, params.Prompt)
+	if userMsg != nil && (userMsg.Message.Content != "" || len(userMsg.Message.MultiContent) > 0) {
+		acpSess.sess.AddMessage(userMsg)
 	}
 
 	if err := a.runAgent(turnCtx, acpSess); err != nil {
@@ -394,74 +417,146 @@ func (a *Agent) Prompt(ctx context.Context, params acp.PromptRequest) (acp.Promp
 
 // buildUserContent constructs user message text from ACP content blocks.
 func (a *Agent) buildUserContent(ctx context.Context, sessionID string, prompt []acp.ContentBlock) string {
-	var parts []string
+	msg := a.buildUserMessage(ctx, sessionID, prompt)
+	if msg == nil {
+		return ""
+	}
+	return msg.Message.Content
+}
+
+func (a *Agent) buildUserMessage(ctx context.Context, sessionID string, prompt []acp.ContentBlock) *session.Message {
+	var (
+		parts          []string
+		multiContent   []chat.MessagePart
+		hasRichContent bool
+	)
+
+	appendText := func(text string) {
+		if text == "" {
+			return
+		}
+		parts = append(parts, text)
+		multiContent = append(multiContent, chat.MessagePart{Type: chat.MessagePartTypeText, Text: text})
+	}
 
 	for _, content := range prompt {
 		switch {
 		case content.Text != nil:
-			parts = append(parts, content.Text.Text)
+			appendText(content.Text.Text)
 
 		case content.ResourceLink != nil:
 			rl := content.ResourceLink
 			slog.DebugContext(ctx, "Processing resource link", "uri", rl.Uri, "name", rl.Name)
 
-			if fileContent := a.readResourceLink(ctx, sessionID, rl); fileContent != "" {
-				parts = append(parts, fmt.Sprintf("\n\n--- File: %s ---\n%s\n--- End File ---\n", rl.Name, fileContent))
+			if fileContent, ok := a.readResourceLink(ctx, sessionID, rl); ok {
+				appendText(fmt.Sprintf("\n\n--- File: %s ---\n%s\n--- End File ---\n", resourceLinkName(rl), fileContent))
 			} else {
-				parts = append(parts, fmt.Sprintf("\n[Referenced file: %s (URI: %s)]\n", rl.Name, rl.Uri))
+				appendText(fmt.Sprintf("\n[Referenced file: %s (content unavailable)]\n", resourceLinkName(rl)))
 			}
 
 		case content.Resource != nil:
 			res := content.Resource.Resource
 			if res.TextResourceContents != nil {
 				slog.DebugContext(ctx, "Processing embedded text resource", "uri", res.TextResourceContents.Uri)
-				parts = append(parts, fmt.Sprintf("\n\n--- Resource: %s ---\n%s\n--- End Resource ---\n",
+				appendText(fmt.Sprintf("\n\n--- Resource: %s ---\n%s\n--- End Resource ---\n",
 					res.TextResourceContents.Uri, res.TextResourceContents.Text))
 			} else if res.BlobResourceContents != nil {
 				slog.DebugContext(ctx, "Processing embedded blob resource", "uri", res.BlobResourceContents.Uri)
-				parts = append(parts, fmt.Sprintf("\n[Binary resource: %s (type: %s)]\n",
+				appendText(fmt.Sprintf("\n[Binary resource: %s (type: %s)]\n",
 					res.BlobResourceContents.Uri, stringOrDefault(res.BlobResourceContents.MimeType, "unknown")))
 			}
 
 		case content.Image != nil:
-			slog.DebugContext(ctx, "Image content received but not yet fully supported")
-			parts = append(parts, "[Image content provided]")
+			img := content.Image
+			slog.DebugContext(ctx, "Processing image content", "mime_type", img.MimeType)
+			hasRichContent = true
+			multiContent = append(multiContent, chat.MessagePart{
+				Type: chat.MessagePartTypeImageURL,
+				ImageURL: &chat.MessageImageURL{
+					URL:    imageDataURL(img.MimeType, img.Data),
+					Detail: chat.ImageURLDetailAuto,
+				},
+			})
 
 		case content.Audio != nil:
 			slog.DebugContext(ctx, "Audio content received but not yet supported")
-			parts = append(parts, "[Audio content provided]")
+			appendText("[Audio content provided]")
 		}
 	}
 
-	return strings.Join(parts, "")
+	content := strings.Join(parts, "")
+	if !hasRichContent {
+		return session.UserMessage(content)
+	}
+	return session.UserMessage(content, multiContent...)
 }
 
 // readResourceLink attempts to read a text file referenced by an ACP resource link.
-//
-// For security reasons, this function applies basic path hardening:
-//   - Only relative paths are allowed
-//   - Path traversal (e.g. "../") is blocked
-//
-// If the path is unsafe or the file cannot be read, an empty string is returned.
-func (a *Agent) readResourceLink(ctx context.Context, sessionID string, rl *acp.ContentBlockResourceLink) string {
-	path := strings.TrimPrefix(rl.Uri, "file://")
-	clean := filepath.Clean(path)
+func (a *Agent) readResourceLink(ctx context.Context, sessionID string, rl *acp.ContentBlockResourceLink) (string, bool) {
+	if !a.supportsClientReadTextFile() {
+		slog.DebugContext(ctx, "ACP client does not support reading resource links")
+		return "", false
+	}
 
-	if filepath.IsAbs(clean) || strings.HasPrefix(clean, "..") {
-		slog.WarnContext(ctx, "Blocked unsafe file resource link", "path", path)
-		return ""
+	path, ok := resourceLinkPath(rl.Uri)
+	if !ok {
+		slog.DebugContext(ctx, "Unsupported ACP resource link URI", "uri", rl.Uri)
+		return "", false
+	}
+
+	resolvedPath, err := a.resolveSessionPath(sessionID, path)
+	if err != nil {
+		slog.WarnContext(ctx, "Blocked unsafe file resource link", "path", path, "error", err)
+		return "", false
 	}
 
 	resp, err := a.conn.ReadTextFile(ctx, acp.ReadTextFileRequest{
 		SessionId: acp.SessionId(sessionID),
-		Path:      clean,
+		Path:      resolvedPath,
 	})
 	if err != nil {
-		slog.DebugContext(ctx, "Failed to read resource link", "path", clean, "error", err)
-		return ""
+		slog.DebugContext(ctx, "Failed to read resource link", "path", resolvedPath, "error", err)
+		return "", false
 	}
 
-	return resp.Content
+	return resp.Content, true
+}
+
+func resourceLinkName(rl *acp.ContentBlockResourceLink) string {
+	if rl.Name != "" {
+		return rl.Name
+	}
+	if path, ok := resourceLinkPath(rl.Uri); ok {
+		if base := filepath.Base(path); base != "." && base != string(filepath.Separator) {
+			return base
+		}
+	}
+	return "resource"
+}
+
+func resourceLinkPath(rawURI string) (string, bool) {
+	u, err := url.Parse(rawURI)
+	if err != nil || u.Scheme == "" {
+		return rawURI, rawURI != ""
+	}
+	if u.Scheme != "file" {
+		return "", false
+	}
+	if u.Host != "" && u.Host != "localhost" {
+		return "", false
+	}
+	path, err := url.PathUnescape(u.Path)
+	if err != nil {
+		return "", false
+	}
+	return path, path != ""
+}
+
+func imageDataURL(mimeType, data string) string {
+	if strings.HasPrefix(data, "data:") {
+		return data
+	}
+	return fmt.Sprintf("data:%s;base64,%s", mimeType, data)
 }
 
 func stringOrDefault(s *string, def string) string {
@@ -472,8 +567,9 @@ func stringOrDefault(s *string, def string) string {
 }
 
 // SetSessionMode implements acp.Agent (optional).
-func (a *Agent) SetSessionMode(context.Context, acp.SetSessionModeRequest) (acp.SetSessionModeResponse, error) {
-	return acp.SetSessionModeResponse{}, nil
+func (a *Agent) SetSessionMode(ctx context.Context, _ acp.SetSessionModeRequest) (acp.SetSessionModeResponse, error) {
+	slog.DebugContext(ctx, "ACP SetSessionMode called (not supported)")
+	return acp.SetSessionModeResponse{}, acp.NewMethodNotFound(acp.AgentMethodSessionSetMode)
 }
 
 // sendUpdate sends a session update notification to the ACP client.
@@ -702,7 +798,100 @@ func (a *Agent) emitAvailableCommands(ctx context.Context, acpSess *Session) err
 	})
 }
 
-// resolveWorkingDir validates and normalizes a working directory path.
+func (a *Agent) supportsClientReadTextFile() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.clientFS.ReadTextFile && a.conn != nil
+}
+
+func (a *Agent) supportsClientWriteTextFile() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.clientFS.WriteTextFile && a.conn != nil
+}
+
+func (a *Agent) resolveSessionPath(sessionID, userPath string) (string, error) {
+	a.mu.Lock()
+	acpSess := a.sessions[sessionID]
+	a.mu.Unlock()
+	if acpSess == nil {
+		return "", fmt.Errorf("session %s not found", sessionID)
+	}
+
+	workingDir, roots := acpSess.pathRoots(a.defaultWorkingDir())
+	return resolvePathInRoots(userPath, workingDir, roots)
+}
+
+func (a *Agent) sessionListPaths(ctx context.Context, sessionID string) (string, []string) {
+	a.mu.Lock()
+	acpSess := a.sessions[sessionID]
+	a.mu.Unlock()
+	if acpSess != nil {
+		cwd, _ := acpSess.pathRoots(a.defaultWorkingDir())
+		return cwd, append([]string(nil), acpSess.additionalDirs...)
+	}
+
+	cwd := a.defaultWorkingDir()
+	if a.sessionStore != nil {
+		if sess, err := a.sessionStore.GetSession(ctx, sessionID); err == nil && sess.WorkingDir != "" {
+			cwd = sess.WorkingDir
+		}
+	}
+	return cwd, nil
+}
+
+func (a *Agent) defaultWorkingDir() string {
+	if a.runConfig != nil && a.runConfig.WorkingDir != "" {
+		if wd, err := resolveWorkingDir(a.runConfig.WorkingDir); err == nil {
+			return wd
+		}
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	wd, err := resolveWorkingDir(cwd)
+	if err != nil {
+		return cwd
+	}
+	return wd
+}
+
+func (s *Session) pathRoots(fallbackWorkingDir string) (string, []string) {
+	workingDir := s.workingDir
+	if workingDir == "" && s.sess != nil {
+		workingDir = s.sess.WorkingDir
+	}
+	if workingDir == "" {
+		workingDir = fallbackWorkingDir
+	}
+
+	roots := make([]string, 0, 1+len(s.additionalDirs))
+	if workingDir != "" {
+		roots = append(roots, workingDir)
+	}
+	roots = append(roots, s.additionalDirs...)
+	return workingDir, dedupePaths(roots)
+}
+
+func dedupePaths(paths []string) []string {
+	seen := make(map[string]struct{}, len(paths))
+	result := make([]string, 0, len(paths))
+	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+		key := normalizePathForComparison(filepath.Clean(path))
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, filepath.Clean(path))
+	}
+	return result
+}
+
+// resolveWorkingDir normalizes a working directory path.
 func resolveWorkingDir(cwd string) (string, error) {
 	wd := strings.TrimSpace(cwd)
 	if wd == "" {
@@ -712,5 +901,41 @@ func resolveWorkingDir(cwd string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("invalid working directory: %w", err)
 	}
-	return absWd, nil
+	return filepath.Clean(absWd), nil
+}
+
+func validateWorkingDir(workingDir string) error {
+	if workingDir == "" {
+		return nil
+	}
+	info, err := os.Stat(workingDir)
+	if err != nil {
+		return fmt.Errorf("working directory does not exist: %w", err)
+	}
+	if !info.IsDir() {
+		return errors.New("working directory must be a directory")
+	}
+	return nil
+}
+
+func resolveAdditionalDirectories(dirs []string) ([]string, error) {
+	resolved := make([]string, 0, len(dirs))
+	for _, dir := range dirs {
+		dir = strings.TrimSpace(dir)
+		if dir == "" {
+			continue
+		}
+		if !filepath.IsAbs(dir) {
+			return nil, fmt.Errorf("additional directory must be absolute: %s", dir)
+		}
+		absDir, err := resolveWorkingDir(dir)
+		if err != nil {
+			return nil, err
+		}
+		if err := validateWorkingDir(absDir); err != nil {
+			return nil, fmt.Errorf("invalid additional directory %q: %w", dir, err)
+		}
+		resolved = append(resolved, absDir)
+	}
+	return dedupePaths(resolved), nil
 }

--- a/pkg/acp/agent_test.go
+++ b/pkg/acp/agent_test.go
@@ -53,6 +53,77 @@ func (m *mockProvider) BaseConfig() base.Config { return base.Config{} }
 
 func (m *mockProvider) MaxTokens() int { return 0 }
 
+func TestBuildUserContent_ResourceLinkFallbackDoesNotExposeAbsoluteURI(t *testing.T) {
+	t.Parallel()
+
+	acpAgent := &Agent{sessions: make(map[string]*Session)}
+	uri := "file:///var/folders/40/w2lqxd4564132ydf4v_7s5wh0000gn/T/TemporaryItems/Screenshot%202026-06-15.png"
+
+	content := acpAgent.buildUserContent(t.Context(), "missing-session", []acpsdk.ContentBlock{
+		acpsdk.ResourceLinkBlock("Screenshot 2026-06-15.png", uri),
+	})
+
+	assert.Contains(t, content, "Screenshot 2026-06-15.png")
+	assert.Contains(t, content, "content unavailable")
+	assert.NotContains(t, content, uri)
+	assert.NotContains(t, content, "/var/folders")
+}
+
+func TestBuildUserMessage_ImageContent(t *testing.T) {
+	t.Parallel()
+
+	acpAgent := &Agent{sessions: make(map[string]*Session)}
+	msg := acpAgent.buildUserMessage(t.Context(), "session-id", []acpsdk.ContentBlock{
+		acpsdk.TextBlock("look at this"),
+		acpsdk.ImageBlock("AAAA", "image/png"),
+	})
+
+	require.NotNil(t, msg)
+	assert.Equal(t, "look at this", msg.Message.Content)
+	require.Len(t, msg.Message.MultiContent, 2)
+	assert.Equal(t, chat.MessagePartTypeText, msg.Message.MultiContent[0].Type)
+	assert.Equal(t, "look at this", msg.Message.MultiContent[0].Text)
+	assert.Equal(t, chat.MessagePartTypeImageURL, msg.Message.MultiContent[1].Type)
+	require.NotNil(t, msg.Message.MultiContent[1].ImageURL)
+	assert.Equal(t, "data:image/png;base64,AAAA", msg.Message.MultiContent[1].ImageURL.URL)
+}
+
+func TestResolveSessionPathUsesSessionRoots(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	additionalDir := t.TempDir()
+	outsideDir := t.TempDir()
+	absWorkingDir, err := filepath.EvalSymlinks(workingDir)
+	require.NoError(t, err)
+	absAdditionalDir, err := filepath.EvalSymlinks(additionalDir)
+	require.NoError(t, err)
+
+	acpAgent := &Agent{
+		runConfig: &config.RuntimeConfig{},
+		sessions: map[string]*Session{
+			"session-id": {
+				id:             "session-id",
+				sess:           session.New(session.WithWorkingDir(workingDir)),
+				workingDir:     workingDir,
+				additionalDirs: []string{additionalDir},
+			},
+		},
+	}
+
+	resolved, err := acpAgent.resolveSessionPath("session-id", "relative.txt")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(absWorkingDir, "relative.txt"), resolved)
+
+	resolved, err = acpAgent.resolveSessionPath("session-id", filepath.Join(additionalDir, "attached.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(absAdditionalDir, "attached.txt"), resolved)
+
+	_, err = acpAgent.resolveSessionPath("session-id", filepath.Join(outsideDir, "blocked.txt"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "escapes the working directory")
+}
+
 // TestACPSessionPersistence verifies that ACP sessions are persisted to the SQLite store.
 func TestACPSessionPersistence(t *testing.T) {
 	t.Parallel()

--- a/pkg/acp/filesystem.go
+++ b/pkg/acp/filesystem.go
@@ -3,6 +3,7 @@ package acp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -75,11 +76,41 @@ func (t *FilesystemToolset) Tools(ctx context.Context) ([]tools.Tool, error) {
 // It follows symlinks to prevent a symlink inside the working directory from
 // pointing outside it.
 func (t *FilesystemToolset) resolvePath(userPath string) (string, error) {
-	resolved := filepath.Clean(filepath.Join(t.workingDir, userPath))
-	absWorkingDir, err := filepath.Abs(t.workingDir)
-	if err != nil {
-		return "", fmt.Errorf("failed to resolve working directory: %w", err)
+	return resolvePathInRoots(userPath, t.workingDir, []string{t.workingDir})
+}
+
+func (t *FilesystemToolset) resolvePathForSession(ctx context.Context, userPath string) (string, error) {
+	sessionID, ok := getSessionID(ctx)
+	if !ok {
+		return "", errors.New("session ID not found in context")
 	}
+	if t.agent == nil {
+		return "", errors.New("ACP agent not configured")
+	}
+
+	t.agent.mu.Lock()
+	acpSess := t.agent.sessions[sessionID]
+	t.agent.mu.Unlock()
+	if acpSess == nil {
+		return "", fmt.Errorf("session %s not found", sessionID)
+	}
+
+	workingDir, roots := acpSess.pathRoots(t.workingDir)
+	return resolvePathInRoots(userPath, workingDir, roots)
+}
+
+func resolvePathInRoots(userPath, workingDir string, roots []string) (string, error) {
+	if workingDir == "" {
+		return "", errors.New("working directory is not configured")
+	}
+
+	var resolved string
+	if filepath.IsAbs(userPath) {
+		resolved = filepath.Clean(userPath)
+	} else {
+		resolved = filepath.Clean(filepath.Join(workingDir, userPath))
+	}
+
 	absResolved, err := filepath.Abs(resolved)
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve path: %w", err)
@@ -92,19 +123,38 @@ func (t *FilesystemToolset) resolvePath(userPath string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to evaluate symlinks: %w", err)
 	}
-	realWorkingDir, err := filepath.EvalSymlinks(absWorkingDir)
-	if err != nil {
-		return "", fmt.Errorf("failed to evaluate symlinks for working directory: %w", err)
+
+	for _, root := range roots {
+		if root == "" {
+			continue
+		}
+		absRoot, err := filepath.Abs(root)
+		if err != nil {
+			return "", fmt.Errorf("failed to resolve working directory: %w", err)
+		}
+		realRoot, err := filepath.EvalSymlinks(absRoot)
+		if err != nil {
+			return "", fmt.Errorf("failed to evaluate symlinks for working directory: %w", err)
+		}
+		if pathWithinRoot(realResolved, realRoot) {
+			return realResolved, nil
+		}
 	}
 
-	// Normalize paths for comparison to prevent bypasses on case-insensitive
-	// filesystems (macOS, Windows) where differing case could defeat the check.
-	normResolved := normalizePathForComparison(realResolved)
-	normWorkingDir := normalizePathForComparison(realWorkingDir)
-	if !strings.HasPrefix(normResolved, normWorkingDir+string(filepath.Separator)) && normResolved != normWorkingDir {
-		return "", fmt.Errorf("path %q escapes the working directory", userPath)
+	return "", fmt.Errorf("path %q escapes the working directory", userPath)
+}
+
+func pathWithinRoot(path, root string) bool {
+	normPath := normalizePathForComparison(filepath.Clean(path))
+	normRoot := normalizePathForComparison(filepath.Clean(root))
+	if normPath == normRoot {
+		return true
 	}
-	return realResolved, nil
+	rel, err := filepath.Rel(normRoot, normPath)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel)
 }
 
 // evalSymlinksAllowMissing resolves symlinks for a path that may not fully
@@ -142,8 +192,11 @@ func (t *FilesystemToolset) handleReadFile(ctx context.Context, toolCall tools.T
 	if !ok {
 		return tools.ResultError("Error: session ID not found in context"), nil
 	}
+	if !t.agent.supportsClientReadTextFile() {
+		return tools.ResultError("Error: ACP client does not support reading files"), nil
+	}
 
-	resolvedPath, err := t.resolvePath(args.Path)
+	resolvedPath, err := t.resolvePathForSession(ctx, args.Path)
 	if err != nil {
 		return tools.ResultError(fmt.Sprintf("Error: %s", err)), nil
 	}
@@ -169,8 +222,11 @@ func (t *FilesystemToolset) handleWriteFile(ctx context.Context, toolCall tools.
 	if !ok {
 		return tools.ResultError("Error: session ID not found in context"), nil
 	}
+	if !t.agent.supportsClientWriteTextFile() {
+		return tools.ResultError("Error: ACP client does not support writing files"), nil
+	}
 
-	resolvedPath, err := t.resolvePath(args.Path)
+	resolvedPath, err := t.resolvePathForSession(ctx, args.Path)
 	if err != nil {
 		return tools.ResultError(fmt.Sprintf("Error: %s", err)), nil
 	}
@@ -201,8 +257,11 @@ func (t *FilesystemToolset) handleEditFile(ctx context.Context, toolCall tools.T
 	if !ok {
 		return tools.ResultError("Error: session ID not found in context"), nil
 	}
+	if !t.agent.supportsClientReadTextFile() || !t.agent.supportsClientWriteTextFile() {
+		return tools.ResultError("Error: ACP client does not support editing files"), nil
+	}
 
-	resolvedPath, err := t.resolvePath(args.Path)
+	resolvedPath, err := t.resolvePathForSession(ctx, args.Path)
 	if err != nil {
 		return tools.ResultError(fmt.Sprintf("Error: %s", err)), nil
 	}

--- a/pkg/acp/filesystem_test.go
+++ b/pkg/acp/filesystem_test.go
@@ -14,12 +14,15 @@ func TestResolvePath(t *testing.T) {
 	t.Parallel()
 
 	workingDir := t.TempDir()
+	outsideDir := t.TempDir()
 
 	ts := &FilesystemToolset{
 		workingDir: workingDir,
 	}
 
 	absWorkingDir, err := filepath.EvalSymlinks(workingDir)
+	require.NoError(t, err)
+	absOutsideDir, err := filepath.EvalSymlinks(outsideDir)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -58,6 +61,16 @@ func TestResolvePath(t *testing.T) {
 			userPath: "subdir/../file.txt",
 			wantPath: filepath.Join(absWorkingDir, "file.txt"),
 		},
+		{
+			name:     "absolute path inside working dir is allowed",
+			userPath: filepath.Join(absWorkingDir, "file.txt"),
+			wantPath: filepath.Join(absWorkingDir, "file.txt"),
+		},
+		{
+			name:      "absolute path outside working dir is blocked",
+			userPath:  filepath.Join(absOutsideDir, "file.txt"),
+			wantError: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -74,6 +87,33 @@ func TestResolvePath(t *testing.T) {
 			assert.Equal(t, tt.wantPath, resolved)
 		})
 	}
+}
+
+func TestResolvePath_AdditionalDirectories(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	additionalDir := t.TempDir()
+	outsideDir := t.TempDir()
+
+	absWorkingDir, err := filepath.EvalSymlinks(workingDir)
+	require.NoError(t, err)
+	absAdditionalDir, err := filepath.EvalSymlinks(additionalDir)
+	require.NoError(t, err)
+	absOutsideDir, err := filepath.EvalSymlinks(outsideDir)
+	require.NoError(t, err)
+
+	resolved, err := resolvePathInRoots("relative.txt", workingDir, []string{workingDir, additionalDir})
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(absWorkingDir, "relative.txt"), resolved)
+
+	resolved, err = resolvePathInRoots(filepath.Join(additionalDir, "attached.txt"), workingDir, []string{workingDir, additionalDir})
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(absAdditionalDir, "attached.txt"), resolved)
+
+	_, err = resolvePathInRoots(filepath.Join(absOutsideDir, "blocked.txt"), workingDir, []string{workingDir, additionalDir})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "escapes the working directory")
 }
 
 func TestNormalizePathForComparison(t *testing.T) {

--- a/pkg/acp/registry.go
+++ b/pkg/acp/registry.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/teamloader"
 	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/tools/builtin/filesystem"
 )
 
 // createToolsetRegistry creates a custom toolset registry with ACP-specific filesystem toolset
@@ -34,8 +35,38 @@ func (r *acpToolsetRegistry) CreateTool(ctx context.Context, toolset latest.Tool
 			}
 		}
 
-		return NewFilesystemToolset(r.agent, wd), nil
+		return NewFilesystemToolset(r.agent, wd, filesystemOptions(toolset)...), nil
 	}
 
 	return r.registry.CreateTool(ctx, toolset, parentDir, runConfig, agentName)
+}
+
+func filesystemOptions(toolset latest.Toolset) []filesystem.Opt {
+	opts := []filesystem.Opt{}
+
+	ignoreVCS := true
+	if toolset.IgnoreVCS != nil {
+		ignoreVCS = *toolset.IgnoreVCS
+	}
+	opts = append(opts, filesystem.WithIgnoreVCS(ignoreVCS))
+
+	if len(toolset.AllowList) > 0 {
+		opts = append(opts, filesystem.WithAllowList(toolset.AllowList))
+	}
+	if len(toolset.DenyList) > 0 {
+		opts = append(opts, filesystem.WithDenyList(toolset.DenyList))
+	}
+
+	if len(toolset.PostEdit) > 0 {
+		postEditConfigs := make([]filesystem.PostEditConfig, len(toolset.PostEdit))
+		for i, pe := range toolset.PostEdit {
+			postEditConfigs[i] = filesystem.PostEditConfig{
+				Path: pe.Path,
+				Cmd:  pe.Cmd,
+			}
+		}
+		opts = append(opts, filesystem.WithPostEditCommands(postEditConfigs))
+	}
+
+	return opts
 }

--- a/pkg/acp/toolcall.go
+++ b/pkg/acp/toolcall.go
@@ -47,7 +47,7 @@ func buildToolCallComplete(arguments string, event *runtime.ToolCallResponseEven
 		status = acp.ToolCallStatusFailed
 	}
 
-	if isFileEditTool(event.ToolDefinition.Name) {
+	if status == acp.ToolCallStatusCompleted && isFileEditTool(event.ToolDefinition.Name) {
 		if diffContent := extractDiffContent(event.ToolDefinition.Name, arguments); diffContent != nil {
 			return acp.UpdateToolCall(
 				acp.ToolCallId(event.ToolCallID),


### PR DESCRIPTION
Resolve ACP filesystem paths against the session cwd and advertised additional directories instead of re-rooting absolute paths under the agent process directory. This prevents temporary screenshot paths from creating project-local var/folders trees.

Also advertise inline image prompt support, avoid leaking blocked resource-link URIs into prompts, preserve filesystem tool options in the ACP registry, and return method-not-found for unsupported optional ACP calls.