### PR TITLE
feat(config): accept ${env.X} in toolset env values (#2615)

### DIFF
--- a/docs/configuration/overview/index.md
+++ b/docs/configuration/overview/index.md
@@ -260,7 +260,7 @@ Applies to:
 
 - `agents.<name>.toolsets[*].working_dir` (MCP, LSP)
 - `agents.<name>.toolsets[*].path` (memory, tasks)
-- `agents.<name>.toolsets[*].env` values (MCP, shell, script, LSP) — these go through `os.Expand`, not the JS evaluator, so `${env.X}` is **not** recognized here.
+- `agents.<name>.toolsets[*].env` values (MCP, shell, script, LSP)
 - The `~` prefix is also accepted in any path-like field documented as such.
 
 ```yaml
@@ -274,7 +274,7 @@ agents:
         working_dir: "$HOME/work"
 ```
 
-The `working_dir` and `path` fields additionally accept the `${env.VAR}` form as an alias for `${VAR}`, so the JS-style syntax works there too. Richer JS expressions (e.g. `${env.VAR || 'default'}`) are still **not** evaluated in path fields. The `env` values fields remain shell-only.
+The `working_dir`, `path`, and `env` value fields additionally accept the `${env.VAR}` form as an alias for `${VAR}`, so the JS-style syntax works there too. Richer JS expressions (e.g. `${env.VAR || 'default'}`) are still **not** evaluated in these fields.
 
 ### Quick reference
 
@@ -285,7 +285,9 @@ The `working_dir` and `path` fields additionally accept the `${env.VAR}` form as
 | `commands.*`                                  |     ✓      |       ✗       |  ✗  |
 | `headers`, `remote.headers`, `api_config.headers` |     ✓      |       ✗       |  ✗  |
 | `working_dir`, `path`                         |     ✓      |       ✓       |  ✓  |
-| `env` values                                  |     ✗      |       ✓       |  ✗  |
+| `env` values                                  |     ✓      |       ✓       |  ✗  |
+
+The `~` prefix is meaningful only in path-like fields (`working_dir`, `path`).
 
 When in doubt, prefer `${env.X}` for prompts and headers, and `${X}` (or `$X`) for paths.
 

--- a/pkg/config/expansion_warnings.go
+++ b/pkg/config/expansion_warnings.go
@@ -93,9 +93,9 @@ func warnExpansionMismatches(ctx context.Context, logger *slog.Logger, cfg *late
 				// directly to exec.Cmd without expansion, so neither syntax
 				// works there. Flag the JS form because that's the
 				// surprising silent failure (it looks template-y).
-				warnPathField(ctx, logger, shellLoc, "working_dir", sh.WorkingDir)
+				warnExecField(ctx, logger, shellLoc, "working_dir", sh.WorkingDir)
 				for k, v := range sh.Env {
-					warnPathField(ctx, logger, shellLoc, "env."+k, v)
+					warnExecField(ctx, logger, shellLoc, "env."+k, v)
 				}
 			}
 		}
@@ -162,9 +162,9 @@ func warnHooksConfig(ctx context.Context, logger *slog.Logger, agentName string,
 
 func warnHookDefinition(ctx context.Context, logger *slog.Logger, agentName, group string, idx int, hook *latest.HookDefinition) {
 	loc := "agent " + agentName + " hooks." + group + "[" + strconv.Itoa(idx) + "]"
-	warnPathField(ctx, logger, loc, "working_dir", hook.WorkingDir)
+	warnExecField(ctx, logger, loc, "working_dir", hook.WorkingDir)
 	for k, v := range hook.Env {
-		warnPathField(ctx, logger, loc, "env."+k, v)
+		warnExecField(ctx, logger, loc, "env."+k, v)
 	}
 }
 
@@ -199,18 +199,20 @@ func warnJSField(ctx context.Context, logger *slog.Logger, loc, field, value str
 	}
 }
 
-// warnPathField warns when a verbatim-exec field (ScriptShell/hook env and
+// warnExecField warns when a verbatim-exec field (ScriptShell/hook env and
 // working_dir) contains a `${env.X}` reference. Those fields are forwarded
