### PR TITLE
test(teamloader): wire test provider registry in agent config retention test

### DIFF
--- a/pkg/teamloader/teamloader_test.go
+++ b/pkg/teamloader/teamloader_test.go
@@ -677,7 +677,7 @@ func TestLoadRetainsAgentConfig(t *testing.T) {
         tools: [shell]
 `)
 
-	team, err := Load(t.Context(), config.NewBytesSource("inspector.yaml", data), &config.RuntimeConfig{})
+	team, err := Load(t.Context(), config.NewBytesSource("inspector.yaml", data), &config.RuntimeConfig{}, withTestProviderRegistry()...)
 	require.NoError(t, err)
 
 	cfg, ok := team.AgentConfig("root")


### PR DESCRIPTION
## Summary

Fixes the failing `TestLoadRetainsAgentConfig` test in `pkg/teamloader`, which was breaking CI on `main` with:

```
failed to get models: unknown provider type "openai"
(register it with provider.NewRegistry or use providers.NewDefaultRegistry)
```

## Root cause

A **semantic merge conflict** between two individually-green PRs:

- **PR #3184** (`cf5a430d2`) intentionally emptied the non-js default provider registry (`provider.DefaultRegistry()` now returns empty by design) and migrated all *then-existing* teamloader test call sites to the `withTestProviderRegistry()` helper.
- **`TestLoadRetainsAgentConfig`** was added in parallel on commit `95374887c` (TUI Agent Inspector), so PR #3184 never saw it and could not migrate it.

Merged together, the orphaned test called an empty registry → `unknown provider type "openai"`. Each PR was green against its own base; the breakage only appears on the combined `main`.

## Fix

A single, test-only line: add `withTestProviderRegistry()...` to the `Load(...)` call at `teamloader_test.go:680`, matching the convention used by every sibling test in the file. No production code is touched; the intentional #3184 decoupling is preserved (no repopulation of `provider.defaultFactories`, no change to the `LoadWithConfig` default).

## Validation

- `go test ./pkg/teamloader/ -run TestLoadRetainsAgentConfig` ✅ pass
- `go test ./pkg/teamloader/` ✅ pass
- `task lint` ✅ 0 issues

> Note: `TestLoadExamples` fails locally with a pre-existing/environmental CDN `416` error pulling `ai/qwen3` — confirmed to reproduce on unmodified `main` and unrelated to this change.