### PR TITLE
fix(dmr): prefer local models and surface actionable pull errors

### DIFF
--- a/pkg/config/auto.go
+++ b/pkg/config/auto.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -56,6 +57,14 @@ type AutoModelFallbackError struct {
 	Cause error
 }
 
+// pullErrorSummarizer is implemented by provider errors (e.g. DMR pull
+// failures) that already carry their own multi-line actionable guidance. When
+// such an error is the Cause, AutoModelFallbackError shows only its concise
+// summary so the two "To fix this" blocks don't stack.
+type pullErrorSummarizer interface {
+	ModelPullErrorSummary() string
+}
+
 func (e *AutoModelFallbackError) Error() string {
 	var hints []string
 	for _, p := range cloudProviders {
@@ -64,7 +73,12 @@ func (e *AutoModelFallbackError) Error() string {
 
 	var b strings.Builder
 	if e.Cause != nil {
-		fmt.Fprintf(&b, "Could not initialize the auto-selected model: %v\n\n", e.Cause)
+		var summarizer pullErrorSummarizer
+		if errors.As(e.Cause, &summarizer) {
+			fmt.Fprintf(&b, "Could not initialize the auto-selected model: %s\n\n", summarizer.ModelPullErrorSummary())
+		} else {
+			fmt.Fprintf(&b, "Could not initialize the auto-selected model: %v\n\n", e.Cause)
+		}
 	}
 	b.WriteString("No model is currently available.\n\nTo fix this, you can:\n")
 	b.WriteString("  - Pull a Docker Model Runner model, e.g. `docker model pull ai/qwen3`\n")
@@ -128,7 +142,7 @@ func AutoModelConfig(ctx context.Context, modelsGateway string, env environment.
 		// Prefer a model the user already pulled so that, when DMR is set up
 		// with models other than ai/qwen3:latest, auto-selection doesn't force
 		// a pull prompt and then fail when it's declined.
-		model = pickDMRAutoModel(ctx, model, dmrLister)
+		model, _ = PickDMRModel(ctx, model, dmrLister)
 	}
 
 	return latest.ModelConfig{
@@ -138,30 +152,34 @@ func AutoModelConfig(ctx context.Context, modelsGateway string, env environment.
 	}
 }
 
-// pickDMRAutoModel chooses which Docker Model Runner model auto-selection
-// should use. It prefers the configured default when it is already pulled
-// locally; otherwise it falls back to the first locally-available
-// (non-embedding) model. When discovery fails, finds nothing, or no lister is
-// provided, it returns defaultModel unchanged, preserving the previous
-// behavior of pulling the default on demand.
-func pickDMRAutoModel(ctx context.Context, defaultModel string, lister DMRModelLister) string {
+// PickDMRModel chooses which Docker Model Runner model a fallback selection
+// (the `auto` model or a `first_available` candidate) should use. It prefers
+// the configured default when it is already pulled locally; otherwise it falls
+// back to the first locally-available (non-embedding) model. When discovery
+// fails, finds nothing, or no lister is provided, it returns defaultModel
+// unchanged, preserving the behavior of pulling the default on demand.
+//
+// foundLocal reports whether a locally-available model was chosen. It is false
+// when defaultModel was kept because no usable local model exists, so callers
+// know an on-demand pull would be required.
+func PickDMRModel(ctx context.Context, defaultModel string, lister DMRModelLister) (model string, foundLocal bool) {
 	if lister == nil {
-		return defaultModel
+		return defaultModel, false
 	}
 
 	installed, err := lister(ctx)
 	if err != nil {
-		slog.DebugContext(ctx, "DMR model discovery failed during auto-selection, using default", "error", err, "default", defaultModel)
-		return defaultModel
+		slog.DebugContext(ctx, "DMR model discovery failed during selection, using default", "error", err, "default", defaultModel)
+		return defaultModel, false
 	}
 	if len(installed) == 0 {
-		return defaultModel
+		return defaultModel, false
 	}
 
 	// The default is already pulled: use it so behavior is unchanged for users
 	// who do have ai/qwen3:latest.
 	if slices.Contains(installed, defaultModel) {
-		return defaultModel
+		return defaultModel, true
 	}
 
 	// The default model pulled under a different tag (e.g. ai/qwen3:Q4_K_M)
@@ -169,8 +187,8 @@ func pickDMRAutoModel(ctx context.Context, defaultModel string, lister DMRModelL
 	defaultRepo := dmrModelRepo(defaultModel)
 	for _, m := range installed {
 		if dmrModelRepo(m) == defaultRepo {
-			slog.DebugContext(ctx, "DMR auto-selection using default model under a non-default tag", "model", m, "default", defaultModel)
-			return m
+			slog.DebugContext(ctx, "DMR selection using default model under a non-default tag", "model", m, "default", defaultModel)
+			return m, true
 		}
 	}
 
@@ -178,12 +196,40 @@ func pickDMRAutoModel(ctx context.Context, defaultModel string, lister DMRModelL
 	// the choice is deterministic and never lands on an embedding model.
 	for _, m := range installed {
 		if !looksLikeEmbeddingModel(m) {
-			slog.DebugContext(ctx, "DMR auto-selection using locally-available model", "model", m, "default_not_installed", defaultModel)
-			return m
+			slog.DebugContext(ctx, "DMR selection using locally-available model", "model", m, "default_not_installed", defaultModel)
+			return m, true
 		}
 	}
 
-	return defaultModel
+	return defaultModel, false
+}
+
+// PreferLocalDMRModels adjusts `first_available` selectors that resolved to a
+// Docker Model Runner model so they use a locally-pulled model instead of
+// forcing an on-demand pull of the configured default. selectorNames is the set
+// of model names that were `first_available` selectors before resolution (their
+// definitions in cfg are now concrete). cfg is mutated in place.
+//
+// It returns the set of selector names that resolved to DMR but found no usable
+// local model, so callers can treat an initialization failure for those as a
+// "no model available" fallback rather than an opaque pull error.
+func PreferLocalDMRModels(ctx context.Context, cfg *latest.Config, selectorNames map[string]bool, lister DMRModelLister) map[string]bool {
+	noLocal := map[string]bool{}
+	for name := range selectorNames {
+		mc, ok := cfg.Models[name]
+		if !ok || mc.Provider != "dmr" || mc.Model == "" {
+			continue
+		}
+		chosen, foundLocal := PickDMRModel(ctx, mc.Model, lister)
+		if chosen != mc.Model {
+			mc.Model = chosen
+			cfg.Models[name] = mc
+		}
+		if !foundLocal {
+			noLocal[name] = true
+		}
+	}
+	return noLocal
 }
 
 // dmrModelRepo returns the repository portion of a DMR model ID, dropping a

--- a/pkg/config/auto_test.go
+++ b/pkg/config/auto_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -549,6 +550,84 @@ func TestAutoModelConfig_DMRLocalModels(t *testing.T) {
 	}
 }
 
+func TestPickDMRModel(t *testing.T) {
+	t.Parallel()
+
+	lister := func(models []string, err error) DMRModelLister {
+		return func(context.Context) ([]string, error) { return models, err }
+	}
+
+	tests := []struct {
+		name          string
+		lister        DMRModelLister
+		expectedModel string
+		expectedLocal bool
+	}{
+		{"nil lister keeps default, not local", nil, "ai/qwen3", false},
+		{"default pulled is local", lister([]string{"ai/qwen3"}, nil), "ai/qwen3", true},
+		{"repo match under different tag is local", lister([]string{"ai/qwen3:Q4_K_M"}, nil), "ai/qwen3:Q4_K_M", true},
+		{"first chat-capable installed is local", lister([]string{"qwen3:4B-UD-Q4_K_XL"}, nil), "qwen3:4B-UD-Q4_K_XL", true},
+		{"embedding-only keeps default, not local", lister([]string{"ai/embeddinggemma"}, nil), "ai/qwen3", false},
+		{"discovery error keeps default, not local", lister(nil, errors.New("dmr down")), "ai/qwen3", false},
+		{"empty list keeps default, not local", lister([]string{}, nil), "ai/qwen3", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			model, foundLocal := PickDMRModel(t.Context(), "ai/qwen3", tt.lister)
+			assert.Equal(t, tt.expectedModel, model)
+			assert.Equal(t, tt.expectedLocal, foundLocal)
+		})
+	}
+}
+
+func TestPreferLocalDMRModels(t *testing.T) {
+	t.Parallel()
+
+	lister := func(models []string, err error) DMRModelLister {
+		return func(context.Context) ([]string, error) { return models, err }
+	}
+
+	t.Run("uses a locally-pulled model and reports no fallback", func(t *testing.T) {
+		t.Parallel()
+		cfg := &latest.Config{Models: map[string]latest.ModelConfig{
+			"smart": {Provider: "dmr", Model: "ai/qwen3"},
+		}}
+		noLocal := PreferLocalDMRModels(t.Context(), cfg, map[string]bool{"smart": true}, lister([]string{"qwen3:4B-UD-Q4_K_XL"}, nil))
+
+		assert.Equal(t, "qwen3:4B-UD-Q4_K_XL", cfg.Models["smart"].Model)
+		assert.NotContains(t, noLocal, "smart")
+	})
+
+	t.Run("no usable local model leaves default and flags the selector", func(t *testing.T) {
+		t.Parallel()
+		cfg := &latest.Config{Models: map[string]latest.ModelConfig{
+			"smart": {Provider: "dmr", Model: "ai/qwen3"},
+		}}
+		noLocal := PreferLocalDMRModels(t.Context(), cfg, map[string]bool{"smart": true}, lister([]string{}, nil))
+
+		assert.Equal(t, "ai/qwen3", cfg.Models["smart"].Model)
+		assert.True(t, noLocal["smart"])
+	})
+
+	t.Run("non-dmr resolved selector is untouched", func(t *testing.T) {
+		t.Parallel()
+		cfg := &latest.Config{Models: map[string]latest.ModelConfig{
+			"smart": {Provider: "anthropic", Model: "claude-sonnet-4-6"},
+		}}
+		called := false
+		noLocal := PreferLocalDMRModels(t.Context(), cfg, map[string]bool{"smart": true}, func(context.Context) ([]string, error) {
+			called = true
+			return nil, nil
+		})
+
+		assert.Equal(t, "claude-sonnet-4-6", cfg.Models["smart"].Model)
+		assert.Empty(t, noLocal)
+		assert.False(t, called, "lister must not run for a non-dmr selection")
+	})
+}
+
 func TestAutoModelConfig_DMRListerNotConsultedForCloudProvider(t *testing.T) {
 	t.Parallel()
 
@@ -593,4 +672,34 @@ func TestAutoModelFallbackError(t *testing.T) {
 		assert.Contains(t, err.Error(), "model pull declined by user")
 		assert.ErrorIs(t, err, cause)
 	})
+
+	t.Run("pull-failure cause is summarized, not duplicated", func(t *testing.T) {
+		t.Parallel()
+
+		// A cause that carries its own multi-line "To fix this" guidance must be
+		// reduced to its one-line summary so the two blocks don't stack.
+		cause := &stubPullError{
+			summary:    "failed to pull model ai/qwen3",
+			fullDetail: "VERBOSE DETAIL: 416 Requested Range Not Satisfiable\nTo fix this: remove and re-pull",
+		}
+		err := &AutoModelFallbackError{Cause: cause}
+		msg := err.Error()
+
+		assert.Contains(t, msg, "Could not initialize the auto-selected model: failed to pull model ai/qwen3")
+		assert.NotContains(t, msg, "VERBOSE DETAIL")
+		// Exactly one remediation block (the one AutoModelFallbackError owns).
+		assert.Equal(t, 1, strings.Count(msg, "To fix this"))
+		assert.ErrorIs(t, err, cause)
+	})
 }
+
+// stubPullError implements pullErrorSummarizer with a verbose Error() to prove
+// the summary path avoids duplicating remediation guidance.
+type stubPullError struct {
+	summary    string
+	fullDetail string
+}
+
+func (e *stubPullError) Error() string { return e.fullDetail }
+
+func (e *stubPullError) ModelPullErrorSummary() string { return e.summary }

--- a/pkg/model/provider/dmr/pull.go
+++ b/pkg/model/provider/dmr/pull.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 
 	"golang.org/x/term"
@@ -31,9 +32,13 @@ func pullDockerModelIfNeeded(ctx context.Context, model string) error {
 
 	cmd := exec.CommandContext(ctx, "docker", "model", "pull", model)
 	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	// Tee stderr so the live pull output still reaches the terminal while we
+	// also capture it, otherwise the real cause (e.g. a registry error) is lost
+	// and the returned error degrades to a bare "exit status 1".
+	var stderr bytes.Buffer
+	cmd.Stderr = io.MultiWriter(os.Stderr, &stderr)
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to pull model %s: %w", model, err)
+		return &PullFailedError{Model: model, Detail: cleanPullStderr(stderr.String()), Cause: err}
 	}
 
 	slog.InfoContext(ctx, "Model pulled successfully", "model", model)
@@ -76,4 +81,91 @@ func modelExists(ctx context.Context, model string) bool {
 		return false
 	}
 	return true
+}
+
+// PullFailedError is returned when `docker model pull` fails. It carries the
+// model name and the captured pull output so callers (and the user) get an
+// actionable message instead of a bare "exit status 1". teamloader surfaces it
+// unwrapped, so its Error() is what the user sees.
+type PullFailedError struct {
+	Model  string
+	Detail string // cleaned stderr from `docker model pull`
+	Cause  error  // underlying *exec.ExitError, exposed via Unwrap
+}
+
+func (e *PullFailedError) Error() string {
+	return buildPullErrorMessage(e.Model, e.Detail, e.Cause)
+}
+
+func (e *PullFailedError) Unwrap() error { return e.Cause }
+
+// ModelPullErrorSummary is a concise one-liner used when this error is nested
+// as the cause of another error (e.g. config.AutoModelFallbackError), so the
+// full multi-line guidance is not duplicated.
+func (e *PullFailedError) ModelPullErrorSummary() string {
+	return "failed to pull model " + e.Model
+}
+
+// ansiEscape matches the CSI escape sequences (colors, cursor moves, line
+// erase) emitted by `docker model pull` progress output. The final byte of
+// these sequences is always an ASCII letter (e.g. m, K, A, H).
+var ansiEscape = regexp.MustCompile(`\x1b\[[0-9;?]*[a-zA-Z]`)
+
+// maxPullStderrLines bounds how many trailing stderr lines are embedded in the
+// error so progress-bar spam doesn't bury the real message.
+const maxPullStderrLines = 5
+
+// cleanPullStderr normalizes captured `docker model pull` stderr for embedding
+// in an error message: it strips ANSI escapes, collapses carriage-return
+// progress rewrites to the final state of each line, drops blank lines, and
+// keeps only the last few lines (where the actual failure reason lives).
+func cleanPullStderr(raw string) string {
+	raw = ansiEscape.ReplaceAllString(raw, "")
+
+	var lines []string
+	for line := range strings.SplitSeq(raw, "\n") {
+		// Progress bars rewrite a line in place with '\r'; keep the last state.
+		if i := strings.LastIndex(line, "\r"); i >= 0 {
+			line = line[i+1:]
+		}
+		line = strings.TrimRight(line, " \t")
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		lines = append(lines, line)
+	}
+
+	if len(lines) > maxPullStderrLines {
+		lines = lines[len(lines)-maxPullStderrLines:]
+	}
+	return strings.Join(lines, "\n")
+}
+
+// buildPullErrorMessage renders the user-facing message for a failed model
+// pull. It leads with the remove-and-repull remediation because the common
+// cause is a partially downloaded or corrupted copy, for which a bare retry
+// reproduces the failure.
+func buildPullErrorMessage(model, detail string, cause error) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "failed to pull model %s", model)
+
+	// Never produce a contentless message: fall back to the underlying cause
+	// when no stderr was captured.
+	if detail == "" && cause != nil {
+		detail = strings.TrimSpace(cause.Error())
+	}
+	if detail != "" {
+		b.WriteString("\n\ndocker model pull reported:\n")
+		for line := range strings.SplitSeq(detail, "\n") {
+			fmt.Fprintf(&b, "    %s\n", line)
+		}
+	} else {
+		b.WriteString("\n")
+	}
+
+	b.WriteString("\nTo resolve this, you can:\n")
+	fmt.Fprintf(&b, "  - Check the model name is correct and pull it manually:\n      docker model pull %s\n", model)
+	fmt.Fprintf(&b, "  - If a previous pull was interrupted or the copy is corrupted, remove it and retry:\n      docker model rm %s\n      docker model pull %s\n", model, model)
+	b.WriteString("  - Or choose a model that is already available (see `docker model ls`).")
+	return b.String()
 }

