### PR TITLE
refactor: extract themeRegistry struct for parallel-safe tests

### DIFF
--- a/pkg/tui/styles/theme.go
+++ b/pkg/tui/styles/theme.go
@@ -32,20 +32,37 @@ type themeCacheEntry struct {
 	path    string    // For user themes: file path; for built-in: empty
 }
 
-var (
-	themeCache   = make(map[string]*themeCacheEntry)
-	themeCacheMu sync.RWMutex
+// themeRegistry holds the mutable theme state: embedder-registered theme
+// sources and the lazy caches derived from them. The package-level theme API
+// is backed by a single process-wide defaultRegistry, but tests can construct
+// isolated instances with newThemeRegistry to exercise registration and
+// loading in parallel without racing on shared globals.
+type themeRegistry struct {
+	cacheMu sync.RWMutex
+	cache   map[string]*themeCacheEntry
+	// generation changes whenever cached entries are invalidated, so in-flight
+	// loads can avoid repopulating stale data after registration.
+	generation uint64
 
-	// builtinRefsCache caches the list of built-in theme refs (they never change at runtime)
-	builtinRefsCache   []string
-	builtinRefsCacheOK bool
-	builtinRefsCacheMu sync.Mutex
+	// builtinRefs caches the list of built-in theme refs (they never change at
+	// runtime); builtinRefsOK guards its lazy population.
+	refsMu        sync.Mutex
+	builtinRefs   []string
+	builtinRefsOK bool
 
-	// extraThemeFSes holds additional theme sources contributed by embedders via
+	// extraFSes holds additional theme sources contributed by embedders via
 	// RegisterBuiltinThemes. They are consulted alongside the bundled themes.
-	extraThemeFSes   []fs.FS
-	extraThemeFSesMu sync.RWMutex
-)
+	extraMu   sync.RWMutex
+	extraFSes []fs.FS
+}
+
+// newThemeRegistry returns an empty registry with an initialized theme cache.
+func newThemeRegistry() *themeRegistry {
+	return &themeRegistry{cache: make(map[string]*themeCacheEntry)}
+}
+
+// defaultRegistry backs the package-level theme API.
+var defaultRegistry = newThemeRegistry()
 
 // RegisterBuiltinThemes adds an additional source of built-in themes from fsys.
 // It must contain theme files at "themes/<ref>.yaml" (or .yml) — the same layout
