### PR TITLE
Let embedders register custom tool renderers

### DIFF
--- a/examples/golibrary/renderer/main.go
+++ b/examples/golibrary/renderer/main.go
@@ -1,0 +1,237 @@
+// This example embeds cagent as a library and launches its TUI with a *custom
+// tool renderer applied to an MCP-server tool*.
+//
+// It is fully self-contained: it starts an in-process MCP server (over HTTP via
+// httptest, no subprocess) exposing a "search_repositories" tool with canned
+// data, attaches it to the agent as a remote MCP toolset named "github" — so the
+// tool surfaces as "github_search_repositories" with category "mcp" (see
+// pkg/tools/mcp/mcp.go) — and registers a custom renderer for that exposed name.
+// When the agent calls the MCP tool, the result is drawn as a bordered repo list
+// instead of the generic tool view.
+//
+// The renderer is wired via tui.WithToolRenderers; the key is just the tool's
+// name, so the exact same call styles built-in or Go-SDK tools too. To style
+// every MCP tool at once, register under "category:mcp" instead.
+//
+// Run it (uses a Gemini model, so set GOOGLE_API_KEY):
+//
+//	GOOGLE_API_KEY=... go run ./examples/golibrary/renderer
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/signal"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/app"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/environment"
+	"github.com/docker/docker-agent/pkg/model/provider/gemini"
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/team"
+	"github.com/docker/docker-agent/pkg/tools"
+	mcptools "github.com/docker/docker-agent/pkg/tools/mcp"
+	"github.com/docker/docker-agent/pkg/tui"
+	"github.com/docker/docker-agent/pkg/tui/components/spinner"
+	"github.com/docker/docker-agent/pkg/tui/components/tool"
+	"github.com/docker/docker-agent/pkg/tui/components/toolcommon"
+	"github.com/docker/docker-agent/pkg/tui/core/layout"
+	"github.com/docker/docker-agent/pkg/tui/service"
+	"github.com/docker/docker-agent/pkg/tui/styles"
+	"github.com/docker/docker-agent/pkg/tui/types"
+)
+
+func main() {
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	if err := run(ctx); err != nil {
+		log.Println(err)
+	}
+}
+
+// --- the in-process MCP server -------------------------------------------------
+
+type searchInput struct {
+	Query string `json:"query" jsonschema:"the repository search query"`
+}
+
+type repo struct {
+	Name        string `json:"name"`
+	Stars       int    `json:"stars"`
+	Description string `json:"description"`
+}
+
+type searchOutput struct {
+	Repositories []repo `json:"repositories"`
+}
+
+var repoIndex = []repo{
+	{"docker/cagent", 4200, "Build and run multi-agent systems from simple config"},
+	{"docker/compose", 35000, "Define and run multi-container applications with Docker"},
+	{"moby/moby", 69000, "The Moby Project — a framework to assemble container systems"},
+	{"docker/buildx", 3700, "Docker CLI plugin for extended build capabilities with BuildKit"},
+	{"kubernetes/kubernetes", 112000, "Production-Grade Container Scheduling and Management"},
+}
+
+func searchRepositories(_ context.Context, _ *gomcp.CallToolRequest, in searchInput) (*gomcp.CallToolResult, searchOutput, error) {
+	// Simulate latency so the in-flight custom render ("searching…") is visible.
+	time.Sleep(3 * time.Second)
+
+	q := strings.ToLower(strings.TrimSpace(in.Query))
+	hits := []repo{} // empty (not nil) so no matches marshal as "[]", not "null"
+	for _, r := range repoIndex {
+		if q == "" || strings.Contains(strings.ToLower(r.Name), q) || strings.Contains(strings.ToLower(r.Description), q) {
+			hits = append(hits, r)
+		}
+	}
+	sort.Slice(hits, func(i, j int) bool { return hits[i].Stars > hits[j].Stars })
+
+	// Return the results as TextContent (JSON); cagent surfaces this as the tool
+	// result text, which the custom renderer parses.
+	payload, _ := json.Marshal(hits)
+	return &gomcp.CallToolResult{
+		Content: []gomcp.Content{&gomcp.TextContent{Text: string(payload)}},
+	}, searchOutput{Repositories: hits}, nil
+}
+
+// startMCPServer mounts an in-process MCP server on a local HTTP test server and
+// returns it; the caller connects to its URL and closes it when done.
+func startMCPServer() *httptest.Server {
+	server := gomcp.NewServer(&gomcp.Implementation{Name: "repo-demo", Version: "0.1.0"}, nil)
+	gomcp.AddTool(server, &gomcp.Tool{
+		Name:         "search_repositories",
+		Description:  "Search GitHub-like repositories by keyword. Returns name, stars, and description.",
+		Annotations:  &gomcp.ToolAnnotations{ReadOnlyHint: true},
+		InputSchema:  tools.MustSchemaFor[searchInput](),
+		OutputSchema: tools.MustSchemaFor[searchOutput](),
+	}, searchRepositories)
+
+	handler := gomcp.NewStreamableHTTPHandler(func(*http.Request) *gomcp.Server { return server }, nil)
+	return httptest.NewServer(handler)
+}
+
+// --- the embedded cagent app ---------------------------------------------------
+
+func run(ctx context.Context) error {
+	// cagent logs via slog; discard it so log lines don't paint over the TUI.
+	// (The CLI does the same when --debug is off; pass a file handler instead to
+	// capture logs.)
+	slog.SetDefault(slog.New(slog.DiscardHandler))
+
+	mcpHTTP := startMCPServer()
+	defer mcpHTTP.Close()
+
+	// Attach the in-process MCP server as a remote toolset named "github". Its
+	// "search_repositories" tool is therefore exposed as "github_search_repositories".
+	githubTools := mcptools.NewRemoteToolset("github", mcpHTTP.URL, "streamable", nil, nil)
+
+	llm, err := gemini.NewClient(ctx, &latest.ModelConfig{
+		Provider: "google",
+		Model:    "gemini-2.5-flash",
+	}, environment.NewDefaultProvider())
+	if err != nil {
+		return err
+	}
+
+	assistant := agent.New(
+		"root",
+		"You help users find GitHub repositories. Whenever the user asks to find, "+
+			"search, or list repositories, call the github_search_repositories tool "+
+			"with a short keyword query. Always use the tool rather than answering "+
+			"from memory, then summarize the top result in one sentence.",
+		agent.WithModel(llm),
+		agent.WithToolSets(githubTools),
+	)
+
+	t := team.New(team.WithAgents(assistant))
+	defer func() { _ = t.StopToolSets(ctx) }()
+
+	rt, err := runtime.New(t)
+	if err != nil {
+		return err
+	}
+
+	// Send a first message so the MCP tool is called (and the custom renderer
+	// shown) on launch; auto-approve tools so the call runs without a prompt. A
+	// fixed title avoids the auto-titler.
+	const firstMessage = "Find docker repositories"
+	sess := session.New(
+		session.WithTitle("Repository search demo"),
+		session.WithToolsApproved(true),
+	)
+	a := app.New(ctx, rt, sess, app.WithFirstMessage(firstMessage))
+
+	// The one line that matters: a custom renderer for the MCP tool.
+	wd, _ := os.Getwd()
+	model := tui.New(ctx, nil, a, wd, func() {}, tui.WithToolRenderers(map[string]tool.Builder{
+		"github_search_repositories": newRepoRenderer,
+	}))
+
+	p := tea.NewProgram(model, tea.WithContext(ctx))
+	if m, ok := model.(interface{ SetProgram(p *tea.Program) }); ok {
+		m.SetProgram(p)
+	}
+	_, err = p.Run()
+	return err
+}
+
+// --- the custom renderer -------------------------------------------------------
+
+func newRepoRenderer(msg *types.Message, ss service.SessionStateReader) layout.Model {
+	return toolcommon.NewBase(msg, ss, renderRepoSearch)
+}
+
+func renderRepoSearch(msg *types.Message, _ spinner.Spinner, _ service.SessionStateReader, width, _ int) string {
+	var args searchInput
+	_ = json.Unmarshal([]byte(msg.ToolCall.Function.Arguments), &args)
+
+	title := lipgloss.NewStyle().Bold(true).Foreground(styles.Accent).
+		Render("⌬ GitHub repository search  ·  custom MCP renderer")
+	sub := styles.MutedStyle.Render("query: ") + lipgloss.NewStyle().Bold(true).Render(args.Query)
+
+	var body string
+	switch msg.Content {
+	case "":
+		body = styles.MutedStyle.Render("searching…")
+	default:
+		var repos []repo
+		switch err := json.Unmarshal([]byte(msg.Content), &repos); {
+		case err != nil:
+			body = msg.Content // not JSON — show raw
+		case len(repos) == 0:
+			body = styles.MutedStyle.Render("no repositories found")
+		default:
+			var b strings.Builder
+			for _, r := range repos {
+				stars := lipgloss.NewStyle().Foreground(styles.Warning).Render(fmt.Sprintf("★ %d", r.Stars))
+				name := lipgloss.NewStyle().Bold(true).Foreground(styles.Highlight).Render(r.Name)
+				fmt.Fprintf(&b, "%s  %s\n  %s\n", name, stars, styles.MutedStyle.Render(r.Description))
+			}
+			body = strings.TrimRight(b.String(), "\n")
+		}
+	}
+
+	box := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(styles.Accent).
+		Padding(0, 1).
+		Width(max(width-4, 24))
+	return box.Render(title + "\n" + sub + "\n\n" + body)
+}

