### PR TITLE
Expose ParseTheme for in-memory/embedded themes

### DIFF
--- a/pkg/tui/styles/theme.go
+++ b/pkg/tui/styles/theme.go
@@ -490,6 +490,30 @@ func LoadTheme(ref string) (*Theme, error) {
 	return theme, nil
 }
 
+// ParseTheme decodes a theme from raw YAML bytes and merges it onto the default
+// theme, so a partial theme need only specify the fields it wants to override.
+// This is the same merge behavior used when loading built-in and user themes
+// (see loadBuiltinTheme / loadThemeFrom), exposed for in-memory or embedded
+// themes that are not backed by a file on disk.
+//
+// Unlike LoadTheme, ParseTheme does not consult the theme cache and leaves Ref
+// unset, since an in-memory theme has no reference to reload from.
+func ParseTheme(data []byte) (*Theme, error) {
+	var override Theme
+	if err := yaml.Unmarshal(data, &override); err != nil {
+		return nil, fmt.Errorf("parsing theme: %w", err)
+	}
+
+	// mergeTheme inherits the default's Name when the override omits one, which
+	// would mislabel an unnamed custom theme as "Default". Name it explicitly.
+	merged := mergeTheme(DefaultTheme(), &override)
+	if override.Name == "" {
+		merged.Name = "custom"
+	}
+
+	return merged, nil
+}
+
 // getUserThemeFileInfo returns the path and modTime of a user theme file if it exists.
 // Returns empty path and zero time if the file doesn't exist.
 func getUserThemeFileInfo(ref string) (path string, modTime time.Time) {

--- a/pkg/tui/styles/theme_test.go
+++ b/pkg/tui/styles/theme_test.go
@@ -41,6 +41,43 @@ func TestDefaultTheme(t *testing.T) {
 	assert.NotEmpty(t, theme.Markdown.Heading)
 }
 
+func TestParseTheme_PartialOverrideMergesOntoDefault(t *testing.T) {
+	t.Parallel()
+
+	def := DefaultTheme()
+
+	// A partial theme that overrides only the accent color.
+	data := []byte("name: Branded\ncolors:\n  accent: \"#FF0000\"\n")
+
+	theme, err := ParseTheme(data)
+	require.NoError(t, err)
+	require.NotNil(t, theme)
+
+	// Overridden field takes the new value.
+	assert.Equal(t, "#FF0000", theme.Colors.Accent)
+	assert.Equal(t, "Branded", theme.Name)
+
+	// Unspecified fields are inherited from the default theme.
+	assert.Equal(t, def.Colors.Background, theme.Colors.Background)
+	assert.Equal(t, def.Colors.Success, theme.Colors.Success)
+	assert.Equal(t, def.Markdown.Heading, theme.Markdown.Heading)
+}
+
+func TestParseTheme_DefaultsNameWhenAbsent(t *testing.T) {
+	t.Parallel()
+
+	theme, err := ParseTheme([]byte("colors:\n  accent: \"#FF0000\"\n"))
+	require.NoError(t, err)
+	assert.Equal(t, "custom", theme.Name)
+}
+
+func TestParseTheme_InvalidYAML(t *testing.T) {
+	t.Parallel()
+
+	_, err := ParseTheme([]byte("colors: [this is not a map"))
+	require.Error(t, err)
+}
+
 func TestListThemeRefs_EmptyDir(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

Adds a public `styles.ParseTheme([]byte) (*Theme, error)` that decodes a theme
from raw YAML and merges it onto the default theme.

## Why

Themes are already partial overrides on top of `DefaultTheme()` — `loadBuiltinTheme`
and `loadThemeFrom` both do `mergeTheme(DefaultTheme(), &override)`, which is why a
bundled theme YAML only declares the colors it changes. That merge is the useful
part, but today it is reachable only through `LoadTheme`, which requires the theme
to exist on disk under a ref.

Downstream embedders that build a branded CLI/TUI on top of cagent want to ship a
custom theme compiled into the binary. Without a byte-level entrypoint the only
option is to unmarshal directly into a `Theme` and `ApplyTheme` it — which bypasses
the merge, so every unspecified field becomes a zero value. `ParseTheme` exposes the
existing merge behavior for in-memory/embedded themes, with no file round-trip.

It does not touch the theme cache and leaves `Ref` unset, since an in-memory theme
has no reference to reload from.

## Embed use case

```go
import (
    _ "embed"

    "github.com/docker/docker-agent/pkg/tui/styles"
)

//go:embed branded.yaml
var brandedTheme []byte

func applyBrandTheme() error {
    theme, err := styles.ParseTheme(brandedTheme)
    if err != nil {
        return err
    }
    styles.ApplyTheme(theme)
    return nil
}
```

## Example partial theme (overrides defaults)

Only the listed fields change; everything else is inherited from `DefaultTheme()`.

```yaml
# branded.yaml — a partial theme; unset fields fall back to the default theme.
name: Branded
colors:
  accent: "#FF5C00"        # override the accent
  brand: "#FF5C00"
  background: "#101014"    # override the background
markdown:
  heading: "#FF5C00"
# text_primary, success, error, chroma.*, etc. are NOT set here,
# so they keep the default theme's values.
```

## Test

`TestParseTheme_PartialOverrideMergesOntoDefault` asserts an overridden field takes
the new value while unspecified fields (`background`, `success`, `markdown.heading`)
match `DefaultTheme()`. Also covers name defaulting and invalid YAML.
