### PR TITLE
fix(modelerrors): retry stream truncation and clarify the error (#3298)

### DIFF
--- a/pkg/modelerrors/modelerrors.go
+++ b/pkg/modelerrors/modelerrors.go
@@ -400,6 +400,47 @@ var retryablePatterns = []string{
 	"internal_error",        // HTTP/2 INTERNAL_ERROR (stream-level)
 }
 
+// streamTruncationPatterns matches errors where the response body was cut off
+// mid-stream, before a clean end-of-stream marker. For local backends (e.g.
+// Docker Model Runner / llama.cpp) this most often happens when a large
+// prompt's prefill takes long enough with no bytes flowing that an idle or
+// connection timeout in the model server -- or a proxy in front of it -- drops
+// the connection before the first token is streamed (see issue #3298). The
+// connection reset / closed-by-peer variants are already covered by
+// [retryablePatterns]; these two cover the clean-FIN-mid-event shapes that
+// surface from the SSE/JSON decoder instead of the socket layer.
+//
+// Patterns MUST be lowercase: they are compared against a lowercased error
+// message (see [IsStreamTruncationError]).
+var streamTruncationPatterns = []string{
+	"unexpected eof",               // io.ErrUnexpectedEOF: HTTP body cut mid-frame
+	"unexpected end of json input", // json.Unmarshal on a truncated SSE event
+}
+
+// IsStreamTruncationError reports whether err indicates the model stream was
+// cut off before a clean completion: the connection was dropped or the body
+// was truncated mid-stream. See [streamTruncationPatterns] for why this happens
+// and why it is treated as retryable.
+//
+// Context cancellation/deadline is excluded: that is the caller tearing the
+// request down (e.g. the idle-timeout cancel or a user Ctrl+C), not an upstream
+// drop, and must stay non-retryable.
+func IsStreamTruncationError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, p := range streamTruncationPatterns {
+		if strings.Contains(msg, p) {
+			return true
+		}
+	}
+	return false
+}
+
 // nonRetryablePatterns contains error message substrings that indicate a
 // permanent/non-retryable failure. Numeric status codes (429, 401, etc.) are
 // handled separately by extractHTTPStatusCode.
@@ -468,6 +509,17 @@ func isRetryableModelError(err error) bool {
 			slog.Debug("Network timeout error, retryable", "error", err)
 			return true
 		}
+	}
+
+	// A stream truncated mid-response is transient: the upstream (or a proxy)
+	// dropped a connection that was making progress, most often during a long
+	// prefill with no bytes flowing yet. Retrying usually succeeds because the
+	// backend's prompt cache makes the second prefill fast enough to beat the
+	// idle limit. Checked before the pattern loops below so the truncated-JSON
+	// variant isn't mis-classified by the "invalid" non-retryable pattern.
+	if IsStreamTruncationError(err) {
+		slog.Debug("Stream truncated mid-response, retryable", "error", err)
+		return true
 	}
 
 	errMsg := strings.ToLower(err.Error())
@@ -586,6 +638,14 @@ func FormatError(err error) string {
 	case OverflowKindTokens:
 		return "The conversation has exceeded the model's context window and automatic compaction is not enabled. " +
 			"Try running /compact to reduce the conversation size, or start a new session."
+	}
+
+	if IsStreamTruncationError(err) {
+		return "The connection to the model closed before it produced any output. " +
+			"With local models (e.g. Docker Model Runner), this usually means a large prompt's prefill " +
+			"exceeded an idle or connection timeout in the model server, or in a proxy in front of it, " +
+			"before the first token was streamed. Try a shorter prompt, or raise the model server's " +
+			"idle/keep-alive timeout."
 	}
 
 	return err.Error()

--- a/pkg/modelerrors/modelerrors.go
+++ b/pkg/modelerrors/modelerrors.go
@@ -641,11 +641,11 @@ func FormatError(err error) string {
 	}
 
 	if IsStreamTruncationError(err) {
-		return "The connection to the model closed before it produced any output. " +
-			"With local models (e.g. Docker Model Runner), this usually means a large prompt's prefill " +
-			"exceeded an idle or connection timeout in the model server, or in a proxy in front of it, " +
-			"before the first token was streamed. Try a shorter prompt, or raise the model server's " +
-			"idle/keep-alive timeout."
+		return "The connection to the model was closed unexpectedly before it completed its response. " +
+			"With local models (e.g. Docker Model Runner), this can happen when an idle or " +
+			"connection timeout in the model server (or a proxy in front of it) drops a silent " +
+			"prefill before the first token, or cuts a long response mid-stream. " +
+			"Try a shorter prompt, or raise the model server's idle/keep-alive timeout."
 	}
 
 	return err.Error()

