### PR TITLE
fix: fail fast on OAuth MCP auth in non-interactive sessions

### DIFF
--- a/pkg/runtime/agent_delegation.go
+++ b/pkg/runtime/agent_delegation.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/docker-agent/pkg/tools"
 	agenttool "github.com/docker/docker-agent/pkg/tools/builtin/agent"
 	"github.com/docker/docker-agent/pkg/tools/builtin/handoff"
+	mcptools "github.com/docker/docker-agent/pkg/tools/mcp"
 )
 
 // agentNames returns the names of the given agents.
@@ -380,7 +381,50 @@ func (r *LocalRuntime) runCollecting(ctx context.Context, parent *session.Sessio
 		return &agenttool.RunResult{ErrMsg: errMsg}
 	}
 
-	return &agenttool.RunResult{Result: s.GetLastAssistantMessageContent()}
+	result := s.GetLastAssistantMessageContent()
+	// A remote MCP toolset that needs first-time interactive OAuth fails fast
+	// in a background (non-interactive) session instead of hanging on an
+	// unanswerable elicitation (issue #3200). The resulting "needs auth" state
+	// never reaches the orchestrating model on its own — runCollecting drops
+	// warning events — so the sub-agent would silently lack a capability with
+	// no explanation. Prepend an actionable note so the model (and, through it,
+	// the user) learns the server must be authorized interactively first.
+	if note := backgroundAuthRequiredNote(child); note != "" {
+		if result != "" {
+			result = note + "\n\n" + result
+		} else {
+			result = note
+		}
+	}
+	return &agenttool.RunResult{Result: result}
+}
+
+// backgroundAuthRequiredNote returns a model-readable note naming the child
+// agent's MCP toolsets that could not start because they require first-time
+// interactive OAuth authorization, which a background agent cannot complete
+// (issue #3200). It returns "" when no toolset is in that state. Detection is
+// typed (mcptools.IsAuthorizationRequired against the toolset's recorded
+// LastError) rather than string-matched, so it stays correct if the user-facing
+// error text changes.
+func backgroundAuthRequiredNote(child *agent.Agent) string {
+	var needAuth []string
+	for _, ts := range child.ToolSets() {
+		status := toolsetStatusFor(ts)
+		if mcptools.IsAuthorizationRequired(status.LastError) {
+			needAuth = append(needAuth, status.Name)
+		}
+	}
+	if len(needAuth) == 0 {
+		return ""
+	}
+	return fmt.Sprintf(
+		"Note: the following MCP tool server(s) could not be used because they "+
+			"require first-time interactive OAuth authorization, which cannot be "+
+			"completed by a background agent: %s. Ask the user to authorize them "+
+			"once from an interactive session (run the agent in the foreground and "+
+			"approve the OAuth prompt), then retry this task.",
+		strings.Join(needAuth, ", "),
+	)
 }
 
 // persistBackgroundSubSession writes a completed background sub-session to the

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -29,6 +29,7 @@ import (
 	"github.com/docker/docker-agent/pkg/tools/builtin/shell"
 	"github.com/docker/docker-agent/pkg/tools/builtin/skills"
 	"github.com/docker/docker-agent/pkg/tools/builtin/transfertask"
+	mcptools "github.com/docker/docker-agent/pkg/tools/mcp"
 )
 
 // registerDefaultTools wires up the built-in tool handlers (delegation,
@@ -224,6 +225,21 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 	// rides over W3C `baggage` so it crosses MCP / sandbox /
 	// HTTP boundaries too.
 	ctx = genai.WithConversationID(ctx, sess.ID)
+
+	// A non-interactive session (background_agents via runCollecting, MCP
+	// serve, A2A, evals) has no live UI that can answer an OAuth elicitation,
+	// and runCollecting drops events rather than forwarding them. If a remote
+	// MCP toolset needs first-time OAuth, blocking on an elicitation that
+	// nobody can answer hangs the sub-agent forever (issue #3200): the
+	// connection context is detached with context.WithoutCancel, so not even
+	// cancellation can unblock it. Mark the context so toolset Start() fails
+	// fast with an AuthorizationRequiredError — the same fast-fail the startup
+	// tool probe uses (see EmitStartupInfo) — instead of eliciting. A real user
+	// authorizes such servers from an interactive turn (or transfer_task, which
+	// keeps NonInteractive=false and forwards the dialog to the TUI).
+	if sess.NonInteractive {
+		ctx = mcptools.WithoutInteractivePrompts(ctx)
+	}
 
 	// runtime.session is the root span for one stream. gen_ai.* keys
 	// are emitted alongside the legacy `agent` / `session.id` keys

