### PR TITLE
feat: add Cloudflare Workers AI and AI Gateway as model providers

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -182,7 +182,7 @@
       "properties": {
         "provider": {
           "type": "string",
-          "description": "The underlying provider type. Defaults to \"openai\" when not set. Supported values: openai, anthropic, google, amazon-bedrock, dmr, and any built-in alias (requesty, openrouter, azure, xai, ollama, mistral, baseten, ovhcloud, groq, fireworks, deepseek, cerebras, together, huggingface, moonshot, vercel, etc.).",
+          "description": "The underlying provider type. Defaults to \"openai\" when not set. Supported values: openai, anthropic, google, amazon-bedrock, dmr, and any built-in alias (requesty, openrouter, azure, xai, ollama, mistral, baseten, ovhcloud, groq, fireworks, deepseek, cerebras, together, huggingface, moonshot, vercel, cloudflare-workers-ai, cloudflare-ai-gateway, etc.).",
           "examples": [
             "openai",
             "anthropic",

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -143,6 +143,10 @@
       url: /providers/baseten/
     - title: Cerebras
       url: /providers/cerebras/
+    - title: Cloudflare AI Gateway
+      url: /providers/cloudflare-ai-gateway/
+    - title: Cloudflare Workers AI
+      url: /providers/cloudflare-workers-ai/
     - title: DeepSeek
       url: /providers/deepseek/
     - title: Docker Model Runner

--- a/docs/concepts/models/index.md
+++ b/docs/concepts/models/index.md
@@ -89,8 +89,10 @@ for details.
 | Cerebras            | `cerebras`       | GPT-OSS, GLM (fast inference)         | `CEREBRAS_API_KEY`                  |
 | Together AI         | `together`       | Llama, Qwen, DeepSeek, Kimi (open models) | `TOGETHER_API_KEY`             |
 | Hugging Face        | `huggingface`    | Llama, Qwen, DeepSeek, GLM (open models) | `HF_TOKEN`                      |
+| Cloudflare Workers AI | `cloudflare-workers-ai` | Llama, Mistral, Qwen, Gemma (edge-hosted open models) | `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` |
 | Moonshot AI         | `moonshot`       | Kimi K2 chat, reasoning, and coding models | `MOONSHOT_API_KEY`             |
 | Vercel AI Gateway   | `vercel`         | Multi-provider gateway               | `AI_GATEWAY_API_KEY`                |
+| Cloudflare AI Gateway | `cloudflare-ai-gateway` | Multi-provider gateway         | `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_GATEWAY_ID` |
 | Requesty            | `requesty`       | Multi-provider gateway               | `REQUESTY_API_KEY`                  |
 | OpenRouter          | `openrouter`     | Multi-provider gateway               | `OPENROUTER_API_KEY`                |
 | Azure OpenAI        | `azure`          | gpt-4o, gpt-5 on Azure               | `AZURE_API_KEY` + `base_url`        |

--- a/docs/configuration/models/index.md
+++ b/docs/configuration/models/index.md
@@ -17,7 +17,7 @@ models:
     first_available: [list] # Optional: candidate model refs, tried in order by available credentials.
                             # Mutually exclusive with other model settings.
     provider: string # Required unless using first_available. One of: openai, anthropic, google, amazon-bedrock,
-                     # dmr, mistral, xai, nebius, minimax, baseten, ovhcloud, groq, fireworks, deepseek, cerebras, together, huggingface, moonshot, vercel, requesty, openrouter,
+                     # dmr, mistral, xai, nebius, minimax, baseten, ovhcloud, groq, fireworks, deepseek, cerebras, together, huggingface, moonshot, vercel, cloudflare-workers-ai, cloudflare-ai-gateway, requesty, openrouter,
                      # azure, ollama, github-copilot, or a named provider defined
                      # under the top-level `providers:` section.
     model: string # Required: model identifier
@@ -48,7 +48,7 @@ models:
 | Property              | Type       | Required | Description                                                                           |
 | --------------------- | ---------- | -------- | ------------------------------------------------------------------------------------- |
 | `first_available`     | array      | ✗        | Candidate model references tried in order; selects the first whose credentials are configured. Mutually exclusive with other model settings. |
-| `provider`            | string     | ✓/✗      | Required for regular model definitions; omitted for `first_available` selectors. Provider: `openai`, `anthropic`, `google`, `amazon-bedrock`, `dmr`, `mistral`, `xai`, `nebius`, `minimax`, `baseten`, `ovhcloud`, `groq`, `fireworks`, `deepseek`, `cerebras`, `together`, `huggingface`, `moonshot`, `vercel`, `requesty`, `openrouter`, `azure`, `ollama`, `github-copilot`, or any [named provider]({{ '/providers/custom/' | relative_url }}). |
+| `provider`            | string     | ✓/✗      | Required for regular model definitions; omitted for `first_available` selectors. Provider: `openai`, `anthropic`, `google`, `amazon-bedrock`, `dmr`, `mistral`, `xai`, `nebius`, `minimax`, `baseten`, `ovhcloud`, `groq`, `fireworks`, `deepseek`, `cerebras`, `together`, `huggingface`, `moonshot`, `vercel`, `cloudflare-workers-ai`, `cloudflare-ai-gateway`, `requesty`, `openrouter`, `azure`, `ollama`, `github-copilot`, or any [named provider]({{ '/providers/custom/' | relative_url }}). |
 | `model`               | string     | ✓/✗      | Required for regular model definitions; omitted for `first_available` selectors. Model name (e.g., `gpt-4o`, `claude-sonnet-4-5`, `gemini-3.5-flash`) |
 | `temperature`         | float      | ✗        | Sampling randomness. Range is provider-dependent — typically `0.0–2.0` (Anthropic caps at `1.0`). `0.0` is deterministic. |
 | `max_tokens`          | int        | ✗        | Maximum response length in tokens                                                     |
@@ -404,7 +404,7 @@ See the [Anthropic provider page]({{ '/providers/anthropic/#thinking-display' | 
 ## Custom HTTP Headers
 
 For OpenAI-compatible providers (`openai`, `github-copilot`, `mistral`, `xai`,
-`nebius`, `minimax`, `baseten`, `ovhcloud`, `groq`, `fireworks`, `deepseek`, `cerebras`, `together`, `huggingface`, `moonshot`, `vercel`, `requesty`, `openrouter`, `ollama`, and any custom provider using the OpenAI API),
+`nebius`, `minimax`, `baseten`, `ovhcloud`, `groq`, `fireworks`, `deepseek`, `cerebras`, `together`, `huggingface`, `moonshot`, `vercel`, `cloudflare-workers-ai`, `cloudflare-ai-gateway`, `requesty`, `openrouter`, `ollama`, and any custom provider using the OpenAI API),
 `provider_opts.http_headers` adds arbitrary HTTP headers to every outgoing
 request:
 

--- a/docs/providers/cloudflare-ai-gateway/index.md
+++ b/docs/providers/cloudflare-ai-gateway/index.md
@@ -1,0 +1,115 @@
+---
+title: "Cloudflare AI Gateway"
+description: "Use Cloudflare AI Gateway models with docker-agent."
+permalink: /providers/cloudflare-ai-gateway/
+---
+
+# Cloudflare AI Gateway
+
+_Use Cloudflare AI Gateway models with docker-agent._
+
+## Overview
+
+[Cloudflare AI Gateway](https://developers.cloudflare.com/ai-gateway/) is a
+single OpenAI-compatible endpoint that routes to models from OpenAI, Anthropic,
+Workers AI and more, with caching, rate limiting and observability. docker-agent
+includes built-in support for AI Gateway as an alias provider.
+
+The alias sends your token in the standard `Authorization: Bearer` header, so it
+works out of the box with a gateway that has **authentication disabled** (the
+default), typically to route to your own Workers AI models through a gateway you
+own. See [Authentication](#authentication) below for the unified-billing /
+authenticated-gateway caveat.
+
+## Setup
+
+The gateway endpoint is account- and gateway-scoped, so its base URL is resolved
+from your account ID and gateway ID. Three environment variables are required:
+
+```bash
+export CLOUDFLARE_ACCOUNT_ID=your-account-id
+export CLOUDFLARE_GATEWAY_ID=your-gateway-id
+export CLOUDFLARE_API_TOKEN=your-api-token
+```
+
+Create a gateway from the
+[AI Gateway dashboard](https://dash.cloudflare.com/?to=/:account/ai/ai-gateway)
+and an API token with the appropriate permissions.
+
+## Usage
+
+AI Gateway model IDs use the gateway's `provider/model` form (for example
+`workers-ai/@cf/meta/llama-3.1-8b-instruct` or `openai/gpt-4o`); the gateway
+routes each request to the underlying provider.
+
+### Inline Syntax
+
+```yaml
+agents:
+  root:
+    model: cloudflare-ai-gateway/workers-ai/@cf/meta/llama-3.1-8b-instruct
+    description: Assistant using Cloudflare AI Gateway
+    instruction: You are a helpful assistant.
+```
+
+### Named Model
+
+For more control over parameters:
+
+```yaml
+models:
+  cloudflare_model:
+    provider: cloudflare-ai-gateway
+    model: "workers-ai/@cf/meta/llama-3.1-8b-instruct"
+    temperature: 0.7
+    max_tokens: 8192
+
+agents:
+  root:
+    model: cloudflare_model
+    description: Assistant using Cloudflare AI Gateway
+    instruction: You are a helpful assistant.
+```
+
+## Available Models
+
+AI Gateway exposes models from many providers behind one endpoint. Check the
+[AI Gateway documentation](https://developers.cloudflare.com/ai-gateway/) for
+the current provider list, model IDs, and how billing works.
+
+> Model IDs are case-sensitive and must be passed exactly as the gateway lists
+> them, including the `provider/` prefix.
+
+## How It Works
+
+Cloudflare AI Gateway is implemented as a built-in alias in docker-agent:
+
+- **API Type:** OpenAI-compatible (`openai_chatcompletions`)
+- **Base URL:** `https://gateway.ai.cloudflare.com/v1/${CLOUDFLARE_ACCOUNT_ID}/${CLOUDFLARE_GATEWAY_ID}/compat`
+- **Token Variable:** `CLOUDFLARE_API_TOKEN`
+
+The base URL is templated: `${CLOUDFLARE_ACCOUNT_ID}` and
+`${CLOUDFLARE_GATEWAY_ID}` are substituted from the environment when the provider
+is built, so both must be set in addition to `CLOUDFLARE_API_TOKEN`. Because the
+gateway can route to open-weight models with strict chat templates, docker-agent
+coalesces consecutive system messages into a single leading one for this
+provider.
+
+## Authentication
+
+docker-agent authenticates by sending `CLOUDFLARE_API_TOKEN` in the standard
+`Authorization: Bearer` header. On the `.../compat` endpoint that header is
+treated as the **provider** key, so this alias works when:
+
+- the gateway has **authentication disabled** (the default), and
+- the routed models accept that token as their provider key, which is the case
+  for **Workers AI** models (`workers-ai/@cf/...`).
+
+A gateway with **authentication enabled** (required for
+[unified billing](https://developers.cloudflare.com/ai-gateway/features/unified-billing/))
+instead expects the token in Cloudflare's `cf-aig-authorization` header. The
+alias does not send that header, and custom `provider_opts.http_headers` values
+are not environment-expanded, so an authenticated gateway is **not supported out
+of the box** today. For that setup, use an unauthenticated gateway, or configure
+a [custom provider]({{ '/providers/custom/' | relative_url }}) against the
+Cloudflare AI Gateway REST API.

--- a/docs/providers/cloudflare-workers-ai/index.md
+++ b/docs/providers/cloudflare-workers-ai/index.md
@@ -1,0 +1,91 @@
+---
+title: "Cloudflare Workers AI"
+description: "Use Cloudflare Workers AI models with docker-agent."
+permalink: /providers/cloudflare-workers-ai/
+---
+
+# Cloudflare Workers AI
+
+_Use Cloudflare Workers AI models with docker-agent._
+
+## Overview
+
+[Cloudflare Workers AI](https://developers.cloudflare.com/workers-ai/) runs
+open-weight models (Llama, Mistral, Qwen, Gemma, and more) on Cloudflare's
+global edge network through an OpenAI-compatible endpoint. No separate provider
+accounts are needed for the supported models. docker-agent includes built-in
+support for Workers AI as an alias provider.
+
+## Setup
+
+Workers AI is account-scoped, so its base URL is resolved from your account ID.
+Two environment variables are required:
+
+```bash
+export CLOUDFLARE_ACCOUNT_ID=your-account-id
+export CLOUDFLARE_API_TOKEN=your-api-token
+```
+
+Create an API token with the `Workers AI` permission from the
+[Cloudflare dashboard](https://dash.cloudflare.com/profile/api-tokens). Your
+account ID is shown on the Workers AI page.
+
+## Usage
+
+Workers AI model IDs use the `@cf/...` form (for example
+`@cf/meta/llama-3.1-8b-instruct`).
+
+### Inline Syntax
+
+```yaml
+agents:
+  root:
+    model: cloudflare-workers-ai/@cf/meta/llama-3.1-8b-instruct
+    description: Assistant using Cloudflare Workers AI
+    instruction: You are a helpful assistant.
+```
+
+### Named Model
+
+For more control over parameters:
+
+```yaml
+models:
+  cloudflare_model:
+    provider: cloudflare-workers-ai
+    model: "@cf/meta/llama-3.1-8b-instruct"
+    temperature: 0.7
+    max_tokens: 8192
+
+agents:
+  root:
+    model: cloudflare_model
+    description: Assistant using Cloudflare Workers AI
+    instruction: You are a helpful assistant.
+```
+
+## Available Models
+
+Check the
+[Workers AI models catalog](https://developers.cloudflare.com/workers-ai/models/)
+for the current list, IDs, and pricing.
+
+| Model | Description |
+| --- | --- |
+| `@cf/meta/llama-3.1-8b-instruct` | Meta Llama 3.1 8B Instruct |
+| `@cf/mistralai/mistral-small-3.1-24b-instruct` | Mistral Small 3.1 24B Instruct |
+| `@cf/qwen/qwen2.5-coder-32b-instruct` | Qwen 2.5 Coder 32B Instruct |
+
+## How It Works
+
+Cloudflare Workers AI is implemented as a built-in alias in docker-agent:
+
+- **API Type:** OpenAI-compatible (`openai_chatcompletions`)
+- **Base URL:** `https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/ai/v1`
+- **Token Variable:** `CLOUDFLARE_API_TOKEN`
+
+The base URL is templated: `${CLOUDFLARE_ACCOUNT_ID}` is substituted from the
+environment when the provider is built, so `CLOUDFLARE_ACCOUNT_ID` must be set in
+addition to `CLOUDFLARE_API_TOKEN`. Because Workers AI serves open-weight models
+with strict chat templates, docker-agent coalesces consecutive system messages
+into a single leading one for this provider.

--- a/docs/providers/overview/index.md
+++ b/docs/providers/overview/index.md
@@ -73,8 +73,10 @@ docker-agent also includes built-in aliases for these providers:
 | Cerebras       | `cerebras`       | `CEREBRAS_API_KEY`                  |
 | Together AI    | `together`       | `TOGETHER_API_KEY`                  |
 | Hugging Face   | `huggingface`    | `HF_TOKEN`                          |
+| Cloudflare Workers AI | `cloudflare-workers-ai` | `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` |
 | Moonshot AI    | `moonshot`       | `MOONSHOT_API_KEY`                  |
 | Vercel AI Gateway | `vercel`      | `AI_GATEWAY_API_KEY`                |
+| Cloudflare AI Gateway | `cloudflare-ai-gateway` | `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_GATEWAY_ID` |
 | Requesty       | `requesty`       | `REQUESTY_API_KEY`                  |
 | OpenRouter     | `openrouter`     | `OPENROUTER_API_KEY`                |
 | Azure OpenAI   | `azure`          | `AZURE_API_KEY` + `base_url`        |

--- a/examples/README.md
+++ b/examples/README.md
@@ -203,6 +203,8 @@ remote MCP endpoints.
 | [`huggingface.yaml`](huggingface.yaml) | Hugging Face Inference Providers open-model router. |
 | [`moonshot.yaml`](moonshot.yaml) | Moonshot AI (Kimi K2) provider. |
 | [`vercel.yaml`](vercel.yaml) | Vercel AI Gateway multi-provider router. |
+| [`cloudflare-workers-ai.yaml`](cloudflare-workers-ai.yaml) | Cloudflare Workers AI edge-hosted open models. |
+| [`cloudflare-ai-gateway.yaml`](cloudflare-ai-gateway.yaml) | Cloudflare AI Gateway multi-provider router. |
 | [`grok.yaml`](grok.yaml) | xAI Grok model. |
 | [`github-copilot.yaml`](github-copilot.yaml) | GitHub Copilot models via OAuth device-flow. |
 | [`fallback_models.yaml`](fallback_models.yaml) | Automatic fallback to a secondary model when the primary fails. |

--- a/examples/cloudflare-ai-gateway.yaml
+++ b/examples/cloudflare-ai-gateway.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=../agent-schema.json
+
+# Requires CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_GATEWAY_ID and CLOUDFLARE_API_TOKEN
+# in the environment. The gateway-scoped base URL is resolved from
+# CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_GATEWAY_ID. Model IDs use the gateway's
+# provider/model form (see the Cloudflare AI Gateway docs).
+#
+# The token is sent as "Authorization: Bearer", so this works with a gateway
+# that has authentication disabled (the default), routing to Workers AI models.
+# An authenticated gateway (unified billing) needs the cf-aig-authorization
+# header, which this alias does not send. See docs/providers/cloudflare-ai-gateway.
+models:
+  cloudflare_model:
+    provider: cloudflare-ai-gateway
+    model: "workers-ai/@cf/meta/llama-3.1-8b-instruct"
+
+agents:
+  root:
+    model: cloudflare_model
+    description: Assistant using Cloudflare AI Gateway
+    instruction: |
+      You are a helpful assistant.
+    toolsets:
+      - type: filesystem
+      - type: shell
+      - type: think

--- a/examples/cloudflare-workers-ai.yaml
+++ b/examples/cloudflare-workers-ai.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=../agent-schema.json
+
+# Requires CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN in the environment.
+# The account-scoped base URL is resolved from CLOUDFLARE_ACCOUNT_ID.
+models:
+  cloudflare_model:
+    provider: cloudflare-workers-ai
+    model: "@cf/meta/llama-3.1-8b-instruct"
+
+agents:
+  root:
+    model: cloudflare_model
+    description: Assistant using Cloudflare Workers AI
+    instruction: |
+      You are a helpful assistant.
+    toolsets:
+      - type: filesystem
+      - type: shell
+      - type: think

--- a/pkg/config/examples_test.go
+++ b/pkg/config/examples_test.go
@@ -19,13 +19,15 @@ import (
 // are not expected to exist in the remote models.dev catalog. The test
 // skips models.dev lookups for these to avoid false failures.
 var modelsDevAbsentProviders = map[string]bool{
-	"dmr":          true, // Docker Model Runner (local, not in catalog)
-	"opencode-zen": true, // not yet registered in models.dev
-	"ovhcloud":     true, // OVHcloud AI Endpoints (not yet in models.dev)
-	"fireworks":    true, // models.dev catalogs Fireworks under the "fireworks-ai" id, not "fireworks"
-	"together":     true, // models.dev catalogs Together AI under the "togetherai" id, not "together"
-	"moonshot":     true, // models.dev catalogs Moonshot AI under the "moonshotai" id, not "moonshot"
-	"vercel":       true, // Vercel AI Gateway is a multi-provider router, not a models.dev catalog id
+	"dmr":                   true, // Docker Model Runner (local, not in catalog)
+	"opencode-zen":          true, // not yet registered in models.dev
+	"ovhcloud":              true, // OVHcloud AI Endpoints (not yet in models.dev)
+	"fireworks":             true, // models.dev catalogs Fireworks under the "fireworks-ai" id, not "fireworks"
+	"together":              true, // models.dev catalogs Together AI under the "togetherai" id, not "together"
+	"moonshot":              true, // models.dev catalogs Moonshot AI under the "moonshotai" id, not "moonshot"
+	"vercel":                true, // Vercel AI Gateway is a multi-provider router, not a models.dev catalog id
+	"cloudflare-workers-ai": true, // example uses an @cf/... model id not present in the models.dev snapshot (only variant ids like -fp8 are listed)
+	"cloudflare-ai-gateway": true, // multi-provider router; example model ids use the gateway's provider/model form, not guaranteed to match a models.dev id
 }
 
 func collectExamples(t *testing.T) []string {

--- a/pkg/config/gather.go
+++ b/pkg/config/gather.go
@@ -176,6 +176,12 @@ func addEnvVarsForModelConfig(ctx context.Context, model *latest.ModelConfig, cu
 		if alias.TokenEnvVar != "" {
 			requiredEnv[alias.TokenEnvVar] = true
 		}
+		// A templated alias base URL (e.g. Cloudflare's account/gateway-scoped
+		// endpoint) references env vars that must resolve when the provider is
+		// built, so surface them in the preflight check too.
+		for _, name := range environment.Refs(alias.BaseURL) {
+			requiredEnv[name] = true
+		}
 	} else {
 		addEnvVarsForCoreProvider(ctx, model.Provider, model, requiredEnv, env)
 	}

--- a/pkg/config/gather_alias_env_test.go
+++ b/pkg/config/gather_alias_env_test.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/environment"
+)
+
+// TestGatherEnvVarsForModels_TemplatedAliasBaseURL verifies that the env vars
+// referenced by an alias's templated base URL (e.g. Cloudflare's
+// account/gateway-scoped endpoints) are reported as required, alongside the
+// token, so a missing account/gateway id is caught by the preflight check
+// instead of only failing at provider-build time.
+func TestGatherEnvVarsForModels_TemplatedAliasBaseURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		provider    string
+		wantPresent []string
+	}{
+		{
+			name:        "workers-ai requires account id and token",
+			provider:    "cloudflare-workers-ai",
+			wantPresent: []string{"CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID"},
+		},
+		{
+			name:        "ai-gateway requires account id, gateway id and token",
+			provider:    "cloudflare-ai-gateway",
+			wantPresent: []string{"CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID", "CLOUDFLARE_GATEWAY_ID"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &latest.Config{
+				Agents: []latest.AgentConfig{{Name: "a", Model: "m"}},
+				Models: map[string]latest.ModelConfig{
+					"m": {Provider: tt.provider, Model: "some-model"},
+				},
+			}
+
+			got := GatherEnvVarsForModels(t.Context(), cfg, environment.NewNoEnvProvider())
+			for _, want := range tt.wantPresent {
+				assert.Contains(t, got, want, "expected %q in %v", want, got)
+			}
+		})
+	}
+}

--- a/pkg/model/provider/aliases.go
+++ b/pkg/model/provider/aliases.go
@@ -9,8 +9,11 @@ import (
 
 // Alias defines the configuration for a provider alias.
 type Alias struct {
-	APIType     string // The actual API type to use (openai, anthropic, etc.)
-	BaseURL     string // Default base URL for the provider
+	APIType string // The actual API type to use (openai, anthropic, etc.)
+	// BaseURL is the default base URL for the provider. It may contain
+	// ${VAR}/${env.VAR} references (e.g. ${CLOUDFLARE_ACCOUNT_ID}) that are
+	// resolved from the runtime environment when the provider is built.
+	BaseURL     string
 	TokenEnvVar string // Environment variable name for the API token
 }
 
@@ -117,6 +120,19 @@ var Aliases = map[string]Alias{
 		APIType:     "openai",
 		BaseURL:     "https://ai-gateway.vercel.sh/v1",
 		TokenEnvVar: "AI_GATEWAY_API_KEY",
+	},
+	// Cloudflare endpoints are account-scoped, so their base URLs are templated
+	// with ${CLOUDFLARE_ACCOUNT_ID} (and ${CLOUDFLARE_GATEWAY_ID} for the
+	// gateway), resolved from the environment at provider-build time.
+	"cloudflare-workers-ai": {
+		APIType:     "openai",
+		BaseURL:     "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/ai/v1",
+		TokenEnvVar: "CLOUDFLARE_API_TOKEN",
+	},
+	"cloudflare-ai-gateway": {
+		APIType:     "openai",
+		BaseURL:     "https://gateway.ai.cloudflare.com/v1/${CLOUDFLARE_ACCOUNT_ID}/${CLOUDFLARE_GATEWAY_ID}/compat",
+		TokenEnvVar: "CLOUDFLARE_API_TOKEN",
 	},
 	"github-copilot": {
 		APIType:     "openai",

--- a/pkg/model/provider/aliases_test.go
+++ b/pkg/model/provider/aliases_test.go
@@ -62,6 +62,38 @@ func TestCatalogAliases(t *testing.T) {
 	}
 }
 
+// TestCloudflareAliases asserts the two Cloudflare aliases resolve to their
+// account/gateway-scoped, env-templated base URLs. Unlike the static aliases
+// above, their BaseURL carries ${...} references that are expanded at
+// provider-build time (see cloudflare_alias_test.go for the resolution path).
+func TestCloudflareAliases(t *testing.T) {
+	t.Parallel()
+
+	expected := map[string]Alias{
+		"cloudflare-workers-ai": {
+			APIType:     "openai",
+			BaseURL:     "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/ai/v1",
+			TokenEnvVar: "CLOUDFLARE_API_TOKEN",
+		},
+		"cloudflare-ai-gateway": {
+			APIType:     "openai",
+			BaseURL:     "https://gateway.ai.cloudflare.com/v1/${CLOUDFLARE_ACCOUNT_ID}/${CLOUDFLARE_GATEWAY_ID}/compat",
+			TokenEnvVar: "CLOUDFLARE_API_TOKEN",
+		},
+	}
+
+	for name, want := range expected {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			alias, ok := LookupAlias(name)
+			require.True(t, ok)
+			assert.Equal(t, want, alias)
+			assert.True(t, IsKnownProvider(name))
+		})
+	}
+}
+
 func TestEachAlias(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/model/provider/cloudflare_alias_test.go
+++ b/pkg/model/provider/cloudflare_alias_test.go
@@ -1,0 +1,100 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/environment"
+)
+
+// TestCloudflareAlias_ResolvesTemplatedBaseURL proves the account/gateway-scoped
+// Cloudflare aliases resolve their ${...}-templated base URL against the
+// environment before the provider is built, and inherit CLOUDFLARE_API_TOKEN as
+// the token key. This is the mechanism that makes a non-static alias work
+// (issues #3354/#3355), reusing the ${env.X} expansion path from #2261.
+func TestCloudflareAlias_ResolvesTemplatedBaseURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		provider    string
+		env         map[string]string
+		wantBaseURL string
+	}{
+		{
+			name:        "workers-ai interpolates account id",
+			provider:    "cloudflare-workers-ai",
+			env:         map[string]string{"CLOUDFLARE_ACCOUNT_ID": "acc-123"},
+			wantBaseURL: "https://api.cloudflare.com/client/v4/accounts/acc-123/ai/v1",
+		},
+		{
+			name:     "ai-gateway interpolates account and gateway ids",
+			provider: "cloudflare-ai-gateway",
+			env: map[string]string{
+				"CLOUDFLARE_ACCOUNT_ID": "acc-123",
+				"CLOUDFLARE_GATEWAY_ID": "gw-9",
+			},
+			wantBaseURL: "https://gateway.ai.cloudflare.com/v1/acc-123/gw-9/compat",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got *latest.ModelConfig
+			r := NewRegistry(map[string]providerFactory{"openai": captureFactory(&got)})
+
+			cfg := &latest.ModelConfig{Provider: tt.provider, Model: "some-model"}
+			_, err := r.createDirectProvider(t.Context(), cfg, environment.NewMapEnvProvider(tt.env))
+			require.NoError(t, err)
+			require.NotNil(t, got)
+
+			assert.Equal(t, tt.wantBaseURL, got.BaseURL, "templated base URL must be resolved from the environment")
+			assert.Equal(t, "CLOUDFLARE_API_TOKEN", got.TokenKey, "token key must come from the alias")
+		})
+	}
+}
+
+// TestCloudflareAlias_MissingEnvVarErrors verifies an unset account/gateway id
+// surfaces as a clear provider-creation error instead of dialing a malformed
+// URL, so a misconfigured Cloudflare provider fails loudly and actionably.
+func TestCloudflareAlias_MissingEnvVarErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		provider string
+		env      map[string]string
+		wantVar  string
+	}{
+		{
+			name:     "workers-ai without account id",
+			provider: "cloudflare-workers-ai",
+			env:      map[string]string{},
+			wantVar:  "CLOUDFLARE_ACCOUNT_ID",
+		},
+		{
+			name:     "ai-gateway without gateway id",
+			provider: "cloudflare-ai-gateway",
+			env:      map[string]string{"CLOUDFLARE_ACCOUNT_ID": "acc-123"},
+			wantVar:  "CLOUDFLARE_GATEWAY_ID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := NewRegistry(map[string]providerFactory{"openai": tagFactory("openai")})
+			cfg := &latest.ModelConfig{Provider: tt.provider, Model: "some-model"}
+
+			_, err := r.createDirectProvider(t.Context(), cfg, environment.NewMapEnvProvider(tt.env))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantVar)
+		})
+	}
+}

--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -246,6 +246,11 @@ var openModelHostProviders = map[string]bool{
 	"together":    true,
 	"huggingface": true,
 	"vercel":      true,
+	// Cloudflare Workers AI serves open-weight models directly; the AI Gateway
+	// fronts them (and other providers) through one endpoint. Both plausibly
+	// reach models with strict single-system-message chat templates.
+	"cloudflare-workers-ai": true,
+	"cloudflare-ai-gateway": true,
 }
 
 // shouldMergeConsecutiveMessages reports whether the chat-completions request

--- a/pkg/model/provider/openai_alias_providers_test.go
+++ b/pkg/model/provider/openai_alias_providers_test.go
@@ -40,6 +40,12 @@ type openAIAliasProvider struct {
 	// system messages to be coalesced into a single leading one (issue #3344).
 	// First-party APIs with a fixed model lineup leave them untouched.
 	mergesSystemMessages bool
+
+	// extraLiveEnvVars lists additional env vars (beyond envVar) that must be set
+	// for the live API test to run. Aliases with a templated base URL (e.g.
+	// Cloudflare's account/gateway-scoped endpoints) need these to resolve a real
+	// URL; the hermetic end-to-end test overrides the base URL so it ignores them.
+	extraLiveEnvVars []string
 }
 
 var openAIAliasProviders = []openAIAliasProvider{
@@ -102,6 +108,31 @@ var openAIAliasProviders = []openAIAliasProvider{
 		model:                "openai/gpt-5",
 		greeting:             "Hello from Vercel",
 		mergesSystemMessages: true,
+	},
+	{
+		// Cloudflare Workers AI serves open-weight models from the edge, so its
+		// per-source system messages are coalesced like the other open-model
+		// hosts (issue #3344). Its base URL is account-scoped, so the live test
+		// additionally needs CLOUDFLARE_ACCOUNT_ID.
+		provider:             "cloudflare-workers-ai",
+		envVar:               "CLOUDFLARE_API_TOKEN",
+		testKey:              "cf-test-workers-ai-key",
+		model:                "@cf/meta/llama-3.1-8b-instruct",
+		greeting:             "Hello from Cloudflare Workers AI",
+		mergesSystemMessages: true,
+		extraLiveEnvVars:     []string{"CLOUDFLARE_ACCOUNT_ID"},
+	},
+	{
+		// Cloudflare AI Gateway is a multi-provider router that can front
+		// open-weight models, coalesced like Vercel/OpenRouter. Its base URL is
+		// account- and gateway-scoped, so the live test needs both ids.
+		provider:             "cloudflare-ai-gateway",
+		envVar:               "CLOUDFLARE_API_TOKEN",
+		testKey:              "cf-test-ai-gateway-key",
+		model:                "workers-ai/@cf/meta/llama-3.1-8b-instruct",
+		greeting:             "Hello from Cloudflare AI Gateway",
+		mergesSystemMessages: true,
+		extraLiveEnvVars:     []string{"CLOUDFLARE_ACCOUNT_ID", "CLOUDFLARE_GATEWAY_ID"},
 	},
 }
 
@@ -244,6 +275,13 @@ func TestOpenAIAliasProvider_LiveAPI(t *testing.T) {
 			apiKey := os.Getenv(p.envVar)
 			if apiKey == "" {
 				t.Skipf("%s not set; skipping live %s API test", p.envVar, p.provider)
+			}
+			// Templated-base-URL aliases (e.g. Cloudflare) also need their
+			// account/gateway ids to resolve a real endpoint.
+			for _, e := range p.extraLiveEnvVars {
+				if os.Getenv(e) == "" {
+					t.Skipf("%s not set; skipping live %s API test", e, p.provider)
+				}
 			}
 
 			// No BaseURL/TokenKey: both come from the built-in alias, so this

--- a/pkg/runtime/model_switcher.go
+++ b/pkg/runtime/model_switcher.go
@@ -708,6 +708,20 @@ func isEmbeddingModel(family, name string) bool {
 	return strings.Contains(familyLower, "embed") || strings.Contains(nameLower, "embed")
 }
 
+// aliasBaseURLResolvable reports whether every environment variable referenced
+// by a (possibly templated) alias base URL is set. Aliases like Cloudflare's
+// account/gateway-scoped endpoints need extra vars beyond their token; without
+// them the alias would resolve to a broken URL, so it must not be advertised as
+// an available provider (mirrors the preflight check in config.gather).
+func aliasBaseURLResolvable(ctx context.Context, baseURL string, env environment.Provider) bool {
+	for _, name := range environment.Refs(baseURL) {
+		if v, _ := env.Get(ctx, name); v == "" {
+			return false
+		}
+	}
+	return true
+}
+
 // getAvailableProviders returns a map of provider names that the user has credentials for.
 func (r *LocalRuntime) getAvailableProviders(ctx context.Context) map[string]bool {
 	available := make(map[string]bool)
@@ -731,9 +745,16 @@ func (r *LocalRuntime) getAvailableProviders(ctx context.Context) map[string]boo
 		if alias.TokenEnvVar == "" {
 			continue
 		}
-		if key, _ := env.Get(ctx, alias.TokenEnvVar); key != "" {
-			available[name] = true
+		if key, _ := env.Get(ctx, alias.TokenEnvVar); key == "" {
+			continue
 		}
+		// A templated base URL (e.g. Cloudflare's account/gateway-scoped
+		// endpoint) also needs the vars it references; without them the alias
+		// resolves to a broken URL, so don't advertise its catalog models.
+		if !aliasBaseURLResolvable(ctx, alias.BaseURL, env) {
+			continue
+		}
+		available[name] = true
 	}
 
 	// Check core providers with well-known env vars

--- a/pkg/runtime/model_switcher_test.go
+++ b/pkg/runtime/model_switcher_test.go
@@ -516,6 +516,73 @@ func TestGetAvailableProviders(t *testing.T) {
 	}
 }
 
+// TestGetAvailableProviders_TemplatedAlias verifies that an alias with a
+// templated base URL (Cloudflare's account/gateway-scoped endpoints) is only
+// advertised once every env var its URL references is set, not on the token
+// alone. Otherwise the picker would surface catalog models that cannot be
+// selected (they fail at build time on the missing account/gateway id).
+func TestGetAvailableProviders_TemplatedAlias(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		envVars     map[string]string
+		wantPresent []string
+		wantAbsent  []string
+	}{
+		{
+			name:       "token alone does not advertise Cloudflare",
+			envVars:    map[string]string{"CLOUDFLARE_API_TOKEN": "cf-test"},
+			wantAbsent: []string{"cloudflare-workers-ai", "cloudflare-ai-gateway"},
+		},
+		{
+			name: "token and account id advertise workers-ai but not the gateway",
+			envVars: map[string]string{
+				"CLOUDFLARE_API_TOKEN":  "cf-test",
+				"CLOUDFLARE_ACCOUNT_ID": "acc-123",
+			},
+			wantPresent: []string{"cloudflare-workers-ai"},
+			wantAbsent:  []string{"cloudflare-ai-gateway"},
+		},
+		{
+			name: "token, account and gateway ids advertise both",
+			envVars: map[string]string{
+				"CLOUDFLARE_API_TOKEN":  "cf-test",
+				"CLOUDFLARE_ACCOUNT_ID": "acc-123",
+				"CLOUDFLARE_GATEWAY_ID": "gw-9",
+			},
+			wantPresent: []string{"cloudflare-workers-ai", "cloudflare-ai-gateway"},
+		},
+		{
+			name:        "static-URL alias is still advertised on its token alone",
+			envVars:     map[string]string{"AI_GATEWAY_API_KEY": "vck-test"},
+			wantPresent: []string{"vercel"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := &LocalRuntime{
+				modelSwitcherCfg: &ModelSwitcherConfig{
+					ProviderRegistry: testProviderRegistry(),
+					EnvProvider:      environment.NewMapEnvProvider(tt.envVars),
+				},
+			}
+
+			got := r.getAvailableProviders(t.Context())
+
+			for _, want := range tt.wantPresent {
+				assert.True(t, got[want], "expected provider %s to be available", want)
+			}
+			for _, absent := range tt.wantAbsent {
+				assert.False(t, got[absent], "expected provider %s to NOT be available", absent)
+			}
+		})
+	}
+}
+
 // TestGetAvailableProviders_AnthropicWIF verifies that a workspace configured
 // with Workload Identity Federation surfaces the anthropic provider in the
 // model picker even without ANTHROPIC_API_KEY in the env.


### PR DESCRIPTION
## Summary

Adds two OpenAI-compatible provider aliases for Cloudflare, closing #3355 (Workers AI) and #3354 (AI Gateway). They share the `CLOUDFLARE_*` environment variables and are handled together.

Both endpoints are account/gateway scoped, so a fully static alias is not possible. The chosen approach is a **templated base URL**: the alias `BaseURL` carries `${CLOUDFLARE_ACCOUNT_ID}` (and `${CLOUDFLARE_GATEWAY_ID}` for the gateway), resolved from the environment at provider-build time via the existing `${env.X}` expansion path (issue #2261). No new resolution machinery is introduced.

| Provider | Alias | Base URL (templated) | Required env |
| --- | --- | --- | --- |
| Workers AI | `cloudflare-workers-ai` | `https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/ai/v1` | `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID` |
| AI Gateway | `cloudflare-ai-gateway` | `https://gateway.ai.cloudflare.com/v1/${CLOUDFLARE_ACCOUNT_ID}/${CLOUDFLARE_GATEWAY_ID}/compat` | `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_GATEWAY_ID` |

## Definition of Done

| Expectation (both issues) | Status | Where |
| --- | --- | --- |
| Usable as a provider (alias with templated base URL) | yes | `pkg/model/provider/aliases.go` |
| Unit / config test covering the setup | yes | see Testing below |
| Example YAML config | yes | `examples/cloudflare-workers-ai.yaml`, `examples/cloudflare-ai-gateway.yaml` |
| Docs updated (required env vars) | yes | `docs/providers/cloudflare-*`, overview, concepts, configuration, nav |
| JSON schema entry | yes | `agent-schema.json` |

## Design decisions

- **Templated base URL over custom-provider only.** Reuses the `${env.X}` expansion already applied to `model`/`base_url`, so a bare `provider: cloudflare-workers-ai` resolves the endpoint from the environment. A missing variable produces a clear error instead of dialing a malformed URL.
- **Preflight and picker made env-aware.** The config preflight (`pkg/config/gather.go`) now also requires the env vars referenced by a templated alias base URL. The runtime model picker (`pkg/runtime/model_switcher.go`) only advertises such an alias once all of them are set, not on the token alone, so it never surfaces catalog models that cannot be selected (the embedded models.dev snapshot does list Cloudflare models).
- **Not wired into auto-selection.** Cloudflare needs a conjunction of variables (token plus account, plus gateway), which the disjunctive "any key set" detection model in `pkg/config/auto.go` cannot express. Cloudflare stays an explicitly configured provider. Auto-selection is not part of either issue's Definition of Done.
- **System-message coalescing.** Both are added to `openModelHostProviders`: Workers AI serves open-weight models directly, and the gateway can front them.

## AI Gateway authentication (residual design point)

Verified against the Cloudflare docs. The alias sends `CLOUDFLARE_API_TOKEN` in the standard `Authorization: Bearer` header, so it works with a gateway that has authentication **disabled** (the default), routing to Workers AI models. A gateway with authentication **enabled** (unified billing) instead expects the `cf-aig-authorization` header; the alias does not send it, and `provider_opts.http_headers` values are not environment-expanded, so that case is not supported out of the box. This is documented on the provider page with a custom-provider fallback. Adding a first-class, env-expanded gateway-auth header can be a follow-up if unified billing is wanted; the current change does not preclude it.

## Testing

| Area | Test |
| --- | --- |
| Alias definitions | `TestCloudflareAliases` (`pkg/model/provider/aliases_test.go`) |
| Templated URL resolution and missing-env errors | `pkg/model/provider/cloudflare_alias_test.go` |
| End-to-end (auth, routing, system-message merge) | rows in `pkg/model/provider/openai_alias_providers_test.go` (hermetic, plus opt-in live via `CLOUDFLARE_*`) |
| Preflight env gathering | `pkg/config/gather_alias_env_test.go` |
| Picker availability requires all env vars | `TestGetAvailableProviders_TemplatedAlias` (`pkg/runtime/model_switcher_test.go`) |

`go build ./...`, `go vet`, and `golangci-lint` (0 issues) pass; tests for the affected packages (`pkg/config`, `pkg/model/provider`, `pkg/runtime`) pass.

## Not covered

No live request was executed against the Cloudflare API in this change. The opt-in `TestOpenAIAliasProvider_LiveAPI` runs a real request when `CLOUDFLARE_API_TOKEN` (and the account/gateway ids) are present, and stays skipped otherwise.
