### PR TITLE
docs: document URL-opening /commands and clean up /feedback and /bug

### DIFF
--- a/docs/configuration/agents/index.md
+++ b/docs/configuration/agents/index.md
@@ -96,7 +96,7 @@ agents:
 | `max_old_tool_call_tokens`  | int     | ✗        | Maximum number of tokens to keep from old tool call arguments and results. Older tool calls beyond this budget have their content replaced with a placeholder, saving context space. Tokens are approximated as `len/4`. Truncation is disabled by default; set a positive value to enable it. Set to `-1` to disable truncation (unlimited). |
 | `num_history_items`         | int     | ✗        | Limit the number of conversation history messages sent to the model. Useful for managing context window size with long conversations. Default: unlimited (all messages sent). |
 | `skills`                    | bool/array | ✗     | Enable automatic skill discovery. `true` loads all discovered local skills, `false` disables them. A list can mix skill sources (`local` or `https://…` URLs) and skill names to include — see [Skills]({{ '/features/skills/' | relative_url }}).                                                     |
-| `commands`                  | object  | ✗        | Named prompts that can be run with `docker agent run config.yaml /command_name`. Can be simple strings or objects with `instruction` and/or `agent` fields for agent switching. See [Named Commands](#named-commands) below. |
+| `commands`                  | object  | ✗        | Named prompts that can be run with `docker agent run config.yaml /command_name`. Can be simple strings or objects with `instruction` and/or `agent` fields for agent switching, or a `url` field to open a link in the browser. See [Named Commands](#named-commands) below. |
 | `use_commands`              | list of string | ✗   | Names of top-level `commands` groups to merge into this agent. Inline `commands` entries take precedence on name conflicts. Default: `[]`. |
 | `use_skills`                | list of string | ✗   | Names of top-level `skills` groups to merge into this agent. Inline skills are deduplicated by name against merged entries. Default: `[]`. |
 | `use_toolsets`              | list of string | ✗   | Names of top-level `toolsets` groups to merge into this agent. See [Reusable Toolsets]({{ '/configuration/overview/#reusable-toolsets-toolsets' | relative_url }}). Default: `[]`. |
@@ -268,7 +268,7 @@ agents:
 
 ## Named Commands
 
-Define reusable prompt shortcuts that can send prompts to the current agent or switch to a different sub-agent:
+Define reusable prompt shortcuts that can send prompts to the current agent, switch to a different sub-agent, or open a URL in the browser:
 
 > **Note:** Named slash commands execute immediately, even while the agent is processing another message. Unlike regular chat messages (which are queued), slash commands interrupt or direct the agent even while it is mid-response.
 
@@ -291,12 +291,17 @@ agents:
       # Agent switching without instruction - forwards remaining text as prompt
       review:
         agent: reviewer  # Any text after /review is sent to the reviewer agent
+
+      # URL command - opens a link in the browser instead of messaging the agent
+      docs:
+        description: "Open the documentation"
+        url: https://docs.docker.com/
 ```
 
 
 ### Command Formats
 
-Commands support two formats:
+Commands support three formats:
 
 1. **Simple string format**: The string becomes the instruction sent to the current agent
    ```yaml
@@ -309,6 +314,13 @@ Commands support two formats:
      agent: planner           # Required: name of sub-agent to switch to
      instruction: "Plan: $1"  # Optional: prompt to send after switching
      description: "Switch to planning mode"  # Optional: shown in help text
+   ```
+
+3. **URL format**: Opens a link in the browser instead of messaging the agent
+   ```yaml
+   docs:
+     url: https://docs.docker.com/          # Required: URL to open
+     description: "Open the documentation"  # Optional: shown in help text
    ```
 
 When `agent` is set without `instruction`, any text typed after the slash command (e.g., `/plan build a web app`) is forwarded as a prompt to the target agent. The target agent must be listed in the current agent's `sub_agents` array.
@@ -360,6 +372,36 @@ agents:
 `transfer_task` launches a **sub-session**: the root agent sends a task, the child runs in isolation, and the result is returned to the root. The root agent stays in control and the child's work is never in the main conversation. Use `transfer_task` (via `sub_agents`) when you want delegation with a clean result; use agent-switching commands when you want to *become* a different agent for the rest of the conversation.
 
 See [`examples/agent_switching_commands.yaml`](https://github.com/docker/docker-agent/blob/main/examples/agent_switching_commands.yaml) for a complete example.
+
+### URL Commands
+
+A command with a `url` field opens that URL in the user's default browser instead of sending a prompt to the agent. Any URI scheme the OS knows how to dispatch works — both standard web URLs and custom schemes such as `docker-desktop://` for deep links.
+
+```yaml
+agents:
+  root:
+    model: openai/gpt-5
+    description: An agent with handy URL shortcuts.
+    instruction: You are a helpful assistant.
+    commands:
+      feedback:
+        description: "Open the feedback site for this session"
+        url: https://example.com/feedback?session={{session_id}}
+      docs:
+        description: "Open the documentation"
+        url: https://docs.docker.com/
+      desktop:
+        description: "Open this session in Docker Desktop"
+        url: docker-desktop://dashboard/session/{{session_id}}
+```
+
+The `{{session_id}}` token is replaced at invocation time with the current session ID (URL-query-escaped so it can't break the URL or inject extra query parameters), letting a command deep-link to something scoped to the conversation. This token deliberately uses `{{...}}` rather than the `${...}` JS-expansion syntax, since the session ID is only known at dispatch time.
+
+URLs are validated before being handed to the OS opener: a parseable URL with a non-empty scheme is required, and flag-like inputs (those starting with `-`) are rejected to prevent argument injection. URL commands are TUI-only.
+
+The `/feedback` and `/bug` built-in slash commands work the same way — they open the docker-agent feedback site and the issue tracker, respectively. See [Slash Commands]({{ '/features/tui/#slash-commands' | relative_url }}).
+
+See [`examples/url_commands.yaml`](https://github.com/docker/docker-agent/blob/main/examples/url_commands.yaml) for a complete example.
 
 ```bash
 # Run commands from the CLI

--- a/docs/configuration/agents/index.md
+++ b/docs/configuration/agents/index.md
@@ -39,7 +39,7 @@ agents:
     use_commands: [list] # Optional: names of top-level commands groups to merge into this agent
     use_skills: [list] # Optional: names of top-level skills groups to merge into this agent
     commands: # Optional: named prompts
-      name: "prompt text" # or {instruction: "prompt", agent: "sub_agent_name"}
+      name: "prompt text" # or {instruction: "prompt", agent: "sub_agent_name"} or {url: "https://..."} (TUI only)
     welcome_message: string # Optional: message shown at session start
     handoffs: [list] # Optional: agent names this agent can hand off to
     force_handoff: string # Optional: agent that always receives the conversation when this agent stops
@@ -96,7 +96,7 @@ agents:
 | `max_old_tool_call_tokens`  | int     | ✗        | Maximum number of tokens to keep from old tool call arguments and results. Older tool calls beyond this budget have their content replaced with a placeholder, saving context space. Tokens are approximated as `len/4`. Truncation is disabled by default; set a positive value to enable it. Set to `-1` to disable truncation (unlimited). |
 | `num_history_items`         | int     | ✗        | Limit the number of conversation history messages sent to the model. Useful for managing context window size with long conversations. Default: unlimited (all messages sent). |
 | `skills`                    | bool/array | ✗     | Enable automatic skill discovery. `true` loads all discovered local skills, `false` disables them. A list can mix skill sources (`local` or `https://…` URLs) and skill names to include — see [Skills]({{ '/features/skills/' | relative_url }}).                                                     |
-| `commands`                  | object  | ✗        | Named prompts that can be run with `docker agent run config.yaml /command_name`. Can be simple strings or objects with `instruction` and/or `agent` fields for agent switching, or a `url` field to open a link in the browser. See [Named Commands](#named-commands) below. |
+| `commands`                  | object  | ✗        | Named prompts that can be run with `docker agent run config.yaml /command_name`. Can be simple strings or objects with `instruction` and/or `agent` fields for agent switching, or a `url` field to open a link in the browser (TUI only). See [Named Commands](#named-commands) below. |
 | `use_commands`              | list of string | ✗   | Names of top-level `commands` groups to merge into this agent. Inline `commands` entries take precedence on name conflicts. Default: `[]`. |
 | `use_skills`                | list of string | ✗   | Names of top-level `skills` groups to merge into this agent. Inline skills are deduplicated by name against merged entries. Default: `[]`. |
 | `use_toolsets`              | list of string | ✗   | Names of top-level `toolsets` groups to merge into this agent. See [Reusable Toolsets]({{ '/configuration/overview/#reusable-toolsets-toolsets' | relative_url }}). Default: `[]`. |
@@ -373,9 +373,22 @@ agents:
 
 See [`examples/agent_switching_commands.yaml`](https://github.com/docker/docker-agent/blob/main/examples/agent_switching_commands.yaml) for a complete example.
 
+```bash
+# Run commands from the CLI
+$ docker agent run agent.yaml /df
+$ docker agent run agent.yaml /greet
+$ PROJECT_NAME=myapp ENV=production docker agent run agent.yaml /deploy
+```
+
+Commands use JavaScript template literal syntax (`${env.VAR}`) for environment variable interpolation. Undefined variables expand to empty strings.
+
+The same syntax is also expanded in agent and toolset instructions: `agents.<name>.instruction` and `toolsets[*].instruction` support `${env.X}` placeholders (with optional `||` defaults and ternary expressions). `agents.<name>.description` and `agents.<name>.welcome_message` also support it.
+
+Note that path-like fields (`working_dir`, `path`) primarily use a shell-style syntax (`$VAR`, `${VAR}`, `~`), and also accept `${env.X}` as an alias (though not richer JS expressions). See [Variable Expansion in Config Fields]({{ '/configuration/overview/#variable-expansion-in-config-fields' | relative_url }}) for the full table.
+
 ### URL Commands
 
-A command with a `url` field opens that URL in the user's default browser instead of sending a prompt to the agent. Any URI scheme the OS knows how to dispatch works — both standard web URLs and custom schemes such as `docker-desktop://` for deep links.
+A command with a `url` field opens that URL in the user's default browser instead of sending a prompt to the agent. Any URI scheme the OS knows how to dispatch works — both standard web URLs and custom schemes such as `docker-desktop://` for deep links. URL commands are TUI-only — they have no effect when run from the CLI.
 
 ```yaml
 agents:
@@ -397,24 +410,11 @@ agents:
 
 The `{{session_id}}` token is replaced at invocation time with the current session ID (URL-query-escaped so it can't break the URL or inject extra query parameters), letting a command deep-link to something scoped to the conversation. This token deliberately uses `{{...}}` rather than the `${...}` JS-expansion syntax, since the session ID is only known at dispatch time.
 
-URLs are validated before being handed to the OS opener: a parseable URL with a non-empty scheme is required, and flag-like inputs (those starting with `-`) are rejected to prevent argument injection. URL commands are TUI-only.
+URLs are validated before being handed to the OS opener: a parseable URL with a non-empty scheme is required, and flag-like inputs (those starting with `-`) are rejected to prevent argument injection.
 
 The `/feedback` and `/bug` built-in slash commands work the same way — they open the docker-agent feedback site and the issue tracker, respectively. See [Slash Commands]({{ '/features/tui/#slash-commands' | relative_url }}).
 
 See [`examples/url_commands.yaml`](https://github.com/docker/docker-agent/blob/main/examples/url_commands.yaml) for a complete example.
-
-```bash
-# Run commands from the CLI
-$ docker agent run agent.yaml /df
-$ docker agent run agent.yaml /greet
-$ PROJECT_NAME=myapp ENV=production docker agent run agent.yaml /deploy
-```
-
-Commands use JavaScript template literal syntax (`${env.VAR}`) for environment variable interpolation. Undefined variables expand to empty strings.
-
-The same syntax is also expanded in agent and toolset instructions: `agents.<name>.instruction` and `toolsets[*].instruction` support `${env.X}` placeholders (with optional `||` defaults and ternary expressions). `agents.<name>.description` and `agents.<name>.welcome_message` also support it.
-
-Note that path-like fields (`working_dir`, `path`) primarily use a shell-style syntax (`$VAR`, `${VAR}`, `~`), and also accept `${env.X}` as an alias (though not richer JS expressions). See [Variable Expansion in Config Fields]({{ '/configuration/overview/#variable-expansion-in-config-fields' | relative_url }}) for the full table.
 
 ## Read-Only Agents
 

--- a/docs/configuration/agents/index.md
+++ b/docs/configuration/agents/index.md
@@ -412,8 +412,6 @@ The `{{session_id}}` token is replaced at invocation time with the current sessi
 
 URLs are validated before being handed to the OS opener: a parseable URL with a non-empty scheme is required, and flag-like inputs (those starting with `-`) are rejected to prevent argument injection.
 
-The `/feedback` and `/bug` built-in slash commands work the same way — they open the docker-agent feedback site and the issue tracker, respectively. See [Slash Commands]({{ '/features/tui/#slash-commands' | relative_url }}).
-
 See [`examples/url_commands.yaml`](https://github.com/docker/docker-agent/blob/main/examples/url_commands.yaml) for a complete example.
 
 ## Read-Only Agents

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -90,6 +90,8 @@ Type `/` during a session to see available commands, or press <kbd>Ctrl</kbd>+<k
 | `/permissions`     | Inspect and edit tool permission rules                                               |
 | `/split-diff`      | Toggle split-diff view for file edits                                                |
 | `/speak`           | Voice input via system speech-to-text (macOS only)                                   |
+| `/feedback`        | Open the docker-agent feedback site in your browser                                  |
+| `/bug`             | Open the docker-agent issue tracker in your browser                                  |
 | `/exit`            | Exit the application (aliases: `/quit`, `/q`)                                        |
 
 Slash commands (both built-in and named) execute immediately when entered. Regular chat messages are queued and processed in order. This means you can invoke a slash command to interrupt or direct the agent even while it is mid-response.

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -90,8 +90,6 @@ Type `/` during a session to see available commands, or press <kbd>Ctrl</kbd>+<k
 | `/permissions`     | Inspect and edit tool permission rules                                               |
 | `/split-diff`      | Toggle split-diff view for file edits                                                |
 | `/speak`           | Voice input via system speech-to-text (macOS only)                                   |
-| `/feedback`        | Open the docker-agent feedback site in your browser                                  |
-| `/bug`             | Open the docker-agent issue tracker in your browser                                  |
 | `/exit`            | Exit the application (aliases: `/quit`, `/q`)                                        |
 
 Slash commands (both built-in and named) execute immediately when entered. Regular chat messages are queued and processed in order. This means you can invoke a slash command to interrupt or direct the agent even while it is mid-response.

--- a/pkg/tui/commands/commands.go
+++ b/pkg/tui/commands/commands.go
@@ -375,23 +375,19 @@ func builtInSettingsCommands() []Item {
 func builtInFeedbackCommands() []Item {
 	return []Item{
 		{
-			ID:           "feedback.feedback",
-			Label:        "Give Feedback",
-			SlashCommand: "/feedback",
-			Description:  "Provide feedback about docker agent",
-			Category:     "Feedback",
-			Immediate:    true,
+			ID:          "feedback.feedback",
+			Label:       "Give Feedback",
+			Description: "Provide feedback about docker agent",
+			Category:    "Feedback",
 			Execute: func(string) tea.Cmd {
 				return core.CmdHandler(messages.OpenURLMsg{URL: feedback.Link})
 			},
 		},
 		{
-			ID:           "feedback.bug",
-			Label:        "Report Bug",
-			SlashCommand: "/bug",
-			Description:  "Report a bug or issue",
-			Category:     "Feedback",
-			Immediate:    true,
+			ID:          "feedback.bug",
+			Label:       "Report Bug",
+			Description: "Report a bug or issue",
+			Category:    "Feedback",
 			Execute: func(string) tea.Cmd {
 				return core.CmdHandler(messages.OpenURLMsg{URL: "https://github.com/docker/docker-agent/issues/new/choose"})
 			},

--- a/pkg/tui/commands/commands_test.go
+++ b/pkg/tui/commands/commands_test.go
@@ -13,7 +13,6 @@ func newTestParser() *Parser {
 	return NewParser(
 		Category{Name: "Session", Commands: builtInSessionCommands()},
 		Category{Name: "Settings", Commands: builtInSettingsCommands()},
-		Category{Name: "Feedback", Commands: builtInFeedbackCommands()},
 	)
 }
 
@@ -124,26 +123,6 @@ func TestParseSlashCommand_OtherCommands(t *testing.T) {
 		msg := cmd()
 		_, ok := msg.(messages.ShowSkillsDialogMsg)
 		assert.True(t, ok)
-	})
-
-	t.Run("feedback command opens URL", func(t *testing.T) {
-		t.Parallel()
-		cmd := parser.Parse("/feedback")
-		require.NotNil(t, cmd)
-		msg := cmd()
-		openMsg, ok := msg.(messages.OpenURLMsg)
-		require.True(t, ok)
-		assert.NotEmpty(t, openMsg.URL)
-	})
-
-	t.Run("bug command opens URL", func(t *testing.T) {
-		t.Parallel()
-		cmd := parser.Parse("/bug")
-		require.NotNil(t, cmd)
-		msg := cmd()
-		openMsg, ok := msg.(messages.OpenURLMsg)
-		require.True(t, ok)
-		assert.NotEmpty(t, openMsg.URL)
 	})
 
 	t.Run("unknown command returns nil", func(t *testing.T) {


### PR DESCRIPTION
PR #3261 introduced a `url` field for agent `/commands` that opens a link in the user's default browser instead of sending a prompt to the agent. This PR adds the missing documentation for that feature and reverts the `/feedback` and `/bug` slash command definitions that #3261 had added but that don't belong in the default command set.

The docs now cover the full command format in `docs/configuration/agents/index.md`: the existing prompt-style commands, the new URL command variant, supported URI schemes (including custom ones like `docker-desktop://`), the `{{session_id}}` placeholder that is URL-query-escaped at invocation time, and a note that URL commands are TUI-only. The slash-commands reference in `docs/features/tui/index.md` has also been updated to reflect this.

On the code side, `pkg/tui/commands/commands.go` drops the `SlashCommand` and `Immediate` fields from the `/feedback` and `/bug` entries so they remain command-palette-only, and the corresponding parser subtests are removed from `commands_test.go`.