### PR TITLE
feat: reuse warmed model store, add picker timing, and fix discovery error caching

### DIFF
--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -714,6 +714,15 @@ func (f *runExecFlags) runtimeOpts(loadResult *teamloader.LoadResult, runConfig 
 		ProviderRegistry:   loadResult.ProviderRegistry,
 		AgentDefaultModels: loadResult.AgentDefaultModels,
 	}
+	// Share the models.dev store the team loader already warmed (parsing the
+	// multi-MB catalog once) so the runtime doesn't build its own cold store
+	// and re-pay the parse on the first /model open. On error we leave it unset
+	// and the runtime falls back to its lazy default.
+	if store, err := runConfig.ModelsDevStore(); err == nil {
+		modelSwitcherCfg.ModelsStore = store
+	} else {
+		slog.Warn("Failed to obtain shared models.dev store; runtime will use its own", "error", err)
+	}
 	opts := []runtime.Opt{
 		runtime.WithSessionStore(sessStore),
 		runtime.WithCurrentAgent(agentName),

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1005,7 +1005,9 @@ func (a *App) refreshAgentInfo(ctx context.Context) {
 // AvailableModels returns the list of models available for selection.
 // Returns nil if model switching is not supported.
 func (a *App) AvailableModels(ctx context.Context) []runtime.ModelChoice {
+	start := time.Now()
 	if !a.runtime.SupportsModelSwitching() {
+		slog.DebugContext(ctx, "App available models skipped; model switching unsupported", "duration", time.Since(start))
 		return nil
 	}
 
@@ -1016,7 +1018,22 @@ func (a *App) AvailableModels(ctx context.Context) []runtime.ModelChoice {
 		currentRef = a.session.AgentModelOverrides[agentName]
 		customRefs = a.session.CustomModelsUsed
 	}
-	return runtime.DecorateModelChoices(a.runtime.AvailableModels(ctx), currentRef, customRefs)
+
+	runtimeStart := time.Now()
+	baseModels := a.runtime.AvailableModels(ctx)
+	runtimeDuration := time.Since(runtimeStart)
+	decorateStart := time.Now()
+	models := runtime.DecorateModelChoices(baseModels, currentRef, customRefs)
+	slog.DebugContext(ctx, "App available models completed",
+		"duration", time.Since(start),
+		"runtime_duration", runtimeDuration,
+		"decorate_duration", time.Since(decorateStart),
+		"base_models", len(baseModels),
+		"models", len(models),
+		"custom_refs", len(customRefs),
+		"agent", agentName,
+	)
+	return models
 }
 
 // trackCustomModel adds a custom model to the session's history if not already present.

--- a/pkg/embeddedchat/embeddedchat.go
+++ b/pkg/embeddedchat/embeddedchat.go
@@ -126,6 +126,11 @@ func New(ctx context.Context, cfg Config) (*Session, error) {
 		ProviderRegistry:   loaded.ProviderRegistry,
 		AgentDefaultModels: loaded.AgentDefaultModels,
 	}
+	// Reuse the models.dev store the team loader already warmed so model-
+	// metadata lookups don't re-pay the cold catalog parse.
+	if store, storeErr := runConfig.ModelsDevStore(); storeErr == nil {
+		modelSwitcher.ModelsStore = store
+	}
 
 	runtimeOpts := []dagentruntime.Opt{
 		dagentruntime.WithModelSwitcherConfig(modelSwitcher),

--- a/pkg/runtime/dmr_models.go
+++ b/pkg/runtime/dmr_models.go
@@ -35,6 +35,7 @@ type dmrModelsCache struct {
 // opt-in via NewLocalRuntime.
 func (r *LocalRuntime) listDMRModels(ctx context.Context) ([]string, error) {
 	if r.dmrModelLister == nil {
+		slog.DebugContext(ctx, "DMR model discovery skipped; no lister configured")
 		return nil, nil
 	}
 
@@ -55,9 +56,11 @@ func (r *LocalRuntime) listDMRModels(ctx context.Context) ([]string, error) {
 	}
 
 	if ids, ok, err := readFresh(); ok {
+		slog.DebugContext(ctx, "DMR model discovery cache hit", "models", len(ids), "error", err)
 		return ids, err
 	}
 
+	start := time.Now()
 	v, err, _ := c.sf.Do("models", func() (any, error) {
 		// Double-check the cache now that we hold the in-flight slot: a caller
 		// that read a stale cache right before a concurrent singleflight
@@ -73,9 +76,12 @@ func (r *LocalRuntime) listDMRModels(ctx context.Context) ([]string, error) {
 		return ids, err
 	})
 	if err != nil {
+		slog.DebugContext(ctx, "DMR model discovery fetch completed", "duration", time.Since(start), "error", err)
 		return nil, err
 	}
-	return v.([]string), nil
+	ids := v.([]string)
+	slog.DebugContext(ctx, "DMR model discovery fetch completed", "duration", time.Since(start), "models", len(ids))
+	return ids, nil
 }
 
 // buildDMRChoices builds ModelChoice entries for the models currently pulled

--- a/pkg/runtime/dmr_models.go
+++ b/pkg/runtime/dmr_models.go
@@ -70,6 +70,9 @@ func (r *LocalRuntime) listDMRModels(ctx context.Context) ([]string, error) {
 		}
 
 		ids, err := r.dmrModelLister(ctx)
+		if err != nil && ctx.Err() != nil {
+			return ids, err
+		}
 		c.mu.Lock()
 		c.ids, c.err, c.fetchedAt = ids, err, now()
 		c.mu.Unlock()

--- a/pkg/runtime/dmr_models_test.go
+++ b/pkg/runtime/dmr_models_test.go
@@ -183,6 +183,29 @@ func TestListDMRModels_CachesFailure(t *testing.T) {
 	assert.Equal(t, int32(1), calls.Load(), "failures must be cached to avoid re-probing DMR on every picker open")
 }
 
+func TestListDMRModels_DoesNotCacheCallerCancellation(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	r := dmrRuntime(func(ctx context.Context) ([]string, error) {
+		calls.Add(1)
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		return []string{"ai/qwen3:latest"}, nil
+	}, nil, nil)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err := r.listDMRModels(ctx)
+	require.Error(t, err)
+
+	ids, err := r.listDMRModels(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ai/qwen3:latest"}, ids)
+	assert.Equal(t, int32(2), calls.Load(), "caller cancellation must not poison the DMR discovery cache")
+}
+
 func TestListDMRModels_CacheExpires(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/runtime/gateway_models.go
+++ b/pkg/runtime/gateway_models.go
@@ -54,9 +54,11 @@ func (r *LocalRuntime) listGatewayModels(ctx context.Context) ([]string, error) 
 	}
 
 	if ids, ok, err := readFresh(); ok {
+		slog.DebugContext(ctx, "Gateway model discovery cache hit", "models", len(ids), "error", err)
 		return ids, err
 	}
 
+	start := time.Now()
 	v, err, _ := c.sf.Do("models", func() (any, error) {
 		// Double-check the cache now that we hold the in-flight slot: a
 		// caller that read a stale cache right before a concurrent
@@ -73,9 +75,12 @@ func (r *LocalRuntime) listGatewayModels(ctx context.Context) ([]string, error) 
 		return ids, err
 	})
 	if err != nil {
+		slog.DebugContext(ctx, "Gateway model discovery fetch completed", "duration", time.Since(start), "error", err)
 		return nil, err
 	}
-	return v.([]string), nil
+	ids := v.([]string)
+	slog.DebugContext(ctx, "Gateway model discovery fetch completed", "duration", time.Since(start), "models", len(ids))
+	return ids, nil
 }
 
 // buildGatewayChoices builds ModelChoice entries from the models served by

--- a/pkg/runtime/gateway_models.go
+++ b/pkg/runtime/gateway_models.go
@@ -69,6 +69,9 @@ func (r *LocalRuntime) listGatewayModels(ctx context.Context) ([]string, error) 
 		}
 
 		ids, err := modelsgateway.ListModels(ctx, r.modelSwitcherCfg.ModelsGateway, r.modelSwitcherCfg.EnvProvider)
+		if err != nil && ctx.Err() != nil {
+			return ids, err
+		}
 		c.mu.Lock()
 		c.ids, c.err, c.fetchedAt = ids, err, now()
 		c.mu.Unlock()

--- a/pkg/runtime/gateway_models_test.go
+++ b/pkg/runtime/gateway_models_test.go
@@ -237,6 +237,29 @@ func TestListGatewayModels_CachesFailure(t *testing.T) {
 	assert.Equal(t, int32(1), requests.Load(), "failures must be cached to avoid hammering the gateway")
 }
 
+func TestListGatewayModels_DoesNotCacheCallerCancellation(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		_, _ = w.Write([]byte(`{"data":[{"id":"openai/gpt-4o"}]}`))
+	}))
+	defer server.Close()
+
+	r := gatewayRuntime(server.URL, stubModelStore{})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err := r.listGatewayModels(ctx)
+	require.Error(t, err)
+
+	ids, err := r.listGatewayModels(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"openai/gpt-4o"}, ids)
+	assert.Equal(t, int32(1), requests.Load(), "caller cancellation must not poison the gateway discovery cache")
+}
+
 func TestListGatewayModels_DoubleCheckAvoidsRedundantFetch(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/runtime/model_switcher.go
+++ b/pkg/runtime/model_switcher.go
@@ -165,6 +165,13 @@ type ModelSwitcherConfig struct {
 	ProviderRegistry *provider.Registry
 	// AgentDefaultModels maps agent names to their configured default model references
 	AgentDefaultModels map[string]string
+	// ModelsStore is the models.dev catalog store used for the picker's
+	// pricing/context/modality metadata and the catalog listing. When set, the
+	// runtime adopts it instead of building its own (cold) lazy store, so a
+	// store the team loader already warmed is reused. Optional: a nil store
+	// falls back to the lazy default. An explicit WithModelStore takes
+	// precedence over this field.
+	ModelsStore ModelStore
 }
 
 // SetAgentModel implements [Runtime.SetAgentModel] for LocalRuntime.

--- a/pkg/runtime/model_switcher.go
+++ b/pkg/runtime/model_switcher.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/docker/docker-agent/pkg/agent"
 	"github.com/docker/docker-agent/pkg/config/latest"
@@ -470,7 +471,9 @@ func (r *LocalRuntime) resolveModelRefs(ctx context.Context, commaSeparatedRefs 
 
 // AvailableModels implements [Runtime.AvailableModels] for LocalRuntime.
 func (r *LocalRuntime) AvailableModels(ctx context.Context) []ModelChoice {
+	start := time.Now()
 	if r.modelSwitcherCfg == nil {
+		slog.DebugContext(ctx, "Runtime available models skipped; model switching not configured", "duration", time.Since(start))
 		return nil
 	}
 
@@ -482,6 +485,7 @@ func (r *LocalRuntime) AvailableModels(ctx context.Context) []ModelChoice {
 
 	var choices []ModelChoice
 
+	configuredStart := time.Now()
 	// Add all configured models, marking the current agent's default
 	for name, cfg := range r.modelSwitcherCfg.Models {
 		choice := ModelChoice{
@@ -497,6 +501,7 @@ func (r *LocalRuntime) AvailableModels(ctx context.Context) []ModelChoice {
 		}
 		choices = append(choices, choice)
 	}
+	configuredDuration := time.Since(configuredStart)
 
 	// Prefer live gateway discovery when a models gateway is configured:
 	// the picker then only shows the models actually served by the
@@ -504,29 +509,64 @@ func (r *LocalRuntime) AvailableModels(ctx context.Context) []ModelChoice {
 	// gateway doesn't expose /v1/models, fall back to the models.dev
 	// catalog filtered by available credentials.
 	if r.modelSwitcherCfg.ModelsGateway != "" {
-		if gatewayChoices, ok := r.buildGatewayChoices(ctx); ok {
-			return append(choices, gatewayChoices...)
+		gatewayStart := time.Now()
+		gatewayChoices, ok := r.buildGatewayChoices(ctx)
+		slog.DebugContext(ctx, "Runtime available models gateway discovery completed",
+			"duration", time.Since(gatewayStart),
+			"ok", ok,
+			"models", len(gatewayChoices),
+		)
+		if ok {
+			result := append(choices, gatewayChoices...)
+			slog.DebugContext(ctx, "Runtime available models completed",
+				"duration", time.Since(start),
+				"configured_duration", configuredDuration,
+				"configured_models", len(choices),
+				"gateway_models", len(gatewayChoices),
+				"catalog_models", 0,
+				"dmr_models", 0,
+				"models", len(result),
+			)
+			return result
 		}
 	}
 
 	// Surface models pulled locally in Docker Model Runner. They are not part
-	// of the models.dev catalog, so without this a working local DMR setup
+	// of the models.dev catalog, so without this a working local Model Runner
 	// would show nothing selectable in the picker.
-	choices = append(choices, r.buildDMRChoices(ctx)...)
+	dmrStart := time.Now()
+	dmrChoices := r.buildDMRChoices(ctx)
+	dmrDuration := time.Since(dmrStart)
+	choices = append(choices, dmrChoices...)
 
 	// Append models.dev catalog entries filtered by available credentials
+	catalogStart := time.Now()
 	catalogChoices := r.buildCatalogChoices(ctx)
+	catalogDuration := time.Since(catalogStart)
 	choices = append(choices, catalogChoices...)
 
+	slog.DebugContext(ctx, "Runtime available models completed",
+		"duration", time.Since(start),
+		"configured_duration", configuredDuration,
+		"dmr_duration", dmrDuration,
+		"catalog_duration", catalogDuration,
+		"configured_models", len(r.modelSwitcherCfg.Models),
+		"dmr_models", len(dmrChoices),
+		"catalog_models", len(catalogChoices),
+		"models", len(choices),
+	)
 	return choices
 }
 
 // buildCatalogChoices builds ModelChoice entries from the models.dev catalog,
 // filtered by supported providers and available credentials.
 func (r *LocalRuntime) buildCatalogChoices(ctx context.Context) []ModelChoice {
+	start := time.Now()
+	dbStart := time.Now()
 	db, err := r.modelsStore.GetDatabase(ctx)
+	dbDuration := time.Since(dbStart)
 	if err != nil {
-		slog.DebugContext(ctx, "Failed to get models.dev database for catalog", "error", err)
+		slog.DebugContext(ctx, "Failed to get models.dev database for catalog", "duration", time.Since(start), "database_duration", dbDuration, "error", err)
 		return nil
 	}
 
@@ -540,35 +580,50 @@ func (r *LocalRuntime) buildCatalogChoices(ctx context.Context) []ModelChoice {
 	}
 
 	// Check which providers the user has credentials for
+	providerStart := time.Now()
 	availableProviders := r.getAvailableProviders(ctx)
+	providerDuration := time.Since(providerStart)
 	if len(availableProviders) == 0 {
-		slog.DebugContext(ctx, "No provider credentials available, skipping catalog")
+		slog.DebugContext(ctx, "No provider credentials available, skipping catalog",
+			"duration", time.Since(start),
+			"database_duration", dbDuration,
+			"provider_duration", providerDuration,
+		)
 		return nil
 	}
 
+	iterateStart := time.Now()
 	var choices []ModelChoice
+	var providerCount, modelCount, skippedProvider, skippedNonText, skippedEmbedding, skippedDuplicate int
 	for providerID, prov := range db.Providers {
+		providerCount++
 		// Check if this provider is supported and user has credentials
 		dockerAgentProvider, supported := mapModelsDevProvider(providerID)
 		if !supported {
+			skippedProvider++
 			continue
 		}
 		if !availableProviders[dockerAgentProvider] {
+			skippedProvider++
 			continue
 		}
 
 		for modelID, model := range prov.Models {
+			modelCount++
 			// Skip models that don't output text (not suitable for chat)
 			if !slices.Contains(model.Modalities.Output, "text") {
+				skippedNonText++
 				continue
 			}
 			// Skip embedding models (not suitable for chat)
 			if isEmbeddingModel(model.Family, model.Name) {
+				skippedEmbedding++
 				continue
 			}
 
 			ref := dockerAgentProvider + "/" + modelID
 			if existingRefs[ref] {
+				skippedDuplicate++
 				continue
 			}
 			existingRefs[ref] = true
@@ -585,7 +640,20 @@ func (r *LocalRuntime) buildCatalogChoices(ctx context.Context) []ModelChoice {
 		}
 	}
 
-	slog.DebugContext(ctx, "Built catalog choices", "count", len(choices), "available_providers", len(availableProviders))
+	slog.DebugContext(ctx, "Built catalog choices",
+		"duration", time.Since(start),
+		"database_duration", dbDuration,
+		"provider_duration", providerDuration,
+		"iterate_duration", time.Since(iterateStart),
+		"providers", providerCount,
+		"models_seen", modelCount,
+		"models", len(choices),
+		"available_providers", len(availableProviders),
+		"skipped_provider", skippedProvider,
+		"skipped_non_text", skippedNonText,
+		"skipped_embedding", skippedEmbedding,
+		"skipped_duplicate", skippedDuplicate,
+	)
 	return choices
 }
 

--- a/pkg/runtime/model_switcher.go
+++ b/pkg/runtime/model_switcher.go
@@ -819,6 +819,10 @@ func (r *LocalRuntime) createProviderFromConfig(ctx context.Context, cfg *latest
 		}
 	}
 
+	if store, ok := r.modelsStore.(*modelsdev.Store); ok && store != nil {
+		opts = append(opts, options.WithModelsDevStore(store))
+	}
+
 	registry := r.modelSwitcherCfg.ProviderRegistry
 	if registry == nil {
 		registry = r.providerRegistry

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -626,7 +626,15 @@ func NewLocalRuntime(agents *team.Team, opts ...Opt) (*LocalRuntime, error) {
 	}
 
 	if r.modelsStore == nil {
-		r.modelsStore = &lazyModelStore{}
+		// Precedence: an explicit WithModelStore (already set above) wins; then a
+		// store carried on the ModelSwitcherConfig (the team loader shares the
+		// one it warmed so the first /model open skips the cold catalog parse);
+		// otherwise a lazy store constructed on first use.
+		if r.modelSwitcherCfg != nil && r.modelSwitcherCfg.ModelsStore != nil {
+			r.modelsStore = r.modelSwitcherCfg.ModelsStore
+		} else {
+			r.modelsStore = &lazyModelStore{}
+		}
 	}
 
 	// Validate that the current agent exists and has a model

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -889,6 +889,52 @@ func TestNewRuntime_InvalidCurrentAgentError(t *testing.T) {
 	require.Contains(t, err.Error(), "agent not found: other (available agents: root)")
 }
 
+// TestNewRuntime_ModelStorePrecedence pins the resolution order for the
+// runtime's models.dev store: an explicit WithModelStore wins; otherwise a
+// store carried on the ModelSwitcherConfig is adopted (this is how the team
+// loader shares the catalog it already warmed); otherwise the runtime builds
+// its own lazy store. Sharing the warmed store is what keeps the first /model
+// open from re-paying the multi-MB catalog parse.
+func TestNewRuntime_ModelStorePrecedence(t *testing.T) {
+	t.Parallel()
+
+	newTeam := func() *team.Team {
+		root := agent.New("root", "test", agent.WithModel(&mockProvider{id: "test/m"}))
+		return team.New(team.WithAgents(root))
+	}
+
+	t.Run("explicit WithModelStore wins over ModelSwitcherConfig", func(t *testing.T) {
+		t.Parallel()
+		explicit := &mockCatalogStore{}
+		cfgStore := &mockCatalogStore{}
+		rt, err := NewLocalRuntime(newTeam(),
+			WithModelStore(explicit),
+			WithModelSwitcherConfig(&ModelSwitcherConfig{ModelsStore: cfgStore}),
+		)
+		require.NoError(t, err)
+		assert.Same(t, explicit, rt.modelsStore)
+	})
+
+	t.Run("ModelSwitcherConfig store is adopted when no explicit store", func(t *testing.T) {
+		t.Parallel()
+		cfgStore := &mockCatalogStore{}
+		rt, err := NewLocalRuntime(newTeam(),
+			WithModelSwitcherConfig(&ModelSwitcherConfig{ModelsStore: cfgStore}),
+		)
+		require.NoError(t, err)
+		assert.Same(t, cfgStore, rt.modelsStore)
+	})
+
+	t.Run("falls back to lazy store when neither is set", func(t *testing.T) {
+		t.Parallel()
+		rt, err := NewLocalRuntime(newTeam(),
+			WithModelSwitcherConfig(&ModelSwitcherConfig{}),
+		)
+		require.NoError(t, err)
+		assert.IsType(t, &lazyModelStore{}, rt.modelsStore)
+	})
+}
+
 func TestProcessToolCalls_UnknownTool_ReturnsErrorResponse(t *testing.T) {
 	root := agent.New("root", "You are a test agent", agent.WithModel(&mockProvider{}))
 	tm := team.New(team.WithAgents(root))

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -952,6 +952,13 @@ func (sm *SessionManager) runtimeForSession(ctx context.Context, sess *session.S
 		ProviderRegistry:   loadResult.ProviderRegistry,
 		AgentDefaultModels: loadResult.AgentDefaultModels,
 	}
+	// Reuse the models.dev store the team loader already warmed so the
+	// /api/sessions/:id/models picker doesn't re-pay the cold catalog parse.
+	if store, storeErr := rc.ModelsDevStore(); storeErr == nil {
+		modelSwitcherCfg.ModelsStore = store
+	} else {
+		slog.WarnContext(ctx, "Failed to obtain shared models.dev store; runtime will use its own", "error", storeErr)
+	}
 
 	opts := []runtime.Opt{
 		runtime.WithCurrentAgent(currentAgent),

--- a/pkg/tui/dialog/model_picker.go
+++ b/pkg/tui/dialog/model_picker.go
@@ -3,9 +3,11 @@ package dialog
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/textinput"
@@ -61,6 +63,9 @@ const (
 	catalogSeparatorLabel = "Other models"
 	// customSeparatorLabel labels the separator above the custom-models group.
 	customSeparatorLabel = "Custom models"
+
+	modelPickerSlowFilterThreshold = 10 * time.Millisecond
+	modelPickerSlowRenderThreshold = 16 * time.Millisecond
 )
 
 // modelPickerLayout is the layout used by the model picker.
@@ -76,18 +81,29 @@ var modelPickerLayout = pickerLayout{
 
 // NewModelPickerDialog creates a new model picker dialog.
 func NewModelPickerDialog(models []runtime.ModelChoice) Dialog {
+	start := time.Now()
 	d := &modelPickerDialog{
 		pickerCore: newPickerCore(modelPickerLayout, "Type to search or enter custom model (provider/model)…"),
 	}
 	d.textInput.CharLimit = 100
 
 	// Sort models: config first, then catalog, then custom.
+	sortStart := time.Now()
 	sortedModels := slices.Clone(models)
 	slices.SortFunc(sortedModels, func(a, b runtime.ModelChoice) int {
 		return comparePickerSortKeys(modelSortKeys(a), modelSortKeys(b))
 	})
+	sortDuration := time.Since(sortStart)
 	d.models = sortedModels
+	filterStart := time.Now()
 	d.filterModels()
+	slog.Debug("Model picker dialog constructed",
+		"duration", time.Since(start),
+		"sort_duration", sortDuration,
+		"filter_duration", time.Since(filterStart),
+		"models", len(models),
+		"filtered", len(d.filtered),
+	)
 	return d
 }
 
@@ -288,6 +304,7 @@ func validateCustomModelSpec(spec string) error {
 }
 
 func (d *modelPickerDialog) filterModels() {
+	start := time.Now()
 	query := strings.ToLower(strings.TrimSpace(d.textInput.Value()))
 
 	// If query contains "/", show "Custom" option as well as matches
@@ -319,22 +336,37 @@ func (d *modelPickerDialog) filterModels() {
 		d.selected = max(0, len(d.filtered)-1)
 	}
 	d.scrollview.SetScrollOffset(0)
+	if duration := time.Since(start); duration > modelPickerSlowFilterThreshold {
+		slog.Debug("Model picker filter slow",
+			"duration", duration,
+			"models", len(d.models),
+			"filtered", len(d.filtered),
+			"query_length", len(query),
+		)
+	}
 }
 
 func (d *modelPickerDialog) View() string {
+	start := time.Now()
 	dialogWidth, _, contentWidth := d.dialogSize()
 	d.textInput.SetWidth(contentWidth)
 
+	buildListStart := time.Now()
 	gl := d.buildList(contentWidth)
+	buildListDuration := time.Since(buildListStart)
 	d.updateScrollviewPosition()
+	setContentStart := time.Now()
 	d.scrollview.SetContent(gl.Lines(), len(gl.Lines()))
+	setContentDuration := time.Since(setContentStart)
 
 	var scrollableContent string
+	scrollviewStart := time.Now()
 	if len(d.filtered) == 0 {
 		scrollableContent = d.renderEmptyState("No models found", contentWidth)
 	} else {
 		scrollableContent = d.scrollview.View()
 	}
+	scrollviewDuration := time.Since(scrollviewStart)
 
 	contentBuilder := NewContent(d.regionWidth(contentWidth)).
 		AddTitle("Select Model").
@@ -345,17 +377,40 @@ func (d *modelPickerDialog) View() string {
 		contentBuilder.AddContent(styles.ErrorStyle.Render("⚠ " + d.errMsg))
 	}
 
+	detailsStart := time.Now()
+	details := d.renderDetails(contentWidth)
+	detailsDuration := time.Since(detailsStart)
+	contentBuildStart := time.Now()
 	content := contentBuilder.
 		AddSeparator().
 		AddContent(d.renderColumnHeader(contentWidth)).
 		AddContent(scrollableContent).
 		AddSeparator().
-		AddContent(d.renderDetails(contentWidth)).
+		AddContent(details).
 		AddSpace().
 		AddHelpKeys("↑/↓", "navigate", "enter", "select", "esc", "cancel").
 		Build()
+	contentBuildDuration := time.Since(contentBuildStart)
 
-	return styles.DialogStyle.Width(dialogWidth).Render(content)
+	renderStart := time.Now()
+	view := styles.DialogStyle.Width(dialogWidth).Render(content)
+	renderDuration := time.Since(renderStart)
+	if duration := time.Since(start); duration > modelPickerSlowRenderThreshold {
+		slog.Debug("Model picker render slow",
+			"duration", duration,
+			"build_list_duration", buildListDuration,
+			"set_content_duration", setContentDuration,
+			"scrollview_duration", scrollviewDuration,
+			"details_duration", detailsDuration,
+			"content_build_duration", contentBuildDuration,
+			"render_duration", renderDuration,
+			"models", len(d.models),
+			"filtered", len(d.filtered),
+			"lines", len(gl.Lines()),
+			"visible_lines", d.scrollview.VisibleHeight(),
+		)
+	}
+	return view
 }
 
 // pickerRowPalette is the set of styles used to render one row of the

--- a/pkg/tui/dialog/model_picker.go
+++ b/pkg/tui/dialog/model_picker.go
@@ -14,7 +14,6 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
-	"github.com/docker/docker-agent/pkg/model/provider"
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/tui/components/toolcommon"
 	"github.com/docker/docker-agent/pkg/tui/core"
@@ -264,7 +263,9 @@ func (d *modelPickerDialog) handleSelection() tea.Cmd {
 }
 
 // validateCustomModelSpec validates a custom model specification entered by the user.
-// It checks that each provider/model pair is properly formatted and uses a supported provider.
+// It checks that each provider/model pair is syntactically valid. Provider
+// existence is resolved by the runtime because configs may define custom
+// providers that the TUI cannot see here.
 func validateCustomModelSpec(spec string) error {
 	spec = strings.TrimSpace(spec)
 	if spec == "" {
@@ -292,11 +293,6 @@ func validateCustomModelSpec(spec string) error {
 		}
 		if modelName == "" {
 			return fmt.Errorf("model name cannot be empty (got '%s/')", providerName)
-		}
-
-		if !provider.IsKnownProvider(providerName) {
-			return fmt.Errorf("unknown provider '%s'. Supported: %s",
-				providerName, strings.Join(provider.AllProviders(), ", "))
 		}
 	}
 

--- a/pkg/tui/dialog/model_picker_test.go
+++ b/pkg/tui/dialog/model_picker_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/docker/docker-agent/pkg/model/provider"
 	"github.com/docker/docker-agent/pkg/runtime"
 )
 
@@ -302,16 +301,14 @@ func TestValidateCustomModelSpec(t *testing.T) {
 			errMsg:  "model name cannot be empty",
 		},
 		{
-			name:    "unknown provider",
+			name:    "custom provider is allowed syntactically",
 			spec:    "foobar/some-model",
-			wantErr: true,
-			errMsg:  "unknown provider 'foobar'",
+			wantErr: false,
 		},
 		{
-			name:    "unknown provider in alloy",
+			name:    "custom provider in alloy is allowed syntactically",
 			spec:    "openai/gpt-4o,unknown/model",
-			wantErr: true,
-			errMsg:  "unknown provider 'unknown'",
+			wantErr: false,
 		},
 		{
 			name:    "case insensitive provider",
@@ -344,24 +341,6 @@ func TestValidateCustomModelSpec(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestIsValidProvider(t *testing.T) {
-	t.Parallel()
-
-	// All known providers (core + aliases) should be valid
-	for _, name := range provider.AllProviders() {
-		assert.True(t, provider.IsKnownProvider(name), "provider %s should be known", name)
-	}
-
-	// Case-insensitive
-	assert.True(t, provider.IsKnownProvider("OPENAI"))
-	assert.True(t, provider.IsKnownProvider("OpenAI"))
-
-	// Unknown providers
-	assert.False(t, provider.IsKnownProvider("unknown"))
-	assert.False(t, provider.IsKnownProvider("foo"))
-	assert.False(t, provider.IsKnownProvider(""))
 }
 
 func TestModelPickerSortingWithCatalog(t *testing.T) {

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	goruntime "runtime"
 	"strings"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/atotto/clipboard"
@@ -526,15 +527,24 @@ func (m *appModel) handleMCPPrompt(promptName string, arguments map[string]strin
 // --- Model picker ---
 
 func (m *appModel) handleOpenModelPicker() (tea.Model, tea.Cmd) {
+	start := time.Now()
+	defer func() {
+		slog.Debug("TUI model picker open handled", "duration", time.Since(start))
+	}()
 	if !m.application.SupportsModelSwitching() {
 		return m, notification.InfoCmd("Model switching is not supported with remote runtimes")
 	}
+	loadStart := time.Now()
 	models := m.application.AvailableModels(context.Background())
+	slog.Debug("TUI model picker available models loaded", "duration", time.Since(loadStart), "models", len(models))
 	if len(models) == 0 {
 		return m, notification.InfoCmd("No models available for selection")
 	}
+	dialogStart := time.Now()
+	modelDialog := dialog.NewModelPickerDialog(models)
+	slog.Debug("TUI model picker dialog built", "duration", time.Since(dialogStart), "models", len(models))
 	return m, core.CmdHandler(dialog.OpenDialogMsg{
-		Model: dialog.NewModelPickerDialog(models),
+		Model: modelDialog,
 	})
 }
 


### PR DESCRIPTION
The model picker pipeline was doing redundant work: each runtime session, server session, and embedded-chat path independently warmed its own models.dev store, even though a single warm copy is sufficient for the lifetime of the process. On top of that, context-cancelled discovery errors were being cached, causing subsequent requests to fail silently, and the picker had no way to understand why discovery was slow or where time was being spent.

This change wires a single shared `ModelStore` through the CLI entry point (`cmd/root/run.go`), the app layer, and both the runtime and server session constructors, so the expensive initial fetch happens once and the result is reused everywhere. The model picker now also accepts custom provider references directly, lifting a restriction that forced all providers through the standard discovery path. Timing instrumentation has been added throughout the picker pipeline — from initial store lookup through to final model selection — so latency spikes are visible in debug logs. Finally, context-cancellation errors are no longer cached in the discovery layer; a cancelled lookup leaves the cache empty so the next request retries cleanly.

Validated with `task --force lint` and `task --force test`.