### PR TITLE
fix(session): drop duplicate tool results in sanitizeToolCalls

### DIFF
--- a/pkg/session/sanitize_orphan_test.go
+++ b/pkg/session/sanitize_orphan_test.go
@@ -78,6 +78,37 @@ func TestSanitizeToolCalls_KeepsMissingResultBalanced(t *testing.T) {
 	assertToolPairingInvariant(t, out) // synthetic result injected
 }
 
+// TestSanitizeToolCalls_DropsDuplicateToolResult guards the remaining
+// toolResult/toolUse imbalance that orphan-dropping alone does not cover: a
+// second tool_result carrying the same tool_call_id. Bedrock counts it as an
+// extra toolResult block ("the number of toolResult blocks ... exceeds the
+// number of toolUse blocks of previous turn"), the same ValidationException
+// family as #1676 and #1593. Only the first result for a given tool_use should
+// survive.
+func TestSanitizeToolCalls_DropsDuplicateToolResult(t *testing.T) {
+	messages := []chat.Message{
+		{Role: chat.MessageRoleUser, Content: "hi"},
+		{Role: chat.MessageRoleAssistant, ToolCalls: []tools.ToolCall{{ID: "tc1"}}},
+		{Role: chat.MessageRoleTool, ToolCallID: "tc1", Content: "result"},
+		{Role: chat.MessageRoleTool, ToolCallID: "tc1", Content: "duplicate result"},
+		{Role: chat.MessageRoleUser, Content: "next"},
+	}
+
+	out := sanitizeToolCalls(messages)
+
+	assertToolPairingInvariant(t, out)
+
+	var count int
+	for _, m := range out {
+		if m.Role == chat.MessageRoleTool && m.ToolCallID == "tc1" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly one tool result for tc1 after dedup, got %d", count)
+	}
+}
+
 // TestGetMessages_ResumeAfterCompaction_NoOrphanedToolResult exercises the full
 // GetMessages reconstruction path that runs on the first turn after a session
 // is resumed (runtime/loop.go calls sess.GetMessages before the loop starts).

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -1307,6 +1307,12 @@ func sanitizeToolCalls(messages []chat.Message) []chat.Message {
 			if msg.ToolCallID == "" || !pendingIDs[msg.ToolCallID] {
 				continue
 			}
+			// Drop duplicate tool results: a second result for the same
+			// tool_use leaves more toolResult than toolUse blocks, which strict
+			// providers (AWS Bedrock) reject the same way as an orphaned result.
+			if resultIDs[msg.ToolCallID] {
+				continue
+			}
 			resultIDs[msg.ToolCallID] = true
 
 		case msg.Role == chat.MessageRoleAssistant && len(msg.ToolCalls) > 0:


### PR DESCRIPTION
## TL;DR

- Most of this is already fixed by #3001: `sanitizeToolCalls` drops orphaned tool results and injects placeholders for missing ones, keeping `tool_use`/`tool_result` balanced for strict providers (AWS Bedrock, including via a LiteLLM proxy). Related to #1676 and #1593.
- This PR is a small follow-up that closes the one variant #3001 did not cover: a duplicate `tool_result` for the same `tool_call_id`.

## Context

AWS Bedrock rejects any turn whose toolResult blocks outnumber the previous turn's toolUse blocks:

> The number of toolResult blocks ... exceeds the number of toolUse blocks of previous turn.

Known structural causes and coverage:

| Cause | Handled by | Status |
| --- | --- | --- |
| Result with no matching `tool_use` (orphan) | `sanitizeToolCalls` (#3001) | covered |
| Result for a `tool_use` that never produced one (missing) | placeholder injection (#3001) | covered |
| Second result for the same `tool_call_id` (duplicate) | this PR | new |

## Change

- Drop a `tool_result` whose `tool_call_id` already received a result; keep the first.
- ~3 lines in `sanitizeToolCalls`, same spirit as #3001.

## Test

- `TestSanitizeToolCalls_DropsDuplicateToolResult` (new)
- existing sanitize / orphan tests still pass

## Notes

- Duplicates can surface from provider or streaming quirks (tool-call deltas re-emitting an id), so this completes the guard rather than fixing a confirmed in-the-wild trigger.