--- a/pkg/model/provider/dmr/pull.go
+++ b/pkg/model/provider/dmr/pull.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -27,6 +28,39 @@ func pullDockerModelIfNeeded(ctx context.Context, model string) error {
 		return err
 	}
 
+	err := runModelPull(ctx, model)
+	if err == nil {
+		return nil
+	}
+
+	// A 416 (Requested Range Not Satisfiable) means Docker Model Runner resumed
+	// from a corrupted partial: a leftover ".incomplete" blob larger than the
+	// remote object, so the resume Range is unsatisfiable and the pull loops on
+	// the same error forever. Offer to remove the exact file (parsed from the
+	// failure) and retry once.
+	var pfe *PullFailedError
+	if !errors.As(err, &pfe) {
+		return err
+	}
+	if path, size, ok := corruptPartial(pfe.Detail); ok {
+		pfe.CorruptPartial = path
+		if confirmRemoveCorruptPartial(ctx, path, size) {
+			if rmErr := os.Remove(path); rmErr != nil {
+				slog.WarnContext(ctx, "Failed to remove corrupted partial download", "path", path, "error", rmErr)
+			} else {
+				slog.InfoContext(ctx, "Removed corrupted partial download, retrying pull", "path", path, "model", model)
+				fmt.Printf("Removed corrupted partial download. Retrying...\n")
+				return runModelPull(ctx, model)
+			}
+		}
+	}
+	return pfe
+}
+
+// runModelPull shells out to `docker model pull`, streaming output live while
+// capturing stderr so a failure carries the real cause. It returns a
+// *PullFailedError on failure so callers can inspect the captured output.
+func runModelPull(ctx context.Context, model string) error {
 	slog.InfoContext(ctx, "Pulling DMR model", "model", model)
 	fmt.Printf("Pulling model %s...\n", model)
 
@@ -43,7 +77,6 @@ func pullDockerModelIfNeeded(ctx context.Context, model string) error {
 
 	slog.InfoContext(ctx, "Model pulled successfully", "model", model)
 	fmt.Printf("Model %s pulled successfully.\n", model)
-
 	return nil
 }
 
@@ -91,10 +124,14 @@ type PullFailedError struct {
 	Model  string
 	Detail string // cleaned stderr from `docker model pull`
 	Cause  error  // underlying *exec.ExitError, exposed via Unwrap
+	// CorruptPartial is the path to a leftover ".incomplete" blob that caused a
+	// 416 on resume, when one was identified. When set, the remediation names
+	// the exact file to remove.
+	CorruptPartial string
 }
 
 func (e *PullFailedError) Error() string {
-	return buildPullErrorMessage(e.Model, e.Detail, e.Cause)
+	return buildPullErrorMessage(e.Model, e.Detail, e.CorruptPartial, e.Cause)
 }
 
 func (e *PullFailedError) Unwrap() error { return e.Cause }
@@ -142,10 +179,9 @@ func cleanPullStderr(raw string) string {
 }
 
 // buildPullErrorMessage renders the user-facing message for a failed model
-// pull. It leads with the remove-and-repull remediation because the common
-// cause is a partially downloaded or corrupted copy, for which a bare retry
-// reproduces the failure.
-func buildPullErrorMessage(model, detail string, cause error) string {
+// pull. When a corrupted partial download is identified, it names the exact
+// file to remove; otherwise it gives generic, actionable remediation.
+func buildPullErrorMessage(model, detail, corruptPartial string, cause error) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "failed to pull model %s", model)
 
@@ -164,8 +200,91 @@ func buildPullErrorMessage(model, detail string, cause error) string {
 	}
 
 	b.WriteString("\nTo resolve this, you can:\n")
+	if corruptPartial != "" {
+		// A leftover partial blob larger than the remote object makes the
+		// resume Range unsatisfiable (HTTP 416); removing it forces a clean
+		// re-download.
+		fmt.Fprintf(&b, "  - Remove the corrupted partial download and pull again:\n      rm %s\n      docker model pull %s\n", corruptPartial, model)
+		b.WriteString("  - Or choose a model that is already available (see `docker model ls`).")
+		return b.String()
+	}
 	fmt.Fprintf(&b, "  - Check the model name is correct and pull it manually:\n      docker model pull %s\n", model)
 	fmt.Fprintf(&b, "  - If a previous pull was interrupted or the copy is corrupted, remove it and retry:\n      docker model rm %s\n      docker model pull %s\n", model, model)
 	b.WriteString("  - Or choose a model that is already available (see `docker model ls`).")
 	return b.String()
+}
+
+// blobDigestRe captures the blob digest from a Model Runner registry URL of the
+// form ".../blobs/sha256/<aa>/<digest>/data".
+var blobDigestRe = regexp.MustCompile(`blobs/sha256/[0-9a-f]{2}/([0-9a-f]{64})`)
+
+// corruptPartial reports the path and size of a leftover ".incomplete" blob in
+// the Model Runner content store when a pull failed with HTTP 416 (Requested
+// Range Not Satisfiable). That status means the puller resumed from a partial
+// larger than the remote object, so the file is corrupt and must be removed.
+// It returns ok=false when the failure is not a 416, the digest cannot be
+// parsed, or no matching ".incomplete" file exists.
+func corruptPartial(detail string) (path string, size int64, ok bool) {
+	if !strings.Contains(detail, "416") &&
+		!strings.Contains(strings.ToLower(detail), "requested range not satisfiable") {
+		return "", 0, false
+	}
+	m := blobDigestRe.FindStringSubmatch(detail)
+	if m == nil {
+		return "", 0, false
+	}
+	dir := modelStoreDir()
+	if dir == "" {
+		return "", 0, false
+	}
+	p := filepath.Join(dir, "blobs", "sha256", m[1]+".incomplete")
+	fi, err := os.Stat(p)
+	if err != nil || fi.IsDir() {
+		return "", 0, false
+	}
+	return p, fi.Size(), true
+}
+
+// modelStoreDir returns the Docker Model Runner content store directory,
+// honoring DOCKER_CONFIG and otherwise defaulting to ~/.docker/models.
+func modelStoreDir() string {
+	if dc := os.Getenv("DOCKER_CONFIG"); dc != "" {
+		return filepath.Join(dc, "models")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".docker", "models")
+}
+
+// confirmRemoveCorruptPartial asks, in interactive mode, whether to delete a
+// corrupted partial download. In non-interactive mode it returns false so files
+// are never removed without explicit consent.
+func confirmRemoveCorruptPartial(ctx context.Context, path string, size int64) bool {
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return false
+	}
+	fmt.Printf("\nThe pull failed because a partially downloaded copy is corrupted:\n  %s (%s)\n", path, humanizeBytes(size))
+	fmt.Printf("Remove it and retry the pull? ([y]es/[n]o): ")
+	response, err := input.ReadLine(ctx, os.Stdin)
+	if err != nil {
+		return false
+	}
+	response = strings.TrimSpace(strings.ToLower(response))
+	return response == "y" || response == "yes"
+}
+
+// humanizeBytes formats a byte count using binary (IEC) units.
+func humanizeBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for v := n / unit; v >= unit; v /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(n)/float64(div), "KMGTPE"[exp])
 }

