### PR TITLE
fix: clamp max_tokens to the context window for OpenAI-compatible providers

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -244,7 +244,7 @@
         },
         "max_tokens": {
           "type": "integer",
-          "description": "Default maximum number of tokens for models using this provider."
+          "description": "Default maximum output tokens per response for models using this provider. This is the completion budget, NOT the context window: OpenAI-compatible servers require prompt_tokens + max_tokens to fit the context window, so a value close to the window leaves no room for the prompt. Set provider_opts.context_size to declare the window."
         },
         "top_p": {
           "type": "number",
@@ -1443,7 +1443,7 @@
         },
         "max_tokens": {
           "type": "integer",
-          "description": "Maximum number of tokens",
+          "description": "Maximum output tokens per response (the completion budget), NOT the context window. OpenAI-compatible servers require prompt_tokens + max_tokens to fit the context window, so a value close to the window leaves no room for the prompt. Set provider_opts.context_size to declare the window.",
           "minimum": 1
         },
         "top_p": {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -66,6 +66,7 @@ func Load(ctx context.Context, source Source) (*latest.Config, error) {
 	}
 
 	warnExpansionMismatches(ctx, slog.Default(), &config)
+	warnMaxTokensVsContextWindow(ctx, slog.Default(), &config)
 
 	return &config, nil
 }

