### PR TITLE
docs(runtime): document StreamStopped ordering and teardown trade-offs (#3074)

### DIFF
--- a/pkg/runtime/elicitation.go
+++ b/pkg/runtime/elicitation.go
@@ -92,7 +92,17 @@ func (b *elicitationBridge) send(ev Event) (err error) {
 }
 
 // restoreAndClose restores the previous stream channel and closes the current
-// stream channel under the bridge write lock.
+// stream channel under the bridge write lock, so the close is mutually
+// exclusive with an in-flight send. This is the #3069 fix: close can no longer
+// race a parked sender and panic with "send on closed channel".
+//
+// Accepted trade-off (do not "fix" by dropping the lock): holding the write
+// lock makes restoreAndClose wait for any in-flight send to finish, because
+// send holds the read lock across "b.ch <- ev". If the stream consumer has
+// gone away and current is full (or unbuffered), that parked send never
+// drains, so this call blocks on Lock forever and the teardown goroutine
+// leaks. A leaked goroutine is the deliberate, accepted alternative to
+// crashing the whole process with a send-on-closed-channel panic.
 func (b *elicitationBridge) restoreAndClose(current, previous chan Event) {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/pkg/runtime/elicitation_test.go
+++ b/pkg/runtime/elicitation_test.go
@@ -236,6 +236,49 @@ func TestLocalRuntime_FinalizeEventChannelDoesNotDeadlockWhenBufferFullAndConsum
 	assert.Zero(t, stopped, "StreamStopped should be dropped instead of blocking when the buffer is full")
 }
 
+// TestLocalRuntime_FinalizeEventChannelStreamStoppedIsLastBeforeClose pins the
+// Option B decision from #3074: StreamStopped is emitted before the session-end
+// hooks and telemetry run (so the UI reacts immediately), but it must still be
+// the final event a consumer observes before the channel close that terminates
+// its range. Session-end hooks dispatch with a nil event sink, so nothing is
+// delivered onto the stream after StreamStopped and the close is the terminal
+// signal. If a future change emits onto the events channel after StreamStopped
+// (for example by handing the events sink to a session_end hook), this fails.
+func TestLocalRuntime_FinalizeEventChannelStreamStoppedIsLastBeforeClose(t *testing.T) {
+	t.Parallel()
+
+	rt := newElicitationTestRuntime(t)
+	sess := session.New()
+	events := make(chan Event, defaultEventChannelCapacity)
+	parent := make(chan Event, 1)
+
+	// Seed events that stand in for the stream's prior output so asserting
+	// StreamStopped is *last* is a real ordering check, not merely "it was the
+	// only event delivered".
+	events <- Error("prior stream output 1")
+	events <- Error("prior stream output 2")
+	rt.elicitation.swap(events)
+
+	rt.finalizeEventChannel(t.Context(), sess, turnEndReasonNormal, parent, events)
+
+	var delivered []Event
+	for ev := range events {
+		delivered = append(delivered, ev)
+	}
+
+	require.NotEmpty(t, delivered, "expected events delivered before the channel close")
+
+	var stopped int
+	for _, ev := range delivered {
+		if _, ok := ev.(*StreamStoppedEvent); ok {
+			stopped++
+		}
+	}
+	assert.Equal(t, 1, stopped, "exactly one StreamStopped should be delivered")
+	assert.IsType(t, &StreamStoppedEvent{}, delivered[len(delivered)-1],
+		"StreamStopped must be the last event delivered before the channel closes")
+}
+
 // TestRunStreamClosesChannelAndRestoresElicitationOnEarlyReturn is the
 // regression test for issue #3073: runStreamLoop swapped this stream's
 // events channel into the elicitation bridge before registering the

--- a/pkg/runtime/event.go
+++ b/pkg/runtime/event.go
@@ -464,6 +464,15 @@ func SessionCompaction(sessionID, status, agentName string) Event {
 
 func (e *SessionCompactionEvent) GetSessionID() string { return e.SessionID }
 
+// StreamStoppedEvent reports that a RunStream loop has stopped. Reason carries
+// the turnEndReason* classification (normal, error, canceled) so consumers can
+// tell successful completion apart from crashes and user-initiated stops.
+//
+// Delivery is best-effort: it is emitted non-blockingly during teardown and is
+// dropped if the events buffer is full and the consumer has gone away (see
+// finalizeEventChannel). Treat the channel close, not receipt of this event, as
+// the guaranteed terminal signal. Do not assume session-end hooks have finished
+// when this event arrives: it is emitted before they run.
 type StreamStoppedEvent struct {
 	AgentContext
 

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -172,6 +172,21 @@ func (r *LocalRuntime) emitHookDrivenShutdown(
 // the StreamStoppedEvent so external consumers (boards, dashboards) can
 // distinguish between successful completion, crashes, and user-initiated
 // stops without reverse-engineering reconnect failures.
+//
+// Ordering (decided in #3074): StreamStopped is emitted before the session-end
+// hooks and telemetry run, not after, so consumers react immediately (the TUI
+// stops its spinner and drains its queued messages) instead of waiting behind
+// potentially slow user-configured session_end hooks. This is safe because
+// those hooks dispatch with a nil event sink and never emit onto this channel,
+// so StreamStopped stays the last event a consumer observes. The authoritative
+// "all cleanup done" signal is the channel close (done last, in
+// restoreAndClose) that terminates a `for range`, not the StreamStopped event.
+//
+// Delivery: StreamStopped is best-effort. It is emitted non-blockingly and is
+// dropped when the buffer is full and the consumer has gone away, rather than
+// blocking teardown (a blocking send here is the deadlock #3070 fixed).
+// Consumers must rely on the channel close, not on receiving StreamStopped, as
+// the guaranteed terminal signal.
 func (r *LocalRuntime) finalizeEventChannel(ctx context.Context, sess *session.Session, reason string, prevElicitationCh, events chan Event) {
 	a := r.resolveSessionAgent(sess)
 
@@ -179,6 +194,9 @@ func (r *LocalRuntime) finalizeEventChannel(ctx context.Context, sess *session.S
 		reason = turnEndReasonCanceled
 	}
 
+	// Best-effort, non-blocking on purpose: a blocking send here reintroduces
+	// the #3070 teardown deadlock. See the doc comment for the ordering and
+	// delivery contract.
 	nonBlocking(&channelSink{ch: events}).Emit(StreamStopped(sess.ID, a.Name(), reason))
 
 	// Execute session end hooks with a context that won't be cancelled so


### PR DESCRIPTION
## What

Follow-up to #3074, the documentation and decision debt left by #3070 (fix for #3069). No production behavior change: the only code edits are doc comments; the runtime ordering is kept as-is (Option B) and a regression test is added.

## Decision: Option B (keep current order)

`StreamStopped` stays emitted before the session-end hooks and telemetry, rather than moving it after (Option A). An audit of every `StreamStoppedEvent` consumer (TUI chat, sidebar, supervisor, leantui, A2A adapter, API server) shows none rely on session-end hooks having completed, so the order is safe, and emit-before-hooks keeps the TUI responsive (spinner stop and queue drain are not delayed behind user-configured `session_end` hooks). The authoritative terminal signal remains the channel close, not the event. Full rationale and the consumer audit are in #3074.

This is opened as a draft because #3074 listed Option A as the recommended option; a maintainer decision on B versus A would unblock marking it ready. Option A is a one-line move and the docs plus test apply unchanged either way.

## Changes

| File | Change |
|---|---|
| `pkg/runtime/elicitation.go` | Doc on `restoreAndClose`: close-under-write-lock is the #3069 fix, and the accepted trade-off that teardown blocks (goroutine leak) instead of panicking when a parked sender cannot drain |
| `pkg/runtime/loop.go` | Doc on `finalizeEventChannel`: ordering decision (#3074) and best-effort delivery; inline note on the non-blocking emit warning against reintroducing the #3070 deadlock |
| `pkg/runtime/event.go` | Doc on `StreamStoppedEvent`: best-effort delivery, channel close is the terminal signal, hooks run after the event |
| `pkg/runtime/elicitation_test.go` | New `TestLocalRuntime_FinalizeEventChannelStreamStoppedIsLastBeforeClose`: asserts exactly one StreamStopped and that it is the last event delivered before the channel close |

## Issue scope mapping

| Issue item | Status |
|---|---|
| Ordering decision | Option B, documented |
| Document `restoreAndClose` leak-over-panic trade-off | done |
| Document StreamStopped best-effort delivery | done |
| Test: StreamStopped last before close | done |

## Validation

| Command | Result |
|---|---|
| `task build` | pass |
| `golangci-lint run ./pkg/runtime/...` | 0 issues |
| `go test ./pkg/runtime/` | pass |
| `go test -race ./pkg/runtime/ -run 'Elicitation\|FinalizeEventChannel\|RunStreamClosesChannel'` | pass |

Note: `go test -race ./pkg/runtime/` (full package) reports a data race in `TestHandleStream_ContextCancellation`. It is pre-existing and unrelated to this change (reproduced on a tree with these edits stashed) and lives in the `stalledStream.Close()` test double in `streaming_test.go`, which is invoked concurrently without synchronization. It does not surface under the standard `task test` run (no `-race`). Out of scope here; a separate fix can add a mutex or atomic to `stalledStream.Close()`.

## Relations

- Resolves #3074
- Follow-up to #3070 / #3069
