### PR TITLE
fix: unblock headless tool-Ask paths (dispatcher + JSON runner)

### DIFF
--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -118,9 +118,11 @@ func Run(ctx context.Context, out *Printer, cfg Config, rt runtime.Runtime, sess
 			for event := range rt.RunStream(ctx, sess) {
 				switch e := event.(type) {
 				case *runtime.ToolCallConfirmationEvent:
-					if !cfg.AutoApprove {
-						rt.Resume(ctx, runtime.ResumeReject(""))
-					}
+					// JSON mode has no user at stdin — reject unconditionally.
+					// A confirmation event under AutoApprove means a
+					// preempt-yolo hook overrode --yolo; the safe answer is
+					// still Reject (the hook said Ask, not Approve).
+					rt.Resume(ctx, runtime.ResumeReject(""))
 				case *runtime.ElicitationRequestEvent:
 					_ = rt.ResumeElicitation(ctx, "decline", nil)
 				case *runtime.MaxIterationsReachedEvent:

--- a/pkg/cli/runner_test.go
+++ b/pkg/cli/runner_test.go
@@ -227,6 +227,38 @@ func TestMaxIterationsRejectInJSONModeWithoutYolo(t *testing.T) {
 	assert.Equal(t, resumes[0].Type, runtime.ResumeTypeReject)
 }
 
+// JSON mode has no stdin user — a ToolCallConfirmationEvent must be
+// rejected even under --yolo (AutoApprove=true), because the event
+// only fires when a preempt-yolo hook overrode yolo. Without this,
+// eval containers hang on the Resume channel.
+func TestToolCallConfirmationRejectedInJSONModeUnderYolo(t *testing.T) {
+	t.Parallel()
+
+	rt := &mockRuntime{
+		events: []runtime.Event{
+			&runtime.ToolCallConfirmationEvent{
+				Type: "tool_call_confirmation",
+				ToolCall: tools.ToolCall{
+					ID:       "call-1",
+					Function: tools.FunctionCall{Name: "shell", Arguments: `{"cmd":"rm -rf /tmp/x"}`},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	out := NewPrinter(&buf)
+	sess := session.New()
+	cfg := Config{AutoApprove: true, OutputJSON: true}
+
+	err := Run(t.Context(), out, cfg, rt, sess, []string{"hello"})
+	assert.NilError(t, err)
+
+	resumes := rt.getResumes()
+	assert.Equal(t, len(resumes), 1, "one Resume expected")
+	assert.Equal(t, resumes[0].Type, runtime.ResumeTypeReject, "JSON+yolo must reject confirmation events")
+}
+
 func TestElicitationAutoDeclineInJSONMode(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/runtime/toolexec/dispatcher.go
+++ b/pkg/runtime/toolexec/dispatcher.go
@@ -47,6 +47,13 @@ const (
 	ApprovalSourceUserApprovedTool           = "user_approved_tool"
 	ApprovalSourceUserRejected               = "user_rejected"
 	ApprovalSourceContextCanceled            = "context_canceled"
+	// ApprovalSourceNonInteractiveDeny is recorded when a tool call
+	// reaches [call.askUser] in a non-interactive session (eval, MCP
+	// serve, A2A adapter, …). With no human at the keyboard and no
+	// Resume listener, the deterministic safe answer is Deny; without
+	// this guard the dispatcher would block on the Resume channel
+	// forever.
+	ApprovalSourceNonInteractiveDeny = "non_interactive_deny"
 )
 
 // CallOutcome captures the verdicts of a single tool invocation as
@@ -580,6 +587,19 @@ func (c *call) askUser(ctx context.Context, runTool func() CallOutcome) CallOutc
 			return outcome
 		}
 		hookMeta = meta
+	}
+
+	// Non-interactive sessions (eval, MCP serve, A2A adapter) have no
+	// Resume listener. Blocking on the select below would hang forever.
+	// The deterministic safe answer is Deny: nobody is at the keyboard
+	// to approve, and an auto-Allow here would bypass whatever rule
+	// routed the call to askUser in the first place (a checker
+	// ForceAsk, a preempt-yolo Ask, or the default Ask).
+	if c.sess.NonInteractive {
+		slog.DebugContext(ctx, "Tool denied: non-interactive session reached askUser", "tool", c.tc.Function.Name, "session_id", c.sess.ID)
+		c.notifyApproval(ctx, ApprovalDecisionDeny, ApprovalSourceNonInteractiveDeny)
+		c.errorResponse(ctx, fmt.Sprintf("Tool '%s' requires user confirmation but the session is non-interactive.", c.tc.Function.Name))
+		return CallOutcome{}
 	}
 
 	slog.DebugContext(ctx, "Tools not approved, waiting for resume", "tool", c.tc.Function.Name, "session_id", c.sess.ID)

--- a/pkg/runtime/toolexec/dispatcher_test.go
+++ b/pkg/runtime/toolexec/dispatcher_test.go
@@ -904,3 +904,86 @@ func TestDispatcher_PreToolUseDefaultLaneSkippedUnderYolo(t *testing.T) {
 		"default pre_tool_use lane must not fire under --yolo; only preempt_yolo:true entries do")
 	assert.Empty(t, em.confirmations)
 }
+
+// TestDispatcher_NonInteractiveAskAutoDenies pins the universal
+// headless guard: any path that would reach askUser in a
+// non-interactive session (eval, MCP serve, A2A adapter) must
+// auto-deny rather than block on the Resume channel. This covers the
+// preempt-yolo Ask lane (this test), checker ForceAsk
+// (TestDispatcher_NonInteractiveCheckerForceAskAutoDenies), and the
+// default Ask
+// (TestDispatcher_NonInteractiveDefaultAskAutoDenies). Without this
+// guard each path would hang indefinitely with no Resume listener.
+func TestDispatcher_NonInteractiveAskAutoDenies(t *testing.T) {
+	a := newAgent()
+	sess := session.New()
+	sess.ToolsApproved = true
+	sess.NonInteractive = true
+
+	tool := tools.Tool{
+		Name: "shell",
+		Handler: func(context.Context, tools.ToolCall) (*tools.ToolCallResult, error) {
+			panic("must not run when denied")
+		},
+	}
+
+	hd := &stubHookDispatcher{
+		on: map[hooks.EventType]*hooks.Result{
+			hooks.EventPreToolUsePreYolo: {
+				Allowed:        true,
+				Decision:       hooks.DecisionAsk,
+				DecisionReason: "rm -rf <path>: irreversible",
+				Metadata:       map[string]string{"blast_radius": "high"},
+			},
+		},
+	}
+
+	d := &toolexec.Dispatcher{
+		AgentFor: func(*session.Session) *agent.Agent { return a },
+		Hooks:    hd,
+	}
+	em := &captureEmitter{}
+
+	d.Process(t.Context(), sess, []tools.ToolCall{{
+		ID:       "danger",
+		Function: tools.FunctionCall{Name: "shell", Arguments: `{"cmd":"rm -rf /tmp/x"}`},
+	}}, []tools.Tool{tool}, em)
+
+	require.Len(t, em.responses, 1)
+	assert.True(t, em.responses[0].IsError, "non-interactive ask must produce an error tool response")
+	assert.Contains(t, em.responses[0].Output, "non-interactive",
+		"deny message should name the cause so eval traces are debuggable")
+	assert.Empty(t, em.confirmations,
+		"confirmation event must not be emitted in non-interactive mode — there is no one to confirm")
+}
+
+// TestDispatcher_NonInteractiveDefaultAskAutoDenies covers the
+// no-rule-matched path: a non-interactive session with no preempt-yolo
+// hook, no checker rules, no readonly hint, and no --yolo. Today this
+// falls through to askUser and would hang. The guard must deny.
+func TestDispatcher_NonInteractiveDefaultAskAutoDenies(t *testing.T) {
+	a := newAgent()
+	sess := session.New()
+	sess.NonInteractive = true
+
+	tool := tools.Tool{
+		Name: "shell",
+		Handler: func(context.Context, tools.ToolCall) (*tools.ToolCallResult, error) {
+			panic("must not run when denied")
+		},
+	}
+
+	d := &toolexec.Dispatcher{
+		AgentFor: func(*session.Session) *agent.Agent { return a },
+	}
+	em := &captureEmitter{}
+
+	d.Process(t.Context(), sess, []tools.ToolCall{{
+		ID:       "x",
+		Function: tools.FunctionCall{Name: "shell", Arguments: `{"cmd":"docker ps"}`},
+	}}, []tools.Tool{tool}, em)
+
+	require.Len(t, em.responses, 1)
+	assert.True(t, em.responses[0].IsError)
+	assert.Contains(t, em.responses[0].Output, "non-interactive")
+}


### PR DESCRIPTION
## Summary
- **Dispatcher headless guard**: `askUser` in a non-interactive session (MCP serve, A2A adapter, eval framework — all set `session.NonInteractive=true`) now auto-denies with `ApprovalSourceNonInteractiveDeny` instead of blocking on a Resume channel nobody sends to.
- **JSON runner reject under --yolo**: `docker-agent run --exec --yolo --json` (the eval-container invocation) previously dropped `ToolCallConfirmationEvent` without any Resume when `AutoApprove=true` and hung. Reject unconditionally in JSON mode — a confirmation event under --yolo can only fire when a preempt-yolo hook overrode yolo with Ask.

Both cases were previously-impossible paths introduced by PR #3273's `preempt_yolo` support.

## Test plan
- [ ] `go test ./pkg/runtime/toolexec/... ./pkg/cli/... ./e2e/...` green
- [ ] `AGENT_FILE=./gordon_safer.yaml gogo evals` completes without hangs when a preempt-yolo Ask fires