### PR TITLE
docs: prepare pages for the docs.docker.com module mount

### DIFF
--- a/docs/404.md
+++ b/docs/404.md
@@ -4,8 +4,6 @@ title: "Page Not Found"
 permalink: /404.html
 ---
 
-# Page not found
-
 The page you're looking for doesn't exist or has been moved.
 
 <a href="{{ '/' | relative_url }}" class="btn btn-primary" style="background:var(--accent);color:white;display:inline-block;margin-top:1rem;">← Back to Docs</a>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -85,6 +85,11 @@
         The stable documentation lives at
         <a href="https://docs.docker.com/ai/docker-agent/">docs.docker.com</a>.
       </div>
+      {% comment %}
+        Pages no longer carry a body H1: like docs.docker.com, the layout
+        renders the front matter title. The homepage has its own hero.
+      {% endcomment %}
+      {% if page.title and page.url != '/' %}<h1>{{ page.title }}</h1>{% endif %}
       {{ content }}
       {% unless page.url == '/' %}{% include page-nav.html %}{% endunless %}
     </div>

--- a/docs/community/_index.md
+++ b/docs/community/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Community"
+description: "Contributing, troubleshooting, and telemetry."
+weight: 80
+---

--- a/docs/community/contributing/index.md
+++ b/docs/community/contributing/index.md
@@ -2,9 +2,8 @@
 title: "Contributing"
 description: "docker-agent is open source. Here's how to set up your development environment and contribute."
 keywords: docker agent, ai agents, community, contributing
+weight: 10
 ---
-
-# Contributing
 
 _docker-agent is open source. Here's how to set up your development environment and contribute._
 

--- a/docs/community/opentelemetry/index.md
+++ b/docs/community/opentelemetry/index.md
@@ -2,9 +2,8 @@
 title: "OpenTelemetry Tracing"
 description: "Export docker-agent traces to any OTLP backend, including Langfuse and LangSmith, for debugging agentic workflows."
 keywords: docker agent, ai agents, community, opentelemetry tracing
+weight: 40
 ---
-
-# OpenTelemetry Tracing
 
 _docker-agent can export OpenTelemetry traces of an agent run to any OTLP/HTTP backend. This is separate from [product-analytics telemetry](../telemetry/index.md) and is opt-in via the `--otel` flag._
 

--- a/docs/community/telemetry/index.md
+++ b/docs/community/telemetry/index.md
@@ -2,9 +2,8 @@
 title: "Telemetry"
 description: "docker-agent collects anonymous usage data to help improve the tool. Telemetry can be disabled at any time."
 keywords: docker agent, ai agents, community, telemetry
+weight: 30
 ---
-
-# Telemetry
 
 _docker-agent collects anonymous usage data to help improve the tool. Telemetry can be disabled at any time._
 

--- a/docs/community/troubleshooting/index.md
+++ b/docs/community/troubleshooting/index.md
@@ -2,9 +2,8 @@
 title: "Troubleshooting"
 description: "Common issues and how to resolve them when working with docker-agent."
 keywords: docker agent, ai agents, community, troubleshooting
+weight: 20
 ---
-
-# Troubleshooting
 
 _Common issues and how to resolve them when working with docker-agent._
 

--- a/docs/concepts/_index.md
+++ b/docs/concepts/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Core Concepts"
+description: "The core ideas behind Docker Agent: agents, models, tools, and multi-agent teams."
+weight: 20
+---

--- a/docs/concepts/agents/index.md
+++ b/docs/concepts/agents/index.md
@@ -2,9 +2,8 @@
 title: "Agents"
 description: "Agents are the core building blocks of docker-agent. Each agent is an AI-powered entity with a model, instructions, tools, and optional sub-agents."
 keywords: docker agent, ai agents, concepts, agents
+weight: 10
 ---
-
-# Agents
 
 _Agents are the core building blocks of docker-agent. Each agent is an AI-powered entity with a model, instructions, tools, and optional sub-agents._
 

--- a/docs/concepts/distribution/index.md
+++ b/docs/concepts/distribution/index.md
@@ -2,9 +2,10 @@
 title: "Agent Distribution"
 description: "Package, share, and run agents via OCI-compatible registries — just like container images."
 keywords: docker agent, ai agents, concepts, agent distribution
+weight: 50
+aliases:
+  - /ai/docker-agent/sharing-agents/
 ---
-
-# Agent Distribution
 
 _Package, share, and run agents via OCI-compatible registries — just like container images._
 

--- a/docs/concepts/models/index.md
+++ b/docs/concepts/models/index.md
@@ -2,9 +2,8 @@
 title: "Models"
 description: "Models are the AI brains behind your agents. docker-agent supports multiple providers and flexible configuration."
 keywords: docker agent, ai agents, concepts, models
+weight: 20
 ---
-
-# Models
 
 _Models are the AI brains behind your agents. docker-agent supports multiple providers and flexible configuration._
 

--- a/docs/concepts/multi-agent/index.md
+++ b/docs/concepts/multi-agent/index.md
@@ -2,9 +2,9 @@
 title: "Multi-Agent Systems"
 description: "Build teams of specialized agents that collaborate and delegate tasks to each other."
 keywords: docker agent, ai agents, concepts, multi-agent systems
+linkTitle: "Multi-Agent"
+weight: 40
 ---
-
-# Multi-Agent Systems
 
 _Build teams of specialized agents that collaborate and delegate tasks to each other._
 

--- a/docs/concepts/tools/index.md
+++ b/docs/concepts/tools/index.md
@@ -2,9 +2,8 @@
 title: "Tools"
 description: "Tools give agents the ability to interact with the world — read files, run commands, search the web, query databases, and more."
 keywords: docker agent, ai agents, concepts, tools
+weight: 30
 ---
-
-# Tools
 
 _Tools give agents the ability to interact with the world — read files, run commands, search the web, query databases, and more._
 