--- a/pkg/modelerrors/modelerrors_test.go
+++ b/pkg/modelerrors/modelerrors_test.go
@@ -57,6 +57,14 @@ func TestIsRetryableModelError(t *testing.T) {
 		{name: "reset before headers", err: errors.New("reset before headers"), expected: true},
 		{name: "upstream connect error", err: errors.New("upstream connect error"), expected: true},
 		{name: "HTTP/2 INTERNAL_ERROR", err: fmt.Errorf("error receiving from stream: %w", errors.New("stream error: stream ID 1; INTERNAL_ERROR; received from peer")), expected: true},
+		// Stream truncated mid-response during a long prefill (issue #3298):
+		// the upstream / proxy dropped a healthy connection before the first
+		// token. Retryable so the warm-cache retry can beat the idle limit.
+		{name: "stream truncated - unexpected end of JSON input", err: fmt.Errorf("error receiving from stream: %w", errors.New("unexpected end of JSON input")), expected: true},
+		{name: "stream truncated - unexpected EOF", err: fmt.Errorf("error receiving from stream: %w", errors.New("unexpected EOF")), expected: true},
+		// A genuinely malformed (not merely truncated) JSON payload stays
+		// non-retryable: "invalid character ..." is not a truncation signature.
+		{name: "malformed stream - invalid character not retried", err: fmt.Errorf("error receiving from stream: %w", errors.New("invalid character 'x' looking for beginning of value")), expected: false},
 		{name: "context overflow - prompt too long", err: errors.New("prompt is too long: 226360 tokens > 200000 maximum"), expected: false},
 		{name: "context overflow - thinking budget", err: errors.New("max_tokens must be greater than thinking.budget_tokens"), expected: false},
 		{name: "context overflow - wrapped", err: &ContextOverflowError{Underlying: errors.New("test")}, expected: false},
@@ -467,12 +475,50 @@ func TestMatchesTransientPattern(t *testing.T) {
 	}
 }
 
