### PR TITLE
feat: support global hooks in user config

### DIFF
--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -315,6 +315,7 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 	// User settings only apply if the flag wasn't explicitly set by the user
 	userSettings := userconfig.Get()
 	f.applyUserSettings(ctx, userSettings)
+	f.runConfig.GlobalHooks = userSettings.GlobalHooks()
 
 	// Apply alias options if this is an alias reference
 	// Alias options only apply if the flag wasn't explicitly set by the user

--- a/docs/configuration/hooks/index.md
+++ b/docs/configuration/hooks/index.md
@@ -66,6 +66,8 @@ docker-agent dispatches the following hook events:
 
 ## Configuration
 
+You can configure hooks directly in an agent YAML file under the agent's `hooks:` block:
+
 ```yaml
 agents:
   root:
@@ -113,6 +115,35 @@ agents:
         - type: command
           command: "./scripts/alert.sh"
 ```
+
+## Global (user-level) hooks
+
+Global hooks let you apply the same hook configuration to every agent you run. Define them in your user config file at `~/.config/cagent/config.yaml` under `settings.hooks`:
+
+```yaml
+# ~/.config/cagent/config.yaml
+settings:
+  hooks:
+    session_start:
+      - type: command
+        command: "~/.config/cagent/hooks/session-start.sh"
+    pre_compact:
+      - type: command
+        command: "~/.config/cagent/hooks/pre-compact.sh"
+    pre_tool_use:
+      - matcher: "shell"
+        hooks:
+          - type: command
+            command: "~/.config/cagent/hooks/check-shell.sh"
+```
+
+Global hooks use the same schema as agent-level hooks and are additive. If an event is configured in multiple places, all matching hooks run in this order:
+
+1. Agent-config hooks from the agent YAML
+2. Global hooks from `settings.hooks`
+3. CLI hooks from `--hook-*` flags
+
+Global hooks cannot be suppressed by an individual agent. Use them for user-wide audit logging, personal guardrails, notifications, and setup/cleanup behavior that should apply everywhere.
 
 ## Built-in Hooks
 
@@ -879,4 +910,4 @@ $ docker agent run agentcatalog/coder \
 > [!NOTE]
 > **Merging behavior**
 >
-> CLI hooks are **appended** to any hooks already defined in the agent's YAML config. They don't replace existing hooks. Pre/post-tool-use hooks added via CLI match all tools (equivalent to `matcher: "*"`).
+> Agent-config, global, and CLI hooks are additive. For each event, hooks run in this order: agent-config hooks first, then global hooks from `settings.hooks`, then CLI hooks. No source replaces another, and individual agents cannot opt out of global hooks.

--- a/docs/configuration/permissions/index.md
+++ b/docs/configuration/permissions/index.md
@@ -25,6 +25,8 @@ Permissions can be defined at two levels:
 | **Agent-level** | Agent YAML config (`permissions:` section) | Applies to that specific agent config |
 | **Global (user-level)** | `~/.config/cagent/config.yaml` under `settings.permissions` | Applies to every agent you run |
 
