### PR TITLE
fix(runtime): suppress spurious empty-response warning for benign post-tool stops

### DIFF
--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -572,6 +572,37 @@ type loopState struct {
 	prevTurnMadeToolCalls bool
 }
 
+// emptyTurnWarning classifies an empty assistant turn (no content, no tool
+// calls) and returns the user-facing warning message, or "" when the turn is
+// benign and should stay silent. Known cases:
+//   - benign: a natural stop right after a tool-call turn — the model already
+//     did its work and had nothing left to say (common at the tail of a
+//     fork-skill sequence, e.g. commit / open-pr). The real answer is the
+//     previous assistant message, so a UI warning would be noise.
+//   - reasoning-only: thinking-mode models (e.g. Qwen3 via
+//     openai_chatcompletions) that stream only reasoning tokens and then stop
+//     or hit the output token limit, leaving visible content empty (see #3145).
+//   - otherwise: an empty stream from a rate-limited or token-capped provider.
+//
+// Refusals are handled separately by the caller and never reach here.
+func emptyTurnWarning(res streamResult, prevTurnMadeToolCalls bool, modelID string, reason chat.FinishReason) string {
+	switch {
+	case res.Stopped && prevTurnMadeToolCalls:
+		return ""
+	case strings.TrimSpace(res.ReasoningContent) != "":
+		return fmt.Sprintf(
+			"Model %s produced only reasoning and no reply (stop reason: %s). "+
+				"Thinking-mode models can emit reasoning tokens without a final answer; "+
+				"the reasoning is not used as the response.",
+			modelID, reason)
+	default:
+		return fmt.Sprintf(
+			"Model %s returned an empty response (stop reason: %s). "+
+				"This usually means the provider rate-limited the request or the output token limit was reached.",
+			modelID, reason)
+	}
+}
+
 // runTurn performs one iteration of the run-stream loop, from
 // turn_start onwards. Wrapping the body in its own function exists for
 // one reason: a deferred call can fire turn_end on every exit path — a
