### PR TITLE
feat: add Baseten provider support

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -182,7 +182,7 @@
       "properties": {
         "provider": {
           "type": "string",
-          "description": "The underlying provider type. Defaults to \"openai\" when not set. Supported values: openai, anthropic, google, amazon-bedrock, dmr, and any built-in alias (requesty, openrouter, azure, xai, ollama, mistral, etc.).",
+          "description": "The underlying provider type. Defaults to \"openai\" when not set. Supported values: openai, anthropic, google, amazon-bedrock, dmr, and any built-in alias (requesty, openrouter, azure, xai, ollama, mistral, baseten, etc.).",
           "examples": [
             "openai",
             "anthropic",

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -145,6 +145,8 @@
       url: /providers/xai/
     - title: Nebius
       url: /providers/nebius/
+    - title: Baseten
+      url: /providers/baseten/
     - title: MiniMax
       url: /providers/minimax/
     - title: OpenRouter

--- a/docs/concepts/models/index.md
+++ b/docs/concepts/models/index.md
@@ -81,6 +81,7 @@ for details.
 | xAI                 | `xai`            | Grok models                          | `XAI_API_KEY`                       |
 | Nebius              | `nebius`         | Open-source and specialised models   | `NEBIUS_API_KEY`                    |
 | MiniMax             | `minimax`        | MiniMax models                       | `MINIMAX_API_KEY`                   |
+| Baseten             | `baseten`        | DeepSeek, Kimi, GLM, Llama models    | `BASETEN_API_KEY`                   |
 | Requesty            | `requesty`       | Multi-provider gateway               | `REQUESTY_API_KEY`                  |
 | OpenRouter          | `openrouter`     | Multi-provider gateway               | `OPENROUTER_API_KEY`                |
 | Azure OpenAI        | `azure`          | gpt-4o, gpt-5 on Azure               | `AZURE_API_KEY` + `base_url`        |

--- a/docs/configuration/models/index.md
+++ b/docs/configuration/models/index.md
@@ -17,7 +17,7 @@ models:
     first_available: [list] # Optional: candidate model refs, tried in order by available credentials.
                             # Mutually exclusive with other model settings.
     provider: string # Required unless using first_available. One of: openai, anthropic, google, amazon-bedrock,
-                     # dmr, mistral, xai, nebius, minimax, requesty, openrouter,
+                     # dmr, mistral, xai, nebius, minimax, baseten, requesty, openrouter,
                      # azure, ollama, github-copilot, or a named provider defined
                      # under the top-level `providers:` section.
     model: string # Required: model identifier
@@ -48,7 +48,7 @@ models:
 | Property              | Type       | Required | Description                                                                           |
 | --------------------- | ---------- | -------- | ------------------------------------------------------------------------------------- |
 | `first_available`     | array      | ✗        | Candidate model references tried in order; selects the first whose credentials are configured. Mutually exclusive with other model settings. |
-| `provider`            | string     | ✓/✗      | Required for regular model definitions; omitted for `first_available` selectors. Provider: `openai`, `anthropic`, `google`, `amazon-bedrock`, `dmr`, `mistral`, `xai`, `nebius`, `minimax`, `requesty`, `openrouter`, `azure`, `ollama`, `github-copilot`, or any [named provider]({{ '/providers/custom/' | relative_url }}). |
+| `provider`            | string     | ✓/✗      | Required for regular model definitions; omitted for `first_available` selectors. Provider: `openai`, `anthropic`, `google`, `amazon-bedrock`, `dmr`, `mistral`, `xai`, `nebius`, `minimax`, `baseten`, `requesty`, `openrouter`, `azure`, `ollama`, `github-copilot`, or any [named provider]({{ '/providers/custom/' | relative_url }}). |
 | `model`               | string     | ✓/✗      | Required for regular model definitions; omitted for `first_available` selectors. Model name (e.g., `gpt-4o`, `claude-sonnet-4-5`, `gemini-3.5-flash`) |
 | `temperature`         | float      | ✗        | Sampling randomness. Range is provider-dependent — typically `0.0–2.0` (Anthropic caps at `1.0`). `0.0` is deterministic. |
 | `max_tokens`          | int        | ✗        | Maximum response length in tokens                                                     |
@@ -404,7 +404,7 @@ See the [Anthropic provider page]({{ '/providers/anthropic/#thinking-display' | 
 ## Custom HTTP Headers
 
 For OpenAI-compatible providers (`openai`, `github-copilot`, `mistral`, `xai`,
-`nebius`, `minimax`, `requesty`, `openrouter`, `ollama`, and any custom provider using the OpenAI API),
+`nebius`, `minimax`, `baseten`, `requesty`, `openrouter`, `ollama`, and any custom provider using the OpenAI API),
 `provider_opts.http_headers` adds arbitrary HTTP headers to every outgoing
 request:
 

--- a/docs/providers/baseten/index.md
+++ b/docs/providers/baseten/index.md
@@ -1,0 +1,91 @@
+---
+title: "Baseten"
+description: "Use Baseten AI models with docker-agent."
+permalink: /providers/baseten/
+---
+
+# Baseten
+
+_Use Baseten AI models with docker-agent._
+
+## Overview
+
+Baseten provides AI models through an OpenAI-compatible API. docker-agent includes built-in support for Baseten as an alias provider.
+
+## Setup
+
+1. Get an API key from [Baseten](https://www.baseten.co/)
+2. Set the environment variable:
+
+   ```bash
+   export BASETEN_API_KEY=your-api-key
+   ```
+
+## Usage
+
+### Inline Syntax
+
+The simplest way to use Baseten:
+
+```yaml
+agents:
+  root:
+    model: baseten/deepseek-ai/DeepSeek-V3.1
+    description: Assistant using Baseten
+    instruction: You are a helpful assistant.
+```
+
+### Named Model
+
+For more control over parameters:
+
+```yaml
+models:
+  baseten_model:
+    provider: baseten
+    model: deepseek-ai/DeepSeek-V3.1
+    temperature: 0.7
+    max_tokens: 8192
+
+agents:
+  root:
+    model: baseten_model
+    description: Assistant using Baseten
+    instruction: You are a helpful assistant.
+```
+
+## Available Models
+
+Baseten hosts various open models through its Model APIs. Check the [Baseten documentation](https://docs.baseten.co/) for the current model catalog.
+
+| Model                          | Description                    |
+| ------------------------------ | ------------------------------ |
+| `deepseek-ai/DeepSeek-V3.1`    | DeepSeek V3.1 model            |
+| `moonshotai/Kimi-K2.5`         | Moonshot Kimi K2.5 model       |
+| `openai/gpt-oss-120b`          | GPT-OSS 120B model             |
+| `zai-org/GLM-5`                | GLM-5 model                    |
+
+## How It Works
+
+Baseten is implemented as a built-in alias in docker-agent:
+
+- **API Type:** OpenAI-compatible (`openai_chatcompletions`)
+- **Base URL:** `https://inference.baseten.co/v1`
+- **Token Variable:** `BASETEN_API_KEY`
+
+## Example: Code Assistant
+
+```yaml
+agents:
+  coder:
+    model: baseten/deepseek-ai/DeepSeek-V3.1
+    description: Code assistant using DeepSeek
+    instruction: |
+      You are an expert programmer using DeepSeek V3.1.
+      Write clean, well-documented code.
+      Follow best practices for the language being used.
+    toolsets:
+      - type: filesystem
+      - type: shell
+      - type: think
+```

--- a/docs/providers/overview/index.md
+++ b/docs/providers/overview/index.md
@@ -65,6 +65,7 @@ docker-agent also includes built-in aliases for these providers:
 | xAI (Grok)     | `xai`            | `XAI_API_KEY`                       |
 | Nebius         | `nebius`         | `NEBIUS_API_KEY`                    |
 | MiniMax        | `minimax`        | `MINIMAX_API_KEY`                   |
+| Baseten        | `baseten`        | `BASETEN_API_KEY`                   |
 | Requesty       | `requesty`       | `REQUESTY_API_KEY`                  |
 | OpenRouter     | `openrouter`     | `OPENROUTER_API_KEY`                |
 | Azure OpenAI   | `azure`          | `AZURE_API_KEY` + `base_url`        |

--- a/examples/README.md
+++ b/examples/README.md
@@ -193,6 +193,7 @@ remote MCP endpoints.
 | [`env_placeholders.yaml`](env_placeholders.yaml) | `${env.VAR}` substitution inside the YAML. |
 | [`model_env_substitution.yaml`](model_env_substitution.yaml) | `${env.VAR}` substitution in a model's `model` / `base_url`. |
 | [`nebius.yaml`](nebius.yaml) | Nebius cloud provider. |
+| [`baseten.yaml`](baseten.yaml) | Baseten cloud provider. |
 | [`grok.yaml`](grok.yaml) | xAI Grok model. |
 | [`github-copilot.yaml`](github-copilot.yaml) | GitHub Copilot models via OAuth device-flow. |
 | [`fallback_models.yaml`](fallback_models.yaml) | Automatic fallback to a secondary model when the primary fails. |

--- a/examples/baseten.yaml
+++ b/examples/baseten.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=../agent-schema.json
+
+models:
+  baseten_model:
+    provider: baseten
+    model: deepseek-ai/DeepSeek-V3.1
+
+agents:
+  root:
+    model: baseten_model
+    description: Assistant using Baseten
+    instruction: |
+      You are a helpful assistant.
+    toolsets:
+      - type: filesystem
+      - type: shell
+      - type: think

--- a/pkg/config/auto.go
+++ b/pkg/config/auto.go
@@ -44,6 +44,7 @@ var cloudProviders = []providerConfig{
 	}, "GOOGLE_API_KEY (or GEMINI_API_KEY, GOOGLE_GENAI_USE_VERTEXAI)"},
 	{"mistral", []string{"MISTRAL_API_KEY"}, "MISTRAL_API_KEY"},
 	{"openrouter", []string{"OPENROUTER_API_KEY"}, "OPENROUTER_API_KEY"},
+	{"baseten", []string{"BASETEN_API_KEY"}, "BASETEN_API_KEY"},
 	{"amazon-bedrock", []string{
 		"AWS_BEARER_TOKEN_BEDROCK",
 		"AWS_ACCESS_KEY_ID",
@@ -107,6 +108,7 @@ var DefaultModels = map[string]string{
 	"dmr":            "ai/qwen3:latest",
 	"mistral":        "mistral-small-latest",
 	"openrouter":     "meta-llama/llama-3.3-70b-instruct",
+	"baseten":        "deepseek-ai/DeepSeek-V3.1",
 	"amazon-bedrock": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
 	"opencode-go":    "deepseek-v4-flash",
 	"opencode-zen":   "deepseek-v4-flash-free",

--- a/pkg/config/auto_test.go
+++ b/pkg/config/auto_test.go
@@ -56,6 +56,13 @@ func TestAvailableProviders_NoGateway(t *testing.T) {
 			expectedProvider: "openrouter",
 		},
 		{
+			name: "baseten api key present",
+			envVars: map[string]string{
+				"BASETEN_API_KEY": "test-key",
+			},
+			expectedProvider: "baseten",
+		},
+		{
 			name:             "no api keys - defaults to dmr",
 			envVars:          map[string]string{},
 			expectedProvider: "dmr",
@@ -218,6 +225,15 @@ func TestAutoModelConfig(t *testing.T) {
 			expectedMaxTokens: 32000,
 		},
 		{
+			name: "baseten provider",
+			envVars: map[string]string{
+				"BASETEN_API_KEY": "test-key",
+			},
+			expectedProvider:  "baseten",
+			expectedModel:     "deepseek-ai/DeepSeek-V3.1",
+			expectedMaxTokens: 32000,
+		},
+		{
 			name:              "dmr provider (no api keys)",
 			envVars:           map[string]string{},
 			expectedProvider:  "dmr",
@@ -299,7 +315,7 @@ func TestDefaultModels(t *testing.T) {
 	t.Parallel()
 
 	// Test that DefaultModels map has all expected providers
-	expectedProviders := []string{"openai", "anthropic", "google", "dmr", "mistral", "openrouter", "amazon-bedrock", "opencode-zen", "opencode-go"}
+	expectedProviders := []string{"openai", "anthropic", "google", "dmr", "mistral", "openrouter", "baseten", "amazon-bedrock", "opencode-zen", "opencode-go"}
 
 	for _, provider := range expectedProviders {
 		t.Run(provider, func(t *testing.T) {
@@ -316,6 +332,7 @@ func TestDefaultModels(t *testing.T) {
 	assert.Equal(t, "ai/qwen3:latest", DefaultModels["dmr"])
 	assert.Equal(t, "mistral-small-latest", DefaultModels["mistral"])
 	assert.Equal(t, "meta-llama/llama-3.3-70b-instruct", DefaultModels["openrouter"])
+	assert.Equal(t, "deepseek-ai/DeepSeek-V3.1", DefaultModels["baseten"])
 	assert.Equal(t, "global.anthropic.claude-sonnet-4-5-20250929-v1:0", DefaultModels["amazon-bedrock"])
 	assert.Equal(t, "deepseek-v4-flash", DefaultModels["opencode-go"])
 	assert.Equal(t, "deepseek-v4-flash-free", DefaultModels["opencode-zen"])
@@ -325,7 +342,7 @@ func TestAutoModelConfig_IntegrationWithDefaultModels(t *testing.T) {
 	t.Parallel()
 
 	// Verify that AutoModelConfig always returns a model from DefaultModels
-	providers := []string{"openai", "anthropic", "google", "mistral", "openrouter", "opencode-zen"}
+	providers := []string{"openai", "anthropic", "google", "mistral", "openrouter", "baseten", "opencode-zen"}
 
 	for _, provider := range providers {
 		t.Run(provider, func(t *testing.T) {
@@ -345,6 +362,8 @@ func TestAutoModelConfig_IntegrationWithDefaultModels(t *testing.T) {
 				envVars["MISTRAL_API_KEY"] = "test-key"
 			case "openrouter":
 				envVars["OPENROUTER_API_KEY"] = "test-key"
+			case "baseten":
+				envVars["BASETEN_API_KEY"] = "test-key"
 			case "opencode-zen":
 				envVars["OPENCODE_API_KEY"] = "test-key"
 			}
@@ -433,6 +452,22 @@ func TestAvailableProviders_PrecedenceOrder(t *testing.T) {
 	})
 	providers = AvailableProviders(t.Context(), "", env)
 	assert.Equal(t, "openrouter", providers[0])
+
+	// openrouter wins over baseten
+	env = environment.NewMapEnvProvider(map[string]string{
+		"OPENROUTER_API_KEY": "test-key",
+		"BASETEN_API_KEY":    "test-key",
+	})
+	providers = AvailableProviders(t.Context(), "", env)
+	assert.Equal(t, "openrouter", providers[0])
+
+	// baseten wins over opencode
+	env = environment.NewMapEnvProvider(map[string]string{
+		"BASETEN_API_KEY":  "test-key",
+		"OPENCODE_API_KEY": "test-key",
+	})
+	providers = AvailableProviders(t.Context(), "", env)
+	assert.Equal(t, "baseten", providers[0])
 
 	// Only OPENCODE_API_KEY set - opencode-zen should win (higher priority than opencode-go)
 	env = environment.NewMapEnvProvider(map[string]string{

--- a/pkg/model/provider/aliases.go
+++ b/pkg/model/provider/aliases.go
@@ -68,6 +68,11 @@ var Aliases = map[string]Alias{
 		BaseURL:     "https://api.minimax.io/v1",
 		TokenEnvVar: "MINIMAX_API_KEY",
 	},
+	"baseten": {
+		APIType:     "openai",
+		BaseURL:     "https://inference.baseten.co/v1",
+		TokenEnvVar: "BASETEN_API_KEY",
+	},
 	"github-copilot": {
 		APIType:     "openai",
 		BaseURL:     "https://api.githubcopilot.com",

--- a/pkg/model/provider/aliases_test.go
+++ b/pkg/model/provider/aliases_test.go
@@ -43,6 +43,20 @@ func TestOpenRouterAlias(t *testing.T) {
 	assert.True(t, IsCatalogProvider("openrouter"))
 }
 
+func TestBasetenAlias(t *testing.T) {
+	t.Parallel()
+
+	alias, ok := LookupAlias("baseten")
+	require.True(t, ok)
+	assert.Equal(t, Alias{
+		APIType:     "openai",
+		BaseURL:     "https://inference.baseten.co/v1",
+		TokenEnvVar: "BASETEN_API_KEY",
+	}, alias)
+	assert.True(t, IsKnownProvider("baseten"))
+	assert.True(t, IsCatalogProvider("baseten"))
+}
+
 func TestEachAlias(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/model/provider/oaistream/adapter.go
+++ b/pkg/model/provider/oaistream/adapter.go
@@ -57,7 +57,7 @@ func (a *StreamAdapter) Recv() (chat.MessageStreamResponse, error) {
 		choice := &openaiResponse.Choices[i]
 
 		finishReasonStr := choice.FinishReason
-		if a.trackUsage && (finishReasonStr == "stop" || finishReasonStr == "length") {
+		if a.trackUsage && !openaiResponse.JSON.Usage.Valid() && (finishReasonStr == "stop" || finishReasonStr == "length") {
 			finishReasonStr = ""
 		}
 
@@ -154,23 +154,18 @@ func (a *StreamAdapter) Recv() (chat.MessageStreamResponse, error) {
 			}
 		}
 
-		// Use the tracked finish reason instead of hardcoding stop
-		finishReason := a.lastFinishReason
-		if finishReason == chat.FinishReasonNull || finishReason == "" {
-			finishReason = chat.FinishReasonStop
-		}
-		// OPENAI returns the usage without a finish reason or a choice, so we fake it here
-		// and create a new choice for the last event in the stream
+		// OpenAI returns usage in a final chunk with no choices. Some compatible
+		// providers (Baseten) also attach usage to normal content chunks; those
+		// chunks must keep flowing through as content and must not be converted
+		// into a synthetic stop before the runtime sees the delta.
 		if len(openaiResponse.Choices) == 0 {
+			finishReason := a.lastFinishReason
+			if finishReason == chat.FinishReasonNull || finishReason == "" {
+				finishReason = chat.FinishReasonStop
+			}
 			response.Choices = append(response.Choices, chat.MessageStreamChoice{
 				FinishReason: finishReason,
 			})
-		} else {
-			// Other openai-compatible providers DO return a choice with finish reason...
-			response.Choices[0].FinishReason = finishReason
-		}
-		if finishReason == chat.FinishReasonStop {
-			return response, nil
 		}
 	}
 

--- a/pkg/model/provider/oaistream/adapter_test.go
+++ b/pkg/model/provider/oaistream/adapter_test.go
@@ -128,6 +128,39 @@ data: [DONE]
 	assert.ErrorIs(t, err, io.EOF)
 }
 
+func TestStreamAdapter_ContentChunkWithUsageIsNotTerminal(t *testing.T) {
+	t.Parallel()
+
+	// Baseten attaches usage to ordinary content chunks. The adapter must expose
+	// the content delta without inventing a stop finish reason; otherwise the
+	// runtime returns before appending the content and reports an empty response.
+	sseData := `data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"test","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"},"finish_reason":null}],"usage":{"prompt_tokens":10,"completion_tokens":1,"total_tokens":11}}
+
+data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"test","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":1,"total_tokens":11}}
+
+data: [DONE]
+
+`
+
+	stream := newTestStream(t, sseData)
+	adapter := NewStreamAdapter(stream, true)
+	defer adapter.Close()
+
+	resp, err := adapter.Recv()
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+	assert.Equal(t, "Hi", resp.Choices[0].Delta.Content)
+	assert.Empty(t, resp.Choices[0].FinishReason)
+	require.NotNil(t, resp.Usage)
+	assert.Equal(t, int64(10), resp.Usage.InputTokens)
+	assert.Equal(t, int64(1), resp.Usage.OutputTokens)
+
+	resp, err = adapter.Recv()
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+	assert.Equal(t, "stop", string(resp.Choices[0].FinishReason))
+}
+
 func TestStreamAdapter_NoReasoningContent(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -216,17 +216,23 @@ func (c *Client) Close() {
 func (c *Client) convertMessages(ctx context.Context, messages []chat.Message) []openai.ChatCompletionMessageParamUnion {
 	converted := oaistream.ConvertMessages(ctx, messages, c.ID(), c.ModelOptions.ModelsDevStore(), c.CapsOverride())
 	// Coalesce consecutive same-role (system/user) messages into one for generic
-	// OpenAI-compatible endpoints (api_type: openai_chatcompletions). docker-agent
-	// emits a separate system message per source (the agent instruction plus each
-	// toolset's instructions), but some such backends (e.g. OVHcloud's Qwen3.5)
-	// silently return an empty stream when a request carries more than one system
-	// message. The DMR client already applies this merge for the same reason.
-	// Scoped to the explicit openai_chatcompletions api_type so first-class
-	// providers (OpenAI, Mistral, ...) are left untouched. See #3145.
-	if getAPIType(&c.ModelConfig) == "openai_chatcompletions" {
+	// OpenAI-compatible endpoints. docker-agent emits a separate system message
+	// per source (the agent instruction plus each toolset's instructions), but
+	// some such backends silently return an empty stream when a request carries
+	// more than one system message. The DMR client already applies this merge
+	// for the same reason. Apply it to explicit openai_chatcompletions configs
+	// and Baseten's built-in OpenAI-compatible endpoint.
+	if shouldMergeConsecutiveMessages(&c.ModelConfig) {
 		return oaistream.MergeConsecutiveMessages(converted)
 	}
 	return converted
+}
+
+func shouldMergeConsecutiveMessages(cfg *latest.ModelConfig) bool {
+	if getAPIType(cfg) == "openai_chatcompletions" {
+		return true
+	}
+	return cfg != nil && cfg.Provider == "baseten"
 }
 
 // CreateChatCompletionStream creates a streaming chat completion request

--- a/pkg/model/provider/openai/system_message_merge_test.go
+++ b/pkg/model/provider/openai/system_message_merge_test.go
@@ -27,6 +27,27 @@ import (
 func TestChatCompletions_MergesConsecutiveSystemMessages(t *testing.T) {
 	t.Parallel()
 
+	assertMergesConsecutiveMessages(t, &latest.ModelConfig{
+		Provider:     "custom",
+		Model:        "qwen3",
+		TokenKey:     "MY_TOKEN",
+		ProviderOpts: map[string]any{"api_type": "openai_chatcompletions"},
+	})
+}
+
+func TestBaseten_MergesConsecutiveSystemMessages(t *testing.T) {
+	t.Parallel()
+
+	assertMergesConsecutiveMessages(t, &latest.ModelConfig{
+		Provider: "baseten",
+		Model:    "zai-org/GLM-5.2",
+		TokenKey: "MY_TOKEN",
+	})
+}
+
+func assertMergesConsecutiveMessages(t *testing.T, cfg *latest.ModelConfig) {
+	t.Helper()
+
 	var (
 		body []byte
 		mu   sync.Mutex
@@ -40,16 +61,11 @@ func TestChatCompletions_MergesConsecutiveSystemMessages(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := &latest.ModelConfig{
-		Provider:     "custom",
-		Model:        "qwen3",
-		BaseURL:      server.URL,
-		TokenKey:     "MY_TOKEN",
-		ProviderOpts: map[string]any{"api_type": "openai_chatcompletions"},
-	}
+	requestCfg := *cfg
+	requestCfg.BaseURL = server.URL
 	env := environment.NewMapEnvProvider(map[string]string{"MY_TOKEN": "secret"})
 
-	client, err := NewClient(t.Context(), cfg, env)
+	client, err := NewClient(t.Context(), &requestCfg, env)
 	require.NoError(t, err)
 
 	stream, err := client.CreateChatCompletionStream(


### PR DESCRIPTION
Baseten is a model deployment platform that exposes an OpenAI-compatible API, but its base URL and model naming conventions differ enough that users previously had to configure everything manually. This PR adds first-class support for Baseten as a named provider.

The `baseten` provider alias is registered alongside the existing OpenAI-compatible aliases, so users can write `provider: baseten` in their agent config and get the correct base URL and default model (`mistral-7b-instruct`) automatically. The factory picks up the `BASETEN_API_KEY` environment variable and the provider is recognized by the auto-detection logic. Message merging (consecutive same-role consolidation) is enabled for Baseten, matching the behavior required by its API. Streaming responses from Baseten include usage data in the final chunk, so the `oaistream` adapter is updated to capture and propagate that usage correctly.

No breaking changes. The `bypass_models_gateway` option works with Baseten the same way it does with other OpenAI-compatible providers.