### PR TITLE
fix: data race in stalledStream.Close using sync.Once

### DIFF
--- a/pkg/runtime/streaming_test.go
+++ b/pkg/runtime/streaming_test.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"io"
+	"sync"
 	"testing"
 	"time"
 
@@ -158,10 +159,11 @@ func TestHandleStream_ToolCallThenSeparateStop(t *testing.T) {
 // either unblocked or the stream is closed. It is used to simulate a
 // half-open TCP connection where the remote side stops sending data.
 type stalledStream struct {
-	// unblock is closed (or sent on) to release a blocked Recv call.
+	// unblock is closed to release a blocked Recv call.
 	unblock chan struct{}
-	// closed is set when Close is called.
-	closed bool
+	// closeOnce guards unblock so Close is safe to call concurrently from
+	// both the test goroutine and handleStream's deferred Close.
+	closeOnce sync.Once
 }
 
 func newStalledStream() *stalledStream {
@@ -175,10 +177,7 @@ func (s *stalledStream) Recv() (chat.MessageStreamResponse, error) {
 }
 
 func (s *stalledStream) Close() {
-	if !s.closed {
-		s.closed = true
-		close(s.unblock)
-	}
+	s.closeOnce.Do(func() { close(s.unblock) })
 }
 
 // withShortStreamIdleTimeout temporarily overrides defaultStreamIdleTimeout


### PR DESCRIPTION
The race detector flagged a data race in `TestHandleStream_ContextCancellation`: `stalledStream.Close()` could be called concurrently from the test goroutine and from `handleStream`'s deferred `stream.Close()`, both reading and writing the same `closed bool` field without synchronisation.

This replaces the unguarded `closed bool` with a `sync.Once`, so the channel close happens exactly once regardless of which caller reaches it first. As a bonus, this also prevents a potential double-close panic on the channel in cases where both callers race to close it.

Verified clean under `go test -race -count=20` on the affected package.