### PR TITLE
fix(agent): dedupe duplicate tool names with once-per-streak warning

### DIFF
--- a/docs/tools/mcp/index.md
+++ b/docs/tools/mcp/index.md
@@ -276,7 +276,7 @@ agents:
 <div class="callout callout-warning" markdown="1">
 <div class="callout-title">Toolset order matters
 </div>
-  <p>If multiple toolsets provide a tool with the same name, the first one wins. Order your toolsets intentionally.</p>
+  <p>If multiple toolsets provide a tool with the same name, the first one wins: the duplicate from the later toolset is ignored and a warning identifies both toolsets. Order your toolsets intentionally. To keep both tools callable, give the MCP toolset a unique <code>name:</code> (its tools are then exposed as <code>&lt;name&gt;_&lt;tool&gt;</code>) or restrict the overlapping toolset with its <code>tools:</code> filter.</p>
 </div>
 
 ## See Also

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -57,6 +57,12 @@ type Agent struct {
 	// the TUI and session manager.
 	warningsMu      sync.Mutex
 	pendingWarnings []string
+
+	// collisionsMu guards reportedCollisions, the once-per-streak guard for
+	// duplicate-tool-name warnings. collectTools may run concurrently from
+	// the runtime loop and MCP notification handlers.
+	collisionsMu       sync.Mutex
+	reportedCollisions map[string]bool
 }
 
 // New creates a new agent
@@ -380,8 +386,30 @@ func (a *Agent) StartedTools(ctx context.Context) ([]tools.Tool, error) {
 }
 
 // collectTools gathers tools from all started toolsets plus static tools.
