### PR TITLE
docs: group and collapse left navigation sections

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -44,55 +44,65 @@
       url: /configuration/routing/
 
 - section: Built-in Tools
-  items:
-    - title: Filesystem
-      url: /tools/filesystem/
-    - title: Shell
-      url: /tools/shell/
-    - title: Think
-      url: /tools/think/
-    - title: Plan
-      url: /tools/plan/
-    - title: Session Plan
-      url: /tools/session_plan/
-    - title: Session Context
-      url: /tools/session_context/
-    - title: Todo
-      url: /tools/todo/
-    - title: Memory
-      url: /tools/memory/
-    - title: Tasks
-      url: /tools/tasks/
-    - title: Fetch
-      url: /tools/fetch/
-    - title: Script
-      url: /tools/script/
-    - title: LSP
-      url: /tools/lsp/
-    - title: API
-      url: /tools/api/
-    - title: User Prompt
-      url: /tools/user-prompt/
-    - title: Open URL
-      url: /tools/open-url/
-    - title: Transfer Task
-      url: /tools/transfer-task/
-    - title: Background Agents
-      url: /tools/background-agents/
-    - title: Handoff
-      url: /tools/handoff/
-    - title: Model Picker
-      url: /tools/model-picker/
-    - title: OpenAPI
-      url: /tools/openapi/
-    - title: MCP
-      url: /tools/mcp/
-    - title: A2A
-      url: /tools/a2a/
-    - title: RAG
-      url: /tools/rag/
-    - title: MCP Catalog
-      url: /tools/mcp-catalog/
+  groups:
+    - label: File & Shell
+      items:
+        - title: Filesystem
+          url: /tools/filesystem/
+        - title: Shell
+          url: /tools/shell/
+        - title: Script
+          url: /tools/script/
+        - title: Open URL
+          url: /tools/open-url/
+        - title: Fetch
+          url: /tools/fetch/
+    - label: Agent Coordination
+      items:
+        - title: A2A
+          url: /tools/a2a/
+        - title: Handoff
+          url: /tools/handoff/
+        - title: Transfer Task
+          url: /tools/transfer-task/
+        - title: Background Agents
+          url: /tools/background-agents/
+    - label: Memory & Knowledge
+      items:
+        - title: Memory
+          url: /tools/memory/
+        - title: RAG
+          url: /tools/rag/
+        - title: MCP Catalog
+          url: /tools/mcp-catalog/
+        - title: MCP
+          url: /tools/mcp/
+    - label: Planning & Reasoning
+      items:
+        - title: Think
+          url: /tools/think/
+        - title: Plan
+          url: /tools/plan/
+        - title: Session Plan
+          url: /tools/session_plan/
+        - title: Todo
+          url: /tools/todo/
+        - title: Tasks
+          url: /tools/tasks/
+    - label: Interaction
+      items:
+        - title: User Prompt
+          url: /tools/user-prompt/
+        - title: Model Picker
+          url: /tools/model-picker/
+        - title: Session Context
+          url: /tools/session_context/
+        - title: LSP
+          url: /tools/lsp/
+        - title: OpenAPI
+          url: /tools/openapi/
+        - title: API
+          url: /tools/api/
 
 - section: Features
   items:
@@ -162,24 +172,25 @@
     - title: Provider Definitions
       url: /providers/custom/
 
-- section: Guides
-  items:
-    - title: Tips & Best Practices
-      url: /guides/tips/
-    - title: Thinking / Reasoning
-      url: /guides/thinking/
-    - title: Managing Secrets
-      url: /guides/secrets/
-    - title: Go SDK
-      url: /guides/go-sdk/
-
-- section: Community
-  items:
-    - title: Contributing
-      url: /community/contributing/
-    - title: Troubleshooting
-      url: /community/troubleshooting/
-    - title: Telemetry
-      url: /community/telemetry/
-    - title: OpenTelemetry Tracing
-      url: /community/opentelemetry/
+- section: Resources
+  groups:
+    - label: Guides
+      items:
+        - title: Tips & Best Practices
+          url: /guides/tips/
+        - title: Thinking / Reasoning
+          url: /guides/thinking/
+        - title: Managing Secrets
+          url: /guides/secrets/
+        - title: Go SDK
+          url: /guides/go-sdk/
+    - label: Community
+      items:
+        - title: Contributing
+          url: /community/contributing/
+        - title: Troubleshooting
+          url: /community/troubleshooting/
+        - title: Telemetry
+          url: /community/telemetry/
+        - title: OpenTelemetry Tracing
+          url: /community/opentelemetry/

--- a/docs/_includes/page-nav.html
+++ b/docs/_includes/page-nav.html
@@ -1,9 +1,18 @@
-{% comment %}Build a flat list of all pages from nav data and find prev/next{% endcomment %}
+{% comment %}Build a flat list of all pages from nav data (handles both flat items and grouped items) and find prev/next{% endcomment %}
 {% assign all_pages = "" | split: "" %}
 {% for group in site.data.nav %}
