### PR TITLE
fix: persist MCP OAuth tokens in sandboxes via file-backed keyring fallback (#3037)

### DIFF
--- a/pkg/tools/mcp/keyringstore/tokenstore.go
+++ b/pkg/tools/mcp/keyringstore/tokenstore.go
@@ -140,18 +140,29 @@ var defaultStore = sync.OnceValue(func() mcp.OAuthTokenStore {
 	if testing.Testing() {
 		return mcp.NewInMemoryTokenStore()
 	}
-	configDir := paths.GetConfigDir()
-	ring, err := openKeyring()
+	return buildDefaultStore(paths.GetConfigDir(), openKeyring, openFileKeyring)
+})
+
+// buildDefaultStore resolves the token store backend in order of preference:
+// the OS-native keyring, then a file-backed keyring under configDir, then an
+// in-memory store. The keyring openers are injected so the fallback ordering
+// can be exercised in tests without touching a real OS credential store.
+func buildDefaultStore(
+	configDir string,
+	openNative func() (keyring.Keyring, error),
+	openFallback func(string) (keyring.Keyring, error),
+) mcp.OAuthTokenStore {
+	ring, err := openNative()
 	if err != nil {
 		slog.Warn("OS keyring not available, falling back to file-based OAuth token store", "error", err)
-		ring, err = openFileKeyring(filepath.Join(configDir, fallbackKeyringDir))
+		ring, err = openFallback(filepath.Join(configDir, fallbackKeyringDir))
 		if err != nil {
 			slog.Warn("File-based keyring not available, falling back to in-memory token store", "error", err)
 			return mcp.NewInMemoryTokenStore()
 		}
 	}
 	return newKeyringTokenStore(ring, filepath.Join(configDir, tokenFileName))
-})
+}
 
 // Register installs the keyring-backed token store as the default for MCP
 // OAuth. The CLI calls this during startup; embedders that don't need

