### PR TITLE
fix(providers): consume delta.reasoning in chat-completions stream adapter

### DIFF
--- a/pkg/model/provider/oaistream/adapter.go
+++ b/pkg/model/provider/oaistream/adapter.go
@@ -67,15 +67,31 @@ func (a *StreamAdapter) Recv() (chat.MessageStreamResponse, error) {
 			a.lastFinishReason = finishReason
 		}
 
-		// Extract reasoning_content from ExtraFields since the OpenAI SDK
-		// does not yet have a dedicated field for it. Providers like DMR
-		// send reasoning tokens as a "reasoning_content" JSON field in the
-		// chat completion chunk delta.
+		// Extract reasoning text from ExtraFields since the OpenAI SDK does
+		// not have a dedicated field for it. OpenAI-compatible providers
+		// carry thinking tokens under different keys: DMR/DeepSeek use
+		// "reasoning_content", while Qwen3 thinking mode (e.g. via OVHcloud
+		// AI Endpoints), OpenRouter and several vLLM/SGLang builds use
+		// "reasoning". Without handling "reasoning", a Qwen3 turn that only
+		// reasons and then stops is dropped entirely and the user sees an
+		// empty reply. See https://github.com/docker/docker-agent/issues/3145.
 		var reasoningContent string
-		if ef, ok := choice.Delta.JSON.ExtraFields["reasoning_content"]; ok && ef.Raw() != "" {
-			// ef.Raw() returns the raw JSON value (e.g. `"some text"`), so
-			// we unmarshal it to get the plain Go string.
-			_ = json.Unmarshal([]byte(ef.Raw()), &reasoningContent)
+		for _, key := range []string{"reasoning_content", "reasoning"} {
+			ef, ok := choice.Delta.JSON.ExtraFields[key]
+			if !ok || ef.Raw() == "" {
+				continue
+			}
+			// ef.Raw() returns the raw JSON value (e.g. `"some text"`), so we
+			// unmarshal it to get the plain Go string. Some providers send a
+			// non-string "reasoning" (e.g. an object); ignore those and keep
+			// looking rather than surfacing a partial value.
+			if err := json.Unmarshal([]byte(ef.Raw()), &reasoningContent); err != nil {
+				reasoningContent = ""
+				continue
+			}
+			if reasoningContent != "" {
+				break
+			}
 		}
 
 		response.Choices[i] = chat.MessageStreamChoice{

--- a/pkg/model/provider/oaistream/adapter_test.go
+++ b/pkg/model/provider/oaistream/adapter_test.go
@@ -81,6 +81,53 @@ data: [DONE]
 	assert.ErrorIs(t, err, io.EOF)
 }
 
+// TestStreamAdapter_ReasoningField is a regression test for
+// https://github.com/docker/docker-agent/issues/3145. Qwen3 thinking mode (e.g.
+// via OVHcloud AI Endpoints), OpenRouter and several vLLM/SGLang builds stream
+// thinking tokens under a "reasoning" delta field (note the extra non-standard
+// "name" field too), not "reasoning_content". Before the fix the adapter only
+// read "reasoning_content", so a turn that only reasoned and then stopped was
+// dropped entirely and the user saw an empty reply.
+func TestStreamAdapter_ReasoningField(t *testing.T) {
+	t.Parallel()
+
+	// Faithful to the bytes captured from OVHcloud's Qwen3.5 endpoint: the
+	// model reasons via delta.reasoning, then stops with no content and no
+	// tool calls.
+	sseData := `data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"Qwen3.5","choices":[{"index":0,"delta":{"role":"assistant","reasoning":"The user","name":"assistant"}}]}
+
+data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"Qwen3.5","choices":[{"index":0,"delta":{"role":"assistant","reasoning":" wants help","name":"assistant"}}]}
+
+data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"Qwen3.5","choices":[{"index":0,"delta":{"role":"assistant","name":"assistant"},"finish_reason":"stop"}]}
+
+data: [DONE]
+
+`
+
+	stream := newTestStream(t, sseData)
+	adapter := NewStreamAdapter(stream, false)
+	defer adapter.Close()
+
+	resp, err := adapter.Recv()
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+	assert.Equal(t, "The user", resp.Choices[0].Delta.ReasoningContent)
+	assert.Empty(t, resp.Choices[0].Delta.Content)
+
+	resp, err = adapter.Recv()
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+	assert.Equal(t, " wants help", resp.Choices[0].Delta.ReasoningContent)
+
+	resp, err = adapter.Recv()
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+	assert.Equal(t, "stop", string(resp.Choices[0].FinishReason))
+
+	_, err = adapter.Recv()
+	assert.ErrorIs(t, err, io.EOF)
+}
+
 func TestStreamAdapter_NoReasoningContent(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #3145.

## TL;DR

Qwen3 thinking mode streams its thinking under a non-standard `delta.reasoning` SSE field. The shared OpenAI-compatible adapter only read `delta.reasoning_content`, so the thinking was dropped. A turn that **only reasons and then stops** ended up completely empty and silent.

## Symptom

```
Stream processed       tool_calls=0 content_length=0 stopped=true
Skipping empty assistant message (no content and no tool calls)
Conversation stopped
```

## Investigation

Hypotheses tested against the real OVHcloud Qwen3.5 stream:

| Hypothesis | Verdict |
|---|---|
| `delta.reasoning` breaks SSE/JSON decoding | ❌ reasoning+tool_call streams parse fine |
| SSE filter / HTTP client truncates the stream | ❌ body always complete (HTTP/1.0/1.1/2, byte-by-byte) |
| OVH `data: [DONE]`-only responses | ⚠️ real, but a rate-limit artifact, not this bug |
| **`delta.reasoning` silently dropped by the adapter** | ✅ **confirmed** |

Only a "reason, then stop" turn reproduces `content_length=0 / tool_calls=0 / stopped=true`.

## Root cause

| | |
|---|---|
| Field used by Qwen3 / OpenRouter / some vLLM/SGLang | `delta.reasoning` |
| Field read by docker-agent | `delta.reasoning_content` only |
| Result | reasoning dropped → empty assistant message → nothing shown |

## Fix

`pkg/model/provider/oaistream/adapter.go`: read `reasoning` in addition to `reasoning_content`.

- `reasoning_content` keeps priority when both are present
- non-string values (e.g. an object) are ignored

## Behaviour — same "reason, then stop" stream

| | Before | After |
|---|---|---|
| stdout | *(empty)* | thinking is streamed |
| reasoning captured | no | yes |

## Verify

`go test ./pkg/model/provider/oaistream/ -run TestStreamAdapter_ReasoningField` (new regression test, fails without the fix).
