### PR TITLE
feat(1password): cache op:// resolutions and coalesce concurrent lookups

### DIFF
--- a/docs/guides/secrets/index.md
+++ b/docs/guides/secrets/index.md
@@ -233,7 +233,7 @@ References follow the `op://<vault>/<item>/<field>` format. Make sure the `op` C
 
 <div class="callout callout-warning" markdown="1">
 <div class="callout-title">Behaviour when resolution fails</div>
-<p>If the value starts with <code>op://</code> but the <code>op</code> CLI is not installed, or the reference cannot be read (not signed in, wrong path, locked vault), docker-agent logs a warning and treats the variable as <strong>unset</strong> — it never forwards the raw <code>op://</code> reference to a model provider or tool.</p>
+<p>If the value starts with <code>op://</code> but the <code>op</code> CLI is not installed, or the reference cannot be read (not signed in, wrong path, locked vault), docker-agent logs a warning and uses an <strong>empty value</strong> — it never forwards the raw <code>op://</code> reference to a model provider or tool. Resolved references (and deterministic failures) are cached for the lifetime of the run; transient failures such as a cancelled lookup are not cached, so a later attempt can retry.</p>
 </div>
 
 ## Choosing a Method

--- a/pkg/environment/onepassword.go
+++ b/pkg/environment/onepassword.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"strings"
+	"sync"
 )
 
 // onePasswordPrefix marks an environment value as a 1Password secret reference
@@ -19,6 +20,12 @@ type OnePasswordProvider struct {
 	// resolve turns a "op://..." reference into its secret value. It is a field
 	// so tests can inject a fake resolver without relying on the `op` binary.
 	resolve func(ctx context.Context, reference string) (string, bool)
+
+	// cache memoizes resolved references so the same secret is not looked up
+	// (and the `op` CLI not spawned) repeatedly. Failed resolutions are cached
+	// as an empty string too, since they are equally deterministic per run.
+	mu    sync.Mutex
+	cache map[string]string
 }
 
 type OnePasswordNotAvailableError struct{}
@@ -35,6 +42,7 @@ func NewOnePasswordProvider(provider Provider) Provider {
 	return &OnePasswordProvider{
 		provider: provider,
 		resolve:  resolveOnePasswordReference,
+		cache:    make(map[string]string),
 	}
 }
 
@@ -54,11 +62,29 @@ func (p *OnePasswordProvider) Get(ctx context.Context, name string) (string, boo
 		return value, found
 	}
 
-	resolved, ok := p.resolve(ctx, value)
-	if !ok {
-		slog.WarnContext(ctx, "Failed to resolve 1Password secret reference", "name", name)
-		return "", false
+	// Always report the variable as found: returning the raw "op://" reference
+	// would leak it to downstream providers, so an unresolved reference becomes
+	// an empty value instead.
+	return p.resolveCached(ctx, value), true
+}
+
+func (p *OnePasswordProvider) resolveCached(ctx context.Context, reference string) string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.cache == nil {
+		p.cache = make(map[string]string)
+	}
+	if resolved, ok := p.cache[reference]; ok {
+		return resolved
 	}
 
-	return resolved, true
+	resolved, ok := p.resolve(ctx, reference)
+	if !ok {
+		slog.WarnContext(ctx, "Failed to resolve 1Password secret reference; using empty value", "reference", reference)
+		resolved = ""
+	}
+
+	p.cache[reference] = resolved
+	return resolved
 }

--- a/pkg/environment/onepassword.go
+++ b/pkg/environment/onepassword.go
@@ -5,6 +5,8 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+
+	"golang.org/x/sync/singleflight"
 )
 
 // onePasswordPrefix marks an environment value as a 1Password secret reference
