### PR TITLE
feat: add top-level shared toolsets with use_toolsets agent field

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -84,6 +84,13 @@
         "$ref": "#/definitions/SkillsConfig"
       }
     },
+    "toolsets": {
+      "type": "object",
+      "description": "Map of reusable, named toolset definitions. Define a toolset here and reference it by name from an agent's use_toolsets to share the same toolset across multiple agents.",
+      "additionalProperties": {
+        "$ref": "#/definitions/Toolset"
+      }
+    },
     "metadata": {
       "$ref": "#/definitions/Metadata",
       "description": "Configuration metadata"
@@ -775,6 +782,13 @@
         "use_skills": {
           "type": "array",
           "description": "Names of reusable skill groups (defined in the top-level skills section) to merge into this agent. Inline skills on the agent take precedence on name conflicts.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "use_toolsets": {
+          "type": "array",
+          "description": "Names of reusable toolset definitions (defined in the top-level toolsets section) to append to this agent's toolsets. Inline toolsets on the agent come first, followed by each referenced toolset in order.",
           "items": {
             "type": "string"
           }

--- a/examples/shared-toolsets.yaml
+++ b/examples/shared-toolsets.yaml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=../agent-schema.json
+
+# This example demonstrates how to use the top-level `toolsets` section to
+# define toolsets once and reuse them across multiple agents via `use_toolsets`,
+# avoiding duplication.
+
+models:
+  model:
+    provider: anthropic
+    model: claude-sonnet-4-0
+    max_tokens: 64000
+
+# Define reusable toolsets once at the top level. Any toolset type is allowed.
+toolsets:
+  fs:
+    type: filesystem
+  docs:
+    type: fetch
+    allowed_domains:
+      - docker.com
+      - docs.docker.com
+
+agents:
+  root:
+    model: model
+    description: Lead developer
+    instruction: |
+      You are the lead developer. Coordinate the team.
+    sub_agents: [reviewer]
+    # Pull in the shared toolsets by name. Inline toolsets (think) come first,
+    # followed by the referenced toolsets in order.
+    use_toolsets: [fs, docs]
+    toolsets:
+      - type: think
+
+  reviewer:
+    model: model
+    description: Code reviewer
+    instruction: |
+      You review code changes.
+    # The same toolset definitions are reused here.
+    use_toolsets: [fs]

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -135,6 +135,10 @@ func validateConfig(cfg *latest.Config) error {
 		return err
 	}
 
+	if err := resolveToolsetDefinitions(cfg); err != nil {
+		return err
+	}
+
 	if err := resolveMCPDefinitions(cfg); err != nil {
 		return err
 	}

--- a/pkg/config/hcl/hcl.go
+++ b/pkg/config/hcl/hcl.go
@@ -8,6 +8,8 @@
 //     `commands: { name: { ... } }`.
 //   - Toolsets use the label as the `type` field:
 //     `toolset "mcp" { ... }` becomes `toolsets: [{ type: mcp, ... }]`.
+//     At the top level, `toolsets "name" { ... }` instead defines a reusable,
+//     named toolset under `toolsets: { name: { ... } }`.
 //   - Multi-line strings should use heredocs. Because HCL templates expand
 //     `${...}` interpolation, any literal `${...}` (such as
 //     `${shell({cmd: "..."})}`) must be escaped as `$${...}`.
@@ -64,7 +66,7 @@ func LooksLikeHCL(data []byte) bool {
 // topLevelHCLKeywords lists the block names that may legitimately appear at
 // the top level of a docker-agent HCL document.
 var topLevelHCLKeywords = []string{
-	"agent", "model", "provider", "mcp", "rag", "metadata", "permissions",
+	"agent", "model", "provider", "mcp", "rag", "metadata", "permissions", "toolsets",
 }
 
 // ToYAML parses an HCL document and returns an equivalent YAML document
@@ -140,6 +142,10 @@ var blockRules = map[string]blockRule{
 	"rag":      {mode: modeMapByLabel, outKey: "rag"},
 	"command":  {mode: modeMapByLabel, outKey: "commands"},
 	"skill":    {mode: modeMapByLabel, outKey: "skills"},
+	// Top-level reusable toolset definitions: `toolsets "name" { ... }` becomes
+	// toolsets: { name: { ... } }. Distinct from the agent-level `toolset`
+	// (singular) block, which aggregates into a list under the same key.
+	"toolsets": {mode: modeMapByLabel, outKey: "toolsets"},
 	// `shell "name" { ... }` is used inside script toolsets as a map of
 	// scripted shell commands.
 	"shell": {mode: modeMapByLabel, outKey: "shell"},

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -31,11 +31,17 @@ type Config struct {
 	// or AgentConfig.UseSkills; the group is merged into the agent during config
 	// resolution (see resolveCommandDefinitions / resolveSkillDefinitions). This
 	// mirrors the top-level MCPs/RAG reference-by-name convention.
-	Commands    map[string]types.Commands `json:"commands,omitempty"`
-	Skills      map[string]SkillsConfig   `json:"skills,omitempty"`
-	Metadata    Metadata                  `json:"metadata"`
-	Permissions *PermissionsConfig        `json:"permissions,omitempty"`
-	Runtime     *RuntimeDefaults          `json:"runtime,omitempty"`
+	Commands map[string]types.Commands `json:"commands,omitempty"`
+	Skills   map[string]SkillsConfig   `json:"skills,omitempty"`
+	// Toolsets is a map of reusable, named toolset definitions shared across
+	// agents. An agent opts in by listing a name in AgentConfig.UseToolsets;
+	// the named toolset is appended to the agent during config resolution
+	// (see resolveToolsetDefinitions). This mirrors the top-level MCPs/RAG
+	// reference-by-name convention but works for any toolset type.
+	Toolsets    map[string]Toolset `json:"toolsets,omitempty"`
+	Metadata    Metadata           `json:"metadata"`
+	Permissions *PermissionsConfig `json:"permissions,omitempty"`
+	Runtime     *RuntimeDefaults   `json:"runtime,omitempty"`
 }
 
 // RuntimeDefaults captures execution-time defaults the agent author
@@ -469,8 +475,13 @@ type AgentConfig struct {
 	// top-level Config.Commands / Config.Skills sections. The referenced
 	// groups are merged into Commands / Skills during config resolution;
 	// inline entries on the agent take precedence on name conflicts.
-	UseCommands []string     `json:"use_commands,omitempty"`
-	UseSkills   []string     `json:"use_skills,omitempty"`
+	UseCommands []string `json:"use_commands,omitempty"`
+	UseSkills   []string `json:"use_skills,omitempty"`
+	// UseToolsets references reusable toolset definitions defined in the
+	// top-level Config.Toolsets section. The referenced toolsets are appended
+	// to the agent's own Toolsets during config resolution (see
+	// resolveToolsetDefinitions). Inline toolsets on the agent come first.
+	UseToolsets []string     `json:"use_toolsets,omitempty"`
 	Hooks       *HooksConfig `json:"hooks,omitempty"`
 	Cache       *CacheConfig `json:"cache,omitempty"`
 }

--- a/pkg/config/latest/validate.go
+++ b/pkg/config/latest/validate.go
@@ -33,9 +33,11 @@ func (t *Config) Validate() error {
 		}
 	}
 
-	// Validate reusable, named toolset definitions even when no agent
-	// references them (parity with the top-level MCP/skill definition
-	// validation).
+	// Re-validate reusable, named toolset definitions here so they are
+	// checked even when no agent references them, and when a Config is
+	// constructed programmatically rather than parsed from YAML. (When
+	// parsed, each value is already validated by Toolset.UnmarshalYAML.)
+	// Mirrors the agent-toolset validation loop below.
 	for name := range t.Toolsets {
 		ts := t.Toolsets[name]
 		if err := ts.validate(); err != nil {

--- a/pkg/config/latest/validate.go
+++ b/pkg/config/latest/validate.go
@@ -33,6 +33,16 @@ func (t *Config) Validate() error {
 		}
 	}
 
+	// Validate reusable, named toolset definitions even when no agent
+	// references them (parity with the top-level MCP/skill definition
+	// validation).
+	for name := range t.Toolsets {
+		ts := t.Toolsets[name]
+		if err := ts.validate(); err != nil {
+			return fmt.Errorf("toolsets.%s: %w", name, err)
+		}
+	}
+
 	for i := range t.Agents {
 		agent := &t.Agents[i]
 

--- a/pkg/config/shared_toolsets_test.go
+++ b/pkg/config/shared_toolsets_test.go
@@ -1,0 +1,47 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSharedToolsets_Resolve(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := Load(t.Context(), NewFileSource("testdata/shared_toolsets.yaml"))
+	require.NoError(t, err)
+
+	dev, ok := cfg.Agents.Lookup("dev")
+	require.True(t, ok)
+	// Inline toolset comes first, followed by the referenced toolsets in order.
+	require.Len(t, dev.Toolsets, 3)
+	assert.Equal(t, "think", dev.Toolsets[0].Type)
+	assert.Equal(t, "filesystem", dev.Toolsets[1].Type)
+	assert.Equal(t, "fetch", dev.Toolsets[2].Type)
+	assert.Equal(t, []string{"docker.com"}, dev.Toolsets[2].AllowedDomains)
+
+	// The same definitions are reusable across agents.
+	ops, ok := cfg.Agents.Lookup("ops")
+	require.True(t, ok)
+	require.Len(t, ops.Toolsets, 1)
+	assert.Equal(t, "filesystem", ops.Toolsets[0].Type)
+}
+
+func TestSharedToolsets_MissingDefinition(t *testing.T) {
+	t.Parallel()
+
+	_, err := Load(t.Context(), NewFileSource("testdata/shared_toolsets_missing.yaml"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-existent toolset 'nonexistent'")
+}
+
+func TestSharedToolsets_InvalidDefinitionValidated(t *testing.T) {
+	t.Parallel()
+
+	// Top-level toolset definitions are validated even when no agent references them.
+	_, err := Load(t.Context(), NewFileSource("testdata/shared_toolsets_invalid.yaml"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "allow_list can only be used with type 'filesystem'")
+}

--- a/pkg/config/testdata/shared_toolsets.yaml
+++ b/pkg/config/testdata/shared_toolsets.yaml
@@ -1,0 +1,23 @@
+models:
+  model:
+    provider: anthropic
+    model: claude-sonnet-4-0
+    max_tokens: 64000
+
+toolsets:
+  fs:
+    type: filesystem
+  web:
+    type: fetch
+    allowed_domains:
+      - docker.com
+
+agents:
+  dev:
+    model: model
+    use_toolsets: [fs, web]
+    toolsets:
+      - type: think
+  ops:
+    model: model
+    use_toolsets: [fs]

--- a/pkg/config/testdata/shared_toolsets_invalid.yaml
+++ b/pkg/config/testdata/shared_toolsets_invalid.yaml
@@ -1,0 +1,16 @@
+models:
+  model:
+    provider: anthropic
+    model: claude-sonnet-4-0
+
+# allow_list is only valid on filesystem toolsets; this top-level definition
+# must be rejected even though no agent references it.
+toolsets:
+  bad:
+    type: shell
+    allow_list:
+      - "."
+
+agents:
+  dev:
+    model: model

--- a/pkg/config/testdata/shared_toolsets_missing.yaml
+++ b/pkg/config/testdata/shared_toolsets_missing.yaml
@@ -1,0 +1,9 @@
+models:
+  model:
+    provider: anthropic
+    model: claude-sonnet-4-0
+
+agents:
+  dev:
+    model: model
+    use_toolsets: [nonexistent]

--- a/pkg/config/toolsets.go
+++ b/pkg/config/toolsets.go
@@ -1,0 +1,30 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/docker/docker-agent/pkg/config/latest"
+)
+
+// resolveToolsetDefinitions appends reusable toolset definitions referenced by
+// agents (via use_toolsets) from the top-level toolsets section onto each
+// agent's Toolsets slice. Inline toolsets defined on the agent come first,
+// followed by the toolsets from each referenced definition in order. This
+// mirrors the use_commands / use_skills group convention but works for any
+// toolset type.
+//
+// It runs before resolveMCPDefinitions / resolveRAGDefinitions so that mcp and
+// rag toolsets pulled in from a definition still have their refs resolved.
+func resolveToolsetDefinitions(cfg *latest.Config) error {
+	for i := range cfg.Agents {
+		agent := &cfg.Agents[i]
+		for _, ref := range agent.UseToolsets {
+			ts, ok := cfg.Toolsets[ref]
+			if !ok {
+				return fmt.Errorf("agent '%s' references non-existent toolset '%s'", agent.Name, ref)
+			}
+			agent.Toolsets = append(agent.Toolsets, ts)
+		}
+	}
+	return nil
+}

--- a/pkg/profiling/pprof_server.go
+++ b/pkg/profiling/pprof_server.go
@@ -46,7 +46,7 @@ func StartPprofServer(ctx context.Context, addr string) error {
 
 	go func() {
 		if err := srv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			slog.Warn("pprof server error", "error", err)
+			slog.WarnContext(ctx, "pprof server error", "error", err)
 		}
 	}()
 

--- a/pkg/runtime/cache.go
+++ b/pkg/runtime/cache.go
@@ -110,7 +110,7 @@ func (r *LocalRuntime) cacheResponseBuiltin(ctx context.Context, in *hooks.Input
 	}
 	a, err := r.team.Agent(in.AgentName)
 	if err != nil || a == nil {
-		slog.Debug("cache_response: agent lookup failed",
+		slog.DebugContext(ctx, "cache_response: agent lookup failed",
 			"agent", in.AgentName, "error", err)
 		return nil, nil
 	}

--- a/pkg/tools/mcp/oauth.go
+++ b/pkg/tools/mcp/oauth.go
@@ -390,7 +390,7 @@ func (t *oauthTransport) handleServerRejectedToken(ctx context.Context, prev *OA
 
 	// Refresh not possible or failed: fall back to interactive OAuth if the
 	// context allows it.
-	if !interactivePromptsAllowed(ctx) {
+	if !InteractivePromptsAllowed(ctx) {
 		slog.DebugContext(ctx, "Non-interactive context: deferring re-auth after server-side token rejection", "url", t.baseURL)
 		t.mu.Lock()
 		t.lastAuthRequired = true


### PR DESCRIPTION
Agents that need the same toolset in multiple places currently have to copy the full toolset definition for each agent. This adds a top-level `toolsets` map to the config schema that lets you define a toolset once and reference it by name from any agent via a new `use_toolsets` field, mirroring how top-level `mcps` and `rag` definitions already work.

At runtime, `resolveToolsetDefinitions` runs before the MCP/RAG resolution pass so that shared toolsets can themselves contain MCP or RAG references; the resolved entries are merged into each agent's toolset list before the rest of the pipeline runs. The HCL decoder gains a block rule for `toolsets "name" {}`, the JSON schema is updated, and an example config at `examples/shared-toolsets.yaml` shows the feature end-to-end.

This PR also carries two small fixes that were blocking a clean build: the `interactivePromptsAllowed` call in the OAuth MCP handler was using the wrong casing (`InteractivePromptsAllowed` is the exported name), and two `slog.Warn`/`slog.Debug` calls in the pprof server and cache builtin were using the package-level logger instead of the context-aware one required by the linter.