### PR TITLE
feat: builtin hooks now honor working_dir and env

### DIFF
--- a/pkg/hooks/builtin_test.go
+++ b/pkg/hooks/builtin_test.go
@@ -3,6 +3,8 @@ package hooks
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -133,6 +135,107 @@ func TestBuiltinHookEmptyNameIsRejected(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, result.Allowed)
 	assert.Contains(t, result.Message, "builtin hook requires a name")
+}
+
+// TestBuiltinHookHonorsWorkingDir pins that a builtin hook's working_dir
+// override repoints Input.Cwd before the BuiltinFunc runs — the same
+// resolution command hooks get. A relative override is joined onto the
+// executor's working directory.
+func TestBuiltinHookHonorsWorkingDir(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(baseDir, "scripts"), 0o755))
+
+	registry := NewRegistry()
+	var seenCwd string
+	require.NoError(t, registry.RegisterBuiltin("capture-cwd", func(_ context.Context, in *Input, _ []string) (*Output, error) {
+		seenCwd = in.Cwd
+		return nil, nil
+	}))
+
+	exec := NewExecutorWithRegistry(&Config{SessionStart: []Hook{{
+		Type:       HookTypeBuiltin,
+		Command:    "capture-cwd",
+		WorkingDir: "scripts",
+	}}}, baseDir, nil, registry)
+
+	_, err := exec.Dispatch(t.Context(), EventSessionStart, &Input{SessionID: "s"})
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(baseDir, "scripts"), seenCwd)
+}
+
+// TestBuiltinHookWithoutWorkingDirKeepsInputCwd pins that, absent a
+// working_dir override, a builtin sees the Input.Cwd the caller
+// supplied — the executor must not clobber it with its own working
+// directory. This matters for events like worktree_create whose cwd is
+// set explicitly by the dispatcher.
+func TestBuiltinHookWithoutWorkingDirKeepsInputCwd(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	var seenCwd string
+	require.NoError(t, registry.RegisterBuiltin("capture-cwd", func(_ context.Context, in *Input, _ []string) (*Output, error) {
+		seenCwd = in.Cwd
+		return nil, nil
+	}))
+
+	exec := NewExecutorWithRegistry(&Config{SessionStart: []Hook{{
+		Type:    HookTypeBuiltin,
+		Command: "capture-cwd",
+	}}}, t.TempDir(), nil, registry)
+
+	_, err := exec.Dispatch(t.Context(), EventSessionStart, &Input{SessionID: "s", Cwd: "/explicit/cwd"})
+	require.NoError(t, err)
+	assert.Equal(t, "/explicit/cwd", seenCwd)
+}
+
+// TestBuiltinHookHonorsEnv pins that per-hook env overrides reach the
+// BuiltinFunc through the context, merged onto the executor env, so
+// builtins that shell out can run subprocesses with per-hook variables.
+func TestBuiltinHookHonorsEnv(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	var seenEnv []string
+	require.NoError(t, registry.RegisterBuiltin("capture-env", func(ctx context.Context, _ *Input, _ []string) (*Output, error) {
+		seenEnv = EnvFromContext(ctx)
+		return nil, nil
+	}))
+
+	exec := NewExecutorWithRegistry(&Config{SessionStart: []Hook{{
+		Type:    HookTypeBuiltin,
+		Command: "capture-env",
+		Env:     map[string]string{"HOOK_VALUE": "from-hook"},
+	}}}, t.TempDir(), []string{"BASE=1"}, registry)
+
+	_, err := exec.Dispatch(t.Context(), EventSessionStart, &Input{SessionID: "s"})
+	require.NoError(t, err)
+	assert.Contains(t, seenEnv, "BASE=1")
+	assert.Contains(t, seenEnv, "HOOK_VALUE=from-hook")
+}
+
+// TestBuiltinHookWithoutEnvInheritsProcess pins that a builtin without an
+// env override sees a nil env from the context, the signal to inherit the
+// process environment (exec.Cmd's default).
+func TestBuiltinHookWithoutEnvInheritsProcess(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	sawEnv := true
+	require.NoError(t, registry.RegisterBuiltin("capture-env", func(ctx context.Context, _ *Input, _ []string) (*Output, error) {
+		sawEnv = EnvFromContext(ctx) != nil
+		return nil, nil
+	}))
+
+	exec := NewExecutorWithRegistry(&Config{SessionStart: []Hook{{
+		Type:    HookTypeBuiltin,
+		Command: "capture-env",
+	}}}, t.TempDir(), nil, registry)
+
+	_, err := exec.Dispatch(t.Context(), EventSessionStart, &Input{SessionID: "s"})
+	require.NoError(t, err)
+	assert.False(t, sawEnv, "nil executor env + no override must yield a nil hook env")
 }
 
 // TestBuiltinHookErrorFailsClosed documents that an error returned by the

