### PR TITLE
feat: add OpenCode Go and OpenCode Zen provider support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,31 @@
-.opencode/
-22
-v2202602316573433449.powersrv.de
+bin
+dist
+.task
+/.cache/
+.DS_Store
+evals
+*.db*
+.crush
+.vscode
+.idea/
+*.debug
+/lint/lint
+
+# agents
+agent.yaml
+vendor
+
+# Local environment files
+.env.local
+.claude/settings.local.json
+
+# CI-downloaded binaries (cagent-action places these in the workspace root)
+/cagent
+/cagent-*
+/docker-mcp-*
+docker-agent
+
+# Generated wasm artifacts (built locally; see cmd/wasm/README.md)
+/wasm
+cmd/wasm/web/docker-agent.wasm
+cmd/wasm/web/wasm_exec.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,31 +1,3 @@
-bin
-dist
-.task
-/.cache/
-.DS_Store
-evals
-*.db*
-.crush
-.vscode
-.idea/
-*.debug
-/lint/lint
-
-# agents
-agent.yaml
-vendor
-
-# Local environment files
-.env.local
-.claude/settings.local.json
-
-# CI-downloaded binaries (cagent-action places these in the workspace root)
-/cagent
-/cagent-*
-/docker-mcp-*
-docker-agent
-
-# Generated wasm artifacts (built locally; see cmd/wasm/README.md)
-/wasm
-cmd/wasm/web/docker-agent.wasm
-cmd/wasm/web/wasm_exec.js
+.opencode/
+22
+v2202602316573433449.powersrv.de

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ docker-agent
 /wasm
 cmd/wasm/web/docker-agent.wasm
 cmd/wasm/web/wasm_exec.js
+
+# Knowledge graph output
+/graphify-out/

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,3 @@ docker-agent
 /wasm
 cmd/wasm/web/docker-agent.wasm
 cmd/wasm/web/wasm_exec.js
-
-# Knowledge graph output
-/graphify-out/

--- a/cmd/root/models.go
+++ b/cmd/root/models.go
@@ -17,8 +17,9 @@ import (
 	"github.com/docker/docker-agent/pkg/cli"
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/environment"
+	"github.com/docker/docker-agent/pkg/httpclient"
 	"github.com/docker/docker-agent/pkg/model/provider"
-	"github.com/docker/docker-agent/pkg/remote"
 	"github.com/docker/docker-agent/pkg/telemetry"
 )
 
@@ -27,6 +28,22 @@ type modelsListFlags struct {
 	format         string
 	all            bool
 	runConfig      config.RuntimeConfig
+}
+
+// listTimeout bounds the live /v1/models request for the `models list` command
+// so a slow or unreachable provider endpoint cannot stall an interactive
+// listing. Matches the 5-second budget used by DMR and models-gateway
+// discovery (pkg/model/provider/dmr/list.go, pkg/modelsgateway/discovery.go).
+const listTimeout = 5 * time.Second
+
+// liveFetchProviders is the allow-list of catalog aliases that may be queried
+// directly at their own /v1/models endpoint when models.dev does not yet
+// include them. Scoping the fetch (rather than firing for every alias absent
+// from the snapshot) prevents surprising side effects like `docker agent models
+// --provider ollama` issuing a real GET against localhost.
+var liveFetchProviders = map[string]bool{
+	"opencode-zen": true,
+	"opencode-go":  true,
 }
 
 // modelRow represents a single model entry for display or serialization.
