### PR TITLE
feat(config): support external instruction files via instruction_file

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -561,6 +561,10 @@
           "type": "string",
           "description": "Instructions for the agent"
         },
+        "instruction_file": {
+          "type": "string",
+          "description": "Path to a file, relative to the config file's directory, whose contents become the agent's instruction. Loaded at startup. Mutually exclusive with 'instruction'. Must be a local relative path inside the config directory (absolute paths and '..' traversal are rejected). Only supported for local file-based configs, not OCI/URL sources."
+        },
         "harness": {
           "$ref": "#/definitions/HarnessConfig",
           "description": "External coding harness to run this agent with instead of a docker-agent model provider"

--- a/docs/configuration/agents/index.md
+++ b/docs/configuration/agents/index.md
@@ -16,7 +16,8 @@ agents:
   agent_name:
     model: string # Required: model reference
     description: string # Required: what this agent does
-    instruction: string # Required: system prompt
+    instruction: string # Required (unless instruction_file): system prompt
+    instruction_file: string # Optional: load the system prompt from a file relative to this config (mutually exclusive with instruction)
     sub_agents: [list] # Optional: local or external sub-agent references
     toolsets: [list] # Optional: tool configurations (use `type: rag` for RAG sources)
     fallback: # Optional: fallback config
@@ -81,7 +82,8 @@ agents:
 | --------------------------- | ------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `model`                     | string  | ✓        | Model reference. Either inline (`openai/gpt-5`) or a named model from the `models` section.                                                                              |
 | `description`               | string  | ✓        | Brief description of the agent's purpose. Used by coordinators to decide delegation.                                                                                          |
-| `instruction`               | string  | ✓        | System prompt that defines the agent's behavior, personality, and constraints.                                                                                                |
+| `instruction`               | string  | ✓        | System prompt that defines the agent's behavior, personality, and constraints. Required unless `instruction_file` is set.                                                      |
+| `instruction_file`          | string  | ✗        | Path to a file (relative to the config file's directory) whose contents become the agent's instruction, loaded at startup. Mutually exclusive with `instruction`. Must be a local relative path inside the config directory (absolute paths and `..` traversal are rejected). Only supported for local file-based configs, not OCI/URL sources. See [External Instruction Files](#external-instruction-files) below. |
 | `sub_agents`                | array   | ✗        | List of agent names or external OCI references this agent can delegate to. Supports local agents, registry references (e.g., `agentcatalog/pirate`), and named references (`name:reference`). Automatically enables the `transfer_task` tool. Pin external OCI references to a digest (`name@sha256:…`) to skip the per-run registry lookup that tag references incur. See [External Sub-Agents]({{ '/concepts/multi-agent/#external-sub-agents-from-registries' | relative_url }}). |
 | `toolsets`                  | array   | ✗        | List of tool configurations. See [Tool Config]({{ '/configuration/tools/' | relative_url }}).                                                                                                        |
 | `fallback`                  | object  | ✗        | Automatic model failover configuration.                                                                                                                                       |
@@ -115,6 +117,41 @@ agents:
   <p>Default is <code>0</code> (unlimited). Always set <code>max_iterations</code> for agents with powerful tools like <code>shell</code> to prevent infinite loops. A value of 20–50 is typical for development agents.</p>
 
 </div>
+
+## External Instruction Files
+
+Long system prompts can be kept in their own files instead of being inlined in
+the YAML, using `instruction_file`. This separates infrastructure configuration
+(models, providers, tools) from behavioral content (the prompt), which keeps
+version-control diffs focused, reduces merge conflicts on shared configs, and
+lets instruction content be edited without risking YAML syntax errors.
+
+```yaml
+agents:
+  coordinator:
+    model: openai/gpt-5-mini
+    description: Routes work between specialist agents
+    instruction_file: instructions/coordinator.md
+    sub_agents:
+      - writer
+  writer:
+    model: openai/gpt-5-mini
+    description: Drafts and edits written content
+    instruction_file: instructions/writer.md
+```
+
+The path is resolved relative to the config file's directory and the file's
+contents are loaded as the agent's instruction when the config is loaded. Notes:
+
+- **Mutually exclusive** with `instruction`. Setting both is an error.
+- The path must be a **local relative path inside the config directory**.
+  Absolute paths and `..` traversal are rejected.
+- Only supported for **local file-based configs**, not agents loaded from OCI
+  registries or URLs. When an agent is pushed with `docker agent share push`,
+  the file contents are inlined into the pushed artifact, so the published
+  agent stays self-contained.
+
+A runnable example lives in [`examples/instruction_file.yaml`](https://github.com/docker/docker-agent/blob/main/examples/instruction_file.yaml).
 
 ## Response Cache
 

--- a/examples/instruction_file.yaml
+++ b/examples/instruction_file.yaml
@@ -1,0 +1,15 @@
+agents:
+  coordinator:
+    model: openai/gpt-5-mini
+    description: Routes work between specialist agents
+    # Instead of inlining a long prompt here, point at a Markdown file kept
+    # next to the config. The path is relative to this config file's directory
+    # and its contents are loaded as the agent's instruction at startup.
+    instruction_file: instructions/coordinator.md
+    sub_agents:
+      - writer
+
+  writer:
+    model: openai/gpt-5-mini
+    description: Drafts and edits written content
+    instruction_file: instructions/writer.md

--- a/examples/instructions/coordinator.md
+++ b/examples/instructions/coordinator.md
@@ -1,0 +1,8 @@
+You are a coordinator agent.
+
+Your job is to understand the user's request, break it into clear steps, and
+delegate writing work to the `writer` sub-agent. Keep your own responses short:
+summarize what you delegated and relay the result back to the user.
+
+Do not write long-form content yourself. Always hand drafting and editing tasks
+to the `writer`.

--- a/examples/instructions/writer.md
+++ b/examples/instructions/writer.md
@@ -1,0 +1,6 @@
+You are a writing specialist.
+
+Produce clear, well-structured prose tailored to the requested audience and
+tone. When asked to edit, preserve the author's intent while improving clarity,
+flow, and correctness. Prefer concrete examples over abstractions, and keep
+paragraphs focused on a single idea.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"maps"
 	"net/url"
+	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -56,6 +57,10 @@ func Load(ctx context.Context, source Source) (*latest.Config, error) {
 
 	config.Version = raw.Version
 
+	if err := resolveInstructionFiles(&config, source); err != nil {
+		return nil, err
+	}
+
 	if err := validateConfig(&config); err != nil {
 		return nil, err
 	}
@@ -63,6 +68,52 @@ func Load(ctx context.Context, source Source) (*latest.Config, error) {
 	warnExpansionMismatches(ctx, slog.Default(), &config)
 
 	return &config, nil
+}
+
+// resolveInstructionFiles replaces every agent's instruction_file reference
+// with the file's contents, loaded relative to the config file's directory.
+// Resolution happens once at load time so the rest of the pipeline (and any
+// marshalled/pushed copy of the config) only ever sees the inlined
+// Instruction; the InstructionFile field is cleared afterwards to keep the
+// loaded config self-contained.
+//
+// The reference must be a local relative path inside the config directory:
+// absolute paths and "../" traversal are rejected, and reads are confined to
+// the directory with os.OpenRoot so symlinks cannot escape it. This mirrors
+// the path-safety rules used by the HCL file() helper and fileSource.Read.
+func resolveInstructionFiles(cfg *latest.Config, source Source) error {
+	parentDir := source.ParentDir()
+
+	for i := range cfg.Agents {
+		agent := &cfg.Agents[i]
+		if agent.InstructionFile == "" {
+			continue
+		}
+		if agent.Instruction != "" {
+			return fmt.Errorf("agent %q: 'instruction' and 'instruction_file' are mutually exclusive, set only one", agent.Name)
+		}
+		if parentDir == "" {
+			return fmt.Errorf("agent %q: 'instruction_file' is only supported for local file-based configs, not OCI/URL sources", agent.Name)
+		}
+		if !filepath.IsLocal(agent.InstructionFile) {
+			return fmt.Errorf("agent %q: instruction_file %q must be a local relative path inside the config directory", agent.Name, agent.InstructionFile)
+		}
+
+		root, err := os.OpenRoot(parentDir)
+		if err != nil {
+			return fmt.Errorf("agent %q: opening config directory %q: %w", agent.Name, parentDir, err)
+		}
+		data, err := root.ReadFile(filepath.ToSlash(agent.InstructionFile))
+		_ = root.Close()
+		if err != nil {
+			return fmt.Errorf("agent %q: reading instruction_file %q: %w", agent.Name, agent.InstructionFile, err)
+		}
+
+		agent.Instruction = string(data)
+		agent.InstructionFile = ""
+	}
+
+	return nil
 }
 
 // CheckRequiredEnvVars checks which environment variables are required by the models and tools.

--- a/pkg/config/instruction_file_test.go
+++ b/pkg/config/instruction_file_test.go
@@ -1,0 +1,182 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeConfigDir creates a temp directory holding an agent config file named
+// agent.yaml with the given body, plus any extra files (path relative to the
+// directory -> contents). It returns the directory path.
+func writeConfigDir(t *testing.T, configYAML string, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "agent.yaml"), []byte(configYAML), 0o644))
+	for name, content := range files {
+		full := filepath.Join(dir, name)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte(content), 0o644))
+	}
+	return dir
+}
+
+func TestInstructionFileResolved(t *testing.T) {
+	t.Parallel()
+
+	cfgYAML := `agents:
+  root:
+    model: openai/gpt-4o
+    description: test agent
+    instruction_file: instructions/root.md
+`
+	dir := writeConfigDir(t, cfgYAML, map[string]string{
+		"instructions/root.md": "You are a helpful assistant.\n",
+	})
+
+	cfg, err := Load(t.Context(), NewFileSource(filepath.Join(dir, "agent.yaml")))
+	require.NoError(t, err)
+
+	agent := cfg.Agents.First()
+	assert.Equal(t, "You are a helpful assistant.\n", agent.Instruction)
+	// The reference is cleared after resolution so the in-memory config is
+	// self-contained and round-trips through marshalling.
+	assert.Empty(t, agent.InstructionFile)
+}
+
+func TestInstructionFileMissing(t *testing.T) {
+	t.Parallel()
+
+	cfgYAML := `agents:
+  root:
+    model: openai/gpt-4o
+    description: test agent
+    instruction_file: instructions/missing.md
+`
+	dir := writeConfigDir(t, cfgYAML, nil)
+
+	_, err := Load(t.Context(), NewFileSource(filepath.Join(dir, "agent.yaml")))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "root")
+	assert.Contains(t, err.Error(), "instruction_file")
+	assert.Contains(t, err.Error(), "instructions/missing.md")
+}
+
+func TestInstructionFileRejectsTraversal(t *testing.T) {
+	t.Parallel()
+
+	cfgYAML := `agents:
+  root:
+    model: openai/gpt-4o
+    description: test agent
+    instruction_file: ../secret.md
+`
+	dir := writeConfigDir(t, cfgYAML, nil)
+	// A file outside the config directory that traversal would try to reach.
+	require.NoError(t, os.WriteFile(filepath.Join(filepath.Dir(dir), "secret.md"), []byte("secret"), 0o644))
+
+	_, err := Load(t.Context(), NewFileSource(filepath.Join(dir, "agent.yaml")))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "local relative path")
+	assert.Contains(t, err.Error(), "../secret.md")
+}
+
+func TestInstructionFileRejectsAbsolutePath(t *testing.T) {
+	t.Parallel()
+
+	abs := filepath.Join(t.TempDir(), "outside.md")
+	require.NoError(t, os.WriteFile(abs, []byte("secret"), 0o644))
+
+	cfgYAML := `agents:
+  root:
+    model: openai/gpt-4o
+    description: test agent
+    instruction_file: ` + abs + `
+`
+	dir := writeConfigDir(t, cfgYAML, nil)
+
+	_, err := Load(t.Context(), NewFileSource(filepath.Join(dir, "agent.yaml")))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "local relative path")
+}
+
+func TestInstructionFileMutuallyExclusive(t *testing.T) {
+	t.Parallel()
+
+	cfgYAML := `agents:
+  root:
+    model: openai/gpt-4o
+    description: test agent
+    instruction: inline prompt
+    instruction_file: instructions/root.md
+`
+	dir := writeConfigDir(t, cfgYAML, map[string]string{
+		"instructions/root.md": "from file",
+	})
+
+	_, err := Load(t.Context(), NewFileSource(filepath.Join(dir, "agent.yaml")))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+func TestInstructionFileParentlessSource(t *testing.T) {
+	t.Parallel()
+
+	cfgYAML := `agents:
+  root:
+    model: openai/gpt-4o
+    description: test agent
+    instruction_file: instructions/root.md
+`
+	// A bytes source has no directory to resolve the reference against.
+	_, err := Load(t.Context(), NewBytesSource("config.yaml", []byte(cfgYAML)))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "local file-based configs")
+}
+
+func TestInstructionFileRejectsSymlinkEscape(t *testing.T) {
+	t.Parallel()
+
+	cfgYAML := `agents:
+  root:
+    model: openai/gpt-4o
+    description: test agent
+    instruction_file: instructions/root.md
+`
+	dir := writeConfigDir(t, cfgYAML, nil)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "instructions"), 0o755))
+
+	outside := filepath.Join(filepath.Dir(dir), "outside.md")
+	require.NoError(t, os.WriteFile(outside, []byte("secret"), 0o644))
+
+	link := filepath.Join(dir, "instructions", "root.md")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	_, err := Load(t.Context(), NewFileSource(filepath.Join(dir, "agent.yaml")))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "instruction_file")
+}
+
+// TestInstructionFileEmptyStringIgnored verifies that an explicit empty
+// instruction_file is treated as unset rather than triggering resolution.
+func TestInstructionFileEmptyStringIgnored(t *testing.T) {
+	t.Parallel()
+
+	cfgYAML := `agents:
+  root:
+    model: openai/gpt-4o
+    description: test agent
+    instruction: inline prompt
+    instruction_file: ""
+`
+	dir := writeConfigDir(t, cfgYAML, nil)
+
+	cfg, err := Load(t.Context(), NewFileSource(filepath.Join(dir, "agent.yaml")))
+	require.NoError(t, err)
+	assert.Equal(t, "inline prompt", cfg.Agents.First().Instruction)
+}

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -433,9 +433,18 @@ type AgentConfig struct {
 	WelcomeMessage string          `json:"welcome_message,omitempty"`
 	Toolsets       []Toolset       `json:"toolsets,omitempty"`
 	Instruction    string          `json:"instruction,omitempty"`
-	Harness        *HarnessConfig  `json:"harness,omitempty"`
-	SubAgents      []string        `json:"sub_agents,omitempty"`
-	Handoffs       []string        `json:"handoffs,omitempty"`
+	// InstructionFile names a file, relative to the config file's directory,
+	// whose contents are loaded into Instruction when the config is loaded.
+	// It keeps long behavioral prompts out of the YAML, letting infrastructure
+	// configuration and instruction content evolve in separate files. Mutually
+	// exclusive with Instruction. Only file-based config sources are supported
+	// (not OCI/URL/bytes sources, which have no directory to resolve against).
+	// The field is cleared once resolved so the in-memory config stays
+	// self-contained (see config.Load).
+	InstructionFile string         `json:"instruction_file,omitempty" yaml:"instruction_file,omitempty"`
+	Harness         *HarnessConfig `json:"harness,omitempty"`
+	SubAgents       []string       `json:"sub_agents,omitempty"`
+	Handoffs        []string       `json:"handoffs,omitempty"`
 	// ForceHandoff names an agent that unconditionally receives the
 	// conversation whenever this agent produces a final response,
 	// bypassing the LLM's tool-calling entirely. Unlike Handoffs (which

--- a/pkg/oci/package.go
+++ b/pkg/oci/package.go
@@ -1,6 +1,7 @@
 package oci
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"path/filepath"
@@ -43,9 +44,16 @@ func PackageFileAsOCIToStore(ctx context.Context, agentSource config.Source, art
 		return "", fmt.Errorf("looking for version in config file\n%s", yaml.FormatError(err, true, true))
 	}
 
-	// Make sure we push a yaml with a version (Use latest if missing)
-	if raw.Version == "" {
-		cfg.Version = latest.Version
+	// Push a self-contained artifact. Normally we preserve the author's raw
+	// bytes (keeping comments and formatting), but we must serialize the
+	// resolved config instead when either:
+	//   - the config has no version (we inject the latest one), or
+	//   - any agent uses instruction_file: its contents have already been
+	//     inlined into Instruction by config.Load, and a pulled artifact has
+	//     no local directory to resolve the original path against, so the raw
+	//     reference would be unreadable.
+	if raw.Version == "" || configUsesInstructionFile(data) {
+		cfg.Version = cmp.Or(raw.Version, latest.Version)
 		data, err = yaml.MarshalWithOptions(cfg, yaml.Indent(2))
 		if err != nil {
 			return "", fmt.Errorf("marshaling config: %w", err)
@@ -86,4 +94,29 @@ func PackageFileAsOCIToStore(ctx context.Context, agentSource config.Source, art
 	}
 
 	return digest, nil
+}
+
+// configUsesInstructionFile reports whether any agent in the raw config sets a
+// non-empty instruction_file. It is a best-effort, format-tolerant probe: a
+// parse failure (e.g. HCL) simply yields false, in which case the caller falls
+// back to its version-based decision.
+func configUsesInstructionFile(data []byte) bool {
+	var probe map[string]any
+	if err := yaml.Unmarshal(data, &probe); err != nil {
+		return false
+	}
+	agents, ok := probe["agents"].(map[string]any)
+	if !ok {
+		return false
+	}
+	for _, v := range agents {
+		agent, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+		if path, ok := agent["instruction_file"].(string); ok && path != "" {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/oci/package_test.go
+++ b/pkg/oci/package_test.go
@@ -55,6 +55,57 @@ agents:
 	assert.Equal(t, "OCI artifact containing test.yaml", metadata.Annotations["org.opencontainers.image.description"])
 }
 
+func TestPackageFileAsOCIToStore_InlinesInstructionFile(t *testing.T) {
+	// A config that uses instruction_file must be pushed self-contained: the
+	// file contents are inlined and the now-unresolvable reference is dropped,
+	// even when the config carries an explicit version (which normally makes
+	// the packager preserve the raw bytes).
+	dir := t.TempDir()
+	agentFilename := filepath.Join(dir, "test.yaml")
+	testContent := `version: "11"
+agents:
+  root:
+    model: auto
+    description: Test agent
+    instruction_file: instructions/root.md
+`
+	require.NoError(t, os.WriteFile(agentFilename, []byte(testContent), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "instructions"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "instructions", "root.md"), []byte("You are a self-contained agent."), 0o644))
+
+	store, err := content.NewStore(content.WithBaseDir(t.TempDir()))
+	require.NoError(t, err)
+
+	agentSource, err := config.Resolve(agentFilename, nil)
+	require.NoError(t, err)
+
+	tag := "test-instruction-file:v1.0.0"
+	digest, err := PackageFileAsOCIToStore(t.Context(), agentSource, tag, store)
+	require.NoError(t, err)
+	assert.NotEmpty(t, digest)
+	t.Cleanup(func() { _ = store.DeleteArtifact(digest) })
+
+	img, err := store.GetArtifactImage(tag)
+	require.NoError(t, err)
+	layers, err := img.Layers()
+	require.NoError(t, err)
+	require.Len(t, layers, 1)
+	reader, err := layers[0].Uncompressed()
+	require.NoError(t, err)
+	defer reader.Close()
+	data, err := io.ReadAll(reader)
+	require.NoError(t, err)
+
+	// The instruction is inlined and the file reference is gone.
+	assert.Contains(t, string(data), "You are a self-contained agent.")
+	assert.NotContains(t, string(data), "instruction_file")
+
+	// The pushed artifact loads without the original local file present.
+	cfg, err := config.Load(t.Context(), config.NewBytesSource("pulled.yaml", data))
+	require.NoError(t, err)
+	assert.Equal(t, "You are a self-contained agent.", cfg.Agents.First().Instruction)
+}
+
 func TestPackageFileAsOCIToStoreInvalidTag(t *testing.T) {
 	agentFilename := filepath.Join(t.TempDir(), "test.txt")
 	require.NoError(t, os.WriteFile(agentFilename, []byte("test content"), 0o644))

--- a/pkg/teamloader/teamloader_test.go
+++ b/pkg/teamloader/teamloader_test.go
@@ -108,10 +108,12 @@ func TestLoadExamples(t *testing.T) {
 			require.NoError(t, yaml.Unmarshal(data, &v))
 			require.Empty(t, v.Version, "example %s should not define a version", agentFilename)
 
-			// Use a bytes source (ParentDir == "") plus a temp WorkingDir so
-			// toolsets that write to disk (memory, RAG, cache, ...) land in
-			// the temp dir instead of the examples/ tree.
-			agentSource := config.NewBytesSource(agentFilename, data)
+			// Use a file source so the config's directory is known: examples
+			// such as instruction_file.yaml reference sibling files that are
+			// resolved relative to it at load time. A temp WorkingDir still
+			// redirects toolsets that write to disk (memory, RAG, cache, ...)
+			// away from the examples/ tree.
+			agentSource := config.NewFileSource(agentFilename)
 			runConfig := &config.RuntimeConfig{}
 			runConfig.WorkingDir = t.TempDir()
 


### PR DESCRIPTION
## Summary

Adds an optional `instruction_file` field on agent config so an agent's instruction can live in its own file (relative to the config file's directory) instead of being inlined in the YAML. This separates infrastructure configuration from behavioral content, which keeps version-control diffs focused, reduces merge conflicts on shared configs, and avoids YAML syntax risk when editing long prompts.

Scope is Option 1 (local file references) from the issue. The inline `instruction` field stays fully supported and is not deprecated.

```yaml
agents:
  coordinator:
    model: openai/gpt-5-mini
    description: Routes work between specialist agents
    instruction_file: instructions/coordinator.md
```

## Acceptance criteria

| Criterion | Status | Notes |
| --- | --- | --- |
| `instruction_file` parameter supported | yes | New field on the latest `AgentConfig` |
| Relative paths (relative to config file) | yes | Resolved against `Source.ParentDir()` |
| File content loaded at startup | yes | Resolved in `config.Load`, between migration and validation |
| Clear error messages if file not found | yes | Errors name the agent and the path |
| Backward compatible with inline `instruction` | yes | Both fields supported; setting both is rejected |
| Documentation updated with examples | yes | New docs section plus a runnable example |
| Tests cover file loading scenarios | yes | See test list below |

## Design decisions

- **Resolution point.** `config.Load` is the single choke point for every consumer (run, teamloader, OCI push, sandbox kit), so resolution happens there. The whole pipeline only ever sees the inlined `Instruction`; no downstream change is needed.
- **Self-containment.** After reading the file into `Instruction`, `InstructionFile` is cleared. This keeps the in-memory config self-contained and is required for the marshalling round-trip test (`TestParseExamplesAfterMarshalling` reloads via a parentless bytes source).
- **Path safety.** The reference must be a local relative path inside the config directory. Absolute paths and `..` traversal are rejected via `filepath.IsLocal`, and reads are confined with `os.OpenRoot` (TOCTOU-safe, blocks symlink escapes). This mirrors the existing HCL `file()` helper and `fileSource.Read`.
- **Mutual exclusivity.** `instruction` and `instruction_file` cannot both be set.
- **Parentless sources.** OCI/URL/bytes sources have no directory to resolve against, so `instruction_file` is rejected there with a clear message. `share push` re-serializes the resolved config when `instruction_file` is used, so pushed artifacts inline the contents and stay self-contained.

## Files

| File | Change |
| --- | --- |
| `pkg/config/latest/types.go` | New `InstructionFile` field (latest config only; v0..v10 frozen) |
| `pkg/config/config.go` | `resolveInstructionFiles` called from `Load` |
| `agent-schema.json` | `instruction_file` added to the `AgentConfig` definition |
| `pkg/oci/package.go` | Re-serialize resolved config when `instruction_file` is used |
| `examples/instruction_file.yaml`, `examples/instructions/*.md` | Runnable coordinator/specialist example |
| `pkg/config/instruction_file_test.go`, `pkg/oci/package_test.go` | Tests |
| `docs/configuration/agents/index.md` | External Instruction Files section plus reference row |

Test coverage: resolution from a relative path, file in a subdirectory, missing file, `..` traversal rejected, absolute path rejected, symlink escape rejected, mutual exclusivity, parentless source rejected, empty-string treated as unset, and OCI push inlining (loads from the pushed bytes without the local file).

## Validation

- `golangci-lint run ./pkg/config/... ./pkg/oci/...` reports no issues.
- `go build ./...` passes (the `lint/` tooling module needs a network fetch unavailable in the sandbox and is unrelated).
- `pkg/config` and `pkg/oci` suites pass. The only failures in the local run are `TestURLSource_Read_RejectsLocalAddresses`, which are network-dependent SSRF tests unrelated to this change (they time out instead of rejecting because outbound network is blocked in the sandbox).

## Possible follow-up

Option 2 from the issue (`instruction_ref` for OCI artifact references) is not included here and can be added later if maintainers want remote versioning.

Closes #1666