### PR TITLE
fix(runtime): close cost-accounting blind spots (reasoning tokens, $0 spend leaks)

### DIFF
--- a/pkg/model/provider/anthropic/adapter.go
+++ b/pkg/model/provider/anthropic/adapter.go
@@ -143,18 +143,28 @@ func (a *streamAdapter) Recv() (chat.MessageStreamResponse, error) {
 	case anthropic.MessageDeltaEvent:
 		a.stopReason = eventVariant.Delta.StopReason
 		if a.trackUsage {
-			response.Usage = &chat.Usage{
-				InputTokens:       eventVariant.Usage.InputTokens,
-				OutputTokens:      eventVariant.Usage.OutputTokens,
-				CachedInputTokens: eventVariant.Usage.CacheReadInputTokens,
-				CacheWriteTokens:  eventVariant.Usage.CacheCreationInputTokens,
-			}
+			response.Usage = usageFromDelta(eventVariant.Usage)
 		}
 	case anthropic.MessageStopEvent:
 		response.Choices[0].FinishReason = finishReason(a.stopReason, a.toolCall)
 	}
 
 	return response, nil
+}
+
+// usageFromDelta maps the standard Messages API streaming usage onto chat.Usage.
+// ReasoningTokens comes from OutputTokensDetails.ThinkingTokens, which Anthropic
+// reports as a read-only decomposition of OutputTokens (thinking is already
+// billed inside output), so surfacing it never changes the cost computed in the
+// runtime — it only makes the otherwise-invisible thinking spend observable.
+func usageFromDelta(u anthropic.MessageDeltaUsage) *chat.Usage {
+	return &chat.Usage{
+		InputTokens:       u.InputTokens,
+		OutputTokens:      u.OutputTokens,
+		CachedInputTokens: u.CacheReadInputTokens,
+		CacheWriteTokens:  u.CacheCreationInputTokens,
+		ReasoningTokens:   u.OutputTokensDetails.ThinkingTokens,
+	}
 }
 
 // finishReason maps an Anthropic stop reason (received on message_delta) onto

--- a/pkg/model/provider/anthropic/adapter_test.go
+++ b/pkg/model/provider/anthropic/adapter_test.go
@@ -5,9 +5,59 @@ import (
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/chat"
 )
