### PR TITLE
fix: seal MCP OAuth tokens with keyring-backed file

### DIFF
--- a/pkg/tools/mcp/tokenstore_keyring.go
+++ b/pkg/tools/mcp/tokenstore_keyring.go
@@ -65,6 +65,7 @@ type KeyringTokenStore struct {
 
 	mu     sync.Mutex
 	cache  map[string]*OAuthToken
+	key    []byte // cached encryption key; fetched from the keyring once
 	loaded bool
 }
 
@@ -145,33 +146,33 @@ func (s *KeyringTokenStore) load() {
 			s.cache = map[string]*OAuthToken{}
 		}
 	case errors.Is(err, os.ErrNotExist):
-		// Possibly an upgrade from the old keyring-bundle layout. Best-effort
+		// Possibly an upgrade from an older keyring-only layout. Best-effort
 		// migration; failures here are silent so an upgrade is never worse
 		// than a fresh install.
-		if migrated := s.migrateLegacyLocked(); migrated > 0 {
-			slog.Debug("Migrated legacy OAuth tokens", "count", migrated)
-			if perr := s.persistLocked(); perr != nil {
-				slog.Warn("Failed to persist migrated OAuth tokens", "error", perr)
-			}
-		}
+		s.migrateLegacyLocked()
 	default:
 		slog.Warn("Failed to read OAuth token file; using in-memory cache for this process", "error", err)
 	}
 }
 
 // encryptionKey fetches the AES key from the keyring, generating and
