### PR TITLE
fix(runtime): bound per-toolset tool listing during startup (#3137)

### DIFF
--- a/pkg/runtime/defaults.go
+++ b/pkg/runtime/defaults.go
@@ -30,3 +30,15 @@ const defaultMaxOverflowCompactions = 1
 // a notification from a server), so a slow or stuck server cannot be
 // allowed to wedge the caller indefinitely.
 const toolsChangedTimeout = 5 * time.Second
+
+// defaultToolListTimeout bounds how long EmitStartupInfo waits for a single
+// toolset to enumerate its tools while populating the sidebar. A toolset
+// whose Tools() blocks indefinitely — e.g. an MCP stdio subprocess that
+// never answers tools/list, possibly while also ignoring context
+// cancellation — would otherwise stall the whole startup: the terminal
+// ToolsetInfo{Loading:false} event is never emitted, so the sidebar stays
+// on "Loading tools…" forever and /quit appears to hang. A timed-out
+// toolset is skipped here; it stays usable for the actual agent turn, which
+// lists its tools again without this startup bound. Tests override it via
+// WithToolListTimeout to exercise the skip path without a real-time wait.
+const defaultToolListTimeout = 10 * time.Second

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -287,6 +287,12 @@ type LocalRuntime struct {
 	// succeeded" and "compaction exhausted" branches.
 	maxOverflowCompactions int
 
+	// toolListTimeout bounds how long EmitStartupInfo waits for a single
+	// toolset to enumerate its tools before skipping it, so one hung toolset
+	// cannot stall the sidebar's "Loading tools…" state forever. Defaults to
+	// defaultToolListTimeout; overridden via WithToolListTimeout.
+	toolListTimeout time.Duration
+
 	// pauseMu guards pauseCh.
 	pauseMu sync.Mutex
 	// pauseCh is non-nil and open while /pause has paused the run loop;
@@ -433,6 +439,19 @@ func WithMaxOverflowCompactions(n int) Opt {
 	}
 }
 
+// WithToolListTimeout overrides how long EmitStartupInfo waits for a single
+// toolset to enumerate its tools before skipping it. Defaults to
+// defaultToolListTimeout. A non-positive value is ignored so the default
+// stands. Tests pass a short timeout to exercise the skip path (a toolset
+// whose Tools() blocks) without a real-time wait.
+func WithToolListTimeout(d time.Duration) Opt {
+	return func(r *LocalRuntime) {
+		if d > 0 {
+			r.toolListTimeout = d
+		}
+	}
+}
+
 // WithRetryOnRateLimit enables automatic retry with backoff for HTTP 429 (rate limit)
 // errors when no fallback models are available. When enabled, the runtime will honor
 // the Retry-After header from the provider's response to determine wait time before
@@ -518,6 +537,7 @@ func NewLocalRuntime(agents *team.Team, opts ...Opt) (*LocalRuntime, error) {
 		now:                    time.Now,
 		telemetry:              defaultTelemetry{},
 		maxOverflowCompactions: defaultMaxOverflowCompactions,
+		toolListTimeout:        defaultToolListTimeout,
 	}
 	r.bgAgents = agenttool.NewHandler(r)
 
@@ -1250,10 +1270,18 @@ func (r *LocalRuntime) emitToolsProgressively(ctx context.Context, a *agent.Agen
 			}
 		}
 
-		// Get tools from this toolset
-		ts, err := toolset.Tools(ctx)
+		// Get tools from this toolset under a bounded deadline. A toolset
+		// whose Tools() blocks indefinitely would otherwise stall the whole
+		// loop: the terminal ToolsetInfo{Loading:false} below is never sent,
+		// so the sidebar stays on "Loading tools…" forever and /quit appears
+		// to hang. Time it out, skip it, and move on. The skip is only for
+		// this startup sidebar pass — the toolset is not torn down, so a
+		// slow-but-responsive one is listed (and counted) again on the next
+		// turn or tool-change refresh.
+		ts, err := listToolsWithTimeout(ctx, toolset, r.toolListTimeout)
 		if err != nil {
-			slog.WarnContext(ctx, "Failed to get tools from toolset", "agent", a.Name(), "error", err)
+			slog.WarnContext(ctx, "Failed to list tools from toolset; skipping",
+				"agent", a.Name(), "toolset", tools.DescribeToolSet(toolset), "error", err)
 			continue
 		}
 
