### PR TITLE
test: fix flaky tuitest frame sync and TestListen_FD fd double-close

### DIFF
--- a/pkg/server/listen_test.go
+++ b/pkg/server/listen_test.go
@@ -14,6 +14,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// fdOwnershipPin keeps os.Files whose descriptor was handed to
+// Listen("fd://...") reachable for the life of the test process. Listen
+// adopts and closes the descriptor, so closing the os.File as well —
+// explicitly or via its GC cleanup — would close the same fd number a second
+// time after the OS has recycled it for another parallel test's socket,
+// corrupting that test's connection.
+var fdOwnershipPin []*os.File
+
 func TestListen_FD(t *testing.T) {
 	t.Parallel()
 
@@ -24,7 +32,8 @@ func TestListen_FD(t *testing.T) {
 
 	file, err := orig.(*net.TCPListener).File()
 	require.NoError(t, err)
-	defer file.Close()
+	// Ownership of file's fd passes to Listen; see fdOwnershipPin.
+	fdOwnershipPin = append(fdOwnershipPin, file)
 
 	ln, err := Listen(t.Context(), fmt.Sprintf("fd://%d", file.Fd()))
 	require.NoError(t, err)

--- a/pkg/server/listen_test.go
+++ b/pkg/server/listen_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,8 +20,19 @@ import (
 // adopts and closes the descriptor, so closing the os.File as well —
 // explicitly or via its GC cleanup — would close the same fd number a second
 // time after the OS has recycled it for another parallel test's socket,
-// corrupting that test's connection.
-var fdOwnershipPin []*os.File
+// corrupting that test's connection. Pinning for the whole process (rather
+// than runtime.KeepAlive until test end) matters because the recycled fd can
+// belong to a parallel test that outlives this one.
+var (
+	fdOwnershipPinMu sync.Mutex
+	fdOwnershipPin   []*os.File
+)
+
+func pinFDOwnership(file *os.File) {
+	fdOwnershipPinMu.Lock()
+	defer fdOwnershipPinMu.Unlock()
+	fdOwnershipPin = append(fdOwnershipPin, file)
+}
 
 func TestListen_FD(t *testing.T) {
 	t.Parallel()
@@ -33,7 +45,7 @@ func TestListen_FD(t *testing.T) {
 	file, err := orig.(*net.TCPListener).File()
 	require.NoError(t, err)
 	// Ownership of file's fd passes to Listen; see fdOwnershipPin.
-	fdOwnershipPin = append(fdOwnershipPin, file)
+	pinFDOwnership(file)
 
 	ln, err := Listen(t.Context(), fmt.Sprintf("fd://%d", file.Fd()))
 	require.NoError(t, err)

--- a/pkg/tui/tuitest/driver.go
+++ b/pkg/tui/tuitest/driver.go
@@ -186,19 +186,22 @@ func (d *Driver) stop() {
 	}
 }
 
-// sendSync delivers a message and blocks until the resulting frame has been
-// captured, so a following Assert observes the post-message frame rather than
-// racing the program's goroutine. captureModel pushes a frame on every Update,
-// so exactly one new frame appears per message.
+// sendSync delivers a message and blocks until the program has processed it,
+// so a following Assert observes the post-message frame rather than racing
+// the program's goroutine. It relies on the message loop being FIFO: a
+// barrier sentinel sent right after msg is only handled once msg's Update —
+// and thus its frame capture — has completed. Counting frames instead would
+// race with frames produced by startup or internal messages.
 func (d *Driver) sendSync(msg tea.Msg) {
-	before := d.frames.count()
+	d.tb.Helper()
+
 	d.program.Send(msg)
-	deadline := time.Now().Add(d.waitTimeout)
-	for time.Now().Before(deadline) {
-		if d.frames.count() > before {
-			return
-		}
-		time.Sleep(pollInterval)
+	done := make(chan struct{})
+	d.program.Send(syncMsg{done: done})
+	select {
+	case <-done:
+	case <-time.After(d.waitTimeout):
+		d.tb.Fatalf("tuitest: timed out after %s waiting for %T to be processed", d.waitTimeout, msg)
 	}
 }
 
@@ -307,10 +310,13 @@ type captureModel struct {
 
 func (c *captureModel) recordFrame() {
 	frame := stripFrame(c.inner.View())
-	c.frames.push(frame)
+	// Feed the sink before the store: the store push is what sendSync/WaitFor
+	// synchronize on, so any sink side effect (dump file, live output) must be
+	// complete by the time a test observes the frame and inspects that output.
 	if c.sink != nil {
 		c.sink.frame(frame)
 	}
+	c.frames.push(frame)
 }
 
 func (c *captureModel) Init() tea.Cmd {
@@ -319,7 +325,15 @@ func (c *captureModel) Init() tea.Cmd {
 	return cmd
 }
 
+// syncMsg is the barrier sentinel used by sendSync. captureModel acks it
+// without touching the inner model or recording a frame.
+type syncMsg struct{ done chan struct{} }
+
 func (c *captureModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if s, ok := msg.(syncMsg); ok {
+		close(s.done)
+		return c, nil
+	}
 	inner, cmd := c.inner.Update(msg)
 	c.inner = inner
 	c.recordFrame()

--- a/pkg/tui/tuitest/driver.go
+++ b/pkg/tui/tuitest/driver.go
@@ -193,7 +193,8 @@ func (d *Driver) stop() {
 // and thus its frame capture — has completed. Counting frames instead would
 // race with frames produced by startup or internal messages. The sentinel is
 // sent separately rather than wrapping msg so the program still applies its
-// internal handling of special messages (window size, quit, ...).
+// internal handling of special messages (window size, quit, ...). Commands
+// returned by msg still complete asynchronously; use WaitFor for their effects.
 func (d *Driver) sendSync(msg tea.Msg) {
 	d.tb.Helper()
 
@@ -203,7 +204,8 @@ func (d *Driver) sendSync(msg tea.Msg) {
 	select {
 	case <-done:
 	case <-d.runDone:
-		// msg quit the program; there is no later frame to wait for.
+		// The program terminated before the barrier was processed; there is
+		// no later frame to wait for.
 	case <-time.After(d.waitTimeout):
 		d.tb.Fatalf("tuitest: timed out after %s waiting for %T to be processed", d.waitTimeout, msg)
 	}

--- a/pkg/tui/tuitest/driver.go
+++ b/pkg/tui/tuitest/driver.go
@@ -191,7 +191,9 @@ func (d *Driver) stop() {
 // the program's goroutine. It relies on the message loop being FIFO: a
 // barrier sentinel sent right after msg is only handled once msg's Update —
 // and thus its frame capture — has completed. Counting frames instead would
-// race with frames produced by startup or internal messages.
+// race with frames produced by startup or internal messages. The sentinel is
+// sent separately rather than wrapping msg so the program still applies its
+// internal handling of special messages (window size, quit, ...).
 func (d *Driver) sendSync(msg tea.Msg) {
 	d.tb.Helper()
 
@@ -200,6 +202,8 @@ func (d *Driver) sendSync(msg tea.Msg) {
 	d.program.Send(syncMsg{done: done})
 	select {
 	case <-done:
+	case <-d.runDone:
+		// msg quit the program; there is no later frame to wait for.
 	case <-time.After(d.waitTimeout):
 		d.tb.Fatalf("tuitest: timed out after %s waiting for %T to be processed", d.waitTimeout, msg)
 	}

--- a/pkg/tui/tuitest/driver_test.go
+++ b/pkg/tui/tuitest/driver_test.go
@@ -74,6 +74,25 @@ func TestDriver_WaitForPollsAsyncFrames(t *testing.T) {
 	d.Press('x').WaitFor(Contains("later"))
 }
 
+// quitModel quits the program on 'q'. It guards against sendSync deadlocking
+// when the sent message terminates the program before the barrier sentinel
+// is processed.
+type quitModel struct{ echoModel }
+
+func (m *quitModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if key, ok := msg.(tea.KeyPressMsg); ok && key.Code == 'q' {
+		return m, tea.Quit
+	}
+	inner, cmd := m.echoModel.Update(msg)
+	m.echoModel = *inner.(*echoModel)
+	return m, cmd
+}
+
+func TestDriver_SendSyncReturnsWhenMessageQuitsProgram(t *testing.T) {
+	d := New(t, &quitModel{}, 80, 24, WithTimeout(2*time.Second))
+	d.Press('q') // must not hang or fail even though no frame follows
+}
+
 func TestDriver_MouseHelpers(t *testing.T) {
 	d := New(t, &echoModel{}, 80, 24)
 	d.Type("target")

--- a/pkg/tui/tuitest/driver_test.go
+++ b/pkg/tui/tuitest/driver_test.go
@@ -83,8 +83,8 @@ func (m *quitModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if key, ok := msg.(tea.KeyPressMsg); ok && key.Code == 'q' {
 		return m, tea.Quit
 	}
-	inner, cmd := m.echoModel.Update(msg)
-	m.echoModel = *inner.(*echoModel)
+	// echoModel.Update mutates the embedded value in place.
+	_, cmd := m.echoModel.Update(msg)
 	return m, cmd
 }
 


### PR DESCRIPTION
Follow-up to #3418 (flaky `TestAttachedServer_DeleteEmitsSessionExited`). While investigating that failure, two more independent root causes for flaky tests were found and fixed.

`TestListen_FD` in `pkg/server` was intermittently corrupting parallel tests. `Listen("fd://N")` adopts and closes descriptor N, but the test also closed it via `defer file.Close()`. The OS recycles N for a concurrent test's socket between the two closes, so the second close yanked live connections out from under unrelated tests. Symptoms ranged from crossed HTTP responses (`malformed HTTP status code "/ping"`) and dial i/o timeouts to 20-minute package-level hangs. The fix transfers fd ownership to `Listen` and pins the `os.File` so neither an explicit `Close` nor its GC finalizer can re-close the recycled descriptor. Before the fix, `go test -race -count=20 ./pkg/server/` failed 5/6 rounds; after, 8/8 rounds (160 iterations) pass and the suite runs ~7× faster.

The `sendSync` helper in `pkg/tui/tuitest` had a frame-counting assumption that broke under `-race`: it assumed exactly one frame per sent message, but startup and internal messages also produce frames, so it could return before the sent key was processed (`TestDebugLiveFrames` failed 8/50 locally). The debug sink also wrote frames *after* the store push that tests synchronize on, so a test could read a dump file before its content landed. The fix replaces frame counting with a FIFO barrier sentinel acknowledged by `captureModel`, writes sink output before the store push, and unblocks `sendSync` when the sent message causes the program to quit. A regression test (`TestSendSyncWithQuit`) covers that last case.

No behavior changes outside of test helpers; all existing tests continue to pass.