### PR TITLE
feat(server): accept title in POST /api/sessions to skip LLM title generation

### DIFF
--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -339,6 +339,13 @@ func (sm *SessionManager) CreateSession(ctx context.Context, sessionTemplate *se
 		session.WithToolsApproved(sessionTemplate.ToolsApproved),
 	)
 
+	// Carry a caller-supplied title (from the POST /api/sessions request body)
+	// into the new session. When set, RunSession's needsTitle check skips the
+	// LLM title-generation call and re-emits this title instead.
+	if title := strings.TrimSpace(sessionTemplate.Title); title != "" {
+		opts = append(opts, session.WithTitle(title))
+	}
+
 	if wd := strings.TrimSpace(sessionTemplate.WorkingDir); wd != "" {
 		absWd, err := filepath.Abs(wd)
 		if err != nil {

--- a/pkg/server/session_models_test.go
+++ b/pkg/server/session_models_test.go
@@ -658,3 +658,32 @@ func TestApplyStoredOverrides(t *testing.T) {
 		})
 	})
 }
+
+func TestSessionManager_CreateSession_CarriesTitle(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := session.NewInMemorySessionStore()
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+
+	t.Run("non-empty title is preserved on the created session", func(t *testing.T) {
+		t.Parallel()
+		created, err := sm.CreateSession(ctx, &session.Session{Title: "harbor-watch"})
+		require.NoError(t, err)
+		assert.Equal(t, "harbor-watch", created.Title)
+	})
+
+	t.Run("whitespace-only title is not set (TrimSpace guard)", func(t *testing.T) {
+		t.Parallel()
+		created, err := sm.CreateSession(ctx, &session.Session{Title: "   "})
+		require.NoError(t, err)
+		assert.Empty(t, created.Title)
+	})
+
+	t.Run("empty title leaves session title unset", func(t *testing.T) {
+		t.Parallel()
+		created, err := sm.CreateSession(ctx, &session.Session{})
+		require.NoError(t, err)
+		assert.Empty(t, created.Title)
+	})
+}


### PR DESCRIPTION
## Problem

`POST /api/sessions` accepts a `title` field in the request body (via the existing `json:"title"` tag on `session.Session`), but `CreateSession` silently drops it — the field is deserialized but never forwarded into the new session via `WithTitle`.

`RunSession` already has a skip condition for title generation:
```go
// session_manager.go
needsTitle := titleToEmit == "" && len(userMessages) > 0 && titleGen != nil
```
where `titleToEmit := sess.Title`. If `sess.Title` is non-empty before `RunSession` is called, the LLM title-generation call is skipped and the existing title is re-emitted instead.

## Fix

Wire up the missing assignment, mirroring the adjacent `WorkingDir` pattern:

```go
if title := strings.TrimSpace(sessionTemplate.Title); title != "" {
    opts = append(opts, session.WithTitle(title))
}
```

## Motivation

The LLM title-generation call (`sessiontitle.generate` span) runs in a goroutine but sends its `session_title` event through the same SSE stream — the connection stays open until the goroutine finishes (~2–3s). For callers that create ephemeral sessions with a known purpose and immediately delete them, this is wasted LLM inference on every invocation. Pre-supplying a title at creation is the correct fix with no client-side workarounds needed.

## Verification

```
# Before patch
POST /api/sessions {}
→ {"id": "...", "title": ""}   ← needsTitle=true, LLM fires

# After patch  
POST /api/sessions {"title":"harbor-watch"}
→ {"id": "...", "title": "harbor-watch"}  ← needsTitle=false, skipped
```

Verified locally by building the patched binary and confirming the `title` field is preserved on the session after creation.

## Testing

Added `TestSessionManager_CreateSession_CarriesTitle` with three subtests covering the non-empty, whitespace-only (TrimSpace guard), and empty cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)