--- a/docs/configuration/_index.md
+++ b/docs/configuration/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Configuration"
+description: "Complete reference for configuring agents in YAML or HCL."
+weight: 30
+---

--- a/docs/configuration/agents/index.md
+++ b/docs/configuration/agents/index.md
@@ -2,9 +2,9 @@
 title: "Agent Configuration"
 description: "Complete reference for defining agents in your YAML configuration."
 keywords: docker agent, ai agents, configuration, yaml, agent configuration
+linkTitle: "Agent Config"
+weight: 30
 ---
-
-# Agent Configuration
 
 _Complete reference for defining agents in your YAML configuration._
 

--- a/docs/configuration/hcl/index.md
+++ b/docs/configuration/hcl/index.md
@@ -2,9 +2,8 @@
 title: "HCL Configuration"
 description: "Write docker-agent configs in HCL instead of YAML, using labeled blocks, heredocs, and the same underlying schema."
 keywords: docker agent, ai agents, configuration, yaml, hcl configuration
+weight: 20
 ---
-
-# HCL Configuration
 
 _Write docker-agent configs in HCL instead of YAML. It maps to the same docker-agent schema and validation rules._
 

--- a/docs/configuration/hooks/index.md
+++ b/docs/configuration/hooks/index.md
@@ -2,9 +2,8 @@
 title: "Hooks"
 description: "Run shell commands at various points during agent execution for deterministic control over behavior."
 keywords: docker agent, ai agents, configuration, yaml, hooks
+weight: 60
 ---
-
-# Hooks
 
 _Run shell commands at various points during agent execution for deterministic control over behavior._
 

--- a/docs/configuration/models/index.md
+++ b/docs/configuration/models/index.md
@@ -2,9 +2,9 @@
 title: "Model Configuration"
 description: "Complete reference for defining models with providers, parameters, and reasoning settings."
 keywords: docker agent, ai agents, configuration, yaml, model configuration
+linkTitle: "Model Config"
+weight: 40
 ---
-
-# Model Configuration
 
 _Complete reference for defining models with providers, parameters, and reasoning settings._
 

--- a/docs/configuration/overview/index.md
+++ b/docs/configuration/overview/index.md
@@ -2,9 +2,11 @@
 title: "Configuration Overview"
 description: "docker-agent uses YAML or HCL configuration files to define agents, models, tools, and their relationships."
 keywords: docker agent, ai agents, configuration, yaml, configuration overview
+linkTitle: "Overview"
+weight: 10
+aliases:
+  - /ai/docker-agent/reference/config/
 ---
-
-# Configuration Overview
 
 _docker-agent uses YAML or HCL configuration files to define agents, models, tools, and their relationships._
 

--- a/docs/configuration/permissions/index.md
+++ b/docs/configuration/permissions/index.md
@@ -2,9 +2,8 @@
 title: "Permissions"
 description: "Control which tools can execute automatically, require confirmation, or are blocked entirely."
 keywords: docker agent, ai agents, configuration, yaml, permissions
+weight: 70
 ---
-
-# Permissions
 
 _Control which tools can execute automatically, require confirmation, or are blocked entirely._
 

--- a/docs/configuration/routing/index.md
+++ b/docs/configuration/routing/index.md
@@ -2,9 +2,8 @@
 title: "Model Routing"
 description: "Route requests to different models based on the content of user messages."
 keywords: docker agent, ai agents, configuration, yaml, model routing
+weight: 100
 ---
-
-# Model Routing
 
 _Route requests to different models based on the content of user messages._
 

--- a/docs/configuration/sandbox/index.md
+++ b/docs/configuration/sandbox/index.md
@@ -2,9 +2,8 @@
 title: "Sandbox Mode"
 description: "Run agents in an isolated Docker sandbox VM for enhanced security."
 keywords: docker agent, ai agents, configuration, yaml, sandbox mode
+weight: 80
 ---
-
-# Sandbox Mode
 
 _Run agents in an isolated Docker sandbox VM for enhanced security._
 

--- a/docs/configuration/structured-output/index.md
+++ b/docs/configuration/structured-output/index.md
@@ -2,9 +2,8 @@
 title: "Structured Output"
 description: "Force the agent to respond with JSON matching a specific schema."
 keywords: docker agent, ai agents, configuration, yaml, structured output
+weight: 90
 ---
-
-# Structured Output
 
 _Force the agent to respond with JSON matching a specific schema._
 

--- a/docs/configuration/tools/index.md
+++ b/docs/configuration/tools/index.md
@@ -2,9 +2,11 @@
 title: "Tool Configuration"
 description: "Complete reference for configuring built-in tools, MCP tools, and Docker-based tools."
 keywords: docker agent, ai agents, configuration, yaml, tool configuration
+linkTitle: "Tool Config"
+weight: 50
+aliases:
+  - /ai/docker-agent/reference/toolsets/
 ---
-
-# Tool Configuration
 
 _Complete reference for configuring built-in tools, MCP tools, and Docker-based tools._
 

--- a/docs/features/_index.md
+++ b/docs/features/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Features"
+description: "Interfaces and features: TUI, CLI, API server, protocols, and more."
+weight: 50
+---

--- a/docs/features/a2a/index.md
+++ b/docs/features/a2a/index.md
@@ -2,9 +2,10 @@
 title: "A2A Protocol"
 description: "Expose docker-agent agents via Google's Agent-to-Agent (A2A) protocol for interoperability with other agent frameworks."
 keywords: docker agent, ai agents, features, a2a protocol
+weight: 60
+aliases:
+  - /ai/docker-agent/integrations/a2a/
 ---
-
-# A2A Protocol
 
 _Expose docker-agent agents via Google's Agent-to-Agent (A2A) protocol for interoperability with other agent frameworks._
 

--- a/docs/features/acp/index.md
+++ b/docs/features/acp/index.md
@@ -2,9 +2,11 @@
 title: "ACP (Agent Client Protocol)"
 description: "Expose docker-agent agents via the Agent Client Protocol for integration with ACP-compatible hosts like VS Code, IDEs, and other developer tools."
 keywords: docker agent, ai agents, features, acp (agent client protocol)
