### PR TITLE
fix: thread provider registry into RAG, eval, wasm and a2a/mcp/chat runtimes

### DIFF
--- a/pkg/a2a/adapter.go
+++ b/pkg/a2a/adapter.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/genai"
 
 	dagent "github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/model/provider"
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/team"
@@ -23,7 +24,7 @@ import (
 // newDockerAgentAdapter creates a new ADK agent adapter from a docker agent team and agent name.
 // When agentName is empty, the team's default agent (one explicitly named "root" if it
 // exists, otherwise the first agent declared) is used.
-func newDockerAgentAdapter(t *team.Team, agentName string, sessStore session.Store) (agent.Agent, error) {
+func newDockerAgentAdapter(t *team.Team, agentName string, sessStore session.Store, providerRegistry *provider.Registry) (agent.Agent, error) {
 	a, err := t.AgentOrDefault(agentName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get agent %s: %w", agentName, err)
@@ -36,13 +37,13 @@ func newDockerAgentAdapter(t *team.Team, agentName string, sessStore session.Sto
 		Name:        agentName,
 		Description: desc,
 		Run: func(ctx agent.InvocationContext) iter.Seq2[*adksession.Event, error] {
-			return runDockerAgent(ctx, t, agentName, a, sessStore)
+			return runDockerAgent(ctx, t, agentName, a, sessStore, providerRegistry)
 		},
 	})
 }
 
 // runDockerAgent executes a docker agent and returns ADK session events
-func runDockerAgent(ctx agent.InvocationContext, t *team.Team, agentName string, a *dagent.Agent, sessStore session.Store) iter.Seq2[*adksession.Event, error] {
+func runDockerAgent(ctx agent.InvocationContext, t *team.Team, agentName string, a *dagent.Agent, sessStore session.Store, providerRegistry *provider.Registry) iter.Seq2[*adksession.Event, error] {
 	return func(yield func(*adksession.Event, error) bool) {
 		// Extract user message from the ADK context
 		userContent := ctx.UserContent()
@@ -79,6 +80,7 @@ func runDockerAgent(ctx agent.InvocationContext, t *team.Team, agentName string,
 			runtime.WithCurrentAgent(agentName),
 			runtime.WithSessionStore(sessStore),
 			runtime.WithTracer(otel.Tracer("cagent")),
+			runtime.WithProviderRegistry(providerRegistry),
 		)
 		if err != nil {
 			yield(nil, fmt.Errorf("failed to create runtime: %w", err))

--- a/pkg/a2a/adapter_test.go
+++ b/pkg/a2a/adapter_test.go
@@ -24,7 +24,7 @@ func TestNewDockerAgentAdapter(t *testing.T) {
 		require.NoError(t, team.StopToolSets(t.Context()))
 	}()
 
-	adapter, err := newDockerAgentAdapter(team, "root", nil)
+	adapter, err := newDockerAgentAdapter(team, "root", nil, nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, "root", adapter.Name())
@@ -43,7 +43,7 @@ func TestNewCAgentAdapter_NonExistent(t *testing.T) {
 		require.NoError(t, team.StopToolSets(t.Context()))
 	}()
 
-	_, err = newDockerAgentAdapter(team, "nonexistent", nil)
+	_, err = newDockerAgentAdapter(team, "nonexistent", nil, nil)
 
 	assert.Contains(t, err.Error(), "failed to get agent")
 }

--- a/pkg/a2a/server.go
+++ b/pkg/a2a/server.go
@@ -47,10 +47,11 @@ func Run(ctx context.Context, agentFilename, agentName, sessionDB string, runCon
 		return err
 	}
 
-	t, err := teamloader.Load(ctx, agentSource, runConfig, loaderdefaults.Opts()...)
+	loadResult, err := teamloader.LoadWithConfig(ctx, agentSource, runConfig, loaderdefaults.Opts()...)
 	if err != nil {
 		return fmt.Errorf("failed to load agents: %w", err)
 	}
+	t := loadResult.Team
 	defer func() {
 		if err := t.StopToolSets(ctx); err != nil {
 			slog.ErrorContext(ctx, "Failed to stop tool sets", "error", err)
@@ -66,7 +67,7 @@ func Run(ctx context.Context, agentFilename, agentName, sessionDB string, runCon
 		return fmt.Errorf("failed to open session store: %w", err)
 	}
 
-	adkAgent, err := newDockerAgentAdapter(t, agentName, sessStore)
+	adkAgent, err := newDockerAgentAdapter(t, agentName, sessStore, loadResult.ProviderRegistry)
 	if err != nil {
 		return fmt.Errorf("failed to create ADK agent adapter: %w", err)
 	}

--- a/pkg/chatserver/runtime_pool.go
+++ b/pkg/chatserver/runtime_pool.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"sync"
 
+	"github.com/docker/docker-agent/pkg/model/provider"
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/team"
 )
@@ -23,8 +24,9 @@ import (
 // `maxIdle` bounds the number of idle runtimes per agent. Returning a
 // runtime to a full pool is a no-op; it simply gets garbage collected.
 type runtimePool struct {
-	team    *team.Team
-	maxIdle int
+	team             *team.Team
+	maxIdle          int
+	providerRegistry *provider.Registry
 
 	mu   sync.Mutex
 	idle map[string]chan runtime.Runtime
@@ -36,14 +38,15 @@ type runtimePool struct {
 // cancellation in a future async path).
 var errInvalidRuntime = errors.New("failed to acquire runtime")
 
-func newRuntimePool(t *team.Team, maxIdle int) *runtimePool {
+func newRuntimePool(t *team.Team, maxIdle int, providerRegistry *provider.Registry) *runtimePool {
 	if maxIdle < 0 {
 		maxIdle = 0
 	}
 	return &runtimePool{
-		team:    t,
-		maxIdle: maxIdle,
-		idle:    make(map[string]chan runtime.Runtime),
+		team:             t,
+		maxIdle:          maxIdle,
+		providerRegistry: providerRegistry,
+		idle:             make(map[string]chan runtime.Runtime),
 	}
 }
 
@@ -56,7 +59,7 @@ func (p *runtimePool) Get(agent string) (runtime.Runtime, error) {
 	if rt := p.takeIdle(agent); rt != nil {
 		return rt, nil
 	}
-	rt, err := runtime.New(p.team, runtime.WithCurrentAgent(agent))
+	rt, err := runtime.New(p.team, runtime.WithCurrentAgent(agent), runtime.WithProviderRegistry(p.providerRegistry))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/chatserver/runtime_pool_test.go
+++ b/pkg/chatserver/runtime_pool_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestRuntimePool_DisabledIsNotCached(t *testing.T) {
-	p := newRuntimePool(nil, 0)
+	p := newRuntimePool(nil, 0, nil)
 
 	// Put with maxIdle=0 must be a no-op (we don't have a runtime to put,
 	// but the channel-for behaviour itself shouldn't allocate).
@@ -16,11 +16,11 @@ func TestRuntimePool_DisabledIsNotCached(t *testing.T) {
 }
 
 func TestRuntimePool_NegativeCapTreatedAsZero(t *testing.T) {
-	p := newRuntimePool(nil, -1)
+	p := newRuntimePool(nil, -1, nil)
 	assert.Equal(t, 0, p.maxIdle)
 }
 
 func TestRuntimePool_takeIdleNoChannel(t *testing.T) {
-	p := newRuntimePool(nil, 4)
+	p := newRuntimePool(nil, 4, nil)
 	assert.Nil(t, p.takeIdle("anything"))
 }

--- a/pkg/chatserver/server.go
+++ b/pkg/chatserver/server.go
@@ -112,10 +112,11 @@ const (
 func Run(ctx context.Context, agentFilename string, opts Options, ln net.Listener) error {
 	slog.DebugContext(ctx, "Starting chat completions server", "agent", agentFilename, "addr", ln.Addr())
 
-	t, err := loadTeam(ctx, agentFilename, opts.RunConfig)
+	loadResult, err := loadTeam(ctx, agentFilename, opts.RunConfig)
 	if err != nil {
 		return err
 	}
+	t := loadResult.Team
 	defer func() {
 		if err := t.StopToolSets(ctx); err != nil {
 			slog.ErrorContext(ctx, "Failed to stop tool sets", "error", err)
@@ -133,7 +134,7 @@ func Run(ctx context.Context, agentFilename string, opts Options, ln net.Listene
 			policy:            policy,
 			conversations:     newConversationStore(opts.ConversationsMaxSessions, conversationTTL(opts)),
 			conversationLocks: newConversationLockSet(),
-			runtimes:          newRuntimePool(t, opts.MaxIdleRuntimes),
+			runtimes:          newRuntimePool(t, opts.MaxIdleRuntimes, loadResult.ProviderRegistry),
 		}, opts),
 		ReadHeaderTimeout: 30 * time.Second,
 	}
@@ -147,17 +148,19 @@ func conversationTTL(opts Options) time.Duration {
 	return defaultConversationTTL
 }
 
-// loadTeam resolves and loads the team referenced by agentFilename.
-func loadTeam(ctx context.Context, agentFilename string, runConfig *config.RuntimeConfig) (*team.Team, error) {
+// loadTeam resolves and loads the team referenced by agentFilename. It returns
+// the full LoadResult so callers can thread the provider registry into the
+// runtimes they build (needed by `type: model` hooks for non-dmr models).
+func loadTeam(ctx context.Context, agentFilename string, runConfig *config.RuntimeConfig) (*teamloader.LoadResult, error) {
 	src, err := config.Resolve(agentFilename, nil)
 	if err != nil {
 		return nil, err
 	}
-	t, err := teamloader.Load(ctx, src, runConfig, loaderdefaults.Opts()...)
+	loadResult, err := teamloader.LoadWithConfig(ctx, src, runConfig, loaderdefaults.Opts()...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load agents: %w", err)
 	}
-	return t, nil
+	return loadResult, nil
 }
 
 // serve runs httpServer on ln until ctx is cancelled, then triggers a

--- a/pkg/evaluation/eval.go
+++ b/pkg/evaluation/eval.go
@@ -26,6 +26,7 @@ import (
 	"github.com/docker/docker-agent/pkg/environment"
 	"github.com/docker/docker-agent/pkg/model/provider"
 	"github.com/docker/docker-agent/pkg/model/provider/options"
+	"github.com/docker/docker-agent/pkg/model/provider/providers"
 	"github.com/docker/docker-agent/pkg/session"
 )
 
@@ -667,7 +668,10 @@ func createJudgeModel(ctx context.Context, judgeModel string, runConfig *config.
 		opts = append(opts, options.WithGateway(runConfig.ModelsGateway))
 	}
 
-	judge, err := provider.New(ctx, &cfg, runConfig.EnvProvider(), opts...)
+	// Use the full provider registry: the judge is typically an openai/anthropic
+	// model, and the package-level provider.New only knows the slim default
+	// registry (dmr), which would fail with "unknown provider type".
+	judge, err := providers.NewDefaultRegistry().New(ctx, &cfg, runConfig.EnvProvider(), opts...)
 	if err != nil {
 		return nil, fmt.Errorf("creating judge model: %w", err)
 	}

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/docker/docker-agent/pkg/agent"
 	"github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/model/provider"
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/team"
@@ -92,10 +93,11 @@ func createMCPServer(ctx context.Context, agentFilename, agentName string, runCo
 		return nil, nil, err
 	}
 
-	t, err := teamloader.Load(ctx, agentSource, runConfig, loaderdefaults.Opts()...)
+	loadResult, err := teamloader.LoadWithConfig(ctx, agentSource, runConfig, loaderdefaults.Opts()...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to load agents: %w", err)
 	}
+	t := loadResult.Team
 
 	cleanup := func() {
 		if err := t.StopToolSets(ctx); err != nil {
@@ -154,13 +156,13 @@ func createMCPServer(ctx context.Context, agentFilename, agentName string, runCo
 			OutputSchema: tools.MustSchemaFor[ToolOutput](),
 		}
 
-		mcp.AddTool(server, toolDef, CreateToolHandler(t, agentName))
+		mcp.AddTool(server, toolDef, CreateToolHandler(t, agentName, loadResult.ProviderRegistry))
 	}
 
 	return server, cleanup, nil
 }
 
-func CreateToolHandler(t *team.Team, agentName string) func(context.Context, *mcp.CallToolRequest, ToolInput) (*mcp.CallToolResult, ToolOutput, error) {
+func CreateToolHandler(t *team.Team, agentName string, providerRegistry *provider.Registry) func(context.Context, *mcp.CallToolRequest, ToolInput) (*mcp.CallToolResult, ToolOutput, error) {
 	return func(ctx context.Context, req *mcp.CallToolRequest, input ToolInput) (*mcp.CallToolResult, ToolOutput, error) {
 		slog.DebugContext(ctx, "MCP tool called", "agent", agentName, "message", input.Message)
 
@@ -183,6 +185,7 @@ func CreateToolHandler(t *team.Team, agentName string) func(context.Context, *mc
 			runtime.WithCurrentAgent(agentName),
 			runtime.WithNonInteractive(true),
 			runtime.WithTracer(otel.Tracer("cagent")),
+			runtime.WithProviderRegistry(providerRegistry),
 		)
 		if err != nil {
 			return nil, ToolOutput{}, fmt.Errorf("failed to create runtime: %w", err)

--- a/pkg/model/provider/factory_js.go
+++ b/pkg/model/provider/factory_js.go
@@ -10,6 +10,9 @@ import (
 
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/environment"
+	"github.com/docker/docker-agent/pkg/model/provider/anthropic"
+	"github.com/docker/docker-agent/pkg/model/provider/gemini"
+	"github.com/docker/docker-agent/pkg/model/provider/openai"
 	"github.com/docker/docker-agent/pkg/model/provider/options"
 	"github.com/docker/docker-agent/pkg/model/provider/rulebased"
 )
@@ -26,9 +29,32 @@ func NewRegistry(factories map[string]Factory) *Registry {
 	return &Registry{factories: copied}
 }
 
-var defaultFactories map[string]Factory
+// defaultFactories is the slim js/wasm provider set. Only providers reachable
+// from a browser over plain net/http (mapped to fetch by the Go runtime) are
+// included: openai (+ its chat-completions / responses aliases), anthropic and
+// gemini. dmr (os/exec) and the cloud SDKs (bedrock, vertex) don't cross-compile
+// to wasm and are intentionally absent.
+var defaultFactories = map[string]Factory{
+	"openai":                 openaiFactory,
+	"openai_chatcompletions": openaiFactory,
+	"openai_responses":       openaiFactory,
+	"anthropic":              anthropicFactory,
+	"google":                 googleFactory,
+}
 
 func DefaultRegistry() *Registry { return NewRegistry(defaultFactories) }
+
+func openaiFactory(ctx context.Context, cfg *latest.ModelConfig, env environment.Provider, opts ...options.Opt) (Provider, error) {
+	return openai.NewClient(ctx, cfg, env, opts...)
+}
+
+func anthropicFactory(ctx context.Context, cfg *latest.ModelConfig, env environment.Provider, opts ...options.Opt) (Provider, error) {
+	return anthropic.NewClient(ctx, cfg, env, opts...)
+}
+
+func googleFactory(ctx context.Context, cfg *latest.ModelConfig, env environment.Provider, opts ...options.Opt) (Provider, error) {
+	return gemini.NewClient(ctx, cfg, env, opts...)
+}
 
 func (r *Registry) New(ctx context.Context, cfg *latest.ModelConfig, env environment.Provider, opts ...options.Opt) (Provider, error) {
 	return r.NewWithModels(ctx, cfg, nil, env, opts...)

--- a/pkg/rag/builder.go
+++ b/pkg/rag/builder.go
@@ -24,12 +24,20 @@ type ManagersBuildConfig struct {
 	Models        map[string]latest.ModelConfig    // Model configurations from config
 	Providers     map[string]latest.ProviderConfig // Custom provider configurations from config
 	RuntimeConfig *config.RuntimeConfig
+	// ProviderRegistry instantiates the embedding/reranking model providers.
+	// When nil, the slim default registry is used (dmr only), which fails for
+	// openai/anthropic/google/bedrock embedding models.
+	ProviderRegistry *provider.Registry
 }
 
 // NewProvider creates a model provider using the build config's environment,
 // gateway, and custom provider settings.
 func (c ManagersBuildConfig) NewProvider(ctx context.Context, cfg *latest.ModelConfig) (provider.Provider, error) {
-	return provider.New(ctx, cfg, c.Env,
+	registry := c.ProviderRegistry
+	if registry == nil {
+		registry = provider.DefaultRegistry()
+	}
+	return registry.New(ctx, cfg, c.Env,
 		options.WithGateway(c.ModelsGateway),
 		options.WithProviders(c.Providers))
 }
@@ -52,15 +60,16 @@ func NewManager(
 
 	// Build context for strategy builders
 	strategyBuildCtx := strategy.BuildContext{
-		RAGName:       ragName,
-		ParentDir:     buildCfg.ParentDir,
-		SharedDocs:    GetAbsolutePaths(buildCfg.ParentDir, ragCfg.Docs),
-		Models:        buildCfg.Models,
-		Providers:     buildCfg.Providers,
-		Env:           buildCfg.Env,
-		ModelsGateway: buildCfg.ModelsGateway,
-		RespectVCS:    ragCfg.GetRespectVCS(),
-		RuntimeConfig: buildCfg.RuntimeConfig,
+		RAGName:          ragName,
+		ParentDir:        buildCfg.ParentDir,
+		SharedDocs:       GetAbsolutePaths(buildCfg.ParentDir, ragCfg.Docs),
+		Models:           buildCfg.Models,
+		Providers:        buildCfg.Providers,
+		Env:              buildCfg.Env,
+		ModelsGateway:    buildCfg.ModelsGateway,
+		RespectVCS:       ragCfg.GetRespectVCS(),
+		RuntimeConfig:    buildCfg.RuntimeConfig,
+		ProviderRegistry: buildCfg.ProviderRegistry,
 	}
 
 	strategyConfigs, strategyEvents, err := buildStrategyConfigs(ctx, *ragCfg, strategyBuildCtx, ragName)

--- a/pkg/rag/strategy/strategy.go
+++ b/pkg/rag/strategy/strategy.go
@@ -23,12 +23,20 @@ type BuildContext struct {
 	ModelsGateway string
 	RespectVCS    bool // Whether to respect VCS ignore files (e.g., .gitignore) when collecting files
 	RuntimeConfig *config.RuntimeConfig
+	// ProviderRegistry instantiates the strategy's embedding model providers.
+	// When nil, the slim default registry is used (dmr only), which fails for
+	// openai/anthropic/google/bedrock embedding models.
+	ProviderRegistry *provider.Registry
 }
 
 // NewProvider creates a model provider using the build context's environment,
 // gateway, and custom provider settings.
 func (c BuildContext) NewProvider(ctx context.Context, cfg *latest.ModelConfig) (provider.Provider, error) {
-	return provider.New(ctx, cfg, c.Env,
+	registry := c.ProviderRegistry
+	if registry == nil {
+		registry = provider.DefaultRegistry()
+	}
+	return registry.New(ctx, cfg, c.Env,
 		options.WithGateway(c.ModelsGateway),
 		options.WithProviders(c.Providers))
 }

--- a/pkg/teamloader/toolsets/toolsets.go
+++ b/pkg/teamloader/toolsets/toolsets.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/model/provider/providers"
 	"github.com/docker/docker-agent/pkg/teamloader"
 	"github.com/docker/docker-agent/pkg/tools"
 	"github.com/docker/docker-agent/pkg/tools/a2a"
@@ -91,7 +92,7 @@ func DefaultToolsetCreators() map[string]teamloader.ToolsetCreator {
 			return agenttool.CreateToolSet()
 		},
 		"rag": func(ctx context.Context, toolset latest.Toolset, parentDir string, runConfig *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
-			return rag.CreateToolSet(ctx, toolset, parentDir, runConfig)
+			return rag.CreateToolSet(ctx, toolset, parentDir, runConfig, providers.NewDefaultRegistry())
 		},
 	}
 }

--- a/pkg/tools/builtin/rag/rag.go
+++ b/pkg/tools/builtin/rag/rag.go
@@ -11,13 +11,16 @@ import (
 
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/model/provider"
 	"github.com/docker/docker-agent/pkg/rag"
 	ragtypes "github.com/docker/docker-agent/pkg/rag/types"
 	"github.com/docker/docker-agent/pkg/tools"
 )
 
-// CreateToolSet is used by the tools registry.
-func CreateToolSet(ctx context.Context, toolset latest.Toolset, parentDir string, runConfig *config.RuntimeConfig) (tools.ToolSet, error) {
+// CreateToolSet is used by the tools registry. providerRegistry instantiates the
+// embedding/reranking model providers; pass the application's full registry
+// (e.g. providers.NewDefaultRegistry()) so non-dmr embedding models resolve.
+func CreateToolSet(ctx context.Context, toolset latest.Toolset, parentDir string, runConfig *config.RuntimeConfig, providerRegistry *provider.Registry) (tools.ToolSet, error) {
 	if toolset.RAGConfig == nil {
 		return nil, errors.New("rag toolset requires either a rag_config block or a ref")
 	}
@@ -25,12 +28,13 @@ func CreateToolSet(ctx context.Context, toolset latest.Toolset, parentDir string
 	ragName := cmp.Or(toolset.Name, "rag")
 
 	mgr, err := rag.NewManager(ctx, ragName, toolset.RAGConfig, rag.ManagersBuildConfig{
-		ParentDir:     parentDir,
-		ModelsGateway: runConfig.ModelsGateway,
-		Env:           runConfig.EnvProvider(),
-		Models:        runConfig.Models,
-		Providers:     runConfig.Providers,
-		RuntimeConfig: runConfig,
+		ParentDir:        parentDir,
+		ModelsGateway:    runConfig.ModelsGateway,
+		Env:              runConfig.EnvProvider(),
+		Models:           runConfig.Models,
+		Providers:        runConfig.Providers,
+		RuntimeConfig:    runConfig,
+		ProviderRegistry: providerRegistry,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create RAG manager: %w", err)


### PR DESCRIPTION
## Context

Follow-up to #3184, which made the model provider registry explicit. The package-level `provider.New` / `provider.NewWithModels` now resolve against the slim default registry (`dmr` only on native, empty on js/wasm); the full provider set lives in `providers.NewDefaultRegistry()` and must be passed explicitly.

Several production paths still call the package-level helpers and were not updated by #3184. They silently fall back to the slim registry and fail at runtime with `unknown provider type "openai"` (or anthropic/google/bedrock). All of them compile cleanly, so neither the compiler nor CI caught the regression; it only surfaces when the path is exercised.

## Regressions fixed

| Severity | Path | Symptom before this PR |
|---|---|---|
| Blocker | `rag` toolset (`pkg/rag`) | A RAG toolset with a non-dmr embedding/reranking model (e.g. `openai/text-embedding-3-small`) fails at `Start()`. `model: auto` silently drops the openai candidate. |
| Blocker | js/wasm browser build (`cmd/wasm`) | Every model fails with `provider type "openai" is not registered`; the whole browser build was non-functional. |
| Warning | `eval` command (`pkg/evaluation`) | `eval` with a non-dmr judge (the default is `anthropic/...`) fails at judge construction. |
| Warning | a2a / mcp / chatserver runtimes | `type: model` hooks fail for non-dmr models (the runtime model hook got the slim registry). |

## Approach

- **rag**: thread a `*provider.Registry` through `ManagersBuildConfig` and `strategy.BuildContext`. The rag toolset creator passes `providers.NewDefaultRegistry()`. A nil registry still falls back to the slim default, so direct constructions are unaffected.
- **evaluation**: build the LLM judge through `providers.NewDefaultRegistry()`.
- **js/wasm**: repopulate `factory_js.go`'s default registry with the browser-capable providers (openai/anthropic/gemini), matching the pre-#3184 slim set. `cmd/wasm` is unchanged.
- **a2a / mcp / chatserver**: load via `LoadWithConfig` and pass `runtime.WithProviderRegistry(loadResult.ProviderRegistry)`, mirroring what `acp` and `new` already do.

## Tradeoff

`pkg/teamloader/toolsets` now imports `pkg/model/provider/providers` (for the rag creator), so the batteries-included toolset registry pulls the provider SDKs. This is the same coupling `defaults.Opts()` already has, and embedders building a slim toolset registry are unaffected. A more surgical alternative would thread the registry through the `ToolsetCreator` signature, but that churns a freshly-introduced public API.

## Verification

- `go build ./...` and `GOOS=js GOARCH=wasm go build ./cmd/wasm/...` pass.
- `go vet` and `go test` pass for `rag`, `tools/builtin/rag`, `teamloader`, `evaluation`, `a2a`, `mcp`, `chatserver`, `model/provider/...`.