### PR TITLE
refactor: receiver-based Coordinator and parallel provider tests

### DIFF
--- a/pkg/model/provider/factory_compat_test.go
+++ b/pkg/model/provider/factory_compat_test.go
@@ -6,32 +6,19 @@ import (
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/environment"
 	"github.com/docker/docker-agent/pkg/model/provider/options"
-	"github.com/docker/docker-agent/pkg/model/provider/rulebased"
 	"github.com/docker/docker-agent/pkg/model/provider/vertexai"
 )
 
 type providerFactory = Factory
 
-var providerFactories = DefaultRegistry().factories
-
-func testRegistry() *Registry { return NewRegistry(providerFactories) }
-
-func createDirectProvider(ctx context.Context, cfg *latest.ModelConfig, env environment.Provider, opts ...options.Opt) (Provider, error) {
-	return testRegistry().createDirectProvider(ctx, cfg, env, opts...)
-}
-
-func resolveRoutedModel(ctx context.Context, modelSpec string, models map[string]latest.ModelConfig, env environment.Provider, factoryOpts ...options.Opt) (rulebased.Provider, error) {
-	return testRegistry().resolveRoutedModel(ctx, modelSpec, models, env, factoryOpts...)
-}
-
-var (
-	geminiClientFactory providerFactory
-	vertexClientFactory providerFactory
-)
-
-func googleFactory(ctx context.Context, cfg *latest.ModelConfig, env environment.Provider) (Provider, error) {
-	if vertexai.IsModelGardenConfig(cfg) {
-		return vertexClientFactory(ctx, cfg, env)
+// googleFactoryWith builds a google dispatch factory that routes Model Garden
+// configs to vertex and everything else to gemini. Tests construct one per
+// case instead of swapping package-level factory variables.
+func googleFactoryWith(gemini, vertex providerFactory) providerFactory {
+	return func(ctx context.Context, cfg *latest.ModelConfig, env environment.Provider, opts ...options.Opt) (Provider, error) {
+		if vertexai.IsModelGardenConfig(cfg) {
+			return vertex(ctx, cfg, env, opts...)
+		}
+		return gemini(ctx, cfg, env, opts...)
 	}
-	return geminiClientFactory(ctx, cfg, env)
 }

--- a/pkg/model/provider/factory_test.go
+++ b/pkg/model/provider/factory_test.go
@@ -28,16 +28,6 @@ func (f *fakeProvider) CreateChatCompletionStream(_ context.Context, _ []chat.Me
 }
 func (f *fakeProvider) BaseConfig() base.Config { return base.Config{} }
 
-// withFactories installs the given factory map for the duration of a test.
-// The original map is restored via t.Cleanup so parallel tests outside the
-// caller still see the production registry.
-func withFactories(t *testing.T, factories map[string]providerFactory) {
-	t.Helper()
-	original := providerFactories
-	providerFactories = factories
-	t.Cleanup(func() { providerFactories = original })
-}
-
 func tagFactory(id string) providerFactory {
 	return func(_ context.Context, _ *latest.ModelConfig, _ environment.Provider, _ ...options.Opt) (Provider, error) {
 		return &fakeProvider{id: modelsdev.NewID("test", id)}, nil
@@ -48,7 +38,8 @@ func tagFactory(id string) providerFactory {
 // output is mapped to the right factory entry for every supported value,
 // including the OpenAI api_type aliases.
 func TestCreateDirectProvider_DispatchByType(t *testing.T) {
-	withFactories(t, map[string]providerFactory{
+	t.Parallel()
+	r := NewRegistry(map[string]providerFactory{
 		"openai":                 tagFactory("openai"),
 		"openai_chatcompletions": tagFactory("openai_chatcompletions"),
 		"openai_responses":       tagFactory("openai_responses"),
@@ -107,7 +98,8 @@ func TestCreateDirectProvider_DispatchByType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p, err := createDirectProvider(t.Context(), tt.cfg, environment.NewNoEnvProvider())
+			t.Parallel()
+			p, err := r.createDirectProvider(t.Context(), tt.cfg, environment.NewNoEnvProvider())
 			require.NoError(t, err)
 			leaf := unwrapProvider(p)
 			fp, ok := leaf.(*fakeProvider)
@@ -120,13 +112,14 @@ func TestCreateDirectProvider_DispatchByType(t *testing.T) {
 // TestCreateDirectProvider_UnknownProviderType verifies the previously
 // unreachable error branch when the resolved provider type is not registered.
 func TestCreateDirectProvider_UnknownProviderType(t *testing.T) {
-	withFactories(t, map[string]providerFactory{
+	t.Parallel()
+	r := NewRegistry(map[string]providerFactory{
 		"openai": tagFactory("openai"),
 	})
 
 	cfg := &latest.ModelConfig{Provider: "completely-unknown", Model: "x"}
 
-	_, err := createDirectProvider(t.Context(), cfg, environment.NewNoEnvProvider())
+	_, err := r.createDirectProvider(t.Context(), cfg, environment.NewNoEnvProvider())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown provider type")
 	assert.Contains(t, err.Error(), "completely-unknown")
@@ -135,14 +128,15 @@ func TestCreateDirectProvider_UnknownProviderType(t *testing.T) {
 // TestCreateDirectProvider_FactoryError ensures errors returned by a factory
 // are propagated unchanged to the caller.
 func TestCreateDirectProvider_FactoryError(t *testing.T) {
+	t.Parallel()
 	sentinel := errors.New("boom")
-	withFactories(t, map[string]providerFactory{
+	r := NewRegistry(map[string]providerFactory{
 		"openai": func(_ context.Context, _ *latest.ModelConfig, _ environment.Provider, _ ...options.Opt) (Provider, error) {
 			return nil, sentinel
 		},
 	})
 
-	_, err := createDirectProvider(t.Context(), &latest.ModelConfig{Provider: "openai", Model: "gpt-4o"}, environment.NewNoEnvProvider())
+	_, err := r.createDirectProvider(t.Context(), &latest.ModelConfig{Provider: "openai", Model: "gpt-4o"}, environment.NewNoEnvProvider())
 	require.ErrorIs(t, err, sentinel)
 }
 
@@ -150,8 +144,9 @@ func TestCreateDirectProvider_FactoryError(t *testing.T) {
 // receives the *enhanced* config (i.e. applyProviderDefaults has run) before
 // dispatch — the BaseURL from a custom provider must be visible to the factory.
 func TestCreateDirectProvider_AppliesProviderDefaults(t *testing.T) {
+	t.Parallel()
 	var got *latest.ModelConfig
-	withFactories(t, map[string]providerFactory{
+	r := NewRegistry(map[string]providerFactory{
 		"openai_chatcompletions": func(_ context.Context, cfg *latest.ModelConfig, _ environment.Provider, _ ...options.Opt) (Provider, error) {
 			got = cfg
 			return &fakeProvider{id: modelsdev.NewID("test", "captured")}, nil
@@ -168,7 +163,7 @@ func TestCreateDirectProvider_AppliesProviderDefaults(t *testing.T) {
 
 	cfg := &latest.ModelConfig{Provider: "my_gateway", Model: "gpt-4o"}
 
-	_, err := createDirectProvider(
+	_, err := r.createDirectProvider(
 		t.Context(), cfg, environment.NewNoEnvProvider(),
 		options.WithProviders(customProviders),
 	)

--- a/pkg/model/provider/google_factory_test.go
+++ b/pkg/model/provider/google_factory_test.go
@@ -15,23 +15,11 @@ import (
 	"github.com/docker/docker-agent/pkg/model/provider/options"
 )
 
-// withGoogleFactories swaps the gemini and vertex inner factories for the
-// duration of a test, restoring the production functions via t.Cleanup.
-func withGoogleFactories(t *testing.T, gemini, vertex providerFactory) {
-	t.Helper()
-	originalGemini, originalVertex := geminiClientFactory, vertexClientFactory
-	geminiClientFactory = gemini
-	vertexClientFactory = vertex
-	t.Cleanup(func() {
-		geminiClientFactory = originalGemini
-		vertexClientFactory = originalVertex
-	})
-}
-
 // TestGoogleFactory_RoutesGeminiByDefault verifies that a plain "google" model
 // (no Vertex Model Garden hints) is dispatched to the Gemini client.
 func TestGoogleFactory_RoutesGeminiByDefault(t *testing.T) {
-	withGoogleFactories(t,
+	t.Parallel()
+	googleFactory := googleFactoryWith(
 		tagFactory("gemini"),
 		func(_ context.Context, _ *latest.ModelConfig, _ environment.Provider, _ ...options.Opt) (Provider, error) {
 			t.Errorf("vertex factory should not be called for plain Gemini config")
@@ -52,7 +40,8 @@ func TestGoogleFactory_RoutesGeminiByDefault(t *testing.T) {
 // edge case in vertexai.IsModelGardenConfig: publisher=google still routes to
 // Gemini (it's only a Model Garden config when publisher is non-google).
 func TestGoogleFactory_RoutesGeminiWhenPublisherIsGoogle(t *testing.T) {
-	withGoogleFactories(t,
+	t.Parallel()
+	googleFactory := googleFactoryWith(
 		tagFactory("gemini"),
 		func(_ context.Context, _ *latest.ModelConfig, _ environment.Provider, _ ...options.Opt) (Provider, error) {
 			t.Errorf("vertex factory must not be called when publisher=google")
@@ -76,7 +65,8 @@ func TestGoogleFactory_RoutesGeminiWhenPublisherIsGoogle(t *testing.T) {
 // TestGoogleFactory_RoutesVertexForModelGarden verifies that any non-Google
 // publisher routes through the Vertex Model Garden factory.
 func TestGoogleFactory_RoutesVertexForModelGarden(t *testing.T) {
-	withGoogleFactories(t,
+	t.Parallel()
+	googleFactory := googleFactoryWith(
 		func(_ context.Context, _ *latest.ModelConfig, _ environment.Provider, _ ...options.Opt) (Provider, error) {
 			t.Errorf("gemini factory must not be called for Model Garden config")
 			return nil, errors.New("unreachable")
@@ -100,8 +90,9 @@ func TestGoogleFactory_RoutesVertexForModelGarden(t *testing.T) {
 // TestGoogleFactory_PropagatesGeminiError verifies that errors from the inner
 // gemini factory are surfaced unchanged.
 func TestGoogleFactory_PropagatesGeminiError(t *testing.T) {
+	t.Parallel()
 	sentinel := errors.New("gemini-fail")
-	withGoogleFactories(t,
+	googleFactory := googleFactoryWith(
 		func(_ context.Context, _ *latest.ModelConfig, _ environment.Provider, _ ...options.Opt) (Provider, error) {
 			return nil, sentinel
 		},
@@ -117,8 +108,9 @@ func TestGoogleFactory_PropagatesGeminiError(t *testing.T) {
 // TestGoogleFactory_PropagatesVertexError verifies that errors from the inner
 // vertex factory are surfaced unchanged.
 func TestGoogleFactory_PropagatesVertexError(t *testing.T) {
+	t.Parallel()
 	sentinel := errors.New("vertex-fail")
-	withGoogleFactories(t,
+	googleFactory := googleFactoryWith(
 		tagFactory("gemini"),
 		func(_ context.Context, _ *latest.ModelConfig, _ environment.Provider, _ ...options.Opt) (Provider, error) {
 			return nil, sentinel

--- a/pkg/model/provider/router_factory_test.go
+++ b/pkg/model/provider/router_factory_test.go
@@ -17,8 +17,9 @@ import (
 // TestResolveRoutedModel_NamedReference verifies that a model name in the
 // models map is resolved to its config and dispatched through the registry.
 func TestResolveRoutedModel_NamedReference(t *testing.T) {
+	t.Parallel()
 	var capturedCfg *latest.ModelConfig
-	withFactories(t, map[string]providerFactory{
+	r := NewRegistry(map[string]providerFactory{
 		"openai": func(_ context.Context, cfg *latest.ModelConfig, _ environment.Provider, _ ...options.Opt) (Provider, error) {
 			capturedCfg = cfg
 			return &fakeProvider{id: modelsdev.NewID("openai", "captured")}, nil
@@ -29,7 +30,7 @@ func TestResolveRoutedModel_NamedReference(t *testing.T) {
 		"fast": {Provider: "openai", Model: "gpt-4o-mini"},
 	}
 
-	p, err := resolveRoutedModel(t.Context(), "fast", models, environment.NewNoEnvProvider())
+	p, err := r.resolveRoutedModel(t.Context(), "fast", models, environment.NewNoEnvProvider())
 	require.NoError(t, err)
 	require.NotNil(t, p)
 
@@ -41,15 +42,16 @@ func TestResolveRoutedModel_NamedReference(t *testing.T) {
 // TestResolveRoutedModel_InlineSpec verifies that a "provider/model" string
 // not present in the models map is parsed as an inline reference.
 func TestResolveRoutedModel_InlineSpec(t *testing.T) {
+	t.Parallel()
 	var capturedCfg *latest.ModelConfig
-	withFactories(t, map[string]providerFactory{
+	r := NewRegistry(map[string]providerFactory{
 		"openai": func(_ context.Context, cfg *latest.ModelConfig, _ environment.Provider, _ ...options.Opt) (Provider, error) {
 			capturedCfg = cfg
 			return &fakeProvider{id: modelsdev.NewID("openai", "captured")}, nil
 		},
 	})
 
-	p, err := resolveRoutedModel(t.Context(), "openai/gpt-4o", nil, environment.NewNoEnvProvider())
+	p, err := r.resolveRoutedModel(t.Context(), "openai/gpt-4o", nil, environment.NewNoEnvProvider())
 	require.NoError(t, err)
 	require.NotNil(t, p)
 
@@ -61,11 +63,12 @@ func TestResolveRoutedModel_InlineSpec(t *testing.T) {
 // TestResolveRoutedModel_InvalidInlineSpec covers the previously-unreachable
 // ParseModelRef error branch (modelSpec not in map and not parseable).
 func TestResolveRoutedModel_InvalidInlineSpec(t *testing.T) {
-	withFactories(t, map[string]providerFactory{
+	t.Parallel()
+	r := NewRegistry(map[string]providerFactory{
 		"openai": tagFactory("openai"),
 	})
 
-	_, err := resolveRoutedModel(t.Context(), "no-slash-here", nil, environment.NewNoEnvProvider())
+	_, err := r.resolveRoutedModel(t.Context(), "no-slash-here", nil, environment.NewNoEnvProvider())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid model spec")
 	assert.Contains(t, err.Error(), "no-slash-here")
@@ -74,7 +77,8 @@ func TestResolveRoutedModel_InvalidInlineSpec(t *testing.T) {
 // TestResolveRoutedModel_RecursiveRoutingRejected covers the recursion-prevention
 // branch: a routing target may not itself have routing rules.
 func TestResolveRoutedModel_RecursiveRoutingRejected(t *testing.T) {
-	withFactories(t, map[string]providerFactory{
+	t.Parallel()
+	r := NewRegistry(map[string]providerFactory{
 		"openai": tagFactory("openai"),
 	})
 
@@ -86,7 +90,7 @@ func TestResolveRoutedModel_RecursiveRoutingRejected(t *testing.T) {
 		},
 	}
 
-	_, err := resolveRoutedModel(t.Context(), "router-as-target", models, environment.NewNoEnvProvider())
+	_, err := r.resolveRoutedModel(t.Context(), "router-as-target", models, environment.NewNoEnvProvider())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "routing rules")
 	assert.Contains(t, err.Error(), "router-as-target")
@@ -95,8 +99,9 @@ func TestResolveRoutedModel_RecursiveRoutingRejected(t *testing.T) {
 // TestResolveRoutedModel_FactoryErrorPropagated_NamedRef verifies that when a
 // named model's factory fails, the error is returned to the caller.
 func TestResolveRoutedModel_FactoryErrorPropagated_NamedRef(t *testing.T) {
+	t.Parallel()
 	sentinel := errors.New("named-fail")
-	withFactories(t, map[string]providerFactory{
+	r := NewRegistry(map[string]providerFactory{
 		"openai": func(_ context.Context, _ *latest.ModelConfig, _ environment.Provider, _ ...options.Opt) (Provider, error) {
 			return nil, sentinel
 		},
@@ -106,21 +111,22 @@ func TestResolveRoutedModel_FactoryErrorPropagated_NamedRef(t *testing.T) {
 		"fast": {Provider: "openai", Model: "gpt-4o-mini"},
 	}
 
-	_, err := resolveRoutedModel(t.Context(), "fast", models, environment.NewNoEnvProvider())
+	_, err := r.resolveRoutedModel(t.Context(), "fast", models, environment.NewNoEnvProvider())
 	require.ErrorIs(t, err, sentinel)
 }
 
 // TestResolveRoutedModel_FactoryErrorPropagated_Inline verifies the same for
 // an inline "provider/model" spec.
 func TestResolveRoutedModel_FactoryErrorPropagated_Inline(t *testing.T) {
+	t.Parallel()
 	sentinel := errors.New("inline-fail")
-	withFactories(t, map[string]providerFactory{
+	r := NewRegistry(map[string]providerFactory{
 		"openai": func(_ context.Context, _ *latest.ModelConfig, _ environment.Provider, _ ...options.Opt) (Provider, error) {
 			return nil, sentinel
 		},
 	})
 
-	_, err := resolveRoutedModel(t.Context(), "openai/gpt-4o", nil, environment.NewNoEnvProvider())
+	_, err := r.resolveRoutedModel(t.Context(), "openai/gpt-4o", nil, environment.NewNoEnvProvider())
 	require.ErrorIs(t, err, sentinel)
 }
 
@@ -128,8 +134,9 @@ func TestResolveRoutedModel_FactoryErrorPropagated_Inline(t *testing.T) {
 // downstream factory unchanged. This guards against accidentally dropping
 // options (e.g. WithProviders) when extracting the closure.
 func TestResolveRoutedModel_OptionsForwarded(t *testing.T) {
+	t.Parallel()
 	var capturedOpts []options.Opt
-	withFactories(t, map[string]providerFactory{
+	r := NewRegistry(map[string]providerFactory{
 		"openai": func(_ context.Context, _ *latest.ModelConfig, _ environment.Provider, opts ...options.Opt) (Provider, error) {
 			capturedOpts = opts
 			return &fakeProvider{id: modelsdev.NewID("openai", "ok")}, nil
@@ -137,7 +144,7 @@ func TestResolveRoutedModel_OptionsForwarded(t *testing.T) {
 	})
 
 	maxTokens := int64(2048)
-	_, err := resolveRoutedModel(
+	_, err := r.resolveRoutedModel(
 		t.Context(), "openai/gpt-4o", nil, environment.NewNoEnvProvider(),
 		options.WithMaxTokens(maxTokens),
 	)

--- a/pkg/model/provider/schema_test.go
+++ b/pkg/model/provider/schema_test.go
@@ -58,6 +58,7 @@ func parseFunctionParameters(t *testing.T, schemaJSON string) map[string]any {
 }
 
 func TestEmptyMapSchemaForGemini(t *testing.T) {
+	t.Parallel()
 	schema, err := gemini.ConvertParametersToSchema(map[string]any{})
 	require.NoError(t, err)
 
@@ -67,6 +68,7 @@ func TestEmptyMapSchemaForGemini(t *testing.T) {
 }
 
 func TestEmptySchemaForGemini(t *testing.T) {
+	t.Parallel()
 	parameters := parseFunctionParameters(t, "{}")
 
 	schema, err := gemini.ConvertParametersToSchema(parameters)
@@ -78,6 +80,7 @@ func TestEmptySchemaForGemini(t *testing.T) {
 }
 
 func TestNilSchemaForGemini(t *testing.T) {
+	t.Parallel()
 	schema, err := gemini.ConvertParametersToSchema(nil)
 	require.NoError(t, err)
 
@@ -87,6 +90,7 @@ func TestNilSchemaForGemini(t *testing.T) {
 }
 
 func TestSchemaForGemini(t *testing.T) {
+	t.Parallel()
 	parameters := parseFunctionParameters(t, schemaJSON)
 
 	schema, err := gemini.ConvertParametersToSchema(parameters)
@@ -129,6 +133,7 @@ func TestSchemaForGemini(t *testing.T) {
 }
 
 func TestEmptyMapSchemaForAnthropic(t *testing.T) {
+	t.Parallel()
 	shema, err := anthropic.ConvertParametersToSchema(map[string]any{})
 	require.NoError(t, err)
 
@@ -138,6 +143,7 @@ func TestEmptyMapSchemaForAnthropic(t *testing.T) {
 }
 
 func TestNilSchemaForAnthropic(t *testing.T) {
+	t.Parallel()
 	shema, err := anthropic.ConvertParametersToSchema(nil)
 	require.NoError(t, err)
 
@@ -147,6 +153,7 @@ func TestNilSchemaForAnthropic(t *testing.T) {
 }
 
 func TestSchemaForAnthropic(t *testing.T) {
+	t.Parallel()
 	parameters := parseFunctionParameters(t, schemaJSON)
 	shema, err := anthropic.ConvertParametersToSchema(parameters)
 	require.NoError(t, err)
@@ -188,6 +195,7 @@ func TestSchemaForAnthropic(t *testing.T) {
 // OpenAI and LM Studio accept.
 // See https://github.com/docker/docker-agent/issues/278
 func TestEmptyMapSchemaForOpenai(t *testing.T) {
+	t.Parallel()
 	schema, _, err := openai.ConvertParametersToSchema(map[string]any{})
 	require.NoError(t, err)
 
@@ -197,6 +205,7 @@ func TestEmptyMapSchemaForOpenai(t *testing.T) {
 }
 
 func TestNilSchemaForOpenai(t *testing.T) {
+	t.Parallel()
 	schema, _, err := openai.ConvertParametersToSchema(nil)
 	require.NoError(t, err)
 
@@ -206,6 +215,7 @@ func TestNilSchemaForOpenai(t *testing.T) {
 }
 
 func TestSchemaForOpenai(t *testing.T) {
+	t.Parallel()
 	parameters := parseFunctionParameters(t, schemaJSON)
 
 	schema, _, err := openai.ConvertParametersToSchema(parameters)
@@ -246,6 +256,7 @@ func TestSchemaForOpenai(t *testing.T) {
 }
 
 func TestEmptyMapSchemaForDMR(t *testing.T) {
+	t.Parallel()
 	schema, err := dmr.ConvertParametersToSchema(map[string]any{})
 	require.NoError(t, err)
 
@@ -255,6 +266,7 @@ func TestEmptyMapSchemaForDMR(t *testing.T) {
 }
 
 func TestNilSchemaForDMR(t *testing.T) {
+	t.Parallel()
 	schema, err := dmr.ConvertParametersToSchema(nil)
 	require.NoError(t, err)
 
@@ -264,6 +276,7 @@ func TestNilSchemaForDMR(t *testing.T) {
 }
 
 func TestSchemaForDMR(t *testing.T) {
+	t.Parallel()
 	parameters := parseFunctionParameters(t, schemaJSON)
 
 	schema, err := dmr.ConvertParametersToSchema(parameters)

--- a/pkg/tui/animation/coordinator.go
+++ b/pkg/tui/animation/coordinator.go
@@ -30,55 +30,52 @@ type Coordinator struct {
 	active int32
 }
 
-// globalCoordinator is the singleton coordinator instance.
-var globalCoordinator = &Coordinator{}
-
 // Register increments the active animation count.
 // Call this when an animation starts.
-func Register() {
-	globalCoordinator.mu.Lock()
-	defer globalCoordinator.mu.Unlock()
-	globalCoordinator.active++
+func (c *Coordinator) Register() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.active++
 }
 
 // Unregister decrements the active animation count.
 // Call this when an animation stops.
-func Unregister() {
-	globalCoordinator.mu.Lock()
-	defer globalCoordinator.mu.Unlock()
-	if globalCoordinator.active > 0 {
-		globalCoordinator.active--
+func (c *Coordinator) Unregister() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.active > 0 {
+		c.active--
 	}
 }
 
 // HasActive returns true if any animations are currently active.
-func HasActive() bool {
-	globalCoordinator.mu.Lock()
-	defer globalCoordinator.mu.Unlock()
-	return globalCoordinator.active > 0
+func (c *Coordinator) HasActive() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.active > 0
 }
 
-// StartTick starts the global animation tick if any animations are active.
+// StartTick starts the animation tick if any animations are active.
 // Call this after processing a TickMsg to continue the tick stream.
-func StartTick() tea.Cmd {
-	globalCoordinator.mu.Lock()
-	defer globalCoordinator.mu.Unlock()
-	if globalCoordinator.active <= 0 {
+func (c *Coordinator) StartTick() tea.Cmd {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.active <= 0 {
 		return nil
 	}
-	return globalCoordinator.tickLocked()
+	return c.tickLocked()
 }
 
 // StartTickIfFirst registers an animation and starts the tick if this is the first.
 // This is atomic: no race between checking and registering.
 // Returns the tick command if the tick stream was started, nil otherwise.
-func StartTickIfFirst() tea.Cmd {
-	globalCoordinator.mu.Lock()
-	defer globalCoordinator.mu.Unlock()
-	wasEmpty := globalCoordinator.active == 0
-	globalCoordinator.active++
+func (c *Coordinator) StartTickIfFirst() tea.Cmd {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	wasEmpty := c.active == 0
+	c.active++
 	if wasEmpty {
-		return globalCoordinator.tickLocked()
+		return c.tickLocked()
 	}
 	return nil
 }
@@ -94,3 +91,23 @@ func (c *Coordinator) tickLocked() tea.Cmd {
 		return TickMsg{Frame: frame}
 	})
 }
+
+// globalCoordinator is the singleton coordinator instance shared by all
+// animated components in the running TUI.
+var globalCoordinator = &Coordinator{}
+
+// Register increments the active animation count on the global coordinator.
+func Register() { globalCoordinator.Register() }
+
+// Unregister decrements the active animation count on the global coordinator.
+func Unregister() { globalCoordinator.Unregister() }
+
+// HasActive reports whether any animations are active on the global coordinator.
+func HasActive() bool { return globalCoordinator.HasActive() }
+
+// StartTick starts the global animation tick if any animations are active.
+func StartTick() tea.Cmd { return globalCoordinator.StartTick() }
+
+// StartTickIfFirst registers an animation on the global coordinator and starts
+// the tick if it is the first.
+func StartTickIfFirst() tea.Cmd { return globalCoordinator.StartTickIfFirst() }

--- a/pkg/tui/animation/coordinator_test.go
+++ b/pkg/tui/animation/coordinator_test.go
@@ -10,18 +10,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func resetGlobalCoordinator(t *testing.T) {
-	t.Helper()
-	globalCoordinator.mu.Lock()
-	defer globalCoordinator.mu.Unlock()
-	globalCoordinator.active = 0
-	globalCoordinator.frame = 0
-}
-
-func getActiveCount() int32 {
-	globalCoordinator.mu.Lock()
-	defer globalCoordinator.mu.Unlock()
-	return globalCoordinator.active
+func getActiveCount(c *Coordinator) int32 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.active
 }
 
 func runCmdWithTimeout(t *testing.T, cmd tea.Cmd) tea.Msg {
@@ -57,51 +49,54 @@ func runTickCmd(t *testing.T, cmd tea.Cmd) TickMsg {
 }
 
 func TestGlobalCoordinatorLifecycle(t *testing.T) {
-	resetGlobalCoordinator(t)
+	t.Parallel()
+	c := &Coordinator{}
 
 	// No active animations = no tick
-	require.Nil(t, StartTick())
+	require.Nil(t, c.StartTick())
 
 	// First registration starts tick
-	firstTick := StartTickIfFirst()
+	firstTick := c.StartTickIfFirst()
 	tickMsg := runTickCmd(t, firstTick)
 	assert.Equal(t, 1, tickMsg.Frame)
 
 	// Subsequent tick continues
-	nextTick := StartTick()
+	nextTick := c.StartTick()
 	tickMsg = runTickCmd(t, nextTick)
 	assert.Equal(t, 2, tickMsg.Frame)
 
 	// Second StartTickIfFirst registers but doesn't return tick (not first)
-	cmd := StartTickIfFirst()
+	cmd := c.StartTickIfFirst()
 	require.Nil(t, cmd)
-	assert.Equal(t, int32(2), getActiveCount())
+	assert.Equal(t, int32(2), getActiveCount(c))
 
 	// Unregister one, still active
-	Unregister()
-	require.True(t, HasActive())
-	require.NotNil(t, StartTick())
+	c.Unregister()
+	require.True(t, c.HasActive())
+	require.NotNil(t, c.StartTick())
 
 	// Unregister last one
-	Unregister()
-	require.False(t, HasActive())
-	require.Nil(t, StartTick())
+	c.Unregister()
+	require.False(t, c.HasActive())
+	require.Nil(t, c.StartTick())
 }
 
 func TestUnregisterNeverGoesNegative(t *testing.T) {
-	resetGlobalCoordinator(t)
+	t.Parallel()
+	c := &Coordinator{}
 
 	// Multiple unregisters when already at 0
-	Unregister()
-	Unregister()
-	Unregister()
+	c.Unregister()
+	c.Unregister()
+	c.Unregister()
 
-	assert.Equal(t, int32(0), getActiveCount())
-	require.False(t, HasActive())
+	assert.Equal(t, int32(0), getActiveCount(c))
+	require.False(t, c.HasActive())
 }
 
 func TestConcurrentRegisterUnregister(t *testing.T) {
-	resetGlobalCoordinator(t)
+	t.Parallel()
+	c := &Coordinator{}
 
 	const goroutines = 100
 	const opsPerGoroutine = 100
@@ -114,7 +109,7 @@ func TestConcurrentRegisterUnregister(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for range opsPerGoroutine {
-				Register()
+				c.Register()
 			}
 		}()
 	}
@@ -124,7 +119,7 @@ func TestConcurrentRegisterUnregister(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for range opsPerGoroutine {
-				Unregister()
+				c.Unregister()
 			}
 		}()
 	}
@@ -134,12 +129,13 @@ func TestConcurrentRegisterUnregister(t *testing.T) {
 	// Should have exactly goroutines * opsPerGoroutine registers
 	// minus whatever unregisters succeeded (capped at 0)
 	// Final count should be >= 0
-	count := getActiveCount()
+	count := getActiveCount(c)
 	assert.GreaterOrEqual(t, count, int32(0), "active count should never be negative")
 }
 
 func TestConcurrentStartTickIfFirst(t *testing.T) {
-	resetGlobalCoordinator(t)
+	t.Parallel()
+	c := &Coordinator{}
 
 	const goroutines = 50
 	var wg sync.WaitGroup
@@ -151,7 +147,7 @@ func TestConcurrentStartTickIfFirst(t *testing.T) {
 	for range goroutines {
 		go func() {
 			defer wg.Done()
-			cmd := StartTickIfFirst()
+			cmd := c.StartTickIfFirst()
 			cmds <- cmd
 		}()
 	}
@@ -170,5 +166,5 @@ func TestConcurrentStartTickIfFirst(t *testing.T) {
 	// Exactly one should have started the tick
 	assert.Equal(t, 1, ticksStarted, "exactly one goroutine should start the tick")
 	// All should have registered
-	assert.Equal(t, int32(goroutines), getActiveCount())
+	assert.Equal(t, int32(goroutines), getActiveCount(c))
 }


### PR DESCRIPTION
The animation `Coordinator` type was previously accessed only through package-level functions that held a single global instance. This made the code harder to test in isolation and prevented running tests in parallel, since all callers shared state.

`Coordinator`'s methods are now defined directly on the receiver so each caller can hold its own instance. The package-level shims (`Start`, `Stop`, `Add`, etc.) are kept intact for backward compatibility, delegating to a default instance. Provider tests have been updated to construct per-test registries instead of relying on shared global state, and all updated test functions call `t.Parallel()`.

Validated with `go build ./...`, `golangci-lint run`, and `task test`.