### PR TITLE
fix(config): substitute ${env.X} in model and base_url fields

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -204,9 +204,17 @@
           ]
         },
         "base_url": {
-          "type": "string",
-          "description": "Base URL for the provider's API endpoint. Required for OpenAI-compatible providers, optional for native providers.",
-          "format": "uri",
+          "description": "Base URL for the provider's API endpoint. Required for OpenAI-compatible providers, optional for native providers. Accepts ${env.VAR} / ${VAR} references, substituted from the environment when a model using this provider is loaded.",
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "uri"
+            },
+            {
+              "type": "string",
+              "pattern": "^\\S*\\$\\{?[A-Za-z_]\\S*$"
+            }
+          ],
           "examples": [
             "https://router.example.com/v1"
           ]
@@ -1447,9 +1455,17 @@
           "maximum": 2
         },
         "base_url": {
-          "type": "string",
-          "description": "Base URL for the model API",
-          "format": "uri"
+          "description": "Base URL for the model API. Accepts ${env.VAR} / ${VAR} references, substituted from the environment when the model is loaded.",
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "uri"
+            },
+            {
+              "type": "string",
+              "pattern": "^\\S*\\$\\{?[A-Za-z_]\\S*$"
+            }
+          ]
         },
         "parallel_tool_calls": {
           "type": "boolean",

--- a/docs/configuration/models/index.md
+++ b/docs/configuration/models/index.md
@@ -410,6 +410,18 @@ models:
     token_key: INTERNAL_API_KEY
 ```
 
+The `model` and `base_url` fields accept `${env.VAR}` (or `${VAR}`) references, which are substituted from the environment when the model is loaded. This keeps the model id or endpoint out of the config when it is supplied by the environment, e.g. a Docker Compose / DMR setup:
+
+```yaml
+models:
+  nemotron3:
+    provider: dmr
+    model: "${env.NEMOTRON3_MODEL}"
+    base_url: "${env.DMR_BASE_URL}"
+```
+
+See [Variable Expansion in Config Fields]({{ '/configuration/overview/#variable-expansion-in-config-fields' | relative_url }}) for the full set of fields and supported syntaxes.
+
 See [Local Models]({{ '/providers/local/' | relative_url }}) for more examples of custom endpoints.
 
 ## Inheriting from Provider Definitions

--- a/docs/configuration/overview/index.md
+++ b/docs/configuration/overview/index.md
@@ -276,6 +276,18 @@ agents:
 
 The `working_dir`, `path`, and `env` value fields additionally accept the `${env.VAR}` form as an alias for `${VAR}`, so the JS-style syntax works there too. Richer JS expressions (e.g. `${env.VAR || 'default'}`) are still **not** evaluated in these fields.
 
+Model definitions follow the same rule. The `models.<name>.model` and `models.<name>.base_url` fields are expanded when the provider is built, accepting both `${env.VAR}` and `${VAR}`. This is useful when the model id or endpoint is injected by the environment (for example a Docker Compose / DMR setup that exports the model reference as a variable):
+
+```yaml
+models:
+  nemotron3:
+    provider: dmr
+    model: "${env.NEMOTRON3_MODEL}" # resolved from the environment at load time
+    base_url: "${DMR_BASE_URL}"     # ${VAR} is accepted as well
+```
+
+`token_key` is **not** expanded: it already names the environment variable that holds the API token, so its value is used as a key rather than substituted. An unset variable in `model` or `base_url` is reported as an error instead of dialing with an empty value.
+
 ### Quick reference
 
 | Field                                         | `${env.X}` | `$X` / `${X}` | `~` |
@@ -284,6 +296,7 @@ The `working_dir`, `path`, and `env` value fields additionally accept the `${env
 | `instruction` (agent and toolset)             |     ✓      |       ✗       |  ✗  |
 | `commands.*`                                  |     ✓      |       ✗       |  ✗  |
 | `headers`, `remote.headers`, `api_config.headers` |     ✓      |       ✗       |  ✗  |
+| `models.*.model`, `models.*.base_url`         |     ✓      |       ✓       |  ✗  |
 | `working_dir`, `path`                         |     ✓      |       ✓       |  ✓  |
 | `env` values                                  |     ✓      |       ✓       |  ✗  |
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -191,6 +191,7 @@ remote MCP endpoints.
 | [`custom_provider.yaml`](custom_provider.yaml) | Talking to any OpenAI-compatible endpoint via a custom provider. |
 | [`compose-secrets.yaml`](compose-secrets.yaml) | Reading API keys from Docker Compose / Swarm secrets. |
 | [`env_placeholders.yaml`](env_placeholders.yaml) | `${ENV_VAR}` substitution inside the YAML. |
+| [`model_env_substitution.yaml`](model_env_substitution.yaml) | `${env.VAR}` substitution in a model's `model` / `base_url`. |
 | [`nebius.yaml`](nebius.yaml) | Nebius cloud provider. |
 | [`grok.yaml`](grok.yaml) | xAI Grok model. |
 | [`github-copilot.yaml`](github-copilot.yaml) | GitHub Copilot models via OAuth device-flow. |

--- a/examples/model_env_substitution.yaml
+++ b/examples/model_env_substitution.yaml
@@ -1,0 +1,32 @@
+# Example: environment variable substitution in model definitions
+#
+# The `model` and `base_url` fields of a model definition accept ${env.VAR}
+# (and the shell-style ${VAR}) placeholders. They are substituted from the
+# environment when the model is loaded, so the model id and endpoint can be
+# injected by the environment (e.g. a Docker Compose / DMR setup) instead of
+# being hard-coded in the config.
+#
+# Usage:
+#   export NEMOTRON3_MODEL=huggingface.co/unsloth/nemotron-3-nano-30b-a3b-gguf:Q3_K_M
+#   export DMR_BASE_URL=http://localhost:12434/engines/v1
+#   docker agent run model_env_substitution.yaml
+#
+# Note: unlike command/instruction placeholders, an unset variable in `model`
+# or `base_url` is reported as an error rather than expanding to an empty
+# string, so a misconfigured environment fails fast.
+
+agents:
+  root:
+    model: nemotron3
+    description: Assistant whose model id comes from the environment
+    instruction: |
+      You are a helpful AI assistant.
+    toolsets:
+      - type: filesystem
+      - type: shell
+
+models:
+  nemotron3:
+    provider: dmr
+    model: "${env.NEMOTRON3_MODEL}"
+    base_url: "${env.DMR_BASE_URL}"

--- a/pkg/config/gather.go
+++ b/pkg/config/gather.go
@@ -93,6 +93,16 @@ func gatherEnvVarsForModel(ctx context.Context, cfg *latest.Config, modelName st
 // addEnvVarsForModelConfig adds required environment variables for a model config.
 // It checks custom providers first, then built-in aliases, then hardcoded fallbacks.
 func addEnvVarsForModelConfig(ctx context.Context, model *latest.ModelConfig, customProviders map[string]latest.ProviderConfig, requiredEnv map[string]bool, env environment.Provider) {
+	// The model and base_url fields support ${env.X}/${X} substitution, so any
+	// variable they reference must be set for the provider to be built (issue
+	// #2261). Collect these regardless of the credential logic below, which can
+	// return early (e.g. when base_url is set).
+	for _, field := range []string{model.Model, model.BaseURL} {
+		for _, name := range environment.Refs(field) {
+			requiredEnv[name] = true
+		}
+	}
+
 	// A model with non-API-key auth (e.g. Workload Identity Federation) does
 	// not require a TokenKey or the hardcoded API-key env var. Instead, the
 	// env vars referenced by its identity-token source are required.

--- a/pkg/config/latest/expand_env_test.go
+++ b/pkg/config/latest/expand_env_test.go
@@ -1,0 +1,74 @@
+package latest
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// upper is a stand-in expander: it substitutes ${env.NAME} / ${NAME} markers
+// from a fixed table so the test stays free of pkg/environment.
+func tableExpander(vars map[string]string) func(string) (string, error) {
+	return func(s string) (string, error) {
+		out := s
+		for k, v := range vars {
+			out = strings.ReplaceAll(out, "${env."+k+"}", v)
+			out = strings.ReplaceAll(out, "${"+k+"}", v)
+		}
+		return out, nil
+	}
+}
+
+func TestModelConfig_ExpandEnv(t *testing.T) {
+	vars := map[string]string{
+		"NEMOTRON3_MODEL": "huggingface.co/unsloth/nemotron-3-nano:Q3_K_M",
+		"DMR_BASE_URL":    "http://localhost:12434/engines/v1",
+	}
+
+	t.Run("expands model and base_url", func(t *testing.T) {
+		m := &ModelConfig{
+			Provider: "dmr",
+			Model:    "${env.NEMOTRON3_MODEL}",
+			BaseURL:  "${DMR_BASE_URL}",
+			TokenKey: "NEMOTRON3_MODEL", // must NOT be expanded: it names a var
+		}
+		require.NoError(t, m.ExpandEnv(tableExpander(vars)))
+		assert.Equal(t, "huggingface.co/unsloth/nemotron-3-nano:Q3_K_M", m.Model)
+		assert.Equal(t, "http://localhost:12434/engines/v1", m.BaseURL)
+		assert.Equal(t, "NEMOTRON3_MODEL", m.TokenKey)
+		assert.Equal(t, "dmr", m.Provider)
+	})
+
+	t.Run("plain values unchanged", func(t *testing.T) {
+		m := &ModelConfig{Model: "gpt-4o", BaseURL: "https://api.openai.com/v1"}
+		require.NoError(t, m.ExpandEnv(tableExpander(vars)))
+		assert.Equal(t, "gpt-4o", m.Model)
+		assert.Equal(t, "https://api.openai.com/v1", m.BaseURL)
+	})
+
+	t.Run("empty fields and nil expander are no-ops", func(t *testing.T) {
+		m := &ModelConfig{Model: "${env.NEMOTRON3_MODEL}"}
+		require.NoError(t, m.ExpandEnv(nil))
+		assert.Equal(t, "${env.NEMOTRON3_MODEL}", m.Model)
+
+		empty := &ModelConfig{}
+		require.NoError(t, empty.ExpandEnv(tableExpander(vars)))
+		assert.Empty(t, empty.Model)
+		assert.Empty(t, empty.BaseURL)
+	})
+
+	t.Run("nil receiver is a no-op", func(t *testing.T) {
+		var m *ModelConfig
+		require.NoError(t, m.ExpandEnv(tableExpander(vars)))
+	})
+
+	t.Run("propagates expander error", func(t *testing.T) {
+		boom := errors.New("variable not set")
+		m := &ModelConfig{Model: "${env.MISSING}"}
+		err := m.ExpandEnv(func(string) (string, error) { return "", boom })
+		assert.ErrorIs(t, err, boom)
+	})
+}

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -950,6 +950,37 @@ func (m *ModelConfig) UnloadAPI() string {
 	return v
 }
 
+// ExpandEnv rewrites the model config's value-bearing string fields in place by
+// passing each through expand, which substitutes ${env.X} / ${X} references
+// against the runtime environment. Only fields that carry a literal value the
+// provider sends or dials are expanded: model (the model identifier) and
+// base_url (the endpoint). token_key is intentionally excluded because it names
+// an environment variable rather than holding a value, and reference-only
+// fields (provider, routing/fallback specs) are resolved before a provider is
+// built.
+//
+// expand is injected so this package keeps no dependency on pkg/environment,
+// which already depends on the config packages. A nil expand or an empty field
+// is a no-op; the first expansion error is returned and stops processing.
+// Addresses issue #2261, where ${env.X} in a model's model field reached the
+// provider verbatim instead of being substituted.
+func (m *ModelConfig) ExpandEnv(expand func(string) (string, error)) error {
+	if m == nil || expand == nil {
+		return nil
+	}
+	for _, field := range []*string{&m.Model, &m.BaseURL} {
+		if *field == "" {
+			continue
+		}
+		expanded, err := expand(*field)
+		if err != nil {
+			return err
+		}
+		*field = expanded
+	}
+	return nil
+}
+
 // FlexibleModelConfig wraps ModelConfig to support both shorthand and full syntax.
 // It can be unmarshaled from either:
 //   - A shorthand string: "provider/model" (e.g., "anthropic/claude-sonnet-4-5")

--- a/pkg/environment/expand.go
+++ b/pkg/environment/expand.go
@@ -45,6 +45,26 @@ func Expand(ctx context.Context, value string, env Provider) (string, error) {
 	return expanded, nil
 }
 
+// Refs returns the names of the environment variables referenced by value
+// using the same ${env.X} / ${X} syntax Expand resolves, in first-seen order
+// and de-duplicated. It lets callers discover which variables a config field
+// requires (e.g. for an up-front "missing env var" check) without resolving
+// them. A value with no references yields nil.
+func Refs(value string) []string {
+	value = path.NormalizeEnvRefs(value)
+
+	var names []string
+	seen := map[string]bool{}
+	os.Expand(value, func(name string) string {
+		if !seen[name] {
+			seen[name] = true
+			names = append(names, name)
+		}
+		return ""
+	})
+	return names
+}
+
 func ToValues(envMap map[string]string) []string {
 	var values []string
 	for k, v := range envMap {

--- a/pkg/environment/refs_test.go
+++ b/pkg/environment/refs_test.go
@@ -1,0 +1,28 @@
+package environment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRefs(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  []string
+	}{
+		{"empty", "", nil},
+		{"no refs", "huggingface.co/unsloth/model:Q3_K_M", nil},
+		{"js form", "${env.NEMOTRON3_MODEL}", []string{"NEMOTRON3_MODEL"}},
+		{"shell form", "${DMR_BASE_URL}", []string{"DMR_BASE_URL"}},
+		{"bare form", "$MODEL", []string{"MODEL"}},
+		{"mixed and embedded", "http://${env.HOST}:${PORT}/v1", []string{"HOST", "PORT"}},
+		{"deduplicated", "${env.X}-${X}", []string{"X"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, Refs(tt.value))
+		})
+	}
+}

--- a/pkg/model/provider/defaults.go
+++ b/pkg/model/provider/defaults.go
@@ -2,12 +2,25 @@ package provider
 
 import (
 	"cmp"
+	"context"
 	"log/slog"
 	"maps"
 
 	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/environment"
 	"github.com/docker/docker-agent/pkg/modelinfo"
 )
+
+// expandModelConfigEnv substitutes ${env.X} / ${X} references in the model
+// config's value-bearing fields (model, base_url) against the runtime
+// environment. createDirectProvider calls it on the cloned, defaults-applied
+// config so every leaf provider (direct, routed, fallback, title) dials the
+// resolved endpoint and sends the resolved model id. See issue #2261.
+func expandModelConfigEnv(ctx context.Context, cfg *latest.ModelConfig, env environment.Provider) error {
+	return cfg.ExpandEnv(func(s string) (string, error) {
+		return environment.Expand(ctx, s, env)
+	})
+}
 
 // ---------------------------------------------------------------------------
 // Provider-type resolution

--- a/pkg/model/provider/factory.go
+++ b/pkg/model/provider/factory.go
@@ -72,6 +72,9 @@ func (r *Registry) createDirectProvider(ctx context.Context, cfg *latest.ModelCo
 		opt(&globalOptions)
 	}
 	enhancedCfg := applyProviderDefaults(cfg, globalOptions.Providers())
+	if err := expandModelConfigEnv(ctx, enhancedCfg, env); err != nil {
+		return nil, err
+	}
 	providerType := resolveProviderType(enhancedCfg)
 	factory, ok := r.factories[providerType]
 	if !ok {

--- a/pkg/model/provider/factory_env_test.go
+++ b/pkg/model/provider/factory_env_test.go
@@ -1,0 +1,103 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/environment"
+	"github.com/docker/docker-agent/pkg/model/provider/options"
+)
+
+// captureFactory records the config the factory receives so tests can assert
+// the value-bearing fields were expanded before the provider was built.
+func captureFactory(into **latest.ModelConfig) providerFactory {
+	return func(_ context.Context, cfg *latest.ModelConfig, _ environment.Provider, _ ...options.Opt) (Provider, error) {
+		*into = cfg
+		return &fakeProvider{}, nil
+	}
+}
+
+// TestCreateDirectProvider_ExpandsModelEnv covers issue #2261: ${env.X} in a
+// model config's model and base_url fields must be substituted against the
+// runtime environment before the provider is built, instead of being passed
+// through verbatim.
+func TestCreateDirectProvider_ExpandsModelEnv(t *testing.T) {
+	t.Parallel()
+
+	env := environment.NewMapEnvProvider(map[string]string{
+		"NEMOTRON3_MODEL": "huggingface.co/unsloth/nemotron-3-nano-30b-a3b-gguf:Q3_K_M",
+		"DMR_BASE_URL":    "http://localhost:12434/engines/v1",
+	})
+
+	var got *latest.ModelConfig
+	r := NewRegistry(map[string]providerFactory{"dmr": captureFactory(&got)})
+
+	cfg := &latest.ModelConfig{
+		Provider: "dmr",
+		Model:    "${env.NEMOTRON3_MODEL}",
+		BaseURL:  "${env.DMR_BASE_URL}",
+	}
+
+	_, err := r.createDirectProvider(t.Context(), cfg, env)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "huggingface.co/unsloth/nemotron-3-nano-30b-a3b-gguf:Q3_K_M", got.Model)
+	assert.Equal(t, "http://localhost:12434/engines/v1", got.BaseURL)
+
+	// The caller's config must be left untouched: expansion happens on the
+	// clone applyProviderDefaults returns, not the shared models map entry.
+	assert.Equal(t, "${env.NEMOTRON3_MODEL}", cfg.Model)
+	assert.Equal(t, "${env.DMR_BASE_URL}", cfg.BaseURL)
+}
+
+// TestCreateDirectProvider_ExpandsBareAndAliasForms verifies the shell-style
+// ${X} alias is accepted alongside the JS-template ${env.X} form, matching the
+// other env-expanded config fields.
+func TestCreateDirectProvider_ExpandsBareAndAliasForms(t *testing.T) {
+	t.Parallel()
+
+	env := environment.NewMapEnvProvider(map[string]string{"MY_MODEL": "gpt-4o"})
+
+	var got *latest.ModelConfig
+	r := NewRegistry(map[string]providerFactory{"openai": captureFactory(&got)})
+
+	cfg := &latest.ModelConfig{Provider: "openai", Model: "${MY_MODEL}"}
+	_, err := r.createDirectProvider(t.Context(), cfg, env)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "gpt-4o", got.Model)
+}
+
+// TestCreateDirectProvider_MissingEnvVarErrors verifies an unset variable
+// surfaces as a clear provider-creation error rather than dialing with an
+// empty model id.
+func TestCreateDirectProvider_MissingEnvVarErrors(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry(map[string]providerFactory{"dmr": tagFactory("dmr")})
+	cfg := &latest.ModelConfig{Provider: "dmr", Model: "${env.NOT_SET_MODEL}"}
+
+	_, err := r.createDirectProvider(t.Context(), cfg, environment.NewNoEnvProvider())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "NOT_SET_MODEL")
+}
+
+// TestCreateDirectProvider_PlainModelUnchanged verifies configs without any
+// reference are left exactly as-is (no spurious expansion or error).
+func TestCreateDirectProvider_PlainModelUnchanged(t *testing.T) {
+	t.Parallel()
+
+	var got *latest.ModelConfig
+	r := NewRegistry(map[string]providerFactory{"openai": captureFactory(&got)})
+
+	cfg := &latest.ModelConfig{Provider: "openai", Model: "gpt-4o", BaseURL: "https://api.openai.com/v1"}
+	_, err := r.createDirectProvider(t.Context(), cfg, environment.NewNoEnvProvider())
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "gpt-4o", got.Model)
+	assert.Equal(t, "https://api.openai.com/v1", got.BaseURL)
+}