+func TestIsStreamTruncationError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{name: "nil error", err: nil, expected: false},
+		{name: "unexpected end of JSON input", err: errors.New("unexpected end of JSON input"), expected: true},
+		{name: "unexpected EOF", err: errors.New("unexpected EOF"), expected: true},
+		{name: "mixed case", err: errors.New("Unexpected EOF"), expected: true},
+		{name: "wrapped by stream layer", err: fmt.Errorf("error receiving from stream: %w", errors.New("unexpected end of JSON input")), expected: true},
+		// Context teardown must NOT be claimed as an upstream truncation, even
+		// if the message happens to mention EOF-ish text.
+		{name: "context canceled", err: context.Canceled, expected: false},
+		{name: "context deadline", err: context.DeadlineExceeded, expected: false},
+		{name: "clean EOF is not a truncation signature", err: errors.New("EOF"), expected: false},
+		{name: "unrelated error", err: errors.New("connection refused"), expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, IsStreamTruncationError(tt.err), "IsStreamTruncationError(%v)", tt.err)
+		})
+	}
+}
+
 func TestFormatError(t *testing.T) {
 	t.Parallel()
 
 	t.Run("nil error", func(t *testing.T) {
 		t.Parallel()
 		assert.Empty(t, FormatError(nil))
+	})
+
+	t.Run("stream truncation shows prefill/timeout guidance", func(t *testing.T) {
+		t.Parallel()
+		err := fmt.Errorf("error receiving from stream: %w", errors.New("unexpected end of JSON input"))
+		msg := FormatError(err)
+		assert.Contains(t, msg, "closed before it produced any output")
+		assert.Contains(t, msg, "prefill")
+		assert.NotContains(t, msg, "unexpected end of JSON input")
 	})
 
 	t.Run("context overflow shows user-friendly message", func(t *testing.T) {

--- a/pkg/modelerrors/modelerrors_test.go
+++ b/pkg/modelerrors/modelerrors_test.go
@@ -516,8 +516,11 @@ func TestFormatError(t *testing.T) {
 		t.Parallel()
 		err := fmt.Errorf("error receiving from stream: %w", errors.New("unexpected end of JSON input"))
 		msg := FormatError(err)
-		assert.Contains(t, msg, "closed before it produced any output")
+		assert.Contains(t, msg, "closed unexpectedly before it completed its response")
+		// Covers both the silent-prefill drop and a mid-stream cut, since the
+		// truncation patterns can fire after partial tokens have streamed too.
 		assert.Contains(t, msg, "prefill")
+		assert.Contains(t, msg, "mid-stream")
 		assert.NotContains(t, msg, "unexpected end of JSON input")
 	})
 


### PR DESCRIPTION
## Summary

Fixes the failure mode in #3298 where a long local-model (DMR) prefill aborts with `model failed: error receiving from stream: unexpected end of JSON input`.

Investigation showed the issue's premise (a fixed ~30s client deadline in docker-agent) does not hold: docker-agent imposes no sub-5-minute stream deadline on either DMR endpoint path, on `main` or on v1.73.0. The real, fixable problem is error handling: when an intermediary drops a healthy-but-silent prefill connection, the resulting error is classified inconsistently and surfaced as a raw decoder string.

| Aspect | Before | After |
|---|---|---|
| `connection reset` mid-stream | retryable | retryable (unchanged) |
| `unexpected EOF` mid-stream | non-retryable | retryable |
| `unexpected end of JSON input` | non-retryable | retryable |
| truncated-JSON variant | matched `"invalid"` to non-retryable | retryable |
| user-facing message | raw decoder error | actionable guidance |

## Root cause

A long prefill on a local model streams no bytes until the first token. An idle/connection timeout in the model server, or in a proxy in front of it (on Docker Desktop the DMR `model-runner.docker.internal` endpoint is reached through the Docker socket experimental endpoint), can drop that idle connection before the first token. `curl` against a direct endpoint avoids the proxy hop and succeeds.

The dropped connection surfaces from the openai-go SSE decoder as one of `unexpected EOF`, `unexpected end of JSON input`, `connection reset by peer`, or `invalid character ...`, all wrapped as `error receiving from stream: <x>`. Only the `connection reset` variant was retryable; the truncation variants were classified non-retryable (one even matched the `"invalid"` non-retryable pattern), so the request failed hard with a cryptic message.

## Change

`pkg/modelerrors`:

- Add `streamTruncationPatterns` + `IsStreamTruncationError` for the `unexpected EOF` / `unexpected end of JSON input` shapes (context cancel/deadline explicitly excluded so user/idle-timeout teardown stays non-retryable).
- Classify these as retryable in `isRetryableModelError`, checked before the pattern loops so the truncated-JSON variant is not mis-caught by `"invalid"`.
- Return an actionable message from `FormatError` instead of the raw decoder error.

Why retrying helps: a truncation mid-prefill is transient. The backend's prompt (KV) cache makes a subsequent identical request's prefill fast enough to beat the idle limit. Verified on a real DMR instance (`ai/smollm2`): an identical prompt's time-to-first-byte collapses from ~0.55s to ~0.00s once cached, and the cache survives a connection aborted mid-prefill.

## Tests

- `pkg/modelerrors`: new cases in `TestIsRetryableModelError` (the exact wrapped strings, plus a genuinely-malformed payload that must stay non-retryable), a dedicated `TestIsStreamTruncationError`, and a `FormatError` truncation case.
- End-to-end against a fake DMR server through `docker agent run --exec`:

| Scenario | Result |
|---|---|
| First attempt truncated, backend serves normally after | retried and recovered (was: immediate non-retryable failure) |
| Every attempt truncated | retried with backoff, then the actionable message |

`task build` passes; `golangci-lint run ./pkg/modelerrors/...` reports 0 issues. (`task lint` could not run fully in the sandbox: the custom `lint/` tool fails to fetch a dependency over TLS, unrelated to this change.)

## Residual considerations

- The ~30s limit itself lives upstream (model server / proxy), not in docker-agent, so a client-side timeout knob would not prevent the drop. The deeper fix (SSE keep-alive during prefill, or a higher idle timeout) belongs in Docker Model Runner.
- DMR/llama.cpp uses round-robin slot caching, so the first retry may land on a cold slot and re-incur the prefill; later attempts hit the warm slot. The default 2 retries (3 attempts) usually covers this, but a configuration with more slots or a shorter idle limit could still exhaust attempts. If preferred, the retry count for stream-truncation specifically can be raised in a follow-up.
- The "idle between bytes" semantics requested in the issue already exists on `main` via the 5-minute idle timer (added in #3210, after v1.73.0). Exposing that timer as configurable (per-model YAML field or env var) is a separate change and can be added if maintainers want it.

Refs #3298
