### PR TITLE
fix(mcp/oauth): merge query params when building authorize URL (#3229)

### DIFF
--- a/pkg/tools/mcp/oauth_helpers.go
+++ b/pkg/tools/mcp/oauth_helpers.go
@@ -134,20 +134,29 @@ func GenerateState() (string, error) {
 	return base64.RawURLEncoding.EncodeToString(b), nil
 }
 
-// BuildAuthorizationURL builds the OAuth authorization URL with PKCE
+// BuildAuthorizationURL builds the OAuth authorization URL with PKCE.
+// It merges the OAuth parameters into any query string already present on
+// authEndpoint (e.g. Grafana Cloud's grafana_url= selector) so the result
+// always has exactly one '?' even when the endpoint carries pre-existing params.
 func BuildAuthorizationURL(authEndpoint, clientID, redirectURI, state, codeChallenge, resourceURL string, scopes []string) string {
-	params := url.Values{}
-	params.Set("response_type", "code")
-	params.Set("client_id", clientID)
-	params.Set("redirect_uri", redirectURI)
-	params.Set("state", state)
-	params.Set("code_challenge", codeChallenge)
-	params.Set("code_challenge_method", "S256")
-	params.Set("resource", resourceURL) // RFC 8707: Resource Indicators
-	if len(scopes) > 0 {
-		params.Set("scope", strings.Join(scopes, " "))
+	u, err := url.Parse(authEndpoint)
+	if err != nil {
+		// Degrade gracefully: treat the whole input as an opaque endpoint.
+		u = &url.URL{Path: authEndpoint}
 	}
-	return authEndpoint + "?" + params.Encode()
+	q := u.Query() // preserves any params the auth server baked into the endpoint (e.g. grafana_url)
+	q.Set("response_type", "code")
+	q.Set("client_id", clientID)
+	q.Set("redirect_uri", redirectURI)
+	q.Set("state", state)
+	q.Set("code_challenge", codeChallenge)
+	q.Set("code_challenge_method", "S256")
+	q.Set("resource", resourceURL) // RFC 8707: Resource Indicators
+	if len(scopes) > 0 {
+		q.Set("scope", strings.Join(scopes, " "))
+	}
+	u.RawQuery = q.Encode()
+	return u.String()
 }
 
 // ExchangeCodeForToken exchanges an authorization code for an access token.

--- a/pkg/tools/mcp/oauth_test.go
+++ b/pkg/tools/mcp/oauth_test.go
@@ -2569,10 +2569,10 @@ func TestBuildAuthorizationURL(t *testing.T) {
 			},
 		},
 		{
-			name:        "empty scopes omits scope param",
+			name:         "empty scopes omits scope param",
 			authEndpoint: "https://auth.example.com/authorize",
-			scopes:      nil,
-			wantNoScope: true,
+			scopes:       nil,
+			wantNoScope:  true,
 		},
 		{
 			name:         "multiple scopes are space-joined",

--- a/pkg/tools/mcp/oauth_test.go
+++ b/pkg/tools/mcp/oauth_test.go
@@ -2534,3 +2534,86 @@ func TestRoundTrip_ConcurrentInvalidToken_NoRefresh_StickyDecline(t *testing.T) 
 	assert.Equal(t, int32(0), tokenCalls.Load(),
 		"token endpoint must NOT be hit: no refresh token exists")
 }
+
+// TestBuildAuthorizationURL verifies that BuildAuthorizationURL always
+// produces a well-formed URL with exactly one '?' regardless of whether the
+// auth endpoint already contains a query string. Regression test for #3229.
+func TestBuildAuthorizationURL(t *testing.T) {
+	const (
+		clientID      = "test-client"
+		redirectURI   = "https://example.com/callback"
+		state         = "test-state"
+		codeChallenge = "test-challenge"
+		resourceURL   = "https://mcp.example.com"
+	)
+
+	tests := []struct {
+		name               string
+		authEndpoint       string
+		scopes             []string
+		wantPreservedParam map[string]string // params the endpoint already carried
+		wantNoScope        bool
+	}{
+		{
+			name:         "plain endpoint without existing query string",
+			authEndpoint: "https://auth.example.com/authorize",
+			scopes:       []string{"read", "write"},
+		},
+		{
+			// Regression case: Grafana Cloud bakes grafana_url= into the endpoint.
+			name:         "endpoint with pre-existing query string (Grafana Cloud)",
+			authEndpoint: "https://mcp.grafana.com/mcp/oauth/authorize?grafana_url=https%3A%2F%2Fdockerinc.grafana.net",
+			scopes:       []string{"metrics:read"},
+			wantPreservedParam: map[string]string{
+				"grafana_url": "https://dockerinc.grafana.net",
+			},
+		},
+		{
+			name:        "empty scopes omits scope param",
+			authEndpoint: "https://auth.example.com/authorize",
+			scopes:      nil,
+			wantNoScope: true,
+		},
+		{
+			name:         "multiple scopes are space-joined",
+			authEndpoint: "https://auth.example.com/authorize",
+			scopes:       []string{"openid", "profile", "email"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := BuildAuthorizationURL(tc.authEndpoint, clientID, redirectURI, state, codeChallenge, resourceURL, tc.scopes)
+
+			// Exactly one '?' in the result.
+			assert.Equal(t, 1, strings.Count(result, "?"),
+				"result must contain exactly one '?': %s", result)
+
+			// Parse and inspect individual query parameters.
+			u, err := url.Parse(result)
+			require.NoError(t, err, "result must be a valid URL")
+			q := u.Query()
+
+			assert.Equal(t, "code", q.Get("response_type"))
+			assert.Equal(t, clientID, q.Get("client_id"))
+			assert.Equal(t, redirectURI, q.Get("redirect_uri"))
+			assert.Equal(t, state, q.Get("state"))
+			assert.Equal(t, codeChallenge, q.Get("code_challenge"))
+			assert.Equal(t, "S256", q.Get("code_challenge_method"))
+			assert.Equal(t, resourceURL, q.Get("resource"))
+
+			// scope handling
+			if tc.wantNoScope {
+				assert.False(t, q.Has("scope"), "scope param must be absent when scopes is empty")
+			} else {
+				assert.Equal(t, strings.Join(tc.scopes, " "), q.Get("scope"))
+			}
+
+			// pre-existing params must survive intact
+			for k, want := range tc.wantPreservedParam {
+				assert.Equal(t, want, q.Get(k),
+					"pre-existing param %q must be preserved unchanged", k)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Fixes `BuildAuthorizationURL` in `pkg/tools/mcp/oauth_helpers.go` so it correctly handles an OAuth authorization endpoint that already carries a query string.

Closes #3229.

## Why

The previous implementation built the authorize URL by naive concatenation:

```go
return authEndpoint + "?" + params.Encode()
```

When the auth-server-advertised authorization endpoint already contains a query string, this appended a **second `?`**, so the provider parsed the entire tail as one query-parameter value and the real OAuth/PKCE params were lost.

This broke the Grafana Cloud MCP server, which (when reached with the `X-Grafana-URL` routing header) advertises an instance-scoped authorize endpoint like:

```
https://mcp.grafana.com/mcp/oauth/authorize?grafana_url=https%3A%2F%2Fdockerinc.grafana.net
```

The builder produced a URL with two `?`, and Grafana responded:

```json
{"error":"invalid_request","error_description":"missing required parameters: client_id, redirect_uri, code_challenge, state"}
```

This is a latent bug newly exposed by the header-forwarding feature (#3148), and would affect any MCP whose authorize endpoint carries a query string.

## How

`BuildAuthorizationURL` now parses the endpoint with `url.Parse`, starts from its existing `url.Values` (`u.Query()`), sets the OAuth/PKCE params on top, and encodes once via `u.RawQuery = q.Encode()`. This preserves any pre-existing params (e.g. `grafana_url`) and always emits a single `?` with `&`-separated params. Behaviour for query-less endpoints is unchanged.

## Tests

Added table-driven tests for `BuildAuthorizationURL` (`pkg/tools/mcp/oauth_test.go`) covering:
- a query-less endpoint (single `?`, all params correct);
- the **regression case** — a query-bearing endpoint (Grafana Cloud): exactly one `?`, `grafana_url` preserved, and `client_id`/`redirect_uri`/`state`/`code_challenge`/`code_challenge_method`/`response_type`/`resource` all present as independent params;
- empty vs. multi-scope handling.

## Note for reviewers

This branch also includes a small unrelated build fix: a missed rename from PR #3213 left one call site referencing `interactivePromptsAllowed` after the function was exported to `InteractivePromptsAllowed`, which broke the build. Corrected here so the package compiles. Happy to split this into its own PR if preferred.

## Validation

```
go build ./...              # PASS
go vet ./...                # PASS
go test ./pkg/tools/mcp/... # PASS (incl. new regression subtests)
```