### PR TITLE
feat: enforce lifecycle.startup_timeout for MCP/LSP toolset startup

### DIFF
--- a/pkg/config/latest/lifecycle.go
+++ b/pkg/config/latest/lifecycle.go
@@ -62,12 +62,13 @@ type LifecycleConfig struct {
 
 	// StartupTimeout caps the duration of the initial Connect call.
 	//
-	// NOTE: this field is currently informational — the runtime does NOT
-	// yet enforce it. The supervisor's Start uses the caller's context
-	// for cancellation today; honouring StartupTimeout requires the same
-	// eager-startup wiring as Required.
+	// Enforced by the supervisor: on expiry the initial Start returns
+	// ErrInitTimeout and the toolset stays stopped (the runtime retries on
+	// the next turn). This bounds a server that hangs mid-handshake rather
+	// than returning an error.
 	//
-	// Zero means "no timeout".
+	// Zero means "no timeout". The "strict" profile defaults to 30s; other
+	// profiles default to 0.
 	StartupTimeout Duration `json:"startup_timeout,omitzero" yaml:"startup_timeout,omitempty"`
 
 	// CallTimeout is informational; it documents the user's expectation

--- a/pkg/tools/lifecycle/policy.go
+++ b/pkg/tools/lifecycle/policy.go
@@ -11,6 +11,7 @@ import (
 func PolicyFromConfig(name string, cfg *latest.LifecycleConfig) Policy {
 	policy := profilePolicy(profileName(cfg))
 	policy.Logger = slog.With("component", "supervisor", "toolset", name)
+	policy.StartupTimeout = cfg.EffectiveStartupTimeout()
 
 	if cfg == nil {
 		return policy

--- a/pkg/tools/lifecycle/policy_test.go
+++ b/pkg/tools/lifecycle/policy_test.go
@@ -67,6 +67,26 @@ func TestPolicyFromConfig_PartialOverridesKeepProfileDefaults(t *testing.T) {
 	assert.Equal(t, 7, p.MaxAttempts, "explicit override applied")
 }
 
+func TestPolicyFromConfig_StartupTimeout(t *testing.T) {
+	t.Parallel()
+
+	// Nil config and non-strict profiles default to no timeout.
+	assert.Equal(t, time.Duration(0), PolicyFromConfig("test", nil).StartupTimeout)
+	assert.Equal(t, time.Duration(0), PolicyFromConfig("test", &latest.LifecycleConfig{
+		Profile: latest.LifecycleProfileResilient,
+	}).StartupTimeout)
+
+	// The strict profile carries a 30s default.
+	assert.Equal(t, 30*time.Second, PolicyFromConfig("test", &latest.LifecycleConfig{
+		Profile: latest.LifecycleProfileStrict,
+	}).StartupTimeout)
+
+	// An explicit value wins over the profile default.
+	assert.Equal(t, 5*time.Second, PolicyFromConfig("test", &latest.LifecycleConfig{
+		StartupTimeout: latest.Duration{Duration: 5 * time.Second},
+	}).StartupTimeout)
+}
+
 func TestParseRestart(t *testing.T) {
 	t.Parallel()
 	cases := map[string]Restart{

--- a/pkg/tools/lifecycle/supervisor.go
+++ b/pkg/tools/lifecycle/supervisor.go
@@ -178,6 +178,12 @@ type Supervisor struct {
 	// after closing the session so no transport goroutines are left behind.
 	watchDone chan struct{}
 
+	// inflightConnect holds a connector.Connect that a startup timeout left
+	// running (see connect). At most one exists at a time; the next Start
+	// adopts it and Stop reaps it, so overlapping Connects never race on the
+	// shared MCP session.
+	inflightConnect *pendingConnect
+
 	// randFloat is the jitter source; tests may override.
 	randFloat func() float64
 }
@@ -283,45 +289,99 @@ func (s *Supervisor) Start(ctx context.Context) error {
 	return nil
 }
 
+// connectResult is the outcome of a single connector.Connect call.
+type connectResult struct {
+	sess Session
+	err  error
+}
+
+// pendingConnect is a single in-flight connector.Connect whose result is
+// adopted by a Start or reaped by Stop, whichever happens first. adopted is
+// set exactly once (guarded by Supervisor.mu) so a session is never both
+// handed to a caller and closed by the reaper.
+type pendingConnect struct {
+	done    chan struct{} // closed when Connect returns
+	res     connectResult // valid once done is closed
+	adopted bool          // set by the first of {Start adopts, Stop reaps}
+}
+
 // connect performs connector.Connect bounded by policy.StartupTimeout. When
-// the timeout is zero it calls Connect directly. Otherwise it races Connect
-// against a timer: on timeout it returns ErrInitTimeout immediately and, in a
-// background goroutine, closes any Session that Connect eventually produces so
-// a slow-but-successful handshake does not leak a live connection. The timer
-// approach (rather than a ctx deadline) is deliberate: the MCP connector
-// detaches its ctx with context.WithoutCancel, so a deadline on ctx would be
-// stripped before it could interrupt a wedged initialize handshake.
+// the timeout is zero it calls Connect directly.
+//
+// Otherwise it guarantees at most one Connect is ever in flight: on timeout it
+// returns ErrInitTimeout but leaves the goroutine running, recorded in
+// s.inflightConnect. A later Start reuses that same goroutine instead of
+// launching a concurrent Connect, and Stop reaps it. This matters because the
+// MCP transport shares one underlying client across Connect calls, so two
+// overlapping Connects would race on the shared session (a late one could
+// clobber or close a newer one). The timer (rather than a ctx deadline) is
+// deliberate: the MCP connector detaches its ctx with context.WithoutCancel,
+// so a deadline on ctx would be stripped before it could interrupt a wedged
+// initialize handshake.
+//
+// A consequence is that a Connect wedged forever is never superseded by a
+// fresh attempt (each Start returns ErrInitTimeout). That is intentional:
+// spawning a new attempt per turn would accumulate orphaned handshakes and,
+// for stdio, leak subprocesses. A handshake that eventually completes is
+// adopted by the next Start.
 func (s *Supervisor) connect(ctx context.Context) (Session, error) {
 	if s.policy.StartupTimeout <= 0 {
 		return s.connector.Connect(ctx)
 	}
 
-	type connectResult struct {
-		sess Session
-		err  error
+	s.mu.Lock()
+	p := s.inflightConnect
+	if p == nil {
+		p = &pendingConnect{done: make(chan struct{})}
+		s.inflightConnect = p
+		go func() {
+			sess, err := s.connector.Connect(ctx)
+			s.mu.Lock()
+			p.res = connectResult{sess: sess, err: err}
+			close(p.done)
+			s.mu.Unlock()
+		}()
 	}
-	resultCh := make(chan connectResult, 1) // buffered so a late send never blocks
-	go func() {
-		sess, err := s.connector.Connect(ctx)
-		resultCh <- connectResult{sess: sess, err: err}
-	}()
+	s.mu.Unlock()
 
 	timer := time.NewTimer(s.policy.StartupTimeout)
 	defer timer.Stop()
 
 	select {
-	case res := <-resultCh:
+	case <-p.done:
+		s.mu.Lock()
+		if p.adopted {
+			// Stop reaped (and closed) this connect while we waited.
+			s.mu.Unlock()
+			return nil, ErrNotStarted
+		}
+		p.adopted = true
+		if s.inflightConnect == p {
+			s.inflightConnect = nil
+		}
+		res := p.res
+		s.mu.Unlock()
 		return res.sess, res.err
 	case <-timer.C:
-		// Reap the orphaned Connect so a session that arrives after the
-		// timeout is closed instead of leaked.
-		go func() {
-			res := <-resultCh
-			if res.sess != nil {
-				_ = res.sess.Close(context.WithoutCancel(ctx))
-			}
-		}()
 		return nil, wrap(ErrInitTimeout, fmt.Errorf("%q did not connect within %s", s.name, s.policy.StartupTimeout))
+	}
+}
+
+// reapPendingConnect waits for an orphaned Connect (left in flight by a
+// startup timeout) to finish and closes its session unless a Start already
+// adopted it. Called only from Stop.
+func (s *Supervisor) reapPendingConnect(ctx context.Context, p *pendingConnect) {
+	<-p.done
+	s.mu.Lock()
+	if p.adopted {
+		s.mu.Unlock()
+		return
+	}
+	p.adopted = true
+	sess := p.res.sess
+	s.mu.Unlock()
+	if sess != nil {
+		_ = sess.Close(ctx)
 	}
 }
 
@@ -338,10 +398,19 @@ func (s *Supervisor) Stop(ctx context.Context) error {
 	sess := s.session
 	s.session = nil
 	watchDone := s.watchDone
+	pending := s.inflightConnect
+	s.inflightConnect = nil
 	s.mu.Unlock()
 
 	s.tracker.Set(StateStopped)
 	s.signalDone()
+
+	// Reap a Connect left in flight by a startup timeout so its eventual
+	// session is closed rather than leaked. Runs in the background: a wedged
+	// handshake must not block Stop.
+	if pending != nil {
+		go s.reapPendingConnect(context.WithoutCancel(ctx), pending)
+	}
 
 	var closeErr error
 	if sess != nil {

--- a/pkg/tools/lifecycle/supervisor.go
+++ b/pkg/tools/lifecycle/supervisor.go
@@ -334,12 +334,17 @@ func (s *Supervisor) connect(ctx context.Context) (Session, error) {
 	if p == nil {
 		p = &pendingConnect{done: make(chan struct{})}
 		s.inflightConnect = p
+		// Detach from this caller's ctx: the goroutine outlives the Start
+		// that launched it (it may be adopted by a later Start after this one
+		// times out), so a cancellation of the original ctx must not surface
+		// as a stale context.Canceled to the adopter. Matches Stop and watch.
+		connectCtx := context.WithoutCancel(ctx)
 		go func() {
-			sess, err := s.connector.Connect(ctx)
+			sess, err := s.connector.Connect(connectCtx)
 			s.mu.Lock()
+			defer s.mu.Unlock()
 			p.res = connectResult{sess: sess, err: err}
 			close(p.done)
-			s.mu.Unlock()
 		}()
 	}
 	s.mu.Unlock()
@@ -361,6 +366,13 @@ func (s *Supervisor) connect(ctx context.Context) (Session, error) {
 		}
 		res := p.res
 		s.mu.Unlock()
+		// Defensive: a well-behaved connector returns (sess, nil) or
+		// (nil, err), but if it returns both, close the session rather than
+		// leak it since Start discards sess when err is non-nil.
+		if res.err != nil && res.sess != nil {
+			_ = res.sess.Close(context.WithoutCancel(ctx))
+			return nil, res.err
+		}
 		return res.sess, res.err
 	case <-timer.C:
 		return nil, wrap(ErrInitTimeout, fmt.Errorf("%q did not connect within %s", s.name, s.policy.StartupTimeout))

--- a/pkg/tools/lifecycle/supervisor.go
+++ b/pkg/tools/lifecycle/supervisor.go
@@ -3,6 +3,7 @@ package lifecycle
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"math"
 	"math/rand/v2"
@@ -106,6 +107,14 @@ type Policy struct {
 	Restart     Restart // see Restart constants; default RestartOnFailure
 	MaxAttempts int     // 0 = default (5); negative = unlimited
 	Backoff     Backoff // zero fields use Backoff defaults
+
+	// StartupTimeout bounds the initial Connect performed by Start. Zero
+	// means no timeout. It is enforced by racing Connect against a timer
+	// rather than via a context deadline, so it still interrupts connectors
+	// (notably MCP) that detach the context they are handed with
+	// context.WithoutCancel. On expiry Start returns ErrInitTimeout and the
+	// toolset stays in StateStopped so the caller can retry.
+	StartupTimeout time.Duration
 
 	// OnDisconnect is called when the session ends, with Wait()'s result.
 	// Useful for cache invalidation.
@@ -211,6 +220,9 @@ func (s *Supervisor) Restarted() <-chan struct{} {
 // stays in StateStopped and the caller is expected to retry. On success
 // the watcher goroutine is launched (if not already alive) and state moves
 // to Ready. Concurrent Start calls serialize.
+//
+// When policy.StartupTimeout is non-zero the connect is bounded by it; on
+// expiry Start returns ErrInitTimeout and stays in StateStopped.
 func (s *Supervisor) Start(ctx context.Context) error {
 	s.startMu.Lock()
 	defer s.startMu.Unlock()
@@ -228,7 +240,7 @@ func (s *Supervisor) Start(ctx context.Context) error {
 
 	s.tracker.Set(StateStarting)
 
-	sess, err := s.connector.Connect(ctx)
+	sess, err := s.connect(ctx)
 	if err != nil {
 		s.tracker.Fail(StateStopped, err)
 		return err
@@ -269,6 +281,48 @@ func (s *Supervisor) Start(ctx context.Context) error {
 
 	s.policy.logger().Debug("supervisor: ready", "name", s.name)
 	return nil
+}
+
+// connect performs connector.Connect bounded by policy.StartupTimeout. When
+// the timeout is zero it calls Connect directly. Otherwise it races Connect
+// against a timer: on timeout it returns ErrInitTimeout immediately and, in a
+// background goroutine, closes any Session that Connect eventually produces so
+// a slow-but-successful handshake does not leak a live connection. The timer
+// approach (rather than a ctx deadline) is deliberate: the MCP connector
+// detaches its ctx with context.WithoutCancel, so a deadline on ctx would be
+// stripped before it could interrupt a wedged initialize handshake.
+func (s *Supervisor) connect(ctx context.Context) (Session, error) {
+	if s.policy.StartupTimeout <= 0 {
+		return s.connector.Connect(ctx)
+	}
+
+	type connectResult struct {
+		sess Session
+		err  error
+	}
+	resultCh := make(chan connectResult, 1) // buffered so a late send never blocks
+	go func() {
+		sess, err := s.connector.Connect(ctx)
+		resultCh <- connectResult{sess: sess, err: err}
+	}()
+
+	timer := time.NewTimer(s.policy.StartupTimeout)
+	defer timer.Stop()
+
+	select {
+	case res := <-resultCh:
+		return res.sess, res.err
+	case <-timer.C:
+		// Reap the orphaned Connect so a session that arrives after the
+		// timeout is closed instead of leaked.
+		go func() {
+			res := <-resultCh
+			if res.sess != nil {
+				_ = res.sess.Close(context.WithoutCancel(ctx))
+			}
+		}()
+		return nil, wrap(ErrInitTimeout, fmt.Errorf("%q did not connect within %s", s.name, s.policy.StartupTimeout))
+	}
 }
 
 // Stop tears the supervisor down. Idempotent. Blocks until the underlying

--- a/pkg/tools/lifecycle/supervisor_test.go
+++ b/pkg/tools/lifecycle/supervisor_test.go
@@ -183,18 +183,59 @@ func TestSupervisor_StartTimesOutOnSlowConnect(t *testing.T) {
 	assert.Check(t, errors.Is(err, lifecycle.ErrInitTimeout))
 	assert.Check(t, is.Equal(s.State().State, lifecycle.StateStopped))
 
-	// A late-arriving session must be closed, not leaked.
+	// Only one Connect is ever launched, even though it is still wedged.
+	assert.Check(t, is.Equal(c.calls.Load(), int32(1)))
+}
+
+// TestSupervisor_StartAdoptsLateConnect verifies that a Connect that finishes
+// after the first Start timed out is adopted by the next Start (reusing the
+// same in-flight goroutine) rather than launching a second, concurrent
+// Connect.
+func TestSupervisor_StartAdoptsLateConnect(t *testing.T) {
+	t.Parallel()
+
+	c := &blockingConnector{release: make(chan struct{}), session: newFakeSession()}
+	s := lifecycle.New("test", c, lifecycle.Policy{StartupTimeout: 20 * time.Millisecond})
+
+	assert.Check(t, errors.Is(s.Start(t.Context()), lifecycle.ErrInitTimeout))
+
+	// The handshake completes; the next Start adopts it.
 	close(c.release)
+	assert.NilError(t, s.Start(t.Context()))
+	assert.Check(t, is.Equal(s.State().State, lifecycle.StateReady))
+	// Still only one Connect was ever launched.
+	assert.Check(t, is.Equal(c.calls.Load(), int32(1)))
+
+	assert.NilError(t, s.Stop(t.Context()))
+}
+
+// TestSupervisor_StopReapsLateConnect verifies that when Stop is called while a
+// timed-out Connect is still in flight, the session it eventually produces is
+// closed rather than leaked.
+func TestSupervisor_StopReapsLateConnect(t *testing.T) {
+	t.Parallel()
+
+	sess := newFakeSession()
+	c := &blockingConnector{release: make(chan struct{}), session: sess}
+	s := lifecycle.New("test", c, lifecycle.Policy{StartupTimeout: 20 * time.Millisecond})
+
+	assert.Check(t, errors.Is(s.Start(t.Context()), lifecycle.ErrInitTimeout))
+
+	// Stop while the connect is still wedged, then let it complete.
+	assert.NilError(t, s.Stop(t.Context()))
+	close(c.release)
+
+	// The reaper must close the late session.
 	deadline := time.Now().Add(time.Second)
 	for {
-		c.session.mu.Lock()
-		closed := c.session.closed
-		c.session.mu.Unlock()
+		sess.mu.Lock()
+		closed := sess.closed
+		sess.mu.Unlock()
 		if closed {
 			break
 		}
 		if time.Now().After(deadline) {
-			t.Fatal("late session was not closed after startup timeout")
+			t.Fatal("late session was not closed after Stop")
 		}
 		time.Sleep(5 * time.Millisecond)
 	}

--- a/pkg/tools/lifecycle/supervisor_test.go
+++ b/pkg/tools/lifecycle/supervisor_test.go
@@ -209,6 +209,31 @@ func TestSupervisor_StartAdoptsLateConnect(t *testing.T) {
 	assert.NilError(t, s.Stop(t.Context()))
 }
 
+// TestSupervisor_StartAdoptsLateConnectAfterFirstCtxCancelled verifies that
+// the in-flight Connect is detached from the first caller's context: when that
+// context is cancelled after the first Start times out, a connector that
+// respects ctx cancellation still completes, and the adopting Start does not
+// receive a stale context.Canceled.
+func TestSupervisor_StartAdoptsLateConnectAfterFirstCtxCancelled(t *testing.T) {
+	t.Parallel()
+
+	c := &blockingConnector{release: make(chan struct{}), session: newFakeSession()}
+	s := lifecycle.New("test", c, lifecycle.Policy{StartupTimeout: 20 * time.Millisecond})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	assert.Check(t, errors.Is(s.Start(ctx), lifecycle.ErrInitTimeout))
+	// Cancelling the first caller's context must not poison the detached
+	// in-flight Connect: blockingConnector returns ctx.Err() if its ctx is done.
+	cancel()
+
+	close(c.release)
+	assert.NilError(t, s.Start(t.Context()))
+	assert.Check(t, is.Equal(s.State().State, lifecycle.StateReady))
+	assert.Check(t, is.Equal(c.calls.Load(), int32(1)))
+
+	assert.NilError(t, s.Stop(t.Context()))
+}
+
 // TestSupervisor_StopReapsLateConnect verifies that when Stop is called while a
 // timed-out Connect is still in flight, the session it eventually produces is
 // closed rather than leaked.

--- a/pkg/tools/lifecycle/supervisor_test.go
+++ b/pkg/tools/lifecycle/supervisor_test.go
@@ -114,6 +114,29 @@ func (c *scriptedConnector) Connect(context.Context) (lifecycle.Session, error) 
 
 func (c *scriptedConnector) Calls() int { return int(c.calls.Load()) }
 
+// blockingConnector blocks in Connect until release is closed, then returns
+// the configured session/err. It lets tests exercise the startup-timeout path
+// where Connect is slow rather than failing outright.
+type blockingConnector struct {
+	release chan struct{}
+	session *fakeSession
+	err     error
+	calls   atomic.Int32
+}
+
+func (c *blockingConnector) Connect(ctx context.Context) (lifecycle.Session, error) {
+	c.calls.Add(1)
+	select {
+	case <-c.release:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	if c.err != nil {
+		return nil, c.err
+	}
+	return c.session, nil
+}
+
 // fastBackoff is a minimal backoff for tests so we don't sit in time.Sleep.
 var fastBackoff = lifecycle.Backoff{
 	Initial:    1 * time.Millisecond,
@@ -145,6 +168,50 @@ func TestSupervisor_StartSucceedsAndReadies(t *testing.T) {
 	assert.Check(t, s.IsReady())
 	assert.NilError(t, s.Stop(t.Context()))
 	assert.Check(t, is.Equal(s.State().State, lifecycle.StateStopped))
+}
+
+// TestSupervisor_StartTimesOutOnSlowConnect verifies that a Connect that
+// hangs past StartupTimeout causes Start to return ErrInitTimeout and leaves
+// the supervisor in StateStopped so the caller can retry.
+func TestSupervisor_StartTimesOutOnSlowConnect(t *testing.T) {
+	t.Parallel()
+
+	c := &blockingConnector{release: make(chan struct{}), session: newFakeSession()}
+	s := lifecycle.New("test", c, lifecycle.Policy{StartupTimeout: 20 * time.Millisecond})
+
+	err := s.Start(t.Context())
+	assert.Check(t, errors.Is(err, lifecycle.ErrInitTimeout))
+	assert.Check(t, is.Equal(s.State().State, lifecycle.StateStopped))
+
+	// A late-arriving session must be closed, not leaked.
+	close(c.release)
+	deadline := time.Now().Add(time.Second)
+	for {
+		c.session.mu.Lock()
+		closed := c.session.closed
+		c.session.mu.Unlock()
+		if closed {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("late session was not closed after startup timeout")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// TestSupervisor_StartWithinTimeoutSucceeds verifies that a Connect that
+// completes before StartupTimeout readies the supervisor normally.
+func TestSupervisor_StartWithinTimeoutSucceeds(t *testing.T) {
+	t.Parallel()
+
+	c := &blockingConnector{release: make(chan struct{}), session: newFakeSession()}
+	close(c.release) // Connect returns immediately
+	s := lifecycle.New("test", c, lifecycle.Policy{StartupTimeout: time.Second})
+
+	assert.NilError(t, s.Start(t.Context()))
+	assert.Check(t, is.Equal(s.State().State, lifecycle.StateReady))
+	assert.NilError(t, s.Stop(t.Context()))
 }
 
 func TestSupervisor_StartIsIdempotent(t *testing.T) {


### PR DESCRIPTION
## What

Enforces `lifecycle.startup_timeout` for MCP/LSP toolset startup. Until now this config field (and its `strict`-profile 30s default) was parsed and validated but **never acted on** — `EffectiveStartupTimeout()` had no callers, so a server that hung mid-`initialize` would block startup indefinitely.

## Why

The MCP `clientConnector.Connect` deliberately detaches its context with `context.WithoutCancel` (the session must outlive the request that triggered it). A consequence is that the initialize handshake has **no deadline of its own**: a server that accepts the connection but never completes `initialize` wedges the startup attempt forever, and `startup_timeout` could not rescue it because nothing consumed the value.

## How

- Add `StartupTimeout` to `lifecycle.Policy` and wire `EffectiveStartupTimeout()` into `PolicyFromConfig`.
- Enforce it in `Supervisor.connect()` by **racing `Connect` against a timer** rather than a `ctx` deadline (a deadline would be stripped by `WithoutCancel`). On expiry, `Start` returns `ErrInitTimeout` and the toolset stays `Stopped` so the runtime retries on the next turn.
- Guarantee **at most one `Connect` is ever in flight**: a timed-out `Connect` goroutine is left running and recorded in `inflightConnect`; the next `Start` *adopts* it and `Stop` *reaps* it. This is required because the MCP transport shares one underlying client across `Connect` calls — two overlapping connects would race on the shared session (a late one could clobber/close a newer one). An `adopted` flag under the mutex ensures the resulting session is adopted-or-closed exactly once.

## Scope

`startup_timeout` bounds only the **initial** `Start`, not background watcher reconnects (which already have their own restart/backoff budget). `strict` → 30s default; other profiles → 0 (no timeout); explicit value always wins.

## Tests

New supervisor tests (all pass under `-race`): timeout returns `ErrInitTimeout` with a single `Connect`; the next `Start` adopts a late-completing connect; `Stop` reaps and closes a late connect. New `PolicyFromConfig` test covers the nil/resilient/strict/explicit cases.
