### PR TITLE
feat: add open_url built-in toolset

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -1890,6 +1890,7 @@
             "lsp",
             "user_prompt",
             "openapi",
+            "open_url",
             "model_picker",
             "background_agents",
             "rag"
@@ -2099,7 +2100,7 @@
         },
         "url": {
           "type": "string",
-          "description": "URL for the a2a or openapi tool",
+          "description": "URL for the a2a, openapi or open_url tool",
           "format": "uri"
         },
         "headers": {
@@ -2275,6 +2276,22 @@
               "properties": {
                 "type": {
                   "const": "openapi"
+                }
+              }
+            },
+            {
+              "required": [
+                "url"
+              ]
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "properties": {
+                "type": {
+                  "const": "open_url"
                 }
               }
             },

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -69,6 +69,8 @@
       url: /tools/api/
     - title: User Prompt
       url: /tools/user-prompt/
+    - title: Open URL
+      url: /tools/open-url/
     - title: Transfer Task
       url: /tools/transfer-task/
     - title: Background Agents

--- a/docs/concepts/tools/index.md
+++ b/docs/concepts/tools/index.md
@@ -43,6 +43,7 @@ docker-agent ships with several built-in tools that require no external dependen
 | [RAG]({{ '/tools/rag/' | relative_url }}) | Retrieval-augmented generation over indexed sources |
 | [Model Picker]({{ '/tools/model-picker/' | relative_url }}) | Let the agent pick between several models per turn |
 | [User Prompt]({{ '/tools/user-prompt/' | relative_url }}) | Ask users questions and collect interactive input |
+| [Open URL]({{ '/tools/open-url/' | relative_url }}) | Open a fixed URL in the user's default browser |
 | [Transfer Task]({{ '/tools/transfer-task/' | relative_url }}) | Delegate tasks to sub-agents (auto-enabled with `sub_agents`) |
 | [Background Agents]({{ '/tools/background-agents/' | relative_url }}) | Dispatch work to sub-agents concurrently |
 | [Handoff]({{ '/tools/handoff/' | relative_url }}) | Hand the conversation off to another local agent in the same config (auto-enabled with `handoffs:`) |

--- a/docs/configuration/tools/index.md
+++ b/docs/configuration/tools/index.md
@@ -29,6 +29,7 @@ Built-in tools are included with docker-agent and require no external dependenci
 | `rag` | Retrieval-augmented generation over indexed sources | [RAG]({{ '/tools/rag/' | relative_url }}) |
 | `model_picker` | Let the agent pick between several models per turn | [Model Picker]({{ '/tools/model-picker/' | relative_url }}) |
 | `user_prompt` | Interactive user input | [User Prompt]({{ '/tools/user-prompt/' | relative_url }}) |
+| `open_url` | Open a fixed URL in the user's default browser | [Open URL]({{ '/tools/open-url/' | relative_url }}) |
 | `transfer_task` | Delegate to sub-agents (auto-enabled) | [Transfer Task]({{ '/tools/transfer-task/' | relative_url }}) |
 | `background_agents` | Parallel sub-agent dispatch | [Background Agents]({{ '/tools/background-agents/' | relative_url }}) |
 | `handoff` | Local conversation handoff to another agent in the same config (auto-enabled by `handoffs:`) | [Handoff]({{ '/tools/handoff/' | relative_url }}) |

