### PR TITLE
refactor: introduce Resolver type in userid and inject cagent ID source in httpclient for parallel-safe tests

### DIFF
--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -19,13 +19,20 @@ import (
 type HTTPOptions struct {
 	Header http.Header
 	Query  url.Values
+
+	// cagentID resolves the persistent install UUID stamped as
+	// `X-Cagent-Id` on gateway-bound requests. It defaults to
+	// [userid.Get]; tests inject their own source via
+	// [withCagentIDSource] to stay independent of global state.
+	cagentID func() string
 }
 
 type Opt func(*HTTPOptions)
 
 func NewHTTPClient(ctx context.Context, opts ...Opt) *http.Client {
 	httpOptions := HTTPOptions{
-		Header: make(http.Header),
+		Header:   make(http.Header),
+		cagentID: userid.Get,
 	}
 
 	for _, opt := range opts {
@@ -125,14 +132,16 @@ func WithProxiedBaseURL(value string) Opt {
 		o.Header.Set("X-Cagent-Arch", runtime.GOARCH)
 		o.Header.Set("X-Cagent-Runtime", "cagent")
 		o.Header.Set("X-Cagent-Runtime-Version", version.Version)
+	}
+}
 
-		// Stamp the persistent UUID identifying this cagent install so
-		// the gateway can correlate calls coming from the same client
-		// across sessions and processes. Same value as the `user_uuid`
-		// telemetry property; the gateway is free to ignore it.
-		if id := userid.Get(); id != "" {
-			o.Header.Set("X-Cagent-Id", id)
-		}
+// withCagentIDSource overrides the source of the `X-Cagent-Id` header.
+// Unexported because it exists solely so tests can supply a
+// deterministic, isolated [userid.Resolver] instead of the global
+// default.
+func withCagentIDSource(fn func() string) Opt {
+	return func(o *HTTPOptions) {
+		o.cagentID = fn
 	}
 }
 
@@ -196,6 +205,16 @@ func (u *userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error
 	if r2.Header.Get("X-Cagent-Forward") != "" {
 		if sid := SessionIDFromContext(r2.Context()); sid != "" {
 			r2.Header.Set("X-Cagent-Session-Id", sid)
+		}
+
+		// Stamp the persistent UUID identifying this cagent install so
+		// the gateway can correlate calls coming from the same client
+		// across sessions and processes. Same value as the `user_uuid`
+		// telemetry property; the gateway is free to ignore it.
+		if u.httpOptions.cagentID != nil {
+			if id := u.httpOptions.cagentID(); id != "" {
+				r2.Header.Set("X-Cagent-Id", id)
+			}
 		}
 	}
 

--- a/pkg/httpclient/client_test.go
+++ b/pkg/httpclient/client_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -16,12 +15,11 @@ import (
 	"github.com/docker/docker-agent/pkg/userid"
 )
 
-// TestMain redirects the config directory used by [userid.Get] to a
-// throw-away temp dir so the package's tests, which exercise
-// gateway-bound HTTP requests, never read or write the real user-uuid
-// file in the developer's config dir. Individual tests can still
-// override the directory and call [userid.ResetForTests] for finer
-// control.
+// TestMain points the config dir used by the default [userid.Get] at a
+// throw-away temp dir so tests exercising gateway-bound requests never
+// read or write the real user-uuid file. The override is set once and
+// never mutated, so it stays safe for parallel tests. Tests needing a
+// deterministic UUID inject their own resolver via [withCagentIDSource].
 func TestMain(m *testing.M) {
 	//nolint:forbidigo // TestMain has no *testing.T, so t.TempDir is unavailable.
 	dir, err := os.MkdirTemp("", "httpclient-test-config-*")
@@ -30,7 +28,6 @@ func TestMain(m *testing.M) {
 	}
 
 	paths.SetConfigDir(dir)
-	userid.ResetForTests()
 
 	code := m.Run()
 
@@ -181,12 +178,16 @@ func TestContextWithSessionID_RoundTrip(t *testing.T) {
 }
 
 func TestCagentIDHeader_GatewayBoundOnly(t *testing.T) {
-	// Pin the persistent UUID file to a temp dir so the test does
-	// not touch the real config dir and the value is deterministic.
-	// We do not call t.Parallel because we mutate the package-level
-	// paths override and the userid cache.
+	t.Parallel()
+
+	// Seed a fixed UUID into an isolated resolver so the value is
+	// deterministic and the test touches neither the real config dir
+	// nor any global state — letting it run in parallel.
 	const stored = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
-	withStoredUserUUID(t, stored)
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "user-uuid"), []byte(stored), 0o600))
+	idSource := userid.New(dir).Get
+	require.Equal(t, stored, idSource(), "seeded resolver must return the stored UUID")
 
 	tests := []struct {
 		name           string
@@ -207,7 +208,10 @@ func TestCagentIDHeader_GatewayBoundOnly(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			headers := doRequest(t, tt.opts...)
+			t.Parallel()
+
+			opts := append([]Opt{withCagentIDSource(idSource)}, tt.opts...)
+			headers := doRequest(t, opts...)
 
 			if tt.wantHeaderSent {
 				assert.Equal(t, stored, headers.Get("X-Cagent-Id"))
@@ -216,28 +220,4 @@ func TestCagentIDHeader_GatewayBoundOnly(t *testing.T) {
 			}
 		})
 	}
-}
-
-// withStoredUserUUID seeds a fixed UUID into a temporary config dir for
-// the duration of the test, so the persistent identifier surfaced by
-// userid.Get is deterministic and isolated from other tests. The
-// previous override is restored on cleanup so we keep the package-wide
-// isolation set up by [TestMain].
-func withStoredUserUUID(t *testing.T, id string) {
-	t.Helper()
-
-	_, err := uuid.Parse(id)
-	require.NoError(t, err, "seeded value must be a valid UUID")
-
-	previous := paths.GetConfigDir()
-
-	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "user-uuid"), []byte(id), 0o600))
-
-	paths.SetConfigDir(dir)
-	userid.ResetForTests()
-	t.Cleanup(func() {
-		paths.SetConfigDir(previous)
-		userid.ResetForTests()
-	})
 }