-// persisting a fresh one the first time. This is the only keyring access
-// the store performs.
+// persisting a fresh one the first time. The key is cached in memory after
+// the first call, so the keyring is touched at most once per process.
 //
 // Caller must hold s.mu.
 func (s *KeyringTokenStore) encryptionKey() ([]byte, error) {
+	if s.key != nil {
+		return s.key, nil
+	}
+
 	item, err := s.ring.Get(encryptionKeyItem)
 	switch {
 	case err == nil:
 		if len(item.Data) != encryptionKeySize {
 			return nil, fmt.Errorf("stored encryption key has wrong size %d", len(item.Data))
 		}
-		return item.Data, nil
+		s.key = item.Data
+		return s.key, nil
 	case errors.Is(err, keyring.ErrKeyNotFound):
 		key := make([]byte, encryptionKeySize)
 		if _, rerr := rand.Read(key); rerr != nil {
@@ -184,7 +185,8 @@ func (s *KeyringTokenStore) encryptionKey() ([]byte, error) {
 		}); serr != nil {
 			return nil, fmt.Errorf("failed to store encryption key: %w", serr)
 		}
-		return key, nil
+		s.key = key
+		return s.key, nil
 	default:
 		return nil, err
 	}
@@ -215,26 +217,57 @@ func (s *KeyringTokenStore) decryptInto(key, data []byte) error {
 
 // migrateLegacyLocked folds tokens written by the previous keyring-only
 // layouts (the single "oauth:tokens" bundle, or the even older
-// per-resource items) into s.cache and deletes the legacy keyring entries.
+// per-resource items) into s.cache, persists them to the encrypted file,
+// and only then removes the legacy keyring entries.
+//
+// The persist-before-delete ordering is deliberate: if the file write
+// fails we leave the legacy entries untouched so the next process can
+// retry, rather than deleting the only copy of the user's tokens. The
+// in-memory cache is still populated so the current session keeps working.
+//
 // Caller must hold s.mu.
-func (s *KeyringTokenStore) migrateLegacyLocked() int {
+func (s *KeyringTokenStore) migrateLegacyLocked() {
+	legacyKeys := s.collectLegacyTokensLocked()
+	if len(legacyKeys) == 0 {
+		return
+	}
+
+	if err := s.persistLocked(); err != nil {
+		slog.Warn("Failed to persist migrated OAuth tokens; leaving legacy keyring entries in place for retry", "error", err)
+		return
+	}
+	slog.Debug("Migrated legacy OAuth tokens", "count", len(s.cache))
+
+	for _, key := range legacyKeys {
+		_ = s.ring.Remove(key)
+	}
+}
+
+// collectLegacyTokensLocked reads tokens from both legacy keyring layouts
+// into s.cache and returns the keyring keys that should be removed once the
+// migration has been safely persisted. It does not mutate the keyring.
+//
+// Caller must hold s.mu.
+func (s *KeyringTokenStore) collectLegacyTokensLocked() []string {
+	var legacyKeys []string
+
 	// Newer legacy layout: a single JSON bundle under one keyring item.
 	if item, err := s.ring.Get(legacyBundleKey); err == nil {
 		bundle := map[string]*OAuthToken{}
 		if json.Unmarshal(item.Data, &bundle) == nil {
 			maps.Copy(s.cache, bundle)
 		}
-		_ = s.ring.Remove(legacyBundleKey)
+		legacyKeys = append(legacyKeys, legacyBundleKey)
 	}
 
 	// Oldest legacy layout: one keyring item per resource URL.
 	keys, err := s.ring.Keys()
 	if err != nil {
-		return len(s.cache)
+		return legacyKeys
 	}
 	for _, key := range keys {
 		if key == legacyIndexKey {
-			_ = s.ring.Remove(key)
+			legacyKeys = append(legacyKeys, key)
 			continue
 		}
 		if key == legacyBundleKey || key == encryptionKeyItem || !strings.HasPrefix(key, legacyTokenPrefix) {
@@ -250,9 +283,9 @@ func (s *KeyringTokenStore) migrateLegacyLocked() int {
 			continue
 		}
 		s.cache[strings.TrimPrefix(key, legacyTokenPrefix)] = &token
-		_ = s.ring.Remove(key)
+		legacyKeys = append(legacyKeys, key)
 	}
-	return len(s.cache)
+	return legacyKeys
 }
 
 // persistLocked encrypts the in-memory bundle and writes it atomically to

--- a/pkg/tools/mcp/tokenstore_keyring.go
+++ b/pkg/tools/mcp/tokenstore_keyring.go
@@ -1,40 +1,67 @@
 package mcp
 
 import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
 
 	"github.com/99designs/keyring"
+
+	"github.com/docker/docker-agent/pkg/paths"
 )
 
-// All OAuth tokens for all MCP servers are stored under a single keyring
-// item. On macOS each keychain item carries its own ACL, so storing N
-// tokens as N items would prompt the user N times the first time each is
-// read (and again whenever the binary's signature changes). Bundling them
-// collapses that to a single prompt — and a single "Always Allow"
-// decision — for any number of MCP servers.
+// OAuth tokens are encrypted with AES-256-GCM and written to a single file
+// on disk; the encryption key is the only thing kept in the OS keyring.
+//
+// This split solves two problems that the previous "everything in one
+// keyring item" layout could not solve at once:
+//
+//   - Size: keyring backends cap item size (Windows Credential Manager at
+//     2560 bytes, the Linux kernel keyring at a per-user quota). A bundle
+//     of several multi-kilobyte OAuth tokens easily blows past that. The
+//     key we store is a fixed 32 bytes, so it always fits; the unbounded
+//     token blob lives in a file instead.
+//   - Prompts: on macOS each keychain item carries its own ACL, so N items
+//     means N permission prompts (and re-prompts whenever the binary's
+//     signature changes). Keeping exactly one keyring item collapses that
+//     to a single prompt — and a single "Always Allow" — no matter how
+//     many MCP servers the user authorizes.
 const (
 	keyringServiceName = "docker-agent-oauth"
-	bundleKey          = "oauth:tokens"
 
-	// Items written by the previous one-token-per-item layout, migrated
-	// into the bundle on first load and then removed.
+	// encryptionKeyItem is the single keyring item we read/write: the
+	// AES-256 key that seals the on-disk token file.
+	encryptionKeyItem = "oauth:encryption-key"
+	encryptionKeySize = 32 // AES-256
+
+	// tokenFileName is the encrypted token bundle, stored under the config
+	// dir alongside other docker-agent state.
+	tokenFileName = "mcp-oauth-tokens.enc"
+
+	// Legacy keyring keys from the previous "bundle in the keyring"
+	// layout. Migrated into the encrypted file on first load, then removed.
+	legacyBundleKey   = "oauth:tokens"
 	legacyTokenPrefix = "oauth:"
 	legacyIndexKey    = "oauth:_index"
 )
 
-// KeyringTokenStore implements OAuthTokenStore by caching the bundled
-// keyring item in memory: the OAuth transport's hot path stays in memory
-// after the first hit, and writes always target the same keyring item so
-// the user's "Always Allow" decision keeps applying to refreshes and to
-// new MCP servers.
+// KeyringTokenStore keeps OAuth tokens in memory, sealing them to disk with
+// a key held in the OS keyring. The keyring is touched at most once per
+// process (to fetch or create the key), so the user's "Always Allow"
+// decision keeps applying to refreshes and to newly authorized servers.
 type KeyringTokenStore struct {
-	ring keyring.Keyring
+	ring     keyring.Keyring
+	filePath string
 
 	mu     sync.Mutex
 	cache  map[string]*OAuthToken
@@ -69,7 +96,7 @@ var defaultStore = sync.OnceValue(func() OAuthTokenStore {
 		slog.Warn("OS keyring not available, falling back to in-memory token store", "error", err)
 		return NewInMemoryTokenStore()
 	}
-	return newKeyringTokenStore(ring)
+	return newKeyringTokenStore(ring, filepath.Join(paths.GetConfigDir(), tokenFileName))
 })
 
 // NewKeyringTokenStore returns the process-wide token store backed by the
@@ -79,21 +106,23 @@ func NewKeyringTokenStore() OAuthTokenStore {
 	return defaultStore()
 }
 
-// newKeyringTokenStore wraps an arbitrary keyring with the bundle-and-cache
-// store. Used by tests to inject keyring.NewArrayKeyring().
-func newKeyringTokenStore(ring keyring.Keyring) *KeyringTokenStore {
+// newKeyringTokenStore wraps a keyring and an on-disk file path with the
+// encrypt-and-cache store. Used by tests to inject keyring.NewArrayKeyring()
+// and a temp file.
+func newKeyringTokenStore(ring keyring.Keyring, filePath string) *KeyringTokenStore {
 	return &KeyringTokenStore{
-		ring:  ring,
-		cache: map[string]*OAuthToken{},
+		ring:     ring,
+		filePath: filePath,
+		cache:    map[string]*OAuthToken{},
 	}
 }
 
-// load fetches the bundled item from the keyring on first use and caches
-// it. Subsequent calls are no-ops, so methods can call load() at the top
-// of every operation without re-prompting the user. Failures are logged
-// but not propagated — an empty in-memory cache lets the OAuth flow
-// re-populate fresh tokens, and marking the cache loaded eagerly keeps a
-// denied access from snowballing into a prompt on every call.
+// load decrypts the on-disk token file on first use and caches it.
+// Subsequent calls are no-ops, so methods can call load() at the top of
+// every operation without re-touching the keyring. Failures are logged but
+// not propagated — an empty in-memory cache lets the OAuth flow re-populate
+// fresh tokens, and marking the cache loaded eagerly keeps a denied keyring
+// access from snowballing into a prompt on every call.
 //
 // Caller must hold s.mu.
 func (s *KeyringTokenStore) load() {
@@ -102,17 +131,23 @@ func (s *KeyringTokenStore) load() {
 	}
 	s.loaded = true
 
-	item, err := s.ring.Get(bundleKey)
+	key, err := s.encryptionKey()
+	if err != nil {
+		slog.Warn("Failed to obtain OAuth encryption key; using in-memory cache for this process", "error", err)
+		return
+	}
+
+	data, err := os.ReadFile(s.filePath)
 	switch {
 	case err == nil:
-		if uerr := json.Unmarshal(item.Data, &s.cache); uerr != nil {
-			slog.Warn("OAuth token bundle is corrupt; starting fresh", "error", uerr)
+		if derr := s.decryptInto(key, data); derr != nil {
+			slog.Warn("OAuth token file is corrupt; starting fresh", "error", derr)
 			s.cache = map[string]*OAuthToken{}
 		}
-	case errors.Is(err, keyring.ErrKeyNotFound):
-		// Possibly an upgrade from the old per-token layout. Best-effort
-		// migration; failures here are silent so an upgrade is never
-		// worse than a fresh install.
+	case errors.Is(err, os.ErrNotExist):
+		// Possibly an upgrade from the old keyring-bundle layout. Best-effort
+		// migration; failures here are silent so an upgrade is never worse
+		// than a fresh install.
 		if migrated := s.migrateLegacyLocked(); migrated > 0 {
 			slog.Debug("Migrated legacy OAuth tokens", "count", migrated)
 			if perr := s.persistLocked(); perr != nil {
@@ -120,25 +155,89 @@ func (s *KeyringTokenStore) load() {
 			}
 		}
 	default:
-		slog.Warn("Failed to load OAuth tokens from keyring; using in-memory cache for this process", "error", err)
+		slog.Warn("Failed to read OAuth token file; using in-memory cache for this process", "error", err)
 	}
 }
 
-// migrateLegacyLocked folds tokens written by the old per-resource layout
-// into s.cache and deletes the legacy entries. Caller must hold s.mu.
-func (s *KeyringTokenStore) migrateLegacyLocked() int {
-	keys, err := s.ring.Keys()
+// encryptionKey fetches the AES key from the keyring, generating and
+// persisting a fresh one the first time. This is the only keyring access
+// the store performs.
+//
+// Caller must hold s.mu.
+func (s *KeyringTokenStore) encryptionKey() ([]byte, error) {
+	item, err := s.ring.Get(encryptionKeyItem)
+	switch {
+	case err == nil:
+		if len(item.Data) != encryptionKeySize {
+			return nil, fmt.Errorf("stored encryption key has wrong size %d", len(item.Data))
+		}
+		return item.Data, nil
+	case errors.Is(err, keyring.ErrKeyNotFound):
+		key := make([]byte, encryptionKeySize)
+		if _, rerr := rand.Read(key); rerr != nil {
+			return nil, fmt.Errorf("failed to generate encryption key: %w", rerr)
+		}
+		if serr := s.ring.Set(keyring.Item{
+			Key:   encryptionKeyItem,
+			Data:  key,
+			Label: "Docker Agent OAuth Encryption Key",
+		}); serr != nil {
+			return nil, fmt.Errorf("failed to store encryption key: %w", serr)
+		}
+		return key, nil
+	default:
+		return nil, err
+	}
+}
+
+// decryptInto decrypts data into s.cache. The nonce is prepended to the
+// ciphertext. Caller must hold s.mu.
+func (s *KeyringTokenStore) decryptInto(key, data []byte) error {
+	gcm, err := newGCM(key)
 	if err != nil {
-		return 0
+		return err
+	}
+	if len(data) < gcm.NonceSize() {
+		return errors.New("token file too short")
+	}
+	nonce, ciphertext := data[:gcm.NonceSize()], data[gcm.NonceSize():]
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return fmt.Errorf("failed to decrypt token file: %w", err)
+	}
+	cache := map[string]*OAuthToken{}
+	if err := json.Unmarshal(plaintext, &cache); err != nil {
+		return fmt.Errorf("failed to unmarshal token bundle: %w", err)
+	}
+	s.cache = cache
+	return nil
+}
+
+// migrateLegacyLocked folds tokens written by the previous keyring-only
+// layouts (the single "oauth:tokens" bundle, or the even older
+// per-resource items) into s.cache and deletes the legacy keyring entries.
+// Caller must hold s.mu.
+func (s *KeyringTokenStore) migrateLegacyLocked() int {
+	// Newer legacy layout: a single JSON bundle under one keyring item.
+	if item, err := s.ring.Get(legacyBundleKey); err == nil {
+		bundle := map[string]*OAuthToken{}
+		if json.Unmarshal(item.Data, &bundle) == nil {
+			maps.Copy(s.cache, bundle)
+		}
+		_ = s.ring.Remove(legacyBundleKey)
 	}
 
-	var migrated int
+	// Oldest legacy layout: one keyring item per resource URL.
+	keys, err := s.ring.Keys()
+	if err != nil {
+		return len(s.cache)
+	}
 	for _, key := range keys {
 		if key == legacyIndexKey {
 			_ = s.ring.Remove(key)
 			continue
 		}
-		if key == bundleKey || !strings.HasPrefix(key, legacyTokenPrefix) {
+		if key == legacyBundleKey || key == encryptionKeyItem || !strings.HasPrefix(key, legacyTokenPrefix) {
 			continue
 		}
 
@@ -152,23 +251,76 @@ func (s *KeyringTokenStore) migrateLegacyLocked() int {
 		}
 		s.cache[strings.TrimPrefix(key, legacyTokenPrefix)] = &token
 		_ = s.ring.Remove(key)
-		migrated++
 	}
-	return migrated
+	return len(s.cache)
 }
 
-// persistLocked writes the in-memory bundle back to the keyring.
-// Caller must hold s.mu.
+// persistLocked encrypts the in-memory bundle and writes it atomically to
+// disk. Caller must hold s.mu.
 func (s *KeyringTokenStore) persistLocked() error {
-	data, err := json.Marshal(s.cache) //nolint:gosec // OAuth token bundle is intentionally serialized for keyring storage
+	key, err := s.encryptionKey()
+	if err != nil {
+		return err
+	}
+
+	plaintext, err := json.Marshal(s.cache) //nolint:gosec // OAuth token bundle is intentionally serialized for storage
 	if err != nil {
 		return fmt.Errorf("failed to marshal token bundle: %w", err)
 	}
-	return s.ring.Set(keyring.Item{
-		Key:   bundleKey,
-		Data:  data,
-		Label: "Docker Agent OAuth Tokens",
-	})
+
+	gcm, err := newGCM(key)
+	if err != nil {
+		return err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return fmt.Errorf("failed to generate nonce: %w", err)
+	}
+	sealed := gcm.Seal(nonce, nonce, plaintext, nil)
+
+	if err := os.MkdirAll(filepath.Dir(s.filePath), 0o700); err != nil {
+		return fmt.Errorf("failed to create token directory: %w", err)
+	}
+	return atomicWrite(s.filePath, sealed)
+}
+
+func newGCM(key []byte) (cipher.AEAD, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GCM: %w", err)
+	}
+	return gcm, nil
+}
+
+// atomicWrite writes data to a temp file in the same directory and renames
+// it over the target, so a crash mid-write never leaves a truncated file.
+func atomicWrite(path string, data []byte) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".oauth-tokens-*.tmp")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return fmt.Errorf("failed to chmod temp file: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("failed to write temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("failed to close temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("failed to rename token file: %w", err)
+	}
+	return nil
 }
 
 func (s *KeyringTokenStore) GetToken(resourceURL string) (*OAuthToken, error) {

--- a/pkg/tools/mcp/tokenstore_keyring.go
+++ b/pkg/tools/mcp/tokenstore_keyring.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/99designs/keyring"
 
+	"github.com/docker/docker-agent/pkg/atomicfile"
 	"github.com/docker/docker-agent/pkg/paths"
 )
 
@@ -62,11 +64,13 @@ const (
 type KeyringTokenStore struct {
 	ring     keyring.Keyring
 	filePath string
+	write    func(string, []byte) error
 
-	mu     sync.Mutex
-	cache  map[string]*OAuthToken
-	key    []byte // cached encryption key; fetched from the keyring once
-	loaded bool
+	mu      sync.Mutex
+	cache   map[string]*OAuthToken
+	key     []byte // cached encryption key; fetched from the keyring once
+	loaded  bool
+	loadErr error
 }
 
 func openKeyring() (keyring.Keyring, error) {
@@ -114,6 +118,7 @@ func newKeyringTokenStore(ring keyring.Keyring, filePath string) *KeyringTokenSt
 	return &KeyringTokenStore{
 		ring:     ring,
 		filePath: filePath,
+		write:    writeTokenFile,
 		cache:    map[string]*OAuthToken{},
 	}
 }
@@ -132,15 +137,14 @@ func (s *KeyringTokenStore) load() {
 	}
 	s.loaded = true
 
-	key, err := s.encryptionKey()
-	if err != nil {
-		slog.Warn("Failed to obtain OAuth encryption key; using in-memory cache for this process", "error", err)
-		return
-	}
-
 	data, err := os.ReadFile(s.filePath)
 	switch {
 	case err == nil:
+		key, kerr := s.encryptionKey()
+		if kerr != nil {
+			slog.Warn("Failed to obtain OAuth encryption key; using in-memory cache for this process", "error", kerr)
+			return
+		}
 		if derr := s.decryptInto(key, data); derr != nil {
 			slog.Warn("OAuth token file is corrupt; starting fresh", "error", derr)
 			s.cache = map[string]*OAuthToken{}
@@ -151,7 +155,8 @@ func (s *KeyringTokenStore) load() {
 		// than a fresh install.
 		s.migrateLegacyLocked()
 	default:
-		slog.Warn("Failed to read OAuth token file; using in-memory cache for this process", "error", err)
+		s.loadErr = fmt.Errorf("failed to read OAuth token file: %w", err)
+		slog.Warn("Failed to read OAuth token file; refusing to overwrite it", "error", err)
 	}
 }
 
@@ -227,6 +232,18 @@ func (s *KeyringTokenStore) decryptInto(key, data []byte) error {
 //
 // Caller must hold s.mu.
 func (s *KeyringTokenStore) migrateLegacyLocked() {
+	unlock, err := lockTokenFile(s.filePath)
+	if err != nil {
+		slog.Warn("Failed to lock OAuth token file for migration; leaving legacy keyring entries in place for retry", "error", err)
+		return
+	}
+	defer unlock()
+
+	if err := s.reloadFromDiskLocked(); err != nil {
+		slog.Warn("Failed to reload OAuth token file during migration; leaving legacy keyring entries in place for retry", "error", err)
+		return
+	}
+
 	legacyKeys := s.collectLegacyTokensLocked()
 	if len(legacyKeys) == 0 {
 		return
@@ -250,40 +267,50 @@ func (s *KeyringTokenStore) migrateLegacyLocked() {
 // Caller must hold s.mu.
 func (s *KeyringTokenStore) collectLegacyTokensLocked() []string {
 	var legacyKeys []string
+	legacyTokens := map[string]*OAuthToken{}
 
-	// Newer legacy layout: a single JSON bundle under one keyring item.
+	// Oldest legacy layout: one keyring item per resource URL.
+	keys, err := s.ring.Keys()
+	if err == nil {
+		for _, key := range keys {
+			if key == legacyIndexKey {
+				legacyKeys = append(legacyKeys, key)
+				continue
+			}
+			if key == legacyBundleKey || key == encryptionKeyItem || !strings.HasPrefix(key, legacyTokenPrefix) {
+				continue
+			}
+
+			item, err := s.ring.Get(key)
+			if err != nil {
+				continue
+			}
+			var token OAuthToken
+			if json.Unmarshal(item.Data, &token) != nil {
+				continue
+			}
+			legacyTokens[strings.TrimPrefix(key, legacyTokenPrefix)] = &token
+			legacyKeys = append(legacyKeys, key)
+		}
+	}
+
+	// Newer legacy layout: a single JSON bundle under one keyring item. It
+	// intentionally wins over per-resource items for the same URL.
 	if item, err := s.ring.Get(legacyBundleKey); err == nil {
 		bundle := map[string]*OAuthToken{}
 		if json.Unmarshal(item.Data, &bundle) == nil {
-			maps.Copy(s.cache, bundle)
+			maps.Copy(legacyTokens, bundle)
 		}
 		legacyKeys = append(legacyKeys, legacyBundleKey)
 	}
 
-	// Oldest legacy layout: one keyring item per resource URL.
-	keys, err := s.ring.Keys()
-	if err != nil {
-		return legacyKeys
-	}
-	for _, key := range keys {
-		if key == legacyIndexKey {
-			legacyKeys = append(legacyKeys, key)
-			continue
+	// The encrypted file is the newest source of truth. Legacy tokens only
+	// fill gaps, which prevents a stale legacy entry from overwriting a token
+	// another process just persisted while this process was starting.
+	for url, token := range legacyTokens {
+		if _, exists := s.cache[url]; !exists {
+			s.cache[url] = token
 		}
-		if key == legacyBundleKey || key == encryptionKeyItem || !strings.HasPrefix(key, legacyTokenPrefix) {
-			continue
-		}
-
-		item, err := s.ring.Get(key)
-		if err != nil {
-			continue
-		}
-		var token OAuthToken
-		if json.Unmarshal(item.Data, &token) != nil {
-			continue
-		}
-		s.cache[strings.TrimPrefix(key, legacyTokenPrefix)] = &token
-		legacyKeys = append(legacyKeys, key)
 	}
 	return legacyKeys
 }
@@ -311,10 +338,50 @@ func (s *KeyringTokenStore) persistLocked() error {
 	}
 	sealed := gcm.Seal(nonce, nonce, plaintext, nil)
 
-	if err := os.MkdirAll(filepath.Dir(s.filePath), 0o700); err != nil {
+	if err := ensurePrivateDir(filepath.Dir(s.filePath)); err != nil {
+		return err
+	}
+	return s.write(s.filePath, sealed)
+}
+
+func ensurePrivateDir(dir string) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("failed to create token directory: %w", err)
 	}
-	return atomicWrite(s.filePath, sealed)
+	if err := os.Chmod(dir, 0o700); err != nil { //nolint:gosec // directory needs execute bit; 0700 is owner-only
+		return fmt.Errorf("failed to secure token directory: %w", err)
+	}
+	return nil
+}
+
+// reloadFromDiskLocked refreshes s.cache from the encrypted file while the
+// caller holds both s.mu and the cross-process file lock. A missing file is
+// not an error; a corrupt file is treated as empty so StoreToken can recover
+// by writing a fresh encrypted bundle.
+func (s *KeyringTokenStore) reloadFromDiskLocked() error {
+	data, err := os.ReadFile(s.filePath)
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		return nil
+	case err != nil:
+		return fmt.Errorf("failed to read OAuth token file: %w", err)
+	}
+	key, err := s.encryptionKey()
+	if err != nil {
+		return err
+	}
+	if err := s.decryptInto(key, data); err != nil {
+		slog.Warn("OAuth token file is corrupt; overwriting with fresh token bundle", "error", err)
+		s.cache = map[string]*OAuthToken{}
+	}
+	return nil
+}
+
+func writeTokenFile(path string, data []byte) error {
+	if err := ensurePrivateDir(filepath.Dir(path)); err != nil {
+		return err
+	}
+	return atomicfile.Write(path, bytes.NewReader(data), 0o600)
 }
 
 func newGCM(key []byte) (cipher.AEAD, error) {
@@ -327,33 +394,6 @@ func newGCM(key []byte) (cipher.AEAD, error) {
 		return nil, fmt.Errorf("failed to create GCM: %w", err)
 	}
 	return gcm, nil
-}
-
-// atomicWrite writes data to a temp file in the same directory and renames
-// it over the target, so a crash mid-write never leaves a truncated file.
-func atomicWrite(path string, data []byte) error {
-	tmp, err := os.CreateTemp(filepath.Dir(path), ".oauth-tokens-*.tmp")
-	if err != nil {
-		return fmt.Errorf("failed to create temp file: %w", err)
-	}
-	tmpName := tmp.Name()
-	defer os.Remove(tmpName)
-
-	if err := tmp.Chmod(0o600); err != nil {
-		tmp.Close()
-		return fmt.Errorf("failed to chmod temp file: %w", err)
-	}
-	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
-		return fmt.Errorf("failed to write temp file: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		return fmt.Errorf("failed to close temp file: %w", err)
-	}
-	if err := os.Rename(tmpName, path); err != nil {
-		return fmt.Errorf("failed to rename token file: %w", err)
-	}
-	return nil
 }
 
 func (s *KeyringTokenStore) GetToken(resourceURL string) (*OAuthToken, error) {
@@ -372,6 +412,18 @@ func (s *KeyringTokenStore) StoreToken(resourceURL string, token *OAuthToken) er
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.load()
+	if s.loadErr != nil {
+		return s.loadErr
+	}
+
+	unlock, err := lockTokenFile(s.filePath)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	if err := s.reloadFromDiskLocked(); err != nil {
+		return err
+	}
 
 	s.cache[resourceURL] = token
 	return s.persistLocked()
@@ -381,6 +433,18 @@ func (s *KeyringTokenStore) RemoveToken(resourceURL string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.load()
+	if s.loadErr != nil {
+		return s.loadErr
+	}
+
+	unlock, err := lockTokenFile(s.filePath)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	if err := s.reloadFromDiskLocked(); err != nil {
+		return err
+	}
 
 	if _, ok := s.cache[resourceURL]; !ok {
 		return nil

--- a/pkg/tools/mcp/tokenstore_keyring_test.go
+++ b/pkg/tools/mcp/tokenstore_keyring_test.go
@@ -227,6 +227,60 @@ func TestEncryptedStore_WritesTouchKeyringOnce(t *testing.T) {
 	}
 }
 
+func TestEncryptedStore_GetMissDoesNotCreateKeyringItem(t *testing.T) {
+	ring := keyring.NewArrayKeyring(nil)
+	store := newKeyringTokenStore(ring, filepath.Join(t.TempDir(), tokenFileName))
+
+	if _, err := store.GetToken("https://missing.example/mcp"); err == nil {
+		t.Fatal("expected missing token error")
+	}
+
+	keys, err := ring.Keys()
+	if err != nil {
+		t.Fatalf("Keys: %v", err)
+	}
+	if len(keys) != 0 {
+		t.Fatalf("missing-token lookup should not create keyring entries, got %v", keys)
+	}
+}
+
+func TestEncryptedStore_CrossProcessStoresMerge(t *testing.T) {
+	ring := keyring.NewArrayKeyring(nil)
+	path := filepath.Join(t.TempDir(), tokenFileName)
+
+	processA := newKeyringTokenStore(ring, path)
+	processB := newKeyringTokenStore(ring, path)
+
+	if err := processA.StoreToken("https://a.example/mcp", &OAuthToken{AccessToken: "a"}); err != nil {
+		t.Fatalf("processA initial StoreToken: %v", err)
+	}
+	// Process B loads the same initial state before A writes again.
+	if _, err := processB.GetToken("https://a.example/mcp"); err != nil {
+		t.Fatalf("processB load: %v", err)
+	}
+	if err := processA.StoreToken("https://c.example/mcp", &OAuthToken{AccessToken: "c"}); err != nil {
+		t.Fatalf("processA second StoreToken: %v", err)
+	}
+	if err := processB.StoreToken("https://b.example/mcp", &OAuthToken{AccessToken: "b"}); err != nil {
+		t.Fatalf("processB StoreToken: %v", err)
+	}
+
+	fresh := newKeyringTokenStore(ring, path)
+	for url, want := range map[string]string{
+		"https://a.example/mcp": "a",
+		"https://b.example/mcp": "b",
+		"https://c.example/mcp": "c",
+	} {
+		got, err := fresh.GetToken(url)
+		if err != nil {
+			t.Fatalf("GetToken(%s): %v", url, err)
+		}
+		if got.AccessToken != want {
+			t.Errorf("AccessToken for %s = %q, want %q", url, got.AccessToken, want)
+		}
+	}
+}
+
 // TestEncryptedStore_KeyringHoldsOnlyTheKey verifies that no matter how
 // many resource URLs are stored, the keyring holds exactly one item: the
 // encryption key. The tokens themselves live in the file, so macOS only
@@ -379,6 +433,31 @@ func TestEncryptedStore_LegacyPerTokenMigration(t *testing.T) {
 	}
 }
 
+func TestEncryptedStore_LegacyBundleWinsOverPerTokenMigration(t *testing.T) {
+	ring := keyring.NewArrayKeyring(nil)
+	path := filepath.Join(t.TempDir(), tokenFileName)
+	const url = "https://legacy.example/mcp"
+
+	seedLegacyToken(t, ring, url, &OAuthToken{AccessToken: "old-per-token"})
+	bundleData, err := json.Marshal(map[string]*OAuthToken{
+		url: {AccessToken: "new-bundle"},
+	})
+	if err != nil {
+		t.Fatalf("marshal legacy bundle: %v", err)
+	}
+	if err := ring.Set(keyring.Item{Key: legacyBundleKey, Data: bundleData}); err != nil {
+		t.Fatalf("seed legacy bundle: %v", err)
+	}
+
+	got, err := newKeyringTokenStore(ring, path).GetToken(url)
+	if err != nil {
+		t.Fatalf("GetToken: %v", err)
+	}
+	if got.AccessToken != "new-bundle" {
+		t.Fatalf("AccessToken = %q, want newer bundle token", got.AccessToken)
+	}
+}
+
 func seedLegacyToken(t *testing.T, ring keyring.Keyring, url string, tok *OAuthToken) {
 	t.Helper()
 	data, err := json.Marshal(tok)
@@ -408,17 +487,8 @@ func TestEncryptedStore_MigrationKeepsLegacyOnPersistFailure(t *testing.T) {
 		t.Fatalf("seed legacy bundle: %v", err)
 	}
 
-	// Point the store at a file inside a read-only directory: reading the
-	// (absent) file still reports os.ErrNotExist so migration runs, but the
-	// atomic write into the read-only directory fails.
-	roDir := filepath.Join(t.TempDir(), "ro")
-	if err := os.Mkdir(roDir, 0o500); err != nil {
-		t.Fatalf("mkdir ro: %v", err)
-	}
-	t.Cleanup(func() { _ = os.Chmod(roDir, 0o700) }) // let TempDir cleanup remove it
-	path := filepath.Join(roDir, tokenFileName)
-
-	store := newKeyringTokenStore(ring, path)
+	store := newKeyringTokenStore(ring, filepath.Join(t.TempDir(), tokenFileName))
+	store.write = func(string, []byte) error { return errors.New("simulated persist failure") }
 
 	// The token is still served from the in-memory cache for this session.
 	got, err := store.GetToken("https://legacy-a.example/mcp")
@@ -433,6 +503,19 @@ func TestEncryptedStore_MigrationKeepsLegacyOnPersistFailure(t *testing.T) {
 	// can retry the migration.
 	if _, err := ring.Get(legacyBundleKey); err != nil {
 		t.Errorf("legacy bundle must survive a failed persist so migration can retry, got: %v", err)
+	}
+}
+
+func TestEncryptedStore_StoreRefusesAfterUnreadableFile(t *testing.T) {
+	ring := keyring.NewArrayKeyring(nil)
+	blocker := filepath.Join(t.TempDir(), "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write blocker: %v", err)
+	}
+	store := newKeyringTokenStore(ring, filepath.Join(blocker, tokenFileName))
+
+	if err := store.StoreToken("https://a.example/mcp", &OAuthToken{AccessToken: "a"}); err == nil {
+		t.Fatal("StoreToken should refuse to overwrite after unreadable token file")
 	}
 }
 

--- a/pkg/tools/mcp/tokenstore_keyring_test.go
+++ b/pkg/tools/mcp/tokenstore_keyring_test.go
@@ -200,6 +200,33 @@ func TestEncryptedStore_ReadsTouchKeyringOnce(t *testing.T) {
 	}
 }
 
+// TestEncryptedStore_WritesTouchKeyringOnce verifies repeated writes within
+// a process reuse the cached encryption key rather than re-fetching it from
+// the keyring on every persist.
+func TestEncryptedStore_WritesTouchKeyringOnce(t *testing.T) {
+	ring := newCountingKeyring()
+	path := filepath.Join(t.TempDir(), tokenFileName)
+	store := newKeyringTokenStore(ring, path)
+
+	for i := range 5 {
+		url := fmt.Sprintf("https://server-%d.example/mcp", i)
+		if err := store.StoreToken(url, &OAuthToken{AccessToken: "at"}); err != nil {
+			t.Fatalf("StoreToken(%s): %v", url, err)
+		}
+	}
+	if err := store.RemoveToken("https://server-0.example/mcp"); err != nil {
+		t.Fatalf("RemoveToken: %v", err)
+	}
+
+	// The encryption key is fetched and created once on the first
+	// operation; every subsequent write must reuse the cached key and not
+	// touch the encryption-key item again. (The one-time Set is the key
+	// creation.)
+	if ring.sets != 1 {
+		t.Errorf("expected exactly 1 keyring Set (key creation) across many writes, got %d", ring.sets)
+	}
+}
+
 // TestEncryptedStore_KeyringHoldsOnlyTheKey verifies that no matter how
 // many resource URLs are stored, the keyring holds exactly one item: the
 // encryption key. The tokens themselves live in the file, so macOS only
@@ -360,6 +387,52 @@ func seedLegacyToken(t *testing.T, ring keyring.Keyring, url string, tok *OAuthT
 	}
 	if err := ring.Set(keyring.Item{Key: legacyTokenPrefix + url, Data: data}); err != nil {
 		t.Fatalf("seed legacy item: %v", err)
+	}
+}
+
+// TestEncryptedStore_MigrationKeepsLegacyOnPersistFailure is the regression
+// test for the data-loss window: if the encrypted file cannot be written,
+// migration must NOT delete the legacy keyring entries, so a later process
+// can retry instead of leaving the user with no tokens at all.
+func TestEncryptedStore_MigrationKeepsLegacyOnPersistFailure(t *testing.T) {
+	ring := keyring.NewArrayKeyring(nil)
+
+	bundle := map[string]*OAuthToken{
+		"https://legacy-a.example/mcp": {AccessToken: "legacy-a"},
+	}
+	data, err := json.Marshal(bundle)
+	if err != nil {
+		t.Fatalf("marshal legacy bundle: %v", err)
+	}
+	if err := ring.Set(keyring.Item{Key: legacyBundleKey, Data: data}); err != nil {
+		t.Fatalf("seed legacy bundle: %v", err)
+	}
+
+	// Point the store at a file inside a read-only directory: reading the
+	// (absent) file still reports os.ErrNotExist so migration runs, but the
+	// atomic write into the read-only directory fails.
+	roDir := filepath.Join(t.TempDir(), "ro")
+	if err := os.Mkdir(roDir, 0o500); err != nil {
+		t.Fatalf("mkdir ro: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(roDir, 0o700) }) // let TempDir cleanup remove it
+	path := filepath.Join(roDir, tokenFileName)
+
+	store := newKeyringTokenStore(ring, path)
+
+	// The token is still served from the in-memory cache for this session.
+	got, err := store.GetToken("https://legacy-a.example/mcp")
+	if err != nil {
+		t.Fatalf("GetToken after failed-persist migration: %v", err)
+	}
+	if got.AccessToken != "legacy-a" {
+		t.Errorf("AccessToken = %q, want %q", got.AccessToken, "legacy-a")
+	}
+
+	// The legacy bundle must still be in the keyring so the next process
+	// can retry the migration.
+	if _, err := ring.Get(legacyBundleKey); err != nil {
+		t.Errorf("legacy bundle must survive a failed persist so migration can retry, got: %v", err)
 	}
 }
 

--- a/pkg/tools/mcp/tokenstore_keyring_test.go
+++ b/pkg/tools/mcp/tokenstore_keyring_test.go
@@ -1,15 +1,27 @@
 package mcp
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/99designs/keyring"
 )
+
+// newTestStore returns a KeyringTokenStore backed by an in-memory array
+// keyring and a token file inside a fresh temp dir.
+func newTestStore(t *testing.T) (*KeyringTokenStore, keyring.Keyring) {
+	t.Helper()
+	ring := keyring.NewArrayKeyring(nil)
+	path := filepath.Join(t.TempDir(), tokenFileName)
+	return newKeyringTokenStore(ring, path), ring
+}
 
 func TestKeyringTokenStore_RoundTrip(t *testing.T) {
 	// Use in-memory store to avoid triggering macOS keychain permission dialogs
@@ -89,9 +101,41 @@ func TestKeyringTokenStore_RemoveNonExistent(t *testing.T) {
 	}
 }
 
+// TestEncryptedStore_PersistsAcrossReload verifies tokens written by one
+// store instance are readable by a fresh instance pointed at the same
+// keyring + file — i.e. they survive a process restart.
+func TestEncryptedStore_PersistsAcrossReload(t *testing.T) {
+	store, ring := newTestStore(t)
+
+	urls := []string{
+		"https://server-a.example/mcp",
+		"https://server-b.example/mcp",
+		"https://server-c.example/mcp",
+	}
+	for i, url := range urls {
+		if err := store.StoreToken(url, &OAuthToken{AccessToken: "at-" + string(rune('A'+i))}); err != nil {
+			t.Fatalf("StoreToken(%s): %v", url, err)
+		}
+	}
+
+	// A fresh store over the same ring + file (like a new process) must
+	// decrypt and surface every token.
+	fresh := newKeyringTokenStore(ring, store.filePath)
+	for i, url := range urls {
+		got, err := fresh.GetToken(url)
+		if err != nil {
+			t.Fatalf("GetToken(%s): %v", url, err)
+		}
+		if want := "at-" + string(rune('A'+i)); got.AccessToken != want {
+			t.Errorf("AccessToken for %s = %q, want %q", url, got.AccessToken, want)
+		}
+	}
+}
+
 // countingKeyring tracks how many times Get and Set are invoked on the
-// underlying ring. Used to assert that the bundled layout collapses N
-// tokens into a single keyring read.
+// underlying ring. Used to assert that the store touches the keyring at
+// most once per process regardless of how many tokens are looked up — the
+// property that avoids the "many keychain prompts on macOS" problem.
 type countingKeyring struct {
 	keyring.Keyring
 
@@ -112,11 +156,12 @@ func (k *countingKeyring) Set(item keyring.Item) error {
 	return k.Keyring.Set(item)
 }
 
-// TestBundledKeyringStore_ReadsCollapsedToOneGet verifies the central
-// claim of the bundled layout: regardless of how many resource URLs are
-// looked up, the underlying keyring sees only a single Get for the bundle
-// key. This is what avoids the "many keychain prompts on macOS" problem.
-func TestBundledKeyringStore_ReadsCollapsedToOneGet(t *testing.T) {
+// TestEncryptedStore_ReadsTouchKeyringOnce verifies that, regardless of how
+// many resource URLs are looked up, a process touches the keyring exactly
+// once (to fetch the encryption key). Everything else is served from the
+// in-memory cache or the encrypted file. This is what avoids repeated
+// keychain prompts on macOS.
+func TestEncryptedStore_ReadsTouchKeyringOnce(t *testing.T) {
 	urls := []string{
 		"https://server-a.example/mcp",
 		"https://server-b.example/mcp",
@@ -124,20 +169,21 @@ func TestBundledKeyringStore_ReadsCollapsedToOneGet(t *testing.T) {
 	}
 
 	ring := newCountingKeyring()
-	store := newKeyringTokenStore(ring)
+	path := filepath.Join(t.TempDir(), tokenFileName)
+	store := newKeyringTokenStore(ring, path)
 	for i, url := range urls {
 		if err := store.StoreToken(url, &OAuthToken{AccessToken: "at-" + string(rune('A'+i))}); err != nil {
 			t.Fatalf("StoreToken(%s): %v", url, err)
 		}
 	}
 
-	// Drop the cache by wrapping the same ring with a fresh store, so we
-	// exercise a real load() like a new process would.
+	// Drop the cache by wrapping the same ring + file with a fresh store,
+	// so we exercise a real load() like a new process would.
 	ring.gets, ring.sets = 0, 0
-	fresh := newKeyringTokenStore(ring)
+	fresh := newKeyringTokenStore(ring, path)
 
 	// Read each token several times; only the first read should hit the
-	// keyring.
+	// keyring (for the encryption key).
 	for range 5 {
 		for _, url := range urls {
 			if _, err := fresh.GetToken(url); err != nil {
@@ -147,19 +193,19 @@ func TestBundledKeyringStore_ReadsCollapsedToOneGet(t *testing.T) {
 	}
 
 	if ring.gets != 1 {
-		t.Errorf("expected exactly 1 underlying keyring Get, got %d", ring.gets)
+		t.Errorf("expected exactly 1 underlying keyring Get (encryption key), got %d", ring.gets)
 	}
 	if ring.sets != 0 {
-		t.Errorf("read-only path must not write, got %d Set calls", ring.sets)
+		t.Errorf("read-only path must not write to the keyring, got %d Set calls", ring.sets)
 	}
 }
 
-// TestBundledKeyringStore_StoreReusesSameItem verifies that storing
-// tokens for many different resource URLs all go to the same keyring item
-// — so macOS only ever asks for permission on a single ACL.
-func TestBundledKeyringStore_StoreReusesSameItem(t *testing.T) {
-	ring := keyring.NewArrayKeyring(nil)
-	store := newKeyringTokenStore(ring)
+// TestEncryptedStore_KeyringHoldsOnlyTheKey verifies that no matter how
+// many resource URLs are stored, the keyring holds exactly one item: the
+// encryption key. The tokens themselves live in the file, so macOS only
+// ever asks for permission on a single ACL.
+func TestEncryptedStore_KeyringHoldsOnlyTheKey(t *testing.T) {
+	store, ring := newTestStore(t)
 
 	for _, url := range []string{
 		"https://server-a.example/mcp",
@@ -175,16 +221,100 @@ func TestBundledKeyringStore_StoreReusesSameItem(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Keys: %v", err)
 	}
-	if len(keys) != 1 || keys[0] != bundleKey {
-		t.Fatalf("expected single bundle item %q, got %v", bundleKey, keys)
+	if len(keys) != 1 || keys[0] != encryptionKeyItem {
+		t.Fatalf("expected single keyring item %q, got %v", encryptionKeyItem, keys)
 	}
 }
 
-// TestBundledKeyringStore_LegacyMigration confirms tokens previously
-// stored with the per-resource layout are folded into the bundle on first
-// load and the legacy entries are cleaned up.
-func TestBundledKeyringStore_LegacyMigration(t *testing.T) {
+// TestEncryptedStore_FileIsNotPlaintext guards against accidentally writing
+// tokens in the clear: the access token must not be findable in the file.
+func TestEncryptedStore_FileIsNotPlaintext(t *testing.T) {
+	store, _ := newTestStore(t)
+
+	const secret = "super-secret-access-token-value"
+	if err := store.StoreToken("https://a.example/mcp", &OAuthToken{AccessToken: secret}); err != nil {
+		t.Fatalf("StoreToken: %v", err)
+	}
+
+	data, err := os.ReadFile(store.filePath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("token file is empty")
+	}
+	if bytes.Contains(data, []byte(secret)) {
+		t.Fatal("access token found in plaintext in the token file")
+	}
+}
+
+// TestEncryptedStore_FilePermissions checks the token file is created with
+// owner-only permissions.
+func TestEncryptedStore_FilePermissions(t *testing.T) {
+	store, _ := newTestStore(t)
+	if err := store.StoreToken("https://a.example/mcp", &OAuthToken{AccessToken: "x"}); err != nil {
+		t.Fatalf("StoreToken: %v", err)
+	}
+	info, err := os.Stat(store.filePath)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("token file permissions = %o, want 0600", perm)
+	}
+}
+
+// TestEncryptedStore_LegacyBundleMigration confirms tokens previously
+// stored in the single keyring bundle are folded into the encrypted file
+// on first load and the legacy keyring entry is cleaned up.
+func TestEncryptedStore_LegacyBundleMigration(t *testing.T) {
 	ring := keyring.NewArrayKeyring(nil)
+	path := filepath.Join(t.TempDir(), tokenFileName)
+
+	bundle := map[string]*OAuthToken{
+		"https://legacy-a.example/mcp": {AccessToken: "legacy-a"},
+		"https://legacy-b.example/mcp": {AccessToken: "legacy-b"},
+	}
+	data, err := json.Marshal(bundle)
+	if err != nil {
+		t.Fatalf("marshal legacy bundle: %v", err)
+	}
+	if err := ring.Set(keyring.Item{Key: legacyBundleKey, Data: data}); err != nil {
+		t.Fatalf("seed legacy bundle: %v", err)
+	}
+
+	store := newKeyringTokenStore(ring, path)
+	for url, want := range bundle {
+		got, err := store.GetToken(url)
+		if err != nil {
+			t.Fatalf("GetToken(%s): %v", url, err)
+		}
+		if got.AccessToken != want.AccessToken {
+			t.Errorf("AccessToken for %s = %q, want %q", url, got.AccessToken, want.AccessToken)
+		}
+	}
+
+	// The legacy bundle key must be gone; only the encryption key remains.
+	keys, err := ring.Keys()
+	if err != nil {
+		t.Fatalf("Keys: %v", err)
+	}
+	if len(keys) != 1 || keys[0] != encryptionKeyItem {
+		t.Errorf("expected only encryption key after migration, got %v", keys)
+	}
+
+	// Tokens must now survive a reload purely from the file.
+	fresh := newKeyringTokenStore(ring, path)
+	if _, err := fresh.GetToken("https://legacy-a.example/mcp"); err != nil {
+		t.Errorf("migrated token not readable after reload: %v", err)
+	}
+}
+
+// TestEncryptedStore_LegacyPerTokenMigration confirms the oldest layout —
+// one keyring item per resource URL — is migrated and cleaned up.
+func TestEncryptedStore_LegacyPerTokenMigration(t *testing.T) {
+	ring := keyring.NewArrayKeyring(nil)
+	path := filepath.Join(t.TempDir(), tokenFileName)
 
 	urls := []string{
 		"https://legacy-a.example/mcp",
@@ -193,8 +323,8 @@ func TestBundledKeyringStore_LegacyMigration(t *testing.T) {
 	for _, url := range urls {
 		seedLegacyToken(t, ring, url, &OAuthToken{AccessToken: "legacy-" + url})
 	}
-	// Also seed the legacy index, which should be removed without
-	// becoming a token entry.
+	// Also seed the legacy index, which should be removed without becoming
+	// a token entry.
 	if err := ring.Set(keyring.Item{
 		Key:  legacyIndexKey,
 		Data: []byte(`["https://legacy-a.example/mcp"]`),
@@ -202,10 +332,7 @@ func TestBundledKeyringStore_LegacyMigration(t *testing.T) {
 		t.Fatalf("seed legacy index: %v", err)
 	}
 
-	store := newKeyringTokenStore(ring)
-
-	// Reading any token triggers migration; both legacy tokens should be
-	// reachable afterwards.
+	store := newKeyringTokenStore(ring, path)
 	for _, url := range urls {
 		got, err := store.GetToken(url)
 		if err != nil {
@@ -216,13 +343,12 @@ func TestBundledKeyringStore_LegacyMigration(t *testing.T) {
 		}
 	}
 
-	// The keyring should now contain only the bundle key.
 	keys, err := ring.Keys()
 	if err != nil {
 		t.Fatalf("Keys: %v", err)
 	}
-	if len(keys) != 1 || keys[0] != bundleKey {
-		t.Errorf("expected only bundle key after migration, got %v", keys)
+	if len(keys) != 1 || keys[0] != encryptionKeyItem {
+		t.Errorf("expected only encryption key after migration, got %v", keys)
 	}
 }
 
@@ -237,12 +363,11 @@ func seedLegacyToken(t *testing.T, ring keyring.Keyring, url string, tok *OAuthT
 	}
 }
 
-// TestBundledKeyringStore_RemoveCleansBundle verifies that deleting a
-// token rewrites the bundle without it, so subsequent reads no longer see
-// it even after the in-memory cache is dropped.
-func TestBundledKeyringStore_RemoveCleansBundle(t *testing.T) {
-	ring := keyring.NewArrayKeyring(nil)
-	store := newKeyringTokenStore(ring)
+// TestEncryptedStore_RemovePersists verifies that deleting a token rewrites
+// the file without it, so subsequent reads no longer see it even after the
+// in-memory cache is dropped.
+func TestEncryptedStore_RemovePersists(t *testing.T) {
+	store, ring := newTestStore(t)
 
 	url := "https://to-remove.example/mcp"
 	if err := store.StoreToken(url, &OAuthToken{AccessToken: "x"}); err != nil {
@@ -252,40 +377,44 @@ func TestBundledKeyringStore_RemoveCleansBundle(t *testing.T) {
 		t.Fatalf("RemoveToken: %v", err)
 	}
 
-	if _, err := newKeyringTokenStore(ring).GetToken(url); err == nil {
+	if _, err := newKeyringTokenStore(ring, store.filePath).GetToken(url); err == nil {
 		t.Fatal("expected GetToken to fail after RemoveToken")
 	}
 }
 
-// TestBundledKeyringStore_CorruptBundle ensures a corrupt bundle doesn't
-// crash callers — we treat it as empty and let the OAuth flow re-populate.
-func TestBundledKeyringStore_CorruptBundle(t *testing.T) {
-	ring := keyring.NewArrayKeyring(nil)
-	if err := ring.Set(keyring.Item{Key: bundleKey, Data: []byte("not json")}); err != nil {
-		t.Fatalf("seed corrupt bundle: %v", err)
+// TestEncryptedStore_CorruptFile ensures a corrupt token file doesn't crash
+// callers — we treat it as empty and let the OAuth flow re-populate.
+func TestEncryptedStore_CorruptFile(t *testing.T) {
+	store, ring := newTestStore(t)
+
+	// Seed the encryption key by writing a real token first, then clobber
+	// the file with garbage that won't decrypt.
+	if err := store.StoreToken("https://seed.example/mcp", &OAuthToken{AccessToken: "seed"}); err != nil {
+		t.Fatalf("seed StoreToken: %v", err)
+	}
+	if err := os.WriteFile(store.filePath, []byte("not-encrypted-garbage"), 0o600); err != nil {
+		t.Fatalf("clobber file: %v", err)
 	}
 
-	store := newKeyringTokenStore(ring)
-
-	if _, err := store.GetToken("https://anything.example/mcp"); err == nil {
+	fresh := newKeyringTokenStore(ring, store.filePath)
+	if _, err := fresh.GetToken("https://anything.example/mcp"); err == nil {
 		t.Fatal("expected GetToken to report missing token, got nil")
 	}
 
-	// StoreToken on top of a corrupt bundle should overwrite it.
-	if err := store.StoreToken("https://anything.example/mcp", &OAuthToken{AccessToken: "fresh"}); err != nil {
-		t.Fatalf("StoreToken after corrupt bundle: %v", err)
+	// StoreToken on top of a corrupt file should overwrite it.
+	if err := fresh.StoreToken("https://anything.example/mcp", &OAuthToken{AccessToken: "fresh"}); err != nil {
+		t.Fatalf("StoreToken after corrupt file: %v", err)
 	}
-	got, err := store.GetToken("https://anything.example/mcp")
+	got, err := fresh.GetToken("https://anything.example/mcp")
 	if err != nil || got.AccessToken != "fresh" {
 		t.Fatalf("expected fresh token after recovery, got token=%v err=%v", got, err)
 	}
 }
 
-// TestKeyringTokenStore_ListReturnsAllEntries exercises the list helper
-// used by `agent debug oauth list`.
-func TestKeyringTokenStore_ListReturnsAllEntries(t *testing.T) {
-	ring := keyring.NewArrayKeyring(nil)
-	store := newKeyringTokenStore(ring)
+// TestEncryptedStore_ListReturnsAllEntries exercises the list helper used by
+// `agent debug oauth list`.
+func TestEncryptedStore_ListReturnsAllEntries(t *testing.T) {
+	store, ring := newTestStore(t)
 
 	if err := store.StoreToken("https://a.example/mcp", &OAuthToken{AccessToken: "a"}); err != nil {
 		t.Fatalf("StoreToken: %v", err)
@@ -294,8 +423,8 @@ func TestKeyringTokenStore_ListReturnsAllEntries(t *testing.T) {
 		t.Fatalf("StoreToken: %v", err)
 	}
 
-	// Reload from the ring (mirroring what a fresh process would do).
-	entries := newKeyringTokenStore(ring).list()
+	// Reload from the ring + file (mirroring what a fresh process would do).
+	entries := newKeyringTokenStore(ring, store.filePath).list()
 	if len(entries) != 2 {
 		t.Fatalf("expected 2 entries, got %d: %+v", len(entries), entries)
 	}
@@ -308,8 +437,8 @@ func TestKeyringTokenStore_ListReturnsAllEntries(t *testing.T) {
 	}
 }
 
-// failingKeyring returns a fixed error from Get; used to make sure the
-// store doesn't permanently re-prompt when keychain access is denied.
+// failingKeyring returns a fixed error from Get; used to make sure the store
+// doesn't permanently re-prompt when keychain access is denied.
 type failingKeyring struct {
 	keyring.Keyring
 
@@ -328,13 +457,13 @@ func (*failingKeyring) Remove(string) error                          { return ni
 func (*failingKeyring) Keys() ([]string, error)                      { return nil, nil }
 func (*failingKeyring) GetMetadata(string) (keyring.Metadata, error) { return keyring.Metadata{}, nil }
 
-// TestBundledKeyringStore_LoadFailureIsCachedOnce checks that a single
-// keyring failure does not turn into an avalanche of repeated prompts:
-// load() marks the cache as loaded eagerly so a denied access surfaces
-// once per process, not once per token operation.
-func TestBundledKeyringStore_LoadFailureIsCachedOnce(t *testing.T) {
+// TestEncryptedStore_KeyringFailureIsCachedOnce checks that a keyring
+// failure does not turn into an avalanche of repeated prompts: load() marks
+// the cache as loaded eagerly so a denied access surfaces once per process,
+// not once per token operation.
+func TestEncryptedStore_KeyringFailureIsCachedOnce(t *testing.T) {
 	ring := &failingKeyring{getErr: errors.New("simulated denied access")}
-	store := newKeyringTokenStore(ring)
+	store := newKeyringTokenStore(ring, filepath.Join(t.TempDir(), tokenFileName))
 
 	if _, err := store.GetToken("https://a.example/mcp"); err == nil {
 		t.Fatal("expected GetToken to report missing token after denied keyring access")
@@ -344,11 +473,10 @@ func TestBundledKeyringStore_LoadFailureIsCachedOnce(t *testing.T) {
 	}
 }
 
-// TestKeyringTokenStore_ConcurrentAccess verifies that concurrent reads
-// and writes to the token store are safe and don't cause data races.
+// TestKeyringTokenStore_ConcurrentAccess verifies that concurrent reads and
+// writes to the token store are safe and don't cause data races.
 func TestKeyringTokenStore_ConcurrentAccess(t *testing.T) {
-	ring := keyring.NewArrayKeyring(nil)
-	store := newKeyringTokenStore(ring)
+	store, _ := newTestStore(t)
 
 	const numGoroutines = 10
 	const numOperations = 100

--- a/pkg/tools/mcp/tokenstore_lock.go
+++ b/pkg/tools/mcp/tokenstore_lock.go
@@ -1,0 +1,32 @@
+package mcp
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// lockTokenFile takes an exclusive advisory lock on "<path>.lock",
+// creating the lock file and parent directory if needed. The lock file is
+// intentionally long-lived: deleting it would allow different processes to
+// lock different inodes for the same logical token bundle.
+func lockTokenFile(path string) (func(), error) {
+	lockPath := path + ".lock"
+	if dir := filepath.Dir(lockPath); dir != "" {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return nil, fmt.Errorf("creating OAuth token lock directory %q: %w", dir, err)
+		}
+	}
+	f, err := os.OpenFile(lockPath, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("opening OAuth token lock file %q: %w", lockPath, err)
+	}
+	if err := lockExclusive(f); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("locking OAuth token file %q: %w", lockPath, err)
+	}
+	return func() {
+		_ = unlockFile(f)
+		_ = f.Close()
+	}, nil
+}

--- a/pkg/tools/mcp/tokenstore_lock_js.go
+++ b/pkg/tools/mcp/tokenstore_lock_js.go
@@ -1,0 +1,9 @@
+//go:build js && wasm
+
+package mcp
+
+import "os"
+
+func lockExclusive(_ *os.File) error { return nil }
+
+func unlockFile(_ *os.File) error { return nil }

--- a/pkg/tools/mcp/tokenstore_lock_unix.go
+++ b/pkg/tools/mcp/tokenstore_lock_unix.go
@@ -1,0 +1,17 @@
+//go:build unix
+
+package mcp
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func lockExclusive(f *os.File) error {
+	return unix.Flock(int(f.Fd()), unix.LOCK_EX)
+}
+
+func unlockFile(f *os.File) error {
+	return unix.Flock(int(f.Fd()), unix.LOCK_UN)
+}

--- a/pkg/tools/mcp/tokenstore_lock_windows.go
+++ b/pkg/tools/mcp/tokenstore_lock_windows.go
@@ -1,0 +1,34 @@
+//go:build windows
+
+package mcp
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+const maxLockRange = ^uint32(0)
+
+func lockExclusive(f *os.File) error {
+	var ol windows.Overlapped
+	return windows.LockFileEx(
+		windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK,
+		0,
+		maxLockRange,
+		maxLockRange,
+		&ol,
+	)
+}
+
+func unlockFile(f *os.File) error {
+	var ol windows.Overlapped
+	return windows.UnlockFileEx(
+		windows.Handle(f.Fd()),
+		0,
+		maxLockRange,
+		maxLockRange,
+		&ol,
+	)
+}


### PR DESCRIPTION
## Summary

- Replace the single keyring OAuth token bundle with a keyring-sealed encrypted file.
- Store only a fixed-size AES-256 key in the OS keyring; store the OAuth token bundle in an AES-GCM encrypted file under the config dir.
- Migrate existing legacy keyring entries safely, preserving both the previous bundled layout and the older per-resource layout.
- Harden persistence with cross-process locking, reload-before-write merge semantics, Windows-safe atomic file replacement, and unreadable-file safeguards.