+// Tool names must be unique across the whole set (providers such as
+// Anthropic reject requests with duplicate tool names, and the dispatcher
+// resolves calls by name), so duplicates are dropped as they are collected:
+// the first toolset in configuration order wins, as documented in the MCP
+// toolset docs. Each collision is surfaced to the user once per streak via
+// reportCollisions. See #2251.
 func (a *Agent) collectTools(ctx context.Context) ([]tools.Tool, error) {
 	var agentTools []tools.Tool
+	origins := make(map[string]string)
+	collisions := make(map[string]string)
+
+	collect := func(candidates []tools.Tool, origin string) {
+		for _, tool := range candidates {
+			if firstOrigin, exists := origins[tool.Name]; exists {
+				collisions[collisionKey(tool.Name, firstOrigin, origin)] = fmt.Sprintf(
+					"duplicate tool %q: kept from %s, ignored from %s (first toolset in config wins) — set a unique 'name:' on the MCP toolset or use its 'tools:' filter to disambiguate",
+					tool.Name, firstOrigin, origin)
+				continue
+			}
+			origins[tool.Name] = origin
+			agentTools = append(agentTools, tool)
+		}
+	}
+
 	for _, toolSet := range a.toolsets {
 		if !toolSet.IsStarted() {
 			// Toolset not started; skip it
@@ -402,16 +430,54 @@ func (a *Agent) collectTools(ctx context.Context) ([]tools.Tool, error) {
 			}
 			continue
 		}
-		agentTools = append(agentTools, ta...)
+		collect(ta, tools.DescribeToolSet(toolSet))
 	}
 
-	agentTools = append(agentTools, a.tools...)
+	collect(a.tools, "agent static tools")
+
+	a.reportCollisions(ctx, collisions)
 
 	if a.addDescriptionParameter {
 		agentTools = tools.AddDescriptionParameter(agentTools)
 	}
 
 	return agentTools, nil
+}
+
+// collisionKey identifies one (tool, kept origin, dropped origin) collision so
+// the same persistent collision is reported once per streak, while a new
+// collision (e.g. introduced by an MCP ToolListChanged notification) is
+// reported as fresh.
+func collisionKey(toolName, keptOrigin, droppedOrigin string) string {
+	return toolName + "\x00" + keptOrigin + "\x00" + droppedOrigin
+}
+
+// reportCollisions surfaces duplicate-tool-name collisions to the user once
+// per streak: a collision present on consecutive collectTools runs is only
+// logged at debug level after the first report, and a collision that
+// disappears then reappears is reported again. This mirrors the
+// once-per-streak semantics of toolset start/list failure warnings so the
+// user is alerted without being spammed on every conversation turn.
+func (a *Agent) reportCollisions(ctx context.Context, collisions map[string]string) {
+	a.collisionsMu.Lock()
+	defer a.collisionsMu.Unlock()
+
+	if len(collisions) == 0 {
+		a.reportedCollisions = nil
+		return
+	}
+
+	reported := make(map[string]bool, len(collisions))
+	for key, msg := range collisions {
+		if a.reportedCollisions[key] {
+			slog.DebugContext(ctx, "Duplicate tool name still present", "agent", a.Name(), "detail", msg)
+		} else {
+			slog.WarnContext(ctx, "Duplicate tool name; keeping first occurrence", "agent", a.Name(), "detail", msg)
+			a.AddToolWarning(msg)
+		}
+		reported[key] = true
+	}
+	a.reportedCollisions = reported
 }
 
 func (a *Agent) ToolSets() []tools.ToolSet {

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -46,6 +46,22 @@ func (s *stubToolSet) Tools(context.Context) ([]tools.Tool, error) {
 	return s.tools, nil
 }
 
+// describedToolSet is a stubToolSet with a stable user-visible description,
+// so tests can assert which toolset a warning attributes a tool to.
+type describedToolSet struct {
+	stubToolSet
+
+	desc string
+}
+
+var _ tools.Describer = (*describedToolSet)(nil)
+
+func (d *describedToolSet) Describe() string { return d.desc }
+
+func newDescribedToolSet(desc string, toolsList []tools.Tool) *describedToolSet {
+	return &describedToolSet{stubToolSet: stubToolSet{tools: toolsList}, desc: desc}
+}
+
 // flappyToolSet is a ToolSet+Startable that returns a scripted sequence of
 // errors from Start(). nil in the sequence means success.
 type flappyToolSet struct {
@@ -149,6 +165,19 @@ func TestAgentTools(t *testing.T) {
 			wantToolCount: 0,
 			wantWarnings:  0,
 		},
+		{
+			// #2251: two toolsets emitting the same names (e.g. the same
+			// built-in type configured twice) must collapse to a unique set,
+			// otherwise providers reject the request with "Tool names must
+			// be unique." Each dropped duplicate surfaces one warning.
+			name: "duplicate names across toolsets are deduped",
+			toolsets: []tools.ToolSet{
+				newStubToolSet(nil, []tools.Tool{{Name: "read_file", Parameters: map[string]any{}}, {Name: "write_file", Parameters: map[string]any{}}}, nil),
+				newStubToolSet(nil, []tools.Tool{{Name: "read_file", Parameters: map[string]any{}}, {Name: "write_file", Parameters: map[string]any{}}}, nil),
+			},
+			wantToolCount: 2,
+			wantWarnings:  2,
+		},
 	}
 
 	for _, tt := range tests {
@@ -195,6 +224,111 @@ func TestAgentNoDuplicateListWarnings(t *testing.T) {
 	_, err = a.Tools(t.Context())
 	require.NoError(t, err)
 	assert.Empty(t, a.DrainWarnings(), "turn 3: no duplicate warning on repeated list failure")
+}
+
+// TestAgentToolsDedupeKeepsFirstInOrder pins the deduplication contract from
+// #2251 (and documented in the MCP toolset docs): when several toolsets emit
+// the same tool name, Tools() keeps the occurrence from the first toolset in
+// configuration order, preserves the first-seen order of distinct names, and
+// never returns a duplicate name.
+func TestAgentToolsDedupeKeepsFirstInOrder(t *testing.T) {
+	t.Parallel()
+
+	first := newStubToolSet(nil, []tools.Tool{
+		{Name: "read_file", Description: "from first", Parameters: map[string]any{}},
+		{Name: "fetch", Description: "from first", Parameters: map[string]any{}},
+	}, nil)
+	second := newStubToolSet(nil, []tools.Tool{
+		{Name: "read_file", Description: "from second", Parameters: map[string]any{}},
+		{Name: "write_file", Description: "from second", Parameters: map[string]any{}},
+	}, nil)
+
+	a := New("root", "test", WithToolSets(first, second))
+	got, err := a.Tools(t.Context())
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+
+	names := make([]string, len(got))
+	for i, tool := range got {
+		names[i] = tool.Name
+	}
+	assert.Equal(t, []string{"read_file", "fetch", "write_file"}, names,
+		"distinct names in first-seen order, no duplicates")
+	assert.Equal(t, "from first", got[0].Description,
+		"the first occurrence of read_file must win")
+}
+
+// TestAgentToolsCollisionWarningIdentifiesOrigins verifies the duplicate-tool
+// warning names both the toolset that won and the toolset whose tool was
+// ignored, and points the user at the config-level remedies.
+func TestAgentToolsCollisionWarningIdentifiesOrigins(t *testing.T) {
+	t.Parallel()
+
+	builtin := newDescribedToolSet("fetch built-in", []tools.Tool{{Name: "fetch", Parameters: map[string]any{}}})
+	jira := newDescribedToolSet("mcp(ref=jira)", []tools.Tool{{Name: "fetch", Parameters: map[string]any{}}})
+
+	a := New("root", "test", WithToolSets(builtin, jira))
+	_, err := a.Tools(t.Context())
+	require.NoError(t, err)
+
+	warnings := a.DrainWarnings()
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], `duplicate tool "fetch"`)
+	assert.Contains(t, warnings[0], "kept from fetch built-in")
+	assert.Contains(t, warnings[0], "ignored from mcp(ref=jira)")
+	assert.Contains(t, warnings[0], "'name:'", "warning must point at the config remedy")
+}
+
+// TestAgentToolsCollisionWarningOncePerStreak verifies once-per-streak
+// semantics for duplicate-tool warnings: a persistent collision warns only on
+// the first turn, a collision that disappears resets the streak, and a new
+// collision (e.g. introduced by an MCP ToolListChanged notification) is
+// reported as fresh.
+func TestAgentToolsCollisionWarningOncePerStreak(t *testing.T) {
+	t.Parallel()
+
+	static := newDescribedToolSet("static", []tools.Tool{{Name: "fetch", Parameters: map[string]any{}}})
+	dynamic := newDescribedToolSet("dynamic", []tools.Tool{{Name: "fetch", Parameters: map[string]any{}}})
+	a := New("root", "test", WithToolSets(static, dynamic))
+
+	// Turn 1: collision on "fetch" → one warning.
+	_, err := a.Tools(t.Context())
+	require.NoError(t, err)
+	require.Len(t, a.DrainWarnings(), 1, "turn 1: one warning on first collision")
+
+	// Turn 2: same collision persists → no new warning.
+	_, err = a.Tools(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, a.DrainWarnings(), "turn 2: persistent collision must not re-warn")
+
+	// Turn 3: the dynamic toolset changes its list (ToolListChanged) and now
+	// also collides on "search" → exactly one warning, for the new collision.
+	dynamic.tools = []tools.Tool{
+		{Name: "fetch", Parameters: map[string]any{}},
+		{Name: "search", Parameters: map[string]any{}},
+	}
+	static.tools = []tools.Tool{
+		{Name: "fetch", Parameters: map[string]any{}},
+		{Name: "search", Parameters: map[string]any{}},
+	}
+	_, err = a.Tools(t.Context())
+	require.NoError(t, err)
+	warnings := a.DrainWarnings()
+	require.Len(t, warnings, 1, "turn 3: only the new collision warns")
+	assert.Contains(t, warnings[0], `duplicate tool "search"`)
+
+	// Turn 4: all collisions resolved → streak resets, no warning.
+	dynamic.tools = nil
+	static.tools = []tools.Tool{{Name: "fetch", Parameters: map[string]any{}}, {Name: "search", Parameters: map[string]any{}}}
+	_, err = a.Tools(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, a.DrainWarnings(), "turn 4: no collision, no warning")
+
+	// Turn 5: the same collision reappears → reported as a fresh streak.
+	dynamic.tools = []tools.Tool{{Name: "fetch", Parameters: map[string]any{}}}
+	_, err = a.Tools(t.Context())
+	require.NoError(t, err)
+	require.Len(t, a.DrainWarnings(), 1, "turn 5: reappearing collision starts a new streak")
 }
 
 // mockProvider implements provider.Provider for testing