+linkTitle: "ACP"
+weight: 70
+aliases:
+  - /ai/docker-agent/integrations/acp/
 ---
-
-# ACP (Agent Client Protocol)
 
 _Expose docker-agent agents via the Agent Client Protocol for integration with ACP-compatible hosts like VS Code, IDEs, and other developer tools._
 

--- a/docs/features/api-server/index.md
+++ b/docs/features/api-server/index.md
@@ -2,9 +2,8 @@
 title: "API Server"
 description: "Expose your agents via an HTTP API for programmatic access, web frontends, and integrations."
 keywords: docker agent, ai agents, features, api server
+weight: 80
 ---
-
-# API Server
 
 _Expose your agents via an HTTP API for programmatic access, web frontends, and integrations._
 

--- a/docs/features/chat-server/index.md
+++ b/docs/features/chat-server/index.md
@@ -2,9 +2,8 @@
 title: "Chat Server"
 description: "Expose your agents through an OpenAI-compatible Chat Completions API so any tool that already speaks OpenAI can drive a docker-agent agent."
 keywords: docker agent, ai agents, features, chat server
+weight: 90
 ---
-
-# Chat Server
 
 _Expose your agents through an OpenAI-compatible Chat Completions API so any tool that already speaks OpenAI can drive a docker-agent agent._
 

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -2,9 +2,10 @@
 title: "CLI Reference"
 description: "Complete reference for all docker-agent command-line commands and flags."
 keywords: docker agent, ai agents, features, cli reference
+weight: 30
+aliases:
+  - /ai/docker-agent/reference/cli/
 ---
-
-# CLI Reference
 
 _Complete reference for all docker-agent command-line commands and flags._
 

--- a/docs/features/evaluation/index.md
+++ b/docs/features/evaluation/index.md
@@ -2,9 +2,10 @@
 title: "Evaluation"
 description: "Measure agent quality with automated evaluations — tool call accuracy, response relevance, output size, and more."
 keywords: docker agent, ai agents, features, evaluation
+weight: 100
+aliases:
+  - /ai/docker-agent/evals/
 ---
-
-# Evaluation
 
 _Measure agent quality with automated evaluations — tool call accuracy, response relevance, output size, and more._
 

--- a/docs/features/harnesses/index.md
+++ b/docs/features/harnesses/index.md
@@ -2,9 +2,8 @@
 title: "Coding Harnesses"
 description: "Delegate coding tasks to external AI coding CLIs (Claude Code, Codex, opencode) as sub-agents."
 keywords: docker agent, ai agents, features, coding harnesses
+weight: 50
 ---
-
-# Coding Harnesses
 
 _Delegate coding tasks to external AI coding CLIs (Claude Code, Codex, opencode) as sub-agents._
 

--- a/docs/features/mcp-mode/index.md
+++ b/docs/features/mcp-mode/index.md
@@ -2,9 +2,8 @@
 title: "MCP Mode"
 description: "Expose your docker-agent agents as MCP tools for use in Claude Desktop, Claude Code, and other MCP-compatible applications."
 keywords: docker agent, ai agents, features, mcp mode
+weight: 40
 ---
-
-# MCP Mode
 
 _Expose your docker-agent agents as MCP tools for use in Claude Desktop, Claude Code, and other MCP-compatible applications._
 

--- a/docs/features/remote-mcp/index.md
+++ b/docs/features/remote-mcp/index.md
@@ -2,9 +2,8 @@
 title: "Remote MCP Servers"
 description: "Connect docker-agent to cloud services via remote MCP servers with built-in OAuth authentication."
 keywords: docker agent, ai agents, features, remote mcp servers
+weight: 120
 ---
-
-# Remote MCP Servers
 
 _Connect docker-agent to cloud services via remote MCP servers with built-in OAuth authentication._
 

--- a/docs/features/skills/index.md
+++ b/docs/features/skills/index.md
@@ -2,9 +2,8 @@
 title: "Skills"
 description: "Skills provide specialized instructions that agents can load on demand when a task matches a skill's description."
 keywords: docker agent, ai agents, features, skills
+weight: 110
 ---
-
-# Skills
 
 _Skills provide specialized instructions that agents can load on demand when a task matches a skill's description._
 

--- a/docs/features/snapshots/index.md
+++ b/docs/features/snapshots/index.md
@@ -2,9 +2,8 @@
 title: "Snapshots"
 description: "Shadow-git snapshots capture your workspace at turn boundaries so you can review what an agent changed and undo it without touching your real git history."
 keywords: docker agent, ai agents, features, snapshots
+weight: 20
 ---
-
-# Snapshots
 
 _Shadow-git snapshots capture your workspace at turn boundaries so you can review what an agent changed and undo it without touching your real git history._
 

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -2,9 +2,9 @@
 title: "Terminal UI (TUI)"
 description: "docker-agent's default interface is a rich, interactive terminal UI with file attachments, themes, session management, and more."
 keywords: docker agent, ai agents, features, terminal ui (tui)
+linkTitle: "Terminal UI"
+weight: 10
 ---
-
-# Terminal UI (TUI)
 
 _docker-agent's default interface is a rich, interactive terminal UI with file attachments, themes, session management, and more._
 

--- a/docs/getting-started/_index.md
+++ b/docs/getting-started/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Getting Started"
+description: "Install Docker Agent and build your first agent."
+weight: 10
+---

--- a/docs/getting-started/installation/index.md
+++ b/docs/getting-started/installation/index.md
@@ -2,9 +2,8 @@
 title: "Installation"
 description: "Get docker-agent running on your system in minutes."
 keywords: docker agent, ai agents, getting started, installation
+weight: 20
 ---
-
-# Installation
 
 _Get docker-agent running on your system in minutes._
 