--- a/pkg/config/latest/context_size_test.go
+++ b/pkg/config/latest/context_size_test.go
@@ -1,0 +1,52 @@
+package latest
+
+import (
+	"testing"
+
+	"github.com/goccy/go-yaml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContextSizeFromProviderOpts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		opts map[string]any
+		want int64
+	}{
+		{"absent", map[string]any{}, 0},
+		{"nil map", nil, 0},
+		{"int", map[string]any{"context_size": 32768}, 32768},
+		{"int64", map[string]any{"context_size": int64(65536)}, 65536},
+		{"int32", map[string]any{"context_size": int32(4096)}, 4096},
+		// goccy/go-yaml decodes a positive YAML integer as uint64 (see #3387).
+		{"uint64", map[string]any{"context_size": uint64(262144)}, 262144},
+		{"uint", map[string]any{"context_size": uint(8192)}, 8192},
+		{"float64 (json)", map[string]any{"context_size": float64(8192)}, 8192},
+		{"string decimal", map[string]any{"context_size": " 16384 "}, 16384},
+		{"zero", map[string]any{"context_size": 0}, 0},
+		{"negative", map[string]any{"context_size": int64(-1)}, 0},
+		{"unparseable string", map[string]any{"context_size": "big"}, 0},
+		{"wrong type", map[string]any{"context_size": true}, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, ContextSizeFromProviderOpts(tt.opts))
+		})
+	}
+}
+
+// TestContextSizeFromProviderOpts_YAMLRoundTrip guards the real decode path:
+// a context_size declared in YAML must resolve to its value. goccy/go-yaml
+// produces uint64 for positive integers, which a naive int/int64 switch drops
+// to 0 (the latent bug behind #3387's failed context_size workaround).
+func TestContextSizeFromProviderOpts_YAMLRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	var opts map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte("context_size: 262144\n"), &opts))
+	assert.Equal(t, int64(262144), ContextSizeFromProviderOpts(opts))
+}

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"math"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1043,6 +1045,58 @@ func (m *ModelConfig) DisplayOrModel() string {
 func (m *ModelConfig) UnloadAPI() string {
 	v, _ := m.ProviderOpts["unload_api"].(string)
 	return v
+}
+
+// ContextSizeFromProviderOpts reads a positive `context_size` from a
+// provider_opts map, returning 0 when the key is absent, non-positive, or not
+// parseable as an integer. Accepted shapes mirror what the YAML/JSON decoders
+// produce: goccy/go-yaml decodes a positive integer as uint64 (and a negative
+// one as int64), JSON decodes numbers as float64, and env expansion can leave a
+// decimal string. Shared by the runtime (context-limit resolution) and the
+// provider clients (max_tokens clamping) so the two never diverge on how
+// context_size is interpreted.
+func ContextSizeFromProviderOpts(opts map[string]any) int64 {
+	v, ok := opts["context_size"]
+	if !ok {
+		return 0
+	}
+	var n int64
+	switch t := v.(type) {
+	case int64:
+		n = t
+	case int:
+		n = int64(t)
+	case int32:
+		n = int64(t)
+	case uint64:
+		if t > math.MaxInt64 {
+			return 0
+		}
+		n = int64(t)
+	case uint:
+		if uint64(t) > math.MaxInt64 {
+			return 0
+		}
+		n = int64(t)
+	case uint32:
+		n = int64(t)
+	case float64:
+		n = int64(t)
+	case float32:
+		n = int64(t)
+	case string:
+		parsed, err := strconv.ParseInt(strings.TrimSpace(t), 10, 64)
+		if err != nil {
+			return 0
+		}
+		n = parsed
+	default:
+		return 0
+	}
+	if n <= 0 {
+		return 0
+	}
+	return n
 }
 
 // ExpandEnv rewrites the model config's value-bearing string fields in place by

--- a/pkg/config/max_tokens_warning.go
+++ b/pkg/config/max_tokens_warning.go
@@ -1,0 +1,65 @@
+package config
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/docker/docker-agent/pkg/config/latest"
+)
+
+// suspiciousMaxTokens is the threshold above which a max_tokens set without a
+// discoverable context_size is flagged. Legitimate output caps are small (a
+// few thousand tokens); a value this large almost always means max_tokens (the
+// per-response OUTPUT cap) was confused with the model's context window, which
+// leaves no room for the prompt and makes every request fail (issue #3387).
+const suspiciousMaxTokens = 100_000
+
+// warnMaxTokensVsContextWindow flags provider/model configs whose max_tokens is
+// set so high that it cannot coexist with a prompt. max_tokens is the maximum
+// OUTPUT tokens per response, not the context window; OpenAI-compatible servers
+// (e.g. vLLM) reject a request when prompt_tokens + max_tokens exceeds the
+// window, so max_tokens >= the window rejects even a one-token "hello".
+//
+// The check is advisory and best-effort: it inspects each provider and model
+// entry independently using that entry's own max_tokens and context_size and
+// does not resolve provider->model inheritance. The runtime clamp in the
+// provider clients is the actual guard; this warning surfaces the likely
+// misconfiguration at load time, including for models whose window is not in
+// the models.dev catalogue (where the clamp cannot engage on its own).
+//
+// The logger is injected so tests can capture warnings without racing on the
+// global default logger.
+func warnMaxTokensVsContextWindow(ctx context.Context, logger *slog.Logger, cfg *latest.Config) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	for name, p := range cfg.Providers {
+		warnMaxTokensEntry(ctx, logger, "provider "+name, p.MaxTokens, latest.ContextSizeFromProviderOpts(p.ProviderOpts))
+	}
+	for name, m := range cfg.Models {
+		warnMaxTokensEntry(ctx, logger, "model "+name, m.MaxTokens, latest.ContextSizeFromProviderOpts(m.ProviderOpts))
+	}
+}
+
+func warnMaxTokensEntry(ctx context.Context, logger *slog.Logger, loc string, maxTokens *int64, contextSize int64) {
+	if maxTokens == nil || *maxTokens <= 0 {
+		return
+	}
+	switch {
+	case contextSize > 0 && *maxTokens >= contextSize:
+		logger.WarnContext(ctx,
+			"max_tokens is the maximum output tokens per response, not the context window; it is >= context_size and will be clamped to leave room for the prompt. Set a smaller max_tokens to silence this",
+			"location", loc,
+			"max_tokens", *maxTokens,
+			"context_size", contextSize,
+			"see", "https://github.com/docker/docker-agent/issues/3387",
+		)
+	case contextSize == 0 && *maxTokens >= suspiciousMaxTokens:
+		logger.WarnContext(ctx,
+			"max_tokens is the maximum output tokens per response, not the context window; this value is unusually large. If requests fail with 'maximum context length', lower max_tokens or set provider_opts.context_size to the model's real window",
+			"location", loc,
+			"max_tokens", *maxTokens,
+			"see", "https://github.com/docker/docker-agent/issues/3387",
+		)
+	}
+}