@@ -1267,6 +1295,41 @@ func (r *LocalRuntime) emitToolsProgressively(ctx context.Context, a *agent.Agen
 
 	// Emit final state (not loading)
 	send(ToolsetInfo(totalTools, false, r.CurrentAgentName()))
+}
+
+// listToolsWithTimeout enumerates a toolset's tools under a bounded deadline.
+// The (potentially blocking) Tools call runs in a goroutine and we select on
+// either its completion or the timeout, so a toolset whose Tools() ignores
+// context cancellation — e.g. a wedged MCP stdio subprocess — cannot block
+// startup. On timeout it returns the context error; the orphaned goroutine
+// sends into a buffered channel and exits if the call ever returns, so it does
+// not leak past the eventual (or never) return of Tools().
+func listToolsWithTimeout(ctx context.Context, toolset tools.ToolSet, timeout time.Duration) ([]tools.Tool, error) {
+	// Defend against a zero/negative timeout (e.g. a directly-constructed
+	// LocalRuntime that bypassed NewLocalRuntime) so we never collapse to an
+	// already-expired context that skips every toolset.
+	if timeout <= 0 {
+		timeout = defaultToolListTimeout
+	}
+	toolCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	type listResult struct {
+		tools []tools.Tool
+		err   error
+	}
+	done := make(chan listResult, 1) // buffered so a late send never blocks
+	go func() {
+		ts, err := toolset.Tools(toolCtx)
+		done <- listResult{tools: ts, err: err}
+	}()
+
+	select {
+	case <-toolCtx.Done():
+		return nil, toolCtx.Err()
+	case res := <-done:
+		return res.tools, res.err
+	}
 }
 
 func (r *LocalRuntime) Resume(_ context.Context, req ResumeRequest) {

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -59,6 +59,21 @@ func (s *stubToolSet) Tools(context.Context) ([]tools.Tool, error) {
 	return s.tools, nil
 }
 
+// blockingToolSet models a toolset whose Tools() never returns on its own —
+// e.g. a wedged MCP stdio subprocess that does not even answer context
+// cancellation. It deliberately ignores ctx and blocks until release is
+// closed, which tests do on cleanup so the orphaned listing goroutine exits.
+type blockingToolSet struct {
+	release <-chan struct{}
+}
+
+var _ tools.ToolSet = (*blockingToolSet)(nil)
+
+func (b *blockingToolSet) Tools(context.Context) ([]tools.Tool, error) {
+	<-b.release
+	return nil, nil
+}
+
 type mockStream struct {
 	responses []chat.MessageStreamResponse
 	idx       int
@@ -1070,6 +1085,64 @@ func TestEmitStartupInfo_SurfacesToolsetStartFailureAsWarning(t *testing.T) {
 	require.NotNil(t, warning, "EmitStartupInfo should emit a WarningEvent when a toolset fails to start")
 	assert.Contains(t, warning.Message, "App is not enabled for Slack MCP server access.",
 		"warning should include the toolset's actual error message so the user can see the real cause")
+}
+
+// TestEmitStartupInfo_SkipsToolsetWhoseListingHangs is the regression test for
+// issue #3137: a toolset whose Tools() blocks indefinitely must not stall the
+// whole startup tool-loading loop. Before the per-toolset timeout,
+// emitToolsProgressively blocked forever on the hung toolset, so the terminal
+// ToolsetInfo{Loading:false} was never emitted (sidebar stuck on "Loading
+// tools…") and EmitStartupInfo's goroutine leaked, also delaying /quit.
+func TestEmitStartupInfo_SkipsToolsetWhoseListingHangs(t *testing.T) {
+	prov := &mockProvider{id: "test/startup-model", stream: &mockStream{}}
+
+	// release is closed on cleanup so the orphaned listing goroutine (whose
+	// Tools() ignores context cancellation) exits instead of leaking.
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+
+	hanging := &blockingToolSet{release: release}
+	fast := newStubToolSet(nil, []tools.Tool{{Name: "ready"}}, nil)
+
+	root := agent.New("root", "agent",
+		agent.WithModel(prov),
+		agent.WithToolSets(hanging, fast),
+	)
+	tm := team.New(team.WithAgents(root))
+
+	rt, err := NewLocalRuntime(tm,
+		WithCurrentAgent("root"),
+		WithModelStore(mockModelStore{}),
+		WithToolListTimeout(50*time.Millisecond),
+	)
+	require.NoError(t, err)
+
+	events := make(chan Event, 32)
+	done := make(chan struct{})
+	go func() {
+		rt.EmitStartupInfo(t.Context(), nil, NewChannelSink(events))
+		close(events)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("EmitStartupInfo did not return: a hung toolset blocked startup tool loading")
+	}
+
+	var toolsetInfos []*ToolsetInfoEvent
+	for e := range events {
+		if ti, ok := e.(*ToolsetInfoEvent); ok {
+			toolsetInfos = append(toolsetInfos, ti)
+		}
+	}
+
+	require.NotEmpty(t, toolsetInfos, "expected at least one ToolsetInfo event")
+	last := toolsetInfos[len(toolsetInfos)-1]
+	assert.False(t, last.Loading, "final ToolsetInfo must report Loading=false so the sidebar resolves")
+	assert.Equal(t, 1, last.AvailableTools,
+		"the hung toolset is skipped; the fast toolset's single tool is still counted")
 }
 
 // TestEmitStartupInfo_AuthRequiredIsSilent verifies that when a toolset's


### PR DESCRIPTION
Fixes #3137.

## what

`emitToolsProgressively` called `toolset.Tools(ctx)` with no timeout, so if a toolset's `Tools()` blocked forever (e.g. a wedged MCP stdio server that never answers `tools/list`), startup tool loading never finished. The terminal `ToolsetInfo{Loading:false}` was never sent, so the sidebar stayed on "Loading tools..." and `EmitStartupInfo`'s goroutine leaked.

This adds `listToolsWithTimeout`, which runs `Tools()` in a goroutine and bounds it with a per-toolset deadline (default 10s, configurable via `WithToolListTimeout`). I went with goroutine + select instead of a plain context timeout because the MCP client detaches ctx with `WithoutCancel`, so a wedged server might not honor cancellation. A timed-out toolset is skipped with a warning, and the terminal `ToolsetInfo` is always sent so the sidebar resolves and shows whatever loaded fine. The toolset is not torn down, so a slow-but-responsive one is listed again on the next turn.

## how it maps to the issue

the issue lists three expected behaviours:

1. per-toolset timeout, skip with a warning: done
2. sidebar shows the tools that loaded, not an infinite spinner: done
3. /quit exits promptly: mostly. the leaked startup goroutine that blocked it is gone now that `EmitStartupInfo` returns. i left the 30s `stopToolSets` bound alone since the issue lists it as "consider" and lowering it risks cutting off a legit graceful shutdown. happy to do it as a follow-up if you'd prefer.

## possible follow-up (not in this PR)

a server that wedges during `initialize`/`Start()` would stall startup the same way, and that path is also unbounded (`Connect` detaches ctx, the supervisor has no connect deadline). the same pattern would fix it. kept it out here to stay close to the issue's stated root cause (`Tools()`).

## test

added `TestEmitStartupInfo_SkipsToolsetWhoseListingHangs` (passes under `-race`). also reproduced by hand: hangs before, resolves after, using a hung toolset plus a tiny MCP stdio server that finishes initialize then never answers `tools/list`.
