### PR TITLE
feat: support URL-opening /commands in agent config

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -905,7 +905,7 @@
     },
     "CommandConfig": {
       "type": "object",
-      "description": "Advanced command configuration. Set 'instruction' to send a prompt to the current agent. Set 'agent' to switch the active agent to a sub-agent (e.g. /plan -> the 'planner' sub-agent). Both fields can be combined: the agent is switched first, then the instruction is sent to the new agent.",
+      "description": "Advanced command configuration. Set 'instruction' to send a prompt to the current agent. Set 'agent' to switch the active agent to a sub-agent (e.g. /plan -> the 'planner' sub-agent). Both fields can be combined: the agent is switched first, then the instruction is sent to the new agent. Set 'url' to open a URL in the user's browser instead of messaging the agent.",
       "properties": {
         "description": {
           "type": "string",
@@ -918,6 +918,10 @@
         "agent": {
           "type": "string",
           "description": "Name of a sub-agent to switch to when this command is invoked. The agent must be defined in the team configuration. When set without 'instruction', any text typed after the slash command is forwarded as a prompt to the target agent."
+        },
+        "url": {
+          "type": "string",
+          "description": "URL to open in the user's default browser when this command is invoked, instead of sending a prompt to the agent. Any URI scheme the OS knows how to handle works (e.g. https:// or a custom scheme like docker-desktop:// to deep-link into Docker Desktop)."
         }
       },
       "additionalProperties": false

--- a/agent-schema.json
+++ b/agent-schema.json
@@ -921,7 +921,7 @@
         },
         "url": {
           "type": "string",
-          "description": "URL to open in the user's default browser when this command is invoked, instead of sending a prompt to the agent. Any URI scheme the OS knows how to handle works (e.g. https:// or a custom scheme like docker-desktop:// to deep-link into Docker Desktop)."
+          "description": "URL to open in the user's default browser when this command is invoked, instead of sending a prompt to the agent. Any URI scheme the OS knows how to handle works (e.g. https:// or a custom scheme like docker-desktop:// to deep-link into Docker Desktop). The token {{session_id}} is replaced at invocation time with the current session ID (URL-query-escaped)."
         }
       },
       "additionalProperties": false

--- a/examples/url_commands.yaml
+++ b/examples/url_commands.yaml
@@ -1,0 +1,28 @@
+# This example demonstrates slash commands that open a URL in the user's
+# default browser instead of sending a prompt to the agent.
+#
+# Type "/feedback" in the TUI to open the feedback site, "/docs" to open the
+# documentation, or "/desktop" to deep-link into Docker Desktop via its custom
+# URI scheme. Any URI scheme the OS knows how to handle works.
+
+models:
+  claude:
+    provider: anthropic
+    model: claude-sonnet-4-5
+
+agents:
+  root:
+    model: claude
+    description: An agent with handy URL shortcuts.
+    instruction: |
+      You are a helpful assistant.
+    commands:
+      feedback:
+        description: "Open the feedback site"
+        url: https://example.com/feedback
+      docs:
+        description: "Open the documentation"
+        url: https://docs.docker.com/
+      desktop:
+        description: "Open Docker Desktop"
+        url: docker-desktop://dashboard

--- a/examples/url_commands.yaml
+++ b/examples/url_commands.yaml
@@ -4,6 +4,10 @@
 # Type "/feedback" in the TUI to open the feedback site, "/docs" to open the
 # documentation, or "/desktop" to deep-link into Docker Desktop via its custom
 # URI scheme. Any URI scheme the OS knows how to handle works.
+#
+# The token {{session_id}} in a url is replaced at invocation time with the
+# current session ID (URL-query-escaped), so a command can link to something
+# scoped to the conversation.
 
 models:
   claude:
@@ -18,11 +22,11 @@ agents:
       You are a helpful assistant.
     commands:
       feedback:
-        description: "Open the feedback site"
-        url: https://example.com/feedback
+        description: "Open the feedback site for this session"
+        url: https://example.com/feedback?session={{session_id}}
       docs:
         description: "Open the documentation"
         url: https://docs.docker.com/
       desktop:
-        description: "Open Docker Desktop"
-        url: docker-desktop://dashboard
+        description: "Open this session in Docker Desktop"
+        url: docker-desktop://dashboard/session/{{session_id}}