--- a/pkg/model/provider/factory_js.go
+++ b/pkg/model/provider/factory_js.go
@@ -105,6 +105,9 @@ func (r *Registry) createDirectProvider(ctx context.Context, cfg *latest.ModelCo
 		opt(&globalOptions)
 	}
 	enhancedCfg := applyProviderDefaults(cfg, globalOptions.Providers())
+	if err := expandModelConfigEnv(ctx, enhancedCfg, env); err != nil {
+		return nil, err
+	}
 	providerType := resolveProviderType(enhancedCfg)
 	factory, ok := r.factories[providerType]
 	if !ok {


### PR DESCRIPTION
## Summary

`${env.X}` references in a model definition's `model` and `base_url` fields were passed to the provider verbatim instead of being substituted. The TUI showed the literal `Model: ${env.NEMOTRON3_MODEL}` (see the issue screenshot), and DMR received the unexpanded string as the model id.

Variable expansion was already wired for prompts, instructions, headers, paths and `env` values, but model definition fields were consumed raw by every provider.

## Root cause

| Aspect | Detail |
|--------|--------|
| Where | `model` / `base_url` are read directly by provider clients (e.g. DMR `pullDockerModelIfNeeded(cfg.Model)`, `configureModel(..., cfg.Model)`; OpenAI `cfg.BaseURL`) |
| Gap | No call site ran these fields through `environment.Expand` (only gemini/vertexai expanded `provider_opts`) |
| Status | Documented expansion table never listed model fields, so this was unimplemented behavior, not a regression |

## What changed

| File | Change |
|------|--------|
| `pkg/config/latest/types.go` | New `ModelConfig.ExpandEnv(expand)` rewrites `model` and `base_url` through an injected callback (keeps `config/latest` free of an `environment` import) |
| `pkg/model/provider/{defaults,factory,factory_js}.go` | `expandModelConfigEnv` is called in `createDirectProvider`, the single point every model (direct, routed, fallback, title) is built through; it runs on the clone `applyProviderDefaults` returns, so the shared models map is untouched |
| `pkg/environment/expand.go` | New `Refs(value)` extracts referenced variable names |
| `pkg/config/gather.go` | Required-env preflight now reports variables referenced by `model` / `base_url` |
| `docs/`, `examples/` | Expansion docs, quick-reference table row, and `examples/model_env_substitution.yaml` |

## Behavior

Both forms used elsewhere in configs are accepted; richer JS expressions (e.g. `${env.X || 'y'}`) are not, matching the other shell-style fields.

| Form from the issue | Result |
|---------------------|--------|
| `${env.NEMOTRON3_MODEL}` | substituted |
| `${NEMOTRON3_MODEL}` | substituted |
| `$NEMOTRON3_MODEL` | substituted |
| `NEMOTRON3_MODEL`, `env.NEMOTRON3_MODEL` | unchanged (not placeholder syntax in any field) |

`token_key` is intentionally not expanded: it names the variable holding the token rather than carrying a value. An unset variable in `model` / `base_url` now fails fast with `environment variable "X" not set` instead of dialing with an empty value.

## Tests

- `pkg/config/latest`: `ExpandEnv` (both fields, plain passthrough, empty/nil no-ops, error propagation)
- `pkg/environment`: `Refs` (js / shell / bare / mixed / dedup forms)
- `pkg/model/provider`: `createDirectProvider` expands `model` + `base_url`, accepts `${X}`, errors on a missing variable, leaves the caller config untouched, and passes plain configs through unchanged

## Validation note

The provider, config, and teamloader packages could not be compiled in the local sandbox (its firewall blocks fetching `github.com/docker/cli v29.6.1`, which is pinned in `go.mod` but absent from the module cache; the pristine tree fails identically). The leaf-package tests above were run and pass, and the rest is left to CI. The new DMR example is covered by `TestLoadExamples`, which sets dummy values for every referenced variable; a non-empty `base_url` makes the DMR client skip its status query, so it builds without a running endpoint.

Closes #2261
