### PR TITLE
fix(openai): coalesce system messages for self-hosted and open-model endpoints

### DIFF
--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -218,25 +218,60 @@ func (c *Client) convertMessages(ctx context.Context, messages []chat.Message) [
 	// Coalesce consecutive same-role (system/user) messages into one for generic
 	// OpenAI-compatible endpoints. docker-agent emits a separate system message
 	// per source (the agent instruction plus each toolset's instructions), but
-	// some such backends silently return an empty stream when a request carries
-	// more than one system message. The DMR client already applies this merge
-	// for the same reason. Apply it to explicit openai_chatcompletions configs
-	// and built-in OpenAI-compatible endpoints (Baseten, OVHcloud) that do not
-	// set api_type in ProviderOpts.
+	// some such backends reject a request that carries more than one system
+	// message. Two failure modes have been observed: OVHcloud's Qwen3.5 returns
+	// an empty stream (#3145), while vLLM serving Qwen 3.5/3.6 fails hard with
+	// "HTTP 400: System message must be at the beginning" (#2327, #3344) because
+	// the model's Jinja chat template only allows a system message at index 0.
+	// The DMR client already applies this merge for the same reason.
 	if shouldMergeConsecutiveMessages(&c.ModelConfig) {
 		return oaistream.MergeConsecutiveMessages(converted)
 	}
 	return converted
 }
 
+// openModelHostProviders are built-in OpenAI-compatible aliases that front
+// arbitrary open-weight models (Qwen, GLM, Llama, DeepSeek, ...) whose
+// server-side chat templates may reject a request with more than one system
+// message. First-party APIs with a fixed, vendor-controlled model lineup
+// (openai, mistral, xai, minimax, github-copilot, opencode) tolerate multiple
+// system messages and are deliberately absent so their behavior is unchanged.
+var openModelHostProviders = map[string]bool{
+	"baseten":    true,
+	"ovhcloud":   true,
+	"openrouter": true,
+	"nebius":     true,
+}
+
+// shouldMergeConsecutiveMessages reports whether the chat-completions request
+// should coalesce consecutive same-role messages before sending.
+//
+// docker-agent emits one system message per source (the agent instruction plus
+// each toolset's instructions). Some OpenAI-compatible backends reject more than
+// one system message because the served model's Jinja chat template only allows
+// a system message at index 0 (Qwen 3.5/3.6 on vLLM, #2327/#3344), or return an
+// empty stream (OVHcloud Qwen3.5, #3145). Merging is a safe normalization
+// (same-role content is concatenated), and the DMR client already does it.
+//
+// It is scoped to endpoints that plausibly front such models: explicit
+// chat-completions custom providers, a self-hosted server reached by pointing
+// the openai provider at a custom base_url (vLLM/SGLang), and the open-model
+// host aliases above. The official OpenAI API and other first-party APIs are
+// left untouched.
 func shouldMergeConsecutiveMessages(cfg *latest.ModelConfig) bool {
-	if getAPIType(cfg) == "openai_chatcompletions" {
-		return true
-	}
 	if cfg == nil {
 		return false
 	}
-	return cfg.Provider == "baseten" || cfg.Provider == "ovhcloud"
+	// Custom providers pin the chat-completions api_type in ProviderOpts.
+	if getAPIType(cfg) == "openai_chatcompletions" {
+		return true
+	}
+	// A custom base_url on the openai provider means a self-hosted or
+	// third-party OpenAI-compatible server (e.g. vLLM), not api.openai.com.
+	if cfg.Provider == "openai" && cfg.BaseURL != "" {
+		return true
+	}
+	return openModelHostProviders[cfg.Provider]
 }
 
 // CreateChatCompletionStream creates a streaming chat completion request

