### PR TITLE
feat(server): fork session by user-message ordinal

### DIFF
--- a/docs/features/api-server/index.md
+++ b/docs/features/api-server/index.md
@@ -308,27 +308,26 @@ as soon as any session is ready.
 **Request body:**
 
 ```json
-{ "message_index": 2 }
+{ "user_message_index": 1 }
 ```
 
-`message_index` is a **0-based index** into the flat, user-visible message list (the same shape `GET /api/sessions/:id` returns in `messages`). The fork includes messages `[0, message_index)` — the message at `message_index` is **excluded**, so clients can prefill it into their chat input for the user to edit and resubmit.
+`user_message_index` is a **0-based ordinal** that counts only user-role messages in the parent's flat, user-visible message list. The targeted user message is **excluded** from the fork so clients can prefill it into their chat input for the user to edit and resubmit.
 
 **Example:**
 
 ```bash
-# Fork a session before message index 4 (the user message the user wants to rewrite)
+# Fork a session before the second user message (ordinal 1)
 $ curl -X POST http://localhost:8080/api/sessions/$SID/fork \
   -H 'Content-Type: application/json' \
-  -d '{"message_index": 4}'
+  -d '{"user_message_index": 1}'
 # Returns: api.SessionResponse for the new forked session
 # New session title: "<parent title> (fork 1)", "(fork 2)", etc.
 ```
 
 **Validation:**
 
-- `message_index` must point to a **user-role message**; pointing at an assistant turn returns `400 Bad Request`.
-- Out-of-range indices return `400 Bad Request`.
-- An index that falls inside a sub-session returns `400 Bad Request`. A sub-session is a nested session created when a multi-agent config delegates work to a child agent; its messages are embedded within the parent session's message list and cannot be used as a fork boundary.
+- Out-of-range ordinals (negative, or at/past the user-message count) return `400 Bad Request`.
+- An ordinal that resolves to a user message inside a sub-session returns `400 Bad Request`. A sub-session is a nested session created when a multi-agent config delegates work to a child agent; its messages are embedded within the parent session's message list and cannot be used as a fork boundary.
 
 ## Idempotent follow-ups
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -187,13 +187,13 @@ type UpdateSessionTitleRequest struct {
 	Title string `json:"title"`
 }
 
-// ForkSessionRequest represents a request to fork a session at a given
-// message index. MessageIndex points at the user message to fork BEFORE
-// (exclusive cut): the new session contains messages [0, MessageIndex)
-// from the parent. The clicked message is excluded so clients can prefill
-// it into the chat input of the new session for the user to edit.
+// ForkSessionRequest represents a request to fork a session at the Nth
+// user message. UserMessageIndex is a 0-based ordinal counting only
+// user-role messages in the parent's flat, user-visible message list;
+// the targeted message is excluded from the fork so clients can
+// prefill it into the chat input.
 type ForkSessionRequest struct {
-	MessageIndex int `json:"message_index"`
+	UserMessageIndex int `json:"user_message_index"`
 }
 
 // UpdateSessionTitleResponse represents the response from updating a session's title

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -241,23 +241,20 @@ func (s *Server) createSession(c echo.Context) error {
 	return c.JSON(http.StatusOK, sess)
 }
 
-// forkSession creates a new session whose history is a deep copy of an
-// existing session up to (but excluding) the message at MessageIndex. The
-// fork point must be a user message; the new session uses a
-// fork-numbered title derived from the parent and starts with no runtime
-// attached. Clients are expected to prefill the excluded user message into
-// their chat input for the user to edit and resubmit.
+// forkSession creates a new session whose history is a deep copy of
+// an existing session up to (but excluding) the Nth user message. The
+// new session uses a fork-numbered title and starts with no runtime
+// attached.
 func (s *Server) forkSession(c echo.Context) error {
 	var req api.ForkSessionRequest
 	if err := c.Bind(&req); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid request body: %v", err))
 	}
 
