### PR TITLE
Add constructor side-effect lint cops

### DIFF
--- a/cmd/root/new.go
+++ b/cmd/root/new.go
@@ -95,7 +95,7 @@ func runTUI(ctx context.Context, rt runtime.Runtime, sess *session.Session, spaw
 		opts = append(opts, app.WithTitleGenerator(gen))
 	}
 
-	a := app.New(ctx, rt, sess, opts...)
+	a := app.New(rt, sess, opts...)
 
 	coalescer := tuiinput.NewWheelCoalescer()
 	filter := func(model tea.Model, msg tea.Msg) tea.Msg {

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -890,7 +890,8 @@ func (f *runExecFlags) runLeanTUI(ctx context.Context, rt runtime.Runtime, sess 
 	if gen := rt.TitleGenerator(); gen != nil {
 		opts = append(opts, app.WithTitleGenerator(gen))
 	}
-	a := app.New(ctx, rt, sess, opts...)
+	a := app.New(rt, sess, opts...)
+	a.Start(ctx)
 
 	firstMessage, err := readInitialMessage(args)
 	if err != nil {
@@ -1020,7 +1021,7 @@ func (f *runExecFlags) createSessionSpawner(agentSource config.Source, sessStore
 			appOpts = append(appOpts, app.WithSnapshotController(ctrl))
 		}
 
-		a := app.New(spawnCtx, localRt, newSess, appOpts...)
+		a := app.New(localRt, newSess, appOpts...)
 
 		return a, newSess, cleanup, nil
 	}

--- a/e2e/tui/setup_test.go
+++ b/e2e/tui/setup_test.go
@@ -76,7 +76,7 @@ func newTUI(t *testing.T, agentFile string, width, height int, tuiOpts ...tui.Op
 	if gen := rt.TitleGenerator(); gen != nil {
 		appOpts = append(appOpts, app.WithTitleGenerator(gen))
 	}
-	application := app.New(ctx, rt, session.New(), appOpts...)
+	application := app.New(rt, session.New(), appOpts...)
 
 	wd, _ := os.Getwd()
 	model := tui.New(ctx, nil /* no spawner: single tab */, application, wd, func() {}, tuiOpts...)

--- a/examples/golibrary/renderer/main.go
+++ b/examples/golibrary/renderer/main.go
@@ -176,7 +176,7 @@ func run(ctx context.Context) error {
 		session.WithTitle("Repository search demo"),
 		session.WithToolsApproved(true),
 	)
-	a := app.New(ctx, rt, sess, app.WithFirstMessage(firstMessage))
+	a := app.New(rt, sess, app.WithFirstMessage(firstMessage))
 
 	// The one line that matters: a custom renderer for the MCP tool.
 	wd, _ := os.Getwd()

--- a/lint/constructor_command_exec.go
+++ b/lint/constructor_command_exec.go
@@ -21,8 +21,8 @@ import (
 // broad at first and may catch non-exec methods with those names; keep any
 // suppression close to the intentional constructor side effect.
 //
-// Calls inside nested function literals are ignored because the closure body runs
-// when that closure is invoked, not while the constructor itself executes.
+// Calls inside nested function literals are ignored unless the literal is
+// immediately invoked as part of constructor execution.
 //
 // Annotate an intentional case with //rubocop:disable Lint/ConstructorCommandExec.
 var ConstructorCommandExec = &cop.Func{
@@ -96,15 +96,11 @@ func commandExecutionMethodCall(call *ast.CallExpr) (string, bool) {
 }
 
 // forEachConstructionCallExpr invokes fn for every call expression that runs as
-// part of executing body, skipping nested function literals.
+// part of executing body.
 func forEachConstructionCallExpr(body *ast.BlockStmt, fn func(*ast.CallExpr)) {
-	ast.Inspect(body, func(n ast.Node) bool {
-		switch s := n.(type) {
-		case *ast.FuncLit:
-			return false
-		case *ast.CallExpr:
-			fn(s)
+	inspectConstructionBody(body, func(n ast.Node) {
+		if call, ok := n.(*ast.CallExpr); ok {
+			fn(call)
 		}
-		return true
 	})
 }

--- a/lint/constructor_command_exec.go
+++ b/lint/constructor_command_exec.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"go/ast"
+	"go/types"
+
+	"github.com/dgageot/rubocop-go/cop"
+)
+
+// ConstructorCommandExec enforces that constructors do not prepare or run
+// external commands directly.
+//
+// Constructors should assemble state and return it. Creating or executing an
+// exec.Cmd there hides process lifecycle and I/O side effects behind New*, before
+// the caller can decide when to start work, provide cancellation, or handle
+// failures as part of an explicit operation.
+//
+// Detection is intentionally local and direct: calls to os/exec.Command and
+// CommandContext are flagged, as are selector calls named Start, Run, Output, or
+// CombinedOutput in constructor bodies. The selector-call check is deliberately
+// broad at first and may catch non-exec methods with those names; keep any
+// suppression close to the intentional constructor side effect.
+//
+// Calls inside nested function literals are ignored because the closure body runs
+// when that closure is invoked, not while the constructor itself executes.
+//
+// Annotate an intentional case with //rubocop:disable Lint/ConstructorCommandExec.
+var ConstructorCommandExec = &cop.Func{
+	Meta: cop.Meta{
+		Name:        "Lint/ConstructorCommandExec",
+		Description: "constructors (New*) must not create or execute commands",
+		Severity:    cop.Error,
+	},
+	Types: true,
+	Run: func(p *cop.Pass) {
+		p.ForEachFunc(func(fn *ast.FuncDecl) {
+			if !isConstructor(fn) || fn.Body == nil {
+				return
+			}
+			forEachConstructionCallExpr(fn.Body, func(call *ast.CallExpr) {
+				if name, ok := commandConstructorCall(p, call); ok {
+					p.Reportf(call,
+						"constructor %s calls os/exec.%s; move command setup/execution behind an explicit method so process side effects are deliberate",
+						fn.Name.Name, name)
+				}
+				if name, ok := commandExecutionMethodCall(call); ok {
+					p.Reportf(call,
+						"constructor %s calls .%s(); move command execution behind an explicit method so process side effects are deliberate",
+						fn.Name.Name, name)
+				}
+			})
+		})
+	},
+}
+
+func commandConstructorCall(p *cop.Pass, call *ast.CallExpr) (string, bool) {
+	if p.Info != nil {
+		switch fun := call.Fun.(type) {
+		case *ast.SelectorExpr:
+			if name, ok := osExecFuncName(p.Info.Uses[fun.Sel]); ok {
+				return name, true
+			}
+		case *ast.Ident:
+			if name, ok := osExecFuncName(p.Info.Uses[fun]); ok {
+				return name, true
+			}
+		}
+	}
+	return cop.CallTo(call, "exec", "Command", "CommandContext")
+}
+
+func osExecFuncName(obj types.Object) (string, bool) {
+	fn, ok := obj.(*types.Func)
+	if !ok {
+		return "", false
+	}
+	pkg := fn.Pkg()
+	if pkg != nil && pkg.Path() == "os/exec" && (fn.Name() == "Command" || fn.Name() == "CommandContext") {
+		return fn.Name(), true
+	}
+	return "", false
+}
+
+func commandExecutionMethodCall(call *ast.CallExpr) (string, bool) {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return "", false
+	}
+	name := sel.Sel.Name
+	switch name {
+	case "Start", "Run", "Output", "CombinedOutput":
+		return name, true
+	default:
+		return "", false
+	}
+}
+
+// forEachConstructionCallExpr invokes fn for every call expression that runs as
+// part of executing body, skipping nested function literals.
+func forEachConstructionCallExpr(body *ast.BlockStmt, fn func(*ast.CallExpr)) {
+	ast.Inspect(body, func(n ast.Node) bool {
+		switch s := n.(type) {
+		case *ast.FuncLit:
+			return false
+		case *ast.CallExpr:
+			fn(s)
+		}
+		return true
+	})
+}

--- a/lint/constructor_network_io.go
+++ b/lint/constructor_network_io.go
@@ -18,8 +18,8 @@ import (
 // functions in net and net/http are flagged. Method calls such as .Do and
 // .Accept are out of scope for now.
 //
-// Calls inside nested function literals are ignored because the closure body runs
-// when that closure is invoked, not while the constructor itself executes.
+// Calls inside nested function literals are ignored unless the literal is
+// immediately invoked as part of constructor execution.
 //
 // Annotate an intentional case with //rubocop:disable Lint/ConstructorNetworkIO.
 var ConstructorNetworkIO = &cop.Func{

--- a/lint/constructor_network_io.go
+++ b/lint/constructor_network_io.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"go/ast"
+	"go/types"
+
+	"github.com/dgageot/rubocop-go/cop"
+)
+
+// ConstructorNetworkIO enforces that constructors do not perform network I/O.
+//
+// Constructors should assemble state and return it. Dialing, listening, or
+// issuing HTTP requests from New* hides network side effects before the caller
+// can decide when to connect, arrange cancellation, or surface failures from an
+// explicit operation.
+//
+// Detection is intentionally low-noise: only direct calls to selected package
+// functions in net and net/http are flagged. Method calls such as .Do and
+// .Accept are out of scope for now.
+//
+// Calls inside nested function literals are ignored because the closure body runs
+// when that closure is invoked, not while the constructor itself executes.
+//
+// Annotate an intentional case with //rubocop:disable Lint/ConstructorNetworkIO.
+var ConstructorNetworkIO = &cop.Func{
+	Meta: cop.Meta{
+		Name:        "Lint/ConstructorNetworkIO",
+		Description: "constructors (New*) must not perform network I/O",
+		Severity:    cop.Error,
+	},
+	Types: true,
+	Run: func(p *cop.Pass) {
+		p.ForEachFunc(func(fn *ast.FuncDecl) {
+			if !isConstructor(fn) || fn.Body == nil {
+				return
+			}
+			forEachConstructionCallExpr(fn.Body, func(call *ast.CallExpr) {
+				pkg, name, ok := networkIOCall(p, call)
+				if !ok {
+					return
+				}
+				p.Reportf(call,
+					"constructor %s calls %s.%s; move network I/O out of New into Start/Connect or the first request path",
+					fn.Name.Name, pkg, name)
+			})
+		})
+	},
+}
+
+func networkIOCall(p *cop.Pass, call *ast.CallExpr) (string, string, bool) {
+	if p.Info != nil {
+		switch fun := call.Fun.(type) {
+		case *ast.SelectorExpr:
+			if pkg, name, ok := networkIOFuncName(p.Info.Uses[fun.Sel]); ok {
+				return pkg, name, true
+			}
+		case *ast.Ident:
+			if pkg, name, ok := networkIOFuncName(p.Info.Uses[fun]); ok {
+				return pkg, name, true
+			}
+		}
+	}
+
+	if name, ok := cop.CallTo(call, "net", "Dial", "DialTimeout", "Listen", "ListenPacket", "ListenTCP", "ListenUDP", "ListenUnix"); ok {
+		return "net", name, true
+	}
+	if name, ok := cop.CallTo(call, "http", "Get", "Head", "Post", "PostForm"); ok {
+		return "http", name, true
+	}
+	return "", "", false
+}
+
+func networkIOFuncName(obj types.Object) (string, string, bool) {
+	fn, ok := obj.(*types.Func)
+	if !ok {
+		return "", "", false
+	}
+	pkg := fn.Pkg()
+	if pkg == nil {
+		return "", "", false
+	}
+	name := fn.Name()
+	switch pkg.Path() {
+	case "net":
+		switch name {
+		case "Dial", "DialTimeout", "Listen", "ListenPacket", "ListenTCP", "ListenUDP", "ListenUnix":
+			return "net", name, true
+		}
+	case "net/http":
+		switch name {
+		case "Get", "Head", "Post", "PostForm":
+			return "http", name, true
+		}
+	}
+	return "", "", false
+}

--- a/lint/constructor_purity.go
+++ b/lint/constructor_purity.go
@@ -25,8 +25,9 @@ import (
 // as part of construction are flagged. A `go` nested inside a function
 // literal that the constructor merely returns or stores runs when that
 // closure is later invoked, not at construction time, so it is intentionally
-// ignored. Goroutines started indirectly through a helper call are out of
-// scope — catching those would require call-graph analysis.
+// ignored. Immediately-invoked function literals are inspected because they
+// do run during construction. Goroutines started indirectly through a helper
+// call are out of scope — catching those would require call-graph analysis.
 //
 // Annotate an intentional case with //rubocop:disable Lint/ConstructorPurity.
 var ConstructorPurity = &cop.Func{
@@ -68,18 +69,62 @@ func isConstructorName(name string) bool {
 	return name == "New" || (len(name) > 3 && name[:3] == "New" && name[3] >= 'A' && name[3] <= 'Z')
 }
 
-// forEachConstructionGoStmt invokes fn for every `go` statement that runs as
-// part of executing body, skipping any nested inside a function literal: a
-// closure's body runs when the closure is called, not when the constructor
-// returns it.
-func forEachConstructionGoStmt(body *ast.BlockStmt, fn func(*ast.GoStmt)) {
-	ast.Inspect(body, func(n ast.Node) bool {
+// inspectConstructionBody walks body and visits nodes that run as part of
+// executing the constructor. Nested function literals are skipped unless they
+// are immediately invoked (func() { ... })(), in which case their body runs
+// during construction and is inspected.
+func inspectConstructionBody(body *ast.BlockStmt, visit func(ast.Node)) {
+	if body == nil {
+		return
+	}
+	inspectConstructionNode(body, visit)
+}
+
+func inspectConstructionNode(root ast.Node, visit func(ast.Node)) {
+	ast.Inspect(root, func(n ast.Node) bool {
 		switch s := n.(type) {
+		case nil:
+			return true
 		case *ast.FuncLit:
 			return false
 		case *ast.GoStmt:
-			fn(s)
+			visit(s)
+			return false
+		case *ast.CallExpr:
+			visit(s)
+			if fl := calledFuncLit(s.Fun); fl != nil {
+				for _, arg := range s.Args {
+					inspectConstructionNode(arg, visit)
+				}
+				inspectConstructionNode(fl.Body, visit)
+				return false
+			}
+		default:
+			visit(s)
 		}
 		return true
+	})
+}
+
+func calledFuncLit(expr ast.Expr) *ast.FuncLit {
+	for {
+		switch e := expr.(type) {
+		case *ast.FuncLit:
+			return e
+		case *ast.ParenExpr:
+			expr = e.X
+		default:
+			return nil
+		}
+	}
+}
+
+// forEachConstructionGoStmt invokes fn for every `go` statement that runs as
+// part of executing body.
+func forEachConstructionGoStmt(body *ast.BlockStmt, fn func(*ast.GoStmt)) {
+	inspectConstructionBody(body, func(n ast.Node) {
+		if g, ok := n.(*ast.GoStmt); ok {
+			fn(g)
+		}
 	})
 }

--- a/lint/constructor_purity.go
+++ b/lint/constructor_purity.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"go/ast"
+
+	"github.com/dgageot/rubocop-go/cop"
+)
+
+// ConstructorPurity enforces that constructors do not start goroutines.
+//
+// A constructor here is a top-level function (no receiver) named New or
+// New<Something> that returns at least one value — the standard Go naming
+// convention. Such functions should wire up and return state; they should
+// not own a background lifecycle. A `go …` in a constructor means the
+// goroutine starts the instant the value is built, before the caller can
+// configure it, decide not to use it, or arrange for it to be stopped. The
+// caller has no handle to that goroutine and no way to wait for it or shut
+// it down, which leaks goroutines in tests and makes shutdown racy.
+//
+// The fix is to defer the spawn to an explicit Start/Run method (or to
+// accept a context the goroutine honours), so that starting background work
+// is a deliberate, observable step rather than a hidden effect of New.
+//
+// Detection is body-local and syntactic: only `go` statements that execute
+// as part of construction are flagged. A `go` nested inside a function
+// literal that the constructor merely returns or stores runs when that
+// closure is later invoked, not at construction time, so it is intentionally
+// ignored. Goroutines started indirectly through a helper call are out of
+// scope — catching those would require call-graph analysis.
+//
+// Annotate an intentional case with //rubocop:disable Lint/ConstructorPurity.
+var ConstructorPurity = &cop.Func{
+	Meta: cop.Meta{
+		Name:        "Lint/ConstructorPurity",
+		Description: "constructors (New*) must not start goroutines",
+		Severity:    cop.Error,
+	},
+	Run: func(p *cop.Pass) {
+		p.ForEachFunc(func(fn *ast.FuncDecl) {
+			if !isConstructor(fn) || fn.Body == nil {
+				return
+			}
+			forEachConstructionGoStmt(fn.Body, func(g *ast.GoStmt) {
+				p.Reportf(g,
+					"constructor %s starts a goroutine; defer this to a Start/Run method"+
+						" so background work is started deliberately and can be stopped",
+					fn.Name.Name)
+			})
+		})
+	},
+}
+
+// isConstructor reports whether fn is a plain top-level function named New or
+// New<Something> (the next rune after "New" is upper-case) that returns at
+// least one result.
+func isConstructor(fn *ast.FuncDecl) bool {
+	if fn.Recv != nil || fn.Name == nil {
+		return false
+	}
+	name := fn.Name.Name
+	if !isConstructorName(name) {
+		return false
+	}
+	return fn.Type.Results != nil && len(fn.Type.Results.List) > 0
+}
+
+func isConstructorName(name string) bool {
+	return name == "New" || (len(name) > 3 && name[:3] == "New" && name[3] >= 'A' && name[3] <= 'Z')
+}
+
+// forEachConstructionGoStmt invokes fn for every `go` statement that runs as
+// part of executing body, skipping any nested inside a function literal: a
+// closure's body runs when the closure is called, not when the constructor
+// returns it.
+func forEachConstructionGoStmt(body *ast.BlockStmt, fn func(*ast.GoStmt)) {
+	ast.Inspect(body, func(n ast.Node) bool {
+		switch s := n.(type) {
+		case *ast.FuncLit:
+			return false
+		case *ast.GoStmt:
+			fn(s)
+		}
+		return true
+	})
+}

--- a/lint/main.go
+++ b/lint/main.go
@@ -30,6 +30,7 @@ var cops = []cop.Cop{
 	HookBuiltinsRegistered,
 	SlogContextual,
 	ConstructorPurity,
+	ConstructorCommandExec,
 }
 
 func main() {

--- a/lint/main.go
+++ b/lint/main.go
@@ -29,6 +29,7 @@ var cops = []cop.Cop{
 	HookConfigSync,
 	HookBuiltinsRegistered,
 	SlogContextual,
+	ConstructorPurity,
 }
 
 func main() {

--- a/lint/main.go
+++ b/lint/main.go
@@ -31,6 +31,7 @@ var cops = []cop.Cop{
 	SlogContextual,
 	ConstructorPurity,
 	ConstructorCommandExec,
+	ConstructorNetworkIO,
 }
 
 func main() {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -50,6 +50,7 @@ type App struct {
 	titleGen               *sessiontitle.Generator     // Title generator for local runtime (nil for remote)
 	snapshotController     builtins.SnapshotController // Drives /undo, /snapshots, /reset; nil for runtimes that don't capture snapshots
 
+	startOnce  sync.Once
 	subsMu     sync.Mutex
 	subs       []chan tea.Msg
 	fanoutOnce sync.Once
@@ -117,7 +118,7 @@ func WithSnapshotController(c builtins.SnapshotController) Opt {
 	}
 }
 
-func New(ctx context.Context, rt runtime.Runtime, sess *session.Session, opts ...Opt) *App {
+func New(rt runtime.Runtime, sess *session.Session, opts ...Opt) *App {
 	app := &App{
 		runtime:          rt,
 		session:          sess,
@@ -129,34 +130,41 @@ func New(ctx context.Context, rt runtime.Runtime, sess *session.Session, opts ..
 		opt(app)
 	}
 
-	// Emit startup info (agent, team, tools) through the events channel.
-	// This runs in the background so the TUI can start immediately while
-	// slow operations (like MCP tool loading) complete asynchronously.
-	go func() {
-		startupEvents := make(chan runtime.Event, 10)
-		go func() {
-			defer close(startupEvents)
-			rt.EmitStartupInfo(ctx, sess, runtime.NewChannelSink(startupEvents))
-		}()
-		for event := range startupEvents {
-			select {
-			case app.events <- event:
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
-
-	// Subscribe to tool list changes so the sidebar updates immediately
-	// when an MCP server adds or removes tools (outside of a RunStream).
-	rt.OnToolsChanged(func(event runtime.Event) {
-		select {
-		case app.events <- event:
-		case <-ctx.Done():
-		}
-	})
-
 	return app
+}
+
+// Start begins App-owned background event producers. Construction stays cheap
+// and side-effect free; embedders call Start when the App enters a managed
+// lifecycle.
+func (a *App) Start(ctx context.Context) {
+	a.startOnce.Do(func() {
+		// Emit startup info (agent, team, tools) through the events channel.
+		// This runs in the background so the TUI can start immediately while
+		// slow operations (like MCP tool loading) complete asynchronously.
+		go func() {
+			startupEvents := make(chan runtime.Event, 10)
+			go func() {
+				defer close(startupEvents)
+				a.runtime.EmitStartupInfo(ctx, a.session, runtime.NewChannelSink(startupEvents))
+			}()
+			for event := range startupEvents {
+				select {
+				case a.events <- event:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+
+		// Subscribe to tool list changes so the sidebar updates immediately
+		// when an MCP server adds or removes tools (outside of a RunStream).
+		a.runtime.OnToolsChanged(func(event runtime.Event) {
+			select {
+			case a.events <- event:
+			case <-ctx.Done():
+			}
+		})
+	})
 }
 
 func (a *App) SendFirstMessage() tea.Cmd {

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -195,14 +195,13 @@ var _ builtins.SnapshotController = (*stubSnapshotController)(nil)
 func TestApp_NewSession_PreservesToolsApproved(t *testing.T) {
 	t.Parallel()
 
-	ctx := t.Context()
 	rt := &mockRuntime{}
 
 	// Create initial session with tools approved
 	initialSess := session.New(session.WithToolsApproved(true))
 	require.True(t, initialSess.ToolsApproved, "Initial session should have tools approved")
 
-	app := New(ctx, rt, initialSess)
+	app := New(rt, initialSess)
 
 	// Call NewSession - should preserve ToolsApproved
 	app.NewSession()
@@ -213,14 +212,13 @@ func TestApp_NewSession_PreservesToolsApproved(t *testing.T) {
 func TestApp_NewSession_PreservesHideToolResults(t *testing.T) {
 	t.Parallel()
 
-	ctx := t.Context()
 	rt := &mockRuntime{}
 
 	// Create initial session with hide tool results
 	initialSess := session.New(session.WithHideToolResults(true))
 	require.True(t, initialSess.HideToolResults, "Initial session should have HideToolResults")
 
-	app := New(ctx, rt, initialSess)
+	app := New(rt, initialSess)
 
 	// Call NewSession - should preserve HideToolResults
 	app.NewSession()
@@ -322,7 +320,7 @@ func TestApp_ResolveSkillCommand_NoLocalRuntime(t *testing.T) {
 	ctx := t.Context()
 	rt := &mockRuntime{}
 	sess := session.New()
-	app := New(ctx, rt, sess)
+	app := New(rt, sess)
 
 	// mockRuntime is not a LocalRuntime, so no skills should be returned
 	resolved, err := app.ResolveSkillCommand(ctx, "/some-skill")
@@ -336,7 +334,7 @@ func TestApp_ResolveSkillCommand_NotSlashCommand(t *testing.T) {
 	ctx := t.Context()
 	rt := &mockRuntime{}
 	sess := session.New()
-	app := New(ctx, rt, sess)
+	app := New(rt, sess)
 
 	resolved, err := app.ResolveSkillCommand(ctx, "not a slash command")
 	require.NoError(t, err)
@@ -347,7 +345,7 @@ func TestApp_UndoLastSnapshot(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
-	app := New(ctx, &mockRuntime{}, session.New(),
+	app := New(&mockRuntime{}, session.New(),
 		WithSnapshotController(&stubSnapshotController{enabled: true, files: 2, ok: true}),
 	)
 	result, err := app.UndoLastSnapshot(ctx)
@@ -359,7 +357,7 @@ func TestApp_UndoLastSnapshot_NoSnapshot(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
-	app := New(ctx, &mockRuntime{}, session.New(),
+	app := New(&mockRuntime{}, session.New(),
 		WithSnapshotController(&stubSnapshotController{enabled: true}),
 	)
 	_, err := app.UndoLastSnapshot(ctx)
@@ -373,7 +371,7 @@ func TestApp_UndoLastSnapshot_NoController(t *testing.T) {
 	// so the same UI affordance can light up regardless of which
 	// runtime the embedder paired the App with.
 	ctx := t.Context()
-	app := New(ctx, &mockRuntime{}, session.New())
+	app := New(&mockRuntime{}, session.New())
 	_, err := app.UndoLastSnapshot(ctx)
 	require.ErrorIs(t, err, ErrNothingToUndo)
 	assert.False(t, app.SnapshotsEnabled())
@@ -399,7 +397,7 @@ func TestApp_SubscribeWith_FanOutToMultipleSubscribers(t *testing.T) {
 	defer cancel()
 
 	rt := &mockRuntime{}
-	app := New(ctx, rt, session.New())
+	app := New(rt, session.New())
 
 	recv := func() (chan tea.Msg, context.CancelFunc) {
 		subCtx, subCancel := context.WithCancel(ctx)

--- a/pkg/app/app_working_dir_test.go
+++ b/pkg/app/app_working_dir_test.go
@@ -12,13 +12,12 @@ import (
 func TestApp_NewSession_PreservesWorkingDir(t *testing.T) {
 	t.Parallel()
 
-	ctx := t.Context()
 	rt := &mockRuntime{}
 
 	initialSess := session.New(
 		session.WithWorkingDir("/projects/myapp"),
 	)
-	app := New(ctx, rt, initialSess)
+	app := New(rt, initialSess)
 	require.Equal(t, "/projects/myapp", app.Session().WorkingDir)
 
 	app.NewSession()
@@ -32,7 +31,6 @@ func TestApp_NewSession_PreservesWorkingDir(t *testing.T) {
 func TestApp_NewSession_PreservesAllSessionFlags(t *testing.T) {
 	t.Parallel()
 
-	ctx := t.Context()
 	rt := &mockRuntime{}
 
 	initialSess := session.New(
@@ -40,7 +38,7 @@ func TestApp_NewSession_PreservesAllSessionFlags(t *testing.T) {
 		session.WithHideToolResults(true),
 		session.WithWorkingDir("/work"),
 	)
-	app := New(ctx, rt, initialSess)
+	app := New(rt, initialSess)
 
 	app.NewSession()
 

--- a/pkg/app/skills_fork_test.go
+++ b/pkg/app/skills_fork_test.go
@@ -111,7 +111,7 @@ func TestApp_SlashSkill_ForkContext_DispatchesToRunSkillFork(t *testing.T) {
 	sess := session.New(session.WithUserMessage("hi there"))
 	require.Equal(t, 1, sess.MessageCount())
 
-	a := New(ctx, rt, sess)
+	a := New(rt, sess)
 
 	// Detection.
 	skillName, task, ok := a.SkillCommandFork(ctx, "/commit please commit")
@@ -166,7 +166,7 @@ func TestApp_SlashSkill_InlineContext_StillInlines(t *testing.T) {
 	}
 
 	ctx := t.Context()
-	a := New(ctx, rt, session.New())
+	a := New(rt, session.New())
 
 	_, _, ok := a.SkillCommandFork(ctx, "/review the diff")
 	assert.False(t, ok)
@@ -210,7 +210,7 @@ func TestApp_SlashSkill_NonFork_E2E(t *testing.T) {
 	sess := session.New(session.WithUserMessage("hi there"))
 	require.Equal(t, 1, sess.MessageCount())
 
-	a := New(ctx, rt, sess)
+	a := New(rt, sess)
 
 	// Same dispatch as chat.processMessage.
 	input := "/review carefully"

--- a/pkg/leantui/update_test.go
+++ b/pkg/leantui/update_test.go
@@ -104,7 +104,7 @@ var _ runtime.Runtime = (*cycleThinkingRuntime)(nil)
 func TestShiftTabCyclesThinkingLevel(t *testing.T) {
 	rt := &cycleThinkingRuntime{supports: true, level: effort.High}
 	m := bareModel(24)
-	m.app = app.New(t.Context(), rt, session.New())
+	m.app = app.New(rt, session.New())
 
 	m.handleKey(t.Context(), key{typ: keyShiftTab})
 
@@ -116,7 +116,7 @@ func TestShiftTabCyclesThinkingLevel(t *testing.T) {
 func TestShiftTabReportsUnsupportedThinkingLevel(t *testing.T) {
 	rt := &cycleThinkingRuntime{supports: true, err: runtime.ErrUnsupported}
 	m := bareModel(24)
-	m.app = app.New(t.Context(), rt, session.New())
+	m.app = app.New(rt, session.New())
 
 	m.handleKey(t.Context(), key{typ: keyShiftTab})
 

--- a/pkg/model/provider/gemini/adapter.go
+++ b/pkg/model/provider/gemini/adapter.go
@@ -170,9 +170,22 @@ func (g *StreamAdapter) send(res result) bool {
 
 // Recv gets the next Gemini content chunk
 func (g *StreamAdapter) Recv() (chat.MessageStreamResponse, error) {
+	select {
+	case <-g.done:
+		return chat.MessageStreamResponse{}, io.EOF
+	default:
+	}
+
 	g.start()
-	res, ok := <-g.ch
-	if !ok {
+
+	var res result
+	select {
+	case r, ok := <-g.ch:
+		if !ok {
+			return chat.MessageStreamResponse{}, io.EOF
+		}
+		res = r
+	case <-g.done:
 		return chat.MessageStreamResponse{}, io.EOF
 	}
 

--- a/pkg/model/provider/gemini/adapter.go
+++ b/pkg/model/provider/gemini/adapter.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/google/uuid"
 	"google.golang.org/genai"
@@ -21,7 +22,11 @@ const http2BodyClosedError = "http2: response body closed"
 
 // StreamAdapter adapts the Gemini streaming iterator to chat.MessageStream
 type StreamAdapter struct {
+	iter       func(func(*genai.GenerateContentResponse, error) bool)
 	ch         chan result
+	done       chan struct{}
+	startOnce  sync.Once
+	closeOnce  sync.Once
 	model      string
 	trackUsage bool
 }
@@ -34,112 +39,138 @@ type result struct {
 
 // NewStreamAdapter constructs a StreamAdapter from Gemini's iterator
 func NewStreamAdapter(iter func(func(*genai.GenerateContentResponse, error) bool), model string, trackUsage bool) *StreamAdapter {
-	adapter := &StreamAdapter{
+	return &StreamAdapter{
+		iter:       iter,
 		ch:         make(chan result),
+		done:       make(chan struct{}),
 		model:      model,
 		trackUsage: trackUsage,
 	}
+}
 
-	go func() {
-		defer close(adapter.ch)
+func (g *StreamAdapter) start() {
+	g.startOnce.Do(func() {
+		go g.run()
+	})
+}
 
-		hasContent := false
-		hasToolCalls := false
-		var lastResponse *genai.GenerateContentResponse
+func (g *StreamAdapter) run() {
+	defer close(g.ch)
 
-		// Consume the iterator
-		iter(func(resp *genai.GenerateContentResponse, err error) bool {
-			// Skip noisy http2 errors
-			if err != nil && err.Error() == http2BodyClosedError {
-				return true
-			}
+	hasContent := false
+	hasToolCalls := false
+	var lastResponse *genai.GenerateContentResponse
 
-			// Handle streaming parser errors from new Gemini 2.5 response fields
-			if err != nil {
-				errMsg := err.Error()
-				// Check if this is a streaming chunk parsing error that contains valid response data
-				if strings.Contains(errMsg, "invalid stream chunk") && strings.Contains(errMsg, `"text":`) {
-					// Try to extract text content from the error message
-					if textContent := extractTextFromError(errMsg); textContent != "" {
-						// Create a synthetic response with the extracted text
-						adapter.ch <- result{resp: &genai.GenerateContentResponse{
-							Candidates: []*genai.Candidate{
-								{
-									Content: &genai.Content{
-										Parts: []*genai.Part{
-											{Text: textContent},
-										},
+	// Consume the iterator
+	g.iter(func(resp *genai.GenerateContentResponse, err error) bool {
+		// Skip noisy http2 errors
+		if err != nil && err.Error() == http2BodyClosedError {
+			return true
+		}
+
+		// Handle streaming parser errors from new Gemini 2.5 response fields
+		if err != nil {
+			errMsg := err.Error()
+			// Check if this is a streaming chunk parsing error that contains valid response data
+			if strings.Contains(errMsg, "invalid stream chunk") && strings.Contains(errMsg, `"text":`) {
+				// Try to extract text content from the error message
+				if textContent := extractTextFromError(errMsg); textContent != "" {
+					// Create a synthetic response with the extracted text
+					if !g.send(result{resp: &genai.GenerateContentResponse{
+						Candidates: []*genai.Candidate{
+							{
+								Content: &genai.Content{
+									Parts: []*genai.Part{
+										{Text: textContent},
 									},
 								},
 							},
-						}}
-						hasContent = true
+						},
+					}}) {
+						return false
+					}
+					hasContent = true
 
-						// Check if this appears to be a complete response (has finishReason)
-						if strings.Contains(errMsg, `"finishReason"`) {
-							// This is the final chunk, send done signal
-							adapter.ch <- result{done: true}
+					// Check if this appears to be a complete response (has finishReason)
+					if strings.Contains(errMsg, `"finishReason"`) {
+						// This is the final chunk, send done signal
+						if !g.send(result{done: true}) {
 							return false
 						}
-
-						// Continue iteration to potentially get more chunks
-						return true
+						return false
 					}
-				}
 
-				adapter.ch <- result{err: err}
+					// Continue iteration to potentially get more chunks
+					return true
+				}
+			}
+
+			if !g.send(result{err: err}) {
 				return false
 			}
+			return false
+		}
 
-			if resp != nil {
-				// Check for text content without using Text() to avoid warnings
-				hasText := false
-				for _, candidate := range resp.Candidates {
-					if candidate.Content != nil {
-						for _, part := range candidate.Content.Parts {
-							if part.Text != "" {
-								hasText = true
-								break
-							}
+		if resp != nil {
+			// Check for text content without using Text() to avoid warnings
+			hasText := false
+			for _, candidate := range resp.Candidates {
+				if candidate.Content != nil {
+					for _, part := range candidate.Content.Parts {
+						if part.Text != "" {
+							hasText = true
+							break
 						}
 					}
-					if hasText {
-						break
-					}
 				}
-
-				// Check for function calls
-				hasFuncs := len(resp.FunctionCalls()) > 0
-				// Gemini 3 can emit usage metadata on chunks without text/tool
-				// calls. Forward such chunks so downstream can capture token usage.
-				hasUsage := resp.UsageMetadata != nil
-
-				// Send response if it has content, function calls, or usage metadata
-				if hasText || hasFuncs || hasUsage {
-					hasContent = hasContent || hasText
-					hasToolCalls = hasToolCalls || hasFuncs
-					lastResponse = resp // Store for final message
-					adapter.ch <- result{resp: resp}
+				if hasText {
+					break
 				}
 			}
 
-			return true
-		})
+			// Check for function calls
+			hasFuncs := len(resp.FunctionCalls()) > 0
+			// Gemini 3 can emit usage metadata on chunks without text/tool
+			// calls. Forward such chunks so downstream can capture token usage.
+			hasUsage := resp.UsageMetadata != nil
 
-		// Send final message with appropriate stop reason
-		if hasContent || hasToolCalls {
-			if lastResponse == nil {
-				lastResponse = &genai.GenerateContentResponse{}
+			// Send response if it has content, function calls, or usage metadata
+			if hasText || hasFuncs || hasUsage {
+				hasContent = hasContent || hasText
+				hasToolCalls = hasToolCalls || hasFuncs
+				lastResponse = resp // Store for final message
+				if !g.send(result{resp: resp}) {
+					return false
+				}
 			}
-			adapter.ch <- result{done: true, resp: lastResponse}
 		}
-	}()
 
-	return adapter
+		return true
+	})
+
+	// Send final message with appropriate stop reason
+	if hasContent || hasToolCalls {
+		if lastResponse == nil {
+			lastResponse = &genai.GenerateContentResponse{}
+		}
+		if !g.send(result{done: true, resp: lastResponse}) {
+			return
+		}
+	}
+}
+
+func (g *StreamAdapter) send(res result) bool {
+	select {
+	case g.ch <- res:
+		return true
+	case <-g.done:
+		return false
+	}
 }
 
 // Recv gets the next Gemini content chunk
 func (g *StreamAdapter) Recv() (chat.MessageStreamResponse, error) {
+	g.start()
 	res, ok := <-g.ch
 	if !ok {
 		return chat.MessageStreamResponse{}, io.EOF
@@ -242,11 +273,9 @@ func (g *StreamAdapter) Recv() (chat.MessageStreamResponse, error) {
 
 // Close closes the stream
 func (g *StreamAdapter) Close() {
-	// Drain channel to let goroutine exit
-	go func() {
-		for range g.ch {
-		}
-	}()
+	g.closeOnce.Do(func() {
+		close(g.done)
+	})
 }
 
 // extractTextFromError attempts to extract text content from streaming parsing errors

--- a/pkg/model/provider/gemini/adapter_test.go
+++ b/pkg/model/provider/gemini/adapter_test.go
@@ -1,6 +1,7 @@
 package gemini
 
 import (
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -8,6 +9,19 @@ import (
 
 	"github.com/docker/docker-agent/pkg/chat"
 )
+
+func TestStreamAdapter_CloseBeforeRecv(t *testing.T) {
+	called := false
+	adapter := NewStreamAdapter(func(func(*genai.GenerateContentResponse, error) bool) {
+		called = true
+	}, "test-model", true)
+
+	adapter.Close()
+	_, err := adapter.Recv()
+
+	require.ErrorIs(t, err, io.EOF)
+	require.False(t, called, "Recv after Close must not start the upstream iterator")
+}
 
 func TestStreamAdapter_GeminiUsageMetadata(t *testing.T) {
 	// Gemini 3 (and any future model that emits usage metadata on its own chunk

--- a/pkg/tui/page/chat/queue_test.go
+++ b/pkg/tui/page/chat/queue_test.go
@@ -205,7 +205,7 @@ func TestQueueFlow_BusyAgent_BangCommandBypassesQueue(t *testing.T) {
 	t.Parallel()
 
 	sess := session.New()
-	p := New(app.New(t.Context(), queueTestRuntime{}, sess), service.NewSessionState(sess)).(*chatPage)
+	p := New(app.New(queueTestRuntime{}, sess), service.NewSessionState(sess)).(*chatPage)
 	p.working = true
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
@@ -237,7 +237,7 @@ func TestQueueFlow_SkillCommand_DispatchesOnceWithoutLooping(t *testing.T) {
 	t.Parallel()
 
 	sess := session.New()
-	p := New(app.New(t.Context(), queueTestRuntime{}, sess), service.NewSessionState(sess)).(*chatPage)
+	p := New(app.New(queueTestRuntime{}, sess), service.NewSessionState(sess)).(*chatPage)
 
 	calls := 0
 	p.commandParser = commands.NewParser(commands.Category{
@@ -396,7 +396,7 @@ func TestReadOnly_RejectsMessages(t *testing.T) {
 	t.Parallel()
 
 	sess := session.New()
-	a := app.New(t.Context(), queueTestRuntime{}, sess, app.WithReadOnly())
+	a := app.New(queueTestRuntime{}, sess, app.WithReadOnly())
 	require.True(t, a.IsReadOnly())
 
 	p := New(a, service.NewSessionState(sess)).(*chatPage)
@@ -411,7 +411,7 @@ func TestReadOnly_AllowsSlashCommands(t *testing.T) {
 	t.Parallel()
 
 	sess := session.New()
-	a := app.New(t.Context(), queueTestRuntime{}, sess, app.WithReadOnly())
+	a := app.New(queueTestRuntime{}, sess, app.WithReadOnly())
 	p := New(a, service.NewSessionState(sess)).(*chatPage)
 	p.commandParser = commands.NewParser(commands.Category{
 		Name: "Test",
@@ -489,7 +489,7 @@ func TestHandleSendMsg_ForkSkillRunsViaFork(t *testing.T) {
 	}}, t.TempDir())
 	rt := &skillDispatchRuntime{skillset: skillSet}
 	sess := session.New()
-	p := New(app.New(t.Context(), rt, sess), service.NewSessionState(sess)).(*chatPage)
+	p := New(app.New(rt, sess), service.NewSessionState(sess)).(*chatPage)
 	p.commandParser = skillCommandParser("services")
 
 	dispatchTypedSkill(t, p, "/services please")
@@ -514,7 +514,7 @@ func TestHandleSendMsg_InlineSkillRunsViaResolveInput(t *testing.T) {
 	}}, t.TempDir())
 	rt := &skillDispatchRuntime{skillset: skillSet}
 	sess := session.New()
-	p := New(app.New(t.Context(), rt, sess), service.NewSessionState(sess)).(*chatPage)
+	p := New(app.New(rt, sess), service.NewSessionState(sess)).(*chatPage)
 	p.commandParser = skillCommandParser("services")
 
 	dispatchTypedSkill(t, p, "/services please")
@@ -535,7 +535,7 @@ func TestReadOnly_RejectsBypassQueueCommands(t *testing.T) {
 	t.Parallel()
 
 	sess := session.New()
-	a := app.New(t.Context(), queueTestRuntime{}, sess, app.WithReadOnly())
+	a := app.New(queueTestRuntime{}, sess, app.WithReadOnly())
 	p := New(a, service.NewSessionState(sess)).(*chatPage)
 
 	_, cmd := p.handleSendMsg(messages.SendMsg{Content: "/myskill", BypassQueue: true})

--- a/pkg/tui/service/supervisor/supervisor.go
+++ b/pkg/tui/service/supervisor/supervisor.go
@@ -85,6 +85,9 @@ func (s *Supervisor) AddSession(ctx context.Context, a *app.App, sess *session.S
 	// Create a cancellable context for this session
 	sessionCtx, cancel := context.WithCancel(ctx)
 	runner.cancel = cancel
+	if a != nil {
+		a.Start(sessionCtx)
+	}
 
 	s.runners[sess.ID] = runner
 	s.order = append(s.order, sess.ID)
@@ -94,7 +97,9 @@ func (s *Supervisor) AddSession(ctx context.Context, a *app.App, sess *session.S
 	}
 
 	// Start the subscription goroutine with routing
-	go s.subscribeWithRouting(sessionCtx, a, sess.ID)
+	if a != nil {
+		go s.subscribeWithRouting(sessionCtx, a, sess.ID)
+	}
 
 	return sess.ID
 }
@@ -355,6 +360,7 @@ func (s *Supervisor) ReplaceRunnerApp(ctx context.Context, sessionID string, new
 	// Create a new cancellable context for the replacement.
 	sessionCtx, cancel := context.WithCancel(ctx)
 	runner.cancel = cancel
+	newApp.Start(sessionCtx)
 
 	s.notifyTabsUpdated()
 	s.mu.Unlock()

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	goruntime "runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"charm.land/bubbles/v2/help"
@@ -66,6 +67,7 @@ const (
 // Model is the top-level TUI model that wraps the chat page.
 type appModel struct {
 	shutdownDone <-chan struct{}
+	cleanupOnce  sync.Once
 
 	supervisor *supervisor.Supervisor
 	tabBar     *tabbar.TabBar
@@ -528,10 +530,7 @@ func (m *appModel) contextShutdownCmd() tea.Cmd {
 	return func() tea.Msg {
 		go func() {
 			<-m.shutdownDone
-			if m.tuiStore != nil {
-				_ = m.tuiStore.Close()
-			}
-			m.supervisor.Shutdown()
+			m.cleanupManagedResources()
 		}()
 		return nil
 	}
@@ -2546,6 +2545,20 @@ var exitFunc = os.Exit
 
 var shutdownTimeout = 5 * time.Second
 
+// cleanupManagedResources shuts down resources owned by the top-level TUI
+// lifecycle. It is safe to call from both the Bubble Tea event loop (normal
+// exit) and the context watcher (external cancellation).
+func (m *appModel) cleanupManagedResources() {
+	m.cleanupOnce.Do(func() {
+		if m.tuiStore != nil {
+			_ = m.tuiStore.Close()
+		}
+		if m.supervisor != nil {
+			m.supervisor.Shutdown()
+		}
+	})
+}
+
 // cleanupAll cleans up all sessions, editors, and resources.
 func (m *appModel) cleanupAll() {
 	m.transcriber.Stop()
@@ -2553,6 +2566,7 @@ func (m *appModel) cleanupAll() {
 	for _, ed := range m.editors {
 		ed.Cleanup()
 	}
+	m.cleanupManagedResources()
 
 	// Safety net: bubbletea's renderer can deadlock on shutdown if stdout
 	// is wedged — the final flush re-acquires the mutex that the still

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -65,6 +65,8 @@ const (
 
 // Model is the top-level TUI model that wraps the chat page.
 type appModel struct {
+	shutdownDone <-chan struct{}
+
 	supervisor *supervisor.Supervisor
 	tabBar     *tabbar.TabBar
 	tuiStore   *tuistate.Store
@@ -344,6 +346,7 @@ func New(ctx context.Context, spawner SessionSpawner, initialApp *app.App, initi
 	sessID := initialApp.Session().ID
 
 	m := &appModel{
+		shutdownDone: ctx.Done(),
 		buildCommandCategories: func(ctx context.Context, _ tea.Model) []commands.Category {
 			return commands.BuildCommandCategories(ctx, initialApp)
 		},
@@ -400,18 +403,6 @@ func New(ctx context.Context, spawner SessionSpawner, initialApp *app.App, initi
 	tabs, activeIdx := sv.GetTabs()
 	tb.SetTabs(tabs, activeIdx)
 	m.statusBar.SetShowNewTab(tb.Height() == 0)
-
-	// Make sure to stop on context cancellation.
-	// Note: chatPages/editors cleanup is handled by cleanupAll() on the
-	// normal exit path (ExitConfirmedMsg). We don't iterate those maps
-	// here to avoid racing with the Bubble Tea event loop.
-	go func() {
-		<-ctx.Done()
-		if ts != nil {
-			_ = ts.Close()
-		}
-		sv.Shutdown()
-	}()
 
 	return m
 }
@@ -533,8 +524,22 @@ func (m *appModel) initAndFocusComponents() tea.Cmd {
 	)
 }
 
+func (m *appModel) contextShutdownCmd() tea.Cmd {
+	return func() tea.Msg {
+		go func() {
+			<-m.shutdownDone
+			if m.tuiStore != nil {
+				_ = m.tuiStore.Close()
+			}
+			m.supervisor.Shutdown()
+		}()
+		return nil
+	}
+}
+
 // Init initializes the model.
 func (m *appModel) Init() tea.Cmd {
+	shutdownCmd := m.contextShutdownCmd()
 	// If a different tab should be active on startup, switch to it directly.
 	// The initial tab's pending restore stays lazy — it will be loaded via
 	// handleSwitchTab when the user eventually opens it, just like every
@@ -543,7 +548,7 @@ func (m *appModel) Init() tea.Cmd {
 		tabID := m.pendingActiveTab
 		m.pendingActiveTab = ""
 		_, switchCmd := m.handleSwitchTab(tabID)
-		return tea.Batch(m.dialogMgr.Init(), switchCmd)
+		return tea.Batch(m.dialogMgr.Init(), switchCmd, shutdownCmd)
 	}
 
 	// If the initial tab has a pending session restore, go through
@@ -564,12 +569,13 @@ func (m *appModel) Init() tea.Cmd {
 				cmd = tea.Batch(cmd, m.applySidebarCollapsed(activeID))
 				m.persistActiveTab(sess.ID)
 
-				return tea.Batch(m.dialogMgr.Init(), cmd)
+				return tea.Batch(m.dialogMgr.Init(), cmd, shutdownCmd)
 			}
 		}
 	}
 
 	return tea.Batch(
+		shutdownCmd,
 		m.dialogMgr.Init(),
 		m.chatPage.Init(),
 		m.editor.Init(),

--- a/pkg/tui/tuitest/driver.go
+++ b/pkg/tui/tuitest/driver.go
@@ -151,7 +151,8 @@ func New(tb testing.TB, model tea.Model, width, height int, opts ...Option) *Dri
 		opt(d)
 	}
 
-	go func() {
+	// tuitest.New intentionally returns a running driver and registers cleanup with testing.TB.
+	go func() { //rubocop:disable Lint/ConstructorPurity
 		defer close(d.runDone)
 		_, _ = p.Run()
 	}()


### PR DESCRIPTION
## Summary
- Prevent goroutines in constructors and refactor existing lifecycle sites
- Add command-exec and network-I/O constructor cops

## Validation
- task lint
- task test