--- a/docs/getting-started/introduction/index.md
+++ b/docs/getting-started/introduction/index.md
@@ -2,9 +2,8 @@
 title: "Introduction"
 description: "Docker Agent is a multi-agent runtime that lets you build, run, and share AI agents with a YAML or HCL config — no glue code required."
 keywords: docker agent, ai agents, getting started, introduction
+weight: 10
 ---
-
-# Introduction
 
 _Docker Agent is a multi-agent runtime that lets you build, run, and share AI agents with a YAML or HCL config — no glue code required._
 

--- a/docs/getting-started/quickstart/index.md
+++ b/docs/getting-started/quickstart/index.md
@@ -2,9 +2,10 @@
 title: "Quick Start"
 description: "Get up and running with Docker Agent in under 5 minutes. Pick whichever path suits you best."
 keywords: docker agent, ai agents, getting started, quick start
+weight: 30
+aliases:
+  - /ai/docker-agent/tutorial/
 ---
-
-# Quick Start
 
 _Get up and running with Docker Agent in under 5 minutes. Pick whichever path suits you best._
 

--- a/docs/guides/_index.md
+++ b/docs/guides/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Guides"
+description: "Practical guides for building and running agents."
+weight: 70
+---

--- a/docs/guides/go-sdk/index.md
+++ b/docs/guides/go-sdk/index.md
@@ -2,9 +2,8 @@
 title: "Go SDK"
 description: "Use docker-agent as a Go library to embed AI agents in your applications."
 keywords: docker agent, ai agents, guides, go sdk
+weight: 40
 ---
-
-# Go SDK
 
 _Use docker-agent as a Go library to embed AI agents in your applications._
 

--- a/docs/guides/secrets/index.md
+++ b/docs/guides/secrets/index.md
@@ -2,9 +2,8 @@
 title: "Managing Secrets"
 description: "How to securely provide API keys and credentials to docker-agent using environment variables, env files, Docker Compose secrets, macOS Keychain, pass, and 1Password references."
 keywords: docker agent, ai agents, guides, managing secrets
+weight: 30
 ---
-
-# Managing Secrets
 
 _How to securely provide API keys and credentials to docker-agent._
 

--- a/docs/guides/thinking/index.md
+++ b/docs/guides/thinking/index.md
@@ -2,9 +2,8 @@
 title: "Thinking / Reasoning"
 description: "Control how much a model reasons before responding. Works across OpenAI, Anthropic, Google Gemini, AWS Bedrock, and Docker Model Runner."
 keywords: docker agent, ai agents, guides, thinking / reasoning
+weight: 20
 ---
-
-# Thinking / Reasoning
 
 _Control how much a model reasons before responding. Works across OpenAI, Anthropic, Google Gemini, AWS Bedrock, and Docker Model Runner._
 

--- a/docs/guides/tips/index.md
+++ b/docs/guides/tips/index.md
@@ -2,9 +2,10 @@
 title: "Tips & Best Practices"
 description: "Expert guidance for building effective, efficient, and secure agents."
 keywords: docker agent, ai agents, guides, tips & best practices
+weight: 10
+aliases:
+  - /ai/docker-agent/best-practices/
 ---
-
-# Tips & Best Practices
 
 _Expert guidance for building effective, efficient, and secure agents._
 

--- a/docs/providers/_index.md
+++ b/docs/providers/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Model Providers"
+description: "Model providers supported by Docker Agent."
+weight: 60
+---

--- a/docs/providers/anthropic/index.md
+++ b/docs/providers/anthropic/index.md
@@ -2,9 +2,8 @@
 title: "Anthropic"
 description: "Use Claude Sonnet 4, Claude Sonnet 4.5, and other Anthropic models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, anthropic
+weight: 20
 ---
-
-# Anthropic
 
 _Use Claude Sonnet 4, Claude Sonnet 4.5, and other Anthropic models with docker-agent._
 

--- a/docs/providers/baseten/index.md
+++ b/docs/providers/baseten/index.md
@@ -2,9 +2,8 @@
 title: "Baseten"
 description: "Use Baseten AI models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, baseten
+weight: 40
 ---
-
-# Baseten
 
 _Use Baseten AI models with docker-agent._
 

--- a/docs/providers/bedrock/index.md
+++ b/docs/providers/bedrock/index.md
@@ -2,9 +2,8 @@
 title: "AWS Bedrock"
 description: "Access Claude, Nova, Llama, and more through AWS infrastructure with enterprise-grade security and compliance."
 keywords: docker agent, ai agents, model providers, llm, aws bedrock
+weight: 30
 ---
-
-# AWS Bedrock
 
 _Access Claude, Nova, Llama, and more through AWS infrastructure with enterprise-grade security and compliance._
 

--- a/docs/providers/cerebras/index.md
+++ b/docs/providers/cerebras/index.md
@@ -2,9 +2,8 @@
 title: "Cerebras"
 description: "Use Cerebras models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, cerebras
+weight: 50
 ---
-
-# Cerebras
 
 _Use Cerebras models with docker-agent._
 

--- a/docs/providers/cloudflare-ai-gateway/index.md
+++ b/docs/providers/cloudflare-ai-gateway/index.md
@@ -2,9 +2,8 @@
 title: "Cloudflare AI Gateway"
 description: "Use Cloudflare AI Gateway models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, cloudflare ai gateway
+weight: 60
 ---
-
-# Cloudflare AI Gateway
 
 _Use Cloudflare AI Gateway models with docker-agent._
 

--- a/docs/providers/cloudflare-workers-ai/index.md
+++ b/docs/providers/cloudflare-workers-ai/index.md
@@ -2,9 +2,8 @@
 title: "Cloudflare Workers AI"
 description: "Use Cloudflare Workers AI models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, cloudflare workers ai
+weight: 70
 ---
-
-# Cloudflare Workers AI
 
 _Use Cloudflare Workers AI models with docker-agent._
 

