### PR TITLE
fix(tui): keep tool call render stable while args stream

### DIFF
--- a/pkg/leantui/tool.go
+++ b/pkg/leantui/tool.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/charmbracelet/x/ansi"
+
 	"github.com/docker/docker-agent/pkg/tools"
 	"github.com/docker/docker-agent/pkg/tui/animation"
 	toolcomponent "github.com/docker/docker-agent/pkg/tui/components/tool"
@@ -15,8 +17,10 @@ import (
 // the same TUI message shape used by the full-screen TUI so the lean renderer
 // can delegate the visual representation to pkg/tui/components/tool.
 type toolView struct {
-	message *tuitypes.Message
-	images  []inlineImage
+	message   *tuitypes.Message
+	images    []inlineImage
+	lastWidth int
+	lastLines []string
 }
 
 const maxToolOutputLines = 12
@@ -38,14 +42,14 @@ func ensureToolDefinition(toolCall tools.ToolCall, toolDef tools.Tool) tools.Too
 // full TUI. This keeps built-in tools and registered custom renderers visually
 // consistent between the normal and lean interfaces.
 func renderTool(t toolView, width int) []string {
-	return renderToolWithState(t, width, 0, service.StaticSessionState{})
+	return renderToolWithState(&t, width, 0, service.StaticSessionState{})
 }
 
-func renderToolWithState(t toolView, width, frame int, sessionState service.SessionStateReader) []string {
+func renderToolWithState(t *toolView, width, frame int, sessionState service.SessionStateReader) []string {
 	if width < 1 {
 		width = 1
 	}
-	if t.message == nil {
+	if t == nil || t.message == nil {
 		return nil
 	}
 	if sessionState == nil {
@@ -63,7 +67,40 @@ func renderToolWithState(t toolView, width, frame int, sessionState service.Sess
 	for _, img := range t.images {
 		lines = append(lines, renderInlineImage(img, width)...)
 	}
+
+	if t.shouldKeepLastPendingLines(width, lines) {
+		return cloneLines(t.lastLines)
+	}
+	if t.message.ToolStatus == tuitypes.ToolStatusPending && len(lines) > 0 {
+		t.lastWidth = width
+		t.lastLines = cloneLines(lines)
+	} else if t.message.ToolStatus != tuitypes.ToolStatusPending {
+		t.lastLines = nil
+		t.lastWidth = 0
+	}
 	return lines
+}
+
+func (t *toolView) shouldKeepLastPendingLines(width int, lines []string) bool {
+	if t.message.ToolStatus != tuitypes.ToolStatusPending || t.lastWidth != width || len(t.lastLines) == 0 {
+		return false
+	}
+	if len(lines) == 0 || len(lines) < len(t.lastLines) {
+		return true
+	}
+	return len(lines) == len(t.lastLines) && totalContentWidth(lines) < totalContentWidth(t.lastLines)
+}
+
+func cloneLines(lines []string) []string {
+	return append([]string(nil), lines...)
+}
+
+func totalContentWidth(lines []string) int {
+	total := 0
+	for _, line := range lines {
+		total += displayWidth(strings.TrimRight(ansi.Strip(line), " "))
+	}
+	return total
 }
 
 func splitRenderedTool(rendered string, width int) []string {

--- a/pkg/leantui/tool_test.go
+++ b/pkg/leantui/tool_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/tools/builtin/filesystem"
 	builtinshell "github.com/docker/docker-agent/pkg/tools/builtin/shell"
 	"github.com/docker/docker-agent/pkg/tui/animation"
 	tuitypes "github.com/docker/docker-agent/pkg/tui/types"
@@ -34,10 +36,43 @@ func TestRenderToolUsesFullTUIRenderer(t *testing.T) {
 }
 
 func TestRenderToolDoesNotLeakAnimationSubscription(t *testing.T) {
-	t.Parallel()
 	assert.False(t, animation.HasActive())
-	renderToolWithState(*shellToolView(tuitypes.ToolStatusRunning), 80, 3, nil)
+	renderToolWithState(shellToolView(tuitypes.ToolStatusRunning), 80, 3, nil)
 	assert.False(t, animation.HasActive())
+}
+
+func TestRenderToolKeepsLastLinesWhenArgumentsTemporarilyInvalid(t *testing.T) {
+	tv := newToolView("root", tools.ToolCall{
+		ID: "call-1",
+		Function: tools.FunctionCall{
+			Name:      "Write",
+			Arguments: `{"path": "/tmp/file", "content": "hello"`,
+		},
+	}, tools.Tool{Name: "Write"}, tuitypes.ToolStatusPending)
+
+	first := renderToolWithState(tv, 80, 0, nil)
+	require.Contains(t, strings.Join(first, "\n"), "hello")
+
+	tv.message.ToolCall.Function.Arguments += ","
+	second := renderToolWithState(tv, 80, 1, nil)
+	assert.Contains(t, strings.Join(second, "\n"), "hello")
+}
+
+func TestRenderWriteFileKeepsPathWhenArgumentsTemporarilyInvalid(t *testing.T) {
+	tv := newToolView("root", tools.ToolCall{
+		ID: "call-1",
+		Function: tools.FunctionCall{
+			Name:      filesystem.ToolNameWriteFile,
+			Arguments: `{"path": "/tmp/file"`,
+		},
+	}, tools.Tool{Name: filesystem.ToolNameWriteFile}, tuitypes.ToolStatusPending)
+
+	first := renderToolWithState(tv, 80, 0, nil)
+	require.Contains(t, strings.Join(first, "\n"), "/tmp/file")
+
+	tv.message.ToolCall.Function.Arguments += ","
+	second := renderToolWithState(tv, 80, 1, nil)
+	assert.Contains(t, strings.Join(second, "\n"), "/tmp/file")
 }
 
 func shellToolView(status tuitypes.ToolStatus) *toolView {

--- a/pkg/leantui/update.go
+++ b/pkg/leantui/update.go
@@ -480,7 +480,7 @@ func (m *model) finishTool(e *runtime.ToolCallResponseEvent) {
 
 	msg := *tv.message
 	view := toolView{message: &msg, images: tv.images}
-	m.addBlock(func(w int) []string { return renderToolWithState(view, w, 0, m.sessionState) })
+	m.addBlock(func(w int) []string { return renderToolWithState(&view, w, 0, m.sessionState) })
 
 	m.removeTool(id)
 }

--- a/pkg/leantui/view.go
+++ b/pkg/leantui/view.go
@@ -67,7 +67,7 @@ func (m *model) conversationLines(width int) []string {
 	}
 	for _, id := range m.toolOrder {
 		if tv := m.tools[id]; tv != nil {
-			lines = append(lines, renderToolWithState(*tv, width, m.spinnerFrame, m.sessionState)...)
+			lines = append(lines, renderToolWithState(tv, width, m.spinnerFrame, m.sessionState)...)
 			lines = append(lines, "")
 		}
 	}

--- a/pkg/tui/components/tool/api/apitool.go
+++ b/pkg/tui/components/tool/api/apitool.go
@@ -15,19 +15,23 @@ import (
 )
 
 func New(msg *types.Message, sessionState service.SessionStateReader) layout.Model {
-	return toolcommon.NewBase(msg, sessionState, render)
+	var lastParams string
+	return toolcommon.NewBase(msg, sessionState, func(msg *types.Message, s spinner.Spinner, sessionState service.SessionStateReader, width, height int) string {
+		return render(msg, s, sessionState, width, height, &lastParams)
+	})
 }
 
-func render(msg *types.Message, s spinner.Spinner, sessionState service.SessionStateReader, width, _ int) string {
-	var args map[string]any
-	if err := json.Unmarshal([]byte(msg.ToolCall.Function.Arguments), &args); err != nil {
-		return toolcommon.RenderTool(msg, s, "", "", width, sessionState.HideToolResults())
+func render(msg *types.Message, s spinner.Spinner, sessionState service.SessionStateReader, width, _ int, lastParams *string) string {
+	args, err := toolcommon.ParseArgs[map[string]any](msg.ToolCall.Function.Arguments)
+	if err != nil {
+		return toolcommon.RenderTool(msg, s, *lastParams, "", width, sessionState.HideToolResults())
 	}
 
 	// Extract argument summary for the tool call display
 	var params string
 	if argsText := formatArgs(args); argsText != "" {
 		params = "(" + argsText + ")"
+		*lastParams = params
 	}
 
 	// Add inline result/progress after the tool name

--- a/pkg/tui/components/tool/defaulttool/defaulttool.go
+++ b/pkg/tui/components/tool/defaulttool/defaulttool.go
@@ -11,13 +11,21 @@ import (
 // New creates a new default tool component.
 // It provides a standard visualization with tool name, arguments, and results.
 func New(msg *types.Message, sessionState service.SessionStateReader) layout.Model {
-	return toolcommon.NewBase(msg, sessionState, render)
+	var lastArgs string
+	return toolcommon.NewBase(msg, sessionState, func(msg *types.Message, s spinner.Spinner, sessionState service.SessionStateReader, width, height int) string {
+		return render(msg, s, sessionState, width, height, &lastArgs)
+	})
 }
 
-func render(msg *types.Message, s spinner.Spinner, sessionState service.SessionStateReader, width, _ int) string {
+func render(msg *types.Message, s spinner.Spinner, sessionState service.SessionStateReader, width, _ int, lastArgs *string) string {
 	var argsContent string
 	if msg.ToolCall.Function.Arguments != "" {
 		argsContent = renderToolArgs(msg.ToolCall, width-4-len(msg.ToolDefinition.DisplayName()), width-3)
+		if argsContent != "" {
+			*lastArgs = argsContent
+		} else if msg.ToolStatus == types.ToolStatusPending {
+			argsContent = *lastArgs
+		}
 	}
 
 	if argsContent == "" {

--- a/pkg/tui/components/tool/defaulttool/render.go
+++ b/pkg/tui/components/tool/defaulttool/render.go
@@ -8,6 +8,7 @@ import (
 	"charm.land/lipgloss/v2"
 
 	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/tui/components/toolcommon"
 	"github.com/docker/docker-agent/pkg/tui/styles"
 )
 
@@ -83,6 +84,21 @@ func formatValue(value any) string {
 
 // decodeArguments decodes the JSON-encoded arguments string into an ordered slice of key-value pairs.
 func decodeArguments(arguments string) ([]kv, error) {
+	args, err := decodeArgumentsStrict(arguments)
+	if err == nil {
+		return args, nil
+	}
+
+	if fixed, ok := toolcommon.CompletePartialJSON(arguments); ok {
+		if partialArgs, partialErr := decodeArgumentsStrict(fixed); partialErr == nil {
+			return partialArgs, nil
+		}
+	}
+
+	return nil, err
+}
+
+func decodeArgumentsStrict(arguments string) ([]kv, error) {
 	decoder := json.NewDecoder(strings.NewReader(arguments))
 
 	tok, err := decoder.Token()

--- a/pkg/tui/components/tool/defaulttool/render_test.go
+++ b/pkg/tui/components/tool/defaulttool/render_test.go
@@ -3,7 +3,13 @@ package defaulttool
 import (
 	"testing"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/tui/service"
+	"github.com/docker/docker-agent/pkg/tui/types"
 )
 
 func TestFormatValue_String(t *testing.T) {
@@ -54,4 +60,39 @@ func TestFormatValue_Number(t *testing.T) {
 
 	result := formatValue(42.0)
 	assert.Equal(t, "42", result)
+}
+
+func TestDecodeArgumentsAcceptsPartialStringValue(t *testing.T) {
+	t.Parallel()
+
+	args, err := decodeArguments(`{"path": "/tmp/file", "content": "hello`)
+	require.NoError(t, err)
+	assert.Equal(t, []kv{
+		{Key: "path", Value: "/tmp/file"},
+		{Key: "content", Value: "hello"},
+	}, args)
+}
+
+func TestRendererKeepsLastArgsWhenJSONTemporarilyInvalid(t *testing.T) {
+	t.Parallel()
+
+	msg := types.ToolCallMessage("agent", tools.ToolCall{
+		ID: "call-1",
+		Function: tools.FunctionCall{
+			Name:      "Write",
+			Arguments: `{"path": "/tmp/file", "content": "hello"`,
+		},
+	}, tools.Tool{Name: "Write"}, types.ToolStatusPending)
+
+	view := New(msg, service.StaticSessionState{})
+	_ = view.SetSize(80, 0)
+
+	first := ansi.Strip(view.View())
+	require.Contains(t, first, "content")
+	require.Contains(t, first, "hello")
+
+	msg.ToolCall.Function.Arguments += ","
+	next := ansi.Strip(view.View())
+	assert.Contains(t, next, "content")
+	assert.Contains(t, next, "hello")
 }

--- a/pkg/tui/components/tool/editfile/editfile.go
+++ b/pkg/tui/components/tool/editfile/editfile.go
@@ -20,6 +20,13 @@ func New(msg *types.Message, sessionState service.SessionStateReader) layout.Mod
 	return toolcommon.NewBaseWithCollapsed(msg, sessionState, render, renderCollapsed)
 }
 
+func parseEditFileArgs(args string) (filesystem.EditFileArgs, error) {
+	if parsed, err := toolcommon.ParseArgs[filesystem.EditFileArgs](args); err == nil {
+		return parsed, nil
+	}
+	return filesystem.ParseEditFileArgs([]byte(args))
+}
+
 // render displays the edit_file tool output in the TUI.
 // It prioritizes the agent-provided friendly header when available,
 // hides results when collapsed by the user, and renders tool errors
@@ -31,13 +38,6 @@ func render(
 	width,
 	_ int,
 ) string {
-	// Parse tool arguments to extract the file path for display.
-	args, err := filesystem.ParseEditFileArgs([]byte(msg.ToolCall.Function.Arguments))
-	if err != nil {
-		// If arguments cannot be parsed, fail silently to avoid breaking the TUI.
-		return ""
-	}
-
 	// When the tool failed, render a single-line error header
 	// consistent with other tool error renderings.
 	if msg.ToolStatus == types.ToolStatusError {
@@ -63,6 +63,12 @@ func render(
 	}
 
 	// ---- Normal (non-error) rendering ----
+
+	// Parse tool arguments to extract the file path for display.
+	args, err := parseEditFileArgs(msg.ToolCall.Function.Arguments)
+	if err != nil {
+		return toolcommon.RenderTool(msg, s, "", "", width, sessionState.HideToolResults())
+	}
 
 	// Check for friendly description first
 	var content string
@@ -111,11 +117,6 @@ func renderCollapsed(
 	width,
 	_ int,
 ) string {
-	args, err := filesystem.ParseEditFileArgs([]byte(msg.ToolCall.Function.Arguments))
-	if err != nil {
-		return ""
-	}
-
 	// Error state
 	if msg.ToolStatus == types.ToolStatusError {
 		if msg.Content == "" {
@@ -128,6 +129,11 @@ func renderCollapsed(
 			styles.ToolErrorMessageStyle.Render(msg.Content),
 		)
 		return styles.BaseStyle.MaxWidth(width).Render(line)
+	}
+
+	args, err := parseEditFileArgs(msg.ToolCall.Function.Arguments)
+	if err != nil {
+		return toolcommon.RenderTool(msg, s, "", "", width, false)
 	}
 
 	// Count added/removed lines

--- a/pkg/tui/components/tool/editfile/render.go
+++ b/pkg/tui/components/tool/editfile/render.go
@@ -17,7 +17,6 @@ import (
 	"github.com/docker/docker-agent/pkg/concurrent"
 	"github.com/docker/docker-agent/pkg/lrucache"
 	"github.com/docker/docker-agent/pkg/tools"
-	"github.com/docker/docker-agent/pkg/tools/builtin/filesystem"
 	"github.com/docker/docker-agent/pkg/tui/styles"
 	"github.com/docker/docker-agent/pkg/tui/types"
 )
@@ -123,7 +122,7 @@ func renderEditFile(toolCall tools.ToolCall, width int, splitView bool, toolStat
 }
 
 func renderEditFileUncached(toolCall tools.ToolCall, width int, splitView bool, toolStatus types.ToolStatus) string {
-	args, err := filesystem.ParseEditFileArgs([]byte(toolCall.Function.Arguments))
+	args, err := parseEditFileArgs(toolCall.Function.Arguments)
 	if err != nil {
 		return ""
 	}
@@ -174,7 +173,7 @@ func countDiffLines(toolCall tools.ToolCall, _ types.ToolStatus) (added, removed
 }
 
 func countDiffLinesUncached(toolCall tools.ToolCall) (added, removed int) {
-	args, err := filesystem.ParseEditFileArgs([]byte(toolCall.Function.Arguments))
+	args, err := parseEditFileArgs(toolCall.Function.Arguments)
 	if err != nil {
 		return 0, 0
 	}

--- a/pkg/tui/components/tool/editfile/render_test.go
+++ b/pkg/tui/components/tool/editfile/render_test.go
@@ -7,10 +7,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/tui/service"
 	"github.com/docker/docker-agent/pkg/tui/types"
 )
 
@@ -105,6 +107,23 @@ func TestRenderEditFile_TabIndentedLineDoesNotPanic(t *testing.T) {
 		_ = renderEditFile(toolCall, 120, false, types.ToolStatusCompleted)
 		_ = renderEditFile(toolCall, 120, true, types.ToolStatusCompleted)
 	})
+}
+
+func TestEditFileViewFallsBackToToolHeaderWhenArgumentsCannotParse(t *testing.T) {
+	t.Parallel()
+
+	msg := types.ToolCallMessage("agent", tools.ToolCall{
+		ID: "test-invalid-args",
+		Function: tools.FunctionCall{
+			Name:      "edit_file",
+			Arguments: `{"path": "/tmp/file",`,
+		},
+	}, tools.Tool{Name: "edit_file"}, types.ToolStatusPending)
+
+	view := New(msg, service.StaticSessionState{})
+	_ = view.SetSize(80, 0)
+
+	assert.Contains(t, ansi.Strip(view.View()), "edit_file")
 }
 
 func TestRenderEditFile_MissingFileReturnsEmptyDiff(t *testing.T) {

--- a/pkg/tui/components/tool/handoff/handoff.go
+++ b/pkg/tui/components/tool/handoff/handoff.go
@@ -1,8 +1,6 @@
 package handoff
 
 import (
-	"encoding/json"
-
 	"github.com/docker/docker-agent/pkg/tools/builtin/handoff"
 	"github.com/docker/docker-agent/pkg/tui/components/spinner"
 	"github.com/docker/docker-agent/pkg/tui/components/toolcommon"
@@ -16,10 +14,14 @@ func New(msg *types.Message, sessionState service.SessionStateReader) layout.Mod
 	return toolcommon.NewBase(msg, sessionState, render)
 }
 
-func render(msg *types.Message, _ spinner.Spinner, _ service.SessionStateReader, _, _ int) string {
-	var params handoff.Args
-	if err := json.Unmarshal([]byte(msg.ToolCall.Function.Arguments), &params); err != nil {
-		return ""
+func render(msg *types.Message, s spinner.Spinner, sessionState service.SessionStateReader, width, _ int) string {
+	params, err := toolcommon.ParseArgs[handoff.Args](msg.ToolCall.Function.Arguments)
+	if err != nil || params.Agent == "" {
+		hideResults := false
+		if sessionState != nil {
+			hideResults = sessionState.HideToolResults()
+		}
+		return toolcommon.RenderTool(msg, s, "", "", width, hideResults)
 	}
 
 	return styles.AgentBadgeStyleFor(msg.Sender).MarginLeft(2).Render(msg.Sender) + " ─► " + styles.AgentBadgeStyleFor(params.Agent).Render(params.Agent)

--- a/pkg/tui/components/tool/handoff/handoff_test.go
+++ b/pkg/tui/components/tool/handoff/handoff_test.go
@@ -1,0 +1,30 @@
+package handoff
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/docker/docker-agent/pkg/tools"
+	handofftool "github.com/docker/docker-agent/pkg/tools/builtin/handoff"
+	"github.com/docker/docker-agent/pkg/tui/service"
+	"github.com/docker/docker-agent/pkg/tui/types"
+)
+
+func TestHandoffFallsBackToToolHeaderWhenArgumentsCannotParse(t *testing.T) {
+	t.Parallel()
+
+	msg := types.ToolCallMessage("root", tools.ToolCall{
+		ID: "call-1",
+		Function: tools.FunctionCall{
+			Name:      handofftool.ToolNameHandoff,
+			Arguments: `{"agent":`,
+		},
+	}, tools.Tool{Name: handofftool.ToolNameHandoff}, types.ToolStatusPending)
+
+	view := New(msg, service.StaticSessionState{})
+	_ = view.SetSize(80, 0)
+
+	assert.Contains(t, ansi.Strip(view.View()), handofftool.ToolNameHandoff)
+}

--- a/pkg/tui/components/tool/plantool/plantool.go
+++ b/pkg/tui/components/tool/plantool/plantool.go
@@ -24,7 +24,10 @@ import (
 // New builds the plan tool view: the plan name from the call arguments, plus a
 // compact title/status/revision summary from the result.
 func New(msg *types.Message, sessionState service.SessionStateReader) layout.Model {
-	return toolcommon.NewBase(msg, sessionState, toolcommon.SimpleRendererWithResult(extractName, extractSummary))
+	return toolcommon.NewBase(msg, sessionState, toolcommon.SimpleRendererWithResult(
+		toolcommon.ExtractField(func(a nameArg) string { return a.Name }),
+		extractSummary,
+	))
 }
 
 type nameArg struct {

--- a/pkg/tui/components/tool/readmultiplefiles/readmultiplefiles.go
+++ b/pkg/tui/components/tool/readmultiplefiles/readmultiplefiles.go
@@ -1,7 +1,6 @@
 package readmultiplefiles
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -18,19 +17,16 @@ import (
 )
 
 func New(msg *types.Message, sessionState service.SessionStateReader) layout.Model {
-	return toolcommon.NewBase(msg, sessionState, render)
+	extractPaths := toolcommon.StableExtractor(extractArgs)
+	return toolcommon.NewBase(msg, sessionState, func(msg *types.Message, s spinner.Spinner, sessionState service.SessionStateReader, width, height int) string {
+		return render(msg, s, sessionState, width, height, extractPaths)
+	})
 }
 
-func render(msg *types.Message, s spinner.Spinner, sessionState service.SessionStateReader, width, _ int) string {
-	// Parse arguments
-	var args filesystem.ReadMultipleFilesArgs
-	if err := json.Unmarshal([]byte(msg.ToolCall.Function.Arguments), &args); err != nil {
-		return toolcommon.RenderTool(msg, s, "", "", width, sessionState.HideToolResults())
-	}
-
+func render(msg *types.Message, s spinner.Spinner, sessionState service.SessionStateReader, width, _ int, extractPaths func(string) string) string {
 	// For pending/running state, show files being read
 	if msg.ToolStatus == types.ToolStatusPending || msg.ToolStatus == types.ToolStatusRunning {
-		return toolcommon.RenderTool(msg, s, formatFilesList(args.Paths), "", width, sessionState.HideToolResults())
+		return toolcommon.RenderTool(msg, s, extractPaths(msg.ToolCall.Function.Arguments), "", width, sessionState.HideToolResults())
 	}
 
 	// For completed/error state, render each file line
@@ -111,6 +107,14 @@ func formatSummaryLines(meta *filesystem.ReadMultipleFilesMeta) []fileSummary {
 	}
 
 	return summaries
+}
+
+func extractArgs(args string) string {
+	parsed, err := toolcommon.ParseArgs[filesystem.ReadMultipleFilesArgs](args)
+	if err != nil {
+		return ""
+	}
+	return formatFilesList(parsed.Paths)
 }
 
 // formatFilesList formats a list of file paths for display.

--- a/pkg/tui/components/tool/searchfilescontent/searchfilescontent.go
+++ b/pkg/tui/components/tool/searchfilescontent/searchfilescontent.go
@@ -13,7 +13,7 @@ import (
 
 func New(msg *types.Message, sessionState service.SessionStateReader) layout.Model {
 	return toolcommon.NewBase(msg, sessionState, toolcommon.SimpleRendererWithResult(
-		extractArgs,
+		toolcommon.StableExtractor(extractArgs),
 		extractResult,
 	))
 }

--- a/pkg/tui/components/tool/shell/shell.go
+++ b/pkg/tui/components/tool/shell/shell.go
@@ -15,13 +15,16 @@ import (
 const maxVisibleShellOutputLines = 20
 
 func New(msg *types.Message, sessionState service.SessionStateReader) layout.Model {
-	return toolcommon.NewBase(msg, sessionState, renderShell)
+	extractCmd := toolcommon.ExtractField(func(a builtinshell.RunShellArgs) string { return a.Cmd })
+	return toolcommon.NewBase(msg, sessionState, func(msg *types.Message, s spinner.Spinner, sessionState service.SessionStateReader, width, height int) string {
+		return renderShell(msg, s, sessionState, width, height, extractCmd)
+	})
 }
 
-func renderShell(msg *types.Message, s spinner.Spinner, sessionState service.SessionStateReader, width, _ int) string {
+func renderShell(msg *types.Message, s spinner.Spinner, sessionState service.SessionStateReader, width, _ int, extractCmd func(string) string) string {
 	arg := ""
 	if msg.ToolCall.Function.Arguments != "" {
-		arg = toolcommon.ExtractField(func(a builtinshell.RunShellArgs) string { return a.Cmd })(msg.ToolCall.Function.Arguments)
+		arg = extractCmd(msg.ToolCall.Function.Arguments)
 	}
 
 	result := ""

--- a/pkg/tui/components/tool/transfertask/transfertask.go
+++ b/pkg/tui/components/tool/transfertask/transfertask.go
@@ -1,7 +1,6 @@
 package transfertask
 
 import (
-	"encoding/json"
 	"strings"
 
 	"charm.land/lipgloss/v2"
@@ -19,10 +18,14 @@ func New(msg *types.Message, sessionState service.SessionStateReader) layout.Mod
 	return toolcommon.NewBase(msg, sessionState, render)
 }
 
-func render(msg *types.Message, s spinner.Spinner, _ service.SessionStateReader, width, _ int) string {
-	var params transfertask.Args
-	if err := json.Unmarshal([]byte(msg.ToolCall.Function.Arguments), &params); err != nil {
-		return ""
+func render(msg *types.Message, s spinner.Spinner, sessionState service.SessionStateReader, width, _ int) string {
+	params, err := toolcommon.ParseArgs[transfertask.Args](msg.ToolCall.Function.Arguments)
+	if err != nil || (params.Agent == "" && params.Task == "") {
+		hideResults := false
+		if sessionState != nil {
+			hideResults = sessionState.HideToolResults()
+		}
+		return toolcommon.RenderTool(msg, s, "", "", width, hideResults)
 	}
 
 	header := styles.AgentBadgeStyleFor(msg.Sender).MarginLeft(2).Render(msg.Sender) +

--- a/pkg/tui/components/tool/transfertask/transfertask_test.go
+++ b/pkg/tui/components/tool/transfertask/transfertask_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/docker/docker-agent/pkg/tools"
+	transfertasktool "github.com/docker/docker-agent/pkg/tools/builtin/transfertask"
+	"github.com/docker/docker-agent/pkg/tui/service"
 	"github.com/docker/docker-agent/pkg/tui/types"
 )
 
@@ -79,6 +81,23 @@ func TestTransferTaskCard_StatusIcon(t *testing.T) {
 // the icon stays a single glyph with no elapsed-time suffix, so the wrapped
 // task text keeps the same indent across statuses. Swapping in an elapsed-time
 // icon (e.g. toolcommon.Icon) would shift the running task column and regress.
+func TestTransferTaskFallsBackToToolHeaderWhenArgumentsCannotParse(t *testing.T) {
+	t.Parallel()
+
+	msg := types.ToolCallMessage("root", tools.ToolCall{
+		ID: "call-1",
+		Function: tools.FunctionCall{
+			Name:      transfertasktool.ToolNameTransferTask,
+			Arguments: `{"agent":`,
+		},
+	}, tools.Tool{Name: transfertasktool.ToolNameTransferTask}, types.ToolStatusPending)
+
+	view := New(msg, service.StaticSessionState{})
+	_ = view.SetSize(80, 0)
+
+	assert.Contains(t, stripANSI(view.View()), transfertasktool.ToolNameTransferTask)
+}
+
 func TestTransferTaskCard_IconWidthIsStable(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tui/components/tool/writefile/writefile_test.go
+++ b/pkg/tui/components/tool/writefile/writefile_test.go
@@ -1,0 +1,36 @@
+package writefile
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/tools/builtin/filesystem"
+	"github.com/docker/docker-agent/pkg/tui/service"
+	"github.com/docker/docker-agent/pkg/tui/types"
+)
+
+func TestStreamingArgumentsKeepLastPathWhenJSONTemporarilyInvalid(t *testing.T) {
+	t.Parallel()
+
+	msg := types.ToolCallMessage("agent", tools.ToolCall{
+		ID: "call-1",
+		Function: tools.FunctionCall{
+			Name:      filesystem.ToolNameWriteFile,
+			Arguments: `{"path": "/tmp/file"`,
+		},
+	}, tools.Tool{Name: filesystem.ToolNameWriteFile}, types.ToolStatusPending)
+
+	view := New(msg, service.StaticSessionState{})
+	_ = view.SetSize(80, 0)
+
+	first := ansi.Strip(view.View())
+	require.Contains(t, first, "/tmp/file")
+
+	msg.ToolCall.Function.Arguments += ","
+	next := ansi.Strip(view.View())
+	assert.Contains(t, next, "/tmp/file")
+}

--- a/pkg/tui/components/toolcommon/base.go
+++ b/pkg/tui/components/toolcommon/base.go
@@ -1,7 +1,10 @@
 package toolcommon
 
 import (
+	"strings"
+
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/docker/docker-agent/pkg/tui/components/spinner"
 	"github.com/docker/docker-agent/pkg/tui/core/layout"
@@ -21,14 +24,18 @@ type CollapsedRenderer func(msg *types.Message, s spinner.Spinner, sessionState 
 // Base provides common boilerplate for tool components.
 // It handles spinner management, sizing, and delegates rendering to a custom function.
 type Base struct {
-	message           *types.Message
-	spinner           spinner.Spinner
-	width             int
-	height            int
-	sessionState      service.SessionStateReader // read-only access to session state
-	render            Renderer
-	collapsedRenderer CollapsedRenderer
-	spinnerRegistered bool // tracks whether spinner is registered with coordinator
+	message             *types.Message
+	spinner             spinner.Spinner
+	width               int
+	height              int
+	sessionState        service.SessionStateReader // read-only access to session state
+	render              Renderer
+	collapsedRenderer   CollapsedRenderer
+	spinnerRegistered   bool // tracks whether spinner is registered with coordinator
+	lastRendered        string
+	lastRenderedHeight  int
+	lastCollapsed       string
+	lastCollapsedHeight int
 }
 
 // NewBase creates a new base tool component with the given renderer.
@@ -59,6 +66,12 @@ func NewBaseWithCollapsed(msg *types.Message, sessionState service.SessionStateR
 }
 
 func (b *Base) SetSize(width, height int) tea.Cmd {
+	if b.width != width || b.height != height {
+		b.lastRendered = ""
+		b.lastRenderedHeight = 0
+		b.lastCollapsed = ""
+		b.lastCollapsedHeight = 0
+	}
 	b.width = width
 	b.height = height
 	return nil
@@ -99,7 +112,16 @@ func (b *Base) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 }
 
 func (b *Base) View() string {
-	return b.render(b.message, b.spinner, b.sessionState, b.width, b.height)
+	rendered := b.render(b.message, b.spinner, b.sessionState, b.width, b.height)
+	height := renderedViewHeight(rendered)
+	if b.shouldKeepLastPendingRender(rendered, height, b.lastRendered, b.lastRenderedHeight) {
+		return b.lastRendered
+	}
+	if rendered != "" {
+		b.lastRendered = rendered     //rubocop:disable Lint/TUIViewPurity // render-stability cache for temporarily unparseable streamed arguments
+		b.lastRenderedHeight = height //rubocop:disable Lint/TUIViewPurity // paired height for the render-stability cache above
+	}
+	return rendered
 }
 
 // ExpandedView returns the regular, full tool renderer.
@@ -111,9 +133,43 @@ func (b *Base) ExpandedView() string {
 // Falls back to the regular View() if no collapsed renderer is provided.
 func (b *Base) CollapsedView() string {
 	if b.collapsedRenderer != nil {
-		return b.collapsedRenderer(b.message, b.spinner, b.sessionState, b.width, b.height)
+		rendered := b.collapsedRenderer(b.message, b.spinner, b.sessionState, b.width, b.height)
+		height := renderedViewHeight(rendered)
+		if b.shouldKeepLastPendingRender(rendered, height, b.lastCollapsed, b.lastCollapsedHeight) {
+			return b.lastCollapsed
+		}
+		if rendered != "" {
+			b.lastCollapsed = rendered
+			b.lastCollapsedHeight = height
+		}
+		return rendered
 	}
 	return b.View()
+}
+
+func (b *Base) shouldKeepLastPendingRender(rendered string, height int, last string, lastHeight int) bool {
+	if b.message.ToolStatus != types.ToolStatusPending || last == "" {
+		return false
+	}
+	if rendered == "" || height < lastHeight {
+		return true
+	}
+	return height == lastHeight && renderedContentWidth(rendered) < renderedContentWidth(last)
+}
+
+func renderedContentWidth(rendered string) int {
+	total := 0
+	for line := range strings.SplitSeq(strings.TrimSuffix(rendered, "\n"), "\n") {
+		total += ansi.StringWidth(strings.TrimRight(ansi.Strip(line), " "))
+	}
+	return total
+}
+
+func renderedViewHeight(rendered string) int {
+	if rendered == "" {
+		return 0
+	}
+	return strings.Count(strings.TrimSuffix(rendered, "\n"), "\n") + 1
 }
 
 // StopAnimation stops the spinner animation and unregisters from the animation coordinator.

--- a/pkg/tui/components/toolcommon/common.go
+++ b/pkg/tui/components/toolcommon/common.go
@@ -89,16 +89,56 @@ func tryFixPartialJSON(s string) (string, bool) {
 	return result.String(), true
 }
 
+// CompletePartialJSON attempts to complete a partial JSON object by closing
+// any unclosed strings, arrays, and objects.
+func CompletePartialJSON(s string) (string, bool) {
+	return tryFixPartialJSON(s)
+}
+
 // ExtractField creates an argument extractor function that parses JSON and extracts a field.
 // The field function receives the parsed args and returns the display string.
-// It supports partial JSON parsing for streaming tool calls.
+// It supports partial JSON parsing for streaming tool calls and keeps the last
+// parsed value while a later argument fragment is temporarily unparseable.
 func ExtractField[T any](field func(T) string) func(string) string {
+	var last string
+	var hasLast bool
+
 	return func(args string) string {
 		parsed, err := ParseArgs[T](args)
 		if err != nil {
+			if hasLast {
+				return last
+			}
 			return ""
 		}
-		return field(parsed)
+
+		value := field(parsed)
+		if value != "" {
+			last = value
+			hasLast = true
+		}
+		return value
+	}
+}
+
+// StableExtractor wraps an argument extractor so transient empty returns keep
+// showing the last non-empty value. This is useful for streaming tool-call
+// arguments where an intermediate JSON fragment may be impossible to parse.
+func StableExtractor(extract func(string) string) func(string) string {
+	var last string
+	var hasLast bool
+
+	return func(args string) string {
+		value := extract(args)
+		if value != "" {
+			last = value
+			hasLast = true
+			return value
+		}
+		if hasLast {
+			return last
+		}
+		return ""
 	}
 }
 

--- a/pkg/tui/components/toolcommon/common_test.go
+++ b/pkg/tui/components/toolcommon/common_test.go
@@ -101,6 +101,35 @@ func TestTryFixPartialJSON(t *testing.T) {
 	}
 }
 
+func TestExtractFieldKeepsLastValueWhenFragmentCannotParse(t *testing.T) {
+	t.Parallel()
+	type testArgs struct {
+		Path string `json:"path"`
+	}
+
+	extractPath := ExtractField(func(a testArgs) string { return a.Path })
+
+	assert.Equal(t, "/tmp/file", extractPath(`{"path": "/tmp/file"`))
+	assert.Equal(t, "/tmp/file", extractPath(`{"path": "/tmp/file",`))
+	assert.Equal(t, "/tmp/file", extractPath(`{"path": "/tmp/file", "content": "hello\`))
+	assert.Equal(t, "/tmp/other", extractPath(`{"path": "/tmp/other"}`))
+}
+
+func TestStableExtractorKeepsLastNonEmptyValue(t *testing.T) {
+	t.Parallel()
+
+	extract := StableExtractor(func(args string) string {
+		if args == "bad" {
+			return ""
+		}
+		return args
+	})
+
+	assert.Equal(t, "first", extract("first"))
+	assert.Equal(t, "first", extract("bad"))
+	assert.Equal(t, "second", extract("second"))
+}
+
 func TestParsePartialArgs(t *testing.T) {
 	t.Parallel()
 	type testArgs struct {

--- a/pkg/tui/components/transcript/transcript.go
+++ b/pkg/tui/components/transcript/transcript.go
@@ -113,6 +113,9 @@ func (t *Transcript) AddOrUpdateToolCall(agentName string, toolCall tools.ToolCa
 				msg.ToolCall.Function.Arguments = toolCall.Function.Arguments
 			}
 		}
+		if msg.ToolStatus == status {
+			return nil
+		}
 		return t.refreshToolView(i, status)
 	}
 	t.RemoveLast(types.MessageTypeSpinner)


### PR DESCRIPTION
Remember the last stable pending tool render and fall back to tool headers when streamed arguments are temporarily unparseable. This prevents lean TUI tool calls like edit_file from briefly disappearing or shrinking while JSON arguments are still streaming.