### PR TITLE
fix: sort script toolset keys for deterministic prompt ordering

### DIFF
--- a/pkg/tools/builtin/shell/script_shell.go
+++ b/pkg/tools/builtin/shell/script_shell.go
@@ -95,7 +95,14 @@ func (t *ScriptToolSet) Instructions() string {
 	var sb strings.Builder
 	sb.WriteString("## Custom Shell Tools\n\n")
 
-	for name, tool := range t.shellTools {
+	names := make([]string, 0, len(t.shellTools))
+	for name := range t.shellTools {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+
+	for _, name := range names {
+		tool := t.shellTools[name]
 		fmt.Fprintf(&sb, "### %s\n", name)
 		if tool.Description != "" {
 			fmt.Fprintf(&sb, "%s\n", tool.Description)
@@ -129,8 +136,14 @@ func (t *ScriptToolSet) Instructions() string {
 func (t *ScriptToolSet) Tools(context.Context) ([]tools.Tool, error) {
 	var toolsList []tools.Tool
 
-	for name, toolConfig := range t.shellTools {
-		cfg := toolConfig
+	names := make([]string, 0, len(t.shellTools))
+	for name := range t.shellTools {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+
+	for _, name := range names {
+		cfg := t.shellTools[name]
 		toolName := name
 
 		description := cmp.Or(cfg.Description, "Execute shell command: "+cfg.Cmd)

--- a/pkg/tools/builtin/shell/script_shell.go
+++ b/pkg/tools/builtin/shell/script_shell.go
@@ -110,7 +110,13 @@ func (t *ScriptToolSet) Instructions() string {
 			fmt.Fprintf(&sb, "Runs: `%s`\n", tool.Cmd)
 		}
 
-		for argName, argDef := range tool.Args {
+		argNames := make([]string, 0, len(tool.Args))
+		for argName := range tool.Args {
+			argNames = append(argNames, argName)
+		}
+		slices.Sort(argNames)
+		for _, argName := range argNames {
+			argDef := tool.Args[argName]
 			description := ""
 			if m, ok := argDef.(map[string]any); ok {
 				if d, ok := m["description"].(string); ok {
@@ -144,7 +150,6 @@ func (t *ScriptToolSet) Tools(context.Context) ([]tools.Tool, error) {
 
 	for _, name := range names {
 		cfg := t.shellTools[name]
-		toolName := name
 
 		description := cmp.Or(cfg.Description, "Execute shell command: "+cfg.Cmd)
 
@@ -154,11 +159,11 @@ func (t *ScriptToolSet) Tools(context.Context) ([]tools.Tool, error) {
 			"required":   cfg.Required,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("invalid schema for tool %s: %w", toolName, err)
+			return nil, fmt.Errorf("invalid schema for tool %s: %w", name, err)
 		}
 
 		toolsList = append(toolsList, tools.Tool{
-			Name:         toolName,
+			Name:         name,
 			Category:     "shell",
 			Description:  description,
 			Parameters:   inputSchema,

--- a/pkg/tools/builtin/shell/script_shell_test.go
+++ b/pkg/tools/builtin/shell/script_shell_test.go
@@ -3,6 +3,7 @@ package shell
 import (
 	"encoding/json"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -281,6 +282,39 @@ func TestScriptToolSet_InstructionsNonMapArgDef(t *testing.T) {
 
 	instructions := tool.Instructions()
 	assert.Contains(t, instructions, "`name`")
+}
+
+func TestScriptToolSet_DeterministicOrdering(t *testing.T) {
+	// Three tools whose names sort as: alpha < beta < gamma.
+	// Because Go map iteration is random, without explicit sorting the
+	// returned order could be anything — this test catches regressions.
+	shellTools := map[string]latest.ScriptShellToolConfig{
+		"gamma": {Description: "Third tool", Cmd: "echo gamma"},
+		"alpha": {Description: "First tool", Cmd: "echo alpha"},
+		"beta":  {Description: "Second tool", Cmd: "echo beta"},
+	}
+
+	tool, err := NewScript(shellTools, nil)
+	require.NoError(t, err)
+
+	// Tools() must return tools in alphabetical order.
+	allTools, err := tool.Tools(t.Context())
+	require.NoError(t, err)
+	require.Len(t, allTools, 3)
+	assert.Equal(t, "alpha", allTools[0].Name)
+	assert.Equal(t, "beta", allTools[1].Name)
+	assert.Equal(t, "gamma", allTools[2].Name)
+
+	// Instructions() must list sections in alphabetical order.
+	instructions := tool.Instructions()
+	alphaPos := strings.Index(instructions, "### alpha")
+	betaPos := strings.Index(instructions, "### beta")
+	gammaPos := strings.Index(instructions, "### gamma")
+	assert.Greater(t, alphaPos, -1, "alpha heading not found")
+	assert.Greater(t, betaPos, -1, "beta heading not found")
+	assert.Greater(t, gammaPos, -1, "gamma heading not found")
+	assert.Less(t, alphaPos, betaPos, "alpha must appear before beta")
+	assert.Less(t, betaPos, gammaPos, "beta must appear before gamma")
 }
 
 func TestNewScript_ArgWithoutType(t *testing.T) {

--- a/pkg/tools/builtin/shell/script_shell_test.go
+++ b/pkg/tools/builtin/shell/script_shell_test.go
@@ -286,12 +286,29 @@ func TestScriptToolSet_InstructionsNonMapArgDef(t *testing.T) {
 
 func TestScriptToolSet_DeterministicOrdering(t *testing.T) {
 	// Three tools whose names sort as: alpha < beta < gamma.
+	// Each tool has multiple args to also exercise arg-level sorting in Instructions().
 	// Because Go map iteration is random, without explicit sorting the
 	// returned order could be anything — this test catches regressions.
 	shellTools := map[string]latest.ScriptShellToolConfig{
-		"gamma": {Description: "Third tool", Cmd: "echo gamma"},
-		"alpha": {Description: "First tool", Cmd: "echo alpha"},
-		"beta":  {Description: "Second tool", Cmd: "echo beta"},
+		"gamma": {
+			Description: "Third tool",
+			Cmd:         "echo $z $a",
+			Args: map[string]any{
+				"z": map[string]any{"type": "string", "description": "last arg"},
+				"a": map[string]any{"type": "string", "description": "first arg"},
+			},
+			Required: []string{"z", "a"},
+		},
+		"alpha": {
+			Description: "First tool",
+			Cmd:         "echo $m $b",
+			Args: map[string]any{
+				"m": map[string]any{"type": "string", "description": "middle arg"},
+				"b": map[string]any{"type": "string", "description": "earlier arg"},
+			},
+			Required: []string{"m", "b"},
+		},
+		"beta": {Description: "Second tool", Cmd: "echo beta"},
 	}
 
 	tool, err := NewScript(shellTools, nil)
@@ -305,7 +322,7 @@ func TestScriptToolSet_DeterministicOrdering(t *testing.T) {
 	assert.Equal(t, "beta", allTools[1].Name)
 	assert.Equal(t, "gamma", allTools[2].Name)
 
-	// Instructions() must list sections in alphabetical order.
+	// Instructions() must list tool sections in alphabetical order.
 	instructions := tool.Instructions()
 	alphaPos := strings.Index(instructions, "### alpha")
 	betaPos := strings.Index(instructions, "### beta")
@@ -315,6 +332,23 @@ func TestScriptToolSet_DeterministicOrdering(t *testing.T) {
 	assert.Greater(t, gammaPos, -1, "gamma heading not found")
 	assert.Less(t, alphaPos, betaPos, "alpha must appear before beta")
 	assert.Less(t, betaPos, gammaPos, "beta must appear before gamma")
+
+	// Instructions() must also list args in alphabetical order within each tool.
+	// For "alpha": arg "b" must appear before arg "m".
+	alphaSection := instructions[alphaPos:betaPos]
+	bArgPos := strings.Index(alphaSection, "`b`")
+	mArgPos := strings.Index(alphaSection, "`m`")
+	assert.Greater(t, bArgPos, -1, "arg b not found in alpha section")
+	assert.Greater(t, mArgPos, -1, "arg m not found in alpha section")
+	assert.Less(t, bArgPos, mArgPos, "arg b must appear before arg m in alpha section")
+
+	// For "gamma": arg "a" must appear before arg "z".
+	gammaSection := instructions[gammaPos:]
+	aArgPos := strings.Index(gammaSection, "`a`")
+	zArgPos := strings.Index(gammaSection, "`z`")
+	assert.Greater(t, aArgPos, -1, "arg a not found in gamma section")
+	assert.Greater(t, zArgPos, -1, "arg z not found in gamma section")
+	assert.Less(t, aArgPos, zArgPos, "arg a must appear before arg z in gamma section")
 }
 
 func TestNewScript_ArgWithoutType(t *testing.T) {


### PR DESCRIPTION
Both `Instructions()` and `Tools()` in `ScriptToolSet` iterated directly over Go maps, producing non-deterministic output order on every call. This caused Anthropic (and similar) prompt-caching to miss every turn because the system prompt changed byte-order between calls.

- Sort `shellTools` keys before iterating in both `Instructions()` and `Tools()`
- Sort `tool.Args` keys before iterating inside `Instructions()` (fixes multi-arg tools)
- Remove redundant `toolName := name` variable in `Tools()` (Go 1.22+ per-iteration range)
- Add `TestScriptToolSet_DeterministicOrdering` covering both tool-level and arg-level ordering

Fixes #3233