### PR TITLE
feat(plan): add pluggable Storage interface (parity with todo toolset)

### DIFF
--- a/pkg/tools/builtin/plan/plan.go
+++ b/pkg/tools/builtin/plan/plan.go
@@ -1,16 +1,20 @@
 // Package plan provides a toolset that lets two or more agents collaborate on
-// plans stored in a global shared folder under the docker-agent data
-// directory. Plans are addressed by name, so any agent that loads this toolset
-// can write, read, list, and delete the same shared plans, and they persist
-// across sessions.
+// plans addressed by name. Plans persist through a pluggable Storage backend;
+// the default FilesystemStorage keeps them as JSON files in a global shared
+// folder under the docker-agent data directory, so any agent that loads this
+// toolset can write, read, list, and delete the same shared plans, and they
+// persist across sessions. Embedders can inject an alternative backend (e.g. a
+// database or remote store) with WithStorage.
 //
-// Concurrency: all agents in a single process share one ToolSet instance (see
-// CreateToolSet), so their reads and writes are serialized by a single mutex.
-// On-disk writes are atomic (write-to-temp + rename), so a reader — including
-// a separate docker-agent process — never observes a partially written plan.
-// Two distinct processes writing the *same* plan at the very same instant can
-// still race on the read-modify-write revision bump (last writer wins); this
-// is acceptable for the intended in-process multi-agent collaboration.
+// Concurrency: agents that share one ToolSet instance also share its Storage,
+// which serializes their operations. The default FilesystemStorage guards its
+// read-modify-write revision bump with a mutex and writes atomically
+// (write-to-temp + rename), so a reader — including a separate docker-agent
+// process — never observes a partially written plan. Two distinct processes
+// writing the *same* plan at the very same instant can still race on the
+// revision bump (last writer wins); this is acceptable for the intended
+// in-process multi-agent collaboration. Other backends can make the bump
+// atomic.
 package plan
 
 import (
@@ -77,9 +81,31 @@ type ListResult struct {
 	Warnings []string  `json:"warnings,omitempty"`
 }
 
+// Storage persists the plans a ToolSet operates on. Implementations decide how
+// a plan is stored (files, memory, a database, a remote service) and own the
+// revision bump in Upsert, so a backend can make it atomic. The default
+// FilesystemStorage is used when WithStorage injects nothing else.
+type Storage interface {
+	// Get returns the named plan. The bool is false with a nil error when no
+	// such plan exists, so callers can tell a missing plan apart from a real
+	// read failure (returned as a non-nil error).
+	Get(ctx context.Context, name string) (Plan, bool, error)
+	// Upsert creates or replaces the named plan's content and, when non-empty,
+	// its title and author; omitted title/author are preserved from the
+	// previous revision. It bumps the revision and stamps UpdatedAt, returning
+	// the stored plan.
+	Upsert(ctx context.Context, name, content, title, author string) (Plan, error)
+	// List returns a summary of every stored plan. Warnings carries entries
+	// that could not be read, so a caller can tell "no plans" apart from "some
+	// plans failed to load".
+	List(ctx context.Context) (plans []Summary, warnings []string, err error)
+	// Delete removes the named plan. The bool is false with a nil error when
+	// there was no such plan to delete.
+	Delete(ctx context.Context, name string) (deleted bool, err error)
+}
+
 type ToolSet struct {
-	mu  sync.Mutex
-	dir string
+	storage Storage
 }
 
 var (
@@ -88,22 +114,37 @@ var (
 	_ tools.Describer    = (*ToolSet)(nil)
 )
 
+// Option configures a ToolSet.
+type Option func(*ToolSet)
+
+// WithStorage injects a custom Storage backend in place of the default
+// FilesystemStorage, letting embedders supply their own store and get
+// per-instance isolation. The provided storage must not be nil.
+func WithStorage(storage Storage) Option {
+	if storage == nil {
+		panic("plan: storage must not be nil")
+	}
+	return func(t *ToolSet) {
+		t.storage = storage
+	}
+}
+
 // sharedToolSet returns the one ToolSet shared by every agent in this process,
 // built once on first use. Sharing a single instance means all collaborating
-// agents serialize their plan operations on the same mutex.
+// agents serialize their plan operations on the same storage.
 //
 // Building the struct cannot fail, so the directory is *not* created here:
-// save() runs os.MkdirAll on every write, which means a directory that is
-// momentarily unavailable at startup (e.g. a not-yet-mounted parent) is
+// FilesystemStorage runs os.MkdirAll on every write, which means a directory
+// that is momentarily unavailable at startup (e.g. a not-yet-mounted parent) is
 // recovered from automatically instead of being permanently memoized as an
 // error.
 var sharedToolSet = sync.OnceValue(func() *ToolSet {
-	return New(DefaultDir())
+	return New()
 })
 
 // CreateToolSet is used by the tools registry. It returns a process-wide
 // singleton so that all agents collaborating in the same process share one
-// lock over the global plans folder.
+// storage over the global plans folder.
 func CreateToolSet() (tools.ToolSet, error) {
 	return sharedToolSet(), nil
 }
@@ -114,12 +155,25 @@ func DefaultDir() string {
 	return filepath.Join(paths.GetDataDir(), "plans")
 }
 
-func New(dir string) *ToolSet {
-	return &ToolSet{dir: dir}
+// New builds a per-instance plan toolset. With no options it uses the default
+// FilesystemStorage rooted at DefaultDir(); pass WithStorage to inject another
+// backend. Each call returns an independent instance — use CreateToolSet for
+// the process-wide singleton shared by collaborating agents.
+func New(opts ...Option) *ToolSet {
+	t := &ToolSet{
+		storage: NewFilesystemStorage(DefaultDir()),
+	}
+	for _, opt := range opts {
+		opt(t)
+	}
+	return t
 }
 
 func (t *ToolSet) Describe() string {
-	return "plan(dir=" + t.dir + ")"
+	if s, ok := t.storage.(fmt.Stringer); ok {
+		return "plan(" + s.String() + ")"
+	}
+	return "plan"
 }
 
 func (t *ToolSet) Instructions() string {
@@ -140,53 +194,6 @@ Plan names must be lowercase and may contain only letters, digits, '-' and '_'
 (for example "release-2025" or "db_migration").`
 }
 
-// planPath validates name and returns the absolute path of its plan file. The
-// name is rejected (rather than rewritten) when it does not match namePattern,
-// which guarantees a one-to-one mapping between names and files and prevents
-// path traversal.
-func (t *ToolSet) planPath(name string) (string, error) {
-	if !namePattern.MatchString(name) {
-		return "", fmt.Errorf("invalid plan name %q: use only lowercase letters, digits, '-' and '_', starting with a letter or digit", name)
-	}
-	return filepath.Join(t.dir, name+".json"), nil
-}
-
-// load reads and decodes the plan at path. It distinguishes a missing plan
-// (false, nil) from a real failure such as a permission error or corrupt JSON
-// (false, err), so callers can report the latter instead of masking it as
-// "not found".
-func (t *ToolSet) load(path string) (Plan, bool, error) {
-	data, err := os.ReadFile(path)
-	if errors.Is(err, os.ErrNotExist) {
-		return Plan{}, false, nil
-	}
-	if err != nil {
-		return Plan{}, false, fmt.Errorf("reading plan: %w", err)
-	}
-	var p Plan
-	if err := json.Unmarshal(data, &p); err != nil {
-		return Plan{}, false, fmt.Errorf("plan file %s is corrupt: %w", filepath.Base(path), err)
-	}
-	return p, true, nil
-}
-
-func (t *ToolSet) save(path string, p Plan) error {
-	if err := os.MkdirAll(t.dir, 0o700); err != nil {
-		return fmt.Errorf("creating plans directory: %w", err)
-	}
-	data, err := json.MarshalIndent(p, "", "  ")
-	if err != nil {
-		return fmt.Errorf("marshaling plan: %w", err)
-	}
-	// Atomic write (temp file + rename): readers in other agents or processes
-	// see either the old or the new content, never a partial file, and an
-	// existing symlink at path is replaced rather than followed.
-	if err := atomicfile.Write(path, bytes.NewReader(data), 0o600); err != nil {
-		return fmt.Errorf("writing plan: %w", err)
-	}
-	return nil
-}
-
 type WritePlanArgs struct {
 	Name    string `json:"name" jsonschema:"The plan name. Lowercase letters, digits, '-' and '_' only (e.g. 'release', 'db-migration')."`
 	Content string `json:"content" jsonschema:"The full plan content (markdown). Replaces the existing plan."`
@@ -194,37 +201,13 @@ type WritePlanArgs struct {
 	Author  string `json:"author,omitempty" jsonschema:"Optional label identifying who is writing the plan (typically the agent name). Preserved from the previous revision when omitted."`
 }
 
-func (t *ToolSet) writePlan(_ context.Context, params WritePlanArgs) (*tools.ToolCallResult, error) {
+func (t *ToolSet) writePlan(ctx context.Context, params WritePlanArgs) (*tools.ToolCallResult, error) {
 	if params.Content == "" {
 		return tools.ResultError("content must not be empty"), nil
 	}
-	path, err := t.planPath(params.Name)
+
+	plan, err := t.storage.Upsert(ctx, params.Name, params.Content, params.Title, params.Author)
 	if err != nil {
-		return tools.ResultError(err.Error()), nil
-	}
-
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	plan, _, err := t.load(path)
-	if err != nil {
-		return tools.ResultError(err.Error()), nil
-	}
-	plan.Name = params.Name
-	plan.Content = params.Content
-	// Title and author are preserved across revisions when omitted, so an
-	// agent updating only the content does not wipe the collaboration metadata
-	// set by a previous writer.
-	if params.Title != "" {
-		plan.Title = params.Title
-	}
-	if params.Author != "" {
-		plan.Author = params.Author
-	}
-	plan.Revision++
-	plan.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
-
-	if err := t.save(path, plan); err != nil {
 		return tools.ResultError(err.Error()), nil
 	}
 
@@ -235,16 +218,8 @@ type ReadPlanArgs struct {
 	Name string `json:"name" jsonschema:"The name of the plan to read."`
 }
 
-func (t *ToolSet) readPlan(_ context.Context, params ReadPlanArgs) (*tools.ToolCallResult, error) {
-	path, err := t.planPath(params.Name)
-	if err != nil {
-		return tools.ResultError(err.Error()), nil
-	}
-
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	plan, ok, err := t.load(path)
+func (t *ToolSet) readPlan(ctx context.Context, params ReadPlanArgs) (*tools.ToolCallResult, error) {
+	plan, ok, err := t.storage.Get(ctx, params.Name)
 	if err != nil {
 		return tools.ResultError(err.Error()), nil
 	}
@@ -255,75 +230,31 @@ func (t *ToolSet) readPlan(_ context.Context, params ReadPlanArgs) (*tools.ToolC
 	return tools.ResultJSON(plan), nil
 }
 
-func (t *ToolSet) listPlans(_ context.Context, _ tools.ToolCall) (*tools.ToolCallResult, error) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	entries, err := os.ReadDir(t.dir)
+func (t *ToolSet) listPlans(ctx context.Context, _ tools.ToolCall) (*tools.ToolCallResult, error) {
+	plans, warnings, err := t.storage.List(ctx)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return tools.ResultJSON(ListResult{Plans: []Summary{}}), nil
-		}
 		return tools.ResultError(err.Error()), nil
 	}
-
-	result := ListResult{Plans: []Summary{}}
-	for _, entry := range entries {
-		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
-			continue
-		}
-		// The filename is the authoritative key: read_plan and delete_plan
-		// resolve a name to <name>.json, so the listed name must match the
-		// filename, not the (possibly drifted) name field inside the JSON.
-		name := strings.TrimSuffix(entry.Name(), ".json")
-		plan, ok, err := t.load(filepath.Join(t.dir, entry.Name()))
-		if err != nil || !ok {
-			// Don't abort the whole listing on one bad file, but surface it as
-			// a warning so the caller doesn't mistake an unreadable plan for a
-			// missing one.
-			msg := "unreadable"
-			if err != nil {
-				msg = err.Error()
-			}
-			result.Warnings = append(result.Warnings, fmt.Sprintf("skipped %q: %s", name, msg))
-			continue
-		}
-		result.Plans = append(result.Plans, Summary{
-			Name:      name,
-			Title:     plan.Title,
-			Author:    plan.Author,
-			Revision:  plan.Revision,
-			UpdatedAt: plan.UpdatedAt,
-		})
+	// Always emit a non-nil slice so the output is "plans":[] rather than
+	// "plans":null, regardless of what a backend returns when empty.
+	if plans == nil {
+		plans = []Summary{}
 	}
 
-	sort.Slice(result.Plans, func(i, j int) bool {
-		return result.Plans[i].Name < result.Plans[j].Name
-	})
-
-	return tools.ResultJSON(result), nil
+	return tools.ResultJSON(ListResult{Plans: plans, Warnings: warnings}), nil
 }
 
 type DeletePlanArgs struct {
 	Name string `json:"name" jsonschema:"The name of the plan to delete."`
 }
 
-func (t *ToolSet) deletePlan(_ context.Context, params DeletePlanArgs) (*tools.ToolCallResult, error) {
-	path, err := t.planPath(params.Name)
+func (t *ToolSet) deletePlan(ctx context.Context, params DeletePlanArgs) (*tools.ToolCallResult, error) {
+	deleted, err := t.storage.Delete(ctx, params.Name)
 	if err != nil {
 		return tools.ResultError(err.Error()), nil
 	}
-
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	// Remove the file directly and treat a missing file as "not found". We
-	// don't pre-load the plan: a corrupt plan should still be deletable.
-	if err := os.Remove(path); err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return tools.ResultError(fmt.Sprintf("plan %q not found", params.Name)), nil
-		}
-		return tools.ResultError(err.Error()), nil
+	if !deleted {
+		return tools.ResultError(fmt.Sprintf("plan %q not found", params.Name)), nil
 	}
 
 	return tools.ResultJSON(map[string]string{"deleted": params.Name}), nil
@@ -377,4 +308,192 @@ func (t *ToolSet) Tools(context.Context) ([]tools.Tool, error) {
 			},
 		},
 	}, nil
+}
+
+// FilesystemStorage is the default Storage. It persists each plan as a JSON
+// file named <name>.json in a directory, with atomic temp+rename writes, plan
+// name validation, and unreadable-file warnings on List. A mutex serializes its
+// operations so the read-modify-write revision bump in Upsert is consistent
+// within a process.
+type FilesystemStorage struct {
+	mu  sync.Mutex
+	dir string
+}
+
+var _ Storage = (*FilesystemStorage)(nil)
+
+// NewFilesystemStorage returns a filesystem-backed Storage rooted at dir. The
+// directory is created lazily on the first write, not here, so a parent that is
+// momentarily unavailable at startup is recovered from automatically.
+func NewFilesystemStorage(dir string) *FilesystemStorage {
+	return &FilesystemStorage{dir: dir}
+}
+
+// String renders the backend for ToolSet.Describe, e.g. "dir=/path/to/plans".
+func (s *FilesystemStorage) String() string {
+	return "dir=" + s.dir
+}
+
+// planPath validates name and returns the absolute path of its plan file. The
+// name is rejected (rather than rewritten) when it does not match namePattern,
+// which guarantees a one-to-one mapping between names and files and prevents
+// path traversal.
+func (s *FilesystemStorage) planPath(name string) (string, error) {
+	if !namePattern.MatchString(name) {
+		return "", fmt.Errorf("invalid plan name %q: use only lowercase letters, digits, '-' and '_', starting with a letter or digit", name)
+	}
+	return filepath.Join(s.dir, name+".json"), nil
+}
+
+// load reads and decodes the plan at path. It distinguishes a missing plan
+// (false, nil) from a real failure such as a permission error or corrupt JSON
+// (false, err), so callers can report the latter instead of masking it as
+// "not found".
+func (s *FilesystemStorage) load(path string) (Plan, bool, error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return Plan{}, false, nil
+	}
+	if err != nil {
+		return Plan{}, false, fmt.Errorf("reading plan: %w", err)
+	}
+	var p Plan
+	if err := json.Unmarshal(data, &p); err != nil {
+		return Plan{}, false, fmt.Errorf("plan file %s is corrupt: %w", filepath.Base(path), err)
+	}
+	return p, true, nil
+}
+
+func (s *FilesystemStorage) save(path string, p Plan) error {
+	if err := os.MkdirAll(s.dir, 0o700); err != nil {
+		return fmt.Errorf("creating plans directory: %w", err)
+	}
+	data, err := json.MarshalIndent(p, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling plan: %w", err)
+	}
+	// Atomic write (temp file + rename): readers in other agents or processes
+	// see either the old or the new content, never a partial file, and an
+	// existing symlink at path is replaced rather than followed.
+	if err := atomicfile.Write(path, bytes.NewReader(data), 0o600); err != nil {
+		return fmt.Errorf("writing plan: %w", err)
+	}
+	return nil
+}
+
+func (s *FilesystemStorage) Get(_ context.Context, name string) (Plan, bool, error) {
+	path, err := s.planPath(name)
+	if err != nil {
+		return Plan{}, false, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.load(path)
+}
+
+func (s *FilesystemStorage) Upsert(_ context.Context, name, content, title, author string) (Plan, error) {
+	path, err := s.planPath(name)
+	if err != nil {
+		return Plan{}, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	plan, _, err := s.load(path)
+	if err != nil {
+		return Plan{}, err
+	}
+	plan.Name = name
+	plan.Content = content
+	// Title and author are preserved across revisions when omitted, so an
+	// agent updating only the content does not wipe the collaboration metadata
+	// set by a previous writer.
+	if title != "" {
+		plan.Title = title
+	}
+	if author != "" {
+		plan.Author = author
+	}
+	plan.Revision++
+	plan.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+
+	if err := s.save(path, plan); err != nil {
+		return Plan{}, err
+	}
+
+	return plan, nil
+}
+
+func (s *FilesystemStorage) List(_ context.Context) ([]Summary, []string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return []Summary{}, nil, nil
+		}
+		return nil, nil, err
+	}
+
+	plans := []Summary{}
+	var warnings []string
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		// The filename is the authoritative key: read_plan and delete_plan
+		// resolve a name to <name>.json, so the listed name must match the
+		// filename, not the (possibly drifted) name field inside the JSON.
+		name := strings.TrimSuffix(entry.Name(), ".json")
+		plan, ok, err := s.load(filepath.Join(s.dir, entry.Name()))
+		if err != nil || !ok {
+			// Don't abort the whole listing on one bad file, but surface it as
+			// a warning so the caller doesn't mistake an unreadable plan for a
+			// missing one.
+			msg := "unreadable"
+			if err != nil {
+				msg = err.Error()
+			}
+			warnings = append(warnings, fmt.Sprintf("skipped %q: %s", name, msg))
+			continue
+		}
+		plans = append(plans, Summary{
+			Name:      name,
+			Title:     plan.Title,
+			Author:    plan.Author,
+			Revision:  plan.Revision,
+			UpdatedAt: plan.UpdatedAt,
+		})
+	}
+
+	sort.Slice(plans, func(i, j int) bool {
+		return plans[i].Name < plans[j].Name
+	})
+
+	return plans, warnings, nil
+}
+
+func (s *FilesystemStorage) Delete(_ context.Context, name string) (bool, error) {
+	path, err := s.planPath(name)
+	if err != nil {
+		return false, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Remove the file directly and treat a missing file as "not deleted". We
+	// don't pre-load the plan: a corrupt plan should still be deletable.
+	if err := os.Remove(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
 }

--- a/pkg/tools/builtin/plan/plan_test.go
+++ b/pkg/tools/builtin/plan/plan_test.go
@@ -1,9 +1,13 @@
 package plan
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
+	"sort"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,7 +18,15 @@ import (
 
 func newTestPlanTool(t *testing.T) *ToolSet {
 	t.Helper()
-	return New(t.TempDir())
+	return New(WithStorage(NewFilesystemStorage(t.TempDir())))
+}
+
+// newTestPlanToolWithDir builds a filesystem-backed toolset and returns the
+// directory it stores plans in, for tests that need to plant files directly.
+func newTestPlanToolWithDir(t *testing.T) (*ToolSet, string) {
+	t.Helper()
+	dir := t.TempDir()
+	return New(WithStorage(NewFilesystemStorage(dir))), dir
 }
 
 func TestPlanTool_DisplayNames(t *testing.T) {
@@ -37,6 +49,12 @@ func TestPlanTool_Instructions(t *testing.T) {
 func TestPlanTool_Describe(t *testing.T) {
 	tool := newTestPlanTool(t)
 	assert.Contains(t, tool.Describe(), "plan(dir=")
+}
+
+func TestPlanTool_DescribeCustomBackend(t *testing.T) {
+	// A custom backend that is not a fmt.Stringer falls back to a bare label.
+	tool := New(WithStorage(newMemoryStorage()))
+	assert.Equal(t, "plan", tool.Describe())
 }
 
 func TestPlanTool_Write(t *testing.T) {
@@ -123,10 +141,10 @@ func TestPlanTool_ReadNotFound(t *testing.T) {
 }
 
 func TestPlanTool_ReadCorruptReportsError(t *testing.T) {
-	tool := newTestPlanTool(t)
+	tool, dir := newTestPlanToolWithDir(t)
 
 	// Write a corrupt plan file directly.
-	require.NoError(t, os.WriteFile(filepath.Join(tool.dir, "broken.json"), []byte("{not json"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "broken.json"), []byte("{not json"), 0o600))
 
 	result, err := tool.readPlan(t.Context(), ReadPlanArgs{Name: "broken"})
 	require.NoError(t, err)
@@ -215,14 +233,16 @@ func TestPlanTool_ListEmpty(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(result.Output), &list))
 	assert.Empty(t, list.Plans)
 	assert.Empty(t, list.Warnings)
+	// An empty listing serializes as "plans":[] rather than "plans":null.
+	assert.Contains(t, result.Output, `"plans":[]`)
 }
 
 func TestPlanTool_ListSkipsCorrupt(t *testing.T) {
-	tool := newTestPlanTool(t)
+	tool, dir := newTestPlanToolWithDir(t)
 
 	_, err := tool.writePlan(t.Context(), WritePlanArgs{Name: "good", Content: "ok"})
 	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(filepath.Join(tool.dir, "bad.json"), []byte("{nope"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "bad.json"), []byte("{nope"), 0o600))
 
 	result, err := tool.listPlans(t.Context(), tools.ToolCall{})
 	require.NoError(t, err)
@@ -238,14 +258,14 @@ func TestPlanTool_ListSkipsCorrupt(t *testing.T) {
 }
 
 func TestPlanTool_ListNameFromFilename(t *testing.T) {
-	tool := newTestPlanTool(t)
+	tool, dir := newTestPlanToolWithDir(t)
 
 	// A plan file whose stored name field disagrees with its filename. The
 	// filename is authoritative because read_plan/delete_plan key off it.
 	drifted := Plan{Name: "wrong-name", Content: "x", Revision: 1}
 	data, err := json.Marshal(drifted)
 	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(filepath.Join(tool.dir, "real-name.json"), data, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "real-name.json"), data, 0o600))
 
 	result, err := tool.listPlans(t.Context(), tools.ToolCall{})
 	require.NoError(t, err)
@@ -280,9 +300,9 @@ func TestPlanTool_DeletePlan(t *testing.T) {
 }
 
 func TestPlanTool_DeleteCorruptSucceeds(t *testing.T) {
-	tool := newTestPlanTool(t)
+	tool, dir := newTestPlanToolWithDir(t)
 
-	require.NoError(t, os.WriteFile(filepath.Join(tool.dir, "broken.json"), []byte("{nope"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "broken.json"), []byte("{nope"), 0o600))
 
 	result, err := tool.deletePlan(t.Context(), DeletePlanArgs{Name: "broken"})
 	require.NoError(t, err)
@@ -302,7 +322,7 @@ func TestPlanTool_SharedAcrossInstances(t *testing.T) {
 	dir := t.TempDir()
 
 	// One agent writes the plan.
-	writer := New(dir)
+	writer := New(WithStorage(NewFilesystemStorage(dir)))
 	_, err := writer.writePlan(t.Context(), WritePlanArgs{
 		Name:    "collab",
 		Content: "collaborative plan",
@@ -311,7 +331,7 @@ func TestPlanTool_SharedAcrossInstances(t *testing.T) {
 	require.NoError(t, err)
 
 	// Another agent, sharing the same folder, reads it.
-	reader := New(dir)
+	reader := New(WithStorage(NewFilesystemStorage(dir)))
 	result, err := reader.readPlan(t.Context(), ReadPlanArgs{Name: "collab"})
 	require.NoError(t, err)
 	assert.False(t, result.IsError)
@@ -337,4 +357,282 @@ func TestPlanTool_ParametersAreObjects(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "object", m["type"])
 	}
+}
+
+// TestPlanTool_WithCustomStorage verifies WithStorage injects a backend that
+// the handlers actually write to and read from.
+func TestPlanTool_WithCustomStorage(t *testing.T) {
+	storage := newMemoryStorage()
+	tool := New(WithStorage(storage))
+
+	result, err := tool.writePlan(t.Context(), WritePlanArgs{Name: "p", Content: "v1", Title: "T", Author: "alice"})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	// The write landed in the injected backend, not on disk.
+	stored, ok, err := storage.Get(t.Context(), "p")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "v1", stored.Content)
+	assert.Equal(t, 1, stored.Revision)
+
+	// read_plan reads it back through the toolset.
+	read, err := tool.readPlan(t.Context(), ReadPlanArgs{Name: "p"})
+	require.NoError(t, err)
+	assert.False(t, read.IsError)
+	var got Plan
+	require.NoError(t, json.Unmarshal([]byte(read.Output), &got))
+	assert.Equal(t, "v1", got.Content)
+
+	// delete_plan removes it from the injected backend.
+	del, err := tool.deletePlan(t.Context(), DeletePlanArgs{Name: "p"})
+	require.NoError(t, err)
+	assert.False(t, del.IsError)
+	_, ok, err = storage.Get(t.Context(), "p")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestPlanTool_WithStorage_NilPanics(t *testing.T) {
+	assert.Panics(t, func() {
+		WithStorage(nil)
+	})
+}
+
+// TestPlanTool_ListNilNormalizedToEmptyArray drives list_plans through a
+// backend whose List returns a nil slice, proving the handler emits
+// "plans":[] rather than "plans":null regardless of the backend.
+func TestPlanTool_ListNilNormalizedToEmptyArray(t *testing.T) {
+	tool := New(WithStorage(noBumpStorage{}))
+
+	result, err := tool.listPlans(t.Context(), tools.ToolCall{})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Output, `"plans":[]`)
+	assert.NotContains(t, result.Output, `"plans":null`)
+}
+
+// TestPlanTool_StorageErrorsSurfaceAsIsError verifies every handler maps a
+// backend error to an IsError result rather than masking it as not-found,
+// empty, or success.
+func TestPlanTool_StorageErrorsSurfaceAsIsError(t *testing.T) {
+	tool := New(WithStorage(errStorage{}))
+	ctx := t.Context()
+
+	write, err := tool.writePlan(ctx, WritePlanArgs{Name: "p", Content: "x"})
+	require.NoError(t, err)
+	assert.True(t, write.IsError)
+	assert.Contains(t, write.Output, "backend boom")
+
+	read, err := tool.readPlan(ctx, ReadPlanArgs{Name: "p"})
+	require.NoError(t, err)
+	assert.True(t, read.IsError)
+	assert.Contains(t, read.Output, "backend boom")
+
+	list, err := tool.listPlans(ctx, tools.ToolCall{})
+	require.NoError(t, err)
+	assert.True(t, list.IsError)
+	assert.Contains(t, list.Output, "backend boom")
+
+	del, err := tool.deletePlan(ctx, DeletePlanArgs{Name: "p"})
+	require.NoError(t, err)
+	assert.True(t, del.IsError)
+	assert.Contains(t, del.Output, "backend boom")
+}
+
+// TestPlanTool_RevisionOwnedByStorage proves the revision bump lives in
+// Storage.Upsert, not the handler: a backend that never bumps leaves the
+// revision untouched across repeated writes.
+func TestPlanTool_RevisionOwnedByStorage(t *testing.T) {
+	tool := New(WithStorage(noBumpStorage{}))
+
+	for range 3 {
+		result, err := tool.writePlan(t.Context(), WritePlanArgs{Name: "p", Content: "x"})
+		require.NoError(t, err)
+		var plan Plan
+		require.NoError(t, json.Unmarshal([]byte(result.Output), &plan))
+		assert.Equal(t, 0, plan.Revision)
+	}
+}
+
+// TestStorage_Conformance exercises every Storage method through the interface
+// against both the default filesystem backend and a custom in-memory one, so
+// the two stay behaviorally equivalent.
+func TestStorage_Conformance(t *testing.T) {
+	t.Run("filesystem", func(t *testing.T) {
+		runStorageConformance(t, NewFilesystemStorage(t.TempDir()))
+	})
+	t.Run("memory", func(t *testing.T) {
+		runStorageConformance(t, newMemoryStorage())
+	})
+}
+
+func runStorageConformance(t *testing.T, s Storage) {
+	t.Helper()
+	ctx := t.Context()
+
+	// A missing plan is reported as not-found, not as an error.
+	_, ok, err := s.Get(ctx, "missing")
+	require.NoError(t, err)
+	assert.False(t, ok)
+
+	// An empty store lists nothing without warnings.
+	plans, warnings, err := s.List(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, plans)
+	assert.Empty(t, warnings)
+
+	// Upsert creates the plan at revision 1 and stamps a timestamp.
+	p, err := s.Upsert(ctx, "release", "v1", "Release", "alice")
+	require.NoError(t, err)
+	assert.Equal(t, "release", p.Name)
+	assert.Equal(t, "v1", p.Content)
+	assert.Equal(t, "Release", p.Title)
+	assert.Equal(t, "alice", p.Author)
+	assert.Equal(t, 1, p.Revision)
+	assert.NotEmpty(t, p.UpdatedAt)
+
+	// Get returns exactly what was stored.
+	got, ok, err := s.Get(ctx, "release")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, p, got)
+
+	// Upsert bumps the revision and preserves omitted title/author.
+	p2, err := s.Upsert(ctx, "release", "v2", "", "")
+	require.NoError(t, err)
+	assert.Equal(t, 2, p2.Revision)
+	assert.Equal(t, "v2", p2.Content)
+	assert.Equal(t, "Release", p2.Title)
+	assert.Equal(t, "alice", p2.Author)
+
+	// A non-empty author overwrites the previous one.
+	p3, err := s.Upsert(ctx, "release", "v3", "", "bob")
+	require.NoError(t, err)
+	assert.Equal(t, 3, p3.Revision)
+	assert.Equal(t, "bob", p3.Author)
+
+	// List reflects every plan, sorted by name.
+	_, err = s.Upsert(ctx, "alpha", "a", "", "")
+	require.NoError(t, err)
+	plans, warnings, err = s.List(ctx)
+	require.NoError(t, err)
+	require.Len(t, plans, 2)
+	assert.Equal(t, "alpha", plans[0].Name)
+	assert.Equal(t, "release", plans[1].Name)
+	assert.Empty(t, warnings)
+
+	// Delete removes the plan and reports it was deleted.
+	deleted, err := s.Delete(ctx, "release")
+	require.NoError(t, err)
+	assert.True(t, deleted)
+	_, ok, err = s.Get(ctx, "release")
+	require.NoError(t, err)
+	assert.False(t, ok)
+
+	// Deleting again reports not-deleted, without an error.
+	deleted, err = s.Delete(ctx, "release")
+	require.NoError(t, err)
+	assert.False(t, deleted)
+}
+
+// memoryStorage is an in-memory Storage used to exercise the toolset through a
+// custom backend. It mirrors the filesystem default's contract: Upsert owns the
+// revision bump and preserves title/author when omitted.
+type memoryStorage struct {
+	mu    sync.Mutex
+	plans map[string]Plan
+}
+
+var _ Storage = (*memoryStorage)(nil)
+
+func newMemoryStorage() *memoryStorage {
+	return &memoryStorage{plans: map[string]Plan{}}
+}
+
+func (s *memoryStorage) Get(_ context.Context, name string) (Plan, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p, ok := s.plans[name]
+	return p, ok, nil
+}
+
+func (s *memoryStorage) Upsert(_ context.Context, name, content, title, author string) (Plan, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p := s.plans[name]
+	p.Name = name
+	p.Content = content
+	if title != "" {
+		p.Title = title
+	}
+	if author != "" {
+		p.Author = author
+	}
+	p.Revision++
+	p.UpdatedAt = "2024-01-01T00:00:00Z"
+	s.plans[name] = p
+	return p, nil
+}
+
+func (s *memoryStorage) List(_ context.Context) ([]Summary, []string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]Summary, 0, len(s.plans))
+	for name, p := range s.plans {
+		out = append(out, Summary{Name: name, Title: p.Title, Author: p.Author, Revision: p.Revision, UpdatedAt: p.UpdatedAt})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil, nil
+}
+
+func (s *memoryStorage) Delete(_ context.Context, name string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.plans[name]; !ok {
+		return false, nil
+	}
+	delete(s.plans, name)
+	return true, nil
+}
+
+// noBumpStorage is a deliberately inert backend whose Upsert never bumps the
+// revision, used to prove the toolset handler does not add a bump of its own.
+type noBumpStorage struct{}
+
+var _ Storage = noBumpStorage{}
+
+func (noBumpStorage) Get(context.Context, string) (Plan, bool, error) { return Plan{}, false, nil }
+
+func (noBumpStorage) Upsert(_ context.Context, name, content, title, author string) (Plan, error) {
+	return Plan{Name: name, Content: content, Title: title, Author: author, Revision: 0}, nil
+}
+
+func (noBumpStorage) List(context.Context) ([]Summary, []string, error) { return nil, nil, nil }
+
+func (noBumpStorage) Delete(context.Context, string) (bool, error) { return false, nil }
+
+// errStorage is a backend whose every method fails, used to verify the
+// handlers surface a real backend error as an IsError result.
+type errStorage struct{}
+
+var (
+	_          Storage = errStorage{}
+	errBackend         = errors.New("backend boom")
+)
+
+func (errStorage) Get(context.Context, string) (Plan, bool, error) {
+	return Plan{}, false, errBackend
+}
+
+func (errStorage) Upsert(context.Context, string, string, string, string) (Plan, error) {
+	return Plan{}, errBackend
+}
+
+func (errStorage) List(context.Context) ([]Summary, []string, error) {
+	return nil, nil, errBackend
+}
+
+func (errStorage) Delete(context.Context, string) (bool, error) {
+	return false, errBackend
 }


### PR DESCRIPTION
## Summary

Brings the `plan` builtin toolset to parity with `todo`: storage is now a
pluggable `Storage` interface with a default filesystem backend, an injection
seam, and per-instance construction instead of a process-wide-only singleton.

## Acceptance criteria

| # | Criterion | Status | Where |
|---|---|---|---|
| 1 | `plan.Storage` interface + default filesystem impl | yes | `Storage` interface; `FilesystemStorage` |
| 2 | `plan.WithStorage(...)` injects a custom backend | yes | `WithStorage(Storage) Option`, panics on nil (matches `todo`) |
| 3 | Per-instance constructor; default `CreateToolSet()` preserved | yes | `New(opts ...Option)`; `CreateToolSet()` still returns the `sync.OnceValue` singleton |
| 4 | Revision bump owned by `Storage.Upsert` | yes | bump moved into `FilesystemStorage.Upsert` |
| 5 | Tests for filesystem and custom (in-memory) backend through the interface | yes | `TestStorage_Conformance` runs both backends over all four methods |
| 6 | No behavior change for standalone/CLI usage | yes | registry entry unchanged; filesystem default keeps atomic temp+rename, name validation, unreadable-file warnings, last-writer-wins bump |

## Interface

```go
type Storage interface {
    Get(ctx context.Context, name string) (Plan, bool, error)
    Upsert(ctx context.Context, name, content, title, author string) (Plan, error)
    List(ctx context.Context) (plans []Summary, warnings []string, err error)
    Delete(ctx context.Context, name string) (deleted bool, err error)
}
```

## Behavior preservation

- Handlers (`write_plan` / `read_plan` / `list_plans` / `delete_plan`) delegate to `Storage` rather than calling `load`/`save` directly.
- `FilesystemStorage` retains the original atomic write (temp file + rename), `namePattern` validation, missing-vs-corrupt distinction, corrupt-plan-still-deletable, filename-as-authoritative-key, and lazy directory creation on first write.
- The serialization mutex moves from `ToolSet` to `FilesystemStorage`; the shared singleton still routes every operation through one backend instance, so in-process collaboration is serialized exactly as before.
- `Describe()` reports the backend via `fmt.Stringer`, so the filesystem case still renders `plan(dir=...)`.

## Tests

| Area | Coverage |
|---|---|
| Storage interface | `TestStorage_Conformance` over `FilesystemStorage` and an in-memory backend |
| Injection | custom-backend write/read/delete through `WithStorage`; `WithStorage(nil)` panics |
| Revision ownership | a non-bumping backend proves the handler adds no bump of its own |
| Output contract | nil `List` normalizes to `"plans":[]`; backend errors surface as `IsError` on every handler |

All four handlers and `Describe` are at 100% statement coverage. Remaining uncovered lines in `FilesystemStorage` are OS-error paths (MkdirAll / ReadFile / Remove failures) that require fault injection and were uncovered before this change.

## Design choices open to revision

These follow the issue text and the `todo` pattern, but can be changed if a different shape is preferred:

- `New(dir string)` becomes `New(opts ...Option)`, a breaking signature change to an exported constructor (mirrors `todo.New`). If keeping `New(dir string)` is preferred, a separate constructor can be added instead.
- The in-memory backend lives in tests only; `todo` exports `MemoryTodoStorage` (its default). An exported `plan.MemoryStorage` can be added if embedders want an off-the-shelf ephemeral backend.
- Name validation lives in `FilesystemStorage` (the issue lists it under the filesystem implementation), so custom backends are free to define their own key rules. If validation should be guaranteed for all backends, it can move up into the handler.

## Validation

- `go build ./...`: clean
- `go test ./pkg/tools/builtin/plan/... ./pkg/teamloader/...`: pass
- `golangci-lint run ./pkg/tools/builtin/plan/...`: clean

Closes #3237
