### PR TITLE
refactor: decouple embedder dependencies

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -22,6 +22,7 @@ import (
 	"github.com/docker/docker-agent/pkg/selfupdate"
 	"github.com/docker/docker-agent/pkg/telemetry"
 	"github.com/docker/docker-agent/pkg/tools/builtin/shell"
+	_ "github.com/docker/docker-agent/pkg/tools/mcp/keyringstore"
 	"github.com/docker/docker-agent/pkg/version"
 )
 

--- a/pkg/hooks/builtins/unload.go
+++ b/pkg/hooks/builtins/unload.go
@@ -8,11 +8,11 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
 	"github.com/docker/docker-agent/pkg/hooks"
-	"github.com/docker/docker-agent/pkg/model/provider/dmr"
 )
 
 // Unload is the registered name of the on_agent_switch builtin that
@@ -31,11 +31,6 @@ import (
 // net/http. It carries no runtime-side coupling and silently skips any
 // model whose endpoint isn't reachable as plain HTTP (e.g. cloud
 // providers that don't expose [hooks.ModelEndpoint.BaseURL]).
-//
-// Provider dispatch and URL resolution are owned by
-// [pkg/model/provider/dmr] (see [dmr.ProviderType] and [dmr.UnloadURL]),
-// so this builtin stays a dumb dispatcher and DMR keeps full control
-// of its conventions.
 const Unload = "unload"
 
 // unloadTimeout caps each per-model Unload call so a stalled engine
@@ -52,7 +47,7 @@ func unload(ctx context.Context, in *hooks.Input, _ []string) (*hooks.Output, er
 		return nil, nil
 	}
 	for _, m := range in.FromAgentModels {
-		if m.Provider != dmr.ProviderType {
+		if m.Provider != "dmr" {
 			continue
 		}
 		if err := unloadOne(ctx, m); err != nil {
@@ -68,7 +63,7 @@ func unload(ctx context.Context, in *hooks.Input, _ []string) (*hooks.Output, er
 // (no base_url and no unload_api) is a silent no-op so the hook stays
 // harmless on test / in-process providers.
 func unloadOne(parent context.Context, m hooks.ModelEndpoint) error {
-	endpoint, err := dmr.UnloadURL(m.BaseURL, m.UnloadAPI)
+	endpoint, err := dmrUnloadURL(m.BaseURL, m.UnloadAPI)
 	if err != nil || endpoint == "" {
 		return err
 	}
@@ -105,4 +100,26 @@ func unloadOne(parent context.Context, m hooks.ModelEndpoint) error {
 	// body has been read to EOF and closed).
 	_, _ = io.Copy(io.Discard, resp.Body)
 	return nil
+}
+
+func dmrUnloadURL(baseURL, unloadAPI string) (string, error) {
+	if strings.HasPrefix(unloadAPI, "http://") || strings.HasPrefix(unloadAPI, "https://") {
+		return unloadAPI, nil
+	}
+	if baseURL == "" && unloadAPI == "" {
+		return "", nil
+	}
+	u, err := url.Parse(baseURL)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("base_url %q is not absolute; cannot resolve unload endpoint", baseURL)
+	}
+	switch {
+	case unloadAPI == "":
+		u.Path = strings.TrimSuffix(strings.TrimSuffix(u.Path, "/"), "/v1") + "/_unload"
+	case strings.HasPrefix(unloadAPI, "/"):
+		u.Path = unloadAPI
+	default:
+		u.Path = "/" + unloadAPI
+	}
+	return u.String(), nil
 }

--- a/pkg/hooks/builtins/unload_test.go
+++ b/pkg/hooks/builtins/unload_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/hooks"
-	"github.com/docker/docker-agent/pkg/model/provider/dmr"
 )
 
 // dmrInput builds an on_agent_switch [hooks.Input] carrying a single
@@ -27,7 +26,7 @@ func dmrInput(server *httptest.Server, unloadAPI string, opts ...func(*hooks.Inp
 		FromAgent: "from",
 		ToAgent:   "to",
 		FromAgentModels: []hooks.ModelEndpoint{{
-			Provider:  dmr.ProviderType,
+			Provider:  "dmr",
 			Model:     "ai/qwen3",
 			BaseURL:   server.URL + "/engines/v1",
 			UnloadAPI: unloadAPI,
@@ -133,9 +132,9 @@ func TestUnload_FiltersPerElement(t *testing.T) {
 		ToAgent:   "to",
 		FromAgentModels: []hooks.ModelEndpoint{
 			{Provider: "openai", Model: "gpt-4", BaseURL: "https://api.openai.com/v1"},
-			{Provider: dmr.ProviderType, Model: "ai/qwen3", BaseURL: server.URL + "/engines/v1"},
+			{Provider: "dmr", Model: "ai/qwen3", BaseURL: server.URL + "/engines/v1"},
 			{Provider: "anthropic", Model: "claude", BaseURL: "https://api.anthropic.com"},
-			{Provider: dmr.ProviderType, Model: "ai/llama3.2", BaseURL: server.URL + "/engines/llama.cpp/v1"},
+			{Provider: "dmr", Model: "ai/llama3.2", BaseURL: server.URL + "/engines/llama.cpp/v1"},
 		},
 	}
 
@@ -194,7 +193,7 @@ func TestUnload_NoOpInputs(t *testing.T) {
 			in: func(*httptest.Server) *hooks.Input {
 				return &hooks.Input{
 					FromAgent: "from", ToAgent: "to",
-					FromAgentModels: []hooks.ModelEndpoint{{Provider: dmr.ProviderType, Model: "ai/qwen3"}},
+					FromAgentModels: []hooks.ModelEndpoint{{Provider: "dmr", Model: "ai/qwen3"}},
 				}
 			},
 		},

--- a/pkg/model/provider/factory.go
+++ b/pkg/model/provider/factory.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/environment"
-	"github.com/docker/docker-agent/pkg/model/provider/dmr"
 	"github.com/docker/docker-agent/pkg/model/provider/options"
 	"github.com/docker/docker-agent/pkg/model/provider/rulebased"
 )
@@ -22,8 +21,7 @@ type Registry struct {
 }
 
 func NewRegistry(factories map[string]Factory) *Registry {
-	copied := make(map[string]Factory, len(factories)+1)
-	copied["dmr"] = dmrFactory
+	copied := make(map[string]Factory, len(factories))
 	maps.Copy(copied, factories)
 	return &Registry{factories: copied}
 }
@@ -92,14 +90,13 @@ func (r *Registry) createDirectProvider(ctx context.Context, cfg *latest.ModelCo
 
 var defaultFactories map[string]Factory
 
+// Deprecated: the core registry intentionally contains no concrete SDK-backed
+// providers. Use providers.NewDefaultRegistry for Docker Agent's full provider
+// set, or NewRegistry with the concrete provider factories an embedder needs.
 func DefaultRegistry() *Registry {
 	return NewRegistry(defaultFactories)
 }
 
 func unknownProviderError(providerType string) error {
 	return fmt.Errorf("unknown provider type %q (register it with provider.NewRegistry or use providers.NewDefaultRegistry)", providerType)
-}
-
-func dmrFactory(ctx context.Context, cfg *latest.ModelConfig, _ environment.Provider, opts ...options.Opt) (Provider, error) {
-	return dmr.NewClient(ctx, cfg, opts...)
 }

--- a/pkg/model/provider/factory_js.go
+++ b/pkg/model/provider/factory_js.go
@@ -28,6 +28,9 @@ func NewRegistry(factories map[string]Factory) *Registry {
 
 var defaultFactories map[string]Factory
 
+// Deprecated: the core registry intentionally contains no concrete SDK-backed
+// providers. Use providers.NewDefaultRegistry for Docker Agent's full provider
+// set, or NewRegistry with the concrete provider factories an embedder needs.
 func DefaultRegistry() *Registry { return NewRegistry(defaultFactories) }
 
 func (r *Registry) New(ctx context.Context, cfg *latest.ModelConfig, env environment.Provider, opts ...options.Opt) (Provider, error) {

--- a/pkg/model/provider/provider.go
+++ b/pkg/model/provider/provider.go
@@ -12,8 +12,7 @@
 //     custom providers, built-in aliases, and model-specific rules
 //     (thinking budget, interleaved thinking, ...).
 //   - factory.go: shared dispatch from a resolved provider type to the
-//     concrete client constructor, plus the always-available dmr provider
-//     and the rule-based router.
+//     concrete client constructor, plus the rule-based router.
 //
 // Optional SDK-backed providers live outside this package's default import
 // graph. YAML-loading applications that need Docker Agent's full provider set

--- a/pkg/model/provider/providers/providers.go
+++ b/pkg/model/provider/providers/providers.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/docker-agent/pkg/model/provider"
 	"github.com/docker/docker-agent/pkg/model/provider/anthropic"
 	"github.com/docker/docker-agent/pkg/model/provider/bedrock"
+	"github.com/docker/docker-agent/pkg/model/provider/dmr"
 	"github.com/docker/docker-agent/pkg/model/provider/gemini"
 	"github.com/docker/docker-agent/pkg/model/provider/openai"
 	"github.com/docker/docker-agent/pkg/model/provider/options"
@@ -25,6 +26,7 @@ func DefaultFactories() map[string]provider.Factory {
 		"openai_responses":       openaiFactory,
 		"anthropic":              anthropicFactory,
 		"google":                 googleFactory,
+		"dmr":                    dmrFactory,
 		"amazon-bedrock":         bedrockFactory,
 	}
 }
@@ -42,6 +44,10 @@ func googleFactory(ctx context.Context, cfg *latest.ModelConfig, env environment
 		return vertexai.NewClient(ctx, cfg, env, opts...)
 	}
 	return gemini.NewClient(ctx, cfg, env, opts...)
+}
+
+func dmrFactory(ctx context.Context, cfg *latest.ModelConfig, _ environment.Provider, opts ...options.Opt) (provider.Provider, error) {
+	return dmr.NewClient(ctx, cfg, opts...)
 }
 
 func bedrockFactory(ctx context.Context, cfg *latest.ModelConfig, env environment.Provider, opts ...options.Opt) (provider.Provider, error) {

--- a/pkg/tools/mcp/keyringstore/tokenstore.go
+++ b/pkg/tools/mcp/keyringstore/tokenstore.go
@@ -1,4 +1,4 @@
-package mcp
+package keyringstore
 
 import (
 	"bytes"
@@ -20,6 +20,7 @@ import (
 
 	"github.com/docker/docker-agent/pkg/atomicfile"
 	"github.com/docker/docker-agent/pkg/paths"
+	"github.com/docker/docker-agent/pkg/tools/mcp"
 )
 
 // OAuth tokens are encrypted with AES-256-GCM and written to a single file
@@ -67,7 +68,7 @@ type KeyringTokenStore struct {
 	write    func(string, []byte) error
 
 	mu      sync.Mutex
-	cache   map[string]*OAuthToken
+	cache   map[string]*mcp.OAuthToken
 	key     []byte // cached encryption key; fetched from the keyring once
 	loaded  bool
 	loadErr error
@@ -92,22 +93,31 @@ func openKeyring() (keyring.Keyring, error) {
 // outbound HTTP request, popping a macOS password prompt for the
 // `docker-agent-oauth` keychain item on developer machines that have a
 // token from a prior login.
-var defaultStore = sync.OnceValue(func() OAuthTokenStore {
+var defaultStore = sync.OnceValue(func() mcp.OAuthTokenStore {
 	if testing.Testing() {
-		return NewInMemoryTokenStore()
+		return mcp.NewInMemoryTokenStore()
 	}
 	ring, err := openKeyring()
 	if err != nil {
 		slog.Warn("OS keyring not available, falling back to in-memory token store", "error", err)
-		return NewInMemoryTokenStore()
+		return mcp.NewInMemoryTokenStore()
 	}
 	return newKeyringTokenStore(ring, filepath.Join(paths.GetConfigDir(), tokenFileName))
 })
 
+func init() {
+	Register()
+}
+
+// Register installs the keyring-backed token store as the default for MCP OAuth.
+func Register() {
+	mcp.SetDefaultTokenStoreFactory(NewKeyringTokenStore)
+}
+
 // NewKeyringTokenStore returns the process-wide token store backed by the
 // OS keyring, falling back to InMemoryTokenStore when no backend is
 // available. It always returns the same instance.
-func NewKeyringTokenStore() OAuthTokenStore {
+func NewKeyringTokenStore() mcp.OAuthTokenStore {
 	return defaultStore()
 }
 
@@ -119,7 +129,7 @@ func newKeyringTokenStore(ring keyring.Keyring, filePath string) *KeyringTokenSt
 		ring:     ring,
 		filePath: filePath,
 		write:    writeTokenFile,
-		cache:    map[string]*OAuthToken{},
+		cache:    map[string]*mcp.OAuthToken{},
 	}
 }
 
@@ -147,7 +157,7 @@ func (s *KeyringTokenStore) load() {
 		}
 		if derr := s.decryptInto(key, data); derr != nil {
 			slog.Warn("OAuth token file is corrupt; starting fresh", "error", derr)
-			s.cache = map[string]*OAuthToken{}
+			s.cache = map[string]*mcp.OAuthToken{}
 		}
 	case errors.Is(err, os.ErrNotExist):
 		// Possibly an upgrade from an older keyring-only layout. Best-effort
@@ -212,7 +222,7 @@ func (s *KeyringTokenStore) decryptInto(key, data []byte) error {
 	if err != nil {
 		return fmt.Errorf("failed to decrypt token file: %w", err)
 	}
-	cache := map[string]*OAuthToken{}
+	cache := map[string]*mcp.OAuthToken{}
 	if err := json.Unmarshal(plaintext, &cache); err != nil {
 		return fmt.Errorf("failed to unmarshal token bundle: %w", err)
 	}
@@ -267,7 +277,7 @@ func (s *KeyringTokenStore) migrateLegacyLocked() {
 // Caller must hold s.mu.
 func (s *KeyringTokenStore) collectLegacyTokensLocked() []string {
 	var legacyKeys []string
-	legacyTokens := map[string]*OAuthToken{}
+	legacyTokens := map[string]*mcp.OAuthToken{}
 
 	// Oldest legacy layout: one keyring item per resource URL.
 	keys, err := s.ring.Keys()
@@ -285,7 +295,7 @@ func (s *KeyringTokenStore) collectLegacyTokensLocked() []string {
 			if err != nil {
 				continue
 			}
-			var token OAuthToken
+			var token mcp.OAuthToken
 			if json.Unmarshal(item.Data, &token) != nil {
 				continue
 			}
@@ -297,7 +307,7 @@ func (s *KeyringTokenStore) collectLegacyTokensLocked() []string {
 	// Newer legacy layout: a single JSON bundle under one keyring item. It
 	// intentionally wins over per-resource items for the same URL.
 	if item, err := s.ring.Get(legacyBundleKey); err == nil {
-		bundle := map[string]*OAuthToken{}
+		bundle := map[string]*mcp.OAuthToken{}
 		if json.Unmarshal(item.Data, &bundle) == nil {
 			maps.Copy(legacyTokens, bundle)
 		}
@@ -372,7 +382,7 @@ func (s *KeyringTokenStore) reloadFromDiskLocked() error {
 	}
 	if err := s.decryptInto(key, data); err != nil {
 		slog.Warn("OAuth token file is corrupt; overwriting with fresh token bundle", "error", err)
-		s.cache = map[string]*OAuthToken{}
+		s.cache = map[string]*mcp.OAuthToken{}
 	}
 	return nil
 }
@@ -396,7 +406,7 @@ func newGCM(key []byte) (cipher.AEAD, error) {
 	return gcm, nil
 }
 
-func (s *KeyringTokenStore) GetToken(resourceURL string) (*OAuthToken, error) {
+func (s *KeyringTokenStore) GetToken(resourceURL string) (*mcp.OAuthToken, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.load()
@@ -408,7 +418,7 @@ func (s *KeyringTokenStore) GetToken(resourceURL string) (*OAuthToken, error) {
 	return token, nil
 }
 
-func (s *KeyringTokenStore) StoreToken(resourceURL string, token *OAuthToken) error {
+func (s *KeyringTokenStore) StoreToken(resourceURL string, token *mcp.OAuthToken) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.load()
@@ -453,48 +463,15 @@ func (s *KeyringTokenStore) RemoveToken(resourceURL string) error {
 	return s.persistLocked()
 }
 
-// list returns a snapshot of all stored tokens.
-func (s *KeyringTokenStore) list() []OAuthTokenEntry {
+// ListOAuthTokens returns a snapshot of all stored tokens.
+func (s *KeyringTokenStore) ListOAuthTokens() []mcp.OAuthTokenEntry {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.load()
 
-	entries := make([]OAuthTokenEntry, 0, len(s.cache))
+	entries := make([]mcp.OAuthTokenEntry, 0, len(s.cache))
 	for url, token := range s.cache {
-		entries = append(entries, OAuthTokenEntry{ResourceURL: url, Token: token})
+		entries = append(entries, mcp.OAuthTokenEntry{ResourceURL: url, Token: token})
 	}
 	return entries
-}
-
-// OAuthTokenEntry pairs a stored OAuth token with its resource URL.
-type OAuthTokenEntry struct {
-	ResourceURL string
-	Token       *OAuthToken
-}
-
-// requireKeyring returns the singleton store cast to *KeyringTokenStore,
-// or an error if the OS keyring backend is unavailable.
-func requireKeyring() (*KeyringTokenStore, error) {
-	if s, ok := defaultStore().(*KeyringTokenStore); ok {
-		return s, nil
-	}
-	return nil, errors.New("OS keyring not available")
-}
-
-// ListOAuthTokens returns every OAuth token persisted in the keyring.
-func ListOAuthTokens() ([]OAuthTokenEntry, error) {
-	s, err := requireKeyring()
-	if err != nil {
-		return nil, err
-	}
-	return s.list(), nil
-}
-
-// RemoveOAuthToken deletes the token stored for resourceURL.
-func RemoveOAuthToken(resourceURL string) error {
-	s, err := requireKeyring()
-	if err != nil {
-		return err
-	}
-	return s.RemoveToken(resourceURL)
 }

--- a/pkg/tools/mcp/keyringstore/tokenstore_lock.go
+++ b/pkg/tools/mcp/keyringstore/tokenstore_lock.go
@@ -1,0 +1,52 @@
+package keyringstore
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+var errLockBusy = errors.New("OAuth token file lock busy")
+
+const (
+	tokenFileLockTimeout = 5 * time.Second
+	tokenFileLockRetry   = 25 * time.Millisecond
+)
+
+// lockTokenFile takes an exclusive advisory lock on "<path>.lock",
+// creating the lock file and parent directory if needed. The lock file is
+// intentionally long-lived: deleting it would allow different processes to
+// lock different inodes for the same logical token bundle.
+func lockTokenFile(path string) (func(), error) {
+	lockPath := path + ".lock"
+	if dir := filepath.Dir(lockPath); dir != "" {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return nil, fmt.Errorf("creating OAuth token lock directory %q: %w", dir, err)
+		}
+	}
+	f, err := os.OpenFile(lockPath, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("opening OAuth token lock file %q: %w", lockPath, err)
+	}
+	deadline := time.Now().Add(tokenFileLockTimeout)
+	for {
+		if err := lockExclusive(f); err == nil {
+			break
+		} else if !errors.Is(err, errLockBusy) {
+			f.Close()
+			return nil, fmt.Errorf("locking OAuth token file %q: %w", lockPath, err)
+		}
+
+		if time.Now().After(deadline) {
+			f.Close()
+			return nil, fmt.Errorf("timed out locking OAuth token file %q after %s: %w", lockPath, tokenFileLockTimeout, errLockBusy)
+		}
+		time.Sleep(tokenFileLockRetry)
+	}
+	return func() {
+		_ = unlockFile(f)
+		_ = f.Close()
+	}, nil
+}

--- a/pkg/tools/mcp/keyringstore/tokenstore_lock_js.go
+++ b/pkg/tools/mcp/keyringstore/tokenstore_lock_js.go
@@ -1,0 +1,9 @@
+//go:build js && wasm
+
+package keyringstore
+
+import "os"
+
+func lockExclusive(_ *os.File) error { return nil }
+
+func unlockFile(_ *os.File) error { return nil }

--- a/pkg/tools/mcp/keyringstore/tokenstore_lock_unix.go
+++ b/pkg/tools/mcp/keyringstore/tokenstore_lock_unix.go
@@ -1,0 +1,22 @@
+//go:build unix
+
+package keyringstore
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func lockExclusive(f *os.File) error {
+	err := unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+	if errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN) {
+		return errLockBusy
+	}
+	return err
+}
+
+func unlockFile(f *os.File) error {
+	return unix.Flock(int(f.Fd()), unix.LOCK_UN)
+}

--- a/pkg/tools/mcp/keyringstore/tokenstore_lock_windows.go
+++ b/pkg/tools/mcp/keyringstore/tokenstore_lock_windows.go
@@ -1,0 +1,39 @@
+//go:build windows
+
+package keyringstore
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+const maxLockRange = ^uint32(0)
+
+func lockExclusive(f *os.File) error {
+	var ol windows.Overlapped
+	err := windows.LockFileEx(
+		windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0,
+		maxLockRange,
+		maxLockRange,
+		&ol,
+	)
+	if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+		return errLockBusy
+	}
+	return err
+}
+
+func unlockFile(f *os.File) error {
+	var ol windows.Overlapped
+	return windows.UnlockFileEx(
+		windows.Handle(f.Fd()),
+		0,
+		maxLockRange,
+		maxLockRange,
+		&ol,
+	)
+}

--- a/pkg/tools/mcp/keyringstore/tokenstore_test.go
+++ b/pkg/tools/mcp/keyringstore/tokenstore_test.go
@@ -1,4 +1,4 @@
-package mcp
+package keyringstore
 
 import (
 	"bytes"
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/99designs/keyring"
+
+	"github.com/docker/docker-agent/pkg/tools/mcp"
 )
 
 // newTestStore returns a KeyringTokenStore backed by an in-memory array
@@ -26,7 +28,7 @@ func newTestStore(t *testing.T) (*KeyringTokenStore, keyring.Keyring) {
 func TestKeyringTokenStore_RoundTrip(t *testing.T) {
 	// Use in-memory store to avoid triggering macOS keychain permission dialogs
 	// or failing in CI environments without a keyring.
-	store := NewInMemoryTokenStore()
+	store := mcp.NewInMemoryTokenStore()
 
 	resourceURL := "https://example.com/mcp"
 
@@ -36,7 +38,7 @@ func TestKeyringTokenStore_RoundTrip(t *testing.T) {
 	}
 
 	// Store a token
-	token := &OAuthToken{
+	token := &mcp.OAuthToken{
 		AccessToken:  "access-123",
 		TokenType:    "Bearer",
 		RefreshToken: "refresh-456",
@@ -69,8 +71,8 @@ func TestKeyringTokenStore_RoundTrip(t *testing.T) {
 }
 
 func TestKeyringTokenStore_JSONRoundTrip(t *testing.T) {
-	// Verify that OAuthToken serializes correctly (important for keyring storage)
-	token := &OAuthToken{
+	// Verify that mcp.OAuthToken serializes correctly (important for keyring storage)
+	token := &mcp.OAuthToken{
 		AccessToken:  "at",
 		TokenType:    "Bearer",
 		RefreshToken: "rt",
@@ -84,7 +86,7 @@ func TestKeyringTokenStore_JSONRoundTrip(t *testing.T) {
 		t.Fatalf("Marshal: %v", err)
 	}
 
-	var got OAuthToken
+	var got mcp.OAuthToken
 	if err := json.Unmarshal(data, &got); err != nil {
 		t.Fatalf("Unmarshal: %v", err)
 	}
@@ -95,7 +97,7 @@ func TestKeyringTokenStore_JSONRoundTrip(t *testing.T) {
 }
 
 func TestKeyringTokenStore_RemoveNonExistent(t *testing.T) {
-	store := NewInMemoryTokenStore()
+	store := mcp.NewInMemoryTokenStore()
 	if err := store.RemoveToken("https://nonexistent.example.com"); err != nil {
 		t.Fatalf("RemoveToken for non-existent key should not error: %v", err)
 	}
@@ -113,7 +115,7 @@ func TestEncryptedStore_PersistsAcrossReload(t *testing.T) {
 		"https://server-c.example/mcp",
 	}
 	for i, url := range urls {
-		if err := store.StoreToken(url, &OAuthToken{AccessToken: "at-" + string(rune('A'+i))}); err != nil {
+		if err := store.StoreToken(url, &mcp.OAuthToken{AccessToken: "at-" + string(rune('A'+i))}); err != nil {
 			t.Fatalf("StoreToken(%s): %v", url, err)
 		}
 	}
@@ -172,7 +174,7 @@ func TestEncryptedStore_ReadsTouchKeyringOnce(t *testing.T) {
 	path := filepath.Join(t.TempDir(), tokenFileName)
 	store := newKeyringTokenStore(ring, path)
 	for i, url := range urls {
-		if err := store.StoreToken(url, &OAuthToken{AccessToken: "at-" + string(rune('A'+i))}); err != nil {
+		if err := store.StoreToken(url, &mcp.OAuthToken{AccessToken: "at-" + string(rune('A'+i))}); err != nil {
 			t.Fatalf("StoreToken(%s): %v", url, err)
 		}
 	}
@@ -210,7 +212,7 @@ func TestEncryptedStore_WritesTouchKeyringOnce(t *testing.T) {
 
 	for i := range 5 {
 		url := fmt.Sprintf("https://server-%d.example/mcp", i)
-		if err := store.StoreToken(url, &OAuthToken{AccessToken: "at"}); err != nil {
+		if err := store.StoreToken(url, &mcp.OAuthToken{AccessToken: "at"}); err != nil {
 			t.Fatalf("StoreToken(%s): %v", url, err)
 		}
 	}
@@ -251,17 +253,17 @@ func TestEncryptedStore_CrossProcessStoresMerge(t *testing.T) {
 	processA := newKeyringTokenStore(ring, path)
 	processB := newKeyringTokenStore(ring, path)
 
-	if err := processA.StoreToken("https://a.example/mcp", &OAuthToken{AccessToken: "a"}); err != nil {
+	if err := processA.StoreToken("https://a.example/mcp", &mcp.OAuthToken{AccessToken: "a"}); err != nil {
 		t.Fatalf("processA initial StoreToken: %v", err)
 	}
 	// Process B loads the same initial state before A writes again.
 	if _, err := processB.GetToken("https://a.example/mcp"); err != nil {
 		t.Fatalf("processB load: %v", err)
 	}
-	if err := processA.StoreToken("https://c.example/mcp", &OAuthToken{AccessToken: "c"}); err != nil {
+	if err := processA.StoreToken("https://c.example/mcp", &mcp.OAuthToken{AccessToken: "c"}); err != nil {
 		t.Fatalf("processA second StoreToken: %v", err)
 	}
-	if err := processB.StoreToken("https://b.example/mcp", &OAuthToken{AccessToken: "b"}); err != nil {
+	if err := processB.StoreToken("https://b.example/mcp", &mcp.OAuthToken{AccessToken: "b"}); err != nil {
 		t.Fatalf("processB StoreToken: %v", err)
 	}
 
@@ -293,7 +295,7 @@ func TestEncryptedStore_KeyringHoldsOnlyTheKey(t *testing.T) {
 		"https://server-b.example/mcp",
 		"https://server-c.example/mcp",
 	} {
-		if err := store.StoreToken(url, &OAuthToken{AccessToken: "at"}); err != nil {
+		if err := store.StoreToken(url, &mcp.OAuthToken{AccessToken: "at"}); err != nil {
 			t.Fatalf("StoreToken(%s): %v", url, err)
 		}
 	}
@@ -313,7 +315,7 @@ func TestEncryptedStore_FileIsNotPlaintext(t *testing.T) {
 	store, _ := newTestStore(t)
 
 	const secret = "super-secret-access-token-value"
-	if err := store.StoreToken("https://a.example/mcp", &OAuthToken{AccessToken: secret}); err != nil {
+	if err := store.StoreToken("https://a.example/mcp", &mcp.OAuthToken{AccessToken: secret}); err != nil {
 		t.Fatalf("StoreToken: %v", err)
 	}
 
@@ -333,7 +335,7 @@ func TestEncryptedStore_FileIsNotPlaintext(t *testing.T) {
 // owner-only permissions.
 func TestEncryptedStore_FilePermissions(t *testing.T) {
 	store, _ := newTestStore(t)
-	if err := store.StoreToken("https://a.example/mcp", &OAuthToken{AccessToken: "x"}); err != nil {
+	if err := store.StoreToken("https://a.example/mcp", &mcp.OAuthToken{AccessToken: "x"}); err != nil {
 		t.Fatalf("StoreToken: %v", err)
 	}
 	info, err := os.Stat(store.filePath)
@@ -352,7 +354,7 @@ func TestEncryptedStore_LegacyBundleMigration(t *testing.T) {
 	ring := keyring.NewArrayKeyring(nil)
 	path := filepath.Join(t.TempDir(), tokenFileName)
 
-	bundle := map[string]*OAuthToken{
+	bundle := map[string]*mcp.OAuthToken{
 		"https://legacy-a.example/mcp": {AccessToken: "legacy-a"},
 		"https://legacy-b.example/mcp": {AccessToken: "legacy-b"},
 	}
@@ -402,7 +404,7 @@ func TestEncryptedStore_LegacyPerTokenMigration(t *testing.T) {
 		"https://legacy-b.example/mcp",
 	}
 	for _, url := range urls {
-		seedLegacyToken(t, ring, url, &OAuthToken{AccessToken: "legacy-" + url})
+		seedLegacyToken(t, ring, url, &mcp.OAuthToken{AccessToken: "legacy-" + url})
 	}
 	// Also seed the legacy index, which should be removed without becoming
 	// a token entry.
@@ -438,8 +440,8 @@ func TestEncryptedStore_LegacyBundleWinsOverPerTokenMigration(t *testing.T) {
 	path := filepath.Join(t.TempDir(), tokenFileName)
 	const url = "https://legacy.example/mcp"
 
-	seedLegacyToken(t, ring, url, &OAuthToken{AccessToken: "old-per-token"})
-	bundleData, err := json.Marshal(map[string]*OAuthToken{
+	seedLegacyToken(t, ring, url, &mcp.OAuthToken{AccessToken: "old-per-token"})
+	bundleData, err := json.Marshal(map[string]*mcp.OAuthToken{
 		url: {AccessToken: "new-bundle"},
 	})
 	if err != nil {
@@ -458,7 +460,7 @@ func TestEncryptedStore_LegacyBundleWinsOverPerTokenMigration(t *testing.T) {
 	}
 }
 
-func seedLegacyToken(t *testing.T, ring keyring.Keyring, url string, tok *OAuthToken) {
+func seedLegacyToken(t *testing.T, ring keyring.Keyring, url string, tok *mcp.OAuthToken) {
 	t.Helper()
 	data, err := json.Marshal(tok)
 	if err != nil {
@@ -476,7 +478,7 @@ func seedLegacyToken(t *testing.T, ring keyring.Keyring, url string, tok *OAuthT
 func TestEncryptedStore_MigrationKeepsLegacyOnPersistFailure(t *testing.T) {
 	ring := keyring.NewArrayKeyring(nil)
 
-	bundle := map[string]*OAuthToken{
+	bundle := map[string]*mcp.OAuthToken{
 		"https://legacy-a.example/mcp": {AccessToken: "legacy-a"},
 	}
 	data, err := json.Marshal(bundle)
@@ -514,7 +516,7 @@ func TestEncryptedStore_StoreRefusesAfterUnreadableFile(t *testing.T) {
 	}
 	store := newKeyringTokenStore(ring, filepath.Join(blocker, tokenFileName))
 
-	if err := store.StoreToken("https://a.example/mcp", &OAuthToken{AccessToken: "a"}); err == nil {
+	if err := store.StoreToken("https://a.example/mcp", &mcp.OAuthToken{AccessToken: "a"}); err == nil {
 		t.Fatal("StoreToken should refuse to overwrite after unreadable token file")
 	}
 }
@@ -526,7 +528,7 @@ func TestEncryptedStore_RemovePersists(t *testing.T) {
 	store, ring := newTestStore(t)
 
 	url := "https://to-remove.example/mcp"
-	if err := store.StoreToken(url, &OAuthToken{AccessToken: "x"}); err != nil {
+	if err := store.StoreToken(url, &mcp.OAuthToken{AccessToken: "x"}); err != nil {
 		t.Fatalf("StoreToken: %v", err)
 	}
 	if err := store.RemoveToken(url); err != nil {
@@ -545,7 +547,7 @@ func TestEncryptedStore_CorruptFile(t *testing.T) {
 
 	// Seed the encryption key by writing a real token first, then clobber
 	// the file with garbage that won't decrypt.
-	if err := store.StoreToken("https://seed.example/mcp", &OAuthToken{AccessToken: "seed"}); err != nil {
+	if err := store.StoreToken("https://seed.example/mcp", &mcp.OAuthToken{AccessToken: "seed"}); err != nil {
 		t.Fatalf("seed StoreToken: %v", err)
 	}
 	if err := os.WriteFile(store.filePath, []byte("not-encrypted-garbage"), 0o600); err != nil {
@@ -558,7 +560,7 @@ func TestEncryptedStore_CorruptFile(t *testing.T) {
 	}
 
 	// StoreToken on top of a corrupt file should overwrite it.
-	if err := fresh.StoreToken("https://anything.example/mcp", &OAuthToken{AccessToken: "fresh"}); err != nil {
+	if err := fresh.StoreToken("https://anything.example/mcp", &mcp.OAuthToken{AccessToken: "fresh"}); err != nil {
 		t.Fatalf("StoreToken after corrupt file: %v", err)
 	}
 	got, err := fresh.GetToken("https://anything.example/mcp")
@@ -572,15 +574,15 @@ func TestEncryptedStore_CorruptFile(t *testing.T) {
 func TestEncryptedStore_ListReturnsAllEntries(t *testing.T) {
 	store, ring := newTestStore(t)
 
-	if err := store.StoreToken("https://a.example/mcp", &OAuthToken{AccessToken: "a"}); err != nil {
+	if err := store.StoreToken("https://a.example/mcp", &mcp.OAuthToken{AccessToken: "a"}); err != nil {
 		t.Fatalf("StoreToken: %v", err)
 	}
-	if err := store.StoreToken("https://b.example/mcp", &OAuthToken{AccessToken: "b"}); err != nil {
+	if err := store.StoreToken("https://b.example/mcp", &mcp.OAuthToken{AccessToken: "b"}); err != nil {
 		t.Fatalf("StoreToken: %v", err)
 	}
 
 	// Reload from the ring + file (mirroring what a fresh process would do).
-	entries := newKeyringTokenStore(ring, store.filePath).list()
+	entries := newKeyringTokenStore(ring, store.filePath).ListOAuthTokens()
 	if len(entries) != 2 {
 		t.Fatalf("expected 2 entries, got %d: %+v", len(entries), entries)
 	}
@@ -657,7 +659,7 @@ func TestKeyringTokenStore_ConcurrentAccess(t *testing.T) {
 			defer wg.Done()
 			url := fmt.Sprintf("https://server-%d.example/mcp", id%3)
 			for j := range numOperations {
-				_ = store.StoreToken(url, &OAuthToken{
+				_ = store.StoreToken(url, &mcp.OAuthToken{
 					AccessToken: fmt.Sprintf("token-%d-%d", id, j),
 				})
 			}
@@ -678,6 +680,6 @@ func TestKeyringTokenStore_ConcurrentAccess(t *testing.T) {
 	wg.Wait()
 
 	// Verify the store is still in a consistent state
-	entries := store.list()
+	entries := store.ListOAuthTokens()
 	t.Logf("After concurrent access: %d tokens remain", len(entries))
 }

--- a/pkg/tools/mcp/tokenstore.go
+++ b/pkg/tools/mcp/tokenstore.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/docker/docker-agent/pkg/concurrent"
@@ -15,6 +16,44 @@ type OAuthTokenStore interface {
 	StoreToken(resourceURL string, token *OAuthToken) error
 	// RemoveToken removes a token for the given resource URL
 	RemoveToken(resourceURL string) error
+}
+
+// OAuthTokenStoreFactory constructs the process-wide persistent OAuth token store.
+type OAuthTokenStoreFactory func() OAuthTokenStore
+
+var (
+	defaultStoreMu sync.Mutex
+	defaultStore   = sync.OnceValue(func() OAuthTokenStore { return NewInMemoryTokenStore() })
+)
+
+// SetDefaultTokenStoreFactory installs the process-wide persistent token-store
+// factory used by NewKeyringTokenStore and remote MCP toolsets. It must be
+// called during package initialization, before any NewKeyringTokenStore call;
+// the first store lookup seals the registered factory for the process.
+// Embedders that do not need persistent MCP OAuth storage can avoid importing
+// any OS keyring implementation; docker-agent's CLI registers one from
+// pkg/tools/mcp/keyringstore.
+func SetDefaultTokenStoreFactory(factory OAuthTokenStoreFactory) {
+	if factory == nil {
+		factory = NewInMemoryTokenStore
+	}
+	defaultStoreMu.Lock()
+	defer defaultStoreMu.Unlock()
+	defaultStore = sync.OnceValue(factory)
+}
+
+func defaultTokenStore() OAuthTokenStore {
+	defaultStoreMu.Lock()
+	defer defaultStoreMu.Unlock()
+	return defaultStore()
+}
+
+// NewKeyringTokenStore returns the process-wide persistent OAuth token store.
+// The name is kept for compatibility; without an optional keyring-backed store
+// registered by pkg/tools/mcp/keyringstore before first use, it falls back to
+// an in-memory store.
+func NewKeyringTokenStore() OAuthTokenStore {
+	return defaultTokenStore()
 }
 
 type OAuthToken struct {
@@ -45,7 +84,31 @@ func (t *OAuthToken) IsExpired() bool {
 	return time.Now().Add(30 * time.Second).After(t.ExpiresAt)
 }
 
-// InMemoryTokenStore implements OAuthTokenStore in memory
+// OAuthTokenEntry pairs a stored OAuth token with its resource URL.
+type OAuthTokenEntry struct {
+	ResourceURL string
+	Token       *OAuthToken
+}
+
+type oauthTokenLister interface {
+	ListOAuthTokens() []OAuthTokenEntry
+}
+
+// ListOAuthTokens returns every OAuth token from the registered persistent store.
+func ListOAuthTokens() ([]OAuthTokenEntry, error) {
+	store := NewKeyringTokenStore()
+	lister, ok := store.(oauthTokenLister)
+	if !ok {
+		return nil, fmt.Errorf("persistent OAuth token store not available")
+	}
+	return lister.ListOAuthTokens(), nil
+}
+
+// RemoveOAuthToken deletes the token stored for resourceURL.
+func RemoveOAuthToken(resourceURL string) error {
+	return NewKeyringTokenStore().RemoveToken(resourceURL)
+}
+
 type InMemoryTokenStore struct {
 	tokens *concurrent.Map[string, *OAuthToken]
 }


### PR DESCRIPTION
Packages like `pkg/runtime`, `pkg/model/provider`, and `pkg/tools/mcp` were transitively pulling in `openai-go` and `99designs/keyring` even for embedders that have no need for those dependencies. This made it expensive for downstream consumers to import any of these packages without dragging in heavyweight transitive deps.

DMR registration has moved to the explicit providers registry, so it is no longer wired in at import time. The MCP keyring token store has been extracted into an opt-in `keyringstore` sub-package, meaning callers that do not need keychain integration simply do not import it.

Validation:

```bash
go test ./...
```

```bash
# Both commands should return no output
go list -deps ./pkg/runtime ./pkg/model/provider ./pkg/tools/mcp | grep -E '99designs/keyring|openai-go'
go list -deps ./tui/gordon | grep 'local-replace'
```

No behaviour changes; this is a pure dependency boundary cleanup with no API surface modifications.