### PR TITLE
feat(hooks/safer_shell): adapt classification to session SafetyPolicy

### DIFF
--- a/pkg/hooks/builtins/safer_shell.go
+++ b/pkg/hooks/builtins/safer_shell.go
@@ -1,23 +1,24 @@
 package builtins
 
-// safer_shell is the destructive-command guard for the shell toolset.
-// It fires on EventPreToolUse (registered with preempt_yolo:true so
-// the runtime dispatches it before Decide()/--yolo) and classifies
-// each shell call against an embedded taxonomy:
+// safer_shell classifies shell tool calls and adapts its verdict to
+// the session's SafetyPolicy (read from hooks.Input.SafetyPolicy).
+// Registered on pre_tool_use with preempt_yolo:true so it runs before
+// Decide()/--yolo.
 //
-//   1. Destructive match → Ask + Metadata{blast_radius, category, reason}
-//   2. Safe match        → nil (no opinion; falls through to the
-//                          regular approval pipeline — Decide() /
-//                          --yolo / permissions / readonly hint)
-//   3. No match          → Ask + Metadata{blast_radius=unknown}; the
-//                          user opted into "safer mode", so an
-//                          unrecognised command still surfaces.
+// Modes:
+//   unsafe — silent; returns nil (restores --yolo semantics).
+//   safer  — destructive matches ask; safe-list and unknown fall through.
+//   strict — destructive matches ask; safe-list returns nil; unknown
+//            asks with blast_radius=unknown. Empty SafetyPolicy is
+//            treated as strict.
 //
