### PR TITLE
feat(tui): open effort picker when /effort has no argument

### DIFF
--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -73,7 +73,7 @@ Type `/` during a session to see available commands, or press <kbd>Ctrl</kbd>+<k
 | `/export`          | Export the session as HTML                                                           |
 | `/sessions`        | Browse and load past sessions                                                        |
 | `/model`           | Change the model for the current agent                                               |
-| `/effort`          | Set the current model's reasoning-effort level (`/effort <none\|minimal\|low\|medium\|high\|xhigh\|max>`, reasoning models only) |
+| `/effort`          | Set the current model's reasoning-effort level (`/effort <none\|minimal\|low\|medium\|high\|xhigh\|max>`, or `/effort` alone to pick from the supported levels; reasoning models only) |
 | `/theme`           | Change the color theme                                                               |
 | `/yolo`            | Toggle automatic tool call approval                                                  |
 | `/title`           | Set or regenerate session title                                                      |

--- a/docs/guides/thinking/index.md
+++ b/docs/guides/thinking/index.md
@@ -325,7 +325,7 @@ models:
 
 ## Changing Thinking Level at Runtime
 
-While running in the TUI, press **Shift+Tab** to cycle the thinking effort level for the current model without editing your YAML config, or type `/effort <level>` to jump straight to a specific level (e.g. `/effort high`):
+While running in the TUI, press **Shift+Tab** to cycle the thinking effort level for the current model without editing your YAML config, or type `/effort <level>` to jump straight to a specific level (e.g. `/effort high`). Running `/effort` without an argument opens a picker listing the levels the current model supports:
 
 - The level steps through the model's supported range (model-specific), wrapping around — for example `none → minimal → low → medium → high → none` on OpenAI gpt-5/o-series, `none → minimal → low → medium → high → xhigh → none` on gpt-5.2+, `none → low → medium → high → max → none` on Anthropic Opus 4.6 and Sonnet 4.6, and `none → low → medium → high → xhigh → max → none` on Anthropic Opus 4.7+, Fable 5, and Mythos 5. For older Anthropic models (e.g. Sonnet 4.5) that only accept token budgets, effort-string cycling has no effect — use an integer `thinking_budget` in your YAML config instead.
 - The current level is shown in the sidebar next to the model name (e.g. `openai/gpt-5 • high`).

