### PR TITLE
refactor: replace single-variable mutexes with atomic types

### DIFF
--- a/pkg/model/provider/rulebased/client.go
+++ b/pkg/model/provider/rulebased/client.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
-	"sync"
+	"sync/atomic"
 
 	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/config/latest"
@@ -43,11 +43,13 @@ type ProviderFactory func(ctx context.Context, modelSpec string, models map[stri
 type Client struct {
 	base.Config
 
-	routes         []Provider
-	fallback       Provider
-	matcher        *matcher
-	mu             sync.RWMutex
-	lastSelectedID modelsdev.ID // ID of the provider selected by the most recent call
+	routes   []Provider
+	fallback Provider
+	matcher  *matcher
+	// lastSelectedID holds the ID of the provider selected by the most recent
+	// call. A plain atomic pointer suffices because it is the only mutable
+	// field; everything else is set once at construction and read-only after.
+	lastSelectedID atomic.Pointer[modelsdev.ID]
 }
 
 // NewClient creates a new rule-based routing client.
@@ -133,9 +135,7 @@ func (c *Client) CreateChatCompletionStream(
 	}
 
 	selectedID := provider.ID()
-	c.mu.Lock()
-	c.lastSelectedID = selectedID
-	c.mu.Unlock()
+	c.lastSelectedID.Store(&selectedID)
 	slog.DebugContext(ctx, "Rule-based router selected model",
 		"router", c.ID().String(),
 		"selected_model", selectedID.String(),
@@ -149,9 +149,10 @@ func (c *Client) CreateChatCompletionStream(
 // recent CreateChatCompletionStream call. This allows callers to display
 // the YAML-configured sub-model name for rule-based routing.
 func (c *Client) LastSelectedModelID() modelsdev.ID {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return c.lastSelectedID
+	if id := c.lastSelectedID.Load(); id != nil {
+		return *id
+	}
+	return modelsdev.ID{}
 }
 
 // selectProvider finds the best matching provider for the messages.

--- a/pkg/runtime/agent_router.go
+++ b/pkg/runtime/agent_router.go
@@ -10,8 +10,8 @@ import (
 )
 
 // agentRouter owns the runtime's notion of "which agent is currently
-// driving the conversation". It is a thin wrapper around a team plus a
-// mutex-guarded current-agent name, but pulling it out of *LocalRuntime
+// driving the conversation". It is a thin wrapper around a team plus an
+// atomically-updated current-agent name, but pulling it out of *LocalRuntime
 // turns five methods (CurrentAgentName, setCurrentAgent, SetCurrentAgent,
 // CurrentAgent, resolveSessionAgent) that all touched the same two raw
 // fields into delegations to one type, and lets tests exercise the

--- a/pkg/runtime/agent_router.go
+++ b/pkg/runtime/agent_router.go
@@ -2,7 +2,7 @@ package runtime
 
 import (
 	"log/slog"
-	"sync"
+	"sync/atomic"
 
 	"github.com/docker/docker-agent/pkg/agent"
 	"github.com/docker/docker-agent/pkg/session"
@@ -19,32 +19,34 @@ import (
 //
 // All methods are safe for concurrent use.
 type agentRouter struct {
-	mu      sync.RWMutex
-	team    *team.Team
-	current string
+	team *team.Team
+	// current is the only mutable field; team is set once at construction
+	// and read-only after, so an atomic pointer suffices to guard it.
+	current atomic.Pointer[string]
 }
 
 // newAgentRouter builds an agentRouter with team t and an initial current
 // agent name. Callers are responsible for pre-validating that the initial
 // name exists in t (NewLocalRuntime does this).
 func newAgentRouter(t *team.Team, initial string) *agentRouter {
-	return &agentRouter{team: t, current: initial}
+	r := &agentRouter{team: t}
+	r.current.Store(&initial)
+	return r
 }
 
 // Name returns the name of the currently active agent.
 func (r *agentRouter) Name() string {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.current
+	if name := r.current.Load(); name != nil {
+		return *name
+	}
+	return ""
 }
 
 // Set replaces the current agent name without validating that it exists
 // in the team. Used from agent_delegation.go where the validation has
 // already been performed against the team's transfer/handoff lists.
 func (r *agentRouter) Set(name string) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.current = name
+	r.current.Store(&name)
 }
 
 // SetValidated checks that name exists in the team, then sets it as the

--- a/pkg/tools/builtin/lsp/lsp_lifecycle.go
+++ b/pkg/tools/builtin/lsp/lsp_lifecycle.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"sync"
+	"sync/atomic"
 
 	"github.com/docker/docker-agent/pkg/concurrent"
 	"github.com/docker/docker-agent/pkg/telemetry/genai"
@@ -217,8 +218,7 @@ type lspSession struct {
 	stdin         io.WriteCloser
 	cmd           *exec.Cmd // captured at construction; never nilled by handler teardown.
 
-	mu     sync.Mutex
-	closed bool
+	closed atomic.Bool
 
 	waitOnce sync.Once
 	waitErr  error
@@ -246,10 +246,7 @@ func (s *lspSession) startWait() {
 			// An *exec.ExitError after a signal-induced shutdown
 			// (Close → cancel) is expected; treat it as a clean exit
 			// so the supervisor only restarts on real crashes.
-			s.mu.Lock()
-			closed := s.closed
-			s.mu.Unlock()
-			if closed {
+			if s.closed.Load() {
 				return
 			}
 			s.waitErr = fmt.Errorf("%w: %w", lifecycle.ErrServerCrashed, err)
@@ -260,13 +257,9 @@ func (s *lspSession) startWait() {
 // Close performs the LSP shutdown handshake and tears down the process.
 // Idempotent; safe to call concurrently with Wait.
 func (s *lspSession) Close(ctx context.Context) error {
-	s.mu.Lock()
-	if s.closed {
-		s.mu.Unlock()
+	if !s.closed.CompareAndSwap(false, true) {
 		return nil
 	}
-	s.closed = true
-	s.mu.Unlock()
 
 	slog.DebugContext(ctx, "Stopping LSP server")
 


### PR DESCRIPTION
Each of the three structs changed here used a `sync.Mutex` or `sync.RWMutex` to protect exactly one mutable field — all other fields were written once at construction and never changed afterward. When a mutex guards a single variable, the standard library's `sync/atomic` package offers a simpler and more self-documenting fit: the data and its synchronization are expressed as one value rather than two separate declarations.

`lspSession` in `pkg/tools/builtin/lsp/lsp_lifecycle.go` had a `closed bool` protected by a plain mutex. It is now an `atomic.Bool`, with `CompareAndSwap` in `Close()` to preserve idempotency and `Load()` in the wait goroutine to check the flag. `Client` in `pkg/model/provider/rulebased/client.go` had a `lastSelectedID` of type `modelsdev.ID` behind an `RWMutex`; it is now an `atomic.Pointer[modelsdev.ID]`. `agentRouter` in `pkg/runtime/agent_router.go` had a `current string` behind an `RWMutex`; it is now an `atomic.Pointer[string]`.

All changes are behavior-preserving. The suite passes under `go test -race` and the linter reports no new issues.