### PR TITLE
feat(server): expose session forking over HTTP

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -187,6 +187,15 @@ type UpdateSessionTitleRequest struct {
 	Title string `json:"title"`
 }
 
+// ForkSessionRequest represents a request to fork a session at a given
+// message index. MessageIndex points at the user message to fork BEFORE
+// (exclusive cut): the new session contains messages [0, MessageIndex)
+// from the parent. The clicked message is excluded so clients can prefill
+// it into the chat input of the new session for the user to edit.
+type ForkSessionRequest struct {
+	MessageIndex int `json:"message_index"`
+}
+
 // UpdateSessionTitleResponse represents the response from updating a session's title
 type UpdateSessionTitleResponse struct {
 	ID    string `json:"id"`

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -256,10 +256,9 @@ func (s *Server) forkSession(c echo.Context) error {
 	forked, err := s.sm.ForkSession(c.Request().Context(), c.Param("id"), req.MessageIndex)
 	if err != nil {
 		switch {
-		case errors.Is(err, ErrForkInvalidMessage):
-			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
-		case strings.Contains(err.Error(), "out of range"),
-			strings.Contains(err.Error(), "sub-session"):
+		case errors.Is(err, ErrForkInvalidMessage),
+			errors.Is(err, ErrForkOutOfRange),
+			errors.Is(err, ErrForkInSubSession):
 			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
 		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to fork session: %v", err))

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -77,6 +77,7 @@ func (s *Server) registerRoutes() {
 	group.PATCH("/sessions/:id/starred", s.setSessionStarred)
 	group.GET("/sessions/:id/models", s.getSessionModels)
 	group.POST("/sessions", s.createSession)
+	group.POST("/sessions/:id/fork", s.forkSession)
 	group.DELETE("/sessions/:id", s.deleteSession)
 	group.POST("/sessions/:id/agent/:agent", s.runAgent)
 	group.POST("/sessions/:id/agent/:agent/:agent_name", s.runAgent)
@@ -238,6 +239,43 @@ func (s *Server) createSession(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, sess)
+}
+
+// forkSession creates a new session whose history is a deep copy of an
+// existing session up to (but excluding) the message at MessageIndex. The
+// fork point must be a user message; the new session uses a
+// fork-numbered title derived from the parent and starts with no runtime
+// attached. Clients are expected to prefill the excluded user message into
+// their chat input for the user to edit and resubmit.
+func (s *Server) forkSession(c echo.Context) error {
+	var req api.ForkSessionRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid request body: %v", err))
+	}
+
+	forked, err := s.sm.ForkSession(c.Request().Context(), c.Param("id"), req.MessageIndex)
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrForkInvalidMessage):
+			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+		case strings.Contains(err.Error(), "out of range"),
+			strings.Contains(err.Error(), "sub-session"):
+			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to fork session: %v", err))
+	}
+
+	return c.JSON(http.StatusOK, api.SessionResponse{
+		ID:            forked.ID,
+		Title:         forked.Title,
+		CreatedAt:     forked.CreatedAt,
+		Messages:      forked.GetAllMessages(),
+		ToolsApproved: forked.ToolsApproved,
+		InputTokens:   forked.InputTokens,
+		OutputTokens:  forked.OutputTokens,
+		WorkingDir:    forked.WorkingDir,
+		Permissions:   forked.Permissions,
+	})
 }
 
 func (s *Server) getSession(c echo.Context) error {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -250,6 +250,15 @@ func TestServer_ForkSession(t *testing.T) {
 		"/api/sessions/"+parent.ID+"/fork",
 		api.ForkSessionRequest{MessageIndex: 1})
 	assert.Equal(t, http.StatusBadRequest, rejected.StatusCode, rejected.body)
+
+	// Forking past the end of the visible list (no real "after the last
+	// message" full-clone shortcut) must also return 400, not 500. This
+	// pins the sentinel-driven classification so future error-message
+	// reshuffles can't silently flip the status code.
+	outOfRange := httpRaw(t, ctx, http.MethodPost, lnPath,
+		"/api/sessions/"+parent.ID+"/fork",
+		api.ForkSessionRequest{MessageIndex: 99})
+	assert.Equal(t, http.StatusBadRequest, outOfRange.StatusCode, outOfRange.body)
 }
 
 // httpRaw issues an HTTP request and returns the raw response without

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/api"
+	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/session"
 )
