### PR TITLE
docs: sync documentation with recent main merges

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -53,6 +53,8 @@
       url: /tools/think/
     - title: Plan
       url: /tools/plan/
+    - title: Session Plan
+      url: /tools/session_plan/
     - title: Session Context
       url: /tools/session_context/
     - title: Todo

--- a/docs/configuration/models/index.md
+++ b/docs/configuration/models/index.md
@@ -38,9 +38,9 @@ models:
       pdf: boolean # Optional: whether the model accepts PDF attachments
     provider_opts: # Optional: provider-specific options
       key: value
-    bypass_models_gateway: boolean # Optional: skip the models gateway for this model
     title_model: string # Optional: model used for session-title generation
     compaction_model: string # Optional: model used for session-compaction (summary generation)
+    bypass_models_gateway: boolean # Optional: skip the models gateway for this model
 ```
 
 ## Properties Reference

--- a/docs/configuration/models/index.md
+++ b/docs/configuration/models/index.md
@@ -38,6 +38,9 @@ models:
       pdf: boolean # Optional: whether the model accepts PDF attachments
     provider_opts: # Optional: provider-specific options
       key: value
+    bypass_models_gateway: boolean # Optional: skip the models gateway for this model
+    title_model: string # Optional: model used for session-title generation
+    compaction_model: string # Optional: model used for session-compaction (summary generation)
 ```
 
 ## Properties Reference
