### PR TITLE
fix: cycle thinking level in lean tui

### DIFF
--- a/pkg/leantui/update.go
+++ b/pkg/leantui/update.go
@@ -2,6 +2,8 @@ package leantui
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -36,6 +38,8 @@ func (m *model) handleKey(ctx context.Context, k key) {
 		m.editor.insertNewline()
 	case keyTab:
 		m.handleTab()
+	case keyShiftTab:
+		m.handleCycleThinkingLevel(ctx)
 	case keyUp:
 		if m.ac.active {
 			m.ac.moveUp()
@@ -116,6 +120,27 @@ func (m *model) handleTab() {
 		m.editor.setText("/" + cmd.name + " ")
 		m.ac.sync(m.editor.text())
 	}
+}
+
+func (m *model) handleCycleThinkingLevel(ctx context.Context) {
+	if m.app == nil {
+		return
+	}
+	if !m.app.SupportsModelSwitching() {
+		m.addNotice("", "Thinking levels can't be changed with remote runtimes", stMuted())
+		return
+	}
+	level, err := m.app.CycleAgentThinkingLevel(ctx)
+	if err != nil {
+		if errors.Is(err, runtime.ErrUnsupported) {
+			m.addNotice("", "Current model does not support thinking levels", stMuted())
+			return
+		}
+		m.addNotice("✗ ", fmt.Sprintf("Failed to change thinking level: %v", err), stError())
+		return
+	}
+	m.status.thinking = level.String()
+	m.addNotice("", "Thinking: "+level.String(), stMuted())
 }
 
 func (m *model) submit(ctx context.Context, text string) {
@@ -581,7 +606,8 @@ func (m *model) commitHelp() {
 			stBold().Render("Shortcuts"),
 			stMuted().Render("  Enter      send             Alt+Enter   insert newline"),
 			stMuted().Render("  Up/Down    history           Tab         complete command"),
-			stMuted().Render("  Ctrl+C     cancel / quit     Ctrl+W      delete previous word"),
+			stMuted().Render("  Shift+Tab  cycle thinking    Ctrl+C      cancel / quit"),
+			stMuted().Render("  Ctrl+W     delete previous word"),
 		}
 	})
 }

