### PR TITLE
feat: add key/value metadata to tool-call confirmation events

### DIFF
--- a/docs/configuration/hooks/index.md
+++ b/docs/configuration/hooks/index.md
@@ -334,6 +334,7 @@ The `hook_specific_output` for `pre_tool_use` (and `permission_request`) support
 | `permission_decision`        | string | `allow`, `deny`, or `ask`               |
 | `permission_decision_reason` | string | Explanation for the decision            |
 | `updated_input`              | object | Modified tool input (replaces original) |
+| `metadata`                   | object | (`permission_request` only) string key/value annotations merged onto the tool-call confirmation prompt — see below |
 
 ### Tool-Response-Transform Specific Output
 
@@ -727,6 +728,22 @@ hooks:
 ```
 
 Return nothing to fall through to the usual interactive confirmation.
+
+When the hook falls through (returns no `permission_decision`), it can still attach key/value `metadata` to the confirmation prompt the runtime shows the user. The runtime merges it onto any static metadata the toolset attached to the tool (hook keys win on a clash) and emits it on the tool-call confirmation message, so clients (TUI, HTTP) can render extra per-call context. Keys from multiple matching hooks are merged; the last hook in config order wins on a clash.
+
+```yaml
+hooks:
+  permission_request:
+    - matcher: "shell"
+      hooks:
+        - type: command
+          command: |
+            INPUT=$(cat)
+            CMD=$(echo "$INPUT" | jq -r '.tool_input.cmd // ""')
+            if echo "$CMD" | grep -qE '\brm\b'; then
+              echo '{"hook_specific_output":{"metadata":{"risk":"high","note":"deletes files"}}}'
+            fi
+```
 
 ### LLM as a Judge (Auto-Approving Tool Calls)
 

--- a/pkg/embeddedchat/embeddedchat_test.go
+++ b/pkg/embeddedchat/embeddedchat_test.go
@@ -124,7 +124,7 @@ func TestSessionSendSurfacesConfirmationAndConfirmResumesRuntime(t *testing.T) {
 
 	call := tools.ToolCall{ID: "call-1", Function: tools.FunctionCall{Name: "write_file"}}
 	def := tools.Tool{Name: "write_file"}
-	rt.events <- dagentruntime.ToolCallConfirmation(call, def, "agent")
+	rt.events <- dagentruntime.ToolCallConfirmation(call, def, "agent", nil)
 
 	event := receiveEvent(t, out)
 	require.NotNil(t, event.Tool)

--- a/pkg/hooks/aggregate_test.go
+++ b/pkg/hooks/aggregate_test.go
@@ -104,3 +104,48 @@ func TestAggregateDecisionEmptyForNonPreToolUse(t *testing.T) {
 	assert.Equal(t, Decision(""), final.Decision)
 	assert.Empty(t, final.DecisionReason)
 }
+
+// TestAggregateMergesPermissionRequestMetadata pins the metadata
+// contract for permission_request hooks: keys from every matching hook
+// are merged, and on a clash the later hook in config order wins (results
+// is iterated in registration order).
+func TestAggregateMergesPermissionRequestMetadata(t *testing.T) {
+	t.Parallel()
+
+	mk := func(meta map[string]string) hookResult {
+		return hookResult{HandlerResult: HandlerResult{Output: &Output{
+			HookSpecificOutput: &HookSpecificOutput{
+				HookEventName: EventPermissionRequest,
+				Metadata:      meta,
+			},
+		}}}
+	}
+
+	results := []hookResult{
+		mk(map[string]string{"a": "1", "shared": "first"}),
+		mk(map[string]string{"b": "2", "shared": "second"}),
+	}
+
+	final := aggregate(results, EventPermissionRequest)
+	assert.Equal(t, map[string]string{
+		"a":      "1",
+		"b":      "2",
+		"shared": "second",
+	}, final.Metadata)
+}
+
+// TestAggregateIgnoresMetadataForNonPermissionRequest documents that
+// Metadata is only collected for permission_request events.
+func TestAggregateIgnoresMetadataForNonPermissionRequest(t *testing.T) {
+	t.Parallel()
+
+	results := []hookResult{{HandlerResult: HandlerResult{Output: &Output{
+		HookSpecificOutput: &HookSpecificOutput{
+			HookEventName: EventPreToolUse,
+			Metadata:      map[string]string{"a": "1"},
+		},
+	}}}}
+
+	final := aggregate(results, EventPreToolUse)
+	assert.Nil(t, final.Metadata)
+}

--- a/pkg/hooks/executor.go
+++ b/pkg/hooks/executor.go
@@ -507,6 +507,16 @@ func aggregate(results []hookResult, event EventType) *Result {
 				// blank a leaky tool's output entirely can do so.
 				final.UpdatedToolResponse = hso.UpdatedToolResponse
 			}
+			if event == EventPermissionRequest && len(hso.Metadata) > 0 {
+				// Metadata from every matching hook is merged so multiple
+				// hooks can each contribute keys. On a key clash the last
+				// hook in config order wins (results is iterated in
+				// registration order).
+				if final.Metadata == nil {
+					final.Metadata = make(map[string]string)
+				}
+				maps.Copy(final.Metadata, hso.Metadata)
+			}
 			if hso.AdditionalContext != "" {
 				contexts = append(contexts, hso.AdditionalContext)
 			}

--- a/pkg/hooks/types.go
+++ b/pkg/hooks/types.go
@@ -473,6 +473,15 @@ type HookSpecificOutput struct {
 	// return rewrites concurrently — see aggregate(). Compose multiple
 	// rewriters into a single hook if you need them to chain.
 	UpdatedToolResponse *string `json:"updated_tool_response,omitempty"`
+
+	// Metadata is a set of key/value annotations a
+	// [EventPermissionRequest] hook contributes to the tool-call
+	// confirmation prompt. The runtime merges it onto the tool's own
+	// metadata before emitting the confirmation event, so clients (TUI,
+	// HTTP) can render extra per-call context. Keys from multiple hooks
+	// are merged; on a key clash the last hook in config order wins (see
+	// aggregate()). Ignored on every other event.
+	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
 // Result is the aggregated outcome of dispatching one event.
@@ -512,6 +521,12 @@ type Result struct {
 	// the next LLM call. Pointer-typed so callers can distinguish
 	// "explicitly cleared" (empty string) from "no rewrite" (nil).
 	UpdatedToolResponse *string
+
+	// Metadata aggregates the key/value annotations contributed by
+	// [EventPermissionRequest] hooks. The runtime merges it onto the
+	// tool's own metadata when emitting the tool-call confirmation
+	// event. nil when no hook supplied any.
+	Metadata map[string]string
 
 	// Decision is the most-restrictive PreToolUse verdict reported by
 	// any matching hook in the chain ("" when no hook produced one).

--- a/pkg/leantui/stream_test.go
+++ b/pkg/leantui/stream_test.go
@@ -83,7 +83,7 @@ func TestToolConfirmationReplacesRunningTool(t *testing.T) {
 	m.upsertTool("root", tv.message.ToolCall, tv.message.ToolDefinition, tuitypes.ToolStatusRunning)
 	require.Len(t, m.toolOrder, 1)
 
-	event := runtime.ToolCallConfirmation(tv.message.ToolCall, tv.message.ToolDefinition, "root")
+	event := runtime.ToolCallConfirmation(tv.message.ToolCall, tv.message.ToolDefinition, "root", nil)
 	m.handleEvent(t.Context(), event)
 
 	assert.Empty(t, m.toolOrder)

--- a/pkg/runtime/event.go
+++ b/pkg/runtime/event.go
@@ -111,13 +111,19 @@ type ToolCallConfirmationEvent struct {
 	Type           string         `json:"type"`
 	ToolCall       tools.ToolCall `json:"tool_call"`
 	ToolDefinition tools.Tool     `json:"tool_definition"`
+	// Metadata carries arbitrary key/value annotations attached to the
+	// confirmation prompt. Toolsets contribute static metadata via
+	// [tools.Tool.Metadata]; a permission_request hook can enrich it per
+	// call. nil when neither source supplied any.
+	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
-func ToolCallConfirmation(toolCall tools.ToolCall, toolDefinition tools.Tool, agentName string) Event {
+func ToolCallConfirmation(toolCall tools.ToolCall, toolDefinition tools.Tool, agentName string, metadata map[string]string) Event {
 	return &ToolCallConfirmationEvent{
 		Type:           "tool_call_confirmation",
 		ToolCall:       toolCall,
 		ToolDefinition: toolDefinition,
+		Metadata:       metadata,
 		AgentContext:   newAgentContext(agentName),
 	}
 }

--- a/pkg/runtime/tool_dispatch.go
+++ b/pkg/runtime/tool_dispatch.go
@@ -94,8 +94,8 @@ func (e *sinkEmitter) EmitToolCallResponse(toolCallID string, tool tools.Tool, r
 	e.events.Emit(ToolCallResponse(toolCallID, tool, result, output, agentName))
 }
 
-func (e *sinkEmitter) EmitToolCallConfirmation(toolCall tools.ToolCall, tool tools.Tool, agentName string) {
-	e.events.Emit(ToolCallConfirmation(toolCall, tool, agentName))
+func (e *sinkEmitter) EmitToolCallConfirmation(toolCall tools.ToolCall, tool tools.Tool, agentName string, metadata map[string]string) {
+	e.events.Emit(ToolCallConfirmation(toolCall, tool, agentName, metadata))
 }
 
 func (e *sinkEmitter) EmitHookBlocked(toolCall tools.ToolCall, tool tools.Tool, message, agentName string) {

--- a/pkg/runtime/toolexec/dispatcher.go
+++ b/pkg/runtime/toolexec/dispatcher.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"slices"
 	"strings"
 	"time"
@@ -74,7 +75,7 @@ type Emitter interface {
 	EmitToolCall(toolCall tools.ToolCall, tool tools.Tool, agentName string)
 	EmitToolCallOutput(toolCallID string, tool tools.Tool, output, agentName string)
 	EmitToolCallResponse(toolCallID string, tool tools.Tool, result *tools.ToolCallResult, output, agentName string)
-	EmitToolCallConfirmation(toolCall tools.ToolCall, tool tools.Tool, agentName string)
+	EmitToolCallConfirmation(toolCall tools.ToolCall, tool tools.Tool, agentName string, metadata map[string]string)
 	EmitHookBlocked(toolCall tools.ToolCall, tool tools.Tool, message, agentName string)
 	EmitMessageAdded(sessionID string, msg *session.Message, agentName string)
 }
@@ -506,12 +507,13 @@ func denySourceForChecker(checkerSource string) string {
 // with an explicit allow or deny verdict; returning nothing falls
 // through to the interactive confirmation.
 func (c *call) askUser(ctx context.Context, runTool func() CallOutcome) CallOutcome {
-	if outcome, handled := c.runPermissionRequestHook(ctx, runTool); handled {
+	outcome, handled, hookMeta := c.runPermissionRequestHook(ctx, runTool)
+	if handled {
 		return outcome
 	}
 
 	slog.DebugContext(ctx, "Tools not approved, waiting for resume", "tool", c.tc.Function.Name, "session_id", c.sess.ID)
-	c.em.EmitToolCallConfirmation(c.tc, c.tool, c.a.Name())
+	c.em.EmitToolCallConfirmation(c.tc, c.tool, c.a.Name(), c.confirmationMetadata(hookMeta))
 
 	if c.d.Hooks != nil {
 		c.d.Hooks.NotifyUserInput(ctx, c.sess.ID, "tool confirmation")
@@ -534,9 +536,14 @@ func (c *call) askUser(ctx context.Context, runTool func() CallOutcome) CallOutc
 // ("allow" or "deny") in hook_specific_output. A bare deny (Decision=
 // "block" without permission_decision) is also honoured. Returning
 // nothing keeps the existing behaviour and asks the user.
-func (c *call) runPermissionRequestHook(ctx context.Context, runTool func() CallOutcome) (CallOutcome, bool) {
+//
+// When the hook does not short-circuit (handled=false) it may still
+// have contributed key/value metadata for the confirmation prompt; that
+// is returned so [call.askUser] can merge it onto the tool's own
+// metadata.
+func (c *call) runPermissionRequestHook(ctx context.Context, runTool func() CallOutcome) (outcome CallOutcome, handled bool, metadata map[string]string) {
 	if c.d.Hooks == nil {
-		return CallOutcome{}, false
+		return CallOutcome{}, false, nil
 	}
 
 	toolName := c.tc.Function.Name
@@ -547,7 +554,7 @@ func (c *call) runPermissionRequestHook(ctx context.Context, runTool func() Call
 		ToolInput: ParseToolInput(c.tc.Function.Arguments),
 	})
 	if result == nil {
-		return CallOutcome{}, false
+		return CallOutcome{}, false, nil
 	}
 
 	if !result.Allowed {
@@ -563,16 +570,30 @@ func (c *call) runPermissionRequestHook(ctx context.Context, runTool func() Call
 			rejectMsg += " Reason: " + reason
 		}
 		c.errorResponse(ctx, rejectMsg)
-		return CallOutcome{}, true
+		return CallOutcome{}, true, nil
 	}
 
 	if result.PermissionAllowed {
 		slog.DebugContext(ctx, "Tool auto-approved by permission_request hook", "tool", toolName, "session_id", c.sess.ID, "reason", result.AdditionalContext)
 		c.notifyApproval(ctx, ApprovalDecisionAllow, ApprovalSourcePermissionRequestHookAllow)
-		return runTool(), true
+		return runTool(), true, nil
 	}
 
-	return CallOutcome{}, false
+	return CallOutcome{}, false, result.Metadata
+}
+
+// confirmationMetadata merges the tool's static metadata (set by the
+// toolset) with the per-call metadata a permission_request hook
+// contributed. Hook keys win on a clash. Returns nil when neither
+// source supplied anything, so the confirmation event stays lean.
+func (c *call) confirmationMetadata(hookMeta map[string]string) map[string]string {
+	if len(c.tool.Metadata) == 0 && len(hookMeta) == 0 {
+		return nil
+	}
+	merged := make(map[string]string, len(c.tool.Metadata)+len(hookMeta))
+	maps.Copy(merged, c.tool.Metadata)
+	maps.Copy(merged, hookMeta)
+	return merged
 }
 
 // handleResume applies the user's confirmation decision: run the tool

--- a/pkg/runtime/toolexec/dispatcher_test.go
+++ b/pkg/runtime/toolexec/dispatcher_test.go
@@ -20,13 +20,14 @@ import (
 // channel signals when a confirmation event lands so cancellation tests
 // don't need to busy-wait.
 type captureEmitter struct {
-	calls         []tools.ToolCall
-	outputs       []outputRecord
-	responses     []responseRecord
-	confirmations []tools.ToolCall
-	hookBlocks    []hookBlockRecord
-	messages      []*session.Message
-	confirmed     chan struct{} // optional; closed after the first confirmation event
+	calls            []tools.ToolCall
+	outputs          []outputRecord
+	responses        []responseRecord
+	confirmations    []tools.ToolCall
+	confirmationMeta []map[string]string
+	hookBlocks       []hookBlockRecord
+	messages         []*session.Message
+	confirmed        chan struct{} // optional; closed after the first confirmation event
 }
 
 type outputRecord struct {
@@ -61,8 +62,9 @@ func (e *captureEmitter) EmitToolCallResponse(toolCallID string, _ tools.Tool, r
 	})
 }
 
-func (e *captureEmitter) EmitToolCallConfirmation(tc tools.ToolCall, _ tools.Tool, _ string) {
+func (e *captureEmitter) EmitToolCallConfirmation(tc tools.ToolCall, _ tools.Tool, _ string, metadata map[string]string) {
 	e.confirmations = append(e.confirmations, tc)
+	e.confirmationMeta = append(e.confirmationMeta, metadata)
 	if e.confirmed != nil {
 		select {
 		case <-e.confirmed:
@@ -570,4 +572,113 @@ func TestDispatcher_ToolResponseTransformAppliesToErrorResponse(t *testing.T) {
 	assert.True(t, em.responses[0].IsError)
 	assert.Equal(t, rewritten, em.responses[0].Output,
 		"synthesised error response must also flow through the transform")
+}
+
+// TestDispatcher_ConfirmationCarriesToolMetadata verifies that a
+// toolset's static [tools.Tool.Metadata] reaches the tool-call
+// confirmation event when the user is prompted.
+func TestDispatcher_ConfirmationCarriesToolMetadata(t *testing.T) {
+	a := newAgent()
+	sess := session.New()
+
+	tool := tools.Tool{
+		Name:     "shell",
+		Metadata: map[string]string{"danger": "high", "category": "exec"},
+		Handler:  func(context.Context, tools.ToolCall) (*tools.ToolCallResult, error) { panic("must not run") },
+	}
+
+	resume := make(chan toolexec.ResumeRequest, 1)
+	d := &toolexec.Dispatcher{
+		AgentFor: func(*session.Session) *agent.Agent { return a },
+		Resume:   resume,
+	}
+	em := &captureEmitter{}
+
+	resume <- toolexec.ResumeRequest{Type: toolexec.ResumeTypeReject}
+
+	d.Process(t.Context(), sess, []tools.ToolCall{{
+		ID:       "x",
+		Function: tools.FunctionCall{Name: "shell", Arguments: "{}"},
+	}}, []tools.Tool{tool}, em)
+
+	require.Len(t, em.confirmations, 1)
+	require.Len(t, em.confirmationMeta, 1)
+	assert.Equal(t, map[string]string{"danger": "high", "category": "exec"}, em.confirmationMeta[0])
+}
+
+// TestDispatcher_ConfirmationMergesHookMetadata verifies that a
+// permission_request hook can enrich the confirmation metadata and that
+// hook keys win over the toolset's own keys on a clash.
+func TestDispatcher_ConfirmationMergesHookMetadata(t *testing.T) {
+	a := newAgent()
+	sess := session.New()
+
+	tool := tools.Tool{
+		Name:     "shell",
+		Metadata: map[string]string{"danger": "high", "source": "toolset"},
+		Handler:  func(context.Context, tools.ToolCall) (*tools.ToolCallResult, error) { panic("must not run") },
+	}
+
+	// Hook allows the prompt to proceed (no short-circuit) but contributes
+	// metadata, overriding the toolset's "source" key.
+	hd := &stubHookDispatcher{
+		on: map[hooks.EventType]*hooks.Result{
+			hooks.EventPermissionRequest: {
+				Allowed:  true,
+				Metadata: map[string]string{"source": "hook", "reason": "policy-x"},
+			},
+		},
+	}
+
+	resume := make(chan toolexec.ResumeRequest, 1)
+	d := &toolexec.Dispatcher{
+		AgentFor: func(*session.Session) *agent.Agent { return a },
+		Hooks:    hd,
+		Resume:   resume,
+	}
+	em := &captureEmitter{}
+
+	resume <- toolexec.ResumeRequest{Type: toolexec.ResumeTypeReject}
+
+	d.Process(t.Context(), sess, []tools.ToolCall{{
+		ID:       "x",
+		Function: tools.FunctionCall{Name: "shell", Arguments: "{}"},
+	}}, []tools.Tool{tool}, em)
+
+	require.Len(t, em.confirmationMeta, 1)
+	assert.Equal(t, map[string]string{
+		"danger": "high",
+		"source": "hook",
+		"reason": "policy-x",
+	}, em.confirmationMeta[0])
+}
+
+// TestDispatcher_ConfirmationMetadataNilWhenNoneSupplied verifies that
+// the confirmation event carries nil metadata when neither the toolset
+// nor a hook contributed any, keeping the wire payload lean.
+func TestDispatcher_ConfirmationMetadataNilWhenNoneSupplied(t *testing.T) {
+	a := newAgent()
+	sess := session.New()
+
+	tool := tools.Tool{
+		Name:    "shell",
+		Handler: func(context.Context, tools.ToolCall) (*tools.ToolCallResult, error) { panic("must not run") },
+	}
+
+	resume := make(chan toolexec.ResumeRequest, 1)
+	d := &toolexec.Dispatcher{
+		AgentFor: func(*session.Session) *agent.Agent { return a },
+		Resume:   resume,
+	}
+	em := &captureEmitter{}
+
+	resume <- toolexec.ResumeRequest{Type: toolexec.ResumeTypeReject}
+
+	d.Process(t.Context(), sess, []tools.ToolCall{{
+		ID:       "x",
+		Function: tools.FunctionCall{Name: "shell", Arguments: "{}"},
+	}}, []tools.Tool{tool}, em)
+
+	require.Len(t, em.confirmationMeta, 1)
+	assert.Nil(t, em.confirmationMeta[0])
 }

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -183,6 +183,11 @@ type Tool struct {
 	// ModelOverride is the per-toolset model for the LLM turn that processes
 	// this tool's results. Set automatically from the toolset "model" field.
 	ModelOverride string `json:"-"`
+	// Metadata carries arbitrary key/value annotations a toolset attaches
+	// to a tool. The runtime forwards it onto the tool-call confirmation
+	// message so clients (TUI, HTTP) can render extra context for the
+	// approval prompt. Empty for tools that don't set any.
+	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
 type ToolAnnotations mcp.ToolAnnotations

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -186,8 +186,11 @@ type Tool struct {
 	// Metadata carries arbitrary key/value annotations a toolset attaches
 	// to a tool. The runtime forwards it onto the tool-call confirmation
 	// message so clients (TUI, HTTP) can render extra context for the
-	// approval prompt. Empty for tools that don't set any.
-	Metadata map[string]string `json:"metadata,omitempty"`
+	// approval prompt. Empty for tools that don't set any. Not serialised
+	// directly: clients read the merged value from the confirmation event's
+	// top-level metadata field, so exposing it here would duplicate it (with
+	// a stale, pre-merge value) across every Tool-embedding event.
+	Metadata map[string]string `json:"-"`
 }
 
 type ToolAnnotations mcp.ToolAnnotations

--- a/pkg/tui/dialog/tool_confirmation.go
+++ b/pkg/tui/dialog/tool_confirmation.go
@@ -1,6 +1,10 @@
 package dialog
 
 import (
+	"fmt"
+	"maps"
+	"slices"
+
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
@@ -75,9 +79,16 @@ func (d *toolConfirmationDialog) SetSize(width, height int) tea.Cmd {
 	options := d.renderOptions(contentWidth)
 	optionsHeight := lipgloss.Height(options)
 
+	// The metadata section, when present, adds its own height plus a
+	// leading blank line (matching how View() spaces it).
+	var metadataHeight int
+	if metadata := d.renderMetadata(contentWidth); metadata != "" {
+		metadataHeight = lipgloss.Height(metadata) + 1
+	}
+
 	// Calculate available height for scroll view
 	frameHeight := styles.DialogStyle.GetVerticalFrameSize()
-	fixedContentHeight := titleHeight + separatorHeight + toolConfirmEmptyLinesBefore + questionHeight + toolConfirmEmptyLinesAfter + optionsHeight
+	fixedContentHeight := titleHeight + separatorHeight + toolConfirmEmptyLinesBefore + questionHeight + toolConfirmEmptyLinesAfter + optionsHeight + metadataHeight
 	availableHeight := max(maxDialogHeight-frameHeight-fixedContentHeight, toolConfirmMinScrollHeight)
 	d.scrollView.SetSize(contentWidth, availableHeight)
 
@@ -92,6 +103,28 @@ func (d *toolConfirmationDialog) renderSeparator(contentWidth int) string {
 // renderOptions renders the Y/N/T/A decision row.
 func (d *toolConfirmationDialog) renderOptions(contentWidth int) string {
 	return RenderHelpKeys(contentWidth, toolconfirm.OptionsHelp(d.permissionPattern)...)
+}
+
+// renderMetadata renders the key/value annotations attached to the
+// confirmation prompt (static toolset metadata merged with any
+// permission_request hook contributions). Returns "" when there is none.
+// Keys are sorted so the display order is stable across renders.
+func (d *toolConfirmationDialog) renderMetadata(contentWidth int) string {
+	if len(d.msg.Metadata) == 0 {
+		return ""
+	}
+
+	header := styles.SecondaryStyle.Render("Metadata")
+	lines := []string{header}
+	for _, k := range slices.Sorted(maps.Keys(d.msg.Metadata)) {
+		key := styles.MutedStyle.Render(k + ": ")
+		val := styles.DialogContentStyle.Render(d.msg.Metadata[k])
+		lines = append(lines, fmt.Sprintf("  %s%s", key, val))
+	}
+
+	return styles.DialogContentStyle.Width(contentWidth).Render(
+		lipgloss.JoinVertical(lipgloss.Left, lines...),
+	)
 }
 
 // NewToolConfirmationDialog creates a new tool confirmation dialog
@@ -248,6 +281,10 @@ func (d *toolConfirmationDialog) View() string {
 
 	if argumentsSection != "" {
 		parts = append(parts, "", argumentsSection)
+	}
+
+	if metadata := d.renderMetadata(contentWidth); metadata != "" {
+		parts = append(parts, "", metadata)
 	}
 
 	// Confirmation prompt

--- a/pkg/tui/dialog/tool_confirmation_test.go
+++ b/pkg/tui/dialog/tool_confirmation_test.go
@@ -1,0 +1,71 @@
+package dialog
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/tui/service"
+)
+
+// newConfirmationEvent builds a tool-call confirmation event carrying the
+// supplied metadata for use in the dialog tests.
+func newConfirmationEvent(metadata map[string]string) *runtime.ToolCallConfirmationEvent {
+	return &runtime.ToolCallConfirmationEvent{
+		Type:           "tool_call_confirmation",
+		ToolCall:       tools.ToolCall{ID: "x", Function: tools.FunctionCall{Name: "shell", Arguments: "{}"}},
+		ToolDefinition: tools.Tool{Name: "shell"},
+		Metadata:       metadata,
+	}
+}
+
+func TestToolConfirmationDialog_RendersMetadata(t *testing.T) {
+	t.Parallel()
+
+	dialog := NewToolConfirmationDialog(
+		newConfirmationEvent(map[string]string{"danger": "high", "reason": "policy-x"}),
+		&service.SessionState{},
+	)
+	_, _ = dialog.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+
+	view := ansi.Strip(dialog.View())
+	assert.Contains(t, view, "Metadata")
+	assert.Contains(t, view, "danger: high")
+	assert.Contains(t, view, "reason: policy-x")
+}
+
+func TestToolConfirmationDialog_NoMetadataSection_WhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	dialog := NewToolConfirmationDialog(newConfirmationEvent(nil), &service.SessionState{})
+	_, _ = dialog.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+
+	view := ansi.Strip(dialog.View())
+	assert.NotContains(t, view, "Metadata")
+}
+
+func TestToolConfirmationDialog_MetadataKeysSorted(t *testing.T) {
+	t.Parallel()
+
+	dialog := NewToolConfirmationDialog(
+		newConfirmationEvent(map[string]string{"zebra": "1", "apple": "2", "mango": "3"}),
+		&service.SessionState{},
+	)
+	_, _ = dialog.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+
+	view := ansi.Strip(dialog.View())
+	apple := strings.Index(view, "apple:")
+	mango := strings.Index(view, "mango:")
+	zebra := strings.Index(view, "zebra:")
+	require.NotEqual(t, -1, apple)
+	require.NotEqual(t, -1, mango)
+	require.NotEqual(t, -1, zebra)
+	assert.Less(t, apple, mango, "keys must render in sorted order")
+	assert.Less(t, mango, zebra, "keys must render in sorted order")
+}

--- a/pkg/tui/service/supervisor/supervisor_test.go
+++ b/pkg/tui/service/supervisor/supervisor_test.go
@@ -235,7 +235,7 @@ func TestStreamStopped_TopLevelClearsPendingAndNeedsAttn(t *testing.T) {
 		},
 		{
 			name:    "tool confirmation pending",
-			pending: runtime.ToolCallConfirmation(tools.ToolCall{}, tools.Tool{}, "agent"),
+			pending: runtime.ToolCallConfirmation(tools.ToolCall{}, tools.Tool{}, "agent", nil),
 		},
 		{
 			name:    "max iterations pending",


### PR DESCRIPTION
Clients rendering tool-call confirmation prompts (the TUI, the HTTP SSE stream) currently have no way to display extra context that a toolset or a policy hook might want to surface — for example, a risk classification, a target environment label, or a reason string produced by an external policy engine. This change adds a `metadata` field (`map[string]string`) that travels with every `ToolCallConfirmationEvent` so that context can reach the UI layer without any bespoke event types.

There are two enrichment paths. Toolsets can attach *static* per-tool metadata via the new `tools.Tool.Metadata` field, which is declared once and applies to every call of that tool. For *per-call* context, a `permission_request` hook can return `metadata` in its `hook_specific_output`; the hook aggregation layer collects those maps (last hook in config order wins on a key clash) into `hooks.Result.Metadata`. The dispatcher's new `confirmationMetadata` helper merges both sources — tool-static keys first, hook keys on top — and passes the result into `ToolCallConfirmation(...)`, which now carries it through to `ToolCallConfirmationEvent.Metadata`. The SSE client registry already serialises the event to JSON, so the field round-trips to HTTP consumers with no further changes.

No existing behaviour changes: the field is `omitempty`, both enrichment paths are opt-in, and `confirmationMetadata` returns `nil` when neither source contributes anything so the event stays lean. Unit tests cover the dispatcher merge logic and the hooks aggregation; the docs for `permission_request` hooks are updated to document the new `metadata` output field.