### PR TITLE
fix(mcp): forward configured headers to OAuth discovery on the server host

### DIFF
--- a/pkg/tools/mcp/oauth_helpers.go
+++ b/pkg/tools/mcp/oauth_helpers.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/docker/docker-agent/pkg/browser"
 	"github.com/docker/docker-agent/pkg/httpclient"
+	"github.com/docker/docker-agent/pkg/upstream"
 )
 
 // oauthHTTPClient is the *http.Client used for outbound OAuth requests
@@ -38,6 +39,71 @@ func oauthHTTPClientForAllowPrivateIPs(allowPrivateIPs bool) *http.Client {
 		return &http.Client{Timeout: 30 * time.Second}
 	}
 	return oauthHTTPClient
+}
+
+// oauthHTTPClientWithHeaders builds the HTTP client used by the OAuth flow
+// (protected-resource / authorization-server metadata discovery, dynamic
+// client registration, token exchange and refresh). It layers the configured
+// custom headers on top of the SSRF-safe (or allow_private_ips) transport,
+// but ONLY for requests that target the MCP server's own host.
+//
+// OAuth metadata can advertise authorization servers on hosts chosen by the
+// (untrusted) server response, so forwarding the configured headers to every
+// OAuth request would leak credentials (Authorization, API keys, ...) meant
+// for the MCP server to a third party. Scoping to the server's host mirrors
+// the main channel, which only ever talks to rawURL.
+//
+// This is what makes routing headers such as Grafana Cloud's X-Grafana-URL
+// reach the protected-resource-metadata request (served by the MCP host
+// itself), so the OAuth flow is scoped to the right instance instead of
+// prompting the user for it. See issue #3148.
+//
+// The returned client is a fresh instance; the shared oauthHTTPClient
+// singleton is never mutated.
+func oauthHTTPClientWithHeaders(rawURL string, headers map[string]string, allowPrivateIPs bool) *http.Client {
+	base := oauthHTTPClientForAllowPrivateIPs(allowPrivateIPs)
+	if len(headers) == 0 {
+		return base
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return base
+	}
+
+	// nil Transport means net/http uses DefaultTransport; make it explicit so
+	// the header wrapper sits outside it and the underlying (SSRF-safe) dialer
+	// still runs for header and non-header requests alike.
+	inner := base.Transport
+	if inner == nil {
+		inner = http.DefaultTransport
+	}
+	return &http.Client{
+		Timeout:       base.Timeout,
+		CheckRedirect: base.CheckRedirect,
+		Transport: &hostScopedHeaderTransport{
+			host:        u.Host,
+			withHeaders: upstream.NewHeaderTransport(inner, headers),
+			base:        inner,
+		},
+	}
+}
+
+// hostScopedHeaderTransport applies the configured custom headers only to
+// requests whose host matches host; every other request (e.g. an OAuth call
+// to a third-party authorization server advertised in server metadata) goes
+// through base unchanged so configured credentials are never forwarded
+// off-host.
+type hostScopedHeaderTransport struct {
+	host        string
+	withHeaders http.RoundTripper
+	base        http.RoundTripper
+}
+
+func (t *hostScopedHeaderTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if strings.EqualFold(req.URL.Host, t.host) {
+		return t.withHeaders.RoundTrip(req)
+	}
+	return t.base.RoundTrip(req)
 }
 
 // GenerateState generates a random state parameter for OAuth CSRF protection

