### PR TITLE
fix(runtime): persist sub-session transcript on error path in runCollecting

### DIFF
--- a/pkg/runtime/agent_delegation.go
+++ b/pkg/runtime/agent_delegation.go
@@ -347,14 +347,22 @@ func (r *LocalRuntime) runCollecting(ctx context.Context, parent *session.Sessio
 	for range events {
 	}
 
+	// Persist the sub-session unconditionally — the partial transcript is
+	// the most valuable artifact for debugging a failed background agent.
+	// AddSubSession records it in-memory on both the success and error paths.
+	//
+	// Note: SubSessionCompletedEvent cannot be emitted here because
+	// runCollecting has no EventSink — the persistence observer pipeline
+	// (PersistenceObserver.OnEvent) is not triggered and the sub-session is
+	// not written to the store. Fixing that requires threading EventSink
+	// through RunParams / the Runner interface.
+	parent.AddSubSession(s)
+
 	if errMsg != "" {
 		return &agenttool.RunResult{ErrMsg: errMsg}
 	}
 
-	result := s.GetLastAssistantMessageContent()
-	parent.AddSubSession(s)
-
-	return &agenttool.RunResult{Result: result}
+	return &agenttool.RunResult{Result: s.GetLastAssistantMessageContent()}
 }
 
 // CurrentAgentSubAgentNames implements agenttool.Runner.

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/team"
 	"github.com/docker/docker-agent/pkg/tools"
+	agenttool "github.com/docker/docker-agent/pkg/tools/builtin/agent"
 	mcptools "github.com/docker/docker-agent/pkg/tools/mcp"
 )
 
@@ -3454,4 +3455,46 @@ func TestElicitationHandler_Interactive_NoChannel(t *testing.T) {
 
 	require.Error(t, err, "interactive runtime with no events channel should error")
 	assert.ErrorIs(t, err, errNoElicitationChannel)
+}
+
+// TestRunAgentPersistsSubSessionOnError covers the background-agent path
+// (runCollecting) when the sub-agent's model stream fails. Before the fix,
+// runCollecting returned early on ErrorEvent without calling
+// parent.AddSubSession, so the sub-session was silently dropped from the
+// parent's in-memory record — invisible to any code that walks session.Messages.
+func TestRunAgentPersistsSubSessionOnError(t *testing.T) {
+	t.Parallel()
+
+	parentProv := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
+	failingProv := &mockProviderWithError{id: "test/mock-model"}
+
+	worker := agent.New("worker", "Worker agent", agent.WithModel(failingProv))
+	root := agent.New("root", "Root agent", agent.WithModel(parentProv))
+	agent.WithSubAgents(worker)(root)
+
+	tm := team.New(team.WithAgents(root, worker))
+	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+
+	sess := session.New(session.WithUserMessage("Test"), session.WithToolsApproved(true))
+
+	result := rt.RunAgent(t.Context(), agenttool.RunParams{
+		AgentName:     "worker",
+		Task:          "do something",
+		ParentSession: sess,
+	})
+
+	require.NotEmpty(t, result.ErrMsg, "RunAgent should surface the sub-session error")
+
+	// The parent session must hold a sub-session record even though the
+	// sub-agent errored — without the fix AddSubSession was skipped and
+	// the entire partial transcript was lost.
+	var subSessionItems int
+	for _, item := range sess.Messages {
+		if item.SubSession != nil {
+			subSessionItems++
+		}
+	}
+	assert.Equal(t, 1, subSessionItems,
+		"parent session must record the sub-session even when the background agent errored")
 }


### PR DESCRIPTION
## Problem

`runCollecting` — the background-agent path used by `run_background_agent` — has the same structural bug fixed in #3151 for `runForwarding`: on `ErrorEvent` it returned early without calling `parent.AddSubSession`, silently dropping the sub-session from the parent's in-memory record.

The partial transcript of a failing background agent was invisible to any code walking `session.Messages`, and invisible to debug tooling inspecting the session store.

## Fix

Move `parent.AddSubSession(s)` unconditionally before the error gate, mirroring the pattern introduced in #3151.

## Known limitation

`runCollecting` has no `EventSink` parameter, so `SubSessionCompletedEvent` cannot be emitted here. The persistence observer pipeline (`PersistenceObserver.OnEvent`) is therefore not triggered and background-agent sub-sessions are still not written to the store. Fixing that requires threading `EventSink` through `RunParams` / the `Runner` interface and is left as a follow-up.

## Relationship to #3151

This PR is a companion to #3151 and should stack on top of it. The two PRs fix the same class of bug in the two sibling functions (`runForwarding` and `runCollecting`). They are separate because the `runCollecting` fix has a known limitation (no store persistence) that warrants independent review.

## Test plan

`TestRunAgentPersistsSubSessionOnError` mirrors the structure of `TestTransferTaskPersistsSubSessionOnError` from #3151. It constructs a background agent whose model always fails and asserts that `parent.Messages` contains a sub-session item after `RunAgent` returns an error — which fails without the fix.