### PR TITLE
feat: persist agent failures in the session

### DIFF
--- a/pkg/runtime/persistence_observer.go
+++ b/pkg/runtime/persistence_observer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/session"
@@ -132,6 +133,26 @@ func (p *PersistenceObserver) OnEvent(ctx context.Context, sess *session.Session
 	case *SessionTitleEvent:
 		if err := p.store.UpdateSessionTitle(ctx, sess.ID, e.Title); err != nil {
 			slog.WarnContext(ctx, "Failed to persist session title", "session_id", sess.ID, "error", err)
+		}
+
+	case *ErrorEvent:
+		// Persist agent failures so they survive a session reload and travel
+		// with a shared JSON export for diagnostics. Reset the streaming state
+		// so any in-flight assistant row is finalised in place and the error is
+		// recorded as a distinct trailing item.
+		p.streaming = streamingState{}
+		ts := e.Timestamp
+		if ts.IsZero() {
+			ts = time.Now()
+		}
+		errItem := &session.Error{
+			Message:   e.Error,
+			Code:      e.Code,
+			AgentName: e.AgentName,
+			CreatedAt: ts.Format(time.RFC3339),
+		}
+		if err := p.store.AddError(ctx, sess.ID, errItem); err != nil {
+			slog.WarnContext(ctx, "Failed to persist error", "session_id", sess.ID, "error", err)
 		}
 	}
 }

--- a/pkg/runtime/persistence_observer_error_test.go
+++ b/pkg/runtime/persistence_observer_error_test.go
@@ -1,0 +1,61 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/session"
+)
+
+// TestPersistenceObserver_PersistsErrorEvent verifies that an ErrorEvent is
+// recorded as a session error item so it survives a reload and is included in
+// a JSON export.
+func TestPersistenceObserver_PersistsErrorEvent(t *testing.T) {
+	store := session.NewInMemorySessionStore()
+	obs := newPersistenceObserver(store)
+	require.NotNil(t, obs)
+
+	sess := session.New(session.WithID("s1"), session.WithUserMessage("hi"))
+	require.NoError(t, store.AddSession(t.Context(), sess))
+
+	ev := ErrorWithCodeForSession(sess.ID, ErrorCodeModelError, "model stream failed")
+	obs.OnEvent(t.Context(), sess, ev)
+
+	reloaded, err := store.GetSession(t.Context(), sess.ID)
+	require.NoError(t, err)
+
+	var errItem *session.Error
+	for _, item := range reloaded.Messages {
+		if item.IsError() {
+			errItem = item.Error
+			break
+		}
+	}
+	require.NotNil(t, errItem, "ErrorEvent must be persisted as an error item")
+	assert.Equal(t, "model stream failed", errItem.Message)
+	assert.Equal(t, ErrorCodeModelError, errItem.Code)
+}
+
+// TestPersistenceObserver_SkipsSubSessionError verifies that errors from
+// sub-sessions are not persisted into the parent (the parent absorbs only its
+// own scoped events).
+func TestPersistenceObserver_SkipsSubSessionError(t *testing.T) {
+	store := session.NewInMemorySessionStore()
+	obs := newPersistenceObserver(store)
+	require.NotNil(t, obs)
+
+	sess := session.New(session.WithID("parent"), session.WithUserMessage("hi"))
+	require.NoError(t, store.AddSession(t.Context(), sess))
+
+	// An error tagged with a different session id must be filtered out.
+	ev := ErrorWithCodeForSession("other-session", ErrorCodeModelError, "child failed")
+	obs.OnEvent(t.Context(), sess, ev)
+
+	reloaded, err := store.GetSession(t.Context(), sess.ID)
+	require.NoError(t, err)
+	for _, item := range reloaded.Messages {
+		assert.False(t, item.IsError(), "sub-session error must not be persisted into parent")
+	}
+}

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -820,6 +820,10 @@ func (s *RemoteSessionStore) AddSummary(context.Context, string, string, int) er
 	return fmt.Errorf("add summary: %w", ErrUnsupported)
 }
 
