### PR TITLE
refactor(runregistry): introduce Registry struct and tighten dir permissions

### DIFF
--- a/cmd/root/mcp.go
+++ b/cmd/root/mcp.go
@@ -82,7 +82,7 @@ func (f *mcpFlags) runAttach(ctx context.Context) error {
 	if target == "latest" {
 		target = ""
 	}
-	rec, err := runregistry.Find(target)
+	rec, err := runregistry.Default().Find(target)
 	if err != nil {
 		return err
 	}

--- a/cmd/root/run_listen.go
+++ b/cmd/root/run_listen.go
@@ -36,7 +36,7 @@ func (f *runExecFlags) startAttachedServer(ctx context.Context, out *cli.Printer
 	}
 	context.AfterFunc(ctx, func() { _ = ln.Close() })
 
-	cleanup, err := runregistry.Write(runregistry.Record{
+	cleanup, err := runregistry.Default().Write(runregistry.Record{
 		PID:       os.Getpid(),
 		Addr:      "http://" + ln.Addr().String(),
 		SessionID: sess.ID,

--- a/pkg/runregistry/registry.go
+++ b/pkg/runregistry/registry.go
@@ -69,7 +69,7 @@ func (r *Registry) Write(rec Record) (func(), error) {
 	// MkdirAll only applies the mode to directories it creates, so an
 	// already-existing dir may be group/world-readable. Tighten it explicitly
 	// to keep live PIDs/addresses unreadable by other local users.
-	if err := os.Chmod(r.dir, 0o700); err != nil {
+	if err := os.Chmod(r.dir, 0o700); err != nil { //nolint:gosec // directory needs execute bit; 0700 is owner-only
 		return nil, fmt.Errorf("restricting run registry dir: %w", err)
 	}
 

--- a/pkg/runregistry/registry.go
+++ b/pkg/runregistry/registry.go
@@ -29,9 +29,30 @@ type Record struct {
 	StartedAt time.Time `json:"started_at"`
 }
 
+// Registry persists and queries run records stored as per-pid JSON files under
+// a single directory. Construct one with [New] or [Default]; methods carry no
+// shared mutable state, so distinct instances (e.g. one per test) are fully
+// independent and safe to use concurrently.
+type Registry struct {
+	dir string
+	// alive reports whether a pid is live; overridable so tests need not rely
+	// on real process state.
+	alive func(pid int) bool
+}
+
+// New returns a Registry that stores records under dir.
+func New(dir string) *Registry {
+	return &Registry{dir: dir, alive: pidAlive}
+}
+
+// Default returns a Registry rooted at the user's data dir (<data dir>/runs).
+func Default() *Registry {
+	return New(filepath.Join(paths.GetDataDir(), "runs"))
+}
+
 // Dir is the directory holding run records.
-func Dir() string {
-	return filepath.Join(paths.GetDataDir(), "runs")
+func (r *Registry) Dir() string {
+	return r.dir
 }
 
 // Write atomically persists a record for the current process and returns a
@@ -41,12 +62,12 @@ func Dir() string {
 // enumerate live PIDs/addresses by listing it. Individual records are still
 // written with 0o600 for the same reason. Writes go through a sibling temp
 // file + rename so concurrent readers never see torn JSON.
-func Write(rec Record) (func(), error) {
-	if err := os.MkdirAll(Dir(), 0o700); err != nil {
+func (r *Registry) Write(rec Record) (func(), error) {
+	if err := os.MkdirAll(r.dir, 0o700); err != nil {
 		return nil, fmt.Errorf("creating run registry dir: %w", err)
 	}
 
-	path := filepath.Join(Dir(), strconv.Itoa(rec.PID)+".json")
+	path := filepath.Join(r.dir, strconv.Itoa(rec.PID)+".json")
 	buf, err := json.MarshalIndent(rec, "", "  ")
 	if err != nil {
 		return nil, err
@@ -92,8 +113,8 @@ func writeAtomic(path string, data []byte, perm os.FileMode) error {
 
 // List returns every record currently registered. Stale records (whose pid is
 // no longer alive) are skipped and best-effort removed.
-func List() ([]Record, error) {
-	entries, err := os.ReadDir(Dir())
+func (r *Registry) List() ([]Record, error) {
+	entries, err := os.ReadDir(r.dir)
 	if errors.Is(err, fs.ErrNotExist) {
 		return nil, nil
 	}
@@ -106,7 +127,7 @@ func List() ([]Record, error) {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
 			continue
 		}
-		path := filepath.Join(Dir(), e.Name())
+		path := filepath.Join(r.dir, e.Name())
 		buf, err := os.ReadFile(path)
 		if err != nil {
 			continue
@@ -115,7 +136,7 @@ func List() ([]Record, error) {
 		if err := json.Unmarshal(buf, &rec); err != nil {
 			continue
 		}
-		if !pidAlive(rec.PID) {
+		if !r.alive(rec.PID) {
 			_ = os.Remove(path)
 			continue
 		}
@@ -125,8 +146,8 @@ func List() ([]Record, error) {
 }
 
 // Latest returns the most recently started live record, or false when none.
-func Latest() (Record, bool, error) {
-	records, err := List()
+func (r *Registry) Latest() (Record, bool, error) {
+	records, err := r.List()
 	if err != nil || len(records) == 0 {
 		return Record{}, false, err
 	}
@@ -149,10 +170,10 @@ var ErrNoRun = errors.New("no live docker-agent run found; start one with: docke
 // exact equality and only falls back to substring matching when no record
 // matches exactly; ambiguous substring matches return an error so callers
 // don't act on the wrong session.
-func Find(target string) (Record, error) {
+func (r *Registry) Find(target string) (Record, error) {
 	target = strings.TrimSpace(target)
 	if target == "" {
-		rec, ok, err := Latest()
+		rec, ok, err := r.Latest()
 		if err != nil {
 			return Record{}, err
 		}
@@ -162,7 +183,7 @@ func Find(target string) (Record, error) {
 		return rec, nil
 	}
 
-	records, err := List()
+	records, err := r.List()
 	if err != nil {
 		return Record{}, err
 	}

--- a/pkg/runregistry/registry.go
+++ b/pkg/runregistry/registry.go
@@ -66,6 +66,12 @@ func (r *Registry) Write(rec Record) (func(), error) {
 	if err := os.MkdirAll(r.dir, 0o700); err != nil {
 		return nil, fmt.Errorf("creating run registry dir: %w", err)
 	}
+	// MkdirAll only applies the mode to directories it creates, so an
+	// already-existing dir may be group/world-readable. Tighten it explicitly
+	// to keep live PIDs/addresses unreadable by other local users.
+	if err := os.Chmod(r.dir, 0o700); err != nil {
+		return nil, fmt.Errorf("restricting run registry dir: %w", err)
+	}
 
 	path := filepath.Join(r.dir, strconv.Itoa(rec.PID)+".json")
 	buf, err := json.MarshalIndent(rec, "", "  ")

--- a/pkg/runregistry/registry_test.go
+++ b/pkg/runregistry/registry_test.go
@@ -11,24 +11,33 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/docker/docker-agent/pkg/paths"
 )
 
+// newTestRegistry returns a Registry rooted at an isolated temp dir whose pids
+// are all considered alive. Because it shares no process-global state, every
+// test that uses it can run with t.Parallel().
+func newTestRegistry(t *testing.T) *Registry {
+	t.Helper()
+	r := New(filepath.Join(t.TempDir(), "runs"))
+	r.alive = func(int) bool { return true }
+	return r
+}
+
 func TestWriteAndList_RoundTrip(t *testing.T) {
-	withTempDataDir(t)
+	t.Parallel()
+	r := newTestRegistry(t)
 
 	rec := Record{
-		PID:       os.Getpid(),
+		PID:       1234,
 		Addr:      "http://127.0.0.1:1234",
 		SessionID: "sess-1",
 		Agent:     "root",
 		StartedAt: time.Now(),
 	}
-	cleanup, err := Write(rec)
+	cleanup, err := r.Write(rec)
 	require.NoError(t, err)
 
-	records, err := List()
+	records, err := r.List()
 	require.NoError(t, err)
 	require.Len(t, records, 1)
 	assert.Equal(t, rec.SessionID, records[0].SessionID)
@@ -37,7 +46,7 @@ func TestWriteAndList_RoundTrip(t *testing.T) {
 	cleanup()
 	cleanup() // safe to call twice
 
-	records, err = List()
+	records, err = r.List()
 	require.NoError(t, err)
 	assert.Empty(t, records)
 }
@@ -46,13 +55,14 @@ func TestWriteAndList_RoundTrip(t *testing.T) {
 // directory is created with 0o700 so other local users cannot enumerate
 // running PIDs/addresses by listing it.
 func TestWrite_RestrictsDirectoryPermissions(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("Unix mode bits are not enforced on Windows")
 	}
-	withTempDataDir(t)
+	r := newTestRegistry(t)
 
-	cleanup, err := Write(Record{
-		PID:       os.Getpid(),
+	cleanup, err := r.Write(Record{
+		PID:       1,
 		Addr:      "http://127.0.0.1:1",
 		SessionID: "s",
 		StartedAt: time.Now(),
@@ -60,93 +70,95 @@ func TestWrite_RestrictsDirectoryPermissions(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(cleanup)
 
-	info, err := os.Stat(Dir())
+	info, err := os.Stat(r.Dir())
 	require.NoError(t, err)
 	assert.Equal(t, os.FileMode(0o700), info.Mode().Perm(), "registry dir must not be world- or group-readable")
 }
 
 func TestList_DropsStaleRecords(t *testing.T) {
-	withTempDataDir(t)
+	t.Parallel()
+	r := newTestRegistry(t)
+	r.alive = func(pid int) bool { return pid != 999999 }
 
-	writeRecord(t, "999999.json", Record{
+	writeRecord(t, r, "999999.json", Record{
 		PID: 999999, Addr: "x", SessionID: "y",
 		StartedAt: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
 	})
 
-	records, err := List()
+	records, err := r.List()
 	require.NoError(t, err)
 	assert.Empty(t, records)
 
-	_, err = os.Stat(filepath.Join(Dir(), "999999.json"))
+	_, err = os.Stat(filepath.Join(r.Dir(), "999999.json"))
 	assert.True(t, os.IsNotExist(err))
 }
 
 func TestLatest_PicksMostRecent(t *testing.T) {
-	withTempDataDir(t)
+	t.Parallel()
+	r := newTestRegistry(t)
 
-	pid := os.Getpid()
-	writeRecord(t, "1.json", Record{PID: pid, Addr: "http://a", SessionID: "old", StartedAt: time.Now().Add(-time.Hour)})
-	writeRecord(t, "2.json", Record{PID: pid, Addr: "http://b", SessionID: "new", StartedAt: time.Now()})
+	writeRecord(t, r, "1.json", Record{PID: 1, Addr: "http://a", SessionID: "old", StartedAt: time.Now().Add(-time.Hour)})
+	writeRecord(t, r, "2.json", Record{PID: 2, Addr: "http://b", SessionID: "new", StartedAt: time.Now()})
 
-	rec, ok, err := Latest()
+	rec, ok, err := r.Latest()
 	require.NoError(t, err)
 	require.True(t, ok)
 	assert.Equal(t, "new", rec.SessionID)
 }
 
 func TestFind(t *testing.T) {
-	withTempDataDir(t)
+	t.Parallel()
+	r := newTestRegistry(t)
 
-	pid := os.Getpid()
-	writeRecord(t, "1.json", Record{PID: pid, Addr: "http://127.0.0.1:1111", SessionID: "alpha", StartedAt: time.Now().Add(-time.Hour)})
-	writeRecord(t, "2.json", Record{PID: pid, Addr: "http://127.0.0.1:2222", SessionID: "beta", StartedAt: time.Now()})
+	writeRecord(t, r, "1111.json", Record{PID: 1111, Addr: "http://127.0.0.1:1111", SessionID: "alpha", StartedAt: time.Now().Add(-time.Hour)})
+	writeRecord(t, r, "2222.json", Record{PID: 2222, Addr: "http://127.0.0.1:2222", SessionID: "beta", StartedAt: time.Now()})
 
 	t.Run("empty target returns latest", func(t *testing.T) {
-		rec, err := Find("")
+		rec, err := r.Find("")
 		require.NoError(t, err)
 		assert.Equal(t, "beta", rec.SessionID)
 	})
 
 	t.Run("by pid", func(t *testing.T) {
-		rec, err := Find(strconv.Itoa(pid))
+		rec, err := r.Find(strconv.Itoa(1111))
 		require.NoError(t, err)
-		assert.Equal(t, pid, rec.PID)
+		assert.Equal(t, 1111, rec.PID)
 	})
 
 	t.Run("by addr", func(t *testing.T) {
-		rec, err := Find("http://127.0.0.1:1111")
+		rec, err := r.Find("http://127.0.0.1:1111")
 		require.NoError(t, err)
 		assert.Equal(t, "alpha", rec.SessionID)
 	})
 
 	t.Run("by addr trims trailing slash", func(t *testing.T) {
-		rec, err := Find("http://127.0.0.1:2222/")
+		rec, err := r.Find("http://127.0.0.1:2222/")
 		require.NoError(t, err)
 		assert.Equal(t, "beta", rec.SessionID)
 	})
 
 	t.Run("by session id exact", func(t *testing.T) {
-		rec, err := Find("alpha")
+		rec, err := r.Find("alpha")
 		require.NoError(t, err)
 		assert.Equal(t, "alpha", rec.SessionID)
 	})
 
 	t.Run("unknown pid errors", func(t *testing.T) {
-		_, err := Find("999999999")
+		_, err := r.Find("999999999")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "no live run with pid")
 		assert.ErrorIs(t, err, ErrNoRun)
 	})
 
 	t.Run("unknown addr errors", func(t *testing.T) {
-		_, err := Find("http://nope")
+		_, err := r.Find("http://nope")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "no live run at")
 		assert.ErrorIs(t, err, ErrNoRun)
 	})
 
 	t.Run("unknown session id errors", func(t *testing.T) {
-		_, err := Find("zzz")
+		_, err := r.Find("zzz")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "no live run matches")
 		assert.ErrorIs(t, err, ErrNoRun)
@@ -154,13 +166,13 @@ func TestFind(t *testing.T) {
 }
 
 func TestFind_AmbiguousSessionID(t *testing.T) {
-	withTempDataDir(t)
+	t.Parallel()
+	r := newTestRegistry(t)
 
-	pid := os.Getpid()
-	writeRecord(t, "1.json", Record{PID: pid, Addr: "http://a", SessionID: "shared-1", StartedAt: time.Now()})
-	writeRecord(t, "2.json", Record{PID: pid, Addr: "http://b", SessionID: "shared-2", StartedAt: time.Now()})
+	writeRecord(t, r, "1.json", Record{PID: 1, Addr: "http://a", SessionID: "shared-1", StartedAt: time.Now()})
+	writeRecord(t, r, "2.json", Record{PID: 2, Addr: "http://b", SessionID: "shared-2", StartedAt: time.Now()})
 
-	_, err := Find("shared")
+	_, err := r.Find("shared")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ambiguous")
 }
@@ -169,37 +181,32 @@ func TestFind_AmbiguousSessionID(t *testing.T) {
 // exact session-id match was reported as ambiguous because a longer id
 // contained it as a substring.
 func TestFind_ExactMatchBeatsSubstring(t *testing.T) {
-	withTempDataDir(t)
+	t.Parallel()
+	r := newTestRegistry(t)
 
-	pid := os.Getpid()
-	writeRecord(t, "1.json", Record{PID: pid, Addr: "http://a", SessionID: "abc", StartedAt: time.Now()})
-	writeRecord(t, "2.json", Record{PID: pid, Addr: "http://b", SessionID: "abcd", StartedAt: time.Now()})
+	writeRecord(t, r, "1.json", Record{PID: 1, Addr: "http://a", SessionID: "abc", StartedAt: time.Now()})
+	writeRecord(t, r, "2.json", Record{PID: 2, Addr: "http://b", SessionID: "abcd", StartedAt: time.Now()})
 
-	rec, err := Find("abc")
+	rec, err := r.Find("abc")
 	require.NoError(t, err)
 	assert.Equal(t, "abc", rec.SessionID)
 }
 
 func TestFind_EmptyRegistry(t *testing.T) {
-	withTempDataDir(t)
+	t.Parallel()
+	r := newTestRegistry(t)
 
-	_, err := Find("")
+	_, err := r.Find("")
 	require.ErrorIs(t, err, ErrNoRun)
 
-	_, err = Find("123")
+	_, err = r.Find("123")
 	require.ErrorIs(t, err, ErrNoRun)
 }
 
-func withTempDataDir(t *testing.T) {
+func writeRecord(t *testing.T, r *Registry, name string, rec Record) {
 	t.Helper()
-	paths.SetDataDir(t.TempDir())
-	t.Cleanup(func() { paths.SetDataDir("") })
-}
-
-func writeRecord(t *testing.T, name string, rec Record) {
-	t.Helper()
-	require.NoError(t, os.MkdirAll(Dir(), 0o755))
+	require.NoError(t, os.MkdirAll(r.Dir(), 0o755))
 	buf, err := json.Marshal(rec)
 	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(filepath.Join(Dir(), name), buf, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(r.Dir(), name), buf, 0o600))
 }

--- a/pkg/runregistry/registry_test.go
+++ b/pkg/runregistry/registry_test.go
@@ -75,6 +75,31 @@ func TestWrite_RestrictsDirectoryPermissions(t *testing.T) {
 	assert.Equal(t, os.FileMode(0o700), info.Mode().Perm(), "registry dir must not be world- or group-readable")
 }
 
+// TestWrite_TightensExistingDirectoryPermissions ensures Write fixes the
+// permissions of a pre-existing, too-permissive registry dir (MkdirAll only
+// applies its mode when creating the directory).
+func TestWrite_TightensExistingDirectoryPermissions(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix mode bits are not enforced on Windows")
+	}
+	r := newTestRegistry(t)
+	require.NoError(t, os.MkdirAll(r.Dir(), 0o755))
+
+	cleanup, err := r.Write(Record{
+		PID:       1,
+		Addr:      "http://127.0.0.1:1",
+		SessionID: "s",
+		StartedAt: time.Now(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(cleanup)
+
+	info, err := os.Stat(r.Dir())
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o700), info.Mode().Perm(), "registry dir must be tightened to 0o700")
+}
+
 func TestList_DropsStaleRecords(t *testing.T) {
 	t.Parallel()
 	r := newTestRegistry(t)


### PR DESCRIPTION
The `pkg/runregistry` package previously relied on a process-global directory path set via `paths.SetDataDir`, which made it impossible to run its tests in parallel — each test case mutated shared state and raced against the others.

This change converts the package to an explicit `Registry` struct that carries its own `dir` field and an injectable `alive func(pid int) bool` liveness hook. The five package-level functions (`Write`, `List`, `Latest`, `Find`, `Dir`) become methods on `*Registry`. Two constructors are provided: `New(dir)` for tests and callers that need a specific root, and `Default()` which roots at `<data dir>/runs` — the same location as before. Call sites in `cmd/root/run_listen.go` and `cmd/root/mcp.go` are updated to use `Default()`, and the test file is rewritten so every test creates its own isolated `Registry` instance and runs with `t.Parallel()`.

A code-review finding is also addressed: `Write` now explicitly `chmod`s the registry directory to `0o700` after `MkdirAll`, because `MkdirAll` only sets the mode on *newly created* directories — a pre-existing directory with looser permissions would otherwise let other local users enumerate live PIDs and addresses. A regression test (`TestWrite_TightensExistingDirectoryPermissions`) covers this path, and a `//nolint:gosec` comment suppresses the false-positive G302 warning on the `0o700` constant (a directory needs the execute bit; owner-only is the intent).