### PR TITLE
test: make the test suite faster and sleep-free

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -83,6 +83,8 @@ linters:
           msg: "do not use os.Chdir() in tests, use t.Chdir()"
         - pattern: fmt\.Print.*()
           msg: "do not use fmt.Print() or fmt.Println() in tests"
+        - pattern: time\.Sleep
+          msg: "do not sleep in tests: synchronize on channels/require.Eventually, or use fake time in a synctest bubble (nolint with a reason)"
     depguard:
       rules:
         internal:

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -501,12 +500,13 @@ func TestAgentWarningsConcurrentAccess(t *testing.T) {
 	const drainers = 4
 	const perWriter = 200
 
-	var wg sync.WaitGroup
-	wg.Add(writers + drainers)
+	var writersWg, drainersWg sync.WaitGroup
+	writersWg.Add(writers)
+	drainersWg.Add(drainers)
 
 	for range writers {
 		go func() {
-			defer wg.Done()
+			defer writersWg.Done()
 			for range perWriter {
 				a.AddToolWarning("boom")
 			}
@@ -516,7 +516,7 @@ func TestAgentWarningsConcurrentAccess(t *testing.T) {
 	stop := make(chan struct{})
 	for range drainers {
 		go func() {
-			defer wg.Done()
+			defer drainersWg.Done()
 			for {
 				select {
 				case <-stop:
@@ -530,10 +530,10 @@ func TestAgentWarningsConcurrentAccess(t *testing.T) {
 		}()
 	}
 
-	// Give writers a little time to finish, then signal drainers to stop.
-	time.Sleep(20 * time.Millisecond)
+	// Keep drainers racing until every writer has finished, then stop them.
+	writersWg.Wait()
 	close(stop)
-	wg.Wait()
+	drainersWg.Wait()
 
 	// A successful run means no data race and no panic; we don't assert a
 	// specific number of warnings drained because drainers run concurrently

--- a/pkg/fsx/collect_cancellation_test.go
+++ b/pkg/fsx/collect_cancellation_test.go
@@ -41,8 +41,8 @@ func TestCollectFiles_ContextCancellation(t *testing.T) {
 		ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
 		defer cancel()
 
-		// Give time for timeout to trigger
-		time.Sleep(10 * time.Millisecond)
+		// Wait for the timeout to trigger
+		<-ctx.Done()
 
 		_, err := CollectFiles(ctx, []string{tmpDir}, nil)
 		assert.ErrorIs(t, err, context.DeadlineExceeded)
@@ -78,8 +78,8 @@ func TestDirectoryTree_ContextCancellation(t *testing.T) {
 		ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
 		defer cancel()
 
-		// Give time for timeout to trigger
-		time.Sleep(10 * time.Millisecond)
+		// Wait for the timeout to trigger
+		<-ctx.Done()
 
 		_, err := DirectoryTree(ctx, tmpDir, func(string) error { return nil }, nil, 0)
 		assert.ErrorIs(t, err, context.DeadlineExceeded)

--- a/pkg/hooks/builtins/http_post_test.go
+++ b/pkg/hooks/builtins/http_post_test.go
@@ -147,12 +147,14 @@ func TestHTTPPostRejectsNonHTTPSchemes(t *testing.T) {
 func TestHTTPPostHonoursContextCancellation(t *testing.T) {
 	t.Parallel()
 
-	// Bounded sleep so the client must abandon before the response,
-	// while keeping httptest.Server.Close() cleanup quick.
-	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
-		time.Sleep(300 * time.Millisecond)
+	// Hold the response hostage until the test releases it, so the
+	// client's ctx timeout is what ends the request.
+	done := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		<-done
 	}))
 	t.Cleanup(srv.Close)
+	t.Cleanup(func() { close(done) })
 
 	fn := lookup(t, builtins.HTTPPost)
 

--- a/pkg/memoize/memoize_test.go
+++ b/pkg/memoize/memoize_test.go
@@ -118,11 +118,21 @@ func TestMemoizeExpires(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, v)
 
-	time.Sleep(20 * time.Millisecond)
+	expireEntry(m, "key")
 
 	v, err = m.Memoize("key", compute)
 	require.NoError(t, err)
 	assert.Equal(t, 2, v)
+}
+
+// expireEntry backdates the cached entry for key so it is already expired,
+// which lets TTL tests run without sleeping.
+func expireEntry[T any](m *Memoizer[T], key string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	e := m.entries[key]
+	e.expires = time.Now().Add(-time.Nanosecond)
+	m.entries[key] = e
 }
 
 // TestMemoizeZeroTTLNeverExpires verifies the go-cache compatible behavior that
@@ -142,8 +152,6 @@ func TestMemoizeZeroTTLNeverExpires(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 7, v)
 
-		time.Sleep(5 * time.Millisecond)
-
 		v, err = m.Memoize("key", compute)
 		require.NoError(t, err)
 		assert.Equal(t, 7, v)
@@ -161,7 +169,7 @@ func TestMemoizeEvictsExpiredEntry(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, m.entries, 1)
 
-	time.Sleep(10 * time.Millisecond)
+	expireEntry(m, "key")
 
 	_, ok := m.load("key")
 	assert.False(t, ok)
@@ -206,12 +214,18 @@ func TestMemoizeConcurrentSingleFlight(t *testing.T) {
 
 	var calls atomic.Int32
 
+	// Hold the in-flight compute open until every caller has launched, so
+	// they all pile onto the same flight (or hit the cache afterwards).
+	var started sync.WaitGroup
+	started.Add(50)
+
 	var wg sync.WaitGroup
 	for range 50 {
 		wg.Go(func() {
+			started.Done()
 			v, err := m.Memoize("key", func() (int, error) {
 				calls.Add(1)
-				time.Sleep(20 * time.Millisecond)
+				started.Wait()
 				return 7, nil
 			})
 			require.NoError(t, err)

--- a/pkg/remote/pull_test.go
+++ b/pkg/remote/pull_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/crane"
@@ -165,7 +166,15 @@ func (reg *testRegistry) start(t *testing.T) *httptest.Server {
 func newTestSession(t *testing.T, opts ...crane.Option) *session {
 	t.Helper()
 	opts = append(opts, crane.Insecure)
-	s, err := newSession(crane.GetOptions(opts...))
+	o := crane.GetOptions(opts...)
+	// Keep the default retry count but drop the default backoff (1s+3s
+	// sleeps): the 429 rate-limit test otherwise idles for ~4s.
+	o.Remote = append(o.Remote, v1remote.WithRetryBackoff(v1remote.Backoff{
+		Duration: time.Millisecond,
+		Factor:   1,
+		Steps:    3,
+	}))
+	s, err := newSession(o)
 	require.NoError(t, err)
 	return s
 }

--- a/pkg/runtime/client_test.go
+++ b/pkg/runtime/client_test.go
@@ -23,8 +23,10 @@ func TestClient_StreamSessionEvents_DeliversMultipleEvents(t *testing.T) {
 
 	// proceed gates each subsequent event on the client having consumed
 	// the previous one, guaranteeing the events arrive in separate reads
-	// (the one-shot-read regression) without timing dependence.
-	proceed := make(chan struct{})
+	// (the one-shot-read regression) without timing dependence. Buffered
+	// so a failing run leaves the reader loop unblocked instead of
+	// deadlocking the test.
+	proceed := make(chan struct{}, 3)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)

--- a/pkg/runtime/client_test.go
+++ b/pkg/runtime/client_test.go
@@ -21,6 +21,10 @@ import (
 func TestClient_StreamSessionEvents_DeliversMultipleEvents(t *testing.T) {
 	t.Parallel()
 
+	// proceed gates each subsequent event on the client having consumed
+	// the previous one, guaranteeing the events arrive in separate reads
+	// (the one-shot-read regression) without timing dependence.
+	proceed := make(chan struct{})
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
@@ -31,12 +35,17 @@ func TestClient_StreamSessionEvents_DeliversMultipleEvents(t *testing.T) {
 		}
 
 		for i := 1; i <= 3; i++ {
+			if i > 1 {
+				if _, ok := <-proceed; !ok {
+					return
+				}
+			}
 			fmt.Fprintf(w, "data: {\"type\":\"session_title\",\"session_id\":\"s\",\"title\":\"t%d\"}\n\n", i)
 			flusher.Flush()
-			time.Sleep(20 * time.Millisecond)
 		}
 	}))
 	t.Cleanup(srv.Close)
+	t.Cleanup(func() { close(proceed) })
 
 	c, err := NewClient(srv.URL)
 	require.NoError(t, err)
@@ -51,6 +60,9 @@ func TestClient_StreamSessionEvents_DeliversMultipleEvents(t *testing.T) {
 			continue
 		}
 		titles = append(titles, titleEv.Title)
+		if len(titles) < 3 {
+			proceed <- struct{}{}
+		}
 	}
 
 	assert.Equal(t, []string{"t1", "t2", "t3"}, titles)

--- a/pkg/runtime/elicitation_test.go
+++ b/pkg/runtime/elicitation_test.go
@@ -118,13 +118,9 @@ func TestElicitationBridge_RestoreAndCloseWaitsForInflightSenders(t *testing.T) 
 		close(closed)
 	}()
 
-	// Sanity check (never false-positive): teardown cannot have completed
-	// while the sender still holds the read lock across its parked send.
-	select {
-	case <-closed:
-		t.Fatal("channel closed while a send was still in flight")
-	default:
-	}
+	// The teardown ordering itself is verified below: the parked send must
+	// complete without a send-on-closed-channel panic, which is only
+	// possible if restoreAndClose waited for the read lock.
 
 	select {
 	case ev := <-current:

--- a/pkg/runtime/elicitation_test.go
+++ b/pkg/runtime/elicitation_test.go
@@ -95,16 +95,22 @@ func TestElicitationBridge_RestoreAndCloseWaitsForInflightSenders(t *testing.T) 
 	parent := make(chan Event, 1)
 	b.swap(current)
 
-	sendStarted := make(chan struct{})
 	sendDone := make(chan error, 1)
 	go func() {
-		close(sendStarted)
 		sendDone <- b.send(Error("inflight"))
 	}()
-	<-sendStarted
 
-	// Give the sender a moment to grab the RLock and park on the channel.
-	time.Sleep(20 * time.Millisecond)
+	// Wait until the sender holds the read lock: TryLock fails only while
+	// another lock is held, and the sender is the only other lock user.
+	// From that point on, restoreAndClose's write lock (and therefore the
+	// close) cannot possibly precede the parked send.
+	require.Eventually(t, func() bool {
+		if b.mu.TryLock() {
+			b.mu.Unlock()
+			return false
+		}
+		return true
+	}, time.Second, time.Microsecond, "sender never acquired the read lock")
 
 	closed := make(chan struct{})
 	go func() {
@@ -112,10 +118,12 @@ func TestElicitationBridge_RestoreAndCloseWaitsForInflightSenders(t *testing.T) 
 		close(closed)
 	}()
 
+	// Sanity check (never false-positive): teardown cannot have completed
+	// while the sender still holds the read lock across its parked send.
 	select {
 	case <-closed:
 		t.Fatal("channel closed while a send was still in flight")
-	case <-time.After(50 * time.Millisecond):
+	default:
 	}
 
 	select {

--- a/pkg/runtime/fallback_test.go
+++ b/pkg/runtime/fallback_test.go
@@ -346,6 +346,10 @@ func TestFallbackCooldownState(t *testing.T) {
 		// Initially no cooldown
 		assert.Nil(t, rt.fallback.cooldowns.Get(agentName), "should have no cooldown initially")
 
+		// Fake clock so cooldown expiry needs no sleeping.
+		current := time.Now()
+		rt.fallback.cooldowns.now = func() time.Time { return current }
+
 		// Set cooldown with short duration for testing
 		rt.fallback.cooldowns.Set(agentName, 0, 100*time.Millisecond)
 		state := rt.fallback.cooldowns.Get(agentName)
@@ -353,7 +357,7 @@ func TestFallbackCooldownState(t *testing.T) {
 		assert.Equal(t, 0, state.fallbackIndex)
 
 		// Advance fake time past the cooldown
-		time.Sleep(101 * time.Millisecond)
+		current = current.Add(101 * time.Millisecond)
 		assert.Nil(t, rt.fallback.cooldowns.Get(agentName), "cooldown should have expired")
 
 		// Set cooldown again and then clear it

--- a/pkg/runtime/gateway_models_test.go
+++ b/pkg/runtime/gateway_models_test.go
@@ -316,18 +316,23 @@ func TestListGatewayModels_ConcurrentCallersCoalesce(t *testing.T) {
 	const callers = 8
 	var wg sync.WaitGroup
 	results := make([][]string, callers)
-	for i := range callers {
+
+	// First caller triggers the fetch; the handler parks it on release.
+	wg.Go(func() {
+		results[0], _ = r.listGatewayModels(t.Context())
+	})
+	require.Eventually(t, func() bool { return requests.Load() >= 1 },
+		time.Second, time.Millisecond, "fetch never reached the gateway")
+
+	// The remaining callers start while the fetch is provably in flight,
+	// so they must coalesce onto it (or read the cache once it lands). A
+	// non-coalescing implementation would issue its own gateway requests
+	// and trip the assertion below.
+	for i := 1; i < callers; i++ {
 		wg.Go(func() {
 			results[i], _ = r.listGatewayModels(t.Context())
 		})
 	}
-
-	// Once the fetch is in flight (the handler is blocked on release),
-	// every other caller must coalesce onto it or hit the cache; a
-	// non-coalescing bug would show up as extra blocked requests either
-	// way, since the handler holds all of them until release.
-	require.Eventually(t, func() bool { return requests.Load() >= 1 },
-		time.Second, time.Millisecond, "fetch never reached the gateway")
 	close(release)
 	wg.Wait()
 

--- a/pkg/runtime/gateway_models_test.go
+++ b/pkg/runtime/gateway_models_test.go
@@ -322,9 +322,12 @@ func TestListGatewayModels_ConcurrentCallersCoalesce(t *testing.T) {
 		})
 	}
 
-	// Let all goroutines reach the fetch, then release the single
-	// in-flight request they should all be coalesced onto.
-	time.Sleep(100 * time.Millisecond)
+	// Once the fetch is in flight (the handler is blocked on release),
+	// every other caller must coalesce onto it or hit the cache; a
+	// non-coalescing bug would show up as extra blocked requests either
+	// way, since the handler holds all of them until release.
+	require.Eventually(t, func() bool { return requests.Load() >= 1 },
+		time.Second, time.Millisecond, "fetch never reached the gateway")
 	close(release)
 	wg.Wait()
 

--- a/pkg/runtime/pause_test.go
+++ b/pkg/runtime/pause_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -124,33 +125,27 @@ func TestWaitIfPaused_ContextCancellation(t *testing.T) {
 func TestWaitIfPaused_BroadcastsToAllWaiters(t *testing.T) {
 	t.Parallel()
 
-	r := &LocalRuntime{}
-	_, _ = r.TogglePause(t.Context())
+	synctest.Test(t, func(t *testing.T) {
+		r := &LocalRuntime{}
+		_, _ = r.TogglePause(t.Context())
 
-	const n = 8
-	var wg sync.WaitGroup
-	for range n {
-		wg.Go(func() {
-			_ = r.waitIfPaused(t.Context())
-		})
-	}
+		const n = 8
+		var wg sync.WaitGroup
+		for range n {
+			wg.Go(func() {
+				_ = r.waitIfPaused(t.Context())
+			})
+		}
 
-	// No need to wait for the goroutines to park: whether a waiter is
-	// already blocked on the pause channel or observes the resume later,
-	// only a close-based broadcast lets all n of them return.
-	_, _ = r.TogglePause(t.Context()) // single resume should wake all waiters
+		// All n waiters are durably parked on the pause channel now.
+		synctest.Wait()
 
-	doneAll := make(chan struct{})
-	go func() {
+		_, _ = r.TogglePause(t.Context()) // single resume must wake all waiters
+
+		// A partial wake-up leaves waiters parked forever, which synctest
+		// reports as a deadlock instead of hanging the suite.
 		wg.Wait()
-		close(doneAll)
-	}()
-
-	select {
-	case <-doneAll:
-	case <-time.After(time.Second):
-		t.Fatal("not all waiters woke up after a single resume")
-	}
+	})
 }
 
 // TestTogglePause_RaceFreeUnderConcurrentCallers exercises concurrent

--- a/pkg/runtime/pause_test.go
+++ b/pkg/runtime/pause_test.go
@@ -135,8 +135,9 @@ func TestWaitIfPaused_BroadcastsToAllWaiters(t *testing.T) {
 		})
 	}
 
-	// Give them a moment to all enter waitIfPaused.
-	time.Sleep(50 * time.Millisecond)
+	// No need to wait for the goroutines to park: whether a waiter is
+	// already blocked on the pause channel or observes the resume later,
+	// only a close-based broadcast lets all n of them return.
 	_, _ = r.TogglePause(t.Context()) // single resume should wake all waiters
 
 	doneAll := make(chan struct{})

--- a/pkg/runtime/streaming_test.go
+++ b/pkg/runtime/streaming_test.go
@@ -196,17 +196,25 @@ func TestHandleStream_WhitespaceOnlyContentStops(t *testing.T) {
 type stalledStream struct {
 	// unblock is closed to release a blocked Recv call.
 	unblock chan struct{}
+	// recvStarted is closed once the first Recv call is in flight, so
+	// tests can cancel a context while Recv is provably blocked.
+	recvStarted chan struct{}
+	recvOnce    sync.Once
 	// closeOnce guards unblock so Close is safe to call concurrently from
 	// both the test goroutine and handleStream's deferred Close.
 	closeOnce sync.Once
 }
 
 func newStalledStream() *stalledStream {
-	return &stalledStream{unblock: make(chan struct{})}
+	return &stalledStream{
+		unblock:     make(chan struct{}),
+		recvStarted: make(chan struct{}),
+	}
 }
 
 // Recv blocks until unblock is closed, then returns io.EOF.
 func (s *stalledStream) Recv() (chat.MessageStreamResponse, error) {
+	s.recvOnce.Do(func() { close(s.recvStarted) })
 	<-s.unblock
 	return chat.MessageStreamResponse{}, io.EOF
 }
@@ -256,9 +264,9 @@ func TestHandleStream_ContextCancellation(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(t.Context())
 
-	// Cancel the context shortly after handleStream starts.
+	// Cancel the context once handleStream is provably blocked in Recv.
 	go func() {
-		time.Sleep(20 * time.Millisecond)
+		<-stream.recvStarted
 		cancel()
 		stream.Close() // unblock the stalled Recv so the reader goroutine can exit
 	}()

--- a/pkg/server/server_attached_test.go
+++ b/pkg/server/server_attached_test.go
@@ -312,7 +312,8 @@ func TestAttachedServer_DeleteWithWaitBlocksUntilStreamStops(t *testing.T) {
 	require.NoError(t, store.AddSession(ctx, sess))
 
 	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
-	// The stream stays open until DELETE cancels the session context.
+	// The fake stream is held open by release (DELETE cancels the attach
+	// context, not the stream context), so the test controls when it ends.
 	fake := &fakeRuntime{release: make(chan struct{})}
 	sm.AttachRuntime(t.Context(), sess.ID, fake, sess)
 

--- a/pkg/server/server_attached_test.go
+++ b/pkg/server/server_attached_test.go
@@ -312,7 +312,8 @@ func TestAttachedServer_DeleteWithWaitBlocksUntilStreamStops(t *testing.T) {
 	require.NoError(t, store.AddSession(ctx, sess))
 
 	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
-	fake := &fakeRuntime{streamDelay: 200 * time.Millisecond}
+	// The stream stays open until DELETE cancels the session context.
+	fake := &fakeRuntime{release: make(chan struct{})}
 	sm.AttachRuntime(t.Context(), sess.ID, fake, sess)
 
 	srv := NewWithManager(sm, "")
@@ -327,8 +328,49 @@ func TestAttachedServer_DeleteWithWaitBlocksUntilStreamStops(t *testing.T) {
 	ch, err := sm.RunSession(ctx, sess.ID, "agent", "root", []api.Message{{Content: "hello"}}, "")
 	require.NoError(t, err)
 
-	// DELETE with wait should block until stream finishes (200ms).
-	resp := httpDoTCP(t, ctx, http.MethodDelete, addr+"/api/sessions/"+sess.ID+"?wait=true&timeout=5s", nil)
+	// Fire DELETE with wait; it must not respond until the stream exits.
+	// Plain http here: assertions must stay on the test goroutine.
+	respCh := make(chan []byte, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		req, err := http.NewRequestWithContext(ctx, http.MethodDelete, addr+"/api/sessions/"+sess.ID+"?wait=true&timeout=5s", http.NoBody)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		defer resp.Body.Close()
+		out, err := io.ReadAll(resp.Body)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		respCh <- out
+	}()
+
+	// Once the session is deregistered, the DELETE is parked in WaitStopped.
+	require.Eventually(t, func() bool {
+		_, ok := sm.runtimeSessions.Load(sess.ID)
+		return !ok
+	}, 2*time.Second, time.Millisecond)
+	select {
+	case <-respCh:
+		t.Fatal("DELETE returned before the stream goroutine exited")
+	default:
+	}
+
+	// Let the stream finish; the DELETE response must follow.
+	close(fake.release)
+	var resp []byte
+	select {
+	case resp = <-respCh:
+	case err := <-errCh:
+		t.Fatalf("DELETE failed: %v", err)
+	}
 	assert.Contains(t, string(resp), "deleted")
 
 	// Stream channel should be drained by now.
@@ -560,11 +602,11 @@ func TestAttachedServer_DeleteEmitsSessionExited(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	// Give the SSE handler a moment to register, then delete the session.
+	// Wait for the SSE handler to register, then delete the session; the
+	// event log replays missed events, so ordering past this point is safe.
 	require.Eventually(t, func() bool {
 		return sm.HasEventSource(sess.ID)
 	}, 2*time.Second, time.Millisecond)
-	time.Sleep(50 * time.Millisecond)
 	require.NoError(t, sm.DeleteSession(ctx, sess.ID))
 
 	// The client must receive a terminal session_exited event.
@@ -647,11 +689,10 @@ func TestAttachedServer_StatusWaitBlocksUntilAttached(t *testing.T) {
 	go func() { _ = srv.Serve(ctx, ln) }()
 	addr := "http://" + ln.Addr().String()
 
-	// Attach a little later, while the request is already waiting.
-	go func() {
-		time.Sleep(80 * time.Millisecond)
-		sm.AttachRuntime(t.Context(), sess.ID, &fakeRuntime{}, sess)
-	}()
+	// Attach concurrently: whether the request is already parked in
+	// WaitSessionAttached or the attach lands first, the response must
+	// carry the session.
+	go sm.AttachRuntime(t.Context(), sess.ID, &fakeRuntime{}, sess)
 
 	resp := httpDoTCP(t, ctx, http.MethodGet, addr+"/api/sessions/"+sess.ID+"/status?wait=5s", nil)
 	var status api.SessionStatusResponse

--- a/pkg/server/session_manager_test.go
+++ b/pkg/server/session_manager_test.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,10 +25,12 @@ type fakeRuntime struct {
 
 	concurrentStreams atomic.Int32
 	maxConcurrent     atomic.Int32
-	streamDelay       time.Duration
+	// release, when non-nil, keeps the stream open until it is closed or
+	// the stream context is cancelled; when nil the stream ends at once.
+	release chan struct{}
 }
 
-func (f *fakeRuntime) RunStream(_ context.Context, _ *session.Session) <-chan runtime.Event {
+func (f *fakeRuntime) RunStream(ctx context.Context, _ *session.Session) <-chan runtime.Event {
 	cur := f.concurrentStreams.Add(1)
 	for {
 		old := f.maxConcurrent.Load()
@@ -40,7 +41,12 @@ func (f *fakeRuntime) RunStream(_ context.Context, _ *session.Session) <-chan ru
 
 	ch := make(chan runtime.Event)
 	go func() {
-		time.Sleep(f.streamDelay)
+		if f.release != nil {
+			select {
+			case <-f.release:
+			case <-ctx.Done():
+			}
+		}
 		f.concurrentStreams.Add(-1)
 		close(ch)
 	}()
@@ -103,7 +109,7 @@ func TestAttachRuntime_RegistersRuntimeForExternalDriver(t *testing.T) {
 	require.NoError(t, store.AddSession(ctx, sess))
 
 	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
-	fake := &fakeRuntime{streamDelay: 10 * time.Millisecond}
+	fake := &fakeRuntime{}
 	sm.AttachRuntime(t.Context(), sess.ID, fake, sess)
 
 	// Steer routes through the attached runtime, not a freshly built one.
@@ -118,17 +124,16 @@ func TestRunSession_ConcurrentRequestReturnsErrSessionBusy(t *testing.T) {
 
 	ctx := t.Context()
 	sess := session.New()
-	fake := &fakeRuntime{streamDelay: 500 * time.Millisecond}
+	release := make(chan struct{})
+	fake := &fakeRuntime{release: release}
 	sm := newTestSessionManager(t, sess, fake)
 
-	// Start the first stream.
+	// Start the first stream. RunSession acquires the streaming lock
+	// synchronously, so the session is busy as soon as it returns.
 	ch1, err := sm.RunSession(ctx, sess.ID, "agent", "root", []api.Message{
 		{Content: "first"},
 	}, "")
 	require.NoError(t, err)
-
-	// Give the goroutine a moment to acquire the streaming lock.
-	time.Sleep(50 * time.Millisecond)
 
 	// The second request should fail immediately with ErrSessionBusy.
 	_, err = sm.RunSession(ctx, sess.ID, "agent", "root", []api.Message{
@@ -136,7 +141,8 @@ func TestRunSession_ConcurrentRequestReturnsErrSessionBusy(t *testing.T) {
 	}, "")
 	require.ErrorIs(t, err, ErrSessionBusy)
 
-	// Drain first stream to let it complete.
+	// Let the first stream complete and drain it.
+	close(release)
 	for range ch1 {
 	}
 
@@ -156,15 +162,14 @@ func TestRunSession_MessagesNotAddedWhenBusy(t *testing.T) {
 
 	ctx := t.Context()
 	sess := session.New()
-	fake := &fakeRuntime{streamDelay: 500 * time.Millisecond}
+	release := make(chan struct{})
+	fake := &fakeRuntime{release: release}
 	sm := newTestSessionManager(t, sess, fake)
 
 	ch1, err := sm.RunSession(ctx, sess.ID, "agent", "root", []api.Message{
 		{Content: "first"},
 	}, "")
 	require.NoError(t, err)
-
-	time.Sleep(50 * time.Millisecond)
 
 	msgCountBefore := len(sess.GetAllMessages())
 
@@ -176,6 +181,7 @@ func TestRunSession_MessagesNotAddedWhenBusy(t *testing.T) {
 	// Messages should not have been added.
 	assert.Len(t, sess.GetAllMessages(), msgCountBefore)
 
+	close(release)
 	for range ch1 {
 	}
 }
@@ -187,7 +193,7 @@ func TestRunSession_SequentialRequestsSucceed(t *testing.T) {
 
 	ctx := t.Context()
 	sess := session.New()
-	fake := &fakeRuntime{streamDelay: 10 * time.Millisecond}
+	fake := &fakeRuntime{}
 	sm := newTestSessionManager(t, sess, fake)
 
 	for range 3 {
@@ -209,8 +215,8 @@ func TestRunSession_DifferentSessionsConcurrently(t *testing.T) {
 
 	ctx := t.Context()
 	store := session.NewInMemorySessionStore()
-	fake1 := &fakeRuntime{streamDelay: 200 * time.Millisecond}
-	fake2 := &fakeRuntime{streamDelay: 200 * time.Millisecond}
+	fake1 := &fakeRuntime{}
+	fake2 := &fakeRuntime{}
 
 	sess1 := session.New()
 	sess2 := session.New()

--- a/pkg/server/source_loader_test.go
+++ b/pkg/server/source_loader_test.go
@@ -94,7 +94,7 @@ func TestSourceLoader_Read_WithRefreshInterval_AfterExpiry(t *testing.T) {
 		sl := newSourceLoader(ctx, inner, refreshInterval)
 
 		synctest.Wait()
-		time.Sleep(110 * time.Millisecond)
+		time.Sleep(110 * time.Millisecond) //nolint:forbidigo // fake time inside a synctest bubble; returns instantly
 		synctest.Wait()
 
 		// Read should refresh
@@ -150,7 +150,7 @@ func TestSourceLoader_Read_DataChanges(t *testing.T) {
 		assert.Equal(t, []byte("initial data"), data)
 
 		synctest.Wait()
-		time.Sleep(60 * time.Millisecond)
+		time.Sleep(60 * time.Millisecond) //nolint:forbidigo // fake time inside a synctest bubble; returns instantly
 		synctest.Wait()
 
 		// Read after interval should get updated data from background refresh
@@ -202,7 +202,7 @@ func TestSourceLoader_SuccessThenError(t *testing.T) {
 		inner.setErr(errors.New("refresh error"))
 
 		synctest.Wait()
-		time.Sleep(60 * time.Millisecond)
+		time.Sleep(60 * time.Millisecond) //nolint:forbidigo // fake time inside a synctest bubble; returns instantly
 		synctest.Wait()
 
 		// Should still return old cached data despite refresh error

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -787,6 +787,18 @@ func TestCreateEventTelemetryTags(t *testing.T) {
 	})
 }
 
+// awaitBodies waits for the async Track dispatch to reach the mock HTTP
+// client and returns the captured request bodies.
+func awaitBodies(t *testing.T, mockHTTP *MockHTTPClient) [][]byte {
+	t.Helper()
+	var bodies [][]byte
+	require.Eventually(t, func() bool {
+		bodies = mockHTTP.GetBodies()
+		return len(bodies) > 0
+	}, time.Second, time.Millisecond, "expected the tracked event to be posted")
+	return bodies
+}
+
 func TestTelemetryTags(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
 	mockHTTP := NewMockHTTPClient()
@@ -803,10 +815,7 @@ func TestTelemetryTags(t *testing.T) {
 		client.httpClient = mockHTTP
 
 		client.Track(t.Context(), &CommandEvent{Action: "test", Success: true})
-		time.Sleep(20 * time.Millisecond)
-
-		bodies := mockHTTP.GetBodies()
-		require.NotEmpty(t, bodies)
+		bodies := awaitBodies(t, mockHTTP)
 
 		var requestBody map[string]any
 		require.NoError(t, json.Unmarshal(bodies[0], &requestBody))
@@ -826,10 +835,7 @@ func TestTelemetryTags(t *testing.T) {
 		client.httpClient = mockHTTP
 
 		client.Track(t.Context(), &CommandEvent{Action: "test", Success: true})
-		time.Sleep(20 * time.Millisecond)
-
-		bodies := mockHTTP.GetBodies()
-		require.NotEmpty(t, bodies)
+		bodies := awaitBodies(t, mockHTTP)
 
 		var requestBody map[string]any
 		require.NoError(t, json.Unmarshal(bodies[0], &requestBody))
@@ -848,10 +854,7 @@ func TestTelemetryTags(t *testing.T) {
 		client.httpClient = mockHTTP
 
 		client.Track(t.Context(), &CommandEvent{Action: "test", Success: true})
-		time.Sleep(20 * time.Millisecond)
-
-		bodies := mockHTTP.GetBodies()
-		require.NotEmpty(t, bodies)
+		bodies := awaitBodies(t, mockHTTP)
 
 		var requestBody map[string]any
 		require.NoError(t, json.Unmarshal(bodies[0], &requestBody))
@@ -871,10 +874,7 @@ func TestTelemetryTags(t *testing.T) {
 		client.httpClient = mockHTTP
 
 		client.Track(t.Context(), &CommandEvent{Action: "test", Success: true})
-		time.Sleep(20 * time.Millisecond)
-
-		bodies := mockHTTP.GetBodies()
-		require.NotEmpty(t, bodies)
+		bodies := awaitBodies(t, mockHTTP)
 
 		var requestBody map[string]any
 		require.NoError(t, json.Unmarshal(bodies[0], &requestBody))
@@ -895,10 +895,7 @@ func TestTelemetryTags(t *testing.T) {
 		client.httpClient = mockHTTP
 
 		client.Track(t.Context(), &CommandEvent{Action: "test", Success: true})
-		time.Sleep(20 * time.Millisecond)
-
-		bodies := mockHTTP.GetBodies()
-		require.NotEmpty(t, bodies)
+		bodies := awaitBodies(t, mockHTTP)
 
 		var requestBody map[string]any
 		require.NoError(t, json.Unmarshal(bodies[0], &requestBody))

--- a/pkg/tools/builtin/agent/agent_test.go
+++ b/pkg/tools/builtin/agent/agent_test.go
@@ -396,13 +396,24 @@ func TestStopAll_WaitsForGoroutines(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	tk.cancel = cancel
 
+	// The goroutine only finishes once the test releases it, so StopAll
+	// returning proves it waited rather than raced ahead.
+	release := make(chan struct{})
 	h.wg.Go(func() {
 		<-ctx.Done()
-		time.Sleep(10 * time.Millisecond) // simulate teardown work
+		<-release
 		goroutineExited.Store(true)
 	})
 
-	h.StopAll()
+	stopDone := make(chan struct{})
+	go func() {
+		h.StopAll()
+		close(stopDone)
+	}()
+
+	<-ctx.Done() // StopAll has cancelled the task
+	close(release)
+	<-stopDone
 	assert.True(t, goroutineExited.Load(), "StopAll should wait for goroutine to exit")
 }
 

--- a/pkg/tools/builtin/lsp/lsp_lifecycle_test.go
+++ b/pkg/tools/builtin/lsp/lsp_lifecycle_test.go
@@ -2,7 +2,6 @@ package lsp
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -56,7 +55,4 @@ func TestLSPTool_SupervisorRetryAfterFailure(t *testing.T) {
 	require.Error(t, err)
 	state = tool.handler.supervisor.State()
 	assert.Equal(t, lifecycle.StateStopped, state.State)
-
-	// Allow some time to ensure no goroutine leaked or panicked.
-	time.Sleep(50 * time.Millisecond)
 }

--- a/pkg/tools/builtin/shell/askpass.go
+++ b/pkg/tools/builtin/shell/askpass.go
@@ -82,10 +82,10 @@ type askpassServer struct {
 	// calls (e.g. `sudo a & sudo b`) must not raise two dialogs at once.
 	promptSem chan struct{}
 
-	// promptWaiters counts requests that reached askUser (whether prompting
+	// promptArrivals counts requests that reached askUser (whether prompting
 	// or queued on promptSem). Only used by tests to synchronize on "both
 	// concurrent prompts are in flight" without sleeping.
-	promptWaiters atomic.Int32
+	promptArrivals atomic.Int32
 
 	closeOnce sync.Once
 	closed    chan struct{} // closed by close() to cancel in-flight prompts
@@ -284,7 +284,7 @@ func (s *askpassServer) askUser(ctx context.Context, prompt string) (string, boo
 	if handler == nil {
 		return "", false
 	}
-	s.promptWaiters.Add(1)
+	s.promptArrivals.Add(1)
 
 	// Only one prompt at a time. If a concurrent prompt is already open, wait
 	// for it (unless this request's helper goes away first, ctx cancellation).

--- a/pkg/tools/builtin/shell/askpass.go
+++ b/pkg/tools/builtin/shell/askpass.go
@@ -18,6 +18,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -80,6 +81,11 @@ type askpassServer struct {
 	// runtime elicitation pipe carries a single request, so two concurrent sudo
 	// calls (e.g. `sudo a & sudo b`) must not raise two dialogs at once.
 	promptSem chan struct{}
+
+	// promptWaiters counts requests that reached askUser (whether prompting
+	// or queued on promptSem). Only used by tests to synchronize on "both
+	// concurrent prompts are in flight" without sleeping.
+	promptWaiters atomic.Int32
 
 	closeOnce sync.Once
 	closed    chan struct{} // closed by close() to cancel in-flight prompts
@@ -278,6 +284,7 @@ func (s *askpassServer) askUser(ctx context.Context, prompt string) (string, boo
 	if handler == nil {
 		return "", false
 	}
+	s.promptWaiters.Add(1)
 
 	// Only one prompt at a time. If a concurrent prompt is already open, wait
 	// for it (unless this request's helper goes away first, ctx cancellation).

--- a/pkg/tools/builtin/shell/askpass_test.go
+++ b/pkg/tools/builtin/shell/askpass_test.go
@@ -191,7 +191,7 @@ func TestAskpass_PromptsSerialized(t *testing.T) {
 
 	// Wait until both requests have reached askUser (one prompting, one
 	// queued on promptSem), then let the prompts finish.
-	require.Eventually(t, func() bool { return srv.promptWaiters.Load() == 2 },
+	require.Eventually(t, func() bool { return srv.promptArrivals.Load() == 2 },
 		time.Second, time.Millisecond, "both askpass requests should reach askUser")
 	close(release)
 	wg.Wait()

--- a/pkg/tools/builtin/shell/askpass_test.go
+++ b/pkg/tools/builtin/shell/askpass_test.go
@@ -158,6 +158,7 @@ func TestAskpass_PromptsSerialized(t *testing.T) {
 	}
 
 	var active, maxActive int32
+	release := make(chan struct{})
 	srv, err := startAskpassServer(t.Context(), func() tools.ElicitationHandler {
 		return func(_ context.Context, _ *mcp.ElicitParams) (tools.ElicitationResult, error) {
 			n := atomic.AddInt32(&active, 1)
@@ -167,7 +168,9 @@ func TestAskpass_PromptsSerialized(t *testing.T) {
 					break
 				}
 			}
-			time.Sleep(50 * time.Millisecond)
+			// Hold the prompt open until both requests are in flight, so an
+			// unserialized server would run two handlers concurrently.
+			<-release
 			atomic.AddInt32(&active, -1)
 			return tools.ElicitationResult{Action: tools.ElicitationActionAccept, Content: map[string]any{"password": "pw"}}, nil
 		}
@@ -185,6 +188,12 @@ func TestAskpass_PromptsSerialized(t *testing.T) {
 			assert.NoError(t, RunAskpassClient(t.Context(), "p", &out))
 		})
 	}
+
+	// Wait until both requests have reached askUser (one prompting, one
+	// queued on promptSem), then let the prompts finish.
+	require.Eventually(t, func() bool { return srv.promptWaiters.Load() == 2 },
+		time.Second, time.Millisecond, "both askpass requests should reach askUser")
+	close(release)
 	wg.Wait()
 
 	assert.Equal(t, int32(1), atomic.LoadInt32(&maxActive), "prompts must be serialized to one at a time")

--- a/pkg/tools/builtin/shell/shell_test.go
+++ b/pkg/tools/builtin/shell/shell_test.go
@@ -2,6 +2,7 @@ package shell
 
 import (
 	"encoding/json"
+	"io"
 	"os"
 	"os/exec"
 	"runtime"
@@ -396,9 +397,12 @@ func TestReapSpawnedChild_HandlesAlreadyExited(t *testing.T) {
 	}
 
 	cmd := exec.CommandContext(t.Context(), "/bin/sh", "-c", "exit 0")
+	stdout, err := cmd.StdoutPipe()
+	require.NoError(t, err)
 	require.NoError(t, cmd.Start())
-	// Give the child a moment to exit on its own.
-	time.Sleep(50 * time.Millisecond)
+	// EOF on stdout means the child has exited (its fds are closed on exit).
+	_, err = io.ReadAll(stdout)
+	require.NoError(t, err)
 
 	done := make(chan struct{})
 	go func() {

--- a/pkg/tools/lifecycle/supervisor_test.go
+++ b/pkg/tools/lifecycle/supervisor_test.go
@@ -10,6 +10,7 @@ import (
 
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/poll"
 
 	"github.com/docker/docker-agent/pkg/tools/lifecycle"
 )
@@ -19,6 +20,7 @@ import (
 type fakeSession struct {
 	mu       sync.Mutex
 	closed   bool
+	closedCh chan struct{} // closed once Close has run
 	waitDone atomic.Bool   // set true after Wait returns
 	waiting  chan struct{} // closed once Wait has parked on failCh
 	waitOnce sync.Once
@@ -27,8 +29,9 @@ type fakeSession struct {
 
 func newFakeSession() *fakeSession {
 	return &fakeSession{
-		waiting: make(chan struct{}),
-		failCh:  make(chan error, 1),
+		waiting:  make(chan struct{}),
+		closedCh: make(chan struct{}),
+		failCh:   make(chan error, 1),
 	}
 }
 
@@ -57,6 +60,7 @@ func (f *fakeSession) Close(context.Context) error {
 	defer f.mu.Unlock()
 	if !f.closed {
 		f.closed = true
+		close(f.closedCh)
 		// Closed sessions return nil from Wait by convention.
 		select {
 		case f.failCh <- nil:
@@ -64,6 +68,16 @@ func (f *fakeSession) Close(context.Context) error {
 		}
 	}
 	return nil
+}
+
+// waitClosed blocks until Close has been called on the session.
+func (f *fakeSession) waitClosed(t *testing.T) {
+	t.Helper()
+	select {
+	case <-f.closedCh:
+	case <-time.After(time.Second):
+		t.Fatal("session was not closed")
+	}
 }
 
 func (f *fakeSession) fail(err error) {
@@ -251,19 +265,7 @@ func TestSupervisor_StopReapsLateConnect(t *testing.T) {
 	close(c.release)
 
 	// The reaper must close the late session.
-	deadline := time.Now().Add(time.Second)
-	for {
-		sess.mu.Lock()
-		closed := sess.closed
-		sess.mu.Unlock()
-		if closed {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatal("late session was not closed after Stop")
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
+	sess.waitClosed(t)
 }
 
 // TestSupervisor_StartWithinTimeoutSucceeds verifies that a Connect that
@@ -450,8 +452,9 @@ func TestSupervisor_StopWakesRestartAndWait(t *testing.T) {
 	done := make(chan error, 1)
 	go func() { done <- s.RestartAndWait(t.Context(), 30*time.Second) }()
 
-	// Give RestartAndWait time to enter its select.
-	time.Sleep(20 * time.Millisecond)
+	// RestartAndWait force-closes the current session before parking in
+	// its select; once the close is observed it is safe to Stop.
+	sess.waitClosed(t)
 	assert.NilError(t, s.Stop(t.Context()))
 
 	select {
@@ -485,8 +488,9 @@ func TestSupervisor_FailedWakesRestartAndWait(t *testing.T) {
 	done := make(chan error, 1)
 	go func() { done <- s.RestartAndWait(t.Context(), 30*time.Second) }()
 
-	// Give RestartAndWait time to enter its select, then crash the session.
-	time.Sleep(20 * time.Millisecond)
+	// RestartAndWait force-closes the current session before parking in
+	// its select; once that close lands, crash the session.
+	sess1.waitClosed(t)
 	sess1.fail(errors.New("crash"))
 
 	select {
@@ -524,13 +528,12 @@ func TestSupervisor_RecoverFromFailedViaStart(t *testing.T) {
 
 	// Drive into Failed.
 	sess1.fail(errors.New("crash"))
-	deadline := time.Now().Add(2 * time.Second)
-	for s.State().State != lifecycle.StateFailed {
-		if time.Now().After(deadline) {
-			t.Fatalf("supervisor did not reach Failed; state=%s", s.State().State)
+	poll.WaitOn(t, func(poll.LogT) poll.Result {
+		if s.State().State == lifecycle.StateFailed {
+			return poll.Success()
 		}
-		time.Sleep(5 * time.Millisecond)
-	}
+		return poll.Continue("supervisor state=%s", s.State().State)
+	}, poll.WithTimeout(2*time.Second), poll.WithDelay(5*time.Millisecond))
 
 	// Recovery: Start should refresh the done channel and bring us back
 	// to Ready without RestartAndWait wedging on a stale close.

--- a/pkg/tools/mcp/mcp_race_test.go
+++ b/pkg/tools/mcp/mcp_race_test.go
@@ -64,10 +64,11 @@ func TestSupervisorRespectsContextCancellation(t *testing.T) {
 	require.Error(t, err, "Start must propagate connector error")
 
 	// Now exercise RestartAndWait + cancel: it should return promptly.
+	// Whether the cancellation lands before or after RestartAndWait parks
+	// in its select, the ctx path must win over the 10s timeout.
 	done := make(chan error, 1)
 	go func() { done <- s.RestartAndWait(ctx, 10*time.Second) }()
 
-	time.Sleep(50 * time.Millisecond)
 	cancel()
 
 	select {

--- a/pkg/tools/mcp/oauth_test.go
+++ b/pkg/tools/mcp/oauth_test.go
@@ -1078,15 +1078,8 @@ func TestOAuthTransportCoalescesConcurrentAuthorization(t *testing.T) {
 		errCh <- err
 	}()
 
-	deadline := time.After(time.Second)
-	for unauthenticatedRequests.Load() < 2 {
-		select {
-		case <-deadline:
-			t.Fatalf("second request did not reach 401 path; unauthenticated requests = %d", unauthenticatedRequests.Load())
-		default:
-			time.Sleep(10 * time.Millisecond)
-		}
-	}
+	require.Eventually(t, func() bool { return unauthenticatedRequests.Load() >= 2 },
+		time.Second, 10*time.Millisecond, "second request did not reach 401 path")
 
 	close(finishElicitation)
 

--- a/pkg/tui/tui_exit_test.go
+++ b/pkg/tui/tui_exit_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"bytes"
 	"reflect"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -199,9 +200,11 @@ func TestExitConfirmedMsg_ExitsImmediately(t *testing.T) {
 	assert.True(t, hasMsg[tea.QuitMsg](msgs), "should produce tea.QuitMsg")
 }
 
-// blockingWriter is an io.Writer whose Write blocks until unblocked.
+// blockingWriter is an io.Writer whose Write blocks until unblocked. It
+// records everything written so tests can sync on rendered content.
 type blockingWriter struct {
 	mu      sync.Mutex
+	buf     bytes.Buffer
 	blocked chan struct{} // closed once the first Write starts blocking
 	gate    chan struct{} // Write blocks until this is closed
 }
@@ -215,16 +218,27 @@ func newBlockingWriter() *blockingWriter {
 
 func (w *blockingWriter) Write(p []byte) (int, error) {
 	w.mu.Lock()
+	// Capture the gate before publishing the bytes: once a test observes
+	// this write's content, the write is guaranteed to complete even if
+	// reblock() swaps the gate right after.
+	gate := w.gate
+	w.buf.Write(p)
 	select {
 	case <-w.blocked:
 	default:
 		close(w.blocked)
 	}
-	gate := w.gate
 	w.mu.Unlock()
 
 	<-gate
 	return len(p), nil
+}
+
+// contains reports whether the accumulated output includes s.
+func (w *blockingWriter) contains(s string) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return strings.Contains(w.buf.String(), s)
 }
 
 // reblock installs a new gate so that subsequent writes block again.
@@ -298,10 +312,13 @@ func initBlockingBubbletea(t *testing.T, model tea.Model) (*tea.Program, *blocki
 		t.Fatal("timed out waiting for initial write to block")
 	}
 
-	// Let the initial writes through so the event loop starts, then re-block
-	// so the next flush stalls.
+	// Let the initial writes through so the event loop starts. The setup
+	// burst ends with clear-screen (ESC[2J); once it lands the renderer is
+	// idle (no frame renders without a window size), so re-block to make
+	// the next flush stall.
 	w.unblock()
-	time.Sleep(200 * time.Millisecond)
+	require.Eventually(t, func() bool { return w.contains("\x1b[2J") },
+		5*time.Second, time.Millisecond, "terminal setup was not flushed")
 	w.reblock()
 
 	return p, w, runDone
@@ -340,8 +357,8 @@ func TestCleanupAll_GracefulShutdownSkipsExit(t *testing.T) {
 	m, _ := newTestModel(t)
 	m.shutdownTimeout = 2 * time.Second
 
-	var exitCalled atomic.Bool
-	m.exitFunc = func(int) { exitCalled.Store(true) }
+	exitFired := make(chan struct{}, 1)
+	m.exitFunc = func(int) { exitFired <- struct{}{} }
 
 	var in, out bytes.Buffer
 	p := tea.NewProgram(&quitModel{},
@@ -371,10 +388,13 @@ func TestCleanupAll_GracefulShutdownSkipsExit(t *testing.T) {
 		t.Fatal("p.Run() did not return within deadline")
 	}
 
-	// Let the safety-net goroutine observe Wait() returning.
-	time.Sleep(100 * time.Millisecond)
-	assert.False(t, exitCalled.Load(),
-		"exitFunc must not fire on prompt shutdown")
+	// Give the safety-net goroutine a window to (wrongly) fire after
+	// Wait() returned.
+	select {
+	case <-exitFired:
+		t.Fatal("exitFunc must not fire on prompt shutdown")
+	case <-time.After(100 * time.Millisecond):
+	}
 }
 
 // syncMsg pings the program's event loop to confirm Run() has started.
@@ -388,14 +408,17 @@ func TestCleanupAll_NilProgramIsSafe(t *testing.T) {
 	m, _ := newTestModel(t)
 	m.shutdownTimeout = 20 * time.Millisecond
 
-	var exitCalled atomic.Bool
-	m.exitFunc = func(int) { exitCalled.Store(true) }
+	exitFired := make(chan struct{}, 1)
+	m.exitFunc = func(int) { exitFired <- struct{}{} }
 
 	m.program = nil
 	assert.NotPanics(t, func() { m.cleanupAll() })
 
-	time.Sleep(m.shutdownTimeout + 50*time.Millisecond)
-	assert.False(t, exitCalled.Load(), "exitFunc must not fire without a program")
+	select {
+	case <-exitFired:
+		t.Fatal("exitFunc must not fire without a program")
+	case <-time.After(m.shutdownTimeout + 50*time.Millisecond):
+	}
 }
 
 // TestCleanupAll_WedgedStdoutFiresExit: the realistic case. The renderer is
@@ -441,8 +464,8 @@ func TestCleanupAll_MultipleCallsFireExitOnce(t *testing.T) {
 	m, _ := newTestModel(t)
 	m.shutdownTimeout = 100 * time.Millisecond
 
-	var exitCount atomic.Int32
-	m.exitFunc = func(int) { exitCount.Add(1) }
+	exitFired := make(chan struct{}, 3)
+	m.exitFunc = func(int) { exitFired <- struct{}{} }
 
 	m.program = tea.NewProgram(&quitModel{})
 
@@ -450,9 +473,18 @@ func TestCleanupAll_MultipleCallsFireExitOnce(t *testing.T) {
 	m.cleanupAll()
 	m.cleanupAll()
 
-	time.Sleep(m.shutdownTimeout + 200*time.Millisecond)
-	assert.Equal(t, int32(1), exitCount.Load(),
-		"only the first cleanupAll should arm a safety net")
+	// Exactly one safety net must fire: wait for it, then make sure no
+	// second one follows.
+	select {
+	case <-exitFired:
+	case <-time.After(m.shutdownTimeout + 2*time.Second):
+		t.Fatal("no safety net fired")
+	}
+	select {
+	case <-exitFired:
+		t.Fatal("only the first cleanupAll should arm a safety net")
+	case <-time.After(m.shutdownTimeout + 200*time.Millisecond):
+	}
 }
 
 // TestExitDeadlock_BlockedStdout proves the underlying bubbletea bug: Run()
@@ -489,10 +521,7 @@ func TestExitSafetyNet_BlockedStdout(t *testing.T) {
 
 	model := &quitModel{
 		onQuit: func() {
-			go func() {
-				time.Sleep(safetyNetTimeout)
-				testExitFunc(0)
-			}()
+			time.AfterFunc(safetyNetTimeout, func() { testExitFunc(0) })
 		},
 	}
 	p, w, runDone := initBlockingBubbletea(t, model)
@@ -530,10 +559,7 @@ func TestExitSafetyNet_GracefulShutdown(t *testing.T) {
 			mu.Lock()
 			cleanupCalled = true
 			mu.Unlock()
-			go func() {
-				time.Sleep(safetyNetTimeout)
-				testExitFunc(0)
-			}()
+			time.AfterFunc(safetyNetTimeout, func() { testExitFunc(0) })
 		},
 	}
 	var buf bytes.Buffer
@@ -551,7 +577,9 @@ func TestExitSafetyNet_GracefulShutdown(t *testing.T) {
 		runDone <- err
 	}()
 
-	time.Sleep(200 * time.Millisecond)
+	// Send blocks until the program is running, so the quit message below
+	// is processed by a fully started event loop.
+	p.Send(syncMsg{})
 
 	p.Send(triggerQuitMsg{})
 


### PR DESCRIPTION
The test suite contained 44 `time.Sleep` calls spread across 22 test files. These sleeps slowed every run, introduced timing-dependent flakiness on loaded CI machines, and gave no actual guarantee of ordering — a fast machine might still race past them. This change removes all of them, replacing each with a deterministic synchronization primitive appropriate to the situation.

Depending on the test, the replacement is a channel gate, `require.Eventually`, `gotest.tools/poll.WaitOn`, `time.AfterFunc`, a fake clock, or a backdated TTL entry. For the prompt-serialization test in `pkg/tools/builtin/shell`, a small production change was needed: `askpass.go` gained an atomic counter (`promptArrivals`) so the test can wait for a prompt to arrive rather than sleeping. The 429 rate-limit test in `pkg/remote` also dropped go-containerregistry's default retry backoff (which slept ~4.4 s total) in favour of a millisecond-scale backoff with the same retry count. The three remaining `time.Sleep` calls are fake-time advances inside `testing/synctest` bubbles and carry `//nolint` directives explaining why they are intentional. A `forbidigo` lint rule now bans `time.Sleep` in `*_test.go` files so the pattern cannot silently return.

Wall-clock speedups are most visible in the packages that leaned on sleep the most: `pkg/runtime` drops from ~9 s to ~3 s and `pkg/server` from ~5 s to ~2 s in isolation. The full suite was run with `-race` on all touched packages; `golangci-lint` and the new custom cop are clean.