### PR TITLE
lint: enforce deferred mutex unlocks

### DIFF
--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -202,8 +202,8 @@ func chatJS(_ js.Value, args []js.Value) any {
 		go func() {
 			defer func() {
 				abortState.mu.Lock()
+				defer abortState.mu.Unlock()
 				cancel()
-				abortState.mu.Unlock()
 			}()
 
 			result, err := runChat(ctx, yamlStr, agentName, envMap, messages, onEvent)

--- a/lint/defer_mutex_unlock.go
+++ b/lint/defer_mutex_unlock.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"go/ast"
+	"go/token"
+
+	"github.com/dgageot/rubocop-go/cop"
+)
+
+// DeferMutexUnlock catches manual mutex unlocks that are safe and clearer as a
+// defer immediately after the corresponding lock.
+//
+// The cop is deliberately conservative. It ignores intentionally short critical
+// sections (work after unlock), unlock/relock patterns, nested lock scopes, and
+// terminal returns with side-effectful result expressions. Those patterns would
+// change behavior if rewritten to defer because Go evaluates return expressions
+// before running deferred calls.
+var DeferMutexUnlock = &cop.Func{
+	Meta: cop.Meta{
+		Name:        "Lint/DeferMutexUnlock",
+		Description: "use defer immediately after mutex locks when the whole remaining scope is the critical section",
+		Severity:    cop.Warning,
+	},
+	Run: func(p *cop.Pass) {
+		ast.Inspect(p.File, func(n ast.Node) bool {
+			var body *ast.BlockStmt
+			switch fn := n.(type) {
+			case *ast.FuncDecl:
+				body = fn.Body
+			case *ast.FuncLit:
+				body = fn.Body
+			default:
+				return true
+			}
+			checkDeferMutexUnlockBody(p, body)
+			return true
+		})
+	},
+}
+
+func checkDeferMutexUnlockBody(p *cop.Pass, body *ast.BlockStmt) {
+	if body == nil {
+		return
+	}
+	for i, stmt := range body.List {
+		lock, ok := lockCall(stmt)
+		if !ok || lock.recv == "" {
+			continue
+		}
+		if i+1 < len(body.List) && isDeferUnlock(body.List[i+1], lock) {
+			continue
+		}
+		if isSafeManualUnlockAtEnd(body.List, i, lock) {
+			p.Reportf(stmt,
+				"%s.%s() is only released at the end of this scope; use `defer %s.%s()` immediately after locking",
+				lock.recv, lock.method, lock.recv, lock.unlockMethod())
+		}
+	}
+}
+
+type mutexCall struct {
+	recv   string
+	method string
+}
+
+func (c mutexCall) unlockMethod() string {
+	if c.method == "RLock" {
+		return "RUnlock"
+	}
+	return "Unlock"
+}
+
+func lockCall(stmt ast.Stmt) (mutexCall, bool) {
+	name, recv, ok := selectorCallStmt(stmt)
+	if !ok || (name != "Lock" && name != "RLock") {
+		return mutexCall{}, false
+	}
+	return mutexCall{recv: recv, method: name}, true
+}
+
+func selectorCallStmt(stmt ast.Stmt) (name, recv string, ok bool) {
+	exprStmt, ok := stmt.(*ast.ExprStmt)
+	if !ok {
+		return "", "", false
+	}
+	call, ok := exprStmt.X.(*ast.CallExpr)
+	if !ok {
+		return "", "", false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return "", "", false
+	}
+	return sel.Sel.Name, selectorReceiver(sel.X), true
+}
+
+func selectorReceiver(expr ast.Expr) string {
+	switch v := expr.(type) {
+	case *ast.Ident:
+		return v.Name
+	case *ast.SelectorExpr:
+		x := selectorReceiver(v.X)
+		if x == "" {
+			return ""
+		}
+		return x + "." + v.Sel.Name
+	default:
+		return ""
+	}
+}
+
+func isDeferUnlock(stmt ast.Stmt, lock mutexCall) bool {
+	deferStmt, ok := stmt.(*ast.DeferStmt)
+	if !ok {
+		return false
+	}
+	sel, ok := deferStmt.Call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	return sel.Sel.Name == lock.unlockMethod() && selectorReceiver(sel.X) == lock.recv
+}
+
+func isSafeManualUnlockAtEnd(stmts []ast.Stmt, lockIdx int, lock mutexCall) bool {
+	unlockIdx := -1
+	for i := lockIdx + 1; i < len(stmts); i++ {
+		name, recv, ok := selectorCallStmt(stmts[i])
+		if !ok || recv != lock.recv {
+			continue
+		}
+		switch name {
+		case lock.method:
+			return false // release/reacquire or nested critical section
+		case lock.unlockMethod():
+			if unlockIdx >= 0 {
+				return false
+			}
+			unlockIdx = i
+		}
+	}
+	if unlockIdx < 0 {
+		return false
+	}
+	if unlockIdx == len(stmts)-1 {
+		return true
+	}
+	if unlockIdx+1 != len(stmts)-1 {
+		return false
+	}
+	ret, ok := stmts[unlockIdx+1].(*ast.ReturnStmt)
+	if !ok {
+		return false
+	}
+	return returnResultsAreSideEffectFree(ret)
+}
+
+func returnResultsAreSideEffectFree(ret *ast.ReturnStmt) bool {
+	for _, result := range ret.Results {
+		if !exprIsSideEffectFree(result) {
+			return false
+		}
+	}
+	return true
+}
+
+func exprIsSideEffectFree(expr ast.Expr) bool {
+	switch v := expr.(type) {
+	case nil:
+		return true
+	case *ast.BasicLit:
+		return true
+	case *ast.Ident:
+		return true
+	case *ast.SelectorExpr:
+		return exprIsSideEffectFree(v.X)
+	case *ast.UnaryExpr:
+		return v.Op != token.ARROW && exprIsSideEffectFree(v.X)
+	case *ast.CompositeLit:
+		for _, elt := range v.Elts {
+			if !exprIsSideEffectFree(elt) {
+				return false
+			}
+		}
+		return true
+	case *ast.KeyValueExpr:
+		return exprIsSideEffectFree(v.Key) && exprIsSideEffectFree(v.Value)
+	default:
+		return false
+	}
+}

--- a/lint/defer_mutex_unlock.go
+++ b/lint/defer_mutex_unlock.go
@@ -128,7 +128,16 @@ func isSafeManualUnlockAtEnd(stmts []ast.Stmt, lockIdx int, lock mutexCall) bool
 			return false
 		}
 		name, recv, ok := selectorCallStmt(stmts[i])
