### PR TITLE
Add lean TUI user setting

### DIFF
--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -81,6 +81,7 @@ type runExecFlags struct {
 	// Run only
 	hideToolResults  bool
 	lean             bool
+	leanChanged      bool
 	appName          string
 	sidebar          bool
 	listenAddr       string
@@ -281,6 +282,7 @@ func (f *runExecFlags) runRunCommand(cmd *cobra.Command, args []string) (command
 	if f.worktreeBase != "" && !f.worktree {
 		return errors.New("--worktree-base requires --worktree")
 	}
+	f.leanChanged = cmd.Flags().Changed("lean")
 
 	out := cli.NewPrinter(cmd.OutOrStdout())
 
@@ -309,18 +311,7 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 	// Apply global user settings first (lowest priority)
 	// User settings only apply if the flag wasn't explicitly set by the user
 	userSettings := userconfig.Get()
-	if userSettings.HideToolResults && !f.hideToolResults {
-		f.hideToolResults = true
-		slog.DebugContext(ctx, "Applying user settings", "hide_tool_results", true)
-	}
-	if userSettings.YOLO && !f.autoApprove {
-		f.autoApprove = true
-		slog.DebugContext(ctx, "Applying user settings", "YOLO", true)
-	}
-	if userSettings.SnapshotsEnabled() {
-		f.snapshotsEnabled = true
-		slog.DebugContext(ctx, "Applying user settings", "snapshot", true)
-	}
+	f.applyUserSettings(ctx, userSettings)
 
 	// Apply alias options if this is an alias reference
 	// Alias options only apply if the flag wasn't explicitly set by the user
@@ -506,6 +497,25 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 // It returns the loaded team, the created worktree (nil when neither
 // --worktree nor --worktree-pr was given) and the working directory to run in
 // (the worktree's directory when one was created, otherwise wd unchanged).
+func (f *runExecFlags) applyUserSettings(ctx context.Context, userSettings *userconfig.Settings) {
+	if userSettings.HideToolResults && !f.hideToolResults {
+		f.hideToolResults = true
+		slog.DebugContext(ctx, "Applying user settings", "hide_tool_results", true)
+	}
+	if userSettings.YOLO && !f.autoApprove {
+		f.autoApprove = true
+		slog.DebugContext(ctx, "Applying user settings", "YOLO", true)
+	}
+	if userSettings.Lean && !f.leanChanged && !f.lean {
+		f.lean = true
+		slog.DebugContext(ctx, "Applying user settings", "lean", true)
+	}
+	if userSettings.SnapshotsEnabled() {
+		f.snapshotsEnabled = true
+		slog.DebugContext(ctx, "Applying user settings", "snapshot", true)
+	}
+}
+
 func (f *runExecFlags) loadTeamInWorktree(ctx context.Context, b backend, wd string) (*teamloader.LoadResult, *worktree.Worktree, string, error) {
 	createdWorktree, err := f.setupWorktree(ctx, wd)
 	if err != nil {

--- a/cmd/root/run_user_settings_test.go
+++ b/cmd/root/run_user_settings_test.go
@@ -1,0 +1,50 @@
+package root
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/docker/docker-agent/pkg/userconfig"
+)
+
+func TestRunExecFlagsApplyUserSettingsLean(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		lean        bool
+		leanChanged bool
+		wantLean    bool
+	}{
+		{
+			name:     "applies lean default",
+			wantLean: true,
+		},
+		{
+			name:        "keeps explicit lean false",
+			leanChanged: true,
+			wantLean:    false,
+		},
+		{
+			name:        "keeps explicit lean true",
+			lean:        true,
+			leanChanged: true,
+			wantLean:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			flags := &runExecFlags{
+				lean:        tt.lean,
+				leanChanged: tt.leanChanged,
+			}
+			flags.applyUserSettings(t.Context(), &userconfig.Settings{Lean: true})
+
+			assert.Equal(t, tt.wantLean, flags.lean)
+		})
+	}
+}

--- a/cmd/root/sandbox.go
+++ b/cmd/root/sandbox.go
@@ -258,7 +258,7 @@ func dockerAgentArgs(cmd *cobra.Command, args []string, configDir string) []stri
 		}
 
 		if f.Value.Type() == "bool" {
-			dockerAgentArgs = append(dockerAgentArgs, "--"+f.Name)
+			dockerAgentArgs = append(dockerAgentArgs, "--"+f.Name+"="+f.Value.String())
 		} else {
 			dockerAgentArgs = append(dockerAgentArgs, "--"+f.Name, f.Value.String())
 		}