-	forked, err := s.sm.ForkSession(c.Request().Context(), c.Param("id"), req.MessageIndex)
+	forked, err := s.sm.ForkSession(c.Request().Context(), c.Param("id"), req.UserMessageIndex)
 	if err != nil {
 		switch {
-		case errors.Is(err, ErrForkInvalidMessage),
-			errors.Is(err, ErrForkOutOfRange),
+		case errors.Is(err, ErrForkOutOfRange),
 			errors.Is(err, ErrForkInSubSession):
 			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 		}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -201,9 +201,9 @@ func TestServer_UpdateSessionTitle(t *testing.T) {
 }
 
 // TestServer_ForkSession exercises the POST /api/sessions/:id/fork
-// endpoint end-to-end: a fork at a user message must return a new
-// session with the history before that message, a fork-numbered title,
-// and a fresh ID. Forking at a non-user message must be rejected with
+// endpoint end-to-end: a fork at the Nth user message must return a
+// new session with the history before that message, a fork-numbered
+// title, and a fresh ID. An out-of-range ordinal must be rejected with
 // 400 Bad Request.
 func TestServer_ForkSession(t *testing.T) {
 	t.Parallel()
@@ -225,10 +225,10 @@ func TestServer_ForkSession(t *testing.T) {
 
 	lnPath := startServerWithStore(t, ctx, prepareAgentsDir(t), store)
 
-	// Happy path: fork before the second user message (flat index 2).
+	// Happy path: fork before the second user message (ordinal 1).
 	resp := httpDo(t, ctx, http.MethodPost, lnPath,
 		"/api/sessions/"+parent.ID+"/fork",
-		api.ForkSessionRequest{MessageIndex: 2})
+		api.ForkSessionRequest{UserMessageIndex: 1})
 	var forked api.SessionResponse
 	unmarshal(t, resp, &forked)
 
@@ -245,19 +245,12 @@ func TestServer_ForkSession(t *testing.T) {
 	assert.Equal(t, forked.ID, fetched.ID)
 	assert.Equal(t, "Original (fork 1)", fetched.Title)
 
-	// Forking at the assistant message must be rejected with 400.
-	rejected := httpRaw(t, ctx, http.MethodPost, lnPath,
-		"/api/sessions/"+parent.ID+"/fork",
-		api.ForkSessionRequest{MessageIndex: 1})
-	assert.Equal(t, http.StatusBadRequest, rejected.StatusCode, rejected.body)
-
-	// Forking past the end of the visible list (no real "after the last
-	// message" full-clone shortcut) must also return 400, not 500. This
-	// pins the sentinel-driven classification so future error-message
-	// reshuffles can't silently flip the status code.
+	// Forking past the last user message (no "full clone" shortcut) must
+	// return 400, not 500. This pins the sentinel-driven classification so
+	// future error-message reshuffles can't silently flip the status code.
 	outOfRange := httpRaw(t, ctx, http.MethodPost, lnPath,
 		"/api/sessions/"+parent.ID+"/fork",
-		api.ForkSessionRequest{MessageIndex: 99})
+		api.ForkSessionRequest{UserMessageIndex: 99})
 	assert.Equal(t, http.StatusBadRequest, outOfRange.StatusCode, outOfRange.body)
 }
 

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -375,52 +375,24 @@ func (sm *SessionManager) CreateSession(ctx context.Context, sessionTemplate *se
 	return sess, sm.sessionStore.AddSession(ctx, sess)
 }
 
-// Sentinel errors returned by ForkSession. They are matched with
-// errors.Is by the HTTP handler to classify failures as 400 vs 500, so
-// rewording the error string later is safe — the classification stays
-// pinned to the sentinel rather than to the message text.
+// Sentinel errors returned by ForkSession. Matched via errors.Is by
+// the HTTP handler to classify failures as 400 vs 500, so the messages
+// can be reworded safely.
 var (
-	// ErrForkInvalidMessage is returned when the resolved fork point is
-	// not a user-role message (e.g. an assistant turn, a tool response,
-	// or a sub-session item).
-	ErrForkInvalidMessage = errors.New("fork point must be a user message")
-
-	// ErrForkOutOfRange is returned when the requested message index is
-	// outside the parent session's visible message list.
-	ErrForkOutOfRange = errors.New("fork message index out of range")
-
-	// ErrForkInSubSession is returned when the requested message index
-	// falls inside a sub-session, where positional forking would be
-	// ambiguous (a sub-session can carry many messages but the fork
-	// model is "stop before this user turn in the parent's timeline").
-	ErrForkInSubSession = errors.New("fork message index falls inside a sub-session")
+	ErrForkOutOfRange   = errors.New("fork user-message index out of range")
+	ErrForkInSubSession = errors.New("fork user-message index falls inside a sub-session")
 )
 
-// ForkSession creates a new session whose history is a deep copy of the
-// parent session up to (but excluding) the message at userMessageIndex, with
-// a fork-numbered title ("<parent> (fork N)"). The index refers to the flat,
-// user-visible message list returned by Session.GetAllMessages — the same
-// indexing that api.SessionResponse.Messages exposes to clients — so callers
-// do not need to know about the underlying Item slice.
+// ForkSession creates a new session whose history is a deep copy of
+// the parent session up to (but excluding) the Nth user message, with
+// a fork-numbered title ("<parent> (fork N)"). userMessageOrdinal
+// counts user-role messages in the flat list returned by
+// Session.GetAllMessages.
 //
-// The message at userMessageIndex must be a user-role message in the
-// parent's visible list; values outside `[0, visibleMessageCount)` return
-// ErrForkOutOfRange and non-user messages return ErrForkInvalidMessage.
-// The fork itself does not include that message, so a client can prefill
-// it into its chat input to let the user edit and resubmit.
-//
-// There is intentionally no "full clone" shortcut on this endpoint: every
-// fork must anchor at a real user turn so the resulting history ends
-// cleanly between a user message and its (excluded) follow-up. Callers
-// that need a whole-session duplicate should issue a separate request
-// targeting the index of the most recent user message.
-//
-// The read-then-write of the session store is serialised under sm.mux to
-// match the rest of the manager's mutating methods (DeleteSession,
-// RunSession, etc.). Without it, two concurrent fork requests on the
-// same parent would each see Title="foo", both compute "foo (fork 1)",
-// and produce two distinct sessions with the same auto-numbered title.
-func (sm *SessionManager) ForkSession(ctx context.Context, sessionID string, userMessageIndex int) (*session.Session, error) {
+// The read-then-write of the session store is serialised under sm.mux
+// to keep two concurrent forks on the same parent from racing on the
+// auto-numbered title.
+func (sm *SessionManager) ForkSession(ctx context.Context, sessionID string, userMessageOrdinal int) (*session.Session, error) {
 	sm.mux.Lock()
 	defer sm.mux.Unlock()
 
@@ -429,14 +401,9 @@ func (sm *SessionManager) ForkSession(ctx context.Context, sessionID string, use
 		return nil, err
 	}
 
-	itemIndex, err := flatMessageIndexToItemIndex(parent, userMessageIndex)
+	itemIndex, err := userMessageOrdinalToItemIndex(parent, userMessageOrdinal)
 	if err != nil {
 		return nil, err
-	}
-
-	item := parent.Messages[itemIndex]
-	if item.Message == nil || item.Message.Message.Role != chat.MessageRoleUser {
-		return nil, ErrForkInvalidMessage
 	}
 
 	forked, err := session.ForkSession(parent, itemIndex)
@@ -450,42 +417,47 @@ func (sm *SessionManager) ForkSession(ctx context.Context, sessionID string, use
 	return forked, nil
 }
 
-// flatMessageIndexToItemIndex maps an index in the flat user-visible message
-// list (Session.GetAllMessages — which skips system messages and flattens
-// sub-sessions) into an index in the parent's Session.Messages Item slice.
-// Returns ErrForkOutOfRange if the index is outside the visible list, or
-// ErrForkInSubSession if the index lands inside a sub-session, where
-// positional forking would be ambiguous.
-func flatMessageIndexToItemIndex(s *session.Session, flatIdx int) (int, error) {
-	if flatIdx < 0 {
-		return 0, fmt.Errorf("%w: %d", ErrForkOutOfRange, flatIdx)
+// userMessageOrdinalToItemIndex maps a 0-based user-message ordinal
+// into an index in the parent's Session.Messages Item slice. Returns
+// ErrForkOutOfRange or ErrForkInSubSession on invalid input.
+func userMessageOrdinalToItemIndex(s *session.Session, ordinal int) (int, error) {
+	if ordinal < 0 {
+		return 0, fmt.Errorf("%w: %d", ErrForkOutOfRange, ordinal)
 	}
 	seen := 0
 	for i, item := range s.Messages {
 		switch {
 		case item.IsMessage():
-			// GetAllMessages filters out system messages; mirror that here
-			// so the flat index lines up with what the client sees.
+			// Mirror GetAllMessages: system messages don't count.
 			if item.Message.Message.Role == chat.MessageRoleSystem {
 				continue
 			}
-			if seen == flatIdx {
+			if item.Message.Message.Role != chat.MessageRoleUser {
+				continue
+			}
+			if seen == ordinal {
 				return i, nil
 			}
 			seen++
 		case item.IsSubSession():
-			subCount := len(item.SubSession.GetAllMessages())
-			if flatIdx-seen < subCount {
-				return 0, fmt.Errorf("%w at index %d", ErrForkInSubSession, flatIdx)
+			subCount := countUserMessages(item.SubSession.GetAllMessages())
+			if subCount > 0 && ordinal-seen < subCount {
+				return 0, fmt.Errorf("%w at ordinal %d", ErrForkInSubSession, ordinal)
 			}
 			seen += subCount
 		}
 	}
-	// flatIdx must point at an existing visible message. Values at or
-	// past the end (including the "after the last message" full-clone
-	// shortcut that earlier revisions allowed) are now rejected so the
-	// user-role check in ForkSession can never be skipped.
-	return 0, fmt.Errorf("%w: %d", ErrForkOutOfRange, flatIdx)
+	return 0, fmt.Errorf("%w: %d", ErrForkOutOfRange, ordinal)
+}
+
+func countUserMessages(msgs []session.Message) int {
+	n := 0
+	for _, m := range msgs {
+		if m.Message.Role == chat.MessageRoleUser {
+			n++
+		}
+	}
+	return n
 }
 
 // GetSessions retrieves all sessions.

--- a/pkg/server/session_manager_test.go
+++ b/pkg/server/session_manager_test.go
@@ -393,8 +393,8 @@ func TestForkSession_CopiesHistoryBeforeUserMessage(t *testing.T) {
 
 	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
 
-	// Fork BEFORE the second user message (flat index 2).
-	forked, err := sm.ForkSession(ctx, parent.ID, 2)
+	// Fork BEFORE the second user message (user-message ordinal 1).
+	forked, err := sm.ForkSession(ctx, parent.ID, 1)
 	require.NoError(t, err)
 
 	assert.NotEqual(t, parent.ID, forked.ID, "fork must have a fresh session ID")
@@ -411,38 +411,10 @@ func TestForkSession_CopiesHistoryBeforeUserMessage(t *testing.T) {
 	assert.Equal(t, forked.ID, loaded.ID)
 }
 
-// TestForkSession_RejectsNonUserMessage pins the contract that fork is
-// only valid at a user-role message. Attempting to fork at an assistant
-// turn must fail with ErrForkInvalidMessage, regardless of where the
-// index points in the flat list.
-func TestForkSession_RejectsNonUserMessage(t *testing.T) {
-	t.Parallel()
-
-	ctx := t.Context()
-	store := session.NewInMemorySessionStore()
-	parent := session.New()
-	parent.Messages = []session.Item{
-		session.NewMessageItem(session.UserMessage("hello")),
-		session.NewMessageItem(session.NewAgentMessage("root", &chat.Message{
-			Role:    chat.MessageRoleAssistant,
-			Content: "hi",
-		})),
-	}
-	require.NoError(t, store.AddSession(ctx, parent))
-
-	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
-
-	// Index 1 points at the assistant message in the flat list — must be
-	// rejected even though the position is otherwise valid.
-	_, err := sm.ForkSession(ctx, parent.ID, 1)
-	require.ErrorIs(t, err, ErrForkInvalidMessage)
-}
-
-// TestForkSession_OutOfRange covers the validation boundary: a negative
-// index, an index past the end of the visible message list, and the
-// "after the last message" position must all fail with ErrForkOutOfRange
-// without touching the store. The end-of-list case is the regression
-// guard for the dropped full-clone shortcut.
+// TestForkSession_OutOfRange covers the validation boundary: negative,
+// past-the-end, and equal-to-count ordinals must all fail with
+// ErrForkOutOfRange. The equal-to-count case is the regression guard
+// for the dropped full-clone shortcut.
 func TestForkSession_OutOfRange(t *testing.T) {
 	t.Parallel()
 
@@ -460,8 +432,9 @@ func TestForkSession_OutOfRange(t *testing.T) {
 	_, err = sm.ForkSession(ctx, parent.ID, 5)
 	require.ErrorIs(t, err, ErrForkOutOfRange)
 
-	// Equal to the visible-message count: previously a silent full clone,
-	// now an explicit ErrForkOutOfRange so the role check can't be bypassed.
+	// Equal to the visible user-message count: previously a silent full
+	// clone, now an explicit ErrForkOutOfRange so the contract stays
+	// "anchor on a real user turn".
 	_, err = sm.ForkSession(ctx, parent.ID, 1)
 	require.ErrorIs(t, err, ErrForkOutOfRange)
 }
@@ -495,41 +468,41 @@ func TestForkSession_DeepCopyIsolatesParent(t *testing.T) {
 		"mutating the fork must not affect the parent")
 }
 
-// TestFlatMessageIndexToItemIndex covers the index translation helper in
-// isolation, including the system-message skip rule that mirrors
-// Session.GetAllMessages.
-func TestFlatMessageIndexToItemIndex(t *testing.T) {
+// TestUserMessageOrdinalToItemIndex covers the ordinal translation
+// helper: only user-role messages count; system and assistant items
+// are skipped; out-of-range ordinals are rejected.
+func TestUserMessageOrdinalToItemIndex(t *testing.T) {
 	t.Parallel()
 
 	sess := session.New()
-	// Items: [user(0), system(skipped), user(1)]. From a client's
-	// perspective the flat indexing is 0 → user "u1", 1 → user "u2".
+	// Items 0..3: user, system, assistant, user. Ordinal 0 → item 0,
+	// ordinal 1 → item 3.
 	sess.Messages = []session.Item{
 		session.NewMessageItem(session.UserMessage("u1")),
 		session.NewMessageItem(&session.Message{
 			Message: chat.Message{Role: chat.MessageRoleSystem, Content: "sys"},
 		}),
+		session.NewMessageItem(session.NewAgentMessage("root", &chat.Message{
+			Role:    chat.MessageRoleAssistant,
+			Content: "a1",
+		})),
 		session.NewMessageItem(session.UserMessage("u2")),
 	}
 
-	idx, err := flatMessageIndexToItemIndex(sess, 0)
+	idx, err := userMessageOrdinalToItemIndex(sess, 0)
 	require.NoError(t, err)
 	assert.Equal(t, 0, idx)
 
-	idx, err = flatMessageIndexToItemIndex(sess, 1)
+	idx, err = userMessageOrdinalToItemIndex(sess, 1)
 	require.NoError(t, err)
-	assert.Equal(t, 2, idx, "flat index 1 must skip past the system item")
+	assert.Equal(t, 3, idx, "ordinal 1 must skip past the system and assistant items")
 
-	// Past the end is rejected, including the "after the last message"
-	// position that earlier revisions accepted as a full-clone shortcut.
-	// Forks must anchor on a real user turn so the role validation in
-	// ForkSession is never bypassed.
-	_, err = flatMessageIndexToItemIndex(sess, 2)
+	_, err = userMessageOrdinalToItemIndex(sess, 2)
 	require.ErrorIs(t, err, ErrForkOutOfRange)
 
-	_, err = flatMessageIndexToItemIndex(sess, -1)
+	_, err = userMessageOrdinalToItemIndex(sess, -1)
 	require.ErrorIs(t, err, ErrForkOutOfRange)
 
-	_, err = flatMessageIndexToItemIndex(sess, 3)
+	_, err = userMessageOrdinalToItemIndex(sess, 99)
 	require.ErrorIs(t, err, ErrForkOutOfRange)
 }


### PR DESCRIPTION
## Why

The fork endpoint currently takes a flat-list index into the session's mixed-role message stream (user + assistant + tool, system filtered, sub-sessions flattened). To target "the Nth user message the user clicked on", a client has to translate that intent into a flat index by mirroring the rules the server applies — skip system messages, count tool responses, recurse into sub-sessions.

A streaming client can't reliably do that translation: at the moment a user message lands in the UI, the tool calls and responses that will follow it on the server haven't happened yet, so the client has no way to know what flat index the server will eventually assign. The result is that fork is unavailable on just-sent messages until the client refetches the session.

## What changes

The request body changes from `message_index` (flat-list index) to `user_message_index` (0-based ordinal counting only user-role messages in the same visible list). The targeted user message is still excluded so the client can prefill it into chat input.

```
flat list:   user  assistant  tool  user  assistant  user
             ────  ─────────  ────  ────  ─────────  ────
old index:    0       1        2    3        4        5
ordinal:      0                     1                 2
```

Fork at ordinal 1 = fork before the second user message — same semantics as the previous "fork at flat index 3".

Backwards-incompatible wire change. The previous shape returned 400 for an assistant-targeted index; the new shape can't express that ambiguity, so `ErrForkInvalidMessage` is dropped.