### PR TITLE
feat(session): add SafetyPolicy primitive and hook pass-through

### DIFF
--- a/pkg/hooks/types.go
+++ b/pkg/hooks/types.go
@@ -274,6 +274,12 @@ type Input struct {
 	ToolUseID    string         `json:"tool_use_id,omitempty"`
 	ToolInput    map[string]any `json:"tool_input,omitempty"`
 
+	// SafetyPolicy mirrors the session's safety preference (see
+	// [github.com/docker/docker-agent/pkg/session.SafetyPolicy]) on
+	// tool-call events. Empty ⇒ derive from ToolsApproved. Typed as
+	// string to avoid a session dep.
+	SafetyPolicy string `json:"safety_policy,omitempty"`
+
 	// PostToolUse / ToolResponseTransform: the tool's textual output.
 	// On post_tool_use it carries the (already-rewritten) response a
 	// tool_response_transform hook produced — hooks scrubbing secrets

--- a/pkg/runtime/payload.go
+++ b/pkg/runtime/payload.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/permissions"
+	"github.com/docker/docker-agent/pkg/session"
 )
 
 // LoadTeamRequest is the typed input to a backend's team load. It carries
@@ -41,8 +42,13 @@ type LoadTeamRequest struct {
 // opaque struct without a wire form yet); it'll get a serializable
 // representation in a follow-up.
 type CreateSessionRequest struct {
-	AgentName         string               `json:"agent_name,omitempty"`
-	ToolsApproved     bool                 `json:"tools_approved"`
+	AgentName string `json:"agent_name,omitempty"`
+	// ToolsApproved is the legacy --yolo signal. New callers should
+	// prefer SafetyPolicy; option setters keep both in sync.
+	ToolsApproved bool `json:"tools_approved"`
+	// SafetyPolicy is the per-session safety preference; empty falls
+	// back to the ToolsApproved-derived default. See [session.SafetyPolicy].
+	SafetyPolicy      session.SafetyPolicy `json:"safety_policy,omitempty"`
 	HideToolResults   bool                 `json:"hide_tool_results"`
 	SessionDB         string               `json:"session_db,omitempty"`
 	ResumeSessionID   string               `json:"resume_session_id,omitempty"`

--- a/pkg/runtime/toolexec/dispatcher.go
+++ b/pkg/runtime/toolexec/dispatcher.go
@@ -618,10 +618,11 @@ func (c *call) runPermissionRequestHook(ctx context.Context, runTool func() Call
 
 	toolName := c.tc.Function.Name
 	result := c.d.Hooks.Dispatch(ctx, c.a, hooks.EventPermissionRequest, &hooks.Input{
-		SessionID: c.sess.ID,
-		ToolName:  toolName,
-		ToolUseID: c.tc.ID,
-		ToolInput: ParseToolInput(c.tc.Function.Arguments),
+		SessionID:    c.sess.ID,
+		ToolName:     toolName,
+		ToolUseID:    c.tc.ID,
+		ToolInput:    ParseToolInput(c.tc.Function.Arguments),
+		SafetyPolicy: string(c.sess.SafetyPolicy),
 	})
 	if result == nil {
 		return CallOutcome{}, false, nil

--- a/pkg/runtime/toolexec/hooks_input.go
+++ b/pkg/runtime/toolexec/hooks_input.go
@@ -10,13 +10,16 @@ import (
 
 // NewHooksInput builds a [hooks.Input] from the common tool-call fields.
 // [hooks.Executor.Dispatch] auto-fills Cwd from the executor's working
-// directory, so callers don't set it here.
+// directory, so callers don't set it here. SafetyPolicy is forwarded
+// as a plain string; the runtime does not act on it — classifiers
+// (e.g. safer_shell) read it and adapt.
 func NewHooksInput(sess *session.Session, toolCall tools.ToolCall) *hooks.Input {
 	return &hooks.Input{
-		SessionID: sess.ID,
-		ToolName:  toolCall.Function.Name,
-		ToolUseID: toolCall.ID,
-		ToolInput: ParseToolInput(toolCall.Function.Arguments),
+		SessionID:    sess.ID,
+		ToolName:     toolCall.Function.Name,
+		ToolUseID:    toolCall.ID,
+		ToolInput:    ParseToolInput(toolCall.Function.Arguments),
+		SafetyPolicy: string(sess.SafetyPolicy),
 	}
 }
 

--- a/pkg/session/safety_policy_test.go
+++ b/pkg/session/safety_policy_test.go
@@ -1,0 +1,62 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSafetyPolicy_IsValid(t *testing.T) {
+	t.Parallel()
+	cases := map[SafetyPolicy]bool{
+		"":                    true,
+		SafetyPolicyUnsafe:    true,
+		SafetyPolicySafer:     true,
+		SafetyPolicyStrict:    true,
+		SafetyPolicy("yolo"):  false,
+		SafetyPolicy("Safer"): false, // case-sensitive on purpose
+	}
+	for in, want := range cases {
+		assert.Equalf(t, want, in.IsValid(), "SafetyPolicy(%q).IsValid()", string(in))
+	}
+}
+
+// WithSafetyPolicy(unsafe) must flip ToolsApproved=true so legacy
+// branches on ToolsApproved (Decide's --yolo short-circuit) still fire.
+// Safer/strict intentionally leave ToolsApproved alone.
+func TestWithSafetyPolicy_UnsafeSyncsToolsApproved(t *testing.T) {
+	t.Parallel()
+	s := New(WithSafetyPolicy(SafetyPolicyUnsafe))
+	assert.Equal(t, SafetyPolicyUnsafe, s.SafetyPolicy)
+	assert.True(t, s.ToolsApproved)
+
+	s = New(WithSafetyPolicy(SafetyPolicySafer))
+	assert.Equal(t, SafetyPolicySafer, s.SafetyPolicy)
+	assert.False(t, s.ToolsApproved)
+}
+
+// WithToolsApproved(true) must backfill SafetyPolicy=unsafe so hooks
+// reading Input.SafetyPolicy see the correct value for legacy --yolo
+// callers (gordon-Slack, MCP, eval) that haven't migrated.
+func TestWithToolsApproved_BackfillsSafetyPolicy(t *testing.T) {
+	t.Parallel()
+	s := New(WithToolsApproved(true))
+	assert.True(t, s.ToolsApproved)
+	assert.Equal(t, SafetyPolicyUnsafe, s.SafetyPolicy)
+
+	s = New(WithToolsApproved(false))
+	assert.False(t, s.ToolsApproved)
+	assert.Equal(t, SafetyPolicy(""), s.SafetyPolicy)
+}
+
+// Explicit WithSafetyPolicy after WithToolsApproved wins over the
+// backfill (e.g. yolo + safer = "auto-approve except destructive").
+func TestWithSafetyPolicy_ExplicitWinsOverToolsApproved(t *testing.T) {
+	t.Parallel()
+	s := New(
+		WithToolsApproved(true),
+		WithSafetyPolicy(SafetyPolicySafer),
+	)
+	assert.True(t, s.ToolsApproved)
+	assert.Equal(t, SafetyPolicySafer, s.SafetyPolicy)
+}

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -25,6 +25,32 @@ const (
 	toolContentPlaceholder = "[content truncated]"
 )
 
+// SafetyPolicy is the per-session safety preference. It is data only:
+// the runtime forwards it to hooks via [hooks.Input.SafetyPolicy] and
+// classifiers (e.g. safer_shell) adapt on it. Empty ⇒ derive from
+// ToolsApproved (true ⇒ unsafe, false ⇒ strict).
+type SafetyPolicy string
+
+const (
+	// SafetyPolicyUnsafe: --yolo / ToolsApproved=true equivalent.
+	// Classifiers stay silent, tool calls auto-approve.
+	SafetyPolicyUnsafe SafetyPolicy = "unsafe"
+	// SafetyPolicySafer: auto-approve except classifier-flagged
+	// destructive calls (blast_radius low/medium/high).
+	SafetyPolicySafer SafetyPolicy = "safer"
+	// SafetyPolicyStrict: today's no-yolo CLI default — prompt for
+	// anything not auto-approved by a checker rule.
+	SafetyPolicyStrict SafetyPolicy = "strict"
+)
+
+func (p SafetyPolicy) IsValid() bool {
+	switch p {
+	case "", SafetyPolicyUnsafe, SafetyPolicySafer, SafetyPolicyStrict:
+		return true
+	}
+	return false
+}
+
 // Item represents a message, a sub-session, a summary, or a recorded error.
 type Item struct {
 	// Message holds a regular conversation message
@@ -121,8 +147,13 @@ type Session struct {
 	// CreatedAt is the time the session was created
 	CreatedAt time.Time `json:"created_at"`
 
-	// ToolsApproved is a flag to indicate if the tools have been approved
+	// ToolsApproved is the legacy --yolo signal. New code should
+	// prefer SafetyPolicy; option setters keep the two in sync.
 	ToolsApproved bool `json:"tools_approved"`
+
+	// SafetyPolicy is the per-session safety preference. See the
+	// [SafetyPolicy] type doc for the three modes and empty-value semantics.
+	SafetyPolicy SafetyPolicy `json:"safety_policy,omitempty"`
 
 	// NonInteractive indicates the session is running in a non-interactive context
 	// (e.g. MCP server, A2A adapter, evaluation framework) where there is no user
@@ -777,9 +808,28 @@ func WithMessages(messages []Item) Opt {
 	}
 }
 
+// WithToolsApproved is the legacy --yolo setter. Prefer
+// [WithSafetyPolicy]. With toolsApproved=true and no explicit
+// SafetyPolicy, pins the policy to [SafetyPolicyUnsafe].
 func WithToolsApproved(toolsApproved bool) Opt {
 	return func(s *Session) {
 		s.ToolsApproved = toolsApproved
+		if toolsApproved && s.SafetyPolicy == "" {
+			s.SafetyPolicy = SafetyPolicyUnsafe
+		}
+	}
+}
+
+// WithSafetyPolicy sets the session's safety preference.
+// [SafetyPolicyUnsafe] also flips ToolsApproved=true so legacy branches
+// on ToolsApproved keep working. The other modes leave ToolsApproved
+// alone — set both if you want auto-approve + selective gating.
+func WithSafetyPolicy(policy SafetyPolicy) Opt {
+	return func(s *Session) {
+		s.SafetyPolicy = policy
+		if policy == SafetyPolicyUnsafe {
+			s.ToolsApproved = true
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `session.SafetyPolicy` (unsafe/safer/strict); `WithToolsApproved(true)` backfills `unsafe` so legacy `--yolo` callers are unchanged.
- Forward the value to hooks via `hooks.Input.SafetyPolicy` (pre_tool_use / pre_tool_use_pre_yolo / permission_request) — pure data, the runtime does not act on it.
- Wire `CreateSessionRequest.SafetyPolicy` for embedders that build sessions through the typed request path.

No behaviour change until a hook reads the field; the adaptive `safer_shell` classifier arrives in a follow-up.

## Test plan
- [ ] `go test ./pkg/session/... ./pkg/hooks/... ./pkg/runtime/toolexec/...` green
- [ ] Confirm legacy `--yolo` behaviour unchanged (`ToolsApproved=true` ⇒ `SafetyPolicy=unsafe`, hooks see `unsafe`)