### PR TITLE
fix(runtime): persist sub-session transcript on error path

### DIFF
--- a/pkg/runtime/agent_delegation.go
+++ b/pkg/runtime/agent_delegation.go
@@ -275,25 +275,38 @@ func (r *LocalRuntime) runForwarding(ctx context.Context, parent *session.Sessio
 	}()
 
 	childEvents := r.RunStream(ctx, s)
+	var subSessionErr error
 	for event := range childEvents {
 		evts.Emit(event)
-		if errEvent, ok := event.(*ErrorEvent); ok {
-			// Drain remaining events (including StreamStoppedEvent) so the
-			// TUI's streamDepth counter stays balanced.
-			for remaining := range childEvents {
-				evts.Emit(remaining)
-			}
-			err := fmt.Errorf("%s", errEvent.Error)
-			span.RecordError(err)
-			span.SetStatus(codes.Error, "sub-session error")
-			return nil, err
+		if errEvent, ok := event.(*ErrorEvent); ok && subSessionErr == nil {
+			// Capture the first ErrorEvent but keep draining the channel so
+			// the sub-session's full transcript still streams through. The
+			// child's run loop may emit additional events (e.g. notifications,
+			// hook output) after the error before its channel closes; dropping
+			// them here would leave the TUI's streamDepth counter unbalanced
+			// and the user without context for what actually went wrong.
+			subSessionErr = fmt.Errorf("%s", errEvent.Error)
 		}
 	}
 
-	parent.ToolsApproved = s.ToolsApproved
+	// Persist the sub-session unconditionally — even on error, the partial
+	// transcript is the most valuable artifact for debugging. The persistence
+	// pipeline relies on SubSessionCompleted to write the sub-session's
+	// messages to the store; without this emission they are silently dropped.
 	parent.AddSubSession(s)
 	evts.Emit(SubSessionCompleted(parent.ID, s, callerAgent.Name()))
 
+	if subSessionErr != nil {
+		span.RecordError(subSessionErr)
+		span.SetStatus(codes.Error, "sub-session error")
+		return nil, subSessionErr
+	}
+
+	// Only propagate ToolsApproved on success. A failed sub-session must not
+	// silently escalate the parent's tool-approval gate: the user approved
+	// tools within a sub-session scope that ended in error, and that approval
+	// should not carry over to the parent's remaining turns.
+	parent.ToolsApproved = s.ToolsApproved
 	span.SetStatus(codes.Ok, "sub-session completed")
 	return tools.ResultSuccess(s.GetLastAssistantMessageContent()), nil
 }

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -1925,6 +1925,88 @@ func TestTransferTaskAllowsSubAgent(t *testing.T) {
 	assert.False(t, result.IsError, "transfer to valid sub-agent should succeed")
 }
 
