### PR TITLE
refactor(provider): deduplicate provider client boilerplate

### DIFF
--- a/pkg/model/provider/anthropic/beta_client.go
+++ b/pkg/model/provider/anthropic/beta_client.go
@@ -123,7 +123,7 @@ func (c *Client) createBetaStream(
 	}
 
 	stream := client.Beta.Messages.NewStreaming(ctx, params, requestOpts...)
-	trackUsage := c.ModelConfig.TrackUsage == nil || *c.ModelConfig.TrackUsage
+	trackUsage := c.TrackUsageEnabled()
 	ad := c.newBetaStreamAdapter(stream, trackUsage)
 
 	// Set up single retry for context length errors
@@ -293,7 +293,7 @@ func (c *Client) Rerank(ctx context.Context, query string, documents []types.Doc
 		return nil, err
 	}
 
-	scores, err := parseRerankScoresAnthropic(rawJSON, len(documents))
+	scores, err := providerutil.ParseRerankScores(rawJSON, len(documents))
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to parse Anthropic rerank scores", "error", err)
 		return nil, err
@@ -344,43 +344,6 @@ func extractAnthropicStructuredOutputJSON(msg *anthropic.BetaMessage) (string, e
 	}
 
 	return "", errors.New("no structured JSON text found in Anthropic BetaMessage content")
-}
-
-// parseRerankScoresAnthropic parses a JSON payload of the form {"scores":[...]} and validates length.
-// This helper is local to the Anthropic provider to avoid cyclic dependencies.
-func parseRerankScoresAnthropic(raw string, expected int) ([]float64, error) {
-	type rerankResponse struct {
-		Scores []float64 `json:"scores"`
-	}
-
-	raw = strings.TrimSpace(raw)
-
-	tryParse := func(s string) ([]float64, error) {
-		var rr rerankResponse
-		if err := json.Unmarshal([]byte(s), &rr); err != nil {
-			return nil, err
-		}
-		if len(rr.Scores) != expected {
-			return nil, fmt.Errorf("expected %d scores, got %d", expected, len(rr.Scores))
-		}
-		return rr.Scores, nil
-	}
-
-	// First attempt: parse whole string as JSON.
-	if scores, err := tryParse(raw); err == nil {
-		return scores, nil
-	}
-
-	// Fallback: extract the first {...} block and try again, in case the model added prose.
-	start := strings.Index(raw, "{")
-	end := strings.LastIndex(raw, "}")
-	if start >= 0 && end > start {
-		if scores, err := tryParse(raw[start : end+1]); err == nil {
-			return scores, nil
-		}
-	}
-
-	return nil, fmt.Errorf("invalid rerank JSON: %s", raw)
 }
 
 // accumulateBetaStreamResponse consumes a Beta streaming response and returns the final BetaMessage.

--- a/pkg/model/provider/anthropic/client.go
+++ b/pkg/model/provider/anthropic/client.go
@@ -1,7 +1,6 @@
 package anthropic
 
 import (
-	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -58,12 +57,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 		return nil, errors.New("environment provider is required")
 	}
 
-	var globalOptions options.ModelOptions
-	for _, opt := range opts {
-		if opt != nil {
-			opt(&globalOptions)
-		}
-	}
+	globalOptions := options.Apply(opts...)
 
 	anthropicClient := &Client{
 		Config: base.Config{
@@ -80,13 +74,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 			return nil, err
 		}
 		httpClient := httpclient.NewHTTPClient(ctx)
-		if w := globalOptions.TransportWrapper(); w != nil {
-			if wrapped := w(httpClient.Transport); wrapped != nil {
-				httpClient.Transport = wrapped
-			} else {
-				slog.WarnContext(ctx, "HTTP transport wrapper returned nil; using original transport")
-			}
-		}
+		globalOptions.WrapTransport(ctx, httpClient)
 		requestOptions := append([]option.RequestOption{
 			option.WithHTTPClient(httpClient),
 		}, authOpts...)
@@ -103,23 +91,17 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 		}
 		// When using a Gateway targeting a Docker domain, tokens are short-lived.
 		// Only require and inject the Docker JWT if the gateway is a .docker.com URL.
