### PR TITLE
docs: document startup tool-listing timeout for wedged MCP servers

### DIFF
--- a/docs/community/troubleshooting/index.md
+++ b/docs/community/troubleshooting/index.md
@@ -134,6 +134,12 @@ MCP tools using stdio transport must complete the initialization handshake befor
 3. Check that the MCP server process starts and responds to `initialize`
 4. Verify environment variables required by the tool are set (check `env` and `env_file` in the toolset config)
 
+<div class="callout callout-info" markdown="1">
+<div class="callout-title">Startup tool-listing timeout
+</div>
+  <p>At startup, docker-agent queries each toolset for its tool list. If a toolset does not respond within 10 seconds (e.g. a wedged MCP stdio server that never answers <code>tools/list</code>), that toolset is skipped with a warning and the remaining toolsets load normally. The sidebar resolves showing whichever tools did load — no infinite spinner. Enable <code>--debug</code> to see the warning message, and use <code>/toolset-restart &lt;name&gt;</code> once the server becomes responsive.</p>
+</div>
+
 If a toolset keeps crashing in a tight loop, tune the [`lifecycle`]({{ '/configuration/tools/#toolset-lifecycle' | relative_url }}) block on the toolset (e.g. raise `backoff.initial`, lower `max_restarts`, or switch to the `best-effort` profile) so a flaky dependency does not amplify into a restart storm.
 
 ## Configuration Errors


### PR DESCRIPTION
Adds a callout to the troubleshooting guide explaining the 10-second per-toolset tool-listing timeout introduced in #3154.

When a MCP server does not respond to `tools/list` at startup, docker-agent now skips it after 10 s and lets the sidebar resolve with whichever toolsets loaded successfully. The callout tells users what to expect, where to find the warning (`--debug`), and how to recover (`/toolset-restart`).

**PR reviewed:** #3154 (fix: bound per-toolset tool listing during startup)
**File changed:** `docs/community/troubleshooting/index.md`