### PR TITLE
feat: allow instruction_file to accept a list of files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 
 
+## [Unreleased]
+
+## What's New
+
+- Extends the agent `instruction_file` field to accept a list of files in addition to a single path; when several files are listed, their contents are concatenated in order (separated by a blank line)
+
+
 ## [v1.90.0] - 2026-06-29
 
 This release adds support for OpenCode Go and OpenCode Zen providers and improves error handling for stream truncation during model inference.

--- a/agent-schema.json
+++ b/agent-schema.json
@@ -562,8 +562,18 @@
           "description": "Instructions for the agent"
         },
         "instruction_file": {
-          "type": "string",
-          "description": "Path to a file, relative to the config file's directory, whose contents become the agent's instruction. Loaded at startup. Mutually exclusive with 'instruction'. Must be a local relative path inside the config directory (absolute paths and '..' traversal are rejected). Only supported for local file-based configs, not OCI/URL sources."
+          "description": "Path(s) to a file or files, relative to the config file's directory, whose contents become the agent's instruction. Accepts a single string or a list of strings; when several files are given their contents are concatenated in order, separated by a blank line. Loaded at startup. Mutually exclusive with 'instruction'. Each path must be a local relative path inside the config directory (absolute paths and '..' traversal are rejected). Only supported for local file-based configs, not OCI/URL sources.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
         },
         "harness": {
           "$ref": "#/definitions/HarnessConfig",

--- a/docs/configuration/agents/index.md
+++ b/docs/configuration/agents/index.md
@@ -17,7 +17,7 @@ agents:
     model: string # Required: model reference
     description: string # Required: what this agent does
     instruction: string # Required (unless instruction_file): system prompt
-    instruction_file: string # Optional: load the system prompt from a file relative to this config (mutually exclusive with instruction)
+    instruction_file: string | [list] # Optional: load the system prompt from one or more files relative to this config (mutually exclusive with instruction)
     sub_agents: [list] # Optional: local or external sub-agent references
     toolsets: [list] # Optional: tool configurations (use `type: rag` for RAG sources)
     fallback: # Optional: fallback config
@@ -83,7 +83,7 @@ agents:
 | `model`                     | string  | ✓        | Model reference. Either inline (`openai/gpt-5`) or a named model from the `models` section.                                                                              |
 | `description`               | string  | ✓        | Brief description of the agent's purpose. Used by coordinators to decide delegation.                                                                                          |
 | `instruction`               | string  | ✓        | System prompt that defines the agent's behavior, personality, and constraints. Required unless `instruction_file` is set.                                                      |
-| `instruction_file`          | string  | ✗        | Path to a file (relative to the config file's directory) whose contents become the agent's instruction, loaded at startup. Mutually exclusive with `instruction`. Must be a local relative path inside the config directory (absolute paths and `..` traversal are rejected). Only supported for local file-based configs, not OCI/URL sources. See [External Instruction Files](#external-instruction-files) below. |
+| `instruction_file`          | string \| array  | ✗        | Path(s) to a file or files (relative to the config file's directory) whose contents become the agent's instruction, loaded at startup. Accepts a single path or a list; multiple files are concatenated in order, separated by a blank line. Mutually exclusive with `instruction`. Each path must be a local relative path inside the config directory (absolute paths and `..` traversal are rejected). Only supported for local file-based configs, not OCI/URL sources. See [External Instruction Files](#external-instruction-files) below. |
 | `sub_agents`                | array   | ✗        | List of agent names or external OCI references this agent can delegate to. Supports local agents, registry references (e.g., `agentcatalog/pirate`), and named references (`name:reference`). Automatically enables the `transfer_task` tool. Pin external OCI references to a digest (`name@sha256:…`) to skip the per-run registry lookup that tag references incur. See [External Sub-Agents]({{ '/concepts/multi-agent/#external-sub-agents-from-registries' | relative_url }}). |
 | `toolsets`                  | array   | ✗        | List of tool configurations. See [Tool Config]({{ '/configuration/tools/' | relative_url }}).                                                                                                        |
 | `fallback`                  | object  | ✗        | Automatic model failover configuration.                                                                                                                                       |
@@ -144,8 +144,22 @@ The path is resolved relative to the config file's directory and the file's
 contents are loaded as the agent's instruction when the config is loaded. Notes:
 
 - **Mutually exclusive** with `instruction`. Setting both is an error.
-- The path must be a **local relative path inside the config directory**.
+- Each path must be a **local relative path inside the config directory**.
   Absolute paths and `..` traversal are rejected.
+- A **list** of files is also accepted; their contents are concatenated in
+  order, separated by a blank line. This lets a shared preamble be reused
+  across agents while each agent appends its own specifics:
+
+  ```yaml
+  agents:
+    writer:
+      model: openai/gpt-5-mini
+      description: Drafts and edits written content
+      instruction_file:
+        - instructions/shared-preamble.md
+        - instructions/writer.md
+  ```
+
 - Only supported for **local file-based configs**, not agents loaded from OCI
   registries or URLs. When an agent is pushed with `docker agent share push`,
   the file contents are inlined into the pushed artifact, so the published

--- a/examples/instruction_file.yaml
+++ b/examples/instruction_file.yaml
@@ -12,4 +12,9 @@ agents:
   writer:
     model: openai/gpt-5-mini
     description: Drafts and edits written content
-    instruction_file: instructions/writer.md
+    # instruction_file also accepts a list of files. Their contents are
+    # concatenated in order (separated by a blank line), so a shared preamble
+    # can be reused across agents while each appends its own specifics.
+    instruction_file:
+      - instructions/shared-preamble.md
+      - instructions/writer.md

--- a/examples/instructions/shared-preamble.md
+++ b/examples/instructions/shared-preamble.md
@@ -1,0 +1,4 @@
+You are part of a collaborative team of agents.
+
+Be honest about uncertainty, cite your sources when you have them, and never
+fabricate facts. Keep responses focused on what the user actually asked.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -72,12 +72,13 @@ func Load(ctx context.Context, source Source) (*latest.Config, error) {
 
 // resolveInstructionFiles replaces every agent's instruction_file reference
 // with the file's contents, loaded relative to the config file's directory.
-// Resolution happens once at load time so the rest of the pipeline (and any
-// marshalled/pushed copy of the config) only ever sees the inlined
-// Instruction; the InstructionFile field is cleared afterwards to keep the
-// loaded config self-contained.
+// When several files are listed their contents are concatenated in order,
+// separated by a blank line. Resolution happens once at load time so the rest
+// of the pipeline (and any marshalled/pushed copy of the config) only ever
+// sees the inlined Instruction; the InstructionFile field is cleared
+// afterwards to keep the loaded config self-contained.
 //
-// The reference must be a local relative path inside the config directory:
+// Each reference must be a local relative path inside the config directory:
 // absolute paths and "../" traversal are rejected, and reads are confined to
 // the directory with os.OpenRoot so symlinks cannot escape it. This mirrors
 // the path-safety rules used by the HCL file() helper and fileSource.Read.
@@ -86,7 +87,7 @@ func resolveInstructionFiles(cfg *latest.Config, source Source) error {
 
 	for i := range cfg.Agents {
 		agent := &cfg.Agents[i]
-		if agent.InstructionFile == "" {
+		if len(agent.InstructionFile) == 0 {
 			continue
 		}
 		if agent.Instruction != "" {
@@ -95,22 +96,29 @@ func resolveInstructionFiles(cfg *latest.Config, source Source) error {
 		if parentDir == "" {
 			return fmt.Errorf("agent %q: 'instruction_file' is only supported for local file-based configs, not OCI/URL sources", agent.Name)
 		}
-		if !filepath.IsLocal(agent.InstructionFile) {
-			return fmt.Errorf("agent %q: instruction_file %q must be a local relative path inside the config directory", agent.Name, agent.InstructionFile)
-		}
 
 		root, err := os.OpenRoot(parentDir)
 		if err != nil {
 			return fmt.Errorf("agent %q: opening config directory %q: %w", agent.Name, parentDir, err)
 		}
-		data, err := root.ReadFile(filepath.ToSlash(agent.InstructionFile))
-		_ = root.Close()
-		if err != nil {
-			return fmt.Errorf("agent %q: reading instruction_file %q: %w", agent.Name, agent.InstructionFile, err)
-		}
 
-		agent.Instruction = string(data)
-		agent.InstructionFile = ""
+		parts := make([]string, 0, len(agent.InstructionFile))
+		for _, path := range agent.InstructionFile {
+			if !filepath.IsLocal(path) {
+				_ = root.Close()
+				return fmt.Errorf("agent %q: instruction_file %q must be a local relative path inside the config directory", agent.Name, path)
+			}
+			data, err := root.ReadFile(filepath.ToSlash(path))
+			if err != nil {
+				_ = root.Close()
+				return fmt.Errorf("agent %q: reading instruction_file %q: %w", agent.Name, path, err)
+			}
+			parts = append(parts, string(data))
+		}
+		_ = root.Close()
+
+		agent.Instruction = strings.Join(parts, "\n\n")
+		agent.InstructionFile = nil
 	}
 
 	return nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -97,31 +97,42 @@ func resolveInstructionFiles(cfg *latest.Config, source Source) error {
 			return fmt.Errorf("agent %q: 'instruction_file' is only supported for local file-based configs, not OCI/URL sources", agent.Name)
 		}
 
-		root, err := os.OpenRoot(parentDir)
+		instruction, err := readInstructionFiles(parentDir, agent.InstructionFile)
 		if err != nil {
-			return fmt.Errorf("agent %q: opening config directory %q: %w", agent.Name, parentDir, err)
+			return fmt.Errorf("agent %q: %w", agent.Name, err)
 		}
 
-		parts := make([]string, 0, len(agent.InstructionFile))
-		for _, path := range agent.InstructionFile {
-			if !filepath.IsLocal(path) {
-				_ = root.Close()
-				return fmt.Errorf("agent %q: instruction_file %q must be a local relative path inside the config directory", agent.Name, path)
-			}
-			data, err := root.ReadFile(filepath.ToSlash(path))
-			if err != nil {
-				_ = root.Close()
-				return fmt.Errorf("agent %q: reading instruction_file %q: %w", agent.Name, path, err)
-			}
-			parts = append(parts, string(data))
-		}
-		_ = root.Close()
-
-		agent.Instruction = strings.Join(parts, "\n\n")
+		agent.Instruction = instruction
 		agent.InstructionFile = nil
 	}
 
 	return nil
+}
+
+// readInstructionFiles loads each path (resolved inside parentDir with
+// os.OpenRoot so symlinks cannot escape) and returns their contents joined by
+// a blank line. Each path must be a local relative path: absolute paths and
+// "../" traversal are rejected.
+func readInstructionFiles(parentDir string, paths []string) (string, error) {
+	root, err := os.OpenRoot(parentDir)
+	if err != nil {
+		return "", fmt.Errorf("opening config directory %q: %w", parentDir, err)
+	}
+	defer root.Close()
+
+	parts := make([]string, 0, len(paths))
+	for _, path := range paths {
+		if !filepath.IsLocal(path) {
+			return "", fmt.Errorf("instruction_file %q must be a local relative path inside the config directory", path)
+		}
+		data, err := root.ReadFile(filepath.ToSlash(path))
+		if err != nil {
+			return "", fmt.Errorf("reading instruction_file %q: %w", path, err)
+		}
+		parts = append(parts, string(data))
+	}
+
+	return strings.Join(parts, "\n\n"), nil
 }
 
 // CheckRequiredEnvVars checks which environment variables are required by the models and tools.

--- a/pkg/config/instruction_file_test.go
+++ b/pkg/config/instruction_file_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/config/latest"
 )
 
 // writeConfigDir creates a temp directory holding an agent config file named
@@ -179,4 +181,91 @@ func TestInstructionFileEmptyStringIgnored(t *testing.T) {
 	cfg, err := Load(t.Context(), NewFileSource(filepath.Join(dir, "agent.yaml")))
 	require.NoError(t, err)
 	assert.Equal(t, "inline prompt", cfg.Agents.First().Instruction)
+}
+
+// TestInstructionFileListConcatenated verifies that a list of instruction
+// files is concatenated in order, separated by a blank line.
+func TestInstructionFileListConcatenated(t *testing.T) {
+	t.Parallel()
+
+	cfgYAML := `agents:
+  root:
+    model: openai/gpt-4o
+    description: test agent
+    instruction_file:
+      - instructions/intro.md
+      - instructions/rules.md
+`
+	dir := writeConfigDir(t, cfgYAML, map[string]string{
+		"instructions/intro.md": "You are a helpful assistant.",
+		"instructions/rules.md": "Always be concise.",
+	})
+
+	cfg, err := Load(t.Context(), NewFileSource(filepath.Join(dir, "agent.yaml")))
+	require.NoError(t, err)
+
+	agent := cfg.Agents.First()
+	assert.Equal(t, "You are a helpful assistant.\n\nAlways be concise.", agent.Instruction)
+	assert.Empty(t, agent.InstructionFile)
+}
+
+// TestInstructionFileListMissingFile verifies that a missing file in the list
+// surfaces a clear error naming the offending path.
+func TestInstructionFileListMissingFile(t *testing.T) {
+	t.Parallel()
+
+	cfgYAML := `agents:
+  root:
+    model: openai/gpt-4o
+    description: test agent
+    instruction_file:
+      - instructions/intro.md
+      - instructions/missing.md
+`
+	dir := writeConfigDir(t, cfgYAML, map[string]string{
+		"instructions/intro.md": "hello",
+	})
+
+	_, err := Load(t.Context(), NewFileSource(filepath.Join(dir, "agent.yaml")))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "instructions/missing.md")
+}
+
+// TestInstructionFileListRejectsTraversal verifies that path-safety checks
+// apply to every entry of the list.
+func TestInstructionFileListRejectsTraversal(t *testing.T) {
+	t.Parallel()
+
+	cfgYAML := `agents:
+  root:
+    model: openai/gpt-4o
+    description: test agent
+    instruction_file:
+      - instructions/intro.md
+      - ../secret.md
+`
+	dir := writeConfigDir(t, cfgYAML, map[string]string{
+		"instructions/intro.md": "hello",
+	})
+	require.NoError(t, os.WriteFile(filepath.Join(filepath.Dir(dir), "secret.md"), []byte("secret"), 0o644))
+
+	_, err := Load(t.Context(), NewFileSource(filepath.Join(dir, "agent.yaml")))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "local relative path")
+	assert.Contains(t, err.Error(), "../secret.md")
+}
+
+// TestInstructionFileSingleElementRoundTrips verifies a single-element list
+// behaves like the scalar form and marshals back as a scalar.
+func TestInstructionFileSingleElementMarshalsAsScalar(t *testing.T) {
+	t.Parallel()
+
+	one := latest.InstructionFiles{"prompt.md"}
+	out, err := one.MarshalYAML()
+	require.NoError(t, err)
+	assert.Equal(t, "prompt.md", out)
+
+	data, err := one.MarshalJSON()
+	require.NoError(t, err)
+	assert.JSONEq(t, `"prompt.md"`, string(data))
 }

--- a/pkg/config/instruction_file_test.go
+++ b/pkg/config/instruction_file_test.go
@@ -269,3 +269,63 @@ func TestInstructionFileSingleElementMarshalsAsScalar(t *testing.T) {
 	require.NoError(t, err)
 	assert.JSONEq(t, `"prompt.md"`, string(data))
 }
+
+// TestInstructionFileEmptyMarshalsAsNull verifies that a zero-length value
+// marshals to null so the omitempty struct tag can drop the field entirely
+// rather than emitting `instruction_file: []`.
+func TestInstructionFileEmptyMarshalsAsNull(t *testing.T) {
+	t.Parallel()
+
+	var empty latest.InstructionFiles
+
+	out, err := empty.MarshalYAML()
+	require.NoError(t, err)
+	assert.Nil(t, out)
+
+	data, err := empty.MarshalJSON()
+	require.NoError(t, err)
+	assert.JSONEq(t, `null`, string(data))
+}
+
+// TestInstructionFileListDropsEmptyEntries verifies that empty strings inside
+// the list are dropped on decode, matching the scalar `""` no-op behaviour
+// instead of tripping the path-safety check.
+func TestInstructionFileListDropsEmptyEntries(t *testing.T) {
+	t.Parallel()
+
+	cfgYAML := `agents:
+  root:
+    model: openai/gpt-4o
+    description: test agent
+    instruction_file:
+      - ""
+      - instructions/intro.md
+`
+	dir := writeConfigDir(t, cfgYAML, map[string]string{
+		"instructions/intro.md": "hello",
+	})
+
+	cfg, err := Load(t.Context(), NewFileSource(filepath.Join(dir, "agent.yaml")))
+	require.NoError(t, err)
+	assert.Equal(t, "hello", cfg.Agents.First().Instruction)
+}
+
+// TestInstructionFileListAllEmptyIgnored verifies that a list made up solely
+// of empty strings is treated as absent (no instruction loaded, no error).
+func TestInstructionFileListAllEmptyIgnored(t *testing.T) {
+	t.Parallel()
+
+	cfgYAML := `agents:
+  root:
+    model: openai/gpt-4o
+    description: test agent
+    instruction: inline prompt
+    instruction_file:
+      - ""
+`
+	dir := writeConfigDir(t, cfgYAML, nil)
+
+	cfg, err := Load(t.Context(), NewFileSource(filepath.Join(dir, "agent.yaml")))
+	require.NoError(t, err)
+	assert.Equal(t, "inline prompt", cfg.Agents.First().Instruction)
+}

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -424,6 +424,55 @@ type HarnessConfig struct {
 	Thinking bool `json:"thinking,omitempty"`
 }
 
+// InstructionFiles holds one or more instruction file paths. It accepts both
+// a single string (`instruction_file: prompt.md`) and a list of strings
+// (`instruction_file: [intro.md, rules.md]`) in YAML and JSON. A single path
+// is marshalled back as a scalar so configs round-trip unchanged.
+type InstructionFiles []string
+
+func (f *InstructionFiles) unmarshal(scalar, list func(any) error) error {
+	var one string
+	if err := scalar(&one); err == nil {
+		if one == "" {
+			*f = nil
+		} else {
+			*f = InstructionFiles{one}
+		}
+		return nil
+	}
+	var many []string
+	if err := list(&many); err != nil {
+		return errors.New("instruction_file must be a string or a list of strings")
+	}
+	*f = InstructionFiles(many)
+	return nil
+}
+
+func (f *InstructionFiles) UnmarshalYAML(unmarshal func(any) error) error {
+	return f.unmarshal(unmarshal, unmarshal)
+}
+
+func (f InstructionFiles) MarshalYAML() (any, error) {
+	if len(f) == 1 {
+		return f[0], nil
+	}
+	return []string(f), nil
+}
+
+func (f *InstructionFiles) UnmarshalJSON(data []byte) error {
+	return f.unmarshal(
+		func(v any) error { return json.Unmarshal(data, v) },
+		func(v any) error { return json.Unmarshal(data, v) },
+	)
+}
+
+func (f InstructionFiles) MarshalJSON() ([]byte, error) {
+	if len(f) == 1 {
+		return json.Marshal(f[0])
+	}
+	return json.Marshal([]string(f))
+}
+
 // AgentConfig represents a single agent configuration
 type AgentConfig struct {
 	Name           string
@@ -433,18 +482,21 @@ type AgentConfig struct {
 	WelcomeMessage string          `json:"welcome_message,omitempty"`
 	Toolsets       []Toolset       `json:"toolsets,omitempty"`
 	Instruction    string          `json:"instruction,omitempty"`
-	// InstructionFile names a file, relative to the config file's directory,
-	// whose contents are loaded into Instruction when the config is loaded.
-	// It keeps long behavioral prompts out of the YAML, letting infrastructure
-	// configuration and instruction content evolve in separate files. Mutually
-	// exclusive with Instruction. Only file-based config sources are supported
-	// (not OCI/URL/bytes sources, which have no directory to resolve against).
-	// The field is cleared once resolved so the in-memory config stays
-	// self-contained (see config.Load).
-	InstructionFile string         `json:"instruction_file,omitempty" yaml:"instruction_file,omitempty"`
-	Harness         *HarnessConfig `json:"harness,omitempty"`
-	SubAgents       []string       `json:"sub_agents,omitempty"`
-	Handoffs        []string       `json:"handoffs,omitempty"`
+	// InstructionFile names one or more files, relative to the config file's
+	// directory, whose contents are loaded into Instruction when the config is
+	// loaded. It accepts either a single path (`instruction_file: prompt.md`)
+	// or a list (`instruction_file: [intro.md, rules.md]`); when several files
+	// are given their contents are concatenated in order, separated by a blank
+	// line. It keeps long behavioral prompts out of the YAML, letting
+	// infrastructure configuration and instruction content evolve in separate
+	// files. Mutually exclusive with Instruction. Only file-based config
+	// sources are supported (not OCI/URL/bytes sources, which have no directory
+	// to resolve against). The field is cleared once resolved so the in-memory
+	// config stays self-contained (see config.Load).
+	InstructionFile InstructionFiles `json:"instruction_file,omitempty" yaml:"instruction_file,omitempty"`
+	Harness         *HarnessConfig   `json:"harness,omitempty"`
+	SubAgents       []string         `json:"sub_agents,omitempty"`
+	Handoffs        []string         `json:"handoffs,omitempty"`
 	// ForceHandoff names an agent that unconditionally receives the
 	// conversation whenever this agent produces a final response,
 	// bypassing the LLM's tool-calling entirely. Unlike Handoffs (which

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -426,26 +426,39 @@ type HarnessConfig struct {
 
 // InstructionFiles holds one or more instruction file paths. It accepts both
 // a single string (`instruction_file: prompt.md`) and a list of strings
-// (`instruction_file: [intro.md, rules.md]`) in YAML and JSON. A single path
-// is marshalled back as a scalar so configs round-trip unchanged.
+// (`instruction_file: [intro.md, rules.md]`) in YAML and JSON. Empty strings
+// are dropped on decode, so `instruction_file: ""` and `instruction_file: [""]`
+// both decode to nil (treated as absent). A single path is marshalled back as
+// a scalar, and an empty value is omitted entirely, so configs round-trip
+// unchanged.
 type InstructionFiles []string
 
 func (f *InstructionFiles) unmarshal(scalar, list func(any) error) error {
 	var one string
 	if err := scalar(&one); err == nil {
-		if one == "" {
-			*f = nil
-		} else {
-			*f = InstructionFiles{one}
-		}
+		*f = nonEmptyInstructionFiles(one)
 		return nil
 	}
 	var many []string
 	if err := list(&many); err != nil {
 		return errors.New("instruction_file must be a string or a list of strings")
 	}
-	*f = InstructionFiles(many)
+	*f = nonEmptyInstructionFiles(many...)
 	return nil
+}
+
+// nonEmptyInstructionFiles returns the given paths with empty strings dropped,
+// or nil when nothing remains. This keeps the list form consistent with the
+// scalar form, where `instruction_file: ""` is treated as absent rather than a
+// path to resolve.
+func nonEmptyInstructionFiles(paths ...string) InstructionFiles {
+	var out InstructionFiles
+	for _, p := range paths {
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 func (f *InstructionFiles) UnmarshalYAML(unmarshal func(any) error) error {
@@ -453,6 +466,9 @@ func (f *InstructionFiles) UnmarshalYAML(unmarshal func(any) error) error {
 }
 
 func (f InstructionFiles) MarshalYAML() (any, error) {
+	if len(f) == 0 {
+		return nil, nil
+	}
 	if len(f) == 1 {
 		return f[0], nil
 	}
@@ -467,6 +483,9 @@ func (f *InstructionFiles) UnmarshalJSON(data []byte) error {
 }
 
 func (f InstructionFiles) MarshalJSON() ([]byte, error) {
+	if len(f) == 0 {
+		return json.Marshal(nil)
+	}
 	if len(f) == 1 {
 		return json.Marshal(f[0])
 	}

--- a/pkg/oci/package.go
+++ b/pkg/oci/package.go
@@ -97,9 +97,10 @@ func PackageFileAsOCIToStore(ctx context.Context, agentSource config.Source, art
 }
 
 // configUsesInstructionFile reports whether any agent in the raw config sets a
-// non-empty instruction_file. It is a best-effort, format-tolerant probe: a
-// parse failure (e.g. HCL) simply yields false, in which case the caller falls
-// back to its version-based decision.
+// non-empty instruction_file (either a single string or a non-empty list). It
+// is a best-effort, format-tolerant probe: a parse failure (e.g. HCL) simply
+// yields false, in which case the caller falls back to its version-based
+// decision.
 func configUsesInstructionFile(data []byte) bool {
 	var probe map[string]any
 	if err := yaml.Unmarshal(data, &probe); err != nil {
@@ -114,8 +115,17 @@ func configUsesInstructionFile(data []byte) bool {
 		if !ok {
 			continue
 		}
-		if path, ok := agent["instruction_file"].(string); ok && path != "" {
-			return true
+		switch ref := agent["instruction_file"].(type) {
+		case string:
+			if ref != "" {
+				return true
+			}
+		case []any:
+			for _, item := range ref {
+				if s, ok := item.(string); ok && s != "" {
+					return true
+				}
+			}
 		}
 	}
 	return false


### PR DESCRIPTION
Agents often share a common preamble — coding conventions, tone guidelines, a project glossary — but each also needs its own role-specific instructions. Previously `instruction_file` accepted only a single path, so teams had to maintain one monolithic file per agent or work around the limitation with custom tooling.

This change extends `instruction_file` so it accepts either a single string (unchanged behaviour) or a list of strings. When multiple paths are given, their contents are concatenated in order separated by a blank line, letting you compose a shared preamble with per-agent specifics cleanly. A single-element list serialises back to scalar form, so existing configs and round-tripped YAML are unaffected. The new form is reflected in `agent-schema.json` (`oneOf` string or array), the docs, and a new example under `examples/instruction_file.yaml` with an accompanying `examples/instructions/shared-preamble.md`.

All existing path-safety rules apply to every entry in the list: absolute paths and `..` traversal are rejected, and reads are confined with `os.OpenRoot` so symlinks cannot escape the config directory. List-form configs are local-file-only; OCI and URL sources are not supported (consistent with the existing single-file restriction). The `configUsesInstructionFile` OCI-push probe handles both string and list forms so pushed artifacts remain self-contained. The implementation lives in a new `InstructionFiles` type with custom YAML/JSON marshalers in `pkg/config/latest/types.go`; the resolution logic in `pkg/config/config.go` was refactored into a `readInstructionFiles` helper that uses a deferred `root.Close` to avoid leaking the `os.Root` handle. New tests cover list concatenation, missing files, per-entry traversal rejection, empty-entry rejection, and single-element scalar marshalling.