+func (s *RemoteSessionStore) AddError(context.Context, string, *session.Error) error {
+	return fmt.Errorf("add error: %w", ErrUnsupported)
+}
+
 func (s *RemoteSessionStore) UpdateSessionTokens(context.Context, string, int64, int64, float64) error {
 	return fmt.Errorf("update session tokens: %w", ErrUnsupported)
 }

--- a/pkg/session/branch.go
+++ b/pkg/session/branch.go
@@ -115,6 +115,10 @@ func (s *Session) Clone() *Session {
 		if item.SubSession != nil {
 			clone.Messages[i].SubSession = item.SubSession.Clone()
 		}
+		if item.Error != nil {
+			errCopy := *item.Error
+			clone.Messages[i].Error = &errCopy
+		}
 	}
 	return clone
 }
@@ -135,6 +139,9 @@ func cloneSessionItem(item Item) (Item, error) {
 		return Item{SubSession: clonedSub}, nil
 	case item.Summary != "":
 		return Item{Summary: item.Summary, Cost: item.Cost}, nil
+	case item.Error != nil:
+		errCopy := *item.Error
+		return Item{Error: &errCopy}, nil
 	default:
 		return Item{}, errors.New("cannot clone empty session item")
 	}

--- a/pkg/session/branch_test.go
+++ b/pkg/session/branch_test.go
@@ -164,6 +164,18 @@ func TestCloneSessionItem(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "test summary", cloned.Summary)
 	})
