### PR TITLE
feat(lint): add OTelTracerName cop to enforce scoped tracer names

### DIFF
--- a/cmd/root/otel.go
+++ b/cmd/root/otel.go
@@ -29,7 +29,7 @@ import (
 	"github.com/docker/docker-agent/pkg/version"
 )
 
-const AppName = "docker-agent"
+const AppName = version.AppName
 
 // initOTelSDK initializes OpenTelemetry SDK with OTLP exporter
 func initOTelSDK(ctx context.Context) (err error) {

--- a/lint/main.go
+++ b/lint/main.go
@@ -36,6 +36,7 @@ var cops = []cop.Cop{
 	ConstructorNetworkIO,
 	WrapErrors,
 	DeferMutexUnlock,
+	OTelTracerName,
 }
 
 // programCops lists whole-program, inter-procedural cops. These run once over

--- a/lint/otel_tracer_name.go
+++ b/lint/otel_tracer_name.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"go/ast"
+	"go/constant"
+	"go/types"
+	"strings"
+
+	"github.com/dgageot/rubocop-go/cop"
+)
+
+const (
+	modulePath             = "github.com/docker/docker-agent"
+	appTracerName          = "docker-agent"
+	legacySharedTracerName = "cagent"
+)
+
+// OTelTracerName enforces package-scoped OpenTelemetry instrumentation names.
+//
+// OpenTelemetry's Tracer name identifies the instrumentation scope, not the
+// service. Spans created directly by a package should therefore use that
+// package's import path, so traces can be attributed to the code that emitted
+// them. Runtime wiring is the exception: it intentionally passes the shared
+// application tracer into runtime code. Prefer otel.Tracer(AppName) for that
+// path; existing otel.Tracer("cagent") calls are kept as legacy shared-tracer
+// exceptions.
+//
+// Per-line suppression: `//rubocop:disable Lint/OTelTracerName`.
+var OTelTracerName = &cop.Func{
+	Meta: cop.Meta{
+		Name:        "Lint/OTelTracerName",
+		Description: "otel.Tracer names must be AppName, cagent, or the current package import path",
+		Severity:    cop.Error,
+	},
+	Types: true,
+	Run: func(p *cop.Pass) {
+		if p.Info == nil || p.Package == nil {
+			return
+		}
+		expected := packageImportPath(p.Package.Path())
+		p.ForEachCall(func(call *ast.CallExpr) {
+			if !isOTelTracerCall(p.Info, call) || len(call.Args) == 0 {
+				return
+			}
+			name, ok := tracerName(p, call.Args[0])
+			if !ok || name == expected || isSharedTracerName(p, call.Args[0], name) {
+				return
+			}
+			p.Reportf(call.Args[0], "otel.Tracer name must be %q for this package, AppName for the shared application tracer, or %q for legacy shared runtime tracing; got %q", expected, legacySharedTracerName, name)
+		})
+	},
+}
+
+func isOTelTracerCall(info *types.Info, call *ast.CallExpr) bool {
+	if info != nil {
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok {
+			if fn, ok := info.Uses[sel.Sel].(*types.Func); ok {
+				pkg := fn.Pkg()
+				return pkg != nil && pkg.Path() == "go.opentelemetry.io/otel" && fn.Name() == "Tracer"
+			}
+		}
+	}
+	return cop.IsCallTo(call, "otel", "Tracer")
+}
+
+func packageImportPath(pkgPath string) string {
+	if strings.HasPrefix(pkgPath, modulePath+"/") || pkgPath == modulePath {
+		return pkgPath
+	}
+	return modulePath + "/" + strings.TrimPrefix(pkgPath, "./")
+}
+
+func isSharedTracerName(p *cop.Pass, expr ast.Expr, name string) bool {
+	if name == legacySharedTracerName {
+		return true
+	}
+	ident, ok := expr.(*ast.Ident)
+	return ok && ident.Name == "AppName" && name == appTracerName && packageImportPath(p.Package.Path()) == modulePath+"/cmd/root"
+}
+
+func stringConstValue(info *types.Info, ident *ast.Ident) (string, bool) {
+	if info == nil {
+		return "", false
+	}
+	c, ok := info.Uses[ident].(*types.Const)
+	if !ok || c.Val().Kind() != constant.String {
+		return "", false
+	}
+	return constant.StringVal(c.Val()), true
+}
+
+func tracerName(p *cop.Pass, expr ast.Expr) (string, bool) {
+	if name, ok := stringLit(expr); ok {
+		return name, true
+	}
+	ident, ok := expr.(*ast.Ident)
+	if !ok {
+		return "", false
+	}
+	if name, ok := stringConstValue(p.Info, ident); ok {
+		return name, true
+	}
+	if val, ok := p.StringConsts()[ident.Name]; ok {
+		return val, true
+	}
+	return "", false
+}