### PR DESCRIPTION
## What

Deduplicate tool names in `Agent.collectTools()`: the first toolset in configuration order wins, and each collision is surfaced to the user once per streak with a warning naming both toolsets involved and the config remedies.

Fixes #2251.

## Why

When several toolsets emit the same tool name, the duplicate reaches the provider and Anthropic rejects the request:

```
HTTP 400: {"type":"error","error":{"type":"invalid_request_error",
"message":"tools: Tool names must be unique."}}
```

Collisions happen in real configs:

- the same built-in toolset type configured twice (e.g. two `filesystem`);
- two unnamed MCP servers exposing the same tool names;
- an MCP tool shadowing a built-in (e.g. `fetch`);
- a collision introduced at runtime by a `ToolListChanged` notification.

#1969 fixed only the multi-LSP case (multiplexer) and 3528ab21 the multi-RAG case; the general problem remained.

| | Before | After |
| --- | --- | --- |
| Anthropic | HTTP 400, zero tools usable | Request accepted, first occurrence wins |
| Tolerant providers | Silent arbitrary shadowing (dispatcher map, last wins) | Deterministic first-wins |
| User feedback | Cryptic 400 or nothing | One warning per collision streak, with origins and remedies |

## How

- Dedup happens during collection (not after flattening), while `tools.DescribeToolSet` is still in scope, so the warning attributes both the kept and the ignored origin.
- First toolset in configuration order wins — the rule the MCP docs already promise (`docs/tools/mcp/index.md`, *Toolset order matters* callout) but the code never implemented.
- Collisions are reported through a once-per-streak guard mirroring the existing start/list failure streaks: a persistent collision warns once (then `slog.Debug`), a resolved collision resets the streak, a new or reappearing one is reported as fresh.
- No automatic renaming or prefixing. The warning points at the existing user-level remedies: a unique `name:` on the MCP toolset, or its `tools:` filter.

