### PR TITLE
feat(tui): add /effort command to select the model's reasoning level

### DIFF
--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -75,6 +75,7 @@ Type `/` during a session to see available commands, or press <kbd>Ctrl</kbd>+<k
 | `/export`          | Export the session as HTML                                                           |
 | `/sessions`        | Browse and load past sessions                                                        |
 | `/model`           | Change the model for the current agent                                               |
+| `/effort`          | Set the current model's reasoning-effort level (`/effort <none\|minimal\|low\|medium\|high\|xhigh\|max>`, reasoning models only) |
 | `/theme`           | Change the color theme                                                               |
 | `/yolo`            | Toggle automatic tool call approval                                                  |
 | `/title`           | Set or regenerate session title                                                      |

--- a/docs/guides/thinking/index.md
+++ b/docs/guides/thinking/index.md
@@ -331,12 +331,13 @@ models:
 
 ## Changing Thinking Level at Runtime
 
-While running in the TUI, press **Shift+Tab** to cycle the thinking effort level for the current model without editing your YAML config:
+While running in the TUI, press **Shift+Tab** to cycle the thinking effort level for the current model without editing your YAML config, or type `/effort <level>` to jump straight to a specific level (e.g. `/effort high`):
 
 - The level steps through the model's supported range (model-specific), wrapping around — for example `none → minimal → low → medium → high → none` on OpenAI gpt-5/o-series, `none → minimal → low → medium → high → xhigh → none` on gpt-5.2+, `none → low → medium → high → max → none` on Anthropic Opus 4.6 and Sonnet 4.6, and `none → low → medium → high → xhigh → max → none` on Anthropic Opus 4.7+, Fable 5, and Mythos 5. For older Anthropic models (e.g. Sonnet 4.5) that only accept token budgets, effort-string cycling has no effect — use an integer `thinking_budget` in your YAML config instead.
 - The current level is shown in the sidebar next to the model name (e.g. `openai/gpt-5 • high`).
 - This applies as a session override — it is **not** saved to the config file. The next session starts from the level defined in your YAML.
 - For models that don't support reasoning, and for remote runtimes, Shift+Tab is a no-op and an informational message is displayed.
+- `/effort` only accepts levels the current model supports; requesting an unsupported level shows the model's supported list. Like Shift+Tab, it is unavailable for non-reasoning models and remote runtimes.
 
 ## Sharing Thinking Config Across Models
 

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1013,6 +1013,21 @@ func (a *App) CycleAgentThinkingLevel(ctx context.Context) (effort.Level, error)
 	return level, nil
 }
 