--- a/docs/providers/custom/index.md
+++ b/docs/providers/custom/index.md
@@ -2,9 +2,8 @@
 title: "Provider Definitions"
 description: "Define reusable provider configurations with shared defaults for any provider type — OpenAI, Anthropic, Google, Bedrock, and more."
 keywords: docker agent, ai agents, model providers, llm, provider definitions
+weight: 280
 ---
-
-# Provider Definitions
 
 _Define reusable provider configurations with shared defaults for any provider type — OpenAI, Anthropic, Google, Bedrock, and more._
 

--- a/docs/providers/deepseek/index.md
+++ b/docs/providers/deepseek/index.md
@@ -2,9 +2,8 @@
 title: "DeepSeek"
 description: "Use DeepSeek models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, deepseek
+weight: 80
 ---
-
-# DeepSeek
 
 _Use DeepSeek models with docker-agent._
 

--- a/docs/providers/dmr/index.md
+++ b/docs/providers/dmr/index.md
@@ -2,9 +2,8 @@
 title: "Docker Model Runner"
 description: "Run AI models locally with Docker — no API keys, no costs, full data privacy."
 keywords: docker agent, ai agents, model providers, llm, docker model runner
+weight: 90
 ---
-
-# Docker Model Runner
 
 _Run AI models locally with Docker — no API keys, no costs, full data privacy._
 

--- a/docs/providers/fireworks/index.md
+++ b/docs/providers/fireworks/index.md
@@ -2,9 +2,8 @@
 title: "Fireworks AI"
 description: "Use Fireworks AI models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, fireworks ai
+weight: 100
 ---
-
-# Fireworks AI
 
 _Use Fireworks AI models with docker-agent._
 

--- a/docs/providers/github-copilot/index.md
+++ b/docs/providers/github-copilot/index.md
@@ -2,9 +2,8 @@
 title: "GitHub Copilot"
 description: "Use GitHub Copilot's hosted models (GPT-4o, Claude, Gemini, and more) with docker-agent through your GitHub subscription."
 keywords: docker agent, ai agents, model providers, llm, github copilot
+weight: 110
 ---
-
-# GitHub Copilot
 
 _Use GitHub Copilot's hosted models with docker-agent through your existing GitHub subscription._
 

--- a/docs/providers/google/index.md
+++ b/docs/providers/google/index.md
@@ -2,9 +2,8 @@
 title: "Google Gemini"
 description: "Use Gemini 2.5 Flash, Gemini 3 Pro, and other Google models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, google gemini
+weight: 120
 ---
-
-# Google Gemini
 
 _Use Gemini 2.5 Flash, Gemini 3 Pro, and other Google models with docker-agent._
 

--- a/docs/providers/groq/index.md
+++ b/docs/providers/groq/index.md
@@ -2,9 +2,8 @@
 title: "Groq"
 description: "Use Groq fast-inference models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, groq
+weight: 130
 ---
-
-# Groq
 
 _Use Groq models with docker-agent._
 

--- a/docs/providers/huggingface/index.md
+++ b/docs/providers/huggingface/index.md
@@ -2,9 +2,8 @@
 title: "Hugging Face"
 description: "Use Hugging Face Inference Providers with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, hugging face
+weight: 140
 ---
-
-# Hugging Face
 
 _Use Hugging Face Inference Providers with docker-agent._
 

--- a/docs/providers/local/index.md
+++ b/docs/providers/local/index.md
@@ -2,9 +2,11 @@
 title: "Local Models (Ollama, vLLM, LocalAI)"
 description: "Run docker-agent with locally hosted models for privacy, offline use, or cost savings."
 keywords: docker agent, ai agents, model providers, llm, local models (ollama, vllm, localai)
+linkTitle: "Local Models"
+weight: 150
+aliases:
+  - /ai/docker-agent/local-models/
 ---
-
-# Local Models (Ollama, vLLM, LocalAI)
 
 _Run docker-agent with locally hosted models for privacy, offline use, or cost savings._
 

--- a/docs/providers/minimax/index.md
+++ b/docs/providers/minimax/index.md
@@ -2,9 +2,8 @@
 title: "MiniMax"
 description: "Use MiniMax AI models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, minimax
+weight: 160
 ---
-
-# MiniMax
 
 _Use MiniMax AI models with docker-agent._
 

--- a/docs/providers/mistral/index.md
+++ b/docs/providers/mistral/index.md
@@ -2,9 +2,8 @@
 title: "Mistral"
 description: "Use Mistral AI models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, mistral
+weight: 170
 ---
-
-# Mistral
 
 _Use Mistral AI models with docker-agent._
 

--- a/docs/providers/moonshot/index.md
+++ b/docs/providers/moonshot/index.md
@@ -2,9 +2,8 @@
 title: "Moonshot AI"
 description: "Use Moonshot AI (Kimi) models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, moonshot ai
+weight: 180
 ---
-
-# Moonshot AI
 
 _Use Moonshot AI (Kimi) models with docker-agent._
 

--- a/docs/providers/nebius/index.md
+++ b/docs/providers/nebius/index.md
@@ -2,9 +2,8 @@
 title: "Nebius"
 description: "Use Nebius AI models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, nebius
+weight: 190
 ---
-
-# Nebius
 
 _Use Nebius AI models with docker-agent._
 

--- a/docs/providers/openai/index.md
+++ b/docs/providers/openai/index.md
@@ -2,9 +2,8 @@
 title: "OpenAI"
 description: "Use GPT-4o, GPT-5, GPT-5-mini, and other OpenAI models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, openai
+weight: 200
 ---
-
-# OpenAI
 
 _Use GPT-4o, GPT-5, GPT-5-mini, and other OpenAI models with docker-agent._
 

--- a/docs/providers/opencode-go/index.md
+++ b/docs/providers/opencode-go/index.md
@@ -2,9 +2,8 @@
 title: "OpenCode Go"
 description: "Use OpenCode Go models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, opencode go
+weight: 210
 ---