--- a/pkg/model/provider/dmr/pull_test.go
+++ b/pkg/model/provider/dmr/pull_test.go
@@ -3,12 +3,67 @@ package dmr
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+const testQwenBlobURL = "https://production.cloudfront.docker.com/registry-v2/docker/registry/v2/blobs/sha256/b5/b505f0cf69207567fdc6acec5a6d36303673a7da8cddf030f041677c85681729/data?Expires=1&Signature=x"
+
+func TestCorruptPartial(t *testing.T) {
+	digest := "b505f0cf69207567fdc6acec5a6d36303673a7da8cddf030f041677c85681729"
+
+	t.Run("non-416 failure is ignored", func(t *testing.T) {
+		_, _, ok := corruptPartial("Error: MANIFEST_UNKNOWN - Model not found")
+		assert.False(t, ok)
+	})
+
+	t.Run("416 but no matching incomplete file", func(t *testing.T) {
+		t.Setenv("DOCKER_CONFIG", t.TempDir())
+		detail := "writing blob: ... GET " + testQwenBlobURL + ": 416 Requested Range Not Satisfiable"
+		_, _, ok := corruptPartial(detail)
+		assert.False(t, ok)
+	})
+
+	t.Run("416 with a matching incomplete file is detected", func(t *testing.T) {
+		cfg := t.TempDir()
+		t.Setenv("DOCKER_CONFIG", cfg)
+		blobDir := filepath.Join(cfg, "models", "blobs", "sha256")
+		require.NoError(t, os.MkdirAll(blobDir, 0o755))
+		partial := filepath.Join(blobDir, digest+".incomplete")
+		require.NoError(t, os.WriteFile(partial, []byte("0123456789"), 0o644))
+
+		detail := "writing blob: read first byte: ... GET " + testQwenBlobURL + ": 416 Requested Range Not Satisfiable"
+		path, size, ok := corruptPartial(detail)
+		require.True(t, ok)
+		assert.Equal(t, partial, path)
+		assert.Equal(t, int64(10), size)
+	})
+}
+
+func TestBuildPullErrorMessage_CorruptPartial(t *testing.T) {
+	t.Parallel()
+
+	partial := "/home/u/.docker/models/blobs/sha256/b505f0cf.incomplete"
+	msg := buildPullErrorMessage("ai/qwen3", "... 416 Requested Range Not Satisfiable", partial, errors.New("exit status 1"))
+
+	assert.Contains(t, msg, "Remove the corrupted partial download")
+	assert.Contains(t, msg, "rm "+partial)
+	assert.Contains(t, msg, "docker model pull ai/qwen3")
+	// The generic "docker model rm" hint is replaced by the targeted one.
+	assert.NotContains(t, msg, "docker model rm ai/qwen3")
+}
+
+func TestHumanizeBytes(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "512 B", humanizeBytes(512))
+	assert.Equal(t, "1.0 KiB", humanizeBytes(1024))
+	assert.Equal(t, "6.2 GiB", humanizeBytes(6677640642))
+}
 
 func TestCleanPullStderr(t *testing.T) {
 	t.Parallel()

--- a/pkg/model/provider/dmr/pull_test.go
+++ b/pkg/model/provider/dmr/pull_test.go
@@ -1,0 +1,122 @@
+package dmr
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCleanPullStderr(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty input", func(t *testing.T) {
+		t.Parallel()
+		assert.Empty(t, cleanPullStderr(""))
+		assert.Empty(t, cleanPullStderr("   \n\n  \n"))
+	})
+
+	t.Run("keeps the 416 failure line", func(t *testing.T) {
+		t.Parallel()
+		raw := "Downloaded 90.68MB of 91.74MB\nFailed to pull model: Error: writing blob: ... 416 Requested Range Not Satisfiable\n"
+		got := cleanPullStderr(raw)
+		assert.Contains(t, got, "416 Requested Range Not Satisfiable")
+	})
+
+	t.Run("collapses carriage-return progress rewrites", func(t *testing.T) {
+		t.Parallel()
+		raw := "Downloaded 1MB\rDownloaded 50MB\rDownloaded 91MB"
+		got := cleanPullStderr(raw)
+		assert.Equal(t, "Downloaded 91MB", got)
+		assert.NotContains(t, got, "Downloaded 1MB")
+		assert.NotContains(t, got, "Downloaded 50MB")
+	})
+
+	t.Run("strips ANSI escape sequences", func(t *testing.T) {
+		t.Parallel()
+		raw := "\x1b[32mpulling\x1b[0m\n\x1b[1mError:\x1b[0m boom"
+		got := cleanPullStderr(raw)
+		assert.NotContains(t, got, "\x1b")
+		assert.Contains(t, got, "Error: boom")
+	})
+
+	t.Run("keeps only the last few lines", func(t *testing.T) {
+		t.Parallel()
+		var lines []string
+		for i := range 25 {
+			lines = append(lines, fmt.Sprintf("line-%02d", i))
+		}
+		got := cleanPullStderr(strings.Join(lines, "\n"))
+		assert.LessOrEqual(t, len(strings.Split(got, "\n")), maxPullStderrLines)
+		// The last line survives, early lines are dropped.
+		assert.Contains(t, got, "line-24")
+		assert.NotContains(t, got, "line-00")
+		assert.NotContains(t, got, "line-19")
+	})
+}
+
+func TestPullFailedError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("renders model, detail and remediation", func(t *testing.T) {
+		t.Parallel()
+		err := &PullFailedError{
+			Model:  "ai/qwen3",
+			Detail: "Error: writing blob: ... 416 Requested Range Not Satisfiable",
+			Cause:  errors.New("exit status 1"),
+		}
+		msg := err.Error()
+
+		assert.Contains(t, msg, "failed to pull model ai/qwen3")
+		assert.Contains(t, msg, "416 Requested Range Not Satisfiable")
+		assert.Contains(t, msg, "docker model rm ai/qwen3")
+		assert.Contains(t, msg, "docker model pull ai/qwen3")
+		assert.Contains(t, msg, "docker model ls")
+		// The new message must not reintroduce the old opaque wrapper.
+		assert.NotContains(t, msg, "failed to get models:")
+	})
+
+	t.Run("empty detail falls back to the cause and stays actionable", func(t *testing.T) {
+		t.Parallel()
+		err := &PullFailedError{
+			Model: "ai/qwen3",
+			Cause: errors.New("exit status 1"),
+		}
+		msg := err.Error()
+
+		assert.Contains(t, msg, "failed to pull model ai/qwen3")
+		assert.Contains(t, msg, "exit status 1")
+		assert.Contains(t, msg, "docker model rm ai/qwen3")
+		assert.NotEmpty(t, strings.TrimSpace(msg))
+	})
+
+	t.Run("empty detail and nil cause is still non-empty", func(t *testing.T) {
+		t.Parallel()
+		err := &PullFailedError{Model: "ai/qwen3"}
+		msg := err.Error()
+		assert.Contains(t, msg, "failed to pull model ai/qwen3")
+		assert.Contains(t, msg, "docker model rm ai/qwen3")
+	})
+
+	t.Run("errors.As matches and Unwrap returns the cause", func(t *testing.T) {
+		t.Parallel()
+		cause := errors.New("exit status 1")
+		var err error = &PullFailedError{Model: "ai/qwen3", Cause: cause}
+
+		var pfe *PullFailedError
+		require.ErrorAs(t, err, &pfe)
+		assert.Equal(t, "ai/qwen3", pfe.Model)
+		assert.Equal(t, cause, errors.Unwrap(err))
+	})
+
+	t.Run("summary is a concise one-liner", func(t *testing.T) {
+		t.Parallel()
+		err := &PullFailedError{Model: "ai/qwen3", Detail: "noisy\nmultiline\ndetail"}
+		summary := err.ModelPullErrorSummary()
+		assert.Equal(t, "failed to pull model ai/qwen3", summary)
+		assert.NotContains(t, summary, "\n")
+	})
+}

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -162,12 +162,29 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 	// Early check for required env vars before loading models and tools.
 	env := runConfig.EnvProvider()
 
