### PR TITLE
chore: bump docker-agent-action to v2.0.1

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -18,7 +18,7 @@ jobs:
     if: |
       github.event_name == 'issue_comment' ||
       github.event.workflow_run.conclusion == 'success'
-    uses: docker/docker-agent-action/.github/workflows/review-pr.yml@3c0fa9d282c3f84d08dfd70ab0a28b151d11db70 # v2.0.0
+    uses: docker/docker-agent-action/.github/workflows/review-pr.yml@e96a4bb40cac114f64358621e1d08346c8eadc8c # v2.0.1
     # Scoped to the job so other jobs in this workflow aren't over-permissioned
     permissions:
       contents: read # Read repository files and PR diffs


### PR DESCRIPTION
Bumps `docker/docker-agent-action` from v2.0.0 (`3c0fa9d`) to v2.0.1 (`e96a4bb`).

Also adds `review_requested` to `pull_request.types` and `actions: read` permission where missing.