Two earlier attempts (#2278, #3122) were closed after review. This design addresses each objection raised there:

| Objection | Raised on | How this PR addresses it |
| --- | --- | --- |
| "We can't just remove tools like this" (jira `fetch` vs built-in `fetch`) | #3122 | Both tools are never reachable today: besides the Anthropic 400, the dispatcher resolves calls through a name-keyed map (`pkg/runtime/toolexec/dispatcher.go`), so one tool already silently shadows the other. This PR makes the shadowing deterministic and loudly reported instead of arbitrary and silent. |
| Renaming breaks MCP-injected instructions ("use the fetch tool") | #3122 | No renaming is done; resolving a collision stays an explicit user decision via the existing `name:` mechanism. |
| User-facing warnings would repeat on every turn | #2278 review | Once-per-streak guard; `collectTools` runs every turn but a persistent collision warns only once. |
| Warning lacks toolset origin | #2278 bot review | Dedup at collection time keeps toolset identity; the warning names the kept and the ignored origin. |

## Tests

- `TestAgentTools`: new table case — duplicate names across toolsets collapse to a unique set, one warning per dropped duplicate.
- `TestAgentToolsDedupeKeepsFirstInOrder`: first occurrence wins, first-seen order preserved.
- `TestAgentToolsCollisionWarningIdentifiesOrigins`: warning names both toolsets and the `name:` remedy.
- `TestAgentToolsCollisionWarningOncePerStreak`: warns once for a persistent collision, re-warns only for new or reappearing collisions across turns.

## Verification

- `golangci-lint run pkg/agent/...` and `go run ./lint .`: no issues.
- `go test ./...`: passes except pre-existing failures in `pkg/tools/builtin/fetch` and `pkg/tools/builtin/openapi` (local network proxy answers 405 on non-public addresses; they fail identically on `main`).

## Out of scope

- The skill sub-session path (`skillSubSessionTools` in `pkg/runtime/loop.go`) appends extra toolset tools after `Agent.Tools()` and could theoretically reintroduce a duplicate; a shared dedup helper could cover it as a follow-up.
- Static config-time validation (e.g. rejecting the same built-in type twice) — insufficient alone since MCP tool lists are only known at runtime.