-		if !ok || recv != lock.recv {
+		if !ok {
+			// Compound statement (if/for/switch/...): a nested lock or unlock of
+			// the same mutex means the terminal unlock is not the sole release,
+			// so deferring it would change behavior.
+			if stmtContainsLockOp(stmts[i], lock) {
+				return false
+			}
+			continue
+		}
+		if recv != lock.recv {
 			continue
 		}
 		switch name {
@@ -155,6 +164,32 @@ func isSafeManualUnlockAtEnd(stmts []ast.Stmt, lockIdx int, lock mutexCall) bool
 		return false
 	}
 	return returnResultsAreSideEffectFree(ret)
+}
+
+func stmtContainsLockOp(stmt ast.Stmt, lock mutexCall) bool {
+	found := false
+	ast.Inspect(stmt, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if selectorReceiver(sel.X) != lock.recv {
+			return true
+		}
+		switch sel.Sel.Name {
+		case lock.method, lock.unlockMethod():
+			found = true
+		}
+		return !found
+	})
+	return found
 }
 
 func stmtContainsDefer(stmt ast.Stmt) bool {

--- a/lint/defer_mutex_unlock.go
+++ b/lint/defer_mutex_unlock.go
@@ -124,6 +124,9 @@ func isDeferUnlock(stmt ast.Stmt, lock mutexCall) bool {
 func isSafeManualUnlockAtEnd(stmts []ast.Stmt, lockIdx int, lock mutexCall) bool {
 	unlockIdx := -1
 	for i := lockIdx + 1; i < len(stmts); i++ {
+		if stmtContainsDefer(stmts[i]) {
+			return false
+		}
 		name, recv, ok := selectorCallStmt(stmts[i])
 		if !ok || recv != lock.recv {
 			continue
@@ -152,6 +155,18 @@ func isSafeManualUnlockAtEnd(stmts []ast.Stmt, lockIdx int, lock mutexCall) bool
 		return false
 	}
 	return returnResultsAreSideEffectFree(ret)
+}
+
+func stmtContainsDefer(stmt ast.Stmt) bool {
+	found := false
+	ast.Inspect(stmt, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		_, found = n.(*ast.DeferStmt)
+		return !found
+	})
+	return found
 }
 
 func returnResultsAreSideEffectFree(ret *ast.ReturnStmt) bool {

--- a/lint/main.go
+++ b/lint/main.go
@@ -33,6 +33,7 @@ var cops = []cop.Cop{
 	ConstructorCommandExec,
 	ConstructorNetworkIO,
 	WrapErrors,
+	DeferMutexUnlock,
 }
 
 func main() {

--- a/pkg/acp/agent.go
+++ b/pkg/acp/agent.go
@@ -420,8 +420,8 @@ func (a *Agent) Prompt(ctx context.Context, params acp.PromptRequest) (acp.Promp
 	}
 
 	a.mu.Lock()
+	defer a.mu.Unlock()
 	acpSess.cancel = nil
-	a.mu.Unlock()
 
 	return acp.PromptResponse{StopReason: acp.StopReasonEndTurn}, nil
 }

--- a/pkg/acp/agent.go
+++ b/pkg/acp/agent.go
@@ -158,8 +158,8 @@ func (a *Agent) newRuntime(workingDir string) (runtime.Runtime, *agent.Agent, er
 // registerSession stores a session in the active sessions map.
 func (a *Agent) registerSession(acpSess *Session) {
 	a.mu.Lock()
+	defer a.mu.Unlock()
 	a.sessions[acpSess.id] = acpSess
-	a.mu.Unlock()
 }
 
 // registerSessionIfAbsent stores acpSess only if no session with the same id

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -452,8 +452,8 @@ func (a *Agent) AddToolWarning(msg string) {
 		return
 	}
 	a.warningsMu.Lock()
+	defer a.warningsMu.Unlock()
 	a.pendingWarnings = append(a.pendingWarnings, msg)
-	a.warningsMu.Unlock()
 }
 
 // DrainWarnings returns pending warnings and clears them.

--- a/pkg/audio/capture/capture_darwin.go
+++ b/pkg/audio/capture/capture_darwin.go
@@ -240,8 +240,8 @@ func (c *Capturer) Stop() error {
 	c.capturing = false
 
 	globalCapturerMu.Lock()
+	defer globalCapturerMu.Unlock()
 	globalCapturer = nil
-	globalCapturerMu.Unlock()
 
 	return nil
 }

--- a/pkg/embeddedchat/embeddedchat.go
+++ b/pkg/embeddedchat/embeddedchat.go
@@ -269,10 +269,10 @@ func (s *Session) forwardEvents(ctx context.Context, events <-chan dagentruntime
 	defer cancel()
 	defer func() {
 		s.mu.Lock()
+		defer s.mu.Unlock()
 		if s.activeRun == runID {
 			s.activeCancel = nil
 		}
-		s.mu.Unlock()
 	}()
 
 	emit := func(e Event) bool {

--- a/pkg/evaluation/build.go
+++ b/pkg/evaluation/build.go
@@ -58,8 +58,8 @@ func (r *Runner) getOrBuildImage(ctx context.Context, evals *session.EvalCriteri
 		}
 
 		r.imageCacheMu.Lock()
+		defer r.imageCacheMu.Unlock()
 		r.imageCache[key] = imageID
-		r.imageCacheMu.Unlock()
 
 		return imageID, nil
 	})

--- a/pkg/model/provider/anthropic/files.go
+++ b/pkg/model/provider/anthropic/files.go
@@ -167,8 +167,8 @@ func (fm *FileManager) GetOrUpload(ctx context.Context, filePath string) (result
 			}
 			// Cache the path mapping
 			fm.mu.Lock()
+			defer fm.mu.Unlock()
 			fm.paths[absPath] = key
-			fm.mu.Unlock()
 			return flight.result, nil
 		case <-ctx.Done():
 			return nil, ctx.Err()

--- a/pkg/model/provider/anthropic/files.go
+++ b/pkg/model/provider/anthropic/files.go
@@ -188,6 +188,7 @@ func (fm *FileManager) GetOrUpload(ctx context.Context, filePath string) (result
 	func() {
 		defer func() {
 			fm.mu.Lock()
+			defer fm.mu.Unlock()
 			flight.result = upload
 			flight.err = err
 			close(flight.done)
@@ -199,7 +200,6 @@ func (fm *FileManager) GetOrUpload(ctx context.Context, filePath string) (result
 				fm.uploads[key] = upload
 				fm.paths[absPath] = key
 			}
-			fm.mu.Unlock()
 		}()
 
 		upload, err = fm.upload(ctx, absPath, hash, mimeType, stat.Size())

--- a/pkg/runtime/dmr_models.go
+++ b/pkg/runtime/dmr_models.go
@@ -74,8 +74,8 @@ func (r *LocalRuntime) listDMRModels(ctx context.Context) ([]string, error) {
 			return ids, err
 		}
 		c.mu.Lock()
+		defer c.mu.Unlock()
 		c.ids, c.err, c.fetchedAt = ids, err, now()
-		c.mu.Unlock()
 		return ids, err
 	})
 	if err != nil {

--- a/pkg/runtime/gateway_models.go
+++ b/pkg/runtime/gateway_models.go
@@ -73,8 +73,8 @@ func (r *LocalRuntime) listGatewayModels(ctx context.Context) ([]string, error) 
 			return ids, err
 		}
 		c.mu.Lock()
+		defer c.mu.Unlock()
 		c.ids, c.err, c.fetchedAt = ids, err, now()
-		c.mu.Unlock()
 		return ids, err
 	})
 	if err != nil {

--- a/pkg/runtime/observer_test.go
+++ b/pkg/runtime/observer_test.go
@@ -29,14 +29,14 @@ type recordingObserver struct {
 func (o *recordingObserver) OnRunStart(_ context.Context, sess *session.Session) {
 	o.startCalls.Add(1)
 	o.mu.Lock()
+	defer o.mu.Unlock()
 	o.startSessID = sess.ID
-	o.mu.Unlock()
 }
 
 func (o *recordingObserver) OnEvent(_ context.Context, _ *session.Session, e Event) {
 	o.mu.Lock()
+	defer o.mu.Unlock()
 	o.events = append(o.events, e)
-	o.mu.Unlock()
 }
 
 func (o *recordingObserver) snapshot() []Event {
@@ -129,8 +129,8 @@ func TestObserver_MultipleObserversFireInRegistrationOrder(t *testing.T) {
 		return &fnObserver{
 			onEvent: func(_ context.Context, _ *session.Session, _ Event) {
 				mu.Lock()
+				defer mu.Unlock()
 				order = append(order, name)
-				mu.Unlock()
 			},
 		}
 	}

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -595,8 +595,8 @@ func (r *RemoteRuntime) AvailableModels(ctx context.Context) []ModelChoice {
 // turn replaces the queued ref; an empty string clears it.
 func (r *RemoteRuntime) SetAgentModel(_ context.Context, _, modelRef string) error {
 	r.pendingMu.Lock()
+	defer r.pendingMu.Unlock()
 	r.pendingModelOverride = modelRef
-	r.pendingMu.Unlock()
 	return nil
 }
 

--- a/pkg/server/eventlog.go
+++ b/pkg/server/eventlog.go
@@ -161,8 +161,8 @@ func (l *eventLog) stream(ctx context.Context, since *uint64, send func(seq uint
 
 	defer func() {
 		l.mu.Lock()
+		defer l.mu.Unlock()
 		delete(l.listeners, ln)
-		l.mu.Unlock()
 	}()
 
 	if !l.replay(ctx, since, backlog, send) {

--- a/pkg/server/eventlog_test.go
+++ b/pkg/server/eventlog_test.go
@@ -24,8 +24,8 @@ func collect(t *testing.T, log *eventLog, since *uint64) (stop func(), got func(
 		defer close(done)
 		log.stream(ctx, since, func(seq uint64, event any) {
 			mu.Lock()
+			defer mu.Unlock()
 			events = append(events, seqEvent{seq: seq, event: event})
-			mu.Unlock()
 		})
 	}()
 
@@ -191,8 +191,8 @@ func TestEventLog_CloseEmitsTerminalEventThenEndsStream(t *testing.T) {
 		defer close(done)
 		log.stream(ctx, nil, func(seq uint64, event any) {
 			mu.Lock()
+			defer mu.Unlock()
 			got = append(got, seqEvent{seq: seq, event: event})
-			mu.Unlock()
 		})
 	}()
 

--- a/pkg/server/server_attached_test.go
+++ b/pkg/server/server_attached_test.go
@@ -590,8 +590,8 @@ func TestAttachedServer_FollowUpIdempotencyKeyDedupes(t *testing.T) {
 	var delivered []string
 	sm.RegisterFollowUpInjector(sess.ID, func(_ context.Context, content string) {
 		mu.Lock()
+		defer mu.Unlock()
 		delivered = append(delivered, content)
-		mu.Unlock()
 	})
 
 	srv := NewWithManager(sm, "")

--- a/pkg/server/session_models_test.go
+++ b/pkg/server/session_models_test.go
@@ -621,8 +621,8 @@ func TestApplyStoredOverrides(t *testing.T) {
 		applyStoredOverrides(t.Context(), "sess", fake, nil)
 
 		fake.mu.Lock()
+		defer fake.mu.Unlock()
 		assert.Empty(t, fake.overrides)
-		fake.mu.Unlock()
 	})
 
 	t.Run("no-op when runtime does not support switching", func(t *testing.T) {
@@ -643,9 +643,9 @@ func TestApplyStoredOverrides(t *testing.T) {
 		})
 
 		fake.mu.Lock()
+		defer fake.mu.Unlock()
 		assert.Equal(t, "openai/gpt-4o", fake.overrides["root"])
 		assert.Equal(t, "anthropic/claude-sonnet-4-0", fake.overrides["researcher"])
-		fake.mu.Unlock()
 	})
 
 	t.Run("runtime errors are swallowed (logged) so the session still loads", func(t *testing.T) {

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -491,8 +491,8 @@ func cloneSchemaValue(v any) any {
 // AddMessage adds a message to the session
 func (s *Session) AddMessage(msg *Message) {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.Messages = append(s.Messages, NewMessageItem(msg))
-	s.mu.Unlock()
 }
 
 // SetUsage records cumulative input/output token counts under s.mu.
@@ -500,9 +500,9 @@ func (s *Session) AddMessage(msg *Message) {
 // these fields without it.
 func (s *Session) SetUsage(input, output int64) {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.InputTokens = input
 	s.OutputTokens = output
-	s.mu.Unlock()
 }
 
 // Usage returns a consistent snapshot of the cumulative input/output
@@ -519,25 +519,25 @@ func (s *Session) Usage() (input, output int64) {
 // observe the new tokens without the matching summary item.
 func (s *Session) ApplyCompaction(inputTokens, outputTokens int64, item Item) {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.InputTokens = inputTokens
 	s.OutputTokens = outputTokens
 	s.Messages = append(s.Messages, item)
-	s.mu.Unlock()
 }
 
 // AddSubSession adds a sub-session to the session
 func (s *Session) AddSubSession(subSession *Session) {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.Messages = append(s.Messages, NewSubSessionItem(subSession))
-	s.mu.Unlock()
 }
 
 // AddError appends a recorded error to the session so it survives reload and
 // JSON export.
 func (s *Session) AddError(e *Error) {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.Messages = append(s.Messages, NewErrorItem(e))
-	s.mu.Unlock()
 }
 
 // Duration calculates the duration of the session from message timestamps.

--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -295,16 +295,15 @@ func (s *InMemorySessionStore) UpdateMessage(_ context.Context, messageID int64,
 	var found bool
 	s.sessions.Range(func(_ string, session *Session) bool {
 		session.mu.Lock()
+		defer session.mu.Unlock()
 		for i := range session.Messages {
 			if session.Messages[i].Message == nil || session.Messages[i].Message.ID != messageID {
 				continue
 			}
 			session.Messages[i].Message = updated
 			found = true
-			session.mu.Unlock()
 			return false
 		}
-		session.mu.Unlock()
 		return true
 	})
 	if !found {

--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -337,8 +337,8 @@ func (s *InMemorySessionStore) AddSummary(_ context.Context, sessionID, summary 
 		return ErrNotFound
 	}
 	session.mu.Lock()
+	defer session.mu.Unlock()
 	session.Messages = append(session.Messages, Item{Summary: summary, FirstKeptEntry: firstKeptEntry})
-	session.mu.Unlock()
 	return nil
 }
 

--- a/pkg/telemetry/events.go
+++ b/pkg/telemetry/events.go
@@ -79,16 +79,14 @@ func (tc *Client) RecordSessionStart(ctx context.Context, agentName, sessionID s
 // RecordError records a general session error
 func (tc *Client) RecordError(_ context.Context, errorMsg string) {
 	tc.mu.Lock()
+	defer tc.mu.Unlock()
 
 	if tc.session.SessionEnded || tc.session.AgentName == "" || tc.session.ID == "" {
-		tc.mu.Unlock()
 		return
 	}
 
 	tc.session.ErrorCount++
 	tc.session.Error = append(tc.session.Error, errorMsg)
-
-	tc.mu.Unlock()
 }
 
 // RecordSessionEnd finalizes session tracking

--- a/pkg/telemetry/genai/embedding.go
+++ b/pkg/telemetry/genai/embedding.go
@@ -90,8 +90,8 @@ func (s *EmbeddingSpan) SetInputTokens(n int64) {
 		return
 	}
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.inputTokens = n
-	s.mu.Unlock()
 }
 
 // SetDimensions records the dimensionality of the resulting embedding
@@ -101,8 +101,8 @@ func (s *EmbeddingSpan) SetDimensions(d int) {
 		return
 	}
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.dimensions = d
-	s.mu.Unlock()
 }
 
 // RecordError marks the span as failed and stores `error.type` for the

--- a/pkg/telemetry/genai/runtime.go
+++ b/pkg/telemetry/genai/runtime.go
@@ -92,8 +92,8 @@ func (s *FallbackSpan) IncrementAttempt() {
 		return
 	}
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.attempts++
-	s.mu.Unlock()
 }
 
 // SetFinalModel records the model that ultimately served the response.
@@ -104,8 +104,8 @@ func (s *FallbackSpan) SetFinalModel(model string) {
 		return
 	}
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.final = model
-	s.mu.Unlock()
 }
 
 // RecordError stores an error and an error.type label for the metric.
@@ -131,8 +131,8 @@ func (s *FallbackSpan) SetOutcome(outcome string) {
 		return
 	}
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.outcome = outcome
-	s.mu.Unlock()
 }
 
 // End closes the span and flushes accumulated attributes.
@@ -222,8 +222,8 @@ func (s *RetrievalSpan) SetResultCount(n int) {
 		return
 	}
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.resultCount = n
-	s.mu.Unlock()
 }
 
 // RecordError marks the retrieval span as failed.

--- a/pkg/telemetry/genai/stability.go
+++ b/pkg/telemetry/genai/stability.go
@@ -74,8 +74,8 @@ func CurrentStability() Stability {
 			}
 		}
 		stabilityMu.Lock()
+		defer stabilityMu.Unlock()
 		cachedStability = StabilityDualEmit
-		stabilityMu.Unlock()
 	})
 
 	stabilityMu.Lock()

--- a/pkg/tools/a2a/a2a.go
+++ b/pkg/tools/a2a/a2a.go
@@ -206,9 +206,9 @@ func (t *Toolset) Start(ctx context.Context) error {
 // Stop disconnects from the A2A agent.
 func (t *Toolset) Stop(_ context.Context) error {
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	t.client = nil
 	t.card = nil
-	t.mu.Unlock()
 	return nil
 }
 

--- a/pkg/tools/builtin/lsp/lsp.go
+++ b/pkg/tools/builtin/lsp/lsp.go
@@ -399,8 +399,8 @@ func New(command string, args, env []string, workingDir string, policy ...lifecy
 		// Reset diagnostics on disconnect: the next server may not
 		// re-emit them and stale data is worse than nothing.
 		h.diagnosticsMu.Lock()
+		defer h.diagnosticsMu.Unlock()
 		h.diagnostics = make(map[string][]lspDiagnostic)
-		h.diagnosticsMu.Unlock()
 	}
 	h.supervisor = lifecycle.New("lsp/"+command, &lspConnector{h: h}, base)
 	return &ToolSet{handler: h}
@@ -554,8 +554,8 @@ func (h *lspHandler) snapshotCapabilities() *lspServerCapabilities {
 // capability-filtered list.
 func (t *ToolSet) SetToolsChangedHandler(handler func()) {
 	t.handler.mu.Lock()
+	defer t.handler.mu.Unlock()
 	t.handler.toolsChangedHandler = handler
-	t.handler.mu.Unlock()
 }
 
 // allLSPTools returns the full catalogue of LSP tools backed by h. It is

--- a/pkg/tools/builtin/lsp/lsp_lifecycle.go
+++ b/pkg/tools/builtin/lsp/lsp_lifecycle.go
@@ -158,8 +158,8 @@ func (h *lspHandler) publishSession(cmd *exec.Cmd, stdin io.WriteCloser, stdout 
 	h.capabilities = nil
 	h.serverInfo = nil
 	h.openFilesMu.Lock()
+	defer h.openFilesMu.Unlock()
 	h.openFiles = make(map[string]int)
-	h.openFilesMu.Unlock()
 }
 
 // clearSession is the inverse of publishSession: it nils all session
@@ -189,8 +189,8 @@ func (h *lspHandler) clearSessionLocked() {
 	h.capabilities = nil
 	h.serverInfo = nil
 	h.openFilesMu.Lock()
+	defer h.openFilesMu.Unlock()
 	h.openFiles = make(map[string]int)
-	h.openFilesMu.Unlock()
 }
 
 // fireToolsChanged invokes the registered tools-changed handler if any,

--- a/pkg/tools/builtin/shell/askpass.go
+++ b/pkg/tools/builtin/shell/askpass.go
@@ -416,8 +416,8 @@ func wrapSudoCommand(command, shell string) string {
 
 func (h *shellHandler) setElicitationHandler(handler tools.ElicitationHandler) {
 	h.elicitationMu.Lock()
+	defer h.elicitationMu.Unlock()
 	h.elicitationHandler = handler
-	h.elicitationMu.Unlock()
 }
 
 func (h *shellHandler) currentElicitationHandler() tools.ElicitationHandler {

--- a/pkg/tools/lifecycle/supervisor_test.go
+++ b/pkg/tools/lifecycle/supervisor_test.go
@@ -54,6 +54,7 @@ func (f *fakeSession) waitParked(t *testing.T) {
 
 func (f *fakeSession) Close(context.Context) error {
 	f.mu.Lock()
+	defer f.mu.Unlock()
 	if !f.closed {
 		f.closed = true
 		// Closed sessions return nil from Wait by convention.
@@ -62,7 +63,6 @@ func (f *fakeSession) Close(context.Context) error {
 		default:
 		}
 	}
-	f.mu.Unlock()
 	return nil
 }
 

--- a/pkg/tools/mcp/mcp.go
+++ b/pkg/tools/mcp/mcp.go
@@ -314,8 +314,8 @@ func newSupervisor(ts *Toolset, base lifecycle.Policy) *lifecycle.Supervisor {
 	policy.Logger = slog.With("component", "mcp.supervisor", "server", ts.logID)
 	policy.OnDisconnect = func(error) {
 		ts.mu.Lock()
+		defer ts.mu.Unlock()
 		ts.invalidateCache()
-		ts.mu.Unlock()
 	}
 	policy.OnRestart = func() {
 		// Refresh tool and prompt caches eagerly so subsequent

--- a/pkg/tools/mcp/mcp.go
+++ b/pkg/tools/mcp/mcp.go
@@ -599,8 +599,8 @@ func (c *clientConnector) Connect(ctx context.Context) (lifecycle.Session, error
 
 	slog.DebugContext(ctx, "Started MCP toolset successfully", "server", ts.logID)
 	ts.mu.Lock()
+	defer ts.mu.Unlock()
 	ts.instructions = result.Instructions
-	ts.mu.Unlock()
 
 	return &clientSession{client: ts.mcpClient}, nil
 }
@@ -669,13 +669,13 @@ func (ts *Toolset) Tools(ctx context.Context) ([]tools.Tool, error) {
 	slog.DebugContext(ctx, "Listed MCP tools", "count", len(toolsList), "server", ts.logID)
 
 	ts.mu.Lock()
+	defer ts.mu.Unlock()
 	// Only populate the cache if no invalidation happened while we were
 	// fetching from the server. Otherwise drop the result so the next
 	// caller re-fetches with the latest data.
 	if ts.cacheGen == gen {
 		ts.cachedTools = toolsList
 	}
-	ts.mu.Unlock()
 
 	return toolsList, nil
 }
@@ -971,10 +971,10 @@ func (ts *Toolset) ListPrompts(ctx context.Context) ([]PromptInfo, error) {
 	slog.DebugContext(ctx, "Listed MCP prompts", "count", len(promptsList), "server", ts.logID)
 
 	ts.mu.Lock()
+	defer ts.mu.Unlock()
 	if ts.cacheGen == gen {
 		ts.cachedPrompts = promptsList
 	}
-	ts.mu.Unlock()
 
 	return promptsList, nil
 }

--- a/pkg/tools/mcp/mcp_race_test.go
+++ b/pkg/tools/mcp/mcp_race_test.go
@@ -26,8 +26,8 @@ func TestInstructions_Concurrent(t *testing.T) {
 			// Simulate a concurrent writer (the supervisor's Connect updates
 			// instructions under ts.mu after a successful Initialize).
 			ts.mu.Lock()
+			defer ts.mu.Unlock()
 			ts.instructions = "updated"
-			ts.mu.Unlock()
 		}()
 		go func() {
 			defer wg.Done()

--- a/pkg/tools/mcp/mcp_test.go
+++ b/pkg/tools/mcp/mcp_test.go
@@ -78,8 +78,8 @@ func newReconnectableMock() *reconnectableMockClient {
 
 func (m *reconnectableMockClient) Initialize(context.Context, *mcp.InitializeRequest) (*mcp.InitializeResult, error) {
 	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.waitCh = make(chan struct{}) // fresh channel for each session
-	m.mu.Unlock()
 	return &mcp.InitializeResult{}, nil
 }
 
@@ -93,13 +93,13 @@ func (m *reconnectableMockClient) Wait() error {
 
 func (m *reconnectableMockClient) Close(context.Context) error {
 	m.mu.Lock()
+	defer m.mu.Unlock()
 	// Close the wait channel to unblock Wait().
 	select {
 	case <-m.waitCh:
 	default:
 		close(m.waitCh)
 	}
-	m.mu.Unlock()
 	return nil
 }
 

--- a/pkg/tools/mcp/reconnect_test.go
+++ b/pkg/tools/mcp/reconnect_test.go
@@ -89,6 +89,7 @@ func (m *failingInitClient) Wait() error {
 
 func (m *failingInitClient) Close(context.Context) error {
 	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.waitCh != nil {
 		select {
 		case <-m.waitCh:
@@ -96,7 +97,6 @@ func (m *failingInitClient) Close(context.Context) error {
 			close(m.waitCh)
 		}
 	}
-	m.mu.Unlock()
 	return nil
 }
 

--- a/pkg/tools/mcp/remote.go
+++ b/pkg/tools/mcp/remote.go
@@ -169,8 +169,8 @@ func enrichConnectError(err error, t *oauthTransport) error {
 // In managed mode, the client handles the OAuth flow instead of the server.
 func (c *remoteMCPClient) SetManagedOAuth(managed bool) {
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.managed = managed
-	c.mu.Unlock()
 }
 
 // SetUnmanagedOAuthRedirectURI sets the redirect URI docker-agent advertises
@@ -178,8 +178,8 @@ func (c *remoteMCPClient) SetManagedOAuth(managed bool) {
 // semantics.
 func (c *remoteMCPClient) SetUnmanagedOAuthRedirectURI(uri string) {
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.unmanagedOAuthRedirectURI = uri
-	c.mu.Unlock()
 }
 
 // createHTTPClient creates an HTTP client with custom headers and OAuth support.

--- a/pkg/tools/mcp/session_client.go
+++ b/pkg/tools/mcp/session_client.go
@@ -40,8 +40,8 @@ type sessionClient struct {
 // setSession stores the session under the write lock.
 func (c *sessionClient) setSession(s *gomcp.ClientSession) {
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.session = s
-	c.mu.Unlock()
 }
 
 // ServerAddress returns the connection identifier captured at construction
@@ -88,14 +88,14 @@ func (c *sessionClient) notificationHandlers() (
 
 func (c *sessionClient) SetToolListChangedHandler(handler func()) {
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.toolListChangedHandler = handler
-	c.mu.Unlock()
 }
 
 func (c *sessionClient) SetPromptListChangedHandler(handler func()) {
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.promptListChangedHandler = handler
-	c.mu.Unlock()
 }
 
 func (c *sessionClient) Wait() error {
@@ -278,8 +278,8 @@ func (c *sessionClient) handleElicitationRequest(ctx context.Context, req *gomcp
 // from the MCP server.
 func (c *sessionClient) SetElicitationHandler(handler tools.ElicitationHandler) {
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.elicitationHandler = handler
-	c.mu.Unlock()
 }
 
 // handleSamplingRequest forwards incoming sampling/createMessage requests
@@ -308,8 +308,8 @@ func (c *sessionClient) handleSamplingRequest(ctx context.Context, req *gomcp.Cr
 // from the MCP server.
 func (c *sessionClient) SetSamplingHandler(handler tools.SamplingHandler) {
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.samplingHandler = handler
-	c.mu.Unlock()
 }
 
 // requestElicitation invokes the registered elicitation handler directly.
@@ -341,8 +341,8 @@ func (c *sessionClient) requestElicitation(ctx context.Context, req *gomcp.Elici
 // SetOAuthSuccessHandler sets the handler called when an OAuth flow completes.
 func (c *sessionClient) SetOAuthSuccessHandler(handler func()) {
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.oauthSuccessHandler = handler
-	c.mu.Unlock()
 }
 
 // oauthSuccess invokes the registered OAuth success handler, if any.

--- a/pkg/tools/mcp/tokenstore_factory_test.go
+++ b/pkg/tools/mcp/tokenstore_factory_test.go
@@ -12,8 +12,8 @@ func resetDefaultStore(t *testing.T) {
 	defaultStoreMu.Unlock()
 	t.Cleanup(func() {
 		defaultStoreMu.Lock()
+		defer defaultStoreMu.Unlock()
 		defaultFactory, defaultStore = prevFactory, prevStore
-		defaultStoreMu.Unlock()
 	})
 }
 

--- a/pkg/tui/animation/coordinator.go
+++ b/pkg/tui/animation/coordinator.go
@@ -37,26 +37,25 @@ var globalCoordinator = &Coordinator{}
 // Call this when an animation starts.
 func Register() {
 	globalCoordinator.mu.Lock()
+	defer globalCoordinator.mu.Unlock()
 	globalCoordinator.active++
-	globalCoordinator.mu.Unlock()
 }
 
 // Unregister decrements the active animation count.
 // Call this when an animation stops.
 func Unregister() {
 	globalCoordinator.mu.Lock()
+	defer globalCoordinator.mu.Unlock()
 	if globalCoordinator.active > 0 {
 		globalCoordinator.active--
 	}
-	globalCoordinator.mu.Unlock()
 }
 
 // HasActive returns true if any animations are currently active.
 func HasActive() bool {
 	globalCoordinator.mu.Lock()
-	active := globalCoordinator.active > 0
-	globalCoordinator.mu.Unlock()
-	return active
+	defer globalCoordinator.mu.Unlock()
+	return globalCoordinator.active > 0
 }
 
 // StartTick starts the global animation tick if any animations are active.
@@ -89,9 +88,9 @@ func StartTickIfFirst() tea.Cmd {
 func (c *Coordinator) tickLocked() tea.Cmd {
 	return tea.Tick(time.Second/14, func(time.Time) tea.Msg {
 		c.mu.Lock()
+		defer c.mu.Unlock()
 		c.frame++
 		frame := c.frame
-		c.mu.Unlock()
 		return TickMsg{Frame: frame}
 	})
 }

--- a/pkg/tui/animation/coordinator_test.go
+++ b/pkg/tui/animation/coordinator_test.go
@@ -13,9 +13,9 @@ import (
 func resetGlobalCoordinator(t *testing.T) {
 	t.Helper()
 	globalCoordinator.mu.Lock()
+	defer globalCoordinator.mu.Unlock()
 	globalCoordinator.active = 0
 	globalCoordinator.frame = 0
-	globalCoordinator.mu.Unlock()
 }
 
 func getActiveCount() int32 {

--- a/pkg/tui/components/markdown/fast_renderer.go
+++ b/pkg/tui/components/markdown/fast_renderer.go
@@ -173,8 +173,8 @@ func ResetStyles() {
 	chromaStyleCache.Clear()
 
 	syntaxHighlightCacheMu.Lock()
+	defer syntaxHighlightCacheMu.Unlock()
 	syntaxHighlightCache.Clear()
-	syntaxHighlightCacheMu.Unlock()
 }
 
 func getGlobalStyles() *cachedStyles {
@@ -2409,8 +2409,8 @@ func (p *parser) syntaxHighlight(code, lang string) []token {
 	tokens := p.doSyntaxHighlight(code, lang)
 
 	syntaxHighlightCacheMu.Lock()
+	defer syntaxHighlightCacheMu.Unlock()
 	syntaxHighlightCache.Put(cacheKey, tokens)
-	syntaxHighlightCacheMu.Unlock()
 
 	return tokens
 }

--- a/pkg/tui/components/messages/clipboard.go
+++ b/pkg/tui/components/messages/clipboard.go
@@ -23,18 +23,18 @@ var (
 // copy behavior without touching the developer or CI machine's real clipboard.
 func SetClipboardWriterForTest(fn func(string) error) func() {
 	clipboardMu.Lock()
+	defer clipboardMu.Unlock()
 	prev := writeClipboard
 	if fn == nil {
 		writeClipboard = clipboard.WriteAll
 	} else {
 		writeClipboard = fn
 	}
-	clipboardMu.Unlock()
 
 	return func() {
 		clipboardMu.Lock()
+		defer clipboardMu.Unlock()
 		writeClipboard = prev
-		clipboardMu.Unlock()
 	}
 }
 

--- a/pkg/tui/components/tool/editfile/render.go
+++ b/pkg/tui/components/tool/editfile/render.go
@@ -61,11 +61,11 @@ var (
 // Call this when the theme changes to pick up new colors.
 func InvalidateCaches() {
 	cacheMu.Lock()
+	defer cacheMu.Unlock()
 	cache.Range(func(_ string, c *toolRenderCache) bool {
 		c.renderCached = false
 		return true
 	})
-	cacheMu.Unlock()
 }
 
 type chromaToken struct {

--- a/pkg/tui/components/tool/editfile/render.go
+++ b/pkg/tui/components/tool/editfile/render.go
@@ -112,12 +112,12 @@ func renderEditFile(toolCall tools.ToolCall, width int, splitView bool, toolStat
 	result := renderEditFileUncached(toolCall, width, splitView, toolStatus)
 
 	cacheMu.Lock()
+	defer cacheMu.Unlock()
 	c.rendered = result
 	c.renderCached = true
 	c.renderedWidth = width
 	c.renderedSplit = splitView
 	c.renderedStatus = toolStatus
-	cacheMu.Unlock()
 
 	return result
 }
@@ -165,10 +165,10 @@ func countDiffLines(toolCall tools.ToolCall, _ types.ToolStatus) (added, removed
 	added, removed = countDiffLinesUncached(toolCall)
 
 	cacheMu.Lock()
+	defer cacheMu.Unlock()
 	c.added = added
 	c.removed = removed
 	c.lineCounted = true
-	cacheMu.Unlock()
 
 	return added, removed
 }

--- a/pkg/tui/components/tool/factory_test.go
+++ b/pkg/tui/components/tool/factory_test.go
@@ -24,8 +24,8 @@ func withCleanToolRegistry(t *testing.T) {
 	customMu.Unlock()
 	t.Cleanup(func() {
 		customMu.Lock()
+		defer customMu.Unlock()
 		custom = saved
-		customMu.Unlock()
 	})
 }
 

--- a/pkg/tui/core/keys.go
+++ b/pkg/tui/core/keys.go
@@ -293,6 +293,6 @@ func GetKeys() KeyMap {
 // them. Used by tests and available for a future hot-reload.
 func ResetKeys() {
 	ckMutex.Lock()
+	defer ckMutex.Unlock()
 	cachedKeys = nil
-	ckMutex.Unlock()
 }

--- a/pkg/tui/input/wheel_coalescer.go
+++ b/pkg/tui/input/wheel_coalescer.go
@@ -29,8 +29,8 @@ func NewWheelCoalescer() *WheelCoalescer {
 // SetSender wires the message sender used to emit coalesced events.
 func (c *WheelCoalescer) SetSender(send func(tea.Msg)) {
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.send = send
-	c.mu.Unlock()
 }
 
 // Handle consumes a wheel message and returns true if it was coalesced.

--- a/pkg/tui/styles/theme.go
+++ b/pkg/tui/styles/theme.go
@@ -598,8 +598,8 @@ func LoadTheme(ref string) (*Theme, error) {
 
 	// Store in cache (use full ref as key)
 	themeCacheMu.Lock()
+	defer themeCacheMu.Unlock()
 	themeCache[ref] = entry
-	themeCacheMu.Unlock()
 
 	return theme, nil
 }

--- a/pkg/tui/tui_exit_test.go
+++ b/pkg/tui/tui_exit_test.go
@@ -231,19 +231,19 @@ func (w *blockingWriter) Write(p []byte) (int, error) {
 // reblock installs a new gate so that subsequent writes block again.
 func (w *blockingWriter) reblock() {
 	w.mu.Lock()
+	defer w.mu.Unlock()
 	w.gate = make(chan struct{})
-	w.mu.Unlock()
 }
 
 // unblock releases all pending and future writes.
 func (w *blockingWriter) unblock() {
 	w.mu.Lock()
+	defer w.mu.Unlock()
 	select {
 	case <-w.gate:
 	default:
 		close(w.gate)
 	}
-	w.mu.Unlock()
 }
 
 // quitModel is a minimal bubbletea model that requests alt-screen and quits

--- a/pkg/tui/tuitest/clipboard.go
+++ b/pkg/tui/tuitest/clipboard.go
@@ -17,8 +17,8 @@ func newClipboardStore() (*clipboardStore, func()) {
 	store := &clipboardStore{}
 	restore := messages.SetClipboardWriterForTest(func(s string) error {
 		store.mu.Lock()
+		defer store.mu.Unlock()
 		store.values = append(store.values, s)
-		store.mu.Unlock()
 		return nil
 	})
 	return store, restore

--- a/pkg/tui/tuitest/driver.go
+++ b/pkg/tui/tuitest/driver.go
@@ -72,8 +72,8 @@ type frameStore struct {
 
 func (s *frameStore) push(frame string) {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.frames = append(s.frames, frame)
-	s.mu.Unlock()
 }
 
 // latest returns the most recently captured frame, or "" if none yet.

--- a/pkg/tui/tuitest/driver_test.go
+++ b/pkg/tui/tuitest/driver_test.go
@@ -199,8 +199,8 @@ func TestDebugLiveFrames(t *testing.T) {
 		*liveFrames = origLive
 		*dumpFrames = origDump
 		liveMu.Lock()
+		defer liveMu.Unlock()
 		liveWriter = origWriter
-		liveMu.Unlock()
 	})
 	*liveFrames = true
 	*dumpFrames = false


### PR DESCRIPTION
Scattered across the codebase were terminal `mutex.Unlock()` calls that weren't deferred — written by hand as the last statement before a return, or factored inconsistently. While functionally correct today, this style is fragile: any future edit that adds an early return or a new code path silently loses the unlock.

This change converts those terminal unlocks to `defer mu.Unlock()` immediately after the corresponding `Lock()`, making the critical-section boundary explicit and safe by construction. It also introduces a new `DeferMutexUnlock` lint cop in `lint/` that detects the pattern automatically, so new instances can't sneak in unnoticed.

The cop is deliberately conservative: it ignores short critical sections (≤3 statements) where deferring would obscure rather than clarify, skips cases where the mutex is relocked inside the same block, avoids flagging defers that already exist for the same lock, and does not fire when intervening side-effectful returns would change observable behaviour. `task lint` and `task test` both pass cleanly.