### PR TITLE
fix: make chmod in Registry.Write best-effort to avoid breaking non-owner callers

### DIFF
--- a/pkg/runregistry/registry.go
+++ b/pkg/runregistry/registry.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"slices"
@@ -68,9 +69,15 @@ func (r *Registry) Write(rec Record) (func(), error) {
 	}
 	// MkdirAll only applies the mode to directories it creates, so an
 	// already-existing dir may be group/world-readable. Tighten it explicitly
-	// to keep live PIDs/addresses unreadable by other local users.
-	if err := os.Chmod(r.dir, 0o700); err != nil { //nolint:gosec // directory needs execute bit; 0700 is owner-only
-		return nil, fmt.Errorf("restricting run registry dir: %w", err)
+	// to keep live PIDs/addresses unreadable by other local users. This is
+	// best-effort: a dir we don't own (e.g. created by root before dropping
+	// privileges) can't be chmod'd, but such a dir is also unlikely to be
+	// readable by arbitrary local users, so we log and carry on rather than
+	// breaking Write permanently.
+	if info, err := os.Stat(r.dir); err == nil && info.Mode().Perm() != 0o700 {
+		if err := os.Chmod(r.dir, 0o700); err != nil { //nolint:gosec // directory needs execute bit; 0700 is owner-only
+			slog.Warn("Could not tighten run registry dir permissions", "dir", r.dir, "error", err)
+		}
 	}
 
 	path := filepath.Join(r.dir, strconv.Itoa(rec.PID)+".json")

--- a/pkg/runregistry/registry.go
+++ b/pkg/runregistry/registry.go
@@ -71,10 +71,12 @@ func (r *Registry) Write(rec Record) (func(), error) {
 	// already-existing dir may be group/world-readable. Tighten it explicitly
 	// to keep live PIDs/addresses unreadable by other local users. This is
 	// best-effort: a dir we don't own (e.g. created by root before dropping
-	// privileges) can't be chmod'd, but such a dir is also unlikely to be
-	// readable by arbitrary local users, so we log and carry on rather than
-	// breaking Write permanently.
-	if info, err := os.Stat(r.dir); err == nil && info.Mode().Perm() != 0o700 {
+	// privileges) can't be chmod'd, so we log and carry on rather than breaking
+	// Write permanently — the directory's existing permissions still apply.
+	switch info, err := os.Stat(r.dir); {
+	case err != nil:
+		slog.Warn("Could not stat run registry dir to verify permissions", "dir", r.dir, "error", err)
+	case info.Mode().Perm() != 0o700:
 		if err := os.Chmod(r.dir, 0o700); err != nil { //nolint:gosec // directory needs execute bit; 0700 is owner-only
 			slog.Warn("Could not tighten run registry dir permissions", "dir", r.dir, "error", err)
 		}


### PR DESCRIPTION
When `Registry.Write` creates the runs directory it calls `os.Chmod` to tighten permissions to `0o700`. That worked fine when the directory was created fresh, but it regresses for callers that don't own the directory — for example, when a root-owned `<datadir>/runs` directory already exists and a privilege-dropped process tries to write into it. In that case `os.Chmod` returns `EPERM`, which previously caused every `Write` call to fail permanently.

The fix makes the chmod best-effort. `os.Stat` is checked first: if the directory already has `0o700` permissions the chmod is skipped entirely. If it can't be skipped and `os.Chmod` fails, the error is now logged via `slog.Warn` rather than surfaced as a hard error. A failed `os.Stat` is also logged so the caller has visibility into filesystem surprises. The comment was also softened to avoid over-claiming that a non-owned directory is unlikely to be readable by other users — that depends entirely on the umask and parent directory ACLs.

No breaking changes. The behavioral delta only affects the already-broken case where chmod was returning an error; callers that succeed today continue to behave identically.