### PR TITLE
fix(modelinfo): offer the max effort tier in the Shift+Tab thinking cycle

### DIFF
--- a/pkg/modelinfo/thinking_levels.go
+++ b/pkg/modelinfo/thinking_levels.go
@@ -25,7 +25,7 @@ func thinkingLevelMap(provider, modelID string) effort.LevelMap {
 		// The Anthropic effort scale starts at low ([effort.ForAnthropic]
 		// maps minimal onto low), so offering minimal would duplicate low.
 		m := effort.LevelMap{effort.Minimal: false}
-		if top := anthropicTopEffort(modelID); top != "" {
+		for _, top := range anthropicTopEfforts(modelID) {
 			m[top] = true
 		}
 		return m
@@ -60,39 +60,92 @@ func providerFamily(providerType string) string {
 	}
 }
 
-// anthropicTopEffort returns the highest selectable effort above high for a
-// Claude model: Max for Opus 4.6 (the only model accepting effort "max"),
-// XHigh for Opus 4.7+ and the Fable family, and "" for every other Claude
-// model, which tops out at high.
+// anthropicTopEfforts returns the explicit-only effort tiers (xhigh and/or
+// max) a Claude model accepts beyond the universal low/medium/high ladder, in
+// canonical ascending order. It returns nil for models that top out at high.
+//
+// xhigh and max are independent capabilities, not a single ladder: Opus 4.6
+// and Sonnet 4.6 accept max without xhigh, while Opus 4.7+, Fable 5 and
+// Mythos 5 accept both. Returning the supported subset (rather than one "top"
+// tier) lets the Shift+Tab cycle offer every tier a model really has.
+//
+// Authoritative per-level availability:
+// https://platform.claude.com/docs/en/build-with-claude/effort
 //
 // Works on bare Anthropic IDs ("claude-opus-4-7", "claude-opus-4.7") as well
 // as Bedrock-style IDs with regional prefixes ("us.anthropic.claude-opus-4-7").
-func anthropicTopEffort(modelID string) effort.Level {
-	m := normalize(modelID)
-	if strings.Contains(m, "fable") {
-		return effort.XHigh
+func anthropicTopEfforts(modelID string) []effort.Level {
+	hasXHigh, hasMax := anthropicTopTierSupport(normalize(modelID))
+	switch {
+	case hasXHigh && hasMax:
+		return []effort.Level{effort.XHigh, effort.Max}
+	case hasMax:
+		return []effort.Level{effort.Max}
+	case hasXHigh:
+		return []effort.Level{effort.XHigh}
+	default:
+		return nil
 	}
-	_, rest, found := strings.Cut(m, "opus-4")
-	if !found {
-		return ""
-	}
-	if rest == "" || (rest[0] != '-' && rest[0] != '.') {
-		return ""
-	}
-	minor, width := leadingInt(rest[1:])
-	// Long digit runs are date stamps (claude-opus-4-20250514 is Opus 4.0),
-	// not minor versions.
-	if width == 0 || width > 2 {
-		return ""
+}
+
+// anthropicTopTierSupport reports whether the normalized Claude model id m
+// accepts the xhigh and max effort tiers. The capability matrix it encodes is
+// quoted in [anthropicTopEfforts]'s authoritative reference.
+func anthropicTopTierSupport(m string) (hasXHigh, hasMax bool) {
+	if bare, ok := bedrockClaudeModelName(m); ok {
+		m = bare
 	}
 	switch {
-	case minor >= 7:
-		return effort.XHigh
-	case minor == 6:
-		return effort.Max
-	default:
-		return ""
+	case strings.Contains(m, "fable"):
+		// Fable 5: both xhigh and max.
+		return true, true
+	case strings.Contains(m, "mythos"):
+		// Mythos model ids are inferred from the effort reference (no
+		// catalogue entry yet): every variant accepts max, and the full
+		// release adds xhigh while the preview tops out at max.
+		return !strings.Contains(m, "preview"), true
 	}
+	family, minor, ok := claudeFamilyMinor(m)
+	if !ok {
+		return false, false
+	}
+	switch family {
+	case "opus":
+		switch {
+		case minor >= 7:
+			return true, true
+		case minor == 6:
+			return false, true
+		}
+	case "sonnet":
+		if minor >= 6 {
+			return false, true
+		}
+	}
+	return false, false
+}
+
+// claudeFamilyMinor extracts the family ("opus" or "sonnet") and minor version
+// from a normalized Claude id of the form "...<family>-4-<minor>" or
+// "...<family>-4.<minor>". It reports ok=false for other families and for
+// date-stamped 4.0 ids such as "claude-opus-4-20250514", whose long digit run
+// is a date, not a minor version.
+func claudeFamilyMinor(m string) (family string, minor int, ok bool) {
+	for _, fam := range []string{"opus", "sonnet"} {
+		_, rest, found := strings.Cut(m, fam+"-4")
+		if !found {
+			continue
+		}
+		if rest == "" || (rest[0] != '-' && rest[0] != '.') {
+			return "", 0, false
+		}
+		minor, width := leadingInt(rest[1:])
+		if width == 0 || width > 2 {
+			return "", 0, false
+		}
+		return fam, minor, true
+	}
+	return "", 0, false
 }
 
 // openAISupportsXHighEffort reports whether an OpenAI model accepts

--- a/pkg/modelinfo/thinking_levels_test.go
+++ b/pkg/modelinfo/thinking_levels_test.go
@@ -48,16 +48,22 @@ func TestSupportedThinkingLevels(t *testing.T) {
 			want:     []effort.Level{effort.None, effort.Low, effort.Medium, effort.High, effort.Max},
 		},
 		{
-			name:     "claude opus 4.7 gets xhigh but not max",
+			name:     "claude opus 4.7 gets xhigh and max",
 			provider: "anthropic",
 			modelID:  "claude-opus-4-7",
-			want:     []effort.Level{effort.None, effort.Low, effort.Medium, effort.High, effort.XHigh},
+			want:     []effort.Level{effort.None, effort.Low, effort.Medium, effort.High, effort.XHigh, effort.Max},
 		},
 		{
-			name:     "claude opus 4.8 gets xhigh",
+			name:     "claude opus 4.8 gets xhigh and max",
 			provider: "anthropic",
 			modelID:  "claude-opus-4-8",
-			want:     []effort.Level{effort.None, effort.Low, effort.Medium, effort.High, effort.XHigh},
+			want:     []effort.Level{effort.None, effort.Low, effort.Medium, effort.High, effort.XHigh, effort.Max},
+		},
+		{
+			name:     "claude sonnet 4.6 gets max but not xhigh",
+			provider: "anthropic",
+			modelID:  "claude-sonnet-4-6",
+			want:     []effort.Level{effort.None, effort.Low, effort.Medium, effort.High, effort.Max},
 		},
 		{
 			name:     "dotted opus version",
@@ -66,10 +72,16 @@ func TestSupportedThinkingLevels(t *testing.T) {
 			want:     []effort.Level{effort.None, effort.Low, effort.Medium, effort.High, effort.Max},
 		},
 		{
-			name:     "bedrock regional opus 4.7",
+			name:     "bedrock regional opus 4.7 gets xhigh and max",
 			provider: "amazon-bedrock",
 			modelID:  "us.anthropic.claude-opus-4-7",
-			want:     []effort.Level{effort.None, effort.Low, effort.Medium, effort.High, effort.XHigh},
+			want:     []effort.Level{effort.None, effort.Low, effort.Medium, effort.High, effort.XHigh, effort.Max},
+		},
+		{
+			name:     "bedrock regional sonnet 4.6 gets max but not xhigh",
+			provider: "amazon-bedrock",
+			modelID:  "global.anthropic.claude-sonnet-4-6",
+			want:     []effort.Level{effort.None, effort.Low, effort.Medium, effort.High, effort.Max},
 		},
 		{
 			name:     "bedrock sonnet tops out at high",
@@ -78,10 +90,22 @@ func TestSupportedThinkingLevels(t *testing.T) {
 			want:     []effort.Level{effort.None, effort.Low, effort.Medium, effort.High},
 		},
 		{
-			name:     "claude fable gets xhigh",
+			name:     "claude fable gets xhigh and max",
 			provider: "anthropic",
 			modelID:  "claude-fable-5",
-			want:     []effort.Level{effort.None, effort.Low, effort.Medium, effort.High, effort.XHigh},
+			want:     []effort.Level{effort.None, effort.Low, effort.Medium, effort.High, effort.XHigh, effort.Max},
+		},
+		{
+			name:     "claude mythos 5 gets xhigh and max",
+			provider: "anthropic",
+			modelID:  "claude-mythos-5",
+			want:     []effort.Level{effort.None, effort.Low, effort.Medium, effort.High, effort.XHigh, effort.Max},
+		},
+		{
+			name:     "claude mythos preview gets max but not xhigh",
+			provider: "anthropic",
+			modelID:  "claude-mythos-preview",
+			want:     []effort.Level{effort.None, effort.Low, effort.Medium, effort.High, effort.Max},
 		},
 		{
 			name:     "gpt-5 tops out at high",
@@ -141,31 +165,47 @@ func TestSupportedThinkingLevels(t *testing.T) {
 	}
 }
 
-func TestAnthropicTopEffort(t *testing.T) {
+func TestAnthropicTopEfforts(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		modelID string
-		want    effort.Level
+		want    []effort.Level
 	}{
-		{"claude-sonnet-4-5", ""},
-		{"claude-opus-4-1-20250805", ""},
-		{"claude-opus-4-20250514", ""},
-		{"claude-opus-4-6", effort.Max},
-		{"claude-opus-4-6-v1", effort.Max},
-		{"claude-opus-4.6", effort.Max},
-		{"claude-opus-4-7", effort.XHigh},
-		{"claude-opus-4-8", effort.XHigh},
-		{"global.anthropic.claude-opus-4-6-v1", effort.Max},
-		{"us.anthropic.claude-opus-4-7", effort.XHigh},
-		{"claude-fable-5", effort.XHigh},
-		{"CLAUDE-OPUS-4-7", effort.XHigh},
+		// Tops out at high (no explicit-only tier).
+		{"claude-sonnet-4-5", nil},
+		{"claude-haiku-4-5-20251001", nil},
+		{"claude-opus-4-5", nil},
+		{"claude-opus-4-1-20250805", nil},
+		{"claude-opus-4-20250514", nil},
+		// Max without xhigh.
+		{"claude-opus-4-6", []effort.Level{effort.Max}},
+		{"claude-opus-4-6-v1", []effort.Level{effort.Max}},
+		{"claude-opus-4.6", []effort.Level{effort.Max}},
+		{"claude-sonnet-4-6", []effort.Level{effort.Max}},
+		{"claude-sonnet-4-6-20260101", []effort.Level{effort.Max}},
+		{"claude-mythos-preview", []effort.Level{effort.Max}},
+		// Both xhigh and max.
+		{"claude-opus-4-7", []effort.Level{effort.XHigh, effort.Max}},
+		{"claude-opus-4-8", []effort.Level{effort.XHigh, effort.Max}},
+		{"claude-fable-5", []effort.Level{effort.XHigh, effort.Max}},
+		{"claude-mythos-5", []effort.Level{effort.XHigh, effort.Max}},
+		// Bedrock-style identifiers with regional prefixes: the prefix is
+		// stripped before both the numeric and the name-matched (fable/mythos)
+		// branches, so all of them must resolve through it.
+		{"global.anthropic.claude-opus-4-6-v1", []effort.Level{effort.Max}},
+		{"us.anthropic.claude-opus-4-7", []effort.Level{effort.XHigh, effort.Max}},
+		{"global.anthropic.claude-sonnet-4-6", []effort.Level{effort.Max}},
+		{"us.anthropic.claude-fable-5", []effort.Level{effort.XHigh, effort.Max}},
+		{"global.anthropic.claude-mythos-preview", []effort.Level{effort.Max}},
+		// Case-insensitive.
+		{"CLAUDE-OPUS-4-7", []effort.Level{effort.XHigh, effort.Max}},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.modelID, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.want, anthropicTopEffort(tt.modelID))
+			assert.Equal(t, tt.want, anthropicTopEfforts(tt.modelID))
 		})
 	}
 }

--- a/pkg/runtime/model_switcher_test.go
+++ b/pkg/runtime/model_switcher_test.go
@@ -211,19 +211,49 @@ func TestCycleAgentThinkingLevel_PerModelTopTier(t *testing.T) {
 		wantCycle []effort.Level
 	}{
 		{
-			name:      "sonnet never reaches xhigh or max",
+			name:      "sonnet 4.5 never reaches xhigh or max",
 			modelID:   "claude-sonnet-4-5",
 			wantCycle: []effort.Level{effort.Low, effort.Medium, effort.High, effort.None},
 		},
 		{
-			name:      "opus 4.6 tops out at max",
+			name:      "opus 4.5 never reaches xhigh or max",
+			modelID:   "claude-opus-4-5",
+			wantCycle: []effort.Level{effort.Low, effort.Medium, effort.High, effort.None},
+		},
+		{
+			name:      "sonnet 4.6 reaches max but not xhigh",
+			modelID:   "claude-sonnet-4-6",
+			wantCycle: []effort.Level{effort.Low, effort.Medium, effort.High, effort.Max, effort.None},
+		},
+		{
+			name:      "opus 4.6 reaches max but not xhigh",
 			modelID:   "claude-opus-4-6",
 			wantCycle: []effort.Level{effort.Low, effort.Medium, effort.High, effort.Max, effort.None},
 		},
 		{
-			name:      "opus 4.7 tops out at xhigh",
+			name:      "opus 4.7 reaches both xhigh and max",
 			modelID:   "claude-opus-4-7",
-			wantCycle: []effort.Level{effort.Low, effort.Medium, effort.High, effort.XHigh, effort.None},
+			wantCycle: []effort.Level{effort.Low, effort.Medium, effort.High, effort.XHigh, effort.Max, effort.None},
+		},
+		{
+			name:      "opus 4.8 reaches both xhigh and max",
+			modelID:   "claude-opus-4-8",
+			wantCycle: []effort.Level{effort.Low, effort.Medium, effort.High, effort.XHigh, effort.Max, effort.None},
+		},
+		{
+			name:      "fable 5 reaches both xhigh and max",
+			modelID:   "claude-fable-5",
+			wantCycle: []effort.Level{effort.Low, effort.Medium, effort.High, effort.XHigh, effort.Max, effort.None},
+		},
+		{
+			name:      "mythos 5 reaches both xhigh and max",
+			modelID:   "claude-mythos-5",
+			wantCycle: []effort.Level{effort.Low, effort.Medium, effort.High, effort.XHigh, effort.Max, effort.None},
+		},
+		{
+			name:      "mythos preview reaches max but not xhigh",
+			modelID:   "claude-mythos-preview",
+			wantCycle: []effort.Level{effort.Low, effort.Medium, effort.High, effort.Max, effort.None},
 		},
 	}
 


### PR DESCRIPTION
## What

The TUI **Shift+Tab thinking-level cycle** hid the `max` effort tier on several Claude models that support it — Opus 4.7/4.8 capped at `xhigh`, Sonnet 4.6 capped at `high`, and Fable 5 capped at `xhigh`.

Root cause: `anthropicTopEffort()` returned a **single** highest tier, implicitly treating the selectable tiers as a linear ladder. But `xhigh` and `max` are **independent capabilities**, not a ladder: Opus 4.6 / Sonnet 4.6 accept `max` *without* `xhigh`, while Opus 4.7+ / Fable 5 / Mythos 5 accept *both*. A single returned tier cannot express that, and because `max` is an explicit-only tier it was dropped by `effort.SupportedLevels()`.

This is a **selector-gating fix only**: the request path (`pkg/model/provider/anthropic/thinking.go`) already sends `adaptive/<effort>` verbatim, so authored `thinking_budget` values were never affected.

## Fix

- Replace `anthropicTopEffort` (one tier) with `anthropicTopEfforts`, which returns the full `{xhigh, max}` subset a model supports.
- Recognise the **Sonnet** family (4.6 → `max`) — previously only Opus/Fable were handled.
- Handle **Mythos** ids best-effort (no catalogue entry exists yet): every variant → `max`, the full release adds `xhigh`, the preview tops out at `max`.

## Capability matrix (now matches [Anthropic's effort docs](https://platform.claude.com/docs/en/build-with-claude/effort))

| Model | low | medium | high | xhigh | max |
|---|:---:|:---:|:---:|:---:|:---:|
| Opus 4.5 | ✓ | ✓ | ✓ | — | — |
| Sonnet 4.5 / Haiku | ✓ | ✓ | ✓ | — | — |
| Sonnet 4.6 | ✓ | ✓ | ✓ | — | ✓ |
| Opus 4.6 | ✓ | ✓ | ✓ | — | ✓ |
| Opus 4.7 | ✓ | ✓ | ✓ | ✓ | ✓ |
| Opus 4.8 | ✓ | ✓ | ✓ | ✓ | ✓ |
| Fable 5 | ✓ | ✓ | ✓ | ✓ | ✓ |
| Mythos 5 | ✓ | ✓ | ✓ | ✓ | ✓ |
| Mythos Preview | ✓ | ✓ | ✓ | — | ✓ |

## Tests

- **Unit** (`TestSupportedThinkingLevels`, `TestAnthropicTopEfforts`): all matrix models + bedrock-prefixed / dotted / date-stamped variants.
- **End-to-end** (`TestCycleAgentThinkingLevel_PerModelTopTier`): walks a full Shift+Tab cycle for all 9 models — the automated equivalent of the manual repro.

Verified: `gofmt` clean, `golangci-lint` 0 issues, `go vet` clean, all tests green.

## Out of scope (follow-ups surfaced by review)

- Docs (`docs/providers/anthropic/index.md`, `docs/guides/thinking/index.md`) still describe effort-based adaptive thinking as "Opus 4.6+ only" — predates this PR and concerns the API request path, not the cycle.
- `RejectsTokenThinking` enumerates only Opus 4.6/4.7/4.8 — the issue explicitly scopes that path as *not affected*; whether Sonnet 4.6 / Fable / Mythos reject token budgets needs authoritative confirmation before changing.

Fixes #3100


