### PR TITLE
fix(provider): WithNoThinking clone no longer leaks provider-level thinking_budget

### DIFF
--- a/pkg/model/provider/clone.go
+++ b/pkg/model/provider/clone.go
@@ -58,18 +58,9 @@ func mergeCloneOptions(cfg base.Config, opts []options.Opt) (latest.ModelConfig,
 		modelConfig.MaxTokens = &mt
 	}
 	if merged.NoThinking() {
-		// Use the explicit "disabled" sentinel (`thinking_budget: none`) instead
-		// of nil so that the downstream applyProviderDefaults → mergeFromProviderConfig
-		// pass cannot revive a provider-level thinking_budget via its
-		// setIfNil(&dst.ThinkingBudget, src.ThinkingBudget) merge. applyModelDefaults
-		// normalises this sentinel back to nil before the provider client sees the
-		// config, so the on-the-wire behaviour matches "thinking is off".
-		//
-		// Without this, calling CloneWithOptions(..., WithNoThinking()) on a model
-		// served by a custom provider that sets thinking_budget at the provider
-		// level (e.g. Gordon's anthropic provider) silently inherits that budget
-		// — turning short-budget callers like session-title generation into hard
-		// failures (max_tokens vs thinking_budget validation).
+		// Write the disabled sentinel instead of nil so the downstream
+		// applyProviderDefaults pass cannot revive a provider-level
+		// thinking_budget via its setIfNil merge.
 		modelConfig.ThinkingBudget = &latest.ThinkingBudget{Effort: "none"}
 	}
 	return modelConfig, mergedOpts

--- a/pkg/model/provider/clone.go
+++ b/pkg/model/provider/clone.go
@@ -58,7 +58,19 @@ func mergeCloneOptions(cfg base.Config, opts []options.Opt) (latest.ModelConfig,
 		modelConfig.MaxTokens = &mt
 	}
 	if merged.NoThinking() {
-		modelConfig.ThinkingBudget = nil
+		// Use the explicit "disabled" sentinel (`thinking_budget: none`) instead
+		// of nil so that the downstream applyProviderDefaults → mergeFromProviderConfig
+		// pass cannot revive a provider-level thinking_budget via its
+		// setIfNil(&dst.ThinkingBudget, src.ThinkingBudget) merge. applyModelDefaults
+		// normalises this sentinel back to nil before the provider client sees the
+		// config, so the on-the-wire behaviour matches "thinking is off".
+		//
+		// Without this, calling CloneWithOptions(..., WithNoThinking()) on a model
+		// served by a custom provider that sets thinking_budget at the provider
+		// level (e.g. Gordon's anthropic provider) silently inherits that budget
+		// — turning short-budget callers like session-title generation into hard
+		// failures (max_tokens vs thinking_budget validation).
+		modelConfig.ThinkingBudget = &latest.ThinkingBudget{Effort: "none"}
 	}
 	return modelConfig, mergedOpts
 }

--- a/pkg/model/provider/clone_merge_test.go
+++ b/pkg/model/provider/clone_merge_test.go
@@ -53,13 +53,9 @@ func TestMergeCloneOptions_MaxTokensOverride(t *testing.T) {
 }
 
 // TestMergeCloneOptions_NoThinking covers the option-merge branch that