--- a/pkg/runtime/oauth_noninteractive_test.go
+++ b/pkg/runtime/oauth_noninteractive_test.go
@@ -1,0 +1,213 @@
+package runtime
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/team"
+	"github.com/docker/docker-agent/pkg/tools"
+	agenttool "github.com/docker/docker-agent/pkg/tools/builtin/agent"
+	"github.com/docker/docker-agent/pkg/tools/lifecycle"
+	mcptools "github.com/docker/docker-agent/pkg/tools/mcp"
+)
+
+// markerProbeToolSet records whether the runtime allowed interactive prompts
+// (i.e. whether the WithoutInteractivePrompts marker was absent) at the moment
+// Start() ran. It always starts successfully so the run proceeds normally.
+type markerProbeToolSet struct {
+	mu      sync.Mutex
+	called  bool
+	allowed bool
+}
+
+var (
+	_ tools.ToolSet   = (*markerProbeToolSet)(nil)
+	_ tools.Startable = (*markerProbeToolSet)(nil)
+)
+
+func (s *markerProbeToolSet) Start(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.called = true
+	s.allowed = mcptools.InteractivePromptsAllowed(ctx)
+	return nil
+}
+
+func (s *markerProbeToolSet) Stop(context.Context) error                  { return nil }
+func (s *markerProbeToolSet) Tools(context.Context) ([]tools.Tool, error) { return nil, nil }
+
+func (s *markerProbeToolSet) snapshot() (called, allowed bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.called, s.allowed
+}
+
+// TestRunStream_NonInteractiveSessionDisablesInteractivePrompts is the
+// unit-level guard for issue #3200's fix: runStreamLoop must mark the
+// per-stream context WithoutInteractivePrompts when (and only when) the
+// session is non-interactive, so that an OAuth-protected MCP toolset fails
+// fast during Start() instead of raising an elicitation no one can answer.
+func TestRunStream_NonInteractiveSessionDisablesInteractivePrompts(t *testing.T) {
+	t.Parallel()
+
+	run := func(t *testing.T, nonInteractive bool) *markerProbeToolSet {
+		t.Helper()
+		probe := &markerProbeToolSet{}
+		prov := &mockProvider{
+			id:     "test/mock-model",
+			stream: newStreamBuilder().AddContent("ok").AddStopWithUsage(1, 1).Build(),
+		}
+		root := agent.New("root", "test", agent.WithModel(prov), agent.WithToolSets(probe))
+		rt, err := NewLocalRuntime(team.New(team.WithAgents(root)),
+			WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+		require.NoError(t, err)
+
+		opts := []session.Opt{session.WithUserMessage("hi")}
+		if nonInteractive {
+			opts = append(opts, session.WithNonInteractive(true))
+		}
+		sess := session.New(opts...)
+		sess.Title = "Unit Test"
+		for range rt.RunStream(t.Context(), sess) {
+		}
+		return probe
+	}
+
+	t.Run("non-interactive session marks the context", func(t *testing.T) {
+		t.Parallel()
+		called, allowed := run(t, true).snapshot()
+		require.True(t, called, "toolset Start must run so the marker is observable")
+		assert.False(t, allowed,
+			"a non-interactive session must mark the context WithoutInteractivePrompts so OAuth fails fast (issue #3200)")
+	})
+
+	t.Run("interactive session leaves prompts enabled", func(t *testing.T) {
+		t.Parallel()
+		called, allowed := run(t, false).snapshot()
+		require.True(t, called, "toolset Start must run so the marker is observable")
+		assert.True(t, allowed,
+			"an interactive session must keep interactive prompts enabled so the user can complete OAuth")
+	})
+}
+
+// oauthGateToolSet models a remote OAuth MCP toolset with no cached token.
+// It mirrors the real transport's branch on the WithoutInteractivePrompts
+// marker: a non-interactive context fails fast with AuthorizationRequiredError,
+// while an interactive context blocks waiting for an elicitation reply. Before
+// the issue #3200 fix the background path took the blocking branch and hung;
+// after the fix it takes the fail-fast branch.
+type oauthGateToolSet struct {
+	mu       sync.Mutex
+	lastErr  error
+	released chan struct{}
+}
+
+func newOAuthGateToolSet() *oauthGateToolSet {
+	return &oauthGateToolSet{released: make(chan struct{})}
+}
+
+var (
+	_ tools.ToolSet   = (*oauthGateToolSet)(nil)
+	_ tools.Startable = (*oauthGateToolSet)(nil)
+	_ tools.Statable  = (*oauthGateToolSet)(nil)
+)
+
+func (s *oauthGateToolSet) Start(ctx context.Context) error {
+	if !mcptools.InteractivePromptsAllowed(ctx) {
+		err := &mcptools.AuthorizationRequiredError{URL: "https://example.test/mcp"}
+		s.mu.Lock()
+		s.lastErr = err
+		s.mu.Unlock()
+		return err
+	}
+	// Interactive context with no answerable elicitation channel: the real
+	// OAuth flow blocks until the user replies. Reproduce that block so that
+	// reverting the fix makes the background test hang and time out, exactly
+	// like issue #3200.
+	<-s.released
+	return nil
+}
+
+func (s *oauthGateToolSet) Stop(context.Context) error                  { return nil }
+func (s *oauthGateToolSet) Tools(context.Context) ([]tools.Tool, error) { return nil, nil }
+
+func (s *oauthGateToolSet) State() lifecycle.StateInfo {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.lastErr != nil {
+		return lifecycle.StateInfo{State: lifecycle.StateStopped, LastError: s.lastErr}
+	}
+	return lifecycle.StateInfo{State: lifecycle.StateReady}
+}
+
+// release unblocks any goroutine parked in the interactive branch of Start.
+// Tests defer this so a pre-fix hang doesn't leak a goroutine after the test
+// has already failed on its timeout.
+func (s *oauthGateToolSet) release() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	select {
+	case <-s.released:
+	default:
+		close(s.released)
+	}
+}
+
+// TestRunAgent_BackgroundOAuthMCP_FailsFastAndNotifiesModel is the regression
+// test for issue #3200: a background agent whose remote MCP toolset needs
+// first-time OAuth used to hang forever (the elicitation was raised into a
+// context that could not answer it and whose Done channel never fires). After
+// the fix the background sub-session is marked non-interactive, the toolset
+// fails fast, the run completes promptly, and the orchestrating model is told
+// the server needs interactive authorization.
+func TestRunAgent_BackgroundOAuthMCP_FailsFastAndNotifiesModel(t *testing.T) {
+	t.Parallel()
+
+	gate := newOAuthGateToolSet()
+	t.Cleanup(gate.release)
+
+	workerStream := newStreamBuilder().AddContent("partial work done").AddStopWithUsage(10, 5).Build()
+	workerProv := &mockProvider{id: "test/mock-model", stream: workerStream}
+	parentProv := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
+
+	worker := agent.New("worker", "Worker agent",
+		agent.WithModel(workerProv), agent.WithToolSets(gate))
+	root := agent.New("root", "Root agent", agent.WithModel(parentProv))
+	agent.WithSubAgents(worker)(root)
+	tm := team.New(team.WithAgents(root, worker))
+
+	// Interactive runtime: r.nonInteractive is false. Only the background
+	// sub-session is non-interactive — exactly the issue #3200 setup where the
+	// runtime-level check at elicitationHandler does not save us.
+	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+
+	sess := session.New(session.WithUserMessage("Test"), session.WithToolsApproved(true))
+
+	done := make(chan *agenttool.RunResult, 1)
+	go func() {
+		done <- rt.RunAgent(t.Context(), agenttool.RunParams{
+			AgentName:     "worker",
+			Task:          "use the remote MCP server",
+			ParentSession: sess,
+		})
+	}()
+
+	select {
+	case res := <-done:
+		require.Empty(t, res.ErrMsg, "background run must complete, not error")
+		assert.Contains(t, res.Result, "interactive OAuth authorization",
+			"the model must be told the MCP server needs interactive OAuth (issue #3200)")
+		assert.Contains(t, res.Result, "partial work done",
+			"the note must be prepended to the sub-agent's own output, not replace it")
+	case <-time.After(5 * time.Second):
+		t.Fatal("background agent hung on an OAuth elicitation it cannot answer (issue #3200)")
+	}
+}

