### PR TITLE
feat(shell): opt-in sudo askpass flow (#1551)

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -2038,6 +2038,10 @@
           "type": "boolean",
           "description": "Opt in to dialling non-public IP addresses (valid for type 'fetch', 'api', 'openapi', 'a2a', and remote MCP toolsets). By default protected HTTP clients refuse connections \u2014 after DNS resolution, so DNS rebinding is also blocked \u2014 to loopback, RFC1918 private ranges, link-local (including the cloud metadata endpoint at 169.254.169.254), multicast and the unspecified address. Set this to true when an agent legitimately needs to call internal services. For fetch, 'allowed_domains' / 'blocked_domains' are evaluated independently and still apply."
         },
+        "sudo_askpass": {
+          "type": "boolean",
+          "description": "Opt in to a sudo privilege escalation flow for the shell toolset (only valid for type 'shell'). When enabled, sudo commands prompt the user for their password through the host UI via SUDO_ASKPASS; in non-interactive runs the prompt is declined automatically. Only a bare 'sudo ...' invocation in a POSIX shell is handled. No effect on Windows. Default false."
+        },
         "url": {
           "type": "string",
           "description": "URL for the a2a or openapi tool",

--- a/cmd/root/askpass.go
+++ b/cmd/root/askpass.go
@@ -1,0 +1,40 @@
+package root
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/docker/docker-agent/pkg/tools/builtin/shell"
+)
+
+// newAskpassCmd returns the hidden `__askpass` helper that sudo invokes (via a
+// generated SUDO_ASKPASS wrapper script) when the shell toolset's
+// `sudo_askpass` flow is enabled. It bridges the password prompt back to the
+// running agent over a private unix socket and prints the password to stdout.
+// It is an internal helper, not meant to be run by hand.
+func newAskpassCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:    shell.AskpassCommandName + " [prompt]",
+		Short:  "Internal sudo askpass helper",
+		Args:   cobra.MaximumNArgs(1),
+		Hidden: true,
+		// Keep stdout clean: sudo reads the password from this command's
+		// stdout, so nothing else may write there.
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var prompt string
+			if len(args) > 0 {
+				prompt = args[0]
+			}
+			if err := shell.RunAskpassClient(cmd.Context(), prompt, cmd.OutOrStdout()); err != nil {
+				// Diagnostics go to stderr only; stdout must carry just the
+				// password for sudo to read.
+				fmt.Fprintln(cmd.ErrOrStderr(), "docker-agent askpass:", err)
+				return err
+			}
+			return nil
+		},
+	}
+}

--- a/cmd/root/askpass_test.go
+++ b/cmd/root/askpass_test.go
@@ -1,0 +1,26 @@
+package root
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/docker/docker-agent/pkg/tools/builtin/shell"
+)
+
+func TestIsAskpassInvocation(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, isAskpassInvocation([]string{shell.AskpassCommandName}))
+	assert.True(t, isAskpassInvocation([]string{shell.AskpassCommandName, "--", "[sudo] password:"}))
+	assert.False(t, isAskpassInvocation(nil))
+	assert.False(t, isAskpassInvocation([]string{"run"}))
+	assert.False(t, isAskpassInvocation([]string{"run", shell.AskpassCommandName}))
+}
+
+func TestAskpassIsManagementInvocation(t *testing.T) {
+	t.Parallel()
+
+	// __askpass must skip self-update (it is invoked by sudo mid-command).
+	assert.True(t, isManagementInvocation([]string{shell.AskpassCommandName, "--", "p"}))
+}

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -21,6 +21,7 @@ import (
 	"github.com/docker/docker-agent/pkg/paths"
 	"github.com/docker/docker-agent/pkg/selfupdate"
 	"github.com/docker/docker-agent/pkg/telemetry"
+	"github.com/docker/docker-agent/pkg/tools/builtin/shell"
 	"github.com/docker/docker-agent/pkg/version"
 )
 
@@ -163,6 +164,7 @@ We collect anonymous usage data to help improve docker agent. To disable:
 		newAliasCmd(),
 		newSandboxCmd(),
 		newServeCmd(),
+		newAskpassCmd(),
 	)
 
 	return cmd
@@ -194,7 +196,12 @@ func Execute(ctx context.Context, stdin io.Reader, stdout, stderr io.Writer, arg
 		}
 	})
 
