### PR TITLE
fix(eval): build judge model from the populated provider registry

### DIFF
--- a/pkg/evaluation/eval.go
+++ b/pkg/evaluation/eval.go
@@ -26,6 +26,7 @@ import (
 	"github.com/docker/docker-agent/pkg/environment"
 	"github.com/docker/docker-agent/pkg/model/provider"
 	"github.com/docker/docker-agent/pkg/model/provider/options"
+	"github.com/docker/docker-agent/pkg/model/provider/providers"
 	"github.com/docker/docker-agent/pkg/session"
 )
 
@@ -667,7 +668,7 @@ func createJudgeModel(ctx context.Context, judgeModel string, runConfig *config.
 		opts = append(opts, options.WithGateway(runConfig.ModelsGateway))
 	}
 
-	judge, err := provider.New(ctx, &cfg, runConfig.EnvProvider(), opts...)
+	judge, err := providers.NewDefaultRegistry().New(ctx, &cfg, runConfig.EnvProvider(), opts...)
 	if err != nil {
 		return nil, fmt.Errorf("creating judge model: %w", err)
 	}

--- a/pkg/evaluation/judge_model_test.go
+++ b/pkg/evaluation/judge_model_test.go
@@ -1,0 +1,38 @@
+package evaluation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/environment"
+)
+
+// TestCreateJudgeModelKnownProvider reproduces issue #3219: creating the eval
+// judge model failed with `unknown provider type "anthropic"` because the judge
+// was built through the empty package-level default registry instead of the
+// fully-populated provider registry.
+func TestCreateJudgeModelKnownProvider(t *testing.T) {
+	t.Parallel()
+
+	runConfig := &config.RuntimeConfig{
+		EnvProviderForTests: environment.NewMapEnvProvider(map[string]string{
+			"ANTHROPIC_API_KEY": "test-key",
+			"OPENAI_API_KEY":    "test-key",
+			"GOOGLE_API_KEY":    "test-key",
+		}),
+	}
+
+	for _, judgeModel := range []string{
+		"anthropic/claude-opus-4-5-20251101", // the default judge model that triggered #3219
+		"anthropic/claude-sonnet-4-0",
+		"openai/gpt-5",
+		"google/gemini-2.5-flash",
+	} {
+		judge, err := createJudgeModel(t.Context(), judgeModel, runConfig)
+		require.NoError(t, err, "judge model %q should resolve to a known provider", judgeModel)
+		assert.NotNil(t, judge)
+	}
+}


### PR DESCRIPTION
Fixes #3219

## Summary

Running evals failed with `creating judge model: unknown provider type "anthropic"` (the exact error from the issue), even when passing `--judge-model`.

| item | detail |
| --- | --- |
| Cause | `createJudgeModel` built the judge through the package-level `provider.New`, which resolves to `provider.DefaultRegistry()`. Since provider registration was made explicit (commit `cf5a430d`), the package-level `defaultFactories` map is never populated, so that registry is empty and rejects every provider type. |
| Trigger | The default judge model is `anthropic/claude-opus-4-5-20251101` (`cmd/root/eval.go`). Both the default path and an explicit `--judge-model` funnel through `createJudgeModel`, so both fail. |
| Fix | Route `createJudgeModel` through `providers.NewDefaultRegistry()`, the fully-populated registry already used by the team loader defaults (`pkg/teamloader/defaults/defaults.go`). |

## Change

`pkg/evaluation/eval.go`:

```go
-	judge, err := provider.New(ctx, &cfg, runConfig.EnvProvider(), opts...)
+	judge, err := providers.NewDefaultRegistry().New(ctx, &cfg, runConfig.EnvProvider(), opts...)
```

Both paths dispatch through the same `Registry.New` method; only the factory map differs (empty vs the registered openai, anthropic, google, dmr, amazon-bedrock factories). Options handling, gateway, structured output, and instrumentation are unchanged. No import cycle (`providers` does not depend on `evaluation`).

## Test

Adds `pkg/evaluation/judge_model_test.go`, a regression guard asserting `createJudgeModel` resolves known provider types (including the default `anthropic/claude-opus-4-5-20251101`) instead of returning the unknown-provider error. Reverting the one-line change makes the test fail with the exact issue error; the fix makes it pass.

## Validation

| check | result |
| --- | --- |
| `go build ./...` | pass |
| `go test ./pkg/evaluation/...` | pass |
| `go test ./pkg/model/provider/...` | pass |
| `go vet ./pkg/evaluation/...` | clean |
| `golangci-lint run ./pkg/evaluation/...` | 0 issues |

## Out of scope (possible follow-ups)

- `createJudgeModel` does not thread `options.WithProviders(runConfig.Providers)`, so a `--judge-model` referencing a config-defined custom provider would still fail to resolve. This was never supported and is not a regression from this change.
- The package-level `provider.New` / `provider.DefaultRegistry` still resolve to an empty registry, so the RAG callers (`pkg/rag/builder.go`, `pkg/rag/strategy/strategy.go`) carry the same latent bug. They are not exercised in the eval host process (the agent under test runs out-of-process via `docker agent run`), so they are out of scope here. A more systemic fix (populate or deprecate `provider.New`) would prevent future direct callers from hitting the same trap.