--- a/lint/otel_tracer_name.go
+++ b/lint/otel_tracer_name.go
@@ -10,9 +10,8 @@ import (
 )
 
 const (
-	modulePath             = "github.com/docker/docker-agent"
-	appTracerName          = "docker-agent"
-	legacySharedTracerName = "cagent"
+	modulePath    = "github.com/docker/docker-agent"
+	appTracerName = "docker-agent"
 )
 
 // OTelTracerName enforces package-scoped OpenTelemetry instrumentation names.
@@ -21,15 +20,13 @@ const (
 // service. Spans created directly by a package should therefore use that
 // package's import path, so traces can be attributed to the code that emitted
 // them. Runtime wiring is the exception: it intentionally passes the shared
-// application tracer into runtime code. Prefer otel.Tracer(AppName) for that
-// path; existing otel.Tracer("cagent") calls are kept as legacy shared-tracer
-// exceptions.
+// application tracer into runtime code via otel.Tracer(AppName).
 //
 // Per-line suppression: `//rubocop:disable Lint/OTelTracerName`.
 var OTelTracerName = &cop.Func{
 	Meta: cop.Meta{
 		Name:        "Lint/OTelTracerName",
-		Description: "otel.Tracer names must be AppName, cagent, or the current package import path",
+		Description: "otel.Tracer names must be AppName or the current package import path",
 		Severity:    cop.Error,
 	},
 	Types: true,
@@ -42,11 +39,16 @@ var OTelTracerName = &cop.Func{
 			if !isOTelTracerCall(p.Info, call) || len(call.Args) == 0 {
 				return
 			}
-			name, ok := tracerName(p, call.Args[0])
-			if !ok || name == expected || isSharedTracerName(p, call.Args[0], name) {
+			arg := call.Args[0]
+			name, ok := tracerName(p, arg)
+			if !ok || name == expected || isAppName(p.Info, arg, name) {
 				return
 			}
-			p.Reportf(call.Args[0], "otel.Tracer name must be %q for this package, AppName for the shared application tracer, or %q for legacy shared runtime tracing; got %q", expected, legacySharedTracerName, name)
+			if name == "cagent" {
+				p.Report(arg, `use otel.Tracer(AppName) instead of otel.Tracer("cagent") for the shared application tracer`)
+				return
+			}
+			p.Reportf(arg, "otel.Tracer name must be %q for this package or AppName for the shared application tracer; got %q", expected, name)
 		})
 	},
 }
@@ -70,35 +72,48 @@ func packageImportPath(pkgPath string) string {
 	return modulePath + "/" + strings.TrimPrefix(pkgPath, "./")
 }
 
