### PR TITLE
feat(runtime): add framing axis to steered messages

### DIFF
--- a/docs/features/api-server/index.md
+++ b/docs/features/api-server/index.md
@@ -54,7 +54,7 @@ All endpoints are under the `/api` prefix.
 | `POST`   | `/api/sessions/:id/resume`          | Resume a paused session (after tool confirmation)       |
 | `POST`   | `/api/sessions/:id/tools/toggle`    | Toggle auto-approve (YOLO) mode                         |
 | `POST`   | `/api/sessions/:id/elicitation`     | Respond to an MCP tool elicitation request              |
-| `POST`   | `/api/sessions/:id/steer`           | Inject messages into a running turn (pre-empts current) |
+| `POST`   | `/api/sessions/:id/steer`           | Inject messages into a running turn, with a `framing` axis (see [Steering a running turn](#steering-a-running-turn)) |
 | `POST`   | `/api/sessions/:id/followup`        | Enqueue messages to run after the current turn finishes (supports an `Idempotency-Key` — see [Idempotent follow-ups](#idempotent-follow-ups)). |
 | `GET`    | `/api/sessions/:id/models`          | List available models for the session's current agent   |
 
@@ -328,6 +328,40 @@ $ curl -X POST http://localhost:8080/api/sessions/$SID/fork \
 
 - Out-of-range ordinals (negative, or at/past the user-message count) return `400 Bad Request`.
 - An ordinal that resolves to a user message inside a sub-session returns `400 Bad Request`. A sub-session is a nested session created when a multi-agent config delegates work to a child agent; its messages are embedded within the parent session's message list and cannot be used as a fork boundary.
+
+## Steering a running turn
+
+`POST /api/sessions/:id/steer` injects messages into a turn that is already
+running. They are picked up after the current batch of tool calls finishes but
+before the next model call, so the agent reacts within the same turn rather
+than waiting for it to end (that is what `followup` is for).
+
+An optional request-level `framing` field controls how the model reads the
+injected text. It is orthogonal to scheduling — it only changes the rendering:
+
+| `framing`       | What the model sees                                             | Use for |
+|-----------------|----------------------------------------------------------------|---------|
+| `instruction`   | The text wrapped in a `<system-reminder>` asking it to finish the current task first, then address the message. **Default.** | Interactive course corrections ("also do Y", "btw, Z"). |
+| `replacement`   | The text wrapped in a `<system-reminder>` asking it to abandon the current task and address the message instead. | Explicit pivots ("stop, do X instead"). |
+| `plain`         | The bare text, as a fresh user turn (no envelope).             | Programmatic callers (chains, channels, bridges) that don't want a meta-instruction. |
+
+An omitted or empty `framing` defaults to `instruction`. An unrecognized value
+returns `400 Bad Request`.
+
+```bash
+# Course-correct without abandoning the in-flight work (default framing):
+$ curl -X POST http://127.0.0.1:8080/api/sessions/$SID/steer \
+    -H 'Content-Type: application/json' \
+    -d '{"messages":[{"content":"also use pytest, not unittest"}]}'
+
+# Explicit pivot:
+$ curl -X POST http://127.0.0.1:8080/api/sessions/$SID/steer \
+    -H 'Content-Type: application/json' \
+    -d '{"messages":[{"content":"skip the bug fix, just write a reproducer test"}],"framing":"replacement"}'
+```
+
+The `followup` endpoint reuses the same request body but ignores `framing`:
+follow-ups always start a fresh turn as a plain user message.
 
 ## Idempotent follow-ups
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -163,8 +163,19 @@ type ResumeElicitationRequest struct {
 // SteerSessionRequest represents a request to inject user messages into a
 // running agent session. The messages are picked up by the agent loop between
 // tool execution and the next LLM call.
+//
+// Framing controls how the steered messages are rendered for the model:
+//   - "plain": a bare user turn (no envelope) — for programmatic callers.
+//   - "instruction": wrapped in a <system-reminder> asking the model to finish
+//     its current task first, then address the message.
+//   - "replacement": wrapped in a <system-reminder> asking the model to abandon
+//     its current task and address the message instead.
+//
+// An empty value defaults to "instruction" on the steer route. The follow-up
+// route reuses this type but ignores Framing — follow-ups are always plain.
 type SteerSessionRequest struct {
 	Messages []Message `json:"messages"`
+	Framing  string    `json:"framing,omitempty"`
 }
 
 // FollowUpResponse is the response to POST /api/sessions/:id/followup.

--- a/pkg/mcp/attach.go
+++ b/pkg/mcp/attach.go
@@ -16,6 +16,7 @@ import (
 type SendInput struct {
 	Message  string `json:"message" jsonschema:"the message to send"`
 	FollowUp bool   `json:"followup,omitempty" jsonschema:"queue as end-of-turn follow-up instead of mid-turn steer"`
+	Framing  string `json:"framing,omitempty" jsonschema:"how a steered message is read by the model: plain (bare turn), instruction (finish current task first), or replacement (abandon current task); empty defaults to instruction; ignored for follow-ups"`
 }
 
 type SendOutput struct {
@@ -63,7 +64,7 @@ func AttachServer(ctx context.Context, addr, sessionID string) (*mcp.Server, err
 		if in.FollowUp {
 			err = client.FollowUpSession(ctx, sessionID, msgs)
 		} else {
-			err = client.SteerSession(ctx, sessionID, msgs)
+			err = client.SteerSession(ctx, sessionID, msgs, in.Framing)
 		}
 		if err != nil {
 			return nil, SendOutput{}, err

--- a/pkg/runtime/client.go
+++ b/pkg/runtime/client.go
@@ -307,9 +307,11 @@ func (c *Client) ResumeSession(ctx context.Context, id, confirmation, reason, to
 	return c.doRequest(ctx, http.MethodPost, "/api/sessions/"+id+"/resume", req, nil)
 }
 
-// SteerSession injects user messages into a running session mid-turn.
-func (c *Client) SteerSession(ctx context.Context, sessionID string, messages []api.Message) error {
-	req := api.SteerSessionRequest{Messages: messages}
+// SteerSession injects user messages into a running session mid-turn. framing
+// selects how the model reads the injected text ("plain", "instruction", or
+// "replacement"); empty defaults to "instruction" server-side.
+func (c *Client) SteerSession(ctx context.Context, sessionID string, messages []api.Message, framing string) error {
+	req := api.SteerSessionRequest{Messages: messages, Framing: framing}
 	return c.doRequest(ctx, http.MethodPost, "/api/sessions/"+sessionID+"/steer", req, nil)
 }
 

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -89,11 +89,19 @@ func (r *LocalRuntime) drainAndEmitSteered(ctx context.Context, sess *session.Se
 	messageCountBefore := len(sess.OwnMessages())
 	contents := make([]string, 0, len(steered))
 	for i, sm := range steered {
+		// Record the raw, unframed text for the
+		// user_steering_messages_submit hook: hooks always see exactly what
+		// the user sent, never the <system-reminder> envelope.
 		contents = append(contents, sm.Content)
+		// Render the framing envelope first, then append the newline
+		// separator to the framed result so the "\n" lands after the
+		// closing tag of a wrapped message (where the gluing it prevents
+		// would otherwise occur).
+		framed := frameSteeredMessage(sm)
 		if i < len(steered)-1 {
-			sm = appendNewlineToQueuedMessage(sm)
+			framed = appendNewlineToQueuedMessage(framed)
 		}
-		r.appendSteerAndEmit(sess, sm, events)
+		r.appendSteerAndEmit(sess, framed, events)
 	}
 	stop, stopMsg, ctxMsgs := r.executeUserSteeringMessagesSubmitHooks(ctx, sess, a, contents, events)
 	return steerResult{
@@ -138,6 +146,68 @@ func appendNewlineToQueuedMessage(sm QueuedMessage) QueuedMessage {
 	// Shallow-copy the slice so we don't mutate the original.
 	parts := append([]chat.MessagePart(nil), sm.MultiContent...)
 	parts[last].Text += "\n"
+	sm.MultiContent = parts
+	return sm
+}
+
+// Framing envelopes. The user's text is embedded between the preamble and
+// postamble so the model reads the user's words inside an explicit
+// meta-instruction. The wrapper is deliberately persisted into the session and
+// surfaced in the UserMessageEvent — the same trade-off documented for the
+// newline above — because the runtime passes chat.Message slices straight to
+// the provider and this injection point is the only place that doesn't require
+// restructuring.
+const (
+	framingInstructionPreamble  = "<system-reminder>\nThe user sent a new message while you were working:\n\n"
+	framingInstructionPostamble = "\n\nIMPORTANT: finish your current task first, then address this. Do not abandon what you're doing.\n</system-reminder>"
+
+	framingReplacementPreamble  = "<system-reminder>\nThe user has changed direction:\n\n"
+	framingReplacementPostamble = "\n\nAbandon your current task and address this instead.\n</system-reminder>"
+)
+
+// resolveSteerFraming maps the zero value to the steer default
+// (FramingInstruction) and leaves explicit, recognized values untouched. Any
+// unrecognized value falls back to FramingPlain so a malformed caller never
+// silently gets an envelope it didn't ask for; the HTTP boundary rejects such
+// values outright, this is the defense-in-depth for direct QueuedMessage
+// construction.
+func resolveSteerFraming(f Framing) Framing {
+	switch f {
+	case FramingPlain, FramingInstruction, FramingReplacement:
+		return f
+	case "":
+		return FramingInstruction
+	default:
+		return FramingPlain
+	}
+}
+
+// frameSteeredMessage renders sm according to its framing. FramingPlain (and
+// the unrecognized fallback) returns sm unchanged. instruction/replacement
+// wrap the message text in a <system-reminder> envelope. For multi-content
+// messages the envelope is added as leading and trailing text parts so
+// non-text parts (e.g. images) are preserved in place, mirroring how
+// appendNewlineToQueuedMessage leaves non-text parts alone.
+func frameSteeredMessage(sm QueuedMessage) QueuedMessage {
+	var pre, post string
+	switch resolveSteerFraming(sm.Framing) {
+	case FramingInstruction:
+		pre, post = framingInstructionPreamble, framingInstructionPostamble
+	case FramingReplacement:
+		pre, post = framingReplacementPreamble, framingReplacementPostamble
+	default:
+		return sm
+	}
+
+	if len(sm.MultiContent) == 0 {
+		sm.Content = pre + sm.Content + post
+		return sm
+	}
+
+	parts := make([]chat.MessagePart, 0, len(sm.MultiContent)+2)
+	parts = append(parts, chat.MessagePart{Type: chat.MessagePartTypeText, Text: pre})
+	parts = append(parts, sm.MultiContent...)
+	parts = append(parts, chat.MessagePart{Type: chat.MessagePartTypeText, Text: post})
 	sm.MultiContent = parts
 	return sm
 }

--- a/pkg/runtime/message_queue.go
+++ b/pkg/runtime/message_queue.go
@@ -6,12 +6,49 @@ import (
 	"github.com/docker/docker-agent/pkg/chat"
 )
 
+// Framing controls how a steered message is rendered for the model when it is
+// drained into the conversation. It is orthogonal to scheduling (which drain
+// site picks the message up): it only changes how the model is told to read
+// the injected text.
+type Framing string
+
+const (
+	// FramingPlain injects the message as a bare user turn — the historical
+	// behavior. Use for programmatic callers (chains, channels, bridges) that
+	// don't want any meta-instruction wrapped around the text.
+	FramingPlain Framing = "plain"
+	// FramingInstruction wraps the message in a <system-reminder> that tells the
+	// model to finish its current task first, then address the message. This is
+	// the default for steered messages and restores the "finish first" UX.
+	FramingInstruction Framing = "instruction"
+	// FramingReplacement wraps the message in a <system-reminder> that tells the
+	// model to abandon its current task and address the message instead.
+	FramingReplacement Framing = "replacement"
+)
+
+// Valid reports whether f is a recognized framing value. The empty string is
+// valid: it represents "unspecified" and is resolved to a route-specific
+// default at drain time (instruction for steered messages, plain for
+// follow-ups).
+func (f Framing) Valid() bool {
+	switch f {
+	case "", FramingPlain, FramingInstruction, FramingReplacement:
+		return true
+	}
+	return false
+}
+
 // QueuedMessage is a user message waiting to be injected into the agent loop,
 // either mid-turn (via the steer queue) or at end-of-turn (via the follow-up
 // queue).
 type QueuedMessage struct {
 	Content      string
 	MultiContent []chat.MessagePart
+	// Framing selects how a steered message is rendered for the model. The zero
+	// value ("") is resolved to FramingInstruction when the message is drained
+	// from the steer queue. Follow-up messages ignore this field and are always
+	// rendered plain.
+	Framing Framing
 }
 
 // MessageQueue is the interface for storing messages that are injected into

--- a/pkg/runtime/remote_client.go
+++ b/pkg/runtime/remote_client.go
@@ -33,8 +33,10 @@ type RemoteClient interface {
 	// RunAgentWithAgentName executes an agent with a specific agent name. See RunAgent for the meaning of model.
 	RunAgentWithAgentName(ctx context.Context, sessionID, agent, agentName string, messages []api.Message, model string) (<-chan Event, error)
 
-	// SteerSession injects user messages into a running session mid-turn
-	SteerSession(ctx context.Context, sessionID string, messages []api.Message) error
+	// SteerSession injects user messages into a running session mid-turn.
+	// framing selects how the model reads the injected text ("plain",
+	// "instruction", or "replacement"); empty defaults to "instruction".
+	SteerSession(ctx context.Context, sessionID string, messages []api.Message, framing string) error
 
 	// FollowUpSession queues messages for end-of-turn processing
 	FollowUpSession(ctx context.Context, sessionID string, messages []api.Message) error

--- a/pkg/runtime/remote_contract_test.go
+++ b/pkg/runtime/remote_contract_test.go
@@ -53,7 +53,7 @@ func (s *stubRemoteClient) RunAgentWithAgentName(context.Context, string, string
 	panic("RunAgentWithAgentName not exercised by the contract test")
 }
 
-func (s *stubRemoteClient) SteerSession(context.Context, string, []api.Message) error {
+func (s *stubRemoteClient) SteerSession(context.Context, string, []api.Message, string) error {
 	return nil
 }
 

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -324,7 +324,7 @@ func (r *RemoteRuntime) Steer(msg QueuedMessage) error {
 	}
 	return r.client.SteerSession(context.Background(), r.sessionID, []api.Message{
 		{Content: msg.Content, MultiContent: msg.MultiContent},
-	})
+	}, string(msg.Framing))
 }
 
 // FollowUp enqueues a message for end-of-turn processing on the remote server.

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -3037,8 +3037,10 @@ func TestSteer_IdleWindowIsConsumedOnNextTurn(t *testing.T) {
 
 	// Enqueue a steer message BEFORE calling RunStream — simulating the
 	// idle-window race where a Steer call lands between two RunStream
-	// invocations.
-	err = rt.Steer(QueuedMessage{Content: "urgent: change direction"})
+	// invocations. Plain framing keeps the content assertions below exact;
+	// the instruction/replacement envelopes are covered by the dedicated
+	// framing tests.
+	err = rt.Steer(QueuedMessage{Content: "urgent: change direction", Framing: FramingPlain})
 	require.NoError(t, err)
 
 	sess := session.New(session.WithUserMessage("Do the task"))
@@ -3131,8 +3133,9 @@ func TestSteer_EmptySessionBootstrap(t *testing.T) {
 	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
-	// Enqueue before RunStream — zero messages in the session.
-	err = rt.Steer(QueuedMessage{Content: "bootstrap message"})
+	// Enqueue before RunStream — zero messages in the session. Plain framing
+	// keeps the content assertions below exact.
+	err = rt.Steer(QueuedMessage{Content: "bootstrap message", Framing: FramingPlain})
 	require.NoError(t, err)
 
 	// Fresh session with NO messages (SendUserMessage defaults to true but
@@ -3287,7 +3290,8 @@ func TestSteer_EndOfIterationRaceIsConsumedInCurrentRunStream(t *testing.T) {
 	turn1 := &hookStream{
 		mockStream: turn1Base,
 		onStop: func() {
-			_ = rt.Steer(QueuedMessage{Content: "end-of-iter steer"})
+			// Plain framing keeps the content assertions below exact.
+			_ = rt.Steer(QueuedMessage{Content: "end-of-iter steer", Framing: FramingPlain})
 		},
 	}
 	// Turn 2: the loop re-entered after the steer was consumed; model acks.
@@ -3445,10 +3449,12 @@ func TestDrainAndEmitSteered_MultipleMessages(t *testing.T) {
 	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
-	// Enqueue three plain-text steer messages before draining.
-	require.NoError(t, rt.Steer(QueuedMessage{Content: "first"}))
-	require.NoError(t, rt.Steer(QueuedMessage{Content: "second"}))
-	require.NoError(t, rt.Steer(QueuedMessage{Content: "third"}))
+	// Enqueue three plain-text steer messages before draining. Plain framing
+	// isolates the newline-separator behavior under test from the
+	// instruction/replacement envelopes.
+	require.NoError(t, rt.Steer(QueuedMessage{Content: "first", Framing: FramingPlain}))
+	require.NoError(t, rt.Steer(QueuedMessage{Content: "second", Framing: FramingPlain}))
+	require.NoError(t, rt.Steer(QueuedMessage{Content: "third", Framing: FramingPlain}))
 
 	sess := session.New()
 	events := make(chan Event, 16)
@@ -3498,7 +3504,8 @@ func TestDrainAndEmitSteered_MultiContent(t *testing.T) {
 	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
-	// Two multi-content messages.
+	// Two multi-content messages. Plain framing isolates the newline-separator
+	// behavior under test from the instruction/replacement envelopes.
 	require.NoError(t, rt.Steer(QueuedMessage{
 		Content: "first",
 		MultiContent: []chat.MessagePart{
@@ -3506,12 +3513,14 @@ func TestDrainAndEmitSteered_MultiContent(t *testing.T) {
 			{Type: chat.MessagePartTypeImageURL, ImageURL: &chat.MessageImageURL{URL: "https://example.com/a.png"}},
 			{Type: chat.MessagePartTypeText, Text: "first-text-after-img"},
 		},
+		Framing: FramingPlain,
 	}))
 	require.NoError(t, rt.Steer(QueuedMessage{
 		Content: "second",
 		MultiContent: []chat.MessagePart{
 			{Type: chat.MessagePartTypeText, Text: "second"},
 		},
+		Framing: FramingPlain,
 	}))
 
 	sess := session.New()

--- a/pkg/runtime/steer_framing_test.go
+++ b/pkg/runtime/steer_framing_test.go
@@ -1,0 +1,290 @@
+package runtime
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/team"
+)
+
+func TestFramingValid(t *testing.T) {
+	t.Parallel()
+
+	for _, f := range []Framing{"", FramingPlain, FramingInstruction, FramingReplacement} {
+		assert.Truef(t, f.Valid(), "framing %q should be valid", f)
+	}
+	for _, f := range []Framing{"bogus", "Plain", "INSTRUCTION", " ", "instruct"} {
+		assert.Falsef(t, f.Valid(), "framing %q should be invalid", f)
+	}
+}
+
+func TestResolveSteerFraming(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, FramingInstruction, resolveSteerFraming(""), "zero value defaults to instruction")
+	assert.Equal(t, FramingPlain, resolveSteerFraming(FramingPlain))
+	assert.Equal(t, FramingInstruction, resolveSteerFraming(FramingInstruction))
+	assert.Equal(t, FramingReplacement, resolveSteerFraming(FramingReplacement))
+	assert.Equal(t, FramingPlain, resolveSteerFraming("bogus"),
+		"unrecognized values fall back to plain so no envelope is injected unexpectedly")
+}
+
+func TestFrameSteeredMessage_Plain(t *testing.T) {
+	t.Parallel()
+
+	got := frameSteeredMessage(QueuedMessage{Content: "hello", Framing: FramingPlain})
+	assert.Equal(t, "hello", got.Content, "plain framing leaves content untouched")
+	assert.Nil(t, got.MultiContent)
+}
+
+func TestFrameSteeredMessage_InstructionIsDefault(t *testing.T) {
+	t.Parallel()
+
+	// Zero-value framing resolves to instruction.
+	got := frameSteeredMessage(QueuedMessage{Content: "also use pytest, not unittest"})
+	assert.Equal(t, framingInstructionPreamble+"also use pytest, not unittest"+framingInstructionPostamble, got.Content)
+	assert.Contains(t, got.Content, "<system-reminder>")
+	assert.Contains(t, got.Content, "finish your current task first")
+	assert.Contains(t, got.Content, "also use pytest, not unittest")
+}
+
+func TestFrameSteeredMessage_Replacement(t *testing.T) {
+	t.Parallel()
+
+	got := frameSteeredMessage(QueuedMessage{
+		Content: "actually skip the bug fix, just write a reproducer test",
+		Framing: FramingReplacement,
+	})
+	assert.Equal(t, framingReplacementPreamble+"actually skip the bug fix, just write a reproducer test"+framingReplacementPostamble, got.Content)
+	assert.Contains(t, got.Content, "<system-reminder>")
+	assert.Contains(t, got.Content, "Abandon your current task")
+	assert.NotContains(t, got.Content, "finish your current task first")
+}
+
+// TestFrameSteeredMessage_MultiContent verifies the envelope is added as
+// leading and trailing text parts so non-text parts (images) stay in place.
+func TestFrameSteeredMessage_MultiContent(t *testing.T) {
+	t.Parallel()
+
+	sm := QueuedMessage{
+		Framing: FramingInstruction,
+		MultiContent: []chat.MessagePart{
+			{Type: chat.MessagePartTypeImageURL, ImageURL: &chat.MessageImageURL{URL: "https://example.com/a.png"}},
+			{Type: chat.MessagePartTypeText, Text: "do this"},
+		},
+	}
+	got := frameSteeredMessage(sm)
+
+	require.Len(t, got.MultiContent, 4, "instruction envelope adds a leading and a trailing text part")
+	assert.Equal(t, chat.MessagePartTypeText, got.MultiContent[0].Type)
+	assert.Equal(t, framingInstructionPreamble, got.MultiContent[0].Text)
+	assert.Equal(t, chat.MessagePartTypeImageURL, got.MultiContent[1].Type, "image part preserved in place")
+	assert.Equal(t, "do this", got.MultiContent[2].Text, "original text part preserved")
+	assert.Equal(t, chat.MessagePartTypeText, got.MultiContent[3].Type)
+	assert.Equal(t, framingInstructionPostamble, got.MultiContent[3].Text)
+}
+
+func TestFrameSteeredMessage_UnrecognizedFraming(t *testing.T) {
+	t.Parallel()
+
+	// Defense-in-depth: an unrecognized value (the HTTP boundary rejects these,
+	// but direct QueuedMessage construction can't) falls back to plain so no
+	// envelope is injected unexpectedly.
+	got := frameSteeredMessage(QueuedMessage{Content: "hello", Framing: "typo"})
+	assert.Equal(t, "hello", got.Content)
+	assert.NotContains(t, got.Content, "<system-reminder>")
+}
+
+func TestFrameSteeredMessage_PlainMultiContentUnchanged(t *testing.T) {
+	t.Parallel()
+
+	sm := QueuedMessage{
+		Framing: FramingPlain,
+		MultiContent: []chat.MessagePart{
+			{Type: chat.MessagePartTypeText, Text: "keep me"},
+		},
+	}
+	got := frameSteeredMessage(sm)
+	require.Len(t, got.MultiContent, 1)
+	assert.Equal(t, "keep me", got.MultiContent[0].Text)
+}
+
+func newFramingTestRuntime(t *testing.T) (*LocalRuntime, *agent.Agent) {
+	t.Helper()
+	prov := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
+	root := agent.New("root", "You are a test agent", agent.WithModel(prov))
+	tm := team.New(team.WithAgents(root))
+	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+	return rt, root
+}
+
+func drainedUserMessages(sess *session.Session) []string {
+	var out []string
+	for _, item := range sess.Messages {
+		if item.IsMessage() && item.Message.Message.Role == chat.MessageRoleUser {
+			out = append(out, item.Message.Message.Content)
+		}
+	}
+	return out
+}
+
+// TestDrainAndEmitSteered_DefaultIsInstruction pins that a steer message
+// queued with the zero-value framing is drained, persisted, and emitted with
+// the instruction envelope.
+func TestDrainAndEmitSteered_DefaultIsInstruction(t *testing.T) {
+	t.Parallel()
+
+	rt, root := newFramingTestRuntime(t)
+	require.NoError(t, rt.Steer(QueuedMessage{Content: "also use pytest"}))
+
+	sess := session.New()
+	events := make(chan Event, 16)
+	sr := rt.drainAndEmitSteered(t.Context(), sess, root, NewChannelSink(events))
+	close(events)
+
+	require.True(t, sr.drained)
+
+	msgs := drainedUserMessages(sess)
+	require.Len(t, msgs, 1)
+	assert.Contains(t, msgs[0], "<system-reminder>")
+	assert.Contains(t, msgs[0], "finish your current task first")
+	assert.Contains(t, msgs[0], "also use pytest")
+
+	var eventMsgs []string
+	for ev := range events {
+		if ue, ok := ev.(*UserMessageEvent); ok {
+			eventMsgs = append(eventMsgs, ue.Message)
+		}
+	}
+	require.Len(t, eventMsgs, 1)
+	assert.Equal(t, msgs[0], eventMsgs[0], "the UserMessageEvent must mirror the framed session message")
+}
+
+// TestDrainAndEmitSteered_Replacement pins the replacement envelope end-to-end
+// through the drain path.
+func TestDrainAndEmitSteered_Replacement(t *testing.T) {
+	t.Parallel()
+
+	rt, root := newFramingTestRuntime(t)
+	require.NoError(t, rt.Steer(QueuedMessage{Content: "stop, the bug is in db.ts", Framing: FramingReplacement}))
+
+	sess := session.New()
+	events := make(chan Event, 16)
+	sr := rt.drainAndEmitSteered(t.Context(), sess, root, NewChannelSink(events))
+	close(events)
+
+	require.True(t, sr.drained)
+	msgs := drainedUserMessages(sess)
+	require.Len(t, msgs, 1)
+	assert.Contains(t, msgs[0], "Abandon your current task")
+	assert.Contains(t, msgs[0], "stop, the bug is in db.ts")
+}
+
+// TestDrainAndEmitSteered_MixedFramingPerMessage verifies framing is resolved
+// per message within a single drained batch, and that the newline separator
+// still lands after a wrapped message's closing tag.
+func TestDrainAndEmitSteered_MixedFramingPerMessage(t *testing.T) {
+	t.Parallel()
+
+	rt, root := newFramingTestRuntime(t)
+	require.NoError(t, rt.Steer(QueuedMessage{Content: "first", Framing: FramingInstruction}))
+	require.NoError(t, rt.Steer(QueuedMessage{Content: "second", Framing: FramingPlain}))
+
+	sess := session.New()
+	events := make(chan Event, 16)
+	sr := rt.drainAndEmitSteered(t.Context(), sess, root, NewChannelSink(events))
+	close(events)
+
+	require.True(t, sr.drained)
+	msgs := drainedUserMessages(sess)
+	require.Len(t, msgs, 2)
+
+	// Non-last message: instruction-wrapped, with the "\n" separator appended
+	// after the closing tag.
+	assert.Contains(t, msgs[0], "<system-reminder>")
+	assert.True(t, strings.HasSuffix(msgs[0], "</system-reminder>\n"),
+		"newline separator must follow the closing tag of a non-last wrapped message; got %q", msgs[0])
+
+	// Last message: plain framing, no envelope, no trailing newline.
+	assert.Equal(t, "second", msgs[1])
+}
+
+// TestSteer_ReplacementFramingReachesModel verifies end-to-end through a full
+// RunStream that a replacement-framed steer message is delivered to the model
+// with the exact envelope wording — not just persisted in the session.
+func TestSteer_ReplacementFramingReachesModel(t *testing.T) {
+	t.Parallel()
+
+	stream := newStreamBuilder().AddContent("ok").AddStopWithUsage(5, 3).Build()
+	prov := &messageRecordingProvider{id: "test/mock-model", streams: []*mockStream{stream}}
+	root := agent.New("root", "You are a test agent", agent.WithModel(prov))
+	tm := team.New(team.WithAgents(root))
+	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+
+	require.NoError(t, rt.Steer(QueuedMessage{Content: "write a reproducer instead", Framing: FramingReplacement}))
+
+	sess := session.New(session.WithUserMessage("fix the bug"))
+	for range rt.RunStream(t.Context(), sess) {
+	}
+
+	prov.mu.Lock()
+	defer prov.mu.Unlock()
+	require.NotEmpty(t, prov.recordedMessages, "expected at least one model call")
+
+	var found bool
+	for _, m := range prov.recordedMessages[0] {
+		if strings.Contains(m.Content, "write a reproducer instead") {
+			found = true
+			assert.Contains(t, m.Content, "<system-reminder>")
+			assert.Contains(t, m.Content, "Abandon your current task")
+			break
+		}
+	}
+	assert.True(t, found, "model must receive the replacement-framed steer message in its first turn")
+}
+
+// TestFollowUpIgnoresFraming pins that follow-up messages always render plain,
+// even when a caller mistakenly sets a Framing — follow-ups are unchanged by
+// this feature.
+func TestFollowUpIgnoresFraming(t *testing.T) {
+	t.Parallel()
+
+	// Two turns: the first stops, the runtime dequeues the follow-up and runs a
+	// second turn which also stops (queue now empty).
+	newStopStream := func() *mockStream {
+		return newStreamBuilder().AddContent("ok").AddStopWithUsage(3, 2).Build()
+	}
+	prov := &queueProvider{
+		id:      "test/mock-model",
+		streams: []chat.MessageStream{newStopStream(), newStopStream()},
+	}
+	root := agent.New("root", "test agent", agent.WithModel(prov))
+	tm := team.New(team.WithAgents(root))
+	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+
+	require.NoError(t, rt.FollowUp(QueuedMessage{Content: "also do this", Framing: FramingReplacement}))
+
+	sess := session.New(session.WithUserMessage("hi"))
+	for range rt.RunStream(t.Context(), sess) {
+	}
+
+	var found bool
+	for _, content := range drainedUserMessages(sess) {
+		if strings.Contains(content, "also do this") {
+			found = true
+			assert.Equal(t, "also do this", content,
+				"follow-ups must render plain regardless of the Framing field")
+			assert.NotContains(t, content, "<system-reminder>")
+		}
+	}
+	assert.True(t, found, "expected the follow-up message in the session")
+}

--- a/pkg/runtime/user_prompt_submit_test.go
+++ b/pkg/runtime/user_prompt_submit_test.go
@@ -119,6 +119,22 @@ func TestUserSteeringMessagesSubmitFiresOnDrain(t *testing.T) {
 	got, _ := seen.Load().([]string)
 	assert.Equal(t, []string{"steer one", "steer two"}, got,
 		"hook must receive the drained messages via Input.SteeringMessages, in order")
+
+	// The hook saw the raw text above, but with the default framing
+	// (instruction) the persisted messages must carry the <system-reminder>
+	// envelope — proving the hook-raw / model-framed split holds in one run.
+	var steered []string
+	for _, item := range sess.Messages {
+		if item.IsMessage() && item.Message.Message.Role == chat.MessageRoleUser {
+			steered = append(steered, item.Message.Message.Content)
+		}
+	}
+	require.Len(t, steered, 2)
+	for _, content := range steered {
+		assert.Contains(t, content, "<system-reminder>",
+			"default-framed steer messages must be wrapped for the model")
+		assert.Contains(t, content, "finish your current task first")
+	}
 }
 
 // setupUserPromptSubmitCounter wires up a single-turn mock runtime with

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -555,7 +555,12 @@ func (s *Server) steerSession(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "at least one message is required")
 	}
 
-	if err := s.sm.SteerSession(c.Request().Context(), sessionID, req.Messages); err != nil {
+	if !runtime.Framing(req.Framing).Valid() {
+		return echo.NewHTTPError(http.StatusBadRequest,
+			fmt.Sprintf("invalid framing %q: must be one of plain, instruction, replacement", req.Framing))
+	}
+
+	if err := s.sm.SteerSession(c.Request().Context(), sessionID, req.Messages, req.Framing); err != nil {
 		if strings.Contains(err.Error(), "queue full") {
 			c.Response().Header().Set("Retry-After", "1")
 			return echo.NewHTTPError(http.StatusTooManyRequests, "steer queue full")

--- a/pkg/server/server_attached_test.go
+++ b/pkg/server/server_attached_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/docker/docker-agent/pkg/api"
 	"github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/session"
 )
 
@@ -41,8 +42,94 @@ func TestAttachedServer_SteerReachesAttachedRuntime(t *testing.T) {
 
 	addr := "http://" + ln.Addr().String()
 	resp := httpDoTCP(t, ctx, http.MethodPost, addr+"/api/sessions/"+sess.ID+"/steer",
-		api.SteerSessionRequest{Messages: []api.Message{{Content: "hello"}}})
+		api.SteerSessionRequest{Messages: []api.Message{{Content: "hello"}}, Framing: "replacement"})
 	assert.Contains(t, string(resp), "queued")
+
+	// The request-level framing must survive JSON binding and reach the runtime.
+	steered := fake.steeredMessages()
+	require.Len(t, steered, 1)
+	assert.Equal(t, "hello", steered[0].Content)
+	assert.Equal(t, runtime.FramingReplacement, steered[0].Framing)
+}
+
+// TestAttachedServer_SteerForwardsDefaultAndPlainFraming verifies that an
+// omitted framing field binds to the zero value (which the runtime resolves to
+// instruction at drain time) and that an explicit "plain" survives JSON
+// binding for programmatic callers.
+func TestAttachedServer_SteerForwardsDefaultAndPlainFraming(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := session.NewInMemorySessionStore()
+	sess := session.New()
+	require.NoError(t, store.AddSession(ctx, sess))
+
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+	fake := &fakeRuntime{}
+	sm.AttachRuntime(sess.ID, fake, sess)
+
+	srv := NewWithManager(sm, "")
+	ln, err := Listen(ctx, "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() { _ = srv.Serve(ctx, ln) }()
+
+	addr := "http://" + ln.Addr().String()
+
+	// Omitted framing must be accepted (no 400) and arrive as the zero value.
+	resp := httpDoTCP(t, ctx, http.MethodPost, addr+"/api/sessions/"+sess.ID+"/steer",
+		api.SteerSessionRequest{Messages: []api.Message{{Content: "default one"}}})
+	assert.Contains(t, string(resp), "queued")
+
+	// Explicit plain framing is forwarded verbatim.
+	resp = httpDoTCP(t, ctx, http.MethodPost, addr+"/api/sessions/"+sess.ID+"/steer",
+		api.SteerSessionRequest{Messages: []api.Message{{Content: "plain one"}}, Framing: "plain"})
+	assert.Contains(t, string(resp), "queued")
+
+	steered := fake.steeredMessages()
+	require.Len(t, steered, 2)
+	assert.Equal(t, runtime.Framing(""), steered[0].Framing, "omitted framing arrives as the zero value")
+	assert.Equal(t, runtime.FramingPlain, steered[1].Framing)
+}
+
+// TestAttachedServer_SteerRejectsInvalidFraming verifies the steer endpoint
+// rejects an unrecognized framing value with 400 before reaching the runtime.
+func TestAttachedServer_SteerRejectsInvalidFraming(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := session.NewInMemorySessionStore()
+	sess := session.New()
+	require.NoError(t, store.AddSession(ctx, sess))
+
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+	fake := &fakeRuntime{}
+	sm.AttachRuntime(sess.ID, fake, sess)
+
+	srv := NewWithManager(sm, "")
+	ln, err := Listen(ctx, "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() { _ = srv.Serve(ctx, ln) }()
+
+	addr := "http://" + ln.Addr().String()
+	buf, err := json.Marshal(api.SteerSessionRequest{
+		Messages: []api.Message{{Content: "hello"}},
+		Framing:  "bogus",
+	})
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		addr+"/api/sessions/"+sess.ID+"/steer", bytes.NewReader(buf))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer httpResp.Body.Close()
+	body, err := io.ReadAll(httpResp.Body)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusBadRequest, httpResp.StatusCode, string(body))
+	assert.Contains(t, string(body), "invalid framing")
+	assert.Empty(t, fake.steeredMessages(), "an invalid framing must be rejected before reaching the runtime")
 }
 
 func TestAttachedServer_EventStreamEmitsRegisteredEvents(t *testing.T) {

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -703,9 +703,11 @@ func (sm *SessionManager) ResumeSession(ctx context.Context, sessionID, confirma
 
 // SteerSession enqueues user messages for mid-turn injection into a running
 // session. The messages are picked up by the agent loop after the current tool
-// calls finish but before the next LLM call. Returns an error if the session
-// is not actively running or if the steer buffer is full.
-func (sm *SessionManager) SteerSession(_ context.Context, sessionID string, messages []api.Message) error {
+// calls finish but before the next LLM call. framing selects how the model
+// reads the injected text ("plain", "instruction", or "replacement"); empty
+// defaults to "instruction" when the message is drained. Returns an error if
+// the session is not actively running or if the steer buffer is full.
+func (sm *SessionManager) SteerSession(_ context.Context, sessionID string, messages []api.Message, framing string) error {
 	rt, exists := sm.runtimeSessions.Load(sessionID)
 	if !exists {
 		return ErrSessionNotRunning
@@ -715,6 +717,7 @@ func (sm *SessionManager) SteerSession(_ context.Context, sessionID string, mess
 		if err := rt.runtime.Steer(runtime.QueuedMessage{
 			Content:      msg.Content,
 			MultiContent: msg.MultiContent,
+			Framing:      runtime.Framing(framing),
 		}); err != nil {
 			return err
 		}

--- a/pkg/server/session_manager_test.go
+++ b/pkg/server/session_manager_test.go
@@ -27,6 +27,10 @@ type fakeRuntime struct {
 	concurrentStreams atomic.Int32
 	maxConcurrent     atomic.Int32
 	streamDelay       time.Duration
+
+	steerMu  sync.Mutex
+	steered  []runtime.QueuedMessage
+	followed []runtime.QueuedMessage
 }
 
 func (f *fakeRuntime) RunStream(_ context.Context, _ *session.Session) <-chan runtime.Event {
@@ -49,9 +53,25 @@ func (f *fakeRuntime) RunStream(_ context.Context, _ *session.Session) <-chan ru
 
 func (f *fakeRuntime) Resume(_ context.Context, _ runtime.ResumeRequest) {}
 
-func (f *fakeRuntime) Steer(_ runtime.QueuedMessage) error { return nil }
+func (f *fakeRuntime) Steer(msg runtime.QueuedMessage) error {
+	f.steerMu.Lock()
+	defer f.steerMu.Unlock()
+	f.steered = append(f.steered, msg)
+	return nil
+}
 
-func (f *fakeRuntime) FollowUp(_ runtime.QueuedMessage) error { return nil }
+func (f *fakeRuntime) FollowUp(msg runtime.QueuedMessage) error {
+	f.steerMu.Lock()
+	defer f.steerMu.Unlock()
+	f.followed = append(f.followed, msg)
+	return nil
+}
+
+func (f *fakeRuntime) steeredMessages() []runtime.QueuedMessage {
+	f.steerMu.Lock()
+	defer f.steerMu.Unlock()
+	return append([]runtime.QueuedMessage(nil), f.steered...)
+}
 
 func (f *fakeRuntime) ResumeElicitation(_ context.Context, _ tools.ElicitationAction, _ map[string]any) error {
 	return nil
@@ -107,7 +127,43 @@ func TestAttachRuntime_RegistersRuntimeForExternalDriver(t *testing.T) {
 	sm.AttachRuntime(sess.ID, fake, sess)
 
 	// Steer routes through the attached runtime, not a freshly built one.
-	require.NoError(t, sm.SteerSession(ctx, sess.ID, []api.Message{{Content: "hi"}}))
+	require.NoError(t, sm.SteerSession(ctx, sess.ID, []api.Message{{Content: "hi"}}, ""))
+
+	steered := fake.steeredMessages()
+	require.Len(t, steered, 1)
+	assert.Equal(t, "hi", steered[0].Content)
+}
+
+// TestSteerSession_ThreadsFramingToRuntime verifies the request-level framing
+// is forwarded verbatim onto every QueuedMessage handed to the runtime, while
+// an empty framing is left as the zero value for the runtime to resolve.
+func TestSteerSession_ThreadsFramingToRuntime(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := session.NewInMemorySessionStore()
+	sess := session.New()
+	require.NoError(t, store.AddSession(ctx, sess))
+
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+	fake := &fakeRuntime{}
+	sm.AttachRuntime(sess.ID, fake, sess)
+
+	require.NoError(t, sm.SteerSession(ctx, sess.ID,
+		[]api.Message{{Content: "one"}, {Content: "two"}}, "replacement"))
+
+	steered := fake.steeredMessages()
+	require.Len(t, steered, 2)
+	for _, msg := range steered {
+		assert.Equal(t, runtime.FramingReplacement, msg.Framing,
+			"request-level framing must reach every queued message")
+	}
+
+	// An empty framing stays the zero value; the runtime resolves the default.
+	require.NoError(t, sm.SteerSession(ctx, sess.ID, []api.Message{{Content: "three"}}, ""))
+	steered = fake.steeredMessages()
+	require.Len(t, steered, 3)
+	assert.Equal(t, runtime.Framing(""), steered[2].Framing)
 }
 
 // TestRunSession_ConcurrentRequestReturnsErrSessionBusy verifies that a


### PR DESCRIPTION
## Summary

Adds an explicit **framing** axis to steered messages so callers can control how the model reads a mid-turn injection. Framing is orthogonal to scheduling: the three drain sites from #2492 and the newline behavior from #2518 are unchanged, and the `user_steering_messages_submit` hook still receives raw, unframed text.

Until now a drained steer message was always injected as plain user text, which the model tends to read as "drop what you're doing". The "finish first, then address" intent was effectively unreachable.

## The three framings

| `framing` | What the model sees | For |
|---|---|---|
| `plain` | bare user turn (previous behavior) | programmatic callers (chains, channels, bridges) |
| `instruction` | `<system-reminder>` asking it to finish the current task first, then address the message | interactive course corrections ("also do Y") |
| `replacement` | `<system-reminder>` asking it to abandon the current task and address the message instead | explicit pivots ("stop, do X instead") |

## Wire shape

Framing is request-level on the HTTP API and applies to every message in the request:

```
POST /api/sessions/:id/steer
{ "messages": [{ "content": "use pytest, not unittest" }], "framing": "instruction" }
```

An unrecognized value returns `400`. An omitted value defaults per the table below.

## Issue expectations mapped

| Issue #2812 expectation | Implementation | Status |
|---|---|---|
| `framing` field on `QueuedMessage` | `pkg/runtime/message_queue.go` (`Framing` type + field + `Valid()`) | done |
| `framing` on the `/steer` payload | `pkg/api/types.go` (`SteerSessionRequest.Framing`) | done |
| three framings plain / instruction / replacement | `frameSteeredMessage` in `pkg/runtime/loop.go` | done |
| default `POST /steer` = instruction | resolved at drain via `resolveSteerFraming` | done |
| default `Runtime.Steer(QueuedMessage{})` = instruction | zero value resolves to instruction | done |
| default `POST /followup` = plain (unchanged) | follow-up path ignores framing | done |
| `Runtime.FollowUp` stays as is | unchanged, always plain | done |
| scheduling drain sites (#2492) unchanged | only rendering changed, not drain sites | done |
| newline behavior (#2518) unchanged | newline applied after framing per message | done |
| hooks see raw text | hook input built from raw content before framing | done |

## Behavior change to weigh

Per the issue's defaults table, the default for `POST /steer` and zero-value `Runtime.Steer` changes from plain to **instruction**, so existing steer callers now get the `<system-reminder>` envelope by default. Programmatic callers that want bare text opt into `plain`. If a different default is preferred, only `resolveSteerFraming` needs to change.

## Verification

- New unit + integration tests in `pkg/runtime/steer_framing_test.go`, plus strengthened existing steer/follow-up tests; scheduling and newline tests pinned to `plain` to isolate them from rendering.
- `go test` (including `-race`) on `pkg/runtime`, `pkg/server`, `pkg/api`, `pkg/mcp` passes; `golangci-lint` reports no issues on the touched packages.
- Verified end-to-end against a real model:

| framing | persisted envelope | observed model behavior |
|---|---|---|
| plain | none | treated as a normal user message |
| instruction | present | finished the original task, then addressed the new one |
| replacement | present | abandoned the original task and pivoted to the new one |

## Docs

`docs/features/api-server/index.md` gains a "Steering a running turn" section documenting the field, defaults, and curl examples. `agent-schema.json` is not affected (this is an HTTP API change, not an agent-config feature).