+// SetAgentThinkingLevel sets the current agent's thinking-effort level to the
+// requested value and returns the applied level. Like
+// [App.CycleAgentThinkingLevel], the change applies to the running session
+// only. Returns an error wrapping [runtime.ErrUnsupported] when the runtime
+// or model cannot switch thinking levels.
+func (a *App) SetAgentThinkingLevel(ctx context.Context, level effort.Level) (effort.Level, error) {
+	agentName := a.runtime.CurrentAgentName(ctx)
+	applied, err := a.runtime.SetAgentThinkingLevel(ctx, agentName, level)
+	if err != nil {
+		return "", err
+	}
+	a.refreshAgentInfo(ctx)
+	return applied, nil
+}
+
 // refreshAgentInfo pushes fresh agent and team info through the events channel
 // without re-running the heavier startup steps (tool discovery, token usage).
 func (a *App) refreshAgentInfo(ctx context.Context) {

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -97,6 +97,10 @@ func (m *mockRuntime) SetAgentModel(context.Context, string, string) error {
 func (m *mockRuntime) CycleAgentThinkingLevel(context.Context, string) (effort.Level, error) {
 	return "", runtime.ErrUnsupported
 }
+
+func (m *mockRuntime) SetAgentThinkingLevel(context.Context, string, effort.Level) (effort.Level, error) {
+	return "", runtime.ErrUnsupported
+}
 func (m *mockRuntime) AvailableModels(context.Context) []runtime.ModelChoice { return nil }
 func (m *mockRuntime) SupportsModelSwitching() bool                          { return false }
 func (m *mockRuntime) OnToolsChanged(func(runtime.Event))                    {}

--- a/pkg/cli/runner_test.go
+++ b/pkg/cli/runner_test.go
@@ -100,6 +100,10 @@ func (m *mockRuntime) SetAgentModel(context.Context, string, string) error      
 func (m *mockRuntime) CycleAgentThinkingLevel(context.Context, string) (effort.Level, error) {
 	return "", runtime.ErrUnsupported
 }
+
+func (m *mockRuntime) SetAgentThinkingLevel(context.Context, string, effort.Level) (effort.Level, error) {
+	return "", runtime.ErrUnsupported
+}
 func (m *mockRuntime) AvailableModels(context.Context) []runtime.ModelChoice                 { return nil }
 func (m *mockRuntime) SupportsModelSwitching() bool                                          { return false }
 func (m *mockRuntime) OnToolsChanged(func(runtime.Event))                                    {}

--- a/pkg/leantui/commands.go
+++ b/pkg/leantui/commands.go
@@ -25,6 +25,7 @@ func builtinCommands() []command {
 	return []command{
 		{name: "new", desc: "Start a new session", kind: cmdBuiltin},
 		{name: "compact", desc: "Summarize and compact the conversation", kind: cmdBuiltin},
+		{name: "effort", desc: "Set the model's reasoning effort (usage: /effort <level>)", kind: cmdBuiltin},
 		{name: "clear", desc: "Clear the screen", kind: cmdBuiltin},
 		{name: "help", desc: "Show keyboard shortcuts and commands", kind: cmdBuiltin},
 		{name: "exit", desc: "Exit", kind: cmdBuiltin},

--- a/pkg/leantui/update.go
+++ b/pkg/leantui/update.go
@@ -11,6 +11,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 
+	"github.com/docker/docker-agent/pkg/effort"
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/tools"
 	"github.com/docker/docker-agent/pkg/tui/messages"
@@ -142,6 +143,38 @@ func (m *model) handleCycleThinkingLevel(ctx context.Context) {
 	m.status.thinking = level.String()
 }
 
+// handleSetThinkingLevel applies the /effort command: it sets the current
+// model's reasoning-effort level to the requested value.
+func (m *model) handleSetThinkingLevel(ctx context.Context, level string) {
+	if m.app == nil {
+		return
+	}
+	if !m.app.SupportsModelSwitching() {
+		m.addNotice("", "Thinking levels can't be changed with remote runtimes", stMuted())
+		return
+	}
+	if level == "" {
+		m.addNotice("", "Usage: /effort <none|minimal|low|medium|high|xhigh|max>", stMuted())
+		return
+	}
+	parsed, ok := effort.Parse(level)
+	if !ok {
+		m.addNotice("✗ ", fmt.Sprintf("Unknown effort level %q (valid: none, minimal, low, medium, high, xhigh, max)", level), stError())
+		return
+	}
+	applied, err := m.app.SetAgentThinkingLevel(ctx, parsed)
+	if err != nil {
+		if errors.Is(err, runtime.ErrUnsupported) {
+			m.addNotice("", "Current model does not support thinking levels", stMuted())
+			return
+		}
+		m.addNotice("✗ ", fmt.Sprintf("Failed to set thinking level: %v", err), stError())
+		return
+	}
+	m.status.thinking = applied.String()
+	m.addNotice("", "Reasoning effort set to "+applied.String(), stMuted())
+}
+
 func (m *model) submit(ctx context.Context, text string) {
 	trimmed := strings.TrimSpace(text)
 	if trimmed == "" {
@@ -188,6 +221,9 @@ func (m *model) handleSlash(ctx context.Context, text string) bool {
 	case "compact":
 		m.addUserEcho(text)
 		m.startCompact(ctx, rest)
+		return true
+	case "effort":
+		m.handleSetThinkingLevel(ctx, rest)
 		return true
 	}
 
@@ -704,6 +740,7 @@ func (m *model) commitHelp() {
 			stBold().Render("Commands"),
 			stMuted().Render("  /new       start a new session"),
 			stMuted().Render("  /compact   summarize and compact the conversation"),
+			stMuted().Render("  /effort    set the model's reasoning effort (e.g. /effort high)"),
 			stMuted().Render("  /clear     clear the screen"),
 			stMuted().Render("  /help      show this help"),
 			stMuted().Render("  /exit      quit"),

--- a/pkg/leantui/update_test.go
+++ b/pkg/leantui/update_test.go
@@ -21,6 +21,8 @@ type cycleThinkingRuntime struct {
 	level      effort.Level
 	err        error
 	cycleCalls int
+	setCalls   int
+	setLevel   effort.Level
 }
 
 func (r *cycleThinkingRuntime) CurrentAgentInfo(context.Context) runtime.CurrentAgentInfo {
@@ -95,6 +97,15 @@ func (r *cycleThinkingRuntime) CycleAgentThinkingLevel(context.Context, string) 
 	}
 	return r.level, nil
 }
+
+func (r *cycleThinkingRuntime) SetAgentThinkingLevel(_ context.Context, _ string, level effort.Level) (effort.Level, error) {
+	r.setCalls++
+	if r.err != nil {
+		return "", r.err
+	}
+	r.setLevel = level
+	return level, nil
+}
 func (r *cycleThinkingRuntime) AvailableModels(context.Context) []runtime.ModelChoice { return nil }
 func (r *cycleThinkingRuntime) SupportsModelSwitching() bool                          { return r.supports }
 func (r *cycleThinkingRuntime) OnToolsChanged(func(runtime.Event))                    {}
@@ -123,6 +134,32 @@ func TestShiftTabReportsUnsupportedThinkingLevel(t *testing.T) {
 	m.handleKey(t.Context(), key{typ: keyShiftTab})
 
 	assert.Equal(t, 1, rt.cycleCalls)
+	assert.Empty(t, m.status.thinking)
+	assert.Len(t, m.blocks, 1)
+}
+
+func TestEffortCommandSetsThinkingLevel(t *testing.T) {
+	t.Parallel()
+	rt := &cycleThinkingRuntime{supports: true}
+	m := bareModel(24)
+	m.app = app.New(t.Context(), rt, session.New())
+
+	m.handleSetThinkingLevel(t.Context(), "high")
+
+	assert.Equal(t, 1, rt.setCalls)
+	assert.Equal(t, effort.High, rt.setLevel)
+	assert.Equal(t, "high", m.status.thinking)
+}
+
+func TestEffortCommandRejectsUnknownLevel(t *testing.T) {
+	t.Parallel()
+	rt := &cycleThinkingRuntime{supports: true}
+	m := bareModel(24)
+	m.app = app.New(t.Context(), rt, session.New())
+
+	m.handleSetThinkingLevel(t.Context(), "turbo")
+
+	assert.Zero(t, rt.setCalls)
 	assert.Empty(t, m.status.thinking)
 	assert.Len(t, m.blocks, 1)
 }

--- a/pkg/runtime/commands_test.go
+++ b/pkg/runtime/commands_test.go
@@ -85,6 +85,10 @@ func (m *mockRuntime) SetAgentModel(context.Context, string, string) error    { 
 func (m *mockRuntime) CycleAgentThinkingLevel(context.Context, string) (effort.Level, error) {
 	return "", ErrUnsupported
 }
+
+func (m *mockRuntime) SetAgentThinkingLevel(context.Context, string, effort.Level) (effort.Level, error) {
+	return "", ErrUnsupported
+}
 func (m *mockRuntime) AvailableModels(context.Context) []ModelChoice { return nil }
 func (m *mockRuntime) SupportsModelSwitching() bool                  { return false }
 func (m *mockRuntime) OnToolsChanged(func(Event))                    {}

--- a/pkg/runtime/model_switcher.go
+++ b/pkg/runtime/model_switcher.go
@@ -194,6 +194,39 @@ func (r *LocalRuntime) SupportsModelSwitching() bool {
 // supports (see [modelinfo.SupportedThinkingLevels]), re-creates the
 // provider(s) with the new level, and installs them as a runtime override.
 func (r *LocalRuntime) CycleAgentThinkingLevel(ctx context.Context, agentName string) (effort.Level, error) {
+	return r.applyAgentThinkingLevel(ctx, agentName, func(supported []effort.Level, current effort.Level) (effort.Level, error) {
+		// Clamp first so a configured level the model does not support re-enters
+		// the cycle at the nearest supported tier instead of resetting it.
+		return effort.NextSupportedLevel(supported, effort.Clamp(supported, current)), nil
+	})
+}
+
+// SetAgentThinkingLevel implements [Runtime.SetAgentThinkingLevel] for
+// LocalRuntime. The requested level must be one the agent's current model
+// supports; otherwise an error listing the supported levels is returned.
+func (r *LocalRuntime) SetAgentThinkingLevel(ctx context.Context, agentName string, level effort.Level) (effort.Level, error) {
+	return r.applyAgentThinkingLevel(ctx, agentName, func(supported []effort.Level, _ effort.Level) (effort.Level, error) {
+		if !slices.Contains(supported, level) {
+			return "", fmt.Errorf("thinking level %q is not supported by this model (supported: %s)", level, levelNames(supported))
+		}
+		return level, nil
+	})
+}
+
+// levelNames renders levels as a comma-separated list for error messages.
+func levelNames(levels []effort.Level) string {
+	names := make([]string, len(levels))
+	for i, l := range levels {
+		names[i] = string(l)
+	}
+	return strings.Join(names, ", ")
+}
+
+// applyAgentThinkingLevel resolves the agent's current model, asks pick to
+// choose the target level among the model's supported ones, re-creates the
+// effective provider(s) with that level, and installs them as a runtime
+// override.
+func (r *LocalRuntime) applyAgentThinkingLevel(ctx context.Context, agentName string, pick func(supported []effort.Level, current effort.Level) (effort.Level, error)) (effort.Level, error) {
 	if r.modelSwitcherCfg == nil {
 		return "", ErrUnsupported
 	}
@@ -214,10 +247,10 @@ func (r *LocalRuntime) CycleAgentThinkingLevel(ctx context.Context, agentName st
 	}
 
 	supported := modelinfo.SupportedThinkingLevels(baseCfg.Provider, baseCfg.Model)
-	// Clamp first so a configured level the model does not support re-enters
-	// the cycle at the nearest supported tier instead of resetting it.
-	current := effort.Clamp(supported, currentThinkingLevel(&baseCfg))
-	next := effort.NextSupportedLevel(supported, current)
+	next, err := pick(supported, currentThinkingLevel(&baseCfg))
+	if err != nil {
+		return "", err
+	}
 
 	// Re-create each effective provider (alloy models can have several) with
 	// the new thinking level so the override preserves the existing pool.
@@ -234,7 +267,7 @@ func (r *LocalRuntime) CycleAgentThinkingLevel(ctx context.Context, agentName st
 	}
 
 	a.SetModelOverride(newProviders...)
-	slog.InfoContext(ctx, "Cycled agent thinking level", "agent", agentName, "level", next)
+	slog.InfoContext(ctx, "Set agent thinking level", "agent", agentName, "level", next)
 	return next, nil
 }
 

--- a/pkg/runtime/model_switcher_test.go
+++ b/pkg/runtime/model_switcher_test.go
@@ -217,6 +217,89 @@ func TestCycleAgentThinkingLevel_AdvancesAndOverrides(t *testing.T) {
 	assert.Equal(t, effort.Low, level)
 }
 
+func TestSetAgentThinkingLevel(t *testing.T) {
+	t.Parallel()
+
+	newThinkingRuntime := func(cfg latest.ModelConfig, env map[string]string) (*LocalRuntime, *agent.Agent) {
+		root := agent.New("root", "test", agent.WithModel(newConfigProvider(cfg)))
+		r := &LocalRuntime{
+			team: team.New(team.WithAgents(root)),
+			modelSwitcherCfg: &ModelSwitcherConfig{
+				ProviderRegistry: testProviderRegistry(),
+				EnvProvider:      environment.NewMapEnvProvider(env),
+			},
+		}
+		return r, root
+	}
+
+	t.Run("supported level installs override", func(t *testing.T) {
+		t.Parallel()
+		r, root := newThinkingRuntime(
+			latest.ModelConfig{Provider: "openai", Model: "gpt-5"},
+			map[string]string{"OPENAI_API_KEY": "sk-test"},
+		)
+
+		level, err := r.SetAgentThinkingLevel(t.Context(), "root", effort.High)
+		require.NoError(t, err)
+		assert.Equal(t, effort.High, level)
+		require.True(t, root.HasModelOverride(), "setting a level must install a runtime override")
+
+		override := root.Model(t.Context())
+		require.NotNil(t, override)
+		budget := override.BaseConfig().ModelConfig.ThinkingBudget
+		require.NotNil(t, budget)
+		assert.Equal(t, "high", budget.Effort)
+	})
+
+	t.Run("unsupported level errors and lists supported levels", func(t *testing.T) {
+		t.Parallel()
+		r, root := newThinkingRuntime(
+			latest.ModelConfig{Provider: "openai", Model: "gpt-5"},
+			map[string]string{"OPENAI_API_KEY": "sk-test"},
+		)
+
+		// gpt-5 tops out at high: max must be rejected, not clamped.
+		_, err := r.SetAgentThinkingLevel(t.Context(), "root", effort.Max)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not supported")
+		assert.Contains(t, err.Error(), "high")
+		assert.False(t, root.HasModelOverride(), "no override should be set on rejection")
+	})
+
+	t.Run("non-reasoning model is unsupported", func(t *testing.T) {
+		t.Parallel()
+		r, root := newThinkingRuntime(
+			latest.ModelConfig{Provider: "openai", Model: "gpt-4o"},
+			map[string]string{"OPENAI_API_KEY": "sk-test"},
+		)
+
+		_, err := r.SetAgentThinkingLevel(t.Context(), "root", effort.High)
+		require.ErrorIs(t, err, ErrUnsupported)
+		assert.False(t, root.HasModelOverride())
+	})
+
+	t.Run("nil modelSwitcherCfg is unsupported", func(t *testing.T) {
+		t.Parallel()
+		root := agent.New("root", "test")
+		r := &LocalRuntime{team: team.New(team.WithAgents(root))}
+
+		_, err := r.SetAgentThinkingLevel(t.Context(), "root", effort.High)
+		require.ErrorIs(t, err, ErrUnsupported)
+	})
+
+	t.Run("model-specific top tier is accepted", func(t *testing.T) {
+		t.Parallel()
+		r, _ := newThinkingRuntime(
+			latest.ModelConfig{Provider: "anthropic", Model: "claude-opus-4-7"},
+			map[string]string{"ANTHROPIC_API_KEY": "sk-test"},
+		)
+
+		level, err := r.SetAgentThinkingLevel(t.Context(), "root", effort.Max)
+		require.NoError(t, err)
+		assert.Equal(t, effort.Max, level)
+	})
+}
+
 // TestCycleAgentThinkingLevel_PerModelTopTier verifies that cycling only
 // offers the top effort tiers to the Claude models whose API accepts them.
 func TestCycleAgentThinkingLevel_PerModelTopTier(t *testing.T) {

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -616,6 +616,12 @@ func (r *RemoteRuntime) CycleAgentThinkingLevel(context.Context, string) (effort
 	return "", ErrUnsupported
 }
 
+// SetAgentThinkingLevel is unsupported on remote runtimes; the server owns
+// model configuration including thinking-effort selection.
+func (r *RemoteRuntime) SetAgentThinkingLevel(context.Context, string, effort.Level) (effort.Level, error) {
+	return "", ErrUnsupported
+}
+
 // SupportsModelSwitching returns true for remote runtimes (model switching is handled server-side).
 func (r *RemoteRuntime) SupportsModelSwitching() bool {
 	return true

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -143,6 +143,14 @@ type Runtime interface {
 	// support thinking-effort selection.
 	CycleAgentThinkingLevel(ctx context.Context, agentName string) (effort.Level, error)
 
+	// SetAgentThinkingLevel sets the named agent's thinking-effort level to
+	// the requested value, applies it as a runtime model override, and
+	// returns the applied level. The level must be one the current model
+	// supports. Returns [ErrUnsupported] for runtimes that can't switch
+	// models (e.g. remote runtimes) or for models that don't support
+	// thinking-effort selection.
+	SetAgentThinkingLevel(ctx context.Context, agentName string, level effort.Level) (effort.Level, error)
+
 	// AvailableModels returns the models the user can pick from in the
 	// /model picker. Returns nil for runtimes that don't expose model
 	// switching; see SupportsModelSwitching for a cheap pre-check.

--- a/pkg/tui/commands/commands.go
+++ b/pkg/tui/commands/commands.go
@@ -129,6 +129,17 @@ func builtInSessionCommands() []Item {
 			},
 		},
 		{
+			ID:           "session.effort",
+			Label:        "Effort",
+			SlashCommand: "/effort",
+			Description:  "Set the reasoning effort of the current model (usage: /effort <level>)",
+			Category:     "Session",
+			Immediate:    true,
+			Execute: func(arg string) tea.Cmd {
+				return core.CmdHandler(messages.SetThinkingLevelMsg{Level: strings.TrimSpace(arg)})
+			},
+		},
+		{
 			ID:           "session.eval",
 			Label:        "Eval",
 			SlashCommand: "/eval",

--- a/pkg/tui/commands/commands_test.go
+++ b/pkg/tui/commands/commands_test.go
@@ -125,6 +125,26 @@ func TestParseSlashCommand_OtherCommands(t *testing.T) {
 		assert.True(t, ok)
 	})
 
+	t.Run("effort command with level", func(t *testing.T) {
+		t.Parallel()
+		cmd := parser.Parse("/effort high")
+		require.NotNil(t, cmd)
+		msg := cmd()
+		setMsg, ok := msg.(messages.SetThinkingLevelMsg)
+		require.True(t, ok)
+		assert.Equal(t, "high", setMsg.Level)
+	})
+
+	t.Run("effort command without level", func(t *testing.T) {
+		t.Parallel()
+		cmd := parser.Parse("/effort")
+		require.NotNil(t, cmd)
+		msg := cmd()
+		setMsg, ok := msg.(messages.SetThinkingLevelMsg)
+		require.True(t, ok)
+		assert.Empty(t, setMsg.Level)
+	})
+
 	t.Run("unknown command returns nil", func(t *testing.T) {
 		t.Parallel()
 		cmd := parser.Parse("/unknown")

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/docker/docker-agent/pkg/app"
 	"github.com/docker/docker-agent/pkg/browser"
+	"github.com/docker/docker-agent/pkg/effort"
 	"github.com/docker/docker-agent/pkg/evaluation"
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/session"
@@ -558,6 +559,31 @@ func (m *appModel) handleCycleThinkingLevel() (tea.Model, tea.Cmd) {
 		return m, notification.ErrorCmd(fmt.Sprintf("Failed to change thinking level: %v", err))
 	}
 	return m, nil
+}
+
+// handleSetThinkingLevel applies the /effort command: it sets the current
+// model's reasoning-effort level to the requested value. An empty level
+// shows usage; unsupported levels surface the model's supported list via
+// the runtime error.
+func (m *appModel) handleSetThinkingLevel(level string) (tea.Model, tea.Cmd) {
+	if !m.application.SupportsModelSwitching() {
+		return m, notification.InfoCmd("Thinking levels can't be changed with remote runtimes")
+	}
+	if level == "" {
+		return m, notification.InfoCmd("Usage: /effort <none|minimal|low|medium|high|xhigh|max>")
+	}
+	parsed, ok := effort.Parse(level)
+	if !ok {
+		return m, notification.ErrorCmd(fmt.Sprintf("Unknown effort level %q (valid: none, minimal, low, medium, high, xhigh, max)", level))
+	}
+	applied, err := m.application.SetAgentThinkingLevel(m.ctx(), parsed)
+	if err != nil {
+		if errors.Is(err, runtime.ErrUnsupported) {
+			return m, notification.InfoCmd("Current model does not support thinking levels")
+		}
+		return m, notification.ErrorCmd(fmt.Sprintf("Failed to set thinking level: %v", err))
+	}
+	return m, notification.SuccessCmd("Reasoning effort set to " + applied.String())
 }
 
 func (m *appModel) handleChangeModel(modelRef string) (tea.Model, tea.Cmd) {

--- a/pkg/tui/messages/agent.go
+++ b/pkg/tui/messages/agent.go
@@ -17,4 +17,8 @@ type (
 
 	// ChangeModelMsg changes the model for the current agent.
 	ChangeModelMsg struct{ ModelRef string }
+
+	// SetThinkingLevelMsg sets the reasoning-effort level of the current
+	// agent's model (/effort command). An empty Level shows usage.
+	SetThinkingLevelMsg struct{ Level string }
 )

--- a/pkg/tui/page/chat/queue_test.go
+++ b/pkg/tui/page/chat/queue_test.go
@@ -100,6 +100,10 @@ func (queueTestRuntime) SetAgentModel(context.Context, string, string) error    
 func (queueTestRuntime) CycleAgentThinkingLevel(context.Context, string) (effort.Level, error) {
 	return "", runtime.ErrUnsupported
 }
+
+func (queueTestRuntime) SetAgentThinkingLevel(context.Context, string, effort.Level) (effort.Level, error) {
+	return "", runtime.ErrUnsupported
+}
 func (queueTestRuntime) AvailableModels(context.Context) []runtime.ModelChoice { return nil }
 func (queueTestRuntime) SupportsModelSwitching() bool                          { return false }
 func (queueTestRuntime) OnToolsChanged(func(runtime.Event))                    {}

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -1016,6 +1016,9 @@ func (m *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case messages.ChangeModelMsg:
 		return m.handleChangeModel(msg.ModelRef)
 
+	case messages.SetThinkingLevelMsg:
+		return m.handleSetThinkingLevel(msg.Level)
+
 	// --- Theme picker ---
 
 	case messages.OpenThemePickerMsg:


### PR DESCRIPTION
## What

New `/effort` slash command to **select** the reasoning-effort level of the current model directly, complementing the existing Shift+Tab cycling. Available in both the full TUI and the lean TUI.

| Input | Behavior |
| --- | --- |
| `/effort high` | Sets the level (session override, never persisted to YAML) |
| `/effort` | Shows usage: `none, minimal, low, medium, high, xhigh, max` |
| `/effort turbo` | Error listing valid level names |
| `/effort max` on gpt-5 | Error listing the levels **this model** supports |
| Non-reasoning model / remote runtime | Informational message (same as Shift+Tab) |

## How

- New `Runtime.SetAgentThinkingLevel(ctx, agent, level)` interface method
- Cycle + set share one path: `applyAgentThinkingLevel` (reasoning check → supported levels via `modelinfo.SupportedThinkingLevels` → provider re-creation incl. alloy pools → override install)
- `RemoteRuntime` → `ErrUnsupported` (server owns model config)
- `App.SetAgentThinkingLevel` refreshes agent info so the sidebar updates
- Success surfaces a toast (full TUI) / notice + status bar update (lean TUI)

## Flow

```
/effort high
   └─ SetThinkingLevelMsg ─ handleSetThinkingLevel (TUI)
        └─ App.SetAgentThinkingLevel
             └─ Runtime.SetAgentThinkingLevel
                  ├─ model reasons? ──no──▶ ErrUnsupported
                  ├─ level supported by model? ──no──▶ error + supported list
                  └─ recreate provider(s) with thinking_budget ─▶ model override
```

## Tests

| Area | Coverage |
| --- | --- |
| `pkg/runtime` | Valid level installs override · unsupported level rejected with supported list · non-reasoning model → `ErrUnsupported` · per-model top tier (`max` on Opus 4.7) accepted |
| `pkg/tui/commands` | `/effort high` and bare `/effort` parsing |
| `pkg/leantui` | Set path updates status · unknown level rejected |
| Mocks | All 5 `Runtime` mocks updated |

## Docs

- `/effort` row in the TUI slash-command table (`docs/features/tui`)
- `/effort` mentioned alongside Shift+Tab in the thinking guide (`docs/guides/thinking`)

## Validation

- [x] `task build`
- [x] `golangci-lint run` — 0 issues
- [x] Tests pass on all touched packages (`runtime`, `app`, `cli`, `tui/...`, `leantui`)