--- a/pkg/leantui/update_test.go
+++ b/pkg/leantui/update_test.go
@@ -1,0 +1,126 @@
+package leantui
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/docker/docker-agent/pkg/app"
+	"github.com/docker/docker-agent/pkg/effort"
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/sessiontitle"
+	"github.com/docker/docker-agent/pkg/tools"
+	skillstool "github.com/docker/docker-agent/pkg/tools/builtin/skills"
+	mcptools "github.com/docker/docker-agent/pkg/tools/mcp"
+)
+
+type cycleThinkingRuntime struct {
+	supports   bool
+	level      effort.Level
+	err        error
+	cycleCalls int
+}
+
+func (r *cycleThinkingRuntime) CurrentAgentInfo(context.Context) runtime.CurrentAgentInfo {
+	return runtime.CurrentAgentInfo{}
+}
+func (r *cycleThinkingRuntime) CurrentAgentName() string     { return "coder" }
+func (r *cycleThinkingRuntime) SetCurrentAgent(string) error { return nil }
+func (r *cycleThinkingRuntime) CurrentAgentTools(context.Context) ([]tools.Tool, error) {
+	return nil, nil
+}
+func (r *cycleThinkingRuntime) CurrentAgentToolsetStatuses() []tools.ToolsetStatus { return nil }
+func (r *cycleThinkingRuntime) RestartToolset(context.Context, string) error       { return nil }
+func (r *cycleThinkingRuntime) EmitStartupInfo(context.Context, *session.Session, runtime.EventSink) {
+}
+
+func (r *cycleThinkingRuntime) EmitAgentInfo(_ context.Context, sink runtime.EventSink) {
+	sink.Emit(runtime.TeamInfo([]runtime.AgentDetails{{Name: "coder", Thinking: r.level.String()}}, "coder"))
+}
+func (r *cycleThinkingRuntime) ResetStartupInfo() {}
+func (r *cycleThinkingRuntime) RunStream(context.Context, *session.Session) <-chan runtime.Event {
+	ch := make(chan runtime.Event)
+	close(ch)
+	return ch
+}
+
+func (r *cycleThinkingRuntime) Run(context.Context, *session.Session) ([]session.Message, error) {
+	return nil, nil
+}
+func (r *cycleThinkingRuntime) Resume(context.Context, runtime.ResumeRequest) {}
+func (r *cycleThinkingRuntime) ResumeElicitation(context.Context, tools.ElicitationAction, map[string]any) error {
+	return nil
+}
+func (r *cycleThinkingRuntime) SessionStore() session.Store { return nil }
+func (r *cycleThinkingRuntime) Summarize(context.Context, *session.Session, string, runtime.EventSink) {
+}
+func (r *cycleThinkingRuntime) PermissionsInfo() *runtime.PermissionsInfo { return nil }
+func (r *cycleThinkingRuntime) CurrentAgentSkillsToolset() *skillstool.ToolSet {
+	return nil
+}
+
+func (r *cycleThinkingRuntime) RunSkillFork(context.Context, *session.Session, skillstool.RunSkillArgs, runtime.EventSink) (*tools.ToolCallResult, error) {
+	return nil, nil
+}
+
+func (r *cycleThinkingRuntime) CurrentMCPPrompts(context.Context) map[string]mcptools.PromptInfo {
+	return nil
+}
+
+func (r *cycleThinkingRuntime) ExecuteMCPPrompt(context.Context, string, map[string]string) (string, error) {
+	return "", nil
+}
+
+func (r *cycleThinkingRuntime) UpdateSessionTitle(_ context.Context, sess *session.Session, title string) error {
+	sess.Title = title
+	return nil
+}
+func (r *cycleThinkingRuntime) TitleGenerator() *sessiontitle.Generator { return nil }
+func (r *cycleThinkingRuntime) Close() error                            { return nil }
+func (r *cycleThinkingRuntime) Stop()                                   {}
+func (r *cycleThinkingRuntime) Steer(runtime.QueuedMessage) error       { return nil }
+func (r *cycleThinkingRuntime) FollowUp(runtime.QueuedMessage) error    { return nil }
+func (r *cycleThinkingRuntime) QueueStatus() runtime.QueueStatus        { return runtime.QueueStatus{} }
+
+func (r *cycleThinkingRuntime) TogglePause(context.Context) (bool, error) {
+	return false, nil
+}
+func (r *cycleThinkingRuntime) SetAgentModel(context.Context, string, string) error { return nil }
+func (r *cycleThinkingRuntime) CycleAgentThinkingLevel(context.Context, string) (effort.Level, error) {
+	r.cycleCalls++
+	if r.err != nil {
+		return "", r.err
+	}
+	return r.level, nil
+}
+func (r *cycleThinkingRuntime) AvailableModels(context.Context) []runtime.ModelChoice { return nil }
+func (r *cycleThinkingRuntime) SupportsModelSwitching() bool                          { return r.supports }
+func (r *cycleThinkingRuntime) OnToolsChanged(func(runtime.Event))                    {}
+
+var _ runtime.Runtime = (*cycleThinkingRuntime)(nil)
+
+func TestShiftTabCyclesThinkingLevel(t *testing.T) {
+	rt := &cycleThinkingRuntime{supports: true, level: effort.High}
+	m := bareModel(24)
+	m.app = app.New(t.Context(), rt, session.New())
+
+	m.handleKey(t.Context(), key{typ: keyShiftTab})
+
+	assert.Equal(t, 1, rt.cycleCalls)
+	assert.Equal(t, "high", m.status.thinking)
+	assert.Len(t, m.blocks, 1)
+}
+
+func TestShiftTabReportsUnsupportedThinkingLevel(t *testing.T) {
+	rt := &cycleThinkingRuntime{supports: true, err: runtime.ErrUnsupported}
+	m := bareModel(24)
+	m.app = app.New(t.Context(), rt, session.New())
+
+	m.handleKey(t.Context(), key{typ: keyShiftTab})
+
+	assert.Equal(t, 1, rt.cycleCalls)
+	assert.Empty(t, m.status.thinking)
+	assert.Len(t, m.blocks, 1)
+}


### PR DESCRIPTION
## Summary
- Handle Shift+Tab in the lean TUI to cycle the current agent's thinking-effort level
- Update the lean footer immediately and show a lightweight notice for success/unsupported/error cases
- Add lean TUI tests for cycling and unsupported models

## Validation
- `go test ./pkg/leantui`
- `go test ./pkg/app ./pkg/tui ./pkg/leantui`
- `go vet ./pkg/leantui`
- `go build ./...`

Note: `task lint` could not be run because `task` is not installed in this environment. `go test ./...` was attempted and hit unrelated existing/environmental failures in `pkg/cache` and `pkg/rag/treesitter` (`CGO_ENABLED=1` required).
