### PR TITLE
docs: update docs for --lean TUI, --session new-id, and hook agent_name

### DIFF
--- a/docs/configuration/hooks/index.md
+++ b/docs/configuration/hooks/index.md
@@ -252,10 +252,10 @@ In addition to the common fields, each event ships its own payload:
 
 | Event                       | Extra fields                                                                                                          |
 | --------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `pre_tool_use`              | `tool_name`, `tool_use_id`, `tool_input`                                                                              |
+| `pre_tool_use`              | `agent_name`, `tool_name`, `tool_use_id`, `tool_input`                                                                |
 | `tool_response_transform`   | `tool_name`, `tool_use_id`, `tool_input`, `tool_response`                                                             |
-| `post_tool_use`             | `tool_name`, `tool_use_id`, `tool_input`, `tool_response`, `tool_error`                                               |
-| `permission_request`        | `tool_name`, `tool_use_id`, `tool_input`                                                                              |
+| `post_tool_use`             | `agent_name`, `tool_name`, `tool_use_id`, `tool_input`, `tool_response`, `tool_error`                                 |
+| `permission_request`        | `agent_name`, `tool_name`, `tool_use_id`, `tool_input`                                                                |
 | `session_start`             | `source` — one of `startup`, `resume`, `clear`, `compact`                                                             |
 | `user_prompt_submit`        | `prompt` — the text the user just submitted                                                                           |
 | `user_steering_messages_submit` | `steering_messages` — the drained steering messages, in submission order                                         |
@@ -282,6 +282,7 @@ In addition to the common fields, each event ships its own payload:
 Notes:
 
 - `tool_response` for `post_tool_use` carries the tool's result; `tool_error` is `true` when the tool failed (the failure detail is surfaced inside `tool_response`).
+- `agent_name` on `pre_tool_use` and `post_tool_use` identifies the agent that issued the tool call — in multi-agent setups this follows the active sub-agent, not always the root agent.
 - `prompt` is only populated for `user_prompt_submit`. Sub-sessions (transferred tasks, background agents, skills) do **not** fire this event because their kick-off message is synthesised by the runtime, not authored by the user.
 - `steering_messages` is only populated for `user_steering_messages_submit`. It carries the user messages the runtime just drained from the steering queue — messages submitted while the agent was already working (mid-turn, after the model stopped, or while idle before the first model call).
 - `prompt` is also populated for `user_followup_submit`, carrying the text of the dequeued follow-up message (a user message queued for end-of-turn processing via the FollowUp API / queue, as opposed to mid-turn steering).

--- a/docs/configuration/hooks/index.md
+++ b/docs/configuration/hooks/index.md
@@ -282,7 +282,7 @@ In addition to the common fields, each event ships its own payload:
 Notes:
 
 - `tool_response` for `post_tool_use` carries the tool's result; `tool_error` is `true` when the tool failed (the failure detail is surfaced inside `tool_response`).
-- `agent_name` on `pre_tool_use` and `post_tool_use` identifies the agent that issued the tool call — in multi-agent setups this follows the active sub-agent, not always the root agent.
+- `agent_name` on `pre_tool_use`, `post_tool_use`, and `permission_request` identifies the agent that issued the tool call — in multi-agent setups this follows the active sub-agent, not always the root agent.
 - `prompt` is only populated for `user_prompt_submit`. Sub-sessions (transferred tasks, background agents, skills) do **not** fire this event because their kick-off message is synthesised by the runtime, not authored by the user.
 - `steering_messages` is only populated for `user_steering_messages_submit`. It carries the user messages the runtime just drained from the steering queue — messages submitted while the agent was already working (mid-turn, after the model stopped, or while idle before the first model call).
 - `prompt` is also populated for `user_followup_submit`, carrying the text of the dequeued follow-up message (a user message queued for end-of-turn processing via the FollowUp API / queue, as opposed to mid-turn steering).

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -30,7 +30,7 @@ $ docker agent run [config] [message...] [flags]
 | `-a, --agent <name>`                    | Run a specific agent from the config                                                                                                      |
 | `--yolo`                                | Auto-approve all tool calls                                                                                                               |
 | `--model <ref>`                         | Override model(s). Use `provider/model` for all agents, or `agent=provider/model` for specific agents. Comma-separate multiple overrides. |
-| `--session <id>`                        | Resume a previous session. Supports relative refs (`-1` = last, `-2` = second to last)                                                    |
+| `--session <id>`                        | Resume a previous session. Supports relative refs (`-1` = last, `-2` = second to last). An explicit ID that does not exist yet is created with that ID, so a supervisor can own the session ID upfront and reuse it across runs. |
 | `-s, --session-db <path>`               | Path to the SQLite session database (default: `~/.cagent/session.db`)                                                                     |
 | `--session-read-only`                   | Open the TUI in read-only mode: conversation history is displayed but no new messages can be sent to the LLM. Cannot be used with `--exec`. |
 | `--prompt-file <path>`                  | Include file contents as additional system context (repeatable)                                                                           |

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -38,7 +38,7 @@ $ docker agent run [config] [message...] [flags]
 | `--dry-run`                             | Initialize the agent without executing anything (useful for validating a config)                                                          |
 | `--remote <addr>`                       | Use a remote runtime at the given address instead of running the agent locally                                                            |
 | `--listen <addr>`                       | Expose this run's control plane over HTTP so an external process can drive the running TUI (send follow-ups, stream events, read the title). Accepts `host:port` or `unix://`, `npipe://`, `fd://`. See the [API Server]({{ '/features/api-server/' | relative_url }}#listen). |
