### PR TITLE
docs: document capabilities override and TUI error recovery

### DIFF
--- a/docs/configuration/models/index.md
+++ b/docs/configuration/models/index.md
@@ -33,6 +33,9 @@ models:
     parallel_tool_calls: boolean # Optional: allow parallel tool calls
     track_usage: boolean # Optional: track token usage
     routing: [list] # Optional: rule-based model routing
+    capabilities: # Optional: override attachment capabilities
+      image: boolean # Optional: whether the model accepts image attachments
+      pdf: boolean # Optional: whether the model accepts PDF attachments
     provider_opts: # Optional: provider-specific options
       key: value
 ```
@@ -56,8 +59,49 @@ models:
 | `parallel_tool_calls` | boolean    | ✗        | Allow model to call multiple tools at once                                            |
 | `track_usage`         | boolean    | ✗        | Track and report token usage for this model                                           |
 | `routing`             | array      | ✗        | Rule-based routing to different models. See [Model Routing]({{ '/configuration/routing/' | relative_url }}). |
+| `capabilities`        | object     | ✗        | Override attachment capabilities for this model. See [Attachment Capability Overrides](#attachment-capability-overrides). |
 | `provider_opts`       | object     | ✗        | Provider-specific options (see provider pages)                                        |
 | `title_model`         | string     | ✗        | Model used for session-title generation. Can be a named model from the `models:` section or an inline `provider/model` string. When omitted, the agent's primary model generates titles. Cannot be combined with `first_available`. |
+
+## Attachment Capability Overrides
+
+For custom OpenAI-compatible providers, local models (Ollama, DMR), and any
+model the built-in catalogue does not describe, docker-agent cannot
+auto-detect whether the endpoint accepts image or PDF attachments. When the
+model is absent from the catalogue, docker-agent logs a diagnostic and falls
+back to text-only, silently dropping attachments.
+
+Declare `capabilities` to make the model's attachment support authoritative
+and skip the catalogue lookup entirely:
+
+```yaml
+models:
+  llava-local:
+    provider: ollama
+    model: llava
+    capabilities:
+      image: true   # accepts image attachments
+      pdf: false    # does not accept PDFs
+
+  proxy-vision:
+    provider: vision-proxy
+    model: gpt-4o
+    capabilities:
+      image: true
+      pdf: true
+```
+
+| Field                  | Type    | Description                                       |
+| ---------------------- | ------- | ------------------------------------------------- |
+| `capabilities.image`   | boolean | Whether the model accepts image attachments       |
+| `capabilities.pdf`     | boolean | Whether the model accepts PDF attachments         |
+
+The flags must match what the endpoint actually accepts. Claiming a modality
+that the endpoint does not support leads to a provider-side API error. When
+`capabilities` is omitted the behaviour is unchanged (catalogue lookup then
+conservative text-only fallback).
+
+See [`examples/capability-overrides.yaml`](https://github.com/docker/docker-agent/blob/main/examples/capability-overrides.yaml) for a complete example.
 
 ## Delegating Session-Title Generation
 

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -205,6 +205,12 @@ When a models gateway is configured (`--models-gateway`) and it exposes an OpenA
 
 Edit any previous user message to branch the conversation. Click on a past message to modify it — the agent will re-process from that point, while the original session history is preserved. This is great for exploring alternative approaches without losing your work.
 
+## Error Recovery
+
+When an agent turn fails (fatal model error, hook block, loop detection, tool-setup failure), the TUI displays the error in the message stream and persists it to the session store. Errors survive a reload and are shown exactly where they occurred, making them visible in shared or remote sessions.
+
+Each error message includes a clickable **↻ retry** button. Clicking it resumes the conversation from the point of failure — without retyping your last message. This lets you recover from transient failures (rate limits, network blips, model API errors) in one click.
+
 ## Session Management
 
 docker-agent automatically saves your sessions. Use `/sessions` to browse past conversations:


### PR DESCRIPTION
Documents two features from recent merged PRs that shipped without docs coverage.

**Attachment capability overrides** (model config) — adds a new `capabilities` section to `docs/configuration/models/index.md` covering the `capabilities.image` and `capabilities.pdf` fields. Custom/local providers (Ollama, user-defined proxies) are not in the models.dev catalogue, so docker-agent can't auto-detect their attachment support. Declaring `capabilities` makes it authoritative and skips the lookup. Includes the properties table, a usage example, and a link to `examples/capability-overrides.yaml`.

**TUI error recovery** — adds an "Error Recovery" section to `docs/features/tui/index.md` covering persisted error messages (survive session reload) and the clickable **↻ retry** button that resumes a failed turn without retyping.

Source PRs: #3205, #3253, #3259