-	if runningStandalone {
+	// The hidden __askpass helper is always invoked directly (sudo execs the
+	// generated wrapper, which execs this binary), but it inherits the docker
+	// CLI plugin reexec env, which would otherwise route it through the plugin
+	// framework and print docker usage to stdout — corrupting the password
+	// sudo reads. Force the standalone cobra path so the subcommand dispatches.
+	if runningStandalone || isAskpassInvocation(args) {
 		return rootCmd.Execute()
 	}
 
@@ -240,12 +247,19 @@ func visitAll(cmd *cobra.Command, fn func(*cobra.Command)) {
 //
 // Help and version are detected anywhere in args, not just at args[0], so that
 // per-subcommand help (e.g. "run --help") is also skipped.
+// isAskpassInvocation reports whether args invoke the hidden sudo askpass
+// helper. It must dispatch through the standalone cobra path even when the
+// docker CLI plugin reexec env is inherited (see Execute).
+func isAskpassInvocation(args []string) bool {
+	return len(args) > 0 && args[0] == shell.AskpassCommandName
+}
+
 func isManagementInvocation(args []string) bool {
 	if len(args) == 0 {
 		return false
 	}
 	switch args[0] {
-	case metadata.MetadataSubcommandName, cobra.ShellCompRequestCmd, cobra.ShellCompNoDescRequestCmd, "completion", "version", "help", "--version":
+	case metadata.MetadataSubcommandName, cobra.ShellCompRequestCmd, cobra.ShellCompNoDescRequestCmd, "completion", "version", "help", "--version", shell.AskpassCommandName:
 		return true
 	}
 	// A help request can appear after a subcommand ("run --help"); never update

--- a/docs/tools/shell/index.md
+++ b/docs/tools/shell/index.md
@@ -52,6 +52,8 @@ toolsets:
 
 When enabled, `sudo` commands prompt you for your password through the host UI (the input is masked). The password is handed to `sudo` over a private, per-session socket via the standard `SUDO_ASKPASS` mechanism — it is never written to the command line, the logs, or stored by the agent.
 
+The bridge environment variables (`SUDO_ASKPASS`, `CAGENT_ASKPASS_SOCKET`, `CAGENT_ASKPASS_TOKEN`) are added only to commands that invoke `sudo`, but within such a command they are visible to every child process, not just `sudo`. They carry a socket path and a session token, not the password; the socket lives in a `0700` directory, so only your own user can reach it.
+
 Notes and limitations:
 
 - Unix only. The flag has no effect on Windows.
@@ -59,6 +61,7 @@ Notes and limitations:
 - Only a bare `sudo ...` invocation in a POSIX shell (`sh`, `bash`, `zsh`, ...) is handled. `sudo` called by absolute path (`/usr/bin/sudo`), via `env sudo`, from inside a nested script, or under a non-POSIX shell (e.g. `fish`) is not intercepted and behaves as before.
 - Caching is `sudo`'s own. Because each shell tool call runs in a fresh shell with no controlling terminal, `sudo`'s credential cache does not persist across separate tool calls: you are prompted once per shell command that uses `sudo`. Within a single command, multiple `sudo` calls (e.g. `sudo a && sudo b`) usually share one prompt, subject to `sudo`'s own timestamp configuration.
 - The prompt must be answered within the command's timeout; raise the `timeout` parameter for `sudo` commands that may wait on input. Background jobs (`run_background_job`) are wired too, but their prompt only works while the originating turn is still active.
+- Prompts are serialized: if a single command runs two `sudo` calls in parallel (e.g. `sudo a & sudo b`), the second waits for the first prompt to be answered rather than opening two dialogs at once.
 
 ## Available Tools
 

--- a/docs/tools/shell/index.md
+++ b/docs/tools/shell/index.md
@@ -23,9 +23,10 @@ toolsets:
 
 ### Options
 
-| Property | Type   | Description                                         |
-| -------- | ------ | --------------------------------------------------- |
-| `env`    | object | Environment variables to set for all shell commands |
+| Property       | Type    | Description                                                                                          |
+| -------------- | ------- | --------------------------------------------------------------------------------------------------- |
+| `env`          | object  | Environment variables to set for all shell commands                                                 |
+| `sudo_askpass` | boolean | Opt in to prompting for a `sudo` password (see [Sudo support](#sudo-support)). Default `false`.     |
 
 ### Custom Environment Variables
 
@@ -36,6 +37,28 @@ toolsets:
       MY_VAR: "value"
       PATH: "${PATH}:/custom/bin"
 ```
+
+### Sudo support
+
+By default a shell command has no controlling terminal, so a `sudo` command that needs a password hangs until it times out (the agent usually gives up and falls back to printing manual instructions).
+
+Set `sudo_askpass: true` to enable a sudo privilege escalation flow:
+
+```yaml
+toolsets:
+  - type: shell
+    sudo_askpass: true
+```
+
+When enabled, `sudo` commands prompt you for your password through the host UI (the input is masked). The password is handed to `sudo` over a private, per-session socket via the standard `SUDO_ASKPASS` mechanism — it is never written to the command line, the logs, or stored by the agent.
+
+Notes and limitations:
+
+- Unix only. The flag has no effect on Windows.
+- Interactive UI only. In headless / non-interactive runs the prompt is declined automatically and `sudo` fails as before.
+- Only a bare `sudo ...` invocation in a POSIX shell (`sh`, `bash`, `zsh`, ...) is handled. `sudo` called by absolute path (`/usr/bin/sudo`), via `env sudo`, from inside a nested script, or under a non-POSIX shell (e.g. `fish`) is not intercepted and behaves as before.
+- Caching is `sudo`'s own. Because each shell tool call runs in a fresh shell with no controlling terminal, `sudo`'s credential cache does not persist across separate tool calls: you are prompted once per shell command that uses `sudo`. Within a single command, multiple `sudo` calls (e.g. `sudo a && sudo b`) usually share one prompt, subject to `sudo`'s own timestamp configuration.
+- The prompt must be answered within the command's timeout; raise the `timeout` parameter for `sudo` commands that may wait on input. Background jobs (`run_background_job`) are wired too, but their prompt only works while the originating turn is still active.
 
 ## Available Tools
 

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -1110,6 +1110,13 @@ type Toolset struct {
 	// nil means the field was omitted and may inherit from a referenced definition.
 	AllowPrivateIPs *bool `json:"allow_private_ips,omitempty" yaml:"allow_private_ips,omitempty"`
 
+	// For the `shell` toolset — opt in to a sudo privilege escalation flow.
+	// When enabled, sudo commands prompt the user for their password (masked)
+	// through the host UI via SUDO_ASKPASS; in non-interactive runs the prompt
+	// is declined automatically and sudo fails as before. No effect on Windows.
+	// nil/false keeps the default behaviour (sudo has no TTY and fails fast).
+	SudoAskpass *bool `json:"sudo_askpass,omitempty" yaml:"sudo_askpass,omitempty"`
+
 	// For the `rag` tool
 	RAGConfig *RAGConfig `json:"rag_config,omitempty" yaml:"rag_config,omitempty"`
 

--- a/pkg/config/latest/validate.go
+++ b/pkg/config/latest/validate.go
@@ -226,6 +226,9 @@ func (t *Toolset) validate() error {
 	if t.AllowPrivateIPsEnabled() && t.Type != "fetch" && t.Type != "mcp" && t.Type != "api" && t.Type != "openapi" && t.Type != "a2a" {
 		return errors.New("allow_private_ips can only be used with type 'fetch', 'api', 'openapi', 'a2a' or remote MCP toolsets")
 	}
+	if t.SudoAskpass != nil && t.Type != "shell" {
+		return errors.New("sudo_askpass can only be used with type 'shell'")
+	}
 	if len(t.AllowedDomains) > 0 && len(t.BlockedDomains) > 0 {
 		return errors.New("allowed_domains and blocked_domains are mutually exclusive")
 	}

--- a/pkg/config/toolset_validate_test.go
+++ b/pkg/config/toolset_validate_test.go
@@ -137,6 +137,69 @@ agents:
 	}
 }
 
+func TestToolset_Validate_SudoAskpass(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		config  string
+		wantErr string
+	}{
+		{
+			name: "sudo_askpass on shell is allowed",
+			config: `
+agents:
+  root:
+    model: "openai/gpt-4"
+    toolsets:
+      - type: shell
+        sudo_askpass: true
+`,
+			wantErr: "",
+		},
+		{
+			name: "sudo_askpass false on shell is allowed",
+			config: `
+agents:
+  root:
+    model: "openai/gpt-4"
+    toolsets:
+      - type: shell
+        sudo_askpass: false
+`,
+			wantErr: "",
+		},
+		{
+			name: "sudo_askpass on non-shell toolset is rejected",
+			config: `
+agents:
+  root:
+    model: "openai/gpt-4"
+    toolsets:
+      - type: filesystem
+        sudo_askpass: true
+`,
+			wantErr: "sudo_askpass can only be used with type 'shell'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var cfg latest.Config
+			err := yaml.Unmarshal([]byte(tt.config), &cfg)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestToolset_Validate_MCP_WorkingDir(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tools/builtin/shell/askpass.go
+++ b/pkg/tools/builtin/shell/askpass.go
@@ -14,6 +14,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"sync"
@@ -74,8 +75,26 @@ type askpassServer struct {
 	// current elicitation handler (it is re-applied each turn).
 	handler func() tools.ElicitationHandler
 
+	// promptSem serializes prompts to one at a time (buffered, size 1). The
+	// runtime elicitation pipe carries a single request, so two concurrent sudo
+	// calls (e.g. `sudo a & sudo b`) must not raise two dialogs at once.
+	promptSem chan struct{}
+
 	closeOnce sync.Once
 	closed    chan struct{} // closed by close() to cancel in-flight prompts
+}
+
+// sudoWordRe matches sudo as a whole word, so substrings like "pseudo",
+// "sudoku" or "sudoers" do not trigger the askpass wiring.
+var sudoWordRe = regexp.MustCompile(`\bsudo\b`)
+
+// commandInvokesSudo reports whether command appears to call sudo. It uses a
+// word boundary to avoid false positives on similar substrings. It can still
+// match a non-invoking mention (e.g. `grep sudo file`); in that case the
+// injected shell function is defined but never called and the bridge env is
+// unused, so the only cost is harmless extra env on that one command.
+func commandInvokesSudo(command string) bool {
+	return sudoWordRe.MatchString(command)
 }
 
 // resolveSelfExecutable returns the absolute path of the running binary,
@@ -152,13 +171,14 @@ func startAskpassServer(handler func() tools.ElicitationHandler) (*askpassServer
 	}
 
 	s := &askpassServer{
-		listener: listener,
-		dir:      dir,
-		socket:   socket,
-		script:   script,
-		token:    token,
-		handler:  handler,
-		closed:   make(chan struct{}),
+		listener:  listener,
+		dir:       dir,
+		socket:    socket,
+		script:    script,
+		token:     token,
+		handler:   handler,
+		promptSem: make(chan struct{}, 1),
+		closed:    make(chan struct{}),
 	}
 	go s.serve()
 	return s, nil
@@ -224,8 +244,13 @@ func (s *askpassServer) handleConn(conn net.Conn) {
 }
 
 // watchConn cancels the prompt when the connection closes (helper died) or the
-// server shuts down. It returns once ctx is done; the inner read goroutine
-// unblocks when handleConn closes the connection on return, so nothing leaks.
+// server shuts down. It uses an inner goroutine because a net.Conn read cannot
+// be selected on directly.
+//
+// Neither goroutine leaks: watchConn returns as soon as ctx is done (which
+// handleConn always triggers via its deferred cancel()), and the inner read
+// goroutine unblocks when handleConn's deferred conn.Close() runs on return,
+// which makes the blocked Read fail and close connClosed.
 func (s *askpassServer) watchConn(ctx context.Context, conn net.Conn, cancel context.CancelFunc) {
 	connClosed := make(chan struct{})
 	go func() {
@@ -249,6 +274,15 @@ func (s *askpassServer) watchConn(ctx context.Context, conn net.Conn, cancel con
 func (s *askpassServer) askUser(ctx context.Context, prompt string) (string, bool) {
 	handler := s.handler()
 	if handler == nil {
+		return "", false
+	}
+
+	// Only one prompt at a time. If a concurrent prompt is already open, wait
+	// for it (unless this request's helper goes away first, ctx cancellation).
+	select {
+	case s.promptSem <- struct{}{}:
+		defer func() { <-s.promptSem }()
+	case <-ctx.Done():
 		return "", false
 	}
 
@@ -298,7 +332,7 @@ func (s *askpassServer) close() {
 func writeAskpassResponse(conn net.Conn, resp askpassResponse) error {
 	// The password is the payload we must return to the askpass helper over
 	// the private local socket; this is the intended transmission, not a leak.
-	data, err := json.Marshal(resp) //nolint:gosec // G117: password is the intended socket payload
+	data, err := json.Marshal(resp) //nolint:gosec // the password is the intended payload returned to the askpass helper over the private local socket
 	if err != nil {
 		return err
 	}
@@ -370,9 +404,9 @@ func posixShellForFunc(shell string) bool {
 
 // wrapSudoCommand prepends a shell function that transparently adds `-A` to
 // every sudo invocation so sudo uses SUDO_ASKPASS instead of a TTY. It only
-// rewrites commands that actually mention sudo, and only for POSIX shells.
+// rewrites commands that invoke sudo, and only for POSIX shells.
 func wrapSudoCommand(command, shell string) string {
-	if !strings.Contains(command, "sudo") || !posixShellForFunc(shell) {
+	if !commandInvokesSudo(command) || !posixShellForFunc(shell) {
 		return command
 	}
 	return "sudo() { command sudo -A \"$@\"; }\n" + command
@@ -427,7 +461,7 @@ func (h *shellHandler) ensureAskpass() *askpassServer {
 // started. This keeps normal shell behaviour and the env surface untouched for
 // the common (non-sudo) case.
 func (h *shellHandler) applyAskpass(command string) (string, []string) {
-	if !h.askpassActive() || !strings.Contains(command, "sudo") {
+	if !h.askpassActive() || !commandInvokesSudo(command) {
 		return command, h.env
 	}
 	srv := h.ensureAskpass()

--- a/pkg/tools/builtin/shell/askpass.go
+++ b/pkg/tools/builtin/shell/askpass.go
@@ -1,0 +1,451 @@
+package shell
+
+import (
+	"bufio"
+	"context"
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+// AskpassCommandName is the hidden CLI subcommand sudo runs (via the generated
+// SUDO_ASKPASS wrapper) to fetch a password. It is exported so the command
+// registration in cmd/root stays in sync with the wrapper script built here.
+const AskpassCommandName = "__askpass"
+
+// Environment variables that bridge the hidden `__askpass` helper (which sudo
+// runs via the generated SUDO_ASKPASS wrapper) back to the running agent.
+const (
+	envAskpassSocket = "CAGENT_ASKPASS_SOCKET"
+	envAskpassToken  = "CAGENT_ASKPASS_TOKEN"
+)
+
+// askpassPromptTimeout caps how long a single password prompt stays open
+// waiting for the user before the request is abandoned.
+const askpassPromptTimeout = 2 * time.Minute
+
+// askpassRequest is sent by the helper to the agent over the private socket.
+type askpassRequest struct {
+	Token  string `json:"token"`
+	Prompt string `json:"prompt"`
+}
+
+// askpassResponse is the agent's reply. When OK is false the helper exits
+// non-zero so sudo aborts cleanly instead of retrying the prompt.
+type askpassResponse struct {
+	OK       bool   `json:"ok"`
+	Password string `json:"password,omitempty"`
+}
+
+// askpassSupported reports whether the sudo askpass flow can run here. It is a
+// Unix-only feature (sudo + a unix socket + a /bin/sh wrapper script); Windows
+// and js/wasm are no-ops.
+func askpassSupported() bool {
+	return runtime.GOOS != "windows" && runtime.GOOS != "js"
+}
+
+// askpassServer listens on a private unix socket for password requests coming
+// from the `__askpass` helper that sudo spawns, and answers them by asking the
+// user through the toolset's elicitation handler.
+type askpassServer struct {
+	listener net.Listener
+	dir      string // 0700 temp dir holding the socket + wrapper script
+	socket   string
+	script   string // SUDO_ASKPASS wrapper script path
+	token    string
+
+	// handler is consulted on every request so the server always sees the
+	// current elicitation handler (it is re-applied each turn).
+	handler func() tools.ElicitationHandler
+
+	closeOnce sync.Once
+	closed    chan struct{} // closed by close() to cancel in-flight prompts
+}
+
+// resolveSelfExecutable returns the absolute path of the running binary,
+// following symlinks (it may be installed as a docker cli-plugin symlink).
+func resolveSelfExecutable() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = resolved
+	}
+	return filepath.Abs(exe)
+}
+
+// shQuote wraps s in POSIX single quotes, escaping embedded single quotes,
+// so it is safe to embed in a /bin/sh command line. Inside single quotes no
+// expansion (`$`, backticks, `\`) occurs.
+func shQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+func randomToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// startAskpassServer creates the private socket plus the SUDO_ASKPASS wrapper
+// script and starts accepting connections. handler is consulted per request so
+// it always reflects the current elicitation handler.
+func startAskpassServer(handler func() tools.ElicitationHandler) (*askpassServer, error) {
+	if !askpassSupported() {
+		return nil, errors.New("sudo askpass is not supported on this platform")
+	}
+
+	exe, err := resolveSelfExecutable()
+	if err != nil {
+		return nil, fmt.Errorf("resolving executable for askpass: %w", err)
+	}
+
+	dir, err := os.MkdirTemp("", "cagent-askpass-")
+	if err != nil {
+		return nil, err
+	}
+
+	token, err := randomToken()
+	if err != nil {
+		_ = os.RemoveAll(dir)
+		return nil, err
+	}
+
+	socket := filepath.Join(dir, "sock")
+	var lnConfig net.ListenConfig
+	listener, err := lnConfig.Listen(context.Background(), "unix", socket)
+	if err != nil {
+		_ = os.RemoveAll(dir)
+		return nil, err
+	}
+
+	// sudo runs SUDO_ASKPASS as a single program with the prompt as its only
+	// argument, so the `__askpass` subcommand cannot be embedded directly.
+	// This wrapper forwards to the running binary; `--` keeps a prompt that
+	// looks like a flag from being parsed as one. The executable path is
+	// single-quoted (shQuote) so metacharacters in it are not interpreted.
+	script := filepath.Join(dir, "askpass.sh")
+	content := fmt.Sprintf("#!/bin/sh\nexec %s %s -- \"$@\"\n", shQuote(exe), AskpassCommandName)
+	if err := os.WriteFile(script, []byte(content), 0o700); err != nil { //nolint:gosec // the wrapper must be executable by its owner; the parent dir is 0700
+		_ = listener.Close()
+		_ = os.RemoveAll(dir)
+		return nil, err
+	}
+
+	s := &askpassServer{
+		listener: listener,
+		dir:      dir,
+		socket:   socket,
+		script:   script,
+		token:    token,
+		handler:  handler,
+		closed:   make(chan struct{}),
+	}
+	go s.serve()
+	return s, nil
+}
+
+// env returns the environment entries to add to a shell child so `sudo -A`
+// reaches back to this server.
+func (s *askpassServer) env() []string {
+	if s == nil {
+		return nil
+	}
+	return []string{
+		"SUDO_ASKPASS=" + s.script,
+		envAskpassSocket + "=" + s.socket,
+		envAskpassToken + "=" + s.token,
+	}
+}
+
+func (s *askpassServer) serve() {
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			return // listener closed
+		}
+		go s.handleConn(conn)
+	}
+}
+
+func (s *askpassServer) handleConn(conn net.Conn) {
+	defer conn.Close()
+
+	// Bound the whole exchange; the prompt (askUser) is the only slow part.
+	ctx, cancel := context.WithTimeout(context.Background(), askpassPromptTimeout)
+	defer cancel()
+
+	// The request is sent immediately, so a short read deadline is enough.
+	_ = conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+	line, err := bufio.NewReader(conn).ReadBytes('\n')
+	if err != nil && len(line) == 0 {
+		return
+	}
+	_ = conn.SetReadDeadline(time.Time{}) // clear; the prompt has its own timeout
+
+	var req askpassRequest
+	if err := json.Unmarshal(line, &req); err != nil {
+		_ = writeAskpassResponse(conn, askpassResponse{OK: false})
+		return
+	}
+	if subtle.ConstantTimeCompare([]byte(req.Token), []byte(s.token)) != 1 {
+		slog.WarnContext(ctx, "Rejected sudo askpass request with invalid token")
+		_ = writeAskpassResponse(conn, askpassResponse{OK: false})
+		return
+	}
+
+	// Cancel the prompt if the helper goes away (its command was killed/timed
+	// out, so its process group was SIGTERM'd) or the server is torn down. This
+	// dismisses the elicitation handler and frees the slot instead of blocking
+	// on a dead client for the full prompt timeout.
+	go s.watchConn(ctx, conn, cancel)
+
+	password, ok := s.askUser(ctx, req.Prompt)
+	_ = writeAskpassResponse(conn, askpassResponse{OK: ok, Password: password})
+}
+
+// watchConn cancels the prompt when the connection closes (helper died) or the
+// server shuts down. It returns once ctx is done; the inner read goroutine
+// unblocks when handleConn closes the connection on return, so nothing leaks.
+func (s *askpassServer) watchConn(ctx context.Context, conn net.Conn, cancel context.CancelFunc) {
+	connClosed := make(chan struct{})
+	go func() {
+		defer close(connClosed)
+		// The client sends nothing more after its request; this Read blocks
+		// until the connection closes (EOF/error), i.e. the helper is gone.
+		_, _ = conn.Read(make([]byte, 1))
+	}()
+	select {
+	case <-connClosed:
+		cancel()
+	case <-s.closed:
+		cancel()
+	case <-ctx.Done():
+	}
+}
+
+// askUser prompts the user for the sudo password through the elicitation
+// handler. It returns ("", false) when no interactive handler is available or
+// the user declines/cancels (or ctx is cancelled because the helper died).
+func (s *askpassServer) askUser(ctx context.Context, prompt string) (string, bool) {
+	handler := s.handler()
+	if handler == nil {
+		return "", false
+	}
+
+	message := strings.TrimSpace(prompt)
+	if message == "" {
+		message = "sudo is requesting your password."
+	}
+
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"password": map[string]any{
+				"type":   "string",
+				"title":  "Password",
+				"format": "password",
+			},
+		},
+		"required": []any{"password"},
+	}
+
+	result, err := handler(ctx, &mcp.ElicitParams{
+		Message:         message,
+		RequestedSchema: schema,
+		Meta:            mcp.Meta{"cagent/title": "sudo password"},
+	})
+	if err != nil || result.Action != tools.ElicitationActionAccept {
+		return "", false
+	}
+	pw, _ := result.Content["password"].(string)
+	if pw == "" {
+		return "", false
+	}
+	return pw, true
+}
+
+func (s *askpassServer) close() {
+	if s == nil {
+		return
+	}
+	s.closeOnce.Do(func() {
+		close(s.closed)
+		_ = s.listener.Close()
+		_ = os.RemoveAll(s.dir)
+	})
+}
+
+func writeAskpassResponse(conn net.Conn, resp askpassResponse) error {
+	// The password is the payload we must return to the askpass helper over
+	// the private local socket; this is the intended transmission, not a leak.
+	data, err := json.Marshal(resp) //nolint:gosec // G117: password is the intended socket payload
+	if err != nil {
+		return err
+	}
+	_ = conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
+	_, err = conn.Write(append(data, '\n'))
+	return err
+}
+
+// RunAskpassClient is the body of the hidden `__askpass` subcommand. sudo runs
+// it (through the generated wrapper script) to obtain a password: it dials the
+// agent's private socket, forwards the prompt, and prints the returned password
+// to out. It returns an error (a non-zero exit, which tells sudo to abort) when
+// the socket is unavailable or the user declines.
+func RunAskpassClient(ctx context.Context, prompt string, out io.Writer) error {
+	socket := os.Getenv(envAskpassSocket)
+	token := os.Getenv(envAskpassToken)
+	if socket == "" || token == "" {
+		return errors.New("askpass: not running under a docker-agent shell (missing socket env)")
+	}
+
+	dialCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	var dialer net.Dialer
+	conn, err := dialer.DialContext(dialCtx, "unix", socket)
+	if err != nil {
+		return fmt.Errorf("askpass: dial: %w", err)
+	}
+	defer conn.Close()
+
+	req, err := json.Marshal(askpassRequest{Token: token, Prompt: prompt})
+	if err != nil {
+		return err
+	}
+	_ = conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
+	if _, err := conn.Write(append(req, '\n')); err != nil {
+		return fmt.Errorf("askpass: send: %w", err)
+	}
+
+	// The user may take a while to type; allow a little more than the server's
+	// own prompt timeout.
+	_ = conn.SetReadDeadline(time.Now().Add(askpassPromptTimeout + 30*time.Second))
+	line, err := bufio.NewReader(conn).ReadBytes('\n')
+	if err != nil && len(line) == 0 {
+		return fmt.Errorf("askpass: read: %w", err)
+	}
+	var resp askpassResponse
+	if err := json.Unmarshal(line, &resp); err != nil {
+		return fmt.Errorf("askpass: decode: %w", err)
+	}
+	if !resp.OK {
+		return errors.New("askpass: password request was declined")
+	}
+	if _, err := io.WriteString(out, resp.Password+"\n"); err != nil {
+		return err
+	}
+	return nil
+}
+
+// posixShellForFunc reports whether the configured shell understands the POSIX
+// function syntax used to force `sudo -A`. Non-POSIX shells (e.g. fish) are
+// left untouched.
+func posixShellForFunc(shell string) bool {
+	switch filepath.Base(shell) {
+	case "sh", "bash", "zsh", "dash", "ash", "ksh", "mksh":
+		return true
+	}
+	return false
+}
+
+// wrapSudoCommand prepends a shell function that transparently adds `-A` to
+// every sudo invocation so sudo uses SUDO_ASKPASS instead of a TTY. It only
+// rewrites commands that actually mention sudo, and only for POSIX shells.
+func wrapSudoCommand(command, shell string) string {
+	if !strings.Contains(command, "sudo") || !posixShellForFunc(shell) {
+		return command
+	}
+	return "sudo() { command sudo -A \"$@\"; }\n" + command
+}
+
+// --- shellHandler askpass glue ---
+
+func (h *shellHandler) setElicitationHandler(handler tools.ElicitationHandler) {
+	h.elicitationMu.Lock()
+	h.elicitationHandler = handler
+	h.elicitationMu.Unlock()
+}
+
+func (h *shellHandler) currentElicitationHandler() tools.ElicitationHandler {
+	h.elicitationMu.RLock()
+	defer h.elicitationMu.RUnlock()
+	return h.elicitationHandler
+}
+
+// askpassActive reports whether the sudo askpass flow should be wired into the
+// next command: enabled in config, supported on this platform, and an
+// interactive elicitation handler is available to answer the prompt.
+func (h *shellHandler) askpassActive() bool {
+	return h.sudoAskpass && askpassSupported() && h.currentElicitationHandler() != nil
+}
+
+// ensureAskpass lazily starts the askpass server the first time it is needed.
+// It returns nil (askpass disabled for this command) on any startup failure.
+// The mutex makes lazy start safe against concurrent commands and a concurrent
+// stopAskpass.
+func (h *shellHandler) ensureAskpass() *askpassServer {
+	h.askpassMu.Lock()
+	defer h.askpassMu.Unlock()
+	if h.askpassStarted {
+		return h.askpass
+	}
+	h.askpassStarted = true
+	srv, err := startAskpassServer(h.currentElicitationHandler)
+	if err != nil {
+		slog.Warn("Failed to start sudo askpass helper; sudo will run without it", "error", err)
+		return nil
+	}
+	h.askpass = srv
+	return h.askpass
+}
+
+// applyAskpass prepares a command for execution under the sudo askpass flow.
+// It returns the command to run (with the `sudo -A` wrapper prepended when
+// applicable) and the environment to use. When the flow is inactive, or the
+// command does not invoke sudo, it is a no-op: the original command and the
+// shared base env are returned unchanged, and the askpass server is not even
+// started. This keeps normal shell behaviour and the env surface untouched for
+// the common (non-sudo) case.
+func (h *shellHandler) applyAskpass(command string) (string, []string) {
+	if !h.askpassActive() || !strings.Contains(command, "sudo") {
+		return command, h.env
+	}
+	srv := h.ensureAskpass()
+	if srv == nil {
+		return command, h.env
+	}
+	env := append(append([]string(nil), h.env...), srv.env()...)
+	return wrapSudoCommand(command, h.shell), env
+}
+
+// stopAskpass tears down the askpass server (socket + wrapper script) and
+// resets the lazy-start state so a later command can start a fresh server if
+// the handler is reused after a Stop.
+func (h *shellHandler) stopAskpass() {
+	h.askpassMu.Lock()
+	srv := h.askpass
+	h.askpass = nil
+	h.askpassStarted = false
+	h.askpassMu.Unlock()
+	srv.close()
+}

--- a/pkg/tools/builtin/shell/askpass_test.go
+++ b/pkg/tools/builtin/shell/askpass_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"net"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -133,6 +135,56 @@ func TestAskpass_CancelledWhenHelperDies(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("prompt was not cancelled after the helper connection closed")
 	}
+}
+
+func TestCommandInvokesSudo(t *testing.T) {
+	assert.True(t, commandInvokesSudo("sudo apt update"))
+	assert.True(t, commandInvokesSudo("echo x && sudo ls"))
+	// Word boundary avoids false positives on similar substrings.
+	assert.False(t, commandInvokesSudo("echo pseudo"))
+	assert.False(t, commandInvokesSudo("ls /etc/sudoers"))
+	assert.False(t, commandInvokesSudo("play sudoku"))
+	assert.False(t, commandInvokesSudo("ls -la"))
+}
+
+// TestAskpass_PromptsSerialized verifies two concurrent sudo prompts never open
+// two dialogs at once (the runtime carries a single elicitation request).
+func TestAskpass_PromptsSerialized(t *testing.T) {
+	if !askpassSupported() {
+		t.Skip("sudo askpass unsupported on this platform")
+	}
+
+	var active, maxActive int32
+	srv, err := startAskpassServer(func() tools.ElicitationHandler {
+		return func(_ context.Context, _ *mcp.ElicitParams) (tools.ElicitationResult, error) {
+			n := atomic.AddInt32(&active, 1)
+			for {
+				m := atomic.LoadInt32(&maxActive)
+				if n <= m || atomic.CompareAndSwapInt32(&maxActive, m, n) {
+					break
+				}
+			}
+			time.Sleep(50 * time.Millisecond)
+			atomic.AddInt32(&active, -1)
+			return tools.ElicitationResult{Action: tools.ElicitationActionAccept, Content: map[string]any{"password": "pw"}}, nil
+		}
+	})
+	require.NoError(t, err)
+	defer srv.close()
+
+	t.Setenv(envAskpassSocket, srv.socket)
+	t.Setenv(envAskpassToken, srv.token)
+
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Go(func() {
+			var out bytes.Buffer
+			assert.NoError(t, RunAskpassClient(t.Context(), "p", &out))
+		})
+	}
+	wg.Wait()
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&maxActive), "prompts must be serialized to one at a time")
 }
 
 func TestWrapSudoCommand(t *testing.T) {

--- a/pkg/tools/builtin/shell/askpass_test.go
+++ b/pkg/tools/builtin/shell/askpass_test.go
@@ -1,0 +1,185 @@
+package shell
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+func acceptHandler(password string) func() tools.ElicitationHandler {
+	return func() tools.ElicitationHandler {
+		return func(_ context.Context, _ *mcp.ElicitParams) (tools.ElicitationResult, error) {
+			return tools.ElicitationResult{
+				Action:  tools.ElicitationActionAccept,
+				Content: map[string]any{"password": password},
+			}, nil
+		}
+	}
+}
+
+func TestAskpass_RoundTrip(t *testing.T) {
+	if !askpassSupported() {
+		t.Skip("sudo askpass unsupported on this platform")
+	}
+
+	srv, err := startAskpassServer(acceptHandler("hunter2"))
+	require.NoError(t, err)
+	defer srv.close()
+
+	t.Setenv(envAskpassSocket, srv.socket)
+	t.Setenv(envAskpassToken, srv.token)
+
+	var out bytes.Buffer
+	require.NoError(t, RunAskpassClient(t.Context(), "[sudo] password for user:", &out))
+	assert.Equal(t, "hunter2\n", out.String())
+}
+
+func TestAskpass_Decline(t *testing.T) {
+	if !askpassSupported() {
+		t.Skip("sudo askpass unsupported on this platform")
+	}
+
+	srv, err := startAskpassServer(func() tools.ElicitationHandler {
+		return func(_ context.Context, _ *mcp.ElicitParams) (tools.ElicitationResult, error) {
+			return tools.ElicitationResult{Action: tools.ElicitationActionDecline}, nil
+		}
+	})
+	require.NoError(t, err)
+	defer srv.close()
+
+	t.Setenv(envAskpassSocket, srv.socket)
+	t.Setenv(envAskpassToken, srv.token)
+
+	var out bytes.Buffer
+	require.Error(t, RunAskpassClient(t.Context(), "prompt", &out))
+	assert.Empty(t, out.String())
+}
+
+func TestAskpass_BadToken(t *testing.T) {
+	if !askpassSupported() {
+		t.Skip("sudo askpass unsupported on this platform")
+	}
+
+	srv, err := startAskpassServer(acceptHandler("hunter2"))
+	require.NoError(t, err)
+	defer srv.close()
+
+	t.Setenv(envAskpassSocket, srv.socket)
+	t.Setenv(envAskpassToken, "wrong-token")
+
+	var out bytes.Buffer
+	require.Error(t, RunAskpassClient(t.Context(), "prompt", &out))
+	assert.Empty(t, out.String())
+}
+
+func TestAskpass_MissingEnv(t *testing.T) {
+	t.Setenv(envAskpassSocket, "")
+	t.Setenv(envAskpassToken, "")
+
+	var out bytes.Buffer
+	require.Error(t, RunAskpassClient(t.Context(), "prompt", &out))
+}
+
+func TestShQuote(t *testing.T) {
+	// No metacharacters: simple single-quote wrap.
+	assert.Equal(t, "'/usr/bin/docker-agent'", shQuote("/usr/bin/docker-agent"))
+	// Embedded single quote is escaped.
+	assert.Equal(t, `'a'\''b'`, shQuote("a'b"))
+	// Command-substitution metacharacters are inert inside single quotes.
+	assert.Equal(t, `'/tmp/x$(touch pwned)/a'`, shQuote("/tmp/x$(touch pwned)/a"))
+}
+
+// TestAskpass_CancelledWhenHelperDies verifies the prompt is cancelled when the
+// dialing helper goes away (its command was killed), instead of blocking on a
+// dead connection for the full prompt timeout.
+func TestAskpass_CancelledWhenHelperDies(t *testing.T) {
+	if !askpassSupported() {
+		t.Skip("sudo askpass unsupported on this platform")
+	}
+
+	cancelled := make(chan struct{})
+	srv, err := startAskpassServer(func() tools.ElicitationHandler {
+		return func(ctx context.Context, _ *mcp.ElicitParams) (tools.ElicitationResult, error) {
+			<-ctx.Done() // block like a real prompt until the context is cancelled
+			close(cancelled)
+			return tools.ElicitationResult{}, ctx.Err()
+		}
+	})
+	require.NoError(t, err)
+	defer srv.close()
+
+	var dialer net.Dialer
+	conn, err := dialer.DialContext(t.Context(), "unix", srv.socket)
+	require.NoError(t, err)
+	req, _ := json.Marshal(askpassRequest{Token: srv.token, Prompt: "p"})
+	_, err = conn.Write(append(req, '\n'))
+	require.NoError(t, err)
+
+	// Simulate the helper dying (killed with its command's process group).
+	require.NoError(t, conn.Close())
+
+	select {
+	case <-cancelled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("prompt was not cancelled after the helper connection closed")
+	}
+}
+
+func TestWrapSudoCommand(t *testing.T) {
+	t.Run("wraps sudo for posix shell", func(t *testing.T) {
+		got := wrapSudoCommand("sudo apt update", "/bin/bash")
+		assert.Contains(t, got, `sudo() { command sudo -A "$@"; }`)
+		assert.Contains(t, got, "sudo apt update")
+	})
+
+	t.Run("leaves non-sudo commands untouched", func(t *testing.T) {
+		assert.Equal(t, "ls -la", wrapSudoCommand("ls -la", "/bin/bash"))
+	})
+
+	t.Run("leaves non-posix shells untouched", func(t *testing.T) {
+		assert.Equal(t, "sudo apt update", wrapSudoCommand("sudo apt update", "/usr/bin/fish"))
+	})
+}
+
+// TestShellToolSet_ElicitableThroughWrappers guards the wiring the askpass flow
+// depends on: the runtime applies the elicitation handler via
+// tools.ConfigureHandlers, which finds the capability with tools.As. The shell
+// toolset is wrapped by NewStartable and WithName before that runs, so As must
+// be able to reach the inner ToolSet through both wrappers.
+func TestShellToolSet_ElicitableThroughWrappers(t *testing.T) {
+	ts := New(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
+	wrapped := tools.WithName(tools.NewStartable(ts), "shell")
+
+	e, ok := tools.As[tools.Elicitable](wrapped)
+	require.True(t, ok, "shell toolset must be discoverable as Elicitable through its wrappers")
+
+	e.SetElicitationHandler(func(_ context.Context, _ *mcp.ElicitParams) (tools.ElicitationResult, error) {
+		return tools.ElicitationResult{}, nil
+	})
+	assert.NotNil(t, ts.handler.currentElicitationHandler(), "handler must reach the inner shell handler")
+}
+
+func TestAskpassActive(t *testing.T) {
+	h := &shellHandler{sudoAskpass: true}
+	// No elicitation handler yet -> inactive.
+	assert.False(t, h.askpassActive())
+
+	h.setElicitationHandler(func(_ context.Context, _ *mcp.ElicitParams) (tools.ElicitationResult, error) {
+		return tools.ElicitationResult{Action: tools.ElicitationActionDecline}, nil
+	})
+	assert.Equal(t, askpassSupported(), h.askpassActive())
+
+	// Disabled in config -> never active even with a handler.
+	h.sudoAskpass = false
+	assert.False(t, h.askpassActive())
+}

--- a/pkg/tools/builtin/shell/shell.go
+++ b/pkg/tools/builtin/shell/shell.go
@@ -42,6 +42,7 @@ var (
 	_ tools.ToolSet      = (*ToolSet)(nil)
 	_ tools.Startable    = (*ToolSet)(nil)
 	_ tools.Instructable = (*ToolSet)(nil)
+	_ tools.Elicitable   = (*ToolSet)(nil)
 )
 
 type shellHandler struct {
@@ -52,6 +53,15 @@ type shellHandler struct {
 	workingDir      string
 	jobs            *concurrent.Map[string, *backgroundJob]
 	jobCounter      atomic.Int64
+
+	// sudoAskpass opts this toolset into the one-time sudo privilege
+	// escalation flow (SUDO_ASKPASS bridged to the elicitation handler).
+	sudoAskpass        bool
+	elicitationMu      sync.RWMutex
+	elicitationHandler tools.ElicitationHandler
+	askpassMu          sync.Mutex
+	askpassStarted     bool
+	askpass            *askpassServer
 }
 
 // Job status constants
@@ -253,8 +263,9 @@ func (h *shellHandler) runNativeCommand(timeoutCtx, ctx context.Context, command
 	// Cancellation is handled manually below (timeoutCtx + Process.Kill +
 	// process group + WaitDelay), so we use exec.Command rather than
 	// exec.CommandContext to keep that flow in one place.
+	command, cmdEnv := h.applyAskpass(command)
 	cmd := exec.Command(h.shell, append(h.shellArgsPrefix, command)...) //nolint:noctx // see comment above
-	cmd.Env = h.env
+	cmd.Env = cmdEnv
 	cmd.Dir = cwd
 	cmd.SysProcAttr = platformSpecificSysProcAttr()
 	cmd.WaitDelay = waitDelayAfterShellExit
@@ -308,8 +319,9 @@ func (h *shellHandler) RunShellBackground(_ context.Context, params RunShellBack
 	counter := h.jobCounter.Add(1)
 	jobID := fmt.Sprintf("job_%d_%d", time.Now().Unix(), counter)
 
-	cmd := exec.Command(h.shell, append(h.shellArgsPrefix, params.Cmd)...) //nolint:noctx // RunShellBackground intentionally outlives the request context
-	cmd.Env = h.env
+	bgCmd, bgEnv := h.applyAskpass(params.Cmd)
+	cmd := exec.Command(h.shell, append(h.shellArgsPrefix, bgCmd)...) //nolint:noctx // RunShellBackground intentionally outlives the request context
+	cmd.Env = bgEnv
 	cmd.Dir = h.resolveWorkDir(params.Cwd)
 	cmd.SysProcAttr = platformSpecificSysProcAttr()
 
@@ -492,7 +504,11 @@ func CreateToolSet(ctx context.Context, toolset latest.Toolset, runConfig *confi
 
 	env = append(env, os.Environ()...)
 
-	return New(env, runConfig), nil
+	ts := New(env, runConfig)
+	if toolset.SudoAskpass != nil && *toolset.SudoAskpass {
+		ts.handler.sudoAskpass = true
+	}
+	return ts, nil
 }
 
 // New creates a new shell toolset.
@@ -615,6 +631,14 @@ func (t *ToolSet) Tools(context.Context) ([]tools.Tool, error) {
 	}, nil
 }
 
+// SetElicitationHandler wires the runtime's elicitation handler into the shell
+// toolset. It is used by the sudo askpass flow to prompt the user for their
+// password. The handler is re-applied at the start of every turn, so this must
+// stay idempotent.
+func (t *ToolSet) SetElicitationHandler(handler tools.ElicitationHandler) {
+	t.handler.setElicitationHandler(handler)
+}
+
 func (t *ToolSet) Start(context.Context) error {
 	return nil
 }
@@ -627,6 +651,9 @@ func (t *ToolSet) Stop(context.Context) error {
 		}
 		return true
 	})
+
+	// Tear down the sudo askpass helper (socket + wrapper script), if started.
+	t.handler.stopAskpass()
 
 	return nil
 }

--- a/pkg/tui/dialog/elicitation.go
+++ b/pkg/tui/dialog/elicitation.go
@@ -364,7 +364,8 @@ func (d *ElicitationDialog) collectAndValidate() (map[string]any, int) {
 			}
 			content[field.Name] = field.EnumValues[idx]
 		default:
-			val := strings.TrimSpace(d.inputs[i].Value())
+			raw := d.inputs[i].Value()
+			val := strings.TrimSpace(raw)
 			if val == "" {
 				if field.Required {
 					d.fieldErrors[i] = "This field is required"
@@ -373,6 +374,12 @@ func (d *ElicitationDialog) collectAndValidate() (map[string]any, int) {
 					}
 				}
 				continue
+			}
+			// Secret fields (e.g. a sudo password) may legitimately contain
+			// leading/trailing whitespace; store the raw value. The trimmed
+			// copy above is only used for the required/empty check.
+			if field.Format == "password" {
+				val = raw
 			}
 			parsed, errMsg := d.parseAndValidateField(val, field)
 			if errMsg != "" {
@@ -728,6 +735,11 @@ func (d *ElicitationDialog) createInput(field ElicitationField, idx int) textinp
 	default: // string
 		ti.Placeholder = cmp.Or(field.Description, "Enter value")
 		ti.CharLimit = cmp.Or(field.MaxLength, defaultCharLimit)
+		// Mask secret fields (JSON Schema "format": "password"), e.g. the sudo
+		// password prompt, so the value is never echoed to the screen.
+		if field.Format == "password" {
+			ti.EchoMode = textinput.EchoPassword
+		}
 	}
 
 	// Set default value

--- a/pkg/tui/dialog/elicitation_test.go
+++ b/pkg/tui/dialog/elicitation_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -574,6 +575,29 @@ func TestElicitationDialog_collectAndValidate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestElicitationDialog_PasswordFieldMaskedAndUntrimmed(t *testing.T) {
+	t.Parallel()
+
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"password": map[string]any{"type": "string", "format": "password"},
+		},
+		"required": []any{"password"},
+	}
+	dialog := NewElicitationDialog("sudo", schema, nil).(*ElicitationDialog)
+
+	// The password input is masked, not echoed in clear text.
+	assert.Equal(t, textinput.EchoPassword, dialog.inputs[0].EchoMode)
+
+	// A password with surrounding whitespace must round-trip unchanged
+	// (regular string fields are trimmed, secret ones are not).
+	dialog.inputs[0].SetValue("  s p a c e d  ")
+	content, firstErrorIdx := dialog.collectAndValidate()
+	assert.Equal(t, -1, firstErrorIdx)
+	assert.Equal(t, "  s p a c e d  ", content["password"])
 }
 
 func TestElicitationDialog_LongEnumScrolls(t *testing.T) {


### PR DESCRIPTION
Closes #1551.

## Problem

Shell commands that run `sudo` get no controlling terminal, so an interactive `sudo` hangs until the command times out and the agent falls back to printing manual instructions.

## Approach

Opt-in `sudo_askpass: true` on the `shell` toolset, bridging sudo's standard `SUDO_ASKPASS` mechanism to the existing elicitation prompt. Nothing changes unless the flag is set and a command actually runs `sudo`.

```yaml
toolsets:
  - type: shell
    sudo_askpass: true
```

Flow when a `sudo` command runs:

1. The toolset lazily starts a private unix-socket server in a `0700` temp dir, writes a `SUDO_ASKPASS` wrapper script, and injects the bridge env (`SUDO_ASKPASS`, `CAGENT_ASKPASS_SOCKET`, `CAGENT_ASKPASS_TOKEN`) only into that command.
2. A `sudo() { command sudo -A "$@"; }` function is prepended (POSIX shells) so sudo uses askpass instead of a TTY.
3. The hidden `__askpass` subcommand dials the socket; the server asks the user via a masked elicitation prompt and returns the password to sudo on stdout.

## Security

| Concern | Handling |
| --- | --- |
| Password exposure | Only transits the local socket and the helper stdout. Never logged, stored, or put on the command line. |
| Socket access | `0700` dir, single-user; request carries a `crypto/rand` token compared with `subtle.ConstantTimeCompare`. |
| Wrapper script | Executable path is single-quote escaped, so metacharacters cannot run as commands. |
| `__askpass` stdout | Forced onto the standalone command path even under the docker CLI plugin reexec env, so plugin usage output never corrupts the password sudo reads. |
| Fail-closed | Decline, cancel, error, headless, bad token, and missing env all make sudo abort, never a spurious success. |

## Limitations (documented)

- Unix only; no effect on Windows.
- Interactive runs only; non-interactive runs decline the prompt and sudo fails as before.
- Only a bare `sudo ...` in a POSIX shell is intercepted (`/usr/bin/sudo`, `env sudo`, nested scripts, and non-POSIX shells like `fish` are not).
- No cross-tool-call credential cache: each shell tool call is a fresh, TTY-less shell, so a prompt appears once per sudo-using command. Within a single command, sudo's own caching applies.

## Tests

- `pkg/tools/builtin/shell`: socket round-trip, decline, bad token, missing env, helper-death cancellation, `shQuote`, sudo wrapping, Elicitable discovery through the toolset wrappers.
- `pkg/config`: `sudo_askpass` validation (shell only) plus schema parity.
- `pkg/tui/dialog`: password field masked and not trimmed.
- `cmd/root`: `__askpass` routing and management-invocation gating.

Verified end to end with the built binary in both standalone and docker-plugin invocation, plus cross-compile for windows and js/wasm.
