### PR TITLE
docs: update documentation for recent merged PRs

### DIFF
--- a/docs/features/remote-mcp/index.md
+++ b/docs/features/remote-mcp/index.md
@@ -53,6 +53,12 @@ For full configuration details, see the [Tool Config]({{ '/configuration/tools/'
 Set `allow_private_ips: true` on a remote MCP toolset only when the MCP server or its OAuth registration/token endpoints intentionally resolve to private, loopback, or link-local addresses. The default blocks those OAuth helper requests to reduce SSRF risk.
 
 <div class="callout callout-info" markdown="1">
+<div class="callout-title">Headers forwarded during OAuth discovery
+</div>
+  <p>Configured <code>headers</code> are forwarded to OAuth protected-resource-metadata discovery requests directed at the MCP server's own host — not to third-party authorization servers. This allows services like Grafana Cloud that require a routing header (e.g. <code>X-Grafana-URL</code>) on the discovery request to scope the OAuth flow correctly. Headers are never sent to a different host than the one in <code>remote.url</code>.</p>
+</div>
+
+<div class="callout callout-info" markdown="1">
 <div class="callout-title">Automatic reconnection after idle timeouts
 </div>
   <p>Remote MCP connections (Streamable HTTP / SSE) automatically reconnect after the server closes an idle connection — no configuration needed. Services like Notion and Linear close idle connections periodically; docker-agent detects the clean close and reconnects with exponential backoff. To tune reconnect behaviour or disable reconnection entirely, use the <a href="{{ '/configuration/tools/#toolset-lifecycle' | relative_url }}"><code>lifecycle</code> block</a>.</p>

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -68,7 +68,7 @@ Type `/` during a session to see available commands, or press <kbd>Ctrl</kbd>+<k
 | `/star`            | Star/unstar the current session                                                      |
 | `/cost`            | Show cost breakdown for this session                                                 |
 | `/eval`            | Create an evaluation report                                                          |
-| `/pause`           | Pause/resume the runtime loop after the current request                              |
+| `/pause`           | Pause/resume the runtime loop. While the agent is mid-request, the resize handle shows "Pausing…" until the in-flight request completes; once the loop is blocked the indicator changes to "⏸ Paused". Run `/pause` again to resume. |
 | `/tools`           | Show every toolset (with lifecycle state) and the tools they expose                  |
 | `/skills`          | List skills available to the current agent                                           |
 | `/toolset-restart` | Force a supervisor-driven reconnect of the named toolset (`/toolset-restart <name>`) |

--- a/docs/providers/custom/index.md
+++ b/docs/providers/custom/index.md
@@ -174,6 +174,12 @@ agents:
     model: local_llm/llama-3.1-8b
 ```
 
+<div class="callout callout-info" markdown="1">
+<div class="callout-title">Reasoning tokens from OpenAI-compatible providers
+</div>
+  <p>Models that stream reasoning under <code>delta.reasoning</code> (e.g. Qwen3 served via OVHcloud AI Endpoints, OpenRouter, or a self-hosted vLLM / SGLang deployment) are fully supported. Docker Agent reads both the <code>delta.reasoning_content</code> and <code>delta.reasoning</code> fields from the stream, so thinking blocks are captured and shown in the TUI regardless of which field the server uses.</p>
+</div>
+
 ### API Router (Requesty, LiteLLM)
 
 ```yaml


### PR DESCRIPTION
Updates docs to reflect three code changes merged to `main` in the last 36 hours.

**PR #3156** — TUI pause visual states
Expanded the `/pause` slash command description in `docs/features/tui/index.md` to document the two-step visual feedback: "Pausing…" while the in-flight request finishes, then "⏸ Paused" once the loop is fully blocked.

**PR #3158** — `delta.reasoning` support for OpenAI-compatible providers
Added a callout in `docs/providers/custom/index.md` noting that Docker Agent now reads both `delta.reasoning_content` and `delta.reasoning` from streaming responses, enabling thinking-mode support for Qwen3 served via OVHcloud AI Endpoints, OpenRouter, or self-hosted vLLM/SGLang.

**PR #3159** — MCP OAuth headers forwarded to discovery
Added a callout in `docs/features/remote-mcp/index.md` clarifying that configured `headers` are now forwarded during the OAuth protected-resource-metadata discovery phase (scoped to the server's own host only), enabling services like Grafana Cloud that require routing headers to work correctly.