--- a/docs/tools/open-url/index.md
+++ b/docs/tools/open-url/index.md
@@ -1,0 +1,97 @@
+---
+title: "Open URL Tool"
+description: "Open a fixed URL in the user's default browser."
+permalink: /tools/open-url/
+---
+
+# Open URL Tool
+
+_Open a fixed URL in the user's default browser._
+
+## Overview
+
+The `open_url` toolset exposes a single, argument-less tool that opens a URL
+baked into the toolset definition in the user's default browser. The model
+never supplies the URL — it just calls the tool by name. Launching the browser
+is cross-platform: docker-agent uses `open` on macOS, `xdg-open` on Linux, and
+`rundll32` on Windows.
+
+<div class="callout callout-info" markdown="1">
+<div class="callout-title">When to Use
+</div>
+
+- Letting an agent open a dashboard, documentation page, or deep link on demand
+- Deep-linking into a desktop app via a custom URI scheme (e.g. `docker-desktop://`)
+- Any "take me there" action where the destination is fixed and known up front
+
+</div>
+
+## Configuration
+
+```yaml
+agents:
+  assistant:
+    model: openai/gpt-4o
+    description: Assistant that can open the dashboard
+    instruction: When the user asks to see the dashboard, call open_dashboard.
+    toolsets:
+      - type: open_url
+        name: open_dashboard
+        url: https://example.com/dashboard
+```
+
+## Properties
+
+| Property | Type   | Required | Description                                                                                          |
+| -------- | ------ | -------- | ---------------------------------------------------------------------------------------------------- |
+| `url`    | string | ✓        | URL to open. Supports `${env.VAR}` interpolation. Any scheme the OS can dispatch is allowed.         |
+| `name`   | string | ✗        | Tool name the agent references. Defaults to `open_url`. Use a descriptive name when configuring several. |
+
+## Multiple URLs
+
+Add one toolset entry per destination, each with its own `name`:
+
+```yaml
+toolsets:
+  - type: open_url
+    name: open_dashboard
+    url: https://example.com/dashboard
+  - type: open_url
+    name: open_docs
+    url: https://docs.example.com/${env.DOCS_VERSION}
+```
+
+## URL Interpolation
+
+The `url` field supports `${env.VAR}` placeholders, expanded at call time
+against the runtime environment:
+
+```yaml
+toolsets:
+  - type: open_url
+    name: open_docs
+    url: https://docs.example.com/${env.DOCS_VERSION}
+```
+
+## Custom URI Schemes
+
+Any scheme the operating system knows how to dispatch works, including deep
+links into desktop applications:
+
+```yaml
+toolsets:
+  - type: open_url
+    name: open_in_docker_desktop
+    url: docker-desktop://dashboard/apps
+```
+
+## Limitations
+
+- The URL must include a scheme (e.g. `https://`); bare paths are rejected.
+- URLs that look like a command-line flag (starting with `-`) are refused to
+  prevent argument injection into the platform `open` helper.
+- The tool opens the URL on the **host** running docker-agent; in headless or
+  remote environments where no browser/launcher is available, the call fails
+  gracefully and reports the error to the agent.
+
+See [`examples/open_url.yaml`](https://github.com/docker/docker-agent/blob/main/examples/open_url.yaml) for a complete configuration.

--- a/examples/open_url.yaml
+++ b/examples/open_url.yaml
@@ -1,0 +1,20 @@
+agents:
+  root:
+    description: Agent that can open a dashboard in the user's browser
+    instruction: |
+      When the user asks to see the dashboard, call the open_dashboard tool.
+      The tool opens a fixed URL in the user's default browser.
+    model: openai/gpt-4o
+    toolsets:
+      # The open_url toolset exposes a single tool that opens a hardcoded URL
+      # in the user's default browser. It works on macOS, Linux and Windows.
+      # The URL is baked into the toolset definition — the model never supplies
+      # it. The optional `name` field renames the tool (defaults to "open_url").
+      - type: open_url
+        name: open_dashboard
+        url: https://example.com/dashboard
+      # ${env.X} interpolation is supported, so the URL can be configured via
+      # the environment without editing the agent file.
+      - type: open_url
+        name: open_docs
+        url: https://docs.example.com/${env.DOCS_VERSION}

--- a/pkg/config/latest/validate.go
+++ b/pkg/config/latest/validate.go
@@ -280,11 +280,11 @@ func (t *Toolset) validate() error {
 	if t.Config != nil && t.Type != "mcp" {
 		return errors.New("config can only be used with type 'mcp'")
 	}
-	if t.URL != "" && t.Type != "a2a" && t.Type != "openapi" {
-		return errors.New("url can only be used with type 'a2a' or 'openapi'")
+	if t.URL != "" && t.Type != "a2a" && t.Type != "openapi" && t.Type != "open_url" {
+		return errors.New("url can only be used with type 'a2a', 'openapi' or 'open_url'")
 	}
-	if t.Name != "" && (t.Type != "mcp" && t.Type != "a2a" && t.Type != "rag") {
-		return errors.New("name can only be used with type 'mcp', 'a2a', or 'rag'")
+	if t.Name != "" && (t.Type != "mcp" && t.Type != "a2a" && t.Type != "rag" && t.Type != "open_url") {
+		return errors.New("name can only be used with type 'mcp', 'a2a', 'rag', or 'open_url'")
 	}
 	if t.RAGConfig != nil && t.Type != "rag" {
 		return errors.New("rag_config can only be used with type 'rag'")
@@ -357,6 +357,10 @@ func (t *Toolset) validate() error {
 	case "openapi":
 		if t.URL == "" {
 			return errors.New("openapi toolset requires a url to be set")
+		}
+	case "open_url":
+		if t.URL == "" {
+			return errors.New("open_url toolset requires a url to be set")
 		}
 	case "model_picker":
 		if len(t.Models) == 0 {

--- a/pkg/teamloader/toolsets/toolsets.go
+++ b/pkg/teamloader/toolsets/toolsets.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/docker-agent/pkg/tools/builtin/memory"
 	"github.com/docker/docker-agent/pkg/tools/builtin/modelpicker"
 	"github.com/docker/docker-agent/pkg/tools/builtin/openapi"
+	"github.com/docker/docker-agent/pkg/tools/builtin/openurl"
 	"github.com/docker/docker-agent/pkg/tools/builtin/plan"
 	"github.com/docker/docker-agent/pkg/tools/builtin/rag"
 	"github.com/docker/docker-agent/pkg/tools/builtin/shell"
@@ -87,6 +88,9 @@ func DefaultToolsetCreators() map[string]teamloader.ToolsetCreator {
 		},
 		"openapi": func(ctx context.Context, toolset latest.Toolset, _ string, runConfig *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
 			return openapi.CreateToolSet(ctx, toolset, runConfig)
+		},
+		"open_url": func(_ context.Context, toolset latest.Toolset, _ string, runConfig *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
+			return openurl.CreateToolSet(toolset, runConfig)
 		},
 		"model_picker": func(_ context.Context, toolset latest.Toolset, _ string, _ *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
 			return modelpicker.CreateToolSet(toolset)

--- a/pkg/tools/builtin/doc.go
+++ b/pkg/tools/builtin/doc.go
@@ -17,5 +17,6 @@
 //   - userprompt — ask the user for input
 //   - api        — external API tool
 //   - openapi    — OpenAPI spec-driven tool
+//   - openurl    — open a fixed URL in the user's browser
 //   - deferred   — deferred toolset wrapper
 package builtin

--- a/pkg/tools/builtin/openurl/openurl.go
+++ b/pkg/tools/builtin/openurl/openurl.go
@@ -105,11 +105,17 @@ func (t *ToolSet) callTool(ctx context.Context, _ struct{}) (*tools.ToolCallResu
 		url = t.expander.Expand(ctx, url, nil)
 	}
 
-	// The platform launcher (open / xdg-open / rundll32) hands the URL to the
-	// OS and exits immediately; the OS then opens the browser asynchronously.
-	// exec.CommandContext kills the launcher when its context is canceled, so
-	// we strip cancellation (while keeping trace/values) to prevent a finishing
-	// or interrupted agent turn from killing the launcher mid-handoff.
+	// browser.Open validates the (post-expansion) URL before launching: it
+	// requires a non-empty scheme and rejects flag-like values (leading "-"),
+	// which would otherwise be parsed as options by the OS launcher
+	// (open / xdg-open / rundll32) — argument injection. Both static and
+	// env-expanded URLs go through this guard. See pkg/browser.validate.
+	//
+	// The launcher hands the URL to the OS and exits immediately; the OS then
+	// opens the browser asynchronously. exec.CommandContext kills the launcher
+	// when its context is canceled, so we strip cancellation (while keeping
+	// trace/values) to prevent a finishing or interrupted agent turn from
+	// killing the launcher mid-handoff.
 	if err := t.open(context.WithoutCancel(ctx), url); err != nil {
 		return tools.ResultError(fmt.Sprintf("failed to open %s: %v", url, err)), nil
 	}

--- a/pkg/tools/builtin/openurl/openurl.go
+++ b/pkg/tools/builtin/openurl/openurl.go
@@ -105,7 +105,12 @@ func (t *ToolSet) callTool(ctx context.Context, _ struct{}) (*tools.ToolCallResu
 		url = t.expander.Expand(ctx, url, nil)
 	}
 
-	if err := t.open(ctx, url); err != nil {
+	// The platform launcher (open / xdg-open / rundll32) hands the URL to the
+	// OS and exits immediately; the OS then opens the browser asynchronously.
+	// exec.CommandContext kills the launcher when its context is canceled, so
+	// we strip cancellation (while keeping trace/values) to prevent a finishing
+	// or interrupted agent turn from killing the launcher mid-handoff.
+	if err := t.open(context.WithoutCancel(ctx), url); err != nil {
 		return tools.ResultError(fmt.Sprintf("failed to open %s: %v", url, err)), nil
 	}
 

--- a/pkg/tools/builtin/openurl/openurl.go
+++ b/pkg/tools/builtin/openurl/openurl.go
@@ -1,0 +1,113 @@
+// Package openurl implements a built-in toolset that exposes a single tool
+// which opens a fixed URL in the user's default browser. The URL is baked
+// into the toolset definition (the YAML `url` field), so the model only has
+// to call the tool by name — it never supplies the URL itself.
+//
+// Opening the URL is delegated to pkg/browser, which picks the right platform
+// helper (open / xdg-open / rundll32), so the tool works across macOS, Linux
+// and Windows.
+package openurl
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/docker/docker-agent/pkg/browser"
+	"github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/js"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+const ToolNameOpenURL = "open_url"
+
+type ToolSet struct {
+	url      string
+	name     string
+	expander *js.Expander
+	open     func(context.Context, string) error
+}
+
+// Verify interface compliance.
+var (
+	_ tools.ToolSet      = (*ToolSet)(nil)
+	_ tools.Instructable = (*ToolSet)(nil)
+)
+
+// CreateToolSet is used by the tools registry.
+func CreateToolSet(toolset latest.Toolset, runConfig *config.RuntimeConfig) (tools.ToolSet, error) {
+	if toolset.URL == "" {
+		return nil, errors.New("open_url toolset requires a url to be set")
+	}
+
+	expander := js.NewJsExpander(runConfig.EnvProvider())
+	return New(toolset.URL, WithName(toolset.Name), WithExpander(expander)), nil
+}
+
+func New(url string, opts ...Option) *ToolSet {
+	t := &ToolSet{
+		url:  url,
+		open: browser.Open,
+	}
+	for _, opt := range opts {
+		opt(t)
+	}
+	return t
+}
+
+type Option func(*ToolSet)
+
+// WithName overrides the tool name. An empty name keeps the default.
+func WithName(name string) Option {
+	return func(t *ToolSet) { t.name = name }
+}
+
+// WithExpander enables ${env.X} interpolation of the configured URL.
+func WithExpander(expander *js.Expander) Option {
+	return func(t *ToolSet) { t.expander = expander }
+}
+
+// WithOpener overrides the function used to open the URL. Tests use it to
+// avoid spawning a real browser.
+func WithOpener(open func(context.Context, string) error) Option {
+	return func(t *ToolSet) { t.open = open }
+}
+
+func (t *ToolSet) toolName() string {
+	return cmp.Or(t.name, ToolNameOpenURL)
+}
+
+func (t *ToolSet) Instructions() string {
+	return fmt.Sprintf("## Open URL Tool\n\nUse the %q tool to open %s in the user's default browser.", t.toolName(), t.url)
+}
+
+func (t *ToolSet) Tools(context.Context) ([]tools.Tool, error) {
+	return []tools.Tool{
+		{
+			Name:         t.toolName(),
+			Category:     "open_url",
+			Description:  fmt.Sprintf("Open the URL %q in the user's default browser. Takes no arguments — the URL is fixed by the tool's configuration.", t.url),
+			Parameters:   tools.MustSchemaFor[struct{}](),
+			OutputSchema: tools.MustSchemaFor[string](),
+			Handler:      tools.NewHandler(t.callTool),
+			Annotations: tools.ToolAnnotations{
+				Title: cmp.Or(t.name, "Open URL"),
+			},
+		},
+	}, nil
+}
+
+func (t *ToolSet) callTool(ctx context.Context, _ struct{}) (*tools.ToolCallResult, error) {
+	url := t.url
+	if t.expander != nil {
+		url = t.expander.Expand(ctx, url, nil)
+	}
+
+	if err := t.open(ctx, url); err != nil {
+		return tools.ResultError(fmt.Sprintf("failed to open %s: %v", url, err)), nil
+	}
+
+	return tools.ResultSuccess("Opened " + url), nil
+}

--- a/pkg/tools/builtin/openurl/openurl_test.go
+++ b/pkg/tools/builtin/openurl/openurl_test.go
@@ -108,6 +108,42 @@ func TestOpenURL_OpenerNotCanceled(t *testing.T) {
 	assert.NoError(t, sawErr, "opener must receive a non-canceled context")
 }
 
+// TestOpenURL_RejectsUnsafeURLs locks in the security guard at the tool
+// boundary using the REAL default opener (browser.Open). Flag-like and
+// schemeless URLs — including ones produced by ${env.X} expansion, which is
+// this package's responsibility — must be rejected before any OS launcher
+// (open / xdg-open / rundll32) is invoked, preventing argument injection.
+// The rejection path errors out in validation before a process is spawned,
+// so exercising the real opener here never launches a browser.
+func TestOpenURL_RejectsUnsafeURLs(t *testing.T) {
+	t.Parallel()
+
+	expander := js.NewJsExpander(environment.NewMapEnvProvider(map[string]string{
+		"FLAG": "-malicious",
+	}))
+
+	for _, tc := range []struct {
+		name string
+		url  string
+		opts []Option
+	}{
+		{"leading dash flag", "-foo", nil},
+		{"double dash flag", "--version", nil},
+		{"schemeless host", "example.com", nil},
+		{"empty", "", nil},
+		{"env expands to flag", "${env.FLAG}", []Option{WithExpander(expander)}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tool := New(tc.url, tc.opts...)
+			result, err := tool.callTool(t.Context(), struct{}{})
+			require.NoError(t, err)
+			assert.True(t, result.IsError, "unsafe URL %q must be rejected", tc.url)
+		})
+	}
+}
+
 func TestCreateToolSet_RequiresURL(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tools/builtin/openurl/openurl_test.go
+++ b/pkg/tools/builtin/openurl/openurl_test.go
@@ -85,6 +85,29 @@ func TestOpenURL_DefaultName(t *testing.T) {
 	assert.Equal(t, ToolNameOpenURL, toolsList[0].Name)
 }
 
+// TestOpenURL_OpenerNotCanceled guards against a regression where the
+// request-scoped context was forwarded straight to the launcher: a canceled
+// turn would then kill the fire-and-forget open/xdg-open/rundll32 process
+// before the OS finished handing off to the browser. The handler must strip
+// cancellation before calling the opener.
+func TestOpenURL_OpenerNotCanceled(t *testing.T) {
+	t.Parallel()
+
+	canceledCtx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	var sawErr error
+	tool := New("https://example.com", WithOpener(func(ctx context.Context, _ string) error {
+		sawErr = ctx.Err()
+		return nil
+	}))
+
+	result, err := tool.callTool(canceledCtx, struct{}{})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.NoError(t, sawErr, "opener must receive a non-canceled context")
+}
+
 func TestCreateToolSet_RequiresURL(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tools/builtin/openurl/openurl_test.go
+++ b/pkg/tools/builtin/openurl/openurl_test.go
@@ -1,0 +1,110 @@
+package openurl
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/environment"
+	"github.com/docker/docker-agent/pkg/js"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+func TestOpenURL_Opens(t *testing.T) {
+	t.Parallel()
+
+	var opened string
+	tool := New("https://example.com/dashboard", WithOpener(func(_ context.Context, url string) error {
+		opened = url
+		return nil
+	}))
+
+	result, err := tool.callTool(t.Context(), struct{}{})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Equal(t, "https://example.com/dashboard", opened)
+	assert.Contains(t, result.Output, "https://example.com/dashboard")
+}
+
+func TestOpenURL_OpenerError(t *testing.T) {
+	t.Parallel()
+
+	tool := New("https://example.com", WithOpener(func(context.Context, string) error {
+		return errors.New("boom")
+	}))
+
+	result, err := tool.callTool(t.Context(), struct{}{})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Output, "boom")
+}
+
+func TestOpenURL_ExpandsEnv(t *testing.T) {
+	t.Parallel()
+
+	expander := js.NewJsExpander(environment.NewMapEnvProvider(map[string]string{
+		"DOCS_VERSION": "v2",
+	}))
+
+	var opened string
+	tool := New("https://docs.example.com/${env.DOCS_VERSION}",
+		WithExpander(expander),
+		WithOpener(func(_ context.Context, url string) error {
+			opened = url
+			return nil
+		}),
+	)
+
+	_, err := tool.callTool(t.Context(), struct{}{})
+	require.NoError(t, err)
+	assert.Equal(t, "https://docs.example.com/v2", opened)
+}
+
+func TestOpenURL_CustomName(t *testing.T) {
+	t.Parallel()
+
+	tool := New("https://example.com", WithName("open_dashboard"))
+	toolsList, err := tool.Tools(t.Context())
+	require.NoError(t, err)
+	require.Len(t, toolsList, 1)
+	assert.Equal(t, "open_dashboard", toolsList[0].Name)
+}
+
+func TestOpenURL_DefaultName(t *testing.T) {
+	t.Parallel()
+
+	tool := New("https://example.com")
+	toolsList, err := tool.Tools(t.Context())
+	require.NoError(t, err)
+	require.Len(t, toolsList, 1)
+	assert.Equal(t, ToolNameOpenURL, toolsList[0].Name)
+}
+
+func TestCreateToolSet_RequiresURL(t *testing.T) {
+	t.Parallel()
+
+	_, err := CreateToolSet(latest.Toolset{Type: "open_url"}, &config.RuntimeConfig{})
+	require.Error(t, err)
+}
+
+func TestCreateToolSet_OK(t *testing.T) {
+	t.Parallel()
+
+	ts, err := CreateToolSet(latest.Toolset{
+		Type: "open_url",
+		URL:  "https://example.com",
+	}, &config.RuntimeConfig{})
+	require.NoError(t, err)
+
+	toolsList, err := ts.Tools(t.Context())
+	require.NoError(t, err)
+	require.Len(t, toolsList, 1)
+
+	_, ok := ts.(tools.Instructable)
+	assert.True(t, ok)
+}


### PR DESCRIPTION
Agents sometimes need to surface a URL to the user — a dashboard, a monitoring page, a deep link into another tool — without letting the model pick arbitrary destinations. The new `open_url` toolset fills that gap: the URL is fixed in the agent config, the model only decides *when* to invoke it.

Adding a toolset of type `open_url` exposes a single tool that opens the configured URL in the user's default browser. Any OS-dispatchable scheme works, including `https://`, custom app deep links like `docker-desktop://`, and anything else the OS knows how to handle. The tool name, description, and URL are all author-controlled; the launcher validates that the value is not a flag-like or schemeless string before dispatching. Cross-platform dispatch uses `open` on macOS, `xdg-open` on Linux, and `rundll32` on Windows, via `pkg/browser`. A second commit wraps the execution context with `context.WithoutCancel` so a finishing agent turn cannot kill the fire-and-forget launcher before the OS hands off to the browser.

```yaml
toolsets:
  - type: open_url
    name: open_dashboard
    url: https://example.com/dashboard
```

No breaking changes. The feature is additive and fully opt-in.