### PR TITLE
feat: collapse file picker shortcuts to one line on wide dialogs

### DIFF
--- a/pkg/tui/dialog/base.go
+++ b/pkg/tui/dialog/base.go
@@ -136,9 +136,10 @@ func RenderHelp(text string, contentWidth int) string {
 	return styles.DialogHelpStyle.Width(contentWidth).Align(lipgloss.Center).Render(text)
 }
 
-// RenderHelpKeys renders key bindings in the same style as the main TUI's status bar.
-// Each binding is a pair of [key, description] strings.
-func RenderHelpKeys(contentWidth int, bindings ...string) string {
+// helpKeysLine formats key bindings into a single line, styled like the main
+// TUI's status bar. Each binding is a pair of [key, description] strings. It
+// returns "" for empty or malformed input.
+func helpKeysLine(bindings ...string) string {
 	if len(bindings) == 0 || len(bindings)%2 != 0 {
 		return ""
 	}
@@ -150,25 +151,23 @@ func RenderHelpKeys(contentWidth int, bindings ...string) string {
 		parts = append(parts, keyPart+" "+descPart)
 	}
 
-	return styles.BaseStyle.Width(contentWidth).Align(lipgloss.Center).Render(strings.Join(parts, "  "))
+	return strings.Join(parts, "  ")
+}
+
+// RenderHelpKeys renders key bindings in the same style as the main TUI's status bar.
+// Each binding is a pair of [key, description] strings.
+func RenderHelpKeys(contentWidth int, bindings ...string) string {
+	if len(bindings) == 0 || len(bindings)%2 != 0 {
+		return ""
+	}
+	return styles.BaseStyle.Width(contentWidth).Align(lipgloss.Center).Render(helpKeysLine(bindings...))
 }
 
 // HelpKeysWidth returns the rendered width of the given key bindings laid out
 // on a single line, using the same formatting as RenderHelpKeys. It returns 0
 // for empty or malformed input.
 func HelpKeysWidth(bindings ...string) int {
-	if len(bindings) == 0 || len(bindings)%2 != 0 {
-		return 0
-	}
-
-	var parts []string
-	for i := 0; i < len(bindings); i += 2 {
-		keyPart := styles.HighlightWhiteStyle.Render(bindings[i])
-		descPart := styles.SecondaryStyle.Render(bindings[i+1])
-		parts = append(parts, keyPart+" "+descPart)
-	}
-
-	return lipgloss.Width(strings.Join(parts, "  "))
+	return lipgloss.Width(helpKeysLine(bindings...))
 }
 
 // HandleQuit checks for the configured quit key and returns tea.Quit if matched.

--- a/pkg/tui/dialog/base.go
+++ b/pkg/tui/dialog/base.go
@@ -153,6 +153,24 @@ func RenderHelpKeys(contentWidth int, bindings ...string) string {
 	return styles.BaseStyle.Width(contentWidth).Align(lipgloss.Center).Render(strings.Join(parts, "  "))
 }
 
+// HelpKeysWidth returns the rendered width of the given key bindings laid out
+// on a single line, using the same formatting as RenderHelpKeys. It returns 0
+// for empty or malformed input.
+func HelpKeysWidth(bindings ...string) int {
+	if len(bindings) == 0 || len(bindings)%2 != 0 {
+		return 0
+	}
+
+	var parts []string
+	for i := 0; i < len(bindings); i += 2 {
+		keyPart := styles.HighlightWhiteStyle.Render(bindings[i])
+		descPart := styles.SecondaryStyle.Render(bindings[i+1])
+		parts = append(parts, keyPart+" "+descPart)
+	}
+
+	return lipgloss.Width(strings.Join(parts, "  "))
+}
+
 // HandleQuit checks for the configured quit key and returns tea.Quit if matched.
 func HandleQuit(msg tea.KeyPressMsg) tea.Cmd {
 	if key.Matches(msg, core.GetKeys().Quit) {

--- a/pkg/tui/dialog/file_picker.go
+++ b/pkg/tui/dialog/file_picker.go
@@ -309,7 +309,7 @@ func (d *filePickerDialog) View() string {
 		scrollableContent = d.scrollview.View()
 	}
 
-	helpRow1, helpRow2 := d.filePickerHelpKeysRows()
+	helpRow1, helpRow2 := d.filePickerHelpKeysRows(d.regionWidth(contentWidth))
 	content := NewContent(d.regionWidth(contentWidth)).
 		AddTitle("Attach File").
 		AddSpace().
@@ -352,7 +352,11 @@ func (d *filePickerDialog) renderEntry(entry fileEntry, selected bool, maxWidth 
 	return line
 }
 
-func (d *filePickerDialog) filePickerHelpKeysRows() (row1, row2 []string) {
+// filePickerHelpKeysRows returns the help key bindings split into two rows.
+// When contentWidth is wide enough to fit every shortcut on a single line,
+// all bindings are returned in row1 and row2 is empty; the second (empty) row
+// keeps the dialog height stable.
+func (d *filePickerDialog) filePickerHelpKeysRows(contentWidth int) (row1, row2 []string) {
 	hiddenLabel := "show hidden"
 	if d.showHidden {
 		hiddenLabel = "hide hidden"
@@ -361,14 +365,15 @@ func (d *filePickerDialog) filePickerHelpKeysRows() (row1, row2 []string) {
 	if d.showIgnored {
 		ignoredLabel = "hide ignored"
 	}
-	row1 = []string{
+	all := []string{
 		"↑/↓", "navigate",
 		"enter", "select",
 		"esc", "close",
 		"alt+h", hiddenLabel,
-	}
-	row2 = []string{
 		"alt+i", ignoredLabel,
 	}
-	return row1, row2
+	if HelpKeysWidth(all...) <= contentWidth {
+		return all, nil
+	}
+	return all[:8], all[8:]
 }

--- a/pkg/tui/dialog/file_picker_test.go
+++ b/pkg/tui/dialog/file_picker_test.go
@@ -176,8 +176,8 @@ func TestFilePickerHelpKeysRows(t *testing.T) {
 
 	d := &filePickerDialog{}
 
-	// Default state: both off.
-	row1, row2 := d.filePickerHelpKeysRows()
+	// Narrow dialog: shortcuts split across two rows.
+	row1, row2 := d.filePickerHelpKeysRows(20)
 	assert.Equal(t, []string{
 		"↑/↓", "navigate",
 		"enter", "select",
@@ -188,20 +188,31 @@ func TestFilePickerHelpKeysRows(t *testing.T) {
 		"alt+i", "show ignored",
 	}, row2)
 
+	// Wide dialog: every shortcut fits on a single row.
+	row1, row2 = d.filePickerHelpKeysRows(200)
+	assert.Equal(t, []string{
+		"↑/↓", "navigate",
+		"enter", "select",
+		"esc", "close",
+		"alt+h", "show hidden",
+		"alt+i", "show ignored",
+	}, row1)
+	assert.Empty(t, row2)
+
 	// showHidden on.
 	d.showHidden = true
-	row1, _ = d.filePickerHelpKeysRows()
+	row1, _ = d.filePickerHelpKeysRows(20)
 	assert.Contains(t, row1, "hide hidden")
 
 	// showIgnored on.
 	d.showIgnored = true
-	_, row2 = d.filePickerHelpKeysRows()
+	_, row2 = d.filePickerHelpKeysRows(20)
 	assert.Contains(t, row2, "hide ignored")
 
 	// Both off again.
 	d.showHidden = false
 	d.showIgnored = false
-	row1, row2 = d.filePickerHelpKeysRows()
+	row1, row2 = d.filePickerHelpKeysRows(20)
 	assert.Contains(t, row1, "show hidden")
 	assert.Contains(t, row2, "show ignored")
 }


### PR DESCRIPTION
The `/attach` file picker dialog always rendered its keyboard shortcuts across two rows at the bottom, regardless of how wide the dialog was. On wider terminals this wasted vertical space and made the dialog taller than necessary.

When the dialog is wide enough to fit all shortcuts on a single line, they now render on one row; on narrower dialogs the two-row layout is preserved as a fallback. The dialog height stays stable in both cases, so there is no layout jump when the window is resized across the threshold.

As part of this work, a `helpKeysLine` helper was extracted in `pkg/tui/dialog/base.go` so that `RenderHelpKeys` and `HelpKeysWidth` share the same formatting logic instead of duplicating it.