--- a/pkg/userid/userid.go
+++ b/pkg/userid/userid.go
@@ -20,30 +20,42 @@ import (
 )
 
 // fileName is the basename of the file holding the persistent UUID,
-// stored under [paths.GetConfigDir].
+// stored under the resolver's directory.
 const fileName = "user-uuid"
 
-var (
+// Resolver owns the directory it reads from and the in-memory cache of
+// the resolved UUID. Each instance is fully independent, so tests can
+// create one per [testing.T.TempDir] and run in parallel without
+// sharing any global state.
+type Resolver struct {
+	dirFn func() string
+
 	mu     sync.Mutex
 	cached string
-)
+}
+
+// New returns a [Resolver] that reads and writes the UUID file in dir.
+func New(dir string) *Resolver {
+	return &Resolver{dirFn: func() string { return dir }}
+}
 
 // Get returns the persistent UUID identifying this cagent installation.
 //
 // On the first call it tries to read the value from
-// `$configDir/user-uuid`; if the file does not exist, is empty, or
-// cannot be read, a fresh UUID is generated and persisted (best
-// effort). The result is cached in memory for the lifetime of the
-// process so subsequent calls do not touch the filesystem.
-func Get() string {
-	mu.Lock()
-	defer mu.Unlock()
+// `<dir>/user-uuid`; if the file does not exist, is empty, contains an
+// invalid UUID, or cannot be read, a fresh UUID is generated and
+// persisted (best effort). The result is cached in memory for the
+// lifetime of the resolver so subsequent calls do not touch the
+// filesystem.
+func (r *Resolver) Get() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
-	if cached != "" {
-		return cached
+	if r.cached != "" {
+		return r.cached
 	}
 
-	file := filePath()
+	file := filepath.Join(r.dirFn(), fileName)
 
 	if data, err := os.ReadFile(file); err == nil {
 		if existing := strings.TrimSpace(string(data)); existing != "" {
@@ -52,8 +64,8 @@ func Get() string {
 			// rather than propagating invalid data to telemetry and
 			// the gateway.
 			if _, err := uuid.Parse(existing); err == nil {
-				cached = existing
-				return cached
+				r.cached = existing
+				return r.cached
 			}
 			// File contains invalid UUID — fall through and regenerate.
 		}
@@ -66,22 +78,19 @@ func Get() string {
 	// disk we still cache it in memory so the same identifier is used
 	// for the rest of this process.
 	_ = save(file, id)
-	cached = id
-	return cached
+	r.cached = id
+	return r.cached
 }
 
-// ResetForTests clears the in-memory cache. Tests in any package
-// that rely on a deterministic config dir override should call this
-// after [paths.SetConfigDir] to force the next [Get] call to re-read
-// from disk.
-func ResetForTests() {
-	mu.Lock()
-	defer mu.Unlock()
-	cached = ""
-}
+// defaultResolver backs the package-level [Get]. It resolves its
+// directory lazily through [paths.GetConfigDir] so it always honours
+// the config-dir override in effect at call time.
+var defaultResolver = &Resolver{dirFn: paths.GetConfigDir}
 
-func filePath() string {
-	return filepath.Join(paths.GetConfigDir(), fileName)
+// Get returns the persistent UUID using the default resolver, which
+// reads from [paths.GetConfigDir].
+func Get() string {
+	return defaultResolver.Get()
 }
 
 func save(file, id string) error {

--- a/pkg/userid/userid_test.go
+++ b/pkg/userid/userid_test.go
@@ -8,15 +8,15 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/docker/docker-agent/pkg/paths"
 )
 
 func TestGet_GeneratesAndPersistsUUID(t *testing.T) {
-	dir := t.TempDir()
-	useConfigDir(t, dir)
+	t.Parallel()
 
-	id := Get()
+	dir := t.TempDir()
+	r := New(dir)
+
+	id := r.Get()
 
 	require.NotEmpty(t, id)
 	_, err := uuid.Parse(id)
@@ -28,69 +28,52 @@ func TestGet_GeneratesAndPersistsUUID(t *testing.T) {
 }
 
 func TestGet_ReturnsExistingUUID(t *testing.T) {
-	dir := t.TempDir()
-	useConfigDir(t, dir)
+	t.Parallel()
 
+	dir := t.TempDir()
 	const stored = "11111111-2222-3333-4444-555555555555"
 	require.NoError(t, os.WriteFile(filepath.Join(dir, fileName), []byte(stored+"\n"), 0o600))
 
-	assert.Equal(t, stored, Get(), "Get must return the persisted UUID, trimmed")
+	assert.Equal(t, stored, New(dir).Get(), "Get must return the persisted UUID, trimmed")
 }
 
 func TestGet_RegeneratesOnEmptyFile(t *testing.T) {
-	dir := t.TempDir()
-	useConfigDir(t, dir)
+	t.Parallel()
 
+	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, fileName), []byte("   \n"), 0o600))
 
-	id := Get()
+	id := New(dir).Get()
 	require.NotEmpty(t, id)
 	_, err := uuid.Parse(id)
 	require.NoError(t, err, "Get must regenerate when the existing file is blank")
 }
 
 func TestGet_CachesAcrossCalls(t *testing.T) {
-	dir := t.TempDir()
-	useConfigDir(t, dir)
+	t.Parallel()
 
-	first := Get()
+	dir := t.TempDir()
+	r := New(dir)
+
+	first := r.Get()
 
 	// Mutating the file on disk after the first call must not change
 	// the value returned by subsequent calls (it is served from the
 	// in-memory cache).
 	require.NoError(t, os.WriteFile(filepath.Join(dir, fileName), []byte("changed-on-disk"), 0o600))
 
-	assert.Equal(t, first, Get(), "Get must return the cached value on subsequent calls")
-}
-
-// useConfigDir points paths.GetConfigDir at dir for the duration of the
-// test and resets the in-memory cache so [Get] is forced to re-read
-// from disk. The override is removed and the cache is cleared on
-// cleanup so subsequent tests start fresh.
-//
-// These tests intentionally do not call [t.Parallel] because they
-// share package-level mutable state (the cached UUID and the global
-// config-dir override).
-func useConfigDir(t *testing.T, dir string) {
-	t.Helper()
-
-	paths.SetConfigDir(dir)
-	ResetForTests()
-
-	t.Cleanup(func() {
-		paths.SetConfigDir("")
-		ResetForTests()
-	})
+	assert.Equal(t, first, r.Get(), "Get must return the cached value on subsequent calls")
 }
 
 func TestGet_RegeneratesOnInvalidUUID(t *testing.T) {
-	dir := t.TempDir()
-	useConfigDir(t, dir)
+	t.Parallel()
 
+	dir := t.TempDir()
 	// Write an invalid UUID to the file (e.g., manually corrupted)
 	require.NoError(t, os.WriteFile(filepath.Join(dir, fileName), []byte("not-a-valid-uuid"), 0o600))
 
-	id := Get()
+	r := New(dir)
+	id := r.Get()
 	require.NotEmpty(t, id)
 	_, err := uuid.Parse(id)
 	require.NoError(t, err, "Get must regenerate when the existing file contains an invalid UUID")


### PR DESCRIPTION
The `pkg/userid` and `pkg/httpclient` tests could not use `t.Parallel()` safely because they both relied on package-global mutable state: `userid` had a cached UUID and a process-wide `paths.SetConfigDir` override, while `httpclient` stamped the `X-Cagent-Id` header by calling the global `userid.Get` directly inside `WithProxiedBaseURL`.

`pkg/userid` now exposes a `Resolver` type that owns its own directory function and an in-memory cache guarded by a mutex. Each test constructs an independent `Resolver` via `New(t.TempDir())` and runs in parallel without interfering with others. The package-level `Get()` delegates to a `defaultResolver` whose directory function is `paths.GetConfigDir`, so production behavior is completely unchanged. The now-unused `ResetForTests()` and `reset()` helpers were removed.

`pkg/httpclient` gains a dependency-injection seam: `HTTPOptions` carries a `cagentID func() string` that defaults to `userid.Get`. The header stamping was moved from `WithProxiedBaseURL` into `RoundTrip`, next to the existing `X-Cagent-Session-Id` logic and gated on the same `X-Cagent-Forward` header, which preserves behavior for all real callers. An unexported `withCagentIDSource(fn)` option lets tests inject a deterministic value, so those tests can also run with `t.Parallel()` without touching global state.

Both packages pass `go test -race` and the full `task test` suite; `task lint` reports no new issues.