### PR TITLE
Add SessionID to ErrorEvent so isRootEvent correctly filters child errors

### DIFF
--- a/pkg/runtime/event.go
+++ b/pkg/runtime/event.go
@@ -239,10 +239,16 @@ const (
 type ErrorEvent struct {
 	AgentContext
 
-	Type  string `json:"type"`
-	Error string `json:"error"`
-	Code  string `json:"code,omitempty"`
+	Type      string `json:"type"`
+	SessionID string `json:"session_id,omitempty"`
+	Error     string `json:"error"`
+	Code      string `json:"code,omitempty"`
 }
+
+// GetSessionID makes ErrorEvent satisfy [SessionScoped] so the existing
+// isRootEvent check in the platform runner correctly distinguishes root-session
+// errors from child-session errors forwarded by runForwarding.
+func (e *ErrorEvent) GetSessionID() string { return e.SessionID }
 
 func Error(msg string) Event {
 	return &ErrorEvent{
@@ -256,6 +262,29 @@ func ErrorWithCode(code, msg string) Event {
 		Type:  "error",
 		Error: msg,
 		Code:  code,
+	}
+}
+
+// ErrorForSession creates an error event tagged with the session ID that
+// produced it. Use this inside the runtime run loop where sess.ID is
+// available so that isRootEvent can distinguish root-session errors from
+// child-session errors forwarded by runForwarding.
+func ErrorForSession(sessionID, msg string) Event {
+	return &ErrorEvent{
+		Type:      "error",
+		SessionID: sessionID,
+		Error:     msg,
+	}
+}
+
+// ErrorWithCodeForSession creates an error event with a code and session ID.
+// See ErrorForSession for the session-tagging rationale.
+func ErrorWithCodeForSession(sessionID, code, msg string) Event {
+	return &ErrorEvent{
+		Type:      "error",
+		SessionID: sessionID,
+		Error:     msg,
+		Code:      code,
 	}
 }
 

--- a/pkg/runtime/harness.go
+++ b/pkg/runtime/harness.go
@@ -27,7 +27,7 @@ func (r *LocalRuntime) runHarnessAgent(ctx context.Context, sess *session.Sessio
 	provider, err := codingharness.NewProvider(a.Harness())
 	if err != nil {
 		msg := fmt.Sprintf("failed to configure harness: %v", err)
-		events.Emit(ErrorWithCode(ErrorCodeModelError, msg))
+		events.Emit(ErrorWithCodeForSession(sess.ID, ErrorCodeModelError, msg))
 		r.notifyError(ctx, a, sess.ID, msg)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "harness configuration error")
@@ -170,7 +170,7 @@ func (r *LocalRuntime) runHarnessAgent(ctx context.Context, sess *session.Sessio
 		}
 		msg := fmt.Sprintf("harness %s failed: %v", provider.Name(), err)
 		completeRemainingToolCalls(tools.ResultError(msg))
-		events.Emit(ErrorWithCode(ErrorCodeModelError, msg))
+		events.Emit(ErrorWithCodeForSession(sess.ID, ErrorCodeModelError, msg))
 		r.notifyError(ctx, a, sess.ID, msg)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "harness run error")

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -157,7 +157,7 @@ func (r *LocalRuntime) emitHookDrivenShutdown(
 		// block without a reason.
 		message = "Agent terminated by a hook."
 	}
-	events.Emit(ErrorWithCode(ErrorCodeHookBlocked, message))
+	events.Emit(ErrorWithCodeForSession(sess.ID, ErrorCodeHookBlocked, message))
 	r.notifyError(ctx, a, sess.ID, message)
 }
 
@@ -286,7 +286,7 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 
 	agentTools, err := r.getTools(ctx, a, sessionSpan, sink, true)
 	if err != nil {
-		sink.Emit(ErrorWithCode(ErrorCodeToolFailed, fmt.Sprintf("failed to get tools: %v", err)))
+		sink.Emit(ErrorWithCodeForSession(sess.ID, ErrorCodeToolFailed, fmt.Sprintf("failed to get tools: %v", err)))
 		return
 	}
 	agentTools = filterExcludedTools(agentTools, sess.ExcludedTools)
@@ -380,7 +380,7 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 
 		agentTools, err := r.getTools(ctx, a, sessionSpan, sink, true)
 		if err != nil {
-			sink.Emit(ErrorWithCode(ErrorCodeToolFailed, fmt.Sprintf("failed to get tools: %v", err)))
+			sink.Emit(ErrorWithCodeForSession(sess.ID, ErrorCodeToolFailed, fmt.Sprintf("failed to get tools: %v", err)))
 			return
 		}
 		agentTools = filterExcludedTools(agentTools, sess.ExcludedTools)
@@ -722,7 +722,7 @@ func (r *LocalRuntime) runTurn(
 			attribute.Int("cagent.loop.consecutive_calls", consecutive),
 		)
 		sessionSpan.SetStatus(codes.Error, errMsg)
-		events.Emit(ErrorWithCode(ErrorCodeLoopDetected, errMsg))
+		events.Emit(ErrorWithCodeForSession(sess.ID, ErrorCodeLoopDetected, errMsg))
 		r.notifyError(ctx, a, sess.ID, errMsg)
 		ls.loopDetector.Reset()
 		endReason = turnEndReasonLoopDetected

--- a/pkg/runtime/loop_steps.go
+++ b/pkg/runtime/loop_steps.go
@@ -184,7 +184,7 @@ func (r *LocalRuntime) handleStreamError(
 	slog.ErrorContext(ctx, "All models failed", "agent", a.Name(), "error", err)
 	r.telemetry.RecordError(ctx, err.Error())
 	errMsg := modelerrors.FormatError(err)
-	events.Emit(ErrorWithCode(classifyErrorCode(err), errMsg))
+	events.Emit(ErrorWithCodeForSession(sess.ID, classifyErrorCode(err), errMsg))
 	r.notifyError(ctx, a, sess.ID, errMsg)
 	return streamErrorFatal
 }

--- a/pkg/runtime/session_compaction.go
+++ b/pkg/runtime/session_compaction.go
@@ -81,7 +81,7 @@ func (r *LocalRuntime) doCompact(ctx context.Context, sess *session.Session, a *
 		if contextLimit <= 0 {
 			slog.ErrorContext(ctx, "Failed to generate session summary",
 				"error", "model definition unavailable")
-			events.Emit(Error("Failed to get model definition"))
+			events.Emit(ErrorForSession(sess.ID, "Failed to get model definition"))
 			return
 		}
 
@@ -95,7 +95,7 @@ func (r *LocalRuntime) doCompact(ctx context.Context, sess *session.Session, a *
 		})
 		if err != nil {
 			slog.ErrorContext(ctx, "Failed to generate session summary", "error", err)
-			events.Emit(Error(err.Error()))
+			events.Emit(ErrorForSession(sess.ID, err.Error()))
 			return
 		}
 		if result == nil {


### PR DESCRIPTION
Paired with docker/agentic-platform#2942.

`ErrorEvent` had no `SessionID` field, so the platform runner's `isRootEvent` (a `SessionScoped` check) always returned `true` for error events — child-session model failures forwarded by `runForwarding` incorrectly looked like root failures.

**Changes:**
- Add `SessionID string` to `ErrorEvent` + `GetSessionID()` impl
- Add `ErrorForSession` and `ErrorWithCodeForSession` session-aware constructors
- Update all run-loop callsites (`loop.go`, `loop_steps.go`, `harness.go`, `session_compaction.go`) to use the session-aware variants
- Keep original `Error()` / `ErrorWithCode()` for backward compat with non-loop callers