-| `--lean`                                | Use a simplified TUI with minimal chrome                                                                                                  |
+| `--lean`                                | Use a simplified, non-alternate-screen TUI. Unlike the default full-screen TUI, this renders inline in the normal terminal buffer — useful in environments where an alternate screen is unwanted (e.g. inside tmux panes, CI with a tty, or log-friendly pipelines). |
 | `--app-name <name>`                     | Override the application name label shown in the TUI (status bar, window title, "/exit" notifications).                                   |
 | `--sidebar`                             | Control sidebar visibility. Set to `--sidebar=false` to hide the sidebar and disable the Ctrl+B toggle (default: `true`).                 |
 | `--disable-commands <list>`             | Hide and disable specific slash commands in the TUI. Accepts a comma-separated list of command names (leading slash optional, case-insensitive). E.g. `--disable-commands="/cost,/eval,/model"`. |
@@ -99,6 +99,12 @@ $ docker agent run agent.yaml --disable-commands="/cost,/eval,/model"
 $ docker agent run --agent-picker
 $ docker agent run --agent-picker=agentcatalog/coder,agentcatalog/researcher
 ```
+
+<div class="callout callout-tip" markdown="1">
+<div class="callout-title">Lean, inline TUI
+</div>
+  <p>Pass <code>--lean</code> to get a lightweight TUI that renders inline in your terminal (no alternate screen). It supports the same slash commands and streaming output as the full TUI, making it handy inside tmux, scripts, or any context where a full-screen takeover is unwanted.</p>
+</div>
 
 <div class="callout callout-tip" markdown="1">
 <div class="callout-title">Isolate a run in a git worktree


### PR DESCRIPTION
## Documentation updates

This PR brings the `/docs` directory in sync with three PRs merged to `main` in the last 36 hours.

### Changes

| Source PR | Doc change |
|-----------|------------|
| [#3119](https://github.com/docker/docker-agent/pull/3119) Support --session new-id | Updated `--session` flag description to document that an explicit unknown ID creates a new session instead of failing |
| [#3127](https://github.com/docker/docker-agent/pull/3127) Secondary, non-alternate screen ui | Expanded `--lean` flag description; added callout tip explaining the non-alternate-screen rendering |
| [#3110](https://github.com/docker/docker-agent/pull/3110) feat(hooks): populate agent_name on tool-use hook events | Added `agent_name` to `pre_tool_use`, `post_tool_use`, and `permission_request` in the hook event fields table; added explanatory note for multi-agent setups |

### PRs reviewed and found up to date

| Source PR | Reason |
|-----------|--------|
| [#3135](https://github.com/docker/docker-agent/pull/3135) fix(acp): respect workspace roots for Zed paths | Internal ACP path-resolution fix; no user-facing doc impact |
| [#3133](https://github.com/docker/docker-agent/pull/3133) Disable old tool-call truncation by default | Docs already updated in the PR |
| [#3131](https://github.com/docker/docker-agent/pull/3131) feat: warn on unpinned external agent refs and document digest pinning | Docs already updated in the PR |
| [#3130](https://github.com/docker/docker-agent/pull/3130) fix(skills): discover .agents/skills in non-git grouping parents | Internal discovery behavior fix; no doc-visible contract change |
| [#3129](https://github.com/docker/docker-agent/pull/3129) fix(runtime): finalize event channel on runStreamLoop early returns | Internal runtime fix; no user-facing behavior change |
| [#3128](https://github.com/docker/docker-agent/pull/3128) perf(tui): skip sidebar scrollbar-probe pass on animation frames | Internal TUI perf optimization; no doc needed |
| [#3126](https://github.com/docker/docker-agent/pull/3126) fix(tui): cache sidebar todo render | Internal TUI perf optimization; no doc needed |
| [#3125](https://github.com/docker/docker-agent/pull/3125) fix: run /shell in the active session's working directory | Bug fix; behavior now matches existing doc expectation |
| [#3124](https://github.com/docker/docker-agent/pull/3124) Improve the TUI control API | Docs already updated in the PR |
| [#3120](https://github.com/docker/docker-agent/pull/3120) Better worktree handling | Docs already updated in the PR |
| [#3113](https://github.com/docker/docker-agent/pull/3113) fix: remove todo strikethrough | Cosmetic UI-only change; no doc impact |
| [#3111](https://github.com/docker/docker-agent/pull/3111) docs: fix per-model Shift+Tab thinking-level cycle description | Docs-only PR; already correct |