-// directly to exec.Cmd without expansion, so the reference is passed through
-// literally. The variable name is captured but the surrounding value is not,
-// since env values frequently contain credentials.
-func warnPathField(ctx context.Context, logger *slog.Logger, loc, field, value string) {
+// directly to exec.Cmd without any expansion, so neither the JS-style
+// `${env.X}` nor the shell-style `${X}`/`$X` form is substituted; the
+// reference is passed through literally. The variable name is captured but
+// the surrounding value is not, since env values frequently contain
+// credentials.
+func warnExecField(ctx context.Context, logger *slog.Logger, loc, field, value string) {
 	if value == "" || !strings.Contains(value, "${env.") {
 		return
 	}
 	for _, m := range jsEnvRefStrict.FindAllStringSubmatch(value, -1) {
 		logger.WarnContext(ctx,
-			"JS-style ${env.X} in shell-expanded field will not be substituted; use ${X} or $X",
+			"${env.X} in this field will not be substituted; it is passed to the command unexpanded",
 			"location", loc,
 			"field", field,
 			"variable", m[1],

--- a/pkg/config/expansion_warnings.go
+++ b/pkg/config/expansion_warnings.go
@@ -24,13 +24,9 @@ var shellEnvVarRef = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)\}`)
 var jsEnvRef = regexp.MustCompile(`\$\{\s*env\.[A-Za-z_][A-Za-z0-9_]*`)
 
 // jsEnvRefStrict matches a `${env.X}` reference with no extra JS expression
-// trailing the identifier. Used to flag occurrences in shell-style fields,
-// where ScriptShellToolConfig and other path-like targets only call
-// os.Expand (no JS evaluator), so the literal `${env.X}` is passed through.
-//
-// Kept in sync with jsEnvRef in pkg/path/expand.go, which uses the same
-// pattern to normalize `${env.X}` to `${X}` in path fields. The pattern is
-// duplicated rather than shared to avoid an import cycle.
+// trailing the identifier. Used to flag occurrences in the ScriptShell and
+// hook fields (env, working_dir) that are forwarded verbatim to exec.Cmd
+// without any expansion, so the literal `${env.X}` is passed through.
 var jsEnvRefStrict = regexp.MustCompile(`\$\{\s*env\.([A-Za-z_][A-Za-z0-9_]*)\s*\}`)
 
 // warnExpansionMismatches scans a loaded config for fields whose contents use
@@ -39,11 +35,12 @@ var jsEnvRefStrict = regexp.MustCompile(`\$\{\s*env\.([A-Za-z_][A-Za-z0-9_]*)\s*
 //
 //   - JS template literals (`${env.X}`) for prompt/instruction/header/command
 //     fields rendered through pkg/js.
-//   - Shell-style (`$VAR` / `${VAR}` / `~`) for toolset env values and the
-//     ScriptShell/hook fields that are forwarded verbatim to exec.Cmd.
+//   - Shell-style (`$VAR` / `${VAR}` / `~`) for the ScriptShell/hook fields
+//     that are forwarded verbatim to exec.Cmd.
 //
-// Toolset path fields (working_dir, path) are not checked here: they flow
-// through pkg/path.ExpandPath, which now accepts both syntaxes (#2615).
+// Toolset path (working_dir, path) and env-value fields are not checked here:
+// they flow through pkg/path.ExpandPath / pkg/environment.Expand, both of
+// which now accept ${env.X} as an alias for ${X} (#2615).
 //
 // Mixing them up currently fails silently; we emit warnings to make the
 // problem visible without changing runtime behavior.
@@ -87,14 +84,9 @@ func warnExpansionMismatches(ctx context.Context, logger *slog.Logger, cfg *late
 				warnJSField(ctx, logger, loc, "api_config.headers."+k, v)
 			}
 
-			// Toolset env values are expanded with os.Expand (shell-style),
-			// not the JS evaluator, so a stray `${env.X}` is the silent-failure
-			// case here. working_dir and path are not checked: they flow through
-			// pkg/path.ExpandPath, which accepts both ${env.X} and ${X} (#2615).
-			for k, v := range t.Env {
-				warnPathField(ctx, logger, loc, "env."+k, v)
-			}
-
+			// Toolset env values, working_dir and path are not checked: they
+			// flow through pkg/environment.Expand / pkg/path.ExpandPath, both of
+			// which accept ${env.X} as an alias for ${X} (#2615).
 			for name, sh := range t.Shell {
 				shellLoc := loc + " shell[" + name + "]"
 				// ScriptShellToolConfig env and working_dir are forwarded
@@ -207,10 +199,11 @@ func warnJSField(ctx context.Context, logger *slog.Logger, loc, field, value str
 	}
 }
 
-// warnPathField warns when a shell-style field contains a `${env.X}`
-// reference, which is JS-template syntax that os.Expand / path.ExpandPath
-// does not recognize. The variable name is captured but the surrounding
-// value is not, since path/env values frequently contain credentials.
+// warnPathField warns when a verbatim-exec field (ScriptShell/hook env and
+// working_dir) contains a `${env.X}` reference. Those fields are forwarded
+// directly to exec.Cmd without expansion, so the reference is passed through
+// literally. The variable name is captured but the surrounding value is not,
+// since env values frequently contain credentials.
 func warnPathField(ctx context.Context, logger *slog.Logger, loc, field, value string) {
 	if value == "" || !strings.Contains(value, "${env.") {
 		return

--- a/pkg/config/expansion_warnings_test.go
+++ b/pkg/config/expansion_warnings_test.go
@@ -66,11 +66,12 @@ func TestWarnExpansionMismatches_LowerCaseShellIdent(t *testing.T) {
 	assert.Contains(t, out, "shell-style")
 }
 
-func TestWarnExpansionMismatches_JSEnvInPathFieldNoLongerWarns(t *testing.T) {
+func TestWarnExpansionMismatches_JSEnvInPathAndEnvNoLongerWarns(t *testing.T) {
 	t.Parallel()
 
-	// working_dir and path flow through pkg/path.ExpandPath, which now accepts
-	// ${env.X}, so these must not warn anymore (#2615).
+	// working_dir and path flow through pkg/path.ExpandPath, and toolset env
+	// values flow through pkg/environment.Expand; both now accept ${env.X}, so
+	// none of these must warn anymore (#2615).
 	cfg := &latest.Config{
 		Agents: []latest.AgentConfig{{
 			Name: "root",
@@ -78,6 +79,9 @@ func TestWarnExpansionMismatches_JSEnvInPathFieldNoLongerWarns(t *testing.T) {
 				Type:       "mcp",
 				Command:    "x",
 				WorkingDir: "${env.HOME}/work",
+				Env: map[string]string{
+					"MEM_DIR": "${env.MEM_DIR}/db",
+				},
 			}, {
 				Type: "memory",
 				Path: "${env.MEM_DIR}/db",
@@ -92,33 +96,7 @@ func TestWarnExpansionMismatches_JSEnvInPathFieldNoLongerWarns(t *testing.T) {
 	assert.NotContains(t, out, "WARN")
 }
 
-func TestWarnExpansionMismatches_JSEnvInToolsetEnv(t *testing.T) {
-	t.Parallel()
-
-	// Toolset env values are still expanded with os.Expand, so ${env.X} there
-	// remains a silent no-op we must warn about.
-	cfg := &latest.Config{
-		Agents: []latest.AgentConfig{{
-			Name: "root",
-			Toolsets: []latest.Toolset{{
-				Type:    "mcp",
-				Command: "x",
-				Env: map[string]string{
-					"MEM_DIR": "${env.MEM_DIR}/db",
-				},
-			}},
-		}},
-	}
-
-	out := captureWarnings(t, func(ctx context.Context, logger *slog.Logger) {
-		warnExpansionMismatches(ctx, logger, cfg)
-	})
-
-	assert.Contains(t, out, "JS-style")
-	assert.Contains(t, out, "MEM_DIR")
-}
-
-func TestWarnExpansionMismatches_DoesNotLeakValueInPathField(t *testing.T) {
+func TestWarnExpansionMismatches_DoesNotLeakValueInExecField(t *testing.T) {
 	t.Parallel()
 
 	const secretToken = "supers3cret-token-DO-NOT-LOG"
@@ -126,14 +104,18 @@ func TestWarnExpansionMismatches_DoesNotLeakValueInPathField(t *testing.T) {
 		Agents: []latest.AgentConfig{{
 			Name: "root",
 			Toolsets: []latest.Toolset{{
-				Type:    "mcp",
-				Command: "x",
-				// Realistic shape: secret prefix followed by an unsupported
-				// JS-style expansion in a shell-expanded env value. We must
-				// surface the variable name so users can fix the typo, but we
-				// must not echo the secret.
-				Env: map[string]string{
-					"TOKEN": secretToken + "/${env.MEM_DIR}/db",
+				Type: "script",
+				Shell: map[string]latest.ScriptShellToolConfig{
+					"build": {
+						Cmd: "make",
+						// Realistic shape: secret prefix followed by an
+						// unsupported JS-style expansion in a verbatim-exec env
+						// value. We must surface the variable name so users can
+						// fix the typo, but we must not echo the secret.
+						Env: map[string]string{
+							"TOKEN": secretToken + "/${env.MEM_DIR}/db",
+						},
+					},
 				},
 			}},
 		}},
@@ -235,30 +217,6 @@ func TestWarnExpansionMismatches_APIConfigHeaders(t *testing.T) {
 	assert.Contains(t, out, "USER_ID")
 	assert.Contains(t, out, "TOKEN")
 	assert.Contains(t, out, "shell-style")
-}
-
-func TestWarnExpansionMismatches_ToolsetEnvJSStyle(t *testing.T) {
-	t.Parallel()
-
-	cfg := &latest.Config{
-		Agents: []latest.AgentConfig{{
-			Name: "root",
-			Toolsets: []latest.Toolset{{
-				Type:    "mcp",
-				Command: "x",
-				Env: map[string]string{
-					"TOKEN": "${env.GH_TOKEN}",
-				},
-			}},
-		}},
-	}
-
-	out := captureWarnings(t, func(ctx context.Context, logger *slog.Logger) {
-		warnExpansionMismatches(ctx, logger, cfg)
-	})
-
-	assert.Contains(t, out, "GH_TOKEN")
-	assert.Contains(t, out, "JS-style")
 }
 
 func TestWarnExpansionMismatches_ScriptShellTool(t *testing.T) {

--- a/pkg/environment/env_files_test.go
+++ b/pkg/environment/env_files_test.go
@@ -35,6 +35,17 @@ func TestExpandAll_EmptyValue(t *testing.T) {
 	assert.Equal(t, []string{""}, expanded)
 }
 
+func TestExpand_JSEnvRefAlias(t *testing.T) {
+	t.Setenv("USER", "alice")
+
+	// The JS-template ${env.X} form is accepted as an alias for ${X} (#2615).
+	for _, input := range []string{"${env.USER}", "${ env.USER }", "hi ${env.USER}!"} {
+		expanded, err := Expand(t.Context(), input, NewOsEnvProvider())
+		require.NoError(t, err)
+		assert.Contains(t, expanded, "alice")
+	}
+}
+
 func TestAbsolutePath(t *testing.T) {
 	homeDir, err := os.UserHomeDir()
 	require.NoError(t, err)

--- a/pkg/environment/expand.go
+++ b/pkg/environment/expand.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"slices"
+
+	"github.com/docker/docker-agent/pkg/path"
 )
 
 func ExpandAll(ctx context.Context, values []string, env Provider) ([]string, error) {
@@ -24,6 +26,10 @@ func ExpandAll(ctx context.Context, values []string, env Provider) ([]string, er
 
 func Expand(ctx context.Context, value string, env Provider) (string, error) {
 	var err error
+
+	// Accept the JS-template `${env.VAR}` form as an alias for `${VAR}` so the
+	// syntax used in prompts/headers also resolves here (issue #2615).
+	value = path.NormalizeEnvRefs(value)
 
 	expanded := os.Expand(value, func(name string) string {
 		v, found := env.Get(ctx, name)

--- a/pkg/path/expand.go
+++ b/pkg/path/expand.go
@@ -6,19 +6,23 @@ import (
 )
 
 // jsEnvRef matches the JS-template form `${env.VAR}` (optional surrounding
-// whitespace). Path fields historically only understood shell-style
-// expansion via os.ExpandEnv, so the JS form was passed through as a literal.
-// We normalize it to `${VAR}` so both syntaxes resolve identically here.
+// whitespace). Shell-style callers (os.Expand / os.ExpandEnv) historically
+// only understood `${VAR}`, so the JS form was passed through as a literal.
+// NormalizeEnvRefs rewrites it to `${VAR}` so both syntaxes resolve
+// identically.
 //
 // Only the plain `${env.VAR}` reference is recognized; richer JS expressions
-// such as `${env.VAR || 'default'}` are not evaluated in path fields (that
-// would require the goja engine, which pkg/path cannot import).
-//
-// Kept in sync with jsEnvRefStrict in pkg/config/expansion_warnings.go: that
-// helper warns about the same `${env.VAR}` form in fields that, unlike paths,
-// cannot resolve it. The pattern is duplicated rather than shared to avoid an
-// import cycle (pkg/environment already imports pkg/path).
+// such as `${env.VAR || 'default'}` are left untouched (evaluating them would
+// require the goja engine, which pkg/path cannot import).
 var jsEnvRef = regexp.MustCompile(`\$\{\s*env\.([A-Za-z_][A-Za-z0-9_]*)\s*\}`)
+
+// NormalizeEnvRefs rewrites the JS-template form `${env.VAR}` to the shell
+// form `${VAR}`, so os.Expand-based callers also accept the JS-style syntax
+// used elsewhere in the config (issue #2615). Richer JS expressions are left
+// untouched; see jsEnvRef.
+func NormalizeEnvRefs(s string) string {
+	return jsEnvRef.ReplaceAllString(s, "${$1}")
+}
 
 // ExpandPath expands shell-like patterns in a file path:
 //   - ~ or ~/ at the start is replaced with the user's home directory
@@ -31,7 +35,7 @@ func ExpandPath(p string) string {
 
 	// Normalize ${env.VAR} to ${VAR} so the JS-template syntax used elsewhere
 	// in the config also works in path fields (issue #2615).
-	p = jsEnvRef.ReplaceAllString(p, "${$1}")
+	p = NormalizeEnvRefs(p)
 
 	// Expand environment variables
 	p = os.ExpandEnv(p)


### PR DESCRIPTION
Toolset `env` values previously only understood the shell-style `${X}` expansion syntax. When an agent config used the JS-template form `${env.X}` — which already works in path fields like `working_dir` and `path` — the runtime would reject it with a hard "environment variable not set" error, silently breaking configs that mixed both styles. This is the first part of fixing the inconsistency tracked in #2615.

The fix extracts a shared `NormalizeEnvRefs` helper in `pkg/path/expand.go` that rewrites `${env.X}` to `${X}` before expansion, then calls it from `pkg/environment/expand.go` ahead of `os.Expand`. Richer JS expressions such as `${env.VAR || 'default'}` are intentionally *not* evaluated in env values — only the plain `${env.X}` alias is handled. The variable-expansion quick-reference table in `docs/configuration/overview/index.md` has been updated to reflect that env values now accept both forms.

A related cleanup drops the now-obsolete startup warning that flagged `${env.X}` in toolset env values. The warning helper for shell and hook fields — which are forwarded verbatim to `exec.Cmd` with no expansion at all — was renamed `warnPathField` → `warnExecField` and its message corrected; the old message incorrectly told users to switch to `${X}` or `$X`, neither of which is substituted in those fields.