-  {% for item in group.items %}
-    {% assign all_pages = all_pages | push: item %}
-  {% endfor %}
+  {% if group.items %}
+    {% for item in group.items %}
+      {% assign all_pages = all_pages | push: item %}
+    {% endfor %}
+  {% endif %}
+  {% if group.groups %}
+    {% for sub in group.groups %}
+      {% for item in sub.items %}
+        {% assign all_pages = all_pages | push: item %}
+      {% endfor %}
+    {% endfor %}
+  {% endif %}
 {% endfor %}
 
 {% assign current_index = -1 %}

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -8,7 +8,7 @@
 
   {% comment %}
     Source path of the current page on disk, used by the right-column
-    \"Edit this page\" link in js/app.js. We point at GitHub's web editor
+    "Edit this page" link in js/app.js. We point at GitHub's web editor
     on the configured repo + branch.
   {% endcomment %}
   <meta name="docs-edit-url" content="https://github.com/docker/docker-agent/edit/main/docs/{{ page.path | replace_first: 'docs/', '' | default: 'index.md' }}">
@@ -35,12 +35,36 @@
   <nav class="sidebar" id="sidebar" role="navigation" aria-label="Documentation navigation">
     <div class="sidebar-tagline">{{ site.tagline | default: 'Run AI agents like containers.' }}</div>
     {% for group in site.data.nav %}
-    <div class="sidebar-section">
-      <div class="sidebar-heading">{{ group.section }}</div>
-      {% for item in group.items %}
-      <a class="sidebar-link{% if page.url == item.url %} active{% endif %}" href="{{ item.url | relative_url }}">{{ item.title }}</a>
-      {% endfor %}
-    </div>
+      {% comment %}Determine whether this section contains the current page{% endcomment %}
+      {% assign section_active = false %}
+      {% if group.items %}
+        {% for item in group.items %}
+          {% if item.url == page.url %}{% assign section_active = true %}{% endif %}
+        {% endfor %}
+      {% endif %}
+      {% if group.groups %}
+        {% for sub in group.groups %}
+          {% for item in sub.items %}
+            {% if item.url == page.url %}{% assign section_active = true %}{% endif %}
+          {% endfor %}
+        {% endfor %}
+      {% endif %}
+    <details class="sidebar-section"{% if section_active %} open{% endif %} title="{{ group.section }}">
+      <summary class="sidebar-heading">{{ group.section }}</summary>
+      {% if group.items %}
+        {% for item in group.items %}
+        <a class="sidebar-link{% if page.url == item.url %} active{% endif %}" href="{{ item.url | relative_url }}">{{ item.title }}</a>
+        {% endfor %}
+      {% endif %}
+      {% if group.groups %}
+        {% for sub in group.groups %}
+        <div class="sidebar-subheading">{{ sub.label }}</div>
+          {% for item in sub.items %}
+        <a class="sidebar-link sidebar-link--sub{% if page.url == item.url %} active{% endif %}" href="{{ item.url | relative_url }}">{{ item.title }}</a>
+          {% endfor %}
+        {% endfor %}
+      {% endif %}
+    </details>
     {% endfor %}
   </nav>
 

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -310,6 +310,15 @@ body {
   margin-bottom: 4px;
 }
 
+/* Remove the default <details> triangle marker */
+.sidebar-section > summary {
+  list-style: none;
+}
+.sidebar-section > summary::marker,
+.sidebar-section > summary::-webkit-details-marker {
+  display: none;
+}
+
 .sidebar-heading {
   padding: 10px 20px 6px;
   font-size: 0.65rem;
@@ -318,6 +327,44 @@ body {
   letter-spacing: 0.1em;
   color: var(--text-muted);
   user-select: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+/* Chevron that rotates open */
+.sidebar-heading::after {
+  content: '';
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  margin-right: 4px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'%3E%3Cpath d='M2 3.5 L5 6.5 L8 3.5' stroke='%23999' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-size: contain;
+  transition: transform 0.2s ease;
+  transform: rotate(-90deg);
+  flex-shrink: 0;
+}
+
+details.sidebar-section[open] > summary.sidebar-heading::after {
+  transform: rotate(0deg);
+}
+
+.sidebar-subheading {
+  padding: 8px 20px 4px 24px;
+  font-size: 0.6rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  user-select: none;
+  opacity: 0.75;
+}
+
+.sidebar-link.sidebar-link--sub {
+  padding-left: 32px;
 }
 
 .sidebar-link {


### PR DESCRIPTION
Closes #3359

The docs left-nav had ~75 items listed flat, making it hard to scan. This PR reduces visual length without moving or renaming any pages.

**Changes:**
- Each top-level section is now a collapsible `<details>`/`<summary>` accordion; the active section opens automatically
- Built-in Tools (24 items) split into 5 sub-categories: File & Shell, Agent Coordination, Memory & Knowledge, Planning & Reasoning, Interaction
- Guides + Community merged into a single "Resources" collapsible section
- Prev/next page-nav updated to traverse sub-groups so no page is dropped
- CSS: summary chevron (rotates on open), sub-category labels, sub-item indent

All 81 nav URLs preserved verbatim. Jekyll build clean (only pre-existing Liquid warnings in hooks/agents docs). Go code untouched.