### PR TITLE
feat: add tool-scoping for fork-mode skills

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -893,7 +893,14 @@
           "items": {
             "type": "string"
           },
-          "description": "Tools the skill expects to use (mirrors the SKILL.md allowed-tools field)."
+          "description": "Tools the skill expects to use (mirrors the SKILL.md allowed-tools field). For a fork-mode skill (context: fork) this is enforced as an allow-list over the parent agent's inherited tools while the skill runs in its sub-session: only tools whose names match an entry are kept (entries support glob patterns like 'read_*', otherwise an exact match). Ignored for non-fork skills."
+        },
+        "toolsets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Names of reusable toolset definitions (from the top-level 'toolsets' section) to expose to this skill while it runs in its fork sub-session, in addition to the parent agent's tools. Only valid for fork-mode skills (context: fork)."
         }
       },
       "required": [

--- a/docs/features/skills/index.md
+++ b/docs/features/skills/index.md
@@ -110,7 +110,8 @@ Inline skills carry their body in the config itself, so they need no `SKILL.md` 
 | `instructions`  | Yes      | The skill body (what a `SKILL.md` would contain below its frontmatter)     |
 | `context`       | No       | Set to `fork` to run the skill as an isolated sub-agent                    |
 | `model`         | No       | Override the model used while running a fork-mode skill                    |
-| `allowed_tools` | No       | Tools the skill expects to use                                             |
+| `allowed_tools` | No       | For a fork-mode skill, restricts the sub-session to the parent tools whose names match an entry (glob or exact). See [Scoping a fork skill's tools](#scoping-a-fork-skills-tools). |
+| `toolsets`      | No       | For a fork-mode skill, names of top-level [`toolsets`]({{ '/configuration/overview/' | relative_url }}#reusable-toolsets) to expose in the sub-session on top of the inherited tools. |
 
 <div class="callout callout-info" markdown="1">
 <div class="callout-title">Inline vs. file-based skills
@@ -150,7 +151,8 @@ When asked to create a Dockerfile:
 | `description`    | Yes      | Short description shown to the agent for skill matching                     |
 | `context`        | No       | Set to `fork` to run the skill as an isolated sub-agent (see below)         |
 | `model`          | No       | Override the model used while running the skill as a sub-agent (fork only)  |
-| `allowed-tools`  | No       | List of tools the skill needs (YAML list or comma-separated string)         |
+| `allowed-tools`  | No       | For a fork-mode skill, restricts the sub-session to the parent tools whose names match an entry (YAML list or comma-separated string). See [Scoping a fork skill's tools](#scoping-a-fork-skills-tools). |
+| `toolsets`       | No       | For a fork-mode skill, names of top-level [`toolsets`]({{ '/configuration/overview/' | relative_url }}#reusable-toolsets) to expose in the sub-session (YAML list or comma-separated string). |
 | `license`        | No       | License identifier (e.g. `Apache-2.0`)                                      |
 | `compatibility`  | No       | Free-text compatibility notes                                               |
 | `metadata`       | No       | Arbitrary key-value pairs (e.g. `author`, `version`)                        |
@@ -181,7 +183,7 @@ When the agent encounters a task that matches a `context: fork` skill, it uses t
 - **Spawns a child session** with the skill content as the system prompt and the caller's task as the user message
 - **Isolates the context window** — the sub-agent has its own conversation history, so lengthy tool-call chains don't eat into the parent's token budget
 - **Folds the result** — only the sub-agent's final answer is returned to the parent as the tool result
-- **Inherits the parent's model and tools** — the sub-agent can use all tools available to the parent agent
+- **Inherits the parent's model and tools** — the sub-agent can use all tools available to the parent agent (scope this with `allowed_tools` / `toolsets`, see [Scoping a fork skill's tools](#scoping-a-fork-skills-tools))
 
 <div class="callout callout-tip" markdown="1">
 <div class="callout-title">When to use context: fork
@@ -228,6 +230,80 @@ only if no one else changed the model in the meantime. If the user
 switches the model via the TUI model picker while the fork skill is
 running, their choice is preserved (the deferred restore becomes a
 no-op).
+
+### Scoping a fork skill's tools
+
+By default a fork skill inherits the parent agent's entire tool set. Two
+optional fields let you scope what the sub-session can use. Both apply
+**only to fork-mode skills** and work the same whether the skill is
+inline or loaded from a `SKILL.md` file.
+
+`allowed_tools` (frontmatter: `allowed-tools`) is an **allow-list** over
+the inherited tools: only tools whose names match an entry are kept,
+everything else is hidden from the sub-session. Entries support glob
+patterns (e.g. `read_*`) and otherwise match exactly. This is the
+Claude-Code-compatible `allowed-tools` field, now enforced for fork
+skills rather than merely recorded.
+
+`toolsets` references reusable [top-level toolsets]({{ '/configuration/overview/' | relative_url }}#reusable-toolsets)
+by name. The referenced toolsets are exposed in the sub-session **in
+addition to** the inherited tools, and they bypass the `allowed_tools`
+filter (the skill explicitly asked for them).
+
+```yaml
+toolsets:
+  web:
+    type: fetch
+
+agents:
+  root:
+    model: openai/gpt-4o
+    instruction: You are a helpful assistant.
+    toolsets:
+      - type: filesystem
+      - type: shell
+    skills:
+      # Inherits the parent tools but is restricted to read-only filesystem
+      # access while it runs — shell and write tools are hidden.
+      - name: audit
+        description: Review the repository layout without modifying anything.
+        context: fork
+        allowed_tools:
+          - read_file
+          - list_directory
+          - directory_tree
+        instructions: Inspect the repository structure and summarise it.
+
+      # Brings in the top-level `web` toolset on top of the parent's tools.
+      - name: research
+        description: Research a topic using web fetches in an isolated context.
+        context: fork
+        toolsets:
+          - web
+        instructions: Research the requested topic and summarise with links.
+```
+
+The equivalent in a `SKILL.md` file uses frontmatter lists:
+
+<!-- yaml-lint:skip -->
+```yaml
+---
+name: research
+description: Research a topic using web fetches
+context: fork
+allowed-tools:
+  - fetch
+toolsets:
+  - web
+---
+```
+
+<div class="callout callout-info" markdown="1">
+<div class="callout-title">Fork only
+</div>
+  <p>Both fields are rejected by config validation when set on a non-fork skill, and a <code>toolsets</code> entry that doesn't resolve to a top-level toolset is a load-time error.</p>
+
+</div>
 
 ## Search Paths
 
@@ -306,6 +382,6 @@ The skill will automatically be available to any agent with skills enabled (`ski
 <div class="callout-title">See also
 </div>
   <p>Skills are enabled in the <a href="{{ '/configuration/agents/' | relative_url }}">Agent Config</a> with the <code>skills</code> property (boolean or list). For tool-based capabilities, see <a href="{{ '/concepts/tools/' | relative_url }}">Tools</a>.</p>
-  <p>Example configs: <a href="https://github.com/docker/docker-agent/blob/main/examples/skills_inline.yaml"><code>examples/skills_inline.yaml</code></a> (inline skill definition), <a href="https://github.com/docker/docker-agent/blob/main/examples/skills_filter.yaml"><code>examples/skills_filter.yaml</code></a> (filtering which skills load).</p>
+  <p>Example configs: <a href="https://github.com/docker/docker-agent/blob/main/examples/skills_inline.yaml"><code>examples/skills_inline.yaml</code></a> (inline skill definition), <a href="https://github.com/docker/docker-agent/blob/main/examples/skills_fork_toolsets.yaml"><code>examples/skills_fork_toolsets.yaml</code></a> (scoping a fork skill's tools), <a href="https://github.com/docker/docker-agent/blob/main/examples/skills_filter.yaml"><code>examples/skills_filter.yaml</code></a> (filtering which skills load).</p>
 
 </div>

--- a/examples/skills_fork_toolsets.yaml
+++ b/examples/skills_fork_toolsets.yaml
@@ -1,0 +1,72 @@
+#!yaml
+# Fork-mode skills with scoped tools.
+#
+# A fork-mode skill (context: fork) runs in an isolated sub-session via the
+# run_skill tool. Two optional fields let you control which tools that
+# sub-session can use. Both apply ONLY to fork-mode skills (they are rejected
+# by config validation on non-fork skills) and work the same way whether the
+# skill is defined inline (below) or loaded from a SKILL.md file:
+#
+#   allowed_tools  An allow-list over the tools the sub-session inherits from
+#                  the parent agent. Only tools whose names match an entry are
+#                  kept; everything else is hidden. Entries support glob
+#                  patterns (e.g. "read_*"), otherwise an exact match. This
+#                  mirrors the SKILL.md `allowed-tools` frontmatter field.
+#
+#   toolsets       Names of reusable toolsets (defined in the top-level
+#                  `toolsets` section) to expose to the sub-session IN ADDITION
+#                  to the inherited tools. These bypass allowed_tools — the
+#                  skill explicitly asked for them.
+#
+# In a SKILL.md file the same fields are written in the frontmatter:
+#
+#   ---
+#   name: research
+#   description: ...
+#   context: fork
+#   allowed-tools:
+#     - fetch
+#   toolsets:
+#     - web
+#   ---
+toolsets:
+  # A reusable toolset a fork skill can pull in for its sub-session.
+  web:
+    type: fetch
+
+agents:
+  root:
+    model: openai/gpt-4o-mini
+    description: An agent that demonstrates tool-scoped fork skills.
+    instruction: |
+      You are a helpful assistant. Use the available skills when the user's
+      request matches one.
+    toolsets:
+      - type: filesystem
+      - type: shell
+    skills:
+      # Inherits the parent agent's tools but is restricted to read-only
+      # filesystem access while it runs — shell and write tools are hidden.
+      - name: audit
+        description: Review the repository layout without modifying anything.
+        context: fork
+        allowed_tools:
+          - read_file
+          - list_directory
+          - directory_tree
+        instructions: |
+          Inspect the repository structure and summarise how it is organised.
+          You can only read files; do not attempt to modify anything.
+
+      # Brings in the top-level `web` toolset (fetch) on top of the parent's
+      # tools so it can retrieve pages while researching.
+      - name: research
+        description: Research a topic using web fetches in an isolated context.
+        context: fork
+        toolsets:
+          - web
+        instructions: |
+          Research the requested topic.
+
+          - Fetch the most authoritative sources you can find.
+          - Summarise findings with links.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -155,6 +155,10 @@ func validateConfig(cfg *latest.Config) error {
 		return err
 	}
 
+	if err := validateSkillToolsetRefs(cfg); err != nil {
+		return err
+	}
+
 	allNames := map[string]bool{}
 	for _, agent := range cfg.Agents {
 		allNames[agent.Name] = true
@@ -323,6 +327,25 @@ func validateProviderName(name string) error {
 	return nil
 }
 
+// validateSkillToolsetRefs checks that every toolset name referenced by an
+// agent's inline fork skills resolves to a definition in the top-level
+// `toolsets` section. Runs after resolveSkillDefinitions so skills merged in
+// via use_skills are covered too.
+func validateSkillToolsetRefs(cfg *latest.Config) error {
+	for i := range cfg.Agents {
+		agent := &cfg.Agents[i]
+		for j := range agent.Skills.Inline {
+			inline := &agent.Skills.Inline[j]
+			for _, ref := range inline.Toolsets {
+				if _, ok := cfg.Toolsets[ref]; !ok {
+					return fmt.Errorf("agent '%s' inline skill '%s' references non-existent toolset '%s'", agent.Name, inline.Name, ref)
+				}
+			}
+		}
+	}
+	return nil
+}
+
 // validateSkills validates a skills configuration. label identifies the owner
 // of the configuration in error messages (e.g. "agent 'foo'" or
 // "skill group 'base'").
@@ -358,6 +381,14 @@ func validateSkills(label string, sc *latest.SkillsConfig) error {
 		}
 		if inline.Context != "" && inline.Context != "fork" {
 			return fmt.Errorf("%s inline skill '%s' has invalid context '%s' (only 'fork' is supported)", label, inline.Name, inline.Context)
+		}
+		if inline.Context != "fork" {
+			if len(inline.Toolsets) > 0 {
+				return fmt.Errorf("%s inline skill '%s' declares toolsets but is not a fork skill (set context: fork)", label, inline.Name)
+			}
+			if len(inline.AllowedTools) > 0 {
+				return fmt.Errorf("%s inline skill '%s' declares allowed_tools but is not a fork skill (set context: fork)", label, inline.Name)
+			}
 		}
 		if seenInline[inline.Name] {
 			return fmt.Errorf("%s has duplicate inline skill '%s'", label, inline.Name)

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -548,8 +548,17 @@ type InlineSkill struct {
 	// Ignored for non-fork skills.
 	Model string `json:"model,omitempty" yaml:"model,omitempty"`
 	// AllowedTools optionally records the tools the skill expects. It mirrors
-	// the SKILL.md `allowed-tools` field.
+	// the SKILL.md `allowed-tools` field. For a fork-mode skill it is enforced
+	// as an allow-list over the parent agent's inherited tools while the skill
+	// runs in its sub-session: only tools whose names match an entry are kept.
+	// Entries are matched with filepath.Match-style globs (e.g. "read_*"),
+	// falling back to an exact match. Ignored for non-fork skills.
 	AllowedTools []string `json:"allowed_tools,omitempty" yaml:"allowed_tools,omitempty"`
+	// Toolsets lists names of reusable toolset definitions (from the top-level
+	// `toolsets` section) to expose to the skill while it runs in its fork
+	// sub-session, in addition to the parent agent's tools. Ignored for
+	// non-fork skills.
+	Toolsets []string `json:"toolsets,omitempty" yaml:"toolsets,omitempty"`
 }
 
 // SkillsConfig controls skill discovery sources, filtering, and inline

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -211,6 +211,120 @@ func TestInlineSkillsValidationErrors(t *testing.T) {
 	}
 }
 
+func TestForkSkillToolsets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid fork skill with toolset reference", func(t *testing.T) {
+		t.Parallel()
+		cfgStr := `version: "` + latest.Version + `"
+toolsets:
+  web:
+    type: fetch
+agents:
+  root:
+    model: openai/gpt-4o
+    instruction: test
+    skills:
+      - name: research
+        description: Research a topic.
+        context: fork
+        toolsets:
+          - web
+        instructions: Do research.
+`
+		cfg, err := Load(t.Context(), NewBytesSource("test", []byte(cfgStr)))
+		require.NoError(t, err)
+		agent, ok := cfg.Agents.Lookup("root")
+		require.True(t, ok)
+		require.Len(t, agent.Skills.Inline, 1)
+		assert.Equal(t, []string{"web"}, agent.Skills.Inline[0].Toolsets)
+	})
+
+	t.Run("valid fork skill with allowed_tools", func(t *testing.T) {
+		t.Parallel()
+		cfgStr := `version: "` + latest.Version + `"
+agents:
+  root:
+    model: openai/gpt-4o
+    instruction: test
+    skills:
+      - name: audit
+        description: Audit the repo.
+        context: fork
+        allowed_tools:
+          - read_file
+        instructions: Inspect only.
+`
+		cfg, err := Load(t.Context(), NewBytesSource("test", []byte(cfgStr)))
+		require.NoError(t, err)
+		agent, ok := cfg.Agents.Lookup("root")
+		require.True(t, ok)
+		require.Len(t, agent.Skills.Inline, 1)
+		assert.Equal(t, []string{"read_file"}, agent.Skills.Inline[0].AllowedTools)
+	})
+
+	t.Run("toolsets on non-fork skill is rejected", func(t *testing.T) {
+		t.Parallel()
+		cfgStr := `version: "` + latest.Version + `"
+toolsets:
+  web:
+    type: fetch
+agents:
+  root:
+    model: openai/gpt-4o
+    instruction: test
+    skills:
+      - name: research
+        description: Research a topic.
+        toolsets:
+          - web
+        instructions: Do research.
+`
+		_, err := Load(t.Context(), NewBytesSource("test", []byte(cfgStr)))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a fork skill")
+	})
+
+	t.Run("allowed_tools on non-fork skill is rejected", func(t *testing.T) {
+		t.Parallel()
+		cfgStr := `version: "` + latest.Version + `"
+agents:
+  root:
+    model: openai/gpt-4o
+    instruction: test
+    skills:
+      - name: audit
+        description: Audit the repo.
+        allowed_tools:
+          - read_file
+        instructions: Inspect only.
+`
+		_, err := Load(t.Context(), NewBytesSource("test", []byte(cfgStr)))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a fork skill")
+	})
+
+	t.Run("unknown toolset reference is rejected", func(t *testing.T) {
+		t.Parallel()
+		cfgStr := `version: "` + latest.Version + `"
+agents:
+  root:
+    model: openai/gpt-4o
+    instruction: test
+    skills:
+      - name: research
+        description: Research a topic.
+        context: fork
+        toolsets:
+          - nonexistent
+        instructions: Do research.
+`
+		_, err := Load(t.Context(), NewBytesSource("test", []byte(cfgStr)))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "non-existent toolset")
+	})
+}
+
 func TestSkillsNameFilter(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/runtime/agent_delegation.go
+++ b/pkg/runtime/agent_delegation.go
@@ -109,6 +109,15 @@ type SubSessionConfig struct {
 	// tool list for the child session. This prevents recursive tool calls
 	// (e.g. run_skill calling itself in a skill sub-session).
 	ExcludedTools []string
+	// AllowedTools, when non-empty, restricts the child session's inherited
+	// agent tools to those whose names match an entry (glob or exact). Used by
+	// fork-mode skills that declare an allowed-tools list. ExtraToolSets are
+	// exempt from this filter.
+	AllowedTools []string
+	// ExtraToolSets are additional toolsets exposed in the child session on
+	// top of the agent's own toolsets. Used by fork-mode skills that declare
+	// assistive toolsets.
+	ExtraToolSets []tools.ToolSet
 }
 
 // delegationRequest bundles a [SubSessionConfig] with the single
@@ -181,6 +190,12 @@ func newSubSession(parent *session.Session, cfg SubSessionConfig, childAgent *ag
 	excludedTools := mergeExcludedTools(parent.ExcludedTools, cfg.ExcludedTools)
 	if len(excludedTools) > 0 {
 		opts = append(opts, session.WithExcludedTools(excludedTools))
+	}
+	if len(cfg.AllowedTools) > 0 {
+		opts = append(opts, session.WithAllowedTools(cfg.AllowedTools))
+	}
+	if len(cfg.ExtraToolSets) > 0 {
+		opts = append(opts, session.WithExtraToolSets(cfg.ExtraToolSets))
 	}
 	return session.New(opts...)
 }

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"path/filepath"
 	"slices"
 	"strings"
 	"time"
@@ -306,6 +307,7 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 		return
 	}
 	agentTools = filterExcludedTools(agentTools, sess.ExcludedTools)
+	agentTools = r.skillSubSessionTools(ctx, sess, a, agentTools, sink)
 
 	// Record the catalogue size on the session span — answers "how
 	// many tools could this turn actually use?" without having to
@@ -400,6 +402,7 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 			return
 		}
 		agentTools = filterExcludedTools(agentTools, sess.ExcludedTools)
+		agentTools = r.skillSubSessionTools(ctx, sess, a, agentTools, sink)
 
 		// Emit updated tool count. After a ToolListChanged MCP notification
 		// the cache is invalidated, so getTools above re-fetches from the
@@ -1093,6 +1096,76 @@ func filterExcludedTools(agentTools []tools.Tool, excluded []string) []tools.Too
 	return filtered
 }
 
+// filterAllowedTools keeps only tools whose names match an entry in allowed
+// (filepath.Match-style glob, falling back to an exact match). An empty
+// allow-list imposes no restriction. Used by fork-mode skill sub-sessions
+// that declare an allowed-tools list.
+func filterAllowedTools(agentTools []tools.Tool, allowed []string) []tools.Tool {
+	if len(allowed) == 0 {
+		return agentTools
+	}
+	filtered := make([]tools.Tool, 0, len(agentTools))
+	for _, t := range agentTools {
+		if toolNameMatchesAny(t.Name, allowed) {
+			filtered = append(filtered, t)
+		}
+	}
+	return filtered
+}
+
+// toolNameMatchesAny reports whether name matches any of the patterns. Each
+// pattern is tried as a filepath.Match glob; a malformed pattern falls back
+// to an exact string comparison.
+func toolNameMatchesAny(name string, patterns []string) bool {
+	for _, p := range patterns {
+		if p == name {
+			return true
+		}
+		if ok, err := filepath.Match(p, name); err == nil && ok {
+			return true
+		}
+	}
+	return false
+}
+
+// skillSubSessionTools augments the agent's tools for a fork-mode skill
+// sub-session: it applies the skill's allowed-tools allow-list to the
+// inherited agent tools, then appends the tools from the skill's assistive
+// toolsets (which bypass the allow-list — the skill explicitly asked for
+// them). It is a no-op for ordinary sessions that set neither field.
+func (r *LocalRuntime) skillSubSessionTools(ctx context.Context, sess *session.Session, a *agent.Agent, agentTools []tools.Tool, events EventSink) []tools.Tool {
+	if len(sess.AllowedTools) == 0 && len(sess.ExtraToolSets) == 0 {
+		return agentTools
+	}
+
+	agentTools = filterAllowedTools(agentTools, sess.AllowedTools)
+
+	for _, ts := range sess.ExtraToolSets {
+		tools.ConfigureHandlers(ts,
+			r.elicitationHandler,
+			r.samplingHandler,
+			func() { events.Emit(Authorization(tools.ElicitationActionAccept, a.Name())) },
+			r.managedOAuth,
+			r.unmanagedOAuthRedirectURI,
+		)
+		if startable, ok := tools.As[tools.Startable](ts); ok {
+			if err := startable.Start(ctx); err != nil {
+				slog.WarnContext(ctx, "Skill toolset failed to start; skipping",
+					"agent", a.Name(), "toolset", tools.DescribeToolSet(ts), "error", err)
+				continue
+			}
+		}
+		extra, err := ts.Tools(ctx)
+		if err != nil {
+			slog.WarnContext(ctx, "Skill toolset listing failed; skipping",
+				"agent", a.Name(), "toolset", tools.DescribeToolSet(ts), "error", err)
+			continue
+		}
+		agentTools = append(agentTools, extra...)
+	}
+	return agentTools
+}
+
 // reprobe re-runs ensureToolSetsAreStarted after a batch of tool calls.
 // If new tools became available (by name-set diff), it emits a ToolsetInfo
 // event to update the TUI immediately. The new tools will be picked up by
@@ -1114,6 +1187,7 @@ func (r *LocalRuntime) reprobe(
 		return
 	}
 	updated = filterExcludedTools(updated, sess.ExcludedTools)
+	updated = r.skillSubSessionTools(ctx, sess, a, updated, events)
 
 	// Emit any pending warnings that getTools just generated.
 	r.emitAgentWarnings(a, events)

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -2644,6 +2644,98 @@ func TestFilterExcludedTools(t *testing.T) {
 	})
 }
 
+func TestFilterAllowedTools(t *testing.T) {
+	allTools := []tools.Tool{
+		{Name: "read_file"},
+		{Name: "list_directory"},
+		{Name: "shell"},
+		{Name: "write_file"},
+	}
+
+	t.Run("empty allow-list returns all tools", func(t *testing.T) {
+		result := filterAllowedTools(allTools, nil)
+		assert.Len(t, result, 4)
+	})
+
+	t.Run("exact names", func(t *testing.T) {
+		result := filterAllowedTools(allTools, []string{"read_file", "shell"})
+		assert.Len(t, result, 2)
+		assert.Equal(t, "read_file", result[0].Name)
+		assert.Equal(t, "shell", result[1].Name)
+	})
+
+	t.Run("glob pattern", func(t *testing.T) {
+		result := filterAllowedTools(allTools, []string{"*_file"})
+		assert.Len(t, result, 2)
+		assert.ElementsMatch(t, []string{"read_file", "write_file"}, []string{result[0].Name, result[1].Name})
+	})
+
+	t.Run("no match yields empty", func(t *testing.T) {
+		result := filterAllowedTools(allTools, []string{"nonexistent"})
+		assert.Empty(t, result)
+	})
+}
+
+func TestToolNameMatchesAny(t *testing.T) {
+	assert.True(t, toolNameMatchesAny("read_file", []string{"read_file"}))
+	assert.True(t, toolNameMatchesAny("read_file", []string{"read_*"}))
+	assert.True(t, toolNameMatchesAny("read_file", []string{"shell", "read_*"}))
+	assert.False(t, toolNameMatchesAny("read_file", []string{"write_*"}))
+	assert.False(t, toolNameMatchesAny("read_file", nil))
+	// A malformed glob pattern falls back to exact comparison.
+	assert.True(t, toolNameMatchesAny("a[b", []string{"a[b"}))
+}
+
+// TestSkillSubSessionTools_ScopesAndInjects verifies that a fork-mode skill
+// sub-session both restricts inherited tools to the skill's allowed-tools
+// list and appends the tools from the skill's assistive toolsets (which are
+// exempt from the allow-list).
+func TestSkillSubSessionTools_ScopesAndInjects(t *testing.T) {
+	t.Parallel()
+
+	prov := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
+	root := agent.New("root", "agent", agent.WithModel(prov))
+	tm := team.New(team.WithAgents(root))
+	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+
+	inherited := []tools.Tool{
+		{Name: "read_file"},
+		{Name: "shell"},
+		{Name: "write_file"},
+	}
+	extraTool := tools.Tool{Name: "fetch"}
+
+	sess := session.New(
+		session.WithAllowedTools([]string{"read_file"}),
+		session.WithExtraToolSets([]tools.ToolSet{newStubToolSet(nil, []tools.Tool{extraTool}, nil)}),
+	)
+
+	result := rt.skillSubSessionTools(t.Context(), sess, root, inherited, NewChannelSink(make(chan Event, 8)))
+
+	names := toolNames(result)
+	// read_file kept (allow-listed), shell/write_file filtered out, fetch injected.
+	assert.ElementsMatch(t, []string{"read_file", "fetch"}, names)
+}
+
+// TestSkillSubSessionTools_NoOpForOrdinarySession verifies that a session
+// without AllowedTools/ExtraToolSets is unaffected.
+func TestSkillSubSessionTools_NoOpForOrdinarySession(t *testing.T) {
+	t.Parallel()
+
+	prov := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
+	root := agent.New("root", "agent", agent.WithModel(prov))
+	tm := team.New(team.WithAgents(root))
+	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+
+	inherited := []tools.Tool{{Name: "read_file"}, {Name: "shell"}}
+	sess := session.New()
+
+	result := rt.skillSubSessionTools(t.Context(), sess, root, inherited, NewChannelSink(make(chan Event, 8)))
+	assert.Equal(t, inherited, result)
+}
+
 func TestMergeExcludedTools(t *testing.T) {
 	t.Run("both empty", func(t *testing.T) {
 		assert.Nil(t, mergeExcludedTools(nil, nil))

--- a/pkg/runtime/skill_runner.go
+++ b/pkg/runtime/skill_runner.go
@@ -112,6 +112,8 @@ func (r *LocalRuntime) RunSkillFork(ctx context.Context, sess *session.Session, 
 			ToolsApproved:       sess.ToolsApproved,
 			NonInteractive:      sess.NonInteractive,
 			ExcludedTools:       []string{skills.ToolNameRunSkill},
+			AllowedTools:        prepared.AllowedTools,
+			ExtraToolSets:       prepared.ToolSets,
 		},
 	})
 }

--- a/pkg/session/branch.go
+++ b/pkg/session/branch.go
@@ -96,6 +96,8 @@ func (s *Session) Clone() *Session {
 		CustomModelsUsed:        cloneStringSlice(s.CustomModelsUsed),
 		AttachedFiles:           cloneStringSlice(s.AttachedFiles),
 		ExcludedTools:           cloneStringSlice(s.ExcludedTools),
+		AllowedTools:            cloneStringSlice(s.AllowedTools),
+		ExtraToolSets:           slices.Clone(s.ExtraToolSets),
 		AgentName:               s.AgentName,
 		ParentID:                s.ParentID,
 		MessageUsageHistory:     slices.Clone(s.MessageUsageHistory),

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -159,6 +159,19 @@ type Session struct {
 	// recursive run_skill calls.
 	ExcludedTools []string `json:"-"`
 
+	// AllowedTools, when non-empty, restricts this session's agent tools to
+	// those whose names match an entry (filepath.Match-style glob, falling
+	// back to an exact match). Used by fork-mode skill sub-sessions that
+	// declare an allowed-tools list. An empty list imposes no restriction.
+	// ExtraToolSets are always kept regardless of this filter.
+	AllowedTools []string `json:"-"`
+
+	// ExtraToolSets holds additional toolsets injected into this session on
+	// top of the agent's own toolsets. Used by fork-mode skill sub-sessions
+	// that declare assistive toolsets. Their tools bypass the AllowedTools
+	// filter (the skill explicitly asked for them).
+	ExtraToolSets []tools.ToolSet `json:"-"`
+
 	// AgentName, when set, tells RunStream which agent to use for this session
 	// instead of reading from the shared runtime currentAgent field. This is
 	// required for background agent tasks where multiple sessions may run
@@ -764,6 +777,24 @@ func WithID(id string) Opt {
 func WithExcludedTools(names []string) Opt {
 	return func(s *Session) {
 		s.ExcludedTools = names
+	}
+}
+
+// WithAllowedTools restricts the session's agent tools to those whose names
+// match an entry (glob or exact). Used by fork-mode skill sub-sessions.
+// ExtraToolSets are exempt from this filter.
+func WithAllowedTools(names []string) Opt {
+	return func(s *Session) {
+		s.AllowedTools = names
+	}
+}
+
+// WithExtraToolSets injects additional toolsets into the session on top of
+// the agent's own toolsets. Used by fork-mode skill sub-sessions that declare
+// assistive toolsets.
+func WithExtraToolSets(toolSets []tools.ToolSet) Opt {
+	return func(s *Session) {
+		s.ExtraToolSets = toolSets
 	}
 }
 

--- a/pkg/skills/frontmatter.go
+++ b/pkg/skills/frontmatter.go
@@ -77,6 +77,17 @@ func parseTopLevelLine(skill *Skill, key, value string) bool {
 				skill.AllowedTools = append(skill.AllowedTools, t)
 			}
 		}
+	case "toolsets":
+		if value == "" {
+			// Block form: subsequent indented "- item" lines.
+			return true
+		}
+		// Inline comma-separated list.
+		for item := range strings.SplitSeq(value, ",") {
+			if t := unquote(strings.TrimSpace(item)); t != "" {
+				skill.Toolsets = append(skill.Toolsets, t)
+			}
+		}
 	}
 	return false
 }
@@ -95,6 +106,10 @@ func parseIndentedLine(skill *Skill, parentKey, line string) {
 	case "allowed-tools":
 		if item, ok := strings.CutPrefix(line, "- "); ok {
 			skill.AllowedTools = append(skill.AllowedTools, unquote(strings.TrimSpace(item)))
+		}
+	case "toolsets":
+		if item, ok := strings.CutPrefix(line, "- "); ok {
+			skill.Toolsets = append(skill.Toolsets, unquote(strings.TrimSpace(item)))
 		}
 	}
 }

--- a/pkg/skills/skills.go
+++ b/pkg/skills/skills.go
@@ -22,7 +22,13 @@ type Skill struct {
 	Compatibility string
 	Metadata      map[string]string
 	AllowedTools  []string
-	Context       string // "fork" to run the skill as an isolated sub-agent
+	// Toolsets lists names of reusable toolset definitions (from the top-level
+	// `toolsets` section) to expose to the skill while it runs as a fork
+	// sub-agent (context: fork), in addition to the parent agent's tools.
+	// Populated from inline config or the SKILL.md `toolsets` frontmatter.
+	// Ignored for non-fork skills.
+	Toolsets []string
+	Context  string // "fork" to run the skill as an isolated sub-agent
 	// Model is an optional model override applied while the skill runs as
 	// a sub-agent (context: fork). It accepts either a named model from the
 	// agent config or an inline "provider/model" reference (e.g.

--- a/pkg/skills/skills_test.go
+++ b/pkg/skills/skills_test.go
@@ -160,6 +160,44 @@ Body`,
 			wantOK: true,
 		},
 		{
+			name: "context fork with toolsets",
+			content: `---
+name: tooled-fork
+description: Fork skill with assistive toolsets
+context: fork
+toolsets:
+  - web
+  - db
+---
+
+Body`,
+			want: Skill{
+				Name:        "tooled-fork",
+				Description: "Fork skill with assistive toolsets",
+				Context:     "fork",
+				Toolsets:    []string{"web", "db"},
+			},
+			wantOK: true,
+		},
+		{
+			name: "toolsets as comma-separated string",
+			content: `---
+name: csv-toolsets
+description: Fork skill with comma-separated toolsets
+context: fork
+toolsets: web, db
+---
+
+Body`,
+			want: Skill{
+				Name:        "csv-toolsets",
+				Description: "Fork skill with comma-separated toolsets",
+				Context:     "fork",
+				Toolsets:    []string{"web", "db"},
+			},
+			wantOK: true,
+		},
+		{
 			name: "model override (named)",
 			content: `---
 name: model-skill
@@ -227,6 +265,7 @@ Body`,
 				assert.Equal(t, tt.want.Compatibility, got.Compatibility)
 				assert.Equal(t, tt.want.Metadata, got.Metadata)
 				assert.Equal(t, tt.want.AllowedTools, got.AllowedTools)
+				assert.Equal(t, tt.want.Toolsets, got.Toolsets)
 				assert.Equal(t, tt.want.Context, got.Context)
 				assert.Equal(t, tt.want.Model, got.Model)
 			}

--- a/pkg/teamloader/skills_toolsets_test.go
+++ b/pkg/teamloader/skills_toolsets_test.go
@@ -54,9 +54,9 @@ agents:
 	assert.Len(t, prepared.ToolSets, 1, "fork skill must carry its resolved assistive toolset")
 }
 
-// TestForkSkillToolsets_NonForkSkipped verifies that toolsets declared on a
-// non-fork skill are not resolved (they are rejected by config validation, so
-// this guards the loader's IsFork gate independently).
+// TestForkSkillToolsets_AllowedToolsThreaded verifies that a fork skill's
+// allowed_tools list is threaded through to the prepared fork (it is enforced
+// against the inherited tools at runtime, see pkg/runtime).
 func TestForkSkillToolsets_AllowedToolsThreaded(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "dummy")
 
@@ -98,4 +98,63 @@ func TestForkSkillToolsets_AllowedToolsThreaded(t *testing.T) {
 // skillSetFrom unwraps a toolset to a *skillstool.ToolSet if possible.
 func skillSetFrom(ts tools.ToolSet) (*skillstool.ToolSet, bool) {
 	return tools.As[*skillstool.ToolSet](ts)
+}
+
+// TestForkSkillToolsets_ReadonlyAgentFiltersMutatingTools verifies that a
+// readonly agent does not gain mutating tools through a fork skill's
+// assistive toolset: the agent-level readonly flag is applied to the skill's
+// toolset, so only read-only tools survive. Without this, a `readonly: true`
+// agent could call a mutating tool (e.g. shell) inside a fork sub-session.
+func TestForkSkillToolsets_ReadonlyAgentFiltersMutatingTools(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "dummy")
+
+	data := []byte(`toolsets:
+  shell_ts:
+    type: shell
+agents:
+  root:
+    model: openai/gpt-4o
+    instruction: test
+    readonly: true
+    skills:
+      - name: builder
+        description: Build things in an isolated context.
+        context: fork
+        toolsets:
+          - shell_ts
+        instructions: Do the build.
+`)
+
+	team, err := Load(t.Context(), config.NewBytesSource("fork_readonly.yaml", data), &config.RuntimeConfig{}, withTestProviderRegistry()...)
+	require.NoError(t, err)
+
+	root, err := team.Agent("root")
+	require.NoError(t, err)
+
+	var skillSet *skillstool.ToolSet
+	for _, ts := range root.ToolSets() {
+		if s, ok := skillSetFrom(ts); ok {
+			skillSet = s
+			break
+		}
+	}
+	require.NotNil(t, skillSet)
+
+	prepared, errResult := skillSet.PrepareForkSubSession(t.Context(), skillstool.RunSkillArgs{Name: "builder", Task: "go"})
+	require.Nil(t, errResult)
+	require.Len(t, prepared.ToolSets, 1)
+
+	// Start and list the skill's toolset; the mutating shell tool must be
+	// filtered out by the agent-level readonly flag, leaving only the
+	// read-only-hinted tools.
+	ts := prepared.ToolSets[0]
+	if startable, ok := tools.As[tools.Startable](ts); ok {
+		require.NoError(t, startable.Start(t.Context()))
+	}
+	listed, err := ts.Tools(t.Context())
+	require.NoError(t, err)
+	for _, tool := range listed {
+		assert.NotEqual(t, "shell", tool.Name, "readonly agent must not expose the mutating shell tool via a fork skill")
+		assert.NotEqual(t, "run_shell_background", tool.Name, "readonly agent must not expose mutating background-shell tools via a fork skill")
+	}
 }

--- a/pkg/teamloader/skills_toolsets_test.go
+++ b/pkg/teamloader/skills_toolsets_test.go
@@ -1,0 +1,101 @@
+package teamloader
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/tools"
+	skillstool "github.com/docker/docker-agent/pkg/tools/builtin/skills"
+)
+
+// TestForkSkillToolsets_Resolved verifies that an inline fork skill that
+// declares assistive toolsets has them resolved from the top-level toolsets
+// section and exposed through the agent's skills toolset, keyed by skill name.
+func TestForkSkillToolsets_Resolved(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "dummy")
+
+	data := []byte(`toolsets:
+  shell_ts:
+    type: shell
+agents:
+  root:
+    model: openai/gpt-4o
+    instruction: test
+    skills:
+      - name: builder
+        description: Build things in an isolated context.
+        context: fork
+        toolsets:
+          - shell_ts
+        instructions: Do the build.
+`)
+
+	team, err := Load(t.Context(), config.NewBytesSource("fork_toolsets.yaml", data), &config.RuntimeConfig{}, withTestProviderRegistry()...)
+	require.NoError(t, err)
+
+	root, err := team.Agent("root")
+	require.NoError(t, err)
+
+	var skillSet *skillstool.ToolSet
+	for _, ts := range root.ToolSets() {
+		if s, ok := skillSetFrom(ts); ok {
+			skillSet = s
+			break
+		}
+	}
+	require.NotNil(t, skillSet, "agent must expose a skills toolset")
+
+	prepared, errResult := skillSet.PrepareForkSubSession(t.Context(), skillstool.RunSkillArgs{Name: "builder", Task: "go"})
+	require.Nil(t, errResult)
+	require.NotNil(t, prepared)
+	assert.Len(t, prepared.ToolSets, 1, "fork skill must carry its resolved assistive toolset")
+}
+
+// TestForkSkillToolsets_NonForkSkipped verifies that toolsets declared on a
+// non-fork skill are not resolved (they are rejected by config validation, so
+// this guards the loader's IsFork gate independently).
+func TestForkSkillToolsets_AllowedToolsThreaded(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "dummy")
+
+	data := []byte(`agents:
+  root:
+    model: openai/gpt-4o
+    instruction: test
+    skills:
+      - name: auditor
+        description: Read-only audit in an isolated context.
+        context: fork
+        allowed_tools:
+          - read_file
+        instructions: Inspect only.
+`)
+
+	team, err := Load(t.Context(), config.NewBytesSource("fork_allowed.yaml", data), &config.RuntimeConfig{}, withTestProviderRegistry()...)
+	require.NoError(t, err)
+
+	root, err := team.Agent("root")
+	require.NoError(t, err)
+
+	var skillSet *skillstool.ToolSet
+	for _, ts := range root.ToolSets() {
+		if s, ok := skillSetFrom(ts); ok {
+			skillSet = s
+			break
+		}
+	}
+	require.NotNil(t, skillSet)
+
+	prepared, errResult := skillSet.PrepareForkSubSession(t.Context(), skillstool.RunSkillArgs{Name: "auditor", Task: "go"})
+	require.Nil(t, errResult)
+	require.NotNil(t, prepared)
+	assert.Equal(t, []string{"read_file"}, prepared.AllowedTools)
+	assert.Empty(t, prepared.ToolSets)
+}
+
+// skillSetFrom unwraps a toolset to a *skillstool.ToolSet if possible.
+func skillSetFrom(ts tools.ToolSet) (*skillstool.ToolSet, bool) {
+	return tools.As[*skillstool.ToolSet](ts)
+}

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -299,7 +299,7 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 				skillSet := skillstool.New(loadedSkills, runConfig.WorkingDir)
 				// Resolve the additional toolsets each fork skill exposes in
 				// its sub-session from the top-level toolsets section.
-				forkToolSets, forkWarnings := forkSkillToolSets(ctx, cfg, loadedSkills, parentDir, runConfig, loadOpts.toolsetRegistry, configName, expander)
+				forkToolSets, forkWarnings := forkSkillToolSets(ctx, cfg, &agentConfig, loadedSkills, parentDir, runConfig, loadOpts.toolsetRegistry, configName, expander)
 				if len(forkToolSets) > 0 {
 					skillSet.SetForkToolSets(forkToolSets)
 				}
@@ -678,10 +678,13 @@ func inlineSkills(defs []latest.InlineSkill) []skills.Skill {
 // list of toolsets to expose while the skill runs in its sub-session. Toolset
 // names are resolved against the top-level `toolsets` section and instantiated
 // through the same registry path agents use, so they get the standard
-// name/filter/instruction wrappers. Non-fork skills and skills without
-// declared toolsets are skipped. Creation failures are collected as warnings
-// (parity with getToolsForAgent) rather than aborting the load.
-func forkSkillToolSets(ctx context.Context, cfg *latest.Config, loadedSkills []skills.Skill, parentDir string, runConfig *config.RuntimeConfig, registry ToolsetRegistry, configName string, expander *js.Expander) (map[string][]tools.ToolSet, []string) {
+// name/filter/instruction wrappers. Each toolset is wrapped in a
+// StartableToolSet so the runtime gets the same lazy, single-flight start and
+// failure-dedup semantics as the agent's own toolsets. Non-fork skills and
+// skills without declared toolsets are skipped. Creation failures are
+// collected as warnings (parity with getToolsForAgent) rather than aborting
+// the load.
+func forkSkillToolSets(ctx context.Context, cfg *latest.Config, a *latest.AgentConfig, loadedSkills []skills.Skill, parentDir string, runConfig *config.RuntimeConfig, registry ToolsetRegistry, configName string, expander *js.Expander) (map[string][]tools.ToolSet, []string) {
 	var (
 		result   map[string][]tools.ToolSet
 		warnings []string
@@ -706,11 +709,16 @@ func forkSkillToolSets(ctx context.Context, cfg *latest.Config, loadedSkills []s
 				continue
 			}
 			wrapped := WithToolsFilter(tool, toolset.Tools...)
-			wrapped = WithReadOnlyFilter(wrapped, toolset.ReadOnly)
+			// Honor the agent-level readonly flag, exactly like getToolsForAgent:
+			// a readonly agent must not gain mutating tools through a fork skill.
+			wrapped = WithReadOnlyFilter(wrapped, toolset.ReadOnly || a.ReadOnly)
 			wrapped = WithInstructions(wrapped, expander.Expand(ctx, toolset.Instruction, nil))
 			wrapped = WithToon(wrapped, toolset.Toon)
 			wrapped = WithModelOverride(wrapped, toolset.Model)
-			built = append(built, wrapped)
+			// Wrap for lazy, single-flight start + failure-dedup, matching
+			// agent.WithToolSets. skillSubSessionTools calls Start() on every
+			// run-loop iteration, so the toolset must tolerate repeated starts.
+			built = append(built, tools.NewStartable(wrapped))
 		}
 		if len(built) > 0 {
 			if result == nil {

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -296,7 +296,17 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 			// always exposed and never subject to the include filter.
 			loadedSkills = append(loadedSkills, inlineSkills(agentConfig.Skills.Inline)...)
 			if len(loadedSkills) > 0 {
-				agentTools = append(agentTools, skillstool.New(loadedSkills, runConfig.WorkingDir))
+				skillSet := skillstool.New(loadedSkills, runConfig.WorkingDir)
+				// Resolve the additional toolsets each fork skill exposes in
+				// its sub-session from the top-level toolsets section.
+				forkToolSets, forkWarnings := forkSkillToolSets(ctx, cfg, loadedSkills, parentDir, runConfig, loadOpts.toolsetRegistry, configName, expander)
+				if len(forkToolSets) > 0 {
+					skillSet.SetForkToolSets(forkToolSets)
+				}
+				if len(forkWarnings) > 0 {
+					opts = append(opts, agent.WithLoadTimeWarnings(forkWarnings))
+				}
+				agentTools = append(agentTools, skillSet)
 			}
 		}
 
@@ -658,9 +668,58 @@ func inlineSkills(defs []latest.InlineSkill) []skills.Skill {
 			Context:       d.Context,
 			Model:         d.Model,
 			AllowedTools:  d.AllowedTools,
+			Toolsets:      d.Toolsets,
 		})
 	}
 	return out
+}
+
+// forkSkillToolSets builds, for each fork skill that declares toolsets, the
+// list of toolsets to expose while the skill runs in its sub-session. Toolset
+// names are resolved against the top-level `toolsets` section and instantiated
+// through the same registry path agents use, so they get the standard
+// name/filter/instruction wrappers. Non-fork skills and skills without
+// declared toolsets are skipped. Creation failures are collected as warnings
+// (parity with getToolsForAgent) rather than aborting the load.
+func forkSkillToolSets(ctx context.Context, cfg *latest.Config, loadedSkills []skills.Skill, parentDir string, runConfig *config.RuntimeConfig, registry ToolsetRegistry, configName string, expander *js.Expander) (map[string][]tools.ToolSet, []string) {
+	var (
+		result   map[string][]tools.ToolSet
+		warnings []string
+	)
+	for i := range loadedSkills {
+		skill := loadedSkills[i]
+		if !skill.IsFork() || len(skill.Toolsets) == 0 {
+			continue
+		}
+		var built []tools.ToolSet
+		for _, ref := range skill.Toolsets {
+			toolset, ok := cfg.Toolsets[ref]
+			if !ok {
+				// Validated in config.validateSkillToolsetRefs; defensive only.
+				warnings = append(warnings, fmt.Sprintf("skill %s references unknown toolset %s", skill.Name, ref))
+				continue
+			}
+			tool, err := registry.CreateTool(ctx, toolset, parentDir, runConfig, configName)
+			if err != nil {
+				slog.WarnContext(ctx, "Skill toolset configuration failed; skipping", "skill", skill.Name, "toolset", ref, "error", err)
+				warnings = append(warnings, fmt.Sprintf("skill %s toolset %s failed: %v", skill.Name, ref, err))
+				continue
+			}
+			wrapped := WithToolsFilter(tool, toolset.Tools...)
+			wrapped = WithReadOnlyFilter(wrapped, toolset.ReadOnly)
+			wrapped = WithInstructions(wrapped, expander.Expand(ctx, toolset.Instruction, nil))
+			wrapped = WithToon(wrapped, toolset.Toon)
+			wrapped = WithModelOverride(wrapped, toolset.Model)
+			built = append(built, wrapped)
+		}
+		if len(built) > 0 {
+			if result == nil {
+				result = make(map[string][]tools.ToolSet)
+			}
+			result[skill.Name] = built
+		}
+	}
+	return result, warnings
 }
 
 // filterSkillsByName returns the subset of skills whose Name matches one of

--- a/pkg/tools/builtin/skills/skills.go
+++ b/pkg/tools/builtin/skills/skills.go
@@ -76,6 +76,10 @@ func stripFrontmatter(content string) string {
 type ToolSet struct {
 	skills     []skills.Skill
 	workingDir string
+	// forkToolSets maps a fork skill's name to the additional toolsets it
+	// exposes while running in its sub-session (resolved from the skill's
+	// declared toolset names by the loader). Nil for skills without any.
+	forkToolSets map[string][]tools.ToolSet
 }
 
 func New(loadedSkills []skills.Skill, workingDir string) *ToolSet {
@@ -83,6 +87,13 @@ func New(loadedSkills []skills.Skill, workingDir string) *ToolSet {
 		skills:     loadedSkills,
 		workingDir: workingDir,
 	}
+}
+
+// SetForkToolSets records the additional toolsets each fork skill exposes
+// while running in its sub-session, keyed by skill name. Called by the loader
+// after resolving the skills' declared toolset names.
+func (s *ToolSet) SetForkToolSets(m map[string][]tools.ToolSet) {
+	s.forkToolSets = m
 }
 
 // Skills returns the loaded skills (used by the app layer for slash commands).
@@ -314,6 +325,13 @@ type PreparedSkillFork struct {
 	// Model is the optional model override declared in the SKILL.md
 	// frontmatter. Empty means "use the parent agent's current model".
 	Model string
+	// AllowedTools, when non-empty, restricts the sub-session to the parent
+	// agent's tools whose names match an entry (glob or exact). Empty means
+	// the parent agent's full tool set is inherited.
+	AllowedTools []string
+	// ToolSets holds the additional toolsets the skill exposes in its
+	// sub-session, on top of the (optionally filtered) inherited tools.
+	ToolSets []tools.ToolSet
 }
 
 // PrepareForkSubSession validates a run_skill request and loads the expanded
@@ -341,10 +359,12 @@ func (s *ToolSet) PrepareForkSubSession(ctx context.Context, args RunSkillArgs) 
 	}
 
 	return &PreparedSkillFork{
-		SkillName: args.Name,
-		Task:      args.Task,
-		Content:   content,
-		Model:     skill.Model,
+		SkillName:    args.Name,
+		Task:         args.Task,
+		Content:      content,
+		Model:        skill.Model,
+		AllowedTools: skill.AllowedTools,
+		ToolSets:     s.forkToolSets[args.Name],
 	}, nil
 }
 


### PR DESCRIPTION
Fork-mode skills run in an isolated sub-session, but until now they inherited every tool available to the parent agent with no way to restrict or augment that set. This made it impossible to write a skill that only needs a small, safe subset of tools, or one that requires a dedicated toolset not part of the main agent's config.

Two new fields address this. `allowed_tools` (frontmatter key `allowed-tools` in `SKILL.md` files) is an allow-list of glob or exact patterns applied to the parent agent's inherited tools — the Claude Code-compatible field was previously parsed but never enforced; it is now enforced in the fork sub-session. `toolsets` is a list of top-level `toolsets` names that are injected into the sub-session in addition to the filtered inherited tools, bypassing the allow-list. Both fields are validated at load time: toolset references must exist in the top-level config, and both fields are rejected on non-fork skills. The agent-level `readonly` flag is honored for assistive toolsets, and assistive toolsets are wrapped with lazy single-flight start semantics via `NewStartable`.

Both fields work for inline skills defined in YAML and for file-based skills loaded from `SKILL.md` frontmatter. An example demonstrating the feature is in `examples/skills_fork_toolsets.yaml`, and the skills documentation in `docs/features/skills/index.md` has been updated accordingly.