--- a/pkg/hooks/builtins/git.go
+++ b/pkg/hooks/builtins/git.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/docker/docker-agent/pkg/hooks"
 )
 
 // isGitRepo checks if the given directory or one of its parents is a git
@@ -60,7 +62,12 @@ func gitOutput(ctx context.Context, dir string, args ...string) (string, error) 
 		return "", errors.New("empty working directory")
 	}
 	full := append([]string{"-C", dir}, args...)
-	out, err := exec.CommandContext(ctx, "git", full...).Output()
+	cmd := exec.CommandContext(ctx, "git", full...)
+	// Honor the hook's resolved env (executor env + per-hook overrides)
+	// when set; a nil env leaves cmd.Env nil so git inherits the process
+	// environment, preserving the prior behavior.
+	cmd.Env = hooks.EnvFromContext(ctx)
+	out, err := cmd.Output()
 	if err != nil {
 		return "", err
 	}

--- a/pkg/hooks/builtins/git_test.go
+++ b/pkg/hooks/builtins/git_test.go
@@ -1,12 +1,16 @@
 package builtins
 
 import (
+	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/hooks"
 )
 
 func TestIsGitRepo(t *testing.T) {
@@ -72,4 +76,48 @@ func TestIsGitRepo(t *testing.T) {
 			assert.Equal(t, tt.want, isGitRepo(tt.setup(t)))
 		})
 	}
+}
+
+// TestGitOutputUsesHookEnv proves the per-hook env reaches the git
+// subprocess gitOutput spawns, end to end through the executor. A
+// builtin probe reads a config key that exists only when git is handed
+// the GIT_CONFIG_* env injection carried by the hook's env override;
+// without it the key is absent and the command errors.
+func TestGitOutputUsesHookEnv(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed; skipping git-backed builtin test")
+	}
+
+	dir := t.TempDir()
+	init := exec.CommandContext(t.Context(), "git", "-C", dir, "init", "--quiet", "-b", "main")
+	out, err := init.CombinedOutput()
+	require.NoErrorf(t, err, "git init failed: %s", out)
+
+	registry := hooks.NewRegistry()
+	var got string
+	require.NoError(t, registry.RegisterBuiltin("git-config-probe", func(ctx context.Context, in *hooks.Input, _ []string) (*hooks.Output, error) {
+		v, gerr := gitOutput(ctx, in.Cwd, "config", "--get", "hook.value")
+		if gerr != nil {
+			return nil, gerr
+		}
+		got = v
+		return nil, nil
+	}))
+
+	// Injects `hook.value=from-env` into git purely through the
+	// environment, so a non-empty read proves the env was applied.
+	hookEnv := map[string]string{
+		"GIT_CONFIG_COUNT":   "1",
+		"GIT_CONFIG_KEY_0":   "hook.value",
+		"GIT_CONFIG_VALUE_0": "from-env",
+	}
+	executor := hooks.NewExecutorWithRegistry(&hooks.Config{SessionStart: []hooks.Hook{{
+		Type:    hooks.HookTypeBuiltin,
+		Command: "git-config-probe",
+		Env:     hookEnv,
+	}}}, dir, os.Environ(), registry)
+
+	_, err = executor.Dispatch(t.Context(), hooks.EventSessionStart, &hooks.Input{SessionID: "s", Cwd: dir})
+	require.NoError(t, err)
+	assert.Equal(t, "from-env", got)
 }

--- a/pkg/hooks/handler.go
+++ b/pkg/hooks/handler.go
@@ -47,6 +47,30 @@ type HandlerEnv struct {
 	Env        []string
 }
 
+// hookEnvKey is the context key under which a builtin hook's resolved
+// environment is carried to the [BuiltinFunc].
+type hookEnvKey struct{}
+
+// withHookEnv returns a context carrying env. A nil env is stored as-is
+// so [EnvFromContext] reports "inherit the process environment".
+func withHookEnv(ctx context.Context, env []string) context.Context {
+	return context.WithValue(ctx, hookEnvKey{}, env)
+}
+
+// EnvFromContext returns the environment a builtin hook should use for
+// any subprocess it spawns, as "KEY=value" entries. It merges the
+// executor's environment with the hook's per-hook env overrides. A nil
+// result means "inherit the current process environment" (the default
+// for hooks without an env override), matching exec.Cmd semantics.
+//
+// Builtins that don't shell out can ignore it. Those that do should
+// pass it to exec.Cmd.Env (falling back to os.Environ() on nil only if
+// they must materialize a concrete slice).
+func EnvFromContext(ctx context.Context) []string {
+	env, _ := ctx.Value(hookEnvKey{}).([]string)
+	return env
+}
+
 // HandlerFactory builds a [Handler] for a single hook invocation.
 // Factories validate the hook (e.g. non-empty [Hook.Command]) and
 // return an error if it isn't runnable.
