### PR TITLE
refactor(sidebar): redesign agents panel to uniform two-line entries

### DIFF
--- a/pkg/tui/components/sidebar/agent_click_test.go
+++ b/pkg/tui/components/sidebar/agent_click_test.go
@@ -92,10 +92,10 @@ func TestSidebar_AgentClickZones_EveryRenderedLineMapped(t *testing.T) {
 	}
 	assert.Positive(t, counts["agent1"], "agent1 should own rendered lines")
 	assert.Positive(t, counts["agent2"], "agent2 should own rendered lines")
-	// agent2 is a non-current roster agent: its row spans two lines (name+badge
+	// agent2 is a non-current roster agent: its entry spans two lines (name+badge
 	// then the indented model), and BOTH must map to it so a click on either
 	// switches to the agent.
-	assert.Equal(t, 2, counts["agent2"], "a roster agent owns both of its two row lines")
+	assert.Equal(t, 2, counts["agent2"], "a roster agent owns both of its two entry lines")
 
 	// The number of click zones equals the number of owned (non-blank) lines:
 	// every owned line is clickable.

--- a/pkg/tui/components/sidebar/agent_panel_test.go
+++ b/pkg/tui/components/sidebar/agent_panel_test.go
@@ -14,18 +14,18 @@ import (
 	"github.com/docker/docker-agent/pkg/tui/styles"
 )
 
