### PR TITLE
refactor(tui): remove redundant agent-switch and thinking-level toasts

### DIFF
--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -323,10 +323,8 @@ func (m *appModel) handleSwitchAgent(agentName string) (tea.Model, tea.Cmd) {
 		return m, notification.ErrorCmd(fmt.Sprintf("Failed to switch to agent '%s': %v", agentName, err))
 	}
 	m.sessionState.SetCurrentAgentName(agentName)
-	return m, tea.Batch(
-		m.updateChatCmd(messages.SessionToggleChangedMsg{}),
-		notification.SuccessCmd(fmt.Sprintf("Switched to agent '%s'", agentName)),
-	)
+	cmd := m.updateChatCmd(messages.SessionToggleChangedMsg{})
+	return m, cmd
 }
 
 // handleShowAgentDetails opens the read-only agent-details dialog for the named
@@ -546,14 +544,13 @@ func (m *appModel) handleCycleThinkingLevel() (tea.Model, tea.Cmd) {
 	if !m.application.SupportsModelSwitching() {
 		return m, notification.InfoCmd("Thinking levels can't be changed with remote runtimes")
 	}
-	level, err := m.application.CycleAgentThinkingLevel(context.Background())
-	if err != nil {
+	if _, err := m.application.CycleAgentThinkingLevel(context.Background()); err != nil {
 		if errors.Is(err, runtime.ErrUnsupported) {
 			return m, notification.InfoCmd("Current model does not support thinking levels")
 		}
 		return m, notification.ErrorCmd(fmt.Sprintf("Failed to change thinking level: %v", err))
 	}
-	return m, notification.InfoCmd(styles.ThinkingGlyph + " Thinking: " + level.String())
+	return m, nil
 }
 
 func (m *appModel) handleChangeModel(modelRef string) (tea.Model, tea.Cmd) {


### PR DESCRIPTION
Two toast notifications in the TUI were firing on actions whose result is already visible in the interface without them. The "Switched to agent" success toast appeared every time the user switched the active agent, even though the chat view header immediately reflects the new agent. The "✻ Thinking: low" info toast appeared on every thinking-level cycle, even though the sidebar already shows the current effort level. Neither notification added information the user couldn't already see.

Both toasts have been removed from `handleSwitchAgent` and `handleCycleThinkingLevel` in `pkg/tui/handlers.go`. All other behavior is unchanged: the underlying state mutations, keybindings, and visual indicators in the chat and sidebar remain exactly as before.

No breaking changes. The only observable difference is the absence of those two transient pop-ups.