### PR TITLE
refactor: thread context throughout and enforce ContextConnectivity lint rule

### DIFF
--- a/cmd/root/api.go
+++ b/cmd/root/api.go
@@ -69,7 +69,7 @@ func (f *apiFlags) runAPICommand(cmd *cobra.Command, args []string) (commandErr 
 	os.Stdin = nil
 
 	// Start fake proxy if --fake is specified
-	cleanup, err := setupFakeProxy(f.fakeResponses, 0, &f.runConfig)
+	cleanup, err := setupFakeProxy(ctx, f.fakeResponses, 0, &f.runConfig)
 	if err != nil {
 		return err
 	}
@@ -80,7 +80,7 @@ func (f *apiFlags) runAPICommand(cmd *cobra.Command, args []string) (commandErr 
 	}()
 
 	// Start recording proxy if --record is specified
-	_, recordCleanup, err := setupRecordingProxy(f.recordPath, &f.runConfig)
+	_, recordCleanup, err := setupRecordingProxy(ctx, f.recordPath, &f.runConfig)
 	if err != nil {
 		return err
 	}
@@ -117,7 +117,7 @@ func (f *apiFlags) runAPICommand(cmd *cobra.Command, args []string) (commandErr 
 		return err
 	}
 
-	sessionStore, err := session.NewSQLiteSessionStore(sessionDB)
+	sessionStore, err := session.NewSQLiteSessionStore(ctx, sessionDB)
 	if err != nil {
 		return fmt.Errorf("creating session store: %w", err)
 	}

--- a/cmd/root/backend.go
+++ b/cmd/root/backend.go
@@ -109,20 +109,20 @@ func (b *localBackend) sessionStore(req runtime.CreateSessionRequest) (session.S
 func (b *localBackend) CreateSession(ctx context.Context, loaded *teamloader.LoadResult, req runtime.CreateSessionRequest) (runtime.Runtime, *session.Session, func(), error) {
 	store, err := b.sessionStore(req)
 	if err != nil {
-		stopToolSets(loaded.Team)
+		stopToolSets(ctx, loaded.Team)
 		return nil, nil, nil, err
 	}
 
 	rt, sess, err := b.flags.createLocalRuntimeAndSession(ctx, loaded, req, store)
 	if err != nil {
-		stopToolSets(loaded.Team)
+		stopToolSets(ctx, loaded.Team)
 		return nil, nil, nil, err
 	}
 
 	var once sync.Once
 	cleanup := func() {
 		once.Do(func() {
-			stopToolSets(loaded.Team)
+			stopToolSets(ctx, loaded.Team)
 			if err := rt.Close(); err != nil {
 				slog.ErrorContext(ctx, "Failed to close runtime", "error", err)
 			}

--- a/cmd/root/backend.go
+++ b/cmd/root/backend.go
@@ -89,14 +89,14 @@ func (b *localBackend) CreateSessionRequest(workingDir string) runtime.CreateSes
 // sessionStore returns the backend-owned session store, opening it on
 // first use. The store is shared by the initial runtime and by every
 // runtime spawned by [localBackend.Spawner].
-func (b *localBackend) sessionStore(req runtime.CreateSessionRequest) (session.Store, error) {
+func (b *localBackend) sessionStore(ctx context.Context, req runtime.CreateSessionRequest) (session.Store, error) {
 	b.storeOnce.Do(func() {
 		sessionDB, err := pathx.ExpandHomeDir(req.SessionDB)
 		if err != nil {
 			b.storeErr = err
 			return
 		}
-		store, err := session.NewSQLiteSessionStore(sessionDB)
+		store, err := session.NewSQLiteSessionStore(context.WithoutCancel(ctx), sessionDB)
 		if err != nil {
 			b.storeErr = fmt.Errorf("creating session store: %w", err)
 			return
@@ -107,7 +107,7 @@ func (b *localBackend) sessionStore(req runtime.CreateSessionRequest) (session.S
 }
 
 func (b *localBackend) CreateSession(ctx context.Context, loaded *teamloader.LoadResult, req runtime.CreateSessionRequest) (runtime.Runtime, *session.Session, func(), error) {
-	store, err := b.sessionStore(req)
+	store, err := b.sessionStore(ctx, req)
 	if err != nil {
 		stopToolSets(ctx, loaded.Team)
 		return nil, nil, nil, err
@@ -148,7 +148,7 @@ func (b *localBackend) ResumeWorkingDir(ctx context.Context) (string, bool) {
 		return "", false
 	}
 
-	store, err := b.sessionStore(b.flags.createSessionRequest(""))
+	store, err := b.sessionStore(ctx, b.flags.createSessionRequest(""))
 	if err != nil {
 		return "", false
 	}

--- a/cmd/root/debug.go
+++ b/cmd/root/debug.go
@@ -70,7 +70,7 @@ func newDebugCmd() *cobra.Command {
 }
 
 // loadTeam loads an agent team from the given agent file.
-// Callers should defer stopToolSets(t) to clean up.
+// Callers should defer stopToolSets(ctx, t) to clean up.
 func (f *debugFlags) loadTeam(ctx context.Context, agentFilename string, opts ...teamloader.Opt) (*team.Team, error) {
 	agentSource, err := config.Resolve(agentFilename, f.runConfig.EnvProvider())
 	if err != nil {
@@ -117,7 +117,7 @@ func (f *debugFlags) runDebugToolsetsCommand(cmd *cobra.Command, args []string) 
 	if err != nil {
 		return err
 	}
-	defer stopToolSets(t)
+	defer stopToolSets(ctx, t)
 
 	out := cli.NewPrinter(cmd.OutOrStdout())
 
@@ -160,7 +160,7 @@ func (f *debugFlags) runDebugSkillsCommand(cmd *cobra.Command, args []string) (c
 	if err != nil {
 		return err
 	}
-	defer stopToolSets(t)
+	defer stopToolSets(ctx, t)
 
 	out := cli.NewPrinter(cmd.OutOrStdout())
 
@@ -210,7 +210,7 @@ func (f *debugFlags) runDebugTitleCommand(cmd *cobra.Command, args []string) (co
 	if err != nil {
 		return err
 	}
-	defer stopToolSets(t)
+	defer stopToolSets(ctx, t)
 
 	agent, err := t.DefaultAgent()
 	if err != nil {

--- a/cmd/root/new.go
+++ b/cmd/root/new.go
@@ -63,7 +63,7 @@ func (f *newFlags) runNewCommand(cmd *cobra.Command, args []string) (commandErr 
 		return err
 	}
 	t := loadResult.Team
-	defer stopToolSets(t)
+	defer stopToolSets(ctx, t)
 
 	rt, err := runtime.New(t,
 		runtime.WithProviderRegistry(loadResult.ProviderRegistry),

--- a/cmd/root/new.go
+++ b/cmd/root/new.go
@@ -95,7 +95,7 @@ func runTUI(ctx context.Context, rt runtime.Runtime, sess *session.Session, spaw
 		opts = append(opts, app.WithTitleGenerator(gen))
 	}
 
-	a := app.New(rt, sess, opts...)
+	a := app.New(ctx, rt, sess, opts...)
 
 	coalescer := tuiinput.NewWheelCoalescer()
 	filter := func(model tea.Model, msg tea.Msg) tea.Msg {

--- a/cmd/root/new.go
+++ b/cmd/root/new.go
@@ -65,7 +65,7 @@ func (f *newFlags) runNewCommand(cmd *cobra.Command, args []string) (commandErr 
 	t := loadResult.Team
 	defer stopToolSets(ctx, t)
 
-	rt, err := runtime.New(t,
+	rt, err := runtime.New(ctx, t,
 		runtime.WithProviderRegistry(loadResult.ProviderRegistry),
 		runtime.WithTracer(otel.Tracer(AppName)),
 	)
@@ -91,7 +91,7 @@ func (f *newFlags) runNewCommand(cmd *cobra.Command, args []string) (commandErr 
 }
 
 func runTUI(ctx context.Context, rt runtime.Runtime, sess *session.Session, spawner tui.SessionSpawner, cleanup func(), tuiOpts []tui.Option, opts ...app.Opt) error {
-	if gen := rt.TitleGenerator(); gen != nil {
+	if gen := rt.TitleGenerator(ctx); gen != nil {
 		opts = append(opts, app.WithTitleGenerator(gen))
 	}
 

--- a/cmd/root/otel.go
+++ b/cmd/root/otel.go
@@ -55,6 +55,7 @@ func initOTelSDK(ctx context.Context) (err error) {
 
 	lp, err := newLoggerProvider(ctx, res, endpoint)
 	if err != nil {
+		//rubocop:disable Lint/ContextConnectivity
 		_ = mp.Shutdown(context.Background())
 		_ = shutdownTracerProvider(tp)
 		return fmt.Errorf("failed to create logger provider: %w", err)
@@ -91,6 +92,7 @@ func initOTelSDK(ctx context.Context) (err error) {
 		// sharing a single timeout meant a stuck logs endpoint silently
 		// dropped buffered metrics and spans.
 		shutdown := func(fn func(context.Context) error) {
+			//rubocop:disable Lint/ContextConnectivity
 			c, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 			_ = fn(c)
@@ -219,6 +221,7 @@ func logExporterOptions(endpoint string) []otlploghttp.Option {
 }
 
 func shutdownTracerProvider(tp *trace.TracerProvider) error {
+	//rubocop:disable Lint/ContextConnectivity
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	return tp.Shutdown(shutdownCtx)

--- a/cmd/root/otel.go
+++ b/cmd/root/otel.go
@@ -48,16 +48,17 @@ func initOTelSDK(ctx context.Context) (err error) {
 
 	mp, err := newMeterProvider(ctx, res, endpoint)
 	if err != nil {
-		_ = shutdownTracerProvider(tp)
+		_ = shutdownTracerProvider(ctx, tp)
 		return fmt.Errorf("failed to create meter provider: %w", err)
 	}
 	otel.SetMeterProvider(mp)
 
 	lp, err := newLoggerProvider(ctx, res, endpoint)
 	if err != nil {
-		//rubocop:disable Lint/ContextConnectivity
-		_ = mp.Shutdown(context.Background())
-		_ = shutdownTracerProvider(tp)
+		// Detach from ctx's cancellation but keep its trace context so
+		// cleanup still runs if ctx is already done.
+		_ = mp.Shutdown(context.WithoutCancel(ctx))
+		_ = shutdownTracerProvider(ctx, tp)
 		return fmt.Errorf("failed to create logger provider: %w", err)
 	}
 	global.SetLoggerProvider(lp)
@@ -92,8 +93,9 @@ func initOTelSDK(ctx context.Context) (err error) {
 		// sharing a single timeout meant a stuck logs endpoint silently
 		// dropped buffered metrics and spans.
 		shutdown := func(fn func(context.Context) error) {
-			//rubocop:disable Lint/ContextConnectivity
-			c, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			// ctx is already cancelled here (we waited on ctx.Done()), so
+			// detach from its cancellation while keeping its trace context.
+			c, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 			defer cancel()
 			_ = fn(c)
 		}
@@ -220,9 +222,10 @@ func logExporterOptions(endpoint string) []otlploghttp.Option {
 	return []otlploghttp.Option{otlploghttp.WithEndpointURL(signalEndpointURL(endpoint, "/v1/logs"))}
 }
 
-func shutdownTracerProvider(tp *trace.TracerProvider) error {
-	//rubocop:disable Lint/ContextConnectivity
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+func shutdownTracerProvider(ctx context.Context, tp *trace.TracerProvider) error {
+	// Detach from ctx's cancellation but keep its trace context so the
+	// final flush still runs when ctx is already done.
+	shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 	defer cancel()
 	return tp.Shutdown(shutdownCtx)
 }

--- a/cmd/root/record.go
+++ b/cmd/root/record.go
@@ -1,14 +1,16 @@
 package root
 
 import (
+	"context"
+
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/recording"
 )
 
 // setupFakeProxy starts a fake proxy if fakeResponses is non-empty.
 // It configures the runtime config's ModelsGateway to point to the proxy.
-func setupFakeProxy(fakeResponses string, streamDelayMs int, runConfig *config.RuntimeConfig) (cleanup func() error, err error) {
-	proxyURL, cleanupFn, err := recording.SetupFakeProxy(fakeResponses, streamDelayMs)
+func setupFakeProxy(ctx context.Context, fakeResponses string, streamDelayMs int, runConfig *config.RuntimeConfig) (cleanup func() error, err error) {
+	proxyURL, cleanupFn, err := recording.SetupFakeProxy(ctx, fakeResponses, streamDelayMs)
 	if err != nil {
 		return nil, err
 	}
@@ -22,8 +24,8 @@ func setupFakeProxy(fakeResponses string, streamDelayMs int, runConfig *config.R
 
 // setupRecordingProxy starts a recording proxy if recordPath is non-empty.
 // It configures the runtime config's ModelsGateway to point to the proxy.
-func setupRecordingProxy(recordPath string, runConfig *config.RuntimeConfig) (cassettePath string, cleanup func() error, err error) {
-	cassettePath, proxyURL, cleanupFn, err := recording.SetupRecordingProxy(recordPath)
+func setupRecordingProxy(ctx context.Context, recordPath string, runConfig *config.RuntimeConfig) (cassettePath string, cleanup func() error, err error) {
+	cassettePath, proxyURL, cleanupFn, err := recording.SetupRecordingProxy(ctx, recordPath)
 	if err != nil {
 		return "", nil, err
 	}

--- a/cmd/root/record_test.go
+++ b/cmd/root/record_test.go
@@ -14,7 +14,7 @@ import (
 func TestSetupRecordingProxy_EmptyPath(t *testing.T) {
 	var runConfig config.RuntimeConfig
 
-	cassettePath, cleanup, err := setupRecordingProxy("", &runConfig)
+	cassettePath, cleanup, err := setupRecordingProxy(t.Context(), "", &runConfig)
 
 	require.NoError(t, err)
 	assert.Empty(t, cassettePath)
@@ -29,7 +29,7 @@ func TestSetupRecordingProxy_AutoGeneratesFilename(t *testing.T) {
 
 	var runConfig config.RuntimeConfig
 
-	cassettePath, cleanup, err := setupRecordingProxy("true", &runConfig)
+	cassettePath, cleanup, err := setupRecordingProxy(t.Context(), "true", &runConfig)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, cleanup()) }()
 
@@ -44,7 +44,7 @@ func TestSetupRecordingProxy_CreatesProxy(t *testing.T) {
 
 	var runConfig config.RuntimeConfig
 
-	resultPath, cleanup, err := setupRecordingProxy(cassettePath, &runConfig)
+	resultPath, cleanup, err := setupRecordingProxy(t.Context(), cassettePath, &runConfig)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, cleanup()) }()
 

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -381,7 +381,7 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 			return err
 		}
 		if loadResult != nil {
-			stopToolSets(loadResult.Team)
+			stopToolSets(ctx, loadResult.Team)
 		}
 		out.Println("Dry run mode enabled. Agent initialized but will not execute.")
 		return nil
@@ -421,7 +421,7 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 		// the nil-guard used for cleanup throughout this function.
 		if loadResult != nil {
 			if err := f.dispatchWorktreeCreate(ctx, out, loadResult.Team, createdWorktree); err != nil {
-				stopToolSets(loadResult.Team)
+				stopToolSets(ctx, loadResult.Team)
 				return err
 			}
 		}
@@ -1024,7 +1024,7 @@ func (f *runExecFlags) createSessionSpawner(agentSource config.Source, sessStore
 
 		// Create cleanup function
 		cleanup := func() {
-			stopToolSets(t)
+			stopToolSets(spawnCtx, t)
 		}
 
 		// Create the app
@@ -1048,10 +1048,11 @@ type toolStopper interface {
 }
 
 // stopToolSets gracefully stops all tool sets with a bounded timeout so
-// that cleanup cannot block indefinitely.
-func stopToolSets(t toolStopper) {
-	//rubocop:disable Lint/ContextConnectivity
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+// that cleanup cannot block indefinitely. It detaches from ctx's
+// cancellation (cleanup often runs after the caller's ctx is already done,
+// e.g. on shutdown or tab close) while keeping ctx's trace context.
+func stopToolSets(ctx context.Context, t toolStopper) {
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 	defer cancel()
 	if err := t.StopToolSets(ctx); err != nil {
 		slog.ErrorContext(ctx, "Failed to stop tool sets", "error", err)

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -899,7 +899,7 @@ func (f *runExecFlags) runLeanTUI(ctx context.Context, rt runtime.Runtime, sess 
 	if gen := rt.TitleGenerator(ctx); gen != nil {
 		opts = append(opts, app.WithTitleGenerator(gen))
 	}
-	a := app.New(rt, sess, opts...)
+	a := app.New(ctx, rt, sess, opts...)
 	a.Start(ctx)
 
 	firstMessage, err := readInitialMessage(args)
@@ -1036,7 +1036,7 @@ func (f *runExecFlags) createSessionSpawner(agentSource config.Source, sessStore
 			appOpts = append(appOpts, app.WithSnapshotController(ctrl))
 		}
 
-		a := app.New(localRt, newSess, appOpts...)
+		a := app.New(spawnCtx, localRt, newSess, appOpts...)
 
 		return a, newSess, cleanup, nil
 	}

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -779,7 +779,7 @@ func (f *runExecFlags) createLocalRuntimeAndSession(ctx context.Context, loadRes
 		return nil, nil, err
 	}
 	runtimeOpts := append(f.runtimeOpts(loadResult, &f.runConfig, sessStore, agentName), rtOpts...)
-	localRt, err := runtime.New(t, runtimeOpts...)
+	localRt, err := runtime.New(ctx, t, runtimeOpts...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating runtime: %w", err)
 	}
@@ -896,7 +896,7 @@ func (f *runExecFlags) tuiOpts() []tui.Option {
 // (no alternate screen) and sends the first/queued messages itself rather than
 // through the App's bubbletea command pipeline.
 func (f *runExecFlags) runLeanTUI(ctx context.Context, rt runtime.Runtime, sess *session.Session, cleanup func(), args []string, opts ...app.Opt) error {
-	if gen := rt.TitleGenerator(); gen != nil {
+	if gen := rt.TitleGenerator(ctx); gen != nil {
 		opts = append(opts, app.WithTitleGenerator(gen))
 	}
 	a := app.New(rt, sess, opts...)
@@ -1012,7 +1012,7 @@ func (f *runExecFlags) createSessionSpawner(agentSource config.Source, sessStore
 			return nil, nil, nil, err
 		}
 		runtimeOpts := append(f.runtimeOpts(loadResult, runConfigCopy, sessStore, agt.Name()), rtOpts...)
-		localRt, err := runtime.New(t, runtimeOpts...)
+		localRt, err := runtime.New(spawnCtx, t, runtimeOpts...)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -1029,7 +1029,7 @@ func (f *runExecFlags) createSessionSpawner(agentSource config.Source, sessStore
 
 		// Create the app
 		var appOpts []app.Opt
-		if gen := localRt.TitleGenerator(); gen != nil {
+		if gen := localRt.TitleGenerator(spawnCtx); gen != nil {
 			appOpts = append(appOpts, app.WithTitleGenerator(gen))
 		}
 		if ctrl != nil {

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -339,7 +339,7 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 	}
 
 	// Start fake proxy if --fake is specified
-	fakeCleanup, err := setupFakeProxy(f.fakeResponses, f.fakeStreamDelay, &f.runConfig)
+	fakeCleanup, err := setupFakeProxy(ctx, f.fakeResponses, f.fakeStreamDelay, &f.runConfig)
 	if err != nil {
 		return err
 	}
@@ -350,7 +350,7 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 	}()
 
 	// Record AI API interactions to a cassette file if --record flag is specified.
-	cassettePath, recordCleanup, err := setupRecordingProxy(f.recordPath, &f.runConfig)
+	cassettePath, recordCleanup, err := setupRecordingProxy(ctx, f.recordPath, &f.runConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -1050,6 +1050,7 @@ type toolStopper interface {
 // stopToolSets gracefully stops all tool sets with a bounded timeout so
 // that cleanup cannot block indefinitely.
 func stopToolSets(t toolStopper) {
+	//rubocop:disable Lint/ContextConnectivity
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	if err := t.StopToolSets(ctx); err != nil {

--- a/cmd/root/run_event_hooks.go
+++ b/cmd/root/run_event_hooks.go
@@ -43,6 +43,7 @@ func withEventHooks(hooks []onEventHook) app.Opt {
 		return nil
 	}
 	return func(a *app.App) {
+		//rubocop:disable Lint/ContextConnectivity
 		go a.SubscribeWith(context.Background(), func(msg tea.Msg) {
 			ev, ok := msg.(runtime.Event)
 			if !ok {
@@ -79,6 +80,7 @@ func runEventHook(command string, payload []byte) {
 	// flushing the last event when the user exits the TUI should be allowed
 	// to finish. Each invocation receives a single event on stdin, processes
 	// it, and exits; the spawning goroutine ends with the subprocess.
+	//rubocop:disable Lint/ContextConnectivity
 	cmd := exec.CommandContext(context.Background(), shell, append(argsPrefix, command)...)
 	cmd.Stdin = bytes.NewReader(payload)
 	var out boundedWriter

--- a/cmd/root/run_listen.go
+++ b/cmd/root/run_listen.go
@@ -28,7 +28,7 @@ func (f *runExecFlags) startAttachedServer(ctx context.Context, out *cli.Printer
 	}
 
 	sm := server.NewSessionManager(ctx, nil, rt.SessionStore(), 0, &f.runConfig)
-	sm.AttachRuntime(sess.ID, rt, sess)
+	sm.AttachRuntime(ctx, sess.ID, rt, sess)
 
 	ln, err := server.Listen(ctx, f.listenAddr)
 	if err != nil {

--- a/cmd/root/run_runtime_opts_test.go
+++ b/cmd/root/run_runtime_opts_test.go
@@ -39,7 +39,7 @@ func TestRuntimeOptsPassesRunConfigWorkingDirToRuntime(t *testing.T) {
 	loaded := &teamloader.LoadResult{Team: team.New(team.WithAgents(agt))}
 	runConfig := &config.RuntimeConfig{Config: config.Config{WorkingDir: workingDir}}
 
-	rt, err := runtime.New(loaded.Team, (&runExecFlags{}).runtimeOpts(loaded, runConfig, session.NewInMemorySessionStore(), "root")...)
+	rt, err := runtime.New(t.Context(), loaded.Team, (&runExecFlags{}).runtimeOpts(loaded, runConfig, session.NewInMemorySessionStore(), "root")...)
 	require.NoError(t, err)
 
 	localRt, ok := rt.(*runtime.LocalRuntime)

--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -85,7 +85,7 @@ func startCagentAPI(t *testing.T, db string) string {
 		_ = ln.Close()
 	})
 
-	sessionStore, err := session.NewSQLiteSessionStore(dbCopy)
+	sessionStore, err := session.NewSQLiteSessionStore(t.Context(), dbCopy)
 	require.NoError(t, err)
 
 	srv, err := server.New(t.Context(), sessionStore, &config.RuntimeConfig{}, 0, nil, "")

--- a/e2e/binary/binary_test.go
+++ b/e2e/binary/binary_test.go
@@ -14,13 +14,13 @@ const binDir = "../../bin"
 
 func TestHelpInAllExecMode(t *testing.T) {
 	t.Run("cli plugin help", func(t *testing.T) {
-		res, err := Exec("docker", "agent", "help")
+		res, err := ExecWithContext(t.Context(), "docker", "agent", "help")
 		require.NoError(t, err)
 		require.Contains(t, res.Stdout, "docker agent run ./agent.yaml")
 	})
 
 	t.Run("docker-agent help", func(t *testing.T) {
-		res, err := Exec(binDir+"/docker-agent", "help")
+		res, err := ExecWithContext(t.Context(), binDir+"/docker-agent", "help")
 		require.NoError(t, err)
 		require.Contains(t, res.Stdout, "docker-agent run ./agent.yaml")
 	})
@@ -28,14 +28,14 @@ func TestHelpInAllExecMode(t *testing.T) {
 
 func TestExecMissingKeys(t *testing.T) {
 	t.Run("cli plugin exec", func(t *testing.T) {
-		res, err := Exec("docker", "agent", "run", "--exec", "./test-agent.yaml")
+		res, err := ExecWithContext(t.Context(), "docker", "agent", "run", "--exec", "./test-agent.yaml")
 		require.Error(t, err)
 		require.Contains(t, res.Stderr, "environment variables must be set")
 		require.Contains(t, res.Stderr, "OPENAI_API_KEY")
 	})
 
 	t.Run("docker-agent exec", func(t *testing.T) {
-		res, err := Exec(binDir+"/docker-agent", "run", "--exec", "./test-agent.yaml")
+		res, err := ExecWithContext(t.Context(), binDir+"/docker-agent", "run", "--exec", "./test-agent.yaml")
 		require.Error(t, err)
 		require.Contains(t, res.Stderr, "environment variables must be set")
 		require.Contains(t, res.Stderr, "OPENAI_API_KEY")
@@ -44,14 +44,14 @@ func TestExecMissingKeys(t *testing.T) {
 
 func TestAutoComplete(t *testing.T) {
 	t.Run("cli plugin auto-complete docker-agent", func(t *testing.T) {
-		res, err := Exec(binDir+"/docker-agent", "__complete", "ser")
+		res, err := ExecWithContext(t.Context(), binDir+"/docker-agent", "__complete", "ser")
 		require.NoError(t, err)
 		props := lines(res.Stdout)
 		require.Contains(t, props[0], "serve")
 	})
 
 	t.Run("cli plugin auto-complete docker-agent sub commands", func(t *testing.T) {
-		res, err := Exec(binDir+"/docker-agent", "__complete", "serve", "")
+		res, err := ExecWithContext(t.Context(), binDir+"/docker-agent", "__complete", "serve", "")
 		require.NoError(t, err)
 		props := lines(res.Stdout)
 		require.Greater(t, len(props), 5)
@@ -64,14 +64,14 @@ func TestAutoComplete(t *testing.T) {
 	})
 
 	t.Run("cli plugin auto-complete docker agent", func(t *testing.T) {
-		res, err := ExecWithEnv([]string{"DOCKER_CLI_PLUGIN_ORIGINAL_CLI_COMMAND=/docker-agent"}, binDir+"/docker-agent", "__complete", "agent", "ser")
+		res, err := ExecWithContextAndEnv(t.Context(), []string{"DOCKER_CLI_PLUGIN_ORIGINAL_CLI_COMMAND=/docker-agent"}, binDir+"/docker-agent", "__complete", "agent", "ser")
 		require.NoError(t, err)
 		props := lines(res.Stdout)
 		require.Contains(t, props[0], "serve")
 	})
 
 	t.Run("cli plugin auto-complete docker agent sub commands", func(t *testing.T) {
-		res, err := ExecWithEnv([]string{"DOCKER_CLI_PLUGIN_ORIGINAL_CLI_COMMAND=/docker-agent"}, binDir+"/docker-agent", "__complete", "agent", "serve", "")
+		res, err := ExecWithContextAndEnv(t.Context(), []string{"DOCKER_CLI_PLUGIN_ORIGINAL_CLI_COMMAND=/docker-agent"}, binDir+"/docker-agent", "__complete", "agent", "serve", "")
 		require.NoError(t, err)
 		props := lines(res.Stdout)
 		require.Greater(t, len(props), 2)

--- a/e2e/binary/shellout.go
+++ b/e2e/binary/shellout.go
@@ -20,16 +20,6 @@ func ExecWithContext(ctx context.Context, cmd string, args ...string) (CmdResult
 	return ExecWithContextInDir(ctx, "", cmd, args, nil)
 }
 
-func Exec(cmd string, args ...string) (CmdResult, error) {
-	//rubocop:disable Lint/ContextConnectivity
-	return ExecWithContextInDir(context.Background(), "", cmd, args, nil)
-}
-
-func ExecWithEnv(env []string, cmd string, args ...string) (CmdResult, error) {
-	//rubocop:disable Lint/ContextConnectivity
-	return ExecWithContextInDir(context.Background(), "", cmd, args, env)
-}
-
 func ExecWithContextAndEnv(ctx context.Context, env []string, cmd string, args ...string) (CmdResult, error) {
 	return ExecWithContextInDir(ctx, "", cmd, args, env)
 }

--- a/e2e/binary/shellout.go
+++ b/e2e/binary/shellout.go
@@ -21,10 +21,12 @@ func ExecWithContext(ctx context.Context, cmd string, args ...string) (CmdResult
 }
 
 func Exec(cmd string, args ...string) (CmdResult, error) {
+	//rubocop:disable Lint/ContextConnectivity
 	return ExecWithContextInDir(context.Background(), "", cmd, args, nil)
 }
 
 func ExecWithEnv(env []string, cmd string, args ...string) (CmdResult, error) {
+	//rubocop:disable Lint/ContextConnectivity
 	return ExecWithContextInDir(context.Background(), "", cmd, args, env)
 }
 

--- a/e2e/proxy_test.go
+++ b/e2e/proxy_test.go
@@ -24,7 +24,7 @@ func startRecordingAIProxy(t *testing.T) (*httptest.Server, *config.RuntimeConfi
 		require.NoError(t, err)
 	})
 
-	proxyURL, cleanup, err := fake.StartProxyWithOptions(
+	proxyURL, cleanup, err := fake.StartProxyWithOptions(t.Context(),
 		cassettePath,
 		recorder.ModeRecordOnce,
 		matcher,

--- a/e2e/runtime_test.go
+++ b/e2e/runtime_test.go
@@ -25,7 +25,7 @@ func TestRuntime_OpenAI_Basic(t *testing.T) {
 	team, err := teamloader.Load(ctx, agentSource, runConfig, loaderdefaults.Opts()...)
 	require.NoError(t, err)
 
-	rt, err := runtime.New(team)
+	rt, err := runtime.New(t.Context(), team)
 	require.NoError(t, err)
 
 	sess := session.New(session.WithUserMessage("What's 2+2?"))
@@ -68,7 +68,7 @@ func TestRuntime_MultiAgent_SessionReload(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { store.Close() })
 
-	rt, err := runtime.New(team, runtime.WithSessionStore(store))
+	rt, err := runtime.New(t.Context(), team, runtime.WithSessionStore(store))
 	require.NoError(t, err)
 
 	// --- Turn 1: trigger a task transfer ---
@@ -111,7 +111,7 @@ func TestRuntime_Mistral_Basic(t *testing.T) {
 	team, err := teamloader.Load(ctx, agentSource, runConfig, append(loaderdefaults.Opts(), teamloader.WithModelOverrides([]string{"mistral/mistral-small"}))...)
 	require.NoError(t, err)
 
-	rt, err := runtime.New(team)
+	rt, err := runtime.New(t.Context(), team)
 	require.NoError(t, err)
 
 	sess := session.New(session.WithUserMessage("What's 2+2?"))

--- a/e2e/runtime_test.go
+++ b/e2e/runtime_test.go
@@ -64,7 +64,7 @@ func TestRuntime_MultiAgent_SessionReload(t *testing.T) {
 
 	// Use a SQLite store so we test real persistence and reload.
 	dbPath := filepath.Join(t.TempDir(), "session.db")
-	store, err := session.NewSQLiteSessionStore(dbPath)
+	store, err := session.NewSQLiteSessionStore(t.Context(), dbPath)
 	require.NoError(t, err)
 	t.Cleanup(func() { store.Close() })
 

--- a/e2e/tui/setup_test.go
+++ b/e2e/tui/setup_test.go
@@ -53,11 +53,11 @@ func newTUI(t *testing.T, agentFile string, width, height int, tuiOpts ...tui.Op
 	agent, err := team.AgentOrDefault("")
 	require.NoError(t, err)
 
-	store, err := session.NewSQLiteSessionStore(filepath.Join(t.TempDir(), "session.db"))
+	store, err := session.NewSQLiteSessionStore(ctx, filepath.Join(t.TempDir(), "session.db"))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = store.Close() })
 
-	rt, err := runtime.New(team,
+	rt, err := runtime.New(ctx, team,
 		runtime.WithSessionStore(store),
 		runtime.WithCurrentAgent(agent.Name()),
 		runtime.WithModelSwitcherConfig(&runtime.ModelSwitcherConfig{
@@ -73,7 +73,7 @@ func newTUI(t *testing.T, agentFile string, width, height int, tuiOpts ...tui.Op
 	t.Cleanup(func() { _ = rt.Close() })
 
 	var appOpts []app.Opt
-	if gen := rt.TitleGenerator(); gen != nil {
+	if gen := rt.TitleGenerator(ctx); gen != nil {
 		appOpts = append(appOpts, app.WithTitleGenerator(gen))
 	}
 	application := app.New(rt, session.New(), appOpts...)
@@ -109,6 +109,7 @@ func startReplayProxy(t *testing.T) *config.RuntimeConfig {
 	matcher := fake.DefaultMatcher(func(err error) { require.NoError(t, err) })
 
 	proxyURL, cleanup, err := fake.StartProxyWithOptions(
+		t.Context(),
 		cassettePath,
 		recorder.ModeReplayOnly,
 		matcher,

--- a/e2e/tui/setup_test.go
+++ b/e2e/tui/setup_test.go
@@ -76,7 +76,7 @@ func newTUI(t *testing.T, agentFile string, width, height int, tuiOpts ...tui.Op
 	if gen := rt.TitleGenerator(ctx); gen != nil {
 		appOpts = append(appOpts, app.WithTitleGenerator(gen))
 	}
-	application := app.New(rt, session.New(), appOpts...)
+	application := app.New(ctx, rt, session.New(), appOpts...)
 
 	wd, _ := os.Getwd()
 	model := tui.New(ctx, nil /* no spawner: single tab */, application, wd, func() {}, tuiOpts...)

--- a/examples/golibrary/builtintool/main.go
+++ b/examples/golibrary/builtintool/main.go
@@ -51,7 +51,7 @@ func run(ctx context.Context) error {
 			),
 		),
 	)
-	rt, err := runtime.New(agents)
+	rt, err := runtime.New(ctx, agents)
 	if err != nil {
 		return err
 	}

--- a/examples/golibrary/multi/main.go
+++ b/examples/golibrary/multi/main.go
@@ -51,7 +51,7 @@ func run(ctx context.Context) error {
 		agent.WithSubAgents(child),
 		agent.WithToolSets(transfertask.New()),
 	)
-	rt, err := runtime.New(team.New(team.WithAgents(root, child)))
+	rt, err := runtime.New(ctx, team.New(team.WithAgents(root, child)))
 	if err != nil {
 		return err
 	}

--- a/examples/golibrary/renderer/main.go
+++ b/examples/golibrary/renderer/main.go
@@ -163,7 +163,7 @@ func run(ctx context.Context) error {
 	t := team.New(team.WithAgents(assistant))
 	defer func() { _ = t.StopToolSets(ctx) }()
 
-	rt, err := runtime.New(t)
+	rt, err := runtime.New(ctx, t)
 	if err != nil {
 		return err
 	}

--- a/examples/golibrary/renderer/main.go
+++ b/examples/golibrary/renderer/main.go
@@ -176,7 +176,7 @@ func run(ctx context.Context) error {
 		session.WithTitle("Repository search demo"),
 		session.WithToolsApproved(true),
 	)
-	a := app.New(rt, sess, app.WithFirstMessage(firstMessage))
+	a := app.New(ctx, rt, sess, app.WithFirstMessage(firstMessage))
 
 	// The one line that matters: a custom renderer for the MCP tool.
 	wd, _ := os.Getwd()

--- a/examples/golibrary/simple/main.go
+++ b/examples/golibrary/simple/main.go
@@ -47,7 +47,7 @@ func run(ctx context.Context) error {
 
 	humanTeam := team.New(team.WithAgents(human))
 
-	rt, err := runtime.New(humanTeam)
+	rt, err := runtime.New(ctx, humanTeam)
 	if err != nil {
 		return err
 	}

--- a/examples/golibrary/stream/main.go
+++ b/examples/golibrary/stream/main.go
@@ -46,7 +46,7 @@ func run(ctx context.Context) error {
 
 	humanTeam := team.New(team.WithAgents(human))
 
-	rt, err := runtime.New(humanTeam)
+	rt, err := runtime.New(ctx, humanTeam)
 	if err != nil {
 		return err
 	}

--- a/examples/golibrary/tool/main.go
+++ b/examples/golibrary/tool/main.go
@@ -74,7 +74,7 @@ func run(ctx context.Context) error {
 
 	calculatorTeam := team.New(team.WithAgents(calculator))
 
-	rt, err := runtime.New(calculatorTeam)
+	rt, err := runtime.New(ctx, calculatorTeam)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -142,7 +142,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/dgageot/rubocop-go v0.0.0-20260625173251-68f54fee9a17
+	github.com/dgageot/rubocop-go v0.0.0-20260626082406-7d0e8755b2c8
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.9.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/danieljoos/wincred v1.2.2/go.mod h1:w7w4Utbrz8lqeMbDAK0lkNJUv5sAOkFi7
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgageot/rubocop-go v0.0.0-20260625173251-68f54fee9a17 h1:rbJ6KuFV5f0nDEMaKSIMgM45eGeNctTkZbbW7hDESeE=
-github.com/dgageot/rubocop-go v0.0.0-20260625173251-68f54fee9a17/go.mod h1:wn4xlnesVpaaCT+xUYHAPW/rPxWd2jZIcUVqFkGUa0U=
+github.com/dgageot/rubocop-go v0.0.0-20260626082406-7d0e8755b2c8 h1:56UtyQJr8uF5xyCJ5qB/boy8rSc70wCAuzOZYuTv2Dc=
+github.com/dgageot/rubocop-go v0.0.0-20260626082406-7d0e8755b2c8/go.mod h1:wn4xlnesVpaaCT+xUYHAPW/rPxWd2jZIcUVqFkGUa0U=
 github.com/dgageot/ultraviolet v0.0.0-20260313154905-9451997d56b6 h1:88fWkkjwzuI4tRTqadbJIbA9O+gO67oyu+2OpHHuuT8=
 github.com/dgageot/ultraviolet v0.0.0-20260313154905-9451997d56b6/go.mod h1:SQpCTRNBtzJkwku5ye4S3HEuthAlGy2n9VXZnWkEW98=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=

--- a/lint/main.go
+++ b/lint/main.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/dgageot/rubocop-go/config"
 	"github.com/dgageot/rubocop-go/cop"
+	rubocops "github.com/dgageot/rubocop-go/cops"
+	"github.com/dgageot/rubocop-go/prog"
 	"github.com/dgageot/rubocop-go/runner"
 )
 
@@ -34,13 +36,20 @@ var cops = []cop.Cop{
 	ConstructorNetworkIO,
 }
 
+// programCops lists whole-program, inter-procedural cops. These run once over
+// the entire loaded program rather than once per file.
+var programCops = []prog.Cop{
+	rubocops.NewLintContextConnectivity(),
+}
+
 func main() {
 	paths := os.Args[1:]
 	if len(paths) == 0 {
 		paths = []string{"."}
 	}
 
-	r := runner.New(cops, config.DefaultConfig(), os.Stdout)
+	r := runner.New(cops, config.DefaultConfig(), os.Stdout).
+		WithProgramCops(programCops)
 	offenseCount, err := r.Run(paths)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)

--- a/pkg/a2a/adapter.go
+++ b/pkg/a2a/adapter.go
@@ -93,7 +93,7 @@ func runDockerAgent(ctx agent.InvocationContext, t *team.Team, agentName string,
 		}
 
 		// Create runtime
-		rt, err := runtime.New(t,
+		rt, err := runtime.New(ctx, t,
 			runtime.WithCurrentAgent(agentName),
 			runtime.WithSessionStore(sessStore),
 			// Match the tracer scope used by `cmd/root/run.go` so

--- a/pkg/a2a/server.go
+++ b/pkg/a2a/server.go
@@ -62,7 +62,7 @@ func Run(ctx context.Context, agentFilename, agentName, sessionDB string, runCon
 	if err != nil {
 		return fmt.Errorf("failed to expand session db path: %w", err)
 	}
-	sessStore, err := session.NewSQLiteSessionStore(expandedSessionDB)
+	sessStore, err := session.NewSQLiteSessionStore(ctx, expandedSessionDB)
 	if err != nil {
 		return fmt.Errorf("failed to open session store: %w", err)
 	}

--- a/pkg/acp/agent.go
+++ b/pkg/acp/agent.go
@@ -126,7 +126,7 @@ func (a *Agent) Initialize(ctx context.Context, params acp.InitializeRequest) (a
 }
 
 // newRuntime creates a new runtime using the default agent.
-func (a *Agent) newRuntime(workingDir string) (runtime.Runtime, *agent.Agent, error) {
+func (a *Agent) newRuntime(ctx context.Context, workingDir string) (runtime.Runtime, *agent.Agent, error) {
 	if a.team == nil {
 		return nil, nil, errors.New("agent not initialized")
 	}
@@ -148,7 +148,7 @@ func (a *Agent) newRuntime(workingDir string) (runtime.Runtime, *agent.Agent, er
 		opts = append(opts, runtime.WithWorkingDir(workingDir))
 	}
 
-	rt, err := runtime.New(a.team, opts...)
+	rt, err := runtime.New(ctx, a.team, opts...)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -202,7 +202,7 @@ func (a *Agent) NewSession(ctx context.Context, params acp.NewSessionRequest) (a
 		return acp.NewSessionResponse{}, err
 	}
 
-	rt, defaultAgent, err := a.newRuntime(workingDir)
+	rt, defaultAgent, err := a.newRuntime(ctx, workingDir)
 	if err != nil {
 		return acp.NewSessionResponse{}, err
 	}
@@ -332,7 +332,7 @@ func (a *Agent) ResumeSession(ctx context.Context, params acp.ResumeSessionReque
 		return acp.ResumeSessionResponse{}, err
 	}
 
-	rt, _, err := a.newRuntime(sess.WorkingDir)
+	rt, _, err := a.newRuntime(ctx, sess.WorkingDir)
 	if err != nil {
 		return acp.ResumeSessionResponse{}, err
 	}

--- a/pkg/acp/agent_test.go
+++ b/pkg/acp/agent_test.go
@@ -131,7 +131,7 @@ func TestACPSessionPersistence(t *testing.T) {
 
 	// Create a temp SQLite session DB
 	dbPath := filepath.Join(t.TempDir(), "session.db")
-	sessStore, err := session.NewSQLiteSessionStore(dbPath)
+	sessStore, err := session.NewSQLiteSessionStore(t.Context(), dbPath)
 	require.NoError(t, err)
 
 	// Close the store at the end

--- a/pkg/acp/run.go
+++ b/pkg/acp/run.go
@@ -21,7 +21,7 @@ func Run(ctx context.Context, agentFilename string, stdin io.Reader, stdout io.W
 	}
 
 	// Create SQLite session store for persistent sessions
-	sessStore, err := session.NewSQLiteSessionStore(sessionDB)
+	sessStore, err := session.NewSQLiteSessionStore(ctx, sessionDB)
 	if err != nil {
 		return fmt.Errorf("creating session store: %w", err)
 	}

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -646,7 +646,7 @@ func (a *App) processInlineAttachment(att messages.Attachment, textBuilder *stri
 func (a *App) Retry(ctx context.Context, cancel context.CancelFunc) {
 	a.cancel = cancel
 
-	go func() { //nolint:gosec // background processing intentionally continues after request ctx ends; uses context.Background() only to forward StreamStoppedEvent
+	go func() {
 		streamStarted := false
 		for event := range a.runtime.RunStream(ctx, a.session) {
 			// If context is cancelled, continue draining but don't forward events
@@ -654,7 +654,7 @@ func (a *App) Retry(ctx context.Context, cancel context.CancelFunc) {
 			// supervisor can mark the session as no longer running.
 			if ctx.Err() != nil {
 				if _, ok := event.(*runtime.StreamStoppedEvent); ok {
-					a.sendEvent(context.Background(), event)
+					a.sendEvent(context.WithoutCancel(ctx), event)
 				}
 				continue
 			}

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -227,19 +227,19 @@ func (a *App) CurrentAgentTools(ctx context.Context) ([]tools.Tool, error) {
 // Only the local runtime (which holds the team) implements it; remote runtimes
 // don't, so the agent-details config sections are simply omitted for them.
 type agentConfigProvider interface {
-	AgentConfigInfo(agentName string) runtime.AgentConfigInfo
+	AgentConfigInfo(ctx context.Context, agentName string) runtime.AgentConfigInfo
 }
 
 // AgentConfigInfo returns the named agent's static configuration for the
 // read-only agent-details dialog, or the zero value when it can't be resolved
 // (remote runtime or unknown agent). It reads resolved config only and starts
 // no toolsets.
-func (a *App) AgentConfigInfo(agentName string) runtime.AgentConfigInfo {
+func (a *App) AgentConfigInfo(ctx context.Context, agentName string) runtime.AgentConfigInfo {
 	cp, ok := a.runtime.(agentConfigProvider)
 	if !ok {
 		return runtime.AgentConfigInfo{}
 	}
-	return cp.AgentConfigInfo(agentName)
+	return cp.AgentConfigInfo(ctx, agentName)
 }
 
 // CurrentAgentToolsetStatuses returns lifecycle status for each toolset of

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -120,7 +120,7 @@ func WithSnapshotController(c builtins.SnapshotController) Opt {
 	}
 }
 
-func New(rt runtime.Runtime, sess *session.Session, opts ...Opt) *App {
+func New(ctx context.Context, rt runtime.Runtime, sess *session.Session, opts ...Opt) *App {
 	app := &App{
 		ctx:              func() context.Context { return context.WithoutCancel(ctx) },
 		runtime:          rt,

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -175,6 +175,7 @@ func (a *App) SendFirstMessage() tea.Cmd {
 	cmds := []tea.Cmd{
 		func() tea.Msg {
 			// Use the shared PrepareUserMessage function for consistent attachment handling
+			//rubocop:disable Lint/ContextConnectivity
 			userMsg, attachedPath, err := cli.PrepareUserMessage(context.Background(), a.runtime, *a.firstMessage, a.firstMessageAttach)
 			if err != nil {
 				slog.Error("Failed to prepare first message", "error", err)
@@ -370,6 +371,7 @@ func (a *App) RunSkillFork(ctx context.Context, cancel context.CancelFunc, skill
 		for event := range events {
 			if ctx.Err() != nil {
 				if _, ok := event.(*runtime.StreamStoppedEvent); ok {
+					//rubocop:disable Lint/ContextConnectivity
 					a.sendEvent(context.Background(), event)
 				}
 				continue
@@ -502,6 +504,7 @@ func (a *App) Run(ctx context.Context, cancel context.CancelFunc, message string
 			// supervisor can mark the session as no longer running.
 			if ctx.Err() != nil {
 				if _, ok := event.(*runtime.StreamStoppedEvent); ok {
+					//rubocop:disable Lint/ContextConnectivity
 					a.sendEvent(context.Background(), event)
 				}
 				continue
@@ -699,6 +702,7 @@ func (a *App) RunWithMessage(ctx context.Context, cancel context.CancelFunc, msg
 			// supervisor can mark the session as no longer running.
 			if ctx.Err() != nil {
 				if _, ok := event.(*runtime.StreamStoppedEvent); ok {
+					//rubocop:disable Lint/ContextConnectivity
 					a.sendEvent(context.Background(), event)
 				}
 				continue
@@ -786,6 +790,7 @@ func (a *App) removeSubscriber(ch chan tea.Msg) {
 // non-blocking; if a subscriber's buffer is full the event is dropped for
 // that subscriber so one slow consumer cannot stall the others.
 func (a *App) startFanOut() {
+	//rubocop:disable Lint/ContextConnectivity
 	throttled := a.throttleEvents(context.Background(), a.events)
 	go func() {
 		for msg := range throttled {
@@ -805,6 +810,7 @@ func (a *App) startFanOut() {
 
 // Resume resumes the runtime with the given confirmation request
 func (a *App) Resume(req runtime.ResumeRequest) {
+	//rubocop:disable Lint/ContextConnectivity
 	a.runtime.Resume(context.Background(), req)
 }
 
@@ -813,6 +819,7 @@ func (a *App) Resume(req runtime.ResumeRequest) {
 // doesn't support pausing (e.g. remote runtimes), in which case the first
 // return value is meaningless.
 func (a *App) TogglePause() (paused, supported bool) {
+	//rubocop:disable Lint/ContextConnectivity
 	p, err := a.runtime.TogglePause(context.Background())
 	if errors.Is(err, runtime.ErrUnsupported) {
 		return false, false
@@ -850,6 +857,7 @@ func (a *App) NewSession() {
 	a.firstMessageAttach = ""
 
 	// Re-emit startup info so the sidebar shows agent/tools info in the new session
+	//rubocop:disable Lint/ContextConnectivity
 	a.reEmitStartupInfo(context.Background())
 }
 

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -400,13 +400,13 @@ func (a *App) ResolveInput(ctx context.Context, input string) string {
 // CurrentAgentModel returns the model ID for the current agent.
 // Returns the tracked model from AgentInfoEvent, or falls back to session overrides.
 // Returns empty string if no model information is available (fail-open scenario).
-func (a *App) CurrentAgentModel() string {
+func (a *App) CurrentAgentModel(ctx context.Context) string {
 	if a.currentAgentModel != "" {
 		return a.currentAgentModel
 	}
 	// Fallback to session overrides
 	if a.session != nil && a.session.AgentModelOverrides != nil {
-		agentName := a.runtime.CurrentAgentName()
+		agentName := a.runtime.CurrentAgentName(ctx)
 		if modelRef, ok := a.session.AgentModelOverrides[agentName]; ok {
 			return modelRef
 		}
@@ -941,7 +941,10 @@ func (a *App) HasPermissions() bool {
 
 // SwitchAgent switches the currently active agent for subsequent user messages
 func (a *App) SwitchAgent(agentName string) error {
-	return a.runtime.SetCurrentAgent(agentName)
+	// Called from the Bubble Tea event loop, which has no context; this is
+	// a TUI-root boundary.
+	//rubocop:disable Lint/ContextConnectivity
+	return a.runtime.SetCurrentAgent(context.Background(), agentName)
 }
 
 // SetCurrentAgentModel sets the model for the current agent and persists
@@ -949,7 +952,7 @@ func (a *App) SwitchAgent(agentName string) error {
 // supported by the runtime (e.g., remote runtimes).
 // Pass an empty modelRef to clear the override and use the agent's default model.
 func (a *App) SetCurrentAgentModel(ctx context.Context, modelRef string) error {
-	agentName := a.runtime.CurrentAgentName()
+	agentName := a.runtime.CurrentAgentName(ctx)
 
 	// Set the model override on the runtime (empty modelRef clears the override)
 	if err := a.runtime.SetAgentModel(ctx, agentName, modelRef); err != nil {
@@ -998,7 +1001,7 @@ func (a *App) SetCurrentAgentModel(ctx context.Context, modelRef string) error {
 // as a model override). Returns an error wrapping [runtime.ErrUnsupported]
 // when the runtime or model cannot cycle thinking levels.
 func (a *App) CycleAgentThinkingLevel(ctx context.Context) (effort.Level, error) {
-	agentName := a.runtime.CurrentAgentName()
+	agentName := a.runtime.CurrentAgentName(ctx)
 	level, err := a.runtime.CycleAgentThinkingLevel(ctx, agentName)
 	if err != nil {
 		return "", err
@@ -1027,7 +1030,7 @@ func (a *App) AvailableModels(ctx context.Context) []runtime.ModelChoice {
 		return nil
 	}
 
-	agentName := a.runtime.CurrentAgentName()
+	agentName := a.runtime.CurrentAgentName(ctx)
 	currentRef := ""
 	var customRefs []string
 	if a.session != nil {
@@ -1096,7 +1099,7 @@ func (a *App) CompactSession(ctx context.Context, cancel context.CancelFunc, add
 	go func() {
 		defer cancel()
 
-		agentName := a.runtime.CurrentAgentName()
+		agentName := a.runtime.CurrentAgentName(ctx)
 		completed := false
 		events := make(chan runtime.Event, 100)
 		go func() {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -35,6 +35,8 @@ import (
 )
 
 type App struct {
+	ctx func() context.Context
+
 	runtime                runtime.Runtime
 	session                *session.Session
 	firstMessage           *string
@@ -120,6 +122,7 @@ func WithSnapshotController(c builtins.SnapshotController) Opt {
 
 func New(rt runtime.Runtime, sess *session.Session, opts ...Opt) *App {
 	app := &App{
+		ctx:              func() context.Context { return context.WithoutCancel(ctx) },
 		runtime:          rt,
 		session:          sess,
 		events:           make(chan tea.Msg, 128),
@@ -175,8 +178,7 @@ func (a *App) SendFirstMessage() tea.Cmd {
 	cmds := []tea.Cmd{
 		func() tea.Msg {
 			// Use the shared PrepareUserMessage function for consistent attachment handling
-			//rubocop:disable Lint/ContextConnectivity
-			userMsg, attachedPath, err := cli.PrepareUserMessage(context.Background(), a.runtime, *a.firstMessage, a.firstMessageAttach)
+			userMsg, attachedPath, err := cli.PrepareUserMessage(a.ctx(), a.runtime, *a.firstMessage, a.firstMessageAttach)
 			if err != nil {
 				slog.Error("Failed to prepare first message", "error", err)
 				return nil
@@ -793,8 +795,7 @@ func (a *App) removeSubscriber(ch chan tea.Msg) {
 // non-blocking; if a subscriber's buffer is full the event is dropped for
 // that subscriber so one slow consumer cannot stall the others.
 func (a *App) startFanOut() {
-	//rubocop:disable Lint/ContextConnectivity
-	throttled := a.throttleEvents(context.Background(), a.events)
+	throttled := a.throttleEvents(a.ctx(), a.events)
 	go func() {
 		for msg := range throttled {
 			a.subsMu.Lock()
@@ -813,8 +814,7 @@ func (a *App) startFanOut() {
 
 // Resume resumes the runtime with the given confirmation request
 func (a *App) Resume(req runtime.ResumeRequest) {
-	//rubocop:disable Lint/ContextConnectivity
-	a.runtime.Resume(context.Background(), req)
+	a.runtime.Resume(a.ctx(), req)
 }
 
 // TogglePause toggles whether the runtime loop is paused at iteration
@@ -822,8 +822,7 @@ func (a *App) Resume(req runtime.ResumeRequest) {
 // doesn't support pausing (e.g. remote runtimes), in which case the first
 // return value is meaningless.
 func (a *App) TogglePause() (paused, supported bool) {
-	//rubocop:disable Lint/ContextConnectivity
-	p, err := a.runtime.TogglePause(context.Background())
+	p, err := a.runtime.TogglePause(a.ctx())
 	if errors.Is(err, runtime.ErrUnsupported) {
 		return false, false
 	}
@@ -860,8 +859,7 @@ func (a *App) NewSession() {
 	a.firstMessageAttach = ""
 
 	// Re-emit startup info so the sidebar shows agent/tools info in the new session
-	//rubocop:disable Lint/ContextConnectivity
-	a.reEmitStartupInfo(context.Background())
+	a.reEmitStartupInfo(a.ctx())
 }
 
 // reEmitStartupInfo resets and re-emits startup info (agent, team, tools)
@@ -946,8 +944,7 @@ func (a *App) HasPermissions() bool {
 func (a *App) SwitchAgent(agentName string) error {
 	// Called from the Bubble Tea event loop, which has no context; this is
 	// a TUI-root boundary.
-	//rubocop:disable Lint/ContextConnectivity
-	return a.runtime.SetCurrentAgent(context.Background(), agentName)
+	return a.runtime.SetCurrentAgent(a.ctx(), agentName)
 }
 
 // SetCurrentAgentModel sets the model for the current agent and persists

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -348,7 +348,7 @@ func (a *App) RunSkillFork(ctx context.Context, cancel context.CancelFunc, skill
 	// Mirrors App.Run's drain loop: forward events to the App bus and
 	// always let StreamStoppedEvent through, even after ctx cancellation,
 	// so the supervisor marks the session idle.
-	go func() { //nolint:gosec // background processing intentionally continues after request ctx ends; uses context.Background() only to forward StreamStoppedEvent
+	go func() {
 		events := make(chan runtime.Event, defaultRuntimeEventBuffer)
 		go func() {
 			defer close(events)
@@ -371,8 +371,9 @@ func (a *App) RunSkillFork(ctx context.Context, cancel context.CancelFunc, skill
 		for event := range events {
 			if ctx.Err() != nil {
 				if _, ok := event.(*runtime.StreamStoppedEvent); ok {
-					//rubocop:disable Lint/ContextConnectivity
-					a.sendEvent(context.Background(), event)
+					// ctx is cancelled; detach cancellation but keep its trace
+					// context so the stop event still reaches subscribers.
+					a.sendEvent(context.WithoutCancel(ctx), event)
 				}
 				continue
 			}
@@ -459,7 +460,7 @@ func (a *App) Run(ctx context.Context, cancel context.CancelFunc, message string
 		go a.generateTitle(ctx, []string{message})
 	}
 
-	go func() { //nolint:gosec // background processing intentionally continues after request ctx ends; uses context.Background() only to forward StreamStoppedEvent
+	go func() {
 		if len(attachments) > 0 {
 			// Build a single text string with the user's message and inlined text files.
 			// Keeping everything in one text block ensures the model sees file content
@@ -504,8 +505,9 @@ func (a *App) Run(ctx context.Context, cancel context.CancelFunc, message string
 			// supervisor can mark the session as no longer running.
 			if ctx.Err() != nil {
 				if _, ok := event.(*runtime.StreamStoppedEvent); ok {
-					//rubocop:disable Lint/ContextConnectivity
-					a.sendEvent(context.Background(), event)
+					// ctx is cancelled; detach cancellation but keep its trace
+					// context so the stop event still reaches subscribers.
+					a.sendEvent(context.WithoutCancel(ctx), event)
 				}
 				continue
 			}
@@ -694,7 +696,7 @@ func (a *App) RunWithMessage(ctx context.Context, cancel context.CancelFunc, msg
 		go a.generateTitle(ctx, []string{userMessage})
 	}
 
-	go func() { //nolint:gosec // background processing intentionally continues after request ctx ends; uses context.Background() only to forward StreamStoppedEvent
+	go func() {
 		a.session.AddMessage(msg)
 		for event := range a.runtime.RunStream(ctx, a.session) {
 			// If context is cancelled, continue draining but don't forward events
@@ -702,8 +704,9 @@ func (a *App) RunWithMessage(ctx context.Context, cancel context.CancelFunc, msg
 			// supervisor can mark the session as no longer running.
 			if ctx.Err() != nil {
 				if _, ok := event.(*runtime.StreamStoppedEvent); ok {
-					//rubocop:disable Lint/ContextConnectivity
-					a.sendEvent(context.Background(), event)
+					// ctx is cancelled; detach cancellation but keep its trace
+					// context so the stop event still reaches subscribers.
+					a.sendEvent(context.WithoutCancel(ctx), event)
 				}
 				continue
 			}

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -233,6 +233,7 @@ func TestApp_NewSession_WithNilSession(t *testing.T) {
 
 	// Create app with nil session (edge case)
 	app := &App{
+		ctx:     t.Context,
 		runtime: rt,
 		session: nil,
 	}
@@ -383,6 +384,7 @@ func TestApp_SnapshotsEnabled_DoesNotRequireSession(t *testing.T) {
 	// SnapshotsEnabled answers a controller-capability question; it
 	// must not silently return false just because no session is attached.
 	app := &App{
+		ctx:                t.Context,
 		runtime:            &mockRuntime{},
 		session:            nil,
 		snapshotController: &stubSnapshotController{enabled: true},
@@ -498,6 +500,7 @@ func TestApp_InjectUserMessage(t *testing.T) {
 
 	events := make(chan tea.Msg, 4)
 	app := &App{
+		ctx:     t.Context,
 		runtime: &mockRuntime{},
 		session: session.New(),
 		events:  events,

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -201,7 +201,7 @@ func TestApp_NewSession_PreservesToolsApproved(t *testing.T) {
 	initialSess := session.New(session.WithToolsApproved(true))
 	require.True(t, initialSess.ToolsApproved, "Initial session should have tools approved")
 
-	app := New(rt, initialSess)
+	app := New(t.Context(), rt, initialSess)
 
 	// Call NewSession - should preserve ToolsApproved
 	app.NewSession()
@@ -218,7 +218,7 @@ func TestApp_NewSession_PreservesHideToolResults(t *testing.T) {
 	initialSess := session.New(session.WithHideToolResults(true))
 	require.True(t, initialSess.HideToolResults, "Initial session should have HideToolResults")
 
-	app := New(rt, initialSess)
+	app := New(t.Context(), rt, initialSess)
 
 	// Call NewSession - should preserve HideToolResults
 	app.NewSession()
@@ -321,7 +321,7 @@ func TestApp_ResolveSkillCommand_NoLocalRuntime(t *testing.T) {
 	ctx := t.Context()
 	rt := &mockRuntime{}
 	sess := session.New()
-	app := New(rt, sess)
+	app := New(t.Context(), rt, sess)
 
 	// mockRuntime is not a LocalRuntime, so no skills should be returned
 	resolved, err := app.ResolveSkillCommand(ctx, "/some-skill")
@@ -335,7 +335,7 @@ func TestApp_ResolveSkillCommand_NotSlashCommand(t *testing.T) {
 	ctx := t.Context()
 	rt := &mockRuntime{}
 	sess := session.New()
-	app := New(rt, sess)
+	app := New(t.Context(), rt, sess)
 
 	resolved, err := app.ResolveSkillCommand(ctx, "not a slash command")
 	require.NoError(t, err)
@@ -346,7 +346,7 @@ func TestApp_UndoLastSnapshot(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
-	app := New(&mockRuntime{}, session.New(),
+	app := New(t.Context(), &mockRuntime{}, session.New(),
 		WithSnapshotController(&stubSnapshotController{enabled: true, files: 2, ok: true}),
 	)
 	result, err := app.UndoLastSnapshot(ctx)
@@ -358,7 +358,7 @@ func TestApp_UndoLastSnapshot_NoSnapshot(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
-	app := New(&mockRuntime{}, session.New(),
+	app := New(t.Context(), &mockRuntime{}, session.New(),
 		WithSnapshotController(&stubSnapshotController{enabled: true}),
 	)
 	_, err := app.UndoLastSnapshot(ctx)
@@ -372,7 +372,7 @@ func TestApp_UndoLastSnapshot_NoController(t *testing.T) {
 	// so the same UI affordance can light up regardless of which
 	// runtime the embedder paired the App with.
 	ctx := t.Context()
-	app := New(&mockRuntime{}, session.New())
+	app := New(t.Context(), &mockRuntime{}, session.New())
 	_, err := app.UndoLastSnapshot(ctx)
 	require.ErrorIs(t, err, ErrNothingToUndo)
 	assert.False(t, app.SnapshotsEnabled())
@@ -399,7 +399,7 @@ func TestApp_SubscribeWith_FanOutToMultipleSubscribers(t *testing.T) {
 	defer cancel()
 
 	rt := &mockRuntime{}
-	app := New(rt, session.New())
+	app := New(t.Context(), rt, session.New())
 
 	recv := func() (chan tea.Msg, context.CancelFunc) {
 		subCtx, subCancel := context.WithCancel(ctx)

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -83,7 +83,7 @@ func (m *mockRuntime) UpdateSessionTitle(_ context.Context, sess *session.Sessio
 	sess.Title = title
 	return nil
 }
-func (m *mockRuntime) TitleGenerator() *sessiontitle.Generator                   { return nil }
+func (m *mockRuntime) TitleGenerator(context.Context) *sessiontitle.Generator    { return nil }
 func (m *mockRuntime) Close() error                                              { return nil }
 func (m *mockRuntime) Stop()                                                     {}
 func (m *mockRuntime) Steer(_ context.Context, _ runtime.QueuedMessage) error    { return nil }

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -33,8 +33,8 @@ type mockRuntime struct {
 func (m *mockRuntime) CurrentAgentInfo(ctx context.Context) runtime.CurrentAgentInfo {
 	return runtime.CurrentAgentInfo{}
 }
-func (m *mockRuntime) CurrentAgentName() string          { return "mock" }
-func (m *mockRuntime) SetCurrentAgent(name string) error { return nil }
+func (m *mockRuntime) CurrentAgentName(context.Context) string              { return "mock" }
+func (m *mockRuntime) SetCurrentAgent(_ context.Context, name string) error { return nil }
 func (m *mockRuntime) CurrentAgentTools(ctx context.Context) ([]tools.Tool, error) {
 	return nil, nil
 }
@@ -83,13 +83,13 @@ func (m *mockRuntime) UpdateSessionTitle(_ context.Context, sess *session.Sessio
 	sess.Title = title
 	return nil
 }
-func (m *mockRuntime) TitleGenerator() *sessiontitle.Generator   { return nil }
-func (m *mockRuntime) Close() error                              { return nil }
-func (m *mockRuntime) Stop()                                     {}
-func (m *mockRuntime) Steer(_ runtime.QueuedMessage) error       { return nil }
-func (m *mockRuntime) FollowUp(_ runtime.QueuedMessage) error    { return nil }
-func (m *mockRuntime) QueueStatus() runtime.QueueStatus          { return runtime.QueueStatus{} }
-func (m *mockRuntime) TogglePause(context.Context) (bool, error) { return false, nil }
+func (m *mockRuntime) TitleGenerator() *sessiontitle.Generator                   { return nil }
+func (m *mockRuntime) Close() error                                              { return nil }
+func (m *mockRuntime) Stop()                                                     {}
+func (m *mockRuntime) Steer(_ context.Context, _ runtime.QueuedMessage) error    { return nil }
+func (m *mockRuntime) FollowUp(_ context.Context, _ runtime.QueuedMessage) error { return nil }
+func (m *mockRuntime) QueueStatus() runtime.QueueStatus                          { return runtime.QueueStatus{} }
+func (m *mockRuntime) TogglePause(context.Context) (bool, error)                 { return false, nil }
 func (m *mockRuntime) SetAgentModel(context.Context, string, string) error {
 	return nil
 }

--- a/pkg/app/app_working_dir_test.go
+++ b/pkg/app/app_working_dir_test.go
@@ -17,7 +17,7 @@ func TestApp_NewSession_PreservesWorkingDir(t *testing.T) {
 	initialSess := session.New(
 		session.WithWorkingDir("/projects/myapp"),
 	)
-	app := New(rt, initialSess)
+	app := New(t.Context(), rt, initialSess)
 	require.Equal(t, "/projects/myapp", app.Session().WorkingDir)
 
 	app.NewSession()
@@ -38,7 +38,7 @@ func TestApp_NewSession_PreservesAllSessionFlags(t *testing.T) {
 		session.WithHideToolResults(true),
 		session.WithWorkingDir("/work"),
 	)
-	app := New(rt, initialSess)
+	app := New(t.Context(), rt, initialSess)
 
 	app.NewSession()
 

--- a/pkg/app/skills_fork_test.go
+++ b/pkg/app/skills_fork_test.go
@@ -111,7 +111,7 @@ func TestApp_SlashSkill_ForkContext_DispatchesToRunSkillFork(t *testing.T) {
 	sess := session.New(session.WithUserMessage("hi there"))
 	require.Equal(t, 1, sess.MessageCount())
 
-	a := New(rt, sess)
+	a := New(t.Context(), rt, sess)
 
 	// Detection.
 	skillName, task, ok := a.SkillCommandFork(ctx, "/commit please commit")
@@ -166,7 +166,7 @@ func TestApp_SlashSkill_InlineContext_StillInlines(t *testing.T) {
 	}
 
 	ctx := t.Context()
-	a := New(rt, session.New())
+	a := New(t.Context(), rt, session.New())
 
 	_, _, ok := a.SkillCommandFork(ctx, "/review the diff")
 	assert.False(t, ok)
@@ -210,7 +210,7 @@ func TestApp_SlashSkill_NonFork_E2E(t *testing.T) {
 	sess := session.New(session.WithUserMessage("hi there"))
 	require.Equal(t, 1, sess.MessageCount())
 
-	a := New(rt, sess)
+	a := New(t.Context(), rt, sess)
 
 	// Same dispatch as chat.processMessage.
 	input := "/review carefully"

--- a/pkg/chatserver/runtime_pool.go
+++ b/pkg/chatserver/runtime_pool.go
@@ -1,6 +1,7 @@
 package chatserver
 
 import (
+	"context"
 	"errors"
 	"sync"
 
@@ -26,6 +27,7 @@ import (
 // runtime to a full pool is a no-op; it simply gets garbage collected.
 type runtimePool struct {
 	team    *team.Team
+	ctx     func() context.Context
 	maxIdle int
 
 	mu   sync.Mutex
@@ -38,12 +40,13 @@ type runtimePool struct {
 // cancellation in a future async path).
 var errInvalidRuntime = errors.New("failed to acquire runtime")
 
-func newRuntimePool(t *team.Team, maxIdle int) *runtimePool {
+func newRuntimePool(ctx context.Context, t *team.Team, maxIdle int) *runtimePool {
 	if maxIdle < 0 {
 		maxIdle = 0
 	}
 	return &runtimePool{
 		team:    t,
+		ctx:     func() context.Context { return context.WithoutCancel(ctx) },
 		maxIdle: maxIdle,
 		idle:    make(map[string]chan runtime.Runtime),
 	}
@@ -61,7 +64,7 @@ func (p *runtimePool) Get(agent string) (runtime.Runtime, error) {
 	// Match the tracer scope used by the CLI; without this the
 	// pooled chatserver runtimes are tracer-less so all `runtime.*`
 	// spans go silent in OpenAI-compatible chat-completions mode.
-	rt, err := runtime.New(p.team,
+	rt, err := runtime.New(p.ctx(), p.team,
 		runtime.WithCurrentAgent(agent),
 		runtime.WithTracer(otel.Tracer("cagent")),
 	)

--- a/pkg/chatserver/runtime_pool_test.go
+++ b/pkg/chatserver/runtime_pool_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestRuntimePool_DisabledIsNotCached(t *testing.T) {
-	p := newRuntimePool(nil, 0)
+	p := newRuntimePool(t.Context(), nil, 0)
 
 	// Put with maxIdle=0 must be a no-op (we don't have a runtime to put,
 	// but the channel-for behaviour itself shouldn't allocate).
@@ -16,11 +16,11 @@ func TestRuntimePool_DisabledIsNotCached(t *testing.T) {
 }
 
 func TestRuntimePool_NegativeCapTreatedAsZero(t *testing.T) {
-	p := newRuntimePool(nil, -1)
+	p := newRuntimePool(t.Context(), nil, -1)
 	assert.Equal(t, 0, p.maxIdle)
 }
 
 func TestRuntimePool_takeIdleNoChannel(t *testing.T) {
-	p := newRuntimePool(nil, 4)
+	p := newRuntimePool(t.Context(), nil, 4)
 	assert.Nil(t, p.takeIdle("anything"))
 }

--- a/pkg/chatserver/server.go
+++ b/pkg/chatserver/server.go
@@ -139,7 +139,7 @@ func Run(ctx context.Context, agentFilename string, opts Options, ln net.Listene
 			policy:            policy,
 			conversations:     newConversationStore(opts.ConversationsMaxSessions, conversationTTL(opts)),
 			conversationLocks: newConversationLockSet(),
-			runtimes:          newRuntimePool(t, opts.MaxIdleRuntimes),
+			runtimes:          newRuntimePool(ctx, t, opts.MaxIdleRuntimes),
 		}, opts),
 		"chatserver",
 	)

--- a/pkg/chatserver/server.go
+++ b/pkg/chatserver/server.go
@@ -178,6 +178,7 @@ func serve(ctx context.Context, httpServer *http.Server, ln net.Listener) error 
 
 	select {
 	case <-ctx.Done():
+		//rubocop:disable Lint/ContextConnectivity
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		return httpServer.Shutdown(shutdownCtx)

--- a/pkg/chatserver/server.go
+++ b/pkg/chatserver/server.go
@@ -178,8 +178,9 @@ func serve(ctx context.Context, httpServer *http.Server, ln net.Listener) error 
 
 	select {
 	case <-ctx.Done():
-		//rubocop:disable Lint/ContextConnectivity
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		// ctx is done; detach from its cancellation but keep its trace
+		// context so the graceful shutdown can still run.
+		shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 		defer cancel()
 		return httpServer.Shutdown(shutdownCtx)
 	case err := <-errCh:

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -146,7 +146,7 @@ func Run(ctx context.Context, out *Printer, cfg Config, rt runtime.Runtime, sess
 		}
 
 		firstLoop := true
-		lastAgent := rt.CurrentAgentName()
+		lastAgent := rt.CurrentAgentName(ctx)
 		var lastConfirmedToolCallID string
 		for event := range rt.RunStream(ctx, sess) {
 			agentName := event.GetAgentName()
@@ -346,7 +346,7 @@ func PrepareUserMessage(ctx context.Context, rt runtime.Runtime, userInput, glob
 	// This must happen before the message is added to the session so the
 	// next runtime turn runs on the right agent.
 	if cmd, _, ok := runtime.LookupCommand(ctx, rt, userInput); ok && cmd.Agent != "" {
-		if err := rt.SetCurrentAgent(cmd.Agent); err != nil {
+		if err := rt.SetCurrentAgent(ctx, cmd.Agent); err != nil {
 			slog.WarnContext(ctx, "Failed to switch agent for /command", "agent", cmd.Agent, "error", err)
 			return nil, "", fmt.Errorf("switch agent %q: %w", cmd.Agent, err)
 		}

--- a/pkg/cli/runner_test.go
+++ b/pkg/cli/runner_test.go
@@ -90,7 +90,7 @@ func (m *mockRuntime) ExecuteMCPPrompt(context.Context, string, map[string]strin
 	return "", nil
 }
 func (m *mockRuntime) UpdateSessionTitle(context.Context, *session.Session, string) error { return nil }
-func (m *mockRuntime) TitleGenerator() *sessiontitle.Generator                            { return nil }
+func (m *mockRuntime) TitleGenerator(context.Context) *sessiontitle.Generator             { return nil }
 func (m *mockRuntime) Close() error                                                       { return nil }
 func (m *mockRuntime) Steer(context.Context, runtime.QueuedMessage) error                 { return nil }
 func (m *mockRuntime) FollowUp(context.Context, runtime.QueuedMessage) error              { return nil }

--- a/pkg/cli/runner_test.go
+++ b/pkg/cli/runner_test.go
@@ -38,11 +38,11 @@ type mockRuntimeWithOverrides struct {
 	currentAgentInfoFn func(context.Context) runtime.CurrentAgentInfo
 }
 
-func (m *mockRuntimeWithOverrides) SetCurrentAgent(name string) error {
+func (m *mockRuntimeWithOverrides) SetCurrentAgent(ctx context.Context, name string) error {
 	if m.setCurrentAgentFn != nil {
 		return m.setCurrentAgentFn(name)
 	}
-	return m.mockRuntime.SetCurrentAgent(name)
+	return m.mockRuntime.SetCurrentAgent(ctx, name)
 }
 
 func (m *mockRuntimeWithOverrides) CurrentAgentInfo(ctx context.Context) runtime.CurrentAgentInfo {
@@ -52,11 +52,11 @@ func (m *mockRuntimeWithOverrides) CurrentAgentInfo(ctx context.Context) runtime
 	return m.mockRuntime.CurrentAgentInfo(ctx)
 }
 
-func (m *mockRuntime) CurrentAgentName() string { return "test" }
+func (m *mockRuntime) CurrentAgentName(context.Context) string { return "test" }
 func (m *mockRuntime) CurrentAgentInfo(context.Context) runtime.CurrentAgentInfo {
 	return runtime.CurrentAgentInfo{Name: "test"}
 }
-func (m *mockRuntime) SetCurrentAgent(string) error                                         { return nil }
+func (m *mockRuntime) SetCurrentAgent(context.Context, string) error                        { return nil }
 func (m *mockRuntime) CurrentAgentTools(context.Context) ([]tools.Tool, error)              { return nil, nil }
 func (m *mockRuntime) CurrentAgentToolsetStatuses() []tools.ToolsetStatus                   { return nil }
 func (m *mockRuntime) RestartToolset(context.Context, string) error                         { return nil }
@@ -92,8 +92,8 @@ func (m *mockRuntime) ExecuteMCPPrompt(context.Context, string, map[string]strin
 func (m *mockRuntime) UpdateSessionTitle(context.Context, *session.Session, string) error { return nil }
 func (m *mockRuntime) TitleGenerator() *sessiontitle.Generator                            { return nil }
 func (m *mockRuntime) Close() error                                                       { return nil }
-func (m *mockRuntime) Steer(runtime.QueuedMessage) error                                  { return nil }
-func (m *mockRuntime) FollowUp(runtime.QueuedMessage) error                               { return nil }
+func (m *mockRuntime) Steer(context.Context, runtime.QueuedMessage) error                 { return nil }
+func (m *mockRuntime) FollowUp(context.Context, runtime.QueuedMessage) error              { return nil }
 func (m *mockRuntime) QueueStatus() runtime.QueueStatus                                   { return runtime.QueueStatus{} }
 func (m *mockRuntime) TogglePause(context.Context) (bool, error)                          { return false, nil }
 func (m *mockRuntime) SetAgentModel(context.Context, string, string) error                { return nil }

--- a/pkg/embeddedchat/embeddedchat.go
+++ b/pkg/embeddedchat/embeddedchat.go
@@ -138,7 +138,7 @@ func New(ctx context.Context, cfg Config) (*Session, error) {
 		dagentruntime.WithSessionStore(session.NewInMemorySessionStore()),
 	}
 	runtimeOpts = append(runtimeOpts, cfg.RuntimeOptions...)
-	rt, err := dagentruntime.New(loaded.Team, runtimeOpts...)
+	rt, err := dagentruntime.New(ctx, loaded.Team, runtimeOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("embeddedchat: create runtime: %w", err)
 	}

--- a/pkg/evaluation/save.go
+++ b/pkg/evaluation/save.go
@@ -27,7 +27,7 @@ func SaveRunSessions(ctx context.Context, run *EvalRun, outputDir string) (strin
 	}
 
 	// Create a new SQLite session store for this eval run
-	store, err := session.NewSQLiteSessionStore(dbPath)
+	store, err := session.NewSQLiteSessionStore(ctx, dbPath)
 	if err != nil {
 		return "", fmt.Errorf("creating session store: %w", err)
 	}

--- a/pkg/evaluation/save_test.go
+++ b/pkg/evaluation/save_test.go
@@ -96,7 +96,7 @@ func TestSaveRunSessions(t *testing.T) {
 	assert.FileExists(t, dbPath)
 
 	// Verify we can read sessions back from the database
-	store, err := session.NewSQLiteSessionStore(dbPath)
+	store, err := session.NewSQLiteSessionStore(t.Context(), dbPath)
 	require.NoError(t, err)
 	defer func() {
 		if closer, ok := store.(interface{ Close() error }); ok {
@@ -323,7 +323,7 @@ func TestSaveRunSessionsWithCost(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify we can read sessions back with cost preserved
-	store, err := session.NewSQLiteSessionStore(dbPath)
+	store, err := session.NewSQLiteSessionStore(t.Context(), dbPath)
 	require.NoError(t, err)
 	defer func() {
 		if closer, ok := store.(interface{ Close() error }); ok {

--- a/pkg/fake/proxy.go
+++ b/pkg/fake/proxy.go
@@ -100,6 +100,7 @@ func StartStreamingRecordingProxy(
 			stopDone <- streamRec.Stop()
 		}()
 
+		//rubocop:disable Lint/ContextConnectivity
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 		defer cancel()
 
@@ -185,6 +186,7 @@ func StartProxyWithOptions(
 			stopDone <- transport.Stop()
 		}()
 
+		//rubocop:disable Lint/ContextConnectivity
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 		defer cancel()
 

--- a/pkg/fake/proxy.go
+++ b/pkg/fake/proxy.go
@@ -51,14 +51,14 @@ func WithStreamChunkDelay(d time.Duration) ProxyOption {
 
 // StartProxy starts an internal HTTP proxy that replays cassette responses.
 // It returns the proxy URL and a cleanup function that should be called when done.
-func StartProxy(cassettePath string, opts ...ProxyOption) (string, func() error, error) {
+func StartProxy(ctx context.Context, cassettePath string, opts ...ProxyOption) (string, func() error, error) {
 	options := &ProxyOptions{
 		StreamChunkDelay: 15 * time.Millisecond,
 	}
 	for _, opt := range opts {
 		opt(options)
 	}
-	return StartProxyWithOptions(cassettePath, recorder.ModeReplayOnly, nil, nil, options)
+	return StartProxyWithOptions(ctx, cassettePath, recorder.ModeReplayOnly, nil, nil, options)
 }
 
 // StartRecordingProxy starts a proxy that records AI API interactions to a cassette file.
@@ -66,14 +66,15 @@ func StartProxy(cassettePath string, opts ...ProxyOption) (string, func() error,
 // The recorded cassette can later be replayed using StartProxy.
 // This uses a streaming-aware recorder that allows responses to stream through
 // in real-time while being recorded, unlike the standard VCR recorder.
-func StartRecordingProxy(cassettePath string) (string, func() error, error) {
-	return StartStreamingRecordingProxy(cassettePath, APIKeyHeaderUpdater)
+func StartRecordingProxy(ctx context.Context, cassettePath string) (string, func() error, error) {
+	return StartStreamingRecordingProxy(ctx, cassettePath, APIKeyHeaderUpdater)
 }
 
 // StartStreamingRecordingProxy starts a recording proxy with streaming support.
 // Unlike StartProxyWithOptions which buffers entire responses, this allows
 // streaming responses to pass through in real-time while being recorded.
 func StartStreamingRecordingProxy(
+	ctx context.Context,
 	cassettePath string,
 	headerUpdater func(host string, req *http.Request),
 ) (string, func() error, error) {
@@ -100,8 +101,7 @@ func StartStreamingRecordingProxy(
 			stopDone <- streamRec.Stop()
 		}()
 
-		//rubocop:disable Lint/ContextConnectivity
-		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 3*time.Second)
 		defer cancel()
 
 		select {
@@ -139,6 +139,7 @@ func APIKeyHeaderUpdater(host string, req *http.Request) {
 // - headerUpdater: optional function to update request headers (for recording with real API keys)
 // - options: proxy options for stream simulation, etc.
 func StartProxyWithOptions(
+	ctx context.Context,
 	cassettePath string,
 	mode recorder.Mode,
 	matcher recorder.MatcherFunc,
@@ -186,8 +187,7 @@ func StartProxyWithOptions(
 			stopDone <- transport.Stop()
 		}()
 
-		//rubocop:disable Lint/ContextConnectivity
-		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 3*time.Second)
 		defer cancel()
 
 		select {

--- a/pkg/gateway/catalog.go
+++ b/pkg/gateway/catalog.go
@@ -41,8 +41,8 @@ func RequiredEnvVars(ctx context.Context, serverName string) ([]Secret, error) {
 	return server.Secrets, nil
 }
 
-func ServerSpec(_ context.Context, serverName string) (Server, error) {
-	catalog, err := catalogOnce()
+func ServerSpec(ctx context.Context, serverName string) (Server, error) {
+	catalog, err := loadCatalog(ctx)
 	if err != nil {
 		return Server{}, err
 	}
@@ -66,15 +66,35 @@ type cachedCatalog struct {
 	ETag    string  `json:"etag,omitempty"`
 }
 
-// catalogOnce guards one-shot catalog loading.
-// We use sync.OnceValues so that:
-//   - the catalog is fetched at most once per process, and
-//   - we detach from the caller's context to avoid permanently
-//     caching a context-cancellation error.
-var catalogOnce = sync.OnceValues(func() (Catalog, error) {
-	//rubocop:disable Lint/ContextConnectivity
-	return fetchAndCache(context.Background())
-})
+// catalogOnce guards one-shot catalog loading: the catalog is fetched at
+// most once per process and the result is memoized for every later caller.
+var (
+	catalogOnce   sync.Once
+	catalogCached struct {
+		catalog Catalog
+		err     error
+	}
+
+	// catalogOverride, when set, replaces the real loader entirely. It is
+	// only assigned from test setup via OverrideCatalogForTesting.
+	catalogOverride func(context.Context) (Catalog, error)
+)
+
+// loadCatalog fetches and caches the catalog on the first call, reusing the
+// memoized result afterwards. The first caller's context is honoured for
+// tracing (and threads the fetch onto the program's context), but its
+// cancellation is detached via WithoutCancel so a cancelled first caller
+// cannot permanently cache a context-cancellation error for everyone else.
+// On every subsequent call ctx is unused — the work has already run.
+func loadCatalog(ctx context.Context) (Catalog, error) {
+	if catalogOverride != nil {
+		return catalogOverride(ctx)
+	}
+	catalogOnce.Do(func() {
+		catalogCached.catalog, catalogCached.err = fetchAndCache(context.WithoutCancel(ctx))
+	})
+	return catalogCached.catalog, catalogCached.err
+}
 
 // fetchAndCache tries to fetch the catalog from the network (using ETag for
 // conditional requests) and falls back to the disk cache on any failure.

--- a/pkg/gateway/catalog.go
+++ b/pkg/gateway/catalog.go
@@ -72,6 +72,7 @@ type cachedCatalog struct {
 //   - we detach from the caller's context to avoid permanently
 //     caching a context-cancellation error.
 var catalogOnce = sync.OnceValues(func() (Catalog, error) {
+	//rubocop:disable Lint/ContextConnectivity
 	return fetchAndCache(context.Background())
 })
 

--- a/pkg/gateway/catalog_test.go
+++ b/pkg/gateway/catalog_test.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -33,8 +34,8 @@ var testCatalog = Catalog{
 }
 
 func TestMain(m *testing.M) {
-	// Override the production catalogOnce so that tests never hit the network.
-	catalogOnce = func() (Catalog, error) {
+	// Override the production loader so that tests never hit the network.
+	catalogOverride = func(context.Context) (Catalog, error) {
 		return testCatalog, nil
 	}
 	os.Exit(m.Run())

--- a/pkg/gateway/testing.go
+++ b/pkg/gateway/testing.go
@@ -1,10 +1,12 @@
 package gateway
 
+import "context"
+
 // OverrideCatalogForTesting replaces the catalog loader with a fixed function
 // that returns the given catalog. It should only be called from TestMain or
 // equivalent test-setup code, before any call to ServerSpec.
 func OverrideCatalogForTesting(catalog Catalog) {
-	catalogOnce = func() (Catalog, error) {
+	catalogOverride = func(context.Context) (Catalog, error) {
 		return catalog, nil
 	}
 }

--- a/pkg/httpclient/ssrf.go
+++ b/pkg/httpclient/ssrf.go
@@ -118,20 +118,17 @@ func NewSSRFSafeTransport() *http.Transport {
 			"type", fmt.Sprintf("%T", http.DefaultTransport))
 		t = &http.Transport{Proxy: http.ProxyFromEnvironment}
 	}
-	t.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
-		proxies := proxyDialAllowlist(ctx)
-		dialer := &net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-			Control: func(network, address string, c syscall.RawConn) error {
-				if _, ok := proxies[canonicalHostPort(address)]; ok {
-					return nil
-				}
-				return SSRFDialControl(network, address, c)
-			},
-		}
-		return dialer.DialContext(ctx, network, address)
-	}
+	proxies := proxyDialAllowlist()
+	t.DialContext = (&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		Control: func(network, address string, c syscall.RawConn) error {
+			if _, ok := proxies[canonicalHostPort(address)]; ok {
+				return nil
+			}
+			return SSRFDialControl(network, address, c)
+		},
+	}).DialContext
 	return t
 }
 
@@ -160,7 +157,9 @@ func canonicalHostPort(address string) string {
 // HTTP_PROXY / HTTPS_PROXY / ALL_PROXY environment variables resolve to.
 // Hostname-based proxies are resolved to all of their A/AAAA records so
 // the comparison can be done against the post-resolution dial address.
-func proxyDialAllowlist(ctx context.Context) map[string]struct{} {
+// The result is a snapshot taken at call time — safe to capture in a
+// dialer's Control closure.
+func proxyDialAllowlist() map[string]struct{} {
 	out := map[string]struct{}{}
 	raw := []string{
 		os.Getenv("HTTP_PROXY"), os.Getenv("http_proxy"),
@@ -168,7 +167,7 @@ func proxyDialAllowlist(ctx context.Context) map[string]struct{} {
 		os.Getenv("ALL_PROXY"), os.Getenv("all_proxy"),
 	}
 	for _, s := range raw {
-		for addr := range proxyHostPorts(ctx, s) {
+		for addr := range proxyHostPorts(s) {
 			out[addr] = struct{}{}
 		}
 	}
@@ -179,7 +178,7 @@ func proxyDialAllowlist(ctx context.Context) map[string]struct{} {
 // accepted by net/http.ProxyFromEnvironment: a full URL or a bare host[:port]
 // in which case http:// is implied) and returns each "ip:port" it can be
 // reached at. A nil/empty input yields an empty set.
-func proxyHostPorts(ctx context.Context, spec string) map[string]struct{} {
+func proxyHostPorts(spec string) map[string]struct{} {
 	if spec == "" {
 		return nil
 	}
@@ -207,7 +206,12 @@ func proxyHostPorts(ctx context.Context, spec string) map[string]struct{} {
 		out[net.JoinHostPort(ip.String(), port)] = struct{}{}
 		return out
 	}
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	// The allowlist is resolved once, at transport-construction time, so its
+	// (potentially blocking) DNS lookups are not repeated on every dial.
+	// There is no caller context at construction; a bounded independent root
+	// is the right base for the resolver timeout.
+	//rubocop:disable Lint/ContextConnectivity
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	ips, _ := net.DefaultResolver.LookupIPAddr(ctx, host)
 	for _, ip := range ips {

--- a/pkg/httpclient/ssrf.go
+++ b/pkg/httpclient/ssrf.go
@@ -206,6 +206,7 @@ func proxyHostPorts(spec string) map[string]struct{} {
 		out[net.JoinHostPort(ip.String(), port)] = struct{}{}
 		return out
 	}
+	//rubocop:disable Lint/ContextConnectivity
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	ips, _ := net.DefaultResolver.LookupIPAddr(ctx, host)

--- a/pkg/httpclient/ssrf.go
+++ b/pkg/httpclient/ssrf.go
@@ -118,17 +118,20 @@ func NewSSRFSafeTransport() *http.Transport {
 			"type", fmt.Sprintf("%T", http.DefaultTransport))
 		t = &http.Transport{Proxy: http.ProxyFromEnvironment}
 	}
-	proxies := proxyDialAllowlist()
-	t.DialContext = (&net.Dialer{
-		Timeout:   30 * time.Second,
-		KeepAlive: 30 * time.Second,
-		Control: func(network, address string, c syscall.RawConn) error {
-			if _, ok := proxies[canonicalHostPort(address)]; ok {
-				return nil
-			}
-			return SSRFDialControl(network, address, c)
-		},
-	}).DialContext
+	t.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		proxies := proxyDialAllowlist(ctx)
+		dialer := &net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			Control: func(network, address string, c syscall.RawConn) error {
+				if _, ok := proxies[canonicalHostPort(address)]; ok {
+					return nil
+				}
+				return SSRFDialControl(network, address, c)
+			},
+		}
+		return dialer.DialContext(ctx, network, address)
+	}
 	return t
 }
 
@@ -157,9 +160,7 @@ func canonicalHostPort(address string) string {
 // HTTP_PROXY / HTTPS_PROXY / ALL_PROXY environment variables resolve to.
 // Hostname-based proxies are resolved to all of their A/AAAA records so
 // the comparison can be done against the post-resolution dial address.
-// The result is a snapshot taken at call time — safe to capture in a
-// dialer's Control closure.
-func proxyDialAllowlist() map[string]struct{} {
+func proxyDialAllowlist(ctx context.Context) map[string]struct{} {
 	out := map[string]struct{}{}
 	raw := []string{
 		os.Getenv("HTTP_PROXY"), os.Getenv("http_proxy"),
@@ -167,7 +168,7 @@ func proxyDialAllowlist() map[string]struct{} {
 		os.Getenv("ALL_PROXY"), os.Getenv("all_proxy"),
 	}
 	for _, s := range raw {
-		for addr := range proxyHostPorts(s) {
+		for addr := range proxyHostPorts(ctx, s) {
 			out[addr] = struct{}{}
 		}
 	}
@@ -178,7 +179,7 @@ func proxyDialAllowlist() map[string]struct{} {
 // accepted by net/http.ProxyFromEnvironment: a full URL or a bare host[:port]
 // in which case http:// is implied) and returns each "ip:port" it can be
 // reached at. A nil/empty input yields an empty set.
-func proxyHostPorts(spec string) map[string]struct{} {
+func proxyHostPorts(ctx context.Context, spec string) map[string]struct{} {
 	if spec == "" {
 		return nil
 	}
@@ -206,8 +207,7 @@ func proxyHostPorts(spec string) map[string]struct{} {
 		out[net.JoinHostPort(ip.String(), port)] = struct{}{}
 		return out
 	}
-	//rubocop:disable Lint/ContextConnectivity
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	ips, _ := net.DefaultResolver.LookupIPAddr(ctx, host)
 	for _, ip := range ips {

--- a/pkg/httpclient/ssrf_test.go
+++ b/pkg/httpclient/ssrf_test.go
@@ -316,7 +316,7 @@ func TestProxyHostPorts(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := proxyHostPorts(t.Context(), tt.spec)
+			got := proxyHostPorts(tt.spec)
 			if tt.want == nil {
 				assert.Empty(t, got)
 				return
@@ -428,37 +428,26 @@ func TestNewSSRFSafeTransport_WrappedDefaultTransport(t *testing.T) {
 	assert.Contains(t, reqErr.Error(), "non-public address")
 }
 
-// TestNewSSRFSafeTransport_AllowlistResolvedAtDial documents that proxy
-// allowlist DNS resolution happens during DialContext, not construction. This
-// keeps NewSSRFSafeTransport side-effect-free while still allowing a proxy
-// configured before the request is dialed.
-func TestNewSSRFSafeTransport_AllowlistResolvedAtDial(t *testing.T) {
-	var lc net.ListenConfig
-	ln, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	addr := ln.Addr().String()
-	require.NoError(t, ln.Close())
-
+// TestNewSSRFSafeTransport_AllowlistFrozenAtConstruction documents that
+// the allowlist is captured when the transport is built, not on every
+// dial. Changing the env after construction has no effect — acceptable
+// because proxy env vars are set at process start.
+func TestNewSSRFSafeTransport_AllowlistFrozenAtConstruction(t *testing.T) {
 	t.Setenv("HTTP_PROXY", "")
 	t.Setenv("HTTPS_PROXY", "")
 	t.Setenv("http_proxy", "")
 	t.Setenv("https_proxy", "")
 
-	transport := NewSSRFSafeTransport()
+	client := &http.Client{Transport: NewSSRFSafeTransport()}
 
-	t.Setenv("HTTP_PROXY", "http://"+addr)
-	proxyURL, err := url.Parse("http://" + addr)
-	require.NoError(t, err)
-	transport.Proxy = http.ProxyURL(proxyURL)
+	t.Setenv("HTTP_PROXY", "http://10.0.0.1:3128")
 
-	client := &http.Client{Transport: transport}
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com/", http.NoBody)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://10.0.0.1:3128/", http.NoBody)
 	require.NoError(t, err)
 	resp, reqErr := client.Do(req)
 	if resp != nil {
 		_ = resp.Body.Close()
 	}
 	require.Error(t, reqErr)
-	assert.NotContains(t, reqErr.Error(), "non-public address")
-	assert.NotContains(t, reqErr.Error(), "not a valid IP")
+	assert.Contains(t, reqErr.Error(), "non-public address")
 }

--- a/pkg/httpclient/ssrf_test.go
+++ b/pkg/httpclient/ssrf_test.go
@@ -316,7 +316,7 @@ func TestProxyHostPorts(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := proxyHostPorts(tt.spec)
+			got := proxyHostPorts(t.Context(), tt.spec)
 			if tt.want == nil {
 				assert.Empty(t, got)
 				return
@@ -428,26 +428,37 @@ func TestNewSSRFSafeTransport_WrappedDefaultTransport(t *testing.T) {
 	assert.Contains(t, reqErr.Error(), "non-public address")
 }
 
-// TestNewSSRFSafeTransport_AllowlistFrozenAtConstruction documents that
-// the allowlist is captured when the transport is built, not on every
-// dial. Changing the env after construction has no effect — acceptable
-// because proxy env vars are set at process start.
-func TestNewSSRFSafeTransport_AllowlistFrozenAtConstruction(t *testing.T) {
+// TestNewSSRFSafeTransport_AllowlistResolvedAtDial documents that proxy
+// allowlist DNS resolution happens during DialContext, not construction. This
+// keeps NewSSRFSafeTransport side-effect-free while still allowing a proxy
+// configured before the request is dialed.
+func TestNewSSRFSafeTransport_AllowlistResolvedAtDial(t *testing.T) {
+	var lc net.ListenConfig
+	ln, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	require.NoError(t, ln.Close())
+
 	t.Setenv("HTTP_PROXY", "")
 	t.Setenv("HTTPS_PROXY", "")
 	t.Setenv("http_proxy", "")
 	t.Setenv("https_proxy", "")
 
-	client := &http.Client{Transport: NewSSRFSafeTransport()}
+	transport := NewSSRFSafeTransport()
 
-	t.Setenv("HTTP_PROXY", "http://10.0.0.1:3128")
+	t.Setenv("HTTP_PROXY", "http://"+addr)
+	proxyURL, err := url.Parse("http://" + addr)
+	require.NoError(t, err)
+	transport.Proxy = http.ProxyURL(proxyURL)
 
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://10.0.0.1:3128/", http.NoBody)
+	client := &http.Client{Transport: transport}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com/", http.NoBody)
 	require.NoError(t, err)
 	resp, reqErr := client.Do(req)
 	if resp != nil {
 		_ = resp.Body.Close()
 	}
 	require.Error(t, reqErr)
-	assert.Contains(t, reqErr.Error(), "non-public address")
+	assert.NotContains(t, reqErr.Error(), "non-public address")
+	assert.NotContains(t, reqErr.Error(), "not a valid IP")
 }

--- a/pkg/leantui/update_test.go
+++ b/pkg/leantui/update_test.go
@@ -26,8 +26,8 @@ type cycleThinkingRuntime struct {
 func (r *cycleThinkingRuntime) CurrentAgentInfo(context.Context) runtime.CurrentAgentInfo {
 	return runtime.CurrentAgentInfo{}
 }
-func (r *cycleThinkingRuntime) CurrentAgentName() string     { return "coder" }
-func (r *cycleThinkingRuntime) SetCurrentAgent(string) error { return nil }
+func (r *cycleThinkingRuntime) CurrentAgentName(context.Context) string       { return "coder" }
+func (r *cycleThinkingRuntime) SetCurrentAgent(context.Context, string) error { return nil }
 func (r *cycleThinkingRuntime) CurrentAgentTools(context.Context) ([]tools.Tool, error) {
 	return nil, nil
 }
@@ -77,12 +77,12 @@ func (r *cycleThinkingRuntime) UpdateSessionTitle(_ context.Context, sess *sessi
 	sess.Title = title
 	return nil
 }
-func (r *cycleThinkingRuntime) TitleGenerator() *sessiontitle.Generator { return nil }
-func (r *cycleThinkingRuntime) Close() error                            { return nil }
-func (r *cycleThinkingRuntime) Stop()                                   {}
-func (r *cycleThinkingRuntime) Steer(runtime.QueuedMessage) error       { return nil }
-func (r *cycleThinkingRuntime) FollowUp(runtime.QueuedMessage) error    { return nil }
-func (r *cycleThinkingRuntime) QueueStatus() runtime.QueueStatus        { return runtime.QueueStatus{} }
+func (r *cycleThinkingRuntime) TitleGenerator(context.Context) *sessiontitle.Generator { return nil }
+func (r *cycleThinkingRuntime) Close() error                                           { return nil }
+func (r *cycleThinkingRuntime) Stop()                                                  {}
+func (r *cycleThinkingRuntime) Steer(context.Context, runtime.QueuedMessage) error     { return nil }
+func (r *cycleThinkingRuntime) FollowUp(context.Context, runtime.QueuedMessage) error  { return nil }
+func (r *cycleThinkingRuntime) QueueStatus() runtime.QueueStatus                       { return runtime.QueueStatus{} }
 
 func (r *cycleThinkingRuntime) TogglePause(context.Context) (bool, error) {
 	return false, nil

--- a/pkg/leantui/update_test.go
+++ b/pkg/leantui/update_test.go
@@ -104,7 +104,7 @@ var _ runtime.Runtime = (*cycleThinkingRuntime)(nil)
 func TestShiftTabCyclesThinkingLevel(t *testing.T) {
 	rt := &cycleThinkingRuntime{supports: true, level: effort.High}
 	m := bareModel(24)
-	m.app = app.New(rt, session.New())
+	m.app = app.New(t.Context(), rt, session.New())
 
 	m.handleKey(t.Context(), key{typ: keyShiftTab})
 
@@ -116,7 +116,7 @@ func TestShiftTabCyclesThinkingLevel(t *testing.T) {
 func TestShiftTabReportsUnsupportedThinkingLevel(t *testing.T) {
 	rt := &cycleThinkingRuntime{supports: true, err: runtime.ErrUnsupported}
 	m := bareModel(24)
-	m.app = app.New(rt, session.New())
+	m.app = app.New(t.Context(), rt, session.New())
 
 	m.handleKey(t.Context(), key{typ: keyShiftTab})
 

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -208,7 +208,7 @@ func CreateToolHandler(t *team.Team, agentName string) func(context.Context, *mc
 			session.WithNonInteractive(true),
 		)
 
-		rt, err := runtime.New(t,
+		rt, err := runtime.New(ctx, t,
 			runtime.WithCurrentAgent(agentName),
 			runtime.WithNonInteractive(true),
 			// See pkg/a2a/adapter.go for rationale — without this

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -86,6 +86,7 @@ func StartHTTPServer(ctx context.Context, agentFilename, agentName string, runCo
 
 	select {
 	case <-ctx.Done():
+		//rubocop:disable Lint/ContextConnectivity
 		return httpServer.Shutdown(context.Background())
 	case err := <-errCh:
 		if errors.Is(err, http.ErrServerClosed) {

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -86,8 +86,9 @@ func StartHTTPServer(ctx context.Context, agentFilename, agentName string, runCo
 
 	select {
 	case <-ctx.Done():
-		//rubocop:disable Lint/ContextConnectivity
-		return httpServer.Shutdown(context.Background())
+		// ctx is done; detach from its cancellation but keep its trace
+		// context so the graceful shutdown can still run.
+		return httpServer.Shutdown(context.WithoutCancel(ctx))
 	case err := <-errCh:
 		if errors.Is(err, http.ErrServerClosed) {
 			return nil

--- a/pkg/memory/database/sqlite/sqlite.go
+++ b/pkg/memory/database/sqlite/sqlite.go
@@ -52,6 +52,7 @@ func NewMemoryDatabase(path string) (database.Database, error) {
 	// Ensure we close the connection if table creation fails
 	// Note: We don't defer close here because we return the db on success
 
+	//rubocop:disable Lint/ContextConnectivity
 	_, err = db.ExecContext(context.Background(), "CREATE TABLE IF NOT EXISTS memories (id TEXT PRIMARY KEY, created_at TEXT, memory TEXT)")
 	if err != nil {
 		db.Close()
@@ -59,6 +60,7 @@ func NewMemoryDatabase(path string) (database.Database, error) {
 	}
 
 	// Add category column if it doesn't exist (transparent migration)
+	//rubocop:disable Lint/ContextConnectivity
 	if _, err := db.ExecContext(context.Background(), "ALTER TABLE memories ADD COLUMN category TEXT DEFAULT ''"); err != nil {
 		if !strings.Contains(err.Error(), "duplicate column name") {
 			db.Close()

--- a/pkg/memory/database/sqlite/sqlite.go
+++ b/pkg/memory/database/sqlite/sqlite.go
@@ -44,24 +44,22 @@ type MemoryDatabase struct {
 	db *sql.DB
 }
 
-func NewMemoryDatabase(path string) (database.Database, error) {
-	db, err := sqliteutil.OpenDB(path)
+func NewMemoryDatabase(ctx context.Context, path string) (database.Database, error) {
+	db, err := sqliteutil.OpenDB(ctx, path)
 	if err != nil {
 		return nil, err
 	}
 	// Ensure we close the connection if table creation fails
 	// Note: We don't defer close here because we return the db on success
 
-	//rubocop:disable Lint/ContextConnectivity
-	_, err = db.ExecContext(context.Background(), "CREATE TABLE IF NOT EXISTS memories (id TEXT PRIMARY KEY, created_at TEXT, memory TEXT)")
+	_, err = db.ExecContext(ctx, "CREATE TABLE IF NOT EXISTS memories (id TEXT PRIMARY KEY, created_at TEXT, memory TEXT)")
 	if err != nil {
 		db.Close()
 		return nil, err
 	}
 
 	// Add category column if it doesn't exist (transparent migration)
-	//rubocop:disable Lint/ContextConnectivity
-	if _, err := db.ExecContext(context.Background(), "ALTER TABLE memories ADD COLUMN category TEXT DEFAULT ''"); err != nil {
+	if _, err := db.ExecContext(ctx, "ALTER TABLE memories ADD COLUMN category TEXT DEFAULT ''"); err != nil {
 		if !strings.Contains(err.Error(), "duplicate column name") {
 			db.Close()
 			return nil, fmt.Errorf("memory database migration failed: %w", err)

--- a/pkg/memory/database/sqlite/sqlite.go
+++ b/pkg/memory/database/sqlite/sqlite.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+	"sync"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -41,19 +42,29 @@ func startMemorySpan(ctx context.Context, op string) (context.Context, trace.Spa
 }
 
 type MemoryDatabase struct {
+	path string
+
+	mu sync.Mutex
 	db *sql.DB
 }
 
-func NewMemoryDatabase(ctx context.Context, path string) (database.Database, error) {
-	db, err := sqliteutil.OpenDB(ctx, path)
+func NewMemoryDatabase(path string) (database.Database, error) {
+	return &MemoryDatabase{path: path}, nil
+}
+
+func (m *MemoryDatabase) ensureDB(ctx context.Context) (*sql.DB, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.db != nil {
+		return m.db, nil
+	}
+
+	db, err := sqliteutil.OpenDB(ctx, m.path)
 	if err != nil {
 		return nil, err
 	}
-	// Ensure we close the connection if table creation fails
-	// Note: We don't defer close here because we return the db on success
 
-	_, err = db.ExecContext(ctx, "CREATE TABLE IF NOT EXISTS memories (id TEXT PRIMARY KEY, created_at TEXT, memory TEXT)")
-	if err != nil {
+	if _, err = db.ExecContext(ctx, "CREATE TABLE IF NOT EXISTS memories (id TEXT PRIMARY KEY, created_at TEXT, memory TEXT)"); err != nil {
 		db.Close()
 		return nil, err
 	}
@@ -66,7 +77,19 @@ func NewMemoryDatabase(ctx context.Context, path string) (database.Database, err
 		}
 	}
 
-	return &MemoryDatabase{db: db}, nil
+	m.db = db
+	return db, nil
+}
+
+func (m *MemoryDatabase) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.db == nil {
+		return nil
+	}
+	err := m.db.Close()
+	m.db = nil
+	return err
 }
 
 func (m *MemoryDatabase) AddMemory(ctx context.Context, memory database.UserMemory) error {
@@ -76,7 +99,13 @@ func (m *MemoryDatabase) AddMemory(ctx context.Context, memory database.UserMemo
 	if memory.ID == "" {
 		return database.ErrEmptyID
 	}
-	_, err := m.db.ExecContext(ctx, "INSERT INTO memories (id, created_at, memory, category) VALUES (?, ?, ?, ?)",
+	db, err := m.ensureDB(ctx)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	_, err = db.ExecContext(ctx, "INSERT INTO memories (id, created_at, memory, category) VALUES (?, ?, ?, ?)",
 		memory.ID, memory.CreatedAt, memory.Memory, memory.Category)
 	if err != nil {
 		span.RecordError(err)
@@ -89,7 +118,11 @@ func (m *MemoryDatabase) GetMemories(ctx context.Context) ([]database.UserMemory
 	ctx, span := startMemorySpan(ctx, "list")
 	defer span.End()
 
-	rows, err := m.db.QueryContext(ctx, "SELECT id, created_at, memory, COALESCE(category, '') FROM memories")
+	db, err := m.ensureDB(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := db.QueryContext(ctx, "SELECT id, created_at, memory, COALESCE(category, '') FROM memories")
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +149,13 @@ func (m *MemoryDatabase) DeleteMemory(ctx context.Context, memory database.UserM
 	ctx, span := startMemorySpan(ctx, "delete")
 	defer span.End()
 
-	_, err := m.db.ExecContext(ctx, "DELETE FROM memories WHERE id = ?", memory.ID)
+	db, err := m.ensureDB(ctx)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	_, err = db.ExecContext(ctx, "DELETE FROM memories WHERE id = ?", memory.ID)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -169,7 +208,11 @@ func (m *MemoryDatabase) SearchMemories(ctx context.Context, query, category str
 	}
 
 	var rows *sql.Rows
-	rows, err = m.db.QueryContext(ctx, stmt, args...)
+	db, err := m.ensureDB(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rows, err = db.QueryContext(ctx, stmt, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +244,11 @@ func (m *MemoryDatabase) UpdateMemory(ctx context.Context, memory database.UserM
 		return database.ErrEmptyID
 	}
 
-	result, err := m.db.ExecContext(ctx, "UPDATE memories SET memory = ?, category = ? WHERE id = ?",
+	db, err := m.ensureDB(ctx)
+	if err != nil {
+		return err
+	}
+	result, err := db.ExecContext(ctx, "UPDATE memories SET memory = ?, category = ? WHERE id = ?",
 		memory.Memory, memory.Category, memory.ID)
 	if err != nil {
 		return err

--- a/pkg/memory/database/sqlite/sqlite_test.go
+++ b/pkg/memory/database/sqlite/sqlite_test.go
@@ -16,7 +16,7 @@ func setupTestDB(t *testing.T) database.Database {
 
 	tmpFile := t.TempDir() + "/test.db"
 
-	db, err := NewMemoryDatabase(tmpFile)
+	db, err := NewMemoryDatabase(t.Context(), tmpFile)
 	require.NoError(t, err)
 	require.NotNil(t, db)
 
@@ -34,7 +34,7 @@ func TestNewMemoryDatabase(t *testing.T) {
 
 	assert.NotNil(t, db, "Database should be created successfully")
 
-	_, err := NewMemoryDatabase("/:invalid:path")
+	_, err := NewMemoryDatabase(t.Context(), "/:invalid:path")
 	require.Error(t, err, "Should fail with invalid database path")
 }
 
@@ -275,7 +275,7 @@ func TestMigrationAddsCategory(t *testing.T) {
 	tmpFile := t.TempDir() + "/migrate.db"
 
 	// Create a DB with the old schema (no category column)
-	db1, err := NewMemoryDatabase(tmpFile)
+	db1, err := NewMemoryDatabase(t.Context(), tmpFile)
 	require.NoError(t, err)
 	memDB1 := db1.(*MemoryDatabase)
 
@@ -289,7 +289,7 @@ func TestMigrationAddsCategory(t *testing.T) {
 	memDB1.db.Close()
 
 	// Reopen - migration should be idempotent
-	db2, err := NewMemoryDatabase(tmpFile)
+	db2, err := NewMemoryDatabase(t.Context(), tmpFile)
 	require.NoError(t, err)
 	memDB2 := db2.(*MemoryDatabase)
 	defer memDB2.db.Close()
@@ -331,7 +331,7 @@ func TestDatabaseOperationsWithCanceledContext(t *testing.T) {
 
 func TestDatabaseWithMultipleInstances(t *testing.T) {
 	tmpFile := t.TempDir() + "/shared.db"
-	db1, err := NewMemoryDatabase(tmpFile)
+	db1, err := NewMemoryDatabase(t.Context(), tmpFile)
 	require.NoError(t, err)
 	defer func() {
 		memDB := db1.(*MemoryDatabase)
@@ -347,7 +347,7 @@ func TestDatabaseWithMultipleInstances(t *testing.T) {
 	err = db1.AddMemory(t.Context(), memory)
 	require.NoError(t, err)
 
-	db2, err := NewMemoryDatabase(tmpFile)
+	db2, err := NewMemoryDatabase(t.Context(), tmpFile)
 	require.NoError(t, err)
 	defer func() {
 		memDB := db2.(*MemoryDatabase)

--- a/pkg/memory/database/sqlite/sqlite_test.go
+++ b/pkg/memory/database/sqlite/sqlite_test.go
@@ -16,14 +16,13 @@ func setupTestDB(t *testing.T) database.Database {
 
 	tmpFile := t.TempDir() + "/test.db"
 
-	db, err := NewMemoryDatabase(t.Context(), tmpFile)
+	db, err := NewMemoryDatabase(tmpFile)
 	require.NoError(t, err)
 	require.NotNil(t, db)
 
 	t.Cleanup(func() {
-		// Close connection
 		memDB := db.(*MemoryDatabase)
-		memDB.db.Close()
+		require.NoError(t, memDB.Close())
 	})
 
 	return db
@@ -34,7 +33,9 @@ func TestNewMemoryDatabase(t *testing.T) {
 
 	assert.NotNil(t, db, "Database should be created successfully")
 
-	_, err := NewMemoryDatabase(t.Context(), "/:invalid:path")
+	db, err := NewMemoryDatabase("/:invalid:path")
+	require.NoError(t, err, "constructor should not touch the filesystem")
+	err = db.AddMemory(t.Context(), database.UserMemory{ID: "1", CreatedAt: time.Now().Format(time.RFC3339), Memory: "x"})
 	require.Error(t, err, "Should fail with invalid database path")
 }
 
@@ -275,7 +276,7 @@ func TestMigrationAddsCategory(t *testing.T) {
 	tmpFile := t.TempDir() + "/migrate.db"
 
 	// Create a DB with the old schema (no category column)
-	db1, err := NewMemoryDatabase(t.Context(), tmpFile)
+	db1, err := NewMemoryDatabase(tmpFile)
 	require.NoError(t, err)
 	memDB1 := db1.(*MemoryDatabase)
 
@@ -286,13 +287,13 @@ func TestMigrationAddsCategory(t *testing.T) {
 		Memory:    "Old memory without category",
 	})
 	require.NoError(t, err)
-	memDB1.db.Close()
+	require.NoError(t, memDB1.Close())
 
 	// Reopen - migration should be idempotent
-	db2, err := NewMemoryDatabase(t.Context(), tmpFile)
+	db2, err := NewMemoryDatabase(tmpFile)
 	require.NoError(t, err)
 	memDB2 := db2.(*MemoryDatabase)
-	defer memDB2.db.Close()
+	defer func() { require.NoError(t, memDB2.Close()) }()
 
 	memories, err := db2.GetMemories(t.Context())
 	require.NoError(t, err)
@@ -331,11 +332,11 @@ func TestDatabaseOperationsWithCanceledContext(t *testing.T) {
 
 func TestDatabaseWithMultipleInstances(t *testing.T) {
 	tmpFile := t.TempDir() + "/shared.db"
-	db1, err := NewMemoryDatabase(t.Context(), tmpFile)
+	db1, err := NewMemoryDatabase(tmpFile)
 	require.NoError(t, err)
 	defer func() {
 		memDB := db1.(*MemoryDatabase)
-		memDB.db.Close()
+		require.NoError(t, memDB.Close())
 	}()
 
 	memory := database.UserMemory{
@@ -347,11 +348,11 @@ func TestDatabaseWithMultipleInstances(t *testing.T) {
 	err = db1.AddMemory(t.Context(), memory)
 	require.NoError(t, err)
 
-	db2, err := NewMemoryDatabase(t.Context(), tmpFile)
+	db2, err := NewMemoryDatabase(tmpFile)
 	require.NoError(t, err)
 	defer func() {
 		memDB := db2.(*MemoryDatabase)
-		memDB.db.Close()
+		require.NoError(t, memDB.Close())
 	}()
 
 	memories, err := db2.GetMemories(t.Context())

--- a/pkg/modelsdev/internal/gen/main.go
+++ b/pkg/modelsdev/internal/gen/main.go
@@ -39,6 +39,9 @@ func run() error {
 		return err
 	}
 
+	// Standalone snapshot generator (its own main); the build-time root
+	// context has no parent to derive from.
+	//rubocop:disable Lint/ContextConnectivity
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 

--- a/pkg/rag/chunk/chunk.go
+++ b/pkg/rag/chunk/chunk.go
@@ -1,6 +1,7 @@
 package chunk
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -19,7 +20,7 @@ type Chunk struct {
 // DocumentProcessor takes file content and returns chunks.
 // Config (size, overlap, etc.) is set at construction time.
 type DocumentProcessor interface {
-	Process(path string, content []byte) ([]Chunk, error)
+	Process(ctx context.Context, path string, content []byte) ([]Chunk, error)
 }
 
 // TextDocumentProcessor is the default text-based chunker
@@ -46,7 +47,7 @@ func NewTextDocumentProcessor(size, overlap int, respectWordBoundaries bool) *Te
 }
 
 // Process implements DocumentProcessor for text-based chunking
-func (t *TextDocumentProcessor) Process(_ string, content []byte) ([]Chunk, error) {
+func (t *TextDocumentProcessor) Process(_ context.Context, _ string, content []byte) ([]Chunk, error) {
 	return t.chunkText(string(content)), nil
 }
 
@@ -169,12 +170,12 @@ func (t *TextDocumentProcessor) isWhitespace(r rune) bool {
 // --- File utility functions (standalone, not tied to any processor) ---
 
 // ProcessFile reads a file and processes it using the given document processor
-func ProcessFile(dp DocumentProcessor, path string) ([]Chunk, error) {
+func ProcessFile(ctx context.Context, dp DocumentProcessor, path string) ([]Chunk, error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file: %w", err)
 	}
-	return dp.Process(path, content)
+	return dp.Process(ctx, path, content)
 }
 
 // FileHash calculates SHA256 hash of a file

--- a/pkg/rag/chunk/chunk_test.go
+++ b/pkg/rag/chunk/chunk_test.go
@@ -95,7 +95,7 @@ func TestChunkText_RespectWordBoundaries(t *testing.T) {
 			t.Parallel()
 
 			pp := NewTextDocumentProcessor(tt.size, tt.overlap, tt.respectWordBoundaries)
-			chunks, err := pp.Process("test.txt", []byte(tt.text))
+			chunks, err := pp.Process(t.Context(), "test.txt", []byte(tt.text))
 			require.NoError(t, err)
 
 			assert.NotEmpty(t, chunks)
@@ -113,7 +113,7 @@ func TestChunkText_BackwardCompatibility(t *testing.T) {
 
 	// Test that default behavior (respectWordBoundaries=false) still works as before
 	text := "This is a test text for chunking"
-	chunks, err := pp.Process("test.txt", []byte(text))
+	chunks, err := pp.Process(t.Context(), "test.txt", []byte(text))
 	require.NoError(t, err)
 
 	assert.NotEmpty(t, chunks)

--- a/pkg/rag/embed/embed.go
+++ b/pkg/rag/embed/embed.go
@@ -14,9 +14,9 @@ import (
 // Embedder generates vector embeddings for text
 type Embedder struct {
 	provider       provider.Provider
-	usageHandler   func(tokens int64, cost float64) // Callback to emit usage events
-	batchSize      int                              // Batch size for API calls
-	maxConcurrency int                              // Maximum concurrent embedding batch requests
+	usageHandler   func(ctx context.Context, tokens int64, cost float64) // Callback to emit usage events
+	batchSize      int                                                   // Batch size for API calls
+	maxConcurrency int                                                   // Maximum concurrent embedding batch requests
 }
 
 // Option is a functional option for configuring the Embedder
@@ -52,7 +52,7 @@ func New(p provider.Provider, opts ...Option) *Embedder {
 }
 
 // SetUsageHandler sets a callback to be called after each embedding with usage info
-func (e *Embedder) SetUsageHandler(handler func(tokens int64, cost float64)) {
+func (e *Embedder) SetUsageHandler(handler func(ctx context.Context, tokens int64, cost float64)) {
 	e.usageHandler = handler
 }
 
@@ -68,7 +68,7 @@ func (e *Embedder) Embed(ctx context.Context, text string) ([]float64, error) {
 
 		// Emit usage event immediately
 		if e.usageHandler != nil {
-			e.usageHandler(result.TotalTokens, result.Cost)
+			e.usageHandler(ctx, result.TotalTokens, result.Cost)
 		}
 
 		slog.DebugContext(ctx, "Embedding generated",
@@ -158,7 +158,7 @@ func (e *Embedder) embedBatchOptimized(ctx context.Context, batchProvider provid
 
 			// Emit usage event (handler should be thread-safe)
 			if e.usageHandler != nil {
-				e.usageHandler(result.TotalTokens, result.Cost)
+				e.usageHandler(ctx, result.TotalTokens, result.Cost)
 			}
 
 			slog.DebugContext(ctx, "Batch completed",

--- a/pkg/rag/strategy/bm25.go
+++ b/pkg/rag/strategy/bm25.go
@@ -556,7 +556,7 @@ func (s *BM25Strategy) indexFile(ctx context.Context, filePath string) error {
 		return fmt.Errorf("failed to delete old documents: %w", err)
 	}
 
-	chunks, err := chunk.ProcessFile(s.docProcessor, filePath)
+	chunks, err := chunk.ProcessFile(ctx, s.docProcessor, filePath)
 	if err != nil {
 		return fmt.Errorf("failed to process file: %w", err)
 	}

--- a/pkg/rag/strategy/bm25.go
+++ b/pkg/rag/strategy/bm25.go
@@ -26,7 +26,7 @@ import (
 )
 
 // NewBM25FromConfig creates a BM25 strategy from configuration
-func NewBM25FromConfig(_ context.Context, cfg latest.RAGStrategyConfig, buildCtx BuildContext, events chan<- types.Event) (*Config, error) {
+func NewBM25FromConfig(ctx context.Context, cfg latest.RAGStrategyConfig, buildCtx BuildContext, events chan<- types.Event) (*Config, error) {
 	// Get optional parameters with defaults
 	k1 := GetParam(cfg.Params, "k1", 1.5)
 	bParam := GetParam(cfg.Params, "b", 0.75)
@@ -52,7 +52,7 @@ func NewBM25FromConfig(_ context.Context, cfg latest.RAGStrategyConfig, buildCtx
 
 	// Create BM25-specific database (no vectors needed).
 	// Pass strategy type as table prefix so multiple strategies can share the same DB file.
-	db, err := newBM25DB(dbPath, cfg.Type)
+	db, err := newBM25DB(ctx, dbPath, cfg.Type)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create database: %w", err)
 	}

--- a/pkg/rag/strategy/bm25_database.go
+++ b/pkg/rag/strategy/bm25_database.go
@@ -18,18 +18,19 @@ import (
 // Uses the base Document type without embeddings.
 type bm25DB struct {
 	db            *sql.DB
+	ctx           func() context.Context
 	tablePrefix   string
 	docsTable     string
 	metadataTable string
 }
 
 // newBM25DB creates a new SQLite database for BM25 strategy.
-func newBM25DB(dbPath, strategyName string) (*bm25DB, error) {
+func newBM25DB(ctx context.Context, dbPath, strategyName string) (*bm25DB, error) {
 	if err := ensureDir(dbPath); err != nil {
 		return nil, fmt.Errorf("failed to create database directory: %w", err)
 	}
 
-	db, err := sqliteutil.OpenDB(dbPath)
+	db, err := sqliteutil.OpenDB(ctx, dbPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
@@ -38,22 +39,23 @@ func newBM25DB(dbPath, strategyName string) (*bm25DB, error) {
 
 	bdb := &bm25DB{
 		db:            db,
+		ctx:           func() context.Context { return context.WithoutCancel(ctx) },
 		tablePrefix:   tablePrefix,
 		docsTable:     tablePrefix + "_documents",
 		metadataTable: tablePrefix + "_file_metadata",
 	}
 
-	if err := bdb.createSchema(); err != nil {
+	if err := bdb.createSchema(ctx); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("failed to create schema: %w", err)
 	}
 
-	slog.Info("BM25 database initialized", "path", dbPath, "table_prefix", tablePrefix)
+	slog.InfoContext(ctx, "BM25 database initialized", "path", dbPath, "table_prefix", tablePrefix)
 
 	return bdb, nil
 }
 
-func (d *bm25DB) createSchema() error {
+func (d *bm25DB) createSchema(ctx context.Context) error {
 	schema := fmt.Sprintf(`
 	CREATE TABLE IF NOT EXISTS %s (
 		id TEXT PRIMARY KEY,
@@ -82,8 +84,7 @@ func (d *bm25DB) createSchema() error {
 		d.metadataTable,
 		d.tablePrefix, d.metadataTable)
 
-	//rubocop:disable Lint/ContextConnectivity
-	_, err := d.db.ExecContext(context.Background(), schema)
+	_, err := d.db.ExecContext(ctx, schema)
 	return err
 }
 
@@ -212,7 +213,7 @@ func (d *bm25DB) DeleteFileMetadata(ctx context.Context, sourcePath string) erro
 }
 
 func (d *bm25DB) Close() error {
-	return sqliteutil.CheckpointAndClose(d.db)
+	return sqliteutil.CheckpointAndClose(d.ctx(), d.db)
 }
 
 // ensureDir creates the parent directory for a file path if it doesn't exist

--- a/pkg/rag/strategy/bm25_database.go
+++ b/pkg/rag/strategy/bm25_database.go
@@ -82,6 +82,7 @@ func (d *bm25DB) createSchema() error {
 		d.metadataTable,
 		d.tablePrefix, d.metadataTable)
 
+	//rubocop:disable Lint/ContextConnectivity
 	_, err := d.db.ExecContext(context.Background(), schema)
 	return err
 }

--- a/pkg/rag/strategy/chunked_embeddings.go
+++ b/pkg/rag/strategy/chunked_embeddings.go
@@ -58,7 +58,7 @@ func NewChunkedEmbeddingsFromConfig(ctx context.Context, cfg latest.RAGStrategyC
 	}
 
 	// Create vector database (internal to this strategy)
-	db, err := newChunkedVectorDB(dbPath, vectorDimensions, strategyName)
+	db, err := newChunkedVectorDB(ctx, dbPath, vectorDimensions, strategyName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create database: %w", err)
 	}

--- a/pkg/rag/strategy/chunked_embeddings.go
+++ b/pkg/rag/strategy/chunked_embeddings.go
@@ -74,6 +74,7 @@ func NewChunkedEmbeddingsFromConfig(ctx context.Context, cfg latest.RAGStrategyC
 
 	// Create vector store
 	store := NewVectorStore(VectorStoreConfig{
+		Context:              func() context.Context { return context.WithoutCancel(ctx) },
 		Name:                 strategyName,
 		Database:             db,
 		Embedder:             embedder,

--- a/pkg/rag/strategy/chunked_embeddings.go
+++ b/pkg/rag/strategy/chunked_embeddings.go
@@ -74,7 +74,6 @@ func NewChunkedEmbeddingsFromConfig(ctx context.Context, cfg latest.RAGStrategyC
 
 	// Create vector store
 	store := NewVectorStore(VectorStoreConfig{
-		Context:              func() context.Context { return context.WithoutCancel(ctx) },
 		Name:                 strategyName,
 		Database:             db,
 		Embedder:             embedder,

--- a/pkg/rag/strategy/chunked_embeddings_database.go
+++ b/pkg/rag/strategy/chunked_embeddings_database.go
@@ -78,6 +78,7 @@ func (d *chunkedVectorDB) createSchema() error {
 	);
 	`, d.filesTable, d.tablePrefix, d.filesTable, d.chunksTable, d.filesTable)
 
+	//rubocop:disable Lint/ContextConnectivity
 	_, err := d.db.ExecContext(context.Background(), schema)
 	return err
 }

--- a/pkg/rag/strategy/chunked_embeddings_database.go
+++ b/pkg/rag/strategy/chunked_embeddings_database.go
@@ -18,6 +18,7 @@ import (
 // It stores document chunks with their embedding vectors (no semantic summaries).
 type chunkedVectorDB struct {
 	db               *sql.DB
+	ctx              func() context.Context
 	vectorDimensions int
 	tablePrefix      string
 	filesTable       string
@@ -25,12 +26,12 @@ type chunkedVectorDB struct {
 }
 
 // newChunkedVectorDB creates a new SQLite database for chunked vector embeddings.
-func newChunkedVectorDB(dbPath string, vectorDimensions int, strategyName string) (*chunkedVectorDB, error) {
+func newChunkedVectorDB(ctx context.Context, dbPath string, vectorDimensions int, strategyName string) (*chunkedVectorDB, error) {
 	if err := ensureDir(dbPath); err != nil {
 		return nil, fmt.Errorf("failed to create database directory: %w", err)
 	}
 
-	db, err := sqliteutil.OpenDB(dbPath)
+	db, err := sqliteutil.OpenDB(ctx, dbPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
@@ -39,18 +40,19 @@ func newChunkedVectorDB(dbPath string, vectorDimensions int, strategyName string
 
 	cdb := &chunkedVectorDB{
 		db:               db,
+		ctx:              func() context.Context { return context.WithoutCancel(ctx) },
 		vectorDimensions: vectorDimensions,
 		tablePrefix:      tablePrefix,
 		filesTable:       tablePrefix + "_files",
 		chunksTable:      tablePrefix + "_chunks",
 	}
 
-	if err := cdb.createSchema(); err != nil {
+	if err := cdb.createSchema(ctx); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("failed to create schema: %w", err)
 	}
 
-	slog.Info("Chunked vector database initialized",
+	slog.InfoContext(ctx, "Chunked vector database initialized",
 		"vector_dimensions", vectorDimensions,
 		"path", dbPath,
 		"table_prefix", tablePrefix)
@@ -58,7 +60,7 @@ func newChunkedVectorDB(dbPath string, vectorDimensions int, strategyName string
 	return cdb, nil
 }
 
-func (d *chunkedVectorDB) createSchema() error {
+func (d *chunkedVectorDB) createSchema(ctx context.Context) error {
 	schema := fmt.Sprintf( //nolint:gosec // table names are internal, no user input
 		`
 	CREATE TABLE IF NOT EXISTS %s (
@@ -78,8 +80,7 @@ func (d *chunkedVectorDB) createSchema() error {
 	);
 	`, d.filesTable, d.tablePrefix, d.filesTable, d.chunksTable, d.filesTable)
 
-	//rubocop:disable Lint/ContextConnectivity
-	_, err := d.db.ExecContext(context.Background(), schema)
+	_, err := d.db.ExecContext(ctx, schema)
 	return err
 }
 
@@ -247,5 +248,5 @@ func (d *chunkedVectorDB) DeleteFileMetadata(ctx context.Context, sourcePath str
 }
 
 func (d *chunkedVectorDB) Close() error {
-	return sqliteutil.CheckpointAndClose(d.db)
+	return sqliteutil.CheckpointAndClose(d.ctx(), d.db)
 }

--- a/pkg/rag/strategy/semantic_embeddings.go
+++ b/pkg/rag/strategy/semantic_embeddings.go
@@ -506,6 +506,7 @@ func calculateSemanticUsageCost(modelsStore modelStore, id modelsdev.ID, usage *
 		return 0
 	}
 
+	//rubocop:disable Lint/ContextConnectivity
 	model, err := modelsStore.GetModel(context.Background(), id)
 	if err != nil {
 		slog.Debug("Failed to get semantic model pricing from models.dev, cost will be 0",

--- a/pkg/rag/strategy/semantic_embeddings.go
+++ b/pkg/rag/strategy/semantic_embeddings.go
@@ -129,7 +129,7 @@ func NewSemanticEmbeddingsFromConfig(ctx context.Context, cfg latest.RAGStrategy
 	}
 
 	// Create semantic vector database (includes embedding_input column for debugging)
-	db, err := newSemanticVectorDB(dbPath, vectorDimensions, strategyName)
+	db, err := newSemanticVectorDB(ctx, dbPath, vectorDimensions, strategyName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create database: %w", err)
 	}

--- a/pkg/rag/strategy/semantic_embeddings.go
+++ b/pkg/rag/strategy/semantic_embeddings.go
@@ -145,7 +145,6 @@ func NewSemanticEmbeddingsFromConfig(ctx context.Context, cfg latest.RAGStrategy
 
 	// Create vector store
 	store := NewVectorStore(VectorStoreConfig{
-		Context:              func() context.Context { return context.WithoutCancel(ctx) },
 		Name:                 strategyName,
 		Database:             db,
 		Embedder:             embedder,

--- a/pkg/rag/strategy/semantic_embeddings.go
+++ b/pkg/rag/strategy/semantic_embeddings.go
@@ -145,6 +145,7 @@ func NewSemanticEmbeddingsFromConfig(ctx context.Context, cfg latest.RAGStrategy
 
 	// Create vector store
 	store := NewVectorStore(VectorStoreConfig{
+		Context:              func() context.Context { return context.WithoutCancel(ctx) },
 		Name:                 strategyName,
 		Database:             db,
 		Embedder:             embedder,
@@ -173,7 +174,7 @@ func NewSemanticEmbeddingsFromConfig(ctx context.Context, cfg latest.RAGStrategy
 			return
 		}
 
-		cost := calculateSemanticUsageCost(embeddingCfg.ModelsStore, chatModelID, usage)
+		cost := calculateSemanticUsageCost(context.WithoutCancel(ctx), embeddingCfg.ModelsStore, chatModelID, usage)
 		store.RecordUsage(totalTokens, cost)
 	}
 
@@ -501,15 +502,14 @@ func humanizeMetadataKey(key string) string {
 }
 
 // calculateSemanticUsageCost calculates cost for semantic LLM usage.
-func calculateSemanticUsageCost(modelsStore modelStore, id modelsdev.ID, usage *chat.Usage) float64 {
+func calculateSemanticUsageCost(ctx context.Context, modelsStore modelStore, id modelsdev.ID, usage *chat.Usage) float64 {
 	if usage == nil || modelsStore == nil || !id.IsValid() || id.Provider == "dmr" {
 		return 0
 	}
 
-	//rubocop:disable Lint/ContextConnectivity
-	model, err := modelsStore.GetModel(context.Background(), id)
+	model, err := modelsStore.GetModel(ctx, id)
 	if err != nil {
-		slog.Debug("Failed to get semantic model pricing from models.dev, cost will be 0",
+		slog.DebugContext(ctx, "Failed to get semantic model pricing from models.dev, cost will be 0",
 			"model_id", id.String(),
 			"error", err)
 		return 0

--- a/pkg/rag/strategy/semantic_embeddings_database.go
+++ b/pkg/rag/strategy/semantic_embeddings_database.go
@@ -80,11 +80,13 @@ func (d *semanticVectorDB) createSchema() error {
 	);
 	`, d.filesTable, d.tablePrefix, d.filesTable, d.chunksTable, d.filesTable)
 
+	//rubocop:disable Lint/ContextConnectivity
 	if _, err := d.db.ExecContext(context.Background(), schema); err != nil {
 		return err
 	}
 
 	// Migration for existing databases that don't have embedding_input column
+	//rubocop:disable Lint/ContextConnectivity
 	_, _ = d.db.ExecContext(context.Background(), fmt.Sprintf(`ALTER TABLE %s ADD COLUMN embedding_input TEXT`, d.chunksTable))
 
 	return nil

--- a/pkg/rag/strategy/semantic_embeddings_database.go
+++ b/pkg/rag/strategy/semantic_embeddings_database.go
@@ -19,6 +19,7 @@ import (
 // summary (embedding_input) for debugging what text produced the embedding.
 type semanticVectorDB struct {
 	db               *sql.DB
+	ctx              func() context.Context
 	vectorDimensions int
 	tablePrefix      string
 	filesTable       string
@@ -26,12 +27,12 @@ type semanticVectorDB struct {
 }
 
 // newSemanticVectorDB creates a new SQLite database for semantic embeddings.
-func newSemanticVectorDB(dbPath string, vectorDimensions int, strategyName string) (*semanticVectorDB, error) {
+func newSemanticVectorDB(ctx context.Context, dbPath string, vectorDimensions int, strategyName string) (*semanticVectorDB, error) {
 	if err := ensureDir(dbPath); err != nil {
 		return nil, fmt.Errorf("failed to create database directory: %w", err)
 	}
 
-	db, err := sqliteutil.OpenDB(dbPath)
+	db, err := sqliteutil.OpenDB(ctx, dbPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
@@ -40,18 +41,19 @@ func newSemanticVectorDB(dbPath string, vectorDimensions int, strategyName strin
 
 	sdb := &semanticVectorDB{
 		db:               db,
+		ctx:              func() context.Context { return context.WithoutCancel(ctx) },
 		vectorDimensions: vectorDimensions,
 		tablePrefix:      tablePrefix,
 		filesTable:       tablePrefix + "_files",
 		chunksTable:      tablePrefix + "_chunks",
 	}
 
-	if err := sdb.createSchema(); err != nil {
+	if err := sdb.createSchema(ctx); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("failed to create schema: %w", err)
 	}
 
-	slog.Info("Semantic vector database initialized",
+	slog.InfoContext(ctx, "Semantic vector database initialized",
 		"vector_dimensions", vectorDimensions,
 		"path", dbPath,
 		"table_prefix", tablePrefix)
@@ -59,7 +61,7 @@ func newSemanticVectorDB(dbPath string, vectorDimensions int, strategyName strin
 	return sdb, nil
 }
 
-func (d *semanticVectorDB) createSchema() error {
+func (d *semanticVectorDB) createSchema(ctx context.Context) error {
 	schema := fmt.Sprintf( //nolint:gosec // table names are internal, no user input
 		`
 	CREATE TABLE IF NOT EXISTS %s (
@@ -80,14 +82,11 @@ func (d *semanticVectorDB) createSchema() error {
 	);
 	`, d.filesTable, d.tablePrefix, d.filesTable, d.chunksTable, d.filesTable)
 
-	//rubocop:disable Lint/ContextConnectivity
-	if _, err := d.db.ExecContext(context.Background(), schema); err != nil {
+	if _, err := d.db.ExecContext(ctx, schema); err != nil {
 		return err
 	}
 
-	// Migration for existing databases that don't have embedding_input column
-	//rubocop:disable Lint/ContextConnectivity
-	_, _ = d.db.ExecContext(context.Background(), fmt.Sprintf(`ALTER TABLE %s ADD COLUMN embedding_input TEXT`, d.chunksTable))
+	_, _ = d.db.ExecContext(ctx, fmt.Sprintf(`ALTER TABLE %s ADD COLUMN embedding_input TEXT`, d.chunksTable))
 
 	return nil
 }
@@ -258,5 +257,5 @@ func (d *semanticVectorDB) DeleteFileMetadata(ctx context.Context, sourcePath st
 }
 
 func (d *semanticVectorDB) Close() error {
-	return sqliteutil.CheckpointAndClose(d.db)
+	return sqliteutil.CheckpointAndClose(d.ctx(), d.db)
 }

--- a/pkg/rag/strategy/vector_store.go
+++ b/pkg/rag/strategy/vector_store.go
@@ -572,7 +572,7 @@ func (s *VectorStore) indexFile(ctx context.Context, filePath string) error {
 		return fmt.Errorf("failed to delete old documents: %w", err)
 	}
 
-	chunks, err := chunk.ProcessFile(s.docProcessor, filePath)
+	chunks, err := chunk.ProcessFile(ctx, s.docProcessor, filePath)
 	if err != nil {
 		return fmt.Errorf("failed to process file: %w", err)
 	}

--- a/pkg/rag/strategy/vector_store.go
+++ b/pkg/rag/strategy/vector_store.go
@@ -152,6 +152,12 @@ func NewVectorStore(cfg VectorStoreConfig) *VectorStore {
 	// Set usage handler to calculate cost from models.dev and emit events with CUMULATIVE totals
 	// This matches how chat completions calculate cost in runtime.go
 	costCtx := cfg.Context
+	if costCtx == nil {
+		// Backward-compatible fallback for callers that construct VectorStoreConfig
+		// without a context provider.
+		//rubocop:disable Lint/ContextConnectivity
+		costCtx = context.Background
+	}
 	cfg.Embedder.SetUsageHandler(func(tokens int64, _ float64) {
 		cost := s.calculateCost(costCtx(), tokens)
 		s.recordUsage(tokens, cost)

--- a/pkg/rag/strategy/vector_store.go
+++ b/pkg/rag/strategy/vector_store.go
@@ -175,6 +175,7 @@ func (s *VectorStore) calculateCost(tokens int64) float64 {
 		return 0
 	}
 
+	//rubocop:disable Lint/ContextConnectivity
 	model, err := s.modelsStore.GetModel(context.Background(), s.modelID)
 	if err != nil {
 		slog.Debug("Failed to get model pricing from models.dev, cost will be 0",

--- a/pkg/rag/strategy/vector_store.go
+++ b/pkg/rag/strategy/vector_store.go
@@ -109,7 +109,6 @@ func (d DefaultEmbeddingInputBuilder) BuildEmbeddingInput(_ context.Context, _ s
 
 // VectorStoreConfig holds configuration for creating a VectorStore.
 type VectorStoreConfig struct {
-	Context              func() context.Context
 	Name                 string
 	Database             vectorStoreDB
 	Embedder             *embed.Embedder
@@ -151,15 +150,8 @@ func NewVectorStore(cfg VectorStoreConfig) *VectorStore {
 
 	// Set usage handler to calculate cost from models.dev and emit events with CUMULATIVE totals
 	// This matches how chat completions calculate cost in runtime.go
-	costCtx := cfg.Context
-	if costCtx == nil {
-		// Backward-compatible fallback for callers that construct VectorStoreConfig
-		// without a context provider.
-		//rubocop:disable Lint/ContextConnectivity
-		costCtx = context.Background
-	}
-	cfg.Embedder.SetUsageHandler(func(tokens int64, _ float64) {
-		cost := s.calculateCost(costCtx(), tokens)
+	cfg.Embedder.SetUsageHandler(func(ctx context.Context, tokens int64, _ float64) {
+		cost := s.calculateCost(ctx, tokens)
 		s.recordUsage(tokens, cost)
 	})
 

--- a/pkg/rag/strategy/vector_store.go
+++ b/pkg/rag/strategy/vector_store.go
@@ -109,6 +109,7 @@ func (d DefaultEmbeddingInputBuilder) BuildEmbeddingInput(_ context.Context, _ s
 
 // VectorStoreConfig holds configuration for creating a VectorStore.
 type VectorStoreConfig struct {
+	Context              func() context.Context
 	Name                 string
 	Database             vectorStoreDB
 	Embedder             *embed.Embedder
@@ -150,8 +151,9 @@ func NewVectorStore(cfg VectorStoreConfig) *VectorStore {
 
 	// Set usage handler to calculate cost from models.dev and emit events with CUMULATIVE totals
 	// This matches how chat completions calculate cost in runtime.go
+	costCtx := cfg.Context
 	cfg.Embedder.SetUsageHandler(func(tokens int64, _ float64) {
-		cost := s.calculateCost(tokens)
+		cost := s.calculateCost(costCtx(), tokens)
 		s.recordUsage(tokens, cost)
 	})
 
@@ -170,15 +172,14 @@ func (s *VectorStore) SetEmbeddingInputBuilder(builder EmbeddingInputBuilder) {
 }
 
 // calculateCost calculates embedding cost using models.dev pricing
-func (s *VectorStore) calculateCost(tokens int64) float64 {
+func (s *VectorStore) calculateCost(ctx context.Context, tokens int64) float64 {
 	if s.modelsStore == nil || s.modelID.Provider == "dmr" {
 		return 0
 	}
 
-	//rubocop:disable Lint/ContextConnectivity
-	model, err := s.modelsStore.GetModel(context.Background(), s.modelID)
+	model, err := s.modelsStore.GetModel(ctx, s.modelID)
 	if err != nil {
-		slog.Debug("Failed to get model pricing from models.dev, cost will be 0",
+		slog.DebugContext(ctx, "Failed to get model pricing from models.dev, cost will be 0",
 			"model_id", s.modelID.String(),
 			"error", err)
 		return 0

--- a/pkg/rag/strategy/vector_store_test.go
+++ b/pkg/rag/strategy/vector_store_test.go
@@ -142,7 +142,6 @@ func newTestVectorStore(t *testing.T, embedErr error) (*VectorStore, *fakeEmbedd
 
 	fake := &fakeEmbeddingProvider{err: embedErr}
 	store := NewVectorStore(VectorStoreConfig{
-		Context:              t.Context,
 		Name:                 "test",
 		Database:             newFakeVectorDB(),
 		Embedder:             embed.New(fake),

--- a/pkg/rag/strategy/vector_store_test.go
+++ b/pkg/rag/strategy/vector_store_test.go
@@ -142,6 +142,7 @@ func newTestVectorStore(t *testing.T, embedErr error) (*VectorStore, *fakeEmbedd
 
 	fake := &fakeEmbeddingProvider{err: embedErr}
 	store := NewVectorStore(VectorStoreConfig{
+		Context:              t.Context,
 		Name:                 "test",
 		Database:             newFakeVectorDB(),
 		Embedder:             embed.New(fake),

--- a/pkg/rag/treesitter/treesitter.go
+++ b/pkg/rag/treesitter/treesitter.go
@@ -59,8 +59,8 @@ func NewDocumentProcessor(chunkSize, chunkOverlap int, respectWordBoundaries boo
 }
 
 // Process implements chunk.DocumentProcessor.
-func (p *DocumentProcessor) Process(path string, content []byte) ([]chunk.Chunk, error) {
-	slog.Debug("[TreeSitter] Starting to process file",
+func (p *DocumentProcessor) Process(ctx context.Context, path string, content []byte) ([]chunk.Chunk, error) {
+	slog.DebugContext(ctx, "[TreeSitter] Starting to process file",
 		"path", path,
 		"content_size", len(content),
 		"chunk_size", p.chunkSize,
@@ -69,13 +69,13 @@ func (p *DocumentProcessor) Process(path string, content []byte) ([]chunk.Chunk,
 	ext := strings.ToLower(filepath.Ext(path))
 	lang, ok := p.langByExt[ext]
 	if !ok {
-		slog.Debug("[TreeSitter] Unsupported file extension, falling back to text chunking",
+		slog.DebugContext(ctx, "[TreeSitter] Unsupported file extension, falling back to text chunking",
 			"path", path,
 			"extension", ext)
-		return p.textFallback.Process(path, content)
+		return p.textFallback.Process(ctx, path, content)
 	}
 
-	slog.Debug("[TreeSitter] Language detected",
+	slog.DebugContext(ctx, "[TreeSitter] Language detected",
 		"path", path,
 		"extension", ext)
 
@@ -83,30 +83,29 @@ func (p *DocumentProcessor) Process(path string, content []byte) ([]chunk.Chunk,
 	parser := sitter.NewParser()
 	parser.SetLanguage(lang)
 
-	slog.Debug("[TreeSitter] Parsing source code with tree-sitter",
+	slog.DebugContext(ctx, "[TreeSitter] Parsing source code with tree-sitter",
 		"path", path)
 
 	// Use ParseCtx instead of deprecated Parse
-	//rubocop:disable Lint/ContextConnectivity
-	tree, err := parser.ParseCtx(context.Background(), nil, content)
+	tree, err := parser.ParseCtx(ctx, nil, content)
 	if err != nil || tree == nil || tree.RootNode() == nil {
-		slog.Debug("[TreeSitter] Parsing failed, falling back to text chunking",
+		slog.DebugContext(ctx, "[TreeSitter] Parsing failed, falling back to text chunking",
 			"path", path,
 			"error", err)
-		return p.textFallback.Process(path, content)
+		return p.textFallback.Process(ctx, path, content)
 	}
 
-	slog.Debug("[TreeSitter] Successfully parsed source code",
+	slog.DebugContext(ctx, "[TreeSitter] Successfully parsed source code",
 		"path", path)
 
 	root := tree.RootNode()
 	packageName := extractPackageName(root, content)
 	fnFilter, ok := p.functionNode[ext]
 	if !ok {
-		slog.Debug("[TreeSitter] No function filter defined for extension, falling back to text chunking",
+		slog.DebugContext(ctx, "[TreeSitter] No function filter defined for extension, falling back to text chunking",
 			"path", path,
 			"extension", ext)
-		return p.textFallback.Process(path, content)
+		return p.textFallback.Process(ctx, path, content)
 	}
 
 	// Extract function-like nodes.
@@ -127,15 +126,15 @@ func (p *DocumentProcessor) Process(path string, content []byte) ([]chunk.Chunk,
 	}
 	walk(root)
 
-	slog.Debug("[TreeSitter] Extracted function nodes from syntax tree",
+	slog.DebugContext(ctx, "[TreeSitter] Extracted function nodes from syntax tree",
 		"path", path,
 		"function_count", len(funcNodes))
 
 	// If we didn't find any function-like nodes, fall back to text chunking.
 	if len(funcNodes) == 0 {
-		slog.Debug("[TreeSitter] No function nodes found, falling back to text chunking",
+		slog.DebugContext(ctx, "[TreeSitter] No function nodes found, falling back to text chunking",
 			"path", path)
-		return p.textFallback.Process(path, content)
+		return p.textFallback.Process(ctx, path, content)
 	}
 
 	// Group functions into chunks under the size budget where possible, without
@@ -163,7 +162,7 @@ func (p *DocumentProcessor) Process(path string, content []byte) ([]chunk.Chunk,
 			Content:  c,
 			Metadata: buildChunkMetadata(chunkFunctions),
 		})
-		slog.Debug("[TreeSitter] Created code-aware chunk",
+		slog.DebugContext(ctx, "[TreeSitter] Created code-aware chunk",
 			"chunk_index", index,
 			"chunk_content", c)
 		index++
@@ -177,7 +176,7 @@ func (p *DocumentProcessor) Process(path string, content []byte) ([]chunk.Chunk,
 		start := int(findPrecedingComments(fn, content))
 		end := int(fn.EndByte())
 		if start < 0 || end <= start || end > len(text) {
-			slog.Debug("[TreeSitter] Skipping function node with invalid byte range",
+			slog.DebugContext(ctx, "[TreeSitter] Skipping function node with invalid byte range",
 				"path", path,
 				"function_index", funcIdx,
 				"start_byte", start,
@@ -187,7 +186,7 @@ func (p *DocumentProcessor) Process(path string, content []byte) ([]chunk.Chunk,
 
 		fnText := strings.TrimSpace(text[start:end])
 		if fnText == "" {
-			slog.Debug("[TreeSitter] Skipping empty function node",
+			slog.DebugContext(ctx, "[TreeSitter] Skipping empty function node",
 				"path", path,
 				"function_index", funcIdx)
 			continue
@@ -202,7 +201,7 @@ func (p *DocumentProcessor) Process(path string, content []byte) ([]chunk.Chunk,
 			docText = string(content[start:funcStart])
 		}
 
-		slog.Debug("[TreeSitter] Processing function node",
+		slog.DebugContext(ctx, "[TreeSitter] Processing function node",
 			"path", path,
 			"function_index", funcIdx,
 			"function_type", fnType,
@@ -213,7 +212,7 @@ func (p *DocumentProcessor) Process(path string, content []byte) ([]chunk.Chunk,
 		// If the function alone is larger than chunkSize, emit it as its own
 		// chunk to avoid splitting function bodies.
 		if p.chunkSize > 0 && fnLen > p.chunkSize {
-			slog.Debug("[TreeSitter] Function exceeds chunk size, creating dedicated chunk",
+			slog.DebugContext(ctx, "[TreeSitter] Function exceeds chunk size, creating dedicated chunk",
 				"path", path,
 				"function_index", funcIdx,
 				"function_length", fnLen,
@@ -226,7 +225,7 @@ func (p *DocumentProcessor) Process(path string, content []byte) ([]chunk.Chunk,
 				Content:  fnText,
 				Metadata: buildChunkMetadata([]functionMetadata{meta}),
 			})
-			slog.Debug("[TreeSitter] Created code-aware chunk for large function",
+			slog.DebugContext(ctx, "[TreeSitter] Created code-aware chunk for large function",
 				"chunk_index", index,
 				"chunk_content", fnText)
 			index++
@@ -235,7 +234,7 @@ func (p *DocumentProcessor) Process(path string, content []byte) ([]chunk.Chunk,
 
 		// If adding this function would exceed the budget, flush and start new.
 		if p.chunkSize > 0 && currentLen > 0 && currentLen+fnLen > p.chunkSize {
-			slog.Debug("[TreeSitter] Adding function would exceed chunk size, flushing current chunk",
+			slog.DebugContext(ctx, "[TreeSitter] Adding function would exceed chunk size, flushing current chunk",
 				"path", path,
 				"function_index", funcIdx,
 				"current_chunk_length", currentLen,
@@ -246,7 +245,7 @@ func (p *DocumentProcessor) Process(path string, content []byte) ([]chunk.Chunk,
 			flush()
 		}
 
-		slog.Debug("[TreeSitter] Adding function to current chunk",
+		slog.DebugContext(ctx, "[TreeSitter] Adding function to current chunk",
 			"path", path,
 			"function_index", funcIdx,
 			"function_length", fnLen,
@@ -263,9 +262,9 @@ func (p *DocumentProcessor) Process(path string, content []byte) ([]chunk.Chunk,
 	flush()
 
 	if len(chunksOut) == 0 {
-		slog.Debug("[TreeSitter] No chunks produced after processing, falling back to text chunking",
+		slog.DebugContext(ctx, "[TreeSitter] No chunks produced after processing, falling back to text chunking",
 			"path", path)
-		return p.textFallback.Process(path, content)
+		return p.textFallback.Process(ctx, path, content)
 	}
 
 	// Calculate statistics
@@ -287,7 +286,7 @@ func (p *DocumentProcessor) Process(path string, content []byte) ([]chunk.Chunk,
 		avgChunkSize = totalChars / len(chunksOut)
 	}
 
-	slog.Debug("[TreeSitter] Successfully chunked file using syntax tree",
+	slog.DebugContext(ctx, "[TreeSitter] Successfully chunked file using syntax tree",
 		"path", path,
 		"total_functions", len(funcNodes),
 		"total_chunks", len(chunksOut),

--- a/pkg/rag/treesitter/treesitter.go
+++ b/pkg/rag/treesitter/treesitter.go
@@ -87,6 +87,7 @@ func (p *DocumentProcessor) Process(path string, content []byte) ([]chunk.Chunk,
 		"path", path)
 
 	// Use ParseCtx instead of deprecated Parse
+	//rubocop:disable Lint/ContextConnectivity
 	tree, err := parser.ParseCtx(context.Background(), nil, content)
 	if err != nil || tree == nil || tree.RootNode() == nil {
 		slog.Debug("[TreeSitter] Parsing failed, falling back to text chunking",

--- a/pkg/rag/treesitter/treesitter_nocgo.go
+++ b/pkg/rag/treesitter/treesitter_nocgo.go
@@ -3,6 +3,7 @@
 package treesitter
 
 import (
+	"context"
 	"errors"
 
 	"github.com/docker/docker-agent/pkg/rag/chunk"
@@ -19,6 +20,6 @@ func NewDocumentProcessor(_, _ int, _ bool) *DocumentProcessor {
 }
 
 // Process implements chunk.DocumentProcessor.
-func (p *DocumentProcessor) Process(_ string, _ []byte) ([]chunk.Chunk, error) {
+func (p *DocumentProcessor) Process(context.Context, string, []byte) ([]chunk.Chunk, error) {
 	return nil, errors.New("rag/treesitter: document processor must be built with CGO_ENABLED=1")
 }

--- a/pkg/rag/treesitter/treesitter_test.go
+++ b/pkg/rag/treesitter/treesitter_test.go
@@ -20,7 +20,7 @@ func (c *Calculator) Add(a, b int) int {
 }
 `)
 
-	chunks, err := processor.Process("calc.go", content)
+	chunks, err := processor.Process(t.Context(), "calc.go", content)
 	require.NoError(t, err)
 	require.Len(t, chunks, 1)
 
@@ -54,7 +54,7 @@ func Subtract(a, b int) int {
 `)
 
 	// Use small chunk size to force separate chunks
-	chunks, err := processor.Process("test.go", content)
+	chunks, err := processor.Process(t.Context(), "test.go", content)
 	require.NoError(t, err)
 	require.Len(t, chunks, 2, "Expected 2 chunks (one per function)")
 
@@ -78,7 +78,7 @@ func Multiply(a, b int) int {
 }
 `)
 
-	chunks, err := processor.Process("test.go", content)
+	chunks, err := processor.Process(t.Context(), "test.go", content)
 	require.NoError(t, err)
 	require.Len(t, chunks, 1)
 
@@ -100,7 +100,7 @@ func (c Calculator) Calculate(a, b int) int {
 }
 `)
 
-	chunks, err := processor.Process("test.go", content)
+	chunks, err := processor.Process(t.Context(), "test.go", content)
 	require.NoError(t, err)
 	require.Len(t, chunks, 1)
 
@@ -125,7 +125,7 @@ func Divide(a, b int) (int, error) {
 }
 `)
 
-	chunks, err := processor.Process("test.go", content)
+	chunks, err := processor.Process(t.Context(), "test.go", content)
 	require.NoError(t, err)
 	require.Len(t, chunks, 1)
 
@@ -151,7 +151,7 @@ func Process() {
 }
 `)
 
-	chunks, err := processor.Process("test.go", content)
+	chunks, err := processor.Process(t.Context(), "test.go", content)
 	require.NoError(t, err)
 	require.Len(t, chunks, 1)
 
@@ -172,7 +172,7 @@ func Handler() {
 }
 `)
 
-	chunks, err := processor.Process("test.go", content)
+	chunks, err := processor.Process(t.Context(), "test.go", content)
 	require.NoError(t, err)
 	require.Len(t, chunks, 1)
 
@@ -205,7 +205,7 @@ func Third() {
 `)
 
 	// Use small chunk size to force separate chunks
-	chunks, err := processor.Process("test.go", content)
+	chunks, err := processor.Process(t.Context(), "test.go", content)
 	require.NoError(t, err)
 	require.Len(t, chunks, 3)
 
@@ -240,7 +240,7 @@ func Another(x int) int {
 `)
 
 	// Set a small chunk size to force separate chunks
-	chunks, err := processor.Process("test.go", content)
+	chunks, err := processor.Process(t.Context(), "test.go", content)
 	require.NoError(t, err)
 
 	// With a small chunk size, functions should be in separate chunks
@@ -269,7 +269,7 @@ func ProcessData() {
 `)
 
 	// Set chunk size smaller than the function
-	chunks, err := processor.Process("test.go", content)
+	chunks, err := processor.Process(t.Context(), "test.go", content)
 	require.NoError(t, err)
 	require.Len(t, chunks, 1, "Large function should be in its own chunk despite exceeding limit")
 
@@ -284,7 +284,7 @@ func TestTreeSitterPreProcessor_UnsupportedExtension(t *testing.T) {
 	content := []byte(`console.log("hello");`)
 
 	// For unsupported extensions, it falls back to text chunking
-	chunks, err := processor.Process("test.js", content)
+	chunks, err := processor.Process(t.Context(), "test.js", content)
 	require.NoError(t, err)
 	// Text fallback should produce chunks
 	require.NotNil(t, chunks)
@@ -296,7 +296,7 @@ func TestTreeSitterPreProcessor_EmptyFile(t *testing.T) {
 
 	content := []byte(`package main`)
 
-	chunks, err := processor.Process("test.go", content)
+	chunks, err := processor.Process(t.Context(), "test.go", content)
 	require.NoError(t, err)
 	// Falls back to text chunking for files with no functions
 	require.NotEmpty(t, chunks)
@@ -316,7 +316,7 @@ func BlockCommented() {
 }
 `)
 
-	chunks, err := processor.Process("test.go", content)
+	chunks, err := processor.Process(t.Context(), "test.go", content)
 	require.NoError(t, err)
 	require.Len(t, chunks, 1)
 
@@ -348,7 +348,7 @@ func C() int {
 `)
 
 	// Large chunk size should group all functions together
-	chunks, err := processor.Process("test.go", content)
+	chunks, err := processor.Process(t.Context(), "test.go", content)
 	require.NoError(t, err)
 	require.Len(t, chunks, 1, "Expected all small functions to be grouped in one chunk")
 

--- a/pkg/recording/recording.go
+++ b/pkg/recording/recording.go
@@ -2,6 +2,7 @@
 package recording
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -13,7 +14,7 @@ import (
 // SetupFakeProxy starts a fake proxy if fakeResponses is non-empty.
 // streamDelayMs controls simulated streaming: 0 = disabled, >0 = delay in milliseconds between chunks.
 // It returns the proxy URL and a cleanup function that must be called when done (typically via defer).
-func SetupFakeProxy(fakeResponses string, streamDelayMs int) (proxyURL string, cleanup func() error, err error) {
+func SetupFakeProxy(ctx context.Context, fakeResponses string, streamDelayMs int) (proxyURL string, cleanup func() error, err error) {
 	if fakeResponses == "" {
 		return "", noop, nil
 	}
@@ -29,12 +30,12 @@ func SetupFakeProxy(fakeResponses string, streamDelayMs int) (proxyURL string, c
 		)
 	}
 
-	proxyURL, cleanupFn, err := fake.StartProxy(fakeResponses, opts...)
+	proxyURL, cleanupFn, err := fake.StartProxy(ctx, fakeResponses, opts...)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to start fake proxy: %w", err)
 	}
 
-	slog.Info("Fake mode enabled", "cassette", fakeResponses, "proxy", proxyURL)
+	slog.InfoContext(ctx, "Fake mode enabled", "cassette", fakeResponses, "proxy", proxyURL)
 
 	return proxyURL, cleanupFn, nil
 }
@@ -44,7 +45,7 @@ func SetupFakeProxy(fakeResponses string, streamDelayMs int) (proxyURL string, c
 // and normalizes the path by stripping any .yaml suffix.
 // Returns the cassette path (with .yaml extension), the proxy URL, and a cleanup function.
 // The cleanup function must be called when done (typically via defer).
-func SetupRecordingProxy(recordPath string) (cassettePath, proxyURL string, cleanup func() error, err error) {
+func SetupRecordingProxy(ctx context.Context, recordPath string) (cassettePath, proxyURL string, cleanup func() error, err error) {
 	if recordPath == "" {
 		return "", "", noop, nil
 	}
@@ -56,14 +57,14 @@ func SetupRecordingProxy(recordPath string) (cassettePath, proxyURL string, clea
 		recordPath = strings.TrimSuffix(recordPath, ".yaml")
 	}
 
-	proxyURL, cleanupFn, err := fake.StartRecordingProxy(recordPath)
+	proxyURL, cleanupFn, err := fake.StartRecordingProxy(ctx, recordPath)
 	if err != nil {
 		return "", "", nil, fmt.Errorf("failed to start recording proxy: %w", err)
 	}
 
 	cassettePath = recordPath + ".yaml"
 
-	slog.Info("Recording mode enabled", "cassette", cassettePath, "proxy", proxyURL)
+	slog.InfoContext(ctx, "Recording mode enabled", "cassette", cassettePath, "proxy", proxyURL)
 
 	return cassettePath, proxyURL, cleanupFn, nil
 }

--- a/pkg/remote/transport.go
+++ b/pkg/remote/transport.go
@@ -28,6 +28,7 @@ func NewTransport(ctx context.Context) http.RoundTripper {
 	transport := t.Clone()
 
 	desktopRunning, err := memoizer.Memoize("desktopRunning", func() (bool, error) {
+		//rubocop:disable Lint/ContextConnectivity
 		return desktop.IsDockerDesktopRunning(context.Background()), nil
 	})
 	if err != nil {

--- a/pkg/remote/transport.go
+++ b/pkg/remote/transport.go
@@ -28,8 +28,10 @@ func NewTransport(ctx context.Context) http.RoundTripper {
 	transport := t.Clone()
 
 	desktopRunning, err := memoizer.Memoize("desktopRunning", func() (bool, error) {
-		//rubocop:disable Lint/ContextConnectivity
-		return desktop.IsDockerDesktopRunning(context.Background()), nil
+		// Memoized once per process: detach the first caller's cancellation
+		// (so a cancelled caller can't poison the cached result) while keeping
+		// its trace context.
+		return desktop.IsDockerDesktopRunning(context.WithoutCancel(ctx)), nil
 	})
 	if err != nil {
 		return transport

--- a/pkg/runtime/after_llm_call_test.go
+++ b/pkg/runtime/after_llm_call_test.go
@@ -123,7 +123,7 @@ func captureAfterLLMCall(t *testing.T, store ModelStore) (*hooks.Input, *session
 	)
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm,
+	rt, err := NewLocalRuntime(t.Context(), tm,
 		WithSessionCompaction(false),
 		WithModelStore(store),
 	)
@@ -279,7 +279,7 @@ printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":120,"output_toke
 			AfterLLMCall: []latest.HookDefinition{{Type: "builtin", Command: hookName}},
 		}),
 	)
-	rt, err := NewLocalRuntime(team.New(team.WithAgents(root)),
+	rt, err := NewLocalRuntime(t.Context(), team.New(team.WithAgents(root)),
 		WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 

--- a/pkg/runtime/after_llm_call_test.go
+++ b/pkg/runtime/after_llm_call_test.go
@@ -67,7 +67,7 @@ func TestAfterLLMCallHook_PopulatesModelID(t *testing.T) {
 	)
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm,
+	rt, err := NewLocalRuntime(t.Context(), tm,
 		WithSessionCompaction(false),
 		WithModelStore(mockModelStore{}),
 	)

--- a/pkg/runtime/agent_delegation.go
+++ b/pkg/runtime/agent_delegation.go
@@ -235,12 +235,12 @@ func (r *LocalRuntime) swapCurrentAgent(ctx context.Context, sessionID string, f
 	evts.Emit(AgentSwitching(true, from.Name(), to.Name()))
 	r.executeOnAgentSwitchHooks(ctx, from, sessionID, from.Name(), to.Name(), agentSwitchKindTransferTask)
 	r.setCurrentAgent(to.Name())
-	evts.Emit(AgentInfo(to.Name(), agentModelLabel(to), to.Description(), to.WelcomeMessage()))
+	evts.Emit(AgentInfo(to.Name(), agentModelLabel(ctx, to), to.Description(), to.WelcomeMessage()))
 	return func() {
 		r.setCurrentAgent(from.Name())
 		evts.Emit(AgentSwitching(false, to.Name(), from.Name()))
 		r.executeOnAgentSwitchHooks(ctx, from, sessionID, to.Name(), from.Name(), agentSwitchKindTransferTaskReturn)
-		evts.Emit(AgentInfo(from.Name(), agentModelLabel(from), from.Description(), from.WelcomeMessage()))
+		evts.Emit(AgentInfo(from.Name(), agentModelLabel(ctx, from), from.Description(), from.WelcomeMessage()))
 	}
 }
 

--- a/pkg/runtime/agent_delegation.go
+++ b/pkg/runtime/agent_delegation.go
@@ -265,7 +265,7 @@ func (r *LocalRuntime) swapCurrentAgent(ctx context.Context, sessionID string, f
 func (r *LocalRuntime) runForwarding(ctx context.Context, parent *session.Session, evts EventSink, req delegationRequest) (*tools.ToolCallResult, error) {
 	span := trace.SpanFromContext(ctx)
 
-	callerAgent, err := r.team.Agent(r.CurrentAgentName())
+	callerAgent, err := r.team.Agent(r.currentAgentName())
 	if err != nil {
 		return nil, fmt.Errorf("current agent not found: %w", err)
 	}
@@ -558,7 +558,7 @@ func (r *LocalRuntime) handleHandoff(ctx context.Context, sess *session.Session,
 		return nil, fmt.Errorf("invalid arguments: %w", err)
 	}
 
-	ca := r.CurrentAgentName()
+	ca := r.currentAgentName()
 	currentAgent, err := r.team.Agent(ca)
 	if err != nil {
 		return nil, fmt.Errorf("current agent not found: %w", err)

--- a/pkg/runtime/agent_inspector_test.go
+++ b/pkg/runtime/agent_inspector_test.go
@@ -114,7 +114,7 @@ func TestAgentConfigInfo_Inspector(t *testing.T) {
 	started := root.ToolSets()[0].(*tools.StartableToolSet)
 	require.NoError(t, started.Start(ctx))
 
-	got := r.AgentConfigInfo("root")
+	got := r.AgentConfigInfo(t.Context(), "root")
 
 	assert.Equal(t, []string{"coder"}, got.SubAgents)
 	assert.Equal(t, []string{"planner"}, got.Handoffs)
@@ -154,9 +154,9 @@ func TestAgentConfigInfo_Degrades(t *testing.T) {
 
 	r := &LocalRuntime{team: tm, agents: newAgentRouter(tm, "root")}
 
-	assert.Equal(t, AgentConfigInfo{}, r.AgentConfigInfo("missing"), "unknown agent -> zero value")
+	assert.Equal(t, AgentConfigInfo{}, r.AgentConfigInfo(t.Context(), "missing"), "unknown agent -> zero value")
 
-	got := r.AgentConfigInfo("other")
+	got := r.AgentConfigInfo(t.Context(), "other")
 	assert.False(t, got.IsCurrent, "non-current agent")
 	assert.Nil(t, got.Skills, "no skills without retained config")
 	assert.Nil(t, got.Options, "no enabled options")

--- a/pkg/runtime/before_llm_call_test.go
+++ b/pkg/runtime/before_llm_call_test.go
@@ -53,7 +53,7 @@ func TestBeforeLLMCallHookFiresOncePerLoopIteration(t *testing.T) {
 	)
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm,
+	rt, err := NewLocalRuntime(t.Context(), tm,
 		WithSessionCompaction(false),
 		WithModelStore(mockModelStore{}),
 	)
@@ -147,7 +147,7 @@ func TestMaxIterationsBuiltin_TripsAfterConfiguredLimit(t *testing.T) {
 	)
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm,
+	rt, err := NewLocalRuntime(t.Context(), tm,
 		WithSessionCompaction(false),
 		WithModelStore(mockModelStore{}),
 	)
@@ -231,7 +231,7 @@ func TestMaxIterationsBuiltin_NoOpOnInvalidLimit(t *testing.T) {
 			)
 			tm := team.New(team.WithAgents(root))
 
-			rt, err := NewLocalRuntime(tm,
+			rt, err := NewLocalRuntime(t.Context(), tm,
 				WithSessionCompaction(false),
 				WithModelStore(mockModelStore{}),
 			)

--- a/pkg/runtime/cache_test.go
+++ b/pkg/runtime/cache_test.go
@@ -24,7 +24,7 @@ func runWithCache(t *testing.T, c *cache.Cache, prov *messageRecordingProvider, 
 	)
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 	sess.Title = "cache test"
 
@@ -161,7 +161,7 @@ func TestCache_StorageIsAStopHookBuiltin(t *testing.T) {
 	)
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	// The runtime should have auto-injected a stop hook of type=builtin

--- a/pkg/runtime/clock_test.go
+++ b/pkg/runtime/clock_test.go
@@ -33,7 +33,7 @@ func TestWithClock_AppliedToRuntime(t *testing.T) {
 	fixed := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
 	clock := newFakeClock(fixed)
 
-	rt, err := NewLocalRuntime(tm,
+	rt, err := NewLocalRuntime(t.Context(), tm,
 		WithClock(clock.Now),
 		WithModelStore(mockModelStore{}),
 	)
@@ -49,7 +49,7 @@ func TestWithClock_NilLeavesDefault(t *testing.T) {
 	root := agent.New("root", "test", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm,
+	rt, err := NewLocalRuntime(t.Context(), tm,
 		WithClock(nil),
 		WithModelStore(mockModelStore{}),
 	)
@@ -68,7 +68,7 @@ func TestFallbackCooldown_UsesInjectedClock(t *testing.T) {
 	tm := team.New(team.WithAgents(root))
 
 	clock := newFakeClock(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
-	rt, err := NewLocalRuntime(tm,
+	rt, err := NewLocalRuntime(t.Context(), tm,
 		WithClock(clock.Now),
 		WithModelStore(mockModelStore{}),
 	)

--- a/pkg/runtime/close_test.go
+++ b/pkg/runtime/close_test.go
@@ -35,7 +35,7 @@ func TestRuntimeClose_DoesNotCloseExternalSessionStore(t *testing.T) {
 	root := agent.New("root", "You are a test agent", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := New(tm,
+	rt, err := New(t.Context(), tm,
 		WithSessionCompaction(false),
 		WithModelStore(mockModelStore{}),
 		WithSessionStore(store),

--- a/pkg/runtime/commands_test.go
+++ b/pkg/runtime/commands_test.go
@@ -75,13 +75,13 @@ func (m *mockRuntime) ExecuteMCPPrompt(context.Context, string, map[string]strin
 func (m *mockRuntime) UpdateSessionTitle(context.Context, *session.Session, string) error {
 	return nil
 }
-func (m *mockRuntime) TitleGenerator() *sessiontitle.Generator             { return nil }
-func (m *mockRuntime) Close() error                                        { return nil }
-func (m *mockRuntime) Steer(context.Context, QueuedMessage) error          { return nil }
-func (m *mockRuntime) FollowUp(context.Context, QueuedMessage) error       { return nil }
-func (m *mockRuntime) QueueStatus() QueueStatus                            { return QueueStatus{} }
-func (m *mockRuntime) TogglePause(context.Context) (bool, error)           { return false, nil }
-func (m *mockRuntime) SetAgentModel(context.Context, string, string) error { return nil }
+func (m *mockRuntime) TitleGenerator(context.Context) *sessiontitle.Generator { return nil }
+func (m *mockRuntime) Close() error                                           { return nil }
+func (m *mockRuntime) Steer(context.Context, QueuedMessage) error             { return nil }
+func (m *mockRuntime) FollowUp(context.Context, QueuedMessage) error          { return nil }
+func (m *mockRuntime) QueueStatus() QueueStatus                               { return QueueStatus{} }
+func (m *mockRuntime) TogglePause(context.Context) (bool, error)              { return false, nil }
+func (m *mockRuntime) SetAgentModel(context.Context, string, string) error    { return nil }
 func (m *mockRuntime) CycleAgentThinkingLevel(context.Context, string) (effort.Level, error) {
 	return "", ErrUnsupported
 }

--- a/pkg/runtime/commands_test.go
+++ b/pkg/runtime/commands_test.go
@@ -24,7 +24,7 @@ type mockRuntime struct {
 func (m *mockRuntime) CurrentAgentTools(context.Context) ([]tools.Tool, error) {
 	return m.tools, nil
 }
-func (m *mockRuntime) CurrentAgentName() string                           { return "test" }
+func (m *mockRuntime) CurrentAgentName(context.Context) string            { return "test" }
 func (m *mockRuntime) CurrentAgentToolsetStatuses() []tools.ToolsetStatus { return nil }
 func (m *mockRuntime) RestartToolset(context.Context, string) error       { return nil }
 func (m *mockRuntime) CurrentAgentInfo(context.Context) CurrentAgentInfo {
@@ -35,7 +35,7 @@ func (m *mockRuntime) CurrentAgentInfo(context.Context) CurrentAgentInfo {
 	}
 }
 
-func (m *mockRuntime) SetCurrentAgent(string) error {
+func (m *mockRuntime) SetCurrentAgent(context.Context, string) error {
 	return nil
 }
 func (m *mockRuntime) EmitStartupInfo(context.Context, *session.Session, EventSink) {}
@@ -77,8 +77,8 @@ func (m *mockRuntime) UpdateSessionTitle(context.Context, *session.Session, stri
 }
 func (m *mockRuntime) TitleGenerator() *sessiontitle.Generator             { return nil }
 func (m *mockRuntime) Close() error                                        { return nil }
-func (m *mockRuntime) Steer(QueuedMessage) error                           { return nil }
-func (m *mockRuntime) FollowUp(QueuedMessage) error                        { return nil }
+func (m *mockRuntime) Steer(context.Context, QueuedMessage) error          { return nil }
+func (m *mockRuntime) FollowUp(context.Context, QueuedMessage) error       { return nil }
 func (m *mockRuntime) QueueStatus() QueueStatus                            { return QueueStatus{} }
 func (m *mockRuntime) TogglePause(context.Context) (bool, error)           { return false, nil }
 func (m *mockRuntime) SetAgentModel(context.Context, string, string) error { return nil }

--- a/pkg/runtime/compaction_context_limit_test.go
+++ b/pkg/runtime/compaction_context_limit_test.go
@@ -114,7 +114,7 @@ func TestCompactionContextLimit_FallsBackToProviderOpts(t *testing.T) {
 	root := agent.New("root", "test", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithModelStore(errorModelStore{err: errors.New("not in catalogue")}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithModelStore(errorModelStore{err: errors.New("not in catalogue")}))
 	require.NoError(t, err)
 
 	got := rt.compactionContextLimit(t.Context(), root)
@@ -138,7 +138,7 @@ func TestCompactionContextLimit_PrefersProviderOpts(t *testing.T) {
 	root := agent.New("root", "test", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithModelStore(mockModelStoreWithLimit{limit: 200_000}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithModelStore(mockModelStoreWithLimit{limit: 200_000}))
 	require.NoError(t, err)
 
 	got := rt.compactionContextLimit(t.Context(), root)
@@ -156,7 +156,7 @@ func TestCompactionContextLimit_FallsBackToCatalogue(t *testing.T) {
 	root := agent.New("root", "test", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithModelStore(mockModelStoreWithLimit{limit: 200_000}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithModelStore(mockModelStoreWithLimit{limit: 200_000}))
 	require.NoError(t, err)
 
 	got := rt.compactionContextLimit(t.Context(), root)
@@ -174,7 +174,7 @@ func TestCompactionContextLimit_NoSourcesYieldsZero(t *testing.T) {
 	root := agent.New("root", "test", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	got := rt.compactionContextLimit(t.Context(), root)

--- a/pkg/runtime/compaction_trigger_test.go
+++ b/pkg/runtime/compaction_trigger_test.go
@@ -28,7 +28,7 @@ func TestCompactIfNeeded_IgnoresSubSessionTokens(t *testing.T) {
 	root := agent.New("root", "agent", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm,
+	rt, err := NewLocalRuntime(t.Context(), tm,
 		WithSessionCompaction(true),
 		WithModelStore(mockModelStoreWithLimit{limit: 100_000}))
 	require.NoError(t, err)
@@ -74,7 +74,7 @@ func TestCompactIfNeeded_TriggersOnOwnMessages(t *testing.T) {
 	root := agent.New("root", "agent", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm,
+	rt, err := NewLocalRuntime(t.Context(), tm,
 		WithSessionCompaction(true),
 		WithModelStore(mockModelStoreWithLimit{limit: 100_000}))
 	require.NoError(t, err)

--- a/pkg/runtime/contract_test.go
+++ b/pkg/runtime/contract_test.go
@@ -135,7 +135,7 @@ func TestLocalRuntime_Contract(t *testing.T) {
 		root := agent.New("root", "You are a test agent", agent.WithModel(prov))
 		tm := team.New(team.WithAgents(root))
 
-		rt, err := New(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+		rt, err := New(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 		require.NoError(t, err)
 		return rt
 	})

--- a/pkg/runtime/contract_test.go
+++ b/pkg/runtime/contract_test.go
@@ -24,20 +24,20 @@ func runRuntimeContract(t *testing.T, newRT func(t *testing.T) Runtime) {
 	t.Run("CurrentAgentName not empty", func(t *testing.T) {
 		rt := newRT(t)
 		t.Cleanup(func() { _ = rt.Close() })
-		assert.NotEmpty(t, rt.CurrentAgentName())
+		assert.NotEmpty(t, rt.CurrentAgentName(t.Context()))
 	})
 
 	t.Run("CurrentAgentInfo carries the current name", func(t *testing.T) {
 		rt := newRT(t)
 		t.Cleanup(func() { _ = rt.Close() })
 		info := rt.CurrentAgentInfo(t.Context())
-		assert.Equal(t, rt.CurrentAgentName(), info.Name)
+		assert.Equal(t, rt.CurrentAgentName(t.Context()), info.Name)
 	})
 
 	t.Run("SetCurrentAgent rejects unknown agents", func(t *testing.T) {
 		rt := newRT(t)
 		t.Cleanup(func() { _ = rt.Close() })
-		err := rt.SetCurrentAgent("nonexistent-agent")
+		err := rt.SetCurrentAgent(t.Context(), "nonexistent-agent")
 		assert.Error(t, err)
 	})
 
@@ -80,7 +80,7 @@ func runRuntimeContract(t *testing.T, newRT func(t *testing.T) Runtime) {
 	t.Run("Steer accepts a message", func(t *testing.T) {
 		rt := newRT(t)
 		t.Cleanup(func() { _ = rt.Close() })
-		err := rt.Steer(QueuedMessage{Content: "hello"})
+		err := rt.Steer(t.Context(), QueuedMessage{Content: "hello"})
 		if err != nil {
 			assert.ErrorIs(t, err, ErrUnsupported, "unexpected error type: %v", err)
 		}
@@ -89,7 +89,7 @@ func runRuntimeContract(t *testing.T, newRT func(t *testing.T) Runtime) {
 	t.Run("FollowUp accepts a message", func(t *testing.T) {
 		rt := newRT(t)
 		t.Cleanup(func() { _ = rt.Close() })
-		err := rt.FollowUp(QueuedMessage{Content: "hello"})
+		err := rt.FollowUp(t.Context(), QueuedMessage{Content: "hello"})
 		if err != nil {
 			assert.ErrorIs(t, err, ErrUnsupported, "unexpected error type: %v", err)
 		}

--- a/pkg/runtime/elicitation.go
+++ b/pkg/runtime/elicitation.go
@@ -114,7 +114,7 @@ func (b *elicitationBridge) restoreAndClose(current, previous chan Event) {
 // elicitation request. Returns an error if no elicitation is in progress
 // or if the context is cancelled before the response can be delivered.
 func (r *LocalRuntime) ResumeElicitation(ctx context.Context, action tools.ElicitationAction, content map[string]any) error {
-	slog.DebugContext(ctx, "Resuming runtime with elicitation response", "agent", r.CurrentAgentName(), "action", action)
+	slog.DebugContext(ctx, "Resuming runtime with elicitation response", "agent", r.currentAgentName(), "action", action)
 
 	result := ElicitationResult{
 		Action:  action,
@@ -160,7 +160,7 @@ func (r *LocalRuntime) elicitationHandler(ctx context.Context, req *mcp.ElicitPa
 	slog.DebugContext(ctx, "Elicitation request meta", "meta", req.Meta)
 
 	if err := r.elicitation.send(
-		ElicitationRequest(req.Message, req.Mode, req.RequestedSchema, req.URL, req.ElicitationID, req.Meta, r.CurrentAgentName()),
+		ElicitationRequest(req.Message, req.Mode, req.RequestedSchema, req.URL, req.ElicitationID, req.Meta, r.currentAgentName()),
 	); err != nil {
 		return tools.ElicitationResult{}, err
 	}

--- a/pkg/runtime/elicitation_test.go
+++ b/pkg/runtime/elicitation_test.go
@@ -305,7 +305,7 @@ func TestRunStreamClosesChannelAndRestoresElicitationOnEarlyReturn(t *testing.T)
 			},
 		}),
 	)
-	rt, err := NewLocalRuntime(team.New(team.WithAgents(root)),
+	rt, err := NewLocalRuntime(t.Context(), team.New(team.WithAgents(root)),
 		WithSessionCompaction(false),
 		WithModelStore(mockModelStore{}),
 	)
@@ -350,7 +350,7 @@ func newElicitationTestRuntime(t *testing.T) *LocalRuntime {
 
 	prov := &mockProvider{id: "test/mock-model"}
 	root := agent.New("root", "test", agent.WithModel(prov))
-	rt, err := NewLocalRuntime(team.New(team.WithAgents(root)), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), team.New(team.WithAgents(root)), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 	return rt
 }

--- a/pkg/runtime/fallback_test.go
+++ b/pkg/runtime/fallback_test.go
@@ -113,7 +113,7 @@ func TestFallbackOrder(t *testing.T) {
 		)
 
 		tm := team.New(team.WithAgents(root))
-		rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+		rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 		require.NoError(t, err)
 
 		sess := session.New(session.WithUserMessage("test"))
@@ -144,7 +144,7 @@ func TestFallbackNoRetryOnNonRetryableError(t *testing.T) {
 		)
 
 		tm := team.New(team.WithAgents(root))
-		rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+		rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 		require.NoError(t, err)
 
 		sess := session.New(session.WithUserMessage("test"))
@@ -182,7 +182,7 @@ func TestFallbackRetriesWithBackoff(t *testing.T) {
 		)
 
 		tm := team.New(team.WithAgents(root))
-		rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+		rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 		require.NoError(t, err)
 
 		sess := session.New(session.WithUserMessage("test"))
@@ -222,7 +222,7 @@ func TestPrimaryRetriesWithBackoff(t *testing.T) {
 		)
 
 		tm := team.New(team.WithAgents(root))
-		rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+		rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 		require.NoError(t, err)
 
 		sess := session.New(session.WithUserMessage("test"))
@@ -259,7 +259,7 @@ func TestNoFallbackWhenPrimarySucceeds(t *testing.T) {
 		)
 
 		tm := team.New(team.WithAgents(root))
-		rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+		rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 		require.NoError(t, err)
 
 		sess := session.New(session.WithUserMessage("test"))
@@ -301,7 +301,7 @@ func TestFallback429SkipsToNextModel(t *testing.T) {
 		)
 
 		tm := team.New(team.WithAgents(root))
-		rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+		rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 		require.NoError(t, err)
 
 		sess := session.New(session.WithUserMessage("test"))
@@ -324,7 +324,7 @@ func TestFallbackCooldownState(t *testing.T) {
 		tm := team.New(team.WithAgents(
 			agent.New("test-agent", "test instruction", agent.WithModel(mockModel)),
 		))
-		rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+		rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 		require.NoError(t, err)
 
 		agentName := "test-agent"
@@ -401,7 +401,7 @@ func TestFallback429WithFallbacksSkipsToNextModel(t *testing.T) {
 		)
 
 		tm := team.New(team.WithAgents(root))
-		rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+		rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 		require.NoError(t, err)
 
 		sess := session.New(session.WithUserMessage("test"))
@@ -440,7 +440,7 @@ func TestFallback429WithoutFallbacksRetriesSameModel(t *testing.T) {
 		)
 
 		tm := team.New(team.WithAgents(root))
-		rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}), WithRetryOnRateLimit())
+		rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}), WithRetryOnRateLimit())
 		require.NoError(t, err)
 
 		sess := session.New(session.WithUserMessage("test"))
@@ -472,7 +472,7 @@ func TestFallback429WithoutFallbacksExhaustsRetries(t *testing.T) {
 		)
 
 		tm := team.New(team.WithAgents(root))
-		rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}), WithRetryOnRateLimit())
+		rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}), WithRetryOnRateLimit())
 		require.NoError(t, err)
 
 		sess := session.New(session.WithUserMessage("test"))
@@ -509,7 +509,7 @@ func TestFallback500RetryableWithBackoff(t *testing.T) {
 		)
 
 		tm := team.New(team.WithAgents(root))
-		rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+		rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 		require.NoError(t, err)
 
 		sess := session.New(session.WithUserMessage("test"))
@@ -546,7 +546,7 @@ func TestRateLimitGate_DisabledNoFallbacks_FailsImmediately(t *testing.T) {
 
 		tm := team.New(team.WithAgents(root))
 		// Note: WithRetryOnRateLimit() is NOT passed — default off
-		rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+		rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 		require.NoError(t, err)
 
 		sess := session.New(session.WithUserMessage("test"))
@@ -585,7 +585,7 @@ func TestRateLimitGate_EnabledNoFallbacks_RetriesSameModel(t *testing.T) {
 		)
 
 		tm := team.New(team.WithAgents(root))
-		rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}), WithRetryOnRateLimit())
+		rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}), WithRetryOnRateLimit())
 		require.NoError(t, err)
 
 		sess := session.New(session.WithUserMessage("test"))
@@ -625,7 +625,7 @@ func TestRateLimitGate_EnabledWithFallbacks_SkipsToFallback(t *testing.T) {
 
 		tm := team.New(team.WithAgents(root))
 		// opt-in is enabled, but fallbacks are present → should still skip to fallback
-		rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}), WithRetryOnRateLimit())
+		rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}), WithRetryOnRateLimit())
 		require.NoError(t, err)
 
 		sess := session.New(session.WithUserMessage("test"))

--- a/pkg/runtime/force_handoff_test.go
+++ b/pkg/runtime/force_handoff_test.go
@@ -59,7 +59,7 @@ func forceHandoffTeam(t *testing.T, rootStream, summarizerStream *mockStream) (*
 	root := agent.New("root", "You extract", agent.WithModel(rootProv), agent.WithForceHandoff(summarizer))
 	tm := team.New(team.WithAgents(root, summarizer))
 
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 	return rt, sumProv
 }

--- a/pkg/runtime/force_handoff_test.go
+++ b/pkg/runtime/force_handoff_test.go
@@ -90,7 +90,7 @@ func TestForceHandoff_RoutesToTargetOnNaturalStop(t *testing.T) {
 		require.False(t, isErr, "unexpected error event: %+v", errEv)
 	}
 
-	assert.Equal(t, "summarizer", rt.CurrentAgentName(), "current agent must be the force_handoff target after the run")
+	assert.Equal(t, "summarizer", rt.CurrentAgentName(t.Context()), "current agent must be the force_handoff target after the run")
 	assert.Equal(t, 1, sumProv.handoffCallCount(), "target agent's model must be invoked exactly once")
 	assert.Equal(t, "final summary", sess.GetLastAssistantMessageContent())
 
@@ -140,6 +140,6 @@ func TestForceHandoff_SkippedForPinnedSession(t *testing.T) {
 	}
 
 	assert.Equal(t, 0, sumProv.handoffCallCount(), "force_handoff target must not run for pinned sessions")
-	assert.Equal(t, "root", rt.CurrentAgentName())
+	assert.Equal(t, "root", rt.CurrentAgentName(t.Context()))
 	assert.Equal(t, "done", sess.GetLastAssistantMessageContent())
 }

--- a/pkg/runtime/harness.go
+++ b/pkg/runtime/harness.go
@@ -34,7 +34,7 @@ func (r *LocalRuntime) runHarnessAgent(ctx context.Context, sess *session.Sessio
 		return turnEndReasonError
 	}
 
-	modelID := agentModelLabel(a)
+	modelID := agentModelLabel(ctx, a)
 	events.Emit(AgentInfo(a.Name(), modelID, a.Description(), a.WelcomeMessage()))
 
 	endReason := turnEndReasonNormal
@@ -211,14 +211,14 @@ func (r *LocalRuntime) runHarnessAgent(ctx context.Context, sess *session.Sessio
 	return endReason
 }
 
-func agentModelLabel(a *agent.Agent) string {
+func agentModelLabel(ctx context.Context, a *agent.Agent) string {
 	if a == nil {
 		return ""
 	}
 	if a.HasHarness() {
 		return codingharness.Label(a.Harness())
 	}
-	return getAgentModelID(a).String()
+	return getAgentModelID(ctx, a).String()
 }
 
 func traceAttributesForHarness(sess *session.Session, a *agent.Agent) []attribute.KeyValue {

--- a/pkg/runtime/harness_test.go
+++ b/pkg/runtime/harness_test.go
@@ -175,7 +175,7 @@ func writeHarnessScript(t *testing.T, dir, name, content string) {
 func newHarnessRuntime(t *testing.T, harnessType string) *LocalRuntime {
 	t.Helper()
 	root := agent.New("root", "You are an external coder.", agent.WithHarness(&latest.HarnessConfig{Type: harnessType}))
-	rt, err := NewLocalRuntime(team.New(team.WithAgents(root)), WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), team.New(team.WithAgents(root)), WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 	return rt
 }

--- a/pkg/runtime/hooks_wiring_test.go
+++ b/pkg/runtime/hooks_wiring_test.go
@@ -78,7 +78,7 @@ func TestHooksExecWiresAgentFlagsToBuiltins(t *testing.T) {
 
 			a := agent.New("root", "instructions", tc.opts...)
 			tm := team.New(team.WithAgents(a))
-			r, err := NewLocalRuntime(tm, WithModelStore(mockModelStore{}))
+			r, err := NewLocalRuntime(t.Context(), tm, WithModelStore(mockModelStore{}))
 			require.NoError(t, err)
 
 			exec := r.hooksExec(a)
@@ -134,7 +134,7 @@ func TestModelHookFactoryIsRegistered(t *testing.T) {
 	prov := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
 	a := agent.New("root", "instructions", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(a))
-	r, err := NewLocalRuntime(tm, WithModelStore(mockModelStore{}))
+	r, err := NewLocalRuntime(t.Context(), tm, WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	factory, ok := r.hooksRegistry.Lookup(hooks.HookTypeModel)

--- a/pkg/runtime/lazy_model_store_test.go
+++ b/pkg/runtime/lazy_model_store_test.go
@@ -29,7 +29,7 @@ func TestNewLocalRuntime_DefaultsToLazyModelStore(t *testing.T) {
 	root := agent.New("root", "test", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm)
+	rt, err := NewLocalRuntime(t.Context(), tm)
 	require.NoError(t, err)
 
 	_, ok := rt.modelsStore.(*lazyModelStore)
@@ -47,7 +47,7 @@ func TestNewLocalRuntime_WithModelStoreSkipsLazyDefault(t *testing.T) {
 	tm := team.New(team.WithAgents(root))
 
 	stub := mockModelStore{}
-	rt, err := NewLocalRuntime(tm, WithModelStore(stub))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithModelStore(stub))
 	require.NoError(t, err)
 
 	assert.Equal(t, stub, rt.modelsStore)

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -216,7 +216,7 @@ func (r *LocalRuntime) finalizeEventChannel(ctx context.Context, sess *session.S
 // the response, executes any tool calls, and loops until the model signals stop
 // or the iteration limit is reached.
 func (r *LocalRuntime) RunStream(ctx context.Context, sess *session.Session) <-chan Event {
-	slog.DebugContext(ctx, "Starting runtime stream", "agent", r.CurrentAgentName(), "session_id", sess.ID)
+	slog.DebugContext(ctx, "Starting runtime stream", "agent", r.currentAgentName(), "session_id", sess.ID)
 	events := make(chan Event, defaultEventChannelCapacity)
 
 	go r.runStreamLoop(ctx, sess, events)
@@ -234,7 +234,7 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 	// back to the originating session. Plumbing happens in
 	// pkg/httpclient/userAgentTransport, gated on `X-Cagent-Forward`.
 	ctx = httpclient.ContextWithSessionID(ctx, sess.ID)
-	r.telemetry.RecordSessionStart(ctx, r.CurrentAgentName(), sess.ID)
+	r.telemetry.RecordSessionStart(ctx, r.currentAgentName(), sess.ID)
 
 	// Seed `gen_ai.conversation.id` into baggage at the session
 	// boundary. Every span the runtime, providers, MCP client, RAG,
@@ -268,11 +268,11 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 	// OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental.
 	sessionAttrs := []attribute.KeyValue{
 		attribute.String(genai.AttrConversationID, sess.ID),
-		attribute.String(genai.AttrAgentNameRuntime, r.CurrentAgentName()),
+		attribute.String(genai.AttrAgentNameRuntime, r.currentAgentName()),
 	}
 	if genai.EmitLegacyAttributes() {
 		sessionAttrs = append(sessionAttrs,
-			attribute.String("agent", r.CurrentAgentName()),
+			attribute.String("agent", r.currentAgentName()),
 			attribute.String("session.id", sess.ID),
 		)
 	}

--- a/pkg/runtime/loop_steps_test.go
+++ b/pkg/runtime/loop_steps_test.go
@@ -36,7 +36,7 @@ func newTestRuntime(t *testing.T) (*LocalRuntime, *agent.Agent) {
 	prov := &mockProvider{id: "test/mock-model"}
 	root := agent.New("root", "test", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
-	rt, err := NewLocalRuntime(tm, WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 	return rt, root
 }
@@ -192,7 +192,7 @@ func TestHandleStreamError_OverflowWithCompactionEnabled_Retries(t *testing.T) {
 	prov := &mockProvider{id: "test/mock-model"}
 	root := agent.New("root", "test", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
-	rt, err := NewLocalRuntime(tm, WithModelStore(errModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithModelStore(errModelStore{}))
 	require.NoError(t, err)
 
 	sess := session.New()
@@ -251,7 +251,7 @@ func TestHandleStreamError_OverflowWithCompactionDisabled_Fatal(t *testing.T) {
 	prov := &mockProvider{id: "test/mock-model"}
 	root := agent.New("root", "test", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
-	rt, err := NewLocalRuntime(tm,
+	rt, err := NewLocalRuntime(t.Context(), tm,
 		WithSessionCompaction(false),
 		WithModelStore(mockModelStore{}),
 	)

--- a/pkg/runtime/model_picker.go
+++ b/pkg/runtime/model_picker.go
@@ -71,7 +71,7 @@ func (r *LocalRuntime) setModelAndEmitInfo(ctx context.Context, modelRef string,
 	}
 
 	if a, err := r.team.Agent(currentName); err == nil {
-		events.Emit(AgentInfo(a.Name(), r.getEffectiveModelID(a).String(), a.Description(), a.WelcomeMessage()))
+		events.Emit(AgentInfo(a.Name(), r.getEffectiveModelID(ctx, a).String(), a.Description(), a.WelcomeMessage()))
 	} else {
 		slog.WarnContext(ctx, "Failed to retrieve agent after model change; UI may not reflect the update", "agent", currentName, "error", err)
 	}

--- a/pkg/runtime/model_picker.go
+++ b/pkg/runtime/model_picker.go
@@ -16,7 +16,7 @@ import (
 // findModelPickerTool returns the Tool from the current agent's
 // toolsets, or nil if the agent has no model_picker configured.
 func (r *LocalRuntime) findModelPickerTool() *modelpicker.ToolSet {
-	currentName := r.CurrentAgentName()
+	currentName := r.currentAgentName()
 	a, err := r.team.Agent(currentName)
 	if err != nil {
 		return nil
@@ -65,7 +65,7 @@ func (r *LocalRuntime) handleRevertModel(ctx context.Context, _ *session.Session
 // AgentInfo event so the UI reflects the change. An empty modelRef reverts to
 // the agent's default model.
 func (r *LocalRuntime) setModelAndEmitInfo(ctx context.Context, modelRef string, events EventSink) (*tools.ToolCallResult, error) {
-	currentName := r.CurrentAgentName()
+	currentName := r.currentAgentName()
 	if err := r.SetAgentModel(ctx, currentName, modelRef); err != nil {
 		return tools.ResultError(fmt.Sprintf("failed to set model: %v", err)), nil
 	}

--- a/pkg/runtime/model_switcher.go
+++ b/pkg/runtime/model_switcher.go
@@ -480,7 +480,7 @@ func (r *LocalRuntime) AvailableModels(ctx context.Context) []ModelChoice {
 	// Get the current agent's default model reference
 	currentAgentDefault := ""
 	if r.modelSwitcherCfg.AgentDefaultModels != nil {
-		currentAgentDefault = r.modelSwitcherCfg.AgentDefaultModels[r.CurrentAgentName()]
+		currentAgentDefault = r.modelSwitcherCfg.AgentDefaultModels[r.currentAgentName()]
 	}
 
 	var choices []ModelChoice

--- a/pkg/runtime/oauth_noninteractive_test.go
+++ b/pkg/runtime/oauth_noninteractive_test.go
@@ -65,7 +65,7 @@ func TestRunStream_NonInteractiveSessionDisablesInteractivePrompts(t *testing.T)
 			stream: newStreamBuilder().AddContent("ok").AddStopWithUsage(1, 1).Build(),
 		}
 		root := agent.New("root", "test", agent.WithModel(prov), agent.WithToolSets(probe))
-		rt, err := NewLocalRuntime(team.New(team.WithAgents(root)),
+		rt, err := NewLocalRuntime(t.Context(), team.New(team.WithAgents(root)),
 			WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 		require.NoError(t, err)
 
@@ -186,7 +186,7 @@ func TestRunAgent_BackgroundOAuthMCP_FailsFastAndNotifiesModel(t *testing.T) {
 	// Interactive runtime: r.nonInteractive is false. Only the background
 	// sub-session is non-interactive — exactly the issue #3200 setup where the
 	// runtime-level check at elicitationHandler does not save us.
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	sess := session.New(session.WithUserMessage("Test"), session.WithToolsApproved(true))

--- a/pkg/runtime/observer_test.go
+++ b/pkg/runtime/observer_test.go
@@ -60,7 +60,7 @@ func runtimeWithObserver(t *testing.T, obs EventObserver) (*LocalRuntime, *sessi
 	a := agent.New("root", "instructions", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(a))
 
-	r, err := NewLocalRuntime(tm,
+	r, err := NewLocalRuntime(t.Context(), tm,
 		WithModelStore(mockModelStore{}),
 		WithSessionCompaction(false),
 		WithEventObserver(obs),
@@ -142,7 +142,7 @@ func TestObserver_MultipleObserversFireInRegistrationOrder(t *testing.T) {
 	a := agent.New("root", "instructions", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(a))
 
-	r, err := NewLocalRuntime(tm,
+	r, err := NewLocalRuntime(t.Context(), tm,
 		WithModelStore(mockModelStore{}),
 		WithSessionCompaction(false),
 		WithEventObserver(tag("first")),
@@ -175,7 +175,7 @@ func TestObserver_NilOptIsIgnored(t *testing.T) {
 	a := agent.New("root", "instructions", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(a))
 
-	r, err := NewLocalRuntime(tm,
+	r, err := NewLocalRuntime(t.Context(), tm,
 		WithModelStore(mockModelStore{}),
 		WithEventObserver(nil),
 	)

--- a/pkg/runtime/on_agent_switch_test.go
+++ b/pkg/runtime/on_agent_switch_test.go
@@ -69,7 +69,7 @@ func runtimeWithRecordedAgentSwitch(t *testing.T, agentName string, opts ...agen
 	a := agent.New(agentName, "instructions", allOpts...)
 	tm := team.New(team.WithAgents(a))
 
-	r, err := NewLocalRuntime(tm, WithModelStore(mockModelStore{}))
+	r, err := NewLocalRuntime(t.Context(), tm, WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	// Register our recording builtin on the runtime's private registry
@@ -115,7 +115,7 @@ func TestExecuteOnAgentSwitchHooks_NoopWhenNoHookRegistered(t *testing.T) {
 	a := agent.New("root", "instructions", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(a))
 
-	r, err := NewLocalRuntime(tm, WithModelStore(mockModelStore{}))
+	r, err := NewLocalRuntime(t.Context(), tm, WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	// Should be a successful no-op rather than a panic or error.
@@ -166,7 +166,7 @@ func TestExecuteOnAgentSwitchHooks_PopulatesFromAgentModels(t *testing.T) {
 	to := agent.New("planner", "instructions", agent.WithModel(next))
 	tm := team.New(team.WithAgents(from, to))
 
-	r, err := NewLocalRuntime(tm, WithModelStore(mockModelStore{}))
+	r, err := NewLocalRuntime(t.Context(), tm, WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 	require.NoError(t, r.hooksRegistry.RegisterBuiltin("test_record_agent_switch", rb.hook))
 	r.buildHooksExecutors()

--- a/pkg/runtime/on_session_resume_test.go
+++ b/pkg/runtime/on_session_resume_test.go
@@ -32,7 +32,7 @@ func runtimeWithRecordedSessionResume(t *testing.T) (*LocalRuntime, *recordingBu
 	)
 	tm := team.New(team.WithAgents(a))
 
-	r, err := NewLocalRuntime(tm, WithModelStore(mockModelStore{}))
+	r, err := NewLocalRuntime(t.Context(), tm, WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	require.NoError(t, r.hooksRegistry.RegisterBuiltin("test_record_session_resume", rb.hook))
@@ -72,7 +72,7 @@ func TestExecuteOnSessionResumeHooks_NoopWhenNoHookRegistered(t *testing.T) {
 	a := agent.New("root", "instructions", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(a))
 
-	r, err := NewLocalRuntime(tm, WithModelStore(mockModelStore{}))
+	r, err := NewLocalRuntime(t.Context(), tm, WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	r.executeOnSessionResumeHooks(t.Context(), a, "s", 5, 15)

--- a/pkg/runtime/on_tool_approval_decision_test.go
+++ b/pkg/runtime/on_tool_approval_decision_test.go
@@ -34,7 +34,7 @@ func runtimeWithRecordedToolApproval(t *testing.T) (*LocalRuntime, *recordingBui
 	)
 	tm := team.New(team.WithAgents(a))
 
-	r, err := NewLocalRuntime(tm, WithModelStore(mockModelStore{}))
+	r, err := NewLocalRuntime(t.Context(), tm, WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	require.NoError(t, r.hooksRegistry.RegisterBuiltin("test_record_tool_approval", rb.hook))

--- a/pkg/runtime/overflow_compaction_test.go
+++ b/pkg/runtime/overflow_compaction_test.go
@@ -40,7 +40,7 @@ func TestWithMaxOverflowCompactions_Zero(t *testing.T) {
 	root := agent.New("root", "test", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm,
+	rt, err := NewLocalRuntime(t.Context(), tm,
 		WithSessionCompaction(true),
 		WithMaxOverflowCompactions(0),
 		WithModelStore(mockModelStoreWithLimit{limit: 100}),
@@ -61,7 +61,7 @@ func TestWithMaxOverflowCompactions_Negative(t *testing.T) {
 	root := agent.New("root", "test", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithMaxOverflowCompactions(-5))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithMaxOverflowCompactions(-5))
 	require.NoError(t, err)
 
 	require.Equal(t, 0, rt.maxOverflowCompactions, "negative caps should clamp to 0")
@@ -78,7 +78,7 @@ func TestWithMaxOverflowCompactions_Default(t *testing.T) {
 	root := agent.New("root", "test", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm,
+	rt, err := NewLocalRuntime(t.Context(), tm,
 		WithSessionCompaction(true),
 		WithModelStore(mockModelStoreWithLimit{limit: 100}),
 	)

--- a/pkg/runtime/pre_tool_use_approval_test.go
+++ b/pkg/runtime/pre_tool_use_approval_test.go
@@ -107,7 +107,7 @@ func makeJudgedRuntime(
 	tm := team.New(teamOpts...)
 
 	var err error
-	rt, err = NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err = NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 	require.NoError(t, rt.hooksRegistry.RegisterBuiltin(hookName, func(_ context.Context, in *hooks.Input, _ []string) (*hooks.Output, error) {
 		if in == nil || in.HookEventName != hooks.EventPreToolUse {
@@ -277,7 +277,7 @@ func TestPreToolUseHook_ReceivesAgentName(t *testing.T) {
 		agent.WithToolSets(newStubToolSet(nil, agentTools, nil)),
 		agent.WithHooks(preToolUseHooksConfig(hookName)),
 	)
-	rt, err := NewLocalRuntime(team.New(team.WithAgents(root)),
+	rt, err := NewLocalRuntime(t.Context(), team.New(team.WithAgents(root)),
 		WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 

--- a/pkg/runtime/rag.go
+++ b/pkg/runtime/rag.go
@@ -10,7 +10,7 @@ import (
 // ragEventForwarder returns a callback that converts RAG manager events to runtime events.
 func ragEventForwarder(ragName string, r *LocalRuntime, sendEvent func(Event)) ragtypes.EventCallback {
 	return func(ragEvent ragtypes.Event) {
-		agentName := r.CurrentAgentName()
+		agentName := r.currentAgentName()
 		slog.Debug("Forwarding RAG event", "type", ragEvent.Type, "rag", ragName, "agent", agentName)
 
 		switch ragEvent.Type {

--- a/pkg/runtime/remote_contract_test.go
+++ b/pkg/runtime/remote_contract_test.go
@@ -190,7 +190,7 @@ func TestRemoteRuntime_SetCurrentAgent_PropagatesClientError(t *testing.T) {
 	rt, err := NewRemoteRuntime(client)
 	require.NoError(t, err)
 
-	err = rt.SetCurrentAgent("anything")
+	err = rt.SetCurrentAgent(t.Context(), "anything")
 	require.Error(t, err)
 	require.ErrorIs(t, err, want)
 	assert.Empty(t, rt.currentAgent, "currentAgent must not be mutated when validation fails")

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -679,7 +679,7 @@ func (r *RemoteRuntime) ExecuteMCPPrompt(ctx context.Context, promptName string,
 }
 
 // TitleGenerator is not supported on remote runtimes (titles are generated server-side).
-func (r *RemoteRuntime) TitleGenerator() *sessiontitle.Generator {
+func (r *RemoteRuntime) TitleGenerator(context.Context) *sessiontitle.Generator {
 	return nil
 }
 

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -45,10 +45,10 @@ type RemoteRuntime struct {
 	pendingModelOverride string
 
 	// resolvedDefault caches the team's default agent name fetched from the
-	// server, so [CurrentAgentName] stays an O(1) field read after the first
-	// call when no specific agent has been selected.
-	resolvedDefault     string
-	resolvedDefaultOnce sync.Once
+	// server after a successful lookup, so [CurrentAgentName] stays an O(1)
+	// field read when no specific agent has been selected.
+	resolvedDefault   string
+	resolvedDefaultMu sync.Mutex
 }
 
 // RemoteRuntimeOption is a function for configuring the RemoteRuntime
@@ -105,12 +105,18 @@ func (r *RemoteRuntime) CurrentAgentName(ctx context.Context) string {
 	if r.currentAgent != "" {
 		return r.currentAgent
 	}
-	r.resolvedDefaultOnce.Do(func() {
-		// First call performs the remote lookup; detach cancellation so a
-		// cancelled caller cannot poison the cached default for everyone.
-		r.resolvedDefault, _ = r.resolvedAgent(context.WithoutCancel(ctx))
-	})
-	return r.resolvedDefault
+	r.resolvedDefaultMu.Lock()
+	defer r.resolvedDefaultMu.Unlock()
+	if r.resolvedDefault != "" {
+		return r.resolvedDefault
+	}
+	// First successful call performs and caches the remote lookup; detach
+	// cancellation so a cancelled caller cannot poison the cached default.
+	name, _ := r.resolvedAgent(context.WithoutCancel(ctx))
+	if name != "" {
+		r.resolvedDefault = name
+	}
+	return name
 }
 
 func (r *RemoteRuntime) CurrentAgentInfo(ctx context.Context) CurrentAgentInfo {

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -106,6 +106,7 @@ func (r *RemoteRuntime) CurrentAgentName() string {
 		return r.currentAgent
 	}
 	r.resolvedDefaultOnce.Do(func() {
+		//rubocop:disable Lint/ContextConnectivity
 		r.resolvedDefault, _ = r.resolvedAgent(context.Background())
 	})
 	return r.resolvedDefault
@@ -127,6 +128,7 @@ func (r *RemoteRuntime) CurrentAgentInfo(ctx context.Context) CurrentAgentInfo {
 // propagated rather than silently accepted — the whole point of this check
 // is closing that silent-breakage gap.
 func (r *RemoteRuntime) SetCurrentAgent(agentName string) error {
+	//rubocop:disable Lint/ContextConnectivity
 	cfg, err := r.client.GetAgent(context.Background(), r.agentFilename)
 	if err != nil {
 		return fmt.Errorf("validate agent %q against remote team: %w", agentName, err)
@@ -322,6 +324,7 @@ func (r *RemoteRuntime) Steer(msg QueuedMessage) error {
 	if r.sessionID == "" {
 		return errors.New("no active session")
 	}
+	//rubocop:disable Lint/ContextConnectivity
 	return r.client.SteerSession(context.Background(), r.sessionID, []api.Message{
 		{Content: msg.Content, MultiContent: msg.MultiContent},
 	})
@@ -332,6 +335,7 @@ func (r *RemoteRuntime) FollowUp(msg QueuedMessage) error {
 	if r.sessionID == "" {
 		return errors.New("no active session")
 	}
+	//rubocop:disable Lint/ContextConnectivity
 	return r.client.FollowUpSession(context.Background(), r.sessionID, []api.Message{
 		{Content: msg.Content, MultiContent: msg.MultiContent},
 	})
@@ -457,6 +461,7 @@ func (r *RemoteRuntime) handleOAuthElicitation(ctx context.Context, req *Elicita
 		return fmt.Errorf("failed to create callback server: %w", err)
 	}
 	defer func() {
+		//rubocop:disable Lint/ContextConnectivity
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer shutdownCancel()
 		if err := callbackServer.Shutdown(shutdownCtx); err != nil {

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -452,7 +452,7 @@ func (r *RemoteRuntime) handleOAuthElicitation(ctx context.Context, req *Elicita
 	defer cancel()
 
 	slog.DebugContext(ctx, "Creating OAuth callback server")
-	callbackServer, err := mcp.NewCallbackServer()
+	callbackServer, err := mcp.NewCallbackServer(ctx)
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to create callback server", "error", err)
 		_ = r.client.ResumeElicitation(ctx, r.sessionID, "decline", nil)

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -461,8 +461,9 @@ func (r *RemoteRuntime) handleOAuthElicitation(ctx context.Context, req *Elicita
 		return fmt.Errorf("failed to create callback server: %w", err)
 	}
 	defer func() {
-		//rubocop:disable Lint/ContextConnectivity
-		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		// Detach from ctx's cancellation (the request may be done) but
+		// keep its trace context for the shutdown.
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 		defer shutdownCancel()
 		if err := callbackServer.Shutdown(shutdownCtx); err != nil {
 			slog.ErrorContext(ctx, "Failed to shutdown callback server", "error", err)

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -101,13 +101,14 @@ func (r *RemoteRuntime) resolvedAgent(ctx context.Context) (string, latest.Agent
 // When no specific agent has been selected, it falls back to the first agent
 // declared by the remote team config. The remote lookup happens at most once;
 // the result is cached so subsequent calls are O(1).
-func (r *RemoteRuntime) CurrentAgentName() string {
+func (r *RemoteRuntime) CurrentAgentName(ctx context.Context) string {
 	if r.currentAgent != "" {
 		return r.currentAgent
 	}
 	r.resolvedDefaultOnce.Do(func() {
-		//rubocop:disable Lint/ContextConnectivity
-		r.resolvedDefault, _ = r.resolvedAgent(context.Background())
+		// First call performs the remote lookup; detach cancellation so a
+		// cancelled caller cannot poison the cached default for everyone.
+		r.resolvedDefault, _ = r.resolvedAgent(context.WithoutCancel(ctx))
 	})
 	return r.resolvedDefault
 }
@@ -127,9 +128,8 @@ func (r *RemoteRuntime) CurrentAgentInfo(ctx context.Context) CurrentAgentInfo {
 // fetch the team config (network error, auth failure, missing remote) is
 // propagated rather than silently accepted — the whole point of this check
 // is closing that silent-breakage gap.
-func (r *RemoteRuntime) SetCurrentAgent(agentName string) error {
-	//rubocop:disable Lint/ContextConnectivity
-	cfg, err := r.client.GetAgent(context.Background(), r.agentFilename)
+func (r *RemoteRuntime) SetCurrentAgent(ctx context.Context, agentName string) error {
+	cfg, err := r.client.GetAgent(ctx, r.agentFilename)
 	if err != nil {
 		return fmt.Errorf("validate agent %q against remote team: %w", agentName, err)
 	}
@@ -144,7 +144,7 @@ func (r *RemoteRuntime) SetCurrentAgent(agentName string) error {
 		return fmt.Errorf("agent %q not found in remote team", agentName)
 	}
 	r.currentAgent = agentName
-	slog.Debug("Switched current agent (remote)", "agent", agentName)
+	slog.DebugContext(ctx, "Switched current agent (remote)", "agent", agentName)
 	return nil
 }
 
@@ -320,23 +320,21 @@ func (r *RemoteRuntime) Run(ctx context.Context, sess *session.Session) ([]sessi
 
 // Steer enqueues a user message for mid-turn injection into the running
 // agent loop on the remote server.
-func (r *RemoteRuntime) Steer(msg QueuedMessage) error {
+func (r *RemoteRuntime) Steer(ctx context.Context, msg QueuedMessage) error {
 	if r.sessionID == "" {
 		return errors.New("no active session")
 	}
-	//rubocop:disable Lint/ContextConnectivity
-	return r.client.SteerSession(context.Background(), r.sessionID, []api.Message{
+	return r.client.SteerSession(ctx, r.sessionID, []api.Message{
 		{Content: msg.Content, MultiContent: msg.MultiContent},
 	})
 }
 
 // FollowUp enqueues a message for end-of-turn processing on the remote server.
-func (r *RemoteRuntime) FollowUp(msg QueuedMessage) error {
+func (r *RemoteRuntime) FollowUp(ctx context.Context, msg QueuedMessage) error {
 	if r.sessionID == "" {
 		return errors.New("no active session")
 	}
-	//rubocop:disable Lint/ContextConnectivity
-	return r.client.FollowUpSession(context.Background(), r.sessionID, []api.Message{
+	return r.client.FollowUpSession(ctx, r.sessionID, []api.Message{
 		{Content: msg.Content, MultiContent: msg.MultiContent},
 	})
 }

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -765,7 +765,7 @@ type AgentConfigInfo struct {
 // already-started toolsets (never starting one), so it is safe to call for any
 // agent whether or not it has run. Unknown agents yield the zero value, so the
 // modal omits the corresponding sections.
-func (r *LocalRuntime) AgentConfigInfo(agentName string) AgentConfigInfo {
+func (r *LocalRuntime) AgentConfigInfo(ctx context.Context, agentName string) AgentConfigInfo {
 	a, err := r.team.Agent(agentName)
 	if err != nil || a == nil {
 		return AgentConfigInfo{}
@@ -802,7 +802,7 @@ func (r *LocalRuntime) AgentConfigInfo(agentName string) AgentConfigInfo {
 		NumHistoryItems:         a.NumHistoryItems(),
 		MaxConsecutiveToolCalls: a.MaxConsecutiveToolCalls(),
 		Options:                 agentOptionFlags(a, cfg, hasCfg),
-		Toolsets:                toolsetDetails(a, cfg, hasCfg),
+		Toolsets:                toolsetDetails(ctx, a, cfg, hasCfg),
 		IsCurrent:               r.agents != nil && r.agents.Name() == agentName,
 	}
 	if hasCfg {
@@ -851,7 +851,7 @@ func configSkillNames(cfg latest.AgentConfig) []string {
 // combining the side-effect-free lifecycle status with tool names: live names
 // for started toolsets, otherwise the declared `tools:` allow-list keyed by the
 // same name the registry assigns (cmp.Or(name, type)).
-func toolsetDetails(a *agent.Agent, cfg latest.AgentConfig, hasCfg bool) []ToolsetDetail {
+func toolsetDetails(ctx context.Context, a *agent.Agent, cfg latest.AgentConfig, hasCfg bool) []ToolsetDetail {
 	toolSets := a.ToolSets()
 	if len(toolSets) == 0 {
 		return nil
@@ -868,7 +868,7 @@ func toolsetDetails(a *agent.Agent, cfg latest.AgentConfig, hasCfg bool) []Tools
 			Kind:  status.Kind,
 			State: toolsetStateBucket(status.State),
 		}
-		if live, ok := startedToolNames(ts); ok {
+		if live, ok := startedToolNames(ctx, ts); ok {
 			info.Tools = live
 		} else if names, ok := declared[status.Name]; ok {
 			info.Tools = names
@@ -898,15 +898,12 @@ func toolsetStateBucket(s lifecycle.State) ToolsetState {
 // caller can fall back to the declared allow-list. context.TODO is safe here:
 // the toolset is already started, so listing returns its cached tools without
 // a cancellable round-trip.
-func startedToolNames(ts tools.ToolSet) ([]string, bool) {
+func startedToolNames(ctx context.Context, ts tools.ToolSet) ([]string, bool) {
 	s, ok := tools.As[*tools.StartableToolSet](ts)
 	if !ok || !s.IsStarted() {
 		return nil, false
 	}
-	// startedToolNames is a leaf helper below the ctx boundary; Tools' ctx is
-	// only used for log correlation. context.TODO marks the intentional gap.
-	//rubocop:disable Lint/ContextConnectivity
-	tl, err := s.Tools(context.TODO())
+	tl, err := s.Tools(ctx)
 	if err != nil {
 		return nil, false
 	}
@@ -1224,14 +1221,11 @@ func (r *LocalRuntime) TitleGenerator() *sessiontitle.Generator {
 
 // getAgentModelID returns the model ID for an agent. The zero ID is
 // returned when no model is configured.
-func getAgentModelID(a *agent.Agent) modelsdev.ID {
+func getAgentModelID(ctx context.Context, a *agent.Agent) modelsdev.ID {
 	if a == nil {
 		return modelsdev.ID{}
 	}
-	// getAgentModelID is reached from several ctx-less callbacks; Model's ctx
-	// is only used for log correlation. context.TODO marks the intentional gap.
-	//rubocop:disable Lint/ContextConnectivity
-	if model := a.Model(context.TODO()); model != nil {
+	if model := a.Model(ctx); model != nil {
 		return model.ID()
 	}
 	return modelsdev.ID{}
@@ -1240,7 +1234,7 @@ func getAgentModelID(a *agent.Agent) modelsdev.ID {
 // getEffectiveModelID returns the currently active model ID for an agent, accounting
 // for any active fallback cooldown. During a cooldown period, this returns the fallback
 // model ID instead of the configured primary model, so the UI reflects the actual model in use.
-func (r *LocalRuntime) getEffectiveModelID(a *agent.Agent) modelsdev.ID {
+func (r *LocalRuntime) getEffectiveModelID(ctx context.Context, a *agent.Agent) modelsdev.ID {
 	cooldownState := r.fallback.cooldowns.Get(a.Name())
 	if cooldownState != nil {
 		fallbacks := a.FallbackModels()
@@ -1248,14 +1242,14 @@ func (r *LocalRuntime) getEffectiveModelID(a *agent.Agent) modelsdev.ID {
 			return fallbacks[cooldownState.fallbackIndex].ID()
 		}
 	}
-	return getAgentModelID(a)
+	return getAgentModelID(ctx, a)
 }
 
 // agentDetailsFromTeam converts team agent info to AgentDetails for events.
 // It accounts for active fallback cooldowns, returning the effective model
 // instead of the configured model when a fallback is in effect.
 func (r *LocalRuntime) agentDetailsFromTeam(ctx context.Context) []AgentDetails {
-	agentsInfo := r.team.AgentsInfo()
+	agentsInfo := r.team.AgentsInfo(ctx)
 	details := make([]AgentDetails, len(agentsInfo))
 	for i, info := range agentsInfo {
 		providerName := info.Provider
@@ -1406,9 +1400,9 @@ func (r *LocalRuntime) emitToolsChanged() {
 // aborted (e.g. the context was cancelled). Shared by EmitStartupInfo and
 // EmitAgentInfo so both render identical model labels.
 func (r *LocalRuntime) emitAgentAndTeamInfo(ctx context.Context, a *agent.Agent, send func(Event) bool) bool {
-	modelLabel := r.getEffectiveModelID(a).String()
+	modelLabel := r.getEffectiveModelID(ctx, a).String()
 	if a.HasHarness() {
-		modelLabel = agentModelLabel(a)
+		modelLabel = agentModelLabel(ctx, a)
 	}
 	if !send(AgentInfo(a.Name(), modelLabel, a.Description(), a.WelcomeMessage())) {
 		return false
@@ -1455,7 +1449,7 @@ func (r *LocalRuntime) EmitStartupInfo(ctx context.Context, sess *session.Sessio
 
 	// Emit agent and team information immediately for fast sidebar display.
 	// Use getEffectiveModelID to account for active fallback cooldowns.
-	modelID := r.getEffectiveModelID(a)
+	modelID := r.getEffectiveModelID(ctx, a)
 	if !r.emitAgentAndTeamInfo(ctx, a, send) {
 		return
 	}
@@ -1792,7 +1786,7 @@ func (r *LocalRuntime) compactWithReason(ctx context.Context, sess *session.Sess
 	// Emit a TokenUsageEvent so the sidebar immediately reflects the
 	// compaction: tokens drop to the summary size, context % drops, and
 	// cost increases by the summary generation cost.
-	modelID := r.getEffectiveModelID(a)
+	modelID := r.getEffectiveModelID(ctx, a)
 	contextLimit := r.resolveContextLimit(ctx, a.Model(ctx), modelID)
 	events.Emit(NewTokenUsageEvent(sess.ID, a.Name(), SessionUsage(sess, contextLimit)))
 }

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -116,7 +116,7 @@ type Runtime interface {
 
 	// TitleGenerator returns a generator for automatic session titles, or nil
 	// if the runtime does not support local title generation (e.g. remote runtimes).
-	TitleGenerator() *sessiontitle.Generator
+	TitleGenerator(ctx context.Context) *sessiontitle.Generator
 
 	// Steer enqueues a user message for urgent mid-turn injection into the
 	// running agent loop. Returns an error if the queue is full or steering
@@ -531,13 +531,13 @@ func WithHooksRegistry(reg *hooks.Registry) Opt {
 // the configured (or default in-memory) session store; pass
 // [WithSessionStore] to override and [WithEventObserver] to layer
 // additional observers (telemetry, audit, ...).
-func New(agents *team.Team, opts ...Opt) (Runtime, error) {
-	return NewLocalRuntime(agents, opts...)
+func New(ctx context.Context, agents *team.Team, opts ...Opt) (Runtime, error) {
+	return NewLocalRuntime(ctx, agents, opts...)
 }
 
 // NewLocalRuntime creates a new LocalRuntime without the persistence wrapper.
 // This is useful for testing or when persistence is handled externally.
-func NewLocalRuntime(agents *team.Team, opts ...Opt) (*LocalRuntime, error) {
+func NewLocalRuntime(ctx context.Context, agents *team.Team, opts ...Opt) (*LocalRuntime, error) {
 	defaultAgent, err := agents.DefaultAgent()
 	if err != nil {
 		return nil, err
@@ -644,8 +644,7 @@ func NewLocalRuntime(agents *team.Team, opts ...Opt) (*LocalRuntime, error) {
 		return nil, err
 	}
 
-	//rubocop:disable Lint/ContextConnectivity
-	if defaultAgent.Model(context.TODO()) == nil && !defaultAgent.HasHarness() {
+	if defaultAgent.Model(ctx) == nil && !defaultAgent.HasHarness() {
 		return nil, fmt.Errorf("agent %s has no valid model", defaultAgent.Name())
 	}
 
@@ -666,7 +665,7 @@ func NewLocalRuntime(agents *team.Team, opts ...Opt) (*LocalRuntime, error) {
 		r.observers = append([]EventObserver{obs}, r.observers...)
 	}
 
-	slog.Debug("Creating new runtime", "agent", r.agents.Name(), "available_agents", agents.Size())
+	slog.DebugContext(ctx, "Creating new runtime", "agent", r.agents.Name(), "available_agents", agents.Size())
 
 	return r, nil
 }
@@ -1203,16 +1202,12 @@ func (r *LocalRuntime) ExecuteMCPPrompt(ctx context.Context, promptName string, 
 }
 
 // TitleGenerator returns a title generator for automatic session title generation.
-func (r *LocalRuntime) TitleGenerator() *sessiontitle.Generator {
+func (r *LocalRuntime) TitleGenerator(ctx context.Context) *sessiontitle.Generator {
 	a := r.CurrentAgent()
 	if a == nil {
 		return nil
 	}
-	// Title-gen setup happens before any session ctx exists; the resulting
-	// generator carries its own ctx when actually invoked. context.TODO is
-	// the right marker here.
-	//rubocop:disable Lint/ContextConnectivity
-	models := a.TitleModels(context.TODO())
+	models := a.TitleModels(ctx)
 	if len(models) == 0 {
 		return nil
 	}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -644,6 +644,7 @@ func NewLocalRuntime(agents *team.Team, opts ...Opt) (*LocalRuntime, error) {
 		return nil, err
 	}
 
+	//rubocop:disable Lint/ContextConnectivity
 	if defaultAgent.Model(context.TODO()) == nil && !defaultAgent.HasHarness() {
 		return nil, fmt.Errorf("agent %s has no valid model", defaultAgent.Name())
 	}
@@ -893,6 +894,7 @@ func startedToolNames(ts tools.ToolSet) ([]string, bool) {
 	if !ok || !s.IsStarted() {
 		return nil, false
 	}
+	//rubocop:disable Lint/ContextConnectivity
 	tl, err := s.Tools(context.TODO())
 	if err != nil {
 		return nil, false
@@ -1201,6 +1203,7 @@ func (r *LocalRuntime) TitleGenerator() *sessiontitle.Generator {
 	// Title-gen setup happens before any session ctx exists; the resulting
 	// generator carries its own ctx when actually invoked. context.TODO is
 	// the right marker here.
+	//rubocop:disable Lint/ContextConnectivity
 	models := a.TitleModels(context.TODO())
 	if len(models) == 0 {
 		return nil
@@ -1214,6 +1217,7 @@ func getAgentModelID(a *agent.Agent) modelsdev.ID {
 	if a == nil {
 		return modelsdev.ID{}
 	}
+	//rubocop:disable Lint/ContextConnectivity
 	if model := a.Model(context.TODO()); model != nil {
 		return model.ID()
 	}
@@ -1373,6 +1377,7 @@ func (r *LocalRuntime) emitToolsChanged() {
 	if r.onToolsChanged == nil {
 		return
 	}
+	//rubocop:disable Lint/ContextConnectivity
 	ctx, cancel := context.WithTimeout(context.Background(), toolsChangedTimeout)
 	defer cancel()
 	a := r.CurrentAgent()
@@ -1682,6 +1687,7 @@ func (r *LocalRuntime) Resume(_ context.Context, req ResumeRequest) {
 // running agent loop. The message will be picked up after the current batch
 // of tool calls finishes but before the loop checks whether to stop.
 func (r *LocalRuntime) Steer(msg QueuedMessage) error {
+	//rubocop:disable Lint/ContextConnectivity
 	if !r.steerQueue.Enqueue(context.Background(), msg) {
 		return errors.New("steer queue full")
 	}
@@ -1692,6 +1698,7 @@ func (r *LocalRuntime) Steer(msg QueuedMessage) error {
 // finishes. Unlike Steer, follow-ups are popped one at a time and each gets
 // a full undivided agent turn.
 func (r *LocalRuntime) FollowUp(msg QueuedMessage) error {
+	//rubocop:disable Lint/ContextConnectivity
 	if !r.followUpQueue.Enqueue(context.Background(), msg) {
 		return errors.New("follow-up queue full")
 	}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -197,6 +197,7 @@ type ModelStore interface {
 
 // LocalRuntime manages the execution of agents
 type LocalRuntime struct {
+	ctx                       func() context.Context
 	toolMap                   map[string]ToolHandlerFunc
 	team                      *team.Team
 	agents                    *agentRouter
@@ -544,6 +545,7 @@ func NewLocalRuntime(ctx context.Context, agents *team.Team, opts ...Opt) (*Loca
 	}
 
 	r := &LocalRuntime{
+		ctx:                    func() context.Context { return context.WithoutCancel(ctx) },
 		toolMap:                make(map[string]ToolHandlerFunc),
 		team:                   agents,
 		agents:                 newAgentRouter(agents, defaultAgent.Name()),
@@ -1379,8 +1381,7 @@ func (r *LocalRuntime) emitToolsChanged() {
 	if r.onToolsChanged == nil {
 		return
 	}
-	//rubocop:disable Lint/ContextConnectivity
-	ctx, cancel := context.WithTimeout(context.Background(), toolsChangedTimeout)
+	ctx, cancel := context.WithTimeout(r.ctx(), toolsChangedTimeout)
 	defer cancel()
 	a := r.CurrentAgent()
 	agentTools, err := a.StartedTools(ctx)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -46,9 +46,9 @@ type Runtime interface {
 	// CurrentAgentInfo returns information about the currently active agent
 	CurrentAgentInfo(ctx context.Context) CurrentAgentInfo
 	// CurrentAgentName returns the name of the currently active agent
-	CurrentAgentName() string
+	CurrentAgentName(ctx context.Context) string
 	// SetCurrentAgent sets the currently active agent for subsequent user messages
-	SetCurrentAgent(agentName string) error
+	SetCurrentAgent(ctx context.Context, agentName string) error
 	// CurrentAgentTools returns the tools for the active agent
 	CurrentAgentTools(ctx context.Context) ([]tools.Tool, error)
 	// CurrentAgentToolsetStatuses returns lifecycle status for each toolset of
@@ -121,10 +121,10 @@ type Runtime interface {
 	// Steer enqueues a user message for urgent mid-turn injection into the
 	// running agent loop. Returns an error if the queue is full or steering
 	// is not available.
-	Steer(msg QueuedMessage) error
+	Steer(ctx context.Context, msg QueuedMessage) error
 	// FollowUp enqueues a message for end-of-turn processing. Each follow-up
 	// gets a full undivided agent turn. Returns an error if the queue is full.
-	FollowUp(msg QueuedMessage) error
+	FollowUp(ctx context.Context, msg QueuedMessage) error
 
 	// SetAgentModel sets a model override for the named agent.
 	// modelRef can be:
@@ -671,7 +671,16 @@ func NewLocalRuntime(agents *team.Team, opts ...Opt) (*LocalRuntime, error) {
 	return r, nil
 }
 
-func (r *LocalRuntime) CurrentAgentName() string {
+func (r *LocalRuntime) CurrentAgentName(context.Context) string {
+	return r.currentAgentName()
+}
+
+// currentAgentName is the context-free internal accessor. LocalRuntime
+// resolves the active agent purely from in-memory state, so its internal
+// callers (event callbacks, logging) use this directly; the exported
+// context-taking method exists to satisfy the Runtime interface, whose
+// remote implementation needs a context for its one-time lookup.
+func (r *LocalRuntime) currentAgentName() string {
 	return r.agents.Name()
 }
 
@@ -689,7 +698,7 @@ func (r *LocalRuntime) CurrentAgentInfo(context.Context) CurrentAgentInfo {
 	}
 }
 
-func (r *LocalRuntime) SetCurrentAgent(agentName string) error {
+func (r *LocalRuntime) SetCurrentAgent(_ context.Context, agentName string) error {
 	return r.agents.SetValidated(agentName)
 }
 
@@ -894,6 +903,8 @@ func startedToolNames(ts tools.ToolSet) ([]string, bool) {
 	if !ok || !s.IsStarted() {
 		return nil, false
 	}
+	// startedToolNames is a leaf helper below the ctx boundary; Tools' ctx is
+	// only used for log correlation. context.TODO marks the intentional gap.
 	//rubocop:disable Lint/ContextConnectivity
 	tl, err := s.Tools(context.TODO())
 	if err != nil {
@@ -1217,6 +1228,8 @@ func getAgentModelID(a *agent.Agent) modelsdev.ID {
 	if a == nil {
 		return modelsdev.ID{}
 	}
+	// getAgentModelID is reached from several ctx-less callbacks; Model's ctx
+	// is only used for log correlation. context.TODO marks the intentional gap.
 	//rubocop:disable Lint/ContextConnectivity
 	if model := a.Model(context.TODO()); model != nil {
 		return model.ID()
@@ -1385,7 +1398,7 @@ func (r *LocalRuntime) emitToolsChanged() {
 	if err != nil {
 		return
 	}
-	r.onToolsChanged(ToolsetInfo(len(agentTools), false, r.CurrentAgentName()))
+	r.onToolsChanged(ToolsetInfo(len(agentTools), false, r.currentAgentName()))
 }
 
 // emitAgentAndTeamInfo sends the AgentInfo and TeamInfo events that drive the
@@ -1400,7 +1413,7 @@ func (r *LocalRuntime) emitAgentAndTeamInfo(ctx context.Context, a *agent.Agent,
 	if !send(AgentInfo(a.Name(), modelLabel, a.Description(), a.WelcomeMessage())) {
 		return false
 	}
-	return send(TeamInfo(r.agentDetailsFromTeam(ctx), r.CurrentAgentName()))
+	return send(TeamInfo(r.agentDetailsFromTeam(ctx), r.currentAgentName()))
 }
 
 // EmitAgentInfo implements [Runtime.EmitAgentInfo]: it refreshes the agent and
@@ -1485,7 +1498,7 @@ func (r *LocalRuntime) EmitStartupInfo(ctx context.Context, sess *session.Sessio
 			break
 		}
 
-		send(NewTokenUsageEvent(sess.ID, r.CurrentAgentName(), usage))
+		send(NewTokenUsageEvent(sess.ID, r.currentAgentName(), usage))
 	}
 
 	// Tool loading can be slow (MCP servers need to start). Mark the
@@ -1516,12 +1529,12 @@ func (r *LocalRuntime) emitToolsProgressively(ctx context.Context, a *agent.Agen
 
 	// If no toolsets, emit final state immediately
 	if totalToolsets == 0 {
-		send(ToolsetInfo(0, false, r.CurrentAgentName()))
+		send(ToolsetInfo(0, false, r.currentAgentName()))
 		return
 	}
 
 	// Emit initial loading state
-	if !send(ToolsetInfo(0, true, r.CurrentAgentName())) {
+	if !send(ToolsetInfo(0, true, r.currentAgentName())) {
 		return
 	}
 
@@ -1603,13 +1616,13 @@ func (r *LocalRuntime) emitToolsProgressively(ctx context.Context, a *agent.Agen
 		totalTools += len(ts)
 
 		// Emit progress update - still loading unless this is the last toolset
-		if !send(ToolsetInfo(totalTools, !isLast, r.CurrentAgentName())) {
+		if !send(ToolsetInfo(totalTools, !isLast, r.currentAgentName())) {
 			return
 		}
 	}
 
 	// Emit final state (not loading)
-	send(ToolsetInfo(totalTools, false, r.CurrentAgentName()))
+	send(ToolsetInfo(totalTools, false, r.currentAgentName()))
 }
 
 // listToolsWithTimeout enumerates a toolset's tools under a bounded deadline.
@@ -1648,7 +1661,7 @@ func listToolsWithTimeout(ctx context.Context, toolset tools.ToolSet, timeout ti
 }
 
 func (r *LocalRuntime) Resume(_ context.Context, req ResumeRequest) {
-	slog.Debug("Resuming runtime", "agent", r.CurrentAgentName(), "type", req.Type, "reason", req.Reason)
+	slog.Debug("Resuming runtime", "agent", r.currentAgentName(), "type", req.Type, "reason", req.Reason)
 
 	// Defensive validation:
 	//
@@ -1659,7 +1672,7 @@ func (r *LocalRuntime) Resume(_ context.Context, req ResumeRequest) {
 	if !IsValidResumeType(req.Type) {
 		slog.Warn(
 			"Invalid resume type received; ignoring resume request",
-			"agent", r.CurrentAgentName(),
+			"agent", r.currentAgentName(),
 			"confirmation_type", req.Type,
 			"valid_types", ValidResumeTypes(),
 		)
@@ -1673,11 +1686,11 @@ func (r *LocalRuntime) Resume(_ context.Context, req ResumeRequest) {
 	// canceled, or shutting down).
 	select {
 	case r.resumeChan <- req:
-		slog.Debug("Resume signal sent", "agent", r.CurrentAgentName())
+		slog.Debug("Resume signal sent", "agent", r.currentAgentName())
 	default:
 		slog.Debug(
 			"Resume channel not ready; resume signal dropped",
-			"agent", r.CurrentAgentName(),
+			"agent", r.currentAgentName(),
 			"confirmation_type", req.Type,
 		)
 	}
@@ -1686,9 +1699,8 @@ func (r *LocalRuntime) Resume(_ context.Context, req ResumeRequest) {
 // Steer enqueues a user message for urgent mid-turn injection into the
 // running agent loop. The message will be picked up after the current batch
 // of tool calls finishes but before the loop checks whether to stop.
-func (r *LocalRuntime) Steer(msg QueuedMessage) error {
-	//rubocop:disable Lint/ContextConnectivity
-	if !r.steerQueue.Enqueue(context.Background(), msg) {
+func (r *LocalRuntime) Steer(ctx context.Context, msg QueuedMessage) error {
+	if !r.steerQueue.Enqueue(ctx, msg) {
 		return errors.New("steer queue full")
 	}
 	return nil
@@ -1697,9 +1709,8 @@ func (r *LocalRuntime) Steer(msg QueuedMessage) error {
 // FollowUp enqueues a message to be processed after the current agent turn
 // finishes. Unlike Steer, follow-ups are popped one at a time and each gets
 // a full undivided agent turn.
-func (r *LocalRuntime) FollowUp(msg QueuedMessage) error {
-	//rubocop:disable Lint/ContextConnectivity
-	if !r.followUpQueue.Enqueue(context.Background(), msg) {
+func (r *LocalRuntime) FollowUp(ctx context.Context, msg QueuedMessage) error {
+	if !r.followUpQueue.Enqueue(ctx, msg) {
 		return errors.New("follow-up queue full")
 	}
 	return nil

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -2742,7 +2742,7 @@ func TestSkillSubSessionTools_ScopesAndInjects(t *testing.T) {
 	prov := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
 	root := agent.New("root", "agent", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	inherited := []tools.Tool{
@@ -2772,7 +2772,7 @@ func TestSkillSubSessionTools_NoOpForOrdinarySession(t *testing.T) {
 	prov := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
 	root := agent.New("root", "agent", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	inherited := []tools.Tool{{Name: "read_file"}, {Name: "shell"}}

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -214,7 +214,7 @@ func runSession(t *testing.T, sess *session.Session, stream *mockStream) []Event
 	root := agent.New("root", "You are a test agent", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	sess.Title = "Unit Test"
@@ -538,7 +538,7 @@ func TestErrorEvent(t *testing.T) {
 	root := agent.New("root", "You are a test agent", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	sess := session.New(session.WithUserMessage("Hi"))
@@ -575,7 +575,7 @@ func TestContextCancellation(t *testing.T) {
 	root := agent.New("root", "You are a test agent", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	sess := session.New(session.WithUserMessage("Hi"))
@@ -707,7 +707,7 @@ func TestCompaction(t *testing.T) {
 	tm := team.New(team.WithAgents(root))
 
 	// Enable compaction and provide a model store with context limit = 100
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(true), WithModelStore(mockModelStoreWithLimit{limit: 100}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(true), WithModelStore(mockModelStoreWithLimit{limit: 100}))
 	require.NoError(t, err)
 
 	sess := session.New(session.WithUserMessage("Start"))
@@ -760,7 +760,7 @@ func TestCompactionOverflowDoesNotLoop(t *testing.T) {
 	root := agent.New("root", "You are a test agent", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(true), WithModelStore(mockModelStoreWithLimit{limit: 100}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(true), WithModelStore(mockModelStoreWithLimit{limit: 100}))
 	require.NoError(t, err)
 
 	sess := session.New(session.WithUserMessage("Hello"))
@@ -854,7 +854,7 @@ func TestGetTools_WarningHandling(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			root := agent.New("root", "test", agent.WithToolSets(tt.toolsets...), agent.WithModel(&mockProvider{}))
 			tm := team.New(team.WithAgents(root))
-			rt, err := NewLocalRuntime(tm, WithModelStore(mockModelStore{}))
+			rt, err := NewLocalRuntime(t.Context(), tm, WithModelStore(mockModelStore{}))
 			require.NoError(t, err)
 
 			events := make(chan Event, 10)
@@ -875,7 +875,7 @@ func TestGetTools_WarningHandling(t *testing.T) {
 func TestNewRuntime_NoAgentsError(t *testing.T) {
 	tm := team.New()
 
-	_, err := New(tm, WithModelStore(mockModelStore{}))
+	_, err := New(t.Context(), tm, WithModelStore(mockModelStore{}))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no agents loaded")
 }
@@ -885,7 +885,7 @@ func TestNewRuntime_InvalidCurrentAgentError(t *testing.T) {
 	tm := team.New(team.WithAgents(root))
 
 	// Ask for a non-existent current agent
-	_, err := New(tm, WithCurrentAgent("other"), WithModelStore(mockModelStore{}))
+	_, err := New(t.Context(), tm, WithCurrentAgent("other"), WithModelStore(mockModelStore{}))
 	require.Contains(t, err.Error(), "agent not found: other (available agents: root)")
 }
 
@@ -907,7 +907,7 @@ func TestNewRuntime_ModelStorePrecedence(t *testing.T) {
 		t.Parallel()
 		explicit := &mockCatalogStore{}
 		cfgStore := &mockCatalogStore{}
-		rt, err := NewLocalRuntime(newTeam(),
+		rt, err := NewLocalRuntime(t.Context(), newTeam(),
 			WithModelStore(explicit),
 			WithModelSwitcherConfig(&ModelSwitcherConfig{ModelsStore: cfgStore}),
 		)
@@ -918,7 +918,7 @@ func TestNewRuntime_ModelStorePrecedence(t *testing.T) {
 	t.Run("ModelSwitcherConfig store is adopted when no explicit store", func(t *testing.T) {
 		t.Parallel()
 		cfgStore := &mockCatalogStore{}
-		rt, err := NewLocalRuntime(newTeam(),
+		rt, err := NewLocalRuntime(t.Context(), newTeam(),
 			WithModelSwitcherConfig(&ModelSwitcherConfig{ModelsStore: cfgStore}),
 		)
 		require.NoError(t, err)
@@ -927,7 +927,7 @@ func TestNewRuntime_ModelStorePrecedence(t *testing.T) {
 
 	t.Run("falls back to lazy store when neither is set", func(t *testing.T) {
 		t.Parallel()
-		rt, err := NewLocalRuntime(newTeam(),
+		rt, err := NewLocalRuntime(t.Context(), newTeam(),
 			WithModelSwitcherConfig(&ModelSwitcherConfig{}),
 		)
 		require.NoError(t, err)
@@ -939,7 +939,7 @@ func TestProcessToolCalls_UnknownTool_ReturnsErrorResponse(t *testing.T) {
 	root := agent.New("root", "You are a test agent", agent.WithModel(&mockProvider{}))
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 	rt.registerDefaultTools()
 
@@ -1054,7 +1054,7 @@ func TestEmitStartupInfo_DoesNotBlockOnInteractiveOAuth(t *testing.T) {
 	)
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithCurrentAgent("root"), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithCurrentAgent("root"), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	events := make(chan Event, 20)
@@ -1115,7 +1115,7 @@ func TestEmitStartupInfo_SurfacesToolsetStartFailureAsWarning(t *testing.T) {
 	)
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithCurrentAgent("root"), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithCurrentAgent("root"), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	events := make(chan Event, 32)
@@ -1157,7 +1157,7 @@ func TestEmitStartupInfo_SkipsToolsetWhoseListingHangs(t *testing.T) {
 	)
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm,
+	rt, err := NewLocalRuntime(t.Context(), tm,
 		WithCurrentAgent("root"),
 		WithModelStore(mockModelStore{}),
 		WithToolListTimeout(50*time.Millisecond),
@@ -1212,7 +1212,7 @@ func TestEmitStartupInfo_AuthRequiredIsSilent(t *testing.T) {
 	)
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithCurrentAgent("root"), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithCurrentAgent("root"), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	events := make(chan Event, 32)
@@ -1252,7 +1252,7 @@ func TestEmitStartupInfo_DeferredAuthDoesNotConsumeFailureGate(t *testing.T) {
 	)
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithCurrentAgent("root"), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithCurrentAgent("root"), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	events := make(chan Event, 32)
@@ -1312,7 +1312,7 @@ func TestEmitStartupInfo_RecoveryAuthNoticeEmittedOnce(t *testing.T) {
 		agent.WithToolSets(inner),
 	)
 	tm := team.New(team.WithAgents(root))
-	rt, err := NewLocalRuntime(tm, WithCurrentAgent("root"), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithCurrentAgent("root"), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	var wrapped *tools.StartableToolSet
@@ -1385,7 +1385,7 @@ func TestEmitAgentWarnings_OnlyEmitsFailures(t *testing.T) {
 	prov := &mockProvider{id: "test/m", stream: &mockStream{}}
 	root := agent.New("root", "agent", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
-	rt, err := NewLocalRuntime(tm, WithCurrentAgent("root"), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithCurrentAgent("root"), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	root.AddToolWarning("toolset_a start failed: connection refused")
@@ -1413,7 +1413,7 @@ func TestEmitAgentWarnings_NoEventsWhenQueueEmpty(t *testing.T) {
 	prov := &mockProvider{id: "test/m", stream: &mockStream{}}
 	root := agent.New("root", "agent", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
-	rt, err := NewLocalRuntime(tm, WithCurrentAgent("root"), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithCurrentAgent("root"), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	var emitted int
@@ -1435,7 +1435,7 @@ func TestEmitStartupInfo(t *testing.T) {
 	)
 	tm := team.New(team.WithAgents(root, other))
 
-	rt, err := NewLocalRuntime(tm, WithCurrentAgent("startup-test-agent"), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithCurrentAgent("startup-test-agent"), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	// Create a channel to collect events
@@ -1488,7 +1488,7 @@ func TestEmitStartupInfo_WithSessionTokenData(t *testing.T) {
 	)
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithCurrentAgent("startup-test-agent"),
+	rt, err := NewLocalRuntime(t.Context(), tm, WithCurrentAgent("startup-test-agent"),
 		WithModelStore(mockModelStoreWithLimit{limit: 200_000}))
 	require.NoError(t, err)
 
@@ -1529,7 +1529,7 @@ func TestEmitStartupInfo_CostIncludesSubSessions(t *testing.T) {
 	)
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithCurrentAgent("root"),
+	rt, err := NewLocalRuntime(t.Context(), tm, WithCurrentAgent("root"),
 		WithModelStore(mockModelStoreWithLimit{limit: 128_000}))
 	require.NoError(t, err)
 
@@ -1594,7 +1594,7 @@ func TestEmitStartupInfo_LastMessageFinishReason(t *testing.T) {
 	)
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithCurrentAgent("root"),
+	rt, err := NewLocalRuntime(t.Context(), tm, WithCurrentAgent("root"),
 		WithModelStore(mockModelStoreWithLimit{limit: 128_000}))
 	require.NoError(t, err)
 
@@ -1645,7 +1645,7 @@ func TestEmitStartupInfo_NilSessionNoTokenEvent(t *testing.T) {
 	)
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithCurrentAgent("startup-test-agent"),
+	rt, err := NewLocalRuntime(t.Context(), tm, WithCurrentAgent("startup-test-agent"),
 		WithModelStore(mockModelStoreWithLimit{limit: 200_000}))
 	require.NoError(t, err)
 
@@ -1672,7 +1672,7 @@ func TestPermissions_DenyBlocksToolExecution(t *testing.T) {
 		team.WithPermissions(permChecker),
 	)
 
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	sess := session.New(session.WithUserMessage("Test"))
@@ -1736,7 +1736,7 @@ func TestPermissions_AllowAutoApprovesTool(t *testing.T) {
 		team.WithPermissions(permChecker),
 	)
 
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	sess := session.New(session.WithUserMessage("Test"))
@@ -1771,7 +1771,7 @@ func TestPermissions_DenyTakesPriorityOverAllow(t *testing.T) {
 		team.WithPermissions(permChecker),
 	)
 
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	sess := session.New(session.WithUserMessage("Test"))
@@ -1813,7 +1813,7 @@ func TestSessionPermissions_DenyBlocksToolExecution(t *testing.T) {
 	root := agent.New("root", "You are a test agent", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	// Create session with permissions that deny the tool
@@ -1873,7 +1873,7 @@ func TestSessionPermissions_AllowAutoApprovesTool(t *testing.T) {
 	)
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	// Create session with permissions that allow the tool
@@ -1912,7 +1912,7 @@ func TestSessionPermissions_TakePriorityOverTeamPermissions(t *testing.T) {
 		team.WithPermissions(teamPermChecker),
 	)
 
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	// Session denies the tool (should override team allow)
@@ -1972,7 +1972,7 @@ func TestToolRejectionWithReason(t *testing.T) {
 	)
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	sess := session.New(session.WithUserMessage("Test"))
@@ -2028,7 +2028,7 @@ func TestToolRejectionWithoutReason(t *testing.T) {
 	)
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	sess := session.New(session.WithUserMessage("Test"))
@@ -2079,7 +2079,7 @@ func TestTransferTaskRejectsNonSubAgent(t *testing.T) {
 
 	tm := team.New(team.WithAgents(root, planner, librarian))
 
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	sess := session.New(session.WithUserMessage("Test"))
@@ -2117,7 +2117,7 @@ func TestTransferTaskAllowsSubAgent(t *testing.T) {
 
 	tm := team.New(team.WithAgents(root, librarian))
 
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	sess := session.New(session.WithUserMessage("Test"), session.WithToolsApproved(true))
@@ -2162,7 +2162,7 @@ func TestTransferTaskPersistsSubSessionOnError(t *testing.T) {
 	agent.WithSubAgents(librarian)(root)
 
 	tm := team.New(team.WithAgents(root, librarian))
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	sess := session.New(session.WithUserMessage("Test"), session.WithToolsApproved(true))
@@ -2246,7 +2246,7 @@ func TestYoloMode_OverridesPermissionsDeny(t *testing.T) {
 		team.WithPermissions(permChecker),
 	)
 
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	sess := session.New(session.WithUserMessage("Test"), session.WithToolsApproved(true))
@@ -2292,7 +2292,7 @@ func TestYoloMode_OverridesForceAsk(t *testing.T) {
 		team.WithPermissions(permChecker),
 	)
 
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	sess := session.New(session.WithUserMessage("Test"), session.WithToolsApproved(true))
@@ -2331,7 +2331,7 @@ func TestYoloMode_OverridesSessionDeny(t *testing.T) {
 	)
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	sess := session.New(
@@ -2566,7 +2566,7 @@ func TestResolveSessionAgent_PinnedAgent(t *testing.T) {
 	root := agent.New("root", "Root agent", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root, worker))
 
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 	assert.Equal(t, "root", rt.CurrentAgentName(t.Context()), "default agent should be root")
 
@@ -2585,7 +2585,7 @@ func TestResolveSessionAgent_FallsBackToCurrentAgent(t *testing.T) {
 	root := agent.New("root", "Root agent", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	sess := session.New() // no AgentName
@@ -2601,7 +2601,7 @@ func TestResolveSessionAgent_InvalidNameFallsBack(t *testing.T) {
 	root := agent.New("root", "Root agent", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	sess := session.New(session.WithAgentName("nonexistent"))
@@ -2630,7 +2630,7 @@ func TestProcessToolCalls_UsesPinnedAgent(t *testing.T) {
 	root := agent.New("root", "Root agent", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root, worker))
 
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 	rt.registerDefaultTools()
 	assert.Equal(t, "root", rt.CurrentAgentName(t.Context()))
@@ -2820,7 +2820,7 @@ func TestRunStream_EmptyMessages_SendUserMessage(t *testing.T) {
 	root := agent.New("root", "", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	sess := session.New() // SendUserMessage=true, no messages
@@ -2857,7 +2857,7 @@ func TestRunStream_AddEnvironmentInfo_DoesNotPolluteSession(t *testing.T) {
 	)
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(
+	rt, err := NewLocalRuntime(t.Context(),
 		tm,
 		WithSessionCompaction(false),
 		WithModelStore(mockModelStore{}),
@@ -3008,7 +3008,7 @@ func TestReprobe_NewToolsAvailableAfterToolCall(t *testing.T) {
 	)
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 	rt.registerDefaultTools()
 
@@ -3075,7 +3075,7 @@ func TestReprobe_NoChangeMeansNoExtraEvents(t *testing.T) {
 	root := agent.New("root", "test", agent.WithModel(prov), agent.WithToolSets(ts))
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 	rt.registerDefaultTools()
 
@@ -3170,7 +3170,7 @@ func TestSteer_IdleWindowIsConsumedOnNextTurn(t *testing.T) {
 	root := agent.New("root", "You are a test agent", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	// Enqueue a steer message BEFORE calling RunStream — simulating the
@@ -3266,7 +3266,7 @@ func TestSteer_EmptySessionBootstrap(t *testing.T) {
 	root := agent.New("root", "You are a test agent", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	// Enqueue before RunStream — zero messages in the session.
@@ -3443,7 +3443,7 @@ func TestSteer_EndOfIterationRaceIsConsumedInCurrentRunStream(t *testing.T) {
 	tm := team.New(team.WithAgents(root))
 
 	var err error
-	rt, err = NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err = NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	sess := session.New(session.WithUserMessage("Do the task"))
@@ -3580,7 +3580,7 @@ func TestDrainAndEmitSteered_MultipleMessages(t *testing.T) {
 	root := agent.New("root", "You are a test agent", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	// Enqueue three plain-text steer messages before draining.
@@ -3633,7 +3633,7 @@ func TestDrainAndEmitSteered_MultiContent(t *testing.T) {
 	root := agent.New("root", "You are a test agent", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	// Two multi-content messages.
@@ -3712,7 +3712,7 @@ func TestPostToolHookReceivesToolResult(t *testing.T) {
 		}),
 	)
 	tm := team.New(team.WithAgents(root))
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 	rt.hooksRegistry = registry
 	rt.buildHooksExecutors()
@@ -3764,7 +3764,7 @@ func TestPostToolHookEmitsLifecycleEvents(t *testing.T) {
 		}),
 	)
 	tm := team.New(team.WithAgents(root))
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 	rt.hooksRegistry = registry
 	rt.buildHooksExecutors()
@@ -3809,7 +3809,7 @@ func TestElicitationHandler_NonInteractive(t *testing.T) {
 	root := agent.New("root", "test", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm, WithNonInteractive(true))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithNonInteractive(true))
 	require.NoError(t, err)
 
 	params := &mcp.ElicitParams{
@@ -3830,7 +3830,7 @@ func TestElicitationHandler_Interactive_NoChannel(t *testing.T) {
 	tm := team.New(team.WithAgents(root))
 
 	// Default runtime (interactive mode) with no events channel set
-	rt, err := NewLocalRuntime(tm)
+	rt, err := NewLocalRuntime(t.Context(), tm)
 	require.NoError(t, err)
 
 	params := &mcp.ElicitParams{
@@ -3865,7 +3865,7 @@ func TestRunAgentPersistsSubSessionToStore(t *testing.T) {
 	tm := team.New(team.WithAgents(root, worker))
 
 	store := session.NewInMemorySessionStore()
-	rt, err := NewLocalRuntime(tm,
+	rt, err := NewLocalRuntime(t.Context(), tm,
 		WithSessionCompaction(false),
 		WithModelStore(mockModelStore{}),
 		WithSessionStore(store),
@@ -3923,7 +3923,7 @@ func TestRunAgentPersistsSubSessionOnError(t *testing.T) {
 	agent.WithSubAgents(worker)(root)
 
 	tm := team.New(team.WithAgents(root, worker))
-	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	sess := session.New(session.WithUserMessage("Test"), session.WithToolsApproved(true))

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -2100,7 +2100,7 @@ func TestTransferTaskRejectsNonSubAgent(t *testing.T) {
 	assert.True(t, result.IsError, "transfer to non-sub-agent should return an error result")
 	assert.Contains(t, result.Output, "cannot transfer task to planner")
 	assert.Contains(t, result.Output, "librarian")
-	assert.Equal(t, "root", rt.CurrentAgentName(), "current agent should remain root")
+	assert.Equal(t, "root", rt.CurrentAgentName(t.Context()), "current agent should remain root")
 }
 
 func TestTransferTaskAllowsSubAgent(t *testing.T) {
@@ -2568,7 +2568,7 @@ func TestResolveSessionAgent_PinnedAgent(t *testing.T) {
 
 	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
-	assert.Equal(t, "root", rt.CurrentAgentName(), "default agent should be root")
+	assert.Equal(t, "root", rt.CurrentAgentName(t.Context()), "default agent should be root")
 
 	// Session pinned to worker (as run_background_agent does).
 	sess := session.New(session.WithAgentName("worker"))
@@ -2633,7 +2633,7 @@ func TestProcessToolCalls_UsesPinnedAgent(t *testing.T) {
 	rt, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 	rt.registerDefaultTools()
-	assert.Equal(t, "root", rt.CurrentAgentName())
+	assert.Equal(t, "root", rt.CurrentAgentName(t.Context()))
 
 	// Simulate a background session pinned to "worker".
 	sess := session.New(
@@ -3176,7 +3176,7 @@ func TestSteer_IdleWindowIsConsumedOnNextTurn(t *testing.T) {
 	// Enqueue a steer message BEFORE calling RunStream — simulating the
 	// idle-window race where a Steer call lands between two RunStream
 	// invocations.
-	err = rt.Steer(QueuedMessage{Content: "urgent: change direction"})
+	err = rt.Steer(t.Context(), QueuedMessage{Content: "urgent: change direction"})
 	require.NoError(t, err)
 
 	sess := session.New(session.WithUserMessage("Do the task"))
@@ -3270,7 +3270,7 @@ func TestSteer_EmptySessionBootstrap(t *testing.T) {
 	require.NoError(t, err)
 
 	// Enqueue before RunStream — zero messages in the session.
-	err = rt.Steer(QueuedMessage{Content: "bootstrap message"})
+	err = rt.Steer(t.Context(), QueuedMessage{Content: "bootstrap message"})
 	require.NoError(t, err)
 
 	// Fresh session with NO messages (SendUserMessage defaults to true but
@@ -3425,7 +3425,7 @@ func TestSteer_EndOfIterationRaceIsConsumedInCurrentRunStream(t *testing.T) {
 	turn1 := &hookStream{
 		mockStream: turn1Base,
 		onStop: func() {
-			_ = rt.Steer(QueuedMessage{Content: "end-of-iter steer"})
+			_ = rt.Steer(t.Context(), QueuedMessage{Content: "end-of-iter steer"})
 		},
 	}
 	// Turn 2: the loop re-entered after the steer was consumed; model acks.
@@ -3584,9 +3584,9 @@ func TestDrainAndEmitSteered_MultipleMessages(t *testing.T) {
 	require.NoError(t, err)
 
 	// Enqueue three plain-text steer messages before draining.
-	require.NoError(t, rt.Steer(QueuedMessage{Content: "first"}))
-	require.NoError(t, rt.Steer(QueuedMessage{Content: "second"}))
-	require.NoError(t, rt.Steer(QueuedMessage{Content: "third"}))
+	require.NoError(t, rt.Steer(t.Context(), QueuedMessage{Content: "first"}))
+	require.NoError(t, rt.Steer(t.Context(), QueuedMessage{Content: "second"}))
+	require.NoError(t, rt.Steer(t.Context(), QueuedMessage{Content: "third"}))
 
 	sess := session.New()
 	events := make(chan Event, 16)
@@ -3637,7 +3637,7 @@ func TestDrainAndEmitSteered_MultiContent(t *testing.T) {
 	require.NoError(t, err)
 
 	// Two multi-content messages.
-	require.NoError(t, rt.Steer(QueuedMessage{
+	require.NoError(t, rt.Steer(t.Context(), QueuedMessage{
 		Content: "first",
 		MultiContent: []chat.MessagePart{
 			{Type: chat.MessagePartTypeText, Text: "first"},
@@ -3645,7 +3645,7 @@ func TestDrainAndEmitSteered_MultiContent(t *testing.T) {
 			{Type: chat.MessagePartTypeText, Text: "first-text-after-img"},
 		},
 	}))
-	require.NoError(t, rt.Steer(QueuedMessage{
+	require.NoError(t, rt.Steer(t.Context(), QueuedMessage{
 		Content: "second",
 		MultiContent: []chat.MessagePart{
 			{Type: chat.MessagePartTypeText, Text: "second"},

--- a/pkg/runtime/session_compaction.go
+++ b/pkg/runtime/session_compaction.go
@@ -253,7 +253,7 @@ func providerContextLimit(p provider.Provider) int64 {
 // which avoids creating an import cycle on [pkg/runtime].
 func (r *LocalRuntime) runCompactionAgent(ctx context.Context, a *agent.Agent, sess *session.Session) error {
 	t := team.New(team.WithAgents(a))
-	rt, err := New(t, WithSessionCompaction(false))
+	rt, err := New(ctx, t, WithSessionCompaction(false))
 	if err != nil {
 		return err
 	}

--- a/pkg/runtime/session_compaction_test.go
+++ b/pkg/runtime/session_compaction_test.go
@@ -115,7 +115,7 @@ func TestDoCompactBeforeHookDeniesSkipsCompaction(t *testing.T) {
 	)
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm,
+	rt, err := NewLocalRuntime(t.Context(), tm,
 		WithSessionCompaction(false),
 		WithModelStore(mockModelStoreWithLimit{limit: 100_000}),
 	)
@@ -172,7 +172,7 @@ func TestDoCompactBeforeHookSuppliesSummary(t *testing.T) {
 	)
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm,
+	rt, err := NewLocalRuntime(t.Context(), tm,
 		WithSessionCompaction(false),
 		WithModelStore(mockModelStoreWithLimit{limit: 100_000}),
 	)
@@ -248,7 +248,7 @@ func TestDoCompactAfterHookFires(t *testing.T) {
 	)
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm,
+	rt, err := NewLocalRuntime(t.Context(), tm,
 		WithSessionCompaction(false),
 		WithModelStore(mockModelStoreWithLimit{limit: 100_000}),
 	)
@@ -289,7 +289,7 @@ func TestDoCompactNoHooksMatchesPriorBehavior(t *testing.T) {
 	root := agent.New("root", "test", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm,
+	rt, err := NewLocalRuntime(t.Context(), tm,
 		WithSessionCompaction(false),
 		WithModelStore(mockModelStoreWithLimit{limit: 100_000}),
 	)

--- a/pkg/runtime/skill_runner.go
+++ b/pkg/runtime/skill_runner.go
@@ -40,7 +40,7 @@ func (r *LocalRuntime) RunSkillFork(ctx context.Context, sess *session.Session, 
 		return errResult, nil
 	}
 
-	ca := r.CurrentAgentName()
+	ca := r.currentAgentName()
 
 	// Open the span before any pre-delegation work so model resolution
 	// (inside WithAgentModel) is recorded under runtime.run_skill rather

--- a/pkg/runtime/telemetry_test.go
+++ b/pkg/runtime/telemetry_test.go
@@ -107,7 +107,7 @@ func TestWithTelemetry_AppliedToRuntime(t *testing.T) {
 	tm := team.New(team.WithAgents(root))
 
 	rec := &recordingTelemetry{}
-	rt, err := NewLocalRuntime(tm,
+	rt, err := NewLocalRuntime(t.Context(), tm,
 		WithTelemetry(rec),
 		WithModelStore(mockModelStore{}),
 	)
@@ -123,7 +123,7 @@ func TestWithTelemetry_NilLeavesDefault(t *testing.T) {
 	root := agent.New("root", "test", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm,
+	rt, err := NewLocalRuntime(t.Context(), tm,
 		WithTelemetry(nil),
 		WithModelStore(mockModelStore{}),
 	)
@@ -146,7 +146,7 @@ func TestRuntime_RecordsSessionStartAndEnd(t *testing.T) {
 	root := agent.New("root", "test", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm,
+	rt, err := NewLocalRuntime(t.Context(), tm,
 		WithTelemetry(rec),
 		WithSessionCompaction(false),
 		WithModelStore(mockModelStore{}),

--- a/pkg/runtime/transforms_test.go
+++ b/pkg/runtime/transforms_test.go
@@ -98,7 +98,7 @@ func TestStripUnsupportedModalitiesTransform(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			r, err := NewLocalRuntime(tm, WithModelStore(tc.store))
+			r, err := NewLocalRuntime(t.Context(), tm, WithModelStore(tc.store))
 			require.NoError(t, err)
 
 			got, err := r.stripUnsupportedModalitiesTransform(t.Context(),
@@ -138,7 +138,7 @@ func TestStripUnsupportedModalitiesTransform_UsesInputModelID(t *testing.T) {
 		"multi/modal":           {Modalities: modelsdev.Modalities{Input: []string{"text", "image"}}},
 		"test/agent-pool-model": {Modalities: modelsdev.Modalities{Input: []string{"text", "image"}}},
 	}}
-	r, err := NewLocalRuntime(tm, WithModelStore(store))
+	r, err := NewLocalRuntime(t.Context(), tm, WithModelStore(store))
 	require.NoError(t, err)
 
 	imgMsg := chat.Message{
@@ -173,7 +173,7 @@ func TestApplyBeforeLLMCallTransforms_NoTransformsIsCheap(t *testing.T) {
 	prov := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
 	a := agent.New("root", "instructions", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(a))
-	r, err := NewLocalRuntime(tm, WithModelStore(mockModelStore{}))
+	r, err := NewLocalRuntime(t.Context(), tm, WithModelStore(mockModelStore{}))
 	require.NoError(t, err)
 
 	// Drop the runtime-shipped strip transform so we can observe the
@@ -209,7 +209,7 @@ func TestApplyBeforeLLMCallTransforms_OrderAndChain(t *testing.T) {
 	prov := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
 	a := agent.New("root", "instructions", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(a))
-	r, err := NewLocalRuntime(tm,
+	r, err := NewLocalRuntime(t.Context(), tm,
 		WithModelStore(mockModelStore{}),
 		WithMessageTransform("tag_a", tag("tag_a")),
 		WithMessageTransform("tag_b", tag("tag_b")),
@@ -251,7 +251,7 @@ func TestApplyBeforeLLMCallTransforms_ErrorsAreSwallowed(t *testing.T) {
 	prov := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
 	a := agent.New("root", "instructions", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(a))
-	r, err := NewLocalRuntime(tm,
+	r, err := NewLocalRuntime(t.Context(), tm,
 		WithModelStore(mockModelStore{}),
 		WithMessageTransform("failing", failing),
 		WithMessageTransform("tag", tag),
@@ -286,7 +286,7 @@ func TestRunStream_StripsImagesForTextOnlyModel(t *testing.T) {
 	store := modalityModelStore{model: &modelsdev.Model{
 		Modalities: modelsdev.Modalities{Input: []string{"text"}},
 	}}
-	r, err := NewLocalRuntime(tm, WithSessionCompaction(false), WithModelStore(store))
+	r, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(store))
 	require.NoError(t, err)
 
 	sess := session.New()
@@ -323,7 +323,7 @@ func TestRunStream_TransformErrorDoesNotBreakRun(t *testing.T) {
 
 	a := agent.New("root", "instructions", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(a))
-	r, err := NewLocalRuntime(tm,
+	r, err := NewLocalRuntime(t.Context(), tm,
 		WithSessionCompaction(false),
 		WithModelStore(mockModelStore{}),
 		WithMessageTransform("failing", failing),
@@ -350,7 +350,7 @@ func TestWithMessageTransform_RejectsEmptyAndNil(t *testing.T) {
 	a := agent.New("root", "instructions", agent.WithModel(prov))
 	tm := team.New(team.WithAgents(a))
 
-	r, err := NewLocalRuntime(tm,
+	r, err := NewLocalRuntime(t.Context(), tm,
 		WithModelStore(mockModelStore{}),
 		WithMessageTransform("", func(_ context.Context, _ *hooks.Input, msgs []chat.Message) ([]chat.Message, error) {
 			return msgs, nil

--- a/pkg/runtime/turn_end_test.go
+++ b/pkg/runtime/turn_end_test.go
@@ -84,7 +84,7 @@ func TestTurnEndFiresOnNormalStop(t *testing.T) {
 	)
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm,
+	rt, err := NewLocalRuntime(t.Context(), tm,
 		WithSessionCompaction(false),
 		WithModelStore(mockModelStore{}),
 	)
@@ -129,7 +129,7 @@ func TestTurnEndFiresOnHookBlocked(t *testing.T) {
 	)
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm,
+	rt, err := NewLocalRuntime(t.Context(), tm,
 		WithSessionCompaction(false),
 		WithModelStore(mockModelStore{}),
 	)
@@ -179,7 +179,7 @@ func TestTurnEndFiresOnStreamError(t *testing.T) {
 	)
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm,
+	rt, err := NewLocalRuntime(t.Context(), tm,
 		WithSessionCompaction(false),
 		WithModelStore(mockModelStore{}),
 	)
@@ -272,7 +272,7 @@ func TestTurnEndFiresOnContextCancellation(t *testing.T) {
 	)
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm,
+	rt, err := NewLocalRuntime(t.Context(), tm,
 		WithSessionCompaction(false),
 		WithModelStore(mockModelStore{}),
 	)
@@ -364,7 +364,7 @@ func TestTurnEndFiresEveryIteration(t *testing.T) {
 	)
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm,
+	rt, err := NewLocalRuntime(t.Context(), tm,
 		WithSessionCompaction(false),
 		WithModelStore(mockModelStore{}),
 	)

--- a/pkg/runtime/user_prompt_submit_test.go
+++ b/pkg/runtime/user_prompt_submit_test.go
@@ -88,7 +88,7 @@ func TestUserSteeringMessagesSubmitFiresOnDrain(t *testing.T) {
 	)
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm,
+	rt, err := NewLocalRuntime(t.Context(), tm,
 		WithSessionCompaction(false),
 		WithModelStore(mockModelStore{}),
 	)
@@ -148,7 +148,7 @@ func setupUserPromptSubmitCounter(t *testing.T, opts ...session.Opt) (*atomic.In
 	)
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm,
+	rt, err := NewLocalRuntime(t.Context(), tm,
 		WithSessionCompaction(false),
 		WithModelStore(mockModelStore{}),
 	)
@@ -204,7 +204,7 @@ func TestUserFollowupSubmitFiresOnDequeue(t *testing.T) {
 	)
 	tm := team.New(team.WithAgents(root))
 
-	rt, err := NewLocalRuntime(tm,
+	rt, err := NewLocalRuntime(t.Context(), tm,
 		WithSessionCompaction(false),
 		WithModelStore(mockModelStore{}),
 	)

--- a/pkg/runtime/user_prompt_submit_test.go
+++ b/pkg/runtime/user_prompt_submit_test.go
@@ -105,8 +105,8 @@ func TestUserSteeringMessagesSubmitFiresOnDrain(t *testing.T) {
 
 	// Enqueue before RunStream so the messages are drained at the
 	// idle/first-turn drain site at the top of the run loop.
-	require.NoError(t, rt.Steer(QueuedMessage{Content: "steer one"}))
-	require.NoError(t, rt.Steer(QueuedMessage{Content: "steer two"}))
+	require.NoError(t, rt.Steer(t.Context(), QueuedMessage{Content: "steer one"}))
+	require.NoError(t, rt.Steer(t.Context(), QueuedMessage{Content: "steer two"}))
 
 	sess := session.New()
 	sess.Title = "Unit Test"
@@ -221,7 +221,7 @@ func TestUserFollowupSubmitFiresOnDequeue(t *testing.T) {
 
 	// Enqueue before RunStream so the follow-up is dequeued when the
 	// first turn stops.
-	require.NoError(t, rt.FollowUp(QueuedMessage{Content: "please also do this"}))
+	require.NoError(t, rt.FollowUp(t.Context(), QueuedMessage{Content: "please also do this"}))
 
 	sess := session.New(session.WithUserMessage("hi"))
 	sess.Title = "Unit Test"

--- a/pkg/sandbox/kit/kit.go
+++ b/pkg/sandbox/kit/kit.go
@@ -242,7 +242,7 @@ func Build(ctx context.Context, opts Options) (*Result, error) {
 		cfg = &latestcfg.Config{}
 	}
 
-	skillsEntries, redactions, err := stageSkills(stagingDir, cfg)
+	skillsEntries, redactions, err := stageSkills(ctx, stagingDir, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -380,7 +380,7 @@ func loadConfig(ctx context.Context, opts Options) (*latestcfg.Config, error) {
 // filter, only the union of those filters is staged. An agent that
 // enables local skills without a filter is the wide case — every local
 // skill is staged.
-func stageSkills(kitDir string, cfg *latestcfg.Config) ([]Entry, []Redaction, error) {
+func stageSkills(ctx context.Context, kitDir string, cfg *latestcfg.Config) ([]Entry, []Redaction, error) {
 	target := filepath.Join(kitDir, skills.KitSkillsSubdir)
 	if err := os.MkdirAll(target, 0o750); err != nil {
 		return nil, nil, fmt.Errorf("creating kit skills dir: %w", err)
@@ -395,7 +395,7 @@ func stageSkills(kitDir string, cfg *latestcfg.Config) ([]Entry, []Redaction, er
 		entries    []Entry
 		redactions []Redaction
 	)
-	for _, skill := range skills.Load([]string{"local"}) {
+	for _, skill := range skills.Load(ctx, []string{"local"}) {
 		if skill.BaseDir == "" {
 			continue
 		}

--- a/pkg/server/server_attached_test.go
+++ b/pkg/server/server_attached_test.go
@@ -31,7 +31,7 @@ func TestAttachedServer_SteerReachesAttachedRuntime(t *testing.T) {
 
 	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
 	fake := &fakeRuntime{}
-	sm.AttachRuntime(sess.ID, fake, sess)
+	sm.AttachRuntime(t.Context(), sess.ID, fake, sess)
 
 	srv := NewWithManager(sm, "")
 
@@ -56,7 +56,7 @@ func TestAttachedServer_EventStreamEmitsRegisteredEvents(t *testing.T) {
 	require.NoError(t, store.AddSession(ctx, sess))
 
 	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
-	sm.AttachRuntime(sess.ID, &fakeRuntime{}, sess)
+	sm.AttachRuntime(t.Context(), sess.ID, &fakeRuntime{}, sess)
 
 	events := make(chan any, 4)
 	sm.RegisterEventSource(sess.ID, func(ctx context.Context, send func(any)) {
@@ -138,7 +138,7 @@ func TestAttachedServer_DeleteSessionStopsEventStream(t *testing.T) {
 	require.NoError(t, store.AddSession(ctx, sess))
 
 	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
-	sm.AttachRuntime(sess.ID, &fakeRuntime{}, sess)
+	sm.AttachRuntime(t.Context(), sess.ID, &fakeRuntime{}, sess)
 
 	sourceStarted := make(chan struct{})
 	sourceCtxDone := make(chan struct{})
@@ -203,7 +203,7 @@ func TestAttachedServer_StatusEndpointReturnsCurrentState(t *testing.T) {
 
 	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
 	fake := &fakeRuntime{}
-	sm.AttachRuntime(sess.ID, fake, sess)
+	sm.AttachRuntime(t.Context(), sess.ID, fake, sess)
 
 	srv := NewWithManager(sm, "")
 
@@ -235,7 +235,7 @@ func TestAttachedServer_FollowUpWhileIdleReturnsQueuedIdle(t *testing.T) {
 	require.NoError(t, store.AddSession(ctx, sess))
 
 	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
-	sm.AttachRuntime(sess.ID, &fakeRuntime{}, sess)
+	sm.AttachRuntime(t.Context(), sess.ID, &fakeRuntime{}, sess)
 
 	srv := NewWithManager(sm, "")
 
@@ -262,7 +262,7 @@ func TestAttachedServer_ReadyEndpointReturnsImmediately(t *testing.T) {
 	require.NoError(t, store.AddSession(ctx, sess))
 
 	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
-	sm.AttachRuntime(sess.ID, &fakeRuntime{}, sess)
+	sm.AttachRuntime(t.Context(), sess.ID, &fakeRuntime{}, sess)
 
 	srv := NewWithManager(sm, "")
 
@@ -313,7 +313,7 @@ func TestAttachedServer_DeleteWithWaitBlocksUntilStreamStops(t *testing.T) {
 
 	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
 	fake := &fakeRuntime{streamDelay: 200 * time.Millisecond}
-	sm.AttachRuntime(sess.ID, fake, sess)
+	sm.AttachRuntime(t.Context(), sess.ID, fake, sess)
 
 	srv := NewWithManager(sm, "")
 
@@ -350,7 +350,7 @@ func TestAttachedServer_EventStreamReplaysFromLastEventID(t *testing.T) {
 	require.NoError(t, store.AddSession(ctx, sess))
 
 	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
-	sm.AttachRuntime(sess.ID, &fakeRuntime{}, sess)
+	sm.AttachRuntime(t.Context(), sess.ID, &fakeRuntime{}, sess)
 
 	events := make(chan any, 8)
 	sm.RegisterEventSource(sess.ID, func(ctx context.Context, send func(any)) {
@@ -405,7 +405,7 @@ func TestAttachedServer_EventStreamSignalsGapWhenResumePointEvicted(t *testing.T
 	require.NoError(t, store.AddSession(ctx, sess))
 
 	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
-	sm.AttachRuntime(sess.ID, &fakeRuntime{}, sess)
+	sm.AttachRuntime(t.Context(), sess.ID, &fakeRuntime{}, sess)
 
 	// Tiny buffer so early events are evicted.
 	_, pumpCancel := context.WithCancel(t.Context())
@@ -476,7 +476,7 @@ func TestAttachedServer_SnapshotReturnsStateAndLastEventSeq(t *testing.T) {
 	require.NoError(t, store.AddSession(ctx, sess))
 
 	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
-	sm.AttachRuntime(sess.ID, &fakeRuntime{}, sess)
+	sm.AttachRuntime(t.Context(), sess.ID, &fakeRuntime{}, sess)
 
 	events := make(chan any, 4)
 	sm.RegisterEventSource(sess.ID, func(ctx context.Context, send func(any)) {
@@ -543,7 +543,7 @@ func TestAttachedServer_DeleteEmitsSessionExited(t *testing.T) {
 	require.NoError(t, store.AddSession(ctx, sess))
 
 	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
-	sm.AttachRuntime(sess.ID, &fakeRuntime{}, sess)
+	sm.AttachRuntime(t.Context(), sess.ID, &fakeRuntime{}, sess)
 	sm.RegisterEventSource(sess.ID, func(ctx context.Context, _ func(any)) {
 		<-ctx.Done()
 	})
@@ -584,7 +584,7 @@ func TestAttachedServer_FollowUpIdempotencyKeyDedupes(t *testing.T) {
 	require.NoError(t, store.AddSession(ctx, sess))
 
 	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
-	sm.AttachRuntime(sess.ID, &fakeRuntime{}, sess)
+	sm.AttachRuntime(t.Context(), sess.ID, &fakeRuntime{}, sess)
 
 	var mu sync.Mutex
 	var delivered []string
@@ -650,7 +650,7 @@ func TestAttachedServer_StatusWaitBlocksUntilAttached(t *testing.T) {
 	// Attach a little later, while the request is already waiting.
 	go func() {
 		time.Sleep(80 * time.Millisecond)
-		sm.AttachRuntime(sess.ID, &fakeRuntime{}, sess)
+		sm.AttachRuntime(t.Context(), sess.ID, &fakeRuntime{}, sess)
 	}()
 
 	resp := httpDoTCP(t, ctx, http.MethodGet, addr+"/api/sessions/"+sess.ID+"/status?wait=5s", nil)

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -971,7 +971,7 @@ func (sm *SessionManager) runtimeForSession(ctx context.Context, sess *session.S
 		runtime.WithTracer(otel.Tracer("cagent")),
 		runtime.WithModelSwitcherConfig(modelSwitcherCfg),
 	}
-	run, err := runtime.New(t, opts...)
+	run, err := runtime.New(ctx, t, opts...)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -202,6 +202,7 @@ func (sm *SessionManager) StreamEvents(ctx context.Context, sessionID string, si
 // SSE streams and other lifetime-bound consumers use it (via
 // [SessionManager.StreamEvents]) to terminate when the session is detached.
 func (sm *SessionManager) AttachRuntime(sessionID string, rt runtime.Runtime, sess *session.Session) {
+	//rubocop:disable Lint/ContextConnectivity
 	ctx, cancel := context.WithCancel(context.Background())
 	sm.runtimeSessions.Store(sessionID, &activeRuntimes{
 		runtime: rt,

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -255,7 +255,7 @@ func (sm *SessionManager) WaitSessionAttached(ctx context.Context, sessionID str
 // GetSessionStatus returns a lightweight snapshot of the session's current
 // runtime state. Designed for late-joining SSE consumers that need to know
 // the session's state without waiting for the next event transition.
-func (sm *SessionManager) GetSessionStatus(_ context.Context, id string) (*api.SessionStatusResponse, error) {
+func (sm *SessionManager) GetSessionStatus(ctx context.Context, id string) (*api.SessionStatusResponse, error) {
 	rs, ok := sm.runtimeSessions.Load(id)
 	if !ok {
 		return nil, fmt.Errorf("session %s not found", id)
@@ -274,7 +274,7 @@ func (sm *SessionManager) GetSessionStatus(_ context.Context, id string) (*api.S
 		ID:           sess.ID,
 		Title:        sess.Title,
 		Streaming:    streaming,
-		Agent:        rs.runtime.CurrentAgentName(),
+		Agent:        rs.runtime.CurrentAgentName(ctx),
 		InputTokens:  sess.InputTokens,
 		OutputTokens: sess.OutputTokens,
 		NumMessages:  len(sess.GetAllMessages()),
@@ -295,7 +295,7 @@ func (sm *SessionManager) GetSessionSnapshot(ctx context.Context, id string) (*a
 	agent := ""
 	if rs, ok := sm.runtimeSessions.Load(id); ok {
 		sess = rs.session
-		agent = rs.runtime.CurrentAgentName()
+		agent = rs.runtime.CurrentAgentName(ctx)
 		// Probe streaming state without interfering: TryLock succeeds only
 		// when no RunStream is in progress.
 		if rs.streaming.TryLock() {
@@ -718,14 +718,14 @@ func (sm *SessionManager) ResumeSession(ctx context.Context, sessionID, confirma
 // session. The messages are picked up by the agent loop after the current tool
 // calls finish but before the next LLM call. Returns an error if the session
 // is not actively running or if the steer buffer is full.
-func (sm *SessionManager) SteerSession(_ context.Context, sessionID string, messages []api.Message) error {
+func (sm *SessionManager) SteerSession(ctx context.Context, sessionID string, messages []api.Message) error {
 	rt, exists := sm.runtimeSessions.Load(sessionID)
 	if !exists {
 		return ErrSessionNotRunning
 	}
 
 	for _, msg := range messages {
-		if err := rt.runtime.Steer(runtime.QueuedMessage{
+		if err := rt.runtime.Steer(ctx, runtime.QueuedMessage{
 			Content:      msg.Content,
 			MultiContent: msg.MultiContent,
 		}); err != nil {
@@ -786,7 +786,7 @@ func (sm *SessionManager) FollowUpSession(ctx context.Context, sessionID string,
 	}
 
 	for _, msg := range messages {
-		if err := rt.runtime.FollowUp(runtime.QueuedMessage{
+		if err := rt.runtime.FollowUp(ctx, runtime.QueuedMessage{
 			Content:      msg.Content,
 			MultiContent: msg.MultiContent,
 		}); err != nil {
@@ -1033,7 +1033,7 @@ func (sm *SessionManager) applyRunModelOverride(ctx context.Context, rs *activeR
 		return "", false, noop, ErrModelSwitchingNotSupported
 	}
 
-	agentName := rs.runtime.CurrentAgentName()
+	agentName := rs.runtime.CurrentAgentName(ctx)
 	sess := rs.session
 
 	if sess != nil && sess.AgentModelOverrides != nil {
@@ -1213,7 +1213,7 @@ func (sm *SessionManager) AvailableSessionModels(ctx context.Context, sessionID 
 		return "", "", nil, ErrModelSwitchingNotSupported
 	}
 
-	agentName := rs.runtime.CurrentAgentName()
+	agentName := rs.runtime.CurrentAgentName(ctx)
 
 	// Snapshot the override and custom-model history under sm.mux so the
 	// read is atomic with respect to SetSessionAgentModel writes. The
@@ -1258,7 +1258,7 @@ func (sm *SessionManager) SetSessionAgentModel(ctx context.Context, sessionID, m
 		return "", "", ErrModelSwitchingNotSupported
 	}
 
-	agentName := rs.runtime.CurrentAgentName()
+	agentName := rs.runtime.CurrentAgentName(ctx)
 	sess := rs.session
 
 	// Snapshot current state so we can roll back if persistence fails

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -201,9 +201,8 @@ func (sm *SessionManager) StreamEvents(ctx context.Context, sessionID string, si
 // The internal cancellation signal is fired by [SessionManager.DeleteSession];
 // SSE streams and other lifetime-bound consumers use it (via
 // [SessionManager.StreamEvents]) to terminate when the session is detached.
-func (sm *SessionManager) AttachRuntime(sessionID string, rt runtime.Runtime, sess *session.Session) {
-	//rubocop:disable Lint/ContextConnectivity
-	ctx, cancel := context.WithCancel(context.Background())
+func (sm *SessionManager) AttachRuntime(ctx context.Context, sessionID string, rt runtime.Runtime, sess *session.Session) {
+	ctx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 	sm.runtimeSessions.Store(sessionID, &activeRuntimes{
 		runtime: rt,
 		done:    ctx.Done(),

--- a/pkg/server/session_manager_test.go
+++ b/pkg/server/session_manager_test.go
@@ -104,7 +104,7 @@ func TestAttachRuntime_RegistersRuntimeForExternalDriver(t *testing.T) {
 
 	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
 	fake := &fakeRuntime{streamDelay: 10 * time.Millisecond}
-	sm.AttachRuntime(sess.ID, fake, sess)
+	sm.AttachRuntime(t.Context(), sess.ID, fake, sess)
 
 	// Steer routes through the attached runtime, not a freshly built one.
 	require.NoError(t, sm.SteerSession(ctx, sess.ID, []api.Message{{Content: "hi"}}))

--- a/pkg/server/session_manager_test.go
+++ b/pkg/server/session_manager_test.go
@@ -49,15 +49,15 @@ func (f *fakeRuntime) RunStream(_ context.Context, _ *session.Session) <-chan ru
 
 func (f *fakeRuntime) Resume(_ context.Context, _ runtime.ResumeRequest) {}
 
-func (f *fakeRuntime) Steer(_ runtime.QueuedMessage) error { return nil }
+func (f *fakeRuntime) Steer(_ context.Context, _ runtime.QueuedMessage) error { return nil }
 
-func (f *fakeRuntime) FollowUp(_ runtime.QueuedMessage) error { return nil }
+func (f *fakeRuntime) FollowUp(_ context.Context, _ runtime.QueuedMessage) error { return nil }
 
 func (f *fakeRuntime) ResumeElicitation(_ context.Context, _ tools.ElicitationAction, _ map[string]any) error {
 	return nil
 }
 
-func (f *fakeRuntime) CurrentAgentName() string { return "root" }
+func (f *fakeRuntime) CurrentAgentName(context.Context) string { return "root" }
 
 // SupportsModelSwitching reports false by default. Tests that exercise
 // the /models endpoints embed fakeRuntime and override this.
@@ -269,7 +269,7 @@ type recordingFollowUpRuntime struct {
 	followUps []string
 }
 
-func (r *recordingFollowUpRuntime) FollowUp(msg runtime.QueuedMessage) error {
+func (r *recordingFollowUpRuntime) FollowUp(_ context.Context, msg runtime.QueuedMessage) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.followUps = append(r.followUps, msg.Content)

--- a/pkg/server/session_models_test.go
+++ b/pkg/server/session_models_test.go
@@ -55,7 +55,7 @@ func newModelSwitchingRuntime(models []runtime.ModelChoice) *modelSwitchingRunti
 	}
 }
 
-func (m *modelSwitchingRuntime) CurrentAgentName() string { return m.currentAgent }
+func (m *modelSwitchingRuntime) CurrentAgentName(context.Context) string { return m.currentAgent }
 
 func (m *modelSwitchingRuntime) SupportsModelSwitching() bool { return true }
 

--- a/pkg/server/session_models_test.go
+++ b/pkg/server/session_models_test.go
@@ -172,7 +172,7 @@ func TestAttachedServer_GetSessionModels(t *testing.T) {
 	fake := newModelSwitchingRuntime(choices)
 
 	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
-	sm.AttachRuntime(sess.ID, fake, sess)
+	sm.AttachRuntime(t.Context(), sess.ID, fake, sess)
 
 	addr := startAttachedServer(t, ctx, sm)
 	resp := httpDoTCP(t, ctx, http.MethodGet, addr+"/api/sessions/"+sess.ID+"/models", nil)
@@ -208,7 +208,7 @@ func TestAttachedServer_GetSessionModels_DefaultMarkedCurrent(t *testing.T) {
 	fake := newModelSwitchingRuntime(choices)
 
 	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
-	sm.AttachRuntime(sess.ID, fake, sess)
+	sm.AttachRuntime(t.Context(), sess.ID, fake, sess)
 
 	addr := startAttachedServer(t, ctx, sm)
 	resp := httpDoTCP(t, ctx, http.MethodGet, addr+"/api/sessions/"+sess.ID+"/models", nil)
@@ -240,7 +240,7 @@ func TestAttachedServer_GetSessionModels_AppendsCustomModels(t *testing.T) {
 	fake := newModelSwitchingRuntime(choices)
 
 	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
-	sm.AttachRuntime(sess.ID, fake, sess)
+	sm.AttachRuntime(t.Context(), sess.ID, fake, sess)
 
 	addr := startAttachedServer(t, ctx, sm)
 	resp := httpDoTCP(t, ctx, http.MethodGet, addr+"/api/sessions/"+sess.ID+"/models", nil)
@@ -271,7 +271,7 @@ func TestAttachedServer_SetSessionModel_PersistsViaRunAgent(t *testing.T) {
 	fake := newModelSwitchingRuntime(nil)
 
 	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
-	sm.AttachRuntime(sess.ID, fake, sess)
+	sm.AttachRuntime(t.Context(), sess.ID, fake, sess)
 
 	addr := startAttachedServer(t, ctx, sm)
 	resp := httpDoTCP(t, ctx, http.MethodPost,
@@ -313,7 +313,7 @@ func TestAttachedServer_RunAgent_EmptyModelLeavesOverrideUntouched(t *testing.T)
 	fake.overrides["root"] = "openai/gpt-4o"
 
 	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
-	sm.AttachRuntime(sess.ID, fake, sess)
+	sm.AttachRuntime(t.Context(), sess.ID, fake, sess)
 
 	addr := startAttachedServer(t, ctx, sm)
 	_ = httpDoTCP(t, ctx, http.MethodPost,
@@ -340,7 +340,7 @@ func TestAttachedServer_GetSessionModels_NotSupported(t *testing.T) {
 	require.NoError(t, store.AddSession(ctx, sess))
 
 	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
-	sm.AttachRuntime(sess.ID, &fakeRuntime{}, sess)
+	sm.AttachRuntime(t.Context(), sess.ID, &fakeRuntime{}, sess)
 
 	addr := startAttachedServer(t, ctx, sm)
 
@@ -385,7 +385,7 @@ func TestSessionManager_SetSessionAgentModel_RollsBackOnStoreFailure(t *testing.
 	fake := newModelSwitchingRuntime(nil)
 
 	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
-	sm.AttachRuntime(sess.ID, fake, sess)
+	sm.AttachRuntime(t.Context(), sess.ID, fake, sess)
 
 	store.mu.Lock()
 	store.failUpdate = true
@@ -422,7 +422,7 @@ func TestSessionManager_SetSessionAgentModel_RuntimeFailureLeavesStateUntouched(
 	fake.setErr = errors.New("runtime says no")
 
 	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
-	sm.AttachRuntime(sess.ID, fake, sess)
+	sm.AttachRuntime(t.Context(), sess.ID, fake, sess)
 
 	_, _, err := sm.SetSessionAgentModel(ctx, sess.ID, "anthropic/claude-sonnet-4-0")
 	require.Error(t, err)
@@ -446,7 +446,7 @@ func TestAttachedServer_RunAgent_StoreFailureReturns500(t *testing.T) {
 	fake := newModelSwitchingRuntime(nil)
 
 	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
-	sm.AttachRuntime(sess.ID, fake, sess)
+	sm.AttachRuntime(t.Context(), sess.ID, fake, sess)
 
 	store.mu.Lock()
 	store.failUpdate = true
@@ -516,8 +516,8 @@ func TestSessionManager_AvailableSessionModels_DoesNotHoldMuxDuringRuntimeIO(t *
 	slow.availableModelsDelay = release
 
 	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
-	sm.AttachRuntime(slowSess.ID, slow, slowSess)
-	sm.AttachRuntime(unrelatedSess.ID, &fakeRuntime{}, unrelatedSess)
+	sm.AttachRuntime(t.Context(), slowSess.ID, slow, slowSess)
+	sm.AttachRuntime(t.Context(), unrelatedSess.ID, &fakeRuntime{}, unrelatedSess)
 
 	// Start a slow AvailableSessionModels call on the first session.
 	done := make(chan struct{})
@@ -575,8 +575,8 @@ func TestSessionManager_SetSessionAgentModel_DoesNotHoldMuxDuringRuntimeIO(t *te
 	slow.setAgentModelDelay = release
 
 	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
-	sm.AttachRuntime(slowSess.ID, slow, slowSess)
-	sm.AttachRuntime(unrelatedSess.ID, &fakeRuntime{}, unrelatedSess)
+	sm.AttachRuntime(t.Context(), slowSess.ID, slow, slowSess)
+	sm.AttachRuntime(t.Context(), unrelatedSess.ID, &fakeRuntime{}, unrelatedSess)
 
 	done := make(chan struct{})
 	go func() {

--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -462,8 +462,8 @@ func (s *InMemorySessionStore) Close() error {
 // at path. If migrations fail (other than a version mismatch or a filesystem
 // open failure) the existing database is moved aside to <path>.bak and a
 // fresh one is created.
-func NewSQLiteSessionStore(path string) (Store, error) {
-	store, err := openAndMigrateSQLiteStore(path)
+func NewSQLiteSessionStore(ctx context.Context, path string) (Store, error) {
+	store, err := openAndMigrateSQLiteStore(ctx, path)
 	if err != nil {
 		// Don't attempt recovery for version mismatch - the user needs to upgrade,
 		// not silently lose their data by starting fresh.
@@ -481,22 +481,22 @@ func NewSQLiteSessionStore(path string) (Store, error) {
 		}
 
 		// If migrations failed, try to recover by backing up the database and starting fresh
-		slog.Warn("Failed to open session store, attempting recovery", "error", err)
+		slog.WarnContext(ctx, "Failed to open session store, attempting recovery", "error", err)
 
 		backupErr := backupDatabase(path)
 		if backupErr != nil {
 			// Return the original error if backup failed
-			slog.Error("Failed to backup database for recovery", "error", backupErr)
+			slog.ErrorContext(ctx, "Failed to backup database for recovery", "error", backupErr)
 			return nil, fmt.Errorf("migration failed: %w (backup also failed: %w)", err, backupErr)
 		}
 
 		// Try again with a fresh database
-		store, err = openAndMigrateSQLiteStore(path)
+		store, err = openAndMigrateSQLiteStore(ctx, path)
 		if err != nil {
 			return nil, fmt.Errorf("migration failed even after database reset: %w", err)
 		}
 
-		slog.Info("Successfully recovered session store with fresh database")
+		slog.InfoContext(ctx, "Successfully recovered session store with fresh database")
 	}
 
 	return store, nil
@@ -510,24 +510,24 @@ func NewSQLiteSessionStore(path string) (Store, error) {
 // This is intended primarily for tests that want to use an in-memory database
 // (sql.Open("sqlite", ":memory:")) or pre-seed a database with non-default
 // state. Production callers should use NewSQLiteSessionStore.
-func NewSQLiteSessionStoreFromDB(db *sql.DB) (*SQLiteSessionStore, error) {
+func NewSQLiteSessionStoreFromDB(ctx context.Context, db *sql.DB) (*SQLiteSessionStore, error) {
 	if db == nil {
 		return nil, errors.New("db is nil")
 	}
-	if err := setupAndMigrate(db); err != nil {
+	if err := setupAndMigrate(ctx, db); err != nil {
 		return nil, err
 	}
 	return &SQLiteSessionStore{db: db}, nil
 }
 
 // openAndMigrateSQLiteStore opens the database and runs migrations
-func openAndMigrateSQLiteStore(path string) (*SQLiteSessionStore, error) {
-	db, err := sqliteutil.OpenDB(path)
+func openAndMigrateSQLiteStore(ctx context.Context, path string) (*SQLiteSessionStore, error) {
+	db, err := sqliteutil.OpenDB(ctx, path)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := setupAndMigrate(db); err != nil {
+	if err := setupAndMigrate(ctx, db); err != nil {
 		db.Close()
 		if sqliteutil.IsCantOpenError(err) {
 			return nil, sqliteutil.DiagnoseDBOpenError(path, err)
@@ -542,9 +542,8 @@ func openAndMigrateSQLiteStore(path string) (*SQLiteSessionStore, error) {
 // all pending schema migrations. The bootstrap schema only declares the
 // columns the very first migration expects to find; later columns are added
 // by subsequent ALTER TABLE migrations.
-func setupAndMigrate(db *sql.DB) error {
-	//rubocop:disable Lint/ContextConnectivity
-	_, err := db.ExecContext(context.Background(), `
+func setupAndMigrate(ctx context.Context, db *sql.DB) error {
+	_, err := db.ExecContext(ctx, `
 		CREATE TABLE IF NOT EXISTS sessions (
 			id TEXT PRIMARY KEY,
 			messages TEXT,
@@ -556,8 +555,7 @@ func setupAndMigrate(db *sql.DB) error {
 	}
 
 	migrationManager := NewMigrationManager(db)
-	//rubocop:disable Lint/ContextConnectivity
-	return migrationManager.InitializeMigrations(context.Background())
+	return migrationManager.InitializeMigrations(ctx)
 }
 
 // backupDatabase moves the database file (and related WAL files) to a backup

--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -543,6 +543,7 @@ func openAndMigrateSQLiteStore(path string) (*SQLiteSessionStore, error) {
 // columns the very first migration expects to find; later columns are added
 // by subsequent ALTER TABLE migrations.
 func setupAndMigrate(db *sql.DB) error {
+	//rubocop:disable Lint/ContextConnectivity
 	_, err := db.ExecContext(context.Background(), `
 		CREATE TABLE IF NOT EXISTS sessions (
 			id TEXT PRIMARY KEY,
@@ -555,6 +556,7 @@ func setupAndMigrate(db *sql.DB) error {
 	}
 
 	migrationManager := NewMigrationManager(db)
+	//rubocop:disable Lint/ContextConnectivity
 	return migrationManager.InitializeMigrations(context.Background())
 }
 

--- a/pkg/session/store_memory_test.go
+++ b/pkg/session/store_memory_test.go
@@ -27,14 +27,14 @@ func openMemoryStore(t *testing.T) *SQLiteSessionStore {
 	t.Cleanup(func() { _ = db.Close() })
 	db.SetMaxOpenConns(1)
 
-	store, err := NewSQLiteSessionStoreFromDB(db)
+	store, err := NewSQLiteSessionStoreFromDB(t.Context(), db)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = store.Close() })
 	return store
 }
 
 func TestNewSQLiteSessionStoreFromDB_NilDB(t *testing.T) {
-	_, err := NewSQLiteSessionStoreFromDB(nil)
+	_, err := NewSQLiteSessionStoreFromDB(t.Context(), nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "nil")
 }

--- a/pkg/session/store_test.go
+++ b/pkg/session/store_test.go
@@ -857,7 +857,7 @@ func TestMigration_ExistingMessagesToSessionItems(t *testing.T) {
 func TestAddError_SQLiteRoundTrip(t *testing.T) {
 	tempDB := filepath.Join(t.TempDir(), "test_add_error.db")
 
-	store, err := NewSQLiteSessionStore(tempDB)
+	store, err := NewSQLiteSessionStore(t.Context(), tempDB)
 	require.NoError(t, err)
 	defer store.(*SQLiteSessionStore).Close()
 

--- a/pkg/session/store_test.go
+++ b/pkg/session/store_test.go
@@ -18,7 +18,7 @@ import (
 func TestStoreAgentName(t *testing.T) {
 	tempDB := filepath.Join(t.TempDir(), "test_store.db")
 
-	store, err := NewSQLiteSessionStore(tempDB)
+	store, err := NewSQLiteSessionStore(t.Context(), tempDB)
 	require.NoError(t, err)
 	defer store.(*SQLiteSessionStore).Close()
 
@@ -70,7 +70,7 @@ func TestStoreAgentName(t *testing.T) {
 func TestStoreMultipleAgents(t *testing.T) {
 	tempDB := filepath.Join(t.TempDir(), "test_store_multi.db")
 
-	store, err := NewSQLiteSessionStore(tempDB)
+	store, err := NewSQLiteSessionStore(t.Context(), tempDB)
 	require.NoError(t, err)
 	defer store.(*SQLiteSessionStore).Close()
 
@@ -119,7 +119,7 @@ func TestStoreMultipleAgents(t *testing.T) {
 func TestGetSessions(t *testing.T) {
 	tempDB := filepath.Join(t.TempDir(), "test_get_sessions.db")
 
-	store, err := NewSQLiteSessionStore(tempDB)
+	store, err := NewSQLiteSessionStore(t.Context(), tempDB)
 	require.NoError(t, err)
 	defer store.(*SQLiteSessionStore).Close()
 
@@ -167,7 +167,7 @@ func TestGetSessions(t *testing.T) {
 func TestGetSessionSummaries(t *testing.T) {
 	tempDB := filepath.Join(t.TempDir(), "test_get_session_summaries.db")
 
-	store, err := NewSQLiteSessionStore(tempDB)
+	store, err := NewSQLiteSessionStore(t.Context(), tempDB)
 	require.NoError(t, err)
 	defer store.(*SQLiteSessionStore).Close()
 
@@ -226,7 +226,7 @@ func TestGetSessionSummaries(t *testing.T) {
 func TestBranchSessionCopiesPrefix(t *testing.T) {
 	tempDB := filepath.Join(t.TempDir(), "test_branch_prefix.db")
 
-	store, err := NewSQLiteSessionStore(tempDB)
+	store, err := NewSQLiteSessionStore(t.Context(), tempDB)
 	require.NoError(t, err)
 	defer store.(*SQLiteSessionStore).Close()
 
@@ -265,7 +265,7 @@ func TestBranchSessionCopiesPrefix(t *testing.T) {
 func TestBranchSessionClonesSubSession(t *testing.T) {
 	tempDB := filepath.Join(t.TempDir(), "test_branch_subsession.db")
 
-	store, err := NewSQLiteSessionStore(tempDB)
+	store, err := NewSQLiteSessionStore(t.Context(), tempDB)
 	require.NoError(t, err)
 	defer store.(*SQLiteSessionStore).Close()
 
@@ -311,7 +311,7 @@ func TestBranchSessionClonesSubSession(t *testing.T) {
 func TestStoreAgentNameJSON(t *testing.T) {
 	tempDB := filepath.Join(t.TempDir(), "test_store_json.db")
 
-	store, err := NewSQLiteSessionStore(tempDB)
+	store, err := NewSQLiteSessionStore(t.Context(), tempDB)
 	require.NoError(t, err)
 	defer store.(*SQLiteSessionStore).Close()
 
@@ -353,7 +353,7 @@ func TestNewSQLiteSessionStore_DirectoryNotWritable(t *testing.T) {
 	err := os.Mkdir(readOnlyDir, 0o555)
 	require.NoError(t, err)
 
-	_, err = NewSQLiteSessionStore(filepath.Join(readOnlyDir, "session.db"))
+	_, err = NewSQLiteSessionStore(t.Context(), filepath.Join(readOnlyDir, "session.db"))
 	require.Error(t, err)
 
 	assert.Contains(t, err.Error(), "cannot create database")
@@ -369,7 +369,7 @@ func TestNewSQLiteSessionStore_DirectoryNotWritable(t *testing.T) {
 func TestUpdateSession_LazyCreation(t *testing.T) {
 	tempDB := filepath.Join(t.TempDir(), "test_lazy.db")
 
-	store, err := NewSQLiteSessionStore(tempDB)
+	store, err := NewSQLiteSessionStore(t.Context(), tempDB)
 	require.NoError(t, err)
 	defer store.(*SQLiteSessionStore).Close()
 
@@ -456,7 +456,7 @@ func TestUpdateSession_LazyCreation_InMemory(t *testing.T) {
 func TestStorePermissions(t *testing.T) {
 	tempDB := filepath.Join(t.TempDir(), "test_permissions.db")
 
-	store, err := NewSQLiteSessionStore(tempDB)
+	store, err := NewSQLiteSessionStore(t.Context(), tempDB)
 	require.NoError(t, err)
 	defer store.(*SQLiteSessionStore).Close()
 
@@ -486,7 +486,7 @@ func TestStorePermissions(t *testing.T) {
 func TestStorePermissions_NilPermissions(t *testing.T) {
 	tempDB := filepath.Join(t.TempDir(), "test_nil_permissions.db")
 
-	store, err := NewSQLiteSessionStore(tempDB)
+	store, err := NewSQLiteSessionStore(t.Context(), tempDB)
 	require.NoError(t, err)
 	defer store.(*SQLiteSessionStore).Close()
 
@@ -511,7 +511,7 @@ func TestStorePermissions_NilPermissions(t *testing.T) {
 func TestUpdateSession_Permissions(t *testing.T) {
 	tempDB := filepath.Join(t.TempDir(), "test_update_permissions.db")
 
-	store, err := NewSQLiteSessionStore(tempDB)
+	store, err := NewSQLiteSessionStore(t.Context(), tempDB)
 	require.NoError(t, err)
 	defer store.(*SQLiteSessionStore).Close()
 
@@ -545,7 +545,7 @@ func TestUpdateSession_Permissions(t *testing.T) {
 func TestAgentModelOverrides_SQLite(t *testing.T) {
 	tempDB := filepath.Join(t.TempDir(), "test_model_overrides.db")
 
-	store, err := NewSQLiteSessionStore(tempDB)
+	store, err := NewSQLiteSessionStore(t.Context(), tempDB)
 	require.NoError(t, err)
 	defer store.(*SQLiteSessionStore).Close()
 
@@ -578,7 +578,7 @@ func TestAgentModelOverrides_SQLite(t *testing.T) {
 func TestAgentModelOverrides_Update(t *testing.T) {
 	tempDB := filepath.Join(t.TempDir(), "test_model_overrides_update.db")
 
-	store, err := NewSQLiteSessionStore(tempDB)
+	store, err := NewSQLiteSessionStore(t.Context(), tempDB)
 	require.NoError(t, err)
 	defer store.(*SQLiteSessionStore).Close()
 
@@ -612,7 +612,7 @@ func TestAgentModelOverrides_Update(t *testing.T) {
 func TestAgentModelOverrides_EmptyMap(t *testing.T) {
 	tempDB := filepath.Join(t.TempDir(), "test_model_overrides_empty.db")
 
-	store, err := NewSQLiteSessionStore(tempDB)
+	store, err := NewSQLiteSessionStore(t.Context(), tempDB)
 	require.NoError(t, err)
 	defer store.(*SQLiteSessionStore).Close()
 
@@ -640,7 +640,7 @@ func TestNewSQLiteSessionStore_RejectsNewerDatabase(t *testing.T) {
 	dbPath := filepath.Join(tempDir, "test_newer_db.db")
 
 	// Create a valid store first (applies all known migrations)
-	store, err := NewSQLiteSessionStore(dbPath)
+	store, err := NewSQLiteSessionStore(t.Context(), dbPath)
 	require.NoError(t, err)
 	defer store.(*SQLiteSessionStore).Close()
 
@@ -654,7 +654,7 @@ func TestNewSQLiteSessionStore_RejectsNewerDatabase(t *testing.T) {
 	db.Close()
 
 	// Opening the store should fail with a clear error about version mismatch
-	_, err = NewSQLiteSessionStore(dbPath)
+	_, err = NewSQLiteSessionStore(t.Context(), dbPath)
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrNewerDatabase)
 	assert.Contains(t, err.Error(), "9999")
@@ -671,7 +671,7 @@ func TestNewSQLiteSessionStore_MigrationFailureRecovery(t *testing.T) {
 	require.NoError(t, err)
 
 	// Opening should trigger recovery: backup the corrupt file and create fresh db
-	store, err := NewSQLiteSessionStore(dbPath)
+	store, err := NewSQLiteSessionStore(t.Context(), dbPath)
 	require.NoError(t, err)
 	defer store.(*SQLiteSessionStore).Close()
 
@@ -747,7 +747,7 @@ func TestBackupDatabase(t *testing.T) {
 func TestOrphanedSubsessionReference(t *testing.T) {
 	tempDB := filepath.Join(t.TempDir(), "test_orphaned.db")
 
-	store, err := NewSQLiteSessionStore(tempDB)
+	store, err := NewSQLiteSessionStore(t.Context(), tempDB)
 	require.NoError(t, err)
 	defer store.(*SQLiteSessionStore).Close()
 
@@ -841,7 +841,7 @@ func TestMigration_ExistingMessagesToSessionItems(t *testing.T) {
 	db.Close()
 
 	// Now open with the store, which runs migrations
-	store, err := NewSQLiteSessionStore(tempDB)
+	store, err := NewSQLiteSessionStore(t.Context(), tempDB)
 	require.NoError(t, err)
 	defer store.(*SQLiteSessionStore).Close()
 
@@ -952,7 +952,7 @@ func TestParseRelativeSessionRef(t *testing.T) {
 func TestResolveSessionID_SQLite(t *testing.T) {
 	tempDB := filepath.Join(t.TempDir(), "test_resolve.db")
 
-	store, err := NewSQLiteSessionStore(tempDB)
+	store, err := NewSQLiteSessionStore(t.Context(), tempDB)
 	require.NoError(t, err)
 	defer store.(*SQLiteSessionStore).Close()
 
@@ -1009,7 +1009,7 @@ func TestResolveSessionID_SQLite(t *testing.T) {
 func TestResolveSessionID_ExcludesSubSessions(t *testing.T) {
 	tempDB := filepath.Join(t.TempDir(), "test_resolve_subsessions.db")
 
-	store, err := NewSQLiteSessionStore(tempDB)
+	store, err := NewSQLiteSessionStore(t.Context(), tempDB)
 	require.NoError(t, err)
 	defer store.(*SQLiteSessionStore).Close()
 

--- a/pkg/skills/remote_test.go
+++ b/pkg/skills/remote_test.go
@@ -213,7 +213,7 @@ func TestLoadWithRemoteSources(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	skills := Load([]string{srv.URL})
+	skills := Load(t.Context(), []string{srv.URL})
 
 	found := false
 	for _, s := range skills {
@@ -248,7 +248,7 @@ func TestLoadWithMixedSources(t *testing.T) {
 	t.Chdir(tmpDir)
 	t.Setenv("HOME", t.TempDir())
 
-	skills := Load([]string{"local", srv.URL})
+	skills := Load(t.Context(), []string{"local", srv.URL})
 
 	found := false
 	for _, s := range skills {
@@ -261,10 +261,10 @@ func TestLoadWithMixedSources(t *testing.T) {
 }
 
 func TestLoadWithEmptySources(t *testing.T) {
-	skills := Load(nil)
+	skills := Load(t.Context(), nil)
 	assert.Empty(t, skills)
 
-	skills = Load([]string{})
+	skills = Load(t.Context(), []string{})
 	assert.Empty(t, skills)
 }
 

--- a/pkg/skills/skills.go
+++ b/pkg/skills/skills.go
@@ -82,6 +82,7 @@ func Load(sources []string) []Skill {
 			if remoteCache == nil {
 				remoteCache = newDiskCache(filepath.Join(paths.GetCacheDir(), "skills"))
 			}
+			//rubocop:disable Lint/ContextConnectivity
 			for _, skill := range loadRemoteSkills(context.Background(), source, remoteCache) {
 				skillMap[source+"/"+skill.Name] = skill
 			}

--- a/pkg/skills/skills.go
+++ b/pkg/skills/skills.go
@@ -70,7 +70,7 @@ func (s Skill) IsFork() bool {
 //     enclosing git root outside $HOME — down to cwd)
 //
 // The returned slice is sorted by skill name for deterministic ordering.
-func Load(sources []string) []Skill {
+func Load(ctx context.Context, sources []string) []Skill {
 	skillMap := make(map[string]Skill)
 
 	var remoteCache *diskCache
@@ -82,8 +82,7 @@ func Load(sources []string) []Skill {
 			if remoteCache == nil {
 				remoteCache = newDiskCache(filepath.Join(paths.GetCacheDir(), "skills"))
 			}
-			//rubocop:disable Lint/ContextConnectivity
-			for _, skill := range loadRemoteSkills(context.Background(), source, remoteCache) {
+			for _, skill := range loadRemoteSkills(ctx, source, remoteCache) {
 				skillMap[source+"/"+skill.Name] = skill
 			}
 		}

--- a/pkg/skills/skills_test.go
+++ b/pkg/skills/skills_test.go
@@ -433,7 +433,7 @@ description: Test project skill
 `
 	require.NoError(t, os.WriteFile(filepath.Join(claudeProjectDir, "SKILL.md"), []byte(skillContent), 0o644))
 
-	skills := Load([]string{"local"})
+	skills := Load(t.Context(), []string{"local"})
 
 	found := false
 	for _, s := range skills {
@@ -467,7 +467,7 @@ description: A global agents skill
 	tmpCwd := t.TempDir()
 	t.Chdir(tmpCwd)
 
-	skills := Load([]string{"local"})
+	skills := Load(t.Context(), []string{"local"})
 
 	found := false
 	for _, s := range skills {
@@ -516,7 +516,7 @@ description: A flat global agents skill
 	tmpCwd := t.TempDir()
 	t.Chdir(tmpCwd)
 
-	skills := Load([]string{"local"})
+	skills := Load(t.Context(), []string{"local"})
 
 	// Both nested and flat skills should be found
 	foundNested := false
@@ -604,7 +604,7 @@ description: A skill from repo root
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
 
-	skills := Load([]string{"local"})
+	skills := Load(t.Context(), []string{"local"})
 
 	found := false
 	for _, s := range skills {
@@ -645,7 +645,7 @@ description: Cross-repo helper skill
 	require.NoError(t, os.Mkdir(filepath.Join(repo, ".git"), 0o755))
 	t.Chdir(workdir)
 
-	skills := Load([]string{"local"})
+	skills := Load(t.Context(), []string{"local"})
 
 	found := false
 	for _, s := range skills {
@@ -693,7 +693,7 @@ description: Grouping version
 	require.NoError(t, os.Mkdir(filepath.Join(repo, ".git"), 0o755))
 	t.Chdir(repo)
 
-	skills := Load([]string{"local"})
+	skills := Load(t.Context(), []string{"local"})
 
 	found := false
 	for _, s := range skills {
@@ -742,7 +742,7 @@ description: Project version of shared skill
 
 	t.Chdir(tmpRepo)
 
-	skills := Load([]string{"local"})
+	skills := Load(t.Context(), []string{"local"})
 
 	found := false
 	for _, s := range skills {
@@ -797,7 +797,7 @@ description: Subproject version
 
 	// From repo root, should get root version
 	t.Chdir(tmpRepo)
-	skills := Load([]string{"local"})
+	skills := Load(t.Context(), []string{"local"})
 	for _, s := range skills {
 		if s.Name == "local-skill" {
 			assert.Equal(t, "Root version", s.Description)
@@ -807,7 +807,7 @@ description: Subproject version
 
 	// From subproject, should get subproject version (closer wins)
 	t.Chdir(subDir)
-	skills = Load([]string{"local"})
+	skills = Load(t.Context(), []string{"local"})
 	for _, s := range skills {
 		if s.Name == "local-skill" {
 			assert.Equal(t, "Subproject version", s.Description)
@@ -872,7 +872,7 @@ func TestLoad_KitDirOverridesEverything(t *testing.T) {
 	t.Setenv(KitDirEnv, kitDir)
 	t.Chdir(t.TempDir())
 
-	skills := Load([]string{"local"})
+	skills := Load(t.Context(), []string{"local"})
 
 	names := make([]string, 0, len(skills))
 	for _, s := range skills {

--- a/pkg/sound/sound.go
+++ b/pkg/sound/sound.go
@@ -22,35 +22,35 @@ const (
 // Play plays a notification sound for the given event in the background.
 // It is non-blocking and safe to call from any goroutine.
 // If the sound cannot be played, the error is logged and silently ignored.
-func Play(event Event) {
+func Play(ctx context.Context, event Event) {
 	go func() {
-		if err := playSound(event); err != nil {
-			slog.Debug("Failed to play sound", "event", event, "error", err)
+		ctx := context.WithoutCancel(ctx)
+		if err := playSound(ctx, event); err != nil {
+			slog.DebugContext(ctx, "Failed to play sound", "event", event, "error", err)
 		}
 	}()
 }
 
-func playSound(event Event) error {
+func playSound(ctx context.Context, event Event) error {
 	switch runtime.GOOS {
 	case "darwin":
-		return playDarwin(event)
+		return playDarwin(ctx, event)
 	case "linux":
-		return playLinux(event)
+		return playLinux(ctx, event)
 	case "windows":
-		return playWindows(event)
+		return playWindows(ctx, event)
 	default:
 		return nil
 	}
 }
 
 // runDetached executes a command for fire-and-forget audio playback. The
-// process is short-lived and not tied to any caller-provided context.
-func runDetached(name string, args ...string) error {
-	//rubocop:disable Lint/ContextConnectivity
-	return exec.CommandContext(context.Background(), name, args...).Run()
+// process is short-lived and not tied to caller cancellation.
+func runDetached(ctx context.Context, name string, args ...string) error {
+	return exec.CommandContext(ctx, name, args...).Run()
 }
 
-func playDarwin(event Event) error {
+func playDarwin(ctx context.Context, event Event) error {
 	// Use macOS built-in system sounds via afplay
 	var soundFile string
 	switch event {
@@ -59,10 +59,10 @@ func playDarwin(event Event) error {
 	case Failure:
 		soundFile = "/System/Library/Sounds/Basso.aiff"
 	}
-	return runDetached("afplay", soundFile)
+	return runDetached(ctx, "afplay", soundFile)
 }
 
-func playLinux(event Event) error {
+func playLinux(ctx context.Context, event Event) error {
 	// Try paplay (PulseAudio) first, then fall back to terminal bell
 	var soundFile string
 	switch event {
@@ -73,14 +73,14 @@ func playLinux(event Event) error {
 	}
 
 	if path, err := exec.LookPath("paplay"); err == nil {
-		return runDetached(path, soundFile)
+		return runDetached(ctx, path, soundFile)
 	}
 
 	// Fallback: terminal bell via printf
-	return runDetached("printf", `\a`)
+	return runDetached(ctx, "printf", `\a`)
 }
 
-func playWindows(event Event) error {
+func playWindows(ctx context.Context, event Event) error {
 	// Use PowerShell to play system sounds
 	var script string
 	switch event {
@@ -89,5 +89,5 @@ func playWindows(event Event) error {
 	case Failure:
 		script = `[System.Media.SystemSounds]::Hand.Play()`
 	}
-	return runDetached("powershell", "-NoProfile", "-NonInteractive", "-Command", script)
+	return runDetached(ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command", script)
 }

--- a/pkg/sound/sound.go
+++ b/pkg/sound/sound.go
@@ -46,6 +46,7 @@ func playSound(event Event) error {
 // runDetached executes a command for fire-and-forget audio playback. The
 // process is short-lived and not tied to any caller-provided context.
 func runDetached(name string, args ...string) error {
+	//rubocop:disable Lint/ContextConnectivity
 	return exec.CommandContext(context.Background(), name, args...).Run()
 }
 

--- a/pkg/sqliteutil/sqlite.go
+++ b/pkg/sqliteutil/sqlite.go
@@ -42,6 +42,7 @@ func OpenDB(path string) (*sql.DB, error) {
 	db.SetConnMaxLifetime(0)
 
 	// Verify connection works (this will trigger file creation/open)
+	//rubocop:disable Lint/ContextConnectivity
 	if err := db.PingContext(context.Background()); err != nil {
 		db.Close()
 		if IsCantOpenError(err) {
@@ -86,6 +87,7 @@ func DiagnoseDBOpenError(path string, originalErr error) error {
 // so it isn't left behind on disk after shutdown. A checkpoint failure is
 // logged but does not prevent the close.
 func CheckpointAndClose(db *sql.DB) error {
+	//rubocop:disable Lint/ContextConnectivity
 	if _, err := db.ExecContext(context.Background(), "PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
 		slog.Warn("Failed to checkpoint WAL before close", "error", err)
 	}

--- a/pkg/sqliteutil/sqlite.go
+++ b/pkg/sqliteutil/sqlite.go
@@ -15,7 +15,7 @@ import (
 
 // OpenDB opens a SQLite database with recommended pragmas for concurrency and foreign key support.
 // It configures the connection pool for serialized writes (MaxOpenConns=1).
-func OpenDB(path string) (*sql.DB, error) {
+func OpenDB(ctx context.Context, path string) (*sql.DB, error) {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, fmt.Errorf("cannot create database directory %q: %w", dir, err)
@@ -42,8 +42,7 @@ func OpenDB(path string) (*sql.DB, error) {
 	db.SetConnMaxLifetime(0)
 
 	// Verify connection works (this will trigger file creation/open)
-	//rubocop:disable Lint/ContextConnectivity
-	if err := db.PingContext(context.Background()); err != nil {
+	if err := db.PingContext(ctx); err != nil {
 		db.Close()
 		if IsCantOpenError(err) {
 			return nil, DiagnoseDBOpenError(path, err)
@@ -86,10 +85,10 @@ func DiagnoseDBOpenError(path string, originalErr error) error {
 // The TRUNCATE checkpoint folds the -wal file back into the main database
 // so it isn't left behind on disk after shutdown. A checkpoint failure is
 // logged but does not prevent the close.
-func CheckpointAndClose(db *sql.DB) error {
-	//rubocop:disable Lint/ContextConnectivity
-	if _, err := db.ExecContext(context.Background(), "PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
-		slog.Warn("Failed to checkpoint WAL before close", "error", err)
+func CheckpointAndClose(ctx context.Context, db *sql.DB) error {
+	ctx = context.WithoutCancel(ctx)
+	if _, err := db.ExecContext(ctx, "PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+		slog.WarnContext(ctx, "Failed to checkpoint WAL before close", "error", err)
 	}
 	return db.Close()
 }

--- a/pkg/team/team.go
+++ b/pkg/team/team.go
@@ -72,7 +72,7 @@ type AgentInfo struct {
 }
 
 // AgentsInfo returns information about all agents in the team
-func (t *Team) AgentsInfo() []AgentInfo {
+func (t *Team) AgentsInfo(ctx context.Context) []AgentInfo {
 	var infos []AgentInfo
 	for _, a := range t.agents {
 		info := AgentInfo{
@@ -80,10 +80,7 @@ func (t *Team) AgentsInfo() []AgentInfo {
 			Description: a.Description(),
 			Commands:    a.Commands(),
 		}
-		// AgentsInfo has no caller context; Model's ctx is only used for log
-		// correlation. context.TODO marks the intentional gap.
-		//rubocop:disable Lint/ContextConnectivity
-		if model := a.Model(context.TODO()); model != nil {
+		if model := a.Model(ctx); model != nil {
 			id := model.ID()
 			info.Provider = id.Provider
 			info.Model = id.Model

--- a/pkg/team/team.go
+++ b/pkg/team/team.go
@@ -80,6 +80,7 @@ func (t *Team) AgentsInfo() []AgentInfo {
 			Description: a.Description(),
 			Commands:    a.Commands(),
 		}
+		//rubocop:disable Lint/ContextConnectivity
 		if model := a.Model(context.TODO()); model != nil {
 			id := model.ID()
 			info.Provider = id.Provider

--- a/pkg/team/team.go
+++ b/pkg/team/team.go
@@ -80,6 +80,8 @@ func (t *Team) AgentsInfo() []AgentInfo {
 			Description: a.Description(),
 			Commands:    a.Commands(),
 		}
+		// AgentsInfo has no caller context; Model's ctx is only used for log
+		// correlation. context.TODO marks the intentional gap.
 		//rubocop:disable Lint/ContextConnectivity
 		if model := a.Model(context.TODO()); model != nil {
 			id := model.ID()

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -309,7 +309,7 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 
 		// Add skills toolset if skills are enabled
 		if agentConfig.Skills.Enabled() {
-			loadedSkills := skills.Load(agentConfig.Skills.Sources)
+			loadedSkills := skills.Load(ctx, agentConfig.Skills.Sources)
 			loadedSkills = filterSkillsByName(loadedSkills, agentConfig.Skills.Include)
 			// Inline skills are defined in the agent config itself; they are
 			// always exposed and never subject to the include filter.

--- a/pkg/telemetry/events.go
+++ b/pkg/telemetry/events.go
@@ -15,7 +15,7 @@ func (tc *Client) Track(ctx context.Context, structuredEvent StructuredEvent) {
 	tc.track(ctx, structuredEvent, true)
 }
 
-func (tc *Client) track(_ context.Context, structuredEvent StructuredEvent, async bool) {
+func (tc *Client) track(ctx context.Context, structuredEvent StructuredEvent, async bool) {
 	eventType := structuredEvent.GetEventType()
 	structuredProps := structuredEvent.ToStructuredProperties()
 
@@ -43,9 +43,9 @@ func (tc *Client) track(_ context.Context, structuredEvent StructuredEvent, asyn
 	}
 
 	if async {
-		go tc.sendEvent(&event) //nolint:gosec // telemetry is fire-and-forget; sendEvent uses its own context internally
+		go tc.sendEvent(context.WithoutCancel(ctx), &event)
 	} else {
-		tc.sendEvent(&event)
+		tc.sendEvent(ctx, &event)
 	}
 }
 

--- a/pkg/telemetry/events.go
+++ b/pkg/telemetry/events.go
@@ -5,8 +5,8 @@ import (
 	"time"
 )
 
-func (tc *Client) TrackSynchronous(_ context.Context, structuredEvent StructuredEvent) {
-	tc.track(context.Background(), structuredEvent, false)
+func (tc *Client) TrackSynchronous(ctx context.Context, structuredEvent StructuredEvent) {
+	tc.track(ctx, structuredEvent, false)
 }
 
 // Track records a structured telemetry event with type-safe properties (synchronous)

--- a/pkg/telemetry/http.go
+++ b/pkg/telemetry/http.go
@@ -103,6 +103,7 @@ func (tc *Client) sendEvent(event *EventPayload) {
 	tc.logger.Debug("Event recorded", logArgs...)
 
 	// Enhanced debug logging with full event structure
+	//rubocop:disable Lint/ContextConnectivity
 	if tc.logger.Enabled(context.Background(), slog.LevelDebug) {
 		if jsonData, err := json.Marshal(event); err == nil {
 			tc.logger.Debug("Full telemetry event JSON", "json", string(jsonData))
@@ -124,6 +125,7 @@ func (tc *Client) performHTTPRequest(event *EventPayload, version string) error 
 	}
 
 	// Send request with timeout context
+	//rubocop:disable Lint/ContextConnectivity
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 

--- a/pkg/telemetry/http.go
+++ b/pkg/telemetry/http.go
@@ -60,7 +60,7 @@ func (tc *Client) printEvent(event *EventPayload) {
 }
 
 // sendEvent sends a single event to Docker events API and handles logging
-func (tc *Client) sendEvent(event *EventPayload) {
+func (tc *Client) sendEvent(ctx context.Context, event *EventPayload) {
 	// Get version before acquiring lock to avoid deadlock
 	version := tc.getVersion()
 
@@ -72,7 +72,7 @@ func (tc *Client) sendEvent(event *EventPayload) {
 		tc.logger.Debug("Sending telemetry event via HTTP", "event_type", event.Event, "endpoint", tc.endpoint)
 
 		// Perform HTTP request inline
-		if err := tc.performHTTPRequest(event, version); err != nil {
+		if err := tc.performHTTPRequest(ctx, event, version); err != nil {
 			tc.logger.Debug("Failed to send telemetry event to Docker API", "error", err, "event_type", event.Event)
 		} else {
 			tc.logger.Debug("Successfully sent telemetry event via HTTP", "event_type", event.Event)
@@ -103,8 +103,7 @@ func (tc *Client) sendEvent(event *EventPayload) {
 	tc.logger.Debug("Event recorded", logArgs...)
 
 	// Enhanced debug logging with full event structure
-	//rubocop:disable Lint/ContextConnectivity
-	if tc.logger.Enabled(context.Background(), slog.LevelDebug) {
+	if tc.logger.Enabled(ctx, slog.LevelDebug) {
 		if jsonData, err := json.Marshal(event); err == nil {
 			tc.logger.Debug("Full telemetry event JSON", "json", string(jsonData))
 		}
@@ -112,7 +111,7 @@ func (tc *Client) sendEvent(event *EventPayload) {
 }
 
 // performHTTPRequest handles the actual HTTP request to the telemetry API
-func (tc *Client) performHTTPRequest(event *EventPayload, version string) error {
+func (tc *Client) performHTTPRequest(ctx context.Context, event *EventPayload, version string) error {
 	// Wrap event in records array to match MarlinRequest format
 	requestBody := map[string]any{
 		"records": []any{event},
@@ -124,9 +123,9 @@ func (tc *Client) performHTTPRequest(event *EventPayload, version string) error 
 		return fmt.Errorf("failed to marshal request to JSON: %w", err)
 	}
 
-	// Send request with timeout context
-	//rubocop:disable Lint/ContextConnectivity
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	// Send request with timeout context. Telemetry sends should outlive a
+	// cancelled caller, but keep its trace context for correlation.
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 	defer cancel()
 
 	// Create HTTP request

--- a/pkg/tools/builtin/lsp/lsp.go
+++ b/pkg/tools/builtin/lsp/lsp.go
@@ -712,6 +712,7 @@ func (h *lspHandler) ensureInitialized() error {
 	// Lazy-start through the supervisor. Concurrent ensureInitialized
 	// callers serialize inside Supervisor.Start.
 	if !h.supervisor.IsReady() {
+		//rubocop:disable Lint/ContextConnectivity
 		if err := h.supervisor.Start(context.Background()); err != nil {
 			return fmt.Errorf("failed to start LSP server: %w", err)
 		}

--- a/pkg/tools/builtin/lsp/lsp.go
+++ b/pkg/tools/builtin/lsp/lsp.go
@@ -696,7 +696,7 @@ func isProviderEnabled(v any) bool {
 // responsible for the per-request JSON-RPC protocol and the persistent
 // state (open files, diagnostics) that survives reconnects.
 
-func (h *lspHandler) ensureInitialized() error {
+func (h *lspHandler) ensureInitialized(ctx context.Context) error {
 	// Fast path: rely on the atomic initialized flag. lspConnector.Connect
 	// only sets initialized=true after publishing h.cmd / h.stdin /
 	// h.stdout under h.mu, and lspSession.Close clears initialized BEFORE
@@ -712,8 +712,7 @@ func (h *lspHandler) ensureInitialized() error {
 	// Lazy-start through the supervisor. Concurrent ensureInitialized
 	// callers serialize inside Supervisor.Start.
 	if !h.supervisor.IsReady() {
-		//rubocop:disable Lint/ContextConnectivity
-		if err := h.supervisor.Start(context.Background()); err != nil {
+		if err := h.supervisor.Start(ctx); err != nil {
 			return fmt.Errorf("failed to start LSP server: %w", err)
 		}
 	}
@@ -797,7 +796,7 @@ func (h *lspHandler) initializeLocked() error {
 
 // prepareFileRequest handles common setup for file-based requests
 func (h *lspHandler) prepareFileRequest(ctx context.Context, file string) (string, error) {
-	if err := h.ensureInitialized(); err != nil {
+	if err := h.ensureInitialized(ctx); err != nil {
 		return "", fmt.Errorf("LSP initialization failed: %w", err)
 	}
 	uri := pathToURI(file)
@@ -810,7 +809,7 @@ func (h *lspHandler) prepareFileRequest(ctx context.Context, file string) (strin
 // Tool handler implementations
 
 func (h *lspHandler) workspace(ctx context.Context, _ WorkspaceArgs) (*tools.ToolCallResult, error) {
-	if err := h.ensureInitialized(); err != nil {
+	if err := h.ensureInitialized(ctx); err != nil {
 		return tools.ResultError(fmt.Sprintf("LSP initialization failed: %s", err)), nil
 	}
 
@@ -995,7 +994,7 @@ func (h *lspHandler) documentSymbols(ctx context.Context, args FileArgs) (*tools
 }
 
 func (h *lspHandler) workspaceSymbols(ctx context.Context, args WorkspaceSymbolsArgs) (*tools.ToolCallResult, error) {
-	if err := h.ensureInitialized(); err != nil {
+	if err := h.ensureInitialized(ctx); err != nil {
 		return tools.ResultError(fmt.Sprintf("LSP initialization failed: %s", err)), nil
 	}
 
@@ -1018,7 +1017,7 @@ func (h *lspHandler) workspaceSymbols(ctx context.Context, args WorkspaceSymbols
 }
 
 func (h *lspHandler) getDiagnostics(ctx context.Context, args FileArgs) (*tools.ToolCallResult, error) {
-	if err := h.ensureInitialized(); err != nil {
+	if err := h.ensureInitialized(ctx); err != nil {
 		return tools.ResultError(fmt.Sprintf("LSP initialization failed: %s", err)), nil
 	}
 

--- a/pkg/tools/builtin/lsp/lsp_lifecycle.go
+++ b/pkg/tools/builtin/lsp/lsp_lifecycle.go
@@ -78,6 +78,7 @@ func spawnLSPProcess(callerCtx context.Context, h *lspHandler) (*lspProcess, err
 	// The process must outlive the caller's request context (which is
 	// often cancelled when an HTTP/agent turn ends). The supervisor
 	// calls Close to shut it down on Stop or restart.
+	//rubocop:disable Lint/ContextConnectivity
 	processCtx, processCancel := context.WithCancel(context.Background())
 
 	cmd := exec.CommandContext(processCtx, h.command, h.args...)

--- a/pkg/tools/builtin/lsp/lsp_lifecycle.go
+++ b/pkg/tools/builtin/lsp/lsp_lifecycle.go
@@ -76,10 +76,11 @@ type lspProcess struct {
 // apply the right policy.
 func spawnLSPProcess(callerCtx context.Context, h *lspHandler) (*lspProcess, error) {
 	// The process must outlive the caller's request context (which is
-	// often cancelled when an HTTP/agent turn ends). The supervisor
-	// calls Close to shut it down on Stop or restart.
-	//rubocop:disable Lint/ContextConnectivity
-	processCtx, processCancel := context.WithCancel(context.Background())
+	// often cancelled when an HTTP/agent turn ends). WithoutCancel keeps
+	// the caller's trace context (so spans/the env injection below chain
+	// onto the agent trace) while detaching from its cancellation. The
+	// supervisor calls Close to shut it down on Stop or restart.
+	processCtx, processCancel := context.WithCancel(context.WithoutCancel(callerCtx))
 
 	cmd := exec.CommandContext(processCtx, h.command, h.args...)
 	// Inherit the caller's W3C trace context (the Connect call's

--- a/pkg/tools/builtin/memory/memory.go
+++ b/pkg/tools/builtin/memory/memory.go
@@ -68,10 +68,7 @@ func CreateToolSet(toolset latest.Toolset, parentDir string, runConfig *config.R
 		return nil, fmt.Errorf("failed to create memory database directory: %w", err)
 	}
 
-	// Toolset constructors do not receive a request context; DB bootstrap is a
-	// one-time setup step for this toolset.
-	//rubocop:disable Lint/ContextConnectivity
-	db, err := sqlite.NewMemoryDatabase(context.Background(), validatedMemoryPath)
+	db, err := sqlite.NewMemoryDatabase(validatedMemoryPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create memory database: %w", err)
 	}

--- a/pkg/tools/builtin/memory/memory.go
+++ b/pkg/tools/builtin/memory/memory.go
@@ -68,7 +68,10 @@ func CreateToolSet(toolset latest.Toolset, parentDir string, runConfig *config.R
 		return nil, fmt.Errorf("failed to create memory database directory: %w", err)
 	}
 
-	db, err := sqlite.NewMemoryDatabase(validatedMemoryPath)
+	// Toolset constructors do not receive a request context; DB bootstrap is a
+	// one-time setup step for this toolset.
+	//rubocop:disable Lint/ContextConnectivity
+	db, err := sqlite.NewMemoryDatabase(context.Background(), validatedMemoryPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create memory database: %w", err)
 	}

--- a/pkg/tools/builtin/shell/askpass.go
+++ b/pkg/tools/builtin/shell/askpass.go
@@ -448,6 +448,10 @@ func (h *shellHandler) ensureAskpass(ctx context.Context) *askpassServer {
 	h.askpassStarted = true
 	srv, err := startAskpassServer(ctx, h.currentElicitationHandler)
 	if err != nil {
+		// Reset so a later command retries: this call's ctx may simply have
+		// been cancelled mid-startup; we must not disable askpass for the
+		// whole session because of one cancelled request.
+		h.askpassStarted = false
 		slog.WarnContext(ctx, "Failed to start sudo askpass helper; sudo will run without it", "error", err)
 		return nil
 	}

--- a/pkg/tools/builtin/shell/askpass.go
+++ b/pkg/tools/builtin/shell/askpass.go
@@ -65,6 +65,7 @@ func askpassSupported() bool {
 // from the `__askpass` helper that sudo spawns, and answers them by asking the
 // user through the toolset's elicitation handler.
 type askpassServer struct {
+	ctx      func() context.Context
 	listener net.Listener
 	dir      string // 0700 temp dir holding the socket + wrapper script
 	socket   string
@@ -171,6 +172,7 @@ func startAskpassServer(ctx context.Context, handler func() tools.ElicitationHan
 	}
 
 	s := &askpassServer{
+		ctx:       func() context.Context { return context.WithoutCancel(ctx) },
 		listener:  listener,
 		dir:       dir,
 		socket:    socket,
@@ -211,8 +213,7 @@ func (s *askpassServer) handleConn(conn net.Conn) {
 	defer conn.Close()
 
 	// Bound the whole exchange; the prompt (askUser) is the only slow part.
-	//rubocop:disable Lint/ContextConnectivity
-	ctx, cancel := context.WithTimeout(context.Background(), askpassPromptTimeout)
+	ctx, cancel := context.WithTimeout(s.ctx(), askpassPromptTimeout)
 	defer cancel()
 
 	// The request is sent immediately, so a short read deadline is enough.

--- a/pkg/tools/builtin/shell/askpass.go
+++ b/pkg/tools/builtin/shell/askpass.go
@@ -151,6 +151,7 @@ func startAskpassServer(handler func() tools.ElicitationHandler) (*askpassServer
 
 	socket := filepath.Join(dir, "sock")
 	var lnConfig net.ListenConfig
+	//rubocop:disable Lint/ContextConnectivity
 	listener, err := lnConfig.Listen(context.Background(), "unix", socket)
 	if err != nil {
 		_ = os.RemoveAll(dir)
@@ -211,6 +212,7 @@ func (s *askpassServer) handleConn(conn net.Conn) {
 	defer conn.Close()
 
 	// Bound the whole exchange; the prompt (askUser) is the only slow part.
+	//rubocop:disable Lint/ContextConnectivity
 	ctx, cancel := context.WithTimeout(context.Background(), askpassPromptTimeout)
 	defer cancel()
 

--- a/pkg/tools/builtin/shell/askpass.go
+++ b/pkg/tools/builtin/shell/askpass.go
@@ -128,7 +128,7 @@ func randomToken() (string, error) {
 // startAskpassServer creates the private socket plus the SUDO_ASKPASS wrapper
 // script and starts accepting connections. handler is consulted per request so
 // it always reflects the current elicitation handler.
-func startAskpassServer(handler func() tools.ElicitationHandler) (*askpassServer, error) {
+func startAskpassServer(ctx context.Context, handler func() tools.ElicitationHandler) (*askpassServer, error) {
 	if !askpassSupported() {
 		return nil, errors.New("sudo askpass is not supported on this platform")
 	}
@@ -151,8 +151,7 @@ func startAskpassServer(handler func() tools.ElicitationHandler) (*askpassServer
 
 	socket := filepath.Join(dir, "sock")
 	var lnConfig net.ListenConfig
-	//rubocop:disable Lint/ContextConnectivity
-	listener, err := lnConfig.Listen(context.Background(), "unix", socket)
+	listener, err := lnConfig.Listen(ctx, "unix", socket)
 	if err != nil {
 		_ = os.RemoveAll(dir)
 		return nil, err
@@ -439,16 +438,16 @@ func (h *shellHandler) askpassActive() bool {
 // It returns nil (askpass disabled for this command) on any startup failure.
 // The mutex makes lazy start safe against concurrent commands and a concurrent
 // stopAskpass.
-func (h *shellHandler) ensureAskpass() *askpassServer {
+func (h *shellHandler) ensureAskpass(ctx context.Context) *askpassServer {
 	h.askpassMu.Lock()
 	defer h.askpassMu.Unlock()
 	if h.askpassStarted {
 		return h.askpass
 	}
 	h.askpassStarted = true
-	srv, err := startAskpassServer(h.currentElicitationHandler)
+	srv, err := startAskpassServer(ctx, h.currentElicitationHandler)
 	if err != nil {
-		slog.Warn("Failed to start sudo askpass helper; sudo will run without it", "error", err)
+		slog.WarnContext(ctx, "Failed to start sudo askpass helper; sudo will run without it", "error", err)
 		return nil
 	}
 	h.askpass = srv
@@ -462,11 +461,11 @@ func (h *shellHandler) ensureAskpass() *askpassServer {
 // shared base env are returned unchanged, and the askpass server is not even
 // started. This keeps normal shell behaviour and the env surface untouched for
 // the common (non-sudo) case.
-func (h *shellHandler) applyAskpass(command string) (string, []string) {
+func (h *shellHandler) applyAskpass(ctx context.Context, command string) (string, []string) {
 	if !h.askpassActive() || !commandInvokesSudo(command) {
 		return command, h.env
 	}
-	srv := h.ensureAskpass()
+	srv := h.ensureAskpass(ctx)
 	if srv == nil {
 		return command, h.env
 	}

--- a/pkg/tools/builtin/shell/askpass_test.go
+++ b/pkg/tools/builtin/shell/askpass_test.go
@@ -34,7 +34,7 @@ func TestAskpass_RoundTrip(t *testing.T) {
 		t.Skip("sudo askpass unsupported on this platform")
 	}
 
-	srv, err := startAskpassServer(acceptHandler("hunter2"))
+	srv, err := startAskpassServer(t.Context(), acceptHandler("hunter2"))
 	require.NoError(t, err)
 	defer srv.close()
 
@@ -51,7 +51,7 @@ func TestAskpass_Decline(t *testing.T) {
 		t.Skip("sudo askpass unsupported on this platform")
 	}
 
-	srv, err := startAskpassServer(func() tools.ElicitationHandler {
+	srv, err := startAskpassServer(t.Context(), func() tools.ElicitationHandler {
 		return func(_ context.Context, _ *mcp.ElicitParams) (tools.ElicitationResult, error) {
 			return tools.ElicitationResult{Action: tools.ElicitationActionDecline}, nil
 		}
@@ -72,7 +72,7 @@ func TestAskpass_BadToken(t *testing.T) {
 		t.Skip("sudo askpass unsupported on this platform")
 	}
 
-	srv, err := startAskpassServer(acceptHandler("hunter2"))
+	srv, err := startAskpassServer(t.Context(), acceptHandler("hunter2"))
 	require.NoError(t, err)
 	defer srv.close()
 
@@ -110,7 +110,7 @@ func TestAskpass_CancelledWhenHelperDies(t *testing.T) {
 	}
 
 	cancelled := make(chan struct{})
-	srv, err := startAskpassServer(func() tools.ElicitationHandler {
+	srv, err := startAskpassServer(t.Context(), func() tools.ElicitationHandler {
 		return func(ctx context.Context, _ *mcp.ElicitParams) (tools.ElicitationResult, error) {
 			<-ctx.Done() // block like a real prompt until the context is cancelled
 			close(cancelled)
@@ -155,7 +155,7 @@ func TestAskpass_PromptsSerialized(t *testing.T) {
 	}
 
 	var active, maxActive int32
-	srv, err := startAskpassServer(func() tools.ElicitationHandler {
+	srv, err := startAskpassServer(t.Context(), func() tools.ElicitationHandler {
 		return func(_ context.Context, _ *mcp.ElicitParams) (tools.ElicitationResult, error) {
 			n := atomic.AddInt32(&active, 1)
 			for {

--- a/pkg/tools/builtin/shell/shell.go
+++ b/pkg/tools/builtin/shell/shell.go
@@ -279,7 +279,7 @@ func (h *shellHandler) runNativeCommand(timeoutCtx, ctx context.Context, command
 	// Cancellation is handled manually below (timeoutCtx + Process.Kill +
 	// process group + WaitDelay), so we use exec.Command rather than
 	// exec.CommandContext to keep that flow in one place.
-	command, cmdEnv := h.applyAskpass(command)
+	command, cmdEnv := h.applyAskpass(ctx, command)
 	cmd := exec.Command(h.shell, append(h.shellArgsPrefix, command)...) //nolint:noctx // see comment above
 	cmd.Env = cmdEnv
 	cmd.Dir = cwd
@@ -327,7 +327,7 @@ func (h *shellHandler) runNativeCommand(timeoutCtx, ctx context.Context, command
 	return tools.ResultSuccess(limitOutput(formattedOutput))
 }
 
-func (h *shellHandler) RunShellBackground(_ context.Context, params RunShellBackgroundArgs) (*tools.ToolCallResult, error) {
+func (h *shellHandler) RunShellBackground(ctx context.Context, params RunShellBackgroundArgs) (*tools.ToolCallResult, error) {
 	if strings.TrimSpace(params.Cmd) == "" {
 		return tools.ResultError(`Error: missing or empty "cmd" parameter. Pass the shell command as {"cmd": "..."}.`), nil
 	}
@@ -335,7 +335,7 @@ func (h *shellHandler) RunShellBackground(_ context.Context, params RunShellBack
 	counter := h.jobCounter.Add(1)
 	jobID := fmt.Sprintf("job_%d_%d", time.Now().Unix(), counter)
 
-	bgCmd, bgEnv := h.applyAskpass(params.Cmd)
+	bgCmd, bgEnv := h.applyAskpass(ctx, params.Cmd)
 	cmd := exec.Command(h.shell, append(h.shellArgsPrefix, bgCmd)...) //nolint:noctx // RunShellBackground intentionally outlives the request context
 	cmd.Env = bgEnv
 	cmd.Dir = h.resolveWorkDir(params.Cwd)

--- a/pkg/tools/lifecycle/supervisor.go
+++ b/pkg/tools/lifecycle/supervisor.go
@@ -112,7 +112,7 @@ type Policy struct {
 	OnDisconnect func(err error)
 	// OnRestart is called after each successful reconnect. Useful for
 	// re-fetching server-side state (tools, prompts).
-	OnRestart func()
+	OnRestart func(ctx context.Context)
 	// OnFailed is called once when the supervisor enters StateFailed.
 	OnFailed func(err error)
 
@@ -425,7 +425,7 @@ func (s *Supervisor) watch(ctx context.Context) {
 		}
 
 		if cb := s.policy.OnRestart; cb != nil {
-			cb()
+			cb(ctx)
 		}
 	}
 }

--- a/pkg/tools/lifecycle/supervisor_test.go
+++ b/pkg/tools/lifecycle/supervisor_test.go
@@ -173,7 +173,7 @@ func TestSupervisor_RestartAfterDisconnect(t *testing.T) {
 	restarted := make(chan struct{}, 1)
 	s := lifecycle.New("test", c, lifecycle.Policy{
 		Backoff: fastBackoff,
-		OnRestart: func() {
+		OnRestart: func(context.Context) {
 			select {
 			case restarted <- struct{}{}:
 			default:
@@ -547,7 +547,7 @@ func TestSupervisor_RestartAlwaysReconnectsCleanCloseAndResetsBudget(t *testing.
 		Restart:     lifecycle.RestartAlways,
 		MaxAttempts: 1,
 		Backoff:     fastBackoff,
-		OnRestart: func() {
+		OnRestart: func(context.Context) {
 			select {
 			case restarted <- struct{}{}:
 			default:

--- a/pkg/tools/mcp/mcp.go
+++ b/pkg/tools/mcp/mcp.go
@@ -317,14 +317,12 @@ func newSupervisor(ts *Toolset, base lifecycle.Policy) *lifecycle.Supervisor {
 		ts.invalidateCache()
 		ts.mu.Unlock()
 	}
-	policy.OnRestart = func() {
+	policy.OnRestart = func(ctx context.Context) {
 		// Refresh tool and prompt caches eagerly so subsequent
 		// Tools()/ListPrompts() calls return the up-to-date data
 		// from the new server. The new server may expose a
 		// different set of tools/prompts and notifications won't
 		// fire for tools that disappeared.
-		//rubocop:disable Lint/ContextConnectivity
-		ctx := context.Background()
 		ts.refreshToolCache(ctx)
 		ts.refreshPromptCache(ctx)
 	}

--- a/pkg/tools/mcp/mcp.go
+++ b/pkg/tools/mcp/mcp.go
@@ -323,6 +323,7 @@ func newSupervisor(ts *Toolset, base lifecycle.Policy) *lifecycle.Supervisor {
 		// from the new server. The new server may expose a
 		// different set of tools/prompts and notifications won't
 		// fire for tools that disappeared.
+		//rubocop:disable Lint/ContextConnectivity
 		ctx := context.Background()
 		ts.refreshToolCache(ctx)
 		ts.refreshPromptCache(ctx)

--- a/pkg/tools/mcp/oauth.go
+++ b/pkg/tools/mcp/oauth.go
@@ -991,6 +991,7 @@ func (t *oauthTransport) handleManagedOAuthFlow(ctx context.Context, authServer,
 		return fmt.Errorf("failed to create callback server: %w", err)
 	}
 	defer func() {
+		//rubocop:disable Lint/ContextConnectivity
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		if err := callbackServer.Shutdown(shutdownCtx); err != nil {

--- a/pkg/tools/mcp/oauth.go
+++ b/pkg/tools/mcp/oauth.go
@@ -986,7 +986,7 @@ func (t *oauthTransport) handleManagedOAuthFlow(ctx context.Context, authServer,
 	if t.oauthConfig != nil {
 		callbackPort = t.oauthConfig.CallbackPort
 	}
-	callbackServer, err := NewCallbackServerOnPort(callbackPort)
+	callbackServer, err := NewCallbackServerOnPort(ctx, callbackPort)
 	if err != nil {
 		return fmt.Errorf("failed to create callback server: %w", err)
 	}

--- a/pkg/tools/mcp/oauth.go
+++ b/pkg/tools/mcp/oauth.go
@@ -991,8 +991,9 @@ func (t *oauthTransport) handleManagedOAuthFlow(ctx context.Context, authServer,
 		return fmt.Errorf("failed to create callback server: %w", err)
 	}
 	defer func() {
-		//rubocop:disable Lint/ContextConnectivity
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		// Detach from ctx's cancellation (the request may be done) but
+		// keep its trace context for the shutdown.
+		shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 		defer cancel()
 		if err := callbackServer.Shutdown(shutdownCtx); err != nil {
 			slog.ErrorContext(ctx, "Failed to shutdown callback server", "error", err)

--- a/pkg/tools/mcp/oauth_login.go
+++ b/pkg/tools/mcp/oauth_login.go
@@ -69,6 +69,7 @@ func PerformOAuthLogin(ctx context.Context, serverURL string) error {
 		return fmt.Errorf("failed to create callback server: %w", err)
 	}
 	defer func() {
+		//rubocop:disable Lint/ContextConnectivity
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		if err := callbackServer.Shutdown(shutdownCtx); err != nil {

--- a/pkg/tools/mcp/oauth_login.go
+++ b/pkg/tools/mcp/oauth_login.go
@@ -69,8 +69,9 @@ func PerformOAuthLogin(ctx context.Context, serverURL string) error {
 		return fmt.Errorf("failed to create callback server: %w", err)
 	}
 	defer func() {
-		//rubocop:disable Lint/ContextConnectivity
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		// Detach from ctx's cancellation (the request may be done) but
+		// keep its trace context for the shutdown.
+		shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 		defer cancel()
 		if err := callbackServer.Shutdown(shutdownCtx); err != nil {
 			slog.ErrorContext(ctx, "Failed to shutdown callback server", "error", err)

--- a/pkg/tools/mcp/oauth_login.go
+++ b/pkg/tools/mcp/oauth_login.go
@@ -64,7 +64,7 @@ func PerformOAuthLogin(ctx context.Context, serverURL string) error {
 	}
 
 	// Set up the callback server for the redirect.
-	callbackServer, err := NewCallbackServer()
+	callbackServer, err := NewCallbackServer(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create callback server: %w", err)
 	}

--- a/pkg/tools/mcp/oauth_server.go
+++ b/pkg/tools/mcp/oauth_server.go
@@ -50,6 +50,7 @@ func NewCallbackServer() (*CallbackServer, error) {
 // Use port 0 to let the OS pick a random available port.
 func NewCallbackServerOnPort(port int) (*CallbackServer, error) {
 	var lc net.ListenConfig
+	//rubocop:disable Lint/ContextConnectivity
 	listener, err := lc.Listen(context.Background(), "tcp", fmt.Sprintf("127.0.0.1:%d", port))
 	if err != nil {
 		return nil, fmt.Errorf("failed to find available port: %w", err)

--- a/pkg/tools/mcp/oauth_server.go
+++ b/pkg/tools/mcp/oauth_server.go
@@ -42,16 +42,15 @@ type callbackResult struct {
 }
 
 // NewCallbackServer creates a new OAuth callback server on a random available port
-func NewCallbackServer() (*CallbackServer, error) {
-	return NewCallbackServerOnPort(0)
+func NewCallbackServer(ctx context.Context) (*CallbackServer, error) {
+	return NewCallbackServerOnPort(ctx, 0)
 }
 
 // NewCallbackServerOnPort creates a new OAuth callback server on a specific port.
 // Use port 0 to let the OS pick a random available port.
-func NewCallbackServerOnPort(port int) (*CallbackServer, error) {
+func NewCallbackServerOnPort(ctx context.Context, port int) (*CallbackServer, error) {
 	var lc net.ListenConfig
-	//rubocop:disable Lint/ContextConnectivity
-	listener, err := lc.Listen(context.Background(), "tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	listener, err := lc.Listen(ctx, "tcp", fmt.Sprintf("127.0.0.1:%d", port))
 	if err != nil {
 		return nil, fmt.Errorf("failed to find available port: %w", err)
 	}

--- a/pkg/tools/mcp/oauth_server_test.go
+++ b/pkg/tools/mcp/oauth_server_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestCallbackServer_Port(t *testing.T) {
-	cs, err := NewCallbackServer()
+	cs, err := NewCallbackServer(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +81,7 @@ func TestBuildRedirectURI(t *testing.T) {
 // a full result channel. Sends are now non-blocking; the first callback
 // wins and later ones must be dropped without wedging the server.
 func TestCallbackServer_DuplicateCallbacksDoNotBlock(t *testing.T) {
-	cs, err := NewCallbackServer()
+	cs, err := NewCallbackServer(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -132,7 +132,7 @@ func TestCallbackServer_DuplicateCallbacksDoNotBlock(t *testing.T) {
 // TestCallbackServer_ResolveRedirectURI exercises the method wrapper end-to-end
 // to make sure it stitches GetRedirectURI() and Port() together correctly.
 func TestCallbackServer_ResolveRedirectURI(t *testing.T) {
-	cs, err := NewCallbackServer()
+	cs, err := NewCallbackServer(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/tools/mcp/oauth_test.go
+++ b/pkg/tools/mcp/oauth_test.go
@@ -354,7 +354,7 @@ func TestRefreshAccessToken_SendsEmptyClientIDWhenNotStored(t *testing.T) {
 // TestCallbackServer_RejectsCallbackBeforeStateSet verifies that a callback
 // arriving before SetExpectedState is called is rejected (CSRF protection).
 func TestCallbackServer_RejectsCallbackBeforeStateSet(t *testing.T) {
-	cs, err := NewCallbackServer()
+	cs, err := NewCallbackServer(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/tui/agent_switch_test.go
+++ b/pkg/tui/agent_switch_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestHandleSwitchAgentNoOpForCurrentAgent(t *testing.T) {
-	m, _ := newTestModel()
+	m, _ := newTestModel(t)
 	m.sessionState = service.NewSessionState(session.New())
 	m.sessionState.SetCurrentAgentName("agent1")
 

--- a/pkg/tui/components/editor/completions/file.go
+++ b/pkg/tui/components/editor/completions/file.go
@@ -56,6 +56,7 @@ func (c *fileCompletion) Items() []completion.Item {
 	}
 
 	// Use bounded walker to avoid scanning huge directories
+	//rubocop:disable Lint/ContextConnectivity
 	files, err := fsx.WalkFiles(context.Background(), ".", fsx.WalkFilesOptions{
 		ShouldIgnore: shouldIgnore,
 	})

--- a/pkg/tui/components/editor/completions/file.go
+++ b/pkg/tui/components/editor/completions/file.go
@@ -16,13 +16,15 @@ const (
 )
 
 type fileCompletion struct {
+	ctx func() context.Context
+
 	mu     sync.Mutex
 	items  []completion.Item
 	loaded bool
 }
 
-func NewFileCompletion() Completion {
-	return &fileCompletion{}
+func NewFileCompletion(ctx context.Context) Completion {
+	return &fileCompletion{ctx: func() context.Context { return context.WithoutCancel(ctx) }}
 }
 
 func (c *fileCompletion) AutoSubmit() bool {
@@ -56,8 +58,7 @@ func (c *fileCompletion) Items() []completion.Item {
 	}
 
 	// Use bounded walker to avoid scanning huge directories
-	//rubocop:disable Lint/ContextConnectivity
-	files, err := fsx.WalkFiles(context.Background(), ".", fsx.WalkFilesOptions{
+	files, err := fsx.WalkFiles(c.ctx(), ".", fsx.WalkFilesOptions{
 		ShouldIgnore: shouldIgnore,
 	})
 	if err != nil {

--- a/pkg/tui/components/sidebar/agent_click_test.go
+++ b/pkg/tui/components/sidebar/agent_click_test.go
@@ -20,7 +20,7 @@ func TestSidebar_HandleClickType_Agent(t *testing.T) {
 	sess := session.New()
 	sessionState := service.NewSessionState(sess)
 	sessionState.SetCurrentAgentName("agent1")
-	sb := New(sessionState)
+	sb := New(t.Context(), sessionState)
 
 	m := sb.(*model)
 	m.sessionHasContent = true
@@ -67,7 +67,7 @@ func TestSidebar_AgentClickZones_EveryRenderedLineMapped(t *testing.T) {
 	sess := session.New()
 	sessionState := service.NewSessionState(sess)
 	sessionState.SetCurrentAgentName("agent1")
-	sb := New(sessionState)
+	sb := New(t.Context(), sessionState)
 
 	m := sb.(*model)
 	m.sessionHasContent = true
@@ -117,7 +117,7 @@ func TestSidebar_BuildAgentClickZones_NoBlankSeparators(t *testing.T) {
 
 	sess := session.New()
 	sessionState := service.NewSessionState(sess)
-	m := New(sessionState).(*model)
+	m := New(t.Context(), sessionState).(*model)
 
 	// Simulate a compact roster: three agents, one rendered line each, no
 	// blank separators (the future layout this refactor unblocks).
@@ -141,7 +141,7 @@ func TestSidebar_BuildAgentClickZones_SkipsBlankOwners(t *testing.T) {
 
 	sess := session.New()
 	sessionState := service.NewSessionState(sess)
-	m := New(sessionState).(*model)
+	m := New(t.Context(), sessionState).(*model)
 
 	// agent1 spans two lines, a blank separator follows, then agent2.
 	m.agentLineOwners = []string{"agent1", "agent1", "", "agent2"}

--- a/pkg/tui/components/sidebar/agent_info_test.go
+++ b/pkg/tui/components/sidebar/agent_info_test.go
@@ -77,7 +77,7 @@ func TestSetAgentInfo_UpdatesProviderAndModel(t *testing.T) {
 			// Create a sidebar model with initial agent details
 			sess := session.New()
 			sessionState := service.NewSessionState(sess)
-			m := New(sessionState).(*model)
+			m := New(t.Context(), sessionState).(*model)
 
 			// Set up initial availableAgents
 			m.availableAgents = []runtime.AgentDetails{
@@ -107,7 +107,7 @@ func TestSetAgentInfo_OnlyUpdatesMatchingAgent(t *testing.T) {
 
 	sess := session.New()
 	sessionState := service.NewSessionState(sess)
-	m := New(sessionState).(*model)
+	m := New(t.Context(), sessionState).(*model)
 
 	// Set up multiple agents
 	m.availableAgents = []runtime.AgentDetails{
@@ -135,7 +135,7 @@ func TestSetAgentInfo_EmptyModelIDNoUpdate(t *testing.T) {
 
 	sess := session.New()
 	sessionState := service.NewSessionState(sess)
-	m := New(sessionState).(*model)
+	m := New(t.Context(), sessionState).(*model)
 
 	// Set up initial agent
 	m.availableAgents = []runtime.AgentDetails{
@@ -155,7 +155,7 @@ func TestSetAgentInfo_NonexistentAgent(t *testing.T) {
 
 	sess := session.New()
 	sessionState := service.NewSessionState(sess)
-	m := New(sessionState).(*model)
+	m := New(t.Context(), sessionState).(*model)
 
 	// Set up agents without the target
 	m.availableAgents = []runtime.AgentDetails{

--- a/pkg/tui/components/sidebar/agent_panel_test.go
+++ b/pkg/tui/components/sidebar/agent_panel_test.go
@@ -21,7 +21,7 @@ func newAgentPanelSidebar(t *testing.T, current string, width int, agents ...run
 	sess := session.New()
 	ss := service.NewSessionState(sess)
 	ss.SetCurrentAgentName(current)
-	m := New(ss).(*model)
+	m := New(t.Context(), ss).(*model)
 	m.sessionHasContent = true
 	m.titleGenerated = true
 	m.sessionTitle = "Test"
@@ -343,7 +343,7 @@ func TestClickZonesCardAndRow(t *testing.T) {
 	sess := session.New()
 	ss := service.NewSessionState(sess)
 	ss.SetCurrentAgentName("root")
-	sb := New(ss)
+	sb := New(t.Context(), ss)
 	m := sb.(*model)
 	m.sessionHasContent = true
 	m.titleGenerated = true

--- a/pkg/tui/components/sidebar/bench_test.go
+++ b/pkg/tui/components/sidebar/bench_test.go
@@ -34,7 +34,7 @@ func makeTodos(n int) *tools.ToolCallResult {
 func BenchmarkSidebarStreamingTodos(b *testing.B) {
 	for _, n := range []int{10, 50, 150} {
 		b.Run(fmt.Sprintf("todos=%d", n), func(b *testing.B) {
-			m := New(service.NewSessionState(session.New())).(*model)
+			m := New(b.Context(), service.NewSessionState(session.New())).(*model)
 			m.SetMode(ModeVertical)
 			m.SetSize(40, 40) // small height so the long list overflows (two-pass)
 			m.workingAgent = "root"

--- a/pkg/tui/components/sidebar/context_percent_test.go
+++ b/pkg/tui/components/sidebar/context_percent_test.go
@@ -13,7 +13,7 @@ import (
 func TestContextPercent_SingleSession(t *testing.T) {
 	t.Parallel()
 
-	m := newTestSidebar()
+	m := newTestSidebar(t)
 	m.startStream("session-1", "root")
 	m.recordUsage("session-1", "root", 10000, 100000)
 
@@ -26,7 +26,7 @@ func TestContextPercent_SingleSession(t *testing.T) {
 func TestContextPercent_TracksActiveSession(t *testing.T) {
 	t.Parallel()
 
-	m := newTestSidebar()
+	m := newTestSidebar(t)
 
 	m.startStream("session-root", "root")
 	m.recordUsage("session-root", "root", 30000, 100000)
@@ -42,7 +42,7 @@ func TestContextPercent_TracksActiveSession(t *testing.T) {
 func TestContextPercent_NoContextLimit(t *testing.T) {
 	t.Parallel()
 
-	m := newTestSidebar()
+	m := newTestSidebar(t)
 	m.startStream("session-1", "root")
 	m.recordUsage("session-1", "root", 10000, 0) // No context limit
 
@@ -54,7 +54,7 @@ func TestContextPercent_EmptyUsage(t *testing.T) {
 
 	sess := session.New()
 	sessionState := service.NewSessionState(sess)
-	m := New(sessionState).(*model)
+	m := New(t.Context(), sessionState).(*model)
 
 	assert.Empty(t, m.contextPercent())
 }
@@ -64,7 +64,7 @@ func TestContextPercent_FallbackToSingleSession(t *testing.T) {
 
 	sess := session.New()
 	sessionState := service.NewSessionState(sess)
-	m := New(sessionState).(*model)
+	m := New(t.Context(), sessionState).(*model)
 
 	// Session with no active stream (e.g., restored from persistence)
 	m.sessionUsage["session-1"] = &runtime.Usage{
@@ -83,7 +83,7 @@ func TestContextPercent_FallbackToSingleSession(t *testing.T) {
 func TestContextPercent_StableDuringSubAgent(t *testing.T) {
 	t.Parallel()
 
-	m := newTestSidebar()
+	m := newTestSidebar(t)
 
 	m.startStream("session-root", "root")
 	m.recordUsage("session-root", "root", 30000, 100000)
@@ -102,7 +102,7 @@ func TestContextPercent_StableDuringSubAgent(t *testing.T) {
 func TestContextPercent_RoundTripDelegations(t *testing.T) {
 	t.Parallel()
 
-	m := newTestSidebar()
+	m := newTestSidebar(t)
 
 	// Parent starts.
 	m.startStream("parent-session", "root")
@@ -141,10 +141,11 @@ type testSidebar struct {
 	*model
 }
 
-func newTestSidebar() *testSidebar {
+func newTestSidebar(tb testing.TB) *testSidebar {
+	tb.Helper()
 	sess := session.New()
 	return &testSidebar{
-		model: New(service.NewSessionState(sess)).(*model),
+		model: New(testContext(tb), service.NewSessionState(sess)).(*model),
 	}
 }
 

--- a/pkg/tui/components/sidebar/layout_test.go
+++ b/pkg/tui/components/sidebar/layout_test.go
@@ -149,7 +149,7 @@ func TestScrollbarGapInOutput(t *testing.T) {
 // This verifies that scrolling uses the render cache instead of re-rendering sections.
 func BenchmarkSidebarVerticalView_Scroll(b *testing.B) {
 	sessionState := &service.SessionState{}
-	m := New(sessionState).(*model)
+	m := New(b.Context(), sessionState).(*model)
 	m.SetSize(35, 50)
 	m.SetMode(ModeVertical)
 
@@ -191,7 +191,7 @@ func BenchmarkSidebarVerticalView_Scroll(b *testing.B) {
 // This shows the cost of full re-rendering for comparison.
 func BenchmarkSidebarVerticalView_NoCache(b *testing.B) {
 	sessionState := &service.SessionState{}
-	m := New(sessionState).(*model)
+	m := New(b.Context(), sessionState).(*model)
 	m.SetSize(35, 50)
 	m.SetMode(ModeVertical)
 

--- a/pkg/tui/components/sidebar/queue_test.go
+++ b/pkg/tui/components/sidebar/queue_test.go
@@ -14,7 +14,7 @@ func TestQueueSection_SingleMessage(t *testing.T) {
 	t.Parallel()
 
 	sessionState := &service.SessionState{}
-	m := New(sessionState).(*model)
+	m := New(t.Context(), sessionState).(*model)
 
 	m.SetQueuedMessages("Hello world")
 
@@ -37,7 +37,7 @@ func TestQueueSection_MultipleMessages(t *testing.T) {
 	t.Parallel()
 
 	sessionState := &service.SessionState{}
-	m := New(sessionState).(*model)
+	m := New(t.Context(), sessionState).(*model)
 
 	m.SetQueuedMessages("First", "Second", "Third")
 
@@ -63,7 +63,7 @@ func TestQueueSection_LongMessageTruncation(t *testing.T) {
 	t.Parallel()
 
 	sessionState := &service.SessionState{}
-	m := New(sessionState).(*model)
+	m := New(t.Context(), sessionState).(*model)
 
 	// Create a very long message
 	longMessage := strings.Repeat("x", 100)
@@ -82,7 +82,7 @@ func TestQueueSection_InRenderSections(t *testing.T) {
 	t.Parallel()
 
 	sessionState := &service.SessionState{}
-	m := New(sessionState).(*model)
+	m := New(t.Context(), sessionState).(*model)
 	m.SetSize(40, 100) // Set a reasonable size
 
 	// Without queued messages, queue section should not appear in output

--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -574,6 +574,7 @@ func gitBranch(dir string) string {
 	if dir == "" {
 		return ""
 	}
+	//rubocop:disable Lint/ContextConnectivity
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	out, err := exec.CommandContext(ctx, "git", "-C", dir, "rev-parse", "--abbrev-ref", "HEAD").Output()

--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -151,6 +151,8 @@ type model struct {
 	titleInput         textinput.Model
 	lastTitleClickTime time.Time // for double-click detection on title
 
+	ctx func() context.Context
+
 	// Render cache to avoid re-rendering sections on every frame during scroll
 	cachedLines          []string // Cached rendered lines
 	cachedWidth          int      // Width used for cached render
@@ -168,15 +170,16 @@ type model struct {
 }
 
 // New creates a new sidebar bound to the given session state.
-func New(sessionState *service.SessionState) Model {
+func New(ctx context.Context, sessionState *service.SessionState) Model {
 	ti := textinput.New()
 	ti.Placeholder = "Session title"
 	ti.CharLimit = 50
 	ti.Prompt = "" // No prompt to maximize usable width in collapsed sidebar
 
-	wd, branch := getCurrentWorkingDirectory()
+	wd, branch := getCurrentWorkingDirectory(ctx)
 
 	m := &model{
+		ctx:          func() context.Context { return context.WithoutCancel(ctx) },
 		width:        20,
 		layoutCfg:    DefaultLayoutConfig(),
 		height:       24,
@@ -494,7 +497,7 @@ func (m *model) LoadFromSession(sess *session.Session) {
 
 	// Load working directory from session
 	if sess.WorkingDir != "" {
-		m.workingDirectory, m.gitBranchName = formatWorkingDirectory(sess.WorkingDir)
+		m.workingDirectory, m.gitBranchName = formatWorkingDirectory(m.ctx(), sess.WorkingDir)
 	}
 
 	// Session has content if it has messages or token usage
@@ -570,12 +573,11 @@ func (m *model) contextPercent() string {
 
 // gitBranch returns the current git branch name for the given directory,
 // or an empty string if the directory is not inside a git repository.
-func gitBranch(dir string) string {
+func gitBranch(ctx context.Context, dir string) string {
 	if dir == "" {
 		return ""
 	}
-	//rubocop:disable Lint/ContextConnectivity
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 	out, err := exec.CommandContext(ctx, "git", "-C", dir, "rev-parse", "--abbrev-ref", "HEAD").Output()
 	if err != nil {
@@ -587,12 +589,12 @@ func gitBranch(dir string) string {
 // formatWorkingDirectory formats a raw directory path for display,
 // replacing the home prefix with ~/. Returns the display path and the
 // current git branch (empty if not in a repo).
-func formatWorkingDirectory(rawDir string) (display, branch string) {
+func formatWorkingDirectory(ctx context.Context, rawDir string) (display, branch string) {
 	if rawDir == "" {
 		return "", ""
 	}
 
-	branch = gitBranch(rawDir)
+	branch = gitBranch(ctx, rawDir)
 
 	display = rawDir
 	if homeDir := paths.GetHomeDir(); homeDir != "" && strings.HasPrefix(display, homeDir) {
@@ -604,13 +606,13 @@ func formatWorkingDirectory(rawDir string) (display, branch string) {
 
 // getCurrentWorkingDirectory returns the current working directory with home directory
 // replaced by ~/, along with the current git branch name.
-func getCurrentWorkingDirectory() (string, string) {
+func getCurrentWorkingDirectory(ctx context.Context) (string, string) {
 	pwd, err := os.Getwd()
 	if err != nil {
 		return "", ""
 	}
 
-	return formatWorkingDirectory(pwd)
+	return formatWorkingDirectory(ctx, pwd)
 }
 
 // workingDirWithBranch returns the working directory path with the git branch

--- a/pkg/tui/components/sidebar/streaming_perf_test.go
+++ b/pkg/tui/components/sidebar/streaming_perf_test.go
@@ -1,6 +1,7 @@
 package sidebar
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -28,6 +29,18 @@ func makeStreamingTodos(n int) []todo.Todo {
 	return out
 }
 
+type contextTB interface {
+	Context() context.Context
+}
+
+func testContext(tb testing.TB) context.Context {
+	tb.Helper()
+	if c, ok := tb.(contextTB); ok {
+		return c.Context()
+	}
+	panic("testing.TB does not expose Context")
+}
+
 // buildStreamingSidebar returns a sidebar in a realistic "agent is streaming"
 // state (working agent set, spinner active, token usage, two agents, a todo
 // list) with its render cache warmed.
@@ -36,7 +49,7 @@ func buildStreamingSidebar(tb testing.TB, nTodos int) *model {
 	sess := session.New()
 	ss := service.NewSessionState(sess)
 	ss.SetCurrentAgentName("root")
-	m := New(ss).(*model)
+	m := New(testContext(tb), ss).(*model)
 	m.SetSize(40, 30)
 	m.SetTeamInfo([]runtime.AgentDetails{
 		{Name: "root", Provider: "openai", Model: "gpt-4o", Description: "Expert developer that plans and executes migrations"},

--- a/pkg/tui/components/sidebar/title_edit_test.go
+++ b/pkg/tui/components/sidebar/title_edit_test.go
@@ -15,7 +15,7 @@ func TestSidebar_TitleEditStateTransitions(t *testing.T) {
 
 	sess := session.New()
 	sessionState := service.NewSessionState(sess)
-	sb := New(sessionState)
+	sb := New(t.Context(), sessionState)
 
 	// Initially not editing
 	assert.False(t, sb.IsEditingTitle(), "should not be editing initially")
@@ -43,7 +43,7 @@ func TestSidebar_TitleEditPreservesInput(t *testing.T) {
 
 	sess := session.New()
 	sessionState := service.NewSessionState(sess)
-	sb := New(sessionState)
+	sb := New(t.Context(), sessionState)
 
 	// Set initial title by simulating session load
 	m := sb.(*model)
@@ -65,7 +65,7 @@ func TestSidebar_TitleEditCancelRestoresOriginal(t *testing.T) {
 
 	sess := session.New()
 	sessionState := service.NewSessionState(sess)
-	sb := New(sessionState)
+	sb := New(t.Context(), sessionState)
 
 	// Set initial title
 	m := sb.(*model)
@@ -87,7 +87,7 @@ func TestSidebar_HandleClickType(t *testing.T) {
 
 	sess := session.New()
 	sessionState := service.NewSessionState(sess)
-	sb := New(sessionState)
+	sb := New(t.Context(), sessionState)
 
 	m := sb.(*model)
 	m.sessionHasContent = true // Enable star visibility
@@ -125,7 +125,7 @@ func TestSidebar_TitleRegenerating(t *testing.T) {
 
 	sess := session.New()
 	sessionState := service.NewSessionState(sess)
-	sb := New(sessionState)
+	sb := New(t.Context(), sessionState)
 
 	m := sb.(*model)
 	m.sessionTitle = "Original Title"
@@ -153,7 +153,7 @@ func TestSidebar_HandleClickType_WrappedTitle_Collapsed(t *testing.T) {
 
 	sess := session.New()
 	sessionState := service.NewSessionState(sess)
-	sb := New(sessionState)
+	sb := New(t.Context(), sessionState)
 
 	m := sb.(*model)
 	m.sessionHasContent = true
@@ -190,7 +190,7 @@ func TestSidebar_HandleClickType_WrappedTitle_Vertical(t *testing.T) {
 
 	sess := session.New()
 	sessionState := service.NewSessionState(sess)
-	sb := New(sessionState)
+	sb := New(t.Context(), sessionState)
 
 	m := sb.(*model)
 	m.sessionHasContent = true
@@ -228,7 +228,7 @@ func TestSidebar_HandleClickType_NoWrap(t *testing.T) {
 
 	sess := session.New()
 	sessionState := service.NewSessionState(sess)
-	sb := New(sessionState)
+	sb := New(t.Context(), sessionState)
 
 	m := sb.(*model)
 	m.sessionHasContent = true
@@ -261,7 +261,7 @@ func TestSidebar_HandleClickType_WorkingDir_Vertical(t *testing.T) {
 
 	sess := session.New()
 	sessionState := service.NewSessionState(sess)
-	sb := New(sessionState)
+	sb := New(t.Context(), sessionState)
 
 	m := sb.(*model)
 	m.sessionHasContent = true
@@ -295,7 +295,7 @@ func TestSidebar_HandleClickType_WorkingDir_Collapsed(t *testing.T) {
 
 	sess := session.New()
 	sessionState := service.NewSessionState(sess)
-	sb := New(sessionState)
+	sb := New(t.Context(), sessionState)
 
 	m := sb.(*model)
 	m.sessionHasContent = true
@@ -325,7 +325,7 @@ func TestSidebar_WorkingDirectory(t *testing.T) {
 
 	sess := session.New()
 	sessionState := service.NewSessionState(sess)
-	sb := New(sessionState)
+	sb := New(t.Context(), sessionState)
 
 	m := sb.(*model)
 	m.workingDirectory = "~/projects/myapp"

--- a/pkg/tui/components/sidebar/token_usage_test.go
+++ b/pkg/tui/components/sidebar/token_usage_test.go
@@ -15,7 +15,7 @@ import (
 func TestActiveSessionTokens_SingleSession(t *testing.T) {
 	t.Parallel()
 
-	m := newTestSidebar()
+	m := newTestSidebar(t)
 	m.startStream("session-1", "root")
 	m.recordUsageTokens("session-1", "root", 5000, 3000)
 
@@ -30,7 +30,7 @@ func TestActiveSessionTokens_SingleSession(t *testing.T) {
 func TestActiveSessionTokens_TracksActiveSubSession(t *testing.T) {
 	t.Parallel()
 
-	m := newTestSidebar()
+	m := newTestSidebar(t)
 
 	m.startStream("session-root", "root")
 	m.recordUsageTokens("session-root", "root", 20000, 10000)
@@ -55,7 +55,7 @@ func TestActiveSessionTokens_FallbackToSingleSession(t *testing.T) {
 
 	sess := session.New()
 	sessionState := service.NewSessionState(sess)
-	m := New(sessionState).(*model)
+	m := New(t.Context(), sessionState).(*model)
 
 	m.sessionUsage["session-1"] = &runtime.Usage{
 		InputTokens:  5000,
@@ -72,7 +72,7 @@ func TestActiveSessionTokens_Empty(t *testing.T) {
 
 	sess := session.New()
 	sessionState := service.NewSessionState(sess)
-	m := New(sessionState).(*model)
+	m := New(t.Context(), sessionState).(*model)
 
 	tokens, found := m.activeSessionTokens()
 	assert.False(t, found)
@@ -85,7 +85,7 @@ func TestActiveSessionTokens_Empty(t *testing.T) {
 func TestActiveSessionTokens_StableDuringSubAgent(t *testing.T) {
 	t.Parallel()
 
-	m := newTestSidebar()
+	m := newTestSidebar(t)
 
 	m.startStream("session-root", "root")
 	m.recordUsageTokens("session-root", "root", 20000, 10000)
@@ -109,7 +109,7 @@ func TestActiveSessionTokens_StableDuringSubAgent(t *testing.T) {
 func TestActiveSessionTokens_RecoversFromImbalancedStreams(t *testing.T) {
 	t.Parallel()
 
-	m := newTestSidebar()
+	m := newTestSidebar(t)
 
 	// Turn 1: a sub-agent stream is left unbalanced (no matching stop).
 	m.startStream("session-root", "root")
@@ -132,7 +132,7 @@ func TestActiveSessionTokens_RecoversFromImbalancedStreams(t *testing.T) {
 func TestTokenUsageSummary_SingleSession(t *testing.T) {
 	t.Parallel()
 
-	m := newTestSidebar()
+	m := newTestSidebar(t)
 	m.startStream("session-1", "root")
 	m.SetTokenUsage(&runtime.TokenUsageEvent{
 		SessionID:    "session-1",
@@ -157,7 +157,7 @@ func TestTokenUsageSummary_SingleSession(t *testing.T) {
 func TestTokenUsageSummary_MultipleSessions_ShowsActiveSessionTokens(t *testing.T) {
 	t.Parallel()
 
-	m := newTestSidebar()
+	m := newTestSidebar(t)
 
 	// Root agent session: 30K tokens, $0.10
 	m.startStream("session-root", "root")
@@ -208,7 +208,7 @@ func TestTokenUsageSummary_Empty(t *testing.T) {
 
 	sess := session.New()
 	sessionState := service.NewSessionState(sess)
-	m := New(sessionState).(*model)
+	m := New(t.Context(), sessionState).(*model)
 
 	assert.Empty(t, m.tokenUsageSummary())
 }
@@ -218,7 +218,7 @@ func TestTokenUsageSummary_Empty(t *testing.T) {
 func TestTokenUsageTab_ShowsTokenGlyph(t *testing.T) {
 	t.Parallel()
 
-	m := newTestSidebar()
+	m := newTestSidebar(t)
 	m.startStream("session-1", "root")
 	m.recordUsageTokens("session-1", "root", 5000, 3000)
 

--- a/pkg/tui/dialog/oauth_authorization.go
+++ b/pkg/tui/dialog/oauth_authorization.go
@@ -49,10 +49,12 @@ func (d *oauthAuthorizationDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 
 		model, cmd, handled := HandleConfirmKeys(msg, d.keyMap,
 			func() (layout.Model, tea.Cmd) {
+				//rubocop:disable Lint/ContextConnectivity
 				_ = d.app.ResumeElicitation(context.Background(), tools.ElicitationActionAccept, nil)
 				return d, core.CmdHandler(CloseDialogMsg{})
 			},
 			func() (layout.Model, tea.Cmd) {
+				//rubocop:disable Lint/ContextConnectivity
 				_ = d.app.ResumeElicitation(context.Background(), tools.ElicitationActionDecline, nil)
 				return d, core.CmdHandler(CloseDialogMsg{})
 			},

--- a/pkg/tui/dialog/oauth_authorization.go
+++ b/pkg/tui/dialog/oauth_authorization.go
@@ -16,14 +16,17 @@ import (
 type oauthAuthorizationDialog struct {
 	BaseDialog
 
+	ctx func() context.Context
+
 	serverURL string
 	app       *app.App
 	keyMap    ConfirmKeyMap
 }
 
 // NewOAuthAuthorizationDialog creates a new OAuth authorization confirmation dialog
-func NewOAuthAuthorizationDialog(serverURL string, appInstance *app.App) Dialog {
+func NewOAuthAuthorizationDialog(ctx context.Context, serverURL string, appInstance *app.App) Dialog {
 	return &oauthAuthorizationDialog{
+		ctx:       func() context.Context { return context.WithoutCancel(ctx) },
 		serverURL: serverURL,
 		app:       appInstance,
 		keyMap:    DefaultConfirmKeyMap(),
@@ -49,13 +52,11 @@ func (d *oauthAuthorizationDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 
 		model, cmd, handled := HandleConfirmKeys(msg, d.keyMap,
 			func() (layout.Model, tea.Cmd) {
-				//rubocop:disable Lint/ContextConnectivity
-				_ = d.app.ResumeElicitation(context.Background(), tools.ElicitationActionAccept, nil)
+				_ = d.app.ResumeElicitation(d.ctx(), tools.ElicitationActionAccept, nil)
 				return d, core.CmdHandler(CloseDialogMsg{})
 			},
 			func() (layout.Model, tea.Cmd) {
-				//rubocop:disable Lint/ContextConnectivity
-				_ = d.app.ResumeElicitation(context.Background(), tools.ElicitationActionDecline, nil)
+				_ = d.app.ResumeElicitation(d.ctx(), tools.ElicitationActionDecline, nil)
 				return d, core.CmdHandler(CloseDialogMsg{})
 			},
 		)

--- a/pkg/tui/dialog/url_elicitation.go
+++ b/pkg/tui/dialog/url_elicitation.go
@@ -84,6 +84,7 @@ func (d *URLElicitationDialog) openURLInBrowser() tea.Cmd {
 		if d.url == "" {
 			return nil
 		}
+		//rubocop:disable Lint/ContextConnectivity
 		if err := browser.Open(context.Background(), d.url); err != nil {
 			slog.Error("Failed to open URL in browser", "url", d.url, "error", err)
 		}

--- a/pkg/tui/dialog/url_elicitation.go
+++ b/pkg/tui/dialog/url_elicitation.go
@@ -18,6 +18,8 @@ import (
 type URLElicitationDialog struct {
 	BaseDialog
 
+	ctx func() context.Context
+
 	message     string
 	url         string
 	keyMap      ConfirmKeyMap
@@ -26,8 +28,9 @@ type URLElicitationDialog struct {
 }
 
 // NewURLElicitationDialog creates a new URL elicitation dialog.
-func NewURLElicitationDialog(message, url string) Dialog {
+func NewURLElicitationDialog(ctx context.Context, message, url string) Dialog {
 	return &URLElicitationDialog{
+		ctx:     func() context.Context { return context.WithoutCancel(ctx) },
 		message: message,
 		url:     url,
 		keyMap:  DefaultConfirmKeyMap(),
@@ -84,8 +87,7 @@ func (d *URLElicitationDialog) openURLInBrowser() tea.Cmd {
 		if d.url == "" {
 			return nil
 		}
-		//rubocop:disable Lint/ContextConnectivity
-		if err := browser.Open(context.Background(), d.url); err != nil {
+		if err := browser.Open(d.ctx(), d.url); err != nil {
 			slog.Error("Failed to open URL in browser", "url", d.url, "error", err)
 		}
 		return nil

--- a/pkg/tui/dialog/url_elicitation_test.go
+++ b/pkg/tui/dialog/url_elicitation_test.go
@@ -30,7 +30,7 @@ func TestNewURLElicitationDialog(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			dialog := NewURLElicitationDialog(tt.message, tt.url)
+			dialog := NewURLElicitationDialog(t.Context(), tt.message, tt.url)
 			require.NotNil(t, dialog)
 
 			ud, ok := dialog.(*URLElicitationDialog)
@@ -44,7 +44,7 @@ func TestNewURLElicitationDialog(t *testing.T) {
 func TestURLElicitationDialog_View(t *testing.T) {
 	t.Parallel()
 
-	dialog := NewURLElicitationDialog("Please visit the URL", "https://example.com/callback").(*URLElicitationDialog)
+	dialog := NewURLElicitationDialog(t.Context(), "Please visit the URL", "https://example.com/callback").(*URLElicitationDialog)
 	dialog.SetSize(100, 50)
 
 	view := dialog.View()
@@ -61,7 +61,7 @@ func TestURLElicitationDialog_View(t *testing.T) {
 func TestURLElicitationDialog_HasOpenKeyBinding(t *testing.T) {
 	t.Parallel()
 
-	dialog := NewURLElicitationDialog("Test", "https://example.com").(*URLElicitationDialog)
+	dialog := NewURLElicitationDialog(t.Context(), "Test", "https://example.com").(*URLElicitationDialog)
 
 	// Verify the openBrowser key binding exists and is configured correctly
 	require.NotNil(t, dialog.openBrowser)

--- a/pkg/tui/dialog/working_dir_picker.go
+++ b/pkg/tui/dialog/working_dir_picker.go
@@ -480,6 +480,7 @@ func (d *workingDirPickerDialog) toggleFavorite() {
 		return
 	}
 
+	//rubocop:disable Lint/ContextConnectivity
 	isFav, err := d.tuiStore.ToggleFavoriteDir(context.Background(), togglePath)
 	if err != nil {
 		return

--- a/pkg/tui/dialog/working_dir_picker.go
+++ b/pkg/tui/dialog/working_dir_picker.go
@@ -112,6 +112,8 @@ type tabRegion struct {
 type workingDirPickerDialog struct {
 	BaseDialog
 
+	ctx func() context.Context
+
 	textInput textinput.Model
 	section   dirSection
 
@@ -154,7 +156,7 @@ type workingDirPickerDialog struct {
 // store is used for persisting favorite directory changes (may be nil).
 // sessionWorkingDir is the working directory of the active session; when non-empty
 // it is used as the initial browse directory instead of the process working directory.
-func NewWorkingDirPickerDialog(recentDirs, favoriteDirs []string, store *tuistate.Store, sessionWorkingDir string) Dialog {
+func NewWorkingDirPickerDialog(ctx context.Context, recentDirs, favoriteDirs []string, store *tuistate.Store, sessionWorkingDir string) Dialog {
 	ti := textinput.New()
 	ti.Placeholder = "Type to filter directories…"
 	ti.Focus()
@@ -184,6 +186,7 @@ func NewWorkingDirPickerDialog(recentDirs, favoriteDirs []string, store *tuistat
 	}
 
 	d := &workingDirPickerDialog{
+		ctx:          func() context.Context { return context.WithoutCancel(ctx) },
 		textInput:    ti,
 		section:      sectionBrowse,
 		currentDir:   cwd,
@@ -480,8 +483,7 @@ func (d *workingDirPickerDialog) toggleFavorite() {
 		return
 	}
 
-	//rubocop:disable Lint/ContextConnectivity
-	isFav, err := d.tuiStore.ToggleFavoriteDir(context.Background(), togglePath)
+	isFav, err := d.tuiStore.ToggleFavoriteDir(d.ctx(), togglePath)
 	if err != nil {
 		return
 	}

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -330,7 +330,7 @@ func (m *appModel) handleSwitchAgent(agentName string) (tea.Model, tea.Cmd) {
 func (m *appModel) handleShowAgentDetails(agentName string) (tea.Model, tea.Cmd) {
 	for _, agent := range m.sessionState.AvailableAgents() {
 		if agent.Name == agentName {
-			cfg := m.application.AgentConfigInfo(agentName)
+			cfg := m.application.AgentConfigInfo(m.ctx(), agentName)
 			return m, core.CmdHandler(dialog.OpenDialogMsg{
 				Model: dialog.NewAgentDetailsDialog(agent, cfg),
 			})

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -44,6 +44,7 @@ func (m *appModel) handleBranchFromEdit(msg messages.BranchFromEditMsg) (tea.Mod
 		return m, notification.ErrorCmd("No parent session for branch")
 	}
 
+	//rubocop:disable Lint/ContextConnectivity
 	ctx := context.Background()
 
 	parent, err := store.GetSession(ctx, msg.ParentSessionID)
@@ -116,6 +117,7 @@ func (m *appModel) handleForkSession() (tea.Model, tea.Cmd) {
 		return m, notification.ErrorCmd("Session spawning not available")
 	}
 
+	//rubocop:disable Lint/ContextConnectivity
 	ctx := context.Background()
 
 	// Fork the session and clone all messages.
@@ -155,14 +157,17 @@ func (m *appModel) handleToggleSessionStar(sessionID string) (tea.Model, tea.Cmd
 	if currentSess != nil && currentSess.ID == sessionID {
 		currentSess.Starred = !currentSess.Starred
 		m.chatPage.SetSessionStarred(currentSess.Starred)
+		//rubocop:disable Lint/ContextConnectivity
 		if err := store.UpdateSession(context.Background(), currentSess); err != nil {
 			return m, notification.ErrorCmd(fmt.Sprintf("Failed to save session: %v", err))
 		}
 	} else {
+		//rubocop:disable Lint/ContextConnectivity
 		sess, err := store.GetSession(context.Background(), sessionID)
 		if err != nil {
 			return m, notification.ErrorCmd(fmt.Sprintf("Failed to load session: %v", err))
 		}
+		//rubocop:disable Lint/ContextConnectivity
 		if err := store.SetSessionStarred(context.Background(), sessionID, !sess.Starred); err != nil {
 			return m, notification.ErrorCmd(fmt.Sprintf("Failed to update session: %v", err))
 		}
@@ -171,6 +176,7 @@ func (m *appModel) handleToggleSessionStar(sessionID string) (tea.Model, tea.Cmd
 }
 
 func (m *appModel) handleSetSessionTitle(title string) (tea.Model, tea.Cmd) {
+	//rubocop:disable Lint/ContextConnectivity
 	if err := m.application.UpdateSessionTitle(context.Background(), title); err != nil {
 		if errors.Is(err, app.ErrTitleGenerating) {
 			return m, notification.WarningCmd("Title is being generated, please wait")
@@ -188,6 +194,7 @@ func (m *appModel) handleRegenerateTitle() (tea.Model, tea.Cmd) {
 	if len(sess.GetLastUserMessages(1)) == 0 {
 		return m, notification.ErrorCmd("Cannot regenerate title: no user message in session")
 	}
+	//rubocop:disable Lint/ContextConnectivity
 	if err := m.application.RegenerateSessionTitle(context.Background()); err != nil {
 		if errors.Is(err, app.ErrTitleGenerating) {
 			return m, notification.WarningCmd("Title is being generated, please wait")
@@ -204,6 +211,7 @@ func (m *appModel) handleDeleteSession(sessionID string) (tea.Model, tea.Cmd) {
 		return m, notification.ErrorCmd("No session store configured")
 	}
 
+	//rubocop:disable Lint/ContextConnectivity
 	if err := store.DeleteSession(context.Background(), sessionID); err != nil {
 		return m, notification.ErrorCmd("Failed to delete session: " + err.Error())
 	}
@@ -219,6 +227,7 @@ func (m *appModel) handleEvalSession(filename string) (tea.Model, tea.Cmd) {
 }
 
 func (m *appModel) handleExportSession(filename string) (tea.Model, tea.Cmd) {
+	//rubocop:disable Lint/ContextConnectivity
 	exportFile, err := m.application.ExportHTML(context.Background(), filename)
 	if err != nil {
 		return m, notification.ErrorCmd(fmt.Sprintf("Failed to export session: %v", err))
@@ -254,6 +263,7 @@ func (m *appModel) handleUndoSnapshot() (tea.Model, tea.Cmd) {
 	if m.chatPage.IsWorking() {
 		return m, notification.WarningCmd("Wait for the current response to finish before undoing")
 	}
+	//rubocop:disable Lint/ContextConnectivity
 	result, err := m.application.UndoLastSnapshot(context.Background())
 	if err != nil {
 		if errors.Is(err, app.ErrNothingToUndo) {
@@ -277,6 +287,7 @@ func (m *appModel) handleResetSnapshot(keep int) (tea.Model, tea.Cmd) {
 	if m.chatPage.IsWorking() {
 		return m, notification.WarningCmd("Wait for the current response to finish before resetting")
 	}
+	//rubocop:disable Lint/ContextConnectivity
 	result, err := m.application.ResetSnapshot(context.Background(), keep)
 	if err != nil {
 		if errors.Is(err, app.ErrNothingToUndo) {
@@ -459,6 +470,7 @@ func (m *appModel) handleShowPermissionsDialog() (tea.Model, tea.Cmd) {
 }
 
 func (m *appModel) handleShowToolsDialog() (tea.Model, tea.Cmd) {
+	//rubocop:disable Lint/ContextConnectivity
 	agentTools, err := m.application.CurrentAgentTools(context.Background())
 	if err != nil {
 		return m, notification.ErrorCmd(fmt.Sprintf("Failed to load tools: %v", err))
@@ -490,6 +502,7 @@ func (m *appModel) handleRestartToolset(name string) (tea.Model, tea.Cmd) {
 	return m, tea.Batch(
 		notification.InfoCmd(fmt.Sprintf("Restarting toolset %q…", name)),
 		func() tea.Msg {
+			//rubocop:disable Lint/ContextConnectivity
 			if err := appRef.RestartToolset(context.Background(), name); err != nil {
 				return notification.ShowMsg{
 					Text: fmt.Sprintf("Failed to restart %q: %v", name, err),
@@ -517,6 +530,7 @@ func (m *appModel) handleShowMCPPromptInput(promptName string, promptInfo any) (
 }
 
 func (m *appModel) handleMCPPrompt(promptName string, arguments map[string]string) (tea.Model, tea.Cmd) {
+	//rubocop:disable Lint/ContextConnectivity
 	promptContent, err := m.application.ExecuteMCPPrompt(context.Background(), promptName, arguments)
 	if err != nil {
 		return m, notification.ErrorCmd(fmt.Sprintf("Error executing MCP prompt '%s': %v", promptName, err))
@@ -535,6 +549,7 @@ func (m *appModel) handleOpenModelPicker() (tea.Model, tea.Cmd) {
 		return m, notification.InfoCmd("Model switching is not supported with remote runtimes")
 	}
 	loadStart := time.Now()
+	//rubocop:disable Lint/ContextConnectivity
 	models := m.application.AvailableModels(context.Background())
 	slog.Debug("TUI model picker available models loaded", "duration", time.Since(loadStart), "models", len(models))
 	if len(models) == 0 {
@@ -555,6 +570,7 @@ func (m *appModel) handleCycleThinkingLevel() (tea.Model, tea.Cmd) {
 	if !m.application.SupportsModelSwitching() {
 		return m, notification.InfoCmd("Thinking levels can't be changed with remote runtimes")
 	}
+	//rubocop:disable Lint/ContextConnectivity
 	if _, err := m.application.CycleAgentThinkingLevel(context.Background()); err != nil {
 		if errors.Is(err, runtime.ErrUnsupported) {
 			return m, notification.InfoCmd("Current model does not support thinking levels")
@@ -565,6 +581,7 @@ func (m *appModel) handleCycleThinkingLevel() (tea.Model, tea.Cmd) {
 }
 
 func (m *appModel) handleChangeModel(modelRef string) (tea.Model, tea.Cmd) {
+	//rubocop:disable Lint/ContextConnectivity
 	if err := m.application.SetCurrentAgentModel(context.Background(), modelRef); err != nil {
 		return m, notification.ErrorCmd(fmt.Sprintf("Failed to change model: %v", err))
 	}
@@ -676,6 +693,7 @@ func (m *appModel) handleThemeFileChanged(themeRef string) (tea.Model, tea.Cmd) 
 // --- Miscellaneous ---
 
 func (m *appModel) handleOpenURL(url string) (tea.Model, tea.Cmd) {
+	//rubocop:disable Lint/ContextConnectivity
 	if err := browser.Open(context.Background(), url); err != nil {
 		slog.Warn("Failed to open URL", "url", url, "error", err)
 		return m, notification.ErrorCmd("Failed to open URL in browser")
@@ -684,6 +702,7 @@ func (m *appModel) handleOpenURL(url string) (tea.Model, tea.Cmd) {
 }
 
 func (m *appModel) handleAgentCommand(command string) (tea.Model, tea.Cmd) {
+	//rubocop:disable Lint/ContextConnectivity
 	ctx := context.Background()
 
 	// Inspect the command before resolving so we can detect /commands that
@@ -786,6 +805,7 @@ func (m *appModel) handleStartSpeak() (tea.Model, tea.Cmd) {
 
 	ch := make(chan string, 100)
 	m.transcriptCh = ch
+	//rubocop:disable Lint/ContextConnectivity
 	err := m.transcriber.Start(context.Background(), func(delta string) {
 		select {
 		case ch <- delta:
@@ -838,6 +858,7 @@ func (m *appModel) closeTranscriptCh() {
 }
 
 func (m *appModel) handleElicitationResponse(action tools.ElicitationAction, content map[string]any) (tea.Model, tea.Cmd) {
+	//rubocop:disable Lint/ContextConnectivity
 	if err := m.application.ResumeElicitation(context.Background(), action, content); err != nil {
 		slog.Error("Failed to resume elicitation", "action", action, "error", err)
 		return m, notification.ErrorCmd("Failed to complete server request: " + err.Error())

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -1,7 +1,6 @@
 package tui
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -43,9 +42,7 @@ func (m *appModel) handleBranchFromEdit(msg messages.BranchFromEditMsg) (tea.Mod
 	if msg.ParentSessionID == "" {
 		return m, notification.ErrorCmd("No parent session for branch")
 	}
-
-	//rubocop:disable Lint/ContextConnectivity
-	ctx := context.Background()
+	ctx := m.ctx()
 
 	parent, err := store.GetSession(ctx, msg.ParentSessionID)
 	if err != nil {
@@ -116,9 +113,7 @@ func (m *appModel) handleForkSession() (tea.Model, tea.Cmd) {
 	if spawner == nil {
 		return m, notification.ErrorCmd("Session spawning not available")
 	}
-
-	//rubocop:disable Lint/ContextConnectivity
-	ctx := context.Background()
+	ctx := m.ctx()
 
 	// Fork the session and clone all messages.
 	forkedSession, err := session.BranchSession(currentSession, len(currentSession.Messages))
@@ -157,18 +152,15 @@ func (m *appModel) handleToggleSessionStar(sessionID string) (tea.Model, tea.Cmd
 	if currentSess != nil && currentSess.ID == sessionID {
 		currentSess.Starred = !currentSess.Starred
 		m.chatPage.SetSessionStarred(currentSess.Starred)
-		//rubocop:disable Lint/ContextConnectivity
-		if err := store.UpdateSession(context.Background(), currentSess); err != nil {
+		if err := store.UpdateSession(m.ctx(), currentSess); err != nil {
 			return m, notification.ErrorCmd(fmt.Sprintf("Failed to save session: %v", err))
 		}
 	} else {
-		//rubocop:disable Lint/ContextConnectivity
-		sess, err := store.GetSession(context.Background(), sessionID)
+		sess, err := store.GetSession(m.ctx(), sessionID)
 		if err != nil {
 			return m, notification.ErrorCmd(fmt.Sprintf("Failed to load session: %v", err))
 		}
-		//rubocop:disable Lint/ContextConnectivity
-		if err := store.SetSessionStarred(context.Background(), sessionID, !sess.Starred); err != nil {
+		if err := store.SetSessionStarred(m.ctx(), sessionID, !sess.Starred); err != nil {
 			return m, notification.ErrorCmd(fmt.Sprintf("Failed to update session: %v", err))
 		}
 	}
@@ -176,8 +168,7 @@ func (m *appModel) handleToggleSessionStar(sessionID string) (tea.Model, tea.Cmd
 }
 
 func (m *appModel) handleSetSessionTitle(title string) (tea.Model, tea.Cmd) {
-	//rubocop:disable Lint/ContextConnectivity
-	if err := m.application.UpdateSessionTitle(context.Background(), title); err != nil {
+	if err := m.application.UpdateSessionTitle(m.ctx(), title); err != nil {
 		if errors.Is(err, app.ErrTitleGenerating) {
 			return m, notification.WarningCmd("Title is being generated, please wait")
 		}
@@ -194,8 +185,7 @@ func (m *appModel) handleRegenerateTitle() (tea.Model, tea.Cmd) {
 	if len(sess.GetLastUserMessages(1)) == 0 {
 		return m, notification.ErrorCmd("Cannot regenerate title: no user message in session")
 	}
-	//rubocop:disable Lint/ContextConnectivity
-	if err := m.application.RegenerateSessionTitle(context.Background()); err != nil {
+	if err := m.application.RegenerateSessionTitle(m.ctx()); err != nil {
 		if errors.Is(err, app.ErrTitleGenerating) {
 			return m, notification.WarningCmd("Title is being generated, please wait")
 		}
@@ -210,9 +200,7 @@ func (m *appModel) handleDeleteSession(sessionID string) (tea.Model, tea.Cmd) {
 	if store == nil {
 		return m, notification.ErrorCmd("No session store configured")
 	}
-
-	//rubocop:disable Lint/ContextConnectivity
-	if err := store.DeleteSession(context.Background(), sessionID); err != nil {
+	if err := store.DeleteSession(m.ctx(), sessionID); err != nil {
 		return m, notification.ErrorCmd("Failed to delete session: " + err.Error())
 	}
 
@@ -227,8 +215,7 @@ func (m *appModel) handleEvalSession(filename string) (tea.Model, tea.Cmd) {
 }
 
 func (m *appModel) handleExportSession(filename string) (tea.Model, tea.Cmd) {
-	//rubocop:disable Lint/ContextConnectivity
-	exportFile, err := m.application.ExportHTML(context.Background(), filename)
+	exportFile, err := m.application.ExportHTML(m.ctx(), filename)
 	if err != nil {
 		return m, notification.ErrorCmd(fmt.Sprintf("Failed to export session: %v", err))
 	}
@@ -263,8 +250,7 @@ func (m *appModel) handleUndoSnapshot() (tea.Model, tea.Cmd) {
 	if m.chatPage.IsWorking() {
 		return m, notification.WarningCmd("Wait for the current response to finish before undoing")
 	}
-	//rubocop:disable Lint/ContextConnectivity
-	result, err := m.application.UndoLastSnapshot(context.Background())
+	result, err := m.application.UndoLastSnapshot(m.ctx())
 	if err != nil {
 		if errors.Is(err, app.ErrNothingToUndo) {
 			return m, notification.InfoCmd("No snapshot to undo")
@@ -287,8 +273,7 @@ func (m *appModel) handleResetSnapshot(keep int) (tea.Model, tea.Cmd) {
 	if m.chatPage.IsWorking() {
 		return m, notification.WarningCmd("Wait for the current response to finish before resetting")
 	}
-	//rubocop:disable Lint/ContextConnectivity
-	result, err := m.application.ResetSnapshot(context.Background(), keep)
+	result, err := m.application.ResetSnapshot(m.ctx(), keep)
 	if err != nil {
 		if errors.Is(err, app.ErrNothingToUndo) {
 			return m, notification.InfoCmd("Nothing to reset")
@@ -470,8 +455,7 @@ func (m *appModel) handleShowPermissionsDialog() (tea.Model, tea.Cmd) {
 }
 
 func (m *appModel) handleShowToolsDialog() (tea.Model, tea.Cmd) {
-	//rubocop:disable Lint/ContextConnectivity
-	agentTools, err := m.application.CurrentAgentTools(context.Background())
+	agentTools, err := m.application.CurrentAgentTools(m.ctx())
 	if err != nil {
 		return m, notification.ErrorCmd(fmt.Sprintf("Failed to load tools: %v", err))
 	}
@@ -502,8 +486,7 @@ func (m *appModel) handleRestartToolset(name string) (tea.Model, tea.Cmd) {
 	return m, tea.Batch(
 		notification.InfoCmd(fmt.Sprintf("Restarting toolset %q…", name)),
 		func() tea.Msg {
-			//rubocop:disable Lint/ContextConnectivity
-			if err := appRef.RestartToolset(context.Background(), name); err != nil {
+			if err := appRef.RestartToolset(m.ctx(), name); err != nil {
 				return notification.ShowMsg{
 					Text: fmt.Sprintf("Failed to restart %q: %v", name, err),
 					Type: notification.TypeError,
@@ -530,8 +513,7 @@ func (m *appModel) handleShowMCPPromptInput(promptName string, promptInfo any) (
 }
 
 func (m *appModel) handleMCPPrompt(promptName string, arguments map[string]string) (tea.Model, tea.Cmd) {
-	//rubocop:disable Lint/ContextConnectivity
-	promptContent, err := m.application.ExecuteMCPPrompt(context.Background(), promptName, arguments)
+	promptContent, err := m.application.ExecuteMCPPrompt(m.ctx(), promptName, arguments)
 	if err != nil {
 		return m, notification.ErrorCmd(fmt.Sprintf("Error executing MCP prompt '%s': %v", promptName, err))
 	}
@@ -549,8 +531,7 @@ func (m *appModel) handleOpenModelPicker() (tea.Model, tea.Cmd) {
 		return m, notification.InfoCmd("Model switching is not supported with remote runtimes")
 	}
 	loadStart := time.Now()
-	//rubocop:disable Lint/ContextConnectivity
-	models := m.application.AvailableModels(context.Background())
+	models := m.application.AvailableModels(m.ctx())
 	slog.Debug("TUI model picker available models loaded", "duration", time.Since(loadStart), "models", len(models))
 	if len(models) == 0 {
 		return m, notification.InfoCmd("No models available for selection")
@@ -570,8 +551,7 @@ func (m *appModel) handleCycleThinkingLevel() (tea.Model, tea.Cmd) {
 	if !m.application.SupportsModelSwitching() {
 		return m, notification.InfoCmd("Thinking levels can't be changed with remote runtimes")
 	}
-	//rubocop:disable Lint/ContextConnectivity
-	if _, err := m.application.CycleAgentThinkingLevel(context.Background()); err != nil {
+	if _, err := m.application.CycleAgentThinkingLevel(m.ctx()); err != nil {
 		if errors.Is(err, runtime.ErrUnsupported) {
 			return m, notification.InfoCmd("Current model does not support thinking levels")
 		}
@@ -581,8 +561,7 @@ func (m *appModel) handleCycleThinkingLevel() (tea.Model, tea.Cmd) {
 }
 
 func (m *appModel) handleChangeModel(modelRef string) (tea.Model, tea.Cmd) {
-	//rubocop:disable Lint/ContextConnectivity
-	if err := m.application.SetCurrentAgentModel(context.Background(), modelRef); err != nil {
+	if err := m.application.SetCurrentAgentModel(m.ctx(), modelRef); err != nil {
 		return m, notification.ErrorCmd(fmt.Sprintf("Failed to change model: %v", err))
 	}
 	if modelRef == "" {
@@ -693,8 +672,7 @@ func (m *appModel) handleThemeFileChanged(themeRef string) (tea.Model, tea.Cmd) 
 // --- Miscellaneous ---
 
 func (m *appModel) handleOpenURL(url string) (tea.Model, tea.Cmd) {
-	//rubocop:disable Lint/ContextConnectivity
-	if err := browser.Open(context.Background(), url); err != nil {
+	if err := browser.Open(m.ctx(), url); err != nil {
 		slog.Warn("Failed to open URL", "url", url, "error", err)
 		return m, notification.ErrorCmd("Failed to open URL in browser")
 	}
@@ -702,8 +680,7 @@ func (m *appModel) handleOpenURL(url string) (tea.Model, tea.Cmd) {
 }
 
 func (m *appModel) handleAgentCommand(command string) (tea.Model, tea.Cmd) {
-	//rubocop:disable Lint/ContextConnectivity
-	ctx := context.Background()
+	ctx := m.ctx()
 
 	// Inspect the command before resolving so we can detect /commands that
 	// switch to a sub-agent. For those, we switch first and only then send
@@ -805,8 +782,7 @@ func (m *appModel) handleStartSpeak() (tea.Model, tea.Cmd) {
 
 	ch := make(chan string, 100)
 	m.transcriptCh = ch
-	//rubocop:disable Lint/ContextConnectivity
-	err := m.transcriber.Start(context.Background(), func(delta string) {
+	err := m.transcriber.Start(m.ctx(), func(delta string) {
 		select {
 		case ch <- delta:
 		default:
@@ -858,8 +834,7 @@ func (m *appModel) closeTranscriptCh() {
 }
 
 func (m *appModel) handleElicitationResponse(action tools.ElicitationAction, content map[string]any) (tea.Model, tea.Cmd) {
-	//rubocop:disable Lint/ContextConnectivity
-	if err := m.application.ResumeElicitation(context.Background(), action, content); err != nil {
+	if err := m.application.ResumeElicitation(m.ctx(), action, content); err != nil {
 		slog.Error("Failed to resume elicitation", "action", action, "error", err)
 		return m, notification.ErrorCmd("Failed to complete server request: " + err.Error())
 	}

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -964,7 +964,7 @@ func (p *chatPage) handleRetry() (layout.Model, tea.Cmd) {
 	p.sidebar.ResetStreamTracking()
 
 	var ctx context.Context
-	ctx, p.msgCancel = context.WithCancel(context.Background())
+	ctx, p.msgCancel = context.WithCancel(p.ctx())
 
 	spinnerCmd := p.setWorking(true)
 	p.app.Retry(ctx, p.msgCancel)

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -898,6 +898,7 @@ func (p *chatPage) processMessage(msg msgtypes.SendMsg) tea.Cmd {
 	}
 
 	if isBangCommand(msg.Content) {
+		//rubocop:disable Lint/ContextConnectivity
 		p.app.RunBangCommand(context.Background(), msg.Content[1:])
 		return p.messages.ScrollToBottom()
 	}
@@ -975,6 +976,7 @@ func (p *chatPage) CompactSession(additionalPrompt string) tea.Cmd {
 	cancelCmd := p.cancelStream(false)
 
 	var ctx context.Context
+	//rubocop:disable Lint/ContextConnectivity
 	ctx, p.msgCancel = context.WithCancel(context.Background())
 	p.app.CompactSession(ctx, p.msgCancel, additionalPrompt)
 

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -161,6 +161,8 @@ type chatPage struct {
 	// Key map
 	keyMap KeyMap
 
+	ctx func() context.Context
+
 	app *app.App
 
 	// Command parser for handling slash commands in the editor
@@ -264,9 +266,10 @@ func defaultKeyMap() KeyMap {
 }
 
 // New creates a new chat page
-func New(a *app.App, sessionState *service.SessionState, opts ...PageOption) Page {
+func New(ctx context.Context, a *app.App, sessionState *service.SessionState, opts ...PageOption) Page {
 	p := &chatPage{
-		sidebar:       sidebar.New(sessionState),
+		ctx:           func() context.Context { return context.WithoutCancel(ctx) },
+		sidebar:       sidebar.New(ctx, sessionState),
 		messages:      messages.New(sessionState),
 		app:           a,
 		keyMap:        defaultKeyMap(),
@@ -898,8 +901,7 @@ func (p *chatPage) processMessage(msg msgtypes.SendMsg) tea.Cmd {
 	}
 
 	if isBangCommand(msg.Content) {
-		//rubocop:disable Lint/ContextConnectivity
-		p.app.RunBangCommand(context.Background(), msg.Content[1:])
+		p.app.RunBangCommand(p.ctx(), msg.Content[1:])
 		return p.messages.ScrollToBottom()
 	}
 
@@ -912,7 +914,7 @@ func (p *chatPage) processMessage(msg msgtypes.SendMsg) tea.Cmd {
 	p.sidebar.ResetStreamTracking()
 
 	var ctx context.Context
-	ctx, p.msgCancel = context.WithCancel(context.Background())
+	ctx, p.msgCancel = context.WithCancel(p.ctx())
 
 	// Start working state immediately to show the user something is happening.
 	// This provides visual feedback while the runtime loads tools and prepares the stream.
@@ -976,8 +978,7 @@ func (p *chatPage) CompactSession(additionalPrompt string) tea.Cmd {
 	cancelCmd := p.cancelStream(false)
 
 	var ctx context.Context
-	//rubocop:disable Lint/ContextConnectivity
-	ctx, p.msgCancel = context.WithCancel(context.Background())
+	ctx, p.msgCancel = context.WithCancel(p.ctx())
 	p.app.CompactSession(ctx, p.msgCancel, additionalPrompt)
 
 	return tea.Batch(

--- a/pkg/tui/page/chat/input_handlers.go
+++ b/pkg/tui/page/chat/input_handlers.go
@@ -78,6 +78,7 @@ func (p *chatPage) handleKeyPress(msg tea.KeyPressMsg) (layout.Model, tea.Cmd) {
 // persistSessionTitle saves the new session title to the store
 func (p *chatPage) persistSessionTitle(newTitle string) tea.Cmd {
 	return func() tea.Msg {
+		//rubocop:disable Lint/ContextConnectivity
 		if err := p.app.UpdateSessionTitle(context.Background(), newTitle); err != nil {
 			// Show warning if title generation is in progress
 			if errors.Is(err, app.ErrTitleGenerating) {

--- a/pkg/tui/page/chat/input_handlers.go
+++ b/pkg/tui/page/chat/input_handlers.go
@@ -1,7 +1,6 @@
 package chat
 
 import (
-	"context"
 	"errors"
 	"log/slog"
 
@@ -78,8 +77,7 @@ func (p *chatPage) handleKeyPress(msg tea.KeyPressMsg) (layout.Model, tea.Cmd) {
 // persistSessionTitle saves the new session title to the store
 func (p *chatPage) persistSessionTitle(newTitle string) tea.Cmd {
 	return func() tea.Msg {
-		//rubocop:disable Lint/ContextConnectivity
-		if err := p.app.UpdateSessionTitle(context.Background(), newTitle); err != nil {
+		if err := p.app.UpdateSessionTitle(p.ctx(), newTitle); err != nil {
 			// Show warning if title generation is in progress
 			if errors.Is(err, app.ErrTitleGenerating) {
 				return notification.ShowMsg{Text: "Title is being generated, please wait", Type: notification.TypeWarning}

--- a/pkg/tui/page/chat/queue_test.go
+++ b/pkg/tui/page/chat/queue_test.go
@@ -93,10 +93,10 @@ func (queueTestRuntime) ExecuteMCPPrompt(context.Context, string, map[string]str
 func (queueTestRuntime) UpdateSessionTitle(context.Context, *session.Session, string) error {
 	return nil
 }
-func (queueTestRuntime) TitleGenerator() *sessiontitle.Generator               { return nil }
-func (queueTestRuntime) Steer(context.Context, runtime.QueuedMessage) error    { return nil }
-func (queueTestRuntime) FollowUp(context.Context, runtime.QueuedMessage) error { return nil }
-func (queueTestRuntime) SetAgentModel(context.Context, string, string) error   { return nil }
+func (queueTestRuntime) TitleGenerator(context.Context) *sessiontitle.Generator { return nil }
+func (queueTestRuntime) Steer(context.Context, runtime.QueuedMessage) error     { return nil }
+func (queueTestRuntime) FollowUp(context.Context, runtime.QueuedMessage) error  { return nil }
+func (queueTestRuntime) SetAgentModel(context.Context, string, string) error    { return nil }
 func (queueTestRuntime) CycleAgentThinkingLevel(context.Context, string) (effort.Level, error) {
 	return "", runtime.ErrUnsupported
 }

--- a/pkg/tui/page/chat/queue_test.go
+++ b/pkg/tui/page/chat/queue_test.go
@@ -396,7 +396,7 @@ func TestReadOnly_RejectsMessages(t *testing.T) {
 	t.Parallel()
 
 	sess := session.New()
-	a := app.New(queueTestRuntime{}, sess, app.WithReadOnly())
+	a := app.New(t.Context(), queueTestRuntime{}, sess, app.WithReadOnly())
 	require.True(t, a.IsReadOnly())
 
 	p := New(t.Context(), a, service.NewSessionState(sess)).(*chatPage)

--- a/pkg/tui/page/chat/queue_test.go
+++ b/pkg/tui/page/chat/queue_test.go
@@ -35,7 +35,7 @@ func newTestChatPage(t *testing.T) *chatPage {
 	sessionState := &service.SessionState{}
 
 	return &chatPage{
-		sidebar:      sidebar.New(sessionState),
+		sidebar:      sidebar.New(t.Context(), sessionState),
 		sessionState: sessionState,
 		working:      true, // Start busy so messages get queued
 	}
@@ -205,7 +205,7 @@ func TestQueueFlow_BusyAgent_BangCommandBypassesQueue(t *testing.T) {
 	t.Parallel()
 
 	sess := session.New()
-	p := New(app.New(queueTestRuntime{}, sess), service.NewSessionState(sess)).(*chatPage)
+	p := New(t.Context(), app.New(t.Context(), queueTestRuntime{}, sess), service.NewSessionState(sess)).(*chatPage)
 	p.working = true
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
@@ -237,7 +237,7 @@ func TestQueueFlow_SkillCommand_DispatchesOnceWithoutLooping(t *testing.T) {
 	t.Parallel()
 
 	sess := session.New()
-	p := New(app.New(queueTestRuntime{}, sess), service.NewSessionState(sess)).(*chatPage)
+	p := New(t.Context(), app.New(t.Context(), queueTestRuntime{}, sess), service.NewSessionState(sess)).(*chatPage)
 
 	calls := 0
 	p.commandParser = commands.NewParser(commands.Category{
@@ -399,7 +399,7 @@ func TestReadOnly_RejectsMessages(t *testing.T) {
 	a := app.New(queueTestRuntime{}, sess, app.WithReadOnly())
 	require.True(t, a.IsReadOnly())
 
-	p := New(a, service.NewSessionState(sess)).(*chatPage)
+	p := New(t.Context(), a, service.NewSessionState(sess)).(*chatPage)
 
 	_, cmd := p.handleSendMsg(messages.SendMsg{Content: "hello"})
 
@@ -411,8 +411,8 @@ func TestReadOnly_AllowsSlashCommands(t *testing.T) {
 	t.Parallel()
 
 	sess := session.New()
-	a := app.New(queueTestRuntime{}, sess, app.WithReadOnly())
-	p := New(a, service.NewSessionState(sess)).(*chatPage)
+	a := app.New(t.Context(), queueTestRuntime{}, sess, app.WithReadOnly())
+	p := New(t.Context(), a, service.NewSessionState(sess)).(*chatPage)
 	p.commandParser = commands.NewParser(commands.Category{
 		Name: "Test",
 		Commands: []commands.Item{
@@ -489,7 +489,7 @@ func TestHandleSendMsg_ForkSkillRunsViaFork(t *testing.T) {
 	}}, t.TempDir())
 	rt := &skillDispatchRuntime{skillset: skillSet}
 	sess := session.New()
-	p := New(app.New(rt, sess), service.NewSessionState(sess)).(*chatPage)
+	p := New(t.Context(), app.New(t.Context(), rt, sess), service.NewSessionState(sess)).(*chatPage)
 	p.commandParser = skillCommandParser("services")
 
 	dispatchTypedSkill(t, p, "/services please")
@@ -514,7 +514,7 @@ func TestHandleSendMsg_InlineSkillRunsViaResolveInput(t *testing.T) {
 	}}, t.TempDir())
 	rt := &skillDispatchRuntime{skillset: skillSet}
 	sess := session.New()
-	p := New(app.New(rt, sess), service.NewSessionState(sess)).(*chatPage)
+	p := New(t.Context(), app.New(t.Context(), rt, sess), service.NewSessionState(sess)).(*chatPage)
 	p.commandParser = skillCommandParser("services")
 
 	dispatchTypedSkill(t, p, "/services please")
@@ -535,8 +535,8 @@ func TestReadOnly_RejectsBypassQueueCommands(t *testing.T) {
 	t.Parallel()
 
 	sess := session.New()
-	a := app.New(queueTestRuntime{}, sess, app.WithReadOnly())
-	p := New(a, service.NewSessionState(sess)).(*chatPage)
+	a := app.New(t.Context(), queueTestRuntime{}, sess, app.WithReadOnly())
+	p := New(t.Context(), a, service.NewSessionState(sess)).(*chatPage)
 
 	_, cmd := p.handleSendMsg(messages.SendMsg{Content: "/myskill", BypassQueue: true})
 

--- a/pkg/tui/page/chat/queue_test.go
+++ b/pkg/tui/page/chat/queue_test.go
@@ -48,8 +48,8 @@ type queueTestRuntime struct{}
 func (queueTestRuntime) CurrentAgentInfo(context.Context) runtime.CurrentAgentInfo {
 	return runtime.CurrentAgentInfo{}
 }
-func (queueTestRuntime) CurrentAgentName() string                                { return "root" }
-func (queueTestRuntime) SetCurrentAgent(string) error                            { return nil }
+func (queueTestRuntime) CurrentAgentName(context.Context) string                 { return "root" }
+func (queueTestRuntime) SetCurrentAgent(context.Context, string) error           { return nil }
 func (queueTestRuntime) CurrentAgentTools(context.Context) ([]tools.Tool, error) { return nil, nil }
 func (queueTestRuntime) CurrentAgentToolsetStatuses() []tools.ToolsetStatus      { return nil }
 func (queueTestRuntime) RestartToolset(context.Context, string) error            { return nil }
@@ -93,10 +93,10 @@ func (queueTestRuntime) ExecuteMCPPrompt(context.Context, string, map[string]str
 func (queueTestRuntime) UpdateSessionTitle(context.Context, *session.Session, string) error {
 	return nil
 }
-func (queueTestRuntime) TitleGenerator() *sessiontitle.Generator             { return nil }
-func (queueTestRuntime) Steer(runtime.QueuedMessage) error                   { return nil }
-func (queueTestRuntime) FollowUp(runtime.QueuedMessage) error                { return nil }
-func (queueTestRuntime) SetAgentModel(context.Context, string, string) error { return nil }
+func (queueTestRuntime) TitleGenerator() *sessiontitle.Generator               { return nil }
+func (queueTestRuntime) Steer(context.Context, runtime.QueuedMessage) error    { return nil }
+func (queueTestRuntime) FollowUp(context.Context, runtime.QueuedMessage) error { return nil }
+func (queueTestRuntime) SetAgentModel(context.Context, string, string) error   { return nil }
 func (queueTestRuntime) CycleAgentThinkingLevel(context.Context, string) (effort.Level, error) {
 	return "", runtime.ErrUnsupported
 }

--- a/pkg/tui/page/chat/runtime_events.go
+++ b/pkg/tui/page/chat/runtime_events.go
@@ -56,7 +56,7 @@ func (p *chatPage) handleRuntimeEvent(msg tea.Msg) (bool, tea.Cmd) {
 	// ===== Error and Warning Events =====
 	case *runtime.ErrorEvent:
 		if userconfig.Get().GetSound() {
-			sound.Play(sound.Failure)
+			sound.Play(p.ctx(), sound.Failure)
 		}
 		return true, p.messages.AddErrorMessage(msg.Error)
 
@@ -270,7 +270,7 @@ func (p *chatPage) handleStreamStopped(msg *runtime.StreamStoppedEvent) tea.Cmd 
 		duration := time.Since(p.streamStartTime)
 		threshold := time.Duration(userconfig.Get().GetSoundThreshold()) * time.Second
 		if duration >= threshold {
-			sound.Play(sound.Success)
+			sound.Play(p.ctx(), sound.Success)
 		}
 	}
 	p.msgCancel = nil

--- a/pkg/tui/page/chat/runtime_events.go
+++ b/pkg/tui/page/chat/runtime_events.go
@@ -365,7 +365,7 @@ func (p *chatPage) handleElicitationRequest(msg *runtime.ElicitationRequestEvent
 				serverURL = url
 			}
 			dialogCmd := core.CmdHandler(dialog.OpenDialogMsg{
-				Model:            dialog.NewOAuthAuthorizationDialog(serverURL, p.app),
+				Model:            dialog.NewOAuthAuthorizationDialog(p.ctx(), serverURL, p.app),
 				OriginatingEvent: msg,
 			})
 			return tea.Batch(spinnerCmd, dialogCmd)
@@ -377,7 +377,7 @@ func (p *chatPage) handleElicitationRequest(msg *runtime.ElicitationRequestEvent
 	case "url":
 		// URL-based elicitation - show URL dialog
 		dialogCmd := core.CmdHandler(dialog.OpenDialogMsg{
-			Model:            dialog.NewURLElicitationDialog(msg.Message, msg.URL),
+			Model:            dialog.NewURLElicitationDialog(p.ctx(), msg.Message, msg.URL),
 			OriginatingEvent: msg,
 		})
 		return tea.Batch(spinnerCmd, dialogCmd)

--- a/pkg/tui/service/tuistate/store.go
+++ b/pkg/tui/service/tuistate/store.go
@@ -35,6 +35,7 @@ func New() (*Store, error) {
 
 // migrate runs database migrations.
 func (s *Store) migrate() error {
+	//rubocop:disable Lint/ContextConnectivity
 	ctx := context.Background()
 	_, err := s.db.ExecContext(ctx, `
 		CREATE TABLE IF NOT EXISTS tabs (

--- a/pkg/tui/service/tuistate/store.go
+++ b/pkg/tui/service/tuistate/store.go
@@ -19,7 +19,7 @@ type Store struct {
 // New creates a new TUI state store, initializing the database if needed.
 func New(ctx context.Context) (*Store, error) {
 	dbPath := filepath.Join(paths.GetDataDir(), "tui_state.db")
-	db, err := sqliteutil.OpenDB(dbPath)
+	db, err := sqliteutil.OpenDB(ctx, dbPath)
 	if err != nil {
 		return nil, fmt.Errorf("opening TUI state store: %w", err)
 	}

--- a/pkg/tui/service/tuistate/store.go
+++ b/pkg/tui/service/tuistate/store.go
@@ -17,7 +17,7 @@ type Store struct {
 }
 
 // New creates a new TUI state store, initializing the database if needed.
-func New() (*Store, error) {
+func New(ctx context.Context) (*Store, error) {
 	dbPath := filepath.Join(paths.GetDataDir(), "tui_state.db")
 	db, err := sqliteutil.OpenDB(dbPath)
 	if err != nil {
@@ -25,7 +25,7 @@ func New() (*Store, error) {
 	}
 
 	store := &Store{db: db}
-	if err := store.migrate(); err != nil {
+	if err := store.migrate(ctx); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("migrating TUI state store: %w", err)
 	}
@@ -34,9 +34,7 @@ func New() (*Store, error) {
 }
 
 // migrate runs database migrations.
-func (s *Store) migrate() error {
-	//rubocop:disable Lint/ContextConnectivity
-	ctx := context.Background()
+func (s *Store) migrate(ctx context.Context) error {
 	_, err := s.db.ExecContext(ctx, `
 		CREATE TABLE IF NOT EXISTS tabs (
 			session_id TEXT PRIMARY KEY,

--- a/pkg/tui/service/tuistate/store_test.go
+++ b/pkg/tui/service/tuistate/store_test.go
@@ -14,7 +14,7 @@ import (
 func newTestStore(t *testing.T) *Store {
 	t.Helper()
 	dbPath := filepath.Join(t.TempDir(), "tui_state.db")
-	db, err := sqliteutil.OpenDB(dbPath)
+	db, err := sqliteutil.OpenDB(t.Context(), dbPath)
 	require.NoError(t, err)
 	t.Cleanup(func() { db.Close() })
 

--- a/pkg/tui/service/tuistate/store_test.go
+++ b/pkg/tui/service/tuistate/store_test.go
@@ -19,7 +19,7 @@ func newTestStore(t *testing.T) *Store {
 	t.Cleanup(func() { db.Close() })
 
 	store := &Store{db: db}
-	require.NoError(t, store.migrate())
+	require.NoError(t, store.migrate(t.Context()))
 	return store
 }
 

--- a/pkg/tui/tabs.go
+++ b/pkg/tui/tabs.go
@@ -26,6 +26,7 @@ func (m *appModel) persistActiveTab(persistedID string) {
 	if m.tuiStore == nil {
 		return
 	}
+	//rubocop:disable Lint/ContextConnectivity
 	if err := m.tuiStore.SetActiveTab(context.Background(), persistedID); err != nil {
 		slog.Warn("Failed to set active tab", "error", err)
 	}

--- a/pkg/tui/tabs.go
+++ b/pkg/tui/tabs.go
@@ -26,8 +26,7 @@ func (m *appModel) persistActiveTab(persistedID string) {
 	if m.tuiStore == nil {
 		return
 	}
-	//rubocop:disable Lint/ContextConnectivity
-	if err := m.tuiStore.SetActiveTab(context.Background(), persistedID); err != nil {
+	if err := m.tuiStore.SetActiveTab(m.ctx(), persistedID); err != nil {
 		slog.Warn("Failed to set active tab", "error", err)
 	}
 }

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -444,6 +444,7 @@ func (m *appModel) reapplyKeyboardEnhancements() {
 }
 
 func (m *appModel) commandCategories() []commands.Category {
+	//rubocop:disable Lint/ContextConnectivity
 	categories := m.buildCommandCategories(context.Background(), m)
 	if len(m.disabledCommands) == 0 {
 		return categories
@@ -556,10 +557,13 @@ func (m *appModel) Init() tea.Cmd {
 	if oldSessionID, ok := m.pendingRestores[activeID]; ok {
 		delete(m.pendingRestores, activeID)
 		if store := m.application.SessionStore(); store != nil {
+			//rubocop:disable Lint/ContextConnectivity
 			if sess, err := store.GetSession(context.Background(), oldSessionID); err == nil {
+				//rubocop:disable Lint/ContextConnectivity
 				_, cmd := m.replaceActiveSession(context.Background(), sess)
 
 				if m.tuiStore != nil && sess.WorkingDir != "" {
+					//rubocop:disable Lint/ContextConnectivity
 					if err := m.tuiStore.UpdateTabWorkingDir(context.Background(), oldSessionID, sess.WorkingDir); err != nil {
 						slog.Warn("Failed to update persisted working dir", "error", err)
 					}
@@ -654,6 +658,7 @@ func (m *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if m.tuiStore != nil {
 			persistedID := m.persistedSessionID(m.supervisor.ActiveID())
+			//rubocop:disable Lint/ContextConnectivity
 			if err := m.tuiStore.ToggleSidebarCollapsed(context.Background(), persistedID); err != nil {
 				slog.Warn("Failed to persist sidebar collapsed state", "error", err)
 			}
@@ -1052,6 +1057,7 @@ func (m *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.application.IsReadOnly() {
 			return m, notification.WarningCmd("Session is read-only. No new messages can be sent.")
 		}
+		//rubocop:disable Lint/ContextConnectivity
 		m.application.RunWithMessage(context.Background(), nil, msg.Content)
 		return m, nil
 
@@ -1170,6 +1176,7 @@ func (m *appModel) handleOpenSessionBrowser() (tea.Model, tea.Cmd) {
 		return m, notification.InfoCmd("No session store configured")
 	}
 
+	//rubocop:disable Lint/ContextConnectivity
 	sessions, err := store.GetSessionSummaries(context.Background())
 	if err != nil {
 		return m, notification.ErrorCmd(fmt.Sprintf("Failed to load sessions: %v", err))
@@ -1190,6 +1197,7 @@ func (m *appModel) handleLoadSession(sessionID string) (tea.Model, tea.Cmd) {
 		return m, notification.ErrorCmd("No session store configured")
 	}
 
+	//rubocop:disable Lint/ContextConnectivity
 	sess, err := store.GetSession(context.Background(), sessionID)
 	if err != nil {
 		return m, notification.ErrorCmd(fmt.Sprintf("Failed to load session: %v", err))
@@ -1205,6 +1213,7 @@ func (m *appModel) handleLoadSession(sessionID string) (tea.Model, tea.Cmd) {
 	if workingDir == "" {
 		workingDir = m.application.Session().WorkingDir
 	}
+	//rubocop:disable Lint/ContextConnectivity
 	ctx := context.Background()
 
 	// If the current session is empty (no messages, no title — the default state
@@ -1333,6 +1342,7 @@ func (m *appModel) handleClearSession() (tea.Model, tea.Cmd) {
 
 	// Update persisted tab to point to the new session.
 	if m.tuiStore != nil {
+		//rubocop:disable Lint/ContextConnectivity
 		ctx := context.Background()
 		oldPersistedID := m.persistedSessionID(activeID)
 		if err := m.tuiStore.UpdateTabSessionID(ctx, oldPersistedID, newSess.ID); err != nil {
@@ -1358,6 +1368,7 @@ func (m *appModel) handleSpawnSession(workingDir string) (tea.Model, tea.Cmd) {
 	}
 
 	// Spawn the new session
+	//rubocop:disable Lint/ContextConnectivity
 	ctx := context.Background()
 	sessionID, err := m.supervisor.SpawnSession(ctx, workingDir)
 	if err != nil {
@@ -1379,7 +1390,9 @@ func (m *appModel) handleSpawnSession(workingDir string) (tea.Model, tea.Cmd) {
 func (m *appModel) openWorkingDirPicker() (tea.Model, tea.Cmd) {
 	var recentDirs, favoriteDirs []string
 	if m.tuiStore != nil {
+		//rubocop:disable Lint/ContextConnectivity
 		recentDirs, _ = m.tuiStore.GetRecentDirs(context.Background(), 10)
+		//rubocop:disable Lint/ContextConnectivity
 		favoriteDirs, _ = m.tuiStore.GetFavoriteDirs(context.Background())
 	}
 
@@ -1458,11 +1471,14 @@ func (m *appModel) handleSwitchTab(sessionID string) (tea.Model, tea.Cmd) {
 		delete(m.pendingRestores, sessionID)
 		m.application = runner.App
 		if store := runner.App.SessionStore(); store != nil {
+			//rubocop:disable Lint/ContextConnectivity
 			if sess, err := store.GetSession(context.Background(), oldSessionID); err == nil {
 				m.persistActiveTab(sess.ID)
+				//rubocop:disable Lint/ContextConnectivity
 				model, cmd := m.replaceActiveSession(context.Background(), sess)
 
 				if m.tuiStore != nil && sess.WorkingDir != "" {
+					//rubocop:disable Lint/ContextConnectivity
 					if err := m.tuiStore.UpdateTabWorkingDir(context.Background(), oldSessionID, sess.WorkingDir); err != nil {
 						slog.Warn("Failed to update persisted working dir", "error", err)
 					}
@@ -1634,6 +1650,7 @@ func (m *appModel) handleReorderTab(msg messages.ReorderTabMsg) (tea.Model, tea.
 		for i, tab := range tabs {
 			ids[i] = m.persistedSessionID(tab.SessionID)
 		}
+		//rubocop:disable Lint/ContextConnectivity
 		if err := m.tuiStore.ReorderTab(context.Background(), ids); err != nil {
 			slog.Warn("Failed to persist tab reorder", "error", err)
 		}
@@ -1671,6 +1688,7 @@ func (m *appModel) handleCloseTab(sessionID string) (tea.Model, tea.Cmd) {
 	var cmds []tea.Cmd
 	// Remove from persistent store using the persisted session-store ID.
 	if m.tuiStore != nil {
+		//rubocop:disable Lint/ContextConnectivity
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
 		if err := m.tuiStore.RemoveTab(ctx, persistedID); err != nil {

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -86,6 +86,12 @@ type appModel struct {
 	chatPage     chat.Page
 	editor       editor.Editor
 
+	// ctx preserves values from the root TUI context (trace context,
+	// baggage, log attrs) without inheriting cancellation. Bubble Tea
+	// handlers have no ctx parameter and many calls are persistence/cleanup
+	// work that must survive shutdown cancellation.
+	ctx func() context.Context
+
 	// Shared history for command history across all editors
 	history *history.History
 
@@ -323,6 +329,8 @@ func WithToolRenderers(renderers map[string]tool.Builder) Option {
 
 // New creates a new Model.
 func New(ctx context.Context, spawner SessionSpawner, initialApp *app.App, initialWorkingDir string, cleanup func(), opts ...Option) tea.Model {
+	tuiCtx := func() context.Context { return context.WithoutCancel(ctx) }
+
 	// Initialize supervisor
 	sv := supervisor.New(spawner)
 
@@ -333,7 +341,7 @@ func New(ctx context.Context, spawner SessionSpawner, initialApp *app.App, initi
 	// Initialize tab store
 	var ts *tuistate.Store
 	var tsErr error
-	ts, tsErr = tuistate.New()
+	ts, tsErr = tuistate.New(tuiCtx())
 	if tsErr != nil {
 		slog.WarnContext(ctx, "Failed to open TUI state store, tabs won't persist", "error", tsErr)
 	}
@@ -359,6 +367,7 @@ func New(ctx context.Context, spawner SessionSpawner, initialApp *app.App, initi
 		editors:                       map[string]editor.Editor{},
 		sessionStates:                 map[string]*service.SessionState{sessID: initialSessionState},
 		application:                   initialApp,
+		ctx:                           tuiCtx,
 		sessionState:                  initialSessionState,
 		history:                       historyStore,
 		pendingRestores:               make(map[string]string),
@@ -388,7 +397,7 @@ func New(ctx context.Context, spawner SessionSpawner, initialApp *app.App, initi
 	m.editor = initialEditor
 
 	// Create initial chat page (after options are applied so leanMode is set)
-	initialChatPage := chat.New(initialApp, initialSessionState, m.chatPageOpts()...)
+	initialChatPage := chat.New(m.ctx(), initialApp, initialSessionState, m.chatPageOpts()...)
 	m.chatPages[sessID] = initialChatPage
 	m.chatPage = initialChatPage
 
@@ -444,8 +453,7 @@ func (m *appModel) reapplyKeyboardEnhancements() {
 }
 
 func (m *appModel) commandCategories() []commands.Category {
-	//rubocop:disable Lint/ContextConnectivity
-	categories := m.buildCommandCategories(context.Background(), m)
+	categories := m.buildCommandCategories(m.ctx(), m)
 	if len(m.disabledCommands) == 0 {
 		return categories
 	}
@@ -488,7 +496,7 @@ func (m *appModel) editorOpts() []editor.Option {
 	opts := []editor.Option{
 		editor.WithCompletions(
 			completions.NewCommandCompletion(m.commandCategories()),
-			completions.NewFileCompletion(),
+			completions.NewFileCompletion(m.ctx()),
 		),
 	}
 	if m.application.IsReadOnly() {
@@ -502,7 +510,7 @@ func (m *appModel) editorOpts() []editor.Option {
 // convenience pointers (m.chatPage, m.sessionState, m.editor) are also updated.
 func (m *appModel) initSessionComponents(tabID string, a *app.App, sess *session.Session) {
 	ss := service.NewSessionState(sess)
-	cp := chat.New(a, ss, m.chatPageOpts()...)
+	cp := chat.New(m.ctx(), a, ss, m.chatPageOpts()...)
 	ed := editor.New(m.history, m.editorOpts()...)
 
 	m.chatPages[tabID] = cp
@@ -557,14 +565,11 @@ func (m *appModel) Init() tea.Cmd {
 	if oldSessionID, ok := m.pendingRestores[activeID]; ok {
 		delete(m.pendingRestores, activeID)
 		if store := m.application.SessionStore(); store != nil {
-			//rubocop:disable Lint/ContextConnectivity
-			if sess, err := store.GetSession(context.Background(), oldSessionID); err == nil {
-				//rubocop:disable Lint/ContextConnectivity
-				_, cmd := m.replaceActiveSession(context.Background(), sess)
+			if sess, err := store.GetSession(m.ctx(), oldSessionID); err == nil {
+				_, cmd := m.replaceActiveSession(m.ctx(), sess)
 
 				if m.tuiStore != nil && sess.WorkingDir != "" {
-					//rubocop:disable Lint/ContextConnectivity
-					if err := m.tuiStore.UpdateTabWorkingDir(context.Background(), oldSessionID, sess.WorkingDir); err != nil {
+					if err := m.tuiStore.UpdateTabWorkingDir(m.ctx(), oldSessionID, sess.WorkingDir); err != nil {
 						slog.Warn("Failed to update persisted working dir", "error", err)
 					}
 				}
@@ -658,8 +663,7 @@ func (m *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if m.tuiStore != nil {
 			persistedID := m.persistedSessionID(m.supervisor.ActiveID())
-			//rubocop:disable Lint/ContextConnectivity
-			if err := m.tuiStore.ToggleSidebarCollapsed(context.Background(), persistedID); err != nil {
+			if err := m.tuiStore.ToggleSidebarCollapsed(m.ctx(), persistedID); err != nil {
 				slog.Warn("Failed to persist sidebar collapsed state", "error", err)
 			}
 		}
@@ -1057,8 +1061,7 @@ func (m *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.application.IsReadOnly() {
 			return m, notification.WarningCmd("Session is read-only. No new messages can be sent.")
 		}
-		//rubocop:disable Lint/ContextConnectivity
-		m.application.RunWithMessage(context.Background(), nil, msg.Content)
+		m.application.RunWithMessage(m.ctx(), nil, msg.Content)
 		return m, nil
 
 	// --- URL opening ---
@@ -1175,9 +1178,7 @@ func (m *appModel) handleOpenSessionBrowser() (tea.Model, tea.Cmd) {
 	if store == nil {
 		return m, notification.InfoCmd("No session store configured")
 	}
-
-	//rubocop:disable Lint/ContextConnectivity
-	sessions, err := store.GetSessionSummaries(context.Background())
+	sessions, err := store.GetSessionSummaries(m.ctx())
 	if err != nil {
 		return m, notification.ErrorCmd(fmt.Sprintf("Failed to load sessions: %v", err))
 	}
@@ -1196,9 +1197,7 @@ func (m *appModel) handleLoadSession(sessionID string) (tea.Model, tea.Cmd) {
 	if store == nil {
 		return m, notification.ErrorCmd("No session store configured")
 	}
-
-	//rubocop:disable Lint/ContextConnectivity
-	sess, err := store.GetSession(context.Background(), sessionID)
+	sess, err := store.GetSession(m.ctx(), sessionID)
 	if err != nil {
 		return m, notification.ErrorCmd(fmt.Sprintf("Failed to load session: %v", err))
 	}
@@ -1213,8 +1212,7 @@ func (m *appModel) handleLoadSession(sessionID string) (tea.Model, tea.Cmd) {
 	if workingDir == "" {
 		workingDir = m.application.Session().WorkingDir
 	}
-	//rubocop:disable Lint/ContextConnectivity
-	ctx := context.Background()
+	ctx := m.ctx()
 
 	// If the current session is empty (no messages, no title — the default state
 	// when opening the TUI or creating a new tab), replace it in-place instead of
@@ -1342,8 +1340,7 @@ func (m *appModel) handleClearSession() (tea.Model, tea.Cmd) {
 
 	// Update persisted tab to point to the new session.
 	if m.tuiStore != nil {
-		//rubocop:disable Lint/ContextConnectivity
-		ctx := context.Background()
+		ctx := m.ctx()
 		oldPersistedID := m.persistedSessionID(activeID)
 		if err := m.tuiStore.UpdateTabSessionID(ctx, oldPersistedID, newSess.ID); err != nil {
 			slog.WarnContext(ctx, "Failed to update tab session ID after clear", "error", err)
@@ -1368,8 +1365,7 @@ func (m *appModel) handleSpawnSession(workingDir string) (tea.Model, tea.Cmd) {
 	}
 
 	// Spawn the new session
-	//rubocop:disable Lint/ContextConnectivity
-	ctx := context.Background()
+	ctx := m.ctx()
 	sessionID, err := m.supervisor.SpawnSession(ctx, workingDir)
 	if err != nil {
 		return m, notification.ErrorCmd("Failed to spawn session: " + err.Error())
@@ -1390,10 +1386,8 @@ func (m *appModel) handleSpawnSession(workingDir string) (tea.Model, tea.Cmd) {
 func (m *appModel) openWorkingDirPicker() (tea.Model, tea.Cmd) {
 	var recentDirs, favoriteDirs []string
 	if m.tuiStore != nil {
-		//rubocop:disable Lint/ContextConnectivity
-		recentDirs, _ = m.tuiStore.GetRecentDirs(context.Background(), 10)
-		//rubocop:disable Lint/ContextConnectivity
-		favoriteDirs, _ = m.tuiStore.GetFavoriteDirs(context.Background())
+		recentDirs, _ = m.tuiStore.GetRecentDirs(m.ctx(), 10)
+		favoriteDirs, _ = m.tuiStore.GetFavoriteDirs(m.ctx())
 	}
 
 	// Use the active session's working directory so the picker reflects it
@@ -1404,7 +1398,7 @@ func (m *appModel) openWorkingDirPicker() (tea.Model, tea.Cmd) {
 	}
 
 	return m, core.CmdHandler(dialog.OpenDialogMsg{
-		Model: dialog.NewWorkingDirPickerDialog(recentDirs, favoriteDirs, m.tuiStore, sessionWorkingDir),
+		Model: dialog.NewWorkingDirPickerDialog(m.ctx(), recentDirs, favoriteDirs, m.tuiStore, sessionWorkingDir),
 	})
 }
 
@@ -1471,15 +1465,12 @@ func (m *appModel) handleSwitchTab(sessionID string) (tea.Model, tea.Cmd) {
 		delete(m.pendingRestores, sessionID)
 		m.application = runner.App
 		if store := runner.App.SessionStore(); store != nil {
-			//rubocop:disable Lint/ContextConnectivity
-			if sess, err := store.GetSession(context.Background(), oldSessionID); err == nil {
+			if sess, err := store.GetSession(m.ctx(), oldSessionID); err == nil {
 				m.persistActiveTab(sess.ID)
-				//rubocop:disable Lint/ContextConnectivity
-				model, cmd := m.replaceActiveSession(context.Background(), sess)
+				model, cmd := m.replaceActiveSession(m.ctx(), sess)
 
 				if m.tuiStore != nil && sess.WorkingDir != "" {
-					//rubocop:disable Lint/ContextConnectivity
-					if err := m.tuiStore.UpdateTabWorkingDir(context.Background(), oldSessionID, sess.WorkingDir); err != nil {
+					if err := m.tuiStore.UpdateTabWorkingDir(m.ctx(), oldSessionID, sess.WorkingDir); err != nil {
 						slog.Warn("Failed to update persisted working dir", "error", err)
 					}
 				}
@@ -1620,7 +1611,7 @@ func (m *appModel) replayElicitationEvent(ev *runtime.ElicitationRequestEvent) t
 				serverURL = url
 			}
 			return core.CmdHandler(dialog.OpenDialogMsg{
-				Model:            dialog.NewOAuthAuthorizationDialog(serverURL, m.application),
+				Model:            dialog.NewOAuthAuthorizationDialog(m.ctx(), serverURL, m.application),
 				OriginatingEvent: ev,
 			})
 		}
@@ -1629,7 +1620,7 @@ func (m *appModel) replayElicitationEvent(ev *runtime.ElicitationRequestEvent) t
 	switch ev.Mode {
 	case "url":
 		return core.CmdHandler(dialog.OpenDialogMsg{
-			Model:            dialog.NewURLElicitationDialog(ev.Message, ev.URL),
+			Model:            dialog.NewURLElicitationDialog(m.ctx(), ev.Message, ev.URL),
 			OriginatingEvent: ev,
 		})
 	default:
@@ -1650,8 +1641,7 @@ func (m *appModel) handleReorderTab(msg messages.ReorderTabMsg) (tea.Model, tea.
 		for i, tab := range tabs {
 			ids[i] = m.persistedSessionID(tab.SessionID)
 		}
-		//rubocop:disable Lint/ContextConnectivity
-		if err := m.tuiStore.ReorderTab(context.Background(), ids); err != nil {
+		if err := m.tuiStore.ReorderTab(m.ctx(), ids); err != nil {
 			slog.Warn("Failed to persist tab reorder", "error", err)
 		}
 	}
@@ -1688,8 +1678,7 @@ func (m *appModel) handleCloseTab(sessionID string) (tea.Model, tea.Cmd) {
 	var cmds []tea.Cmd
 	// Remove from persistent store using the persisted session-store ID.
 	if m.tuiStore != nil {
-		//rubocop:disable Lint/ContextConnectivity
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		ctx, cancel := context.WithTimeout(m.ctx(), 1*time.Second)
 		defer cancel()
 		if err := m.tuiStore.RemoveTab(ctx, persistedID); err != nil {
 			slog.ErrorContext(ctx, "Failed to remove tab from store", "error", err)

--- a/pkg/tui/tui_ctrlc_test.go
+++ b/pkg/tui/tui_ctrlc_test.go
@@ -25,7 +25,7 @@ func applyOpenDialogMsgs(t *testing.T, m *appModel, cmd tea.Cmd) {
 func TestCtrlC_NoDialog_OpensExitConfirmation(t *testing.T) {
 	t.Parallel()
 
-	m, _ := newTestModel()
+	m, _ := newTestModel(t)
 	require.False(t, m.dialogMgr.Open(), "no dialog should be open initially")
 
 	_, cmd := m.Update(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})
@@ -39,7 +39,7 @@ func TestCtrlC_NoDialog_OpensExitConfirmation(t *testing.T) {
 func TestCtrlC_OnOtherDialog_StacksExitConfirmation(t *testing.T) {
 	t.Parallel()
 
-	m, _ := newTestModel()
+	m, _ := newTestModel(t)
 
 	// Open an arbitrary, non-exit dialog first.
 	_, cmd := m.Update(dialog.OpenDialogMsg{Model: dialog.NewHelpDialog(nil)})
@@ -62,7 +62,7 @@ func TestCtrlC_OnOtherDialog_StacksExitConfirmation(t *testing.T) {
 func TestCtrlC_OnExitConfirmation_ForwardsAndExits(t *testing.T) {
 	neutralizeExitFunc(t)
 
-	m, _ := newTestModel()
+	m, _ := newTestModel(t)
 
 	// Put the exit confirmation dialog on top first (via a regular ctrl+c).
 	_, cmd := m.Update(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})

--- a/pkg/tui/tui_exit_test.go
+++ b/pkg/tui/tui_exit_test.go
@@ -126,11 +126,13 @@ func hasMsg[T any](msgs []tea.Msg) bool {
 	return false
 }
 
-func newTestModel() (*appModel, *mockEditor) {
+func newTestModel(tb testing.TB) (*appModel, *mockEditor) {
+	tb.Helper()
 	page := &mockChatPage{}
 	ed := &mockEditor{}
 
 	m := &appModel{
+		ctx:                     tb.Context,
 		chatPages:               map[string]chat.Page{"test": page},
 		sessionStates:           map[string]*service.SessionState{},
 		editors:                 map[string]editor.Editor{"test": ed},
@@ -177,7 +179,7 @@ func neutralizeExitFunc(t *testing.T) {
 func TestExitSessionMsg_ExitsImmediately(t *testing.T) {
 	neutralizeExitFunc(t)
 
-	m, ed := newTestModel()
+	m, ed := newTestModel(t)
 
 	_, cmd := m.Update(messages.ExitSessionMsg{})
 
@@ -190,7 +192,7 @@ func TestExitSessionMsg_ExitsImmediately(t *testing.T) {
 func TestExitConfirmedMsg_ExitsImmediately(t *testing.T) {
 	neutralizeExitFunc(t)
 
-	m, ed := newTestModel()
+	m, ed := newTestModel(t)
 
 	_, cmd := m.Update(dialog.ExitConfirmedMsg{})
 
@@ -325,7 +327,7 @@ func TestCleanupAll_SpawnsSafetyNet(t *testing.T) {
 		exitDone <- code
 	}
 
-	m, _ := newTestModel()
+	m, _ := newTestModel(t)
 	m.program = tea.NewProgram(&quitModel{})
 	m.cleanupAll()
 
@@ -368,7 +370,7 @@ func TestCleanupAll_GracefulShutdownSkipsExit(t *testing.T) {
 	// initialized p.finished — otherwise Wait() races the assignment.
 	p.Send(syncMsg{})
 
-	m, _ := newTestModel()
+	m, _ := newTestModel(t)
 	m.program = p
 	m.cleanupAll()
 
@@ -403,7 +405,7 @@ func TestCleanupAll_NilProgramIsSafe(t *testing.T) {
 	var exitCalled atomic.Bool
 	exitFunc = func(int) { exitCalled.Store(true) }
 
-	m, _ := newTestModel()
+	m, _ := newTestModel(t)
 	m.program = nil
 	assert.NotPanics(t, func() { m.cleanupAll() })
 
@@ -430,7 +432,7 @@ func TestCleanupAll_WedgedStdoutFiresExit(t *testing.T) {
 	p, w, _ := initBlockingBubbletea(t, &quitModel{})
 	defer w.unblock()
 
-	m, _ := newTestModel()
+	m, _ := newTestModel(t)
 	m.program = p
 	m.cleanupAll()
 
@@ -464,7 +466,7 @@ func TestCleanupAll_MultipleCallsFireExitOnce(t *testing.T) {
 	var exitCount atomic.Int32
 	exitFunc = func(int) { exitCount.Add(1) }
 
-	m, _ := newTestModel()
+	m, _ := newTestModel(t)
 	m.program = tea.NewProgram(&quitModel{})
 
 	m.cleanupAll()

--- a/pkg/tui/tui_helpers_test.go
+++ b/pkg/tui/tui_helpers_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestKeyboardEnhancementsInvalidateStatusBarHelp(t *testing.T) {
-	m, _ := newTestModel()
+	m, _ := newTestModel(t)
 	m.focusedPanel = PanelEditor
 	m.tabBar = tabbar.New(0)
 	m.statusBar = statusbar.New(m)
@@ -271,7 +271,7 @@ func TestCommandCategories_DisabledCommandsFilter(t *testing.T) {
 
 	t.Run("no filter keeps everything", func(t *testing.T) {
 		t.Parallel()
-		m := &appModel{buildCommandCategories: build}
+		m := &appModel{ctx: t.Context, buildCommandCategories: build}
 		got := m.commandCategories()
 		if len(got) != 2 {
 			t.Fatalf("len(categories) = %d, want 2", len(got))
@@ -280,7 +280,7 @@ func TestCommandCategories_DisabledCommandsFilter(t *testing.T) {
 
 	t.Run("filters slash commands and drops empty categories", func(t *testing.T) {
 		t.Parallel()
-		m := &appModel{buildCommandCategories: build}
+		m := &appModel{ctx: t.Context, buildCommandCategories: build}
 		WithDisabledCommands([]string{"/cost", "eval", "/theme"})(m)
 
 		got := m.commandCategories()
@@ -297,7 +297,7 @@ func TestCommandCategories_DisabledCommandsFilter(t *testing.T) {
 
 	t.Run("blank entries are ignored", func(t *testing.T) {
 		t.Parallel()
-		m := &appModel{buildCommandCategories: build}
+		m := &appModel{ctx: t.Context, buildCommandCategories: build}
 		WithDisabledCommands([]string{"", "  "})(m)
 		got := m.commandCategories()
 		if len(got) != 2 {
@@ -307,7 +307,7 @@ func TestCommandCategories_DisabledCommandsFilter(t *testing.T) {
 
 	t.Run("matching is case-insensitive", func(t *testing.T) {
 		t.Parallel()
-		m := &appModel{buildCommandCategories: build}
+		m := &appModel{ctx: t.Context, buildCommandCategories: build}
 		WithDisabledCommands([]string{"/Cost", "EVAL", "/Theme"})(m)
 		got := m.commandCategories()
 		if len(got) != 1 {

--- a/pkg/tui/tui_speak_test.go
+++ b/pkg/tui/tui_speak_test.go
@@ -47,11 +47,13 @@ func (f *fakeTranscriber) Stop() {
 // newSpeakTestModel builds an appModel wired with a fakeTranscriber so that the
 // speech-to-text handlers can be tested in isolation. It leverages the same
 // minimal scaffolding used by the exit tests.
-func newSpeakTestModel(ft *fakeTranscriber) *appModel {
+func newSpeakTestModel(tb testing.TB, ft *fakeTranscriber) *appModel {
+	tb.Helper()
 	page := &mockChatPage{}
 	ed := &mockEditor{}
 
 	return &appModel{
+		ctx:                     tb.Context,
 		chatPages:               map[string]chat.Page{"test": page},
 		sessionStates:           map[string]*service.SessionState{},
 		editors:                 map[string]editor.Editor{"test": ed},
@@ -66,7 +68,7 @@ func newSpeakTestModel(ft *fakeTranscriber) *appModel {
 
 func TestHandleStartSpeak_NoOpIfAlreadyRunning(t *testing.T) {
 	ft := &fakeTranscriber{running: true}
-	m := newSpeakTestModel(ft)
+	m := newSpeakTestModel(t, ft)
 
 	_, cmd := m.handleStartSpeak()
 	if cmd != nil {
@@ -79,7 +81,7 @@ func TestHandleStartSpeak_NoOpIfAlreadyRunning(t *testing.T) {
 
 func TestHandleStartSpeak_ReturnsErrorNotificationOnStartFailure(t *testing.T) {
 	ft := &fakeTranscriber{startErr: errors.New("boom")}
-	m := newSpeakTestModel(ft)
+	m := newSpeakTestModel(t, ft)
 
 	_, cmd := m.handleStartSpeak()
 	if cmd == nil {
@@ -108,7 +110,7 @@ func TestHandleStartSpeak_ReturnsErrorNotificationOnStartFailure(t *testing.T) {
 
 func TestHandleStopSpeak_NoOpWhenNotRunning(t *testing.T) {
 	ft := &fakeTranscriber{running: false}
-	m := newSpeakTestModel(ft)
+	m := newSpeakTestModel(t, ft)
 
 	_, cmd := m.handleStopSpeak()
 	if cmd != nil {
@@ -121,7 +123,7 @@ func TestHandleStopSpeak_NoOpWhenNotRunning(t *testing.T) {
 
 func TestHandleStopSpeak_StopsAndNotifies(t *testing.T) {
 	ft := &fakeTranscriber{running: true}
-	m := newSpeakTestModel(ft)
+	m := newSpeakTestModel(t, ft)
 	// Pretend a previous start opened a channel.
 	m.transcriptCh = make(chan string, 1)
 

--- a/pkg/tui/tui_stash_dialog_test.go
+++ b/pkg/tui/tui_stash_dialog_test.go
@@ -44,7 +44,7 @@ func TestReplayPendingEvent_RestoresStashedDialog(t *testing.T) {
 
 	// Build a model with a single-session supervisor so ConsumePendingEvent
 	// has a real runner to read from.
-	m, _ := newTestModel()
+	m, _ := newTestModel(t)
 	m.supervisor = supervisor.New(nil)
 	require.NotEmpty(t, m.supervisor.AddSession(
 		t.Context(),
@@ -95,7 +95,7 @@ func TestReplayPendingEvent_DiscardsStaleStash(t *testing.T) {
 
 	const sessionID = "session-A"
 
-	m, _ := newTestModel()
+	m, _ := newTestModel(t)
 	m.supervisor = supervisor.New(nil)
 	m.supervisor.AddSession(
 		t.Context(),
@@ -147,7 +147,7 @@ func TestReplayPendingEvent_NoPendingEvent_ClearsStash(t *testing.T) {
 
 	const sessionID = "session-A"
 
-	m, _ := newTestModel()
+	m, _ := newTestModel(t)
 	m.supervisor = supervisor.New(nil)
 	m.supervisor.AddSession(
 		t.Context(),


### PR DESCRIPTION
This branch integrates the `Lint/ContextConnectivity` cop from `rubocop-go` as a whole-program static analysis pass and then resolves every violation it finds. The cop detects places where a `context.Context` is available but a derived or background context is used instead — patterns that silently lose deadlines, cancellation signals, and trace spans.

The bulk of the work is mechanical but intentional: context threading was pushed down into the `Runtime` interface and its implementations, through RAG embedding and chunking helpers, into the SQLite memory backend (now lazily opened with the caller's context), through the telemetry `TrackSynchronous` path, into proxy-allowlist resolution at dial time, and across dozens of test harnesses that previously created detached roots with `context.Background()`. Places where a genuinely detached context is correct — shutdown flushes, background notification playback — are suppressed with `context.WithoutCancel` derivation, which was added to the `rubocop-go` dependency in the same batch.

No behaviour changes are intended. `task --force lint` and `task --force test` both pass.