--- a/pkg/tui/commands/commands.go
+++ b/pkg/tui/commands/commands.go
@@ -132,7 +132,7 @@ func builtInSessionCommands() []Item {
 			ID:           "session.effort",
 			Label:        "Effort",
 			SlashCommand: "/effort",
-			Description:  "Set the reasoning effort of the current model (usage: /effort <level>)",
+			Description:  "Set the reasoning effort of the current model (usage: /effort [level])",
 			Category:     "Session",
 			Immediate:    true,
 			Execute: func(arg string) tea.Cmd {

--- a/pkg/tui/dialog/effort_picker.go
+++ b/pkg/tui/dialog/effort_picker.go
@@ -1,0 +1,139 @@
+package dialog
+
+import (
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/docker/docker-agent/pkg/effort"
+	"github.com/docker/docker-agent/pkg/tui/components/toolcommon"
+	"github.com/docker/docker-agent/pkg/tui/core"
+	"github.com/docker/docker-agent/pkg/tui/core/layout"
+	"github.com/docker/docker-agent/pkg/tui/messages"
+	"github.com/docker/docker-agent/pkg/tui/styles"
+)
+
+const (
+	effortPickerWidthPercent = 40
+	// Wide enough that the three help-key bindings fit on a single line.
+	effortPickerMinWidth = 46
+	effortPickerMaxWidth = 50
+)
+
+// effortPickerDialog lets the user pick a reasoning-effort level for the
+// current model among the levels that model supports. It backs /effort when
+// no level argument is given.
+type effortPickerDialog struct {
+	BaseDialog
+
+	levels   []effort.Level
+	current  effort.Level
+	selected int
+}
+
+// NewEffortPickerDialog creates an effort picker over the given supported
+// levels. current marks the active level and is preselected; pass an empty
+// level when the active configuration doesn't map onto a listed level
+// (adaptive or token-based budgets).
+func NewEffortPickerDialog(levels []effort.Level, current effort.Level) Dialog {
+	d := &effortPickerDialog{levels: levels, current: current}
+	for i, l := range levels {
+		if l == current {
+			d.selected = i
+			break
+		}
+	}
+	return d
+}
+
+func (d *effortPickerDialog) Init() tea.Cmd { return nil }
+
+func (d *effortPickerDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		cmd := d.SetSize(msg.Width, msg.Height)
+		return d, cmd
+
+	case tea.KeyPressMsg:
+		if cmd := HandleQuit(msg); cmd != nil {
+			return d, cmd
+		}
+		cmd := d.handleKey(msg)
+		return d, cmd
+	}
+	return d, nil
+}
+
+func (d *effortPickerDialog) handleKey(msg tea.KeyPressMsg) tea.Cmd {
+	switch msg.String() {
+	case "esc", "q":
+		return closeDialogCmd()
+	case "up", "k", "ctrl+k":
+		if d.selected > 0 {
+			d.selected--
+		}
+	case "down", "j", "ctrl+j":
+		if d.selected < len(d.levels)-1 {
+			d.selected++
+		}
+	case "home", "g":
+		d.selected = 0
+	case "end", "G":
+		d.selected = max(0, len(d.levels)-1)
+	case "enter":
+		return d.handleSelection()
+	}
+	return nil
+}
+
+func (d *effortPickerDialog) handleSelection() tea.Cmd {
+	if d.selected < 0 || d.selected >= len(d.levels) {
+		return nil
+	}
+	return tea.Sequence(
+		closeDialogCmd(),
+		core.CmdHandler(messages.SetThinkingLevelMsg{Level: d.levels[d.selected].String()}),
+	)
+}
+
+func (d *effortPickerDialog) Position() (row, col int) {
+	return d.CenterDialog(d.View())
+}
+
+func (d *effortPickerDialog) View() string {
+	width := d.ComputeDialogWidth(effortPickerWidthPercent, effortPickerMinWidth, effortPickerMaxWidth)
+	inner := d.ContentWidth(width, 2)
+
+	rows := make([]string, 0, len(d.levels))
+	for i, level := range d.levels {
+		rows = append(rows, d.renderLevel(level, i == d.selected))
+	}
+
+	content := NewContent(inner).
+		AddTitle("Select Reasoning Effort").
+		AddSeparator().
+		AddSpace().
+		AddContent(lipgloss.JoinVertical(lipgloss.Left, rows...)).
+		AddSpace().
+		AddHelpKeys("↑/↓", "navigate", "enter", "select", "esc", "cancel").
+		Build()
+
+	return styles.DialogStyle.Width(width).Render(content)
+}
+
+// renderLevel draws one list entry: the six-cell effort gauge (empty for
+// none, matching the sidebar's visual language), the level name, and a
+// "(current)" badge on the active level.
+func (d *effortPickerDialog) renderLevel(level effort.Level, selected bool) string {
+	nameStyle := styles.PaletteUnselectedActionStyle
+	currentBadgeStyle := styles.BadgeCurrentStyle
+	if selected {
+		nameStyle = styles.PaletteSelectedActionStyle
+		currentBadgeStyle = currentBadgeStyle.Background(styles.MobyBlue)
+	}
+
+	name := nameStyle.Render(" " + level.String() + " ")
+	if level == d.current {
+		name += currentBadgeStyle.Render("(current)")
+	}
+	return toolcommon.EffortGauge(level) + " " + name
+}

--- a/pkg/tui/dialog/effort_picker_test.go
+++ b/pkg/tui/dialog/effort_picker_test.go
@@ -1,0 +1,113 @@
+package dialog
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/effort"
+)
+
+func newTestEffortPicker(t *testing.T, levels []effort.Level, current effort.Level) *effortPickerDialog {
+	t.Helper()
+	dialog := NewEffortPickerDialog(levels, current)
+	d, ok := dialog.(*effortPickerDialog)
+	require.True(t, ok)
+	d.Init()
+	d.Update(tea.WindowSizeMsg{Width: 100, Height: 50})
+	return d
+}
+
+func TestEffortPickerPreselectsCurrent(t *testing.T) {
+	t.Parallel()
+
+	levels := []effort.Level{effort.None, effort.Low, effort.Medium, effort.High}
+	d := newTestEffortPicker(t, levels, effort.Medium)
+
+	require.Equal(t, 2, d.selected, "current level should be preselected")
+}
+
+func TestEffortPickerUnknownCurrentSelectsFirst(t *testing.T) {
+	t.Parallel()
+
+	levels := []effort.Level{effort.None, effort.Low, effort.Medium, effort.High}
+	d := newTestEffortPicker(t, levels, "")
+
+	require.Equal(t, 0, d.selected, "unknown current should leave the first level selected")
+}
+
+func TestEffortPickerNavigation(t *testing.T) {
+	t.Parallel()
+
+	levels := []effort.Level{effort.None, effort.Low, effort.Medium}
+	d := newTestEffortPicker(t, levels, effort.None)
+
+	downKey := tea.KeyPressMsg{Code: tea.KeyDown}
+	upKey := tea.KeyPressMsg{Code: tea.KeyUp}
+
+	d.Update(downKey)
+	require.Equal(t, 1, d.selected)
+
+	d.Update(downKey)
+	require.Equal(t, 2, d.selected)
+
+	// At the end, down must not move past the last level.
+	d.Update(downKey)
+	require.Equal(t, 2, d.selected)
+
+	d.Update(upKey)
+	require.Equal(t, 1, d.selected)
+
+	d.Update(upKey)
+	d.Update(upKey)
+	require.Equal(t, 0, d.selected, "up must not move before the first level")
+}
+
+func TestEffortPickerSelectionReturnsCommand(t *testing.T) {
+	t.Parallel()
+
+	levels := []effort.Level{effort.None, effort.Low, effort.Medium}
+	d := newTestEffortPicker(t, levels, effort.Low)
+
+	_, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	require.NotNil(t, cmd, "enter should return a command")
+}
+
+func TestEffortPickerEscape(t *testing.T) {
+	t.Parallel()
+
+	levels := []effort.Level{effort.None, effort.Low}
+	d := newTestEffortPicker(t, levels, effort.Low)
+
+	_, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	require.NotNil(t, cmd, "escape should return a command")
+}
+
+func TestEffortPickerViewShowsLevelsAndCurrent(t *testing.T) {
+	t.Parallel()
+
+	levels := []effort.Level{effort.None, effort.Low, effort.Medium, effort.High, effort.Max}
+	d := newTestEffortPicker(t, levels, effort.High)
+
+	view := d.View()
+	assert.Contains(t, view, "Select Reasoning Effort")
+	for _, level := range levels {
+		assert.Contains(t, view, level.String())
+	}
+	assert.Contains(t, view, "(current)")
+}
+
+func TestEffortPickerViewChangesOnNavigation(t *testing.T) {
+	t.Parallel()
+
+	levels := []effort.Level{effort.None, effort.Low, effort.Medium}
+	d := newTestEffortPicker(t, levels, effort.None)
+
+	view1 := d.View()
+	d.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	view2 := d.View()
+
+	require.NotEqual(t, view1, view2, "view should change after navigation")
+}

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/docker-agent/pkg/browser"
 	"github.com/docker/docker-agent/pkg/effort"
 	"github.com/docker/docker-agent/pkg/evaluation"
