### PR TITLE
feat(server): bump fork suffix across sibling forks

### DIFF
--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -411,6 +411,18 @@ func (sm *SessionManager) ForkSession(ctx context.Context, sessionID string, use
 		return nil, err
 	}
 
+	// Sibling-aware title so repeated forks of the same parent get
+	// (fork 1), (fork 2), … instead of colliding on (fork 1).
+	siblings, err := sm.sessionStore.GetSessions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	siblingTitles := make([]string, 0, len(siblings))
+	for _, s := range siblings {
+		siblingTitles = append(siblingTitles, s.Title)
+	}
+	forked.Title = session.NextForkTitle(parent.Title, siblingTitles)
+
 	if err := sm.sessionStore.AddSession(ctx, forked); err != nil {
 		return nil, err
 	}

--- a/pkg/server/session_manager_test.go
+++ b/pkg/server/session_manager_test.go
@@ -411,6 +411,50 @@ func TestForkSession_CopiesHistoryBeforeUserMessage(t *testing.T) {
 	assert.Equal(t, forked.ID, loaded.ID)
 }
 
+// Regression: repeated forks of the same parent must pick (fork 1),
+// (fork 2), (fork 3) rather than three copies of (fork 1).
+func TestForkSession_TitleIncrementsAcrossSiblings(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := session.NewInMemorySessionStore()
+	parent := session.New()
+	parent.Title = "Original"
+	parent.Messages = []session.Item{
+		session.NewMessageItem(session.UserMessage("u1")),
+		session.NewMessageItem(session.NewAgentMessage("root", &chat.Message{
+			Role:    chat.MessageRoleAssistant,
+			Content: "a1",
+		})),
+		session.NewMessageItem(session.UserMessage("u2")),
+		session.NewMessageItem(session.NewAgentMessage("root", &chat.Message{
+			Role:    chat.MessageRoleAssistant,
+			Content: "a2",
+		})),
+		session.NewMessageItem(session.UserMessage("u3")),
+	}
+	require.NoError(t, store.AddSession(ctx, parent))
+
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+
+	fork1, err := sm.ForkSession(ctx, parent.ID, 0)
+	require.NoError(t, err)
+	assert.Equal(t, "Original (fork 1)", fork1.Title)
+
+	fork2, err := sm.ForkSession(ctx, parent.ID, 1)
+	require.NoError(t, err)
+	assert.Equal(t, "Original (fork 2)", fork2.Title)
+
+	fork3, err := sm.ForkSession(ctx, parent.ID, 2)
+	require.NoError(t, err)
+	assert.Equal(t, "Original (fork 3)", fork3.Title)
+
+	// Forking a fork shares the counter rather than restarting at 1.
+	forkOfFork, err := sm.ForkSession(ctx, fork2.ID, 0)
+	require.NoError(t, err)
+	assert.Equal(t, "Original (fork 4)", forkOfFork.Title)
+}
+
 // TestForkSession_OutOfRange covers the validation boundary: negative,
 // past-the-end, and equal-to-count ordinals must all fail with
 // ErrForkOutOfRange. The equal-to-count case is the regression guard

--- a/pkg/session/branch.go
+++ b/pkg/session/branch.go
@@ -245,6 +245,33 @@ func generateForkTitle(parentTitle string) string {
 	return parentTitle + " (fork 1)"
 }
 
+// NextForkTitle returns the next free "<root> (fork N)" title for a
+// fork of parentTitle. Forks descending from the same root share a
+// single counter scanned out of siblingTitles. Returns empty for an
+// empty parentTitle so the caller's auto-title path kicks in.
+func NextForkTitle(parentTitle string, siblingTitles []string) string {
+	if parentTitle == "" {
+		return ""
+	}
+	baseTitle := parentTitle
+	if m := forkSuffixRe.FindStringSubmatch(parentTitle); m != nil {
+		baseTitle = m[1]
+	}
+	siblingRe := regexp.MustCompile(`^` + regexp.QuoteMeta(baseTitle) + `[ \t]*\(fork (\d+)\)$`)
+	highest := 0
+	for _, t := range siblingTitles {
+		m := siblingRe.FindStringSubmatch(t)
+		if m == nil {
+			continue
+		}
+		var n int
+		if _, err := fmt.Sscanf(m[1], "%d", &n); err == nil && n > highest {
+			highest = n
+		}
+	}
+	return fmt.Sprintf("%s (fork %d)", baseTitle, highest+1)
+}
+
 func cloneEvalCriteria(src *EvalCriteria) *EvalCriteria {
 	if src == nil {
 		return nil

--- a/pkg/session/branch_test.go
+++ b/pkg/session/branch_test.go
@@ -144,6 +144,58 @@ func TestGenerateForkTitle(t *testing.T) {
 	}
 }
 
+func TestNextForkTitle(t *testing.T) {
+	tests := []struct {
+		name        string
+		parentTitle string
+		siblings    []string
+		expected    string
+	}{
+		{
+			name:        "empty parent title returns empty",
+			parentTitle: "",
+			siblings:    []string{"Other"},
+			expected:    "",
+		},
+		{
+			name:        "no siblings: starts at fork 1",
+			parentTitle: "My Session",
+			siblings:    []string{},
+			expected:    "My Session (fork 1)",
+		},
+		{
+			name:        "ignores unrelated siblings, picks next free N",
+			parentTitle: "My Session",
+			siblings:    []string{"My Session (fork 1)", "Unrelated", "My Session (fork 2)"},
+			expected:    "My Session (fork 3)",
+		},
+		{
+			name:        "parent already has (fork N), counter rooted on base title",
+			parentTitle: "My Session (fork 2)",
+			siblings:    []string{"My Session (fork 1)", "My Session (fork 2)"},
+			expected:    "My Session (fork 3)",
+		},
+		{
+			name:        "gaps in fork numbering are tolerated, picks max+1",
+			parentTitle: "My Session",
+			siblings:    []string{"My Session (fork 1)", "My Session (fork 5)"},
+			expected:    "My Session (fork 6)",
+		},
+		{
+			name:        "mid-title (fork N) is not a sibling",
+			parentTitle: "Q1 Analysis",
+			siblings:    []string{"Q1 (fork 2) Analysis"},
+			expected:    "Q1 Analysis (fork 1)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, NextForkTitle(tt.parentTitle, tt.siblings))
+		})
+	}
+}
+
 func TestCloneSessionItem(t *testing.T) {
 	t.Run("empty item returns error", func(t *testing.T) {
 		_, err := cloneSessionItem(Item{})


### PR DESCRIPTION
## Why

`generateForkTitle` only looks at the parent's own title, so forking the same parent from different cut points produced N copies of `<parent> (fork 1)` instead of `(fork 1)`, `(fork 2)`, `(fork 3)`. The title increment only kicks in when you fork a fork — and even then only off the immediate parent's suffix, so it's still possible to collide with an unrelated existing sibling.

## What changes

`ForkSession` now picks the next free `(fork N)` suffix by scanning sibling titles in the session store under `sm.mux`. Forks descending from the same root title share a single counter, so re-forking the original or forking a fork keeps producing fresh, monotonically-increasing numbers.

```
parent           fork at u1     fork at u2     fork at u3
─────────        ──────────     ──────────     ──────────
Original   →     (fork 1)       (fork 2)       (fork 3)

fork of fork (any cut point):
Original (fork 2) → Original (fork 4)
```

`NextForkTitle(parentTitle, siblingTitles)` is exported so other call sites can opt into the same sibling-aware behaviour later.