### PR TITLE
docs: replace stale safety_check references with preempt_yolo pre_tool_use

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -2108,7 +2108,7 @@
         },
         "safer": {
           "type": "boolean",
-          "description": "Opt in to destructive-command detection for the shell toolset (only valid for type 'shell'). When enabled, the agent auto-registers the safer_shell builtin under the safety_check hook event. Destructive commands (rm -rf, docker volume rm, mkfs, ...) get an Ask verdict with a blast-radius classification; known-safe reads (ls, git status, docker ps, ...) flow through silently; everything else asks with blast_radius=unknown so the user sees the prompt before --yolo or permission allow-rules can auto-approve it. Default false."
+          "description": "Opt in to destructive-command detection for the shell toolset (only valid for type 'shell'). When enabled, the agent auto-registers the safer_shell builtin under the pre_tool_use hook event with preempt_yolo:true. Destructive commands (rm -rf, docker volume rm, mkfs, ...) get an Ask verdict with a blast-radius classification; known-safe reads (ls, git status, docker ps, ...) flow through silently; everything else asks with blast_radius=unknown so the user sees the prompt before --yolo or permission allow-rules can auto-approve it. Default false."
         },
         "url": {
           "type": "string",

--- a/docs/tools/shell/index.md
+++ b/docs/tools/shell/index.md
@@ -57,7 +57,7 @@ before `Decide()` / `--yolo`. Three behaviors:
 - **Known-safe reads** (`ls`, `cat`, `git status`, `git diff`, `docker ps`, `docker logs`, `kubectl get`, …) flow through silently — they're treated as no-opinion and follow the regular approval pipeline (`--yolo`, permission rules, read-only hint).
 - **Everything else** asks with `blast_radius=unknown`. Safer mode is conservative by default: unrecognised commands surface to the user before `--yolo` or permission allow-rules can auto-approve them.
 
-The verdict cannot be bypassed by `--yolo` or by a `permission_request` hook that returns `allow` — `safety_check` runs before both. Compound shell (`a && b`, `a; b`, `a | b`) is never matched against the safe allowlist; any destructive segment falls through to ask. The full taxonomy lives in [`pkg/hooks/builtins/safety_patterns.json`](https://github.com/docker/docker-agent/blob/main/pkg/hooks/builtins/safety_patterns.json).
+The verdict cannot be bypassed by `--yolo` or by a `permission_request` hook that returns `allow` — the `preempt_yolo` lane runs before both. Compound shell (`a && b`, `a; b`, `a | b`) is never matched against the safe allowlist; any destructive segment falls through to ask. The full taxonomy lives in [`pkg/hooks/builtins/safety_patterns.json`](https://github.com/docker/docker-agent/blob/main/pkg/hooks/builtins/safety_patterns.json).
 
 See [`examples/shell_safer.yaml`](https://github.com/docker/docker-agent/blob/main/examples/shell_safer.yaml) for a full example. Under the hood, `safer: true` is a sugar that appends one entry under `hooks.pre_tool_use` with `preempt_yolo: true`; writing the entry by hand achieves the same thing.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -65,7 +65,7 @@ Examples that wire up one of the toolsets shipped with docker-agent
 | File | What it shows |
 |------|---------------|
 | [`shell.yaml`](shell.yaml) | Plain `shell` toolset. |
-| [`shell_safer.yaml`](shell_safer.yaml) | Shell toolset wired with the `safer_shell` builtin under `safety_check` — destructive commands force confirmation regardless of `--yolo`; known-safe reads pass through silently. |
+| [`shell_safer.yaml`](shell_safer.yaml) | Shell toolset wired with the `safer_shell` builtin under `pre_tool_use` with `preempt_yolo: true` — destructive commands force confirmation regardless of `--yolo`; known-safe reads pass through silently. |
 | [`filesystem.yaml`](filesystem.yaml) | Plain `filesystem` toolset. |
 | [`filesystem_allow_deny.yaml`](filesystem_allow_deny.yaml) | Restricting the filesystem tool with allow/deny path lists. |
 | [`script_shell.yaml`](script_shell.yaml) | Defining custom shell commands as named tools via `type: script`. |

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -103,8 +103,8 @@ func (a *Agent) RedactSecrets() bool {
 
 // SaferShell reports whether any of the agent's shell toolsets opted
 // into the `safer: true` destructive-command guard. When true, the
-// runtime auto-injects the safer_shell builtin under safety_check;
-// see [builtins.ApplyAgentDefaults].
+// runtime auto-injects the safer_shell builtin under pre_tool_use
+// with preempt_yolo:true; see [builtins.ApplyAgentDefaults].
 func (a *Agent) SaferShell() bool {
 	return a.saferShell
 }

--- a/pkg/agent/opts.go
+++ b/pkg/agent/opts.go
@@ -137,11 +137,11 @@ func WithRedactSecrets(redactSecrets bool) Opt {
 	}
 }
 
-// WithSaferShell registers the safer_shell builtin under safety_check
-// when any of the agent's shell toolsets has `safer: true`. The
-// builtin runs pre-Decide() and routes destructive shell commands to
-// user confirmation regardless of --yolo or permission allow-rules.
-// See [builtins.SaferShell] and [hooks.EventSafetyCheck].
+// WithSaferShell registers the safer_shell builtin under pre_tool_use
+// with preempt_yolo:true when any of the agent's shell toolsets has
+// `safer: true`. The builtin runs pre-Decide() and routes destructive
+// shell commands to user confirmation regardless of --yolo or
+// permission allow-rules. See [builtins.SaferShell].
 func WithSaferShell(saferShell bool) Opt {
 	return func(a *Agent) {
 		a.saferShell = saferShell

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -1207,7 +1207,7 @@ type Toolset struct {
 
 	// For the `shell` toolset — opt in to destructive-command detection.
 	// When enabled, the agent auto-registers the safer_shell builtin under
-	// the safety_check hook event. Destructive commands (rm -rf, docker
+	// pre_tool_use with preempt_yolo:true. Destructive commands (rm -rf, docker
 	// volume rm, mkfs, …) get an Ask verdict carrying a blast-radius
 	// classification; known-safe reads (ls, git status, docker ps, …)
 	// flow through silently; everything else asks with blast_radius=unknown

--- a/pkg/hooks/aggregate_test.go
+++ b/pkg/hooks/aggregate_test.go
@@ -86,8 +86,8 @@ func TestAggregateTracksMostRestrictiveDecision(t *testing.T) {
 }
 
 // TestAggregateDecisionEmptyForNonPreToolUse documents that
-// Result.Decision is meaningful only for pre_tool_use and
-// safety_check events. Other events (turn_start, post_tool_use, ...)
+// Result.Decision is meaningful only for pre_tool_use (both the
+// default and preempt-yolo lanes). Other events (turn_start, post_tool_use, ...)
 // MUST leave it empty so a runtime that consults it can't accidentally
 // act on a stale verdict from an unrelated hook.
 func TestAggregateDecisionEmptyForNonPreToolUse(t *testing.T) {

--- a/pkg/hooks/builtins/safer_shell.go
+++ b/pkg/hooks/builtins/safer_shell.go
@@ -32,7 +32,8 @@ import (
 )
 
 // SaferShell is the registered name of the builtin that classifies
-// destructive shell commands and forces confirmation via SafetyCheck.
+// destructive shell commands and forces confirmation by preempting
+// --yolo on the pre_tool_use chain.
 const SaferShell = "safer_shell"
 
 // shellToolName is the tool name that this builtin acts on. The shell
@@ -147,7 +148,7 @@ func compileSafe(value any) ([]safePattern, error) {
 // On taxonomy load failure the call is routed to user confirmation
 // with blast_radius=unknown rather than allowed silently — failing
 // closed is the security-meaningful choice and matches [failClosed]'s
-// treatment of EventSafetyCheck.
+// treatment of the pre_tool_use preempt-yolo lane.
 func saferShell(_ context.Context, in *hooks.Input, _ []string) (*hooks.Output, error) {
 	if in == nil || in.HookEventName != hooks.EventPreToolUse {
 		return nil, nil

--- a/pkg/hooks/builtins/safer_shell_test.go
+++ b/pkg/hooks/builtins/safer_shell_test.go
@@ -11,7 +11,7 @@ import (
 
 // TestSaferShell_MatchesDestructivePatterns covers the destructive
 // taxonomy: each fixture must produce an Ask verdict with the
-// expected blast-radius level when run under EventSafetyCheck against
+// expected blast-radius level when run under EventPreToolUse against
 // a shell tool call. Metadata carries blast_radius + category + reason.
 func TestSaferShell_MatchesDestructivePatterns(t *testing.T) {
 	cases := []struct {
@@ -172,7 +172,7 @@ func TestSaferShell_AcceptsCommandAliasKey(t *testing.T) {
 
 // TestSaferShell_NoOpForNonShellTool keeps the no-op contract: the
 // builtin is registered under matcher "*", so it sees every
-// safety_check dispatch. It must return nil for tools it doesn't
+// pre_tool_use dispatch. It must return nil for tools it doesn't
 // classify.
 func TestSaferShell_NoOpForNonShellTool(t *testing.T) {
 	out, err := saferShell(t.Context(), &hooks.Input{

--- a/pkg/tui/dialog/tool_confirmation.go
+++ b/pkg/tui/dialog/tool_confirmation.go
@@ -172,7 +172,7 @@ func (d *toolConfirmationDialog) renderSafetyWarning(contentWidth int) string {
 
 // renderMetadata renders the key/value annotations attached to the
 // confirmation prompt (static toolset metadata merged with any
-// permission_request / safety_check hook contributions). Returns ""
+// permission_request / preempt-yolo pre_tool_use hook contributions). Returns ""
 // when there is none.
 //
 // Metadata keys the safer_shell builtin uses to express its verdict


### PR DESCRIPTION
PR #3273 originally introduced a `safety_check` hook event, but a late design pivot dropped that event in favour of the `preempt_yolo` flag on `pre_tool_use` entries. Most of the implementation was updated before merge, but a number of comments, godoc strings, and user-facing docs were left describing the old mechanism — including a broken `[hooks.EventSafetyCheck]` godoc link in `pkg/agent/opts.go` that refers to a symbol that no longer exists.

This PR replaces every stale `safety_check` / `EventSafetyCheck` / `SafetyCheck` reference across comments, godoc, test descriptions, and documentation with accurate descriptions of the actual `preempt_yolo` / `pre_tool_use` mechanism. The broken godoc cross-reference is removed, and the `WithSaferShell` / `SaferShell` docs are rewritten to match reality. There are no behaviour changes — every touched line is a comment or documentation string.