### PR TITLE
fix(hooks): cap oversized mcp and a2a tool results

### DIFF
--- a/pkg/hooks/builtins/builtins_test.go
+++ b/pkg/hooks/builtins/builtins_test.go
@@ -316,17 +316,38 @@ const (
 	largeToolCallResultTailBytesForTest = 50 * 1024
 )
 
-func TestLimitLargeToolResultsNoopsOutsideFilesystemAndShell(t *testing.T) {
+func TestLimitLargeToolResultsNoopsForInternalCategory(t *testing.T) {
 	t.Parallel()
 
 	fn := lookup(t, builtins.LimitLargeToolResults)
 	out, err := fn(t.Context(), &hooks.Input{
 		HookEventName: hooks.EventToolResponseTransform,
-		ToolCategory:  "mcp",
+		ToolCategory:  "memory",
 		ToolResponse:  strings.Repeat("x", maxToolCallResultBytesForTest+1),
 	}, nil)
 	require.NoError(t, err)
 	assert.Nil(t, out)
+}
+
+func TestLimitLargeToolResultsCapsExternalToolCategories(t *testing.T) {
+	for _, category := range []string{"mcp", "a2a"} {
+		t.Run(category, func(t *testing.T) {
+			t.Setenv("TMPDIR", t.TempDir())
+
+			fn := lookup(t, builtins.LimitLargeToolResults)
+			out, err := fn(t.Context(), &hooks.Input{
+				SessionID:     category + "-session",
+				HookEventName: hooks.EventToolResponseTransform,
+				ToolCategory:  category,
+				ToolResponse:  strings.Repeat("x", maxToolCallResultBytesForTest+1),
+			}, nil)
+			require.NoError(t, err)
+			require.NotNil(t, out)
+			require.NotNil(t, out.HookSpecificOutput)
+			require.NotNil(t, out.HookSpecificOutput.UpdatedToolResponse)
+			assert.Contains(t, *out.HookSpecificOutput.UpdatedToolResponse, "Tool call result was too large")
+		})
+	}
 }
 
 func TestLimitLargeToolResultsTriggersOnLineCount(t *testing.T) {

--- a/pkg/hooks/builtins/limit_large_tool_results.go
+++ b/pkg/hooks/builtins/limit_large_tool_results.go
@@ -25,6 +25,20 @@ const (
 	largeToolCallResultTailBytes = 50 * 1024
 )
 
+// largeResultCategories lists the tool categories whose results can be
+// arbitrarily large and are not bounded anywhere else, so they are subject
+// to the oversized-result cap. filesystem and shell are the high-output
+// built-in toolsets; mcp and a2a call external servers that impose no
+// per-result limit of their own (unlike the openapi/api toolsets, which
+// already truncate their output). Internal toolsets (memory, plan, tasks,
+// think, ...) return bounded, structured results and are left untouched.
+var largeResultCategories = map[string]bool{
+	"filesystem": true,
+	"shell":      true,
+	"mcp":        true,
+	"a2a":        true,
+}
+
 func limitLargeToolResults(ctx context.Context, in *hooks.Input, _ []string) (*hooks.Output, error) {
 	if in == nil {
 		return nil, nil
@@ -42,7 +56,7 @@ func limitLargeToolResults(ctx context.Context, in *hooks.Input, _ []string) (*h
 }
 
 func limitLargeToolResponse(ctx context.Context, in *hooks.Input) (*hooks.Output, error) {
-	if in.ToolCategory != "filesystem" && in.ToolCategory != "shell" {
+	if !largeResultCategories[in.ToolCategory] {
 		return nil, nil
 	}
 


### PR DESCRIPTION
## Summary

The always-on `limit_large_tool_results` hook (#3290) caps oversized tool results to keep them out of conversation history, but it only acts on the `filesystem` and `shell` categories. MCP and A2A tool output, which have no per-result limit of their own, are left unbounded. This is the gap reported in #2722.

This PR extends that hook to the `mcp` and `a2a` categories, reusing the existing save-to-file plus bounded-tail mechanism unchanged.

## Root cause

| Tool category | Own per-result cap | Capped by `limit_large_tool_results` before | After this PR |
|---|---|---|---|
| `filesystem`  | no  | yes | yes |
| `shell`       | no  | yes | yes |
| `mcp`         | no  | no  | yes |
| `a2a`         | no  | no  | yes |
| `openapi` / `api` | yes (30000 chars) | no | no (own cap kept) |
| internal (`memory`, `plan`, `tasks`, `think`, ...) | n/a, bounded output | no | no |

With an oversized MCP result the agent breaks: a single large result overflows the model context window, and overflow compaction no-ops when one message alone exceeds the budget, so the run gets stuck with no recovery (overflow compaction is bounded to 1 attempt).

## Change

- Replace the inline `filesystem`/`shell` allowlist in `limitLargeToolResponse` with a documented `largeResultCategories` set, adding `mcp` and `a2a`. The named set also documents why the other categories are excluded, so a future external toolset is less likely to be missed silently (which is how MCP was missed).
- MCP/A2A output is already flattened into the string tool result before the `tool_response_transform` hook runs, so no other change is needed.

## Verification

Unit tests (`pkg/hooks/builtins`):

- `TestLimitLargeToolResultsCapsExternalToolCategories` (new) covers `mcp` and `a2a`.
- `TestLimitLargeToolResultsNoopsForInternalCategory` (renamed from the old `...NoopsOutsideFilesystemAndShell`) now asserts an internal category (`memory`) stays untouched.

End-to-end run against a real model (`claude-sonnet-4-5`) and a stdio MCP server returning 375 KB / 5000 lines, before and after the change on the same setup:

| Observation | Before (filesystem/shell only) | After |
|---|---|---|
| Hook notice emitted on the MCP result | 0 | 1 |
| Full 375 KB payload sent to the model | yes | no (notice + bounded tail) |
| Full result saved to a temp file | n/a | yes (`docker-agent-tool-results/<session>/tool-result-*.txt`) |
| `session_end` cleanup of the temp dir | n/a | yes |
| Context overflow / stuck agent | depends on context size | no |

`task build`, `go vet`, `gofmt`, and the standard linters on the changed package all pass.

## Notes for reviewers

- The retained behavior is a bounded tail. For JSON-heavy MCP responses a tail is not parseable; the model still gets the file pointer and a clear "result too large" signal so it can re-query or read the file with `shell`/`filesystem`. Switching to head, or head+tail, would affect all categories and is left as a separate change.
- The file pointer is only directly usable when the agent has a `shell` or `filesystem` toolset; an MCP-only agent gets the inline tail. This matches the existing hook behavior.
- Non-text MCP content (`StructuredContent`, images, documents) is carried on separate result fields and does not pass through this hook; only the text output is bounded.

Supersedes #2728 (a separate `handle_large_tool_output` builtin), which predates `limit_large_tool_results` and is now redundant.

Closes #2722