-		if environment.IsTrustedDockerURL(gateway) {
-			// Fail fast if Docker Desktop's auth token isn't available
-			if token, _ := env.Get(ctx, environment.DockerDesktopTokenEnv); token == "" {
-				slog.ErrorContext(ctx, "Anthropic client creation failed", "error", "failed to get Docker Desktop's authentication token")
-				return nil, errors.New("sorry, you first need to sign in Docker Desktop to use the Docker AI Gateway")
-			}
+		if err := base.VerifyDockerGatewayAuth(ctx, env, gateway); err != nil {
+			slog.ErrorContext(ctx, "Anthropic client creation failed", "error", "failed to get Docker Desktop's authentication token")
+			return nil, err
 		}
 
 		// When using a Gateway, tokens are short-lived.
 		anthropicClient.clientFn = func(ctx context.Context) (anthropic.Client, error) {
-			var authToken string
-			if environment.IsTrustedDockerURL(gateway) {
-				// Query a fresh auth token each time the client is used
-				authToken, _ = env.Get(ctx, environment.DockerDesktopTokenEnv)
-				if authToken == "" {
-					return anthropic.Client{}, errors.New(base.NoDesktopTokenErrorMessage)
-				}
+			// Query a fresh auth token each time the client is used.
+			authToken, err := base.GatewayAuthToken(ctx, env, gateway)
+			if err != nil {
+				return anthropic.Client{}, err
 			}
 
 			url, err := url.Parse(gateway)
@@ -129,25 +111,10 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 			baseURL := fmt.Sprintf("%s://%s%s/", url.Scheme, url.Host, url.Path)
 
 			// Configure a custom HTTP client to inject headers and query params used by the Gateway.
-			httpOptions := []httpclient.Opt{
-				httpclient.WithProxiedBaseURL(cmp.Or(cfg.BaseURL, "https://api.anthropic.com/")),
-				httpclient.WithProvider(cfg.Provider),
-				httpclient.WithModel(cfg.Model),
-				httpclient.WithModelName(cfg.Name),
-				httpclient.WithQuery(url.Query()),
-			}
-			if globalOptions.GeneratingTitle() {
-				httpOptions = append(httpOptions, httpclient.WithHeader("X-Cagent-GeneratingTitle", "1"))
-			}
+			httpOptions := base.GatewayHTTPOptions(url, "https://api.anthropic.com/", cfg, globalOptions.GeneratingTitle())
 
 			gatewayHTTPClient := httpclient.NewHTTPClient(ctx, httpOptions...)
-			if w := globalOptions.TransportWrapper(); w != nil {
-				if wrapped := w(gatewayHTTPClient.Transport); wrapped != nil {
-					gatewayHTTPClient.Transport = wrapped
-				} else {
-					slog.WarnContext(ctx, "HTTP transport wrapper returned nil; using original transport")
-				}
-			}
+			globalOptions.WrapTransport(ctx, gatewayHTTPClient)
 			clientOptions := []option.RequestOption{
 				option.WithBaseURL(baseURL),
 				option.WithHTTPClient(gatewayHTTPClient),
@@ -330,7 +297,7 @@ func (c *Client) CreateChatCompletionStream(
 	requestOpts = append(requestOpts, option.WithHeader("anthropic-beta", betas))
 
 	stream := client.Messages.NewStreaming(ctx, params, requestOpts...)
-	trackUsage := c.ModelConfig.TrackUsage == nil || *c.ModelConfig.TrackUsage
+	trackUsage := c.TrackUsageEnabled()
 	ad := c.newStreamAdapter(stream, trackUsage)
 
 	// Set up single retry for context length errors

--- a/pkg/model/provider/anthropic/vertex.go
+++ b/pkg/model/provider/anthropic/vertex.go
@@ -44,12 +44,7 @@ func NewVertexClient(ctx context.Context, cfg *latest.ModelConfig, env environme
 		return nil, errors.New("vertex AI requires a GCP location")
 	}
 
-	var globalOptions options.ModelOptions
-	for _, opt := range opts {
-		if opt != nil {
-			opt(&globalOptions)
-		}
-	}
+	globalOptions := options.Apply(opts...)
 
 	// Resolve GCP credentials up front so we can return a descriptive error
 	// instead of the panic that vertex.WithGoogleAuth would raise.

--- a/pkg/model/provider/base/base.go
+++ b/pkg/model/provider/base/base.go
@@ -53,6 +53,13 @@ func (c *Config) BaseConfig() Config {
 	return *c
 }
 
+// TrackUsageEnabled reports whether token-usage tracking is enabled for this
+// model. Tracking defaults to on and is disabled only when the config
+// explicitly sets track_usage: false.
+func (c *Config) TrackUsageEnabled() bool {
+	return c.ModelConfig.TrackUsage == nil || *c.ModelConfig.TrackUsage
+}
+
 // CapsOverride returns the model's explicit attachment-capability override
 // derived from its config, or nil when the config declares none (the common
 // case, in which capabilities are detected from models.dev). Provider clients

--- a/pkg/model/provider/base/gateway.go
+++ b/pkg/model/provider/base/gateway.go
@@ -1,0 +1,58 @@
+package base
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"net/url"
+
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/environment"
+	"github.com/docker/docker-agent/pkg/httpclient"
+)
+
+// VerifyDockerGatewayAuth fails fast when gateway targets a trusted Docker
+// domain but Docker Desktop's auth token is unavailable. Provider clients
+// call it at construction time so a missing sign-in surfaces before the
+// first request. Non-Docker gateways need no Desktop token and always pass.
+func VerifyDockerGatewayAuth(ctx context.Context, env environment.Provider, gateway string) error {
+	if !environment.IsTrustedDockerURL(gateway) {
+		return nil
+	}
+	if token, _ := env.Get(ctx, environment.DockerDesktopTokenEnv); token == "" {
+		return errors.New("sorry, you first need to sign in Docker Desktop to use the Docker AI Gateway")
+	}
+	return nil
+}
+
+// GatewayAuthToken returns a fresh Docker Desktop auth token when gateway
+// targets a trusted Docker domain, or "" for other gateways. Gateway clients
+// call it on every request because Desktop tokens are short-lived.
+func GatewayAuthToken(ctx context.Context, env environment.Provider, gateway string) (string, error) {
+	if !environment.IsTrustedDockerURL(gateway) {
+		return "", nil
+	}
+	token, _ := env.Get(ctx, environment.DockerDesktopTokenEnv)
+	if token == "" {
+		return "", errors.New(NoDesktopTokenErrorMessage)
+	}
+	return token, nil
+}
+
+// GatewayHTTPOptions builds the httpclient options shared by all
+// gateway-mode provider clients: the proxied base URL (the provider's public
+// endpoint unless the model overrides base_url), provider/model identity,
+// the gateway's query parameters, and the title-generation marker.
+func GatewayHTTPOptions(gatewayURL *url.URL, defaultBaseURL string, cfg *latest.ModelConfig, generatingTitle bool) []httpclient.Opt {
+	opts := []httpclient.Opt{
+		httpclient.WithProxiedBaseURL(cmp.Or(cfg.BaseURL, defaultBaseURL)),
+		httpclient.WithProvider(cfg.Provider),
+		httpclient.WithModel(cfg.Model),
+		httpclient.WithModelName(cfg.Name),
+		httpclient.WithQuery(gatewayURL.Query()),
+	}
+	if generatingTitle {
+		opts = append(opts, httpclient.WithHeader("X-Cagent-GeneratingTitle", "1"))
+	}
+	return opts
+}

--- a/pkg/model/provider/base/gateway_test.go
+++ b/pkg/model/provider/base/gateway_test.go
@@ -1,0 +1,109 @@
+package base
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/environment"
+	"github.com/docker/docker-agent/pkg/httpclient"
+)
+
+type fakeEnv map[string]string
+
+func (f fakeEnv) Get(_ context.Context, name string) (string, bool) {
+	v, ok := f[name]
+	return v, ok
+}
+
+func TestVerifyDockerGatewayAuth(t *testing.T) {
+	t.Parallel()
+
+	t.Run("non-docker gateway needs no token", func(t *testing.T) {
+		t.Parallel()
+		assert.NoError(t, VerifyDockerGatewayAuth(t.Context(), fakeEnv{}, "https://gateway.example.com"))
+	})
+
+	t.Run("trusted docker gateway with token", func(t *testing.T) {
+		t.Parallel()
+		env := fakeEnv{environment.DockerDesktopTokenEnv: "jwt"}
+		assert.NoError(t, VerifyDockerGatewayAuth(t.Context(), env, "https://api.docker.com/models"))
+	})
+
+	t.Run("trusted docker gateway without token", func(t *testing.T) {
+		t.Parallel()
+		err := VerifyDockerGatewayAuth(t.Context(), fakeEnv{}, "https://api.docker.com/models")
+		assert.EqualError(t, err, "sorry, you first need to sign in Docker Desktop to use the Docker AI Gateway")
+	})
+}
+
+func TestGatewayAuthToken(t *testing.T) {
+	t.Parallel()
+
+	t.Run("non-docker gateway returns empty token", func(t *testing.T) {
+		t.Parallel()
+		token, err := GatewayAuthToken(t.Context(), fakeEnv{}, "https://gateway.example.com")
+		require.NoError(t, err)
+		assert.Empty(t, token)
+	})
+
+	t.Run("trusted docker gateway returns fresh token", func(t *testing.T) {
+		t.Parallel()
+		env := fakeEnv{environment.DockerDesktopTokenEnv: "jwt"}
+		token, err := GatewayAuthToken(t.Context(), env, "https://api.docker.com/models")
+		require.NoError(t, err)
+		assert.Equal(t, "jwt", token)
+	})
+
+	t.Run("trusted docker gateway without token", func(t *testing.T) {
+		t.Parallel()
+		_, err := GatewayAuthToken(t.Context(), fakeEnv{}, "https://api.docker.com/models")
+		assert.EqualError(t, err, NoDesktopTokenErrorMessage)
+	})
+}
+
+func TestGatewayHTTPOptions(t *testing.T) {
+	t.Parallel()
+
+	apply := func(opts []httpclient.Opt) *httpclient.HTTPOptions {
+		o := &httpclient.HTTPOptions{Header: make(http.Header)}
+		for _, opt := range opts {
+			opt(o)
+		}
+		return o
+	}
+
+	gatewayURL, err := url.Parse("https://api.docker.com/models?tier=pro")
+	require.NoError(t, err)
+
+	t.Run("default base URL and identity headers", func(t *testing.T) {
+		t.Parallel()
+		cfg := &latest.ModelConfig{Provider: "openai", Model: "gpt-4o", Name: "smart"}
+		o := apply(GatewayHTTPOptions(gatewayURL, "https://api.openai.com/v1", cfg, false))
+		assert.Equal(t, "https://api.openai.com/v1", o.Header.Get("X-Cagent-Forward"))
+		assert.Equal(t, "openai", o.Header.Get("X-Cagent-Provider"))
+		assert.Equal(t, "gpt-4o", o.Header.Get("X-Cagent-Model"))
+		assert.Equal(t, "smart", o.Header.Get("X-Cagent-Model-Name"))
+		assert.Equal(t, "pro", o.Query.Get("tier"))
+		assert.Empty(t, o.Header.Get("X-Cagent-GeneratingTitle"))
+	})
+
+	t.Run("model base_url overrides the default", func(t *testing.T) {
+		t.Parallel()
+		cfg := &latest.ModelConfig{Provider: "openai", Model: "gpt-4o", BaseURL: "https://example.com/v1"}
+		o := apply(GatewayHTTPOptions(gatewayURL, "https://api.openai.com/v1", cfg, false))
+		assert.Equal(t, "https://example.com/v1", o.Header.Get("X-Cagent-Forward"))
+	})
+
+	t.Run("title generation marker", func(t *testing.T) {
+		t.Parallel()
+		cfg := &latest.ModelConfig{Provider: "openai", Model: "gpt-4o"}
+		o := apply(GatewayHTTPOptions(gatewayURL, "https://api.openai.com/v1", cfg, true))
+		assert.Equal(t, "1", o.Header.Get("X-Cagent-GeneratingTitle"))
+	})
+}

--- a/pkg/model/provider/base/track_usage_test.go
+++ b/pkg/model/provider/base/track_usage_test.go
@@ -1,0 +1,33 @@
+package base
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/docker/docker-agent/pkg/config/latest"
+)
+
+func TestTrackUsageEnabled(t *testing.T) {
+	t.Parallel()
+
+	boolPtr := func(b bool) *bool { return &b }
+
+	t.Run("defaults to on when unset", func(t *testing.T) {
+		t.Parallel()
+		c := &Config{ModelConfig: latest.ModelConfig{}}
+		assert.True(t, c.TrackUsageEnabled())
+	})
+
+	t.Run("explicit true", func(t *testing.T) {
+		t.Parallel()
+		c := &Config{ModelConfig: latest.ModelConfig{TrackUsage: boolPtr(true)}}
+		assert.True(t, c.TrackUsageEnabled())
+	})
+
+	t.Run("explicit false disables", func(t *testing.T) {
+		t.Parallel()
+		c := &Config{ModelConfig: latest.ModelConfig{TrackUsage: boolPtr(false)}}
+		assert.False(t, c.TrackUsageEnabled())
+	})
+}

--- a/pkg/model/provider/bedrock/client.go
+++ b/pkg/model/provider/bedrock/client.go
@@ -58,10 +58,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 		return nil, errors.New("model type must be 'amazon-bedrock'")
 	}
 
-	var globalOptions options.ModelOptions
-	for _, opt := range opts {
-		opt(&globalOptions)
-	}
+	globalOptions := options.Apply(opts...)
 
 	// Check for bearer token
 	// Bearer token is optional: if not provided, falls back to standard AWS credential chain (SigV4).
@@ -94,13 +91,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 	}
 
 	// Apply the transport wrapper, if registered, over the full chain.
