### PR TITLE
chore: bump github.com/anthropics/anthropic-sdk-go to v1.55.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/a2aproject/a2a-go v0.3.15
 	github.com/alecthomas/chroma/v2 v2.27.0
 	github.com/alpkeskin/gotoon v0.1.1
-	github.com/anthropics/anthropic-sdk-go v1.53.0
+	github.com/anthropics/anthropic-sdk-go v1.55.0
 	github.com/atotto/clipboard v0.1.4
 	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.26

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,8 @@ github.com/alpkeskin/gotoon v0.1.1 h1:GQOVwMfWKINnfEA6slrXHJaJYDwnUFmrPlXOtnuja1
 github.com/alpkeskin/gotoon v0.1.1/go.mod h1:XRTz8RM4tz8M2nB37MNRN8rHF4YgeYd8nIXmoU0B0+M=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
-github.com/anthropics/anthropic-sdk-go v1.53.0 h1:R/99NOmSXlfha2kwVVDUBiDxfoG5eHaxfQ9omcKgITM=
-github.com/anthropics/anthropic-sdk-go v1.53.0/go.mod h1:3EfIfmFqxH6rbiLcIP4tPFyXL/IHakx2wDG4OU+TIEI=
+github.com/anthropics/anthropic-sdk-go v1.55.0 h1:bBAuqAsRQaDQADZ3FqsJex1qMOdUr/kgZELLk/vnu/c=
+github.com/anthropics/anthropic-sdk-go v1.55.0/go.mod h1:3EfIfmFqxH6rbiLcIP4tPFyXL/IHakx2wDG4OU+TIEI=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=


### PR DESCRIPTION
## Summary

Bump direct Go dependencies, one commit per bump, validated with `task lint` and `task test`.

| Module | From | To | Status |
|--------|------|----|--------|
| github.com/anthropics/anthropic-sdk-go | v1.53.0 | v1.55.0 | bumped |
| google.golang.org/adk | v1.2.0 | v1.4.0 | skipped — lint failure (adka2a deprecated, requires migration to adka2a/v2) |

## Notes

`google.golang.org/adk` v1.4.0 deprecates `google.golang.org/adk/server/adka2a` in favor of `google.golang.org/adk/server/adka2a/v2`, which trips staticcheck SA1019 in `pkg/a2a/`. That bump needs a code migration and is out of scope here.

Assisted-By: docker-agent