--- a/pkg/config/max_tokens_warning_test.go
+++ b/pkg/config/max_tokens_warning_test.go
@@ -1,0 +1,100 @@
+package config
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/docker/docker-agent/pkg/config/latest"
+)
+
+func TestWarnMaxTokens_ExceedsContextSize(t *testing.T) {
+	t.Parallel()
+
+	maxTokens := int64(262144)
+	cfg := &latest.Config{
+		Providers: map[string]latest.ProviderConfig{
+			"my_llm": {
+				MaxTokens:    &maxTokens,
+				ProviderOpts: map[string]any{"context_size": 262144},
+			},
+		},
+	}
+
+	out := captureWarnings(t, func(ctx context.Context, logger *slog.Logger) {
+		warnMaxTokensVsContextWindow(ctx, logger, cfg)
+	})
+
+	assert.Contains(t, out, "provider my_llm")
+	assert.Contains(t, out, "context window")
+	assert.Contains(t, out, "3387")
+}
+
+// TestWarnMaxTokens_LargeValueWithoutContextSize covers the reporter's exact
+// config: max_tokens set to a context-window-sized value with no context_size,
+// so the window is not discoverable at load time. The instructional warning is
+// the only signal that reaches this user.
+func TestWarnMaxTokens_LargeValueWithoutContextSize(t *testing.T) {
+	t.Parallel()
+
+	maxTokens := int64(262144)
+	cfg := &latest.Config{
+		Providers: map[string]latest.ProviderConfig{
+			"my_llm": {MaxTokens: &maxTokens},
+		},
+	}
+
+	out := captureWarnings(t, func(ctx context.Context, logger *slog.Logger) {
+		warnMaxTokensVsContextWindow(ctx, logger, cfg)
+	})
+
+	assert.Contains(t, out, "provider my_llm")
+	assert.Contains(t, out, "context_size")
+}
+
+func TestWarnMaxTokens_ReasonableOutputCapIsSilent(t *testing.T) {
+	t.Parallel()
+
+	providerMax := int64(4096)
+	modelMax := int64(8192)
+	cfg := &latest.Config{
+		Providers: map[string]latest.ProviderConfig{
+			"my_llm": {MaxTokens: &providerMax},
+		},
+		Models: map[string]latest.ModelConfig{
+			"main": {
+				MaxTokens:    &modelMax,
+				ProviderOpts: map[string]any{"context_size": 262144},
+			},
+		},
+	}
+
+	out := captureWarnings(t, func(ctx context.Context, logger *slog.Logger) {
+		warnMaxTokensVsContextWindow(ctx, logger, cfg)
+	})
+
+	assert.Empty(t, out, "a sensible output cap below the window must not warn")
+}
+
+func TestWarnMaxTokens_ModelExceedsContextSize(t *testing.T) {
+	t.Parallel()
+
+	maxTokens := int64(200000)
+	cfg := &latest.Config{
+		Models: map[string]latest.ModelConfig{
+			"main": {
+				MaxTokens:    &maxTokens,
+				ProviderOpts: map[string]any{"context_size": 131072},
+			},
+		},
+	}
+
+	out := captureWarnings(t, func(ctx context.Context, logger *slog.Logger) {
+		warnMaxTokensVsContextWindow(ctx, logger, cfg)
+	})
+
+	assert.Contains(t, out, "model main")
+	assert.Contains(t, out, "3387")
+}

--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -279,6 +279,46 @@ func shouldMergeConsecutiveMessages(cfg *latest.ModelConfig) bool {
 	return openModelHostProviders[cfg.Provider]
 }
 
