### PR TITLE
chore: migrate cagent-action to docker-agent-action (v2.0.0)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -18,7 +18,7 @@ jobs:
     if: |
       github.event_name == 'issue_comment' ||
       github.event.workflow_run.conclusion == 'success'
-    uses: docker/cagent-action/.github/workflows/review-pr.yml@0498757af1c50b084f763d626f571918cf317509 # v1.5.1
+    uses: docker/docker-agent-action/.github/workflows/review-pr.yml@3c0fa9d282c3f84d08dfd70ab0a28b151d11db70 # v2.0.0
     # Scoped to the job so other jobs in this workflow aren't over-permissioned
     permissions:
       contents: read # Read repository files and PR diffs


### PR DESCRIPTION
## Summary

`docker/cagent-action` has moved to a new repository: `docker/docker-agent-action`.
GitHub Actions `uses:` references must be updated explicitly, so this PR migrates all references and pins them to [v2.0.0](https://github.com/docker/docker-agent-action/releases/tag/v2.0.0).

- **New repository**: `docker/docker-agent-action`
- **Pinned commit**: `3c0fa9d282c3f84d08dfd70ab0a28b151d11db70`
- **Version**: `v2.0.0`

ℹ️ The old `docker/cagent-action` repo remains functional, so there is no deadline — merge whenever convenient. New features and fixes land in the new repo, which is where you'll want to be going forward.

> Auto-generated by the [migrate-consumers](https://github.com/docker/docker-agent-action/actions/runs/27975760101) workflow.