### PR TITLE
fix(tui): restore ctrl+1..ctrl+9 agent quick-switch shortcuts

### DIFF
--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -2027,11 +2027,24 @@ func (m *appModel) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// parseCtrlNumberKey checks if msg is ctrl+1 through ctrl+9 and returns the index (0-8), or -1 if not matched
+// parseCtrlNumberKey checks if msg is ctrl+1 through ctrl+9 and returns the index (0-8), or -1 if not matched.
+//
+// It inspects the key's modifiers and code directly rather than msg.String():
+// terminals with keyboard enhancements (e.g. the Kitty protocol) populate the
+// key's Text field, which makes String() return the bare digit ("1") instead of
+// "ctrl+1", silently breaking string-based matching.
 func parseCtrlNumberKey(msg tea.KeyPressMsg) int {
-	s := msg.String()
-	if len(s) == 6 && s[:5] == "ctrl+" && s[5] >= '1' && s[5] <= '9' {
-		return int(s[5] - '1')
+	if msg.Mod != tea.ModCtrl {
+		return -1
+	}
+	// Prefer BaseCode (the PC-101 layout key) when present so the shortcut
+	// works on international keyboards; fall back to Code otherwise.
+	code := msg.Code
+	if msg.BaseCode != 0 {
+		code = msg.BaseCode
+	}
+	if code >= '1' && code <= '9' {
+		return int(code - '1')
 	}
 	return -1
 }

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -2027,6 +2027,12 @@ func (m *appModel) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// lockModifiers are the keyboard lock states (Caps/Num/Scroll Lock). They ride
+// along in a key event's modifier set under the Kitty protocol but must be
+// ignored when matching shortcuts, since whether Caps Lock is on has no bearing
+// on whether the user pressed ctrl+1.
+const lockModifiers = tea.ModCapsLock | tea.ModNumLock | tea.ModScrollLock
+
 // parseCtrlNumberKey checks if msg is ctrl+1 through ctrl+9 and returns the index (0-8), or -1 if not matched.
 //
 // It inspects the key's modifiers and code directly rather than msg.String():
@@ -2034,7 +2040,9 @@ func (m *appModel) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 // key's Text field, which makes String() return the bare digit ("1") instead of
 // "ctrl+1", silently breaking string-based matching.
 func parseCtrlNumberKey(msg tea.KeyPressMsg) int {
-	if msg.Mod != tea.ModCtrl {
+	// Require Ctrl and no other active modifier. Lock states (Caps/Num/Scroll)
+	// are masked out first so the shortcut still fires when, e.g., Caps Lock is on.
+	if msg.Mod&^lockModifiers != tea.ModCtrl {
 		return -1
 	}
 	// Prefer BaseCode (the PC-101 layout key) when present so the shortcut

--- a/pkg/tui/tui_helpers_test.go
+++ b/pkg/tui/tui_helpers_test.go
@@ -37,58 +37,33 @@ func TestParseCtrlNumberKey(t *testing.T) {
 
 	tests := []struct {
 		name string
-		key  string
+		msg  tea.KeyPressMsg
 		want int
 	}{
-		{name: "ctrl+1", key: "ctrl+1", want: 0},
-		{name: "ctrl+2", key: "ctrl+2", want: 1},
-		{name: "ctrl+5", key: "ctrl+5", want: 4},
-		{name: "ctrl+9", key: "ctrl+9", want: 8},
-		{name: "ctrl+0 (out of range)", key: "ctrl+0", want: -1},
-		{name: "no ctrl modifier", key: "1", want: -1},
-		{name: "letter key", key: "ctrl+a", want: -1},
-		{name: "empty string", key: "", want: -1},
-		{name: "ctrl+1+extra (wrong length)", key: "ctrl+1a", want: -1},
-		{name: "different prefix", key: "alt+1", want: -1},
+		{name: "ctrl+1", msg: tea.KeyPressMsg{Code: '1', Mod: tea.ModCtrl}, want: 0},
+		{name: "ctrl+2", msg: tea.KeyPressMsg{Code: '2', Mod: tea.ModCtrl}, want: 1},
+		{name: "ctrl+5", msg: tea.KeyPressMsg{Code: '5', Mod: tea.ModCtrl}, want: 4},
+		{name: "ctrl+9", msg: tea.KeyPressMsg{Code: '9', Mod: tea.ModCtrl}, want: 8},
+		{name: "ctrl+0 (out of range)", msg: tea.KeyPressMsg{Code: '0', Mod: tea.ModCtrl}, want: -1},
+		{name: "no ctrl modifier", msg: tea.KeyPressMsg{Code: '1'}, want: -1},
+		{name: "letter key", msg: tea.KeyPressMsg{Code: 'a', Mod: tea.ModCtrl}, want: -1},
+		{name: "empty key", msg: tea.KeyPressMsg{}, want: -1},
+		{name: "ctrl+alt+a", msg: tea.KeyPressMsg{Code: 'a', Mod: tea.ModCtrl | tea.ModAlt}, want: -1},
+		{name: "alt+1", msg: tea.KeyPressMsg{Code: '1', Mod: tea.ModAlt}, want: -1},
+		// Kitty keyboard protocol populates Text, which makes String() report
+		// the bare digit instead of "ctrl+1". The parser must still match.
+		{name: "ctrl+1 with kitty text", msg: tea.KeyPressMsg{Code: '1', Text: "1", Mod: tea.ModCtrl}, want: 0},
+		// International layout: BaseCode carries the PC-101 digit.
+		{name: "ctrl+3 via BaseCode", msg: tea.KeyPressMsg{Code: '"', BaseCode: '3', Mod: tea.ModCtrl}, want: 2},
+		// ctrl+alt+1 must not match (extra modifier).
+		{name: "ctrl+alt+1", msg: tea.KeyPressMsg{Code: '1', Mod: tea.ModCtrl | tea.ModAlt}, want: -1},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-
-			// Construct a KeyPressMsg whose String() reports tt.key. The simplest
-			// way is to feed the rune+mod through tea.KeyPressMsg directly when
-			// possible; for unsupported strings we synthesize via Code.
-			var msg tea.KeyPressMsg
-			switch tt.key {
-			case "ctrl+0", "ctrl+1", "ctrl+2", "ctrl+3", "ctrl+4", "ctrl+5", "ctrl+6", "ctrl+7", "ctrl+8", "ctrl+9":
-				msg = tea.KeyPressMsg{Code: rune(tt.key[5]), Mod: tea.ModCtrl}
-			case "alt+1":
-				msg = tea.KeyPressMsg{Code: '1', Mod: tea.ModAlt}
-			case "ctrl+a":
-				msg = tea.KeyPressMsg{Code: 'a', Mod: tea.ModCtrl}
-			case "1":
-				msg = tea.KeyPressMsg{Code: '1'}
-			case "":
-				msg = tea.KeyPressMsg{}
-			case "ctrl+1a":
-				// Synthesize a key whose String() doesn't match the parser.
-				// parseCtrlNumberKey checks len == 6, so a 7-char string
-				// reliably falls through to -1.
-				msg = tea.KeyPressMsg{Code: 'a', Mod: tea.ModCtrl | tea.ModAlt}
-			}
-
-			got := parseCtrlNumberKey(msg)
-			// For the "ctrl+1a" synthetic case the actual String() is whatever
-			// bubbletea produces; we only require the function to return -1.
-			if tt.key == "ctrl+1a" {
-				if got != -1 {
-					t.Errorf("parseCtrlNumberKey(%q) = %d, want -1 (any non-numeric ctrl key)", msg.String(), got)
-				}
-				return
-			}
-			if got != tt.want {
-				t.Errorf("parseCtrlNumberKey(%q) = %d, want %d", msg.String(), got, tt.want)
+			if got := parseCtrlNumberKey(tt.msg); got != tt.want {
+				t.Errorf("parseCtrlNumberKey(%+v) = %d, want %d", tt.msg, got, tt.want)
 			}
 		})
 	}

--- a/pkg/tui/tui_helpers_test.go
+++ b/pkg/tui/tui_helpers_test.go
@@ -57,6 +57,12 @@ func TestParseCtrlNumberKey(t *testing.T) {
 		{name: "ctrl+3 via BaseCode", msg: tea.KeyPressMsg{Code: '"', BaseCode: '3', Mod: tea.ModCtrl}, want: 2},
 		// ctrl+alt+1 must not match (extra modifier).
 		{name: "ctrl+alt+1", msg: tea.KeyPressMsg{Code: '1', Mod: tea.ModCtrl | tea.ModAlt}, want: -1},
+		// Lock states (Caps/Num Lock) ride along under the Kitty protocol but
+		// must be ignored so the shortcut still fires.
+		{name: "ctrl+1 with caps lock", msg: tea.KeyPressMsg{Code: '1', Mod: tea.ModCtrl | tea.ModCapsLock}, want: 0},
+		{name: "ctrl+4 with num lock", msg: tea.KeyPressMsg{Code: '4', Mod: tea.ModCtrl | tea.ModNumLock}, want: 3},
+		// Lock state alone (no Ctrl) must not match.
+		{name: "caps lock only", msg: tea.KeyPressMsg{Code: '1', Mod: tea.ModCapsLock}, want: -1},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
The `ctrl+1` through `ctrl+9` shortcuts for switching between agents stopped working on terminals that support the Kitty keyboard protocol. Under that protocol, key events carry a `Text` field, which caused `tea.KeyPressMsg.String()` to return the bare digit (e.g. `"1"`) instead of `"ctrl+1"`, so the string-based match in `parseCtrlNumberKey` silently failed.

`parseCtrlNumberKey` now inspects the `Mod` and `Code`/`BaseCode` fields of the key event directly rather than parsing the result of `String()`. It prefers `BaseCode` — the PC-101 layout key — so the shortcut works correctly on international keyboard layouts too. Lock-state modifiers (`CapsLock`, `NumLock`, `ScrollLock`) that the Kitty protocol passes along in the `Mod` field are masked out before the comparison, so the shortcut fires even when Caps Lock or Num Lock is on.

The test suite for this helper was rewritten to construct `tea.KeyPressMsg` values directly instead of relying on string parsing, with new cases covering the Kitty `Text` regression, `BaseCode`/international layout, and lock-modifier scenarios.