### PR TITLE
refactor(rag): make the rag toolset opt-in to drop cgo from embedders

### DIFF
--- a/cmd/root/toolsets.go
+++ b/cmd/root/toolsets.go
@@ -1,0 +1,13 @@
+package root
+
+// Blank-import optional toolsets so they register themselves with teamloader
+// (via their init()) and are available in the default toolset registry.
+//
+// These toolsets are deliberately kept out of teamloader's static import graph
+// so embedders that don't need them aren't forced to link their dependencies.
+// "rag" in particular pulls in a cgo tree-sitter dependency; importing it here
+// keeps the docker-agent CLI's behavior unchanged while letting lighter
+// embedders opt out.
+import (
+	_ "github.com/docker/docker-agent/pkg/tools/builtin/rag"
+)

--- a/cmd/root/toolsets_test.go
+++ b/cmd/root/toolsets_test.go
@@ -1,7 +1,6 @@
 package root
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -22,7 +21,7 @@ func TestRAGToolsetRegistered(t *testing.T) {
 	// A rag toolset with no config fails inside the creator with a config
 	// error — not with "unknown toolset type". Reaching that creator-level
 	// error proves the "rag" creator is registered.
-	_, err := registry.CreateTool(context.Background(), latest.Toolset{Type: "rag"}, "", &config.RuntimeConfig{}, "")
+	_, err := registry.CreateTool(t.Context(), latest.Toolset{Type: "rag"}, "", &config.RuntimeConfig{}, "")
 	require.Error(t, err)
 	require.NotContains(t, err.Error(), "unknown toolset type",
 		"the rag toolset is not registered; check the blank import in cmd/root/toolsets.go")

--- a/cmd/root/toolsets_test.go
+++ b/cmd/root/toolsets_test.go
@@ -1,0 +1,29 @@
+package root
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/teamloader"
+)
+
+// TestRAGToolsetRegistered guards the blank import in toolsets.go: the "rag"
+// toolset registers itself with teamloader via init(), so it must resolve in
+// the default registry of the CLI binary. If someone drops the blank import,
+// "rag" would silently become an unknown toolset type at runtime; this test
+// turns that into a build-time failure instead.
+func TestRAGToolsetRegistered(t *testing.T) {
+	registry := teamloader.NewDefaultToolsetRegistry()
+
+	// A rag toolset with no config fails inside the creator with a config
+	// error — not with "unknown toolset type". Reaching that creator-level
+	// error proves the "rag" creator is registered.
+	_, err := registry.CreateTool(context.Background(), latest.Toolset{Type: "rag"}, "", &config.RuntimeConfig{}, "")
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "unknown toolset type",
+		"the rag toolset is not registered; check the blank import in cmd/root/toolsets.go")
+}

--- a/pkg/rag/types/types.go
+++ b/pkg/rag/types/types.go
@@ -50,5 +50,5 @@ type EventForwarder interface {
 	// Name returns the toolset's user-facing name.
 	Name() string
 	// SetEventCallback registers the callback; must be called before Start.
-	SetEventCallback(EventCallback)
+	SetEventCallback(callback EventCallback)
 }

--- a/pkg/rag/types/types.go
+++ b/pkg/rag/types/types.go
@@ -37,3 +37,18 @@ type Progress struct {
 	Current int
 	Total   int
 }
