### PR TITLE
docs: update Go SDK guide for explicit toolset registry and MCP OAuth token persistence

### DIFF
--- a/docs/guides/go-sdk/index.md
+++ b/docs/guides/go-sdk/index.md
@@ -154,19 +154,28 @@ Requesting a model whose provider was compiled out fails at construction time wi
   <p>The Google provider's Vertex Model Garden support also imports the Anthropic SDK, so the Anthropic dependency is only fully removed when <em>both</em> <code>docker_agent_no_anthropic</code> and <code>docker_agent_no_google</code> are set.</p>
 </div>
 
-## RAG Toolset (cgo-free builds)
+## RAG Toolset (opt-out)
 
-The RAG toolset (`type: rag`) uses a tree-sitter code parser that requires cgo. When building without cgo — or when you want to drop the cgo dependency entirely — do not import the `pkg/rag` package in your binary.
+The RAG toolset (`type: rag`) is included in `NewDefaultToolsetRegistry()` (from `pkg/teamloader/toolsets`) and `loaderdefaults.Opts()` (from `pkg/teamloader/defaults`).
 
-By default the RAG toolset is **opt-in**: it is only linked when you blank-import its package:
+The underlying tree-sitter code parser uses cgo, but build-tag guards in `pkg/rag/treesitter` mean importing the package is safe regardless of `CGO_ENABLED`: with `CGO_ENABLED=0` the parser stub compiles in and returns a runtime error on first use rather than failing at compile time.
+
+If you want to exclude the RAG toolset from your binary entirely — surfacing a load-time warning on the agent rather than a deferred runtime error from the `!cgo` stub — remove it from the registry before passing it to `teamloader.Load`:
 
 ```go
 import (
-    _ "github.com/docker/docker-agent/pkg/tools/builtin/rag" // register RAG toolset
+    "github.com/docker/docker-agent/pkg/teamloader"
+    loadertoolsets "github.com/docker/docker-agent/pkg/teamloader/toolsets"
 )
+
+// Opt out of the RAG toolset; a config that declares type: rag attaches
+// a load-time warning to the agent instead of failing at document processing.
+creators := loadertoolsets.DefaultToolsetCreators()
+delete(creators, "rag")
+registry := teamloader.NewToolsetRegistry(creators)
 ```
 
-Without this import, a config that declares `type: rag` fails with a "toolset type not registered" error at startup. If your application does not use RAG, simply omit the blank import; the rest of docker-agent works without cgo.
+Pass the custom registry via `teamloader.WithToolsetRegistry(registry)` when calling `teamloader.Load`. Note that `teamloader.Load()` does not return an error for unknown toolset types — the failure is recorded as a load-time warning on the agent (`agent.LoadTimeWarnings()`) and surfaced via logging and TUI notifications.
 
 ## Basic Example
 

--- a/docs/guides/go-sdk/index.md
+++ b/docs/guides/go-sdk/index.md
@@ -156,7 +156,7 @@ Requesting a model whose provider was compiled out fails at construction time wi
 
 ## RAG Toolset (opt-out)
 
-The RAG toolset (`type: rag`) is included in `NewDefaultToolsetRegistry()` (from `pkg/teamloader/toolsets`) and `loaderdefaults.Opts()` (from `pkg/teamloader/defaults`).
+The RAG toolset (`type: rag`) is included in `NewDefaultToolsetRegistry()` (from `pkg/teamloader/toolsets`) and `loaderdefaults.Opts()` (from `pkg/teamloader/defaults`, using the conventional import alias `loaderdefaults`).
 
 The underlying tree-sitter code parser uses cgo, but build-tag guards in `pkg/rag/treesitter` mean importing the package is safe regardless of `CGO_ENABLED`: with `CGO_ENABLED=0` the parser stub compiles in and returns a runtime error on first use rather than failing at compile time.
 
@@ -175,7 +175,31 @@ delete(creators, "rag")
 registry := teamloader.NewToolsetRegistry(creators)
 ```
 
-Pass the custom registry via `teamloader.WithToolsetRegistry(registry)` when calling `teamloader.Load`. Note that `teamloader.Load()` does not return an error for unknown toolset types — the failure is recorded as a load-time warning on the agent (`agent.LoadTimeWarnings()`) and surfaced via logging and TUI notifications.
+Pass the custom registry via `teamloader.WithToolsetRegistry(registry)` when calling `teamloader.Load`. Note that `teamloader.Load()` does not return an error for unknown toolset types — the failure is recorded as a load-time warning and can be retrieved with `agent.DrainWarnings()`; it is also surfaced via logging and TUI notifications.
+
+## MCP OAuth Token Persistence
+
+By default, MCP OAuth tokens are stored in-memory only and are not persisted across process restarts. The CLI registers a keyring-backed store automatically at startup; when embedding docker-agent as a library you must do this yourself if you want tokens to survive restarts.
+
+Call `keyringstore.Register()` **before** any MCP toolset is initialised to enable the OS keyring-backed token store:
+
+```go
+import "github.com/docker/docker-agent/pkg/tools/mcp/keyringstore"
+
+func main() {
+    // Must be called before teamloader.Load() on configs with remote MCP
+    // toolsets; calling it after the store is created panics.
+    keyringstore.Register()
+    // ... rest of your startup code
+}
+```
+
+<div class="callout callout-warning" markdown="1">
+<div class="callout-title">Call order matters</div>
+  <p>If <code>keyringstore.Register()</code> is called after the default token store has already been lazily initialised, docker-agent panics. The store is initialised when any remote MCP toolset is constructed — which happens inside <code>teamloader.Load()</code>. Always call <code>keyringstore.Register()</code> before calling <code>teamloader.Load()</code> on a config that includes remote MCP toolsets.</p>
+</div>
+
+If you do not need persistent OAuth tokens (for example, in short-lived batch jobs or tests), omit the call and tokens will be kept in-memory for the process lifetime.
 
 ## Basic Example
 


### PR DESCRIPTION
Updates to `docs/guides/go-sdk/index.md` for two merged PRs.

**PR #3184** (refactor: make toolsets and providers explicit): The RAG toolset is now included in `NewDefaultToolsetRegistry()` by default via `pkg/teamloader/toolsets` — no blank import needed. Updated the Go SDK guide to replace the opt-in blank-import pattern with the new opt-out registry pattern for binaries that want a load-time warning rather than a deferred runtime error from the `!cgo` stub.

**PR #3189** (refactor: decouple embedder deps): The OS keyring token store for MCP OAuth is now opt-in for library embedders. The CLI calls `keyringstore.Register()` at startup; embedders must call it themselves before `teamloader.Load()` on configs with remote MCP toolsets, or tokens are in-memory only. Added a new section documenting this, including the panic on late registration.

PRs reviewed and found no docs impact: #3190 (CHANGELOG), #3187 (remove unused wasm agent), #3183 (prior docs update), #3181 (lean TUI — docs included in PR itself), #3179 (CHANGELOG), #3178 (thinking cycle — covered by #3183).