@@ -21,9 +23,15 @@ type OnePasswordProvider struct {
 	// so tests can inject a fake resolver without relying on the `op` binary.
 	resolve func(ctx context.Context, reference string) (string, bool)
 
-	// cache memoizes resolved references so the same secret is not looked up
-	// (and the `op` CLI not spawned) repeatedly. Failed resolutions are cached
-	// as an empty string too, since they are equally deterministic per run.
+	// group coalesces concurrent resolutions of the same reference so the `op`
+	// CLI is spawned at most once per reference, while still allowing distinct
+	// references to resolve in parallel.
+	group singleflight.Group
+
+	// cache memoizes resolved references. Successful results and deterministic
+	// failures (op missing, bad reference) are cached so we don't keep spawning
+	// the CLI; transient failures (e.g. context cancellation) are not cached so
+	// a later call can retry.
 	mu    sync.Mutex
 	cache map[string]string
 }
@@ -69,22 +77,45 @@ func (p *OnePasswordProvider) Get(ctx context.Context, name string) (string, boo
 }
 
 func (p *OnePasswordProvider) resolveCached(ctx context.Context, reference string) string {
+	if cached, ok := p.cachedValue(reference); ok {
+		return cached
+	}
+
+	resolved, _, _ := p.group.Do(reference, func() (any, error) {
+		if cached, ok := p.cachedValue(reference); ok {
+			return cached, nil
+		}
+
+		value, ok := p.resolve(ctx, reference)
+		if !ok {
+			slog.WarnContext(ctx, "Failed to resolve 1Password secret reference; using empty value")
+			value = ""
+			// Don't cache failures caused by a cancelled/expired context: those
+			// are transient and a later call should be allowed to retry.
+			if ctx.Err() != nil {
+				return value, nil
+			}
+		}
+
+		p.storeValue(reference, value)
+		return value, nil
+	})
+
+	return resolved.(string)
+}
+
+func (p *OnePasswordProvider) cachedValue(reference string) (string, bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	value, ok := p.cache[reference]
+	return value, ok
+}
 
+func (p *OnePasswordProvider) storeValue(reference, value string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	if p.cache == nil {
 		p.cache = make(map[string]string)
 	}
-	if resolved, ok := p.cache[reference]; ok {
-		return resolved
-	}
-
-	resolved, ok := p.resolve(ctx, reference)
-	if !ok {
-		slog.WarnContext(ctx, "Failed to resolve 1Password secret reference; using empty value", "reference", reference)
-		resolved = ""
-	}
-
-	p.cache[reference] = resolved
-	return resolved
+	p.cache[reference] = value
 }

--- a/pkg/environment/onepassword_test.go
+++ b/pkg/environment/onepassword_test.go
@@ -41,13 +41,14 @@ func TestOnePasswordProvider_Get(t *testing.T) {
 			wantFound: false,
 		},
 		{
-			name:   "failed resolution reports not found",
+			name:   "failed resolution yields empty value but stays found",
 			stored: map[string]string{"API_KEY": "op://vault/item/field"},
 			resolve: func(context.Context, string) (string, bool) {
 				return "", false
 			},
 			lookup:    "API_KEY",
-			wantFound: false,
+			wantValue: "",
+			wantFound: true,
 		},
 	}
 
