### PR TITLE
feat: add Hugging Face Inference Providers as a supported model provider

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -182,7 +182,7 @@
       "properties": {
         "provider": {
           "type": "string",
-          "description": "The underlying provider type. Defaults to \"openai\" when not set. Supported values: openai, anthropic, google, amazon-bedrock, dmr, and any built-in alias (requesty, openrouter, azure, xai, ollama, mistral, baseten, ovhcloud, groq, fireworks, deepseek, cerebras, together, etc.).",
+          "description": "The underlying provider type. Defaults to \"openai\" when not set. Supported values: openai, anthropic, google, amazon-bedrock, dmr, and any built-in alias (requesty, openrouter, azure, xai, ollama, mistral, baseten, ovhcloud, groq, fireworks, deepseek, cerebras, together, huggingface, etc.).",
           "examples": [
             "openai",
             "anthropic",

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -155,6 +155,8 @@
       url: /providers/google/
     - title: Groq
       url: /providers/groq/
+    - title: Hugging Face
+      url: /providers/huggingface/
     - title: Local Models
       url: /providers/local/
     - title: MiniMax

--- a/docs/concepts/models/index.md
+++ b/docs/concepts/models/index.md
@@ -88,6 +88,7 @@ for details.
 | DeepSeek            | `deepseek`       | DeepSeek-V3 chat and R1 reasoner     | `DEEPSEEK_API_KEY`                  |
 | Cerebras            | `cerebras`       | GPT-OSS, GLM (fast inference)         | `CEREBRAS_API_KEY`                  |
 | Together AI         | `together`       | Llama, Qwen, DeepSeek, Kimi (open models) | `TOGETHER_API_KEY`             |
+| Hugging Face        | `huggingface`    | Llama, Qwen, DeepSeek, GLM (open models) | `HF_TOKEN`                      |
 | Requesty            | `requesty`       | Multi-provider gateway               | `REQUESTY_API_KEY`                  |
 | OpenRouter          | `openrouter`     | Multi-provider gateway               | `OPENROUTER_API_KEY`                |
 | Azure OpenAI        | `azure`          | gpt-4o, gpt-5 on Azure               | `AZURE_API_KEY` + `base_url`        |

--- a/docs/configuration/models/index.md
+++ b/docs/configuration/models/index.md
@@ -17,7 +17,7 @@ models:
     first_available: [list] # Optional: candidate model refs, tried in order by available credentials.
                             # Mutually exclusive with other model settings.
     provider: string # Required unless using first_available. One of: openai, anthropic, google, amazon-bedrock,
-                     # dmr, mistral, xai, nebius, minimax, baseten, ovhcloud, groq, fireworks, deepseek, cerebras, together, requesty, openrouter,
+                     # dmr, mistral, xai, nebius, minimax, baseten, ovhcloud, groq, fireworks, deepseek, cerebras, together, huggingface, requesty, openrouter,
                      # azure, ollama, github-copilot, or a named provider defined
                      # under the top-level `providers:` section.
     model: string # Required: model identifier
@@ -48,7 +48,7 @@ models:
 | Property              | Type       | Required | Description                                                                           |
 | --------------------- | ---------- | -------- | ------------------------------------------------------------------------------------- |
 | `first_available`     | array      | ✗        | Candidate model references tried in order; selects the first whose credentials are configured. Mutually exclusive with other model settings. |
-| `provider`            | string     | ✓/✗      | Required for regular model definitions; omitted for `first_available` selectors. Provider: `openai`, `anthropic`, `google`, `amazon-bedrock`, `dmr`, `mistral`, `xai`, `nebius`, `minimax`, `baseten`, `ovhcloud`, `groq`, `fireworks`, `deepseek`, `cerebras`, `together`, `requesty`, `openrouter`, `azure`, `ollama`, `github-copilot`, or any [named provider]({{ '/providers/custom/' | relative_url }}). |
+| `provider`            | string     | ✓/✗      | Required for regular model definitions; omitted for `first_available` selectors. Provider: `openai`, `anthropic`, `google`, `amazon-bedrock`, `dmr`, `mistral`, `xai`, `nebius`, `minimax`, `baseten`, `ovhcloud`, `groq`, `fireworks`, `deepseek`, `cerebras`, `together`, `huggingface`, `requesty`, `openrouter`, `azure`, `ollama`, `github-copilot`, or any [named provider]({{ '/providers/custom/' | relative_url }}). |
 | `model`               | string     | ✓/✗      | Required for regular model definitions; omitted for `first_available` selectors. Model name (e.g., `gpt-4o`, `claude-sonnet-4-5`, `gemini-3.5-flash`) |
 | `temperature`         | float      | ✗        | Sampling randomness. Range is provider-dependent — typically `0.0–2.0` (Anthropic caps at `1.0`). `0.0` is deterministic. |
 | `max_tokens`          | int        | ✗        | Maximum response length in tokens                                                     |
@@ -404,7 +404,7 @@ See the [Anthropic provider page]({{ '/providers/anthropic/#thinking-display' | 
 ## Custom HTTP Headers
 
 For OpenAI-compatible providers (`openai`, `github-copilot`, `mistral`, `xai`,
-`nebius`, `minimax`, `baseten`, `ovhcloud`, `groq`, `fireworks`, `deepseek`, `cerebras`, `together`, `requesty`, `openrouter`, `ollama`, and any custom provider using the OpenAI API),
+`nebius`, `minimax`, `baseten`, `ovhcloud`, `groq`, `fireworks`, `deepseek`, `cerebras`, `together`, `huggingface`, `requesty`, `openrouter`, `ollama`, and any custom provider using the OpenAI API),
 `provider_opts.http_headers` adds arbitrary HTTP headers to every outgoing
 request:
 

--- a/docs/providers/huggingface/index.md
+++ b/docs/providers/huggingface/index.md
@@ -1,0 +1,101 @@
+---
+title: "Hugging Face"
+description: "Use Hugging Face Inference Providers with docker-agent."
+permalink: /providers/huggingface/
+---
+
+# Hugging Face
+
+_Use Hugging Face Inference Providers with docker-agent._
+
+## Overview
+
+[Hugging Face Inference Providers](https://huggingface.co/docs/inference-providers/index)
+routes requests to open models (Llama, Qwen, DeepSeek, Kimi, GLM and others)
+across many backends through a single OpenAI-compatible endpoint. docker-agent
+includes built-in support for Hugging Face as an alias provider.
+
+## Setup
+
+1. Create a token from the [Hugging Face token settings](https://huggingface.co/settings/tokens).
+2. Set the environment variable:
+
+   ```bash
+   export HF_TOKEN=your-token
+   ```
+
+## Usage
+
+### Inline Syntax
+
+The simplest way to use Hugging Face:
+
+```yaml
+agents:
+  root:
+    model: huggingface/meta-llama/Llama-3.3-70B-Instruct
+    description: Assistant using Hugging Face Inference Providers
+    instruction: You are a helpful assistant.
+```
+
+### Named Model
+
+For more control over parameters:
+
+```yaml
+models:
+  huggingface_model:
+    provider: huggingface
+    model: meta-llama/Llama-3.3-70B-Instruct
+    temperature: 0.7
+    max_tokens: 8192
+
+agents:
+  root:
+    model: huggingface_model
+    description: Assistant using Hugging Face Inference Providers
+    instruction: You are a helpful assistant.
+```
+
+## Available Models
+
+Hugging Face routes to a broad, changing catalog of open-weight models. Check the
+[Hugging Face models page](https://huggingface.co/models?inference_provider=all)
+for current model IDs, context limits, and pricing.
+
+| Model | Description |
+| --- | --- |
+| `meta-llama/Llama-3.3-70B-Instruct` | Llama 3.3 70B, general-purpose chat and tool calling |
+| `Qwen/Qwen3-235B-A22B` | Qwen3 235B mixture-of-experts instruct model |
+| `deepseek-ai/DeepSeek-V3.2` | DeepSeek, strong coding and reasoning |
+
+> Model IDs are case-sensitive and must be passed exactly as the catalogue lists
+> them.
+
+## How It Works
+
+Hugging Face is implemented as a built-in alias in docker-agent:
+
+- **API Type:** OpenAI-compatible (`openai_chatcompletions`)
+- **Base URL:** `https://router.huggingface.co/v1`
+- **Token Variable:** `HF_TOKEN`
+
+Because Hugging Face fronts open-weight models whose chat templates may reject
+more than one leading system message, docker-agent coalesces its per-source
+system messages into a single one for this provider.
+
+## Example: Code Assistant
+
+```yaml
+agents:
+  coder:
+    model: huggingface/Qwen/Qwen3-Coder-480B-A35B-Instruct
+    description: Code assistant using Qwen3 Coder on Hugging Face
+    instruction: |
+      You are an expert programmer.
+      Write clean, well-documented code and follow language best practices.
+    toolsets:
+      - type: filesystem
+      - type: shell
+      - type: think
+```

--- a/docs/providers/overview/index.md
+++ b/docs/providers/overview/index.md
@@ -72,6 +72,7 @@ docker-agent also includes built-in aliases for these providers:
 | DeepSeek       | `deepseek`       | `DEEPSEEK_API_KEY`                  |
 | Cerebras       | `cerebras`       | `CEREBRAS_API_KEY`                  |
 | Together AI    | `together`       | `TOGETHER_API_KEY`                  |
+| Hugging Face   | `huggingface`    | `HF_TOKEN`                          |
 | Requesty       | `requesty`       | `REQUESTY_API_KEY`                  |
 | OpenRouter     | `openrouter`     | `OPENROUTER_API_KEY`                |
 | Azure OpenAI   | `azure`          | `AZURE_API_KEY` + `base_url`        |

--- a/examples/README.md
+++ b/examples/README.md
@@ -200,6 +200,7 @@ remote MCP endpoints.
 | [`deepseek.yaml`](deepseek.yaml) | DeepSeek chat and reasoning provider. |
 | [`cerebras.yaml`](cerebras.yaml) | Cerebras fast-inference provider. |
 | [`together.yaml`](together.yaml) | Together AI open-model inference provider. |
+| [`huggingface.yaml`](huggingface.yaml) | Hugging Face Inference Providers open-model router. |
 | [`grok.yaml`](grok.yaml) | xAI Grok model. |
 | [`github-copilot.yaml`](github-copilot.yaml) | GitHub Copilot models via OAuth device-flow. |
 | [`fallback_models.yaml`](fallback_models.yaml) | Automatic fallback to a secondary model when the primary fails. |

--- a/examples/huggingface.yaml
+++ b/examples/huggingface.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=../agent-schema.json
+
+models:
+  huggingface_model:
+    provider: huggingface
+    model: meta-llama/Llama-3.3-70B-Instruct
+
+agents:
+  root:
+    model: huggingface_model
+    description: Assistant using Hugging Face Inference Providers
+    instruction: |
+      You are a helpful assistant.
+    toolsets:
+      - type: filesystem
+      - type: shell
+      - type: think

--- a/pkg/config/auto.go
+++ b/pkg/config/auto.go
@@ -61,6 +61,7 @@ var cloudProviders = []providerConfig{
 	{"deepseek", []string{"DEEPSEEK_API_KEY"}, "DEEPSEEK_API_KEY", "DEEPSEEK_API_KEY"},
 	{"cerebras", []string{"CEREBRAS_API_KEY"}, "CEREBRAS_API_KEY", "CEREBRAS_API_KEY"},
 	{"together", []string{"TOGETHER_API_KEY"}, "TOGETHER_API_KEY", "TOGETHER_API_KEY"},
+	{"huggingface", []string{"HF_TOKEN"}, "HF_TOKEN", "HF_TOKEN"},
 	{"amazon-bedrock", []string{
 		"AWS_BEARER_TOKEN_BEDROCK",
 		"AWS_ACCESS_KEY_ID",
@@ -131,6 +132,7 @@ var DefaultModels = map[string]string{
 	"deepseek":       "deepseek-chat",
 	"cerebras":       "gpt-oss-120b",
 	"together":       "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+	"huggingface":    "meta-llama/Llama-3.3-70B-Instruct",
 	"amazon-bedrock": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
 	"opencode-go":    "deepseek-v4-flash",
 	"opencode-zen":   "deepseek-v4-flash-free",

--- a/pkg/config/auto_test.go
+++ b/pkg/config/auto_test.go
@@ -106,6 +106,13 @@ func TestAvailableProviders_NoGateway(t *testing.T) {
 			expectedProvider: "together",
 		},
 		{
+			name: "huggingface token present",
+			envVars: map[string]string{
+				"HF_TOKEN": "test-token",
+			},
+			expectedProvider: "huggingface",
+		},
+		{
 			name:             "no api keys - defaults to dmr",
 			envVars:          map[string]string{},
 			expectedProvider: "dmr",
@@ -331,6 +338,15 @@ func TestAutoModelConfig(t *testing.T) {
 			expectedMaxTokens: 32000,
 		},
 		{
+			name: "huggingface provider",
+			envVars: map[string]string{
+				"HF_TOKEN": "test-token",
+			},
+			expectedProvider:  "huggingface",
+			expectedModel:     "meta-llama/Llama-3.3-70B-Instruct",
+			expectedMaxTokens: 32000,
+		},
+		{
 			name:              "dmr provider (no api keys)",
 			envVars:           map[string]string{},
 			expectedProvider:  "dmr",
@@ -412,7 +428,7 @@ func TestDefaultModels(t *testing.T) {
 	t.Parallel()
 
 	// Test that DefaultModels map has all expected providers
-	expectedProviders := []string{"openai", "anthropic", "google", "dmr", "mistral", "openrouter", "baseten", "ovhcloud", "groq", "fireworks", "deepseek", "cerebras", "together", "amazon-bedrock", "opencode-zen", "opencode-go"}
+	expectedProviders := []string{"openai", "anthropic", "google", "dmr", "mistral", "openrouter", "baseten", "ovhcloud", "groq", "fireworks", "deepseek", "cerebras", "together", "huggingface", "amazon-bedrock", "opencode-zen", "opencode-go"}
 
 	for _, provider := range expectedProviders {
 		t.Run(provider, func(t *testing.T) {
@@ -436,6 +452,7 @@ func TestDefaultModels(t *testing.T) {
 	assert.Equal(t, "deepseek-chat", DefaultModels["deepseek"])
 	assert.Equal(t, "gpt-oss-120b", DefaultModels["cerebras"])
 	assert.Equal(t, "meta-llama/Llama-3.3-70B-Instruct-Turbo", DefaultModels["together"])
+	assert.Equal(t, "meta-llama/Llama-3.3-70B-Instruct", DefaultModels["huggingface"])
 	assert.Equal(t, "global.anthropic.claude-sonnet-4-5-20250929-v1:0", DefaultModels["amazon-bedrock"])
 	assert.Equal(t, "deepseek-v4-flash", DefaultModels["opencode-go"])
 	assert.Equal(t, "deepseek-v4-flash-free", DefaultModels["opencode-zen"])
@@ -445,7 +462,7 @@ func TestAutoModelConfig_IntegrationWithDefaultModels(t *testing.T) {
 	t.Parallel()
 
 	// Verify that AutoModelConfig always returns a model from DefaultModels
-	providers := []string{"openai", "anthropic", "google", "mistral", "openrouter", "baseten", "ovhcloud", "groq", "fireworks", "deepseek", "cerebras", "together", "opencode-zen"}
+	providers := []string{"openai", "anthropic", "google", "mistral", "openrouter", "baseten", "ovhcloud", "groq", "fireworks", "deepseek", "cerebras", "together", "huggingface", "opencode-zen"}
 
 	for _, provider := range providers {
 		t.Run(provider, func(t *testing.T) {
@@ -479,6 +496,8 @@ func TestAutoModelConfig_IntegrationWithDefaultModels(t *testing.T) {
 				envVars["CEREBRAS_API_KEY"] = "test-key"
 			case "together":
 				envVars["TOGETHER_API_KEY"] = "test-key"
+			case "huggingface":
+				envVars["HF_TOKEN"] = "test-token"
 			case "opencode-zen":
 				envVars["OPENCODE_API_KEY"] = "test-key"
 			}
@@ -632,13 +651,21 @@ func TestAvailableProviders_PrecedenceOrder(t *testing.T) {
 	providers = AvailableProviders(t.Context(), "", env)
 	assert.Equal(t, "cerebras", providers[0])
 
-	// together wins over amazon-bedrock
+	// together wins over huggingface
 	env = environment.NewMapEnvProvider(map[string]string{
-		"TOGETHER_API_KEY":  "test-key",
-		"AWS_ACCESS_KEY_ID": "test-key",
+		"TOGETHER_API_KEY": "test-key",
+		"HF_TOKEN":         "test-token",
 	})
 	providers = AvailableProviders(t.Context(), "", env)
 	assert.Equal(t, "together", providers[0])
+
+	// huggingface wins over amazon-bedrock
+	env = environment.NewMapEnvProvider(map[string]string{
+		"HF_TOKEN":          "test-token",
+		"AWS_ACCESS_KEY_ID": "test-key",
+	})
+	providers = AvailableProviders(t.Context(), "", env)
+	assert.Equal(t, "huggingface", providers[0])
 
 	// Only OPENCODE_API_KEY set - opencode-zen should win (higher priority than opencode-go)
 	env = environment.NewMapEnvProvider(map[string]string{

--- a/pkg/model/provider/aliases.go
+++ b/pkg/model/provider/aliases.go
@@ -103,6 +103,11 @@ var Aliases = map[string]Alias{
 		BaseURL:     "https://api.together.xyz/v1",
 		TokenEnvVar: "TOGETHER_API_KEY",
 	},
+	"huggingface": {
+		APIType:     "openai",
+		BaseURL:     "https://router.huggingface.co/v1",
+		TokenEnvVar: "HF_TOKEN",
+	},
 	"github-copilot": {
 		APIType:     "openai",
 		BaseURL:     "https://api.githubcopilot.com",

--- a/pkg/model/provider/aliases_test.go
+++ b/pkg/model/provider/aliases_test.go
@@ -36,14 +36,15 @@ func TestCatalogAliases(t *testing.T) {
 	t.Parallel()
 
 	expected := map[string]Alias{
-		"openrouter": {APIType: "openai", BaseURL: "https://openrouter.ai/api/v1", TokenEnvVar: "OPENROUTER_API_KEY"},
-		"baseten":    {APIType: "openai", BaseURL: "https://inference.baseten.co/v1", TokenEnvVar: "BASETEN_API_KEY"},
-		"ovhcloud":   {APIType: "openai", BaseURL: "https://oai.endpoints.kepler.ai.cloud.ovh.net/v1", TokenEnvVar: "OVH_AI_ENDPOINTS_ACCESS_TOKEN"},
-		"groq":       {APIType: "openai", BaseURL: "https://api.groq.com/openai/v1", TokenEnvVar: "GROQ_API_KEY"},
-		"deepseek":   {APIType: "openai", BaseURL: "https://api.deepseek.com/v1", TokenEnvVar: "DEEPSEEK_API_KEY"},
-		"cerebras":   {APIType: "openai", BaseURL: "https://api.cerebras.ai/v1", TokenEnvVar: "CEREBRAS_API_KEY"},
-		"fireworks":  {APIType: "openai", BaseURL: "https://api.fireworks.ai/inference/v1", TokenEnvVar: "FIREWORKS_API_KEY"},
-		"together":   {APIType: "openai", BaseURL: "https://api.together.xyz/v1", TokenEnvVar: "TOGETHER_API_KEY"},
+		"openrouter":  {APIType: "openai", BaseURL: "https://openrouter.ai/api/v1", TokenEnvVar: "OPENROUTER_API_KEY"},
+		"baseten":     {APIType: "openai", BaseURL: "https://inference.baseten.co/v1", TokenEnvVar: "BASETEN_API_KEY"},
+		"ovhcloud":    {APIType: "openai", BaseURL: "https://oai.endpoints.kepler.ai.cloud.ovh.net/v1", TokenEnvVar: "OVH_AI_ENDPOINTS_ACCESS_TOKEN"},
+		"groq":        {APIType: "openai", BaseURL: "https://api.groq.com/openai/v1", TokenEnvVar: "GROQ_API_KEY"},
+		"deepseek":    {APIType: "openai", BaseURL: "https://api.deepseek.com/v1", TokenEnvVar: "DEEPSEEK_API_KEY"},
+		"cerebras":    {APIType: "openai", BaseURL: "https://api.cerebras.ai/v1", TokenEnvVar: "CEREBRAS_API_KEY"},
+		"fireworks":   {APIType: "openai", BaseURL: "https://api.fireworks.ai/inference/v1", TokenEnvVar: "FIREWORKS_API_KEY"},
+		"together":    {APIType: "openai", BaseURL: "https://api.together.xyz/v1", TokenEnvVar: "TOGETHER_API_KEY"},
+		"huggingface": {APIType: "openai", BaseURL: "https://router.huggingface.co/v1", TokenEnvVar: "HF_TOKEN"},
 	}
 
 	for name, want := range expected {

--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -237,13 +237,14 @@ func (c *Client) convertMessages(ctx context.Context, messages []chat.Message) [
 // (openai, mistral, xai, minimax, github-copilot, opencode) tolerate multiple
 // system messages and are deliberately absent so their behavior is unchanged.
 var openModelHostProviders = map[string]bool{
-	"baseten":    true,
-	"ovhcloud":   true,
-	"openrouter": true,
-	"nebius":     true,
-	"cerebras":   true,
-	"fireworks":  true,
-	"together":   true,
+	"baseten":     true,
+	"ovhcloud":    true,
+	"openrouter":  true,
+	"nebius":      true,
+	"cerebras":    true,
+	"fireworks":   true,
+	"together":    true,
+	"huggingface": true,
 }
 
 // shouldMergeConsecutiveMessages reports whether the chat-completions request

--- a/pkg/model/provider/openai/system_message_merge_test.go
+++ b/pkg/model/provider/openai/system_message_merge_test.go
@@ -163,6 +163,7 @@ func TestShouldMergeConsecutiveMessages_Gating(t *testing.T) {
 		{"open-model host alias cerebras", &latest.ModelConfig{Provider: "cerebras", Model: "qwen-3-coder-480b"}, true},
 		{"open-model host fireworks", &latest.ModelConfig{Provider: "fireworks", Model: "accounts/fireworks/models/kimi-k2-instruct"}, true},
 		{"open-model host together", &latest.ModelConfig{Provider: "together", Model: "Qwen/Qwen3-235B-A22B-Instruct-2507-tput"}, true},
+		{"open-model host huggingface", &latest.ModelConfig{Provider: "huggingface", Model: "meta-llama/Llama-3.3-70B-Instruct"}, true},
 		{"explicit api_type openai_chatcompletions", &latest.ModelConfig{Provider: "custom", Model: "qwen3", ProviderOpts: map[string]any{"api_type": "openai_chatcompletions"}}, true},
 		// First-party APIs with fixed model lineups: unchanged (no merge).
 		{"first-party mistral", &latest.ModelConfig{Provider: "mistral", Model: "mistral-small"}, false},

--- a/pkg/model/provider/openai_alias_providers_test.go
+++ b/pkg/model/provider/openai_alias_providers_test.go
@@ -74,6 +74,14 @@ var openAIAliasProviders = []openAIAliasProvider{
 		greeting:             "Hello from Together",
 		mergesSystemMessages: true,
 	},
+	{
+		provider:             "huggingface",
+		envVar:               "HF_TOKEN",
+		testKey:              "hf_test-huggingface-key",
+		model:                "meta-llama/Llama-3.3-70B-Instruct",
+		greeting:             "Hello from Hugging Face",
+		mergesSystemMessages: true,
+	},
 }
 
 // TestOpenAIAliasProvider_EndToEndRequest drives a real request through the full


### PR DESCRIPTION
## Summary

Adds first-class support for Hugging Face Inference Providers as an OpenAI-compatible model provider via the alias map, following the existing fireworks/cerebras/together pattern.

Closes #3351

> [!IMPORTANT]
> This branch is stacked on #3376 (Together AI) and targets `feat/together-provider` as its base, so the diff here shows only the Hugging Face changes. Merge #3376 first, then retarget this PR to `main` (or rebase onto `main`); git drops the already-merged Together commit and leaves only the Hugging Face changes. Merging this before #3376 would pull the Together changes in as well.

## Definition of Done

| Item | Status | Where |
| --- | --- | --- |
| Alias entry `huggingface` (`openai`, `https://router.huggingface.co/v1`, `HF_TOKEN`) | done | `pkg/model/provider/aliases.go` |
| Unit test asserts the alias resolves and `IsCatalogProvider("huggingface")` is true | done | `TestCatalogAliases` (`huggingface` row), `pkg/model/provider/aliases_test.go` |
| Provider appears in the model catalog via `CatalogProviders()` | yes (has a `BaseURL`) | `aliases.go` |
| `task test` and `task lint` pass | yes (see Validation) | |
| Example YAML config using a Hugging Face model | done | `examples/huggingface.yaml` |

Beyond the stated DoD, this also wires auto-detection, a default model, the JSON schema, and the provider docs, mirroring how Fireworks/Cerebras/Together were added.

## Design decisions

| Decision | Rationale |
| --- | --- |
| Not listed in `modelsDevAbsentProviders` | models.dev catalogs Hugging Face under the exact id `huggingface` (unlike Together, whose id is `togetherai`). The default/example model is present in that catalog, so `TestParseExamples` validates `examples/huggingface.yaml` against models.dev instead of skipping it. |
| Added to `openModelHostProviders` (system-message coalescing) | Hugging Face fronts open-weight models (Llama, Qwen, DeepSeek, GLM) whose chat templates may reject more than one leading system message. Consecutive system messages are coalesced, per #3344 / #3145 / #2327. |
| Default model `meta-llama/Llama-3.3-70B-Instruct` | Well-known general-purpose open model, present in the models.dev `huggingface` catalog. Analogous to Together's `meta-llama/Llama-3.3-70B-Instruct-Turbo`. |
| Auto-detection priority after `together`, before `amazon-bedrock` | Keeps the open-model-host ordering consistent; precedence assertions updated accordingly. |

## Tests

| Test | Coverage |
| --- | --- |
| `TestCatalogAliases` (`huggingface`) | Alias resolution and catalog membership. |
| `TestParseExamples` (`huggingface.yaml`) | Validates the example config, including a real models.dev lookup of `meta-llama/Llama-3.3-70B-Instruct` under the `huggingface` provider. |
| `TestOpenAIAliasProvider_EndToEndRequest` (`huggingface`) | Real HTTP request through the full stack against a local OpenAI-compatible server: asserts POST, `Bearer HF_TOKEN`, `/chat/completions` route, verbatim model, stream reassembly, and that consecutive system messages are coalesced into one. |
| `TestOpenAIAliasProvider_LiveAPI` (`huggingface`) | Live API call, skipped unless `HF_TOKEN` is set, so the default run stays hermetic. |
| `TestShouldMergeConsecutiveMessages_Gating` (`huggingface`) | Asserts coalescing is enabled for `huggingface`. |
| `auto_test.go` cases | Detection, default model, precedence chain, integration with `DefaultModels`. |

## Validation

| Gate | Result |
| --- | --- |
| `task build` | passes |
| `golangci-lint` on the changed packages (with `.golangci.yml`) | 0 issues |
| touched-package tests (`pkg/config`, `pkg/model/provider`, `pkg/model/provider/openai`) | pass; the only failure is the pre-existing SSRF/network test (`TestURLSource_Read_RejectsLocalAddresses`), which requires live network and is unrelated to this change |
| `go.mod` / `go.sum` | untouched |