@@ -740,42 +771,20 @@ func (r *LocalRuntime) runTurn(
 	} else if strings.TrimSpace(res.Content) == "" && len(res.Calls) == 0 {
 		// Surface otherwise-silent empty turns. recordAssistantMessage skips a
 		// turn with no content and no tool calls, which previously left the user
-		// staring at silence with no explanation. Two known causes:
-		//   - thinking-mode models (e.g. Qwen3 via openai_chatcompletions) that
-		//     stream only reasoning tokens and then stop or hit the output token
-		//     limit, so the visible content stays empty (see #3145); and
-		//   - an empty stream from a rate-limited or token-capped provider.
-		// Refusals are reported above and are excluded here by the else branch.
+		// staring at silence with no explanation. See emptyTurnWarning for the
+		// classification of the known causes.
 		reason := res.FinishReason
 		if reason == "" {
 			reason = chat.FinishReasonNull
 		}
-		switch {
-		case res.Stopped && ls.prevTurnMadeToolCalls:
-			// Benign trailing empty turn: the model naturally stopped right
-			// after doing tool work and had nothing left to add. Common at
-			// the tail of a fork-skill sequence (e.g. the last action is a
-			// commit / open-pr tool call). The real answer is the previous,
-			// non-empty assistant message, so a UI warning here is noise.
-			// Log at debug for traceability without alarming the user.
+		warning := emptyTurnWarning(res, ls.prevTurnMadeToolCalls, modelID.String(), reason)
+		if warning == "" {
+			// Benign trailing stop after tool work: log at debug for
+			// traceability without alarming the user or noising up WARN logs.
 			slog.DebugContext(ctx, "Empty trailing turn after tool calls (benign natural stop)",
 				"agent", a.Name(), "model", modelID.String(),
 				"finish_reason", string(reason), "session_id", sess.ID)
-		case strings.TrimSpace(res.ReasoningContent) != "":
-			warning := fmt.Sprintf(
-				"Model %s produced only reasoning and no reply (stop reason: %s). "+
-					"Thinking-mode models can emit reasoning tokens without a final answer; "+
-					"the reasoning is not used as the response.",
-				modelID.String(), reason)
-			slog.WarnContext(ctx, "Empty assistant turn",
-				"agent", a.Name(), "model", modelID.String(),
-				"finish_reason", string(reason), "reasoning_length", len(res.ReasoningContent), "session_id", sess.ID)
-			events.Emit(Warning(warning, a.Name()))
-		default:
-			warning := fmt.Sprintf(
-				"Model %s returned an empty response (stop reason: %s). "+
-					"This usually means the provider rate-limited the request or the output token limit was reached.",
-				modelID.String(), reason)
+		} else {
 			slog.WarnContext(ctx, "Empty assistant turn",
 				"agent", a.Name(), "model", modelID.String(),
 				"finish_reason", string(reason), "reasoning_length", len(res.ReasoningContent), "session_id", sess.ID)

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -412,9 +412,13 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 		a = r.resolveSessionAgent(sess)
 
 		// Clear per-tool model override on agent switch so it doesn't
-		// leak from one agent's toolset into another agent's turn.
+		// leak from one agent's toolset into another agent's turn. Also
+		// reset prevTurnMadeToolCalls so a new agent's empty first turn is
+		// judged on its own merits, not silenced by the previous agent's
+		// tool activity.
 		if a.Name() != ls.prevAgentName {
 			ls.toolModelOverride = ""
+			ls.prevTurnMadeToolCalls = false
 			ls.prevAgentName = a.Name()
 		}
 
@@ -565,20 +569,23 @@ type loopState struct {
 	exitReason          string
 	// prevTurnMadeToolCalls reports whether the immediately preceding
 	// turn emitted tool calls. Used to classify an empty trailing turn:
-	// a natural stop right after tool work is benign (the model already
+	// a clean stop right after tool work is benign (the model already
 	// did its job and has nothing left to say — common at the tail of a
 	// fork-skill sequence), not the rate-limit / token-cap case the
-	// empty-response warning would otherwise imply.
+	// empty-response warning would otherwise imply. Reset on agent switch
+	// so it never carries across agents.
 	prevTurnMadeToolCalls bool
 }
 
 // emptyTurnWarning classifies an empty assistant turn (no content, no tool
 // calls) and returns the user-facing warning message, or "" when the turn is
 // benign and should stay silent. Known cases:
-//   - benign: a natural stop right after a tool-call turn — the model already
-//     did its work and had nothing left to say (common at the tail of a
-//     fork-skill sequence, e.g. commit / open-pr). The real answer is the
-//     previous assistant message, so a UI warning would be noise.
+//   - benign: a clean stop (finish_reason "stop") right after a tool-call turn
+//     — the model already did its work and had nothing left to say (common at
+//     the tail of a fork-skill sequence, e.g. commit / open-pr). The real
+//     answer is the previous assistant message, so a UI warning would be noise.
+//     Only "stop" qualifies: a "length" finish after tool calls means the reply
+//     was truncated by the output token limit and must still warn.
 //   - reasoning-only: thinking-mode models (e.g. Qwen3 via
 //     openai_chatcompletions) that stream only reasoning tokens and then stop
 //     or hit the output token limit, leaving visible content empty (see #3145).
@@ -587,7 +594,7 @@ type loopState struct {
 // Refusals are handled separately by the caller and never reach here.
 func emptyTurnWarning(res streamResult, prevTurnMadeToolCalls bool, modelID string, reason chat.FinishReason) string {
 	switch {
-	case res.Stopped && prevTurnMadeToolCalls:
+	case reason == chat.FinishReasonStop && prevTurnMadeToolCalls:
 		return ""
 	case strings.TrimSpace(res.ReasoningContent) != "":
 		return fmt.Sprintf(

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -563,6 +563,13 @@ type loopState struct {
 	sessionStartMsgs    []chat.Message
 	userPromptMsgs      []chat.Message
 	exitReason          string
+	// prevTurnMadeToolCalls reports whether the immediately preceding
+	// turn emitted tool calls. Used to classify an empty trailing turn:
+	// a natural stop right after tool work is benign (the model already
+	// did its job and has nothing left to say — common at the tail of a
+	// fork-skill sequence), not the rate-limit / token-cap case the
+	// empty-response warning would otherwise imply.
+	prevTurnMadeToolCalls bool
 }
 
 // runTurn performs one iteration of the run-stream loop, from
@@ -743,23 +750,37 @@ func (r *LocalRuntime) runTurn(
 		if reason == "" {
 			reason = chat.FinishReasonNull
 		}
-		var warning string
-		if strings.TrimSpace(res.ReasoningContent) != "" {
-			warning = fmt.Sprintf(
+		switch {
+		case res.Stopped && ls.prevTurnMadeToolCalls:
+			// Benign trailing empty turn: the model naturally stopped right
+			// after doing tool work and had nothing left to add. Common at
+			// the tail of a fork-skill sequence (e.g. the last action is a
+			// commit / open-pr tool call). The real answer is the previous,
+			// non-empty assistant message, so a UI warning here is noise.
+			// Log at debug for traceability without alarming the user.
+			slog.DebugContext(ctx, "Empty trailing turn after tool calls (benign natural stop)",
+				"agent", a.Name(), "model", modelID.String(),
+				"finish_reason", string(reason), "session_id", sess.ID)
+		case strings.TrimSpace(res.ReasoningContent) != "":
+			warning := fmt.Sprintf(
 				"Model %s produced only reasoning and no reply (stop reason: %s). "+
 					"Thinking-mode models can emit reasoning tokens without a final answer; "+
 					"the reasoning is not used as the response.",
 				modelID.String(), reason)
-		} else {
-			warning = fmt.Sprintf(
+			slog.WarnContext(ctx, "Empty assistant turn",
+				"agent", a.Name(), "model", modelID.String(),
+				"finish_reason", string(reason), "reasoning_length", len(res.ReasoningContent), "session_id", sess.ID)
+			events.Emit(Warning(warning, a.Name()))
+		default:
+			warning := fmt.Sprintf(
 				"Model %s returned an empty response (stop reason: %s). "+
 					"This usually means the provider rate-limited the request or the output token limit was reached.",
 				modelID.String(), reason)
+			slog.WarnContext(ctx, "Empty assistant turn",
+				"agent", a.Name(), "model", modelID.String(),
+				"finish_reason", string(reason), "reasoning_length", len(res.ReasoningContent), "session_id", sess.ID)
+			events.Emit(Warning(warning, a.Name()))
 		}
-		slog.WarnContext(ctx, "Empty assistant turn",
-			"agent", a.Name(), "model", modelID.String(),
-			"finish_reason", string(reason), "reasoning_length", len(res.ReasoningContent), "session_id", sess.ID)
-		events.Emit(Warning(warning, a.Name()))
 	}
 
 	msgUsage := r.recordAssistantMessage(sess, a, res, agentTools, modelID.String(), msgCost, events)
@@ -830,6 +851,12 @@ func (r *LocalRuntime) runTurn(
 		endReason = turnEndReasonHookBlocked
 		return turnExit
 	}
+
+	// Record whether this turn made tool calls so the next iteration can
+	// classify a trailing empty turn as a benign post-tool stop rather than
+	// a rate-limit / token-cap event. Set after processToolCalls so it
+	// reflects the turn just completed.
+	ls.prevTurnMadeToolCalls = len(res.Calls) > 0
 
 	// Record per-toolset model override for the next LLM turn.
 	ls.toolModelOverride = toolexec.ResolveModelOverride(res.Calls, agentTools)

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -4204,6 +4204,15 @@ func TestEmptyTurnWarning(t *testing.T) {
 		assert.Contains(t, got, "empty response")
 	})
 
+	t.Run("length finish after tool calls still warns (truncated, not benign)", func(t *testing.T) {
+		// A "length" stop means the reply was cut off by the output token
+		// limit; even after tool calls this is a real truncation the user
+		// should see, so it must NOT be silenced by the benign case.
+		res := streamResult{Stopped: true}
+		got := emptyTurnWarning(res, true, "test/model", chat.FinishReasonLength)
+		assert.Contains(t, got, "empty response")
+	})
+
 	t.Run("non-stop empty turn after tool calls still warns", func(t *testing.T) {
 		res := streamResult{Stopped: false}
 		got := emptyTurnWarning(res, true, "test/model", chat.FinishReasonNull)

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -4172,3 +4172,41 @@ func TestEmptyTrailingTurnAfterToolCallsIsSilent(t *testing.T) {
 		}
 	}
 }
+
+// TestEmptyTurnWarning exercises the pure classification helper directly,
+// covering each branch without spinning up a full run loop.
+func TestEmptyTurnWarning(t *testing.T) {
+	t.Parallel()
+
+	t.Run("benign stop after tool calls is silent", func(t *testing.T) {
+		res := streamResult{Stopped: true}
+		got := emptyTurnWarning(res, true, "test/model", chat.FinishReasonStop)
+		assert.Empty(t, got)
+	})
+
+	t.Run("reasoning-only turn warns about reasoning", func(t *testing.T) {
+		res := streamResult{Stopped: true, ReasoningContent: "thinking..."}
+		got := emptyTurnWarning(res, false, "test/model", chat.FinishReasonStop)
+		assert.Contains(t, got, "only reasoning")
+	})
+
+	t.Run("benign check takes precedence over reasoning-only", func(t *testing.T) {
+		// A reasoning-only turn that naturally stops right after tool work is
+		// still benign: the tool calls were the turn's real output.
+		res := streamResult{Stopped: true, ReasoningContent: "thinking..."}
+		got := emptyTurnWarning(res, true, "test/model", chat.FinishReasonStop)
+		assert.Empty(t, got)
+	})
+
+	t.Run("empty turn without prior tool calls warns", func(t *testing.T) {
+		res := streamResult{Stopped: true}
+		got := emptyTurnWarning(res, false, "test/model", chat.FinishReasonStop)
+		assert.Contains(t, got, "empty response")
+	})
+
+	t.Run("non-stop empty turn after tool calls still warns", func(t *testing.T) {
+		res := streamResult{Stopped: false}
+		got := emptyTurnWarning(res, true, "test/model", chat.FinishReasonNull)
+		assert.Contains(t, got, "empty response")
+	})
+}

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -4113,3 +4113,62 @@ func TestEmptyTurnEmitsWarning(t *testing.T) {
 	require.NotNil(t, warn, "expected a Warning event for an empty turn")
 	assert.Contains(t, warn.Message, "empty response")
 }
+
+// TestEmptyTrailingTurnAfterToolCallsIsSilent verifies that a natural empty
+// stop immediately following a tool-call turn does NOT emit the empty-response
+// warning. This is the common fork-skill tail (the last action is a tool call
+// such as commit/open-pr, then the model stops with nothing left to say); the
+// scary rate-limit / token-cap warning there is pure noise. Turns that stop
+// empty WITHOUT preceding tool work still warn (covered by TestEmptyTurnEmitsWarning).
+func TestEmptyTrailingTurnAfterToolCallsIsSilent(t *testing.T) {
+	t.Parallel()
+
+	doneTool := tools.Tool{
+		Name:       "do_thing",
+		Parameters: map[string]any{},
+		Handler: func(_ context.Context, _ tools.ToolCall) (*tools.ToolCallResult, error) {
+			return tools.ResultSuccess("done"), nil
+		},
+	}
+
+	// Turn 1: model calls the tool and keeps going.
+	// Turn 2: model stops with no content and no tool calls (benign tail).
+	turn1 := newStreamBuilder().
+		AddToolCallName("c1", "do_thing").
+		AddToolCallArguments("c1", `{}`).
+		AddToolCallStopWithUsage(5, 5).
+		Build()
+	turn2 := newStreamBuilder().
+		AddStopWithUsage(3, 0).
+		Build()
+
+	prov := &recordingProvider{
+		id:      "test/mock-model",
+		streams: []*mockStream{turn1, turn2},
+	}
+
+	ts := newStubToolSet(nil, []tools.Tool{doneTool}, nil)
+	root := agent.New("root", "test", agent.WithModel(prov), agent.WithToolSets(ts))
+	tm := team.New(team.WithAgents(root))
+
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+	rt.registerDefaultTools()
+
+	sess := session.New(session.WithUserMessage("Do the thing"))
+	sess.Title = "empty trailing turn test"
+	sess.ToolsApproved = true
+
+	evCh := rt.RunStream(t.Context(), sess)
+	var events []Event
+	for ev := range evCh {
+		events = append(events, ev)
+	}
+
+	for _, ev := range events {
+		if w, ok := ev.(*WarningEvent); ok {
+			assert.NotContains(t, w.Message, "empty response",
+				"a benign empty stop right after tool calls must not emit the empty-response warning")
+		}
+	}
+}


### PR DESCRIPTION
## What

The runtime run loop (`runTurn`) emits a UI warning whenever a model turn comes back empty (no text content and no tool calls):

> Model X returned an empty response (stop reason: stop). This usually means the provider rate-limited the request or the output token limit was reached.

This fires spuriously at the tail of **forked-skill sub-sessions**, where the model's last real action is a tool call (e.g. `commit` / `open-pr`) and it then naturally stops with an empty final turn. That's benign — the model already did its work and had nothing left to say — but the warning wrongly implied a rate-limit / token-cap event.

## How

- Track whether the immediately preceding turn made tool calls (`prevTurnMadeToolCalls` on `loopState`), reset on agent switch so it never leaks across agents.
- When an empty turn follows a **clean stop** (`finish_reason == "stop"`) **and** the previous turn made tool calls, treat it as benign: log at debug, no UI warning.
- All other empty turns still warn as before:
  - reasoning-only thinking-mode turns (Qwen3 et al., see #3145),
  - genuinely empty turns with no prior tool work,
  - **`length` truncations** — an output-token-limit cutoff after a tool call is a real failure and must still be surfaced.
- Extracted the message classification into a pure, unit-testable helper `emptyTurnWarning(...)` that returns the warning string or `""` when benign.

## Why `stop`-only (not just "stopped")

`res.Stopped` is `true` for both `finish_reason: stop` and `finish_reason: length`. Keying the benign case on `res.Stopped` would silently swallow genuine token-limit truncations that happen to follow a tool-call turn. The Anthropic adapter maps `end_turn → stop` and `max_tokens → length`, so keying strictly on `stop` preserves the original reported case (`stop reason: stop`) while keeping truncation warnings intact.

## Tests

- `TestEmptyTrailingTurnAfterToolCallsIsSilent` — full run-loop: benign empty stop after a tool call emits no warning.
- `TestEmptyTurnWarning` — pure helper: benign stop, reasoning-only, benign-precedence, no-prior-tools, `length`-after-tool-calls (still warns), non-stop.
- Existing `TestEmptyTurnEmitsWarning` / `TestReasoningOnlyTurnEmitsWarning` still pass.

## Validation

- `go test ./pkg/runtime/... ./pkg/model/provider/anthropic/...` — green
- `task lint` — 0 issues

## Commits

1. `feat(runtime): suppress empty-response warning for benign post-tool stops`
2. `refactor(runtime): extract emptyTurnWarning classification helper`
3. `fix(runtime): tighten empty-turn benign check after review`