-	if w := globalOptions.TransportWrapper(); w != nil {
-		if wrapped := w(httpClient.Transport); wrapped != nil {
-			httpClient.Transport = wrapped
-		} else {
-			slog.WarnContext(ctx, "HTTP transport wrapper returned nil; using original transport")
-		}
-	}
+	globalOptions.WrapTransport(ctx, httpClient)
 
 	// Build AWS config using default credential chain
 	awsCfg, err := buildAWSConfig(ctx, cfg, env)
@@ -246,7 +237,7 @@ func (c *Client) CreateChatCompletionStream(
 		return nil, wrapBedrockError(fmt.Errorf("bedrock converse stream failed: %w", err))
 	}
 
-	trackUsage := c.ModelConfig.TrackUsage == nil || *c.ModelConfig.TrackUsage
+	trackUsage := c.TrackUsageEnabled()
 	return newStreamAdapter(output.GetStream(), c.ModelConfig.Model, trackUsage), nil
 }
 

--- a/pkg/model/provider/dmr/client.go
+++ b/pkg/model/provider/dmr/client.go
@@ -77,10 +77,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, opts ...options.Opt
 		return nil, errors.New("model type must be 'dmr'")
 	}
 
-	var globalOptions options.ModelOptions
-	for _, opt := range opts {
-		opt(&globalOptions)
-	}
+	globalOptions := options.Apply(opts...)
 
 	// Skip docker model status query when BaseURL is explicitly provided.
 	// This avoids unnecessary exec calls and speeds up tests/CI scenarios.