-// newAgentPanelSidebar builds a sidebar whose current agent and roster are set,
-// ready to render the Agents panel at the given outer width.
-func newAgentPanelSidebar(t *testing.T, current string, width int, agents ...runtime.AgentDetails) *model {
+// newAgentPanelSidebar builds a sidebar whose current agent is "root" and whose
+// roster is set, ready to render the Agents panel at the given outer width.
+func newAgentPanelSidebar(t *testing.T, width int, agents ...runtime.AgentDetails) *model {
 	t.Helper()
 	sess := session.New()
 	ss := service.NewSessionState(sess)
-	ss.SetCurrentAgentName(current)
+	ss.SetCurrentAgentName("root")
 	m := New(t.Context(), ss).(*model)
 	m.sessionHasContent = true
 	m.titleGenerated = true
 	m.sessionTitle = "Test"
-	m.currentAgent = current
+	m.currentAgent = "root"
 	m.availableAgents = agents
 	m.width = width
 	m.height = 200
@@ -36,6 +36,30 @@ func newAgentPanelSidebar(t *testing.T, current string, width int, agents ...run
 func renderAgentPanel(m *model) []string {
 	out := ansi.Strip(m.agentInfo(m.contentWidth(false)))
 	return strings.Split(out, "\n")
+}
+
+const tabHeaderLines = 2 // tab title + TabStyle top padding before the body
+
+// agentBody returns the ANSI-stripped panel body lines aligned 1:1 with
+// m.agentLineOwners (populated as a side effect of rendering).
+func agentBody(m *model) (body []string) {
+	lines := renderAgentPanel(m)
+	return lines[tabHeaderLines : tabHeaderLines+len(m.agentLineOwners)]
+}
+
+// agentLines returns the two ANSI-stripped content lines owned by the named
+// agent: line1 (name + thinking + shortcut) and line2 (provider/model).
+func agentLines(m *model, name string) (line1, line2 string) {
+	body := agentBody(m)
+	for j, owner := range m.agentLineOwners {
+		if owner == name {
+			if j+1 < len(body) {
+				return body[j], body[j+1]
+			}
+			return body[j], ""
+		}
+	}
+	return "", ""
 }
 
 func TestClassifyThinking(t *testing.T) {
@@ -60,112 +84,114 @@ func TestClassifyThinking(t *testing.T) {
 	}
 }
 
-// TestCardThinkingLine covers every vocabulary case for the focus-card thinking
-// line, including the empty case (line omitted) and the token-budget formatting.
-func TestCardThinkingLine(t *testing.T) {
+// TestAgentEntryLayout verifies an agent renders as two lines: line 1 carries
+// the name, thinking badge and "^N" shortcut (no description), and line 2 the
+// provider/model.
+func TestAgentEntryLayout(t *testing.T) {
 	t.Parallel()
 
-	cases := []struct {
-		label    string
-		contains string
-		omit     bool
-	}{
-		{"high", "thinking " + gaugePattern(4) + " high", false},
-		{"adaptive", "thinking auto adaptive", false},
-		{"8192", "thinking " + styles.TokenGlyph + " 8.2K tokens", false},
-		{"off", "thinking " + gaugePattern(0) + " off", false},
-		{"", "", true},
-	}
-	for _, c := range cases {
-		got := ansi.Strip(cardThinkingLine(c.label))
-		if c.omit {
-			assert.Emptyf(t, got, "label %q should omit the card line", c.label)
-			continue
-		}
-		assert.Equalf(t, c.contains, got, "label %q", c.label)
-	}
+	m := newAgentPanelSidebar(t, 40,
+		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "claude-opus-4-8", Description: "Executive assistant", Thinking: "high"},
+	)
+
+	line1, line2 := agentLines(m, "root")
+	require.NotEmpty(t, line1)
+	assert.Contains(t, line1, "root", "line 1 shows the agent name")
+	assert.Contains(t, line1, "^1", "line 1 shows the switch shortcut")
+	assert.Contains(t, line1, gaugePattern(4), "line 1 shows the thinking gauge")
+	assert.NotContains(t, line1, "Executive assistant", "description is not shown")
+
+	body := strings.Join(agentBody(m), "\n")
+	assert.NotContains(t, body, "Executive assistant", "description is not shown anywhere")
+	assert.Contains(t, line2, "anthropic/claude-opus-4-8", "line 2 shows the provider/model")
 }
 
-// TestCardRenderedInPlace verifies the current agent renders as a focus card at
-// its natural config-order position (not pinned to the top), with the wrapped
-// description, full model id and thinking line, while the agents before it
-// render as compact rows.
-func TestCardRenderedInPlace(t *testing.T) {
+// TestCurrentAgentMarker verifies the current agent is marked with ▶ while the
+// other agents are not, and that each agent owns exactly its two content lines
+// (separators are unowned).
+func TestCurrentAgentMarker(t *testing.T) {
 	t.Parallel()
 
-	m := newAgentPanelSidebar(t, "root", 40,
+	m := newAgentPanelSidebar(t, 40,
 		runtime.AgentDetails{Name: "first", Provider: "openai", Model: "gpt-5.4-mini", Thinking: "off"},
-		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "claude-opus-4-8", Description: "Executive assistant", Thinking: "high"},
+		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "claude-opus-4-8", Thinking: "high"},
 		runtime.AgentDetails{Name: "last", Provider: "google", Model: "gemini-flash", Thinking: "off"},
 	)
 
-	lines := renderAgentPanel(m)
+	rootLine1, _ := agentLines(m, "root")
+	firstLine1, _ := agentLines(m, "first")
+	require.NotEmpty(t, rootLine1)
+	require.NotEmpty(t, firstLine1)
+	assert.Contains(t, rootLine1, "▶", "current agent is marked with ▶")
+	assert.NotContains(t, firstLine1, "▶", "non-current agents have no marker")
 
-	// Find the compact row for "first" and the card header for "root".
-	firstRow := -1
-	cardHeader := -1
-	for i, l := range lines {
-		if strings.Contains(l, "first") && strings.Contains(l, "^1") {
-			firstRow = i
+	// Each agent owns exactly its two content lines; separators are unowned.
+	counts := map[string]int{}
+	blanks := 0
+	for _, owner := range m.agentLineOwners {
+		if owner == "" {
+			blanks++
+			continue
 		}
-		if strings.Contains(l, "▶ root") {
-			cardHeader = i
-		}
+		counts[owner]++
 	}
-	require.Positive(t, firstRow, "compact row for the first (non-current) agent should render")
-	require.Positive(t, cardHeader, "card header for the current agent should render")
-	assert.Less(t, firstRow, cardHeader, "card must render in place, after the first agent's row")
-
-	body := strings.Join(lines, "\n")
-	assert.Contains(t, body, "Executive assistant", "card shows description")
-	assert.Contains(t, body, "anthropic/claude-opus-4-8", "card shows full provider/model")
-	assert.Contains(t, body, "thinking "+gaugePattern(4)+" high", "card shows gauge+value thinking line")
+	assert.Equal(t, 2, counts["first"])
+	assert.Equal(t, 2, counts["root"])
+	assert.Equal(t, 2, counts["last"])
+	assert.Positive(t, blanks, "entries are separated by blank, unowned lines")
 }
 
-// TestCardDescriptionWrapsToTwoLinesWithEllipsis verifies a long description is
-// wrapped to at most two lines, with the second line ending in an ellipsis.
-func TestCardDescriptionWrapsToTwoLinesWithEllipsis(t *testing.T) {
+// TestShortcutAtRightmost verifies the "^N" shortcut is the last visible content
+// on the name line: nothing is rendered to the right of it.
+func TestShortcutAtRightmost(t *testing.T) {
 	t.Parallel()
 
-	long := "This is a very long agent description that certainly will not fit on a single sidebar line and must wrap onto a second line and then be truncated"
-	m := newAgentPanelSidebar(t, "root", 40,
-		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "claude-opus-4-8", Description: long, Thinking: "high"},
+	m := newAgentPanelSidebar(t, 40,
+		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "opus", Thinking: "high"},
+		runtime.AgentDetails{Name: "alpha", Provider: "openai", Model: "gpt-5.4-mini", Thinking: "8192"},
 	)
 
-	lines := renderAgentPanel(m)
-
-	// Description lines are the wrapped body lines under the card.
-	var descLines []string
-	for _, l := range lines {
-		if strings.Contains(l, "This is a very long") || strings.Contains(l, "that certainly") {
-			descLines = append(descLines, l)
-		}
+	for _, name := range []string{"root", "alpha"} {
+		line1, _ := agentLines(m, name)
+		line := strings.TrimRight(line1, " ")
+		require.NotEmpty(t, line)
+		assert.Truef(t, strings.HasSuffix(line, "^1") || strings.HasSuffix(line, "^2"),
+			"line for %q must end with its shortcut, got %q", name, line)
 	}
-	require.Len(t, descLines, 2, "description must wrap to exactly two lines")
-	assert.Contains(t, descLines[1], "…", "second description line ends with an ellipsis")
 }
 
-// TestHarnessCardNoThinkingLine verifies a harness-backed current agent (empty
-// Thinking, harness type as model) shows the harness type and no thinking line.
-func TestHarnessCardNoThinkingLine(t *testing.T) {
+// TestShortcutColumnAlignment verifies the shortcuts align at a single right
+// column across name lines regardless of name length or badge width.
+func TestShortcutColumnAlignment(t *testing.T) {
 	t.Parallel()
 
-	m := newAgentPanelSidebar(t, "slack", 40,
-		runtime.AgentDetails{Name: "slack", Model: "claude-code", Description: "Slack agent", Thinking: ""},
+	m := newAgentPanelSidebar(t, 40,
+		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "opus", Thinking: "high"},
+		runtime.AgentDetails{Name: "a", Provider: "openai", Model: "gpt-4o", Thinking: "off"},
+		runtime.AgentDetails{Name: "longer-name", Provider: "openai", Model: "gpt-5.4", Thinking: "8192"},
 	)
 
-	body := strings.Join(renderAgentPanel(m), "\n")
-	assert.Contains(t, body, "claude-code", "harness card shows the harness type as the model")
-	assert.NotContains(t, body, "thinking:", "harness card has no thinking line")
+	end := -1
+	for _, name := range []string{"root", "a", "longer-name"} {
+		line1, _ := agentLines(m, name)
+		line := strings.TrimRight(line1, " ")
+		w := len([]rune(line))
+		if end == -1 {
+			end = w
+		} else {
+			assert.Equalf(t, end, w, "shortcuts for %q must end in a single column", name)
+		}
+	}
 }
 
-// TestRowColumnAlignment verifies roster rows share an aligned badge column and
-// that badges render with the expected vocabulary: effort levels become the
-// fixed-width gauge while token/adaptive/off keep their text badges.
-func TestRowColumnAlignment(t *testing.T) {
+// TestThinkingBadgeVocabularyOnLine verifies the thinking badge vocabulary
+// renders on the agent's name line: effort levels become the gauge, token
+// budgets keep the token glyph, adaptive becomes "auto", and off becomes an
+// empty gauge.
+func TestThinkingBadgeVocabularyOnLine(t *testing.T) {
 	t.Parallel()
 
-	m := newAgentPanelSidebar(t, "root", 40,
+	m := newAgentPanelSidebar(t, 40,
 		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "opus", Thinking: "high"},
 		runtime.AgentDetails{Name: "alpha", Provider: "openai", Model: "gpt-5.4-mini", Thinking: "off"},
 		runtime.AgentDetails{Name: "beta", Provider: "openai", Model: "gpt-5.4", Thinking: "high"},
@@ -173,103 +199,33 @@ func TestRowColumnAlignment(t *testing.T) {
 		runtime.AgentDetails{Name: "delta", Provider: "google", Model: "gemini", Thinking: "adaptive"},
 	)
 
-	lines := renderAgentPanel(m)
-
-	type rowBadge struct{ line, badge string }
-	var rows []rowBadge
-	for _, l := range lines {
-		switch {
-		case strings.Contains(l, "alpha"):
-			rows = append(rows, rowBadge{l, gaugePattern(0)}) // off → empty gauge
-		case strings.Contains(l, "beta"):
-			rows = append(rows, rowBadge{l, gaugePattern(4)}) // high → six-cell gauge
-		case strings.Contains(l, "gamma"):
-			rows = append(rows, rowBadge{l, styles.TokenGlyph + " 8.2K"})
-		case strings.Contains(l, "delta"):
-			rows = append(rows, rowBadge{l, "auto"})
-		}
+	want := map[string]string{
+		"alpha": gaugePattern(0),
+		"beta":  gaugePattern(4),
+		"gamma": styles.TokenGlyph + " 8.2K",
+		"delta": "auto",
 	}
-	require.Len(t, rows, 4, "all four non-current rows should render")
-
-	for _, r := range rows {
-		assert.Truef(t, strings.HasSuffix(strings.TrimRight(r.line, " "), r.badge), "row %q should end with badge %q", r.line, r.badge)
-	}
-
-	// Badges are right-aligned: every row is padded to the same total width, so
-	// the trimmed rows share the same rune length (badges end at one column).
-	end := -1
-	for _, r := range rows {
-		require.GreaterOrEqual(t, strings.LastIndex(r.line, r.badge), 0)
-		w := len([]rune(strings.TrimRight(r.line, " ")))
-		if end == -1 {
-			end = w
-		} else {
-			assert.Equal(t, end, w, "right-aligned badges must end in a single column")
-		}
+	for name, badge := range want {
+		line1, _ := agentLines(m, name)
+		require.NotEmptyf(t, line1, "row for %q should render", name)
+		assert.Containsf(t, line1, badge, "row %q should show badge %q", name, badge)
 	}
 }
 
-// TestRowModelLeftTruncated verifies the model column keeps its informative tail
-// (left-truncation with a leading ellipsis) when it overflows.
-func TestRowModelLeftTruncated(t *testing.T) {
+// TestModelLineLeftTruncated verifies the provider/model on line 2 keeps its
+// informative tail (left-truncation with a leading ellipsis) when it overflows.
+func TestModelLineLeftTruncated(t *testing.T) {
 	t.Parallel()
 
-	m := newAgentPanelSidebar(t, "root", 30,
+	m := newAgentPanelSidebar(t, 28,
 		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "opus", Thinking: "high"},
 		runtime.AgentDetails{Name: "agent2", Provider: "anthropic", Model: "claude-sonnet-4-6", Thinking: "off"},
 	)
 
-	lines := renderAgentPanel(m)
-	var model string
-	for i, l := range lines {
-		if strings.Contains(l, "agent2") && i+1 < len(lines) {
-			model = lines[i+1] // the provider/model is the row's second line
-		}
-	}
-	require.NotEmpty(t, model)
-	assert.Contains(t, model, "…", "overflowing model is left-truncated with an ellipsis")
-	assert.Contains(t, model, "-4-6", "informative model tail survives left-truncation")
-}
-
-// TestRowDigitsRenderTokenBadge verifies a digits-only wire label produces a
-// token badge with the token glyph and formatted count.
-func TestRowDigitsRenderTokenBadge(t *testing.T) {
-	t.Parallel()
-
-	m := newAgentPanelSidebar(t, "root", 40,
-		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "opus", Thinking: "high"},
-		runtime.AgentDetails{Name: "gateway", Provider: "openai", Model: "gpt-5.4", Thinking: "8192"},
-	)
-
-	body := strings.Join(renderAgentPanel(m), "\n")
-	assert.Contains(t, body, styles.TokenGlyph+" 8.2K", "digits label renders a token badge")
-}
-
-// TestHarnessRowNoBadge verifies a harness row shows the harness type as the
-// model and no thinking badge.
-func TestHarnessRowNoBadge(t *testing.T) {
-	t.Parallel()
-
-	m := newAgentPanelSidebar(t, "root", 40,
-		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "opus", Thinking: "high"},
-		runtime.AgentDetails{Name: "slack", Model: "claude-code", Thinking: ""},
-	)
-
-	lines := renderAgentPanel(m)
-	var line1, line2 string
-	for i, l := range lines {
-		if strings.Contains(l, "slack") {
-			line1 = l
-			if i+1 < len(lines) {
-				line2 = lines[i+1]
-			}
-		}
-	}
-	require.NotEmpty(t, line1)
-	assert.Contains(t, line2, "claude-code", "harness row shows the harness type on its model line")
-	assert.NotContains(t, line1, styles.GaugeFilled, "harness row has no thinking gauge")
-	assert.NotContains(t, line1, styles.GaugeEmpty, "harness row has no thinking gauge")
-	assert.NotContains(t, line1, styles.TokenGlyph, "harness row has no token badge")
+	_, line2 := agentLines(m, "agent2")
+	require.NotEmpty(t, line2)
+	assert.Contains(t, line2, "…", "overflowing model is left-truncated with an ellipsis")
+	assert.Contains(t, line2, "-4-6", "informative model tail survives left-truncation")
 }
 
 // TestMoreThanNineAgentsNoShortcutBeyond9 verifies agents past the 9th get no
@@ -288,56 +244,34 @@ func TestMoreThanNineAgentsNoShortcutBeyond9(t *testing.T) {
 			Thinking: "off",
 		})
 	}
-	m := newAgentPanelSidebar(t, "root", 40, agents...)
+	m := newAgentPanelSidebar(t, 40, agents...)
 
 	body := strings.Join(renderAgentPanel(m), "\n")
 	assert.Contains(t, body, "^9", "the 9th agent keeps its shortcut")
 	assert.NotContains(t, body, "^10", "agents beyond the 9th have no shortcut")
 }
 
-// TestDegradationLadder verifies the two-line roster degrades by available
-// width: the provider/model always occupies line 2, while line 1's thinking
-// gauge collapses from the full six-cell gauge to a single cell near MinWidth.
-func TestDegradationLadder(t *testing.T) {
+// TestNameTruncatesNearMinWidth verifies that at a narrow width the gauge
+// collapses to a single cell while the model still occupies line 2.
+func TestNameTruncatesNearMinWidth(t *testing.T) {
 	t.Parallel()
 
-	makeModel := func(width int) *model {
-		return newAgentPanelSidebar(t, "root", width,
-			runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "opus", Thinking: "high"},
-			runtime.AgentDetails{Name: "agent2", Provider: "anthropic", Model: "claude-sonnet-4-6", Thinking: "off"},
-		)
-	}
+	m := newAgentPanelSidebar(t, 21,
+		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "opus", Thinking: "high"},
+		runtime.AgentDetails{Name: "agent2", Provider: "anthropic", Model: "claude-sonnet-4-6", Thinking: "high"},
+	)
 
-	linesFor := func(m *model, name string) (line1, line2 string) {
-		ls := renderAgentPanel(m)
-		for i, l := range ls {
-			if strings.Contains(l, name) {
-				line1 = l
-				if i+1 < len(ls) {
-					line2 = ls[i+1]
-				}
-				return line1, line2
-			}
-		}
-		return "", ""
-	}
-
-	// Wide: full empty gauge on line 1, full model on line 2.
-	w1, w2 := linesFor(makeModel(40), "agent2")
-	assert.Contains(t, w1, gaugePattern(0), "wide layout shows the full empty gauge for off")
-	assert.Contains(t, w2, "sonnet-4-6", "wide layout shows the full model on line 2")
-
-	// Near MinWidth (content < rowGlyphOnlyMinWidth): line-1 gauge collapses to a
-	// single cell; the model on line 2 truncates with a leading ellipsis.
-	n1, n2 := linesFor(makeModel(21), "agent2")
-	assert.NotContains(t, n1, gaugePattern(0), "glyph-only layout collapses the full gauge")
-	assert.Contains(t, n1, styles.GaugeEmpty, "glyph-only layout keeps a single gauge cell")
-	assert.Contains(t, n2, "…", "narrow layout left-truncates the model on line 2")
+	line1, line2 := agentLines(m, "agent2")
+	require.NotEmpty(t, line1)
+	// glyph-only step keeps a single filled gauge cell, not the full six-cell gauge.
+	assert.NotContains(t, line1, gaugePattern(4), "narrow layout collapses the full gauge")
+	assert.Contains(t, line1, styles.GaugeFilled, "narrow layout keeps a single gauge cell")
+	assert.Contains(t, line2, "…", "narrow layout left-truncates the model on line 2")
 }
 
-// TestClickZonesCardAndRow verifies that clicking a card line and clicking a row
-// line both resolve to the correct agent.
-func TestClickZonesCardAndRow(t *testing.T) {
+// TestClickZonesEveryLine verifies that clicking any rendered agent line (either
+// the name line or the model line) resolves to the correct agent.
+func TestClickZonesEveryLine(t *testing.T) {
 	t.Parallel()
 
 	sess := session.New()
@@ -351,7 +285,7 @@ func TestClickZonesCardAndRow(t *testing.T) {
 	m.currentAgent = "root"
 	m.availableAgents = []runtime.AgentDetails{
 		{Name: "first", Provider: "openai", Model: "gpt-5.4-mini", Thinking: "off"},
-		{Name: "root", Provider: "anthropic", Model: "claude-opus-4-8", Description: "Executive assistant", Thinking: "high"},
+		{Name: "root", Provider: "anthropic", Model: "claude-opus-4-8", Thinking: "high"},
 	}
 	m.width = 40
 	m.height = 200
@@ -359,42 +293,38 @@ func TestClickZonesCardAndRow(t *testing.T) {
 	_ = sb.View()
 
 	paddingLeft := m.layoutCfg.PaddingLeft
-	foundCard := false
-	foundRow := false
+	foundCurrent := false
+	foundOther := false
 	for y := range len(m.cachedLines) {
 		result, name := sb.HandleClickType(paddingLeft+2, y)
 		if result != ClickAgent {
 			continue
 		}
 		if name == "root" {
-			foundCard = true
+			foundCurrent = true
 		}
 		if name == "first" {
-			foundRow = true
+			foundOther = true
 		}
 	}
-	assert.True(t, foundCard, "clicking a card line should switch to the card's agent")
-	assert.True(t, foundRow, "clicking a row line should switch to the row's agent")
+	assert.True(t, foundCurrent, "clicking the current agent's line switches to it")
+	assert.True(t, foundOther, "clicking another agent's line switches to it")
 }
 
 // TestRosterSeparatesAgentsWithBlankLine verifies a blank separator line is
-// inserted between agent entries (so the two-line rows and the card don't blend
-// together) and that the separator carries an empty owner: a roster agent owns
-// exactly its two content lines, never the separator, so click zones stay
-// aligned.
+// inserted between agent entries and that the separator carries an empty owner,
+// so each agent owns exactly its two content lines and click zones stay aligned.
 func TestRosterSeparatesAgentsWithBlankLine(t *testing.T) {
 	t.Parallel()
 
-	m := newAgentPanelSidebar(t, "root", 40,
-		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "opus", Description: "Lead", Thinking: "high"},
+	m := newAgentPanelSidebar(t, 40,
+		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "opus", Thinking: "high"},
 		runtime.AgentDetails{Name: "alpha", Provider: "openai", Model: "gpt-5.4-mini", Thinking: "off"},
 		runtime.AgentDetails{Name: "beta", Provider: "openai", Model: "gpt-5.4", Thinking: "high"},
 	)
 
 	_ = renderAgentPanel(m) // populates agentLineOwners
 
-	// Each non-current roster agent owns exactly its two content lines; the
-	// separators between entries are owned by nobody.
 	counts := map[string]int{}
 	blanks := 0
 	for _, owner := range m.agentLineOwners {
@@ -404,12 +334,13 @@ func TestRosterSeparatesAgentsWithBlankLine(t *testing.T) {
 		}
 		counts[owner]++
 	}
-	assert.Equal(t, 2, counts["alpha"], "a roster agent owns exactly its two content lines, not the separator")
-	assert.Equal(t, 2, counts["beta"], "a roster agent owns exactly its two content lines, not the separator")
+	assert.Equal(t, 2, counts["root"], "an agent owns exactly its two content lines, not the separator")
+	assert.Equal(t, 2, counts["alpha"])
+	assert.Equal(t, 2, counts["beta"])
 	assert.Positive(t, blanks, "agents are separated by blank, unowned lines")
 
-	// A blank separator immediately precedes each non-first agent's first owned
-	// line, and no separator leads the panel.
+	// The panel does not start with a separator, and a blank separator precedes
+	// the alpha entry.
 	require.NotEmpty(t, m.agentLineOwners)
 	assert.NotEmpty(t, m.agentLineOwners[0], "the panel does not start with a separator")
 	alphaStart := -1
@@ -419,6 +350,6 @@ func TestRosterSeparatesAgentsWithBlankLine(t *testing.T) {
 			break
 		}
 	}
-	require.Positive(t, alphaStart, "alpha should own lines after the card")
+	require.Positive(t, alphaStart, "alpha should own lines after root")
 	assert.Empty(t, m.agentLineOwners[alphaStart-1], "a blank separator precedes the alpha entry")
 }

--- a/pkg/tui/components/sidebar/effort_gauge_test.go
+++ b/pkg/tui/components/sidebar/effort_gauge_test.go
@@ -68,61 +68,45 @@ func TestThinkingBadgeVocabulary(t *testing.T) {
 	}
 }
 
-// TestCardThinkingLineShowsGaugeAndValue verifies the focus card thinking line
-// is "thinking <gauge> <word>" (no ✻): both the gauge and the descriptive word.
-func TestCardThinkingLineShowsGaugeAndValue(t *testing.T) {
+// TestCardThinkingLineShowsGaugeAndValue verifies the shared thinking summary
+// used by the agent-details dialog is "<gauge> <word>" (no ✻): both the gauge
+// and the descriptive word.
+func TestThinkingGaugeValueShowsGaugeAndWord(t *testing.T) {
 	t.Parallel()
 
-	got := ansi.Strip(cardThinkingLine("high"))
-	assert.Equal(t, "thinking "+gaugePattern(4)+" high", got)
-	assert.NotContains(t, got, styles.ThinkingGlyph, "card line carries no ✻ glyph")
+	got := ansi.Strip(toolcommon.ThinkingGaugeValue("high"))
+	assert.Equal(t, gaugePattern(4)+" high", got)
+	assert.NotContains(t, got, styles.ThinkingGlyph, "summary carries no ✻ glyph")
 
 	// off shows a dim empty gauge plus the word "off".
-	gotOff := ansi.Strip(cardThinkingLine("off"))
-	assert.Equal(t, "thinking "+strings.Repeat(styles.GaugeEmpty, toolcommon.EffortGaugeCells)+" off", gotOff)
+	gotOff := ansi.Strip(toolcommon.ThinkingGaugeValue("off"))
+	assert.Equal(t, strings.Repeat(styles.GaugeEmpty, toolcommon.EffortGaugeCells)+" off", gotOff)
 
-	// Empty label omits the line entirely.
-	assert.Empty(t, ansi.Strip(cardThinkingLine("")))
+	// Empty label omits the summary entirely.
+	assert.Empty(t, ansi.Strip(toolcommon.ThinkingGaugeValue("")))
 }
 
 // TestRowGaugeColumnAlignment verifies a roster of effort-level agents renders
-// fixed-width six-cell gauges on line 1 that all end in the same right-aligned
-// column.
+// fixed-width six-cell gauges that all end before the shortcut column at the
+// same right-aligned position.
 func TestRowGaugeColumnAlignment(t *testing.T) {
 	t.Parallel()
 
-	m := newAgentPanelSidebar(t, "root", 40,
+	m := newAgentPanelSidebar(t, 40,
 		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "opus", Thinking: "high"},
 		runtime.AgentDetails{Name: "alpha", Provider: "openai", Model: "gpt-5.4-mini", Thinking: "minimal"},
 		runtime.AgentDetails{Name: "beta", Provider: "openai", Model: "gpt-5.4", Thinking: "medium"},
 		runtime.AgentDetails{Name: "gamma", Provider: "openai", Model: "gpt-4o", Thinking: "max"},
 	)
 
-	lines := renderAgentPanel(m)
-
 	wantGauge := map[string]string{
 		"alpha": gaugePattern(1),
 		"beta":  gaugePattern(3),
 		"gamma": gaugePattern(6),
 	}
-	seen := 0
-	end := -1
-	for _, l := range lines {
-		for name, gauge := range wantGauge {
-			// The name sits on line 1; the model (line 2) never contains it.
-			if !strings.Contains(l, name) {
-				continue
-			}
-			seen++
-			trimmed := strings.TrimRight(l, " ")
-			assert.Truef(t, strings.HasSuffix(trimmed, gauge), "row %q should end with gauge %q", trimmed, gauge)
-			w := len([]rune(trimmed))
-			if end == -1 {
-				end = w
-			} else {
-				assert.Equal(t, end, w, "fixed-width gauges must end in a single column")
-			}
-		}
+	for name, gauge := range wantGauge {
+		line1, _ := agentLines(m, name)
+		require.NotEmptyf(t, line1, "row for %q should render", name)
+		assert.Containsf(t, line1, gauge, "row %q should contain gauge %q", name, gauge)
 	}
-	require.Equal(t, len(wantGauge), seen, "every effort-level row should render")
 }

--- a/pkg/tui/components/sidebar/effort_gauge_test.go
+++ b/pkg/tui/components/sidebar/effort_gauge_test.go
@@ -68,7 +68,7 @@ func TestThinkingBadgeVocabulary(t *testing.T) {
 	}
 }
 
-// TestCardThinkingLineShowsGaugeAndValue verifies the shared thinking summary
+// TestThinkingGaugeValueShowsGaugeAndWord verifies the shared thinking summary
 // used by the agent-details dialog is "<gauge> <word>" (no ✻): both the gauge
 // and the descriptive word.
 func TestThinkingGaugeValueShowsGaugeAndWord(t *testing.T) {
@@ -87,8 +87,8 @@ func TestThinkingGaugeValueShowsGaugeAndWord(t *testing.T) {
 }
 
 // TestRowGaugeColumnAlignment verifies a roster of effort-level agents renders
-// fixed-width six-cell gauges that all end before the shortcut column at the
-// same right-aligned position.
+// fixed-width six-cell gauges on their name line, and that the gauges all end
+// at the same right-aligned column (just before the shared shortcut column).
 func TestRowGaugeColumnAlignment(t *testing.T) {
 	t.Parallel()
 
@@ -104,9 +104,21 @@ func TestRowGaugeColumnAlignment(t *testing.T) {
 		"beta":  gaugePattern(3),
 		"gamma": gaugePattern(6),
 	}
+	gaugeEnd := -1
 	for name, gauge := range wantGauge {
 		line1, _ := agentLines(m, name)
 		require.NotEmptyf(t, line1, "row for %q should render", name)
 		assert.Containsf(t, line1, gauge, "row %q should contain gauge %q", name, gauge)
+
+		// The gauge column ends where the gauge substring ends; all rows must
+		// share that column so the badges line up.
+		idx := strings.Index(line1, gauge)
+		require.GreaterOrEqualf(t, idx, 0, "gauge %q must appear in row %q", gauge, line1)
+		end := len([]rune(line1[:idx])) + len([]rune(gauge))
+		if gaugeEnd == -1 {
+			gaugeEnd = end
+		} else {
+			assert.Equalf(t, gaugeEnd, end, "gauge for %q must end in the shared badge column", name)
+		}
 	}
 }

--- a/pkg/tui/components/sidebar/layout.go
+++ b/pkg/tui/components/sidebar/layout.go
@@ -7,17 +7,19 @@ const (
 	// treePrefixWidth is the width of tree-structure prefixes like "├ " and "└ ".
 	treePrefixWidth = 2
 
-	// rowShortcutWidth is the fixed width of a roster row's leading
-	// shortcut/spinner cell ("^N" or a spinner frame) plus its trailing space.
-	rowShortcutWidth = 3
+	// agentMarkerWidth is the fixed width of an agent line's leading marker cell
+	// (the ▶ current-agent / spinner glyph plus a trailing space). Non-current
+	// agents pad this column so their names stay aligned.
+	agentMarkerWidth = 2
 
-	// rowIndentWidth is the indent of a roster row's second line (the
-	// provider/model), aligning the model under the agent name on line 1.
-	rowIndentWidth = 3
+	// agentShortcutWidth is the fixed width of an agent line's trailing "^N"
+	// switch-shortcut column, kept constant so the shortcuts align at the right
+	// edge whether or not a given agent has one.
+	agentShortcutWidth = 2
 
 	// rowGlyphOnlyMinWidth is the content-column breakpoint (near MinWidth) below
-	// which a roster row's line-1 thinking gauge collapses to a single cell so
-	// the name column keeps usable room. The model always stays on line 2.
+	// which an agent line's thinking gauge collapses to a single cell so the name
+	// column keeps usable room.
 	rowGlyphOnlyMinWidth = 22
 
 	// starClickWidth is the clickable area width for the star indicator.

--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -1231,14 +1231,16 @@ func (m *model) queueSection(contentWidth int) string {
 	return m.renderTab(title, strings.Join(lines, "\n"), contentWidth)
 }
 
-// agentInfo renders the Agents panel: the current agent as a focus card in its
-// natural config-order position, and every other agent as a compact two-line
-// roster row, with a blank separator line between entries so the two-line rows
-// and the card don't blend together. It records which body line belongs to
-// which agent (agentLineOwners) so click zones can be registered explicitly
-// (see buildAgentClickZones) rather than re-derived from blank-line heuristics;
-// each separator carries an empty owner so it stays unclickable and never
-// shifts an agent's click zone.
+// agentInfo renders the Agents panel: every agent as a two-line entry, with a
+// blank separator line between entries. Line 1 shows the agent's name (in its
+// accent color), the thinking badge right-aligned, and the "^N" switch shortcut
+// flush against the right edge; line 2 shows the indented provider/model. The
+// current agent is marked with ▶ (or the spinner while it works); the other
+// agents pad that marker column so their names stay aligned. Descriptions are
+// deliberately omitted. Each content line is owned by its agent (agentLineOwners)
+// so click zones can be registered explicitly (see buildAgentClickZones) and a
+// click on either line switches to that agent; separators carry an empty owner
+// so they stay unclickable.
 func (m *model) agentInfo(contentWidth int) string {
 	// Read current agent from session state so sidebar updates when agent is switched
 	currentAgent := m.sessionState.CurrentAgentName()
@@ -1254,33 +1256,26 @@ func (m *model) agentInfo(contentWidth int) string {
 		agentTitle += " ↔"
 	}
 
-	rl := m.computeRosterLayout(contentWidth, currentAgent)
+	glyphOnly := contentWidth < rowGlyphOnlyMinWidth
+	nameWidth := m.agentNameWidth(contentWidth, glyphOnly)
 
-	var bodyLines []string
-	var owners []string
+	var bodyLines, owners []string
 	add := func(line, owner string) {
 		bodyLines = append(bodyLines, line)
 		owners = append(owners, owner)
 	}
-
 	for i, agent := range m.availableAgents {
-		// Separate every agent entry with a blank line so the two-line rows and
-		// the focus card stay visually distinct. The separator carries an empty
-		// owner so it is never attributed to an agent or made clickable.
+		// Separate entries with a blank, unowned line so the two-line entries stay
+		// visually distinct without being attributed to (or made clickable for)
+		// any agent.
 		if len(bodyLines) > 0 {
 			add("", "")
 		}
-		if agent.Name == currentAgent {
-			for _, line := range m.renderAgentCard(agent, i, contentWidth) {
-				add(line, agent.Name)
-			}
-			continue
-		}
-		for _, line := range m.renderAgentRow(agent, i, rl) {
+		current := agent.Name == currentAgent
+		for _, line := range m.renderAgentLine(agent, i, contentWidth, nameWidth, glyphOnly, current) {
 			add(line, agent.Name)
 		}
 	}
-
 	m.agentLineOwners = owners
 
 	return m.renderTab(agentTitle, strings.Join(bodyLines, "\n"), contentWidth)
@@ -1360,197 +1355,88 @@ func thinkingBadge(label string) (badge, compact string) {
 	}
 }
 
-// cardThinkingLine returns the focus card's thinking body line
-// "thinking <gauge> <wording>" (no ✻), or "" when the agent has no thinking
-// configuration. The gauge and wording are shared with the agent-details dialog
-// via toolcommon.ThinkingGaugeValue, so all three surfaces speak one language.
-func cardThinkingLine(label string) string {
-	gv := toolcommon.ThinkingGaugeValue(label)
-	if gv == "" {
-		return ""
-	}
-	return styles.MutedStyle.Render("thinking ") + gv
-}
-
-// rosterLayout holds the roster column widths computed once per render so all
-// rows align. Each non-current agent renders on two lines: line 1 is the
-// shortcut + colored name with the thinking badge right-aligned at the content
-// edge; line 2 is the indented provider/model. glyphOnly collapses line 1's
-// badge to a single cell near MinWidth.
-type rosterLayout struct {
-	contentWidth int
-	nameWidth    int
-	modelWidth   int
-	badgeWidth   int
-	glyphOnly    bool
-}
-
-// computeRosterLayout derives the roster column widths for the given content
-// width. The two-line layout always keeps the model (on its own line 2), so the
-// only degradation is line 1's badge: below rowGlyphOnlyMinWidth (near MinWidth)
-// the gauge collapses to a single cell to give the name column more room.
-func (m *model) computeRosterLayout(contentWidth int, currentAgent string) rosterLayout {
-	fullBadge, compactBadge := 0, 0
+// badgeColumnWidth returns the widest thinking badge across the roster so every
+// agent line reserves the same badge column and the badges stay aligned.
+// glyphOnly selects the single-cell compact form used near MinWidth.
+func (m *model) badgeColumnWidth(glyphOnly bool) int {
+	w := 0
 	for _, a := range m.availableAgents {
-		if a.Name == currentAgent {
-			continue // the current agent renders as the card, not a row
+		full, compact := thinkingBadge(a.Thinking)
+		b := full
+		if glyphOnly {
+			b = compact
 		}
-		b, c := thinkingBadge(a.Thinking)
-		fullBadge = max(fullBadge, lipgloss.Width(b))
-		compactBadge = max(compactBadge, lipgloss.Width(c))
+		w = max(w, lipgloss.Width(b))
 	}
-
-	l := rosterLayout{contentWidth: contentWidth, badgeWidth: fullBadge}
-	if contentWidth < rowGlyphOnlyMinWidth {
-		l.glyphOnly = true
-		l.badgeWidth = compactBadge
-	}
-
-	// Line 1: shortcut + name + minGap + right-aligned badge.
-	l.nameWidth = max(1, contentWidth-rowShortcutWidth-minGap-l.badgeWidth)
-	// Line 2: indented provider/model.
-	l.modelWidth = max(1, contentWidth-rowIndentWidth)
-	return l
+	return w
 }
 
-// rowShortcutCell renders the fixed-width leading cell of a roster row: the
-// spinner frame when the agent is working, the "^N" hint for agents 1–9, or
-// blank padding otherwise.
-func (m *model) rowShortcutCell(agent runtime.AgentDetails, index int) string {
+// agentNameWidth returns the width available for the agent name column given the
+// fixed marker, thinking-badge and shortcut columns. Below rowGlyphOnlyMinWidth
+// the badge collapses to a single cell (glyphOnly) so the name keeps room.
+func (m *model) agentNameWidth(contentWidth int, glyphOnly bool) int {
+	badgeWidth := m.badgeColumnWidth(glyphOnly)
+	return max(1, contentWidth-agentMarkerWidth-minGap-badgeWidth-1-agentShortcutWidth)
+}
+
+// padRight pads a (possibly styled) string with trailing spaces to width.
+func padRight(s string, width int) string {
+	return s + strings.Repeat(" ", max(0, width-lipgloss.Width(s)))
+}
+
+// padLeft pads a (possibly styled) string with leading spaces to width, i.e.
+// right-aligns it within the column.
+func padLeft(s string, width int) string {
+	return strings.Repeat(" ", max(0, width-lipgloss.Width(s))) + s
+}
+
+// renderAgentLine renders a single agent as two lines:
+//
+//	▶ name            <thinking> ^N
+//	  provider/model
+//
+// Line 1: the name is left-aligned in its accent color, the thinking badge is
+// right-aligned in a shared column, and the "^N" switch shortcut sits flush
+// against the right edge. The current agent is marked with ▶ (or the spinner
+// while it — or any agent — is working); other agents pad the marker column so
+// the names stay aligned. Line 2: the indented provider/model, left-truncated
+// so its informative tail survives. The description is omitted. Agents past the
+// 9th have no shortcut.
+func (m *model) renderAgentLine(agent runtime.AgentDetails, index, contentWidth, nameWidth int, glyphOnly, current bool) []string {
+	agentStyle := styles.AgentAccentStyleFor(agent.Name)
+
+	var marker string
 	switch {
 	case m.workingAgent == agent.Name:
-		frame := styles.AgentAccentStyleFor(agent.Name).Render(m.spinner.RawFrame())
-		return frame + strings.Repeat(" ", max(0, rowShortcutWidth-lipgloss.Width(frame)))
-	case index >= 0 && index < 9:
-		hint := styles.MutedStyle.Render(fmt.Sprintf("^%d", index+1))
-		return hint + strings.Repeat(" ", max(0, rowShortcutWidth-lipgloss.Width(hint)))
-	default:
-		return strings.Repeat(" ", rowShortcutWidth)
+		marker = agentStyle.Render(m.spinner.RawFrame())
+	case current:
+		marker = agentStyle.Render("▶")
 	}
-}
+	left := padRight(marker, agentMarkerWidth) + agentStyle.Render(toolcommon.TruncateText(agent.Name, nameWidth))
 
-// rightAlign appends padding so hint sits flush against the right edge of width.
-func rightAlign(left, hint string, width int) string {
-	if hint == "" {
-		return left
-	}
-	space := max(1, width-lipgloss.Width(left)-lipgloss.Width(hint))
-	return left + strings.Repeat(" ", space) + hint
-}
-
-// renderAgentRow renders a non-current agent as two lines: line 1 is the
-// shortcut (or spinner) + colored name with the thinking badge right-aligned at
-// the content edge; line 2 is the indented provider/model (or harness type).
-// Harness and non-reasoning agents simply have no badge on line 1. Both lines
-// are owned by the agent so a click on either switches to it.
-func (m *model) renderAgentRow(agent runtime.AgentDetails, index int, l rosterLayout) []string {
-	agentStyle := styles.AgentAccentStyleFor(agent.Name)
-	shortcut := m.rowShortcutCell(agent, index)
-
-	name := toolcommon.TruncateText(agent.Name, l.nameWidth)
 	badge, compact := thinkingBadge(agent.Thinking)
-	if l.glyphOnly {
+	if glyphOnly {
 		badge = compact
 	}
-	line1 := rightAlign(shortcut+agentStyle.Render(name), badge, l.contentWidth)
+	badgeWidth := m.badgeColumnWidth(glyphOnly)
+
+	var shortcut string
+	if index >= 0 && index < 9 {
+		shortcut = styles.MutedStyle.Render(fmt.Sprintf("^%d", index+1))
+	}
+
+	right := padLeft(badge, badgeWidth) + " " + padLeft(shortcut, agentShortcutWidth)
+	gap := max(1, contentWidth-lipgloss.Width(left)-lipgloss.Width(right))
+	line1 := left + strings.Repeat(" ", gap) + right
 
 	modelText := agent.Model
 	if agent.Provider != "" {
 		modelText = agent.Provider + "/" + agent.Model
 	}
-	model := toolcommon.TruncateTextLeft(modelText, l.modelWidth)
-	line2 := strings.Repeat(" ", rowIndentWidth) + styles.MutedStyle.Render(model)
+	model := toolcommon.TruncateTextLeft(modelText, max(1, contentWidth-agentMarkerWidth))
+	line2 := strings.Repeat(" ", agentMarkerWidth) + styles.MutedStyle.Render(model)
 
 	return []string{line1, line2}
-}
-
-// renderAgentCard renders the multi-line focus card for the current agent.
-func (m *model) renderAgentCard(agent runtime.AgentDetails, index, contentWidth int) []string {
-	agentStyle := styles.AgentAccentStyleFor(agent.Name)
-	var prefix string
-	if m.workingAgent == agent.Name {
-		prefix = agentStyle.Render(m.spinner.RawFrame()) + " "
-	} else {
-		prefix = agentStyle.Render("▶") + " "
-	}
-	var hint string
-	if index >= 0 && index < 9 {
-		hint = styles.MutedStyle.Render(fmt.Sprintf("^%d", index+1))
-	}
-	header := rightAlign(prefix+agentStyle.Render(agent.Name), hint, contentWidth)
-
-	bodyWidth := contentWidth - treePrefixWidth
-	var nodes [][]string
-	if desc := wrapDescription(agent.Description, bodyWidth, 2); len(desc) > 0 {
-		nodes = append(nodes, desc)
-	}
-	modelText := agent.Model
-	if agent.Provider != "" {
-		modelText = agent.Provider + "/" + agent.Model
-	}
-	if modelText != "" {
-		nodes = append(nodes, []string{toolcommon.TruncateTextLeft(modelText, bodyWidth)})
-	}
-	if line := cardThinkingLine(agent.Thinking); line != "" {
-		nodes = append(nodes, []string{line})
-	}
-
-	lines := []string{header}
-	lines = append(lines, renderTreeNodes(nodes)...)
-	return lines
-}
-
-// renderTreeNodes renders body nodes with tree-structure prefixes. Each node is
-// one or more already-styled lines; the last node uses "└ ", earlier nodes use
-// "├ ", and continuation lines use "│ " (or blank under the last node).
-func renderTreeNodes(nodes [][]string) []string {
-	var out []string
-	for ni, node := range nodes {
-		last := ni == len(nodes)-1
-		for li, line := range node {
-			var prefix string
-			switch {
-			case li == 0 && last:
-				prefix = "└ "
-			case li == 0:
-				prefix = "├ "
-			case last:
-				prefix = "  "
-			default:
-				prefix = "│ "
-			}
-			out = append(out, styles.MutedStyle.Render(prefix)+line)
-		}
-	}
-	return out
-}
-
-// wrapDescription wraps plain description text to at most maxLines lines within
-// width, appending an ellipsis to the final line when content is dropped.
-func wrapDescription(desc string, width, maxLines int) []string {
-	if desc == "" || width <= 0 || maxLines <= 0 {
-		return nil
-	}
-	wrapped := toolcommon.WrapLinesWords(desc, width)
-	if len(wrapped) <= maxLines {
-		return wrapped
-	}
-	wrapped = wrapped[:maxLines]
-	wrapped[maxLines-1] = ellipsizePlain(wrapped[maxLines-1], width)
-	return wrapped
-}
-
-// ellipsizePlain shortens plain text to width and guarantees a trailing ellipsis
-// to signal dropped content.
-func ellipsizePlain(s string, width int) string {
-	if width <= 1 {
-		return "…"
-	}
-	r := []rune(s)
-	for lipgloss.Width(string(r)) > width-1 {
-		r = r[:len(r)-1]
-	}
-	return strings.TrimRight(string(r), " ") + "…"
 }
 
 // buildAgentClickZones populates agentClickZones from the explicit per-line

--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -1256,8 +1256,11 @@ func (m *model) agentInfo(contentWidth int) string {
 		agentTitle += " ↔"
 	}
 
+	// Compute the shared column widths once so every entry aligns and the badge
+	// width is not recomputed per agent.
 	glyphOnly := contentWidth < rowGlyphOnlyMinWidth
-	nameWidth := m.agentNameWidth(contentWidth, glyphOnly)
+	badgeWidth := m.badgeColumnWidth(glyphOnly)
+	nameWidth := max(1, contentWidth-agentMarkerWidth-minGap-badgeWidth-1-agentShortcutWidth)
 
 	var bodyLines, owners []string
 	add := func(line, owner string) {
@@ -1272,7 +1275,7 @@ func (m *model) agentInfo(contentWidth int) string {
 			add("", "")
 		}
 		current := agent.Name == currentAgent
-		for _, line := range m.renderAgentLine(agent, i, contentWidth, nameWidth, glyphOnly, current) {
+		for _, line := range m.renderAgentLine(agent, i, contentWidth, nameWidth, badgeWidth, glyphOnly, current) {
 			add(line, agent.Name)
 		}
 	}
@@ -1282,11 +1285,11 @@ func (m *model) agentInfo(contentWidth int) string {
 }
 
 // thinkingKind classifies an agent's raw thinking wire label into the badge
-// vocabulary used by the card and roster rows.
+// vocabulary used by the agent lines.
 type thinkingKind int
 
 const (
-	thinkingNone     thinkingKind = iota // empty label: no badge / no card line
+	thinkingNone     thinkingKind = iota // empty label: no badge
 	thinkingOff                          // "off": disabled on a capable model
 	thinkingAdaptive                     // "adaptive": adaptive budget
 	thinkingTokens                       // decimal token count
@@ -1323,11 +1326,11 @@ func isAllDigits(s string) bool {
 	return true
 }
 
-// thinkingBadge returns the styled right-aligned roster badge for an agent's
-// thinking label and the compact single-cell form used in the glyph-only
-// degradation step. Both are empty when the agent has no thinking
-// configuration. The vocabulary carries no ✻ glyph: the effort gauge is the
-// only visual language for thinking.
+// thinkingBadge returns the styled right-aligned badge for an agent's thinking
+// label and the compact single-cell form used in the glyph-only degradation
+// step. Both are empty when the agent has no thinking configuration. The
+// vocabulary carries no ✻ glyph: the effort gauge is the only visual language
+// for thinking.
 func thinkingBadge(label string) (badge, compact string) {
 	kind, tokens := classifyThinking(label)
 	switch kind {
@@ -1371,14 +1374,6 @@ func (m *model) badgeColumnWidth(glyphOnly bool) int {
 	return w
 }
 
-// agentNameWidth returns the width available for the agent name column given the
-// fixed marker, thinking-badge and shortcut columns. Below rowGlyphOnlyMinWidth
-// the badge collapses to a single cell (glyphOnly) so the name keeps room.
-func (m *model) agentNameWidth(contentWidth int, glyphOnly bool) int {
-	badgeWidth := m.badgeColumnWidth(glyphOnly)
-	return max(1, contentWidth-agentMarkerWidth-minGap-badgeWidth-1-agentShortcutWidth)
-}
-
 // padRight pads a (possibly styled) string with trailing spaces to width.
 func padRight(s string, width int) string {
 	return s + strings.Repeat(" ", max(0, width-lipgloss.Width(s)))
@@ -1402,7 +1397,7 @@ func padLeft(s string, width int) string {
 // the names stay aligned. Line 2: the indented provider/model, left-truncated
 // so its informative tail survives. The description is omitted. Agents past the
 // 9th have no shortcut.
-func (m *model) renderAgentLine(agent runtime.AgentDetails, index, contentWidth, nameWidth int, glyphOnly, current bool) []string {
+func (m *model) renderAgentLine(agent runtime.AgentDetails, index, contentWidth, nameWidth, badgeWidth int, glyphOnly, current bool) []string {
 	agentStyle := styles.AgentAccentStyleFor(agent.Name)
 
 	var marker string
@@ -1418,7 +1413,6 @@ func (m *model) renderAgentLine(agent runtime.AgentDetails, index, contentWidth,
 	if glyphOnly {
 		badge = compact
 	}
-	badgeWidth := m.badgeColumnWidth(glyphOnly)
 
 	var shortcut string
 	if index >= 0 && index < 9 {


### PR DESCRIPTION
The agents panel in the TUI sidebar had two distinct rendering modes: a multi-line "focus card" for the current agent and compact "roster rows" for the others. This asymmetry made the layout shift noticeably when switching agents and required maintaining separate layout computation paths.

This change replaces both modes with a single `renderAgentLine` that produces a consistent two-line entry for every agent. Line 1 shows the agent name in its accent color, a thinking-effort badge right-aligned in a shared column, and a `^N` switch shortcut flush against the right edge. Line 2 shows the provider/model string, indented and left-truncated so the informative tail is always visible. The current agent is marked with ▶ (or the spinner while working); other agents pad the marker column so names stay aligned. Agent descriptions are removed from the sidebar — they remain accessible in the agent-details dialog.

Click zones are updated so both rendered lines of an entry are owned by the agent, while the blank separator lines between entries remain unclickable. The `^N` shortcut displayed matches the existing `ctrl+1`..`ctrl+9` keyboard handler.

Removed now-unused helpers — `renderAgentCard`, `renderAgentRow`, `computeRosterLayout`, `cardThinkingLine`, `renderTreeNodes`, `wrapDescription`, `ellipsizePlain`, `rowShortcutCell`, `rightAlign` — and the `rosterLayout` type. Added small `padLeft`/`padRight`/`badgeColumnWidth` helpers and moved badge-column-width computation into `agentInfo` so it is derived once rather than per render. Layout constants `rowShortcutWidth`/`rowIndentWidth` are replaced by `agentMarkerWidth`/`agentShortcutWidth`.

One pre-existing edge case (not a regression): below the `MinWidth` auto-collapse threshold combined with very long agent names, `tab.Render` may wrap body lines and misalign click zones.