### PR TITLE
ci: don't cancel in-progress runs on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Previously, the CI workflow used `cancel-in-progress: true` unconditionally, which means a new push to `main` would cancel any still-running workflow triggered by the previous push. This is fine for feature branches, where you want stale runs discarded quickly, but it's the wrong behaviour for `main`: every push to main represents a merged, reviewed commit and its CI run should always complete.

This change makes `cancel-in-progress` conditional on the ref being something other than `main`. PR branches and other non-main refs continue to cancel stale in-progress runs as before, saving CI minutes on rapid iteration. Pushes to `main` are now guaranteed to run to completion and will never be silently skipped by a faster-arriving sibling run.

No functional change to any workflow job; only the concurrency cancellation policy is affected.