@@ -197,6 +198,103 @@ func TestServer_UpdateSessionTitle(t *testing.T) {
 	unmarshal(t, getResp, &sessionResp)
 
 	assert.Equal(t, newTitle, sessionResp.Title)
+}
+
+// TestServer_ForkSession exercises the POST /api/sessions/:id/fork
+// endpoint end-to-end: a fork at a user message must return a new
+// session with the history before that message, a fork-numbered title,
+// and a fresh ID. Forking at a non-user message must be rejected with
+// 400 Bad Request.
+func TestServer_ForkSession(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := session.NewInMemorySessionStore()
+
+	parent := session.New()
+	parent.Title = "Original"
+	parent.Messages = []session.Item{
+		session.NewMessageItem(session.UserMessage("hello")),
+		session.NewMessageItem(session.NewAgentMessage("root", &chat.Message{
+			Role:    chat.MessageRoleAssistant,
+			Content: "hi there",
+		})),
+		session.NewMessageItem(session.UserMessage("ignore me")),
+	}
+	require.NoError(t, store.AddSession(ctx, parent))
+
+	lnPath := startServerWithStore(t, ctx, prepareAgentsDir(t), store)
+
+	// Happy path: fork before the second user message (flat index 2).
+	resp := httpDo(t, ctx, http.MethodPost, lnPath,
+		"/api/sessions/"+parent.ID+"/fork",
+		api.ForkSessionRequest{MessageIndex: 2})
+	var forked api.SessionResponse
+	unmarshal(t, resp, &forked)
+
+	assert.NotEqual(t, parent.ID, forked.ID)
+	assert.Equal(t, "Original (fork 1)", forked.Title)
+	require.Len(t, forked.Messages, 2)
+	assert.Equal(t, "hello", forked.Messages[0].Message.Content)
+	assert.Equal(t, "hi there", forked.Messages[1].Message.Content)
+
+	// Fork must be persisted server-side so a subsequent GET returns it.
+	getResp := httpGET(t, ctx, lnPath, "/api/sessions/"+forked.ID)
+	var fetched api.SessionResponse
+	unmarshal(t, getResp, &fetched)
+	assert.Equal(t, forked.ID, fetched.ID)
+	assert.Equal(t, "Original (fork 1)", fetched.Title)
+
+	// Forking at the assistant message must be rejected with 400.
+	rejected := httpRaw(t, ctx, http.MethodPost, lnPath,
+		"/api/sessions/"+parent.ID+"/fork",
+		api.ForkSessionRequest{MessageIndex: 1})
+	assert.Equal(t, http.StatusBadRequest, rejected.StatusCode, rejected.body)
+}
+
+// httpRaw issues an HTTP request and returns the raw response without
+// asserting on the status code, so tests can verify 4xx/5xx paths.
+func httpRaw(t *testing.T, ctx context.Context, method, socketPath, path string, payload any) struct {
+	StatusCode int
+	body       string
+} {
+	t.Helper()
+
+	var (
+		body        io.Reader
+		contentType string
+	)
+	if payload != nil {
+		buf, err := json.Marshal(payload)
+		require.NoError(t, err)
+		body = bytes.NewReader(buf)
+		contentType = "application/json"
+	} else {
+		body = http.NoBody
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, "http://_"+path, body)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", contentType)
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, "unix", strings.TrimPrefix(socketPath, "unix://"))
+			},
+		},
+	}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	buf, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return struct {
+		StatusCode int
+		body       string
+	}{StatusCode: resp.StatusCode, body: string(buf)}
 }
 
 func startServerWithStore(t *testing.T, ctx context.Context, agentsDir string, store session.Store) string {

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -375,10 +375,26 @@ func (sm *SessionManager) CreateSession(ctx context.Context, sessionTemplate *se
 	return sess, sm.sessionStore.AddSession(ctx, sess)
 }
 
-// ErrForkInvalidMessage is returned when a fork is requested at a message
-// index that does not point at a user-role message (e.g. an assistant turn,
-// a tool response, or a sub-session item).
-var ErrForkInvalidMessage = errors.New("fork point must be a user message")
+// Sentinel errors returned by ForkSession. They are matched with
+// errors.Is by the HTTP handler to classify failures as 400 vs 500, so
+// rewording the error string later is safe — the classification stays
+// pinned to the sentinel rather than to the message text.
+var (
+	// ErrForkInvalidMessage is returned when the resolved fork point is
+	// not a user-role message (e.g. an assistant turn, a tool response,
+	// or a sub-session item).
+	ErrForkInvalidMessage = errors.New("fork point must be a user message")
+
+	// ErrForkOutOfRange is returned when the requested message index is
+	// outside the parent session's visible message list.
+	ErrForkOutOfRange = errors.New("fork message index out of range")
+
+	// ErrForkInSubSession is returned when the requested message index
+	// falls inside a sub-session, where positional forking would be
+	// ambiguous (a sub-session can carry many messages but the fork
+	// model is "stop before this user turn in the parent's timeline").
+	ErrForkInSubSession = errors.New("fork message index falls inside a sub-session")
+)
 
 // ForkSession creates a new session whose history is a deep copy of the
 // parent session up to (but excluding) the message at userMessageIndex, with
@@ -387,10 +403,17 @@ var ErrForkInvalidMessage = errors.New("fork point must be a user message")
 // indexing that api.SessionResponse.Messages exposes to clients — so callers
 // do not need to know about the underlying Item slice.
 //
-// The message at userMessageIndex must be a user message; otherwise
-// ErrForkInvalidMessage is returned. The fork itself does not include that
-// message, so a client can prefill it into its chat input to let the user
-// edit and resubmit.
+// The message at userMessageIndex must be a user-role message in the
+// parent's visible list; values outside `[0, visibleMessageCount)` return
+// ErrForkOutOfRange and non-user messages return ErrForkInvalidMessage.
+// The fork itself does not include that message, so a client can prefill
+// it into its chat input to let the user edit and resubmit.
+//
+// There is intentionally no "full clone" shortcut on this endpoint: every
+// fork must anchor at a real user turn so the resulting history ends
+// cleanly between a user message and its (excluded) follow-up. Callers
+// that need a whole-session duplicate should issue a separate request
+// targeting the index of the most recent user message.
 func (sm *SessionManager) ForkSession(ctx context.Context, sessionID string, userMessageIndex int) (*session.Session, error) {
 	parent, err := sm.sessionStore.GetSession(ctx, sessionID)
 	if err != nil {
@@ -402,11 +425,9 @@ func (sm *SessionManager) ForkSession(ctx context.Context, sessionID string, use
 		return nil, err
 	}
 
-	if itemIndex < len(parent.Messages) {
-		item := parent.Messages[itemIndex]
-		if item.Message == nil || item.Message.Message.Role != chat.MessageRoleUser {
-			return nil, ErrForkInvalidMessage
-		}
+	item := parent.Messages[itemIndex]
+	if item.Message == nil || item.Message.Message.Role != chat.MessageRoleUser {
+		return nil, ErrForkInvalidMessage
 	}
 
 	forked, err := session.ForkSession(parent, itemIndex)
@@ -423,11 +444,12 @@ func (sm *SessionManager) ForkSession(ctx context.Context, sessionID string, use
 // flatMessageIndexToItemIndex maps an index in the flat user-visible message
 // list (Session.GetAllMessages — which skips system messages and flattens
 // sub-sessions) into an index in the parent's Session.Messages Item slice.
-// Returns an error if the index is out of range or lands inside a
-// sub-session, where positional forking would be ambiguous.
+// Returns ErrForkOutOfRange if the index is outside the visible list, or
+// ErrForkInSubSession if the index lands inside a sub-session, where
+// positional forking would be ambiguous.
 func flatMessageIndexToItemIndex(s *session.Session, flatIdx int) (int, error) {
 	if flatIdx < 0 {
-		return 0, fmt.Errorf("message index %d out of range", flatIdx)
+		return 0, fmt.Errorf("%w: %d", ErrForkOutOfRange, flatIdx)
 	}
 	seen := 0
 	for i, item := range s.Messages {
@@ -445,16 +467,16 @@ func flatMessageIndexToItemIndex(s *session.Session, flatIdx int) (int, error) {
 		case item.IsSubSession():
 			subCount := len(item.SubSession.GetAllMessages())
 			if flatIdx-seen < subCount {
-				return 0, fmt.Errorf("cannot fork at message index %d: position falls inside a sub-session", flatIdx)
+				return 0, fmt.Errorf("%w at index %d", ErrForkInSubSession, flatIdx)
 			}
 			seen += subCount
 		}
 	}
-	// Allow flatIdx == seen, meaning "after the last message" — a full clone.
-	if flatIdx == seen {
-		return len(s.Messages), nil
-	}
-	return 0, fmt.Errorf("message index %d out of range", flatIdx)
+	// flatIdx must point at an existing visible message. Values at or
+	// past the end (including the "after the last message" full-clone
+	// shortcut that earlier revisions allowed) are now rejected so the
+	// user-role check in ForkSession can never be skipped.
+	return 0, fmt.Errorf("%w: %d", ErrForkOutOfRange, flatIdx)
 }
 
 // GetSessions retrieves all sessions.

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -19,6 +19,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/docker/docker-agent/pkg/api"
+	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/concurrent"
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/runtime"
@@ -372,6 +373,88 @@ func (sm *SessionManager) CreateSession(ctx context.Context, sessionTemplate *se
 	}
 
 	return sess, sm.sessionStore.AddSession(ctx, sess)
+}
+
+// ErrForkInvalidMessage is returned when a fork is requested at a message
+// index that does not point at a user-role message (e.g. an assistant turn,
+// a tool response, or a sub-session item).
+var ErrForkInvalidMessage = errors.New("fork point must be a user message")
+
+// ForkSession creates a new session whose history is a deep copy of the
+// parent session up to (but excluding) the message at userMessageIndex, with
+// a fork-numbered title ("<parent> (fork N)"). The index refers to the flat,
+// user-visible message list returned by Session.GetAllMessages — the same
+// indexing that api.SessionResponse.Messages exposes to clients — so callers
+// do not need to know about the underlying Item slice.
+//
+// The message at userMessageIndex must be a user message; otherwise
+// ErrForkInvalidMessage is returned. The fork itself does not include that
+// message, so a client can prefill it into its chat input to let the user
+// edit and resubmit.
+func (sm *SessionManager) ForkSession(ctx context.Context, sessionID string, userMessageIndex int) (*session.Session, error) {
+	parent, err := sm.sessionStore.GetSession(ctx, sessionID)
+	if err != nil {
+		return nil, err
+	}
+
+	itemIndex, err := flatMessageIndexToItemIndex(parent, userMessageIndex)
+	if err != nil {
+		return nil, err
+	}
+
+	if itemIndex < len(parent.Messages) {
+		item := parent.Messages[itemIndex]
+		if item.Message == nil || item.Message.Message.Role != chat.MessageRoleUser {
+			return nil, ErrForkInvalidMessage
+		}
+	}
+
+	forked, err := session.ForkSession(parent, itemIndex)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := sm.sessionStore.AddSession(ctx, forked); err != nil {
+		return nil, err
+	}
+	return forked, nil
+}
+
+// flatMessageIndexToItemIndex maps an index in the flat user-visible message
+// list (Session.GetAllMessages — which skips system messages and flattens
+// sub-sessions) into an index in the parent's Session.Messages Item slice.
+// Returns an error if the index is out of range or lands inside a
+// sub-session, where positional forking would be ambiguous.
+func flatMessageIndexToItemIndex(s *session.Session, flatIdx int) (int, error) {
+	if flatIdx < 0 {
+		return 0, fmt.Errorf("message index %d out of range", flatIdx)
+	}
+	seen := 0
+	for i, item := range s.Messages {
+		switch {
+		case item.IsMessage():
+			// GetAllMessages filters out system messages; mirror that here
+			// so the flat index lines up with what the client sees.
+			if item.Message.Message.Role == chat.MessageRoleSystem {
+				continue
+			}
+			if seen == flatIdx {
+				return i, nil
+			}
+			seen++
+		case item.IsSubSession():
+			subCount := len(item.SubSession.GetAllMessages())
+			if flatIdx-seen < subCount {
+				return 0, fmt.Errorf("cannot fork at message index %d: position falls inside a sub-session", flatIdx)
+			}
+			seen += subCount
+		}
+	}
+	// Allow flatIdx == seen, meaning "after the last message" — a full clone.
+	if flatIdx == seen {
+		return len(s.Messages), nil
+	}
+	return 0, fmt.Errorf("message index %d out of range", flatIdx)
 }
 
 // GetSessions retrieves all sessions.

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -414,7 +414,16 @@ var (
 // cleanly between a user message and its (excluded) follow-up. Callers
 // that need a whole-session duplicate should issue a separate request
 // targeting the index of the most recent user message.
+//
+// The read-then-write of the session store is serialised under sm.mux to
+// match the rest of the manager's mutating methods (DeleteSession,
+// RunSession, etc.). Without it, two concurrent fork requests on the
+// same parent would each see Title="foo", both compute "foo (fork 1)",
+// and produce two distinct sessions with the same auto-numbered title.
 func (sm *SessionManager) ForkSession(ctx context.Context, sessionID string, userMessageIndex int) (*session.Session, error) {
+	sm.mux.Lock()
+	defer sm.mux.Unlock()
+
 	parent, err := sm.sessionStore.GetSession(ctx, sessionID)
 	if err != nil {
 		return nil, err

--- a/pkg/server/session_manager_test.go
+++ b/pkg/server/session_manager_test.go
@@ -439,8 +439,10 @@ func TestForkSession_RejectsNonUserMessage(t *testing.T) {
 }
 
 // TestForkSession_OutOfRange covers the validation boundary: a negative
-// index, or one past the end of the message list when not used as a full
-// clone, must fail without touching the store.
+// index, an index past the end of the visible message list, and the
+// "after the last message" position must all fail with ErrForkOutOfRange
+// without touching the store. The end-of-list case is the regression
+// guard for the dropped full-clone shortcut.
 func TestForkSession_OutOfRange(t *testing.T) {
 	t.Parallel()
 
@@ -453,12 +455,15 @@ func TestForkSession_OutOfRange(t *testing.T) {
 	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
 
 	_, err := sm.ForkSession(ctx, parent.ID, -1)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "out of range")
+	require.ErrorIs(t, err, ErrForkOutOfRange)
 
 	_, err = sm.ForkSession(ctx, parent.ID, 5)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "out of range")
+	require.ErrorIs(t, err, ErrForkOutOfRange)
+
+	// Equal to the visible-message count: previously a silent full clone,
+	// now an explicit ErrForkOutOfRange so the role check can't be bypassed.
+	_, err = sm.ForkSession(ctx, parent.ID, 1)
+	require.ErrorIs(t, err, ErrForkOutOfRange)
 }
 
 // TestForkSession_DeepCopyIsolatesParent verifies that mutating the
@@ -515,14 +520,16 @@ func TestFlatMessageIndexToItemIndex(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 2, idx, "flat index 1 must skip past the system item")
 
-	// End-of-history (full clone) is allowed.
-	idx, err = flatMessageIndexToItemIndex(sess, 2)
-	require.NoError(t, err)
-	assert.Equal(t, len(sess.Messages), idx)
+	// Past the end is rejected, including the "after the last message"
+	// position that earlier revisions accepted as a full-clone shortcut.
+	// Forks must anchor on a real user turn so the role validation in
+	// ForkSession is never bypassed.
+	_, err = flatMessageIndexToItemIndex(sess, 2)
+	require.ErrorIs(t, err, ErrForkOutOfRange)
 
 	_, err = flatMessageIndexToItemIndex(sess, -1)
-	require.Error(t, err)
+	require.ErrorIs(t, err, ErrForkOutOfRange)
 
 	_, err = flatMessageIndexToItemIndex(sess, 3)
-	require.Error(t, err)
+	require.ErrorIs(t, err, ErrForkOutOfRange)
 }

--- a/pkg/server/session_manager_test.go
+++ b/pkg/server/session_manager_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/api"
+	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/concurrent"
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/runtime"
@@ -364,4 +365,164 @@ func TestFollowUpSession_IdempotencyKeyDedupes(t *testing.T) {
 
 	assert.Equal(t, []string{"once", "again"}, fake.followUpContents(),
 		"the deduplicated follow-up must be delivered exactly once")
+}
+
+// TestForkSession_CopiesHistoryBeforeUserMessage exercises the happy path:
+// forking at the second user message keeps the first user/assistant pair
+// and drops everything from the fork point onwards.
+func TestForkSession_CopiesHistoryBeforeUserMessage(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := session.NewInMemorySessionStore()
+	parent := session.New()
+	parent.Title = "Parent Title"
+	parent.Messages = []session.Item{
+		session.NewMessageItem(session.UserMessage("first user")),
+		session.NewMessageItem(session.NewAgentMessage("root", &chat.Message{
+			Role:    chat.MessageRoleAssistant,
+			Content: "first answer",
+		})),
+		session.NewMessageItem(session.UserMessage("second user")),
+		session.NewMessageItem(session.NewAgentMessage("root", &chat.Message{
+			Role:    chat.MessageRoleAssistant,
+			Content: "second answer",
+		})),
+	}
+	require.NoError(t, store.AddSession(ctx, parent))
+
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+
+	// Fork BEFORE the second user message (flat index 2).
+	forked, err := sm.ForkSession(ctx, parent.ID, 2)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, parent.ID, forked.ID, "fork must have a fresh session ID")
+	assert.Equal(t, "Parent Title (fork 1)", forked.Title)
+
+	msgs := forked.GetAllMessages()
+	require.Len(t, msgs, 2, "fork must contain only the user/assistant pair before the cut point")
+	assert.Equal(t, "first user", msgs[0].Message.Content)
+	assert.Equal(t, "first answer", msgs[1].Message.Content)
+
+	// The forked session must be persisted and retrievable.
+	loaded, err := store.GetSession(ctx, forked.ID)
+	require.NoError(t, err)
+	assert.Equal(t, forked.ID, loaded.ID)
+}
+
+// TestForkSession_RejectsNonUserMessage pins the contract that fork is
+// only valid at a user-role message. Attempting to fork at an assistant
+// turn must fail with ErrForkInvalidMessage, regardless of where the
+// index points in the flat list.
+func TestForkSession_RejectsNonUserMessage(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := session.NewInMemorySessionStore()
+	parent := session.New()
+	parent.Messages = []session.Item{
+		session.NewMessageItem(session.UserMessage("hello")),
+		session.NewMessageItem(session.NewAgentMessage("root", &chat.Message{
+			Role:    chat.MessageRoleAssistant,
+			Content: "hi",
+		})),
+	}
+	require.NoError(t, store.AddSession(ctx, parent))
+
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+
+	// Index 1 points at the assistant message in the flat list — must be
+	// rejected even though the position is otherwise valid.
+	_, err := sm.ForkSession(ctx, parent.ID, 1)
+	require.ErrorIs(t, err, ErrForkInvalidMessage)
+}
+
+// TestForkSession_OutOfRange covers the validation boundary: a negative
+// index, or one past the end of the message list when not used as a full
+// clone, must fail without touching the store.
+func TestForkSession_OutOfRange(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := session.NewInMemorySessionStore()
+	parent := session.New()
+	parent.Messages = []session.Item{session.NewMessageItem(session.UserMessage("hello"))}
+	require.NoError(t, store.AddSession(ctx, parent))
+
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+
+	_, err := sm.ForkSession(ctx, parent.ID, -1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "out of range")
+
+	_, err = sm.ForkSession(ctx, parent.ID, 5)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "out of range")
+}
+
+// TestForkSession_DeepCopyIsolatesParent verifies that mutating the
+// forked session's messages does not leak back into the parent: this is
+// the property that makes a fork safe to edit independently.
+func TestForkSession_DeepCopyIsolatesParent(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := session.NewInMemorySessionStore()
+	parent := session.New()
+	parent.Messages = []session.Item{
+		session.NewMessageItem(session.UserMessage("original")),
+		session.NewMessageItem(session.UserMessage("next")),
+	}
+	require.NoError(t, store.AddSession(ctx, parent))
+
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+
+	forked, err := sm.ForkSession(ctx, parent.ID, 1)
+	require.NoError(t, err)
+	require.Len(t, forked.Messages, 1)
+
+	forked.Messages[0].Message.Message.Content = "mutated"
+
+	parentReloaded, err := store.GetSession(ctx, parent.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "original", parentReloaded.Messages[0].Message.Message.Content,
+		"mutating the fork must not affect the parent")
+}
+
+// TestFlatMessageIndexToItemIndex covers the index translation helper in
+// isolation, including the system-message skip rule that mirrors
+// Session.GetAllMessages.
+func TestFlatMessageIndexToItemIndex(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	// Items: [user(0), system(skipped), user(1)]. From a client's
+	// perspective the flat indexing is 0 → user "u1", 1 → user "u2".
+	sess.Messages = []session.Item{
+		session.NewMessageItem(session.UserMessage("u1")),
+		session.NewMessageItem(&session.Message{
+			Message: chat.Message{Role: chat.MessageRoleSystem, Content: "sys"},
+		}),
+		session.NewMessageItem(session.UserMessage("u2")),
+	}
+
+	idx, err := flatMessageIndexToItemIndex(sess, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 0, idx)
+
+	idx, err = flatMessageIndexToItemIndex(sess, 1)
+	require.NoError(t, err)
+	assert.Equal(t, 2, idx, "flat index 1 must skip past the system item")
+
+	// End-of-history (full clone) is allowed.
+	idx, err = flatMessageIndexToItemIndex(sess, 2)
+	require.NoError(t, err)
+	assert.Equal(t, len(sess.Messages), idx)
+
+	_, err = flatMessageIndexToItemIndex(sess, -1)
+	require.Error(t, err)
+
+	_, err = flatMessageIndexToItemIndex(sess, 3)
+	require.Error(t, err)
 }

--- a/pkg/session/branch.go
+++ b/pkg/session/branch.go
@@ -4,11 +4,19 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"regexp"
 	"slices"
 	"strings"
 
 	"github.com/docker/docker-agent/pkg/chat"
 )
+
+// forkSuffixRe matches a "(fork N)" trailing suffix on a session title,
+// with optional leading whitespace before the parenthesis. Anchored at
+// the end of the string so mid-title occurrences of "(fork N)" (e.g.
+// in a user-chosen title like "Q1 (fork 2) Analysis") are not detected
+// as a suffix and the trailing content is not silently dropped.
+var forkSuffixRe = regexp.MustCompile(`^(.*?)[ \t]*\(fork (\d+)\)$`)
 
 // BranchSession creates a new session branched from the parent at the given position.
 // Messages up to (but not including) branchAtPosition are deep-cloned into the new session.
@@ -207,16 +215,21 @@ func generateBranchTitle(parentTitle string) string {
 // title using "(fork N)" suffixes that increment on repeated forks.
 // If the parent has no title, returns empty string (will trigger auto-generation).
 // "<title>" -> "<title> (fork 1)"; "<title> (fork N)" -> "<title> (fork N+1)".
+//
+// The "(fork N)" detection is anchored at the end of the title so a mid-title
+// occurrence (e.g. "Q1 (fork 2) Analysis") is not treated as a suffix.
+// generateBranchTitle uses an older LastIndex+Sscanf approach that has the
+// same end-anchoring gap; that's a pre-existing issue in the TUI's branch
+// flow and is intentionally left alone here.
 func generateForkTitle(parentTitle string) string {
 	if parentTitle == "" {
 		return ""
 	}
 
-	if idx := strings.LastIndex(parentTitle, "(fork "); idx >= 0 {
-		suffix := parentTitle[idx:]
+	if m := forkSuffixRe.FindStringSubmatch(parentTitle); m != nil {
+		baseTitle := m[1]
 		var n int
-		if _, err := fmt.Sscanf(suffix, "(fork %d)", &n); err == nil && n >= 1 {
-			baseTitle := strings.TrimRight(parentTitle[:idx], " \t")
+		if _, err := fmt.Sscanf(m[2], "%d", &n); err == nil && n >= 1 {
 			return fmt.Sprintf("%s (fork %d)", baseTitle, n+1)
 		}
 	}

--- a/pkg/session/branch.go
+++ b/pkg/session/branch.go
@@ -13,6 +13,18 @@ import (
 // BranchSession creates a new session branched from the parent at the given position.
 // Messages up to (but not including) branchAtPosition are deep-cloned into the new session.
 func BranchSession(parent *Session, branchAtPosition int) (*Session, error) {
+	return branchSessionWithTitle(parent, branchAtPosition, generateBranchTitle)
+}
+
+// ForkSession is like BranchSession but uses fork-numbered titles
+// ("<title> (fork 1)", "(fork 2)", …). It is intended for HTTP/API clients
+// that expose a "fork from here" UX distinct from the TUI's branch-from-edit
+// flow, which keeps using BranchSession.
+func ForkSession(parent *Session, branchAtPosition int) (*Session, error) {
+	return branchSessionWithTitle(parent, branchAtPosition, generateForkTitle)
+}
+
+func branchSessionWithTitle(parent *Session, branchAtPosition int, titleFn func(string) string) (*Session, error) {
 	if parent == nil {
 		return nil, errors.New("parent session is nil")
 	}
@@ -21,7 +33,7 @@ func BranchSession(parent *Session, branchAtPosition int) (*Session, error) {
 	}
 
 	branched := New()
-	copySessionMetadata(branched, parent, generateBranchTitle(parent.Title))
+	copySessionMetadata(branched, parent, titleFn(parent.Title))
 
 	branched.Messages = make([]Item, 0, branchAtPosition)
 	for i := range branchAtPosition {
@@ -189,6 +201,27 @@ func generateBranchTitle(parentTitle string) string {
 	}
 
 	return parentTitle + " (branched)"
+}
+
+// generateForkTitle creates a title for a forked session based on the parent
+// title using "(fork N)" suffixes that increment on repeated forks.
+// If the parent has no title, returns empty string (will trigger auto-generation).
+// "<title>" -> "<title> (fork 1)"; "<title> (fork N)" -> "<title> (fork N+1)".
+func generateForkTitle(parentTitle string) string {
+	if parentTitle == "" {
+		return ""
+	}
+
+	if idx := strings.LastIndex(parentTitle, "(fork "); idx >= 0 {
+		suffix := parentTitle[idx:]
+		var n int
+		if _, err := fmt.Sscanf(suffix, "(fork %d)", &n); err == nil && n >= 1 {
+			baseTitle := strings.TrimRight(parentTitle[:idx], " \t")
+			return fmt.Sprintf("%s (fork %d)", baseTitle, n+1)
+		}
+	}
+
+	return parentTitle + " (fork 1)"
 }
 
 func cloneEvalCriteria(src *EvalCriteria) *EvalCriteria {

--- a/pkg/session/branch.go
+++ b/pkg/session/branch.go
@@ -172,6 +172,14 @@ func copySessionMetadata(dst, src *Session, title string) {
 	dst.WorkingDir = src.WorkingDir
 	dst.SendUserMessage = src.SendUserMessage
 	dst.MaxIterations = src.MaxIterations
+	// MaxConsecutiveToolCalls and MaxOldToolCallTokens are safety / context
+	// rails that may be configured deliberately by the user or operator
+	// (consecutive-tool-call cutoff, old-tool-call truncation budget).
+	// Dropping them on a fork or branch would silently make the new
+	// session behave differently from its parent. Clone() preserves both,
+	// so do the same here.
+	dst.MaxConsecutiveToolCalls = src.MaxConsecutiveToolCalls
+	dst.MaxOldToolCallTokens = src.MaxOldToolCallTokens
 	dst.Starred = src.Starred
 	dst.Permissions = clonePermissionsConfig(src.Permissions)
 	dst.AgentModelOverrides = cloneStringMap(src.AgentModelOverrides)

--- a/pkg/session/branch_test.go
+++ b/pkg/session/branch_test.go
@@ -121,6 +121,19 @@ func TestGenerateForkTitle(t *testing.T) {
 			parentTitle: "My Session  (fork 1)",
 			expected:    "My Session (fork 2)",
 		},
+		{
+			// Regression: a user-chosen title containing "(fork N)" anywhere
+			// other than at the end must not be treated as a suffix — the
+			// trailing content has to be preserved.
+			name:        "mid-title (fork N) is not treated as suffix",
+			parentTitle: "Q1 (fork 2) Analysis",
+			expected:    "Q1 (fork 2) Analysis (fork 1)",
+		},
+		{
+			name:        "title ending with ) but not (fork N)) is appended verbatim",
+			parentTitle: "My Session (notes)",
+			expected:    "My Session (notes) (fork 1)",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/session/branch_test.go
+++ b/pkg/session/branch_test.go
@@ -70,6 +70,67 @@ func TestGenerateBranchTitle(t *testing.T) {
 	}
 }
 
+func TestGenerateForkTitle(t *testing.T) {
+	tests := []struct {
+		name        string
+		parentTitle string
+		expected    string
+	}{
+		{
+			name:        "empty title returns empty",
+			parentTitle: "",
+			expected:    "",
+		},
+		{
+			name:        "simple title gets fork 1 suffix",
+			parentTitle: "My Session",
+			expected:    "My Session (fork 1)",
+		},
+		{
+			name:        "fork 1 becomes fork 2",
+			parentTitle: "My Session (fork 1)",
+			expected:    "My Session (fork 2)",
+		},
+		{
+			name:        "fork 2 becomes fork 3",
+			parentTitle: "My Session (fork 2)",
+			expected:    "My Session (fork 3)",
+		},
+		{
+			name:        "fork 99 becomes fork 100",
+			parentTitle: "My Session (fork 99)",
+			expected:    "My Session (fork 100)",
+		},
+		{
+			name:        "title with fork in middle is treated as simple title",
+			parentTitle: "fork analysis session",
+			expected:    "fork analysis session (fork 1)",
+		},
+		{
+			name:        "title ending with (fork but no number treated as simple",
+			parentTitle: "My Session (fork",
+			expected:    "My Session (fork (fork 1)",
+		},
+		{
+			name:        "branched title is treated as a simple title (separate series)",
+			parentTitle: "My Session (branched)",
+			expected:    "My Session (branched) (fork 1)",
+		},
+		{
+			name:        "trims whitespace before suffix",
+			parentTitle: "My Session  (fork 1)",
+			expected:    "My Session (fork 2)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := generateForkTitle(tt.parentTitle)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestCloneSessionItem(t *testing.T) {
 	t.Run("empty item returns error", func(t *testing.T) {
 		_, err := cloneSessionItem(Item{})
@@ -188,5 +249,63 @@ func TestBranchSession(t *testing.T) {
 		assert.Equal(t, "/tmp/parent.txt", parentParts[1].File.Path, "File must be deep-copied")
 		assert.Equal(t, "parent.pdf", parentParts[2].Document.Name, "Document must be deep-copied")
 		assert.Equal(t, []byte("parent"), parentParts[2].Document.Source.InlineData, "Document InlineData must be deep-copied")
+	})
+}
+
+func TestForkSession(t *testing.T) {
+	t.Run("nil parent returns error", func(t *testing.T) {
+		_, err := ForkSession(nil, 0)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "parent session is nil")
+	})
+
+	t.Run("out-of-range position returns error", func(t *testing.T) {
+		parent := &Session{Messages: []Item{NewMessageItem(UserMessage("test"))}}
+		_, err := ForkSession(parent, 2)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "out of range")
+	})
+
+	t.Run("copies messages up to position and uses fork-numbered title", func(t *testing.T) {
+		parent := &Session{
+			ID:    "parent-id",
+			Title: "Parent Title",
+			Messages: []Item{
+				NewMessageItem(UserMessage("msg1")),
+				NewMessageItem(UserMessage("msg2")),
+				NewMessageItem(UserMessage("msg3")),
+			},
+		}
+
+		forked, err := ForkSession(parent, 2)
+		require.NoError(t, err)
+		assert.NotEqual(t, parent.ID, forked.ID)
+		assert.Equal(t, "Parent Title (fork 1)", forked.Title)
+		assert.Len(t, forked.Messages, 2)
+		assert.Equal(t, "msg1", forked.Messages[0].Message.Message.Content)
+		assert.Equal(t, "msg2", forked.Messages[1].Message.Message.Content)
+	})
+
+	t.Run("fork of a fork increments the counter", func(t *testing.T) {
+		parent := &Session{
+			Title:    "Parent Title (fork 2)",
+			Messages: []Item{NewMessageItem(UserMessage("hi"))},
+		}
+
+		forked, err := ForkSession(parent, 1)
+		require.NoError(t, err)
+		assert.Equal(t, "Parent Title (fork 3)", forked.Title)
+	})
+
+	t.Run("position zero produces an empty fork", func(t *testing.T) {
+		parent := &Session{
+			Title:    "Parent Title",
+			Messages: []Item{NewMessageItem(UserMessage("only"))},
+		}
+
+		forked, err := ForkSession(parent, 0)
+		require.NoError(t, err)
+		assert.Empty(t, forked.Messages)
+		assert.Equal(t, "Parent Title (fork 1)", forked.Title)
 	})
 }

--- a/pkg/session/branch_test.go
+++ b/pkg/session/branch_test.go
@@ -321,4 +321,25 @@ func TestForkSession(t *testing.T) {
 		assert.Empty(t, forked.Messages)
 		assert.Equal(t, "Parent Title (fork 1)", forked.Title)
 	})
+
+	t.Run("copies safety-rail limits onto the fork", func(t *testing.T) {
+		// Regression: MaxConsecutiveToolCalls / MaxOldToolCallTokens used to
+		// be silently zeroed out, making the fork behave differently from
+		// the parent (tool-call cutoff and old-tool-call truncation budget
+		// would reset to "use built-in default") despite the user having
+		// configured them deliberately.
+		parent := &Session{
+			Title:                   "Parent Title",
+			Messages:                []Item{NewMessageItem(UserMessage("hi"))},
+			MaxIterations:           42,
+			MaxConsecutiveToolCalls: 17,
+			MaxOldToolCallTokens:    9000,
+		}
+
+		forked, err := ForkSession(parent, 1)
+		require.NoError(t, err)
+		assert.Equal(t, 42, forked.MaxIterations)
+		assert.Equal(t, 17, forked.MaxConsecutiveToolCalls)
+		assert.Equal(t, 9000, forked.MaxOldToolCallTokens)
+	})
 }


### PR DESCRIPTION
## Why

Downstream HTTP consumers want to let users branch a conversation from a specific user turn — "rewind to this message and try a different question" — without losing the history that came before. Today the only way to do this over the API is to read out the full message list and `POST /api/sessions` a brand-new session with replayed messages, which is lossy (no metadata carry-over, no shared title lineage) and forces every client to re-implement the deep-copy semantics.

`session.BranchSession` already exists in-tree and is exercised by the TUI for the same purpose, but it isn't reachable over HTTP. This PR exposes it.

## What the endpoint does

```
POST /api/sessions/:id/fork
  body: { "message_index": <int> }
  200:  api.SessionResponse for the new session
  400:  index out of range / not a user message / falls inside a sub-session
  404:  parent session not found
```

`message_index` is a 0-based index into the flat, user-visible message list (the same shape `GET /api/sessions/:id` returns). The fork **excludes** the message at that index, so the new session contains messages `[0, message_index)` of the parent. This lets a client prefill the excluded user message into its own input UI for the user to edit and resubmit.

```
parent.messages:   [u0]──[a0]──[u1]──[a1]──[u2]──[a2]
                                 ▲
                            fork here (message_index = 2)

forked.messages:   [u0]──[a0]
forked.title:      "<parent.title> (fork 1)"  →  "(fork 2)" on repeat forks
```

## Design notes

- **User-message-only fork point.** Branching mid-tool-call would dangle a `tool_use` without its matching `tool_result` in the forked session and break the next provider call. The handler validates the resolved item's role and returns 400 otherwise.
- **Index translation.** `Session.GetAllMessages()` returns a flat list (skipping system messages, flattening sub-sessions) while `BranchSession` expects an index into `Session.Messages` (the `Item` slice). The new handler bridges the two via `flatMessageIndexToItemIndex`, so the API stays stable if `Item` ever grows new variants.
- **Title series kept separate.** `BranchSession`'s callers (the TUI's branch-from-edit + fork-session handlers) keep their `(branched)` / `(branch N)` titles. The new HTTP path uses `(fork N)` so consumers can tell the two flows apart in a sessions list. The two functions share their body via a private `branchSessionWithTitle` helper.
- **No persisted parent link.** Migration 016 once carried `branch_parent_*` columns and migration 019 dropped them. Adding them back is out of scope for this PR — clients that need provenance can stash it in `metadata` for now.

## Notes for reviewers

- The deep-copy path is `session.BranchSession`, which already has regression tests for `MultiContent` pointer aliasing, sub-session cloning, and message ID resets. The new code re-uses that.
- Fields `BranchSession` deliberately does **not** copy (`Cost`, `InputTokens`/`OutputTokens` are recomputed; `MaxConsecutiveToolCalls`/`MaxOldToolCallTokens` are not preserved) are unchanged here — happy to revisit in a follow-up if downstream needs them.
