### PR TITLE
refactor: remove process-global clock/ID vars from pkg/session

### DIFF
--- a/pkg/session/clock_test.go
+++ b/pkg/session/clock_test.go
@@ -100,6 +100,28 @@ func TestImplicitUserMessageAt_IsImplicitAndUsesClock(t *testing.T) {
 	}
 }
 
+func TestWithMessageOptions_UseInjectedClock(t *testing.T) {
+	t.Parallel()
+	fixed := time.Date(2024, 3, 4, 5, 6, 7, 0, time.UTC)
+	want := fixed.Format(time.RFC3339)
+
+	s := New(
+		WithClock(fixedClock(fixed)),
+		WithUserMessage("user"),
+		WithSystemMessage("system"),
+		WithImplicitUserMessage("implicit"),
+	)
+
+	if len(s.Messages) != 3 {
+		t.Fatalf("len(Messages) = %d, want 3", len(s.Messages))
+	}
+	for i, item := range s.Messages {
+		if item.Message.Message.CreatedAt != want {
+			t.Errorf("Messages[%d].CreatedAt = %q, want %q", i, item.Message.Message.CreatedAt, want)
+		}
+	}
+}
+
 func TestDuration_DeterministicWithExplicitTimestamps(t *testing.T) {
 	t.Parallel()
 	t0 := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)

--- a/pkg/session/clock_test.go
+++ b/pkg/session/clock_test.go
@@ -7,49 +7,33 @@ import (
 	"github.com/docker/docker-agent/pkg/chat"
 )
 
