### PR TITLE
docs: update docs for features merged 2026-06-25 (plan toolset, readonly, shared toolsets)

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -51,6 +51,8 @@
       url: /tools/shell/
     - title: Think
       url: /tools/think/
+    - title: Plan
+      url: /tools/plan/
     - title: Todo
       url: /tools/todo/
     - title: Memory

--- a/docs/configuration/agents/index.md
+++ b/docs/configuration/agents/index.md
@@ -33,6 +33,8 @@ agents:
     max_consecutive_tool_calls: int # Optional: max identical consecutive tool calls
     max_old_tool_call_tokens: int # Optional: token budget for old tool call content (disabled unless positive)
     num_history_items: int # Optional: limit conversation history
+    use_toolsets: [list] # Optional: names of top-level toolsets to merge into this agent
+    readonly: boolean # Optional: restrict all toolsets to read-only tools only
     skills: boolean | [list] # Optional: enable skill discovery (true/false or list of names and/or sources)
     use_commands: [list] # Optional: names of top-level commands groups to merge into this agent
     use_skills: [list] # Optional: names of top-level skills groups to merge into this agent
@@ -97,6 +99,8 @@ agents:
 | `commands`                  | object  | ✗        | Named prompts that can be run with `docker agent run config.yaml /command_name`. Can be simple strings or objects with `instruction` and/or `agent` fields for agent switching. See [Named Commands](#named-commands) below. |
 | `use_commands`              | list of string | ✗   | Names of top-level `commands` groups to merge into this agent. Inline `commands` entries take precedence on name conflicts. Default: `[]`. |
 | `use_skills`                | list of string | ✗   | Names of top-level `skills` groups to merge into this agent. Inline skills are deduplicated by name against merged entries. Default: `[]`. |
+| `use_toolsets`              | list of string | ✗   | Names of top-level `toolsets` groups to merge into this agent. See [Reusable Toolsets]({{ '/configuration/overview/#reusable-toolsets-toolsets' | relative_url }}). Default: `[]`. |
+| `readonly`                  | boolean | ✗   | When `true`, every toolset on this agent is filtered to expose only read-only tools (those annotated with a read-only hint). Mutating tools are removed at load time and cannot be called even if the model tries. See [Read-Only Agents](#read-only-agents) below. |
 | `welcome_message`           | string  | ✗        | Message displayed to the user when a session starts. Rendered as Markdown in the TUI. **Not sent to the model** — it exists purely for the user's benefit. Useful for telling users what the agent can do and what commands are available. |
 | `handoffs`                  | array   | ✗        | List of agent names this agent can hand off the conversation to. Enables the `handoff` tool. See [Handoffs Routing]({{ '/concepts/multi-agent/#handoffs-routing' | relative_url }}).                  |
 | `force_handoff`             | string  | ✗        | Name of an agent that unconditionally receives the conversation whenever this agent produces a final response. The runtime performs the switch itself, bypassing the LLM's tool-calling, guaranteeing deterministic pipelines. Must not reference the agent itself, and chains must not form a cycle. See [Forced Handoffs]({{ '/concepts/multi-agent/#forced-handoffs' | relative_url }}). |
@@ -369,6 +373,44 @@ Commands use JavaScript template literal syntax (`${env.VAR}`) for environment v
 The same syntax is also expanded in agent and toolset instructions: `agents.<name>.instruction` and `toolsets[*].instruction` support `${env.X}` placeholders (with optional `||` defaults and ternary expressions). `agents.<name>.description` and `agents.<name>.welcome_message` also support it.
 
 Note that path-like fields (`working_dir`, `path`) primarily use a shell-style syntax (`$VAR`, `${VAR}`, `~`), and also accept `${env.X}` as an alias (though not richer JS expressions). See [Variable Expansion in Config Fields]({{ '/configuration/overview/#variable-expansion-in-config-fields' | relative_url }}) for the full table.
+
+## Read-Only Agents
+
+Set `readonly: true` on an agent to restrict all of its toolsets to tools that are annotated as read-only. Mutating tools are filtered out at load time — the agent cannot list or call them, even if the model hallucinates a call.
+
+You can also set `readonly: true` on an individual toolset to restrict only that toolset while leaving others unrestricted.
+
+```yaml
+agents:
+  # Agent-level readonly: every toolset is restricted to read-only tools.
+  inspector:
+    model: anthropic/claude-sonnet-4-5
+    description: Read-only inspector that can explore but never modify.
+    instruction: Explore the project. Do not make changes.
+    readonly: true
+    toolsets:
+      - type: filesystem
+      - type: shell
+
+  # Toolset-level readonly: only the filesystem toolset is restricted;
+  # the shell toolset keeps all of its tools.
+  mixed:
+    model: anthropic/claude-sonnet-4-5
+    description: Read-only file access, full shell access.
+    instruction: You can read files and run any shell command.
+    toolsets:
+      - type: filesystem
+        readonly: true
+      - type: shell
+```
+
+See [`examples/readonly.yaml`](https://github.com/docker/docker-agent/blob/main/examples/readonly.yaml) for a complete example.
+
+<div class="callout callout-info" markdown="1">
+<div class="callout-title">Which tools are read-only?
+</div>
+  <p>Whether a tool is read-only is determined by its <code>ReadOnlyHint</code> annotation. For built-in tools, read-only operations (list/read/search) carry the hint; mutating operations (write/delete/execute) do not. Custom and MCP tools expose the hint via their own annotations.</p>
+</div>
 
 ## Complete Example
 

--- a/docs/configuration/overview/index.md
+++ b/docs/configuration/overview/index.md
@@ -74,6 +74,11 @@ commands:
     deploy: "Deploy the application"
 skills:
   base: [local, git]
+
+# 10. Toolsets — reusable, named toolset definitions shared across agents (optional)
+toolsets:
+  fs:
+    type: filesystem
 ```
 
 ## Minimal Config
@@ -366,6 +371,39 @@ agents:
 ```
 
 An `mcps` entry accepts every field a regular `type: mcp` toolset accepts (command/args/env, `remote` with `url`/`transport_type`/`headers`/`oauth`, `tools` filter, `instruction`, `defer`, …) — the `type: mcp` is implicit. See the [Tool Config]({{ '/configuration/tools/' | relative_url }}) page for all options and the [Remote MCP Servers]({{ '/features/remote-mcp/' | relative_url }}) guide for remote setups.
+
+## Reusable Toolsets (`toolsets:`)
+
+The top-level `toolsets:` map defines named toolset configurations that agents can reference by name through `use_toolsets:`. This avoids repeating the same toolset definition across multiple agents — the same pattern as `mcps:` for MCP servers and `commands:` / `skills:` for reusable prompt groups.
+
+Any toolset type is supported, including ones that reference MCP or RAG definitions. Shared toolsets are resolved before the MCP/RAG pass, so they can contain `{type: mcp, ref: <name>}` references.
+
+```yaml
+toolsets:
+  fs:               # a named shared toolset
+    type: filesystem
+  docs:
+    type: fetch
+    allowed_domains:
+      - docker.com
+
+agents:
+  root:
+    model: openai/gpt-5
+    # Pull in shared toolsets by name; inline toolsets come first.
+    use_toolsets: [fs, docs]
+    toolsets:
+      - type: think
+
+  reviewer:
+    model: openai/gpt-5
+    # Reuse the same filesystem toolset without copying its definition.
+    use_toolsets: [fs]
+```
+
+Inline `toolsets:` entries listed directly on the agent take precedence in ordering (they come first) and are always included alongside referenced ones.
+
+See [`examples/shared-toolsets.yaml`](https://github.com/docker/docker-agent/blob/main/examples/shared-toolsets.yaml) for a complete example.
 
 ## Reusable Commands & Skills (`commands:` / `skills:`)
 

--- a/docs/configuration/tools/index.md
+++ b/docs/configuration/tools/index.md
@@ -17,10 +17,10 @@ Built-in tools are included with docker-agent and require no external dependenci
 | `filesystem` | Read, write, list, search, navigate | [Filesystem]({{ '/tools/filesystem/' | relative_url }}) |
 | `shell` | Execute shell commands (sync + background jobs) | [Shell]({{ '/tools/shell/' | relative_url }}) |
 | `think` | Reasoning scratchpad | [Think]({{ '/tools/think/' | relative_url }}) |
-| `todo` | Task list management | [Todo]({{ '/tools/todo/' | relative_url }}) |
 | `plan` | Shared persistent scratchpad for multi-agent collaboration | [Plan]({{ '/tools/plan/' | relative_url }}) |
-| `tasks` | Persistent task database shared across sessions | [Tasks]({{ '/tools/tasks/' | relative_url }}) |
+| `todo` | Task list management | [Todo]({{ '/tools/todo/' | relative_url }}) |
 | `memory` | Persistent key-value storage (SQLite) | [Memory]({{ '/tools/memory/' | relative_url }}) |
+| `tasks` | Persistent task database shared across sessions | [Tasks]({{ '/tools/tasks/' | relative_url }}) |
 | `fetch` | HTTP `GET` requests with text/markdown/html output | [Fetch]({{ '/tools/fetch/' | relative_url }}) |
 | `script` | Custom shell scripts as tools | [Script]({{ '/tools/script/' | relative_url }}) |
 | `lsp` | Language Server Protocol integration | [LSP]({{ '/tools/lsp/' | relative_url }}) |

--- a/docs/configuration/tools/index.md
+++ b/docs/configuration/tools/index.md
@@ -18,6 +18,7 @@ Built-in tools are included with docker-agent and require no external dependenci
 | `shell` | Execute shell commands (sync + background jobs) | [Shell]({{ '/tools/shell/' | relative_url }}) |
 | `think` | Reasoning scratchpad | [Think]({{ '/tools/think/' | relative_url }}) |
 | `todo` | Task list management | [Todo]({{ '/tools/todo/' | relative_url }}) |
+| `plan` | Shared persistent scratchpad for multi-agent collaboration | [Plan]({{ '/tools/plan/' | relative_url }}) |
 | `tasks` | Persistent task database shared across sessions | [Tasks]({{ '/tools/tasks/' | relative_url }}) |
 | `memory` | Persistent key-value storage (SQLite) | [Memory]({{ '/tools/memory/' | relative_url }}) |
 | `fetch` | HTTP `GET` requests with text/markdown/html output | [Fetch]({{ '/tools/fetch/' | relative_url }}) |

--- a/docs/tools/plan/index.md
+++ b/docs/tools/plan/index.md
@@ -28,7 +28,7 @@ No additional options are required. All agents that include `type: plan` in thei
 | Tool          | Description                                                                                       |
 | ------------- | ------------------------------------------------------------------------------------------------- |
 | `write_plan`  | Create or update a shared plan by name. Replaces the entire plan content — read it first to preserve what you want to keep. Each write bumps the revision number. |
-| `read_plan`   | Read a shared plan by name, including its title, content, author, and revision number.            |
+| `read_plan`   | Read a shared plan by name, including its title, content, author, revision number, and last-updated timestamp. |
 | `list_plans`  | List all shared plans with their name, title, author, revision, and last-updated timestamp. |
 | `delete_plan` | Delete a shared plan by name.                                                                     |
 

--- a/docs/tools/plan/index.md
+++ b/docs/tools/plan/index.md
@@ -29,7 +29,7 @@ No additional options are required. All agents that include `type: plan` in thei
 | ------------- | ------------------------------------------------------------------------------------------------- |
 | `write_plan`  | Create or update a shared plan by name. Replaces the entire plan content — read it first to preserve what you want to keep. Each write bumps the revision number. |
 | `read_plan`   | Read a shared plan by name, including its title, content, author, and revision number.            |
-| `list_plans`  | List all shared plans with their name, title, author, and revision.                               |
+| `list_plans`  | List all shared plans with their name, title, author, revision, and last-updated timestamp. |
 | `delete_plan` | Delete a shared plan by name.                                                                     |
 
 ### Plan Names

--- a/docs/tools/plan/index.md
+++ b/docs/tools/plan/index.md
@@ -1,0 +1,100 @@
+---
+title: "Plan Tool"
+description: "Shared persistent scratchpad for multi-agent collaboration."
+permalink: /tools/plan/
+---
+
+# Plan Tool
+
+_Shared persistent scratchpad for multi-agent collaboration._
+
+## Overview
+
+The plan tool gives agents a shared, persistent scratchpad of named documents. Any agent in a multi-agent config that loads the `plan` toolset can read and write the same plans, and those plans survive across sessions. This makes it straightforward to wire a planner agent that sketches work and one or more executor agents that consume it without any custom tool wiring.
+
+Plans are stored as JSON files in the docker-agent data directory (`~/.cagent/plans/` by default). All agents that share a process serialize on a single mutex so concurrent reads and writes are safe. Writes are atomic (temp file + rename), so a reader never observes partial content.
+
+## Configuration
+
+```yaml
+toolsets:
+  - type: plan
+```
+
+No additional options are required. All agents that include `type: plan` in their toolsets share the same plans.
+
+## Available Tools
+
+| Tool          | Description                                                                                       |
+| ------------- | ------------------------------------------------------------------------------------------------- |
+| `write_plan`  | Create or update a shared plan by name. Replaces the entire plan content — read it first to preserve what you want to keep. Each write bumps the revision number. |
+| `read_plan`   | Read a shared plan by name, including its title, content, author, and revision number.            |
+| `list_plans`  | List all shared plans with their name, title, author, and revision.                               |
+| `delete_plan` | Delete a shared plan by name.                                                                     |
+
+### Plan Names
+
+Plan names must match the pattern `[a-z0-9][a-z0-9_-]*` (lowercase letters, digits, `-`, `_`). This is enforced structurally so two different inputs can never collapse onto the same file and path-traversal is impossible by construction.
+
+### Plan Fields
+
+Each plan document contains:
+
+| Field      | Description                                               |
+| ---------- | --------------------------------------------------------- |
+| `name`     | The plan's unique slug name                               |
+| `title`    | A short human-readable title (optional)                   |
+| `content`  | The full Markdown or free-form plan text                  |
+| `author`   | Free-form label identifying who last wrote the plan       |
+| `revision` | Monotonically increasing counter, bumped on every write   |
+| `updatedAt`| ISO 8601 timestamp of the last write                      |
+
+## Example
+
+Two agents collaborate on a shared plan — the architect drafts it and the builder refines it:
+
+```yaml
+agents:
+  root:
+    model: anthropic/claude-sonnet-4-5
+    description: Coordinator
+    instruction: |
+      Route work between the architect and the builder.
+    handoffs: [architect, builder]
+
+  architect:
+    model: anthropic/claude-sonnet-4-5
+    description: Drafts high-level plans
+    instruction: |
+      Use list_plans and read_plan to inspect existing plans, then write_plan
+      to create or revise one. Always read before writing. When done, hand off
+      to the builder.
+    toolsets:
+      - type: plan
+    handoffs: [builder]
+
+  builder:
+    model: openai/gpt-4o
+    description: Adds implementation steps to plans
+    instruction: |
+      Read the architect's plan with read_plan, then use write_plan to append
+      concrete implementation steps. Always read before writing. When done,
+      hand off back to root.
+    toolsets:
+      - type: plan
+    handoffs: [root]
+```
+
+See [`examples/shared_plan.yaml`](https://github.com/docker/docker-agent/blob/main/examples/shared_plan.yaml) for a complete working example.
+
+## Error Handling
+
+- `read_plan` returns a distinct "not found" error when a plan does not exist, as opposed to any other I/O error, so callers can tell "plan missing" from "plan unreadable."
+- `list_plans` skips corrupt entries but reports them in a `warnings` field so an agent can detect and recover from a bad state (e.g., by calling `delete_plan`).
+- `delete_plan` can remove a corrupt plan to recover from a bad state.
+
+<div class="callout callout-tip" markdown="1">
+<div class="callout-title">Plan vs. Todo vs. Tasks
+</div>
+  <p>Use <strong>plan</strong> for shared, free-form documents that multiple agents collaborate on (design docs, requirements, work items). Use <a href="{{ '/tools/todo/' | relative_url }}">todo</a> for lightweight in-session task lists. Use <a href="{{ '/tools/tasks/' | relative_url }}">tasks</a> for a structured, persistent task database with priorities and dependencies.</p>
+</div>


### PR DESCRIPTION
Covers documentation for three feature PRs merged to main on 2026-06-25:

**#3227 – `plan` builtin toolset**
- New page `docs/tools/plan/` documenting all four tools (`write_plan`, `read_plan`, `list_plans`, `delete_plan`), plan-name constraints, plan fields, and a multi-agent example
- Added `plan` to the nav sidebar (between Think and Todo) and to the built-in tools reference table

**#3226 – `readonly` attribute for toolsets and agents**
- Updated agent config Full Schema and Properties Reference to document the new `readonly` field
- Added a "Read-Only Agents" section with usage examples for both agent-level and toolset-level `readonly: true`

**#3232 – top-level `toolsets:` and `use_toolsets:`**
- Added "Reusable Toolsets (`toolsets:`)" section to the Configuration Overview, mirroring the existing `mcps:` and `commands:` / `skills:` sections
- Added `use_toolsets` and updated `readonly` entries to the agent Properties Reference table
- Updated the File Structure code block to show the new `toolsets:` top-level section

PRs whose docs were already updated by the feature author (no changes needed here): #3240 (OpenTelemetry), #3204 (TUI keybindings), #3108 (TUI Agents panel redesign).