### PR TITLE
test: enable t.Parallel() on isolated unit tests

### DIFF
--- a/pkg/runtime/cost_test.go
+++ b/pkg/runtime/cost_test.go
@@ -13,6 +13,7 @@ import (
 // nil/unpriced branches are exercised by TestComputeMessageCost in
 // after_llm_call_test.go, which shares the same computeMessageCost source.
 func TestUsageHasTokens(t *testing.T) {
+	t.Parallel()
 	assert.False(t, usageHasTokens(nil), "nil usage has no tokens")
 	assert.False(t, usageHasTokens(&chat.Usage{}), "zero usage has no tokens")
 	assert.True(t, usageHasTokens(&chat.Usage{InputTokens: 1}))

--- a/pkg/session/branch_test.go
+++ b/pkg/session/branch_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestGenerateBranchTitle(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		parentTitle string
@@ -64,6 +65,7 @@ func TestGenerateBranchTitle(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := generateBranchTitle(tt.parentTitle)
 			assert.Equal(t, tt.expected, result)
 		})
@@ -71,6 +73,7 @@ func TestGenerateBranchTitle(t *testing.T) {
 }
 
 func TestGenerateForkTitle(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		parentTitle string
@@ -138,6 +141,7 @@ func TestGenerateForkTitle(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := generateForkTitle(tt.parentTitle)
 			assert.Equal(t, tt.expected, result)
 		})
@@ -145,6 +149,7 @@ func TestGenerateForkTitle(t *testing.T) {
 }
 
 func TestNextForkTitle(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		parentTitle string
@@ -191,19 +196,23 @@ func TestNextForkTitle(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, tt.expected, NextForkTitle(tt.parentTitle, tt.siblings))
 		})
 	}
 }
 
 func TestCloneSessionItem(t *testing.T) {
+	t.Parallel()
 	t.Run("empty item returns error", func(t *testing.T) {
+		t.Parallel()
 		_, err := cloneSessionItem(Item{})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "cannot clone empty session item")
 	})
 
 	t.Run("message item clones successfully", func(t *testing.T) {
+		t.Parallel()
 		item := NewMessageItem(UserMessage("test"))
 		cloned, err := cloneSessionItem(item)
 		require.NoError(t, err)
@@ -211,6 +220,7 @@ func TestCloneSessionItem(t *testing.T) {
 	})
 
 	t.Run("summary item clones successfully", func(t *testing.T) {
+		t.Parallel()
 		item := Item{Summary: "test summary"}
 		cloned, err := cloneSessionItem(item)
 		require.NoError(t, err)
@@ -218,6 +228,7 @@ func TestCloneSessionItem(t *testing.T) {
 	})
 
 	t.Run("error item clones into a distinct pointer", func(t *testing.T) {
+		t.Parallel()
 		item := NewErrorItem(&Error{Message: "boom", Code: "model_error"})
 		cloned, err := cloneSessionItem(item)
 		require.NoError(t, err)
@@ -231,13 +242,16 @@ func TestCloneSessionItem(t *testing.T) {
 }
 
 func TestBranchSession(t *testing.T) {
+	t.Parallel()
 	t.Run("nil parent returns error", func(t *testing.T) {
+		t.Parallel()
 		_, err := BranchSession(nil, 0)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "parent session is nil")
 	})
 
 	t.Run("negative position returns error", func(t *testing.T) {
+		t.Parallel()
 		parent := &Session{Messages: []Item{NewMessageItem(UserMessage("test"))}}
 		_, err := BranchSession(parent, -1)
 		require.Error(t, err)
@@ -245,6 +259,7 @@ func TestBranchSession(t *testing.T) {
 	})
 
 	t.Run("position beyond messages returns error", func(t *testing.T) {
+		t.Parallel()
 		parent := &Session{Messages: []Item{NewMessageItem(UserMessage("test"))}}
 		_, err := BranchSession(parent, 2)
 		require.Error(t, err)
@@ -252,12 +267,14 @@ func TestBranchSession(t *testing.T) {
 	})
 
 	t.Run("position equal to messages length no error", func(t *testing.T) {
+		t.Parallel()
 		parent := &Session{Messages: []Item{NewMessageItem(UserMessage("test"))}}
 		_, err := BranchSession(parent, 1)
 		require.NoError(t, err)
 	})
 
 	t.Run("branches across a persisted error item", func(t *testing.T) {
+		t.Parallel()
 		// Regression: a session containing a recorded failure must remain
 		// branchable. cloneSessionItem previously errored on error items,
 		// breaking branch/fork for any failed session.
@@ -281,6 +298,7 @@ func TestBranchSession(t *testing.T) {
 	})
 
 	t.Run("valid branch copies messages up to position", func(t *testing.T) {
+		t.Parallel()
 		parent := &Session{
 			ID:    "parent-id",
 			Title: "Parent Title",
@@ -303,6 +321,7 @@ func TestBranchSession(t *testing.T) {
 	})
 
 	t.Run("deep-copies pointer fields in MultiContent", func(t *testing.T) {
+		t.Parallel()
 		// Regression test: MultiContent pointer fields must not be shared
 		// between branched sessions and their parents.
 		parent := &Session{
@@ -353,13 +372,16 @@ func TestBranchSession(t *testing.T) {
 }
 
 func TestForkSession(t *testing.T) {
+	t.Parallel()
 	t.Run("nil parent returns error", func(t *testing.T) {
+		t.Parallel()
 		_, err := ForkSession(nil, 0)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "parent session is nil")
 	})
 
 	t.Run("out-of-range position returns error", func(t *testing.T) {
+		t.Parallel()
 		parent := &Session{Messages: []Item{NewMessageItem(UserMessage("test"))}}
 		_, err := ForkSession(parent, 2)
 		require.Error(t, err)
@@ -367,6 +389,7 @@ func TestForkSession(t *testing.T) {
 	})
 
 	t.Run("copies messages up to position and uses fork-numbered title", func(t *testing.T) {
+		t.Parallel()
 		parent := &Session{
 			ID:    "parent-id",
 			Title: "Parent Title",
@@ -387,6 +410,7 @@ func TestForkSession(t *testing.T) {
 	})
 
 	t.Run("fork of a fork increments the counter", func(t *testing.T) {
+		t.Parallel()
 		parent := &Session{
 			Title:    "Parent Title (fork 2)",
 			Messages: []Item{NewMessageItem(UserMessage("hi"))},
@@ -398,6 +422,7 @@ func TestForkSession(t *testing.T) {
 	})
 
 	t.Run("position zero produces an empty fork", func(t *testing.T) {
+		t.Parallel()
 		parent := &Session{
 			Title:    "Parent Title",
 			Messages: []Item{NewMessageItem(UserMessage("only"))},
@@ -410,6 +435,7 @@ func TestForkSession(t *testing.T) {
 	})
 
 	t.Run("copies safety-rail limits onto the fork", func(t *testing.T) {
+		t.Parallel()
 		// Regression: MaxConsecutiveToolCalls / MaxOldToolCallTokens used to
 		// be silently zeroed out, making the fork behave differently from
 		// the parent (tool-call cutoff and old-tool-call truncation budget

--- a/pkg/session/clone_test.go
+++ b/pkg/session/clone_test.go
@@ -11,11 +11,13 @@ import (
 )
 
 func TestClone_NilSession(t *testing.T) {
+	t.Parallel()
 	var s *Session
 	assert.Nil(t, s.Clone())
 }
 
 func TestClone_CopiesScalarFields(t *testing.T) {
+	t.Parallel()
 	orig := &Session{
 		ID:                      "sess-1",
 		Title:                   "title",
@@ -68,6 +70,7 @@ func TestClone_CopiesScalarFields(t *testing.T) {
 }
 
 func TestClone_DeepCopiesEvalFields(t *testing.T) {
+	t.Parallel()
 	orig := &Session{
 		Evals: &EvalCriteria{
 			Relevance:  []string{"is helpful"},
@@ -104,6 +107,7 @@ func TestClone_DeepCopiesEvalFields(t *testing.T) {
 }
 
 func TestClone_DeepCopiesMessagesAndConfig(t *testing.T) {
+	t.Parallel()
 	orig := &Session{
 		ID:                  "sess-1",
 		Permissions:         &PermissionsConfig{Allow: []string{"a"}, Ask: []string{"k"}},
@@ -166,6 +170,7 @@ func TestClone_DeepCopiesMessagesAndConfig(t *testing.T) {
 }
 
 func TestClone_AppendingDoesNotAffectOriginal(t *testing.T) {
+	t.Parallel()
 	orig := New()
 	orig.AddMessage(UserMessage("first"))
 
@@ -179,6 +184,7 @@ func TestClone_AppendingDoesNotAffectOriginal(t *testing.T) {
 }
 
 func TestClone_PreservesSubSessionAndSummary(t *testing.T) {
+	t.Parallel()
 	sub := New()
 	sub.AddMessage(UserMessage("sub message"))
 
@@ -202,6 +208,7 @@ func TestClone_PreservesSubSessionAndSummary(t *testing.T) {
 // items field-by-field and silently drops the per-item Cost / FirstKeptEntry
 // that can ride alongside a message.
 func TestClone_PreservesItemValueFields(t *testing.T) {
+	t.Parallel()
 	orig := New()
 	orig.Messages = []Item{{
 		Message:        UserMessage("hello"),
@@ -220,6 +227,7 @@ func TestClone_PreservesItemValueFields(t *testing.T) {
 // pointer with the original, which would let a mutation on one leak into the
 // other.
 func TestClone_DeepCopiesErrorItem(t *testing.T) {
+	t.Parallel()
 	orig := New()
 	orig.AddError(&Error{Message: "boom", Code: "model_error", AgentName: "root"})
 

--- a/pkg/session/get_messages_tool_truncation_test.go
+++ b/pkg/session/get_messages_tool_truncation_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestGetMessagesMaxOldToolCallTokensDefaultDoesNotTruncate(t *testing.T) {
+	t.Parallel()
 	oldResult := strings.Repeat("old-result-", 15000)
 	newResult := "new result"
 
@@ -27,6 +28,7 @@ func TestGetMessagesMaxOldToolCallTokensDefaultDoesNotTruncate(t *testing.T) {
 }
 
 func TestGetMessagesMaxOldToolCallTokensPositiveTruncatesOldContent(t *testing.T) {
+	t.Parallel()
 	oldResult := strings.Repeat("old-result-", 15000)
 	newResult := "new result"
 

--- a/pkg/session/migrations_unit_test.go
+++ b/pkg/session/migrations_unit_test.go
@@ -29,6 +29,7 @@ func openMigrationsDB(t *testing.T) *sql.DB {
 }
 
 func TestMigrationManager_RunPendingMigrations_AppliesAllAndIsIdempotent(t *testing.T) {
+	t.Parallel()
 	db := openMigrationsDB(t)
 	migrations := []Migration{
 		{
@@ -65,6 +66,7 @@ func TestMigrationManager_RunPendingMigrations_AppliesAllAndIsIdempotent(t *test
 }
 
 func TestMigrationManager_RunPendingMigrations_OnlyAppliesNewMigrations(t *testing.T) {
+	t.Parallel()
 	db := openMigrationsDB(t)
 	first := []Migration{{ID: 1, Name: "001_a", UpSQL: `CREATE TABLE a (id INTEGER)`}}
 	require.NoError(t, NewMigrationManagerWithMigrations(db, first).RunPendingMigrations(t.Context()))
@@ -89,6 +91,7 @@ func TestMigrationManager_RunPendingMigrations_OnlyAppliesNewMigrations(t *testi
 }
 
 func TestMigrationManager_BadUpSQL_RollsBackAndIsRetryable(t *testing.T) {
+	t.Parallel()
 	db := openMigrationsDB(t)
 	bad := []Migration{{
 		ID:    1,
@@ -109,6 +112,7 @@ func TestMigrationManager_BadUpSQL_RollsBackAndIsRetryable(t *testing.T) {
 }
 
 func TestMigrationManager_UpFuncFailure_DoesNotRetryButReturnsError(t *testing.T) {
+	t.Parallel()
 	db := openMigrationsDB(t)
 	wantErr := errors.New("boom")
 	mgr := NewMigrationManagerWithMigrations(db, []Migration{{
@@ -133,6 +137,7 @@ func TestMigrationManager_UpFuncFailure_DoesNotRetryButReturnsError(t *testing.T
 }
 
 func TestMigrationManager_CheckForUnknownMigrations_RejectsNewerDB(t *testing.T) {
+	t.Parallel()
 	db := openMigrationsDB(t)
 	// Apply two migrations as a "newer" docker-agent would.
 	full := []Migration{
@@ -149,6 +154,7 @@ func TestMigrationManager_CheckForUnknownMigrations_RejectsNewerDB(t *testing.T)
 }
 
 func TestMigrationManager_CheckForUnknownMigrations_AllowsEqualOrOlderDB(t *testing.T) {
+	t.Parallel()
 	db := openMigrationsDB(t)
 	migrations := []Migration{{ID: 1, Name: "001_a", UpSQL: `CREATE TABLE a (id INTEGER)`}}
 	require.NoError(t, NewMigrationManagerWithMigrations(db, migrations).RunPendingMigrations(t.Context()))
@@ -163,6 +169,7 @@ func TestMigrationManager_CheckForUnknownMigrations_AllowsEqualOrOlderDB(t *test
 }
 
 func TestMigrationManager_EmptyMigrations_NoOp(t *testing.T) {
+	t.Parallel()
 	db := openMigrationsDB(t)
 	mgr := NewMigrationManagerWithMigrations(db, nil)
 

--- a/pkg/session/sanitize_orphan_test.go
+++ b/pkg/session/sanitize_orphan_test.go
@@ -43,6 +43,7 @@ func assertToolPairingInvariant(t *testing.T, messages []chat.Message) {
 // sanitizeToolCalls is the final guard before the request hits the provider and
 // must drop that orphaned result so the request stays valid.
 func TestSanitizeToolCalls_DropsOrphanedToolResult(t *testing.T) {
+	t.Parallel()
 	// History as reconstructed on resume after compaction: the toolUse-bearing
 	// assistant message is gone (folded into the summary), only its result and
 	// the following turn survive.
@@ -68,6 +69,7 @@ func TestSanitizeToolCalls_DropsOrphanedToolResult(t *testing.T) {
 // TestSanitizeToolCalls_KeepsMissingResultBalanced pins the opposite direction:
 // a dangling toolUse (no result) gets a synthetic result and stays balanced.
 func TestSanitizeToolCalls_KeepsMissingResultBalanced(t *testing.T) {
+	t.Parallel()
 	messages := []chat.Message{
 		{Role: chat.MessageRoleUser, Content: "hi"},
 		{Role: chat.MessageRoleAssistant, ToolCalls: []tools.ToolCall{{ID: "tc1"}}},
@@ -86,6 +88,7 @@ func TestSanitizeToolCalls_KeepsMissingResultBalanced(t *testing.T) {
 // family as #1676 and #1593. Only the first result for a given tool_use should
 // survive.
 func TestSanitizeToolCalls_DropsDuplicateToolResult(t *testing.T) {
+	t.Parallel()
 	messages := []chat.Message{
 		{Role: chat.MessageRoleUser, Content: "hi"},
 		{Role: chat.MessageRoleAssistant, ToolCalls: []tools.ToolCall{{ID: "tc1"}}},
@@ -118,6 +121,7 @@ func TestSanitizeToolCalls_DropsDuplicateToolResult(t *testing.T) {
 // tool_result, so buildSessionSummaryMessages emits the conversation starting at
 // the orphaned tool_result. GetMessages must return a provider-valid sequence.
 func TestGetMessages_ResumeAfterCompaction_NoOrphanedToolResult(t *testing.T) {
+	t.Parallel()
 	testAgent := &agent.Agent{}
 	s := New()
 

--- a/pkg/session/session_options_test.go
+++ b/pkg/session/session_options_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestWithWorkingDir_SetsAllowedDirectories(t *testing.T) {
+	t.Parallel()
 	s := New(WithWorkingDir("/projects/myapp"))
 
 	assert.Equal(t, "/projects/myapp", s.WorkingDir)
@@ -14,6 +15,7 @@ func TestWithWorkingDir_SetsAllowedDirectories(t *testing.T) {
 }
 
 func TestWithWorkingDir_EmptyReturnsNilAllowedDirs(t *testing.T) {
+	t.Parallel()
 	s := New()
 
 	assert.Empty(t, s.WorkingDir)
@@ -21,6 +23,7 @@ func TestWithWorkingDir_EmptyReturnsNilAllowedDirs(t *testing.T) {
 }
 
 func TestNewSession_AllOptionsApplied(t *testing.T) {
+	t.Parallel()
 	s := New(
 		WithMaxIterations(10),
 		WithToolsApproved(true),
@@ -40,6 +43,7 @@ func TestNewSession_AllOptionsApplied(t *testing.T) {
 // This test documents the expected option set so that adding a new option
 // to one path without the other will be caught.
 func TestNewSession_ConsistencyBetweenInitialAndSpawned(t *testing.T) {
+	t.Parallel()
 	workingDir := "/projects/app"
 	autoApprove := true
 	hideToolResults := true
@@ -69,7 +73,9 @@ func TestNewSession_ConsistencyBetweenInitialAndSpawned(t *testing.T) {
 }
 
 func TestAddAttachedFile(t *testing.T) {
+	t.Parallel()
 	t.Run("deduplicates and preserves order", func(t *testing.T) {
+		t.Parallel()
 		s := New()
 		s.AddAttachedFile("/abs/foo.go")
 		s.AddAttachedFile("/abs/bar.go")
@@ -78,12 +84,14 @@ func TestAddAttachedFile(t *testing.T) {
 	})
 
 	t.Run("ignores empty paths", func(t *testing.T) {
+		t.Parallel()
 		s := New()
 		s.AddAttachedFile("")
 		assert.Empty(t, s.AttachedFilesSnapshot())
 	})
 
 	t.Run("ignores non-absolute paths", func(t *testing.T) {
+		t.Parallel()
 		s := New()
 		s.AddAttachedFile("foo.go")
 		s.AddAttachedFile("./bar.go")
@@ -92,6 +100,7 @@ func TestAddAttachedFile(t *testing.T) {
 	})
 
 	t.Run("snapshot is independent of session storage", func(t *testing.T) {
+		t.Parallel()
 		s := New()
 		s.AddAttachedFile("/abs/foo.go")
 		snap := s.AttachedFilesSnapshot()
@@ -101,6 +110,7 @@ func TestAddAttachedFile(t *testing.T) {
 }
 
 func TestWithAttachedFiles(t *testing.T) {
+	t.Parallel()
 	s := New(WithAttachedFiles([]string{"/abs/foo.go", "", "relative/path.go", "/abs/bar.go", "/abs/foo.go"}))
 	assert.Equal(t, []string{"/abs/foo.go", "/abs/bar.go"}, s.AttachedFilesSnapshot())
 }

--- a/pkg/session/store_memory_test.go
+++ b/pkg/session/store_memory_test.go
@@ -34,12 +34,14 @@ func openMemoryStore(t *testing.T) *SQLiteSessionStore {
 }
 
 func TestNewSQLiteSessionStoreFromDB_NilDB(t *testing.T) {
+	t.Parallel()
 	_, err := NewSQLiteSessionStoreFromDB(t.Context(), nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "nil")
 }
 
 func TestNewSQLiteSessionStoreFromDB_RunsMigrations(t *testing.T) {
+	t.Parallel()
 	store := openMemoryStore(t)
 
 	// The applied migration list should be the full production list. We don't
@@ -55,6 +57,7 @@ func TestNewSQLiteSessionStoreFromDB_RunsMigrations(t *testing.T) {
 }
 
 func TestNewSQLiteSessionStoreFromDB_RoundTripWithMessages(t *testing.T) {
+	t.Parallel()
 	store := openMemoryStore(t)
 	ctx := t.Context()
 

--- a/pkg/session/store_persisted_fields_test.go
+++ b/pkg/session/store_persisted_fields_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestSessionPersistedFieldsOf_Defaults(t *testing.T) {
+	t.Parallel()
 	got, err := sessionPersistedFieldsOf(&Session{ID: "x"})
 	require.NoError(t, err)
 
@@ -18,6 +19,7 @@ func TestSessionPersistedFieldsOf_Defaults(t *testing.T) {
 }
 
 func TestSessionPersistedFieldsOf_PopulatedValues(t *testing.T) {
+	t.Parallel()
 	session := &Session{
 		ID:       "x",
 		ParentID: "parent-1",
@@ -38,6 +40,7 @@ func TestSessionPersistedFieldsOf_PopulatedValues(t *testing.T) {
 }
 
 func TestSessionPersistedFieldsOf_EmptyMapsAndSlicesUseDefaults(t *testing.T) {
+	t.Parallel()
 	// len() == 0 for non-nil empty values must take the default branch
 	// because JSON encoding "{}" / "[]" matches what the schema expects.
 	got, err := sessionPersistedFieldsOf(&Session{

--- a/pkg/session/truncate_test.go
+++ b/pkg/session/truncate_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestApproximateTokens(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		in   string
@@ -26,6 +27,7 @@ func TestApproximateTokens(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := approximateTokens(tt.in); got != tt.want {
 				t.Errorf("approximateTokens(%d chars) = %d, want %d", len(tt.in), got, tt.want)
 			}
@@ -34,7 +36,9 @@ func TestApproximateTokens(t *testing.T) {
 }
 
 func TestTruncateOldToolContent(t *testing.T) {
+	t.Parallel()
 	t.Run("keeps recent tool content within budget", func(t *testing.T) {
+		t.Parallel()
 		messages := []chat.Message{
 			{Role: chat.MessageRoleUser, Content: "hello"},
 			{
@@ -53,6 +57,7 @@ func TestTruncateOldToolContent(t *testing.T) {
 	})
 
 	t.Run("truncates oldest tool content when budget exceeded", func(t *testing.T) {
+		t.Parallel()
 		oldArgs := strings.Repeat("a", 400)   // 100 tokens
 		oldResult := strings.Repeat("b", 400) // 100 tokens
 		newArgs := strings.Repeat("c", 200)   // 50 tokens
@@ -86,6 +91,7 @@ func TestTruncateOldToolContent(t *testing.T) {
 	})
 
 	t.Run("does not modify non-tool messages", func(t *testing.T) {
+		t.Parallel()
 		messages := []chat.Message{
 			{Role: chat.MessageRoleUser, Content: strings.Repeat("x", 1000)},
 			{Role: chat.MessageRoleAssistant, Content: strings.Repeat("y", 1000)},
@@ -100,6 +106,7 @@ func TestTruncateOldToolContent(t *testing.T) {
 	})
 
 	t.Run("returns original messages when maxTokens is zero", func(t *testing.T) {
+		t.Parallel()
 		messages := []chat.Message{
 			{
 				Role: chat.MessageRoleAssistant,
@@ -116,6 +123,7 @@ func TestTruncateOldToolContent(t *testing.T) {
 	})
 
 	t.Run("returns original messages when maxTokens is negative", func(t *testing.T) {
+		t.Parallel()
 		messages := []chat.Message{
 			{
 				Role: chat.MessageRoleAssistant,
@@ -132,6 +140,7 @@ func TestTruncateOldToolContent(t *testing.T) {
 	})
 
 	t.Run("does not modify original slice", func(t *testing.T) {
+		t.Parallel()
 		originalContent := strings.Repeat("y", 400)
 		messages := []chat.Message{
 			{
@@ -153,6 +162,7 @@ func TestTruncateOldToolContent(t *testing.T) {
 	})
 
 	t.Run("handles empty messages slice", func(t *testing.T) {
+		t.Parallel()
 		result := truncateOldToolContent(nil, 1000)
 		assert.Nil(t, result)
 

--- a/pkg/tools/schema_test.go
+++ b/pkg/tools/schema_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestSchemaToMap_Nil(t *testing.T) {
+	t.Parallel()
 	m, err := SchemaToMap(nil)
 	require.NoError(t, err)
 
@@ -18,6 +19,7 @@ func TestSchemaToMap_Nil(t *testing.T) {
 }
 
 func TestSchemaToMap_MissingType(t *testing.T) {
+	t.Parallel()
 	m, err := SchemaToMap(map[string]any{
 		"properties": map[string]any{},
 	})
@@ -30,6 +32,7 @@ func TestSchemaToMap_MissingType(t *testing.T) {
 }
 
 func TestSchemaToMap_MissingEmptyProperties(t *testing.T) {
+	t.Parallel()
 	m, err := SchemaToMap(map[string]any{
 		"type": "object",
 	})
@@ -42,6 +45,7 @@ func TestSchemaToMap_MissingEmptyProperties(t *testing.T) {
 }
 
 func TestSchemaToMap_PropertyWithoutType(t *testing.T) {
+	t.Parallel()
 	m, err := SchemaToMap(map[string]any{
 		"type": "object",
 		"properties": map[string]any{
@@ -70,6 +74,7 @@ func TestSchemaToMap_PropertyWithoutType(t *testing.T) {
 }
 
 func TestSchemaToMap_NestedPropertyWithoutType(t *testing.T) {
+	t.Parallel()
 	m, err := SchemaToMap(map[string]any{
 		"type": "object",
 		"properties": map[string]any{
@@ -108,6 +113,7 @@ func TestSchemaToMap_NestedPropertyWithoutType(t *testing.T) {
 }
 
 func TestSchemaToMap_ArrayItemsPropertyWithoutType(t *testing.T) {
+	t.Parallel()
 	m, err := SchemaToMap(map[string]any{
 		"type": "object",
 		"properties": map[string]any{
@@ -146,6 +152,7 @@ func TestSchemaToMap_ArrayItemsPropertyWithoutType(t *testing.T) {
 }
 
 func TestSchemaToMap_DeeplyNestedPropertyWithoutType(t *testing.T) {
+	t.Parallel()
 	m, err := SchemaToMap(map[string]any{
 		"type": "object",
 		"properties": map[string]any{
@@ -188,6 +195,7 @@ func TestSchemaToMap_DeeplyNestedPropertyWithoutType(t *testing.T) {
 }
 
 func TestSchemaToMap_StripsNullFromRequiredArrayTypes(t *testing.T) {
+	t.Parallel()
 	m, err := SchemaToMap(map[string]any{
 		"type": "object",
 		"properties": map[string]any{

--- a/pkg/tui/styles/composite_test.go
+++ b/pkg/tui/styles/composite_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestRenderComposite(t *testing.T) {
+	t.Parallel()
 	// Define a parent style with a background color and Bold
 	// Blue background, White text, Bold
 	parent := lipgloss.NewStyle().
@@ -81,6 +82,7 @@ func TestRenderComposite(t *testing.T) {
 }
 
 func TestRenderComposite_FastPath(t *testing.T) {
+	t.Parallel()
 	// Test fast path when content has no ANSI sequences
 	parent := lipgloss.NewStyle().
 		Background(lipgloss.Color("#0000FF")).


### PR DESCRIPTION
## What

Adds `t.Parallel()` to a set of pure, well-isolated unit tests that were previously running serially.

Parallelism was added at both the top-level and subtest/table-driven levels for:

| Package | Files |
|---------|-------|
| `pkg/session` | `truncate_test.go`, `session_options_test.go`, `branch_test.go`, `clone_test.go`, `sanitize_orphan_test.go`, `store_persisted_fields_test.go`, `get_messages_tool_truncation_test.go`, `migrations_unit_test.go`, `store_memory_test.go` |
| `pkg/tools` | `schema_test.go` |
| `pkg/tui/styles` | `composite_test.go` |
| `pkg/runtime` | `cost_test.go` |

## Why

These tests are pure / self-contained: they build their own inputs (or open a private in-memory SQLite DB per test) and share no global mutable state, so they are safe to run in parallel and shorten total test time.

## Scope / what was deliberately left out

Tests that use `t.Setenv`, `t.Chdir`, or mutate global state (e.g. `pkg/path`, `pkg/shellpath`, `pkg/userid`, theme state in `pkg/tui/styles/hooks_test.go`) were **not** changed — `t.Parallel()` is incompatible with those.

## Validation

- `go test ./pkg/session/... ./pkg/tools/ ./pkg/tui/styles/ ./pkg/runtime/` — pass
- `go test -race -count=5` on the affected packages — pass
- `golangci-lint` — 0 issues
- `gofmt` — clean

> Note: a pre-existing data race in `TestHandleStream_ContextCancellation` (`pkg/runtime`) exists independently on `main` and is unrelated to this change (verified by stashing these edits).