+// TestTransferTaskPersistsSubSessionOnError covers the case where a sub-agent's
+// run loop emits an ErrorEvent — for example because the model stream failed,
+// the loop detector fired, or a hook blocked execution. Before the fix in
+// runForwarding, an ErrorEvent caused an early return that skipped both
+// parent.AddSubSession and the SubSessionCompletedEvent emission, so the
+// entire sub-session transcript was silently dropped — invisible to the user,
+// invisible to debug tooling that walks session_items.
+//
+// The fix persists unconditionally: capture the error, drain the channel,
+// AddSubSession + emit SubSessionCompleted, then return the error so the
+// parent's tool dispatcher still records an error tool result.
+func TestTransferTaskPersistsSubSessionOnError(t *testing.T) {
+	t.Parallel()
+	// Root has a librarian sub-agent whose model always fails to produce a
+	// stream. This mirrors the production failure mode where a sub-agent
+	// hits an irrecoverable error mid-stream.
+	parentProv := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
+	failingProv := &mockProviderWithError{id: "test/mock-model"}
+
+	librarian := agent.New("librarian", "Library agent", agent.WithModel(failingProv))
+	root := agent.New("root", "Root agent", agent.WithModel(parentProv))
+	agent.WithSubAgents(librarian)(root)
+
+	tm := team.New(team.WithAgents(root, librarian))
+	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+
+	sess := session.New(session.WithUserMessage("Test"), session.WithToolsApproved(true))
+	sess.NonInteractive = true // mirror --exec mode
+	evts := make(chan Event, 128)
+
+	toolCall := tools.ToolCall{
+		ID:   "call_1",
+		Type: "function",
+		Function: tools.FunctionCall{
+			Name:      "transfer_task",
+			Arguments: `{"agent":"librarian","task":"find a book","expected_output":"book title"}`,
+		},
+	}
+
+	// runForwarding returns an error because the child emitted an ErrorEvent,
+	// but only *after* persisting the sub-session.
+	_, err = rt.handleTaskTransfer(t.Context(), sess, toolCall, NewChannelSink(evts))
+	require.Error(t, err, "transfer should surface the sub-session error to the caller")
+
+	// The parent session must now hold a sub-session item — without the fix
+	// this would be empty because AddSubSession was skipped on the error path.
+	var subSessionItems int
+	for _, item := range sess.Messages {
+		if item.SubSession != nil {
+			subSessionItems++
+		}
+	}
+	assert.Equal(t, 1, subSessionItems,
+		"parent session must record the sub-session even when the sub-agent errored — "+
+			"otherwise the entire transcript is lost and the failure is invisible to observers")
+
+	// Drain the event channel and assert both required events are present.
+	//
+	// ErrorEvent must reach the parent sink: runForwarding forwards it
+	// unconditionally so the TUI's streamDepth counter stays balanced and
+	// the user sees the error context.
+	//
+	// SubSessionCompletedEvent must fire: the persistence pipeline
+	// (PersistenceObserver) writes the sub-session to the store on this
+	// event; without it the store never learns the sub-session existed.
+	close(evts)
+	var sawSubSessionCompleted, sawErrorEvent bool
+	for ev := range evts {
+		switch ev.(type) {
+		case *SubSessionCompletedEvent:
+			sawSubSessionCompleted = true
+		case *ErrorEvent:
+			sawErrorEvent = true
+		}
+	}
+	assert.True(t, sawErrorEvent,
+		"ErrorEvent must be forwarded to the parent sink to keep TUI streamDepth balanced")
+	assert.True(t, sawSubSessionCompleted,
+		"SubSessionCompletedEvent must fire on the error path so observers persist the sub-session")
+}
+
 func TestYoloMode_OverridesPermissionsDeny(t *testing.T) {
 	// Test that --yolo flag takes precedence over deny permissions
 	permChecker := permissions.NewChecker(&latest.PermissionsConfig{


### PR DESCRIPTION
## Problem

When a sub-agent's run loop emits an `ErrorEvent` (model stream failure, loop detector trip, hook-driven termination, tool-load error), `runForwarding` early-returned at the first error event. This skipped both `parent.AddSubSession` and the `SubSessionCompletedEvent` emission.

The persistence pipeline relies on `SubSessionCompletedEvent` to write the sub-session to the store. This contract is documented explicitly in `persistence_observer.go:68–72`:

> *Sub-session events are skipped (the parent absorbs them on SubSessionCompleted), and any SessionScoped event tagged with a different session id (forwarded sub-agent streaming events) is filtered out so it can't pollute the parent's transcript.*

The result: any sub-agent that hit an error mid-stream had its entire transcript silently dropped. The parent agent received `"Error calling tool: <message>"` with no record of what the sub-agent actually did — invisible in session_items, invisible in the TUI.

## Fix

- Capture the first `ErrorEvent` into a local variable instead of early-returning.
- Continue draining the channel so the TUI's `streamDepth` counter stays balanced and any trailing events (notifications, hook output) reach the parent's event stream.
- Always emit `SubSessionCompletedEvent` (and call `parent.AddSubSession`) before returning, regardless of whether the sub-session errored.
- Guard `parent.ToolsApproved` propagation to the success path only — a failed sub-session must not silently escalate the parent's tool-approval gate.

## Test plan

`TestTransferTaskPersistsSubSessionOnError` uses `mockProviderWithError` to make a sub-agent fail to start its model stream. It asserts:
- `parent.Messages` contains the sub-session item (fails on pre-fix code)
- `ErrorEvent` was forwarded to the parent sink
- `SubSessionCompletedEvent` fired (fails on pre-fix code)

Verify by stashing the fix and re-running the test — it fails without the change.

## Related

A companion fix for `runCollecting` (the background-agent path) is in a separate PR — it has the same structural bug but the `SubSessionCompletedEvent` emission requires a larger interface change.