### PR TITLE
fix(runtime): exempt list_background_agents from the loop-killer

### DIFF
--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -303,16 +303,17 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 	}
 
 	// Initialize consecutive duplicate tool call detector.
-	// Polling tools (view_background_agent, view_background_job) are
-	// expected to be called repeatedly with identical arguments while a
-	// background task is in progress. Exempt them so they never trigger
-	// the loop-termination path.
+	// Polling tools (view_background_agent, list_background_agents,
+	// view_background_job) are expected to be called repeatedly with
+	// identical arguments while a background task is in progress. Exempt
+	// them so they never trigger the loop-termination path.
 	loopThreshold := sess.MaxConsecutiveToolCalls
 	if loopThreshold == 0 {
 		loopThreshold = 5 // default: always active
 	}
 	ls.loopDetector = toolexec.NewLoopDetector(loopThreshold,
 		bgagent.ToolNameViewBackgroundAgent,
+		bgagent.ToolNameListBackgroundAgents,
 		shell.ToolNameViewBackgroundJob,
 	)
 

--- a/pkg/runtime/toolexec/loop_detector.go
+++ b/pkg/runtime/toolexec/loop_detector.go
@@ -25,8 +25,8 @@ type LoopDetector struct {
 // NewLoopDetector creates a detector that triggers after threshold
 // consecutive identical call batches. Tool names passed in exemptTools
 // are polling-safe: batches composed entirely of exempt tools (e.g.
-// view_background_agent, view_background_job) never count toward the
-// consecutive-duplicate limit.
+// view_background_agent, list_background_agents, view_background_job)
+// never count toward the consecutive-duplicate limit.
 func NewLoopDetector(threshold int, exemptTools ...string) *LoopDetector {
 	exempt := make(map[string]struct{}, len(exemptTools))
 	for _, name := range exemptTools {

--- a/pkg/runtime/toolexec/loop_detector_test.go
+++ b/pkg/runtime/toolexec/loop_detector_test.go
@@ -150,6 +150,24 @@ func TestLoopDetector(t *testing.T) {
 			wantCount: 0,
 		},
 		{
+			// list_background_agents is zero-arg, so every call is byte-identical.
+			// That makes it the textbook trigger for the consecutive-duplicate
+			// killer — but it's also the natural reach-for tool when a model
+			// has lost track of task IDs and needs to re-discover them. The
+			// runtime exempts it for the same reason it exempts the view_*
+			// tools: polling status is a legitimate, expected pattern.
+			name:        "exempt list_background_agents polling does not count as a loop",
+			threshold:   2,
+			exemptTools: []string{bgagent.ToolNameListBackgroundAgents},
+			batches: [][]tools.ToolCall{
+				makeCalls(bgagent.ToolNameListBackgroundAgents, `{}`),
+				makeCalls(bgagent.ToolNameListBackgroundAgents, `{}`),
+				makeCalls(bgagent.ToolNameListBackgroundAgents, `{}`),
+			},
+			wantTrip:  false,
+			wantCount: 0,
+		},
+		{
 			// A looping model cannot evade detection by interleaving a single
 			// polling call between identical non-exempt calls. Exempt calls are
 			// completely invisible to the detector and do NOT reset the counter.


### PR DESCRIPTION
## Summary

The runtime loop detector exempts polling tools (`view_background_agent`, `view_background_job`) because models legitimately call them repeatedly while waiting for background tasks. `list_background_agents` was missing from that exempt set — even though:

- It's the natural reach-for tool when an agent has lost track of task IDs and needs to re-discover them.
- It's the **most** likely victim of the killer, because it takes zero arguments — every call is byte-identical, so the consecutive-duplicate counter trips fast.

Hit this in production: an agent waiting on a background research task fell into a `list_background_agents` poll loop and got terminated mid-turn. Five identical zero-arg calls is exactly the consecutive-duplicate killer's trigger pattern, but it's also the user's intent (poll status). The right fix is to mirror what we already do for the `view_*` tools.

## Changes

- `pkg/runtime/loop.go`: add `bgagent.ToolNameListBackgroundAgents` to the exempt list passed to `NewLoopDetector`, and update the surrounding comment.
- `pkg/runtime/toolexec/loop_detector.go`: update the `NewLoopDetector` docstring's example list to include `list_background_agents`.
- `pkg/runtime/toolexec/loop_detector_test.go`: add a regression test for repeated zero-arg `list_background_agents` calls (matches the existing `view_background_agent` / `view_background_job` exemption tests).

## Test plan

- [x] `go test ./pkg/runtime/toolexec/...` — passes
- [x] `go build ./pkg/runtime/...` — clean
- [ ] Reviewer confirms the exemption is the right call vs. the alternative (teaching agents to use `view_background_agent` instead). My read: both are right, but a heuristic safety net that punishes the natural status-check tool is a footgun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)