--- a/pkg/browser/browser.go
+++ b/pkg/browser/browser.go
@@ -2,12 +2,19 @@ package browser
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/url"
 	"os/exec"
 	"runtime"
+	"strings"
 )
 
 func Open(ctx context.Context, urlToOpen string) error {
+	if err := validate(urlToOpen); err != nil {
+		return err
+	}
+
 	var cmd string
 	var args []string
 
@@ -30,5 +37,34 @@ func Open(ctx context.Context, urlToOpen string) error {
 		return fmt.Errorf("failed to open browser: %w", err)
 	}
 
+	return nil
+}
+
+// validate rejects inputs that are unsafe to hand to the platform "open"
+// helper (open, xdg-open, rundll32). Those helpers receive the URL as a
+// positional argument, so a value beginning with "-" would be parsed as a
+// command-line flag rather than a URL (argument injection). This matters now
+// that URLs can come from agent configuration, which may be pulled from an
+// untrusted registry.
+//
+// We require a parseable URL with a non-empty scheme so that option-like
+// strings ("-foo", "--version") and bare paths are rejected. Any scheme the
+// OS knows how to dispatch is allowed — including custom schemes such as
+// "docker-desktop://" — since restricting to http(s) would defeat deep-link
+// use cases.
+func validate(raw string) error {
+	if raw == "" {
+		return errors.New("empty URL")
+	}
+	if strings.HasPrefix(raw, "-") {
+		return fmt.Errorf("refusing to open URL that looks like a command-line flag: %q", raw)
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid URL %q: %w", raw, err)
+	}
+	if u.Scheme == "" {
+		return fmt.Errorf("URL must include a scheme (e.g. https://): %q", raw)
+	}
 	return nil
 }

