### PR TITLE
fix: open /shell in the session working directory (e.g. --worktree)

### DIFF
--- a/cmd/root/new.go
+++ b/cmd/root/new.go
@@ -112,7 +112,13 @@ func runTUI(ctx context.Context, rt runtime.Runtime, sess *session.Session, spaw
 	if cleanup == nil {
 		cleanup = func() {}
 	}
-	wd, _ := os.Getwd()
+	// Prefer the session's working directory so the TUI (and features keyed
+	// off it, like /shell) operate where the tools do — e.g. the worktree
+	// created by --worktree, not the process CWD it was launched from.
+	wd := sess.WorkingDir
+	if wd == "" {
+		wd, _ = os.Getwd()
+	}
 	model := tui.New(ctx, spawner, a, wd, cleanup, tuiOpts...)
 
 	p := tea.NewProgram(model, tea.WithContext(ctx), tea.WithFilter(filter))

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -904,7 +904,13 @@ func (f *runExecFlags) runLeanTUI(ctx context.Context, rt runtime.Runtime, sess 
 		cleanup = func() {}
 	}
 
-	wd, _ := os.Getwd()
+	// Prefer the session's working directory so the lean status bar shows
+	// where the tools operate — e.g. the worktree from --worktree, not the
+	// process CWD it was launched from.
+	wd := sess.WorkingDir
+	if wd == "" {
+		wd, _ = os.Getwd()
+	}
 	return leantui.Run(ctx, leantui.Config{
 		App:                    a,
 		WorkingDir:             wd,


### PR DESCRIPTION
When running with `--worktree`, docker-agent creates a dedicated worktree directory and stores its path in the session's `WorkingDir` field. The process CWD, however, is never changed to match. Both the full and lean TUI were calling `os.Getwd()` to determine the initial working directory, which meant features like `/shell` opened a terminal rooted in the original checkout rather than the worktree.

The fix is straightforward: `runTUI` and `runLeanTUI` now prefer `sess.WorkingDir` when it is non-empty, falling back to `os.Getwd()` only when it is not set. This preserves the existing behaviour for `docker-agent new` and any other flow that does not set a session working directory, while ensuring that worktree-based runs open `/shell` (and display the git branch in the status bar) in the correct directory.

No breaking changes. The fallback path is identical to the previous behaviour.