### PR TITLE
fix(memory): sanitise reserved characters in default-path config segment

### DIFF
--- a/pkg/tools/builtin/memory/memory.go
+++ b/pkg/tools/builtin/memory/memory.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/docker/docker-agent/pkg/config"
@@ -60,7 +61,7 @@ func CreateToolSet(toolset latest.Toolset, parentDir string, runConfig *config.R
 		if configName == "" {
 			configName = "default"
 		}
-		validatedMemoryPath = filepath.Join(paths.GetDataDir(), "memory", configName, "memory.db")
+		validatedMemoryPath = filepath.Join(paths.GetDataDir(), "memory", sanitizePathSegment(configName), "memory.db")
 	}
 
 	if err := os.MkdirAll(filepath.Dir(validatedMemoryPath), 0o700); err != nil {
@@ -73,6 +74,26 @@ func CreateToolSet(toolset latest.Toolset, parentDir string, runConfig *config.R
 	}
 
 	return NewWithPath(db, validatedMemoryPath), nil
+}
+
+// sanitizePathSegment replaces characters that are illegal in a single path
+// component on Windows with '_'. Agent sources loaded from an OCI reference
+// (e.g. "namespace/repo:tag") produce config names that include the image
+// tag's ':'; the colon causes os.MkdirAll to fail with ERROR_INVALID_NAME on
+// NTFS. The replacement is lossy but safe — the hash suffix already in the
+// config name preserves uniqueness, so collisions from sanitisation aren't a
+// concern in practice.
+func sanitizePathSegment(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch r {
+		case '<', '>', ':', '"', '|', '?', '*', '\\', '/':
+			return '_'
+		}
+		if r < 0x20 {
+			return '_'
+		}
+		return r
+	}, s)
 }
 
 func New(manager DB) *ToolSet {

--- a/pkg/tools/builtin/memory/memory_test.go
+++ b/pkg/tools/builtin/memory/memory_test.go
@@ -3,6 +3,8 @@ package memory
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -10,7 +12,10 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/memory/database"
+	"github.com/docker/docker-agent/pkg/paths"
 	"github.com/docker/docker-agent/pkg/tools"
 )
 
@@ -228,4 +233,38 @@ func TestMemoryTool_ParametersAreObjects(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "object", m["type"])
 	}
+}
+
+// TestCreateToolSet_DefaultPath_SanitisesReservedChars guards the
+// default-path branch against config names that contain characters which
+// are illegal in a Windows path component. Agents loaded from an OCI
+// reference produce config names that include the image tag's ':', and
+// without sanitisation os.MkdirAll fails with ERROR_INVALID_NAME on NTFS.
+// The test runs the same assertions on every OS so the behaviour is
+// pinned regardless of where the suite executes.
+func TestCreateToolSet_DefaultPath_SanitisesReservedChars(t *testing.T) {
+	dataDir := t.TempDir()
+	paths.SetDataDir(dataDir)
+	t.Cleanup(func() { paths.SetDataDir("") })
+
+	ts, err := CreateToolSet(latest.Toolset{Type: "memory"}, "", &config.RuntimeConfig{}, `oci:v8<>"|?*\/-deadbeef`)
+	require.NoError(t, err)
+	require.NotNil(t, ts)
+
+	// The directory under <dataDir>/memory must exist and contain no
+	// Windows-reserved characters in its single path segment.
+	entries, err := os.ReadDir(filepath.Join(dataDir, "memory"))
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+
+	name := entries[0].Name()
+	assert.NotContains(t, name, ":")
+	assert.NotContains(t, name, "<")
+	assert.NotContains(t, name, ">")
+	assert.NotContains(t, name, `"`)
+	assert.NotContains(t, name, "|")
+	assert.NotContains(t, name, "?")
+	assert.NotContains(t, name, "*")
+	assert.NotContains(t, name, `\`)
+	assert.NotContains(t, name, "/")
 }


### PR DESCRIPTION
Refs: docker/desktop-feedback#449, https://docker.atlassian.net/browse/DDB-503

When an agent is loaded from an OCI reference, the config name passed
into the memory toolset's default-path branch carries the image tag's
`:` through to the directory name. `os.MkdirAll` then fails with
`ERROR_INVALID_NAME (123)` on NTFS because Windows reserves
`< > : " | ? * \ /` in any single path component, so the toolset
fails to initialise on every Windows host where an agent is consumed
that way.

The sanitisation is intentionally narrow: it only touches the segment
the memory toolset itself constructs, so the config name keeps its
shape everywhere else (logs, UI labels, …). The hash suffix already
embedded in the config name absorbs any loss from the replacement, so
this can't introduce collisions in practice.