### PR TITLE
feat(tui): show pausing/paused state for /pause

### DIFF
--- a/pkg/runtime/client.go
+++ b/pkg/runtime/client.go
@@ -84,6 +84,7 @@ func NewClient(baseURL string, opts ...ClientOption) (*Client, error) {
 			"tool_call_confirmation": func() Event { return &ToolCallConfirmationEvent{} },
 			"token_usage":            func() Event { return &TokenUsageEvent{} },
 			"stream_stopped":         func() Event { return &StreamStoppedEvent{} },
+			"runtime_paused":         func() Event { return &PausedEvent{} },
 			"stream_started":         func() Event { return &StreamStartedEvent{} },
 			"shell":                  func() Event { return &ShellOutputEvent{} },
 			"session_title":          func() Event { return &SessionTitleEvent{} },

--- a/pkg/runtime/event.go
+++ b/pkg/runtime/event.go
@@ -448,6 +448,29 @@ func StreamStopped(sessionID, agentName, reason string) Event {
 
 func (e *StreamStoppedEvent) GetSessionID() string { return e.SessionID }
 
+// PausedEvent reports that the run loop has reached an iteration
+// boundary and is now blocked because /pause was toggled on. It is emitted
+// once the in-flight LLM request and its tool calls have finished — i.e. the
+// transition from "pausing" (still finishing a roundtrip) to "paused"
+// (idle until resumed). The TUI uses it to flip its indicator from
+// "Pausing…" to "Paused".
+type PausedEvent struct {
+	AgentContext
+
+	Type      string `json:"type"`
+	SessionID string `json:"session_id,omitempty"`
+}
+
+func Paused(sessionID, agentName string) Event {
+	return &PausedEvent{
+		Type:         "runtime_paused",
+		SessionID:    sessionID,
+		AgentContext: newAgentContext(agentName),
+	}
+}
+
+func (e *PausedEvent) GetSessionID() string { return e.SessionID }
+
 // ElicitationRequestEvent is sent when an elicitation request is received from an MCP server
 type ElicitationRequestEvent struct {
 	AgentContext

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -326,9 +326,14 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 
 	for {
 		// Pause the loop here if /pause has been toggled on. Any in-flight
-		// LLM request and its tool calls have already completed.
-		if err := r.waitIfPaused(ctx); err != nil {
-			return
+		// LLM request and its tool calls have already completed. Emit a
+		// RuntimePaused event right before blocking so the TUI can flip its
+		// indicator from "Pausing…" to "Paused".
+		if r.isPaused() {
+			sink.Emit(Paused(sess.ID, a.Name()))
+			if err := r.waitIfPaused(ctx); err != nil {
+				return
+			}
 		}
 
 		a = r.resolveSessionAgent(sess)

--- a/pkg/runtime/pause.go
+++ b/pkg/runtime/pause.go
@@ -23,6 +23,14 @@ func (r *LocalRuntime) TogglePause(context.Context) (bool, error) {
 	return true, nil
 }
 
+// isPaused reports whether /pause is currently armed (the run loop will
+// block at the next iteration boundary).
+func (r *LocalRuntime) isPaused() bool {
+	r.pauseMu.Lock()
+	defer r.pauseMu.Unlock()
+	return r.pauseCh != nil
+}
+
 // waitIfPaused blocks until the runtime is resumed or ctx is cancelled.
 func (r *LocalRuntime) waitIfPaused(ctx context.Context) error {
 	r.pauseMu.Lock()

--- a/pkg/runtime/pause_test.go
+++ b/pkg/runtime/pause_test.go
@@ -30,6 +30,21 @@ func TestTogglePause_StateCycles(t *testing.T) {
 	assertToggle(false, "fourth toggle should resume again")
 }
 
+// TestIsPaused_TracksToggle verifies isPaused mirrors the armed state set by
+// TogglePause.
+func TestIsPaused_TracksToggle(t *testing.T) {
+	t.Parallel()
+
+	r := &LocalRuntime{}
+	assert.False(t, r.isPaused(), "should not be paused initially")
+
+	_, _ = r.TogglePause(t.Context())
+	assert.True(t, r.isPaused(), "should be paused after first toggle")
+
+	_, _ = r.TogglePause(t.Context())
+	assert.False(t, r.isPaused(), "should not be paused after second toggle")
+}
+
 // TestWaitIfPaused_NotPaused returns immediately when the runtime isn't paused.
 func TestWaitIfPaused_NotPaused(t *testing.T) {
 	t.Parallel()

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -26,6 +26,7 @@ import (
 	"github.com/docker/docker-agent/pkg/tui/core"
 	"github.com/docker/docker-agent/pkg/tui/dialog"
 	"github.com/docker/docker-agent/pkg/tui/messages"
+	"github.com/docker/docker-agent/pkg/tui/service"
 	"github.com/docker/docker-agent/pkg/tui/styles"
 	"github.com/docker/docker-agent/pkg/userconfig"
 )
@@ -367,14 +368,25 @@ func (m *appModel) handleToggleYolo() (tea.Model, tea.Cmd) {
 // handleTogglePause toggles whether the runtime loop is paused at iteration
 // boundaries. The pause kicks in once the in-flight LLM request and its tool
 // calls finish; running /pause again resumes the loop.
+//
+// The TUI reflects this in the resize-handle indicator: requesting a pause
+// while the agent is working shows "Pausing…" until the runtime emits a
+// RuntimePausedEvent at the next iteration boundary (flipping it to
+// "Paused"); requesting a pause while idle shows "Paused" immediately.
 func (m *appModel) handleTogglePause() (tea.Model, tea.Cmd) {
 	paused, supported := m.application.TogglePause()
 	switch {
 	case !supported:
 		return m, notification.InfoCmd("Pause is not supported with remote runtimes")
 	case paused:
+		if m.chatPage.IsWorking() {
+			m.sessionState.SetPauseState(service.PausePausing)
+			return m, notification.InfoCmd("Pausing after the current request — /pause again to resume")
+		}
+		m.sessionState.SetPauseState(service.PausePaused)
 		return m, notification.InfoCmd("Runtime paused — /pause again to resume")
 	default:
+		m.sessionState.SetPauseState(service.PauseNone)
 		return m, notification.SuccessCmd("Runtime resumed")
 	}
 }

--- a/pkg/tui/service/sessionstate.go
+++ b/pkg/tui/service/sessionstate.go
@@ -8,6 +8,22 @@ import (
 	"github.com/docker/docker-agent/pkg/userconfig"
 )
 
+// PauseState describes how /pause is currently affecting the runtime loop
+// for a session, so the TUI can show whether the system is winding down a
+// roundtrip before pausing or fully paused.
+type PauseState int
+
+const (
+	// PauseNone means the runtime is not paused.
+	PauseNone PauseState = iota
+	// PausePausing means /pause was requested but the runtime is still
+	// finishing the in-flight LLM request and its tool calls.
+	PausePausing
+	// PausePaused means the runtime has reached an iteration boundary and is
+	// idle until the user resumes.
+	PausePaused
+)
+
 // SessionStateReader provides read-only access to session state.
 // Components that only need to read state should depend on this interface
 // rather than the full SessionState, following the principle of least privilege.
@@ -21,6 +37,7 @@ type SessionStateReader interface {
 	SessionTitle() string
 	AvailableAgents() []runtime.AgentDetails
 	GetCurrentAgent() runtime.AgentDetails
+	PauseState() PauseState
 }
 
 // Verify SessionState implements SessionStateReader
@@ -39,6 +56,7 @@ type SessionState struct {
 	previousMessage  *types.Message
 	currentAgentName string
 	availableAgents  []runtime.AgentDetails
+	pauseState       PauseState
 }
 
 func NewSessionState(s *session.Session) *SessionState {
@@ -130,6 +148,17 @@ func (s *SessionState) SetAvailableAgents(availableAgents []runtime.AgentDetails
 		names[i] = a.Name
 	}
 	styles.SetAgentOrder(names)
+}
+
+func (s *SessionState) PauseState() PauseState {
+	if s == nil {
+		return PauseNone
+	}
+	return s.pauseState
+}
+
+func (s *SessionState) SetPauseState(state PauseState) {
+	s.pauseState = state
 }
 
 func (s *SessionState) GetCurrentAgent() runtime.AgentDetails {

--- a/pkg/tui/service/staticsessionstate.go
+++ b/pkg/tui/service/staticsessionstate.go
@@ -29,3 +29,4 @@ func (s StaticSessionState) PreviousMessage() *types.Message         { return ni
 func (s StaticSessionState) SessionTitle() string                    { return s.Title }
 func (s StaticSessionState) AvailableAgents() []runtime.AgentDetails { return nil }
 func (s StaticSessionState) GetCurrentAgent() runtime.AgentDetails   { return runtime.AgentDetails{} }
+func (s StaticSessionState) PauseState() PauseState                  { return PauseNone }

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -1052,6 +1052,7 @@ func (m *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if agentName := event.GetAgentName(); agentName != "" {
 				m.sessionState.SetCurrentAgentName(agentName)
 			}
+			m.applyPauseEvent(m.sessionState, msg)
 			return m.forwardChat(msg)
 		}
 
@@ -1087,6 +1088,7 @@ func (m *appModel) handleRoutedMsg(msg messages.RoutedMsg) (tea.Model, tea.Cmd) 
 			if agentName := event.GetAgentName(); agentName != "" {
 				sessionState.SetCurrentAgentName(agentName)
 			}
+			m.applyPauseEvent(sessionState, msg.Inner)
 		}
 	}
 
@@ -1094,6 +1096,29 @@ func (m *appModel) handleRoutedMsg(msg messages.RoutedMsg) (tea.Model, tea.Cmd) 
 	updated, _ := chatPage.Update(msg.Inner)
 	m.chatPages[msg.SessionID] = updated.(chat.Page)
 	return m, nil
+}
+
+// applyPauseEvent advances a session's pause indicator in response to runtime
+// events. The runtime emits a PausedEvent when the loop reaches an
+// iteration boundary and blocks, which flips a pending "Pausing…" state to
+// "Paused". A stream that stops while still "Pausing…" (e.g. the agent
+// happened to finish its final turn before re-entering the loop) is likewise
+// resolved to "Paused", since /pause stays armed for the next run. The arm/
+// disarm transitions themselves are driven by handleTogglePause.
+func (m *appModel) applyPauseEvent(ss *service.SessionState, msg tea.Msg) {
+	if ss == nil {
+		return
+	}
+	switch msg.(type) {
+	case *runtime.PausedEvent:
+		if ss.PauseState() != service.PauseNone {
+			ss.SetPauseState(service.PausePaused)
+		}
+	case *runtime.StreamStoppedEvent:
+		if ss.PauseState() == service.PausePausing {
+			ss.SetPauseState(service.PausePaused)
+		}
+	}
 }
 
 // handleWorkingStateChanged updates the editor working indicator and resize handle spinner.
@@ -1678,8 +1703,8 @@ func (m *appModel) resizeAll() tea.Cmd {
 	// Calculate chrome height (everything that isn't content or editor)
 	chromeHeight := 0
 	if m.leanMode {
-		if m.chatPage.IsWorking() {
-			chromeHeight = 1 // working indicator line
+		if m.chatPage.IsWorking() || m.sessionState.PauseState() != service.PauseNone {
+			chromeHeight = 1 // working/pause indicator line
 		}
 	} else {
 		chromeHeight = m.tabBar.Height() + m.statusBar.Height() + 1 // +1 for resize handle
@@ -2298,14 +2323,23 @@ func (m *appModel) handleEditorResize(y int) tea.Cmd {
 	return nil
 }
 
-// renderLeanWorkingIndicator renders a single-line working indicator for lean mode.
+// renderLeanWorkingIndicator renders a single-line working/pause indicator for
+// lean mode.
 func (m *appModel) renderLeanWorkingIndicator() string {
 	innerWidth := m.width - appPaddingHorizontal
-	workingText := "Working\u2026"
-	if queueLen := m.chatPage.QueueLength(); queueLen > 0 {
-		workingText = fmt.Sprintf("Working\u2026 (%d queued)", queueLen)
+	var line string
+	switch m.sessionState.PauseState() {
+	case service.PausePaused:
+		line = styles.WarningStyle.Render("⏸ Paused") + " " + styles.MutedStyle.Render("(/pause to resume)")
+	case service.PausePausing:
+		line = m.workingSpinner.View() + " " + styles.WarningStyle.Render("Pausing… (finishing current request)")
+	default:
+		workingText := "Working\u2026"
+		if queueLen := m.chatPage.QueueLength(); queueLen > 0 {
+			workingText = fmt.Sprintf("Working\u2026 (%d queued)", queueLen)
+		}
+		line = m.workingSpinner.View() + " " + styles.SpinnerDotsHighlightStyle.Render(workingText)
 	}
-	line := m.workingSpinner.View() + " " + styles.SpinnerDotsHighlightStyle.Render(workingText)
 	return lipgloss.NewStyle().Padding(0, styles.AppPadding).Width(innerWidth + appPaddingHorizontal).Render(line)
 }
 
@@ -2336,6 +2370,19 @@ func (m *appModel) renderResizeHandle(width int) string {
 
 	var result string
 	switch {
+	case m.sessionState.PauseState() == service.PausePaused:
+		// Static indicator: the loop is idle until the user resumes.
+		resumeKey := styles.HighlightWhiteStyle.Render("/pause")
+		suffix := " " + styles.WarningStyle.Render("⏸ Paused") + " (" + resumeKey + " to resume)"
+		suffixWidth := lipgloss.Width(suffix)
+		result = lipgloss.NewStyle().MaxWidth(innerWidth-suffixWidth).Render(fullLine) + suffix
+
+	case m.sessionState.PauseState() == service.PausePausing:
+		// The agent is finishing the in-flight request before it pauses.
+		suffix := " " + m.workingSpinner.View() + " " + styles.WarningStyle.Render("Pausing…") + " (finishing current request)"
+		suffixWidth := lipgloss.Width(suffix)
+		result = lipgloss.NewStyle().MaxWidth(innerWidth-suffixWidth).Render(fullLine) + suffix
+
 	case m.chatPage.IsWorking():
 		// Truncate right side and append spinner (handle stays centered)
 		workingText := "Working…"
@@ -2388,7 +2435,7 @@ func (m *appModel) View() tea.View {
 	// space pushed to the top via bottom-alignment.
 	if m.leanMode {
 		viewParts := []string{contentView}
-		if m.chatPage.IsWorking() {
+		if m.chatPage.IsWorking() || m.sessionState.PauseState() != service.PauseNone {
 			viewParts = append(viewParts, m.renderLeanWorkingIndicator())
 		}
 		viewParts = append(viewParts, m.editor.View())


### PR DESCRIPTION
The `/pause` command interrupts the run loop at the next iteration boundary, blocking it until resumed with `/pause` again. However, users can't currently see that this has happened—the TUI remains responsive to input, but there's no visual feedback indicating that the agent has been paused or is in the process of pausing.

This change adds visual state indicators to improve that experience. It introduces a `PausedEvent` emitted by the runtime when the run loop blocks at an iteration boundary, an `isPaused()` helper for checking pause state, and a three-state machine (`None`, `Pausing`, `Paused`) tracked per session in the TUI. The `handleTogglePause` function drives state transitions, and pause-related text is rendered directly in both the resize handle and lean-mode status views.

Users now see "Pausing… (finishing current request)" during the transient pause window, and "⏸ Paused (/pause to resume)" once the agent has fully stopped, making the pause action's effect clear and actionable.