### PR TITLE
refactor: replace test-overridden globals with parallel-safe injection

### DIFF
--- a/cmd/root/flags.go
+++ b/cmd/root/flags.go
@@ -26,7 +26,7 @@ const (
 )
 
 func addRuntimeConfigFlags(cmd *cobra.Command, runConfig *config.RuntimeConfig) {
-	addGatewayFlags(cmd, runConfig)
+	addGatewayFlags(cmd, runConfig, userconfig.Load)
 	cmd.PersistentFlags().StringSliceVar(&runConfig.EnvFiles, "env-from-file", nil, "Set environment variables from file")
 	cmd.PersistentFlags().BoolVar(&runConfig.GlobalCodeMode, "code-mode-tools", false, "Provide a single tool to call other tools via Javascript")
 	cmd.PersistentFlags().StringVar(&runConfig.WorkingDir, "working-dir", "", "Set the working directory for the session (applies to tools and relative paths)")
@@ -73,11 +73,12 @@ func canonize(endpoint string) string {
 	return strings.TrimSuffix(strings.TrimSpace(endpoint), "/")
 }
 
-// loadUserConfig is the function used to load user configuration.
-// It can be overridden in tests.
-var loadUserConfig = userconfig.Load
+// userConfigLoader loads the user configuration. Production passes
+// [userconfig.Load]; tests inject a stub so they neither touch the real
+// config file nor share a mutable package global (and can run in parallel).
+type userConfigLoader func() (*userconfig.Config, error)
 
-func addGatewayFlags(cmd *cobra.Command, runConfig *config.RuntimeConfig) {
+func addGatewayFlags(cmd *cobra.Command, runConfig *config.RuntimeConfig, loadUserConfig userConfigLoader) {
 	cmd.PersistentFlags().StringVar(&runConfig.ModelsGateway, flagModelsGateway, "", "Set the models gateway address")
 
 	persistentPreRunE := cmd.PersistentPreRunE

--- a/cmd/root/flags_test.go
+++ b/cmd/root/flags_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/environment"
 	"github.com/docker/docker-agent/pkg/userconfig"
 )
 
@@ -70,26 +71,30 @@ func TestGatewayLogic(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("CAGENT_MODELS_GATEWAY", tt.env) // Make sure the user doesn't have an old env set
-			t.Setenv("DOCKER_AGENT_MODELS_GATEWAY", tt.env)
+			t.Parallel()
 
-			// Mock user config loader
-			original := loadUserConfig
-			loadUserConfig = func() (*userconfig.Config, error) {
+			// Inject env via a map provider rather than t.Setenv so the
+			// test stays parallel-safe.
+			loadUserConfig := func() (*userconfig.Config, error) {
 				if tt.userConfig != nil {
 					return tt.userConfig, nil
 				}
 				return &userconfig.Config{}, nil
 			}
-			t.Cleanup(func() { loadUserConfig = original })
 
 			cmd := &cobra.Command{
 				RunE: func(*cobra.Command, []string) error {
 					return nil
 				},
 			}
-			runConfig := config.RuntimeConfig{}
-			addGatewayFlags(cmd, &runConfig)
+			env := map[string]string{}
+			if tt.env != "" {
+				env[envModelsGateway] = tt.env
+			}
+			runConfig := config.RuntimeConfig{
+				EnvProviderForTests: environment.NewMapEnvProvider(env),
+			}
+			addGatewayFlags(cmd, &runConfig, loadUserConfig)
 
 			cmd.SetArgs(tt.args)
 			err := cmd.Execute()
@@ -123,7 +128,7 @@ func TestGatewayFlags_CallsAncestorPersistentPreRunE(t *testing.T) {
 		RunE: func(*cobra.Command, []string) error { return nil },
 	}
 	runConfig := config.RuntimeConfig{}
-	addGatewayFlags(leaf, &runConfig)
+	addGatewayFlags(leaf, &runConfig, userconfig.Load)
 
 	middle.AddCommand(leaf)
 	root.AddCommand(middle)
@@ -166,7 +171,7 @@ func TestGatewayFlags_RunsParentBeforeMaterialisingEnvProvider(t *testing.T) {
 	runConfig := config.RuntimeConfig{
 		EnvProviderForTests: &recordingProvider{onGet: func() { envProviderConsulted = true }},
 	}
-	addGatewayFlags(leaf, &runConfig)
+	addGatewayFlags(leaf, &runConfig, userconfig.Load)
 	root.AddCommand(leaf)
 
 	root.SetArgs([]string{"leaf"})
@@ -285,25 +290,28 @@ func TestDefaultModelLogic(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("DOCKER_AGENT_DEFAULT_MODEL", tt.env)
+			t.Parallel()
 
-			// Mock user config loader
-			original := loadUserConfig
-			loadUserConfig = func() (*userconfig.Config, error) {
+			loadUserConfig := func() (*userconfig.Config, error) {
 				if tt.userConfig != nil {
 					return tt.userConfig, nil
 				}
 				return &userconfig.Config{}, nil
 			}
-			t.Cleanup(func() { loadUserConfig = original })
 
 			cmd := &cobra.Command{
 				RunE: func(*cobra.Command, []string) error {
 					return nil
 				},
 			}
-			runConfig := config.RuntimeConfig{}
-			addGatewayFlags(cmd, &runConfig)
+			env := map[string]string{}
+			if tt.env != "" {
+				env[envDefaultModel] = tt.env
+			}
+			runConfig := config.RuntimeConfig{
+				EnvProviderForTests: environment.NewMapEnvProvider(env),
+			}
+			addGatewayFlags(cmd, &runConfig, loadUserConfig)
 
 			cmd.SetArgs(nil)
 			err := cmd.Execute()

--- a/cmd/root/models.go
+++ b/cmd/root/models.go
@@ -21,6 +21,7 @@ import (
 	"github.com/docker/docker-agent/pkg/httpclient"
 	"github.com/docker/docker-agent/pkg/model/provider"
 	"github.com/docker/docker-agent/pkg/telemetry"
+	"github.com/docker/docker-agent/pkg/userconfig"
 )
 
 type modelsListFlags struct {
@@ -96,7 +97,7 @@ func newModelsListCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&flags.providerFilter, "provider", "p", "", "Filter by provider name")
 	cmd.Flags().StringVar(&flags.format, "format", "table", "Output format: table, json")
 	cmd.Flags().BoolVarP(&flags.all, "all", "a", false, "Include models from all providers, not just those with credentials")
-	addGatewayFlags(cmd, &flags.runConfig)
+	addGatewayFlags(cmd, &flags.runConfig, userconfig.Load)
 
 	return cmd
 }

--- a/cmd/root/models_test.go
+++ b/cmd/root/models_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/config"
-	"github.com/docker/docker-agent/pkg/userconfig"
+	"github.com/docker/docker-agent/pkg/paths"
 )
 
 func TestModelsListCommand_DefaultOutput(t *testing.T) {
@@ -24,9 +24,10 @@ func TestModelsListCommand_DefaultOutput(t *testing.T) {
 	t.Setenv("DOCKER_AGENT_MODELS_GATEWAY", "")
 	t.Setenv("DOCKER_AGENT_DEFAULT_MODEL", "")
 
-	original := loadUserConfig
-	loadUserConfig = func() (*userconfig.Config, error) { return &userconfig.Config{}, nil }
-	t.Cleanup(func() { loadUserConfig = original })
+	// Point at an empty config dir so userconfig.Load returns an empty
+	// config without reading the developer's real ~/.config/cagent.
+	paths.SetConfigDir(t.TempDir())
+	t.Cleanup(func() { paths.SetConfigDir("") })
 
 	var buf bytes.Buffer
 	cmd := newModelsCmd()
@@ -49,9 +50,10 @@ func TestModelsListCommand_ProviderFilter(t *testing.T) {
 	t.Setenv("DOCKER_AGENT_MODELS_GATEWAY", "")
 	t.Setenv("DOCKER_AGENT_DEFAULT_MODEL", "")
 
-	original := loadUserConfig
-	loadUserConfig = func() (*userconfig.Config, error) { return &userconfig.Config{}, nil }
-	t.Cleanup(func() { loadUserConfig = original })
+	// Point at an empty config dir so userconfig.Load returns an empty
+	// config without reading the developer's real ~/.config/cagent.
+	paths.SetConfigDir(t.TempDir())
+	t.Cleanup(func() { paths.SetConfigDir("") })
 
 	var buf bytes.Buffer
 	cmd := newModelsCmd()
@@ -79,9 +81,10 @@ func TestModelsListCommand_JSONFormat(t *testing.T) {
 	t.Setenv("DOCKER_AGENT_MODELS_GATEWAY", "")
 	t.Setenv("DOCKER_AGENT_DEFAULT_MODEL", "")
 
-	original := loadUserConfig
-	loadUserConfig = func() (*userconfig.Config, error) { return &userconfig.Config{}, nil }
-	t.Cleanup(func() { loadUserConfig = original })
+	// Point at an empty config dir so userconfig.Load returns an empty
+	// config without reading the developer's real ~/.config/cagent.
+	paths.SetConfigDir(t.TempDir())
+	t.Cleanup(func() { paths.SetConfigDir("") })
 
 	var buf bytes.Buffer
 	cmd := newModelsCmd()
@@ -114,9 +117,10 @@ func TestModelsListCommand_DefaultMarker(t *testing.T) {
 	t.Setenv("DOCKER_AGENT_MODELS_GATEWAY", "")
 	t.Setenv("DOCKER_AGENT_DEFAULT_MODEL", "")
 
-	original := loadUserConfig
-	loadUserConfig = func() (*userconfig.Config, error) { return &userconfig.Config{}, nil }
-	t.Cleanup(func() { loadUserConfig = original })
+	// Point at an empty config dir so userconfig.Load returns an empty
+	// config without reading the developer's real ~/.config/cagent.
+	paths.SetConfigDir(t.TempDir())
+	t.Cleanup(func() { paths.SetConfigDir("") })
 
 	var buf bytes.Buffer
 	cmd := newModelsCmd()
@@ -307,9 +311,10 @@ func TestModelsListCommand_NoCredentials(t *testing.T) {
 	t.Setenv("DOCKER_AGENT_MODELS_GATEWAY", "")
 	t.Setenv("DOCKER_AGENT_DEFAULT_MODEL", "")
 
-	original := loadUserConfig
-	loadUserConfig = func() (*userconfig.Config, error) { return &userconfig.Config{}, nil }
-	t.Cleanup(func() { loadUserConfig = original })
+	// Point at an empty config dir so userconfig.Load returns an empty
+	// config without reading the developer's real ~/.config/cagent.
+	paths.SetConfigDir(t.TempDir())
+	t.Cleanup(func() { paths.SetConfigDir("") })
 
 	var buf bytes.Buffer
 	cmd := newModelsCmd()

--- a/pkg/runtime/fallback.go
+++ b/pkg/runtime/fallback.go
@@ -333,7 +333,7 @@ func (e *fallbackExecutor) execute(
 				}
 			}
 
-			res, err := handleStream(streamCtx, streamCancel, stream, a, agentTools, sess, m, e.telemetry, events)
+			res, err := handleStream(streamCtx, streamCancel, stream, a, agentTools, sess, m, e.telemetry, events, defaultStreamIdleTimeout)
 			streamCancel(nil) // always release the child context
 			if err != nil {
 				lastErr = err

--- a/pkg/runtime/streaming.go
+++ b/pkg/runtime/streaming.go
@@ -26,9 +26,10 @@ import (
 // for tens of seconds during extended thinking. The timeout only fires when
 // absolutely no bytes arrive at the SSE layer (not just no new tokens).
 //
-// This is a var rather than a const so tests can shorten it without changing
-// production behaviour.
-var defaultStreamIdleTimeout = 5 * time.Minute
+// handleStream takes the idle timeout as a parameter rather than reading this
+// constant directly, so tests can pass a short timeout without mutating shared
+// state (and can therefore run in parallel).
+const defaultStreamIdleTimeout = 5 * time.Minute
 
 // errStreamIdle is the sentinel error returned when the upstream model stream
 // produces no SSE events for longer than defaultStreamIdleTimeout. It does
@@ -61,12 +62,15 @@ type streamResult struct {
 // passed to CreateChatCompletionStream so that Go's HTTP transport closes the
 // underlying TCP connection and unblocks the stream reader goroutine.
 //
+// idleTimeout bounds the wait for the next SSE chunk; production callers pass
+// defaultStreamIdleTimeout, tests pass a short value.
+//
 // handleStream is a pure stream-aggregation routine: it does not touch
 // runtime state and can be unit-tested by feeding a mock chat.MessageStream.
 // It is intentionally a free function rather than a method on *LocalRuntime
 // so the dependency direction is explicit (the loop calls into the chunker,
 // never the reverse).
-func handleStream(ctx context.Context, cancelStream context.CancelCauseFunc, stream chat.MessageStream, a *agent.Agent, agentTools []tools.Tool, sess *session.Session, m *modelsdev.Model, tel Telemetry, events EventSink) (streamResult, error) {
+func handleStream(ctx context.Context, cancelStream context.CancelCauseFunc, stream chat.MessageStream, a *agent.Agent, agentTools []tools.Tool, sess *session.Session, m *modelsdev.Model, tel Telemetry, events EventSink, idleTimeout time.Duration) (streamResult, error) {
 	// done is closed when handleStream exits (for any reason) so the reader
 	// goroutine below can detect it and stop trying to send on recvCh.
 	done := make(chan struct{})
@@ -98,7 +102,7 @@ func handleStream(ctx context.Context, cancelStream context.CancelCauseFunc, str
 		}
 	}()
 
-	idleTimer := time.NewTimer(defaultStreamIdleTimeout)
+	idleTimer := time.NewTimer(idleTimeout)
 	defer idleTimer.Stop()
 
 	var fullContent strings.Builder
@@ -174,7 +178,7 @@ mainLoop:
 				default:
 				}
 			}
-			idleTimer.Reset(defaultStreamIdleTimeout)
+			idleTimer.Reset(idleTimeout)
 
 			if errors.Is(res.err, io.EOF) {
 				break mainLoop
@@ -339,7 +343,7 @@ mainLoop:
 			slog.WarnContext(ctx, "Model stream stalled: no data received within idle timeout",
 				"agent", a.Name(),
 				"session_id", sess.ID,
-				"idle_timeout", defaultStreamIdleTimeout,
+				"idle_timeout", idleTimeout,
 			)
 			// Cancel the HTTP request context so Go's transport closes the
 			// underlying TCP connection and unblocks the reader goroutine.
@@ -347,7 +351,7 @@ mainLoop:
 				cancelStream(errStreamIdle)
 			}
 			return streamResult{Stopped: true}, fmt.Errorf("model stream stalled after %s with no data: %w",
-				defaultStreamIdleTimeout, errStreamIdle)
+				idleTimeout, errStreamIdle)
 		}
 	}
 

--- a/pkg/runtime/streaming_test.go
+++ b/pkg/runtime/streaming_test.go
@@ -67,7 +67,7 @@ func TestHandleStream_Refusal(t *testing.T) {
 	evCh := make(chan Event, 64)
 	res, err := handleStream(
 		t.Context(), nil, stream, a, nil, sess, nil,
-		defaultTelemetry{}, NewChannelSink(evCh),
+		defaultTelemetry{}, NewChannelSink(evCh), defaultStreamIdleTimeout,
 	)
 	require.NoError(t, err)
 
@@ -95,7 +95,7 @@ func TestHandleStream_RefusalDropsPartialToolCalls(t *testing.T) {
 	evCh := make(chan Event, 64)
 	res, err := handleStream(
 		t.Context(), nil, stream, a, nil, sess, nil,
-		defaultTelemetry{}, NewChannelSink(evCh),
+		defaultTelemetry{}, NewChannelSink(evCh), defaultStreamIdleTimeout,
 	)
 	require.NoError(t, err)
 
@@ -122,7 +122,7 @@ func TestHandleStream_ToolCallAndStopInSameChunk(t *testing.T) {
 	evCh := make(chan Event, 64) // buffered so handleStream never blocks on Emit
 	res, err := handleStream(
 		t.Context(), nil, stream, a, nil, sess, nil,
-		defaultTelemetry{}, NewChannelSink(evCh),
+		defaultTelemetry{}, NewChannelSink(evCh), defaultStreamIdleTimeout,
 	)
 	require.NoError(t, err)
 
@@ -152,7 +152,7 @@ func TestHandleStream_ToolCallThenSeparateStop(t *testing.T) {
 	evCh := make(chan Event, 64)
 	res, err := handleStream(
 		t.Context(), nil, stream, a, nil, sess, nil,
-		defaultTelemetry{}, NewChannelSink(evCh),
+		defaultTelemetry{}, NewChannelSink(evCh), defaultStreamIdleTimeout,
 	)
 	require.NoError(t, err)
 
@@ -181,7 +181,7 @@ func TestHandleStream_WhitespaceOnlyContentStops(t *testing.T) {
 	evCh := make(chan Event, 64)
 	res, err := handleStream(
 		t.Context(), nil, stream, a, nil, sess, nil,
-		defaultTelemetry{}, NewChannelSink(evCh),
+		defaultTelemetry{}, NewChannelSink(evCh), defaultStreamIdleTimeout,
 	)
 	require.NoError(t, err)
 
@@ -215,21 +215,12 @@ func (s *stalledStream) Close() {
 	s.closeOnce.Do(func() { close(s.unblock) })
 }
 
-// withShortStreamIdleTimeout temporarily overrides defaultStreamIdleTimeout
-// to shorten it for tests. Restores the original value via t.Cleanup.
-func withShortStreamIdleTimeout(t *testing.T, d time.Duration) {
-	t.Helper()
-	orig := defaultStreamIdleTimeout
-	defaultStreamIdleTimeout = d
-	t.Cleanup(func() { defaultStreamIdleTimeout = orig })
-}
-
 // TestHandleStream_IdleTimeout verifies that handleStream returns an error
 // wrapping errStreamIdle when no SSE chunk arrives within the idle window.
 // It also checks that the provided cancelStream function is called so the
 // HTTP transport can close the underlying TCP connection.
 func TestHandleStream_IdleTimeout(t *testing.T) {
-	withShortStreamIdleTimeout(t, 50*time.Millisecond)
+	t.Parallel()
 
 	stream := newStalledStream()
 	a := agent.New("root", "test", agent.WithModel(&mockProvider{id: "test/mock-model", stream: stream}))
@@ -244,7 +235,7 @@ func TestHandleStream_IdleTimeout(t *testing.T) {
 	evCh := make(chan Event, 64)
 	res, err := handleStream(
 		t.Context(), cancelStream, stream, a, nil, sess, nil,
-		defaultTelemetry{}, NewChannelSink(evCh),
+		defaultTelemetry{}, NewChannelSink(evCh), 50*time.Millisecond,
 	)
 
 	require.Error(t, err)
@@ -257,8 +248,7 @@ func TestHandleStream_IdleTimeout(t *testing.T) {
 // promptly when the caller's context is cancelled, even while a Recv call
 // is blocked. This covers the SIGTERM / graceful-shutdown path.
 func TestHandleStream_ContextCancellation(t *testing.T) {
-	// Use a long idle timeout so only context cancellation can trigger.
-	withShortStreamIdleTimeout(t, 10*time.Minute)
+	t.Parallel()
 
 	stream := newStalledStream()
 	a := agent.New("root", "test", agent.WithModel(&mockProvider{id: "test/mock-model", stream: stream}))
@@ -275,9 +265,10 @@ func TestHandleStream_ContextCancellation(t *testing.T) {
 
 	evCh := make(chan Event, 64)
 	_, cancelStream := context.WithCancelCause(ctx)
+	// Use a long idle timeout so only context cancellation can trigger.
 	res, err := handleStream(
 		ctx, cancelStream, stream, a, nil, sess, nil,
-		defaultTelemetry{}, NewChannelSink(evCh),
+		defaultTelemetry{}, NewChannelSink(evCh), 10*time.Minute,
 	)
 
 	require.Error(t, err)

--- a/pkg/toolinstall/archive.go
+++ b/pkg/toolinstall/archive.go
@@ -26,17 +26,32 @@ var templateFuncs = template.FuncMap{
 	"trimV": func(s string) string { return strings.TrimPrefix(s, "v") },
 }
 
-// Conservative bounds preventing zip-bomb / tar-bomb attacks from
-// adversaries that control a GitHub release referenced by a tool
-// resolver. The limits are deliberately generous for legitimate CLI
-// releases, which typically weigh single-digit MB compressed. They
-// are vars rather than consts so tests can lower them.
-var (
-	maxArchiveCompressed   int64 = 1 << 30   // 1 GiB
-	maxArchiveUncompressed int64 = 2 << 30   // 2 GiB
-	maxFileUncompressed    int64 = 500 << 20 // 500 MiB
-	maxArchiveEntries            = 100_000
-)
+// limits holds the conservative bounds that defend against zip-bomb /
+// tar-bomb attacks from adversaries controlling a GitHub release
+// referenced by a tool resolver. The defaults are deliberately generous
+// for legitimate CLI releases, which typically weigh single-digit MB
+// compressed.
+//
+// Carrying the bounds in a value (rather than package globals) lets each
+// caller — and each test — own an independent copy. Tests can shrink a
+// limit on their own instance and run with t.Parallel() without racing or
+// clobbering a shared global.
+type limits struct {
+	maxArchiveCompressed   int64
+	maxArchiveUncompressed int64
+	maxFileUncompressed    int64
+	maxArchiveEntries      int
+}
+
+// defaultLimits returns the production extraction bounds.
+func defaultLimits() limits {
+	return limits{
+		maxArchiveCompressed:   1 << 30,   // 1 GiB
+		maxArchiveUncompressed: 2 << 30,   // 2 GiB
+		maxFileUncompressed:    500 << 20, // 500 MiB
+		maxArchiveEntries:      100_000,
+	}
+}
 
 // errExtractTooLarge is returned when an archive (or a single entry
 // within it) exceeds the configured extraction size or entry-count
@@ -62,12 +77,12 @@ func renderTemplate(tmplStr string, data templateData) (string, error) {
 // For tar.gz, the response body is streamed directly through gzip → tar.
 // For zip, the body is spooled to a temporary file (zip requires random access).
 // Raw/single-binary formats are handled by the caller before reaching this function.
-func extractRelease(body io.ReadCloser, destDir, format string, files []PackageFile, tmplData templateData) error {
+func (l limits) extractRelease(body io.ReadCloser, destDir, format string, files []PackageFile, tmplData templateData) error {
 	switch format {
 	case "tar.gz", "tgz":
-		return extractTarGz(body, destDir, files, tmplData)
+		return l.extractTarGz(body, destDir, files, tmplData)
 	case "zip":
-		return extractZipFromStream(body, destDir, files, tmplData)
+		return l.extractZipFromStream(body, destDir, files, tmplData)
 	default:
 		return fmt.Errorf("unsupported archive format: %s", format)
 	}
@@ -76,14 +91,14 @@ func extractRelease(body io.ReadCloser, destDir, format string, files []PackageF
 // writeRawBinary writes a raw (non-archived) binary stream directly to destPath
 // with executable permissions. The body is bounded by maxFileUncompressed
 // to avoid an attacker-controlled release asset from filling the disk.
-func writeRawBinary(r io.Reader, destPath string) error {
+func (l limits) writeRawBinary(r io.Reader, destPath string) error {
 	f, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755) //nolint:gosec // extracted binary needs +x
 	if err != nil {
 		return fmt.Errorf("creating raw binary %s: %w", destPath, err)
 	}
 
-	n, copyErr := io.Copy(f, io.LimitReader(r, maxFileUncompressed+1))
-	if copyErr == nil && n > maxFileUncompressed {
+	n, copyErr := io.Copy(f, io.LimitReader(r, l.maxFileUncompressed+1))
+	if copyErr == nil && n > l.maxFileUncompressed {
 		copyErr = errExtractTooLarge
 	}
 	closeErr := f.Close()
@@ -101,7 +116,7 @@ func writeRawBinary(r io.Reader, destPath string) error {
 // extractTarGz extracts files from a tar.gz archive.
 // It reads from the provided reader in a streaming fashion (gzip → tar)
 // without buffering the entire archive in memory.
-func extractTarGz(r io.Reader, destDir string, files []PackageFile, tmplData templateData) error {
+func (l limits) extractTarGz(r io.Reader, destDir string, files []PackageFile, tmplData templateData) error {
 	gzReader, err := gzip.NewReader(r)
 	if err != nil {
 		return fmt.Errorf("extracting tar.gz: %w", err)
@@ -127,7 +142,7 @@ func extractTarGz(r io.Reader, destDir string, files []PackageFile, tmplData tem
 		}
 
 		entries++
-		if entries > maxArchiveEntries {
+		if entries > l.maxArchiveEntries {
 			return errExtractTooLarge
 		}
 
@@ -144,7 +159,7 @@ func extractTarGz(r io.Reader, destDir string, files []PackageFile, tmplData tem
 		// already advertises a too-large size lets us fail without
 		// spending CPU on decompression. The LimitReader below
 		// guards against headers that lie.
-		if header.Size > maxFileUncompressed {
+		if header.Size > l.maxFileUncompressed {
 			return errExtractTooLarge
 		}
 
@@ -161,16 +176,16 @@ func extractTarGz(r io.Reader, destDir string, files []PackageFile, tmplData tem
 			return err
 		}
 
-		n, copyErr := io.Copy(f, io.LimitReader(tarReader, maxFileUncompressed+1))
+		n, copyErr := io.Copy(f, io.LimitReader(tarReader, l.maxFileUncompressed+1))
 		f.Close()
 		if copyErr != nil {
 			return copyErr
 		}
-		if n > maxFileUncompressed {
+		if n > l.maxFileUncompressed {
 			return errExtractTooLarge
 		}
 		totalBytes += n
-		if totalBytes > maxArchiveUncompressed {
+		if totalBytes > l.maxArchiveUncompressed {
 			return errExtractTooLarge
 		}
 	}
@@ -181,13 +196,13 @@ func extractTarGz(r io.Reader, destDir string, files []PackageFile, tmplData tem
 // extractZip extracts files from a zip archive.
 // It requires random access via io.ReaderAt; callers should provide either
 // an *os.File (spooled to a temp file) or a *bytes.Reader.
-func extractZip(ra io.ReaderAt, size int64, destDir string, files []PackageFile, tmplData templateData) error {
+func (l limits) extractZip(ra io.ReaderAt, size int64, destDir string, files []PackageFile, tmplData templateData) error {
 	reader, err := zip.NewReader(ra, size)
 	if err != nil {
 		return fmt.Errorf("extracting zip: %w", err)
 	}
 
-	if len(reader.File) > maxArchiveEntries {
+	if len(reader.File) > l.maxArchiveEntries {
 		return errExtractTooLarge
 	}
 
@@ -210,7 +225,7 @@ func extractZip(ra io.ReaderAt, size int64, destDir string, files []PackageFile,
 		// UncompressedSize64 comes from the central directory and
 		// is attacker-controlled, but lets us reject obvious bombs
 		// without spending CPU on decompression first.
-		if f.UncompressedSize64 > uint64(maxFileUncompressed) { //nolint:gosec // maxFileUncompressed is a positive constant
+		if f.UncompressedSize64 > uint64(l.maxFileUncompressed) { //nolint:gosec // maxFileUncompressed is a positive constant
 			return errExtractTooLarge
 		}
 
@@ -219,12 +234,12 @@ func extractZip(ra io.ReaderAt, size int64, destDir string, files []PackageFile,
 			return err
 		}
 
-		n, err := extractZipFile(f, destPath)
+		n, err := l.extractZipFile(f, destPath)
 		if err != nil {
 			return err
 		}
 		totalBytes += n
-		if totalBytes > maxArchiveUncompressed {
+		if totalBytes > l.maxArchiveUncompressed {
 			return errExtractTooLarge
 		}
 	}
@@ -232,7 +247,7 @@ func extractZip(ra io.ReaderAt, size int64, destDir string, files []PackageFile,
 	return nil
 }
 
-func extractZipFile(f *zip.File, destPath string) (int64, error) {
+func (l limits) extractZipFile(f *zip.File, destPath string) (int64, error) {
 	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil { //nolint:gosec // zip entry directory for extracted binaries
 		return 0, err
 	}
@@ -249,11 +264,11 @@ func extractZipFile(f *zip.File, destPath string) (int64, error) {
 	}
 	defer outFile.Close()
 
-	n, err := io.Copy(outFile, io.LimitReader(rc, maxFileUncompressed+1))
+	n, err := io.Copy(outFile, io.LimitReader(rc, l.maxFileUncompressed+1))
 	if err != nil {
 		return n, err
 	}
-	if n > maxFileUncompressed {
+	if n > l.maxFileUncompressed {
 		return n, errExtractTooLarge
 	}
 	return n, nil
@@ -262,7 +277,7 @@ func extractZipFile(f *zip.File, destPath string) (int64, error) {
 // extractZipFromStream spools an io.Reader to a temporary file and then
 // extracts the zip archive. This avoids holding the entire archive in memory
 // while satisfying zip's requirement for random access (io.ReaderAt).
-func extractZipFromStream(r io.Reader, destDir string, files []PackageFile, tmplData templateData) error {
+func (l limits) extractZipFromStream(r io.Reader, destDir string, files []PackageFile, tmplData templateData) error {
 	tmpFile, err := os.CreateTemp("", "cagent-zip-*.zip")
 	if err != nil {
 		return fmt.Errorf("creating temp file for zip: %w", err)
@@ -270,11 +285,11 @@ func extractZipFromStream(r io.Reader, destDir string, files []PackageFile, tmpl
 	defer os.Remove(tmpFile.Name())
 	defer tmpFile.Close()
 
-	size, err := io.Copy(tmpFile, io.LimitReader(r, maxArchiveCompressed+1))
+	size, err := io.Copy(tmpFile, io.LimitReader(r, l.maxArchiveCompressed+1))
 	if err != nil {
 		return fmt.Errorf("spooling zip to temp file: %w", err)
 	}
-	if size > maxArchiveCompressed {
+	if size > l.maxArchiveCompressed {
 		return errExtractTooLarge
 	}
 
@@ -282,7 +297,7 @@ func extractZipFromStream(r io.Reader, destDir string, files []PackageFile, tmpl
 		return fmt.Errorf("seeking temp file: %w", err)
 	}
 
-	return extractZip(tmpFile, size, destDir, files, tmplData)
+	return l.extractZip(tmpFile, size, destDir, files, tmplData)
 }
 
 // buildFileMap builds a map from rendered src paths to destination binary names.

--- a/pkg/toolinstall/archive_test.go
+++ b/pkg/toolinstall/archive_test.go
@@ -74,9 +74,8 @@ func TestWriteRawBinary(t *testing.T) {
 	destPath := filepath.Join(destDir, "mytool")
 	content := "#!/bin/sh\necho hello"
 
-	err := writeRawBinary(strings.NewReader(content), destPath)
+	err := defaultLimits().writeRawBinary(strings.NewReader(content), destPath)
 	require.NoError(t, err)
-
 	data, err := os.ReadFile(destPath)
 	require.NoError(t, err)
 	assert.Equal(t, content, string(data))
@@ -89,7 +88,7 @@ func TestWriteRawBinary(t *testing.T) {
 func TestWriteRawBinary_ErrorOnBadPath(t *testing.T) {
 	t.Parallel()
 
-	err := writeRawBinary(strings.NewReader("data"), "/nonexistent/dir/binary")
+	err := defaultLimits().writeRawBinary(strings.NewReader("data"), "/nonexistent/dir/binary")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "creating raw binary")
 }
@@ -116,7 +115,7 @@ func TestExtractTarGz(t *testing.T) {
 	files := []PackageFile{{Name: "mytool", Src: "tool_{{.Version}}_{{.OS}}/bin/mytool"}}
 	data := templateData{Version: "1.0.0", OS: "linux", Arch: "amd64"}
 
-	require.NoError(t, extractTarGz(&buf, destDir, files, data))
+	require.NoError(t, defaultLimits().extractTarGz(&buf, destDir, files, data))
 
 	extracted, err := os.ReadFile(filepath.Join(destDir, "mytool"))
 	require.NoError(t, err)
@@ -140,7 +139,7 @@ func TestExtractZip(t *testing.T) {
 	files := []PackageFile{{Name: "mytool", Src: "tool_{{.Version}}/bin/mytool"}}
 	data := templateData{Version: "1.0.0", OS: "linux", Arch: "amd64"}
 
-	require.NoError(t, extractZip(bytes.NewReader(buf.Bytes()), int64(buf.Len()), destDir, files, data))
+	require.NoError(t, defaultLimits().extractZip(bytes.NewReader(buf.Bytes()), int64(buf.Len()), destDir, files, data))
 
 	extracted, err := os.ReadFile(filepath.Join(destDir, "mytool"))
 	require.NoError(t, err)
@@ -241,7 +240,7 @@ func TestExtractTarGz_PathTraversal(t *testing.T) {
 	destDir := t.TempDir()
 	// Map entry to a traversal dest name.
 	files := []PackageFile{{Name: "../../etc/passwd", Src: "evil"}}
-	err = extractTarGz(&buf, destDir, files, templateData{})
+	err = defaultLimits().extractTarGz(&buf, destDir, files, templateData{})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errPathTraversal)
 }
@@ -262,22 +261,22 @@ func TestExtractZip_PathTraversal(t *testing.T) {
 	destDir := t.TempDir()
 	// Map entry to a traversal dest name.
 	files := []PackageFile{{Name: "../../etc/passwd", Src: "evil"}}
-	err = extractZip(bytes.NewReader(buf.Bytes()), int64(buf.Len()), destDir, files, templateData{})
+	err = defaultLimits().extractZip(bytes.NewReader(buf.Bytes()), int64(buf.Len()), destDir, files, templateData{})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errPathTraversal)
 }
 
-// withFileLimit lowers the per-file extraction cap for the duration of
-// a test, restoring it on cleanup.
-func withFileLimit(t *testing.T, n int64) {
-	t.Helper()
-	prev := maxFileUncompressed
-	maxFileUncompressed = n
-	t.Cleanup(func() { maxFileUncompressed = prev })
+// limitsWithFileCap returns extraction limits with a lowered per-file cap.
+// Each test gets its own value, so tests that exercise the cap can run with
+// t.Parallel() — there is no shared global to clobber or restore.
+func limitsWithFileCap(n int64) limits {
+	l := defaultLimits()
+	l.maxFileUncompressed = n
+	return l
 }
 
 func TestExtractTarGz_TooLarge(t *testing.T) {
-	withFileLimit(t, 32)
+	t.Parallel()
 
 	var buf bytes.Buffer
 	gw := gzip.NewWriter(&buf)
@@ -297,13 +296,13 @@ func TestExtractTarGz_TooLarge(t *testing.T) {
 	require.NoError(t, gw.Close())
 
 	files := []PackageFile{{Name: "mytool", Src: "tool/bin/mytool"}}
-	err = extractTarGz(&buf, t.TempDir(), files, templateData{})
+	err = limitsWithFileCap(32).extractTarGz(&buf, t.TempDir(), files, templateData{})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errExtractTooLarge)
 }
 
 func TestExtractZip_TooLarge(t *testing.T) {
-	withFileLimit(t, 32)
+	t.Parallel()
 
 	var buf bytes.Buffer
 	zw := zip.NewWriter(&buf)
@@ -314,16 +313,16 @@ func TestExtractZip_TooLarge(t *testing.T) {
 	require.NoError(t, zw.Close())
 
 	files := []PackageFile{{Name: "mytool", Src: "tool/bin/mytool"}}
-	err = extractZip(bytes.NewReader(buf.Bytes()), int64(buf.Len()), t.TempDir(), files, templateData{})
+	err = limitsWithFileCap(32).extractZip(bytes.NewReader(buf.Bytes()), int64(buf.Len()), t.TempDir(), files, templateData{})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errExtractTooLarge)
 }
 
 func TestWriteRawBinary_TooLarge(t *testing.T) {
-	withFileLimit(t, 32)
+	t.Parallel()
 
 	dest := filepath.Join(t.TempDir(), "big")
-	err := writeRawBinary(strings.NewReader(strings.Repeat("A", 1024)), dest)
+	err := limitsWithFileCap(32).writeRawBinary(strings.NewReader(strings.Repeat("A", 1024)), dest)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errExtractTooLarge)
 }

--- a/pkg/toolinstall/installer.go
+++ b/pkg/toolinstall/installer.go
@@ -125,7 +125,7 @@ func (r *Registry) installGitHubRelease(ctx context.Context, pkg *Package, versi
 
 	// Spool the asset to disk so its checksum can be verified before any of
 	// its bytes are extracted and made executable.
-	asset, err := spoolToTemp(body)
+	asset, err := r.extractor().spoolToTemp(body)
 	if err != nil {
 		return "", fmt.Errorf("downloading %s: %w", downloadURL, err)
 	}
@@ -147,11 +147,11 @@ func (r *Registry) installGitHubRelease(ctx context.Context, pkg *Package, versi
 	switch pc.Format {
 	case "raw", "":
 		// Single-binary download — write the asset directly to binaryPath.
-		if err := writeRawBinary(asset, binaryPath); err != nil {
+		if err := r.extractor().writeRawBinary(asset, binaryPath); err != nil {
 			return "", err
 		}
 	default:
-		if err := extractRelease(asset, pkgDir, pc.Format, pc.Files, pc.TemplateData); err != nil {
+		if err := r.extractor().extractRelease(asset, pkgDir, pc.Format, pc.Files, pc.TemplateData); err != nil {
 			return "", err
 		}
 	}
@@ -252,7 +252,7 @@ func resolveForPlatform(pkg *Package, version string) platformConfig {
 // start; the caller must close and remove it. The copy is bounded by
 // maxArchiveCompressed to defend against an attacker-controlled release
 // streaming an unbounded body.
-func spoolToTemp(r io.Reader) (*os.File, error) {
+func (l limits) spoolToTemp(r io.Reader) (*os.File, error) {
 	f, err := os.CreateTemp("", "cagent-asset-*")
 	if err != nil {
 		return nil, fmt.Errorf("creating temp file: %w", err)
@@ -263,12 +263,12 @@ func spoolToTemp(r io.Reader) (*os.File, error) {
 		_ = os.Remove(f.Name())
 	}
 
-	n, err := io.Copy(f, io.LimitReader(r, maxArchiveCompressed+1))
+	n, err := io.Copy(f, io.LimitReader(r, l.maxArchiveCompressed+1))
 	if err != nil {
 		cleanup()
 		return nil, fmt.Errorf("buffering asset: %w", err)
 	}
-	if n > maxArchiveCompressed {
+	if n > l.maxArchiveCompressed {
 		cleanup()
 		return nil, errExtractTooLarge
 	}

--- a/pkg/toolinstall/registry.go
+++ b/pkg/toolinstall/registry.go
@@ -137,6 +137,21 @@ type Registry struct {
 	httpClient *http.Client
 	baseURL    string
 	cacheDir   string
+	// limits bounds archive extraction. The zero value means "use
+	// defaultLimits()", so Registry literals built in tests (which only
+	// set httpClient) still extract with the production bounds. Resolve
+	// it through extractor() rather than reading the field directly.
+	limits limits
+}
+
+// extractor returns the extraction limits to use, falling back to the
+// production defaults when the Registry was built without explicit limits
+// (e.g. a test literal that only sets httpClient).
+func (r *Registry) extractor() limits {
+	if r.limits == (limits{}) {
+		return defaultLimits()
+	}
+	return r.limits
 }
 
 var (

--- a/pkg/tools/mcp/oauth.go
+++ b/pkg/tools/mcp/oauth.go
@@ -45,13 +45,17 @@ func errorCodeFromWWWAuth(wwwAuth string) string {
 	return ""
 }
 
-// unmanagedOAuthWaitTimeout is the upper bound on how long the unmanaged
-// OAuth flow blocks waiting for a reply (elicitation result or
+// unmanagedOAuthWaitTimeout is the default upper bound on how long the
+// unmanaged OAuth flow blocks waiting for a reply (elicitation result or
 // out-of-band callback). Generous enough to accommodate a user clicking
 // through an IdP consent screen and any IdP-side prompts; small enough
 // that a silently-disconnected MCP client can't hold the per-session
 // streaming lock indefinitely.
-var unmanagedOAuthWaitTimeout = 10 * time.Minute
+//
+// oauthTransport reads this through waitTimeoutOrDefault, which lets a
+// transport carry its own shorter timeout (tests do this) without mutating
+// shared state, so those tests can run in parallel.
+const unmanagedOAuthWaitTimeout = 10 * time.Minute
 
 // oauth is a simple struct for compatibility with existing code
 type oauth struct {
@@ -301,6 +305,11 @@ type oauthTransport struct {
 	oauthHTTPClient           *http.Client
 	oauthFlowMu               sync.Mutex
 
+	// waitTimeout overrides the unmanaged-OAuth reply wait bound. Zero means
+	// use unmanagedOAuthWaitTimeout. Tests set a short value here instead of
+	// mutating a package global, so they remain parallel-safe.
+	waitTimeout time.Duration
+
 	// mu protects refreshFailedAt and lastErr* from concurrent access.
 	mu sync.Mutex
 	// refreshFailedAt tracks the last time a silent token refresh failed,
@@ -340,6 +349,15 @@ func (t *oauthTransport) oauthClient() *http.Client {
 		return t.oauthHTTPClient
 	}
 	return oauthHTTPClient
+}
+
+// waitTimeoutOrDefault returns the unmanaged-OAuth reply wait bound for this
+// transport, falling back to unmanagedOAuthWaitTimeout when unset.
+func (t *oauthTransport) waitTimeoutOrDefault() time.Duration {
+	if t.waitTimeout > 0 {
+		return t.waitTimeout
+	}
+	return unmanagedOAuthWaitTimeout
 }
 
 // handleServerRejectedToken is called when the server returned 401 for a
@@ -1294,7 +1312,8 @@ func (t *oauthTransport) handleUnmanagedOAuthFlow(ctx context.Context, authServe
 		err    error
 	}
 	elicCh := make(chan elicResult, 1)
-	elicCtx, elicCancel := context.WithTimeout(ctx, unmanagedOAuthWaitTimeout)
+	waitTimeout := t.waitTimeoutOrDefault()
+	elicCtx, elicCancel := context.WithTimeout(ctx, waitTimeout)
 	defer elicCancel()
 	go func() {
 		r, e := t.client.requestElicitation(elicCtx, &mcpsdk.ElicitParams{
@@ -1352,7 +1371,7 @@ func (t *oauthTransport) handleUnmanagedOAuthFlow(ctx context.Context, authServe
 		// lock from being held indefinitely. In practice the elicCh
 		// case below usually fires first with a deadline-exceeded
 		// error wrapped from requestElicitation.
-		return fmt.Errorf("OAuth flow timed out waiting for a reply after %s", unmanagedOAuthWaitTimeout)
+		return fmt.Errorf("OAuth flow timed out waiting for a reply after %s", waitTimeout)
 	case cb := <-callbackCh:
 		// Direct deeplink callback won. Release the in-flight
 		// elicitation goroutine; any UI the embedder showed for this

--- a/pkg/tools/mcp/oauth_test.go
+++ b/pkg/tools/mcp/oauth_test.go
@@ -2042,9 +2042,7 @@ func TestUnmanagedOAuthFlow_DriveFlow_AbortsOnParentCtxCancellation(t *testing.T
 // level would stay held, and every subsequent message from that session
 // would return 409 / ErrSessionBusy until a process restart.
 func TestUnmanagedOAuthFlow_DriveFlow_TimesOutWhenNoReplyArrives(t *testing.T) {
-	original := unmanagedOAuthWaitTimeout
-	unmanagedOAuthWaitTimeout = 200 * time.Millisecond
-	t.Cleanup(func() { unmanagedOAuthWaitTimeout = original })
+	t.Parallel()
 
 	srv := newUnmanagedOAuthTestServer(t)
 	defer srv.Close()
@@ -2061,6 +2059,9 @@ func TestUnmanagedOAuthFlow_DriveFlow_TimesOutWhenNoReplyArrives(t *testing.T) {
 		return tools.ElicitationResult{Action: tools.ElicitationActionDecline}
 	}
 	transport, _ := newUnmanagedTestTransport(t, srv.URL, redirectURI, capture)
+	// Short per-transport wait so the timeout fires quickly; no global
+	// mutation, so this test stays parallel-safe.
+	transport.waitTimeout = 200 * time.Millisecond
 
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL, strings.NewReader("{}"))
 	require.NoError(t, err)

--- a/pkg/tui/components/notification/notification.go
+++ b/pkg/tui/components/notification/notification.go
@@ -27,8 +27,6 @@ const (
 
 var nextID atomic.Uint64
 
-var timerDuration = defaultDuration
-
 // Type represents the type of notification
 type Type int
 
@@ -38,10 +36,6 @@ const (
 	TypeInfo
 	TypeError
 )
-
-func (t Type) autoHideDuration() time.Duration {
-	return timerDuration
-}
 
 // style returns the lipgloss style for this notification type.
 func (t Type) style() lipgloss.Style {
@@ -142,9 +136,14 @@ type Manager struct {
 	hoveredID      uint64
 	closeHoveredID uint64
 	copiedID       uint64
+	// autoHideDuration is how long a notification stays before its timer
+	// fires. Defaulted by New(); tests construct a Manager with a shorter
+	// (or zero) value so their auto-hide timers resolve promptly without
+	// mutating shared state, keeping them parallel-safe.
+	autoHideDuration time.Duration
 }
 
-func New() Manager { return Manager{} }
+func New() Manager { return Manager{autoHideDuration: defaultDuration} }
 
 // SetSize records the screen size used to position notifications.
 func (n *Manager) SetSize(width, height int) {
@@ -195,7 +194,7 @@ func (n *Manager) handleShow(msg ShowMsg) (Manager, tea.Cmd) {
 	item := notificationItem{ID: id, Text: msg.Text, Type: notifType}
 	n.items = append([]notificationItem{item}, n.items...)
 
-	return *n, makeTimerCmd(id, item.timerGen, notifType.autoHideDuration())
+	return *n, makeTimerCmd(id, item.timerGen, n.autoHideDuration)
 }
 
 func (n *Manager) handleAutoHide(msg AutoHideMsg) (Manager, tea.Cmd) {
@@ -438,7 +437,7 @@ func (n *Manager) HandleMouseMotion(x, y int) (Manager, tea.Cmd) {
 
 		if n.hoveredID != 0 {
 			if idx := n.findItemIndex(n.hoveredID); idx >= 0 {
-				cmd = makeTimerCmd(n.items[idx].ID, n.items[idx].timerGen, n.items[idx].Type.autoHideDuration())
+				cmd = makeTimerCmd(n.items[idx].ID, n.items[idx].timerGen, n.autoHideDuration)
 			}
 		}
 

--- a/pkg/tui/components/notification/notification_test.go
+++ b/pkg/tui/components/notification/notification_test.go
@@ -3,7 +3,6 @@ package notification
 import (
 	"strings"
 	"testing"
-	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -25,10 +24,7 @@ func TestNotification_InitialState(t *testing.T) {
 func TestNotification_AutoHideDurations(t *testing.T) {
 	t.Parallel()
 
-	require.Equal(t, defaultDuration, TypeSuccess.autoHideDuration())
-	require.Equal(t, defaultDuration, TypeInfo.autoHideDuration())
-	require.Equal(t, defaultDuration, TypeError.autoHideDuration())
-	require.Equal(t, defaultDuration, TypeWarning.autoHideDuration())
+	require.Equal(t, defaultDuration, New().autoHideDuration)
 }
 
 func TestNotification_Show(t *testing.T) {
@@ -146,12 +142,12 @@ func TestNotification_StaleTimerIgnored(t *testing.T) {
 }
 
 func TestNotification_HoverEnterLeaveRestartsTimer(t *testing.T) {
-	t.Cleanup(func(previous time.Duration) func() {
-		timerDuration = 0
-		return func() { timerDuration = previous }
-	}(timerDuration))
+	t.Parallel()
 
 	n := New()
+	// Zero duration so the auto-hide timer resolves promptly; set on this
+	// Manager only, so the test stays parallel-safe.
+	n.autoHideDuration = 0
 	n.SetSize(100, 50)
 	updated, _ := n.Update(ShowMsg{Text: "hover", Type: TypeInfo})
 	id := updated.items[0].ID
@@ -174,12 +170,12 @@ func TestNotification_HoverEnterLeaveRestartsTimer(t *testing.T) {
 }
 
 func TestNotification_WarningHoverEnterLeaveRestartsTimer(t *testing.T) {
-	t.Cleanup(func(previous time.Duration) func() {
-		timerDuration = 0
-		return func() { timerDuration = previous }
-	}(timerDuration))
+	t.Parallel()
 
 	n := New()
+	// Zero duration so the auto-hide timer resolves promptly; set on this
+	// Manager only, so the test stays parallel-safe.
+	n.autoHideDuration = 0
 	n.SetSize(100, 50)
 	updated, showCmd := n.Update(ShowMsg{Text: "warning", Type: TypeWarning})
 	require.NotNil(t, showCmd)
@@ -290,12 +286,12 @@ func TestNotification_CloseGlyphAndPaddingRegression(t *testing.T) {
 }
 
 func TestNotification_WarningsAutoHide(t *testing.T) {
-	t.Cleanup(func(previous time.Duration) func() {
-		timerDuration = 0
-		return func() { timerDuration = previous }
-	}(timerDuration))
+	t.Parallel()
 
 	n := New()
+	// Zero duration so the auto-hide timer resolves promptly; set on this
+	// Manager only, so the test stays parallel-safe.
+	n.autoHideDuration = 0
 	updated, cmd := n.Update(ShowMsg{Text: "warn", Type: TypeWarning})
 	require.NotNil(t, cmd)
 	require.Len(t, updated.items, 1)
@@ -312,12 +308,12 @@ func TestNotification_WarningsAutoHide(t *testing.T) {
 }
 
 func TestNotification_ErrorAutoHides(t *testing.T) {
-	t.Cleanup(func(previous time.Duration) func() {
-		timerDuration = 0
-		return func() { timerDuration = previous }
-	}(timerDuration))
+	t.Parallel()
 
 	n := New()
+	// Zero duration so the auto-hide timer resolves promptly; set on this
+	// Manager only, so the test stays parallel-safe.
+	n.autoHideDuration = 0
 	updated, cmd := n.Update(ShowMsg{Text: "err", Type: TypeError})
 	require.NotNil(t, cmd)
 	require.Len(t, updated.items, 1)
@@ -334,12 +330,12 @@ func TestNotification_ErrorAutoHides(t *testing.T) {
 }
 
 func TestNotification_ErrorHoverEnterLeaveRestartsTimer(t *testing.T) {
-	t.Cleanup(func(previous time.Duration) func() {
-		timerDuration = 0
-		return func() { timerDuration = previous }
-	}(timerDuration))
+	t.Parallel()
 
 	n := New()
+	// Zero duration so the auto-hide timer resolves promptly; set on this
+	// Manager only, so the test stays parallel-safe.
+	n.autoHideDuration = 0
 	n.SetSize(100, 50)
 	updated, _ := n.Update(ShowMsg{Text: "err", Type: TypeError})
 	id := updated.items[0].ID
@@ -365,12 +361,12 @@ func TestNotification_ErrorHoverEnterLeaveRestartsTimer(t *testing.T) {
 }
 
 func TestNotification_ErrorAutodetectAutoHides(t *testing.T) {
-	t.Cleanup(func(previous time.Duration) func() {
-		timerDuration = 0
-		return func() { timerDuration = previous }
-	}(timerDuration))
+	t.Parallel()
 
 	n := New()
+	// Zero duration so the auto-hide timer resolves promptly; set on this
+	// Manager only, so the test stays parallel-safe.
+	n.autoHideDuration = 0
 	updated, cmd := n.Update(ShowMsg{Text: "operation failed"})
 
 	require.NotNil(t, cmd)

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -69,6 +69,14 @@ type appModel struct {
 	shutdownDone <-chan struct{}
 	cleanupOnce  sync.Once
 
+	// exitFunc and shutdownTimeout override the shutdown safety net's
+	// behaviour. Both are zero by default and resolved through
+	// exitFn()/shutdownTimeoutOrDefault(), which fall back to the package
+	// defaults (os.Exit / 5s). Tests set them per-model so they can run in
+	// parallel without mutating package globals.
+	exitFunc        func(int)
+	shutdownTimeout time.Duration
+
 	supervisor *supervisor.Supervisor
 	tabBar     *tabbar.TabBar
 	tuiStore   *tuistate.Store
@@ -2545,12 +2553,31 @@ func formatWindowTitle(appName, sessionTitle string, working bool, animFrame int
 	return title
 }
 
-// exitFunc is the function called by the shutdown safety net when the
-// graceful exit times out. It defaults to os.Exit but can be replaced
-// in tests.
-var exitFunc = os.Exit
+// defaultExitFunc is the process-exit function used by the shutdown safety
+// net when the graceful exit times out. It is a package var (not a const)
+// only so the os.Exit indirection is testable at the package level; per-model
+// overrides go through appModel.exitFunc.
+var defaultExitFunc = os.Exit
 
-var shutdownTimeout = 5 * time.Second
+const defaultShutdownTimeout = 5 * time.Second
+
+// exitFn returns the exit function for this model, falling back to the
+// package default when unset.
+func (m *appModel) exitFn() func(int) {
+	if m.exitFunc != nil {
+		return m.exitFunc
+	}
+	return defaultExitFunc
+}
+
+// shutdownTimeoutOrDefault returns the shutdown grace period for this model,
+// falling back to the package default when unset.
+func (m *appModel) shutdownTimeoutOrDefault() time.Duration {
+	if m.shutdownTimeout > 0 {
+		return m.shutdownTimeout
+	}
+	return defaultShutdownTimeout
+}
 
 // cleanupManagedResources shuts down resources owned by the top-level TUI
 // lifecycle. It is safe to call from both the Bubble Tea event loop (normal
@@ -2587,8 +2614,8 @@ func (m *appModel) cleanupAll() {
 		return
 	}
 	m.program = nil
-	timeout := shutdownTimeout
-	exit := exitFunc
+	timeout := m.shutdownTimeoutOrDefault()
+	exit := m.exitFn()
 	go func() {
 		done := make(chan struct{})
 		go func() {

--- a/pkg/tui/tui_ctrlc_test.go
+++ b/pkg/tui/tui_ctrlc_test.go
@@ -60,9 +60,10 @@ func TestCtrlC_OnOtherDialog_StacksExitConfirmation(t *testing.T) {
 }
 
 func TestCtrlC_OnExitConfirmation_ForwardsAndExits(t *testing.T) {
-	neutralizeExitFunc(t)
+	t.Parallel()
 
 	m, _ := newTestModel(t)
+	neutralizeExitFunc(t, m)
 
 	// Put the exit confirmation dialog on top first (via a regular ctrl+c).
 	_, cmd := m.Update(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})

--- a/pkg/tui/tui_exit_test.go
+++ b/pkg/tui/tui_exit_test.go
@@ -149,37 +149,33 @@ func newTestModel(tb testing.TB) (*appModel, *mockEditor) {
 	return m, ed
 }
 
-// neutralizeExitFunc replaces exitFunc with a no-op for the duration of the
-// test and waits for the safety-net goroutine to fire (or time out) before
-// restoring the originals. Tests using this helper must NOT use t.Parallel()
-// because exitFunc and shutdownTimeout are package globals.
-func neutralizeExitFunc(t *testing.T) {
+// neutralizeExitFunc replaces the model's exit function with a no-op for the
+// duration of the test and waits for the safety-net goroutine to fire (or time
+// out). It sets per-model fields rather than package globals, so tests using
+// it may run in parallel.
+func neutralizeExitFunc(t *testing.T, m *appModel) {
 	t.Helper()
-
-	origExitFunc := exitFunc
-	origTimeout := shutdownTimeout
 
 	fired := make(chan struct{})
 	var once sync.Once
-	exitFunc = func(int) {
+	m.exitFunc = func(int) {
 		once.Do(func() { close(fired) })
 	}
-	shutdownTimeout = 10 * time.Millisecond
+	m.shutdownTimeout = 10 * time.Millisecond
 
 	t.Cleanup(func() {
 		select {
 		case <-fired:
 		case <-time.After(200 * time.Millisecond):
 		}
-		exitFunc = origExitFunc
-		shutdownTimeout = origTimeout
 	})
 }
 
 func TestExitSessionMsg_ExitsImmediately(t *testing.T) {
-	neutralizeExitFunc(t)
+	t.Parallel()
 
 	m, ed := newTestModel(t)
+	neutralizeExitFunc(t, m)
 
 	_, cmd := m.Update(messages.ExitSessionMsg{})
 
@@ -190,9 +186,10 @@ func TestExitSessionMsg_ExitsImmediately(t *testing.T) {
 }
 
 func TestExitConfirmedMsg_ExitsImmediately(t *testing.T) {
-	neutralizeExitFunc(t)
+	t.Parallel()
 
 	m, ed := newTestModel(t)
+	neutralizeExitFunc(t, m)
 
 	_, cmd := m.Update(dialog.ExitConfirmedMsg{})
 
@@ -314,27 +311,23 @@ func initBlockingBubbletea(t *testing.T, model tea.Model) (*tea.Program, *blocki
 // channel, so Wait() blocks forever — same shape as a real renderer
 // deadlock. exitFunc must fire after shutdownTimeout.
 func TestCleanupAll_SpawnsSafetyNet(t *testing.T) {
-	origTimeout := shutdownTimeout
-	origExitFunc := exitFunc
-	t.Cleanup(func() {
-		shutdownTimeout = origTimeout
-		exitFunc = origExitFunc
-	})
-	shutdownTimeout = 200 * time.Millisecond
+	t.Parallel()
+
+	m, _ := newTestModel(t)
+	m.shutdownTimeout = 200 * time.Millisecond
 
 	exitDone := make(chan int, 1)
-	exitFunc = func(code int) {
+	m.exitFunc = func(code int) {
 		exitDone <- code
 	}
 
-	m, _ := newTestModel(t)
 	m.program = tea.NewProgram(&quitModel{})
 	m.cleanupAll()
 
 	select {
 	case code := <-exitDone:
 		assert.Equal(t, 0, code)
-	case <-time.After(shutdownTimeout + time.Second):
+	case <-time.After(m.shutdownTimeout + time.Second):
 		t.Fatal("exitFunc was not called — safety net is missing from cleanupAll")
 	}
 }
@@ -342,16 +335,13 @@ func TestCleanupAll_SpawnsSafetyNet(t *testing.T) {
 // TestCleanupAll_GracefulShutdownSkipsExit: when Wait() returns promptly,
 // the safety net must not call exitFunc.
 func TestCleanupAll_GracefulShutdownSkipsExit(t *testing.T) {
-	origTimeout := shutdownTimeout
-	origExitFunc := exitFunc
-	t.Cleanup(func() {
-		shutdownTimeout = origTimeout
-		exitFunc = origExitFunc
-	})
-	shutdownTimeout = 2 * time.Second
+	t.Parallel()
+
+	m, _ := newTestModel(t)
+	m.shutdownTimeout = 2 * time.Second
 
 	var exitCalled atomic.Bool
-	exitFunc = func(int) { exitCalled.Store(true) }
+	m.exitFunc = func(int) { exitCalled.Store(true) }
 
 	var in, out bytes.Buffer
 	p := tea.NewProgram(&quitModel{},
@@ -370,7 +360,6 @@ func TestCleanupAll_GracefulShutdownSkipsExit(t *testing.T) {
 	// initialized p.finished — otherwise Wait() races the assignment.
 	p.Send(syncMsg{})
 
-	m, _ := newTestModel(t)
 	m.program = p
 	m.cleanupAll()
 
@@ -394,22 +383,18 @@ type syncMsg struct{}
 // TestCleanupAll_NilProgramIsSafe: with no program wired, cleanupAll is a
 // no-op and exitFunc is never called.
 func TestCleanupAll_NilProgramIsSafe(t *testing.T) {
-	origTimeout := shutdownTimeout
-	origExitFunc := exitFunc
-	t.Cleanup(func() {
-		shutdownTimeout = origTimeout
-		exitFunc = origExitFunc
-	})
-	shutdownTimeout = 20 * time.Millisecond
-
-	var exitCalled atomic.Bool
-	exitFunc = func(int) { exitCalled.Store(true) }
+	t.Parallel()
 
 	m, _ := newTestModel(t)
+	m.shutdownTimeout = 20 * time.Millisecond
+
+	var exitCalled atomic.Bool
+	m.exitFunc = func(int) { exitCalled.Store(true) }
+
 	m.program = nil
 	assert.NotPanics(t, func() { m.cleanupAll() })
 
-	time.Sleep(shutdownTimeout + 50*time.Millisecond)
+	time.Sleep(m.shutdownTimeout + 50*time.Millisecond)
 	assert.False(t, exitCalled.Load(), "exitFunc must not fire without a program")
 }
 
@@ -418,21 +403,17 @@ func TestCleanupAll_NilProgramIsSafe(t *testing.T) {
 // would itself re-acquire the same mutex — a hard deadlock. Wait() never
 // returns and ReleaseTerminal would block too; exitFunc must still fire.
 func TestCleanupAll_WedgedStdoutFiresExit(t *testing.T) {
-	origTimeout := shutdownTimeout
-	origExitFunc := exitFunc
-	t.Cleanup(func() {
-		shutdownTimeout = origTimeout
-		exitFunc = origExitFunc
-	})
-	shutdownTimeout = 300 * time.Millisecond
+	t.Parallel()
+
+	m, _ := newTestModel(t)
+	m.shutdownTimeout = 300 * time.Millisecond
 
 	exitDone := make(chan struct{})
-	exitFunc = func(int) { close(exitDone) }
+	m.exitFunc = func(int) { close(exitDone) }
 
 	p, w, _ := initBlockingBubbletea(t, &quitModel{})
 	defer w.unblock()
 
-	m, _ := newTestModel(t)
 	m.program = p
 	m.cleanupAll()
 
@@ -443,7 +424,7 @@ func TestCleanupAll_WedgedStdoutFiresExit(t *testing.T) {
 
 	select {
 	case <-exitDone:
-	case <-time.After(shutdownTimeout + 2*time.Second):
+	case <-time.After(m.shutdownTimeout + 2*time.Second):
 		t.Fatal("exitFunc was not called — safety net is blocked by ReleaseTerminal")
 	}
 }
@@ -455,25 +436,21 @@ func TestCleanupAll_WedgedStdoutFiresExit(t *testing.T) {
 // fine in production where exit is os.Exit, fatal in tests where it's a
 // channel close.
 func TestCleanupAll_MultipleCallsFireExitOnce(t *testing.T) {
-	origTimeout := shutdownTimeout
-	origExitFunc := exitFunc
-	t.Cleanup(func() {
-		shutdownTimeout = origTimeout
-		exitFunc = origExitFunc
-	})
-	shutdownTimeout = 100 * time.Millisecond
-
-	var exitCount atomic.Int32
-	exitFunc = func(int) { exitCount.Add(1) }
+	t.Parallel()
 
 	m, _ := newTestModel(t)
+	m.shutdownTimeout = 100 * time.Millisecond
+
+	var exitCount atomic.Int32
+	m.exitFunc = func(int) { exitCount.Add(1) }
+
 	m.program = tea.NewProgram(&quitModel{})
 
 	m.cleanupAll()
 	m.cleanupAll()
 	m.cleanupAll()
 
-	time.Sleep(shutdownTimeout + 200*time.Millisecond)
+	time.Sleep(m.shutdownTimeout + 200*time.Millisecond)
 	assert.Equal(t, int32(1), exitCount.Load(),
 		"only the first cleanupAll should arm a safety net")
 }


### PR DESCRIPTION
## What

Removes a cluster of mutable package-level global variables that tests were overriding in place. Overriding a shared global forces the tests that do it to run serially; replacing each global with either an explicit parameter or a field on the owning struct lets those tests run with `t.Parallel()` and no shared-state mutation.

This is a behavior-preserving refactor — production defaults are unchanged. Each commit is independently green (build, `go test -race`, `golangci-lint`, and the repo's custom cops).

## Why

Several packages carried `var x = …` globals whose only reason for being a `var` (not a `const` or a struct field) was so a test could reassign them via `orig := x; x = …; t.Cleanup(func(){ x = orig })`. That pattern:

- is not race-safe and silently blocks `t.Parallel()` on the affected tests;
- spreads a half-dozen slightly different idioms for the same need;
- leaves test-only seams (and the occasional exported `Reset*ForTest`) in production code.

## How

Two consistent patterns, matching what the codebase already does well elsewhere (`pkg/userid.Resolver`, `pkg/paths`):

1. **Explicit parameter** when the consumer is a free function.
2. **Field on the owning struct + a zero-value-means-default accessor** when the consumer is a method, so existing struct literals (including hand-built test ones) keep working untouched.

## Commits

| Commit | Package | Global removed | Pattern | Tests unblocked |
|--------|---------|----------------|---------|-----------------|
| `refactor(toolinstall)` | `pkg/toolinstall` | 4 × `max*` limit vars | `limits` value type + `Registry.extractor()` accessor | 3 |
| `refactor(runtime)` | `pkg/runtime` | `defaultStreamIdleTimeout` | const default + `handleStream` parameter | 2 |
| `refactor(mcp)` | `pkg/tools/mcp` | `unmanagedOAuthWaitTimeout` | const default + per-`oauthTransport` field | 1 |
| `refactor(notification)` | `pkg/tui/components/notification` | `timerDuration` | `Manager.autoHideDuration` field, defaulted in `New()` | 6 |
| `refactor(tui)` | `pkg/tui` | `exitFunc`, `shutdownTimeout` | per-`appModel` fields + accessors | 10 |
| `refactor(cmd/root)` | `cmd/root` | `loadUserConfig` | `userConfigLoader` parameter; tests inject `MapEnvProvider` | gateway/default-model tests |

**~22 tests** that previously had to run serially now run in parallel.

## Safety notes

- The zip/tar-bomb extraction bounds, the OAuth wait timeout, and the stream idle timeout all keep their exact production defaults.
- The "zero-value-means-default" accessors were checked against every production construction site: `Registry` is only built via `NewRegistry()` and `Manager` only via `New()`, so the default is always applied in production. The zero-value fallback only ever benefits test literals.

## Test plan

- `task build`
- `go test -race ./...` for each touched package
- `task lint` (golangci-lint + 18 custom cops) — clean