@@ -66,6 +83,10 @@ var (
 // Call this at startup, before applying any persisted theme, so that a persisted
 // selection naming a registered theme resolves.
 func RegisterBuiltinThemes(fsys fs.FS) error {
+	return defaultRegistry.RegisterBuiltinThemes(fsys)
+}
+
+func (r *themeRegistry) RegisterBuiltinThemes(fsys fs.FS) error {
 	if fsys == nil {
 		return errors.New("register built-in themes: nil fs")
 	}
@@ -74,31 +95,31 @@ func RegisterBuiltinThemes(fsys fs.FS) error {
 		return fmt.Errorf("register built-in themes: %w", err)
 	}
 
-	extraThemeFSesMu.Lock()
-	extraThemeFSes = append(extraThemeFSes, fsys)
-	extraThemeFSesMu.Unlock()
+	r.extraMu.Lock()
+	r.extraFSes = append(r.extraFSes, fsys)
+	r.extraMu.Unlock()
 
 	// Newly registered themes must appear in subsequent listings.
-	builtinRefsCacheMu.Lock()
-	builtinRefsCacheOK = false
-	builtinRefsCacheMu.Unlock()
+	r.refsMu.Lock()
+	r.builtinRefsOK = false
+	r.refsMu.Unlock()
 
 	// Drop any theme already resolved under a ref this source overrides (a bundled
 	// built-in, or "default"), so the registered override/mask wins even when it
 	// was loaded before registration — built-in cache entries are otherwise treated
 	// as permanently valid. DefaultTheme()'s own cache is separate and untouched, so
 	// it stays the pristine merge base.
-	InvalidateThemeCache("")
+	r.InvalidateThemeCache("")
 
 	return nil
 }
 
 // registeredThemeFSes returns a snapshot of the embedder-contributed theme
 // sources.
-func registeredThemeFSes() []fs.FS {
-	extraThemeFSesMu.RLock()
-	defer extraThemeFSesMu.RUnlock()
-	return extraThemeFSes
+func (r *themeRegistry) registeredThemeFSes() []fs.FS {
+	r.extraMu.RLock()
+	defer r.extraMu.RUnlock()
+	return slices.Clone(r.extraFSes)
 }
 
 // readThemeRefsFromFS lists the theme refs (file basenames without extension)
@@ -139,9 +160,9 @@ func readThemeData(fsys fs.FS, ref string) ([]byte, bool) {
 // cagent's bundled themes, so an embedder can override a built-in — including
 // masking "default" with their own — and a later RegisterBuiltinThemes call wins
 // a name collision with an earlier one (last-wins).
-func readRegisteredThemeData(ref string) ([]byte, bool) {
+func (r *themeRegistry) readRegisteredThemeData(ref string) ([]byte, bool) {
 	// Iterate newest-first so a later RegisterBuiltinThemes call wins (last-wins).
-	for _, fsys := range slices.Backward(registeredThemeFSes()) {
+	for _, fsys := range slices.Backward(r.registeredThemeFSes()) {
 		if data, ok := readThemeData(fsys, ref); ok {
 			return data, true
 		}
@@ -152,12 +173,17 @@ func readRegisteredThemeData(ref string) ([]byte, bool) {
 // InvalidateThemeCache clears the theme cache for a specific ref, or all if ref is empty.
 // This is primarily for testing; the cache is mtime-aware so it auto-invalidates on file changes.
 func InvalidateThemeCache(ref string) {
-	themeCacheMu.Lock()
-	defer themeCacheMu.Unlock()
+	defaultRegistry.InvalidateThemeCache(ref)
+}
+
+func (r *themeRegistry) InvalidateThemeCache(ref string) {
+	r.cacheMu.Lock()
+	defer r.cacheMu.Unlock()
+	r.generation++
 	if ref == "" {
-		themeCache = make(map[string]*themeCacheEntry)
+		r.cache = make(map[string]*themeCacheEntry)
 	} else {
-		delete(themeCache, ref)
+		delete(r.cache, ref)
 	}
 }
 
@@ -329,6 +355,10 @@ const UserThemePrefix = "user:"
 // User themes with names matching built-in themes are prefixed with "user:" to distinguish them.
 // The "default" theme is always listed first for UX purposes.
 func ListThemeRefs() ([]string, error) {
+	return defaultRegistry.ListThemeRefs()
+}
+
+func (r *themeRegistry) ListThemeRefs() ([]string, error) {
 	// Track built-in refs to detect conflicts with user themes
 	builtinSet := make(map[string]bool)
 
@@ -337,7 +367,7 @@ func ListThemeRefs() ([]string, error) {
 	builtinSet[DefaultThemeRef] = true
 
 	// Add built-in themes from embedded files (default.yaml will be skipped since already added)
-	builtinRefs, err := listBuiltinThemeRefs()
+	builtinRefs, err := r.listBuiltinThemeRefs()
 	if err != nil {
 		return nil, fmt.Errorf("listing built-in themes: %w", err)
 	}
@@ -369,11 +399,15 @@ func ListThemeRefs() ([]string, error) {
 // listBuiltinThemeRefs returns the list of built-in theme references from embedded files.
 // Results are cached since built-in themes never change at runtime.
 func listBuiltinThemeRefs() ([]string, error) {
-	builtinRefsCacheMu.Lock()
-	defer builtinRefsCacheMu.Unlock()
+	return defaultRegistry.listBuiltinThemeRefs()
+}
 
-	if builtinRefsCacheOK {
-		return builtinRefsCache, nil
+func (r *themeRegistry) listBuiltinThemeRefs() ([]string, error) {
+	r.refsMu.Lock()
+	defer r.refsMu.Unlock()
+
+	if r.builtinRefsOK {
+		return slices.Clone(r.builtinRefs), nil
 	}
 
 	refs, err := readThemeRefsFromFS(builtinThemes)
@@ -384,26 +418,26 @@ func listBuiltinThemeRefs() ([]string, error) {
 	// Append themes contributed by embedders, skipping the reserved "default"
 	// ref and any name that collides with an existing built-in.
 	seen := make(map[string]bool, len(refs))
-	for _, r := range refs {
-		seen[r] = true
+	for _, ref := range refs {
+		seen[ref] = true
 	}
-	for _, fsys := range registeredThemeFSes() {
+	for _, fsys := range r.registeredThemeFSes() {
 		extraRefs, err := readThemeRefsFromFS(fsys)
 		if err != nil {
 			return nil, fmt.Errorf("reading registered themes: %w", err)
 		}
-		for _, r := range extraRefs {
-			if r == DefaultThemeRef || seen[r] {
+		for _, ref := range extraRefs {
+			if ref == DefaultThemeRef || seen[ref] {
 				continue
 			}
-			seen[r] = true
-			refs = append(refs, r)
+			seen[ref] = true
+			refs = append(refs, ref)
 		}
 	}
 
-	builtinRefsCache = refs
-	builtinRefsCacheOK = true
-	return refs, nil
+	r.builtinRefs = refs
+	r.builtinRefsOK = true
+	return slices.Clone(refs), nil
 }
 
 // listUserThemeRefs returns the list of user theme references from ~/.cagent/themes/.
@@ -519,6 +553,10 @@ func listThemeRefsFrom(dir string) ([]string, error) {
 // The cache is mtime-aware: user themes are re-parsed only when the file's modTime changes.
 // If a user theme file exists but fails to parse, an error is returned (no silent fallback).
 func LoadTheme(ref string) (*Theme, error) {
+	return defaultRegistry.LoadTheme(ref)
+}
+
+func (r *themeRegistry) LoadTheme(ref string) (*Theme, error) {
 	// Empty ref means "use default theme" - caller should resolve this to DefaultThemeRef
 	if ref == "" {
 		return nil, fmt.Errorf("cannot load theme with empty ref; use %q instead", DefaultThemeRef)
@@ -536,72 +574,81 @@ func LoadTheme(ref string) (*Theme, error) {
 		return nil, err
 	}
 
-	// Determine if this should load from built-in or user themes
-	isBuiltin := !forceUserTheme && IsBuiltinTheme(baseRef)
+	for {
+		// Determine if this should load from built-in or user themes
+		isBuiltin := !forceUserTheme && r.IsBuiltinTheme(baseRef)
 
-	// For user themes, check if file exists and get modTime
-	var userThemePath string
-	var userModTime time.Time
-	if !isBuiltin {
-		userThemePath, userModTime = getUserThemeFileInfo(baseRef)
+		// For user themes, check if file exists and get modTime
+		var userThemePath string
+		var userModTime time.Time
+		if !isBuiltin {
+			userThemePath, userModTime = getUserThemeFileInfo(baseRef)
+		}
+
+		// Check the cache (use the full ref as cache key to distinguish user:nord from nord)
+		r.cacheMu.RLock()
+		generation := r.generation
+		cached, hasCached := r.cache[ref]
+		r.cacheMu.RUnlock()
+
+		if hasCached {
+			if isBuiltin {
+				// Built-in themes don't change at runtime, cache is always valid
+				return cached.theme, nil
+			}
+			// User theme: check if modTime matches
+			if cached.path == userThemePath && cached.modTime.Equal(userModTime) {
+				return cached.theme, nil
+			}
+			// modTime changed or path changed, need to reload
+		}
+
+		// Load and cache the theme
+		var theme *Theme
+		var err error
+		var entry *themeCacheEntry
+
+		switch {
+		case isBuiltin:
+			// Load built-in theme from embedded files
+			theme, err = r.loadBuiltinTheme(baseRef)
+			if err != nil {
+				return nil, err
+			}
+			entry = &themeCacheEntry{
+				theme:   theme,
+				modTime: time.Time{}, // Zero time for built-in themes
+				path:    "",          // Empty path for built-in themes
+			}
+		case userThemePath != "":
+			// User theme file exists - load it
+			theme, err = loadThemeFrom(baseRef, ThemesDir())
+			if err != nil {
+				return nil, err
+			}
+			entry = &themeCacheEntry{
+				theme:   theme,
+				modTime: userModTime,
+				path:    userThemePath,
+			}
+		default:
+			// Not a built-in and no user theme file exists
+			return nil, fmt.Errorf("theme %q not found", ref)
+		}
+
+		// Store in cache (use full ref as key). If registration or explicit
+		// invalidation happened while we loaded, retry so an old source cannot
+		// repopulate the cache after invalidation.
+		r.cacheMu.Lock()
+		if r.generation != generation {
+			r.cacheMu.Unlock()
+			continue
+		}
+		r.cache[ref] = entry
+		r.cacheMu.Unlock()
+
+		return theme, nil
 	}
-
-	// Check the cache (use the full ref as cache key to distinguish user:nord from nord)
-	themeCacheMu.RLock()
-	cached, hasCached := themeCache[ref]
-	themeCacheMu.RUnlock()
-
-	if hasCached {
-		if isBuiltin {
-			// Built-in themes don't change at runtime, cache is always valid
-			return cached.theme, nil
-		}
-		// User theme: check if modTime matches
-		if cached.path == userThemePath && cached.modTime.Equal(userModTime) {
-			return cached.theme, nil
-		}
-		// modTime changed or path changed, need to reload
-	}
-
-	// Load and cache the theme
-	var theme *Theme
-	var err error
-	var entry *themeCacheEntry
-
-	switch {
-	case isBuiltin:
-		// Load built-in theme from embedded files
-		theme, err = loadBuiltinTheme(baseRef)
-		if err != nil {
-			return nil, err
-		}
-		entry = &themeCacheEntry{
-			theme:   theme,
-			modTime: time.Time{}, // Zero time for built-in themes
-			path:    "",          // Empty path for built-in themes
-		}
-	case userThemePath != "":
-		// User theme file exists - load it
-		theme, err = loadThemeFrom(baseRef, ThemesDir())
-		if err != nil {
-			return nil, err
-		}
-		entry = &themeCacheEntry{
-			theme:   theme,
-			modTime: userModTime,
-			path:    userThemePath,
-		}
-	default:
-		// Not a built-in and no user theme file exists
-		return nil, fmt.Errorf("theme %q not found", ref)
-	}
-
-	// Store in cache (use full ref as key)
-	themeCacheMu.Lock()
-	defer themeCacheMu.Unlock()
-	themeCache[ref] = entry
-
-	return theme, nil
 }
 
 // getUserThemeFileInfo returns the path and modTime of a user theme file if it exists.
@@ -636,13 +683,17 @@ func validateThemeRef(ref string) error {
 
 // loadBuiltinTheme loads a built-in theme from embedded files.
 func loadBuiltinTheme(ref string) (*Theme, error) {
+	return defaultRegistry.loadBuiltinTheme(ref)
+}
+
+func (r *themeRegistry) loadBuiltinTheme(ref string) (*Theme, error) {
 	base := DefaultTheme()
 
 	// Prefer embedder-registered sources over cagent's bundled themes, so an
 	// embedder can override a built-in — including masking "default" with their
 	// own. The override is still merged onto the bundled DefaultTheme() base, so
 	// a registered theme only needs to specify the fields it changes.
-	data, ok := readRegisteredThemeData(ref)
+	data, ok := r.readRegisteredThemeData(ref)
 	if !ok {
 		data, ok = readThemeData(builtinThemes, ref)
 	}
@@ -668,6 +719,10 @@ func loadBuiltinTheme(ref string) (*Theme, error) {
 // IsBuiltinTheme returns true if the given theme reference is a built-in theme.
 // Refs prefixed with "user:" are always considered user themes, not built-in.
 func IsBuiltinTheme(ref string) bool {
+	return defaultRegistry.IsBuiltinTheme(ref)
+}
+
+func (r *themeRegistry) IsBuiltinTheme(ref string) bool {
 	// User-prefixed refs are explicitly user themes
 	if strings.HasPrefix(ref, UserThemePrefix) {
 		return false
@@ -677,7 +732,7 @@ func IsBuiltinTheme(ref string) bool {
 		return true
 	}
 
-	builtinRefs, err := listBuiltinThemeRefs()
+	builtinRefs, err := r.listBuiltinThemeRefs()
 	if err != nil {
 		return false
 	}

--- a/pkg/tui/styles/theme_test.go
+++ b/pkg/tui/styles/theme_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sync"
 	"testing"
 	"testing/fstest"
 
@@ -22,48 +23,48 @@ import (
 //go:embed testdata/themes/*.yaml
 var embedderThemes embed.FS
 
-// resetThemes clears embedder-registered theme sources and the theme caches
-// before and after a test, so tests that register themes stay isolated.
-func resetThemes(t *testing.T) {
-	t.Helper()
-	reset := func() {
-		extraThemeFSesMu.Lock()
-		extraThemeFSes = nil
-		extraThemeFSesMu.Unlock()
+type blockingThemeFS struct {
+	fstest.MapFS
 
-		builtinRefsCacheMu.Lock()
-		builtinRefsCacheOK = false
-		builtinRefsCache = nil
-		builtinRefsCacheMu.Unlock()
+	opened  chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
 
-		InvalidateThemeCache("")
+func (fsys *blockingThemeFS) ReadFile(name string) ([]byte, error) {
+	if name == "themes/nord.yaml" {
+		fsys.once.Do(func() {
+			close(fsys.opened)
+			<-fsys.release
+		})
 	}
-	reset()
-	t.Cleanup(reset)
+	return fs.ReadFile(fsys.MapFS, name)
 }
 
 // TestRegisterBuiltinThemes_Integration exercises the full embedder loop:
 // register a theme from a real embed.FS, then discover, load, and apply it the
 // way a downstream CLI/TUI would. The narrower tests below isolate individual
 // behaviors (merge, precedence, errors) with synthetic sources.
-func TestRegisterBuiltinThemes_Integration(t *testing.T) {
-	resetThemes(t)
+func TestRegisterBuiltinThemes_Integration(t *testing.T) { //nolint:paralleltest // ApplyTheme mutates package-wide style variables.
+	registry := newThemeRegistry()
 	original := CurrentTheme()
 	t.Cleanup(func() { ApplyTheme(original) })
 
 	themesFS, err := fs.Sub(embedderThemes, "testdata")
 	require.NoError(t, err)
-	require.NoError(t, RegisterBuiltinThemes(themesFS))
+	require.NoError(t, registry.RegisterBuiltinThemes(themesFS))
 
 	// The registered theme is discoverable and classified like a built-in.
-	refs, err := ListThemeRefs()
+	refs, err := registry.ListThemeRefs()
 	require.NoError(t, err)
 	assert.Contains(t, refs, "embedder")
-	assert.True(t, IsBuiltinTheme("embedder"))
+	assert.True(t, registry.IsBuiltinTheme("embedder"))
 
 	// It applies via the embedder entry point, merged onto the default theme so
 	// unspecified fields are inherited.
-	applied := ApplyThemeRef("embedder")
+	applied, err := registry.LoadTheme("embedder")
+	require.NoError(t, err)
+	ApplyTheme(applied)
 	require.NotNil(t, applied)
 	assert.Equal(t, "embedder", applied.Ref)
 	assert.Equal(t, "Embedder", applied.Name)
@@ -72,11 +73,35 @@ func TestRegisterBuiltinThemes_Integration(t *testing.T) {
 	assert.Equal(t, "embedder", CurrentTheme().Ref)
 }
 
+// TestRegisterBuiltinThemes_PackageAPI verifies the exported wrapper functions
+// use the package-wide default registry correctly.
+func TestRegisterBuiltinThemes_PackageAPI(t *testing.T) { //nolint:paralleltest // Temporarily swaps package-wide defaultRegistry.
+	previous := defaultRegistry
+	defaultRegistry = newThemeRegistry()
+	t.Cleanup(func() { defaultRegistry = previous })
+
+	src := fstest.MapFS{
+		"themes/package-api.yaml": &fstest.MapFile{Data: []byte("name: Package API\n")},
+	}
+	require.NoError(t, RegisterBuiltinThemes(src))
+
+	refs, err := ListThemeRefs()
+	require.NoError(t, err)
+	assert.Contains(t, refs, "package-api")
+	assert.True(t, IsBuiltinTheme("package-api"))
+
+	theme, err := LoadTheme("package-api")
+	require.NoError(t, err)
+	assert.Equal(t, "Package API", theme.Name)
+	assert.Equal(t, "package-api", theme.Ref)
+}
+
 // TestRegisterBuiltinThemes covers core registration: a registered theme is
 // listed, classified as built-in, and loads merged onto the default theme.
 func TestRegisterBuiltinThemes(t *testing.T) {
-	resetThemes(t)
+	t.Parallel()
 
+	registry := newThemeRegistry()
 	def := DefaultTheme()
 
 	src := fstest.MapFS{
@@ -84,14 +109,14 @@ func TestRegisterBuiltinThemes(t *testing.T) {
 			Data: []byte("name: Branded\ncolors:\n  accent: \"#FF0000\"\n"),
 		},
 	}
-	require.NoError(t, RegisterBuiltinThemes(src))
+	require.NoError(t, registry.RegisterBuiltinThemes(src))
 
-	refs, err := ListThemeRefs()
+	refs, err := registry.ListThemeRefs()
 	require.NoError(t, err)
 	assert.Contains(t, refs, "branded")
-	assert.True(t, IsBuiltinTheme("branded"))
+	assert.True(t, registry.IsBuiltinTheme("branded"))
 
-	theme, err := LoadTheme("branded")
+	theme, err := registry.LoadTheme("branded")
 	require.NoError(t, err)
 	assert.Equal(t, "Branded", theme.Name)
 	assert.Equal(t, "branded", theme.Ref)
@@ -104,7 +129,9 @@ func TestRegisterBuiltinThemes(t *testing.T) {
 // across more than one registered source, and that the later-registered source
 // wins a name collision between two registered sources (last-wins).
 func TestRegisterBuiltinThemes_MultipleSources(t *testing.T) {
-	resetThemes(t)
+	t.Parallel()
+
+	registry := newThemeRegistry()
 
 	first := fstest.MapFS{
 		"themes/alpha.yaml":  &fstest.MapFile{Data: []byte("name: Alpha\n")},
@@ -114,16 +141,16 @@ func TestRegisterBuiltinThemes_MultipleSources(t *testing.T) {
 		"themes/beta.yaml":   &fstest.MapFile{Data: []byte("name: Beta\n")},
 		"themes/shared.yaml": &fstest.MapFile{Data: []byte("name: Second\n")},
 	}
-	require.NoError(t, RegisterBuiltinThemes(first))
-	require.NoError(t, RegisterBuiltinThemes(second))
+	require.NoError(t, registry.RegisterBuiltinThemes(first))
+	require.NoError(t, registry.RegisterBuiltinThemes(second))
 
-	refs, err := ListThemeRefs()
+	refs, err := registry.ListThemeRefs()
 	require.NoError(t, err)
 	assert.Contains(t, refs, "alpha")
 	assert.Contains(t, refs, "beta")
 
 	// Later registration wins a collision between two registered sources (last-wins).
-	shared, err := LoadTheme("shared")
+	shared, err := registry.LoadTheme("shared")
 	require.NoError(t, err)
 	assert.Equal(t, "Second", shared.Name)
 }
@@ -131,16 +158,18 @@ func TestRegisterBuiltinThemes_MultipleSources(t *testing.T) {
 // TestRegisterBuiltinThemes_OverridesBuiltin verifies a registered source takes
 // precedence over a bundled theme of the same name.
 func TestRegisterBuiltinThemes_OverridesBuiltin(t *testing.T) {
-	resetThemes(t)
+	t.Parallel()
+
+	registry := newThemeRegistry()
 
 	src := fstest.MapFS{
 		"themes/nord.yaml": &fstest.MapFile{
 			Data: []byte("name: NotNord\ncolors:\n  accent: \"#123456\"\n"),
 		},
 	}
-	require.NoError(t, RegisterBuiltinThemes(src))
+	require.NoError(t, registry.RegisterBuiltinThemes(src))
 
-	got, err := LoadTheme("nord")
+	got, err := registry.LoadTheme("nord")
 	require.NoError(t, err)
 	assert.Equal(t, "#123456", got.Colors.Accent)
 	assert.Equal(t, "NotNord", got.Name)
@@ -149,8 +178,9 @@ func TestRegisterBuiltinThemes_OverridesBuiltin(t *testing.T) {
 // TestRegisterBuiltinThemes_MasksDefault verifies an embedder can replace the
 // "default" theme; the override merges onto cagent's pristine default base.
 func TestRegisterBuiltinThemes_MasksDefault(t *testing.T) {
-	resetThemes(t)
+	t.Parallel()
 
+	registry := newThemeRegistry()
 	cagentDefault := DefaultTheme()
 
 	src := fstest.MapFS{
@@ -158,9 +188,9 @@ func TestRegisterBuiltinThemes_MasksDefault(t *testing.T) {
 			Data: []byte("name: Branded Default\ncolors:\n  accent: \"#ABCDEF\"\n"),
 		},
 	}
-	require.NoError(t, RegisterBuiltinThemes(src))
+	require.NoError(t, registry.RegisterBuiltinThemes(src))
 
-	got, err := LoadTheme(DefaultThemeRef)
+	got, err := registry.LoadTheme(DefaultThemeRef)
 	require.NoError(t, err)
 	assert.Equal(t, "#ABCDEF", got.Colors.Accent)
 	assert.Equal(t, "Branded Default", got.Name)
@@ -176,14 +206,16 @@ func TestRegisterBuiltinThemes_MasksDefault(t *testing.T) {
 // as permanently valid, so registration must drop them; otherwise the override is
 // a silent no-op.
 func TestRegisterBuiltinThemes_OverrideAfterLoad(t *testing.T) {
-	resetThemes(t)
+	t.Parallel()
+
+	registry := newThemeRegistry()
 
 	// Warm the theme cache with the bundled built-in and the bundled default.
-	bundledNord, err := LoadTheme("nord")
+	bundledNord, err := registry.LoadTheme("nord")
 	require.NoError(t, err)
 	require.NotEqual(t, "#123456", bundledNord.Colors.Accent)
 
-	bundledDefault, err := LoadTheme(DefaultThemeRef)
+	bundledDefault, err := registry.LoadTheme(DefaultThemeRef)
 	require.NoError(t, err)
 	require.NotEqual(t, "#ABCDEF", bundledDefault.Colors.Accent)
 
@@ -195,26 +227,73 @@ func TestRegisterBuiltinThemes_OverrideAfterLoad(t *testing.T) {
 			Data: []byte("name: Branded Default\ncolors:\n  accent: \"#ABCDEF\"\n"),
 		},
 	}
-	require.NoError(t, RegisterBuiltinThemes(src))
+	require.NoError(t, registry.RegisterBuiltinThemes(src))
 
-	gotNord, err := LoadTheme("nord")
+	gotNord, err := registry.LoadTheme("nord")
 	require.NoError(t, err)
 	assert.Equal(t, "#123456", gotNord.Colors.Accent)
 	assert.Equal(t, "NotNord", gotNord.Name)
 
-	gotDefault, err := LoadTheme(DefaultThemeRef)
+	gotDefault, err := registry.LoadTheme(DefaultThemeRef)
 	require.NoError(t, err)
 	assert.Equal(t, "#ABCDEF", gotDefault.Colors.Accent)
 	assert.Equal(t, "Branded Default", gotDefault.Name)
 }
 
+// TestRegisterBuiltinThemes_ConcurrentLoadDoesNotRepopulateStaleCache verifies
+// that a load already in progress when registration invalidates the cache cannot
+// store stale built-in data after the invalidation.
+func TestRegisterBuiltinThemes_ConcurrentLoadDoesNotRepopulateStaleCache(t *testing.T) {
+	t.Parallel()
+
+	registry := newThemeRegistry()
+	oldSource := &blockingThemeFS{
+		MapFS: fstest.MapFS{
+			"themes/nord.yaml": &fstest.MapFile{Data: []byte("name: Stale Nord\ncolors:\n  accent: \"#111111\"\n")},
+		},
+		opened:  make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	newSource := fstest.MapFS{
+		"themes/nord.yaml": &fstest.MapFile{Data: []byte("name: Fresh Nord\ncolors:\n  accent: \"#222222\"\n")},
+	}
+	require.NoError(t, registry.RegisterBuiltinThemes(oldSource))
+
+	type loadResult struct {
+		theme *Theme
+		err   error
+	}
+	loaded := make(chan loadResult, 1)
+	go func() {
+		theme, err := registry.LoadTheme("nord")
+		loaded <- loadResult{theme: theme, err: err}
+	}()
+	<-oldSource.opened
+
+	require.NoError(t, registry.RegisterBuiltinThemes(newSource))
+	close(oldSource.release)
+
+	result := <-loaded
+	require.NoError(t, result.err)
+	require.NotNil(t, result.theme)
+	assert.Equal(t, "Fresh Nord", result.theme.Name)
+	assert.Equal(t, "#222222", result.theme.Colors.Accent)
+
+	cached, err := registry.LoadTheme("nord")
+	require.NoError(t, err)
+	assert.Equal(t, "Fresh Nord", cached.Name)
+	assert.Equal(t, "#222222", cached.Colors.Accent)
+}
+
 // TestRegisterBuiltinThemes_Errors covers eager validation of the source.
 func TestRegisterBuiltinThemes_Errors(t *testing.T) {
-	resetThemes(t)
+	t.Parallel()
 
-	require.Error(t, RegisterBuiltinThemes(nil))
+	registry := newThemeRegistry()
+
+	require.Error(t, registry.RegisterBuiltinThemes(nil))
 	// A source without a "themes" directory is rejected eagerly.
-	require.Error(t, RegisterBuiltinThemes(fstest.MapFS{
+	require.Error(t, registry.RegisterBuiltinThemes(fstest.MapFS{
 		"other/x.yaml": &fstest.MapFile{Data: []byte("{}")},
 	}))
 }
@@ -399,7 +478,7 @@ name: YML Theme
 	assert.Equal(t, "YML Theme", theme.Name)
 }
 
-func TestApplyTheme(t *testing.T) {
+func TestApplyTheme(t *testing.T) { //nolint:paralleltest // ApplyTheme mutates package-wide style variables.
 	// Note: Cannot use t.Parallel() because ApplyTheme modifies global state
 
 	// Create a custom theme


### PR DESCRIPTION
## Summary
- Extract theme registry state into an isolated `themeRegistry` struct
- Keep package-level APIs backed by a default registry
- Allow registry-focused theme tests to run safely in parallel

## Validation
- task test
- task build
- task lint