### PR TITLE
feat(tui): configurable keybindings (Shift+Enter / Ctrl+J newline alternative)

### DIFF
--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -220,6 +220,50 @@ Customize session titles to make them more meaningful and easier to find. By def
 
 Press <kbd>Ctrl</kbd>+<kbd>H</kbd> to view the complete list of all available keyboard shortcuts.
 
+### Custom Keybindings
+
+You can remap the shortcuts above by adding a `keybindings` list to the `settings` block of your `~/.config/cagent/config.yaml`. Each entry maps an action to one or more key combinations in [Bubbles key format](https://github.com/charmbracelet/bubbles) (for example `ctrl+q`, `alt+enter`, `f2`). Unlisted actions keep their defaults.
+
+This is the recommended way to replace the `Ctrl+J` newline fallback, which conflicts with common editor/terminal shortcuts (for example inside VS Code).
+
+```yaml
+settings:
+  keybindings:
+    # Insert a newline with Alt+Enter instead of Ctrl+J. Shift+Enter still
+    # works automatically on terminals that report it.
+    - action: "editor_newline"
+      keys: ["alt+enter"]
+    # Allow several keys for one action.
+    - action: "commands"
+      keys: ["f2", "ctrl+k"]
+    - action: "quit"
+      keys: ["ctrl+q"]
+```
+
+**Valid actions:**
+
+| Action                     | Default      | Description                            |
+| -------------------------- | ------------ | -------------------------------------- |
+| `editor_send`              | `enter`      | Send the current message               |
+| `editor_newline`           | `ctrl+j`     | Insert a newline in the input          |
+| `quit`                     | `ctrl+c`     | Quit (opens the exit confirmation)     |
+| `switch_focus`             | `tab`        | Switch focus between panels            |
+| `commands`                 | `ctrl+k`     | Open the command palette               |
+| `help`                     | `ctrl+h`     | Show the help dialog                   |
+| `toggle_yolo`              | `ctrl+y`     | Toggle YOLO mode                       |
+| `toggle_hide_tool_results` | `ctrl+o`     | Toggle hiding tool results             |
+| `cycle_agent`              | `ctrl+s`     | Cycle to the next agent                |
+| `model_picker`             | `ctrl+m`     | Open the model picker                  |
+| `clear_queue`              | `ctrl+x`     | Clear queued messages                  |
+| `suspend`                  | `ctrl+z`     | Suspend the TUI                        |
+| `toggle_sidebar`           | `ctrl+b`     | Toggle the sidebar                     |
+| `edit_external`            | `ctrl+g`     | Edit input in an external editor       |
+| `history_search`           | `ctrl+r`     | Incremental history search             |
+
+`Shift+Enter` for newline is detected from your terminal's capabilities and is always available where supported, independent of `editor_newline`.
+
+Invalid entries are ignored with a warning (visible with `--debug`) so a bad config never breaks the TUI: unknown actions, empty or malformed keys, and keys that would collide with another action are dropped while every other binding keeps working.
+
 ## History Search
 
 Press <kbd>Ctrl</kbd>+<kbd>R</kbd> to enter incremental history search mode. Start typing to filter through your previous inputs. Press <kbd>Enter</kbd> to select a match, or <kbd>Escape</kbd> to cancel.

--- a/pkg/tui/components/editor/editor.go
+++ b/pkg/tui/components/editor/editor.go
@@ -647,19 +647,19 @@ func (e *editor) resetAndSend(content string) tea.Cmd {
 	return core.CmdHandler(messages.SendMsg{Content: content, Attachments: finalAttachments})
 }
 
-// configureNewlineKeybinding sets up the appropriate newline keybinding
-// based on terminal keyboard enhancement support.
+// configureNewlineKeybinding sets up the newline keybinding from the
+// user-configurable EditorNewline binding (ctrl+j by default), layering
+// shift+enter on top whenever the terminal can report it. This keeps the
+// historical defaults intact while letting users replace the ctrl+j fallback
+// that conflicts with common editor/terminal shortcuts (see issue #1626).
 func (e *editor) configureNewlineKeybinding() {
-	// Configure textarea's InsertNewline binding based on terminal capabilities
-	if e.keyboardEnhancementsSupported {
-		// Modern terminals:
-		e.textarea.KeyMap.InsertNewline.SetKeys("shift+enter", "ctrl+j")
-		e.textarea.KeyMap.InsertNewline.SetEnabled(true)
-	} else {
-		// Legacy terminals:
-		e.textarea.KeyMap.InsertNewline.SetKeys("ctrl+j")
-		e.textarea.KeyMap.InsertNewline.SetEnabled(true)
+	// Clone so the textarea's keymap never aliases the cached KeyMap slice.
+	newlineKeys := slices.Clone(core.GetKeys().EditorNewline.Keys())
+	if e.keyboardEnhancementsSupported && !slices.Contains(newlineKeys, "shift+enter") {
+		newlineKeys = append([]string{"shift+enter"}, newlineKeys...)
 	}
+	e.textarea.KeyMap.InsertNewline.SetKeys(newlineKeys...)
+	e.textarea.KeyMap.InsertNewline.SetEnabled(true)
 }
 
 // Update handles messages and updates the component state
@@ -814,11 +814,12 @@ func (e *editor) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 			return e.handleGraphemeBackspace()
 		}
 
-		// Handle send/newline keys:
-		// - Enter: submit current input (if textarea inserted a newline, submit previous buffer).
-		// - Shift+Enter: insert newline when keyboard enhancements are supported.
-		// - Ctrl+J: fallback to insert '\n' when keyboard enhancements are not supported.
-		if msg.String() == "enter" || key.Matches(msg, e.textarea.KeyMap.InsertNewline) {
+		// Handle send/newline keys (both user-configurable, see issue #1626):
+		// - EditorSend (enter by default): submit the current input.
+		// - EditorNewline (ctrl+j by default) / shift+enter: insert a newline,
+		//   handled by the textarea's InsertNewline binding.
+		isSend := key.Matches(msg, core.GetKeys().EditorSend)
+		if isSend || key.Matches(msg, e.textarea.KeyMap.InsertNewline) {
 			if !e.textarea.Focused() {
 				return e, nil
 			}
@@ -829,13 +830,13 @@ func (e *editor) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 			value := e.textarea.Value()
 
 			// If textarea inserted a newline, just refresh and return
-			if value != prev && msg.String() != "enter" {
+			if value != prev && !isSend {
 				e.refreshSuggestion()
 				return e, nil
 			}
 
-			// If plain enter and textarea inserted a newline, submit the previous value
-			if value != prev && msg.String() == "enter" {
+			// If the send key also inserted a newline, submit the previous value
+			if value != prev && isSend {
 				if prev != "" {
 					e.textarea.SetValue(prev)
 					e.textarea.MoveToEnd()
@@ -845,7 +846,7 @@ func (e *editor) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 				return e, nil
 			}
 
-			// Normal enter submit: send current value
+			// Normal send: send current value
 			if value != "" {
 				cmd := e.resetAndSend(value)
 				return e, cmd

--- a/pkg/tui/components/editor/keybinding_test.go
+++ b/pkg/tui/components/editor/keybinding_test.go
@@ -1,0 +1,38 @@
+package editor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/history"
+	"github.com/docker/docker-agent/pkg/tui/core"
+)
+
+// TestConfigureNewlineKeybinding verifies the editor wires its newline keys
+// from the configurable EditorNewline binding and still layers shift+enter on
+// terminals that report keyboard enhancements (issue #1626). Expectations are
+// derived from the resolved config so the test holds whether or not a user has
+// remapped editor_newline.
+func TestConfigureNewlineKeybinding(t *testing.T) {
+	core.ResetKeys()
+	t.Cleanup(core.ResetKeys)
+	want := core.GetKeys().EditorNewline.Keys()
+
+	h, err := history.New(t.TempDir())
+	require.NoError(t, err)
+	e := New(h).(*editor)
+
+	e.keyboardEnhancementsSupported = false
+	e.configureNewlineKeybinding()
+	assert.Equal(t, want, e.textarea.KeyMap.InsertNewline.Keys(),
+		"without keyboard enhancements the newline keys should match the configured binding")
+
+	e.keyboardEnhancementsSupported = true
+	e.configureNewlineKeybinding()
+	got := e.textarea.KeyMap.InsertNewline.Keys()
+	require.NotEmpty(t, got)
+	assert.Equal(t, "shift+enter", got[0], "shift+enter should be offered first on capable terminals")
+	assert.Subset(t, got, want, "configured newline keys must remain available")
+}

--- a/pkg/tui/components/messages/messages.go
+++ b/pkg/tui/components/messages/messages.go
@@ -471,11 +471,14 @@ func (m *model) handleKeyPress(msg tea.KeyPressMsg) (layout.Model, tea.Cmd) {
 			return m, cmd
 		}
 
-		switch msg.Key().Code {
-		case tea.KeyEnter:
-			// Plain Enter commits the edit
+		// The configured send key commits the edit (Enter by default), mirroring
+		// the composer so a remapped editor_send works here too.
+		if key.Matches(msg, core.GetKeys().EditorSend) {
 			cmd := m.commitInlineEdit()
 			return m, cmd
+		}
+
+		switch msg.Key().Code {
 		case tea.KeyEscape:
 			// Esc cancels the edit
 			cmd := m.CancelInlineEdit()
@@ -2030,9 +2033,14 @@ func (m *model) StartInlineEdit(msgIndex, sessionPosition int, content string) t
 	}
 	ta.SetStyles(inlineEditStyle)
 
-	// Configure newline keybinding - use ctrl+j as the safe default
-	// (shift+enter only works on terminals with keyboard enhancements)
-	ta.KeyMap.InsertNewline.SetKeys("shift+enter", "ctrl+j")
+	// Mirror the composer's configurable newline keys (ctrl+j by default),
+	// always offering shift+enter for terminals with keyboard enhancements.
+	// Clone so the keymap never aliases the cached KeyMap slice.
+	newlineKeys := slices.Clone(core.GetKeys().EditorNewline.Keys())
+	if !slices.Contains(newlineKeys, "shift+enter") {
+		newlineKeys = append([]string{"shift+enter"}, newlineKeys...)
+	}
+	ta.KeyMap.InsertNewline.SetKeys(newlineKeys...)
 	ta.KeyMap.InsertNewline.SetEnabled(true)
 
 	m.inlineEditTextarea = ta

--- a/pkg/tui/core/keys.go
+++ b/pkg/tui/core/keys.go
@@ -1,0 +1,298 @@
+package core
+
+import (
+	"log/slog"
+	"sort"
+	"strings"
+	"sync"
+	"unicode"
+
+	"charm.land/bubbles/v2/key"
+
+	"github.com/docker/docker-agent/pkg/userconfig"
+)
+
+// KeyMap contains the keybindings used across the TUI. Bindings are resolved
+// once from DefaultKeyMap() merged with the user's overrides (see GetKeys).
+type KeyMap struct {
+	Quit                  key.Binding
+	SwitchFocus           key.Binding
+	Commands              key.Binding
+	Help                  key.Binding
+	ToggleYolo            key.Binding
+	ToggleHideToolResults key.Binding
+	CycleAgent            key.Binding
+	ModelPicker           key.Binding
+	ClearQueue            key.Binding
+	Suspend               key.Binding
+	ToggleSidebar         key.Binding
+	EditExternal          key.Binding
+	HistorySearch         key.Binding
+
+	// EditorSend submits the editor content. EditorNewline inserts a line
+	// break. These are the input bindings referenced by issue #1626. The
+	// editor additionally offers shift+enter for newline on terminals that
+	// can report it; that is detected at runtime and is not part of the
+	// configurable default.
+	EditorSend    key.Binding
+	EditorNewline key.Binding
+}
+
+var (
+	ckMutex    sync.RWMutex
+	cachedKeys *KeyMap
+)
+
+// keyModifiers are the modifier prefixes Bubbletea emits, in any order.
+var keyModifiers = map[string]bool{
+	"ctrl": true, "alt": true, "shift": true,
+	"meta": true, "hyper": true, "super": true,
+}
+
+// namedKeys are the multi-character key names Bubbletea can emit (function
+// keys fN are handled separately). Validating against this set turns a typo
+// like "entre" or "ctrl+foobar" into an ignored-with-warning entry instead of
+// a silently dead binding that could lock the user out of an action.
+var namedKeys = map[string]bool{
+	"backspace": true, "begin": true, "capslock": true, "comma": true,
+	"delete": true, "div": true, "down": true, "end": true, "enter": true,
+	"equal": true, "esc": true, "find": true, "home": true, "insert": true,
+	"left": true, "menu": true, "minus": true, "mul": true, "mute": true,
+	"numlock": true, "pause": true, "period": true, "pgdown": true,
+	"pgup": true, "plus": true, "printscreen": true, "right": true,
+	"scrolllock": true, "select": true, "sep": true, "space": true,
+	"tab": true, "up": true,
+}
+
+// reservedKeys are bound by the TUI outside the configurable KeyMap (tab bar,
+// agent quick-switch, thinking-level, cancel). Seeding them into the conflict
+// table makes an override onto one of them rejected-with-warning rather than
+// silently shadowed by the built-in handler.
+var reservedKeys = []string{
+	"ctrl+t", "ctrl+w", "ctrl+p", "ctrl+n", // tab bar
+	"shift+tab", // cycle thinking level
+	"esc",       // cancel / dismiss
+	"ctrl+1", "ctrl+2", "ctrl+3", "ctrl+4", "ctrl+5",
+	"ctrl+6", "ctrl+7", "ctrl+8", "ctrl+9", // agent quick-switch
+}
+
+// DefaultKeyMap returns the built-in keybindings used when the user has not
+// overridden them. Newline defaults to ctrl+j only; shift+enter is layered on
+// at runtime by the editor when the terminal supports it.
+func DefaultKeyMap() KeyMap {
+	return KeyMap{
+		Quit:                  key.NewBinding(key.WithKeys("ctrl+c"), key.WithHelp("Ctrl+c", "quit")),
+		SwitchFocus:           key.NewBinding(key.WithKeys("tab"), key.WithHelp("Tab", "switch focus")),
+		Commands:              key.NewBinding(key.WithKeys("ctrl+k"), key.WithHelp("Ctrl+k", "commands")),
+		Help:                  key.NewBinding(key.WithKeys("ctrl+h", "f1", "ctrl+?"), key.WithHelp("Ctrl+h", "help")),
+		ToggleYolo:            key.NewBinding(key.WithKeys("ctrl+y"), key.WithHelp("Ctrl+y", "toggle yolo mode")),
+		ToggleHideToolResults: key.NewBinding(key.WithKeys("ctrl+o"), key.WithHelp("Ctrl+o", "toggle hide tool results")),
+		CycleAgent:            key.NewBinding(key.WithKeys("ctrl+s"), key.WithHelp("Ctrl+s", "cycle agent")),
+		ModelPicker:           key.NewBinding(key.WithKeys("ctrl+m"), key.WithHelp("Ctrl+m", "model picker")),
+		ClearQueue:            key.NewBinding(key.WithKeys("ctrl+x"), key.WithHelp("Ctrl+x", "clear queue")),
+		Suspend:               key.NewBinding(key.WithKeys("ctrl+z"), key.WithHelp("Ctrl+z", "suspend")),
+		ToggleSidebar:         key.NewBinding(key.WithKeys("ctrl+b"), key.WithHelp("Ctrl+b", "toggle sidebar")),
+		EditExternal:          key.NewBinding(key.WithKeys("ctrl+g"), key.WithHelp("Ctrl+g", "edit in external editor")),
+		HistorySearch:         key.NewBinding(key.WithKeys("ctrl+r"), key.WithHelp("Ctrl+r", "history search")),
+		EditorSend:            key.NewBinding(key.WithKeys("enter"), key.WithHelp("Enter", "send message")),
+		EditorNewline:         key.NewBinding(key.WithKeys("ctrl+j"), key.WithHelp("Ctrl+j", "insert newline")),
+	}
+}
+
+// actionEntry links an action name to its binding pointer (inside a working
+// KeyMap) and the human-readable description kept across remaps.
+type actionEntry struct {
+	action  string
+	binding *key.Binding
+	help    string
+}
+
+// actionMapFor lists the remappable actions for a working KeyMap. The slice
+// order also defines conflict-resolution priority: earlier actions keep a
+// contested key, later ones lose it.
+func actionMapFor(keys *KeyMap) []actionEntry {
+	return []actionEntry{
+		{"quit", &keys.Quit, "quit"},
+		{"switch_focus", &keys.SwitchFocus, "switch focus"},
+		{"commands", &keys.Commands, "commands"},
+		{"help", &keys.Help, "help"},
+		{"toggle_yolo", &keys.ToggleYolo, "toggle yolo mode"},
+		{"toggle_hide_tool_results", &keys.ToggleHideToolResults, "toggle hide tool results"},
+		{"cycle_agent", &keys.CycleAgent, "cycle agent"},
+		{"model_picker", &keys.ModelPicker, "model picker"},
+		{"clear_queue", &keys.ClearQueue, "clear queue"},
+		{"suspend", &keys.Suspend, "suspend"},
+		{"toggle_sidebar", &keys.ToggleSidebar, "toggle sidebar"},
+		{"edit_external", &keys.EditExternal, "edit in external editor"},
+		{"history_search", &keys.HistorySearch, "history search"},
+		{"editor_send", &keys.EditorSend, "send message"},
+		{"editor_newline", &keys.EditorNewline, "insert newline"},
+	}
+}
+
+// ValidActions returns the sorted list of action names that can be remapped.
+// Useful for documentation and a future "show active bindings" command.
+func ValidActions() []string {
+	entries := actionMapFor(&KeyMap{})
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.action)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// isFunctionKey reports whether s is a function-key name f1..f63.
+func isFunctionKey(s string) bool {
+	if len(s) < 2 || s[0] != 'f' {
+		return false
+	}
+	n := 0
+	for _, c := range s[1:] {
+		if c < '0' || c > '9' {
+			return false
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n >= 1 && n <= 63
+}
+
+// validateKey reports whether a key string can actually be produced by a key
+// event, so that a typo (e.g. "entre", "ctrl+foobar") is rejected instead of
+// silently replacing an action's working keys. A key is a chain of modifiers
+// joined by "+" ending in a base key that is a single rune, a function key, or
+// a known named key. This is intentionally strict: rejected keys fall back to
+// the action's default with a logged warning, so a bad config never strands
+// the user without a way to send, quit, or insert a newline.
+func validateKey(k string) bool {
+	if k == "" || strings.ContainsAny(k, " \t") {
+		return false
+	}
+	parts := strings.Split(k, "+")
+	for _, m := range parts[:len(parts)-1] {
+		if !keyModifiers[m] {
+			return false
+		}
+	}
+	base := parts[len(parts)-1]
+	if base == "" {
+		return false
+	}
+	if len([]rune(base)) == 1 {
+		return true
+	}
+	return isFunctionKey(base) || namedKeys[base]
+}
+
+// displayKey returns the help-label form of a key string, matching the TUI's
+// convention of capitalizing the leading modifier (e.g. "ctrl+q" -> "Ctrl+q").
+func displayKey(k string) string {
+	if k == "" {
+		return k
+	}
+	r := []rune(k)
+	r[0] = unicode.ToUpper(r[0])
+	return string(r)
+}
+
+// applyUserKeybindings overrides defaults in-place from the user config.
+// boundKeys is seeded with the defaults of every action the user is NOT
+// remapping, so a custom key that collides with another action's default is
+// detected and skipped (not bound to two actions). Intra-config collisions are
+// resolved by config order. Every rejection is logged.
+func applyUserKeybindings(bindings []userconfig.Keybinding, entries []actionEntry) {
+	byAction := make(map[string]actionEntry, len(entries))
+	for _, e := range entries {
+		byAction[e.action] = e
+	}
+
+	overridden := make(map[string]bool)
+	for _, b := range bindings {
+		if _, ok := byAction[b.Action]; ok {
+			overridden[b.Action] = true
+		}
+	}
+
+	boundKeys := make(map[string]string)
+	for _, k := range reservedKeys {
+		boundKeys[k] = "a built-in shortcut"
+	}
+	for _, e := range entries {
+		if overridden[e.action] {
+			continue
+		}
+		for _, k := range e.binding.Keys() {
+			boundKeys[k] = e.action
+		}
+	}
+
+	for _, b := range bindings {
+		e, ok := byAction[b.Action]
+		if !ok {
+			slog.Warn("Ignoring unrecognized keybinding action",
+				"action", b.Action, "valid_actions", strings.Join(ValidActions(), ", "))
+			continue
+		}
+		if len(b.Keys) == 0 {
+			slog.Warn("Ignoring keybinding with no keys", "action", b.Action)
+			continue
+		}
+
+		var validKeys []string
+		for _, raw := range b.Keys {
+			k := strings.TrimSpace(raw)
+			if !validateKey(k) {
+				slog.Warn("Ignoring malformed key", "action", b.Action, "key", raw)
+				continue
+			}
+			if owner, exists := boundKeys[k]; exists && owner != b.Action {
+				slog.Warn("Ignoring conflicting key", "key", k, "action", b.Action, "conflicts_with", owner)
+				continue
+			}
+			boundKeys[k] = b.Action
+			validKeys = append(validKeys, k)
+		}
+
+		if len(validKeys) > 0 {
+			*e.binding = key.NewBinding(key.WithKeys(validKeys...), key.WithHelp(displayKey(validKeys[0]), e.help))
+		}
+	}
+}
+
+// buildKeys merges user config overrides onto the defaults. It is split from
+// GetKeys so it can be unit-tested with arbitrary settings.
+func buildKeys(settings *userconfig.Settings) KeyMap {
+	keys := DefaultKeyMap()
+	if settings != nil && len(settings.Keybindings) > 0 {
+		applyUserKeybindings(settings.Keybindings, actionMapFor(&keys))
+	}
+	return keys
+}
+
+// GetKeys returns the resolved keybindings, merging the user config over the
+// defaults. The result is read from disk once and cached; subsequent calls are
+// lock-cheap so hot paths (key handling, help rendering) stay allocation-free.
+func GetKeys() KeyMap {
+	ckMutex.RLock()
+	k := cachedKeys
+	ckMutex.RUnlock()
+	if k != nil {
+		return *k
+	}
+
+	ckMutex.Lock()
+	defer ckMutex.Unlock()
+	if cachedKeys == nil {
+		built := buildKeys(userconfig.Get())
+		cachedKeys = &built
+	}
+	return *cachedKeys
+}
+
+// ResetKeys clears the cached keybindings so the next GetKeys call rebuilds
+// them. Used by tests and available for a future hot-reload.
+func ResetKeys() {
+	ckMutex.Lock()
+	cachedKeys = nil
+	ckMutex.Unlock()
+}

--- a/pkg/tui/core/keys_test.go
+++ b/pkg/tui/core/keys_test.go
@@ -1,0 +1,183 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/goccy/go-yaml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/userconfig"
+)
+
+func TestBuildKeys_Defaults(t *testing.T) {
+	keys := buildKeys(nil)
+
+	assert.Equal(t, []string{"ctrl+c"}, keys.Quit.Keys())
+	assert.Equal(t, []string{"tab"}, keys.SwitchFocus.Keys())
+	assert.Equal(t, []string{"ctrl+k"}, keys.Commands.Keys())
+	assert.Equal(t, []string{"ctrl+h", "f1", "ctrl+?"}, keys.Help.Keys())
+	assert.Equal(t, []string{"ctrl+r"}, keys.HistorySearch.Keys())
+	assert.Equal(t, []string{"enter"}, keys.EditorSend.Keys())
+	assert.Equal(t, []string{"ctrl+j"}, keys.EditorNewline.Keys())
+}
+
+func TestBuildKeys_Overrides(t *testing.T) {
+	settings := &userconfig.Settings{
+		Keybindings: []userconfig.Keybinding{
+			{Action: "quit", Keys: []string{"ctrl+q"}},
+			{Action: "commands", Keys: []string{"f2", "ctrl+k"}},
+			{Action: "editor_newline", Keys: []string{"alt+enter"}},
+			{Action: "editor_send", Keys: []string{"ctrl+d"}},
+			{Action: "unknown_action", Keys: []string{"ctrl+u"}}, // ignored
+		},
+	}
+
+	keys := buildKeys(settings)
+
+	assert.Equal(t, []string{"ctrl+q"}, keys.Quit.Keys())
+	assert.Equal(t, []string{"f2", "ctrl+k"}, keys.Commands.Keys())
+	assert.Equal(t, []string{"alt+enter"}, keys.EditorNewline.Keys())
+	assert.Equal(t, []string{"ctrl+d"}, keys.EditorSend.Keys())
+
+	// The first override key drives the help label, capitalized for display.
+	assert.Equal(t, "Ctrl+q", keys.Quit.Help().Key)
+
+	// Untouched actions keep their defaults.
+	assert.Equal(t, []string{"tab"}, keys.SwitchFocus.Keys())
+	assert.Equal(t, []string{"ctrl+h", "f1", "ctrl+?"}, keys.Help.Keys())
+}
+
+func TestBuildKeys_EmptySettings(t *testing.T) {
+	keys := buildKeys(&userconfig.Settings{})
+	assert.Equal(t, []string{"ctrl+c"}, keys.Quit.Keys())
+	assert.Equal(t, []string{"enter"}, keys.EditorSend.Keys())
+}
+
+func TestBuildKeys_EmptyKeysIgnored(t *testing.T) {
+	keys := buildKeys(&userconfig.Settings{
+		Keybindings: []userconfig.Keybinding{
+			{Action: "quit", Keys: []string{}},
+		},
+	})
+	assert.Equal(t, []string{"ctrl+c"}, keys.Quit.Keys())
+}
+
+func TestBuildKeys_MalformedKeysIgnored(t *testing.T) {
+	keys := buildKeys(&userconfig.Settings{
+		Keybindings: []userconfig.Keybinding{
+			{Action: "quit", Keys: []string{"ctrl+q", " ", "", "ctrl q"}},
+		},
+	})
+	// Only the well-formed key survives.
+	assert.Equal(t, []string{"ctrl+q"}, keys.Quit.Keys())
+}
+
+func TestBuildKeys_IntraConfigConflict(t *testing.T) {
+	keys := buildKeys(&userconfig.Settings{
+		Keybindings: []userconfig.Keybinding{
+			{Action: "quit", Keys: []string{"ctrl+q"}},
+			{Action: "suspend", Keys: []string{"ctrl+q"}}, // conflicts with quit, skipped
+		},
+	})
+	assert.Equal(t, []string{"ctrl+q"}, keys.Quit.Keys())
+	assert.Equal(t, []string{"ctrl+z"}, keys.Suspend.Keys()) // default preserved
+}
+
+// A custom key that collides with a non-remapped action's default must be
+// rejected so it is never bound to two actions.
+func TestBuildKeys_ConflictWithDefault(t *testing.T) {
+	keys := buildKeys(&userconfig.Settings{
+		Keybindings: []userconfig.Keybinding{
+			{Action: "editor_send", Keys: []string{"ctrl+j"}}, // ctrl+j is newline's default
+		},
+	})
+	assert.Equal(t, []string{"enter"}, keys.EditorSend.Keys())     // rejected, stays default
+	assert.Equal(t, []string{"ctrl+j"}, keys.EditorNewline.Keys()) // default intact
+}
+
+// Reassigning a key away from its default action frees it for another action.
+func TestBuildKeys_ReuseFreedKey(t *testing.T) {
+	keys := buildKeys(&userconfig.Settings{
+		Keybindings: []userconfig.Keybinding{
+			{Action: "editor_newline", Keys: []string{"alt+enter"}}, // frees ctrl+j
+			{Action: "editor_send", Keys: []string{"ctrl+j"}},       // now allowed
+		},
+	})
+	assert.Equal(t, []string{"alt+enter"}, keys.EditorNewline.Keys())
+	assert.Equal(t, []string{"ctrl+j"}, keys.EditorSend.Keys())
+}
+
+func TestValidateKey(t *testing.T) {
+	valid := []string{"ctrl+q", "q", "?", "enter", "tab", "esc", "space", "f1", "f13", "shift+enter", "alt+enter", "ctrl+?", "ctrl+shift+a", "up"}
+	for _, k := range valid {
+		assert.True(t, validateKey(k), "expected %q to be valid", k)
+	}
+	invalid := []string{"", " ", "ctrl q", "foobar", "ctrl+foobar", "entre", "f0", "f64", "bogus+a", "ctrl+", "+"}
+	for _, k := range invalid {
+		assert.False(t, validateKey(k), "expected %q to be invalid", k)
+	}
+}
+
+// A typo'd key name must be rejected so it never silently replaces a critical
+// action's working default (the lock-out footgun).
+func TestBuildKeys_InvalidKeyNameKeepsDefault(t *testing.T) {
+	keys := buildKeys(&userconfig.Settings{
+		Keybindings: []userconfig.Keybinding{
+			{Action: "editor_send", Keys: []string{"foobar"}},
+		},
+	})
+	assert.Equal(t, []string{"enter"}, keys.EditorSend.Keys())
+}
+
+// Overriding onto a key reserved by a built-in shortcut is rejected.
+func TestBuildKeys_ReservedKeyConflict(t *testing.T) {
+	keys := buildKeys(&userconfig.Settings{
+		Keybindings: []userconfig.Keybinding{
+			{Action: "commands", Keys: []string{"ctrl+t"}}, // ctrl+t is the new-tab shortcut
+		},
+	})
+	assert.Equal(t, []string{"ctrl+k"}, keys.Commands.Keys())
+}
+
+func TestBuildKeys_FromYAML(t *testing.T) {
+	yamlConfig := `
+settings:
+  keybindings:
+    - action: "quit"
+      keys: ["ctrl+q"]
+    - action: "editor_newline"
+      keys: ["alt+enter"]
+    - action: "history_search"
+      keys: ["ctrl+f"]
+`
+	var config userconfig.Config
+	require.NoError(t, yaml.Unmarshal([]byte(yamlConfig), &config))
+
+	keys := buildKeys(config.Settings)
+
+	assert.Equal(t, []string{"ctrl+q"}, keys.Quit.Keys())
+	assert.Equal(t, []string{"alt+enter"}, keys.EditorNewline.Keys())
+	assert.Equal(t, []string{"ctrl+f"}, keys.HistorySearch.Keys())
+	assert.Equal(t, []string{"tab"}, keys.SwitchFocus.Keys())
+}
+
+func TestGetKeys_CacheAndReset(t *testing.T) {
+	ResetKeys()
+	t.Cleanup(ResetKeys)
+
+	first := GetKeys()
+	second := GetKeys()
+	assert.Equal(t, first.Quit.Keys(), second.Quit.Keys())
+
+	ResetKeys() // should not panic and forces a rebuild on next call
+	assert.NotEmpty(t, GetKeys().Quit.Keys())
+}
+
+func TestValidActions(t *testing.T) {
+	actions := ValidActions()
+	assert.Contains(t, actions, "editor_send")
+	assert.Contains(t, actions, "editor_newline")
+	assert.Contains(t, actions, "quit")
+	assert.Len(t, actions, 15)
+}

--- a/pkg/tui/dialog/base.go
+++ b/pkg/tui/dialog/base.go
@@ -153,9 +153,9 @@ func RenderHelpKeys(contentWidth int, bindings ...string) string {
 	return styles.BaseStyle.Width(contentWidth).Align(lipgloss.Center).Render(strings.Join(parts, "  "))
 }
 
-// HandleQuit checks for ctrl+c and returns tea.Quit if matched.
+// HandleQuit checks for the configured quit key and returns tea.Quit if matched.
 func HandleQuit(msg tea.KeyPressMsg) tea.Cmd {
-	if msg.String() == "ctrl+c" {
+	if key.Matches(msg, core.GetKeys().Quit) {
 		return tea.Quit
 	}
 	return nil

--- a/pkg/tui/dialog/exit_confirmation.go
+++ b/pkg/tui/dialog/exit_confirmation.go
@@ -19,9 +19,13 @@ type exitConfirmationKeyMap struct {
 }
 
 func defaultExitConfirmationKeyMap() exitConfirmationKeyMap {
+	// Pressing the quit key again confirms exit, so fold the configured quit
+	// keys into the Yes binding.
+	yesKeys := append([]string{"y", "Y"}, core.GetKeys().Quit.Keys()...)
+
 	return exitConfirmationKeyMap{
 		Yes: key.NewBinding(
-			key.WithKeys("y", "Y", "ctrl+c"),
+			key.WithKeys(yesKeys...),
 			key.WithHelp("Y", "yes"),
 		),
 		No: key.NewBinding(

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -1748,57 +1748,28 @@ func (m *appModel) Help() help.KeyMap {
 
 // AllBindings returns ALL available key bindings for the help dialog (comprehensive list).
 func (m *appModel) AllBindings() []key.Binding {
-	quitBinding := key.NewBinding(
-		key.WithKeys("ctrl+c"),
-		key.WithHelp("Ctrl+c", "quit"),
-	)
+	keys := core.GetKeys()
+	quitBinding := keys.Quit
 
 	if m.leanMode {
 		return []key.Binding{quitBinding}
 	}
 
-	tabBinding := key.NewBinding(
-		key.WithKeys("tab"),
-		key.WithHelp("Tab", "switch focus"),
-	)
+	tabBinding := keys.SwitchFocus
 
 	bindings := []key.Binding{quitBinding, tabBinding}
 	bindings = append(bindings, m.tabBar.Bindings()...)
 
-	// Additional global shortcuts
+	// Additional global shortcuts. shift+tab is not user-configurable.
 	bindings = append(bindings,
-		key.NewBinding(
-			key.WithKeys("ctrl+k"),
-			key.WithHelp("Ctrl+k", "commands"),
-		),
-		key.NewBinding(
-			key.WithKeys("ctrl+h"),
-			key.WithHelp("Ctrl+h", "help"),
-		),
-		key.NewBinding(
-			key.WithKeys("ctrl+y"),
-			key.WithHelp("Ctrl+y", "toggle yolo mode"),
-		),
-		key.NewBinding(
-			key.WithKeys("ctrl+o"),
-			key.WithHelp("Ctrl+o", "toggle hide tool results"),
-		),
-		key.NewBinding(
-			key.WithKeys("ctrl+s"),
-			key.WithHelp("Ctrl+s", "cycle agent"),
-		),
-		key.NewBinding(
-			key.WithKeys("ctrl+m"),
-			key.WithHelp("Ctrl+m", "model picker"),
-		),
-		key.NewBinding(
-			key.WithKeys("ctrl+x"),
-			key.WithHelp("Ctrl+x", "clear queue"),
-		),
-		key.NewBinding(
-			key.WithKeys("ctrl+z"),
-			key.WithHelp("Ctrl+z", "suspend"),
-		),
+		keys.Commands,
+		keys.Help,
+		keys.ToggleYolo,
+		keys.ToggleHideToolResults,
+		keys.CycleAgent,
+		keys.ModelPicker,
+		keys.ClearQueue,
+		keys.Suspend,
 		key.NewBinding(
 			key.WithKeys("shift+tab"),
 			key.WithHelp("Shift+Tab", "cycle thinking level"),
@@ -1807,22 +1778,21 @@ func (m *appModel) AllBindings() []key.Binding {
 
 	// leanMode already returned above, so only hideSidebar matters here.
 	if !m.hideSidebar {
-		bindings = append(bindings, key.NewBinding(
-			key.WithKeys("ctrl+b"),
-			key.WithHelp("Ctrl+b", "toggle sidebar"),
-		))
+		bindings = append(bindings, keys.ToggleSidebar)
 	}
 
-	// Show newline help based on keyboard enhancement support
+	// Show newline help based on keyboard enhancement support. shift+enter is
+	// detected at runtime; otherwise fall back to the configured newline key.
 	if m.keyboardEnhancementsSupported {
 		bindings = append(bindings, key.NewBinding(
 			key.WithKeys("shift+enter"),
 			key.WithHelp("Shift+Enter", "newline"),
 		))
 	} else {
+		nl := keys.EditorNewline
 		bindings = append(bindings, key.NewBinding(
-			key.WithKeys("ctrl+j"),
-			key.WithHelp("Ctrl+j", "newline"),
+			key.WithKeys(nl.Keys()...),
+			key.WithHelp(nl.Help().Key, "newline"),
 		))
 	}
 
@@ -1830,15 +1800,12 @@ func (m *appModel) AllBindings() []key.Binding {
 		bindings = append(bindings, m.chatPage.Bindings()...)
 	} else {
 		editorName := editorname.FromEnv(os.Getenv("VISUAL"), os.Getenv("EDITOR"))
+		editExternal := keys.EditExternal
+		// Keep the binding's capitalized key label; only swap the description.
+		editExternal.SetHelp(editExternal.Help().Key, "edit in "+editorName)
 		bindings = append(bindings,
-			key.NewBinding(
-				key.WithKeys("ctrl+g"),
-				key.WithHelp("Ctrl+g", "edit in "+editorName),
-			),
-			key.NewBinding(
-				key.WithKeys("ctrl+r"),
-				key.WithHelp("Ctrl+r", "history search"),
-			),
+			editExternal,
+			keys.HistorySearch,
 		)
 	}
 	return bindings
@@ -1850,19 +1817,20 @@ func (m *appModel) Bindings() []key.Binding {
 	all := m.AllBindings()
 
 	// Define which keys should appear in the status bar
+	keys := core.GetKeys()
 	statusBarKeys := map[string]bool{
-		"ctrl+c":      true, // quit
-		"tab":         true, // switch focus
-		"ctrl+t":      true, // new tab (from tabBar)
-		"ctrl+w":      true, // close tab (from tabBar)
-		"ctrl+p":      true, // prev tab (from tabBar)
-		"ctrl+n":      true, // next tab (from tabBar)
-		"ctrl+k":      true, // commands
-		"ctrl+h":      true, // help
-		"shift+enter": true, // newline
-		"ctrl+j":      true, // newline fallback
-		"ctrl+g":      true, // edit in external editor (editor context)
-		"ctrl+r":      true, // history search (editor context)
+		keys.Quit.Keys()[0]:          true, // quit
+		keys.SwitchFocus.Keys()[0]:   true, // switch focus
+		"ctrl+t":                     true, // new tab (from tabBar)
+		"ctrl+w":                     true, // close tab (from tabBar)
+		"ctrl+p":                     true, // prev tab (from tabBar)
+		"ctrl+n":                     true, // next tab (from tabBar)
+		keys.Commands.Keys()[0]:      true, // commands
+		keys.Help.Keys()[0]:          true, // help
+		"shift+enter":                true, // newline
+		keys.EditorNewline.Keys()[0]: true, // newline fallback
+		keys.EditExternal.Keys()[0]:  true, // edit in external editor (editor context)
+		keys.HistorySearch.Keys()[0]: true, // history search (editor context)
 		// Content panel bindings (↑↓, c, e, d) are always included
 		"up":   true,
 		"down": true,
@@ -1900,15 +1868,17 @@ func (m *appModel) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 
-	// Ctrl+c is intercepted before any dialog handling so that every dialog
-	// reacts to it consistently:
+	keys := core.GetKeys()
+
+	// The quit key is intercepted before any dialog handling so that every
+	// dialog reacts to it consistently:
 	//   - With no dialog open: open the exit confirmation dialog.
 	//   - With any other dialog open: stack the exit confirmation on top so
-	//     that the user can confirm exit (a second ctrl+c or Y exits) or
+	//     that the user can confirm exit (a second quit key or Y exits) or
 	//     cancel it (N/Esc) and return to the original dialog.
 	//   - With the exit confirmation already on top: forward the key so it
 	//     can exit the program via its own Yes binding.
-	if msg.String() == "ctrl+c" {
+	if key.Matches(msg, keys.Quit) {
 		if m.dialogMgr.TopIsExitConfirmation() {
 			return m.forwardDialog(msg)
 		}
@@ -1952,31 +1922,31 @@ func (m *appModel) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 	// Global keyboard shortcuts (active even during history search)
 	switch {
-	case key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+z"))):
+	case key.Matches(msg, keys.Suspend):
 		return m, tea.Suspend
 
-	case key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+k"))):
+	case key.Matches(msg, keys.Commands):
 		categories := m.commandCategories()
 		return m, core.CmdHandler(dialog.OpenDialogMsg{
 			Model: dialog.NewCommandPaletteDialog(categories),
 		})
 
-	case key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+y"))):
+	case key.Matches(msg, keys.ToggleYolo):
 		return m, core.CmdHandler(messages.ToggleYoloMsg{})
 
-	case key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+o"))):
+	case key.Matches(msg, keys.ToggleHideToolResults):
 		return m, core.CmdHandler(messages.ToggleHideToolResultsMsg{})
 
-	case key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+s"))):
+	case key.Matches(msg, keys.CycleAgent):
 		return m.handleCycleAgent()
 
-	case key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+m"))):
+	case key.Matches(msg, keys.ModelPicker):
 		return m.handleOpenModelPicker()
 
-	case key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+x"))):
+	case key.Matches(msg, keys.ClearQueue):
 		return m, core.CmdHandler(messages.ClearQueueMsg{})
 
-	case key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+h", "f1", "ctrl+?"))):
+	case key.Matches(msg, keys.Help):
 		// Show contextual help dialog with ALL available key bindings
 		return m, core.CmdHandler(dialog.OpenDialogMsg{
 			Model: dialog.NewHelpDialog(m.AllBindings()),
@@ -1989,10 +1959,10 @@ func (m *appModel) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 
 	switch {
-	case key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+g"))):
+	case key.Matches(msg, keys.EditExternal):
 		return m.openExternalEditor()
 
-	case key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+r"))):
+	case key.Matches(msg, keys.HistorySearch):
 		if m.focusedPanel == PanelEditor && !m.editor.IsRecording() {
 			model, cmd := m.editor.EnterHistorySearch()
 			m.editor = model.(editor.Editor)
@@ -2000,7 +1970,7 @@ func (m *appModel) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 
 	// Toggle sidebar (propagates to content view regardless of focus)
-	case key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+b"))):
+	case key.Matches(msg, keys.ToggleSidebar):
 		if m.leanMode || m.hideSidebar {
 			return m, nil
 		}
@@ -2011,7 +1981,7 @@ func (m *appModel) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m.handleCycleThinkingLevel()
 
 	// Focus switching: Tab key toggles between content and editor
-	case key.Matches(msg, key.NewBinding(key.WithKeys("tab"))):
+	case key.Matches(msg, keys.SwitchFocus):
 		return m.switchFocus()
 
 	// Esc: cancel stream (works regardless of focus)

--- a/pkg/userconfig/userconfig.go
+++ b/pkg/userconfig/userconfig.go
@@ -75,6 +75,21 @@ type Settings struct {
 	// and agents. These act as user-wide defaults; session-level and agent-level
 	// permissions override them.
 	Permissions *latest.PermissionsConfig `yaml:"permissions,omitempty"`
+	// Keybindings lets users remap TUI keyboard shortcuts. Each entry maps an
+	// action name to one or more key combinations (Bubbles key format, e.g.
+	// "ctrl+q", "f2"). Unknown actions, malformed keys, and conflicts are
+	// ignored with a logged warning so a bad entry never breaks the TUI.
+	Keybindings []Keybinding `yaml:"keybindings,omitempty"`
+}
+
+// Keybinding maps a single TUI action to the key combinations that trigger it.
+type Keybinding struct {
+	// Action is the identifier of the action to remap (e.g. "quit",
+	// "editor_newline"). See pkg/tui/core for the list of valid actions.
+	Action string `yaml:"action"`
+	// Keys is the list of key combinations bound to the action, in Bubbles
+	// key format (e.g. "ctrl+q", "shift+enter", "f2").
+	Keys []string `yaml:"keys"`
 }
 
 // DefaultTabTitleMaxLength is the default maximum tab title length when not configured.


### PR DESCRIPTION
## Summary

Adds user-configurable TUI keybindings, driven by a `keybindings` list in `~/.config/cagent/config.yaml`. The primary goal is resolving the `Ctrl+J` newline conflict from #1626 (common in VS Code and tmux) by making the newline and send keys remappable, while keeping `Shift+Enter` auto-detected on terminals that report keyboard enhancements.

The design follows the direction agreed on the previous attempts: configuration lives in `pkg/userconfig` (not env vars, per the discussion on #1629) and reuses the central-KeyMap approach reviewed positively on #2415, with the review items from that PR addressed.

```yaml
settings:
  keybindings:
    - action: "editor_newline"
      keys: ["alt+enter"]      # replaces the Ctrl+J fallback; Shift+Enter still works
    - action: "commands"
      keys: ["f2", "ctrl+k"]
    - action: "quit"
      keys: ["ctrl+q"]
```

## Issue expectations

| #1626 asks for | Status | Notes |
| --- | --- | --- |
| Configurable newline key | yes | `editor_newline` action (default `ctrl+j`) |
| Configurable send key | yes | `editor_send` action (default `enter`) |
| Env var override | intentionally omitted | env vars were rejected in the #1629 discussion in favor of the global config |
| Runtime display of active bindings | partial | the `Ctrl+H` help dialog and status bar now reflect the resolved bindings |

## How it works

| Concern | Handled by |
| --- | --- |
| Defaults + user overrides | `core.DefaultKeyMap()` merged in `core.buildKeys()` |
| Resolution and caching | `core.GetKeys()` reads the config once and caches it behind an `RWMutex` |
| Validation | structural key check against the Bubbletea key vocabulary (modifiers + named keys / runes / `fN`) |
| Conflict detection | a key bound to two actions is rejected; built-in reserved keys (tab bar, `shift+tab`, `ctrl+1..9`, `esc`) are seeded so overrides onto them are rejected rather than silently shadowed |
| Newline terminal handling | the editor layers `shift+enter` on top of the configured keys when `keyboardEnhancementsSupported` |
| Bad config | unknown actions, malformed keys, and conflicts are ignored with a logged warning, so the TUI never breaks |

`tui.go`, `dialog/base.go`, and `dialog/exit_confirmation.go` resolve their bindings through `core.GetKeys()`. The composer (`editor.go`) and the inline message editor (`messages.go`) honor the configured send and newline keys.

## Behavior preservation

With no configuration the behavior is unchanged:

| Context | Newline keys | Send |
| --- | --- | --- |
| Terminal with keyboard enhancements | `shift+enter`, `ctrl+j` | `enter` |
| Terminal without | `ctrl+j` | `enter` |

Only `editor_newline`/`editor_send` and the listed global actions are configurable. The tab-bar keys, `shift+tab`, `ctrl+1..9`, and history-search mode-local keys remain fixed.

## Tests

- `pkg/tui/core/keys_test.go`: defaults, overrides, intra-config and reserved-key conflicts, malformed/typo'd key rejection, YAML round-trip, cache reset, key validation table.
- `pkg/tui/components/editor/keybinding_test.go`: the editor wires its newline keys from the configurable binding and layers `shift+enter` on capable terminals.

## Validation

- `task build` and the affected package tests pass (`core` also under `-race`).
- `golangci-lint` reports no issues on the changed packages.

## Notes for reviewers

A few low-priority, pre-existing inconsistencies were left as follow-ups to keep this change focused: history-search uses literal `enter`/`ctrl+g`, the list dialogs keep the vi-style `ctrl+j` "down" alias, and the inline editor's newline help label is not gated on keyboard-enhancement support. If a broader "remap everything" scope is preferred, the central KeyMap is the place to extend.

Closes #1626