--- a/cmd/root/sandbox_test.go
+++ b/cmd/root/sandbox_test.go
@@ -79,11 +79,28 @@ func TestDockerAgentArgs_PreservesUserYolo(t *testing.T) {
 
 	yoloCount := 0
 	for _, a := range got {
-		if a == "--yolo" {
+		if strings.HasPrefix(a, "--yolo") {
 			yoloCount++
 		}
 	}
 	assert.Equal(t, 1, yoloCount, "--yolo should not be duplicated, got: %v", got)
+	assert.Contains(t, got, "--yolo=true")
+}
+
+func TestDockerAgentArgs_PreservesExplicitFalseBool(t *testing.T) {
+	cmd := &cobra.Command{
+		RunE: func(*cobra.Command, []string) error { return nil },
+	}
+	var sandboxFlag, lean bool
+	cmd.PersistentFlags().BoolVar(&sandboxFlag, "sandbox", false, "")
+	cmd.PersistentFlags().BoolVar(&lean, "lean", true, "")
+
+	require.NoError(t, cmd.ParseFlags([]string{"--sandbox", "--lean=false"}))
+
+	got := dockerAgentArgs(cmd, []string{"./agent.yaml"}, "/cfg")
+
+	assert.Contains(t, got, "--lean=false")
+	assert.NotContains(t, got, "--lean")
 }
 
 func TestGatewayHostPort(t *testing.T) {

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -41,7 +41,22 @@ $ docker agent run agent.yaml --disable-commands="/cost,/eval,/model"
 
 # Open in read-only mode to review a past session without sending new messages
 $ docker agent run agent.yaml --session -1 --session-read-only
+
+# Use the lean TUI for this run
+$ docker agent run agent.yaml --lean
 ```
+
+### Lean TUI
+
+The lean TUI uses a simplified terminal interface with minimal chrome. To make it the default for interactive runs, set `lean` in your user config:
+
+```yaml
+# ~/.config/cagent/config.yaml
+settings:
+  lean: true
+```
+
+Omit `lean` or set it to `false` to keep the full TUI as the default. You can still use `--lean` for a single run, or `--lean=false` to use the full TUI when `settings.lean` is enabled.
 
 ## Slash Commands
 

--- a/pkg/userconfig/userconfig.go
+++ b/pkg/userconfig/userconfig.go
@@ -55,6 +55,8 @@ type Settings struct {
 	Theme string `yaml:"theme,omitempty"`
 	// YOLO enables auto-approve mode for all tool calls globally
 	YOLO bool `yaml:"YOLO,omitempty"`
+	// Lean makes the simplified TUI with minimal chrome the default UI.
+	Lean bool `yaml:"lean,omitempty"`
 	// TabTitleMaxLength is the maximum display length for tab titles in the TUI.
 	// Titles longer than this are truncated with an ellipsis. Defaults to 20.
 	TabTitleMaxLength int `yaml:"tab_title_max_length,omitempty"`

--- a/pkg/userconfig/userconfig_test.go
+++ b/pkg/userconfig/userconfig_test.go
@@ -510,6 +510,27 @@ func TestConfig_Settings_HideToolResults(t *testing.T) {
 	assert.True(t, loaded.Settings.HideToolResults)
 }
 
+func TestConfig_Settings_Lean(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+
+	config := &Config{
+		Settings: &Settings{
+			Lean: true,
+		},
+	}
+
+	require.NoError(t, config.saveTo(configFile))
+
+	loaded, err := loadFrom(configFile, "")
+	require.NoError(t, err)
+
+	assert.NotNil(t, loaded.Settings)
+	assert.True(t, loaded.Settings.Lean)
+}
+
 func TestConfig_Settings_Empty(t *testing.T) {
 	t.Parallel()
 
@@ -523,6 +544,7 @@ func TestConfig_Settings_Empty(t *testing.T) {
 	settings := config.GetSettings()
 	assert.NotNil(t, settings)
 	assert.False(t, settings.HideToolResults)
+	assert.False(t, settings.Lean)
 	assert.False(t, settings.GetExpandThinking())
 }
 


### PR DESCRIPTION
Adds a global `settings.lean` user config option so users can make the lean TUI the default for interactive runs.

- Applies `settings.lean: true` as a low-priority default
- Preserves explicit CLI overrides, including `--lean=false`
- Preserves explicit false bool flags when forwarding sandboxed runs
- Documents the new config option

Testing:
- `go test ./pkg/userconfig/...`
- `go test ./cmd/root ./pkg/userconfig ./pkg/leantui ./pkg/tui`
- `./scripts/build.sh`
- `go run ./lint .`
- `go mod tidy --diff`

Full `go test ./...` was attempted but hit unrelated environment/pre-existing failures: localhost DNS, `pkg/cache`, and `pkg/rag/treesitter` CGO.