+	"github.com/docker/docker-agent/pkg/modelinfo"
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/shellpath"
@@ -563,14 +564,14 @@ func (m *appModel) handleCycleThinkingLevel() (tea.Model, tea.Cmd) {
 
 // handleSetThinkingLevel applies the /effort command: it sets the current
 // model's reasoning-effort level to the requested value. An empty level
-// shows usage; unsupported levels surface the model's supported list via
-// the runtime error.
+// opens the effort picker dialog; unsupported levels surface the model's
+// supported list via the runtime error.
 func (m *appModel) handleSetThinkingLevel(level string) (tea.Model, tea.Cmd) {
 	if !m.application.SupportsModelSwitching() {
 		return m, notification.InfoCmd("Thinking levels can't be changed with remote runtimes")
 	}
 	if level == "" {
-		return m, notification.InfoCmd("Usage: /effort <none|minimal|low|medium|high|xhigh|max>")
+		return m.openEffortPicker()
 	}
 	parsed, ok := effort.Parse(level)
 	if !ok {
@@ -584,6 +585,26 @@ func (m *appModel) handleSetThinkingLevel(level string) (tea.Model, tea.Cmd) {
 		return m, notification.ErrorCmd(fmt.Sprintf("Failed to set thinking level: %v", err))
 	}
 	return m, notification.SuccessCmd("Reasoning effort set to " + applied.String())
+}
+
+// openEffortPicker opens the effort picker dialog listing the thinking-effort
+// levels supported by the current agent's model (/effort without arguments).
+// The sidebar's thinking label doubles as the support signal: it is empty
+// exactly when the runtime reports no selectable thinking configuration.
+func (m *appModel) openEffortPicker() (tea.Model, tea.Cmd) {
+	agent := m.sessionState.GetCurrentAgent()
+	if agent.Thinking == "" {
+		return m, notification.InfoCmd("Current model does not support thinking levels")
+	}
+	levels := modelinfo.SupportedThinkingLevels(agent.Provider, agent.Model)
+	// "off" maps onto none; adaptive/token labels leave no level marked current.
+	current, ok := effort.Parse(agent.Thinking)
+	if !ok && agent.Thinking == "off" {
+		current = effort.None
+	}
+	return m, core.CmdHandler(dialog.OpenDialogMsg{
+		Model: dialog.NewEffortPickerDialog(levels, current),
+	})
 }
 
 func (m *appModel) handleChangeModel(modelRef string) (tea.Model, tea.Cmd) {


### PR DESCRIPTION
## Summary

`/effort` without an argument now opens a small selection dialog, in the same spirit as `/model`, instead of printing a usage hint. `/effort <level>` is unchanged.

```
+- Select Reasoning Effort -----------+
|  ▱▱▱▱▱▱  none                       |
|  ▰▰▱▱▱▱  low                        |
|  ▰▰▰▱▱▱  medium (current)           |
|  ▰▰▰▰▱▱  high                       |
|  ▰▰▰▰▰▰  max                        |
|  ↑/↓ navigate  enter select  esc    |
+-------------------------------------+
```

## Flow

```
/effort (no argument)
  -> model supports thinking? (empty sidebar thinking label means no -> info notification)
    -> modelinfo.SupportedThinkingLevels(provider, model): only levels the model accepts
      -> picker: effort gauge + level name + (current) badge, preselected on the active level
        -> enter sends SetThinkingLevelMsg{level}: reuses existing validation and notifications
```

## Changes

| File | Change |
| --- | --- |
| `pkg/tui/dialog/effort_picker.go` | New effort picker dialog (keyboard navigation, gauge rendering) |
| `pkg/tui/dialog/effort_picker_test.go` | Tests: preselection, navigation bounds, enter/esc, view content |
| `pkg/tui/handlers.go` | `/effort` with no argument opens the picker instead of the usage hint |
| `pkg/tui/commands/commands.go` | Command description: level argument is now optional |
| `docs/features/tui/index.md`, `docs/guides/thinking/index.md` | Documentation updated |

## Notes

- Listed levels come from `modelinfo.SupportedThinkingLevels` with the same provider/model values the runtime validates against, so any selection is accepted.
- "off" maps onto `none`; adaptive and token budgets leave no level marked current.
- `leantui` keeps its text usage hint: it has no dialog system (no `/model` picker either).

## Validation

- `go build ./...` and `pkg/tui/...` tests pass
- golangci-lint: 0 issues; internal lint: 0 offenses; markdownlint on docs: 0 errors
