### PR TITLE
feat: notify docker-agent-action on new releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,3 +153,18 @@ jobs:
             GIT_COMMIT=${{ github.sha }}
           cache-from: type=gha,scope=buildx
           cache-to: type=gha,mode=max,scope=buildx
+
+  notify-docker-agent-action:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [build-and-push-image]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Notify docker-agent-action of new release
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
+        with:
+          token: ${{ secrets.DOCKER_AGENT_ACTION_DISPATCH_TOKEN }}
+          repository: docker/docker-agent-action
+          event-type: docker-agent-release
+          client-payload: '{"version": "${{ github.ref_name }}"}'


### PR DESCRIPTION
## What

Add a `notify-docker-agent-action` job to `.github/workflows/ci.yml` that dispatches a `repository_dispatch` event to `docker/docker-agent-action` whenever a new version tag is pushed.

## Why

This creates automatic version update propagation: when a new `docker/docker-agent` release is tagged and the image is built and pushed, the downstream `docker/docker-agent-action` repo is notified via a `docker-agent-release` event. That event triggers the `update-docker-agent-version` workflow in `docker/docker-agent-action`, which can open a PR bumping the pinned version automatically.

## How it works

- Job condition: `startsWith(github.ref, 'refs/tags/v')` — only fires on version tag pushes
- Depends on `build-and-push-image` succeeding (image is live before the downstream is notified)
- Uses `peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0` (v3.0.0, pinned SHA)
- Sends event type `docker-agent-release` with payload `{"version": "<tag>"}`

## Required secret

A secret `DOCKER_AGENT_ACTION_DISPATCH_TOKEN` must be added to this repository's settings. It should be a PAT with `repo` scope on `docker/docker-agent-action` (so it can trigger repository_dispatch events there).