### PR TITLE
feat: add retry button to TUI error messages

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -619,10 +619,20 @@ func (a *App) processInlineAttachment(att messages.Attachment, textBuilder *stri
 // user message. It is used to resume the conversation after an error: the
 // session already holds the messages exchanged so far, so RunStream picks up
 // from where it left off.
+//
+// RunStream re-emits a UserMessageEvent for the trailing session message at
+// startup (before StreamStarted) whenever SendUserMessage is set. On retry
+// that message is already displayed, so forwarding the re-emission would
+// duplicate the user bubble — or, when the tail is a tool/assistant message,
+// render non-user content inside a spurious user bubble. We suppress any
+// UserMessageEvent observed before StreamStarted to drop exactly that
+// re-emission; genuine user messages injected mid-run (steer / follow-up)
+// arrive after StreamStarted and are forwarded normally.
 func (a *App) Retry(ctx context.Context, cancel context.CancelFunc) {
 	a.cancel = cancel
 
 	go func() { //nolint:gosec // background processing intentionally continues after request ctx ends; uses context.Background() only to forward StreamStoppedEvent
+		streamStarted := false
 		for event := range a.runtime.RunStream(ctx, a.session) {
 			// If context is cancelled, continue draining but don't forward events
 			// — except StreamStoppedEvent, which must always propagate so the
@@ -632,6 +642,15 @@ func (a *App) Retry(ctx context.Context, cancel context.CancelFunc) {
 					a.sendEvent(context.Background(), event)
 				}
 				continue
+			}
+
+			switch event.(type) {
+			case *runtime.StreamStartedEvent:
+				streamStarted = true
+			case *runtime.UserMessageEvent:
+				if !streamStarted {
+					continue
+				}
 			}
 
 			if _, ok := event.(*runtime.SessionTitleEvent); ok {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -615,6 +615,34 @@ func (a *App) processInlineAttachment(att messages.Attachment, textBuilder *stri
 	fmt.Fprintf(textBuilder, "<attached_file path=%q>\n%s\n</attached_file>", att.Name, att.Content)
 }
 
+// Retry re-runs the agent loop on the current session without adding a new
+// user message. It is used to resume the conversation after an error: the
+// session already holds the messages exchanged so far, so RunStream picks up
+// from where it left off.
+func (a *App) Retry(ctx context.Context, cancel context.CancelFunc) {
+	a.cancel = cancel
+
+	go func() { //nolint:gosec // background processing intentionally continues after request ctx ends; uses context.Background() only to forward StreamStoppedEvent
+		for event := range a.runtime.RunStream(ctx, a.session) {
+			// If context is cancelled, continue draining but don't forward events
+			// — except StreamStoppedEvent, which must always propagate so the
+			// supervisor can mark the session as no longer running.
+			if ctx.Err() != nil {
+				if _, ok := event.(*runtime.StreamStoppedEvent); ok {
+					a.sendEvent(context.Background(), event)
+				}
+				continue
+			}
+
+			if _, ok := event.(*runtime.SessionTitleEvent); ok {
+				a.titleGenerating.Store(false)
+			}
+
+			a.sendEvent(ctx, event)
+		}
+	}()
+}
+
 // RunWithMessage runs the agent loop with a pre-constructed message.
 // This is used for special cases like image attachments.
 func (a *App) RunWithMessage(ctx context.Context, cancel context.CancelFunc, msg *session.Message) {

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -104,6 +104,69 @@ func (m *mockRuntime) OnToolsChanged(func(runtime.Event))                    {}
 // Verify mockRuntime implements runtime.Runtime
 var _ runtime.Runtime = (*mockRuntime)(nil)
 
+// retryMockRuntime mimics the real run loop's startup event ordering: it
+// re-emits a UserMessageEvent for the session's trailing message BEFORE
+// StreamStarted (exactly what LocalRuntime.runStreamLoop does when
+// SendUserMessage is set), then a StreamStopped. Used to verify App.Retry
+// suppresses the pre-StreamStarted re-emission.
+type retryMockRuntime struct {
+	mockRuntime
+}
+
+func (m *retryMockRuntime) RunStream(_ context.Context, sess *session.Session) <-chan runtime.Event {
+	ch := make(chan runtime.Event, 8)
+	go func() {
+		defer close(ch)
+		// Re-emitted user message (pre-StreamStarted): must be suppressed.
+		ch <- runtime.UserMessage("hello", sess.ID, nil, 0)
+		ch <- runtime.StreamStarted(sess.ID, "mock")
+		// A genuine mid-run user message (post-StreamStarted): must pass through.
+		ch <- runtime.UserMessage("steered", sess.ID, nil, 1)
+		ch <- runtime.StreamStopped(sess.ID, "mock", "normal")
+	}()
+	return ch
+}
+
+func TestApp_Retry_SuppressesReEmittedUserMessage(t *testing.T) {
+	t.Parallel()
+
+	events := make(chan tea.Msg, 16)
+	app := &App{
+		runtime: &retryMockRuntime{},
+		session: session.New(),
+		events:  events,
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	app.Retry(ctx, cancel)
+
+	var userMessages []string
+	var sawStreamStarted, sawStreamStopped bool
+	deadline := time.After(2 * time.Second)
+	for !sawStreamStopped {
+		select {
+		case ev := <-events:
+			switch e := ev.(type) {
+			case *runtime.UserMessageEvent:
+				userMessages = append(userMessages, e.Message)
+			case *runtime.StreamStartedEvent:
+				sawStreamStarted = true
+			case *runtime.StreamStoppedEvent:
+				sawStreamStopped = true
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for StreamStopped")
+		}
+	}
+
+	assert.True(t, sawStreamStarted, "StreamStarted should be forwarded")
+	// The pre-StreamStarted re-emission is dropped; the post-StreamStarted
+	// (steered) user message is kept.
+	assert.Equal(t, []string{"steered"}, userMessages,
+		"only the post-StreamStarted user message should be forwarded")
+}
+
 // stubSnapshotController is a tiny SnapshotController used by the app
 // tests to drive /undo without spinning up a real shadow-git
 // repository. enabled gates SnapshotsEnabled(), and the (files, ok,

--- a/pkg/tui/components/message/message.go
+++ b/pkg/tui/components/message/message.go
@@ -387,7 +387,11 @@ func (mv *messageModel) render(width int) string {
 		}
 		return messageStyle.Width(width - 1).Render(strings.TrimRight(rendered, "\n\r\t "))
 	case types.MessageTypeError:
-		return styles.ErrorMessageStyle.Width(width - 1).Render(msg.Content)
+		// Render the error content with a clickable retry affordance on its own
+		// trailing line so the user can resume the conversation after a failure.
+		retryHint := styles.MutedStyle.Render(types.ErrorRetryLabel)
+		content := msg.Content + "\n\n" + retryHint
+		return styles.ErrorMessageStyle.Width(width - 1).Render(content)
 	case types.MessageTypeLoading:
 		// Show spinner with the loading description, truncated to fit width
 		spinnerView := mv.spinner.View()

--- a/pkg/tui/components/message/message_test.go
+++ b/pkg/tui/components/message/message_test.go
@@ -52,6 +52,18 @@ func TestErrorMessageWrapping(t *testing.T) {
 	}
 }
 
+func TestErrorMessageShowsRetryAffordance(t *testing.T) {
+	t.Parallel()
+
+	msg := types.Error("Something went wrong")
+	mv := New(msg, nil)
+	mv.SetSize(80, 0)
+
+	plainRendered := stripANSI(mv.View())
+	assert.Contains(t, plainRendered, "Something went wrong")
+	assert.Contains(t, plainRendered, types.ErrorRetryLabel)
+}
+
 func TestErrorMessageWithShortContent(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tui/components/messages/messages.go
+++ b/pkg/tui/components/messages/messages.go
@@ -337,6 +337,10 @@ func (m *model) handleMouseClick(msg tea.MouseClickMsg) (layout.Model, tea.Cmd) 
 			cmd := m.copyMessageToClipboard(msgIdx)
 			return m, cmd
 		}
+
+		if m.isRetryLabelClick(msgIdx, localLine, col) {
+			return m, core.CmdHandler(messages.RetryMsg{})
+		}
 	}
 
 	if url := m.urlAt(line, col); url != "" {
@@ -1900,6 +1904,34 @@ func (m *model) isCopyLabelClick(msgIdx, localLine, col int) bool {
 
 	labelStart := ansi.StringWidth(before)
 	labelEnd := labelStart + ansi.StringWidth(types.AssistantMessageCopyLabel)
+	return col >= labelStart && col < labelEnd
+}
+
+// isRetryLabelClick checks if the click is on the retry label of an error message.
+func (m *model) isRetryLabelClick(msgIdx, localLine, col int) bool {
+	if msgIdx < 0 || msgIdx >= len(m.messages) {
+		return false
+	}
+	if m.messages[msgIdx].Type != types.MessageTypeError {
+		return false
+	}
+	if msgIdx >= len(m.views) {
+		return false
+	}
+
+	item := m.renderItem(msgIdx, m.views[msgIdx])
+	if localLine < 0 || localLine >= len(item.lines) {
+		return false
+	}
+
+	plainLine := ansi.Strip(item.lines[localLine])
+	before, _, ok := strings.Cut(plainLine, types.ErrorRetryLabel)
+	if !ok {
+		return false
+	}
+
+	labelStart := ansi.StringWidth(before)
+	labelEnd := labelStart + ansi.StringWidth(types.ErrorRetryLabel)
 	return col >= labelStart && col < labelEnd
 }
 

--- a/pkg/tui/components/messages/messages_test.go
+++ b/pkg/tui/components/messages/messages_test.go
@@ -55,6 +55,39 @@ func TestMouseClickOnURLOpensURL(t *testing.T) {
 	assert.Equal(t, "https://example.com", msg.URL)
 }
 
+func TestMouseClickOnRetryLabelEmitsRetryMsg(t *testing.T) {
+	t.Parallel()
+
+	m := NewScrollableView(80, 24, &service.SessionState{}).(*model)
+	m.SetSize(80, 24)
+
+	// Add an error message which renders a clickable retry affordance.
+	m.AddErrorMessage("boom")
+
+	// Render to populate line offsets and item caches.
+	m.View()
+
+	// Locate the retry label within the rendered error message.
+	var line, col int
+	found := false
+	for i, rendered := range m.renderedLines {
+		plain := ansi.Strip(rendered)
+		if before, _, ok := strings.Cut(plain, types.ErrorRetryLabel); ok {
+			line = i
+			col = ansi.StringWidth(before)
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "retry label should be rendered")
+
+	_, cmd := m.handleMouseClick(tea.MouseClickMsg{X: col, Y: line, Button: tea.MouseLeft})
+	require.NotNil(t, cmd)
+
+	_, ok := cmd().(tuimessages.RetryMsg)
+	assert.True(t, ok, "clicking retry should emit RetryMsg")
+}
+
 func TestLoadFromSessionIncludesReasoningContent(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tui/messages/edit.go
+++ b/pkg/tui/messages/edit.go
@@ -19,6 +19,10 @@ type BranchFromEditMsg struct {
 // This is emitted when bindings change (e.g., entering/exiting inline edit mode).
 type InvalidateStatusBarMsg struct{}
 
+// RetryMsg requests re-running the agent turn after an error, resuming the
+// conversation from where it left off without adding a new user message.
+type RetryMsg struct{}
+
 // FocusPanel identifies a focusable panel in the TUI.
 type FocusPanel int
 

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -385,6 +385,9 @@ func (p *chatPage) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		slog.Debug(msg.Content)
 		return p.handleSendMsg(msg)
 
+	case msgtypes.RetryMsg:
+		return p.handleRetry()
+
 	case msgtypes.ToggleHideToolResultsMsg:
 		// Forward to messages component to invalidate cache and trigger redraw
 		model, cmd := p.messages.Update(messages.ToggleHideToolResultsMsg{})
@@ -935,6 +938,35 @@ func (p *chatPage) processMessage(msg msgtypes.SendMsg) tea.Cmd {
 	}()
 
 	return tea.Batch(p.messages.ScrollToBottom(), spinnerCmd, loadingCmd)
+}
+
+// handleRetry re-runs the agent turn after an error, resuming the conversation
+// from the current session state without adding a new user message.
+func (p *chatPage) handleRetry() (layout.Model, tea.Cmd) {
+	if p.app == nil || p.app.IsReadOnly() {
+		return p, notification.WarningCmd("Session is read-only. No new messages can be sent.")
+	}
+
+	// Ignore retry requests while a turn is already in flight.
+	if p.working {
+		return p, nil
+	}
+
+	if p.msgCancel != nil {
+		p.msgCancel()
+	}
+
+	p.streamDepth = 0
+	p.agentStack = nil
+	p.sidebar.ResetStreamTracking()
+
+	var ctx context.Context
+	ctx, p.msgCancel = context.WithCancel(context.Background())
+
+	spinnerCmd := p.setWorking(true)
+	p.app.Retry(ctx, p.msgCancel)
+
+	return p, tea.Batch(p.messages.ScrollToBottom(), spinnerCmd)
 }
 
 // CompactSession generates a summary and compacts the session history

--- a/pkg/tui/types/types.go
+++ b/pkg/tui/types/types.go
@@ -27,6 +27,7 @@ const (
 const (
 	UserMessageEditLabel      = "✎"
 	AssistantMessageCopyLabel = "⎘"
+	ErrorRetryLabel           = "↻ retry"
 )
 
 const (


### PR DESCRIPTION
## What

Adds a clickable **↻ retry** button to error messages in the TUI. When an agent turn fails (fatal model error, hook block, loop detection, tool-setup failure), the user can click the button to resume the conversation from where it left off — without retyping the last message.

## Why

Previously, when the TUI showed an error in the messages view, there was no way to continue the conversation after a failure. The user had to re-enter their message manually. This adds a one-click recovery path.

## How

- `pkg/tui/types/types.go`: new `ErrorRetryLabel` ("↻ retry") constant.
- `pkg/tui/components/message/message.go`: error messages render the retry affordance on a trailing line.
- `pkg/tui/messages/edit.go`: new `RetryMsg` event.
- `pkg/tui/components/messages/messages.go`: `isRetryLabelClick` detects clicks on the label and emits `RetryMsg`.
- `pkg/app/app.go`: new `App.Retry` re-runs `RunStream` on the existing session (no new user message), so the conversation continues from where it stopped.
- `pkg/tui/page/chat/chat.go`: handles `RetryMsg` — starts a fresh cancel context, resets stream tracking, shows the working spinner, and calls `App.Retry`. Guards against read-only sessions and in-flight turns.

## Notable bug fixed during review

`RunStream` re-emits a `UserMessageEvent` for the trailing session message *before* `StreamStarted` whenever `SendUserMessage` is set. On retry this would duplicate the user bubble already on screen — or, when the tail is a tool/assistant message, render non-user content inside a spurious user bubble. `App.Retry` now suppresses any `UserMessageEvent` observed before `StreamStarted`, while still forwarding genuine mid-run user messages (steer / follow-up) that arrive afterward.

## Testing

- New unit tests:
  - `TestErrorMessageShowsRetryAffordance` (message rendering)
  - `TestMouseClickOnRetryLabelEmitsRetryMsg` (click detection)
  - `TestApp_Retry_SuppressesReEmittedUserMessage` (re-emission suppression)
- `task lint` → 0 issues
- `task test` → all green