-func isSharedTracerName(p *cop.Pass, expr ast.Expr, name string) bool {
-	if name == legacySharedTracerName {
-		return true
+func isAppName(info *types.Info, expr ast.Expr, name string) bool {
+	if name != appTracerName {
+		return false
 	}
-	ident, ok := expr.(*ast.Ident)
-	return ok && ident.Name == "AppName" && name == appTracerName && packageImportPath(p.Package.Path()) == modulePath+"/cmd/root"
+	c, ok := constObject(info, expr)
+	return ok && c.Name() == "AppName"
 }
 
-func stringConstValue(info *types.Info, ident *ast.Ident) (string, bool) {
-	if info == nil {
-		return "", false
-	}
-	c, ok := info.Uses[ident].(*types.Const)
+func constStringValue(info *types.Info, expr ast.Expr) (string, bool) {
+	c, ok := constObject(info, expr)
 	if !ok || c.Val().Kind() != constant.String {
 		return "", false
 	}
 	return constant.StringVal(c.Val()), true
 }
 
+func constObject(info *types.Info, expr ast.Expr) (*types.Const, bool) {
+	if info == nil {
+		return nil, false
+	}
+	switch e := expr.(type) {
+	case *ast.Ident:
+		c, ok := info.Uses[e].(*types.Const)
+		return c, ok
+	case *ast.SelectorExpr:
+		c, ok := info.Uses[e.Sel].(*types.Const)
+		return c, ok
+	default:
+		return nil, false
+	}
+}
+
 func tracerName(p *cop.Pass, expr ast.Expr) (string, bool) {
 	if name, ok := stringLit(expr); ok {
+		return name, true
+	}
+	if name, ok := constStringValue(p.Info, expr); ok {
 		return name, true
 	}
 	ident, ok := expr.(*ast.Ident)
 	if !ok {
 		return "", false
-	}
-	if name, ok := stringConstValue(p.Info, ident); ok {
-		return name, true
 	}
 	if val, ok := p.StringConsts()[ident.Name]; ok {
 		return val, true

--- a/lint/otel_tracer_name.go
+++ b/lint/otel_tracer_name.go
@@ -10,8 +10,9 @@ import (
 )
 
 const (
-	modulePath    = "github.com/docker/docker-agent"
-	appTracerName = "docker-agent"
+	modulePath     = "github.com/docker/docker-agent"
+	versionPkgPath = modulePath + "/pkg/version"
+	cmdRootPkgPath = modulePath + "/cmd/root"
 )
 
 // OTelTracerName enforces package-scoped OpenTelemetry instrumentation names.
@@ -41,7 +42,7 @@ var OTelTracerName = &cop.Func{
 			}
 			arg := call.Args[0]
 			name, ok := tracerName(p, arg)
-			if !ok || name == expected || isAppName(p.Info, arg, name) {
+			if !ok || name == expected || isAppName(p.Info, arg) {
 				return
 			}
 			if name == "cagent" {
@@ -72,12 +73,13 @@ func packageImportPath(pkgPath string) string {
 	return modulePath + "/" + strings.TrimPrefix(pkgPath, "./")
 }
 
-func isAppName(info *types.Info, expr ast.Expr, name string) bool {
-	if name != appTracerName {
+func isAppName(info *types.Info, expr ast.Expr) bool {
+	c, ok := constObject(info, expr)
+	if !ok || c.Name() != "AppName" || c.Pkg() == nil {
 		return false
 	}
-	c, ok := constObject(info, expr)
-	return ok && c.Name() == "AppName"
+	pkg := c.Pkg().Path()
+	return pkg == versionPkgPath || pkg == cmdRootPkgPath
 }
 
 func constStringValue(info *types.Info, expr ast.Expr) (string, bool) {

--- a/lint/otel_tracer_name_test.go
+++ b/lint/otel_tracer_name_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/dgageot/rubocop-go/coptest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOTelTracerNameFlagsCagent(t *testing.T) {
+	t.Parallel()
+	src := `package p
+import "go.opentelemetry.io/otel"
+func f() { _ = otel.Tracer("cagent") }
+`
+	offenses := coptest.RunTyped(t, OTelTracerName, src)
+	require.Len(t, offenses, 1)
+	assert.Equal(t, "Lint/OTelTracerName", offenses[0].CopName)
+	assert.Contains(t, offenses[0].Message, `otel.Tracer(AppName)`)
+}
+
+func TestOTelTracerNameAllowsAppName(t *testing.T) {
+	t.Parallel()
+	src := `package p
+import "go.opentelemetry.io/otel"
+const AppName = "docker-agent"
+func f() { _ = otel.Tracer(AppName) }
+`
+	assert.Empty(t, coptest.RunTyped(t, OTelTracerName, src))
+}
+
+func TestOTelTracerNameAllowsVersionAppName(t *testing.T) {
+	t.Parallel()
+	src := `package p
+import (
+	"go.opentelemetry.io/otel"
+	"github.com/docker/docker-agent/pkg/version"
+)
+func f() { _ = otel.Tracer(version.AppName) }
+`
+	assert.Empty(t, coptest.RunTyped(t, OTelTracerName, src))
+}
+
+func TestOTelTracerNameFlagsWrongName(t *testing.T) {
+	t.Parallel()
+	src := `package p
+import "go.opentelemetry.io/otel"
+func f() { _ = otel.Tracer("wrong") }
+`
+	offenses := coptest.RunTyped(t, OTelTracerName, src)
+	require.Len(t, offenses, 1)
+	assert.Contains(t, offenses[0].Message, `got "wrong"`)
+}

--- a/lint/otel_tracer_name_test.go
+++ b/lint/otel_tracer_name_test.go
@@ -20,14 +20,17 @@ func f() { _ = otel.Tracer("cagent") }
 	assert.Contains(t, offenses[0].Message, `otel.Tracer(AppName)`)
 }
 
-func TestOTelTracerNameAllowsAppName(t *testing.T) {
+func TestOTelTracerNameFlagsLocalAppName(t *testing.T) {
 	t.Parallel()
+	// A local const named AppName from an unrelated package must not bypass the cop.
 	src := `package p
 import "go.opentelemetry.io/otel"
 const AppName = "docker-agent"
 func f() { _ = otel.Tracer(AppName) }
 `
-	assert.Empty(t, coptest.RunTyped(t, OTelTracerName, src))
+	offenses := coptest.RunTyped(t, OTelTracerName, src)
+	require.Len(t, offenses, 1)
+	assert.Contains(t, offenses[0].Message, `got "docker-agent"`)
 }
 
 func TestOTelTracerNameAllowsVersionAppName(t *testing.T) {

--- a/pkg/a2a/adapter.go
+++ b/pkg/a2a/adapter.go
@@ -21,6 +21,7 @@ import (
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/team"
 	cgenai "github.com/docker/docker-agent/pkg/telemetry/genai"
+	"github.com/docker/docker-agent/pkg/version"
 )
 
 // newDockerAgentAdapter creates a new ADK agent adapter from a docker agent team and agent name.
@@ -103,7 +104,7 @@ func runDockerAgent(ctx agent.InvocationContext, t *team.Team, agentName string,
 			// returns no-op spans for runtime.session, runtime.stream,
 			// runtime.tool.call, runtime.fallback, runtime.run_skill,
 			// hook events, and so on.
-			runtime.WithTracer(otel.Tracer("cagent")),
+			runtime.WithTracer(otel.Tracer(version.AppName)),
 		)
 		if err != nil {
 			yield(nil, fmt.Errorf("failed to create runtime: %w", err))

--- a/pkg/acp/agent.go
+++ b/pkg/acp/agent.go
@@ -142,7 +142,7 @@ func (a *Agent) newRuntime(ctx context.Context, workingDir string) (runtime.Runt
 		runtime.WithProviderRegistry(a.providerRegistry),
 		// Match the CLI tracer scope; without this the ACP-mode
 		// runtime's `startSpan` is a no-op for every runtime.* span.
-		runtime.WithTracer(otel.Tracer("cagent")),
+		runtime.WithTracer(otel.Tracer(version.AppName)),
 	}
 	if workingDir != "" {
 		opts = append(opts, runtime.WithWorkingDir(workingDir))

--- a/pkg/chatserver/runtime_pool.go
+++ b/pkg/chatserver/runtime_pool.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/team"
+	"github.com/docker/docker-agent/pkg/version"
 )
 
 // runtimePool keeps a small set of `runtime.Runtime` instances ready for
@@ -66,7 +67,7 @@ func (p *runtimePool) Get(agent string) (runtime.Runtime, error) {
 	// spans go silent in OpenAI-compatible chat-completions mode.
 	rt, err := runtime.New(p.ctx(), p.team,
 		runtime.WithCurrentAgent(agent),
-		runtime.WithTracer(otel.Tracer("cagent")),
+		runtime.WithTracer(otel.Tracer(version.AppName)),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -217,7 +217,7 @@ func CreateToolHandler(t *team.Team, agentName string) func(context.Context, *mc
 			// See pkg/a2a/adapter.go for rationale — without this
 			// the runtime's startSpan is a no-op when cagent runs as
 			// an MCP server, so all our runtime.* spans go silent.
-			runtime.WithTracer(otel.Tracer("cagent")),
+			runtime.WithTracer(otel.Tracer(version.AppName)),
 		)
 		if err != nil {
 			return nil, ToolOutput{}, fmt.Errorf("failed to create runtime: %w", err)

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -29,6 +29,7 @@ import (
 	"github.com/docker/docker-agent/pkg/teamloader"
 	loaderdefaults "github.com/docker/docker-agent/pkg/teamloader/defaults"
 	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/version"
 )
 
 type activeRuntimes struct {
@@ -975,7 +976,7 @@ func (sm *SessionManager) runtimeForSession(ctx context.Context, sess *session.S
 		// Match the tracer scope used by the CLI; without this the
 		// API-server runtime's startSpan is a no-op so all the
 		// runtime.* spans go silent in HTTP-server mode.
-		runtime.WithTracer(otel.Tracer("cagent")),
+		runtime.WithTracer(otel.Tracer(version.AppName)),
 		runtime.WithModelSwitcherConfig(modelSwitcherCfg),
 	}
 	run, err := runtime.New(ctx, t, opts...)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,5 +1,7 @@
 package version
 
+const AppName = "docker-agent"
+
 // version information
 var (
 	Version = "dev"


### PR DESCRIPTION
OpenTelemetry tracer names identify the *instrumentation scope*, not the service. Before this change, several call sites passed the hard-coded string `"cagent"` to `otel.Tracer()`, which attributed spans to a stale internal name and made it impossible to tell which package originated a trace. There was also no enforcement to prevent the pattern from spreading.

This adds a custom `Lint/OTelTracerName` cop to the in-tree linter. The cop rejects any `otel.Tracer()` call whose argument is not either the current package's import path or the shared `AppName` constant. The special case `"cagent"` is called out explicitly with a message directing the author to use `otel.Tracer(AppName)` instead. Existing call sites in `pkg/a2a`, `pkg/acp`, `pkg/chatserver`, `pkg/mcp`, and `pkg/server` are updated to pass `AppName`. The constant itself is consolidated in `pkg/version` so every package can import a single source of truth; the duplicate declaration in `cmd/root` is replaced with a reference to `version.AppName`.

`task lint`, `task test`, and `task build` all pass with these changes.