@@ -77,6 +78,48 @@ func TestOnePasswordProvider_Get(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOnePasswordProvider_CachesResolvedReferences(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	provider := &OnePasswordProvider{
+		provider: NewMapEnvProvider(map[string]string{"API_KEY": "op://vault/item/field"}),
+		resolve: func(context.Context, string) (string, bool) {
+			calls++
+			return "resolved-secret", true
+		},
+	}
+
+	for range 3 {
+		value, found := provider.Get(t.Context(), "API_KEY")
+		assert.True(t, found)
+		assert.Equal(t, "resolved-secret", value)
+	}
+
+	assert.Equal(t, 1, calls, "reference should only be resolved once")
+}
+
+func TestOnePasswordProvider_CachesFailedResolutions(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	provider := &OnePasswordProvider{
+		provider: NewMapEnvProvider(map[string]string{"API_KEY": "op://vault/item/field"}),
+		resolve: func(context.Context, string) (string, bool) {
+			calls++
+			return "", false
+		},
+	}
+
+	for range 3 {
+		value, found := provider.Get(t.Context(), "API_KEY")
+		assert.True(t, found)
+		assert.Empty(t, value)
+	}
+
+	assert.Equal(t, 1, calls, "failed resolution should only be attempted once")
 }
 
 func TestNewOnePasswordProvider_AlwaysWraps(t *testing.T) {

--- a/pkg/environment/onepassword_test.go
+++ b/pkg/environment/onepassword_test.go
@@ -2,6 +2,7 @@ package environment
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -120,6 +121,75 @@ func TestOnePasswordProvider_CachesFailedResolutions(t *testing.T) {
 	}
 
 	assert.Equal(t, 1, calls, "failed resolution should only be attempted once")
+}
+
+func TestOnePasswordProvider_DoesNotCacheContextCancelledFailures(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	provider := &OnePasswordProvider{
+		provider: NewMapEnvProvider(map[string]string{"API_KEY": "op://vault/item/field"}),
+		resolve: func(ctx context.Context, _ string) (string, bool) {
+			calls++
+			if ctx.Err() != nil {
+				return "", false
+			}
+			return "resolved-secret", true
+		},
+	}
+
+	// A first lookup under a cancelled context must not poison the cache.
+	cancelled, cancel := context.WithCancel(t.Context())
+	cancel()
+	value, found := provider.Get(cancelled, "API_KEY")
+	assert.True(t, found)
+	assert.Empty(t, value)
+
+	// A subsequent lookup with a healthy context should retry and succeed.
+	value, found = provider.Get(t.Context(), "API_KEY")
+	assert.True(t, found)
+	assert.Equal(t, "resolved-secret", value)
+	assert.Equal(t, 2, calls, "cancelled failure must not be cached")
+}
+
+func TestOnePasswordProvider_ConcurrentLookups(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	calls := map[string]int{}
+	provider := &OnePasswordProvider{
+		provider: NewMapEnvProvider(map[string]string{
+			"A": "op://vault/a/field",
+			"B": "op://vault/b/field",
+		}),
+		resolve: func(_ context.Context, reference string) (string, bool) {
+			mu.Lock()
+			calls[reference]++
+			mu.Unlock()
+			return "value-for-" + reference, true
+		},
+	}
+
+	var wg sync.WaitGroup
+	for range 20 {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			value, found := provider.Get(t.Context(), "A")
+			assert.True(t, found)
+			assert.Equal(t, "value-for-op://vault/a/field", value)
+		}()
+		go func() {
+			defer wg.Done()
+			value, found := provider.Get(t.Context(), "B")
+			assert.True(t, found)
+			assert.Equal(t, "value-for-op://vault/b/field", value)
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, 1, calls["op://vault/a/field"], "reference A should resolve once")
+	assert.Equal(t, 1, calls["op://vault/b/field"], "reference B should resolve once")
 }
 
 func TestNewOnePasswordProvider_AlwaysWraps(t *testing.T) {


### PR DESCRIPTION
Every time an agent environment variable resolved to an `op://` reference, the `op` CLI was spawned unconditionally. In workloads that reference the same secret many times—or that have concurrent tool calls touching the same variable—this produced redundant subprocess invocations and, in some edge cases, leaked the raw `op://` string to downstream providers when resolution failed.

This change introduces two complementary fixes. First, resolved references are now memoized so the `op` CLI is called at most once per distinct `op://` reference per process lifetime; successful resolutions and deterministic failures (missing binary, bad reference) are cached, while failures caused by a cancelled or expired context are deliberately *not* cached so a later call can retry. Second, `golang.org/x/sync/singleflight` is used to coalesce concurrent resolutions of the *same* reference—preventing redundant `op` invocations under parallelism while still allowing different references to resolve in parallel. The `Get` method also now returns `("", true)` instead of `("", false)` when a reference cannot be resolved, so a raw `op://` string is never passed to downstream providers as a literal value. Finally, the raw reference is no longer logged on failure to avoid leaking vault/item/field metadata into log output.

No breaking changes; the public API and behavior for callers that were already getting a resolved secret are unchanged.