+
+// EventCallback receives RAG manager events during initialization.
+type EventCallback func(event Event)
+
+// EventForwarder is implemented by RAG toolsets that can stream lifecycle
+// events (indexing progress, usage, errors) to a callback. The runtime
+// type-asserts to this interface to wire event forwarding without importing
+// the concrete rag toolset package — which keeps the cgo tree-sitter
+// dependency out of the runtime's import graph.
+type EventForwarder interface {
+	// Name returns the toolset's user-facing name.
+	Name() string
+	// SetEventCallback registers the callback; must be called before Start.
+	SetEventCallback(EventCallback)
+}

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -18,13 +18,13 @@ import (
 	"github.com/docker/docker-agent/pkg/httpclient"
 	"github.com/docker/docker-agent/pkg/model/provider"
 	"github.com/docker/docker-agent/pkg/modelsdev"
+	ragtypes "github.com/docker/docker-agent/pkg/rag/types"
 	"github.com/docker/docker-agent/pkg/runtime/toolexec"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/tools"
 	bgagent "github.com/docker/docker-agent/pkg/tools/builtin/agent"
 	"github.com/docker/docker-agent/pkg/tools/builtin/handoff"
 	"github.com/docker/docker-agent/pkg/tools/builtin/modelpicker"
-	builtinrag "github.com/docker/docker-agent/pkg/tools/builtin/rag"
 	"github.com/docker/docker-agent/pkg/tools/builtin/shell"
 	"github.com/docker/docker-agent/pkg/tools/builtin/skills"
 	"github.com/docker/docker-agent/pkg/tools/builtin/transfertask"
@@ -983,7 +983,7 @@ func (r *LocalRuntime) configureToolsetHandlers(a *agent.Agent, events EventSink
 		// channel; a blocking send after the channel is closed would
 		// crash, and a blocking send when the consumer has gone away
 		// would deadlock.
-		if ragTool, ok := tools.As[*builtinrag.ToolSet](toolset); ok {
+		if ragTool, ok := tools.As[ragtypes.EventForwarder](toolset); ok {
 			ragTool.SetEventCallback(ragEventForwarder(ragTool.Name(), r, nonBlocking(events).Emit))
 		}
 	}

--- a/pkg/runtime/rag.go
+++ b/pkg/runtime/rag.go
@@ -5,11 +5,10 @@ import (
 	"log/slog"
 
 	ragtypes "github.com/docker/docker-agent/pkg/rag/types"
-	"github.com/docker/docker-agent/pkg/tools/builtin/rag"
 )
 
 // ragEventForwarder returns a callback that converts RAG manager events to runtime events.
-func ragEventForwarder(ragName string, r *LocalRuntime, sendEvent func(Event)) rag.EventCallback {
+func ragEventForwarder(ragName string, r *LocalRuntime, sendEvent func(Event)) ragtypes.EventCallback {
 	return func(ragEvent ragtypes.Event) {
 		agentName := r.CurrentAgentName()
 		slog.Debug("Forwarding RAG event", "type", ragEvent.Type, "rag", ragName, "agent", agentName)

--- a/pkg/teamloader/registry.go
+++ b/pkg/teamloader/registry.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"context"
 	"fmt"
+	"maps"
 
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/config/latest"
@@ -118,9 +119,7 @@ func NewDefaultToolsetRegistry() ToolsetRegistry {
 		},
 	}
 	// Merge in creators contributed via RegisterToolsetCreator (e.g. "rag").
-	for toolsetType, creator := range extraCreators {
-		r.creators[toolsetType] = creator
-	}
+	maps.Copy(r.creators, extraCreators)
 	return r
 }
 

--- a/pkg/teamloader/registry.go
+++ b/pkg/teamloader/registry.go
@@ -18,7 +18,6 @@ import (
 	"github.com/docker/docker-agent/pkg/tools/builtin/memory"
 	"github.com/docker/docker-agent/pkg/tools/builtin/modelpicker"
 	"github.com/docker/docker-agent/pkg/tools/builtin/openapi"
-	builtinrag "github.com/docker/docker-agent/pkg/tools/builtin/rag"
 	"github.com/docker/docker-agent/pkg/tools/builtin/shell"
 	"github.com/docker/docker-agent/pkg/tools/builtin/tasks"
 	"github.com/docker/docker-agent/pkg/tools/builtin/think"
@@ -31,13 +30,32 @@ import (
 // configName identifies the agent config file (e.g. "memory_agent" from "memory_agent.yaml").
 type ToolsetCreator func(ctx context.Context, toolset latest.Toolset, parentDir string, runConfig *config.RuntimeConfig, configName string) (tools.ToolSet, error)
 
+// extraCreators holds toolset creators contributed by packages that opt in via
+// RegisterToolsetCreator. This keeps optional toolsets (e.g. "rag", which pulls
+// in a cgo tree-sitter dependency) out of teamloader's static import graph:
+// they are linked only when the owning package is blank-imported by the binary.
+var extraCreators = map[string]ToolsetCreator{}
+
+// RegisterToolsetCreator registers a creator for the given toolset type, to be
+// included in every registry returned by NewDefaultToolsetRegistry. Packages
+// call it from an init() so that a blank import is enough to make their toolset
+// available; binaries that don't import the package don't pay for its
+// dependencies. It panics on a duplicate registration to surface wiring bugs at
+// startup. Not safe for concurrent use; call only from init().
+func RegisterToolsetCreator(toolsetType string, creator ToolsetCreator) {
+	if _, exists := extraCreators[toolsetType]; exists {
+		panic(fmt.Sprintf("teamloader: toolset creator %q already registered", toolsetType))
+	}
+	extraCreators[toolsetType] = creator
+}
+
 // ToolsetRegistry manages the registration of toolset creators by type.
 type ToolsetRegistry interface {
 	CreateTool(ctx context.Context, toolset latest.Toolset, parentDir string, runConfig *config.RuntimeConfig, agentName string) (tools.ToolSet, error)
 }
 
 func NewDefaultToolsetRegistry() ToolsetRegistry {
-	return &toolsetRegistry{
+	r := &toolsetRegistry{
 		creators: map[string]ToolsetCreator{
 			"todo": func(_ context.Context, toolset latest.Toolset, _ string, _ *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
 				return todo.CreateToolSet(toolset)
@@ -97,11 +115,13 @@ func NewDefaultToolsetRegistry() ToolsetRegistry {
 			"background_agents": func(_ context.Context, _ latest.Toolset, _ string, _ *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
 				return agenttool.CreateToolSet()
 			},
-			"rag": func(ctx context.Context, toolset latest.Toolset, parentDir string, runConfig *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
-				return builtinrag.CreateToolSet(ctx, toolset, parentDir, runConfig)
-			},
 		},
 	}
+	// Merge in creators contributed via RegisterToolsetCreator (e.g. "rag").
+	for toolsetType, creator := range extraCreators {
+		r.creators[toolsetType] = creator
+	}
+	return r
 }
 
 // toolsetRegistry manages the registration of toolset creators by type.

--- a/pkg/tools/builtin/rag/rag.go
+++ b/pkg/tools/builtin/rag/rag.go
@@ -41,7 +41,7 @@ func CreateToolSet(ctx context.Context, toolset latest.Toolset, parentDir string
 }
 
 // EventCallback is called to forward RAG manager events during initialization.
-type EventCallback func(event ragtypes.Event)
+type EventCallback = ragtypes.EventCallback
 
 // ToolSet provides document querying capabilities for a single RAG source.
 type ToolSet struct {

--- a/pkg/tools/builtin/rag/register.go
+++ b/pkg/tools/builtin/rag/register.go
@@ -14,6 +14,8 @@ import (
 // pkg/rag), so the "rag" toolset is only linked into binaries that blank-import
 // this package. The docker-agent CLI does so; embedders that don't need RAG can
 // omit it and build without the cgo dependency.
+//
+//nolint:gochecknoinits // Intentional: self-registers the optional rag toolset so a blank import enables it without pulling cgo into teamloader's import graph.
 func init() {
 	teamloader.RegisterToolsetCreator("rag", func(ctx context.Context, toolset latest.Toolset, parentDir string, runConfig *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
 		return CreateToolSet(ctx, toolset, parentDir, runConfig)

--- a/pkg/tools/builtin/rag/register.go
+++ b/pkg/tools/builtin/rag/register.go
@@ -1,0 +1,21 @@
+package rag
+
+import (
+	"context"
+
+	"github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/teamloader"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+// init registers the "rag" toolset with teamloader. This package is kept out of
+// teamloader's static import graph (it pulls in a cgo tree-sitter dependency via
+// pkg/rag), so the "rag" toolset is only linked into binaries that blank-import
+// this package. The docker-agent CLI does so; embedders that don't need RAG can
+// omit it and build without the cgo dependency.
+func init() {
+	teamloader.RegisterToolsetCreator("rag", func(ctx context.Context, toolset latest.Toolset, parentDir string, runConfig *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
+		return CreateToolSet(ctx, toolset, parentDir, runConfig)
+	})
+}


### PR DESCRIPTION
The rag toolset depends on go-tree-sitter, which is cgo-only and has no pure-Go fallback. Two static import edges dragged it into the binary of every embedder of this library: `pkg/teamloader`'s registry hard-coded the `rag` creator, and `pkg/runtime` type-asserted the concrete `*builtinrag.ToolSet` to wire indexing-progress events into the UI. Because `pkg/runtime`, `pkg/embeddedchat`, and `pkg/teamloader` are exactly what downstream embedders import, they all linked tree-sitter even when rag is never configured. That forces those embedders to build with `CGO_ENABLED=0` (or ship a C toolchain) when cross-compiling to targets like Windows, purely to satisfy a dependency they don't use.

This change makes rag opt-in without changing the CLI's behavior. `teamloader` now exposes `RegisterToolsetCreator`, and the rag package self-registers its `rag` creator from an `init()`, so a single blank import is enough to enable it. The runtime no longer references the concrete rag type; it asserts a small `EventForwarder` interface defined in the pure-Go `pkg/rag/types` package instead. `cmd/root` blank-imports the rag package, so the docker-agent CLI keeps rag exactly as before, while embedders that don't import it get a tree-sitter-free dependency graph and can build with cgo enabled.

The one risk is that an entrypoint which needs rag forgets the blank import, silently turning `rag` into an unknown toolset type at runtime. A guard test in `cmd/root` resolves `rag` against the default registry so that mistake fails the build instead.