-// disables thinking when WithNoThinking is set.
-//
-// The clone records "disabled" as an explicit sentinel (Effort: "none") rather
-// than nil so the subsequent applyProviderDefaults pass cannot revive a
-// provider-level thinking_budget via its setIfNil merge. applyModelDefaults
-// normalises this sentinel back to nil before the provider client sees the
-// config, so the wire-level behaviour is identical to a real nil.
+// disables thinking when WithNoThinking is set. The clone writes the
+// disabled sentinel rather than nil so the subsequent applyProviderDefaults
+// pass cannot revive a provider-level thinking_budget.
 func TestMergeCloneOptions_NoThinking(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/model/provider/clone_merge_test.go
+++ b/pkg/model/provider/clone_merge_test.go
@@ -52,8 +52,14 @@ func TestMergeCloneOptions_MaxTokensOverride(t *testing.T) {
 	assert.Len(t, mergedOpts, 1, "user-supplied option should appear in mergedOpts")
 }
 
-// TestMergeCloneOptions_NoThinking covers the previously-uncovered branch in
-// the option-merge loop that nils out ThinkingBudget when WithNoThinking is set.
+// TestMergeCloneOptions_NoThinking covers the option-merge branch that
+// disables thinking when WithNoThinking is set.
+//
+// The clone records "disabled" as an explicit sentinel (Effort: "none") rather
+// than nil so the subsequent applyProviderDefaults pass cannot revive a
+// provider-level thinking_budget via its setIfNil merge. applyModelDefaults
+// normalises this sentinel back to nil before the provider client sees the
+// config, so the wire-level behaviour is identical to a real nil.
 func TestMergeCloneOptions_NoThinking(t *testing.T) {
 	t.Parallel()
 
@@ -67,7 +73,9 @@ func TestMergeCloneOptions_NoThinking(t *testing.T) {
 
 	got, _ := mergeCloneOptions(cfg, []options.Opt{options.WithNoThinking()})
 
-	assert.Nil(t, got.ThinkingBudget, "WithNoThinking must clear ThinkingBudget")
+	require.NotNil(t, got.ThinkingBudget, "WithNoThinking must write the disabled sentinel, not nil")
+	assert.True(t, got.ThinkingBudget.IsDisabled(),
+		"WithNoThinking must write a sentinel that IsDisabled() recognises so applyModelDefaults normalises it back to nil")
 }
 
 func TestMergeCloneOptions_PreservesBaseOptions(t *testing.T) {

--- a/pkg/model/provider/provider_defaults_test.go
+++ b/pkg/model/provider/provider_defaults_test.go
@@ -415,18 +415,10 @@ func TestApplyProviderDefaults_AliasFallback(t *testing.T) {
 	assert.Empty(t, cfg.TokenKey)
 }
 
-// TestApplyProviderDefaults_NoThinkingSentinelBlocksProviderBudget is the
-// regression test for the title-generation failure caused by a clone calling
-// WithNoThinking on a model whose custom provider sets thinking_budget at the
-// provider level (e.g. Gordon's anthropic provider).
-//
-// CloneWithOptions writes the disabled sentinel (Effort: "none") on the
-// cloned ModelConfig so the subsequent applyProviderDefaults pass cannot
-// revive the provider-level budget via mergeFromProviderConfig's
-// setIfNil(&dst.ThinkingBudget, src.ThinkingBudget) merge. applyModelDefaults
-// then normalises the sentinel back to nil. End result: thinking really is
-// off when WithNoThinking is set, no matter where thinking_budget was
-// declared in the user's config.
+// TestApplyProviderDefaults_NoThinkingSentinelBlocksProviderBudget verifies
+// that the disabled sentinel written by CloneWithOptions(WithNoThinking())
+// survives mergeFromProviderConfig and is normalised back to nil by
+// applyModelDefaults, even when the custom provider sets thinking_budget.
 func TestApplyProviderDefaults_NoThinkingSentinelBlocksProviderBudget(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/model/provider/provider_defaults_test.go
+++ b/pkg/model/provider/provider_defaults_test.go
@@ -414,3 +414,36 @@ func TestApplyProviderDefaults_AliasFallback(t *testing.T) {
 	assert.Empty(t, cfg.BaseURL)
 	assert.Empty(t, cfg.TokenKey)
 }
+
+// TestApplyProviderDefaults_NoThinkingSentinelBlocksProviderBudget is the
+// regression test for the title-generation failure caused by a clone calling
+// WithNoThinking on a model whose custom provider sets thinking_budget at the
+// provider level (e.g. Gordon's anthropic provider).
+//
+// CloneWithOptions writes the disabled sentinel (Effort: "none") on the
+// cloned ModelConfig so the subsequent applyProviderDefaults pass cannot
+// revive the provider-level budget via mergeFromProviderConfig's
+// setIfNil(&dst.ThinkingBudget, src.ThinkingBudget) merge. applyModelDefaults
+// then normalises the sentinel back to nil. End result: thinking really is
+// off when WithNoThinking is set, no matter where thinking_budget was
+// declared in the user's config.
+func TestApplyProviderDefaults_NoThinkingSentinelBlocksProviderBudget(t *testing.T) {
+	t.Parallel()
+
+	cfg := &latest.ModelConfig{
+		Provider:       "anthropic",
+		Model:          "claude-haiku-4-5-20251001",
+		ThinkingBudget: &latest.ThinkingBudget{Effort: "none"}, // sentinel written by CloneWithOptions(WithNoThinking)
+	}
+	customProviders := map[string]latest.ProviderConfig{
+		"anthropic": {
+			Provider:       "anthropic",
+			ThinkingBudget: &latest.ThinkingBudget{Tokens: 5000},
+		},
+	}
+
+	got := applyProviderDefaults(cfg, customProviders)
+
+	assert.Nil(t, got.ThinkingBudget,
+		"WithNoThinking sentinel must survive mergeFromProviderConfig and be normalised to nil by applyModelDefaults")
+}


### PR DESCRIPTION
## What

`CloneWithOptions(..., WithNoThinking())` does not actually disable thinking when the model's provider sets `thinking_budget` at the provider level. Short-budget callers (session-title generation, summaries) then fail hard for every request.

## Why this happens

`mergeCloneOptions` cleared the cloned `ModelConfig.ThinkingBudget` to `nil`, but the cloned config then ran through `applyProviderDefaults` again, and `mergeFromProviderConfig` calls

```go
setIfNil(&dst.ThinkingBudget, src.ThinkingBudget)
```

A `nil` `dst.ThinkingBudget` looks like "unset", so the provider-level budget is happily merged back in. The override is silently undone before the provider client sees the config.

For Anthropic specifically, this means a title-generation clone with `max_tokens=20` is now paired with a revived `thinking_budget=5000`, which fails the `max_tokens > thinking_budget` validation in `adjustMaxTokensForThinking` (`pkg/model/provider/anthropic/thinking.go`). The whole title gen fails and the user never sees a generated title.

This is reachable any time `thinking_budget` is declared on a custom provider rather than on a model. It is not specific to Anthropic — the merge happens for every provider — but the Anthropic validation is what surfaces it loudly.

## Fix

Distinguish "explicitly turned off" from "unset" in the cloned config: write the existing `thinking_budget: none` sentinel instead of `nil` when `WithNoThinking()` is set. `setIfNil` then leaves it alone (it is not nil), and `applyModelDefaults` normalises the sentinel back to `nil` before the provider client sees the config, so the wire-level behaviour for the non-custom-provider case is unchanged.

```
mergeCloneOptions     →  ThinkingBudget = {Effort: "none"}    ← explicit sentinel
mergeFromProviderConfig  ↓ setIfNil: not nil, leave alone
                      →  ThinkingBudget = {Effort: "none"}
applyModelDefaults    ↓ IsDisabled() → true
                      →  ThinkingBudget = nil                 ← what the client sees
```