--- a/pkg/tools/mcp/keyringstore/tokenstore.go
+++ b/pkg/tools/mcp/keyringstore/tokenstore.go
@@ -51,6 +51,18 @@ const (
 	// dir alongside other docker-agent state.
 	tokenFileName = "mcp-oauth-tokens.enc"
 
+	// fallbackKeyringDir holds the file-backed keyring used when no OS-native
+	// credential store is available (e.g. inside a sandbox). It lives under
+	// the config dir next to the encrypted token file.
+	fallbackKeyringDir = "mcp-oauth-keyring"
+
+	// fallbackKeyringPassword seals the file-backed keyring. It is a fixed,
+	// non-secret value: the fallback's only real boundary is the 0700
+	// directory it lives in, which is the same boundary already protecting
+	// the encrypted token file beside it. It exists solely because the
+	// file backend requires a password function.
+	fallbackKeyringPassword = "docker-agent-oauth-fallback"
+
 	// Legacy keyring keys from the previous "bundle in the keyring"
 	// layout. Migrated into the encrypted file on first load, then removed.
 	legacyBundleKey   = "oauth:tokens"
@@ -74,12 +86,43 @@ type KeyringTokenStore struct {
 	loadErr error
 }
 
+// secureBackends lists the OS-native credential stores we trust. The generic
+// "file" and "pass" backends are deliberately excluded: their openers succeed
+// unconditionally, so leaving them in would mask a missing OS keyring (e.g.
+// inside a sandbox) and defer the failure to the first Get/Set, where it
+// surfaces as the opaque "No directory provided for file keyring" error.
+// Excluding them lets openKeyring return an error we can fall back from.
+var secureBackends = []keyring.BackendType{
+	keyring.WinCredBackend,
+	keyring.KeychainBackend,
+	keyring.SecretServiceBackend,
+	keyring.KWalletBackend,
+	keyring.KeyCtlBackend,
+}
+
 func openKeyring() (keyring.Keyring, error) {
 	return keyring.Open(keyring.Config{
 		ServiceName:                    keyringServiceName,
+		AllowedBackends:                secureBackends,
 		KeychainTrustApplication:       true,
 		KeychainSynchronizable:         false,
 		KeychainAccessibleWhenUnlocked: true,
+	})
+}
+
+// openFileKeyring returns a file-backed keyring rooted in dir, used when no
+// OS-native credential store is available. It persists the encryption key to
+// disk so OAuth tokens survive a restart inside a sandbox, where the in-memory
+// store would force a fresh login on every run.
+func openFileKeyring(dir string) (keyring.Keyring, error) {
+	if err := ensurePrivateDir(dir); err != nil {
+		return nil, err
+	}
+	return keyring.Open(keyring.Config{
+		ServiceName:      keyringServiceName,
+		AllowedBackends:  []keyring.BackendType{keyring.FileBackend},
+		FileDir:          dir,
+		FilePasswordFunc: keyring.FixedStringPrompt(fallbackKeyringPassword),
 	})
 }
 
@@ -97,12 +140,17 @@ var defaultStore = sync.OnceValue(func() mcp.OAuthTokenStore {
 	if testing.Testing() {
 		return mcp.NewInMemoryTokenStore()
 	}
+	configDir := paths.GetConfigDir()
 	ring, err := openKeyring()
 	if err != nil {
-		slog.Warn("OS keyring not available, falling back to in-memory token store", "error", err)
-		return mcp.NewInMemoryTokenStore()
+		slog.Warn("OS keyring not available, falling back to file-based OAuth token store", "error", err)
+		ring, err = openFileKeyring(filepath.Join(configDir, fallbackKeyringDir))
+		if err != nil {
+			slog.Warn("File-based keyring not available, falling back to in-memory token store", "error", err)
+			return mcp.NewInMemoryTokenStore()
+		}
 	}
-	return newKeyringTokenStore(ring, filepath.Join(paths.GetConfigDir(), tokenFileName))
+	return newKeyringTokenStore(ring, filepath.Join(configDir, tokenFileName))
 })
 
 // Register installs the keyring-backed token store as the default for MCP

--- a/pkg/tools/mcp/keyringstore/tokenstore.go
+++ b/pkg/tools/mcp/keyringstore/tokenstore.go
@@ -5,6 +5,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -56,12 +57,10 @@ const (
 	// the config dir next to the encrypted token file.
 	fallbackKeyringDir = "mcp-oauth-keyring"
 
-	// fallbackKeyringPassword seals the file-backed keyring. It is a fixed,
-	// non-secret value: the fallback's only real boundary is the 0700
-	// directory it lives in, which is the same boundary already protecting
-	// the encrypted token file beside it. It exists solely because the
-	// file backend requires a password function.
-	fallbackKeyringPassword = "docker-agent-oauth-fallback"
+	// fallbackPassphraseFile holds the passphrase that seals the file-backed
+	// keyring. It lives inside fallbackKeyringDir, behind the same 0700
+	// boundary as the keyring itself.
+	fallbackPassphraseFile = "passphrase"
 
 	// Legacy keyring keys from the previous "bundle in the keyring"
 	// layout. Migrated into the encrypted file on first load, then removed.
@@ -118,12 +117,47 @@ func openFileKeyring(dir string) (keyring.Keyring, error) {
 	if err := ensurePrivateDir(dir); err != nil {
 		return nil, err
 	}
+	passphrase, err := fileKeyringPassphrase(dir)
+	if err != nil {
+		return nil, err
+	}
 	return keyring.Open(keyring.Config{
 		ServiceName:      keyringServiceName,
 		AllowedBackends:  []keyring.BackendType{keyring.FileBackend},
 		FileDir:          dir,
-		FilePasswordFunc: keyring.FixedStringPrompt(fallbackKeyringPassword),
+		FilePasswordFunc: keyring.FixedStringPrompt(passphrase),
 	})
+}
+
+// fileKeyringPassphrase returns the passphrase sealing the file-backed
+// keyring, generating and persisting a random per-install value on first use.
+//
+// A random secret rather than a hardcoded constant means reading the source
+// code alone is not enough to decrypt the keyring: an attacker also needs read
+// access to the passphrase file, which lives behind the same owner-only
+// directory as the tokens. The directory remains the real security boundary;
+// this just removes the "public constant" foot-gun so each install is unique.
+func fileKeyringPassphrase(dir string) (string, error) {
+	path := filepath.Join(dir, fallbackPassphraseFile)
+	switch data, err := os.ReadFile(path); {
+	case err == nil:
+		if len(data) == 0 {
+			return "", fmt.Errorf("file keyring passphrase is empty: %s", path)
+		}
+		return string(data), nil
+	case errors.Is(err, os.ErrNotExist):
+		secret := make([]byte, encryptionKeySize)
+		if _, rerr := rand.Read(secret); rerr != nil {
+			return "", fmt.Errorf("failed to generate file keyring passphrase: %w", rerr)
+		}
+		encoded := []byte(hex.EncodeToString(secret))
+		if werr := atomicfile.Write(path, bytes.NewReader(encoded), 0o600); werr != nil {
+			return "", fmt.Errorf("failed to persist file keyring passphrase: %w", werr)
+		}
+		return string(encoded), nil
+	default:
+		return "", fmt.Errorf("failed to read file keyring passphrase: %w", err)
+	}
 }
 
 // defaultStore returns the process-wide token store, opening the OS
@@ -153,10 +187,10 @@ func buildDefaultStore(
 	openFallback func(string) (keyring.Keyring, error),
 ) mcp.OAuthTokenStore {
 	ring, err := openNative()
-	if err != nil {
+	if err != nil || ring == nil {
 		slog.Warn("OS keyring not available, falling back to file-based OAuth token store", "error", err)
 		ring, err = openFallback(filepath.Join(configDir, fallbackKeyringDir))
-		if err != nil {
+		if err != nil || ring == nil {
 			slog.Warn("File-based keyring not available, falling back to in-memory token store", "error", err)
 			return mcp.NewInMemoryTokenStore()
 		}

--- a/pkg/tools/mcp/keyringstore/tokenstore_test.go
+++ b/pkg/tools/mcp/keyringstore/tokenstore_test.go
@@ -701,6 +701,68 @@ func TestFileKeyringBackedStore_PersistsAcrossReload(t *testing.T) {
 	}
 }
 
+// TestBuildDefaultStore_PrefersNativeKeyring verifies the native keyring is
+// used when it opens successfully, without ever consulting the fallback.
+func TestBuildDefaultStore_PrefersNativeKeyring(t *testing.T) {
+	native := keyring.NewArrayKeyring(nil)
+	fallbackCalled := false
+
+	store := buildDefaultStore(t.TempDir(),
+		func() (keyring.Keyring, error) { return native, nil },
+		func(string) (keyring.Keyring, error) {
+			fallbackCalled = true
+			return nil, errors.New("should not be called")
+		},
+	)
+
+	if _, ok := store.(*KeyringTokenStore); !ok {
+		t.Fatalf("expected *KeyringTokenStore, got %T", store)
+	}
+	if fallbackCalled {
+		t.Error("fallback keyring must not be opened when the native keyring succeeds")
+	}
+}
+
+// TestBuildDefaultStore_FallsBackToFileKeyring verifies that when the native
+// keyring is unavailable (as inside a sandbox), the file-backed keyring is
+// used — the regression path for issue #3037.
+func TestBuildDefaultStore_FallsBackToFileKeyring(t *testing.T) {
+	fallback := keyring.NewArrayKeyring(nil)
+	var gotDir string
+
+	store := buildDefaultStore(t.TempDir(),
+		func() (keyring.Keyring, error) { return nil, errors.New("no OS keyring") },
+		func(dir string) (keyring.Keyring, error) {
+			gotDir = dir
+			return fallback, nil
+		},
+	)
+
+	ks, ok := store.(*KeyringTokenStore)
+	if !ok {
+		t.Fatalf("expected *KeyringTokenStore, got %T", store)
+	}
+	if ks.ring != fallback {
+		t.Error("expected the store to be backed by the fallback keyring")
+	}
+	if filepath.Base(gotDir) != fallbackKeyringDir {
+		t.Errorf("fallback dir = %q, want basename %q", gotDir, fallbackKeyringDir)
+	}
+}
+
+// TestBuildDefaultStore_FallsBackToMemory verifies the last-resort in-memory
+// store is used when neither keyring backend can be opened.
+func TestBuildDefaultStore_FallsBackToMemory(t *testing.T) {
+	store := buildDefaultStore(t.TempDir(),
+		func() (keyring.Keyring, error) { return nil, errors.New("no OS keyring") },
+		func(string) (keyring.Keyring, error) { return nil, errors.New("no file keyring") },
+	)
+
+	if _, ok := store.(*KeyringTokenStore); ok {
+		t.Fatal("expected in-memory store, got *KeyringTokenStore")
+	}
+}
+
 // TestKeyringTokenStore_ConcurrentAccess verifies that concurrent reads and
 // writes to the token store are safe and don't cause data races.
 func TestKeyringTokenStore_ConcurrentAccess(t *testing.T) {

--- a/pkg/tools/mcp/keyringstore/tokenstore_test.go
+++ b/pkg/tools/mcp/keyringstore/tokenstore_test.go
@@ -701,6 +701,56 @@ func TestFileKeyringBackedStore_PersistsAcrossReload(t *testing.T) {
 	}
 }
 
+// TestFileKeyringPassphrase_RandomAndPersistent verifies the file-keyring
+// passphrase is generated randomly on first use, persisted with owner-only
+// permissions, and reused on subsequent calls — so it is unique per install
+// rather than a hardcoded constant baked into the binary.
+func TestFileKeyringPassphrase_RandomAndPersistent(t *testing.T) {
+	dirA := filepath.Join(t.TempDir(), fallbackKeyringDir)
+	if err := ensurePrivateDir(dirA); err != nil {
+		t.Fatalf("ensurePrivateDir: %v", err)
+	}
+
+	first, err := fileKeyringPassphrase(dirA)
+	if err != nil {
+		t.Fatalf("fileKeyringPassphrase: %v", err)
+	}
+	if first == "" {
+		t.Fatal("passphrase must not be empty")
+	}
+
+	// A second call in the same dir must reuse the persisted passphrase.
+	second, err := fileKeyringPassphrase(dirA)
+	if err != nil {
+		t.Fatalf("fileKeyringPassphrase (reuse): %v", err)
+	}
+	if second != first {
+		t.Errorf("passphrase changed across calls: %q != %q", second, first)
+	}
+
+	// The passphrase file must be owner-only.
+	info, err := os.Stat(filepath.Join(dirA, fallbackPassphraseFile))
+	if err != nil {
+		t.Fatalf("Stat passphrase file: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("passphrase file permissions = %o, want 0600", perm)
+	}
+
+	// A different install dir must get a different passphrase.
+	dirB := filepath.Join(t.TempDir(), fallbackKeyringDir)
+	if err := ensurePrivateDir(dirB); err != nil {
+		t.Fatalf("ensurePrivateDir: %v", err)
+	}
+	other, err := fileKeyringPassphrase(dirB)
+	if err != nil {
+		t.Fatalf("fileKeyringPassphrase (dirB): %v", err)
+	}
+	if other == first {
+		t.Error("two independent installs must not share a passphrase")
+	}
+}
+
 // TestBuildDefaultStore_PrefersNativeKeyring verifies the native keyring is
 // used when it opens successfully, without ever consulting the fallback.
 func TestBuildDefaultStore_PrefersNativeKeyring(t *testing.T) {
@@ -760,6 +810,35 @@ func TestBuildDefaultStore_FallsBackToMemory(t *testing.T) {
 
 	if _, ok := store.(*KeyringTokenStore); ok {
 		t.Fatal("expected in-memory store, got *KeyringTokenStore")
+	}
+}
+
+// TestBuildDefaultStore_NilRingFallsThrough guards against a (nil, nil) return
+// from an opener: a nil keyring must be treated like an error and fall through
+// to the next tier rather than constructing a store that panics on first use.
+func TestBuildDefaultStore_NilRingFallsThrough(t *testing.T) {
+	fallback := keyring.NewArrayKeyring(nil)
+
+	// Native opener returns (nil, nil): must not be used, must fall through.
+	store := buildDefaultStore(t.TempDir(),
+		func() (keyring.Keyring, error) { return nil, nil },
+		func(string) (keyring.Keyring, error) { return fallback, nil },
+	)
+	ks, ok := store.(*KeyringTokenStore)
+	if !ok {
+		t.Fatalf("expected *KeyringTokenStore, got %T", store)
+	}
+	if ks.ring != fallback {
+		t.Error("a nil native ring must fall through to the fallback keyring")
+	}
+
+	// Both openers return (nil, nil): must land on the in-memory store.
+	memStore := buildDefaultStore(t.TempDir(),
+		func() (keyring.Keyring, error) { return nil, nil },
+		func(string) (keyring.Keyring, error) { return nil, nil },
+	)
+	if _, ok := memStore.(*KeyringTokenStore); ok {
+		t.Fatal("a nil fallback ring must fall through to the in-memory store")
 	}
 }
 

--- a/pkg/tools/mcp/keyringstore/tokenstore_test.go
+++ b/pkg/tools/mcp/keyringstore/tokenstore_test.go
@@ -631,6 +631,76 @@ func TestEncryptedStore_KeyringFailureIsCachedOnce(t *testing.T) {
 	}
 }
 
+// TestSecureBackendsExcludeGenericFile guards the fix for the sandbox failure:
+// the generic "file" and "pass" backends must never be in the secure list, or
+// openKeyring would silently return a half-broken backend instead of an error
+// the caller can fall back from.
+func TestSecureBackendsExcludeGenericFile(t *testing.T) {
+	for _, b := range secureBackends {
+		if b == keyring.FileBackend || b == keyring.PassBackend {
+			t.Fatalf("secureBackends must not contain the generic %q backend", b)
+		}
+	}
+}
+
+// TestOpenFileKeyring_Persists verifies the file-backed fallback used inside a
+// sandbox actually persists an item to disk and survives a reopen, so tokens
+// don't vanish between runs.
+func TestOpenFileKeyring_Persists(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), fallbackKeyringDir)
+
+	ring, err := openFileKeyring(dir)
+	if err != nil {
+		t.Fatalf("openFileKeyring: %v", err)
+	}
+	if err := ring.Set(keyring.Item{Key: encryptionKeyItem, Data: []byte("secret")}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	reopened, err := openFileKeyring(dir)
+	if err != nil {
+		t.Fatalf("reopen openFileKeyring: %v", err)
+	}
+	item, err := reopened.Get(encryptionKeyItem)
+	if err != nil {
+		t.Fatalf("Get after reopen: %v", err)
+	}
+	if string(item.Data) != "secret" {
+		t.Errorf("Data = %q, want %q", item.Data, "secret")
+	}
+}
+
+// TestFileKeyringBackedStore_PersistsAcrossReload exercises the full fallback
+// path a sandbox would take: a KeyringTokenStore backed by the file keyring
+// must round-trip tokens across a simulated process restart.
+func TestFileKeyringBackedStore_PersistsAcrossReload(t *testing.T) {
+	root := t.TempDir()
+	keyringDir := filepath.Join(root, fallbackKeyringDir)
+	tokenPath := filepath.Join(root, tokenFileName)
+
+	ring, err := openFileKeyring(keyringDir)
+	if err != nil {
+		t.Fatalf("openFileKeyring: %v", err)
+	}
+
+	const url = "https://mcp.notion.com/sse"
+	if err := newKeyringTokenStore(ring, tokenPath).StoreToken(url, &mcp.OAuthToken{AccessToken: "notion-token"}); err != nil {
+		t.Fatalf("StoreToken: %v", err)
+	}
+
+	reopened, err := openFileKeyring(keyringDir)
+	if err != nil {
+		t.Fatalf("reopen openFileKeyring: %v", err)
+	}
+	got, err := newKeyringTokenStore(reopened, tokenPath).GetToken(url)
+	if err != nil {
+		t.Fatalf("GetToken after reload: %v", err)
+	}
+	if got.AccessToken != "notion-token" {
+		t.Errorf("AccessToken = %q, want %q", got.AccessToken, "notion-token")
+	}
+}
+
 // TestKeyringTokenStore_ConcurrentAccess verifies that concurrent reads and
 // writes to the token store are safe and don't cause data races.
 func TestKeyringTokenStore_ConcurrentAccess(t *testing.T) {


### PR DESCRIPTION
## What

Fixes #3037 — remote MCP OAuth tokens cannot be stored when running inside a sandbox (`sbx`), because no OS keyring is available there.

## Why it failed

`keyring.Open()` was called with no backend restriction. The generic `file` backend's opener **always succeeds** (it just constructs a struct), so in a sandbox `openKeyring()` returned a half-broken file keyring with an empty `FileDir` instead of an error. The in-memory fallback was therefore never reached, and the first token write failed with the opaque `"No directory provided for file keyring"` error — so the agent failed to initialize after completing the OAuth flow.

## The fix

Backend resolution now follows a clear, layered order: **OS-native keyring → encrypted file-backed keyring → in-memory**.

1. **Restrict `openKeyring()` to secure OS-native backends** (`wincred`, `keychain`, `secret-service`, `kwallet`, `keyctl`) via `AllowedBackends`. The generic `file`/`pass` backends are excluded, so a missing OS keyring is now a detectable `Open` error we can act on instead of a deferred failure.
2. **Add `openFileKeyring(dir)`** — a persistent file-backed fallback rooted in a `0700` directory under the config dir. This lets OAuth tokens **survive sandbox restarts** rather than being lost (or forcing a fresh login) every run, which is the "fallback storage mechanism" the issue asks for.
3. **Wire the fallback into the default store**, with a final in-memory fallback if even the file keyring can't be opened. A `(nil, nil)` return from any opener is treated as a failure and falls through to the next tier, so the store can never be built around a nil keyring.

## Security model of the file-backed fallback

The file keyring is sealed with a **per-install random passphrase**, not a hardcoded constant: a random 32-byte secret is generated on first use and persisted to a `0600` `passphrase` file inside the keyring directory, then reused. This means reading the source code alone is not enough to decrypt the keyring — an attacker also needs read access to the install's passphrase file.

The owner-only `0700` directory remains the real security boundary (the same boundary already protecting the encrypted token file beside it). This tier is intentionally weaker than an OS keyring and is only used when no native store exists.

## Tests

- `secureBackends` excludes the generic `file`/`pass` backends.
- The file keyring persists and round-trips across reopen.
- Full token round-trip through the fallback path (using `https://mcp.notion.com/sse`).
- The file-keyring passphrase is random, persisted at `0600`, reused across calls, and unique per install dir.
- The `buildDefaultStore` ordering is exercised directly via injectable openers: native preferred, file fallback (the #3037 regression path), last-resort in-memory, and `(nil, nil)` rings falling through.

All tests, `golangci-lint`, and the custom linter pass cleanly.