@@ -223,7 +247,14 @@ func (h *commandHandler) Run(ctx context.Context, input []byte) (HandlerResult, 
 // builtinFactory resolves Hook.Command in the registry's builtin table
 // and returns a [Handler] that bridges the JSON-on-stdin protocol to a
 // typed [BuiltinFunc].
-func (r *Registry) builtinFactory(_ HandlerEnv, hook Hook) (Handler, error) {
+//
+// The factory resolves the same working_dir and env overrides honored
+// by command hooks: working_dir repoints the [Input.Cwd] every builtin
+// keys off (the git/listing builtins shell out or stat relative to it),
+// and env is exposed via [HookEnv] so builtins that exec a subprocess
+// can run it with per-hook variables. Both default to the executor's
+// values when the hook leaves them unset, preserving prior behavior.
+func (r *Registry) builtinFactory(env HandlerEnv, hook Hook) (Handler, error) {
 	if hook.Command == "" {
 		return nil, errors.New("builtin hook requires a name in command")
 	}
@@ -231,12 +262,23 @@ func (r *Registry) builtinFactory(_ HandlerEnv, hook Hook) (Handler, error) {
 	if !ok {
 		return nil, fmt.Errorf("no builtin hook registered as %q", hook.Command)
 	}
-	return &builtinHandler{fn: fn, args: hook.Args}, nil
+	return &builtinHandler{
+		fn:         fn,
+		args:       hook.Args,
+		workingDir: hook.WorkingDir,
+		baseDir:    env.WorkingDir,
+		env:        hookEnv(env.Env, hook.Env),
+	}, nil
 }
 
 type builtinHandler struct {
 	fn   BuiltinFunc
 	args []string
+	// workingDir is the hook's working_dir override (possibly relative);
+	// baseDir is the executor's working directory it resolves against.
+	workingDir string
+	baseDir    string
+	env        []string
 }
 
 func (h *builtinHandler) Run(ctx context.Context, input []byte) (HandlerResult, error) {
@@ -244,6 +286,13 @@ func (h *builtinHandler) Run(ctx context.Context, input []byte) (HandlerResult, 
 	if err := json.Unmarshal(input, &in); err != nil {
 		return HandlerResult{ExitCode: -1}, fmt.Errorf("decode hook input: %w", err)
 	}
+	// A working_dir override repoints Input.Cwd, the directory every
+	// builtin keys off. With no override Input.Cwd is left as-is so
+	// callers that supply a cwd (e.g. the worktree_create event) keep it.
+	if h.workingDir != "" {
+		in.Cwd = hookWorkingDir(h.baseDir, h.workingDir)
+	}
+	ctx = withHookEnv(ctx, h.env)
 	out, err := h.fn(ctx, &in, h.args)
 	if err != nil {
 		return HandlerResult{ExitCode: -1}, err

--- a/pkg/hooks/handler.go
+++ b/pkg/hooks/handler.go
@@ -251,9 +251,10 @@ func (h *commandHandler) Run(ctx context.Context, input []byte) (HandlerResult, 
 // The factory resolves the same working_dir and env overrides honored
 // by command hooks: working_dir repoints the [Input.Cwd] every builtin
 // keys off (the git/listing builtins shell out or stat relative to it),
-// and env is exposed via [HookEnv] so builtins that exec a subprocess
-// can run it with per-hook variables. Both default to the executor's
-// values when the hook leaves them unset, preserving prior behavior.
+// and env is exposed via [EnvFromContext] so builtins that exec a
+// subprocess can run it with per-hook variables. Both default to the
+// executor's values when the hook leaves them unset, preserving prior
+// behavior.
 func (r *Registry) builtinFactory(env HandlerEnv, hook Hook) (Handler, error) {
 	if hook.Command == "" {
 		return nil, errors.New("builtin hook requires a name in command")


### PR DESCRIPTION
Of the three hook types (`command`, `builtin`, `model`), only `command` hooks honored the per-hook `working_dir` and `env` fields. The `HookDefinition` struct shares those fields across all hook types, they pass validation, and they're even flagged by the config-expansion linter — but the builtin factory silently discarded the `HandlerEnv` it received and never forwarded an override directory. A user setting `working_dir` on a `builtin` hook got no effect; the same for per-hook env overrides.

Builtin hooks now resolve `working_dir` with the same `hookWorkingDir` logic command hooks use (an absolute path wins outright; a relative path joins onto the executor directory) and repoint `Input.Cwd` before invoking the `BuiltinFunc`. The resolved env is carried on the context via a new `EnvFromContext` accessor. The git builtins read that env and pass it to `exec.Cmd.Env`; a `nil` value leaves `Env` unset so git still inherits `os.Environ()`, preserving prior behavior exactly. The `working_dir` override is applied only when set, so dispatcher-supplied cwd (e.g. the `worktree_create` event) continues to win when no per-hook override is configured. The `model` hook type still ignores both fields by design — it doesn't shell out.

No existing behavior changes: in production `WithEnv` is never called, so `hookEnv(nil, nil)` returns `nil` and `cmd.Env` stays unset.