-
-# OpenCode Go
 
 _Use OpenCode Go models with docker-agent._
 

--- a/docs/providers/opencode-zen/index.md
+++ b/docs/providers/opencode-zen/index.md
@@ -2,9 +2,8 @@
 title: "OpenCode Zen"
 description: "Use OpenCode Zen models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, opencode zen
+weight: 220
 ---
-
-# OpenCode Zen
 
 _Use OpenCode Zen models with docker-agent._
 

--- a/docs/providers/openrouter/index.md
+++ b/docs/providers/openrouter/index.md
@@ -2,9 +2,8 @@
 title: "OpenRouter"
 description: "Use OpenRouter models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, openrouter
+weight: 230
 ---
-
-# OpenRouter
 
 _Use OpenRouter models with docker-agent._
 

--- a/docs/providers/overview/index.md
+++ b/docs/providers/overview/index.md
@@ -2,9 +2,11 @@
 title: "Model Providers"
 description: "docker-agent supports multiple AI model providers. Choose the right one for your use case, or use multiple providers in the same configuration."
 keywords: docker agent, ai agents, model providers, llm
+linkTitle: "Overview"
+weight: 10
+aliases:
+  - /ai/docker-agent/model-providers/
 ---
-
-# Model Providers
 
 _docker-agent supports multiple AI model providers. Choose the right one for your use case, or use multiple providers in the same configuration._
 

--- a/docs/providers/ovhcloud/index.md
+++ b/docs/providers/ovhcloud/index.md
@@ -2,9 +2,8 @@
 title: "OVHcloud"
 description: "Use OVHcloud AI Endpoints models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, ovhcloud
+weight: 240
 ---
-
-# OVHcloud
 
 _Use OVHcloud AI Endpoints models with docker-agent._
 

--- a/docs/providers/together/index.md
+++ b/docs/providers/together/index.md
@@ -2,9 +2,8 @@
 title: "Together AI"
 description: "Use Together AI models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, together ai
+weight: 250
 ---
-
-# Together AI
 
 _Use Together AI models with docker-agent._
 

--- a/docs/providers/vercel/index.md
+++ b/docs/providers/vercel/index.md
@@ -2,9 +2,8 @@
 title: "Vercel AI Gateway"
 description: "Use Vercel AI Gateway models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, vercel ai gateway
+weight: 260
 ---
-
-# Vercel AI Gateway
 
 _Use Vercel AI Gateway models with docker-agent._
 

--- a/docs/providers/xai/index.md
+++ b/docs/providers/xai/index.md
@@ -2,7 +2,6 @@
 title: "xAI (Grok)"
 description: "Use xAI's Grok models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, xai (grok)
-linkTitle: ""xAI (Grok)""
 weight: 270
 ---
 

--- a/docs/providers/xai/index.md
+++ b/docs/providers/xai/index.md
@@ -2,9 +2,9 @@
 title: "xAI (Grok)"
 description: "Use xAI's Grok models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, xai (grok)
+linkTitle: ""xAI (Grok)""
+weight: 270
 ---
-
-# xAI (Grok)
 
 _Use xAI's Grok models with docker-agent._
 

--- a/docs/tools/_index.md
+++ b/docs/tools/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Built-in Tools"
+description: "Built-in toolsets agents can use out of the box."
+weight: 40
+---

--- a/docs/tools/a2a/index.md
+++ b/docs/tools/a2a/index.md
@@ -2,9 +2,9 @@
 title: "A2A Tool"
 description: "Connect to remote agents via the Agent-to-Agent protocol."
 keywords: docker agent, ai agents, tools, toolsets, a2a tool
+linkTitle: "A2A"
+weight: 60
 ---
-
-# A2A Tool
 
 _Connect to remote agents via the Agent-to-Agent protocol._
 

--- a/docs/tools/api/index.md
+++ b/docs/tools/api/index.md
@@ -2,9 +2,9 @@
 title: "API Tool"
 description: "Create custom tools that call HTTP APIs."
 keywords: docker agent, ai agents, tools, toolsets, api tool
+linkTitle: "API"
+weight: 240
 ---
-
-# API Tool
 
 _Create custom tools that call HTTP APIs._
 

--- a/docs/tools/background-agents/index.md
+++ b/docs/tools/background-agents/index.md
@@ -2,9 +2,9 @@
 title: "Background Agents Tool"
 description: "Dispatch work to sub-agents concurrently and collect results asynchronously."
 keywords: docker agent, ai agents, tools, toolsets, background agents tool
+linkTitle: "Background Agents"
+weight: 90
 ---
-
-# Background Agents Tool
 
 _Dispatch work to sub-agents concurrently and collect results asynchronously._
 

--- a/docs/tools/fetch/index.md
+++ b/docs/tools/fetch/index.md
@@ -2,9 +2,9 @@
 title: "Fetch Tool"
 description: "Read content from HTTP/HTTPS URLs."
 keywords: docker agent, ai agents, tools, toolsets, fetch tool
+linkTitle: "Fetch"
+weight: 50
 ---
-
-# Fetch Tool
 
 _Read content from HTTP/HTTPS URLs._
 

--- a/docs/tools/filesystem/index.md
+++ b/docs/tools/filesystem/index.md
@@ -2,9 +2,9 @@
 title: "Filesystem Tool"
 description: "Read, write, list, search, and navigate files and directories."
 keywords: docker agent, ai agents, tools, toolsets, filesystem tool
+linkTitle: "Filesystem"
+weight: 10
 ---
-
-# Filesystem Tool
 
 _Read, write, list, search, and navigate files and directories._
 

--- a/docs/tools/handoff/index.md
+++ b/docs/tools/handoff/index.md
@@ -2,9 +2,9 @@
 title: "Handoff Tool"
 description: "Hand off the active conversation to another local agent defined in the same config."
 keywords: docker agent, ai agents, tools, toolsets, handoff tool
+linkTitle: "Handoff"
+weight: 70
 ---