--- a/pkg/tools/mcp/oauth_helpers.go
+++ b/pkg/tools/mcp/oauth_helpers.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -81,7 +82,7 @@ func oauthHTTPClientWithHeaders(rawURL string, headers map[string]string, allowP
 		Timeout:       base.Timeout,
 		CheckRedirect: base.CheckRedirect,
 		Transport: &hostScopedHeaderTransport{
-			host:        u.Host,
+			host:        hostWithoutDefaultPort(u.Host, u.Scheme),
 			withHeaders: upstream.NewHeaderTransport(inner, headers),
 			base:        inner,
 		},
@@ -100,10 +101,28 @@ type hostScopedHeaderTransport struct {
 }
 
 func (t *hostScopedHeaderTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	if strings.EqualFold(req.URL.Host, t.host) {
+	if strings.EqualFold(hostWithoutDefaultPort(req.URL.Host, req.URL.Scheme), t.host) {
 		return t.withHeaders.RoundTrip(req)
 	}
 	return t.base.RoundTrip(req)
+}
+
+// hostWithoutDefaultPort strips the scheme's default port from host so that
+// "mcp.example.com:443" and "mcp.example.com" compare equal under https
+// (likewise :80 under http). A non-default or absent port is left untouched.
+//
+// Both sides of the host-scoping comparison are normalised through this so
+// headers still flow when the configured URL and a server-advertised
+// discovery URL disagree on whether to spell out the standard port.
+func hostWithoutDefaultPort(host, scheme string) string {
+	h, port, err := net.SplitHostPort(host)
+	if err != nil {
+		return host // no port present
+	}
+	if (scheme == "https" && port == "443") || (scheme == "http" && port == "80") {
+		return h
+	}
+	return host
 }
 
 // GenerateState generates a random state parameter for OAuth CSRF protection

--- a/pkg/tools/mcp/oauth_test.go
+++ b/pkg/tools/mcp/oauth_test.go
@@ -1243,6 +1243,7 @@ type unmanagedOAuthTestServer struct {
 
 	tokenCalls atomic.Int32
 	lastForm   url.Values
+	prmHeaders http.Header
 }
 
 func newUnmanagedOAuthTestServer(t *testing.T) *unmanagedOAuthTestServer {
@@ -1251,6 +1252,7 @@ func newUnmanagedOAuthTestServer(t *testing.T) *unmanagedOAuthTestServer {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/.well-known/oauth-protected-resource", func(w http.ResponseWriter, r *http.Request) {
+		srv.prmHeaders = r.Header.Clone()
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(protectedResourceMetadata{
 			Resource:             srv.URL,
@@ -1398,6 +1400,37 @@ func TestUnmanagedOAuthFlow_DriveFlow_ExchangesCodeForToken(t *testing.T) {
 	assert.Equal(t, "registered-client-id", tok.ClientID)
 	assert.Equal(t, "registered-secret", tok.ClientSecret)
 	assert.Equal(t, srv.URL, tok.AuthServer)
+}
+
+// TestInitialize_CustomHeadersReachOAuthDiscovery drives the real
+// Initialize -> createHTTPClient path (not a hand-built transport) to prove
+// the production wiring forwards configured custom headers to the OAuth
+// protected-resource-metadata discovery request. Grafana Cloud relies on the
+// X-Grafana-URL header on that request to scope the OAuth flow to the right
+// instance; without it the auth screen prompts for the instance. Regression
+// test for issue #3148.
+func TestInitialize_CustomHeadersReachOAuthDiscovery(t *testing.T) {
+	srv := newUnmanagedOAuthTestServer(t)
+	defer srv.Close()
+
+	headers := map[string]string{"X-Grafana-URL": "https://instance.grafana.net/"}
+	client := newRemoteClient(srv.URL, "streamable", headers, NewInMemoryTokenStore(), nil, true)
+
+	// Decline the OAuth elicitation: the unmanaged flow reaches the
+	// protected-resource-metadata discovery request (which carries the
+	// header) before the elicitation, so declining lets Initialize return
+	// promptly while still exercising the discovery request through the real
+	// createHTTPClient wiring.
+	client.SetElicitationHandler(func(context.Context, *gomcp.ElicitParams) (tools.ElicitationResult, error) {
+		return tools.ElicitationResult{Action: tools.ElicitationActionDecline}, nil
+	})
+
+	_, err := client.Initialize(t.Context(), nil)
+	require.Error(t, err, "Initialize should fail after the OAuth elicitation is declined")
+
+	require.NotNil(t, srv.prmHeaders, "protected-resource-metadata endpoint was never hit during the OAuth flow")
+	assert.Equal(t, "https://instance.grafana.net/", srv.prmHeaders.Get("X-Grafana-URL"),
+		"the configured header must reach the protected-resource-metadata discovery request (issue #3148)")
 }
 
 // TestUnmanagedOAuthFlow_ElicitationDeclineReturnsSentinel verifies that

--- a/pkg/tools/mcp/oauth_test.go
+++ b/pkg/tools/mcp/oauth_test.go
@@ -878,6 +878,59 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
 
+// TestOAuthHTTPClientWithHeaders_StripsDefaultPort verifies that an explicit
+// standard port in the configured URL (e.g. https://host:443) is stripped
+// when building the host-scoping transport, so it matches the port-less
+// discovery URLs servers usually advertise instead of silently dropping the
+// headers. Guards the construction call site.
+func TestOAuthHTTPClientWithHeaders_StripsDefaultPort(t *testing.T) {
+	t.Parallel()
+
+	client := oauthHTTPClientWithHeaders("https://mcp.example.com:443/mcp",
+		map[string]string{"X-Grafana-URL": "https://instance.grafana.net/"}, false)
+	hst, ok := client.Transport.(*hostScopedHeaderTransport)
+	require.True(t, ok, "expected a host-scoped transport when headers are configured")
+	assert.Equal(t, "mcp.example.com", hst.host,
+		"a configured standard :443 port must be stripped so it matches port-less discovery URLs")
+}
+
+// TestHostScopedHeaderTransport_NormalizesRequestPort verifies the other side:
+// when the configured host omits the port but a server-advertised discovery
+// URL spells out :443, RoundTrip still routes through the header-bearing
+// transport. Guards the per-request normalisation in RoundTrip.
+func TestHostScopedHeaderTransport_NormalizesRequestPort(t *testing.T) {
+	t.Parallel()
+
+	var withHeadersCalled, baseCalled bool
+	mark := func(flag *bool) roundTripFunc {
+		return func(*http.Request) (*http.Response, error) {
+			*flag = true
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("")),
+			}, nil
+		}
+	}
+
+	tr := &hostScopedHeaderTransport{
+		host:        "mcp.example.com", // configured without an explicit port
+		withHeaders: mark(&withHeadersCalled),
+		base:        mark(&baseCalled),
+	}
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet,
+		"https://mcp.example.com:443/.well-known/oauth-protected-resource", http.NoBody)
+	require.NoError(t, err)
+	resp, err := tr.RoundTrip(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.True(t, withHeadersCalled,
+		"a request that spells out :443 must route through the header-bearing transport when the configured host omits it")
+	assert.False(t, baseCalled, "must not fall through to the header-less branch")
+}
+
 func TestOAuthTransportCoalescesConcurrentAuthorization(t *testing.T) {
 	authMux := http.NewServeMux()
 	authSrv := httptest.NewServer(authMux)

--- a/pkg/tools/mcp/remote.go
+++ b/pkg/tools/mcp/remote.go
@@ -178,7 +178,7 @@ func (c *remoteMCPClient) createHTTPClient() (*http.Client, *oauthTransport, err
 		managed:                   c.managed,
 		unmanagedOAuthRedirectURI: c.unmanagedOAuthRedirectURI,
 		oauthConfig:               c.oauthConfig,
-		oauthHTTPClient:           oauthHTTPClientForAllowPrivateIPs(c.allowPrivateIPs),
+		oauthHTTPClient:           oauthHTTPClientWithHeaders(c.url, c.headers, c.allowPrivateIPs),
 	}
 
 	// Persist cookies across requests

--- a/pkg/tools/mcp/remote_test.go
+++ b/pkg/tools/mcp/remote_test.go
@@ -184,6 +184,65 @@ func TestRemoteClientEmptyHeaders(t *testing.T) {
 	}
 }
 
+// TestOAuthHTTPClientWithHeaders_ScopesHeadersToMCPHost verifies that the
+// OAuth HTTP client forwards configured custom headers to requests targeting
+// the MCP server's own host — where protected-resource-metadata discovery is
+// served (issue #3148) — but NOT to requests aimed at a different host, such
+// as an authorization server advertised in the server's own metadata.
+func TestOAuthHTTPClientWithHeaders_ScopesHeadersToMCPHost(t *testing.T) {
+	t.Parallel()
+
+	var mcpHostHeader, thirdPartyHeader string
+	mcpHostHit := make(chan struct{}, 1)
+	thirdPartyHit := make(chan struct{}, 1)
+
+	mcpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mcpHostHeader = r.Header.Get("X-Grafana-URL")
+		w.WriteHeader(http.StatusOK)
+		mcpHostHit <- struct{}{}
+	}))
+	defer mcpServer.Close()
+
+	thirdParty := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		thirdPartyHeader = r.Header.Get("X-Grafana-URL")
+		w.WriteHeader(http.StatusOK)
+		thirdPartyHit <- struct{}{}
+	}))
+	defer thirdParty.Close()
+
+	headers := map[string]string{"X-Grafana-URL": "https://instance.grafana.net/"}
+	client := oauthHTTPClientWithHeaders(mcpServer.URL, headers, true)
+
+	mcpReq, err := http.NewRequestWithContext(t.Context(), http.MethodGet, mcpServer.URL, http.NoBody)
+	require.NoError(t, err)
+	resp, err := client.Do(mcpReq)
+	require.NoError(t, err)
+	resp.Body.Close()
+	<-mcpHostHit
+	assert.Equal(t, "https://instance.grafana.net/", mcpHostHeader,
+		"requests to the MCP server's own host must carry the configured header")
+
+	thirdPartyReq, err := http.NewRequestWithContext(t.Context(), http.MethodGet, thirdParty.URL, http.NoBody)
+	require.NoError(t, err)
+	resp, err = client.Do(thirdPartyReq)
+	require.NoError(t, err)
+	resp.Body.Close()
+	<-thirdPartyHit
+	assert.Empty(t, thirdPartyHeader,
+		"requests to a third-party host must NOT carry the configured header (credential-leak guard)")
+}
+
+// TestOAuthHTTPClientWithHeaders_NoHeadersReusesBaseClient verifies that with
+// no configured headers the helper returns the shared SSRF-safe OAuth client
+// unchanged — no wrapping, and the package singleton is never mutated.
+func TestOAuthHTTPClientWithHeaders_NoHeadersReusesBaseClient(t *testing.T) {
+	t.Parallel()
+
+	got := oauthHTTPClientWithHeaders("https://mcp.example.com/mcp", nil, false)
+	assert.Same(t, oauthHTTPClientForAllowPrivateIPs(false), got,
+		"with no headers the helper must return the base OAuth client unchanged")
+}
+
 // TestInitialize_SurfacesServerErrorInReturnedError verifies that when an
 // MCP server rejects the initialize call with a 4xx carrying a JSON-RPC
 // error body, the error returned by Initialize contains the server's own