--- a/pkg/browser/browser_test.go
+++ b/pkg/browser/browser_test.go
@@ -1,0 +1,38 @@
+package browser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidate(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name    string
+		raw     string
+		wantErr bool
+	}{
+		{"https", "https://example.com", false},
+		{"http", "http://example.com/path?q=1", false},
+		{"custom scheme deep link", "docker-desktop://dashboard", false},
+		{"mailto", "mailto:a@b.com", false},
+		{"empty", "", true},
+		{"bare path", "foo/bar", true},
+		{"no scheme", "example.com", true},
+		{"leading dash flag", "-foo", true},
+		{"double dash flag", "--version", true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validate(tt.raw)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/pkg/config/types/commands.go
+++ b/pkg/config/types/commands.go
@@ -25,6 +25,12 @@ import (
 //	plan:
 //	  description: "Hand off to the planner sub-agent"
 //	  agent: planner
+//
+// URL-opening format (object value):
+//
+//	feedback:
+//	  description: "Open the feedback site"
+//	  url: https://example.com/feedback
 type Command struct {
 	// Description is shown in completion dialogs and help text.
 	// For simple format commands, this is empty and the instruction is used for display.
@@ -41,6 +47,12 @@ type Command struct {
 	// hand off to a different agent with a single slash command, e.g. /plan
 	// to switch to the "planner" sub-agent.
 	Agent string `json:"agent,omitempty"`
+
+	// URL, when set, makes the command open the given URL in the user's
+	// default browser instead of sending a prompt to the agent. Any custom
+	// URI scheme the OS knows how to handle works too (e.g. docker-desktop://
+	// to deep-link into Docker Desktop).
+	URL string `json:"url,omitempty"`
 }
 
 // DisplayText returns the text to show in completion dialogs.
@@ -54,6 +66,9 @@ func (c Command) DisplayText() string {
 	}
 	if c.Instruction != "" {
 		return c.Instruction
+	}
+	if c.URL != "" {
+		return "Open " + c.URL
 	}
 	if c.Agent != "" {
 		return "Switch to " + c.Agent
@@ -143,19 +158,20 @@ func parseCommandValue(v any) (Command, error) {
 		desc, _ := val["description"].(string)
 		inst, _ := val["instruction"].(string)
 		agent, _ := val["agent"].(string)
+		url, _ := val["url"].(string)
 
-		if inst == "" && desc == "" && agent == "" {
-			return Command{}, errors.New("command must have at least 'instruction', 'description' or 'agent'")
+		if inst == "" && desc == "" && agent == "" && url == "" {
+			return Command{}, errors.New("command must have at least 'instruction', 'description', 'agent' or 'url'")
 		}
 		// Fallback: if no instruction is provided but we have a description (and no
-		// agent target), use the description as the instruction. This allows shorthand
-		// command definitions like `{"cmd": "Do something"}` where the description
-		// doubles as the instruction text.
-		if inst == "" && agent == "" {
+		// agent target or URL), use the description as the instruction. This allows
+		// shorthand command definitions like `{"cmd": "Do something"}` where the
+		// description doubles as the instruction text.
+		if inst == "" && agent == "" && url == "" {
 			inst = desc
 		}
 
-		return Command{Description: desc, Instruction: inst, Agent: agent}, nil
+		return Command{Description: desc, Instruction: inst, Agent: agent, URL: url}, nil
 	default:
 		return Command{}, fmt.Errorf("invalid command value type: %T", v)
 	}

--- a/pkg/config/types/commands.go
+++ b/pkg/config/types/commands.go
@@ -51,7 +51,8 @@ type Command struct {
 	// URL, when set, makes the command open the given URL in the user's
 	// default browser instead of sending a prompt to the agent. Any custom
 	// URI scheme the OS knows how to handle works too (e.g. docker-desktop://
-	// to deep-link into Docker Desktop).
+	// to deep-link into Docker Desktop). The token {{session_id}} is replaced
+	// at invocation time with the current session ID (URL-query-escaped).
 	URL string `json:"url,omitempty"`
 }
 

--- a/pkg/config/types_test.go
+++ b/pkg/config/types_test.go
@@ -35,6 +35,25 @@ func TestCommandsUnmarshal_List(t *testing.T) {
 	require.Equal(t, "list files", c["ls"].Instruction)
 }
 
+func TestCommandsUnmarshal_URL(t *testing.T) {
+	var c types.Commands
+	input := []byte(`
+feedback:
+  description: "Open the feedback site"
+  url: https://example.com/feedback
+desktop:
+  url: docker-desktop://dashboard
+`)
+	err := yaml.Unmarshal(input, &c)
+	require.NoError(t, err)
+	require.Equal(t, "https://example.com/feedback", c["feedback"].URL)
+	require.Equal(t, "Open the feedback site", c["feedback"].Description)
+	require.Empty(t, c["feedback"].Instruction)
+	require.Equal(t, "docker-desktop://dashboard", c["desktop"].URL)
+	// A URL-only command falls back to the URL for its display text.
+	require.Equal(t, "Open docker-desktop://dashboard", c["desktop"].DisplayText())
+}
+
 func TestThinkingBudget_MarshalUnmarshal_String(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/js/expand.go
+++ b/pkg/js/expand.go
@@ -130,6 +130,7 @@ func (exp *Expander) ExpandCommands(ctx context.Context, cmds types.Commands) ty
 		// new fields are added to types.Command.
 		cmd.Description = runExpansion(vm, cmd.Description)
 		cmd.Instruction = runExpansion(vm, cmd.Instruction)
+		cmd.URL = runExpansion(vm, cmd.URL)
 		expanded[k] = cmd
 	}
 	return expanded

--- a/pkg/runtime/commands_test.go
+++ b/pkg/runtime/commands_test.go
@@ -652,6 +652,24 @@ func TestLookupCommand_AgentTarget(t *testing.T) {
 	assert.Equal(t, "add a logout button", rest)
 }
 
+func TestLookupCommand_URLTarget(t *testing.T) {
+	t.Parallel()
+
+	rt := &mockRuntime{
+		commands: types.Commands{
+			"feedback": types.Command{
+				Description: "Open the feedback site",
+				URL:         "https://example.com/feedback",
+			},
+		},
+	}
+
+	cmd, _, ok := LookupCommand(t.Context(), rt, "/feedback")
+	assert.True(t, ok)
+	assert.Equal(t, "https://example.com/feedback", cmd.URL)
+	assert.Empty(t, cmd.Instruction)
+}
+
 func TestLookupCommand_NotACommand(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tui/commands/commands.go
+++ b/pkg/tui/commands/commands.go
@@ -375,19 +375,23 @@ func builtInSettingsCommands() []Item {
 func builtInFeedbackCommands() []Item {
 	return []Item{
 		{
-			ID:          "feedback.feedback",
-			Label:       "Give Feedback",
-			Description: "Provide feedback about docker agent",
-			Category:    "Feedback",
+			ID:           "feedback.feedback",
+			Label:        "Give Feedback",
+			SlashCommand: "/feedback",
+			Description:  "Provide feedback about docker agent",
+			Category:     "Feedback",
+			Immediate:    true,
 			Execute: func(string) tea.Cmd {
 				return core.CmdHandler(messages.OpenURLMsg{URL: feedback.Link})
 			},
 		},
 		{
-			ID:          "feedback.bug",
-			Label:       "Report Bug",
-			Description: "Report a bug or issue",
-			Category:    "Feedback",
+			ID:           "feedback.bug",
+			Label:        "Report Bug",
+			SlashCommand: "/bug",
+			Description:  "Report a bug or issue",
+			Category:     "Feedback",
+			Immediate:    true,
 			Execute: func(string) tea.Cmd {
 				return core.CmdHandler(messages.OpenURLMsg{URL: "https://github.com/docker/docker-agent/issues/new/choose"})
 			},

--- a/pkg/tui/commands/commands_test.go
+++ b/pkg/tui/commands/commands_test.go
@@ -13,6 +13,7 @@ func newTestParser() *Parser {
 	return NewParser(
 		Category{Name: "Session", Commands: builtInSessionCommands()},
 		Category{Name: "Settings", Commands: builtInSettingsCommands()},
+		Category{Name: "Feedback", Commands: builtInFeedbackCommands()},
 	)
 }
 
@@ -123,6 +124,26 @@ func TestParseSlashCommand_OtherCommands(t *testing.T) {
 		msg := cmd()
 		_, ok := msg.(messages.ShowSkillsDialogMsg)
 		assert.True(t, ok)
+	})
+
+	t.Run("feedback command opens URL", func(t *testing.T) {
+		t.Parallel()
+		cmd := parser.Parse("/feedback")
+		require.NotNil(t, cmd)
+		msg := cmd()
+		openMsg, ok := msg.(messages.OpenURLMsg)
+		require.True(t, ok)
+		assert.NotEmpty(t, openMsg.URL)
+	})
+
+	t.Run("bug command opens URL", func(t *testing.T) {
+		t.Parallel()
+		cmd := parser.Parse("/bug")
+		require.NotNil(t, cmd)
+		msg := cmd()
+		openMsg, ok := msg.(messages.OpenURLMsg)
+		require.True(t, ok)
+		assert.NotEmpty(t, openMsg.URL)
 	})
 
 	t.Run("unknown command returns nil", func(t *testing.T) {

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -683,6 +683,13 @@ func (m *appModel) handleAgentCommand(command string) (tea.Model, tea.Cmd) {
 	// the resolved message — otherwise the message would be processed by
 	// the previous agent.
 	cmd, _, ok := m.application.LookupCommand(ctx, command)
+
+	// URL commands open the configured URL in the browser instead of sending
+	// a prompt to the agent.
+	if ok && cmd.URL != "" {
+		return m, core.CmdHandler(messages.OpenURLMsg{URL: cmd.URL})
+	}
+
 	resolved := m.application.ResolveCommand(ctx, command)
 
 	var cmds []tea.Cmd

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	neturl "net/url"
 	"os"
 	"os/exec"
 	goruntime "runtime"
@@ -687,7 +688,7 @@ func (m *appModel) handleAgentCommand(command string) (tea.Model, tea.Cmd) {
 	// URL commands open the configured URL in the browser instead of sending
 	// a prompt to the agent.
 	if ok && cmd.URL != "" {
-		return m, core.CmdHandler(messages.OpenURLMsg{URL: cmd.URL})
+		return m, core.CmdHandler(messages.OpenURLMsg{URL: m.expandURLPlaceholders(cmd.URL)})
 	}
 
 	resolved := m.application.ResolveCommand(ctx, command)
@@ -720,6 +721,29 @@ func (m *appModel) handleAgentCommand(command string) (tea.Model, tea.Cmd) {
 	}
 
 	return m, tea.Batch(cmds...)
+}
+
+// expandURLPlaceholders substitutes runtime placeholders in a command URL.
+// Currently only {{session_id}} is supported. The token is intentionally
+// distinct from the ${...} syntax used for config-time JS expansion, since
+// the session ID is only known at dispatch time.
+func (m *appModel) expandURLPlaceholders(url string) string {
+	var sessionID string
+	if m.application != nil {
+		if sess := m.application.Session(); sess != nil {
+			sessionID = sess.ID
+		}
+	}
+	return expandSessionPlaceholder(url, sessionID)
+}
+
+// expandSessionPlaceholder replaces the {{session_id}} token with sessionID,
+// URL-query-escaped so it can't break the URL or inject extra parameters.
+func expandSessionPlaceholder(url, sessionID string) string {
+	if !strings.Contains(url, "{{session_id}}") {
+		return url
+	}
+	return strings.ReplaceAll(url, "{{session_id}}", neturl.QueryEscape(sessionID))
 }
 
 func (m *appModel) handleAttachFile(filePath string) (tea.Model, tea.Cmd) {

--- a/pkg/tui/url_placeholder_test.go
+++ b/pkg/tui/url_placeholder_test.go
@@ -1,0 +1,59 @@
+package tui
+
+import "testing"
+
+func TestExpandSessionPlaceholder(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name      string
+		url       string
+		sessionID string
+		want      string
+	}{
+		{
+			name:      "no placeholder is unchanged",
+			url:       "https://example.com/feedback",
+			sessionID: "abc123",
+			want:      "https://example.com/feedback",
+		},
+		{
+			name:      "query placeholder substituted",
+			url:       "https://example.com/feedback?session={{session_id}}",
+			sessionID: "abc123",
+			want:      "https://example.com/feedback?session=abc123",
+		},
+		{
+			name:      "custom scheme deep link",
+			url:       "docker-desktop://dashboard/session/{{session_id}}",
+			sessionID: "abc123",
+			want:      "docker-desktop://dashboard/session/abc123",
+		},
+		{
+			name:      "multiple occurrences",
+			url:       "https://x/{{session_id}}?s={{session_id}}",
+			sessionID: "abc123",
+			want:      "https://x/abc123?s=abc123",
+		},
+		{
+			name:      "session id is query-escaped",
+			url:       "https://example.com/?s={{session_id}}",
+			sessionID: "a b&c=d",
+			want:      "https://example.com/?s=a+b%26c%3Dd",
+		},
+		{
+			name:      "empty session id yields empty value",
+			url:       "https://example.com/?s={{session_id}}",
+			sessionID: "",
+			want:      "https://example.com/?s=",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := expandSessionPlaceholder(tt.url, tt.sessionID)
+			if got != tt.want {
+				t.Fatalf("expandSessionPlaceholder(%q, %q) = %q, want %q", tt.url, tt.sessionID, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds support for `/commands` that open a URL, configurable per-agent in `agent.yaml`, plus a couple of supporting changes.

### `url` field in agent `/commands`

A command can now declare a `url`, which opens it in the user's browser instead of sending a prompt to the agent. Any OS-dispatchable scheme works, including custom ones like `docker-desktop://` for deep links.

```yaml
agents:
  root:
    model: claude
    commands:
      feedback:
        description: "Open the feedback site"
        url: https://example.com/feedback
      desktop:
        description: "Open Docker Desktop"
        url: docker-desktop://dashboard
```

- New `url` field on the shared `Command` type (parsed, validated, and `${...}`-expanded like the other text fields).
- `handleAgentCommand` intercepts url commands and emits `OpenURLMsg`.
- `DisplayText` falls back to the URL for url-only commands.
- Documented in `agent-schema.json` with an example under `examples/url_commands.yaml`.

### `/feedback` and `/bug` slash commands

The feedback palette entries already opened URLs but were not reachable as typed slash commands. They now have `SlashCommand` + `Immediate`, so `/feedback` and `/bug` work from the editor and show up in completion.

### Security: validate URLs before handing them to the OS opener

`browser.Open` passes its argument positionally to `open`/`xdg-open`/`rundll32`, so a value beginning with `-` would be interpreted as a command-line flag rather than a URL (argument injection). This was harmless while every URL was hardcoded or an http(s) OAuth/MCP URL, but agent `/commands` can now supply a `url` from configuration that may be pulled from an untrusted registry.

`browser.Open` now requires a parseable URL with a non-empty scheme and rejects flag-like inputs. Custom schemes (e.g. `docker-desktop://`) remain allowed so deep links keep working.

## Testing

- `task lint` — clean
- `task test` — passing
- Added unit tests for command parsing, URL lookup/dispatch, and browser URL validation.