+// contextLimit returns this model's context window in tokens, preferring an
+// explicit provider_opts.context_size (authoritative for self-hosted
+// endpoints) and falling back to the models.dev catalogue. It returns 0 when
+// the window cannot be determined, in which case [clampMaxTokens] leaves
+// max_tokens untouched.
+func (c *Client) contextLimit(ctx context.Context) int64 {
+	if n := latest.ContextSizeFromProviderOpts(c.ModelConfig.ProviderOpts); n > 0 {
+		return n
+	}
+	return modelinfo.ContextLimit(ctx, c.ModelOptions.ModelsDevStore(), c.ID(), 0)
+}
+
+// clampMaxTokens caps a configured max_tokens (the per-response completion
+// budget) so it cannot consume the whole context window, leaving headroom for
+// the prompt. OpenAI-compatible servers such as vLLM reject a request when
+// prompt_tokens + max_tokens exceeds the model's context window, so a
+// max_tokens set equal to the window makes even a one-token prompt fail with a
+// "maximum context length" error (issue #3387). When the window is unknown (0)
+// the value is returned unchanged; a genuinely oversized prompt is then handled
+// by the runtime's overflow detection and compaction, not here.
+func clampMaxTokens(ctx context.Context, configured, window int64, model string) int64 {
+	if window <= 0 {
+		return configured
+	}
+	const safety = int64(1024)
+	capped := max(window-safety, 1)
+	if configured > capped {
+		slog.WarnContext(ctx,
+			"max_tokens exceeds the context window minus headroom; clamping to leave room for the prompt",
+			"configured", configured,
+			"clamped", capped,
+			"context_window", window,
+			"model", model,
+			"see", "https://github.com/docker/docker-agent/issues/3387",
+		)
+		return capped
+	}
+	return configured
+}
+
 // CreateChatCompletionStream creates a streaming chat completion request
 // It returns a stream that can be iterated over to get completion chunks
 func (c *Client) CreateChatCompletionStream(
@@ -342,11 +382,12 @@ func (c *Client) CreateChatCompletionStream(
 	}
 
 	if maxToken := c.ModelConfig.MaxTokens; maxToken != nil && *maxToken > 0 {
+		effective := clampMaxTokens(ctx, *maxToken, c.contextLimit(ctx), c.ModelConfig.Model)
 		if !modelinfo.SupportsResponsesAPI(c.ModelConfig.Model) {
-			params.MaxTokens = openai.Int(*maxToken)
-			slog.DebugContext(ctx, "OpenAI request configured with max tokens", "max_tokens", *maxToken, "model", c.ModelConfig.Model)
+			params.MaxTokens = openai.Int(effective)
+			slog.DebugContext(ctx, "OpenAI request configured with max tokens", "max_tokens", effective, "model", c.ModelConfig.Model)
 		} else {
-			params.MaxCompletionTokens = openai.Int(*maxToken)
+			params.MaxCompletionTokens = openai.Int(effective)
 			slog.DebugContext(ctx, "using max_completion_tokens instead of max_tokens for Responses-API models", "model", c.ModelConfig.Model)
 		}
 	}
@@ -485,7 +526,7 @@ func (c *Client) CreateResponseStream(
 	}
 
 	if maxToken := c.ModelConfig.MaxTokens; maxToken != nil && *maxToken > 0 {
-		maxTokens := *maxToken
+		maxTokens := clampMaxTokens(ctx, *maxToken, c.contextLimit(ctx), c.ModelConfig.Model)
 		params.MaxOutputTokens = param.NewOpt(maxTokens)
 		slog.DebugContext(ctx, "OpenAI responses request configured with max output tokens", "max_output_tokens", maxTokens)
 	}

--- a/pkg/model/provider/openai/max_tokens_test.go
+++ b/pkg/model/provider/openai/max_tokens_test.go
@@ -1,0 +1,140 @@
+package openai
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/environment"
+)
+
+// TestChatCompletions_ClampsMaxTokensToContextWindow is a regression test for
+// https://github.com/docker/docker-agent/issues/3387. A self-hosted vLLM user
+// set max_tokens equal to the model's context window (262144). vLLM requires
+// prompt_tokens + max_tokens to fit the window, so reserving the whole window
+// for output leaves no room for the prompt and even a "hello" is rejected with
+// a "maximum context length" error. When the window is known (here via
+// provider_opts.context_size) the client must clamp max_tokens to leave
+// headroom for the prompt.
+func TestChatCompletions_ClampsMaxTokensToContextWindow(t *testing.T) {
+	t.Parallel()
+
+	got, ok := requestMaxTokens(t, 262144, map[string]any{"context_size": 262144})
+	require.True(t, ok, "max_tokens must be present in the request")
+	assert.Equal(t, int64(262144-1024), got, "max_tokens must be clamped to leave prompt headroom (see #3387)")
+}
+
+// TestChatCompletions_DoesNotClampWhenWindowUnknown documents the reporter's
+// actual state: the model is not in models.dev and no context_size is set, so
+// the window is unknown at request time. The client must NOT fabricate a window
+// and must forward max_tokens verbatim; surfacing the misconfiguration is left
+// to the load-time warning and the user setting provider_opts.context_size.
+func TestChatCompletions_DoesNotClampWhenWindowUnknown(t *testing.T) {
+	t.Parallel()
+
+	got, ok := requestMaxTokens(t, 262144, nil)
+	require.True(t, ok)
+	assert.Equal(t, int64(262144), got, "with no discoverable context window, max_tokens must be sent verbatim")
+}
+
+// TestChatCompletions_DoesNotClampMaxTokensBelowWindow ensures a sensible
+// output cap passes through untouched when a window is known.
+func TestChatCompletions_DoesNotClampMaxTokensBelowWindow(t *testing.T) {
+	t.Parallel()
+
+	got, ok := requestMaxTokens(t, 4096, map[string]any{"context_size": 262144})
+	require.True(t, ok)
+	assert.Equal(t, int64(4096), got, "a reasonable max_tokens must pass through unchanged")
+}
+
+func TestClampMaxTokens(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		configured int64
+		window     int64
+		want       int64
+	}{
+		{"unknown window passes through", 262144, 0, 262144},
+		{"negative window passes through", 500, -1, 500},
+		{"equal to window is clamped", 262144, 262144, 262144 - 1024},
+		{"above window minus headroom is clamped", 300000, 262144, 262144 - 1024},
+		{"below window minus headroom unchanged", 4096, 262144, 4096},
+		{"window smaller than headroom floors at 1", 100, 512, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, clampMaxTokens(t.Context(), tt.configured, tt.window, "test-model"))
+		})
+	}
+}
+
+// requestMaxTokens drives a chat-completions request (against a mock server)
+// for a self-hosted openai-compatible model configured with the given
+// max_tokens and provider_opts, and returns the max_tokens field observed in
+// the request body (and whether it was present at all).
+func requestMaxTokens(t *testing.T, maxTokens int64, providerOpts map[string]any) (int64, bool) {
+	t.Helper()
+
+	var (
+		body []byte
+		mu   sync.Mutex
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		body = b
+		mu.Unlock()
+		writeSSEResponse(w)
+	}))
+	defer server.Close()
+
+	requestCfg := latest.ModelConfig{
+		Provider:     "openai",
+		Model:        "Qwen/Qwen3.6-35B",
+		TokenKey:     "MY_TOKEN",
+		BaseURL:      server.URL,
+		MaxTokens:    &maxTokens,
+		ProviderOpts: providerOpts,
+	}
+	env := environment.NewMapEnvProvider(map[string]string{"MY_TOKEN": "secret"})
+
+	client, err := NewClient(t.Context(), &requestCfg, env)
+	require.NoError(t, err)
+
+	stream, err := client.CreateChatCompletionStream(
+		t.Context(),
+		[]chat.Message{{Role: chat.MessageRoleUser, Content: "hello"}},
+		nil,
+	)
+	require.NoError(t, err)
+	defer stream.Close()
+	for {
+		if _, err := stream.Recv(); err != nil {
+			break
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotEmpty(t, body, "chat/completions should have been called")
+
+	var req struct {
+		MaxTokens *int64 `json:"max_tokens"`
+	}
+	require.NoError(t, json.Unmarshal(body, &req))
+	if req.MaxTokens == nil {
+		return 0, false
+	}
+	return *req.MaxTokens, true
+}

--- a/pkg/runtime/compaction_context_limit_test.go
+++ b/pkg/runtime/compaction_context_limit_test.go
@@ -56,6 +56,7 @@ func TestProviderContextLimit(t *testing.T) {
 		{name: "missing key", opts: map[string]any{"other": 123}, want: 0},
 		{name: "int", opts: map[string]any{"context_size": 32768}, want: 32768},
 		{name: "int64", opts: map[string]any{"context_size": int64(65536)}, want: 65536},
+		{name: "uint64 (yaml)", opts: map[string]any{"context_size": uint64(262144)}, want: 262144},
 		{name: "float64 (json)", opts: map[string]any{"context_size": float64(8192)}, want: 8192},
 		{name: "string decimal", opts: map[string]any{"context_size": "16384"}, want: 16384},
 		{name: "string with whitespace", opts: map[string]any{"context_size": "  4096 "}, want: 4096},

--- a/pkg/runtime/session_compaction.go
+++ b/pkg/runtime/session_compaction.go
@@ -3,12 +3,11 @@ package runtime
 import (
 	"context"
 	"log/slog"
-	"strconv"
-	"strings"
 
 	"github.com/docker/docker-agent/pkg/agent"
 	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/compaction"
+	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/hooks"
 	"github.com/docker/docker-agent/pkg/model/provider"
 	"github.com/docker/docker-agent/pkg/model/provider/options"
@@ -246,44 +245,14 @@ func (r *LocalRuntime) resolveContextLimit(ctx context.Context, p provider.Provi
 // models.dev catalogue does not have an entry for the configured
 // model (typically Docker Model Runner with a HuggingFace GGUF model).
 //
-// Accepted shapes mirror what YAML/JSON decoders may produce: int,
-// int64, float64, and decimal strings. Negative or zero values are
-// treated as "unset" so callers don't accidentally trigger
-// compaction with a degenerate limit.
+// The parsing is shared with the provider clients (which clamp max_tokens
+// against the same window) via [latest.ContextSizeFromProviderOpts], so the
+// two never disagree on how context_size is interpreted.
 func providerContextLimit(p provider.Provider) int64 {
 	if p == nil {
 		return 0
 	}
-	opts := p.BaseConfig().ModelConfig.ProviderOpts
-	v, ok := opts["context_size"]
-	if !ok {
-		return 0
-	}
-	var n int64
-	switch t := v.(type) {
-	case int64:
-		n = t
-	case int:
-		n = int64(t)
-	case int32:
-		n = int64(t)
-	case float64:
-		n = int64(t)
-	case float32:
-		n = int64(t)
-	case string:
-		parsed, err := strconv.ParseInt(strings.TrimSpace(t), 10, 64)
-		if err != nil {
-			return 0
-		}
-		n = parsed
-	default:
-		return 0
-	}
-	if n <= 0 {
-		return 0
-	}
-	return n
+	return latest.ContextSizeFromProviderOpts(p.BaseConfig().ModelConfig.ProviderOpts)
 }
 
 // runCompactionAgent runs an agent against a sub-session for compaction.


### PR DESCRIPTION
## Summary
A self-hosted vLLM user (#3387) got "the conversation has exceeded the model's context window" on a bare "hello". Root cause: `max_tokens` (the per-response output budget) was set equal to the context window and forwarded verbatim. vLLM requires `prompt_tokens + max_tokens <= context_window`, so no room was left for the prompt.

## Root cause
| Cause | Handled by | Status |
|---|---|---|
| `max_tokens` forwarded unclamped | clamp in OpenAI client | fixed |
| YAML `context_size` read as 0 (`uint64` not handled) | shared parser handles unsigned ints | fixed |
| Misleading config, no early signal | load-time warning + schema doc | fixed |

## Changes
- `pkg/model/provider/openai/client.go`: clamp `max_tokens` to `window - 1024` when the window is known (`provider_opts.context_size` first, then models.dev), on both the chat-completions and responses paths. Window unknown, value left unchanged.
- `pkg/config/latest/types.go`: `ContextSizeFromProviderOpts`, a single parser now used by the runtime and the client. Handles `uint64`/`uint`/`uint32` (goccy/go-yaml decodes positive YAML integers as `uint64`), so a YAML `context_size` is honored. This also restored proactive compaction for those configs.
- `pkg/runtime/session_compaction.go`: `providerContextLimit` delegates to the shared parser.
- `pkg/config/max_tokens_warning.go`: load-time warning when `max_tokens >= context_size`, or when it is set to a context-window-sized value with no discoverable window.
- `agent-schema.json`: `max_tokens` documented as the output budget, not the context window.

## Reproduction (mock enforcing vLLM's rule, `max_model_len = 262144`)
| Scenario | max_tokens sent | Server | Result |
|---|---|---|---|
| Reporter config (no `context_size`) | 262144 | reject `12 + 262144 > 262144` | bug reproduced, warning shown |
| With `context_size: 262144` | 261120 (clamped) | accept `12 + 261120 <= 262144` | reply returned |

## Design note (open to maintainer preference)
The clamp reserves a fixed 1024-token headroom (`window - 1024`), matching the Anthropic client's `clampMaxTokens`. It is deliberately prompt-agnostic (no token-count round-trip): it guarantees room for a small prompt, not necessarily a very large one. A large agent prompt under a known window could still overflow and would fall through to the existing overflow detection and compaction. If a percentage-based margin (for example `window - max(1024, window/8)`) is preferred to better fit large agent prompts, it is a one-line change.

## Testing
- `pkg/model/provider/openai`: clamp fires when the window is known, verbatim when unknown, plus a unit test of the clamp math.
- `pkg/config/latest`: parser covers int/uint64/float64/string and a real YAML round-trip.
- `pkg/config`: load-time warning cases.
- `pkg/runtime`: `uint64` case added to the existing context-limit test.
- `task build` and `task lint` pass.

Fixes #3387