--- a/examples/golibrary/renderer/main_test.go
+++ b/examples/golibrary/renderer/main_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/tools"
+	mcptools "github.com/docker/docker-agent/pkg/tools/mcp"
+)
+
+func TestEmbeddedMCPExposesPrefixedTool(t *testing.T) {
+	ctx := t.Context()
+	srv := startMCPServer()
+	defer srv.Close()
+
+	ts := tools.NewStartable(mcptools.NewRemoteToolset("github", srv.URL, "streamable", nil, nil))
+	require.NoError(t, ts.Start(ctx))
+	defer func() { _ = ts.Stop(ctx) }()
+
+	got, err := ts.Tools(ctx)
+	require.NoError(t, err)
+
+	var names []string
+	for _, tl := range got {
+		names = append(names, tl.Name)
+	}
+	assert.Contains(t, names, "github_search_repositories")
+}

--- a/pkg/tui/components/tool/factory.go
+++ b/pkg/tui/components/tool/factory.go
@@ -6,6 +6,8 @@
 package tool
 
 import (
+	"sync"
+
 	"github.com/docker/docker-agent/pkg/tools/builtin/fetch"
 	"github.com/docker/docker-agent/pkg/tools/builtin/filesystem"
 	handofftool "github.com/docker/docker-agent/pkg/tools/builtin/handoff"
@@ -32,12 +34,13 @@ import (
 	"github.com/docker/docker-agent/pkg/tui/types"
 )
 
-// builder constructs the layout.Model for a tool message.
-type builder func(msg *types.Message, sessionState service.SessionStateReader) layout.Model
+// Builder constructs the layout.Model for a tool message. Embedders implement
+// this to provide a custom view for a tool and register it via Register.
+type Builder = func(msg *types.Message, sessionState service.SessionStateReader) layout.Model
 
 // builders maps a tool name (or a "category:<name>" key) to its renderer.
 // Tools sharing the same visual representation point at the same builder.
-var builders = map[string]builder{
+var builders = map[string]Builder{
 	transfertasktool.ToolNameTransferTask: transfertask.New,
 	handofftool.ToolNameHandoff:           handoff.New,
 	filesystem.ToolNameEditFile:           editfile.New,
@@ -57,14 +60,49 @@ var builders = map[string]builder{
 	todo.ToolNameListTodos:                todotool.New,
 }
 
+// custom holds renderers registered by embedders via Register. They are
+// consulted before the built-in builders, so an embedder can override a
+// built-in tool's view as well as render tools cagent has no view for.
+var (
+	customMu sync.RWMutex
+	custom   = map[string]Builder{}
+)
+
+// Register installs a custom renderer for the given key, which is a tool name
+// (e.g. "add") or a "category:<name>" key (e.g. "category:compute"). Registering
+// a key that already exists replaces the previous renderer. Registered renderers
+// take precedence over the built-in ones.
+//
+// Register is safe for concurrent use, but is normally called once at startup
+// (e.g. via tui.WithToolRenderers) before the TUI begins rendering.
+func Register(key string, b Builder) {
+	customMu.Lock()
+	defer customMu.Unlock()
+	custom[key] = b
+}
+
+// resolve returns the renderer for key, preferring a registered custom renderer
+// over the built-in one.
+func resolve(key string) (Builder, bool) {
+	customMu.RLock()
+	b, ok := custom[key]
+	customMu.RUnlock()
+	if ok {
+		return b, true
+	}
+	b, ok = builders[key]
+	return b, ok
+}
+
 // New returns the appropriate tool view for the given message.
 // Lookup order: exact tool name, then "category:<category>", then default.
+// At each tier a registered custom renderer wins over the built-in one.
 func New(msg *types.Message, sessionState service.SessionStateReader) layout.Model {
-	if b, ok := builders[msg.ToolCall.Function.Name]; ok {
+	if b, ok := resolve(msg.ToolCall.Function.Name); ok {
 		return b(msg, sessionState)
 	}
 	if cat := msg.ToolDefinition.Category; cat != "" {
-		if b, ok := builders["category:"+cat]; ok {
+		if b, ok := resolve("category:" + cat); ok {
 			return b(msg, sessionState)
 		}
 	}

--- a/pkg/tui/components/tool/factory_test.go
+++ b/pkg/tui/components/tool/factory_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/docker/docker-agent/pkg/tools"
 	"github.com/docker/docker-agent/pkg/tools/builtin/filesystem"
 	shelltool "github.com/docker/docker-agent/pkg/tools/builtin/shell"
 	"github.com/docker/docker-agent/pkg/tui/core/layout"
@@ -12,9 +13,10 @@ import (
 	"github.com/docker/docker-agent/pkg/tui/types"
 )
 
-func TestRegisterAndResolve(t *testing.T) {
-	// Snapshot and restore the package-global custom registry so the test does
-	// not leak registrations into other tests.
+// withCleanToolRegistry snapshots the package-global custom renderer registry and
+// restores it when the test finishes, so Register calls don't leak across tests.
+func withCleanToolRegistry(t *testing.T) {
+	t.Helper()
 	customMu.Lock()
 	saved := custom
 	custom = map[string]Builder{}
@@ -24,6 +26,10 @@ func TestRegisterAndResolve(t *testing.T) {
 		custom = saved
 		customMu.Unlock()
 	})
+}
+
+func TestRegisterAndResolve(t *testing.T) {
+	withCleanToolRegistry(t)
 
 	// Unknown, unregistered key resolves to nothing.
 	_, ok := resolve("add")
@@ -54,4 +60,67 @@ func TestRegisterAndResolve(t *testing.T) {
 	// A built-in with no custom override still resolves to its built-in renderer.
 	_, ok = resolve(filesystem.ToolNameReadFile)
 	assert.True(t, ok)
+}
+
+// TestNew_Dispatch verifies New()'s renderer selection: a registered renderer is
+// chosen by exact tool name first, then by "category:<category>", with the exact
+// name winning when both match, and an unregistered tool falling through to the
+// default. The factory is origin-agnostic — it keys only on the tool-call name
+// and category — so this holds for built-in, Go-SDK, and MCP tools alike. (For an
+// end-to-end custom renderer over a real MCP tool, see examples/golibrary/renderer.)
+func TestNew_Dispatch(t *testing.T) {
+	ss := service.StaticSessionState{}
+
+	newMsg := func() *types.Message {
+		return &types.Message{
+			ToolCall:       tools.ToolCall{Function: tools.FunctionCall{Name: "weather_report"}},
+			ToolDefinition: tools.Tool{Name: "weather_report", Category: "external"},
+		}
+	}
+
+	t.Run("by exact tool name", func(t *testing.T) {
+		withCleanToolRegistry(t)
+		called := false
+		Register("weather_report", func(*types.Message, service.SessionStateReader) layout.Model {
+			called = true
+			return nil
+		})
+		New(newMsg(), ss)
+		assert.True(t, called, "renderer registered under the exact tool name should be selected")
+	})
+
+	t.Run("by category", func(t *testing.T) {
+		withCleanToolRegistry(t)
+		called := false
+		Register("category:external", func(*types.Message, service.SessionStateReader) layout.Model {
+			called = true
+			return nil
+		})
+		New(newMsg(), ss)
+		assert.True(t, called, "a category renderer should match any tool in that category")
+	})
+
+	t.Run("exact name wins over category", func(t *testing.T) {
+		withCleanToolRegistry(t)
+		exactCalled, categoryCalled := false, false
+		Register("weather_report", func(*types.Message, service.SessionStateReader) layout.Model {
+			exactCalled = true
+			return nil
+		})
+		Register("category:external", func(*types.Message, service.SessionStateReader) layout.Model {
+			categoryCalled = true
+			return nil
+		})
+		New(newMsg(), ss)
+		assert.True(t, exactCalled, "exact-name renderer should take precedence")
+		assert.False(t, categoryCalled, "category renderer should not run when an exact-name match exists")
+	})
+
+	t.Run("unregistered tool falls through to default", func(t *testing.T) {
+		withCleanToolRegistry(t)
+		_, byName := resolve("weather_report")
+		_, byCategory := resolve("category:external")
+		assert.False(t, byName, "no per-tool renderer registered")
+		assert.False(t, byCategory, "no category renderer registered")
+	})
 }

--- a/pkg/tui/components/tool/factory_test.go
+++ b/pkg/tui/components/tool/factory_test.go
@@ -1,0 +1,57 @@
+package tool
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/docker/docker-agent/pkg/tools/builtin/filesystem"
+	shelltool "github.com/docker/docker-agent/pkg/tools/builtin/shell"
+	"github.com/docker/docker-agent/pkg/tui/core/layout"
+	"github.com/docker/docker-agent/pkg/tui/service"
+	"github.com/docker/docker-agent/pkg/tui/types"
+)
+
+func TestRegisterAndResolve(t *testing.T) {
+	// Snapshot and restore the package-global custom registry so the test does
+	// not leak registrations into other tests.
+	customMu.Lock()
+	saved := custom
+	custom = map[string]Builder{}
+	customMu.Unlock()
+	t.Cleanup(func() {
+		customMu.Lock()
+		custom = saved
+		customMu.Unlock()
+	})
+
+	// Unknown, unregistered key resolves to nothing.
+	_, ok := resolve("add")
+	assert.False(t, ok)
+
+	// A new tool name resolves to its registered renderer.
+	customCalled := false
+	Register("add", func(*types.Message, service.SessionStateReader) layout.Model {
+		customCalled = true
+		return nil
+	})
+	b, ok := resolve("add")
+	assert.True(t, ok)
+	b(nil, nil)
+	assert.True(t, customCalled)
+
+	// A custom renderer takes precedence over a built-in one for the same key.
+	overrodeBuiltin := false
+	Register(shelltool.ToolNameShell, func(*types.Message, service.SessionStateReader) layout.Model {
+		overrodeBuiltin = true
+		return nil
+	})
+	b, ok = resolve(shelltool.ToolNameShell)
+	assert.True(t, ok)
+	b(nil, nil)
+	assert.True(t, overrodeBuiltin)
+
+	// A built-in with no custom override still resolves to its built-in renderer.
+	_, ok = resolve(filesystem.ToolNameReadFile)
+	assert.True(t, ok)
+}

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -31,6 +31,7 @@ import (
 	"github.com/docker/docker-agent/pkg/tui/components/spinner"
 	"github.com/docker/docker-agent/pkg/tui/components/statusbar"
 	"github.com/docker/docker-agent/pkg/tui/components/tabbar"
+	"github.com/docker/docker-agent/pkg/tui/components/tool"
 	"github.com/docker/docker-agent/pkg/tui/core"
 	"github.com/docker/docker-agent/pkg/tui/dialog"
 	"github.com/docker/docker-agent/pkg/tui/internal/editorname"
@@ -296,6 +297,22 @@ func WithTranscriber(t Transcriber) Option {
 	return func(m *appModel) {
 		if t != nil {
 			m.transcriber = t
+		}
+	}
+}
+
+// WithToolRenderers registers custom tool-call renderers, keyed by tool name
+// (e.g. "add") or a "category:<name>" key (e.g. "category:compute"). Registered
+// renderers take precedence over the built-in ones, letting an embedder customize
+// how specific tools are displayed — e.g. typesetting a calculator's result as
+// math instead of the generic view.
+//
+// See pkg/tui/components/tool for the Builder contract; a renderer is typically
+// a thin wrapper around toolcommon.NewBase.
+func WithToolRenderers(renderers map[string]tool.Builder) Option {
+	return func(*appModel) {
+		for key, b := range renderers {
+			tool.Register(key, b)
 		}
 	}
 }


### PR DESCRIPTION
Adds a public API for embedders to supply custom TUI renderers for tool calls, plus a runnable example.

- `tool.Register` / `tui.WithToolRenderers(map[string]tool.Builder)` — register a renderer keyed by tool name (or `category:<name>`); registered renderers take precedence over the built-ins.
- `examples/golibrary/renderer` — embeds an in-process MCP server and renders its tool with a custom panel.

## Example

A screenshot from the example program, depicting two tool calls, one that has a result and one that is in-progress:

<img width="997" height="880" alt="image" src="https://github.com/user-attachments/assets/e004e246-794e-4aae-b943-2bdfa91aba25" />