+
+	t.Run("error item clones into a distinct pointer", func(t *testing.T) {
+		item := NewErrorItem(&Error{Message: "boom", Code: "model_error"})
+		cloned, err := cloneSessionItem(item)
+		require.NoError(t, err)
+		require.NotNil(t, cloned.Error)
+		assert.Equal(t, "boom", cloned.Error.Message)
+		assert.Equal(t, "model_error", cloned.Error.Code)
+		// Mutating the clone must not affect the original item.
+		cloned.Error.Message = "mutated"
+		assert.Equal(t, "boom", item.Error.Message)
+	})
 }
 
 func TestBranchSession(t *testing.T) {
@@ -191,6 +203,29 @@ func TestBranchSession(t *testing.T) {
 		parent := &Session{Messages: []Item{NewMessageItem(UserMessage("test"))}}
 		_, err := BranchSession(parent, 1)
 		require.NoError(t, err)
+	})
+
+	t.Run("branches across a persisted error item", func(t *testing.T) {
+		// Regression: a session containing a recorded failure must remain
+		// branchable. cloneSessionItem previously errored on error items,
+		// breaking branch/fork for any failed session.
+		parent := &Session{
+			Messages: []Item{
+				NewMessageItem(UserMessage("hi")),
+				NewErrorItem(&Error{Message: "boom", Code: "model_error"}),
+				NewMessageItem(UserMessage("again")),
+			},
+		}
+
+		branched, err := BranchSession(parent, 3)
+		require.NoError(t, err)
+		require.Len(t, branched.Messages, 3)
+		require.True(t, branched.Messages[1].IsError())
+		assert.Equal(t, "boom", branched.Messages[1].Error.Message)
+
+		// Deep copy: mutating the branch must not touch the parent.
+		branched.Messages[1].Error.Message = "mutated"
+		assert.Equal(t, "boom", parent.Messages[1].Error.Message)
 	})
 
 	t.Run("valid branch copies messages up to position", func(t *testing.T) {

--- a/pkg/session/clone_test.go
+++ b/pkg/session/clone_test.go
@@ -215,3 +215,19 @@ func TestClone_PreservesItemValueFields(t *testing.T) {
 	assert.InEpsilon(t, 0.5, clone.Messages[0].Cost, 1e-9)
 	assert.Equal(t, 3, clone.Messages[0].FirstKeptEntry)
 }
+
+// TestClone_DeepCopiesErrorItem guards against the clone sharing the *Error
+// pointer with the original, which would let a mutation on one leak into the
+// other.
+func TestClone_DeepCopiesErrorItem(t *testing.T) {
+	orig := New()
+	orig.AddError(&Error{Message: "boom", Code: "model_error", AgentName: "root"})
+
+	clone := orig.Clone()
+	require.Len(t, clone.Messages, 1)
+	require.True(t, clone.Messages[0].IsError())
+	assert.Equal(t, "boom", clone.Messages[0].Error.Message)
+
+	clone.Messages[0].Error.Message = "mutated"
+	assert.Equal(t, "boom", orig.Messages[0].Error.Message, "Error must be deep-copied")
+}

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -31,13 +31,18 @@ const (
 	toolContentPlaceholder = "[content truncated]"
 )
 
-// Item represents either a message or a sub-session
+// Item represents a message, a sub-session, a summary, or a recorded error.
 type Item struct {
 	// Message holds a regular conversation message
 	Message *Message `json:"message,omitempty"`
 
 	// SubSession holds a complete sub-session from task transfers
 	SubSession *Session `json:"sub_session,omitempty"`
+
+	// Error holds a recorded agent failure. Persisting failures lets the
+	// error survive a session reload and travel with a shared JSON export
+	// for diagnostics.
+	Error *Error `json:"error,omitempty"`
 
 	// Summary is a summary of the session up until this point
 	Summary string `json:"summary,omitempty"`
@@ -62,6 +67,26 @@ func (si *Item) IsMessage() bool {
 // IsSubSession returns true if this item contains a sub-session
 func (si *Item) IsSubSession() bool {
 	return si.SubSession != nil
+}
+
+// IsError returns true if this item contains a recorded error
+func (si *Item) IsError() bool {
+	return si.Error != nil
+}
+
+// Error records an agent failure that occurred during a run. It is stored as
+// a session item so the error is visible when the session is reopened and is
+// included in a shared JSON session export for diagnostics.
+type Error struct {
+	// Message is the human-readable error message.
+	Message string `json:"message"`
+	// Code classifies the error (see runtime.ErrorCode* constants). Empty
+	// when the error was emitted without a code.
+	Code string `json:"code,omitempty"`
+	// AgentName is the agent that was running when the error occurred.
+	AgentName string `json:"agent_name,omitempty"`
+	// CreatedAt is the RFC3339 timestamp of the failure.
+	CreatedAt string `json:"created_at,omitempty"`
 }
 
 // Session represents the agent's state including conversation history and variables
@@ -253,6 +278,11 @@ func NewMessageItem(msg *Message) Item {
 // NewSubSessionItem creates a SessionItem containing a sub-session
 func NewSubSessionItem(subSession *Session) Item {
 	return Item{SubSession: subSession}
+}
+
+// NewErrorItem creates a SessionItem containing a recorded error
+func NewErrorItem(e *Error) Item {
+	return Item{Error: e}
 }
 
 // EvalResult contains the evaluation scoring outcome for a session.
@@ -486,6 +516,14 @@ func (s *Session) ApplyCompaction(inputTokens, outputTokens int64, item Item) {
 func (s *Session) AddSubSession(subSession *Session) {
 	s.mu.Lock()
 	s.Messages = append(s.Messages, NewSubSessionItem(subSession))
+	s.mu.Unlock()
+}
+
+// AddError appends a recorded error to the session so it survives reload and
+// JSON export.
+func (s *Session) AddError(e *Error) {
+	s.mu.Lock()
+	s.Messages = append(s.Messages, NewErrorItem(e))
 	s.mu.Unlock()
 }
 

--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -115,6 +115,10 @@ type Store interface {
 	// firstKeptEntry is the index of the first message kept verbatim during compaction.
 	AddSummary(ctx context.Context, sessionID, summary string, firstKeptEntry int) error
 
+	// AddError appends a recorded error item to a session at the next position.
+	// Persisting failures lets them survive a reload and travel with a JSON export.
+	AddError(ctx context.Context, sessionID string, e *Error) error
+
 	// === Granular metadata updates ===
 
 	// UpdateSessionTokens updates only token/cost fields
@@ -336,6 +340,20 @@ func (s *InMemorySessionStore) AddSummary(_ context.Context, sessionID, summary 
 	session.mu.Lock()
 	session.Messages = append(session.Messages, Item{Summary: summary, FirstKeptEntry: firstKeptEntry})
 	session.mu.Unlock()
+	return nil
+}
+
+// AddError appends a recorded error item to a session at the next position.
+func (s *InMemorySessionStore) AddError(_ context.Context, sessionID string, e *Error) error {
+	if sessionID == "" {
+		return ErrEmptyID
+	}
+	session, exists := s.sessions.Load(sessionID)
+	if !exists {
+		return ErrNotFound
+	}
+	errCopy := *e
+	session.AddError(&errCopy)
 	return nil
 }
 
@@ -762,6 +780,15 @@ func (s *SQLiteSessionStore) loadSessionItems(ctx context.Context, q querier, se
 
 		case "summary":
 			items = append(items, Item{Summary: row.summaryText.String, FirstKeptEntry: row.firstKeptEntry})
+
+		case "error":
+			var e Error
+			if row.messageJSON.Valid && row.messageJSON.String != "" {
+				if err := json.Unmarshal([]byte(row.messageJSON.String), &e); err != nil {
+					return nil, fmt.Errorf("unmarshaling error at position %d: %w", row.position, err)
+				}
+			}
+			items = append(items, Item{Error: &e})
 		}
 	}
 
@@ -1155,6 +1182,17 @@ func (s *SQLiteSessionStore) addItemTx(ctx context.Context, tx *sql.Tx, sessionI
 			sessionID, position, item.Summary, item.FirstKeptEntry)
 		return err
 
+	case item.Error != nil:
+		errJSON, err := json.Marshal(item.Error)
+		if err != nil {
+			return fmt.Errorf("marshaling error: %w", err)
+		}
+		_, err = tx.ExecContext(ctx,
+			`INSERT INTO session_items (session_id, position, item_type, message_json)
+			 VALUES (?, ?, 'error', ?)`,
+			sessionID, position, string(errJSON))
+		return err
+
 	default:
 		return nil // Empty item, skip
 	}
@@ -1175,6 +1213,26 @@ func (s *SQLiteSessionStore) AddSummary(ctx context.Context, sessionID, summary 
 	}
 
 	return nil
+}
+
+// AddError appends a recorded error item to a session at the next position.
+// The error payload is stored as JSON in the message_json column, reusing the
+// existing schema (item_type discriminates the row).
+func (s *SQLiteSessionStore) AddError(ctx context.Context, sessionID string, e *Error) error {
+	if sessionID == "" {
+		return ErrEmptyID
+	}
+
+	errJSON, err := json.Marshal(e)
+	if err != nil {
+		return fmt.Errorf("marshaling error: %w", err)
+	}
+
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO session_items (session_id, position, item_type, message_json)
+		 VALUES (?, (SELECT COALESCE(MAX(position), -1) + 1 FROM session_items WHERE session_id = ?), 'error', ?)`,
+		sessionID, sessionID, string(errJSON))
+	return err
 }
 
 // UpdateSessionTokens updates only token/cost fields.

--- a/pkg/session/store_test.go
+++ b/pkg/session/store_test.go
@@ -854,6 +854,64 @@ func TestMigration_ExistingMessagesToSessionItems(t *testing.T) {
 	assert.Equal(t, "legacy-agent", retrieved.Messages[1].Message.AgentName)
 }
 
+func TestAddError_SQLiteRoundTrip(t *testing.T) {
+	tempDB := filepath.Join(t.TempDir(), "test_add_error.db")
+
+	store, err := NewSQLiteSessionStore(tempDB)
+	require.NoError(t, err)
+	defer store.(*SQLiteSessionStore).Close()
+
+	session := &Session{ID: "error-session", CreatedAt: time.Now()}
+	require.NoError(t, store.AddSession(t.Context(), session))
+
+	_, err = store.AddMessage(t.Context(), "error-session", UserMessage("do something"))
+	require.NoError(t, err)
+
+	err = store.AddError(t.Context(), "error-session", &Error{
+		Message:   "model stream failed",
+		Code:      "model_error",
+		AgentName: "root",
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+	})
+	require.NoError(t, err)
+
+	retrieved, err := store.GetSession(t.Context(), "error-session")
+	require.NoError(t, err)
+	require.Len(t, retrieved.Messages, 2)
+
+	errItem := retrieved.Messages[1]
+	require.True(t, errItem.IsError())
+	assert.Equal(t, "model stream failed", errItem.Error.Message)
+	assert.Equal(t, "model_error", errItem.Error.Code)
+	assert.Equal(t, "root", errItem.Error.AgentName)
+
+	// Errors are not conversation messages, so GetAllMessages skips them.
+	assert.Len(t, retrieved.GetAllMessages(), 1)
+}
+
+func TestAddError_InMemoryRoundTrip(t *testing.T) {
+	store := NewInMemorySessionStore()
+
+	session := &Session{ID: "error-session", CreatedAt: time.Now()}
+	require.NoError(t, store.AddSession(t.Context(), session))
+
+	err := store.AddError(t.Context(), "error-session", &Error{Message: "boom", Code: "tool_failed"})
+	require.NoError(t, err)
+
+	retrieved, err := store.GetSession(t.Context(), "error-session")
+	require.NoError(t, err)
+	require.Len(t, retrieved.Messages, 1)
+	require.True(t, retrieved.Messages[0].IsError())
+	assert.Equal(t, "boom", retrieved.Messages[0].Error.Message)
+	assert.Equal(t, "tool_failed", retrieved.Messages[0].Error.Code)
+}
+
+func TestAddError_NotFound(t *testing.T) {
+	store := NewInMemorySessionStore()
+	err := store.AddError(t.Context(), "missing", &Error{Message: "boom"})
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
 func TestIsRelativeSessionRef(t *testing.T) {
 	assert.True(t, IsRelativeSessionRef("-1"))
 	assert.True(t, IsRelativeSessionRef("-10"))

--- a/pkg/tui/components/messages/messages.go
+++ b/pkg/tui/components/messages/messages.go
@@ -1383,6 +1383,11 @@ func (m *model) LoadFromSession(sess *session.Session) tea.Cmd {
 	}
 
 	for pos, item := range sess.Messages {
+		if item.IsError() {
+			errMsg := types.Error(item.Error.Message)
+			appendSessionMessage(errMsg, m.createMessageView(errMsg))
+			continue
+		}
 		if !item.IsMessage() {
 			continue
 		}


### PR DESCRIPTION
When an agent run fails, the error currently disappears as soon as the session is reloaded: the TUI shows nothing, and a shared JSON export gives no clue about what went wrong. This makes diagnosing failures frustrating, especially for shared or remote sessions.

This change introduces a first-class `Error` session item type. Failures captured during a run are written to the session store alongside messages, so they survive a reload and appear in the TUI exactly where they occurred. Because the implementation reuses the existing `message_json` column with `item_type='error'`, no schema migration is needed. The `Session.AddError` method and matching `Store` interface method follow the same patterns as the existing message helpers. The persistence observer now flushes any in-flight streaming state before recording an `ErrorEvent`, and the TUI message renderer handles the new item type on reload.

A follow-up fix in the same branch closes a bug the feature introduced: `cloneSessionItem` did not handle error items, which caused `BranchSession` and `ForkSession` to fail for any session that contained a failure. `Session.Clone` also shallow-shared the `*Error` pointer, which could lead to aliasing. Both are now corrected, with regression tests.