### PR TITLE
fix: add 5s timeout to graceful-shutdown calls that used WithoutCancel

### DIFF
--- a/cmd/root/otel.go
+++ b/cmd/root/otel.go
@@ -56,8 +56,11 @@ func initOTelSDK(ctx context.Context) (err error) {
 	lp, err := newLoggerProvider(ctx, res, endpoint)
 	if err != nil {
 		// Detach from ctx's cancellation but keep its trace context so
-		// cleanup still runs if ctx is already done.
-		_ = mp.Shutdown(context.WithoutCancel(ctx))
+		// cleanup still runs if ctx is already done. Bound it so a slow
+		// exporter can't block the failure path indefinitely.
+		shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer cancel()
+		_ = mp.Shutdown(shutdownCtx)
 		_ = shutdownTracerProvider(ctx, tp)
 		return fmt.Errorf("failed to create logger provider: %w", err)
 	}

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -87,8 +87,11 @@ func StartHTTPServer(ctx context.Context, agentFilename, agentName string, runCo
 	select {
 	case <-ctx.Done():
 		// ctx is done; detach from its cancellation but keep its trace
-		// context so the graceful shutdown can still run.
-		return httpServer.Shutdown(context.WithoutCancel(ctx))
+		// context so the graceful shutdown can still run. Bound it so a
+		// hung client connection can't block shutdown indefinitely.
+		shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer cancel()
+		return httpServer.Shutdown(shutdownCtx)
 	case err := <-errCh:
 		if errors.Is(err, http.ErrServerClosed) {
 			return nil


### PR DESCRIPTION
Two shutdown paths in the codebase used `context.WithoutCancel` without pairing it with a deadline, meaning they could block indefinitely if the underlying server or provider failed to stop. In `pkg/mcp/server.go`, the HTTP server shutdown triggered by a cancelled context had no timeout. In `cmd/root/otel.go`, the metric-provider shutdown inside a logger-provider error path had the same issue.

Both calls now use a 5-second timeout context, matching the pattern already in place in `pkg/chatserver/server.go` and in `shutdownTracerProvider` within the same `otel.go` file. The fix is purely additive — no behavior changes except that these two paths now bound their wait time the same way all sibling shutdown calls do.

No breaking changes. Validated with `task build` and `task lint` (zero new issues).