### PR TITLE
fix(modelsdev): skip models.dev fetch for custom providers (#3165)

### DIFF
--- a/pkg/config/runtime.go
+++ b/pkg/config/runtime.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/environment"
+	"github.com/docker/docker-agent/pkg/model/provider"
 	"github.com/docker/docker-agent/pkg/modelsdev"
 )
 
@@ -101,7 +102,9 @@ func (runConfig *RuntimeConfig) ModelsDevStore() (*modelsdev.Store, error) {
 		return runConfig.ModelsDevStoreOverride, nil
 	}
 	runConfig.modelsDevStoreOnce.Do(func() {
-		runConfig.modelsDevStore, runConfig.modelsDevStoreErr = modelsdev.NewStore()
+		runConfig.modelsDevStore, runConfig.modelsDevStoreErr = modelsdev.NewStore(
+			modelsdev.WithKnownProvider(provider.IsKnownProvider),
+		)
 	})
 	return runConfig.modelsDevStore, runConfig.modelsDevStoreErr
 }

--- a/pkg/modelsdev/store.go
+++ b/pkg/modelsdev/store.go
@@ -34,16 +34,25 @@ const (
 // The database is loaded on first access via GetDatabase and
 // then cached in memory for the lifetime of the Store.
 type Store struct {
-	cacheFile string
-	mu        sync.Mutex
-	db        *Database
+	cacheFile     string
+	knownProvider func(string) bool
+	mu            sync.Mutex
+	// db is the authoritative catalog from the full (fetch-eligible) load path.
+	db *Database
+	// cacheDB is a cache-only snapshot served to fetch-disallowed lookups. It is
+	// kept separate from db because it may be empty or stale and must never
+	// satisfy a later fetch-eligible lookup for a known provider; memoizing it
+	// keeps the hot path from re-reading and re-parsing the catalog file on
+	// every custom-provider resolution.
+	cacheDB *Database
 }
 
 // Opt configures a Store created with NewStore.
 type Opt func(*storeOptions)
 
 type storeOptions struct {
-	cacheFile string
+	cacheFile     string
+	knownProvider func(string) bool
 }
 
 // WithCache overrides the path of the on-disk cache file used by the Store.
@@ -51,6 +60,24 @@ type storeOptions struct {
 func WithCache(path string) Opt {
 	return func(o *storeOptions) {
 		o.cacheFile = path
+	}
+}
+
+// WithKnownProvider restricts which provider names may trigger an outbound
+// fetch of the models.dev catalog. The predicate should report whether a
+// provider is one models.dev could plausibly contain (a built-in or alias).
+//
+// Looking up a model for a provider the predicate rejects — typically a
+// user-defined custom provider whose config (base_url + token) is already
+// self-contained — resolves against the cached catalog only and never reaches
+// the network. This keeps custom providers working in internet-restricted
+// environments instead of blocking on a doomed GET to models.dev (issue #3165).
+//
+// When no predicate is set, every provider may trigger a fetch (the default,
+// backwards-compatible behaviour).
+func WithKnownProvider(fn func(string) bool) Opt {
+	return func(o *storeOptions) {
+		o.knownProvider = fn
 	}
 }
 
@@ -80,7 +107,8 @@ func NewStore(opts ...Opt) (*Store, error) {
 	}
 
 	return &Store{
-		cacheFile: cacheFile,
+		cacheFile:     cacheFile,
+		knownProvider: options.knownProvider,
 	}, nil
 }
 
@@ -94,25 +122,52 @@ func NewDatabaseStore(db *Database) *Store {
 
 // GetDatabase returns the models.dev database, fetching from cache or API as needed.
 func (s *Store) GetDatabase(ctx context.Context) (*Database, error) {
+	return s.getDatabase(ctx, true)
+}
+
+// getDatabase returns the models.dev database. When allowFetch is false the
+// catalog is served from memory or the on-disk cache only and the network is
+// never touched; a cache miss yields an empty database rather than an error.
+func (s *Store) getDatabase(ctx context.Context, allowFetch bool) (*Database, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	// The authoritative catalog, once loaded, serves every lookup — including
+	// fetch-disallowed ones, which then benefit from the fresher data.
 	if s.db != nil {
 		return s.db, nil
 	}
 
-	db, err := loadDatabase(ctx, s.cacheFile)
+	if !allowFetch {
+		// Serve (and memoize) a cache-only snapshot without touching the
+		// network. Kept out of s.db so it can never satisfy a later
+		// fetch-eligible lookup for a known provider.
+		if s.cacheDB == nil {
+			db, err := loadDatabase(ctx, s.cacheFile, false)
+			if err != nil {
+				return nil, err
+			}
+			s.cacheDB = db
+		}
+		return s.cacheDB, nil
+	}
+
+	db, err := loadDatabase(ctx, s.cacheFile, true)
 	if err != nil {
 		return nil, err
 	}
-
 	s.db = db
 	return db, nil
 }
 
-// getProvider returns a specific provider by ID.
+// getProvider returns a specific provider by ID. A provider the Store's
+// knownProvider predicate rejects (a user-defined custom provider) is looked
+// up without ever fetching the catalog from the network, so a self-contained
+// custom-provider config keeps working when models.dev is unreachable.
 func (s *Store) getProvider(ctx context.Context, providerID string) (*Provider, error) {
-	db, err := s.GetDatabase(ctx)
+	allowFetch := s.knownProvider == nil || s.knownProvider(providerID)
+
+	db, err := s.getDatabase(ctx, allowFetch)
 	if err != nil {
 		return nil, err
 	}
@@ -158,11 +213,26 @@ func (s *Store) GetModel(ctx context.Context, id ID) (*Model, error) {
 
 // loadDatabase loads the database from the local cache file or
 // falls back to fetching from the models.dev API.
-func loadDatabase(ctx context.Context, cacheFile string) (*Database, error) {
+//
+// When allowFetch is false the network is never touched: a fresh cache is
+// returned as-is, a stale cache is returned regardless of age, and a missing
+// cache yields an empty database. This lets lookups for providers models.dev
+// cannot know about resolve locally without a doomed outbound call.
+func loadDatabase(ctx context.Context, cacheFile string, allowFetch bool) (*Database, error) {
 	// Try to load from cache first
 	cached, err := loadFromCache(cacheFile)
-	if err == nil && time.Since(cached.LastRefresh) < refreshInterval {
+	if err == nil && (!allowFetch || time.Since(cached.LastRefresh) < refreshInterval) {
 		return &cached.Database, nil
+	}
+
+	if !allowFetch {
+		// No fresh cache and fetching is disallowed: use a stale cache if we
+		// have one, otherwise serve an empty catalog so the caller resolves to
+		// "provider not found" with no network call.
+		if cached != nil {
+			return &cached.Database, nil
+		}
+		return &Database{}, nil
 	}
 
 	// Cache is stale or doesn't exist — try a conditional fetch with the ETag.

--- a/pkg/modelsdev/store_test.go
+++ b/pkg/modelsdev/store_test.go
@@ -1,10 +1,154 @@
 package modelsdev
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// writeCache writes a fresh on-disk catalog cache the Store can load without
+// touching the network.
+func writeCache(tb testing.TB, path string, db Database) {
+	tb.Helper()
+	data, err := json.Marshal(CachedData{Database: db, LastRefresh: time.Now()})
+	require.NoError(tb, err)
+	require.NoError(tb, os.WriteFile(path, data, 0o600))
+}
+
+// expiredContext returns a context whose deadline is already in the past, so
+// any HTTP request built from it fails instantly without touching the network.
+// It stands in for an environment where models.dev is unreachable.
+func expiredContext(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithDeadline(t.Context(), time.Unix(0, 0))
+	t.Cleanup(cancel)
+	return ctx
+}
+
+// TestKnownProviderGatesFetch is the regression test for issue #3165: a lookup
+// for a provider the knownProvider predicate rejects (a user-defined custom
+// provider) must resolve locally without ever fetching the models.dev catalog,
+// while a known provider may still trigger a fetch.
+func TestKnownProviderGatesFetch(t *testing.T) {
+	t.Parallel()
+
+	// A cache path that does not exist, so there is no on-disk catalog to fall
+	// back on — the cold-start situation from the issue.
+	cacheFile := filepath.Join(t.TempDir(), "models_dev.json")
+	store, err := NewStore(
+		WithCache(cacheFile),
+		WithKnownProvider(func(p string) bool { return p == "openai" }),
+	)
+	require.NoError(t, err)
+
+	ctx := expiredContext(t)
+
+	// Custom provider: not known -> resolves locally, no network attempt.
+	_, err = store.GetModel(ctx, NewID("mistral_gateway", "mistral-small-latest"))
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "fetch from API",
+		"custom provider must not trigger a models.dev fetch")
+	assert.Contains(t, err.Error(), `provider "mistral_gateway" not found`)
+
+	// Known provider: a cold cache still warrants a fetch, which fails here
+	// only because the network is unreachable — confirming the gate did not
+	// disable fetching wholesale.
+	_, err = store.GetModel(ctx, NewID("openai", "gpt-4o"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fetch from API",
+		"known provider must still fetch the catalog when the cache is cold")
+}
+
+// TestNoPredicateAlwaysAllowsFetch guards the default, backwards-compatible
+// behaviour: with no knownProvider predicate every provider may fetch.
+func TestNoPredicateAlwaysAllowsFetch(t *testing.T) {
+	t.Parallel()
+
+	cacheFile := filepath.Join(t.TempDir(), "models_dev.json")
+	store, err := NewStore(WithCache(cacheFile))
+	require.NoError(t, err)
+
+	_, err = store.GetModel(expiredContext(t), NewID("mistral_gateway", "mistral-small-latest"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fetch from API")
+}
+
+// TestFetchDisallowedServesFromCache checks the cache-only path: a provider the
+// predicate rejects but that IS present in the on-disk cache resolves from the
+// cache without any network call, and an absent one is a clean "not found".
+func TestFetchDisallowedServesFromCache(t *testing.T) {
+	t.Parallel()
+
+	cacheFile := filepath.Join(t.TempDir(), "models_dev.json")
+	writeCache(t, cacheFile, Database{Providers: map[string]Provider{
+		// Present in the catalog but not in the known-provider set below.
+		"deepseek": {Models: map[string]Model{
+			"deepseek-chat": {Name: "DeepSeek Chat", Limit: Limit{Context: 64000}},
+		}},
+	}})
+
+	store, err := NewStore(
+		WithCache(cacheFile),
+		WithKnownProvider(func(p string) bool { return p == "openai" }),
+	)
+	require.NoError(t, err)
+
+	// Expired context: proves resolution is cache-only (no network) for a
+	// fetch-disallowed provider.
+	ctx := expiredContext(t)
+
+	m, err := store.GetModel(ctx, NewID("deepseek", "deepseek-chat"))
+	require.NoError(t, err)
+	assert.Equal(t, 64000, m.Limit.Context)
+
+	// Repeated lookups stay consistent (served from the memoized snapshot).
+	again, err := store.GetModel(ctx, NewID("deepseek", "deepseek-chat"))
+	require.NoError(t, err)
+	assert.Equal(t, m.Limit.Context, again.Limit.Context)
+
+	// A provider absent from the cache is still a clean not-found, no fetch.
+	_, err = store.GetModel(ctx, NewID("mistral_gateway", "x"))
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "fetch from API")
+}
+
+// BenchmarkGetModelFetchDisallowed guards the hot path: repeatedly resolving a
+// fetch-disallowed provider against a warm, sizable cache must not re-read and
+// re-parse the catalog file each call (the snapshot is memoized).
+func BenchmarkGetModelFetchDisallowed(b *testing.B) {
+	cacheFile := filepath.Join(b.TempDir(), "models_dev.json")
+	providers := make(map[string]Provider, 200)
+	for i := range 200 {
+		models := make(map[string]Model, 50)
+		for j := range 50 {
+			id := fmt.Sprintf("m-%d-%d", i, j)
+			models[id] = Model{Name: id, Limit: Limit{Context: 128000}}
+		}
+		providers[fmt.Sprintf("prov-%d", i)] = Provider{Models: models}
+	}
+	writeCache(b, cacheFile, Database{Providers: providers})
+
+	store, err := NewStore(
+		WithCache(cacheFile),
+		WithKnownProvider(func(p string) bool { return p == "openai" }),
+	)
+	require.NoError(b, err)
+
+	id := NewID("mistral_gateway", "whatever")
+	ctx := b.Context()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_, _ = store.GetModel(ctx, id)
+	}
+}
 
 func TestResolveModelAlias(t *testing.T) {
 	t.Parallel()

--- a/pkg/runtime/lazy_model_store.go
+++ b/pkg/runtime/lazy_model_store.go
@@ -4,20 +4,25 @@ import (
 	"context"
 	"sync"
 
+	"github.com/docker/docker-agent/pkg/model/provider"
 	"github.com/docker/docker-agent/pkg/modelsdev"
 )
 
 // lazyModelStore is the default ModelStore wired in when the caller did not
-// pass WithModelStore. It defers modelsdev.NewStore() (which calls
+// pass WithModelStore. It defers constructing the modelsdev store (which calls
 // os.UserHomeDir and creates the ~/.cagent cache directory) until the first
 // method invocation. This keeps NewLocalRuntime free of disk I/O — tests
 // that never touch the catalog can build a runtime without paying the cost
 // or hitting failure modes that depend on the host filesystem.
 //
-// The underlying modelsdev.NewStore is itself memoized via sync.OnceValues,
-// so wrapping it in a per-runtime sync.Once does not change cross-runtime
-// caching semantics; it simply isolates the failure of the home-dir lookup
-// to the first caller that actually needs catalog data.
+// The store is created with WithKnownProvider so that resolving a model for a
+// user-defined custom provider never triggers an outbound models.dev fetch.
+// Without it the request loop (loop.go) and session compaction would block on
+// a doomed GET to models.dev for every custom-provider model in an
+// internet-restricted environment (issue #3165).
+//
+// Each runtime gets its own *Store; the per-runtime sync.Once only defers
+// construction, it does not share catalog state across runtimes.
 type lazyModelStore struct {
 	once sync.Once
 	st   *modelsdev.Store
@@ -26,7 +31,7 @@ type lazyModelStore struct {
 
 func (l *lazyModelStore) load() (*modelsdev.Store, error) {
 	l.once.Do(func() {
-		l.st, l.err = modelsdev.NewStore()
+		l.st, l.err = modelsdev.NewStore(modelsdev.WithKnownProvider(provider.IsKnownProvider))
 	})
 	return l.st, l.err
 }

--- a/pkg/runtime/lazy_model_store_test.go
+++ b/pkg/runtime/lazy_model_store_test.go
@@ -1,8 +1,10 @@
 package runtime
 
 import (
+	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -76,4 +78,30 @@ func TestLazyModelStore_DefersError(t *testing.T) {
 	require.ErrorIs(t, err, wantErr)
 
 	assert.Equal(t, 1, calls, "loader should only run once even after multiple method calls")
+}
+
+// TestLazyModelStore_GatesCustomProvider is the regression test for issue
+// #3165. The runtime's default ModelStore must not reach out to models.dev
+// when resolving a model for a user-defined custom provider, so a
+// self-contained custom-provider config stays usable when models.dev is
+// unreachable. This exercises the exact store the request loop (loop.go:405)
+// and session compaction (session_compaction.go:198) use in production.
+func TestLazyModelStore_GatesCustomProvider(t *testing.T) {
+	// Point the cache at an empty home so there is no on-disk catalog to fall
+	// back on: a cold start, as in a freshly-spawned pod. t.Setenv forbids
+	// t.Parallel, which is fine here.
+	t.Setenv("HOME", t.TempDir())
+
+	var store ModelStore = &lazyModelStore{}
+
+	// An already-expired deadline makes any HTTP attempt fail instantly,
+	// standing in for "models.dev is unreachable" without real network state.
+	ctx, cancel := context.WithDeadline(t.Context(), time.Unix(0, 0))
+	defer cancel()
+
+	_, err := store.GetModel(ctx, modelsdev.NewID("mistral_gateway", "mistral-small-latest"))
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "fetch from API",
+		"custom provider must not trigger a models.dev fetch from the runtime store")
+	assert.Contains(t, err.Error(), `provider "mistral_gateway" not found`)
 }


### PR DESCRIPTION
## Problem

A custom provider — a name that is not a built-in/alias (e.g. `mistral_gateway`) defined with `base_url` + `token_key` — triggered a blocking `GET https://models.dev/api.json` (full ~3.4 MB catalog) during model resolution. In internet-restricted environments this hangs ~30s on every turn, making a self-contained custom-provider config unusable. Renaming to a known provider (e.g. `openai`) bypassed it.

Closes #3165.

## Fix

`modelsdev.Store` gains `WithKnownProvider`: a provider the predicate rejects is served cache-only and never fetches (missing cache → empty catalog → clean "provider not found"). The runtime's default store (`lazyModelStore`) and `RuntimeConfig.ModelsDevStore()` are wired with `provider.IsKnownProvider`, so only catalog providers (built-ins + aliases) can reach the network.

| Path | Before | After |
|---|---|---|
| `loop.go` `GetModel` (every turn) | fetch catalog for any provider | custom → no fetch |
| `session_compaction.go` `resolveContextLimit` | ~30s hang air-gapped | resolves instantly |
| known provider (openai/anthropic/bedrock…) | fetch | unchanged |

## Verification

Real binary, cold cache, custom-provider config from the issue:

| Binary | models.dev catalog fetched |
|---|---|
| `origin/main` | yes (~3.4 MB download) |
| this PR | no |

- `TestLazyModelStore_GatesCustomProvider` (runtime) reproduces the exact issue error without the fix, passes with it.
- `modelsdev` gate unit tests; `go build` / `vet` / `golangci-lint` / `-race` green.

## Known limitations (follow-ups, out of scope)

- TUI model picker / `models` CLI still fetch the full catalog (not the request-loop path).
- A custom provider without `provider_opts.context_size` has no context limit, so compaction stays disabled for it (inference unaffected — it routes via `base_url`).
