### PR TITLE
fix: bound toolset startup and never block the TUI exit when Docker is wedged

### DIFF
--- a/pkg/runtime/defaults.go
+++ b/pkg/runtime/defaults.go
@@ -42,3 +42,15 @@ const toolsChangedTimeout = 5 * time.Second
 // lists its tools again without this startup bound. Tests override it via
 // WithToolListTimeout to exercise the skip path without a real-time wait.
 const defaultToolListTimeout = 10 * time.Second
+
+// defaultToolStartTimeout bounds how long EmitStartupInfo waits for a single
+// toolset to start while populating the sidebar. A toolset whose Start()
+// blocks indefinitely — e.g. an MCP stdio server backed by a wedged Docker
+// daemon that never finishes launching the container — would otherwise stall
+// the loop the same way a hung Tools() does: the terminal
+// ToolsetInfo{Loading:false} event is never emitted and the sidebar animates
+// "tools available…" forever. A timed-out toolset is skipped for this startup
+// pass only; the run loop retries Start on the first user message. It is
+// longer than defaultToolListTimeout because a cold start can legitimately
+// include an image pull. Tests override it via WithToolStartTimeout.
+const defaultToolStartTimeout = 30 * time.Second

--- a/pkg/runtime/defaults.go
+++ b/pkg/runtime/defaults.go
@@ -50,7 +50,8 @@ const defaultToolListTimeout = 10 * time.Second
 // the loop the same way a hung Tools() does: the terminal
 // ToolsetInfo{Loading:false} event is never emitted and the sidebar animates
 // "tools available…" forever. A timed-out toolset is skipped for this startup
-// pass only; the run loop retries Start on the first user message. It is
-// longer than defaultToolListTimeout because a cold start can legitimately
-// include an image pull. Tests override it via WithToolStartTimeout.
+// pass only — the original start attempt keeps running and the toolset is
+// picked up once it completes. It is longer than defaultToolListTimeout
+// because a cold start can legitimately include an image pull. Tests override
+// it via WithToolStartTimeout.
 const defaultToolStartTimeout = 30 * time.Second

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -315,6 +315,11 @@ type LocalRuntime struct {
 	// defaultToolListTimeout; overridden via WithToolListTimeout.
 	toolListTimeout time.Duration
 
+	// toolStartTimeout bounds how long EmitStartupInfo waits for a single
+	// toolset to start before skipping it for the startup sidebar pass.
+	// Defaults to defaultToolStartTimeout; overridden via WithToolStartTimeout.
+	toolStartTimeout time.Duration
+
 	// pauseMu guards pauseCh.
 	pauseMu sync.Mutex
 	// pauseCh is non-nil and open while /pause has paused the run loop;
@@ -482,6 +487,19 @@ func WithToolListTimeout(d time.Duration) Opt {
 	}
 }
 
+// WithToolStartTimeout overrides how long EmitStartupInfo waits for a single
+// toolset to start before skipping it. Defaults to defaultToolStartTimeout.
+// A non-positive value is ignored so the default stands. Tests pass a short
+// timeout to exercise the skip path (a toolset whose Start() blocks) without
+// a real-time wait.
+func WithToolStartTimeout(d time.Duration) Opt {
+	return func(r *LocalRuntime) {
+		if d > 0 {
+			r.toolStartTimeout = d
+		}
+	}
+}
+
 // WithRetryOnRateLimit enables automatic retry with backoff for HTTP 429 (rate limit)
 // errors when no fallback models are available. When enabled, the runtime will honor
 // the Retry-After header from the provider's response to determine wait time before
@@ -570,6 +588,7 @@ func NewLocalRuntime(ctx context.Context, agents *team.Team, opts ...Opt) (*Loca
 		providerRegistry:       provider.DefaultRegistry(),
 		maxOverflowCompactions: defaultMaxOverflowCompactions,
 		toolListTimeout:        defaultToolListTimeout,
+		toolStartTimeout:       defaultToolStartTimeout,
 		dmrModelLister:         dmr.ListModels,
 	}
 	r.bgAgents = agenttool.NewHandler(r)
