### PR TITLE
feat: codify prefix-stability invariant + regression tests (APT-396)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 on:
   workflow_dispatch:

--- a/pkg/hooks/builtins/builtins.go
+++ b/pkg/hooks/builtins/builtins.go
@@ -39,7 +39,33 @@
 //
 // turn_start builtins recompute every turn (date, git state).
 // session_start builtins run once per session for context that's
-// stable for its duration. snapshot is stateful: it keeps per-session
+// stable for its duration.
+//
+// PREFIX-STABILITY CONTRACT (prompt-cache efficiency)
+//
+// All session_start and turn_start builtins inject their AdditionalContext
+// into the cacheable prefix — the region of the Anthropic system prompt
+// that lies before the second cache checkpoint (CP2).  To preserve prompt
+// caching across consecutive turns:
+//
+//   - session_start context (add_environment_info, add_directory_listing,
+//     add_user_info, add_recent_commits) must be byte-stable for the
+//     session's entire life.
+//   - turn_start context (add_prompt_files) must be byte-stable for the
+//     session's entire life (files do not change mid-session).
+//   - add_date is the ONLY sanctioned volatile turn_start item.  Its
+//     "Today's date: YYYY-MM-DD" payload rotates at most once per session
+//     (at UTC midnight) and never busts checkpoint #1 (system + tools).
+//
+// Do NOT add timestamps, wall-clock time, per-request IDs, mutable
+// counters, or any other per-turn volatile data to a session_start or
+// turn_start builtin.  Every such addition degrades prompt-cache reads
+// for every turn of every session that uses the builtin.
+// Note: add_git_status and add_git_diff are deliberately volatile turn_start
+// builtins; configuring them trades away CP2 cache-hit efficiency in exchange
+// for up-to-date diff context.  They are not auto-injected by the platform.
+//
+// snapshot is stateful: it keeps per-session
 // turn/tool snapshot hashes and undo checkpoints in memory while the
 // shadow git objects live under the data directory. Undo checkpoints
 // intentionally survive the RunStream session_end cleanup so /undo

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -611,6 +611,17 @@ func (r *LocalRuntime) runTurn(
 	// hook's output is persisted, so per-turn signals (date, prompt
 	// files) refresh every turn while session-level context (cwd, OS,
 	// arch) stays stable — all without bloating the stored history.
+	//
+	// Splice order (extras passed to GetMessages):
+	//   session_start: ls.sessionStartMsgs  (stable for the session's life)
+	//   user_prompt_submit: ls.userPromptMsgs (only on real user prompts)
+	//   turn_start: turnStartMsgs           (refreshed each turn)
+	//
+	// PREFIX-STABILITY RULE: all extras must be byte-stable within a UTC
+	// day.  Only add_date ("Today's date: YYYY-MM-DD") may rotate, and
+	// only at midnight.  Do NOT add timestamps, counters, request IDs, or
+	// other per-turn volatile content here — each such addition busts the
+	// prompt-cache read for every turn of every session.
 	turnStartMsgs := r.executeTurnStartHooks(ctx, sess, a, events)
 	messages := sess.GetMessages(a, slices.Concat(ls.sessionStartMsgs, ls.userPromptMsgs, turnStartMsgs)...)
 	slog.DebugContext(ctx, "Retrieved messages for processing", "agent", a.Name(), "message_count", len(messages))

--- a/pkg/session/prefix_stability_test.go
+++ b/pkg/session/prefix_stability_test.go
@@ -1,0 +1,112 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/chat"
+)
+
+// cacheablePrefix returns the messages that form the cacheable prefix: all
+// messages up to and including the second cache-control checkpoint.  These
+// correspond to the Anthropic "system" parameter blocks that lie before
+// (a) the invariant checkpoint (CP1) and (b) the extras checkpoint (CP2).
+// Both must be byte-stable across consecutive turns for prompt-cache reads
+// to hit.  Returns nil when fewer than two checkpoints are present.
+func cacheablePrefix(messages []chat.Message) []chat.Message {
+	cp := 0
+	end := -1
+	for i, msg := range messages {
+		if msg.Role == chat.MessageRoleSystem && msg.CacheControl {
+			cp++
+			if cp == 2 {
+				end = i
+				break
+			}
+		}
+	}
+	if end < 0 {
+		return nil
+	}
+	return messages[:end+1]
+}
+
+// TestPrefixStabilityAcrossConversationGrowth is the prefix-stability
+// regression guard:
+//
+//   - The cacheable prefix (system messages up to and including CP2) must be
+//     byte-identical across two consecutive GetMessages calls whose only
+//     difference is additional conversation history.
+//
+// Any future change that accidentally injects a timestamp, per-request ID,
+// counter, or other volatile value into the invariant system messages or the
+// turn_start / session_start extras will break this test, alerting the
+// author that prompt-cache efficiency would be degraded for every turn.
+func TestPrefixStabilityAcrossConversationGrowth(t *testing.T) {
+	testAgent := agent.New("root", "test agent instructions",
+		agent.WithToolSets(todoToolSet(t)),
+	)
+
+	// Extras represent what the runtime passes on each turn:
+	// session_start env info (stable) + turn_start date (stable within a day).
+	sessionStart := chat.Message{
+		Role:    chat.MessageRoleSystem,
+		Content: "Here is useful information about the environment: Working directory: /workspace",
+	}
+	turnStart := chat.Message{
+		Role:    chat.MessageRoleSystem,
+		Content: "Today's date: 2026-06-25",
+	}
+	extras := []chat.Message{sessionStart, turnStart}
+
+	// — Turn N: session has two messages ————————————————————————————————
+	sess := New()
+	sess.AddMessage(NewAgentMessage("root", &chat.Message{Role: chat.MessageRoleUser, Content: "Hello!"}))
+	sess.AddMessage(NewAgentMessage("root", &chat.Message{Role: chat.MessageRoleAssistant, Content: "Hi there!"}))
+
+	msgsN := sess.GetMessages(testAgent, extras...)
+	prefixN := cacheablePrefix(msgsN)
+	require.NotNil(t, prefixN, "expected two cache-control checkpoints in turn N")
+
+	// — Turn N+1: history grew by one more round-trip ————————————————————
+	sess.AddMessage(NewAgentMessage("root", &chat.Message{Role: chat.MessageRoleUser, Content: "What can you do?"}))
+	sess.AddMessage(NewAgentMessage("root", &chat.Message{Role: chat.MessageRoleAssistant, Content: "I can help with tasks!"}))
+
+	msgsN1 := sess.GetMessages(testAgent, extras...)
+	prefixN1 := cacheablePrefix(msgsN1)
+	require.NotNil(t, prefixN1, "expected two cache-control checkpoints in turn N+1")
+
+	// The prefixes must be byte-identical.
+	assert.Equal(t, prefixN, prefixN1,
+		"cacheable prefix (system messages up to CP2) must be byte-stable "+
+			"across consecutive turns: any difference busts prompt-cache reads "+
+			"for every turn of every session")
+}
+
+// TestPrefixStabilityIdempotent asserts that calling GetMessages twice in
+// succession with identical inputs produces identical prefixes.  This guards
+// against non-deterministic sources inside GetMessages itself (e.g.
+// map-iteration order, pointer-dependent formatting).
+func TestPrefixStabilityIdempotent(t *testing.T) {
+	testAgent := agent.New("root", "determinism test",
+		agent.WithToolSets(todoToolSet(t)),
+	)
+
+	extra := chat.Message{
+		Role:    chat.MessageRoleSystem,
+		Content: "Today's date: 2026-06-25",
+	}
+
+	sess := New()
+	sess.AddMessage(NewAgentMessage("root", &chat.Message{Role: chat.MessageRoleUser, Content: "hello"}))
+
+	prefix1 := cacheablePrefix(sess.GetMessages(testAgent, extra))
+	prefix2 := cacheablePrefix(sess.GetMessages(testAgent, extra))
+
+	require.NotNil(t, prefix1)
+	assert.Equal(t, prefix1, prefix2,
+		"repeated GetMessages calls with identical inputs must yield identical prefixes")
+}

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -1081,6 +1081,29 @@ func (s *Session) GetMessages(a *agent.Agent, extraSystemMessages ...chat.Messag
 	// is acceptable: the cache simply rotates when the date rolls over,
 	// matching the behavior of the previous inline
 	// buildContextSpecificSystemMessages path.
+	//
+	// PREFIX-STABILITY INVARIANT
+	// The cacheable prefix — system param checkpoint #1 (invariant) plus
+	// checkpoint #2 (last extra) — MUST be byte-stable across consecutive
+	// turns of the same session so that Anthropic prompt-cache reads hit
+	// rather than paying full-price cache-creation tokens each turn.
+	//
+	// Rules:
+	//   1. Invariant system messages (agent instruction, toolset instructions,
+	//      sub-agent/handoff prompts) must be derived solely from static agent
+	//      configuration — no timestamps, counts, IDs, or per-session state.
+	//   2. Extras supplied here (session_start / turn_start hook output,
+	//      prompt-file contents) must likewise be byte-stable within a UTC day.
+	//   3. The add_date builtin ("Today's date: YYYY-MM-DD") is the ONLY
+	//      sanctioned volatile extra.  It rotates at UTC midnight — at most
+	//      once per session — and never busts checkpoint #1.  Adding further
+	//      volatile content (time-of-day, counters, per-request IDs, etc.)
+	//      is prohibited; doing so degrades prompt-cache efficiency for every
+	//      turn of every session.
+	//
+	// See docker/agentic-platform docs/design/prefix-stability-audit.md for
+	// the full per-source audit and the rationale for accepting add_date's
+	// daily rotation.
 	if len(extraSystemMessages) > 0 {
 		messages = append(messages, extraSystemMessages...)
 		markLastMessageAsCacheControl(messages[len(messages)-len(extraSystemMessages):])


### PR DESCRIPTION
## What

Codifies the **cacheable-prefix byte-stability invariant** as explicit code
comments and guards it with two regression tests.

For Anthropic prompt caching to work across consecutive turns, the system-param
prefix (CP1: invariant system messages; CP2: turn/session-start extras) must be
byte-identical every turn.

## Audit findings

| Source | Verdict |
|---|---|
| Agent instruction / sub-agent / handoff prompts | ✅ Static config |
| Toolset instructions | ✅ Static config; slice-ordered (deterministic) |
| MCP tool list | ✅ Server-order preserved in slice; result cached per-session |
| `add_environment_info` (session_start) | ✅ Stable for session life (cwd/OS/arch) |
| `add_prompt_files` (turn_start) | ✅ Files read at provisioning; stable |
| `add_date` (turn_start) | ⚠️ **Single volatile item** — rotates daily at UTC midnight; never busts CP1 (system+tools); accepted as documented exception |
| Platform toolset instructions (artifacts, s2s, todo) | ✅ Static text |
| Steering / system-reminder text | ✅ Appended to message tail (behind rotating BP3/BP4), not in prefix |
| LLM gateway proxy body | ✅ Transparent proxy; no per-request mutations |

**Conclusion:** The prefix is already byte-stable across consecutive same-day
turns.  is the only volatile early-prefix item; it rotates at most
once per session per UTC midnight.

## Changes

-  — extend GetMessages extras comment with the
   rule block
-  — extend turn_start splice comment with the
   and splice-order table
-  — add  section
  naming  as the sole sanctioned volatile item and prohibiting
  per-turn timestamps/IDs/counters
-  (new) — two tests:
  -  — prefix byte-stable as history grows
  -  — repeated calls yield identical prefix (non-determinism guard)

A companion PR in [docker/agentic-platform](https://github.com/docker/agentic-platform/issues/2931)
contains the full audit document and platform-level invariant note.

Related: APT-396