### PR TITLE
feat(otel): append OTLP signal path so Langfuse and LangSmith work

### DIFF
--- a/cmd/root/otel.go
+++ b/cmd/root/otel.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/url"
 	"os"
+	"path"
 	"runtime"
 	"strings"
 	"time"
@@ -158,19 +160,12 @@ func newLoggerProvider(ctx context.Context, res *resource.Resource, endpoint str
 }
 
 // normalizeOTLPEndpoint turns a possibly-bare `host:port` into a fully
-// scheme-qualified URL so all three OTLP/HTTP exporters can be wired via
-// `WithEndpointURL` consistently. We can't rely on the SDKs' default
-// scheme inference: `otlptracehttp` (older API) treats a bare endpoint
-// as TLS-by-default while `otlploghttp` (newer API) treats the same
-// bare endpoint as insecure-by-default. With `OTEL_EXPORTER_OTLP_CERTIFICATE`
-// set in the env, the log exporter then errors out with
-// `insecure HTTP endpoint cannot use TLS client configuration`,
-// `initOTelSDK` propagates the failure, and the entire telemetry
-// pipeline (including traces) is torn down.
-//
-// Pinning the scheme up front removes that asymmetry: localhost gets
-// `http://`, every other host gets `https://`, and any explicit scheme
-// the caller already supplied is honoured verbatim.
+// scheme-qualified URL so it can be fed to `WithEndpointURL`. This is
+// required because `url.Parse("host:port")` parses `host` as the URL
+// scheme and leaves `Host` empty, which produces a broken exporter.
+// Pinning the scheme up front makes the value parse correctly: localhost
+// gets `http://`, every other host gets `https://`, and any explicit
+// scheme the caller already supplied is honoured verbatim.
 func normalizeOTLPEndpoint(endpoint string) string {
 	if strings.HasPrefix(endpoint, "http://") || strings.HasPrefix(endpoint, "https://") {
 		return endpoint
@@ -181,16 +176,46 @@ func normalizeOTLPEndpoint(endpoint string) string {
 	return "https://" + endpoint
 }
 
+// signalEndpointURL scheme-qualifies the configured base endpoint and
+// appends the OTLP signal subpath (`/v1/traces`, `/v1/metrics`,
+// `/v1/logs`), mirroring what the OTel SDK does when it reads
+// `OTEL_EXPORTER_OTLP_ENDPOINT` natively (`path.Join(u.Path, signalPath)`).
+//
+// We have to reproduce that append ourselves: docker-agent reads the
+// endpoint from the environment and re-injects it through
+// `WithEndpointURL`, which takes the URL path verbatim and only falls back
+// to the signal subpath when the path is empty. Without the append,
+// base-path backends silently break — Langfuse (`/api/public/otel`) and
+// LangSmith (`/otel`) expect traces at `<base>/v1/traces`, and a bare
+// collector endpoint would post logs to `/`.
+//
+// A base URL that already ends in the requested signal subpath is returned
+// unchanged so a caller that passes a full per-signal URL is not
+// double-suffixed.
+func signalEndpointURL(endpoint, signalPath string) string {
+	normalized := normalizeOTLPEndpoint(endpoint)
+	u, err := url.Parse(normalized)
+	if err != nil {
+		// Let the exporter surface the parse error against the raw value.
+		return normalized
+	}
+	if strings.HasSuffix(strings.TrimRight(u.Path, "/"), signalPath) {
+		return normalized
+	}
+	u.Path = path.Join(u.Path, signalPath)
+	return u.String()
+}
+
 func traceExporterOptions(endpoint string) []otlptracehttp.Option {
-	return []otlptracehttp.Option{otlptracehttp.WithEndpointURL(normalizeOTLPEndpoint(endpoint))}
+	return []otlptracehttp.Option{otlptracehttp.WithEndpointURL(signalEndpointURL(endpoint, "/v1/traces"))}
 }
 
 func metricExporterOptions(endpoint string) []otlpmetrichttp.Option {
-	return []otlpmetrichttp.Option{otlpmetrichttp.WithEndpointURL(normalizeOTLPEndpoint(endpoint))}
+	return []otlpmetrichttp.Option{otlpmetrichttp.WithEndpointURL(signalEndpointURL(endpoint, "/v1/metrics"))}
 }
 
 func logExporterOptions(endpoint string) []otlploghttp.Option {
-	return []otlploghttp.Option{otlploghttp.WithEndpointURL(normalizeOTLPEndpoint(endpoint))}
+	return []otlploghttp.Option{otlploghttp.WithEndpointURL(signalEndpointURL(endpoint, "/v1/logs"))}
 }
 
 func shutdownTracerProvider(tp *trace.TracerProvider) error {

--- a/cmd/root/otel_test.go
+++ b/cmd/root/otel_test.go
@@ -73,6 +73,38 @@ func TestNormalizeOTLPEndpoint(t *testing.T) {
 	}
 }
 
+// TestSignalEndpointURL pins the base-endpoint -> per-signal URL mapping.
+// docker-agent re-injects the configured endpoint through WithEndpointURL,
+// which takes the path verbatim; signalEndpointURL restores the signal
+// subpath the OTel SDK would otherwise append, so base-path backends such
+// as Langfuse and LangSmith receive traces at <base>/v1/traces instead of
+// 404ing on the bare base URL.
+func TestSignalEndpointURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		endpoint   string
+		signalPath string
+		want       string
+	}{
+		{"langfuse base appends traces", "https://cloud.langfuse.com/api/public/otel", "/v1/traces", "https://cloud.langfuse.com/api/public/otel/v1/traces"},
+		{"langsmith base appends traces", "https://api.smith.langchain.com/otel", "/v1/traces", "https://api.smith.langchain.com/otel/v1/traces"},
+		{"full per-signal url preserved", "https://api.smith.langchain.com/otel/v1/traces", "/v1/traces", "https://api.smith.langchain.com/otel/v1/traces"},
+		{"trailing slash base joins single slash", "https://cloud.langfuse.com/api/public/otel/", "/v1/logs", "https://cloud.langfuse.com/api/public/otel/v1/logs"},
+		{"bare localhost host:port -> http + traces", "localhost:4318", "/v1/traces", "http://localhost:4318/v1/traces"},
+		{"bare remote host:port -> https + metrics", "collector.example.com:4318", "/v1/metrics", "https://collector.example.com:4318/v1/metrics"},
+		{"root-only endpoint appends traces", "https://collector.example.com", "/v1/traces", "https://collector.example.com/v1/traces"},
+		{"explicit http preserved + logs", "http://localhost:4318", "/v1/logs", "http://localhost:4318/v1/logs"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, signalEndpointURL(tt.endpoint, tt.signalPath))
+		})
+	}
+}
+
 func TestIsLocalhostEndpoint(t *testing.T) {
 	t.Parallel()
 

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -161,3 +161,5 @@
       url: /community/troubleshooting/
     - title: Telemetry
       url: /community/telemetry/
+    - title: OpenTelemetry Tracing
+      url: /community/opentelemetry/

--- a/docs/community/opentelemetry/index.md
+++ b/docs/community/opentelemetry/index.md
@@ -1,0 +1,105 @@
+---
+title: "OpenTelemetry Tracing"
+description: "Export docker-agent traces to any OTLP backend, including Langfuse and LangSmith, for debugging agentic workflows."
+permalink: /community/opentelemetry/
+---
+
+# OpenTelemetry Tracing
+
+_docker-agent can export OpenTelemetry traces of an agent run to any OTLP/HTTP backend. This is separate from [product-analytics telemetry](/community/telemetry/) and is opt-in via the `--otel` flag._
+
+When enabled, docker-agent emits OpenTelemetry GenAI (`gen_ai.*`) and MCP (`mcp.*`) spans following the [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/). Spans cover the agent turn, model calls (with token usage and cost attributes), tool calls, MCP client/server activity, sub-agent hand-offs, and provider fallbacks. W3C `traceparent` context is propagated so the whole run renders as a single connected trace tree.
+
+## Enabling
+
+```bash
+docker agent run agent.yaml --otel
+```
+
+Without an exporter endpoint configured, spans are recorded locally as no-ops. To ship them somewhere, set the standard OTLP environment variables described below.
+
+## Configuration
+
+docker-agent reads the standard OTLP environment variables:
+
+| Variable | Purpose |
+| --- | --- |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Base OTLP/HTTP endpoint. The signal subpath (`/v1/traces`, `/v1/metrics`, `/v1/logs`) is appended automatically. |
+| `OTEL_EXPORTER_OTLP_HEADERS` | Comma-separated `key=value` headers sent with every export request (for example, an `Authorization` header). |
+| `OTEL_RESOURCE_ATTRIBUTES` | Extra resource attributes merged into every span. |
+| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | Set to `true` to capture prompt and response message content as span attributes. Off by default. |
+
+<div class="callout callout-info" markdown="1">
+<div class="callout-title">Base endpoint, not the full signal URL
+</div>
+  <p>Set <code>OTEL_EXPORTER_OTLP_ENDPOINT</code> to the <strong>base</strong> endpoint (for example <code>https://cloud.langfuse.com/api/public/otel</code>). docker-agent appends <code>/v1/traces</code> for you, matching the value documented by Langfuse and LangSmith. A bare <code>host:port</code> is also accepted and gets <code>https://</code> (or <code>http://</code> for localhost).</p>
+
+</div>
+
+<div class="callout callout-warning" markdown="1">
+<div class="callout-title">Message content can contain sensitive data
+</div>
+  <p><code>OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT</code> is off by default because chat history routinely contains PII, secrets, and internal documents. Enable it only for backends and environments where exporting that content is acceptable.</p>
+
+</div>
+
+## Backends
+
+Protocol support is OTLP over HTTP (`http/protobuf`). gRPC endpoints are not currently supported.
+
+### Langfuse
+
+[Langfuse](https://langfuse.com) exposes an OTLP endpoint and authenticates with HTTP Basic auth built from a project's public and secret keys.
+
+```bash
+# Base64 of "public_key:secret_key"
+LANGFUSE_AUTH=$(echo -n "pk-lf-...:sk-lf-..." | base64)
+
+export OTEL_EXPORTER_OTLP_ENDPOINT="https://cloud.langfuse.com/api/public/otel"
+export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic ${LANGFUSE_AUTH}"
+
+docker agent run agent.yaml --otel
+```
+
+Regional and self-hosted hosts use the same `/api/public/otel` base path:
+
+| Region | Endpoint |
+| --- | --- |
+| EU | `https://cloud.langfuse.com/api/public/otel` |
+| US | `https://us.cloud.langfuse.com/api/public/otel` |
+| Self-hosted (>= v3.22.0) | `http://localhost:3000/api/public/otel` |
+
+### LangSmith
+
+[LangSmith](https://docs.langchain.com/langsmith/trace-with-opentelemetry) authenticates with an `x-api-key` header (the raw API key, with no `Basic`/`Bearer` prefix). An optional `Langsmith-Project` header routes traces to a named project.
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.smith.langchain.com/otel"
+export OTEL_EXPORTER_OTLP_HEADERS="x-api-key=<your-api-key>,Langsmith-Project=<project>"
+
+docker agent run agent.yaml --otel
+```
+
+### OpenTelemetry Collector
+
+Any OTLP/HTTP collector (the OpenTelemetry Collector, Grafana Alloy, Jaeger, and so on) works by pointing at its base endpoint:
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318"
+docker agent run agent.yaml --otel
+```
+
+<div class="callout callout-info" markdown="1">
+<div class="callout-title">Langfuse and LangSmith ingest traces only
+</div>
+  <p>Both backends accept the traces signal only. docker-agent also wires metric and log exporters at the same endpoint, so their periodic exports return <code>404</code> against trace-only backends. This is harmless to traces but appears in the debug log. Point a full OTLP collector at the endpoint if you also want metrics and logs.</p>
+
+</div>
+
+## Inspecting traces locally
+
+Use `--debug` to print telemetry activity to the debug log (`~/.cagent/cagent.debug.log` by default) without standing up a backend:
+
+```bash
+docker agent run agent.yaml --otel --debug
+```


### PR DESCRIPTION
## Summary

Closes #3142. Makes `--otel` trace export work against generic OTLP backends whose endpoint has a non-root base path, specifically Langfuse and LangSmith.

docker-agent already emits rich `gen_ai.*` and `mcp.*` spans; the only gap was that they did not reach base-path backends. The endpoint was read from the env and re-injected through `WithEndpointURL`, which takes the URL path verbatim and appends the signal subpath only when the path is empty. With the documented base endpoints the path is non-empty, so nothing was appended and exports hit the bare base URL (404), dropping traces.

| Cause | Handled by | Status |
| --- | --- | --- |
| `WithEndpointURL` uses the path verbatim, no `/v1/traces` append | `signalEndpointURL` appends the per-signal subpath via `path.Join`, mirroring the SDK's native env handling | fixed |
| Log exporter posted to `/` for a bare collector endpoint (latent) | same helper now appends `/v1/logs` | fixed |
| `normalizeOTLPEndpoint` comment described a non-existent TLS trace/log asymmetry | comment corrected to the real reason (`url.Parse("host:port")` parses host as scheme) | fixed |
| Auth headers (`OTEL_EXPORTER_OTLP_HEADERS`) | already applied by the SDK env layer, untouched by `WithEndpointURL` | already worked |

## Behavior

| Endpoint (`OTEL_EXPORTER_OTLP_ENDPOINT`) | Signal | Before | After |
| --- | --- | --- | --- |
| `https://cloud.langfuse.com/api/public/otel` | traces | POST `/api/public/otel` (404) | POST `/api/public/otel/v1/traces` |
| `https://api.smith.langchain.com/otel` | traces | POST `/otel` (404) | POST `/otel/v1/traces` |
| `http://collector:4318` | logs | POST `/` | POST `/v1/logs` |
| `https://x/otel/v1/traces` (full per-signal URL) | traces | POST `/otel/v1/traces` | POST `/otel/v1/traces` (preserved) |

## Issue expectations mapping

| Issue ask | Result |
| --- | --- |
| trace LLM calls / debug tool calls | existing `gen_ai.*` / `mcp.*` / tool spans now reach Langfuse and LangSmith |
| ship to self-hosted / public OTLP instances | base-endpoint path append fixes generic OTLP backends |
| ship to custom endpoints | any OTLP/HTTP base endpoint works; signal subpath appended automatically |
| Langfuse / LangSmith examples | documented (Basic auth for Langfuse, `x-api-key` for LangSmith) |

## Tests

- `TestSignalEndpointURL`: base-endpoint to per-signal URL mapping (Langfuse, LangSmith, full-URL passthrough, trailing slash, bare `host:port`, root-only).
- Existing `TestNormalizeOTLPEndpoint`, `TestProvidersWithoutEndpoint`, `TestIsLocalhostEndpoint` remain unchanged and pass.
- Verified end-to-end against a local HTTP server that the trace exporter posts to `<base>/v1/traces` and that `OTEL_EXPORTER_OTLP_HEADERS` survives.

## Docs

New `OpenTelemetry Tracing` page under Community (distinct from the existing product-analytics telemetry page), with Langfuse and LangSmith setup, the message-content capture opt-in, and the trace-only note below.

## Open questions for maintainers

1. **Metrics and logs against trace-only backends.** Langfuse and LangSmith ingest traces only, so the metric and log exporters will periodically 404 there (harmless to traces, noisy in the debug log). This PR documents it. Alternatives if preferred: honor `OTEL_EXPORTER_OTLP_{TRACES,METRICS,LOGS}_ENDPOINT` so signals can be split across backends, or add a switch to disable metric/log exporters. Can be a follow-up.
2. **gRPC** (`OTEL_EXPORTER_OTLP_PROTOCOL=grpc`) is still unsupported (both target backends are HTTP). Out of scope here; can be tracked separately if wanted.
3. **Behavior change**: a root-path endpoint now gets `/v1/<signal>` appended (spec-correct, but a change for anyone relying on the old verbatim-root quirk). Worth a CHANGELOG note at release time.