@@ -1562,8 +1581,19 @@ func (r *LocalRuntime) emitToolsProgressively(ctx context.Context, a *agent.Agen
 		// can fire the targeted re-auth notice. Start() is a no-op when the
 		// toolset is already healthy, so calling it unconditionally is safe.
 		if startable, ok := toolset.(*tools.StartableToolSet); ok {
-			if err := startable.Start(ctx); err != nil {
+			if err := startToolsetWithTimeout(ctx, startable, r.toolStartTimeout); err != nil {
 				desc := tools.DescribeToolSet(startable.ToolSet)
+				// A start that outlived its deadline (e.g. an MCP container
+				// stuck behind a wedged Docker daemon) is reported directly:
+				// the abandoned Start goroutine has not returned, so the
+				// once-per-streak guard below has recorded nothing and would
+				// silently swallow the warning.
+				if errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
+					slog.WarnContext(ctx, "Toolset start timed out; skipping",
+						"agent", a.Name(), "toolset", desc, "timeout", r.toolStartTimeout)
+					a.AddToolWarning(fmt.Sprintf("%s is taking too long to start (>%s) — it will be retried on your next message", desc, r.toolStartTimeout))
+					continue
+				}
 				// IsAuthorizationRequired must be checked BEFORE
 				// ShouldReportFailure: this is the first — expected —
 				// failure of a deferred-OAuth toolset, and consuming the
@@ -1665,6 +1695,34 @@ func listToolsWithTimeout(ctx context.Context, toolset tools.ToolSet, timeout ti
 		return nil, toolCtx.Err()
 	case res := <-done:
 		return res.tools, res.err
+	}
+}
+
+// startToolsetWithTimeout starts a toolset under a bounded deadline, mirroring
+// listToolsWithTimeout. The deadline must be enforced by racing the call
+// against the timeout (not only via the context): the MCP connector detaches
+// the context it is handed with context.WithoutCancel, so a wedged initialize
+// handshake (e.g. Docker failing to start the server container) would ignore a
+// ctx deadline and block startup forever. On timeout it returns the context
+// error; the orphaned goroutine sends into a buffered channel and exits if the
+// call ever returns.
+func startToolsetWithTimeout(ctx context.Context, toolset *tools.StartableToolSet, timeout time.Duration) error {
+	if timeout <= 0 {
+		timeout = defaultToolStartTimeout
+	}
+	startCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	done := make(chan error, 1) // buffered so a late send never blocks
+	go func() {
+		done <- toolset.Start(startCtx)
+	}()
+
+	select {
+	case <-startCtx.Done():
+		return startCtx.Err()
+	case err := <-done:
+		return err
 	}
 }
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1591,7 +1591,7 @@ func (r *LocalRuntime) emitToolsProgressively(ctx context.Context, a *agent.Agen
 				if errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
 					slog.WarnContext(ctx, "Toolset start timed out; skipping",
 						"agent", a.Name(), "toolset", desc, "timeout", r.toolStartTimeout)
-					a.AddToolWarning(fmt.Sprintf("%s is taking too long to start (>%s) — it will be retried on your next message", desc, r.toolStartTimeout))
+					a.AddToolWarning(fmt.Sprintf("%s is taking too long to start (>%s) — it keeps starting in the background and its tools appear once it is ready", desc, r.toolStartTimeout))
 					continue
 				}
 				// IsAuthorizationRequired must be checked BEFORE
@@ -1706,6 +1706,12 @@ func listToolsWithTimeout(ctx context.Context, toolset tools.ToolSet, timeout ti
 // ctx deadline and block startup forever. On timeout it returns the context
 // error; the orphaned goroutine sends into a buffered channel and exits if the
 // call ever returns.
+//
+// The abandoned goroutine keeps holding the StartableToolSet's single-flight
+// lock, so later Start/Stop calls on the same toolset wait for the original
+// attempt rather than racing it — if it eventually completes, the toolset
+// becomes usable on the next turn; if it never does, the TUI shutdown safety
+// net still bounds the exit path.
 func startToolsetWithTimeout(ctx context.Context, toolset *tools.StartableToolSet, timeout time.Duration) error {
 	if timeout <= 0 {
 		timeout = defaultToolStartTimeout

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -75,6 +75,27 @@ func (b *blockingToolSet) Tools(context.Context) ([]tools.Tool, error) {
 	return nil, nil
 }
 
+// blockingStartToolSet models a toolset whose Start() never returns on its
+// own — e.g. an MCP stdio server whose container never comes up because the
+// Docker daemon is wedged. It deliberately ignores ctx and blocks until
+// release is closed, which tests do on cleanup so the orphaned start
+// goroutine exits.
+type blockingStartToolSet struct {
+	release <-chan struct{}
+}
+
+var (
+	_ tools.ToolSet   = (*blockingStartToolSet)(nil)
+	_ tools.Startable = (*blockingStartToolSet)(nil)
+)
+
+func (b *blockingStartToolSet) Start(context.Context) error {
+	<-b.release
+	return nil
+}
+func (b *blockingStartToolSet) Stop(context.Context) error                  { return nil }
+func (b *blockingStartToolSet) Tools(context.Context) ([]tools.Tool, error) { return nil, nil }
+
 type mockStream struct {
 	responses []chat.MessageStreamResponse
 	idx       int
@@ -1230,6 +1251,73 @@ func TestEmitStartupInfo_SkipsToolsetWhoseListingHangs(t *testing.T) {
 	assert.False(t, last.Loading, "final ToolsetInfo must report Loading=false so the sidebar resolves")
 	assert.Equal(t, 1, last.AvailableTools,
 		"the hung toolset is skipped; the fast toolset's single tool is still counted")
+}
+
+// TestEmitStartupInfo_SkipsToolsetWhoseStartHangs is the companion of the
+// listing-hang test above for the Start() phase: a toolset whose Start()
+// blocks indefinitely (e.g. an MCP server container that Docker never manages
+// to launch) must not stall startup tool loading. Without the per-toolset
+// start timeout the terminal ToolsetInfo{Loading:false} was never emitted, so
+// the sidebar animated "tools available…" forever.
+func TestEmitStartupInfo_SkipsToolsetWhoseStartHangs(t *testing.T) {
+	t.Parallel()
+
+	prov := &mockProvider{id: "test/startup-model", stream: &mockStream{}}
+
+	// release is closed on cleanup so the orphaned start goroutine (whose
+	// Start() ignores context cancellation) exits instead of leaking.
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+
+	hanging := &blockingStartToolSet{release: release}
+	fast := newStubToolSet(nil, []tools.Tool{{Name: "ready"}}, nil)
+
+	root := agent.New("root", "agent",
+		agent.WithModel(prov),
+		agent.WithToolSets(hanging, fast),
+	)
+	tm := team.New(team.WithAgents(root))
+
+	rt, err := NewLocalRuntime(t.Context(), tm,
+		WithCurrentAgent("root"),
+		WithModelStore(mockModelStore{}),
+		WithToolStartTimeout(50*time.Millisecond),
+	)
+	require.NoError(t, err)
+
+	events := make(chan Event, 32)
+	done := make(chan struct{})
+	go func() {
+		rt.EmitStartupInfo(t.Context(), nil, NewChannelSink(events))
+		close(events)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("EmitStartupInfo did not return: a toolset with a hung Start blocked startup tool loading")
+	}
+
+	var toolsetInfos []*ToolsetInfoEvent
+	var warning *WarningEvent
+	for e := range events {
+		switch ev := e.(type) {
+		case *ToolsetInfoEvent:
+			toolsetInfos = append(toolsetInfos, ev)
+		case *WarningEvent:
+			warning = ev
+		}
+	}
+
+	require.NotEmpty(t, toolsetInfos, "expected at least one ToolsetInfo event")
+	last := toolsetInfos[len(toolsetInfos)-1]
+	assert.False(t, last.Loading, "final ToolsetInfo must report Loading=false so the sidebar spinner stops")
+	assert.Equal(t, 1, last.AvailableTools,
+		"the hung toolset is skipped; the fast toolset's single tool is still counted")
+
+	require.NotNil(t, warning, "a start timeout must surface a user-visible warning")
+	assert.Contains(t, warning.Message, "taking too long to start")
 }
 
 // TestEmitStartupInfo_AuthRequiredIsSilent verifies that when a toolset's

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -69,6 +69,12 @@ type appModel struct {
 	shutdownDone <-chan struct{}
 	cleanupOnce  sync.Once
 
+	// cleanupAllOnce guards the full cleanupAll shutdown sequence so repeat
+	// invocations (ExitSessionMsg followed by ExitConfirmedMsg, …) are no-ops:
+	// they must not stack goroutines behind a wedged cleanup or arm parallel
+	// safety nets that would each call exit.
+	cleanupAllOnce sync.Once
+
 	// exitFunc and shutdownTimeout override the shutdown safety net's
 	// behaviour. Both are zero by default and resolved through
 	// exitFn()/shutdownTimeoutOrDefault(), which fall back to the package
@@ -2596,62 +2602,68 @@ func (m *appModel) cleanupManagedResources() {
 	})
 }
 
-// cleanupAll cleans up all sessions, editors, and resources.
+// cleanupAll cleans up all sessions, editors, and resources. It is invoked
+// from several message handlers (ExitSessionMsg, ExitConfirmedMsg, …) and may
+// be called more than once on the same model; the entire shutdown sequence is
+// once-guarded so repeat calls are no-ops and cannot pile up goroutines on a
+// wedged cleanup or arm parallel safety nets.
 func (m *appModel) cleanupAll() {
-	m.transcriber.Stop()
-	m.closeTranscriptCh()
-	for _, ed := range m.editors {
-		ed.Cleanup()
-	}
+	m.cleanupAllOnce.Do(func() {
+		m.transcriber.Stop()
+		m.closeTranscriptCh()
+		for _, ed := range m.editors {
+			ed.Cleanup()
+		}
 
-	// Shut down managed resources (supervisor, TUI state store) in the
-	// background: supervisor.Shutdown stops every session's toolsets, which
-	// can block indefinitely (e.g. an MCP toolset wedged behind a broken
-	// Docker daemon). Running it synchronously here would freeze the Update
-	// loop before tea.Quit is ever returned, leaving the exit confirmation
-	// apparently ignored.
-	cleanupDone := make(chan struct{})
-	go func() {
-		defer close(cleanupDone)
-		m.cleanupManagedResources()
-	}()
-
-	// Safety net: bubbletea's renderer can deadlock on shutdown if stdout
-	// is wedged — the final flush re-acquires the mutex that the still
-	// blocked previous flush is holding — and the resource cleanup above can
-	// likewise stall forever. Race both against a deadline and force-exit if
-	// shutdown stalls. Snapshot the package globals so they can't race with
-	// t.Cleanup. Clear m.program so subsequent calls to cleanupAll (e.g.
-	// ExitSessionMsg followed by ExitConfirmedMsg) are no-ops and don't spawn
-	// parallel safety nets that would each call exit.
-	program := m.program
-	if program == nil {
-		return
-	}
-	m.program = nil
-	timeout := m.shutdownTimeoutOrDefault()
-	exit := m.exitFn()
-	go func() {
-		done := make(chan struct{})
+		// Shut down managed resources (supervisor, TUI state store) in the
+		// background: supervisor.Shutdown stops every session's toolsets, which
+		// can block indefinitely (e.g. an MCP toolset wedged behind a broken
+		// Docker daemon). Running it synchronously here would freeze the Update
+		// loop before tea.Quit is ever returned, leaving the exit confirmation
+		// apparently ignored.
+		cleanupDone := make(chan struct{})
 		go func() {
-			program.Wait()
-			close(done)
+			defer close(cleanupDone)
+			m.cleanupManagedResources()
 		}()
 
-		deadline := time.After(timeout)
-		for _, ch := range []<-chan struct{}{done, cleanupDone} {
-			select {
-			case <-ch:
-			case <-deadline:
-				slog.Warn("Graceful shutdown timed out, forcing exit")
-				// ReleaseTerminal grabs the same mutex that's stuck, so
-				// fire-and-forget; exit either way.
-				go func() { _ = program.ReleaseTerminal() }()
-				exit(0)
-				return
-			}
+		// Safety net: bubbletea's renderer can deadlock on shutdown if stdout
+		// is wedged — the final flush re-acquires the mutex that the still
+		// blocked previous flush is holding — and the resource cleanup above can
+		// likewise stall forever. Race both against a deadline and force-exit if
+		// shutdown stalls. Snapshot the program and package globals so they
+		// can't race with t.Cleanup. Without a program (tests, exit before
+		// SetProgram) there is no renderer to deadlock and no UI left to
+		// unblock, so no safety net is armed; the background cleanup still runs.
+		program := m.program
+		if program == nil {
+			return
 		}
-	}()
+		m.program = nil
+		timeout := m.shutdownTimeoutOrDefault()
+		exit := m.exitFn()
+		go func() {
+			done := make(chan struct{})
+			go func() {
+				program.Wait()
+				close(done)
+			}()
+
+			deadline := time.After(timeout)
+			for _, ch := range []<-chan struct{}{done, cleanupDone} {
+				select {
+				case <-ch:
+				case <-deadline:
+					slog.Warn("Graceful shutdown timed out, forcing exit")
+					// ReleaseTerminal grabs the same mutex that's stuck, so
+					// fire-and-forget; exit either way.
+					go func() { _ = program.ReleaseTerminal() }()
+					exit(0)
+					return
+				}
+			}
+		}()
+	})
 }
 
 // openExternalEditor opens the current editor content in an external editor.

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -2603,15 +2603,27 @@ func (m *appModel) cleanupAll() {
 	for _, ed := range m.editors {
 		ed.Cleanup()
 	}
-	m.cleanupManagedResources()
+
+	// Shut down managed resources (supervisor, TUI state store) in the
+	// background: supervisor.Shutdown stops every session's toolsets, which
+	// can block indefinitely (e.g. an MCP toolset wedged behind a broken
+	// Docker daemon). Running it synchronously here would freeze the Update
+	// loop before tea.Quit is ever returned, leaving the exit confirmation
+	// apparently ignored.
+	cleanupDone := make(chan struct{})
+	go func() {
+		defer close(cleanupDone)
+		m.cleanupManagedResources()
+	}()
 
 	// Safety net: bubbletea's renderer can deadlock on shutdown if stdout
 	// is wedged — the final flush re-acquires the mutex that the still
-	// blocked previous flush is holding. Race Wait() against a deadline
-	// and force-exit if shutdown stalls. Snapshot the package globals so
-	// they can't race with t.Cleanup. Clear m.program so subsequent calls
-	// to cleanupAll (e.g. ExitSessionMsg followed by ExitConfirmedMsg) are
-	// no-ops and don't spawn parallel safety nets that would each call exit.
+	// blocked previous flush is holding — and the resource cleanup above can
+	// likewise stall forever. Race both against a deadline and force-exit if
+	// shutdown stalls. Snapshot the package globals so they can't race with
+	// t.Cleanup. Clear m.program so subsequent calls to cleanupAll (e.g.
+	// ExitSessionMsg followed by ExitConfirmedMsg) are no-ops and don't spawn
+	// parallel safety nets that would each call exit.
 	program := m.program
 	if program == nil {
 		return
@@ -2626,14 +2638,18 @@ func (m *appModel) cleanupAll() {
 			close(done)
 		}()
 
-		select {
-		case <-done:
-		case <-time.After(timeout):
-			slog.Warn("Graceful shutdown timed out, forcing exit")
-			// ReleaseTerminal grabs the same mutex that's stuck, so
-			// fire-and-forget; exit either way.
-			go func() { _ = program.ReleaseTerminal() }()
-			exit(0)
+		deadline := time.After(timeout)
+		for _, ch := range []<-chan struct{}{done, cleanupDone} {
+			select {
+			case <-ch:
+			case <-deadline:
+				slog.Warn("Graceful shutdown timed out, forcing exit")
+				// ReleaseTerminal grabs the same mutex that's stuck, so
+				// fire-and-forget; exit either way.
+				go func() { _ = program.ReleaseTerminal() }()
+				exit(0)
+				return
+			}
 		}
 	}()
 }

--- a/pkg/tui/tui_exit_test.go
+++ b/pkg/tui/tui_exit_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/tui/components/completion"
 	"github.com/docker/docker-agent/pkg/tui/components/editor"
 	"github.com/docker/docker-agent/pkg/tui/components/notification"
@@ -23,6 +24,7 @@ import (
 	"github.com/docker/docker-agent/pkg/tui/messages"
 	"github.com/docker/docker-agent/pkg/tui/page/chat"
 	"github.com/docker/docker-agent/pkg/tui/service"
+	"github.com/docker/docker-agent/pkg/tui/service/supervisor"
 )
 
 // mockChatPage implements chat.Page for testing.
@@ -399,6 +401,65 @@ func TestCleanupAll_GracefulShutdownSkipsExit(t *testing.T) {
 
 // syncMsg pings the program's event loop to confirm Run() has started.
 type syncMsg struct{}
+
+// TestCleanupAll_WedgedResourceCleanupForcesExit: supervisor shutdown can
+// block indefinitely (e.g. a toolset Stop wedged behind a broken Docker
+// daemon). cleanupAll must not run it synchronously — that would freeze the
+// Update loop before tea.Quit is ever processed, so confirming the exit
+// dialog would appear to do nothing — and the safety net must force the exit
+// when the cleanup never completes.
+func TestCleanupAll_WedgedResourceCleanupForcesExit(t *testing.T) {
+	t.Parallel()
+
+	m, _ := newTestModel(t)
+	m.shutdownTimeout = 200 * time.Millisecond
+
+	exitDone := make(chan struct{})
+	m.exitFunc = func(int) { close(exitDone) }
+
+	// A session whose cleanup blocks forever, as a wedged toolset Stop would.
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	sv := supervisor.New(nil)
+	sv.AddSession(t.Context(), nil, session.New(), t.TempDir(), func() { <-release })
+	m.supervisor = sv
+
+	var in, out bytes.Buffer
+	p := tea.NewProgram(&quitModel{},
+		tea.WithContext(t.Context()),
+		tea.WithInput(&in),
+		tea.WithOutput(&out),
+	)
+	runDone := make(chan struct{})
+	go func() {
+		defer close(runDone)
+		_, _ = p.Run()
+	}()
+	p.Send(syncMsg{})
+
+	m.program = p
+
+	// cleanupAll must return promptly even though the supervisor cleanup is
+	// wedged — it runs from the Update loop, right before tea.Quit.
+	returned := make(chan struct{})
+	go func() {
+		m.cleanupAll()
+		close(returned)
+	}()
+	select {
+	case <-returned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cleanupAll blocked on the wedged resource cleanup")
+	}
+
+	p.Send(triggerQuitMsg{})
+
+	select {
+	case <-exitDone:
+	case <-time.After(m.shutdownTimeout + 2*time.Second):
+		t.Fatal("exitFunc was not called — a wedged resource cleanup must force exit")
+	}
+}
 
 // TestCleanupAll_NilProgramIsSafe: with no program wired, cleanupAll is a
 // no-op and exitFunc is never called.

--- a/pkg/tui/tui_exit_test.go
+++ b/pkg/tui/tui_exit_test.go
@@ -402,6 +402,45 @@ func TestCleanupAll_GracefulShutdownSkipsExit(t *testing.T) {
 // syncMsg pings the program's event loop to confirm Run() has started.
 type syncMsg struct{}
 
+// TestCleanupAll_RepeatCallsDoNotStackOnWedgedCleanup: once the first
+// cleanupAll has kicked off a (possibly wedged) resource cleanup, later calls
+// must be complete no-ops — they must not spawn more goroutines that pile up
+// behind the wedged sync.Once inside cleanupManagedResources.
+func TestCleanupAll_RepeatCallsDoNotStackOnWedgedCleanup(t *testing.T) {
+	t.Parallel()
+
+	m, _ := newTestModel(t)
+	m.shutdownTimeout = 100 * time.Millisecond
+	m.exitFunc = func(int) {}
+
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	var cleanupCalls atomic.Int32
+	sv := supervisor.New(nil)
+	sv.AddSession(t.Context(), nil, session.New(), t.TempDir(), func() {
+		cleanupCalls.Add(1)
+		<-release
+	})
+	m.supervisor = sv
+
+	// All calls must return promptly, and only the first may start a cleanup.
+	for range 3 {
+		returned := make(chan struct{})
+		go func() {
+			m.cleanupAll()
+			close(returned)
+		}()
+		select {
+		case <-returned:
+		case <-time.After(2 * time.Second):
+			t.Fatal("cleanupAll blocked on the wedged resource cleanup")
+		}
+	}
+
+	assert.LessOrEqual(t, cleanupCalls.Load(), int32(1),
+		"repeat cleanupAll calls must not start additional resource cleanups")
+}
+
 // TestCleanupAll_WedgedResourceCleanupForcesExit: supervisor shutdown can
 // block indefinitely (e.g. a toolset Stop wedged behind a broken Docker
 // daemon). cleanupAll must not run it synchronously — that would freeze the


### PR DESCRIPTION
When Docker Desktop is wedged and containers fail to start, running an agent with MCP toolsets produced two interrelated failures. First, the sidebar "N tools available…" spinner would animate forever: `emitStartupInfo` had a timeout for *listing* tools but not for toolset *Start*, and the default resilient lifecycle profile carries no startup timeout while the MCP connector detaches its context with `context.WithoutCancel`, so a wedged `docker`-backed MCP server blocked `emitToolsProgressively` indefinitely and the terminal `ToolsetInfo{Loading:false}` event was never emitted. Second, confirming the Ctrl-C exit dialog did nothing: `cleanupAll` called `cleanupManagedResources` (supervisor shutdown → toolset `Stop`) synchronously inside the Bubble Tea `Update` loop, and `Stop` blocks on the `StartableToolSet` mutex held by the wedged `Start`, so `tea.Quit` was never returned — and the shutdown safety net was only armed after that blocking call.

The fix addresses both independently and then hardens the shutdown path. Toolset `Start` is now raced against a new `toolStartTimeout` (default 30 s, overridable via `WithToolStartTimeout` for tests) inside `startToolsetWithTimeout`, mirroring the existing `listToolsWithTimeout`. A toolset that times out is skipped in the startup sidebar pass with a user-visible warning; the original start attempt continues in the background and the toolset is picked up once it becomes ready. For the exit path, managed-resource cleanup is now launched in a background goroutine from `cleanupAll`, and the shutdown safety net races both `program.Wait()` and that cleanup goroutine against the deadline, force-exiting whichever stalls first. Ctrl-C and confirm now always exits within the shutdown timeout (5 s) even with Docker fully wedged. A final follow-up commit wraps the entire `cleanupAll` sequence in a `sync.Once` so that repeat invocations cannot stack goroutines behind a wedged cleanup or arm parallel safety nets, and rewords the start-timeout warning so it does not over-promise — the abandoned `Start` goroutine holds the toolset's single-flight lock, meaning the next turn waits for the original attempt rather than spawning a fresh retry.

Three regression tests cover the new behaviour: `TestEmitStartupInfo_SkipsToolsetWhoseStartHangs`, `TestCleanupAll_WedgedResourceCleanupForcesExit`, and `TestCleanupAll_RepeatCallsDoNotStackOnWedgedCleanup`. All pass under `-race`. The only pre-existing test failures (`TestLoadExamples` for `dmr.yaml` and `unload_on_switch.yaml`) also fail on the unmodified baseline and require a working local Docker model runner.