### PR TITLE
feat: add Moonshot AI (Kimi) as a supported model provider

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -182,7 +182,7 @@
       "properties": {
         "provider": {
           "type": "string",
-          "description": "The underlying provider type. Defaults to \"openai\" when not set. Supported values: openai, anthropic, google, amazon-bedrock, dmr, and any built-in alias (requesty, openrouter, azure, xai, ollama, mistral, baseten, ovhcloud, groq, fireworks, deepseek, cerebras, together, huggingface, etc.).",
+          "description": "The underlying provider type. Defaults to \"openai\" when not set. Supported values: openai, anthropic, google, amazon-bedrock, dmr, and any built-in alias (requesty, openrouter, azure, xai, ollama, mistral, baseten, ovhcloud, groq, fireworks, deepseek, cerebras, together, huggingface, moonshot, etc.).",
           "examples": [
             "openai",
             "anthropic",

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -163,6 +163,8 @@
       url: /providers/minimax/
     - title: Mistral
       url: /providers/mistral/
+    - title: Moonshot AI
+      url: /providers/moonshot/
     - title: Nebius
       url: /providers/nebius/
     - title: OpenAI

--- a/docs/concepts/models/index.md
+++ b/docs/concepts/models/index.md
@@ -89,6 +89,7 @@ for details.
 | Cerebras            | `cerebras`       | GPT-OSS, GLM (fast inference)         | `CEREBRAS_API_KEY`                  |
 | Together AI         | `together`       | Llama, Qwen, DeepSeek, Kimi (open models) | `TOGETHER_API_KEY`             |
 | Hugging Face        | `huggingface`    | Llama, Qwen, DeepSeek, GLM (open models) | `HF_TOKEN`                      |
+| Moonshot AI         | `moonshot`       | Kimi K2 chat, reasoning, and coding models | `MOONSHOT_API_KEY`             |
 | Requesty            | `requesty`       | Multi-provider gateway               | `REQUESTY_API_KEY`                  |
 | OpenRouter          | `openrouter`     | Multi-provider gateway               | `OPENROUTER_API_KEY`                |
 | Azure OpenAI        | `azure`          | gpt-4o, gpt-5 on Azure               | `AZURE_API_KEY` + `base_url`        |

--- a/docs/configuration/models/index.md
+++ b/docs/configuration/models/index.md
@@ -17,7 +17,7 @@ models:
     first_available: [list] # Optional: candidate model refs, tried in order by available credentials.
                             # Mutually exclusive with other model settings.
     provider: string # Required unless using first_available. One of: openai, anthropic, google, amazon-bedrock,
-                     # dmr, mistral, xai, nebius, minimax, baseten, ovhcloud, groq, fireworks, deepseek, cerebras, together, huggingface, requesty, openrouter,
+                     # dmr, mistral, xai, nebius, minimax, baseten, ovhcloud, groq, fireworks, deepseek, cerebras, together, huggingface, moonshot, requesty, openrouter,
                      # azure, ollama, github-copilot, or a named provider defined
                      # under the top-level `providers:` section.
     model: string # Required: model identifier
@@ -48,7 +48,7 @@ models:
 | Property              | Type       | Required | Description                                                                           |
 | --------------------- | ---------- | -------- | ------------------------------------------------------------------------------------- |
 | `first_available`     | array      | ✗        | Candidate model references tried in order; selects the first whose credentials are configured. Mutually exclusive with other model settings. |
-| `provider`            | string     | ✓/✗      | Required for regular model definitions; omitted for `first_available` selectors. Provider: `openai`, `anthropic`, `google`, `amazon-bedrock`, `dmr`, `mistral`, `xai`, `nebius`, `minimax`, `baseten`, `ovhcloud`, `groq`, `fireworks`, `deepseek`, `cerebras`, `together`, `huggingface`, `requesty`, `openrouter`, `azure`, `ollama`, `github-copilot`, or any [named provider]({{ '/providers/custom/' | relative_url }}). |
+| `provider`            | string     | ✓/✗      | Required for regular model definitions; omitted for `first_available` selectors. Provider: `openai`, `anthropic`, `google`, `amazon-bedrock`, `dmr`, `mistral`, `xai`, `nebius`, `minimax`, `baseten`, `ovhcloud`, `groq`, `fireworks`, `deepseek`, `cerebras`, `together`, `huggingface`, `moonshot`, `requesty`, `openrouter`, `azure`, `ollama`, `github-copilot`, or any [named provider]({{ '/providers/custom/' | relative_url }}). |
 | `model`               | string     | ✓/✗      | Required for regular model definitions; omitted for `first_available` selectors. Model name (e.g., `gpt-4o`, `claude-sonnet-4-5`, `gemini-3.5-flash`) |
 | `temperature`         | float      | ✗        | Sampling randomness. Range is provider-dependent — typically `0.0–2.0` (Anthropic caps at `1.0`). `0.0` is deterministic. |
 | `max_tokens`          | int        | ✗        | Maximum response length in tokens                                                     |
@@ -404,7 +404,7 @@ See the [Anthropic provider page]({{ '/providers/anthropic/#thinking-display' | 
 ## Custom HTTP Headers
 
 For OpenAI-compatible providers (`openai`, `github-copilot`, `mistral`, `xai`,
-`nebius`, `minimax`, `baseten`, `ovhcloud`, `groq`, `fireworks`, `deepseek`, `cerebras`, `together`, `huggingface`, `requesty`, `openrouter`, `ollama`, and any custom provider using the OpenAI API),
+`nebius`, `minimax`, `baseten`, `ovhcloud`, `groq`, `fireworks`, `deepseek`, `cerebras`, `together`, `huggingface`, `moonshot`, `requesty`, `openrouter`, `ollama`, and any custom provider using the OpenAI API),
 `provider_opts.http_headers` adds arbitrary HTTP headers to every outgoing
 request:
 

--- a/docs/providers/moonshot/index.md
+++ b/docs/providers/moonshot/index.md
@@ -1,0 +1,97 @@
+---
+title: "Moonshot AI"
+description: "Use Moonshot AI (Kimi) models with docker-agent."
+permalink: /providers/moonshot/
+---
+
+# Moonshot AI
+
+_Use Moonshot AI (Kimi) models with docker-agent._
+
+## Overview
+
+[Moonshot AI](https://www.moonshot.ai/) serves its Kimi model family through an
+OpenAI-compatible API. The Kimi K2 models have strong momentum for coding and
+agentic tasks. docker-agent includes built-in support for Moonshot AI as an
+alias provider.
+
+## Setup
+
+1. Create an API key from the [Moonshot AI console](https://platform.moonshot.ai/console/api-keys).
+2. Set the environment variable:
+
+   ```bash
+   export MOONSHOT_API_KEY=your-api-key
+   ```
+
+## Usage
+
+### Inline Syntax
+
+The simplest way to use Moonshot AI:
+
+```yaml
+agents:
+  root:
+    model: moonshot/kimi-k2-0905-preview
+    description: Assistant using Moonshot AI
+    instruction: You are a helpful assistant.
+```
+
+### Named Model
+
+For more control over parameters:
+
+```yaml
+models:
+  moonshot_model:
+    provider: moonshot
+    model: kimi-k2-0905-preview
+    temperature: 0.7
+    max_tokens: 8192
+
+agents:
+  root:
+    model: moonshot_model
+    description: Assistant using Moonshot AI
+    instruction: You are a helpful assistant.
+```
+
+## Available Models
+
+Moonshot AI exposes a vendor-controlled Kimi model lineup. Check the
+[Moonshot API documentation](https://platform.moonshot.ai/docs/api) for current
+model IDs, context limits, and pricing.
+
+| Model | Description |
+| --- | --- |
+| `kimi-k2-0905-preview` | Kimi K2, general-purpose chat, coding, and tool calling |
+| `kimi-k2-turbo-preview` | Kimi K2 optimized for higher throughput |
+| `kimi-k2-thinking` | Kimi K2 extended-reasoning model |
+
+> Model IDs are case-sensitive and must be passed exactly as the catalogue lists
+> them.
+
+## How It Works
+
+Moonshot AI is implemented as a built-in alias in docker-agent:
+
+- **API Type:** OpenAI-compatible (`openai_chatcompletions`)
+- **Base URL:** `https://api.moonshot.ai/v1`
+- **Token Variable:** `MOONSHOT_API_KEY`
+
+## Example: Code Assistant
+
+```yaml
+agents:
+  coder:
+    model: moonshot/kimi-k2-0905-preview
+    description: Code assistant using Kimi K2
+    instruction: |
+      You are an expert programmer.
+      Write clean, well-documented code and follow language best practices.
+    toolsets:
+      - type: filesystem
+      - type: shell
+      - type: think
+```

--- a/docs/providers/overview/index.md
+++ b/docs/providers/overview/index.md
@@ -73,6 +73,7 @@ docker-agent also includes built-in aliases for these providers:
 | Cerebras       | `cerebras`       | `CEREBRAS_API_KEY`                  |
 | Together AI    | `together`       | `TOGETHER_API_KEY`                  |
 | Hugging Face   | `huggingface`    | `HF_TOKEN`                          |
+| Moonshot AI    | `moonshot`       | `MOONSHOT_API_KEY`                  |
 | Requesty       | `requesty`       | `REQUESTY_API_KEY`                  |
 | OpenRouter     | `openrouter`     | `OPENROUTER_API_KEY`                |
 | Azure OpenAI   | `azure`          | `AZURE_API_KEY` + `base_url`        |

--- a/examples/README.md
+++ b/examples/README.md
@@ -201,6 +201,7 @@ remote MCP endpoints.
 | [`cerebras.yaml`](cerebras.yaml) | Cerebras fast-inference provider. |
 | [`together.yaml`](together.yaml) | Together AI open-model inference provider. |
 | [`huggingface.yaml`](huggingface.yaml) | Hugging Face Inference Providers open-model router. |
+| [`moonshot.yaml`](moonshot.yaml) | Moonshot AI (Kimi K2) provider. |
 | [`grok.yaml`](grok.yaml) | xAI Grok model. |
 | [`github-copilot.yaml`](github-copilot.yaml) | GitHub Copilot models via OAuth device-flow. |
 | [`fallback_models.yaml`](fallback_models.yaml) | Automatic fallback to a secondary model when the primary fails. |

--- a/examples/moonshot.yaml
+++ b/examples/moonshot.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=../agent-schema.json
+
+models:
+  moonshot_model:
+    provider: moonshot
+    model: kimi-k2-0905-preview
+
+agents:
+  root:
+    model: moonshot_model
+    description: Assistant using Moonshot AI (Kimi)
+    instruction: |
+      You are a helpful assistant.
+    toolsets:
+      - type: filesystem
+      - type: shell
+      - type: think

--- a/pkg/config/auto.go
+++ b/pkg/config/auto.go
@@ -62,6 +62,7 @@ var cloudProviders = []providerConfig{
 	{"cerebras", []string{"CEREBRAS_API_KEY"}, "CEREBRAS_API_KEY", "CEREBRAS_API_KEY"},
 	{"together", []string{"TOGETHER_API_KEY"}, "TOGETHER_API_KEY", "TOGETHER_API_KEY"},
 	{"huggingface", []string{"HF_TOKEN"}, "HF_TOKEN", "HF_TOKEN"},
+	{"moonshot", []string{"MOONSHOT_API_KEY"}, "MOONSHOT_API_KEY", "MOONSHOT_API_KEY"},
 	{"amazon-bedrock", []string{
 		"AWS_BEARER_TOKEN_BEDROCK",
 		"AWS_ACCESS_KEY_ID",
@@ -133,6 +134,7 @@ var DefaultModels = map[string]string{
 	"cerebras":       "gpt-oss-120b",
 	"together":       "meta-llama/Llama-3.3-70B-Instruct-Turbo",
 	"huggingface":    "meta-llama/Llama-3.3-70B-Instruct",
+	"moonshot":       "kimi-k2-0905-preview",
 	"amazon-bedrock": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
 	"opencode-go":    "deepseek-v4-flash",
 	"opencode-zen":   "deepseek-v4-flash-free",

--- a/pkg/config/auto_test.go
+++ b/pkg/config/auto_test.go
@@ -113,6 +113,13 @@ func TestAvailableProviders_NoGateway(t *testing.T) {
 			expectedProvider: "huggingface",
 		},
 		{
+			name: "moonshot api key present",
+			envVars: map[string]string{
+				"MOONSHOT_API_KEY": "test-key",
+			},
+			expectedProvider: "moonshot",
+		},
+		{
 			name:             "no api keys - defaults to dmr",
 			envVars:          map[string]string{},
 			expectedProvider: "dmr",
@@ -347,6 +354,15 @@ func TestAutoModelConfig(t *testing.T) {
 			expectedMaxTokens: 32000,
 		},
 		{
+			name: "moonshot provider",
+			envVars: map[string]string{
+				"MOONSHOT_API_KEY": "test-key",
+			},
+			expectedProvider:  "moonshot",
+			expectedModel:     "kimi-k2-0905-preview",
+			expectedMaxTokens: 32000,
+		},
+		{
 			name:              "dmr provider (no api keys)",
 			envVars:           map[string]string{},
 			expectedProvider:  "dmr",
@@ -428,7 +444,7 @@ func TestDefaultModels(t *testing.T) {
 	t.Parallel()
 
 	// Test that DefaultModels map has all expected providers
-	expectedProviders := []string{"openai", "anthropic", "google", "dmr", "mistral", "openrouter", "baseten", "ovhcloud", "groq", "fireworks", "deepseek", "cerebras", "together", "huggingface", "amazon-bedrock", "opencode-zen", "opencode-go"}
+	expectedProviders := []string{"openai", "anthropic", "google", "dmr", "mistral", "openrouter", "baseten", "ovhcloud", "groq", "fireworks", "deepseek", "cerebras", "together", "huggingface", "moonshot", "amazon-bedrock", "opencode-zen", "opencode-go"}
 
 	for _, provider := range expectedProviders {
 		t.Run(provider, func(t *testing.T) {
@@ -453,6 +469,7 @@ func TestDefaultModels(t *testing.T) {
 	assert.Equal(t, "gpt-oss-120b", DefaultModels["cerebras"])
 	assert.Equal(t, "meta-llama/Llama-3.3-70B-Instruct-Turbo", DefaultModels["together"])
 	assert.Equal(t, "meta-llama/Llama-3.3-70B-Instruct", DefaultModels["huggingface"])
+	assert.Equal(t, "kimi-k2-0905-preview", DefaultModels["moonshot"])
 	assert.Equal(t, "global.anthropic.claude-sonnet-4-5-20250929-v1:0", DefaultModels["amazon-bedrock"])
 	assert.Equal(t, "deepseek-v4-flash", DefaultModels["opencode-go"])
 	assert.Equal(t, "deepseek-v4-flash-free", DefaultModels["opencode-zen"])
@@ -462,7 +479,7 @@ func TestAutoModelConfig_IntegrationWithDefaultModels(t *testing.T) {
 	t.Parallel()
 
 	// Verify that AutoModelConfig always returns a model from DefaultModels
-	providers := []string{"openai", "anthropic", "google", "mistral", "openrouter", "baseten", "ovhcloud", "groq", "fireworks", "deepseek", "cerebras", "together", "huggingface", "opencode-zen"}
+	providers := []string{"openai", "anthropic", "google", "mistral", "openrouter", "baseten", "ovhcloud", "groq", "fireworks", "deepseek", "cerebras", "together", "huggingface", "moonshot", "opencode-zen"}
 
 	for _, provider := range providers {
 		t.Run(provider, func(t *testing.T) {
@@ -498,6 +515,8 @@ func TestAutoModelConfig_IntegrationWithDefaultModels(t *testing.T) {
 				envVars["TOGETHER_API_KEY"] = "test-key"
 			case "huggingface":
 				envVars["HF_TOKEN"] = "test-token"
+			case "moonshot":
+				envVars["MOONSHOT_API_KEY"] = "test-key"
 			case "opencode-zen":
 				envVars["OPENCODE_API_KEY"] = "test-key"
 			}
@@ -659,13 +678,21 @@ func TestAvailableProviders_PrecedenceOrder(t *testing.T) {
 	providers = AvailableProviders(t.Context(), "", env)
 	assert.Equal(t, "together", providers[0])
 
-	// huggingface wins over amazon-bedrock
+	// huggingface wins over moonshot
 	env = environment.NewMapEnvProvider(map[string]string{
-		"HF_TOKEN":          "test-token",
-		"AWS_ACCESS_KEY_ID": "test-key",
+		"HF_TOKEN":         "test-token",
+		"MOONSHOT_API_KEY": "test-key",
 	})
 	providers = AvailableProviders(t.Context(), "", env)
 	assert.Equal(t, "huggingface", providers[0])
+
+	// moonshot wins over amazon-bedrock
+	env = environment.NewMapEnvProvider(map[string]string{
+		"MOONSHOT_API_KEY":  "test-key",
+		"AWS_ACCESS_KEY_ID": "test-key",
+	})
+	providers = AvailableProviders(t.Context(), "", env)
+	assert.Equal(t, "moonshot", providers[0])
 
 	// Only OPENCODE_API_KEY set - opencode-zen should win (higher priority than opencode-go)
 	env = environment.NewMapEnvProvider(map[string]string{

--- a/pkg/config/examples_test.go
+++ b/pkg/config/examples_test.go
@@ -24,6 +24,7 @@ var modelsDevAbsentProviders = map[string]bool{
 	"ovhcloud":     true, // OVHcloud AI Endpoints (not yet in models.dev)
 	"fireworks":    true, // models.dev catalogs Fireworks under the "fireworks-ai" id, not "fireworks"
 	"together":     true, // models.dev catalogs Together AI under the "togetherai" id, not "together"
+	"moonshot":     true, // models.dev catalogs Moonshot AI under the "moonshotai" id, not "moonshot"
 }
 
 func collectExamples(t *testing.T) []string {

--- a/pkg/model/provider/aliases.go
+++ b/pkg/model/provider/aliases.go
@@ -108,6 +108,11 @@ var Aliases = map[string]Alias{
 		BaseURL:     "https://router.huggingface.co/v1",
 		TokenEnvVar: "HF_TOKEN",
 	},
+	"moonshot": {
+		APIType:     "openai",
+		BaseURL:     "https://api.moonshot.ai/v1",
+		TokenEnvVar: "MOONSHOT_API_KEY",
+	},
 	"github-copilot": {
 		APIType:     "openai",
 		BaseURL:     "https://api.githubcopilot.com",

--- a/pkg/model/provider/aliases_test.go
+++ b/pkg/model/provider/aliases_test.go
@@ -45,6 +45,7 @@ func TestCatalogAliases(t *testing.T) {
 		"fireworks":   {APIType: "openai", BaseURL: "https://api.fireworks.ai/inference/v1", TokenEnvVar: "FIREWORKS_API_KEY"},
 		"together":    {APIType: "openai", BaseURL: "https://api.together.xyz/v1", TokenEnvVar: "TOGETHER_API_KEY"},
 		"huggingface": {APIType: "openai", BaseURL: "https://router.huggingface.co/v1", TokenEnvVar: "HF_TOKEN"},
+		"moonshot":    {APIType: "openai", BaseURL: "https://api.moonshot.ai/v1", TokenEnvVar: "MOONSHOT_API_KEY"},
 	}
 
 	for name, want := range expected {

--- a/pkg/model/provider/openai/system_message_merge_test.go
+++ b/pkg/model/provider/openai/system_message_merge_test.go
@@ -169,6 +169,7 @@ func TestShouldMergeConsecutiveMessages_Gating(t *testing.T) {
 		{"first-party mistral", &latest.ModelConfig{Provider: "mistral", Model: "mistral-small"}, false},
 		{"first-party xai", &latest.ModelConfig{Provider: "xai", Model: "grok-4"}, false},
 		{"first-party deepseek", &latest.ModelConfig{Provider: "deepseek", Model: "deepseek-chat"}, false},
+		{"first-party moonshot", &latest.ModelConfig{Provider: "moonshot", Model: "kimi-k2-0905-preview"}, false},
 	}
 
 	for _, tt := range tests {

--- a/pkg/model/provider/openai_alias_providers_test.go
+++ b/pkg/model/provider/openai_alias_providers_test.go
@@ -82,6 +82,16 @@ var openAIAliasProviders = []openAIAliasProvider{
 		greeting:             "Hello from Hugging Face",
 		mergesSystemMessages: true,
 	},
+	{
+		// Moonshot AI is a first-party API serving its own Kimi lineup, so its
+		// per-source system messages are left untouched (mergesSystemMessages
+		// omitted, like deepseek).
+		provider: "moonshot",
+		envVar:   "MOONSHOT_API_KEY",
+		testKey:  "sk-test-moonshot-key",
+		model:    "kimi-k2-0905-preview",
+		greeting: "Hello from Moonshot",
+	},
 }
 
 // TestOpenAIAliasProvider_EndToEndRequest drives a real request through the full


### PR DESCRIPTION
## Summary

Adds first-class support for Moonshot AI (Kimi) as a built-in OpenAI-compatible alias provider, resolving #3352. The change mirrors the most recent provider addition (#3376, Together AI) for consistency.

Alias: `moonshot` (`openai`, `https://api.moonshot.ai/v1`, `MOONSHOT_API_KEY`).

## Definition of Done

| Expectation (from #3352) | Status | Where |
| --- | --- | --- |
| Alias entry added | done | `pkg/model/provider/aliases.go` |
| Unit test: alias resolves and `IsCatalogProvider("moonshot")` is true | done | `pkg/model/provider/aliases_test.go` (`TestCatalogAliases`) |
| Provider appears via `CatalogProviders()` | done | Alias has a `BaseURL`, so it is auto-included; asserted by `TestCatalogAliases` |
| `task test` and `task lint` pass | done | See Validation below |
| Example YAML added | done | `examples/moonshot.yaml` |

## Design decision

Moonshot is classified as a **first-party** provider (it serves its own Kimi lineup through an OpenAI-compatible API), so it is treated exactly like `deepseek`:

- not added to `openModelHostProviders`, i.e. per-source system messages are left untouched (no merge).

The system-message merge is only needed for open-model host aggregators (cerebras, together, huggingface, ...) whose community models can carry strict chat templates. If maintainers prefer to treat Moonshot as an open-model host instead, the classification is a single-line change (add `"moonshot"` to `openModelHostProviders`) plus the corresponding test expectations.

Default model: `kimi-k2-0905-preview` (used by auto-selection and the example).

## Changes

| Area | Files |
| --- | --- |
| Provider registration | `pkg/model/provider/aliases.go`, `pkg/config/auto.go` |
| Schema | `agent-schema.json` |
| Docs | `docs/_data/nav.yml`, `docs/concepts/models/index.md`, `docs/configuration/models/index.md`, `docs/providers/overview/index.md`, `docs/providers/moonshot/index.md` (new) |
| Example | `examples/moonshot.yaml` (new), `examples/README.md` |
| Tests | `pkg/model/provider/aliases_test.go`, `pkg/model/provider/openai_alias_providers_test.go`, `pkg/model/provider/openai/system_message_merge_test.go`, `pkg/config/auto_test.go`, `pkg/config/examples_test.go` |

## Tests

The shared table-driven alias harness gains one `moonshot` row, which exercises:

| Test | Coverage |
| --- | --- |
| `TestOpenAIAliasProvider_EndToEndRequest/moonshot` | Hermetic end-to-end: alias resolution, chat-completions client, real HTTP, SSE parsing. Asserts `Bearer` auth from `MOONSHOT_API_KEY`, `/chat/completions` routing, verbatim model, stream reassembly, and that the two system messages are left unmerged (first-party). |
| `TestOpenAIAliasProvider_LiveAPI/moonshot` | Real API call, skipped unless `MOONSHOT_API_KEY` is set. |

`moonshot` is added to `modelsDevAbsentProviders` because models.dev catalogs it under the `moonshotai` id, not `moonshot` (same as `together`/`togetherai`).

## Validation

| Step | Result |
| --- | --- |
| `task build` | pass |
| Targeted tests (`pkg/model/provider/...`, `pkg/config/` auto + examples + gating) | pass, all `moonshot` cases green |
| `golangci-lint` on changed packages | 0 issues |
| `gofmt` / `go vet` | clean |

No new dependencies were introduced; `go.mod`/`go.sum` are unchanged.