### PR TITLE
feat: add mouse support to the agent picker (hover, double-click, wheel)

### DIFF
--- a/cmd/root/agent_picker.go
+++ b/cmd/root/agent_picker.go
@@ -196,6 +196,7 @@ func (m *agentPickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			switch {
 			case key.Matches(msg, agentPickerKeys.Quit), key.Matches(msg, agentPickerKeys.Details):
 				m.showDetails = false
+				m.resetClickTracking()
 				return m, nil
 			}
 			var cmd tea.Cmd
@@ -315,11 +316,20 @@ func (m *agentPickerModel) openDetails() {
 	if m.cursor < 0 || m.cursor >= len(m.choices) {
 		return
 	}
+	m.resetClickTracking()
 	m.resizeDetails()
 	m.details.SetContent(m.detailsContent(m.choices[m.cursor]))
 	m.details.GotoTop()
 	m.syncDetailsBar()
 	m.showDetails = true
+}
+
+// resetClickTracking clears double-click state so an unrelated later click
+// can't be paired with a stale earlier one (e.g. across opening/closing the
+// details dialog).
+func (m *agentPickerModel) resetClickTracking() {
+	m.lastClickIndex = -1
+	m.lastClickTime = time.Time{}
 }
 
 // detailsContent returns the text shown in the YAML dialog for a choice.
@@ -452,9 +462,7 @@ func (m *agentPickerModel) cardWidth() int {
 // are stacked with no gaps below the title/subtitle. The bool is false when
 // the point is outside every card.
 func (m *agentPickerModel) cardAt(x, y int) (int, bool) {
-	// Measure the real panel so the hit zones track the rendered layout even
-	// when the subtitle or help line is wider than the cards.
-	panelWidth, panelHeight := lipgloss.Size(m.render())
+	panelWidth, panelHeight := m.panelSize()
 	originX := max((m.width-panelWidth)/2, 0)
 	originY := max((m.height-panelHeight)/2, 0)
 
@@ -471,18 +479,33 @@ func (m *agentPickerModel) cardAt(x, y int) (int, bool) {
 	return i, true
 }
 
-func (m *agentPickerModel) render() string {
-	title := styles.HighlightWhiteStyle.Render("Choose an agent to run")
-	subtitle := styles.MutedStyle.Render("Pick the agent you want to start a session with, or double-click a card.")
+// panelSize returns the outer dimensions of the rendered picker panel without
+// rendering every card. cardAt relies on it to place hit zones, and it is
+// called on every mouse-motion event, so it must stay cheap: cards all share
+// cardWidth, so only the (variable-width) header lines need measuring.
+func (m *agentPickerModel) panelSize() (w, h int) {
+	title, subtitle, help := m.headerText()
+	contentWidth := max(
+		m.cardWidth(),
+		lipgloss.Width(title),
+		lipgloss.Width(subtitle),
+		lipgloss.Width(help),
+	)
+	// Horizontal chrome: border (1) + padding (3) on each side.
+	w = contentWidth + 2*(1+3)
+	// Content rows: title + subtitle + blank + cards + blank + help.
+	rows := 3 + len(m.choices)*agentPickerCardHeight + 2
+	// Vertical chrome: border (2) + padding (2).
+	h = rows + 4
+	return w, h
+}
 
-	cards := make([]string, 0, len(m.choices))
-	cardWidth := m.cardWidth()
-	for i, choice := range m.choices {
-		cards = append(cards, m.renderCard(choice, cardWidth, i == m.cursor))
-	}
-	list := lipgloss.JoinVertical(lipgloss.Left, cards...)
-
-	help := styles.MutedStyle.Render(
+// headerText returns the (styled) title, subtitle, and help lines shared by
+// render and panelSize so their layout math can't drift apart.
+func (m *agentPickerModel) headerText() (title, subtitle, help string) {
+	title = styles.HighlightWhiteStyle.Render("Choose an agent to run")
+	subtitle = styles.MutedStyle.Render("Pick the agent you want to start a session with, or double-click a card.")
+	help = styles.MutedStyle.Render(
 		strings.Join([]string{
 			"↑↓ move",
 			"double-click select",
@@ -491,6 +514,18 @@ func (m *agentPickerModel) render() string {
 			agentPickerKeys.Quit.Help().Key + " " + agentPickerKeys.Quit.Help().Desc,
 		}, "   "),
 	)
+	return title, subtitle, help
+}
+
+func (m *agentPickerModel) render() string {
+	title, subtitle, help := m.headerText()
+
+	cards := make([]string, 0, len(m.choices))
+	cardWidth := m.cardWidth()
+	for i, choice := range m.choices {
+		cards = append(cards, m.renderCard(choice, cardWidth, i == m.cursor))
+	}
+	list := lipgloss.JoinVertical(lipgloss.Left, cards...)
 
 	content := lipgloss.JoinVertical(
 		lipgloss.Left,
@@ -566,10 +601,11 @@ func (m *agentPickerModel) renderCard(choice agentChoice, cardWidth int, selecte
 	header := marker + nameStyle.Render(toolcommon.TruncateText(choice.ref, cardWidth-6))
 
 	// Descriptions and load errors can come from arbitrary (including
-	// remote) configs, so collapse them to a single line and truncate to
-	// the card width to keep the layout intact. The detail sits inside the
-	// card's 2-space indent and 1-column horizontal padding on each side.
-	detailWidth := cardWidth - 4
+	// remote) configs, so collapse them to a single line and truncate to fit
+	// the card. The detail sits behind a 2-space indent and inside the card's
+	// border (1) + padding (1) on each side, matching the header's budget of
+	// cardWidth-6.
+	detailWidth := cardWidth - 6
 	var detail string
 	switch {
 	case choice.err != nil:

--- a/cmd/root/agent_picker.go
+++ b/cmd/root/agent_picker.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strconv"
 	"strings"
+	"time"
 
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/viewport"
@@ -147,6 +148,12 @@ type agentPickerModel struct {
 	showDetails bool
 	details     viewport.Model
 	detailsBar  *scrollbar.Model
+
+	// lastClickIndex and lastClickTime back double-click detection on the
+	// agent cards: a second left-click on the same card within the threshold
+	// selects it.
+	lastClickIndex int
+	lastClickTime  time.Time
 }
 
 func newAgentPickerModel(choices []agentChoice) *agentPickerModel {
@@ -154,9 +161,10 @@ func newAgentPickerModel(choices []agentChoice) *agentPickerModel {
 	vp.FillHeight = true
 	vp.SoftWrap = true
 	return &agentPickerModel{
-		choices:    choices,
-		details:    vp,
-		detailsBar: scrollbar.New(),
+		choices:        choices,
+		details:        vp,
+		detailsBar:     scrollbar.New(),
+		lastClickIndex: -1,
 	}
 }
 
@@ -212,7 +220,48 @@ func (m *agentPickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(msg, agentPickerKeys.Choose):
 			return m, tea.Quit
 		}
+	case tea.MouseWheelMsg:
+		if m.showDetails {
+			var cmd tea.Cmd
+			m.details, cmd = m.details.Update(msg)
+			m.syncDetailsBar()
+			return m, cmd
+		}
+		return m, nil
+	case tea.MouseMotionMsg:
+		if !m.showDetails {
+			if i, ok := m.cardAt(msg.X, msg.Y); ok {
+				m.cursor = i
+			}
+		}
+		return m, nil
+	case tea.MouseClickMsg:
+		return m.handleMouseClick(msg)
 	}
+	return m, nil
+}
+
+// handleMouseClick moves the cursor to the clicked card and treats a second
+// left-click on the same card (within the double-click threshold) as a
+// selection. Clicks are ignored while the YAML dialog is open.
+func (m *agentPickerModel) handleMouseClick(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) {
+	if m.showDetails || msg.Button != tea.MouseLeft {
+		return m, nil
+	}
+	i, ok := m.cardAt(msg.X, msg.Y)
+	if !ok {
+		m.lastClickIndex = -1
+		return m, nil
+	}
+	m.cursor = i
+
+	now := time.Now()
+	if m.lastClickIndex == i && now.Sub(m.lastClickTime) < styles.DoubleClickThreshold {
+		m.lastClickIndex = -1
+		return m, tea.Quit
+	}
+	m.lastClickIndex = i
+	m.lastClickTime = now
 	return m, nil
 }
 
@@ -358,6 +407,7 @@ func (m *agentPickerModel) View() tea.View {
 
 	view := tea.NewView(centered)
 	view.AltScreen = true
+	view.MouseMode = tea.MouseModeAllMotion
 	view.BackgroundColor = styles.Background
 	view.WindowTitle = "Select an agent"
 	return view
@@ -367,6 +417,18 @@ func (m *agentPickerModel) View() tea.View {
 const (
 	agentPickerCardWidth    = 64
 	agentPickerMinCardWidth = 24
+
+	// agentPickerCardHeight is the rendered height of a card: 2 content rows
+	// (header + detail) wrapped by a top and bottom border.
+	agentPickerCardHeight = 4
+
+	// agentPickerCardsTop is the number of rows from the panel's top edge to
+	// the first card: border (1) + padding (1) + title (1) + subtitle (1) +
+	// blank separator (1).
+	agentPickerCardsTop = 5
+	// agentPickerCardsLeft is the number of columns from the panel's left
+	// edge to a card: border (1) + padding (3).
+	agentPickerCardsLeft = 4
 )
 
 // cardWidth returns the card width to use, shrinking to fit narrow terminals.
@@ -385,9 +447,33 @@ func (m *agentPickerModel) cardWidth() int {
 	return w
 }
 
+// cardAt maps terminal coordinates to the index of the agent card under them.
+// It mirrors the layout produced by render: the panel is centered, and cards
+// are stacked with no gaps below the title/subtitle. The bool is false when
+// the point is outside every card.
+func (m *agentPickerModel) cardAt(x, y int) (int, bool) {
+	// Measure the real panel so the hit zones track the rendered layout even
+	// when the subtitle or help line is wider than the cards.
+	panelWidth, panelHeight := lipgloss.Size(m.render())
+	originX := max((m.width-panelWidth)/2, 0)
+	originY := max((m.height-panelHeight)/2, 0)
+
+	cardWidth := m.cardWidth()
+	relX := x - originX - agentPickerCardsLeft
+	relY := y - originY - agentPickerCardsTop
+	if relX < 0 || relX >= cardWidth || relY < 0 {
+		return 0, false
+	}
+	i := relY / agentPickerCardHeight
+	if i >= len(m.choices) {
+		return 0, false
+	}
+	return i, true
+}
+
 func (m *agentPickerModel) render() string {
 	title := styles.HighlightWhiteStyle.Render("Choose an agent to run")
-	subtitle := styles.MutedStyle.Render("Pick the agent you want to start a session with.")
+	subtitle := styles.MutedStyle.Render("Pick the agent you want to start a session with, or double-click a card.")
 
 	cards := make([]string, 0, len(m.choices))
 	cardWidth := m.cardWidth()
@@ -399,6 +485,7 @@ func (m *agentPickerModel) render() string {
 	help := styles.MutedStyle.Render(
 		strings.Join([]string{
 			"↑↓ move",
+			"double-click select",
 			agentPickerKeys.Choose.Help().Key + " " + agentPickerKeys.Choose.Help().Desc,
 			agentPickerKeys.Details.Help().Key + " " + agentPickerKeys.Details.Help().Desc,
 			agentPickerKeys.Quit.Help().Key + " " + agentPickerKeys.Quit.Help().Desc,

--- a/cmd/root/agent_picker_test.go
+++ b/cmd/root/agent_picker_test.go
@@ -323,6 +323,117 @@ func TestAgentPickerClickOutsideDoesNothing(t *testing.T) {
 	assert.Equal(t, -1, m.lastClickIndex, "a miss resets double-click tracking")
 }
 
+func TestAgentPickerPanelSizeMatchesRender(t *testing.T) {
+	t.Parallel()
+
+	// panelSize must agree with the actual rendered panel; otherwise cardAt's
+	// hit zones drift away from what the user sees.
+	cases := [][]agentChoice{
+		{{ref: "default"}, {ref: "coder"}},
+		{{ref: "a", description: "short"}},
+		{
+			{ref: "default", description: strings.Repeat("long description ", 10)},
+			{ref: "agentcatalog/some-really-long-agent-reference-name"},
+			{ref: "broken", err: errors.New("boom")},
+		},
+	}
+	for _, choices := range cases {
+		m := newAgentPickerModel(choices)
+		m.width = 120
+		m.height = 40
+		gotW, gotH := m.panelSize()
+		wantW, wantH := lipgloss.Size(m.render())
+		assert.Equal(t, wantW, gotW, "panel width mismatch")
+		assert.Equal(t, wantH, gotH, "panel height mismatch")
+	}
+}
+
+func TestAgentPickerCardAtMatchesRenderedText(t *testing.T) {
+	t.Parallel()
+
+	// Independently relate hit-testing to the rendered output: the row where a
+	// card's ref text appears (as centered on screen) must hit that card, and
+	// the title/help rows must miss.
+	m := newAgentPickerModel([]agentChoice{
+		{ref: "alpha-agent"},
+		{ref: "beta-agent"},
+	})
+	m.width = 120
+	m.height = 40
+
+	screen := ansi.Strip(lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, m.render()))
+	lines := strings.Split(screen, "\n")
+
+	findRow := func(substr string) int {
+		for y, line := range lines {
+			if strings.Contains(line, substr) {
+				return y
+			}
+		}
+		t.Fatalf("%q not found on screen", substr)
+		return -1
+	}
+
+	for idx, ref := range []string{"alpha-agent", "beta-agent"} {
+		y := findRow(ref)
+		x := strings.Index(lines[y], ref)
+		i, ok := m.cardAt(x, y)
+		assert.True(t, ok, "ref row for %q should hit a card", ref)
+		assert.Equal(t, idx, i, "ref row for %q should hit card %d", ref, idx)
+	}
+
+	// The title and help rows must not resolve to any card.
+	titleY := findRow("Choose an agent to run")
+	_, ok := m.cardAt(m.width/2, titleY)
+	assert.False(t, ok, "title row must not hit a card")
+
+	helpY := findRow("double-click")
+	_, ok = m.cardAt(m.width/2, helpY)
+	assert.False(t, ok, "help row must not hit a card")
+}
+
+func TestAgentPickerDetailsResetsClickTracking(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPickerModel([]agentChoice{
+		{ref: "default", yaml: "a: b\n"},
+		{ref: "coder", yaml: "c: d\n"},
+	})
+	m.width = 120
+	m.height = 40
+
+	x, y := firstCardPoint(t, m, 0)
+	click := tea.MouseClickMsg{X: x, Y: y, Button: tea.MouseLeft}
+
+	// First click primes double-click tracking.
+	_, cmd := m.Update(click)
+	assert.Nil(t, cmd)
+
+	// Opening then closing the details dialog must clear that state, so the
+	// next click can't be paired with the pre-dialog one into a double-click.
+	m.openDetails()
+	assert.Equal(t, -1, m.lastClickIndex)
+
+	_, _ = m.Update(tea.KeyPressMsg{Code: '?', Text: "?"})
+	assert.False(t, m.showDetails)
+	assert.Equal(t, -1, m.lastClickIndex)
+
+	_, cmd = m.Update(click)
+	assert.Nil(t, cmd, "click after closing details must not complete a double-click")
+}
+
+func TestAgentPickerWheelIgnoredWithoutDetails(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPickerModel([]agentChoice{{ref: "default"}, {ref: "coder"}})
+	m.width = 120
+	m.height = 40
+
+	_, cmd := m.Update(tea.MouseWheelMsg{Button: tea.MouseWheelDown})
+	assert.Nil(t, cmd, "wheel does nothing while the card list is shown")
+	assert.Equal(t, 0, m.cursor)
+}
+
 // firstCardPoint scans the grid for a coordinate that maps to card index want.
 func firstCardPoint(t *testing.T, m *agentPickerModel, want int) (int, int) {
 	t.Helper()

--- a/cmd/root/agent_picker_test.go
+++ b/cmd/root/agent_picker_test.go
@@ -5,7 +5,9 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
+	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/assert"
@@ -217,4 +219,120 @@ func TestAgentPickerModelNavigation(t *testing.T) {
 
 	m.moveUp()
 	assert.Equal(t, 0, m.cursor)
+}
+
+func TestAgentPickerCardAt(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPickerModel([]agentChoice{
+		{ref: "default", description: "first"},
+		{ref: "coder", description: "second"},
+	})
+	m.width = 120
+	m.height = 40
+
+	// A point far outside the panel hits nothing.
+	_, ok := m.cardAt(0, 0)
+	assert.False(t, ok)
+
+	// Find the coordinates of each card by scanning the whole grid and
+	// checking the reported index is stable and in range.
+	seen := map[int]bool{}
+	for y := range m.height {
+		for x := range m.width {
+			if i, ok := m.cardAt(x, y); ok {
+				assert.GreaterOrEqual(t, i, 0)
+				assert.Less(t, i, len(m.choices))
+				seen[i] = true
+			}
+		}
+	}
+	// Both cards must be reachable.
+	assert.True(t, seen[0])
+	assert.True(t, seen[1])
+}
+
+func TestAgentPickerMouseHoverSelects(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPickerModel([]agentChoice{
+		{ref: "default"},
+		{ref: "coder"},
+	})
+	m.width = 120
+	m.height = 40
+
+	x, y := firstCardPoint(t, m, 1)
+	_, _ = m.Update(tea.MouseMotionMsg{X: x, Y: y})
+	assert.Equal(t, 1, m.cursor, "hover should move the cursor to the hovered card")
+}
+
+func TestAgentPickerDoubleClickSelects(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPickerModel([]agentChoice{
+		{ref: "default"},
+		{ref: "coder"},
+	})
+	m.width = 120
+	m.height = 40
+
+	x, y := firstCardPoint(t, m, 1)
+	click := tea.MouseClickMsg{X: x, Y: y, Button: tea.MouseLeft}
+
+	// First click selects (moves cursor) but does not quit.
+	_, cmd := m.Update(click)
+	assert.Equal(t, 1, m.cursor)
+	assert.Nil(t, cmd, "single click must not quit")
+
+	// Second click on the same card within the threshold quits (selects).
+	_, cmd = m.Update(click)
+	assert.NotNil(t, cmd, "double click must quit")
+	assert.IsType(t, tea.QuitMsg{}, cmd())
+}
+
+func TestAgentPickerDoubleClickResetsAfterTimeout(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPickerModel([]agentChoice{{ref: "default"}, {ref: "coder"}})
+	m.width = 120
+	m.height = 40
+
+	x, y := firstCardPoint(t, m, 0)
+	click := tea.MouseClickMsg{X: x, Y: y, Button: tea.MouseLeft}
+
+	_, cmd := m.Update(click)
+	assert.Nil(t, cmd)
+
+	// Simulate the threshold elapsing: a stale first click can't complete a
+	// double-click, so the next click is treated as a fresh first click.
+	m.lastClickTime = time.Now().Add(-2 * time.Second)
+	_, cmd = m.Update(click)
+	assert.Nil(t, cmd, "click after the threshold must not quit")
+}
+
+func TestAgentPickerClickOutsideDoesNothing(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPickerModel([]agentChoice{{ref: "default"}, {ref: "coder"}})
+	m.width = 120
+	m.height = 40
+
+	_, cmd := m.Update(tea.MouseClickMsg{X: 0, Y: 0, Button: tea.MouseLeft})
+	assert.Nil(t, cmd)
+	assert.Equal(t, -1, m.lastClickIndex, "a miss resets double-click tracking")
+}
+
+// firstCardPoint scans the grid for a coordinate that maps to card index want.
+func firstCardPoint(t *testing.T, m *agentPickerModel, want int) (int, int) {
+	t.Helper()
+	for y := range m.height {
+		for x := range m.width {
+			if i, ok := m.cardAt(x, y); ok && i == want {
+				return x, y
+			}
+		}
+	}
+	t.Fatalf("no coordinate maps to card %d", want)
+	return 0, 0
 }


### PR DESCRIPTION
The agent picker previously required keyboard navigation to select an agent. This adds full mouse support so users can point and click their way through the list without touching the keyboard.

Hovering over a card highlights it; a single click moves the selection to that card; a double-click selects the card and immediately starts the session — matching the muscle memory most users have from any file-picker dialog. When the YAML details panel is open, mouse-wheel events are forwarded to its viewport so the content can be scrolled without switching to keyboard mode. The subtitle bar now advertises the double-click gesture so the feature is discoverable.

The implementation avoids re-rendering the entire panel on every mouse-motion event by introducing a `panelSize` helper that computes card dimensions cheaply and sharing a `headerText` helper between it and the full `render` path so the two can't drift. A layout bug was also fixed in the details panel: the description width was using `cardWidth-4` instead of `cardWidth-6`, causing long descriptions to wrap and break the fixed card height that hit-testing relies on. Double-click tracking is cleared whenever the details dialog is opened or closed to prevent phantom clicks from carrying across state transitions. The new behaviour is covered by table-driven tests that verify `panelSize` stays consistent with `render`, that `cardAt` resolves the correct card from rendered text positions, that details-reset clears click state, and that wheel events are ignored when no details dialog is open.