@@ -186,7 +183,7 @@ func (c *Client) CreateChatCompletionStream(ctx context.Context, messages []chat
 		return nil, errors.New("at least one message is required")
 	}
 
-	trackUsage := c.ModelConfig.TrackUsage == nil || *c.ModelConfig.TrackUsage
+	trackUsage := c.TrackUsageEnabled()
 
 	params := openai.ChatCompletionNewParams{
 		Model:    c.ModelConfig.Model,

--- a/pkg/model/provider/factory.go
+++ b/pkg/model/provider/factory.go
@@ -38,12 +38,7 @@ func (r *Registry) NewWithModels(ctx context.Context, cfg *latest.ModelConfig, m
 		// bypass to every child so the whole routing subtree dials directly.
 		// Routed targets that are named models can still set their own flag.
 		if cfg.BypassModelsGateway {
-			var globalOptions options.ModelOptions
-			for _, opt := range opts {
-				if opt != nil {
-					opt(&globalOptions)
-				}
-			}
+			globalOptions := options.Apply(opts...)
 			if globalOptions.Gateway() != "" {
 				slog.DebugContext(ctx, "Bypassing models gateway for routing model", "provider", cfg.Provider, "model", cfg.Model)
 				opts = append(opts, options.WithGateway(""))
@@ -83,10 +78,7 @@ func (r *Registry) createDirectProvider(ctx context.Context, cfg *latest.ModelCo
 	if r == nil {
 		r = DefaultRegistry()
 	}
-	var globalOptions options.ModelOptions
-	for _, opt := range opts {
-		opt(&globalOptions)
-	}
+	globalOptions := options.Apply(opts...)
 	enhancedCfg := applyProviderDefaults(cfg, globalOptions.Providers())
 	if err := expandModelConfigEnv(ctx, enhancedCfg, env); err != nil {
 		return nil, err

--- a/pkg/model/provider/factory_js.go
+++ b/pkg/model/provider/factory_js.go
@@ -100,10 +100,7 @@ func (r *Registry) createDirectProvider(ctx context.Context, cfg *latest.ModelCo
 	if r == nil {
 		r = DefaultRegistry()
 	}
-	var globalOptions options.ModelOptions
-	for _, opt := range opts {
-		opt(&globalOptions)
-	}
+	globalOptions := options.Apply(opts...)
 	enhancedCfg := applyProviderDefaults(cfg, globalOptions.Providers())
 	if err := expandModelConfigEnv(ctx, enhancedCfg, env); err != nil {
 		return nil, err

--- a/pkg/model/provider/gemini/client.go
+++ b/pkg/model/provider/gemini/client.go
@@ -1,7 +1,6 @@
 package gemini
 
 import (
-	"cmp"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -47,10 +46,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 		return nil, errors.New("model type must be 'google'")
 	}
 
-	var globalOptions options.ModelOptions
-	for _, opt := range opts {
-		opt(&globalOptions)
-	}
+	globalOptions := options.Apply(opts...)
 
 	var clientFn func(context.Context) (*genai.Client, error)
 	if gateway := globalOptions.Gateway(); gateway == "" {
@@ -115,13 +111,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 			httpClient = httpclient.NewHTTPClient(ctx)
 		}
 
-		if w := globalOptions.TransportWrapper(); w != nil {
-			if wrapped := w(httpClient.Transport); wrapped != nil {
-				httpClient.Transport = wrapped
-			} else {
-				slog.WarnContext(ctx, "HTTP transport wrapper returned nil; using original transport")
-			}
-		}
+		globalOptions.WrapTransport(ctx, httpClient)
 
 		client, err := genai.NewClient(ctx, &genai.ClientConfig{
 			APIKey:     apiKey,
@@ -143,23 +133,17 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 	} else {
 		// When using a Gateway targeting a Docker domain, tokens are short-lived.
 		// Only require and inject the Docker JWT if the gateway is a .docker.com URL.
-		if environment.IsTrustedDockerURL(gateway) {
-			// Fail fast if Docker Desktop's auth token isn't available
-			if token, _ := env.Get(ctx, environment.DockerDesktopTokenEnv); token == "" {
-				slog.ErrorContext(ctx, "Gemini client creation failed", "error", "failed to get Docker Desktop's authentication token")
-				return nil, errors.New("sorry, you first need to sign in Docker Desktop to use the Docker AI Gateway")
-			}
+		if err := base.VerifyDockerGatewayAuth(ctx, env, gateway); err != nil {
+			slog.ErrorContext(ctx, "Gemini client creation failed", "error", "failed to get Docker Desktop's authentication token")
+			return nil, err
 		}
 
 		// When using a Gateway, tokens are short-lived.
 		clientFn = func(ctx context.Context) (*genai.Client, error) {
-			var authToken string
-			if environment.IsTrustedDockerURL(gateway) {
-				// Query a fresh auth token each time the client is used
-				authToken, _ = env.Get(ctx, environment.DockerDesktopTokenEnv)
-				if authToken == "" {
-					return nil, errors.New(base.NoDesktopTokenErrorMessage)
-				}
+			// Query a fresh auth token each time the client is used.
+			authToken, err := base.GatewayAuthToken(ctx, env, gateway)
+			if err != nil {
+				return nil, err
 			}
 
 			url, err := url.Parse(gateway)
@@ -168,16 +152,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 			}
 			baseURL := fmt.Sprintf("%s://%s%s/", url.Scheme, url.Host, url.Path)
 
-			httpOptions := []httpclient.Opt{
-				httpclient.WithProxiedBaseURL(cmp.Or(cfg.BaseURL, "https://generativelanguage.googleapis.com/")),
-				httpclient.WithProvider(cfg.Provider),
-				httpclient.WithModel(cfg.Model),
-				httpclient.WithModelName(cfg.Name),
-				httpclient.WithQuery(url.Query()),
-			}
-			if globalOptions.GeneratingTitle() {
-				httpOptions = append(httpOptions, httpclient.WithHeader("X-Cagent-GeneratingTitle", "1"))
-			}
+			httpOptions := base.GatewayHTTPOptions(url, "https://generativelanguage.googleapis.com/", cfg, globalOptions.GeneratingTitle())
 
 			httpOpts := genai.HTTPOptions{
 				BaseURL: baseURL,
@@ -189,13 +164,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 			}
 
 			gatewayHTTPClient := httpclient.NewHTTPClient(ctx, httpOptions...)
-			if w := globalOptions.TransportWrapper(); w != nil {
-				if wrapped := w(gatewayHTTPClient.Transport); wrapped != nil {
-					gatewayHTTPClient.Transport = wrapped
-				} else {
-					slog.WarnContext(ctx, "HTTP transport wrapper returned nil; using original transport")
-				}
-			}
+			globalOptions.WrapTransport(ctx, gatewayHTTPClient)
 
 			return genai.NewClient(ctx, &genai.ClientConfig{
 				APIKey:      authToken,
@@ -703,7 +672,7 @@ func (c *Client) CreateChatCompletionStream(
 
 	// Build a fresh client per request when using the gateway
 	iter := client.Models.GenerateContentStream(ctx, c.ModelConfig.Model, contents, config)
-	trackUsage := c.ModelConfig.TrackUsage == nil || *c.ModelConfig.TrackUsage
+	trackUsage := c.TrackUsageEnabled()
 	return NewStreamAdapter(iter, c.ModelConfig.Model, trackUsage), nil
 }
 

--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -25,6 +25,7 @@ import (
 	"github.com/docker/docker-agent/pkg/model/provider/base"
 	"github.com/docker/docker-agent/pkg/model/provider/oaistream"
 	"github.com/docker/docker-agent/pkg/model/provider/options"
+	"github.com/docker/docker-agent/pkg/model/provider/providerutil"
 	"github.com/docker/docker-agent/pkg/modelinfo"
 	"github.com/docker/docker-agent/pkg/rag/prompts"
 	"github.com/docker/docker-agent/pkg/rag/types"
@@ -50,10 +51,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 		return nil, errors.New("model configuration is required")
 	}
 
-	var globalOptions options.ModelOptions
-	for _, opt := range opts {
-		opt(&globalOptions)
-	}
+	globalOptions := options.Apply(opts...)
 
 	var clientFn func(context.Context) (*openai.Client, error)
 	if gateway := globalOptions.Gateway(); gateway == "" {
@@ -103,13 +101,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 		clientOptions = append(clientOptions, option.WithMiddleware(oaistream.ErrorBodyMiddleware()))
 
 		httpClient := httpclient.NewHTTPClient(ctx)
-		if w := globalOptions.TransportWrapper(); w != nil {
-			if wrapped := w(httpClient.Transport); wrapped != nil {
-				httpClient.Transport = wrapped
-			} else {
-				slog.WarnContext(ctx, "HTTP transport wrapper returned nil; using original transport")
-			}
-		}
+		globalOptions.WrapTransport(ctx, httpClient)
 		clientOptions = append(clientOptions, option.WithHTTPClient(httpClient))
 
 		client := openai.NewClient(clientOptions...)
@@ -119,23 +111,17 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 	} else {
 		// When using a Gateway targeting a Docker domain, tokens are short-lived.
 		// Only require and inject the Docker JWT if the gateway is a .docker.com URL.
-		if environment.IsTrustedDockerURL(gateway) {
-			// Fail fast if Docker Desktop's auth token isn't available
-			if token, _ := env.Get(ctx, environment.DockerDesktopTokenEnv); token == "" {
-				slog.ErrorContext(ctx, "OpenAI client creation failed", "error", "failed to get Docker Desktop's authentication token")
-				return nil, errors.New("sorry, you first need to sign in Docker Desktop to use the Docker AI Gateway")
-			}
+		if err := base.VerifyDockerGatewayAuth(ctx, env, gateway); err != nil {
+			slog.ErrorContext(ctx, "OpenAI client creation failed", "error", "failed to get Docker Desktop's authentication token")
+			return nil, err
 		}
 
 		// When using a Gateway, tokens are short-lived.
 		clientFn = func(ctx context.Context) (*openai.Client, error) {
-			var authToken string
-			if environment.IsTrustedDockerURL(gateway) {
-				// Query a fresh auth token each time the client is used
-				authToken, _ = env.Get(ctx, environment.DockerDesktopTokenEnv)
-				if authToken == "" {
-					return nil, errors.New(base.NoDesktopTokenErrorMessage)
-				}
+			// Query a fresh auth token each time the client is used.
+			authToken, err := base.GatewayAuthToken(ctx, env, gateway)
+			if err != nil {
+				return nil, err
 			}
 
 			url, err := url.Parse(gateway)
@@ -145,25 +131,10 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 			baseURL := fmt.Sprintf("%s://%s%s/v1/", url.Scheme, url.Host, url.Path)
 
 			// Configure a custom HTTP client to inject headers and query params used by the Gateway.
-			httpOptions := []httpclient.Opt{
-				httpclient.WithProxiedBaseURL(cmp.Or(cfg.BaseURL, "https://api.openai.com/v1")),
-				httpclient.WithProvider(cfg.Provider),
-				httpclient.WithModel(cfg.Model),
-				httpclient.WithModelName(cfg.Name),
-				httpclient.WithQuery(url.Query()),
-			}
-			if globalOptions.GeneratingTitle() {
-				httpOptions = append(httpOptions, httpclient.WithHeader("X-Cagent-GeneratingTitle", "1"))
-			}
+			httpOptions := base.GatewayHTTPOptions(url, "https://api.openai.com/v1", cfg, globalOptions.GeneratingTitle())
 
 			gatewayHTTPClient := httpclient.NewHTTPClient(ctx, httpOptions...)
-			if w := globalOptions.TransportWrapper(); w != nil {
-				if wrapped := w(gatewayHTTPClient.Transport); wrapped != nil {
-					gatewayHTTPClient.Transport = wrapped
-				} else {
-					slog.WarnContext(ctx, "HTTP transport wrapper returned nil; using original transport")
-				}
-			}
+			globalOptions.WrapTransport(ctx, gatewayHTTPClient)
 			clientOptions := []option.RequestOption{
 				option.WithBaseURL(baseURL),
 				option.WithHTTPClient(gatewayHTTPClient),
@@ -323,7 +294,7 @@ func (c *Client) CreateChatCompletionStream(
 		return nil, errors.New("at least one message is required")
 	}
 
-	trackUsage := c.ModelConfig.TrackUsage == nil || *c.ModelConfig.TrackUsage
+	trackUsage := c.TrackUsageEnabled()
 
 	params := openai.ChatCompletionNewParams{
 		Model:    c.ModelConfig.Model,
@@ -601,7 +572,7 @@ func (c *Client) CreateResponseStream(
 	// dials raw TCP and never calls http.RoundTripper, so the wrapper cannot intercept those
 	// connections. Fall back to SSE so the wrapper applies to all requests.
 	transport := getTransport(&c.ModelConfig)
-	trackUsage := c.ModelConfig.TrackUsage == nil || *c.ModelConfig.TrackUsage
+	trackUsage := c.TrackUsageEnabled()
 
 	switch {
 	case transport == "websocket" && c.ModelOptions.Gateway() == "" && c.ModelOptions.TransportWrapper() == nil:
@@ -1112,7 +1083,7 @@ func (c *Client) Rerank(ctx context.Context, query string, documents []types.Doc
 		return nil, err
 	}
 
-	scores, err := parseRerankScores(raw, len(documents))
+	scores, err := providerutil.ParseRerankScores(raw, len(documents))
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to parse OpenAI rerank scores", "error", err)
 		return nil, err
@@ -1165,42 +1136,6 @@ func extractOpenAIContentAsString(msg openai.ChatCompletionMessage) (string, err
 	default:
 		return "", fmt.Errorf("unsupported OpenAI content JSON type %T", v)
 	}
-}
-
-// parseRerankScores parses a JSON payload of the form {"scores":[...]} and validates length.
-func parseRerankScores(raw string, expected int) ([]float64, error) {
-	type rerankResponse struct {
-		Scores []float64 `json:"scores"`
-	}
-
-	raw = strings.TrimSpace(raw)
-
-	tryParse := func(s string) ([]float64, error) {
-		var rr rerankResponse
-		if err := json.Unmarshal([]byte(s), &rr); err != nil {
-			return nil, err
-		}
-		if len(rr.Scores) != expected {
-			return nil, fmt.Errorf("expected %d scores, got %d", expected, len(rr.Scores))
-		}
-		return rr.Scores, nil
-	}
-
-	// First attempt: parse whole string as JSON.
-	if scores, err := tryParse(raw); err == nil {
-		return scores, nil
-	}
-
-	// Fallback: extract the first {...} block and try again, in case the model added prose.
-	start := strings.Index(raw, "{")
-	end := strings.LastIndex(raw, "}")
-	if start >= 0 && end > start {
-		if scores, err := tryParse(raw[start : end+1]); err == nil {
-			return scores, nil
-		}
-	}
-
-	return nil, fmt.Errorf("invalid rerank JSON: %s", raw)
 }
 
 // getAPIType extracts the api_type from ProviderOpts if present.

--- a/pkg/model/provider/options/apply_test.go
+++ b/pkg/model/provider/options/apply_test.go
@@ -1,0 +1,77 @@
+package options
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApply(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty yields zero options", func(t *testing.T) {
+		t.Parallel()
+		m := Apply()
+		assert.Empty(t, m.Gateway())
+		assert.False(t, m.GeneratingTitle())
+	})
+
+	t.Run("applies opts in order", func(t *testing.T) {
+		t.Parallel()
+		m := Apply(WithGateway("first"), WithGateway("second"), WithMaxTokens(42))
+		assert.Equal(t, "second", m.Gateway())
+		assert.Equal(t, int64(42), m.MaxTokens())
+	})
+
+	t.Run("skips nil opts", func(t *testing.T) {
+		t.Parallel()
+		m := Apply(nil, WithGateway("gw"))
+		assert.Equal(t, "gw", m.Gateway())
+	})
+}
+
+type staticTransport struct{ base http.RoundTripper }
+
+func (s *staticTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return s.base.RoundTrip(req)
+}
+
+func TestWrapTransport(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no wrapper keeps transport", func(t *testing.T) {
+		t.Parallel()
+		client := &http.Client{Transport: http.DefaultTransport}
+		m := Apply()
+		m.WrapTransport(t.Context(), client)
+		assert.Same(t, http.DefaultTransport, client.Transport)
+	})
+
+	t.Run("wrapper replaces transport and receives the original", func(t *testing.T) {
+		t.Parallel()
+		client := &http.Client{Transport: http.DefaultTransport}
+		m := Apply(WithHTTPTransportWrapper(func(base http.RoundTripper) http.RoundTripper {
+			return &staticTransport{base: base}
+		}))
+		m.WrapTransport(t.Context(), client)
+		wrapped, ok := client.Transport.(*staticTransport)
+		require.True(t, ok)
+		assert.Same(t, http.DefaultTransport, wrapped.base)
+	})
+
+	t.Run("nil-returning wrapper keeps original transport", func(t *testing.T) {
+		t.Parallel()
+		client := &http.Client{Transport: http.DefaultTransport}
+		m := Apply(WithHTTPTransportWrapper(func(http.RoundTripper) http.RoundTripper { return nil }))
+		m.WrapTransport(t.Context(), client)
+		assert.Same(t, http.DefaultTransport, client.Transport)
+	})
+
+	t.Run("nil client is a no-op", func(t *testing.T) {
+		t.Parallel()
+		m := Apply(WithHTTPTransportWrapper(func(base http.RoundTripper) http.RoundTripper { return base }))
+		assert.NotPanics(t, func() { m.WrapTransport(t.Context(), nil) })
+	})
+}

--- a/pkg/model/provider/options/options.go
+++ b/pkg/model/provider/options/options.go
@@ -1,6 +1,8 @@
 package options
 
 import (
+	"context"
+	"log/slog"
 	"net/http"
 
 	"github.com/docker/docker-agent/pkg/config/latest"
@@ -52,7 +54,36 @@ func (c *ModelOptions) TransportWrapper() func(http.RoundTripper) http.RoundTrip
 	return c.transportWrapper
 }
 
+// WrapTransport applies the registered transport wrapper (if any) to client's
+// transport in place. A wrapper that returns nil is treated as a no-op and the
+// original transport is kept (with a warning). No-op when client is nil or no
+// wrapper is registered.
+func (c *ModelOptions) WrapTransport(ctx context.Context, client *http.Client) {
+	w := c.transportWrapper
+	if w == nil || client == nil {
+		return
+	}
+	if wrapped := w(client.Transport); wrapped != nil {
+		client.Transport = wrapped
+	} else {
+		slog.WarnContext(ctx, "HTTP transport wrapper returned nil; using original transport")
+	}
+}
+
 type Opt func(*ModelOptions)
+
+// Apply builds a ModelOptions from a list of Opts, skipping nil entries.
+// It centralises the accumulation loop that every provider constructor
+// otherwise repeats.
+func Apply(opts ...Opt) ModelOptions {
+	var m ModelOptions
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&m)
+		}
+	}
+	return m
+}
 
 func WithGateway(gateway string) Opt {
 	return func(cfg *ModelOptions) {

--- a/pkg/model/provider/providerutil/rerank.go
+++ b/pkg/model/provider/providerutil/rerank.go
@@ -1,0 +1,50 @@
+package providerutil
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// ParseRerankScores parses a JSON payload of the form {"scores":[...]} and
+// validates that it holds exactly expected scores. If the whole payload is
+// not valid JSON (e.g. the model added prose around it), the first {...}
+// block is extracted and parsed as a fallback. A payload that parses but
+// carries the wrong number of scores fails with a count-specific error.
+func ParseRerankScores(raw string, expected int) ([]float64, error) {
+	type rerankResponse struct {
+		Scores []float64 `json:"scores"`
+	}
+
+	raw = strings.TrimSpace(raw)
+
+	tryParse := func(s string) ([]float64, bool) {
+		var rr rerankResponse
+		if err := json.Unmarshal([]byte(s), &rr); err != nil {
+			return nil, false
+		}
+		return rr.Scores, true
+	}
+	validate := func(scores []float64) ([]float64, error) {
+		if len(scores) != expected {
+			return nil, fmt.Errorf("expected %d scores, got %d", expected, len(scores))
+		}
+		return scores, nil
+	}
+
+	// First attempt: parse whole string as JSON.
+	if scores, ok := tryParse(raw); ok {
+		return validate(scores)
+	}
+
+	// Fallback: extract the first {...} block and try again, in case the model added prose.
+	start := strings.Index(raw, "{")
+	end := strings.LastIndex(raw, "}")
+	if start >= 0 && end > start {
+		if scores, ok := tryParse(raw[start : end+1]); ok {
+			return validate(scores)
+		}
+	}
+
+	return nil, fmt.Errorf("invalid rerank JSON: %s", raw)
+}

--- a/pkg/model/provider/providerutil/rerank_test.go
+++ b/pkg/model/provider/providerutil/rerank_test.go
@@ -1,0 +1,51 @@
+package providerutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRerankScores(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid JSON", func(t *testing.T) {
+		t.Parallel()
+		scores, err := ParseRerankScores(`{"scores":[0.9,0.1,0.5]}`, 3)
+		require.NoError(t, err)
+		assert.Equal(t, []float64{0.9, 0.1, 0.5}, scores)
+	})
+
+	t.Run("surrounding whitespace", func(t *testing.T) {
+		t.Parallel()
+		scores, err := ParseRerankScores("  \n{\"scores\":[1]}\n ", 1)
+		require.NoError(t, err)
+		assert.Equal(t, []float64{1}, scores)
+	})
+
+	t.Run("JSON embedded in prose", func(t *testing.T) {
+		t.Parallel()
+		scores, err := ParseRerankScores(`Here are the scores: {"scores":[0.3,0.7]} hope that helps`, 2)
+		require.NoError(t, err)
+		assert.Equal(t, []float64{0.3, 0.7}, scores)
+	})
+
+	t.Run("wrong score count", func(t *testing.T) {
+		t.Parallel()
+		_, err := ParseRerankScores(`{"scores":[0.9]}`, 2)
+		assert.EqualError(t, err, "expected 2 scores, got 1")
+	})
+
+	t.Run("wrong score count in prose-embedded JSON", func(t *testing.T) {
+		t.Parallel()
+		_, err := ParseRerankScores(`scores below: {"scores":[0.9]}`, 2)
+		assert.EqualError(t, err, "expected 2 scores, got 1")
+	})
+
+	t.Run("invalid payload", func(t *testing.T) {
+		t.Parallel()
+		_, err := ParseRerankScores("not json at all", 1)
+		assert.ErrorContains(t, err, "invalid rerank JSON")
+	})
+}


### PR DESCRIPTION
The five provider clients (openai, anthropic, gemini, bedrock, dmr) each
contained several identical blocks of setup code, making every new provider a
copy-paste exercise and any cross-cutting fix a multi-file hunt. This PR
extracts those repeated patterns into shared helpers with no observable
behavior change.

Six kinds of duplication were collapsed: the option-accumulation loop that all
constructors and factories ran (`options.Apply`); the HTTP transport-wrapping
block repeated in seven places (`options.ModelOptions.WrapTransport`); the
`track_usage` flag check present at seven call sites (`base.Config.TrackUsageEnabled`);
the Docker AI Gateway fail-fast and per-request short-lived token fetch that
appeared in six constructors (`base.VerifyDockerGatewayAuth` and
`base.GatewayAuthToken`); the gateway `httpclient` option list copied three
times (`base.GatewayHTTPOptions`); and the rerank-score JSON parser that was
byte-identical in openai and anthropic (`providerutil.ParseRerankScores`). One
small behavior improvement is folded in: `ParseRerankScores` now returns
"expected N scores, got M" when the JSON is valid but the score count is wrong,
instead of the generic "invalid rerank JSON" error. All other error strings,
log lines, and side-effect timing are preserved exactly — the per-request token
fetch still happens inside its gateway closure.

New unit tests cover every extracted helper directly, and the full test suite,
linter, race detector, and `GOOS=js GOARCH=wasm` build all pass.