### PR TITLE
fix: add idle timeout and context cancellation to model stream reads

### DIFF
--- a/pkg/runtime/fallback.go
+++ b/pkg/runtime/fallback.go
@@ -301,8 +301,14 @@ func (e *fallbackExecutor) execute(
 				"in_cooldown", startIndex > 0,
 				"attempt", attempt+1)
 
-			stream, err := modelEntry.provider.CreateChatCompletionStream(ctx, messages, agentTools)
+			// Create a per-attempt cancellable child context so that the idle
+			// timeout in handleStream can cancel the HTTP request and unblock
+			// the goroutine reading the response body.
+			streamCtx, streamCancel := context.WithCancelCause(ctx)
+
+			stream, err := modelEntry.provider.CreateChatCompletionStream(streamCtx, messages, agentTools)
 			if err != nil {
+				streamCancel(nil)
 				lastErr = err
 				decision, retErr := e.classifyAttemptError(ctx, err, a, modelEntry, attempt, hasFallbacks, &primaryFailedWithNonRetryable)
 				if retErr != nil {
@@ -327,7 +333,8 @@ func (e *fallbackExecutor) execute(
 				}
 			}
 
-			res, err := handleStream(ctx, stream, a, agentTools, sess, m, e.telemetry, events)
+			res, err := handleStream(streamCtx, streamCancel, stream, a, agentTools, sess, m, e.telemetry, events)
+			streamCancel(nil) // always release the child context
 			if err != nil {
 				lastErr = err
 				decision, retErr := e.classifyAttemptError(ctx, err, a, modelEntry, attempt, hasFallbacks, &primaryFailedWithNonRetryable)

--- a/pkg/runtime/streaming.go
+++ b/pkg/runtime/streaming.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/docker/docker-agent/pkg/agent"
 	"github.com/docker/docker-agent/pkg/chat"
@@ -14,6 +15,27 @@ import (
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/tools"
 )
+
+// defaultStreamIdleTimeout is the maximum time handleStream will wait for the
+// next SSE chunk before declaring the upstream connection stalled. A
+// half-open TCP connection to the model gateway (remote side gone without
+// sending FIN) would otherwise block the goroutine forever and prevent
+// graceful shutdown.
+//
+// Five minutes is intentionally generous: LLM streams can legitimately pause
+// for tens of seconds during extended thinking. The timeout only fires when
+// absolutely no bytes arrive at the SSE layer (not just no new tokens).
+//
+// This is a var rather than a const so tests can shorten it without changing
+// production behaviour.
+var defaultStreamIdleTimeout = 5 * time.Minute
+
+// errStreamIdle is the sentinel error returned when the upstream model stream
+// produces no SSE events for longer than defaultStreamIdleTimeout. It does
+// not wrap any standard context error so that the retry/fallback machinery
+// treats it as a non-retryable, non-context-cancelled failure and surfaces a
+// clear error message to the user.
+var errStreamIdle = errors.New("model stream stalled: no data received from upstream")
 
 // streamResult holds the aggregated result of processing a single chat
 // completion stream: the assistant's textual reply, any tool calls requested,
@@ -34,13 +56,50 @@ type streamResult struct {
 // the aggregated streamResult. The caller is responsible for adding the
 // resulting assistant message to the session.
 //
+// cancelStream, when non-nil, is called with errStreamIdle when the idle
+// timeout fires. It must be the cancel function for the context that was
+// passed to CreateChatCompletionStream so that Go's HTTP transport closes the
+// underlying TCP connection and unblocks the stream reader goroutine.
+//
 // handleStream is a pure stream-aggregation routine: it does not touch
 // runtime state and can be unit-tested by feeding a mock chat.MessageStream.
 // It is intentionally a free function rather than a method on *LocalRuntime
 // so the dependency direction is explicit (the loop calls into the chunker,
 // never the reverse).
-func handleStream(ctx context.Context, stream chat.MessageStream, a *agent.Agent, agentTools []tools.Tool, sess *session.Session, m *modelsdev.Model, tel Telemetry, events EventSink) (streamResult, error) {
+func handleStream(ctx context.Context, cancelStream context.CancelCauseFunc, stream chat.MessageStream, a *agent.Agent, agentTools []tools.Tool, sess *session.Session, m *modelsdev.Model, tel Telemetry, events EventSink) (streamResult, error) {
+	// done is closed when handleStream exits (for any reason) so the reader
+	// goroutine below can detect it and stop trying to send on recvCh.
+	done := make(chan struct{})
+	defer close(done)
 	defer stream.Close()
+
+	type recvResult struct {
+		response chat.MessageStreamResponse
+		err      error
+	}
+	recvCh := make(chan recvResult, 1)
+
+	// Read chunks in a dedicated goroutine so the main select below can
+	// enforce both context cancellation and the idle timeout without
+	// blocking on a potentially stalled network read.
+	go func() {
+		for {
+			r, err := stream.Recv()
+			select {
+			case recvCh <- recvResult{r, err}:
+				if err != nil {
+					return
+				}
+			case <-done:
+				return
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	idleTimer := time.NewTimer(defaultStreamIdleTimeout)
+	defer idleTimer.Stop()
 
 	var fullContent strings.Builder
 	var fullReasoningContent strings.Builder
@@ -104,158 +163,191 @@ func handleStream(ctx context.Context, stream chat.MessageStream, a *agent.Agent
 		tel.RecordTokenUsage(ctx, modelName, input, messageUsage.OutputTokens, sess.TotalCost())
 	}
 
+mainLoop:
 	for {
-		response, err := stream.Recv()
-		if errors.Is(err, io.EOF) {
-			break
-		}
-		if err != nil {
-			return streamResult{Stopped: true}, fmt.Errorf("error receiving from stream: %w", err)
-		}
-
-		if response.Usage != nil {
-			// Always keep the latest usage snapshot; some providers (e.g.
-			// Gemini) emit updated usage on every chunk with cumulative
-			// token counts, so the last value is the most accurate.
-			messageUsage = response.Usage
-		}
-
-		if len(response.Choices) == 0 {
-			continue
-		}
-		choice := response.Choices[0]
-
-		if len(choice.Delta.ThoughtSignature) > 0 {
-			thoughtSignature = choice.Delta.ThoughtSignature
-		}
-
-		// Accumulate tool call deltas from this chunk *before* evaluating the
-		// finish reason below. Some OpenAI-compatible providers (e.g. LiteLLM
-		// in front of Gemini) pack a complete tool call and a terminal
-		// finish_reason ("stop") into the same chunk; handling the finish
-		// reason first would drop the call and the turn would end with an
-		// empty assistant message ("No response from agent").
-		if len(choice.Delta.ToolCalls) > 0 {
-			// Process each tool call delta
-			for _, delta := range choice.Delta.ToolCalls {
-				idx, exists := toolCallIndex[delta.ID]
-				if !exists {
-					idx = len(toolCalls)
-					toolCallIndex[delta.ID] = idx
-					toolCalls = append(toolCalls, tools.ToolCall{
-						ID:   delta.ID,
-						Type: delta.Type,
-					})
-				}
-
-				tc := &toolCalls[idx]
-
-				// Track if we're learning the name for the first time
-				learningName := delta.Function.Name != "" && tc.Function.Name == ""
-
-				// Update fields from delta
-				if delta.Type != "" {
-					tc.Type = delta.Type
-				}
-				if delta.Function.Name != "" {
-					tc.Function.Name = delta.Function.Name
-				}
-				if delta.Function.Arguments != "" {
-					tc.Function.Arguments += delta.Function.Arguments
-				}
-
-				// Emit PartialToolCall once we have a name, and on subsequent argument deltas.
-				// Only the newly received argument bytes are sent, not the full
-				// accumulated arguments, to avoid re-transmitting the entire payload
-				// on every token.
-				if tc.Function.Name != "" && (learningName || delta.Function.Arguments != "") {
-					if !emittedPartial[delta.ID] || delta.Function.Arguments != "" {
-						partial := tools.ToolCall{
-							ID:   tc.ID,
-							Type: tc.Type,
-							Function: tools.FunctionCall{
-								Name:      tc.Function.Name,
-								Arguments: delta.Function.Arguments,
-							},
-						}
-						toolDef := tools.Tool{}
-						if !emittedPartial[delta.ID] {
-							toolDef = toolDefMap[tc.Function.Name]
-						}
-						events.Emit(PartialToolCall(partial, toolDef, a.Name()))
-						emittedPartial[delta.ID] = true
-					}
+		select {
+		case res := <-recvCh:
+			// Reset the idle timer on every received chunk.
+			if !idleTimer.Stop() {
+				select {
+				case <-idleTimer.C:
+				default:
 				}
 			}
-			// Short-circuit only when the chunk carried nothing but tool call
-			// deltas. If it also carries a terminal finish reason, fall through
-			// so the early return below sees the freshly accumulated call.
-			if choice.FinishReason == "" {
+			idleTimer.Reset(defaultStreamIdleTimeout)
+
+			if errors.Is(res.err, io.EOF) {
+				break mainLoop
+			}
+			if res.err != nil {
+				return streamResult{Stopped: true}, fmt.Errorf("error receiving from stream: %w", res.err)
+			}
+
+			response := res.response
+
+			if response.Usage != nil {
+				// Always keep the latest usage snapshot; some providers (e.g.
+				// Gemini) emit updated usage on every chunk with cumulative
+				// token counts, so the last value is the most accurate.
+				messageUsage = response.Usage
+			}
+
+			if len(response.Choices) == 0 {
 				continue
 			}
-		}
+			choice := response.Choices[0]
 
-		if choice.FinishReason == chat.FinishReasonStop || choice.FinishReason == chat.FinishReasonLength || choice.FinishReason == chat.FinishReasonRefusal {
-			recordUsage()
-			finishReason := choice.FinishReason
-			if finishReason == chat.FinishReasonRefusal {
-				// A refusal voids tool calls streamed before the safety
-				// classifier ended the turn: executing them would perform
-				// actions the model refused to complete, and replaying their
-				// tool_use blocks without results breaks the next request.
-				if len(toolCalls) > 0 {
-					slog.WarnContext(ctx, "Dropping tool calls from refused turn",
-						"agent", a.Name(), "tool_calls", len(toolCalls))
-					toolCalls = nil
-				}
-			} else {
-				applyXMLFallback()
-				if finishReason == chat.FinishReasonStop && len(toolCalls) > 0 {
-					finishReason = chat.FinishReasonToolCalls
-				}
+			if len(choice.Delta.ThoughtSignature) > 0 {
+				thoughtSignature = choice.Delta.ThoughtSignature
 			}
-			return streamResult{
-				Calls:             toolCalls,
-				Content:           fullContent.String(),
-				ReasoningContent:  fullReasoningContent.String(),
-				ThinkingSignature: thinkingSignature,
-				ThoughtSignature:  thoughtSignature,
-				Stopped:           len(toolCalls) == 0, // stop only when there are no tool calls to execute
-				FinishReason:      finishReason,
-				Usage:             messageUsage,
-			}, nil
-		}
 
-		// Track the provider's explicit finish reason (e.g. tool_calls) so we
-		// can prefer it over inference after the loop.  stop/length/refusal are
-		// already handled by the early return above.
-		if choice.FinishReason != "" {
-			providerFinishReason = choice.FinishReason
-		}
+			// Accumulate tool call deltas from this chunk *before* evaluating the
+			// finish reason below. Some OpenAI-compatible providers (e.g. LiteLLM
+			// in front of Gemini) pack a complete tool call and a terminal
+			// finish_reason ("stop") into the same chunk; handling the finish
+			// reason first would drop the call and the turn would end with an
+			// empty assistant message ("No response from agent").
+			if len(choice.Delta.ToolCalls) > 0 {
+				// Process each tool call delta
+				for _, delta := range choice.Delta.ToolCalls {
+					idx, exists := toolCallIndex[delta.ID]
+					if !exists {
+						idx = len(toolCalls)
+						toolCallIndex[delta.ID] = idx
+						toolCalls = append(toolCalls, tools.ToolCall{
+							ID:   delta.ID,
+							Type: delta.Type,
+						})
+					}
 
-		if choice.Delta.ReasoningContent != "" {
-			events.Emit(AgentChoiceReasoning(a.Name(), sess.ID, choice.Delta.ReasoningContent))
-			fullReasoningContent.WriteString(choice.Delta.ReasoningContent)
-		}
+					tc := &toolCalls[idx]
 
-		// Capture thinking signature for Anthropic extended thinking
-		if choice.Delta.ThinkingSignature != "" {
-			thinkingSignature = choice.Delta.ThinkingSignature
-		}
+					// Track if we're learning the name for the first time
+					learningName := delta.Function.Name != "" && tc.Function.Name == ""
 
-		if choice.Delta.Content != "" {
-			if !xmlToolCallGate {
-				tagIdx := strings.Index(choice.Delta.Content, "<tool_call>")
-				if tagIdx < 0 {
-					events.Emit(AgentChoice(a.Name(), sess.ID, choice.Delta.Content))
-				} else {
-					xmlToolCallGate = true
-					if tagIdx > 0 {
-						events.Emit(AgentChoice(a.Name(), sess.ID, choice.Delta.Content[:tagIdx]))
+					// Update fields from delta
+					if delta.Type != "" {
+						tc.Type = delta.Type
+					}
+					if delta.Function.Name != "" {
+						tc.Function.Name = delta.Function.Name
+					}
+					if delta.Function.Arguments != "" {
+						tc.Function.Arguments += delta.Function.Arguments
+					}
+
+					// Emit PartialToolCall once we have a name, and on subsequent argument deltas.
+					// Only the newly received argument bytes are sent, not the full
+					// accumulated arguments, to avoid re-transmitting the entire payload
+					// on every token.
+					if tc.Function.Name != "" && (learningName || delta.Function.Arguments != "") {
+						if !emittedPartial[delta.ID] || delta.Function.Arguments != "" {
+							partial := tools.ToolCall{
+								ID:   tc.ID,
+								Type: tc.Type,
+								Function: tools.FunctionCall{
+									Name:      tc.Function.Name,
+									Arguments: delta.Function.Arguments,
+								},
+							}
+							toolDef := tools.Tool{}
+							if !emittedPartial[delta.ID] {
+								toolDef = toolDefMap[tc.Function.Name]
+							}
+							events.Emit(PartialToolCall(partial, toolDef, a.Name()))
+							emittedPartial[delta.ID] = true
+						}
 					}
 				}
+				// Short-circuit only when the chunk carried nothing but tool call
+				// deltas. If it also carries a terminal finish reason, fall through
+				// so the early return below sees the freshly accumulated call.
+				if choice.FinishReason == "" {
+					continue
+				}
 			}
-			fullContent.WriteString(choice.Delta.Content)
+
+			if choice.FinishReason == chat.FinishReasonStop || choice.FinishReason == chat.FinishReasonLength || choice.FinishReason == chat.FinishReasonRefusal {
+				recordUsage()
+				finishReason := choice.FinishReason
+				if finishReason == chat.FinishReasonRefusal {
+					// A refusal voids tool calls streamed before the safety
+					// classifier ended the turn: executing them would perform
+					// actions the model refused to complete, and replaying their
+					// tool_use blocks without results breaks the next request.
+					if len(toolCalls) > 0 {
+						slog.WarnContext(ctx, "Dropping tool calls from refused turn",
+							"agent", a.Name(), "tool_calls", len(toolCalls))
+						toolCalls = nil
+					}
+				} else {
+					applyXMLFallback()
+					if finishReason == chat.FinishReasonStop && len(toolCalls) > 0 {
+						finishReason = chat.FinishReasonToolCalls
+					}
+				}
+				return streamResult{
+					Calls:             toolCalls,
+					Content:           fullContent.String(),
+					ReasoningContent:  fullReasoningContent.String(),
+					ThinkingSignature: thinkingSignature,
+					ThoughtSignature:  thoughtSignature,
+					Stopped:           len(toolCalls) == 0, // stop only when there are no tool calls to execute
+					FinishReason:      finishReason,
+					Usage:             messageUsage,
+				}, nil
+			}
+
+			// Track the provider's explicit finish reason (e.g. tool_calls) so we
+			// can prefer it over inference after the loop.  stop/length/refusal are
+			// already handled by the early return above.
+			if choice.FinishReason != "" {
+				providerFinishReason = choice.FinishReason
+			}
+
+			if choice.Delta.ReasoningContent != "" {
+				events.Emit(AgentChoiceReasoning(a.Name(), sess.ID, choice.Delta.ReasoningContent))
+				fullReasoningContent.WriteString(choice.Delta.ReasoningContent)
+			}
+
+			// Capture thinking signature for Anthropic extended thinking
+			if choice.Delta.ThinkingSignature != "" {
+				thinkingSignature = choice.Delta.ThinkingSignature
+			}
+
+			if choice.Delta.Content != "" {
+				if !xmlToolCallGate {
+					tagIdx := strings.Index(choice.Delta.Content, "<tool_call>")
+					if tagIdx < 0 {
+						events.Emit(AgentChoice(a.Name(), sess.ID, choice.Delta.Content))
+					} else {
+						xmlToolCallGate = true
+						if tagIdx > 0 {
+							events.Emit(AgentChoice(a.Name(), sess.ID, choice.Delta.Content[:tagIdx]))
+						}
+					}
+				}
+				fullContent.WriteString(choice.Delta.Content)
+			}
+
+		case <-ctx.Done():
+			// Context cancelled (SIGTERM, Ctrl+C, or idle-timeout cancel from
+			// this function). Return promptly so graceful shutdown can proceed.
+			return streamResult{Stopped: true}, ctx.Err()
+
+		case <-idleTimer.C:
+			slog.WarnContext(ctx, "Model stream stalled: no data received within idle timeout",
+				"agent", a.Name(),
+				"session_id", sess.ID,
+				"idle_timeout", defaultStreamIdleTimeout,
+			)
+			// Cancel the HTTP request context so Go's transport closes the
+			// underlying TCP connection and unblocks the reader goroutine.
+			if cancelStream != nil {
+				cancelStream(errStreamIdle)
+			}
+			return streamResult{Stopped: true}, fmt.Errorf("model stream stalled after %s with no data: %w",
+				defaultStreamIdleTimeout, errStreamIdle)
 		}
 	}
 

--- a/pkg/runtime/streaming_test.go
+++ b/pkg/runtime/streaming_test.go
@@ -1,7 +1,10 @@
 package runtime
 
 import (
+	"context"
+	"io"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -60,7 +63,7 @@ func TestHandleStream_Refusal(t *testing.T) {
 
 	evCh := make(chan Event, 64)
 	res, err := handleStream(
-		t.Context(), stream, a, nil, sess, nil,
+		t.Context(), nil, stream, a, nil, sess, nil,
 		defaultTelemetry{}, NewChannelSink(evCh),
 	)
 	require.NoError(t, err)
@@ -86,7 +89,7 @@ func TestHandleStream_RefusalDropsPartialToolCalls(t *testing.T) {
 
 	evCh := make(chan Event, 64)
 	res, err := handleStream(
-		t.Context(), stream, a, nil, sess, nil,
+		t.Context(), nil, stream, a, nil, sess, nil,
 		defaultTelemetry{}, NewChannelSink(evCh),
 	)
 	require.NoError(t, err)
@@ -111,7 +114,7 @@ func TestHandleStream_ToolCallAndStopInSameChunk(t *testing.T) {
 
 	evCh := make(chan Event, 64) // buffered so handleStream never blocks on Emit
 	res, err := handleStream(
-		t.Context(), stream, a, nil, sess, nil,
+		t.Context(), nil, stream, a, nil, sess, nil,
 		defaultTelemetry{}, NewChannelSink(evCh),
 	)
 	require.NoError(t, err)
@@ -139,7 +142,7 @@ func TestHandleStream_ToolCallThenSeparateStop(t *testing.T) {
 
 	evCh := make(chan Event, 64)
 	res, err := handleStream(
-		t.Context(), stream, a, nil, sess, nil,
+		t.Context(), nil, stream, a, nil, sess, nil,
 		defaultTelemetry{}, NewChannelSink(evCh),
 	)
 	require.NoError(t, err)
@@ -149,4 +152,101 @@ func TestHandleStream_ToolCallThenSeparateStop(t *testing.T) {
 	assert.JSONEq(t, `{"query":"x"}`, res.Calls[0].Function.Arguments)
 	assert.Equal(t, chat.FinishReasonToolCalls, res.FinishReason)
 	assert.False(t, res.Stopped)
+}
+
+// stalledStream is a chat.MessageStream that blocks in Recv() until
+// either unblocked or the stream is closed. It is used to simulate a
+// half-open TCP connection where the remote side stops sending data.
+type stalledStream struct {
+	// unblock is closed (or sent on) to release a blocked Recv call.
+	unblock chan struct{}
+	// closed is set when Close is called.
+	closed bool
+}
+
+func newStalledStream() *stalledStream {
+	return &stalledStream{unblock: make(chan struct{})}
+}
+
+// Recv blocks until unblock is closed, then returns io.EOF.
+func (s *stalledStream) Recv() (chat.MessageStreamResponse, error) {
+	<-s.unblock
+	return chat.MessageStreamResponse{}, io.EOF
+}
+
+func (s *stalledStream) Close() {
+	if !s.closed {
+		s.closed = true
+		close(s.unblock)
+	}
+}
+
+// withShortStreamIdleTimeout temporarily overrides defaultStreamIdleTimeout
+// to shorten it for tests. Restores the original value via t.Cleanup.
+func withShortStreamIdleTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	orig := defaultStreamIdleTimeout
+	defaultStreamIdleTimeout = d
+	t.Cleanup(func() { defaultStreamIdleTimeout = orig })
+}
+
+// TestHandleStream_IdleTimeout verifies that handleStream returns an error
+// wrapping errStreamIdle when no SSE chunk arrives within the idle window.
+// It also checks that the provided cancelStream function is called so the
+// HTTP transport can close the underlying TCP connection.
+func TestHandleStream_IdleTimeout(t *testing.T) {
+	withShortStreamIdleTimeout(t, 50*time.Millisecond)
+
+	stream := newStalledStream()
+	a := agent.New("root", "test", agent.WithModel(&mockProvider{id: "test/mock-model", stream: stream}))
+	sess := session.New(session.WithUserMessage("go"))
+
+	cancelCalled := false
+	cancelStream := func(cause error) {
+		cancelCalled = true
+		stream.Close() // unblock the stalled Recv so the reader goroutine can exit
+	}
+
+	evCh := make(chan Event, 64)
+	res, err := handleStream(
+		t.Context(), cancelStream, stream, a, nil, sess, nil,
+		defaultTelemetry{}, NewChannelSink(evCh),
+	)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, errStreamIdle, "error must wrap errStreamIdle")
+	assert.True(t, res.Stopped)
+	assert.True(t, cancelCalled, "cancelStream must be called on idle timeout")
+}
+
+// TestHandleStream_ContextCancellation verifies that handleStream returns
+// promptly when the caller's context is cancelled, even while a Recv call
+// is blocked. This covers the SIGTERM / graceful-shutdown path.
+func TestHandleStream_ContextCancellation(t *testing.T) {
+	// Use a long idle timeout so only context cancellation can trigger.
+	withShortStreamIdleTimeout(t, 10*time.Minute)
+
+	stream := newStalledStream()
+	a := agent.New("root", "test", agent.WithModel(&mockProvider{id: "test/mock-model", stream: stream}))
+	sess := session.New(session.WithUserMessage("go"))
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	// Cancel the context shortly after handleStream starts.
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+		stream.Close() // unblock the stalled Recv so the reader goroutine can exit
+	}()
+
+	evCh := make(chan Event, 64)
+	_, cancelStream := context.WithCancelCause(ctx)
+	res, err := handleStream(
+		ctx, cancelStream, stream, a, nil, sess, nil,
+		defaultTelemetry{}, NewChannelSink(evCh),
+	)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled, "error must be context.Canceled")
+	assert.True(t, res.Stopped)
 }


### PR DESCRIPTION
## Problem

A `docker-agent run` session hung permanently when a streaming LLM request to the model gateway stalled. The outbound TCP connection stayed ESTABLISHED but no data was flowing. Debug logs froze mid-request, CPU dropped to 0%, and SIGTERM was ignored — only SIGKILL worked.

**Root cause** (confirmed by code analysis):

The SSE stream-reading loop in `handleStream` blocked indefinitely in `stream.Recv()` → `bufio.Scanner.Scan()` → `body.Read()` → `syscall.Read`. There was no idle/read deadline and no explicit context-cancellation check between chunks, so:

1. A half-open TCP connection (remote side stopped sending data without closing) would park the goroutine forever.
2. SIGTERM (which cancels the root context) only helped if Go's `net/http` transport's `readLoop` goroutine happened to race ahead and call `pc.close()` before the `body.Read` blocked. Under scheduler contention or proxy configurations this race could be lost, making graceful shutdown unreliable.

## Fix

### `pkg/runtime/streaming.go`

- **Idle timeout**: `stream.Recv()` is moved into a dedicated reader goroutine. The main loop selects between the result channel, `ctx.Done()`, and a **5-minute idle timer**. The timer resets on every received chunk. If no chunk arrives within the window the stream is declared stalled.
- **cancelStream hook**: on idle timeout, `cancelStream(errStreamIdle)` is called. This cancels the HTTP-request child context, which propagates to Go's `net/http` transport's `readLoop`; `pc.close()` closes the TCP socket and unblocks the goroutine that is stuck in `body.Read()`.
- **Context cancellation**: the `ctx.Done()` select arm returns `ctx.Err()` immediately, making SIGTERM / Ctrl-C terminate the stream without racing against the transport.
- **Goroutine cleanup**: a `done` channel (closed via `defer`) signals the reader goroutine to exit on any return path, preventing leaks.

### `pkg/runtime/fallback.go`

- Creates a `context.WithCancelCause` child context (`streamCtx`) for each stream attempt.
- Passes `streamCtx` to `CreateChatCompletionStream` **and** `handleStream`.
- The `streamCancel` function is the `cancelStream` hook described above.

## Tests

Two new tests in `pkg/runtime/streaming_test.go`:

| Test | What it verifies |
|------|-----------------|
| `TestHandleStream_IdleTimeout` | A never-sending stream times out in 50 ms; `errStreamIdle` is returned; `cancelStream` is called |
| `TestHandleStream_ContextCancellation` | A never-sending stream is interrupted by context cancellation in 20 ms; `context.Canceled` is returned |

## Validation

- `task build` ✅
- `task test` ✅ (pre-existing `TestLoadExamples/{dmr,unload_on_switch}` failures confirmed unrelated)
- `task lint` ✅ (0 new golangci-lint issues; 2 pre-existing custom-linter warnings in unrelated files)

Closes #3209