### PR TITLE
feat: add Groq as a supported model provider

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -182,7 +182,7 @@
       "properties": {
         "provider": {
           "type": "string",
-          "description": "The underlying provider type. Defaults to \"openai\" when not set. Supported values: openai, anthropic, google, amazon-bedrock, dmr, and any built-in alias (requesty, openrouter, azure, xai, ollama, mistral, baseten, ovhcloud, etc.).",
+          "description": "The underlying provider type. Defaults to \"openai\" when not set. Supported values: openai, anthropic, google, amazon-bedrock, dmr, and any built-in alias (requesty, openrouter, azure, xai, ollama, mistral, baseten, ovhcloud, groq, etc.).",
           "examples": [
             "openai",
             "anthropic",

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -149,6 +149,8 @@
       url: /providers/baseten/
     - title: OVHcloud
       url: /providers/ovhcloud/
+    - title: Groq
+      url: /providers/groq/
     - title: MiniMax
       url: /providers/minimax/
     - title: OpenRouter

--- a/docs/concepts/models/index.md
+++ b/docs/concepts/models/index.md
@@ -83,6 +83,7 @@ for details.
 | MiniMax             | `minimax`        | MiniMax models                       | `MINIMAX_API_KEY`                   |
 | Baseten             | `baseten`        | DeepSeek, Kimi, GLM, Llama models    | `BASETEN_API_KEY`                   |
 | OVHcloud            | `ovhcloud`       | Qwen, Llama, Mistral, DeepSeek (EU-hosted) | `OVH_AI_ENDPOINTS_ACCESS_TOKEN` |
+| Groq                | `groq`           | Llama, Qwen, GPT-OSS (fast inference) | `GROQ_API_KEY`                     |
 | Requesty            | `requesty`       | Multi-provider gateway               | `REQUESTY_API_KEY`                  |
 | OpenRouter          | `openrouter`     | Multi-provider gateway               | `OPENROUTER_API_KEY`                |
 | Azure OpenAI        | `azure`          | gpt-4o, gpt-5 on Azure               | `AZURE_API_KEY` + `base_url`        |

--- a/docs/configuration/models/index.md
+++ b/docs/configuration/models/index.md
@@ -17,7 +17,7 @@ models:
     first_available: [list] # Optional: candidate model refs, tried in order by available credentials.
                             # Mutually exclusive with other model settings.
     provider: string # Required unless using first_available. One of: openai, anthropic, google, amazon-bedrock,
-                     # dmr, mistral, xai, nebius, minimax, baseten, ovhcloud, requesty, openrouter,
+                     # dmr, mistral, xai, nebius, minimax, baseten, ovhcloud, groq, requesty, openrouter,
                      # azure, ollama, github-copilot, or a named provider defined
                      # under the top-level `providers:` section.
     model: string # Required: model identifier
@@ -48,7 +48,7 @@ models:
 | Property              | Type       | Required | Description                                                                           |
 | --------------------- | ---------- | -------- | ------------------------------------------------------------------------------------- |
 | `first_available`     | array      | ✗        | Candidate model references tried in order; selects the first whose credentials are configured. Mutually exclusive with other model settings. |
-| `provider`            | string     | ✓/✗      | Required for regular model definitions; omitted for `first_available` selectors. Provider: `openai`, `anthropic`, `google`, `amazon-bedrock`, `dmr`, `mistral`, `xai`, `nebius`, `minimax`, `baseten`, `ovhcloud`, `requesty`, `openrouter`, `azure`, `ollama`, `github-copilot`, or any [named provider]({{ '/providers/custom/' | relative_url }}). |
+| `provider`            | string     | ✓/✗      | Required for regular model definitions; omitted for `first_available` selectors. Provider: `openai`, `anthropic`, `google`, `amazon-bedrock`, `dmr`, `mistral`, `xai`, `nebius`, `minimax`, `baseten`, `ovhcloud`, `groq`, `requesty`, `openrouter`, `azure`, `ollama`, `github-copilot`, or any [named provider]({{ '/providers/custom/' | relative_url }}). |
 | `model`               | string     | ✓/✗      | Required for regular model definitions; omitted for `first_available` selectors. Model name (e.g., `gpt-4o`, `claude-sonnet-4-5`, `gemini-3.5-flash`) |
 | `temperature`         | float      | ✗        | Sampling randomness. Range is provider-dependent — typically `0.0–2.0` (Anthropic caps at `1.0`). `0.0` is deterministic. |
 | `max_tokens`          | int        | ✗        | Maximum response length in tokens                                                     |
@@ -404,7 +404,7 @@ See the [Anthropic provider page]({{ '/providers/anthropic/#thinking-display' | 
 ## Custom HTTP Headers
 
 For OpenAI-compatible providers (`openai`, `github-copilot`, `mistral`, `xai`,
-`nebius`, `minimax`, `baseten`, `ovhcloud`, `requesty`, `openrouter`, `ollama`, and any custom provider using the OpenAI API),
+`nebius`, `minimax`, `baseten`, `ovhcloud`, `groq`, `requesty`, `openrouter`, `ollama`, and any custom provider using the OpenAI API),
 `provider_opts.http_headers` adds arbitrary HTTP headers to every outgoing
 request:
 

--- a/docs/providers/groq/index.md
+++ b/docs/providers/groq/index.md
@@ -1,0 +1,99 @@
+---
+title: "Groq"
+description: "Use Groq fast-inference models with docker-agent."
+permalink: /providers/groq/
+---
+
+# Groq
+
+_Use Groq models with docker-agent._
+
+## Overview
+
+[Groq](https://groq.com/) serves open-weight models on its LPU inference engine
+through an OpenAI-compatible API, with a focus on very low latency. docker-agent
+includes built-in support for Groq as an alias provider.
+
+## Setup
+
+1. Create an API key from the [Groq Console](https://console.groq.com/keys).
+2. Set the environment variable:
+
+   ```bash
+   export GROQ_API_KEY=your-api-key
+   ```
+
+## Usage
+
+### Inline Syntax
+
+The simplest way to use Groq:
+
+```yaml
+agents:
+  root:
+    model: groq/llama-3.3-70b-versatile
+    description: Assistant using Groq
+    instruction: You are a helpful assistant.
+```
+
+### Named Model
+
+For more control over parameters:
+
+```yaml
+models:
+  groq_model:
+    provider: groq
+    model: llama-3.3-70b-versatile
+    temperature: 0.7
+    max_tokens: 8192
+
+agents:
+  root:
+    model: groq_model
+    description: Assistant using Groq
+    instruction: You are a helpful assistant.
+```
+
+## Available Models
+
+Groq hosts a rotating catalogue of open-weight models. Check the
+[Groq models documentation](https://console.groq.com/docs/models) for current
+model IDs, context limits, and rate limits.
+
+| Model | Description |
+| --- | --- |
+| `llama-3.3-70b-versatile` | Llama 3.3 70B, reliable general-purpose chat and tool calling |
+| `llama-3.1-8b-instant` | Llama 3.1 8B, fastest and cheapest |
+| `openai/gpt-oss-120b` | GPT-OSS 120B, strong reasoning and tool calling |
+| `openai/gpt-oss-20b` | GPT-OSS 20B, compact reasoning model |
+| `qwen/qwen3-32b` | Qwen3 32B, reasoning and tool calling |
+| `meta-llama/llama-4-scout-17b-16e-instruct` | Llama 4 Scout MoE |
+
+> Model IDs are case-sensitive and must be passed exactly as the catalogue lists
+> them.
+
+## How It Works
+
+Groq is implemented as a built-in alias in docker-agent:
+
+- **API Type:** OpenAI-compatible (`openai_chatcompletions`)
+- **Base URL:** `https://api.groq.com/openai/v1`
+- **Token Variable:** `GROQ_API_KEY`
+
+## Example: Code Assistant
+
+```yaml
+agents:
+  coder:
+    model: groq/llama-3.3-70b-versatile
+    description: Code assistant using Llama 3.3
+    instruction: |
+      You are an expert programmer.
+      Write clean, well-documented code and follow language best practices.
+    toolsets:
+      - type: filesystem
+      - type: shell
+      - type: think
+```

--- a/docs/providers/overview/index.md
+++ b/docs/providers/overview/index.md
@@ -67,6 +67,7 @@ docker-agent also includes built-in aliases for these providers:
 | MiniMax        | `minimax`        | `MINIMAX_API_KEY`                   |
 | Baseten        | `baseten`        | `BASETEN_API_KEY`                   |
 | OVHcloud       | `ovhcloud`       | `OVH_AI_ENDPOINTS_ACCESS_TOKEN`     |
+| Groq           | `groq`           | `GROQ_API_KEY`                      |
 | Requesty       | `requesty`       | `REQUESTY_API_KEY`                  |
 | OpenRouter     | `openrouter`     | `OPENROUTER_API_KEY`                |
 | Azure OpenAI   | `azure`          | `AZURE_API_KEY` + `base_url`        |

--- a/examples/README.md
+++ b/examples/README.md
@@ -195,6 +195,7 @@ remote MCP endpoints.
 | [`nebius.yaml`](nebius.yaml) | Nebius cloud provider. |
 | [`baseten.yaml`](baseten.yaml) | Baseten cloud provider. |
 | [`ovhcloud.yaml`](ovhcloud.yaml) | OVHcloud AI Endpoints provider. |
+| [`groq.yaml`](groq.yaml) | Groq fast-inference provider. |
 | [`grok.yaml`](grok.yaml) | xAI Grok model. |
 | [`github-copilot.yaml`](github-copilot.yaml) | GitHub Copilot models via OAuth device-flow. |
 | [`fallback_models.yaml`](fallback_models.yaml) | Automatic fallback to a secondary model when the primary fails. |

--- a/examples/groq.yaml
+++ b/examples/groq.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=../agent-schema.json
+
+models:
+  groq_model:
+    provider: groq
+    model: llama-3.3-70b-versatile
+
+agents:
+  root:
+    model: groq_model
+    description: Assistant using Groq
+    instruction: |
+      You are a helpful assistant.
+    toolsets:
+      - type: filesystem
+      - type: shell
+      - type: think

--- a/pkg/config/auto.go
+++ b/pkg/config/auto.go
@@ -46,6 +46,7 @@ var cloudProviders = []providerConfig{
 	{"openrouter", []string{"OPENROUTER_API_KEY"}, "OPENROUTER_API_KEY"},
 	{"baseten", []string{"BASETEN_API_KEY"}, "BASETEN_API_KEY"},
 	{"ovhcloud", []string{"OVH_AI_ENDPOINTS_ACCESS_TOKEN"}, "OVH_AI_ENDPOINTS_ACCESS_TOKEN"},
+	{"groq", []string{"GROQ_API_KEY"}, "GROQ_API_KEY"},
 	{"amazon-bedrock", []string{
 		"AWS_BEARER_TOKEN_BEDROCK",
 		"AWS_ACCESS_KEY_ID",
@@ -111,6 +112,7 @@ var DefaultModels = map[string]string{
 	"openrouter":     "meta-llama/llama-3.3-70b-instruct",
 	"baseten":        "deepseek-ai/DeepSeek-V3.1",
 	"ovhcloud":       "Qwen3.5-397B-A17B",
+	"groq":           "llama-3.3-70b-versatile",
 	"amazon-bedrock": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
 	"opencode-go":    "deepseek-v4-flash",
 	"opencode-zen":   "deepseek-v4-flash-free",

--- a/pkg/config/auto_test.go
+++ b/pkg/config/auto_test.go
@@ -70,6 +70,13 @@ func TestAvailableProviders_NoGateway(t *testing.T) {
 			expectedProvider: "ovhcloud",
 		},
 		{
+			name: "groq api key present",
+			envVars: map[string]string{
+				"GROQ_API_KEY": "test-key",
+			},
+			expectedProvider: "groq",
+		},
+		{
 			name:             "no api keys - defaults to dmr",
 			envVars:          map[string]string{},
 			expectedProvider: "dmr",
@@ -250,6 +257,15 @@ func TestAutoModelConfig(t *testing.T) {
 			expectedMaxTokens: 32000,
 		},
 		{
+			name: "groq provider",
+			envVars: map[string]string{
+				"GROQ_API_KEY": "test-key",
+			},
+			expectedProvider:  "groq",
+			expectedModel:     "llama-3.3-70b-versatile",
+			expectedMaxTokens: 32000,
+		},
+		{
 			name:              "dmr provider (no api keys)",
 			envVars:           map[string]string{},
 			expectedProvider:  "dmr",
@@ -331,7 +347,7 @@ func TestDefaultModels(t *testing.T) {
 	t.Parallel()
 
 	// Test that DefaultModels map has all expected providers
-	expectedProviders := []string{"openai", "anthropic", "google", "dmr", "mistral", "openrouter", "baseten", "ovhcloud", "amazon-bedrock", "opencode-zen", "opencode-go"}
+	expectedProviders := []string{"openai", "anthropic", "google", "dmr", "mistral", "openrouter", "baseten", "ovhcloud", "groq", "amazon-bedrock", "opencode-zen", "opencode-go"}
 
 	for _, provider := range expectedProviders {
 		t.Run(provider, func(t *testing.T) {
@@ -350,6 +366,7 @@ func TestDefaultModels(t *testing.T) {
 	assert.Equal(t, "meta-llama/llama-3.3-70b-instruct", DefaultModels["openrouter"])
 	assert.Equal(t, "deepseek-ai/DeepSeek-V3.1", DefaultModels["baseten"])
 	assert.Equal(t, "Qwen3.5-397B-A17B", DefaultModels["ovhcloud"])
+	assert.Equal(t, "llama-3.3-70b-versatile", DefaultModels["groq"])
 	assert.Equal(t, "global.anthropic.claude-sonnet-4-5-20250929-v1:0", DefaultModels["amazon-bedrock"])
 	assert.Equal(t, "deepseek-v4-flash", DefaultModels["opencode-go"])
 	assert.Equal(t, "deepseek-v4-flash-free", DefaultModels["opencode-zen"])
@@ -359,7 +376,7 @@ func TestAutoModelConfig_IntegrationWithDefaultModels(t *testing.T) {
 	t.Parallel()
 
 	// Verify that AutoModelConfig always returns a model from DefaultModels
-	providers := []string{"openai", "anthropic", "google", "mistral", "openrouter", "baseten", "ovhcloud", "opencode-zen"}
+	providers := []string{"openai", "anthropic", "google", "mistral", "openrouter", "baseten", "ovhcloud", "groq", "opencode-zen"}
 
 	for _, provider := range providers {
 		t.Run(provider, func(t *testing.T) {
@@ -383,6 +400,8 @@ func TestAutoModelConfig_IntegrationWithDefaultModels(t *testing.T) {
 				envVars["BASETEN_API_KEY"] = "test-key"
 			case "ovhcloud":
 				envVars["OVH_AI_ENDPOINTS_ACCESS_TOKEN"] = "test-token"
+			case "groq":
+				envVars["GROQ_API_KEY"] = "test-key"
 			case "opencode-zen":
 				envVars["OPENCODE_API_KEY"] = "test-key"
 			}
@@ -496,13 +515,21 @@ func TestAvailableProviders_PrecedenceOrder(t *testing.T) {
 	providers = AvailableProviders(t.Context(), "", env)
 	assert.Equal(t, "baseten", providers[0])
 
-	// ovhcloud wins over amazon-bedrock
+	// ovhcloud wins over groq
 	env = environment.NewMapEnvProvider(map[string]string{
 		"OVH_AI_ENDPOINTS_ACCESS_TOKEN": "test-token",
-		"AWS_ACCESS_KEY_ID":             "test-key",
+		"GROQ_API_KEY":                  "test-key",
 	})
 	providers = AvailableProviders(t.Context(), "", env)
 	assert.Equal(t, "ovhcloud", providers[0])
+
+	// groq wins over amazon-bedrock
+	env = environment.NewMapEnvProvider(map[string]string{
+		"GROQ_API_KEY":      "test-key",
+		"AWS_ACCESS_KEY_ID": "test-key",
+	})
+	providers = AvailableProviders(t.Context(), "", env)
+	assert.Equal(t, "groq", providers[0])
 
 	// Only OPENCODE_API_KEY set - opencode-zen should win (higher priority than opencode-go)
 	env = environment.NewMapEnvProvider(map[string]string{

--- a/pkg/model/provider/aliases.go
+++ b/pkg/model/provider/aliases.go
@@ -78,6 +78,11 @@ var Aliases = map[string]Alias{
 		BaseURL:     "https://oai.endpoints.kepler.ai.cloud.ovh.net/v1",
 		TokenEnvVar: "OVH_AI_ENDPOINTS_ACCESS_TOKEN",
 	},
+	"groq": {
+		APIType:     "openai",
+		BaseURL:     "https://api.groq.com/openai/v1",
+		TokenEnvVar: "GROQ_API_KEY",
+	},
 	"github-copilot": {
 		APIType:     "openai",
 		BaseURL:     "https://api.githubcopilot.com",

--- a/pkg/model/provider/aliases_test.go
+++ b/pkg/model/provider/aliases_test.go
@@ -71,6 +71,20 @@ func TestOVHcloudAlias(t *testing.T) {
 	assert.True(t, IsCatalogProvider("ovhcloud"))
 }
 
+func TestGroqAlias(t *testing.T) {
+	t.Parallel()
+
+	alias, ok := LookupAlias("groq")
+	require.True(t, ok)
+	assert.Equal(t, Alias{
+		APIType:     "openai",
+		BaseURL:     "https://api.groq.com/openai/v1",
+		TokenEnvVar: "GROQ_API_KEY",
+	}, alias)
+	assert.True(t, IsKnownProvider("groq"))
+	assert.True(t, IsCatalogProvider("groq"))
+}
+
 func TestEachAlias(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Adds `groq` as a built-in OpenAI-compatible alias provider, following the `baseten` pattern. Users can write `provider: groq` (or inline `groq/<model>`) and get the correct base URL, token env var, and auto-detection with no `providers:` block.

- API type: `openai`
- Base URL: `https://api.groq.com/openai/v1`
- Token env var: `GROQ_API_KEY`
- Default / featured model: `llama-3.3-70b-versatile`

## Definition of Done

| Item from #3346 | Status |
| --- | --- |
| Alias entry `groq` (openai, base URL, `GROQ_API_KEY`) | done, `pkg/model/provider/aliases.go` |
| Unit test: alias resolves and `IsCatalogProvider("groq")` is true | done, `pkg/model/provider/aliases_test.go` (`TestGroqAlias`) |
| Provider appears in the catalog via `CatalogProviders()` | done, alias has a `BaseURL` so it is included automatically |
| `task test` and `task lint` pass | see "Validation" below |
| Example YAML using a Groq model | done, `examples/groq.yaml` |

## Beyond the minimum (to match the `baseten` and `ovhcloud` precedent)

- Auto-detection: added to `cloudProviders` (priority after `ovhcloud`, before `amazon-bedrock`) and to `DefaultModels` in `pkg/config/auto.go`, with matching cases in `pkg/config/auto_test.go`.
- Docs: provider page (`docs/providers/groq/index.md`), nav entry, and the model tables in `concepts/models`, `configuration/models`, and `providers/overview`.
- Schema: `groq` added to the `provider` enum description in `agent-schema.json`.

## Design notes

- Groq is present in models.dev, so it is treated as a first-class catalog provider and is deliberately not added to `modelsDevAbsentProviders`. `TestParseExamples` validates `groq/llama-3.3-70b-versatile` against the models.dev catalog and passes.
- `groq` is intentionally left out of `shouldMergeConsecutiveMessages`. That workaround targets the Qwen3 empty-stream behaviour observed on baseten and ovhcloud when a request carries more than one system message; the groq default is a Llama model. See "Residual verification" for the one open item.

## Validation

Run in a sandbox where the module proxy could not be reached, so the full `task build` / `task test` could not run there (the recently bumped `anthropic-sdk-go v1.55.0` was not fetchable). Everything runnable offline is green:

| Check | Result |
| --- | --- |
| Build of changed packages | pass |
| `gofmt`, `go vet`, `golangci-lint` on changed packages | 0 issues |
| `pkg/config` tests (incl. `TestParseExamples/groq.yaml`, precedence, default models) | pass |
| Alias resolution, catalog membership, auto-selection, default model | verified at runtime |

CI runs the full `task test` and `task lint` on a clean network.

## Residual verification

One live check is recommended before merge: run an agent with multiple toolsets (multiple system messages) against `llama-3.3-70b-versatile` on Groq to confirm the endpoint streams normally. If Groq shows the same empty-stream behaviour as Qwen3 on baseten/ovhcloud, add `cfg.Provider == "groq"` to `shouldMergeConsecutiveMessages` plus a `TestGroq_MergesConsecutiveSystemMessages` case. If that option seems more appropriate up front, it can be added to this PR.

Closes #3346