@@ -94,6 +111,13 @@ func (f *modelsListFlags) runModelsListCommand(cmd *cobra.Command, args []string
 	out := cli.NewPrinter(cmd.OutOrStdout())
 	env := f.runConfig.EnvProvider()
 
+	// Normalize the provider filter to lowercase so case-sensitive map lookups
+	// in AvailableProviders, db.Providers and IsCatalogProvider all match the
+	// same way strings.EqualFold does in the outer row filter below.
+	if f.providerFilter != "" {
+		f.providerFilter = strings.ToLower(f.providerFilter)
+	}
+
 	// Determine which providers the user has credentials for.
 	availableProviders := make(map[string]bool)
 	for _, p := range config.AvailableProviders(ctx, f.runConfig.ModelsGateway, env) {
@@ -106,7 +130,7 @@ func (f *modelsListFlags) runModelsListCommand(cmd *cobra.Command, args []string
 	// default rather than a locally-pulled DMR model.
 	autoModel := config.AutoModelConfig(ctx, f.runConfig.ModelsGateway, env, f.runConfig.DefaultModel, nil)
 
-	rows := f.collectModels(ctx, availableProviders, autoModel)
+	rows := f.collectModels(ctx, env, availableProviders, autoModel)
 
 	// Apply provider filter
 	if f.providerFilter != "" {
@@ -148,7 +172,7 @@ func (f *modelsListFlags) runModelsListCommand(cmd *cobra.Command, args []string
 // collectModels returns all models from the catalog, filtered by credential
 // availability unless --all is set. Default models for each available provider
 // are always included even if the catalog fetch fails.
-func (f *modelsListFlags) collectModels(ctx context.Context, availableProviders map[string]bool, autoModel latest.ModelConfig) []modelRow {
+func (f *modelsListFlags) collectModels(ctx context.Context, env environment.Provider, availableProviders map[string]bool, autoModel latest.ModelConfig) []modelRow {
 	seen := make(map[string]bool)
 	var rows []modelRow
 
@@ -205,22 +229,25 @@ func (f *modelsListFlags) collectModels(ctx context.Context, availableProviders 
 		}
 	}
 
-	// When the user explicitly filters by provider (--provider), try fetching
-	// models directly from that provider's own API if models.dev lacks it.
-	if f.providerFilter != "" && db != nil && (f.all || availableProviders[f.providerFilter]) {
+	// When the user explicitly filters by provider (--provider) and that
+	// provider is one of the catalog aliases that publishes a live /v1/models
+	// endpoint but is not yet in the embedded models.dev snapshot, fetch the
+	// catalog directly. Scoping the query to liveFetchProviders keeps the
+	// listing side-effect-free for every other alias (e.g. ollama), and the
+	// `availableProviders` guard (or `--all`) prevents a network call when the
+	// user has not configured credentials for the alias.
+	if f.providerFilter != "" && (f.all || availableProviders[f.providerFilter]) && liveFetchProviders[f.providerFilter] {
 		if _, exists := db.Providers[f.providerFilter]; !exists {
-			if provider.IsCatalogProvider(f.providerFilter) {
-				for _, m := range fetchProviderModels(ctx, f.providerFilter) {
-					if isEmbeddingModel(m, m) {
-						continue
-					}
-					ref := f.providerFilter + "/" + m
-					if seen[ref] {
-						continue
-					}
-					seen[ref] = true
-					rows = append(rows, modelRow{Provider: f.providerFilter, Model: m})
+			for _, m := range fetchProviderModels(ctx, f.providerFilter, env) {
+				if isEmbeddingModel(m, m) {
+					continue
 				}
+				ref := f.providerFilter + "/" + m
+				if seen[ref] {
+					continue
+				}
+				seen[ref] = true
+				rows = append(rows, modelRow{Provider: f.providerFilter, Model: m})
 			}
 		}
 	}
@@ -237,29 +264,60 @@ type openAIModelsResponse struct {
 
 // fetchProviderModels fetches the model list from a provider's own /v1/models
 // endpoint. Only works for alias providers with a predefined BaseURL.
-func fetchProviderModels(ctx context.Context, providerName string) []string {
+//
+// The request:
+//   - Uses httpclient.NewHTTPClient so it carries the Cagent User-Agent and
+//     OpenTelemetry tracing like every other outbound call.
+//   - Sends Bearer auth using the alias's declared TokenEnvVar, so an
+//     authenticated user does not silently receive an empty list from a
+//     provider that requires the API key on /v1/models.
+//   - Bounded by listTimeout (5s) so a slow endpoint cannot stall `models list`.
+func fetchProviderModels(ctx context.Context, providerName string, env environment.Provider) []string {
 	alias, ok := provider.LookupAlias(providerName)
 	if !ok || alias.BaseURL == "" {
 		return nil
 	}
 
 	modelsURL := strings.TrimRight(alias.BaseURL, "/") + "/models"
-	client := &http.Client{
-		Timeout:   30 * time.Second,
-		Transport: remote.NewTransport(ctx),
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, modelsURL, http.NoBody)
+	if err != nil {
+		slog.WarnContext(ctx, "failed to create request for provider models", "url", modelsURL, "error", err)
+		return nil
 	}
-	return fetchModelsFromURL(ctx, modelsURL, client)
+
+	// Send the alias's declared API key so providers that require it on
+	// /v1/models authenticate the request instead of returning 401/403.
+	if alias.TokenEnvVar != "" {
+		if token, _ := env.Get(ctx, alias.TokenEnvVar); token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, listTimeout)
+	defer cancel()
+
+	return dispatchModelsRequest(ctx, req, httpclient.NewHTTPClient(ctx))
 }
 
-// fetchModelsFromURL fetches and parses an OpenAI-compatible models list
-// from the given URL. The client parameter allows tests to inject an
-// httptest server's client.
+// fetchModelsFromURL fetches and parses an OpenAI-compatible models list from
+// the given URL using the supplied client. It is a thin wrapper around
+// dispatchModelsRequest for tests that inject an httptest server's client.
 func fetchModelsFromURL(ctx context.Context, url string, client *http.Client) []string {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	if err != nil {
 		slog.WarnContext(ctx, "failed to create request for provider models", "url", url, "error", err)
 		return nil
 	}
+	return dispatchModelsRequest(ctx, req, client)
+}
+
+// dispatchModelsRequest sends req via client and parses the OpenAI-style model
+// list returned. Empty IDs are skipped; duplicates are preserved (the caller
+// — collectModels — already deduplicates by ref). The function logs and
+// returns nil on any failure so the listing command degrades gracefully.
+func dispatchModelsRequest(ctx context.Context, req *http.Request, client *http.Client) []string {
+	url := req.URL.String()
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/cmd/root/models.go
+++ b/cmd/root/models.go
@@ -207,10 +207,13 @@ func (f *modelsListFlags) collectModels(ctx context.Context, availableProviders 
 
 	// When the user explicitly filters by provider (--provider), try fetching
 	// models directly from that provider's own API if models.dev lacks it.
-	if f.providerFilter != "" && db != nil {
+	if f.providerFilter != "" && db != nil && (f.all || availableProviders[f.providerFilter]) {
 		if _, exists := db.Providers[f.providerFilter]; !exists {
 			if provider.IsCatalogProvider(f.providerFilter) {
 				for _, m := range fetchProviderModels(ctx, f.providerFilter) {
+					if isEmbeddingModel(m, m) {
+						continue
+					}
 					ref := f.providerFilter + "/" + m
 					if seen[ref] {
 						continue

--- a/cmd/root/models.go
+++ b/cmd/root/models.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"slices"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -16,6 +18,7 @@ import (
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/model/provider"
+	"github.com/docker/docker-agent/pkg/remote"
 	"github.com/docker/docker-agent/pkg/telemetry"
 )
 
@@ -202,27 +205,20 @@ func (f *modelsListFlags) collectModels(ctx context.Context, availableProviders 
 		}
 	}
 
-	// For catalog providers not found in models.dev, try fetching models
-	// directly from the provider's own API (e.g. opencode-zen).
-	for _, name := range provider.CatalogProviders() {
-		if name == "dmr" {
-			continue
-		}
-		if _, exists := db.Providers[name]; exists {
-			continue
-		}
-		if !f.all && !availableProviders[name] {
-			continue
-		}
-
-		models := fetchProviderModels(ctx, name)
-		for _, m := range models {
-			ref := name + "/" + m
-			if seen[ref] {
-				continue
+	// When the user explicitly filters by provider (--provider), try fetching
+	// models directly from that provider's own API if models.dev lacks it.
+	if f.providerFilter != "" && db != nil {
+		if _, exists := db.Providers[f.providerFilter]; !exists {
+			if provider.IsCatalogProvider(f.providerFilter) {
+				for _, m := range fetchProviderModels(ctx, f.providerFilter) {
+					ref := f.providerFilter + "/" + m
+					if seen[ref] {
+						continue
+					}
+					seen[ref] = true
+					rows = append(rows, modelRow{Provider: f.providerFilter, Model: m})
+				}
 			}
-			seen[ref] = true
-			rows = append(rows, modelRow{Provider: name, Model: m})
 		}
 	}
 
@@ -245,33 +241,52 @@ func fetchProviderModels(ctx context.Context, providerName string) []string {
 	}
 
 	modelsURL := strings.TrimRight(alias.BaseURL, "/") + "/models"
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, modelsURL, http.NoBody)
+	client := &http.Client{
+		Timeout:   30 * time.Second,
+		Transport: remote.NewTransport(ctx),
+	}
+	return fetchModelsFromURL(ctx, modelsURL, client)
+}
+
+// fetchModelsFromURL fetches and parses an OpenAI-compatible models list
+// from the given URL. The client parameter allows tests to inject an
+// httptest server's client.
+func fetchModelsFromURL(ctx context.Context, url string, client *http.Client) []string {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	if err != nil {
+		slog.WarnContext(ctx, "failed to create request for provider models", "url", url, "error", err)
 		return nil
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
+		slog.WarnContext(ctx, "failed to fetch provider models", "url", url, "error", err)
 		return nil
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		slog.WarnContext(ctx, "provider models endpoint returned non-200", "url", url, "status", resp.StatusCode)
 		return nil
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
+		slog.WarnContext(ctx, "failed to read provider models response", "url", url, "error", err)
 		return nil
 	}
 
 	var result openAIModelsResponse
 	if err := json.Unmarshal(body, &result); err != nil {
+		slog.WarnContext(ctx, "failed to parse provider models response", "url", url, "error", err)
 		return nil
 	}
 
 	models := make([]string, 0, len(result.Data))
 	for _, m := range result.Data {
+		if m.ID == "" {
+			continue
+		}
 		models = append(models, m.ID)
 	}
 	return models

--- a/cmd/root/models.go
+++ b/cmd/root/models.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"slices"
 	"strings"
 	"text/tabwriter"
@@ -200,7 +202,79 @@ func (f *modelsListFlags) collectModels(ctx context.Context, availableProviders 
 		}
 	}
 
+	// For catalog providers not found in models.dev, try fetching models
+	// directly from the provider's own API (e.g. opencode-zen).
+	for _, name := range provider.CatalogProviders() {
+		if name == "dmr" {
+			continue
+		}
+		if _, exists := db.Providers[name]; exists {
+			continue
+		}
+		if !f.all && !availableProviders[name] {
+			continue
+		}
+
+		models := fetchProviderModels(ctx, name)
+		for _, m := range models {
+			ref := name + "/" + m
+			if seen[ref] {
+				continue
+			}
+			seen[ref] = true
+			rows = append(rows, modelRow{Provider: name, Model: m})
+		}
+	}
+
 	return rows
+}
+
+// openAIModelsResponse is the standard OpenAI-compatible models list format.
+type openAIModelsResponse struct {
+	Data []struct {
+		ID string `json:"id"`
+	} `json:"data"`
+}
+
+// fetchProviderModels fetches the model list from a provider's own /v1/models
+// endpoint. Only works for alias providers with a predefined BaseURL.
+func fetchProviderModels(ctx context.Context, providerName string) []string {
+	alias, ok := provider.LookupAlias(providerName)
+	if !ok || alias.BaseURL == "" {
+		return nil
+	}
+
+	modelsURL := strings.TrimRight(alias.BaseURL, "/") + "/models"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, modelsURL, http.NoBody)
+	if err != nil {
+		return nil
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil
+	}
+
+	var result openAIModelsResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil
+	}
+
+	models := make([]string, 0, len(result.Data))
+	for _, m := range result.Data {
+		models = append(models, m.ID)
+	}
+	return models
 }
 
 func isEmbeddingModel(family, name string) bool {

--- a/cmd/root/models_test.go
+++ b/cmd/root/models_test.go
@@ -146,11 +146,12 @@ func TestFetchModelsFromURL_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/v1/models", r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"object":"list","data":[
+		_, err := w.Write([]byte(`{"object":"list","data":[
 			{"id":"model-a","object":"model"},
 			{"id":"model-b","object":"model"},
 			{"id":"model-c","object":"model"}
 		]}`))
+		assert.NoError(t, err)
 	}))
 	t.Cleanup(server.Close)
 
@@ -187,7 +188,8 @@ func TestFetchModelsFromURL_MalformedJSON(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`not json`))
+		_, err := w.Write([]byte(`not json`))
+		assert.NoError(t, err)
 	}))
 	t.Cleanup(server.Close)
 
@@ -212,7 +214,8 @@ func TestFetchModelsFromURL_EmptyDataArray(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"object":"list","data":[]}`))
+		_, err := w.Write([]byte(`{"object":"list","data":[]}`))
+		assert.NoError(t, err)
 	}))
 	t.Cleanup(server.Close)
 
@@ -225,11 +228,12 @@ func TestFetchModelsFromURL_DuplicateIDs(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"object":"list","data":[
+		_, err := w.Write([]byte(`{"object":"list","data":[
 			{"id":"dup"},
 			{"id":"dup"},
 			{"id":"unique"}
 		]}`))
+		assert.NoError(t, err)
 	}))
 	t.Cleanup(server.Close)
 
@@ -242,11 +246,12 @@ func TestFetchModelsFromURL_EmptyIDs(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"object":"list","data":[
+		_, err := w.Write([]byte(`{"object":"list","data":[
 			{"id":""},
 			{"id":"valid"},
 			{"id":""}
 		]}`))
+		assert.NoError(t, err)
 	}))
 	t.Cleanup(server.Close)
 
@@ -277,10 +282,11 @@ func TestFetchModelsFromURL_SkipsEmbeddingModels(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"object":"list","data":[
+		_, err := w.Write([]byte(`{"object":"list","data":[
 			{"id":"text-embedding-3"},
 			{"id":"gpt-5"}
 		]}`))
+		assert.NoError(t, err)
 	}))
 	t.Cleanup(server.Close)
 

--- a/cmd/root/models_test.go
+++ b/cmd/root/models_test.go
@@ -2,8 +2,12 @@ package root
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -134,6 +138,154 @@ func TestModelsListCommand_DefaultMarker(t *testing.T) {
 			assert.True(t, r.Default, "auto-selected model %s/%s should be marked as default", r.Provider, r.Model)
 		}
 	}
+}
+
+func TestFetchModelsFromURL_Success(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/models", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"object":"list","data":[
+			{"id":"model-a","object":"model"},
+			{"id":"model-b","object":"model"},
+			{"id":"model-c","object":"model"}
+		]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	models := fetchModelsFromURL(t.Context(), server.URL+"/v1/models", server.Client())
+	assert.Equal(t, []string{"model-a", "model-b", "model-c"}, models)
+}
+
+func TestFetchModelsFromURL_Non200(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(server.Close)
+
+	models := fetchModelsFromURL(t.Context(), server.URL+"/v1/models", server.Client())
+	assert.Empty(t, models)
+}
+
+func TestFetchModelsFromURL_Status500(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	models := fetchModelsFromURL(t.Context(), server.URL+"/v1/models", server.Client())
+	assert.Empty(t, models)
+}
+
+func TestFetchModelsFromURL_MalformedJSON(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`not json`))
+	}))
+	t.Cleanup(server.Close)
+
+	models := fetchModelsFromURL(t.Context(), server.URL+"/v1/models", server.Client())
+	assert.Empty(t, models)
+}
+
+func TestFetchModelsFromURL_EmptyBody(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+	}))
+	t.Cleanup(server.Close)
+
+	models := fetchModelsFromURL(t.Context(), server.URL+"/v1/models", server.Client())
+	assert.Empty(t, models)
+}
+
+func TestFetchModelsFromURL_EmptyDataArray(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"object":"list","data":[]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	models := fetchModelsFromURL(t.Context(), server.URL+"/v1/models", server.Client())
+	assert.Empty(t, models)
+}
+
+func TestFetchModelsFromURL_DuplicateIDs(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"object":"list","data":[
+			{"id":"dup"},
+			{"id":"dup"},
+			{"id":"unique"}
+		]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	models := fetchModelsFromURL(t.Context(), server.URL+"/v1/models", server.Client())
+	assert.Equal(t, []string{"dup", "dup", "unique"}, models)
+}
+
+func TestFetchModelsFromURL_EmptyIDs(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"object":"list","data":[
+			{"id":""},
+			{"id":"valid"},
+			{"id":""}
+		]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	models := fetchModelsFromURL(t.Context(), server.URL+"/v1/models", server.Client())
+	assert.Equal(t, []string{"valid"}, models)
+}
+
+func TestFetchModelsFromURL_ContextCanceled(t *testing.T) {
+	t.Parallel()
+
+	var called atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called.Store(true)
+	}))
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	models := fetchModelsFromURL(ctx, server.URL+"/v1/models", server.Client())
+	assert.Empty(t, models)
+}
+
+func TestFetchModelsFromURL_SkipsEmbeddingModels(t *testing.T) {
+	// The function passes all model IDs through; embedding filtering
+	// is done at the caller level (collectModels). Verify IDs are intact.
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"object":"list","data":[
+			{"id":"text-embedding-3"},
+			{"id":"gpt-5"}
+		]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	models := fetchModelsFromURL(t.Context(), server.URL+"/v1/models", server.Client())
+	assert.Equal(t, []string{"text-embedding-3", "gpt-5"}, models)
 }
 
 func TestModelsListCommand_NoCredentials(t *testing.T) {

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -131,10 +131,10 @@
       url: /providers/bedrock/
     - title: Docker Model Runner
       url: /providers/dmr/
-    - title: OpenCode Go
-      url: /providers/opencode-go/
     - title: OpenCode Zen
       url: /providers/opencode-zen/
+    - title: OpenCode Go
+      url: /providers/opencode-go/
     - title: Mistral
       url: /providers/mistral/
     - title: "xAI (Grok)"

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -131,6 +131,10 @@
       url: /providers/bedrock/
     - title: Docker Model Runner
       url: /providers/dmr/
+    - title: OpenCode Go
+      url: /providers/opencode-go/
+    - title: OpenCode Zen
+      url: /providers/opencode-zen/
     - title: Mistral
       url: /providers/mistral/
     - title: "xAI (Grok)"

--- a/docs/providers/opencode-go/index.md
+++ b/docs/providers/opencode-go/index.md
@@ -154,7 +154,7 @@ agents:
 OpenCode Go subscriptions include the following limits:
 
 - **5-hour rolling limit** — $12 of usage
-- **Weekly limit** — $30 of usage  
+- **Weekly limit** — $30 of usage
 - **Monthly limit** — $60 of usage
 
 Limits are defined as dollar values. More expensive models allow fewer requests per limit period. You can also [add Zen balance](https://opencode.ai/auth) to continue usage beyond the limits.

--- a/docs/providers/opencode-go/index.md
+++ b/docs/providers/opencode-go/index.md
@@ -10,7 +10,7 @@ _Use OpenCode Go models with docker-agent._
 
 ## Overview
 
-[OpenCode Go](https://opencode.ai/docs/es/go) is a low-cost subscription service ($5 first month, then $10/month) that provides reliable access to popular open-source coding models. It serves models through both OpenAI-compatible and Anthropic-compatible APIs from globally distributed endpoints.
+[OpenCode Go](https://opencode.ai/docs/go) is a low-cost subscription service ($5 first month, then $10/month) that provides reliable access to popular open-source coding models. It serves models through both OpenAI-compatible and Anthropic-compatible APIs from globally distributed endpoints.
 
 docker-agent includes built-in support for OpenCode Go as an alias provider.
 

--- a/docs/providers/opencode-go/index.md
+++ b/docs/providers/opencode-go/index.md
@@ -1,0 +1,160 @@
+---
+title: "OpenCode Go"
+description: "Use OpenCode Go models with docker-agent."
+permalink: /providers/opencode-go/
+---
+
+# OpenCode Go
+
+_Use OpenCode Go models with docker-agent._
+
+## Overview
+
+[OpenCode Go](https://opencode.ai/docs/es/go) is a low-cost subscription service ($5 first month, then $10/month) that provides reliable access to popular open-source coding models. It serves models through both OpenAI-compatible and Anthropic-compatible APIs from globally distributed endpoints.
+
+docker-agent includes built-in support for OpenCode Go as an alias provider.
+
+## Setup
+
+1. Subscribe to OpenCode Go at [opencode.ai/auth](https://opencode.ai/auth)
+2. Copy your API key from the console
+3. Set the environment variable:
+
+   ```bash
+   export OPENCODE_API_KEY=your-api-key
+   ```
+
+## Usage
+
+### Inline Syntax
+
+The simplest way to use OpenCode Go:
+
+```yaml
+agents:
+  root:
+    model: opencode-go/deepseek-v4-flash
+    description: Assistant using OpenCode Go
+    instruction: You are a helpful assistant.
+```
+
+### Named Model
+
+For more control over parameters:
+
+```yaml
+models:
+  my_model:
+    provider: opencode-go
+    model: deepseek-v4-pro
+    temperature: 0.7
+    max_tokens: 8192
+
+agents:
+  root:
+    model: my_model
+    description: Assistant using OpenCode Go
+    instruction: You are a helpful assistant.
+```
+
+## Available Models
+
+You can retrieve the full, up-to-date model list at any time:
+
+```bash
+curl https://opencode.ai/zen/go/v1/models
+```
+
+### OpenAI-Compatible
+
+These models use the `/v1/chat/completions` endpoint and work directly with the `opencode-go` alias:
+
+| Model               | Description                           |
+| ------------------- | ------------------------------------- |
+| `deepseek-v4-flash` | Fast and cost-effective DeepSeek model |
+| `deepseek-v4-pro`   | Most capable DeepSeek model           |
+| `kimi-k2.7-code`    | Kimi K2.7 optimized for code          |
+| `kimi-k2.6`         | Kimi K2.6 model                       |
+| `kimi-k2.5`         | Kimi K2.5 model                       |
+| `glm-5.2`           | GLM 5.2 flagship model                |
+| `glm-5.1`           | GLM 5.1 model                         |
+| `glm-5`             | GLM 5 model                           |
+| `mimo-v2.5`         | MiMo V2.5 efficient model             |
+| `mimo-v2.5-pro`     | MiMo V2.5 Pro model                   |
+| `mimo-v2-pro`       | MiMo V2 Pro model                     |
+| `mimo-v2-omni`      | MiMo V2 Omni model                    |
+| `hy3-preview`       | HY3 preview model                     |
+
+### Anthropic-Compatible
+
+These models use the `/v1/messages` endpoint and require a [custom provider definition]({{ '/providers/custom/' | relative_url }}):
+
+| Model             | Description              |
+| ----------------- | ------------------------ |
+| `minimax-m3`      | MiniMax M3 model         |
+| `minimax-m2.7`    | MiniMax M2.7 model       |
+| `minimax-m2.5`    | MiniMax M2.5 model       |
+| `qwen3.7-max`     | Qwen 3.7 Max model       |
+| `qwen3.7-plus`    | Qwen 3.7 Plus model      |
+| `qwen3.6-plus`    | Qwen 3.6 Plus model      |
+| `qwen3.5-plus`    | Qwen 3.5 Plus model      |
+
+To use an Anthropic-compatible model, define a custom provider:
+
+```yaml
+providers:
+  opengo-ant:
+    provider: anthropic
+    base_url: https://opencode.ai/zen/go
+    token_key: OPENCODE_API_KEY
+
+models:
+  qwen:
+    provider: opengo-ant
+    model: qwen3.7-max
+
+agents:
+  root:
+    model: qwen
+    description: Assistant using Qwen through OpenCode Go
+    instruction: You are a helpful assistant.
+```
+
+## How It Works
+
+OpenCode Go is implemented as a built-in alias in docker-agent:
+
+- **API Type:** OpenAI-compatible (`openai_chatcompletions`)
+- **Base URL:** `https://opencode.ai/zen/go/v1`
+- **Token Variable:** `OPENCODE_API_KEY`
+
+This means OpenCode Go uses the same client as OpenAI, making it fully compatible with all OpenAI features supported by docker-agent.
+
+For Anthropic-compatible models (MiniMax, Qwen), docker-agent uses a custom provider pointing to the Anthropic client at `https://opencode.ai/zen/go` with the same token.
+
+## Example: Code Assistant
+
+```yaml
+agents:
+  coder:
+    model: opencode-go/deepseek-v4-flash
+    description: Expert code assistant
+    instruction: |
+      You are an expert programmer using DeepSeek V4 Flash.
+      Write clean, efficient, well-documented code.
+      Explain your reasoning when helpful.
+    toolsets:
+      - type: filesystem
+      - type: shell
+      - type: think
+```
+
+## Usage Limits
+
+OpenCode Go subscriptions include the following limits:
+
+- **5-hour rolling limit** — $12 of usage
+- **Weekly limit** — $30 of usage  
+- **Monthly limit** — $60 of usage
+
+Limits are defined as dollar values. More expensive models allow fewer requests per limit period. You can also [add Zen balance](https://opencode.ai/auth) to continue usage beyond the limits.

--- a/docs/providers/opencode-zen/index.md
+++ b/docs/providers/opencode-zen/index.md
@@ -177,7 +177,7 @@ To use a Google model:
 providers:
   opencode-zen-gemini:
     provider: google
-    base_url: https://opencode.ai/zen/v1
+    base_url: https://opencode.ai/zen
     token_key: OPENCODE_API_KEY
 
 models:
@@ -202,7 +202,7 @@ OpenCode Zen is implemented as a built-in alias in docker-agent:
 
 The same API key works for both OpenCode Go and OpenCode Zen — they are part of the same platform. Zen uses a pay-per-use billing model, while Go uses a fixed subscription.
 
-For Anthropic-compatible models, docker-agent uses a custom provider pointing to the Anthropic client at `https://opencode.ai/zen` with the same token. For Google models, a custom provider points to the Google client at `https://opencode.ai/zen/v1`.
+For Anthropic-compatible models, docker-agent uses a custom provider pointing to the Anthropic client at `https://opencode.ai/zen` with the same token. For Google models, a custom provider points to the Google client at `https://opencode.ai/zen` (the Google SDK appends its own `/v1beta/models/...` path segment).
 
 ### Differences from OpenCode Go
 

--- a/docs/providers/opencode-zen/index.md
+++ b/docs/providers/opencode-zen/index.md
@@ -10,7 +10,7 @@ _Use OpenCode Zen models with docker-agent._
 
 ## Overview
 
-[OpenCode Zen](https://opencode.ai/docs/es/zen) is a curated gateway of tested and verified AI models provided by the OpenCode team. It offers pay-per-use access to a wide range of models — from GPT and Claude to open-source models — all through a single API key. Several free models are also available.
+[OpenCode Zen](https://opencode.ai/docs/zen) is a curated gateway of tested and verified AI models provided by the OpenCode team. It offers pay-per-use access to a wide range of models — from GPT and Claude to open-source models — all through a single API key. Several free models are also available.
 
 docker-agent includes built-in support for OpenCode Zen as an alias provider for OpenAI-compatible models. Anthropic and Google models are supported via custom provider definitions.
 
@@ -126,15 +126,15 @@ These models use the `/v1/messages` endpoint and require a [custom provider defi
 | Model                   | Description                   |
 | ----------------------- | ----------------------------- |
 | `claude-fable-5`        | Claude Fable 5 model          |
-| `claude-opus-4.8`       | Claude Opus 4.8 model         |
-| `claude-opus-4.7`       | Claude Opus 4.7 model         |
-| `claude-opus-4.6`       | Claude Opus 4.6 model         |
-| `claude-opus-4.5`       | Claude Opus 4.5 model         |
-| `claude-opus-4.1`       | Claude Opus 4.1 model         |
-| `claude-sonnet-4.6`     | Claude Sonnet 4.6 model       |
-| `claude-sonnet-4.5`     | Claude Sonnet 4.5 model       |
+| `claude-opus-4-8`       | Claude Opus 4.8 model         |
+| `claude-opus-4-7`       | Claude Opus 4.7 model         |
+| `claude-opus-4-6`       | Claude Opus 4.6 model         |
+| `claude-opus-4-5`       | Claude Opus 4.5 model         |
+| `claude-opus-4-1`       | Claude Opus 4.1 model         |
+| `claude-sonnet-4-6`     | Claude Sonnet 4.6 model       |
+| `claude-sonnet-4-5`     | Claude Sonnet 4.5 model       |
 | `claude-sonnet-4`       | Claude Sonnet 4 model         |
-| `claude-haiku-4.5`      | Claude Haiku 4.5 model        |
+| `claude-haiku-4-5`      | Claude Haiku 4.5 model        |
 | `qwen3.7-max`           | Qwen 3.7 Max model            |
 | `qwen3.7-plus`          | Qwen 3.7 Plus model           |
 | `qwen3.6-plus`          | Qwen 3.6 Plus model           |
@@ -152,7 +152,7 @@ providers:
 models:
   claude:
     provider: opencode-zen-claude
-    model: claude-sonnet-4.5
+    model: claude-sonnet-4-5
 
 agents:
   root:
@@ -177,7 +177,7 @@ To use a Google model:
 providers:
   opencode-zen-gemini:
     provider: google
-    base_url: https://opencode.ai/zen/v1/models
+    base_url: https://opencode.ai/zen/v1
     token_key: OPENCODE_API_KEY
 
 models:
@@ -202,7 +202,7 @@ OpenCode Zen is implemented as a built-in alias in docker-agent:
 
 The same API key works for both OpenCode Go and OpenCode Zen — they are part of the same platform. Zen uses a pay-per-use billing model, while Go uses a fixed subscription.
 
-For Anthropic-compatible models, docker-agent uses a custom provider pointing to the Anthropic client at `https://opencode.ai/zen` with the same token. For Google models, a custom provider points to the Google client at `https://opencode.ai/zen/v1/models`.
+For Anthropic-compatible models, docker-agent uses a custom provider pointing to the Anthropic client at `https://opencode.ai/zen` with the same token. For Google models, a custom provider points to the Google client at `https://opencode.ai/zen/v1`.
 
 ### Differences from OpenCode Go
 
@@ -215,7 +215,7 @@ For Anthropic-compatible models, docker-agent uses a custom provider pointing to
 
 ## Usage Limits and Pricing
 
-OpenCode Zen uses a pay-per-use model. See the [OpenCode Zen documentation](https://opencode.ai/docs/es/zen) for current pricing. Automatic top-up and monthly usage limits are available from the console.
+OpenCode Zen uses a pay-per-use model. See the [OpenCode Zen documentation](https://opencode.ai/docs/zen) for current pricing. Automatic top-up and monthly usage limits are available from the console.
 
 You can retrieve the full model catalog at any time:
 

--- a/docs/providers/opencode-zen/index.md
+++ b/docs/providers/opencode-zen/index.md
@@ -1,0 +1,224 @@
+---
+title: "OpenCode Zen"
+description: "Use OpenCode Zen models with docker-agent."
+permalink: /providers/opencode-zen/
+---
+
+# OpenCode Zen
+
+_Use OpenCode Zen models with docker-agent._
+
+## Overview
+
+[OpenCode Zen](https://opencode.ai/docs/es/zen) is a curated gateway of tested and verified AI models provided by the OpenCode team. It offers pay-per-use access to a wide range of models — from GPT and Claude to open-source models — all through a single API key. Several free models are also available.
+
+docker-agent includes built-in support for OpenCode Zen as an alias provider for OpenAI-compatible models. Anthropic and Google models are supported via custom provider definitions.
+
+## Setup
+
+1. Sign in to [OpenCode Zen](https://opencode.ai/auth), add billing information, and copy your API key
+2. Set the environment variable:
+
+   ```bash
+   export OPENCODE_API_KEY=your-api-key
+   ```
+
+3. Verify available models:
+
+   ```bash
+   curl https://opencode.ai/zen/v1/models
+   ```
+
+## Usage
+
+### Inline Syntax
+
+The simplest way to use OpenCode Zen with a free model:
+
+```yaml
+agents:
+  root:
+    model: opencode-zen/deepseek-v4-flash-free
+    description: Assistant using OpenCode Zen (free)
+    instruction: You are a helpful assistant.
+```
+
+### Named Model
+
+For more control over parameters:
+
+```yaml
+models:
+  zen_model:
+    provider: opencode-zen
+    model: gpt-5.5
+    temperature: 0.7
+    max_tokens: 16384
+
+agents:
+  root:
+    model: zen_model
+    description: Assistant using OpenCode Zen
+    instruction: You are a helpful assistant.
+```
+
+## Available Models
+
+### Free Models
+
+These models are available at no cost:
+
+| Model                     | Description                        |
+| ------------------------- | ---------------------------------- |
+| `deepseek-v4-flash-free`  | Free DeepSeek V4 Flash             |
+| `mimo-v2.5-free`          | Free MiMo V2.5 model               |
+| `qwen3.6-plus-free`       | Free Qwen 3.6 Plus model           |
+| `minimax-m3-free`         | Free MiniMax M3 model              |
+| `nemotron-3-ultra-free`   | Free Nemotron 3 Ultra model        |
+| `north-mini-code-free`    | Free North Mini Code model         |
+| `big-pickle`              | Free stealth model                 |
+
+### OpenAI-Compatible (Chat Completions)
+
+These models use the `/v1/chat/completions` endpoint and work directly with the `opencode-zen` alias:
+
+| Model                 | Description                        |
+| --------------------- | ---------------------------------- |
+| `deepseek-v4-pro`     | DeepSeek V4 Pro model              |
+| `deepseek-v4-flash`   | Fast DeepSeek V4 model             |
+| `glm-5.2`             | GLM 5.2 model                      |
+| `glm-5.1`             | GLM 5.1 model                      |
+| `glm-5`               | GLM 5 model                        |
+| `kimi-k2.6`           | Kimi K2.6 model                    |
+| `kimi-k2.5`           | Kimi K2.5 model                    |
+| `minimax-m2.7`        | MiniMax M2.7 model                 |
+| `minimax-m2.5`        | MiniMax M2.5 model                 |
+| `grok-build-0.1`      | Grok Build 0.1 model               |
+
+### OpenAI-Compatible (Responses API)
+
+These models use the `/v1/responses` endpoint and are auto-detected by docker-agent based on the model name:
+
+| Model                  | Description                       |
+| ---------------------- | --------------------------------- |
+| `gpt-5.5`              | Latest GPT model                  |
+| `gpt-5.5-pro`          | GPT 5.5 Pro, highest capability   |
+| `gpt-5.4`              | GPT 5.4 model                     |
+| `gpt-5.4-pro`          | GPT 5.4 Pro model                 |
+| `gpt-5.4-mini`         | GPT 5.4 Mini model                |
+| `gpt-5.4-nano`         | GPT 5.4 Nano, fastest             |
+| `gpt-5.3-codex`        | GPT 5.3 Codex for coding          |
+| `gpt-5.3-codex-spark`  | GPT 5.3 Codex Spark               |
+| `gpt-5.2`              | GPT 5.2 model                     |
+| `gpt-5.2-codex`        | GPT 5.2 Codex                     |
+| `gpt-5.1`              | GPT 5.1 model                     |
+| `gpt-5.1-codex`        | GPT 5.1 Codex                     |
+| `gpt-5.1-codex-max`    | GPT 5.1 Codex Max                 |
+| `gpt-5.1-codex-mini`   | GPT 5.1 Codex Mini                |
+| `gpt-5`                | GPT 5 model                       |
+| `gpt-5-codex`          | GPT 5 Codex                       |
+| `gpt-5-nano`           | GPT 5 Nano                        |
+
+### Anthropic-Compatible (Messages API)
+
+These models use the `/v1/messages` endpoint and require a [custom provider definition]({{ '/providers/custom/' | relative_url }}):
+
+| Model                   | Description                   |
+| ----------------------- | ----------------------------- |
+| `claude-fable-5`        | Claude Fable 5 model          |
+| `claude-opus-4.8`       | Claude Opus 4.8 model         |
+| `claude-opus-4.7`       | Claude Opus 4.7 model         |
+| `claude-opus-4.6`       | Claude Opus 4.6 model         |
+| `claude-opus-4.5`       | Claude Opus 4.5 model         |
+| `claude-opus-4.1`       | Claude Opus 4.1 model         |
+| `claude-sonnet-4.6`     | Claude Sonnet 4.6 model       |
+| `claude-sonnet-4.5`     | Claude Sonnet 4.5 model       |
+| `claude-sonnet-4`       | Claude Sonnet 4 model         |
+| `claude-haiku-4.5`      | Claude Haiku 4.5 model        |
+| `qwen3.7-max`           | Qwen 3.7 Max model            |
+| `qwen3.7-plus`          | Qwen 3.7 Plus model           |
+| `qwen3.6-plus`          | Qwen 3.6 Plus model           |
+| `qwen3.5-plus`          | Qwen 3.5 Plus model           |
+
+To use an Anthropic-compatible model:
+
+```yaml
+providers:
+  opencode-zen-claude:
+    provider: anthropic
+    base_url: https://opencode.ai/zen
+    token_key: OPENCODE_API_KEY
+
+models:
+  claude:
+    provider: opencode-zen-claude
+    model: claude-sonnet-4.5
+
+agents:
+  root:
+    model: claude
+    description: Assistant using Claude through OpenCode Zen
+    instruction: You are a helpful assistant.
+```
+
+### Google-Compatible
+
+These models require a [custom provider definition]({{ '/providers/custom/' | relative_url }}) with a Google-compatible client:
+
+| Model               | Description              |
+| ------------------- | ------------------------ |
+| `gemini-3.5-flash`  | Gemini 3.5 Flash model   |
+| `gemini-3.1-pro`    | Gemini 3.1 Pro model     |
+| `gemini-3-flash`    | Gemini 3 Flash model     |
+
+To use a Google model:
+
+```yaml
+providers:
+  opencode-zen-gemini:
+    provider: google
+    base_url: https://opencode.ai/zen/v1/models
+    token_key: OPENCODE_API_KEY
+
+models:
+  gemini:
+    provider: opencode-zen-gemini
+    model: gemini-3.5-flash
+
+agents:
+  root:
+    model: gemini
+    description: Assistant using Gemini through OpenCode Zen
+    instruction: You are a helpful assistant.
+```
+
+## How It Works
+
+OpenCode Zen is implemented as a built-in alias in docker-agent:
+
+- **API Type:** OpenAI-compatible (auto-detects Responses API for GPT models, Chat Completions for others)
+- **Base URL:** `https://opencode.ai/zen/v1`
+- **Token Variable:** `OPENCODE_API_KEY`
+
+The same API key works for both OpenCode Go and OpenCode Zen — they are part of the same platform. Zen uses a pay-per-use billing model, while Go uses a fixed subscription.
+
+For Anthropic-compatible models, docker-agent uses a custom provider pointing to the Anthropic client at `https://opencode.ai/zen` with the same token. For Google models, a custom provider points to the Google client at `https://opencode.ai/zen/v1/models`.
+
+### Differences from OpenCode Go
+
+| Aspect | OpenCode Zen | OpenCode Go |
+|--------|-------------|-------------|
+| Billing | Pay-per-use | $10/month subscription |
+| Models | GPT-5.x, Claude, Gemini, open-source | Open-source only |
+| Free models | Yes (7 models) | No |
+| Base URL | `https://opencode.ai/zen/v1` | `https://opencode.ai/zen/go/v1` |
+
+## Usage Limits and Pricing
+
+OpenCode Zen uses a pay-per-use model. See the [OpenCode Zen documentation](https://opencode.ai/docs/es/zen) for current pricing. Automatic top-up and monthly usage limits are available from the console.
+
+You can retrieve the full model catalog at any time:
+
+```bash
+curl https://opencode.ai/zen/v1/models
+```

--- a/docs/providers/overview/index.md
+++ b/docs/providers/overview/index.md
@@ -59,6 +59,8 @@ docker-agent also includes built-in aliases for these providers:
 
 | Provider       | Alias            | API Key / Env Variable              |
 | -------------- | ---------------- | ----------------------------------- |
+| OpenCode Zen   | `opencode-zen`   | `OPENCODE_API_KEY`                  |
+| OpenCode Go    | `opencode-go`    | `OPENCODE_API_KEY`                  |
 | Mistral        | `mistral`        | `MISTRAL_API_KEY`                   |
 | xAI (Grok)     | `xai`            | `XAI_API_KEY`                       |
 | Nebius         | `nebius`         | `NEBIUS_API_KEY`                    |

--- a/examples/opencode-go-practical.yaml
+++ b/examples/opencode-go-practical.yaml
@@ -7,7 +7,7 @@
 #
 # Available models:
 #   OpenAI-compatible (/v1/chat/completions):
-#     deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7, kimi-k2.6,
+#     deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, kimi-k2.6,
 #     glm-5.2, glm-5.1, mimo-v2.5, mimo-v2.5-pro
 #
 #   Anthropic-compatible (/v1/messages) — requires a custom provider:

--- a/examples/opencode-go-practical.yaml
+++ b/examples/opencode-go-practical.yaml
@@ -1,0 +1,26 @@
+# OpenCode Go — Practical Example
+#
+# Requirements:
+#   1. Subscribe to OpenCode Go at https://opencode.ai/auth
+#   2. Copy your API key and export it as an environment variable:
+#      export OPENCODE_API_KEY="your-api-key"
+#
+# Available models:
+#   OpenAI-compatible (/v1/chat/completions):
+#     deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7, kimi-k2.6,
+#     glm-5.2, glm-5.1, mimo-v2.5, mimo-v2.5-pro
+#
+#   Anthropic-compatible (/v1/messages) — requires a custom provider:
+#     minimax-m3, minimax-m2.7, qwen3.7-max, qwen3.7-plus, qwen3.6-plus
+
+agents:
+  root:
+    model: opencode-go/deepseek-v4-flash
+    description: Go assistant for programming tasks
+    instruction: |
+      You are an expert programming assistant.
+      You help with code, debugging, code review, and software architecture.
+    commands:
+      code: Write clean, well-structured code for the user's request.
+      review: Review the provided code and suggest improvements.
+      debug: Help debug the described code issue.

--- a/examples/opencode-go.yaml
+++ b/examples/opencode-go.yaml
@@ -1,0 +1,8 @@
+agents:
+  root:
+    model: opencode-go/deepseek-v4-flash
+    description: A helpful AI assistant powered by OpenCode Go
+    instruction: |
+      You are a helpful AI assistant powered by OpenCode Go.
+      Be helpful, accurate, and concise in your responses.
+      You are powered by open-source models served through OpenCode Go.

--- a/examples/opencode-zen.yaml
+++ b/examples/opencode-zen.yaml
@@ -1,0 +1,17 @@
+# OpenCode Zen — Free Model Example
+#
+# Requirements:
+#   1. Sign in to OpenCode Zen at https://opencode.ai/auth
+#   2. Copy your API key and export it:
+#      export OPENCODE_API_KEY="your-api-key"
+#
+# deepseek-v4-flash-free is a free model — no charges apply.
+# Full model list: https://opencode.ai/zen/v1/models
+
+agents:
+  root:
+    model: opencode-zen/deepseek-v4-flash-free
+    description: A helpful AI assistant powered by OpenCode Zen (free)
+    instruction: |
+      You are a helpful AI assistant powered by OpenCode Zen.
+      Be helpful, accurate, and concise in your responses.

--- a/pkg/config/auto.go
+++ b/pkg/config/auto.go
@@ -29,6 +29,11 @@ type providerConfig struct {
 // cloudProviders defines the available cloud providers in priority order.
 // The first provider with a configured API key will be selected by AutoModelConfig.
 // DMR is always appended as the final fallback (not listed here).
+//
+// opencode-zen is ordered before opencode-go because both share OPENCODE_API_KEY:
+// when the key is set, Zen wins auto-selection. A subscriber who only uses Go
+// should set the provider explicitly (e.g. `--model opencode-go/...`) rather than
+// relying on auto; see docs/providers/opencode-go for details.
 var cloudProviders = []providerConfig{
 	{"anthropic", []string{"ANTHROPIC_API_KEY"}, "ANTHROPIC_API_KEY"},
 	{"openai", []string{"OPENAI_API_KEY"}, "OPENAI_API_KEY"},

--- a/pkg/config/auto.go
+++ b/pkg/config/auto.go
@@ -44,6 +44,8 @@ var cloudProviders = []providerConfig{
 		"AWS_PROFILE",
 		"AWS_ROLE_ARN",
 	}, "AWS_ACCESS_KEY_ID (or AWS_PROFILE, AWS_ROLE_ARN, AWS_BEARER_TOKEN_BEDROCK)"},
+	{"opencode-zen", []string{"OPENCODE_API_KEY"}, "OPENCODE_API_KEY"},
+	{"opencode-go", []string{"OPENCODE_API_KEY"}, "OPENCODE_API_KEY"},
 }
 
 // AutoModelFallbackError is returned when auto model selection fails because

--- a/pkg/config/auto.go
+++ b/pkg/config/auto.go
@@ -99,6 +99,8 @@ var DefaultModels = map[string]string{
 	"dmr":            "ai/qwen3:latest",
 	"mistral":        "mistral-small-latest",
 	"amazon-bedrock": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+	"opencode-go":    "deepseek-v4-flash",
+	"opencode-zen":   "deepseek-v4-flash-free",
 }
 
 func AvailableProviders(ctx context.Context, modelsGateway string, env environment.Provider) []string {

--- a/pkg/config/auto_test.go
+++ b/pkg/config/auto_test.go
@@ -279,7 +279,7 @@ func TestDefaultModels(t *testing.T) {
 	t.Parallel()
 
 	// Test that DefaultModels map has all expected providers
-	expectedProviders := []string{"openai", "anthropic", "google", "dmr", "mistral", "amazon-bedrock"}
+	expectedProviders := []string{"openai", "anthropic", "google", "dmr", "mistral", "amazon-bedrock", "opencode-zen", "opencode-go"}
 
 	for _, provider := range expectedProviders {
 		t.Run(provider, func(t *testing.T) {
@@ -296,13 +296,15 @@ func TestDefaultModels(t *testing.T) {
 	assert.Equal(t, "ai/qwen3:latest", DefaultModels["dmr"])
 	assert.Equal(t, "mistral-small-latest", DefaultModels["mistral"])
 	assert.Equal(t, "global.anthropic.claude-sonnet-4-5-20250929-v1:0", DefaultModels["amazon-bedrock"])
+	assert.Equal(t, "deepseek-v4-flash", DefaultModels["opencode-go"])
+	assert.Equal(t, "deepseek-v4-flash-free", DefaultModels["opencode-zen"])
 }
 
 func TestAutoModelConfig_IntegrationWithDefaultModels(t *testing.T) {
 	t.Parallel()
 
 	// Verify that AutoModelConfig always returns a model from DefaultModels
-	providers := []string{"openai", "anthropic", "google", "mistral"}
+	providers := []string{"openai", "anthropic", "google", "mistral", "opencode-zen"}
 
 	for _, provider := range providers {
 		t.Run(provider, func(t *testing.T) {
@@ -320,6 +322,8 @@ func TestAutoModelConfig_IntegrationWithDefaultModels(t *testing.T) {
 				envVars["GOOGLE_API_KEY"] = "test-key"
 			case "mistral":
 				envVars["MISTRAL_API_KEY"] = "test-key"
+			case "opencode-zen":
+				envVars["OPENCODE_API_KEY"] = "test-key"
 			}
 
 			modelConfig := AutoModelConfig(t.Context(), "", environment.NewMapEnvProvider(envVars), nil, nil)
@@ -330,6 +334,20 @@ func TestAutoModelConfig_IntegrationWithDefaultModels(t *testing.T) {
 			assert.Equal(t, provider, modelConfig.Provider)
 		})
 	}
+
+	// opencode-go shares OPENCODE_API_KEY with opencode-zen, so it can never be
+	// auto-selected when the env var is set (zen wins due to cloudProviders
+	// ordering). Test it via a user-specified default model instead.
+	t.Run("opencode-go", func(t *testing.T) {
+		t.Parallel()
+
+		modelConfig := AutoModelConfig(t.Context(), "", environment.NewMapEnvProvider(map[string]string{
+			"OPENCODE_API_KEY": "test-key",
+		}), &latest.ModelConfig{Provider: "opencode-go", Model: DefaultModels["opencode-go"]})
+
+		assert.Equal(t, "opencode-go", modelConfig.Provider)
+		assert.Equal(t, DefaultModels["opencode-go"], modelConfig.Model)
+	})
 
 	// Test dmr provider (no API keys)
 	t.Run("dmr", func(t *testing.T) {
@@ -352,33 +370,44 @@ func TestAvailableProviders_PrecedenceOrder(t *testing.T) {
 		"OPENAI_API_KEY":    "test-key",
 		"GOOGLE_API_KEY":    "test-key",
 		"MISTRAL_API_KEY":   "test-key",
+		"OPENCODE_API_KEY":  "test-key",
 	})
 	providers := AvailableProviders(t.Context(), "", env)
 	assert.Equal(t, "anthropic", providers[0])
 
 	// No anthropic - openai should win
 	env = environment.NewMapEnvProvider(map[string]string{
-		"OPENAI_API_KEY":  "test-key",
-		"GOOGLE_API_KEY":  "test-key",
-		"MISTRAL_API_KEY": "test-key",
+		"OPENAI_API_KEY":   "test-key",
+		"GOOGLE_API_KEY":   "test-key",
+		"MISTRAL_API_KEY":  "test-key",
+		"OPENCODE_API_KEY": "test-key",
 	})
 	providers = AvailableProviders(t.Context(), "", env)
 	assert.Equal(t, "openai", providers[0])
 
 	// No anthropic or openai - google should win
 	env = environment.NewMapEnvProvider(map[string]string{
-		"GOOGLE_API_KEY":  "test-key",
-		"MISTRAL_API_KEY": "test-key",
+		"GOOGLE_API_KEY":   "test-key",
+		"MISTRAL_API_KEY":  "test-key",
+		"OPENCODE_API_KEY": "test-key",
 	})
 	providers = AvailableProviders(t.Context(), "", env)
 	assert.Equal(t, "google", providers[0])
 
 	// No anthropic, openai, or google - mistral should win
 	env = environment.NewMapEnvProvider(map[string]string{
-		"MISTRAL_API_KEY": "test-key",
+		"MISTRAL_API_KEY":  "test-key",
+		"OPENCODE_API_KEY": "test-key",
 	})
 	providers = AvailableProviders(t.Context(), "", env)
 	assert.Equal(t, "mistral", providers[0])
+
+	// Only OPENCODE_API_KEY set - opencode-zen should win (higher priority than opencode-go)
+	env = environment.NewMapEnvProvider(map[string]string{
+		"OPENCODE_API_KEY": "test-key",
+	})
+	providers = AvailableProviders(t.Context(), "", env)
+	assert.Equal(t, "opencode-zen", providers[0])
 
 	// No keys at all - dmr should be selected
 	env = environment.NewNoEnvProvider()

--- a/pkg/config/auto_test.go
+++ b/pkg/config/auto_test.go
@@ -343,7 +343,7 @@ func TestAutoModelConfig_IntegrationWithDefaultModels(t *testing.T) {
 
 		modelConfig := AutoModelConfig(t.Context(), "", environment.NewMapEnvProvider(map[string]string{
 			"OPENCODE_API_KEY": "test-key",
-		}), &latest.ModelConfig{Provider: "opencode-go", Model: DefaultModels["opencode-go"]})
+		}), &latest.ModelConfig{Provider: "opencode-go", Model: DefaultModels["opencode-go"]}, nil)
 
 		assert.Equal(t, "opencode-go", modelConfig.Provider)
 		assert.Equal(t, DefaultModels["opencode-go"], modelConfig.Model)

--- a/pkg/config/examples_test.go
+++ b/pkg/config/examples_test.go
@@ -15,6 +15,14 @@ import (
 	"github.com/docker/docker-agent/pkg/modelsdev"
 )
 
+// modelsDevAbsentProviders lists providers that are valid at runtime but
+// are not expected to exist in the remote models.dev catalog. The test
+// skips models.dev lookups for these to avoid false failures.
+var modelsDevAbsentProviders = map[string]bool{
+	"dmr":          true, // Docker Model Runner (local, not in catalog)
+	"opencode-zen": true, // not yet registered in models.dev
+}
+
 func collectExamples(t *testing.T) []string {
 	t.Helper()
 
@@ -67,8 +75,8 @@ func TestParseExamples(t *testing.T) {
 				}
 				require.NotEmpty(t, model.Provider)
 				require.NotEmpty(t, model.Model)
-				// Skip providers that don't have entries in models.dev
-				if model.Provider == "dmr" || model.Provider == "opencode-zen" {
+				// Skip providers that don't have entries in models.dev.
+				if modelsDevAbsentProviders[model.Provider] {
 					continue
 				}
 				// Skip models with routing rules - they use multiple providers

--- a/pkg/config/examples_test.go
+++ b/pkg/config/examples_test.go
@@ -68,7 +68,7 @@ func TestParseExamples(t *testing.T) {
 				require.NotEmpty(t, model.Provider)
 				require.NotEmpty(t, model.Model)
 				// Skip providers that don't have entries in models.dev
-				if model.Provider == "dmr" {
+				if model.Provider == "dmr" || model.Provider == "opencode-zen" {
 					continue
 				}
 				// Skip models with routing rules - they use multiple providers

--- a/pkg/model/provider/aliases.go
+++ b/pkg/model/provider/aliases.go
@@ -68,6 +68,16 @@ var Aliases = map[string]Alias{
 		BaseURL:     "https://api.githubcopilot.com",
 		TokenEnvVar: "GITHUB_TOKEN",
 	},
+	"opencode-go": {
+		APIType:     "openai",
+		BaseURL:     "https://opencode.ai/zen/go/v1",
+		TokenEnvVar: "OPENCODE_API_KEY",
+	},
+	"opencode-zen": {
+		APIType:     "openai",
+		BaseURL:     "https://opencode.ai/zen/v1",
+		TokenEnvVar: "OPENCODE_API_KEY",
+	},
 }
 
 // LookupAlias returns the Alias registered for the given name (if any).

--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -1158,11 +1158,12 @@ func isCustomProvider(cfg *latest.ModelConfig) bool {
 // autoSelectsResponsesAPI reports whether, absent an explicit api_type, the
 // provider should auto-select the Responses API for models that require it.
 //
-// This covers OpenAI directly and GitHub Copilot, which proxies the same
+// This covers OpenAI directly, GitHub Copilot (which proxies the same
 // OpenAI models and rejects newer ones (gpt-5, Codex, ...) on the legacy
-// /chat/completions endpoint with a 400. Detection is driven by
-// modelinfo.SupportsResponsesAPI so new models are picked up by naming
-// convention rather than a hardcoded allow-list.
+// /chat/completions endpoint with a 400), and OpenCode Zen (which publishes
+// the same OpenAI Responses endpoint for its GPT model lineup). Detection is
+// driven by modelinfo.SupportsResponsesAPI so new models are picked up by
+// naming convention rather than a hardcoded allow-list.
 func autoSelectsResponsesAPI(provider string) bool {
 	switch provider {
 	case "openai", "github-copilot", "opencode-zen":

--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -1165,7 +1165,7 @@ func isCustomProvider(cfg *latest.ModelConfig) bool {
 // convention rather than a hardcoded allow-list.
 func autoSelectsResponsesAPI(provider string) bool {
 	switch provider {
-	case "openai", "github-copilot":
+	case "openai", "github-copilot", "opencode-go", "opencode-zen":
 		return true
 	}
 	return false

--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -1165,7 +1165,7 @@ func isCustomProvider(cfg *latest.ModelConfig) bool {
 // convention rather than a hardcoded allow-list.
 func autoSelectsResponsesAPI(provider string) bool {
 	switch provider {
-	case "openai", "github-copilot", "opencode-go", "opencode-zen":
+	case "openai", "github-copilot", "opencode-zen":
 		return true
 	}
 	return false


### PR DESCRIPTION
## Summary

Add built-in alias support and full documentation for **OpenCode Go** and **OpenCode Zen** — the two subscription plans offered by [OpenCode](https://opencode.ai).

## OpenCode Go (`opencode-go`)

- Low-cost subscription ($10/mo) for open-source coding models
- OpenAI-compatible endpoint at `https://opencode.ai/zen/go/v1`
- Covers models: DeepSeek, GLM, Kimi, MiMo, HY3, MiniMax, Qwen
- Anthropic-compatible models (MiniMax, Qwen) via custom provider config

## OpenCode Zen (`opencode-zen`)

- Pay-per-use curated gateway for premium + open-source models
- OpenAI-compatible endpoint at `https://opencode.ai/zen/v1`
- Covers models: GPT-5.x, Claude, Gemini, DeepSeek, GLM, Kimi, Grok, MiniMax, Qwen
- Includes **7 free models** (deepseek-v4-flash-free, mimo-v2.5-free, etc.)
- Anthropic and Google models via custom provider config

Both share the `OPENCODE_API_KEY` environment variable — the same API key works for both services.

## Technical Changes

| File | Change |
|---|---|
| `pkg/model/provider/aliases.go` | Register `opencode-go` and `opencode-zen` aliases |
| `pkg/config/auto.go` | Add default models for both providers |
| `cmd/root/models.go` | Add live API fetch from provider `/v1/models` endpoint when models.dev has no entry |
| `pkg/config/examples_test.go` | Skip opencode-zen in models.dev validation |
| `docs/providers/opencode-go/index.md` | Full documentation page for Go |
| `docs/providers/opencode-zen/index.md` | Full documentation page for Zen |
| `docs/providers/overview/index.md` | Add both to built-in aliases table |
| `docs/_data/nav.yml` | Add both to navigation sidebar |
| `examples/opencode-go.yaml` | Basic Go usage example |
| `examples/opencode-go-practical.yaml` | Practical Go example with commands |
| `examples/opencode-zen.yaml` | Zen example with free model |
| `.gitignore` | Add `graphify-out/` |

## Usage

```bash
export OPENCODE_API_KEY="your-api-key"
docker agent run examples/opencode-go.yaml
docker agent run examples/opencode-zen.yaml
```