### PR TITLE
docs: sync /docs with main — Grafana Cloud catalog, lean TUI banner, memory path sanitization

### DIFF
--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -38,7 +38,7 @@ $ docker agent run [config] [message...] [flags]
 | `--dry-run`                             | Initialize the agent without executing anything (useful for validating a config)                                                          |
 | `--remote <addr>`                       | Use a remote runtime at the given address instead of running the agent locally                                                            |
 | `--listen <addr>`                       | Expose this run's control plane over HTTP so an external process can drive the running TUI (send follow-ups, stream events, read the title). Accepts `host:port` or `unix://`, `npipe://`, `fd://`. See the [API Server]({{ '/features/api-server/' | relative_url }}#listen). |
-| `--lean`                                | Use a simplified, non-alternate-screen TUI. Unlike the default full-screen TUI, this renders inline in the normal terminal buffer — useful in environments where an alternate screen is unwanted (e.g. inside tmux panes, CI with a tty, or log-friendly pipelines). |
+| `--lean`                                | Use a simplified, non-alternate-screen TUI. Unlike the default full-screen TUI, this renders inline in the normal terminal buffer — useful in environments where an alternate screen is unwanted (e.g. inside tmux panes, CI with a tty, or log-friendly pipelines). Displays an ASCII art banner on startup. |
 | `--app-name <name>`                     | Override the application name label shown in the TUI (status bar, window title, "/exit" notifications).                                   |
 | `--sidebar`                             | Control sidebar visibility. Set to `--sidebar=false` to hide the sidebar and disable the Ctrl+B toggle (default: `true`).                 |
 | `--disable-commands <list>`             | Hide and disable specific slash commands in the TUI. Accepts a comma-separated list of command names (leading slash optional, case-insensitive). E.g. `--disable-commands="/cost,/eval,/model"`. |
@@ -103,7 +103,7 @@ $ docker agent run --agent-picker=agentcatalog/coder,agentcatalog/researcher
 <div class="callout callout-tip" markdown="1">
 <div class="callout-title">Lean, inline TUI
 </div>
-  <p>Pass <code>--lean</code> to get a lightweight TUI that renders inline in your terminal (no alternate screen). It supports the same slash commands and streaming output as the full TUI, making it handy inside tmux, scripts, or any context where a full-screen takeover is unwanted.</p>
+  <p>Pass <code>--lean</code> to get a lightweight TUI that renders inline in your terminal (no alternate screen). It displays an ASCII art banner on startup and supports the same slash commands and streaming output as the full TUI, making it handy inside tmux, scripts, or any context where a full-screen takeover is unwanted.</p>
 </div>
 
 <div class="callout callout-tip" markdown="1">

--- a/docs/tools/mcp-catalog/index.md
+++ b/docs/tools/mcp-catalog/index.md
@@ -63,7 +63,7 @@ Up to five tools are exposed to the model. The disable / reset-auth pair only ap
 
 ### Workflow
 
-1. The agent calls `search_remote_mcp_servers` with a keyword matching the user's intent (`"notion"`, `"stripe"`, `"docs"`, `"browser"`, …).
+1. The agent calls `search_remote_mcp_servers` with a keyword matching the user's intent (`"notion"`, `"stripe"`, `"docs"`, `"browser"`, `"grafana"`, …).
 2. It picks a matching server id and calls `enable_remote_mcp_server`. **`enable` blocks** until the MCP handshake (and any required OAuth flow) completes:
    - on success the server's tools are available **in the same turn** — the agent goes straight to the user's original request, no re-ask required;
    - on failure (user dismissed the authorization dialog, server refused) the tool returns an error result naming the specific reason so the agent can recover instead of pretending the server is connected.

--- a/docs/tools/memory/index.md
+++ b/docs/tools/memory/index.md
@@ -12,7 +12,7 @@ _Persistent key-value storage backed by SQLite for cross-session recall._
 
 The memory tool provides persistent key-value storage backed by SQLite. Data survives across sessions, allowing agents to remember facts, user preferences, project context, and past decisions. Memories can be organized with categories and searched by keyword.
 
-By default, the database is stored at `~/.cagent/memory/<config-name>/memory.db`, where `<config-name>` is derived from the loaded configuration (typically the YAML file name) and falls back to `default` when unavailable. Agents declared in the same configuration share this database by default; set an explicit `path` per toolset to isolate them.
+By default, the database is stored at `~/.cagent/memory/<config-name>/memory.db`, where `<config-name>` is derived from the loaded configuration (typically the YAML file name) and falls back to `default` when unavailable. When the agent is loaded from an OCI reference (e.g. `docker/my-agent:latest`), characters that are reserved in filesystem paths (such as `:`) are sanitised in the `<config-name>` segment — the agent's display name elsewhere is unchanged. Agents declared in the same configuration share this database by default; set an explicit `path` per toolset to isolate them.
 
 ## Available Tools
 


### PR DESCRIPTION
## Documentation updates

This PR brings `/docs` in sync with three code changes merged to `main` in the last 36 hours.

### Changes

| Source PR | File | Doc change |
|-----------|------|------------|
| [#3139](https://github.com/docker/docker-agent/pull/3139) feat(mcpcatalog): add Grafana Cloud remote MCP server | `docs/tools/mcp-catalog/index.md` | Added `"grafana"` to the keyword examples in the Workflow section, so users discover the new monitoring/observability server when browsing the catalog docs |
| [#3147](https://github.com/docker/docker-agent/pull/3147) Add a banner in the lean TUI | `docs/features/cli/index.md` | Updated the `--lean` flag table row and the callout tip to note that the lean TUI displays an ASCII art banner on startup |
| [#3146](https://github.com/docker/docker-agent/pull/3146) fix(memory): sanitise reserved characters in default-path config segment | `docs/tools/memory/index.md` | Added a sentence to the Overview noting that when an agent is loaded from an OCI reference, reserved characters in the config name are sanitised in the storage path segment |

### PRs reviewed and found up to date

| Source PR | Reason |
|-----------|--------|
| [#3131](https://github.com/docker/docker-agent/pull/3131) feat: warn on unpinned external agent refs and document digest pinning | Docs updated within the PR |
| [#3133](https://github.com/docker/docker-agent/pull/3133) Disable old tool-call truncation by default | Docs updated within the PR |
| [#3136](https://github.com/docker/docker-agent/pull/3136) docs: update docs for --lean TUI, --session new-id, and hook agent_name | Was itself a docs PR |
| [#3143](https://github.com/docker/docker-agent/pull/3143) docs: update CHANGELOG.md for v1.81.2 | Was itself a docs PR (automated release) |
| [#3120](https://github.com/docker/docker-agent/pull/3120) Better worktree handling | Docs (`--worktree-base`, `--worktree-pr`) updated within the PR |
| [#3124](https://github.com/docker/docker-agent/pull/3124) Improve the TUI control API | Docs updated within the PR |
| [#3127](https://github.com/docker/docker-agent/pull/3127) Secondary, non-alternate screen UI | `--lean` docs covered by #3136 |
| [#3135](https://github.com/docker/docker-agent/pull/3135) fix(acp): respect workspace roots for Zed paths | Internal path-resolution fix; no user-facing config or API change |
| [#3141](https://github.com/docker/docker-agent/pull/3141) Use lipgloss and x/term for window size changes events | Internal TUI library change; no behavioral delta for users |
| [#3149](https://github.com/docker/docker-agent/pull/3149) chore: bump Go dependencies | Dependency bump only |