### PR TITLE
telemetry: don't record error on chat span after successful LLM completion

### DIFF
--- a/pkg/telemetry/genai/genai_test.go
+++ b/pkg/telemetry/genai/genai_test.go
@@ -8,6 +8,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
 	"github.com/docker/docker-agent/pkg/chat"
 )
@@ -138,6 +142,138 @@ func TestWrapStreamNilSpanReturnsOriginal(t *testing.T) {
 	s := &fakeStream{}
 	got := WrapStream(nil, s)
 	assert.Same(t, s, got)
+}
+
+// installRecordingTracer replaces the global OTel tracer with an in-memory
+// SDK tracer for the duration of the test and returns the span exporter so
+// callers can inspect recorded spans.
+func installRecordingTracer(t *testing.T) *tracetest.InMemoryExporter {
+	t.Helper()
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		_ = tp.Shutdown(t.Context())
+		otel.SetTracerProvider(prev)
+	})
+	return exp
+}
+
+// errorStream yields an optional finish-reason chunk then returns a
+// transport error on the next Recv. When finishWithError is true it returns
+// both the finish reason and the error in the same Recv call.
+type errorStream struct {
+	finishFirst     bool
+	finishWithError bool
+	sent            bool
+	err             error
+}
+
+func (s *errorStream) Recv() (chat.MessageStreamResponse, error) {
+	if s.finishWithError && !s.sent {
+		s.sent = true
+		return chat.MessageStreamResponse{
+			Choices: []chat.MessageStreamChoice{
+				{FinishReason: chat.FinishReasonStop},
+			},
+		}, s.err
+	}
+	if s.finishFirst && !s.sent {
+		s.sent = true
+		return chat.MessageStreamResponse{
+			Choices: []chat.MessageStreamChoice{
+				{FinishReason: chat.FinishReasonStop},
+			},
+		}, nil
+	}
+	return chat.MessageStreamResponse{}, s.err
+}
+
+func (s *errorStream) Close() {}
+
+// TestWrapStream_ErrorBeforeFinishReason verifies that a transport error
+// arriving before any finish reason is recorded on the span as an error.
+// Mutates the global OTel tracer provider; cannot run in parallel.
+func TestWrapStream_ErrorBeforeFinishReason(t *testing.T) {
+	exp := installRecordingTracer(t)
+
+	_, span := StartChat(t.Context(), ChatRequest{
+		Provider: ProviderAnthropic,
+		Model:    "claude-haiku-4-5",
+		Stream:   true,
+	})
+	require.NotNil(t, span)
+
+	stream := &errorStream{finishFirst: false, err: errors.New("http2: response body closed")}
+	wrapped := WrapStream(span, stream)
+
+	_, err := wrapped.Recv()
+	require.Error(t, err)
+	wrapped.Close()
+
+	spans := exp.GetSpans()
+	require.Len(t, spans, 1)
+	assert.Equal(t, sdktrace.Status{Code: codes.Error, Description: "http2: response body closed"}, spans[0].Status)
+}
+
+// TestWrapStream_ErrorAfterFinishReason verifies that a transport error
+// arriving after a terminal finish reason is NOT recorded on the span —
+// it is benign teardown from the consumer closing the body early.
+// Mutates the global OTel tracer provider; cannot run in parallel.
+func TestWrapStream_ErrorAfterFinishReason(t *testing.T) {
+	exp := installRecordingTracer(t)
+
+	_, span := StartChat(t.Context(), ChatRequest{
+		Provider: ProviderAnthropic,
+		Model:    "claude-haiku-4-5",
+		Stream:   true,
+	})
+	require.NotNil(t, span)
+
+	stream := &errorStream{finishFirst: true, err: errors.New("http2: response body closed")}
+	wrapped := WrapStream(span, stream)
+
+	// First Recv delivers finish_reason=stop.
+	_, err := wrapped.Recv()
+	require.NoError(t, err)
+
+	// Second Recv returns the transport error — should be suppressed.
+	_, err = wrapped.Recv()
+	require.Error(t, err)
+	wrapped.Close()
+
+	spans := exp.GetSpans()
+	require.Len(t, spans, 1)
+	assert.Equal(t, sdktrace.Status{Code: codes.Unset}, spans[0].Status,
+		"transport error after finish_reason must not mark the span as failed")
+}
+
+// TestWrapStream_FinishReasonAndErrorSameRecv verifies the edge case where a
+// provider returns both a terminal finish reason and a transport error in the
+// same Recv call — the span should still be treated as successful.
+// Mutates the global OTel tracer provider; cannot run in parallel.
+func TestWrapStream_FinishReasonAndErrorSameRecv(t *testing.T) {
+	exp := installRecordingTracer(t)
+
+	_, span := StartChat(t.Context(), ChatRequest{
+		Provider: ProviderAnthropic,
+		Model:    "claude-haiku-4-5",
+		Stream:   true,
+	})
+	require.NotNil(t, span)
+
+	stream := &errorStream{finishWithError: true, err: errors.New("http2: response body closed")}
+	wrapped := WrapStream(span, stream)
+
+	_, err := wrapped.Recv()
+	require.Error(t, err)
+	wrapped.Close()
+
+	spans := exp.GetSpans()
+	require.Len(t, spans, 1)
+	assert.Equal(t, sdktrace.Status{Code: codes.Unset}, spans[0].Status,
+		"finish_reason and transport error in same Recv must not mark the span as failed")
 }
 
 func TestServerAddressFromURL(t *testing.T) {

--- a/pkg/telemetry/genai/stream.go
+++ b/pkg/telemetry/genai/stream.go
@@ -67,6 +67,13 @@ type instrumentedStream struct {
 	ended       bool
 	innerClosed bool
 
+	// finishReasonSeen is set to true the first time Recv delivers a
+	// terminal finish reason. After that, errors from the underlying
+	// transport (e.g. "http2: response body closed" when the consumer
+	// closes the body before draining to io.EOF) are benign teardown,
+	// not real failures, and should not be recorded on the span.
+	finishReasonSeen bool
+
 	// capture buffers the streamed deltas for emission as
 	// `gen_ai.output.messages` on Close. Filled only when content
 	// capture is opted in (`OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true`)
@@ -82,14 +89,29 @@ func (s *instrumentedStream) Recv() (chat.MessageStreamResponse, error) {
 	resp, err := s.inner.Recv()
 	if err != nil {
 		// io.EOF is the normal stream terminator and is not an error
-		// for the span's purposes — End handles closing.
-		// For non-EOF errors we end the span here too: callers that
-		// abandon the stream after an error (a common pattern for
-		// network failures) would otherwise leak the span and skip the
-		// duration metric. Close remains idempotent so the canonical
-		// `defer Close()` path still works.
+		// for the span's purposes — End handles closing. For other
+		// errors we end the span here too so callers that abandon the
+		// stream on failure don't leak the span or skip the duration
+		// metric; Close remains idempotent so the canonical
+		// `defer Close()` path still works. We skip RecordError when a
+		// terminal finish reason was already delivered: the completion
+		// succeeded, and the subsequent transport error (typically
+		// "http2: response body closed") is benign teardown from the
+		// consumer closing the body before draining to io.EOF.
+		//
+		// Some providers pack a finish reason and a transport error into
+		// the same Recv call. Scan resp before checking finishReasonSeen
+		// so that case is also treated as a successful completion.
+		for i := range resp.Choices {
+			if resp.Choices[i].FinishReason != "" {
+				s.span.AddFinishReason(string(resp.Choices[i].FinishReason))
+				s.finishReasonSeen = true
+			}
+		}
 		if !errors.Is(err, io.EOF) {
-			s.span.RecordError(err, ClassifyError(err))
+			if !s.finishReasonSeen {
+				s.span.RecordError(err, ClassifyError(err))
+			}
 			s.endOnce()
 		}
 		return resp, err
@@ -111,6 +133,7 @@ func (s *instrumentedStream) Recv() (chat.MessageStreamResponse, error) {
 	for i := range resp.Choices {
 		if resp.Choices[i].FinishReason != "" {
 			s.span.AddFinishReason(string(resp.Choices[i].FinishReason))
+			s.finishReasonSeen = true
 		}
 	}
 	if resp.Usage != nil {


### PR DESCRIPTION
## Summary

- `handleStream` returns the moment it sees a terminal `finish_reason` (a deliberate latency optimisation — don't block the next turn on trailing `message_stop`/EOF). The deferred `stream.Close()` then closes the HTTP/2 body while the reader goroutine is still blocked in `Recv()`, causing that read to return `"http2: response body closed"` (or `"context canceled"` if the per-attempt `streamCancel` fires first).
- `instrumentedStream` was recording this transport-level teardown as a span error even when the completion had fully succeeded — every affected span also carries `gen_ai.response.finish_reasons=["stop"]` and full token usage, confirming the response was complete.
- This inflates the `docker-agent` error rate on every LLM call. Observed consistently across all `harbor_watch.investigation` traces in Tempo.

**Fix:** add `finishReasonSeen bool` to `instrumentedStream` (set-once on the single-consumer `Recv` path). Once a terminal finish reason is delivered, skip `RecordError` for subsequent transport errors — they're benign teardown, not failures. `endOnce` is still called so the span closes.

## Test plan

- [ ] Verify existing `genai` package tests pass: `go test ./pkg/telemetry/genai/...`
- [ ] In Tempo: after deploy, confirm `chat claude-*` spans with `finish_reasons=stop` no longer appear as `STATUS_CODE_ERROR`
- [ ] Confirm spans that fail *before* a finish reason (genuine mid-stream errors) still record errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)