-// setNowForTest installs a fixed clock for the duration of t and restores the
-// previous clock on cleanup. Tests use this to assert on CreatedAt fields
-// without flakiness.
-//
-// The clock is a package-level variable, so tests using this helper MUST NOT
-// call t.Parallel(): two parallel tests would race on nowFn.
-func setNowForTest(t *testing.T, fixed time.Time) {
-	t.Helper()
-	prev := nowFn
-	nowFn = func() time.Time { return fixed }
-	t.Cleanup(func() { nowFn = prev })
+// fixedClock returns a clock func that always reports t. Used to make
+// CreatedAt assertions deterministic without touching any global state, so
+// these tests are safe to run in parallel.
+func fixedClock(t time.Time) func() time.Time {
+	return func() time.Time { return t }
 }
 
-// setIDForTest installs a deterministic ID generator for the duration of t and
-// restores the previous generator on cleanup. The supplied IDs are returned
-// in order; running out triggers t.Fatalf.
-//
-// Like setNowForTest, this helper mutates a package-level variable and is not
-// safe to use with t.Parallel(). Additionally, the installed generator calls
-// t.Fatalf if exhausted, which is only valid on the test goroutine — do not
-// use this helper if production code under test may call New() from a
-// background goroutine.
-func setIDForTest(t *testing.T, ids ...string) {
+// stubIDs returns an ID generator that yields the supplied IDs in order and
+// fails the test if exhausted.
+func stubIDs(t *testing.T, ids ...string) func() string {
 	t.Helper()
-	prev := newIDFn
 	i := 0
-	newIDFn = func() string {
+	return func() string {
 		if i >= len(ids) {
-			t.Fatalf("setIDForTest: ran out of IDs after %d calls", i)
+			t.Fatalf("stubIDs: ran out of IDs after %d calls", i)
 		}
 		id := ids[i]
 		i++
 		return id
 	}
-	t.Cleanup(func() { newIDFn = prev })
 }
 
 func TestNew_UsesInjectedClockAndID(t *testing.T) {
+	t.Parallel()
 	fixed := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
-	setNowForTest(t, fixed)
-	setIDForTest(t, "test-session-1")
 
-	s := New()
+	s := New(WithClock(fixedClock(fixed)), WithIDGen(stubIDs(t, "test-session-1")))
 
 	if s.ID != "test-session-1" {
 		t.Errorf("ID = %q, want %q", s.ID, "test-session-1")
@@ -63,20 +47,19 @@ func TestNew_UsesInjectedClockAndID(t *testing.T) {
 }
 
 func TestNew_WithIDOverridesGenerator(t *testing.T) {
-	setIDForTest(t, "should-not-be-used")
-
-	s := New(WithID("explicit-id"))
+	t.Parallel()
+	s := New(WithIDGen(stubIDs(t)), WithID("explicit-id"))
 
 	if s.ID != "explicit-id" {
 		t.Errorf("ID = %q, want %q", s.ID, "explicit-id")
 	}
 }
 
-func TestUserMessage_UsesInjectedClock(t *testing.T) {
+func TestUserMessageAt_UsesProvidedClock(t *testing.T) {
+	t.Parallel()
 	fixed := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
-	setNowForTest(t, fixed)
 
-	msg := UserMessage("hello")
+	msg := UserMessageAt(fixed, "hello")
 
 	if msg.Message.Role != chat.MessageRoleUser {
 		t.Errorf("Role = %v, want user", msg.Message.Role)
@@ -89,11 +72,11 @@ func TestUserMessage_UsesInjectedClock(t *testing.T) {
 	}
 }
 
-func TestSystemMessage_UsesInjectedClock(t *testing.T) {
+func TestSystemMessageAt_UsesProvidedClock(t *testing.T) {
+	t.Parallel()
 	fixed := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
-	setNowForTest(t, fixed)
 
-	msg := SystemMessage("you are a helpful assistant")
+	msg := SystemMessageAt(fixed, "you are a helpful assistant")
 
 	if msg.Message.Role != chat.MessageRoleSystem {
 		t.Errorf("Role = %v, want system", msg.Message.Role)
@@ -103,11 +86,11 @@ func TestSystemMessage_UsesInjectedClock(t *testing.T) {
 	}
 }
 
-func TestImplicitUserMessage_IsImplicitAndUsesClock(t *testing.T) {
+func TestImplicitUserMessageAt_IsImplicitAndUsesClock(t *testing.T) {
+	t.Parallel()
 	fixed := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
-	setNowForTest(t, fixed)
 
-	msg := ImplicitUserMessage("delegated task")
+	msg := ImplicitUserMessageAt(fixed, "delegated task")
 
 	if !msg.Implicit {
 		t.Error("Implicit = false, want true")
@@ -117,15 +100,13 @@ func TestImplicitUserMessage_IsImplicitAndUsesClock(t *testing.T) {
 	}
 }
 
-func TestDuration_DeterministicWithInjectedClock(t *testing.T) {
+func TestDuration_DeterministicWithExplicitTimestamps(t *testing.T) {
+	t.Parallel()
 	t0 := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
 	s := New()
 
-	setNowForTest(t, t0)
-	s.AddMessage(UserMessage("first"))
-
-	setNowForTest(t, t0.Add(5*time.Second))
-	s.AddMessage(UserMessage("second"))
+	s.AddMessage(UserMessageAt(t0, "first"))
+	s.AddMessage(UserMessageAt(t0.Add(5*time.Second), "second"))
 
 	got := s.Duration()
 	want := 5 * time.Second

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -718,19 +718,19 @@ type Opt func(s *Session)
 
 func WithUserMessage(content string) Opt {
 	return func(s *Session) {
-		s.AddMessage(UserMessage(content))
+		s.AddMessage(UserMessageAt(s.now(), content))
 	}
 }
 
 func WithImplicitUserMessage(content string) Opt {
 	return func(s *Session) {
-		s.AddMessage(ImplicitUserMessage(content))
+		s.AddMessage(ImplicitUserMessageAt(s.now(), content))
 	}
 }
 
 func WithSystemMessage(content string) Opt {
 	return func(s *Session) {
-		s.AddMessage(SystemMessage(content))
+		s.AddMessage(SystemMessageAt(s.now(), content))
 	}
 }
 
@@ -831,10 +831,13 @@ func WithID(id string) Opt {
 	}
 }
 
-// WithClock injects the time source used for the session's CreatedAt and for
-// timestamping messages it generates (summaries, compaction input). Primarily
-// for tests that need a deterministic clock; production code leaves it unset
-// and falls back to time.Now.
+// WithClock injects the time source used for the session's CreatedAt, for
+// timestamping messages it generates (summaries, compaction input), and for
+// messages added through WithUserMessage/WithSystemMessage/
+// WithImplicitUserMessage. Because those message options read the clock when
+// they run, WithClock must precede them in the option list (the natural
+// ordering). Primarily for tests that need a deterministic clock; production
+// code leaves it unset and falls back to time.Now.
 func WithClock(now func() time.Time) Opt {
 	return func(s *Session) {
 		s.clock = now

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -17,14 +17,8 @@ import (
 	"github.com/docker/docker-agent/pkg/tools"
 )
 
-// nowFn returns the current time. Indirected through a package-level variable
-// so that tests can install a deterministic clock via setNowForTest.
-var nowFn = time.Now
-
-// newIDFn returns a fresh session ID. Indirected through a package-level
-// variable so that tests can install a deterministic ID generator via
-// setIDForTest.
-var newIDFn = func() string { return uuid.New().String() }
+// defaultNewID returns a fresh random session ID.
+func defaultNewID() string { return uuid.New().String() }
 
 const (
 	// toolContentPlaceholder is the text used to replace truncated tool content
@@ -93,6 +87,16 @@ type Error struct {
 type Session struct {
 	// mu protects Messages from concurrent read/write access.
 	mu sync.RWMutex `json:"-"`
+
+	// now and newID are per-session sources of time and identity. They are
+	// indirected (rather than calling time.Now/uuid.New directly) so that
+	// tests can inject a deterministic clock and ID generator via WithClock
+	// and WithIDGen without mutating any process-global state — which keeps
+	// such tests safe to run with t.Parallel(). Sessions created outside New
+	// (e.g. via JSON deserialization or struct literals) leave these nil; use
+	// the now() and newID() accessors which fall back to real implementations.
+	clock func() time.Time `json:"-"`
+	idgen func() string    `json:"-"`
 
 	// ID is the unique identifier for the session
 	ID string `json:"id"`
@@ -248,18 +252,30 @@ type Message struct {
 }
 
 func ImplicitUserMessage(content string) *Message {
-	msg := UserMessage(content)
+	return ImplicitUserMessageAt(time.Now(), content)
+}
+
+// ImplicitUserMessageAt is like ImplicitUserMessage but stamps the message with
+// an explicit creation time, letting callers (and tests) avoid the wall clock.
+func ImplicitUserMessageAt(createdAt time.Time, content string) *Message {
+	msg := UserMessageAt(createdAt, content)
 	msg.Implicit = true
 	return msg
 }
 
 func UserMessage(content string, multiContent ...chat.MessagePart) *Message {
+	return UserMessageAt(time.Now(), content, multiContent...)
+}
+
+// UserMessageAt is like UserMessage but stamps the message with an explicit
+// creation time, letting callers (and tests) avoid the wall clock.
+func UserMessageAt(createdAt time.Time, content string, multiContent ...chat.MessagePart) *Message {
 	return &Message{
 		Message: chat.Message{
 			Role:         chat.MessageRoleUser,
 			Content:      content,
 			MultiContent: multiContent,
-			CreatedAt:    nowFn().Format(time.RFC3339),
+			CreatedAt:    createdAt.Format(time.RFC3339),
 		},
 	}
 }
@@ -272,11 +288,17 @@ func NewAgentMessage(agentName string, message *chat.Message) *Message {
 }
 
 func SystemMessage(content string) *Message {
+	return SystemMessageAt(time.Now(), content)
+}
+
+// SystemMessageAt is like SystemMessage but stamps the message with an explicit
+// creation time, letting callers (and tests) avoid the wall clock.
+func SystemMessageAt(createdAt time.Time, content string) *Message {
 	return &Message{
 		Message: chat.Message{
 			Role:      chat.MessageRoleSystem,
 			Content:   content,
-			CreatedAt: nowFn().Format(time.RFC3339),
+			CreatedAt: createdAt.Format(time.RFC3339),
 		},
 	}
 }
@@ -809,6 +831,25 @@ func WithID(id string) Opt {
 	}
 }
 
+// WithClock injects the time source used for the session's CreatedAt and for
+// timestamping messages it generates (summaries, compaction input). Primarily
+// for tests that need a deterministic clock; production code leaves it unset
+// and falls back to time.Now.
+func WithClock(now func() time.Time) Opt {
+	return func(s *Session) {
+		s.clock = now
+	}
+}
+
+// WithIDGen injects the generator used to mint the session ID when no explicit
+// ID is provided. Primarily for tests that need deterministic IDs; production
+// code leaves it unset and falls back to a random UUID.
+func WithIDGen(gen func() string) Opt {
+	return func(s *Session) {
+		s.idgen = gen
+	}
+}
+
 // WithExcludedTools sets tool names that should be filtered out of the agent's
 // tool list for this session. This prevents recursive tool calls in skill
 // sub-sessions.
@@ -904,17 +945,41 @@ func (s *Session) OwnCost() float64 {
 	return cost
 }
 
+// now returns the session's current time, falling back to time.Now for
+// sessions created without a clock (e.g. JSON deserialization).
+func (s *Session) now() time.Time {
+	if s.clock != nil {
+		return s.clock()
+	}
+	return time.Now()
+}
+
+// newID returns a fresh session ID using the session's generator, falling back
+// to a random UUID for sessions created without one.
+func (s *Session) newID() string {
+	if s.idgen != nil {
+		return s.idgen()
+	}
+	return defaultNewID()
+}
+
 // New creates a new agent session
 func New(opts ...Opt) *Session {
 	s := &Session{
-		ID:              newIDFn(),
-		CreatedAt:       nowFn(),
 		SendUserMessage: true,
 	}
 
 	for _, opt := range opts {
 		opt(s)
 	}
+
+	// Generate the ID and creation time after options run so that
+	// WithClock/WithIDGen (and WithID) can influence them. WithID short-
+	// circuits the generator when an explicit ID was provided.
+	if s.ID == "" {
+		s.ID = s.newID()
+	}
+	s.CreatedAt = s.now()
 
 	slog.Debug("Creating new session", "session_id", s.ID)
 	return s
@@ -1013,7 +1078,7 @@ func buildInvariantSystemMessages(a *agent.Agent) []chat.Message {
 // first kept message so that recent context is preserved after compaction.
 // Otherwise it is lastSummaryIndex+1 (i.e. right after the summary item), or
 // 0 when there is no summary.
-func buildSessionSummaryMessages(items []Item) ([]chat.Message, int) {
+func (s *Session) buildSessionSummaryMessages(items []Item) ([]chat.Message, int) {
 	var messages []chat.Message
 	// Find the last summary index to determine where conversation messages start
 	// and to include the summary in session summary messages
@@ -1029,7 +1094,7 @@ func buildSessionSummaryMessages(items []Item) ([]chat.Message, int) {
 		messages = append(messages, chat.Message{
 			Role:      chat.MessageRoleUser,
 			Content:   "Session Summary: " + items[lastSummaryIndex].Summary,
-			CreatedAt: nowFn().Format(time.RFC3339),
+			CreatedAt: s.now().Format(time.RFC3339),
 		})
 	}
 
@@ -1094,7 +1159,7 @@ func (s *Session) CompactionInput() ([]chat.Message, []int) {
 		messages = append(messages, chat.Message{
 			Role:      chat.MessageRoleUser,
 			Content:   "Session Summary: " + items[lastSummaryIndex].Summary,
-			CreatedAt: nowFn().Format(time.RFC3339),
+			CreatedAt: s.now().Format(time.RFC3339),
 		})
 		// The synthetic message stands in for the prior summary item;
 		// when this index lands inside the kept tail we want the
@@ -1137,7 +1202,7 @@ func (s *Session) GetMessages(a *agent.Agent, extraSystemMessages ...chat.Messag
 	items := s.snapshotItems()
 
 	// Build session summary messages (vary per session)
-	summaryMessages, startIndex := buildSessionSummaryMessages(items)
+	summaryMessages, startIndex := s.buildSessionSummaryMessages(items)
 
 	var messages []chat.Message
 	messages = append(messages, invariantMessages...)


### PR DESCRIPTION
Global mutable variables in `pkg/session` — a `nowFn` pointing to `time.Now` and a `newIDFn` wrapping a UUID generator — were shared state that tests mutated directly. This made the test suite inherently sequential in that package and introduced data-race potential under `-race`.

The fix moves those dependencies inside each `Session` as unexported `clock func() time.Time` and `idgen func() string` fields, exposed through `now()` and `newID()` accessor methods that fall back to `time.Now` and a random UUID when nil. Existing `&Session{}` literals and JSON-deserialized sessions continue to work without any call-site changes. Two new constructor options, `WithClock` and `WithIDGen`, allow deterministic injection in tests. `New()` now applies all options before generating the ID and `CreatedAt` timestamp, so `WithID` can still short-circuit ID generation as before. Explicit-timestamp message constructors (`UserMessageAt`, `SystemMessageAt`, `ImplicitUserMessageAt`) were added so the originals delegate to them rather than capturing `time.Now` at call time; `buildSessionSummaryMessages` became a method on `*Session` to use `s.now()`. The clock tests in `pkg/session/clock_test.go` were rewritten with local `fixedClock`/`stubIDs` helpers and `t.Parallel()`, so that file now runs its cases in parallel cleanly.

No behaviour is changed for callers. The package passes `go test -race ./pkg/session/...` with all tests marked `t.Parallel()`.