### PR TITLE
fix: correct exported name InteractivePromptsAllowed in OAuth MCP handler

### DIFF
--- a/pkg/tools/mcp/oauth.go
+++ b/pkg/tools/mcp/oauth.go
@@ -390,7 +390,7 @@ func (t *oauthTransport) handleServerRejectedToken(ctx context.Context, prev *OA
 
 	// Refresh not possible or failed: fall back to interactive OAuth if the
 	// context allows it.
-	if !interactivePromptsAllowed(ctx) {
+	if !InteractivePromptsAllowed(ctx) {
 		slog.DebugContext(ctx, "Non-interactive context: deferring re-auth after server-side token rejection", "url", t.baseURL)
 		t.mu.Lock()
 		t.lastAuthRequired = true


### PR DESCRIPTION
After the rename that made `interactivePromptsAllowed` an exported symbol (`InteractivePromptsAllowed`), a call site in `pkg/tools/mcp/oauth.go` (line 393) was left using the old unexported name, causing a compile error that broke the main branch build.

This change updates that call site to use the correct exported name `InteractivePromptsAllowed`, restoring a clean build. No behaviour is changed.