### PR TITLE
feat: add Vercel AI Gateway as a supported model provider

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -182,7 +182,7 @@
       "properties": {
         "provider": {
           "type": "string",
-          "description": "The underlying provider type. Defaults to \"openai\" when not set. Supported values: openai, anthropic, google, amazon-bedrock, dmr, and any built-in alias (requesty, openrouter, azure, xai, ollama, mistral, baseten, ovhcloud, groq, fireworks, deepseek, cerebras, together, huggingface, moonshot, etc.).",
+          "description": "The underlying provider type. Defaults to \"openai\" when not set. Supported values: openai, anthropic, google, amazon-bedrock, dmr, and any built-in alias (requesty, openrouter, azure, xai, ollama, mistral, baseten, ovhcloud, groq, fireworks, deepseek, cerebras, together, huggingface, moonshot, vercel, etc.).",
           "examples": [
             "openai",
             "anthropic",

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -179,6 +179,8 @@
       url: /providers/ovhcloud/
     - title: Together AI
       url: /providers/together/
+    - title: Vercel AI Gateway
+      url: /providers/vercel/
     - title: "xAI (Grok)"
       url: /providers/xai/
     - title: Provider Definitions

--- a/docs/concepts/models/index.md
+++ b/docs/concepts/models/index.md
@@ -90,6 +90,7 @@ for details.
 | Together AI         | `together`       | Llama, Qwen, DeepSeek, Kimi (open models) | `TOGETHER_API_KEY`             |
 | Hugging Face        | `huggingface`    | Llama, Qwen, DeepSeek, GLM (open models) | `HF_TOKEN`                      |
 | Moonshot AI         | `moonshot`       | Kimi K2 chat, reasoning, and coding models | `MOONSHOT_API_KEY`             |
+| Vercel AI Gateway   | `vercel`         | Multi-provider gateway               | `AI_GATEWAY_API_KEY`                |
 | Requesty            | `requesty`       | Multi-provider gateway               | `REQUESTY_API_KEY`                  |
 | OpenRouter          | `openrouter`     | Multi-provider gateway               | `OPENROUTER_API_KEY`                |
 | Azure OpenAI        | `azure`          | gpt-4o, gpt-5 on Azure               | `AZURE_API_KEY` + `base_url`        |

--- a/docs/configuration/models/index.md
+++ b/docs/configuration/models/index.md
@@ -17,7 +17,7 @@ models:
     first_available: [list] # Optional: candidate model refs, tried in order by available credentials.
                             # Mutually exclusive with other model settings.
     provider: string # Required unless using first_available. One of: openai, anthropic, google, amazon-bedrock,
-                     # dmr, mistral, xai, nebius, minimax, baseten, ovhcloud, groq, fireworks, deepseek, cerebras, together, huggingface, moonshot, requesty, openrouter,
+                     # dmr, mistral, xai, nebius, minimax, baseten, ovhcloud, groq, fireworks, deepseek, cerebras, together, huggingface, moonshot, vercel, requesty, openrouter,
                      # azure, ollama, github-copilot, or a named provider defined
                      # under the top-level `providers:` section.
     model: string # Required: model identifier
@@ -48,7 +48,7 @@ models:
 | Property              | Type       | Required | Description                                                                           |
 | --------------------- | ---------- | -------- | ------------------------------------------------------------------------------------- |
 | `first_available`     | array      | ✗        | Candidate model references tried in order; selects the first whose credentials are configured. Mutually exclusive with other model settings. |
-| `provider`            | string     | ✓/✗      | Required for regular model definitions; omitted for `first_available` selectors. Provider: `openai`, `anthropic`, `google`, `amazon-bedrock`, `dmr`, `mistral`, `xai`, `nebius`, `minimax`, `baseten`, `ovhcloud`, `groq`, `fireworks`, `deepseek`, `cerebras`, `together`, `huggingface`, `moonshot`, `requesty`, `openrouter`, `azure`, `ollama`, `github-copilot`, or any [named provider]({{ '/providers/custom/' | relative_url }}). |
+| `provider`            | string     | ✓/✗      | Required for regular model definitions; omitted for `first_available` selectors. Provider: `openai`, `anthropic`, `google`, `amazon-bedrock`, `dmr`, `mistral`, `xai`, `nebius`, `minimax`, `baseten`, `ovhcloud`, `groq`, `fireworks`, `deepseek`, `cerebras`, `together`, `huggingface`, `moonshot`, `vercel`, `requesty`, `openrouter`, `azure`, `ollama`, `github-copilot`, or any [named provider]({{ '/providers/custom/' | relative_url }}). |
 | `model`               | string     | ✓/✗      | Required for regular model definitions; omitted for `first_available` selectors. Model name (e.g., `gpt-4o`, `claude-sonnet-4-5`, `gemini-3.5-flash`) |
 | `temperature`         | float      | ✗        | Sampling randomness. Range is provider-dependent — typically `0.0–2.0` (Anthropic caps at `1.0`). `0.0` is deterministic. |
 | `max_tokens`          | int        | ✗        | Maximum response length in tokens                                                     |
@@ -404,7 +404,7 @@ See the [Anthropic provider page]({{ '/providers/anthropic/#thinking-display' | 
 ## Custom HTTP Headers
 
 For OpenAI-compatible providers (`openai`, `github-copilot`, `mistral`, `xai`,
-`nebius`, `minimax`, `baseten`, `ovhcloud`, `groq`, `fireworks`, `deepseek`, `cerebras`, `together`, `huggingface`, `moonshot`, `requesty`, `openrouter`, `ollama`, and any custom provider using the OpenAI API),
+`nebius`, `minimax`, `baseten`, `ovhcloud`, `groq`, `fireworks`, `deepseek`, `cerebras`, `together`, `huggingface`, `moonshot`, `vercel`, `requesty`, `openrouter`, `ollama`, and any custom provider using the OpenAI API),
 `provider_opts.http_headers` adds arbitrary HTTP headers to every outgoing
 request:
 

--- a/docs/providers/overview/index.md
+++ b/docs/providers/overview/index.md
@@ -74,6 +74,7 @@ docker-agent also includes built-in aliases for these providers:
 | Together AI    | `together`       | `TOGETHER_API_KEY`                  |
 | Hugging Face   | `huggingface`    | `HF_TOKEN`                          |
 | Moonshot AI    | `moonshot`       | `MOONSHOT_API_KEY`                  |
+| Vercel AI Gateway | `vercel`      | `AI_GATEWAY_API_KEY`                |
 | Requesty       | `requesty`       | `REQUESTY_API_KEY`                  |
 | OpenRouter     | `openrouter`     | `OPENROUTER_API_KEY`                |
 | Azure OpenAI   | `azure`          | `AZURE_API_KEY` + `base_url`        |

--- a/docs/providers/vercel/index.md
+++ b/docs/providers/vercel/index.md
@@ -1,0 +1,106 @@
+---
+title: "Vercel AI Gateway"
+description: "Use Vercel AI Gateway models with docker-agent."
+permalink: /providers/vercel/
+---
+
+# Vercel AI Gateway
+
+_Use Vercel AI Gateway models with docker-agent._
+
+## Overview
+
+[Vercel AI Gateway](https://vercel.com/docs/ai-gateway) is a single, unified
+OpenAI-compatible endpoint that routes to models from OpenAI, Anthropic, Google,
+xAI and more at list price with no markup, plus provider routing and failover.
+It lets you reach many providers with one API key. docker-agent includes
+built-in support for Vercel AI Gateway as an alias provider.
+
+## Setup
+
+1. Create an API key from the [Vercel AI Gateway dashboard](https://vercel.com/docs/ai-gateway).
+2. Set the environment variable:
+
+   ```bash
+   export AI_GATEWAY_API_KEY=your-api-key
+   ```
+
+## Usage
+
+Vercel AI Gateway model IDs use a `creator/model` form (for example
+`openai/gpt-5` or `anthropic/claude-sonnet-4.5`); the gateway routes each
+request to the underlying provider.
+
+### Inline Syntax
+
+The simplest way to use Vercel AI Gateway:
+
+```yaml
+agents:
+  root:
+    model: vercel/openai/gpt-5
+    description: Assistant using Vercel AI Gateway
+    instruction: You are a helpful assistant.
+```
+
+### Named Model
+
+For more control over parameters:
+
+```yaml
+models:
+  vercel_model:
+    provider: vercel
+    model: openai/gpt-5
+    temperature: 0.7
+    max_tokens: 8192
+
+agents:
+  root:
+    model: vercel_model
+    description: Assistant using Vercel AI Gateway
+    instruction: You are a helpful assistant.
+```
+
+## Available Models
+
+Vercel AI Gateway exposes models from many providers behind one endpoint. Check
+the [Vercel AI Gateway documentation](https://vercel.com/docs/ai-gateway) for
+the current model list, IDs, and pricing.
+
+| Model | Description |
+| --- | --- |
+| `openai/gpt-5` | OpenAI GPT-5 routed through the gateway |
+| `anthropic/claude-sonnet-4.5` | Anthropic Claude Sonnet routed through the gateway |
+| `google/gemini-2.5-flash` | Google Gemini routed through the gateway |
+
+> Model IDs are case-sensitive and must be passed exactly as the gateway lists
+> them, including the `creator/` prefix.
+
+## How It Works
+
+Vercel AI Gateway is implemented as a built-in alias in docker-agent:
+
+- **API Type:** OpenAI-compatible (`openai_chatcompletions`)
+- **Base URL:** `https://ai-gateway.vercel.sh/v1`
+- **Token Variable:** `AI_GATEWAY_API_KEY`
+
+Because the gateway can route to open-weight models with strict chat templates,
+docker-agent coalesces consecutive system messages into a single leading one for
+this provider.
+
+## Example: Code Assistant
+
+```yaml
+agents:
+  coder:
+    model: vercel/anthropic/claude-sonnet-4.5
+    description: Code assistant via Vercel AI Gateway
+    instruction: |
+      You are an expert programmer.
+      Write clean, well-documented code and follow language best practices.
+    toolsets:
+      - type: filesystem
+      - type: shell
+      - type: think
+```

--- a/examples/README.md
+++ b/examples/README.md
@@ -202,6 +202,7 @@ remote MCP endpoints.
 | [`together.yaml`](together.yaml) | Together AI open-model inference provider. |
 | [`huggingface.yaml`](huggingface.yaml) | Hugging Face Inference Providers open-model router. |
 | [`moonshot.yaml`](moonshot.yaml) | Moonshot AI (Kimi K2) provider. |
+| [`vercel.yaml`](vercel.yaml) | Vercel AI Gateway multi-provider router. |
 | [`grok.yaml`](grok.yaml) | xAI Grok model. |
 | [`github-copilot.yaml`](github-copilot.yaml) | GitHub Copilot models via OAuth device-flow. |
 | [`fallback_models.yaml`](fallback_models.yaml) | Automatic fallback to a secondary model when the primary fails. |

--- a/examples/vercel.yaml
+++ b/examples/vercel.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=../agent-schema.json
+
+models:
+  vercel_model:
+    provider: vercel
+    model: openai/gpt-5
+
+agents:
+  root:
+    model: vercel_model
+    description: Assistant using Vercel AI Gateway
+    instruction: |
+      You are a helpful assistant.
+    toolsets:
+      - type: filesystem
+      - type: shell
+      - type: think

--- a/pkg/config/auto.go
+++ b/pkg/config/auto.go
@@ -63,6 +63,7 @@ var cloudProviders = []providerConfig{
 	{"together", []string{"TOGETHER_API_KEY"}, "TOGETHER_API_KEY", "TOGETHER_API_KEY"},
 	{"huggingface", []string{"HF_TOKEN"}, "HF_TOKEN", "HF_TOKEN"},
 	{"moonshot", []string{"MOONSHOT_API_KEY"}, "MOONSHOT_API_KEY", "MOONSHOT_API_KEY"},
+	{"vercel", []string{"AI_GATEWAY_API_KEY"}, "AI_GATEWAY_API_KEY", "AI_GATEWAY_API_KEY"},
 	{"amazon-bedrock", []string{
 		"AWS_BEARER_TOKEN_BEDROCK",
 		"AWS_ACCESS_KEY_ID",
@@ -135,6 +136,7 @@ var DefaultModels = map[string]string{
 	"together":       "meta-llama/Llama-3.3-70B-Instruct-Turbo",
 	"huggingface":    "meta-llama/Llama-3.3-70B-Instruct",
 	"moonshot":       "kimi-k2-0905-preview",
+	"vercel":         "openai/gpt-5",
 	"amazon-bedrock": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
 	"opencode-go":    "deepseek-v4-flash",
 	"opencode-zen":   "deepseek-v4-flash-free",

--- a/pkg/config/auto_test.go
+++ b/pkg/config/auto_test.go
@@ -120,6 +120,13 @@ func TestAvailableProviders_NoGateway(t *testing.T) {
 			expectedProvider: "moonshot",
 		},
 		{
+			name: "vercel ai gateway key present",
+			envVars: map[string]string{
+				"AI_GATEWAY_API_KEY": "test-key",
+			},
+			expectedProvider: "vercel",
+		},
+		{
 			name:             "no api keys - defaults to dmr",
 			envVars:          map[string]string{},
 			expectedProvider: "dmr",
@@ -363,6 +370,15 @@ func TestAutoModelConfig(t *testing.T) {
 			expectedMaxTokens: 32000,
 		},
 		{
+			name: "vercel provider",
+			envVars: map[string]string{
+				"AI_GATEWAY_API_KEY": "test-key",
+			},
+			expectedProvider:  "vercel",
+			expectedModel:     "openai/gpt-5",
+			expectedMaxTokens: 32000,
+		},
+		{
 			name:              "dmr provider (no api keys)",
 			envVars:           map[string]string{},
 			expectedProvider:  "dmr",
@@ -444,7 +460,7 @@ func TestDefaultModels(t *testing.T) {
 	t.Parallel()
 
 	// Test that DefaultModels map has all expected providers
-	expectedProviders := []string{"openai", "anthropic", "google", "dmr", "mistral", "openrouter", "baseten", "ovhcloud", "groq", "fireworks", "deepseek", "cerebras", "together", "huggingface", "moonshot", "amazon-bedrock", "opencode-zen", "opencode-go"}
+	expectedProviders := []string{"openai", "anthropic", "google", "dmr", "mistral", "openrouter", "baseten", "ovhcloud", "groq", "fireworks", "deepseek", "cerebras", "together", "huggingface", "moonshot", "vercel", "amazon-bedrock", "opencode-zen", "opencode-go"}
 
 	for _, provider := range expectedProviders {
 		t.Run(provider, func(t *testing.T) {
@@ -470,6 +486,7 @@ func TestDefaultModels(t *testing.T) {
 	assert.Equal(t, "meta-llama/Llama-3.3-70B-Instruct-Turbo", DefaultModels["together"])
 	assert.Equal(t, "meta-llama/Llama-3.3-70B-Instruct", DefaultModels["huggingface"])
 	assert.Equal(t, "kimi-k2-0905-preview", DefaultModels["moonshot"])
+	assert.Equal(t, "openai/gpt-5", DefaultModels["vercel"])
 	assert.Equal(t, "global.anthropic.claude-sonnet-4-5-20250929-v1:0", DefaultModels["amazon-bedrock"])
 	assert.Equal(t, "deepseek-v4-flash", DefaultModels["opencode-go"])
 	assert.Equal(t, "deepseek-v4-flash-free", DefaultModels["opencode-zen"])
@@ -479,7 +496,7 @@ func TestAutoModelConfig_IntegrationWithDefaultModels(t *testing.T) {
 	t.Parallel()
 
 	// Verify that AutoModelConfig always returns a model from DefaultModels
-	providers := []string{"openai", "anthropic", "google", "mistral", "openrouter", "baseten", "ovhcloud", "groq", "fireworks", "deepseek", "cerebras", "together", "huggingface", "moonshot", "opencode-zen"}
+	providers := []string{"openai", "anthropic", "google", "mistral", "openrouter", "baseten", "ovhcloud", "groq", "fireworks", "deepseek", "cerebras", "together", "huggingface", "moonshot", "vercel", "opencode-zen"}
 
 	for _, provider := range providers {
 		t.Run(provider, func(t *testing.T) {
@@ -517,6 +534,8 @@ func TestAutoModelConfig_IntegrationWithDefaultModels(t *testing.T) {
 				envVars["HF_TOKEN"] = "test-token"
 			case "moonshot":
 				envVars["MOONSHOT_API_KEY"] = "test-key"
+			case "vercel":
+				envVars["AI_GATEWAY_API_KEY"] = "test-key"
 			case "opencode-zen":
 				envVars["OPENCODE_API_KEY"] = "test-key"
 			}
@@ -686,13 +705,21 @@ func TestAvailableProviders_PrecedenceOrder(t *testing.T) {
 	providers = AvailableProviders(t.Context(), "", env)
 	assert.Equal(t, "huggingface", providers[0])
 
-	// moonshot wins over amazon-bedrock
+	// moonshot wins over vercel
 	env = environment.NewMapEnvProvider(map[string]string{
-		"MOONSHOT_API_KEY":  "test-key",
-		"AWS_ACCESS_KEY_ID": "test-key",
+		"MOONSHOT_API_KEY":   "test-key",
+		"AI_GATEWAY_API_KEY": "test-key",
 	})
 	providers = AvailableProviders(t.Context(), "", env)
 	assert.Equal(t, "moonshot", providers[0])
+
+	// vercel wins over amazon-bedrock
+	env = environment.NewMapEnvProvider(map[string]string{
+		"AI_GATEWAY_API_KEY": "test-key",
+		"AWS_ACCESS_KEY_ID":  "test-key",
+	})
+	providers = AvailableProviders(t.Context(), "", env)
+	assert.Equal(t, "vercel", providers[0])
 
 	// Only OPENCODE_API_KEY set - opencode-zen should win (higher priority than opencode-go)
 	env = environment.NewMapEnvProvider(map[string]string{

--- a/pkg/config/examples_test.go
+++ b/pkg/config/examples_test.go
@@ -25,6 +25,7 @@ var modelsDevAbsentProviders = map[string]bool{
 	"fireworks":    true, // models.dev catalogs Fireworks under the "fireworks-ai" id, not "fireworks"
 	"together":     true, // models.dev catalogs Together AI under the "togetherai" id, not "together"
 	"moonshot":     true, // models.dev catalogs Moonshot AI under the "moonshotai" id, not "moonshot"
+	"vercel":       true, // Vercel AI Gateway is a multi-provider router, not a models.dev catalog id
 }
 
 func collectExamples(t *testing.T) []string {

--- a/pkg/model/provider/aliases.go
+++ b/pkg/model/provider/aliases.go
@@ -113,6 +113,11 @@ var Aliases = map[string]Alias{
 		BaseURL:     "https://api.moonshot.ai/v1",
 		TokenEnvVar: "MOONSHOT_API_KEY",
 	},
+	"vercel": {
+		APIType:     "openai",
+		BaseURL:     "https://ai-gateway.vercel.sh/v1",
+		TokenEnvVar: "AI_GATEWAY_API_KEY",
+	},
 	"github-copilot": {
 		APIType:     "openai",
 		BaseURL:     "https://api.githubcopilot.com",

--- a/pkg/model/provider/aliases_test.go
+++ b/pkg/model/provider/aliases_test.go
@@ -46,6 +46,7 @@ func TestCatalogAliases(t *testing.T) {
 		"together":    {APIType: "openai", BaseURL: "https://api.together.xyz/v1", TokenEnvVar: "TOGETHER_API_KEY"},
 		"huggingface": {APIType: "openai", BaseURL: "https://router.huggingface.co/v1", TokenEnvVar: "HF_TOKEN"},
 		"moonshot":    {APIType: "openai", BaseURL: "https://api.moonshot.ai/v1", TokenEnvVar: "MOONSHOT_API_KEY"},
+		"vercel":      {APIType: "openai", BaseURL: "https://ai-gateway.vercel.sh/v1", TokenEnvVar: "AI_GATEWAY_API_KEY"},
 	}
 
 	for name, want := range expected {

--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -245,6 +245,7 @@ var openModelHostProviders = map[string]bool{
 	"fireworks":   true,
 	"together":    true,
 	"huggingface": true,
+	"vercel":      true,
 }
 
 // shouldMergeConsecutiveMessages reports whether the chat-completions request

--- a/pkg/model/provider/openai/system_message_merge_test.go
+++ b/pkg/model/provider/openai/system_message_merge_test.go
@@ -164,6 +164,7 @@ func TestShouldMergeConsecutiveMessages_Gating(t *testing.T) {
 		{"open-model host fireworks", &latest.ModelConfig{Provider: "fireworks", Model: "accounts/fireworks/models/kimi-k2-instruct"}, true},
 		{"open-model host together", &latest.ModelConfig{Provider: "together", Model: "Qwen/Qwen3-235B-A22B-Instruct-2507-tput"}, true},
 		{"open-model host huggingface", &latest.ModelConfig{Provider: "huggingface", Model: "meta-llama/Llama-3.3-70B-Instruct"}, true},
+		{"open-model host gateway vercel", &latest.ModelConfig{Provider: "vercel", Model: "openai/gpt-5"}, true},
 		{"explicit api_type openai_chatcompletions", &latest.ModelConfig{Provider: "custom", Model: "qwen3", ProviderOpts: map[string]any{"api_type": "openai_chatcompletions"}}, true},
 		// First-party APIs with fixed model lineups: unchanged (no merge).
 		{"first-party mistral", &latest.ModelConfig{Provider: "mistral", Model: "mistral-small"}, false},

--- a/pkg/model/provider/openai_alias_providers_test.go
+++ b/pkg/model/provider/openai_alias_providers_test.go
@@ -92,6 +92,17 @@ var openAIAliasProviders = []openAIAliasProvider{
 		model:    "kimi-k2-0905-preview",
 		greeting: "Hello from Moonshot",
 	},
+	{
+		// Vercel AI Gateway is a multi-provider router that can front open-weight
+		// models (Qwen, Llama, DeepSeek, ...), so its per-source system messages
+		// are coalesced like the other gateway/open-model hosts (issue #3344).
+		provider:             "vercel",
+		envVar:               "AI_GATEWAY_API_KEY",
+		testKey:              "vck-test-vercel-key",
+		model:                "openai/gpt-5",
+		greeting:             "Hello from Vercel",
+		mergesSystemMessages: true,
+	},
 }
 
 // TestOpenAIAliasProvider_EndToEndRequest drives a real request through the full


### PR DESCRIPTION
## Summary

Adds first-class support for [Vercel AI Gateway](https://vercel.com/docs/ai-gateway) as an OpenAI-compatible provider via the alias map. Vercel AI Gateway exposes a single unified endpoint (`https://ai-gateway.vercel.sh/v1`) routing to OpenAI, Anthropic, Google, xAI and more, authenticated with `AI_GATEWAY_API_KEY`.

Implementation mirrors the recently merged Moonshot provider (`17a6e5ec`), with one deliberate difference: Vercel is classified as a multi-provider gateway (coalesces consecutive system messages, like `openrouter`) rather than a first-party API, since it can front open-weight models with strict chat templates (issue #3344).

## Definition of Done

| Item | Status | Where |
| --- | --- | --- |
| Alias entry `vercel` (openai / base URL / `AI_GATEWAY_API_KEY`) | done | `pkg/model/provider/aliases.go` |
| Unit test: alias resolves and `IsCatalogProvider("vercel")` is true | done | `pkg/model/provider/aliases_test.go` (`TestCatalogAliases`) |
| Provider appears in `CatalogProviders()` | done | covered by existing `EachAlias`-driven `TestCatalogProviders` |
| `task test` and `task lint` pass | done | see Validation below |
| Example YAML config | done | `examples/vercel.yaml` |

## Additional wiring (matches the Moonshot precedent)

| Area | Files |
| --- | --- |
| Gateway classification (system-message merge) | `pkg/model/provider/openai/client.go`, `openai/system_message_merge_test.go` |
| End-to-end and opt-in live API test | `pkg/model/provider/openai_alias_providers_test.go` |
| Auto model selection | `pkg/config/auto.go`, `pkg/config/auto_test.go` |
| Example parsing (skip models.dev lookup for the router) | `pkg/config/examples_test.go` |
| Schema and docs | `agent-schema.json`, `docs/_data/nav.yml`, `docs/concepts/models/`, `docs/configuration/models/`, `docs/providers/overview/`, `docs/providers/vercel/index.md`, `examples/README.md` |

## Tests

Coverage is added as rows in the existing table-driven harnesses rather than new bespoke files. The shared alias harness gives both a hermetic end-to-end request (auth header, endpoint, model, SSE reassembly, system-message coalescing) and an opt-in live API check:

```
AI_GATEWAY_API_KEY=... go test -run TestOpenAIAliasProvider_LiveAPI ./pkg/model/provider/
```

## Validation

| Check | Result |
| --- | --- |
| `go build ./...` | pass |
| targeted tests (`pkg/model/provider/...`, `pkg/config/...`) | pass, all `vercel` subtests green |
| `golangci-lint run` | 0 issues |
| custom `go run ./lint .` | no offenses (1330 files) |

## Design note

Auto-selection wiring and the default model (`vercel/openai/gpt-5`, placed `moonshot > vercel > amazon-bedrock` in the priority order) go beyond the strict DoD, added for parity with the Moonshot provider. If keeping Vercel as an alias-only provider (resolvable but not auto-selected, like `requesty`) is preferred, the `pkg/config/auto.go` and `auto_test.go` changes can be dropped.