@@ -62,6 +65,8 @@ models:
 | `capabilities`        | object     | ✗        | Override attachment capabilities for this model. See [Attachment Capability Overrides](#attachment-capability-overrides). |
 | `provider_opts`       | object     | ✗        | Provider-specific options (see provider pages)                                        |
 | `title_model`         | string     | ✗        | Model used for session-title generation. Can be a named model from the `models:` section or an inline `provider/model` string. When omitted, the agent's primary model generates titles. Cannot be combined with `first_available`. |
+| `compaction_model`    | string     | ✗        | Model used for session compaction (summary generation). Can be a named model or an inline `provider/model` string. When omitted, the primary model compacts. Cannot be combined with `first_available`. See [Delegating Session Compaction](#delegating-session-compaction). |
+| `bypass_models_gateway` | boolean  | ✗        | When `true`, this model connects directly to its provider even when a models gateway (`--models-gateway` / `CAGENT_MODELS_GATEWAY`) is configured. See [Gateway Bypass](#gateway-bypass). |
 
 ## Attachment Capability Overrides
 
@@ -122,6 +127,79 @@ titles.
 </div>
   <p><code>title_model</code> cannot be combined with <code>first_available</code> model selection — the combination is rejected at validation time.</p>
 </div>
+
+## Delegating Session Compaction
+
+The `compaction_model` field lets a heavyweight primary model hand off the expensive
+compaction (summary generation) call to a smaller, faster model:
+
+```yaml
+models:
+  primary:
+    provider: anthropic
+    model: claude-sonnet-4-5
+    compaction_model: fast
+  fast:
+    provider: anthropic
+    model: claude-haiku-4-5
+```
+
+The value can be a named entry from the `models` stanza or an inline
+`provider/model` string. When omitted, the primary model compacts.
+
+If the compaction model has a **smaller context window** than the primary,
+docker-agent triggers compaction against the smaller window so the summary
+call can always ingest the full conversation. Pair the primary with a
+compaction model whose window is at least as large to keep the proactive
+trigger aligned with the primary's window.
+
+<div class="callout callout-warning" markdown="1">
+<div class="callout-title">Constraint
+</div>
+  <p><code>compaction_model</code> cannot be combined with <code>first_available</code> model selection — the combination is rejected at validation time.</p>
+</div>
+
+See [`examples/compaction_model.yaml`](https://github.com/docker/docker-agent/blob/main/examples/compaction_model.yaml) for a complete example.
+
+## Gateway Bypass
+
+When a models gateway (`--models-gateway` / `CAGENT_MODELS_GATEWAY`) is configured,
+all models route through it by default. Set `bypass_models_gateway: true` on a
+specific model to make it connect directly to its provider instead:
+
+```yaml
+models:
+  gateway-model:
+    provider: openai
+    model: gpt-5
+
+  direct-model:
+    provider: anthropic
+    model: claude-sonnet-4-5
+    bypass_models_gateway: true  # uses ANTHROPIC_API_KEY directly
+```
+
+The bypassed model authenticates with the provider's own credentials
+(`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `token_key`, etc.) rather than the
+gateway's short-lived token. The rest of the agent's models continue routing
+through the gateway as before.
+
+Bypass is propagated transparently through router models: a bypass-flagged routing
+model passes the flag to all of its routed targets automatically.
+
+<div class="callout callout-warning" markdown="1">
+<div class="callout-title">Security note
+</div>
+  <p>On an untrusted config, a malicious <code>base_url</code> combined with <code>bypass_models_gateway: true</code> could route provider credentials to an attacker-controlled endpoint. Only enable this on configs you control.</p>
+</div>
+
+<div class="callout callout-warning" markdown="1">
+<div class="callout-title">Constraint
+</div>
+  <p><code>bypass_models_gateway: true</code> cannot be combined with <code>first_available</code> — the combination is rejected at validation time.</p>
+</div>
+
+See [`examples/bypass_models_gateway.yaml`](https://github.com/docker/docker-agent/blob/main/examples/bypass_models_gateway.yaml) for a complete example.
 
 ## First Available Models
 

--- a/docs/configuration/tools/index.md
+++ b/docs/configuration/tools/index.md
@@ -18,6 +18,7 @@ Built-in tools are included with docker-agent and require no external dependenci
 | `shell` | Execute shell commands (sync + background jobs) | [Shell]({{ '/tools/shell/' | relative_url }}) |
 | `think` | Reasoning scratchpad | [Think]({{ '/tools/think/' | relative_url }}) |
 | `plan` | Shared persistent scratchpad for multi-agent collaboration | [Plan]({{ '/tools/plan/' | relative_url }}) |
+| `session_plan` | Per-session markdown plan for the draft-review-execute workflow | [Session Plan]({{ '/tools/session_plan/' | relative_url }}) |
 | `session_context` | Reference a previous session as context (read-only) | [Session Context]({{ '/tools/session_context/' | relative_url }}) |
 | `todo` | Task list management | [Todo]({{ '/tools/todo/' | relative_url }}) |
 | `memory` | Persistent key-value storage (SQLite) | [Memory]({{ '/tools/memory/' | relative_url }}) |


### PR DESCRIPTION
Syncs `/docs` with three merged feature PRs from the last 36 hours.

**PR #3305** — `docs/_data/nav.yml` + `docs/configuration/tools/index.md`
Added the `session_plan` toolset to the nav sidebar and to the built-in tools table. The page `docs/tools/session_plan/index.md` was shipped in the PR itself; only the navigation wiring was missing.

**PR #3335** — `docs/configuration/models/index.md`
Documented the new `compaction_model` field: schema block, Properties Reference table row, and a "Delegating Session Compaction" section with a YAML example, a note on window-sizing behaviour, a constraint callout, and a link to the example file.

**PR #3338** — `docs/configuration/models/index.md`
Documented the new `bypass_models_gateway` field: schema block, Properties Reference table row, and a "Gateway Bypass" section with a YAML example, propagation-through-router note, a security callout, a constraint callout, and a link to the example file.

PRs not requiring doc changes: #3337 (OpenRouter — shipped its own docs), #3320 (session\_context — shipped its own docs), #3306 (instruction\_file list — shipped its own docs), #3322 (1password caching — shipped its own docs), #3325/#3304 (docs PRs themselves), #3327/#3312/#3324/#3323 (bug fixes with no config surface), #3321/#3326/#3328–#3332 (internal refactors/tests), #3334 (CI), #3314/#3331/#3339 (CHANGELOG only), #3310 (covered by PR #3313 docs sync).