### PR TITLE
ci: install Task from prebuilt binary instead of compiling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,9 @@ jobs:
           cache: true
 
       - name: Install Task
-        run: go install github.com/go-task/task/v3/cmd/task@latest
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+        with:
+          version: 3.51.1
 
       - name: Create bin directory
         run: mkdir -p "$HOME/bin"


### PR DESCRIPTION
The `build-and-test` job spent ~51s on `go install github.com/go-task/task/v3/cmd/task@latest`, which compiles Task from source on every run.

This switches to `arduino/setup-task`, which downloads a pinned prebuilt Task binary, removing the compile step.

- Action is pinned by 40-char SHA (`b91d5d2…` = `v2.0.0`), per repo policy.
- `version: 3.51.1` is an exact pin; the action re-adds the `v` prefix itself.

**Verified on CI** (this PR's runs): the *Install Task* step dropped from **~51s → 1s**, with build-and-test still passing.

Validated locally with `actionlint` and `scripts/workflow-lint.sh`.