--- a/pkg/model/provider/openai/repro_issue3344_test.go
+++ b/pkg/model/provider/openai/repro_issue3344_test.go
@@ -1,0 +1,208 @@
+package openai
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/environment"
+)
+
+// TestReproIssue3344_QwenViaVLLM reproduces
+// https://github.com/docker/docker-agent/issues/3344.
+//
+// docker-agent emits one system message per source: the agent instruction plus
+// each toolset's instructions (see session.go buildInvariantSystemMessages).
+// When such a request is sent to a Qwen 3.5/3.6 model served by vLLM, the
+// model's Jinja chat template rejects any system message that is not the very
+// first message with:
+//
+//	HTTP 400: System message must be at the beginning.
+//
+// (see the unsloth Qwen3.5 chat_template.jinja, and issue #2327).
+//
+// The chat-completions path already coalesces consecutive system messages, but
+// only for a hard-coded allow-list (explicit api_type=openai_chatcompletions,
+// baseten, ovhcloud). Users who point docker-agent at a self-hosted vLLM server
+// with the intuitive `provider: openai` + `base_url` form, or through an
+// OpenAI-compatible alias (openrouter, nebius, ...), bypass the merge and hit
+// the error. These are exactly the configs exercised below: each must send a
+// single system message so the vLLM/Qwen template accepts the request.
+func TestReproIssue3344_QwenViaVLLM(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		cfg  *latest.ModelConfig
+	}{
+		{
+			// The config reported in #3344 / #2327: point the built-in openai
+			// provider at a self-hosted vLLM endpoint via base_url.
+			name: "provider_openai_with_custom_base_url",
+			cfg: &latest.ModelConfig{
+				Provider: "openai",
+				Model:    "Qwen/Qwen3.6-35B",
+				TokenKey: "MY_TOKEN",
+			},
+		},
+		{
+			// OpenAI-compatible aliases (here OpenRouter, which serves Qwen)
+			// resolve to api_type "openai" rather than "openai_chatcompletions",
+			// so they hit the same gap.
+			name: "openai_compatible_alias_openrouter",
+			cfg: &latest.ModelConfig{
+				Provider: "openrouter",
+				Model:    "qwen/qwen3.6-35b",
+				TokenKey: "MY_TOKEN",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assertVLLMQwenAcceptsRequest(t, tc.cfg)
+		})
+	}
+}
+
+// assertVLLMQwenAcceptsRequest stands up a fake vLLM server that enforces the
+// Qwen chat-template rule ("system message must be at the beginning") and
+// asserts that docker-agent's request is accepted, i.e. that it carries a
+// single, leading system message.
+func assertVLLMQwenAcceptsRequest(t *testing.T, cfg *latest.ModelConfig) {
+	t.Helper()
+
+	var (
+		systemCount int
+		mu          sync.Mutex
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+
+		var req struct {
+			Messages []struct {
+				Role string `json:"role"`
+			} `json:"messages"`
+		}
+		_ = json.Unmarshal(body, &req)
+
+		count := 0
+		violation := false
+		for i, m := range req.Messages {
+			if m.Role == "system" {
+				count++
+				if i != 0 {
+					// Mimic the Qwen 3.5/3.6 Jinja template served by vLLM.
+					violation = true
+				}
+			}
+		}
+
+		mu.Lock()
+		systemCount = count
+		mu.Unlock()
+
+		if violation {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{
+					"message": "System message must be at the beginning.",
+					"type":    "BadRequestError",
+					"code":    400,
+				},
+			})
+			return
+		}
+
+		writeSSEResponse(w)
+	}))
+	defer server.Close()
+
+	requestCfg := *cfg
+	requestCfg.BaseURL = server.URL
+	env := environment.NewMapEnvProvider(map[string]string{"MY_TOKEN": "secret"})
+
+	client, err := NewClient(t.Context(), &requestCfg, env)
+	require.NoError(t, err)
+
+	// The message list docker-agent builds for an agent with a toolset: one
+	// system message for the agent instruction, one for the toolset's
+	// instructions, then the user turn.
+	stream, err := client.CreateChatCompletionStream(
+		t.Context(),
+		[]chat.Message{
+			{Role: chat.MessageRoleSystem, Content: "You are a helpful coding assistant."},
+			{Role: chat.MessageRoleSystem, Content: "## Filesystem Tools\n\n- Relative paths resolve from the working directory"},
+			{Role: chat.MessageRoleUser, Content: "List the files."},
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	defer stream.Close()
+
+	var streamErr error
+	for {
+		if _, err := stream.Recv(); err != nil {
+			if !errors.Is(err, io.EOF) {
+				streamErr = err
+			}
+			break
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if streamErr != nil && strings.Contains(streamErr.Error(), "System message must be at the beginning") {
+		t.Fatalf("vLLM/Qwen rejected the request: docker-agent sent %d system messages instead of 1 (issue #3344): %v", systemCount, streamErr)
+	}
+	require.NoError(t, streamErr)
+	assert.Equal(t, 1, systemCount, "docker-agent must coalesce its system messages into a single leading one for vLLM/Qwen (issue #3344)")
+}
+
+// TestShouldMergeConsecutiveMessages_Gating documents which endpoints coalesce
+// consecutive system messages. Self-hosted OpenAI-compatible servers and
+// open-model host aliases (which may front strict-template models like Qwen)
+// merge; first-party APIs with a fixed model lineup (official OpenAI, Mistral,
+// xAI, ...) tolerate multiple system messages and are left untouched.
+func TestShouldMergeConsecutiveMessages_Gating(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cfg  *latest.ModelConfig
+		want bool
+	}{
+		{"nil config", nil, false},
+		{"official openai, no base_url", &latest.ModelConfig{Provider: "openai", Model: "gpt-4o"}, false},
+		{"openai with custom base_url (vLLM)", &latest.ModelConfig{Provider: "openai", Model: "Qwen/Qwen3.6-35B", BaseURL: "http://box:8000/v1"}, true},
+		{"open-model host alias openrouter", &latest.ModelConfig{Provider: "openrouter", Model: "qwen/qwen3.6-35b"}, true},
+		{"open-model host alias nebius", &latest.ModelConfig{Provider: "nebius", Model: "Qwen/Qwen3"}, true},
+		{"baseten", &latest.ModelConfig{Provider: "baseten", Model: "zai-org/GLM-5.2"}, true},
+		{"ovhcloud", &latest.ModelConfig{Provider: "ovhcloud", Model: "Qwen3.5-397B-A17B"}, true},
+		{"explicit api_type openai_chatcompletions", &latest.ModelConfig{Provider: "custom", Model: "qwen3", ProviderOpts: map[string]any{"api_type": "openai_chatcompletions"}}, true},
+		// First-party APIs with fixed model lineups: unchanged (no merge).
+		{"first-party mistral", &latest.ModelConfig{Provider: "mistral", Model: "mistral-small"}, false},
+		{"first-party xai", &latest.ModelConfig{Provider: "xai", Model: "grok-4"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, shouldMergeConsecutiveMessages(tt.cfg))
+		})
+	}
+}


### PR DESCRIPTION
## Problem

docker-agent emits one system message per source: the agent instruction plus each toolset's instructions (see `session.go` `buildInvariantSystemMessages`), and a handoff prompt in multi-agent teams. Some OpenAI-compatible backends reject a request that carries more than one system message.

Reported in #3344 (previously #2327): Qwen 3.5/3.6 served by vLLM fails with

> HTTP 400: System message must be at the beginning.

The model's Jinja chat template raises `raise_exception('System message must be at the beginning.')` for any system message that is not at index 0.

## Root cause

The chat-completions path already coalesces consecutive system messages, but `shouldMergeConsecutiveMessages` gated it to a narrow allow-list, so common vLLM configs fell through:

| Config | merged before this PR | result |
| --- | --- | --- |
| custom provider (api_type auto-set to `openai_chatcompletions`) | yes | ok |
| `provider: baseten` / `ovhcloud` | yes | ok |
| `provider: openai` + `base_url` (self-hosted vLLM) | no | HTTP 400 |
| `openrouter` / `nebius` + Qwen | no | HTTP 400 |

The config in the report (`provider: openai` with a `base_url` pointing at a self-hosted vLLM server) is the third row.

## Fix

Extend `shouldMergeConsecutiveMessages` to cover the endpoints that plausibly front a strict-template model, while leaving first-party APIs untouched:

- `provider: openai` with a custom `base_url` (self-hosted vLLM / SGLang), the exact reported config.
- Open-model host aliases that serve models such as Qwen: `openrouter`, `nebius` (alongside the existing `baseten`, `ovhcloud`).
- Unchanged: explicit `api_type: openai_chatcompletions` (custom providers already merged).

First-party APIs with a fixed model lineup (official OpenAI, Mistral, xAI, MiniMax, GitHub Copilot, OpenCode) tolerate multiple system messages and are deliberately excluded, so their behavior and recorded e2e cassettes are unchanged. Merging is a safe normalization (same-role content is concatenated), runs only on the Chat Completions path (the Responses path uses a separate converter), and matches what the DMR client already does.

## Validation

Reproduced end to end using the real binary output and the real upstream Qwen chat template:

| docker-agent binary | system messages sent | real strict Qwen3.5 `chat_template.jinja` rendered via jinja2 (the engine transformers/vLLM use) |
| --- | --- | --- |
| before | 2 (`[system, system, user]`) | rejected: `System message must be at the beginning.` |
| after | 1 (`[system, user]`, merged) | rendered ok |

The request bodies were captured from a real `docker-agent run --exec` against a `provider: openai` + `base_url` endpoint. The template is the upstream strict version hosted at `unsloth/Qwen3.5-2B@8b63d90c32e8` (the guard cited in #2327).

Tests (no network or GPU dependency, CI-safe):

- `TestReproIssue3344_QwenViaVLLM`: fake vLLM/Qwen server enforcing the leading-system-message rule, covering `provider: openai` + `base_url` and the `openrouter` alias.
- `TestShouldMergeConsecutiveMessages_Gating`: table asserting which endpoints merge, including that first-party `mistral` and `xai` do not.

Existing `system_message_merge_test.go` (baseten, ovhcloud, explicit `api_type`) and the Mistral e2e cassette tests (`TestExec_Mistral`, `TestExec_Mistral_ToolCall`) stay green.

## Note on real-hardware testing

This change was not validated against a live vLLM deployment: no GPU was available to run vLLM with model weights. Instead the exact failing code path (server-side Jinja chat-template rendering) was reproduced faithfully with the real captured request body and the real upstream Qwen chat template, plus the CI tests above.

Re #3344
