### PR TITLE
fix(tui): remove duplicate MCP-init spinner from sidebar

### DIFF
--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -118,7 +118,6 @@ type model struct {
 	layoutCfg          LayoutConfig              // layout configuration for spacing
 	sessionUsage       map[string]*runtime.Usage // sessionID -> latest usage snapshot
 	todoComp           *todotool.SidebarComponent
-	mcpInit            bool
 	ragIndexing        map[string]*ragIndexingState // strategy name -> indexing state
 	spinner            spinner.Spinner
 	spinnerActive      bool // true when spinner is registered with animation coordinator
@@ -209,7 +208,7 @@ func (m *model) Init() tea.Cmd {
 
 // needsSpinner returns true if any spinner-driving state is active.
 func (m *model) needsSpinner() bool {
-	return m.workingAgent != "" || m.toolsLoading || m.mcpInit || m.titleRegenerating
+	return m.workingAgent != "" || m.toolsLoading || m.titleRegenerating
 }
 
 // startSpinner registers the spinner with the animation coordinator if not already active.
@@ -643,25 +642,6 @@ func (m *model) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 	case *runtime.TokenUsageEvent:
 		m.SetTokenUsage(msg)
 		return m, nil
-	case *runtime.MCPInitStartedEvent:
-		// Ignore if stream was cancelled (stale event from before cancellation)
-		if m.streamCancelled {
-			return m, nil
-		}
-		if !m.mcpInit {
-			m.mcpInit = true
-			m.invalidateCache()
-			cmd := m.startSpinner()
-			return m, cmd
-		}
-		return m, nil
-	case *runtime.MCPInitFinishedEvent:
-		if m.mcpInit {
-			m.mcpInit = false
-			m.invalidateCache()
-			m.stopSpinner() // Will only stop if no other state needs it
-		}
-		return m, nil
 	case *runtime.RAGIndexingStartedEvent:
 		// Ignore if stream was cancelled (stale event from before cancellation)
 		if m.streamCancelled {
@@ -776,7 +756,6 @@ func (m *model) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		m.workingAgent = ""
 		m.sessionStack = nil
 		m.toolsLoading = false
-		m.mcpInit = false
 		m.titleRegenerating = false
 		// Force-stop main spinner if it was active (state is now cleared)
 		if m.spinnerActive {
@@ -824,8 +803,8 @@ func (m *model) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		var cmds []tea.Cmd
 		needsInvalidate := false
 
-		// Update main spinner when MCP is initializing, tools are loading, agent is working, or title is regenerating
-		if m.mcpInit || m.toolsLoading || m.workingAgent != "" || m.titleRegenerating {
+		// Update main spinner when tools are loading, agent is working, or title is regenerating
+		if m.toolsLoading || m.workingAgent != "" || m.titleRegenerating {
 			model, cmd := m.spinner.Update(msg)
 			m.spinner = model.(spinner.Spinner)
 			cmds = append(cmds, cmd)
@@ -1049,10 +1028,6 @@ func (m *model) groupedRAGIndexing() (ragNames []string, ragGroups map[string][]
 func (m *model) workingIndicator() string {
 	var indicators []string
 
-	if m.mcpInit {
-		indicators = append(indicators, styles.ActiveStyle.Render(m.spinner.View()+" Initializing MCP servers…"))
-	}
-
 	ragNames, ragGroups := m.groupedRAGIndexing()
 	for _, ragName := range ragNames {
 		strategies := ragGroups[ragName]
@@ -1081,10 +1056,6 @@ func (m *model) workingIndicator() string {
 // workingIndicatorCollapsed returns a single-line version of the working indicator for collapsed mode
 func (m *model) workingIndicatorCollapsed() string {
 	var labels []string
-
-	if m.mcpInit {
-		labels = append(labels, "Initializing MCP servers…")
-	}
 
 	ragNames, ragGroups := m.groupedRAGIndexing()
 	for _, ragName := range ragNames {


### PR DESCRIPTION
The sidebar was showing an "Initializing MCP servers…" spinner that duplicated the existing `ToolsetInfoEvent`-driven "Loading tools…" indicator. Worse, it fired on every conversation turn even for agents with no MCP servers — including the default built-in agent whose toolsets are filesystem, shell, and fetch. The runtime emits `MCPInitStartedEvent` and `MCPInitFinishedEvent` around `getTools()` on every loop iteration whenever the agent has any toolset at all, so the misleading message flashed repeatedly for roughly three seconds on some turns.

This removes the sidebar's MCP-init spinner UI only: the `mcpInit` bool field, its event handlers in `Update()`, its role in `needsSpinner()` and the spinner-tick guard, its reset in `StreamCancelledMsg`, and the "Initializing MCP servers…" render lines in both the expanded and collapsed `workingIndicator()` views. The `MCPInitStartedEvent` and `MCPInitFinishedEvent` types are intentionally kept — they are still emitted by the runtime and consumed by the remote client and other API consumers.