### PR TITLE
feat(memory): strengthen default toolset instructions

### DIFF
--- a/pkg/tools/builtin/memory/memory.go
+++ b/pkg/tools/builtin/memory/memory.go
@@ -142,12 +142,15 @@ type UpdateMemoryArgs struct {
 func (t *ToolSet) Instructions() string {
 	return `## Memory Tools
 
-Check stored memories for relevant context before acting. Store useful information silently — never mention using this tool.
+You have persistent memory that survives across sessions. Use it silently: never mention memory operations in your replies (no "I'll remember that", "stored", "saved", "noted", "I searched my memory"). Just act on what you recall or store.
 
-- Remember: user preferences, corrections, key decisions, project conventions
+RECALL: Before acting on a request or answering a question that depends on prior context — preferences, past decisions, or personal facts like "what's my name?" — call search_memories first. Skip this only for simple greetings and self-contained informational questions.
+
+STORE: Scan each user message for durable facts worth keeping — preferences, corrections, project conventions, tech stack, environment, constraints, and decisions — including details mentioned in passing. Corrections ("use alpine instead") are preferences; store them. Capture every distinct fact. Never store secrets, tokens, or transient debugging details.
+
 - Use search_memories with keywords/category for targeted lookup; use get_memories only for a full dump
-- Use update_memory to edit existing entries; use add_memory only for new information
-- Organize with categories: "preference", "fact", "project", "decision"`
+- Use update_memory to revise existing entries instead of adding duplicates; use add_memory only for genuinely new information
+- Organize with categories: "preference", "fact", "project", "decision", "environment", "correction"`
 }
 
 func (t *ToolSet) Tools(context.Context) ([]tools.Tool, error) {


### PR DESCRIPTION
The default `Instructions()` in the memory toolset were written at a fairly high level of abstraction, making it easy for agents to leak tool usage into their replies or to skip recall when it would help. This PR ports the memory-handling lessons that were refined in the `assistant/gordon.yaml` doctrine and validated by the `assistant/evals/memory-*.json` eval suite into the shared toolset defaults, so every agent that uses the memory toolset benefits.

The changes tighten four areas. First, the silence rule now lists the specific phrases to avoid ("I'll remember that", "stored", "saved", "noted", "I searched my memory") rather than a vague directive, which makes it actionable for an LLM rather than interpretable. Second, a RECALL-first rule instructs agents to call `search_memories` before answering context-dependent or personal questions (e.g. "what's my name?"), with an explicit carve-out for greetings and self-contained informational questions so the tool is not overused. Third, a proactive STORE scan asks agents to check each user message for durable facts — including ones mentioned in passing — and to treat corrections as preferences rather than one-off overrides. Fourth, a secret-hygiene rule prevents storing secrets, tokens, or transient debugging details.

Two categories ("environment" and "correction") were added to the suggested taxonomy to match the new behavioral rules. Gordon-specific persona rules (banned words, response styles, empty-prose mechanics) were deliberately excluded; those remain in `gordon.yaml` where they belong.

`go test ./pkg/tools/builtin/memory/...` passes with the updated `TestMemoryTool_Instructions` assertions, and `gofmt`/`go vet` are clean.