### PR TITLE
chore: bump rubocop-go for whole-program context cop

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -142,7 +142,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/dgageot/rubocop-go v0.0.0-20260507084512-2695e6771458
+	github.com/dgageot/rubocop-go v0.0.0-20260625173251-68f54fee9a17
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.9.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/danieljoos/wincred v1.2.2/go.mod h1:w7w4Utbrz8lqeMbDAK0lkNJUv5sAOkFi7
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgageot/rubocop-go v0.0.0-20260507084512-2695e6771458 h1:qLFMffgwEigJvNG9kNGVlgfpVmLz92dy92Nr1sPJt4M=
-github.com/dgageot/rubocop-go v0.0.0-20260507084512-2695e6771458/go.mod h1:r8YOJV5+/30NZ8HW/2NbWUObBGDXGvfHrjgury5YlFI=
+github.com/dgageot/rubocop-go v0.0.0-20260625173251-68f54fee9a17 h1:rbJ6KuFV5f0nDEMaKSIMgM45eGeNctTkZbbW7hDESeE=
+github.com/dgageot/rubocop-go v0.0.0-20260625173251-68f54fee9a17/go.mod h1:wn4xlnesVpaaCT+xUYHAPW/rPxWd2jZIcUVqFkGUa0U=
 github.com/dgageot/ultraviolet v0.0.0-20260313154905-9451997d56b6 h1:88fWkkjwzuI4tRTqadbJIbA9O+gO67oyu+2OpHHuuT8=
 github.com/dgageot/ultraviolet v0.0.0-20260313154905-9451997d56b6/go.mod h1:SQpCTRNBtzJkwku5ye4S3HEuthAlGy2n9VXZnWkEW98=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=


### PR DESCRIPTION
Bumps `github.com/dgageot/rubocop-go` to `v0.0.0-20260625173251-68f54fee9a17` to pull in the new whole-program, inter-procedural dataflow analysis engine and the `Lint/ContextConnectivity` cop it enables. The previous version predates this work and cannot detect the cross-function `context.Context` propagation patterns we want to lint for.

This is the dependency-only step. The new version is now available in the module graph but nothing in `./lint` yet invokes the new cop — that wiring comes in a follow-up commit once the API is confirmed stable.

No behavior change to docker-agent itself; only `go.mod` and `go.sum` are modified. `go build ./...` passes and the module files are tidy.