+	// Snapshot which models are `first_available` selectors before resolution
+	// rewrites them in place, so we can prefer locally-available DMR models for
+	// any selector that falls back to Docker Model Runner.
+	firstAvailableSelectors := map[string]bool{}
+	for name, m := range cfg.Models {
+		if m.IsFirstAvailable() {
+			firstAvailableSelectors[name] = true
+		}
+	}
+
 	// Resolve `first_available` model selectors into concrete provider/model
 	// definitions now that the environment is available, so the rest of the
 	// pipeline sees regular model definitions.
 	if err := config.ResolveFirstAvailableModels(ctx, cfg, runConfig.ModelsGateway, env); err != nil {
 		return nil, err
 	}
+
+	// For selectors that fell back to Docker Model Runner, prefer a model the
+	// user already pulled over forcing an on-demand pull of the default. The
+	// returned set names selectors with no usable local model, so an
+	// initialization failure surfaces a "no model available" fallback rather
+	// than an opaque pull error.
+	dmrFallbackSelectors := config.PreferLocalDMRModels(ctx, cfg, firstAvailableSelectors, dmr.ListModels)
 
 	if modelsStore != nil {
 		config.ResolveModelAliases(ctx, cfg, modelsStore)
@@ -244,11 +261,13 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 			}
 			opts = append(opts, agent.WithHarness(&harnessCfg))
 		} else {
-			models, err := getModelsForAgent(ctx, cfg, &agentConfig, autoModel, runConfig, loadOpts.providerRegistry)
+			models, err := getModelsForAgent(ctx, cfg, &agentConfig, autoModel, dmrFallbackSelectors, runConfig, loadOpts.providerRegistry)
 			if err != nil {
-				// Return auto model fallback errors and DMR not installed errors directly
-				// without wrapping to provide cleaner messages
-				if _, ok := errors.AsType[*config.AutoModelFallbackError](err); ok || errors.Is(err, dmr.ErrNotInstalled) {
+				// Return auto model fallback errors, DMR not installed errors, and
+				// DMR pull failures directly without wrapping to provide cleaner,
+				// actionable messages.
+				_, isPull := errors.AsType[*dmr.PullFailedError](err)
+				if _, ok := errors.AsType[*config.AutoModelFallbackError](err); ok || errors.Is(err, dmr.ErrNotInstalled) || isPull {
 					return nil, err
 				}
 				return nil, fmt.Errorf("failed to get models: %w", err)
@@ -378,7 +397,7 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 	}, nil
 }
 
-func getModelsForAgent(ctx context.Context, cfg *latest.Config, a *latest.AgentConfig, autoModelFn func() latest.ModelConfig, runConfig *config.RuntimeConfig, providerRegistry *provider.Registry) ([]provider.Provider, error) {
+func getModelsForAgent(ctx context.Context, cfg *latest.Config, a *latest.AgentConfig, autoModelFn func() latest.ModelConfig, dmrFallbackSelectors map[string]bool, runConfig *config.RuntimeConfig, providerRegistry *provider.Registry) ([]provider.Provider, error) {
 	var models []provider.Provider
 
 	// Obtain the singleton store once, outside the loop.
@@ -394,6 +413,13 @@ func getModelsForAgent(ctx context.Context, cfg *latest.Config, a *latest.AgentC
 			} else {
 				return nil, fmt.Errorf("model '%s' not found in configuration", name)
 			}
+		}
+		// A `first_available` selector that fell back to Docker Model Runner with
+		// no usable local model is, like `auto`, a best-effort selection: surface
+		// init failures as a "no model available" fallback rather than a raw
+		// pull error.
+		if dmrFallbackSelectors[name] {
+			isAutoModel = true
 		}
 		modelCfg.Name = name
 


### PR DESCRIPTION
## Summary

Make `docker agent` resilient when the default `smart` model falls back to Docker Model Runner (DMR): prefer a locally pulled model, recover from a corrupted partial download, and turn opaque pull failures into actionable messages. Refs #3262.

## Problem

- `smart` is a `first_available` selector ending in `dmr/ai/qwen3`. DMR needs no credentials, so it is always selected last and committed to the hardcoded `ai/qwen3`, ignoring any model already pulled locally.
- A failed pull aborted startup with an opaque, double-wrapped error that discarded the real cause: `Error: failed to get models: failed to pull model ai/qwen3: exit status 1`.
- The pull itself failed forever with HTTP 416 (see root cause below).

## Changes

| Area | Before | After |
| --- | --- | --- |
| `smart` fallback to DMR | forces pull of `ai/qwen3` | prefers a locally pulled DMR model (reuses `PickDMRModel`) |
| DMR fallback, no local model | hard crash on failed pull | "no model available" guidance (pull a model, install DMR, or configure an API key) |
| Pull fails with 416 (corrupt partial) | `failed to get models: ... exit status 1`, loops forever | detects the signature, names the exact `.incomplete` file, and (interactive) offers to remove it and retry |
| Other pull failures | opaque `exit status 1` | typed `PullFailedError` with captured output and remediation, surfaced unwrapped |
| Auto path with a pull cause | n/a | concise one line summary, remediation not duplicated |

Files: `pkg/config/auto.go`, `pkg/teamloader/teamloader.go`, `pkg/model/provider/dmr/pull.go` (plus tests).

## Root cause of the 416

The 416 (Requested Range Not Satisfiable) was traced to a corrupted resume, not the registry or CDN:

| Check | Result |
| --- | --- |
| Remote blob `b505f0cf...` via HEAD | `200`, size 5,027,783,872 bytes |
| Remote blob, `Range: bytes=0-` (what the puller sends) | `206`, full range served (host and in-container) |
| Local `~/.docker/models/blobs/sha256/b505f0cf....incomplete` | 6,677,640,642 bytes |

The local partial was about 1.65 GB larger than the remote object, so Model Runner resumed with `Range: bytes=6677640642-`, which is unsatisfiable, and the pull failed with 416 on every attempt with no self-healing. The registry, CDN, and blob are healthy; the defect is a leftover partial in the local content store. Removing the `.incomplete` file makes the next pull succeed.

This PR makes docker-agent detect that exact case and offer to remove the file and retry. A complementary self-heal (discard an oversized partial automatically) belongs in `docker/model-runner` and can be filed separately.

## Behavior

No cloud API key, local `qwen3` present (debug trace):

```
Resolved first_available model   selected=dmr/ai/qwen3
DMR selection using locally-available model   model=docker.io/ai/qwen3:4B-UD-Q4_K_XL
Model already exists, skipping pull
```

No local model and the pull fails with no recoverable partial:

```
Error: Could not initialize the auto-selected model: failed to pull model ai/qwen3

No model is currently available.

To fix this, you can:
  - Pull a Docker Model Runner model, e.g. `docker model pull ai/qwen3`
  - Install Docker Model Runner: https://docs.docker.com/ai/model-runner/get-started/
  - Configure an API key for a cloud provider:
    - anthropic: ANTHROPIC_API_KEY
    - ...
```

Corrupted partial detected (interactive):

```
The pull failed because a partially downloaded copy is corrupted:
  /home/u/.docker/models/blobs/sha256/b505f0cf....incomplete (6.2 GiB)
Remove it and retry the pull? ([y]es/[n]o):
```

## Issue mapping (#3262)

| Item | Status |
| --- | --- |
| Clearer, actionable message on pull failure | done |
| Do not hard-fail when an alternative is available | done (prefer local model, clean fallback otherwise) |
| Investigate the 416 | done: a local oversized `.incomplete` partial caused an unsatisfiable resume Range, not a registry or CDN defect; docker-agent now detects and offers recovery |

## Testing

- `go test ./pkg/model/provider/dmr/... ./pkg/config/... ./pkg/teamloader/...` pass, excluding two pre-existing environment-dependent tests (`TestLoadExamples/dmr.yaml`, which performs a real pull, and `TestURLSource_Read_RejectsLocalAddresses`, which needs network).
- Manual end to end: local-model preference and the no-model fallback message verified. The corrupt-partial detection, message, and digest parsing are covered by unit tests; reproducing the live resume-416 requires a multi-GB corrupt ingest, so the interactive removal path was validated by unit tests plus the original on-disk diagnosis.