-// Compound shell (a && b, a; b, a | b) does NOT match a single
-// destructive or safe pattern and falls through to branch 3 by
-// design. The matcher is regex-based on a whitespace-normalised form
-// of the command; the `<placeholder>` syntax in patterns matches a
-// single non-whitespace token, and `...` matches any tail.
+// The legacy --yolo boolean is backfilled to SafetyPolicy=unsafe by
+// pkg/session.WithToolsApproved so existing callers stay silent.
+//
+// Compound shell (a && b, a; b, a | b) skips the safe-list and falls
+// through to the destructive scan. The matcher is regex-based on a
+// whitespace-normalised form of the command; `<placeholder>` matches
+// one non-whitespace token, `...` matches any tail.
 
 import (
 	"context"
@@ -143,17 +144,19 @@ func compileSafe(value any) ([]safePattern, error) {
 }
 
 // saferShell is the [hooks.BuiltinFunc] registered under [SaferShell].
-// See the file-level comment for the priority order.
-//
-// On taxonomy load failure the call is routed to user confirmation
-// with blast_radius=unknown rather than allowed silently — failing
-// closed is the security-meaningful choice and matches [failClosed]'s
-// treatment of the pre_tool_use preempt-yolo lane.
-func saferShell(_ context.Context, in *hooks.Input, _ []string) (*hooks.Output, error) {
+// See the file-level comment for the policy-aware logic. Taxonomy
+// load failure asks with blast_radius=unknown regardless of policy
+// (fail-closed), except under unsafe which stays silent.
+func saferShell(_ context.Context, in *hooks.Input, args []string) (*hooks.Output, error) {
 	if in == nil || in.HookEventName != hooks.EventPreToolUse {
 		return nil, nil
 	}
 	if in.ToolName != shellToolName {
+		return nil, nil
+	}
+
+	policy := effectiveSafetyPolicy(in.SafetyPolicy, args)
+	if policy == policyUnsafe {
 		return nil, nil
 	}
 
@@ -165,19 +168,47 @@ func saferShell(_ context.Context, in *hooks.Input, _ []string) (*hooks.Output, 
 	}
 
 	if command != "" {
-		// 1) Destructive match wins.
 		if match := bestDestructiveMatch(command, patterns.destructive); match != nil {
 			return askWithMetadata(match.BlastRadius, match.Category,
 				"Command matches destructive operation: "+match.Pattern), nil
 		}
-		// 2) Safe match → no opinion (falls through to regular pipeline).
 		if matchesSafe(command, patterns.safe) {
 			return nil, nil
 		}
 	}
-	// 3) Unknown → ask with no classified severity.
+	// Unknown command: safer defers, strict asks.
+	if policy == policySafer {
+		return nil, nil
+	}
 	return askWithMetadata("unknown", "",
 		"Shell command requires safer-mode confirmation."), nil
+}
+
+// Mirrors pkg/session.SafetyPolicy strings; the hooks package must
+// stay free of a session dependency.
+const (
+	policyUnsafe = "unsafe"
+	policySafer  = "safer"
+	policyStrict = "strict"
+)
+
+// effectiveSafetyPolicy picks the policy for one invocation.
+// Precedence: args[0] (YAML pin) > session > strict. Unrecognised
+// args[0] falls through to session (so a YAML typo doesn't flip
+// modes silently).
+func effectiveSafetyPolicy(sessionPolicy string, args []string) string {
+	if len(args) > 0 {
+		switch args[0] {
+		case policyUnsafe, policySafer, policyStrict:
+			return args[0]
+		}
+	}
+	switch sessionPolicy {
+	case policyUnsafe, policySafer, policyStrict:
+		return sessionPolicy
+	default:
+		return policyStrict
+	}
 }
 
 func shellCommandArg(input map[string]any) (string, bool) {

--- a/pkg/hooks/builtins/safer_shell_test.go
+++ b/pkg/hooks/builtins/safer_shell_test.go
@@ -286,3 +286,173 @@ func TestSaferShell_ApplyAgentDefaultsAutoInjectsBuiltin(t *testing.T) {
 	assert.Equal(t, hooks.HookTypeBuiltin, mc.Hooks[0].Type)
 	assert.Equal(t, SaferShell, mc.Hooks[0].Command)
 }
+
+// Per-policy classifier behaviour matrix. Docker Desktop flips
+// SafetyPolicy per-session; the classifier MUST follow without any
+// other code changing.
+func TestSaferShell_PolicyMatrix(t *testing.T) {
+	const destructive = "rm -rf /tmp/x"
+	const safe = "docker ps"
+	const unknown = "myproject-cli deploy --prod"
+
+	type want struct {
+		emit        bool
+		blastRadius string
+	}
+
+	cases := []struct {
+		name   string
+		policy string
+		cmd    string
+		want   want
+	}{
+		// unsafe: silent (restores --yolo semantics).
+		{"unsafe + destructive → silent", policyUnsafe, destructive, want{emit: false}},
+		{"unsafe + safe → silent", policyUnsafe, safe, want{emit: false}},
+		{"unsafe + unknown → silent", policyUnsafe, unknown, want{emit: false}},
+
+		// safer: only classified destructive gates.
+		{"safer + destructive → ask (high)", policySafer, destructive, want{emit: true, blastRadius: "high"}},
+		{"safer + safe → silent", policySafer, safe, want{emit: false}},
+		{"safer + unknown → silent (no actionable opinion)", policySafer, unknown, want{emit: false}},
+
+		// strict: destructive + unknown gate; matches PR #3273.
+		{"strict + destructive → ask (high)", policyStrict, destructive, want{emit: true, blastRadius: "high"}},
+		{"strict + safe → silent", policyStrict, safe, want{emit: false}},
+		{"strict + unknown → ask (unknown)", policyStrict, unknown, want{emit: true, blastRadius: "unknown"}},
+
+		// empty / unrecognised → strict (forward-compat fallback).
+		{"empty + destructive → ask (high)", "", destructive, want{emit: true, blastRadius: "high"}},
+		{"empty + unknown → ask (unknown)", "", unknown, want{emit: true, blastRadius: "unknown"}},
+		{"unrecognised policy + destructive → ask (strict fallback)", "future", destructive, want{emit: true, blastRadius: "high"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := saferShell(t.Context(), &hooks.Input{
+				HookEventName: hooks.EventPreToolUse,
+				ToolName:      shellToolName,
+				ToolInput:     map[string]any{"cmd": tc.cmd},
+				SafetyPolicy:  tc.policy,
+			}, nil)
+			require.NoError(t, err)
+			if !tc.want.emit {
+				assert.Nil(t, out, "policy=%q cmd=%q must be silent", tc.policy, tc.cmd)
+				return
+			}
+			require.NotNil(t, out, "policy=%q cmd=%q must produce a verdict", tc.policy, tc.cmd)
+			require.NotNil(t, out.HookSpecificOutput)
+			assert.Equal(t, hooks.DecisionAsk, out.HookSpecificOutput.PermissionDecision)
+			assert.Equal(t, tc.want.blastRadius, out.HookSpecificOutput.Metadata[metaBlastRadius])
+		})
+	}
+}
+
+// YAML args override: `args: ["safer"|"strict"|"unsafe"]` on a hook
+// entry forces the classifier's mode regardless of session policy.
+// Enables eval harnesses (which hardcode --yolo/unsafe) to exercise
+// safer-mode gating. Precedence: args[0] > Input.SafetyPolicy > strict.
+// Unrecognised args fall through to the session (typo tolerance).
+func TestSaferShell_ArgsOverrideSessionPolicy(t *testing.T) {
+	cases := []struct {
+		name          string
+		sessionPolicy string
+		args          []string
+		cmd           string
+		wantEmit      bool
+		wantRadius    string
+	}{
+		{
+			name:          "args=safer overrides unsafe session: destructive gates",
+			sessionPolicy: policyUnsafe,
+			args:          []string{"safer"},
+			cmd:           "rm -rf /tmp/x",
+			wantEmit:      true,
+			wantRadius:    "high",
+		},
+		{
+			name:          "args=safer overrides unsafe session: unknown stays silent",
+			sessionPolicy: policyUnsafe,
+			args:          []string{"safer"},
+			cmd:           "docker build .",
+			wantEmit:      false,
+		},
+		{
+			name:          "args=safer overrides unsafe session: safe stays silent",
+			sessionPolicy: policyUnsafe,
+			args:          []string{"safer"},
+			cmd:           "docker ps",
+			wantEmit:      false,
+		},
+		{
+			name:          "args=strict overrides safer session: unknown now gates",
+			sessionPolicy: policySafer,
+			args:          []string{"strict"},
+			cmd:           "docker build .",
+			wantEmit:      true,
+			wantRadius:    "unknown",
+		},
+		{
+			name:          "args=unsafe overrides strict session: silent on destructive",
+			sessionPolicy: policyStrict,
+			args:          []string{"unsafe"},
+			cmd:           "rm -rf /tmp/x",
+			wantEmit:      false,
+		},
+		{
+			name:          "unrecognised args value falls through to session policy (unsafe → silent)",
+			sessionPolicy: policyUnsafe,
+			args:          []string{"yolo"}, // typo
+			cmd:           "rm -rf /tmp/x",
+			wantEmit:      false,
+		},
+		{
+			name:          "unrecognised args value falls through to session policy (safer → ask)",
+			sessionPolicy: policySafer,
+			args:          []string{"yolo"}, // typo
+			cmd:           "rm -rf /tmp/x",
+			wantEmit:      true,
+			wantRadius:    "high",
+		},
+		{
+			name:          "empty args + empty session: strict fallback gates destructive",
+			sessionPolicy: "",
+			args:          nil,
+			cmd:           "rm -rf /tmp/x",
+			wantEmit:      true,
+			wantRadius:    "high",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := saferShell(t.Context(), &hooks.Input{
+				HookEventName: hooks.EventPreToolUse,
+				ToolName:      shellToolName,
+				ToolInput:     map[string]any{"cmd": tc.cmd},
+				SafetyPolicy:  tc.sessionPolicy,
+			}, tc.args)
+			require.NoError(t, err)
+			if !tc.wantEmit {
+				assert.Nil(t, out)
+				return
+			}
+			require.NotNil(t, out)
+			require.NotNil(t, out.HookSpecificOutput)
+			assert.Equal(t, hooks.DecisionAsk, out.HookSpecificOutput.PermissionDecision)
+			assert.Equal(t, tc.wantRadius, out.HookSpecificOutput.Metadata[metaBlastRadius])
+		})
+	}
+}
+
+// unsafe short-circuits before the taxonomy loader — the one
+// exception to fail-closed on load failure. The embedded JSON can't
+// be corrupted from a test, so this pins the early-return path.
+func TestSaferShell_UnsafeReturnsBeforeTaxonomyLoad(t *testing.T) {
+	out, err := saferShell(t.Context(), &hooks.Input{
+		HookEventName: hooks.EventPreToolUse,
+		ToolName:      shellToolName,
+		ToolInput:     map[string]any{"cmd": "rm -rf /tmp/x"},
+		SafetyPolicy:  policyUnsafe,
+	}, nil)
+	require.NoError(t, err)
+	assert.Nil(t, out, "unsafe must short-circuit before classification")
+}


### PR DESCRIPTION
## Summary
- `safer_shell` now branches on `hooks.Input.SafetyPolicy` (plumbed in PR #3378):
  - **unsafe** — silent; `--yolo` semantics restored.
  - **safer** — destructive matches ask; safe / unknown fall through.
  - **strict** (or empty) — destructive + unknown ask (today's behaviour).
- Hook YAML can pin the mode via `args: ["safer"|"strict"|"unsafe"]`, overriding the session policy for that classifier. Lets eval harnesses that hardcode `--yolo` still exercise safer-mode gating.

Policy stays in the hook — no dispatcher or runtime changes.

## Test plan
- [ ] `go test ./pkg/hooks/builtins/... -run SaferShell` green (matrix over unsafe/safer/strict × destructive/safe/unknown + YAML-args override)
- [ ] Confirm existing eval fixtures unaffected under legacy `--yolo` (SafetyPolicy=unsafe → classifier silent)
- [ ] Confirm destructive-command eval fixtures gate when `gordon_safer.yaml` uses `args: ["safer"]`