### PR TITLE
test: enable t.Parallel() in environment, config, and sessioncontext tests

### DIFF
--- a/pkg/config/latest/expand_env_test.go
+++ b/pkg/config/latest/expand_env_test.go
@@ -23,12 +23,15 @@ func tableExpander(vars map[string]string) func(string) (string, error) {
 }
 
 func TestModelConfig_ExpandEnv(t *testing.T) {
+	t.Parallel()
+
 	vars := map[string]string{
 		"NEMOTRON3_MODEL": "huggingface.co/unsloth/nemotron-3-nano:Q3_K_M",
 		"DMR_BASE_URL":    "http://localhost:12434/engines/v1",
 	}
 
 	t.Run("expands model and base_url", func(t *testing.T) {
+		t.Parallel()
 		m := &ModelConfig{
 			Provider: "dmr",
 			Model:    "${env.NEMOTRON3_MODEL}",
@@ -43,6 +46,7 @@ func TestModelConfig_ExpandEnv(t *testing.T) {
 	})
 
 	t.Run("plain values unchanged", func(t *testing.T) {
+		t.Parallel()
 		m := &ModelConfig{Model: "gpt-4o", BaseURL: "https://api.openai.com/v1"}
 		require.NoError(t, m.ExpandEnv(tableExpander(vars)))
 		assert.Equal(t, "gpt-4o", m.Model)
@@ -50,6 +54,7 @@ func TestModelConfig_ExpandEnv(t *testing.T) {
 	})
 
 	t.Run("empty fields and nil expander are no-ops", func(t *testing.T) {
+		t.Parallel()
 		m := &ModelConfig{Model: "${env.NEMOTRON3_MODEL}"}
 		require.NoError(t, m.ExpandEnv(nil))
 		assert.Equal(t, "${env.NEMOTRON3_MODEL}", m.Model)
@@ -61,11 +66,13 @@ func TestModelConfig_ExpandEnv(t *testing.T) {
 	})
 
 	t.Run("nil receiver is a no-op", func(t *testing.T) {
+		t.Parallel()
 		var m *ModelConfig
 		require.NoError(t, m.ExpandEnv(tableExpander(vars)))
 	})
 
 	t.Run("propagates expander error", func(t *testing.T) {
+		t.Parallel()
 		boom := errors.New("variable not set")
 		m := &ModelConfig{Model: "${env.MISSING}"}
 		err := m.ExpandEnv(func(string) (string, error) { return "", boom })

--- a/pkg/environment/refs_test.go
+++ b/pkg/environment/refs_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestRefs(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name  string
 		value string
@@ -22,6 +24,7 @@ func TestRefs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, tt.want, Refs(tt.value))
 		})
 	}

--- a/pkg/tools/builtin/sessioncontext/sessioncontext_test.go
+++ b/pkg/tools/builtin/sessioncontext/sessioncontext_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestToolsMetadata(t *testing.T) {
+	t.Parallel()
+
 	ts := New()
 	defs, err := ts.Tools(t.Context())
 	require.NoError(t, err)
@@ -26,12 +28,16 @@ func TestToolsMetadata(t *testing.T) {
 }
 
 func TestInstructionsMentionBothTools(t *testing.T) {
+	t.Parallel()
+
 	instr := New().Instructions()
 	assert.Contains(t, instr, ToolNameListSessions)
 	assert.Contains(t, instr, ToolNameReadSession)
 }
 
 func TestClampLimit(t *testing.T) {
+	t.Parallel()
+
 	assert.Equal(t, DefaultListLimit, ClampLimit(0))
 	assert.Equal(t, DefaultListLimit, ClampLimit(-5))
 	assert.Equal(t, 7, ClampLimit(7))
@@ -48,6 +54,8 @@ func assistantMsg(content string) chat.Message {
 }
 
 func TestRenderTranscriptHeaderAndBody(t *testing.T) {
+	t.Parallel()
+
 	created := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
 	out := RenderTranscript(Header{
 		ID:          "abc123",
@@ -70,6 +78,8 @@ func TestRenderTranscriptHeaderAndBody(t *testing.T) {
 }
 
 func TestRenderTranscriptUntitled(t *testing.T) {
+	t.Parallel()
+
 	out := RenderTranscript(Header{ID: "x"}, []chat.Message{userMsg("hi")}, 0)
 	assert.Contains(t, out, "# Session x — (untitled)")
 	// A zero CreatedAt is omitted rather than printing a year-1 timestamp.
@@ -77,6 +87,8 @@ func TestRenderTranscriptUntitled(t *testing.T) {
 }
 
 func TestRenderTranscriptRendersToolCalls(t *testing.T) {
+	t.Parallel()
+
 	msg := chat.Message{
 		Role: chat.MessageRoleAssistant,
 		ToolCalls: []tools.ToolCall{
@@ -88,6 +100,8 @@ func TestRenderTranscriptRendersToolCalls(t *testing.T) {
 }
 
 func TestRenderTranscriptSkipsEmptyMessages(t *testing.T) {
+	t.Parallel()
+
 	out := RenderTranscript(Header{ID: "x"}, []chat.Message{
 		{Role: chat.MessageRoleAssistant, Content: "   "},
 		userMsg("real content"),
@@ -98,6 +112,8 @@ func TestRenderTranscriptSkipsEmptyMessages(t *testing.T) {
 }
 
 func TestRenderTranscriptMultiContentFallback(t *testing.T) {
+	t.Parallel()
+
 	msg := chat.Message{
 		Role: chat.MessageRoleUser,
 		MultiContent: []chat.MessagePart{
@@ -111,6 +127,8 @@ func TestRenderTranscriptMultiContentFallback(t *testing.T) {
 }
 
 func TestRenderTranscriptTruncatesOldestFirst(t *testing.T) {
+	t.Parallel()
+
 	msgs := []chat.Message{
 		userMsg("OLDEST oldest oldest " + strings.Repeat("a", 200)),
 		assistantMsg("MIDDLE middle middle " + strings.Repeat("b", 200)),
@@ -126,6 +144,8 @@ func TestRenderTranscriptTruncatesOldestFirst(t *testing.T) {
 }
 
 func TestRenderTranscriptKeepsAtLeastOneBlock(t *testing.T) {
+	t.Parallel()
+
 	// Even with an impossibly small budget, the single newest block is kept so
 	// read_session never returns a header with no conversation.
 	out := RenderTranscript(Header{ID: "x", NumMessages: 1}, []chat.Message{


### PR DESCRIPTION
Enables `t.Parallel()` in the environment, config, and sessioncontext test suites to improve test execution speed and surface any hidden shared-state issues.