### PR TITLE
fix(docs): restore inline code contrast in light mode

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -663,7 +663,7 @@ details.sidebar-section[open] > summary.sidebar-heading::after {
 
 /* Rouge / highlighter-rouge overrides */
 .content pre[class*="language-"],
-.content code[class*="language-"],
+.content pre code[class*="language-"],
 .content .highlighter-rouge pre.highlight,
 .content .highlighter-rouge pre.highlight code {
   background: var(--bg-code-block);


### PR DESCRIPTION
Inline `code` spans like `opencode-zen` and `OPENCODE_API_KEY` were nearly invisible in light mode: light gray text (#C8CFDA) on a near-white background (#F6F8FA).

**Root cause:** Kramdown+Rouge tags inline code with `class="language-plaintext highlighter-rouge"`. The Rouge block-code override selector `.content code[class*="language-"]` matched these spans and forced the low-contrast colours.

**Fix:** Scope the selector to `.content pre code[class*="language-"]`. Inline code now falls back to `.content code`, which in light mode renders as blue-600 (#1A4DD9) on white (#FFFFFF) with a visible border — the site's existing design intent. Dark mode and block code are unaffected.

**Testing:** Go build ✓, custom linter ✓, go mod tidy ✓. CSS change only.