### PR TITLE
refactor: replace go-memoize and go-cache with internal memoize package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,6 @@ require (
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/junegunn/fzf v0.73.1
 	github.com/k3a/html2text v1.4.0
-	github.com/kofalt/go-memoize v0.0.0-20240506050413-9e5eb99a0f2a
 	github.com/labstack/echo/v4 v4.15.4
 	github.com/mattn/go-isatty v0.0.22
 	github.com/mattn/go-runewidth v0.0.24
@@ -100,6 +99,7 @@ require (
 	github.com/mtibben/percent v0.2.1 // indirect
 	github.com/pb33f/jsonpath v0.8.2 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
+	github.com/smartystreets/assertions v1.2.0 // indirect
 	github.com/standard-webhooks/standard-webhooks/libraries v0.0.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.63.0 // indirect
 	golang.org/x/mod v0.36.0 // indirect
@@ -209,7 +209,6 @@ require (
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
-	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect

--- a/go.sum
+++ b/go.sum
@@ -344,8 +344,6 @@ github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXD
 github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
-github.com/kofalt/go-memoize v0.0.0-20240506050413-9e5eb99a0f2a h1:yyeZ0oZLWgSakB9QzPuL/Kyx9kcXYblDOswXaOEx0tg=
-github.com/kofalt/go-memoize v0.0.0-20240506050413-9e5eb99a0f2a/go.mod h1:EUxMohcCc4AiiO1SImzCQo3EdrEYj9Xkyrxbepg02nQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -417,8 +415,6 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
-github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pb33f/jsonpath v0.8.2 h1:Ou4C7zjYClBm97dfZjDCjdZGusJoynv/vrtiEKNfj2Y=
 github.com/pb33f/jsonpath v0.8.2/go.mod h1:zBV5LJW4OQOPatmQE2QdKpGQJvhDTlE5IEj6ASaRNTo=
 github.com/pb33f/libopenapi v0.38.1 h1:F4mlPaex6MugO1DoGjIy8lnevyzclfGX5lWZrT9LszE=
@@ -480,8 +476,6 @@ github.com/smartystreets/assertions v1.2.0 h1:42S6lae5dvLc7BrLu/0ugRtcFVjoJNMC/N
 github.com/smartystreets/assertions v1.2.0/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
-github.com/smartystreets/gunit v1.4.2 h1:tyWYZffdPhQPfK5VsMQXfauwnJkqg7Tv5DLuQVYxq3Q=
-github.com/smartystreets/gunit v1.4.2/go.mod h1:ZjM1ozSIMJlAz/ay4SG8PeKF00ckUp+zMHZXV9/bvak=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/pkg/desktop/uuid.go
+++ b/pkg/desktop/uuid.go
@@ -3,17 +3,16 @@ package desktop
 import (
 	"context"
 
-	"github.com/kofalt/go-memoize"
-	"github.com/patrickmn/go-cache"
+	"github.com/docker/docker-agent/pkg/memoize"
 )
 
-var uuidMmemoizer = memoize.NewMemoizer(cache.NoExpiration, cache.NoExpiration)
+var uuidMemoizer = memoize.New[string](memoize.NoExpiration)
 
 func GetUUID(ctx context.Context) string {
-	uuid, _, _ := uuidMmemoizer.Memoize("desktopUUID", func() (any, error) {
+	uuid, _ := uuidMemoizer.Memoize("desktopUUID", func() (string, error) {
 		var uuid string
 		_ = ClientBackend.Get(ctx, "/uuid", &uuid)
 		return uuid, nil
 	})
-	return uuid.(string)
+	return uuid
 }

--- a/pkg/desktop/version.go
+++ b/pkg/desktop/version.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/kofalt/go-memoize"
+	"github.com/docker/docker-agent/pkg/memoize"
 )
 
 // versionMemoizer caches the Docker Desktop version lookup with a TTL so:
@@ -12,7 +12,7 @@ import (
 //     recovers automatically once Desktop comes up;
 //   - if Desktop is upgraded mid-session, the new version is picked up
 //     within at most one TTL.
-var versionMemoizer = memoize.NewMemoizer(5*time.Minute, 10*time.Minute)
+var versionMemoizer = memoize.New[string](5 * time.Minute)
 
 // GetVersion returns the running Docker Desktop version (e.g. "4.74.0") or
 // an empty string if Docker Desktop is not running or the call fails.
@@ -23,7 +23,7 @@ var versionMemoizer = memoize.NewMemoizer(5*time.Minute, 10*time.Minute)
 // HTTP call on a cache miss; on a cache hit the cached value is returned
 // without consulting ctx.
 func GetVersion(ctx context.Context) string {
-	v, _, _ := memoize.Call(versionMemoizer, "desktopVersion", func() (string, error) {
+	v, _ := versionMemoizer.Memoize("desktopVersion", func() (string, error) {
 		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		defer cancel()
 

--- a/pkg/memoize/memoize.go
+++ b/pkg/memoize/memoize.go
@@ -1,0 +1,108 @@
+// Package memoize caches the results of expensive function calls, keyed by
+// string, with an optional time-to-live. Concurrent calls for the same key are
+// de-duplicated so the underlying function runs only once at a time.
+//
+// A failed call (one that returns a non-nil error) is never cached, so the next
+// call retries. A panic in the memoized function is propagated to every caller
+// waiting on the same key (the value is wrapped and re-raised by the underlying
+// golang.org/x/sync/singleflight group).
+//
+// Expired entries are evicted lazily, when their key is next accessed or
+// overwritten; there is no background janitor. Memory use is therefore bounded
+// by the number of distinct keys, which suits callers that memoize a small,
+// fixed set of keys.
+package memoize
+
+import (
+	"sync"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+)
+
+// NoExpiration, used as the ttl passed to New, keeps cached values forever.
+// Any ttl <= 0 has the same effect.
+const NoExpiration time.Duration = -1
+
+type entry[T any] struct {
+	value   T
+	expires time.Time // zero means the entry never expires
+}
+
+// Memoizer caches values of type T keyed by string. The zero value is not
+// usable; create one with New. A Memoizer is safe for concurrent use by
+// multiple goroutines.
+type Memoizer[T any] struct {
+	ttl time.Duration
+
+	mu      sync.Mutex
+	entries map[string]entry[T]
+	group   singleflight.Group
+}
+
+// New creates a Memoizer whose cached values expire after ttl. A ttl <= 0
+// (for example NoExpiration) keeps values forever.
+func New[T any](ttl time.Duration) *Memoizer[T] {
+	return &Memoizer[T]{
+		ttl:     ttl,
+		entries: make(map[string]entry[T]),
+	}
+}
+
+// Memoize returns the cached value for key, computing it with fn on a miss or
+// when the cached value has expired. Only one execution of fn is in-flight for
+// a given key at a time; concurrent callers share its result. If fn returns an
+// error, the result is not cached and the error is returned to the caller(s).
+func (m *Memoizer[T]) Memoize(key string, fn func() (T, error)) (T, error) {
+	if v, ok := m.load(key); ok {
+		return v, nil
+	}
+
+	v, err, _ := m.group.Do(key, func() (any, error) {
+		// Re-check under the singleflight key: a previous holder may have
+		// populated the cache between our initial miss and acquiring the key,
+		// which lets us skip a redundant call to fn.
+		if v, ok := m.load(key); ok {
+			return v, nil
+		}
+		v, err := fn()
+		if err != nil {
+			return v, err
+		}
+		m.store(key, v)
+		return v, nil
+	})
+
+	// v is always a T (it originates from fn or from load), but use the
+	// comma-ok form so a nil value of an interface T cannot panic here.
+	result, _ := v.(T)
+	return result, err
+}
+
+func (m *Memoizer[T]) load(key string) (T, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	e, ok := m.entries[key]
+	if !ok {
+		var zero T
+		return zero, false
+	}
+	if !e.expires.IsZero() && !time.Now().Before(e.expires) {
+		delete(m.entries, key)
+		var zero T
+		return zero, false
+	}
+	return e.value, true
+}
+
+func (m *Memoizer[T]) store(key string, value T) {
+	var expires time.Time
+	if m.ttl > 0 {
+		expires = time.Now().Add(m.ttl)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.entries[key] = entry[T]{value: value, expires: expires}
+}

--- a/pkg/memoize/memoize_test.go
+++ b/pkg/memoize/memoize_test.go
@@ -1,0 +1,233 @@
+package memoize
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemoizeCachesValue(t *testing.T) {
+	m := New[int](NoExpiration)
+
+	var calls atomic.Int32
+	compute := func() (int, error) {
+		calls.Add(1)
+		return 42, nil
+	}
+
+	for range 3 {
+		v, err := m.Memoize("key", compute)
+		require.NoError(t, err)
+		assert.Equal(t, 42, v)
+	}
+	assert.Equal(t, int32(1), calls.Load())
+}
+
+func TestMemoizeCachesZeroValue(t *testing.T) {
+	m := New[int](NoExpiration)
+
+	var calls atomic.Int32
+	compute := func() (int, error) {
+		calls.Add(1)
+		return 0, nil
+	}
+
+	for range 3 {
+		v, err := m.Memoize("key", compute)
+		require.NoError(t, err)
+		assert.Equal(t, 0, v)
+	}
+	assert.Equal(t, int32(1), calls.Load(), "a zero value must still be cached")
+}
+
+func TestMemoizeIsolatesKeys(t *testing.T) {
+	m := New[string](NoExpiration)
+
+	a, err := m.Memoize("a", func() (string, error) { return "value-a", nil })
+	require.NoError(t, err)
+	b, err := m.Memoize("b", func() (string, error) { return "value-b", nil })
+	require.NoError(t, err)
+
+	assert.Equal(t, "value-a", a)
+	assert.Equal(t, "value-b", b)
+}
+
+func TestMemoizeDoesNotCacheErrors(t *testing.T) {
+	m := New[int](NoExpiration)
+
+	var calls atomic.Int32
+	wantErr := errors.New("boom")
+	compute := func() (int, error) {
+		calls.Add(1)
+		return 0, wantErr
+	}
+
+	_, err := m.Memoize("key", compute)
+	require.ErrorIs(t, err, wantErr)
+	_, err = m.Memoize("key", compute)
+	require.ErrorIs(t, err, wantErr)
+	assert.Equal(t, int32(2), calls.Load())
+}
+
+func TestMemoizeRetriesAfterErrorThenCaches(t *testing.T) {
+	m := New[int](NoExpiration)
+
+	var calls atomic.Int32
+	compute := func() (int, error) {
+		if calls.Add(1) == 1 {
+			return 0, errors.New("transient")
+		}
+		return 99, nil
+	}
+
+	_, err := m.Memoize("key", compute)
+	require.Error(t, err)
+
+	v, err := m.Memoize("key", compute)
+	require.NoError(t, err)
+	assert.Equal(t, 99, v)
+
+	v, err = m.Memoize("key", compute)
+	require.NoError(t, err)
+	assert.Equal(t, 99, v)
+	assert.Equal(t, int32(2), calls.Load(), "value must be cached after first success")
+}
+
+func TestMemoizeExpires(t *testing.T) {
+	m := New[int](10 * time.Millisecond)
+
+	var calls atomic.Int32
+	compute := func() (int, error) {
+		calls.Add(1)
+		return int(calls.Load()), nil
+	}
+
+	v, err := m.Memoize("key", compute)
+	require.NoError(t, err)
+	assert.Equal(t, 1, v)
+
+	time.Sleep(20 * time.Millisecond)
+
+	v, err = m.Memoize("key", compute)
+	require.NoError(t, err)
+	assert.Equal(t, 2, v)
+}
+
+// TestMemoizeZeroTTLNeverExpires verifies the go-cache compatible behavior that
+// a non-positive ttl caches forever rather than expiring immediately.
+func TestMemoizeZeroTTLNeverExpires(t *testing.T) {
+	for _, ttl := range []time.Duration{0, NoExpiration, -time.Hour} {
+		m := New[int](ttl)
+
+		var calls atomic.Int32
+		compute := func() (int, error) {
+			calls.Add(1)
+			return 7, nil
+		}
+
+		v, err := m.Memoize("key", compute)
+		require.NoError(t, err)
+		assert.Equal(t, 7, v)
+
+		time.Sleep(5 * time.Millisecond)
+
+		v, err = m.Memoize("key", compute)
+		require.NoError(t, err)
+		assert.Equal(t, 7, v)
+		assert.Equal(t, int32(1), calls.Load(), "ttl=%v must never expire", ttl)
+	}
+}
+
+// TestMemoizeEvictsExpiredEntry ensures expired entries are removed on access,
+// so memory does not grow without bound for keys that stop being requested.
+func TestMemoizeEvictsExpiredEntry(t *testing.T) {
+	m := New[int](5 * time.Millisecond)
+
+	_, err := m.Memoize("key", func() (int, error) { return 1, nil })
+	require.NoError(t, err)
+	assert.Len(t, m.entries, 1)
+
+	time.Sleep(10 * time.Millisecond)
+
+	_, ok := m.load("key")
+	assert.False(t, ok)
+	assert.Empty(t, m.entries, "expired entry must be evicted on access")
+}
+
+func TestMemoizePanicPropagates(t *testing.T) {
+	m := New[int](NoExpiration)
+
+	// singleflight wraps the panic value and re-raises it, so we assert that a
+	// panic propagates (matching go-memoize) rather than the exact value.
+	assert.Panics(t, func() {
+		_, _ = m.Memoize("key", func() (int, error) {
+			panic("kaboom")
+		})
+	})
+
+	// After a panic the key must not be cached: a subsequent successful call works.
+	v, err := m.Memoize("key", func() (int, error) { return 5, nil })
+	require.NoError(t, err)
+	assert.Equal(t, 5, v)
+	assert.Len(t, m.entries, 1)
+}
+
+// TestMemoizeNilInterfaceValue guards the type assertion: when T is an
+// interface and fn returns nil, Memoize must return nil without panicking.
+func TestMemoizeNilInterfaceValue(t *testing.T) {
+	m := New[fmt.Stringer](NoExpiration)
+
+	v, err := m.Memoize("key", func() (fmt.Stringer, error) {
+		return nil, nil
+	})
+	require.NoError(t, err)
+	assert.Nil(t, v)
+}
+
+func TestMemoizeConcurrentSingleFlight(t *testing.T) {
+	m := New[int](NoExpiration)
+
+	var calls atomic.Int32
+
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Go(func() {
+			v, err := m.Memoize("key", func() (int, error) {
+				calls.Add(1)
+				time.Sleep(20 * time.Millisecond)
+				return 7, nil
+			})
+			require.NoError(t, err)
+			assert.Equal(t, 7, v)
+		})
+	}
+	wg.Wait()
+
+	assert.Equal(t, int32(1), calls.Load())
+}
+
+// TestMemoizeConcurrentDistinctKeys exercises the lock under contention across
+// many keys to catch data races (run with -race).
+func TestMemoizeConcurrentDistinctKeys(t *testing.T) {
+	m := New[int](time.Millisecond)
+
+	var wg sync.WaitGroup
+	for i := range 100 {
+		wg.Go(func() {
+			key := string(rune('a' + i%5))
+			for range 20 {
+				_, err := m.Memoize(key, func() (int, error) {
+					return i, nil
+				})
+				require.NoError(t, err)
+			}
+		})
+	}
+	wg.Wait()
+}

--- a/pkg/remote/transport.go
+++ b/pkg/remote/transport.go
@@ -10,13 +10,12 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/kofalt/go-memoize"
-
 	"github.com/docker/docker-agent/pkg/desktop"
 	socket "github.com/docker/docker-agent/pkg/desktop/socket"
+	"github.com/docker/docker-agent/pkg/memoize"
 )
 
-var memoizer = memoize.NewMemoizer(1*time.Minute, 1*time.Minute)
+var memoizer = memoize.New[bool](1 * time.Minute)
 
 // NewTransport returns an HTTP transport that uses Docker Desktop proxy if available.
 // If the proxy becomes unavailable during the session, it automatically falls back
@@ -28,13 +27,13 @@ func NewTransport(ctx context.Context) http.RoundTripper {
 	}
 	transport := t.Clone()
 
-	desktopRunning, err, _ := memoizer.Memoize("desktopRunning", func() (any, error) {
+	desktopRunning, err := memoizer.Memoize("desktopRunning", func() (bool, error) {
 		return desktop.IsDockerDesktopRunning(context.Background()), nil
 	})
 	if err != nil {
 		return transport
 	}
-	if running, ok := desktopRunning.(bool); ok && running {
+	if desktopRunning {
 		// Create a proxy transport
 		proxyTransport := t.Clone()
 		proxyTransport.Proxy = http.ProxyURL(&url.URL{

--- a/pkg/tui/components/reasoningblock/reasoningblock_test.go
+++ b/pkg/tui/components/reasoningblock/reasoningblock_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/docker/docker-agent/pkg/paths"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/tools"
 	"github.com/docker/docker-agent/pkg/tui/animation"
@@ -18,8 +19,21 @@ import (
 	"github.com/docker/docker-agent/pkg/tui/types"
 )
 
+// useEmptyUserConfig points paths.GetConfigDir at an empty temp dir so
+// service.NewSessionState reads default user settings rather than the
+// developer's real ~/.config/cagent/config.yaml, which would otherwise leak
+// preferences like expand_thinking into these tests.
+//
+// Tests using it must not call t.Parallel: they mutate the package-level
+// config-dir override.
+func useEmptyUserConfig(t *testing.T) {
+	t.Helper()
+	paths.SetConfigDir(t.TempDir())
+	t.Cleanup(func() { paths.SetConfigDir("") })
+}
+
 func TestReasoningBlockCollapsedByDefaultFromSessionState(t *testing.T) {
-	t.Parallel()
+	useEmptyUserConfig(t)
 
 	sessionState := service.NewSessionState(&session.Session{})
 	block := New("test-default-collapsed", "root", sessionState)
@@ -37,7 +51,7 @@ func TestReasoningBlockCollapsedByDefaultFromSessionState(t *testing.T) {
 }
 
 func TestReasoningBlockCanDefaultExpandedFromSessionState(t *testing.T) {
-	t.Parallel()
+	useEmptyUserConfig(t)
 
 	sessionState := service.NewSessionState(&session.Session{})
 	sessionState.SetExpandThinking(true)


### PR DESCRIPTION
The codebase depended on two external memoization libraries: `github.com/kofalt/go-memoize` for single-flight de-duplication and `github.com/patrickmn/go-cache` for TTL-based caching. Both roles are now served by a small new internal package `pkg/memoize`, built on `golang.org/x/sync/singleflight`, eliminating unnecessary external dependencies.

The new `Memoizer[T]` type is generic, type-safe, and preserves all required semantics: single-flight de-duplication, TTL expiry, error non-caching, panic propagation, and correct handling of the `ttl==0` edge case (now treated as never-expire, matching go-cache's behavior). Expired entries are evicted lazily. Three call sites—`pkg/desktop/uuid.go`, `pkg/desktop/version.go`, and `pkg/remote/transport.go`—were migrated to the new API, removing `interface{}` boxing and type assertions in the process. Unit tests cover 100% of the memoize package and pass under `-race`.

This PR also fixes a pre-existing test isolation bug in `pkg/tui/components/reasoningblock` where two tests (`TestReasoningBlockCollapsedByDefaultFromSessionState` and `TestReasoningBlockCanDefaultExpandedFromSessionState`) read the developer's real `~/.config/cagent/config.yaml` via `userconfig.Get()`, causing spurious failures when `expand_thinking: true` is set. A new `useEmptyUserConfig` helper points paths to a clean temp directory for test isolation; those two tests are no longer parallelized since they mutate the global config-dir override.

Validation: `task build`, `task lint` (0 issues), and `task test` all pass.