-
-# Handoff Tool
 
 _Hand off the active conversation to another local agent defined in the same config._
 

--- a/docs/tools/lsp/index.md
+++ b/docs/tools/lsp/index.md
@@ -2,9 +2,9 @@
 title: "LSP Tool"
 description: "Connect to Language Server Protocol servers for code intelligence."
 keywords: docker agent, ai agents, tools, toolsets, lsp tool
+linkTitle: "LSP"
+weight: 220
 ---
-
-# LSP Tool
 
 _Connect to Language Server Protocol servers for code intelligence._
 

--- a/docs/tools/mcp-catalog/index.md
+++ b/docs/tools/mcp-catalog/index.md
@@ -2,9 +2,9 @@
 title: "MCP Catalog Tool"
 description: "Let the agent discover and activate remote MCP servers from the Docker MCP Catalog on demand."
 keywords: docker agent, ai agents, tools, toolsets, mcp catalog tool
+linkTitle: "MCP Catalog"
+weight: 120
 ---
-
-# MCP Catalog Tool
 
 _Let the agent discover and activate remote MCP servers from the Docker MCP Catalog on demand._
 

--- a/docs/tools/mcp/index.md
+++ b/docs/tools/mcp/index.md
@@ -2,9 +2,11 @@
 title: "MCP Tool"
 description: "Extend agents with external tools via the Model Context Protocol."
 keywords: docker agent, ai agents, tools, toolsets, mcp tool
+linkTitle: "MCP"
+weight: 130
+aliases:
+  - /ai/docker-agent/integrations/mcp/
 ---
-
-# MCP Tool
 
 _Extend agents with external tools via the Model Context Protocol (MCP)._
 

--- a/docs/tools/memory/index.md
+++ b/docs/tools/memory/index.md
@@ -2,9 +2,9 @@
 title: "Memory Tool"
 description: "Persistent key-value storage backed by SQLite for cross-session recall."
 keywords: docker agent, ai agents, tools, toolsets, memory tool
+linkTitle: "Memory"
+weight: 100
 ---
-
-# Memory Tool
 
 _Persistent key-value storage backed by SQLite for cross-session recall._
 

--- a/docs/tools/model-picker/index.md
+++ b/docs/tools/model-picker/index.md
@@ -2,9 +2,9 @@
 title: "Model Picker Tool"
 description: "Let the agent pick between several models per turn."
 keywords: docker agent, ai agents, tools, toolsets, model picker tool
+linkTitle: "Model Picker"
+weight: 200
 ---
-
-# Model Picker Tool
 
 _Let the agent pick between several models per turn._
 

--- a/docs/tools/open-url/index.md
+++ b/docs/tools/open-url/index.md
@@ -2,9 +2,9 @@
 title: "Open URL Tool"
 description: "Open a fixed URL in the user's default browser."
 keywords: docker agent, ai agents, tools, toolsets, open url tool
+linkTitle: "Open URL"
+weight: 40
 ---
-
-# Open URL Tool
 
 _Open a fixed URL in the user's default browser._
 

--- a/docs/tools/openapi/index.md
+++ b/docs/tools/openapi/index.md
@@ -2,9 +2,9 @@
 title: "OpenAPI Tool"
 description: "Automatically generate tools from an OpenAPI specification."
 keywords: docker agent, ai agents, tools, toolsets, openapi tool
+linkTitle: "OpenAPI"
+weight: 230
 ---
-
-# OpenAPI Tool
 
 _Automatically generate tools from an OpenAPI specification._
 

--- a/docs/tools/plan/index.md
+++ b/docs/tools/plan/index.md
@@ -2,9 +2,9 @@
 title: "Plan Tool"
 description: "Shared persistent scratchpad for multi-agent collaboration."
 keywords: docker agent, ai agents, tools, toolsets, plan tool
+linkTitle: "Plan"
+weight: 150
 ---
-
-# Plan Tool
 
 _Shared persistent scratchpad for multi-agent collaboration._
 

--- a/docs/tools/rag/index.md
+++ b/docs/tools/rag/index.md
@@ -2,9 +2,11 @@
 title: "RAG Tool"
 description: "Give your agents access to document knowledge bases with background indexing, multiple retrieval strategies, and hybrid search."
 keywords: docker agent, ai agents, tools, toolsets, rag tool
+linkTitle: "RAG"
+weight: 110
+aliases:
+  - /ai/docker-agent/rag/
 ---
-
-# RAG Tool
 
 _Give your agents access to document knowledge bases with background indexing, multiple retrieval strategies, and hybrid search._
 

--- a/docs/tools/script/index.md
+++ b/docs/tools/script/index.md
@@ -2,9 +2,9 @@
 title: "Script Tool"
 description: "Define custom shell scripts as named tools with typed parameters."
 keywords: docker agent, ai agents, tools, toolsets, script tool
+linkTitle: "Script"
+weight: 30
 ---
-
-# Script Tool
 
 _Define custom shell scripts as named tools with typed parameters._
 

--- a/docs/tools/session_context/index.md
+++ b/docs/tools/session_context/index.md
@@ -2,9 +2,9 @@
 title: "Session Context Tool"
 description: "Reference a previous session as context in the current one."
 keywords: docker agent, ai agents, tools, toolsets, session context tool
+linkTitle: "Session Context"
+weight: 210
 ---
-
-# Session Context Tool
 
 _Reference a previous session as context, without manual export/import._
 

--- a/docs/tools/session_plan/index.md
+++ b/docs/tools/session_plan/index.md
@@ -2,9 +2,9 @@
 title: "Session Plan Tool"
 description: "Per-session plan tracker for the draft, review, execute workflow."
 keywords: docker agent, ai agents, tools, toolsets, session plan tool
+linkTitle: "Session Plan"
+weight: 160
 ---
-
-# Session Plan Tool
 
 _Per-session plan tracker for the "draft, review, execute" workflow._
 