### PR DESCRIPTION
Fixes #3148

## Problem

A remote MCP server's `headers` were applied only to the main MCP channel, never to the OAuth flow. Grafana Cloud needs `X-Grafana-URL` on the OAuth discovery request to scope the flow to the right instance; without it the auth screen keeps prompting for the instance.

## Root cause

| Request | Transport used | Headers sent? |
|---|---|---|
| Main MCP channel | `oauthTransport.base` (header transport) | yes |
| OAuth discovery / token | `oauthHTTPClient` (bare singleton) | no |

The `protected-resource-metadata` request (the one Grafana uses to scope the instance) went out with none of the configured headers.

## Fix

- The OAuth HTTP client now forwards the configured headers...
- ...but only to the MCP server's own host. Requests to a third-party authorization server (URL taken from untrusted server metadata) get no headers, so `Authorization` / API keys can't leak.
- Preserved: SSRF protection, `allow_private_ips`, timeout, and `${headers.NAME}` placeholders. The shared client singleton is never mutated.

## Tests

| Test | Verifies |
|---|---|
| `...ScopesHeadersToMCPHost` | header reaches the MCP host, not a third party |
| `...NoHeadersReusesBaseClient` | no headers configured -> base client returned unchanged |
| `TestInitialize_CustomHeadersReachOAuthDiscovery` | real `Initialize()` path; reverting the fix makes it fail (reproduces #3148) |

Validation: `go build ./...`, `golangci-lint run ./pkg/tools/mcp/...` (0 issues), `go test -race ./pkg/tools/mcp/` all pass.

## Caveat

Scoping is on the exact host of the configured URL. If a server ever required the header on a host different from its MCP endpoint, the scope would need widening. Started strict, for safety.