+
+// TestUsageFromDelta_RecordsReasoningTokens pins the fix for the invisible
+// Anthropic thinking-cost bug: extended-thinking tokens are billed inside
+// OutputTokens but were never surfaced as ReasoningTokens, so the cost dialog
+// and usage dashboards showed zero reasoning for Claude while every other
+// provider (OpenAI, Gemini) reported it. The SDK exposes the breakdown via
+// OutputTokensDetails.ThinkingTokens; this asserts we map it through.
+func TestUsageFromDelta_RecordsReasoningTokens(t *testing.T) {
+	u := anthropic.MessageDeltaUsage{
+		InputTokens:              100,
+		OutputTokens:             80,
+		CacheReadInputTokens:     20,
+		CacheCreationInputTokens: 10,
+		OutputTokensDetails:      anthropic.OutputTokensDetails{ThinkingTokens: 55},
+	}
+
+	got := usageFromDelta(u)
+
+	require.NotNil(t, got)
+	assert.Equal(t, int64(100), got.InputTokens)
+	assert.Equal(t, int64(80), got.OutputTokens)
+	assert.Equal(t, int64(20), got.CachedInputTokens)
+	assert.Equal(t, int64(10), got.CacheWriteTokens)
+	assert.Equal(t, int64(55), got.ReasoningTokens,
+		"thinking tokens must be surfaced as ReasoningTokens, not dropped")
+}
+
+// TestBetaUsageFromDelta_RecordsReasoningTokens is the Beta-API twin of the
+// above. Interleaved thinking (the common case for extended-thinking agents)
+// routes through the Beta stream, so the breakdown must be mapped there too.
+func TestBetaUsageFromDelta_RecordsReasoningTokens(t *testing.T) {
+	u := anthropic.BetaMessageDeltaUsage{
+		InputTokens:              200,
+		OutputTokens:             150,
+		CacheReadInputTokens:     40,
+		CacheCreationInputTokens: 5,
+		OutputTokensDetails:      anthropic.BetaOutputTokensDetails{ThinkingTokens: 90},
+	}
+
+	got := betaUsageFromDelta(u)
+
+	require.NotNil(t, got)
+	assert.Equal(t, int64(200), got.InputTokens)
+	assert.Equal(t, int64(150), got.OutputTokens)
+	assert.Equal(t, int64(40), got.CachedInputTokens)
+	assert.Equal(t, int64(5), got.CacheWriteTokens)
+	assert.Equal(t, int64(90), got.ReasoningTokens,
+		"thinking tokens must be surfaced as ReasoningTokens on the Beta path too")
+}
 
 func TestFinishReason(t *testing.T) {
 	tests := []struct {

--- a/pkg/model/provider/anthropic/beta_adapter.go
+++ b/pkg/model/provider/anthropic/beta_adapter.go
@@ -105,12 +105,7 @@ func (a *betaStreamAdapter) Recv() (chat.MessageStreamResponse, error) {
 	case anthropic.BetaRawMessageDeltaEvent:
 		a.stopReason = eventVariant.Delta.StopReason
 		if a.trackUsage {
-			response.Usage = &chat.Usage{
-				InputTokens:       eventVariant.Usage.InputTokens,
-				OutputTokens:      eventVariant.Usage.OutputTokens,
-				CachedInputTokens: eventVariant.Usage.CacheReadInputTokens,
-				CacheWriteTokens:  eventVariant.Usage.CacheCreationInputTokens,
-			}
+			response.Usage = betaUsageFromDelta(eventVariant.Usage)
 		}
 	case anthropic.BetaRawMessageStopEvent:
 		response.Choices[0].FinishReason = finishReason(anthropic.StopReason(a.stopReason), a.toolCall)
@@ -122,4 +117,18 @@ func (a *betaStreamAdapter) Recv() (chat.MessageStreamResponse, error) {
 // Close closes the Beta stream
 func (a *betaStreamAdapter) Close() {
 	a.stream.Close()
+}
+
+// betaUsageFromDelta maps the Beta Messages API streaming usage onto chat.Usage.
+// As with the standard API, ReasoningTokens is sourced from
+// OutputTokensDetails.ThinkingTokens — a read-only decomposition of the already
+// billed OutputTokens — so recording it is purely additive observability.
+func betaUsageFromDelta(u anthropic.BetaMessageDeltaUsage) *chat.Usage {
+	return &chat.Usage{
+		InputTokens:       u.InputTokens,
+		OutputTokens:      u.OutputTokens,
+		CachedInputTokens: u.CacheReadInputTokens,
+		CacheWriteTokens:  u.CacheCreationInputTokens,
+		ReasoningTokens:   u.OutputTokensDetails.ThinkingTokens,
+	}
 }

--- a/pkg/runtime/agent_delegation.go
+++ b/pkg/runtime/agent_delegation.go
@@ -363,19 +363,39 @@ func (r *LocalRuntime) runCollecting(ctx context.Context, parent *session.Sessio
 	// Persist the sub-session unconditionally — the partial transcript is
 	// the most valuable artifact for debugging a failed background agent.
 	// AddSubSession records it in-memory on both the success and error paths.
-	//
-	// Note: SubSessionCompletedEvent cannot be emitted here because
-	// runCollecting has no EventSink — the persistence observer pipeline
-	// (PersistenceObserver.OnEvent) is not triggered and the sub-session is
-	// not written to the store. Fixing that requires threading EventSink
-	// through RunParams / the Runner interface.
 	parent.AddSubSession(s)
+
+	// Mirror runForwarding's persistence, but write to the store directly
+	// instead of emitting SubSessionCompleted: runCollecting runs on a
+	// detached background goroutine, so routing through the shared observer
+	// chain would race the parent's live RunStream (the PersistenceObserver
+	// keeps unsynchronised streaming state). Without this the background
+	// sub-session never reaches the store — its tokens and cost are recorded
+	// as $0 and escape any spend accounting that reads the store. Use
+	// WithoutCancel so a cancelled/stopped task still persists its transcript.
+	r.persistBackgroundSubSession(context.WithoutCancel(ctx), parent.ID, s)
 
 	if errMsg != "" {
 		return &agenttool.RunResult{ErrMsg: errMsg}
 	}
 
 	return &agenttool.RunResult{Result: s.GetLastAssistantMessageContent()}
+}
+
+// persistBackgroundSubSession writes a completed background sub-session to the
+// session store, linking it under parentID. It is the runCollecting analogue
+// of the SubSessionCompletedEvent that runForwarding emits: background tasks
+// have no live EventSink, so the persistence observer never sees them. Errors
+// are logged rather than surfaced — a failed persist must not change the tool
+// result the caller returns to the model.
+func (r *LocalRuntime) persistBackgroundSubSession(ctx context.Context, parentID string, sub *session.Session) {
+	if r.sessionStore == nil {
+		return
+	}
+	if err := r.sessionStore.AddSubSession(ctx, parentID, sub); err != nil {
+		slog.WarnContext(ctx, "Failed to persist background sub-session",
+			"parent_id", parentID, "sub_session_id", sub.ID, "error", err)
+	}
 }
 
 // CurrentAgentSubAgentNames implements agenttool.Runner.

--- a/pkg/runtime/cost_test.go
+++ b/pkg/runtime/cost_test.go
@@ -1,0 +1,71 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/modelsdev"
+)
+
+// TestComputeMessageCost_UncataloguedModelIsUnpriced is the regression test for
+// the silent "$0 cost despite token usage" leak: when a model is absent from
+// the pricing catalogue (m == nil) or carries no price table (m.Cost == nil),
+// the per-message cost is 0 even though real tokens were spent. Before the fix
+// the caller could not tell this apart from a genuinely free turn, so a spend
+// guardrail built on the cost would never trip. computeMessageCost now reports
+// priced=false for exactly these cases.
+func TestComputeMessageCost_UncataloguedModelIsUnpriced(t *testing.T) {
+	usage := &chat.Usage{InputTokens: 1000, OutputTokens: 500}
+
+	t.Run("model missing from catalogue", func(t *testing.T) {
+		cost, priced := computeMessageCost(usage, nil)
+		assert.Zero(t, cost)
+		assert.False(t, priced, "an uncatalogued model must be reported as unpriced")
+	})
+
+	t.Run("model present but no price table", func(t *testing.T) {
+		cost, priced := computeMessageCost(usage, &modelsdev.Model{})
+		assert.Zero(t, cost)
+		assert.False(t, priced, "a model with no Cost table must be reported as unpriced")
+	})
+
+	t.Run("nil usage", func(t *testing.T) {
+		cost, priced := computeMessageCost(nil, &modelsdev.Model{Cost: &modelsdev.Cost{Input: 1}})
+		assert.Zero(t, cost)
+		assert.False(t, priced)
+	})
+}
+
+// TestComputeMessageCost_PricedModel verifies the cost arithmetic is unchanged
+// from the original inline formula and that a catalogued model reports priced.
+func TestComputeMessageCost_PricedModel(t *testing.T) {
+	usage := &chat.Usage{
+		InputTokens:       1_000_000,
+		OutputTokens:      2_000_000,
+		CachedInputTokens: 3_000_000,
+		CacheWriteTokens:  4_000_000,
+	}
+	m := &modelsdev.Model{Cost: &modelsdev.Cost{
+		Input:      1.0,
+		Output:     2.0,
+		CacheRead:  0.5,
+		CacheWrite: 3.0,
+	}}
+
+	cost, priced := computeMessageCost(usage, m)
+
+	assert.True(t, priced, "a catalogued model with a price table must be reported as priced")
+	// (1e6*1 + 2e6*2 + 3e6*0.5 + 4e6*3) / 1e6 = 1 + 4 + 1.5 + 12 = 18.5
+	assert.InDelta(t, 18.5, cost, 1e-9)
+}
+
+func TestUsageHasTokens(t *testing.T) {
+	assert.False(t, usageHasTokens(nil), "nil usage has no tokens")
+	assert.False(t, usageHasTokens(&chat.Usage{}), "zero usage has no tokens")
+	assert.True(t, usageHasTokens(&chat.Usage{InputTokens: 1}))
+	assert.True(t, usageHasTokens(&chat.Usage{OutputTokens: 1}))
+	assert.True(t, usageHasTokens(&chat.Usage{CachedInputTokens: 1}))
+	assert.True(t, usageHasTokens(&chat.Usage{CacheWriteTokens: 1}))
+}

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -825,12 +825,19 @@ func (r *LocalRuntime) recordAssistantMessage(
 	}
 
 	// Calculate per-message cost when pricing information is available.
-	var messageCost float64
-	if res.Usage != nil && m != nil && m.Cost != nil {
-		messageCost = (float64(res.Usage.InputTokens)*m.Cost.Input +
-			float64(res.Usage.OutputTokens)*m.Cost.Output +
-			float64(res.Usage.CachedInputTokens)*m.Cost.CacheRead +
-			float64(res.Usage.CacheWriteTokens)*m.Cost.CacheWrite) / 1e6
+	// When the model is absent from the catalogue (or carries no price
+	// table) the cost is silently 0 even though tokens were spent; warn so
+	// the otherwise-invisible "uncatalogued model bills $0" leak is at least
+	// observable in logs and any spend guardrail built on top of it.
+	messageCost, priced := computeMessageCost(res.Usage, m)
+	if !priced && usageHasTokens(res.Usage) {
+		slog.Warn("Model is missing from the pricing catalogue; recording $0 cost despite token usage",
+			"agent", a.Name(),
+			"model", modelID,
+			"input_tokens", res.Usage.InputTokens,
+			"output_tokens", res.Usage.OutputTokens,
+			"cached_input_tokens", res.Usage.CachedInputTokens,
+			"cache_write_tokens", res.Usage.CacheWriteTokens)
 	}
 
 	messageModel := modelID
@@ -864,6 +871,35 @@ func (r *LocalRuntime) recordAssistantMessage(
 		FinishReason: res.FinishReason,
 	}
 	return msgUsage
+}
+
+// computeMessageCost returns the dollar cost of a single assistant message
+// and whether pricing information was actually available. priced is false
+// when usage is nil, the model is unknown to the catalogue, or it carries no
+// price table; callers use that signal to distinguish a genuine $0 turn from
+// an uncatalogued-model turn whose real cost is unknown. The arithmetic is
+// unchanged from the original inline computation.
+func computeMessageCost(usage *chat.Usage, m *modelsdev.Model) (cost float64, priced bool) {
+	if usage == nil || m == nil || m.Cost == nil {
+		return 0, false
+	}
+	cost = (float64(usage.InputTokens)*m.Cost.Input +
+		float64(usage.OutputTokens)*m.Cost.Output +
+		float64(usage.CachedInputTokens)*m.Cost.CacheRead +
+		float64(usage.CacheWriteTokens)*m.Cost.CacheWrite) / 1e6
+	return cost, true
+}
+
+// usageHasTokens reports whether any billable tokens were recorded for a turn.
+// Used to suppress the missing-price warning for empty/no-op turns.
+func usageHasTokens(usage *chat.Usage) bool {
+	if usage == nil {
+		return false
+	}
+	return usage.InputTokens > 0 ||
+		usage.OutputTokens > 0 ||
+		usage.CachedInputTokens > 0 ||
+		usage.CacheWriteTokens > 0
 }
 
 // compactIfNeeded estimates the token impact of tool results added since

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -3612,6 +3612,70 @@ func TestElicitationHandler_Interactive_NoChannel(t *testing.T) {
 	assert.ErrorIs(t, err, errNoElicitationChannel)
 }
 
+// TestRunAgentPersistsSubSessionToStore is the regression test for the
+// background-agent spend leak: run_background_agent sub-sessions were added to
+// the parent's in-memory object but never written to the session store, so
+// their tokens and cost were invisible to anything reading the store ($0
+// recorded for work that actually ran). The fix persists the completed
+// sub-session directly from runCollecting. This asserts the sub-session row
+// reaches the store and carries the worker's recorded usage.
+func TestRunAgentPersistsSubSessionToStore(t *testing.T) {
+	t.Parallel()
+
+	// Worker produces real output and usage so the sub-session has a transcript.
+	workerStream := newStreamBuilder().AddContent("worker done").AddStopWithUsage(100, 50).Build()
+	parentProv := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
+	workerProv := &mockProvider{id: "test/mock-model", stream: workerStream}
+
+	worker := agent.New("worker", "Worker agent", agent.WithModel(workerProv))
+	root := agent.New("root", "Root agent", agent.WithModel(parentProv))
+	agent.WithSubAgents(worker)(root)
+
+	tm := team.New(team.WithAgents(root, worker))
+
+	store := session.NewInMemorySessionStore()
+	rt, err := NewLocalRuntime(tm,
+		WithSessionCompaction(false),
+		WithModelStore(mockModelStore{}),
+		WithSessionStore(store),
+	)
+	require.NoError(t, err)
+
+	// The parent must exist in the store before a sub-session can be linked
+	// to it. Use UpdateSession (what OnRunStart calls) so the store holds its
+	// own copy of the parent — exactly as in the real flow — rather than
+	// aliasing the runtime's in-memory object.
+	sess := session.New(session.WithUserMessage("Test"), session.WithToolsApproved(true))
+	require.NoError(t, store.UpdateSession(t.Context(), sess))
+
+	result := rt.RunAgent(t.Context(), agenttool.RunParams{
+		AgentName:     "worker",
+		Task:          "do something",
+		ParentSession: sess,
+	})
+	require.Empty(t, result.ErrMsg, "RunAgent should succeed")
+
+	// The store's copy of the parent must now contain the sub-session — not
+	// just the runtime's in-memory object. Before the fix this was empty,
+	// so the background agent's work was recorded nowhere durable.
+	stored, err := store.GetSession(t.Context(), sess.ID)
+	require.NoError(t, err)
+
+	var storedSubSessions []*session.Session
+	for _, item := range stored.Messages {
+		if item.SubSession != nil {
+			storedSubSessions = append(storedSubSessions, item.SubSession)
+		}
+	}
+	require.Len(t, storedSubSessions, 1,
+		"the background sub-session must be persisted to the store, not just held in memory")
+
+	// The persisted sub-session must carry the worker's token usage so spend
+	// accounting that reads the store sees real numbers, not nothing.
+	assert.Positive(t, storedSubSessions[0].InputTokens+storedSubSessions[0].OutputTokens,
+		"persisted sub-session must carry the worker's recorded token usage")
+}
+
 // TestRunAgentPersistsSubSessionOnError covers the background-agent path
 // (runCollecting) when the sub-agent's model stream fails. Before the fix,
 // runCollecting returned early on ErrorEvent without calling


### PR DESCRIPTION
## Summary

Fixes three genuine cost-accounting/observability bugs in the agent runtime, surfaced by a cost analysis of a delegating multi-agent workload. Each fix is an isolated commit with a regression test that fails before the change.

All fixes are **behavior-preserving for existing cost numbers** — they add missing data/signals rather than changing the cost formula.

## Changes

### `fix(anthropic): record reasoning tokens from streaming usage`
Extended-thinking tokens are billed inside `OutputTokens` but were never surfaced as `chat.Usage.ReasoningTokens`, so the `/cost` dialog and usage dashboards showed **zero reasoning for Claude** while OpenAI and Gemini reported it. Maps `OutputTokensDetails.ThinkingTokens` (a read-only decomposition of the already-billed output tokens) on both the standard and Beta streaming paths. Purely additive observability — the cost formula is unchanged. Extracted `usageFromDelta` / `betaUsageFromDelta` so the mapping is unit-testable without standing up an SSE stream.

### `fix(runtime): warn when an uncatalogued model bills $0 with token usage`
Per-message cost is computed only when the model is in the models.dev catalogue and carries a price table; otherwise it is silently `0` even though real tokens were spent. That makes an uncatalogued model look free, so any spend guardrail built on the recorded cost never trips and the leak is invisible. Extracts `computeMessageCost`, which now reports whether pricing was available, and emits a warning when tokens were spent but no price was found. The cost arithmetic is unchanged.

### `fix(runtime): persist run_background_agent sub-sessions to the store`
Background-agent sub-sessions were added to the parent's in-memory object but never written to the session store: `runCollecting` runs on a detached goroutine with no `EventSink`, so the `PersistenceObserver` never saw a `SubSessionCompleted` event. Their tokens and cost were therefore recorded nowhere durable — **$0 for work that actually ran**, escaping any spend accounting that reads the store. Persists the completed sub-session directly via the (concurrency-safe) store on both the success and error paths, using a non-cancellable context so a stopped task still records its transcript. Writing to the store directly rather than through the shared observer chain avoids racing the parent's live `RunStream`.

## Testing

- `task test` — full suite green
- `golangci-lint run ./...` — 0 issues
- Each fix verified red→green by reverting the production change with the new test in place
- Runtime + anthropic packages pass under `-race`

Rebased on latest `main`.
