### PR TITLE
feat: add tags field to agent config metadata

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -1684,6 +1684,13 @@
         "version": {
           "type": "string",
           "description": "Version of the agent configuration (used for OCI registry publishing)"
+        },
+        "tags": {
+          "type": "array",
+          "description": "Tags describing the agent configuration (e.g. for categorization and discovery)",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/docs/configuration/overview/index.md
+++ b/docs/configuration/overview/index.md
@@ -350,6 +350,7 @@ metadata:
   readme: | # Displayed in registries
     This agent helps with coding tasks.
   version: "1.0.0"
+  tags: [coding, review]
 ```
 
 | Field         | Description                                |
@@ -359,6 +360,7 @@ metadata:
 | `description` | Short description for the agent            |
 | `readme`      | Longer markdown description                |
 | `version`     | Semantic version string                    |
+| `tags`        | Tags for categorization and discovery      |
 
 See [Agent Distribution]({{ '/concepts/distribution/' | relative_url }}) for publishing agents to registries.
 

--- a/examples/echo-agent.yaml
+++ b/examples/echo-agent.yaml
@@ -4,6 +4,10 @@ metadata:
     It defines an agent that repeats back exactly what the user says, without any modifications or additional commentary.
 
     For example, run it with `echo "TEST" | docker agent run echo-agent.yaml -`
+  tags:
+    - example
+    - echo
+    - demo
 
 agents:
   root:

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -1147,11 +1147,12 @@ type RoutingRule struct {
 }
 
 type Metadata struct {
-	Author      string `json:"author,omitempty"`
-	License     string `json:"license,omitempty"`
-	Description string `json:"description,omitempty"`
-	Readme      string `json:"readme,omitempty"`
-	Version     string `json:"version,omitempty"`
+	Author      string   `json:"author,omitempty"`
+	License     string   `json:"license,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Readme      string   `json:"readme,omitempty"`
+	Version     string   `json:"version,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
 }
 
 // Commands represents a set of named prompts for quick-starting conversations.

--- a/pkg/oci/package.go
+++ b/pkg/oci/package.go
@@ -76,6 +76,9 @@ func PackageFileAsOCIToStore(ctx context.Context, agentSource config.Source, art
 	if revision := cfg.Metadata.Version; revision != "" {
 		annotations["org.opencontainers.image.revision"] = revision
 	}
+	if len(cfg.Metadata.Tags) > 0 {
+		annotations["io.docker.agent.tags"] = strings.Join(cfg.Metadata.Tags, ",")
+	}
 
 	layer := static.NewLayer(data, "application/yaml")
 	img, err := mutate.AppendLayers(empty.Image, layer)

--- a/pkg/oci/package_test.go
+++ b/pkg/oci/package_test.go
@@ -56,6 +56,37 @@ agents:
 	assert.Equal(t, "OCI artifact containing test.yaml", metadata.Annotations["org.opencontainers.image.description"])
 }
 
+func TestPackageFileAsOCIToStore_MetadataTagsAnnotation(t *testing.T) {
+	t.Parallel()
+	agentFilename := filepath.Join(t.TempDir(), "test.yaml")
+	testContent := `version: "11"
+metadata:
+  tags:
+    - coding
+    - review
+agents:
+  root:
+    model: auto
+    description: A helpful AI assistant
+`
+	require.NoError(t, os.WriteFile(agentFilename, []byte(testContent), 0o644))
+	store, err := content.NewStore(content.WithBaseDir(t.TempDir()))
+	require.NoError(t, err)
+
+	agentSource, err := config.Resolve(agentFilename, nil)
+	require.NoError(t, err)
+
+	tag := "test-tags:v1.0.0"
+	digest, err := PackageFileAsOCIToStore(t.Context(), agentSource, tag, store)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.DeleteArtifact(digest) })
+
+	metadata, err := store.GetArtifactMetadata(tag)
+	require.NoError(t, err)
+	require.NotNil(t, metadata.Annotations)
+	assert.Equal(t, "coding,review", metadata.Annotations["io.docker.agent.tags"])
+}
+
 func TestPackageFileAsOCIToStore_InlinesInstructionFile(t *testing.T) {
 	t.Parallel()
 	// A config that uses instruction_file must be pushed self-contained: the


### PR DESCRIPTION
Agent configs already carry distribution metadata such as author, license, and version, but there was no way to attach categorization tags. Tags make agents easier to organize and discover, both in a local collection of configs and once they are published to an OCI registry.

This adds an optional `tags` field to the `metadata` block of the latest config schema. Tags are a plain list of strings and, like the other metadata fields, are surfaced when packaging an agent as an OCI artifact: they are joined into an `io.docker.agent.tags` annotation so registry tooling can read them without unpacking the config layer. The JSON schema, an example, and the configuration docs are updated to match.

The change is confined to the latest config version, so older frozen config versions are untouched and continue to migrate through JSON cloning without any special handling.