--- a/pkg/tools/mcp/interactive.go
+++ b/pkg/tools/mcp/interactive.go
@@ -27,10 +27,15 @@ func WithoutInteractivePrompts(ctx context.Context) context.Context {
 	return context.WithValue(ctx, noInteractivePromptsKey{}, true)
 }
 
-// interactivePromptsAllowed reports whether the context allows blocking on
+// InteractivePromptsAllowed reports whether the context allows blocking on
 // user-driven flows. The default is true so existing callers (RunStream,
 // tests) keep working without changes.
-func interactivePromptsAllowed(ctx context.Context) bool {
+//
+// It is the read-side companion to [WithoutInteractivePrompts]: the runtime
+// sets the marker on non-interactive sessions (background agents, MCP serve,
+// A2A) so the OAuth transport can fail fast instead of raising an elicitation
+// that no one can answer.
+func InteractivePromptsAllowed(ctx context.Context) bool {
 	v, _ := ctx.Value(noInteractivePromptsKey{}).(bool)
 	return !v
 }

--- a/pkg/tools/mcp/oauth.go
+++ b/pkg/tools/mcp/oauth.go
@@ -407,7 +407,7 @@ func (t *oauthTransport) roundTrip(req *http.Request, isRetry bool) (*http.Respo
 			// the toolset can be flagged "needs auth" without freezing
 			// the agent and without making Ctrl-C wait for a user response
 			// that will never come.
-			if !interactivePromptsAllowed(req.Context()) {
+			if !InteractivePromptsAllowed(req.Context()) {
 				slog.Debug("Skipping OAuth elicitation in non-interactive context", "url", t.baseURL)
 				resp.Body.Close()
 				t.mu.Lock()


### PR DESCRIPTION
## Summary

An OAuth-protected remote MCP server with no cached token, first reached from a non-interactive execution context (a `background_agents` fan-out via `runCollecting`), raised an authorization elicitation into a context that structurally cannot answer it, then stalled silently with no escalation, no error, and no timeout. Fixes #3200.

## Root cause

| Link | Detail | Location |
|------|--------|----------|
| Sync start | `runStreamLoop` -> `getTools` -> `toolSet.Start(ctx)` runs the connect synchronously on the stream context | `runtime/loop.go`, `agent/agent.go`, `lifecycle/supervisor.go` |
| Detached ctx | `clientConnector.Connect` detaches via `context.WithoutCancel`: values survive, but `Done()` becomes nil and never fires | `tools/mcp/mcp.go` |
| No marker | On 401, `roundTrip` checks `InteractivePromptsAllowed(ctx)`; the background context carries no marker, so the full OAuth flow runs and elicits | `tools/mcp/oauth.go` |
| Wrong scope | `elicitationHandler` checks the runtime-wide `r.nonInteractive` (false for a TUI runtime), not `sess.NonInteractive` (true for the background child), so it does not decline | `runtime/elicitation.go` |
| Unanswerable | The handler blocks on `select { elicitationRequestCh; ctx.Done() }`; the channel has no reader and `Done()` is nil | `runtime/elicitation.go` |
| Dropped event | `runCollecting` drains events but acts only on `AgentChoiceEvent`/`ErrorEvent`, dropping the elicitation request | `runtime/agent_delegation.go` |

`session.NonInteractive` was never propagated to the MCP/OAuth layer. The fast-fail primitive (`WithoutInteractivePrompts` -> `AuthorizationRequiredError`) already existed but was only applied to the startup tool probe, not to non-interactive `RunStream` calls.

## Changes

- `runStreamLoop`: when `sess.NonInteractive`, mark the stream context with `WithoutInteractivePrompts` so toolset `Start()` fails fast instead of eliciting. Covers background agents, MCP serve, A2A, and evals.
- `runCollecting`: prepend a typed, actionable note (detected via `mcptools.IsAuthorizationRequired` against the toolset's recorded `LastError`, not string matching) so the orchestrating model learns the server needs interactive authorization first.
- Export `InteractivePromptsAllowed` as the read-side companion to `WithoutInteractivePrompts`.

Interactive paths are unaffected: the API server (with its `ResumeElicitation` endpoint), the TUI, embeddedchat, and the CLI all build sessions with `NonInteractive=false`, so the marker is not set and interactive OAuth still completes. `transfer_task` likewise inherits `NonInteractive=false` from an interactive parent and keeps forwarding the dialog to the live UI.

## Issue expectations

| Expectation in #3200 | Outcome |
|----------------------|---------|
| Escalate to the interactive session | Not chosen for background agents: no live sink, and reusing the shared elicitation bridge from a detached goroutine risks a swap race. `transfer_task` already provides this when a user is present. |
| Fail fast with a clear, actionable error | Implemented. Toolset start fails fast; the background model receives an actionable note naming the servers that need interactive OAuth. |
| Time out the pending elicitation | Not added. A foreground OAuth flow can legitimately take minutes; the fail-fast change removes the only known stall. Could be added as defense-in-depth (size >= 5 min) if desired. |

## Testing

| Check | Result |
|-------|--------|
| `go build ./...` | pass |
| `pkg/runtime`, `pkg/tools/mcp`, `pkg/agent` tests | pass |
| New regression tests (`-race`) | pass; both fail without the fix (the background test reproduces the indefinite stall via a 5s timeout) |
| golangci-lint (changed packages) | 0 issues |

New tests:
- `TestRunStream_NonInteractiveSessionDisablesInteractivePrompts`: the marker is set for non-interactive sessions and absent for interactive ones.
- `TestRunAgent_BackgroundOAuthMCP_FailsFastAndNotifiesModel`: a background agent with an OAuth-required MCP completes promptly and surfaces the note.

## Notes

- Consequence: a background agent loses OAuth tool servers not authorized beforehand; the note explains the remediation (authorize once from an interactive session, then retry). Pre-warming and persisting tokens during an interactive session would let background agents use such servers, and is left as a separate change.
- A related hardening (declining server-initiated elicitations mid tool call in non-interactive sessions, at the `elicitationHandler` chokepoint) is intentionally out of scope here; it can follow once its interaction with the chatserver decline loop is validated.