--- a/docs/tools/shell/index.md
+++ b/docs/tools/shell/index.md
@@ -2,9 +2,9 @@
 title: "Shell Tool"
 description: "Execute arbitrary shell commands in the user's environment."
 keywords: docker agent, ai agents, tools, toolsets, shell tool
+linkTitle: "Shell"
+weight: 20
 ---
-
-# Shell Tool
 
 _Execute arbitrary shell commands in the user's environment._
 

--- a/docs/tools/shell/index.md
+++ b/docs/tools/shell/index.md
@@ -49,7 +49,7 @@ toolsets:
     safer: true
 ```
 
-This auto-registers the [`safer_shell`](../../configuration/hooks/#built-in-hooks) builtin
+This auto-registers the [`safer_shell`](../../configuration/hooks/index.md#built-in-hooks) builtin
 under `pre_tool_use` with `preempt_yolo: true` so the entry fires
 before `Decide()` / `--yolo`. Three behaviors:
 

--- a/docs/tools/tasks/index.md
+++ b/docs/tools/tasks/index.md
@@ -2,9 +2,9 @@
 title: "Tasks Tool"
 description: "Persistent task database with priorities and dependencies, shared across sessions."
 keywords: docker agent, ai agents, tools, toolsets, tasks tool
+linkTitle: "Tasks"
+weight: 180
 ---
-
-# Tasks Tool
 
 _Persistent task database with priorities and dependencies, shared across sessions._
 

--- a/docs/tools/think/index.md
+++ b/docs/tools/think/index.md
@@ -2,9 +2,9 @@
 title: "Think Tool"
 description: "Step-by-step reasoning scratchpad for planning and decision-making."
 keywords: docker agent, ai agents, tools, toolsets, think tool
+linkTitle: "Think"
+weight: 140
 ---
-
-# Think Tool
 
 _Step-by-step reasoning scratchpad for planning and decision-making._
 

--- a/docs/tools/todo/index.md
+++ b/docs/tools/todo/index.md
@@ -2,9 +2,9 @@
 title: "Todo Tool"
 description: "Task list management for complex multi-step workflows."
 keywords: docker agent, ai agents, tools, toolsets, todo tool
+linkTitle: "Todo"
+weight: 170
 ---
-
-# Todo Tool
 
 _Task list management for complex multi-step workflows._
 

--- a/docs/tools/transfer-task/index.md
+++ b/docs/tools/transfer-task/index.md
@@ -2,9 +2,9 @@
 title: "Transfer Task Tool"
 description: "Delegate tasks to sub-agents in multi-agent setups."
 keywords: docker agent, ai agents, tools, toolsets, transfer task tool
+linkTitle: "Transfer Task"
+weight: 80
 ---
-
-# Transfer Task Tool
 
 _Delegate tasks to sub-agents in multi-agent setups._
 

--- a/docs/tools/user-prompt/index.md
+++ b/docs/tools/user-prompt/index.md
@@ -2,9 +2,9 @@
 title: "User Prompt Tool"
 description: "Ask the user questions and collect interactive input during agent execution."
 keywords: docker agent, ai agents, tools, toolsets, user prompt tool
+linkTitle: "User Prompt"
+weight: 190
 ---
-
-# User Prompt Tool
 
 _Ask the user questions and collect interactive input during agent execution._
 


### PR DESCRIPTION
Companion change for the docs.docker.com Hugo module mount (#3371, phase 2.1). Follows up on #3413 (merged).

## Why

Pages mounted on docs.docker.com must match its conventions: the layout renders the front matter `title` as the page H1, sidebar order comes from `weight`, and the replaced hand-authored URLs need `aliases`. Verified against the pages already mounted from docker/cli and moby/buildkit (none carry a body H1).

## What changed

| Change | Detail |
|---|---|
| Body H1 dropped from all 90 content pages | The Jekyll layout now renders `<h1>{{ page.title }}</h1>` like docs.docker.com does; the homepage keeps its hero |
| `weight:` front matter | Derived from `_data/nav.yml` order so the docs.docker.com sidebar matches github.io navigation |
| `linkTitle:` front matter | Added where the nav label differs from the page title |
| Section `_index.md` files (8) | Title, description, weight per section; Jekyll ignores underscore-prefixed files so github.io output is unchanged |
| `aliases:` front matter | Maps the docs.docker.com URLs of the hand-authored pages being replaced onto their mounted equivalents |

## Alias mapping (old docs.docker.com URL -> mounted page)

| Old page | New owner of the URL |
|---|---|
| `/ai/docker-agent/tutorial/` | `getting-started/quickstart` |
| `/ai/docker-agent/best-practices/` | `guides/tips` |
| `/ai/docker-agent/evals/` | `features/evaluation` |
| `/ai/docker-agent/local-models/` | `providers/local` |
| `/ai/docker-agent/model-providers/` | `providers/overview` |
| `/ai/docker-agent/rag/` | `tools/rag` |
| `/ai/docker-agent/sharing-agents/` | `concepts/distribution` |
| `/ai/docker-agent/integrations/a2a/` | `features/a2a` |
| `/ai/docker-agent/integrations/acp/` | `features/acp` |
| `/ai/docker-agent/integrations/mcp/` | `tools/mcp` |
| `/ai/docker-agent/reference/cli/` | `features/cli` |
| `/ai/docker-agent/reference/config/` | `configuration/overview` |
| `/ai/docker-agent/reference/toolsets/` | `configuration/tools` |

Section indexes (`integrations/`, `reference/`) and `reference/examples/` get aliases on the hand-authored `_index.md` kept in docker/docs (part of the docker/docs PR).

## Validation

| Check | Result |
|---|---|
| markdownlint-cli2 | 0 errors |
| lychee offline link check | 0 errors |
| Jekyll build + rendered HTML | layout H1 renders, homepage untouched, `_index.md` files produce no output |
| muffet crawl (internal links) | 0 errors |

Part of #3371; the docker/docs PR (go.mod pin + hugo.yaml mounts) follows.