+Hooks follow the same user-config pattern: agent-level hooks live under `agents.<name>.hooks`, and global hooks live under `settings.hooks`. See [Hooks](../hooks/index.md#global-user-level-hooks).
+
 Both levels use the same `allow`/`ask`/`deny` pattern syntax. When both are present, they are **merged** at startup -- patterns from both sources are combined into a single checker. See [Merging Behavior](#merging-behavior) for details.
 
 ## Agent-Level Configuration

--- a/pkg/config/hooks_test.go
+++ b/pkg/config/hooks_test.go
@@ -212,6 +212,9 @@ func TestRuntimeConfig_CLIHooks(t *testing.T) {
 func TestRuntimeConfig_Clone_CopiesHooks(t *testing.T) {
 	t.Parallel()
 	rc := &RuntimeConfig{}
+	rc.GlobalHooks = &latest.HooksConfig{
+		SessionStart: []latest.HookDefinition{{Type: "command", Command: "global"}},
+	}
 	rc.HookPreToolUse = []string{"pre"}
 	rc.HookPostToolUse = []string{"post"}
 	rc.HookSessionStart = []string{"start"}
@@ -220,6 +223,7 @@ func TestRuntimeConfig_Clone_CopiesHooks(t *testing.T) {
 	rc.HookStop = []string{"stop"}
 
 	clone := rc.Clone()
+	assert.Equal(t, rc.GlobalHooks, clone.GlobalHooks)
 	assert.Equal(t, rc.HookPreToolUse, clone.HookPreToolUse)
 	assert.Equal(t, rc.HookPostToolUse, clone.HookPostToolUse)
 	assert.Equal(t, rc.HookSessionStart, clone.HookSessionStart)

--- a/pkg/config/runtime.go
+++ b/pkg/config/runtime.go
@@ -41,7 +41,8 @@ type Config struct {
 	Models         map[string]latest.ModelConfig
 	Providers      map[string]latest.ProviderConfig
 
-	// Hook overrides from CLI flags
+	// Hook overrides from user config and CLI flags
+	GlobalHooks      *latest.HooksConfig
 	HookPreToolUse   []string
 	HookPostToolUse  []string
 	HookSessionStart []string

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -213,6 +213,7 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 
 	expander := js.NewJsExpander(env)
 
+	globalHooks := runConfig.GlobalHooks
 	cliHooks := runConfig.CLIHooks()
 
 	for _, agentConfig := range cfg.Agents {
@@ -244,7 +245,7 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 			agent.WithMaxOldToolCallTokens(agentConfig.MaxOldToolCallTokens),
 			agent.WithNumHistoryItems(agentConfig.NumHistoryItems),
 			agent.WithCommands(expander.ExpandCommands(ctx, agentConfig.Commands)),
-			agent.WithHooks(config.MergeHooks(agentConfig.Hooks, cliHooks)),
+			agent.WithHooks(config.MergeHooks(config.MergeHooks(agentConfig.Hooks, globalHooks), cliHooks)),
 		}
 
 		if agentConfig.Cache != nil && agentConfig.Cache.Enabled {

--- a/pkg/teamloader/teamloader_test.go
+++ b/pkg/teamloader/teamloader_test.go
@@ -768,3 +768,82 @@ func TestLoadRetainsAgentConfig(t *testing.T) {
 	_, ok = team.AgentConfig("missing")
 	assert.False(t, ok, "unknown agent reports no retained config")
 }
+
+func TestLoadWithConfig_GlobalHooks(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "dummy")
+
+	data := []byte(`agents:
+  root:
+    model: openai/gpt-4o
+    instruction: test
+`)
+	runConfig := &config.RuntimeConfig{
+		Config: config.Config{
+			GlobalHooks: &latest.HooksConfig{
+				SessionStart: []latest.HookDefinition{{Type: "command", Command: "global"}},
+			},
+		},
+	}
+
+	team, err := Load(t.Context(), config.NewBytesSource("global-hooks.yaml", data), runConfig, withTestProviderRegistry()...)
+	require.NoError(t, err)
+
+	root, err := team.Agent("root")
+	require.NoError(t, err)
+	require.NotNil(t, root.Hooks())
+	require.Len(t, root.Hooks().SessionStart, 1)
+	assert.Equal(t, "global", root.Hooks().SessionStart[0].Command)
+}
+
+func TestLoadWithConfig_MergesAgentGlobalAndCLIHooks(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "dummy")
+
+	data := []byte(`agents:
+  root:
+    model: openai/gpt-4o
+    instruction: test
+    hooks:
+      session_start:
+        - type: command
+          command: agent
+      pre_tool_use:
+        - matcher: shell
+          hooks:
+            - type: command
+              command: agent-pre
+`)
+	runConfig := &config.RuntimeConfig{
+		Config: config.Config{
+			GlobalHooks: &latest.HooksConfig{
+				SessionStart: []latest.HookDefinition{{Type: "command", Command: "global"}},
+				PreToolUse: []latest.HookMatcherConfig{{
+					Matcher: "edit_file",
+					Hooks:   []latest.HookDefinition{{Type: "command", Command: "global-pre"}},
+				}},
+			},
+			HookSessionStart: []string{"cli"},
+			HookPreToolUse:   []string{"cli-pre"},
+		},
+	}
+
+	team, err := Load(t.Context(), config.NewBytesSource("global-hooks.yaml", data), runConfig, withTestProviderRegistry()...)
+	require.NoError(t, err)
+
+	root, err := team.Agent("root")
+	require.NoError(t, err)
+	hooks := root.Hooks()
+	require.NotNil(t, hooks)
+
+	require.Len(t, hooks.SessionStart, 3)
+	assert.Equal(t, "agent", hooks.SessionStart[0].Command)
+	assert.Equal(t, "global", hooks.SessionStart[1].Command)
+	assert.Equal(t, "cli", hooks.SessionStart[2].Command)
+
+	require.Len(t, hooks.PreToolUse, 3)
+	assert.Equal(t, "shell", hooks.PreToolUse[0].Matcher)
+	assert.Equal(t, "agent-pre", hooks.PreToolUse[0].Hooks[0].Command)
+	assert.Equal(t, "edit_file", hooks.PreToolUse[1].Matcher)
+	assert.Equal(t, "global-pre", hooks.PreToolUse[1].Hooks[0].Command)
+	assert.Empty(t, hooks.PreToolUse[2].Matcher)
+	assert.Equal(t, "cli-pre", hooks.PreToolUse[2].Hooks[0].Command)
+}

--- a/pkg/userconfig/userconfig.go
+++ b/pkg/userconfig/userconfig.go
@@ -75,6 +75,9 @@ type Settings struct {
 	// and agents. These act as user-wide defaults; session-level and agent-level
 	// permissions override them.
 	Permissions *latest.PermissionsConfig `yaml:"permissions,omitempty"`
+	// Hooks defines global hooks applied to every agent. These are additive with
+	// agent-config and CLI hooks.
+	Hooks *latest.HooksConfig `yaml:"hooks,omitempty"`
 	// Keybindings lets users remap TUI keyboard shortcuts. Each entry maps an
 	// action name to one or more key combinations (Bubbles key format, e.g.
 	// "ctrl+q", "f2"). Unknown actions, malformed keys, and conflicts are
@@ -141,6 +144,14 @@ func (s *Settings) GetSplitDiffView() bool {
 // SnapshotsEnabled returns whether global snapshot auto-injection is enabled.
 func (s *Settings) SnapshotsEnabled() bool {
 	return s != nil && s.Snapshot != nil && *s.Snapshot
+}
+
+// GlobalHooks returns the user-level hooks config, if configured.
+func (s *Settings) GlobalHooks() *latest.HooksConfig {
+	if s == nil {
+		return nil
+	}
+	return s.Hooks
 }
 
 // CredentialHelper contains configuration for a credential helper command

--- a/pkg/userconfig/userconfig_test.go
+++ b/pkg/userconfig/userconfig_test.go
@@ -1030,3 +1030,49 @@ func TestConfig_SandboxAllowlistRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, original.SandboxAllowlist, loaded.SandboxAllowlist)
 }
+
+func TestConfig_HooksRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+
+	original := &Config{
+		Aliases: make(map[string]*Alias),
+		Settings: &Settings{
+			Hooks: &latest.HooksConfig{
+				SessionStart: []latest.HookDefinition{{Type: "command", Command: "echo start"}},
+				PreCompact:   []latest.HookDefinition{{Type: "command", Command: "echo compact"}},
+			},
+		},
+	}
+
+	require.NoError(t, original.saveTo(configFile))
+
+	loaded, err := loadFrom(configFile, "")
+	require.NoError(t, err)
+	require.NotNil(t, loaded.Settings)
+	require.NotNil(t, loaded.Settings.Hooks)
+	assert.Equal(t, original.Settings.Hooks.SessionStart, loaded.Settings.Hooks.SessionStart)
+	assert.Equal(t, original.Settings.Hooks.PreCompact, loaded.Settings.Hooks.PreCompact)
+
+	reloaded, err := yaml.Marshal(loaded)
+	require.NoError(t, err)
+	assert.Contains(t, string(reloaded), "session_start:")
+	assert.Contains(t, string(reloaded), "pre_compact:")
+}
+
+func TestConfig_Settings_HooksEmpty(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte("settings:\n  hide_tool_results: true\n"), 0o644))
+
+	cfg, err := loadFrom(configFile, "")
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Settings)
+	assert.Nil(t, cfg.Settings.Hooks)
+	assert.Nil(t, cfg.Settings.GlobalHooks())
+	assert.Nil(t, (*Settings)(nil).GlobalHooks())
+}


### PR DESCRIPTION
## Summary
- add user-level `settings.hooks` support in `~/.config/cagent/config.yaml`
- thread global hooks through runtime config and merge them for each agent
- document global hook configuration and additive order: agent config → global → CLI

## Validation
- `go test ./pkg/userconfig ./pkg/config ./pkg/teamloader`
- `go build ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run`
- `go run ./lint .`
- `go mod tidy --diff`

Note: full `go test ./...` was run and still hits existing/environment failures in `pkg/cache` (`TestFileCache_dedupSkipsRedundantWrite`) and `pkg/rag/treesitter` because this sandbox has `CGO_ENABLED=0` while those tests require CGO.