### PR TITLE
feat(embeddedchat): add headless chat session API

### DIFF
--- a/pkg/embeddedchat/embeddedchat.go
+++ b/pkg/embeddedchat/embeddedchat.go
@@ -78,9 +78,9 @@ type ToolActivity struct {
 
 // runtimeRunner is the subset of runtime.Runtime the headless session needs.
 type runtimeRunner interface {
-	RunStream(context.Context, *session.Session) <-chan dagentruntime.Event
-	Resume(context.Context, dagentruntime.ResumeRequest)
-	ResumeElicitation(context.Context, tools.ElicitationAction, map[string]any) error
+	RunStream(ctx context.Context, sess *session.Session) <-chan dagentruntime.Event
+	Resume(ctx context.Context, req dagentruntime.ResumeRequest)
+	ResumeElicitation(ctx context.Context, action tools.ElicitationAction, content map[string]any) error
 	Close() error
 }
 

--- a/pkg/embeddedchat/embeddedchat.go
+++ b/pkg/embeddedchat/embeddedchat.go
@@ -1,0 +1,296 @@
+// Package embeddedchat provides a small headless chat wrapper around the
+// docker-agent runtime for embedders that want to drive an agent from their
+// own UI instead of running docker-agent's Bubble Tea application.
+package embeddedchat
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	dagentcfg "github.com/docker/docker-agent/pkg/config"
+	dagentruntime "github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/teamloader"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+// Config describes an embedded agent session.
+type Config struct {
+	// AgentSource is the agent/team definition to load. Bytes sources are a
+	// good fit for embedders that ship a pinned agent in their binary.
+	AgentSource dagentcfg.Source
+	// RuntimeConfig is passed to the team loader. When nil, a zero runtime
+	// config is used.
+	RuntimeConfig *dagentcfg.RuntimeConfig
+	// ToolsetRegistry resolves toolsets declared by AgentSource. When nil,
+	// docker-agent's default registry is used.
+	ToolsetRegistry teamloader.ToolsetRegistry
+	// RuntimeOptions are appended when constructing the runtime.
+	RuntimeOptions []dagentruntime.Opt
+	// SessionOptions are appended when constructing each conversation session.
+	SessionOptions []session.Opt
+}
+
+// Event is the UI-friendly form of one runtime stream event.
+type Event struct {
+	// Text is an assistant text delta.
+	Text string
+	// Tool describes a tool call starting, awaiting confirmation, or finishing.
+	Tool *ToolActivity
+	// Err is a user-facing runtime error.
+	Err error
+	// Done marks a clean end of the reply stream.
+	Done bool
+	// RuntimeEvent is the original docker-agent runtime event for callers that
+	// need lower-level details not projected above.
+	RuntimeEvent dagentruntime.Event
+}
+
+// ToolActivity describes one tool call surfaced by the runtime.
+type ToolActivity struct {
+	Call     tools.ToolCall
+	Def      tools.Tool
+	Finished bool
+	IsError  bool
+	// NeedsConfirmation is true when the runtime is blocked until Confirm is
+	// called with the user's decision.
+	NeedsConfirmation bool
+}
+
+// runtimeRunner is the subset of runtime.Runtime the headless session needs.
+type runtimeRunner interface {
+	RunStream(context.Context, *session.Session) <-chan dagentruntime.Event
+	Resume(context.Context, dagentruntime.ResumeRequest)
+	ResumeElicitation(context.Context, tools.ElicitationAction, map[string]any) error
+	Close() error
+}
+
+// Session owns one embedded runtime and one mutable conversation session.
+type Session struct {
+	cfg Config
+
+	rt      runtimeRunner
+	session *session.Session
+	welcome string
+
+	mu           sync.Mutex
+	activeCancel context.CancelFunc
+	activeRun    int
+}
+
+// New loads the configured agent and creates a fresh conversation session.
+func New(ctx context.Context, cfg Config) (*Session, error) {
+	if cfg.AgentSource == nil {
+		return nil, errors.New("embeddedchat: agent source is required")
+	}
+	runConfig := cfg.RuntimeConfig
+	if runConfig == nil {
+		runConfig = &dagentcfg.RuntimeConfig{}
+	}
+
+	var loadOpts []teamloader.Opt
+	if cfg.ToolsetRegistry != nil {
+		loadOpts = append(loadOpts, teamloader.WithToolsetRegistry(cfg.ToolsetRegistry))
+	}
+	loaded, err := teamloader.LoadWithConfig(ctx, cfg.AgentSource, runConfig, loadOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("embeddedchat: load agent: %w", err)
+	}
+
+	modelSwitcher := &dagentruntime.ModelSwitcherConfig{
+		Models:             loaded.Models,
+		Providers:          loaded.Providers,
+		ModelsGateway:      runConfig.ModelsGateway,
+		EnvProvider:        runConfig.EnvProvider(),
+		AgentDefaultModels: loaded.AgentDefaultModels,
+	}
+
+	runtimeOpts := []dagentruntime.Opt{
+		dagentruntime.WithModelSwitcherConfig(modelSwitcher),
+		dagentruntime.WithWorkingDir(runConfig.WorkingDir),
+		dagentruntime.WithSessionStore(session.NewInMemorySessionStore()),
+	}
+	runtimeOpts = append(runtimeOpts, cfg.RuntimeOptions...)
+	rt, err := dagentruntime.New(loaded.Team, runtimeOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("embeddedchat: create runtime: %w", err)
+	}
+
+	s := &Session{cfg: cfg, rt: rt}
+	if root, err := loaded.Team.DefaultAgent(); err == nil {
+		s.welcome = root.WelcomeMessage()
+	}
+	s.resetConversationLocked()
+	return s, nil
+}
+
+// WelcomeMessage returns the loaded agent's welcome message.
+func (s *Session) WelcomeMessage() string { return s.welcome }
+
+// Runtime returns the underlying docker-agent runtime for advanced embedders.
+// It returns nil only for sessions not created by New.
+func (s *Session) Runtime() dagentruntime.Runtime {
+	rt, _ := s.rt.(dagentruntime.Runtime)
+	return rt
+}
+
+// Conversation returns the underlying docker-agent session.
+func (s *Session) Conversation() *session.Session { return s.session }
+
+// Restart cancels any active run and replaces the conversation with a fresh
+// session, preserving the runtime and loaded agent.
+func (s *Session) Restart() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cancelActiveLocked()
+	s.resetConversationLocked()
+}
+
+// Close cancels any active run and releases runtime resources.
+func (s *Session) Close() error {
+	s.mu.Lock()
+	s.cancelActiveLocked()
+	s.mu.Unlock()
+	if s.rt != nil {
+		return s.rt.Close()
+	}
+	return nil
+}
+
+func (s *Session) resetConversationLocked() {
+	opts := append([]session.Opt(nil), s.cfg.SessionOptions...)
+	s.session = session.New(opts...)
+}
+
+func (s *Session) cancelActiveLocked() {
+	if s.activeCancel != nil {
+		s.activeCancel()
+		s.activeCancel = nil
+	}
+}
+
+// Send appends prompt to the conversation and streams the assistant reply.
+// The returned channel is closed after either a Done event or an Err event.
+// If ctx is cancelled, Send drains the runtime stream until it stops, but no
+// further events are delivered to the caller.
+func (s *Session) Send(ctx context.Context, prompt string) (<-chan Event, error) {
+	if s.rt == nil || s.session == nil {
+		return nil, errors.New("embeddedchat: session is not initialized")
+	}
+
+	s.mu.Lock()
+	if s.activeCancel != nil {
+		s.mu.Unlock()
+		return nil, errors.New("embeddedchat: a run is already active")
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	s.activeCancel = cancel
+	s.activeRun++
+	runID := s.activeRun
+	s.session.AddMessage(session.UserMessage(prompt))
+	sess := s.session
+	rt := s.rt
+	s.mu.Unlock()
+
+	out := make(chan Event)
+	go s.forwardEvents(runCtx, rt.RunStream(runCtx, sess), out, cancel, runID)
+	return out, nil
+}
+
+// Confirm answers the pending tool confirmation, if any.
+func (s *Session) Confirm(ctx context.Context, req dagentruntime.ResumeRequest) {
+	if s.rt == nil {
+		return
+	}
+	s.rt.Resume(ctx, req)
+}
+
+func (s *Session) forwardEvents(ctx context.Context, events <-chan dagentruntime.Event, out chan<- Event, cancel context.CancelFunc, runID int) {
+	defer close(out)
+	defer cancel()
+	defer func() {
+		s.mu.Lock()
+		if s.activeRun == runID {
+			s.activeCancel = nil
+		}
+		s.mu.Unlock()
+	}()
+
+	emit := func(e Event) bool {
+		select {
+		case out <- e:
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
+
+	errSent := false
+	for event := range events {
+		if ctx.Err() != nil {
+			continue
+		}
+
+		switch e := event.(type) {
+		case *dagentruntime.ToolCallConfirmationEvent:
+			if errSent {
+				s.rt.Resume(ctx, dagentruntime.ResumeReject("The run was aborted."))
+				continue
+			}
+			if !emit(Event{RuntimeEvent: event, Tool: &ToolActivity{Call: e.ToolCall, Def: e.ToolDefinition, NeedsConfirmation: true}}) {
+				s.rt.Resume(ctx, dagentruntime.ResumeReject("The run was aborted."))
+			}
+		case *dagentruntime.ElicitationRequestEvent:
+			// This headless wrapper has no built-in elicitation UI. Decline so the
+			// run cannot hang forever; embedders that need elicitation can consume
+			// RuntimeEvent directly by driving the runtime themselves.
+			_ = s.rt.ResumeElicitation(ctx, "decline", nil)
+		case *dagentruntime.MaxIterationsReachedEvent:
+			s.rt.Resume(ctx, dagentruntime.ResumeReject(""))
+		case *dagentruntime.ErrorEvent:
+			if errSent {
+				continue
+			}
+			if !emit(Event{RuntimeEvent: event, Err: errors.New(e.Error)}) {
+				return
+			}
+			errSent = true
+		default:
+			if errSent {
+				continue
+			}
+			if translated, ok := TranslateRuntimeEvent(event); ok {
+				if !emit(translated) {
+					return
+				}
+			}
+		}
+	}
+	if !errSent && ctx.Err() == nil {
+		emit(Event{Done: true})
+	}
+}
+
+// TranslateRuntimeEvent translates content-bearing runtime events into the
+// compact Event shape used by embedded chat UIs.
+func TranslateRuntimeEvent(event dagentruntime.Event) (Event, bool) {
+	switch e := event.(type) {
+	case *dagentruntime.AgentChoiceEvent:
+		if e.Content == "" {
+			return Event{}, false
+		}
+		return Event{RuntimeEvent: event, Text: e.Content}, true
+	case *dagentruntime.ToolCallEvent:
+		return Event{RuntimeEvent: event, Tool: &ToolActivity{Call: e.ToolCall, Def: e.ToolDefinition}}, true
+	case *dagentruntime.ToolCallResponseEvent:
+		return Event{RuntimeEvent: event, Tool: &ToolActivity{
+			Call:     tools.ToolCall{ID: e.ToolCallID},
+			Def:      e.ToolDefinition,
+			Finished: true,
+			IsError:  e.Result != nil && e.Result.IsError,
+		}}, true
+	}
+	return Event{}, false
+}

--- a/pkg/embeddedchat/embeddedchat.go
+++ b/pkg/embeddedchat/embeddedchat.go
@@ -16,6 +16,19 @@ import (
 	"github.com/docker/docker-agent/pkg/tools"
 )
 
+const defaultEventBuffer = 32
+
+var (
+	// ErrAgentSourceRequired is returned when New is called without an agent source.
+	ErrAgentSourceRequired = errors.New("embeddedchat: agent source is required")
+	// ErrNotInitialized is returned when a Session has no runtime or conversation.
+	ErrNotInitialized = errors.New("embeddedchat: session is not initialized")
+	// ErrRunActive is returned when Send is called while a previous run is still active.
+	ErrRunActive = errors.New("embeddedchat: a run is already active")
+	// ErrClosed is returned when an operation is attempted after Close.
+	ErrClosed = errors.New("embeddedchat: session is closed")
+)
+
 // Config describes an embedded agent session.
 type Config struct {
 	// AgentSource is the agent/team definition to load. Bytes sources are a
@@ -31,6 +44,9 @@ type Config struct {
 	RuntimeOptions []dagentruntime.Opt
 	// SessionOptions are appended when constructing each conversation session.
 	SessionOptions []session.Opt
+	// EventBuffer controls the size of the channel returned by Send. When zero,
+	// a small default buffer is used.
+	EventBuffer int
 }
 
 // Event is the UI-friendly form of one runtime stream event.
@@ -43,8 +59,9 @@ type Event struct {
 	Err error
 	// Done marks a clean end of the reply stream.
 	Done bool
-	// RuntimeEvent is the original docker-agent runtime event for callers that
-	// need lower-level details not projected above.
+	// RuntimeEvent is the original docker-agent runtime event for projected
+	// events. Not every runtime event is forwarded by this compact API; callers
+	// that need the full raw stream can use Runtime().RunStream directly.
 	RuntimeEvent dagentruntime.Event
 }
 
@@ -78,12 +95,13 @@ type Session struct {
 	mu           sync.Mutex
 	activeCancel context.CancelFunc
 	activeRun    int
+	closed       bool
 }
 
 // New loads the configured agent and creates a fresh conversation session.
 func New(ctx context.Context, cfg Config) (*Session, error) {
 	if cfg.AgentSource == nil {
-		return nil, errors.New("embeddedchat: agent source is required")
+		return nil, ErrAgentSourceRequired
 	}
 	runConfig := cfg.RuntimeConfig
 	if runConfig == nil {
@@ -132,29 +150,48 @@ func (s *Session) WelcomeMessage() string { return s.welcome }
 // Runtime returns the underlying docker-agent runtime for advanced embedders.
 // It returns nil only for sessions not created by New.
 func (s *Session) Runtime() dagentruntime.Runtime {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	rt, _ := s.rt.(dagentruntime.Runtime)
 	return rt
 }
 
 // Conversation returns the underlying docker-agent session.
-func (s *Session) Conversation() *session.Session { return s.session }
+//
+// The returned pointer is mutable and may be replaced by Restart. Callers that
+// mutate it directly are responsible for coordinating with Send/Restart.
+func (s *Session) Conversation() *session.Session {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.session
+}
 
 // Restart cancels any active run and replaces the conversation with a fresh
 // session, preserving the runtime and loaded agent.
-func (s *Session) Restart() {
+func (s *Session) Restart() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.closed {
+		return ErrClosed
+	}
 	s.cancelActiveLocked()
 	s.resetConversationLocked()
+	return nil
 }
 
 // Close cancels any active run and releases runtime resources.
 func (s *Session) Close() error {
 	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil
+	}
+	s.closed = true
 	s.cancelActiveLocked()
+	rt := s.rt
 	s.mu.Unlock()
-	if s.rt != nil {
-		return s.rt.Close()
+	if rt != nil {
+		return rt.Close()
 	}
 	return nil
 }
@@ -167,44 +204,57 @@ func (s *Session) resetConversationLocked() {
 func (s *Session) cancelActiveLocked() {
 	if s.activeCancel != nil {
 		s.activeCancel()
-		s.activeCancel = nil
 	}
 }
 
 // Send appends prompt to the conversation and streams the assistant reply.
-// The returned channel is closed after either a Done event or an Err event.
+// The returned channel closes when the runtime stream stops. A clean stream
+// emits a final Done event first; a stream that reports an ErrorEvent emits one
+// Err event, suppresses later projected events, then keeps draining until the
+// runtime stops.
 // If ctx is cancelled, Send drains the runtime stream until it stops, but no
 // further events are delivered to the caller.
 func (s *Session) Send(ctx context.Context, prompt string) (<-chan Event, error) {
-	if s.rt == nil || s.session == nil {
-		return nil, errors.New("embeddedchat: session is not initialized")
-	}
-
 	s.mu.Lock()
+	if s.rt == nil || s.session == nil {
+		s.mu.Unlock()
+		return nil, ErrNotInitialized
+	}
+	if s.closed {
+		s.mu.Unlock()
+		return nil, ErrClosed
+	}
 	if s.activeCancel != nil {
 		s.mu.Unlock()
-		return nil, errors.New("embeddedchat: a run is already active")
+		return nil, ErrRunActive
 	}
 	runCtx, cancel := context.WithCancel(ctx)
 	s.activeCancel = cancel
 	s.activeRun++
 	runID := s.activeRun
 	s.session.AddMessage(session.UserMessage(prompt))
-	sess := s.session
-	rt := s.rt
+	events := s.rt.RunStream(runCtx, s.session)
 	s.mu.Unlock()
 
-	out := make(chan Event)
-	go s.forwardEvents(runCtx, rt.RunStream(runCtx, sess), out, cancel, runID)
+	out := make(chan Event, eventBufferSize(s.cfg.EventBuffer))
+	go s.forwardEvents(runCtx, events, out, cancel, runID)
 	return out, nil
 }
 
 // Confirm answers the pending tool confirmation, if any.
-func (s *Session) Confirm(ctx context.Context, req dagentruntime.ResumeRequest) {
-	if s.rt == nil {
-		return
+func (s *Session) Confirm(ctx context.Context, req dagentruntime.ResumeRequest) error {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return ErrClosed
 	}
-	s.rt.Resume(ctx, req)
+	rt := s.rt
+	s.mu.Unlock()
+	if rt == nil {
+		return ErrNotInitialized
+	}
+	rt.Resume(ctx, req)
+	return nil
 }
 
 func (s *Session) forwardEvents(ctx context.Context, events <-chan dagentruntime.Event, out chan<- Event, cancel context.CancelFunc, runID int) {
@@ -246,7 +296,7 @@ func (s *Session) forwardEvents(ctx context.Context, events <-chan dagentruntime
 			// This headless wrapper has no built-in elicitation UI. Decline so the
 			// run cannot hang forever; embedders that need elicitation can consume
 			// RuntimeEvent directly by driving the runtime themselves.
-			_ = s.rt.ResumeElicitation(ctx, "decline", nil)
+			_ = s.rt.ResumeElicitation(ctx, tools.ElicitationActionDecline, nil)
 		case *dagentruntime.MaxIterationsReachedEvent:
 			s.rt.Resume(ctx, dagentruntime.ResumeReject(""))
 		case *dagentruntime.ErrorEvent:
@@ -271,6 +321,13 @@ func (s *Session) forwardEvents(ctx context.Context, events <-chan dagentruntime
 	if !errSent && ctx.Err() == nil {
 		emit(Event{Done: true})
 	}
+}
+
+func eventBufferSize(configured int) int {
+	if configured > 0 {
+		return configured
+	}
+	return defaultEventBuffer
 }
 
 // TranslateRuntimeEvent translates content-bearing runtime events into the

--- a/pkg/embeddedchat/embeddedchat_test.go
+++ b/pkg/embeddedchat/embeddedchat_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	dagentcfg "github.com/docker/docker-agent/pkg/config"
 	dagentruntime "github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/tools"
-	"github.com/stretchr/testify/require"
 )
 
 func TestNewLoadsAgentAndWelcomeMessage(t *testing.T) {

--- a/pkg/embeddedchat/embeddedchat_test.go
+++ b/pkg/embeddedchat/embeddedchat_test.go
@@ -1,0 +1,242 @@
+package embeddedchat
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	dagentcfg "github.com/docker/docker-agent/pkg/config"
+	dagentruntime "github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewLoadsAgentAndWelcomeMessage(t *testing.T) {
+	cfg := []byte(`agents:
+  root:
+    description: Test agent
+    instruction: Be helpful.
+    welcome_message: Hello from embedded chat.
+    harness:
+      type: claude-code
+`)
+
+	s, err := New(t.Context(), Config{AgentSource: dagentcfg.NewBytesSource("agent.yaml", cfg)})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	require.Equal(t, "Hello from embedded chat.", s.WelcomeMessage())
+	require.NotNil(t, s.Runtime())
+	require.NotNil(t, s.Conversation())
+}
+
+func TestNewRequiresAgentSource(t *testing.T) {
+	s, err := New(t.Context(), Config{})
+	require.Nil(t, s)
+	require.EqualError(t, err, "embeddedchat: agent source is required")
+}
+
+type fakeRuntime struct {
+	events chan dagentruntime.Event
+
+	runCtxs      []context.Context
+	resumes      []dagentruntime.ResumeRequest
+	elicitations []tools.ElicitationAction
+	closed       bool
+}
+
+func newFakeRuntime() *fakeRuntime {
+	return &fakeRuntime{events: make(chan dagentruntime.Event, 8)}
+}
+
+func (f *fakeRuntime) RunStream(ctx context.Context, _ *session.Session) <-chan dagentruntime.Event {
+	f.runCtxs = append(f.runCtxs, ctx)
+	return f.events
+}
+
+func (f *fakeRuntime) Resume(_ context.Context, req dagentruntime.ResumeRequest) {
+	f.resumes = append(f.resumes, req)
+}
+
+func (f *fakeRuntime) ResumeElicitation(_ context.Context, action tools.ElicitationAction, _ map[string]any) error {
+	f.elicitations = append(f.elicitations, action)
+	return nil
+}
+
+func (f *fakeRuntime) Close() error {
+	f.closed = true
+	return nil
+}
+
+func newTestSession(rt *fakeRuntime) *Session {
+	return &Session{rt: rt, session: session.New()}
+}
+
+func TestTranslateRuntimeEvent(t *testing.T) {
+	call := tools.ToolCall{ID: "call-1", Function: tools.FunctionCall{Name: "tool"}}
+	def := tools.Tool{Name: "tool"}
+
+	event, ok := TranslateRuntimeEvent(dagentruntime.AgentChoice("agent", "session", "hello"))
+	require.True(t, ok)
+	require.Equal(t, "hello", event.Text)
+
+	event, ok = TranslateRuntimeEvent(dagentruntime.ToolCall(call, def, "agent"))
+	require.True(t, ok)
+	require.Equal(t, call, event.Tool.Call)
+	require.Equal(t, def, event.Tool.Def)
+	require.False(t, event.Tool.Finished)
+
+	event, ok = TranslateRuntimeEvent(dagentruntime.ToolCallResponse("call-1", def, tools.ResultError("boom"), "boom", "agent"))
+	require.True(t, ok)
+	require.Equal(t, "call-1", event.Tool.Call.ID)
+	require.True(t, event.Tool.Finished)
+	require.True(t, event.Tool.IsError)
+
+	_, ok = TranslateRuntimeEvent(dagentruntime.AgentChoice("agent", "session", ""))
+	require.False(t, ok)
+}
+
+func TestSessionSendStreamsEventsAndDone(t *testing.T) {
+	rt := newFakeRuntime()
+	s := newTestSession(rt)
+
+	out, err := s.Send(t.Context(), "hi")
+	require.NoError(t, err)
+	require.Len(t, s.session.Messages, 1)
+
+	rt.events <- dagentruntime.AgentChoice("agent", s.session.ID, "hello")
+	require.Equal(t, "hello", receiveEvent(t, out).Text)
+
+	close(rt.events)
+	event := receiveEvent(t, out)
+	require.True(t, event.Done)
+	assertClosed(t, out)
+}
+
+func TestSessionSendSurfacesConfirmationAndConfirmResumesRuntime(t *testing.T) {
+	rt := newFakeRuntime()
+	s := newTestSession(rt)
+
+	out, err := s.Send(t.Context(), "use tool")
+	require.NoError(t, err)
+
+	call := tools.ToolCall{ID: "call-1", Function: tools.FunctionCall{Name: "write_file"}}
+	def := tools.Tool{Name: "write_file"}
+	rt.events <- dagentruntime.ToolCallConfirmation(call, def, "agent")
+
+	event := receiveEvent(t, out)
+	require.NotNil(t, event.Tool)
+	require.True(t, event.Tool.NeedsConfirmation)
+	require.Equal(t, call, event.Tool.Call)
+
+	s.Confirm(t.Context(), dagentruntime.ResumeApproveTool("write_file(*)"))
+	require.Len(t, rt.resumes, 1)
+	require.Equal(t, dagentruntime.ResumeTypeApproveTool, rt.resumes[0].Type)
+	require.Equal(t, "write_file(*)", rt.resumes[0].ToolName)
+}
+
+func TestSessionSendHandlesRuntimeErrorWithoutDone(t *testing.T) {
+	rt := newFakeRuntime()
+	s := newTestSession(rt)
+
+	out, err := s.Send(t.Context(), "hi")
+	require.NoError(t, err)
+	rt.events <- dagentruntime.Error("boom")
+
+	event := receiveEvent(t, out)
+	require.EqualError(t, event.Err, "boom")
+
+	rt.events <- dagentruntime.AgentChoice("agent", s.session.ID, "ignored")
+	close(rt.events)
+	assertClosed(t, out)
+}
+
+func TestSessionSendDeclinesElicitationAndRejectsMaxIterations(t *testing.T) {
+	rt := newFakeRuntime()
+	s := newTestSession(rt)
+
+	out, err := s.Send(t.Context(), "hi")
+	require.NoError(t, err)
+	rt.events <- dagentruntime.ElicitationRequest("authorize", "url", nil, "https://example.com", "id", nil, "agent")
+	rt.events <- dagentruntime.MaxIterationsReached(3)
+	close(rt.events)
+
+	require.True(t, receiveEvent(t, out).Done)
+	require.Equal(t, []tools.ElicitationAction{"decline"}, rt.elicitations)
+	require.Len(t, rt.resumes, 1)
+	require.Equal(t, dagentruntime.ResumeTypeReject, rt.resumes[0].Type)
+}
+
+func TestSessionSendRejectsConcurrentRun(t *testing.T) {
+	rt := newFakeRuntime()
+	s := newTestSession(rt)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	_, err := s.Send(ctx, "first")
+	require.NoError(t, err)
+
+	out, err := s.Send(t.Context(), "second")
+	require.Nil(t, out)
+	require.EqualError(t, err, "embeddedchat: a run is already active")
+
+	cancel()
+	close(rt.events)
+}
+
+func TestSessionCloseCancelsActiveRunAndClosesRuntime(t *testing.T) {
+	rt := newFakeRuntime()
+	s := newTestSession(rt)
+
+	_, err := s.Send(t.Context(), "hi")
+	require.NoError(t, err)
+	require.Len(t, rt.runCtxs, 1)
+
+	require.NoError(t, s.Close())
+	require.True(t, rt.closed)
+	require.Eventually(t, func() bool {
+		return errors.Is(rt.runCtxs[0].Err(), context.Canceled)
+	}, time.Second, time.Millisecond)
+
+	close(rt.events)
+}
+
+func TestSessionRestartCancelsRunAndReplacesConversation(t *testing.T) {
+	rt := newFakeRuntime()
+	s := newTestSession(rt)
+
+	_, err := s.Send(t.Context(), "hi")
+	require.NoError(t, err)
+	oldSession := s.session
+
+	s.Restart()
+	require.NotSame(t, oldSession, s.session)
+	require.Empty(t, s.session.Messages)
+	require.Eventually(t, func() bool {
+		return errors.Is(rt.runCtxs[0].Err(), context.Canceled)
+	}, time.Second, time.Millisecond)
+
+	close(rt.events)
+}
+
+func receiveEvent(t *testing.T, ch <-chan Event) Event {
+	t.Helper()
+	select {
+	case event, ok := <-ch:
+		require.True(t, ok)
+		return event
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for embedded chat event")
+		return Event{}
+	}
+}
+
+func assertClosed(t *testing.T, ch <-chan Event) {
+	t.Helper()
+	select {
+	case event, ok := <-ch:
+		require.False(t, ok, "unexpected event: %#v", event)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for embedded chat stream to close")
+	}
+}

--- a/pkg/embeddedchat/embeddedchat_test.go
+++ b/pkg/embeddedchat/embeddedchat_test.go
@@ -34,7 +34,7 @@ func TestNewLoadsAgentAndWelcomeMessage(t *testing.T) {
 func TestNewRequiresAgentSource(t *testing.T) {
 	s, err := New(t.Context(), Config{})
 	require.Nil(t, s)
-	require.EqualError(t, err, "embeddedchat: agent source is required")
+	require.ErrorIs(t, err, ErrAgentSourceRequired)
 }
 
 type fakeRuntime struct {
@@ -130,7 +130,7 @@ func TestSessionSendSurfacesConfirmationAndConfirmResumesRuntime(t *testing.T) {
 	require.True(t, event.Tool.NeedsConfirmation)
 	require.Equal(t, call, event.Tool.Call)
 
-	s.Confirm(t.Context(), dagentruntime.ResumeApproveTool("write_file(*)"))
+	require.NoError(t, s.Confirm(t.Context(), dagentruntime.ResumeApproveTool("write_file(*)")))
 	require.Len(t, rt.resumes, 1)
 	require.Equal(t, dagentruntime.ResumeTypeApproveTool, rt.resumes[0].Type)
 	require.Equal(t, "write_file(*)", rt.resumes[0].ToolName)
@@ -178,9 +178,23 @@ func TestSessionSendRejectsConcurrentRun(t *testing.T) {
 
 	out, err := s.Send(t.Context(), "second")
 	require.Nil(t, out)
-	require.EqualError(t, err, "embeddedchat: a run is already active")
+	require.ErrorIs(t, err, ErrRunActive)
 
 	cancel()
+	close(rt.events)
+}
+
+func TestSessionRejectsOperationsAfterClose(t *testing.T) {
+	rt := newFakeRuntime()
+	s := newTestSession(rt)
+
+	require.NoError(t, s.Close())
+	out, err := s.Send(t.Context(), "hi")
+	require.Nil(t, out)
+	require.ErrorIs(t, err, ErrClosed)
+	require.ErrorIs(t, s.Restart(), ErrClosed)
+	require.ErrorIs(t, s.Confirm(t.Context(), dagentruntime.ResumeApprove()), ErrClosed)
+
 	close(rt.events)
 }
 
@@ -201,6 +215,26 @@ func TestSessionCloseCancelsActiveRunAndClosesRuntime(t *testing.T) {
 	close(rt.events)
 }
 
+func TestSessionRestartKeepsRunActiveUntilRuntimeStops(t *testing.T) {
+	rt := newFakeRuntime()
+	s := newTestSession(rt)
+
+	out, err := s.Send(t.Context(), "first")
+	require.NoError(t, err)
+	require.NoError(t, s.Restart())
+
+	next, err := s.Send(t.Context(), "second")
+	require.Nil(t, next)
+	require.ErrorIs(t, err, ErrRunActive)
+
+	close(rt.events)
+	assertClosed(t, out)
+
+	next, err = s.Send(t.Context(), "second")
+	require.NoError(t, err)
+	require.True(t, receiveEvent(t, next).Done)
+}
+
 func TestSessionRestartCancelsRunAndReplacesConversation(t *testing.T) {
 	rt := newFakeRuntime()
 	s := newTestSession(rt)
@@ -209,7 +243,7 @@ func TestSessionRestartCancelsRunAndReplacesConversation(t *testing.T) {
 	require.NoError(t, err)
 	oldSession := s.session
 
-	s.Restart()
+	require.NoError(t, s.Restart())
 	require.NotSame(t, oldSession, s.session)
 	require.Empty(t, s.session.Messages)
 	require.Eventually(t, func() bool {


### PR DESCRIPTION
## Summary
- add `pkg/embeddedchat`, a headless wrapper for embedding docker-agent runtime conversations in non-docker-agent UIs
- support loading an agent source, streaming assistant text/tool events, confirming tool calls, restarting conversations, and closing active runs
- cover loading, streaming, confirmation, elicitation/max-iteration handling, error handling, concurrent send rejection, and cancellation semantics

## Tests
- `go test ./pkg/embeddedchat ./pkg/app ./pkg/runtime ./pkg/teamloader`