### PR TITLE
refactor: extract shared calleeObject helper in lint cops

### DIFF
--- a/lint/constructor_command_exec.go
+++ b/lint/constructor_command_exec.go
@@ -54,19 +54,27 @@ var ConstructorCommandExec = &cop.Func{
 }
 
 func commandConstructorCall(p *cop.Pass, call *ast.CallExpr) (string, bool) {
-	if p.Info != nil {
-		switch fun := call.Fun.(type) {
-		case *ast.SelectorExpr:
-			if name, ok := osExecFuncName(p.Info.Uses[fun.Sel]); ok {
-				return name, true
-			}
-		case *ast.Ident:
-			if name, ok := osExecFuncName(p.Info.Uses[fun]); ok {
-				return name, true
-			}
-		}
+	if name, ok := osExecFuncName(calleeObject(p.Info, call)); ok {
+		return name, true
 	}
 	return cop.CallTo(call, "exec", "Command", "CommandContext")
+}
+
+// calleeObject resolves the object a call's callee denotes, whether the callee
+// is a bare identifier (f()) or a selector (pkg.F() / recv.F()). Returns nil
+// when info is unavailable or the callee has no resolvable object.
+func calleeObject(info *types.Info, call *ast.CallExpr) types.Object {
+	if info == nil {
+		return nil
+	}
+	switch fun := call.Fun.(type) {
+	case *ast.SelectorExpr:
+		return info.Uses[fun.Sel]
+	case *ast.Ident:
+		return info.Uses[fun]
+	default:
+		return nil
+	}
 }
 
 func osExecFuncName(obj types.Object) (string, bool) {

--- a/lint/constructor_network_io.go
+++ b/lint/constructor_network_io.go
@@ -48,17 +48,8 @@ var ConstructorNetworkIO = &cop.Func{
 }
 
 func networkIOCall(p *cop.Pass, call *ast.CallExpr) (string, string, bool) {
-	if p.Info != nil {
-		switch fun := call.Fun.(type) {
-		case *ast.SelectorExpr:
-			if pkg, name, ok := networkIOFuncName(p.Info.Uses[fun.Sel]); ok {
-				return pkg, name, true
-			}
-		case *ast.Ident:
-			if pkg, name, ok := networkIOFuncName(p.Info.Uses[fun]); ok {
-				return pkg, name, true
-			}
-		}
+	if pkg, name, ok := networkIOFuncName(calleeObject(p.Info, call)); ok {
+		return pkg, name, true
 	}
 
 	if name, ok := cop.CallTo(call, "net", "Dial", "DialTimeout", "Listen", "ListenPacket", "ListenTCP", "ListenUDP", "ListenUnix"); ok {


### PR DESCRIPTION
Both `constructor_command_exec.go` and `constructor_network_io.go` contained nearly identical type-switch blocks to extract the callee object from a call expression — handling both bare `*ast.Ident` and selector-expression `*ast.SelectorExpr` cases, then resolving the corresponding types.Object from type info. The duplication made each cop harder to read and meant any future fix had to be applied twice.

This change extracts that logic into a single `calleeObject` helper in `constructor_command_exec.go` and updates `constructor_network_io.go` to call it, removing around 20 lines of duplicated branching with no change in behaviour.

No breaking changes. Both cops produce identical diagnostics before and after.